### PR TITLE
GH#18550: fix(claim-task-id): address Gemini review feedback from PR #18396

### DIFF
--- a/.agents/scripts/claim-task-id.sh
+++ b/.agents/scripts/claim-task-id.sh
@@ -632,8 +632,8 @@ _try_issue_sync_delegation() {
 	local repo_path="$2"
 
 	# Extract task ID from title (format: "tNNN: description")
-	local task_id
-	task_id=$(printf '%s' "$title" | grep -oE '^t[0-9]+' || echo "")
+	local task_id=""
+	[[ "$title" =~ ^(t[0-9]+) ]] && task_id="${BASH_REMATCH[1]}"
 
 	local issue_sync_helper="${SCRIPT_DIR}/issue-sync-helper.sh"
 	if [[ -z "$task_id" || ! -x "$issue_sync_helper" || ! -f "$repo_path/TODO.md" ]]; then
@@ -675,8 +675,8 @@ _check_duplicate_issue() {
 	fi
 
 	# Extract task ID prefix (e.g. "t1968" from "t1968: ...")
-	local task_id_prefix
-	task_id_prefix=$(printf '%s' "$title" | grep -oE '^t[0-9]+' || echo "")
+	local task_id_prefix=""
+	[[ "$title" =~ ^(t[0-9]+) ]] && task_id_prefix="${BASH_REMATCH[1]}"
 	if [[ -z "$task_id_prefix" ]]; then
 		# No tNNN prefix to match against — fall back to old behaviour
 		# but ONLY if search_terms is substantial enough to be safe.
@@ -688,8 +688,8 @@ _check_duplicate_issue() {
 		local existing_issue
 		existing_issue=$(gh issue list --repo "$repo_slug" \
 			--state open --search "\"$search_terms\"" \
-			--json number --limit 1 -q '.[0].number' 2>/dev/null || echo "")
-		if [[ -n "$existing_issue" && "$existing_issue" != "null" ]]; then
+			--json number --limit 1 -q '.[0].number // empty' 2>/dev/null || echo "")
+		if [[ -n "$existing_issue" ]]; then
 			log_info "Found existing OPEN issue #$existing_issue matching title, skipping duplicate creation"
 			echo "$existing_issue"
 			return 0
@@ -697,14 +697,17 @@ _check_duplicate_issue() {
 		return 1
 	fi
 
-	# Exact tNNN: prefix match, case-sensitive
+	# Exact tNNN: prefix match, case-sensitive; use jq --arg to avoid embedding
+	# the variable in the filter string (defense-in-depth, GH#18550)
 	local existing_issue
 	existing_issue=$(gh issue list --repo "$repo_slug" \
 		--state open --search "${task_id_prefix}: in:title" \
-		--json number,title --limit 10 \
-		-q ".[] | select(.title | startswith(\"${task_id_prefix}: \")) | .number" 2>/dev/null | head -1)
+		--json number,title --limit 10 2>/dev/null |
+		jq -r --arg prefix "${task_id_prefix}: " \
+			'.[] | select(.title | startswith($prefix)) | .number // empty' |
+		head -1)
 
-	if [[ -n "$existing_issue" && "$existing_issue" != "null" ]]; then
+	if [[ -n "$existing_issue" ]]; then
 		log_info "Found existing OPEN issue #$existing_issue with exact ${task_id_prefix} prefix, skipping duplicate creation"
 		echo "$existing_issue"
 		return 0
@@ -749,8 +752,8 @@ _compose_issue_body() {
 		body="$description"
 	else
 		# t1906: Try reading the brief file's What section before falling back to stub
-		local task_id
-		task_id=$(printf '%s' "$title" | grep -oE '^t[0-9]+' || echo "")
+		local task_id=""
+		[[ "$title" =~ ^(t[0-9]+) ]] && task_id="${BASH_REMATCH[1]}"
 		local brief_what=""
 		if [[ -n "$task_id" ]]; then
 			brief_what=$(_read_brief_what_section "$task_id" "$REPO_PATH") || true


### PR DESCRIPTION
## Summary

Addresses the four unresolved Gemini code-review suggestions from PR #18396, all in `.agents/scripts/claim-task-id.sh`.

### Changes

1. **Bash built-in regex instead of grep subshell** — three locations:
   - `_try_issue_sync_delegation` (line 635-636): `grep -oE '^t[0-9]+'` → `[[ "$title" =~ ^(t[0-9]+) ]]`
   - `_check_duplicate_issue` (line 678-679): same pattern
   - `_compose_issue_body` (line 755-756): same pattern
   
   Eliminates subshell fork overhead and is idiomatic for simple prefix extraction.

2. **`jq // empty` fallback in fuzzy-search path** — removes the redundant `!= "null"` string check that Gemini flagged. `jq` with `// empty` emits nothing when `.number` is null, so the bash `[[ -n "$existing_issue" ]]` guard is sufficient.

3. **`jq --arg` for exact tNNN prefix match** — changes the `gh issue list ... -q "..."` inline filter to a `jq --arg prefix "..."` pipeline, avoiding embedding `${task_id_prefix}` directly in the jq filter string. Defense-in-depth against injection (per the general rules noted by Gemini).

### Verification

- `bash -n .agents/scripts/claim-task-id.sh` — syntax OK
- `shellcheck .agents/scripts/claim-task-id.sh` — only pre-existing SC1091 (info, not introduced by this PR)

Resolves #18550