### PR TITLE
t2042: fix(dispatch): clean stale gate comments + classify zero-artifact stale-recovery

### DIFF
--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -135,6 +135,75 @@ has_worker_for_repo_issue() {
 }
 
 #######################################
+# Classify a stale-recovered worker by what (if anything) it produced
+# before stalling. Used by the STALE_RECOVERED branch in
+# _dispatch_dedup_check_layers to give escalate_issue_tier a meaningful
+# crash_type instead of leaving it empty.
+#
+# t2042: addresses the diagnostic gap on #18418 where two stale-recovered
+# workers escalated to tier:reasoning with reason="stale_timeout" and no
+# crash_type, so the cascade comment couldn't tell the next worker
+# whether it was a no-work infra failure or a partial implementation
+# stall.
+#
+# Returns one of:
+#   "partial"  — open PR or remote branch references this issue
+#                (worker reached at least the worktree/PR stage)
+#   "no_work"  — no PR, no branch (worker died before producing any
+#                durable artifact — transient/infrastructure failure)
+#
+# Arguments:
+#   $1 - issue_number
+#   $2 - repo_slug
+# Output: crash_type string on stdout
+#######################################
+_classify_stale_recovery_crash_type() {
+	local issue_number="$1"
+	local repo_slug="$2"
+
+	[[ "$issue_number" =~ ^[0-9]+$ ]] || {
+		printf 'no_work'
+		return 0
+	}
+	[[ -n "$repo_slug" ]] || {
+		printf 'no_work'
+		return 0
+	}
+
+	# Fast path: open PR exists referencing the issue. Worker got far
+	# enough to produce a PR — definitely "partial".
+	local _open_pr_count
+	_open_pr_count=$(gh pr list --repo "$repo_slug" --state open \
+		--search "#${issue_number} in:body" --limit 1 \
+		--json number --jq 'length' 2>/dev/null) || _open_pr_count=0
+	[[ "$_open_pr_count" =~ ^[0-9]+$ ]] || _open_pr_count=0
+	if [[ "$_open_pr_count" -gt 0 ]]; then
+		printf 'partial'
+		return 0
+	fi
+
+	# Second check: any remote branch whose name references the issue
+	# number. Workers create branches like `bugfix/t1992-...`,
+	# `feature/auto-...-issue-18418`, or contain `gh-18418`. If we find
+	# anything, the worker reached the worktree-creation stage.
+	local _branch_count
+	_branch_count=$(gh api "repos/${repo_slug}/branches" --paginate \
+		--jq "[.[] | select(.name | test(\"(t|gh-?)${issue_number}([^0-9]|\$)\"))] | length" \
+		2>/dev/null) || _branch_count=0
+	[[ "$_branch_count" =~ ^[0-9]+$ ]] || _branch_count=0
+	if [[ "$_branch_count" -gt 0 ]]; then
+		printf 'partial'
+		return 0
+	fi
+
+	# No PR, no branch — the worker died before producing any durable
+	# artifact. Classify as no_work so the cascade tier escalation
+	# comment renders the "Likely infrastructure/transient failure" line.
+	printf 'no_work'
+	return 0
+}
+
+#######################################
 # Check if dispatching a worker would be a duplicate (GH#4400, GH#5210, GH#6696, GH#11086)
 #
 # Seven-layer dedup:
@@ -249,8 +318,14 @@ check_dispatch_dedup() {
 		# dispatch→timeout→stale-recovery cycles. Observed: 8+ dispatches in 6h
 		# with 0 PRs and 0 fast-fail entries (GH#17700, GH#17701, GH#17702).
 		if [[ "$assigned_output" == *STALE_RECOVERED* ]]; then
-			echo "[pulse-wrapper] Dedup: stale recovery detected for #${issue_number} in ${repo_slug} — recording fast-fail (t1927)" >>"$LOGFILE"
-			fast_fail_record "$issue_number" "$repo_slug" "stale_timeout" || true
+			# t2042: classify what (if anything) the dead worker produced
+			# before stalling so the cascade tier escalation comment can
+			# render a "Crash type: no_work | partial" diagnostic line
+			# instead of a bare "Reason: stale_timeout" with no signal.
+			local _stale_crash_type
+			_stale_crash_type=$(_classify_stale_recovery_crash_type "$issue_number" "$repo_slug")
+			echo "[pulse-wrapper] Dedup: stale recovery detected for #${issue_number} in ${repo_slug} crash_type=${_stale_crash_type} — recording fast-fail (t1927/t2042)" >>"$LOGFILE"
+			fast_fail_record "$issue_number" "$repo_slug" "stale_timeout" "" "$_stale_crash_type" || true
 		fi
 	fi
 
@@ -937,6 +1012,13 @@ _Automated by \`_issue_targets_large_files()\` in pulse-wrapper.sh_"
 		gh issue edit "$issue_number" --repo "$repo_slug" \
 			--remove-label "needs-simplification" >/dev/null 2>&1 || true
 		echo "[pulse-wrapper] Simplification gate cleared for #${issue_number} (${repo_slug}) — no large files after exclusion filter" >>"$LOGFILE"
+		# t2042: post follow-up "CLEARED" comment so the original
+		# "Held from dispatch" comment doesn't mislead readers. Helper
+		# is defined in pulse-triage.sh which is sourced before this
+		# file (see pulse-wrapper.sh:169-172).
+		if declare -F _post_simplification_gate_cleared_comment >/dev/null 2>&1; then
+			_post_simplification_gate_cleared_comment "$issue_number" "$repo_slug"
+		fi
 	fi
 
 	return 1

--- a/.agents/scripts/pulse-triage.sh
+++ b/.agents/scripts/pulse-triage.sh
@@ -356,6 +356,54 @@ _reevaluate_consolidation_labels() {
 }
 
 #######################################
+# Post a "Large File Simplification Gate — CLEARED" follow-up comment
+# on an issue whose `needs-simplification` label was just removed. This
+# annotates the prior "Held from dispatch" comment as superseded so
+# readers (workers, supervisors, humans) don't act on stale state.
+#
+# Idempotent: uses _gh_idempotent_comment with a per-issue marker so it
+# only posts once per clearing event even if the re-eval loop visits the
+# same issue across multiple cycles.
+#
+# t2042: addresses the misleading-comment failure mode where #18418
+# carried a "Held from dispatch" comment from a pre-t2024 gate
+# evaluation while dispatch was already proceeding under the
+# scoped-range bypass.
+#
+# Arguments:
+#   $1 - issue_number
+#   $2 - repo_slug
+# Returns: 0 always (best-effort, never blocks)
+#######################################
+_post_simplification_gate_cleared_comment() {
+	local issue_number="$1"
+	local repo_slug="$2"
+
+	[[ "$issue_number" =~ ^[0-9]+$ ]] || return 0
+	[[ -n "$repo_slug" ]] || return 0
+
+	local _scoped_threshold="${SCOPED_RANGE_THRESHOLD:-300}"
+	local _large_threshold="${LARGE_FILE_LINE_THRESHOLD:-2000}"
+	local _marker="<!-- simplification-gate-cleared:${issue_number} -->"
+	local _body="${_marker}
+## Large File Simplification Gate — CLEARED
+
+The previous \"Held from dispatch\" comment on this issue no longer
+applies. On re-evaluation, the cited file references either fall within
+the scoped-range bypass (≤ ${_scoped_threshold} lines per range) or the
+target file has been simplified below ${_large_threshold} lines.
+
+The \`needs-simplification\` label has been removed and the issue is
+open for dispatch.
+
+_Automated by \`_post_simplification_gate_cleared_comment()\` in pulse-triage.sh (t2042)_"
+
+	_gh_idempotent_comment "$issue_number" "$repo_slug" \
+		"$_marker" "$_body" || true
+	return 0
+}
+
+#######################################
 # Re-evaluate needs-simplification labeled issues across pulse repos.
 # Same pattern as _reevaluate_consolidation_labels: issues filtered out
 # by the needs-* exclusion never reach dispatch_with_dedup, so the
@@ -396,6 +444,9 @@ _reevaluate_simplification_labels() {
 			# issue, keeping stale needs-simplification labels forever.
 			if ! _issue_targets_large_files "$num" "$slug" "$body" "$rpath" "true"; then
 				total_cleared=$((total_cleared + 1))
+				# t2042: post follow-up "CLEARED" comment so the original
+				# "Held from dispatch" comment doesn't mislead readers.
+				_post_simplification_gate_cleared_comment "$num" "$slug"
 			fi
 		done
 	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "" and .path != "") | "\(.slug)|\(.path)"' "$repos_json" 2>/dev/null)

--- a/.agents/scripts/tests/test-dispatch-lifecycle-comms.sh
+++ b/.agents/scripts/tests/test-dispatch-lifecycle-comms.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# t2042: Regression test for dispatch-lifecycle communication fixes.
+#
+# Covers two distinct fixes that landed together:
+#
+# Fix A — _post_simplification_gate_cleared_comment:
+#   When the simplification gate's `needs-simplification` label is
+#   cleared (either by re-eval in pulse-triage.sh or by the inline
+#   auto-clear in pulse-dispatch-core.sh), a follow-up "CLEARED" comment
+#   is posted exactly once per issue (idempotent via marker).
+#
+# Fix B — _classify_stale_recovery_crash_type:
+#   Stale-recovered workers are classified as "partial" (open PR or
+#   issue-named remote branch exists) or "no_work" (truly zero
+#   artifact). The classification is passed to fast_fail_record so the
+#   cascade tier escalation comment renders a Crash type line.
+#
+# shellcheck disable=SC1090,SC1091
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)" || exit 1
+
+# Isolated environment
+TMP_HOME=$(mktemp -d)
+export HOME="$TMP_HOME"
+export LOGFILE="${TMP_HOME}/test.log"
+export REPOS_JSON="${TMP_HOME}/repos.json"
+printf '{"initialized_repos":[]}' >"$REPOS_JSON"
+
+# Source dependencies in the same order as pulse-wrapper.sh
+# shellcheck source=/dev/null
+source "${SCRIPTS_DIR}/shared-constants.sh"
+# shellcheck source=/dev/null
+source "${SCRIPTS_DIR}/worker-lifecycle-common.sh"
+# shellcheck source=/dev/null
+source "${SCRIPTS_DIR}/pulse-triage.sh"
+# shellcheck source=/dev/null
+source "${SCRIPTS_DIR}/pulse-dispatch-core.sh"
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1"
+	local rc="$2"
+	local detail="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		echo "PASS $name"
+		TESTS_PASSED=$((TESTS_PASSED + 1))
+	else
+		echo "FAIL $name"
+		[[ -n "$detail" ]] && printf '  %s\n' "$detail"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+# --- Mock gh ---
+# State files for each gh subcommand the helpers touch.
+GH_COMMENT_LOG="${TMP_HOME}/gh-comment.log"
+GH_API_COMMENTS_RESPONSE="${TMP_HOME}/gh-api-comments.json"
+GH_PR_LIST_RESPONSE="${TMP_HOME}/gh-pr-list.json"
+GH_API_BRANCHES_RESPONSE="${TMP_HOME}/gh-api-branches.json"
+: >"$GH_COMMENT_LOG"
+printf '[]' >"$GH_API_COMMENTS_RESPONSE"
+printf '[]' >"$GH_PR_LIST_RESPONSE"
+printf '[]' >"$GH_API_BRANCHES_RESPONSE"
+
+# Helper: extract the value of --jq from an argv list, if present.
+_extract_jq_filter() {
+	local prev=""
+	local arg
+	for arg in "$@"; do
+		if [[ "$prev" == "--jq" ]]; then
+			printf '%s' "$arg"
+			return 0
+		fi
+		prev="$arg"
+	done
+	return 1
+}
+
+# Helper: dump a canned response, optionally piped through jq if the
+# caller passed --jq. The real gh applies the jq filter server-side
+# after JSON parsing; we approximate that by piping through real jq.
+_mock_gh_response() {
+	local response_file="$1"
+	shift
+	local jq_filter
+	if jq_filter=$(_extract_jq_filter "$@"); then
+		jq -r "$jq_filter" <"$response_file" 2>/dev/null || cat "$response_file"
+	else
+		cat "$response_file"
+	fi
+	return 0
+}
+
+gh() {
+	local cmd="${1:-}"
+	shift || true
+	case "$cmd" in
+	api)
+		# Path-based dispatch
+		local path="${1:-}"
+		shift || true
+		case "$path" in
+		repos/*/issues/*/comments)
+			_mock_gh_response "$GH_API_COMMENTS_RESPONSE" "$@"
+			;;
+		repos/*/branches)
+			_mock_gh_response "$GH_API_BRANCHES_RESPONSE" "$@"
+			;;
+		*)
+			echo "{}"
+			;;
+		esac
+		;;
+	pr)
+		local sub="${1:-}"
+		shift || true
+		case "$sub" in
+		list)
+			_mock_gh_response "$GH_PR_LIST_RESPONSE" "$@"
+			;;
+		view)
+			_mock_gh_response "$GH_API_COMMENTS_RESPONSE" "$@"
+			;;
+		*)
+			echo "{}"
+			;;
+		esac
+		;;
+	issue)
+		local sub="${1:-}"
+		shift || true
+		case "$sub" in
+		comment)
+			# Capture the --body for assertions.
+			while [[ $# -gt 0 ]]; do
+				if [[ "$1" == "--body" ]]; then
+					printf '%s\n---END_COMMENT---\n' "$2" >>"$GH_COMMENT_LOG"
+					shift 2
+				else
+					shift
+				fi
+			done
+			;;
+		view)
+			# Used by some helpers to fetch issue body/labels — return empty
+			echo "{}"
+			;;
+		*) ;;
+		esac
+		;;
+	*) ;;
+	esac
+	return 0
+}
+
+# Replace jq's argument-passing for the test by exporting it. The helpers
+# call `gh ... --jq '...'` which routes through our mock above; we don't
+# actually need to interpret the jq filter — we just return canned
+# responses based on the subcommand path. The mock above already
+# handles this correctly.
+
+# --- Fix A: _post_simplification_gate_cleared_comment ---
+
+reset_gh_state() {
+	: >"$GH_COMMENT_LOG"
+	printf '[]' >"$GH_API_COMMENTS_RESPONSE"
+	return 0
+}
+
+count_gh_comments() {
+	# Count the number of ---END_COMMENT--- separators in the log.
+	# `grep -c` exits 1 with stdout "0" when there are no matches; suppress
+	# the exit code so this function never returns non-zero, and emit a
+	# single integer on stdout regardless.
+	local n
+	n=$(grep -c '^---END_COMMENT---$' "$GH_COMMENT_LOG" 2>/dev/null || true)
+	[[ "$n" =~ ^[0-9]+$ ]] || n=0
+	printf '%s' "$n"
+	return 0
+}
+
+# Test 1: cleared comment posted on first call when no marker exists
+reset_gh_state
+_post_simplification_gate_cleared_comment "12345" "owner/repo"
+count1=$(count_gh_comments)
+if [[ "$count1" -eq 1 ]]; then
+	print_result "Fix A: posts cleared comment when marker absent" 0
+else
+	print_result "Fix A: posts cleared comment when marker absent" 1 "expected 1 comment got $count1"
+fi
+
+# Test 2: comment body contains the marker and the CLEARED heading
+if grep -q '<!-- simplification-gate-cleared:12345 -->' "$GH_COMMENT_LOG" &&
+	grep -q 'Large File Simplification Gate — CLEARED' "$GH_COMMENT_LOG"; then
+	print_result "Fix A: posted comment body contains marker and heading" 0
+else
+	print_result "Fix A: posted comment body contains marker and heading" 1 "log: $(cat "$GH_COMMENT_LOG")"
+fi
+
+# Test 3: idempotent — second call with marker present does NOT post again
+# Simulate the marker already being present by feeding it back via the
+# api comments response. _gh_idempotent_comment fetches existing comments
+# and skips if the marker is found.
+reset_gh_state
+printf '[{"body":"<!-- simplification-gate-cleared:12345 -->\\n## Large File Simplification Gate — CLEARED"}]' \
+	>"$GH_API_COMMENTS_RESPONSE"
+_post_simplification_gate_cleared_comment "12345" "owner/repo"
+count_after_idempotent=$(count_gh_comments)
+if [[ "$count_after_idempotent" -eq 0 ]]; then
+	print_result "Fix A: idempotent — does not re-post when marker present" 0
+else
+	print_result "Fix A: idempotent — does not re-post when marker present" 1 "expected 0 got $count_after_idempotent"
+fi
+
+# Test 4: handles invalid issue number gracefully
+reset_gh_state
+_post_simplification_gate_cleared_comment "not-a-number" "owner/repo"
+count_invalid=$(count_gh_comments)
+if [[ "$count_invalid" -eq 0 ]]; then
+	print_result "Fix A: skips when issue number invalid" 0
+else
+	print_result "Fix A: skips when issue number invalid" 1 "posted $count_invalid"
+fi
+
+# --- Fix B: _classify_stale_recovery_crash_type ---
+
+# Test 5: returns 'partial' when an open PR exists for the issue
+reset_gh_state
+printf '[{"number":777}]' >"$GH_PR_LIST_RESPONSE"
+printf '[]' >"$GH_API_BRANCHES_RESPONSE"
+crash_type_pr=$(_classify_stale_recovery_crash_type "18418" "owner/repo")
+if [[ "$crash_type_pr" == "partial" ]]; then
+	print_result "Fix B: partial when open PR exists" 0
+else
+	print_result "Fix B: partial when open PR exists" 1 "got '$crash_type_pr'"
+fi
+
+# Test 6: returns 'partial' when a remote branch references the issue
+reset_gh_state
+printf '[]' >"$GH_PR_LIST_RESPONSE"
+printf '[{"name":"bugfix/t18418-fix"},{"name":"main"}]' >"$GH_API_BRANCHES_RESPONSE"
+crash_type_branch=$(_classify_stale_recovery_crash_type "18418" "owner/repo")
+if [[ "$crash_type_branch" == "partial" ]]; then
+	print_result "Fix B: partial when issue-named branch exists" 0
+else
+	print_result "Fix B: partial when issue-named branch exists" 1 "got '$crash_type_branch'"
+fi
+
+# Test 7: returns 'no_work' when no PR and no matching branch
+reset_gh_state
+printf '[]' >"$GH_PR_LIST_RESPONSE"
+printf '[{"name":"main"},{"name":"feature/unrelated-9999"}]' >"$GH_API_BRANCHES_RESPONSE"
+crash_type_none=$(_classify_stale_recovery_crash_type "18418" "owner/repo")
+if [[ "$crash_type_none" == "no_work" ]]; then
+	print_result "Fix B: no_work when no PR and no matching branch" 0
+else
+	print_result "Fix B: no_work when no PR and no matching branch" 1 "got '$crash_type_none'"
+fi
+
+# Test 8: defensive — returns no_work for invalid issue number
+crash_type_invalid=$(_classify_stale_recovery_crash_type "not-a-number" "owner/repo")
+if [[ "$crash_type_invalid" == "no_work" ]]; then
+	print_result "Fix B: no_work on invalid issue number" 0
+else
+	print_result "Fix B: no_work on invalid issue number" 1 "got '$crash_type_invalid'"
+fi
+
+# Test 9: defensive — returns no_work for empty repo slug
+crash_type_no_repo=$(_classify_stale_recovery_crash_type "18418" "")
+if [[ "$crash_type_no_repo" == "no_work" ]]; then
+	print_result "Fix B: no_work on empty repo slug" 0
+else
+	print_result "Fix B: no_work on empty repo slug" 1 "got '$crash_type_no_repo'"
+fi
+
+# Cleanup
+rm -rf "$TMP_HOME"
+
+echo
+echo "Tests run: $TESTS_RUN passed: $TESTS_PASSED failed: $TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
## Summary

Two related dispatch-lifecycle communication fixes that surfaced together on issue #18418 (t1992): a stale 'Held from dispatch' simplification gate comment AND an empty cascade tier escalation comment with no diagnostic. Both fixes restore the mentor-first principle (t1901) — every comment should teach the next reader what happened and what to do next.

Fix A (stale gate comment cleanup): Adds _post_simplification_gate_cleared_comment in pulse-triage.sh and wires it into both clear paths — the re-evaluation loop in _reevaluate_simplification_labels and the inline auto-clear in _issue_targets_large_files. When the needs-simplification label is removed (because the file was simplified, the scoped-range bypass kicked in, or the cited file is excluded), a follow-up CLEARED comment is posted exactly once per clearing event (idempotent via marker). The original 'Held from dispatch' comment stays as audit trail; the new comment annotates it as superseded.

Fix B (zero-artifact stale-recovery diagnostics): Adds _classify_stale_recovery_crash_type in pulse-dispatch-core.sh which inspects whether an open PR or remote branch references the issue. Returns 'partial' when there is some artifact, 'no_work' when the worker died before producing anything. The STALE_RECOVERED branch in _dispatch_dedup_check_layers now passes this classification through to fast_fail_record, which forwards it to escalate_issue_tier. Cascade tier escalation comments will now render the **Crash type:** \`no_work\` line for stale-timeout failures, distinguishing infra/transient stalls from real model overload.

## Files Changed

.agents/scripts/pulse-dispatch-core.sh,.agents/scripts/pulse-triage.sh,.agents/scripts/tests/test-dispatch-lifecycle-comms.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean on pulse-triage.sh, pulse-dispatch-core.sh, and the new test (pre-existing SC2016 warnings on lines 817/832 are unrelated, in regex parsing code I didn't touch); bash test-dispatch-lifecycle-comms.sh -> 9/9 pass; bash test-pulse-wrapper-characterization.sh -> 26/26 pass; bash test-stale-recovery-escalation.sh -> 11/11 pass.

Resolves #18565


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.1 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 28m and 66,652 tokens on this with the user in an interactive session.