### PR TITLE
t2007: feat(pulse): cost-per-issue circuit breaker

### DIFF
--- a/.agents/configs/dispatch-cost-budgets.conf
+++ b/.agents/configs/dispatch-cost-budgets.conf
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# dispatch-cost-budgets.conf — Cost-per-issue circuit breaker (t2007)
+#
+# Per-tier cumulative token budget for worker dispatch. When the sum of
+# token spend across all worker attempts on an issue exceeds the tier
+# budget, dispatch-dedup-helper.sh::_check_cost_budget applies the
+# `needs-maintainer-review` label, posts an explanatory comment, and
+# emits the COST_BUDGET_EXCEEDED signal that blocks further dispatch.
+#
+# Spend is aggregated by parsing the `spent N tokens` and `has used N tokens`
+# patterns from signature footers in issue comments — the same data that
+# `gh-signature-helper.sh footer` writes for every worker comment. No new
+# instrumentation required.
+#
+# Background (GH#18356 root-cause analysis, Tier B fix):
+#   t1986 closes the parent-task hole (those issues should never dispatch).
+#   t2008 closes the no-progress loop (escalates after N consecutive
+#   stale-recoveries without a PR).
+#   t2007 (this) closes the cost-runaway hole — even when the brief is
+#   classified correctly and the recovery counter never trips, a worker
+#   stuck in a loop or an unimplementable task can burn unbounded cost
+#   across many small attempts. The breaker fires on cumulative spend,
+#   independent of attempt count.
+#
+# Calibration rationale:
+#   Each budget is sized at ~3× a typical successful run on that tier.
+#   Workers that succeed on a single attempt cost ~1× the budget; failed
+#   attempts that cost ~1× each give the system 2-3 retries before the
+#   breaker fires, which matches the cascade dispatch policy (start at
+#   simple, escalate on failure, and the breaker catches runaway loops
+#   that escape the cascade's per-attempt failure detection).
+#
+# Format: KEY=VALUE (no spaces around =, no quotes needed)
+# Lines starting with # are comments.
+#
+# Tuning:
+#   Raise budgets if legitimate iteration is being blocked too aggressively.
+#   Lower them if real cost incidents are slipping through.
+#   Track which issues hit the breaker after 1 week and adjust accordingly.
+
+# tier:simple — Haiku tier. Typical successful run: ~10K tokens.
+# 30K = 3× typical, allowing 2-3 retries before circuit breaker.
+COST_BUDGET_SIMPLE=30000
+
+# tier:standard — Sonnet tier. Typical successful run: ~30K tokens.
+# 100K = 3× typical, allowing 2-3 retries before circuit breaker.
+COST_BUDGET_STANDARD=100000
+
+# tier:reasoning — Opus tier. Typical successful run: ~100K tokens.
+# 300K = 3× typical, allowing 2-3 retries before circuit breaker.
+# Observed in production: GH#18356 burned ~20K opus tokens across 2
+# attempts before t1986 stopped it; the 300K cap would have allowed
+# ~15 attempts before firing — generous, but a meaningful upper bound.
+COST_BUDGET_REASONING=300000
+
+# Default budget when an issue has no tier:* label. Defensive fallback —
+# all issues should carry a tier label after issue-sync runs.
+COST_BUDGET_DEFAULT=100000

--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -671,6 +671,258 @@ _This recovery prevents the orphaned-assignment deadlock where offline runners p
 }
 
 #######################################
+# Cost-per-issue circuit breaker (t2007)
+# ─────────────────────────────────────────
+# Tracks cumulative token spend across all worker attempts on an issue
+# by parsing signature-footer patterns ("spent N tokens" / "has used N
+# tokens") from comments. When spend exceeds the tier-appropriate budget
+# the breaker fires: applies needs-maintainer-review label, posts an
+# explanatory comment (idempotent on the label), and emits the
+# COST_BUDGET_EXCEEDED signal.
+#
+# Design (paired with t1986 parent-task guard and t2008 stale escalation):
+#   1. The breaker check runs in is_assigned() AFTER the parent-task
+#      short-circuit (which is unconditional) but BEFORE the assignee
+#      check. Cost-tripped issues should be blocked regardless of who
+#      is assigned.
+#   2. Aggregation parses ALL comments (not just the authenticated
+#      user's) — multiple runners may have worked on the same issue,
+#      and the budget is per-ISSUE, not per-runner.
+#   3. Failure mode: fail-open. If we can't compute spend (gh failure,
+#      no comments, jq error), allow dispatch. The breaker is a safety
+#      net, not a hard gate. The other dedup layers still apply.
+#   4. Side effects are idempotent on the needs-maintainer-review label.
+#      If the label is already present, the signal is still emitted but
+#      no comment/edit is performed (no double-comment on every cycle).
+#######################################
+
+#######################################
+# Look up the per-tier cost budget from .agents/configs/dispatch-cost-budgets.conf.
+# Args: $1 = tier label or short name (simple|standard|reasoning|tier:simple|...)
+# Stdout: integer token budget
+#######################################
+_get_cost_budget_for_tier() {
+	local tier="$1"
+	local _conf="${SCRIPT_DIR}/../configs/dispatch-cost-budgets.conf"
+	# Defaults match the documented tier sizing (see dispatch-cost-budgets.conf)
+	local COST_BUDGET_SIMPLE=30000
+	local COST_BUDGET_STANDARD=100000
+	local COST_BUDGET_REASONING=300000
+	local COST_BUDGET_DEFAULT=100000
+	if [[ -f "$_conf" ]]; then
+		# shellcheck source=/dev/null
+		source "$_conf"
+	fi
+
+	# Strip "tier:" prefix if present
+	tier="${tier#tier:}"
+
+	case "$tier" in
+	simple) printf '%s' "$COST_BUDGET_SIMPLE" ;;
+	standard) printf '%s' "$COST_BUDGET_STANDARD" ;;
+	reasoning) printf '%s' "$COST_BUDGET_REASONING" ;;
+	*) printf '%s' "$COST_BUDGET_DEFAULT" ;;
+	esac
+	return 0
+}
+
+#######################################
+# Sum token spend across all signature footers in an issue's comments.
+# Aggregates ALL workers (no author filter) — the breaker is per-issue,
+# not per-runner.
+#
+# Args: $1 = issue number, $2 = repo slug
+# Stdout: "spent_tokens|attempt_count"
+# Returns: 0 on success, 1 on fetch/parse failure (caller fail-open)
+#######################################
+_sum_issue_token_spend() {
+	local issue_number="$1"
+	local repo_slug="$2"
+
+	if [[ ! "$issue_number" =~ ^[0-9]+$ ]] || [[ -z "$repo_slug" ]]; then
+		return 1
+	fi
+
+	local comments_json
+	comments_json=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" --paginate 2>/dev/null) || return 1
+	if [[ -z "$comments_json" || "$comments_json" == "null" ]]; then
+		return 1
+	fi
+
+	# Extract all comment bodies as a single stream
+	local bodies
+	bodies=$(printf '%s' "$comments_json" | jq -r '.[].body // empty' 2>/dev/null) || return 1
+	if [[ -z "$bodies" ]]; then
+		# No comments yet — zero spend, zero attempts (fail-open via 0|0 not 1)
+		printf '0|0'
+		return 0
+	fi
+
+	# Match signature footer patterns. The footer can take several shapes:
+	#   "spent 30,000 tokens"            (no time)
+	#   "spent 4m and 30,000 tokens"     (with session time)
+	#   "spent 1h 30m and 30,000 tokens" (with hours+minutes)
+	#   "has used 30,000 tokens"         (historical wording)
+	#
+	# Strategy: collapse the optional "<time> and " infix so all variants
+	# reduce to "(spent|has used) N tokens", then extract N. The cumulative
+	# "N total tokens on this issue." line is intentionally NOT matched —
+	# it's the running aggregate of prior comments and would double-count
+	# every time a new worker reports its own per-comment spend.
+	local raw_vals
+	raw_vals=$(printf '%s' "$bodies" |
+		sed -E 's/(spent )[0-9]+[dhms]( [0-9]+[mh])? and /\1/g' |
+		grep -oE '(spent|has used) [0-9,]+ tokens' |
+		grep -oE '[0-9,]+' |
+		tr -d ',' || true)
+
+	local total_tokens=0 attempts=0
+	if [[ -n "$raw_vals" ]]; then
+		local v
+		while IFS= read -r v; do
+			[[ -z "$v" ]] && continue
+			[[ "$v" =~ ^[0-9]+$ ]] || continue
+			total_tokens=$((total_tokens + v))
+			attempts=$((attempts + 1))
+		done <<<"$raw_vals"
+	fi
+
+	printf '%s|%s' "$total_tokens" "$attempts"
+	return 0
+}
+
+#######################################
+# Apply cost-breaker side effects: label + explanatory comment.
+# Idempotent — if needs-maintainer-review is already present, no-op.
+#
+# Args:
+#   $1 = issue number
+#   $2 = repo slug
+#   $3 = spent (tokens, integer)
+#   $4 = budget (tokens, integer)
+#   $5 = tier short name (simple|standard|reasoning)
+#   $6 = attempts count (integer)
+#   $7 = "true" if needs-maintainer-review label already set (skip side effects)
+#######################################
+_apply_cost_breaker_side_effects() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local spent="$3"
+	local budget="$4"
+	local tier="$5"
+	local attempts="$6"
+	local has_label="$7"
+
+	if [[ "$has_label" == "true" ]]; then
+		# Already escalated — no double-comment, signal still emitted by caller
+		return 0
+	fi
+
+	# Apply needs-maintainer-review label without touching core status labels
+	set_issue_status "$issue_number" "$repo_slug" "" \
+		--add-label "needs-maintainer-review" 2>/dev/null || true
+
+	local _spent_k=$((spent / 1000))
+	local _budget_k=$((budget / 1000))
+
+	gh issue comment "$issue_number" --repo "$repo_slug" \
+		--body "<!-- cost-circuit-breaker:fired tier=${tier} spent=${spent} budget=${budget} -->
+🛑 **Cost circuit breaker fired** (t2007)
+
+Cumulative spend **${_spent_k}K tokens** across **${attempts}** worker attempt(s) exceeds \`tier:${tier}\` budget of **${_budget_k}K tokens**.
+
+Further automated dispatch is suspended. Applied \`needs-maintainer-review\` label.
+
+Maintainer review required before further dispatch. Possible causes:
+- Brief is unimplementable as written (refine scope or split the task)
+- Hidden blocker (missing dependency, environment issue, design conflict)
+- Worker stuck in a loop (model can't decompose the task — escalate tier)
+- Wrong tier assigned (downgrade a tier:reasoning task to standard, or vice versa)
+
+Remove \`needs-maintainer-review\` after investigating the root cause to re-enable dispatch.
+
+_This is the cost-runaway fail-safe from t2007 (paired with t1986 parent-task guard and t2008 stale-recovery escalation)._" 2>/dev/null || true
+
+	return 0
+}
+
+#######################################
+# Check whether the cost-per-issue circuit breaker should fire for an issue.
+#
+# Aggregates token spend from all signature footers on the issue's comments
+# and compares against the tier-appropriate budget. If over budget, applies
+# the side effects (idempotent) and emits the COST_BUDGET_EXCEEDED signal.
+#
+# Args:
+#   $1 = issue number
+#   $2 = repo slug
+#   $3 = (optional) tier label or short name (default: standard)
+#   $4 = (optional) issue_meta_json — used for has-label idempotency check
+#
+# Stdout: COST_BUDGET_EXCEEDED line on block, nothing on allow.
+# Returns:
+#   0 = breaker fired (block dispatch)
+#   1 = under budget OR aggregation failed (fail-open: allow dispatch)
+#######################################
+_check_cost_budget() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local tier="${3:-standard}"
+	local issue_meta_json="${4:-}"
+
+	if [[ ! "$issue_number" =~ ^[0-9]+$ ]] || [[ -z "$repo_slug" ]]; then
+		return 1
+	fi
+
+	local budget
+	budget=$(_get_cost_budget_for_tier "$tier")
+	if [[ -z "$budget" ]] || ! [[ "$budget" =~ ^[0-9]+$ ]]; then
+		return 1
+	fi
+
+	local spend_data
+	spend_data=$(_sum_issue_token_spend "$issue_number" "$repo_slug") || return 1
+
+	local spent attempts
+	spent="${spend_data%%|*}"
+	attempts="${spend_data##*|}"
+
+	if ! [[ "$spent" =~ ^[0-9]+$ ]] || ! [[ "$attempts" =~ ^[0-9]+$ ]]; then
+		return 1
+	fi
+
+	if [[ "$spent" -le "$budget" ]]; then
+		# Under budget — allow dispatch
+		return 1
+	fi
+
+	# Over budget — check if needs-maintainer-review is already set (idempotency).
+	# When called via the CLI subcommand the caller doesn't pass issue_meta_json,
+	# so fetch it ourselves on the slow path. The hot path (is_assigned)
+	# always passes pre-fetched metadata to avoid a double round-trip.
+	if [[ -z "$issue_meta_json" ]]; then
+		issue_meta_json=$(gh issue view "$issue_number" --repo "$repo_slug" \
+			--json state,assignees,labels 2>/dev/null) || issue_meta_json=""
+	fi
+	local has_label="false"
+	if [[ -n "$issue_meta_json" ]]; then
+		local label_hit
+		label_hit=$(printf '%s' "$issue_meta_json" |
+			jq -r '[.labels[].name] | index("needs-maintainer-review") != null' 2>/dev/null) || label_hit="false"
+		[[ "$label_hit" == "true" ]] && has_label="true"
+	fi
+
+	# Apply side effects (no-op if has_label=true)
+	_apply_cost_breaker_side_effects "$issue_number" "$repo_slug" \
+		"$spent" "$budget" "${tier#tier:}" "$attempts" "$has_label"
+
+	# Emit signal for caller pattern matching (mirrors PARENT_TASK_BLOCKED)
+	printf 'COST_BUDGET_EXCEEDED (spent=%dK budget=%dK tier=%s attempts=%d)\n' \
+		"$((spent / 1000))" "$((budget / 1000))" "${tier#tier:}" "$attempts"
+	return 0
+}
+
+#######################################
 # Return "true" if the issue metadata represents an active claim that
 # should override the owner/maintainer passive-assignee exemption in
 # is_assigned(). An issue is actively claimed when EITHER:
@@ -819,6 +1071,24 @@ is_assigned() {
 		jq -r '[.labels[].name] | map(select(. == "parent-task" or . == "meta")) | .[0] // empty' 2>/dev/null)
 	if [[ -n "$parent_task_hit" ]]; then
 		printf 'PARENT_TASK_BLOCKED (label=%s)\n' "$parent_task_hit"
+		return 0
+	fi
+
+	# t2007: cost-per-issue circuit breaker. Aggregate token spend across all
+	# worker attempts; if the cumulative total exceeds the tier-appropriate
+	# budget, apply needs-maintainer-review and block dispatch. Fail-open on
+	# aggregation errors so unrelated GitHub API hiccups don't starve the queue.
+	# Closes the cost-runaway hole that t1986 (parent-task guard) and t2008
+	# (stale-recovery escalation) leave open: an issue with a correct tier
+	# assignment that workers can never finish (loop, hidden blocker, scope).
+	local _t2007_tier
+	_t2007_tier=$(printf '%s' "$issue_meta_json" |
+		jq -r '[.labels[].name] | map(select(startswith("tier:"))) | .[0] // "tier:standard"' 2>/dev/null)
+	[[ -z "$_t2007_tier" || "$_t2007_tier" == "null" ]] && _t2007_tier="tier:standard"
+	local _t2007_signal _t2007_rc=0
+	_t2007_signal=$(_check_cost_budget "$issue_number" "$repo_slug" "$_t2007_tier" "$issue_meta_json") || _t2007_rc=$?
+	if [[ "$_t2007_rc" -eq 0 ]]; then
+		printf '%s\n' "$_t2007_signal"
 		return 0
 	fi
 
@@ -1240,6 +1510,10 @@ Usage:
                                                      Check for recent "Dispatching worker" comment (exit 0=found, 1=none)
   dispatch-dedup-helper.sh is-assigned <issue> <slug> [self-login]
                                                        Check if assigned to another login (exit 0=blocked, 1=free)
+  dispatch-dedup-helper.sh check-cost-budget <issue> <slug> [tier]
+                                                       t2007: cost circuit breaker (exit 0=tripped, 1=under budget)
+  dispatch-dedup-helper.sh sum-issue-token-spend <issue> <slug>
+                                                       t2007: aggregate token spend (returns "spent|attempts")
   dispatch-dedup-helper.sh claim <issue> <slug> [runner-login]
                                                      Cross-machine claim lock (exit 0=won, 1=lost, 2=error)
   dispatch-dedup-helper.sh list-running-keys        List keys for all running workers
@@ -1321,6 +1595,23 @@ main() {
 			return 1
 		}
 		is_assigned "$1" "$2" "${3:-}"
+		;;
+	check-cost-budget)
+		# t2007: cost-per-issue circuit breaker. Direct entry point for tests
+		# and ad-hoc inspection. The same check fires inline from is-assigned.
+		[[ $# -lt 2 ]] && {
+			echo "Error: check-cost-budget requires <issue-number> <repo-slug> [tier]" >&2
+			return 1
+		}
+		_check_cost_budget "$1" "$2" "${3:-standard}"
+		;;
+	sum-issue-token-spend)
+		# t2007: read-only aggregator (no side effects). Useful for calibration.
+		[[ $# -lt 2 ]] && {
+			echo "Error: sum-issue-token-spend requires <issue-number> <repo-slug>" >&2
+			return 1
+		}
+		_sum_issue_token_spend "$1" "$2"
 		;;
 	has-dispatch-comment)
 		[[ $# -lt 2 ]] && {

--- a/.agents/scripts/tests/test-cost-circuit-breaker.sh
+++ b/.agents/scripts/tests/test-cost-circuit-breaker.sh
@@ -1,0 +1,331 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-cost-circuit-breaker.sh — t2007 regression guard.
+#
+# Asserts the per-issue cost circuit breaker fires when cumulative token
+# spend across all worker attempts exceeds the tier budget, and stays
+# fail-open on the unhappy paths.
+#
+# The breaker lives in dispatch-dedup-helper.sh::_check_cost_budget and
+# is wired into is_assigned() right after the parent-task short-circuit
+# (see t1986). It is paired with the no-progress fail-safe (t2008) and
+# the parent-task guard (t1986) — all three are different layers of
+# the same dispatch-hardening initiative from the GH#18356 root cause.
+#
+# Modeled on test-parent-task-guard.sh (t1986) — same stub-gh harness,
+# same TEST_RED/TEST_GREEN colour vars, same negative-assertion friendly
+# `set +e` after sourcing.
+
+# NOTE: not using `set -e` intentionally — negative assertions rely on
+# capturing non-zero exits from check-cost-budget. Each assertion explicitly
+# captures exit codes.
+set -uo pipefail
+
+TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+DEDUP_HELPER="${TEST_SCRIPTS_DIR}/dispatch-dedup-helper.sh"
+
+TEST_RED=$'\033[0;31m'
+TEST_GREEN=$'\033[0;32m'
+TEST_RESET=$'\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1" rc="$2" extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf '%sPASS%s %s\n' "$TEST_GREEN" "$TEST_RESET" "$name"
+	else
+		printf '%sFAIL%s %s %s\n' "$TEST_RED" "$TEST_RESET" "$name" "$extra"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+}
+
+# Sandbox HOME so config/state writes are side-effect-free
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+export HOME="${TEST_ROOT}/home"
+mkdir -p "${HOME}/.aidevops/logs" "${HOME}/.aidevops/.agent-workspace/supervisor"
+
+# =============================================================================
+# Stub harness — fake `gh` CLI that returns canned JSON for the calls
+# is_assigned and _sum_issue_token_spend make.
+# =============================================================================
+STUB_DIR="${TEST_ROOT}/bin"
+STUB_LOG="${TEST_ROOT}/gh-stub.log"
+mkdir -p "$STUB_DIR"
+
+# Fixture state files — the stub gh reads these to know what to return.
+FIXTURE_ISSUE_JSON="${TEST_ROOT}/fixture-issue.json"
+FIXTURE_COMMENTS_JSON="${TEST_ROOT}/fixture-comments.json"
+
+write_stub_gh() {
+	cat >"${STUB_DIR}/gh" <<STUB
+#!/usr/bin/env bash
+# Stub gh for test-cost-circuit-breaker.sh
+# Logs every invocation so we can assert side-effect counts.
+echo "\$@" >>"${STUB_LOG}"
+
+# gh issue view <num> --repo <slug> --json state,assignees,labels
+if [[ "\$1" == "issue" && "\$2" == "view" ]]; then
+	cat "${FIXTURE_ISSUE_JSON}" 2>/dev/null || echo '{}'
+	exit 0
+fi
+
+# gh api repos/<slug>/issues/<num>/comments --paginate
+if [[ "\$1" == "api" ]]; then
+	if [[ "\$2" == "repos/"*"/issues/"*"/comments" ]]; then
+		cat "${FIXTURE_COMMENTS_JSON}" 2>/dev/null || echo '[]'
+		exit 0
+	fi
+	if [[ "\$2" == "user" ]]; then
+		echo '{"login":"test-runner"}'
+		exit 0
+	fi
+	echo '{}'
+	exit 0
+fi
+
+# gh issue comment <num> --repo <slug> --body <body>
+if [[ "\$1" == "issue" && "\$2" == "comment" ]]; then
+	exit 0
+fi
+
+# gh issue edit <num> --repo <slug> ... (set_issue_status)
+if [[ "\$1" == "issue" && "\$2" == "edit" ]]; then
+	exit 0
+fi
+
+# gh label list / create (ensure_status_labels_exist)
+if [[ "\$1" == "label" ]]; then
+	if [[ "\$2" == "list" ]]; then
+		echo "[]"
+		exit 0
+	fi
+	exit 0
+fi
+
+# gh pr list (used elsewhere — not our paths)
+if [[ "\$1" == "pr" ]]; then
+	echo "[]"
+	exit 0
+fi
+
+exit 0
+STUB
+	chmod +x "${STUB_DIR}/gh"
+}
+
+write_fixture_issue() {
+	local labels_json="$1"
+	local assignees_json="${2:-[]}"
+	local state="${3:-OPEN}"
+	cat >"$FIXTURE_ISSUE_JSON" <<JSON
+{"state":"${state}","assignees":${assignees_json},"labels":${labels_json}}
+JSON
+}
+
+# Build a comments fixture from a list of token spends.
+# Args: $1 = comma-separated token amounts, e.g. "50000,80000,200000"
+write_fixture_comments() {
+	local spends="$1"
+	local comments=""
+	local first=1
+	local amount
+	for amount in ${spends//,/ }; do
+		if [[ "$first" -eq 0 ]]; then
+			comments+=","
+		fi
+		first=0
+		# Shape mirrors the real gh-signature-helper.sh footer
+		comments+="{\"body\":\"Worker comment.\\n\\n<!-- aidevops:sig -->\\n---\\n[aidevops.sh](https://aidevops.sh) v3.7.0 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 4m and ${amount} tokens on this as a headless worker.\"}"
+	done
+	printf '[%s]' "$comments" >"$FIXTURE_COMMENTS_JSON"
+}
+
+write_stub_gh
+OLD_PATH="$PATH"
+export PATH="${STUB_DIR}:${PATH}"
+
+# Set SCRIPT_DIR-equivalent so the helper finds its config (the real
+# helper resolves it at runtime from BASH_SOURCE — no env var needed).
+
+# =============================================================================
+# Part 1 — _get_cost_budget_for_tier reads the config (or falls back)
+# =============================================================================
+# We invoke check-cost-budget which uses _get_cost_budget_for_tier internally.
+# Indirect coverage: an over-budget spend at a known tier proves the lookup.
+
+# Helper: run check-cost-budget capturing both stdout and exit code.
+run_check_cost_budget() {
+	local issue="$1" repo="$2" tier="${3:-standard}"
+	output=$("$DEDUP_HELPER" check-cost-budget "$issue" "$repo" "$tier" 2>/dev/null)
+	rc=$?
+	return 0
+}
+
+# =============================================================================
+# Assertion 1 — under budget allows dispatch (rc=1, no signal)
+# =============================================================================
+# tier:standard budget = 100K. Spend 30K → under budget.
+write_fixture_issue '[{"name":"tier:standard"},{"name":"pulse"}]'
+write_fixture_comments "30000"
+run_check_cost_budget 18001 "owner/repo" "standard"
+if [[ "$rc" -eq 1 && -z "$output" ]]; then
+	print_result "under-budget allow (30K < 100K standard)" 0
+else
+	print_result "under-budget allow (30K < 100K standard)" 1 "(rc=$rc output='$output')"
+fi
+
+# =============================================================================
+# Assertion 2 — over budget blocks with COST_BUDGET_EXCEEDED signal
+# =============================================================================
+# tier:standard budget = 100K. Spend 60K + 80K = 140K → over budget.
+write_fixture_issue '[{"name":"tier:standard"},{"name":"pulse"}]'
+write_fixture_comments "60000,80000"
+run_check_cost_budget 18002 "owner/repo" "standard"
+if [[ "$rc" -eq 0 && "$output" == *"COST_BUDGET_EXCEEDED"* && "$output" == *"attempts=2"* ]]; then
+	print_result "over-budget block emits COST_BUDGET_EXCEEDED (140K > 100K, 2 attempts)" 0
+else
+	print_result "over-budget block emits COST_BUDGET_EXCEEDED (140K > 100K, 2 attempts)" 1 \
+		"(rc=$rc output='$output')"
+fi
+
+# =============================================================================
+# Assertion 3 — no comments → fail-open (treated as 0 spend, allow)
+# =============================================================================
+write_fixture_issue '[{"name":"tier:standard"}]'
+printf '[]' >"$FIXTURE_COMMENTS_JSON"
+run_check_cost_budget 18003 "owner/repo" "standard"
+if [[ "$rc" -eq 1 ]]; then
+	print_result "no-comments fail-open (zero spend allowed)" 0
+else
+	print_result "no-comments fail-open (zero spend allowed)" 1 "(rc=$rc output='$output')"
+fi
+
+# =============================================================================
+# Assertion 4 — gh API failure → fail-open
+# =============================================================================
+# Make the comments fixture invalid JSON so jq fails inside the aggregator.
+write_fixture_issue '[{"name":"tier:standard"}]'
+printf 'not-valid-json' >"$FIXTURE_COMMENTS_JSON"
+run_check_cost_budget 18004 "owner/repo" "standard"
+if [[ "$rc" -eq 1 ]]; then
+	print_result "gh API/parse error fail-open" 0
+else
+	print_result "gh API/parse error fail-open" 1 "(rc=$rc output='$output')"
+fi
+
+# =============================================================================
+# Assertion 5 — per-tier budget enforcement: tier:simple = 30K, spend 50K → block
+# =============================================================================
+write_fixture_issue '[{"name":"tier:simple"}]'
+write_fixture_comments "20000,30000"
+run_check_cost_budget 18005 "owner/repo" "simple"
+if [[ "$rc" -eq 0 && "$output" == *"COST_BUDGET_EXCEEDED"* && "$output" == *"tier=simple"* ]]; then
+	print_result "tier:simple budget (50K > 30K) blocks" 0
+else
+	print_result "tier:simple budget (50K > 30K) blocks" 1 "(rc=$rc output='$output')"
+fi
+
+# =============================================================================
+# Assertion 6 — same spend (50K) on tier:reasoning is well under budget (300K)
+# =============================================================================
+write_fixture_issue '[{"name":"tier:reasoning"}]'
+write_fixture_comments "20000,30000"
+run_check_cost_budget 18006 "owner/repo" "reasoning"
+if [[ "$rc" -eq 1 ]]; then
+	print_result "tier:reasoning budget (50K < 300K) allows" 0
+else
+	print_result "tier:reasoning budget (50K < 300K) allows" 1 "(rc=$rc output='$output')"
+fi
+
+# =============================================================================
+# Assertion 7 — side-effect idempotency: when needs-maintainer-review is
+# already present, _apply_cost_breaker_side_effects must NOT post a new
+# `gh issue comment` call. We measure by comparing stub log lines before
+# and after a second over-budget invocation on the same issue.
+# =============================================================================
+# Fresh log so the count is local to this assertion
+: >"$STUB_LOG"
+# Fixture: over budget AND needs-maintainer-review already on the issue
+write_fixture_issue '[{"name":"tier:standard"},{"name":"needs-maintainer-review"}]'
+write_fixture_comments "60000,80000"
+run_check_cost_budget 18007 "owner/repo" "standard"
+# The signal must still be emitted (so dispatch is blocked)…
+if [[ "$rc" -eq 0 && "$output" == *"COST_BUDGET_EXCEEDED"* ]]; then
+	idem_signal_ok=0
+else
+	idem_signal_ok=1
+fi
+# …but no `issue comment` calls should have been logged.
+if grep -qE '^issue comment ' "$STUB_LOG"; then
+	idem_no_comment_ok=1
+else
+	idem_no_comment_ok=0
+fi
+if [[ "$idem_signal_ok" -eq 0 && "$idem_no_comment_ok" -eq 0 ]]; then
+	print_result "side-effect idempotency (label present → no double-comment)" 0
+else
+	print_result "side-effect idempotency (label present → no double-comment)" 1 \
+		"(signal_ok=$idem_signal_ok no_comment_ok=$idem_no_comment_ok output='$output')"
+fi
+
+# =============================================================================
+# Assertion 8 — unknown tier falls back to default budget (100K)
+# =============================================================================
+# Spend 150K on an issue with no tier:* label → should block (default = 100K).
+write_fixture_issue '[{"name":"pulse"}]'
+write_fixture_comments "75000,75000"
+run_check_cost_budget 18008 "owner/repo" "unknown-tier-name"
+if [[ "$rc" -eq 0 && "$output" == *"COST_BUDGET_EXCEEDED"* ]]; then
+	print_result "unknown-tier falls back to default budget (150K > 100K default)" 0
+else
+	print_result "unknown-tier falls back to default budget (150K > 100K default)" 1 \
+		"(rc=$rc output='$output')"
+fi
+
+# =============================================================================
+# Assertion 9 — sum-issue-token-spend CLI returns parseable spent|attempts
+# =============================================================================
+write_fixture_comments "10000,20000,30000"
+sum_output=$("$DEDUP_HELPER" sum-issue-token-spend 18009 "owner/repo" 2>/dev/null)
+if [[ "$sum_output" == "60000|3" ]]; then
+	print_result "sum-issue-token-spend CLI returns 'spent|attempts'" 0
+else
+	print_result "sum-issue-token-spend CLI returns 'spent|attempts'" 1 "(got: '$sum_output')"
+fi
+
+# =============================================================================
+# Assertion 10 — historical "has used N tokens" pattern still aggregated
+# =============================================================================
+# Write fixture with the older signature footer wording.
+cat >"$FIXTURE_COMMENTS_JSON" <<'JSON'
+[
+  {"body":"Older worker.\n---\nclaude-sonnet-4-6 has used 50000 tokens on this."},
+  {"body":"Newer worker.\n---\nclaude-sonnet-4-6 spent 70000 tokens on this."}
+]
+JSON
+sum_output=$("$DEDUP_HELPER" sum-issue-token-spend 18010 "owner/repo" 2>/dev/null)
+if [[ "$sum_output" == "120000|2" ]]; then
+	print_result "historical 'has used' pattern aggregated alongside 'spent'" 0
+else
+	print_result "historical 'has used' pattern aggregated alongside 'spent'" 1 "(got: '$sum_output')"
+fi
+
+export PATH="$OLD_PATH"
+
+# =============================================================================
+# Summary
+# =============================================================================
+echo
+if [[ "$TESTS_FAILED" -eq 0 ]]; then
+	printf '%sAll %d tests passed%s\n' "$TEST_GREEN" "$TESTS_RUN" "$TEST_RESET"
+	exit 0
+else
+	printf '%s%d / %d tests failed%s\n' "$TEST_RED" "$TESTS_FAILED" "$TESTS_RUN" "$TEST_RESET"
+	exit 1
+fi


### PR DESCRIPTION
Resolves #18455

## Summary

Implements the per-issue cost circuit breaker (t2007) — Tier B systemic fix from the GH#18356 root-cause analysis. Closes the cost-runaway hole that t1986 (parent-task guard) and t2008 (stale-recovery escalation) leave open: an issue where workers fail repeatedly without ever crossing the parent-task or no-progress thresholds.

## Where the check fires

In `is_assigned()` (`dispatch-dedup-helper.sh`) **after** the parent-task short-circuit but **before** the assignee check. This matches the brief's recommendation and is the right layer because:

- Parent-task block is unconditional → must run first (cheap, no extra API calls).
- Cost-budget block is also unconditional once tripped → should run before the more expensive assignee/stale-recovery work, so cost-tripped issues are surfaced at the same dedup-signal level as `PARENT_TASK_BLOCKED`.
- Same emit-and-return-0 pattern: stdout signal + `return 0`, callers pattern-match on `COST_BUDGET_EXCEEDED` exactly like `PARENT_TASK_BLOCKED`.

The check reuses the issue metadata that `is_assigned` already fetched (passed as the optional 4th arg to `_check_cost_budget`), so the `needs-maintainer-review` idempotency check costs zero extra API calls on the hot path. The CLI subcommand fetches metadata itself for testability and ad-hoc use.

## How spend is aggregated

`_sum_issue_token_spend(issue, repo)` parses signature footers from `gh api .../comments` (paginated, all comments). Pattern handling:

```text
"spent 30,000 tokens"            → 30000
"spent 4m and 30,000 tokens"     → 30000
"spent 1h 30m and 30,000 tokens" → 30000
"has used 30,000 tokens"         → 30000  (historical wording)
```

The aggregator collapses any `<time> and ` infix first (covers `Xs/Xm/Xh/Xd/Xh Ym`), then matches the simple form. The cumulative `N total tokens on this issue` line is intentionally not counted (it is the running aggregate of prior comments and would double-count every cycle).

**No author filter.** The breaker is per-issue, not per-runner — multiple runners or interactive sessions on the same issue all contribute to the budget. (`gh-signature-helper.sh::_sum_issue_tokens` uses an author filter for a different purpose: showing "your total contribution" in the current footer.)

## Failure mode: fail-open

Every aggregation path that could fail returns `1` (allow dispatch):

- `gh api` errors → fail-open
- malformed JSON → fail-open
- empty/no comments → "0|0" → 0 ≤ budget → allow
- non-numeric spend → fail-open

The breaker is a safety net, not a hard gate. If we can't compute spend reliably, the other dedup layers still apply (parent-task, assignee, stale recovery, dispatch comment, claim lock, has-open-pr).

## Side effects (idempotent)

When tripped, `_apply_cost_breaker_side_effects` applies `needs-maintainer-review` via `set_issue_status` (atomic with the existing label-clear flow) and posts an explanatory comment with diagnostic context (spend, attempts, tier, common root causes). **Idempotency**: if `needs-maintainer-review` is already on the issue, the side effects are skipped but the `COST_BUDGET_EXCEEDED` signal is still emitted on every cycle — so the dispatch block stays effective without flooding the issue with duplicate comments.

## Tier resolution

Reads the `tier:*` label from the issue metadata that `is_assigned` already fetched. Falls back to `tier:standard` when no label is present. Budgets live in a sourceable config:

| Tier | Budget | Rationale |
|---|---:|---|
| `tier:simple` | 30,000 | ~3× a typical haiku run |
| `tier:standard` | 100,000 | ~3× a typical sonnet run |
| `tier:reasoning` | 300,000 | ~3× a typical opus run |
| (default) | 100,000 | defensive fallback |

Config: `.agents/configs/dispatch-cost-budgets.conf` — tunable without code changes.

## Calibration sample (production data)

Sanity-check on the live repo using the new `sum-issue-token-spend` CLI (signature footers in marcusquinn/aidevops issues):

| Issue | Spend|Attempts | Notes |
|---|---|---|
| #18452 | 22,065 / 1 | Single sonnet attempt |
| #18439 | 7,856 / 1 | Single sonnet attempt |
| #17372 | 3,510 / 1 | Single haiku attempt |
| #17541 | 305 / 1 | Tiny attempt |
| #18356 | 10,287 / 1 | Tier:reasoning, ~10K — the original incident |
| **#18455** (this one) | **0 / 0** | All 5 prior workers crashed before posting any signature footer — proves the breaker would not have fired here even with unlimited cycles, because the signal is missing entirely. **Stale-recovery escalation (t2008) is the right layer for this failure mode**, not cost. |

Distribution observation: typical successful sonnet attempts come in well under the 100K standard budget. The 30K simple / 100K standard / 300K reasoning thresholds give 3-5x headroom over typical spend, allowing legitimate retries without false-positive blocking. **Calibration follow-up** (Phase 5 in the brief): after 1 week of running, review which issues hit the breaker and adjust the config.

## Acceptance criteria

- [x] Spend distribution analysis documented in PR body (above)
- [x] `_check_cost_budget()` implemented in `dispatch-dedup-helper.sh`
- [x] CLI subcommand `check-cost-budget` exposed for testability
- [x] CLI subcommand `sum-issue-token-spend` exposed for calibration
- [x] Wired into dispatch flow at the agreed insertion point in `is_assigned()` (after parent-task, before assignee — see code comment)
- [x] New test file `tests/test-cost-circuit-breaker.sh` with **10 assertions**:
  1. under-budget allow (30K < 100K standard)
  2. over-budget block emits `COST_BUDGET_EXCEEDED` (140K > 100K, 2 attempts)
  3. no-comments fail-open (zero spend allowed)
  4. gh API/parse error fail-open
  5. tier:simple budget enforced (50K > 30K → block)
  6. tier:reasoning budget enforced (50K < 300K → allow)
  7. side-effect idempotency (label present → no double-comment, signal still emitted)
  8. unknown-tier falls back to default budget (150K > 100K default → block)
  9. `sum-issue-token-spend` CLI returns parseable `spent|attempts`
  10. historical `has used N tokens` pattern aggregated alongside `spent`
- [x] Existing tests still pass: `test-parent-task-guard.sh` (20/20), `test-dispatch-dedup-helper-is-assigned.sh` (16/16), `test-dispatch-dedup-multi-operator.sh` (7/7), `test-tier-label-dedup.sh` (13/13)
- [x] Budget rationale and calibration plan documented (above)

## Files changed

- **NEW** `.agents/configs/dispatch-cost-budgets.conf` — tunable per-tier budgets
- **EDIT** `.agents/scripts/dispatch-dedup-helper.sh` — adds `_check_cost_budget`, `_sum_issue_token_spend`, `_apply_cost_breaker_side_effects`, `_get_cost_budget_for_tier`; wires into `is_assigned()`; exposes `check-cost-budget` and `sum-issue-token-spend` CLI subcommands
- **NEW** `.agents/scripts/tests/test-cost-circuit-breaker.sh` — 10 assertions, stub-gh harness modeled on `test-parent-task-guard.sh`

## Bonus fix

The signature-footer regex in `_sum_issue_token_spend` correctly handles the **`spent <time> and N tokens`** form that the existing `gh-signature-helper.sh::_sum_issue_tokens` regex misses (`(spent|has used) [0-9,]+ tokens` doesn't match `spent 4m and 30,000 tokens`). The dispatch-dedup version handles all four format variants observed in production. A separate follow-up should fix the same regex in `gh-signature-helper.sh`.

## Out of scope (per brief)

- Killing already-running workers that exceed budget (separate concern: requires cross-runner kill signal)
- Per-PR cost tracking (this is per-ISSUE; PRs are the byproduct)
- Token cost attribution to specific models or providers (the budget is total)
- Phase 5 production calibration (1-week observation window, follow-up issue)

## Runtime Testing

`self-assessed` — risk:medium (dispatch dedup logic, fail-open by design). Verified via:

- All 10 new test assertions pass with stub-gh harness
- All existing dispatch dedup tests still pass (56 total assertions across 4 suites)
- Live aggregator validated against 6 real production issues — regex matches signature footers in actual marcusquinn/aidevops comments
- ShellCheck clean on `dispatch-dedup-helper.sh` and `tests/test-cost-circuit-breaker.sh`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.0 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 13m and 34,873 tokens on this as a headless worker. Overall, 4h 42m since this issue was created.