### PR TITLE
GH#18508: add Pre-implementation discovery rule to build.txt

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -71,6 +71,20 @@ Before non-trivial tasks, restate: (1) actual goal, (2) constraints that must ho
 - Finding-to-task completeness: every actionable finding in audit/review reports must become a tracked task before declaring completion.
 - Conversation-end loop scan: before declaring completion or moving to the next task, scan back over the full conversation for: (1) unfulfilled user commitments, (2) unnotified external parties, and (3) requests displaced by troubleshooting or corrections. Internal task creation does not close external loops.
 
+# Pre-implementation discovery (t2046 — MANDATORY before any non-trivial code change)
+# Autonomous coders tend to treat the codebase as frozen at the moment they read
+# it, when in fact other work may have landed since the prompt was loaded. Run
+# this discovery pass before writing code — it is the implementer-side mirror of
+# the Section 0 check that `workflows/review-issue-pr.md` already mandates for
+# reviewers.
+- Before starting work on any issue or writing code, run ONE discovery pass for already-landed duplicates and in-flight collisions:
+  - `git log --since="<issue-age + 2h>" --oneline -- <target-files>` — surfaces commits on the exact files you intend to modify, with authors and subject lines that often contain the keywords of the bug you are about to fix.
+  - `gh pr list --state merged --search "<keywords>" --limit 5` — surfaces recently-merged PRs that reference the same problem space.
+  - `gh pr list --state open --search "<keywords>" --limit 5` — surfaces in-flight work on the same files so you can coordinate instead of collide.
+- Cost: seconds. Value: catches duplicate fixes before you spend 30+ minutes writing one. The cost ratio of a duplicate PR (task ID burn, worktree, brief, commit, push, issue, PR, close comment) vs a one-line `git log` query is asymmetric — skipping the check is never the cheap option.
+- If the discovery pass surfaces a prior landed fix on the exact file/symbol you intended to change, STOP and verify whether the bug is still reproducible against the new code before continuing. Often the fix is already in place and the issue is stale — close it with a link to the prior commit instead of duplicating work.
+- Treat the codebase as a living system, not a frozen snapshot. Other agents and humans are working concurrently; your discovery pass is how you find them.
+
 # Claim discipline (turn-end gate)
 - Never present future intent as completed work.
 - Every claimed action needs one proof artifact (path, command result, metric).

--- a/.agents/workflows/review-issue-pr.md
+++ b/.agents/workflows/review-issue-pr.md
@@ -36,6 +36,8 @@ tools:
 
 Before reading the proposed fix, establish the current state of the codebase and the issue landscape. Skipping this step is how reviewers rubber-stamp fixes for problems that have already been solved, endorse caches that defeat recently-added invariants, or approve symptom-patches whose root cause lives elsewhere. The review verdict is only as good as this discovery step — if it's weak, the rest is decoration.
 
+**Implementer-side mirror (t2046):** The same discipline applies at implementation time — see `prompts/build.txt` "Pre-implementation discovery" for the rule every agent runs before writing code. Reviewers and implementers share the discovery habit; this section is the reviewer-side version of the same check.
+
 ### 0.1 Duplicate and temporal-duplicate check
 
 Two distinct checks, both required. The second is what's usually missed: an issue filed last week may have been silently solved by unrelated work that landed yesterday.


### PR DESCRIPTION
## Summary

Add a "Pre-implementation discovery" rule to `prompts/build.txt` that mirrors Section 0 of `workflows/review-issue-pr.md` onto the implementer side. Every agent session runs a one-command discovery pass (`git log --since` + `gh pr list --search`) on target files BEFORE writing code, catching duplicate fixes and in-flight collisions.

Resolves #18508

## Why

Issue #18508 tracks a specific failure mode from PR #18498 close comment: an agent spent ~30 minutes writing a duplicate fix for a bug that had been fixed 2 hours earlier in t2019 (PR #18491). The duplicate would have been caught by one command:

```bash
git log --since="6 hours ago" --oneline -- .agents/scripts/pulse-ancillary-dispatch.sh
```

t2017 baked this discipline into the reviewer role via `workflows/review-issue-pr.md` Section 0. This PR bakes the same discipline into the implementer role via `prompts/build.txt`. They are the same discipline; they need to live in both places.

## Changes

- **`prompts/build.txt`**: new "Pre-implementation discovery" section immediately after "Completion and quality discipline", three bullets covering the discovery commands, the cost ratio rationale, and the STOP-on-found-prior-fix rule
- **`workflows/review-issue-pr.md`**: reciprocal note at the top of Section 0 pointing at the new build.txt rule, so reviewers know the same discipline applies at implementation time

## Testing

Prompt-level change — no runtime tests. The rule will be exercised by every future agent session. Classification: `self-assessed` (docs/prompt update).

## Scope

Intentionally small. The rule itself is short — three bullets in build.txt plus a one-line reference in the workflow doc. No code changes. The effectiveness of the rule depends on future sessions running the discovery pass, which is a cultural/habit change the rule documents and reminds them of.

---


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.5 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 2h 26m and 218,085 tokens on this with the user in an interactive session.
