### PR TITLE
GH#18650: fix(pulse-merge) post one-time rebase nudge on interactive CONFLICTING PR

### DIFF
--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -941,6 +941,78 @@ _extract_merge_summary() {
 }
 
 #######################################
+# GH#18650 (Fix 4): Post a one-time rebase nudge on an origin:interactive
+# CONFLICTING PR that the pulse is about to skip.
+#
+# Rationale: the merge pass correctly refuses to auto-close origin:interactive
+# PRs (GH#18285 — maintainer session work is theirs to own), but without any
+# counterforce the CONFLICTING state persists and the PR rots silently. The
+# maintainer sees nothing in their inbox and only discovers the stuck PR
+# when they manually check `gh pr list`. This nudge surfaces the stuck state
+# on the PR itself, where GitHub's notification system will ping the author.
+#
+# Idempotent via _gh_idempotent_comment marker — posted once per PR lifetime.
+# If the PR is updated and still conflicts, the nudge does NOT repeat. Workers
+# and humans who care about the PR will see it in the timeline.
+#
+# Fail-open: missing helpers or API errors never block the merge pass. The
+# nudge is best-effort operational plumbing.
+#
+# Args:
+#   $1 - pr_number
+#   $2 - repo_slug (owner/repo)
+#######################################
+_post_rebase_nudge_on_interactive_conflicting() {
+	local pr_number="$1"
+	local repo_slug="$2"
+
+	[[ "$pr_number" =~ ^[0-9]+$ && -n "$repo_slug" ]] || return 0
+
+	# _gh_idempotent_comment is defined in pulse-triage.sh which is sourced
+	# after pulse-merge.sh; bash resolves function names at call time so
+	# this works at runtime. Skip if for some reason the helper is absent
+	# (e.g., out-of-order standalone execution).
+	if ! declare -F _gh_idempotent_comment >/dev/null 2>&1; then
+		echo "[pulse-wrapper] _post_rebase_nudge_on_interactive_conflicting: _gh_idempotent_comment not defined — skipping nudge for PR #${pr_number} in ${repo_slug}" >>"$LOGFILE"
+		return 0
+	fi
+
+	local head_branch
+	head_branch=$(gh pr view "$pr_number" --repo "$repo_slug" \
+		--json headRefName --jq '.headRefName' 2>/dev/null) || head_branch="<branch>"
+	[[ -n "$head_branch" ]] || head_branch="<branch>"
+
+	local marker="<!-- pulse-rebase-nudge -->"
+	local nudge_body
+	nudge_body="${marker}
+## Rebase needed — branch has diverged from \`main\`
+
+This \`origin:interactive\` PR has merge conflicts against \`main\`. The pulse merge pass skips auto-close on maintainer session work (GH#18285), but there is no automated path to resolve conflicts on behalf of a human author — this PR needs your attention.
+
+### To resolve
+
+From a terminal (not a chat session):
+
+\`\`\`bash
+wt switch ${head_branch}
+git pull --rebase origin main
+# resolve any conflicts, then:
+git push --force-with-lease
+\`\`\`
+
+Or use the GitHub web UI's *Update branch* button if the conflicts are trivial enough for GitHub's web merger.
+
+### Why you're seeing this
+
+Every pulse cycle the deterministic merge pass evaluates open PRs and auto-closes \`CONFLICTING\` ones that have no clear owner. \`origin:interactive\` PRs are explicitly protected from that path, which is correct for active maintainer work but left them to rot silently in the queue. This nudge is posted exactly once per PR so the stuck state surfaces in your inbox. If the PR still conflicts after you think you've rebased, the nudge will NOT repeat — re-check manually via \`gh pr view ${pr_number}\`.
+
+<sub>Posted automatically by \`pulse-merge.sh\` (GH#18650 / Fix 4 of the 2026-04-13 dispatch-unblocker pass).</sub>"
+
+	_gh_idempotent_comment "$pr_number" "$repo_slug" "$marker" "$nudge_body" "pr" || true
+	return 0
+}
+
+#######################################
 # Close a conflicting PR with audit comment.
 #
 # GH#17574: Before saying "remains open for re-attempt", check if the
@@ -966,6 +1038,12 @@ _close_conflicting_pr() {
 		--json labels --jq '.labels[].name' 2>/dev/null || true)
 	if printf '%s' "$pr_labels" | grep -q 'origin:interactive'; then
 		echo "[pulse-wrapper] Deterministic merge: skipping auto-close of origin:interactive PR #${pr_number} — maintainer session work is never auto-closed" >>"$LOGFILE"
+		# GH#18650 (Fix 4): post a one-time rebase nudge so the maintainer
+		# has a visible signal that their CONFLICTING PR needs manual
+		# attention. Without this, interactive CONFLICTING PRs rot
+		# silently — the pulse log keeps skipping them every cycle but
+		# the maintainer never sees the signal.
+		_post_rebase_nudge_on_interactive_conflicting "$pr_number" "$repo_slug"
 		return 0
 	fi
 

--- a/.agents/scripts/tests/test-pulse-merge-rebase-nudge.sh
+++ b/.agents/scripts/tests/test-pulse-merge-rebase-nudge.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Tests for _post_rebase_nudge_on_interactive_conflicting() (GH#18650 / Fix 4).
+#
+# The nudge is posted by the pulse merge pass when it skips auto-close on an
+# origin:interactive CONFLICTING PR. These tests exercise the helper in
+# isolation with a mock gh stub and a mock _gh_idempotent_comment so we can
+# verify the body construction (marker presence, rebase command, branch
+# interpolation) without touching a real repository.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+MERGE_SCRIPT="${SCRIPT_DIR}/../pulse-merge.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+LAST_NUDGE_ARGS=""
+LAST_NUDGE_BODY=""
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+	mkdir -p "${TEST_ROOT}/bin"
+	export PATH="${TEST_ROOT}/bin:${PATH}"
+	export LOGFILE="${TEST_ROOT}/pulse.log"
+	: >"$LOGFILE"
+
+	# Stub `gh pr view --json headRefName` to return a fixed branch name.
+	cat >"${TEST_ROOT}/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "pr" && "${2:-}" == "view" && "$*" == *"headRefName"* ]]; then
+	printf 'fix/example-branch\n'
+	exit 0
+fi
+# Any other gh call — return empty
+exit 0
+EOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+
+	return 0
+}
+
+teardown_test_env() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+# Extract the helper under test from pulse-merge.sh and eval it so we run
+# against the real source code, not a duplicate. Same pattern as the
+# force-dispatch and bot-cleanup test helpers.
+define_helper_under_test() {
+	local helper_src
+	helper_src=$(awk '
+		/^_post_rebase_nudge_on_interactive_conflicting\(\) \{/,/^}$/ { print }
+	' "$MERGE_SCRIPT")
+	if [[ -z "$helper_src" ]]; then
+		printf 'ERROR: could not extract _post_rebase_nudge_on_interactive_conflicting from %s\n' "$MERGE_SCRIPT" >&2
+		return 1
+	fi
+	# shellcheck disable=SC1090  # dynamic source from extracted helper
+	eval "$helper_src"
+	return 0
+}
+
+# Mock _gh_idempotent_comment that captures the body for inspection.
+define_mock_idempotent_comment() {
+	_gh_idempotent_comment() {
+		LAST_NUDGE_ARGS="entity=$1 repo=$2 marker_len=${#3} type=${5:-issue}"
+		LAST_NUDGE_BODY="$4"
+		return 0
+	}
+	return 0
+}
+
+# No-op helper that intentionally leaves _gh_idempotent_comment undefined.
+undefine_idempotent_comment() {
+	unset -f _gh_idempotent_comment 2>/dev/null || true
+	return 0
+}
+
+test_nudge_body_contains_marker_and_branch() {
+	define_mock_idempotent_comment
+	LAST_NUDGE_BODY=""
+	LAST_NUDGE_ARGS=""
+
+	_post_rebase_nudge_on_interactive_conflicting "18604" "marcusquinn/aidevops"
+
+	if [[ "$LAST_NUDGE_BODY" != *"<!-- pulse-rebase-nudge -->"* ]]; then
+		print_result "nudge body contains the idempotency marker" 1 \
+			"Expected marker '<!-- pulse-rebase-nudge -->' in body"
+		return 0
+	fi
+	if [[ "$LAST_NUDGE_BODY" != *"wt switch fix/example-branch"* ]]; then
+		print_result "nudge body contains the idempotency marker" 1 \
+			"Expected 'wt switch fix/example-branch' in body (branch interpolation)"
+		return 0
+	fi
+	if [[ "$LAST_NUDGE_BODY" != *"git push --force-with-lease"* ]]; then
+		print_result "nudge body contains the idempotency marker" 1 \
+			"Expected 'git push --force-with-lease' in body"
+		return 0
+	fi
+	print_result "nudge body contains the idempotency marker" 0
+	return 0
+}
+
+test_nudge_posts_as_pr_entity() {
+	define_mock_idempotent_comment
+	LAST_NUDGE_ARGS=""
+
+	_post_rebase_nudge_on_interactive_conflicting "18604" "marcusquinn/aidevops"
+
+	if [[ "$LAST_NUDGE_ARGS" != *"type=pr"* ]]; then
+		print_result "nudge posts as PR entity, not issue" 1 \
+			"Expected entity_type='pr' in idempotent-comment call. Got: ${LAST_NUDGE_ARGS}"
+		return 0
+	fi
+	print_result "nudge posts as PR entity, not issue" 0
+	return 0
+}
+
+test_nudge_passes_pr_number_and_repo() {
+	define_mock_idempotent_comment
+	LAST_NUDGE_ARGS=""
+
+	_post_rebase_nudge_on_interactive_conflicting "18604" "marcusquinn/aidevops"
+
+	if [[ "$LAST_NUDGE_ARGS" != *"entity=18604"* ]]; then
+		print_result "nudge passes PR number and repo slug" 1 \
+			"Expected entity=18604. Got: ${LAST_NUDGE_ARGS}"
+		return 0
+	fi
+	if [[ "$LAST_NUDGE_ARGS" != *"repo=marcusquinn/aidevops"* ]]; then
+		print_result "nudge passes PR number and repo slug" 1 \
+			"Expected repo=marcusquinn/aidevops. Got: ${LAST_NUDGE_ARGS}"
+		return 0
+	fi
+	print_result "nudge passes PR number and repo slug" 0
+	return 0
+}
+
+test_noops_when_idempotent_helper_undefined() {
+	undefine_idempotent_comment
+	LAST_NUDGE_BODY=""
+
+	# Must return 0 (not fail) and not call anything.
+	if ! _post_rebase_nudge_on_interactive_conflicting "18604" "marcusquinn/aidevops"; then
+		print_result "no-ops when _gh_idempotent_comment is undefined" 1 \
+			"Expected return 0 on missing helper (fail-open)"
+		return 0
+	fi
+	# Log should record the skip reason.
+	if ! grep -q "_gh_idempotent_comment not defined" "$LOGFILE" 2>/dev/null; then
+		print_result "no-ops when _gh_idempotent_comment is undefined" 1 \
+			"Expected log entry about missing helper"
+		return 0
+	fi
+	print_result "no-ops when _gh_idempotent_comment is undefined" 0
+	return 0
+}
+
+test_noops_on_invalid_pr_number() {
+	define_mock_idempotent_comment
+	LAST_NUDGE_ARGS=""
+
+	if ! _post_rebase_nudge_on_interactive_conflicting "not-a-number" "marcusquinn/aidevops"; then
+		print_result "no-ops on invalid PR number" 1 \
+			"Expected return 0 on invalid input"
+		return 0
+	fi
+	if [[ -n "$LAST_NUDGE_ARGS" ]]; then
+		print_result "no-ops on invalid PR number" 1 \
+			"Expected no mock call. Got: ${LAST_NUDGE_ARGS}"
+		return 0
+	fi
+	print_result "no-ops on invalid PR number" 0
+	return 0
+}
+
+test_noops_on_empty_repo_slug() {
+	define_mock_idempotent_comment
+	LAST_NUDGE_ARGS=""
+
+	if ! _post_rebase_nudge_on_interactive_conflicting "18604" ""; then
+		print_result "no-ops on empty repo slug" 1 \
+			"Expected return 0 on invalid input"
+		return 0
+	fi
+	if [[ -n "$LAST_NUDGE_ARGS" ]]; then
+		print_result "no-ops on empty repo slug" 1 \
+			"Expected no mock call. Got: ${LAST_NUDGE_ARGS}"
+		return 0
+	fi
+	print_result "no-ops on empty repo slug" 0
+	return 0
+}
+
+main() {
+	trap teardown_test_env EXIT
+	setup_test_env
+
+	if ! define_helper_under_test; then
+		printf 'FATAL: helper extraction failed\n' >&2
+		return 1
+	fi
+
+	test_nudge_body_contains_marker_and_branch
+	test_nudge_posts_as_pr_entity
+	test_nudge_passes_pr_number_and_repo
+	test_noops_when_idempotent_helper_undefined
+	test_noops_on_invalid_pr_number
+	test_noops_on_empty_repo_slug
+
+	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

The pulse merge pass correctly refuses to auto-close origin:interactive CONFLICTING PRs but left them rotting silently. This fix posts a one-time idempotent rebase nudge comment with the exact wt switch + git pull --rebase + git push --force-with-lease command, so the maintainer sees the stuck state in their inbox.

## Files Changed

.agents/scripts/pulse-merge.sh,.agents/scripts/tests/test-pulse-merge-rebase-nudge.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** test-pulse-merge-rebase-nudge.sh: 6/6 new tests via mock _gh_idempotent_comment. Regressions: test-pulse-dispatch-core-bot-cleanup.sh 9/9, test-pulse-dispatch-core-force-dispatch.sh 6/6, test-dispatch-dedup-helper-has-open-pr.sh 7/7. shellcheck clean. _close_conflicting_pr is 96 lines, _post_rebase_nudge_on_interactive_conflicting is 49 lines — both well under the 100-line complexity threshold.

Resolves #18650


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.6 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 1h 18m and 153,257 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated notifications now alert PR authors when interactive merge PRs encounter conflicting branches, providing step-by-step rebasing guidance instead of auto-closing the PR.

* **Tests**
  * Added comprehensive test suite for conflict notification functionality, including validation of notification content and graceful handling of edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->