### PR TITLE
GH#18591: cache gh api user + .login // "" fallback in _push_create_issue

### DIFF
--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -539,7 +539,13 @@ _push_create_issue() {
 	if [[ -n "$num" && -z "$assignee" && "$origin_label" == "origin:interactive" ]]; then
 		local current_user="${AIDEVOPS_SESSION_USER:-}"
 		if [[ -z "$current_user" ]]; then
-			current_user=$(gh api user --jq '.login' 2>/dev/null || echo "")
+			# GH#18591: cache gh api user result to avoid repeated API calls when
+			# processing multiple tasks in a loop. Use .login // "" so a null
+			# login field yields an empty string rather than the literal "null".
+			if [[ -z "${_CACHED_GH_USER:-}" ]]; then
+				_CACHED_GH_USER=$(gh api user --jq '.login // ""' 2>/dev/null || echo "")
+			fi
+			current_user="$_CACHED_GH_USER"
 		fi
 		if [[ -n "$current_user" ]]; then
 			if gh issue edit "$num" --repo "$repo" --add-assignee "$current_user" >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

Address the two Gemini review bot suggestions from PR #18374 that were flagged in #18591.

**File:** `.agents/scripts/issue-sync-helper.sh` — `_push_create_issue` function (lines 539-557)

### Changes

**1. Cache `gh api user` result** (`_CACHED_GH_USER` module-global)

When `issue-sync-helper.sh push` processes multiple tasks in a batch, `_push_create_issue` was calling `gh api user` for each `origin:interactive` issue that needed auto-assignment. Each call is a separate API round-trip. The fix stores the result in `_CACHED_GH_USER` (a shell-scope global — intentionally not `local`) so the API is only called once per process invocation regardless of batch size.

**2. Use `.login // ""` jq fallback**

The previous filter `.login` returns the literal string `null` when the field is present but null in the JSON response. With `.login // ""`, jq short-circuits to an empty string for null values, making the existing `[[ -n "$current_user" ]]` guard sufficient — no separate `!= "null"` string check needed.

The `AIDEVOPS_SESSION_USER` fast-path (set by the GitHub Actions workflow to override the `github-actions[bot]` identity) is unaffected — caching only applies when that env var is absent.

## Verification

- `shellcheck .agents/scripts/issue-sync-helper.sh` — no new violations (only pre-existing SC1091/SC2016 info-level)
- Logic: `AIDEVOPS_SESSION_USER` set → uses env var directly (no API call, no cache read)
- Logic: `AIDEVOPS_SESSION_USER` unset, first issue → calls `gh api user --jq '.login // ""'`, stores in `_CACHED_GH_USER`
- Logic: `AIDEVOPS_SESSION_USER` unset, subsequent issues → reads from `_CACHED_GH_USER`, no API call

Resolves #18591