### PR TITLE
t2045: fix(publish-packages): remove homebrew in-repo sync step

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -123,19 +123,11 @@ jobs:
           sed -i "s|url \"https://github.com/marcusquinn/aidevops/archive/refs/tags/v.*\.tar\.gz\"|url \"https://github.com/marcusquinn/aidevops/archive/refs/tags/v${RELEASE_VERSION}.tar.gz\"|" homebrew/aidevops.rb
           sed -i "s|sha256 \".*\"|sha256 \"${RELEASE_SHA256}\"|" homebrew/aidevops.rb
 
-      - name: Sync Homebrew formula back to repo
-        env:
-          RELEASE_VERSION: ${{ steps.release.outputs.version }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if git diff --quiet -- homebrew/aidevops.rb; then
-            echo "Homebrew formula already current"
-            exit 0
-          fi
-
-          git add homebrew/aidevops.rb
-          git -c user.name="github-actions[bot]" -c user.email="github-actions[bot]@users.noreply.github.com" commit -m "chore: sync homebrew formula for v${RELEASE_VERSION}"
-          git push origin HEAD:main
+      # t2045: the "Sync Homebrew formula back to repo" step that used to live
+      # here pushed directly to protected main, which is rejected by branch
+      # protection (GH006). The real publication path is the separate
+      # homebrew-tap repo push below — the in-repo homebrew/aidevops.rb is
+      # a template, not the consumer-facing formula. See #18583.
 
       - name: Push to homebrew-tap repo
         # Pinned to commit SHA for security


### PR DESCRIPTION
## Summary

Remove the "Sync Homebrew formula back to repo" step in `publish-packages.yml` that was pushing directly to protected main via `GITHUB_TOKEN` — rejected by branch protection (GH006). Evidence: run 24325147206 (v3.8.3 publish).

Resolves #18583

## Why

The in-repo `homebrew/aidevops.rb` is a template, not the consumer-facing formula. Real publication happens via the "Push to homebrew-tap repo" step that follows, which pushes to `marcusquinn/homebrew-tap` using `HOMEBREW_TAP_TOKEN`. That repo is what `brew install marcusquinn/tap/aidevops` consumes.

The in-repo sync was both redundant and fundamentally incompatible with branch protection. Removing it closes the failure path while preserving the actual publication chain. The in-repo file still gets updated at source by `version-manager.sh bump` when releases are made, so drift is bounded to release cycles.

## Testing

Workflow change — will be exercised by the next release. No runtime tests — this is a deletion of a fail-path that was never succeeding.

Classification: `self-assessed` (CI config, fixes a known failing step).

## Alternatives considered

- (a) Open a PR via `gh pr create` and merge with admin bypass — more moving parts, still requires admin bypass which isn't trivially available to `github-actions[bot]`.
- (b) Fine-grained PAT with bypass permission — adds a secret-management surface for a redundant sync.
- (c) Release-time PR — adds a PR for every release with no downstream consumer.
- **(d) Drop the sync** — chosen. The file is updated at source by `version-manager.sh bump` which runs in the same release flow.

---


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.5 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 2h 18m and 210,682 tokens on this with the user in an interactive session.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified package publication workflow by removing a redundant synchronization step. The actual package publication process remains unchanged and unaffected by this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->