### PR TITLE
GH#18594: fix jq // fallback operator and remove redundant null checks in pulse-repo-meta.sh and pulse-routines.sh

### DIFF
--- a/.agents/scripts/pulse-repo-meta.sh
+++ b/.agents/scripts/pulse-repo-meta.sh
@@ -45,10 +45,7 @@ get_repo_path_by_slug() {
 	fi
 
 	local repo_path
-	repo_path=$(jq -r --arg slug "$repo_slug" '.initialized_repos[] | select(.slug == $slug) | .path' "$REPOS_JSON" 2>/dev/null | head -n 1)
-	if [[ "$repo_path" == "null" ]]; then
-		repo_path=""
-	fi
+	repo_path=$(jq -r --arg slug "$repo_slug" '.initialized_repos[] | select(.slug == $slug) | .path // ""' "$REPOS_JSON" 2>/dev/null | head -n 1)
 	echo "$repo_path"
 	return 0
 }
@@ -84,10 +81,7 @@ get_repo_maintainer_by_slug() {
 	fi
 
 	local maintainer
-	maintainer=$(jq -r --arg slug "$repo_slug" '.initialized_repos[] | select(.slug == $slug) | .maintainer // empty' "$REPOS_JSON" 2>/dev/null) || maintainer=""
-	if [[ "$maintainer" == "null" ]]; then
-		maintainer=""
-	fi
+	maintainer=$(jq -r --arg slug "$repo_slug" '.initialized_repos[] | select(.slug == $slug) | .maintainer // ""' "$REPOS_JSON" 2>/dev/null) || maintainer=""
 	printf '%s\n' "$maintainer"
 	return 0
 }
@@ -107,7 +101,7 @@ get_repo_priority_by_slug() {
 
 	local repo_priority
 	repo_priority=$(jq -r --arg slug "$repo_slug" '.initialized_repos[] | select(.slug == $slug) | .priority // "tooling"' "$REPOS_JSON" 2>/dev/null | head -n 1)
-	if [[ -z "$repo_priority" || "$repo_priority" == "null" ]]; then
+	if [[ -z "$repo_priority" ]]; then
 		repo_priority="tooling"
 	fi
 	printf '%s\n' "$repo_priority"
@@ -149,13 +143,14 @@ list_dispatchable_issue_candidates_json() {
 	fi
 	[[ "$limit" =~ ^[0-9]+$ ]] || limit=100
 
-	local issue_json issue_dispatch_err
+	local issue_json issue_dispatch_err gh_exit_code
 	issue_dispatch_err=$(mktemp)
-	issue_json=$(gh issue list --repo "$repo_slug" --state open --json number,title,url,assignees,labels,updatedAt --limit "$limit" 2>"$issue_dispatch_err") || issue_json="[]"
-	if [[ -z "$issue_json" || "$issue_json" == "null" ]]; then
+	gh_exit_code=0
+	issue_json=$(gh issue list --repo "$repo_slug" --state open --json number,title,url,assignees,labels,updatedAt --limit "$limit" 2>"$issue_dispatch_err") || gh_exit_code=$?
+	if [[ "$gh_exit_code" -ne 0 ]] || [[ -z "$issue_json" || "$issue_json" == "null" ]]; then
 		local _issue_dispatch_err_msg
 		_issue_dispatch_err_msg=$(cat "$issue_dispatch_err" 2>/dev/null || echo "unknown error")
-		echo "[pulse-wrapper] list_dispatchable_issue_candidates: gh issue list FAILED for ${repo_slug}: ${_issue_dispatch_err_msg}" >>"$LOGFILE"
+		echo "[pulse-wrapper] list_dispatchable_issue_candidates: gh issue list FAILED for ${repo_slug} (exit ${gh_exit_code}): ${_issue_dispatch_err_msg}" >>"$LOGFILE"
 		issue_json="[]"
 	fi
 	rm -f "$issue_dispatch_err"

--- a/.agents/scripts/pulse-routines.sh
+++ b/.agents/scripts/pulse-routines.sh
@@ -42,7 +42,7 @@ _routine_last_run_epoch() {
 	fi
 	local epoch
 	epoch=$(jq -r --arg id "$routine_id" '.[$id].last_run // ""' "$ROUTINE_STATE_FILE" 2>/dev/null) || epoch=""
-	if [[ -z "$epoch" || "$epoch" == "null" ]]; then
+	if [[ -z "$epoch" ]]; then
 		printf '0'
 		return 0
 	fi


### PR DESCRIPTION
## Summary

Addresses five medium-priority Gemini review suggestions from PR #18366 (t1966 Phase 1 extraction), following the same pattern as PR #18600 which fixed equivalent issues in `pulse-cleanup.sh` and `pulse-issue-reconcile.sh`.

**Changes in `.agents/scripts/pulse-repo-meta.sh`:**
- `get_repo_path_by_slug`: `.path` → `.path // ""` in jq expression — removes redundant `== "null"` check (3 lines → 1 line)
- `get_repo_maintainer_by_slug`: `.maintainer // empty` → `.maintainer // ""` — removes redundant `== "null"` check (the `// empty` idiom was already preventing null output but the check remained)
- `get_repo_priority_by_slug`: removes redundant `|| "$repo_priority" == "null"` guard — `.priority // "tooling"` already ensures null never reaches the shell variable as a literal string
- `list_dispatchable_issue_candidates_json`: captures `gh` exit code explicitly (`gh_exit_code=0; ... || gh_exit_code=$?`) and checks it before checking value — accurately detects failures vs. empty-but-valid responses; includes exit code in log message

**Changes in `.agents/scripts/pulse-routines.sh`:**
- `_routine_last_run_epoch`: removes redundant `|| "$epoch" == "null"` guard — `.last_run // ""` already ensures null never appears as literal string

## Verification

- `shellcheck .agents/scripts/pulse-repo-meta.sh` — 0 violations
- `shellcheck .agents/scripts/pulse-routines.sh` — 0 violations
- Confirmed: no remaining redundant `!= "null"` or `== "null"` patterns in modified files
- Pattern matches PR #18600 approach for consistency

## Runtime Testing

**Risk level**: Low — shell script cleanup only (no logic change, same runtime behaviour). `self-assessed`.

No functional changes. The `// ""` fallback in jq and removal of post-assignment null-string checks are semantically equivalent under all valid inputs. The only observable difference is improved error logging in `list_dispatchable_issue_candidates_json` (exit code now included).

Resolves #18594

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.5 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 2m and 7,095 tokens on this as a headless worker.