### PR TITLE
t2045: fix: remove homebrew sync step that pushes to protected main

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -123,20 +123,6 @@ jobs:
           sed -i "s|url \"https://github.com/marcusquinn/aidevops/archive/refs/tags/v.*\.tar\.gz\"|url \"https://github.com/marcusquinn/aidevops/archive/refs/tags/v${RELEASE_VERSION}.tar.gz\"|" homebrew/aidevops.rb
           sed -i "s|sha256 \".*\"|sha256 \"${RELEASE_SHA256}\"|" homebrew/aidevops.rb
 
-      - name: Sync Homebrew formula back to repo
-        env:
-          RELEASE_VERSION: ${{ steps.release.outputs.version }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if git diff --quiet -- homebrew/aidevops.rb; then
-            echo "Homebrew formula already current"
-            exit 0
-          fi
-
-          git add homebrew/aidevops.rb
-          git -c user.name="github-actions[bot]" -c user.email="github-actions[bot]@users.noreply.github.com" commit -m "chore: sync homebrew formula for v${RELEASE_VERSION}"
-          git push origin HEAD:main
-
       - name: Push to homebrew-tap repo
         # Pinned to commit SHA for security
         uses: dmnemec/copy_file_to_another_repo_action@bbebd3da22e4a37d04dca5f782edd5201cb97083


### PR DESCRIPTION
## Summary

Remove the `Sync Homebrew formula back to repo` step from `publish-packages.yml` that was failing with a branch protection error.

## Problem

The `update-homebrew-tap` job was failing at the `Sync Homebrew formula back to repo` step because it used `git push origin HEAD:main` via `GITHUB_TOKEN`, which is rejected by branch protection:

```
GH006: Protected branch update failed for refs/heads/main.
Changes must be made through a pull request.
```

Evidence: run 24325147206 (v3.8.3)

## Fix

Removed the redundant step (option d from the issue). The `homebrew/aidevops.rb` file in this repo serves as a template; the real publication path is the `Push to homebrew-tap repo` step that pushes to `marcusquinn/homebrew-tap`. Syncing back to `main` was redundant and incompatible with branch protection.

## Verification

The `update-homebrew-tap` job will no longer attempt to push directly to `main`. The Homebrew formula is still updated in-memory and pushed to the tap repo via the `dmnemec/copy_file_to_another_repo_action` step using `HOMEBREW_TAP_TOKEN`.

Resolves #18583


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.3 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 1m and 3,480 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified Homebrew publication workflow by removing redundant repository synchronization steps while maintaining external package repository updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->