### PR TITLE
feat: add --no-open flag to oauth-pool-helper.sh

### DIFF
--- a/.agents/scripts/oauth-pool-helper.sh
+++ b/.agents/scripts/oauth-pool-helper.sh
@@ -8,6 +8,7 @@
 #
 # Usage:
 #   oauth-pool-helper.sh add [anthropic|openai|cursor|google]           # Add account via OAuth/device flow
+#   oauth-pool-helper.sh add --no-open [anthropic|openai|cursor|google]  # Print URL instead of opening browser
 #   oauth-pool-helper.sh check [anthropic|openai|cursor|google|all]     # Health check all accounts
 #   oauth-pool-helper.sh list [anthropic|openai|cursor|google|all]      # List accounts
 #   oauth-pool-helper.sh remove <provider> <email>                      # Remove an account
@@ -26,6 +27,9 @@ IFS=$'\n\t'
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
+
+# Global flag: set by --no-open to skip browser launch and print the URL instead.
+OAUTH_NO_OPEN=false
 
 POOL_FILE="${HOME}/.aidevops/oauth-pool.json"
 OPENCODE_AUTH_FILE="${HOME}/.local/share/opencode/auth.json"
@@ -191,9 +195,17 @@ save_pool() {
 	return 0
 }
 
-# Open URL in browser (best-effort, never fatal — cascades on failure)
+# Open URL in browser (best-effort, never fatal — cascades on failure).
+# When OAUTH_NO_OPEN=true (set by --no-open), skip the browser and just print the URL.
 open_browser() {
 	local url="$1"
+
+	if [[ "$OAUTH_NO_OPEN" == "true" ]]; then
+		print_info "Open this URL in your browser:"
+		printf '%s\n' "$url" >&2
+		return 0
+	fi
+
 	local cmd
 	for cmd in open xdg-open wslview; do
 		if command -v "$cmd" &>/dev/null && "$cmd" "$url" 2>/dev/null; then
@@ -1752,6 +1764,7 @@ Preferred CLI (same commands, no path needed):
 
 Commands:
   add [anthropic|openai|cursor|google]            Add an account (OAuth; OpenAI defaults to device flow)
+  add --no-open [provider]                        Print OAuth URL instead of opening browser
   check [anthropic|openai|cursor|google|all]      Health check: token expiry + live validity
   diagnose [anthropic]                            Full pipeline diagnostics (pool, plugin, CCH, runtime)
   list [anthropic|openai|cursor|google|all]       List accounts with per-account status
@@ -1765,6 +1778,9 @@ Commands:
   remove <provider> <email>                       Remove an account from the pool
   import [claude-cli]                             Import account from Claude CLI auth
 
+Global flags:
+  --no-open                                       Print OAuth URL instead of opening browser
+
 Quickstart (if you see "Key Missing", "invalid request data", or auth errors):
   aidevops model-accounts-pool diagnose          # 0. Full pipeline check (start here)
   aidevops model-accounts-pool status            # 1. See pool health at a glance
@@ -1775,6 +1791,7 @@ Quickstart (if you see "Key Missing", "invalid request data", or auth errors):
 
 Examples:
   oauth-pool-helper.sh add anthropic                      # Claude Pro/Max (browser OAuth)
+  oauth-pool-helper.sh add --no-open anthropic             # Print URL instead of opening browser
   oauth-pool-helper.sh add openai                         # ChatGPT Plus/Pro (device flow default)
   oauth-pool-helper.sh add cursor                         # Cursor Pro (reads from IDE)
   oauth-pool-helper.sh add google                         # Google AI Pro/Ultra/Workspace (browser OAuth)
@@ -2075,20 +2092,34 @@ main() {
 	local cmd="${1:-help}"
 	shift || true
 
+	# Parse global flags before command dispatch
+	local args=()
+	local arg
+	for arg in "$@"; do
+		case "$arg" in
+		--no-open)
+			OAUTH_NO_OPEN=true
+			;;
+		*)
+			args+=("$arg")
+			;;
+		esac
+	done
+
 	case "$cmd" in
-	add) cmd_add "$@" ;;
-	assign-pending | assign_pending) cmd_assign_pending "$@" ;;
-	check | test) cmd_check "$@" ;;
-	diagnose) cmd_diagnose "$@" ;;
-	import) cmd_import "$@" ;;
-	list) cmd_list "$@" ;;
-	mark-failure | mark_failure) cmd_mark_failure "$@" ;;
-	refresh) cmd_refresh "$@" ;;
-	rotate) cmd_rotate "$@" ;;
-	reset-cooldowns | reset_cooldowns | reset) cmd_reset_cooldowns "$@" ;;
-	remove) cmd_remove "$@" ;;
-	set-priority | set_priority) cmd_set_priority "$@" ;;
-	status) cmd_status "$@" ;;
+	add) cmd_add "${args[@]}" ;;
+	assign-pending | assign_pending) cmd_assign_pending "${args[@]}" ;;
+	check | test) cmd_check "${args[@]}" ;;
+	diagnose) cmd_diagnose "${args[@]}" ;;
+	import) cmd_import "${args[@]}" ;;
+	list) cmd_list "${args[@]}" ;;
+	mark-failure | mark_failure) cmd_mark_failure "${args[@]}" ;;
+	refresh) cmd_refresh "${args[@]}" ;;
+	rotate) cmd_rotate "${args[@]}" ;;
+	reset-cooldowns | reset_cooldowns | reset) cmd_reset_cooldowns "${args[@]}" ;;
+	remove) cmd_remove "${args[@]}" ;;
+	set-priority | set_priority) cmd_set_priority "${args[@]}" ;;
+	status) cmd_status "${args[@]}" ;;
 	help | -h | --help) cmd_help ;;
 	*)
 		print_error "Unknown command: $cmd"

--- a/.agents/scripts/oauth-pool-lib/pool_ops_token_utils.py
+++ b/.agents/scripts/oauth-pool-lib/pool_ops_token_utils.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""
+oauth-pool-lib/pool_ops_token_utils.py — Token extraction/decode/read helpers.
+
+Extracted from the pool_ops.py monolith during the t2069 decomposition.
+These commands read from stdin or env vars and print structured output
+consumed by the shell wrapper (oauth-pool-helper.sh).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+# ---------------------------------------------------------------------------
+# extract-token-fields: Extract access_token, refresh_token, expires_in
+# from a JSON token response. Reads JSON from stdin.
+# ---------------------------------------------------------------------------
+
+def cmd_extract_token_fields() -> None:
+    d = json.load(sys.stdin)
+    print(d.get('access_token', ''))
+    print(d.get('refresh_token', ''))
+    print(d.get('expires_in', 3600))
+
+
+# ---------------------------------------------------------------------------
+# extract-token-error: Extract error message from token response.
+# Reads JSON from stdin.
+# ---------------------------------------------------------------------------
+
+def cmd_extract_token_error() -> None:
+    try:
+        d = json.load(sys.stdin)
+        parts = []
+        for k in ('type', 'error', 'message', 'error_description'):
+            if k in d and d[k]:
+                parts.append(str(d[k]))
+        print(': '.join(parts) if parts else 'unknown')
+    except Exception:
+        print('unknown')
+
+
+# ---------------------------------------------------------------------------
+# openai-read-auth: Read OpenAI auth fields from OpenCode auth file.
+# Env: AUTH_PATH
+# ---------------------------------------------------------------------------
+
+def cmd_openai_read_auth() -> None:
+    path = os.environ['AUTH_PATH']
+    try:
+        with open(path) as f:
+            auth = json.load(f)
+    except Exception:
+        print('')
+        print('')
+        print('')
+        print('')
+        sys.exit(0)
+
+    entry = auth.get('openai', {}) if isinstance(auth, dict) else {}
+    print(entry.get('access', ''))
+    print(entry.get('refresh', ''))
+    print(entry.get('expires', ''))
+    print(entry.get('accountId', ''))
+
+
+# ---------------------------------------------------------------------------
+# cursor-read-auth: Read Cursor auth.json fields.
+# Env: AUTH_PATH
+# ---------------------------------------------------------------------------
+
+def cmd_cursor_read_auth() -> None:
+    path = os.environ['AUTH_PATH']
+    try:
+        with open(path) as f:
+            d = json.load(f)
+        print(d.get('accessToken', ''))
+        print(d.get('refreshToken', ''))
+    except Exception:
+        print('')
+        print('')
+
+
+# ---------------------------------------------------------------------------
+# cursor-decode-jwt: Decode JWT fields from access token.
+# Env: ACCESS
+# ---------------------------------------------------------------------------
+
+def cmd_cursor_decode_jwt() -> None:
+    import base64
+
+    token = os.environ['ACCESS']
+    parts = token.split('.')
+    if len(parts) >= 2:
+        payload = parts[1] + '=' * (4 - len(parts[1]) % 4)
+        try:
+            data = json.loads(base64.urlsafe_b64decode(payload))
+            print(data.get('email', ''))
+            print(data.get('exp', 0))
+        except Exception:
+            print('')
+            print(0)
+    else:
+        print('')
+        print(0)
+
+
+# ---------------------------------------------------------------------------
+# google-validate: Validate token against Google API.
+# Env: ACCESS, HEALTH_URL
+# ---------------------------------------------------------------------------
+
+def cmd_google_validate() -> None:
+    from urllib.request import Request, urlopen
+    from urllib.error import HTTPError, URLError
+
+    token = os.environ['ACCESS']
+    url = os.environ['HEALTH_URL']
+    try:
+        req = Request(url, method='GET')
+        req.add_header('Authorization', 'Bearer ' + token)
+        urlopen(req, timeout=10)
+        print('OK')
+    except HTTPError as e:
+        print('HTTP_' + str(e.code))
+    except (URLError, OSError):
+        print('NETWORK_ERROR')
+    except Exception:
+        print('ERROR')


### PR DESCRIPTION
## Summary

- Adds `--no-open` global flag to `oauth-pool-helper.sh` that prints the OAuth URL instead of opening a browser
- Useful for remote/SSH sessions, headless environments, or when you want to open the link in a different browser

## Usage

```bash
oauth-pool-helper.sh add --no-open anthropic
aidevops model-accounts-pool add --no-open google
```

## Changes

- `OAUTH_NO_OPEN` global flag set by `--no-open` argument parsing in `main()`
- `open_browser()` checks the flag and prints the URL with a clear prompt instead of calling `open`/`xdg-open`/`wslview`
- Flag is parsed before command dispatch so it works with any subcommand that calls `open_browser()` (add, import)
- Help text updated with the new flag and example

## Verification

- `shellcheck` passes clean
- `oauth-pool-helper.sh help` shows the new flag in Commands, Global flags, and Examples sections

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a global CLI flag (--no-open) to skip automatic browser launch during OAuth; the tool now prints the URL for manual navigation and updated help/usage text.
  * Added CLI helper commands to parse token responses, read auth data, decode token payloads, and validate Google tokens for easier troubleshooting and automation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->