### PR TITLE
GH#18845: chore: ratchet-down NESTING_DEPTH_THRESHOLD 276→272

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -88,7 +88,8 @@ FUNCTION_COMPLEXITY_THRESHOLD=26
 # Bumped to 276 (GH#18807): proximity guard fired at 268/272 (4 headroom at time of filing); ratchet to
 # 269 (GH#18802) reduced headroom to 0 as violations drifted up to 269. 269 violations + 7 headroom = 276.
 # Proximity guard (warn_at = 276-5 = 271) fires when violations exceed 271 (i.e., at 272), preventing saturation.
-NESTING_DEPTH_THRESHOLD=276
+# Ratcheted down to 272 (GH#18845): actual violations 270 + 2 buffer
+NESTING_DEPTH_THRESHOLD=272
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Lowers `NESTING_DEPTH_THRESHOLD` from 276 to 272, following accumulated simplification wins.

- Actual violations: 270
- New threshold: 272 (270 + 2 buffer)
- Gap at time of filing: 6

## Changes

- `EDIT: .agents/configs/complexity-thresholds.conf` — lowered `NESTING_DEPTH_THRESHOLD` from 276 to 272, added ratchet-down audit comment

## Verification

```
[complexity-scan] INFO: Actual violations — func:26 nest:270 size:58 bash32:71
[complexity-scan] INFO: Current thresholds — func:26 nest:272 size:59 bash32:72
```

`simplification-state.json` was NOT staged in this commit (verified: `git diff --cached --name-only | grep -v simplification-state.json`).

Resolves #18845

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality analysis configuration thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->