### PR TITLE
GH#18659: tighten ubicloud.md — remove redundant cross-ref, compress intro prose

### DIFF
--- a/.agents/services/hosting/ubicloud.md
+++ b/.agents/services/hosting/ubicloud.md
@@ -144,8 +144,6 @@ jobs:
 - **Allowlisting**: private services behind a firewall need to allow Ubicloud's egress IPs from https://api.ubicloud.com/ips-v4 (dynamic list; re-fetch periodically).
 - **SSH debug**: Ubicloud supports `ubicloud/upterm` or `mxschmitt/action-tmate` on its runners the same way GitHub-hosted does — see https://ubicloud.com/docs/github-actions-integration/debug-workflow-with-ssh
 
-Cross-ref: see `tools/git/github-actions.md` "Managed runner alternatives" for the CI-side integration summary.
-
 ## Virtual machines
 
 ```bash
@@ -189,7 +187,7 @@ Configure programs via env: `UBI_SSH`, `UBI_SFTP`, `UBI_SCP`, `UBI_PSQL`, `UBI_P
 
 ## Managed PostgreSQL
 
-Fast because local NVMe is used for storage and Ubicloud designs the data plane for each bare-metal host. ~3x cheaper than AWS RDS for comparable specs.
+Local NVMe, bare-metal-optimised data plane. ~3x cheaper than AWS RDS for comparable specs.
 
 - **Families**: `hobby-{1,2}` (shared CPU, $12.41/$24.81 per month) and `standard-{2..60}` ($49 → $1498 per month).
 - **HA**: synchronous replication with automatic failover on standard-family.
@@ -227,7 +225,7 @@ See https://ubicloud.com/docs/inference/endpoint
 
 ## Hosted (managed SaaS) vs. self-managed (build your own cloud)
 
-Ubicloud is unusual: the same AGPL v3 codebase runs the managed service *and* can be self-hosted on your own bare metal. Choose based on workload maturity, compliance needs, and where the cost savings actually show up.
+Same AGPL v3 codebase runs both the managed service and self-hosted on your own bare metal.
 
 | Dimension | Managed SaaS (console.ubicloud.com) | Self-managed (build your own cloud) |
 |-----------|-------------------------------------|--------------------------------------|


### PR DESCRIPTION
## Summary

Tightens `.agents/services/hosting/ubicloud.md` (299 → 297 lines) per simplification-debt scan.

**Classification: reference corpus** — content was not compressed, only genuinely redundant text removed.

### Changes

- **Removed cross-ref note** (line 147): `Cross-ref: see tools/git/github-actions.md "Managed runner alternatives"...` — duplicate of the Related Agents table at the bottom of the same file
- **Tightened Managed PostgreSQL intro**: `"Fast because local NVMe is used for storage and Ubicloud designs the data plane for each bare-metal host. ~3x cheaper than AWS RDS..."` → `"Local NVMe, bare-metal-optimised data plane. ~3x cheaper than AWS RDS..."` — same facts, 40% shorter
- **Removed vague second sentence in Hosted vs self-managed intro**: `"Choose based on workload maturity, compliance needs, and where the cost savings actually show up."` — adds no information beyond the comparison table that follows immediately

### Verification

- All code blocks, URLs, task ID references, and pricing data preserved verbatim
- Line count: 299 → 297 (code-simplifier.md `~300` threshold: file remains below threshold)
- Cross-ref for github-actions.md still present in Related Agents table (line ~275)
- Qlty: `~/.qlty/bin/qlty smells --all 2>&1 | grep 'ubicloud.md' | grep -c . | grep -q '^0$'` (report SKIP if unavailable)

Resolves #18659

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.6 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 7m and 13,375 tokens on this as a headless worker.