### PR TITLE
GH#18541: fix(docs): add language specifiers to fenced code blocks in t1990-brief.md

### DIFF
--- a/todo/tasks/t1990-brief.md
+++ b/todo/tasks/t1990-brief.md
@@ -86,13 +86,13 @@ During the filing of t1979–t1985 I committed a planning-only change directly o
 
 3. Update `.agents/AGENTS.md`. Find the paragraph:
 
-    ```
+    ```markdown
     **Main-branch planning exception:** `TODO.md` and `todo/*` are the explicit exception to the PR-only flow — planning-only edits may be committed and pushed directly to `main`.
     ```
 
     Replace with:
 
-    ```
+    ```markdown
     **Main-branch planning exception (headless sessions only):** `TODO.md` and `todo/*` are an explicit exception to the PR-only flow for **headless sessions** (pulse, CI workers, routines) — they may be committed and pushed directly to `main`. **Interactive sessions must always use a linked worktree**, regardless of file path. No exceptions. The canonical repo directory always stays on `main`; every interactive edit goes through a worktree at `~/Git/<repo>-<branch>`. Enforced by `pre-edit-check.sh` (t1990).
     ```
 


### PR DESCRIPTION
## Summary

Addresses the Codacy MD040 CodeStyle violations identified in the review followup for PR #18414 (t1990).

The `todo/tasks/t1990-brief.md` file added in PR #18414 contained two fenced code blocks without language specifiers (lines 89 and 95), which violated the MD040 markdownlint rule. The blocks show example AGENTS.md text (old vs new), so `markdown` is the correct language specifier.

Resolves #18541

## Changes

- `EDIT: todo/tasks/t1990-brief.md:89,95` — Added `markdown` language specifier to two fenced code blocks that were triggering MD040 (`fenced-code-language`) violations

## Verification

```bash
cd ~/Git/aidevops.bugfix-GH-18541-md040-brief-code-blocks
markdownlint todo/tasks/t1990-brief.md
# No output = passes
```

## Review Assessment

- **Gemini**: "I have no feedback to provide as there were no review comments to evaluate" — non-actionable
- **Codacy**: 1 minor CodeStyle issue (MD040) — fixed in this PR. `markdownlint` confirms the fix resolves the violation.
- **SonarCloud**: Quality gate passed — no action needed
- **CodeRabbit**: Rate limited, no review produced