### PR TITLE
GH#18648: fix(dispatch) exempt bot-generated review-followup from ever-NMR permanence trap

### DIFF
--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -677,6 +677,62 @@ _task_id_in_changed_files() {
 }
 
 #######################################
+# t1894 + GH#18648: Cryptographic approval gate (ever-NMR) with
+# review-followup exemption for bot-generated cleanup issues.
+#
+# Extracted from _dispatch_dedup_check_layers() to keep the parent
+# function under the 100-line complexity threshold while the exemption
+# logic grew.
+#
+# Logic:
+#   1. Determine if the issue currently has `needs-maintainer-review`
+#      — set known_ever_nmr="true" for the cache-path short-circuit.
+#   2. If the issue is bot-generated cleanup (review-followup or
+#      source:review-scanner) AND the label is not currently present,
+#      override known_ever_nmr="false" to skip the historical timeline
+#      check. This clears the ever-NMR permanence trap for routine
+#      cleanup issues whose NMR label was applied by the fast-fail
+#      escalation path and has since been removed.
+#   3. Call issue_has_required_approval with the determined state.
+#
+# The exemption does NOT fire when the label is currently present —
+# maintainer-applied or bot-applied NMR still blocks dispatch until
+# the label is removed or cryptographic approval is posted.
+#
+# Args:
+#   $1 - issue_number
+#   $2 - repo_slug (owner/repo)
+#   $3 - issue_meta_json (pre-fetched JSON with .labels array)
+#
+# Exit codes:
+#   0 - gate blocks dispatch (ever-NMR without approval)
+#   1 - gate allows dispatch
+#######################################
+_check_nmr_approval_gate() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local issue_meta_json="$3"
+
+	local known_ever_nmr="unknown"
+	if printf '%s' "$issue_meta_json" | jq -e '.labels | map(.name) | index("needs-maintainer-review")' >/dev/null 2>&1; then
+		known_ever_nmr="true"
+	fi
+
+	# GH#18648: bot-generated cleanup exemption. See
+	# _is_bot_generated_cleanup_issue() doc for full rationale.
+	if [[ "$known_ever_nmr" != "true" ]] && _is_bot_generated_cleanup_issue "$issue_meta_json"; then
+		known_ever_nmr="false"
+		echo "[pulse-wrapper] dispatch_with_dedup: review-followup exemption for #${issue_number} in ${repo_slug} — skipping historical ever-NMR check (GH#18648)" >>"$LOGFILE"
+	fi
+
+	if ! issue_has_required_approval "$issue_number" "$repo_slug" "$known_ever_nmr"; then
+		echo "[pulse-wrapper] dispatch_with_dedup: BLOCKED #${issue_number} in ${repo_slug} — requires cryptographic approval (ever-NMR)" >>"$LOGFILE"
+		return 0
+	fi
+	return 1
+}
+
+#######################################
 # GH#17574 + GH#18644: Combined commit-subject dedup gate with
 # force-dispatch maintainer override.
 #
@@ -768,6 +824,39 @@ _has_force_dispatch_label() {
 	[[ -n "$issue_meta_json" ]] || return 1
 	printf '%s' "$issue_meta_json" |
 		jq -e '.labels | map(.name) | index("force-dispatch")' >/dev/null 2>&1
+}
+
+#######################################
+# GH#18648 (Fix 3a): Detect bot-generated cleanup issues.
+#
+# Bot-generated cleanup issues carry either `review-followup` (from
+# post-merge-review-scanner.sh) or `source:review-scanner` (the
+# provenance marker the scanner applies alongside it). Both labels
+# indicate: "this issue was auto-created from already-merged PR
+# review comments, no new maintainer decision is required".
+#
+# Callers use this to exempt the issue from the ever-NMR permanence
+# trap — historical NMR labels applied by automated escalation paths
+# (dispatch-dedup fast-fail circuit breaker) no longer drain the
+# dispatch queue once the label is manually removed.
+#
+# The exemption does NOT fire when the issue CURRENTLY has the
+# needs-maintainer-review label — a present label still requires
+# cryptographic approval, regardless of issue provenance. The fix
+# is surgical to the historical-timeline false-positive case.
+#
+# Args:
+#   $1 - issue_meta_json (pre-fetched JSON with .labels array)
+#
+# Exit codes:
+#   0 - issue is bot-generated cleanup
+#   1 - issue is not bot-generated (or meta_json is empty/invalid)
+#######################################
+_is_bot_generated_cleanup_issue() {
+	local issue_meta_json="$1"
+	[[ -n "$issue_meta_json" ]] || return 1
+	printf '%s' "$issue_meta_json" |
+		jq -e '.labels | map(.name) | (index("review-followup") != null or index("source:review-scanner") != null)' >/dev/null 2>&1
 }
 
 #######################################
@@ -1181,15 +1270,9 @@ _dispatch_dedup_check_layers() {
 		return 1
 	fi
 
-	local known_ever_nmr="unknown"
-	if printf '%s' "$issue_meta_json" | jq -e '.labels | map(.name) | index("needs-maintainer-review")' >/dev/null 2>&1; then
-		known_ever_nmr="true"
-	fi
-
-	# t1894: Cryptographic approval gate — block dispatch for issues that were
-	# ever labeled needs-maintainer-review without a signed approval.
-	if ! issue_has_required_approval "$issue_number" "$repo_slug" "$known_ever_nmr"; then
-		echo "[pulse-wrapper] dispatch_with_dedup: BLOCKED #${issue_number} in ${repo_slug} — requires cryptographic approval (ever-NMR)" >>"$LOGFILE"
+	# t1894/GH#18648: Cryptographic approval gate (ever-NMR) with
+	# review-followup exemption for bot-generated cleanup issues.
+	if _check_nmr_approval_gate "$issue_number" "$repo_slug" "$issue_meta_json"; then
 		return 1
 	fi
 

--- a/.agents/scripts/tests/test-pulse-dispatch-core-bot-cleanup.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-core-bot-cleanup.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Tests for _is_bot_generated_cleanup_issue() (GH#18648 / Fix 3a).
+#
+# Bot-generated cleanup issues created by post-merge-review-scanner.sh
+# are exempt from the ever-NMR permanence trap. These tests verify the
+# label-detection helper that gates the exemption.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+CORE_SCRIPT="${SCRIPT_DIR}/../pulse-dispatch-core.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+# Extract the helper from pulse-dispatch-core.sh and eval it so the test
+# runs against the real source — same pattern as the force-dispatch tests.
+define_helper_under_test() {
+	local helper_src
+	helper_src=$(awk '
+		/^_is_bot_generated_cleanup_issue\(\) \{/,/^}$/ { print }
+	' "$CORE_SCRIPT")
+	if [[ -z "$helper_src" ]]; then
+		printf 'ERROR: could not extract _is_bot_generated_cleanup_issue from %s\n' "$CORE_SCRIPT" >&2
+		return 1
+	fi
+	# shellcheck disable=SC1090  # dynamic source from extracted helper
+	eval "$helper_src"
+	return 0
+}
+
+test_detects_review_followup_label() {
+	local meta='{"number":2294,"labels":[{"name":"auto-dispatch"},{"name":"review-followup"}]}'
+	if _is_bot_generated_cleanup_issue "$meta"; then
+		print_result "detects review-followup label" 0
+		return 0
+	fi
+	print_result "detects review-followup label" 1 \
+		"Expected exit 0 when review-followup is present"
+	return 0
+}
+
+test_detects_source_review_scanner_label() {
+	local meta='{"number":2294,"labels":[{"name":"bug"},{"name":"source:review-scanner"}]}'
+	if _is_bot_generated_cleanup_issue "$meta"; then
+		print_result "detects source:review-scanner label" 0
+		return 0
+	fi
+	print_result "detects source:review-scanner label" 1 \
+		"Expected exit 0 when source:review-scanner is present"
+	return 0
+}
+
+test_detects_both_labels() {
+	local meta='{"number":2294,"labels":[{"name":"review-followup"},{"name":"source:review-scanner"}]}'
+	if _is_bot_generated_cleanup_issue "$meta"; then
+		print_result "detects both review-followup and source:review-scanner" 0
+		return 0
+	fi
+	print_result "detects both review-followup and source:review-scanner" 1
+	return 0
+}
+
+test_ignores_non_cleanup_issue() {
+	local meta='{"number":18599,"labels":[{"name":"bug"},{"name":"auto-dispatch"},{"name":"tier:standard"}]}'
+	if _is_bot_generated_cleanup_issue "$meta"; then
+		print_result "non-cleanup issue returns exit 1" 1 \
+			"Expected exit 1 for a regular bug issue"
+		return 0
+	fi
+	print_result "non-cleanup issue returns exit 1" 0
+	return 0
+}
+
+test_empty_labels_array() {
+	local meta='{"number":1,"labels":[]}'
+	if _is_bot_generated_cleanup_issue "$meta"; then
+		print_result "empty labels array returns exit 1" 1
+		return 0
+	fi
+	print_result "empty labels array returns exit 1" 0
+	return 0
+}
+
+test_empty_meta_json() {
+	if _is_bot_generated_cleanup_issue ""; then
+		print_result "empty meta_json returns exit 1" 1
+		return 0
+	fi
+	print_result "empty meta_json returns exit 1" 0
+	return 0
+}
+
+test_invalid_meta_json() {
+	if _is_bot_generated_cleanup_issue "not valid json"; then
+		print_result "invalid meta_json returns exit 1" 1
+		return 0
+	fi
+	print_result "invalid meta_json returns exit 1" 0
+	return 0
+}
+
+test_partial_label_name_does_not_match() {
+	# Substring match would be a bug — `review-followup-queued` is not the
+	# exemption label. jq's index() uses exact equality.
+	local meta='{"number":1,"labels":[{"name":"review-followup-queued"}]}'
+	if _is_bot_generated_cleanup_issue "$meta"; then
+		print_result "partial 'review-followup-queued' does not match" 1 \
+			"Expected exit 1: partial name must not trigger exemption"
+		return 0
+	fi
+	print_result "partial 'review-followup-queued' does not match" 0
+	return 0
+}
+
+# Regression case representing the exact awardsapp #2294 scenario:
+# real issue labels from the stuck queue.
+test_awardsapp_2294_scenario() {
+	local meta='{"number":2294,"labels":[{"name":"auto-dispatch"},{"name":"origin:worker"},{"name":"origin:interactive"},{"name":"review-followup"},{"name":"source:review-scanner"}]}'
+	if _is_bot_generated_cleanup_issue "$meta"; then
+		print_result "awardsapp #2294 label set triggers exemption" 0
+		return 0
+	fi
+	print_result "awardsapp #2294 label set triggers exemption" 1 \
+		"Expected exit 0: this is the exact stuck-queue scenario Fix 3a addresses"
+	return 0
+}
+
+main() {
+	if ! define_helper_under_test; then
+		printf 'FATAL: helper extraction failed\n' >&2
+		return 1
+	fi
+
+	test_detects_review_followup_label
+	test_detects_source_review_scanner_label
+	test_detects_both_labels
+	test_ignores_non_cleanup_issue
+	test_empty_labels_array
+	test_empty_meta_json
+	test_invalid_meta_json
+	test_partial_label_name_does_not_match
+	test_awardsapp_2294_scenario
+
+	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Adds a scoped exemption so bot-generated cleanup issues (review-followup, source:review-scanner) with NMR label removed no longer hit the ever-NMR permanence trap. Preserves t1894 security posture for maintainer-gated issues — exemption only fires when NMR label is NOT currently present.

## Files Changed

.agents/scripts/pulse-dispatch-core.sh,.agents/scripts/tests/test-pulse-dispatch-core-bot-cleanup.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** test-pulse-dispatch-core-bot-cleanup.sh: 9/9 new (covers <webapp>#2294 scenario directly). test-pulse-dispatch-core-force-dispatch.sh: 6/6. test-dispatch-dedup-helper-has-open-pr.sh: 7/7. test-dispatch-dedup-helper-is-assigned.sh: 16/16. test-dispatch-dedup-multi-operator.sh: 7/7. test-pulse-wrapper-main-commit-check.sh: 8/8. shellcheck clean. _dispatch_dedup_check_layers: 77 lines (under 100).

Resolves #18648


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.6 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 1h 5m and 132,538 tokens on this with the user in an interactive session.