### PR TITLE
GH#18551: fix hardcoded helper paths and non-portable grep in pulse ancillary/quality-debt modules

### DIFF
--- a/.agents/scripts/pulse-ancillary-dispatch.sh
+++ b/.agents/scripts/pulse-ancillary-dispatch.sh
@@ -725,8 +725,10 @@ dispatch_triage_reviews() {
 
 	# Resolve model: prefer opus, fall back to sonnet, then omit --model
 	local resolved_model=""
-	resolved_model=$(~/.aidevops/agents/scripts/model-availability-helper.sh resolve opus 2>/dev/null || echo "")
-	[[ -n "$resolved_model" ]] || resolved_model=$(~/.aidevops/agents/scripts/model-availability-helper.sh resolve sonnet 2>/dev/null || echo "")
+	resolved_model=$("$MODEL_AVAILABILITY_HELPER" resolve opus || echo "")
+	if [[ -z "$resolved_model" ]]; then
+		resolved_model=$("$MODEL_AVAILABILITY_HELPER" resolve sonnet || echo "")
+	fi
 	[[ -n "$resolved_model" ]] || echo "[pulse-wrapper] dispatch_triage_reviews: model resolution failed (opus and sonnet unavailable)" >>"$LOGFILE"
 
 	# Parse "## owner/repo" headers and "- Issue #N: ... [status: **needs-review**]" lines.
@@ -801,7 +803,7 @@ relabel_needs_info_replies() {
 		gh issue comment "$issue_num" --repo "$repo_slug" \
 			--body "Contributor replied to the information request. Relabeled to \`needs-maintainer-review\` for re-evaluation." \
 			2>/dev/null || true
-	done < <(grep -oP '(?<=replied\|)\d+\|[^\n]+' "$state_file" 2>/dev/null || true)
+	done < <(sed -n 's/^replied|//p' "$state_file" 2>/dev/null || true)
 
 	return 0
 }
@@ -866,7 +868,7 @@ dispatch_foss_workers() {
 		[[ "$available" -gt 0 && "$foss_count" -lt "$foss_max" ]] || break
 
 		# Pre-dispatch eligibility check (budget + rate limit)
-		~/.aidevops/agents/scripts/foss-contribution-helper.sh check "$foss_slug" >/dev/null 2>&1 || continue
+		"${SCRIPT_DIR}/foss-contribution-helper.sh" check "$foss_slug" >/dev/null || continue
 
 		# Scan for a suitable issue
 		local labels_filter foss_issue foss_issue_num foss_issue_title
@@ -888,13 +890,13 @@ dispatch_foss_workers() {
 			"$repos_json" 2>/dev/null || echo "true")
 		[[ "$disclosure" == "true" ]] && disclosure_flag=" Include AI disclosure note in the PR."
 
-		~/.aidevops/agents/scripts/headless-runtime-helper.sh run \
+		"$HEADLESS_RUNTIME_HELPER" run \
 			--role worker \
 			--session-key "foss-${foss_slug}-${foss_issue_num}" \
 			--dir "$foss_path" \
 			--title "FOSS: ${foss_slug} #${foss_issue_num}: ${foss_issue_title}" \
 			--prompt "/full-loop Implement issue #${foss_issue_num} (https://github.com/${foss_slug}/issues/${foss_issue_num}) -- ${foss_issue_title}. This is a FOSS contribution.${disclosure_flag} After completion, run: foss-contribution-helper.sh record ${foss_slug} <tokens_used>" \
-			</dev/null >>"/tmp/pulse-foss-${foss_issue_num}.log" 2>&1 9>&- &
+			</dev/null >>"${HOME}/.aidevops/logs/pulse-foss-${foss_issue_num}.log" 2>&1 9>&- &
 		sleep 2
 
 		foss_count=$((foss_count + 1))

--- a/.agents/scripts/pulse-quality-debt.sh
+++ b/.agents/scripts/pulse-quality-debt.sh
@@ -141,9 +141,9 @@ dispatch_enrichment_workers() {
 
 	# Resolve reasoning model
 	local resolved_model=""
-	resolved_model=$(~/.aidevops/agents/scripts/model-availability-helper.sh resolve opus 2>/dev/null || echo "")
+	resolved_model=$("$MODEL_AVAILABILITY_HELPER" resolve opus || echo "")
 	if [[ -z "$resolved_model" ]]; then
-		resolved_model=$(~/.aidevops/agents/scripts/model-availability-helper.sh resolve sonnet 2>/dev/null || echo "")
+		resolved_model=$("$MODEL_AVAILABILITY_HELPER" resolve sonnet || echo "")
 	fi
 	if [[ -z "$resolved_model" ]]; then
 		echo "[pulse-wrapper] dispatch_enrichment_workers: no reasoning model available — skipping" >>"$LOGFILE"


### PR DESCRIPTION
## Summary

Addressed 6 Gemini review findings from PR #18392: replaced hardcoded ~/.aidevops/agents/scripts/model-availability-helper.sh paths with $MODEL_AVAILABILITY_HELPER variable in pulse-ancillary-dispatch.sh and pulse-quality-debt.sh; replaced non-portable grep -oP (PCRE) with POSIX-compatible sed in relabel_needs_info_replies; replaced hardcoded foss-contribution-helper.sh path with ${SCRIPT_DIR}; replaced hardcoded headless-runtime-helper.sh path with $HEADLESS_RUNTIME_HELPER; moved FOSS worker log from /tmp/ to ~/.aidevops/logs/ to prevent symlink attacks.

## Files Changed

.agents/scripts/pulse-ancillary-dispatch.sh,.agents/scripts/pulse-quality-debt.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck passes with zero violations on both files; all hardcoded paths replaced; sed portability verified on macOS BSD grep environment

Resolves #18551


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.1 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 5m and 14,341 tokens on this as a headless worker.