### PR TITLE
GH#18745: t2059: docs(build.txt): promote worker-is-triager to universal worker rule

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -254,6 +254,10 @@ When `rtk` installed, prefer `rtk` prefix for: `git status/log/diff`, `gh pr lis
 - YAML frontmatter: tools, model tier, MCP dependencies.
 - Progressive disclosure: pointers to subagents, not inline content.
 
+## Worker Triage Responsibility (GH#18538)
+
+Workers dispatched against auto-generated issue bodies (review-followup, quality-debt, contribution-watch, framework-routing) are the triagers. See `prompts/build.txt` "Worker triage responsibility" for the three-outcome rule (falsify-and-close / implement-and-PR / escalate-with-recommendation). Never apply `needs-maintainer-review` unconditionally at issue creation.
+
 ## Memory Recall (MANDATORY — t2050)
 
 **Non-optional for every non-trivial task.** Before any code change, PR review, debugging session, or design decision, run ONE targeted memory query:

--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -58,6 +58,13 @@ You do the thinking. User gets your recommendation with reasoning — not a menu
 - NEVER punt analysis back as "questions to consider". That's the model's job.
 - Multiple viable approaches? Recommend one. Mention alternatives briefly with trade-offs.
 
+# Worker triage responsibility (GH#18538)
+When dispatched against an auto-generated issue body (review-followup, quality-debt, contribution-watch, framework-routing, any scanner output), YOU are the triager. Verify the factual premise before acting — bot findings can be wrong (hallucinated line refs, false assumptions about codebase structure, template sweeps without measurements). End in exactly one of three outcomes:
+- **A. Premise falsified → close the issue** with a `> Premise falsified. <claim>. <code reality>. Not acting.` rationale comment. No PR. The closing comment trains the next session and the noise filter.
+- **B. Premise correct + obvious fix → implement and PR** with normal lifecycle gate (`Resolves #<this-issue>`).
+- **C. Premise correct but genuinely ambiguous** (architecture / policy / breaking change the worker cannot resolve autonomously) → post a decision comment containing: **Premise check** (one line), **Analysis** (2-4 bullets on trade-offs), **Recommended path** (what you would do if the call were yours, with rationale), **Specific question** (yes/no or pick-one — not open-ended). Then apply `needs-maintainer-review` and stop. The human wakes up to a ready-to-approve recommendation, not a blank task.
+Ambiguity about scope or style is NOT Outcome C. Applying `needs-maintainer-review` at issue creation time — the "punt analysis to a human who hands it back to an AI" anti-pattern — is forbidden. Reasoning responsibility applies here too: you do the thinking.
+
 # Goal-constraint surfacing
 Before non-trivial tasks, restate: (1) actual goal, (2) constraints that must hold, (3) what would make the obvious approach wrong.
 


### PR DESCRIPTION
## Summary

Added 'Worker triage responsibility' section to build.txt (system prompt) and AGENTS.md (user guide) to universalize the three-outcome rule from post-merge-review-scanner.sh. Workers dispatched against auto-generated issue bodies must verify the premise and end in one of three outcomes: A) Premise falsified → close with rationale, B) Premise correct + obvious fix → implement and PR, C) Ambiguous → decision comment with recommendation, then escalate.

## Files Changed

.agents/AGENTS.md,.agents/prompts/build.txt

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified: grep finds 'Worker triage responsibility' in build.txt, grep finds 'Worker Triage Responsibility' in AGENTS.md, all three outcomes (A/B/C) present in build.txt, markdownlint-cli2 clean on AGENTS.md

Resolves #18745


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.11 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-haiku-4-5 spent 54s and 2,820 tokens on this as a headless worker.