### PR TITLE
GH#18663: fix parent-task-keyword-guard.sh trap/unbound-variable under set -u

### DIFF
--- a/.agents/scripts/parent-task-keyword-guard.sh
+++ b/.agents/scripts/parent-task-keyword-guard.sh
@@ -247,10 +247,11 @@ cmd_check_pr() {
 		return 0
 	fi
 
-	# Write to a temp file and delegate to check-body
+	# Write to a temp file and delegate to check-body.
+	# NOTE: use explicit cleanup (not trap) to avoid unbound-variable error
+	# under set -u when the trap fires after the local variable goes out of scope.
 	local tmp_body
 	tmp_body=$(mktemp)
-	trap 'rm -f "$tmp_body"' EXIT
 	printf '%s\n' "$pr_body" >"$tmp_body"
 
 	local check_args=("--body-file" "$tmp_body" "--repo" "$repo")
@@ -259,6 +260,7 @@ cmd_check_pr() {
 
 	local check_rc=0
 	cmd_check_body "${check_args[@]}" || check_rc=$?
+	rm -f "$tmp_body"
 	return "$check_rc"
 }
 


### PR DESCRIPTION
## Summary

The cmd_check_pr function used 'trap rm -f "$tmp_body" EXIT' with a local variable. Under set -u, this caused 'unbound variable' when the trap fired at script exit (after the local scope was gone), producing a false CI failure. Fixed with explicit cleanup.

## Files Changed

.agents/scripts/parent-task-keyword-guard.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean; test-parent-task-keyword-guard.sh: 6/6 pass

Resolves #18599


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.6 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 16m and 47,025 tokens on this as a headless worker.