### PR TITLE
GH#18537: fix(dispatch-dedup) — (.labels // []) null-fallback for all label jq filters

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -908,7 +908,7 @@ _check_cost_budget() {
 	if [[ -n "$issue_meta_json" ]]; then
 		local label_hit
 		label_hit=$(printf '%s' "$issue_meta_json" |
-			jq -r '[.labels[].name] | index("needs-maintainer-review") != null' 2>/dev/null) || label_hit="false"
+			jq -r '[(.labels // [])[].name] | index("needs-maintainer-review") != null' 2>/dev/null) || label_hit="false"
 		[[ "$label_hit" == "true" ]] && has_label="true"
 	fi
 
@@ -954,7 +954,7 @@ _has_active_claim() {
 	local issue_meta_json="$1"
 	local result
 	result=$(printf '%s' "$issue_meta_json" | jq -r '
-		[.labels[].name] as $labels |
+		[(.labels // [])[].name] as $labels |
 		(
 			($labels | index("status:queued") != null) or
 			($labels | index("status:in-progress") != null) or
@@ -1068,7 +1068,7 @@ is_assigned() {
 	# (mirrors the STALE_RECOVERED token used by stale-recovery path).
 	local parent_task_hit
 	parent_task_hit=$(printf '%s' "$issue_meta_json" |
-		jq -r '[.labels[].name] | map(select(. == "parent-task" or . == "meta")) | .[0] // empty' 2>/dev/null)
+		jq -r '(.labels // [])[].name | select(. == "parent-task" or . == "meta")' | head -n 1 || true)
 	if [[ -n "$parent_task_hit" ]]; then
 		printf 'PARENT_TASK_BLOCKED (label=%s)\n' "$parent_task_hit"
 		return 0
@@ -1083,7 +1083,7 @@ is_assigned() {
 	# assignment that workers can never finish (loop, hidden blocker, scope).
 	local _t2007_tier
 	_t2007_tier=$(printf '%s' "$issue_meta_json" |
-		jq -r '[.labels[].name] | map(select(startswith("tier:"))) | .[0] // "tier:standard"' 2>/dev/null)
+		jq -r '[(.labels // [])[].name] | map(select(startswith("tier:"))) | .[0] // "tier:standard"' 2>/dev/null)
 	[[ -z "$_t2007_tier" || "$_t2007_tier" == "null" ]] && _t2007_tier="tier:standard"
 	local _t2007_signal _t2007_rc=0
 	_t2007_signal=$(_check_cost_budget "$issue_number" "$repo_slug" "$_t2007_tier" "$issue_meta_json") || _t2007_rc=$?
@@ -1318,7 +1318,7 @@ _get_active_claim_meta() {
 	local is_open has_assignee has_active_status
 	is_open=$(printf '%s' "$issue_meta_json" | jq -r '.state == "OPEN"' 2>/dev/null)
 	has_assignee=$(printf '%s' "$issue_meta_json" | jq -r '(.assignees | length) > 0' 2>/dev/null)
-	has_active_status=$(printf '%s' "$issue_meta_json" | jq -r '([.labels[].name] | (index("status:queued") != null or index("status:in-progress") != null))' 2>/dev/null)
+	has_active_status=$(printf '%s' "$issue_meta_json" | jq -r '([(.labels // [])[].name] | (index("status:queued") != null or index("status:in-progress") != null))' 2>/dev/null)
 
 	[[ "$is_open" == "true" || "$is_open" == "false" ]] || is_open="false"
 	[[ "$has_assignee" == "true" || "$has_assignee" == "false" ]] || has_assignee="false"

--- a/.agents/scripts/tests/test-parent-task-guard.sh
+++ b/.agents/scripts/tests/test-parent-task-guard.sh
@@ -231,6 +231,28 @@ else
 	print_result "is-assigned blocks CLOSED parent-task issue (label-first precedence)" 1 "(rc=$rc output='$output')"
 fi
 
+# Case F: labels key is null (missing from response) — must not error, must
+# allow dispatch (no parent-task label = not blocked). Validates the
+# `(.labels // [])` null-fallback fix from GH#18537.
+write_stub_gh '{"state":"OPEN","assignees":[],"labels":null}'
+run_is_assigned 99994 "owner/repo"
+if [[ "$rc" -eq 1 && "$output" != *"PARENT_TASK_BLOCKED"* ]]; then
+	print_result "is-assigned allows dispatch when labels key is null (null-fallback safety)" 0
+else
+	print_result "is-assigned allows dispatch when labels key is null (null-fallback safety)" 1 \
+		"(rc=$rc output='$output')"
+fi
+
+# Case G: labels key absent entirely — must not error, must allow dispatch.
+write_stub_gh '{"state":"OPEN","assignees":[]}'
+run_is_assigned 99993 "owner/repo"
+if [[ "$rc" -eq 1 && "$output" != *"PARENT_TASK_BLOCKED"* ]]; then
+	print_result "is-assigned allows dispatch when labels key is absent (null-fallback safety)" 0
+else
+	print_result "is-assigned allows dispatch when labels key is absent (null-fallback safety)" 1 \
+		"(rc=$rc output='$output')"
+fi
+
 export PATH="$OLD_PATH"
 
 # =============================================================================


### PR DESCRIPTION
Resolves #18537

## Why

PR #18419 (t1986 parent-task guard) introduced five jq label filters that iterate `.labels[].name` directly. If the GitHub API returns a response where `.labels` is `null` or the key is absent entirely, `jq` throws an error and the surrounding shell code falls back to safe defaults — but the failure path is silent and opaque. Gemini's review flagged this as fragile and suggested using the `// []` null-coalescing fallback operator.

## What

**`dispatch-dedup-helper.sh` — 5 filters hardened:**

| Location | Old pattern | New pattern |
|---|---|---|
| `_has_active_claim` (line ~957) | `[.labels[].name] as $labels` | `[(.labels // [])[].name] as $labels` |
| `_check_cost_budget` needs-maintainer-review (line ~911) | `[.labels[].name] \| index(...)` | `[(.labels // [])[].name] \| index(...)` |
| `is_assigned` parent-task hit (line ~1071) | `[.labels[].name] \| map(select(...)) \| .[0] // empty` | `(.labels // [])[].name \| select(...) \| head -n 1 \|\| true` |
| `is_assigned` tier label (line ~1086) | `[.labels[].name] \| map(select(startswith("tier:")))` | `[(.labels // [])[].name] \| map(...)` |
| `normalize_active_issue_assignments` (line ~1321) | `([.labels[].name] \| ...)` | `([(.labels // [])[].name] \| ...)` |

The parent-task hit path additionally uses Gemini's exact suggestion: pipe through `head -n 1 || true` instead of `| .[0] // empty`, which removes `2>/dev/null` (errors remain visible) while still preventing `set -e` propagation on optional lookups.

**`tests/test-parent-task-guard.sh` — 2 new regression cases (Cases F and G):**

- **Case F**: `"labels": null` — verifies `is-assigned` fails-open (rc=1, no PARENT_TASK_BLOCKED) rather than erroring on a null labels array.
- **Case G**: labels key absent entirely — same assertion for completely missing `.labels`.

## Verification

```
bash -n .agents/scripts/dispatch-dedup-helper.sh  # ✓ clean
shellcheck .agents/scripts/dispatch-dedup-helper.sh  # ✓ 0 new violations
bash .agents/scripts/tests/test-parent-task-guard.sh  # ✓ 22/22 pass (was 20/20)
```


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.1 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 3m and 9,689 tokens on this as a headless worker.