### PR TITLE
GH#18508: propagate Section 0 discovery discipline to implementation (build.txt / review-issue-pr.md)

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -71,6 +71,16 @@ Before non-trivial tasks, restate: (1) actual goal, (2) constraints that must ho
 - Finding-to-task completeness: every actionable finding in audit/review reports must become a tracked task before declaring completion.
 - Conversation-end loop scan: before declaring completion or moving to the next task, scan back over the full conversation for: (1) unfulfilled user commitments, (2) unnotified external parties, and (3) requests displaced by troubleshooting or corrections. Internal task creation does not close external loops.
 
+# Pre-implementation discovery (MANDATORY for non-trivial changes)
+# Autonomous coders tend to treat the codebase as frozen at the moment they read it.
+# A bug may be fixed, a pattern already established, or a PR already in flight.
+# Run these checks before writing any code — the same discipline as review Section 0:
+- `git log --since="<issue date or 24h ago>" --oneline -- <affected files>` — look for recent commits that may have already fixed the same bug
+- `gh pr list --state merged --search "<keywords>" --limit 10` — look for recently-merged work that supersedes the task
+- `gh pr list --state open --search "<keywords>" --limit 10` — look for in-flight PRs on the same problem
+- `git log --since="1 day ago" --grep="<keywords>"` — look for related work across the whole repo
+If any check returns a plausible match, STOP and verify whether the work is already done before writing code. A duplicate fix is worse than doing nothing: it wastes tokens, pollutes the timeline, and may regress a correct fix landed elsewhere. Self-assessment applies to implementation too: `workflows/review-issue-pr.md` Section 0 is the same discipline applied at review time — the implementer and the reviewer share this responsibility.
+
 # Claim discipline (turn-end gate)
 - Never present future intent as completed work.
 - Every claimed action needs one proof artifact (path, command result, metric).

--- a/.agents/workflows/review-issue-pr.md
+++ b/.agents/workflows/review-issue-pr.md
@@ -36,6 +36,8 @@ tools:
 
 Before reading the proposed fix, establish the current state of the codebase and the issue landscape. Skipping this step is how reviewers rubber-stamp fixes for problems that have already been solved, endorse caches that defeat recently-added invariants, or approve symptom-patches whose root cause lives elsewhere. The review verdict is only as good as this discovery step — if it's weak, the rest is decoration.
 
+> **Shared discipline:** The same checks apply at implementation time, not just review time. `prompts/build.txt` "Pre-implementation discovery" mirrors this section for the implementer role — the discipline lives in both places so it cannot be bypassed by skipping review.
+
 ### 0.1 Duplicate and temporal-duplicate check
 
 Two distinct checks, both required. The second is what's usually missed: an issue filed last week may have been silently solved by unrelated work that landed yesterday.


### PR DESCRIPTION
## Summary

Propagates the Section 0 Pre-Review Discovery discipline from `workflows/review-issue-pr.md` into the implementer role via a new rule in `prompts/build.txt`.

The motivating failure: a session implemented a duplicate JSON-parsing fix for a bug already resolved 2 hours earlier by commit `a084f425f` (t2019 / PR #18491). One `git log --since` command would have surfaced the conflict.

## Changes

- **`prompts/build.txt`**: New `# Pre-implementation discovery (MANDATORY for non-trivial changes)` section added after `# Completion and quality discipline`. Specifies three commands to run before writing code:
  - `git log --since="<issue date or 24h ago>" --oneline -- <affected files>` — catch recent commits fixing the same bug
  - `gh pr list --state merged --search "<keywords>" --limit 10` — catch recently-merged superseding work
  - `gh pr list --state open --search "<keywords>" --limit 10` — catch in-flight PRs on the same problem
  - `git log --since="1 day ago" --grep="<keywords>"` — catch related work across the whole repo

- **`workflows/review-issue-pr.md`**: Added a `> Shared discipline:` callout at the start of Section 0 pointing back to `prompts/build.txt` — so the connection is visible from both ends.

## Acceptance criteria

- [x] `prompts/build.txt` contains a "Pre-implementation discovery" rule referencing the same checks as `workflows/review-issue-pr.md` Section 0.1
- [x] The rule is positioned after "Completion and quality discipline" so it is discoverable via self-assessment
- [x] A reciprocal reference is added to `workflows/review-issue-pr.md` Section 0 pointing back to `build.txt`

## Verification

```bash
grep -n "Pre-implementation discovery" .agents/prompts/build.txt
grep -n "Shared discipline" .agents/workflows/review-issue-pr.md
```

Both commands return matches.

Resolves #18508