### PR TITLE
GH#18804: fix(pulse-dispatch) log every fill-floor skip reason + PULSE_DEBUG flag

### DIFF
--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -191,6 +191,29 @@ _DFF_CANARY_CACHE=""
 _DFF_THROTTLE_CLEARED=0
 
 #######################################
+# Emit per-candidate debug output for the deterministic fill floor (GH#18804).
+#
+# Always writes to LOGFILE (so the operator sees it in pulse.log). When
+# PULSE_DEBUG is set to a truthy value, the message is prefixed with DEBUG:
+# and emitted unconditionally — useful for one-off operator runs that need
+# verbose per-candidate visibility into label state, dedup probes, and skip
+# decisions.
+#
+# Arguments:
+#   $1 - message body (plain text, no leading prefix)
+# Returns: 0 always
+#######################################
+pulse_dispatch_debug_log() {
+	local message="$1"
+	case "${PULSE_DEBUG:-}" in
+	1 | true | TRUE | yes | YES | on | ON)
+		echo "[pulse-wrapper] DFF DEBUG: ${message}" >>"$LOGFILE"
+		;;
+	esac
+	return 0
+}
+
+#######################################
 # Compute the dispatch capacity for this round.
 #
 # Stdout: "<max_workers> <active_workers> <available_slots>" on success.
@@ -267,7 +290,29 @@ _dff_should_skip_candidate() {
 	local issue_number="$1"
 	local repo_slug="$2"
 
-	if check_terminal_blockers "$issue_number" "$repo_slug" >/dev/null 2>&1; then
+	pulse_dispatch_debug_log "evaluating skip checks for #${issue_number} (${repo_slug})"
+
+	# GH#18804: previously this call used `>/dev/null 2>&1` which suppressed
+	# the helper's own log lines AND, more dangerously, masked silent
+	# false-positive matches across every candidate in a round. The only
+	# observable symptom was `candidates=N` followed immediately by
+	# `Adaptive settle wait: 0 dispatches` with nothing between.
+	#
+	# The set -e-safe capture idiom here is REQUIRED, not stylistic:
+	# `_dff_should_skip_candidate` runs inside the dispatch loop, which
+	# itself runs inside the `dispatch_deterministic_fill_floor` subshell
+	# created by `fill_dispatched=$(dispatch_deterministic_fill_floor)`.
+	# Under `set -euo pipefail` an unguarded `if helper; then` is fine,
+	# but ANY internal capture or assignment that fails would abort the
+	# subshell silently. Capturing the rc explicitly keeps the failure
+	# mode visible in LOGFILE rather than swallowed by the outer `||`.
+	# Same bug class as GH#18770, GH#18784, GH#18786 — see
+	# `.agents/reference/bash-compat.md` pre-merge checklist item 4.
+	local terminal_rc=0
+	check_terminal_blockers "$issue_number" "$repo_slug" >>"$LOGFILE" 2>&1 || terminal_rc=$?
+	pulse_dispatch_debug_log "#${issue_number}: check_terminal_blockers rc=${terminal_rc}"
+	if [[ "$terminal_rc" -eq 0 ]]; then
+		echo "[pulse-wrapper] Deterministic fill floor: skipping #${issue_number} (${repo_slug}) — terminal blocker detected (check_terminal_blockers rc=0)" >>"$LOGFILE"
 		return 0
 	fi
 
@@ -282,6 +327,7 @@ _dff_should_skip_candidate() {
 	# and the current claim-task-id.sh stub marker.
 	local issue_body
 	issue_body=$(gh issue view "$issue_number" --repo "$repo_slug" --json body --jq '.body // ""' 2>/dev/null) || issue_body=""
+	pulse_dispatch_debug_log "#${issue_number}: body length=${#issue_body}"
 	if [[ -z "$issue_body" || "$issue_body" == "Task created via claim-task-id.sh" ]]; then
 		echo "[pulse-wrapper] Deterministic fill floor: skipping #${issue_number} (${repo_slug}) — placeholder/empty issue body, needs enrichment before dispatch" >>"$LOGFILE"
 		return 0
@@ -291,6 +337,7 @@ _dff_should_skip_candidate() {
 		return 0
 	fi
 
+	pulse_dispatch_debug_log "#${issue_number}: passed all skip checks — proceeding to dispatch"
 	return 1
 }
 
@@ -354,8 +401,20 @@ _dff_process_candidate() {
 	issue_url=$(printf '%s' "$candidate_json" | jq -r '.url // empty' 2>/dev/null)
 	issue_title=$(printf '%s' "$candidate_json" | jq -r '.title // empty' 2>/dev/null | tr '\n' ' ')
 	labels_csv=$(printf '%s' "$candidate_json" | jq -r '(.labels // []) | join(",")' 2>/dev/null)
-	[[ "$issue_number" =~ ^[0-9]+$ ]] || return 1
-	[[ -n "$repo_slug" && -n "$repo_path" ]] || return 1
+
+	# GH#18804: previously the next two checks silently `return 1`-ed without
+	# logging. Operators saw `candidates=N` but no per-candidate skip lines,
+	# making malformed candidate JSON impossible to diagnose from pulse.log.
+	if [[ ! "$issue_number" =~ ^[0-9]+$ ]]; then
+		echo "[pulse-wrapper] Deterministic fill floor: skipping malformed candidate — issue_number='${issue_number}' is not numeric (candidate_json prefix: ${candidate_json:0:120})" >>"$LOGFILE"
+		return 1
+	fi
+	if [[ -z "$repo_slug" || -z "$repo_path" ]]; then
+		echo "[pulse-wrapper] Deterministic fill floor: skipping #${issue_number} — missing repo_slug='${repo_slug}' or repo_path='${repo_path}'" >>"$LOGFILE"
+		return 1
+	fi
+
+	pulse_dispatch_debug_log "processing #${issue_number} (${repo_slug}) labels=[${labels_csv}]"
 
 	if _dff_should_skip_candidate "$issue_number" "$repo_slug"; then
 		return 1
@@ -367,11 +426,13 @@ _dff_process_candidate() {
 		prompt="${prompt} (${issue_url})"
 	fi
 	model_override=$(resolve_dispatch_model_for_labels "$labels_csv")
+	pulse_dispatch_debug_log "#${issue_number}: model_override=${model_override:-<auto>} — calling dispatch_with_dedup"
 
 	local dispatch_rc=0
 	dispatch_with_dedup "$issue_number" "$repo_slug" "$dispatch_title" "$issue_title" \
 		"$self_login" "$repo_path" "$prompt" "issue-${issue_number}" "$model_override" || dispatch_rc=$?
 	if [[ "$dispatch_rc" -ne 0 ]]; then
+		echo "[pulse-wrapper] Deterministic fill floor: skipping #${issue_number} (${repo_slug}) — dispatch_with_dedup returned rc=${dispatch_rc}" >>"$LOGFILE"
 		return 1
 	fi
 
@@ -379,7 +440,10 @@ _dff_process_candidate() {
 	_DFF_ROUND_DISPATCHED=$((_DFF_ROUND_DISPATCHED + 1))
 	_PULSE_LAST_LAUNCH_FAILURE=""
 
-	if ! check_worker_launch "$issue_number" "$repo_slug" >/dev/null 2>&1; then
+	local launch_rc=0
+	check_worker_launch "$issue_number" "$repo_slug" >/dev/null 2>&1 || launch_rc=$?
+	if [[ "$launch_rc" -ne 0 ]]; then
+		echo "[pulse-wrapper] Deterministic fill floor: #${issue_number} (${repo_slug}) launch validation failed (rc=${launch_rc}, last_failure='${_PULSE_LAST_LAUNCH_FAILURE}')" >>"$LOGFILE"
 		_dff_record_launch_failure
 		return 1
 	fi
@@ -458,9 +522,23 @@ dispatch_deterministic_fill_floor() {
 
 	echo "[pulse-wrapper] Deterministic fill floor: available=${available_slots}, runnable=${runnable_count}, queued_without_worker=${queued_without_worker}, candidates=${candidate_count}" >>"$LOGFILE"
 
-	local prepass_line triage_dispatched
-	prepass_line=$(_dff_run_prepasses "$available_slots")
+	# GH#18804: Guard the prepass capture against `set -e` kill propagating
+	# from nested helpers (dispatch_triage_reviews / dispatch_enrichment_workers
+	# can run gh/jq/MODEL_AVAILABILITY_HELPER subprocesses whose failures
+	# would otherwise abort this entire subshell silently — the `||` fallback
+	# keeps the function alive and surfaces the failure in pulse.log instead.
+	# Same set-e-in-subshell bug class as GH#18770. The fallback "$slots 0"
+	# preserves the pre-prepass slot count and assumes 0 triage dispatches.
+	local prepass_line=""
+	local triage_dispatched=0
+	if ! prepass_line=$(_dff_run_prepasses "$available_slots" 2>>"$LOGFILE"); then
+		echo "[pulse-wrapper] Deterministic fill floor: _dff_run_prepasses returned non-zero — assuming 0 triage/enrichment, full slot budget" >>"$LOGFILE"
+		prepass_line="${available_slots} 0"
+	fi
 	read -r available_slots triage_dispatched <<<"$prepass_line"
+	[[ "$available_slots" =~ ^[0-9]+$ ]] || available_slots=0
+	[[ "$triage_dispatched" =~ ^[0-9]+$ ]] || triage_dispatched=0
+	pulse_dispatch_debug_log "post-prepasses available_slots=${available_slots} triage_dispatched=${triage_dispatched}"
 
 	# Reset module-level round state before the dispatch loop (t1959).
 	_DFF_ROUND_DISPATCHED=0
@@ -479,9 +557,18 @@ dispatch_deterministic_fill_floor() {
 		echo "[pulse-wrapper] Dispatch throttle active: limiting implementation batch to 1 (runtime degraded)" >>"$LOGFILE"
 	fi
 
+	# GH#18804: fence-post log so operators can see the loop entered. Without
+	# this, a silent exit between the prepass capture and the loop body was
+	# indistinguishable from "everything was skipped" — both produced the
+	# same observable symptom (`Adaptive settle wait: 0 dispatches`).
+	echo "[pulse-wrapper] Deterministic fill floor: entering candidate loop with effective_slots=${_effective_slots}, candidates=${candidate_count}" >>"$LOGFILE"
+
+	local processed_count=0
 	while IFS= read -r candidate_json; do
 		[[ -n "$candidate_json" ]] || continue
+		processed_count=$((processed_count + 1))
 		if [[ "$dispatched_count" -ge "$_effective_slots" ]]; then
+			pulse_dispatch_debug_log "stopping early — dispatched_count=${dispatched_count} reached effective_slots=${_effective_slots}"
 			break
 		fi
 		if [[ -f "$STOP_FLAG" ]]; then
@@ -499,10 +586,11 @@ dispatch_deterministic_fill_floor() {
 		fi
 	done < <(printf '%s' "$candidates_json" | jq -c '.[]' 2>/dev/null)
 
+	pulse_dispatch_debug_log "loop exited — processed=${processed_count} dispatched=${dispatched_count}"
 	_dff_maybe_engage_throttle
 
 	local total_dispatched=$((dispatched_count + triage_dispatched))
-	echo "[pulse-wrapper] Deterministic fill floor complete: dispatched=${total_dispatched} (${triage_dispatched} triage + ${dispatched_count} implementation), target_available=${available_slots}" >>"$LOGFILE"
+	echo "[pulse-wrapper] Deterministic fill floor complete: dispatched=${total_dispatched} (${triage_dispatched} triage + ${dispatched_count} implementation), processed=${processed_count}/${candidate_count}, target_available=${available_slots}" >>"$LOGFILE"
 	echo "$total_dispatched"
 	return 0
 }

--- a/.agents/scripts/tests/test-pulse-wrapper-silent-dispatch.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-silent-dispatch.sh
@@ -1,0 +1,347 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-pulse-wrapper-silent-dispatch.sh - Regression tests for GH#18804
+#
+# The deterministic fill floor pass (_dff_should_skip_candidate +
+# _dff_process_candidate) previously had multiple early-return paths that
+# silently rejected dispatch candidates without writing any log line, making
+# silent-failure rounds (`candidates=N` followed immediately by
+# `Adaptive settle wait: 0 dispatches` with nothing between) impossible to
+# diagnose from pulse.log.
+#
+# These tests assert that EVERY skip path writes an identifiable log line so a
+# future regression can be caught before it ships.
+#
+# Bug-class context: this is the same family as GH#18770, GH#18784, GH#18786 —
+# silent set-e propagation / unchecked return swallowing. See
+# `.agents/reference/bash-compat.md` pre-merge checklist item 4.
+
+set -euo pipefail
+
+# Disable startup jitter — pulse-wrapper.sh sleeps up to 30s on source
+export PULSE_JITTER_MAX=0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+WRAPPER_SCRIPT="${SCRIPT_DIR}/../pulse-wrapper.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+ORIGINAL_HOME="${HOME}"
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+	export HOME="${TEST_ROOT}/home"
+	mkdir -p "${HOME}/.aidevops/logs"
+	# Source the wrapper to get function definitions. Config-load failures are
+	# expected in test environments — disable set -e for the source itself.
+	set +e
+	# shellcheck source=/dev/null
+	source "$WRAPPER_SCRIPT" 2>/dev/null
+	set -e
+	# Force LOGFILE into the test sandbox so log assertions are isolated.
+	LOGFILE="${HOME}/.aidevops/logs/pulse.log"
+	export LOGFILE
+	: >"$LOGFILE"
+	return 0
+}
+
+teardown_test_env() {
+	export HOME="$ORIGINAL_HOME"
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+reset_logfile() {
+	: >"$LOGFILE"
+	return 0
+}
+
+#######################################
+# Test 1: a terminal-blocker skip MUST write a per-candidate log line.
+#
+# Mocks check_terminal_blockers to always return 0 (blocker detected).
+# Asserts the caller logs a skip line naming the check that fired — even
+# though check_terminal_blockers' own log line also goes to LOGFILE, the
+# caller's redundant line is the safety net that survives any future
+# refactor of the helper.
+#######################################
+test_terminal_blocker_skip_logs() {
+	reset_logfile
+	# Mock dependencies: terminal blocker positive, fast-fail negative.
+	check_terminal_blockers() { return 0; }
+	fast_fail_is_skipped() { return 1; }
+	gh() { :; } # not reached because terminal_rc=0 short-circuits
+
+	local rc=0
+	_dff_should_skip_candidate "12345" "owner/repo" || rc=$?
+	unset -f check_terminal_blockers fast_fail_is_skipped gh
+
+	local skip_logged=1
+	if grep -q "skipping #12345 (owner/repo) — terminal blocker detected" "$LOGFILE"; then
+		skip_logged=0
+	fi
+	print_result "terminal blocker skip writes per-candidate log line" "$skip_logged" \
+		"LOGFILE contents: $(cat "$LOGFILE" || true)"
+	# Expected return: 0 (skip)
+	print_result "terminal blocker skip returns 0 (skip)" $((rc == 0 ? 0 : 1)) "got rc=$rc"
+	return 0
+}
+
+#######################################
+# Test 2: fast-fail skip writes per-candidate log line (regression guard).
+#######################################
+test_fast_fail_skip_logs() {
+	reset_logfile
+	check_terminal_blockers() { return 1; } # no terminal blocker
+	fast_fail_is_skipped() { return 0; }    # fast-fail tripped
+
+	local rc=0
+	_dff_should_skip_candidate "23456" "owner/repo" || rc=$?
+	unset -f check_terminal_blockers fast_fail_is_skipped
+
+	local skip_logged=1
+	if grep -q "skipping #23456 (owner/repo) — fast-fail threshold reached" "$LOGFILE"; then
+		skip_logged=0
+	fi
+	print_result "fast-fail skip writes per-candidate log line" "$skip_logged" \
+		"LOGFILE contents: $(cat "$LOGFILE" || true)"
+	print_result "fast-fail skip returns 0 (skip)" $((rc == 0 ? 0 : 1)) "got rc=$rc"
+	return 0
+}
+
+#######################################
+# Test 3: empty body skip writes per-candidate log line.
+#######################################
+test_empty_body_skip_logs() {
+	reset_logfile
+	check_terminal_blockers() { return 1; }
+	fast_fail_is_skipped() { return 1; }
+	# Mock gh issue view to return empty body.
+	gh() {
+		case "$1" in
+		issue)
+			[[ "$2" == "view" ]] && {
+				printf '\n'
+				return 0
+			}
+			;;
+		esac
+		return 0
+	}
+
+	local rc=0
+	_dff_should_skip_candidate "34567" "owner/repo" || rc=$?
+	unset -f check_terminal_blockers fast_fail_is_skipped gh
+
+	local skip_logged=1
+	if grep -q "skipping #34567 (owner/repo) — placeholder/empty issue body" "$LOGFILE"; then
+		skip_logged=0
+	fi
+	print_result "empty body skip writes per-candidate log line" "$skip_logged" \
+		"LOGFILE contents: $(cat "$LOGFILE" || true)"
+	print_result "empty body skip returns 0 (skip)" $((rc == 0 ? 0 : 1)) "got rc=$rc"
+	return 0
+}
+
+#######################################
+# Test 4: stub body skip writes per-candidate log line.
+#######################################
+test_stub_body_skip_logs() {
+	reset_logfile
+	check_terminal_blockers() { return 1; }
+	fast_fail_is_skipped() { return 1; }
+	gh() {
+		case "$1" in
+		issue)
+			[[ "$2" == "view" ]] && {
+				printf 'placeholder body — no description provided — enrich before dispatch\n'
+				return 0
+			}
+			;;
+		esac
+		return 0
+	}
+
+	local rc=0
+	_dff_should_skip_candidate "45678" "owner/repo" || rc=$?
+	unset -f check_terminal_blockers fast_fail_is_skipped gh
+
+	local skip_logged=1
+	if grep -q "skipping #45678 (owner/repo) — claim-task-id.sh stub body" "$LOGFILE"; then
+		skip_logged=0
+	fi
+	print_result "stub body skip writes per-candidate log line" "$skip_logged" \
+		"LOGFILE contents: $(cat "$LOGFILE" || true)"
+	print_result "stub body skip returns 0 (skip)" $((rc == 0 ? 0 : 1)) "got rc=$rc"
+	return 0
+}
+
+#######################################
+# Test 5: malformed candidate JSON in _dff_process_candidate logs the skip
+# instead of returning silently. Pre-GH#18804 this was a silent return 1.
+#######################################
+test_malformed_candidate_logs_skip() {
+	reset_logfile
+	# Bad JSON: number is missing.
+	local bad_json='{"repo_slug":"owner/repo","repo_path":"/tmp/repo"}'
+
+	local rc=0
+	_dff_process_candidate "$bad_json" "test-user" "10" || rc=$?
+
+	local skip_logged=1
+	if grep -q "skipping malformed candidate — issue_number=" "$LOGFILE"; then
+		skip_logged=0
+	fi
+	print_result "malformed candidate JSON logs skip line" "$skip_logged" \
+		"LOGFILE contents: $(cat "$LOGFILE" || true)"
+	print_result "malformed candidate returns 1 (skipped)" $((rc == 1 ? 0 : 1)) "got rc=$rc"
+	return 0
+}
+
+#######################################
+# Test 6: missing repo_path in _dff_process_candidate logs the skip.
+#######################################
+test_missing_repo_path_logs_skip() {
+	reset_logfile
+	# Valid issue_number but repo_path empty.
+	local bad_json='{"number":56789,"repo_slug":"owner/repo","repo_path":""}'
+
+	local rc=0
+	_dff_process_candidate "$bad_json" "test-user" "10" || rc=$?
+
+	local skip_logged=1
+	if grep -q "skipping #56789 — missing repo_slug=" "$LOGFILE"; then
+		skip_logged=0
+	fi
+	print_result "missing repo_path logs skip line" "$skip_logged" \
+		"LOGFILE contents: $(cat "$LOGFILE" || true)"
+	print_result "missing repo_path returns 1 (skipped)" $((rc == 1 ? 0 : 1)) "got rc=$rc"
+	return 0
+}
+
+#######################################
+# Test 7: PULSE_DEBUG=1 produces DFF DEBUG: lines for every candidate.
+#######################################
+test_pulse_debug_emits_per_candidate_logs() {
+	reset_logfile
+	export PULSE_DEBUG=1
+	check_terminal_blockers() { return 1; }
+	fast_fail_is_skipped() { return 1; }
+	gh() {
+		case "$1" in
+		issue)
+			[[ "$2" == "view" ]] && {
+				printf 'a real implementation context\n'
+				return 0
+			}
+			;;
+		esac
+		return 0
+	}
+
+	_dff_should_skip_candidate "67890" "owner/repo" || true
+	unset -f check_terminal_blockers fast_fail_is_skipped gh
+	unset PULSE_DEBUG
+
+	local debug_logged=1
+	if grep -q "DFF DEBUG: evaluating skip checks for #67890 (owner/repo)" "$LOGFILE"; then
+		debug_logged=0
+	fi
+	print_result "PULSE_DEBUG=1 logs per-candidate evaluation line" "$debug_logged" \
+		"LOGFILE contents: $(cat "$LOGFILE" || true)"
+
+	local rc_logged=1
+	if grep -q "DFF DEBUG: #67890: check_terminal_blockers rc=" "$LOGFILE"; then
+		rc_logged=0
+	fi
+	print_result "PULSE_DEBUG=1 logs check_terminal_blockers rc" "$rc_logged" ""
+	return 0
+}
+
+#######################################
+# Test 8: PULSE_DEBUG unset = no DFF DEBUG: lines (default behaviour).
+#######################################
+test_pulse_debug_unset_quiet_default() {
+	reset_logfile
+	unset PULSE_DEBUG
+	check_terminal_blockers() { return 1; }
+	fast_fail_is_skipped() { return 1; }
+	gh() {
+		case "$1" in
+		issue)
+			[[ "$2" == "view" ]] && {
+				printf 'a real implementation context\n'
+				return 0
+			}
+			;;
+		esac
+		return 0
+	}
+
+	_dff_should_skip_candidate "78901" "owner/repo" || true
+	unset -f check_terminal_blockers fast_fail_is_skipped gh
+
+	local quiet_default=0
+	if grep -q "DFF DEBUG:" "$LOGFILE"; then
+		quiet_default=1
+	fi
+	print_result "PULSE_DEBUG unset emits no DFF DEBUG: lines" "$quiet_default" \
+		"LOGFILE contents: $(cat "$LOGFILE" || true)"
+	return 0
+}
+
+#######################################
+# Main
+#######################################
+main() {
+	printf 'Running pulse silent-dispatch regression tests (GH#18804)...\n\n'
+
+	setup_test_env
+
+	test_terminal_blocker_skip_logs
+	test_fast_fail_skip_logs
+	test_empty_body_skip_logs
+	test_stub_body_skip_logs
+	test_malformed_candidate_logs_skip
+	test_missing_repo_path_logs_skip
+	test_pulse_debug_emits_per_candidate_logs
+	test_pulse_debug_unset_quiet_default
+
+	teardown_test_env
+
+	printf '\n%d tests run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

The deterministic fill floor pass had multiple silent early-return paths in _dff_should_skip_candidate and _dff_process_candidate. When all candidates were rejected the only observable log was 'candidates=N' followed immediately by 'Adaptive settle wait: 0 dispatches' with nothing between — an undiagnosable silent-failure round.

Three fixes:

1. Per-candidate skip log lines on every early-return path: terminal blocker, fast-fail, empty body, stub body, malformed JSON, missing repo_path, dispatch_with_dedup failure, launch validation failure. Each line names which check fired.

2. The check_terminal_blockers call no longer suppresses output with '>/dev/null 2>&1'. Its own log lines now reach pulse.log AND the caller wraps the call with set-e-safe rc capture so subshell-kill propagation can no longer mask silent rejections (same bug class as GH#18770, GH#18784, GH#18786).

3. PULSE_DEBUG=1 environment flag enables 'DFF DEBUG:' per-candidate logging — labels, body length, dedup-probe rc, model_override, loop entry/exit fence posts. Off by default to avoid log churn.

Also hardens dispatch_deterministic_fill_floor itself: the prepass capture is now '|| prepass_line=fallback' so a set-e abort inside dispatch_triage_reviews/dispatch_enrichment_workers can no longer silently exit the parent subshell. Two new fence-post log lines wrap the candidate loop so operators can see exactly where execution exited.

New regression test test-pulse-wrapper-silent-dispatch.sh asserts every skip path writes an identifiable log line and PULSE_DEBUG behaviour is correct (15 assertions, all PASS).

## Files Changed

.agents/scripts/pulse-dispatch-engine.sh,.agents/scripts/tests/test-pulse-wrapper-silent-dispatch.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck pulse-dispatch-engine.sh + new test: clean. New test-pulse-wrapper-silent-dispatch.sh: 15/15 PASS. Existing test-pulse-wrapper-terminal-blockers.sh: 11/11 PASS. test-pulse-wrapper-characterization.sh: 26/26 PASS. pulse-wrapper.sh --self-check: ok (33 canonical functions defined, 24 module guards verified).

Resolves #18804


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.17 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 11m and 38,839 tokens on this as a headless worker.