### PR TITLE
GH#18729: chore: ratchet-down FUNCTION_COMPLEXITY_THRESHOLD 33→30 (GH#18729)

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -28,7 +28,8 @@
 # = threshold (no buffer). Ratchet deferred; _dispatch_launch_worker needs further splitting (t2000+).
 # Ratcheted down to 43 (GH#18695): actual violations 41 + 2 buffer
 # Ratcheted down to 33 (GH#18713): actual violations 31 + 2 buffer
-FUNCTION_COMPLEXITY_THRESHOLD=33
+# Ratcheted down to 30 (GH#18729): actual violations 28 + 2 buffer
+FUNCTION_COMPLEXITY_THRESHOLD=30
 
 # Shell nesting depth: files with >8 levels of nesting
 # NOTE: pulse-wrapper.sh has a proximity guard (GH#17808) that warns when


### PR DESCRIPTION
## Summary

Lowered FUNCTION_COMPLEXITY_THRESHOLD from 33 to 30 in .agents/configs/complexity-thresholds.conf. Actual violations: 28, buffer: 2. Added audit trail comment per ratchet-down convention. simplification-state.json excluded from commit as directed.

## Files Changed

.agents/configs/complexity-thresholds.conf

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** grep FUNCTION_COMPLEXITY_THRESHOLD .agents/configs/complexity-thresholds.conf shows 30. State file not staged (git diff --cached --name-only shows only complexity-thresholds.conf).

Resolves #18729


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.11 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 58s and 2,344 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code quality threshold configurations to maintain code standards.

---

**Note:** This is an internal operational change with no direct impact on end-user functionality or features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->