### PR TITLE
t2046: parent-task lifecycle hardening — fail-closed guard + PR keyword guard

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -187,6 +187,8 @@ Worktrees: `wt switch -c {type}/{name}`. Keep the canonical repo directory on `m
 
 **Traceability and signature footer:** Hard rules in `prompts/build.txt` (sections "Traceability" and "#8 Signature footer"). Link both sides when closing (issue→PR, PR→issue). Do NOT pass `--issue` when creating new issues (the issue doesn't exist yet). See `scripts/commands/pulse.md` for dispatch/kill/merge comment templates.
 
+**Parent-task PR keyword rule (t2046 — MANDATORY).** When a PR delivers ANY work for a `parent-task`-labeled issue — including the initial plan-filing PR — use `For #NNN` or `Ref #NNN` in the PR body, NEVER `Closes`/`Resolves`/`Fixes`. The parent issue must stay open until ALL phase children merge; only the final phase PR uses `Closes #NNN`. `full-loop-helper.sh commit-and-pr` enforces this automatically (see `.github/workflows/parent-task-keyword-check.yml`). For leaf (non-parent) issues, use `Resolves #NNN` as normal. See `templates/brief-template.md` "PR Conventions" for the full rule.
+
 **Self-improvement routing (t1541):** Framework-level tasks → `framework-routing-helper.sh log-framework-issue`. Project tasks → current repo. Framework tasks in project repos are invisible to maintainers.
 
 **Pulse scope (t1405):** `PULSE_SCOPE_REPOS` limits code changes. Issues allowed anywhere. Empty/unset = no restriction.

--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -1021,9 +1021,24 @@ _has_active_claim() {
 #   $2 = repo slug (owner/repo)
 #   $3 = (optional) current runner login — if assigned to self, not a dup
 # Returns:
-#   exit 0 if assigned to another login (do NOT dispatch)
+#   exit 0 if assigned to another login (do NOT dispatch), parent-task labeled,
+#          cost-budget exceeded, or guard cannot determine safety (GUARD_UNCERTAIN)
 #   exit 1 if unassigned or assigned only to self (safe to dispatch)
-# Outputs: assignee info on stdout if assigned to another login
+# Outputs: one of the following signals on stdout when blocking:
+#   PARENT_TASK_BLOCKED (label=<name>) — unconditional parent-task block
+#   COST_BUDGET_EXCEEDED (...)         — token spend circuit breaker
+#   GUARD_UNCERTAIN (reason=...)       — internal error, cannot determine safety
+#   <assignee info>                    — active claim by another runner
+#
+# FAIL-CLOSED CONTRACT (t2046):
+#   When the guard cannot determine whether dispatch is safe due to an internal
+#   error (gh API failure, jq error, helper failure), the function MUST block
+#   dispatch and emit GUARD_UNCERTAIN. This is intentionally conservative:
+#   a transient block clears in the next pulse cycle at zero cost; a wasted
+#   worker dispatch burns ~20K tokens for zero output (GH#18458 incident).
+#   The previous default (fail-open) allowed three workers to be dispatched
+#   to a parent-task issue because a jq null-handling bug silently fell through
+#   to the "allow dispatch" code path (see plan in todo/plans/parent-task-incident-hardening.md).
 #######################################
 is_assigned() {
 	local issue_number="$1"
@@ -1040,12 +1055,18 @@ is_assigned() {
 		return 1
 	fi
 
-	local issue_meta_json
+	local issue_meta_json gh_rc=0
 	issue_meta_json=$(gh issue view "$issue_number" --repo "$repo_slug" \
-		--json state,assignees,labels 2>/dev/null) || issue_meta_json=""
+		--json state,assignees,labels 2>/dev/null) || gh_rc=$?
 
-	if [[ -z "$issue_meta_json" ]]; then
-		return 1
+	# t2046: fail-closed on gh API failure. When we cannot fetch issue metadata
+	# (network error, auth failure, rate limit, issue not found), we cannot
+	# determine whether dispatch is safe. Block and emit GUARD_UNCERTAIN so the
+	# pulse skips this cycle rather than dispatching blindly.
+	if [[ "$gh_rc" -ne 0 || -z "$issue_meta_json" ]]; then
+		printf 'GUARD_UNCERTAIN (reason=gh-api-failure issue=%s repo=%s rc=%s)\n' \
+			"$issue_number" "$repo_slug" "$gh_rc"
+		return 0
 	fi
 
 	# t1986: parent-task / meta label is an unconditional dispatch block.

--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -506,8 +506,9 @@ cmd_pre_merge_gate() {
 # Collapses full-loop steps 4.1-4.2.1 into a single deterministic call.
 # Workers and interactive sessions both use this — no parallel logic.
 #
-# Usage: full-loop-helper.sh commit-and-pr --issue <N> --message <msg> [--title <title>] [--summary <what>] [--testing <how>] [--decisions <notes>] [--label <label>...]
+# Usage: full-loop-helper.sh commit-and-pr --issue <N> --message <msg> [--title <title>] [--summary <what>] [--testing <how>] [--decisions <notes>] [--label <label>...] [--allow-parent-close]
 # Exit codes: 0 = PR created (prints PR number to stdout), 1 = failure
+# --allow-parent-close: skip the parent-task keyword guard (final-phase PR only)
 #
 # On rebase conflict: returns 1 with instructions. Caller must resolve and retry.
 # On push failure: returns 1. Caller should check remote state.
@@ -548,6 +549,10 @@ _parse_commit_and_pr_args() {
 		--label)
 			extra_labels+=("$2")
 			shift 2
+			;;
+		--allow-parent-close)
+			allow_parent_close=1
+			shift
 			;;
 		*)
 			print_error "Unknown argument: $1"
@@ -807,6 +812,7 @@ _label_issue_in_review() {
 cmd_commit_and_pr() {
 	local issue_number="" commit_message="" pr_title="" summary_what="" summary_testing="" summary_decisions=""
 	local -a extra_labels=()
+	local allow_parent_close=0
 
 	_parse_commit_and_pr_args "$@" || return 1
 
@@ -838,6 +844,26 @@ cmd_commit_and_pr() {
 
 	local pr_body=""
 	pr_body=$(_build_pr_body "$issue_number" "$summary_what" "$summary_testing" "$files_changed" "$sig_footer")
+
+	# t2046: parent-task keyword guard — prevent Resolves/Closes/Fixes on
+	# parent-task issues. The parent must stay open until all phase children merge.
+	# Runs in --strict mode (exit 2 = abort PR creation). Pass --allow-parent-close
+	# for the legitimate final-phase PR that intentionally closes the parent tracker.
+	local keyword_guard="${SCRIPT_DIR}/parent-task-keyword-guard.sh"
+	if [[ -x "$keyword_guard" ]]; then
+		local tmp_pr_body
+		tmp_pr_body=$(mktemp)
+		printf '%s\n' "$pr_body" >"$tmp_pr_body"
+		local guard_args=("check-body" "--body-file" "$tmp_pr_body" "--repo" "$repo" "--strict")
+		[[ "$allow_parent_close" -eq 1 ]] && guard_args+=("--allow-parent-close")
+		local guard_rc=0
+		"$keyword_guard" "${guard_args[@]}" 2>&1 >&2 || guard_rc=$?
+		rm -f "$tmp_pr_body"
+		if [[ "$guard_rc" -eq 2 ]]; then
+			print_error "Aborting PR creation: parent-task keyword violation (t2046). See error above."
+			return 1
+		fi
+	fi
 
 	# t1955: Validate dispatch claim before creating PR. In headless mode,
 	# abort if this worker was stale-recovered and replaced by another runner.

--- a/.agents/scripts/parent-task-keyword-guard.sh
+++ b/.agents/scripts/parent-task-keyword-guard.sh
@@ -1,0 +1,321 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# parent-task-keyword-guard.sh — t2046 PR keyword guard for parent-task issues
+# =============================================================================
+#
+# Prevents the auto-close trap: PR bodies using Resolves/Closes/Fixes on a
+# parent-task-labeled issue cause GitHub to auto-close the parent on merge,
+# requiring manual reopen (incident: PR #18581 → GH#18458 closed prematurely).
+#
+# Parent issues must stay open until ALL phase children merge. PR bodies for
+# parent-task work MUST use `For #NNN` or `Ref #NNN`, not closing keywords.
+#
+# Usage:
+#   parent-task-keyword-guard.sh check-body --body-file PATH --repo OWNER/REPO [--strict] [--allow-parent-close]
+#   parent-task-keyword-guard.sh check-pr <PR_NUMBER> --repo OWNER/REPO [--strict] [--allow-parent-close]
+#   parent-task-keyword-guard.sh help
+#
+# Exit codes:
+#   0 — no violations (clean or --allow-parent-close set)
+#   1 — warning: closing keyword references a parent-task issue (non-strict mode)
+#   2 — block: closing keyword references a parent-task issue (--strict mode)
+#
+# The `--strict` flag is used by `full-loop-helper.sh commit-and-pr` to abort
+# PR creation before the PR is submitted. Use `--allow-parent-close` only for
+# the legitimate final-phase PR that intentionally closes the parent tracker.
+#
+# Non-strict mode (default): prints a warning and exits 1, but does not abort.
+# Strict mode: prints an error and exits 2, intended to abort the caller.
+#
+# gh API failures during label lookup: fail-open (emit warning, exit 0).
+# The CI workflow provides belt-and-braces for cases where the client-side
+# check is skipped or gh is unavailable.
+#
+# See also:
+#   .github/workflows/parent-task-keyword-check.yml — CI equivalent
+#   .agents/AGENTS.md "Parent-task PR keyword rule"
+#   templates/brief-template.md "PR Conventions"
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit
+
+# Regex that matches GitHub closing keywords followed by an issue reference.
+# Matches:
+#   Closes #123
+#   Resolves #123
+#   Fixes #123
+#   closes owner/repo#123
+#   RESOLVES #123
+#   (with optional leading whitespace or markdown bullet prefix)
+# Does NOT match: "For #123", "Ref #123", "relates to #123"
+_CLOSE_KEYWORD_PATTERN='[Cc][Ll][Oo][Ss][Ee][Ss]|[Rr][Ee][Ss][Oo][Ll][Vv][Ee][Ss]|[Ff][Ii][Xx][Ee][Ss]'
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+# _extract_closing_refs: parse a PR body (stdin) and output one issue number
+# per line for each closing-keyword reference found.
+# Handles both `#NNN` and `OWNER/REPO#NNN` formats.
+_extract_closing_refs() {
+	# Use grep + sed for Bash 3.2 compat (no perl regex in bash natively).
+	# Pattern: keyword (space or nothing) (#NNN or owner/repo#NNN)
+	grep -oiE "(Closes|Resolves|Fixes)[[:space:]]+(([a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+)?#[0-9]+)" |
+		grep -oE '#[0-9]+' |
+		tr -d '#' |
+		sort -un
+	return 0
+}
+
+# _is_parent_task: check if a given issue number has the parent-task label.
+# Args: $1=issue_number $2=repo_slug
+# Returns: 0 if parent-task label present, 1 if not, 2 on gh failure
+_is_parent_task() {
+	local issue_number="$1"
+	local repo_slug="$2"
+
+	local labels_json gh_rc=0
+	labels_json=$(gh issue view "$issue_number" --repo "$repo_slug" \
+		--json labels 2>/dev/null) || gh_rc=$?
+
+	if [[ "$gh_rc" -ne 0 || -z "$labels_json" ]]; then
+		# gh API failure — cannot determine. Return 2 (uncertain).
+		return 2
+	fi
+
+	local hit
+	hit=$(printf '%s' "$labels_json" |
+		jq -r '(.labels // [])[].name | select(. == "parent-task" or . == "meta")' | head -n 1 || true)
+
+	if [[ -n "$hit" ]]; then
+		return 0
+	fi
+	return 1
+}
+
+# =============================================================================
+# check-body subcommand
+# =============================================================================
+cmd_check_body() {
+	local body_file="" repo="" strict=0 allow_parent_close=0
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--body-file)
+			body_file="${2:-}"
+			shift 2
+			;;
+		--repo)
+			repo="${2:-}"
+			shift 2
+			;;
+		--strict)
+			strict=1
+			shift
+			;;
+		--allow-parent-close)
+			allow_parent_close=1
+			shift
+			;;
+		*)
+			echo "Error: Unknown argument: $1" >&2
+			return 1
+			;;
+		esac
+	done
+
+	if [[ -z "$body_file" || -z "$repo" ]]; then
+		echo "Error: --body-file and --repo are required" >&2
+		return 1
+	fi
+
+	if [[ ! -f "$body_file" ]]; then
+		echo "Error: body file not found: $body_file" >&2
+		return 1
+	fi
+
+	if [[ "$allow_parent_close" -eq 1 ]]; then
+		# Explicit opt-out — skip check entirely (final-phase PR exemption)
+		echo "parent-task-keyword-guard: --allow-parent-close set, skipping check" >&2
+		return 0
+	fi
+
+	local -a violations=()
+	local -a uncertain=()
+	local issue_num
+
+	while IFS= read -r issue_num; do
+		[[ -z "$issue_num" ]] && continue
+		local pt_rc=0
+		_is_parent_task "$issue_num" "$repo" || pt_rc=$?
+		case "$pt_rc" in
+		0)
+			violations+=("$issue_num")
+			;;
+		2)
+			uncertain+=("$issue_num")
+			;;
+		*)
+			# Not a parent-task issue — clean
+			;;
+		esac
+	done < <(_extract_closing_refs <"$body_file")
+
+	# Report uncertain lookups (gh failure) — warn only, don't block
+	local unc
+	for unc in "${uncertain[@]+"${uncertain[@]}"}"; do
+		printf 'parent-task-keyword-guard: WARNING: could not check labels for #%s (gh API failure); skipping\n' \
+			"$unc" >&2
+	done
+
+	if [[ "${#violations[@]}" -eq 0 ]]; then
+		return 0
+	fi
+
+	# Violations found
+	local viol
+	for viol in "${violations[@]}"; do
+		if [[ "$strict" -eq 1 ]]; then
+			printf 'parent-task-keyword-guard: ERROR: PR body uses Closes/Resolves/Fixes on parent-task issue #%s.\n' \
+				"$viol" >&2
+			printf 'parent-task-keyword-guard: Use "For #%s" or "Ref #%s" instead.\n' \
+				"$viol" "$viol" >&2
+			printf 'parent-task-keyword-guard: The parent issue must stay open until ALL phase children merge.\n' >&2
+			printf 'parent-task-keyword-guard: To override (final-phase PR only): pass --allow-parent-close\n' >&2
+		else
+			printf 'parent-task-keyword-guard: WARNING: PR body uses Closes/Resolves/Fixes on parent-task issue #%s.\n' \
+				"$viol" >&2
+			printf 'parent-task-keyword-guard: Consider using "For #%s" or "Ref #%s" to keep the parent open.\n' \
+				"$viol" "$viol" >&2
+		fi
+	done
+
+	if [[ "$strict" -eq 1 ]]; then
+		return 2
+	fi
+	return 1
+}
+
+# =============================================================================
+# check-pr subcommand
+# =============================================================================
+cmd_check_pr() {
+	local pr_number="${1:-}"
+	if [[ -z "$pr_number" ]]; then
+		echo "Error: Usage: parent-task-keyword-guard.sh check-pr <PR_NUMBER> --repo OWNER/REPO [--strict] [--allow-parent-close]" >&2
+		return 1
+	fi
+	shift
+
+	local repo="" strict=0 allow_parent_close=0
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--repo)
+			repo="${2:-}"
+			shift 2
+			;;
+		--strict)
+			strict=1
+			shift
+			;;
+		--allow-parent-close)
+			allow_parent_close=1
+			shift
+			;;
+		*)
+			echo "Error: Unknown argument: $1" >&2
+			return 1
+			;;
+		esac
+	done
+
+	if [[ -z "$repo" ]]; then
+		echo "Error: --repo is required" >&2
+		return 1
+	fi
+
+	# Fetch PR body
+	local pr_body gh_rc=0
+	pr_body=$(gh pr view "$pr_number" --repo "$repo" --json body --jq '.body' 2>/dev/null) || gh_rc=$?
+
+	if [[ "$gh_rc" -ne 0 || -z "$pr_body" ]]; then
+		printf 'parent-task-keyword-guard: WARNING: could not fetch PR #%s body (gh rc=%s); skipping check\n' \
+			"$pr_number" "$gh_rc" >&2
+		return 0
+	fi
+
+	# Write to a temp file and delegate to check-body
+	local tmp_body
+	tmp_body=$(mktemp)
+	trap 'rm -f "$tmp_body"' EXIT
+	printf '%s\n' "$pr_body" >"$tmp_body"
+
+	local check_args=("--body-file" "$tmp_body" "--repo" "$repo")
+	[[ "$strict" -eq 1 ]] && check_args+=("--strict")
+	[[ "$allow_parent_close" -eq 1 ]] && check_args+=("--allow-parent-close")
+
+	local check_rc=0
+	cmd_check_body "${check_args[@]}" || check_rc=$?
+	return "$check_rc"
+}
+
+# =============================================================================
+# show_help
+# =============================================================================
+show_help() {
+	cat <<'EOF'
+parent-task-keyword-guard.sh — PR body keyword guard for parent-task issues
+
+Prevents closing keywords (Closes/Resolves/Fixes) from auto-closing parent-task
+issues on PR merge. Parent issues must stay open until ALL phase children merge.
+
+Usage:
+  parent-task-keyword-guard.sh check-body --body-file PATH --repo OWNER/REPO [--strict] [--allow-parent-close]
+  parent-task-keyword-guard.sh check-pr <PR_NUMBER> --repo OWNER/REPO [--strict] [--allow-parent-close]
+  parent-task-keyword-guard.sh help
+
+Exit codes:
+  0 — clean (no violations)
+  1 — warning: closing keyword on parent-task issue (non-strict mode)
+  2 — block: closing keyword on parent-task issue (--strict mode, used by full-loop-helper.sh)
+
+Flags:
+  --strict             Treat violations as errors (exit 2). Used by commit-and-pr.
+  --allow-parent-close Skip the check (final-phase PR exemption only).
+
+Examples:
+  # Check a PR body file before creating the PR
+  parent-task-keyword-guard.sh check-body --body-file /tmp/pr-body.md --repo owner/repo --strict
+
+  # Check an existing PR (CI usage)
+  parent-task-keyword-guard.sh check-pr 12345 --repo owner/repo --strict
+
+  # Final-phase PR that intentionally closes the parent
+  parent-task-keyword-guard.sh check-body --body-file body.md --repo owner/repo --strict --allow-parent-close
+EOF
+	return 0
+}
+
+# =============================================================================
+# main
+# =============================================================================
+main() {
+	local command="${1:-help}"
+	shift || true
+
+	case "$command" in
+	check-body) cmd_check_body "$@" ;;
+	check-pr) cmd_check_pr "$@" ;;
+	help | --help | -h) show_help ;;
+	*)
+		echo "Error: Unknown command: $command" >&2
+		show_help >&2
+		return 1
+		;;
+	esac
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-dispatch-dedup-fail-closed.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-fail-closed.sh
@@ -1,0 +1,174 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-dispatch-dedup-fail-closed.sh — t2046 fail-closed guard regression.
+#
+# Asserts that is_assigned() blocks dispatch (exit 0 + GUARD_UNCERTAIN signal)
+# when the gh API call fails internally, rather than silently allowing dispatch
+# (the previous fail-open default that allowed three workers to be dispatched
+# to a parent-task issue during the t2010 / GH#18458 incident).
+#
+# Test cases (Plan §2.4 of todo/plans/parent-task-incident-hardening.md):
+#   Case 1: gh exits non-zero (command failure)       → GUARD_UNCERTAIN, exit 0 (block)
+#   Case 2: gh exits 0 but returns empty string       → GUARD_UNCERTAIN, exit 0 (block)
+#   Case 3: well-formed parent-task labels            → PARENT_TASK_BLOCKED, exit 0 (block)
+#   Case 4: clean dispatchable issue                  → exit 1 (allow dispatch)
+#
+# Companion to test-parent-task-guard.sh (t1986, GH#18537).
+# Model: same fixture + stub pattern as test-parent-task-guard.sh Parts 3+.
+
+# NOTE: not using `set -e` intentionally — negative assertions rely on
+# capturing non-zero exits. Each assertion explicitly captures exit codes.
+# NOTE: SCRIPT_DIR is NOT readonly — collision avoidance (see test-parent-task-guard.sh).
+set -uo pipefail
+
+TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_RED=$'\033[0;31m'
+TEST_GREEN=$'\033[0;32m'
+TEST_RESET=$'\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1" rc="$2" extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf '%sPASS%s %s\n' "$TEST_GREEN" "$TEST_RESET" "$name"
+	else
+		printf '%sFAIL%s %s %s\n' "$TEST_RED" "$TEST_RESET" "$name" "$extra"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+}
+
+# Sandbox HOME so sourcing is side-effect-free
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+export HOME="${TEST_ROOT}/home"
+mkdir -p "${HOME}/.aidevops/logs" "${HOME}/.aidevops/.agent-workspace/supervisor"
+
+# =============================================================================
+# Stub infrastructure — same pattern as test-parent-task-guard.sh
+# =============================================================================
+STUB_DIR="${TEST_ROOT}/bin"
+mkdir -p "$STUB_DIR"
+
+# write_stub_gh_success: stub gh that exits 0 and returns a given JSON payload.
+write_stub_gh_success() {
+	local payload="$1"
+	cat >"${STUB_DIR}/gh" <<STUB
+#!/usr/bin/env bash
+# Stub for test-dispatch-dedup-fail-closed.sh — exits 0, returns payload
+if [[ "\$1" == "issue" && "\$2" == "view" ]]; then
+	printf '%s\n' '${payload}'
+	exit 0
+fi
+exit 1
+STUB
+	chmod +x "${STUB_DIR}/gh"
+}
+
+# write_stub_gh_fail: stub gh that exits with a given non-zero code.
+write_stub_gh_fail() {
+	local exit_code="${1:-1}"
+	cat >"${STUB_DIR}/gh" <<STUB
+#!/usr/bin/env bash
+# Stub for test-dispatch-dedup-fail-closed.sh — exits ${exit_code} (failure)
+exit ${exit_code}
+STUB
+	chmod +x "${STUB_DIR}/gh"
+}
+
+# write_stub_gh_empty: stub gh that exits 0 but returns empty output.
+write_stub_gh_empty() {
+	cat >"${STUB_DIR}/gh" <<'STUB'
+#!/usr/bin/env bash
+# Stub for test-dispatch-dedup-fail-closed.sh — exits 0, returns empty string
+if [[ "$1" == "issue" && "$2" == "view" ]]; then
+	printf ''
+	exit 0
+fi
+exit 1
+STUB
+	chmod +x "${STUB_DIR}/gh"
+}
+
+OLD_PATH="$PATH"
+export PATH="${STUB_DIR}:${PATH}"
+
+# run_is_assigned: invokes dispatch-dedup-helper.sh is-assigned, captures
+# both stdout (output) and exit code (rc).
+run_is_assigned() {
+	local issue="$1" repo="$2" self="${3:-}"
+	output=$("${TEST_SCRIPTS_DIR}/dispatch-dedup-helper.sh" is-assigned "$issue" "$repo" "$self" 2>/dev/null)
+	rc=$?
+	return 0
+}
+
+# =============================================================================
+# Case 1 — gh exits non-zero → GUARD_UNCERTAIN, exit 0 (block)
+# =============================================================================
+# Simulates: network error, auth failure, rate limit, issue not found
+write_stub_gh_fail 1
+run_is_assigned 99990 "owner/repo"
+if [[ "$rc" -eq 0 && "$output" == *"GUARD_UNCERTAIN"* && "$output" == *"gh-api-failure"* ]]; then
+	print_result "fail-closed: gh exit non-zero → GUARD_UNCERTAIN, exit 0 (block)" 0
+else
+	print_result "fail-closed: gh exit non-zero → GUARD_UNCERTAIN, exit 0 (block)" 1 \
+		"(rc=$rc output='$output')"
+fi
+
+# =============================================================================
+# Case 2 — gh exits 0 but returns empty string → GUARD_UNCERTAIN, exit 0 (block)
+# =============================================================================
+# Simulates: gh bug returning empty body on success — previously allowed dispatch
+write_stub_gh_empty
+run_is_assigned 99991 "owner/repo"
+if [[ "$rc" -eq 0 && "$output" == *"GUARD_UNCERTAIN"* ]]; then
+	print_result "fail-closed: gh empty response → GUARD_UNCERTAIN, exit 0 (block)" 0
+else
+	print_result "fail-closed: gh empty response → GUARD_UNCERTAIN, exit 0 (block)" 1 \
+		"(rc=$rc output='$output')"
+fi
+
+# =============================================================================
+# Case 3 — well-formed parent-task issue → PARENT_TASK_BLOCKED, exit 0
+# =============================================================================
+# Verifies that the existing parent-task guard still fires when gh succeeds.
+write_stub_gh_success '{"state":"OPEN","assignees":[],"labels":[{"name":"parent-task"},{"name":"pulse"}]}'
+run_is_assigned 99992 "owner/repo"
+if [[ "$rc" -eq 0 && "$output" == *"PARENT_TASK_BLOCKED"* && "$output" == *"parent-task"* ]]; then
+	print_result "fail-closed: parent-task label → PARENT_TASK_BLOCKED preserved" 0
+else
+	print_result "fail-closed: parent-task label → PARENT_TASK_BLOCKED preserved" 1 \
+		"(rc=$rc output='$output')"
+fi
+
+# =============================================================================
+# Case 4 — clean dispatchable issue → exit 1 (allow dispatch)
+# =============================================================================
+# Verifies that normal issues (no parent-task, no blocking assignees) are
+# not affected by the fail-closed change — the happy path must still work.
+write_stub_gh_success '{"state":"OPEN","assignees":[],"labels":[{"name":"pulse"},{"name":"tier:standard"}]}'
+run_is_assigned 99993 "owner/repo"
+if [[ "$rc" -eq 1 && "$output" != *"GUARD_UNCERTAIN"* && "$output" != *"PARENT_TASK_BLOCKED"* ]]; then
+	print_result "fail-closed: clean issue → exit 1 (allow dispatch, happy path unaffected)" 0
+else
+	print_result "fail-closed: clean issue → exit 1 (allow dispatch, happy path unaffected)" 1 \
+		"(rc=$rc output='$output')"
+fi
+
+export PATH="$OLD_PATH"
+
+# =============================================================================
+# Summary
+# =============================================================================
+echo
+if [[ "$TESTS_FAILED" -eq 0 ]]; then
+	printf '%sAll %d tests passed%s\n' "$TEST_GREEN" "$TESTS_RUN" "$TEST_RESET"
+	exit 0
+else
+	printf '%s%d / %d tests failed%s\n' "$TEST_RED" "$TESTS_FAILED" "$TESTS_RUN" "$TEST_RESET"
+	exit 1
+fi

--- a/.agents/scripts/tests/test-parent-task-keyword-guard.sh
+++ b/.agents/scripts/tests/test-parent-task-keyword-guard.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-parent-task-keyword-guard.sh — t2046 PR keyword guard regression tests.
+#
+# Asserts that parent-task-keyword-guard.sh check-body correctly:
+#   - Blocks (exit 2) PRs with Resolves/Closes/Fixes on parent-task issues (--strict)
+#   - Allows (exit 0) PRs with For/Ref on parent-task issues
+#   - Allows (exit 0) PRs with Resolves on a normal leaf issue
+#   - Allows (exit 0) PRs with no closing keywords
+#   - Allows (exit 0) with --allow-parent-close even when closing keyword used
+#
+# Test cases from Plan §3.3.2 closing list in
+# todo/plans/parent-task-incident-hardening.md:
+#   Case 1: parent issue + Resolves → block (strict), warn (non-strict)
+#   Case 2: parent issue + For      → allow
+#   Case 3: leaf issue  + Resolves  → allow
+#   Case 4: no closing keyword      → allow
+#   Case 5: parent + Closes + --allow-parent-close → allow (final-phase exemption)
+
+# NOTE: not using `set -e` — negative assertions rely on non-zero exits.
+# NOTE: SCRIPT_DIR is NOT readonly — collision avoidance.
+set -uo pipefail
+
+TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_RED=$'\033[0;31m'
+TEST_GREEN=$'\033[0;32m'
+TEST_RESET=$'\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1" rc="$2" extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf '%sPASS%s %s\n' "$TEST_GREEN" "$TEST_RESET" "$name"
+	else
+		printf '%sFAIL%s %s %s\n' "$TEST_RED" "$TEST_RESET" "$name" "$extra"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+}
+
+# Sandbox HOME
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+export HOME="${TEST_ROOT}/home"
+mkdir -p "${HOME}/.aidevops/logs"
+
+# =============================================================================
+# Stub infrastructure
+# =============================================================================
+STUB_DIR="${TEST_ROOT}/bin"
+mkdir -p "$STUB_DIR"
+
+# write_stub_gh_parent: stub gh that returns parent-task label for a given issue.
+write_stub_gh_parent() {
+	local parent_issue="$1"
+	cat >"${STUB_DIR}/gh" <<STUB
+#!/usr/bin/env bash
+# Stub: returns parent-task labels for issue ${parent_issue}
+if [[ "\$1" == "issue" && "\$2" == "view" && "\$3" == "${parent_issue}" ]]; then
+	printf '{"labels":[{"name":"parent-task"},{"name":"pulse"}]}\n'
+	exit 0
+fi
+# All other issues are leaf issues (no parent-task label)
+if [[ "\$1" == "issue" && "\$2" == "view" ]]; then
+	printf '{"labels":[{"name":"pulse"},{"name":"tier:standard"}]}\n'
+	exit 0
+fi
+exit 1
+STUB
+	chmod +x "${STUB_DIR}/gh"
+}
+
+# write_stub_gh_leaf: stub gh that never returns parent-task label.
+write_stub_gh_leaf() {
+	cat >"${STUB_DIR}/gh" <<'STUB'
+#!/usr/bin/env bash
+# Stub: all issues are leaf (no parent-task label)
+if [[ "$1" == "issue" && "$2" == "view" ]]; then
+	printf '{"labels":[{"name":"pulse"},{"name":"tier:standard"}]}\n'
+	exit 0
+fi
+exit 1
+STUB
+	chmod +x "${STUB_DIR}/gh"
+}
+
+OLD_PATH="$PATH"
+export PATH="${STUB_DIR}:${PATH}"
+
+GUARD="${TEST_SCRIPTS_DIR}/parent-task-keyword-guard.sh"
+
+# run_check_body: runs check-body with a given PR body string and arguments.
+# Sets $guard_rc and $guard_output.
+run_check_body() {
+	local body="$1"
+	shift
+	local tmp_body
+	tmp_body=$(mktemp)
+	printf '%s\n' "$body" >"$tmp_body"
+	guard_output=$("$GUARD" check-body --body-file "$tmp_body" --repo "owner/repo" "$@" 2>&1)
+	guard_rc=$?
+	rm -f "$tmp_body"
+	return 0
+}
+
+# =============================================================================
+# Case 1 — parent issue + Resolves → block (exit 2 in --strict mode)
+# =============================================================================
+# Issue #18458 is the parent fixture (matches incident from plan §3.1)
+write_stub_gh_parent "18458"
+run_check_body "Resolves #18458
+
+This PR files the Phase 0 plan." --strict
+
+if [[ "$guard_rc" -eq 2 ]]; then
+	print_result "Resolves on parent-task issue (--strict) → exit 2 (block)" 0
+else
+	print_result "Resolves on parent-task issue (--strict) → exit 2 (block)" 1 \
+		"(rc=$guard_rc output='$guard_output')"
+fi
+
+# Same scenario without --strict should warn (exit 1) but not block (exit 2)
+write_stub_gh_parent "18458"
+run_check_body "Resolves #18458
+
+This PR files the Phase 0 plan."
+
+if [[ "$guard_rc" -eq 1 ]]; then
+	print_result "Resolves on parent-task issue (non-strict) → exit 1 (warn, not block)" 0
+else
+	print_result "Resolves on parent-task issue (non-strict) → exit 1 (warn, not block)" 1 \
+		"(rc=$guard_rc output='$guard_output')"
+fi
+
+# =============================================================================
+# Case 2 — parent issue + For #NNN → allow (exit 0)
+# =============================================================================
+write_stub_gh_parent "18458"
+run_check_body "For #18458
+
+This PR files the Phase 0 plan." --strict
+
+if [[ "$guard_rc" -eq 0 ]]; then
+	print_result "For on parent-task issue → exit 0 (allow)" 0
+else
+	print_result "For on parent-task issue → exit 0 (allow)" 1 \
+		"(rc=$guard_rc output='$guard_output')"
+fi
+
+# =============================================================================
+# Case 3 — leaf issue + Resolves → allow (exit 0)
+# =============================================================================
+write_stub_gh_leaf
+run_check_body "Resolves #99999
+
+Implements the feature." --strict
+
+if [[ "$guard_rc" -eq 0 ]]; then
+	print_result "Resolves on leaf issue → exit 0 (allow, not a parent-task)" 0
+else
+	print_result "Resolves on leaf issue → exit 0 (allow, not a parent-task)" 1 \
+		"(rc=$guard_rc output='$guard_output')"
+fi
+
+# =============================================================================
+# Case 4 — no closing keyword → allow (exit 0)
+# =============================================================================
+write_stub_gh_parent "18458"
+run_check_body "For #18458
+
+Related work in PR #18579.
+See also: issue #18400" --strict
+
+if [[ "$guard_rc" -eq 0 ]]; then
+	print_result "No closing keyword (only For/Ref) → exit 0 (allow)" 0
+else
+	print_result "No closing keyword (only For/Ref) → exit 0 (allow)" 1 \
+		"(rc=$guard_rc output='$guard_output')"
+fi
+
+# =============================================================================
+# Case 5 — parent + Closes + --allow-parent-close → allow (exit 0)
+# =============================================================================
+# Final-phase PR exemption: the last child merges and intentionally closes parent.
+write_stub_gh_parent "18458"
+run_check_body "Closes #18458
+
+This is the final phase PR — all children have merged." --strict --allow-parent-close
+
+if [[ "$guard_rc" -eq 0 ]]; then
+	print_result "Closes on parent + --allow-parent-close → exit 0 (final-phase exemption)" 0
+else
+	print_result "Closes on parent + --allow-parent-close → exit 0 (final-phase exemption)" 1 \
+		"(rc=$guard_rc output='$guard_output')"
+fi
+
+export PATH="$OLD_PATH"
+
+# =============================================================================
+# Summary
+# =============================================================================
+echo
+if [[ "$TESTS_FAILED" -eq 0 ]]; then
+	printf '%sAll %d tests passed%s\n' "$TEST_GREEN" "$TESTS_RUN" "$TEST_RESET"
+	exit 0
+else
+	printf '%s%d / %d tests failed%s\n' "$TEST_RED" "$TESTS_FAILED" "$TESTS_RUN" "$TEST_RESET"
+	exit 1
+fi

--- a/.agents/templates/brief-template.md
+++ b/.agents/templates/brief-template.md
@@ -48,6 +48,26 @@ All checked = `tier:simple`. Any unchecked = `tier:standard` (default) or `tier:
 drove the decision. e.g., "6 files across 3 packages, fallback retry logic needed -> tier:standard"
 or "Single-file config edit with exact code block provided -> tier:simple"}
 
+## PR Conventions
+
+<!-- PR KEYWORD RULE (t2046 — MANDATORY for parent-task issues):
+
+     **Parent-task PRs.** When a PR delivers ANY work for an issue tagged `parent-task`
+     — including the initial plan-filing PR — the PR body MUST use `For #NNN` or
+     `Ref #NNN`, NEVER `Closes`/`Resolves`/`Fixes`. The parent issue must stay open
+     until ALL phase children merge. The final phase PR uses `Closes #NNN` to close
+     the parent. `full-loop-helper.sh commit-and-pr` enforces this in --strict mode
+     (aborts if the PR body uses a closing keyword on a parent-task issue).
+     CI also checks via `.github/workflows/parent-task-keyword-check.yml`.
+
+     If you wrote `Resolves` and the parent auto-closed, reopen it manually with
+     a comment explaining the convention.
+
+     Leaf (non-parent) issue PRs: use `Resolves #NNN` or `Closes #NNN` as normal. -->
+
+{If this task is for a `parent-task`-labeled issue, confirm: PR body will use `For #NNN`, not `Resolves`.}
+{If leaf task: use `Resolves #NNN` as normal — delete this section or leave it blank.}
+
 ## How (Approach)
 
 <!-- Worker-ready implementation context (t1900): every section below is required

--- a/.github/workflows/parent-task-keyword-check.yml
+++ b/.github/workflows/parent-task-keyword-check.yml
@@ -1,0 +1,70 @@
+name: Parent-Task Keyword Check
+
+# Belt-and-braces guard for the parent-task PR keyword rule (t2046).
+#
+# Prevents PRs from using Resolves/Closes/Fixes on parent-task-labeled issues,
+# which would auto-close the parent tracker on merge (incident: PR #18581).
+#
+# Client-side enforcement: full-loop-helper.sh commit-and-pr (--strict mode).
+# This workflow catches PRs created via the GitHub web UI, external contributors,
+# or any path that bypasses the client-side helper.
+#
+# Exit behavior:
+#   PASS — no closing keywords reference a parent-task issue
+#   FAIL — closing keyword would auto-close a parent-task issue
+#
+# To allow a PR to intentionally close a parent (final-phase PR), a maintainer
+# can set the `allow-parent-close` label on the PR, which skips the check.
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, ready_for_review]
+
+jobs:
+  parent-task-keyword-check:
+    name: Parent-Task Keyword Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    concurrency:
+      group: parent-task-keyword-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+    permissions:
+      pull-requests: read
+      issues: read
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Check PR body for parent-task closing keywords
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          PR_LABELS: ${{ toJson(github.event.pull_request.labels) }}
+        run: |
+          # Check if the PR has the allow-parent-close label (maintainer opt-out)
+          if echo "$PR_LABELS" | grep -q '"allow-parent-close"'; then
+            echo "allow-parent-close label present — skipping check"
+            exit 0
+          fi
+
+          echo "Checking PR #${PR_NUMBER} for parent-task closing keywords..."
+
+          # Run the guard in strict mode. The script is checked out from the PR head.
+          chmod +x .agents/scripts/parent-task-keyword-guard.sh
+          if ! .agents/scripts/parent-task-keyword-guard.sh check-pr "${PR_NUMBER}" \
+              --repo "${REPO}" \
+              --strict; then
+            echo ""
+            echo "FAIL: PR body uses a closing keyword (Closes/Resolves/Fixes) that would"
+            echo "      auto-close a parent-task issue on merge."
+            echo ""
+            echo "Fix: Change the closing keyword to 'For #NNN' or 'Ref #NNN'."
+            echo "     The parent issue must stay open until ALL phase children merge."
+            echo "     Only the final-phase PR should use 'Closes #NNN'."
+            exit 1
+          fi
+
+          echo "PASS: No parent-task keyword violations found."


### PR DESCRIPTION
## Summary

Deliverable A: is_assigned() switched from fail-open to fail-closed — emits GUARD_UNCERTAIN on gh API failure instead of silently allowing dispatch. Deliverable B: parent-task-keyword-guard.sh prevents Resolves/Closes/Fixes on parent-task issues, wired into commit-and-pr --strict, with CI check and 6 test cases.

## Files Changed

.agents/AGENTS.md,.agents/scripts/dispatch-dedup-helper.sh,.agents/scripts/full-loop-helper.sh,.agents/scripts/parent-task-keyword-guard.sh,.agents/scripts/tests/test-dispatch-dedup-fail-closed.sh,.agents/scripts/tests/test-parent-task-keyword-guard.sh,.agents/templates/brief-template.md,.github/workflows/parent-task-keyword-check.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 32/32 tests pass (test-dispatch-dedup-fail-closed.sh: 4, test-parent-task-guard.sh: 22, test-parent-task-keyword-guard.sh: 6). ShellCheck clean on all modified scripts.

For #18599


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.6 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 10m and 32,171 tokens on this as a headless worker.