### PR TITLE
GH#18590: fix _seed_cache temp-file safety in test-privacy-guard.sh

### DIFF
--- a/.agents/scripts/test-privacy-guard.sh
+++ b/.agents/scripts/test-privacy-guard.sh
@@ -254,12 +254,16 @@ _seed_cache() {
 		printf '{}\n' >"$PRIVACY_CACHE_FILE"
 	fi
 	local tmp
-	tmp=$(mktemp)
+	tmp=$(mktemp "${TMP}/cache.XXXXXX")
 	jq --arg slug "$slug" \
 		--argjson private "$private_bool" \
 		--argjson ca "$checked_at" \
 		'.[$slug] = {private: $private, checked_at: $ca}' \
-		"$PRIVACY_CACHE_FILE" >"$tmp"
+		"$PRIVACY_CACHE_FILE" >"$tmp" || {
+		rm -f "$tmp"
+		printf 'Error: failed to update cache file at %s\n' "$PRIVACY_CACHE_FILE" >&2
+		return 1
+	}
 	mv "$tmp" "$PRIVACY_CACHE_FILE"
 	return 0
 }


### PR DESCRIPTION
## Summary

Addresses two unresolved Gemini review-bot findings from PR #18375.

**Change 1 — `mktemp` within managed `$TMP` directory (line 257)**

Before:
```bash
tmp=$(mktemp)
```
After:
```bash
tmp=$(mktemp "${TMP}/cache.XXXXXX")
```
`TMP` is a `mktemp -d` scratch directory with an `EXIT` trap that removes it. Creating the cache temp file inside `$TMP` ensures it's always cleaned up even if the function returns early or the process is killed, not just when an explicit `rm` runs.

**Change 2 — error handling on jq failure (line 262-266)**

Before:
```bash
jq ... "$PRIVACY_CACHE_FILE" >"$tmp"
mv "$tmp" "$PRIVACY_CACHE_FILE"
```
After:
```bash
jq ... "$PRIVACY_CACHE_FILE" >"$tmp" || {
    rm -f "$tmp"
    printf 'Error: failed to update cache file at %s\n' "$PRIVACY_CACHE_FILE" >&2
    return 1
}
mv "$tmp" "$PRIVACY_CACHE_FILE"
```
If `jq` fails (malformed input, write error), the temp file is removed immediately and the function exits with code 1 + a diagnostic message including the file path. Previously a failed `jq` would leave a partial temp file in place and `mv` would silently overwrite the cache with truncated/corrupt output.

## Verification

```
GIT_CONFIG_NOSYSTEM=1 GIT_CONFIG_GLOBAL=/dev/null bash .agents/scripts/test-privacy-guard.sh
All 17 test(s) passed
```

ShellCheck: no new violations (SC1091 dynamic-source info notice is pre-existing and unchanged).

Resolves #18590