### PR TITLE
GH#18595: add missing triedEmails JSDoc param to handle429Recovery

### DIFF
--- a/.agents/plugins/opencode-aidevops/provider-auth.mjs
+++ b/.agents/plugins/opencode-aidevops/provider-auth.mjs
@@ -1176,6 +1176,7 @@ async function handle401Recovery(client, response, accessToken, sessionAccountEm
  * @param {string} accessToken
  * @param {string|null} sessionAccountEmail
  * @param {{requestHeaders: Headers, requestInput: Request|string|URL, requestInit: RequestInit, body: string|null|undefined}} ctx
+ * @param {Set<string>} [triedEmails] - set of account emails already tried this request cycle, used to prevent infinite rotation when all accounts are rate-limited
  * @returns {Promise<{response: Response, sessionAccountEmail: string|null}>}
  */
 async function handle429Recovery(client, response, accessToken, sessionAccountEmail, ctx, triedEmails) {


### PR DESCRIPTION
## Summary

- Add missing `@param {Set<string>} [triedEmails]` JSDoc entry to `handle429Recovery` in `.agents/plugins/opencode-aidevops/provider-auth.mjs`

## Root cause

PR #18363 added the `triedEmails` parameter to `handle429Recovery` to prevent infinite account rotation during 429 rate-limit recovery, but the JSDoc block was not updated. This was flagged by gemini-code-assist in the review of that PR.

## Change

Single-line JSDoc addition at line 1178 (before `@returns`):

```js
 * @param {Set<string>} [triedEmails] - set of account emails already tried this request cycle, used to prevent infinite rotation when all accounts are rate-limited
```

## Runtime Testing

**Risk level:** Low — documentation-only change (JSDoc comment). No runtime behaviour modified.
**Verification:** self-assessed — no code logic changed.

Resolves #18595


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.5 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 1m and 3,001 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal documentation for rate-limit recovery handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->