### PR TITLE
GH#18571: fix gemini-code-assist review findings from PR #18379 (pulse-merge.sh)

### DIFF
--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -529,9 +529,12 @@ merge_ready_prs_all_repos() {
 	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | [.slug, .path] | join("|")' "$REPOS_JSON" 2>/dev/null)
 
 	echo "[pulse-wrapper] Deterministic merge pass complete: merged=${total_merged}, closed_conflicting=${total_closed}, failed=${total_failed}" >>"$LOGFILE"
-	# Accumulate into per-cycle health counters (GH#15107)
-	_PULSE_HEALTH_PRS_MERGED=$((_PULSE_HEALTH_PRS_MERGED + total_merged))
-	_PULSE_HEALTH_PRS_CLOSED_CONFLICTING=$((_PULSE_HEALTH_PRS_CLOSED_CONFLICTING + total_closed))
+	# Write health counter deltas to a temp file (GH#18571, GH#15107).
+	# run_stage_with_timeout backgrounds this function in a subshell, so
+	# direct updates to _PULSE_HEALTH_* variables are lost on return.
+	# The parent process reads this file after the stage completes.
+	local _health_delta_file="${TMPDIR:-/tmp}/pulse-health-merge-$$.tmp"
+	printf '%s %s\n' "$total_merged" "$total_closed" >"$_health_delta_file" || true
 	return 0
 }
 
@@ -775,7 +778,8 @@ _Merged by deterministic merge pass (pulse-wrapper.sh). Neither MERGE_SUMMARY co
 		if [[ -n "$linked_issue" ]]; then
 			_merge_issue_ref="${repo_slug}#${linked_issue}"
 		fi
-		_merge_sig_footer=$("${HOME}/.aidevops/agents/scripts/gh-signature-helper.sh" footer \
+		local _sig_helper="${AGENTS_DIR:-$HOME/.aidevops/agents}/scripts/gh-signature-helper.sh"
+		_merge_sig_footer=$("$_sig_helper" footer \
 			--body "$closing_comment" --no-session --tokens 0 \
 			--time "$_merge_elapsed" --session-type routine \
 			${_merge_issue_ref:+--issue "$_merge_issue_ref"} --solved 2>/dev/null || true)
@@ -984,7 +988,7 @@ _close_conflicting_pr() {
 		# squash-merge "(#NNN)" suffix.
 		local commit_subjects
 		commit_subjects=$(gh api "repos/${repo_slug}/commits" \
-			--method GET -f sha=main -f per_page=50 \
+			--method GET -f per_page=50 \
 			--jq '.[] | .commit.message | split("\n")[0]' \
 			2>/dev/null) || commit_subjects=""
 

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1135,6 +1135,19 @@ main() {
 	# LLM failed to execute merge steps or the prefetch showed 0 PRs.
 	run_stage_with_timeout "deterministic_merge_pass" "$PRE_RUN_STAGE_TIMEOUT" \
 		merge_ready_prs_all_repos || true
+	# Accumulate health counters written by merge_ready_prs_all_repos (GH#18571, GH#15107).
+	# The function runs in a subshell via run_stage_with_timeout, so variable
+	# updates are lost. Read the temp file it writes and accumulate here.
+	local _merge_health_file="${TMPDIR:-/tmp}/pulse-health-merge-$$.tmp"
+	if [[ -f "$_merge_health_file" ]]; then
+		local _mhf_merged=0 _mhf_closed=0
+		read -r _mhf_merged _mhf_closed <"$_merge_health_file" || true
+		[[ "$_mhf_merged" =~ ^[0-9]+$ ]] || _mhf_merged=0
+		[[ "$_mhf_closed" =~ ^[0-9]+$ ]] || _mhf_closed=0
+		_PULSE_HEALTH_PRS_MERGED=$((_PULSE_HEALTH_PRS_MERGED + _mhf_merged))
+		_PULSE_HEALTH_PRS_CLOSED_CONFLICTING=$((_PULSE_HEALTH_PRS_CLOSED_CONFLICTING + _mhf_closed))
+		rm -f "$_merge_health_file" || true
+	fi
 
 	# Dependency graph cache (t1935): build once per cycle so that
 	# is_blocked_by_unresolved() can resolve blocker state without API calls.


### PR DESCRIPTION
## Summary

Addresses three medium-priority findings from gemini-code-assist on PR #18379 (t1972 Phase 4 pulse-merge.sh extraction):

- **Health counter subshell propagation**: `merge_ready_prs_all_repos` is called via `run_stage_with_timeout`, which backgrounds it in a subshell. Variable updates to `_PULSE_HEALTH_PRS_MERGED` and `_PULSE_HEALTH_PRS_CLOSED_CONFLICTING` were silently lost. Fixed by writing counter deltas to a temp file (`${TMPDIR:-/tmp}/pulse-health-merge-$$.tmp`) inside the function, and reading it back in `pulse-wrapper.sh` after the stage returns.

- **Hardcoded helper path**: `gh-signature-helper.sh` was invoked via `"${HOME}/.aidevops/agents/scripts/gh-signature-helper.sh"`. Changed to `"${AGENTS_DIR:-$HOME/.aidevops/agents}/scripts/gh-signature-helper.sh"` — consistent with `approval-helper.sh` (line 185) and `review-bot-gate-helper.sh` (line 722) in the same file.

- **Hardcoded `sha=main`**: Removed `-f sha=main` from the `gh api repos/.../commits` call in `_close_conflicting_pr`. The GitHub API defaults to the repository's actual default branch when `sha` is omitted, making the check correct for non-main default branches.

## Files changed

- EDIT: `.agents/scripts/pulse-merge.sh` — counter temp file write, AGENTS_DIR path, remove sha=main
- EDIT: `.agents/scripts/pulse-wrapper.sh` — counter temp file read after deterministic merge stage

## Verification

```bash
shellcheck .agents/scripts/pulse-merge.sh   # zero violations
shellcheck .agents/scripts/pulse-wrapper.sh  # zero violations
```

Resolves #18571