### PR TITLE
GH#18532: fix(maintainer-gate): add origin:interactive exemption to Job 3

### DIFF
--- a/.github/workflows/maintainer-gate.yml
+++ b/.github/workflows/maintainer-gate.yml
@@ -525,6 +525,37 @@ jobs:
               continue
             fi
 
+            # -----------------------------------------------------------------
+            # Check -1 mirror: origin:interactive — skip pending + rerun for
+            # maintainer-authored interactive PRs (GH#18532, mirrors Job 1).
+            # When an issue changes, Job 3 would otherwise post a "pending"
+            # status that temporarily overrides Job 1's prior "success" for
+            # origin:interactive PRs. For those PRs the gate will always pass,
+            # so post success directly and skip the rerun entirely.
+            #
+            # Security gate: same as Job 1 — only OWNER or MEMBER. COLLABORATOR
+            # is excluded (write-access contributors must still use the normal gate).
+            # -----------------------------------------------------------------
+            PR_INFO=$(gh pr view "$PR_NUM" --repo "$REPO" \
+              --json labels,authorAssociation \
+              --jq '{labels: [.labels[].name], assoc: .authorAssociation}' \
+              2>/dev/null || true)
+            PR_LABELS_J3=$(printf '%s' "$PR_INFO" | jq -r '.labels[]' 2>/dev/null || true)
+            PR_AUTHOR_ASSOC_J3=$(printf '%s' "$PR_INFO" | jq -r '.assoc' 2>/dev/null || true)
+            if printf '%s' "$PR_LABELS_J3" | grep -q 'origin:interactive'; then
+              if [[ "$PR_AUTHOR_ASSOC_J3" == "OWNER" ]] || \
+                 [[ "$PR_AUTHOR_ASSOC_J3" == "MEMBER" ]]; then
+                echo "SKIP rerun: PR #$PR_NUM has origin:interactive and author is maintainer ($PR_AUTHOR_ASSOC_J3) — posting success, no Job 1 rerun needed"
+                gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
+                  --method POST \
+                  -f state=success \
+                  -f context="maintainer-gate" \
+                  -f description="origin:interactive by maintainer — implied approval (Job 3 exemption)" \
+                  2>/dev/null || true
+                continue
+              fi
+            fi
+
             # Post pending status while Job 1 re-evaluates
             # t2037: Job 3 is pure plumbing — gate evaluation is Job 1's sole responsibility
             gh api "repos/${REPO}/statuses/${HEAD_SHA}" \


### PR DESCRIPTION
## Summary

Adds the `origin:interactive` exemption to Job 3 (`retrigger-pr-checks`) in `.github/workflows/maintainer-gate.yml`, mirroring the Check -1 logic added in Job 1 by PR #18512 (t2030).

- When an issue's labels or assignees change, Job 3 finds linked open PRs and posts a `pending` status before triggering a Job 1 rerun.
- For PRs with `origin:interactive` authored by OWNER or MEMBER, the gate will always pass — posting `pending` is unnecessary churn that temporarily downgrades a prior `success` status.
- Fix: after fetching `HEAD_SHA`, fetch PR labels and `authorAssociation`; if `origin:interactive` + OWNER/MEMBER, post `success` directly and `continue` (skipping `pending` + rerun).

Security gate is identical to Job 1: COLLABORATOR is excluded (write-access contributors still go through the normal gate).

## Files Modified

- EDIT: `.github/workflows/maintainer-gate.yml` — added Check -1 mirror block inside the `for PR_NUM in $OPEN_PRS` loop in Job 3 (after line ~526, before the `pending` status post)

## Reference pattern

Follows the same structure as Job 1's Check -1 at lines 164–202 of the same file.

## Verification

1. Create a PR with `origin:interactive` label, authored by OWNER, linking an issue (`Resolves #NNN`).
2. Add/remove a label on the linked issue.
3. Job 3 should log `SKIP rerun: PR #NNN has origin:interactive and author is maintainer (OWNER) — posting success, no Job 1 rerun needed` and post `success` — no `pending` state observed on the PR.

Resolves #18532