### PR TITLE
GH#18556: fix jq null fallback operator in pulse-cleanup.sh and pulse-issue-reconcile.sh

### DIFF
--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -65,7 +65,7 @@ _cleanup_merged_prs_for_all_repos() {
 		# worktrees in any managed repo. Skip local_only repos since
 		# worktree-helper.sh uses gh pr list for squash-merge detection.
 		local repo_paths
-		repo_paths=$(jq -r '.initialized_repos[] | select((.local_only // false) == false) | .path' "$repos_json" || echo "")
+		repo_paths=$(jq -r '.initialized_repos[] | select((.local_only // false) == false) | .path // ""' "$repos_json" || echo "")
 
 		local repo_path
 		while IFS= read -r repo_path; do
@@ -323,7 +323,7 @@ cleanup_worktrees() {
 	[[ -f "$repos_json" ]] && command -v jq &>/dev/null || return 0
 
 	local repo_paths_age
-	repo_paths_age=$(jq -r '.initialized_repos[] | select((.local_only // false) == false) | .path' "$repos_json" || echo "")
+	repo_paths_age=$(jq -r '.initialized_repos[] | select((.local_only // false) == false) | .path // ""' "$repos_json" || echo "")
 
 	local rp_age
 	while IFS= read -r rp_age; do
@@ -387,7 +387,7 @@ cleanup_stashes() {
 
 	if [[ -f "$repos_json" ]] && command -v jq &>/dev/null; then
 		local repo_paths
-		repo_paths=$(jq -r '.initialized_repos[] | select((.local_only // false) == false) | .path' "$repos_json" || echo "")
+		repo_paths=$(jq -r '.initialized_repos[] | select((.local_only // false) == false) | .path // ""' "$repos_json" || echo "")
 
 		local repo_path
 		while IFS= read -r repo_path; do
@@ -467,16 +467,16 @@ reap_zombie_workers() {
 		fi
 		# Fallback: check all pulse-enabled repos
 		if [[ -z "$repo_slug" ]]; then
-			repo_slug=$(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false) | .slug' "$REPOS_JSON" 2>/dev/null | head -1) || continue
+			repo_slug=$(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false) | .slug // ""' "$REPOS_JSON" | head -1) || continue
 		fi
 		[[ -n "$repo_slug" ]] || continue
 
 		# Check if a merged PR exists that closes this issue
 		local merged_pr
 		merged_pr=$(gh pr list --repo "$repo_slug" --state merged --search "closes #${issue_number} OR Closes #${issue_number} OR Resolves #${issue_number} OR resolves #${issue_number}" \
-			--limit 1 --json number --jq '.[0].number' 2>/dev/null) || merged_pr=""
+			--limit 1 --json number --jq '.[0].number // ""' 2>/dev/null) || merged_pr=""
 
-		if [[ -n "$merged_pr" && "$merged_pr" != "null" ]]; then
+		if [[ -n "$merged_pr" ]]; then
 			# Kill the worker process tree
 			worker_pids=$(ps aux | grep "[h]eadless-runtime.*--session-key ${worker_key}" | grep -v grep | awk '{print $2}')
 			if [[ -n "$worker_pids" ]]; then
@@ -639,7 +639,7 @@ cleanup_stalled_workers() {
 		local safe_slug log_file log_size
 		# Check all pulse-enabled repos for matching log
 		local found_log=""
-		for safe_slug in $(jq -r '.initialized_repos[] | select(.pulse == true) | .slug' "$REPOS_JSON" 2>/dev/null | tr '/:' '--'); do
+		for safe_slug in $(jq -r '.initialized_repos[] | select(.pulse == true) | .slug // ""' "$REPOS_JSON" | tr '/:' '--'); do
 			log_file="/tmp/pulse-${safe_slug}-${issue_num}.log"
 			if [[ -f "$log_file" ]]; then
 				found_log="$log_file"

--- a/.agents/scripts/pulse-issue-reconcile.sh
+++ b/.agents/scripts/pulse-issue-reconcile.sh
@@ -95,7 +95,7 @@ _normalize_reassign_self() {
 				total_assigned=$((total_assigned + 1))
 			fi
 		done <<<"$issue_rows"
-	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug' "$repos_json" 2>/dev/null)
+	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug // ""' "$repos_json" || true)
 
 	if [[ "$total_checked" -gt 0 ]]; then
 		echo "[pulse-wrapper] Assignment normalization: assigned ${total_assigned}/${total_checked} active unassigned issues to ${runner_user} (skipped_claimed=${total_skipped_claimed})" >>"$LOGFILE"
@@ -262,7 +262,7 @@ _normalize_unassign_stale() {
 			_normalize_clear_status_labels "$stale_num" "$slug" "$runner_user" || true
 			total_reset=$((total_reset + 1))
 		done <<<"$stale_issues"
-	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug' "$repos_json" 2>/dev/null)
+	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug // ""' "$repos_json" || true)
 
 	if [[ "$total_reset" -gt 0 ]]; then
 		echo "[pulse-wrapper] Stale assignment cleanup: reset ${total_reset} issues for re-dispatch" >>"$LOGFILE"
@@ -536,7 +536,7 @@ _normalize_label_invariants() {
 	while IFS= read -r slug; do
 		[[ -n "$slug" ]] || continue
 		_normalize_label_invariants_for_repo "$slug" "$triage_cutoff"
-	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug' "$repos_json" 2>/dev/null)
+	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug // ""' "$repos_json" || true)
 
 	echo "[pulse-wrapper] label_invariants: checked=${_LI_CHECKED} status_fixed=${_LI_STATUS_FIXED} tier_fixed=${_LI_TIER_FIXED} triage_missing=${_LI_TRIAGE_MISSING}" >>"$LOGFILE"
 
@@ -638,7 +638,7 @@ close_issues_with_merged_prs() {
 		local i=0
 		while [[ "$i" -lt "$issue_count" ]]; do
 			local issue_num issue_title
-			issue_num=$(printf '%s' "$issues_json" | jq -r ".[$i].number" 2>/dev/null)
+			issue_num=$(printf '%s' "$issues_json" | jq -r --argjson i "$i" '.[$i].number // ""') || true
 			issue_title=$(printf '%s' "$issues_json" | jq -r ".[$i].title // empty" 2>/dev/null)
 			i=$((i + 1))
 			[[ "$issue_num" =~ ^[0-9]+$ ]] || continue
@@ -695,7 +695,7 @@ close_issues_with_merged_prs() {
 				total_closed=$((total_closed + 1))
 			fi
 		done
-	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug' "$repos_json" 2>/dev/null)
+	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug // ""' "$repos_json" || true)
 
 	if [[ "$total_closed" -gt 0 ]]; then
 		echo "[pulse-wrapper] Close issues with merged PRs: closed ${total_closed} issue(s)" >>"$LOGFILE"
@@ -744,7 +744,7 @@ reconcile_stale_done_issues() {
 		local i=0
 		while [[ "$i" -lt "$issue_count" ]]; do
 			local issue_num issue_title
-			issue_num=$(printf '%s' "$issues_json" | jq -r ".[$i].number" 2>/dev/null)
+			issue_num=$(printf '%s' "$issues_json" | jq -r --argjson i "$i" '.[$i].number // ""') || true
 			issue_title=$(printf '%s' "$issues_json" | jq -r ".[$i].title // empty" 2>/dev/null)
 			i=$((i + 1))
 			[[ "$issue_num" =~ ^[0-9]+$ ]] || continue
@@ -801,7 +801,7 @@ reconcile_stale_done_issues() {
 				total_reset=$((total_reset + 1))
 			fi
 		done
-	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug' "$repos_json" 2>/dev/null)
+	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug // ""' "$repos_json" || true)
 
 	if [[ "$((total_closed + total_reset))" -gt 0 ]]; then
 		echo "[pulse-wrapper] Reconcile stale done issues: closed=${total_closed}, reset=${total_reset}" >>"$LOGFILE"


### PR DESCRIPTION
## Summary

Addresses all five medium-priority Gemini review suggestions left unresolved from PR #18381 (t1973 Phase 5 extraction).

**Changes in `.agents/scripts/pulse-cleanup.sh`:**
- `.path` → `.path // ""` in three `jq` expressions that extract repo paths (lines 68, 326, 390) — prevents literal `"null"` string output when the key is absent
- `.slug` → `.slug // ""` in `reap_zombie_workers` (line 470) — same fix; also removed `2>/dev/null` so jq errors surface
- `'.[0].number'` → `'.[0].number // ""'` in `reap_zombie_workers` (line 477) — handles absent PR number
- Removed redundant `&& "$merged_pr" != "null"` check (line 479) — with `// ""` fallback, absent values are now empty strings, not the literal string `"null"`
- `.slug` → `.slug // ""` in `cleanup_stale_opencode` (line 642) — removed `2>/dev/null`

**Changes in `.agents/scripts/pulse-issue-reconcile.sh`:**
- `.slug` → `.slug // ""` in all five `done < <(jq ...)` repo-iteration patterns (lines 98, 265, 539, 698, 804); `2>/dev/null` replaced with `|| true` so jq errors are visible
- `jq -r ".[$i].number" 2>/dev/null` → `jq -r --argjson i "$i" '.[$i].number // ""') || true` in two places (lines 641, 747) — uses `--argjson` for type-safe numeric index access

## Verification

- `shellcheck .agents/scripts/pulse-cleanup.sh` — 0 violations
- `shellcheck .agents/scripts/pulse-issue-reconcile.sh` — 0 violations
- All patterns confirmed via `rg` search: no remaining `.path'`, `.slug'`, or `!= "null"` patterns in target files

Resolves #18556