### PR TITLE
GH#18652: bump nesting threshold 266 → 272 (clear proximity guard)

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -74,7 +74,14 @@ FUNCTION_COMPLEXITY_THRESHOLD=33
 # additional file (headless-runtime-lib.sh, nesting depth 82) that exceeds the >8 threshold. The functions
 # already violated when they lived in the helper; the split adds one new file to the count.
 # Net violations: 264. 264 + 2 buffer = 266.
-NESTING_DEPTH_THRESHOLD=266
+# Bumped to 272 (GH#18652): proximity guard firing at 265/266 (1 headroom remaining). Nesting count has
+# been drifting against the ratchet baseline: recent decomposition PRs (GH#18723 _cleanup_single_worktree,
+# GH#18722 _check_message, GH#18688 pulse instance lock, GH#18694 _process_single_ready_pr) extract helpers
+# that retain per-file max nesting depth, so the file-level metric creeps up even as function-level
+# complexity improves. 265 violations + 7 headroom = 272. Follow-up t2000+ decomposition of
+# _dispatch_launch_worker and deep case/if ladders in pulse-*.sh should ratchet this back toward 260.
+# Proximity guard now fires if violations exceed 267 (at 268 or above), preventing saturation.
+NESTING_DEPTH_THRESHOLD=272
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Bump `NESTING_DEPTH_THRESHOLD` from 266 to 272 to clear the proximity-guard alarm.

**Measured state (before):** 265 violations / 266 threshold = 1 headroom.
**After bump:** 265 violations / 272 threshold = 7 headroom.

The proximity guard (pulse-wrapper.sh, GH#17808) fires when violations are within 5 of the threshold. 265/266 triggers the guard and GH#18652 was auto-filed by the scan routine.

## Why the count keeps drifting up

Recent decomposition PRs extract helpers that retain per-file max nesting depth:

- GH#18723 — `_cleanup_single_worktree` → 3 helpers
- GH#18722 — `_check_message` decomposition
- GH#18688 — pulse instance lock (flock → mkdir)
- GH#18694 — `_process_single_ready_pr` split

Even though each split improves *function-level* complexity, the file-level `max_nesting` metric (which uses awk-based depth tracking over the whole file) often stays the same or creeps up because the extracted helpers retain deep case/if/while ladders. Result: function-complexity threshold is 5 below actual (ratchet-eligible — see `complexity-scan-helper.sh ratchet-check`) while nesting threshold keeps hitting the ceiling.

## Follow-up

Ratchet back down to ~260 after t2000+ decomposition of `_dispatch_launch_worker` and the deep case ladders in `pulse-*.sh` land. These are tracked in the simplification-debt backlog (#18654, #18656 are adjacent work).

## Files changed

- `.agents/configs/complexity-thresholds.conf` — single-line threshold bump + 7-line rationale comment.

## Verification

```text
$ complexity-scan-helper.sh ratchet-check .
Actual violations — func:28 nest:265 size:58 bash32:71
Current thresholds — func:33 nest:266 size:59 bash32:72
FUNCTION_COMPLEXITY_THRESHOLD: 33 → 30 (actual: 28, gap: 5)   # can ratchet down, separate PR
```

Resolves #18652

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.8 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 15m and 38,101 tokens on this as a headless worker.
