### PR TITLE
GH#18815: fix(pulse-merge): file-overlap verification before auto-closing conflicting worker PRs

### DIFF
--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -1060,6 +1060,154 @@ Every pulse cycle the deterministic merge pass evaluates open PRs and auto-close
 }
 
 #######################################
+# Detect whether a path is a planning-only file that should NOT be used
+# as evidence of "implementation work landed on main".
+#
+# GH#18815: The deterministic merge pass had a false-positive in PR #18760
+# where a planning-brief PR (`plan(t2059, t2060): file follow-ups`) was
+# mistaken for an implementation PR because the task-ID grep matched the
+# planning commit's subject. Planning paths are excluded from the file
+# overlap check so a planning-only commit cannot satisfy the duplicate-work
+# heuristic on its own.
+#
+# Returns 0 (true) if the path is planning-only, 1 (false) if it is an
+# implementation file.
+#
+# Args: $1 = path
+#######################################
+_is_planning_path_for_overlap() {
+	local path="$1"
+	case "$path" in
+	TODO.md | README.md | CHANGELOG.md | VERSION) return 0 ;;
+	todo/* | .agents/configs/simplification-state.json) return 0 ;;
+	*) return 1 ;;
+	esac
+}
+
+#######################################
+# Verify that the closing PR and the matching commit on main share at
+# least one non-planning file path.
+#
+# GH#18815: This is the file-overlap gate that distinguishes a genuine
+# duplicate (where the same implementation files were touched on both
+# sides) from a false positive (where the task ID appeared in a planning
+# commit's subject but no implementation work landed).
+#
+# Returns 0 if the intersection contains at least one implementation file
+# → genuine duplicate, safe to close as "already landed".
+#
+# Returns 1 if:
+#   - The intersection is empty (planning-only match → false positive)
+#   - File lookup failed (network error, missing API permissions, etc.)
+#
+# In all "return 1" cases the caller MUST NOT auto-close the PR. The
+# function fails CLOSED on lookup errors because the cost of leaving a
+# stuck PR open is far less than the cost of discarding real work.
+#
+# Args: $1 = closing PR number, $2 = repo slug, $3 = matching commit SHA
+#######################################
+_verify_pr_overlaps_commit() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local commit_sha="$3"
+
+	local pr_files commit_files
+	pr_files=$(gh pr view "$pr_number" --repo "$repo_slug" \
+		--json files --jq '.files[].path' 2>/dev/null) || return 1
+	[[ -n "$pr_files" ]] || return 1
+
+	commit_files=$(gh api "repos/${repo_slug}/commits/${commit_sha}" \
+		--jq '.files[].filename' 2>/dev/null) || return 1
+	[[ -n "$commit_files" ]] || return 1
+
+	# Compute intersection, excluding planning paths. Iterate the closing
+	# PR's files (typically smaller set) and check membership in the
+	# matching commit's files via grep -Fxq for exact line match.
+	local file
+	while IFS= read -r file; do
+		[[ -n "$file" ]] || continue
+		if _is_planning_path_for_overlap "$file"; then
+			continue
+		fi
+		if printf '%s\n' "$commit_files" | grep -Fxq -- "$file"; then
+			return 0
+		fi
+	done <<<"$pr_files"
+
+	return 1
+}
+
+#######################################
+# Post a one-time rebase nudge on a conflicting worker PR that the
+# deterministic merge pass left open due to a false-positive task-ID
+# match (GH#18815).
+#
+# Modelled on _post_rebase_nudge_on_interactive_conflicting. Idempotent
+# via the marker `<!-- pulse-rebase-nudge-worker -->` — posted exactly
+# once per PR lifetime.
+#
+# Args:
+#   $1 - pr_number
+#   $2 - repo_slug (owner/repo)
+#   $3 - task_id (e.g., "t2060" or "GH#18746")
+#   $4 - matching_pr (optional — the PR number from the false-positive match)
+#######################################
+_post_rebase_nudge_on_worker_conflicting() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local task_id="$3"
+	local matching_pr="${4:-}"
+
+	[[ "$pr_number" =~ ^[0-9]+$ && -n "$repo_slug" ]] || return 0
+
+	if ! declare -F _gh_idempotent_comment >/dev/null 2>&1; then
+		echo "[pulse-wrapper] _post_rebase_nudge_on_worker_conflicting: _gh_idempotent_comment not defined — skipping nudge for PR #${pr_number} in ${repo_slug}" >>"$LOGFILE"
+		return 0
+	fi
+
+	local head_branch
+	head_branch=$(gh pr view "$pr_number" --repo "$repo_slug" \
+		--json headRefName --jq '.headRefName' 2>/dev/null) || head_branch="<branch>"
+	[[ -n "$head_branch" ]] || head_branch="<branch>"
+
+	local matching_pr_clause=""
+	if [[ -n "$matching_pr" ]]; then
+		matching_pr_clause=" The matching commit was from PR #${matching_pr}, which only touches planning files (briefs, TODO.md). The implementation in this PR has not landed."
+	fi
+
+	local marker="<!-- pulse-rebase-nudge-worker -->"
+	local nudge_body
+	nudge_body="${marker}
+## Rebase needed — task-ID heuristic detected a planning-only match
+
+This worker PR has merge conflicts against \`main\`. The deterministic merge pass found a recent commit on main mentioning task ID \`${task_id}\`, but its file footprint does not overlap with this PR's implementation files.${matching_pr_clause}
+
+To prevent value loss, the merge pass left this PR open instead of auto-closing it. The implementation work in this branch needs to be rebased and re-validated.
+
+### To resolve
+
+From a terminal:
+
+\`\`\`bash
+gh pr checkout ${pr_number}
+git pull --rebase origin main
+# resolve any conflicts, then:
+git push --force-with-lease
+\`\`\`
+
+Or use the GitHub web UI's *Update branch* button if the conflicts are trivial enough for GitHub's web merger.
+
+### Why you're seeing this
+
+Earlier versions of \`_close_conflicting_pr\` would have auto-closed this PR with a false 'already landed on main' claim — the task-ID grep alone matched the planning commit's subject and concluded the implementation had landed. The fix added file-overlap verification: when the task ID matches a commit but the file footprints do not intersect on any non-planning path, the heuristic is treated as a false positive and the PR is preserved.
+
+<sub>Posted automatically by \`pulse-merge.sh\` (GH#18815).</sub>"
+
+	_gh_idempotent_comment "$pr_number" "$repo_slug" "$marker" "$nudge_body" "pr" || true
+	return 0
+}
+
+#######################################
 # Close a conflicting PR with audit comment.
 #
 # GH#17574: Before saying "remains open for re-attempt", check if the
@@ -1068,6 +1216,13 @@ Every pulse cycle the deterministic merge pass evaluates open PRs and auto-close
 # the misleading "remains open for re-attempt" comment was itself a
 # dispatch trigger that caused a third redundant worker in the
 # observed incident.
+#
+# GH#18815: The task-ID grep alone produced a false positive in PR
+# #18760, where a planning PR (`plan(t2059, t2060): file follow-ups`)
+# was mistaken for an implementation PR. The fix requires file overlap
+# between the closing PR and the matching commit before claiming the
+# work landed. On overlap miss or lookup failure, the PR is left open
+# and a one-time rebase nudge is posted.
 #
 # Args: $1=PR number, $2=repo slug, $3=PR title
 #######################################
@@ -1101,37 +1256,68 @@ _close_conflicting_pr() {
 	# on the matching commit subject, so the close comment can cite the
 	# actual audit trail instead of claiming the work was "committed directly
 	# to main" (which is misleading when the common case is a sibling PR).
+	#
+	# GH#18815: Fetch (sha, subject) pairs as JSON instead of subjects only,
+	# so the file-overlap verification step can look up the matching commit's
+	# files via `gh api repos/.../commits/SHA`.
 	local work_on_main="false"
 	local merging_pr=""
 	local task_id_from_pr
 	task_id_from_pr=$(printf '%s' "$pr_title" | grep -oE '^(t[0-9]+|GH#[0-9]+)' | head -1) || task_id_from_pr=""
 
 	if [[ -n "$task_id_from_pr" ]]; then
-		# Fetch recent commit subjects on main and find the first one
-		# matching the task ID. The matching subject is used for two
-		# things: (1) confirming work_on_main, (2) parsing the
-		# squash-merge "(#NNN)" suffix.
-		local commit_subjects
-		commit_subjects=$(gh api "repos/${repo_slug}/commits" \
+		local commits_json
+		commits_json=$(gh api "repos/${repo_slug}/commits" \
 			--method GET -f per_page=50 \
-			--jq '.[] | .commit.message | split("\n")[0]' \
-			2>/dev/null) || commit_subjects=""
+			--jq '[.[] | {sha: .sha, subject: (.commit.message | split("\n")[0])}]' \
+			2>/dev/null) || commits_json=""
 
+		local matching_sha=""
 		local matching_subject=""
-		if [[ -n "$commit_subjects" ]]; then
-			matching_subject=$(printf '%s\n' "$commit_subjects" |
-				grep -iE "(^|[^a-zA-Z0-9])${task_id_from_pr}([^a-zA-Z0-9]|$)" |
-				head -1) || matching_subject=""
+		if [[ -n "$commits_json" && "$commits_json" != "null" ]]; then
+			# Use jq with a regex test for word-boundary matching on the subject.
+			# `first // empty` returns the first match or an empty string when
+			# nothing matches — distinguishable from a malformed JSON response.
+			local matching_obj
+			matching_obj=$(printf '%s' "$commits_json" |
+				jq -c --arg tid "$task_id_from_pr" '
+					[.[] | select(.subject | test("(^|[^a-zA-Z0-9])" + $tid + "([^a-zA-Z0-9]|$)"; "i"))] | first // empty
+				' 2>/dev/null) || matching_obj=""
+			if [[ -n "$matching_obj" && "$matching_obj" != "null" ]]; then
+				matching_sha=$(printf '%s' "$matching_obj" | jq -r '.sha // empty' 2>/dev/null) || matching_sha=""
+				matching_subject=$(printf '%s' "$matching_obj" | jq -r '.subject // empty' 2>/dev/null) || matching_subject=""
+			fi
 		fi
 
-		if [[ -n "$matching_subject" ]]; then
-			work_on_main="true"
-			# Parse trailing "(#NNN)" from the squash-merge commit subject.
-			# Non-squash merges won't have this suffix — that's fine, we
-			# just omit the parenthetical from the close comment.
-			merging_pr=$(printf '%s' "$matching_subject" |
-				grep -oE '\(#[0-9]+\)$' |
-				grep -oE '[0-9]+' | head -1) || merging_pr=""
+		if [[ -n "$matching_sha" ]]; then
+			# GH#18815: Verify the matching commit and the closing PR share
+			# at least one non-planning file. The task-ID grep alone produced
+			# false positives when a planning PR (e.g., 'plan(t2060): file
+			# follow-ups') was merged before the implementation PR — the
+			# regex matched the planning subject and the implementation PR
+			# was wrongly auto-closed (PR #18760 incident, 2026-04-14).
+			if _verify_pr_overlaps_commit "$pr_number" "$repo_slug" "$matching_sha"; then
+				work_on_main="true"
+				# Parse trailing "(#NNN)" from the matching commit's subject.
+				# Non-squash merges won't have this suffix — that's fine, we
+				# just omit the parenthetical from the close comment.
+				merging_pr=$(printf '%s' "$matching_subject" |
+					grep -oE '\(#[0-9]+\)$' |
+					grep -oE '[0-9]+' | head -1) || merging_pr=""
+			else
+				# Task ID matched but file footprints don't overlap, OR file
+				# lookup failed (network error, missing API permissions). Fail
+				# CLOSED — leave the PR open and post a one-time rebase nudge.
+				# Better to leave a stuck PR than to discard real work.
+				local matching_pr_for_nudge=""
+				matching_pr_for_nudge=$(printf '%s' "$matching_subject" |
+					grep -oE '\(#[0-9]+\)$' |
+					grep -oE '[0-9]+' | head -1) || matching_pr_for_nudge=""
+
+				echo "[pulse-wrapper] Deterministic merge: task ID match for ${task_id_from_pr} in commit ${matching_sha:0:8} has no implementation file overlap with PR #${pr_number} — false-positive heuristic, leaving PR open for rebase (GH#18815)" >>"$LOGFILE"
+				_post_rebase_nudge_on_worker_conflicting "$pr_number" "$repo_slug" "$task_id_from_pr" "$matching_pr_for_nudge"
+				return 0
+			fi
 		fi
 	fi
 

--- a/.agents/scripts/tests/test-close-conflicting-pr-wording.sh
+++ b/.agents/scripts/tests/test-close-conflicting-pr-wording.sh
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 #
 # Regression test for the `_close_conflicting_pr` close-comment wording
-# (GH#17574 / t2032).
+# (GH#17574 / t2032) AND the file-overlap verification (GH#18815).
 #
 # Verifies that when the deterministic merge pass detects "work already
 # on main", the close comment:
@@ -11,9 +11,11 @@
 #   2. Includes "(via PR #NNN)" when the matching commit has a
 #      squash-merge suffix
 #   3. Omits the parenthetical when no PR number is parseable
-#
-# The test exercises the function against stubbed `gh` calls; the real
-# pulse-merge.sh is sourced so we test the live code path.
+#   4. (GH#18815) Only fires when the matching commit and the closing PR
+#      share a non-planning file path. A planning-only match (e.g., the
+#      #18760 ↔ #18749 false positive) must NOT close the PR.
+#   5. (GH#18815) Fails CLOSED when file lookups error out — leave the PR
+#      open and post a rebase nudge instead of discarding work.
 
 set -euo pipefail
 
@@ -47,33 +49,53 @@ print_result() {
 	return 0
 }
 
-setup_test_env() {
-	local commit_subjects="$1"
-
-	TEST_ROOT=$(mktemp -d)
-	STUB_DIR="${TEST_ROOT}/stubs"
-	CAPTURED_COMMENT_FILE="${TEST_ROOT}/captured-comment.txt"
-	mkdir -p "$STUB_DIR"
-	: >"$CAPTURED_COMMENT_FILE"
-
-	# Stub `gh` — returns predetermined commit subjects for `gh api ... /commits`
-	# and captures the `--comment` body for `gh pr close`.
+# Stub `gh` for the new file-overlap-aware contract. The stub dispatches on
+# argument shape and reads predetermined response files written by each test
+# case. This keeps the stub stable across tests — only the response files
+# change per case.
+#
+# Response files (written by set_responses):
+#   $TEST_ROOT/commits.json     — output for `gh api repos/.../commits` (JSON array)
+#   $TEST_ROOT/commit-files.txt — output for `gh api repos/.../commits/SHA` (lines)
+#   $TEST_ROOT/pr-files.txt     — output for `gh pr view N --json files` (lines)
+#   $TEST_ROOT/pr-labels.txt    — output for `gh pr view N --json labels` (lines)
+#   $TEST_ROOT/pr-branch.txt    — output for `gh pr view N --json headRefName`
+#
+# A missing or empty response file makes the stub exit 1, simulating a gh
+# API failure for the relevant call.
+write_stub_gh() {
 	cat >"${STUB_DIR}/gh" <<STUB_EOF
 #!/usr/bin/env bash
+TEST_ROOT="${TEST_ROOT}"
+CAPTURED_COMMENT_FILE="${CAPTURED_COMMENT_FILE}"
+
 if [[ "\$1" == "api" ]]; then
-	# Simulate: gh api repos/.../commits --jq '.[] | .commit.message | split("\\n")[0]'
-	cat <<'SUBJECTS_EOF'
-${commit_subjects}
-SUBJECTS_EOF
+	url="\$2"
+	if [[ "\$url" =~ /commits/[a-f0-9]+\$ ]]; then
+		# gh api repos/X/Y/commits/SHA --jq '.files[].filename'
+		response="\${TEST_ROOT}/commit-files.txt"
+		if [[ ! -s "\$response" ]]; then
+			exit 1
+		fi
+		cat "\$response"
+		exit 0
+	elif [[ "\$url" =~ /commits\$ ]]; then
+		# gh api repos/X/Y/commits --jq '[.[] | {sha, subject}]'
+		response="\${TEST_ROOT}/commits.json"
+		if [[ ! -s "\$response" ]]; then
+			exit 1
+		fi
+		cat "\$response"
+		exit 0
+	fi
 	exit 0
 fi
 
 if [[ "\$1" == "pr" && "\$2" == "close" ]]; then
-	# Capture --comment body to the file so the test can assert on it.
 	shift 2
 	while [[ \$# -gt 0 ]]; do
 		if [[ "\$1" == "--comment" ]]; then
-			printf '%s' "\$2" >"${CAPTURED_COMMENT_FILE}"
+			printf '%s' "\$2" >"\${CAPTURED_COMMENT_FILE}"
 			shift 2
 		else
 			shift
@@ -83,47 +105,92 @@ if [[ "\$1" == "pr" && "\$2" == "close" ]]; then
 fi
 
 if [[ "\$1" == "pr" && "\$2" == "view" ]]; then
-	# Used for origin:interactive label check — return empty labels.
-	echo ""
-	exit 0
+	# Find the --json field name to know which response to emit.
+	field=""
+	args=("\$@")
+	i=2
+	while [[ \$i -lt \${#args[@]} ]]; do
+		if [[ "\${args[\$i]}" == "--json" ]]; then
+			j=\$((i + 1))
+			field="\${args[\$j]}"
+			break
+		fi
+		i=\$((i + 1))
+	done
+	case "\$field" in
+		labels)
+			response="\${TEST_ROOT}/pr-labels.txt"
+			if [[ -f "\$response" ]]; then cat "\$response"; fi
+			exit 0
+			;;
+		files)
+			response="\${TEST_ROOT}/pr-files.txt"
+			if [[ ! -s "\$response" ]]; then exit 1; fi
+			cat "\$response"
+			exit 0
+			;;
+		headRefName)
+			response="\${TEST_ROOT}/pr-branch.txt"
+			if [[ -f "\$response" ]]; then cat "\$response"; else echo "feature/test"; fi
+			exit 0
+			;;
+		*)
+			exit 0
+			;;
+	esac
 fi
 
-# Fallback — unknown stub invocation
 exit 0
 STUB_EOF
 	chmod +x "${STUB_DIR}/gh"
+	return 0
+}
+
+setup_sandbox() {
+	TEST_ROOT=$(mktemp -d)
+	STUB_DIR="${TEST_ROOT}/stubs"
+	CAPTURED_COMMENT_FILE="${TEST_ROOT}/captured-comment.txt"
+	mkdir -p "$STUB_DIR"
+	: >"$CAPTURED_COMMENT_FILE"
+
+	write_stub_gh
 
 	export PATH="${STUB_DIR}:${PATH}"
 	export LOGFILE="${TEST_ROOT}/pulse.log"
 	: >"$LOGFILE"
-
 	return 0
 }
 
-teardown_test_env() {
+teardown_sandbox() {
 	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
 		rm -rf "$TEST_ROOT"
 	fi
 	return 0
 }
 
-# Source only the `_close_conflicting_pr` function from pulse-merge.sh in
-# isolation. The parent module is sourced by pulse-wrapper.sh and depends
-# on bootstrap state, so we extract just the function body into a temp file
-# and source that.
-load_function_under_test() {
+# Source the helpers under test from pulse-merge.sh in isolation. The
+# parent module is sourced by pulse-wrapper.sh and depends on bootstrap
+# state, so we extract just the function bodies into a temp file and
+# source that.
+load_functions_under_test() {
 	local repo_root
 	repo_root=$(cd "$(dirname "$0")/../../.." && pwd)
 	local src="${repo_root}/.agents/scripts/pulse-merge.sh"
-	local tmp_fn="${TEST_ROOT}/_close_conflicting_pr.sh"
+	local tmp_fn="${TEST_ROOT}/pulse-merge-funcs.sh"
 
-	# Extract from "_close_conflicting_pr() {" through the matching closing
-	# brace at column 0. Robust for this file because pulse-merge.sh uses
-	# tab-indented function bodies and column-0 closing braces.
+	# Extract these functions in order:
+	#   _is_planning_path_for_overlap
+	#   _verify_pr_overlaps_commit
+	#   _post_rebase_nudge_on_worker_conflicting
+	#   _close_conflicting_pr
+	# Each definition uses tab-indented bodies with a column-0 "}" closer.
 	awk '
-		/^_close_conflicting_pr\(\) \{$/ { in_fn=1 }
-		in_fn { print }
-		in_fn && /^\}$/ { exit }
+		/^_is_planning_path_for_overlap\(\) \{$/    { fn=1 }
+		/^_verify_pr_overlaps_commit\(\) \{$/        { fn=1 }
+		/^_post_rebase_nudge_on_worker_conflicting\(\) \{$/ { fn=1 }
+		/^_close_conflicting_pr\(\) \{$/             { fn=1 }
+		fn { print }
+		fn && /^\}$/ { fn=0 }
 	' "$src" >"$tmp_fn"
 
 	# shellcheck source=/dev/null
@@ -131,15 +198,32 @@ load_function_under_test() {
 	return 0
 }
 
+# Helper to write per-test response files.
+set_responses() {
+	local commits_json="$1"
+	local commit_files="$2"
+	local pr_files="$3"
+	printf '%s' "$commits_json" >"${TEST_ROOT}/commits.json"
+	printf '%s' "$commit_files" >"${TEST_ROOT}/commit-files.txt"
+	printf '%s' "$pr_files" >"${TEST_ROOT}/pr-files.txt"
+	# Default empty labels (no origin:interactive)
+	: >"${TEST_ROOT}/pr-labels.txt"
+	echo "feature/test" >"${TEST_ROOT}/pr-branch.txt"
+	return 0
+}
+
 # ── Test cases ──
 
 test_wording_with_squash_merge_pr_number() {
-	# Matching commit has the standard squash-merge "(#18480)" suffix
-	setup_test_env "t2017: teach /review-issue-pr to do temporal-duplicate checks (#18480)
-chore: something else
-feat: another unrelated commit"
+	setup_sandbox
+	# Matching commit has the standard squash-merge "(#18480)" suffix AND
+	# touches the same implementation file as the closing PR — genuine duplicate.
+	set_responses \
+		'[{"sha":"abc1234567890abcdef","subject":"t2017: teach /review-issue-pr to do temporal-duplicate checks (#18480)"},{"sha":"def4567890abcdef","subject":"chore: something else"}]' \
+		'.agents/workflows/review-issue-pr.md' \
+		'.agents/workflows/review-issue-pr.md'
 
-	load_function_under_test
+	load_functions_under_test
 
 	_close_conflicting_pr "18486" "marcusquinn/aidevops" \
 		"t2017: enhance /review-issue-pr with temporal-duplicate checks"
@@ -158,16 +242,20 @@ feat: another unrelated commit"
 	print_result "cites '(via PR #NNN)' when matching commit has squash-merge suffix" \
 		"$result" \
 		"got: $(printf '%s' "$body" | head -c 200)"
-	teardown_test_env
+	teardown_sandbox
 	return 0
 }
 
 test_wording_without_pr_number_fallback() {
+	setup_sandbox
 	# Matching commit is a direct-to-main commit with no "(#NNN)" suffix
-	setup_test_env "t2017: direct push to main without going through a PR
-chore: unrelated"
+	# but DOES touch the same implementation file → genuine duplicate.
+	set_responses \
+		'[{"sha":"abc1234567890abcdef","subject":"t2017: direct push to main without going through a PR"},{"sha":"def4567890abcdef","subject":"chore: unrelated"}]' \
+		'.agents/workflows/review-issue-pr.md' \
+		'.agents/workflows/review-issue-pr.md'
 
-	load_function_under_test
+	load_functions_under_test
 
 	_close_conflicting_pr "18486" "marcusquinn/aidevops" \
 		"t2017: enhance /review-issue-pr"
@@ -189,17 +277,20 @@ chore: unrelated"
 	print_result "omits parenthetical when no PR number parseable" \
 		"$result" \
 		"got: $(printf '%s' "$body" | head -c 200)"
-	teardown_test_env
+	teardown_sandbox
 	return 0
 }
 
 test_no_match_uses_fallback_message() {
+	setup_sandbox
 	# No commit on main matches the task ID → falls through to the
 	# "work NOT on main" branch; comment must NOT claim "landed on main".
-	setup_test_env "chore: totally unrelated commit
-feat: still unrelated"
+	set_responses \
+		'[{"sha":"abc1234567890abcdef","subject":"chore: totally unrelated commit"},{"sha":"def4567890abcdef","subject":"feat: still unrelated"}]' \
+		'.agents/workflows/review-issue-pr.md' \
+		'.agents/workflows/review-issue-pr.md'
 
-	load_function_under_test
+	load_functions_under_test
 
 	_close_conflicting_pr "18486" "marcusquinn/aidevops" \
 		"t2017: enhance /review-issue-pr"
@@ -221,7 +312,140 @@ feat: still unrelated"
 	print_result "no-match uses 're-attempt' fallback, not 'landed on main'" \
 		"$result" \
 		"got: $(printf '%s' "$body" | head -c 200)"
-	teardown_test_env
+	teardown_sandbox
+	return 0
+}
+
+# GH#18815 regression: reproduces the PR #18760 false-positive close.
+# The matching commit only touches planning files (TODO.md + briefs); the
+# closing PR touches an implementation script. The function MUST NOT close.
+test_no_close_when_matching_commit_only_touches_planning_files() {
+	setup_sandbox
+	set_responses \
+		'[{"sha":"deadbeefcafe1234","subject":"plan(t2059, t2060): file follow-ups from GH#18538 worker-is-triager session (#18749)"},{"sha":"def4567890abcdef","subject":"chore: unrelated"}]' \
+		"$(printf 'TODO.md\ntodo/tasks/t2059-brief.md\ntodo/tasks/t2060-brief.md')" \
+		"$(printf '.agents/scripts/task-complete-helper.sh\n.agents/scripts/tests/test-task-complete-move.sh\nTODO.md')"
+
+	load_functions_under_test
+
+	_close_conflicting_pr "18760" "marcusquinn/aidevops" \
+		"t2060: fix(task-complete-helper): move completed entries to ## Done instead of in-place marking"
+
+	local body
+	body=$(cat "$CAPTURED_COMMENT_FILE")
+
+	local result=0
+	# Must NOT have called gh pr close (captured comment file is empty)
+	if [[ -s "$CAPTURED_COMMENT_FILE" ]]; then
+		result=1
+	fi
+	# Must have logged the false-positive detection
+	if ! grep -q "false-positive heuristic" "$LOGFILE"; then
+		result=1
+	fi
+	if ! grep -q "GH#18815" "$LOGFILE"; then
+		result=1
+	fi
+
+	print_result "GH#18815: planning-only match leaves PR open (no close)" \
+		"$result" \
+		"captured-comment=$(printf '%s' "$body" | head -c 100); log=$(head -3 "$LOGFILE")"
+	teardown_sandbox
+	return 0
+}
+
+# GH#18815 regression: confirms genuine duplicates (real implementation
+# file overlap) still close as before.
+test_close_when_matching_commit_overlaps_implementation_files() {
+	setup_sandbox
+	set_responses \
+		'[{"sha":"abc1234567890abcdef","subject":"t2060: fix(task-complete-helper) (#18999)"},{"sha":"def4567890abcdef","subject":"chore: unrelated"}]' \
+		"$(printf '.agents/scripts/task-complete-helper.sh\nTODO.md')" \
+		"$(printf '.agents/scripts/task-complete-helper.sh\n.agents/scripts/tests/test-task-complete-move.sh\nTODO.md')"
+
+	load_functions_under_test
+
+	_close_conflicting_pr "18760" "marcusquinn/aidevops" \
+		"t2060: fix(task-complete-helper): move completed entries to ## Done instead of in-place marking"
+
+	local body
+	body=$(cat "$CAPTURED_COMMENT_FILE")
+
+	local result=0
+	if [[ ! -s "$CAPTURED_COMMENT_FILE" ]]; then
+		result=1
+	fi
+	if ! printf '%s' "$body" | grep -q "has already landed on main (via PR #18999)"; then
+		result=1
+	fi
+
+	print_result "GH#18815: real implementation overlap still closes PR" \
+		"$result" \
+		"got: $(printf '%s' "$body" | head -c 200)"
+	teardown_sandbox
+	return 0
+}
+
+# GH#18815 regression: file lookup failure → fail-CLOSED → no auto-close.
+# Simulates a gh API failure on the commit-files lookup.
+test_no_close_when_commit_files_lookup_fails() {
+	setup_sandbox
+	set_responses \
+		'[{"sha":"abc1234567890abcdef","subject":"t2060: fix(task-complete-helper) (#18999)"}]' \
+		'' \
+		"$(printf '.agents/scripts/task-complete-helper.sh\nTODO.md')"
+
+	load_functions_under_test
+
+	_close_conflicting_pr "18760" "marcusquinn/aidevops" \
+		"t2060: fix(task-complete-helper): move completed entries to ## Done instead of in-place marking"
+
+	local body
+	body=$(cat "$CAPTURED_COMMENT_FILE")
+
+	local result=0
+	if [[ -s "$CAPTURED_COMMENT_FILE" ]]; then
+		result=1
+	fi
+	if ! grep -q "false-positive heuristic" "$LOGFILE"; then
+		result=1
+	fi
+
+	print_result "GH#18815: commit-files lookup failure leaves PR open (fail-CLOSED)" \
+		"$result" \
+		"captured-comment=$(printf '%s' "$body" | head -c 100); log=$(head -3 "$LOGFILE")"
+	teardown_sandbox
+	return 0
+}
+
+# GH#18815 regression: PR-files lookup failure → fail-CLOSED → no auto-close.
+test_no_close_when_pr_files_lookup_fails() {
+	setup_sandbox
+	set_responses \
+		'[{"sha":"abc1234567890abcdef","subject":"t2060: fix(task-complete-helper) (#18999)"}]' \
+		"$(printf '.agents/scripts/task-complete-helper.sh\nTODO.md')" \
+		''
+
+	load_functions_under_test
+
+	_close_conflicting_pr "18760" "marcusquinn/aidevops" \
+		"t2060: fix(task-complete-helper): move completed entries to ## Done instead of in-place marking"
+
+	local body
+	body=$(cat "$CAPTURED_COMMENT_FILE")
+
+	local result=0
+	if [[ -s "$CAPTURED_COMMENT_FILE" ]]; then
+		result=1
+	fi
+	if ! grep -q "false-positive heuristic" "$LOGFILE"; then
+		result=1
+	fi
+
+	print_result "GH#18815: PR-files lookup failure leaves PR open (fail-CLOSED)" \
+		"$result" \
+		"captured-comment=$(printf '%s' "$body" | head -c 100); log=$(head -3 "$LOGFILE")"
+	teardown_sandbox
 	return 0
 }
 
@@ -230,6 +454,10 @@ feat: still unrelated"
 test_wording_with_squash_merge_pr_number
 test_wording_without_pr_number_fallback
 test_no_match_uses_fallback_message
+test_no_close_when_matching_commit_only_touches_planning_files
+test_close_when_matching_commit_overlaps_implementation_files
+test_no_close_when_commit_files_lookup_fails
+test_no_close_when_pr_files_lookup_fails
 
 printf '\n%d tests run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Fixes the false-positive in _close_conflicting_pr that closed PR #18760 (t2060 task-complete-helper implementation) by claiming the work had landed on main via PR #18749 — when in fact #18749 was a planning-only PR. Implementation files were never touched on main. The fix adds file-overlap verification: a matching commit must share at least one non-planning file with the closing PR before the auto-close fires. On overlap miss or file lookup error, fail CLOSED (leave PR open, post rebase nudge). Recovery for the existing victim is in PR #18760 (reopened).

## Files Changed

.agents/scripts/pulse-merge.sh,.agents/scripts/tests/test-close-conflicting-pr-wording.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean on pulse-merge.sh and test-close-conflicting-pr-wording.sh; 7/7 assertions pass in test-close-conflicting-pr-wording.sh including 4 new GH#18815 regressions; 6/6 pass in test-pulse-merge-rebase-nudge.sh; 26/26 pass in test-pulse-wrapper-characterization.sh; 8/8 pass in test-pulse-wrapper-main-commit-check.sh

Resolves #18815


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.18 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 21m and 64,602 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PR auto-close logic now distinguishes between planning-file overlaps and implementation conflicts. Planning files (README, TODO, VERSION, configs) no longer trigger auto-closure. Workers receive a rebase nudge comment instead. Added fail-closed error handling to prevent false-positive closures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->