### PR TITLE
GH#18668: remove flock from pulse instance lock — mkdir-only is sufficient

### DIFF
--- a/.agents/reference/bash-fd-locking.md
+++ b/.agents/reference/bash-fd-locking.md
@@ -1,0 +1,58 @@
+# Bash FD Locking — Why flock was removed from the pulse instance lock
+
+## Summary
+
+The pulse instance lock uses **mkdir atomicity only**. The supplementary `flock`
+layer (FD 9) was removed in GH#18668 after four recurring deadlock incidents.
+
+## Background
+
+`pulse-instance-lock.sh` uses `mkdir "$LOCKDIR"` as the primary atomic lock
+primitive. Because mkdir is POSIX-guaranteed atomic on all local filesystems
+(APFS, HFS+, ext4, btrfs, xfs), it provides sufficient mutual exclusion without
+additional layers.
+
+A supplementary `flock` on a lock file (FD 9) was added in GH#4513 as a
+"belt-and-suspenders" guard for Linux. It was intended as defence-in-depth,
+not as the primary primitive.
+
+## The recurring problem: FD inheritance
+
+Bash has no built-in equivalent of `fcntl(F_SETFD, FD_CLOEXEC)`. When the pulse
+opens `exec 9>"$LOCKFILE"` in the parent bash process, FD 9 is inherited by
+**every child process** that bash forks — including:
+
+- git commands (`git pull`, `git push`, `git worktree add`, `git rebase`)
+- git hooks (pre-commit, post-receive, commit-msg)
+- git merge drivers (`bd`, custom merge tools)
+- all backgrounded workers
+
+Any of these can daemonise (reparent to PID 1), permanently holding the flock
+after the pulse exits. The next pulse cycle is then deadlocked indefinitely.
+
+## Four failed fix attempts
+
+| Issue | Fix attempted | Why it failed |
+|-------|--------------|---------------|
+| GH#18094 | `python3 -c "import fcntl; fcntl.fcntl(9, fcntl.F_SETFD, FD_CLOEXEC)"` | `fcntl(F_SETFD)` operates on the calling process's FD table. Running it in a child python3 process only set CLOEXEC on python's copy of FD 9, which was discarded when python exited. The parent bash FD 9 was never modified. |
+| GH#18141 | Layer 2 inode self-recovery after 3 bounces | Had a `fuser` parsing bug: `fuser` returned multiple PIDs (orphan + current pulse), `tr -d ' '` concatenated them, `ps -p "298770302558"` failed, `flock_holder_comm` was empty, recovery condition never triggered. |
+| GH#18264 | Append `9>&-` to all child-spawning commands | Correct mechanism but blocklist model. 44 uncovered git calls at time of removal. Any new git call without `9>&-` restores the vulnerability. Invisible requirement — nothing in the code communicates it. |
+| GH#18668 | This issue | Identified as architectural problem; adopted Path A (remove flock). |
+
+## Why mkdir-only is sufficient
+
+- mkdir is atomic at the kernel level. No TOCTOU race is possible.
+- Works on all local filesystems on all platforms — macOS and Linux.
+- No utility dependencies (unlike `flock` which requires util-linux on Linux).
+- Stale locks from SIGKILL or power loss are handled by PID-file staleness
+  detection in `acquire_instance_lock()`.
+- The `flock` layer added defence-in-depth against a scenario that mkdir already
+  handles: concurrent invocations. Its cost (deadlock risk) exceeded its value.
+
+## Policy
+
+- Do not re-add `flock` or any other persistent-FD locking in pulse scripts.
+- If additional concurrency protection is needed, use a separate lock file with
+  a short-lived FD (opened and closed within a single function call).
+- Reference this document when reviewing PRs that add `exec N>file` patterns
+  to pulse orchestration code.

--- a/.agents/scripts/linters-local.sh
+++ b/.agents/scripts/linters-local.sh
@@ -382,6 +382,81 @@ check_string_literals() {
 	return 0
 }
 
+# check_forbidden_exec_fd (GH#18668): categorical block on persistent FD-based
+# file locks in pulse-adjacent scripts. Matches any `exec N>PATH` where PATH
+# references a `.aidevops/logs/*.lock` or `pulse-*.lock` file.
+#
+# Rationale: bash has no built-in for fcntl(F_SETFD, FD_CLOEXEC), so any FD
+# opened with `exec N>` is inherited by every child process (including
+# daemonising git hooks and ancillary workers). This caused four recurring
+# deadlock incidents (GH#18094, GH#18141, GH#18264, GH#18668) before the
+# flock layer was dropped in favour of mkdir atomicity. See
+# reference/bash-fd-locking.md for the full post-mortem and policy.
+#
+# The rule is a hard block (not a ratchet) because the policy is categorical:
+# there is no legitimate reason for the pulse to hold a persistent FD.
+# Short-lived flock inside a single helper (e.g. audit-log-helper.sh) is
+# permitted because the FD dies with the helper and does not get inherited
+# across process spawning.
+check_forbidden_exec_fd() {
+	echo -e "${BLUE}Checking Forbidden exec FD Locks (GH#18668)...${NC}"
+
+	local violations=0
+	local violation_lines=""
+
+	for file in "${ALL_SH_FILES[@]}"; do
+		[[ -f "$file" ]] || continue
+		# Skip the post-mortem doc itself (it quotes the forbidden pattern
+		# in a bash code block), the reference docs, the linter itself
+		# (defines the rule), and archived code.
+		case "$file" in
+		*/_archive/*) continue ;;
+		*/reference/*) continue ;;
+		*/linters-local.sh) continue ;;
+		esac
+
+		# Match: exec N>path, exec N>>path, or exec N>"$VAR" where the
+		# target path (literal or expanded) suggests a lock file.
+		# The grep is intentionally narrow — it matches the exact shape
+		# of the forbidden pattern, not "all flock usage".
+		local matches
+		matches=$(grep -nE '^[[:space:]]*exec[[:space:]]+[0-9]+>[^&]' "$file" 2>/dev/null || true)
+		if [[ -z "$matches" ]]; then
+			continue
+		fi
+
+		# Filter to only lock-suggestive targets: .lock, .lockfile, LOCKFILE
+		# variable references, or .aidevops/logs paths.
+		local filtered
+		filtered=$(printf '%s\n' "$matches" | grep -E '\.lock|LOCKFILE|\.aidevops/logs' 2>/dev/null || true)
+		if [[ -z "$filtered" ]]; then
+			continue
+		fi
+
+		while IFS= read -r line; do
+			[[ -z "$line" ]] && continue
+			violations=$((violations + 1))
+			violation_lines+="${file}:${line}"$'\n'
+		done <<<"$filtered"
+	done
+
+	if [[ $violations -eq 0 ]]; then
+		print_success "Forbidden exec FD locks: 0 violations (policy upheld)"
+		return 0
+	fi
+
+	print_error "Forbidden exec FD locks: $violations violation(s)"
+	printf '%s' "$violation_lines" | head -10
+	if [[ $violations -gt 10 ]]; then
+		echo "... and $((violations - 10)) more"
+	fi
+	print_info "Persistent FD-based locks in bash cannot set CLOEXEC — daemonising"
+	print_info "children inherit the FD and deadlock the next pulse cycle."
+	print_info "Use mkdir-based atomic locking instead. See:"
+	print_info "  .agents/reference/bash-fd-locking.md"
+	return 1
+}
+
 run_shfmt() {
 	echo -e "${BLUE}Running shfmt Syntax Check (fast pre-pass)...${NC}"
 
@@ -1737,6 +1812,11 @@ _run_gate_checks_static() {
 
 	if ! should_skip_gate "string-literals"; then
 		check_string_literals || exit_code=1
+		echo ""
+	fi
+
+	if ! should_skip_gate "forbidden-exec-fd"; then
+		check_forbidden_exec_fd || exit_code=1
 		echo ""
 	fi
 

--- a/.agents/scripts/pulse-ancillary-dispatch.sh
+++ b/.agents/scripts/pulse-ancillary-dispatch.sh
@@ -896,7 +896,7 @@ dispatch_foss_workers() {
 			--dir "$foss_path" \
 			--title "FOSS: ${foss_slug} #${foss_issue_num}: ${foss_issue_title}" \
 			--prompt "/full-loop Implement issue #${foss_issue_num} (https://github.com/${foss_slug}/issues/${foss_issue_num}) -- ${foss_issue_title}. This is a FOSS contribution.${disclosure_flag} After completion, run: foss-contribution-helper.sh record ${foss_slug} <tokens_used>" \
-			</dev/null >>"${HOME}/.aidevops/logs/pulse-foss-${foss_issue_num}.log" 2>&1 9>&- &
+			</dev/null >>"${HOME}/.aidevops/logs/pulse-foss-${foss_issue_num}.log" 2>&1 &
 		sleep 2
 
 		foss_count=$((foss_count + 1))

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -901,7 +901,7 @@ _is_task_committed_to_main() {
 	# Ensure we have the latest remote refs (the dispatch loop already
 	# does git pull, but fetch is cheaper and sufficient for log queries)
 	if [[ -d "$repo_path/.git" ]] || git -C "$repo_path" rev-parse --git-dir >/dev/null 2>&1; then
-		git -C "$repo_path" fetch origin main --quiet 2>/dev/null 9>&- || true
+		git -C "$repo_path" fetch origin main --quiet 2>/dev/null || true
 	else
 		return 1
 	fi
@@ -1461,7 +1461,7 @@ _dispatch_launch_worker() {
 	# close issues as "Invalid — file does not exist" when the target
 	# file was added in a recent commit they haven't pulled.
 	if git -C "$repo_path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-		git -C "$repo_path" pull --ff-only --no-rebase >>"$LOGFILE" 2>&1 9>&- || {
+		git -C "$repo_path" pull --ff-only --no-rebase >>"$LOGFILE" 2>&1 || {
 			echo "[dispatch_with_dedup] Warning: git pull failed for ${repo_path} — proceeding with current checkout" >>"$LOGFILE"
 		}
 	fi
@@ -1551,7 +1551,7 @@ _dispatch_launch_worker() {
 	# exits after its dispatch cycle, bash sends SIGHUP to background jobs.
 	# nohup makes the worker immune to SIGHUP so it survives the parent's
 	# exit. The EXIT trap only releases the instance lock (no child killing).
-	nohup "${worker_cmd[@]}" </dev/null >>"$worker_log" 2>&1 9>&- &
+	nohup "${worker_cmd[@]}" </dev/null >>"$worker_log" 2>&1 &
 	local worker_pid="$!"
 
 	# GH#17549: Stagger delay between worker launches to reduce SQLite

--- a/.agents/scripts/pulse-instance-lock.sh
+++ b/.agents/scripts/pulse-instance-lock.sh
@@ -1,10 +1,19 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
-# pulse-instance-lock.sh — Instance lock (mkdir + flock), PID sentinel handling, dedup guard.
+# pulse-instance-lock.sh — Instance lock (mkdir), PID sentinel handling, dedup guard.
 #
 # Extracted from pulse-wrapper.sh in Phase 1 of the phased decomposition
 # (parent: GH#18356, plan: todo/plans/pulse-wrapper-decomposition.md §6).
+#
+# Lock primitive: mkdir atomicity + PID file for stale detection.
+# flock was removed in GH#18668 after four recurring deadlock incidents
+# (GH#18094 → GH#18141 → GH#18264 → GH#18668) traced to the same root
+# cause: bash has no built-in for fcntl(F_SETFD, FD_CLOEXEC), so any
+# persistent FD held by the parent is inherited by every daemonising
+# descendant. The annotation-based allowlist (`9>&-` on known call
+# sites) was a structurally incomplete blocklist. See:
+#   reference/bash-fd-locking.md
 #
 # This module is sourced by pulse-wrapper.sh. It MUST NOT be executed
 # directly — it relies on the orchestrator having sourced:
@@ -19,10 +28,6 @@
 #   - _handle_setup_sentinel
 #   - _handle_running_pulse_pid
 #   - check_dedup
-#
-# This is a pure move from pulse-wrapper.sh. The function bodies are
-# byte-identical to their pre-extraction form. Any change must go in a
-# separate follow-up PR after the full decomposition (Phase 12) lands.
 
 # Include guard — prevent double-sourcing. pulse-wrapper.sh sources every
 # module unconditionally on start, and characterization tests re-source to
@@ -33,9 +38,14 @@ _PULSE_INSTANCE_LOCK_LOADED=1
 #######################################
 # Acquire an exclusive instance lock using mkdir atomicity (GH#4513)
 #
-# Primary defense against concurrent pulse instances on macOS and Linux.
-# mkdir is POSIX-guaranteed atomic — the kernel ensures only one process
-# succeeds even under concurrent invocations. No TOCTOU race is possible.
+# mkdir is the ONLY lock primitive. flock was removed in GH#18668 after
+# recurring deadlocks — see module header and reference/bash-fd-locking.md
+# for the full rationale.
+#
+# mkdir is POSIX-guaranteed atomic on all local filesystems — the kernel
+# ensures only one process succeeds even under concurrent invocations.
+# No TOCTOU race is possible. Works identically on macOS APFS/HFS+ and
+# Linux ext4/btrfs/xfs without util-linux.
 #
 # The lock directory (LOCKDIR) contains a PID file so stale locks from
 # SIGKILL or power loss can be detected and cleared on the next startup.
@@ -43,14 +53,9 @@ _PULSE_INSTANCE_LOCK_LOADED=1
 # SIGTERM. SIGKILL cannot be trapped — the stale-lock detection handles
 # that case on the next invocation.
 #
-# On Linux with util-linux flock available, flock is used as an additional
-# layer on the LOCKFILE (FD 9) for belt-and-suspenders protection. The
-# mkdir guard is the primary atomic primitive; flock is supplementary.
-#
 # Returns: 0 if lock acquired, 1 if another instance holds the lock
 #######################################
 acquire_instance_lock() {
-	# Step 1: mkdir-based atomic lock (primary — works on macOS and Linux)
 	if ! mkdir "$LOCKDIR" 2>/dev/null; then
 		# Lock directory already exists — check if the owning process is alive
 		local lock_pid=""
@@ -83,74 +88,7 @@ acquire_instance_lock() {
 	# Write our PID into the lock directory for stale-lock detection
 	echo "$$" >"${LOCKDIR}/pid"
 
-	# Step 2: flock as supplementary layer on Linux (belt-and-suspenders)
-	# flock is not available on macOS without util-linux — skip silently.
-	if command -v flock &>/dev/null; then
-		if ! flock -n 9 2>/dev/null; then
-			# flock says another instance holds it — diagnose and attempt recovery
-			# (GH#18141: Layer 1 diagnostic + Layer 2 inode self-recovery)
-			local flock_holder_pid flock_holder_cmd flock_holder_comm
-			local bounce_file bounce_count
-			flock_holder_pid=$(fuser "$LOCKFILE" 2>/dev/null | tr -d ' ')
-			flock_holder_cmd=$(ps -p "$flock_holder_pid" -o args= 2>/dev/null | head -c 120)
-			flock_holder_comm=$(ps -p "$flock_holder_pid" -o comm= 2>/dev/null)
-
-			# Track consecutive bounces in a file so we can detect sustained deadlocks
-			bounce_file="${HOME}/.aidevops/logs/pulse-flock-bounce-count"
-			bounce_count=0
-			[[ -f "$bounce_file" ]] && bounce_count=$(cat "$bounce_file" 2>/dev/null || echo "0")
-			[[ "$bounce_count" =~ ^[0-9]+$ ]] || bounce_count=0
-			bounce_count=$((bounce_count + 1))
-			echo "$bounce_count" >"$bounce_file"
-
-			echo "[pulse-wrapper] flock secondary guard: held by PID ${flock_holder_pid:-unknown} (${flock_holder_cmd:-unknown}), bounce ${bounce_count}" >>"$WRAPPER_LOGFILE"
-
-			# Update deadlock health state for pulse-health.json (GH#18141: Layer 3)
-			_PULSE_HEALTH_DEADLOCK_DETECTED=true
-			_PULSE_HEALTH_DEADLOCK_HOLDER_PID="${flock_holder_pid:-unknown}"
-			_PULSE_HEALTH_DEADLOCK_HOLDER_CMD="${flock_holder_cmd:-unknown}"
-			_PULSE_HEALTH_DEADLOCK_BOUNCES="$bounce_count"
-
-			# GH#18141: Layer 2 — inode recreation self-recovery after 3+ bounces
-			# when the holder is NOT a pulse-wrapper/bash process.
-			# Safety: we hold the mkdir lock (primary guard), so no concurrency hole.
-			# The orphaned child's flock on the old (now unlinked) inode becomes
-			# a lock on nothing — POSIX guarantees unlink+open creates a new inode.
-			if ((bounce_count >= 3)) &&
-				[[ -n "$flock_holder_comm" ]] &&
-				[[ "$flock_holder_comm" != "bash" ]] &&
-				[[ "$flock_holder_comm" != "pulse-wrapper" ]] &&
-				[[ "$flock_holder_comm" != "pulse-wrapper.sh" ]]; then
-				echo "[pulse-wrapper] Deadlock detected: flock held by non-pulse process PID ${flock_holder_pid:-unknown} (${flock_holder_cmd:-unknown}) for ${bounce_count} consecutive bounces — attempting inode recovery" >>"$WRAPPER_LOGFILE"
-				exec 9>&-          # close our FD to the old inode
-				rm -f "$LOCKFILE"  # unlink old inode (orphan keeps its FD)
-				exec 9>"$LOCKFILE" # create new file at same path = new inode
-				if flock -n 9 2>/dev/null; then
-					echo "[pulse-wrapper] Deadlock recovery successful — acquired flock on new inode after ${bounce_count} bounces" >>"$WRAPPER_LOGFILE"
-					echo "0" >"$bounce_file"
-					_PULSE_HEALTH_DEADLOCK_RECOVERED=true
-					# Fall through to success path below
-				else
-					echo "[pulse-wrapper] Deadlock recovery failed — flock still contested after inode recreation, releasing mkdir lock and exiting" >>"$WRAPPER_LOGFILE"
-					rm -rf "$LOCKDIR" 2>/dev/null || true
-					return 1
-				fi
-			else
-				# Holder is a pulse process or bounce threshold not yet met — normal exit
-				rm -rf "$LOCKDIR" 2>/dev/null || true
-				return 1
-			fi
-		else
-			# Successful flock acquisition — reset the bounce counter
-			local bounce_file
-			bounce_file="${HOME}/.aidevops/logs/pulse-flock-bounce-count"
-			[[ -f "$bounce_file" ]] && echo "0" >"$bounce_file"
-		fi
-		echo "[pulse-wrapper] Instance lock acquired via mkdir+flock (PID $$)" >>"$WRAPPER_LOGFILE"
-	else
-		# yeah, mkdir atomicity is sufficient on macOS without flock
-		echo "[pulse-wrapper] Instance lock acquired via mkdir (PID $$, flock not available on this platform)" >>"$WRAPPER_LOGFILE"
-	fi
+	echo "[pulse-wrapper] Instance lock acquired via mkdir (PID $$)" >>"$WRAPPER_LOGFILE"
 
 	# GH#18264: mark that this process owns the lock so release_instance_lock()
 	# only cleans up when we actually hold it.
@@ -173,9 +111,6 @@ release_instance_lock() {
 	# This prevents the EXIT trap from removing LOCKDIR when the lock was
 	# never acquired (e.g., another instance was already running).
 	[[ "$_LOCK_OWNED" == "true" ]] || return 0
-	# exec 9>&- closes FD 9 in the current (parent) bash process, releasing the
-	# flock so the next pulse cycle can acquire it immediately.
-	exec 9>&- 2>/dev/null || true
 	rm -rf "$LOCKDIR" 2>/dev/null || true
 	return 0
 } # nice — idempotent cleanup

--- a/.agents/scripts/pulse-logging.sh
+++ b/.agents/scripts/pulse-logging.sh
@@ -202,7 +202,7 @@ append_cycle_index() {
 #######################################
 # Write pulse-health.json — structured status snapshot for instant diagnosis.
 #
-# Fields (GH#15107, GH#18141):
+# Fields (GH#15107):
 #   workers_active          — current live worker count
 #   workers_max             — configured max worker slots
 #   prs_merged_this_cycle   — PRs squash-merged by deterministic merge pass
@@ -211,11 +211,10 @@ append_cycle_index() {
 #   prefetch_errors         — prefetch_state failures this cycle
 #   stalled_workers_killed  — stalled workers killed by cleanup_stalled_workers
 #   models_backed_off       — active backoff entries in provider_backoff DB
-#   deadlock_detected       — true if flock held by non-pulse process this cycle
-#   deadlock_holder_pid     — PID of the process holding the flock (if deadlock)
-#   deadlock_holder_cmd     — command line of the holder (truncated to 120 chars)
-#   deadlock_bounces        — consecutive flock bounce count at time of detection
-#   deadlock_recovered      — true if inode recreation self-recovery succeeded
+#
+# Historical note (GH#18668): the deadlock_* fields were removed along with
+# the flock layer they reported on. The lock is now mkdir-only and cannot
+# deadlock in the way flock FD inheritance did. See reference/bash-fd-locking.md.
 #
 # Atomic write: write to tmp file then mv to avoid partial reads.
 # Non-fatal: any failure is logged and silently ignored.
@@ -253,15 +252,6 @@ write_pulse_health_file() {
 		return 0
 	}
 
-	# GH#18141: sanitize deadlock holder cmd for JSON embedding.
-	# Escape backslashes first, then double-quotes.
-	local escaped_holder_cmd
-	escaped_holder_cmd="${_PULSE_HEALTH_DEADLOCK_HOLDER_CMD//\\/\\\\}"
-	escaped_holder_cmd="${escaped_holder_cmd//\"/\\\"}"
-
-	local deadlock_bounces="${_PULSE_HEALTH_DEADLOCK_BOUNCES:-0}"
-	[[ "$deadlock_bounces" =~ ^[0-9]+$ ]] || deadlock_bounces=0
-
 	cat >"$tmp_health" <<EOF
 {
   "timestamp": "${ts}",
@@ -272,12 +262,7 @@ write_pulse_health_file() {
   "issues_dispatched": ${issues_dispatched},
   "prefetch_errors": ${_PULSE_HEALTH_PREFETCH_ERRORS},
   "stalled_workers_killed": ${_PULSE_HEALTH_STALLED_KILLED},
-  "models_backed_off": ${models_backed_off},
-  "deadlock_detected": ${_PULSE_HEALTH_DEADLOCK_DETECTED},
-  "deadlock_holder_pid": "${_PULSE_HEALTH_DEADLOCK_HOLDER_PID}",
-  "deadlock_holder_cmd": "${escaped_holder_cmd}",
-  "deadlock_bounces": ${deadlock_bounces},
-  "deadlock_recovered": ${_PULSE_HEALTH_DEADLOCK_RECOVERED}
+  "models_backed_off": ${models_backed_off}
 }
 EOF
 
@@ -287,6 +272,6 @@ EOF
 		return 0
 	}
 
-	echo "[pulse-wrapper] pulse-health.json written: workers=${workers_active}/${workers_max} merged=${_PULSE_HEALTH_PRS_MERGED} closed_conflicting=${_PULSE_HEALTH_PRS_CLOSED_CONFLICTING} dispatched=${issues_dispatched} stalled_killed=${_PULSE_HEALTH_STALLED_KILLED} backed_off=${models_backed_off} deadlock=${_PULSE_HEALTH_DEADLOCK_DETECTED} deadlock_bounces=${deadlock_bounces} deadlock_recovered=${_PULSE_HEALTH_DEADLOCK_RECOVERED}" >>"$LOGFILE"
+	echo "[pulse-wrapper] pulse-health.json written: workers=${workers_active}/${workers_max} merged=${_PULSE_HEALTH_PRS_MERGED} closed_conflicting=${_PULSE_HEALTH_PRS_CLOSED_CONFLICTING} dispatched=${issues_dispatched} stalled_killed=${_PULSE_HEALTH_STALLED_KILLED} backed_off=${models_backed_off}" >>"$LOGFILE"
 	return 0
 }

--- a/.agents/scripts/pulse-prefetch.sh
+++ b/.agents/scripts/pulse-prefetch.sh
@@ -1267,7 +1267,7 @@ prefetch_state() {
 	while IFS='|' read -r slug path; do
 		(
 			_prefetch_single_repo "$slug" "$path" "${tmpdir}/${idx}.txt"
-		) 9>&- &
+		) &
 		pids+=($!)
 		idx=$((idx + 1))
 	done <<<"$repo_entries"

--- a/.agents/scripts/pulse-routines.sh
+++ b/.agents/scripts/pulse-routines.sh
@@ -131,7 +131,7 @@ _routine_execute() {
 			--dir "$dispatch_dir" \
 			--agent "$agent_name" \
 			--title "Routine ${routine_id}: ${description}" \
-			--prompt "Execute routine ${routine_id}: ${description}" 9>&- &
+			--prompt "Execute routine ${routine_id}: ${description}" &
 		# Don't wait — let it run in background like a worker
 	else
 		# Fallback: check for custom script
@@ -151,7 +151,7 @@ _routine_execute() {
 				--session-key "routine-${routine_id}" \
 				--dir "${repo_path:-$PULSE_DIR}" \
 				--title "Routine ${routine_id}: ${description}" \
-				--prompt "Execute routine ${routine_id}: ${description}" 9>&- &
+				--prompt "Execute routine ${routine_id}: ${description}" &
 		fi
 	fi
 

--- a/.agents/scripts/pulse-simplification.sh
+++ b/.agents/scripts/pulse-simplification.sh
@@ -1497,7 +1497,7 @@ _complexity_scan_pull_latest() {
 	# `gtimeout`, and a bash-native PGID-kill fallback.
 	if git -C "$aidevops_path" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
 		if ! GIT_TERMINAL_PROMPT=0 timeout_sec 30 \
-			git -C "$aidevops_path" pull --ff-only --no-rebase >>"$LOGFILE" 2>&1 9>&-; then
+			git -C "$aidevops_path" pull --ff-only --no-rebase >>"$LOGFILE" 2>&1; then
 			echo "[pulse-wrapper] Complexity scan: git pull failed for ${aidevops_path} — skipping this cycle to avoid stale-state warnings" >>"$LOGFILE"
 			return 1
 		fi

--- a/.agents/scripts/pulse-watchdog.sh
+++ b/.agents/scripts/pulse-watchdog.sh
@@ -146,7 +146,7 @@ run_cmd_with_timeout() {
 	shift
 	[[ "$timeout_secs" =~ ^[0-9]+$ ]] || timeout_secs=60
 
-	"$@" 9>&- &
+	"$@" &
 	local cmd_pid=$!
 
 	local elapsed=0
@@ -199,7 +199,7 @@ run_stage_with_timeout() {
 	stage_start=$(date +%s)
 	echo "[pulse-wrapper] Stage start: ${stage_name} (timeout ${timeout_seconds}s)" >>"$LOGFILE"
 
-	"$@" 9>&- &
+	"$@" &
 	local stage_pid=$!
 
 	while kill -0 "$stage_pid" 2>/dev/null; do

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -8,9 +8,9 @@
 #
 # This wrapper:
 #   1. mkdir-based atomic instance lock prevents concurrent pulses (GH#4513)
-#      Falls back to flock on Linux when util-linux flock is available.
 #      mkdir is POSIX-guaranteed atomic on all filesystems (APFS, HFS+, ext4)
-#      and does not require util-linux, which is absent on macOS.
+#      and is the only lock primitive — flock was removed in GH#18668 after
+#      recurring FD-inheritance deadlocks. See reference/bash-fd-locking.md.
 #   2. Uses a PID file with staleness check (not pgrep) for dedup
 #   3. Cleans up orphaned opencode processes before each pulse
 #   4. Kills runaway processes exceeding RSS or runtime limits (t1398.1)
@@ -45,14 +45,21 @@
 #   where launchd fires between rm -f and the next write, which caused the
 #   82-concurrent-pulse incident (2026-03-13T02:06:01Z, issue #4318).
 #
-# Instance lock protocol (GH#4513):
-#   Uses mkdir atomicity as the primary lock primitive. mkdir is guaranteed
+# Instance lock protocol (GH#4513, GH#18668):
+#   Uses mkdir atomicity as the ONLY lock primitive. mkdir is guaranteed
 #   atomic by POSIX on all local filesystems — the kernel ensures only one
 #   process succeeds even under concurrent invocations. The lock directory
 #   contains a PID file so stale locks (from SIGKILL/power loss) can be
 #   detected and cleared on the next startup. A trap ensures cleanup on
-#   normal exit and SIGTERM. flock (Linux util-linux) is used as an
-#   additional layer when available, but mkdir is the primary guard.
+#   normal exit and SIGTERM.
+#
+#   flock was previously layered on top as a secondary guard, but four
+#   recurring deadlock incidents (GH#18094, GH#18141, GH#18264, GH#18668)
+#   all traced to FD 9 being inherited by daemonising git hooks and
+#   ancillary workers. bash has no built-in fcntl(F_SETFD, FD_CLOEXEC),
+#   and annotation-based `9>&-` coverage is a structurally incomplete
+#   blocklist. flock was removed entirely in GH#18668 (Path A) — see
+#   reference/bash-fd-locking.md for the full rationale and policy.
 #
 # Called by launchd every 120s via the supervisor-pulse plist.
 
@@ -414,11 +421,10 @@ EVER_NMR_NEGATIVE_CACHE_TTL_SECS=$(_validate_int EVER_NMR_NEGATIVE_CACHE_TTL_SEC
 # _sanitize_markdown and _sanitize_log_field provided by worker-lifecycle-common.sh
 
 PIDFILE="${HOME}/.aidevops/logs/pulse.pid"
-LOCKFILE="${HOME}/.aidevops/logs/pulse-wrapper.lock"
 LOCKDIR="${HOME}/.aidevops/logs/pulse-wrapper.lockdir"
 # GH#18264: tracks whether this process successfully acquired the instance lock.
-# release_instance_lock() checks this flag so it only closes FD 9 and removes
-# LOCKDIR when this process actually owns the lock.
+# release_instance_lock() checks this flag so it only removes LOCKDIR when
+# this process actually owns the lock.
 _LOCK_OWNED=false
 LOGFILE="${HOME}/.aidevops/logs/pulse.log"
 WRAPPER_LOGFILE="${HOME}/.aidevops/logs/pulse-wrapper.log"
@@ -490,15 +496,6 @@ _PULSE_HEALTH_PRS_MERGED=0
 _PULSE_HEALTH_PRS_CLOSED_CONFLICTING=0
 _PULSE_HEALTH_STALLED_KILLED=0
 _PULSE_HEALTH_PREFETCH_ERRORS=0
-
-# Flock deadlock health state (GH#18141) — set by acquire_instance_lock() when
-# a non-pulse process holds the flock. Persisted to pulse-health.json so the
-# session greeting can warn the user. Cleared on next clean cycle.
-_PULSE_HEALTH_DEADLOCK_DETECTED=false
-_PULSE_HEALTH_DEADLOCK_HOLDER_PID=""
-_PULSE_HEALTH_DEADLOCK_HOLDER_CMD=""
-_PULSE_HEALTH_DEADLOCK_BOUNCES=0
-_PULSE_HEALTH_DEADLOCK_RECOVERED=false
 
 # Validate complexity scan configuration (defined above, validated here)
 COMPLEXITY_SCAN_INTERVAL=$(_validate_int COMPLEXITY_SCAN_INTERVAL "$COMPLEXITY_SCAN_INTERVAL" 900 300)
@@ -602,7 +599,7 @@ gathered by pulse-wrapper.sh BEFORE this session started."
 	if [[ -n "$PULSE_MODEL" ]]; then
 		pulse_cmd+=(--model "$PULSE_MODEL")
 	fi
-	"${pulse_cmd[@]}" >>"$LOGFILE" 2>&1 9>&- &
+	"${pulse_cmd[@]}" >>"$LOGFILE" 2>&1 &
 
 	local opencode_pid=$!
 	echo "$opencode_pid" >"$PIDFILE"
@@ -1117,25 +1114,20 @@ main() {
 	unset _dr_arg
 
 	# GH#4513: Acquire exclusive instance lock FIRST — before any other
-	# check. Uses mkdir atomicity as the primary primitive (POSIX-guaranteed,
-	# works on macOS APFS/HFS+ without util-linux). flock is used as a
-	# supplementary layer on Linux when available.
+	# check. Uses mkdir atomicity as the ONLY primitive (POSIX-guaranteed,
+	# works identically on macOS APFS/HFS+ and Linux ext4/btrfs/xfs).
+	#
+	# flock was removed in GH#18668 after recurring FD 9 inheritance
+	# deadlocks. bash has no built-in fcntl(F_SETFD, FD_CLOEXEC), so any
+	# persistent FD held by the parent is inherited by every daemonising
+	# descendant (git hooks, ancillary workers). See the module header of
+	# pulse-instance-lock.sh and reference/bash-fd-locking.md for history.
 	#
 	# Register EXIT trap BEFORE acquiring the lock so the lock is always
 	# released on exit — including set -e aborts, SIGTERM, and return paths.
 	# SIGKILL cannot be trapped; stale-lock detection handles that case.
 	trap 'release_instance_lock' EXIT
 
-	# Open FD 9 for flock supplementary layer (no-op if flock unavailable)
-	exec 9>"$LOCKFILE"
-	# GH#18264: FD 9 inheritance is prevented by appending 9>&- to every child-
-	# spawning command below (backgrounded workers, git calls, subshells). This
-	# tells bash to close FD 9 in the child before exec — the parent's FD 9 and
-	# flock are unaffected. The previous python3 fcntl(F_SETFD) approach (GH#18094)
-	# was ineffective: fcntl() operates on the calling process's FD table, so
-	# running it in a child python3 process only set CLOEXEC on python's copy of
-	# FD 9, which was discarded when python exited. The parent bash FD 9 was never
-	# modified. Bash has no built-in for fcntl().
 	if ! acquire_instance_lock; then
 		return 0
 	fi

--- a/.agents/scripts/tests/test-pulse-instance-lock-mkdir-only.sh
+++ b/.agents/scripts/tests/test-pulse-instance-lock-mkdir-only.sh
@@ -1,0 +1,385 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Characterization tests for pulse-instance-lock.sh (GH#18668).
+#
+# Purpose: lock in the mkdir-only behaviour after the flock layer was dropped.
+# Any future regression that reintroduces persistent FD-based locking in the
+# pulse parent will fail here.
+#
+# Asserts:
+#   1. acquire_instance_lock creates LOCKDIR + PID file on first attempt
+#   2. A stale lock (dead PID) is cleared and re-acquired
+#   3. A live concurrent lock owner blocks acquisition
+#   4. release_instance_lock removes LOCKDIR and is idempotent
+#   5. NO LOCKFILE is created at the old path — the file-based lock is gone
+#   6. FD 9 is NOT open in the parent after acquisition — the persistent FD
+#      inheritance vector no longer exists
+#   7. After release, a subsequent acquisition succeeds
+#
+# This test sources pulse-instance-lock.sh directly with a minimal stub
+# environment (not the full pulse-wrapper.sh) so the assertions isolate
+# the lock module's contract from every other pulse-wrapper concern.
+#
+# See: .agents/reference/bash-fd-locking.md
+
+set -euo pipefail
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_YELLOW='\033[0;33m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+TEST_ROOT=""
+PULSE_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+readonly PULSE_SCRIPTS_DIR
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+assert_equals() {
+	local name="$1"
+	local expected="$2"
+	local actual="$3"
+	if [[ "$expected" == "$actual" ]]; then
+		print_result "$name" 0
+	else
+		print_result "$name" 1 "expected='${expected}' actual='${actual}'"
+	fi
+	return 0
+}
+
+#######################################
+# Source pulse-instance-lock.sh with a minimal stub environment.
+#
+# The module is normally sourced by pulse-wrapper.sh after shared-constants.sh
+# and worker-lifecycle-common.sh have defined constants and helpers. We stub
+# the minimum surface the module actually uses:
+#   - LOCKDIR, WRAPPER_LOGFILE, LOGFILE, PIDFILE (paths)
+#   - _LOCK_OWNED (state flag)
+#   - _get_process_age (helper)
+#   - _kill_tree, _force_kill_tree (helpers used by check_dedup path)
+#######################################
+setup_sandbox() {
+	TEST_ROOT=$(mktemp -d)
+	export HOME="${TEST_ROOT}/home"
+	mkdir -p "${HOME}/.aidevops/logs"
+
+	# Paths normally set by pulse-wrapper.sh bootstrap
+	LOCKDIR="${HOME}/.aidevops/logs/pulse-wrapper.lockdir"
+	WRAPPER_LOGFILE="${HOME}/.aidevops/logs/pulse-wrapper.log"
+	LOGFILE="${HOME}/.aidevops/logs/pulse.log"
+	PIDFILE="${HOME}/.aidevops/logs/pulse.pid"
+	_LOCK_OWNED=false
+	PULSE_STALE_THRESHOLD=3600
+	export LOCKDIR WRAPPER_LOGFILE LOGFILE PIDFILE _LOCK_OWNED PULSE_STALE_THRESHOLD
+
+	# Minimal helper stubs used by the lock module
+	_get_process_age() {
+		# Stub — return a fixed value. Real helper reads /proc or ps.
+		echo "42"
+	}
+	_kill_tree() { return 0; }
+	_force_kill_tree() { return 0; }
+	get_max_workers_target() { echo "1"; }
+	count_active_workers() { echo "0"; }
+	export -f _get_process_age _kill_tree _force_kill_tree
+	export -f get_max_workers_target count_active_workers
+
+	# shellcheck source=/dev/null
+	source "${PULSE_SCRIPTS_DIR}/pulse-instance-lock.sh"
+	return 0
+}
+
+teardown_sandbox() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	# Clean any stray LOCKDIR so sequential tests are independent
+	if [[ -n "${LOCKDIR:-}" && -d "$LOCKDIR" ]]; then
+		rm -rf "$LOCKDIR"
+	fi
+	_LOCK_OWNED=false
+	return 0
+}
+
+reset_state() {
+	# Between-test reset — remove LOCKDIR and flip _LOCK_OWNED back.
+	if [[ -n "${LOCKDIR:-}" && -d "$LOCKDIR" ]]; then
+		rm -rf "$LOCKDIR"
+	fi
+	_LOCK_OWNED=false
+	return 0
+}
+
+#######################################
+# Test 1: clean acquisition — LOCKDIR does not exist, mkdir succeeds, PID
+# file written, _LOCK_OWNED set to true.
+#######################################
+test_clean_acquisition() {
+	reset_state
+
+	if acquire_instance_lock; then
+		print_result "acquire_instance_lock: first attempt succeeds" 0
+	else
+		print_result "acquire_instance_lock: first attempt succeeds" 1
+		return 0
+	fi
+
+	if [[ -d "$LOCKDIR" ]]; then
+		print_result "acquire_instance_lock: LOCKDIR created" 0
+	else
+		print_result "acquire_instance_lock: LOCKDIR created" 1 "LOCKDIR=${LOCKDIR}"
+	fi
+
+	if [[ -f "${LOCKDIR}/pid" ]]; then
+		local pid_content
+		pid_content=$(cat "${LOCKDIR}/pid")
+		assert_equals "acquire_instance_lock: PID file contains current PID" "$$" "$pid_content"
+	else
+		print_result "acquire_instance_lock: PID file exists" 1 "missing ${LOCKDIR}/pid"
+	fi
+
+	assert_equals "acquire_instance_lock: _LOCK_OWNED set to true" "true" "$_LOCK_OWNED"
+
+	release_instance_lock
+	return 0
+}
+
+#######################################
+# Test 2: stale lock recovery — a PID file containing a dead PID is cleared
+# and re-acquired on the next attempt.
+#######################################
+test_stale_lock_recovery() {
+	reset_state
+
+	# Simulate a stale lock: mkdir the lockdir manually and write a PID
+	# that is guaranteed not to exist. PID 2 exists on Linux (kthreadd)
+	# so use a high PID in the PID-space far above ps -e output.
+	mkdir -p "$LOCKDIR"
+	local fake_dead_pid=999999
+	# Ensure it's actually dead — on the off chance it exists, bump it
+	while ps -p "$fake_dead_pid" >/dev/null 2>&1; do
+		fake_dead_pid=$((fake_dead_pid + 1))
+	done
+	echo "$fake_dead_pid" >"${LOCKDIR}/pid"
+
+	if acquire_instance_lock; then
+		print_result "stale lock recovery: re-acquired after dead PID cleared" 0
+	else
+		print_result "stale lock recovery: re-acquired after dead PID cleared" 1
+		return 0
+	fi
+
+	# The PID file should now contain OUR PID, not the stale one
+	local pid_content
+	pid_content=$(cat "${LOCKDIR}/pid")
+	assert_equals "stale lock recovery: PID file overwritten with our PID" "$$" "$pid_content"
+
+	release_instance_lock
+	return 0
+}
+
+#######################################
+# Test 3: live concurrent owner blocks acquisition — a PID file containing
+# our own PID (which is alive by definition) must block re-acquisition.
+#
+# This exercises the "lock owner is alive" branch of acquire_instance_lock.
+# We cannot easily spawn a real peer bash process that holds the lock and
+# stays alive long enough to observe, so we use our own PID as a stand-in
+# for "a live process that holds the lock". This is a slight fudge — the
+# real contention scenario is another bash PID — but the code path is the
+# same: `ps -p "$lock_pid"` returns success for any live PID including
+# our own, and acquire_instance_lock returns 1.
+#######################################
+test_live_concurrent_owner() {
+	reset_state
+
+	# Manually create a lock dir owned by our own (live) PID
+	mkdir -p "$LOCKDIR"
+	echo "$$" >"${LOCKDIR}/pid"
+	_LOCK_OWNED=false # we didn't go through acquire_instance_lock
+
+	# acquire_instance_lock should see the PID is alive and return 1
+	local rc=0
+	acquire_instance_lock || rc=$?
+	assert_equals "live owner: acquire_instance_lock returns 1" "1" "$rc"
+
+	# LOCKDIR must still exist (we didn't clear a live owner's lock)
+	if [[ -d "$LOCKDIR" ]]; then
+		print_result "live owner: LOCKDIR preserved (not cleared)" 0
+	else
+		print_result "live owner: LOCKDIR preserved (not cleared)" 1
+	fi
+
+	# _LOCK_OWNED must still be false (we didn't acquire)
+	assert_equals "live owner: _LOCK_OWNED remains false" "false" "$_LOCK_OWNED"
+
+	# Clean up for next test
+	rm -rf "$LOCKDIR"
+	return 0
+}
+
+#######################################
+# Test 4: release_instance_lock removes LOCKDIR and is idempotent.
+#######################################
+test_release_is_idempotent() {
+	reset_state
+
+	acquire_instance_lock >/dev/null
+	if [[ ! -d "$LOCKDIR" ]]; then
+		print_result "release: setup (acquire) created LOCKDIR" 1
+		return 0
+	fi
+
+	release_instance_lock
+	if [[ ! -d "$LOCKDIR" ]]; then
+		print_result "release: LOCKDIR removed on first call" 0
+	else
+		print_result "release: LOCKDIR removed on first call" 1
+	fi
+
+	# Second call must not error and must not recreate anything
+	release_instance_lock
+	if [[ ! -d "$LOCKDIR" ]]; then
+		print_result "release: idempotent (safe to call twice)" 0
+	else
+		print_result "release: idempotent (safe to call twice)" 1
+	fi
+	return 0
+}
+
+#######################################
+# Test 5: no LOCKFILE is created — the file-based lock is gone.
+#
+# Before GH#18668, pulse-wrapper.sh opened `exec 9>"$LOCKFILE"` where
+# LOCKFILE=~/.aidevops/logs/pulse-wrapper.lock. After Path A, that line was
+# deleted. This test asserts the old file path is never created during
+# acquisition or release.
+#######################################
+test_no_lockfile_created() {
+	reset_state
+	local legacy_lockfile="${HOME}/.aidevops/logs/pulse-wrapper.lock"
+	rm -f "$legacy_lockfile"
+
+	acquire_instance_lock >/dev/null
+	if [[ ! -f "$legacy_lockfile" ]]; then
+		print_result "no LOCKFILE created during acquisition" 0
+	else
+		print_result "no LOCKFILE created during acquisition" 1 \
+			"unexpected file at ${legacy_lockfile}"
+	fi
+
+	release_instance_lock
+	if [[ ! -f "$legacy_lockfile" ]]; then
+		print_result "no LOCKFILE created during release" 0
+	else
+		print_result "no LOCKFILE created during release" 1
+	fi
+	return 0
+}
+
+#######################################
+# Test 6: FD 9 is NOT open in the parent after acquisition.
+#
+# This is the key negative test — the whole reason for Path A is that bash
+# cannot mark FDs close-on-exec, so any persistent FD 9 leaks into children.
+# After GH#18668, FD 9 must NEVER be open in the pulse parent.
+#
+# We probe FD 9 via /dev/fd/9 (Linux and macOS both provide this). If FD 9
+# is closed, [[ -e /dev/fd/9 ]] returns false.
+#######################################
+test_fd9_not_open() {
+	reset_state
+	acquire_instance_lock >/dev/null
+
+	# Probe FD 9 without opening it. Bash does not expose an API for
+	# "is FD N open" directly, but /dev/fd/N is a symlink to the open
+	# file description — it exists iff N is open.
+	if [[ -e /dev/fd/9 ]]; then
+		print_result "FD 9 not open in parent after acquire_instance_lock" 1 \
+			"/dev/fd/9 exists — persistent FD was opened somewhere"
+	else
+		print_result "FD 9 not open in parent after acquire_instance_lock" 0
+	fi
+
+	release_instance_lock
+	return 0
+}
+
+#######################################
+# Test 7: acquire/release cycle — after release, a fresh acquisition from
+# the same process succeeds. This is the "back-to-back pulse cycles" case
+# that hung in the historical flock incidents.
+#######################################
+test_acquire_release_cycle() {
+	reset_state
+
+	local i
+	for i in 1 2 3; do
+		if acquire_instance_lock >/dev/null; then
+			print_result "cycle ${i}: acquire succeeded" 0
+		else
+			print_result "cycle ${i}: acquire succeeded" 1
+			return 0
+		fi
+		release_instance_lock
+		if [[ -d "$LOCKDIR" ]]; then
+			print_result "cycle ${i}: release cleared LOCKDIR" 1
+			return 0
+		fi
+		print_result "cycle ${i}: release cleared LOCKDIR" 0
+	done
+	return 0
+}
+
+#######################################
+# Main
+#######################################
+main() {
+	printf '%b==> pulse-instance-lock.sh mkdir-only characterization tests%b\n' \
+		"$TEST_YELLOW" "$TEST_RESET"
+	printf '    PULSE_SCRIPTS_DIR=%s\n' "$PULSE_SCRIPTS_DIR"
+
+	setup_sandbox
+
+	test_clean_acquisition
+	test_stale_lock_recovery
+	test_live_concurrent_owner
+	test_release_is_idempotent
+	test_no_lockfile_created
+	test_fd9_not_open
+	test_acquire_release_cycle
+
+	teardown_sandbox
+
+	printf '\n'
+	if [[ "$TESTS_FAILED" -eq 0 ]]; then
+		printf '%bAll %d tests passed%b\n' "$TEST_GREEN" "$TESTS_RUN" "$TEST_RESET"
+		return 0
+	fi
+	printf '%b%d of %d tests failed%b\n' "$TEST_RED" "$TESTS_FAILED" "$TESTS_RUN" "$TEST_RESET"
+	return 1
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Removes the supplementary `flock` layer from `acquire_instance_lock()` after four recurring deadlock incidents (GH#18094 → GH#18141 → GH#18264 → GH#18668) all traced to the same root cause: **bash has no built-in for `fcntl(F_SETFD, FD_CLOEXEC)`**.

## Root cause

When `exec 9>"$LOCKFILE"` opened FD 9 in the parent pulse process, that FD was inherited by every child: git commands, hooks, merge drivers, backgrounded workers. Any child that daemonised then held the flock indefinitely, deadlocking all subsequent pulse cycles.

Three targeted fixes each addressed a symptom:
- GH#18094: `python3 fcntl` — ineffective, operated on child's FD table not parent's
- GH#18141: inode self-recovery — `fuser` concatenated multiple PIDs; `ps` lookup failed
- GH#18264: `9>&-` annotation on child calls — correct mechanism but blocklist model (44 uncovered git calls at time of removal)

## Fix: Path A — remove flock entirely

`mkdir` atomicity is POSIX-guaranteed on all local filesystems (APFS, HFS+, ext4, btrfs, xfs). It is already documented as the "primary atomic primitive". The flock layer added defence against a scenario mkdir already handles, at the cost of recurring deadlocks.

## Files changed

- **`pulse-instance-lock.sh`**: remove 75-line flock section from `acquire_instance_lock()`, remove `exec 9>&-` from `release_instance_lock()`, update module header
- **`pulse-wrapper.sh`**: remove `exec 9>"$LOCKFILE"` setup, `LOCKFILE` variable, `9>&-` on worker launch, update lock protocol documentation
- **`pulse-logging.sh`**: remove `deadlock_*` fields from `pulse-health.json` schema
- **`pulse-ancillary-dispatch.sh`, `pulse-dispatch-core.sh`, `pulse-prefetch.sh`, `pulse-routines.sh`, `pulse-simplification.sh`, `pulse-watchdog.sh`**: remove all `9>&-` annotations (no longer needed)
- **`linters-local.sh`**: add `check_forbidden_exec_fd()` — categorical block on `exec N>*.lock` patterns in pulse scripts; enforces the policy going forward
- **`reference/bash-fd-locking.md`** (new): post-mortem and policy document; explains why re-introducing flock would fail

## Verification

```bash
shellcheck .agents/scripts/pulse-instance-lock.sh \
           .agents/scripts/pulse-wrapper.sh \
           .agents/scripts/pulse-logging.sh \
           .agents/scripts/linters-local.sh
# clean

.agents/scripts/linters-local.sh --gate forbidden-exec-fd
# 0 violations
```

Resolves #18668