### PR TITLE
GH#18539: fix review-followup findings in new-task-helper.sh

### DIFF
--- a/.agents/scripts/new-task-helper.sh
+++ b/.agents/scripts/new-task-helper.sh
@@ -136,7 +136,12 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
-# _append_todo_entry: append a single task line to TODO.md
+# _append_todo_entry: insert a single task line under the active backlog
+# header in TODO.md (## Ready, fallback to ## Backlog), preserving file
+# structure. Falls back to EOF append only if no header is found.
+#
+# Caller MUST validate `$todo_file` exists before calling (cmd_batch does
+# this once before the loop — the check is NOT repeated here per GH#18539).
 # ---------------------------------------------------------------------------
 _append_todo_entry() {
 	local task_id="$1"
@@ -153,13 +158,48 @@ _append_todo_entry() {
 
 	local entry="- [ ] ${task_id} ${title} #auto-dispatch ~1h${ref_field} logged:${today}"
 
-	# Append under the first "## " section header that looks like an active backlog
-	# If no suitable header, append at end of file
-	if [[ -f "$todo_file" ]]; then
-		echo "$entry" >>"$todo_file"
+	# Scan for the first "## Ready" (or "## Backlog") header and track the
+	# last "- [ ]" task line within that section. Insert after that line so
+	# new tasks land at the bottom of the active backlog, not after ## Done.
+	#
+	# Regex is stored in a variable per Bash Pitfall #46: inline regex with
+	# backslash-brackets can be parsed ambiguously against POSIX char classes.
+	local header_re='^##[[:space:]]+(Ready|Backlog)'
+	local next_header_re='^##'
+	local task_re='^-[[:space:]]+\[[[:space:]]+\]'
+	local header_line=0 last_task_line=0 line_num=0
+	local in_section=false
+	local file_line=""
+	while IFS= read -r file_line; do
+		line_num=$((line_num + 1))
+		if [[ "$in_section" == false && "$file_line" =~ $header_re ]]; then
+			in_section=true
+			header_line=$line_num
+			last_task_line=$line_num
+			continue
+		fi
+		if [[ "$in_section" == true ]]; then
+			# Hit the next ## header — stop scanning this section.
+			if [[ "$file_line" =~ $next_header_re ]]; then
+				break
+			fi
+			# Track the last task checkbox in the section.
+			if [[ "$file_line" =~ $task_re ]]; then
+				last_task_line=$line_num
+			fi
+		fi
+	done <"$todo_file"
+
+	if [[ "$header_line" -gt 0 ]]; then
+		# Insert after the last task line (or header if section is empty).
+		local tmp_file
+		tmp_file=$(mktemp)
+		awk -v n="$last_task_line" -v entry="$entry" \
+			'NR==n{print; print entry; next}1' \
+			"$todo_file" >"$tmp_file" && mv "$tmp_file" "$todo_file"
 	else
-		log_error "TODO.md not found at: $todo_file"
-		return 1
+		log_warn "No ## Ready or ## Backlog header found in $todo_file — appending at end"
+		echo "$entry" >>"$todo_file"
 	fi
 
 	return 0
@@ -244,16 +284,22 @@ _parse_batch_args() {
 }
 
 # ---------------------------------------------------------------------------
-# _read_titles_stream: read titles from the current stdin, stripping inline
-# `#` comments and whitespace, appending non-empty lines to `_BATCH_TITLES`.
+# _read_titles_stream: read titles from the current stdin, skipping full-line
+# comments and whitespace, appending non-empty lines to `_BATCH_TITLES`.
 # Called with stdin redirected by the caller (file or pipe).
+#
+# GH#18539: only skip lines that START with `#` (after whitespace). The
+# previous `${line%%#*}` destroyed legitimate titles like "Fix bug #123",
+# "Add PR #42 handler", or any title containing a GitHub issue reference.
 # ---------------------------------------------------------------------------
 _read_titles_stream() {
 	local line
 	while IFS= read -r line; do
-		line="${line%%#*}"                      # strip inline comments
 		line="${line#"${line%%[![:space:]]*}"}" # ltrim
 		line="${line%"${line##*[![:space:]]}"}" # rtrim
+		# Skip full-line comments (entire line is a comment) but preserve
+		# inline `#` refs — do NOT strip with ${line%%#*}.
+		[[ "$line" =~ ^# ]] && continue
 		[[ -n "$line" ]] && _BATCH_TITLES+=("$line")
 	done
 	return 0
@@ -313,7 +359,10 @@ _allocate_one_task() {
 
 	local claim_output=""
 	local claim_rc=0
-	claim_output=$("$claim_script" "${claim_args[@]}" 2>/dev/null) || claim_rc=$?
+	# GH#18539: do NOT suppress claim-task-id.sh stderr — users need to see
+	# auth failures, network errors, and lock contention. Suppressing hides
+	# the diagnostic output that tells them why allocation failed.
+	claim_output=$("$claim_script" "${claim_args[@]}") || claim_rc=$?
 
 	# claim-task-id.sh uses rc 2 for "offline, id claimed locally" — still success
 	if [[ $claim_rc -ne 0 && $claim_rc -ne 2 ]]; then
@@ -454,6 +503,13 @@ cmd_batch() {
 		repo_path=$(git rev-parse --show-toplevel 2>/dev/null || echo "$PWD")
 	fi
 	local todo_file="$repo_path/TODO.md"
+
+	# GH#18539: validate TODO.md once at cmd_batch entry, not per-task
+	# inside `_append_todo_entry`. Fails fast if the target file is missing.
+	if [[ ! -f "$todo_file" ]]; then
+		log_error "TODO.md not found at: $todo_file"
+		return 1
+	fi
 
 	local claim_script="$SCRIPT_DIR/claim-task-id.sh"
 	if [[ ! -x "$claim_script" ]]; then


### PR DESCRIPTION
## Summary

Addresses all 4 actionable review bot findings from PR #18416 on `.agents/scripts/new-task-helper.sh`, re-applied against the post-refactor structure from #18724.

1. **HIGH — TODO.md insertion position**: `_append_todo_entry` was appending to EOF with `>>`, landing new tasks after `## Done` and TOON blocks. Now scans for `## Ready` (falling back to `## Backlog`), tracks the last `- [ ]` task line within that section, and inserts after it via awk. Empty-section, no-header (EOF fallback with warning), and Backlog-only cases are all handled.

2. **MEDIUM — Destructive `#` stripping**: `_read_titles_stream` used `${line%%#*}` which destroyed titles like "Fix bug #123" or "Add PR #42 handler". Changed to skip only lines that START with `#` (after whitespace trim), preserving inline `#` references.

3. **MEDIUM — Redundant TODO.md check**: The file existence check was inside `_append_todo_entry` (called once per task). Moved to `cmd_batch` — validated once before the allocation loop starts. `_append_todo_entry` now assumes the caller validated (documented in the header comment).

4. **MEDIUM — Suppressed stderr**: `2>/dev/null` on `claim-task-id.sh` hid auth failures, network errors, and lock contention. Removed so allocation diagnostics surface properly.

### Why fresh PR instead of rebasing #18604

PR #18604 was created before two substantial refactors landed on main: #18724 (`cmd_batch` decomposed into focused helpers under 100 lines) and #18607+#18610 (`post-merge-review-scanner.sh` gained full inline bodies, file:line refs, `[View inline comment]` links, comprehensive Worker Guidance, and `needs-maintainer-review` gating). The rebase conflicts were too intrusive to resolve cleanly, and the scanner changes in #18604 were obsolete relative to current main. Closed #18604 with explanation; this PR applies just the 4 `new-task-helper.sh` fixes to the current refactored structure, no obsolete scanner changes.

### Bash regex fix

While implementing, hit Bash Pitfall #46 — inline regex with backslash-brackets (`\\[[[:space:]]\\]`) parses ambiguously against POSIX char classes. Moved all three regexes (`header_re`, `next_header_re`, `task_re`) into variables, per the standard workaround. Smoke-tested with 4 TODO.md layouts (populated Ready, Backlog fallback, empty section, no matching header).

## Files Changed

.agents/scripts/new-task-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** - `shellcheck .agents/scripts/new-task-helper.sh` — clean
- `bash -n` syntax check — clean
- Unit smoke tests for `_append_todo_entry`: Ready/Backlog/empty-section/EOF-fallback all pass
- Unit smoke test for `_read_titles_stream`: inline `#123`, `#42`, `#issue-18539` all preserved; full-line and indented `#` comments all skipped
- End-to-end `batch --dry-run` against a throwaway repo: allocates, prints summary, preserves inline `#` in titles
- Missing TODO.md check fires with clear error and exit 1

Risk: **low** (batch task creation helper, no critical paths, planning-only script)
Verification: `self-assessed`

Resolves #18539


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.8 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 10m and 1,175 tokens on this as a headless worker.