### PR TITLE
t2048: implement: fine-grained PAT path for sync-on-pr-merge push

### DIFF
--- a/.github/workflows/issue-sync.yml
+++ b/.github/workflows/issue-sync.yml
@@ -462,7 +462,12 @@ jobs:
         with:
           ref: main
           fetch-depth: 1
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # t2048: prefer SYNC_PAT (fine-grained PAT scoped to this repo,
+          # Contents: Read and write) to bypass branch protection via
+          # enforce_admins:false. Falls back to GITHUB_TOKEN when the secret
+          # is unset, which routes to the t2029/t2034 loud-failure path.
+          # See todo/tasks/t2038-brief.md Decision section for rationale.
+          token: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
 
       - name: Update TODO.md proof-log
         if: steps.extract.outputs.task_id != ''
@@ -476,10 +481,28 @@ jobs:
           # branch correctly but the comment never landed because gh ran
           # without GH_TOKEN and printed nothing visible (gh's silent failure
           # mode on missing auth).
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # t2048: prefer SYNC_PAT for the push so branch protection bypass
+          # works via enforce_admins:false. Still falls back to GITHUB_TOKEN
+          # for the gh CLI call even when SYNC_PAT is unset — the PR comment
+          # is always useful to post regardless of which token did the push.
+          GH_TOKEN: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
+          # t2048: expose secret presence as a boolean-ish env var. GitHub
+          # hides secret values from logs, but ${{ secrets.SYNC_PAT != '' }}
+          # evaluates to 'true' or 'false' at workflow-compile time and is
+          # safe to log.
+          SYNC_PAT_PRESENT: ${{ secrets.SYNC_PAT != '' && 'true' || '' }}
         run: |
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
+
+          # t2048: log which credential path is active so operators can tell
+          # at a glance whether the PAT is wired up. This is the single clear
+          # signal that tells "did the PAT swap land?" without spelunking.
+          if [[ -n "${SYNC_PAT_PRESENT:-}" ]]; then
+            echo "::notice::Using SYNC_PAT for push (t2048 path)"
+          else
+            echo "::notice::Using GITHUB_TOKEN for push (pre-t2048 fallback — push will be rejected by branch protection)"
+          fi
 
           TODAY=$(date +%Y-%m-%d)
           PROOF="pr:#${PR_NUMBER} completed:${TODAY}"


### PR DESCRIPTION
## Summary

- Switches the `sync-on-pr-merge` job in `.github/workflows/issue-sync.yml` to prefer `SYNC_PAT` (fine-grained PAT) over `GITHUB_TOKEN` for the `Checkout main` and `Update TODO.md proof-log` steps
- Uses `${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}` fallback so the workflow continues working via the t2029/t2034 loud-failure path until the maintainer creates the secret
- Adds `SYNC_PAT_PRESENT` env var and a `::notice::` log line so operators can confirm at a glance which credential path is active

## Files Changed

- EDIT: `.github/workflows/issue-sync.yml:458-510` — 3 edits: checkout token, GH_TOKEN env, + diagnostic notice step

## Implementation Notes

Based on t2038 research decision (Path B: fine-grained PAT). Decision rationale in `todo/tasks/t2038-brief.md`.

**Maintainer action required after merge:** Create fine-grained PAT at https://github.com/settings/personal-access-tokens/new with `Contents: Read and write` on `marcusquinn/aidevops` only (no `Workflows: Write`), store as repo Actions secret `SYNC_PAT`. Verify with:
```bash
gh api "repos/marcusquinn/aidevops/actions/secrets" --jq '.secrets[] | select(.name == "SYNC_PAT") | .name'
```

## Verification

```bash
# YAML valid
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/issue-sync.yml'))" && echo OK

# Both || fallbacks present (expect 2)
grep -c "secrets.SYNC_PAT || secrets.GITHUB_TOKEN" .github/workflows/issue-sync.yml

# Notice step present
grep "Using SYNC_PAT for push" .github/workflows/issue-sync.yml

# SYNC_PAT_PRESENT env var present
grep "SYNC_PAT_PRESENT:" .github/workflows/issue-sync.yml
```

Resolves #18643