### PR TITLE
GH#18616: add refresh-description to routine-log-helper.sh; make description refresh truthful in init-routines

### DIFF
--- a/.agents/scripts/init-routines-helper.sh
+++ b/.agents/scripts/init-routines-helper.sh
@@ -773,10 +773,15 @@ _create_core_routine_issues() {
 			gh issue edit "$issue_num" --repo "$slug" --add-label "routine-tracking" 2>/dev/null || true
 			# Store description in state so _build_issue_body includes it
 			_store_routine_description "$rid" "$short_title" "$human_schedule" "$script" "$rtype"
-			# Only fire the initial body-rebuild on fresh init — otherwise we
-			# append a fake success/duration=0 entry to every core routine on
-			# every invocation, polluting streak and avg_duration metrics (t1964).
-			if [[ "$preexisting_state" != true ]]; then
+			if [[ "$preexisting_state" == true ]]; then
+				# Refresh the issue body with the updated description text without
+				# recording a new run entry — prevents metric pollution (t1964)
+				# while making the "refreshing description only" log truthful
+				# (GH#18616). Streak and avg_duration are preserved.
+				bash "$log_helper" refresh-description "$rid" 2>/dev/null || true
+			else
+				# Fresh init: record a synthetic first entry so the metrics table
+				# is populated before the routine's first real run.
 				bash "$log_helper" update "$rid" --status success --duration 0 2>/dev/null || true
 			fi
 		fi

--- a/.agents/scripts/routine-log-helper.sh
+++ b/.agents/scripts/routine-log-helper.sh
@@ -665,6 +665,90 @@ cmd_update() {
 }
 
 # =============================================================================
+# Subcommand: refresh-description
+# =============================================================================
+
+# Rebuild and push the GitHub issue body for an existing routine using the
+# current state and stored description data, without recording a new run entry.
+# Use this when routine description or management text has been updated and
+# the GitHub issue body should reflect the changes (GH#18616).
+# Args: <routine-id>
+cmd_refresh_description() {
+	local routine_id=""
+
+	if [[ $# -lt 1 ]]; then
+		_log_error "Usage: routine-log-helper.sh refresh-description <routine-id>"
+		return 1
+	fi
+	routine_id="$1"
+
+	_check_prerequisites || return 1
+	_ensure_state_dir "$routine_id"
+
+	# Load and validate state — must have a tracking issue already
+	local state
+	state=$(_load_routine_state "$routine_id") || return 1
+
+	local issue_number
+	issue_number=$(echo "$state" | jq -r '.issue_number // empty')
+	local repo_slug
+	repo_slug=$(echo "$state" | jq -r '.repo_slug // empty')
+	local title
+	title=$(echo "$state" | jq -r '.title // "Untitled Routine"')
+	local schedule
+	schedule=$(echo "$state" | jq -r '.schedule // "unknown"')
+	local routine_type
+	routine_type=$(echo "$state" | jq -r '.routine_type // "unknown"')
+	local status_label
+	status_label=$(echo "$state" | jq -r '.status_label // "active"')
+	local last_run
+	last_run=$(echo "$state" | jq -r '.last_run // "never"')
+	local last_status
+	last_status=$(echo "$state" | jq -r '.last_status // "none"')
+	local last_duration
+	last_duration=$(echo "$state" | jq -r '.last_duration // 0')
+	local next_run
+	next_run=$(echo "$state" | jq -r '.next_run // "pending first run"')
+	local streak_count
+	streak_count=$(echo "$state" | jq -r '.streak_count // 0')
+	local streak_type
+	streak_type=$(echo "$state" | jq -r '.streak_type // ""')
+	local total_cost
+	total_cost=$(echo "$state" | jq -r '.total_cost // "0.00"')
+
+	# Compute period summary from existing log — no new entry added
+	local period_summary
+	period_summary=$(_compute_period_summary "$routine_id")
+
+	# Build issue body using current state; no metrics are modified
+	local new_body
+	new_body=$(_build_issue_body \
+		"$routine_id" \
+		"$title" \
+		"$schedule" \
+		"$routine_type" \
+		"$status_label" \
+		"$last_run" \
+		"$last_status" \
+		"$last_duration" \
+		"$next_run" \
+		"$streak_count" \
+		"$streak_type" \
+		"$total_cost" \
+		"$period_summary")
+
+	# Push updated body to GitHub
+	if gh issue edit "$issue_number" --repo "$repo_slug" --body "$new_body" &>/dev/null; then
+		_log_success "Refreshed description for issue #${issue_number} (${routine_id}) — no run entry recorded"
+	else
+		_log_error "Failed to refresh issue #${issue_number} for ${routine_id}"
+		return 1
+	fi
+
+	return 0
+}
+
+# =============================================================================
 # Subcommand: notable
 # =============================================================================
 
@@ -992,6 +1076,12 @@ Usage:
     Create the initial tracking issue with template description.
     Returns the issue number. Stores mapping in routine-state.json.
 
+  routine-log-helper.sh refresh-description <routine-id>
+    Rebuild and push the GitHub issue body using current state and stored
+    description data. Does NOT record a new run entry or modify metrics.
+    Use after init-routines-helper.sh refreshes a description for an
+    existing routine.
+
   routine-log-helper.sh status
     Print summary table of all tracked routines.
 
@@ -1051,6 +1141,9 @@ main() {
 		;;
 	notable)
 		cmd_notable "$@"
+		;;
+	refresh-description)
+		cmd_refresh_description "$@"
 		;;
 	create-issue)
 		cmd_create_issue "$@"


### PR DESCRIPTION
## Summary

- Adds `routine-log-helper.sh refresh-description <routine-id>` — a new subcommand that rebuilds and pushes the GitHub issue body from the current state and stored description data **without** appending a run log entry or modifying any metrics (streak, avg_duration, total_cost, last_run, etc.).
- Updates `init-routines-helper.sh _create_core_routine_issues` to call `refresh-description` on preexisting routines instead of silently doing nothing, making the "refreshing description only" log message accurate.

## Why

PR #18360 (t1964) added a `preexisting_state` guard to prevent metric pollution on re-runs of `init-routines-helper.sh`. However, as Gemini noted in the review, the guard also suppressed the only mechanism that synced GitHub issue bodies — the `update` call. After t1964, the log message said "refreshing description only" but the description was never actually updated. This is the fix.

The new `refresh-description` subcommand is the clean separation the review recommended: it rebuilds the GitHub issue body from the current state file (which was just updated by `_store_routine_description`) without touching any run metrics. Existing state is read-only during this operation.

## Verification

- `shellcheck .agents/scripts/routine-log-helper.sh` — clean (SC1091 info is pre-existing)
- `shellcheck .agents/scripts/init-routines-helper.sh` — clean
- `routine-log-helper.sh refresh-description` without args prints usage and exits 1
- `routine-log-helper.sh help` now documents the new subcommand
- On re-run of `init-routines-helper.sh` with existing state files: streak/avg_duration unchanged, GitHub issue body updated with latest description text

Resolves #18616