### PR TITLE
GH#18683: chore: ratchet down FUNCTION_COMPLEXITY_THRESHOLD 46→43 (GH#18683)

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -26,7 +26,8 @@
 # (92 lines, 0 violations) + _dispatch_launch_worker (214 lines, 1 violation) + orchestrator (53 lines).
 # Net violation change: 0 — replaced one violation with one violation. Full-codebase count: 46 violations
 # = threshold (no buffer). Ratchet deferred; _dispatch_launch_worker needs further splitting (t2000+).
-FUNCTION_COMPLEXITY_THRESHOLD=46
+# Ratcheted down to 43 (GH#18683): actual violations 41 + 2 buffer
+FUNCTION_COMPLEXITY_THRESHOLD=43
 
 # Shell nesting depth: files with >8 levels of nesting
 # NOTE: pulse-wrapper.sh has a proximity guard (GH#17808) that warns when


### PR DESCRIPTION
## Summary

Lowered FUNCTION_COMPLEXITY_THRESHOLD from 46 to 43 (actual violations: 41, 41+2=43 buffer). Added audit trail comment documenting the ratchet. simplification-state.json was not staged.

## Files Changed

.agents/configs/complexity-thresholds.conf

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** grep FUNCTION_COMPLEXITY_THRESHOLD .agents/configs/complexity-thresholds.conf returns 43; git diff --cached --name-only confirms only complexity-thresholds.conf was committed

Resolves #18683


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.8 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 1m and 2,878 tokens on this as a headless worker.