### PR TITLE
GH#18777: refactor(t2069): decompose pool_ops.py into per-command modules

### DIFF
--- a/.agents/scripts/oauth-pool-lib/__init__.py
+++ b/.agents/scripts/oauth-pool-lib/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""oauth-pool-lib package — Python operations for ``oauth-pool-helper.sh``.
+
+Split into per-command modules during the t2069 decomposition. The shell
+wrapper continues to invoke ``python3 pool_ops.py <command>``; that file is
+now a thin dispatcher that re-exports from the per-command submodules.
+"""

--- a/.agents/scripts/oauth-pool-lib/_common.py
+++ b/.agents/scripts/oauth-pool-lib/_common.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""
+oauth-pool-lib/_common.py — Shared primitives for pool_ops_*.py modules.
+
+Houses cross-platform locking, atomic file writes, the provider endpoint
+tables, and the auth.json entry builder. Extracted from pool_ops.py during
+the t2069 decomposition so each per-command module imports from here rather
+than re-declaring its own copies.
+
+Security: No token values are printed by any helper here.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import tempfile
+import time
+import urllib.error
+import urllib.request
+from typing import Any
+
+
+TOKEN_URLS: dict[str, str] = {
+    "anthropic": "https://platform.claude.com/v1/oauth/token",
+    "openai": "https://auth.openai.com/oauth/token",
+    "google": "https://oauth2.googleapis.com/token",
+}
+
+CLIENT_IDS: dict[str, str] = {
+    "anthropic": "9d1c250a-e61b-44d9-88ed-5944d1962f5e",
+    "openai": "app_EMoamEEZ73f0CkXaXp7hrann",
+    "google": "681255809395-oo8ft6t5t0rnmhfqgpnkqtev5b9a2i5j.apps.googleusercontent.com",
+}
+
+
+# ---------------------------------------------------------------------------
+# Cross-platform exclusive file lock (stdlib only, no pip dependencies).
+# ---------------------------------------------------------------------------
+
+def _acquire_lock_win(lock_fd) -> None:
+    import msvcrt
+    deadline = time.time() + 30
+    while True:
+        try:
+            lock_fd.seek(0)
+            msvcrt.locking(lock_fd.fileno(), msvcrt.LK_NBLCK, 1)
+            return
+        except OSError:
+            if time.time() >= deadline:
+                raise
+            time.sleep(0.1)
+
+
+def _release_lock_win(lock_fd) -> None:
+    import msvcrt
+    try:
+        lock_fd.seek(0)
+        msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
+    except OSError:
+        pass
+
+
+def acquire_lock(lock_fd) -> None:
+    """Acquire an exclusive lock on the given file descriptor."""
+    if sys.platform == "win32":
+        _acquire_lock_win(lock_fd)
+        return
+    import fcntl
+    fcntl.flock(lock_fd, fcntl.LOCK_EX)
+
+
+def release_lock(lock_fd) -> None:
+    """Release an exclusive lock on the given file descriptor."""
+    if sys.platform == "win32":
+        _release_lock_win(lock_fd)
+        return
+    import fcntl
+    fcntl.flock(lock_fd, fcntl.LOCK_UN)
+
+
+def atomic_write_json(path: str, data: Any) -> None:
+    """Atomically write JSON data to a file (write-to-temp then rename)."""
+    d = os.path.dirname(path)
+    fd, tmp = tempfile.mkstemp(dir=d, prefix=".tmp-", suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2)
+        os.chmod(tmp, 0o600)
+        os.replace(tmp, path)
+    except BaseException:
+        try:
+            os.unlink(tmp)
+        except OSError:
+            pass
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Auth-entry builder (shared by rotate + refresh self-heal).
+# ---------------------------------------------------------------------------
+
+def build_auth_entry(provider: str, account: dict, current_auth: dict) -> dict:
+    """Build the per-provider entry for ``auth.json`` from a pool account.
+
+    Carries over ``accountId`` for OpenAI (preserving the workspace selection
+    when the new account doesn't override it), and falls back to the existing
+    ``type`` from ``current_auth`` if present (defaults to ``oauth``).
+    """
+    entry: dict[str, Any] = {
+        "type": current_auth.get("type", "oauth") if isinstance(current_auth, dict) else "oauth",
+        "refresh": account.get("refresh", ""),
+        "access": account.get("access", ""),
+        "expires": account.get("expires", 0),
+    }
+    if provider == "openai":
+        existing_id = current_auth.get("accountId", "") if isinstance(current_auth, dict) else ""
+        account_id = account.get("accountId", existing_id)
+        if account_id:
+            entry["accountId"] = account_id
+    return entry
+
+
+# ---------------------------------------------------------------------------
+# OAuth refresh request (shared by cmd_refresh + cmd_rotate auto-refresh).
+# ---------------------------------------------------------------------------
+
+def call_token_endpoint(
+    token_url: str,
+    client_id: str,
+    refresh_tok: str,
+    ua_header: str,
+    timeout: int = 15,
+) -> dict | None:
+    """POST a refresh-token grant to ``token_url`` and return the parsed JSON.
+
+    Returns ``None`` on any HTTP/network error. The caller is responsible for
+    deciding what counts as success — a 200 response that omits
+    ``access_token`` should still be treated as a failure by the caller.
+    """
+    body = json.dumps(
+        {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_tok,
+            "client_id": client_id,
+        }
+    ).encode("utf-8")
+    req = urllib.request.Request(
+        token_url,
+        data=body,
+        headers={
+            "Content-Type": "application/json",
+            "User-Agent": ua_header,
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            return json.loads(resp.read().decode("utf-8"))
+    except (urllib.error.URLError, urllib.error.HTTPError, OSError):
+        return None

--- a/.agents/scripts/oauth-pool-lib/pool_ops.py
+++ b/.agents/scripts/oauth-pool-lib/pool_ops.py
@@ -2,1046 +2,139 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 """
-oauth-pool-lib/pool_ops.py — Python operations for oauth-pool-helper.sh
+oauth-pool-lib/pool_ops.py — dispatcher facade for the per-command modules.
 
-Extracted from inline Python blocks to reduce shell nesting depth.
-Each subcommand reads configuration from environment variables and
-pool data from stdin or the pool file directly.
+This file used to be a 1047-line monolith carrying every ``cmd_*`` function
+(``cmd_refresh`` alone was cyclomatic 72 — the highest-complexity function in
+the entire repo). The t2069 decomposition split each command into its own
+module under ``oauth_pool_lib/`` so that:
 
-Usage:
-  python3 pool_ops.py <command>
+  * ``cmd_refresh`` dispatcher is now a thin orchestrator of focused helpers
+  * each per-command file stays under qlty's per-file complexity threshold
+  * shared primitives (locking, atomic write, provider tables, auth-entry
+    builder, token-endpoint POST) live in ``_common.py``
 
-Commands:
-  auto-clear          Atomically clear expired cooldowns in the pool file
-  upsert              Upsert an account into the pool (reads pool JSON from stdin)
-  rotate              Rotate to next available account (atomic, with lock)
-  refresh             Refresh expired tokens (atomic, with lock)
-  mark-failure        Mark current account as failed (atomic, with lock)
-  check-accounts      Print account details for health check
-  check-validate      Validate a token against provider API
-  check-meta          Print account metadata (status, cooldown, last used)
-  check-expiry        Print token expiry info
-  normalize-cooldowns Normalize expired cooldowns (reads pool JSON from stdin)
-  reset-cooldowns     Reset cooldowns for accounts (reads pool JSON from stdin)
-  set-priority        Set priority on an account (reads pool JSON from stdin)
-  remove-account      Remove an account from pool (reads pool JSON from stdin)
-  assign-pending      Assign pending token to account (reads pool JSON from stdin)
-  check-pending       Check if pending token exists (reads pool JSON from stdin)
-  list-pending        List accounts for pending assignment (reads pool JSON from stdin)
-  import-check        Check if email exists in pool (reads pool JSON from stdin)
-  status-stats        Print pool statistics (reads pool JSON from stdin)
-  list-accounts       List accounts with status (reads pool JSON from stdin)
+The shell wrapper continues to invoke ``python3 oauth-pool-lib/pool_ops.py
+<command>`` exactly as before — this dispatcher is the only file that is
+runnable as a script. The per-command modules are not directly executed.
+
+Backwards compatibility: code that does
+``from oauth_pool_lib.pool_ops import cmd_refresh, cmd_rotate, ...`` will
+continue to work because every ``cmd_*`` symbol is re-exported below.
 
 Security: No token values are printed to stdout/stderr (except structured
 output consumed by the shell wrapper). Secrets flow via env vars, never argv.
 """
 
-import json
+from __future__ import annotations
+
 import os
 import sys
-import tempfile
-import time
-import urllib.error
-import urllib.request
-from datetime import datetime, timezone
 
 
-TOKEN_URLS = {
-    'anthropic': 'https://platform.claude.com/v1/oauth/token',
-    'openai': 'https://auth.openai.com/oauth/token',
-    'google': 'https://oauth2.googleapis.com/token',
-}
+# When invoked as ``python3 pool_ops.py``, ``__package__`` is empty and
+# relative imports fail. Add the parent of this file's directory to
+# ``sys.path`` so absolute ``oauth_pool_lib.<module>`` imports resolve.
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_PARENT = os.path.dirname(_HERE)
+if _PARENT not in sys.path:
+    sys.path.insert(0, _PARENT)
+
+# Inject a stable package alias so ``from oauth_pool_lib.<module> import ...``
+# resolves even though the directory on disk is ``oauth-pool-lib`` (hyphenated,
+# not a valid Python identifier). The parent ``scripts`` dir gets imported as a
+# regular folder, but the hyphenated subdir needs an explicit alias.
+import importlib.util
+_PKG_INIT = os.path.join(_HERE, "__init__.py")
+if "oauth_pool_lib" not in sys.modules:
+    spec = importlib.util.spec_from_file_location(
+        "oauth_pool_lib", _PKG_INIT, submodule_search_locations=[_HERE],
+    )
+    _mod = importlib.util.module_from_spec(spec)
+    sys.modules["oauth_pool_lib"] = _mod
+    spec.loader.exec_module(_mod)
+
+
+from oauth_pool_lib.pool_ops_accounts import (  # noqa: E402
+    cmd_assign_pending,
+    cmd_check_pending,
+    cmd_import_check,
+    cmd_list_accounts,
+    cmd_list_pending,
+    cmd_remove_account,
+    cmd_set_priority,
+    cmd_status_stats,
+    cmd_upsert,
+)
+from oauth_pool_lib.pool_ops_auto_clear import cmd_auto_clear  # noqa: E402
+from oauth_pool_lib.pool_ops_cooldowns import (  # noqa: E402
+    cmd_normalize_cooldowns,
+    cmd_reset_cooldowns,
+)
+from oauth_pool_lib.pool_ops_health import (  # noqa: E402
+    cmd_check_accounts,
+    cmd_check_expiry,
+    cmd_check_meta,
+    cmd_check_validate,
+)
+from oauth_pool_lib.pool_ops_mark_failure import cmd_mark_failure  # noqa: E402
+from oauth_pool_lib.pool_ops_refresh import cmd_refresh  # noqa: E402
+from oauth_pool_lib.pool_ops_rotate import cmd_rotate  # noqa: E402
+from oauth_pool_lib.pool_ops_token_utils import (  # noqa: E402
+    cmd_cursor_decode_jwt,
+    cmd_cursor_read_auth,
+    cmd_extract_token_error,
+    cmd_extract_token_fields,
+    cmd_google_validate,
+    cmd_openai_read_auth,
+)
 
-CLIENT_IDS = {
-    'anthropic': '9d1c250a-e61b-44d9-88ed-5944d1962f5e',
-    'openai': 'app_EMoamEEZ73f0CkXaXp7hrann',
-    'google': '681255809395-oo8ft6t5t0rnmhfqgpnkqtev5b9a2i5j.apps.googleusercontent.com',
-}
-
-
-# ---------------------------------------------------------------------------
-# Cross-platform exclusive file lock (stdlib only, no pip dependencies).
-# ---------------------------------------------------------------------------
-
-def _acquire_lock(lock_fd):
-    """Acquire an exclusive lock on the given file descriptor."""
-    if sys.platform == 'win32':
-        import msvcrt
-        deadline = time.time() + 30
-        while True:
-            try:
-                lock_fd.seek(0)
-                msvcrt.locking(lock_fd.fileno(), msvcrt.LK_NBLCK, 1)
-                return
-            except OSError:
-                if time.time() >= deadline:
-                    raise
-                time.sleep(0.1)
-    else:
-        import fcntl
-        fcntl.flock(lock_fd, fcntl.LOCK_EX)
-
-
-def _release_lock(lock_fd):
-    """Release an exclusive lock on the given file descriptor."""
-    if sys.platform == 'win32':
-        import msvcrt
-        try:
-            lock_fd.seek(0)
-            msvcrt.locking(lock_fd.fileno(), msvcrt.LK_UNLCK, 1)
-        except OSError:
-            pass
-    else:
-        import fcntl
-        fcntl.flock(lock_fd, fcntl.LOCK_UN)
-
-
-def _atomic_write_json(path, data):
-    """Atomically write JSON data to a file (write-to-temp then rename)."""
-    d = os.path.dirname(path)
-    fd, tmp = tempfile.mkstemp(dir=d, prefix='.tmp-', suffix='.tmp')
-    try:
-        with os.fdopen(fd, 'w') as f:
-            json.dump(data, f, indent=2)
-        os.chmod(tmp, 0o600)
-        os.replace(tmp, path)
-    except BaseException:
-        try:
-            os.unlink(tmp)
-        except OSError:
-            pass
-        raise
-
-
-# ---------------------------------------------------------------------------
-# auto-clear: Atomically clear expired cooldowns in the pool file.
-# Env: POOL_FILE_PATH
-# ---------------------------------------------------------------------------
-
-def cmd_auto_clear():
-    pool_path = os.environ['POOL_FILE_PATH']
-
-    lock_path = pool_path + '.lock'
-    lock_fd = open(lock_path, 'w')
-    try:
-        _acquire_lock(lock_fd)
-        with open(pool_path) as f:
-            pool = json.load(f)
-
-        now = int(time.time() * 1000)
-        changed = False
-        for provider in list(pool.keys()):
-            if provider.startswith('_'):
-                continue
-            accounts = pool.get(provider, [])
-            if not isinstance(accounts, list):
-                continue
-            for acct in accounts:
-                cd = acct.get('cooldownUntil')
-                if cd and isinstance(cd, (int, float)) and cd > 0 and cd <= now:
-                    if acct.get('status') == 'rate-limited':
-                        acct['status'] = 'idle'
-                    acct['cooldownUntil'] = 0
-                    changed = True
-        if changed:
-            _atomic_write_json(pool_path, pool)
-            print('CHANGED')
-        else:
-            print('UNCHANGED')
-    finally:
-        _release_lock(lock_fd)
-        lock_fd.close()
-
-
-# ---------------------------------------------------------------------------
-# upsert: Upsert an account into the pool.
-# Reads pool JSON from stdin.
-# Env: PROVIDER, EMAIL, ACCESS, REFRESH, EXPIRES, NOW_ISO, ACCOUNT_ID
-# ---------------------------------------------------------------------------
-
-def cmd_upsert():
-    pool = json.load(sys.stdin)
-    provider = os.environ['PROVIDER']
-    email = os.environ['EMAIL']
-    access = os.environ['ACCESS']
-    refresh = os.environ['REFRESH']
-    expires = int(os.environ['EXPIRES'])
-    now_iso = os.environ['NOW_ISO']
-    account_id = os.environ.get('ACCOUNT_ID', '')
-
-    if provider not in pool:
-        pool[provider] = []
-
-    found = False
-    for account in pool[provider]:
-        if account.get('email') == email:
-            account['access'] = access
-            account['refresh'] = refresh
-            account['expires'] = expires
-            account['lastUsed'] = now_iso
-            account['status'] = 'active'
-            account['cooldownUntil'] = None
-            if account_id:
-                account['accountId'] = account_id
-            found = True
-            break
-
-    if not found:
-        entry = {
-            'email': email,
-            'access': access,
-            'refresh': refresh,
-            'expires': expires,
-            'added': now_iso,
-            'lastUsed': now_iso,
-            'status': 'active',
-            'cooldownUntil': None,
-        }
-        if account_id:
-            entry['accountId'] = account_id
-        pool[provider].append(entry)
-
-    json.dump(pool, sys.stdout, indent=2)
-
-
-# ---------------------------------------------------------------------------
-# normalize-cooldowns: Normalize expired cooldowns.
-# Reads pool JSON from stdin.
-# Env: PROVIDER (provider name or "all")
-# ---------------------------------------------------------------------------
-
-def cmd_normalize_cooldowns():
-    provider = os.environ.get('PROVIDER', 'all')
-    pool = json.load(sys.stdin)
-    now = int(time.time() * 1000)
-    updated = 0
-    providers = list(pool.keys()) if provider == 'all' else [provider]
-    for prov in providers:
-        if prov.startswith('_'):
-            continue
-        for account in pool.get(prov, []):
-            cooldown_ms = account.get('cooldownUntil') or 0
-            if cooldown_ms > 0 and cooldown_ms <= now:
-                account['status'] = 'idle'
-                account['cooldownUntil'] = 0
-                updated += 1
-    json.dump({'updated': updated, 'pool': pool}, sys.stdout, separators=(',', ':'))
-
-
-# ---------------------------------------------------------------------------
-# rotate: Rotate to next available account.
-# Env: POOL_FILE_PATH, AUTH_FILE_PATH, PROVIDER, UA_HEADER
-# ---------------------------------------------------------------------------
-
-def cmd_rotate():
-    pool_path = os.environ['POOL_FILE_PATH']
-    auth_path = os.environ['AUTH_FILE_PATH']
-    provider = os.environ['PROVIDER']
-
-    def _try_refresh(account, prov, now_ms):
-        refresh_tok = account.get('refresh', '')
-        token_url = TOKEN_URLS.get(prov, '')
-        client_id = CLIENT_IDS.get(prov, '')
-        if not (refresh_tok and token_url and client_id):
-            return
-        body = json.dumps({
-            'grant_type': 'refresh_token',
-            'refresh_token': refresh_tok,
-            'client_id': client_id,
-        }).encode('utf-8')
-        req = urllib.request.Request(
-            token_url, data=body,
-            headers={'Content-Type': 'application/json',
-                     'User-Agent': os.environ.get('UA_HEADER', 'aidevops/1.0')},
-            method='POST',
-        )
-        try:
-            with urllib.request.urlopen(req, timeout=15) as resp:
-                rdata = json.loads(resp.read().decode('utf-8'))
-            new_access = rdata.get('access_token', '')
-            if new_access:
-                account['access'] = new_access
-                account['refresh'] = rdata.get('refresh_token', refresh_tok)
-                account['expires'] = now_ms + int(rdata.get('expires_in', 3600)) * 1000
-                account['status'] = 'active'
-                print('REFRESHED', file=sys.stderr)
-        except (urllib.error.URLError, urllib.error.HTTPError) as e:
-            print(f'REFRESH_FAILED:{e}', file=sys.stderr)
-
-    lock_path = pool_path + '.lock'
-    lock_fd = open(lock_path, 'w')
-    try:
-        _acquire_lock(lock_fd)
-
-        with open(pool_path) as f:
-            pool = json.load(f)
-        accounts = pool.get(provider, [])
-        if len(accounts) < 2:
-            print('ERROR:need_accounts')
-            sys.exit(0)
-
-        with open(auth_path) as f:
-            auth = json.load(f)
-        current_auth = auth.get(provider, {})
-        current_access = current_auth.get('access', '')
-
-        current_email = None
-        for a in accounts:
-            if a.get('access', '') == current_access and current_access:
-                current_email = a.get('email', 'unknown')
-                break
-        if current_email is None:
-            sorted_by_used = sorted(accounts, key=lambda a: a.get('lastUsed', ''), reverse=True)
-            current_email = sorted_by_used[0].get('email', 'unknown')
-
-        now_ms = int(time.time() * 1000)
-        # Tier 1: non-current accounts that are available right now
-        candidates = [
-            a for a in accounts
-            if a.get('email') != current_email
-            and a.get('status', 'active') in ('active', 'idle')
-            and (not a.get('cooldownUntil') or a['cooldownUntil'] <= now_ms)
-        ]
-        all_rate_limited = False
-        if not candidates:
-            # Tier 2: ALL accounts sorted by shortest remaining cooldown
-            candidates = sorted(
-                accounts,
-                key=lambda a: a.get('cooldownUntil') or 0,
-            )
-            all_rate_limited = True
-        if not candidates:
-            print('ERROR:no_alternate')
-            sys.exit(0)
-
-        if not all_rate_limited:
-            candidates.sort(key=lambda a: (-(a.get('priority') or 0), a.get('lastUsed', '')))
-
-        next_account = candidates[0]
-        next_email = next_account.get('email', 'unknown')
-
-        # Auto-refresh if expired and refresh token available
-        if next_account.get('expires', 0) <= now_ms and next_account.get('refresh'):
-            _try_refresh(next_account, provider, now_ms)
-
-        auth_entry = {
-            'type':    current_auth.get('type', 'oauth'),
-            'refresh': next_account.get('refresh', ''),
-            'access':  next_account.get('access', ''),
-            'expires': next_account.get('expires', 0),
-        }
-        if provider == 'openai':
-            account_id = next_account.get('accountId', current_auth.get('accountId', ''))
-            if account_id:
-                auth_entry['accountId'] = account_id
-        auth[provider] = auth_entry
-        _atomic_write_json(auth_path, auth)
-
-        now_iso = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
-        for a in pool[provider]:
-            if a.get('email') == next_email:
-                a['lastUsed'] = now_iso
-                break
-        _atomic_write_json(pool_path, pool)
-
-    finally:
-        _release_lock(lock_fd)
-        lock_fd.close()
-
-    if all_rate_limited:
-        cd = next_account.get('cooldownUntil') or 0
-        wait_mins = max(0, (cd - now_ms + 59999) // 60000) if cd > now_ms else 0
-        print(f'OK_COOLDOWN:{wait_mins}')
-    else:
-        print('OK')
-    print(current_email)
-    print(next_email)
-
-
-# ---------------------------------------------------------------------------
-# refresh: Refresh expired tokens.
-# Env: POOL_FILE_PATH, AUTH_FILE_PATH, PROVIDER, TARGET_EMAIL, UA_HEADER
-# ---------------------------------------------------------------------------
-
-def cmd_refresh():
-    pool_path = os.environ['POOL_FILE_PATH']
-    auth_path = os.environ['AUTH_FILE_PATH']
-    provider = os.environ['PROVIDER']
-    target_email = os.environ['TARGET_EMAIL']
-    ua_header = os.environ.get('UA_HEADER', 'aidevops/1.0')
-
-    token_url = TOKEN_URLS.get(provider, '')
-    client_id = CLIENT_IDS.get(provider, '')
-    if not token_url or not client_id:
-        print('ERROR:no_endpoint')
-        sys.exit(0)
-
-    lock_path = pool_path + '.lock'
-    lock_fd = open(lock_path, 'w')
-    try:
-        _acquire_lock(lock_fd)
-
-        with open(pool_path) as f:
-            pool = json.load(f)
-
-        accounts = pool.get(provider, [])
-        now_ms = int(time.time() * 1000)
-        refreshed = []
-        failed = []
-
-        for acct in accounts:
-            email = acct.get('email', 'unknown')
-            if target_email != 'all' and email != target_email:
-                continue
-
-            refresh_tok = acct.get('refresh', '')
-            expires = acct.get('expires', 0)
-
-            if not refresh_tok:
-                continue
-
-            # Only refresh if expired or expiring within 1 hour (3600000ms)
-            if expires and expires > now_ms + 3600000:
-                continue
-
-            body = json.dumps({
-                'grant_type': 'refresh_token',
-                'refresh_token': refresh_tok,
-                'client_id': client_id,
-            }).encode('utf-8')
-
-            req = urllib.request.Request(
-                token_url,
-                data=body,
-                headers={
-                    'Content-Type': 'application/json',
-                    'User-Agent': ua_header,
-                },
-                method='POST',
-            )
-            try:
-                with urllib.request.urlopen(req, timeout=15) as resp:
-                    rdata = json.loads(resp.read().decode('utf-8'))
-                new_access = rdata.get('access_token', '')
-                new_refresh = rdata.get('refresh_token', refresh_tok)
-                new_expires_in = int(rdata.get('expires_in', 3600))
-                if new_access:
-                    acct['access'] = new_access
-                    acct['refresh'] = new_refresh
-                    acct['expires'] = now_ms + new_expires_in * 1000
-                    acct['status'] = 'active'
-                    refreshed.append(email)
-                else:
-                    failed.append(email)
-            except (urllib.error.URLError, urllib.error.HTTPError) as e:
-                failed.append(f'{email}({e})')
-
-        # Write updated pool
-        if refreshed:
-            _atomic_write_json(pool_path, pool)
-
-            # Also update auth.json if the currently-active account was refreshed
-            # OR if auth.json has empty/missing tokens for this provider (self-heal).
-            # GH#17487: Previously, only expired tokens triggered the write-back.
-            if os.path.exists(auth_path):
-                with open(auth_path) as f:
-                    auth = json.load(f)
-                current_access = auth.get(provider, {}).get('access', '')
-                auth_expires = auth.get(provider, {}).get('expires', 0)
-                # Self-heal: detect empty/missing/expired tokens
-                needs_heal = (
-                    not current_access
-                    or (auth_expires and auth_expires <= now_ms)
-                    or not auth_expires
-                )
-                if needs_heal:
-                    heal_acct = None
-                    for acct in accounts:
-                        if acct.get('email') in refreshed:
-                            heal_acct = acct
-                            break
-                    if not heal_acct:
-                        for acct in accounts:
-                            if acct.get('access') and acct.get('expires', 0) > now_ms:
-                                heal_acct = acct
-                                break
-                    if heal_acct:
-                        auth_entry = {
-                            'type': 'oauth',
-                            'refresh': heal_acct.get('refresh', ''),
-                            'access': heal_acct.get('access', ''),
-                            'expires': heal_acct.get('expires', 0),
-                        }
-                        if provider == 'openai':
-                            account_id = heal_acct.get('accountId', auth.get(provider, {}).get('accountId', ''))
-                            if account_id:
-                                auth_entry['accountId'] = account_id
-                        auth[provider] = auth_entry
-                        _atomic_write_json(auth_path, auth)
-                        print(f'HEALED_AUTH:{provider}:{heal_acct.get("email", "")}', file=sys.stderr)
-
-    finally:
-        _release_lock(lock_fd)
-        lock_fd.close()
-
-    for e in refreshed:
-        print(f'REFRESHED:{e}')
-    for e in failed:
-        print(f'FAILED:{e}')
-    if not refreshed and not failed:
-        print('NONE')
-
-
-# ---------------------------------------------------------------------------
-# mark-failure: Mark current account as failed.
-# Env: POOL_FILE_PATH, AUTH_FILE_PATH, PROVIDER, REASON, RETRY_SECONDS
-# ---------------------------------------------------------------------------
-
-def cmd_mark_failure():
-    from datetime import datetime, timezone
-
-    pool_path = os.environ['POOL_FILE_PATH']
-    auth_path = os.environ['AUTH_FILE_PATH']
-    provider = os.environ['PROVIDER']
-    reason = os.environ['REASON']
-    retry_seconds = int(os.environ['RETRY_SECONDS'])
-
-    status_map = {
-        'rate_limit': 'rate-limited',
-        'auth_error': 'auth-error',
-        'provider_error': 'rate-limited',
-    }
-    target_status = status_map.get(reason, 'rate-limited')
-
-    lock_path = pool_path + '.lock'
-    lock_fd = open(lock_path, 'w')
-    try:
-        _acquire_lock(lock_fd)
-        with open(pool_path) as f:
-            pool = json.load(f)
-        with open(auth_path) as f:
-            auth = json.load(f)
-
-        accounts = pool.get(provider, [])
-        if not accounts:
-            print('SKIP:no_accounts')
-            sys.exit(0)
-
-        current_auth = auth.get(provider, {}) if isinstance(auth, dict) else {}
-        current_access = current_auth.get('access', '')
-        current_account_id = current_auth.get('accountId', '')
-
-        idx = -1
-        if current_access:
-            for i, acct in enumerate(accounts):
-                if acct.get('access', '') == current_access:
-                    idx = i
-                    break
-
-        if idx < 0 and provider == 'openai' and current_account_id:
-            for i, acct in enumerate(accounts):
-                if acct.get('accountId', '') == current_account_id:
-                    idx = i
-                    break
-
-        if idx < 0:
-            best_i = 0
-            best_last = ''
-            for i, acct in enumerate(accounts):
-                last = acct.get('lastUsed', '')
-                if last >= best_last:
-                    best_last = last
-                    best_i = i
-            idx = best_i
-
-        now_ms = int(time.time() * 1000)
-        cooldown_until = now_ms + retry_seconds * 1000
-        now_iso = datetime.now(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
-
-        target = accounts[idx]
-        target['status'] = target_status
-        target['cooldownUntil'] = cooldown_until
-        target['lastUsed'] = now_iso
-        pool[provider] = accounts
-
-        _atomic_write_json(pool_path, pool)
-        email = target.get('email', 'unknown')
-        print(f'OK:{email}:{target_status}:{cooldown_until}')
-    finally:
-        _release_lock(lock_fd)
-        lock_fd.close()
-
-
-# ---------------------------------------------------------------------------
-# check-accounts: Print account details for health check.
-# Reads pool JSON from stdin.
-# Env: PROV, NOW_MS
-# ---------------------------------------------------------------------------
-
-def cmd_check_accounts():
-    pool = json.load(sys.stdin)
-    prov = os.environ['PROV']
-    now = int(os.environ['NOW_MS'])
-    for a in pool.get(prov, []):
-        expires_in = a.get('expires', 0) - now
-        print(json.dumps({'email': a['email'], 'expires_in': expires_in,
-                          'account': a}))
-
-
-# ---------------------------------------------------------------------------
-# check-validate: Validate a token against provider API.
-# Env: PROV, EXPIRES_IN, TOKEN, UA
-# ---------------------------------------------------------------------------
-
-def cmd_check_validate():
-    from urllib.request import Request, urlopen
-    from urllib.error import HTTPError, URLError
-
-    prov = os.environ['PROV']
-    expires_in = int(os.environ['EXPIRES_IN'])
-    token = os.environ['TOKEN']
-    ua = os.environ['UA']
-
-    if prov not in ('anthropic', 'google'):
-        raise SystemExit(0)
-    if not token:
-        print('    Validity: no access token')
-        raise SystemExit(0)
-    if expires_in <= 0:
-        print('    Validity: EXPIRED - will auto-refresh on next use')
-        raise SystemExit(0)
-    if prov == 'anthropic':
-        req = Request('https://api.anthropic.com/v1/models', method='GET')
-        req.add_header('Authorization', f'Bearer {token}')
-        req.add_header('User-Agent', ua)
-        req.add_header('anthropic-version', '2023-06-01')
-        req.add_header('anthropic-beta', 'oauth-2025-04-20')
-    else:
-        req = Request('https://generativelanguage.googleapis.com/v1beta/models?pageSize=1', method='GET')
-        req.add_header('Authorization', f'Bearer {token}')
-    try:
-        urlopen(req, timeout=10)
-        print('    Validity: OK')
-    except HTTPError as e:
-        if e.code == 401:
-            print('    Validity: INVALID (401 - needs refresh)')
-        elif prov == 'google' and e.code == 403:
-            print('    Validity: OK (403 - token valid, check AI Pro/Ultra subscription)')
-        else:
-            print(f'    Validity: HTTP {e.code}')
-    except (URLError, OSError):
-        print('    Validity: ERROR (network)')
-    except Exception:
-        print('    Validity: ERROR')
-
-
-# ---------------------------------------------------------------------------
-# check-meta: Print account metadata.
-# Reads account JSON from stdin.
-# Env: NOW_MS
-# ---------------------------------------------------------------------------
-
-def cmd_check_meta():
-    from datetime import datetime
-
-    a = json.load(sys.stdin)
-    now = int(os.environ['NOW_MS'])
-    print(f"    Status: {a.get('status', 'unknown')}")
-    cd = a.get('cooldownUntil')
-    if cd and cd > now:
-        cd_mins = (cd - now + 59999) // 60000
-        print(f'    Cooldown: {cd_mins}m remaining')
-    lu = a.get('lastUsed')
-    if lu:
-        try:
-            lu_ts = datetime.fromisoformat(lu.replace('Z', '+00:00')).timestamp() * 1000
-            ago = now - lu_ts
-            ago_mins = int(ago // 60000)
-            ago_hours = ago_mins // 60
-            if ago_hours > 0:
-                print(f'    Last used: {ago_hours}h {ago_mins % 60}m ago')
-            else:
-                print(f'    Last used: {ago_mins}m ago')
-        except Exception:
-            print(f'    Last used: {lu}')
-    print(f"    Refresh token: {'present' if a.get('refresh') else 'MISSING'}")
-
-
-# ---------------------------------------------------------------------------
-# check-expiry: Print token expiry info.
-# Env: EXPIRES_IN (milliseconds remaining)
-# ---------------------------------------------------------------------------
-
-def cmd_check_expiry():
-    expires_in = int(os.environ['EXPIRES_IN'])
-    if expires_in <= 0:
-        print('    Token: EXPIRED')
-    else:
-        mins = expires_in // 60000
-        hours = mins // 60
-        if hours > 0:
-            print(f'    Token: expires in {hours}h {mins % 60}m')
-        else:
-            print(f'    Token: expires in {mins}m')
-
-
-# ---------------------------------------------------------------------------
-# reset-cooldowns: Reset cooldowns for accounts.
-# Reads pool JSON from stdin.
-# Env: PROVIDER
-# ---------------------------------------------------------------------------
-
-def cmd_reset_cooldowns():
-    pool = json.load(sys.stdin)
-    target = os.environ['PROVIDER']
-    providers = list(pool.keys()) if target == 'all' else [target]
-    cleared = 0
-    for prov in providers:
-        for a in pool.get(prov, []):
-            if a.get('cooldownUntil') or a.get('status') in ('rate-limited', 'auth-error'):
-                a['cooldownUntil'] = None
-                a['status'] = 'idle'
-                cleared += 1
-    json.dump({'cleared': cleared, 'pool': pool}, sys.stdout, indent=2)
-
-
-# ---------------------------------------------------------------------------
-# set-priority: Set priority on an account.
-# Reads pool JSON from stdin.
-# Env: PROVIDER, EMAIL, PRIORITY
-# ---------------------------------------------------------------------------
-
-def cmd_set_priority():
-    pool = json.load(sys.stdin)
-    provider = os.environ['PROVIDER']
-    email = os.environ['EMAIL']
-    priority = int(os.environ['PRIORITY'])
-
-    accounts = pool.get(provider, [])
-    idx = next((i for i, a in enumerate(accounts) if a.get('email') == email), -1)
-    if idx < 0:
-        print('ERROR:not_found')
-        sys.exit(0)
-
-    if priority == 0:
-        accounts[idx].pop('priority', None)
-    else:
-        accounts[idx]['priority'] = priority
-    json.dump(pool, sys.stdout, indent=2)
-
-
-# ---------------------------------------------------------------------------
-# remove-account: Remove an account from pool.
-# Reads pool JSON from stdin.
-# Env: PROVIDER, EMAIL
-# ---------------------------------------------------------------------------
-
-def cmd_remove_account():
-    pool = json.load(sys.stdin)
-    provider = os.environ['PROVIDER']
-    email = os.environ['EMAIL']
-
-    if provider not in pool:
-        print(json.dumps(pool, indent=2))
-        sys.exit(1)
-
-    original_count = len(pool[provider])
-    pool[provider] = [a for a in pool[provider] if a.get('email') != email]
-    new_count = len(pool[provider])
-
-    if original_count == new_count:
-        print(json.dumps(pool, indent=2))
-        sys.exit(1)
-
-    json.dump(pool, sys.stdout, indent=2)
-
-
-# ---------------------------------------------------------------------------
-# assign-pending: Assign pending token to account.
-# Reads pool JSON from stdin.
-# Env: PROVIDER, EMAIL
-# ---------------------------------------------------------------------------
-
-def cmd_assign_pending():
-    pool = json.load(sys.stdin)
-    provider = os.environ['PROVIDER']
-    email = os.environ['EMAIL']
-    pending_key = '_pending_' + provider
-    pending = pool.get(pending_key)
-
-    if not pending:
-        print('ERROR:no_pending')
-        sys.exit(0)
-
-    accounts = pool.get(provider, [])
-    idx = next((i for i, a in enumerate(accounts) if a.get('email') == email), -1)
-    if idx < 0:
-        print('ERROR:not_found')
-        sys.exit(0)
-
-    accounts[idx]['refresh'] = pending.get('refresh', accounts[idx].get('refresh', ''))
-    accounts[idx]['access'] = pending.get('access', accounts[idx].get('access', ''))
-    accounts[idx]['expires'] = pending.get('expires', accounts[idx].get('expires', 0))
-    accounts[idx]['status'] = 'active'
-    accounts[idx]['cooldownUntil'] = None
-    del pool[pending_key]
-    json.dump(pool, sys.stdout, indent=2)
-
-
-# ---------------------------------------------------------------------------
-# check-pending: Check if pending token exists.
-# Reads pool JSON from stdin.
-# Env: PROVIDER
-# ---------------------------------------------------------------------------
-
-def cmd_check_pending():
-    pool = json.load(sys.stdin)
-    provider = os.environ['PROVIDER']
-    pending = pool.get('_pending_' + provider)
-    if pending:
-        print('FOUND:' + pending.get('added', 'unknown'))
-    else:
-        print('NONE')
-
-
-# ---------------------------------------------------------------------------
-# list-pending: List accounts for pending assignment.
-# Reads pool JSON from stdin.
-# Env: PROVIDER
-# ---------------------------------------------------------------------------
-
-def cmd_list_pending():
-    pool = json.load(sys.stdin)
-    provider = os.environ['PROVIDER']
-    for i, a in enumerate(pool.get(provider, []), 1):
-        print(f'  {i}. {a["email"]}')
-
-
-# ---------------------------------------------------------------------------
-# import-check: Check if email exists in pool.
-# Reads pool JSON from stdin.
-# Env: EMAIL
-# ---------------------------------------------------------------------------
-
-def cmd_import_check():
-    pool = json.load(sys.stdin)
-    email = os.environ['EMAIL']
-    for acc in pool.get('anthropic', []):
-        if acc.get('email') == email:
-            print('yes')
-            sys.exit(0)
-    print('no')
-
-
-# ---------------------------------------------------------------------------
-# status-stats: Print pool statistics.
-# Reads pool JSON from stdin.
-# Env: NOW_MS, PROV
-# ---------------------------------------------------------------------------
-
-def cmd_status_stats():
-    pool = json.load(sys.stdin)
-    now = int(os.environ['NOW_MS'])
-    prov = os.environ['PROV']
-    accounts = pool.get(prov, [])
-
-    total = len(accounts)
-    available = sum(1 for a in accounts if not a.get('cooldownUntil') or a['cooldownUntil'] <= now)
-    active = sum(1 for a in accounts if a.get('status') in ('active', 'idle'))
-    rate_lim = sum(1 for a in accounts if a.get('status') == 'rate-limited' and a.get('cooldownUntil', 0) > now)
-    auth_err = sum(1 for a in accounts if a.get('status') == 'auth-error')
-
-    print(f'{prov} pool:')
-    print(f'  Total accounts : {total}')
-    print(f'  Available now  : {available}')
-    print(f'  Active/idle    : {active}')
-    print(f'  Rate limited   : {rate_lim}')
-    print(f'  Auth errors    : {auth_err}')
-    if available == 0 and total > 0:
-        print('  WARNING: no accounts available — run reset-cooldowns or add an account')
-
-
-# ---------------------------------------------------------------------------
-# list-accounts: List accounts with status.
-# Reads pool JSON from stdin.
-# Env: PROVIDER
-# ---------------------------------------------------------------------------
-
-def cmd_list_accounts():
-    pool = json.load(sys.stdin)
-    prov = os.environ['PROVIDER']
-    for i, a in enumerate(pool.get(prov, []), 1):
-        status = a.get('status', 'unknown')
-        email = a.get('email', 'unknown')
-        priority = a.get('priority')
-        priority_str = f' priority:{priority}' if priority is not None else ''
-        print(f'  {i}. {email} [{status}]{priority_str}')
-
-
-# ---------------------------------------------------------------------------
-# extract-token-fields: Extract token fields from JSON response.
-# Reads JSON from stdin.
-# ---------------------------------------------------------------------------
-
-def cmd_extract_token_fields():
-    d = json.load(sys.stdin)
-    print(d.get('access_token', ''))
-    print(d.get('refresh_token', ''))
-    print(d.get('expires_in', 3600))
-
-
-# ---------------------------------------------------------------------------
-# extract-token-error: Extract error message from token response.
-# Reads JSON from stdin.
-# ---------------------------------------------------------------------------
-
-def cmd_extract_token_error():
-    try:
-        d = json.load(sys.stdin)
-        parts = []
-        for k in ('type', 'error', 'message', 'error_description'):
-            if k in d and d[k]:
-                parts.append(str(d[k]))
-        print(': '.join(parts) if parts else 'unknown')
-    except Exception:
-        print('unknown')
-
-
-# ---------------------------------------------------------------------------
-# openai-read-auth: Read OpenAI auth fields from OpenCode auth file.
-# Env: AUTH_PATH
-# ---------------------------------------------------------------------------
-
-def cmd_openai_read_auth():
-    path = os.environ['AUTH_PATH']
-    try:
-        with open(path) as f:
-            auth = json.load(f)
-    except Exception:
-        print('')
-        print('')
-        print('')
-        print('')
-        sys.exit(0)
-
-    entry = auth.get('openai', {}) if isinstance(auth, dict) else {}
-    print(entry.get('access', ''))
-    print(entry.get('refresh', ''))
-    print(entry.get('expires', ''))
-    print(entry.get('accountId', ''))
-
-
-# ---------------------------------------------------------------------------
-# cursor-read-auth: Read Cursor auth.json fields.
-# Env: AUTH_PATH
-# ---------------------------------------------------------------------------
-
-def cmd_cursor_read_auth():
-    path = os.environ['AUTH_PATH']
-    try:
-        with open(path) as f:
-            d = json.load(f)
-        print(d.get('accessToken', ''))
-        print(d.get('refreshToken', ''))
-    except Exception:
-        print('')
-        print('')
-
-
-# ---------------------------------------------------------------------------
-# cursor-decode-jwt: Decode JWT fields from access token.
-# Env: ACCESS
-# ---------------------------------------------------------------------------
-
-def cmd_cursor_decode_jwt():
-    import base64
-
-    token = os.environ['ACCESS']
-    parts = token.split('.')
-    if len(parts) >= 2:
-        payload = parts[1] + '=' * (4 - len(parts[1]) % 4)
-        try:
-            data = json.loads(base64.urlsafe_b64decode(payload))
-            print(data.get('email', ''))
-            print(data.get('exp', 0))
-        except Exception:
-            print('')
-            print(0)
-    else:
-        print('')
-        print(0)
-
-
-# ---------------------------------------------------------------------------
-# google-validate: Validate token against Google API.
-# Env: ACCESS, HEALTH_URL
-# ---------------------------------------------------------------------------
-
-def cmd_google_validate():
-    from urllib.request import Request, urlopen
-    from urllib.error import HTTPError, URLError
-
-    token = os.environ['ACCESS']
-    url = os.environ['HEALTH_URL']
-    try:
-        req = Request(url, method='GET')
-        req.add_header('Authorization', 'Bearer ' + token)
-        urlopen(req, timeout=10)
-        print('OK')
-    except HTTPError as e:
-        print('HTTP_' + str(e.code))
-    except (URLError, OSError):
-        print('NETWORK_ERROR')
-    except Exception:
-        print('ERROR')
-
-
-# ---------------------------------------------------------------------------
-# Dispatch
-# ---------------------------------------------------------------------------
 
 COMMANDS = {
-    'auto-clear': cmd_auto_clear,
-    'upsert': cmd_upsert,
-    'normalize-cooldowns': cmd_normalize_cooldowns,
-    'rotate': cmd_rotate,
-    'refresh': cmd_refresh,
-    'mark-failure': cmd_mark_failure,
-    'check-accounts': cmd_check_accounts,
-    'check-validate': cmd_check_validate,
-    'check-meta': cmd_check_meta,
-    'check-expiry': cmd_check_expiry,
-    'reset-cooldowns': cmd_reset_cooldowns,
-    'set-priority': cmd_set_priority,
-    'remove-account': cmd_remove_account,
-    'assign-pending': cmd_assign_pending,
-    'check-pending': cmd_check_pending,
-    'list-pending': cmd_list_pending,
-    'import-check': cmd_import_check,
-    'status-stats': cmd_status_stats,
-    'list-accounts': cmd_list_accounts,
-    'extract-token-fields': cmd_extract_token_fields,
-    'extract-token-error': cmd_extract_token_error,
-    'openai-read-auth': cmd_openai_read_auth,
-    'cursor-read-auth': cmd_cursor_read_auth,
-    'cursor-decode-jwt': cmd_cursor_decode_jwt,
-    'google-validate': cmd_google_validate,
+    "auto-clear": cmd_auto_clear,
+    "upsert": cmd_upsert,
+    "normalize-cooldowns": cmd_normalize_cooldowns,
+    "rotate": cmd_rotate,
+    "refresh": cmd_refresh,
+    "mark-failure": cmd_mark_failure,
+    "check-accounts": cmd_check_accounts,
+    "check-validate": cmd_check_validate,
+    "check-meta": cmd_check_meta,
+    "check-expiry": cmd_check_expiry,
+    "reset-cooldowns": cmd_reset_cooldowns,
+    "set-priority": cmd_set_priority,
+    "remove-account": cmd_remove_account,
+    "assign-pending": cmd_assign_pending,
+    "check-pending": cmd_check_pending,
+    "list-pending": cmd_list_pending,
+    "import-check": cmd_import_check,
+    "status-stats": cmd_status_stats,
+    "list-accounts": cmd_list_accounts,
+    "extract-token-fields": cmd_extract_token_fields,
+    "extract-token-error": cmd_extract_token_error,
+    "openai-read-auth": cmd_openai_read_auth,
+    "cursor-read-auth": cmd_cursor_read_auth,
+    "cursor-decode-jwt": cmd_cursor_decode_jwt,
+    "google-validate": cmd_google_validate,
 }
 
 
-def main():
+__all__ = list(COMMANDS) + ["main"]
+
+
+def main() -> None:
     if len(sys.argv) < 2:
-        print(f'Usage: {sys.argv[0]} <command>', file=sys.stderr)
-        print(f'Commands: {", ".join(sorted(COMMANDS))}', file=sys.stderr)
+        print(f"Usage: {sys.argv[0]} <command>", file=sys.stderr)
+        print(f"Commands: {', '.join(sorted(COMMANDS))}", file=sys.stderr)
         sys.exit(1)
 
     cmd = sys.argv[1]
     if cmd not in COMMANDS:
-        print(f'Unknown command: {cmd}', file=sys.stderr)
+        print(f"Unknown command: {cmd}", file=sys.stderr)
         sys.exit(1)
 
     COMMANDS[cmd]()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()

--- a/.agents/scripts/oauth-pool-lib/pool_ops_accounts.py
+++ b/.agents/scripts/oauth-pool-lib/pool_ops_accounts.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""
+oauth-pool-lib/pool_ops_accounts.py — account CRUD command implementations.
+
+Pool/account management commands that read pool JSON from stdin and write
+the updated pool to stdout. Extracted from ``pool_ops.py`` during the t2069
+decomposition.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+
+def cmd_upsert() -> None:
+    """upsert: Upsert an account into the pool.
+
+    Env: PROVIDER, EMAIL, ACCESS, REFRESH, EXPIRES, NOW_ISO, ACCOUNT_ID
+    """
+    pool = json.load(sys.stdin)
+    provider = os.environ["PROVIDER"]
+    email = os.environ["EMAIL"]
+    access = os.environ["ACCESS"]
+    refresh = os.environ["REFRESH"]
+    expires = int(os.environ["EXPIRES"])
+    now_iso = os.environ["NOW_ISO"]
+    account_id = os.environ.get("ACCOUNT_ID", "")
+
+    if provider not in pool:
+        pool[provider] = []
+
+    found = False
+    for account in pool[provider]:
+        if account.get("email") == email:
+            account["access"] = access
+            account["refresh"] = refresh
+            account["expires"] = expires
+            account["lastUsed"] = now_iso
+            account["status"] = "active"
+            account["cooldownUntil"] = None
+            if account_id:
+                account["accountId"] = account_id
+            found = True
+            break
+
+    if not found:
+        entry = {
+            "email": email,
+            "access": access,
+            "refresh": refresh,
+            "expires": expires,
+            "added": now_iso,
+            "lastUsed": now_iso,
+            "status": "active",
+            "cooldownUntil": None,
+        }
+        if account_id:
+            entry["accountId"] = account_id
+        pool[provider].append(entry)
+
+    json.dump(pool, sys.stdout, indent=2)
+
+
+def cmd_set_priority() -> None:
+    """set-priority: Set priority on an account.
+
+    Env: PROVIDER, EMAIL, PRIORITY
+    """
+    pool = json.load(sys.stdin)
+    provider = os.environ["PROVIDER"]
+    email = os.environ["EMAIL"]
+    priority = int(os.environ["PRIORITY"])
+
+    accounts = pool.get(provider, [])
+    idx = next((i for i, a in enumerate(accounts) if a.get("email") == email), -1)
+    if idx < 0:
+        print("ERROR:not_found")
+        sys.exit(0)
+
+    if priority == 0:
+        accounts[idx].pop("priority", None)
+    else:
+        accounts[idx]["priority"] = priority
+    json.dump(pool, sys.stdout, indent=2)
+
+
+def cmd_remove_account() -> None:
+    """remove-account: Remove an account from pool.
+
+    Env: PROVIDER, EMAIL
+    """
+    pool = json.load(sys.stdin)
+    provider = os.environ["PROVIDER"]
+    email = os.environ["EMAIL"]
+
+    if provider not in pool:
+        print(json.dumps(pool, indent=2))
+        sys.exit(1)
+
+    original_count = len(pool[provider])
+    pool[provider] = [a for a in pool[provider] if a.get("email") != email]
+    new_count = len(pool[provider])
+
+    if original_count == new_count:
+        print(json.dumps(pool, indent=2))
+        sys.exit(1)
+
+    json.dump(pool, sys.stdout, indent=2)
+
+
+def cmd_assign_pending() -> None:
+    """assign-pending: Assign pending token to account.
+
+    Env: PROVIDER, EMAIL
+    """
+    pool = json.load(sys.stdin)
+    provider = os.environ["PROVIDER"]
+    email = os.environ["EMAIL"]
+    pending_key = "_pending_" + provider
+    pending = pool.get(pending_key)
+
+    if not pending:
+        print("ERROR:no_pending")
+        sys.exit(0)
+
+    accounts = pool.get(provider, [])
+    idx = next((i for i, a in enumerate(accounts) if a.get("email") == email), -1)
+    if idx < 0:
+        print("ERROR:not_found")
+        sys.exit(0)
+
+    accounts[idx]["refresh"] = pending.get("refresh", accounts[idx].get("refresh", ""))
+    accounts[idx]["access"] = pending.get("access", accounts[idx].get("access", ""))
+    accounts[idx]["expires"] = pending.get("expires", accounts[idx].get("expires", 0))
+    accounts[idx]["status"] = "active"
+    accounts[idx]["cooldownUntil"] = None
+    del pool[pending_key]
+    json.dump(pool, sys.stdout, indent=2)
+
+
+def cmd_check_pending() -> None:
+    """check-pending: Check if pending token exists.
+
+    Env: PROVIDER
+    """
+    pool = json.load(sys.stdin)
+    provider = os.environ["PROVIDER"]
+    pending = pool.get("_pending_" + provider)
+    if pending:
+        print("FOUND:" + pending.get("added", "unknown"))
+    else:
+        print("NONE")
+
+
+def cmd_list_pending() -> None:
+    """list-pending: List accounts for pending assignment.
+
+    Env: PROVIDER
+    """
+    pool = json.load(sys.stdin)
+    provider = os.environ["PROVIDER"]
+    for i, a in enumerate(pool.get(provider, []), 1):
+        print(f'  {i}. {a["email"]}')
+
+
+def cmd_import_check() -> None:
+    """import-check: Check if email exists in pool.
+
+    Env: EMAIL
+    """
+    pool = json.load(sys.stdin)
+    email = os.environ["EMAIL"]
+    for acc in pool.get("anthropic", []):
+        if acc.get("email") == email:
+            print("yes")
+            sys.exit(0)
+    print("no")
+
+
+def cmd_status_stats() -> None:
+    """status-stats: Print pool statistics.
+
+    Env: NOW_MS, PROV
+    """
+    pool = json.load(sys.stdin)
+    now = int(os.environ["NOW_MS"])
+    prov = os.environ["PROV"]
+    accounts = pool.get(prov, [])
+
+    total = len(accounts)
+    available = sum(1 for a in accounts if not a.get("cooldownUntil") or a["cooldownUntil"] <= now)
+    active = sum(1 for a in accounts if a.get("status") in ("active", "idle"))
+    rate_lim = sum(
+        1 for a in accounts if a.get("status") == "rate-limited" and a.get("cooldownUntil", 0) > now
+    )
+    auth_err = sum(1 for a in accounts if a.get("status") == "auth-error")
+
+    print(f"{prov} pool:")
+    print(f"  Total accounts : {total}")
+    print(f"  Available now  : {available}")
+    print(f"  Active/idle    : {active}")
+    print(f"  Rate limited   : {rate_lim}")
+    print(f"  Auth errors    : {auth_err}")
+    if available == 0 and total > 0:
+        print("  WARNING: no accounts available — run reset-cooldowns or add an account")
+
+
+def cmd_list_accounts() -> None:
+    """list-accounts: List accounts with status.
+
+    Env: PROVIDER
+    """
+    pool = json.load(sys.stdin)
+    prov = os.environ["PROVIDER"]
+    for i, a in enumerate(pool.get(prov, []), 1):
+        status = a.get("status", "unknown")
+        email = a.get("email", "unknown")
+        priority = a.get("priority")
+        priority_str = f" priority:{priority}" if priority is not None else ""
+        print(f"  {i}. {email} [{status}]{priority_str}")

--- a/.agents/scripts/oauth-pool-lib/pool_ops_auto_clear.py
+++ b/.agents/scripts/oauth-pool-lib/pool_ops_auto_clear.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""
+oauth-pool-lib/pool_ops_auto_clear.py — auto-clear command implementation.
+
+Atomically clears expired cooldowns from the pool file. Extracted from the
+monolithic ``pool_ops.py`` during the t2069 decomposition; the pool_ops
+facade re-dispatches ``auto-clear`` here.
+
+Env: POOL_FILE_PATH
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+
+from ._common import acquire_lock, atomic_write_json, release_lock
+
+
+def _is_account_list(value) -> bool:
+    return isinstance(value, list)
+
+
+def _clear_expired_cooldown(account: dict, now_ms: int) -> bool:
+    """Clear an expired cooldown on a single account.
+
+    Returns True if the account was modified. Status is only cleared from
+    ``rate-limited`` to ``idle``; other statuses (e.g. ``auth-error``) keep
+    their status but lose their cooldown timestamp, matching the pre-refactor
+    behaviour.
+    """
+    cd = account.get("cooldownUntil")
+    if not (cd and isinstance(cd, (int, float)) and cd > 0 and cd <= now_ms):
+        return False
+    if account.get("status") == "rate-limited":
+        account["status"] = "idle"
+    account["cooldownUntil"] = 0
+    return True
+
+
+def _clear_expired_in_pool(pool: dict, now_ms: int) -> bool:
+    """Walk every provider's accounts and clear expired cooldowns in place."""
+    changed = False
+    for provider in list(pool.keys()):
+        if provider.startswith("_"):
+            continue
+        accounts = pool.get(provider, [])
+        if not _is_account_list(accounts):
+            continue
+        for acct in accounts:
+            if _clear_expired_cooldown(acct, now_ms):
+                changed = True
+    return changed
+
+
+def cmd_auto_clear() -> None:
+    pool_path = os.environ["POOL_FILE_PATH"]
+    lock_path = pool_path + ".lock"
+    lock_fd = open(lock_path, "w")
+    try:
+        acquire_lock(lock_fd)
+        with open(pool_path) as f:
+            pool = json.load(f)
+
+        now_ms = int(time.time() * 1000)
+        if _clear_expired_in_pool(pool, now_ms):
+            atomic_write_json(pool_path, pool)
+            print("CHANGED")
+        else:
+            print("UNCHANGED")
+    finally:
+        release_lock(lock_fd)
+        lock_fd.close()

--- a/.agents/scripts/oauth-pool-lib/pool_ops_cooldowns.py
+++ b/.agents/scripts/oauth-pool-lib/pool_ops_cooldowns.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""
+oauth-pool-lib/pool_ops_cooldowns.py — cooldown normalisation commands.
+
+stdin-driven cooldown housekeeping commands extracted from ``pool_ops.py``
+during the t2069 decomposition. ``cmd_auto_clear`` lives in its own module
+because it owns the pool file directly (atomic write under lock); these two
+helpers operate on a pool dict piped via stdin.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+
+
+def cmd_normalize_cooldowns() -> None:
+    """normalize-cooldowns: Normalize expired cooldowns from a piped pool.
+
+    Env: PROVIDER (provider name or "all")
+    """
+    provider = os.environ.get("PROVIDER", "all")
+    pool = json.load(sys.stdin)
+    now = int(time.time() * 1000)
+    updated = 0
+    providers = list(pool.keys()) if provider == "all" else [provider]
+    for prov in providers:
+        if prov.startswith("_"):
+            continue
+        for account in pool.get(prov, []):
+            cooldown_ms = account.get("cooldownUntil") or 0
+            if cooldown_ms > 0 and cooldown_ms <= now:
+                account["status"] = "idle"
+                account["cooldownUntil"] = 0
+                updated += 1
+    json.dump({"updated": updated, "pool": pool}, sys.stdout, separators=(",", ":"))
+
+
+def cmd_reset_cooldowns() -> None:
+    """reset-cooldowns: Reset cooldowns for accounts.
+
+    Env: PROVIDER
+    """
+    pool = json.load(sys.stdin)
+    target = os.environ["PROVIDER"]
+    providers = list(pool.keys()) if target == "all" else [target]
+    cleared = 0
+    for prov in providers:
+        for a in pool.get(prov, []):
+            if a.get("cooldownUntil") or a.get("status") in ("rate-limited", "auth-error"):
+                a["cooldownUntil"] = None
+                a["status"] = "idle"
+                cleared += 1
+    json.dump({"cleared": cleared, "pool": pool}, sys.stdout, indent=2)

--- a/.agents/scripts/oauth-pool-lib/pool_ops_health.py
+++ b/.agents/scripts/oauth-pool-lib/pool_ops_health.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""
+oauth-pool-lib/pool_ops_health.py — health-check command implementations.
+
+Read-only diagnostic commands used by ``oauth-pool-helper.sh check``.
+Extracted from ``pool_ops.py`` during the t2069 decomposition.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from datetime import datetime
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+
+def cmd_check_accounts() -> None:
+    """check-accounts: Print account details for health check.
+
+    Env: PROV, NOW_MS
+    """
+    pool = json.load(sys.stdin)
+    prov = os.environ["PROV"]
+    now = int(os.environ["NOW_MS"])
+    for a in pool.get(prov, []):
+        expires_in = a.get("expires", 0) - now
+        print(json.dumps({"email": a["email"], "expires_in": expires_in, "account": a}))
+
+
+def _build_anthropic_validate_request(token: str, ua: str) -> Request:
+    req = Request("https://api.anthropic.com/v1/models", method="GET")
+    req.add_header("Authorization", f"Bearer {token}")
+    req.add_header("User-Agent", ua)
+    req.add_header("anthropic-version", "2023-06-01")
+    req.add_header("anthropic-beta", "oauth-2025-04-20")
+    return req
+
+
+def _build_google_validate_request(token: str) -> Request:
+    req = Request(
+        "https://generativelanguage.googleapis.com/v1beta/models?pageSize=1",
+        method="GET",
+    )
+    req.add_header("Authorization", f"Bearer {token}")
+    return req
+
+
+def _format_validate_http_error(err: HTTPError, prov: str) -> str:
+    if err.code == 401:
+        return "    Validity: INVALID (401 - needs refresh)"
+    if prov == "google" and err.code == 403:
+        return "    Validity: OK (403 - token valid, check AI Pro/Ultra subscription)"
+    return f"    Validity: HTTP {err.code}"
+
+
+def cmd_check_validate() -> None:
+    """check-validate: Validate a token against provider API.
+
+    Env: PROV, EXPIRES_IN, TOKEN, UA
+    """
+    prov = os.environ["PROV"]
+    expires_in = int(os.environ["EXPIRES_IN"])
+    token = os.environ["TOKEN"]
+    ua = os.environ["UA"]
+
+    if prov not in ("anthropic", "google"):
+        raise SystemExit(0)
+    if not token:
+        print("    Validity: no access token")
+        raise SystemExit(0)
+    if expires_in <= 0:
+        print("    Validity: EXPIRED - will auto-refresh on next use")
+        raise SystemExit(0)
+
+    if prov == "anthropic":
+        req = _build_anthropic_validate_request(token, ua)
+    else:
+        req = _build_google_validate_request(token)
+    try:
+        urlopen(req, timeout=10)
+        print("    Validity: OK")
+    except HTTPError as e:
+        print(_format_validate_http_error(e, prov))
+    except (URLError, OSError):
+        print("    Validity: ERROR (network)")
+    except Exception:
+        print("    Validity: ERROR")
+
+
+def _format_last_used(lu: str, now_ms: int) -> str:
+    """Render the ``Last used:`` line for ``check-meta``.
+
+    Falls back to printing the raw timestamp on parse failure.
+    """
+    try:
+        lu_ts = datetime.fromisoformat(lu.replace("Z", "+00:00")).timestamp() * 1000
+    except Exception:
+        return f"    Last used: {lu}"
+    ago = now_ms - lu_ts
+    ago_mins = int(ago // 60000)
+    ago_hours = ago_mins // 60
+    if ago_hours > 0:
+        return f"    Last used: {ago_hours}h {ago_mins % 60}m ago"
+    return f"    Last used: {ago_mins}m ago"
+
+
+def cmd_check_meta() -> None:
+    """check-meta: Print account metadata.
+
+    Env: NOW_MS
+    """
+    a = json.load(sys.stdin)
+    now = int(os.environ["NOW_MS"])
+    print(f"    Status: {a.get('status', 'unknown')}")
+    cd = a.get("cooldownUntil")
+    if cd and cd > now:
+        cd_mins = (cd - now + 59999) // 60000
+        print(f"    Cooldown: {cd_mins}m remaining")
+    lu = a.get("lastUsed")
+    if lu:
+        print(_format_last_used(lu, now))
+    print(f"    Refresh token: {'present' if a.get('refresh') else 'MISSING'}")
+
+
+def cmd_check_expiry() -> None:
+    """check-expiry: Print token expiry info.
+
+    Env: EXPIRES_IN (milliseconds remaining)
+    """
+    expires_in = int(os.environ["EXPIRES_IN"])
+    if expires_in <= 0:
+        print("    Token: EXPIRED")
+        return
+    mins = expires_in // 60000
+    hours = mins // 60
+    if hours > 0:
+        print(f"    Token: expires in {hours}h {mins % 60}m")
+    else:
+        print(f"    Token: expires in {mins}m")

--- a/.agents/scripts/oauth-pool-lib/pool_ops_mark_failure.py
+++ b/.agents/scripts/oauth-pool-lib/pool_ops_mark_failure.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""
+oauth-pool-lib/pool_ops_mark_failure.py — mark-failure command implementation.
+
+Marks the currently-active account as failed (rate-limited or auth-error)
+and applies a cooldown. Extracted from ``pool_ops.py`` during the t2069
+decomposition.
+
+Env: POOL_FILE_PATH, AUTH_FILE_PATH, PROVIDER, REASON, RETRY_SECONDS
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+
+from ._common import acquire_lock, atomic_write_json, release_lock
+
+
+_REASON_TO_STATUS = {
+    "rate_limit": "rate-limited",
+    "auth_error": "auth-error",
+    "provider_error": "rate-limited",
+}
+
+
+def _find_index_by_access(accounts: list[dict], current_access: str) -> int:
+    if not current_access:
+        return -1
+    for i, acct in enumerate(accounts):
+        if acct.get("access", "") == current_access:
+            return i
+    return -1
+
+
+def _find_index_by_openai_account_id(accounts: list[dict], account_id: str) -> int:
+    if not account_id:
+        return -1
+    for i, acct in enumerate(accounts):
+        if acct.get("accountId", "") == account_id:
+            return i
+    return -1
+
+
+def _find_index_by_most_recent(accounts: list[dict]) -> int:
+    """Pick the account with the most recent ``lastUsed`` timestamp.
+
+    Mirrors the pre-refactor fallback: ties go to the LATER index because the
+    comparison uses ``>=``. Always returns 0 when the list is non-empty.
+    """
+    best_i = 0
+    best_last = ""
+    for i, acct in enumerate(accounts):
+        last = acct.get("lastUsed", "")
+        if last >= best_last:
+            best_last = last
+            best_i = i
+    return best_i
+
+
+def _resolve_failed_index(accounts: list[dict], current_auth: dict, provider: str) -> int:
+    """Resolve which account failed via 3 fallback strategies.
+
+    1. Match by current access token in ``auth.json``
+    2. (OpenAI only) Match by ``accountId``
+    3. Most-recently-used account
+    """
+    current_access = current_auth.get("access", "")
+    idx = _find_index_by_access(accounts, current_access)
+    if idx >= 0:
+        return idx
+    if provider == "openai":
+        idx = _find_index_by_openai_account_id(accounts, current_auth.get("accountId", ""))
+        if idx >= 0:
+            return idx
+    return _find_index_by_most_recent(accounts)
+
+
+def _apply_failure_to_account(
+    account: dict,
+    target_status: str,
+    retry_seconds: int,
+    now_ms: int,
+) -> int:
+    """Apply status, cooldown, and lastUsed to an account in place.
+
+    Returns the cooldown timestamp so the caller can include it in output.
+    """
+    cooldown_until = now_ms + retry_seconds * 1000
+    now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    account["status"] = target_status
+    account["cooldownUntil"] = cooldown_until
+    account["lastUsed"] = now_iso
+    return cooldown_until
+
+
+def cmd_mark_failure() -> None:
+    pool_path = os.environ["POOL_FILE_PATH"]
+    auth_path = os.environ["AUTH_FILE_PATH"]
+    provider = os.environ["PROVIDER"]
+    reason = os.environ["REASON"]
+    retry_seconds = int(os.environ["RETRY_SECONDS"])
+
+    target_status = _REASON_TO_STATUS.get(reason, "rate-limited")
+
+    lock_path = pool_path + ".lock"
+    lock_fd = open(lock_path, "w")
+    try:
+        acquire_lock(lock_fd)
+        with open(pool_path) as f:
+            pool = json.load(f)
+        with open(auth_path) as f:
+            auth = json.load(f)
+
+        accounts = pool.get(provider, [])
+        if not accounts:
+            print("SKIP:no_accounts")
+            sys.exit(0)
+
+        current_auth = auth.get(provider, {}) if isinstance(auth, dict) else {}
+        idx = _resolve_failed_index(accounts, current_auth, provider)
+
+        now_ms = int(time.time() * 1000)
+        target = accounts[idx]
+        cooldown_until = _apply_failure_to_account(target, target_status, retry_seconds, now_ms)
+        pool[provider] = accounts
+
+        atomic_write_json(pool_path, pool)
+        email = target.get("email", "unknown")
+        print(f"OK:{email}:{target_status}:{cooldown_until}")
+    finally:
+        release_lock(lock_fd)
+        lock_fd.close()

--- a/.agents/scripts/oauth-pool-lib/pool_ops_refresh.py
+++ b/.agents/scripts/oauth-pool-lib/pool_ops_refresh.py
@@ -1,0 +1,220 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""
+oauth-pool-lib/pool_ops_refresh.py — refresh command implementation.
+
+Refreshes expired tokens for one or all accounts in a provider's pool, and
+back-fills ``auth.json`` when the active credential is empty/missing/expired
+(self-heal). Extracted from the monolithic ``pool_ops.py`` during the t2069
+decomposition; ``cmd_refresh`` was the single highest-complexity function in
+the repo (cyclomatic 72) before this split.
+
+Env: POOL_FILE_PATH, AUTH_FILE_PATH, PROVIDER, TARGET_EMAIL, UA_HEADER (optional)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from typing import NamedTuple
+
+from ._common import (
+    CLIENT_IDS,
+    TOKEN_URLS,
+    acquire_lock,
+    atomic_write_json,
+    build_auth_entry,
+    call_token_endpoint,
+    release_lock,
+)
+
+
+# Window before expiry that still triggers a refresh (1 hour).
+_EXPIRY_REFRESH_WINDOW_MS = 3_600_000
+
+
+class _RefreshContext(NamedTuple):
+    """Per-run configuration for a refresh sweep.
+
+    Bundles the inputs that don't change between accounts so that helper
+    signatures stay narrow (qlty caps function-parameter count at 5).
+    """
+
+    token_url: str
+    client_id: str
+    ua_header: str
+    target_email: str
+
+
+def _should_refresh_account(account: dict, target_email: str, now_ms: int) -> bool:
+    """Decide whether ``account`` is eligible for refresh in this run."""
+    email = account.get("email", "unknown")
+    if target_email != "all" and email != target_email:
+        return False
+    if not account.get("refresh", ""):
+        return False
+    expires = account.get("expires", 0)
+    if expires and expires > now_ms + _EXPIRY_REFRESH_WINDOW_MS:
+        return False
+    return True
+
+
+def _apply_refresh_response(account: dict, rdata: dict, now_ms: int) -> bool:
+    """Apply a successful token response to ``account`` in place.
+
+    Returns True iff the response carried a non-empty ``access_token``.
+    """
+    new_access = rdata.get("access_token", "")
+    if not new_access:
+        return False
+    account["access"] = new_access
+    account["refresh"] = rdata.get("refresh_token", account.get("refresh", ""))
+    new_expires_in = int(rdata.get("expires_in", 3600))
+    account["expires"] = now_ms + new_expires_in * 1000
+    account["status"] = "active"
+    return True
+
+
+def _refresh_one_account(
+    account: dict,
+    ctx: _RefreshContext,
+    now_ms: int,
+) -> tuple[bool, str]:
+    """Refresh a single account.
+
+    Returns ``(success, error_label)``. ``error_label`` is empty on success,
+    or ``"<email>"`` / ``"<email>(network)"`` on failure for the caller to
+    forward into the failed-list.
+    """
+    email = account.get("email", "unknown")
+    refresh_tok = account.get("refresh", "")
+    rdata = call_token_endpoint(ctx.token_url, ctx.client_id, refresh_tok, ctx.ua_header)
+    if rdata is None:
+        return False, f"{email}(network)"
+    if _apply_refresh_response(account, rdata, now_ms):
+        return True, ""
+    return False, email
+
+
+def _refresh_all_eligible(
+    accounts: list[dict],
+    ctx: _RefreshContext,
+    now_ms: int,
+) -> tuple[list[str], list[str]]:
+    """Walk the account list, refresh eligible ones, return (refreshed, failed)."""
+    refreshed: list[str] = []
+    failed: list[str] = []
+    for acct in accounts:
+        if not _should_refresh_account(acct, ctx.target_email, now_ms):
+            continue
+        ok, err_label = _refresh_one_account(acct, ctx, now_ms)
+        if ok:
+            refreshed.append(acct.get("email", "unknown"))
+        else:
+            failed.append(err_label)
+    return refreshed, failed
+
+
+def _auth_needs_heal(provider_auth: dict, now_ms: int) -> bool:
+    """Self-heal trigger (GH#17487): active credential empty / missing / expired."""
+    current_access = provider_auth.get("access", "")
+    if not current_access:
+        return True
+    auth_expires = provider_auth.get("expires", 0)
+    if not auth_expires:
+        return True
+    return auth_expires <= now_ms
+
+
+def _pick_heal_account(accounts: list[dict], refreshed_emails: list[str], now_ms: int) -> dict | None:
+    """Choose which pool account should populate auth.json after self-heal.
+
+    Prefers a just-refreshed account; falls back to any account with a
+    non-empty access token that isn't expired.
+    """
+    for acct in accounts:
+        if acct.get("email") in refreshed_emails:
+            return acct
+    for acct in accounts:
+        if acct.get("access") and acct.get("expires", 0) > now_ms:
+            return acct
+    return None
+
+
+def _self_heal_auth_file(
+    auth_path: str,
+    provider: str,
+    accounts: list[dict],
+    refreshed_emails: list[str],
+    now_ms: int,
+) -> None:
+    """If auth.json's active credential is missing/expired, back-fill from pool."""
+    if not os.path.exists(auth_path):
+        return
+    with open(auth_path) as f:
+        auth = json.load(f)
+    provider_auth = auth.get(provider, {}) if isinstance(auth, dict) else {}
+    if not _auth_needs_heal(provider_auth, now_ms):
+        return
+    heal_acct = _pick_heal_account(accounts, refreshed_emails, now_ms)
+    if heal_acct is None:
+        return
+    auth[provider] = build_auth_entry(provider, heal_acct, provider_auth)
+    atomic_write_json(auth_path, auth)
+    print(f'HEALED_AUTH:{provider}:{heal_acct.get("email", "")}', file=sys.stderr)
+
+
+def _print_refresh_results(refreshed: list[str], failed: list[str]) -> None:
+    for e in refreshed:
+        print(f"REFRESHED:{e}")
+    for e in failed:
+        print(f"FAILED:{e}")
+    if not refreshed and not failed:
+        print("NONE")
+
+
+def cmd_refresh() -> None:
+    pool_path = os.environ["POOL_FILE_PATH"]
+    auth_path = os.environ["AUTH_FILE_PATH"]
+    provider = os.environ["PROVIDER"]
+    target_email = os.environ["TARGET_EMAIL"]
+    ua_header = os.environ.get("UA_HEADER", "aidevops/1.0")
+
+    token_url = TOKEN_URLS.get(provider, "")
+    client_id = CLIENT_IDS.get(provider, "")
+    if not token_url or not client_id:
+        print("ERROR:no_endpoint")
+        sys.exit(0)
+
+    ctx = _RefreshContext(
+        token_url=token_url,
+        client_id=client_id,
+        ua_header=ua_header,
+        target_email=target_email,
+    )
+
+    lock_path = pool_path + ".lock"
+    lock_fd = open(lock_path, "w")
+    refreshed: list[str] = []
+    failed: list[str] = []
+    try:
+        acquire_lock(lock_fd)
+
+        with open(pool_path) as f:
+            pool = json.load(f)
+        accounts = pool.get(provider, [])
+        now_ms = int(time.time() * 1000)
+
+        refreshed, failed = _refresh_all_eligible(accounts, ctx, now_ms)
+
+        if refreshed:
+            atomic_write_json(pool_path, pool)
+            _self_heal_auth_file(auth_path, provider, accounts, refreshed, now_ms)
+    finally:
+        release_lock(lock_fd)
+        lock_fd.close()
+
+    _print_refresh_results(refreshed, failed)

--- a/.agents/scripts/oauth-pool-lib/pool_ops_rotate.py
+++ b/.agents/scripts/oauth-pool-lib/pool_ops_rotate.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""
+oauth-pool-lib/pool_ops_rotate.py — rotate command implementation.
+
+Rotates ``auth.json`` to the next available account in the pool. Extracted
+from ``pool_ops.py`` during the t2069 decomposition.
+
+Env: POOL_FILE_PATH, AUTH_FILE_PATH, PROVIDER, UA_HEADER (optional)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from datetime import datetime, timezone
+
+from ._common import (
+    CLIENT_IDS,
+    TOKEN_URLS,
+    acquire_lock,
+    atomic_write_json,
+    build_auth_entry,
+    call_token_endpoint,
+    release_lock,
+)
+
+
+def _try_refresh_token(account: dict, provider: str, now_ms: int, ua_header: str) -> None:
+    """Attempt to refresh ``account``'s access token in place.
+
+    No-ops if the provider has no token endpoint or the account has no
+    refresh token. Errors are logged to stderr and swallowed — rotation
+    must continue even if the refresh fails.
+    """
+    refresh_tok = account.get("refresh", "")
+    token_url = TOKEN_URLS.get(provider, "")
+    client_id = CLIENT_IDS.get(provider, "")
+    if not (refresh_tok and token_url and client_id):
+        return
+    rdata = call_token_endpoint(token_url, client_id, refresh_tok, ua_header)
+    if rdata is None:
+        print("REFRESH_FAILED", file=sys.stderr)
+        return
+    new_access = rdata.get("access_token", "")
+    if not new_access:
+        return
+    account["access"] = new_access
+    account["refresh"] = rdata.get("refresh_token", refresh_tok)
+    account["expires"] = now_ms + int(rdata.get("expires_in", 3600)) * 1000
+    account["status"] = "active"
+    print("REFRESHED", file=sys.stderr)
+
+
+def _identify_current_email(accounts: list[dict], current_access: str) -> str:
+    """Resolve which account the current ``auth.json`` access token belongs to.
+
+    Falls back to the most recently used account if no access token matches.
+    """
+    if current_access:
+        for a in accounts:
+            if a.get("access", "") == current_access:
+                return a.get("email", "unknown")
+    sorted_by_used = sorted(accounts, key=lambda a: a.get("lastUsed", ""), reverse=True)
+    return sorted_by_used[0].get("email", "unknown")
+
+
+def _is_immediately_available(account: dict, current_email: str, now_ms: int) -> bool:
+    """Tier-1 check: the account is non-current, active/idle, and not in cooldown."""
+    if account.get("email") == current_email:
+        return False
+    if account.get("status", "active") not in ("active", "idle"):
+        return False
+    cd = account.get("cooldownUntil")
+    return not cd or cd <= now_ms
+
+
+def _select_rotation_candidate(
+    accounts: list[dict],
+    current_email: str,
+    now_ms: int,
+) -> tuple[dict | None, bool]:
+    """Pick the next account to rotate to.
+
+    Returns ``(next_account, all_rate_limited)``. When all accounts are
+    rate-limited (Tier 2), ``all_rate_limited`` is True and the candidate
+    is the one with the *shortest* cooldown remaining. Otherwise (Tier 1),
+    candidates are sorted by ``(-priority, lastUsed)``.
+    """
+    candidates = [a for a in accounts if _is_immediately_available(a, current_email, now_ms)]
+    if candidates:
+        candidates.sort(key=lambda a: (-(a.get("priority") or 0), a.get("lastUsed", "")))
+        return candidates[0], False
+
+    fallback = sorted(accounts, key=lambda a: a.get("cooldownUntil") or 0)
+    if not fallback:
+        return None, True
+    return fallback[0], True
+
+
+def _update_last_used(pool: dict, provider: str, email: str) -> None:
+    now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    for a in pool[provider]:
+        if a.get("email") == email:
+            a["lastUsed"] = now_iso
+            return
+
+
+def _print_rotation_outcome(
+    all_rate_limited: bool,
+    next_account: dict,
+    current_email: str,
+    next_email: str,
+    now_ms: int,
+) -> None:
+    if all_rate_limited:
+        cd = next_account.get("cooldownUntil") or 0
+        wait_mins = max(0, (cd - now_ms + 59999) // 60000) if cd > now_ms else 0
+        print(f"OK_COOLDOWN:{wait_mins}")
+    else:
+        print("OK")
+    print(current_email)
+    print(next_email)
+
+
+def cmd_rotate() -> None:
+    pool_path = os.environ["POOL_FILE_PATH"]
+    auth_path = os.environ["AUTH_FILE_PATH"]
+    provider = os.environ["PROVIDER"]
+    ua_header = os.environ.get("UA_HEADER", "aidevops/1.0")
+
+    lock_path = pool_path + ".lock"
+    lock_fd = open(lock_path, "w")
+
+    # State that crosses the lock boundary so we can print after releasing.
+    all_rate_limited = False
+    next_account: dict | None = None
+    current_email = ""
+    next_email = ""
+    now_ms = int(time.time() * 1000)
+
+    try:
+        acquire_lock(lock_fd)
+
+        with open(pool_path) as f:
+            pool = json.load(f)
+        accounts = pool.get(provider, [])
+        if len(accounts) < 2:
+            print("ERROR:need_accounts")
+            sys.exit(0)
+
+        with open(auth_path) as f:
+            auth = json.load(f)
+        current_auth = auth.get(provider, {})
+        current_access = current_auth.get("access", "")
+
+        current_email = _identify_current_email(accounts, current_access)
+
+        now_ms = int(time.time() * 1000)
+        next_account, all_rate_limited = _select_rotation_candidate(accounts, current_email, now_ms)
+        if next_account is None:
+            print("ERROR:no_alternate")
+            sys.exit(0)
+
+        next_email = next_account.get("email", "unknown")
+
+        # Auto-refresh if expired and refresh token available
+        if next_account.get("expires", 0) <= now_ms and next_account.get("refresh"):
+            _try_refresh_token(next_account, provider, now_ms, ua_header)
+
+        auth[provider] = build_auth_entry(provider, next_account, current_auth)
+        atomic_write_json(auth_path, auth)
+
+        _update_last_used(pool, provider, next_email)
+        atomic_write_json(pool_path, pool)
+    finally:
+        release_lock(lock_fd)
+        lock_fd.close()
+
+    _print_rotation_outcome(all_rate_limited, next_account, current_email, next_email, now_ms)

--- a/.agents/scripts/oauth-pool-lib/tests/test_pool_ops.py
+++ b/.agents/scripts/oauth-pool-lib/tests/test_pool_ops.py
@@ -1,0 +1,733 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""
+Characterisation tests for oauth-pool-lib/pool_ops.py.
+
+These tests pin observable behaviour BEFORE the t2069 refactor split so that
+the per-command file split + helper extraction can be verified to preserve
+byte-for-byte semantics.
+
+Strategy:
+  - All commands run in a subprocess against ``pool_ops.py`` via
+    ``python3 -m oauth_pool_lib.pool_ops <command>`` (the actual shell
+    invocation pattern). This catches dispatch/regression issues end-to-end
+    and works equally against the pre-refactor file and the post-refactor
+    facade.
+  - HTTP-bound commands (``refresh``, ``rotate``) are exercised on the
+    *filter / fallback* branches that don't make network calls. The
+    network-success branch is structurally identical to the test-only path
+    because both go through ``_call_token_endpoint`` after refactor; the
+    pre-refactor inline ``urlopen`` call is left unmocked because it short
+    circuits on the "no candidates need refresh" branch chosen by these
+    fixtures.
+  - Determinism: every test creates an isolated tempdir for the pool /
+    auth files; nothing touches the user's real OAuth state.
+
+Run:
+    python3 -m unittest discover -s .agents/scripts/oauth-pool-lib/tests
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import time
+import unittest
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+POOL_OPS_DIR = REPO_ROOT / "scripts" / "oauth-pool-lib"
+POOL_OPS_PY = POOL_OPS_DIR / "pool_ops.py"
+
+
+def run_pool_ops(command: str, env: dict[str, str], stdin: str | None = None) -> subprocess.CompletedProcess[str]:
+    """Invoke ``python3 pool_ops.py <command>`` like ``oauth-pool-helper.sh``."""
+    full_env = os.environ.copy()
+    full_env.update(env)
+    return subprocess.run(
+        [sys.executable, str(POOL_OPS_PY), command],
+        input=stdin,
+        env=full_env,
+        capture_output=True,
+        text=True,
+        timeout=15,
+        check=False,
+    )
+
+
+def write_json(path: Path, data: dict) -> None:
+    path.write_text(json.dumps(data, indent=2))
+    os.chmod(path, 0o600)
+
+
+def read_json(path: Path) -> dict:
+    return json.loads(path.read_text())
+
+
+class PoolOpsTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = Path(self._tmp.name)
+        self.pool_path = self.tmp / "pool.json"
+        self.auth_path = self.tmp / "auth.json"
+
+    def tearDown(self) -> None:
+        self._tmp.cleanup()
+
+
+# ---------------------------------------------------------------------------
+# cmd_auto_clear (cyclomatic 19)
+# ---------------------------------------------------------------------------
+
+
+class AutoClearTests(PoolOpsTestCase):
+    def test_clears_expired_rate_limited_account(self) -> None:
+        past = int(time.time() * 1000) - 60_000
+        write_json(
+            self.pool_path,
+            {
+                "anthropic": [
+                    {
+                        "email": "a@example.com",
+                        "status": "rate-limited",
+                        "cooldownUntil": past,
+                    }
+                ]
+            },
+        )
+        result = run_pool_ops("auto-clear", {"POOL_FILE_PATH": str(self.pool_path)})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "CHANGED")
+        pool = read_json(self.pool_path)
+        acct = pool["anthropic"][0]
+        self.assertEqual(acct["status"], "idle")
+        self.assertEqual(acct["cooldownUntil"], 0)
+
+    def test_no_changes_when_nothing_expired(self) -> None:
+        future = int(time.time() * 1000) + 600_000
+        write_json(
+            self.pool_path,
+            {
+                "anthropic": [
+                    {
+                        "email": "a@example.com",
+                        "status": "rate-limited",
+                        "cooldownUntil": future,
+                    }
+                ]
+            },
+        )
+        result = run_pool_ops("auto-clear", {"POOL_FILE_PATH": str(self.pool_path)})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "UNCHANGED")
+        pool = read_json(self.pool_path)
+        self.assertEqual(pool["anthropic"][0]["cooldownUntil"], future)
+
+    def test_skips_underscore_prefixed_keys(self) -> None:
+        past = int(time.time() * 1000) - 1_000
+        write_json(
+            self.pool_path,
+            {
+                "_pending_anthropic": {"refresh": "x", "access": "y"},
+                "anthropic": [
+                    {
+                        "email": "a@example.com",
+                        "status": "rate-limited",
+                        "cooldownUntil": past,
+                    }
+                ],
+            },
+        )
+        result = run_pool_ops("auto-clear", {"POOL_FILE_PATH": str(self.pool_path)})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "CHANGED")
+        pool = read_json(self.pool_path)
+        # _pending key untouched
+        self.assertIn("_pending_anthropic", pool)
+        self.assertEqual(pool["anthropic"][0]["status"], "idle")
+
+    def test_does_not_clear_non_rate_limited_status(self) -> None:
+        """Expired cooldown is still cleared, but status remains untouched if not rate-limited."""
+        past = int(time.time() * 1000) - 1_000
+        write_json(
+            self.pool_path,
+            {
+                "anthropic": [
+                    {
+                        "email": "a@example.com",
+                        "status": "auth-error",
+                        "cooldownUntil": past,
+                    }
+                ]
+            },
+        )
+        result = run_pool_ops("auto-clear", {"POOL_FILE_PATH": str(self.pool_path)})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "CHANGED")
+        pool = read_json(self.pool_path)
+        # cooldown cleared, but status preserved
+        self.assertEqual(pool["anthropic"][0]["cooldownUntil"], 0)
+        self.assertEqual(pool["anthropic"][0]["status"], "auth-error")
+
+
+# ---------------------------------------------------------------------------
+# cmd_mark_failure (cyclomatic 23)
+# ---------------------------------------------------------------------------
+
+
+class MarkFailureTests(PoolOpsTestCase):
+    def _make_pool(self, accounts: list[dict]) -> None:
+        write_json(self.pool_path, {"anthropic": accounts})
+
+    def _make_auth(self, provider_entry: dict) -> None:
+        write_json(self.auth_path, {"anthropic": provider_entry})
+
+    def test_marks_account_matched_by_access_token(self) -> None:
+        self._make_pool(
+            [
+                {"email": "a@example.com", "access": "token_A", "lastUsed": "2026-01-01T00:00:00Z"},
+                {"email": "b@example.com", "access": "token_B", "lastUsed": "2026-01-02T00:00:00Z"},
+            ]
+        )
+        self._make_auth({"access": "token_A"})
+        result = run_pool_ops(
+            "mark-failure",
+            {
+                "POOL_FILE_PATH": str(self.pool_path),
+                "AUTH_FILE_PATH": str(self.auth_path),
+                "PROVIDER": "anthropic",
+                "REASON": "rate_limit",
+                "RETRY_SECONDS": "60",
+            },
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(result.stdout.startswith("OK:a@example.com:rate-limited:"))
+        pool = read_json(self.pool_path)
+        a = pool["anthropic"][0]
+        self.assertEqual(a["status"], "rate-limited")
+        self.assertGreater(a["cooldownUntil"], int(time.time() * 1000))
+
+    def test_falls_back_to_openai_account_id(self) -> None:
+        write_json(
+            self.pool_path,
+            {
+                "openai": [
+                    {"email": "x@example.com", "access": "stale_x", "accountId": "acct_X"},
+                    {"email": "y@example.com", "access": "stale_y", "accountId": "acct_Y"},
+                ]
+            },
+        )
+        write_json(self.auth_path, {"openai": {"access": "totally_different", "accountId": "acct_Y"}})
+        result = run_pool_ops(
+            "mark-failure",
+            {
+                "POOL_FILE_PATH": str(self.pool_path),
+                "AUTH_FILE_PATH": str(self.auth_path),
+                "PROVIDER": "openai",
+                "REASON": "auth_error",
+                "RETRY_SECONDS": "300",
+            },
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(result.stdout.startswith("OK:y@example.com:auth-error:"))
+        pool = read_json(self.pool_path)
+        self.assertEqual(pool["openai"][1]["status"], "auth-error")
+        self.assertEqual(pool["openai"][0].get("status", "unset"), "unset")
+
+    def test_falls_back_to_most_recent_last_used(self) -> None:
+        self._make_pool(
+            [
+                {"email": "old@example.com", "access": "tok_old", "lastUsed": "2026-01-01T00:00:00Z"},
+                {"email": "new@example.com", "access": "tok_new", "lastUsed": "2026-04-01T00:00:00Z"},
+            ]
+        )
+        self._make_auth({"access": "totally_unrelated"})
+        result = run_pool_ops(
+            "mark-failure",
+            {
+                "POOL_FILE_PATH": str(self.pool_path),
+                "AUTH_FILE_PATH": str(self.auth_path),
+                "PROVIDER": "anthropic",
+                "REASON": "rate_limit",
+                "RETRY_SECONDS": "60",
+            },
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertTrue(result.stdout.startswith("OK:new@example.com:rate-limited:"))
+
+    def test_skip_when_no_accounts(self) -> None:
+        write_json(self.pool_path, {"anthropic": []})
+        write_json(self.auth_path, {"anthropic": {"access": "x"}})
+        result = run_pool_ops(
+            "mark-failure",
+            {
+                "POOL_FILE_PATH": str(self.pool_path),
+                "AUTH_FILE_PATH": str(self.auth_path),
+                "PROVIDER": "anthropic",
+                "REASON": "rate_limit",
+                "RETRY_SECONDS": "60",
+            },
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "SKIP:no_accounts")
+
+    def test_provider_error_maps_to_rate_limited(self) -> None:
+        self._make_pool([{"email": "a@example.com", "access": "tok"}])
+        self._make_auth({"access": "tok"})
+        result = run_pool_ops(
+            "mark-failure",
+            {
+                "POOL_FILE_PATH": str(self.pool_path),
+                "AUTH_FILE_PATH": str(self.auth_path),
+                "PROVIDER": "anthropic",
+                "REASON": "provider_error",
+                "RETRY_SECONDS": "120",
+            },
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("rate-limited", result.stdout)
+
+
+# ---------------------------------------------------------------------------
+# cmd_rotate (cyclomatic 31)
+# ---------------------------------------------------------------------------
+
+
+class RotateTests(PoolOpsTestCase):
+    def test_errors_when_only_one_account(self) -> None:
+        write_json(self.pool_path, {"anthropic": [{"email": "a@example.com", "access": "tok"}]})
+        write_json(self.auth_path, {"anthropic": {"access": "tok"}})
+        result = run_pool_ops(
+            "rotate",
+            {
+                "POOL_FILE_PATH": str(self.pool_path),
+                "AUTH_FILE_PATH": str(self.auth_path),
+                "PROVIDER": "anthropic",
+            },
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "ERROR:need_accounts")
+
+    def test_rotates_to_idle_account(self) -> None:
+        future = int(time.time() * 1000) + 10 * 60_000
+        write_json(
+            self.pool_path,
+            {
+                "anthropic": [
+                    {
+                        "email": "a@example.com",
+                        "access": "tok_A",
+                        "refresh": "ref_A",
+                        "expires": future,
+                        "status": "active",
+                        "lastUsed": "2026-04-01T00:00:00Z",
+                    },
+                    {
+                        "email": "b@example.com",
+                        "access": "tok_B",
+                        "refresh": "ref_B",
+                        "expires": future,
+                        "status": "idle",
+                        "lastUsed": "2026-04-02T00:00:00Z",
+                    },
+                ]
+            },
+        )
+        write_json(self.auth_path, {"anthropic": {"type": "oauth", "access": "tok_A"}})
+        result = run_pool_ops(
+            "rotate",
+            {
+                "POOL_FILE_PATH": str(self.pool_path),
+                "AUTH_FILE_PATH": str(self.auth_path),
+                "PROVIDER": "anthropic",
+            },
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        lines = result.stdout.strip().splitlines()
+        self.assertEqual(lines[0], "OK")
+        self.assertEqual(lines[1], "a@example.com")
+        self.assertEqual(lines[2], "b@example.com")
+        auth = read_json(self.auth_path)
+        self.assertEqual(auth["anthropic"]["access"], "tok_B")
+
+    def test_tier2_when_all_rate_limited(self) -> None:
+        now_ms = int(time.time() * 1000)
+        soon_cd = now_ms + 30_000   # ~1 minute from now
+        later_cd = now_ms + 600_000  # 10 minutes from now
+        write_json(
+            self.pool_path,
+            {
+                "anthropic": [
+                    {
+                        "email": "a@example.com",
+                        "access": "tok_A",
+                        "refresh": "ref_A",
+                        "expires": now_ms + 60_000,
+                        "status": "rate-limited",
+                        "cooldownUntil": later_cd,
+                        "lastUsed": "2026-04-01T00:00:00Z",
+                    },
+                    {
+                        "email": "b@example.com",
+                        "access": "tok_B",
+                        "refresh": "ref_B",
+                        "expires": now_ms + 60_000,
+                        "status": "rate-limited",
+                        "cooldownUntil": soon_cd,
+                        "lastUsed": "2026-04-02T00:00:00Z",
+                    },
+                ]
+            },
+        )
+        write_json(self.auth_path, {"anthropic": {"type": "oauth", "access": "tok_A"}})
+        result = run_pool_ops(
+            "rotate",
+            {
+                "POOL_FILE_PATH": str(self.pool_path),
+                "AUTH_FILE_PATH": str(self.auth_path),
+                "PROVIDER": "anthropic",
+            },
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        lines = result.stdout.strip().splitlines()
+        self.assertTrue(lines[0].startswith("OK_COOLDOWN:"))
+        # Tier-2 picks the account with the *shortest* cooldown remaining
+        self.assertEqual(lines[2], "b@example.com")
+
+    def test_priority_wins_over_last_used(self) -> None:
+        future = int(time.time() * 1000) + 10 * 60_000
+        write_json(
+            self.pool_path,
+            {
+                "anthropic": [
+                    {
+                        "email": "a@example.com",
+                        "access": "tok_A",
+                        "refresh": "ref_A",
+                        "expires": future,
+                        "status": "active",
+                        "lastUsed": "2026-01-01T00:00:00Z",
+                    },
+                    {
+                        "email": "b@example.com",
+                        "access": "tok_B",
+                        "refresh": "ref_B",
+                        "expires": future,
+                        "status": "active",
+                        "lastUsed": "2026-04-02T00:00:00Z",
+                        "priority": 5,
+                    },
+                    {
+                        "email": "c@example.com",
+                        "access": "tok_C",
+                        "refresh": "ref_C",
+                        "expires": future,
+                        "status": "active",
+                        "lastUsed": "2026-04-03T00:00:00Z",
+                    },
+                ]
+            },
+        )
+        write_json(self.auth_path, {"anthropic": {"type": "oauth", "access": "tok_A"}})
+        result = run_pool_ops(
+            "rotate",
+            {
+                "POOL_FILE_PATH": str(self.pool_path),
+                "AUTH_FILE_PATH": str(self.auth_path),
+                "PROVIDER": "anthropic",
+            },
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        lines = result.stdout.strip().splitlines()
+        self.assertEqual(lines[2], "b@example.com")  # priority 5 wins
+
+
+# ---------------------------------------------------------------------------
+# cmd_refresh (cyclomatic 72) - filter branches only (no HTTP)
+# ---------------------------------------------------------------------------
+
+
+class RefreshTests(PoolOpsTestCase):
+    def test_no_op_when_token_not_expiring(self) -> None:
+        future = int(time.time() * 1000) + 6 * 3_600_000  # 6h out
+        write_json(
+            self.pool_path,
+            {
+                "anthropic": [
+                    {
+                        "email": "a@example.com",
+                        "access": "tok_A",
+                        "refresh": "ref_A",
+                        "expires": future,
+                    }
+                ]
+            },
+        )
+        write_json(self.auth_path, {"anthropic": {"access": "tok_A"}})
+        result = run_pool_ops(
+            "refresh",
+            {
+                "POOL_FILE_PATH": str(self.pool_path),
+                "AUTH_FILE_PATH": str(self.auth_path),
+                "PROVIDER": "anthropic",
+                "TARGET_EMAIL": "all",
+            },
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "NONE")
+
+    def test_no_endpoint_for_unknown_provider(self) -> None:
+        write_json(self.pool_path, {"cursor": []})
+        write_json(self.auth_path, {"cursor": {}})
+        result = run_pool_ops(
+            "refresh",
+            {
+                "POOL_FILE_PATH": str(self.pool_path),
+                "AUTH_FILE_PATH": str(self.auth_path),
+                "PROVIDER": "cursor",
+                "TARGET_EMAIL": "all",
+            },
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "ERROR:no_endpoint")
+
+    def test_no_op_when_no_refresh_token(self) -> None:
+        write_json(
+            self.pool_path,
+            {
+                "anthropic": [
+                    {
+                        "email": "a@example.com",
+                        "access": "tok_A",
+                        "refresh": "",
+                        "expires": 0,
+                    }
+                ]
+            },
+        )
+        write_json(self.auth_path, {"anthropic": {"access": "tok_A"}})
+        result = run_pool_ops(
+            "refresh",
+            {
+                "POOL_FILE_PATH": str(self.pool_path),
+                "AUTH_FILE_PATH": str(self.auth_path),
+                "PROVIDER": "anthropic",
+                "TARGET_EMAIL": "all",
+            },
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "NONE")
+
+    def test_target_email_filter(self) -> None:
+        future = int(time.time() * 1000) + 6 * 3_600_000
+        write_json(
+            self.pool_path,
+            {
+                "anthropic": [
+                    {"email": "a@example.com", "access": "tA", "refresh": "rA", "expires": future},
+                    {"email": "b@example.com", "access": "tB", "refresh": "rB", "expires": future},
+                ]
+            },
+        )
+        write_json(self.auth_path, {"anthropic": {"access": "tA"}})
+        result = run_pool_ops(
+            "refresh",
+            {
+                "POOL_FILE_PATH": str(self.pool_path),
+                "AUTH_FILE_PATH": str(self.auth_path),
+                "PROVIDER": "anthropic",
+                "TARGET_EMAIL": "missing@example.com",
+            },
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "NONE")
+
+
+# ---------------------------------------------------------------------------
+# Smoke tests for non-high-complexity commands (one per module after split)
+# ---------------------------------------------------------------------------
+
+
+class SimpleCommandsSmokeTests(unittest.TestCase):
+    def test_status_stats(self) -> None:
+        pool = {
+            "anthropic": [
+                {"email": "a@example.com", "status": "active"},
+                {"email": "b@example.com", "status": "rate-limited", "cooldownUntil": int(time.time() * 1000) + 60_000},
+            ]
+        }
+        result = run_pool_ops(
+            "status-stats",
+            {"NOW_MS": str(int(time.time() * 1000)), "PROV": "anthropic"},
+            stdin=json.dumps(pool),
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("Total accounts : 2", result.stdout)
+        self.assertIn("anthropic pool", result.stdout)
+
+    def test_list_accounts(self) -> None:
+        pool = {"anthropic": [{"email": "a@example.com", "status": "active", "priority": 3}]}
+        result = run_pool_ops(
+            "list-accounts",
+            {"PROVIDER": "anthropic"},
+            stdin=json.dumps(pool),
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("a@example.com", result.stdout)
+        self.assertIn("priority:3", result.stdout)
+
+    def test_extract_token_fields(self) -> None:
+        result = run_pool_ops(
+            "extract-token-fields",
+            {},
+            stdin=json.dumps({"access_token": "A", "refresh_token": "R", "expires_in": 7200}),
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        lines = result.stdout.strip().splitlines()
+        self.assertEqual(lines, ["A", "R", "7200"])
+
+    def test_extract_token_error_falls_back(self) -> None:
+        result = run_pool_ops("extract-token-error", {}, stdin="not-json")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "unknown")
+
+    def test_normalize_cooldowns(self) -> None:
+        past = int(time.time() * 1000) - 1_000
+        pool = {"anthropic": [{"email": "a@example.com", "status": "rate-limited", "cooldownUntil": past}]}
+        result = run_pool_ops("normalize-cooldowns", {"PROVIDER": "all"}, stdin=json.dumps(pool))
+        self.assertEqual(result.returncode, 0, result.stderr)
+        out = json.loads(result.stdout)
+        self.assertEqual(out["updated"], 1)
+        self.assertEqual(out["pool"]["anthropic"][0]["status"], "idle")
+
+    def test_set_priority(self) -> None:
+        pool = {"anthropic": [{"email": "a@example.com"}, {"email": "b@example.com", "priority": 1}]}
+        result = run_pool_ops(
+            "set-priority",
+            {"PROVIDER": "anthropic", "EMAIL": "a@example.com", "PRIORITY": "5"},
+            stdin=json.dumps(pool),
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        out = json.loads(result.stdout)
+        self.assertEqual(out["anthropic"][0]["priority"], 5)
+        # b unchanged
+        self.assertEqual(out["anthropic"][1]["priority"], 1)
+
+    def test_set_priority_zero_clears(self) -> None:
+        pool = {"anthropic": [{"email": "a@example.com", "priority": 7}]}
+        result = run_pool_ops(
+            "set-priority",
+            {"PROVIDER": "anthropic", "EMAIL": "a@example.com", "PRIORITY": "0"},
+            stdin=json.dumps(pool),
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        out = json.loads(result.stdout)
+        self.assertNotIn("priority", out["anthropic"][0])
+
+    def test_remove_account_success(self) -> None:
+        pool = {"anthropic": [{"email": "a@example.com"}, {"email": "b@example.com"}]}
+        result = run_pool_ops(
+            "remove-account",
+            {"PROVIDER": "anthropic", "EMAIL": "a@example.com"},
+            stdin=json.dumps(pool),
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        out = json.loads(result.stdout)
+        self.assertEqual(len(out["anthropic"]), 1)
+        self.assertEqual(out["anthropic"][0]["email"], "b@example.com")
+
+    def test_remove_account_not_found_returns_1(self) -> None:
+        pool = {"anthropic": [{"email": "a@example.com"}]}
+        result = run_pool_ops(
+            "remove-account",
+            {"PROVIDER": "anthropic", "EMAIL": "missing@example.com"},
+            stdin=json.dumps(pool),
+        )
+        self.assertEqual(result.returncode, 1)
+
+    def test_assign_pending_success(self) -> None:
+        pool = {
+            "anthropic": [{"email": "a@example.com", "access": "old"}],
+            "_pending_anthropic": {"refresh": "newR", "access": "newA", "expires": 12345},
+        }
+        result = run_pool_ops(
+            "assign-pending",
+            {"PROVIDER": "anthropic", "EMAIL": "a@example.com"},
+            stdin=json.dumps(pool),
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        out = json.loads(result.stdout)
+        self.assertEqual(out["anthropic"][0]["access"], "newA")
+        self.assertEqual(out["anthropic"][0]["refresh"], "newR")
+        self.assertNotIn("_pending_anthropic", out)
+
+    def test_assign_pending_no_pending(self) -> None:
+        pool = {"anthropic": [{"email": "a@example.com"}]}
+        result = run_pool_ops(
+            "assign-pending",
+            {"PROVIDER": "anthropic", "EMAIL": "a@example.com"},
+            stdin=json.dumps(pool),
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "ERROR:no_pending")
+
+    def test_check_pending_none(self) -> None:
+        result = run_pool_ops(
+            "check-pending", {"PROVIDER": "anthropic"}, stdin=json.dumps({"anthropic": []})
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "NONE")
+
+    def test_import_check_yes(self) -> None:
+        pool = {"anthropic": [{"email": "a@example.com"}]}
+        result = run_pool_ops("import-check", {"EMAIL": "a@example.com"}, stdin=json.dumps(pool))
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout.strip(), "yes")
+
+    def test_import_check_no(self) -> None:
+        pool = {"anthropic": [{"email": "a@example.com"}]}
+        result = run_pool_ops("import-check", {"EMAIL": "missing@example.com"}, stdin=json.dumps(pool))
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.stdout.strip(), "no")
+
+    def test_check_expiry_negative(self) -> None:
+        result = run_pool_ops("check-expiry", {"EXPIRES_IN": "-1000"})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("EXPIRED", result.stdout)
+
+    def test_check_expiry_minutes(self) -> None:
+        result = run_pool_ops("check-expiry", {"EXPIRES_IN": str(45 * 60 * 1000)})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("45m", result.stdout)
+
+    def test_cursor_decode_jwt_invalid(self) -> None:
+        result = run_pool_ops("cursor-decode-jwt", {"ACCESS": "not-a-jwt"})
+        self.assertEqual(result.returncode, 0, result.stderr)
+        # Single dotless string => parts < 2 => prints empty line then 0.
+        # Don't .strip() — that would lose the leading empty line that callers parse.
+        self.assertEqual(result.stdout, "\n0\n")
+
+    def test_unknown_command_exits_1(self) -> None:
+        result = run_pool_ops("not-a-real-command", {})
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("Unknown command", result.stderr)
+
+    def test_no_args_prints_usage(self) -> None:
+        env = os.environ.copy()
+        result = subprocess.run(
+            [sys.executable, str(POOL_OPS_PY)],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("Usage:", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Split the 1047-line oauth-pool-lib/pool_ops.py monolith (8 qlty smells, cmd_refresh cyclomatic 72 — highest in the repo) into focused per-command modules with shared primitives in _common.py.

cmd_refresh dropped from cyclomatic 72 to ~5 by extracting: _should_refresh_account (eligibility), _apply_refresh_response (parser), _refresh_one_account (HTTP+apply), _refresh_all_eligible (sweep), and _self_heal_auth_file / _pick_heal_account / _auth_needs_heal (the GH#17487 self-heal flow that was 4 nested ifs at depth 5). _RefreshContext NamedTuple bundles per-run config so helpers stay <=5 args.

New layout: _common.py, pool_ops.py (dispatcher facade), pool_ops_refresh.py, pool_ops_rotate.py, pool_ops_mark_failure.py, pool_ops_auto_clear.py, pool_ops_accounts.py, pool_ops_cooldowns.py, pool_ops_health.py, pool_ops_token_utils.py.

oauth-pool-helper.sh continues to invoke python3 oauth-pool-lib/pool_ops.py <command> unchanged. The dispatcher uses importlib.util.spec_from_file_location to register the hyphenated directory as the importable package 'oauth_pool_lib' before any submodule import.

## Files Changed

.agents/scripts/oauth-pool-lib/__init__.py,.agents/scripts/oauth-pool-lib/_common.py,.agents/scripts/oauth-pool-lib/pool_ops.py,.agents/scripts/oauth-pool-lib/pool_ops_accounts.py,.agents/scripts/oauth-pool-lib/pool_ops_auto_clear.py,.agents/scripts/oauth-pool-lib/pool_ops_cooldowns.py,.agents/scripts/oauth-pool-lib/pool_ops_health.py,.agents/scripts/oauth-pool-lib/pool_ops_mark_failure.py,.agents/scripts/oauth-pool-lib/pool_ops_refresh.py,.agents/scripts/oauth-pool-lib/pool_ops_rotate.py,.agents/scripts/oauth-pool-lib/tests/test_pool_ops.py

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 36 characterisation tests pin observable behaviour (committed first as a separate baseline commit so the comparison is auditable). All pass against both pre- and post-refactor code.

Run: python3 -m unittest discover -s .agents/scripts/oauth-pool-lib/tests

qlty: 0 smells across oauth-pool-lib/** (was 8). Repo-wide delta: 109 -> 101 (-8, exceeds >=6 target). All .py files pass python3 -m py_compile. End-to-end smoke tests confirm both POOL_FILE_PATH and stdin command patterns work via the unchanged shell wrapper invocation.

Resolves #18777


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.24 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 12m and 54,055 tokens on this as a headless worker.