### PR TITLE
t2047: fix gh fail-open on API error/offline state

### DIFF
--- a/.agents/hooks/task-id-collision-guard.sh
+++ b/.agents/hooks/task-id-collision-guard.sh
@@ -100,25 +100,6 @@ _find_merge_base() {
 }
 
 # ---------------------------------------------------------------------------
-# Check if a given issue title (from gh) references the t-ID.
-# Returns 0 if it does, 1 if not.
-# ---------------------------------------------------------------------------
-_issue_title_contains_tid() {
-	local tid="${1:-}"
-	local issue_number="${2:-}"
-	if [[ -z "$tid" || -z "$issue_number" ]]; then
-		return 1
-	fi
-	local title
-	title=$(gh issue view "$issue_number" --json title --jq '.title' 2>/dev/null) || return 1
-	_debug "Issue #${issue_number} title: $title"
-	if printf '%s' "$title" | grep -qE "(^|[^0-9])${tid}([^0-9]|$)"; then
-		return 0
-	fi
-	return 1
-}
-
-# ---------------------------------------------------------------------------
 # Extract all tNNN references from text.
 # Outputs one per line.
 # ---------------------------------------------------------------------------
@@ -215,16 +196,44 @@ _check_message() {
 		# The ID is beyond the current counter. Check if any linked issue title
 		# contains this t-ID (cross-reference confirmation).
 		local confirmed=0
-		if [[ -n "$closing_issues" ]]; then
-			local iss_num
-			while IFS= read -r iss_num; do
-				[[ -z "$iss_num" ]] && continue
-				if _issue_title_contains_tid "$tid" "$iss_num"; then
-					_debug "$tid confirmed via linked issue #${iss_num}"
-					confirmed=1
-					break
-				fi
-			done <<<"$closing_issues"
+
+		if [[ -z "$closing_issues" ]]; then
+			# No closing issues — cannot possibly cross-reference. Reject.
+			_debug "$tid: no closing issues — marking as violation"
+			violations="${violations}  ${tid} — numeric ID ${num} > current counter ${counter}, and not confirmed via a linked issue title\n"
+			continue
+		fi
+
+		# Has closing issues. Need gh to verify — check availability first.
+		if ! command -v gh >/dev/null 2>&1; then
+			_warn "gh not available — fail-open (CI will validate on push)"
+			return 2
+		fi
+
+		local iss_num
+		local gh_had_error=0
+		while IFS= read -r iss_num; do
+			[[ -z "$iss_num" ]] && continue
+			local title
+			title=$(gh issue view "$iss_num" --json title --jq '.title' 2>/dev/null)
+			local gh_rc=$?
+			if [[ "$gh_rc" -ne 0 || -z "$title" ]]; then
+				_debug "gh issue view #${iss_num} failed (rc=${gh_rc}) — marking gh_had_error"
+				gh_had_error=1
+				continue
+			fi
+			_debug "Issue #${iss_num} title: $title"
+			if printf '%s' "$title" | grep -qE "(^|[^0-9])${tid}([^0-9]|$)"; then
+				_debug "$tid confirmed via linked issue #${iss_num}"
+				confirmed=1
+				break
+			fi
+		done <<<"$closing_issues"
+
+		# If all gh calls failed (offline, unauthenticated, API error) → fail-open
+		if [[ "$gh_had_error" -eq 1 && "$confirmed" -eq 0 ]]; then
+			_warn "gh API error during cross-reference check — fail-open (CI will validate on push)"
+			return 2
 		fi
 
 		if [[ "$confirmed" -eq 0 ]]; then

--- a/.agents/scripts/tests/test-task-id-collision-guard.sh
+++ b/.agents/scripts/tests/test-task-id-collision-guard.sh
@@ -176,51 +176,23 @@ test_allows_no_tids() {
 }
 
 # ---------------------------------------------------------------------------
-# Case 4: Allow — fail-open when gh CLI unavailable (offline)
+# Case 4: Allow — fail-open when gh API fails (closing issue present, gh errors)
+# This validates acceptance criterion: "fail-safe on gh API failure or offline state"
 # ---------------------------------------------------------------------------
 test_failopen_on_gh_failure() {
-	local name="case-4: fail-open when .task-counter unreadable"
-	# Use an empty counter value — guard should warn and allow
-	local msg="feat(foo): bar (t99999)"
-	local tmpdir
-	tmpdir=$(mktemp -d)
-	# shellcheck disable=SC2064
-	trap "rm -rf '$tmpdir'" RETURN
-
-	# Create a repo with NO .task-counter file at the merge base
-	local base_repo="${tmpdir}/base"
-	mkdir -p "$base_repo"
-	git -C "$base_repo" init -q
-	git -C "$base_repo" config user.email "test@test.local"
-	git -C "$base_repo" config user.name "Test"
-	git -C "$base_repo" config commit.gpgsign false
-	printf 'placeholder' >"${base_repo}/README.md"
-	git -C "$base_repo" add README.md
-	git -C "$base_repo" commit -q -m "init"
-
-	local work_repo="${tmpdir}/work"
-	git clone -q "$base_repo" "$work_repo" 2>/dev/null
-	git -C "$work_repo" config user.email "test@test.local"
-	git -C "$work_repo" config user.name "Test"
-	git -C "$work_repo" config commit.gpgsign false
-
-	printf 'change' >"${work_repo}/change.txt"
-	git -C "$work_repo" add change.txt
-	git -C "$work_repo" commit -q -m "wip"
-
-	local msg_file="${tmpdir}/COMMIT_EDITMSG"
-	printf '%s' "$msg" >"$msg_file"
-
+	local name="case-4: fail-open when gh API fails with closing issue present"
+	# Message has t99999 (> counter) AND a Resolves footer, but gh fails
+	local msg
+	msg=$(printf 'feat(foo): invented id (t99999)\n\nResolves #123\n')
 	local rc
-	GIT_DIR="${work_repo}/.git" \
-		bash "$GUARD" "$msg_file" 2>/dev/null
+	# Pass gh_available=no — stubs gh to exit 1 (API/offline failure)
+	_run_with_counter "$msg" "100" "no"
 	rc=$?
-
-	# Fail-open = exit 0
+	# Fail-open = exit 0 (guard cannot verify cross-ref, CI will catch on push)
 	if [[ "$rc" -eq 0 ]]; then
 		pass "$name"
 	else
-		fail "$name" "expected exit 0 (fail-open), got $rc"
+		fail "$name" "expected exit 0 (fail-open on gh failure), got $rc"
 	fi
 	return 0
 }


### PR DESCRIPTION
## Summary

Follow-up fix to #18662 addressing the gh fail-open acceptance criterion.

The initial implementation (#18662) did not correctly fail-open when `gh` was present but all API calls failed (offline, unauthenticated). This fix corrects the cross-reference logic.

## What changed

**`.agents/hooks/task-id-collision-guard.sh`:**
- Removed `_issue_title_contains_tid` helper (inlined logic for finer error tracking)
- Added early path: if no closing issues present → reject immediately (no gh needed)
- If closing issues present AND `gh` binary absent → fail-open (return 2)
- If closing issues present AND gh present but all `gh issue view` calls fail → fail-open (return 2)
- Only rejects when gh API succeeds for at least one issue AND none confirms the t-ID

**`.agents/scripts/tests/test-task-id-collision-guard.sh`:**
- Updated case-4 to properly test the gh API failure → fail-open path (message with `Resolves #NNN` footer + gh stubbed to fail → exit 0)

## Verification

```
bash .agents/scripts/tests/test-task-id-collision-guard.sh
# Results: 7 passed, 0 failed (including case-4: gh fail-open)

shellcheck .agents/hooks/task-id-collision-guard.sh  # clean
```

Fixes regression in #18662.
Resolves #18624