### PR TITLE
GH#18670: fix(pulse) declare headless origin at pulse-wrapper main() + harden issue-creation sites + cleanup mistagged issues

### DIFF
--- a/.agents/scripts/cleanup-mistagged-origin-interactive.sh
+++ b/.agents/scripts/cleanup-mistagged-origin-interactive.sh
@@ -1,0 +1,286 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# cleanup-mistagged-origin-interactive.sh (GH#18670 / Fix 7 — cleanup)
+#
+# Finds and re-labels issues that were created by pulse shell stages
+# but inherited `origin:interactive` from the pre-fix bug in
+# `detect_session_origin()` defaulting to "interactive" when no headless
+# env var is set.
+#
+# Pulse-signature labels that indicate an issue was automation-generated:
+#   - review-followup
+#   - source:review-scanner
+#   - consolidated
+#   - consolidation-task
+#   - simplification-debt
+#   - code-quality
+#   - recheck-simplicity
+#
+# Any issue carrying ANY of these labels AND `origin:interactive` was
+# mislabeled by the bug. Fix:
+#   1. Remove `origin:interactive` label
+#   2. Add `origin:worker` label
+#   3. Unassign the maintainer IF they are currently assigned (pulse
+#      shell stages auto-assigned via _gh_wrapper_auto_assignee)
+#
+# The cleanup is idempotent: running it twice is safe. Each fix step
+# uses `gh issue edit` which is idempotent at the GitHub API level.
+#
+# Usage:
+#   cleanup-mistagged-origin-interactive.sh [--dry-run] [--repo slug]
+#
+# --dry-run   Print the changes that would be made without applying them.
+# --repo SLUG Limit cleanup to a specific repo. Default: all pulse-enabled
+#             repos from ~/.config/aidevops/repos.json.
+#
+# Exit codes:
+#   0 — all eligible issues processed (or no changes needed)
+#   1 — fatal error (missing gh, invalid repos.json, etc.)
+#   2 — at least one issue failed to update (partial success)
+
+set -euo pipefail
+
+readonly PULSE_SIGNATURE_LABELS=(
+	"review-followup"
+	"source:review-scanner"
+	"consolidated"
+	"consolidation-task"
+	"simplification-debt"
+	"code-quality"
+	"recheck-simplicity"
+)
+
+DRY_RUN=false
+REPO_FILTER=""
+
+usage() {
+	cat <<EOF
+cleanup-mistagged-origin-interactive.sh [--dry-run] [--repo owner/repo]
+
+Re-labels issues mistagged origin:interactive by the pre-Fix-7 pulse
+shell stages (GH#18670). Removes origin:interactive, adds origin:worker,
+unassigns the maintainer. Idempotent.
+
+Options:
+  --dry-run          Print changes without applying.
+  --repo SLUG        Limit to one repo. Default: all pulse-enabled repos.
+  -h, --help         Show this message.
+EOF
+	return 0
+}
+
+parse_args() {
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--dry-run)
+			DRY_RUN=true
+			shift
+			;;
+		--repo)
+			REPO_FILTER="${2:-}"
+			shift 2
+			;;
+		-h | --help)
+			usage
+			exit 0
+			;;
+		*)
+			printf 'unknown argument: %s\n' "$1" >&2
+			usage
+			exit 1
+			;;
+		esac
+	done
+	return 0
+}
+
+resolve_repos() {
+	if [[ -n "$REPO_FILTER" ]]; then
+		printf '%s\n' "$REPO_FILTER"
+		return 0
+	fi
+	local repos_json="${HOME}/.config/aidevops/repos.json"
+	if [[ ! -f "$repos_json" ]]; then
+		printf 'ERROR: %s not found\n' "$repos_json" >&2
+		return 1
+	fi
+	jq -r '
+		.initialized_repos[]
+		| select(.pulse == true and (.local_only // false) == false and .slug != "")
+		| .slug
+	' "$repos_json" 2>/dev/null
+	return 0
+}
+
+list_mistagged_issues_in_repo() {
+	local repo="$1"
+	# Query: open issues with origin:interactive that ALSO have at least
+	# one pulse-signature label. gh issue list accepts multiple --label
+	# flags with AND semantics, but we need AND-with-any-of-7 which is
+	# OR across the signature set. Strategy: query with origin:interactive
+	# once, then filter client-side in jq by label intersection.
+	local issues_json
+	issues_json=$(gh issue list --repo "$repo" \
+		--label "origin:interactive" \
+		--state open \
+		--limit 100 \
+		--json number,title,labels,assignees 2>/dev/null) || issues_json="[]"
+
+	# Client-side filter: keep only issues whose labels intersect with
+	# any signature label. jq renders NDJSON-style one-per-line.
+	local signatures_json
+	signatures_json=$(printf '%s\n' "${PULSE_SIGNATURE_LABELS[@]}" | jq -R . | jq -s .)
+
+	printf '%s' "$issues_json" | jq -rc --argjson sigs "$signatures_json" '
+		.[]
+		| select(
+			(.labels | map(.name)) as $names
+			| any($sigs[]; . as $sig | $names | index($sig))
+		)
+		| {
+			number,
+			title: (.title | .[0:80]),
+			labels: [.labels[].name],
+			assignees: [.assignees[].login]
+		}
+	' 2>/dev/null
+	return 0
+}
+
+fix_issue() {
+	local repo="$1"
+	local issue_number="$2"
+	local assignees_csv="$3"
+	local maintainer="$4"
+
+	local action_summary="#${issue_number}: remove origin:interactive, add origin:worker"
+	local -a assignees_arr=()
+	if [[ -n "$assignees_csv" && "$assignees_csv" != "null" ]]; then
+		# shellcheck disable=SC2034  # assignees_arr is populated here and iterated below
+		IFS=',' read -ra assignees_arr <<<"$assignees_csv"
+	fi
+
+	# Build an unassign list for the maintainer if they are currently
+	# attached. We only unassign the maintainer (the login that the
+	# pre-fix _gh_wrapper_auto_assignee would have applied) — other
+	# assignees (human collaborators) are preserved. The array guard
+	# handles empty-assignee case under `set -u` on bash 3.2.
+	local -a unassign_flags=()
+	if [[ "${#assignees_arr[@]}" -gt 0 ]]; then
+		local a
+		for a in "${assignees_arr[@]}"; do
+			if [[ "$a" == "$maintainer" ]]; then
+				unassign_flags+=(--remove-assignee "$a")
+				action_summary="${action_summary}, unassign ${a}"
+			fi
+		done
+	fi
+
+	if [[ "$DRY_RUN" == "true" ]]; then
+		printf '  DRY-RUN: %s\n' "$action_summary"
+		return 0
+	fi
+
+	# Expand unassign_flags safely when empty (bash 3.2 set -u compat).
+	if gh issue edit "$issue_number" --repo "$repo" \
+		--remove-label "origin:interactive" \
+		--add-label "origin:worker" \
+		${unassign_flags[@]+"${unassign_flags[@]}"} >/dev/null 2>&1; then
+		printf '  FIXED:   %s\n' "$action_summary"
+		return 0
+	fi
+	printf '  FAILED:  %s\n' "$action_summary" >&2
+	return 1
+}
+
+resolve_maintainer_for_repo() {
+	local repo="$1"
+	local repos_json="${HOME}/.config/aidevops/repos.json"
+	if [[ -f "$repos_json" ]]; then
+		jq -r --arg slug "$repo" '
+			.initialized_repos[]
+			| select(.slug == $slug)
+			| .maintainer // (.slug | split("/")[0])
+		' "$repos_json" 2>/dev/null | head -1
+		return 0
+	fi
+	# Fallback: first segment of the slug
+	printf '%s' "${repo%%/*}"
+	return 0
+}
+
+process_repo() {
+	local repo="$1"
+	printf '\n== %s ==\n' "$repo"
+
+	local maintainer
+	maintainer=$(resolve_maintainer_for_repo "$repo")
+	if [[ -z "$maintainer" ]]; then
+		printf '  skip: could not resolve maintainer for %s\n' "$repo"
+		return 0
+	fi
+
+	local issues
+	issues=$(list_mistagged_issues_in_repo "$repo")
+	if [[ -z "$issues" ]]; then
+		printf '  no mistagged issues found\n'
+		return 0
+	fi
+
+	local failed=0 fixed=0
+	while IFS= read -r issue_json; do
+		[[ -n "$issue_json" ]] || continue
+		local issue_number assignees_csv
+		issue_number=$(printf '%s' "$issue_json" | jq -r '.number')
+		assignees_csv=$(printf '%s' "$issue_json" | jq -r '.assignees | join(",")')
+		if fix_issue "$repo" "$issue_number" "$assignees_csv" "$maintainer"; then
+			fixed=$((fixed + 1))
+		else
+			failed=$((failed + 1))
+		fi
+	done <<<"$issues"
+
+	printf '  summary: %d fixed, %d failed\n' "$fixed" "$failed"
+	return "$failed"
+}
+
+main() {
+	parse_args "$@"
+
+	if ! command -v gh >/dev/null 2>&1; then
+		printf 'ERROR: gh CLI not found\n' >&2
+		return 1
+	fi
+	if ! command -v jq >/dev/null 2>&1; then
+		printf 'ERROR: jq not found\n' >&2
+		return 1
+	fi
+
+	local repos
+	if ! repos=$(resolve_repos); then
+		return 1
+	fi
+
+	if [[ "$DRY_RUN" == "true" ]]; then
+		printf 'DRY-RUN mode — no changes will be applied\n'
+	fi
+
+	local total_failed=0
+	while IFS= read -r repo; do
+		[[ -n "$repo" ]] || continue
+		if ! process_repo "$repo"; then
+			total_failed=$((total_failed + $?))
+		fi
+	done <<<"$repos"
+
+	if [[ "$total_failed" -gt 0 ]]; then
+		printf '\nPartial success: %d issue(s) failed to update\n' "$total_failed" >&2
+		return 2
+	fi
+	printf '\nCleanup complete.\n'
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/post-merge-review-scanner.sh
+++ b/.agents/scripts/post-merge-review-scanner.sh
@@ -243,7 +243,16 @@ create_issue() {
 	# findings can have false premises that no amount of body context
 	# rescues. The maintainer either approves (removes label, adds tier),
 	# rejects (closes), or reframes scope before any worker runs.
-	local label_list="$SCANNER_LABEL,source:review-scanner"
+	#
+	# GH#18670 (Fix 7): hardcode origin:worker here as defence in depth
+	# against pulse-wrapper.sh forgetting to export AIDEVOPS_HEADLESS=true
+	# OR against this script being invoked directly from a dev shell
+	# (test runs, manual triage). gh_create_issue deduplicates labels
+	# server-side so there is no harm if session_origin_label() also
+	# produces origin:worker. The hardcoding is a source-of-truth
+	# assertion: this scanner is by definition pulse-only output and
+	# should never ship origin:interactive regardless of caller context.
+	local label_list="$SCANNER_LABEL,source:review-scanner,origin:worker"
 	if [[ "$SCANNER_NEEDS_REVIEW" == "true" ]]; then
 		gh label create "needs-maintainer-review" --repo "$repo" \
 			--description "Requires human triage before worker dispatch" \

--- a/.agents/scripts/pulse-triage.sh
+++ b/.agents/scripts/pulse-triage.sh
@@ -573,9 +573,11 @@ _compose_consolidation_worker_instructions() {
 \`\`\`bash
 gh issue create --repo "${repo_slug}" \\
   --title "consolidated: <concise description derived from the merged spec>" \\
-  --label "consolidated,<copy relevant labels from parent, excluding needs-consolidation and consolidation-task>" \\
+  --label "consolidated,origin:worker,<copy relevant labels from parent, excluding needs-consolidation and consolidation-task>" \\
   --body "<merged body from step 2>"
 \`\`\`
+
+**Note (GH#18670):** \`origin:worker\` is mandatory on this label list — consolidated issues are pulse-generated artifacts, not interactive maintainer work. Without it, the issue is born \`origin:interactive\` (raw \`gh issue create\` has no origin auto-detection), which triggers the GH#18352 dispatch-dedup block and drains the queue.
 
    Capture the new issue number as \$NEW_NUM.
 

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -930,6 +930,26 @@ ROUTINE_SCHEDULE_HELPER="${SCRIPT_DIR}/routine-schedule-helper.sh"
 ROUTINE_LOG_HELPER="${SCRIPT_DIR}/routine-log-helper.sh"
 
 main() {
+	# GH#18670 (Fix 7 — session origin declaration): declare this process
+	# as headless BEFORE anything else runs, so every child shell stage
+	# (post-merge-review-scanner, pulse-triage consolidated-issue, pulse-
+	# dispatch-core simplification-debt, quality-debt-helper, etc.) sees
+	# the env var and detect_session_origin() returns "worker". Without
+	# this, shell stages running in the pulse wrapper's own process find
+	# no headless signal and default to "interactive" (shared-constants.sh
+	# line 796), which makes gh_create_issue label new issues with
+	# origin:interactive AND auto-assign the maintainer via
+	# _gh_wrapper_auto_assignee() — and then GH#18352's dedup guard
+	# (origin:interactive + maintainer assignee → blocked) drains the
+	# queue indefinitely. Placing the export at the very top of main()
+	# covers --self-check, all pulse stages, and any future stages that
+	# may be added. The scope is limited to main() so that callers
+	# sourcing pulse-wrapper.sh for testing (rather than executing main)
+	# do not inherit the env var. Child processes inherit it via normal
+	# POSIX env propagation. This is a declarative source-of-truth: the
+	# pulse KNOWS it is headless; we simply stop pretending otherwise.
+	export AIDEVOPS_HEADLESS=true
+
 	# Phase 0 (t1963, GH#18357): --self-check short-circuit for CI, pre-edit
 	# verification, and post-install smoke testing. Runs before any lock,
 	# state mutation, or side effect. Sources are already in place (the

--- a/.agents/scripts/tests/test-pulse-wrapper-headless-export.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-headless-export.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Tests for the AIDEVOPS_HEADLESS=true export at the top of pulse-wrapper.sh
+# main() (GH#18670 / Fix 7).
+#
+# Behaviors under test:
+#   1. Executing pulse-wrapper.sh --self-check exports AIDEVOPS_HEADLESS=true
+#      before returning (side effect lives only in the self-check subprocess,
+#      but we can verify it from a wrapper that captures `env` via a hook).
+#   2. detect_session_origin() returns "worker" when the env var is set.
+#   3. Sourcing pulse-wrapper.sh WITHOUT invoking main() does NOT set the
+#      env var (scoping guarantee — importing for tests must not pollute
+#      the importing shell).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+WRAPPER_SCRIPT="${SCRIPT_DIR}/../pulse-wrapper.sh"
+SHARED_CONSTANTS="${SCRIPT_DIR}/../shared-constants.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+# Test 1: Static source inspection — the export line exists at the
+# top of main() ABOVE the --self-check flag scan. This is a spec check
+# rather than a runtime check, because running `pulse-wrapper.sh --self-check`
+# in a subprocess doesn't reveal the child's env to the parent.
+test_export_line_present_at_top_of_main() {
+	local snippet
+	snippet=$(awk '
+		/^main\(\) \{/ { in_main=1; next }
+		in_main && /^[[:space:]]*local _sc_flag=0/ { exit }
+		in_main { print }
+	' "$WRAPPER_SCRIPT")
+	if printf '%s' "$snippet" | grep -qE '^[[:space:]]*export AIDEVOPS_HEADLESS=true[[:space:]]*$'; then
+		print_result "export AIDEVOPS_HEADLESS=true present at top of main()" 0
+		return 0
+	fi
+	print_result "export AIDEVOPS_HEADLESS=true present at top of main()" 1 \
+		"Expected 'export AIDEVOPS_HEADLESS=true' line between 'main() {' and 'local _sc_flag=0'. Got snippet:${snippet}"
+	return 0
+}
+
+# Test 2: detect_session_origin() reports "worker" when AIDEVOPS_HEADLESS=true.
+# Sources shared-constants.sh in a subshell, sets the env var, and invokes
+# the function. This is the behavioural half of the contract — Test 1
+# guarantees the export is present, Test 2 guarantees the export has the
+# intended effect on detect_session_origin().
+test_detect_session_origin_returns_worker_when_headless() {
+	local result
+	result=$(
+		# shellcheck source=/dev/null
+		AIDEVOPS_SESSION_ORIGIN="" \
+			AIDEVOPS_HEADLESS="true" \
+			FULL_LOOP_HEADLESS="" \
+			OPENCODE_HEADLESS="" \
+			GITHUB_ACTIONS="" \
+			bash -c "source '$SHARED_CONSTANTS' 2>/dev/null; detect_session_origin"
+	)
+	if [[ "$result" == "worker" ]]; then
+		print_result "detect_session_origin returns 'worker' when AIDEVOPS_HEADLESS=true" 0
+		return 0
+	fi
+	print_result "detect_session_origin returns 'worker' when AIDEVOPS_HEADLESS=true" 1 \
+		"Expected 'worker', got '$result'"
+	return 0
+}
+
+# Test 3: Sourcing pulse-wrapper.sh without invoking main() must NOT
+# set AIDEVOPS_HEADLESS in the caller shell. Scoping guarantee — protects
+# callers that import pulse-wrapper.sh functions for testing.
+#
+# We cannot source pulse-wrapper.sh directly because it depends on a long
+# chain of sibling modules with include guards. Instead we verify the
+# export is INSIDE the main() function body, not at top level, via AST
+# grep. This is a static check but it's the same invariant.
+test_export_is_inside_main_not_top_level() {
+	# Find all lines matching `export AIDEVOPS_HEADLESS=true` anywhere in
+	# the script. There should be exactly one, and it should be inside
+	# the main() function (between `main() {` and the corresponding `}`).
+	local count line_num
+	count=$(grep -cE '^[[:space:]]*export AIDEVOPS_HEADLESS=true[[:space:]]*$' "$WRAPPER_SCRIPT" || echo "0")
+	if [[ "$count" -ne 1 ]]; then
+		print_result "export is inside main(), not top-level" 1 \
+			"Expected exactly 1 export line, found $count"
+		return 0
+	fi
+	line_num=$(grep -nE '^[[:space:]]*export AIDEVOPS_HEADLESS=true[[:space:]]*$' "$WRAPPER_SCRIPT" | head -1 | cut -d: -f1)
+	# The export line must be AFTER `main() {` (indented, inside a function).
+	local main_line
+	main_line=$(grep -nE '^main\(\) \{' "$WRAPPER_SCRIPT" | head -1 | cut -d: -f1)
+	if [[ -z "$main_line" || "$line_num" -le "$main_line" ]]; then
+		print_result "export is inside main(), not top-level" 1 \
+			"Export at line $line_num, main() at line ${main_line:-<not found>}. Export must be after main() {."
+		return 0
+	fi
+	# And the export must be indented (inside a function body), not at
+	# column 0 (which would be top-level code even inside a brace block
+	# that eval shenanigans could abuse).
+	if ! sed -n "${line_num}p" "$WRAPPER_SCRIPT" | grep -qE '^[[:space:]]+export'; then
+		print_result "export is inside main(), not top-level" 1 \
+			"Export line is not indented — appears to be top-level code"
+		return 0
+	fi
+	print_result "export is inside main(), not top-level" 0
+	return 0
+}
+
+# Test 4: the export comes BEFORE the --self-check flag scan, so that
+# --self-check also runs under the headless env. This matters because
+# the self-check is used by CI and installation smoke tests, and those
+# contexts should be treated as headless.
+test_export_before_self_check() {
+	local export_line sc_line
+	export_line=$(grep -nE '^[[:space:]]*export AIDEVOPS_HEADLESS=true[[:space:]]*$' "$WRAPPER_SCRIPT" | head -1 | cut -d: -f1)
+	sc_line=$(awk '/^main\(\) \{/{inmain=1; next} inmain && /^[[:space:]]*local _sc_flag=0/{print NR; exit}' "$WRAPPER_SCRIPT")
+	if [[ -z "$export_line" || -z "$sc_line" ]]; then
+		print_result "export precedes --self-check scan" 1 \
+			"Missing export_line=$export_line or sc_line=$sc_line"
+		return 0
+	fi
+	if [[ "$export_line" -lt "$sc_line" ]]; then
+		print_result "export precedes --self-check scan" 0
+		return 0
+	fi
+	print_result "export precedes --self-check scan" 1 \
+		"Export at line $export_line is AFTER --self-check scan at line $sc_line"
+	return 0
+}
+
+main_test() {
+	test_export_line_present_at_top_of_main
+	test_detect_session_origin_returns_worker_when_headless
+	test_export_is_inside_main_not_top_level
+	test_export_before_self_check
+
+	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main_test "$@"


### PR DESCRIPTION
## Summary

Root fix for the origin:interactive drain: pulse-wrapper.sh now declares AIDEVOPS_HEADLESS=true as the first line of main() so all shell stages see the correct session origin. Belt-and-braces: scanner and consolidation-task template hardcode origin:worker for standalone-invocation safety. Plus a cleanup script that re-labels the 21 currently-mistagged issues across 2 repos.

## Files Changed

.agents/scripts/cleanup-mistagged-origin-interactive.sh,.agents/scripts/post-merge-review-scanner.sh,.agents/scripts/pulse-triage.sh,.agents/scripts/pulse-wrapper.sh,.agents/scripts/tests/test-pulse-wrapper-headless-export.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** test-pulse-wrapper-headless-export.sh: 4/4 new (spec + behavioral + scoping + ordering). Regression guards across Fix 1-6 suites: 29 tests green. Dry-run of cleanup script identifies the expected 12+9=21 mistagged issues. shellcheck clean on all edited files (only pre-existing SC1091 info warning on source line unchanged).

Resolves #18670


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.6 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 2h 36m and 250,806 tokens on this with the user in an interactive session.