### PR TITLE
GH#18753: t2062: docs(build.txt): add self-modifying tooling test discipline rule

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -395,6 +395,34 @@ Git is the audit trail. Procedures: AGENTS.md "Git Workflow" section.
 - After editing code: run relevant linter before next edit. Shell: `shellcheck`. MD: `markdownlint-cli2`.
 - Fix immediately, don't batch for commit time.
 
+# Self-modifying tooling test discipline (GH#18538 / t2062)
+# When you edit a script that's part of the test/verification loop you'll
+# subsequently invoke (e.g., `full-loop-helper.sh`, `pre-edit-check.sh`,
+# `claim-task-id.sh`, anything in your own dev wrapper chain), the local
+# working copy IS your test environment. Running the script from the
+# worktree path executes uncommitted edits, not what's in git.
+#
+# Failure mode: the wrapper succeeds locally because of an uncommitted
+# fix; you commit a different (incomplete) version; main ships broken;
+# next worker silently fails. Invisible until someone notices nothing
+# is merging.
+#
+# Rule:
+# 1. Commit the change BEFORE running it as part of verification, OR
+# 2. Re-test after `git stash && git checkout origin/main -- <script>`
+#    to confirm the committed version actually does what you tested.
+# 3. For wrappers that invoke themselves (full-loop-helper.sh merge
+#    being the canonical case), prefer #2 because #1 can't catch the
+#    "I forgot to stage one of the files" variant.
+#
+# This rule applies to scripts only. Product code where the runtime is
+# separate from the source tree (built binaries, deployed services,
+# language runtimes) doesn't have this footgun.
+#
+# Canonical evidence: GH#18538 → PR #18748 (shipped a `set -e` bug
+# that the local self-test passed because of an uncommitted if-form
+# fix) → PR #18750 (hotfix). Both PRs verified the rule end-to-end.
+
 # Intelligence Over Determinism (CORE PRINCIPLE)
 You are an LLM. You can read, understand context, assess state, and act. No regex or state machine can do this. The framework gives goals, tools, boundaries — not scripts.
 


### PR DESCRIPTION
## Summary

Added new subsection to Quality Standards documenting the test discipline for self-modifying scripts. When editing scripts that are part of the test/verification loop, the local working copy IS the test environment. The rule specifies: commit before running as verification, OR re-test from main after commit. Includes canonical evidence from GH#18538/PR#18748/PR#18750.

## Files Changed

.agents/prompts/build.txt

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified: grep -c 'GH#18538 / t2062' .agents/prompts/build.txt returns 1, and git show HEAD:.agents/prompts/build.txt | grep -c 'GH#18538 / t2062' also returns 1, confirming the rule is in both the working copy and committed version.

Resolves #18753


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.11 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-haiku-4-5 spent 41s and 2,103 tokens on this as a headless worker.