### PR TITLE
GH#18641: fix(dispatch-dedup) require closing keyword in Check 3 body match

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -1249,8 +1249,19 @@ has_open_pr() {
 	# GH#18041 (t1957): When a merged PR matches by task ID, verify it actually
 	# targets the same issue. A task ID collision (counter reset, fabricated ID)
 	# produces a merged PR for a *different* issue — blocking dispatch forever.
-	# Fix: fetch the merged PR body and check if it references our issue_number.
-	# If it references a different issue, it's a collision — warn but don't block.
+	#
+	# GH#18641 (planning-only awareness): The framework convention uses
+	# `For #NNN` / `Ref #NNN` in planning-only PR bodies (briefs, TODO entries,
+	# research docs) so the brief PR does NOT auto-close the real implementation
+	# issue. The previous bare `#NNN` body-reference check treated those as
+	# dispatch blockers, creating a deadlock: every brief PR permanently
+	# blocked dispatch on its own follow-up implementation issue.
+	#
+	# New semantic: a merged PR whose title matches the task ID blocks
+	# dispatch ONLY if the body contains a closing-keyword reference to the
+	# specific issue number (the same pattern used by Check 2 and by GitHub's
+	# own auto-close logic). Planning references (`For #`, `Ref #`) and
+	# unrelated-issue collisions both fall through to "allow dispatch".
 	local task_id
 	task_id=$(printf '%s' "$issue_title" | grep -oE 't[0-9]+(\.[0-9]+)*' | head -1 || true)
 	if [[ -z "$task_id" ]]; then
@@ -1264,23 +1275,29 @@ has_open_pr() {
 	if [[ "$pr_count" -gt 0 ]]; then
 		pr_number=$(printf '%s' "$pr_json" | jq -r '.[0].number // empty' 2>/dev/null)
 		if [[ -n "$pr_number" ]]; then
-			# Verify the merged PR actually targets our issue, not a different
-			# one that happened to reuse the same task ID (collision detection).
+			# Fetch the merged PR body and verify it contains a closing-keyword
+			# reference to OUR specific issue number. This mirrors the pattern
+			# in Check 2 (line 1236) and is the single source of truth for
+			# "this PR closed this issue": if GitHub would auto-close it, we
+			# block; otherwise we allow dispatch.
 			local merged_pr_body
 			merged_pr_body=$(gh pr view "$pr_number" --repo "$repo_slug" --json body --jq '.body' 2>/dev/null) || merged_pr_body=""
-			local merged_pr_title
-			merged_pr_title=$(gh pr view "$pr_number" --repo "$repo_slug" --json title --jq '.title' 2>/dev/null) || merged_pr_title=""
 
-			# Check if the merged PR references our specific issue number
-			local our_issue_pattern="#${issue_number}([^[:alnum:]_]|$)"
-			if printf '%s\n%s' "$merged_pr_title" "$merged_pr_body" | grep -qE "$our_issue_pattern"; then
+			# Match: closing keyword + optional whitespace + #NNN or owner/repo#NNN
+			# followed by a non-word char or end-of-string. Identical to the
+			# Check 2 pattern so the two code paths agree on "closed".
+			local close_pattern_check3="(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#${issue_number}([^[:alnum:]_]|$)"
+			if printf '%s' "$merged_pr_body" | grep -iqE "$close_pattern_check3"; then
 				printf 'merged PR #%s found by task id %s in title\n' "$pr_number" "$task_id"
 				return 0
 			fi
 
-			# The merged PR has the same task ID but targets a different issue.
-			# This is a task ID collision — warn on stderr but don't block dispatch.
-			printf 'COLLISION: merged PR #%s has task id %s but targets a different issue (not #%s) — allowing dispatch\n' \
+			# The merged PR has the same task ID but does NOT close issue
+			# #${issue_number} via a closing keyword. Two valid cases fall
+			# through here: (a) task-ID collision (different issue), and
+			# (b) planning-only brief (For #NNN / Ref #NNN body reference).
+			# Both cases allow dispatch — the real implementation is not done.
+			printf 'NO_CLOSE_REF: merged PR #%s has task id %s but does not close issue #%s via closing keyword — allowing dispatch\n' \
 				"$pr_number" "$task_id" "$issue_number" >&2
 			return 1
 		else

--- a/.agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh
@@ -16,6 +16,7 @@ TESTS_FAILED=0
 
 TEST_ROOT=""
 GH_FIXTURE_FILE=""
+GH_PR_VIEW_FIXTURE_FILE=""
 
 print_result() {
 	local test_name="$1"
@@ -39,15 +40,18 @@ print_result() {
 setup_test_env() {
 	TEST_ROOT=$(mktemp -d)
 	GH_FIXTURE_FILE="${TEST_ROOT}/gh-pr-list-fixtures.txt"
+	GH_PR_VIEW_FIXTURE_FILE="${TEST_ROOT}/gh-pr-view-fixtures.txt"
 
 	mkdir -p "${TEST_ROOT}/bin"
 	export PATH="${TEST_ROOT}/bin:${PATH}"
 	export GH_FIXTURE_FILE
+	export GH_PR_VIEW_FIXTURE_FILE
 
 	cat >"${TEST_ROOT}/bin/gh" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
+# gh pr list — returns fixture JSON for (repo, state, search) lookup.
 if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
 	local_repo=""
 	local_state=""
@@ -94,12 +98,66 @@ if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
 	exit 0
 fi
 
-printf 'unsupported gh invocation in test stub\n' >&2
+# gh pr view <number> --repo R --json body|title --jq '.body|.title'
+# Returns fixture body/title keyed by PR number + field name.
+# Fixture line format: "<pr_number>|<field>|<payload>".
+# <payload> is emitted verbatim to stdout (no jq processing — the helper
+# pipes to `--jq '.body'` but we've already pre-extracted the field value
+# server-side for test simplicity).
+if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
+	pr_num="${3:-}"
+	field=""
+	shift 3 2>/dev/null || true
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--json)
+			field="${2:-}"
+			shift 2
+			;;
+		--jq)
+			shift 2
+			;;
+		--repo)
+			shift 2
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+
+	if [[ -z "$pr_num" || -z "$field" ]]; then
+		exit 1
+	fi
+
+	if [[ -f "${GH_PR_VIEW_FIXTURE_FILE}" ]]; then
+		while IFS= read -r line; do
+			[[ -n "$line" ]] || continue
+			# Split on first two '|' delimiters so payload may contain '|'.
+			fixture_pr="${line%%|*}"
+			rest="${line#*|}"
+			fixture_field="${rest%%|*}"
+			fixture_payload="${rest#*|}"
+			if [[ "$fixture_pr" == "$pr_num" && "$fixture_field" == "$field" ]]; then
+				printf '%s\n' "$fixture_payload"
+				exit 0
+			fi
+		done <"${GH_PR_VIEW_FIXTURE_FILE}"
+	fi
+
+	# No fixture — return empty (helper falls back to empty string).
+	printf '\n'
+	exit 0
+fi
+
+printf 'unsupported gh invocation in test stub: %s\n' "$*" >&2
 exit 1
 EOF
 
 	chmod +x "${TEST_ROOT}/bin/gh"
 	printf '' >"${GH_FIXTURE_FILE}"
+	printf '' >"${GH_PR_VIEW_FIXTURE_FILE}"
 	return 0
 }
 
@@ -116,8 +174,18 @@ set_gh_fixtures() {
 	return 0
 }
 
+set_gh_pr_view_fixtures() {
+	local fixtures="$1"
+	printf '%s\n' "$fixtures" >"${GH_PR_VIEW_FIXTURE_FILE}"
+	return 0
+}
+
 test_has_open_pr_detects_closing_keyword() {
 	set_gh_fixtures 'marcusquinn/aidevops|merged|closes #4527 in:body|[{"number":1145}]'
+	# Check 2 (body search) requires the PR body to contain a real closing
+	# keyword for the target issue — the helper re-fetches the body and
+	# post-filters with a regex to avoid GitHub full-text false positives.
+	set_gh_pr_view_fixtures '1145|body|Closes #4527. Implements the fix.'
 
 	local output=""
 	if output=$("$HELPER_SCRIPT" has-open-pr 4527 marcusquinn/aidevops 't4527: prevent duplicate dispatch'); then
@@ -136,7 +204,11 @@ test_has_open_pr_detects_closing_keyword() {
 }
 
 test_has_open_pr_detects_task_id_fallback() {
+	# Check 3 (task-id title match) now requires the merged PR body to
+	# contain a closing-keyword reference to our specific issue number.
+	# Bare "#NNN" body references are no longer sufficient (GH#18641).
 	set_gh_fixtures 'marcusquinn/aidevops|merged|t063.1 in:title|[{"number":1059}]'
+	set_gh_pr_view_fixtures '1059|body|Closes #9999. The awardsapp duplicate-dispatch guard.'
 
 	local output=""
 	if output=$("$HELPER_SCRIPT" has-open-pr 9999 marcusquinn/aidevops 't063.1: fix awardsapp duplicate PR dispatch'); then
@@ -156,6 +228,7 @@ test_has_open_pr_detects_task_id_fallback() {
 
 test_has_open_pr_returns_nonzero_without_match() {
 	set_gh_fixtures ''
+	set_gh_pr_view_fixtures ''
 
 	if "$HELPER_SCRIPT" has-open-pr 7777 marcusquinn/aidevops 't7777: no merged pr yet'; then
 		print_result "has-open-pr returns nonzero when no evidence exists" 1 "Expected nonzero exit when no merged PR evidence exists"
@@ -166,6 +239,81 @@ test_has_open_pr_returns_nonzero_without_match() {
 	return 0
 }
 
+# GH#18641: planning-only PR bodies use `For #NNN` instead of `Closes #NNN`
+# so the brief PR does NOT auto-close the real implementation issue. Check 3
+# must NOT treat `For #NNN` as dispatch-blocking evidence, otherwise every
+# brief PR permanently blocks dispatch on its own follow-up issue.
+test_has_open_pr_ignores_planning_for_reference() {
+	set_gh_fixtures 'marcusquinn/aidevops|merged|t2047 in:title|[{"number":18627}]'
+	set_gh_pr_view_fixtures '18627|body|Files the brief for **t2047**. Pure planning, no code changes.
+
+For #18624
+For #18599'
+
+	if "$HELPER_SCRIPT" has-open-pr 18624 marcusquinn/aidevops 't2047: task-id collision guard'; then
+		print_result "has-open-pr ignores planning-only 'For #NNN' reference" 1 \
+			"Expected exit 1: brief PR with 'For #18624' must not block dispatch"
+		return 0
+	fi
+
+	print_result "has-open-pr ignores planning-only 'For #NNN' reference" 0
+	return 0
+}
+
+# GH#18641: same convention with `Ref #NNN` phrasing must also be ignored.
+test_has_open_pr_ignores_planning_ref_reference() {
+	set_gh_fixtures 'marcusquinn/aidevops|merged|t2038 in:title|[{"number":18524}]'
+	set_gh_pr_view_fixtures '18524|body|Research brief for t2038.
+
+Ref #18521
+Ref #18522'
+
+	if "$HELPER_SCRIPT" has-open-pr 18522 marcusquinn/aidevops 't2038: research branch protection bypass'; then
+		print_result "has-open-pr ignores planning-only 'Ref #NNN' reference" 1 \
+			"Expected exit 1: research brief with 'Ref #18522' must not block dispatch"
+		return 0
+	fi
+
+	print_result "has-open-pr ignores planning-only 'Ref #NNN' reference" 0
+	return 0
+}
+
+# GH#18641: a PR whose body contains BOTH a closing keyword for a different
+# issue AND a planning reference for ours must still NOT block dispatch on
+# ours — the closing keyword must match OUR issue number specifically.
+test_has_open_pr_requires_close_keyword_for_our_issue() {
+	set_gh_fixtures 'marcusquinn/aidevops|merged|t2037 in:title|[{"number":18524}]'
+	set_gh_pr_view_fixtures '18524|body|Files briefs.
+
+Closes #18521
+For #18522'
+
+	if "$HELPER_SCRIPT" has-open-pr 18522 marcusquinn/aidevops 't2037: inline gate refactor'; then
+		print_result "has-open-pr requires close keyword for OUR issue, not another" 1 \
+			"Expected exit 1: 'Closes #18521' closes a different issue; 'For #18522' is planning-only for ours"
+		return 0
+	fi
+
+	print_result "has-open-pr requires close keyword for OUR issue, not another" 0
+	return 0
+}
+
+# Existing collision case (GH#18041 / t1957) must still allow dispatch:
+# different task used the same ID, merged PR closes some unrelated issue.
+test_has_open_pr_allows_dispatch_on_task_id_collision() {
+	set_gh_fixtures 'marcusquinn/aidevops|merged|t500 in:title|[{"number":1200}]'
+	set_gh_pr_view_fixtures '1200|body|Closes #555. Unrelated work that reused task ID t500.'
+
+	if "$HELPER_SCRIPT" has-open-pr 9999 marcusquinn/aidevops 't500: different work for issue #9999'; then
+		print_result "has-open-pr allows dispatch on task-id collision" 1 \
+			"Expected exit 1: merged PR closes a different issue via task-id collision"
+		return 0
+	fi
+
+	print_result "has-open-pr allows dispatch on task-id collision" 0
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
@@ -173,6 +321,10 @@ main() {
 	test_has_open_pr_detects_closing_keyword
 	test_has_open_pr_detects_task_id_fallback
 	test_has_open_pr_returns_nonzero_without_match
+	test_has_open_pr_ignores_planning_for_reference
+	test_has_open_pr_ignores_planning_ref_reference
+	test_has_open_pr_requires_close_keyword_for_our_issue
+	test_has_open_pr_allows_dispatch_on_task_id_collision
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Aligns Check 3 with Check 2 and GitHub auto-close semantics. Planning-only PRs using For #NNN / Ref #NNN no longer block dispatch on their follow-up issues.

## Files Changed

.agents/scripts/dispatch-dedup-helper.sh,.agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** test-dispatch-dedup-helper-has-open-pr.sh: 7/7 pass (2 previously broken + 1 unchanged + 4 new planning/collision cases). test-dispatch-dedup-helper-is-assigned.sh: 16/16. test-dispatch-dedup-multi-operator.sh: 7/7. shellcheck clean on both edited files.

Resolves #18641


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.6 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 13m and 42,604 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dispatch deduplication logic to distinguish between planning references (e.g., "For #123") and actual closing references (e.g., "Closes #123") in merged pull requests, ensuring more accurate blocking behavior.

* **Tests**
  * Expanded test coverage for dispatch deduplication scenarios, including handling of planning-only references and cross-issue closing keywords.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->