### PR TITLE
GH#18592: refactor _privacy_guard.sh — case statement + cd --

### DIFF
--- a/.agents/scripts/setup/_privacy_guard.sh
+++ b/.agents/scripts/setup/_privacy_guard.sh
@@ -16,7 +16,7 @@
 #######################################
 _load_privacy_guard_installer() {
 	local installer_path
-	installer_path="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../install-privacy-guard.sh"
+	installer_path="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../install-privacy-guard.sh"
 	if [[ ! -f "$installer_path" ]]; then
 		print_warning "install-privacy-guard.sh not found at: $installer_path"
 		return 1
@@ -78,16 +78,21 @@ setup_privacy_guard() {
 			skip=$((skip + 1))
 			continue
 		fi
-		result=$(cd "$path" && bash "$installer_path" install 2>&1 </dev/null || true)
-		if [[ "$result" == *"installed privacy guard"* ]]; then
+		result=$(cd -- "$path" && bash "$installer_path" install 2>&1 </dev/null || true)
+		case "$result" in
+		*"installed privacy guard"*)
 			ok=$((ok + 1))
-		elif [[ "$result" == *"already installed"* ]]; then
+			;;
+		*"already installed"*)
 			already=$((already + 1))
-		elif [[ "$result" == *"Refusing to overwrite"* || "$result" == *"NOT managed"* ]]; then
+			;;
+		*"Refusing to overwrite"* | *"NOT managed"*)
 			conflict=$((conflict + 1))
-		else
+			;;
+		*)
 			err=$((err + 1))
-		fi
+			;;
+		esac
 	done < <(jq -r '.initialized_repos[]? | select(.path != null) | .path' "$repos_config")
 
 	print_info "Privacy guard: ok=$ok already=$already conflict=$conflict skip=$skip err=$err"


### PR DESCRIPTION
## Summary

- Replace if/elif/else with a case statement for outcome classification in setup_privacy_guard() — more idiomatic Bash for multi-way string-pattern branching, as flagged by Gemini in PR #18373 review.
- Use cd -- instead of bare cd in both directory-change sites (_load_privacy_guard_installer and the per-repo install loop) to safely handle paths that could begin with a hyphen.

## Why

These are the two unaddressed Gemini review suggestions from the merged PR #18373. The changes are purely stylistic / safety — no functional behaviour changes.

## Verification

- shellcheck .agents/scripts/setup/_privacy_guard.sh passes with zero violations
- Diff: outcome classification logic unchanged, only syntax form differs

Resolves #18592