### PR TITLE
GH#18588: normalize GH# prefix in complexity-thresholds.conf comments

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -13,12 +13,12 @@
 # Baseline: 404 (2026-03-24) → ratcheted to 31 (GH#17875): 29 violations + 2 buffer
 # Bumped to 36 (GH#17969): pre-existing regression on main — 34 violations vs threshold 31; 34 + 2 buffer
 # Bumped to 40 (GH#18037): pre-existing regression on main — 38 violations vs threshold 36; 38 + 2 buffer
-# Bumped to 43 (post-#18376, t1971 Phase 3): pulse-wrapper decomposition moved calculate_priority_allocations
+# Bumped to 43 (post-GH#18376, t1971 Phase 3): pulse-wrapper decomposition moved calculate_priority_allocations
 # into pulse-capacity-alloc.sh; awk counter now records it at 102 lines (was <=100 in the wrapper due to
 # adjacent context). Net violation count: 41 (was 40). 41 + 2 buffer = 43. This bump is purely the move-side-
 # effect of a byte-preserving extraction; follow-up PRs after the full decomposition (Phase 12) will ratchet
 # back down. Phase 3 merged with a CI failure on this check — bump lands as a hotfix so Phase 4+ CI passes.
-# Bumped to 46 (#18419, t1986): post-merge of t1982 (#18405) added _compose_consolidation_child_body (101)
+# Bumped to 46 (GH#18419, t1986): post-merge of t1982 (GH#18405) added _compose_consolidation_child_body (101)
 # and _dispatch_issue_consolidation (104) to pulse-triage.sh, plus a setup_gh_stub (102) test helper.
 # Net violation count: 44. 44 + 2 buffer = 46. The t1986 fix itself does NOT add any 100+-line functions —
 # this bump is pure drift absorption from main between Phase 10 merge and t1986 PR creation.
@@ -59,16 +59,16 @@ FUNCTION_COMPLEXITY_THRESHOLD=46
 # Ratcheted down to 249 (GH#18293): actual violations 247 + 2 buffer
 # Bumped to 254 (GH#18314): proximity guard firing at 247/249 (2 headroom); 247 violations + 7 headroom; warn_at=249, guard fires when violations exceed 249 (i.e., at 250), preventing saturation
 # Ratcheted down to 249 (GH#18326): actual violations 247 + 2 buffer
-# Bumped to 253 (post-#18376, t1971 Phase 3): decomposition extracted 4 new pulse-*.sh modules;
+# Bumped to 253 (post-GH#18376, t1971 Phase 3): decomposition extracted 4 new pulse-*.sh modules;
 # some extracted functions contributed higher per-file nesting depth to the new modules than their
 # former host function did to pulse-wrapper.sh. Net violations: 251 (was 249). 251 + 2 = 253.
-# Bumped to 260 (#18381, t1973 Phase 5): Phase 5 added pulse-cleanup.sh + pulse-issue-reconcile.sh,
+# Bumped to 260 (GH#18381, t1973 Phase 5): Phase 5 added pulse-cleanup.sh + pulse-issue-reconcile.sh,
 # net violations now 254. Bumped with extra headroom (+6) rather than +2 because Phases 6-10 will
 # each add similar deltas — bumping once per phase is noise. Will ratchet back down after Phase 12.
-# Bumped to 263 (#18435, post t1986): drift absorption from concurrent merges (t1981/t1984/t1996/t1997)
+# Bumped to 263 (GH#18435, post t1986): drift absorption from concurrent merges (t1981/t1984/t1996/t1997)
 # between t1986 PR creation and the chore: sync-todo-completion-markers PR. Net violations: 261 + 2 = 263.
 # Will ratchet back down after Phase 12 (t1987) lands.
-# Bumped to 266 (#18562, t2013): splitting headless-runtime-helper.sh into helper + lib creates one
+# Bumped to 266 (GH#18562, t2013): splitting headless-runtime-helper.sh into helper + lib creates one
 # additional file (headless-runtime-lib.sh, nesting depth 82) that exceeds the >8 threshold. The functions
 # already violated when they lived in the helper; the split adds one new file to the count.
 # Net violations: 264. 264 + 2 buffer = 266.
@@ -77,7 +77,7 @@ NESTING_DEPTH_THRESHOLD=266
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)
 # Bumped to 56 (GH#17969): pre-existing regression on main — 54 violations vs threshold 53; 54 + 2 buffer
-# Bumped to 59 (#18386, t1975 Phase 7): pulse-simplification.sh (1990) + pulse-prefetch.sh (1668)
+# Bumped to 59 (GH#18386, t1975 Phase 7): pulse-simplification.sh (1990) + pulse-prefetch.sh (1668)
 # from the decomposition both exceed 1500. Net violations: 57 + 2 = 59. These two large modules
 # will themselves be split in Phase 12 (post-gate simplification sweep).
 FILE_SIZE_THRESHOLD=59


### PR DESCRIPTION
## Summary

Addresses unresolved Gemini bot review feedback from PR #18377.

The bot flagged that `#18376` on line 16 of `.agents/configs/complexity-thresholds.conf` should use the `GH#` prefix for consistency with the rest of the file. Extended the fix to all 7 bare `#NNNNN` references in the file.

## Changes

**File:** `.agents/configs/complexity-thresholds.conf`

| Line | Before | After |
|------|--------|-------|
| 16 | `post-#18376` | `post-GH#18376` |
| 21 | `#18419`, `#18405` | `GH#18419`, `GH#18405` |
| 62 | `post-#18376` | `post-GH#18376` |
| 65 | `#18381` | `GH#18381` |
| 68 | `#18435` | `GH#18435` |
| 71 | `#18562` | `GH#18562` |
| 80 | `#18386` | `GH#18386` |

## Verification

```bash
grep -n '(#[0-9]\|post-#[0-9]' .agents/configs/complexity-thresholds.conf
# Returns: no output (all bare references fixed)
```

Resolves #18588