### PR TITLE
GH#18593: fix review followup from PR #18368 (stale locks, eval removal, dep-graph perf)

### DIFF
--- a/.agents/scripts/pulse-dep-graph.sh
+++ b/.agents/scripts/pulse-dep-graph.sh
@@ -126,16 +126,20 @@ _dep_graph_process_issue_json() {
 }
 
 #######################################
-# Build per-repo dep graph data (t2031 refactor)
+# Build per-repo dep graph data (t2031 refactor, GH#18593 perf)
 #
-# Fetches all open issues for one repo slug and accumulates the
-# open_issues / task_to_issue / blocked_by / defer_flags state by
-# calling _dep_graph_process_issue_json once per issue. Emits a single
-# JSON object on stdout with the per-repo shape:
-#   { "open_issues": [], "task_to_issue": {}, "blocked_by": {}, "defer_flags": {} }
+# Fetches all open issues for one repo slug and produces the per-repo
+# dep-graph cache object in a single jq call instead of spawning a
+# subshell per issue. This collapses O(n * ~13) process forks down to
+# O(1) per repo, which is significant for repos with 200+ open issues.
 #
-# Extracted from build_dependency_graph_cache so that function stays
-# under the 100-line complexity gate.
+# The jq program replicates the logic of _dep_graph_process_issue_json:
+#   - task ID extraction from title (^tNNN: prefix)
+#   - blocked-by line detection and tID/issueNum extraction
+#   - defer/hold marker detection (same patterns as _body_has_defer_marker)
+#
+# _dep_graph_process_issue_json is retained for unit testing and as a
+# reference implementation.
 #
 # Arguments: $1 - repo slug (owner/repo)
 # Output:    one JSON object on stdout
@@ -146,24 +150,54 @@ _dep_graph_build_repo_data() {
 	issues_json=$(gh issue list --repo "$slug" --state open --limit 200 \
 		--json number,title,body,labels 2>/dev/null) || issues_json='[]'
 
-	# Single compact JSON accumulator threaded through the per-issue
-	# parser. Using one object keeps shell plumbing simple and guarantees
-	# that multi-line jq output can't corrupt the per-field state.
-	local acc='{"open_nums":[],"task_to_issue":{},"blocked_by_map":{},"defer_flags_map":{}}'
+	# Single jq pass: extract all fields, apply regex, build accumulator.
+	# Equivalent to calling _dep_graph_process_issue_json once per issue
+	# but without spawning a subshell for each issue.
+	printf '%s' "$issues_json" | jq -c '
+		reduce .[] as $issue (
+			{"open_nums":[],"task_to_issue":{},"blocked_by_map":{},"defer_flags_map":{}};
+			($issue.number) as $num |
+			($issue.title // "") as $title |
+			($issue.body // "") as $body |
 
-	local issue_json
-	while IFS= read -r issue_json; do
-		[[ -n "$issue_json" ]] || continue
-		acc=$(_dep_graph_process_issue_json "$issue_json" "$acc")
-	done < <(printf '%s' "$issues_json" | jq -c '.[]' 2>/dev/null)
+			# Extract task ID from title (e.g. "t1935: ..." -> "1935")
+			(if ($title | test("^t[0-9]+:"))
+			 then ($title | capture("^t(?<id>[0-9]+):").id)
+			 else ""
+			 end) as $tid |
 
-	# Project the internal accumulator shape onto the stable cache schema.
-	printf '%s' "$acc" | jq -c '{
-		"open_issues": .open_nums,
-		"task_to_issue": .task_to_issue,
-		"blocked_by": .blocked_by_map,
-		"defer_flags": .defer_flags_map
-	}' 2>/dev/null || printf '{"open_issues":[],"task_to_issue":{},"blocked_by":{},"defer_flags":{}}\n'
+			# Extract all lines matching the blocked-by pattern (case-insensitive)
+			([$body | split("\n") | .[] | select(test("(?i)blocked[- ]by"))] | join(" ")) as $blocker_text |
+
+			# Extract tNNN task IDs from blocked-by text (capture group -> number only)
+			([$blocker_text | scan("t([0-9]+)") | .[0]] | unique) as $blocker_tids |
+
+			# Extract #NNN issue numbers from blocked-by text (capture group -> number only)
+			([$blocker_text | scan("#([0-9]+)") | .[0]] | unique) as $blocker_nums |
+
+			# Defer/hold marker detection (mirrors _body_has_defer_marker shell patterns)
+			($body | test("(?i)defer until|do[- ]not[- ]dispatch|on[- ]hold|HUMAN_UNBLOCK_REQUIRED|hold for |paused[[:space:]:]")) as $has_defer |
+
+			(($blocker_tids | length) > 0 or ($blocker_nums | length) > 0) as $has_blockers |
+
+			.open_nums += [$num]
+			| (if $tid != "" then .task_to_issue[$tid] = $num else . end)
+			| (if $has_blockers
+			   then .blocked_by_map[($num | tostring)] = {
+			       "task_ids": $blocker_tids,
+			       "issue_nums": $blocker_nums,
+			       "has_defer_marker": $has_defer
+			   }
+			   else . end)
+			| (if $has_defer then .defer_flags_map[($num | tostring)] = true else . end)
+		)
+		| {
+			"open_issues": .open_nums,
+			"task_to_issue": .task_to_issue,
+			"blocked_by": .blocked_by_map,
+			"defer_flags": .defer_flags_map
+		}
+	' 2>/dev/null || printf '{"open_issues":[],"task_to_issue":{},"blocked_by":{},"defer_flags":{}}\n'
 }
 
 #######################################

--- a/.agents/scripts/pulse-fast-fail.sh
+++ b/.agents/scripts/pulse-fast-fail.sh
@@ -144,10 +144,23 @@ _ff_with_lock() {
 			echo "[pulse-wrapper] _ff_with_lock: lock acquisition timed out" >>"$LOGFILE"
 			return 1
 		fi
+		# Stale lock detection: read the owner PID stored in the lock directory.
+		# If that process is no longer running, the lock is orphaned — clear it.
+		local _ff_owner_pid
+		_ff_owner_pid=$(cat "${lock_dir}/owner.pid" 2>/dev/null || true)
+		if [[ -n "$_ff_owner_pid" ]] && ! kill -0 "$_ff_owner_pid" 2>/dev/null; then
+			echo "[pulse-wrapper] _ff_with_lock: clearing stale lock (owner PID ${_ff_owner_pid} gone)" >>"$LOGFILE"
+			rm -f "${lock_dir}/owner.pid" 2>/dev/null || true
+			rmdir "$lock_dir" 2>/dev/null || true
+			continue
+		fi
 		sleep 0.1
 	done
+	# Record owner PID inside lock directory so retrying callers can detect staleness.
+	printf '%s\n' "$$" >"${lock_dir}/owner.pid" 2>/dev/null || true
 	local rc=0
 	"$@" || rc=$?
+	rm -f "${lock_dir}/owner.pid" 2>/dev/null || true
 	rmdir "$lock_dir" 2>/dev/null || true
 	return "$rc"
 }

--- a/.agents/scripts/pulse-nmr-approval.sh
+++ b/.agents/scripts/pulse-nmr-approval.sh
@@ -72,11 +72,24 @@ _ever_nmr_cache_with_lock() {
 			echo "[pulse-wrapper] _ever_nmr_cache_with_lock: lock acquisition timed out" >>"$LOGFILE"
 			return 1
 		fi
+		# Stale lock detection: read the owner PID stored in the lock directory.
+		# If that process is no longer running, the lock is orphaned — clear it.
+		local _nmr_owner_pid
+		_nmr_owner_pid=$(cat "${lock_dir}/owner.pid" 2>/dev/null || true)
+		if [[ -n "$_nmr_owner_pid" ]] && ! kill -0 "$_nmr_owner_pid" 2>/dev/null; then
+			echo "[pulse-wrapper] _ever_nmr_cache_with_lock: clearing stale lock (owner PID ${_nmr_owner_pid} gone)" >>"$LOGFILE"
+			rm -f "${lock_dir}/owner.pid" 2>/dev/null || true
+			rmdir "$lock_dir" 2>/dev/null || true
+			continue
+		fi
 		sleep 0.1
 	done
 
+	# Record owner PID inside lock directory so retrying callers can detect staleness.
+	printf '%s\n' "$$" >"${lock_dir}/owner.pid" 2>/dev/null || true
 	local rc=0
 	"$@" || rc=$?
+	rm -f "${lock_dir}/owner.pid" 2>/dev/null || true
 	rmdir "$lock_dir" 2>/dev/null || true
 	return "$rc"
 }

--- a/.agents/scripts/pulse-queue-governor.sh
+++ b/.agents/scripts/pulse-queue-governor.sh
@@ -364,23 +364,47 @@ _compute_queue_governor_guidance() {
 	[[ "$ready_prs" =~ ^[0-9]+$ ]] || ready_prs=0
 	[[ "$failing_prs" =~ ^[0-9]+$ ]] || failing_prs=0
 
-	# Load previous cycle metrics
+	# Load previous cycle metrics — use while+printf -v instead of eval (security).
 	local prev_total_prs prev_total_issues prev_ready_prs prev_failing_prs prev_recorded_at
-	eval "$(_load_queue_metrics_history)"
+	local _qg_key _qg_val
+	while IFS='=' read -r _qg_key _qg_val; do
+		[[ -n "$_qg_key" ]] || continue
+		case "$_qg_key" in
+		prev_total_prs | prev_total_issues | prev_ready_prs | prev_failing_prs | prev_recorded_at)
+			printf -v "$_qg_key" '%s' "$_qg_val"
+			;;
+		esac
+	done < <(_load_queue_metrics_history)
 
-	# Compute deltas and drain metrics
+	# Compute deltas and drain metrics — use while+printf -v instead of eval (security).
 	local pr_delta issue_delta ready_delta failing_delta
 	local backlog_drain_per_cycle backlog_growth_pressure drain_rate_per_hour
 	local elapsed_seconds now_epoch
-	eval "$(_compute_queue_deltas \
+	while IFS='=' read -r _qg_key _qg_val; do
+		[[ -n "$_qg_key" ]] || continue
+		case "$_qg_key" in
+		pr_delta | issue_delta | ready_delta | failing_delta | \
+			backlog_drain_per_cycle | backlog_growth_pressure | drain_rate_per_hour | \
+			elapsed_seconds | now_epoch)
+			printf -v "$_qg_key" '%s' "$_qg_val"
+			;;
+		esac
+	done < <(_compute_queue_deltas \
 		"$total_prs" "$total_issues" "$ready_prs" "$failing_prs" \
 		"$prev_total_prs" "$prev_total_issues" "$prev_ready_prs" "$prev_failing_prs" \
-		"$prev_recorded_at")"
+		"$prev_recorded_at")
 
-	# Determine queue mode and focus percentages
+	# Determine queue mode and focus percentages — use while+printf -v instead of eval (security).
 	local queue_mode backlog_band pr_focus_pct new_issue_pct
-	eval "$(_compute_queue_mode \
-		"$total_prs" "$total_issues" "$ready_prs" "$failing_prs" "$pr_delta")"
+	while IFS='=' read -r _qg_key _qg_val; do
+		[[ -n "$_qg_key" ]] || continue
+		case "$_qg_key" in
+		queue_mode | backlog_band | pr_focus_pct | new_issue_pct)
+			printf -v "$_qg_key" '%s' "$_qg_val"
+			;;
+		esac
+	done < <(_compute_queue_mode \
+		"$total_prs" "$total_issues" "$ready_prs" "$failing_prs" "$pr_delta")
 
 	# Get worker utilization
 	local active_workers max_workers utilization_pct


### PR DESCRIPTION
## Summary

Addresses the four unacted gemini-code-assist review findings from PR #18368 that were merged without fixes.

Resolves #18593

## Changes

### High severity

**`pulse-fast-fail.sh` — stale lock detection in `_ff_with_lock`**

The `mkdir` spin-lock had no recovery path for orphaned lock directories left by crashed processes. A SIGKILL during lock ownership would permanently block all fast-fail state updates until manual removal.

Fix: on each retry, read `${lock_dir}/owner.pid` and check if that PID is still running (`kill -0`). If the process is gone, log and clear the stale lock via `rm -f` + `rmdir`, then retry `mkdir`. The owner PID is written into the lock directory immediately after successful `mkdir` acquisition and removed before `rmdir` on clean exit.

**`pulse-nmr-approval.sh` — same stale lock detection in `_ever_nmr_cache_with_lock`**

Identical fix applied to the NMR approval cache lock. An orphaned lock would block all cache updates for NMR provenance tracking.

### Medium severity

**`pulse-queue-governor.sh` — replace `eval` with `while read` + `printf -v`**

Three `eval "$(...)"` calls were used to bulk-assign key=value output from `_load_queue_metrics_history`, `_compute_queue_deltas`, and `_compute_queue_mode`. `eval` on function output is a code-injection risk if the metrics file is ever tampered with.

Fix: replace each `eval` with a `while IFS='=' read -r key val; do ... case; printf -v "$key" '%s' "$val"; done` loop. Only whitelisted variable names are assigned via `printf -v`. This is the pattern recommended in the Gemini review suggestion.

**`pulse-dep-graph.sh` — consolidate per-issue jq/grep forks**

`_dep_graph_build_repo_data` ran a `while` loop calling `_dep_graph_process_issue_json` per issue. Each call spawned ~13 subshells (multiple `jq -r`, `grep`, `jq -Rsc`, `jq -c`). For 200 issues this is ~2600 process forks.

Fix: replace the loop with a single `jq reduce` call that processes the entire issues array in one pass — task ID extraction from title, blocked-by line detection, task/issue ID extraction, and defer marker detection. Reduces O(n×13) subshell forks to O(1) per repo.

`_dep_graph_process_issue_json` is retained as a reference implementation for unit testing.

## Verification

- All 4 modified files pass `shellcheck` with zero violations.
- All 26 characterization tests pass (`test-pulse-wrapper-characterization.sh`).
- All 4 NMR cache tests pass (`test-pulse-wrapper-ever-nmr-cache.sh`).
- jq program logic verified with `jq -n` test data covering: task ID extraction, blocker line parsing, multi-line bodies, defer marker detection.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.6 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 10m and 35,192 tokens on this as a headless worker.