### PR TITLE
GH#18621: complete remaining CodeRabbit findings on claude-proxy (abort cleanup + model table)

### DIFF
--- a/.agents/plugins/opencode-aidevops/claude-proxy.mjs
+++ b/.agents/plugins/opencode-aidevops/claude-proxy.mjs
@@ -494,7 +494,7 @@ function buildClaudeArgs(body, systemPrompt, streaming) {
   return args;
 }
 
-async function runClaudeJsonWithAccount(body, directory, account) {
+async function runClaudeJsonWithAccount(body, directory, account, abortSignal) {
   const childEnv = buildChildEnvWithToken(account.token);
   const child = spawn("claude", buildClaudeArgs(body, body.systemPrompt, false), {
     cwd: directory,
@@ -508,6 +508,23 @@ async function runClaudeJsonWithAccount(body, directory, account) {
     child.kill("SIGKILL");
   }, CHILD_TIMEOUT_MS);
 
+  // Abort cleanup: if the caller's request is aborted (client disconnect),
+  // terminate the child immediately (GH#18621 Finding 1).
+  const onAbort = () => {
+    if (child.exitCode === null && !child.killed) {
+      try {
+        child.kill("SIGTERM");
+        console.error(`[aidevops] Claude proxy: json request aborted by client, killed child pid=${child.pid}`);
+      } catch {
+        // best effort
+      }
+    }
+  };
+  if (abortSignal) {
+    if (abortSignal.aborted) onAbort();
+    else abortSignal.addEventListener("abort", onAbort, { once: true });
+  }
+
   const stdoutChunks = [];
   const stderrChunks = [];
 
@@ -519,6 +536,7 @@ async function runClaudeJsonWithAccount(body, directory, account) {
     child.on("error", () => resolve(1));
   });
   clearTimeout(timeout);
+  if (abortSignal) abortSignal.removeEventListener("abort", onAbort);
   const stdout = Buffer.concat(stdoutChunks).toString("utf-8").trim();
   const stderr = Buffer.concat(stderrChunks).toString("utf-8").trim();
 
@@ -546,15 +564,16 @@ async function runClaudeJsonWithAccount(body, directory, account) {
   };
 }
 
-async function runClaudeJson(body, directory) {
+async function runClaudeJson(body, directory, abortSignal) {
   const accounts = await getAvailableAccounts();
   if (accounts.length === 0) {
     throw new Error("No Anthropic OAuth pool accounts available (all rate-limited or no valid tokens)");
   }
 
   for (const account of accounts) {
+    if (abortSignal && abortSignal.aborted) throw new Error("Request aborted by client");
     console.error(`[aidevops] Claude proxy: trying account ${account.email} (json mode)`);
-    const result = await runClaudeJsonWithAccount(body, directory, account);
+    const result = await runClaudeJsonWithAccount(body, directory, account, abortSignal);
     if (!result.rateLimited) {
       return result;
     }
@@ -665,7 +684,7 @@ function processStreamEvent(event, ctx) {
  * rate limiting before committing to the stream. Returns "rate_limited" if the
  * account is rate-limited, otherwise streams to completion and returns "done".
  */
-function tryStreamWithAccount(controller, encoder, completionId, created, body, directory, account) {
+function tryStreamWithAccount(controller, encoder, completionId, created, body, directory, account, abortRef) {
   return new Promise((resolve) => {
     const childEnv = buildChildEnvWithToken(account.token);
     const child = spawn("claude", buildClaudeArgs(body, body.systemPrompt, true), {
@@ -674,11 +693,20 @@ function tryStreamWithAccount(controller, encoder, completionId, created, body, 
       stdio: ["ignore", "pipe", "pipe"],
     });
 
+    // Expose the running child so the enclosing ReadableStream can signal it
+    // on client disconnect via the `cancel` callback (GH#18621 Finding 1).
+    if (abortRef) abortRef.child = child;
+
     // Lifetime bound: kill child if it exceeds timeout
     const timeout = setTimeout(() => {
       console.error(`[aidevops] Claude proxy: stream child timeout (${CHILD_TIMEOUT_MS}ms), killing`);
       child.kill("SIGKILL");
     }, CHILD_TIMEOUT_MS);
+
+    // If the caller already signalled cancel before the child spawned, kill immediately.
+    if (abortRef && abortRef.cancelled) {
+      child.kill("SIGTERM");
+    }
 
     let buffer = "";
     let closed = false;
@@ -826,6 +854,11 @@ function streamClaudeResponse(body, directory) {
   const created = Math.floor(Date.now() / 1000);
   const encoder = new TextEncoder();
 
+  // Shared ref between start() and cancel() so the cancel callback can kill
+  // whatever child is currently running (GH#18621 Finding 1 — client disconnect
+  // cleanup). `child` is mutated by tryStreamWithAccount as each retry spawns.
+  const abortRef = { child: null, cancelled: false };
+
   return new ReadableStream({
     async start(controller) {
       const accounts = await getAvailableAccounts();
@@ -845,8 +878,9 @@ function streamClaudeResponse(body, directory) {
       }
 
       for (const account of accounts) {
+        if (abortRef.cancelled) return; // client already bailed
         console.error(`[aidevops] Claude proxy: trying account ${account.email} (stream mode)`);
-        const result = await tryStreamWithAccount(controller, encoder, completionId, created, body, directory, account);
+        const result = await tryStreamWithAccount(controller, encoder, completionId, created, body, directory, account, abortRef);
         if (result === "rate_limited") {
           console.error(`[aidevops] Claude proxy: account ${account.email} rate-limited, trying next...`);
           continue;
@@ -865,6 +899,20 @@ function streamClaudeResponse(body, directory) {
         controller.close();
       } catch {
         // already closed
+      }
+    },
+    cancel(reason) {
+      // Client disconnected (or opencode aborted) — kill the in-flight child
+      // so it stops consuming quota and touching the workspace (GH#18621).
+      abortRef.cancelled = true;
+      const child = abortRef.child;
+      if (child && child.exitCode === null && !child.killed) {
+        try {
+          child.kill("SIGTERM");
+          console.error(`[aidevops] Claude proxy: stream cancelled by client (${reason || "no-reason"}), killed child pid=${child.pid}`);
+        } catch {
+          // best effort
+        }
       }
     },
   });
@@ -941,7 +989,9 @@ async function handleChatCompletions(req, directory) {
   }
 
   if (incoming.stream === false) {
-    const result = await runClaudeJson(body, directory);
+    // Thread the fetch Request's abort signal into the JSON path so client
+    // disconnect terminates the child immediately (GH#18621 Finding 1).
+    const result = await runClaudeJson(body, directory, req.signal);
     return new Response(JSON.stringify(buildOpenAIResponse(body, result.content, result.usage)), {
       headers: { "Content-Type": "application/json" },
     });

--- a/.agents/plugins/opencode-aidevops/config-hook.mjs
+++ b/.agents/plugins/opencode-aidevops/config-hook.mjs
@@ -30,37 +30,46 @@ function claudeModelDef(overrides) {
   };
 }
 
-/** Models registered under the built-in anthropic provider (via aidevops OAuth pool). */
-const ANTHROPIC_MODELS = {
-  "claude-haiku-4-5": claudeModelDef({
-    name: "Claude Haiku 4.5 (via aidevops)",
-    limit: { context: 1000000, output: 32000 },
-  }),
-  "claude-sonnet-4-6": claudeModelDef({
-    name: "Claude Sonnet 4.6 (via aidevops)",
-    limit: { context: 1000000, output: 64000 },
-  }),
-  "claude-opus-4-6": claudeModelDef({
-    name: "Claude Opus 4.6 (via aidevops)",
-    limit: { context: 1000000, output: 64000 },
-  }),
+/**
+ * Single source of truth for Claude model limits (GH#18621 Finding 5).
+ * Both ANTHROPIC_MODELS and CLAUDECLI_MODELS derive their `limit` from here so
+ * the transport metadata stays consistent no matter which provider
+ * registration path runs first.
+ */
+const CLAUDE_MODEL_LIMITS = {
+  "claude-haiku-4-5":  { context: 1000000, output: 32000 },
+  "claude-sonnet-4-6": { context: 1000000, output: 64000 },
+  "claude-opus-4-6":   { context: 1000000, output: 64000 },
 };
 
+/**
+ * Build a provider model map from CLAUDE_MODEL_LIMITS with provider-specific
+ * display names. Preserves backward compatibility with the previous
+ * ANTHROPIC_MODELS / CLAUDECLI_MODELS shapes.
+ * @param {Record<string,string>} names - model id → display name
+ * @returns {Record<string,object>}
+ */
+function buildClaudeModelMap(names) {
+  const out = {};
+  for (const [id, limit] of Object.entries(CLAUDE_MODEL_LIMITS)) {
+    out[id] = claudeModelDef({ name: names[id] || id, limit });
+  }
+  return out;
+}
+
+/** Models registered under the built-in anthropic provider (via aidevops OAuth pool). */
+const ANTHROPIC_MODELS = buildClaudeModelMap({
+  "claude-haiku-4-5":  "Claude Haiku 4.5 (via aidevops)",
+  "claude-sonnet-4-6": "Claude Sonnet 4.6 (via aidevops)",
+  "claude-opus-4-6":   "Claude Opus 4.6 (via aidevops)",
+});
+
 /** Models registered under the claudecli provider (via Claude CLI proxy). */
-const CLAUDECLI_MODELS = {
-  "claude-haiku-4-5": claudeModelDef({
-    name: "Claude Haiku 4.5 (via CLI)",
-    limit: { context: 1000000, output: 32000 },
-  }),
-  "claude-sonnet-4-6": claudeModelDef({
-    name: "Claude Sonnet 4.6 (via CLI)",
-    limit: { context: 1000000, output: 64000 },
-  }),
-  "claude-opus-4-6": claudeModelDef({
-    name: "Claude Opus 4.6 (via CLI)",
-    limit: { context: 1000000, output: 64000 },
-  }),
-};
+const CLAUDECLI_MODELS = buildClaudeModelMap({
+  "claude-haiku-4-5":  "Claude Haiku 4.5 (via CLI)",
+  "claude-sonnet-4-6": "Claude Sonnet 4.6 (via CLI)",
+  "claude-opus-4-6":   "Claude Opus 4.6 (via CLI)",
+});
 
 /**
  * Upsert aidevops-managed models into the anthropic and claudecli providers.


### PR DESCRIPTION
## Summary

Closes the remaining unaddressed CodeRabbit findings from PR #18343 (Claude CLI transport proxy).

### Findings status on entry to this PR

| # | Severity | Status on `main` at PR creation |
|---|----------|-------|
| 1. Bound subprocess lifetime | 🟠 Major | Partial — `CHILD_TIMEOUT_MS` timeout existed (10 min), but no abort cleanup on client disconnect |
| 2. Normalize routed model aliases | 🔴 Critical | **Already addressed** — `MODEL_ALIASES` mapping in `handleChatCompletions` (lines 900-911) |
| 3. Drop raw request dump from /tmp | 🟠 Major | **Already addressed** — `DEBUG_DUMP_ENABLED` env gate on the dump (line 931) |
| 4. Remove placeholder claudecli provider when proxy unavailable | 🟠 Major | **Already addressed** — `config-hook.mjs` deletes `config.provider.claudecli` when `!claudeProxyPort` (line 261) |
| 5. Centralize Claude model table | 🟡 Minor | Partial — shared `claudeModelDef()` helper existed, but `limit` fields were still duplicated between `ANTHROPIC_MODELS` and `CLAUDECLI_MODELS` |

This PR closes the two remaining gaps (1 and 5).

## Fix 1 — subprocess abort cleanup (GH#18621 Finding 1)

**Streaming path (`streamClaudeResponse`):**

The `ReadableStream` init now has a `cancel()` callback. A shared `abortRef` is threaded into `tryStreamWithAccount`, which updates `abortRef.child` as each account retry spawns a new subprocess. When the client disconnects, `cancel()` SIGTERM-kills whatever child is currently running. The existing 10-minute `CHILD_TIMEOUT_MS` remains as the worst-case backstop.

```js
cancel(reason) {
  abortRef.cancelled = true;
  const child = abortRef.child;
  if (child && child.exitCode === null && !child.killed) {
    child.kill("SIGTERM");
  }
}
```

**JSON path (`runClaudeJson` / `runClaudeJsonWithAccount`):**

Both functions now accept an optional `AbortSignal`. `handleChatCompletions` threads in `req.signal` from the incoming fetch Request. On abort, the listener SIGTERMs the child and removes itself in the `close` handler to avoid leaks on the normal path.

## Fix 5 — single source of truth for Claude model limits

**`.agents/plugins/opencode-aidevops/config-hook.mjs`:**

- New `CLAUDE_MODEL_LIMITS` constant defines `{context, output}` per model id — one place, three entries.
- New `buildClaudeModelMap(names)` helper constructs a provider-scoped model map from `CLAUDE_MODEL_LIMITS` with provider-specific display names.
- `ANTHROPIC_MODELS` and `CLAUDECLI_MODELS` are now both built via `buildClaudeModelMap()`, eliminating the drift risk that CodeRabbit flagged.

## Files changed

- `.agents/plugins/opencode-aidevops/claude-proxy.mjs` — abort handling (+47 lines)
- `.agents/plugins/opencode-aidevops/config-hook.mjs` — CLAUDE_MODEL_LIMITS consolidation (+31/-31 net-neutral)

## Verification

```bash
node --check .agents/plugins/opencode-aidevops/claude-proxy.mjs   # passes
node --check .agents/plugins/opencode-aidevops/config-hook.mjs     # passes
```

Resolves #18621

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.8 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 20m and 43,674 tokens on this as a headless worker.
