### PR TITLE
GH#18552: address gemini review feedback on dispatch-core and dispatch-engine

### DIFF
--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -1532,6 +1532,7 @@ check_terminal_blockers() {
 	local issue_number="$1"
 	local repo_slug="$2"
 	local max_comments="${3:-5}"
+	[[ "$max_comments" =~ ^[0-9]+$ ]] || max_comments=5
 
 	if [[ -z "$issue_number" || -z "$repo_slug" ]]; then
 		echo "[pulse-wrapper] check_terminal_blockers: missing arguments" >>"$LOGFILE"

--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -290,8 +290,8 @@ dispatch_deterministic_fill_floor() {
 		# Detects both the legacy GitLab stub and the current claim-task-id.sh
 		# stub marker ("no description provided — enrich before dispatch").
 		local issue_body
-		issue_body=$(gh issue view "$issue_number" --repo "$repo_slug" --json body -q '.body' 2>/dev/null || echo "")
-		if [[ -z "$issue_body" || "$issue_body" == "Task created via claim-task-id.sh" || "$issue_body" == "null" ]]; then
+		issue_body=$(gh issue view "$issue_number" --repo "$repo_slug" --json body --jq '.body // ""' 2>/dev/null) || issue_body=""
+		if [[ -z "$issue_body" || "$issue_body" == "Task created via claim-task-id.sh" ]]; then
 			echo "[pulse-wrapper] Deterministic fill floor: skipping #${issue_number} (${repo_slug}) — placeholder/empty issue body, needs enrichment before dispatch" >>"$LOGFILE"
 			continue
 		fi


### PR DESCRIPTION
## Summary

Addresses unaddressed gemini-code-assist review feedback from PR #18390.

Two targeted fixes in the newly extracted dispatch modules:

**1. `pulse-dispatch-core.sh` — validate `max_comments` as integer**

The `max_comments` argument in `check_terminal_blockers()` was used directly in a `gh api --jq` slice expression (`.[-N:]`) without validating it was numeric. A non-integer value would produce an invalid jq expression. Added:
```sh
[[ "$max_comments" =~ ^[0-9]+$ ]] || max_comments=5
```

**2. `pulse-dispatch-engine.sh` — use `// ""` jq fallback for `issue_body`**

The body fetch used `.body` with a shell-level `"null"` string check as a workaround. Changed to use the jq `// ""` fallback operator (consistent with the pattern at `pulse-dispatch-core.sh:1033`), and updated the guard to drop the now-redundant `"null"` literal check:
```sh
# Before
issue_body=$(gh issue view ... --json body -q '.body' 2>/dev/null || echo "")
if [[ -z "$issue_body" || "$issue_body" == "..." || "$issue_body" == "null" ]]; then

# After
issue_body=$(gh issue view ... --json body --jq '.body // ""' 2>/dev/null) || issue_body=""
if [[ -z "$issue_body" || "$issue_body" == "..." ]]; then
```

## Verification

- shellcheck on both files: zero new violations
- Existing tests: `test-pulse-wrapper-terminal-blockers.sh` (11/11) covers `check_terminal_blockers`

Resolves #18552