### PR TITLE
t2057: Phase 2 — wire interactive-session-helper into worktree, claim-task-id, approval paths

### DIFF
--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -352,6 +352,38 @@ _post_issue_approval_updates() {
 		# is idempotent). Unlock still happens after worker completion.
 		gh issue lock "$target_number" --repo "$slug" --reason "resolved" >/dev/null 2>&1 || true
 		_print_info "Issue #$target_number locked (scope finalized, unlocks after worker completion)"
+
+		# t2057: idempotent release of status:in-review. If the maintainer was
+		# interactively reviewing this contributor issue before signing the
+		# cryptographic approval, the `interactive-session-helper.sh claim`
+		# will have applied `status:in-review`. Clear it here so the pulse
+		# dispatch-dedup guard no longer blocks — signing is the handoff to
+		# automation, so the interactive hold must lift. Idempotent: no-op
+		# when the label is not present. Delete the stamp too so the local
+		# state matches the remote.
+		local _ah_labels_json
+		_ah_labels_json=$(gh issue view "$target_number" --repo "$slug" \
+			--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null || echo "")
+		if [[ "$_ah_labels_json" == *"status:in-review"* ]]; then
+			# Use set_issue_status from shared-constants.sh for the atomic
+			# status transition. Located via deployed helper first, then
+			# in-repo source.
+			local _ah_helper=""
+			if [[ -x "${HOME}/.aidevops/agents/scripts/interactive-session-helper.sh" ]]; then
+				_ah_helper="${HOME}/.aidevops/agents/scripts/interactive-session-helper.sh"
+			else
+				# Resolve sibling path relative to this file
+				local _ah_script_dir
+				_ah_script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd) || _ah_script_dir=""
+				if [[ -n "$_ah_script_dir" && -x "${_ah_script_dir}/interactive-session-helper.sh" ]]; then
+					_ah_helper="${_ah_script_dir}/interactive-session-helper.sh"
+				fi
+			fi
+			if [[ -n "$_ah_helper" ]]; then
+				"$_ah_helper" release "$target_number" "$slug" >/dev/null 2>&1 || true
+				_print_info "Released status:in-review (interactive review transitioned to available)"
+			fi
+		fi
 	else
 		# GH#17903: Lock PRs at approval time to close the same prompt-injection
 		# window that exists for issues. Without locking, non-collaborators can

--- a/.agents/scripts/claim-task-id.sh
+++ b/.agents/scripts/claim-task-id.sh
@@ -624,6 +624,52 @@ _auto_assign_issue() {
 	return 0
 }
 
+# t2057: interactive session auto-claim on new-task allocation.
+# After the issue is created and self-assigned, transition it to
+# status:in-review so the pulse dispatch-dedup guard treats it as an active
+# claim and won't dispatch a parallel worker. Only fires for interactive
+# sessions — workers leave the status label to their own dispatch flow.
+#
+# Non-blocking — all failure modes (helper missing, slug unresolvable, gh
+# offline) are swallowed. The Phase 1 AI-guidance rule in prompts/build.txt
+# is the primary enforcement layer; this is the code-level safety net.
+_interactive_session_auto_claim_new_task() {
+	local issue_num="$1"
+	local repo_path="$2"
+
+	# Only for interactive sessions
+	local origin
+	origin=$(detect_session_origin 2>/dev/null || echo "interactive")
+	if [[ "$origin" != "interactive" ]]; then
+		return 0
+	fi
+
+	# Resolve slug from the repo remote
+	local slug
+	slug=$(git -C "$repo_path" remote get-url origin 2>/dev/null |
+		sed 's|.*github\.com[:/]||;s|\.git$||' || echo "")
+	if [[ -z "$slug" ]]; then
+		return 0
+	fi
+
+	# Locate the helper. Prefer deployed over in-repo (deployed is runtime
+	# source of truth); silent on missing helper so the claim-task-id.sh
+	# flow still works before Phase 1 has deployed to the environment.
+	local helper=""
+	if [[ -x "${HOME}/.aidevops/agents/scripts/interactive-session-helper.sh" ]]; then
+		helper="${HOME}/.aidevops/agents/scripts/interactive-session-helper.sh"
+	elif [[ -x "${SCRIPT_DIR}/interactive-session-helper.sh" ]]; then
+		helper="${SCRIPT_DIR}/interactive-session-helper.sh"
+	fi
+
+	if [[ -z "$helper" ]]; then
+		return 0
+	fi
+
+	"$helper" claim "$issue_num" "$slug" --worktree "$repo_path" >/dev/null 2>&1 || true
+	return 0
+}
+
 # Try delegating issue creation to issue-sync-helper.sh for rich bodies,
 # proper labels (including auto-dispatch), and duplicate detection (t1324).
 # Echoes the issue number on success, returns 1 if delegation unavailable/failed.
@@ -805,6 +851,7 @@ create_github_issue() {
 	local issue_num
 	if issue_num=$(_try_issue_sync_delegation "$title" "$repo_path"); then
 		_auto_assign_issue "$issue_num" "$repo_path"
+		_interactive_session_auto_claim_new_task "$issue_num" "$repo_path"
 		echo "$issue_num"
 		return 0
 	fi
@@ -853,6 +900,7 @@ create_github_issue() {
 
 	# Auto-assign to current user to prevent duplicate dispatch
 	_auto_assign_issue "$issue_num" "$repo_path"
+	_interactive_session_auto_claim_new_task "$issue_num" "$repo_path"
 
 	echo "$issue_num"
 	return 0

--- a/.agents/scripts/tests/test-dispatch-dedup-multi-operator.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-multi-operator.sh
@@ -332,6 +332,47 @@ test_reconcile_race_second_runner_blocked() {
 	return 0
 }
 
+# ─── Test 8: Interactive session on existing origin:worker issue ─────────────
+#
+# t2057 — When an interactive session engages with an existing origin:worker
+# issue, it calls interactive-session-helper.sh claim which applies
+# status:in-review and self-assigns. The resulting state is:
+#
+#   assignee: testorg (owner, self-assigned by interactive session)
+#   labels:   origin:worker, status:in-review
+#
+# When a pulse worker (runner-b) checks is_assigned(), it must be BLOCKED
+# via the combined signal: owner + active status label (in-review). The
+# origin:worker label is a creation-time marker that does NOT prevent
+# interactive takeover; the status:in-review label is what signals active
+# human ownership. This closes the gap where an interactive session picking
+# up a worker-origin issue previously left no dispatch-blocking signal.
+#
+# Equivalent to Test 4 but with origin:worker present to confirm the label
+# does not confuse the combined rule.
+test_interactive_on_worker_origin_blocks() {
+	# interactive session on existing origin:worker issue: owner self-assigned,
+	# status:in-review applied by interactive-session-helper.sh claim
+	create_gh_stub "testorg" "origin:worker,status:in-review,tier:standard"
+
+	local output=""
+	if output=$("$HELPER_SCRIPT" is-assigned 100 testorg/testrepo runner-b 2>/dev/null); then
+		case "$output" in
+		*'ASSIGNED:'*'testorg'*)
+			print_result "interactive session on origin:worker issue blocks dispatch (t2057)" 0
+			return 0
+			;;
+		esac
+		print_result "interactive session on origin:worker issue blocks dispatch (t2057)" 1 \
+			"exit 0 but unexpected output: ${output}"
+		return 0
+	fi
+
+	print_result "interactive session on origin:worker issue blocks dispatch (t2057)" 1 \
+		"Expected exit 0 (blocked) but got exit 1 (safe). Interactive claim via status:in-review must block parallel worker dispatch."
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
@@ -346,6 +387,7 @@ main() {
 	test_owner_no_label_is_passive
 	test_maintainer_plus_active_label_blocks
 	test_reconcile_race_second_runner_blocked
+	test_interactive_on_worker_origin_blocks
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/worktree-helper.sh
+++ b/.agents/scripts/worktree-helper.sh
@@ -544,6 +544,93 @@ _remove_show_owner_error() {
 	return 0
 }
 
+# t2057 — interactive issue auto-claim from branch name.
+# When cmd_add creates a worktree whose branch encodes an issue number AND
+# the session is interactive, call interactive-session-helper.sh claim to
+# apply status:in-review + self-assign. The label blocks the pulse's
+# dispatch-dedup guard so no parallel worker can be dispatched on the same
+# issue while the interactive session owns it.
+#
+# Branch name patterns accepted:
+#   <prefix>/gh<NNN>-<rest>     e.g., bugfix/gh18700-foo
+#   <prefix>/t<NNN>-<rest>      e.g., feature/t2057-phase2-wire
+#   <prefix>/gh<NNN>_<rest>     (underscore separator)
+#   <prefix>/t<NNN>_<rest>
+#
+# Note: t<NNN> references a task ID and its linked GitHub issue may differ
+# from NNN. When the branch encodes only a t-ID, we resolve the linked issue
+# number via todo/tasks/<taskid>-brief.md ref:GH#NNN when possible; otherwise
+# the claim is skipped (the task-id path doesn't map to a GH issue reliably).
+# The gh<NNN> path is unambiguous.
+#
+# All failure modes are non-blocking — worktree creation proceeds regardless.
+_interactive_session_auto_claim() {
+	local branch="$1"
+	local worktree_path="$2"
+
+	# Only engage for interactive sessions — workers handle their own
+	# claim flow via dispatch-dedup-helper.sh at dispatch time.
+	if [[ -n "${FULL_LOOP_HEADLESS:-}" ]] || [[ -n "${AIDEVOPS_HEADLESS:-}" ]] ||
+		[[ -n "${OPENCODE_HEADLESS:-}" ]] || [[ -n "${GITHUB_ACTIONS:-}" ]]; then
+		return 0
+	fi
+	if [[ "${AIDEVOPS_SESSION_ORIGIN:-}" == "worker" ]]; then
+		return 0
+	fi
+
+	# Parse issue number from branch. Accept gh<N> unambiguously; skip
+	# t<N>-only branches for now (ambiguous without the todo/tasks lookup).
+	local issue_num=""
+	if [[ "$branch" =~ /gh([0-9]+)[-_] ]]; then
+		issue_num="${BASH_REMATCH[1]}"
+	fi
+	if [[ -z "$issue_num" ]]; then
+		# t<N> branch — attempt to resolve the linked issue from the brief file
+		local task_id=""
+		if [[ "$branch" =~ /(t[0-9]+)[-_] ]]; then
+			task_id="${BASH_REMATCH[1]}"
+		fi
+		if [[ -n "$task_id" ]]; then
+			local brief_file
+			brief_file=$(git rev-parse --show-toplevel 2>/dev/null)/todo/tasks/"${task_id}"-brief.md
+			if [[ -f "$brief_file" ]]; then
+				issue_num=$(grep -oE 'GH#[0-9]+|#[0-9]+' "$brief_file" | grep -oE '[0-9]+' | head -1 || true)
+			fi
+		fi
+	fi
+
+	if [[ -z "$issue_num" ]]; then
+		return 0
+	fi
+
+	# Resolve the repo slug from the git remote
+	local slug
+	slug=$(git -C "$worktree_path" remote get-url origin 2>/dev/null |
+		sed 's|.*github\.com[:/]||;s|\.git$||' || echo "")
+	if [[ -z "$slug" ]]; then
+		return 0
+	fi
+
+	# Locate the helper. Prefer the deployed copy (runtime source of truth);
+	# fall back to the in-repo copy when running from the canonical repo
+	# before deploy. Silent on missing helper — the Phase 1 AI rule handles
+	# the agent-driven path.
+	local helper=""
+	if [[ -x "${HOME}/.aidevops/agents/scripts/interactive-session-helper.sh" ]]; then
+		helper="${HOME}/.aidevops/agents/scripts/interactive-session-helper.sh"
+	elif [[ -x "${SCRIPT_DIR}/interactive-session-helper.sh" ]]; then
+		helper="${SCRIPT_DIR}/interactive-session-helper.sh"
+	fi
+
+	if [[ -z "$helper" ]]; then
+		return 0
+	fi
+
+	echo -e "${BLUE}Auto-claiming issue #${issue_num} for interactive session...${NC}"
+	"$helper" claim "$issue_num" "$slug" --worktree "$worktree_path" >/dev/null 2>&1 || true
+	return 0
+}
+
 cmd_add() {
 	local branch="${1:-}"
 	local path="${2:-}"
@@ -599,6 +686,15 @@ cmd_add() {
 
 	# Register ownership (t189)
 	register_worktree "$path" "$branch"
+
+	# t2057: interactive issue auto-claim. When the branch name encodes an
+	# issue number AND this is an interactive session, immediately apply
+	# status:in-review + self-assign so the pulse's dispatch-dedup guard
+	# blocks parallel worker dispatch. Silent on failure — the agent-driven
+	# contract in prompts/build.txt covers the fallback path. Guard on
+	# helper presence so the worktree create works even before Phase 1
+	# has been deployed to the running environment.
+	_interactive_session_auto_claim "$branch" "$path" || true
 
 	echo ""
 	echo -e "${GREEN}Worktree created successfully!${NC}"


### PR DESCRIPTION
## Summary

Phase 2 of the interactive-session auto-claim feature (parent: t2055 / #18738, builds on Phase 1: t2056 / #18744). Wires the interactive-session-helper from Phase 1 into the three sanctioned paths: (1) worktree-helper.sh cmd_add calls _interactive_session_auto_claim when branch name encodes gh<N>- (or t<N>- with brief lookup) and session is interactive — so every wt switch -c against an existing issue gets status:in-review + self-assign automatically; (2) claim-task-id.sh calls _interactive_session_auto_claim_new_task after _auto_assign_issue on both delegated and fallback issue-creation paths — so new interactive tasks land in status:in-review immediately; (3) approval-helper.sh _post_issue_approval_updates idempotently clears status:in-review via the release helper when the label is present — so sudo aidevops approve issue contributor-flow naturally transitions the maintainer's interactive review into worker-dispatchable state. Plus a new +1 test-dispatch-dedup-multi-operator assertion (now 8 tests, all passing) covering the origin:worker + status:in-review + owner-self-assign combined-signal block that confirms the existing _has_active_claim infrastructure correctly handles the interactive takeover case.

## Files Changed

.agents/scripts/approval-helper.sh,.agents/scripts/claim-task-id.sh,.agents/scripts/tests/test-dispatch-dedup-multi-operator.sh,.agents/scripts/worktree-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean on worktree-helper.sh, claim-task-id.sh, approval-helper.sh, test-dispatch-dedup-multi-operator.sh (SC1091 info on pre-existing source lines only); bash test-interactive-session-claim.sh 12/12 pass (regression check against Phase 1 helper); bash test-dispatch-dedup-multi-operator.sh 8/8 pass including new Test 8: interactive session on origin:worker issue blocks dispatch via status:in-review

Resolves #18740


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.10 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 1h 8m and 147,619 tokens on this with the user in an interactive session.