### PR TITLE
GH#18802: chore(GH#18802): ratchet-down complexity thresholds (func:30→23, nest:272→269)

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -29,7 +29,8 @@
 # Ratcheted down to 43 (GH#18695): actual violations 41 + 2 buffer
 # Ratcheted down to 33 (GH#18713): actual violations 31 + 2 buffer
 # Ratcheted down to 30 (GH#18729): actual violations 28 + 2 buffer
-FUNCTION_COMPLEXITY_THRESHOLD=30
+# Ratcheted down to 23 (GH#18802): actual violations 21 + 2 buffer
+FUNCTION_COMPLEXITY_THRESHOLD=23
 
 # Shell nesting depth: files with >8 levels of nesting
 # NOTE: pulse-wrapper.sh has a proximity guard (GH#17808) that warns when
@@ -82,7 +83,8 @@ FUNCTION_COMPLEXITY_THRESHOLD=30
 # complexity improves. 265 violations + 7 headroom = 272. Follow-up t2000+ decomposition of
 # _dispatch_launch_worker and deep case/if ladders in pulse-*.sh should ratchet this back toward 260.
 # Proximity guard now fires if violations exceed 267 (at 268 or above), preventing saturation.
-NESTING_DEPTH_THRESHOLD=272
+# Ratcheted down to 269 (GH#18802): actual violations 267 + 2 buffer
+NESTING_DEPTH_THRESHOLD=269
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Lowered FUNCTION_COMPLEXITY_THRESHOLD from 30 to 23 (actual violations: 21 + 2 buffer) and NESTING_DEPTH_THRESHOLD from 272 to 269 (actual violations: 267 + 2 buffer). Added ratchet-down comments for audit trail. simplification-state.json not staged.

## Files Changed

.agents/configs/complexity-thresholds.conf

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Ran .agents/scripts/complexity-scan-helper.sh ratchet-check . 5 — output: actual violations func:21 nest:267 both within new thresholds (23, 269). No simplification-state.json in diff.

Resolves #18802


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.17 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 1m and 2,807 tokens on this as a headless worker.