### PR TITLE
fix(full-loop-helper): if-form capture for gh pr merge under set -e

### DIFF
--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -947,9 +947,20 @@ cmd_merge() {
 	# the base-branch-policy error, retry once with `--admin`. Any other
 	# failure is surfaced as-is (no blind --admin escalation).
 	print_info "Merging PR #${pr_number} in ${repo} (${merge_method})..."
-	local _merge_out _merge_rc
-	_merge_out=$(gh pr merge "$pr_number" --repo "$repo" "$merge_method" 2>&1)
-	_merge_rc=$?
+	# Capture output AND exit code under `set -e`. A bare assignment
+	# `_merge_out=$(failing_cmd)` triggers errexit before we reach
+	# `_merge_rc=$?`, so the function exits silently on the first plain-
+	# merge failure and the --admin fallback never runs. The if-form
+	# keeps both available. This is the GH#18538 follow-up to PR #18748,
+	# which shipped the bare-assignment form and was bug-verified
+	# end-to-end (the fallback only worked when run from a worktree with
+	# this fix applied locally before commit).
+	local _merge_out _merge_rc=0
+	if _merge_out=$(gh pr merge "$pr_number" --repo "$repo" "$merge_method" 2>&1); then
+		_merge_rc=0
+	else
+		_merge_rc=$?
+	fi
 	if [[ $_merge_rc -ne 0 ]]; then
 		printf '%s\n' "$_merge_out"
 		if printf '%s' "$_merge_out" | grep -qE 'base branch policy prohibits|Required status checks? (is|are) expected|At least [0-9]+ approving review'; then


### PR DESCRIPTION
## Summary

PR [#18748](https://github.com/marcusquinn/aidevops/pull/18748) shipped the `--admin` fallback for branch-protection rejections (GH#18538), but the implementation used a bare command-substitution under `set -euo pipefail` that exits the script before the exit-code capture runs. The fallback never triggers; the function silently returns 0 without merging.

Switch to the if-form which is portable across bash versions and respects errexit semantics.

## How it was found

PR #18748 self-merged successfully via its own `--admin` fallback — but only because I had this if-form fix applied locally and uncommitted in the worktree at the time I ran the wrapper. The actual merged code was the bare-assignment version, which I verified by checking out fresh main and running the function — it returns silently without printing the fallback path.

## Diff

```diff
-	local _merge_out _merge_rc
-	_merge_out=$(gh pr merge "$pr_number" --repo "$repo" "$merge_method" 2>&1)
-	_merge_rc=$?
+	local _merge_out _merge_rc=0
+	if _merge_out=$(gh pr merge "$pr_number" --repo "$repo" "$merge_method" 2>&1); then
+		_merge_rc=0
+	else
+		_merge_rc=$?
+	fi
```

## Testing

- `bash -n` clean
- `shellcheck` clean (only the pre-existing SC1091 from `shared-constants.sh` source)
- This PR's own merge will be the live test — if the fallback works, the wrapper proves itself.

Ref #18538

---


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.10 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 17h 59m and 69,753 tokens on this with the user in an interactive session.