### PR TITLE
GH#18619: fix: align claude-opus-4-6 maxTokens to 64000 in claude-proxy.mjs

### DIFF
--- a/.agents/plugins/opencode-aidevops/claude-proxy.mjs
+++ b/.agents/plugins/opencode-aidevops/claude-proxy.mjs
@@ -320,7 +320,7 @@ function getClaudeProxyModels() {
       name: "Claude Opus 4.6 (via Claude CLI)",
       reasoning: true,
       contextWindow: 1000000,
-      maxTokens: 32000,
+      maxTokens: 64000,
     },
   ];
 }


### PR DESCRIPTION
## Summary

Fixes an inconsistency flagged by Gemini code review on PR #18351: `maxTokens` for `claude-opus-4-6` was `32000` in `getClaudeProxyModels()` in `claude-proxy.mjs`, while `config-hook.mjs` defines `output: 64000` for the same model in both `ANTHROPIC_MODELS` and `CLAUDECLI_MODELS`.

## Change

**File:** `.agents/plugins/opencode-aidevops/claude-proxy.mjs:323`

```diff
-      maxTokens: 32000,
+      maxTokens: 64000,
```

## Verification

- `claude-opus-4-6` maxTokens in claude-proxy.mjs: `64000` ✓
- Matches `output: 64000` in config-hook.mjs ANTHROPIC_MODELS ✓
- Matches `output: 64000` in config-hook.mjs CLAUDECLI_MODELS ✓
- Haiku `maxTokens: 32000` unchanged (intentional — Haiku has lower output limit) ✓
- Sonnet `maxTokens: 64000` unchanged ✓

Resolves #18619