### PR TITLE
GH#18542: fix(docs): prefix build-agent path with .agents/ for consistency

### DIFF
--- a/.agents/tools/build-agent/build-agent.md
+++ b/.agents/tools/build-agent/build-agent.md
@@ -18,7 +18,7 @@ mode: subagent
 - **MCP servers**: Disabled globally, enabled per-agent
 - **Code refs**: `rg "pattern"` search patterns, not `file:line` (line numbers drift)
 - **Subagents**: `agent-review.md` (review), `agent-testing.md` (testing)
-- **Slash command**: `/build-agent {name} {kind} [category]` → `scripts/commands/build-agent.md` (interactive harness for creating new agents)
+- **Slash command**: `/build-agent {name} {kind} [category]` → `.agents/scripts/commands/build-agent.md` (interactive harness for creating new agents)
 - **Related**: `@code-standards`, `.agents/aidevops/architecture.md`, `tools/browser/browser-automation.md`
 - **After creating/promoting**: `~/.aidevops/agents/scripts/subagent-index-helper.sh generate`
 - **Testing**: `agent-test-helper.sh run my-tests` or `claude -p "Test query"`


### PR DESCRIPTION
## Summary

- Fixes the path `scripts/commands/build-agent.md` → `.agents/scripts/commands/build-agent.md` in `.agents/tools/build-agent/build-agent.md`
- Addresses Gemini review bot feedback from PR #18415: path should be prefixed with `.agents/` to maintain consistency with all other repository-relative paths in the file

## Files Changed

- EDIT: `.agents/tools/build-agent/build-agent.md` line 21 — corrected path prefix

## Verification

- `markdownlint-cli2 .agents/tools/build-agent/build-agent.md` → 0 errors
- Path `.agents/scripts/commands/build-agent.md` confirmed to exist via `git ls-files`

Resolves #18542