### PR TITLE
GH#18555: fix review findings — awk injection, jq efficiency, tree-hash empty-check

### DIFF
--- a/.agents/scripts/pulse-simplification-state.sh
+++ b/.agents/scripts/pulse-simplification-state.sh
@@ -182,14 +182,22 @@ _simplification_state_refresh() {
 
 		local current_hash stored_hash
 		current_hash=$(git -C "$repo_path" hash-object "$full_path" 2>/dev/null) || continue
-		stored_hash=$(jq -r --arg fp "$fp" '.files[$fp].hash // empty' "$tmp_state" 2>/dev/null) || stored_hash=""
+		# Read hash and passes in a single jq call — spawning jq twice per file
+		# inside a loop is inefficient when the state file can have hundreds of entries (GH#18555).
+		local prev_passes
+		IFS=$'\t' read -r stored_hash prev_passes < <(
+			jq -r --arg fp "$fp" \
+				'.files[$fp] // {"hash": "", "passes": 0} | [(.hash // ""), (.passes // 0 | tostring)] | join("\t")' \
+				"$tmp_state" 2>/dev/null
+		)
+		[[ -n "$stored_hash" ]] || stored_hash=""
+		[[ "$prev_passes" =~ ^[0-9]+$ ]] || prev_passes=0
 
 		# Also fix any non-SHA1 hashes (wrong algorithm, t1754)
 		local stored_len=${#stored_hash}
 		if [[ "$current_hash" != "$stored_hash" || "$stored_len" -ne 40 ]]; then
-			local now_iso prev_passes new_passes
+			local now_iso new_passes
 			now_iso=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-			prev_passes=$(jq -r --arg fp "$fp" '.files[$fp].passes // 0' "$tmp_state" 2>/dev/null) || prev_passes=0
 			new_passes=$((prev_passes + 1))
 			local inner_tmp
 			inner_tmp=$(mktemp)
@@ -245,14 +253,16 @@ _simplification_state_prune() {
 	if [[ "$pruned" -gt 0 ]]; then
 		local tmp_file
 		tmp_file=$(mktemp)
-		# Remove all stale entries in one jq pass
-		local jq_filter=".files"
-		while IFS= read -r sp; do
-			[[ -z "$sp" ]] && continue
-			jq_filter="${jq_filter} | del(.[\"${sp}\"])"
-		done < <(printf '%b' "$stale_paths")
-		jq "${jq_filter} | {\"files\": .}" "$state_file" >"$tmp_file" 2>/dev/null || {
-			# Fallback: remove one at a time
+		# Build a JSON array of stale paths and remove all in one jq pass using
+		# --argjson. Building a jq filter by string concatenation is fragile:
+		# paths containing quotes or special characters cause syntax errors and
+		# are a potential injection vector (GH#18555).
+		local stale_paths_json
+		stale_paths_json=$(printf '%b' "$stale_paths" | jq -R . | jq -s .)
+		jq --argjson paths "${stale_paths_json:-[]}" \
+			'reduce $paths[] as $p (.; del(.files[$p])) | {"files": .files}' \
+			"$state_file" >"$tmp_file" 2>/dev/null || {
+			# Fallback: remove entries one at a time using safe --arg (not string concat)
 			cp "$state_file" "$tmp_file"
 			while IFS= read -r sp; do
 				[[ -z "$sp" ]] && continue

--- a/.agents/scripts/pulse-simplification.sh
+++ b/.agents/scripts/pulse-simplification.sh
@@ -235,11 +235,14 @@ _complexity_scan_tree_hash() {
 	# Hash the tree of .agents/ tracked files — covers both .sh and .md targets.
 	# git ls-tree -r HEAD outputs blob hashes + paths; piping through sha256sum
 	# gives a single stable hash that changes iff any tracked file changes.
-	git -C "$repo_path" ls-tree -r HEAD -- .agents/ 2>/dev/null |
-		awk '{print $3, $4}' |
-		sha256sum 2>/dev/null |
-		awk '{print $1}' ||
-		true
+	# Capture output first: sha256sum always produces output (even for empty input),
+	# so an empty-check on the pipeline result is unreliable (GH#18555).
+	local tree_data
+	tree_data=$(git -C "$repo_path" ls-tree -r HEAD -- .agents/ 2>/dev/null)
+	if [[ -z "$tree_data" ]]; then
+		return 0
+	fi
+	printf '%s\n' "$tree_data" | awk '{print $3, $4}' | sha256sum 2>/dev/null | awk '{print $1}' || true
 	return 0
 }
 
@@ -483,9 +486,11 @@ _complexity_scan_collect_violations() {
 		local full_path="${aidevops_path}/${file}"
 		[[ -f "$full_path" ]] || continue
 		local result
-		result=$(awk '
+		# Use -v to pass the threshold safely — interpolating shell variables into
+		# awk scripts is a security risk and breaks if the value contains quotes (GH#18555).
+		result=$(awk -v threshold="$COMPLEXITY_FUNC_LINE_THRESHOLD" '
 			/^[a-zA-Z_][a-zA-Z0-9_]*\(\)[[:space:]]*\{/ { fname=$1; sub(/\(\)/, "", fname); start=NR; next }
-			fname && /^\}$/ { lines=NR-start; if(lines>'"$COMPLEXITY_FUNC_LINE_THRESHOLD"') printf "%s() %d lines\n", fname, lines; fname="" }
+			fname && /^\}$/ { lines=NR-start; if(lines+0>threshold+0) printf "%s() %d lines\n", fname, lines; fname="" }
 		' "$full_path")
 		if [[ -n "$result" ]]; then
 			local count
@@ -1032,9 +1037,11 @@ _complexity_scan_create_issues() {
 			"$repos_json" 2>/dev/null | head -n 1)
 		local details=""
 		if [[ -n "$aidevops_path" && -f "${aidevops_path}/${file_path}" ]]; then
-			details=$(awk '
+			# Use -v to pass the threshold safely — interpolating shell variables into
+			# awk scripts is a security risk and breaks if the value contains quotes (GH#18555).
+			details=$(awk -v threshold="$COMPLEXITY_FUNC_LINE_THRESHOLD" '
 				/^[a-zA-Z_][a-zA-Z0-9_]*\(\)[[:space:]]*\{/ { fname=$1; sub(/\(\)/, "", fname); start=NR; next }
-				fname && /^\}$/ { lines=NR-start; if(lines>'"$COMPLEXITY_FUNC_LINE_THRESHOLD"') printf "%s() %d lines\n", fname, lines; fname="" }
+				fname && /^\}$/ { lines=NR-start; if(lines+0>threshold+0) printf "%s() %d lines\n", fname, lines; fname="" }
 			' "${aidevops_path}/${file_path}" | head -10)
 		fi
 


### PR DESCRIPTION
## Summary

Addresses the 4 actionable gemini-code-assist findings from PR #18384 that were merged unresolved (GH#18555).

### Changes

**`pulse-simplification.sh`**

- `_complexity_scan_tree_hash`: Capture `git ls-tree` output before piping to `sha256sum`. `sha256sum` produces a non-empty hash even for empty input, so the caller's `[[ -z "$current_hash" ]]` check was never true when git found no files. Now returns empty (function exits early) when the repo has no `.agents/` tracked files.

- `_complexity_scan_collect_violations` and `_complexity_scan_create_issues` (both awk blocks): Replace `'"$COMPLEXITY_FUNC_LINE_THRESHOLD"'` shell interpolation inside awk scripts with `awk -v threshold="$COMPLEXITY_FUNC_LINE_THRESHOLD"` and reference `threshold` in the program body. Shell interpolation into awk is a security risk and silently breaks if the variable contains quote characters.

**`pulse-simplification-state.sh`**

- `_simplification_state_refresh`: Consolidate two separate `jq` calls per loop iteration (one for `.hash`, one for `.passes`) into a single call that returns both fields as tab-separated values, read via `IFS=$'\t' read -r stored_hash prev_passes`.

- `_simplification_state_prune`: Replace fragile jq filter string concatenation (`jq_filter="${jq_filter} | del(.[\"${sp}\"])"`) with a safe `--argjson` array. Build the stale-paths JSON array via `jq -R . | jq -s .` then pass via `--argjson paths` with `reduce $paths[] as $p (.; del(.files[$p]))`. Paths with special characters no longer risk filter syntax errors or injection.

### Verification

- `shellcheck` passes on both files (zero violations)
- Logic is functionally equivalent for valid inputs; safe paths now handled without string interpolation risk

Resolves #18555