### PR TITLE
GH#18644: fix(dispatch) force-dispatch override + portable timeout + label seed + test refactor

### DIFF
--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -677,6 +677,39 @@ _task_id_in_changed_files() {
 }
 
 #######################################
+# GH#18644: Detect the `force-dispatch` maintainer override label.
+#
+# Purpose: escape hatch for false-positive task-ID collisions in the
+# commit-subject dedup (_is_task_committed_to_main). When a commit
+# subject accidentally mentions a task ID that was never claimed via
+# claim-task-id.sh — e.g., `chore(build.txt): add rule (t2046)` for a
+# task that is actually GH#18508, not the canonical t2046 — the dedup
+# block fires permanently even though no implementation has happened.
+#
+# The `force-dispatch` label is a maintainer-only override that
+# bypasses this specific check. It does NOT bypass:
+#   - The cryptographic approval gate (ever-NMR) above it
+#   - Any Layer 1-7 claim/lock/assignee/open-PR machinery below it
+#   - Large-file gates, blocked-by dependencies, or supervisor title guards
+#
+# Workers MUST NOT apply this label themselves. It represents a
+# human decision that the dedup signal is wrong for this specific issue.
+#
+# Args:
+#   $1 - issue_meta_json (pre-fetched JSON with a .labels array)
+#
+# Exit codes:
+#   0 - force-dispatch label is present
+#   1 - force-dispatch label is absent (or meta_json is empty/invalid)
+#######################################
+_has_force_dispatch_label() {
+	local issue_meta_json="$1"
+	[[ -n "$issue_meta_json" ]] || return 1
+	printf '%s' "$issue_meta_json" |
+		jq -e '.labels | map(.name) | index("force-dispatch")' >/dev/null 2>&1
+}
+
+#######################################
 # GH#17574: Check if a task has already landed on main (via PR merge or direct commit).
 #
 # Workers that bypass the PR flow (direct commits to main) complete the
@@ -953,6 +986,17 @@ _issue_targets_large_files() {
 			# label application fails but the issue still creates server-side —
 			# see issue-sync-helper.sh:441-464 for the same pattern + GH#15234
 			# context).
+			#
+			# GH#18644: ensure the `simplification-debt` label exists before the
+			# create call. Without this, a first-use of the gate in any repo that
+			# doesn't already have the label fails with "could not add label:
+			# 'simplification-debt' not found" and the whole gate becomes a no-op
+			# for that repo forever. gh label create is idempotent with --force.
+			gh label create "simplification-debt" \
+				--repo "$repo_slug" \
+				--description "Target file needs simplification before implementation work can proceed" \
+				--color "D93F0B" \
+				--force 2>/dev/null || true
 			local _new_num _create_body _create_combined
 			_create_body="## What
 Simplify \`${_lf_path}\` — currently over ${LARGE_FILE_LINE_THRESHOLD} lines. Break into smaller, focused modules.
@@ -1081,6 +1125,16 @@ _dispatch_dedup_check_layers() {
 		known_ever_nmr="true"
 	fi
 
+	# GH#18644 (force-dispatch override): when the maintainer applies the
+	# `force-dispatch` label on an issue, the false-positive commit-subject
+	# dedup check (_is_task_committed_to_main) is bypassed. See helper
+	# _has_force_dispatch_label() below for semantics and constraints.
+	local force_dispatch="false"
+	if _has_force_dispatch_label "$issue_meta_json"; then
+		force_dispatch="true"
+		echo "[pulse-wrapper] dispatch_with_dedup: force-dispatch label active on #${issue_number} in ${repo_slug} — bypassing _is_task_committed_to_main (GH#18644)" >>"$LOGFILE"
+	fi
+
 	# t1894: Cryptographic approval gate — block dispatch for issues that were
 	# ever labeled needs-maintainer-review without a signed approval.
 	if ! issue_has_required_approval "$issue_number" "$repo_slug" "$known_ever_nmr"; then
@@ -1098,7 +1152,8 @@ _dispatch_dedup_check_layers() {
 	# work invisibly — the issue stays open until the pulse's mark-complete
 	# pass runs, which happens AFTER dispatch decisions. Without this check,
 	# the pulse dispatches redundant workers for already-completed work.
-	if _is_task_committed_to_main "$issue_number" "$repo_slug" "$target_title" "$repo_path"; then
+	# GH#18644: skipped entirely when force-dispatch label is set.
+	if [[ "$force_dispatch" == "false" ]] && _is_task_committed_to_main "$issue_number" "$repo_slug" "$target_title" "$repo_path"; then
 		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: task already committed to main (GH#17574)" >>"$LOGFILE"
 		# GH#17642: Do NOT auto-close the issue. The main-commit check has a
 		# high false-positive rate (casual mentions, multi-runner deployment

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -677,6 +677,67 @@ _task_id_in_changed_files() {
 }
 
 #######################################
+# GH#17574 + GH#18644: Combined commit-subject dedup gate with
+# force-dispatch maintainer override.
+#
+# Wraps the _is_task_committed_to_main call with an early bypass when
+# the issue carries the `force-dispatch` label. Extracted from
+# _dispatch_dedup_check_layers() to keep the parent function under the
+# 100-line complexity threshold while the logic-body grows.
+#
+# Args:
+#   $1 - issue_number
+#   $2 - repo_slug (owner/repo)
+#   $3 - target_title (issue title from meta_json)
+#   $4 - repo_path (local path to the repo)
+#   $5 - issue_meta_json (pre-fetched JSON with .labels array)
+#
+# Exit codes:
+#   0 - gate fires (block dispatch — task appears committed to main,
+#       force-dispatch is NOT set)
+#   1 - gate allows dispatch (task not committed, OR force-dispatch
+#       override is set)
+#######################################
+_check_commit_subject_dedup_gate() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local target_title="$3"
+	local repo_path="$4"
+	local issue_meta_json="$5"
+
+	# GH#18644: force-dispatch label bypasses the commit-subject dedup
+	# entirely. The override is for legacy task-ID collisions where a
+	# commit subject accidentally mentions a task ID that was never
+	# claimed via claim-task-id.sh. Maintainer-only — workers must not
+	# apply this label. Does NOT bypass ever-NMR, claim/lock layers,
+	# large-file gates, or blocked-by dependencies.
+	if _has_force_dispatch_label "$issue_meta_json"; then
+		echo "[pulse-wrapper] dispatch_with_dedup: force-dispatch label active on #${issue_number} in ${repo_slug} — bypassing _is_task_committed_to_main (GH#18644)" >>"$LOGFILE"
+		return 1
+	fi
+
+	# GH#17574: Skip dispatch if the task has already been committed
+	# directly to main. Workers that bypass the PR flow (direct commits)
+	# complete the work invisibly — the issue stays open until the
+	# pulse's mark-complete pass runs, which happens AFTER dispatch
+	# decisions for the next cycle. Without this check, the pulse
+	# dispatches redundant workers for already-completed work.
+	#
+	# GH#17642: Do NOT auto-close the issue on a block. The main-commit
+	# check has a high false-positive rate (casual mentions, multi-
+	# runner deployment gaps, stale patterns). A false skip is harmless
+	# (next cycle retries), a false close is destructive (needs manual
+	# reopen, re-dispatch, and loses worker context). Let the verified
+	# merge-pass or human close it.
+	if _is_task_committed_to_main "$issue_number" "$repo_slug" "$target_title" "$repo_path"; then
+		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: task already committed to main (GH#17574)" >>"$LOGFILE"
+		return 0
+	fi
+
+	return 1
+}
+
+#######################################
 # GH#18644: Detect the `force-dispatch` maintainer override label.
 #
 # Purpose: escape hatch for false-positive task-ID collisions in the
@@ -1125,16 +1186,6 @@ _dispatch_dedup_check_layers() {
 		known_ever_nmr="true"
 	fi
 
-	# GH#18644 (force-dispatch override): when the maintainer applies the
-	# `force-dispatch` label on an issue, the false-positive commit-subject
-	# dedup check (_is_task_committed_to_main) is bypassed. See helper
-	# _has_force_dispatch_label() below for semantics and constraints.
-	local force_dispatch="false"
-	if _has_force_dispatch_label "$issue_meta_json"; then
-		force_dispatch="true"
-		echo "[pulse-wrapper] dispatch_with_dedup: force-dispatch label active on #${issue_number} in ${repo_slug} — bypassing _is_task_committed_to_main (GH#18644)" >>"$LOGFILE"
-	fi
-
 	# t1894: Cryptographic approval gate — block dispatch for issues that were
 	# ever labeled needs-maintainer-review without a signed approval.
 	if ! issue_has_required_approval "$issue_number" "$repo_slug" "$known_ever_nmr"; then
@@ -1147,19 +1198,8 @@ _dispatch_dedup_check_layers() {
 		return 1
 	fi
 
-	# GH#17574: Skip dispatch if the task has already been committed directly
-	# to main. Workers that bypass the PR flow (direct commits) complete the
-	# work invisibly — the issue stays open until the pulse's mark-complete
-	# pass runs, which happens AFTER dispatch decisions. Without this check,
-	# the pulse dispatches redundant workers for already-completed work.
-	# GH#18644: skipped entirely when force-dispatch label is set.
-	if [[ "$force_dispatch" == "false" ]] && _is_task_committed_to_main "$issue_number" "$repo_slug" "$target_title" "$repo_path"; then
-		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: task already committed to main (GH#17574)" >>"$LOGFILE"
-		# GH#17642: Do NOT auto-close the issue. The main-commit check has a
-		# high false-positive rate (casual mentions, multi-runner deployment
-		# gaps, stale patterns). A false skip is harmless (next cycle retries),
-		# a false close is destructive (needs manual reopen, re-dispatch, and
-		# loses worker context). Let the verified merge-pass or human close it.
+	# GH#17574/GH#18644: commit-subject dedup gate with force-dispatch override.
+	if _check_commit_subject_dedup_gate "$issue_number" "$repo_slug" "$target_title" "$repo_path" "$issue_meta_json"; then
 		return 1
 	fi
 

--- a/.agents/scripts/pulse-simplification.sh
+++ b/.agents/scripts/pulse-simplification.sh
@@ -1373,9 +1373,14 @@ _complexity_scan_pull_latest() {
 	# with stale data (which would reintroduce the exact problem we're fixing).
 	# Do NOT update COMPLEXITY_SCAN_LAST_RUN on skip — the next cycle retries.
 	# GIT_TERMINAL_PROMPT=0 prevents credential prompts from hanging the pulse.
-	# timeout 30 prevents network hangs from blocking the pulse cycle.
+	# GH#18644: timeout_sec 30 prevents network hangs from blocking the pulse
+	# cycle. Previously used bare `timeout` which is Linux-only — on macOS it
+	# exits immediately with "command not found" and the pull runs without any
+	# timeout protection (or, if set -e is active, aborts the stage). The
+	# portable timeout_sec helper from shared-constants.sh tries `timeout`,
+	# `gtimeout`, and a bash-native PGID-kill fallback.
 	if git -C "$aidevops_path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-		if ! GIT_TERMINAL_PROMPT=0 timeout 30 \
+		if ! GIT_TERMINAL_PROMPT=0 timeout_sec 30 \
 			git -C "$aidevops_path" pull --ff-only --no-rebase >>"$LOGFILE" 2>&1 9>&-; then
 			echo "[pulse-wrapper] Complexity scan: git pull failed for ${aidevops_path} — skipping this cycle to avoid stale-state warnings" >>"$LOGFILE"
 			return 1

--- a/.agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh
@@ -37,17 +37,12 @@ print_result() {
 	return 0
 }
 
-setup_test_env() {
-	TEST_ROOT=$(mktemp -d)
-	GH_FIXTURE_FILE="${TEST_ROOT}/gh-pr-list-fixtures.txt"
-	GH_PR_VIEW_FIXTURE_FILE="${TEST_ROOT}/gh-pr-view-fixtures.txt"
-
-	mkdir -p "${TEST_ROOT}/bin"
-	export PATH="${TEST_ROOT}/bin:${PATH}"
-	export GH_FIXTURE_FILE
-	export GH_PR_VIEW_FIXTURE_FILE
-
-	cat >"${TEST_ROOT}/bin/gh" <<'EOF'
+# GH#18644: extracted from setup_test_env so the latter stays under the
+# 100-line function complexity gate. The stub handles `gh pr list` (by
+# repo/state/search key) and `gh pr view` (by PR number + json field).
+_write_gh_stub() {
+	local stub_path="$1"
+	cat >"$stub_path" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 
@@ -57,32 +52,18 @@ if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
 	local_state=""
 	local_search=""
 	shift 2
-
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
-		--repo)
-			local_repo="${2:-}"
-			shift 2
-			;;
-		--state)
-			local_state="${2:-}"
-			shift 2
-			;;
-		--search)
-			local_search="${2:-}"
-			shift 2
-			;;
-		*)
-			shift
-			;;
+		--repo) local_repo="${2:-}"; shift 2 ;;
+		--state) local_state="${2:-}"; shift 2 ;;
+		--search) local_search="${2:-}"; shift 2 ;;
+		*) shift ;;
 		esac
 	done
-
 	if [[ -z "$local_repo" || -z "$local_state" || -z "$local_search" ]]; then
 		printf '[]\n'
 		exit 0
 	fi
-
 	compound_key="${local_repo}|${local_state}|${local_search}"
 	while IFS= read -r line; do
 		[[ -n "$line" ]] || continue
@@ -93,48 +74,29 @@ if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
 			exit 0
 		fi
 	done <"${GH_FIXTURE_FILE}"
-
 	printf '[]\n'
 	exit 0
 fi
 
 # gh pr view <number> --repo R --json body|title --jq '.body|.title'
-# Returns fixture body/title keyed by PR number + field name.
-# Fixture line format: "<pr_number>|<field>|<payload>".
-# <payload> is emitted verbatim to stdout (no jq processing — the helper
-# pipes to `--jq '.body'` but we've already pre-extracted the field value
-# server-side for test simplicity).
+# Fixture line format: "<pr_number>|<field>|<payload>". Payload may
+# contain '|' — we split on the first two delimiters only.
 if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
 	pr_num="${3:-}"
 	field=""
 	shift 3 2>/dev/null || true
-
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
-		--json)
-			field="${2:-}"
-			shift 2
-			;;
-		--jq)
-			shift 2
-			;;
-		--repo)
-			shift 2
-			;;
-		*)
-			shift
-			;;
+		--json) field="${2:-}"; shift 2 ;;
+		--jq) shift 2 ;;
+		--repo) shift 2 ;;
+		*) shift ;;
 		esac
 	done
-
-	if [[ -z "$pr_num" || -z "$field" ]]; then
-		exit 1
-	fi
-
+	[[ -z "$pr_num" || -z "$field" ]] && exit 1
 	if [[ -f "${GH_PR_VIEW_FIXTURE_FILE}" ]]; then
 		while IFS= read -r line; do
 			[[ -n "$line" ]] || continue
-			# Split on first two '|' delimiters so payload may contain '|'.
 			fixture_pr="${line%%|*}"
 			rest="${line#*|}"
 			fixture_field="${rest%%|*}"
@@ -145,8 +107,6 @@ if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
 			fi
 		done <"${GH_PR_VIEW_FIXTURE_FILE}"
 	fi
-
-	# No fixture — return empty (helper falls back to empty string).
 	printf '\n'
 	exit 0
 fi
@@ -154,8 +114,22 @@ fi
 printf 'unsupported gh invocation in test stub: %s\n' "$*" >&2
 exit 1
 EOF
+	chmod +x "$stub_path"
+	return 0
+}
 
-	chmod +x "${TEST_ROOT}/bin/gh"
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+	GH_FIXTURE_FILE="${TEST_ROOT}/gh-pr-list-fixtures.txt"
+	GH_PR_VIEW_FIXTURE_FILE="${TEST_ROOT}/gh-pr-view-fixtures.txt"
+
+	mkdir -p "${TEST_ROOT}/bin"
+	export PATH="${TEST_ROOT}/bin:${PATH}"
+	export GH_FIXTURE_FILE
+	export GH_PR_VIEW_FIXTURE_FILE
+
+	_write_gh_stub "${TEST_ROOT}/bin/gh"
+
 	printf '' >"${GH_FIXTURE_FILE}"
 	printf '' >"${GH_PR_VIEW_FIXTURE_FILE}"
 	return 0

--- a/.agents/scripts/tests/test-pulse-dispatch-core-force-dispatch.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-core-force-dispatch.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Tests for _has_force_dispatch_label() (GH#18644).
+#
+# The force-dispatch label is a maintainer-only override that bypasses the
+# commit-subject false-positive dedup in _is_task_committed_to_main. These
+# tests exercise the label-detection helper in isolation — the full dispatch
+# gate integration is covered by the characterization tests.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+CORE_SCRIPT="${SCRIPT_DIR}/../pulse-dispatch-core.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+# Source only the helper we need. pulse-dispatch-core.sh sources many siblings
+# via a guarded `if [[ -z $SCRIPT_DIR ]]` block; those are not relevant for
+# unit-testing a pure jq/label helper. We define the function inline from the
+# source file to avoid pulling in the entire core module.
+define_helper_under_test() {
+	# Extract the _has_force_dispatch_label function from the core source
+	# and eval it so the test runs against the real code, not a duplicate.
+	local helper_src
+	helper_src=$(awk '
+		/^_has_force_dispatch_label\(\) \{/,/^}$/ { print }
+	' "$CORE_SCRIPT")
+	if [[ -z "$helper_src" ]]; then
+		printf 'ERROR: could not extract _has_force_dispatch_label from %s\n' "$CORE_SCRIPT" >&2
+		return 1
+	fi
+	# shellcheck disable=SC1090  # dynamic source from extracted helper
+	eval "$helper_src"
+	return 0
+}
+
+test_detects_force_dispatch_label() {
+	local meta='{"number":18599,"labels":[{"name":"bug"},{"name":"force-dispatch"},{"name":"auto-dispatch"}]}'
+	if _has_force_dispatch_label "$meta"; then
+		print_result "detects force-dispatch label among other labels" 0
+		return 0
+	fi
+	print_result "detects force-dispatch label among other labels" 1 \
+		"Expected exit 0 when force-dispatch is present"
+	return 0
+}
+
+test_label_absent_returns_nonzero() {
+	local meta='{"number":18599,"labels":[{"name":"bug"},{"name":"auto-dispatch"},{"name":"tier:standard"}]}'
+	if _has_force_dispatch_label "$meta"; then
+		print_result "absent label returns exit 1" 1 \
+			"Expected exit 1 when force-dispatch is absent"
+		return 0
+	fi
+	print_result "absent label returns exit 1" 0
+	return 0
+}
+
+test_empty_labels_array_returns_nonzero() {
+	local meta='{"number":18599,"labels":[]}'
+	if _has_force_dispatch_label "$meta"; then
+		print_result "empty labels array returns exit 1" 1 \
+			"Expected exit 1 for empty labels"
+		return 0
+	fi
+	print_result "empty labels array returns exit 1" 0
+	return 0
+}
+
+test_empty_meta_json_returns_nonzero() {
+	if _has_force_dispatch_label ""; then
+		print_result "empty meta_json returns exit 1" 1 \
+			"Expected exit 1 when meta is empty"
+		return 0
+	fi
+	print_result "empty meta_json returns exit 1" 0
+	return 0
+}
+
+test_invalid_meta_json_returns_nonzero() {
+	# Malformed JSON — jq will fail; helper must not crash or return 0.
+	local meta='not valid json'
+	if _has_force_dispatch_label "$meta"; then
+		print_result "invalid meta_json returns exit 1" 1 \
+			"Expected exit 1 on invalid JSON"
+		return 0
+	fi
+	print_result "invalid meta_json returns exit 1" 0
+	return 0
+}
+
+test_partial_label_name_does_not_match() {
+	# Substring match would be a bug — `force-dispatch-queued` is not the
+	# override label. jq's index() uses exact equality, so this should be
+	# correctly rejected.
+	local meta='{"number":18599,"labels":[{"name":"force-dispatch-queued"}]}'
+	if _has_force_dispatch_label "$meta"; then
+		print_result "partial label name does not match" 1 \
+			"Expected exit 1: 'force-dispatch-queued' must not trigger the override"
+		return 0
+	fi
+	print_result "partial label name does not match" 0
+	return 0
+}
+
+main() {
+	if ! define_helper_under_test; then
+		printf 'FATAL: helper extraction failed\n' >&2
+		return 1
+	fi
+
+	test_detects_force_dispatch_label
+	test_label_absent_returns_nonzero
+	test_empty_labels_array_returns_nonzero
+	test_empty_meta_json_returns_nonzero
+	test_invalid_meta_json_returns_nonzero
+	test_partial_label_name_does_not_match
+
+	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Four bundled dispatch-pipeline fixes: force-dispatch maintainer override label, portable timeout_sec for macOS complexity scan, simplification-debt label pre-seeding, and test complexity refactor to restore the 46-violation threshold from PR #18642's regression.

## Files Changed

.agents/scripts/pulse-dispatch-core.sh,.agents/scripts/pulse-simplification.sh,.agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh,.agents/scripts/tests/test-pulse-dispatch-core-force-dispatch.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** test-pulse-dispatch-core-force-dispatch.sh: 6/6 new. test-dispatch-dedup-helper-has-open-pr.sh: 7/7 (Fix 1 regression guard). test-dispatch-dedup-helper-is-assigned.sh: 16/16. test-dispatch-dedup-multi-operator.sh: 7/7. test-pulse-wrapper-main-commit-check.sh: 8/8. shellcheck clean on all four edited files (2 pre-existing SC2016 info warnings on lines I didn't touch). setup_test_env is 16 lines, _write_gh_stub is 77 lines — both under the 100-line threshold.

Resolves #18644


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.6 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 45m and 91,746 tokens on this with the user in an interactive session.