### PR TITLE
GH#18718: refactor(GH#18718): decompose _check_message() in task-id-collision-guard.sh

### DIFF
--- a/.agents/hooks/task-id-collision-guard.sh
+++ b/.agents/hooks/task-id-collision-guard.sh
@@ -122,6 +122,81 @@ _extract_closing_issues() {
 }
 
 # ---------------------------------------------------------------------------
+# Cross-reference a single t-ID against closing issues via the gh API.
+# Args:
+#   $1 = tid (e.g. "t2047")
+#   $2 = newline-separated closing issue numbers
+# Returns:
+#   0 = confirmed (title of at least one linked issue contains the t-ID)
+#   1 = not confirmed (violation)
+#   2 = fail-open (gh unavailable or API error with no confirmation)
+# ---------------------------------------------------------------------------
+_verify_tid_via_issues() {
+	local tid="${1:-}"
+	local closing_issues="${2:-}"
+
+	if [[ -z "$closing_issues" ]]; then
+		_debug "$tid: no closing issues — marking as violation"
+		return 1
+	fi
+
+	if ! command -v gh >/dev/null 2>&1; then
+		_warn "gh not available — fail-open (CI will validate on push)"
+		return 2
+	fi
+
+	local iss_num
+	local gh_had_error=0
+	local confirmed=0
+	while IFS= read -r iss_num; do
+		[[ -z "$iss_num" ]] && continue
+		local title
+		title=$(gh issue view "$iss_num" --json title --jq '.title' 2>/dev/null)
+		local gh_rc=$?
+		if [[ "$gh_rc" -ne 0 || -z "$title" ]]; then
+			_debug "gh issue view #${iss_num} failed (rc=${gh_rc}) — marking gh_had_error"
+			gh_had_error=1
+			continue
+		fi
+		_debug "Issue #${iss_num} title: $title"
+		if printf '%s' "$title" | grep -qE "(^|[^0-9])${tid}([^0-9]|$)"; then
+			_debug "$tid confirmed via linked issue #${iss_num}"
+			confirmed=1
+			break
+		fi
+	done <<<"$closing_issues"
+
+	if [[ "$gh_had_error" -eq 1 && "$confirmed" -eq 0 ]]; then
+		_warn "gh API error during cross-reference check — fail-open (CI will validate on push)"
+		return 2
+	fi
+
+	[[ "$confirmed" -eq 1 ]] && return 0
+	return 1
+}
+
+# ---------------------------------------------------------------------------
+# Print the violation block to stderr.
+# Args:
+#   $1 = violations string (printf %b-formatted lines)
+#   $2 = commit subject (for display)
+# ---------------------------------------------------------------------------
+_report_violations() {
+	local violations="${1:-}"
+	local subject="${2:-<unknown>}"
+	printf '\n[task-id-guard][BLOCK] Commit subject references invented task ID(s):\n\n' >&2
+	printf '  Subject: %s\n\n' "$subject" >&2
+	printf '%b\n' "$violations" >&2
+	printf '  To fix:\n' >&2
+	printf '    1. Remove the t-ID from the commit subject/body, OR\n' >&2
+	printf '    2. Claim the ID first: claim-task-id.sh --title "..." → then use the allocated ID, OR\n' >&2
+	printf '    3. If cross-referencing another person'"'"'s task, add "Resolves/Closes/Fixes #NNN" footer\n' >&2
+	printf '       where the linked issue title contains the t-ID.\n' >&2
+	printf '  Bypass (sets audit trail): TASK_ID_GUARD_DISABLE=1 git commit ...  or git commit --no-verify\n\n' >&2
+	return 0
+}
+
+# ---------------------------------------------------------------------------
 # Core check: given a commit message, check if any t\d+ reference is invented.
 # Args:
 #   $1 = full commit message text
@@ -139,12 +214,10 @@ _check_message() {
 		return 0
 	fi
 
-	# Extract first line as the subject if not provided
 	if [[ "$subject" == "<unknown>" ]]; then
 		subject=$(printf '%s' "$msg" | head -1)
 	fi
 
-	# Find all t-ID references
 	local tids
 	tids=$(_extract_tids "$msg")
 	if [[ -z "$tids" ]]; then
@@ -154,12 +227,8 @@ _check_message() {
 
 	_debug "Found t-IDs: $(printf '%s' "$tids" | tr '\n' ' ')"
 
-	# Read counter at merge base
 	local counter=""
-	if [[ -n "$merge_base" ]]; then
-		counter=$(_read_counter_at_ref "$merge_base")
-	fi
-
+	[[ -n "$merge_base" ]] && counter=$(_read_counter_at_ref "$merge_base")
 	if [[ -z "$counter" ]]; then
 		_warn ".task-counter not readable at merge base '${merge_base}' — fail-open"
 		return 2
@@ -167,90 +236,38 @@ _check_message() {
 
 	_debug "Merge-base counter value: $counter"
 
-	# Extract closing issue numbers from the commit footer
 	local closing_issues
 	closing_issues=$(_extract_closing_issues "$msg")
 	_debug "Closing issues: $(printf '%s' "$closing_issues" | tr '\n' ' ')"
 
-	# Check each t-ID
 	local violations=""
 	local tid
 	while IFS= read -r tid; do
 		[[ -z "$tid" ]] && continue
 		local num
 		num=$(printf '%s' "$tid" | tr -d 't')
-
 		if ! [[ "$num" =~ ^[0-9]+$ ]]; then
 			_debug "Non-numeric suffix for $tid — skipping"
 			continue
 		fi
-
-		# If numeric_id <= counter, the ID is claimed (or pre-dates the counter)
 		if [[ "$num" -le "$counter" ]]; then
 			_debug "$tid ≤ counter ($counter) — allowed"
 			continue
 		fi
-
 		_debug "$tid ($num) > counter ($counter) — suspicious, checking linked issues"
-
-		# The ID is beyond the current counter. Check if any linked issue title
-		# contains this t-ID (cross-reference confirmation).
-		local confirmed=0
-
-		if [[ -z "$closing_issues" ]]; then
-			# No closing issues — cannot possibly cross-reference. Reject.
-			_debug "$tid: no closing issues — marking as violation"
-			violations="${violations}  ${tid} — numeric ID ${num} > current counter ${counter}, and not confirmed via a linked issue title\n"
-			continue
-		fi
-
-		# Has closing issues. Need gh to verify — check availability first.
-		if ! command -v gh >/dev/null 2>&1; then
-			_warn "gh not available — fail-open (CI will validate on push)"
+		local verify_rc
+		_verify_tid_via_issues "$tid" "$closing_issues"
+		verify_rc=$?
+		if [[ "$verify_rc" -eq 2 ]]; then
 			return 2
 		fi
-
-		local iss_num
-		local gh_had_error=0
-		while IFS= read -r iss_num; do
-			[[ -z "$iss_num" ]] && continue
-			local title
-			title=$(gh issue view "$iss_num" --json title --jq '.title' 2>/dev/null)
-			local gh_rc=$?
-			if [[ "$gh_rc" -ne 0 || -z "$title" ]]; then
-				_debug "gh issue view #${iss_num} failed (rc=${gh_rc}) — marking gh_had_error"
-				gh_had_error=1
-				continue
-			fi
-			_debug "Issue #${iss_num} title: $title"
-			if printf '%s' "$title" | grep -qE "(^|[^0-9])${tid}([^0-9]|$)"; then
-				_debug "$tid confirmed via linked issue #${iss_num}"
-				confirmed=1
-				break
-			fi
-		done <<<"$closing_issues"
-
-		# If all gh calls failed (offline, unauthenticated, API error) → fail-open
-		if [[ "$gh_had_error" -eq 1 && "$confirmed" -eq 0 ]]; then
-			_warn "gh API error during cross-reference check — fail-open (CI will validate on push)"
-			return 2
-		fi
-
-		if [[ "$confirmed" -eq 0 ]]; then
+		if [[ "$verify_rc" -eq 1 ]]; then
 			violations="${violations}  ${tid} — numeric ID ${num} > current counter ${counter}, and not confirmed via a linked issue title\n"
 		fi
 	done <<<"$tids"
 
 	if [[ -n "$violations" ]]; then
-		printf '\n[task-id-guard][BLOCK] Commit subject references invented task ID(s):\n\n' >&2
-		printf '  Subject: %s\n\n' "$subject" >&2
-		printf '%b\n' "$violations" >&2
-		printf '  To fix:\n' >&2
-		printf '    1. Remove the t-ID from the commit subject/body, OR\n' >&2
-		printf '    2. Claim the ID first: claim-task-id.sh --title "..." → then use the allocated ID, OR\n' >&2
-		printf '    3. If cross-referencing another person'"'"'s task, add "Resolves/Closes/Fixes #NNN" footer\n' >&2
-		printf '       where the linked issue title contains the t-ID.\n' >&2
-		printf '  Bypass (sets audit trail): TASK_ID_GUARD_DISABLE=1 git commit ...  or git commit --no-verify\n\n' >&2
+		_report_violations "$violations" "$subject"
 		return 1
 	fi
 


### PR DESCRIPTION
## Summary

Extracted _verify_tid_via_issues() and _report_violations() helpers from _check_message(), reducing it from 126 to 69 lines. No behaviour change.

## Files Changed

.agents/hooks/task-id-collision-guard.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n and shellcheck both pass with zero violations. _check_message() is now 69 lines, under the 100-line threshold.

Resolves #18718


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.8 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 2m and 8,820 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal task ID verification system with better code organization and error handling in the pre-commit validation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->