### PR TITLE
GH#18534: docs(pr-loop): clarify webhook trigger delay on protect-labels timing

### DIFF
--- a/.agents/workflows/pr-loop.md
+++ b/.agents/workflows/pr-loop.md
@@ -62,7 +62,7 @@ After user-only fixes, the required `Maintainer Review & Assignee Gate` CheckRun
 
 If the required CheckRun does NOT refresh within ~60 seconds after an approval, fall back to manual: `gh run rerun <run_id> --failed` against the latest `Maintainer Gate` workflow run for the PR's HEAD SHA.
 
-**Hard rule:** NEVER remove `needs-maintainer-review` by direct `gh issue edit --remove-label`. The `protect-labels` job in `maintainer-gate.yml` re-applies it ~7 seconds later unless a `<!-- aidevops-signed-approval -->` comment exists on the issue. Removing the label without the signed comment is a guaranteed-to-fail path that wastes tool calls.
+**Hard rule:** NEVER remove `needs-maintainer-review` by direct `gh issue edit --remove-label`. The `protect-labels` job in `maintainer-gate.yml` re-applies it ~7 seconds later (webhook trigger delay) unless a `<!-- aidevops-signed-approval -->` comment exists on the issue. Removing the label without the signed comment is a guaranteed-to-fail path that wastes tool calls.
 
 ## Completion Promises
 


### PR DESCRIPTION
## Summary

- Addresses the unresolved CodeRabbit nitpick from PR #18495 review
- Adds `(webhook trigger delay)` parenthetical to the `~7s` timing note in the `protect-labels` hard rule in `.agents/workflows/pr-loop.md:65`
- Explains *why* the 7-second delay exists (webhook trigger latency), making the timing guidance more informative for future readers

## Change

**File:** `.agents/workflows/pr-loop.md` line 65

```diff
-re-applies it ~7 seconds later unless
+re-applies it ~7 seconds later (webhook trigger delay) unless
```

## Context

PR #18495 (t2027) was merged with two CodeRabbit review suggestions:
1. **Critical**: "Job 3" → `retrigger-pr-checks` — addressed in the PR's final commits
2. **Minor**: `blocked-by:` in t2027 TODO — disputed by owner as a hallucinated requirement (t2027 is already complete)
3. **Nitpick**: Add timing explanation parenthetical at line 65 — this PR addresses it

Resolves #18534


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.1 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 3m and 7,279 tokens on this as a headless worker.