### PR TITLE
GH#18804: bash 3.2 set-e workaround + entry/exit logging in _dff_process_candidate

### DIFF
--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -394,6 +394,23 @@ _dff_process_candidate() {
 	local available_slots="$3"
 	_DFF_THROTTLE_CLEARED=0
 
+	# GH#18804 follow-up #2: defensive set +e wrapping. Bash 3.2 (macOS default)
+	# has a documented bug where the `set -e` "ignore" state inside an `if` or
+	# `||` context does NOT propagate down through nested function calls. So
+	# even when this function is called via `_dff_process_candidate ... || rc=$?`,
+	# any internal command that returns non-zero CAN still abort the parent
+	# subshell silently. The fix: explicitly disable set -e at function entry
+	# and restore the saved state on every return path. Belt-and-braces against
+	# the bash 3.2 quirk + any future bash version's edge cases. See
+	# https://lists.gnu.org/archive/html/bug-bash/2012-12/msg00094.html for the
+	# canonical bug report and the prompts/build.txt "Bash 3.2 Compatibility"
+	# section.
+	local _dff_pc_save_e=""
+	case "$-" in *e*) _dff_pc_save_e="e" ;; esac
+	set +e
+
+	echo "[pulse-wrapper] Deterministic fill floor: _dff_process_candidate ENTRY (save_e=${_dff_pc_save_e:-none})" >>"$LOGFILE"
+
 	local issue_number repo_slug repo_path issue_url issue_title dispatch_title prompt labels_csv model_override
 	issue_number=$(printf '%s' "$candidate_json" | jq -r '.number // empty' 2>/dev/null)
 	repo_slug=$(printf '%s' "$candidate_json" | jq -r '.repo_slug // empty' 2>/dev/null)
@@ -401,22 +418,40 @@ _dff_process_candidate() {
 	issue_url=$(printf '%s' "$candidate_json" | jq -r '.url // empty' 2>/dev/null)
 	issue_title=$(printf '%s' "$candidate_json" | jq -r '.title // empty' 2>/dev/null | tr '\n' ' ')
 	labels_csv=$(printf '%s' "$candidate_json" | jq -r '(.labels // []) | join(",")' 2>/dev/null)
+	echo "[pulse-wrapper] Deterministic fill floor: _dff_process_candidate parsed jq fields for #${issue_number:-?} (${repo_slug:-?})" >>"$LOGFILE"
+
+	# Helper: restore caller's set -e state on every return path.
+	# Bash 3.2 doesn't support `trap RETURN` reliably, so we inline this.
+	_dff_pc_restore() {
+		local rc="${1:-0}"
+		if [[ -n "$_dff_pc_save_e" ]]; then
+			set -e
+		fi
+		return "$rc"
+	}
 
 	# GH#18804: previously the next two checks silently `return 1`-ed without
 	# logging. Operators saw `candidates=N` but no per-candidate skip lines,
 	# making malformed candidate JSON impossible to diagnose from pulse.log.
 	if [[ ! "$issue_number" =~ ^[0-9]+$ ]]; then
 		echo "[pulse-wrapper] Deterministic fill floor: skipping malformed candidate — issue_number='${issue_number}' is not numeric (candidate_json prefix: ${candidate_json:0:120})" >>"$LOGFILE"
+		_dff_pc_restore 1
 		return 1
 	fi
 	if [[ -z "$repo_slug" || -z "$repo_path" ]]; then
 		echo "[pulse-wrapper] Deterministic fill floor: skipping #${issue_number} — missing repo_slug='${repo_slug}' or repo_path='${repo_path}'" >>"$LOGFILE"
+		_dff_pc_restore 1
 		return 1
 	fi
 
 	pulse_dispatch_debug_log "processing #${issue_number} (${repo_slug}) labels=[${labels_csv}]"
+	echo "[pulse-wrapper] Deterministic fill floor: _dff_process_candidate calling _dff_should_skip_candidate for #${issue_number}" >>"$LOGFILE"
 
-	if _dff_should_skip_candidate "$issue_number" "$repo_slug"; then
+	local skip_rc=0
+	_dff_should_skip_candidate "$issue_number" "$repo_slug" || skip_rc=$?
+	echo "[pulse-wrapper] Deterministic fill floor: _dff_should_skip_candidate returned rc=${skip_rc} for #${issue_number}" >>"$LOGFILE"
+	if [[ "$skip_rc" -eq 0 ]]; then
+		_dff_pc_restore 1
 		return 1
 	fi
 
@@ -427,12 +462,15 @@ _dff_process_candidate() {
 	fi
 	model_override=$(resolve_dispatch_model_for_labels "$labels_csv")
 	pulse_dispatch_debug_log "#${issue_number}: model_override=${model_override:-<auto>} — calling dispatch_with_dedup"
+	echo "[pulse-wrapper] Deterministic fill floor: _dff_process_candidate calling dispatch_with_dedup for #${issue_number}" >>"$LOGFILE"
 
 	local dispatch_rc=0
 	dispatch_with_dedup "$issue_number" "$repo_slug" "$dispatch_title" "$issue_title" \
 		"$self_login" "$repo_path" "$prompt" "issue-${issue_number}" "$model_override" || dispatch_rc=$?
+	echo "[pulse-wrapper] Deterministic fill floor: dispatch_with_dedup returned rc=${dispatch_rc} for #${issue_number}" >>"$LOGFILE"
 	if [[ "$dispatch_rc" -ne 0 ]]; then
 		echo "[pulse-wrapper] Deterministic fill floor: skipping #${issue_number} (${repo_slug}) — dispatch_with_dedup returned rc=${dispatch_rc}" >>"$LOGFILE"
+		_dff_pc_restore 1
 		return 1
 	fi
 
@@ -445,6 +483,7 @@ _dff_process_candidate() {
 	if [[ "$launch_rc" -ne 0 ]]; then
 		echo "[pulse-wrapper] Deterministic fill floor: #${issue_number} (${repo_slug}) launch validation failed (rc=${launch_rc}, last_failure='${_PULSE_LAST_LAUNCH_FAILURE}')" >>"$LOGFILE"
 		_dff_record_launch_failure
+		_dff_pc_restore 1
 		return 1
 	fi
 
@@ -457,6 +496,7 @@ _dff_process_candidate() {
 		echo "[pulse-wrapper] Dispatch throttle CLEARED: launch success in throttled mode — restoring full batch=${available_slots}" >>"$LOGFILE"
 		_DFF_THROTTLE_CLEARED=1
 	fi
+	_dff_pc_restore 0
 	return 0
 }
 


### PR DESCRIPTION
## Summary

PR #18821 (v3.8.20) added per-iteration fence-post logging that proved the silent dispatch failure happens INSIDE _dff_process_candidate on the FIRST iteration, between 'loop iter=1 entering body' and the rc capture. Even though _dff_process_candidate is called via the set-e-safe '|| _dff_proc_rc=$?' idiom, the parent subshell still aborts before logging the rc.

Root cause: bash 3.2 (macOS default) has a documented bug where the set -e 'ignore' state inside an if/|| context does NOT propagate down through nested function calls. Internal command failures inside _dff_process_candidate can still abort the parent subshell.

Fix: defensive set +e wrapping. Save the caller's set -e state at function entry, disable set -e for the function body, restore on every return path via _dff_pc_restore helper. Belt-and-braces against the bash 3.2 quirk and any future bash version's edge cases.

Also added unconditional fence-post logging at every key step inside _dff_process_candidate: entry, jq parse, _dff_should_skip_candidate call+return, dispatch_with_dedup call+return. The next pulse cycle will reveal exactly which sub-call is the silent killer.

## Files Changed

.agents/scripts/pulse-dispatch-engine.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck pulse-dispatch-engine.sh: clean. test-pulse-wrapper-silent-dispatch.sh: 15/15 PASS.

Resolves #18804


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.20 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 40m and 87,421 tokens on this as a headless worker.