### PR TITLE
t2058: fix shellcheck SC2154 on install_brew/install_python in setup/_common.sh

### DIFF
--- a/.agents/scripts/setup/_common.sh
+++ b/.agents/scripts/setup/_common.sh
@@ -374,6 +374,10 @@ ensure_homebrew() {
 	print_info "Homebrew (Linuxbrew) is not installed."
 	print_info "Several optional tools (Beads CLI, Worktrunk, bv) install via Homebrew taps."
 	echo ""
+	# Declare before setup_prompt so shellcheck can track it (SC2154).
+	# setup_prompt assigns via `printf -v $var_name`, which shellcheck
+	# cannot follow across the function boundary.
+	local install_brew=""
 	setup_prompt install_brew "Install Homebrew for Linux? [Y/n]: " "Y"
 
 	if [[ ! "$install_brew" =~ ^[Yy]?$ ]]; then
@@ -588,6 +592,10 @@ offer_python_brew_install() {
 		return 1
 	fi
 
+	# Declare before setup_prompt so shellcheck can track it (SC2154).
+	# setup_prompt assigns via `printf -v $var_name`, which shellcheck
+	# cannot follow across the function boundary.
+	local install_python=""
 	setup_prompt install_python "${prompt_verb} Python via Homebrew now? [Y/n]: " "Y"
 	if [[ "$install_python" =~ ^[Yy]?$ ]]; then
 		if run_with_spinner "Installing $recommended_formula" brew install "$recommended_formula"; then


### PR DESCRIPTION
## Summary

setup_prompt assigns variables indirectly via `printf -v $var_name`, which shellcheck cannot track through the function boundary. The two SC2154 warnings were caught by `version-manager.sh release patch` preflight (which scans all files changed since last tag) after PR #18728 touched the same file for an unrelated color-guard fix.

Declared `local install_brew=""` and `local install_python=""` before the respective `setup_prompt` calls. This both silences the warning AND makes scoping explicit — the variables now stay local to their caller instead of being created in whatever outer scope `printf -v` would land in.

No behavioural change.

## Files Changed

.agents/scripts/setup/_common.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** - `shellcheck .agents/scripts/setup/_common.sh` — clean
- `bash -n` — clean
- No functional test needed: the change is a 2-line scoping declaration, no runtime path alteration.

Risk: **low**
Verification: `self-assessed`

Resolves #18741


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.8 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 1h 7m and 1,175 tokens on this as a headless worker.