### PR TITLE
GH#18615: perf(privacy-guard): use grep -F -f for O(lines) slug matching

### DIFF
--- a/.agents/scripts/privacy-guard-helper.sh
+++ b/.agents/scripts/privacy-guard-helper.sh
@@ -304,7 +304,8 @@ privacy_scan_diff() {
 	fi
 
 	# Walk the diff, tracking current file and hunk line counter. Match added
-	# lines (those starting with "+" but not "+++") against each slug.
+	# lines (those starting with "+" but not "+++") against private slugs using
+	# grep -F -f for O(lines) matching instead of O(lines × slugs).
 	local hits=0
 	local current_file=""
 	local line_num=0
@@ -326,16 +327,19 @@ privacy_scan_diff() {
 			# Skip the "+++ b/..." which we already handled
 			[[ "$line" == "+++ "* ]] && continue
 			local added="${line:1}"
-			local slug
-			while IFS= read -r slug; do
-				[[ -z "$slug" ]] && continue
-				# Match as a literal substring. Slugs look like owner/repo and
-				# contain no regex metacharacters by convention.
-				if [[ "$added" == *"$slug"* ]]; then
+			local matching_slugs slug
+			# grep -F -f matches all slugs at once (fixed strings, no regex).
+			# -o outputs only the matched text, one match per line.
+			# grep exits 1 on no match; || true prevents aborting if the caller
+			# has set -e.
+			matching_slugs=$(printf '%s\n' "$added" | grep -F -o -f "$slugs_file" 2>/dev/null || true)
+			if [[ -n "$matching_slugs" ]]; then
+				while IFS= read -r slug; do
+					[[ -z "$slug" ]] && continue
 					printf '%s:%s: %s\n' "$current_file" "$line_num" "$slug"
 					hits=$((hits + 1))
-				fi
-			done <"$slugs_file"
+				done <<<"$matching_slugs"
+			fi
 			line_num=$((line_num + 1))
 			;;
 		" "*)


### PR DESCRIPTION
## Summary

- Replaces the O(lines × slugs) nested loop in `privacy_scan_diff` (`privacy-guard-helper.sh:327-338`) with a single `grep -F -f` call, matching all private slugs against each added diff line at once.
- `grep -F`: fixed-string matching — no regex overhead, no metacharacter escaping needed for `owner/repo` slugs.
- `grep -o`: outputs only the matched text, one slug per line — preserves the existing `file:line: slug` output format.
- `|| true`: guards against caller `set -e` when grep exits 1 on no matches.

## Why

Addresses the medium-priority review bot suggestion from PR #18361 (gemini-code-assist): the prior nested loop iterated over the slugs file for every `+`-prefixed line in the diff, giving O(diff_lines × num_slugs) comparisons. With `grep -F -f`, each diff line is scanned once regardless of slug count.

## Verification

All 17 existing unit + integration tests pass:

```
Running privacy-guard tests
  PASS enumerate picks up mirror_upstream and local_only entries
  PASS enumerate excludes non-private testorg/public-repo slug
  PASS enumerate includes entries from privacy-guard-extra-slugs.txt
  PASS diff with private slug in TODO.md is flagged
  PASS sanitised TODO.md diff is not flagged
  PASS src/ diff outside scan globs is not flagged
  PASS is_target_public: cached public (SSH URL) returns 0
  PASS is_target_public: cached public (HTTPS URL no .git) returns 0
  PASS is_target_public: cached private returns exit 1
  PASS is_target_public: non-github URL returns 2 (fail-open)
  PASS is_target_public: unparseable URL returns 2 (fail-open)
  PASS is_target_public: stale cache entry is refreshed via fresh probe
  PASS hook dispatch: public target + clean diff → exit 0
  PASS hook dispatch: public target + leak diff → exit 1 (blocked)
  PASS hook dispatch: private target + leak diff → exit 0 (fast path)
  PASS hook dispatch: PRIVACY_GUARD_DISABLE=1 bypasses scan → exit 0
  PASS hook dispatch: branch deletion (zeros local SHA) → exit 0

All 17 test(s) passed
```

ShellCheck: clean (zero violations).

Resolves #18615

---
<!-- aidevops:sig -->