### PR TITLE
GH#18623: strip origin:worker label independently of simplification-debt

### DIFF
--- a/.github/workflows/issue-triage-gate.yml
+++ b/.github/workflows/issue-triage-gate.yml
@@ -60,6 +60,11 @@ jobs:
             // GH#18197: simplification-debt issues are exclusively machine-generated.
             // A non-maintainer creating one is either a mistake or an attempt to bypass
             // the assignee gate. Strip the label and apply needs-maintainer-review.
+            //
+            // GH#18623: origin:worker is ALSO machine-only — strip it independently of
+            // simplification-debt. A non-maintainer opening an issue with only the
+            // origin:worker label would previously keep that label, since the stripping
+            // logic was nested inside the simplification-debt check.
             const issueLabels = (issue.labels || []).map(l => l.name);
             if (issueLabels.includes('simplification-debt')) {
               console.log(`Non-maintainer ${author} created issue with simplification-debt label — stripping label and gating`);
@@ -73,7 +78,9 @@ jobs:
               } catch (e) {
                 // Label may not be present — fine
               }
-              // Also strip origin:worker if present (belt-and-suspenders)
+            }
+            if (issueLabels.includes('origin:worker')) {
+              console.log(`Non-maintainer ${author} created issue with origin:worker label — stripping label`);
               try {
                 await github.rest.issues.removeLabel({
                   owner: context.repo.owner,


### PR DESCRIPTION
## Summary

Addresses the CodeRabbit Major finding from PR #18310 review: `origin:worker` label stripping was gated on `simplification-debt` label presence, so a non-maintainer could open an issue with only `origin:worker` and the label would not be stripped.

## Fix

Pull the `origin:worker` check out of the `simplification-debt` block so both checks run independently:

- If non-maintainer adds `simplification-debt` → strip it.
- If non-maintainer adds `origin:worker` (with or without `simplification-debt`) → strip it.

Either or both labels are now handled correctly.

## Files changed

- `.github/workflows/issue-triage-gate.yml` — lines 60-93 (~8 net additions)

## Verification

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/issue-triage-gate.yml'))"` passes (YAML valid)
- Logic trace: non-maintainer issue with `['origin:worker']` (no simplification-debt) now enters the second `if` and removes the label.

Resolves #18623

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.8 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 12m and 37,931 tokens on this as a headless worker.
