### PR TITLE
GH#18671: fix(dispatch) strip ANSI from worktree pre-creation + detect automation-applied NMR

### DIFF
--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -1479,11 +1479,36 @@ _dispatch_launch_worker() {
 		# Run from repo_path — worktree-helper.sh uses git commands that need
 		# to be inside the repo. The pulse-wrapper's cwd is typically / (launchd).
 		_wt_output=$(cd "$repo_path" && "$_wt_helper" add "$worker_worktree_branch" 2>&1) || true
+		# GH#18671: worktree-helper.sh emits ANSI color codes in its status
+		# output, including on the "Path:" line. The original path-extraction
+		# grep `/[^ ]*Git/[^ ]*` matches up to the next whitespace but ANSI
+		# reset sequences (\x1b[0m) contain no whitespace, so the captured
+		# path ends up with a trailing `\x1b[0m` suffix. The subsequent
+		# `[[ -d "$worker_worktree_path" ]]` check then fails because no
+		# such directory exists — the REAL path is the same string without
+		# the reset code. Result: pre-creation was silently marked "failed"
+		# on every dispatch, the worktree was successfully created but
+		# orphaned (27 leftover feature/auto-* directories observed in
+		# ~/Git/), the worker was launched without WORKER_WORKTREE_PATH,
+		# and its self-setup path crashed in ~17 seconds with crash_type=
+		# no_work. That fed the t2008 stale-recovery escalation path,
+		# which applied needs-maintainer-review after 2 failed attempts,
+		# which then drained the dispatch queue to zero.
+		#
+		# Fix: strip ANSI CSI sequences before the path grep so the captured
+		# string is a clean filesystem path. The sed pattern matches the
+		# standard CSI form ESC[ ... m. The $'...' quoting evaluates \x1b
+		# (ESC, 0x1B) at parse time in bash.
+		_wt_output=$(printf '%s' "$_wt_output" | sed $'s/\x1b\\[[0-9;]*m//g')
 		worker_worktree_path=$(printf '%s' "$_wt_output" | grep -oE '/[^ ]*Git/[^ ]*' | head -1) || worker_worktree_path=""
 		if [[ -n "$worker_worktree_path" && -d "$worker_worktree_path" ]]; then
 			echo "[dispatch_with_dedup] Pre-created worktree for #${issue_number}: ${worker_worktree_path} (branch: ${worker_worktree_branch})" >>"$LOGFILE"
 		else
-			echo "[dispatch_with_dedup] Warning: worktree pre-creation failed for #${issue_number} — worker will create its own" >>"$LOGFILE"
+			# GH#18671: emit the raw extracted string on failure so future
+			# regressions in path parsing are visible in the log. Previously
+			# this message gave no diagnostic — 247 failures accumulated in
+			# a single pulse.log before the root cause was found.
+			echo "[dispatch_with_dedup] Warning: worktree pre-creation failed for #${issue_number} — worker will create its own (extracted: '${worker_worktree_path:-<empty>}', wt_helper stdout head: '${_wt_output:0:120}')" >>"$LOGFILE"
 			worker_worktree_path=""
 			worker_worktree_branch=""
 		fi

--- a/.agents/scripts/pulse-nmr-approval.sh
+++ b/.agents/scripts/pulse-nmr-approval.sh
@@ -245,16 +245,105 @@ issue_has_required_approval() {
 }
 
 #######################################
+# GH#18671 (Fix 6b): Check whether an NMR label application on an issue
+# was accompanied by a pulse automation signature — a comment posted
+# immediately after (or within a ~60-second window of) the label event
+# that identifies the automated escalation path.
+#
+# Without this check, `_nmr_applied_by_maintainer` treats every NMR
+# application by the maintainer's GitHub token as a manual hold, even
+# when it was the t2008 stale-recovery circuit breaker, the t2007 cost
+# circuit breaker, or the GH#18538 review-scanner default-NMR path.
+# That is the direct cause of the "NMR drain" where workers crash in
+# ~17s during setup (pre-creation bug, Fix 6a), get stale-recovered,
+# hit the threshold, and are escalated to NMR. The maintainer never
+# touched the label, but auto_approve skips them because
+# _nmr_applied_by_maintainer returns true, and the issues stay blocked
+# until the human manually runs `sudo aidevops approve issue NNN`.
+#
+# Automation signatures detected (all are idempotent markers the pulse
+# leaves when it applies NMR via an escalation path):
+#   - <!-- stale-recovery-tick:escalated   — t2008 stale recovery
+#   - <!-- cost-circuit-breaker:fired      — t2007 cost circuit breaker
+#   - <!-- circuit-breaker-escalated       — legacy fast-fail alias
+#   - <!-- source:review-scanner           — GH#18538 scanner default NMR
+#
+# Args:
+#   $1 - issue_num  : GitHub issue number
+#   $2 - slug       : repo slug (owner/repo)
+#   $3 - label_at   : ISO8601 timestamp when NMR label was applied
+#
+# Exit codes:
+#   0 - automation signature found (NMR was auto-applied, safe to clear)
+#   1 - no automation signature (NMR was likely a manual hold)
+#######################################
+_nmr_application_has_automation_signature() {
+	local issue_num="$1"
+	local slug="$2"
+	local label_at="$3"
+
+	[[ -n "$issue_num" && -n "$slug" && -n "$label_at" ]] || return 1
+
+	# Fetch all issue comments once. Filter in jq to any comment posted
+	# within a 60-second window of the label event AND containing a known
+	# automation marker. The 60s window is generous for API latency between
+	# the label API call and the follow-up comment post, while still tight
+	# enough to exclude unrelated maintainer activity.
+	#
+	# Window math: label_at - 5s ≤ comment.created_at ≤ label_at + 60s.
+	# Lower bound covers the case where the comment was posted first and
+	# the label application was slightly delayed (rare but observed).
+	local has_signature
+	has_signature=$(gh api "repos/${slug}/issues/${issue_num}/comments" --paginate \
+		--jq "[.[] | select((.created_at | fromdateiso8601) >= ((\"${label_at}\" | fromdateiso8601) - 5) and (.created_at | fromdateiso8601) <= ((\"${label_at}\" | fromdateiso8601) + 60)) | .body | select(test(\"stale-recovery-tick:escalated|cost-circuit-breaker:fired|circuit-breaker-escalated|source:review-scanner\"))] | length" \
+		2>/dev/null) || has_signature=0
+	[[ "$has_signature" =~ ^[0-9]+$ ]] || has_signature=0
+
+	if [[ "$has_signature" -gt 0 ]]; then
+		return 0
+	fi
+
+	# Also accept: the issue itself carries review-followup or
+	# source:review-scanner labels (bot-generated cleanup from
+	# post-merge-review-scanner.sh, GH#18538). These issues apply NMR at
+	# creation via the scanner's SCANNER_NEEDS_REVIEW=true default, which
+	# does not necessarily emit a post-label comment marker. The label
+	# presence itself is the automation signature.
+	local has_bot_label
+	has_bot_label=$(gh api "repos/${slug}/issues/${issue_num}" \
+		--jq '[.labels[].name] | map(select(. == "review-followup" or . == "source:review-scanner")) | length' \
+		2>/dev/null) || has_bot_label=0
+	[[ "$has_bot_label" =~ ^[0-9]+$ ]] || has_bot_label=0
+
+	if [[ "$has_bot_label" -gt 0 ]]; then
+		return 0
+	fi
+
+	return 1
+}
+
+#######################################
 # Check if the needs-maintainer-review label was most recently applied
 # by the maintainer themselves (indicating a manual hold).
+#
+# GH#18671 (Fix 6b): the pulse runs as the maintainer's GitHub token, so
+# `actor.login == maintainer` matches both human manual label actions
+# AND automated escalation paths (t2007 cost circuit breaker, t2008
+# stale-recovery, GH#18538 scanner default-NMR). This function now
+# consults `_nmr_application_has_automation_signature` — if the label
+# event has an adjacent automation marker comment (or the issue itself
+# carries bot-cleanup labels), it classifies as automation-applied and
+# returns 1 so `auto_approve_maintainer_issues` can clear the label.
 #
 # Arguments:
 #   $1 - issue_num  : GitHub issue number
 #   $2 - slug       : repo slug (owner/repo)
 #   $3 - maintainer : maintainer GitHub login
 #
-# Returns 0 if the maintainer applied NMR (manual hold — do NOT auto-approve).
-# Returns 1 if NMR was applied by automation or the actor is unknown.
+# Returns 0 if the maintainer applied NMR AND no automation signature
+#           is present (genuine manual hold — do NOT auto-approve).
+# Returns 1 if NMR was applied by automation, the actor is unknown, or
+#           the label event is paired with an automation marker.
 #######################################
 _nmr_applied_by_maintainer() {
 	local issue_num="$1"
@@ -263,16 +352,29 @@ _nmr_applied_by_maintainer() {
 
 	[[ -n "$issue_num" && -n "$slug" && -n "$maintainer" ]] || return 1
 
-	local nmr_actor
-	nmr_actor=$(gh api "repos/${slug}/issues/${issue_num}/timeline" --paginate \
-		--jq '[.[] | select(.event == "labeled" and .label.name == "needs-maintainer-review")] | last | .actor.login // empty' \
-		2>/dev/null) || nmr_actor=""
+	# Fetch both actor and creation timestamp of the latest NMR label event.
+	local nmr_event_json
+	nmr_event_json=$(gh api "repos/${slug}/issues/${issue_num}/timeline" --paginate \
+		--jq '[.[] | select(.event == "labeled" and .label.name == "needs-maintainer-review")] | last | {actor:(.actor.login // ""),at:(.created_at // "")}' \
+		2>/dev/null) || nmr_event_json=""
 
-	if [[ "$nmr_actor" == "$maintainer" ]]; then
-		return 0
+	local nmr_actor nmr_at
+	nmr_actor=$(printf '%s' "$nmr_event_json" | jq -r '.actor // ""' 2>/dev/null) || nmr_actor=""
+	nmr_at=$(printf '%s' "$nmr_event_json" | jq -r '.at // ""' 2>/dev/null) || nmr_at=""
+
+	if [[ "$nmr_actor" != "$maintainer" ]]; then
+		return 1
 	fi
 
-	return 1
+	# Actor matches the maintainer — but is this a real manual action or
+	# the pulse running as the maintainer's token? Check for automation
+	# signature adjacent to the label event.
+	if [[ -n "$nmr_at" ]] && _nmr_application_has_automation_signature "$issue_num" "$slug" "$nmr_at"; then
+		echo "[pulse-wrapper] _nmr_applied_by_maintainer: #${issue_num} in ${slug} — actor=${maintainer} but automation signature detected — classifying as automation-applied (GH#18671)" >>"$LOGFILE"
+		return 1
+	fi
+
+	return 0
 }
 
 #######################################

--- a/.agents/scripts/tests/test-pulse-dispatch-core-ansi-strip.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-core-ansi-strip.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Tests for the ANSI-strip guard in pulse-dispatch-core.sh pre-creation
+# logic (GH#18671 / Fix 6a).
+#
+# The bug: grep -oE '/[^ ]*Git/[^ ]*' extracts the worktree path but
+# captures trailing ANSI reset sequences because they contain no
+# whitespace. The subsequent [[ -d $path ]] check then fails.
+#
+# This test verifies that the ANSI-strip `sed $'s/\x1b\\[[0-9;]*m//g'`
+# recovers a clean path from sample worktree-helper.sh output.
+
+set -euo pipefail
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+# Simulated worktree-helper output — matches the real format including
+# ANSI escapes on the Path: line. This is a byte-faithful copy of the
+# actual output captured from a live dispatch.
+build_simulated_wt_output() {
+	local branch="$1"
+	local path="$2"
+	# Use printf %b to interpret \x1b escape sequences.
+	printf '%b' '\n\x1b[0;34mCreating worktree with new branch '"'"''"$branch"''"'"'...\x1b[0m\nPreparing worktree (new branch '"'"''"$branch"''"'"')\nHEAD is now at abcdef01 some commit\n\n\x1b[0;32mWorktree created successfully!\x1b[0m\n\nPath: \x1b[1m'"$path"'\x1b[0m\nBranch: \x1b[1m'"$branch"'\x1b[0m\n\nTo start working:\n  cd '"$path"'\n'
+}
+
+# This is the fixed extraction logic — mirrors pulse-dispatch-core.sh:
+#   _wt_output=$(printf '%s' "$_wt_output" | sed $'s/\x1b\\[[0-9;]*m//g')
+#   worker_worktree_path=$(printf '%s' "$_wt_output" | grep -oE '/[^ ]*Git/[^ ]*' | head -1)
+extract_path_fixed() {
+	local wt_output="$1"
+	local stripped
+	stripped=$(printf '%s' "$wt_output" | sed $'s/\x1b\\[[0-9;]*m//g')
+	printf '%s' "$stripped" | grep -oE '/[^ ]*Git/[^ ]*' | head -1
+}
+
+# This is the OLD broken extraction logic — same grep, no sed.
+extract_path_broken() {
+	local wt_output="$1"
+	printf '%s' "$wt_output" | grep -oE '/[^ ]*Git/[^ ]*' | head -1
+}
+
+test_fixed_extractor_returns_clean_path() {
+	local wt_out
+	wt_out=$(build_simulated_wt_output "feature/auto-test" "/tmp/aidevops-test-wt/Git/aidevops-feature-auto-test")
+	local extracted
+	extracted=$(extract_path_fixed "$wt_out")
+	if [[ "$extracted" == "/tmp/aidevops-test-wt/Git/aidevops-feature-auto-test" ]]; then
+		print_result "fixed extractor returns clean path without ANSI suffix" 0
+		return 0
+	fi
+	# shellcheck disable=SC2028  # literal \x1b rendering is diagnostic, not a runtime escape
+	print_result "fixed extractor returns clean path without ANSI suffix" 1 \
+		"Expected clean path, got: '${extracted}' (hex-dump: $(printf '%s' "$extracted" | od -c | head -2 | tr '\n' ' '))"
+	return 0
+}
+
+test_broken_extractor_regression() {
+	# Assert that the BROKEN extractor would indeed have produced a
+	# tainted path — this is the regression guard against reintroducing
+	# the bug. If this test starts failing, it means the grep pattern
+	# has been tightened and the sed strip may no longer be needed;
+	# revisit pulse-dispatch-core.sh accordingly.
+	local wt_out
+	wt_out=$(build_simulated_wt_output "feature/auto-test" "/tmp/aidevops-test-wt/Git/aidevops-feature-auto-test")
+	local broken
+	broken=$(extract_path_broken "$wt_out")
+	# The broken extractor captures the first `/…/Git/…` match, which is
+	# the `\x1b[0;34m`-opened "Creating worktree" line — on that line
+	# there IS no Git/ path, so the first actual match is the Path: line
+	# whose value is followed by \x1b[0m (no space). Verify the capture
+	# contains a non-path suffix.
+	if [[ "$broken" == *$'\x1b[0m'* ]]; then
+		print_result "broken extractor regression guard: old path has ANSI suffix" 0
+		return 0
+	fi
+	# If the test simulation produces a clean path even without the sed
+	# strip, the simulation is wrong — the whole test suite is moot.
+	# Fail loudly so the mismatch is visible.
+	print_result "broken extractor regression guard: old path has ANSI suffix" 1 \
+		"Broken extractor did NOT produce an ANSI-suffixed path, got: '${broken}' — simulation may not match real output"
+	return 0
+}
+
+test_fixed_extractor_passes_dir_check_with_tmpdir() {
+	# Stronger assertion: create a real temp directory, simulate the
+	# extractor producing its path (with ANSI wrapper), and verify the
+	# fixed extractor yields a string that passes the subsequent -d check.
+	local tmp_base tmp_path
+	tmp_base=$(mktemp -d) || {
+		print_result "fixed extractor passes real -d dir check" 1 "mktemp failed"
+		return 0
+	}
+	mkdir -p "${tmp_base}/Git"
+	tmp_path="${tmp_base}/Git/aidevops-feature-auto-realcheck"
+	mkdir -p "$tmp_path"
+
+	local wt_out extracted
+	wt_out=$(build_simulated_wt_output "feature/auto-realcheck" "$tmp_path")
+	extracted=$(extract_path_fixed "$wt_out")
+
+	if [[ -n "$extracted" && -d "$extracted" ]]; then
+		rm -rf "$tmp_base"
+		print_result "fixed extractor passes real -d dir check" 0
+		return 0
+	fi
+	rm -rf "$tmp_base"
+	print_result "fixed extractor passes real -d dir check" 1 \
+		"Extracted '${extracted}' failed -d check against real dir '${tmp_path}'"
+	return 0
+}
+
+test_extractor_handles_path_with_multiple_ansi_runs() {
+	# Real worktree-helper output has several ANSI runs. Make sure the
+	# sed strip removes ALL of them, not just the first or last.
+	local path='/tmp/Git/aidevops-multi-ansi'
+	local wt_out
+	# shellcheck disable=SC2028  # these are literal ANSI bytes injected into the simulation fixture
+	wt_out=$(printf '%b' '\x1b[0;34mINFO\x1b[0m start\nPath: \x1b[1m'"$path"'\x1b[0m\n\x1b[0;32mSUCCESS\x1b[0m done\n')
+	local extracted
+	extracted=$(extract_path_fixed "$wt_out")
+	if [[ "$extracted" == "$path" ]]; then
+		print_result "extractor handles multiple ANSI runs on different lines" 0
+		return 0
+	fi
+	print_result "extractor handles multiple ANSI runs on different lines" 1 \
+		"Expected '$path', got '$extracted'"
+	return 0
+}
+
+main() {
+	test_fixed_extractor_returns_clean_path
+	test_broken_extractor_regression
+	test_fixed_extractor_passes_dir_check_with_tmpdir
+	test_extractor_handles_path_with_multiple_ansi_runs
+
+	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-pulse-nmr-automation-signature.sh
+++ b/.agents/scripts/tests/test-pulse-nmr-automation-signature.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Tests for _nmr_application_has_automation_signature() and the updated
+# _nmr_applied_by_maintainer() (GH#18671 / Fix 6b).
+#
+# The pulse runs as the maintainer's GitHub token, so when the t2008
+# stale-recovery or t2007 cost circuit breaker applies the NMR label,
+# the timeline actor is the maintainer. The fix: pair the label event
+# with an adjacent (±60s) comment containing an automation marker, OR
+# detect bot-cleanup labels on the issue itself.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+NMR_SCRIPT="${SCRIPT_DIR}/../pulse-nmr-approval.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+COMMENTS_FIXTURE=""
+ISSUE_META_FIXTURE=""
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+	mkdir -p "${TEST_ROOT}/bin"
+	export PATH="${TEST_ROOT}/bin:${PATH}"
+	export LOGFILE="${TEST_ROOT}/pulse.log"
+	: >"$LOGFILE"
+	COMMENTS_FIXTURE="${TEST_ROOT}/comments.json"
+	ISSUE_META_FIXTURE="${TEST_ROOT}/issue-meta.json"
+	export COMMENTS_FIXTURE ISSUE_META_FIXTURE
+
+	# gh stub: serves comments from COMMENTS_FIXTURE and issue meta from
+	# ISSUE_META_FIXTURE. Handles the --jq filter by piping into real jq.
+	cat >"${TEST_ROOT}/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "api" ]]; then
+	path="${2:-}"
+	jq_filter=""
+	shift 2 2>/dev/null || true
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+			--paginate) shift ;;
+			--jq) jq_filter="$2"; shift 2 ;;
+			*) shift ;;
+		esac
+	done
+	if [[ "$path" == */comments ]]; then
+		if [[ -n "$jq_filter" ]]; then
+			jq -r "$jq_filter" <"$COMMENTS_FIXTURE" 2>/dev/null || echo "0"
+		else
+			cat "$COMMENTS_FIXTURE"
+		fi
+		exit 0
+	fi
+	# repos/OWNER/REPO/issues/NUM (no /comments suffix) — issue meta
+	if [[ "$path" == */issues/* && "$path" != */timeline ]]; then
+		if [[ -n "$jq_filter" ]]; then
+			jq -r "$jq_filter" <"$ISSUE_META_FIXTURE" 2>/dev/null || echo "0"
+		else
+			cat "$ISSUE_META_FIXTURE"
+		fi
+		exit 0
+	fi
+fi
+printf 'unsupported gh invocation: %s\n' "$*" >&2
+exit 1
+EOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+
+	# Seed empty fixtures
+	printf '[]\n' >"$COMMENTS_FIXTURE"
+	printf '{"labels":[]}\n' >"$ISSUE_META_FIXTURE"
+
+	return 0
+}
+
+teardown_test_env() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+set_comments() {
+	printf '%s\n' "$1" >"$COMMENTS_FIXTURE"
+}
+set_issue_meta() {
+	printf '%s\n' "$1" >"$ISSUE_META_FIXTURE"
+}
+
+# Extract the helper from the source file. Same awk-extract-and-eval
+# pattern used by the force-dispatch and bot-cleanup test suites.
+define_helper_under_test() {
+	local helper_src
+	helper_src=$(awk '
+		/^_nmr_application_has_automation_signature\(\) \{/,/^}$/ { print }
+	' "$NMR_SCRIPT")
+	if [[ -z "$helper_src" ]]; then
+		printf 'ERROR: could not extract _nmr_application_has_automation_signature from %s\n' "$NMR_SCRIPT" >&2
+		return 1
+	fi
+	# shellcheck disable=SC1090
+	eval "$helper_src"
+	return 0
+}
+
+# --- test cases --------------------------------------------------------
+
+test_detects_stale_recovery_escalation_marker() {
+	# Real-world ordering: label applied first (t=00:00), comment posted
+	# 2s later (t=00:02) — matches dispatch-dedup-helper.sh:607-609 where
+	# set_issue_status runs before gh issue comment.
+	set_comments '[{"created_at":"2026-04-13T05:00:02Z","body":"<!-- stale-recovery-tick:escalated (threshold=2) -->\n**Stale recovery threshold reached** (t2008)"}]'
+	set_issue_meta '{"labels":[]}'
+	if _nmr_application_has_automation_signature 18623 marcusquinn/aidevops "2026-04-13T05:00:00Z"; then
+		print_result "detects stale-recovery:escalated marker within window" 0
+		return 0
+	fi
+	print_result "detects stale-recovery:escalated marker within window" 1 \
+		"Expected exit 0 — comment is 2s after label event"
+	return 0
+}
+
+test_detects_cost_circuit_breaker_marker() {
+	set_comments '[{"created_at":"2026-04-13T05:00:00Z","body":"<!-- cost-circuit-breaker:fired tier=standard spent=120000 budget=100000 -->\n🛑 Cost circuit breaker fired"}]'
+	set_issue_meta '{"labels":[]}'
+	if _nmr_application_has_automation_signature 18640 marcusquinn/aidevops "2026-04-13T05:00:02Z"; then
+		print_result "detects cost-circuit-breaker:fired marker" 0
+		return 0
+	fi
+	print_result "detects cost-circuit-breaker:fired marker" 1
+	return 0
+}
+
+test_ignores_marker_outside_window() {
+	# Comment 5 minutes after label event — outside the 60s window.
+	set_comments '[{"created_at":"2026-04-13T05:00:00Z","body":"<!-- stale-recovery-tick:escalated -->"}]'
+	set_issue_meta '{"labels":[]}'
+	if _nmr_application_has_automation_signature 18623 marcusquinn/aidevops "2026-04-13T05:05:00Z"; then
+		print_result "ignores marker outside 60s window" 1 \
+			"Expected exit 1 — comment is 5 minutes before label event"
+		return 0
+	fi
+	print_result "ignores marker outside 60s window" 0
+	return 0
+}
+
+test_detects_review_followup_label_as_signature() {
+	# No adjacent comment — but the issue has review-followup label,
+	# indicating bot-generated cleanup (GH#18538 default-NMR path).
+	set_comments '[]'
+	set_issue_meta '{"labels":[{"name":"review-followup"},{"name":"auto-dispatch"}]}'
+	if _nmr_application_has_automation_signature 18539 marcusquinn/aidevops "2026-04-13T04:29:13Z"; then
+		print_result "detects review-followup label as implicit automation signature" 0
+		return 0
+	fi
+	print_result "detects review-followup label as implicit automation signature" 1
+	return 0
+}
+
+test_detects_source_review_scanner_label_as_signature() {
+	set_comments '[]'
+	set_issue_meta '{"labels":[{"name":"source:review-scanner"}]}'
+	if _nmr_application_has_automation_signature 18621 marcusquinn/aidevops "2026-04-13T06:39:22Z"; then
+		print_result "detects source:review-scanner label as implicit signature" 0
+		return 0
+	fi
+	print_result "detects source:review-scanner label as implicit signature" 1
+	return 0
+}
+
+test_ignores_unrelated_comment_in_window() {
+	# Comment is in the window but has no automation marker.
+	set_comments '[{"created_at":"2026-04-13T05:00:30Z","body":"Thanks for the heads up, I will take a look at this tomorrow morning."}]'
+	set_issue_meta '{"labels":[{"name":"bug"}]}'
+	if _nmr_application_has_automation_signature 42 marcusquinn/aidevops "2026-04-13T05:00:00Z"; then
+		print_result "ignores unrelated maintainer comment in window" 1 \
+			"Expected exit 1 — no automation marker in body"
+		return 0
+	fi
+	print_result "ignores unrelated maintainer comment in window" 0
+	return 0
+}
+
+test_detects_lower_bound_comment_before_label() {
+	# Comment posted 3 seconds BEFORE the label event — within the -5s
+	# lower bound. This covers the API-latency race where the comment
+	# goes through faster than the label API call.
+	set_comments '[{"created_at":"2026-04-13T05:00:00Z","body":"<!-- stale-recovery-tick:escalated -->"}]'
+	set_issue_meta '{"labels":[]}'
+	if _nmr_application_has_automation_signature 42 marcusquinn/aidevops "2026-04-13T05:00:03Z"; then
+		print_result "detects marker 3s before label event (lower bound)" 0
+		return 0
+	fi
+	print_result "detects marker 3s before label event (lower bound)" 1
+	return 0
+}
+
+test_empty_args_returns_nonzero() {
+	set_comments '[]'
+	set_issue_meta '{"labels":[]}'
+	if _nmr_application_has_automation_signature "" "" ""; then
+		print_result "empty args return exit 1" 1
+		return 0
+	fi
+	print_result "empty args return exit 1" 0
+	return 0
+}
+
+test_no_comments_no_labels_returns_nonzero() {
+	set_comments '[]'
+	set_issue_meta '{"labels":[{"name":"bug"},{"name":"auto-dispatch"}]}'
+	if _nmr_application_has_automation_signature 42 marcusquinn/aidevops "2026-04-13T05:00:00Z"; then
+		print_result "no signature on normal bug issue returns exit 1" 1
+		return 0
+	fi
+	print_result "no signature on normal bug issue returns exit 1" 0
+	return 0
+}
+
+main() {
+	trap teardown_test_env EXIT
+	setup_test_env
+	if ! define_helper_under_test; then
+		printf 'FATAL: helper extraction failed\n' >&2
+		return 1
+	fi
+
+	test_detects_stale_recovery_escalation_marker
+	test_detects_cost_circuit_breaker_marker
+	test_ignores_marker_outside_window
+	test_detects_review_followup_label_as_signature
+	test_detects_source_review_scanner_label_as_signature
+	test_ignores_unrelated_comment_in_window
+	test_detects_lower_bound_comment_before_label
+	test_empty_args_returns_nonzero
+	test_no_comments_no_labels_returns_nonzero
+
+	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Two bugs that chain to drain the dispatch queue: (1) worktree pre-creation path extraction corrupted by ANSI reset sequences causing workers to crash in ~17s during self-setup, (2) auto-approve treating pulse-applied NMR as manual holds because the pulse runs as the maintainer's token. Fix 1 stops new victims; Fix 2 clears the existing 7-issue backlog on the next pulse cycle.

## Files Changed

.agents/scripts/pulse-dispatch-core.sh,.agents/scripts/pulse-nmr-approval.sh,.agents/scripts/tests/test-pulse-dispatch-core-ansi-strip.sh,.agents/scripts/tests/test-pulse-nmr-automation-signature.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 13 new unit tests (4 ANSI-strip, 9 NMR signature). All 22 regression tests across Fix 1-4 suites green. shellcheck clean. Live verification: (a) real worktree-helper output run through patched extractor yields clean path, -d check passes; (b) patched _nmr_applied_by_maintainer run against all 7 stuck NMR issues classifies every one as automation-applied (AUTO), none as MANUAL. See verification script at /tmp/verify-fix6b.sh in the working worktree.

Resolves #18671


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.6 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 2h 5m and 212,588 tokens on this with the user in an interactive session.