### PR TITLE
GH#18646: fix sudo approve on Linux — resolve SUDO_USER home + recover gh auth

### DIFF
--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -23,7 +23,25 @@
 
 set -euo pipefail
 
-readonly APPROVAL_DIR="$HOME/.aidevops/approval-keys"
+# Resolve the real user's home directory, handling sudo env_reset on Linux.
+# Under sudo on Linux, HOME is reset to /root/ by env_reset; SUDO_USER holds
+# the original username. getent passwd is the canonical resolver on Linux.
+# On macOS, sudo does not reset HOME (and getent is not available), so the
+# fallback to $HOME is correct for both platforms.
+# Security: no escalation — root already has full filesystem access.
+_resolve_real_home() {
+	if [[ -n "${SUDO_USER:-}" && "$(id -u)" -eq 0 ]] && command -v getent &>/dev/null; then
+		getent passwd "$SUDO_USER" | cut -d: -f6
+	else
+		printf '%s' "$HOME"
+	fi
+	return 0
+}
+
+# Compute real home once at script load; used for all path variables below.
+_APPROVAL_HOME=$(_resolve_real_home)
+
+readonly APPROVAL_DIR="$_APPROVAL_HOME/.aidevops/approval-keys"
 readonly APPROVAL_PRIVATE_DIR="$APPROVAL_DIR/private"
 readonly APPROVAL_KEY="$APPROVAL_PRIVATE_DIR/approval.key"
 readonly APPROVAL_PUB="$APPROVAL_DIR/approval.pub"
@@ -41,7 +59,7 @@ _detect_slug() {
 	fi
 	# Fall back to repos.json current directory match
 	if [[ -z "$slug" || "$slug" != *"/"* ]]; then
-		local repos_json="$HOME/.config/aidevops/repos.json"
+		local repos_json="$_APPROVAL_HOME/.config/aidevops/repos.json"
 		if [[ -f "$repos_json" ]]; then
 			local cwd
 			cwd=$(pwd)
@@ -79,12 +97,47 @@ _print_error() {
 }
 
 _require_gh_auth() {
-	if ! gh auth status >/dev/null 2>&1; then
-		_print_error "gh authentication failed (common under sudo on Linux — gnome-keyring is inaccessible)"
-		_print_info "Workaround: export GH_TOKEN before sudo, or run: sudo GH_TOKEN=\$(gh auth token) aidevops approve ..."
-		return 1
+	if gh auth status >/dev/null 2>&1; then
+		return 0
 	fi
-	return 0
+	# Under sudo on Linux, gnome-keyring is inaccessible because env_reset strips
+	# DBUS_SESSION_BUS_ADDRESS. Attempt automatic token resolution via two methods
+	# before falling back to a descriptive error.
+	if [[ -n "${SUDO_USER:-}" && "$(id -u)" -eq 0 ]]; then
+		local real_uid=""
+		real_uid=$(id -u "$SUDO_USER" 2>/dev/null || echo "")
+		# Method 1: reconnect to user's D-Bus session socket via runuser
+		if [[ -n "$real_uid" && -S "/run/user/${real_uid}/bus" ]] && command -v runuser &>/dev/null; then
+			local token=""
+			token=$(runuser -u "$SUDO_USER" -- env \
+				"DBUS_SESSION_BUS_ADDRESS=unix:path=/run/user/${real_uid}/bus" \
+				"XDG_RUNTIME_DIR=/run/user/${real_uid}" \
+				gh auth token 2>/dev/null || echo "")
+			if [[ -n "$token" ]]; then
+				export GH_TOKEN="$token"
+				if gh auth status >/dev/null 2>&1; then
+					return 0
+				fi
+			fi
+		fi
+		# Method 2: read token directly from gh config file (non-keyring storage)
+		local real_home
+		real_home=$(_resolve_real_home)
+		local gh_hosts="${real_home}/.config/gh/hosts.yml"
+		if [[ -f "$gh_hosts" ]]; then
+			local file_token=""
+			file_token=$(awk '/oauth_token:/{print $2; exit}' "$gh_hosts" 2>/dev/null || echo "")
+			if [[ -n "$file_token" ]]; then
+				export GH_TOKEN="$file_token"
+				if gh auth status >/dev/null 2>&1; then
+					return 0
+				fi
+			fi
+		fi
+	fi
+	_print_error "gh authentication failed (common under sudo on Linux — gnome-keyring is inaccessible)"
+	_print_info "Workaround: export GH_TOKEN=\$(gh auth token) && sudo --preserve-env=GH_TOKEN aidevops approve ..."
+	return 1
 }
 
 _require_number_arg() {
@@ -128,9 +181,7 @@ _approval_real_user() {
 }
 
 _approval_real_home() {
-	local real_user
-	real_user=$(_approval_real_user)
-	eval echo "~$real_user"
+	_resolve_real_home
 	return 0
 }
 
@@ -464,7 +515,7 @@ cmd_setup() {
 	# Detect the real user behind sudo
 	local real_user="${SUDO_USER:-$(whoami)}"
 	local real_home
-	real_home=$(eval echo "~$real_user")
+	real_home=$(_resolve_real_home)
 	local actual_approval_dir="$real_home/.aidevops/approval-keys"
 	local actual_private_dir="$actual_approval_dir/private"
 	local actual_key="$actual_private_dir/approval.key"

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -19,9 +19,17 @@ BOLD='\033[1m'
 NC='\033[0m' # No Color
 
 # Paths
-INSTALL_DIR="$HOME/Git/aidevops"
-AGENTS_DIR="$HOME/.aidevops/agents"
-CONFIG_DIR="$HOME/.config/aidevops"
+# When running under sudo on Linux, HOME is reset to /root/ by env_reset.
+# Resolve the real user's home via SUDO_USER so agent/config paths are correct.
+# Security: no escalation — root already has full filesystem access.
+if [[ -n "${SUDO_USER:-}" && "$(id -u)" -eq 0 ]]; then
+	_AIDEVOPS_REAL_HOME=$(getent passwd "$SUDO_USER" | cut -d: -f6)
+else
+	_AIDEVOPS_REAL_HOME="$HOME"
+fi
+INSTALL_DIR="$_AIDEVOPS_REAL_HOME/Git/aidevops"
+AGENTS_DIR="$_AIDEVOPS_REAL_HOME/.aidevops/agents"
+CONFIG_DIR="$_AIDEVOPS_REAL_HOME/.config/aidevops"
 REPOS_FILE="$CONFIG_DIR/repos.json"
 # shellcheck disable=SC2034  # Used in fresh install fallback
 REPO_URL="https://github.com/marcusquinn/aidevops.git"


### PR DESCRIPTION
## Summary

Fixes `sudo aidevops approve issue <number>` on Linux where three cascading failures occur due to sudo's `env_reset` resetting HOME to `/root/`.

## Root causes fixed

1. **Path resolution** — `aidevops.sh` and `approval-helper.sh` used `$HOME` for all path variables; under sudo on Linux this resolves to `/root/`. Fixed by resolving real user home via `SUDO_USER` + `getent passwd`.

2. **gh auth** — `gnome-keyring` is inaccessible under sudo (D-Bus session stripped). Added two-method automatic recovery before falling back to a descriptive error:
   - Method 1: reconnect to user's D-Bus session socket via `runuser` (systemd-based distros)
   - Method 2: read OAuth token directly from `~/.config/gh/hosts.yml` (non-keyring gh config)

## Files changed

**`aidevops.sh`** (lines 22-28):
- Resolve `_AIDEVOPS_REAL_HOME` via `SUDO_USER` + `getent passwd` at startup when running under sudo
- `INSTALL_DIR`, `AGENTS_DIR`, `CONFIG_DIR` now use `_AIDEVOPS_REAL_HOME`

**`.agents/scripts/approval-helper.sh`**:
- Add `_resolve_real_home()` helper — canonical path resolver for both platforms
- Compute `_APPROVAL_HOME` once at script load; replace all `$HOME` references
- `_require_gh_auth()`: attempt automatic token recovery (runuser, then hosts.yml) before error
- `_approval_real_home()`: simplified to delegate to `_resolve_real_home()`
- `cmd_setup()`: replace fragile `eval echo "~$real_user"` with `_resolve_real_home()`

macOS is unaffected: sudo does not reset HOME on macOS; `getent` is absent (falls back to `$HOME`).

## Verification

```bash
shellcheck aidevops.sh .agents/scripts/approval-helper.sh  # clean
```

Manual verification requires a Linux machine with `sudo` and `gnome-keyring`. Behaviour on macOS is unchanged (fallback path).

Resolves #18646