### PR TITLE
GH#18775: t2067: add QLTY_SMELL_THRESHOLD ratchet for multi-language smell count

### DIFF
--- a/.agents/configs/complexity-thresholds-history.md
+++ b/.agents/configs/complexity-thresholds-history.md
@@ -86,3 +86,18 @@ Archives the full change history for `.agents/configs/complexity-thresholds.conf
 |-------|----------|--------|
 | 69 | baseline (2026-04-04) | mostly namerefs in helper scripts |
 | 72 | GH#17830 | pre-existing regression on main — 71 violations vs threshold 69; email-delivery-test-helper.sh and memory-pressure-monitor.sh added namerefs/associative arrays after threshold was set. Adding 1 unit of headroom to unblock PRs; proper fix is to refactor those scripts |
+
+## QLTY_SMELL_THRESHOLD History
+
+Multi-language smell counter (GH#18775, t2067). Covers Python, JS/TS/mjs, and
+cyclomatic complexity via `qlty smells --all` SARIF output — the first ratchet
+counter that measures non-shell files. Enforced by the `qlty-smell-threshold`
+job in `.github/workflows/code-quality.yml`; auto-ratcheted down by
+`.github/workflows/ratchet-post-merge.yml` when the smell count drops below
+`threshold - 2`. Complementary to t2065's per-PR regression gate: t2065
+enforces "no net increase in this PR", t2067 enforces "total count is bounded
+and monotonically decreases".
+
+| Value | PR/Issue | Reason |
+|-------|----------|--------|
+| 111 | baseline (2026-04-14, GH#18775) | initial baseline: 109 actual smells + 2 buffer; qlty 0.619.0 reports 37 qlty:file-complexity, 26 qlty:identical-code, 26 qlty:function-complexity, 7 qlty:return-statements, 5 qlty:function-parameters, 4 qlty:nested-control-flow, 2 qlty:similar-code, 2 qlty:boolean-logic |

--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -118,13 +118,13 @@ FILE_SIZE_THRESHOLD=59
 # namerefs/associative arrays. Proper fix is to refactor those scripts.
 BASH32_COMPAT_THRESHOLD=72
 
-# Qlty maintainability smell baseline (t2065, GH#18773). Seed value for
-# the `.github/workflows/qlty-regression.yml` gate. The gate itself uses
-# a base-vs-head diff (not this threshold directly), but anchoring the
-# ratchet here gives t2067 (ratchet-down discipline) a starting point.
-# Baseline: 109 (2026-04-14, measured against main with
-# `qlty smells --all --sarif | jq '.runs[0].results | length'`).
-QLTY_SMELL_THRESHOLD=109
+# Qlty maintainability smell count — multi-language counter (GH#18775, t2067).
+# Unlike the shell-only thresholds above, this covers Python, JS/TS/mjs, and
+# cyclomatic complexity via `qlty smells --all` SARIF output. Enforced by the
+# qlty-smell-threshold job in code-quality.yml; auto-ratcheted down by
+# ratchet-post-merge.yml when the count drops below threshold - 2.
+# Baseline: 111 (2026-04-14, GH#18775): actual count 109 + 2 buffer
+QLTY_SMELL_THRESHOLD=111
 
 # Qlty smell-count → grade mapping (t2066, GH#18774)
 #

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -525,6 +525,75 @@ jobs:
           echo "No new code smells introduced"
         fi
 
+  # GH#18775 (t2067): absolute-threshold ratchet for the total qlty smell count.
+  # Complementary to the qlty-smells job above: that one enforces "no new smells
+  # in this PR" (per-PR delta); this one enforces "total count is bounded by
+  # QLTY_SMELL_THRESHOLD and monotonically decreases over time". First ratchet
+  # counter that covers non-shell files (Python/JS/TS/mjs). Auto-ratcheted down
+  # by ratchet-post-merge.yml when the count drops below threshold - 2.
+  qlty-smell-threshold:
+    name: Qlty Smell Threshold
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+    - name: Install Qlty CLI
+      uses: qltysh/qlty-action/install@a19242102d17e497f437d7466aa01b528537e899 # v2.2.0
+
+    - name: Qlty smell threshold check
+      run: |
+        # Read threshold from config (GH#18775 — ratchetable smell counter)
+        THRESHOLD=0
+        if [ -f ".agents/configs/complexity-thresholds.conf" ]; then
+          val=$(grep '^QLTY_SMELL_THRESHOLD=' .agents/configs/complexity-thresholds.conf | cut -d= -f2 || true)
+          if [ -n "$val" ] && [ "$val" -eq "$val" ] 2>/dev/null; then
+            THRESHOLD=$val
+          fi
+        fi
+        if [ "$THRESHOLD" -eq 0 ]; then
+          echo "::warning::QLTY_SMELL_THRESHOLD not set in complexity-thresholds.conf — skipping check"
+          exit 0
+        fi
+
+        echo "Counting total qlty smells across all files..."
+        sarif=$(qlty smells --all --sarif --no-snippets --quiet 2>/dev/null || true)
+        if [ -z "$sarif" ]; then
+          echo "::error::Failed to run qlty smells (empty SARIF output)"
+          exit 1
+        fi
+
+        count=$(echo "$sarif" | jq '.runs[0].results | length')
+        if ! [ "$count" -eq "$count" ] 2>/dev/null; then
+          echo "::error::Failed to parse smell count from SARIF output"
+          exit 1
+        fi
+
+        echo ""
+        echo "Total qlty smells: $count"
+        echo "Threshold:         $THRESHOLD"
+        echo ""
+
+        if [ "$count" -gt "$THRESHOLD" ]; then
+          echo "::error::Qlty smell regression: $count smells exceeds threshold $THRESHOLD"
+          echo ""
+          echo "Per-rule breakdown:"
+          echo "$sarif" | jq -r '.runs[0].results | group_by(.ruleId) | map({rule: .[0].ruleId, count: length}) | sort_by(-.count) | .[] | "  \(.count)\t\(.rule)"'
+          echo ""
+          echo "Top 20 files by smell count:"
+          echo "$sarif" | jq -r '.runs[0].results | group_by(.locations[0].physicalLocation.artifactLocation.uri) | map({file: .[0].locations[0].physicalLocation.artifactLocation.uri, count: length}) | sort_by(-.count) | .[0:20] | .[] | "  \(.count)\t\(.file)"'
+          echo ""
+          echo "Fix options:"
+          echo "  1. Reduce smells in your PR (preferred) — run 'qlty smells --all' locally"
+          echo "  2. Justify a bump of QLTY_SMELL_THRESHOLD in complexity-thresholds.conf"
+          echo "     with a history entry in complexity-thresholds-history.md"
+          exit 1
+        fi
+
+        headroom=$((THRESHOLD - count))
+        echo "Within threshold ($headroom headroom)"
+
   sonarcloud:
     name: SonarCloud Analysis
     runs-on: ubuntu-latest

--- a/.github/workflows/ratchet-post-merge.yml
+++ b/.github/workflows/ratchet-post-merge.yml
@@ -1,0 +1,164 @@
+name: Ratchet Post-Merge
+
+# GH#18775 (t2067): post-merge auto-ratchet for QLTY_SMELL_THRESHOLD.
+# When a PR merges to main and the total qlty smell count drops below
+# `threshold - 2`, this workflow bumps the threshold down to `new_count + 2`
+# in a follow-up commit on main. Mirrors the shell-counter ratchet model:
+# monotonic decay, buffer of 2 absorbs formatting noise.
+#
+# Writes to main require SYNC_PAT (t2048) — GITHUB_TOKEN cannot bypass
+# required_pull_request_reviews on this branch protection. Falls back to
+# GITHUB_TOKEN (which will fail) only to produce a loud, visible error.
+
+on:
+  push:
+    branches: [ main ]
+    paths-ignore:
+      - 'TODO.md'
+      - 'todo/**'
+      - 'README.md'
+      - 'CHANGELOG.md'
+      - '.agents/configs/complexity-thresholds.conf'
+      - '.agents/configs/complexity-thresholds-history.md'
+
+concurrency:
+  # Serialise ratchet attempts so two rapid merges don't race on the
+  # threshold file. Per-SHA groups would allow a stale ratchet to overwrite
+  # a newer one; a single shared group queues them.
+  group: ratchet-post-merge
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  ratchet-qlty-smells:
+    name: Ratchet QLTY_SMELL_THRESHOLD
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          ref: main
+          fetch-depth: 1
+          # t2048: prefer SYNC_PAT (fine-grained PAT scoped to this repo,
+          # Contents: Read and write) to bypass branch protection via
+          # enforce_admins:false. Falls back to GITHUB_TOKEN which will be
+          # rejected — the rejection is the loud-failure signal for operators.
+          token: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
+
+      - name: Install Qlty CLI
+        uses: qltysh/qlty-action/install@a19242102d17e497f437d7466aa01b528537e899 # v2.2.0
+
+      - name: Compute smell count and ratchet if reduced
+        env:
+          # t2048: expose secret presence as a boolean-ish env var. GitHub
+          # hides secret values from logs, but ${{ secrets.SYNC_PAT != '' }}
+          # evaluates to 'true' or 'false' at workflow-compile time and is
+          # safe to log.
+          SYNC_PAT_PRESENT: ${{ secrets.SYNC_PAT != '' && 'true' || '' }}
+          GH_TOKEN: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          conf=".agents/configs/complexity-thresholds.conf"
+          history=".agents/configs/complexity-thresholds-history.md"
+
+          if [ ! -f "$conf" ]; then
+            echo "::warning::$conf not found — skipping ratchet"
+            exit 0
+          fi
+
+          current=$(grep '^QLTY_SMELL_THRESHOLD=' "$conf" | cut -d= -f2 || true)
+          if [ -z "$current" ] || ! [ "$current" -eq "$current" ] 2>/dev/null; then
+            echo "::warning::QLTY_SMELL_THRESHOLD not set or non-numeric in $conf — skipping ratchet"
+            exit 0
+          fi
+
+          echo "Current threshold: $current"
+          echo "Computing current qlty smell count..."
+
+          sarif=$(qlty smells --all --sarif --no-snippets --quiet 2>/dev/null || true)
+          if [ -z "$sarif" ]; then
+            echo "::warning::qlty smells produced empty output — skipping ratchet"
+            exit 0
+          fi
+
+          count=$(echo "$sarif" | jq '.runs[0].results | length')
+          if ! [ "$count" -eq "$count" ] 2>/dev/null; then
+            echo "::warning::failed to parse smell count — skipping ratchet"
+            exit 0
+          fi
+
+          echo "Current smell count: $count"
+
+          new_threshold=$((count + 2))
+          if [ "$new_threshold" -ge "$current" ]; then
+            echo "No ratchet needed: new_threshold ($new_threshold) >= current ($current)"
+            exit 0
+          fi
+
+          delta=$((current - new_threshold))
+          echo "Ratcheting: $current → $new_threshold (reduction: $delta)"
+
+          # Derive trigger context (commit SHA, short commit subject) for the
+          # history entry — gives future operators a breadcrumb back to the PR
+          # that enabled the ratchet.
+          sha_short=$(git rev-parse --short HEAD)
+          commit_subject=$(git log -1 --format=%s | cut -c1-80)
+
+          # Update the config value in-place.
+          # sed -i requires a sentinel argument on BSD but not on GNU. CI is
+          # ubuntu-latest so GNU sed — plain -i is correct here.
+          sed -i "s/^QLTY_SMELL_THRESHOLD=.*/QLTY_SMELL_THRESHOLD=$new_threshold/" "$conf"
+
+          # Verify the change landed.
+          if ! grep -qE "^QLTY_SMELL_THRESHOLD=${new_threshold}\$" "$conf"; then
+            echo "::error::sed update of $conf failed — aborting ratchet"
+            exit 1
+          fi
+
+          # Append a history entry. The file already has a QLTY_SMELL_THRESHOLD
+          # History table — we find the last row and append a new row under it.
+          if grep -q '^## QLTY_SMELL_THRESHOLD History' "$history"; then
+            # Append a new table row at the end of the file. Works because the
+            # QLTY_SMELL_THRESHOLD section is the last section in the file.
+            printf '| %s | ratchet-post-merge | auto-ratchet after %s (\"%s\"): count %s + 2 buffer = %s (previously %s, reduction %s) |\n' \
+              "$new_threshold" "$sha_short" "$commit_subject" "$count" "$new_threshold" "$current" "$delta" \
+              >> "$history"
+          else
+            echo "::warning::QLTY_SMELL_THRESHOLD History section missing from $history — skipping history update"
+          fi
+
+          # Configure git identity.
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+
+          # Log which credential path is active.
+          if [ -n "${SYNC_PAT_PRESENT:-}" ]; then
+            echo "::notice::Using SYNC_PAT for push (t2048 path)"
+          else
+            echo "::notice::Using GITHUB_TOKEN for push (pre-t2048 fallback — push will be rejected by branch protection)"
+          fi
+
+          git add "$conf" "$history"
+          git commit -m "chore: ratchet QLTY_SMELL_THRESHOLD ${current}→${new_threshold} (-${delta}) [skip ci]"
+
+          # Push with retry. [skip ci] on the commit prevents a workflow loop;
+          # paths-ignore on this file is a belt-and-braces second layer.
+          for i in 1 2 3; do
+            echo "Push attempt $i..."
+            git pull --rebase origin main || true
+            if git push; then
+              echo "Push succeeded on attempt $i"
+              exit 0
+            fi
+          done
+
+          echo "::warning::Failed to push ratchet update after 3 attempts — the ratchet did not land on main"
+          echo "::warning::Check branch protection bypass: SYNC_PAT must be a fine-grained PAT with Contents: Read and write"
+          # Do not fail the workflow — the ratchet is a nice-to-have, and
+          # failing the workflow only adds noise. The [skip ci] commit was
+          # already written locally; a later merge will re-trigger this.
+          exit 0


### PR DESCRIPTION
## Summary

Extend the existing ratchet discipline to qlty smell count — the first ratchet counter that covers Python/JS/TS/mjs in addition to shell. Complementary to t2065's per-PR regression gate: that one enforces 'no new smells in this PR', this one enforces 'total count is bounded and monotonically decreases over time'.

- Add QLTY_SMELL_THRESHOLD=111 (109 actual smells + 2 buffer) to complexity-thresholds.conf
- Add qlty-smell-threshold CI job to code-quality.yml — runs on push and PR, fails with per-rule and per-file breakdown if count > threshold
- New ratchet-post-merge.yml workflow auto-ratchets threshold down when count drops below threshold - 2 (mirrors shell ratchet decay model); uses SYNC_PAT for branch protection bypass (t2048 path)
- Add QLTY_SMELL_THRESHOLD History section to complexity-thresholds-history.md with baseline entry and per-rule breakdown

Baseline 109 smells: 37 qlty:file-complexity, 26 qlty:identical-code, 26 qlty:function-complexity, 7 qlty:return-statements, 5 qlty:function-parameters, 4 qlty:nested-control-flow, 2 qlty:similar-code, 2 qlty:boolean-logic. This task can merge in parallel with t2065.

## Files Changed

.agents/configs/complexity-thresholds-history.md,.agents/configs/complexity-thresholds.conf,.claude-plugin/marketplace.json,.github/workflows/code-quality.yml,.github/workflows/ratchet-post-merge.yml,CHANGELOG.md,VERSION,aidevops.sh,package.json,setup.sh,sonar-project.properties

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** - actionlint .github/workflows/code-quality.yml .github/workflows/ratchet-post-merge.yml: clean (no findings on new/changed files; pre-existing unknown-bot-alert.yml finding is unrelated)
- Local qlty run: `qlty smells --all --sarif --no-snippets --quiet | jq '.runs[0].results | length'` returns 109
- Config pattern check: `grep -E '^QLTY_SMELL_THRESHOLD=[0-9]+' .agents/configs/complexity-thresholds.conf` returns QLTY_SMELL_THRESHOLD=111
- End-to-end verification: count=109, threshold=111, 109 <= 111 → PASS

Resolves #18775


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.23 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 7m and 20,822 tokens on this as a headless worker.