### PR TITLE
GH#18809: fix(GH#18809): prevent spurious re-queue issues when qlty reports zero smells

_simplification_backfill_verify_remaining_smells had a classic grep -c
fallback bug: when Qlty finds zero smells, grep -c prints '0' and exits
non-zero, causing '|| echo "0"' to append a second '0'. The resulting
literal '0\n0' string failed the '-eq 0' branch check and cascaded into
a false-positive re-queue issue with '0\n0 smells remaining' in the
title.

Fix:
- swallow grep's exit inside a group command ({ grep -c || true; }) so
  no extra output is emitted
- defensively normalise the captured value via tr -d and a regex guard
  before the integer comparison

Same issue produced #18796, #18797, #18798, #18799, #18809, #18829 over
the past 48h on files Qlty reported clean.

### DIFF
--- a/.agents/scripts/pulse-simplification-state.sh
+++ b/.agents/scripts/pulse-simplification-state.sh
@@ -531,7 +531,18 @@ _simplification_backfill_verify_remaining_smells() {
 
 	local full_path="${repo_path}/${file_path}"
 	local remaining_smells
-	remaining_smells=$("$qlty_cmd" smells --all "$full_path" 2>/dev/null | grep -c '^[^ ]' || echo "0")
+	# grep -c always emits a count on stdout; when there are zero matches it
+	# ALSO exits non-zero. A naive `|| echo "0"` fallback appends a second
+	# "0", giving us a literal "0\n0" in $remaining_smells. That string then
+	# fails the `-eq 0` test below and cascades into a spurious re-queue
+	# issue with "0\n0 smells remaining" in the title (seen on GH#18809,
+	# #18829, #18796, #18797, #18798, #18799 — every file Qlty reported
+	# clean generated a false-positive follow-up). Fix: swallow grep's exit
+	# code inside a group command WITHOUT emitting any extra output, then
+	# defensively normalise to a single integer before comparison.
+	remaining_smells=$("$qlty_cmd" smells --all "$full_path" 2>/dev/null | { grep -c '^[^ ]' || true; })
+	remaining_smells=$(printf '%s' "$remaining_smells" | tr -d '[:space:]')
+	[[ ! "$remaining_smells" =~ ^[0-9]+$ ]] && remaining_smells=0
 
 	if [[ "$remaining_smells" -eq 0 ]]; then
 		echo "[pulse-wrapper] backfill: ${file_path} — Qlty clean after #${issue_num} (pass ${new_passes})" >>"$LOGFILE"


### PR DESCRIPTION
## Summary

Fixes a grep -c fallback bug in pulse-simplification-state.sh that caused every Qlty-clean file to trigger a spurious post-merge re-queue issue. The bug produced at least six false-positive simplification-debt issues in the last 48h (including this one, #18809). Root cause: `grep -c '^[^ ]' || echo "0"` concatenates grep's '0' output with the fallback echo, yielding '0\n0', which then fails the subsequent `-eq 0` check and drops into the re-queue branch.

## Files Changed

.agents/scripts/pulse-simplification-state.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Reproduced the old behaviour and verified the fix in an isolated bash harness (old path gives `0\n0` 3-byte string that fails `-eq 0`; new path gives single-byte `0` that passes). Positive-case test with non-empty Qlty output still routes to the re-queue branch as expected. ShellCheck clean on pulse-simplification-state.sh. Bash syntax check clean.

Resolves #18809


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.22 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 3m and 10,285 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect value computation in the simplification verification process that was causing false-positive re-queue behavior. The improvement ensures proper data normalization, reducing unnecessary retries and enhancing system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->