### PR TITLE
GH#18786: fix set -e exit in interactive-session-helper.sh claim flow

### DIFF
--- a/.agents/scripts/interactive-session-helper.sh
+++ b/.agents/scripts/interactive-session-helper.sh
@@ -122,12 +122,23 @@ _isc_gh_reachable() {
 
 # Check whether an issue already carries `status:in-review`. Returns 0 when
 # present, 1 when absent, 2 when the metadata lookup failed.
+#
+# NOTE on the jq query: the two-argument form `any(generator; condition)`
+# passed `.name` as the generator on `(.labels // [])`, which tries to
+# index the *array itself* with string "name" and raises
+# "Cannot index array with string". The single-argument form
+# `any(condition)` iterates over the array automatically, which is both
+# shorter and correct. This was a latent bug that masked the bug fixed
+# in GH#18786 — the jq error (exit 5) was swallowed by `>/dev/null 2>&1`
+# and the function always returned 1 ("label absent"), so the idempotency
+# branch was dead code even before the set -e exit propagation killed
+# the whole claim flow.
 _isc_has_in_review() {
 	local issue="$1"
 	local slug="$2"
 	local json
 	json=$(gh issue view "$issue" --repo "$slug" --json labels 2>/dev/null) || return 2
-	if printf '%s' "$json" | jq -e '(.labels // []) | any(.name; . == "status:in-review")' >/dev/null 2>&1; then
+	if printf '%s' "$json" | jq -e '(.labels // []) | any(.name == "status:in-review")' >/dev/null 2>&1; then
 		return 0
 	fi
 	return 1
@@ -262,15 +273,15 @@ _isc_cmd_claim() {
 		return 0
 	fi
 
-	# Idempotency: if already in-review, just refresh the stamp and exit
-	local had_label=1
-	_isc_has_in_review "$issue" "$slug"
-	local has_rc=$?
-	if [[ $has_rc -eq 0 ]]; then
-		had_label=0
-	fi
-
-	if [[ $had_label -eq 0 ]]; then
+	# Idempotency: if already in-review, just refresh the stamp and exit.
+	# NOTE: `_isc_has_in_review` legitimately returns non-zero ("label absent"
+	# = 1, "lookup failed" = 2). Under `set -e`, a bare call followed by
+	# `local rc=$?` capture kills this function before `rc=$?` runs — because
+	# the unchecked non-zero return propagates up through the parent function.
+	# Use a direct `if` conditional so the return is consumed by the branch,
+	# which `set -e` treats as a tested condition and does not propagate.
+	# Sibling bug class: GH#18770 (pulse self-check), GH#18784 (aidevops.sh getent).
+	if _isc_has_in_review "$issue" "$slug"; then
 		_isc_info "claim: #$issue already has status:in-review — refreshing stamp"
 		_isc_write_stamp "$issue" "$slug" "$worktree_path" "$user"
 		return 0
@@ -350,10 +361,14 @@ _isc_cmd_release() {
 		return 0
 	fi
 
-	# Idempotency: skip label work if not in-review
-	local has_rc
-	_isc_has_in_review "$issue" "$slug"
-	has_rc=$?
+	# Idempotency: skip label work if not in-review. `_isc_has_in_review`
+	# has three return states (0 = present, 1 = absent, 2 = lookup failed),
+	# so we need the actual rc — but a bare call under `set -e` propagates
+	# non-zero returns before `rc=$?` can capture them. Use `|| rc=$?` which
+	# is a tested condition that `set -e` does not propagate. Default to 0
+	# so the "present" branch (rc=0) falls through to the transition below.
+	local has_rc=0
+	_isc_has_in_review "$issue" "$slug" || has_rc=$?
 	if [[ $has_rc -eq 1 ]]; then
 		_isc_info "release: #$issue not in status:in-review — no-op"
 		return 0
@@ -363,7 +378,12 @@ _isc_cmd_release() {
 		return 0
 	fi
 
-	# Transition in-review -> available
+	# Transition in-review -> available. Build the flag list as a plain
+	# array and expand it with the `${arr[@]+"${arr[@]}"}` guard so an
+	# empty array doesn't trip `set -u` on bash 3.2 (macOS default). This
+	# is the idiom documented in reference/bash-compat.md "empty array
+	# expansion". Fourth latent bug found alongside GH#18786: previously
+	# masked because the broken jq query made this branch unreachable.
 	local -a extra_flags=()
 	if [[ $unassign -eq 1 ]]; then
 		local user
@@ -373,7 +393,7 @@ _isc_cmd_release() {
 		fi
 	fi
 
-	if set_issue_status "$issue" "$slug" "available" "${extra_flags[@]}" >/dev/null 2>&1; then
+	if set_issue_status "$issue" "$slug" "available" ${extra_flags[@]+"${extra_flags[@]}"} >/dev/null 2>&1; then
 		_isc_info "release: #$issue → status:available"
 		return 0
 	fi
@@ -552,31 +572,37 @@ EOF
 
 main() {
 	local cmd="${1:-help}"
+	local rc=0
 	shift || true
 
+	# `|| rc=$?` is the `set -e`-safe idiom for capturing subcommand exit
+	# codes. A bare call inside a case branch propagates non-zero returns
+	# out of main() before `return $?` runs (e.g. _isc_cmd_status returning
+	# 1 for "target issue not found"). Use a tested-condition capture so
+	# set -e treats the subcommand as a branch condition and leaves rc intact.
 	case "$cmd" in
 	claim)
-		_isc_cmd_claim "$@"
+		_isc_cmd_claim "$@" || rc=$?
 		;;
 	release)
-		_isc_cmd_release "$@"
+		_isc_cmd_release "$@" || rc=$?
 		;;
 	status)
-		_isc_cmd_status "$@"
+		_isc_cmd_status "$@" || rc=$?
 		;;
 	scan-stale)
-		_isc_cmd_scan_stale "$@"
+		_isc_cmd_scan_stale "$@" || rc=$?
 		;;
 	help | -h | --help)
-		_isc_cmd_help
+		_isc_cmd_help || rc=$?
 		;;
 	*)
 		_isc_err "unknown subcommand: $cmd"
-		_isc_cmd_help
+		_isc_cmd_help || true
 		return 2
 		;;
 	esac
-	return $?
+	return "$rc"
 }
 
 # Only run main when executed, not when sourced (allows tests to source and

--- a/.agents/scripts/tests/test-interactive-session-claim.sh
+++ b/.agents/scripts/tests/test-interactive-session-claim.sh
@@ -60,6 +60,11 @@ STUB_BIN="${TEST_ROOT}/stub-bin"
 STUB_LOG="${TEST_ROOT}/stub-calls.log"
 mkdir -p "$STUB_BIN"
 : >"$STUB_LOG"
+# Export STUB_LOG so subprocess invocations of the stub gh see it. Without
+# the export, subprocesses spawned by `"$HELPER_PATH" claim ...` inherit an
+# unset STUB_LOG and the stub logs to /dev/null, making subprocess-driven
+# assertions blind. Added in the GH#18786 regression coverage.
+export STUB_LOG
 
 # Default stub mode — override via STUB_GH_MODE
 #   online   — gh returns successful responses
@@ -321,6 +326,130 @@ if [[ $bad_issue_rc -eq 2 ]]; then
 	print_result "claim with non-numeric issue returns exit 2" 0
 else
 	print_result "claim with non-numeric issue returns exit 2" 1 "(rc=$bad_issue_rc, expected 2)"
+fi
+
+# =============================================================================
+# Test 11 — GH#18786 regression: claim must reach the label-apply branch
+# under the script's own `set -euo pipefail` when the label is absent.
+#
+# The reported bug was that a bare `_isc_has_in_review` call followed by
+# `has_rc=$?` capture killed _isc_cmd_claim before it could apply the
+# label — because `set -e` propagates unchecked non-zero returns out of
+# the parent function immediately, so `has_rc=$?` never runs. The other
+# tests in this file source the helper and run with `set +e`, which masks
+# this class entirely. This test EXECUTES the helper as a subprocess so
+# the script's `set -euo pipefail` at line 42 is live.
+#
+# A second latent bug was a broken `jq -e 'any(.name; ...)'` query in
+# _isc_has_in_review that raised "Cannot index array with string 'name'"
+# on jq 1.7+, swallowed by `2>&1 /dev/null`, and caused the function to
+# always report "label absent" — masking the set -e bug from Test 2's
+# idempotency assertion (which runs under set +e in source mode).
+#
+# A third latent bug was `"${extra_flags[@]}"` under bash 3.2 set -u,
+# previously unreachable because of the broken jq query.
+#
+# This regression test covers all three by asserting that:
+#   (a) The subprocess exits 0 (set -e did not kill it mid-flight)
+#   (b) `gh issue edit` was called with --add-label status:in-review
+#       (i.e. the label-apply branch actually ran)
+#   (c) A stamp file landed (end-of-claim side effect ran)
+#   (d) The idempotent path (label present) exits 0 AND hits the
+#       "already has status:in-review" info message without calling
+#       `gh issue edit` (no transition spam on repeat claims)
+#
+# Reference: GH#18786, reference/bash-compat.md checklist item 4, sibling
+# set -e bug class GH#18770 and GH#18784.
+# =============================================================================
+
+# Reset stamp dir for a clean run
+rm -f "${claim_dir}"/*.json 2>/dev/null || true
+: >"$STUB_LOG"
+
+# --- Case (a-c): label absent, subprocess exit must be 0 with label applied ---
+STUB_ISSUE_HAS_IN_REVIEW=0 STUB_GH_MODE=online \
+	"$HELPER_PATH" claim 56001 regress/test --worktree /tmp/regress-wt \
+	>/dev/null 2>&1
+subprocess_rc=$?
+
+regress_stamp="${claim_dir}/regress-test-56001.json"
+if [[ $subprocess_rc -eq 0 && -f "$regress_stamp" ]]; then
+	print_result "GH#18786: claim subprocess exits 0 under set -euo pipefail" 0
+else
+	print_result "GH#18786: claim subprocess exits 0 under set -euo pipefail" 1 \
+		"(rc=$subprocess_rc, stamp exists=$([[ -f "$regress_stamp" ]] && echo yes || echo no))"
+fi
+
+# Verify the label-apply branch actually ran (gh issue edit was called with
+# the add-label flag). This closes the test gap where Test 1 only checks the
+# stamp, not whether the label transition API call happened.
+if grep -q 'issue edit 56001' "$STUB_LOG" && grep -q 'add-label status:in-review' "$STUB_LOG"; then
+	print_result "GH#18786: claim applies status:in-review when absent" 0
+else
+	print_result "GH#18786: claim applies status:in-review when absent" 1 \
+		"(stub log: $(tr '\n' '|' <"$STUB_LOG"))"
+fi
+
+# --- Case (d): idempotent path — label already present, no transition ---
+rm -f "${claim_dir}"/*.json 2>/dev/null || true
+: >"$STUB_LOG"
+
+idempotent_out=$(STUB_ISSUE_HAS_IN_REVIEW=1 STUB_GH_MODE=online \
+	"$HELPER_PATH" claim 56001 regress/test --worktree /tmp/regress-wt \
+	2>&1)
+idempotent_rc=$?
+
+if [[ $idempotent_rc -eq 0 ]] && printf '%s' "$idempotent_out" | grep -q 'already has status:in-review'; then
+	print_result "GH#18786: claim idempotent when label already present (subprocess)" 0
+else
+	print_result "GH#18786: claim idempotent when label already present (subprocess)" 1 \
+		"(rc=$idempotent_rc, out=${idempotent_out:0:200})"
+fi
+
+# Idempotent path MUST NOT call gh issue edit (saves an API round-trip and
+# prevents spurious label-change noise on every re-claim).
+if ! grep -q 'issue edit' "$STUB_LOG"; then
+	print_result "GH#18786: idempotent claim skips gh issue edit" 0
+else
+	print_result "GH#18786: idempotent claim skips gh issue edit" 1 \
+		"(stub log: $(tr '\n' '|' <"$STUB_LOG"))"
+fi
+
+# --- Case (e): release subprocess also survives set -euo pipefail ---
+rm -f "${claim_dir}"/*.json 2>/dev/null || true
+: >"$STUB_LOG"
+
+# Pre-populate a stamp so release has something to delete
+STUB_ISSUE_HAS_IN_REVIEW=0 "$HELPER_PATH" claim 56002 regress/test >/dev/null 2>&1
+
+release_sub_rc=0
+STUB_ISSUE_HAS_IN_REVIEW=1 "$HELPER_PATH" release 56002 regress/test >/dev/null 2>&1 || release_sub_rc=$?
+release_stamp="${claim_dir}/regress-test-56002.json"
+
+if [[ $release_sub_rc -eq 0 && ! -f "$release_stamp" ]]; then
+	print_result "GH#18786: release subprocess exits 0 under set -euo pipefail" 0
+else
+	print_result "GH#18786: release subprocess exits 0 under set -euo pipefail" 1 \
+		"(rc=$release_sub_rc, stamp exists=$([[ -f "$release_stamp" ]] && echo yes || echo no))"
+fi
+
+# --- Case (f): _isc_has_in_review jq query is not broken (dead-code gate) ---
+# The previous `any(.name; ...)` form raised "Cannot index array with string".
+# Assert the repaired query correctly distinguishes present from absent and
+# from lookup-failure by driving _isc_has_in_review directly with stub modes.
+export STUB_ISSUE_HAS_IN_REVIEW=1
+_isc_has_in_review 56003 regress/test
+jq_present_rc=$?
+
+export STUB_ISSUE_HAS_IN_REVIEW=0
+_isc_has_in_review 56003 regress/test
+jq_absent_rc=$?
+
+if [[ $jq_present_rc -eq 0 && $jq_absent_rc -eq 1 ]]; then
+	print_result "GH#18786: _isc_has_in_review jq query returns 0/1 correctly" 0
+else
+	print_result "GH#18786: _isc_has_in_review jq query returns 0/1 correctly" 1 \
+		"(present_rc=$jq_present_rc, absent_rc=$jq_absent_rc, expected 0/1)"
 fi
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Repair three latent bugs in interactive-session-helper.sh that combined to break the t2056 interactive issue ownership protocol. Under set -euo pipefail, the bare _isc_has_in_review call at line 267 propagated its legitimate 'label absent' return (rc=1) out of _isc_cmd_claim before 'has_rc=$?' could capture it, so the function exited silently and never applied status:in-review. The same pattern lived at line 355 in _isc_cmd_release. Both were replaced with set -e-safe idioms ('if f; then' in claim, '|| rc=$?' in release). A second latent bug in _isc_has_in_review ('jq any(.name; cond)' form) always raised 'Cannot index array with string' on jq 1.7+, masked by '2>&1 /dev/null', which made the idempotency branch unreachable even before set -e killed it. A third latent bug in _isc_cmd_release ('${extra_flags[@]}' under bash 3.2 set -u) was previously unreachable because of the jq bug; now that the path is live, it needed the standard '${arr[@]+"${arr[@]}"}' guard from reference/bash-compat.md. The main() dispatcher was also hardened so subcommand returns are captured with '|| rc=$?' rather than relying on 'return $?' after a case block that set -e would have killed.

## Files Changed

.agents/scripts/interactive-session-helper.sh,.agents/scripts/tests/test-interactive-session-claim.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean on both files; all 18 tests pass (12 original + 6 new regression assertions); verified regression tests FAIL on pristine buggy version (5 distinct failures caught); end-to-end verified against GH#18786 via both idempotent and absent paths; bash -x trace confirms full code path executes to completion

Resolves #18786


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.15 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 10m and 29,468 tokens on this as a headless worker.