### PR TITLE
GH#18617: GH#18617: simplify _has_active_claim() jq filter using any()

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -954,14 +954,7 @@ _has_active_claim() {
 	local issue_meta_json="$1"
 	local result
 	result=$(printf '%s' "$issue_meta_json" | jq -r '
-		[(.labels // [])[].name] as $labels |
-		(
-			($labels | index("status:queued") != null) or
-			($labels | index("status:in-progress") != null) or
-			($labels | index("status:in-review") != null) or
-			($labels | index("status:claimed") != null) or
-			($labels | index("origin:interactive") != null)
-		)
+		.labels? // [] | any(.[].name; . == "status:queued" or . == "status:in-progress" or . == "status:in-review" or . == "status:claimed" or . == "origin:interactive")
 	' 2>/dev/null) || result="false"
 	[[ "$result" == "true" || "$result" == "false" ]] || result="false"
 	printf '%s' "$result"


### PR DESCRIPTION
## Summary

Simplified the jq filter in _has_active_claim() from a 9-line intermediate-array pattern using multiple index() lookups to a single any(.[].name; ...) filter. Behaviorally identical — verified against 9 edge cases. Reduces 8 deletions, 1 insertion. Note: the Gemini bot suggested any(.name; ...) which was syntactically incorrect; the correct form with an array input is any(.[].name; ...).

## Files Changed

.agents/scripts/dispatch-dedup-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified against 9 edge cases: all 5 matching label names produce 'true'; non-matching label, empty array, null labels, and missing .labels field all produce 'false'. shellcheck passes with zero violations.

Resolves #18617


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.6 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 3m and 6,248 tokens on this as a headless worker.