### PR TITLE
GH#18713: chore: ratchet-down FUNCTION_COMPLEXITY_THRESHOLD 43→33

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -27,7 +27,8 @@
 # Net violation change: 0 — replaced one violation with one violation. Full-codebase count: 46 violations
 # = threshold (no buffer). Ratchet deferred; _dispatch_launch_worker needs further splitting (t2000+).
 # Ratcheted down to 43 (GH#18695): actual violations 41 + 2 buffer
-FUNCTION_COMPLEXITY_THRESHOLD=43
+# Ratcheted down to 33 (GH#18713): actual violations 31 + 2 buffer
+FUNCTION_COMPLEXITY_THRESHOLD=33
 
 # Shell nesting depth: files with >8 levels of nesting
 # NOTE: pulse-wrapper.sh has a proximity guard (GH#17808) that warns when


### PR DESCRIPTION
## Summary

Ratchet-down `FUNCTION_COMPLEXITY_THRESHOLD` from 43 to 33.

At the time issue GH#18713 was created, actual violations were 36 (suggesting target of 38).
Additional simplification PRs have since merged, reducing violations further to **31**.
New threshold: 31 actual + 2 buffer = **33**.

## Changes

- `EDIT: .agents/configs/complexity-thresholds.conf` — lowered `FUNCTION_COMPLEXITY_THRESHOLD` from 43 to 33
- Added audit-trail comment: `# Ratcheted down to 33 (GH#18713): actual violations 31 + 2 buffer`
- Existing bump history comments preserved (not removed)
- `simplification-state.json` NOT staged (verified)

## Verification

```
[complexity-scan] INFO: Actual violations — func:31 nest:266 size:58 bash32:71
[complexity-scan] INFO: Current thresholds — func:33 nest:266 size:59 bash32:72
[complexity-scan] INFO: No ratchet-down available: all thresholds within gap of 5
```

Resolves #18713