### PR TITLE
GH#18711: docs(GH#18711): tighten bash-fd-locking.md prose — 58→54 lines

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -6432,7 +6432,7 @@
       "hash": "476c989fca56149f90f1eefc2b02cafdc5a6e0d5",
       "simplified_at": "2026-04-04T09:17:13Z",
       "issue": "GH#17250",
-      "action": "consolidated 6 group tables + CSS block into single unified table with CSS variable column (94→28 lines)",
+      "action": "consolidated 6 group tables + CSS block into single unified table with CSS variable column (94\u219228 lines)",
       "at": "2026-04-04T14:53:40Z",
       "passes": 1
     },
@@ -7453,5 +7453,12 @@
     "hash": "a73a56209534a71e05ed6485880b63e0439f4d3c0cb0abb93dafb55abe2179f5",
     "status": "simplified",
     "lines": 94
+  },
+  ".agents/reference/bash-fd-locking.md": {
+    "hash": "79e0a0a74b3e71f24fe2bfcea539a2d300a010a19dd5e5e94d48a516f8f79ba2",
+    "lines_before": 58,
+    "lines_after": 54,
+    "action": "tightened",
+    "issue": "GH#18711"
   }
 }

--- a/.agents/reference/bash-fd-locking.md
+++ b/.agents/reference/bash-fd-locking.md
@@ -8,13 +8,9 @@ layer (FD 9) was removed in GH#18668 after four recurring deadlock incidents.
 ## Background
 
 `pulse-instance-lock.sh` uses `mkdir "$LOCKDIR"` as the primary atomic lock
-primitive. Because mkdir is POSIX-guaranteed atomic on all local filesystems
-(APFS, HFS+, ext4, btrfs, xfs), it provides sufficient mutual exclusion without
-additional layers.
-
-A supplementary `flock` on a lock file (FD 9) was added in GH#4513 as a
-"belt-and-suspenders" guard for Linux. It was intended as defence-in-depth,
-not as the primary primitive.
+primitive (POSIX-guaranteed atomic on APFS, HFS+, ext4, btrfs, xfs). A
+supplementary `flock` on FD 9 was added in GH#4513 as a Linux
+"belt-and-suspenders" guard — defence-in-depth, not the primary primitive.
 
 ## The recurring problem: FD inheritance
 
@@ -28,7 +24,7 @@ opens `exec 9>"$LOCKFILE"` in the parent bash process, FD 9 is inherited by
 - all backgrounded workers
 
 Any of these can daemonise (reparent to PID 1), permanently holding the flock
-after the pulse exits. The next pulse cycle is then deadlocked indefinitely.
+and deadlocking the next pulse cycle.
 
 ## Four failed fix attempts
 


### PR DESCRIPTION
## Summary

Merged two verbose Background paragraphs into one and tightened the FD-inheritance closing sentence. Reduced from 58 to 54 lines. All institutional knowledge preserved: GH issue references (GH#4513, GH#18094, GH#18141, GH#18264, GH#18668), the four failed-fix table, Why-mkdir rationale, and the three Policy bullets.

## Files Changed

.agents/configs/simplification-state.json,.agents/reference/bash-fd-locking.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Qlty smells: 0 for target file. Content preserved: all GH refs, code blocks, table rows, and policy items verified present before and after.

Resolves #18711


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.8 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 3m and 9,367 tokens on this as a headless worker.