### PR TITLE
t2074: fix(aidevops.sh): guard getent + expand shell portability rules (GH#18784)

### DIFF
--- a/.agents/reference/bash-compat.md
+++ b/.agents/reference/bash-compat.md
@@ -1,7 +1,23 @@
 <!-- SPDX-License-Identifier: MIT -->
 <!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
 
-# Bash 3.2 Compatibility (macOS default shell)
+# Shell Portability: bash version + command coreutils
+
+Two independent compatibility axes, both required:
+
+1. **Bash version** — macOS ships bash 3.2.57; Linux ships bash 4.0+. Scripts must run on the LOWEST version (3.2).
+2. **Command coreutils** — macOS ships BSD coreutils (no `getent`, `stat --format`, `readlink -f`, `date -d`, `timeout`); has `dscl`, `sw_vers`, `launchctl`, `pbcopy`. Linux ships GNU coreutils with the inverse. Scripts must run on BOTH.
+
+Regression pattern: a fix for one axis breaks the other. Recent production failures:
+
+- **t2074 (GH#18784)** — #18686 added `getent passwd` to `aidevops.sh` to fix Linux-sudo home resolution, omitted the `command -v getent` guard that `approval-helper.sh:33` had. Broke `sudo aidevops approve` on macOS with `getent: command not found` for a full release cycle.
+- **GH#18770** — #18712 refactored `pulse-wrapper.sh` to fix one bash 3.2 issue but forgot `set -e` exit propagation from a `local var=$(f)` capture. Killed the pulse on Linux silently (launchd kept relaunching).
+- **t1983 (GH#18423)** — GNU-awk-specific dynamic-regex construct silently broke `add_gh_ref_to_todo` on macOS BSD awk for weeks.
+- **#17944** — `stat` argument order was Linux-first across 6 scripts; macOS BSD `stat` ignored them.
+
+**Test both platforms before merging.** ShellCheck catches neither axis — manual review and regression tests required.
+
+## Bash 3.2 Compatibility (macOS default shell)
 
 macOS ships bash 3.2.57. All shell scripts MUST work on this version.
 Bash 4.0+ features silently crash or produce wrong results — no error message.
@@ -64,3 +80,68 @@ zsh tied arrays — NEVER use as loop variables:
 
 - Test with `/bin/bash` (not `/opt/homebrew/bin/bash`) to catch 4.0+ usage
 - ShellCheck does NOT catch: bash version incompatibilities, `"\t"` vs `$'\t'`, zsh tied-array collisions — manual review required
+
+---
+
+## Cross-platform command portability (GNU ↔ BSD ↔ macOS)
+
+Even with a compatible bash version, external commands diverge silently between Linux (GNU coreutils) and macOS (BSD coreutils). The runtime error is usually `command not found` or subtly wrong output — never a lint warning.
+
+**Rule:** any command that is NOT in the intersection of GNU + BSD coreutils MUST be either (a) guarded by `command -v <cmd> &>/dev/null`, (b) branched on `[[ "$(uname)" == "Darwin" ]]`, or (c) wrapped in a canonical portable helper. Never call such commands unconditionally.
+
+### Linux-only commands (crash on macOS without guard)
+
+| Command | macOS alternative | Canonical portable pattern |
+|---------|-------------------|----------------------------|
+| `getent passwd $user` | `dscl . -read /Users/$user NFSHomeDirectory` | `setup-modules/shell-env.sh:33-38` (dscl-first, getent-fallback, $HOME-fallback) |
+| `readlink -f <path>` | `perl -MCwd -e 'print Cwd::realpath($ARGV[0])' "$path"` or loop | Prefer `cd "$(dirname "$f")" && pwd -P` when practical |
+| `stat --format='%Y' <f>` | `stat -f '%m' <f>` | Probe order must be **Linux-first** (GNU `stat --format` fails fast on BSD, allowing the fallback branch). See #17944. |
+| `date -d '1 hour ago'` | `date -v-1H` | Python one-liner is the most portable: `python3 -c 'import datetime; print((datetime.datetime.now()-datetime.timedelta(hours=1)).isoformat())'` |
+| `timeout <secs> <cmd>` | coreutils `gtimeout` if installed, else `perl -e 'alarm shift; exec @ARGV' <secs> <cmd>` | `aidevops.sh:_timeout_cmd()` |
+| `sed -i '...'` (GNU) | `sed -i '' '...'` (BSD requires empty suffix) | `aidevops.sh:sed_inplace()` — `if Darwin; sed -i ''; else sed -i; fi` |
+| `sed -r '...'` (extended regex) | `sed -E '...'` | `sed -E` works on both — always use `-E`, never `-r`. |
+| `grep -P '...'` (PCRE) | N/A on BSD grep | Use `grep -E` with POSIX ERE, or pipe to `perl -ne '...'`. |
+| `awk` dynamic regex `match($0, var)` | BSD awk rejects non-literal regex | Use `gsub()` with literal patterns, or switch to `perl`. Caught production bug t1983. |
+| `xargs -r` | BSD xargs has no `-r`; empty input is a no-op by default | Pre-check input with `[[ -s input ]]` before calling xargs, or use `find ... -exec {} +` which is portable. |
+| `find -printf` | BSD find has no `-printf` | Use `find ... -exec <fmt-cmd> {} +` or pipe through `stat`. |
+| `mktemp --suffix=.X` | BSD mktemp uses `-t prefix` differently | `mktemp -t aidevops.XXXXXX` works on both; never use `--suffix`. |
+| `sha256sum <f>` | `shasum -a 256 <f>` | `shasum -a 256` is POSIX-compliant and available on both. |
+| `base64 -w 0` | BSD `base64` has no `-w`; output is already one line | `base64 \| tr -d '\n'` portable. |
+| `readelf`, `ldd`, `strace`, `lsof` flags | Different or missing | Not typically used in aidevops scripts; document if needed. |
+
+### macOS-only commands (crash on Linux without guard)
+
+| Command | Linux alternative | When used |
+|---------|-------------------|-----------|
+| `dscl . -read /Users/$u NFSHomeDirectory` | `getent passwd $u \| cut -d: -f6` | User home/shell lookup |
+| `sw_vers -productVersion` | `lsb_release -rs` or `/etc/os-release` | OS version detection |
+| `launchctl` | `systemctl` | Scheduler/service management |
+| `pbcopy` / `pbpaste` | `xclip -selection clipboard` or `wl-copy` | Clipboard I/O |
+| `sysctl -n hw.ncpu` | `nproc` or `sysctl -n kernel.ncpu` | CPU count (portable: `getconf _NPROCESSORS_ONLN`) |
+| `defaults read/write` | N/A | macOS plist — always guard with `[[ "$(uname)" == "Darwin" ]]` |
+| `security find-generic-password` | `secret-tool` or gopass | Keychain access |
+| `codesign`, `xcrun`, `hdiutil` | N/A | macOS-only toolchain |
+
+### Canonical portable wrappers (already in-tree)
+
+Prefer these over inlining a conditional each time:
+
+| Wrapper | Location | Purpose |
+|---------|----------|---------|
+| `sed_inplace` | `aidevops.sh:39` | In-place sed edit, BSD/GNU |
+| `_timeout_cmd` | `aidevops.sh:42-55` | Timeout command with perl fallback |
+| `_resolve_real_home()` | `.agents/scripts/approval-helper.sh:32-39` | SUDO_USER home resolution, dscl/getent/`$HOME` |
+| `detect_default_shell()` | `setup-modules/shell-env.sh:28-45` | Login shell, dscl/getent/$SHELL |
+
+When adding a new portable wrapper, document it in this table and ShellCheck-clean it.
+
+### Pre-merge checklist for scripts that touch external commands
+
+Before merging any shell script PR that touches coreutils, answer these:
+
+1. Does the script call any command in the Linux-only or macOS-only tables above? If yes, is it guarded?
+2. Does the CI matrix exercise both macOS + Linux for this script? (`bash-32-scanner` job in `.github/workflows/` + a manual macOS run.)
+3. Is there a regression test that runs under the MISSING platform's conditions? (e.g., `test-aidevops-sh-portability.sh` strips `getent` off PATH to simulate macOS.)
+4. Has the change been reviewed for `set -e` exit-code propagation through `local var=$(f)` captures? (GH#18770 cautionary tale.)
+
+Failing any of these is a P0 regression risk — the bug will only surface on the unreviewed platform, often days after merge when the pulse or approval flow breaks silently.

--- a/.agents/scripts/tests/test-aidevops-sh-portability.sh
+++ b/.agents/scripts/tests/test-aidevops-sh-portability.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-aidevops-sh-portability.sh — Regression tests for cross-platform command
+# portability in aidevops.sh (t2074, GH#18784).
+#
+# Background: PR #18686 added SUDO_USER → getent passwd home resolution to
+# aidevops.sh but omitted the `command -v getent` guard (which the sibling
+# fix in .agents/scripts/approval-helper.sh:33 does include). On macOS, where
+# getent is not part of the base system, `set -euo pipefail` killed aidevops.sh
+# before any subcommand could run, breaking `sudo aidevops approve` completely.
+#
+# This test asserts two things:
+#   1. The home-resolution block in aidevops.sh guards getent behind a
+#      `command -v getent` check. Caught by structural grep against the
+#      source file — no sudo required.
+#   2. The block still returns a sensible home directory when getent is
+#      unavailable, simulated by scrubbing getent off PATH and mocking
+#      `id -u` to return 0 (the in-sudo condition that triggers the bug).
+#
+# Both assertions are portable: they run on bash 3.2 (macOS) and bash 4+
+# (Linux) and do not require root, sudo, or any external fixtures.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit
+AIDEVOPS_SH="${REPO_ROOT}/aidevops.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_YELLOW='\033[1;33m'
+readonly TEST_NC='\033[0m'
+
+pass_count=0
+fail_count=0
+
+_pass() {
+	local msg="$1"
+	printf '%b  PASS:%b %s\n' "${TEST_GREEN}" "${TEST_NC}" "${msg}"
+	pass_count=$((pass_count + 1))
+	return 0
+}
+
+_fail() {
+	local msg="$1"
+	printf '%b  FAIL:%b %s\n' "${TEST_RED}" "${TEST_NC}" "${msg}" >&2
+	fail_count=$((fail_count + 1))
+	return 0
+}
+
+_info() {
+	local msg="$1"
+	printf '%b[INFO]%b %s\n' "${TEST_YELLOW}" "${TEST_NC}" "${msg}"
+	return 0
+}
+
+# -----------------------------------------------------------------------------
+# Test 1: structural guard — the getent call must be inside a `command -v` check
+# -----------------------------------------------------------------------------
+test_getent_structural_guard() {
+	_info "Test 1: aidevops.sh getent call must be guarded"
+
+	if [[ ! -f "${AIDEVOPS_SH}" ]]; then
+		_fail "aidevops.sh not found at ${AIDEVOPS_SH}"
+		return 1
+	fi
+
+	# Extract the line that calls `getent passwd "$SUDO_USER"` and inspect the
+	# `if` statement preceding it. The canonical fixed pattern has the guard
+	# on the same logical line: ` && command -v getent &>/dev/null; then`.
+	local getent_line_num
+	getent_line_num=$(grep -n '^[[:space:]]*_AIDEVOPS_REAL_HOME=.*getent passwd' "${AIDEVOPS_SH}" | head -1 | cut -d: -f1)
+
+	if [[ -z "${getent_line_num}" ]]; then
+		_fail "Could not find _AIDEVOPS_REAL_HOME=... getent passwd line in aidevops.sh"
+		return 1
+	fi
+
+	# Scan the 4 lines immediately above the getent call for the guard
+	local guard_start=$((getent_line_num - 4))
+	[[ ${guard_start} -lt 1 ]] && guard_start=1
+
+	local guard_block
+	guard_block=$(sed -n "${guard_start},${getent_line_num}p" "${AIDEVOPS_SH}")
+
+	if grep -q 'command -v getent' <<<"${guard_block}"; then
+		_pass "getent call is guarded by 'command -v getent' check"
+	else
+		_fail "getent call at line ${getent_line_num} is NOT guarded — regression!"
+		printf 'Context:\n%s\n' "${guard_block}" >&2
+		return 1
+	fi
+	return 0
+}
+
+# -----------------------------------------------------------------------------
+# Test 2: runtime behaviour — resolve correctly with getent absent + SUDO_USER set
+# -----------------------------------------------------------------------------
+test_runtime_fallback_no_getent() {
+	_info "Test 2: runtime resolves via \$HOME fallback when getent is absent"
+
+	local out
+	# Strip getent off PATH, mock `id -u` to return 0, set SUDO_USER, and
+	# execute the exact guard+resolution block copied verbatim from aidevops.sh.
+	# We inline the block rather than sourcing aidevops.sh because sourcing
+	# executes the full CLI dispatcher (which we don't want in a unit test).
+	out=$(bash -c '
+		set -euo pipefail
+		id() { if [[ "${1:-}" == "-u" ]]; then echo 0; else command id "$@"; fi; }
+		export SUDO_USER="fakeuser"
+		export HOME="/tmp/aidevops-test-fake-home"
+		export PATH="/usr/bin:/bin"
+		if command -v getent &>/dev/null; then
+			echo "PRECONDITION_FAIL: getent still on PATH"
+			exit 2
+		fi
+		if [[ -n "${SUDO_USER:-}" && "$(id -u)" -eq 0 ]] && command -v getent &>/dev/null; then
+			_AIDEVOPS_REAL_HOME=$(getent passwd "$SUDO_USER" | cut -d: -f6)
+		else
+			_AIDEVOPS_REAL_HOME="$HOME"
+		fi
+		printf "%s\n" "$_AIDEVOPS_REAL_HOME"
+	' 2>&1) || {
+		_fail "Resolution block errored out: ${out}"
+		return 1
+	}
+
+	if [[ "${out}" == "/tmp/aidevops-test-fake-home" ]]; then
+		_pass "Resolved to \$HOME fallback (${out})"
+	elif [[ "${out}" == *"PRECONDITION_FAIL"* ]]; then
+		_fail "Test harness failure: ${out}"
+		return 1
+	else
+		_fail "Unexpected resolution result: ${out}"
+		return 1
+	fi
+	return 0
+}
+
+# -----------------------------------------------------------------------------
+# Test 3: approval-helper.sh continues to carry the same guard
+# -----------------------------------------------------------------------------
+test_approval_helper_still_guarded() {
+	_info "Test 3: approval-helper.sh _resolve_real_home guard is intact"
+
+	local helper="${REPO_ROOT}/.agents/scripts/approval-helper.sh"
+	if [[ ! -f "${helper}" ]]; then
+		_fail "approval-helper.sh not found at ${helper}"
+		return 1
+	fi
+
+	if grep -q 'command -v getent' "${helper}"; then
+		_pass "approval-helper.sh guards getent correctly"
+	else
+		_fail "approval-helper.sh has lost its command -v getent guard"
+		return 1
+	fi
+	return 0
+}
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+main() {
+	_info "aidevops.sh cross-platform portability regression tests (t2074, GH#18784)"
+	printf '\n'
+
+	test_getent_structural_guard
+	test_runtime_fallback_no_getent
+	test_approval_helper_still_guarded
+
+	printf '\n'
+	printf 'Results: %d passed, %d failed\n' "${pass_count}" "${fail_count}"
+
+	if [[ ${fail_count} -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -19,10 +19,15 @@ BOLD='\033[1m'
 NC='\033[0m' # No Color
 
 # Paths
-# When running under sudo on Linux, HOME is reset to /root/ by env_reset.
-# Resolve the real user's home via SUDO_USER so agent/config paths are correct.
+# When running under sudo on Linux, env_reset rewrites HOME to /root/; SUDO_USER
+# holds the original username. getent passwd is the canonical resolver on Linux.
+# On macOS, sudo preserves HOME by default (env_keep+="HOME MAIL" in /etc/sudoers)
+# and getent is not available, so the fallback to $HOME is correct.
+# The command -v getent guard MUST be present — omitting it crashes aidevops.sh
+# under `set -euo pipefail` on any BSD system and breaks sudo aidevops approve.
+# Mirrors the pattern in .agents/scripts/approval-helper.sh:_resolve_real_home().
 # Security: no escalation — root already has full filesystem access.
-if [[ -n "${SUDO_USER:-}" && "$(id -u)" -eq 0 ]]; then
+if [[ -n "${SUDO_USER:-}" && "$(id -u)" -eq 0 ]] && command -v getent &>/dev/null; then
 	_AIDEVOPS_REAL_HOME=$(getent passwd "$SUDO_USER" | cut -d: -f6)
 else
 	_AIDEVOPS_REAL_HOME="$HOME"


### PR DESCRIPTION
## Summary

Fixes the partial-fix regression from #18686 that broke `sudo aidevops approve` on macOS with `getent: command not found`, and expands `bash-compat.md` into a dual-axis "Shell Portability" reference covering both bash version AND coreutils portability.

## The bug

PR #18686 added `SUDO_USER` → `getent passwd` home resolution to both `aidevops.sh` and `approval-helper.sh` to fix Linux sudo env_reset. **Only `approval-helper.sh` got the `command -v getent` guard** (line 33); `aidevops.sh:26` called `getent` unconditionally when `SUDO_USER` was set and we were root — which is always true under sudo on both platforms. On macOS, `getent` does not exist, so the command substitution failed and `set -euo pipefail` killed `aidevops.sh` at line 26 before any subcommand could run.

**Reproduced on:** macOS 15, bash 3.2.57, sudo 1.9.17p2. The user's sudoers carries `env_keep+="HOME MAIL"` so the `$HOME` fallback is correct.

## Fix

### `aidevops.sh` — one-line guard (mirrors `approval-helper.sh:33`)

```diff
-if [[ -n "${SUDO_USER:-}" && "$(id -u)" -eq 0 ]]; then
+if [[ -n "${SUDO_USER:-}" && "$(id -u)" -eq 0 ]] && command -v getent &>/dev/null; then
     _AIDEVOPS_REAL_HOME=$(getent passwd "$SUDO_USER" | cut -d: -f6)
 else
     _AIDEVOPS_REAL_HOME="$HOME"
 fi
```

### `.agents/reference/bash-compat.md` — systemic expansion

Renamed intro to **"Shell Portability: bash version + command coreutils"**. Added a new top-level **"Cross-platform command portability"** section covering:

- **GNU-only commands table** (13 rows): `getent`, `readlink -f`, `stat --format`, `date -d`, `timeout`, `sed -i`, `sed -r`, `grep -P`, `awk` dynamic regex, `xargs -r`, `find -printf`, `mktemp --suffix`, `sha256sum`, `base64 -w`.
- **macOS-only commands table** (8 rows): `dscl`, `sw_vers`, `launchctl`, `pbcopy`, `sysctl hw.*`, `defaults`, `security`, `codesign`.
- **Canonical portable wrappers table** with `file:line` refs: `sed_inplace`, `_timeout_cmd`, `_resolve_real_home`, `detect_default_shell`.
- **Pre-merge checklist** — four questions every PR touching coreutils must answer, including a callout for the `set -e` + `local var=$(f)` gotcha that caused GH#18770.
- **Production-failure examples** cited in the intro: t2074 (this fix), GH#18770 (pulse-wrapper set -e), t1983 (BSD awk dynamic regex), #17944 (stat argument order).

### `test-aidevops-sh-portability.sh` — regression test

Three assertions, all portable across bash 3.2 and bash 4+, no root required:

1. **Structural grep** — `aidevops.sh` must contain `command -v getent` within 4 lines of the `getent passwd "$SUDO_USER"` call. Fails loudly if the guard is reintroduced.
2. **Runtime simulation** — runs the exact resolution block with `PATH=/usr/bin:/bin`, `SUDO_USER=fakeuser`, mocked `id -u` returning 0. Asserts `$HOME` fallback resolves correctly.
3. **Companion guard** — asserts `approval-helper.sh:_resolve_real_home()` still carries its own `command -v getent` check.

All three pass locally on bash 3.2.57 (macOS). ShellCheck clean, markdownlint clean.

## Acceptance criteria

- [x] `aidevops.sh:26` uses `command -v getent` guard (mirrors `approval-helper.sh:33`)
- [x] `aidevops --version` runs without error on macOS (verified: `aidevops 3.8.14`)
- [x] `bash-compat.md` has "Cross-platform command portability" section with GNU/BSD/macOS tables
- [x] `tests/test-aidevops-sh-portability.sh` passes (3/3)
- [x] ShellCheck clean on aidevops.sh + new test
- [x] markdownlint clean on bash-compat.md

## Verification for the user

After merging, on macOS:

```bash
aidevops update
sudo aidevops approve issue 18770
# should prompt for SSH passphrase, NOT 'getent: command not found'
```

## Out of scope (follow-ups I'll file separately)

1. **Static scanner** — a linter that greps all `.sh` files for unguarded Linux/macOS-only command calls. Patterns are listed in the new doc table, but no automated check yet.
2. **CI matrix** — pre-merge checklist item 2 ("does CI exercise both macOS + Linux") is aspirational; only Linux runs in GitHub Actions today. macOS CI is a separate cost/capability question.
3. **Secondary `StandardOutput=` quoting finding** from GH#18770 — affects `setup-modules/schedulers.sh`, `auto-update-helper.sh`, `repo-sync-helper.sh` via `_systemd_escape`. Flagged in the review comment; will file as tier:standard.

Resolves #18784


---


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.14 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 17m and 20,596 tokens on this with the user in an interactive session. Overall, 6m since this issue was created.
