### PR TITLE
GH#18458: improve brief template and tier routing for high-reference tasks

### DIFF
--- a/.agents/reference/task-taxonomy.md
+++ b/.agents/reference/task-taxonomy.md
@@ -73,6 +73,22 @@ If **any** of the following are true, the task is **not** `tier:simple`. Use `ti
 | Decisions | Implementation choices (which API, which pattern) | Architectural choices (what abstraction, what trade-offs) |
 | Error modes | Known error modes with documented recovery | Novel failure modes requiring analysis |
 | Brief detail | Code skeletons with function signatures | Approach description with constraints |
+| Reference material | <2,000 lines total across all files | >2,000 lines, or 5+ files to synthesize |
+
+### High-Reference Tasks (GH#18458 — context budget awareness)
+
+Some tasks require reading large volumes of reference material before implementation
+can begin. These are systematically prone to worker timeout at `tier:standard` because
+sonnet burns its token budget on reading rather than implementing. Indicators:
+
+| Indicator | Example | Mitigation |
+|-----------|---------|------------|
+| >2,000 lines of reference files | Plan doc (649L) + model file (674L) + target file (3,164L) | Use Worker Quick-Start section, inline critical data |
+| 5+ files must be read before first edit | Plan, model test, target, wrapper, CI workflow | Use `tier:reasoning` or split into smaller tasks |
+| Plan sketches reference function signatures | Plan says `fn(a, b)` but actual is `fn(a, b, c)` | Verify sketches against source before filing task |
+| Data must be extracted from large files | "48 function names from Plan section 3.1" | Include the data directly in the brief |
+
+**Decomposition Phase 0 tasks** are a specific high-risk pattern: they require reading the plan document, the model/reference test file, the target source file, and the wrapper/orchestrator file. This routinely exceeds 4,000 lines. Dispatch Phase 0 tasks at `tier:reasoning`. Subsequent phases (1-N) are pure mechanical moves and can use `tier:standard`.
 
 ### Quick-Check at Creation Time
 
@@ -83,7 +99,8 @@ Before assigning a tier, verify these in order. Stop at the first failure:
 3. **Scan for judgment keywords** — fallback, retry, graceful, conditional, coordinate, design in the brief disqualifies `tier:simple`
 4. **Check estimate** — >1h disqualifies `tier:simple`
 5. **Check file size** — if the target file is >500 lines and the brief does not include verbatim `oldString`/`newString`, disqualifies `tier:simple`
-6. **When uncertain** — `tier:standard` (the default exists for this reason)
+6. **Check reference budget** — if the brief's "Research/read" phase totals >2,000 lines, consider `tier:reasoning`
+7. **When uncertain** — `tier:standard` (the default exists for this reason)
 
 See `templates/brief-template.md` "Tier checklist" for the structured version used during task creation.
 
@@ -120,6 +137,7 @@ Structured reasons feed back into brief template optimisation:
 | `ERROR_RECOVERY` | Hit unexpected error, can't self-recover | Add fallback instructions |
 | `TOOL_CHAIN_COMPLEXITY` | Too many sequential tool calls | Pre-compute intermediate state |
 | `MISSING_CONTEXT` | Brief lacks background for the decision | Add "Context & Decisions" section |
+| `CONTEXT_BUDGET_EXCEEDED` | Too much reference material to read before implementing | Inline critical data in brief, add Worker Quick-Start section, consider tier:reasoning |
 
 ## Command Use
 

--- a/.agents/templates/brief-template.md
+++ b/.agents/templates/brief-template.md
@@ -60,7 +60,48 @@ or "Single-file config edit with exact code block provided -> tier:simple"}
      - tier:standard: Code skeletons with function signatures and inline comments.
        The worker fills in logic following the specified pattern.
      - tier:reasoning: Approach description with constraints and trade-offs.
-       The worker designs the solution. -->
+       The worker designs the solution.
+
+     INLINE DATA RULE (GH#18458 — worker token budget protection):
+     When a brief references data from a large file (plan doc, source file, config),
+     include the data INLINE rather than saying "see Plan section X" or "see file Y".
+     Workers that must read 500+ line files just to extract a 50-line data list burn
+     tokens on reading before implementing. Examples:
+       BAD:  "Use the 48 function names from Plan section 3.1"
+       GOOD: List all 48 function names directly in the brief
+       BAD:  "Model on test-pulse-wrapper-characterization.sh"
+       GOOD: "Model on test-pulse-wrapper-characterization.sh — key structure:
+              setup_sandbox(), EXPECTED_FUNCTIONS array, declare -F loop, print_result
+              helper, main() calling all test_* functions"
+
+     PLAN-SKETCH VERIFICATION (GH#18458):
+     When code sketches from a plan document are included in a brief, verify every
+     function call against the actual source file signatures BEFORE filing the child
+     task. Plan sketches are written during planning (before implementation); function
+     signatures may have been updated since. A wrong signature in a brief causes the
+     worker to write broken code and burn tokens debugging. -->
+
+### Worker Quick-Start
+
+<!-- OPTIONAL but RECOMMENDED for tasks with 3+ reference files or >2,000 lines of
+     total reference material. Gives the worker the 5-10 most critical commands/facts
+     to start implementing immediately, without reading all reference files first.
+     Workers dispatched at tier:standard (sonnet) have limited context budgets —
+     front-loading the critical data here prevents token exhaustion during reading.
+     Omit for simple tasks where Implementation Steps are sufficient. -->
+
+{Delete this section if the task is straightforward. For complex tasks:}
+
+```bash
+# 1. Extract key data (e.g., function names from a large file):
+{grep/awk command that extracts the critical data the worker needs}
+
+# 2. Key structural pattern to follow:
+{1-3 line description of the reference file's structure, not "read the whole file"}
+
+# 3. Critical gotchas (verified signatures, known quirks):
+{e.g., "_persist_role_cache takes 3 args (runner_user, repo_slug, role), not 2"}
+```
 
 ### Files to Modify
 
@@ -181,3 +222,15 @@ that defines how to machine-check the criterion. See `.agents/scripts/verify-bri
 | Implementation | {Xh} | {scope} |
 | Testing | {Xm} | {test strategy} |
 | **Total** | **{Xh}** | |
+
+<!-- READING BUDGET CHECK (GH#18458):
+     If the Research/read phase lists >2,000 lines of reference material across all
+     files, the task is at HIGH RISK of worker timeout (token exhaustion before
+     implementation starts). Mitigations:
+     1. Use the Worker Quick-Start section to front-load critical data
+     2. Include extracted data inline (don't just point to large files)
+     3. Consider tier:reasoning if the task requires synthesizing across 5+ files
+     4. For decomposition Phase 0 tasks specifically, use tier:reasoning — these
+        require reading the plan + model file + target file + wrapper file, which
+        routinely exceeds 4,000 lines of reference material.
+-->


### PR DESCRIPTION
## Summary

Systemic fixes to prevent worker failures on tasks that require reading large volumes of reference material before implementation. Motivated by the t2044 Phase 0 worker failure analysis (GH#18458).

For #18458

## What

**brief-template.md** (3 new sections/rules):
- **Worker Quick-Start section** — optional section for tasks with 3+ reference files or >2,000 lines of reference material. Front-loads critical data (extraction commands, structural patterns, signature gotchas) so workers can start implementing without reading all reference files first.
- **Inline data rule** — guidance to include extracted data directly in briefs rather than saying "see Plan section X". Workers that read 500+ line files to extract 50 lines of data waste their token budget.
- **Plan-sketch verification rule** — verify function call signatures in code sketches against actual source before filing child tasks. Plan sketches are written during planning; signatures may have changed since.
- **Reading budget check** — advisory in Estimate Breakdown noting that >2,000 lines of reference material puts the task at high risk of worker timeout.

**task-taxonomy.md** (4 additions):
- **Reference material row** in tier:standard vs tier:reasoning signals table
- **High-Reference Tasks section** with indicators, examples, and mitigations
- **Phase 0 decomposition tier routing** — dispatch at `tier:reasoning`, not `tier:standard`
- **CONTEXT_BUDGET_EXCEEDED** escalation reason added to taxonomy

## Evidence

t2044 worker dispatched at `tier:standard` (sonnet) produced no output after being dispatched to a task requiring ~4,900 lines of reading across 5 files. The plan skeleton also had a wrong function signature (`_persist_role_cache`: 2 args in plan vs 3 in source). An interactive session completed the same task in ~20 minutes.

## Runtime Testing

Risk: **Low** — documentation/template changes only. No code modified.
Verification: `self-assessed`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.6 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 16m and 17,276 tokens on this as a headless worker.