### PR TITLE
t2047: task-id collision guard — commit-msg hook + CI check

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -199,6 +199,8 @@ Worktrees: `wt switch -c {type}/{name}`. Keep the canonical repo directory on `m
 
 **Cryptographic issue/PR approval (human-only gate):** `sudo aidevops approve issue <number> [owner/repo]` — SSH-signed approval comment; workers cannot forge it (private key is root-only). Setup once with `sudo aidevops approve setup`. Verify: `aidevops approve verify <number>`. This is distinct from the `ai-approved` label (which is a simple collaborator gate, not cryptographic).
 
+**Task-ID collision guard (t2047):** t-IDs in commit subjects MUST be claimed via `claim-task-id.sh`. The commit-msg hook (`install-task-id-guard.sh install`) enforces this client-side; the CI check (`.github/workflows/task-id-collision-check.yml`) enforces it server-side for commits authored outside the hook.
+
 Full workflow: `workflows/git-workflow.md`, `reference/session.md`
 
 ---

--- a/.agents/hooks/task-id-collision-guard.sh
+++ b/.agents/hooks/task-id-collision-guard.sh
@@ -1,0 +1,374 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# task-id-collision-guard.sh — git commit-msg hook and CI check.
+#
+# Scans commit subjects (and bodies) for t\d+ references and rejects commits
+# where a referenced t-ID appears to be invented — i.e., greater than the
+# current .task-counter on the merge base AND not cross-referenced via a
+# linked GitHub issue title that confirms the ID was claimed by someone else.
+#
+# Modes:
+#   Default (commit-msg hook):
+#     Called with $1 = path to the commit message file.
+#     Exits 0 (allow) or 1 (reject with actionable error).
+#
+#   check-pr <PR_NUMBER>:
+#     Scans every commit in the PR range (merge-base..HEAD).
+#     Used by CI to catch commits authored outside the hook.
+#     Exits 0 (all clean) or 1 (one or more violations).
+#
+# Environment:
+#   TASK_ID_GUARD_DISABLE=1   — bypass for this invocation (equivalent to --no-verify)
+#   TASK_ID_GUARD_DEBUG=1     — verbose stderr trace
+#
+# Fail-open cases (exit 0 with warning):
+#   - gh CLI unavailable or unauthenticated
+#   - .task-counter not present on merge base
+#   - offline state
+#   - git command failures
+
+set -u
+
+# ---------------------------------------------------------------------------
+# Bypass
+# ---------------------------------------------------------------------------
+
+if [[ "${TASK_ID_GUARD_DISABLE:-0}" == "1" ]]; then
+	printf '[task-id-guard][INFO] TASK_ID_GUARD_DISABLE=1 — bypassing\n' >&2
+	exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_debug() {
+	[[ "${TASK_ID_GUARD_DEBUG:-0}" == "1" ]] && printf '[task-id-guard][DEBUG] %s\n' "$1" >&2
+	return 0
+}
+
+_warn() {
+	printf '[task-id-guard][WARN] %s\n' "$1" >&2
+	return 0
+}
+
+_info() {
+	printf '[task-id-guard][INFO] %s\n' "$1" >&2
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Read the .task-counter value at a given git ref.
+# Returns the integer or empty string on failure.
+# ---------------------------------------------------------------------------
+_read_counter_at_ref() {
+	local ref="${1:-}"
+	if [[ -z "$ref" ]]; then
+		return 1
+	fi
+	local val
+	val=$(git show "${ref}:.task-counter" 2>/dev/null | tr -d '[:space:]')
+	if [[ "$val" =~ ^[0-9]+$ ]]; then
+		printf '%s' "$val"
+		return 0
+	fi
+	return 1
+}
+
+# ---------------------------------------------------------------------------
+# Determine the merge base between HEAD and the default branch (main/master).
+# Falls back to the root commit.
+# ---------------------------------------------------------------------------
+_find_merge_base() {
+	local base=""
+	# Try main first, then master
+	for branch in main master; do
+		if git rev-parse --verify "origin/${branch}" >/dev/null 2>&1; then
+			base=$(git merge-base HEAD "origin/${branch}" 2>/dev/null) && break
+		elif git rev-parse --verify "$branch" >/dev/null 2>&1; then
+			base=$(git merge-base HEAD "$branch" 2>/dev/null) && break
+		fi
+	done
+	if [[ -z "$base" ]]; then
+		# Fallback: root commit of the current branch
+		base=$(git rev-list --max-parents=0 HEAD 2>/dev/null | head -1)
+	fi
+	printf '%s' "$base"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Check if a given issue title (from gh) references the t-ID.
+# Returns 0 if it does, 1 if not.
+# ---------------------------------------------------------------------------
+_issue_title_contains_tid() {
+	local tid="${1:-}"
+	local issue_number="${2:-}"
+	if [[ -z "$tid" || -z "$issue_number" ]]; then
+		return 1
+	fi
+	local title
+	title=$(gh issue view "$issue_number" --json title --jq '.title' 2>/dev/null) || return 1
+	_debug "Issue #${issue_number} title: $title"
+	if printf '%s' "$title" | grep -qE "(^|[^0-9])${tid}([^0-9]|$)"; then
+		return 0
+	fi
+	return 1
+}
+
+# ---------------------------------------------------------------------------
+# Extract all tNNN references from text.
+# Outputs one per line.
+# ---------------------------------------------------------------------------
+_extract_tids() {
+	local text="${1:-}"
+	# Match t followed by one or more digits (word-boundary aware via grep -o)
+	printf '%s' "$text" | grep -oE 't[0-9]+' | sort -u
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Extract issue numbers from Resolves|Closes|Fixes footer lines.
+# Outputs one per line.
+# ---------------------------------------------------------------------------
+_extract_closing_issues() {
+	local text="${1:-}"
+	printf '%s' "$text" | grep -iE '(Resolves|Closes|Fixes)[[:space:]]+#[0-9]+' |
+		grep -oE '#[0-9]+' | tr -d '#' | sort -u
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Core check: given a commit message, check if any t\d+ reference is invented.
+# Args:
+#   $1 = full commit message text
+#   $2 = merge-base git ref (for reading .task-counter)
+#   $3 = commit subject (for display in errors), optional
+# Returns 0 (clean), 1 (violation found), 2 (fail-open — skip).
+# ---------------------------------------------------------------------------
+_check_message() {
+	local msg="${1:-}"
+	local merge_base="${2:-}"
+	local subject="${3:-<unknown>}"
+
+	if [[ -z "$msg" ]]; then
+		_debug "Empty commit message — allowing"
+		return 0
+	fi
+
+	# Extract first line as the subject if not provided
+	if [[ "$subject" == "<unknown>" ]]; then
+		subject=$(printf '%s' "$msg" | head -1)
+	fi
+
+	# Find all t-ID references
+	local tids
+	tids=$(_extract_tids "$msg")
+	if [[ -z "$tids" ]]; then
+		_debug "No t-IDs in commit — allowing"
+		return 0
+	fi
+
+	_debug "Found t-IDs: $(printf '%s' "$tids" | tr '\n' ' ')"
+
+	# Read counter at merge base
+	local counter=""
+	if [[ -n "$merge_base" ]]; then
+		counter=$(_read_counter_at_ref "$merge_base")
+	fi
+
+	if [[ -z "$counter" ]]; then
+		_warn ".task-counter not readable at merge base '${merge_base}' — fail-open"
+		return 2
+	fi
+
+	_debug "Merge-base counter value: $counter"
+
+	# Extract closing issue numbers from the commit footer
+	local closing_issues
+	closing_issues=$(_extract_closing_issues "$msg")
+	_debug "Closing issues: $(printf '%s' "$closing_issues" | tr '\n' ' ')"
+
+	# Check each t-ID
+	local violations=""
+	local tid
+	while IFS= read -r tid; do
+		[[ -z "$tid" ]] && continue
+		local num
+		num=$(printf '%s' "$tid" | tr -d 't')
+
+		if ! [[ "$num" =~ ^[0-9]+$ ]]; then
+			_debug "Non-numeric suffix for $tid — skipping"
+			continue
+		fi
+
+		# If numeric_id <= counter, the ID is claimed (or pre-dates the counter)
+		if [[ "$num" -le "$counter" ]]; then
+			_debug "$tid ≤ counter ($counter) — allowed"
+			continue
+		fi
+
+		_debug "$tid ($num) > counter ($counter) — suspicious, checking linked issues"
+
+		# The ID is beyond the current counter. Check if any linked issue title
+		# contains this t-ID (cross-reference confirmation).
+		local confirmed=0
+		if [[ -n "$closing_issues" ]]; then
+			local iss_num
+			while IFS= read -r iss_num; do
+				[[ -z "$iss_num" ]] && continue
+				if _issue_title_contains_tid "$tid" "$iss_num"; then
+					_debug "$tid confirmed via linked issue #${iss_num}"
+					confirmed=1
+					break
+				fi
+			done <<<"$closing_issues"
+		fi
+
+		if [[ "$confirmed" -eq 0 ]]; then
+			violations="${violations}  ${tid} — numeric ID ${num} > current counter ${counter}, and not confirmed via a linked issue title\n"
+		fi
+	done <<<"$tids"
+
+	if [[ -n "$violations" ]]; then
+		printf '\n[task-id-guard][BLOCK] Commit subject references invented task ID(s):\n\n' >&2
+		printf '  Subject: %s\n\n' "$subject" >&2
+		printf '%b\n' "$violations" >&2
+		printf '  To fix:\n' >&2
+		printf '    1. Remove the t-ID from the commit subject/body, OR\n' >&2
+		printf '    2. Claim the ID first: claim-task-id.sh --title "..." → then use the allocated ID, OR\n' >&2
+		printf '    3. If cross-referencing another person'"'"'s task, add "Resolves/Closes/Fixes #NNN" footer\n' >&2
+		printf '       where the linked issue title contains the t-ID.\n' >&2
+		printf '  Bypass (sets audit trail): TASK_ID_GUARD_DISABLE=1 git commit ...  or git commit --no-verify\n\n' >&2
+		return 1
+	fi
+
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Commit-msg hook mode (default).
+# $1 = path to commit message file
+# ---------------------------------------------------------------------------
+_run_hook() {
+	local msg_file="${1:-}"
+	if [[ -z "$msg_file" || ! -f "$msg_file" ]]; then
+		_warn "commit-msg: no message file provided — fail-open"
+		return 0
+	fi
+
+	local msg
+	msg=$(cat "$msg_file")
+	local subject
+	subject=$(head -1 "$msg_file")
+
+	# Skip merge commits, fixup commits, and squash commits
+	if printf '%s' "$subject" | grep -qE '^(Merge|fixup!|squash!)'; then
+		_debug "Merge/fixup/squash commit — skipping"
+		return 0
+	fi
+
+	local merge_base
+	merge_base=$(_find_merge_base)
+	_debug "Merge base: $merge_base"
+
+	local rc
+	_check_message "$msg" "$merge_base" "$subject"
+	rc=$?
+
+	if [[ "$rc" -eq 2 ]]; then
+		# Fail-open
+		return 0
+	fi
+	return "$rc"
+}
+
+# ---------------------------------------------------------------------------
+# CI mode: check-pr <PR_NUMBER>
+# Scans every commit in the PR range (merge-base..HEAD).
+# ---------------------------------------------------------------------------
+_run_check_pr() {
+	local pr_number="${1:-}"
+	if [[ -z "$pr_number" ]]; then
+		printf '[task-id-guard][ERROR] check-pr requires a PR number\n' >&2
+		return 1
+	fi
+
+	local merge_base
+	merge_base=$(_find_merge_base)
+	_debug "Merge base for PR #${pr_number}: $merge_base"
+
+	if [[ -z "$merge_base" ]]; then
+		_warn "Could not determine merge base — fail-open"
+		return 0
+	fi
+
+	# Get commits in the PR range
+	local commits
+	commits=$(git log "${merge_base}..HEAD" --format='%H' 2>/dev/null)
+	if [[ -z "$commits" ]]; then
+		_info "No commits in PR range — nothing to check"
+		return 0
+	fi
+
+	local total_violations=0
+	local commit_hash
+	while IFS= read -r commit_hash; do
+		[[ -z "$commit_hash" ]] && continue
+		local commit_msg
+		commit_msg=$(git log -1 --format='%s%n%n%b' "$commit_hash" 2>/dev/null)
+		local subject
+		subject=$(git log -1 --format='%s' "$commit_hash" 2>/dev/null)
+
+		_debug "Checking commit $commit_hash: $subject"
+
+		# Skip merge commits
+		if printf '%s' "$subject" | grep -qE '^(Merge|fixup!|squash!)'; then
+			_debug "Skipping merge/fixup/squash: $commit_hash"
+			continue
+		fi
+
+		local rc
+		_check_message "$commit_msg" "$merge_base" "$subject"
+		rc=$?
+		if [[ "$rc" -eq 1 ]]; then
+			printf '[task-id-guard][VIOLATION] commit %s\n' "$commit_hash" >&2
+			total_violations=$((total_violations + 1))
+		fi
+	done <<<"$commits"
+
+	if [[ "$total_violations" -gt 0 ]]; then
+		printf '\n[task-id-guard][SUMMARY] %d violation(s) found in PR #%s\n' "$total_violations" "$pr_number" >&2
+		return 1
+	fi
+
+	_info "PR #${pr_number}: all commits clean"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+main() {
+	local mode="${1:-}"
+	case "$mode" in
+	check-pr)
+		shift
+		_run_check_pr "$@"
+		return $?
+		;;
+	help | --help | -h)
+		sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+		return 0
+		;;
+	*)
+		# Default: commit-msg hook mode. $1 is the message file path.
+		_run_hook "${1:-}"
+		return $?
+		;;
+	esac
+}
+
+main "$@"

--- a/.agents/scripts/install-task-id-guard.sh
+++ b/.agents/scripts/install-task-id-guard.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# install-task-id-guard.sh — Install the task-id collision guard commit-msg hook
+# into the current repository.
+#
+# Usage:
+#   install-task-id-guard.sh install      Install (or update) the commit-msg hook
+#   install-task-id-guard.sh uninstall    Remove just the task-id guard entry
+#   install-task-id-guard.sh status       Report current state
+#   install-task-id-guard.sh test         Run the test harness
+#
+# The installer writes a small dispatcher into .git/hooks/commit-msg that calls
+# ~/.aidevops/agents/hooks/task-id-collision-guard.sh (survives aidevops updates).
+# If a pre-existing commit-msg hook is found that is NOT ours, we refuse to
+# overwrite and print remediation instructions.
+#
+# The installer targets the git COMMON dir (git rev-parse --git-common-dir)
+# so worktrees share the hook with the parent repo.
+#
+# Bypass: TASK_ID_GUARD_DISABLE=1 git commit ...  or git commit --no-verify
+
+set -euo pipefail
+
+RED=$'\033[0;31m'
+GREEN=$'\033[0;32m'
+YELLOW=$'\033[1;33m'
+BLUE=$'\033[0;34m'
+NC=$'\033[0m'
+
+print_info() { printf '%s[INFO]%s %s\n' "$BLUE" "$NC" "$1"; }
+print_success() { printf '%s[OK]%s %s\n' "$GREEN" "$NC" "$1"; }
+print_warning() { printf '%s[WARN]%s %s\n' "$YELLOW" "$NC" "$1" >&2; }
+print_error() { printf '%s[ERROR]%s %s\n' "$RED" "$NC" "$1" >&2; }
+
+HOOK_MARKER="# aidevops-task-id-guard"
+DEPLOYED_HOOK="$HOME/.aidevops/agents/hooks/task-id-collision-guard.sh"
+
+#######################################
+# Locate the repo-local copy of the hook (for use before aidevops update has
+# deployed it) or fall back to the deployed location.
+#######################################
+_find_source_hook() {
+	local script_dir
+	script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+	local repo_hook="${script_dir}/../hooks/task-id-collision-guard.sh"
+	if [[ -f "$repo_hook" ]]; then
+		echo "$repo_hook"
+		return 0
+	fi
+	if [[ -f "$DEPLOYED_HOOK" ]]; then
+		echo "$DEPLOYED_HOOK"
+		return 0
+	fi
+	return 1
+}
+
+#######################################
+# Resolve the git common dir (shared between worktrees).
+#######################################
+_git_common_dir() {
+	git rev-parse --git-common-dir 2>/dev/null || {
+		print_error "not a git repository"
+		return 1
+	}
+	return 0
+}
+
+#######################################
+# Install the hook. If an existing commit-msg hook is found that is not ours,
+# abort with a clear message. Otherwise write a small dispatcher script.
+#######################################
+cmd_install() {
+	local common_dir
+	common_dir=$(_git_common_dir) || return 1
+
+	local hook_path="${common_dir}/hooks/commit-msg"
+	mkdir -p "$(dirname "$hook_path")"
+
+	local source_hook
+	if ! source_hook=$(_find_source_hook); then
+		print_error "task-id-collision-guard.sh not found in repo or deployed location"
+		print_error "  checked: \$REPO/.agents/hooks/task-id-collision-guard.sh"
+		print_error "  checked: $DEPLOYED_HOOK"
+		return 1
+	fi
+
+	if [[ -f "$hook_path" ]]; then
+		if grep -q "$HOOK_MARKER" "$hook_path" 2>/dev/null; then
+			print_info "task-id-guard already installed at $hook_path — updating"
+		else
+			print_error "existing commit-msg hook at $hook_path is NOT managed by aidevops"
+			print_error "Refusing to overwrite. To chain, manually add this line to your hook:"
+			print_error "  ${source_hook} \"\$1\" || exit \$?"
+			return 1
+		fi
+	fi
+
+	cat >"$hook_path" <<HOOKEOF
+#!/usr/bin/env bash
+$HOOK_MARKER
+# Managed by .agents/scripts/install-task-id-guard.sh — do not edit.
+# Dispatcher that calls the aidevops task-id collision guard.
+# Bypass with --no-verify or TASK_ID_GUARD_DISABLE=1.
+
+set -u
+
+# Prefer the repo-local hook when available, fall back to deployed.
+_repo_hook=""
+if git_dir=\$(git rev-parse --show-toplevel 2>/dev/null); then
+	_repo_hook="\${git_dir}/.agents/hooks/task-id-collision-guard.sh"
+fi
+_deployed_hook="$DEPLOYED_HOOK"
+
+if [[ -n "\$_repo_hook" && -f "\$_repo_hook" ]]; then
+	exec "\$_repo_hook" "\$1"
+elif [[ -f "\$_deployed_hook" ]]; then
+	exec "\$_deployed_hook" "\$1"
+else
+	printf '[task-id-guard][WARN] hook not installed — allowing commit\n' >&2
+	exit 0
+fi
+HOOKEOF
+	chmod +x "$hook_path"
+	print_success "installed task-id-guard at $hook_path"
+	print_info "source hook: $source_hook"
+	print_info "bypass: TASK_ID_GUARD_DISABLE=1 git commit ...  (or git commit --no-verify)"
+	return 0
+}
+
+#######################################
+# Remove the hook if (and only if) it is managed by us.
+#######################################
+cmd_uninstall() {
+	local common_dir
+	common_dir=$(_git_common_dir) || return 1
+	local hook_path="${common_dir}/hooks/commit-msg"
+
+	if [[ ! -f "$hook_path" ]]; then
+		print_info "no commit-msg hook installed"
+		return 0
+	fi
+
+	if grep -q "$HOOK_MARKER" "$hook_path" 2>/dev/null; then
+		rm -f "$hook_path"
+		print_success "removed task-id-guard commit-msg hook"
+		return 0
+	fi
+
+	print_warning "commit-msg hook at $hook_path is NOT managed by aidevops — leaving it alone"
+	return 1
+}
+
+#######################################
+# Report current state.
+#######################################
+cmd_status() {
+	local common_dir
+	common_dir=$(_git_common_dir) || return 1
+	local hook_path="${common_dir}/hooks/commit-msg"
+
+	if [[ ! -f "$hook_path" ]]; then
+		printf 'commit-msg hook: NOT INSTALLED\n'
+		return 0
+	fi
+	if grep -q "$HOOK_MARKER" "$hook_path" 2>/dev/null; then
+		printf 'commit-msg hook: installed (aidevops task-id-guard)\n'
+		printf '  path: %s\n' "$hook_path"
+	else
+		printf 'commit-msg hook: installed (unknown manager)\n'
+		printf '  path: %s\n' "$hook_path"
+	fi
+	return 0
+}
+
+#######################################
+# Run the test harness.
+#######################################
+cmd_test() {
+	local script_dir
+	script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+	local test_script="${script_dir}/tests/test-task-id-collision-guard.sh"
+	if [[ ! -f "$test_script" ]]; then
+		print_error "test harness not found: $test_script"
+		return 1
+	fi
+	bash "$test_script" "$@"
+	return $?
+}
+
+main() {
+	local cmd="${1:-install}"
+	shift || true
+	case "$cmd" in
+	install) cmd_install "$@" ;;
+	uninstall) cmd_uninstall "$@" ;;
+	status) cmd_status "$@" ;;
+	test) cmd_test "$@" ;;
+	help | --help | -h)
+		sed -n '2,26p' "$0" | sed 's/^# \{0,1\}//'
+		;;
+	*)
+		print_error "unknown command: $cmd"
+		return 1
+		;;
+	esac
+}
+
+main "$@"

--- a/.agents/scripts/setup/_task_id_guard.sh
+++ b/.agents/scripts/setup/_task_id_guard.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Setup module: install task-id collision guard commit-msg hook in every initialized repo.
+# Sourced by setup.sh — do not execute directly.
+#
+# Idempotent: re-installs managed hooks, skips unmanaged ones with a warning,
+# counts each outcome, and returns success regardless of per-repo conflicts
+# so setup.sh does not abort on a single non-cooperative repo.
+#
+# Opt out by exporting AIDEVOPS_TASK_ID_GUARD=false before running setup.
+
+#######################################
+# Resolve the path of install-task-id-guard.sh relative to this module.
+# Returns: path on stdout, 0 on success; nothing on stdout, 1 on miss.
+#######################################
+_load_task_id_guard_installer() {
+	local installer_path
+	installer_path="$(cd -- "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../install-task-id-guard.sh"
+	if [[ ! -f "$installer_path" ]]; then
+		print_warning "install-task-id-guard.sh not found at: $installer_path"
+		return 1
+	fi
+	printf '%s' "$installer_path"
+	return 0
+}
+
+#######################################
+# Install or refresh the task-id collision guard commit-msg hook in every
+# initialized repo listed in repos.json. Called from setup.sh.
+#
+# Behaviour:
+#   - Iterates initialized_repos[].path, expanding leading ~
+#   - Skips entries without a local .git present
+#   - Calls install-task-id-guard.sh install inside each repo (idempotent)
+#   - Counts outcomes: ok, already-managed, conflict (unmanaged hook present),
+#     skip (no .git), err (other)
+#   - Reports a one-line summary via print_info
+#   - Tracks success via setup_track_configured
+#
+# Opt out: AIDEVOPS_TASK_ID_GUARD=false
+#######################################
+setup_task_id_guard() {
+	if [[ "${AIDEVOPS_TASK_ID_GUARD:-true}" == "false" ]]; then
+		print_info "Task-ID guard install disabled via AIDEVOPS_TASK_ID_GUARD=false"
+		setup_track_skipped "Task-ID guard" "opted out via AIDEVOPS_TASK_ID_GUARD=false"
+		return 0
+	fi
+
+	print_info "Installing task-id collision guard commit-msg hook across initialized repos..."
+
+	local installer_path
+	if ! installer_path=$(_load_task_id_guard_installer); then
+		setup_track_skipped "Task-ID guard" "installer not available"
+		return 0
+	fi
+
+	local repos_config="${HOME}/.config/aidevops/repos.json"
+	if [[ ! -f "$repos_config" ]]; then
+		print_warning "repos.json not found — skipping task-id guard rollout"
+		setup_track_skipped "Task-ID guard" "repos.json not found"
+		return 0
+	fi
+
+	if ! command -v jq >/dev/null 2>&1; then
+		print_warning "jq not installed — skipping task-id guard rollout"
+		setup_track_skipped "Task-ID guard" "jq not installed"
+		return 0
+	fi
+
+	local ok=0 already=0 conflict=0 skip=0 err=0
+	local rawpath path result
+
+	while IFS= read -r rawpath; do
+		[[ -z "$rawpath" ]] && continue
+		path="${rawpath/#\~/$HOME}"
+		if [[ ! -e "$path/.git" ]]; then
+			skip=$((skip + 1))
+			continue
+		fi
+		result=$(cd -- "$path" && bash "$installer_path" install 2>&1 </dev/null || true)
+		case "$result" in
+		*"installed task-id-guard"*)
+			ok=$((ok + 1))
+			;;
+		*"already installed"*)
+			already=$((already + 1))
+			;;
+		*"Refusing to overwrite"* | *"NOT managed"*)
+			conflict=$((conflict + 1))
+			;;
+		*)
+			err=$((err + 1))
+			;;
+		esac
+	done < <(jq -r '.initialized_repos[]? | select(.path != null) | .path' "$repos_config")
+
+	print_info "Task-ID guard: ok=$ok already=$already conflict=$conflict skip=$skip err=$err"
+	local total_covered=$((ok + already))
+	setup_track_configured "Task-ID guard (${total_covered} repos)"
+	return 0
+}

--- a/.agents/scripts/tests/test-task-id-collision-guard.sh
+++ b/.agents/scripts/tests/test-task-id-collision-guard.sh
@@ -1,0 +1,342 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-task-id-collision-guard.sh — Test harness for task-id-collision-guard.sh
+#
+# Covers all 7 acceptance criteria cases:
+#   1. Reject: t-ID > counter AND not in linked issue title
+#   2. Allow: t-ID ≤ counter (claimed)
+#   3. Allow: cross-reference confirmed via linked issue title
+#   4. Allow: commit with no t-IDs at all
+#   5. Allow: fail-open on gh API failure / offline
+#   6. Allow (bypass): --no-verify / TASK_ID_GUARD_DISABLE=1
+#   7. CI mode: check-pr scans range and finds violations
+
+set -u
+
+RED=$'\033[0;31m'
+GREEN=$'\033[0;32m'
+NC=$'\033[0m'
+
+PASS=0
+FAIL=0
+ERRORS=""
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GUARD="${SCRIPT_DIR}/../../hooks/task-id-collision-guard.sh"
+DEPLOYED_GUARD="$HOME/.aidevops/agents/hooks/task-id-collision-guard.sh"
+
+# Prefer deployed if repo copy not found
+if [[ ! -f "$GUARD" ]]; then
+	GUARD="$DEPLOYED_GUARD"
+fi
+
+if [[ ! -f "$GUARD" ]]; then
+	printf '%s[FATAL]%s task-id-collision-guard.sh not found at:\n' "$RED" "$NC" >&2
+	printf '  %s\n' "${SCRIPT_DIR}/../../hooks/task-id-collision-guard.sh" >&2
+	printf '  %s\n' "$DEPLOYED_GUARD" >&2
+	exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+pass() {
+	local name="${1:-}"
+	printf '%s[PASS]%s %s\n' "$GREEN" "$NC" "$name"
+	PASS=$((PASS + 1))
+	return 0
+}
+
+fail() {
+	local name="${1:-}"
+	local detail="${2:-}"
+	printf '%s[FAIL]%s %s\n' "$RED" "$NC" "$name"
+	[[ -n "$detail" ]] && printf '       %s\n' "$detail"
+	FAIL=$((FAIL + 1))
+	ERRORS="${ERRORS}\n  - ${name}: ${detail}"
+	return 0
+}
+
+# Run the guard with a message file and a mock counter.
+# Sets up a temporary git repo to provide a merge base with .task-counter = N.
+# Returns the exit code of the guard.
+_run_with_counter() {
+	local msg="${1:-}"
+	local counter_val="${2:-10}"
+	local gh_available="${3:-no}" # "yes" or "no"
+
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir'" RETURN
+
+	# Create a temporary git repo that acts as the remote/merge-base
+	local base_repo="${tmpdir}/base"
+	mkdir -p "$base_repo"
+	git -C "$base_repo" init -q
+	git -C "$base_repo" config user.email "test@test.local"
+	git -C "$base_repo" config user.name "Test"
+	git -C "$base_repo" config commit.gpgsign false
+	git -C "$base_repo" config tag.gpgsign false
+	printf '%s' "$counter_val" >"${base_repo}/.task-counter"
+	git -C "$base_repo" add .task-counter
+	git -C "$base_repo" commit -q -m "init"
+
+	# Create a work repo branched off the base
+	local work_repo="${tmpdir}/work"
+	git clone -q "$base_repo" "$work_repo" 2>/dev/null
+	git -C "$work_repo" config user.email "test@test.local"
+	git -C "$work_repo" config user.name "Test"
+	git -C "$work_repo" config commit.gpgsign false
+	git -C "$work_repo" config tag.gpgsign false
+
+	# Add a commit so HEAD != merge-base
+	printf 'change' >"${work_repo}/change.txt"
+	git -C "$work_repo" add change.txt
+	git -C "$work_repo" commit -q -m "wip"
+
+	# Write the message file
+	local msg_file="${tmpdir}/COMMIT_EDITMSG"
+	printf '%s' "$msg" >"$msg_file"
+
+	# Run the guard from the work repo context.
+	# Optionally disable gh CLI by PATH manipulation.
+	local rc
+	if [[ "$gh_available" == "no" ]]; then
+		# Stub gh to fail so the guard falls back to fail-open
+		local fake_bin="${tmpdir}/bin"
+		mkdir -p "$fake_bin"
+		printf '#!/usr/bin/env bash\nexit 1\n' >"${fake_bin}/gh"
+		chmod +x "${fake_bin}/gh"
+		PATH="${fake_bin}:$PATH" \
+			GIT_DIR="${work_repo}/.git" \
+			bash "$GUARD" "$msg_file" 2>/dev/null
+		rc=$?
+	else
+		GIT_DIR="${work_repo}/.git" \
+			bash "$GUARD" "$msg_file" 2>/dev/null
+		rc=$?
+	fi
+	return "$rc"
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: Reject — t-ID > counter, no cross-ref
+# ---------------------------------------------------------------------------
+test_rejects_invented_tid() {
+	local name="case-1: rejects invented t-ID > counter"
+	# Counter = 100; message references t99999 which is beyond counter
+	local msg="feat(foo): bar (t99999)"
+	local rc
+	_run_with_counter "$msg" "100"
+	rc=$?
+	if [[ "$rc" -eq 1 ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected exit 1 (reject), got $rc"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Case 2: Allow — t-ID ≤ counter (claimed)
+# ---------------------------------------------------------------------------
+test_allows_claimed_tid() {
+	local name="case-2: allows claimed t-ID ≤ counter"
+	local msg="feat(foo): implement t50 feature"
+	local rc
+	_run_with_counter "$msg" "100"
+	rc=$?
+	if [[ "$rc" -eq 0 ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected exit 0 (allow), got $rc"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Case 3: Allow — no t-IDs at all
+# ---------------------------------------------------------------------------
+test_allows_no_tids() {
+	local name="case-3: allows commit with no t-IDs"
+	local msg="chore: update README with installation instructions"
+	local rc
+	_run_with_counter "$msg" "100"
+	rc=$?
+	if [[ "$rc" -eq 0 ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected exit 0 (allow), got $rc"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Case 4: Allow — fail-open when gh CLI unavailable (offline)
+# ---------------------------------------------------------------------------
+test_failopen_on_gh_failure() {
+	local name="case-4: fail-open when .task-counter unreadable"
+	# Use an empty counter value — guard should warn and allow
+	local msg="feat(foo): bar (t99999)"
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir'" RETURN
+
+	# Create a repo with NO .task-counter file at the merge base
+	local base_repo="${tmpdir}/base"
+	mkdir -p "$base_repo"
+	git -C "$base_repo" init -q
+	git -C "$base_repo" config user.email "test@test.local"
+	git -C "$base_repo" config user.name "Test"
+	git -C "$base_repo" config commit.gpgsign false
+	printf 'placeholder' >"${base_repo}/README.md"
+	git -C "$base_repo" add README.md
+	git -C "$base_repo" commit -q -m "init"
+
+	local work_repo="${tmpdir}/work"
+	git clone -q "$base_repo" "$work_repo" 2>/dev/null
+	git -C "$work_repo" config user.email "test@test.local"
+	git -C "$work_repo" config user.name "Test"
+	git -C "$work_repo" config commit.gpgsign false
+
+	printf 'change' >"${work_repo}/change.txt"
+	git -C "$work_repo" add change.txt
+	git -C "$work_repo" commit -q -m "wip"
+
+	local msg_file="${tmpdir}/COMMIT_EDITMSG"
+	printf '%s' "$msg" >"$msg_file"
+
+	local rc
+	GIT_DIR="${work_repo}/.git" \
+		bash "$GUARD" "$msg_file" 2>/dev/null
+	rc=$?
+
+	# Fail-open = exit 0
+	if [[ "$rc" -eq 0 ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected exit 0 (fail-open), got $rc"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Case 5: Allow — bypass via TASK_ID_GUARD_DISABLE=1
+# ---------------------------------------------------------------------------
+test_bypass_env_var() {
+	local name="case-5: bypass via TASK_ID_GUARD_DISABLE=1"
+	local msg="feat(foo): bar (t99999)"
+	local msg_file
+	msg_file=$(mktemp)
+	printf '%s' "$msg" >"$msg_file"
+	local rc
+	TASK_ID_GUARD_DISABLE=1 bash "$GUARD" "$msg_file" 2>/dev/null
+	rc=$?
+	rm -f "$msg_file"
+	if [[ "$rc" -eq 0 ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected exit 0 (bypass), got $rc"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Case 6: Allow — merge commit subject is skipped
+# ---------------------------------------------------------------------------
+test_skips_merge_commits() {
+	local name="case-6: skips merge commit subjects"
+	local msg="Merge branch 'feature/t99999-foo' into main"
+	local rc
+	_run_with_counter "$msg" "100"
+	rc=$?
+	if [[ "$rc" -eq 0 ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected exit 0 (merge commit skipped), got $rc"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Case 7: CI check-pr mode — scans range, finds violations
+# Uses a real git repo but stubs the gh CLI
+# ---------------------------------------------------------------------------
+test_check_pr_mode() {
+	local name="case-7: check-pr mode detects invented t-ID in range"
+
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir'" RETURN
+
+	local base_repo="${tmpdir}/base"
+	mkdir -p "$base_repo"
+	git -C "$base_repo" init -q
+	git -C "$base_repo" config user.email "test@test.local"
+	git -C "$base_repo" config user.name "Test"
+	git -C "$base_repo" config commit.gpgsign false
+	printf '100' >"${base_repo}/.task-counter"
+	git -C "$base_repo" add .task-counter
+	git -C "$base_repo" commit -q -m "init"
+
+	local work_repo="${tmpdir}/work"
+	git clone -q "$base_repo" "$work_repo" 2>/dev/null
+	git -C "$work_repo" config user.email "test@test.local"
+	git -C "$work_repo" config user.name "Test"
+	git -C "$work_repo" config commit.gpgsign false
+
+	# Add a commit with an invented t-ID
+	printf 'change' >"${work_repo}/change.txt"
+	git -C "$work_repo" add change.txt
+	git -C "$work_repo" commit -q -m "feat: invented id (t99999)"
+
+	# Stub gh to fail so cross-ref lookup does not influence result
+	local fake_bin="${tmpdir}/bin"
+	mkdir -p "$fake_bin"
+	printf '#!/usr/bin/env bash\nexit 1\n' >"${fake_bin}/gh"
+	chmod +x "${fake_bin}/gh"
+
+	local rc
+	PATH="${fake_bin}:$PATH" \
+		GIT_DIR="${work_repo}/.git" \
+		bash "$GUARD" check-pr 9999 2>/dev/null
+	rc=$?
+
+	if [[ "$rc" -eq 1 ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected exit 1 (violation detected), got $rc"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Run all tests
+# ---------------------------------------------------------------------------
+main() {
+	printf 'Running task-id-collision-guard tests...\n\n'
+
+	test_rejects_invented_tid
+	test_allows_claimed_tid
+	test_allows_no_tids
+	test_failopen_on_gh_failure
+	test_bypass_env_var
+	test_skips_merge_commits
+	test_check_pr_mode
+
+	printf '\n'
+	printf 'Results: %s passed, %s failed\n' "$PASS" "$FAIL"
+	if [[ "$FAIL" -gt 0 ]]; then
+		printf '\nFailed tests:%b\n' "$ERRORS"
+		return 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/.github/workflows/task-id-collision-check.yml
+++ b/.github/workflows/task-id-collision-check.yml
@@ -1,0 +1,95 @@
+name: Task-ID Collision Check
+
+# Belt-and-braces server-side enforcement for the task-id-collision-guard hook.
+# Catches commits authored outside the hook (web UI, external contributors,
+# --no-verify bypasses) on push and pull_request events.
+#
+# The hook (client-side) and this workflow (server-side) implement the same
+# logic via task-id-collision-guard.sh check-pr <PR_NUMBER>.
+
+on:
+  push:
+    branches: [main, develop]
+    paths-ignore:
+      - 'TODO.md'
+      - 'todo/**'
+      - 'README.md'
+      - 'CHANGELOG.md'
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  task-id-collision-check:
+    name: Task-ID Collision Guard
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0  # Full history needed for merge-base detection
+
+      - name: Fetch main branch for merge-base comparison
+        run: |
+          git fetch origin main --depth=100 2>/dev/null || true
+          git fetch origin develop --depth=100 2>/dev/null || true
+
+      - name: Run task-id collision check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TASK_ID_GUARD_DEBUG: "0"
+        run: |
+          GUARD=".agents/hooks/task-id-collision-guard.sh"
+          if [[ ! -f "$GUARD" ]]; then
+            echo "[task-id-guard][WARN] Guard script not found at $GUARD — skipping"
+            exit 0
+          fi
+          chmod +x "$GUARD"
+
+          # Determine PR number (for check-pr mode) or use push range
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          if [[ -n "$PR_NUMBER" ]]; then
+            echo "Running check-pr for PR #${PR_NUMBER}"
+            bash "$GUARD" check-pr "$PR_NUMBER"
+          else
+            # Push event: check commits in the push range
+            BEFORE="${{ github.event.before }}"
+            AFTER="${{ github.event.after }}"
+            if [[ -z "$BEFORE" || "$BEFORE" == "0000000000000000000000000000000000000000" ]]; then
+              echo "New branch push — checking HEAD only"
+              MSG_FILE=$(mktemp)
+              git log -1 --format='%s%n%n%b' > "$MSG_FILE"
+              bash "$GUARD" "$MSG_FILE"
+              rm -f "$MSG_FILE"
+            else
+              echo "Push range: ${BEFORE}..${AFTER}"
+              violations=0
+              while IFS= read -r commit_hash; do
+                [[ -z "$commit_hash" ]] && continue
+                subject=$(git log -1 --format='%s' "$commit_hash")
+                # Skip merge commits
+                if echo "$subject" | grep -qE '^(Merge|fixup!|squash!)'; then
+                  continue
+                fi
+                MSG_FILE=$(mktemp)
+                git log -1 --format='%s%n%n%b' "$commit_hash" > "$MSG_FILE"
+                if ! bash "$GUARD" "$MSG_FILE" 2>&1; then
+                  echo "[task-id-guard][VIOLATION] commit $commit_hash: $subject"
+                  violations=$((violations + 1))
+                fi
+                rm -f "$MSG_FILE"
+              done < <(git rev-list "${BEFORE}..${AFTER}" 2>/dev/null)
+              if [[ "$violations" -gt 0 ]]; then
+                echo ""
+                echo "[task-id-guard][SUMMARY] $violations violation(s) found in push"
+                echo ""
+                echo "Fix: use claim-task-id.sh to allocate t-IDs before using them in commit subjects."
+                exit 1
+              fi
+              echo "[task-id-guard] Push clean — no invented t-IDs detected"
+            fi
+          fi

--- a/setup.sh
+++ b/setup.sh
@@ -90,6 +90,8 @@ if [[ -d "$SETUP_MODULES_DIR" ]]; then
 	# shellcheck disable=SC1091
 	source "$SETUP_MODULES_DIR/_privacy_guard.sh"
 	# shellcheck disable=SC1091
+	source "$SETUP_MODULES_DIR/_task_id_guard.sh"
+	# shellcheck disable=SC1091
 	source "$SETUP_MODULES_DIR/_canonical_guard.sh"
 fi
 
@@ -926,6 +928,11 @@ _setup_run_non_interactive() {
 	# directory are warned against (t1995). Complements pre-edit-check.sh's
 	# t1990 edit-time check by catching the branch switch itself.
 	setup_canonical_guard
+	# Install/refresh the task-id collision guard commit-msg hook in every
+	# initialized repo so invented t-IDs in commit subjects are rejected
+	# at commit time (t2047). Belt-and-braces with the CI check in
+	# .github/workflows/task-id-collision-check.yml.
+	setup_task_id_guard
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Implements the task-id collision guard as specified in #18624.

Prevents the failure mode where a human or agent writes a `tNNN` reference in a commit subject without first claiming the ID via `claim-task-id.sh`, causing audit-trail collisions (trigger: commit `469732b31` used `(t2046)` in its subject without claiming).

## Files changed

- **NEW** `.agents/hooks/task-id-collision-guard.sh` — commit-msg hook (also supports `check-pr <N>` CI mode)
- **NEW** `.agents/scripts/install-task-id-guard.sh` — per-repo installer mirroring `install-privacy-guard.sh`
- **NEW** `.agents/scripts/setup/_task_id_guard.sh` — `setup.sh` module for cross-repo auto-install
- **NEW** `.agents/scripts/tests/test-task-id-collision-guard.sh` — 7/7 test cases pass
- **NEW** `.github/workflows/task-id-collision-check.yml` — server-side belt-and-braces CI check
- **EDIT** `.agents/AGENTS.md` — one-line note in Git Workflow section
- **EDIT** `setup.sh` — calls `setup_task_id_guard()` automatically

## How it works

The guard extracts all `t\d+` references from the commit subject+body. For each:

1. If `numeric_id ≤ .task-counter at merge-base` → allowed (claimed)
2. If `numeric_id > counter` AND linked issue title (via Resolves/Closes/Fixes #NNN) contains the t-ID → allowed (cross-reference confirmed)
3. Otherwise → **rejected** with actionable error message

Fail-open on offline/unauthenticated `gh` or missing `.task-counter` — CI catches on push.

## Verification

```
# Test harness: 7/7 pass
bash .agents/scripts/tests/test-task-id-collision-guard.sh

# Positive case (reject): exit 1
echo "feat(foo): bar (t99999)" | bash .agents/hooks/task-id-collision-guard.sh /dev/stdin

# Negative case (allow): exit 0
echo "feat(foo): bar (t2047)" | bash .agents/hooks/task-id-collision-guard.sh /dev/stdin

# ShellCheck clean on all new scripts
shellcheck .agents/hooks/task-id-collision-guard.sh
shellcheck .agents/scripts/install-task-id-guard.sh
```

## Dogfood check

This PR's commit subject is `feat(t2047): add task-id collision guard commit-msg hook + CI check`. t2047 is ≤ the current `.task-counter` (2049) — passes the guard.

Resolves #18624