### PR TITLE
GH#18778: t2070: refactor(claude-proxy): decompose into 6 sibling modules to clear all qlty smells

### DIFF
--- a/.agents/plugins/opencode-aidevops/claude-proxy-context.mjs
+++ b/.agents/plugins/opencode-aidevops/claude-proxy-context.mjs
@@ -1,0 +1,334 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+/**
+ * Request → Claude CLI context translation for the Claude proxy.
+ *
+ * This module owns everything needed to turn an OpenAI-compatible request
+ * into the concrete `claude` subprocess invocation:
+ *   - framework system prompt cache (build.txt + AGENTS.md)
+ *   - per-agent system prompt cache (~/.aidevops/agents/<agent>.md)
+ *   - per-agent MCP config generation
+ *   - chat message parsing (system vs conversation)
+ *   - request → (agentName, model, effortLevel) resolution
+ *   - final `claude` argv builder
+ *
+ * Extracted from claude-proxy.mjs as part of t2070 to drop file complexity.
+ */
+
+import { mkdirSync, readFileSync, writeFileSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
+// ---------------------------------------------------------------------------
+// Framework system prompt cache
+// ---------------------------------------------------------------------------
+
+/** @type {string | null} */
+let _frameworkPromptCache = null;
+
+/**
+ * Load and cache the AI DevOps framework prompt (build.txt + AGENTS.md).
+ * Appended to Claude CLI's default system prompt via --append-system-prompt
+ * so the CLI agent behaves consistently with our OpenCode agent configuration.
+ * Files are read from ~/.aidevops/agents/ (the deployed copy).
+ */
+export function getFrameworkPrompt() {
+  if (_frameworkPromptCache !== null) return _frameworkPromptCache;
+
+  const agentsDir = join(homedir(), ".aidevops", "agents");
+  const files = [
+    join(agentsDir, "prompts", "build.txt"),
+    join(agentsDir, "AGENTS.md"),
+  ];
+
+  const parts = [];
+  for (const filePath of files) {
+    try {
+      const content = readFileSync(filePath, "utf-8").trim();
+      if (content) parts.push(content);
+    } catch {
+      // File may not exist in minimal installations
+    }
+  }
+
+  _frameworkPromptCache = parts.length > 0 ? parts.join("\n\n---\n\n") : "";
+  if (_frameworkPromptCache) {
+    console.error(
+      `[aidevops] Claude proxy: loaded framework prompt (${_frameworkPromptCache.length} chars from ${parts.length} files)`,
+    );
+  }
+  return _frameworkPromptCache;
+}
+
+// ---------------------------------------------------------------------------
+// Agent file mapping + per-agent prompt cache
+// ---------------------------------------------------------------------------
+
+/**
+ * Map of known agent identifiers to their file names in ~/.aidevops/agents/.
+ * The proxy selects an agent based on:
+ *   1. X-Agent header in the request
+ *   2. The middle component of OpenCode's `provider/agent/model` routing key
+ *      (e.g. `claudecli/seo/opus` → agent="seo")
+ *   3. Default: "build-plus" (the primary interactive agent)
+ */
+export const AGENT_FILES = {
+  "build-plus": "build-plus.md",
+  "automate": "automate.md",
+  "seo": "seo.md",
+  "content": "content.md",
+  "research": "research.md",
+  "legal": "legal.md",
+  "business": "business.md",
+};
+
+/** @type {Map<string, string>} agent name → cached prompt content */
+const _agentPromptCache = new Map();
+
+/**
+ * Load the agent-specific prompt file. Falls back to build-plus.md.
+ * @param {string} [agentName]
+ * @returns {string}
+ */
+export function getAgentPrompt(agentName) {
+  const name = agentName && AGENT_FILES[agentName] ? agentName : "build-plus";
+  if (_agentPromptCache.has(name)) return _agentPromptCache.get(name);
+
+  const filePath = join(homedir(), ".aidevops", "agents", AGENT_FILES[name]);
+  let content = "";
+  try {
+    content = readFileSync(filePath, "utf-8").trim();
+  } catch {
+    // agent file not found — use empty
+  }
+  _agentPromptCache.set(name, content);
+  return content;
+}
+
+// ---------------------------------------------------------------------------
+// MCP config generation — per-agent lazy loading
+// ---------------------------------------------------------------------------
+
+/**
+ * Agent → MCP server mapping. Only the MCPs listed here are passed via
+ * --mcp-config for the corresponding agent. Agents not listed get no
+ * extra MCPs (Claude CLI's built-in tools are always available).
+ *
+ * Mirrors the OpenCode pattern: MCPs disabled by default, enabled per-agent.
+ */
+const AGENT_MCPS = {
+  "build-plus": ["context7"],
+  "seo": ["context7", "gsc", "dataforseo"],
+  "automate": ["context7"],
+  "content": ["context7"],
+  "research": ["context7"],
+};
+
+/**
+ * MCP server definitions in Claude CLI --mcp-config format.
+ * Only servers that might be needed per-agent are included here.
+ * Claude CLI's global config (~/.claude.json) handles always-on MCPs.
+ */
+function getMcpDefinition(name) {
+  const defs = {
+    context7: { command: "npx", args: ["-y", "@upstash/context7-mcp@latest"], type: "stdio" },
+    gsc: {
+      command: "/bin/bash",
+      args: ["-c", "GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS:-~/.config/aidevops/gsc-credentials.json} npx -y mcp-server-gsc"],
+      type: "stdio",
+    },
+    dataforseo: {
+      command: "/bin/bash",
+      args: ["-c", "source ~/.config/aidevops/credentials.sh && DATAFORSEO_USERNAME=$DATAFORSEO_USERNAME DATAFORSEO_PASSWORD=$DATAFORSEO_PASSWORD npx -y dataforseo-mcp-server"],
+      type: "stdio",
+    },
+    shadcn: { command: "npx", args: ["shadcn@latest", "mcp"], type: "stdio" },
+    playwright: { command: "npx", args: ["-y", "@playwright/mcp@latest"], type: "stdio" },
+  };
+  return defs[name] || null;
+}
+
+/** @type {Map<string, string>} agent name → path to generated MCP config file */
+const _mcpConfigFileCache = new Map();
+
+/**
+ * Generate a temporary MCP config JSON file for the given agent.
+ * Returns the file path, or null if no agent-specific MCPs are needed.
+ * @param {string} [agentName]
+ * @returns {string | null}
+ */
+export function getMcpConfigForAgent(agentName) {
+  const name = agentName && AGENT_MCPS[agentName] ? agentName : "build-plus";
+  const mcpNames = AGENT_MCPS[name];
+  if (!mcpNames || mcpNames.length === 0) return null;
+
+  if (_mcpConfigFileCache.has(name)) return _mcpConfigFileCache.get(name);
+
+  const mcpServers = {};
+  for (const mcpName of mcpNames) {
+    const def = getMcpDefinition(mcpName);
+    if (def) mcpServers[mcpName] = def;
+  }
+
+  if (Object.keys(mcpServers).length === 0) return null;
+
+  const configDir = join(homedir(), ".aidevops", ".agent-workspace", "tmp");
+  mkdirSync(configDir, { recursive: true });
+  const configPath = join(configDir, `claude-cli-mcp-${name}.json`);
+  writeFileSync(configPath, JSON.stringify({ mcpServers }, null, 2), "utf-8");
+  _mcpConfigFileCache.set(name, configPath);
+  console.error(`[aidevops] Claude proxy: generated MCP config for agent=${name} at ${configPath}`);
+  return configPath;
+}
+
+// ---------------------------------------------------------------------------
+// Chat message parsing
+// ---------------------------------------------------------------------------
+
+function extractTextContent(content) {
+  if (content == null) return "";
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter((part) => part && typeof part === "object" && part.type === "text" && typeof part.text === "string")
+    .map((part) => part.text)
+    .join("\n");
+}
+
+function sanitizeClaudeCliSystemPrompt(text) {
+  return text.replace(/<directories>\s*([\s\S]*?)\s*<\/directories>/g, (_m, inner) => {
+    const content = String(inner || "").trim();
+    return content ? `Directories:\n${content}` : "";
+  });
+}
+
+function renderConversationPrompt(conversation) {
+  if (conversation.length === 0) return "Continue the conversation helpfully.";
+  return [
+    "Continue this conversation naturally.",
+    "",
+    ...conversation.map((message) => `${message.role.toUpperCase()}:\n${message.text}`),
+  ].join("\n\n");
+}
+
+/**
+ * Parse OpenAI chat-completion messages into a `{ systemPrompt, prompt }`
+ * pair. System messages are concatenated; user/assistant messages are
+ * rendered as a transcript.
+ */
+export function parseChatMessages(messages) {
+  const systemParts = [];
+  const conversation = [];
+
+  for (const message of messages || []) {
+    const text = extractTextContent(message?.content);
+    if (!text.trim()) continue;
+    if (message.role === "system") {
+      systemParts.push(text);
+      continue;
+    }
+    conversation.push({ role: message.role || "user", text });
+  }
+
+  return {
+    systemPrompt: sanitizeClaudeCliSystemPrompt(systemParts.join("\n\n").trim()),
+    prompt: renderConversationPrompt(conversation),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Agent + model + effort resolution
+// ---------------------------------------------------------------------------
+
+const MODEL_ALIASES = {
+  haiku: "claude-haiku-4-5",
+  sonnet: "claude-sonnet-4-6",
+  opus: "claude-opus-4-6",
+};
+
+/**
+ * Resolve the agent name + concrete model id from an OpenCode request.
+ * Honours the `X-Agent` header and OpenCode's `provider/agent/model` routing
+ * suffix (e.g. `claudecli/seo/opus` → agent=seo, model=claude-opus-4-6).
+ */
+export function resolveAgentAndModel(req, incoming) {
+  let agentName = req.headers.get("x-agent") || null;
+  let resolvedModel = incoming.model;
+
+  if (typeof incoming.model === "string" && incoming.model.includes("/")) {
+    const parts = incoming.model.split("/");
+    if (parts.length >= 2 && AGENT_FILES[parts[1]]) {
+      agentName = agentName || parts[1];
+    }
+    const modelSuffix = parts[parts.length - 1];
+    resolvedModel = MODEL_ALIASES[modelSuffix] || incoming.model;
+  }
+
+  return { agentName: agentName || "build-plus", resolvedModel };
+}
+
+/** Extract the OpenAI-style reasoning_effort field if it's a known level. */
+export function resolveEffortLevel(incoming) {
+  const EFFORT_LEVELS = new Set(["low", "medium", "high", "max"]);
+  if (typeof incoming.reasoning_effort === "string" && EFFORT_LEVELS.has(incoming.reasoning_effort)) {
+    return incoming.reasoning_effort;
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Claude CLI argv builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the argv list to pass to `claude` for a given request body.
+ * The body must contain `model`, `agentName`, `prompt`, optional `effortLevel`.
+ */
+export function buildClaudeArgs(body, systemPrompt, streaming) {
+  const agentsDir = join(homedir(), ".aidevops", "agents");
+  const agentName = body.agentName || "build-plus";
+  const args = ["-p", "--model", body.model];
+
+  if (body.effortLevel) {
+    args.push("--effort", body.effortLevel);
+  }
+
+  args.push(
+    "--permission-mode",
+    "default",
+    "--no-session-persistence",
+    "--add-dir",
+    agentsDir,
+  );
+
+  // Agent-specific MCP config (lazy loading — only needed MCPs start)
+  const mcpConfig = getMcpConfigForAgent(agentName);
+  if (mcpConfig) {
+    args.push("--mcp-config", mcpConfig);
+  }
+
+  // Combine: framework base (build.txt + AGENTS.md) + agent prompt + request system prompt.
+  // Framework and agent go first (static), OpenCode's context-specific prompt last.
+  const frameworkPrompt = getFrameworkPrompt();
+  const agentPrompt = getAgentPrompt(agentName);
+  const combinedPrompt = [frameworkPrompt, agentPrompt, systemPrompt].filter(Boolean).join("\n\n");
+  if (combinedPrompt) {
+    args.push("--append-system-prompt", combinedPrompt);
+  }
+
+  if (streaming) {
+    args.push(
+      "--verbose",
+      "--output-format",
+      "stream-json",
+      "--include-partial-messages",
+      "--include-hook-events",
+    );
+  } else {
+    args.push("--output-format", "json");
+  }
+
+  args.push(body.prompt);
+  return args;
+}

--- a/.agents/plugins/opencode-aidevops/claude-proxy-jsonpath.mjs
+++ b/.agents/plugins/opencode-aidevops/claude-proxy-jsonpath.mjs
@@ -1,0 +1,161 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+/**
+ * Non-streaming JSON path for the Claude CLI proxy.
+ *
+ * Extracted from claude-proxy.mjs as part of t2070. The proxy supports two
+ * request modes: streaming SSE (lives in claude-proxy.mjs alongside the SSE
+ * session orchestration) and one-shot JSON. When OpenAI clients pass
+ * `stream: false`, this module spawns `claude --output-format json`,
+ * collects stdout/stderr to completion, and returns the assembled response.
+ *
+ * Account rotation is handled here so the JSON path remains independent of
+ * the streaming path's per-account session model.
+ */
+
+import { spawn } from "child_process";
+import {
+  buildChildEnvWithToken,
+  detectRateLimitJson,
+  getAvailableAccounts,
+  markAccountRateLimited,
+} from "./claude-proxy-retry.mjs";
+import { buildClaudeArgs } from "./claude-proxy-context.mjs";
+
+/** Maximum time (ms) a CLI subprocess may run before being killed. */
+const CHILD_TIMEOUT_MS = parseInt(process.env.CLAUDE_PROXY_TIMEOUT || "600000", 10); // 10 min
+
+/**
+ * Wire the caller's AbortSignal to a child process so a client disconnect
+ * (GH#18621 Finding 1) terminates the in-flight `claude` invocation.
+ * @returns {() => void} cleanup function (idempotent)
+ */
+function attachAbortSignalToChild(abortSignal, child, label) {
+  if (!abortSignal) return () => {};
+
+  const onAbort = () => {
+    if (child.exitCode === null && !child.killed) {
+      try {
+        child.kill("SIGTERM");
+        console.error(`[aidevops] Claude proxy: ${label} aborted by client, killed child pid=${child.pid}`);
+      } catch {
+        // best effort
+      }
+    }
+  };
+
+  if (abortSignal.aborted) {
+    onAbort();
+  } else {
+    abortSignal.addEventListener("abort", onAbort, { once: true });
+  }
+
+  return () => abortSignal.removeEventListener("abort", onAbort);
+}
+
+async function runClaudeJsonWithAccount(body, directory, account, abortSignal) {
+  const childEnv = buildChildEnvWithToken(account.token);
+  const child = spawn("claude", buildClaudeArgs(body, body.systemPrompt, false), {
+    cwd: directory,
+    env: childEnv,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  const timeout = setTimeout(() => {
+    console.error(`[aidevops] Claude proxy: json child timeout (${CHILD_TIMEOUT_MS}ms), killing`);
+    child.kill("SIGKILL");
+  }, CHILD_TIMEOUT_MS);
+
+  const detachAbort = attachAbortSignalToChild(abortSignal, child, "json request");
+
+  const stdoutChunks = [];
+  const stderrChunks = [];
+  child.stdout.on("data", (chunk) => stdoutChunks.push(chunk));
+  child.stderr.on("data", (chunk) => stderrChunks.push(chunk));
+
+  const exitCode = await new Promise((resolve) => {
+    child.on("close", resolve);
+    child.on("error", () => resolve(1));
+  });
+  clearTimeout(timeout);
+  detachAbort();
+
+  const stdout = Buffer.concat(stdoutChunks).toString("utf-8").trim();
+  const stderr = Buffer.concat(stderrChunks).toString("utf-8").trim();
+
+  if (!stdout) {
+    throw new Error(stderr || `claude exited with status ${exitCode}`);
+  }
+
+  const parsed = JSON.parse(stdout);
+
+  // Check for rate limit in JSON response
+  const rateLimitResult = detectRateLimitJson(parsed);
+  if (rateLimitResult !== undefined) {
+    markAccountRateLimited(account.email, rateLimitResult);
+    return { rateLimited: true };
+  }
+
+  if (exitCode !== 0) {
+    throw new Error(parsed.result || stderr || `claude exited with status ${exitCode}`);
+  }
+
+  return {
+    rateLimited: false,
+    content: parsed.result || "",
+    usage: parsed.usage || {},
+  };
+}
+
+/**
+ * Run the JSON path: try each available account in priority order, advancing
+ * past any account that comes back rate-limited.
+ *
+ * @returns {Promise<{ content: string, usage: object }>}
+ * @throws if no accounts are available or all are rate-limited
+ */
+export async function runClaudeJson(body, directory, abortSignal) {
+  const accounts = await getAvailableAccounts();
+  if (accounts.length === 0) {
+    throw new Error("No Anthropic OAuth pool accounts available (all rate-limited or no valid tokens)");
+  }
+
+  for (const account of accounts) {
+    if (abortSignal && abortSignal.aborted) throw new Error("Request aborted by client");
+    console.error(`[aidevops] Claude proxy: trying account ${account.email} (json mode)`);
+    const result = await runClaudeJsonWithAccount(body, directory, account, abortSignal);
+    if (!result.rateLimited) {
+      return result;
+    }
+    console.error(`[aidevops] Claude proxy: account ${account.email} rate-limited, trying next...`);
+  }
+
+  throw new Error("All Anthropic OAuth pool accounts are rate-limited");
+}
+
+/**
+ * Build the OpenAI-compatible response body for a non-streaming JSON
+ * Claude run. Usage is mapped from Claude's `input_tokens`/`output_tokens`
+ * to OpenAI's `prompt_tokens`/`completion_tokens` shape.
+ */
+export function buildOpenAIResponse(body, content, usage) {
+  return {
+    id: `chatcmpl-${crypto.randomUUID().replace(/-/g, "").slice(0, 28)}`,
+    object: "chat.completion",
+    created: Math.floor(Date.now() / 1000),
+    model: body.model,
+    choices: [
+      {
+        index: 0,
+        message: { role: "assistant", content },
+        finish_reason: "stop",
+      },
+    ],
+    usage: {
+      prompt_tokens: usage.input_tokens || 0,
+      completion_tokens: usage.output_tokens || 0,
+      total_tokens: (usage.input_tokens || 0) + (usage.output_tokens || 0),
+    },
+  };
+}

--- a/.agents/plugins/opencode-aidevops/claude-proxy-retry.mjs
+++ b/.agents/plugins/opencode-aidevops/claude-proxy-retry.mjs
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+/**
+ * Account rotation, rate-limit tracking, and rate-limit signal detection
+ * for the Claude CLI proxy.
+ *
+ * Extracted from claude-proxy.mjs as part of t2070 to drop file complexity
+ * and keep the streaming path focused on transport. The proxy maintains a
+ * pool of OAuth tokens (one per Anthropic account) and rotates through them
+ * when one hits a rate limit, marking the offender unavailable until its
+ * cooldown expires. Rate-limit signals come back via two channels:
+ *   - JSON mode: `{ is_error: true, result: "...hit your limit..." }`
+ *   - Stream mode: `rate_limit_event` or `assistant` event with `error: "rate_limit"`
+ *
+ * Module-level state (`rateLimitedAccounts`) is intentional — it's process
+ * lifetime cooldown bookkeeping that all callers share.
+ */
+
+import { ensureValidToken, getAccounts } from "./oauth-pool.mjs";
+
+/** Default cooldown (ms) before retrying a rate-limited account. */
+const RATE_LIMIT_COOLDOWN_MS = 5 * 60 * 1000; // 5 minutes
+
+/** Map<email, expiryTimestamp> — accounts known to be rate-limited. */
+const rateLimitedAccounts = new Map();
+
+/**
+ * Sort accounts by descending priority then ascending email for stable order.
+ */
+function sortAccountsByPriority(accounts) {
+  return [...accounts].sort((a, b) => {
+    const pa = Number(a?.priority || 0);
+    const pb = Number(b?.priority || 0);
+    if (pa !== pb) return pb - pa;
+    return (a?.email || "").localeCompare(b?.email || "");
+  });
+}
+
+/**
+ * Mark an account as rate-limited so subsequent requests skip it.
+ * @param {string} email
+ * @param {string} [resetsAt] - optional ISO/epoch from Claude's rate_limit_event
+ */
+export function markAccountRateLimited(email, resetsAt) {
+  let expiry = Date.now() + RATE_LIMIT_COOLDOWN_MS;
+  if (resetsAt) {
+    const parsed = Number(resetsAt) > 1e9 ? Number(resetsAt) * 1000 : Date.parse(resetsAt);
+    if (!isNaN(parsed) && parsed > Date.now()) {
+      expiry = parsed;
+    }
+  }
+  rateLimitedAccounts.set(email, expiry);
+  console.error(
+    `[aidevops] Claude proxy: account ${email} rate-limited until ${new Date(expiry).toISOString()}`,
+  );
+}
+
+export function isAccountRateLimited(email) {
+  const expiry = rateLimitedAccounts.get(email);
+  if (!expiry) return false;
+  if (Date.now() >= expiry) {
+    rateLimitedAccounts.delete(email);
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Get all available accounts with valid tokens, skipping rate-limited ones.
+ * Returns array of `{ email, token }` in priority order.
+ */
+export async function getAvailableAccounts() {
+  const accounts = sortAccountsByPriority(getAccounts("anthropic"));
+  const available = [];
+  for (const account of accounts) {
+    const email = account?.email || "unknown";
+    if (isAccountRateLimited(email)) continue;
+    const token = await ensureValidToken("anthropic", account);
+    if (token) {
+      available.push({ email, token });
+    }
+  }
+  return available;
+}
+
+/**
+ * Build a child-process env that injects the OAuth token via
+ * `CLAUDE_CODE_OAUTH_TOKEN` and strips any inherited `ANTHROPIC_API_KEY`
+ * (which would otherwise win precedence in the Claude CLI).
+ */
+export function buildChildEnvWithToken(token) {
+  const childEnv = { ...process.env };
+  delete childEnv.ANTHROPIC_API_KEY;
+  childEnv.CLAUDE_CODE_OAUTH_TOKEN = token;
+  return childEnv;
+}
+
+/**
+ * Detect a rate-limit signal in Claude CLI JSON output.
+ * @param {object} parsed - parsed JSON from Claude CLI
+ * @returns {string|null|undefined}
+ *   - `null`: rate-limited (no explicit reset time)
+ *   - `undefined`: not rate-limited
+ */
+export function detectRateLimitJson(parsed) {
+  if (parsed?.is_error && typeof parsed?.result === "string" && parsed.result.includes("hit your limit")) {
+    return null;
+  }
+  return undefined;
+}
+
+/**
+ * Detect a rate-limit signal in a stream-json event line.
+ * @param {object} event - parsed stream event
+ * @returns {{ rateLimited: boolean, resetsAt?: string }}
+ */
+export function detectRateLimitStream(event) {
+  if (event?.type === "rate_limit_event") {
+    return { rateLimited: true, resetsAt: event?.rate_limit_info?.resetsAt };
+  }
+  if (event?.type === "assistant" && event?.error === "rate_limit") {
+    return { rateLimited: true };
+  }
+  return { rateLimited: false };
+}

--- a/.agents/plugins/opencode-aidevops/claude-proxy-stream.mjs
+++ b/.agents/plugins/opencode-aidevops/claude-proxy-stream.mjs
@@ -1,0 +1,230 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+/**
+ * SSE stream-event processing for the Claude CLI proxy.
+ *
+ * Extracted from claude-proxy.mjs as part of t2070 to drop file complexity
+ * and the `processStreamEvent` cyclomatic count below the qlty thresholds.
+ *
+ * The proxy reads JSON-lines from `claude --output-format stream-json` on the
+ * child's stdout and translates each event into OpenAI-compatible chunks that
+ * OpenCode's @ai-sdk/openai-compatible provider understands. The original
+ * implementation handled all event types in a single 38-branch function; this
+ * module dispatches to per-event-type handlers via a lookup table so each
+ * handler stays small enough to reason about in isolation.
+ *
+ * Public surface (consumed by claude-proxy.mjs):
+ *   - createOpenAIChunk(id, created, model, delta, finishReason)
+ *   - processStreamEvent(event, ctx)  — main dispatcher
+ *   - isCommitTrigger(event)          — probe-phase commit decision
+ *
+ * `ctx` is the per-stream session object created in claude-proxy.mjs. It must
+ * provide `completionId`, `created`, `model`, `send`, `seenToolUseIds` (Map),
+ * `seenTaskIds` (Set), `seenToolResults` (Set), `finishSent`, `textChunkCount`,
+ * and `textCharCount`. Handlers mutate `ctx` directly.
+ */
+
+/**
+ * Build an OpenAI-style SSE chunk.
+ * @param {string} id
+ * @param {number} created
+ * @param {string} model
+ * @param {object} delta
+ * @param {string|null} [finishReason]
+ */
+export function createOpenAIChunk(id, created, model, delta, finishReason = null) {
+  return {
+    id,
+    object: "chat.completion.chunk",
+    created,
+    model,
+    choices: [{ index: 0, delta, finish_reason: finishReason }],
+  };
+}
+
+/**
+ * Summarise a tool-use input block into a short single-line label for the
+ * status feed. Only the most informative fields are included to keep the
+ * stream legible without leaking full prompts.
+ */
+function summarizeToolInput(input) {
+  if (!input || typeof input !== "object") return "";
+  const parts = [];
+  // Bash
+  if (typeof input.command === "string") parts.push(input.command);
+  // Read / Edit / Write
+  if (typeof input.filePath === "string") parts.push(input.filePath);
+  // Glob
+  if (typeof input.pattern === "string") parts.push(input.pattern);
+  // Grep
+  if (typeof input.regex === "string") parts.push(input.regex);
+  // Description (Bash, Task)
+  if (typeof input.description === "string") parts.push(input.description);
+  // Task / subagent
+  if (typeof input.prompt === "string") parts.push(input.prompt.slice(0, 120));
+  if (typeof input.subagent_type === "string") parts.push(`type=${input.subagent_type}`);
+  return parts.filter(Boolean).join(" — ");
+}
+
+function formatStatusLine(label, detail = "") {
+  return detail ? `[${label}] ${detail}\n` : `[${label}]\n`;
+}
+
+/**
+ * Send a content delta to the consumer.
+ * @param {object} ctx
+ * @param {string} content
+ */
+function sendContent(ctx, content) {
+  ctx.send(createOpenAIChunk(ctx.completionId, ctx.created, ctx.model, { content }));
+}
+
+/**
+ * Send a status-line content delta with [Label] detail formatting.
+ */
+function sendStatusLine(ctx, label, detail) {
+  sendContent(ctx, formatStatusLine(label, detail));
+}
+
+// ---------------------------------------------------------------------------
+// Per-event-type handlers
+// ---------------------------------------------------------------------------
+
+/** stream_event → content_block_delta (text + thinking) */
+function handleContentBlockDelta(inner, ctx) {
+  const delta = inner.delta;
+  if (delta?.type === "text_delta" && delta.text) {
+    ctx.textChunkCount += 1;
+    ctx.textCharCount += delta.text.length;
+    sendContent(ctx, delta.text);
+    return;
+  }
+  if (delta?.type === "thinking_delta" && delta.thinking) {
+    ctx.send(createOpenAIChunk(ctx.completionId, ctx.created, ctx.model, {
+      reasoning_content: delta.thinking,
+    }));
+  }
+}
+
+/** stream_event → message_delta (terminal stop_reason) */
+function handleMessageDelta(inner, ctx) {
+  if (inner.delta?.stop_reason && !ctx.finishSent) {
+    ctx.finishSent = true;
+    ctx.send(createOpenAIChunk(ctx.completionId, ctx.created, ctx.model, {}, "stop"));
+  }
+}
+
+/** stream_event dispatcher (groups content_block_delta + message_delta) */
+function handleStreamEvent(event, ctx) {
+  const inner = event.event;
+  if (!inner) return;
+  if (inner.type === "content_block_delta") {
+    handleContentBlockDelta(inner, ctx);
+    return;
+  }
+  if (inner.type === "message_delta") {
+    handleMessageDelta(inner, ctx);
+  }
+}
+
+/** assistant message — emit one [Tool: name] line per new tool_use block */
+function handleAssistant(event, ctx) {
+  if (!Array.isArray(event.message?.content)) return;
+  for (const block of event.message.content) {
+    if (block?.type !== "tool_use" || !block.id) continue;
+    if (ctx.seenToolUseIds.has(block.id)) continue;
+    ctx.seenToolUseIds.set(block.id, block.name || "unknown");
+    sendStatusLine(ctx, `Tool: ${block.name || "unknown"}`, summarizeToolInput(block.input));
+  }
+}
+
+/** system → task_started subagent dispatch */
+function handleTaskStarted(event, ctx) {
+  if (!event.task_id) return;
+  const key = `start:${event.task_id}`;
+  if (ctx.seenTaskIds.has(key)) return;
+  ctx.seenTaskIds.add(key);
+  sendStatusLine(ctx, "Subagent started", event.description || event.prompt || event.task_id);
+}
+
+/** system → task_notification subagent completion */
+function handleTaskNotification(event, ctx) {
+  if (!event.task_id) return;
+  const key = `done:${event.task_id}`;
+  if (ctx.seenTaskIds.has(key)) return;
+  ctx.seenTaskIds.add(key);
+  sendStatusLine(ctx, "Subagent completed", event.summary || event.task_id);
+}
+
+/** system event dispatcher */
+function handleSystem(event, ctx) {
+  if (event.subtype === "task_started") {
+    handleTaskStarted(event, ctx);
+    return;
+  }
+  if (event.subtype === "task_notification") {
+    handleTaskNotification(event, ctx);
+  }
+}
+
+/**
+ * user → tool_use_result preview line. Correlates the tool name via the
+ * `tool_use_id` from the message content so the status line reads
+ * `[Tool result: Bash]` rather than `[Tool result: unknown]`.
+ */
+function handleUserToolResult(event, ctx) {
+  if (!event.uuid || !event.tool_use_result) return;
+  if (ctx.seenToolResults.has(event.uuid)) return;
+  ctx.seenToolResults.add(event.uuid);
+
+  const toolResult = event.tool_use_result;
+  const toolUseId = event.message?.content?.[0]?.tool_use_id;
+  const toolName = (toolUseId && ctx.seenToolUseIds.get(toolUseId)) || "unknown";
+  const isError = toolResult.is_error === true || event.message?.content?.[0]?.is_error === true;
+  const preview = Array.isArray(toolResult.content)
+    ? toolResult.content.map((item) => item?.text).filter(Boolean).join(" ")
+    : (toolResult.stdout || "");
+  if (!preview) return;
+
+  const label = isError ? `Tool error: ${toolName}` : `Tool result: ${toolName}`;
+  sendStatusLine(ctx, label, preview.slice(0, 500));
+}
+
+// ---------------------------------------------------------------------------
+// Top-level event dispatcher
+// ---------------------------------------------------------------------------
+
+/** Lookup table: event.type → handler(event, ctx) */
+const EVENT_HANDLERS = {
+  stream_event: handleStreamEvent,
+  assistant: handleAssistant,
+  system: handleSystem,
+  user: handleUserToolResult,
+};
+
+/**
+ * Process a single parsed stream-json event and emit the corresponding
+ * OpenAI chunk(s). Handlers mutate `ctx` directly (counters, dedup sets,
+ * finishSent flag). Events with no registered handler are ignored — the
+ * proxy is intentionally permissive about new event types.
+ */
+export function processStreamEvent(event, ctx) {
+  const handler = EVENT_HANDLERS[event?.type];
+  if (handler) handler(event, ctx);
+}
+
+/**
+ * Returns true if a probe-phase event is enough evidence to commit to the
+ * current account (i.e. the request is actually streaming content rather
+ * than rate-limited). This covers:
+ *   - any content_block_start / content_block_delta
+ *   - the initial message_start that carries usage data
+ */
+export function isCommitTrigger(event) {
+  if (event?.type !== "stream_event") return false;
+  const innerType = event.event?.type;
+  if (innerType === "content_block_start" || innerType === "content_block_delta") return true;
+  if (innerType === "message_start" && event.event?.message?.usage) return true;
+  return false;
+}

--- a/.agents/plugins/opencode-aidevops/claude-proxy-streaming.mjs
+++ b/.agents/plugins/opencode-aidevops/claude-proxy-streaming.mjs
@@ -1,0 +1,367 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+/**
+ * SSE streaming orchestration for the Claude CLI proxy.
+ *
+ * This module owns the full streaming path:
+ *   - per-account session lifecycle (probe → commit → drain)
+ *   - child spawn + timeout + abort signal wiring
+ *   - account fail-over on rate limit
+ *   - the public `streamClaudeResponse(body, directory)` ReadableStream factory
+ *
+ * Pure event-handler logic (text / tool_use / task / message_delta dispatch)
+ * lives in claude-proxy-stream.mjs and is consumed via `processStreamEvent`.
+ *
+ * Extracted from claude-proxy.mjs as part of t2070 to drop file complexity.
+ */
+
+import { spawn } from "child_process";
+import {
+  buildChildEnvWithToken,
+  detectRateLimitStream,
+  getAvailableAccounts,
+  markAccountRateLimited,
+} from "./claude-proxy-retry.mjs";
+import {
+  createOpenAIChunk,
+  isCommitTrigger,
+  processStreamEvent,
+} from "./claude-proxy-stream.mjs";
+import { buildClaudeArgs } from "./claude-proxy-context.mjs";
+
+/** Maximum time (ms) a CLI subprocess may run before being killed. */
+const CHILD_TIMEOUT_MS = parseInt(process.env.CLAUDE_PROXY_TIMEOUT || "600000", 10); // 10 min
+
+// ---------------------------------------------------------------------------
+// Per-account session state
+// ---------------------------------------------------------------------------
+
+/**
+ * Per-account streaming session. Bundles all mutable state for one
+ * `tryStreamWithAccount` invocation so the spawn/handler wiring stays small.
+ */
+function createStreamSession(streamCtx, account, resolve) {
+  const session = {
+    // wiring
+    controller: streamCtx.controller,
+    encoder: streamCtx.encoder,
+    completionId: streamCtx.completionId,
+    created: streamCtx.created,
+    body: streamCtx.body,
+    model: streamCtx.body.model,
+    account,
+    resolve,
+    // child + lifecycle
+    child: null,
+    timeout: null,
+    closed: false,
+    finishSent: false,
+    // probe phase: buffer events until we know the account isn't rate-limited
+    probePhase: true,
+    rateLimitBailed: false,
+    bufferedEvents: [],
+    // line-parsing buffer
+    buffer: "",
+    stderrText: "",
+    // counters / dedup (consumed by claude-proxy-stream.mjs handlers)
+    textChunkCount: 0,
+    textCharCount: 0,
+    seenToolUseIds: new Map(),
+    seenTaskIds: new Set(),
+    seenToolResults: new Set(),
+    send(payload) {
+      if (this.closed) return;
+      try {
+        this.controller.enqueue(this.encoder.encode(`data: ${JSON.stringify(payload)}\n\n`));
+      } catch {
+        this.closed = true;
+      }
+    },
+  };
+  return session;
+}
+
+function spawnClaudeStreamChild(body, directory, account) {
+  const childEnv = buildChildEnvWithToken(account.token);
+  return spawn("claude", buildClaudeArgs(body, body.systemPrompt, true), {
+    cwd: directory,
+    env: childEnv,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+// ---------------------------------------------------------------------------
+// stdout / stderr / close / error handlers
+// ---------------------------------------------------------------------------
+
+/**
+ * Flush probe-phase buffered events through the real handler and drop
+ * probe mode for the rest of the stream.
+ */
+function commitBufferedEvents(session) {
+  session.probePhase = false;
+  for (const evt of session.bufferedEvents) {
+    processStreamEvent(evt, session);
+  }
+  session.bufferedEvents.length = 0;
+}
+
+/**
+ * Probe-phase event handler. Watches for rate-limit signals before any
+ * content has been emitted to the controller, so we can silently fail over
+ * to the next account without leaking partial output to the client.
+ *
+ * @returns {boolean} true if the session should stop processing further
+ *   events (the probe bailed out and resolved "rate_limited").
+ */
+function handleProbeEvent(session, event) {
+  const rl = detectRateLimitStream(event);
+  if (rl.rateLimited) {
+    markAccountRateLimited(session.account.email, rl.resetsAt);
+    session.rateLimitBailed = true;
+    session.child.kill("SIGTERM");
+    session.resolve("rate_limited");
+    return true;
+  }
+  session.bufferedEvents.push(event);
+  if (isCommitTrigger(event)) {
+    commitBufferedEvents(session);
+  }
+  return false;
+}
+
+function parseEventLine(line) {
+  try {
+    return JSON.parse(line);
+  } catch {
+    return null;
+  }
+}
+
+function onStreamStdout(session, chunk) {
+  session.buffer += chunk.toString("utf-8");
+  const lines = session.buffer.split("\n");
+  session.buffer = lines.pop() || "";
+
+  for (const line of lines) {
+    if (!line.trim()) continue;
+    const event = parseEventLine(line);
+    if (!event) continue;
+
+    if (session.probePhase) {
+      const stopped = handleProbeEvent(session, event);
+      if (stopped) return;
+      continue;
+    }
+
+    processStreamEvent(event, session);
+  }
+}
+
+function onStreamStderr(session, chunk) {
+  if (session.stderrText.length < 4000) {
+    session.stderrText += chunk.toString("utf-8");
+  }
+}
+
+function finalizeStream(session) {
+  if (session.closed) return;
+  session.closed = true;
+  try {
+    session.controller.enqueue(session.encoder.encode("data: [DONE]\n\n"));
+  } catch {
+    // already closed
+  }
+  try {
+    session.controller.close();
+  } catch {
+    // already closed by runtime
+  }
+}
+
+function emitStderrTransportError(session) {
+  if (!session.stderrText.trim()) return;
+  session.send(createOpenAIChunk(session.completionId, session.created, session.model, {
+    content: `\n[Claude CLI transport error: ${session.stderrText.trim().slice(0, 500)}]`,
+  }));
+}
+
+function emitStopChunkIfNeeded(session) {
+  if (session.finishSent) return;
+  session.finishSent = true;
+  session.send(createOpenAIChunk(session.completionId, session.created, session.model, {}, "stop"));
+}
+
+function logStreamComplete(session, exitCode) {
+  console.error(
+    `[aidevops] Claude proxy: stream complete model=${session.model} account=${session.account.email} exitCode=${exitCode} textChunks=${session.textChunkCount} textChars=${session.textCharCount} stderr=${JSON.stringify(session.stderrText.trim().slice(0, 300))}`,
+  );
+}
+
+function onStreamClose(session, exitCode) {
+  if (session.timeout) clearTimeout(session.timeout);
+
+  // If we bailed due to rate limiting, the controller belongs to the next
+  // account attempt — do NOT write to it or close it.
+  if (session.rateLimitBailed) {
+    console.error(
+      `[aidevops] Claude proxy: killed rate-limited child account=${session.account.email} exitCode=${exitCode}`,
+    );
+    return;
+  }
+
+  // If we never exited probe phase (e.g. very short response), flush now
+  if (session.probePhase) commitBufferedEvents(session);
+
+  if (exitCode !== 0) emitStderrTransportError(session);
+  emitStopChunkIfNeeded(session);
+  logStreamComplete(session, exitCode);
+  finalizeStream(session);
+  session.resolve("done");
+}
+
+function onStreamError(session, err) {
+  if (session.timeout) clearTimeout(session.timeout);
+  if (session.probePhase) {
+    session.resolve("error");
+    return;
+  }
+  session.controller.error(err);
+  session.resolve("done");
+}
+
+// ---------------------------------------------------------------------------
+// Per-attempt + multi-account orchestration
+// ---------------------------------------------------------------------------
+
+/**
+ * Wire the abort ref into a freshly spawned child so client cancel
+ * (GH#18621 Finding 1) terminates the in-flight request.
+ */
+function attachAbortRef(abortRef, child) {
+  if (!abortRef) return;
+  abortRef.child = child;
+  if (abortRef.cancelled) child.kill("SIGTERM");
+}
+
+/**
+ * Attempt to stream with a specific account. Buffers initial events to detect
+ * rate limiting before committing to the stream. Resolves with `"rate_limited"`
+ * if the account is rate-limited (caller advances to next), `"error"` if the
+ * child failed to launch during probe, or `"done"` if the stream completed.
+ *
+ * @returns {Promise<"done"|"rate_limited"|"error">}
+ */
+function tryStreamWithAccount(streamCtx, account) {
+  return new Promise((resolve) => {
+    const session = createStreamSession(streamCtx, account, resolve);
+    const child = spawnClaudeStreamChild(streamCtx.body, streamCtx.directory, account);
+    session.child = child;
+
+    attachAbortRef(streamCtx.abortRef, child);
+
+    session.timeout = setTimeout(() => {
+      console.error(`[aidevops] Claude proxy: stream child timeout (${CHILD_TIMEOUT_MS}ms), killing`);
+      child.kill("SIGKILL");
+    }, CHILD_TIMEOUT_MS);
+
+    child.stdout.on("data", (chunk) => onStreamStdout(session, chunk));
+    child.stderr.on("data", (chunk) => onStreamStderr(session, chunk));
+    child.on("close", (exitCode) => onStreamClose(session, exitCode));
+    child.on("error", (err) => onStreamError(session, err));
+  });
+}
+
+/**
+ * Emit an "all accounts rate-limited" SSE message and close the stream.
+ * Used both when no accounts are available at start and when every account
+ * was exhausted mid-iteration.
+ */
+function emitAllAccountsRateLimited(controller, encoder, completionId, created, model) {
+  const errChunk = createOpenAIChunk(completionId, created, model, {
+    content: "[Claude CLI transport: all Anthropic OAuth pool accounts are rate-limited]",
+  });
+  try {
+    controller.enqueue(encoder.encode(`data: ${JSON.stringify(errChunk)}\n\n`));
+    controller.enqueue(encoder.encode(`data: ${JSON.stringify(createOpenAIChunk(completionId, created, model, {}, "stop"))}\n\n`));
+    controller.enqueue(encoder.encode("data: [DONE]\n\n"));
+    controller.close();
+  } catch {
+    // already closed
+  }
+}
+
+/**
+ * Iterate through available accounts, starting a new stream attempt for each
+ * and stopping at the first non-rate-limited result.
+ */
+async function iterateAccounts(streamCtx, accounts) {
+  for (const account of accounts) {
+    if (streamCtx.abortRef.cancelled) return; // client already bailed
+    console.error(`[aidevops] Claude proxy: trying account ${account.email} (stream mode)`);
+    const result = await tryStreamWithAccount(streamCtx, account);
+    if (result === "rate_limited") {
+      console.error(`[aidevops] Claude proxy: account ${account.email} rate-limited, trying next...`);
+      continue;
+    }
+    return; // stream completed (done or error already handled)
+  }
+
+  // All accounts exhausted
+  emitAllAccountsRateLimited(
+    streamCtx.controller,
+    streamCtx.encoder,
+    streamCtx.completionId,
+    streamCtx.created,
+    streamCtx.body.model,
+  );
+}
+
+/**
+ * Handle a client-initiated cancel from the ReadableStream `cancel` callback.
+ * Terminates whichever child is currently running so it stops consuming
+ * quota and touching the workspace (GH#18621 Finding 1).
+ */
+function handleStreamCancel(abortRef, reason) {
+  abortRef.cancelled = true;
+  const child = abortRef.child;
+  if (!child || child.exitCode !== null || child.killed) return;
+  try {
+    child.kill("SIGTERM");
+    console.error(`[aidevops] Claude proxy: stream cancelled by client (${reason || "no-reason"}), killed child pid=${child.pid}`);
+  } catch {
+    // best effort
+  }
+}
+
+/**
+ * Public entry point: build a ReadableStream that feeds the OpenAI-compatible
+ * SSE chat-completion response by spawning `claude --output-format stream-json`
+ * against the OAuth pool, with rate-limit-aware account fail-over.
+ */
+export function streamClaudeResponse(body, directory) {
+  const completionId = `chatcmpl-${crypto.randomUUID().replace(/-/g, "").slice(0, 28)}`;
+  const created = Math.floor(Date.now() / 1000);
+  const encoder = new TextEncoder();
+
+  // Shared ref between start() and cancel() so the cancel callback can kill
+  // whatever child is currently running. `child` is mutated by
+  // tryStreamWithAccount as each retry spawns.
+  const abortRef = { child: null, cancelled: false };
+
+  return new ReadableStream({
+    async start(controller) {
+      const accounts = await getAvailableAccounts();
+      if (accounts.length === 0) {
+        emitAllAccountsRateLimited(controller, encoder, completionId, created, body.model);
+        return;
+      }
+      const streamCtx = { controller, encoder, completionId, created, body, directory, abortRef };
+      await iterateAccounts(streamCtx, accounts);
+    },
+    cancel(reason) {
+      handleStreamCancel(abortRef, reason);
+    },
+  });
+}

--- a/.agents/plugins/opencode-aidevops/claude-proxy.mjs
+++ b/.agents/plugins/opencode-aidevops/claude-proxy.mjs
@@ -1,14 +1,47 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
-import { spawn, spawnSync } from "child_process";
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+/**
+ * Claude CLI proxy — OpenAI-compatible HTTP front-end for `claude` CLI.
+ *
+ * This file is the public facade for the proxy plugin. It owns:
+ *   - the Bun.serve HTTP listener and lifecycle (`startClaudeProxy`)
+ *   - the OpenCode provider registration into `opencode.json`
+ *     (`registerClaudeProvider`)
+ *   - the top-level HTTP routing for `/v1/models` and `/v1/chat/completions`
+ *
+ * Implementation is decomposed across sibling modules so each subsystem
+ * stays small enough to reason about in isolation:
+ *   - claude-proxy-stream.mjs     — pure SSE event handlers (text, tool_use, …)
+ *   - claude-proxy-streaming.mjs  — streaming session orchestration + ReadableStream
+ *   - claude-proxy-jsonpath.mjs   — non-streaming JSON child orchestration
+ *   - claude-proxy-context.mjs    — framework + agent prompts, MCP, args, request parsing
+ *   - claude-proxy-retry.mjs      — OAuth account pool + rate-limit detection
+ *   - proxy-provider-models.mjs   — shared OpenCode provider entry builder
+ *
+ * Decomposition history: t2070 (qlty C→A campaign) — earlier cleanup landed
+ * in GH#18619 (max-tokens) and GH#18621 (CodeRabbit findings, abort cleanup).
+ */
+
+import { spawnSync } from "child_process";
+import { mkdirSync, readFileSync, writeFileSync } from "fs";
 import { homedir } from "os";
 import { dirname, join } from "path";
-import { ensureValidToken, getAccounts } from "./oauth-pool.mjs";
+import {
+  parseChatMessages,
+  resolveAgentAndModel,
+  resolveEffortLevel,
+} from "./claude-proxy-context.mjs";
+import {
+  buildOpenAIResponse,
+  runClaudeJson,
+} from "./claude-proxy-jsonpath.mjs";
+import { streamClaudeResponse } from "./claude-proxy-streaming.mjs";
+import { buildProviderModels } from "./proxy-provider-models.mjs";
 
 const CLAUDE_PROXY_DEFAULT_PORT = parseInt(process.env.CLAUDE_PROXY_PORT || "32125", 10);
 const CLAUDE_PROVIDER_ID = "claudecli";
 const OPENCODE_CONFIG_PATH = join(homedir(), ".config", "opencode", "opencode.json");
-/** Maximum time (ms) a CLI subprocess may run before being killed. */
-const CHILD_TIMEOUT_MS = parseInt(process.env.CLAUDE_PROXY_TIMEOUT || "600000", 10); // 10 min
 /** Opt-in debug request dump — set CLAUDE_PROXY_DEBUG_DUMP=1 to enable. */
 const DEBUG_DUMP_ENABLED = process.env.CLAUDE_PROXY_DEBUG_DUMP === "1";
 const SSE_HEADERS = {
@@ -25,266 +58,8 @@ let proxyPort = null;
 let proxyStarting = false;
 
 // ---------------------------------------------------------------------------
-// Framework system prompt — loaded once and cached
+// Claude CLI availability + model catalogue
 // ---------------------------------------------------------------------------
-
-/** @type {string | null} */
-let _frameworkPromptCache = null;
-
-/**
- * Load and cache the AI DevOps framework prompt (build.txt + AGENTS.md + main agent).
- * Appended to Claude CLI's default system prompt via --append-system-prompt so
- * the CLI agent behaves consistently with our OpenCode agent configuration.
- * Files are read from ~/.aidevops/agents/ (the deployed copy).
- */
-function getFrameworkPrompt() {
-  if (_frameworkPromptCache !== null) return _frameworkPromptCache;
-
-  const agentsDir = join(homedir(), ".aidevops", "agents");
-  // Framework base only — agent-specific prompt is added separately
-  // via getAgentPrompt() based on per-request agent selection.
-  const files = [
-    join(agentsDir, "prompts", "build.txt"),
-    join(agentsDir, "AGENTS.md"),
-  ];
-
-  const parts = [];
-  for (const filePath of files) {
-    try {
-      const content = readFileSync(filePath, "utf-8").trim();
-      if (content) parts.push(content);
-    } catch {
-      // File may not exist in minimal installations
-    }
-  }
-
-  _frameworkPromptCache = parts.length > 0 ? parts.join("\n\n---\n\n") : "";
-  if (_frameworkPromptCache) {
-    console.error(
-      `[aidevops] Claude proxy: loaded framework prompt (${_frameworkPromptCache.length} chars from ${parts.length} files)`,
-    );
-  }
-  return _frameworkPromptCache;
-}
-
-// ---------------------------------------------------------------------------
-// Agent selection — pick the right agent file for the system prompt
-// ---------------------------------------------------------------------------
-
-/**
- * Map of known agent identifiers to their file names in ~/.aidevops/agents/.
- * The proxy selects an agent based on:
- *   1. X-Agent header in the request (e.g., "build-plus", "automate", "seo")
- *   2. Default: "build-plus" (the primary interactive agent)
- */
-const AGENT_FILES = {
-  "build-plus": "build-plus.md",
-  "automate": "automate.md",
-  "seo": "seo.md",
-  "content": "content.md",
-  "research": "research.md",
-  "legal": "legal.md",
-  "business": "business.md",
-};
-
-/** @type {Map<string, string>} agent name → cached prompt content */
-const _agentPromptCache = new Map();
-
-/**
- * Load the agent-specific prompt file.  Falls back to build-plus.md.
- * @param {string} [agentName]
- * @returns {string}
- */
-function getAgentPrompt(agentName) {
-  const name = agentName && AGENT_FILES[agentName] ? agentName : "build-plus";
-  if (_agentPromptCache.has(name)) return _agentPromptCache.get(name);
-
-  const filePath = join(homedir(), ".aidevops", "agents", AGENT_FILES[name]);
-  let content = "";
-  try {
-    content = readFileSync(filePath, "utf-8").trim();
-  } catch {
-    // agent file not found — use empty
-  }
-  _agentPromptCache.set(name, content);
-  return content;
-}
-
-// ---------------------------------------------------------------------------
-// MCP config generation — per-agent lazy loading
-// ---------------------------------------------------------------------------
-
-/**
- * Agent → MCP server mapping.  Only the MCPs listed here are passed via
- * --mcp-config for the corresponding agent.  Agents not listed get no
- * extra MCPs (Claude CLI's built-in tools are always available).
- *
- * Mirrors the OpenCode pattern: MCPs disabled by default, enabled per-agent.
- */
-const AGENT_MCPS = {
-  "build-plus": ["context7"],
-  "seo": ["context7", "gsc", "dataforseo"],
-  "automate": ["context7"],
-  "content": ["context7"],
-  "research": ["context7"],
-};
-
-/**
- * MCP server definitions in Claude CLI --mcp-config format.
- * Only servers that might be needed per-agent are included here.
- * Claude CLI's global config (~/.claude.json) handles always-on MCPs.
- */
-function getMcpDefinition(name) {
-  const defs = {
-    context7: { command: "npx", args: ["-y", "@upstash/context7-mcp@latest"], type: "stdio" },
-    gsc: {
-      command: "/bin/bash",
-      args: ["-c", "GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS:-~/.config/aidevops/gsc-credentials.json} npx -y mcp-server-gsc"],
-      type: "stdio",
-    },
-    dataforseo: {
-      command: "/bin/bash",
-      args: ["-c", "source ~/.config/aidevops/credentials.sh && DATAFORSEO_USERNAME=$DATAFORSEO_USERNAME DATAFORSEO_PASSWORD=$DATAFORSEO_PASSWORD npx -y dataforseo-mcp-server"],
-      type: "stdio",
-    },
-    shadcn: { command: "npx", args: ["shadcn@latest", "mcp"], type: "stdio" },
-    playwright: { command: "npx", args: ["-y", "@playwright/mcp@latest"], type: "stdio" },
-  };
-  return defs[name] || null;
-}
-
-/** @type {Map<string, string>} agent name → path to generated MCP config file */
-const _mcpConfigFileCache = new Map();
-
-/**
- * Generate a temporary MCP config JSON file for the given agent.
- * Returns the file path, or null if no agent-specific MCPs are needed.
- * @param {string} [agentName]
- * @returns {string | null}
- */
-function getMcpConfigForAgent(agentName) {
-  const name = agentName && AGENT_MCPS[agentName] ? agentName : "build-plus";
-  const mcpNames = AGENT_MCPS[name];
-  if (!mcpNames || mcpNames.length === 0) return null;
-
-  if (_mcpConfigFileCache.has(name)) return _mcpConfigFileCache.get(name);
-
-  const mcpServers = {};
-  for (const mcpName of mcpNames) {
-    const def = getMcpDefinition(mcpName);
-    if (def) mcpServers[mcpName] = def;
-  }
-
-  if (Object.keys(mcpServers).length === 0) return null;
-
-  const configDir = join(homedir(), ".aidevops", ".agent-workspace", "tmp");
-  mkdirSync(configDir, { recursive: true });
-  const configPath = join(configDir, `claude-cli-mcp-${name}.json`);
-  writeFileSync(configPath, JSON.stringify({ mcpServers }, null, 2), "utf-8");
-  _mcpConfigFileCache.set(name, configPath);
-  console.error(`[aidevops] Claude proxy: generated MCP config for agent=${name} at ${configPath}`);
-  return configPath;
-}
-
-// ---------------------------------------------------------------------------
-// Account rotation with rate-limit tracking
-// ---------------------------------------------------------------------------
-
-/** Map<email, expiryTimestamp> — accounts known to be rate-limited. */
-const rateLimitedAccounts = new Map();
-
-/** Default cooldown (ms) before retrying a rate-limited account. */
-const RATE_LIMIT_COOLDOWN_MS = 5 * 60 * 1000; // 5 minutes
-
-function sortAccountsByPriority(accounts) {
-  return [...accounts].sort((a, b) => {
-    const pa = Number(a?.priority || 0);
-    const pb = Number(b?.priority || 0);
-    if (pa !== pb) return pb - pa;
-    return (a?.email || "").localeCompare(b?.email || "");
-  });
-}
-
-/**
- * Mark an account as rate-limited so subsequent requests skip it.
- * @param {string} email
- * @param {string} [resetsAt] - optional ISO/epoch from Claude's rate_limit_event
- */
-function markAccountRateLimited(email, resetsAt) {
-  let expiry = Date.now() + RATE_LIMIT_COOLDOWN_MS;
-  if (resetsAt) {
-    const parsed = Number(resetsAt) > 1e9 ? Number(resetsAt) * 1000 : Date.parse(resetsAt);
-    if (!isNaN(parsed) && parsed > Date.now()) {
-      expiry = parsed;
-    }
-  }
-  rateLimitedAccounts.set(email, expiry);
-  console.error(`[aidevops] Claude proxy: account ${email} rate-limited until ${new Date(expiry).toISOString()}`);
-}
-
-function isAccountRateLimited(email) {
-  const expiry = rateLimitedAccounts.get(email);
-  if (!expiry) return false;
-  if (Date.now() >= expiry) {
-    rateLimitedAccounts.delete(email);
-    return false;
-  }
-  return true;
-}
-
-/**
- * Get all available accounts with valid tokens, skipping rate-limited ones.
- * Returns array of { email, token } in priority order.
- */
-async function getAvailableAccounts() {
-  const accounts = sortAccountsByPriority(getAccounts("anthropic"));
-  const available = [];
-  for (const account of accounts) {
-    const email = account?.email || "unknown";
-    if (isAccountRateLimited(email)) {
-      continue;
-    }
-    const token = await ensureValidToken("anthropic", account);
-    if (token) {
-      available.push({ email, token });
-    }
-  }
-  return available;
-}
-
-function buildChildEnvWithToken(token) {
-  const childEnv = { ...process.env };
-  delete childEnv.ANTHROPIC_API_KEY;
-  childEnv.CLAUDE_CODE_OAUTH_TOKEN = token;
-  return childEnv;
-}
-
-/**
- * Detect rate-limit signals in Claude CLI JSON output.
- * @param {object} parsed - parsed JSON from Claude CLI
- * @returns {string|null} - resetsAt value if rate-limited, null otherwise
- */
-function detectRateLimitJson(parsed) {
-  if (parsed?.is_error && typeof parsed?.result === "string" && parsed.result.includes("hit your limit")) {
-    return null; // rate-limited but no explicit reset time in JSON mode
-  }
-  return undefined; // not rate-limited
-}
-
-/**
- * Detect rate-limit signals in a stream-json event line.
- * @param {object} event - parsed stream event
- * @returns {{ rateLimited: boolean, resetsAt?: string }} 
- */
-function detectRateLimitStream(event) {
-  if (event?.type === "rate_limit_event") {
-    return { rateLimited: true, resetsAt: event?.rate_limit_info?.resetsAt };
-  }
-  if (event?.type === "assistant" && event?.error === "rate_limit") {
-    return { rateLimited: true };
-  }
-  return { rateLimited: false };
-}
 
 function isClaudeCliAvailable() {
   try {
@@ -325,66 +100,60 @@ function getClaudeProxyModels() {
   ];
 }
 
+// ---------------------------------------------------------------------------
+// OpenCode provider registration
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the OpenCode provider entries for the claudecli family. Delegates to
+ * the shared `buildProviderModels` helper so the schema (modalities, cost,
+ * limit, family) is defined in exactly one place across all proxy plugins.
+ */
 function buildClaudeProviderModels(models) {
-  const entries = {};
-  for (const model of models) {
-    entries[model.id] = {
-      name: model.name,
-      attachment: false,
-      tool_call: false,
-      temperature: true,
-      reasoning: model.reasoning || false,
-      modalities: { input: ["text"], output: ["text"] },
-      cost: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
-      limit: {
-        context: model.contextWindow || 200000,
-        output: model.maxTokens || 32000,
-      },
-      family: "claudecli",
-    };
-  }
-  return entries;
+  return buildProviderModels(models, { family: "claudecli" });
 }
 
-export function registerClaudeProvider(config, port, models) {
-  if (!config.provider) config.provider = {};
-
-  const providerModels = buildClaudeProviderModels(models);
-  const baseURL = `http://127.0.0.1:${port}/v1`;
-  const newProvider = {
-    name: "Claude CLI (via aidevops proxy)",
-    npm: "@ai-sdk/openai-compatible",
-    api: baseURL,
-    models: providerModels,
-  };
-
-  const existing = config.provider[CLAUDE_PROVIDER_ID];
-  if (!existing || JSON.stringify(existing) !== JSON.stringify(newProvider)) {
-    config.provider[CLAUDE_PROVIDER_ID] = newProvider;
-    return true;
-  }
-
-  return false;
-}
-
-function persistClaudeProvider(port, models) {
-  let config = {};
-  try {
-    config = JSON.parse(readFileSync(OPENCODE_CONFIG_PATH, "utf-8"));
-  } catch (err) {
-    if (err.code !== "ENOENT") {
-      console.error(`[aidevops] Claude proxy: cannot read opencode.json: ${err.message}`);
-      return;
-    }
-  }
-
-  if (!config.provider) config.provider = {};
-  config.provider[CLAUDE_PROVIDER_ID] = {
+/**
+ * Build the canonical provider config object (consumed by both the in-memory
+ * registration path and the on-disk persist path so they cannot drift).
+ */
+function buildClaudeProviderConfig(port, models) {
+  return {
     name: "Claude CLI (via aidevops proxy)",
     npm: "@ai-sdk/openai-compatible",
     api: `http://127.0.0.1:${port}/v1`,
     models: buildClaudeProviderModels(models),
   };
+}
+
+export function registerClaudeProvider(config, port, models) {
+  if (!config.provider) config.provider = {};
+
+  const newProvider = buildClaudeProviderConfig(port, models);
+  const existing = config.provider[CLAUDE_PROVIDER_ID];
+  if (!existing || JSON.stringify(existing) !== JSON.stringify(newProvider)) {
+    config.provider[CLAUDE_PROVIDER_ID] = newProvider;
+    return true;
+  }
+  return false;
+}
+
+function readOpencodeConfig() {
+  try {
+    return JSON.parse(readFileSync(OPENCODE_CONFIG_PATH, "utf-8"));
+  } catch (err) {
+    if (err.code === "ENOENT") return {};
+    console.error(`[aidevops] Claude proxy: cannot read opencode.json: ${err.message}`);
+    return null;
+  }
+}
+
+function persistClaudeProvider(port, models) {
+  const config = readOpencodeConfig();
+  if (config === null) return;
+
+  if (!config.provider) config.provider = {};
+  config.provider[CLAUDE_PROVIDER_ID] = buildClaudeProviderConfig(port, models);
 
   try {
     mkdirSync(dirname(OPENCODE_CONFIG_PATH), { recursive: true });
@@ -395,598 +164,48 @@ function persistClaudeProvider(port, models) {
   }
 }
 
-function extractTextContent(content) {
-  if (content == null) return "";
-  if (typeof content === "string") return content;
-  if (!Array.isArray(content)) return "";
-  return content
-    .filter((part) => part && typeof part === "object" && part.type === "text" && typeof part.text === "string")
-    .map((part) => part.text)
-    .join("\n");
-}
+// ---------------------------------------------------------------------------
+// HTTP routing
+// ---------------------------------------------------------------------------
 
-function sanitizeClaudeCliSystemPrompt(text) {
-  return text.replace(/<directories>\s*([\s\S]*?)\s*<\/directories>/g, (_m, inner) => {
-    const content = String(inner || "").trim();
-    return content ? `Directories:\n${content}` : "";
-  });
-}
-
-function parseChatMessages(messages) {
-  const systemParts = [];
-  const conversation = [];
-
-  for (const message of messages || []) {
-    const text = extractTextContent(message?.content);
-    if (!text.trim()) continue;
-    if (message.role === "system") {
-      systemParts.push(text);
-      continue;
-    }
-    conversation.push({ role: message.role || "user", text });
-  }
-
-  return {
-    systemPrompt: sanitizeClaudeCliSystemPrompt(systemParts.join("\n\n").trim()),
-    prompt: renderConversationPrompt(conversation),
-  };
-}
-
-function renderConversationPrompt(conversation) {
-  if (conversation.length === 0) return "Continue the conversation helpfully.";
-  return [
-    "Continue this conversation naturally.",
-    "",
-    ...conversation.map((message) => `${message.role.toUpperCase()}:\n${message.text}`),
-  ].join("\n\n");
-}
-
-function buildClaudeArgs(body, systemPrompt, streaming) {
-  const agentsDir = join(homedir(), ".aidevops", "agents");
-  const agentName = body.agentName || "build-plus";
-  const args = [
-    "-p",
-    "--model",
-    body.model,
-  ];
-
-  // Add reasoning effort level if provided
-  if (body.effortLevel) {
-    args.push("--effort", body.effortLevel);
-  }
-
-  args.push(
-    "--permission-mode",
-    "default",
-    "--no-session-persistence",
-    "--add-dir",
-    agentsDir,
-  );
-
-  // Agent-specific MCP config (lazy loading — only needed MCPs start)
-  const mcpConfig = getMcpConfigForAgent(agentName);
-  if (mcpConfig) {
-    args.push("--mcp-config", mcpConfig);
-  }
-
-  // Combine: framework base (build.txt + AGENTS.md) + agent prompt + request system prompt.
-  // Framework and agent go first (static), OpenCode's context-specific prompt last.
-  const frameworkPrompt = getFrameworkPrompt();
-  const agentPrompt = getAgentPrompt(agentName);
-  const combinedPrompt = [frameworkPrompt, agentPrompt, systemPrompt].filter(Boolean).join("\n\n");
-  if (combinedPrompt) {
-    args.push("--append-system-prompt", combinedPrompt);
-  }
-
-  if (streaming) {
-    args.push(
-      "--verbose",
-      "--output-format",
-      "stream-json",
-      "--include-partial-messages",
-      "--include-hook-events",
+function maybeDumpDebugRequest(body) {
+  if (!DEBUG_DUMP_ENABLED) return;
+  try {
+    writeFileSync(
+      "/tmp/claude-proxy-last-request.json",
+      JSON.stringify({ model: body.model, agent: body.agentName, stream: body.stream }, null, 2),
+      "utf-8",
     );
-  } else {
-    args.push("--output-format", "json");
+  } catch {
+    // best effort debugging
   }
-
-  args.push(body.prompt);
-  return args;
-}
-
-async function runClaudeJsonWithAccount(body, directory, account, abortSignal) {
-  const childEnv = buildChildEnvWithToken(account.token);
-  const child = spawn("claude", buildClaudeArgs(body, body.systemPrompt, false), {
-    cwd: directory,
-    env: childEnv,
-    stdio: ["ignore", "pipe", "pipe"],
-  });
-
-  // Lifetime bound: kill child if it exceeds timeout
-  const timeout = setTimeout(() => {
-    console.error(`[aidevops] Claude proxy: json child timeout (${CHILD_TIMEOUT_MS}ms), killing`);
-    child.kill("SIGKILL");
-  }, CHILD_TIMEOUT_MS);
-
-  // Abort cleanup: if the caller's request is aborted (client disconnect),
-  // terminate the child immediately (GH#18621 Finding 1).
-  const onAbort = () => {
-    if (child.exitCode === null && !child.killed) {
-      try {
-        child.kill("SIGTERM");
-        console.error(`[aidevops] Claude proxy: json request aborted by client, killed child pid=${child.pid}`);
-      } catch {
-        // best effort
-      }
-    }
-  };
-  if (abortSignal) {
-    if (abortSignal.aborted) onAbort();
-    else abortSignal.addEventListener("abort", onAbort, { once: true });
-  }
-
-  const stdoutChunks = [];
-  const stderrChunks = [];
-
-  child.stdout.on("data", (chunk) => stdoutChunks.push(chunk));
-  child.stderr.on("data", (chunk) => stderrChunks.push(chunk));
-
-  const exitCode = await new Promise((resolve) => {
-    child.on("close", resolve);
-    child.on("error", () => resolve(1));
-  });
-  clearTimeout(timeout);
-  if (abortSignal) abortSignal.removeEventListener("abort", onAbort);
-  const stdout = Buffer.concat(stdoutChunks).toString("utf-8").trim();
-  const stderr = Buffer.concat(stderrChunks).toString("utf-8").trim();
-
-  if (!stdout) {
-    throw new Error(stderr || `claude exited with status ${exitCode}`);
-  }
-
-  const parsed = JSON.parse(stdout);
-
-  // Check for rate limit in JSON response
-  const rateLimitResult = detectRateLimitJson(parsed);
-  if (rateLimitResult !== undefined) {
-    markAccountRateLimited(account.email, rateLimitResult);
-    return { rateLimited: true };
-  }
-
-  if (exitCode !== 0) {
-    throw new Error(parsed.result || stderr || `claude exited with status ${exitCode}`);
-  }
-
-  return {
-    rateLimited: false,
-    content: parsed.result || "",
-    usage: parsed.usage || {},
-  };
-}
-
-async function runClaudeJson(body, directory, abortSignal) {
-  const accounts = await getAvailableAccounts();
-  if (accounts.length === 0) {
-    throw new Error("No Anthropic OAuth pool accounts available (all rate-limited or no valid tokens)");
-  }
-
-  for (const account of accounts) {
-    if (abortSignal && abortSignal.aborted) throw new Error("Request aborted by client");
-    console.error(`[aidevops] Claude proxy: trying account ${account.email} (json mode)`);
-    const result = await runClaudeJsonWithAccount(body, directory, account, abortSignal);
-    if (!result.rateLimited) {
-      return result;
-    }
-    console.error(`[aidevops] Claude proxy: account ${account.email} rate-limited, trying next...`);
-  }
-
-  throw new Error("All Anthropic OAuth pool accounts are rate-limited");
-}
-
-function createOpenAIChunk(id, created, model, delta, finishReason = null) {
-  return {
-    id,
-    object: "chat.completion.chunk",
-    created,
-    model,
-    choices: [{ index: 0, delta, finish_reason: finishReason }],
-  };
-}
-
-function summarizeToolInput(input) {
-  if (!input || typeof input !== "object") return "";
-  const parts = [];
-  // Bash
-  if (typeof input.command === "string") parts.push(input.command);
-  // Read / Edit / Write
-  if (typeof input.filePath === "string") parts.push(input.filePath);
-  // Glob
-  if (typeof input.pattern === "string") parts.push(input.pattern);
-  // Grep
-  if (typeof input.regex === "string") parts.push(input.regex);
-  // Description (Bash, Task)
-  if (typeof input.description === "string") parts.push(input.description);
-  // Task / subagent
-  if (typeof input.prompt === "string") parts.push(input.prompt.slice(0, 120));
-  if (typeof input.subagent_type === "string") parts.push(`type=${input.subagent_type}`);
-  return parts.filter(Boolean).join(" — ");
-}
-
-function formatStatusLine(label, detail = "") {
-  return detail ? `[${label}] ${detail}\n` : `[${label}]\n`;
 }
 
 /**
- * Process a parsed stream-json event, emitting OpenAI chunks via `send`.
- * Returns true if the event produced visible content (text/thinking/tool).
+ * Build the proxy's normalised request body from an OpenAI-compatible
+ * incoming chat-completion payload + the fetch Request (for header lookup).
  */
-function processStreamEvent(event, ctx) {
-  const { completionId, created, model, send, seenToolUseIds, seenTaskIds, seenToolResults } = ctx;
-
-  if (event.type === "stream_event" && event.event?.type === "content_block_delta") {
-    if (event.event.delta?.type === "text_delta" && event.event.delta.text) {
-      ctx.textChunkCount += 1;
-      ctx.textCharCount += event.event.delta.text.length;
-      send(createOpenAIChunk(completionId, created, model, { content: event.event.delta.text }));
-      return true;
-    }
-    if (event.event.delta?.type === "thinking_delta" && event.event.delta.thinking) {
-      send(createOpenAIChunk(completionId, created, model, { reasoning_content: event.event.delta.thinking }));
-      return true;
-    }
-  } else if (event.type === "stream_event" && event.event?.type === "message_delta") {
-    if (event.event.delta?.stop_reason && !ctx.finishSent) {
-      ctx.finishSent = true;
-      send(createOpenAIChunk(completionId, created, model, {}, "stop"));
-    }
-  } else if (event.type === "assistant" && Array.isArray(event.message?.content)) {
-    for (const block of event.message.content) {
-      if (block?.type === "tool_use" && block.id && !seenToolUseIds.has(block.id)) {
-        seenToolUseIds.set(block.id, block.name || "unknown");
-        send(createOpenAIChunk(completionId, created, model, {
-          content: formatStatusLine(`Tool: ${block.name || "unknown"}`, summarizeToolInput(block.input)),
-        }));
-      }
-    }
-  } else if (event.type === "system" && event.subtype === "task_started" && event.task_id && !seenTaskIds.has(`start:${event.task_id}`)) {
-    seenTaskIds.add(`start:${event.task_id}`);
-    send(createOpenAIChunk(completionId, created, model, {
-      content: formatStatusLine("Subagent started", event.description || event.prompt || event.task_id),
-    }));
-  } else if (event.type === "system" && event.subtype === "task_notification" && event.task_id && !seenTaskIds.has(`done:${event.task_id}`)) {
-    seenTaskIds.add(`done:${event.task_id}`);
-    send(createOpenAIChunk(completionId, created, model, {
-      content: formatStatusLine("Subagent completed", event.summary || event.task_id),
-    }));
-  } else if (event.type === "user" && event.uuid && event.tool_use_result && !seenToolResults.has(event.uuid)) {
-    seenToolResults.add(event.uuid);
-    const toolResult = event.tool_use_result;
-    // Correlate tool name via tool_use_id from the message content
-    const toolUseId = event.message?.content?.[0]?.tool_use_id;
-    const toolName = (toolUseId && seenToolUseIds.get(toolUseId)) || "unknown";
-    const isError = toolResult.is_error === true || event.message?.content?.[0]?.is_error === true;
-    const preview = Array.isArray(toolResult.content)
-      ? toolResult.content.map((item) => item?.text).filter(Boolean).join(" ")
-      : (toolResult.stdout || "");
-    if (preview) {
-      const label = isError ? `Tool error: ${toolName}` : `Tool result: ${toolName}`;
-      send(createOpenAIChunk(completionId, created, model, {
-        content: formatStatusLine(label, preview.slice(0, 500)),
-      }));
-    }
-  }
-
-  return false;
-}
-
-/**
- * Attempt to stream with a specific account. Buffers initial events to detect
- * rate limiting before committing to the stream. Returns "rate_limited" if the
- * account is rate-limited, otherwise streams to completion and returns "done".
- */
-function tryStreamWithAccount(controller, encoder, completionId, created, body, directory, account, abortRef) {
-  return new Promise((resolve) => {
-    const childEnv = buildChildEnvWithToken(account.token);
-    const child = spawn("claude", buildClaudeArgs(body, body.systemPrompt, true), {
-      cwd: directory,
-      env: childEnv,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
-
-    // Expose the running child so the enclosing ReadableStream can signal it
-    // on client disconnect via the `cancel` callback (GH#18621 Finding 1).
-    if (abortRef) abortRef.child = child;
-
-    // Lifetime bound: kill child if it exceeds timeout
-    const timeout = setTimeout(() => {
-      console.error(`[aidevops] Claude proxy: stream child timeout (${CHILD_TIMEOUT_MS}ms), killing`);
-      child.kill("SIGKILL");
-    }, CHILD_TIMEOUT_MS);
-
-    // If the caller already signalled cancel before the child spawned, kill immediately.
-    if (abortRef && abortRef.cancelled) {
-      child.kill("SIGTERM");
-    }
-
-    let buffer = "";
-    let closed = false;
-    let stderrText = "";
-    let probePhase = true; // buffer events until we know it's not rate-limited
-    let rateLimitBailed = false; // true if we resolved "rate_limited" — don't touch controller
-    const bufferedEvents = [];
-
-    const ctx = {
-      completionId,
-      created,
-      model: body.model,
-      textChunkCount: 0,
-      textCharCount: 0,
-      finishSent: false,
-      seenToolUseIds: new Map(),  // id → tool name, for correlating results
-      seenTaskIds: new Set(),
-      seenToolResults: new Set(),
-      send(payload) {
-        if (closed) return;
-        try {
-          controller.enqueue(encoder.encode(`data: ${JSON.stringify(payload)}\n\n`));
-        } catch {
-          closed = true;
-        }
-      },
-    };
-
-    const closeStream = () => {
-      if (closed) return;
-      closed = true;
-      try {
-        controller.enqueue(encoder.encode("data: [DONE]\n\n"));
-      } catch {
-        // already closed
-      }
-      try {
-        controller.close();
-      } catch {
-        // already closed by runtime
-      }
-    };
-
-    /** Flush buffered events and exit probe phase. */
-    const commitToStream = () => {
-      probePhase = false;
-      for (const evt of bufferedEvents) {
-        processStreamEvent(evt, ctx);
-      }
-      bufferedEvents.length = 0;
-    };
-
-    child.stdout.on("data", (chunk) => {
-      buffer += chunk.toString("utf-8");
-      const lines = buffer.split("\n");
-      buffer = lines.pop() || "";
-
-      for (const line of lines) {
-        if (!line.trim()) continue;
-        try {
-          const event = JSON.parse(line);
-
-          // During probe phase, check for rate limiting before sending anything
-          if (probePhase) {
-            const rl = detectRateLimitStream(event);
-            if (rl.rateLimited) {
-              markAccountRateLimited(account.email, rl.resetsAt);
-              rateLimitBailed = true;
-              child.kill("SIGTERM");
-              resolve("rate_limited");
-              return;
-            }
-            bufferedEvents.push(event);
-
-            // If we see actual content, commit to this account
-            if (
-              (event.type === "stream_event" && event.event?.type === "content_block_start") ||
-              (event.type === "stream_event" && event.event?.type === "content_block_delta") ||
-              (event.type === "stream_event" && event.event?.type === "message_start" && event.event?.message?.usage)
-            ) {
-              commitToStream();
-            }
-            continue;
-          }
-
-          processStreamEvent(event, ctx);
-        } catch {
-          // ignore malformed line fragments
-        }
-      }
-    });
-
-    child.stderr.on("data", (chunk) => {
-      if (stderrText.length < 4000) {
-        stderrText += chunk.toString("utf-8");
-      }
-    });
-
-    child.on("close", (exitCode) => {
-      clearTimeout(timeout);
-      // If we bailed due to rate limiting, the controller belongs to the next
-      // account attempt — do NOT write to it or close it.
-      if (rateLimitBailed) {
-        console.error(
-          `[aidevops] Claude proxy: killed rate-limited child account=${account.email} exitCode=${exitCode}`,
-        );
-        return;
-      }
-
-      // If we never exited probe phase (e.g. very short response), flush now
-      if (probePhase) {
-        commitToStream();
-      }
-
-      if (exitCode !== 0 && stderrText.trim()) {
-        ctx.send(createOpenAIChunk(completionId, created, body.model, {
-          content: `\n[Claude CLI transport error: ${stderrText.trim().slice(0, 500)}]`,
-        }));
-      }
-      if (!ctx.finishSent) {
-        ctx.finishSent = true;
-        ctx.send(createOpenAIChunk(completionId, created, body.model, {}, "stop"));
-      }
-      console.error(
-        `[aidevops] Claude proxy: stream complete model=${body.model} account=${account.email} exitCode=${exitCode} textChunks=${ctx.textChunkCount} textChars=${ctx.textCharCount} stderr=${JSON.stringify(stderrText.trim().slice(0, 300))}`,
-      );
-      closeStream();
-      resolve("done");
-    });
-
-    child.on("error", (err) => {
-      clearTimeout(timeout);
-      if (probePhase) {
-        resolve("error");
-        return;
-      }
-      controller.error(err);
-      resolve("done");
-    });
-  });
-}
-
-function streamClaudeResponse(body, directory) {
-  const completionId = `chatcmpl-${crypto.randomUUID().replace(/-/g, "").slice(0, 28)}`;
-  const created = Math.floor(Date.now() / 1000);
-  const encoder = new TextEncoder();
-
-  // Shared ref between start() and cancel() so the cancel callback can kill
-  // whatever child is currently running (GH#18621 Finding 1 — client disconnect
-  // cleanup). `child` is mutated by tryStreamWithAccount as each retry spawns.
-  const abortRef = { child: null, cancelled: false };
-
-  return new ReadableStream({
-    async start(controller) {
-      const accounts = await getAvailableAccounts();
-      if (accounts.length === 0) {
-        const errChunk = createOpenAIChunk(completionId, created, body.model, {
-          content: "[Claude CLI transport: all Anthropic OAuth pool accounts are rate-limited]",
-        });
-        try {
-          controller.enqueue(encoder.encode(`data: ${JSON.stringify(errChunk)}\n\n`));
-          controller.enqueue(encoder.encode(`data: ${JSON.stringify(createOpenAIChunk(completionId, created, body.model, {}, "stop"))}\n\n`));
-          controller.enqueue(encoder.encode("data: [DONE]\n\n"));
-          controller.close();
-        } catch {
-          // already closed
-        }
-        return;
-      }
-
-      for (const account of accounts) {
-        if (abortRef.cancelled) return; // client already bailed
-        console.error(`[aidevops] Claude proxy: trying account ${account.email} (stream mode)`);
-        const result = await tryStreamWithAccount(controller, encoder, completionId, created, body, directory, account, abortRef);
-        if (result === "rate_limited") {
-          console.error(`[aidevops] Claude proxy: account ${account.email} rate-limited, trying next...`);
-          continue;
-        }
-        return; // stream completed
-      }
-
-      // All accounts exhausted
-      const errChunk = createOpenAIChunk(completionId, created, body.model, {
-        content: "[Claude CLI transport: all Anthropic OAuth pool accounts are rate-limited]",
-      });
-      try {
-        controller.enqueue(encoder.encode(`data: ${JSON.stringify(errChunk)}\n\n`));
-        controller.enqueue(encoder.encode(`data: ${JSON.stringify(createOpenAIChunk(completionId, created, body.model, {}, "stop"))}\n\n`));
-        controller.enqueue(encoder.encode("data: [DONE]\n\n"));
-        controller.close();
-      } catch {
-        // already closed
-      }
-    },
-    cancel(reason) {
-      // Client disconnected (or opencode aborted) — kill the in-flight child
-      // so it stops consuming quota and touching the workspace (GH#18621).
-      abortRef.cancelled = true;
-      const child = abortRef.child;
-      if (child && child.exitCode === null && !child.killed) {
-        try {
-          child.kill("SIGTERM");
-          console.error(`[aidevops] Claude proxy: stream cancelled by client (${reason || "no-reason"}), killed child pid=${child.pid}`);
-        } catch {
-          // best effort
-        }
-      }
-    },
-  });
-}
-
-function buildOpenAIResponse(body, content, usage) {
+function normaliseRequestBody(req, incoming) {
+  const parsed = parseChatMessages(incoming.messages || []);
+  const { agentName, resolvedModel } = resolveAgentAndModel(req, incoming);
   return {
-    id: `chatcmpl-${crypto.randomUUID().replace(/-/g, "").slice(0, 28)}`,
-    object: "chat.completion",
-    created: Math.floor(Date.now() / 1000),
-    model: body.model,
-    choices: [
-      {
-        index: 0,
-        message: { role: "assistant", content },
-        finish_reason: "stop",
-      },
-    ],
-    usage: {
-      prompt_tokens: usage.input_tokens || 0,
-      completion_tokens: usage.output_tokens || 0,
-      total_tokens: (usage.input_tokens || 0) + (usage.output_tokens || 0),
-    },
+    model: resolvedModel,
+    agentName,
+    systemPrompt: parsed.systemPrompt,
+    prompt: parsed.prompt,
+    stream: incoming.stream !== false,
+    effortLevel: resolveEffortLevel(incoming),
   };
 }
 
 async function handleChatCompletions(req, directory) {
   const incoming = await req.json();
-  const parsed = parseChatMessages(incoming.messages || []);
-
-  // Agent selection: X-Agent header > model name suffix (e.g. "claudecli/seo/opus") > default
-  let agentName = req.headers.get("x-agent") || null;
-  // Normalize model: strip routing prefix (e.g. "claudecli/seo/opus" → "claude-opus-4-6")
-  let resolvedModel = incoming.model;
-  if (typeof incoming.model === "string" && incoming.model.includes("/")) {
-    const parts = incoming.model.split("/");
-    if (parts.length >= 2 && AGENT_FILES[parts[1]]) {
-      agentName = agentName || parts[1];
-    }
-    // Map model alias suffix to real model ID
-    const modelSuffix = parts[parts.length - 1];
-    const MODEL_ALIASES = { haiku: "claude-haiku-4-5", sonnet: "claude-sonnet-4-6", opus: "claude-opus-4-6" };
-    resolvedModel = MODEL_ALIASES[modelSuffix] || incoming.model;
-  }
-
-  // Extract reasoning effort level from OpenAI-compatible request
-  const EFFORT_LEVELS = new Set(["low", "medium", "high", "max"]);
-  const effortLevel = typeof incoming.reasoning_effort === "string" && EFFORT_LEVELS.has(incoming.reasoning_effort)
-    ? incoming.reasoning_effort
-    : null;
-
-  const body = {
-    model: resolvedModel,
-    agentName: agentName || "build-plus",
-    systemPrompt: parsed.systemPrompt,
-    prompt: parsed.prompt,
-    stream: incoming.stream !== false,
-    effortLevel: effortLevel,
-  };
+  const body = normaliseRequestBody(req, incoming);
 
   console.error(
     `[aidevops] Claude proxy: request model=${body.model} agent=${body.agentName} stream=${body.stream} systemChars=${body.systemPrompt.length} promptChars=${body.prompt.length}`,
   );
-  if (DEBUG_DUMP_ENABLED) {
-    try {
-      writeFileSync(
-        "/tmp/claude-proxy-last-request.json",
-        JSON.stringify({ model: body.model, agent: body.agentName, stream: body.stream }, null, 2),
-        "utf-8",
-      );
-    } catch {
-      // best effort debugging
-    }
-  }
+  maybeDumpDebugRequest(body);
 
   if (incoming.stream === false) {
     // Thread the fetch Request's abort signal into the JSON path so client
@@ -1002,7 +221,71 @@ async function handleChatCompletions(req, directory) {
   });
 }
 
-export async function startClaudeProxy(client, directory) {
+function buildModelsListResponse() {
+  return new Response(JSON.stringify({
+    object: "list",
+    data: getClaudeProxyModels().map((model) => ({ id: model.id, object: "model", owned_by: "claude-cli" })),
+  }), {
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+async function handleChatCompletionsWithErrorWrap(req, directory) {
+  try {
+    return await handleChatCompletions(req, directory);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return new Response(JSON.stringify({
+      error: { message, type: "server_error", code: "internal_error" },
+    }), {
+      status: 500,
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+}
+
+/**
+ * Top-level HTTP request router for the proxy server. Extracted from the
+ * Bun.serve fetch closure to keep `startClaudeProxy` shallow.
+ */
+async function routeProxyRequest(req, directory) {
+  const url = new URL(req.url);
+  if (req.method === "GET" && url.pathname === "/v1/models") {
+    return buildModelsListResponse();
+  }
+  if (req.method === "POST" && url.pathname === "/v1/chat/completions") {
+    return handleChatCompletionsWithErrorWrap(req, directory);
+  }
+  return new Response("Not Found", { status: 404 });
+}
+
+// ---------------------------------------------------------------------------
+// Server lifecycle
+// ---------------------------------------------------------------------------
+
+/**
+ * Best-effort registration of an opaque API key with OpenCode's auth store
+ * so it doesn't prompt the user for credentials on first request. Failures
+ * are logged but never fatal — the proxy works without this entry.
+ */
+async function registerProxyAuth(client) {
+  try {
+    await client.auth.set({
+      path: { id: CLAUDE_PROVIDER_ID },
+      body: { type: "api", key: "claude-cli-proxy" },
+    });
+  } catch {
+    // best effort
+  }
+}
+
+/**
+ * Pre-flight gate for `startClaudeProxy`. Returns:
+ *   - `null` if the proxy should be skipped (no Bun, no claude CLI, race)
+ *   - `{ port, models }` if the proxy is already running (fast-path)
+ *   - `undefined` if the caller should proceed with a full launch
+ */
+function checkProxyPreconditions() {
   if (typeof globalThis.Bun === "undefined") {
     console.error("[aidevops] Claude proxy: skipped (not running under Bun)");
     return null;
@@ -1010,63 +293,45 @@ export async function startClaudeProxy(client, directory) {
   if (!isClaudeCliAvailable()) return null;
   if (proxyStarting) return null;
   if (proxyPort) return { port: proxyPort, models: getClaudeProxyModels() };
+  return undefined;
+}
+
+/**
+ * Bring up the Bun.serve listener, register the provider, persist config.
+ * Throws on any failure — `startClaudeProxy` translates that into a `null`
+ * return so callers always see one of: `{port, models}` or `null`.
+ */
+async function launchProxyServer(client, directory) {
+  proxyServer = Bun.serve({
+    port: CLAUDE_PROXY_DEFAULT_PORT,
+    hostname: "127.0.0.1",
+    idleTimeout: 120,
+    fetch: (req) => routeProxyRequest(req, directory),
+  });
+
+  proxyPort = proxyServer.port;
+  const models = getClaudeProxyModels();
+
+  await registerProxyAuth(client);
+  persistClaudeProvider(proxyPort, models);
+  console.error(`[aidevops] Claude proxy: started on port ${proxyPort}`);
+  return { port: proxyPort, models };
+}
+
+export async function startClaudeProxy(client, directory) {
+  const earlyExit = checkProxyPreconditions();
+  if (earlyExit !== undefined) return earlyExit;
 
   proxyStarting = true;
+  let result = null;
   try {
-    proxyServer = Bun.serve({
-      port: CLAUDE_PROXY_DEFAULT_PORT,
-      hostname: "127.0.0.1",
-      idleTimeout: 120,
-      async fetch(req) {
-        const url = new URL(req.url);
-        if (req.method === "GET" && url.pathname === "/v1/models") {
-          return new Response(JSON.stringify({
-            object: "list",
-            data: getClaudeProxyModels().map((model) => ({ id: model.id, object: "model", owned_by: "claude-cli" })),
-          }), {
-            headers: { "Content-Type": "application/json" },
-          });
-        }
-
-        if (req.method === "POST" && url.pathname === "/v1/chat/completions") {
-          try {
-            return await handleChatCompletions(req, directory);
-          } catch (err) {
-            const message = err instanceof Error ? err.message : String(err);
-            return new Response(JSON.stringify({
-              error: { message, type: "server_error", code: "internal_error" },
-            }), {
-              status: 500,
-              headers: { "Content-Type": "application/json" },
-            });
-          }
-        }
-
-        return new Response("Not Found", { status: 404 });
-      },
-    });
-
-    proxyPort = proxyServer.port;
-    const models = getClaudeProxyModels();
-
-    try {
-      await client.auth.set({
-        path: { id: CLAUDE_PROVIDER_ID },
-        body: { type: "api", key: "claude-cli-proxy" },
-      });
-    } catch {
-      // best effort
-    }
-
-    persistClaudeProvider(proxyPort, models);
-    console.error(`[aidevops] Claude proxy: started on port ${proxyPort}`);
-    return { port: proxyPort, models };
+    result = await launchProxyServer(client, directory);
   } catch (err) {
     console.error(`[aidevops] Claude proxy: failed to start: ${err.message}`);
-    return null;
   } finally {
     proxyStarting = false;
   }
+  return result;
 }
 
 export function getClaudeProxyPort() {

--- a/.agents/plugins/opencode-aidevops/proxy-provider-models.mjs
+++ b/.agents/plugins/opencode-aidevops/proxy-provider-models.mjs
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+/**
+ * Shared OpenCode provider-model entry builder used by all proxy plugins
+ * (claude-proxy, cursor-proxy, google-proxy). Each proxy registers a
+ * `provider.<id>` block in opencode.json whose `models` map describes the
+ * runtime capabilities of every model the proxy can route to.
+ *
+ * The shape of each entry is fixed by OpenCode's @ai-sdk/openai-compatible
+ * provider — see opencode-ai source for the canonical schema. The previous
+ * implementation duplicated this builder across each proxy file, with only
+ * `family` and a few capability flags differing. Centralising it eliminates
+ * the qlty similar-code smell (was 20 lines in 2 locations, mass=89) and
+ * keeps schema drift in one place.
+ *
+ * Extracted from claude-proxy.mjs and cursor-proxy.mjs as part of t2070.
+ */
+
+/**
+ * @typedef {Object} ProxyModel
+ * @property {string} id
+ * @property {string} name
+ * @property {boolean} [reasoning]
+ * @property {number} [contextWindow]
+ * @property {number} [maxTokens]
+ */
+
+/**
+ * @typedef {Object} ProxyProviderModelOpts
+ * @property {string} family - OpenCode family identifier (e.g. "claudecli", "cursor", "google")
+ * @property {boolean} [attachment=false] - Whether models accept attachments
+ * @property {boolean} [toolCall=false]   - Whether models support tool/function calls
+ * @property {boolean} [temperature=true] - Whether models accept a temperature parameter
+ * @property {string[]} [inputModalities=["text"]]  - Input modality list
+ * @property {string[]} [outputModalities=["text"]] - Output modality list
+ * @property {number} [defaultContext=200000]    - Fallback context window
+ * @property {number} [defaultMaxTokens=32000]   - Fallback max-output tokens
+ * @property {(model: ProxyModel) => boolean} [reasoningFn] - Custom reasoning predicate
+ */
+
+/**
+ * Build an OpenCode provider `models` map from a proxy's discovered model list.
+ *
+ * @param {ProxyModel[]} models
+ * @param {ProxyProviderModelOpts} opts
+ * @returns {Record<string, object>}
+ */
+export function buildProviderModels(models, opts) {
+  const {
+    family,
+    attachment = false,
+    toolCall = false,
+    temperature = true,
+    inputModalities = ["text"],
+    outputModalities = ["text"],
+    defaultContext = 200000,
+    defaultMaxTokens = 32000,
+    reasoningFn = (model) => Boolean(model.reasoning),
+  } = opts;
+
+  const entries = {};
+  for (const model of models) {
+    entries[model.id] = {
+      name: model.name,
+      attachment,
+      tool_call: toolCall,
+      temperature,
+      reasoning: reasoningFn(model),
+      modalities: { input: inputModalities, output: outputModalities },
+      cost: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
+      limit: {
+        context: model.contextWindow || defaultContext,
+        output: model.maxTokens || defaultMaxTokens,
+      },
+      family,
+    };
+  }
+  return entries;
+}


### PR DESCRIPTION
## Summary

Decomposes .agents/plugins/opencode-aidevops/claude-proxy.mjs from a 1074-line monolith with 6 qlty smells (file complexity 214, two cyclomatic-30+ functions, an 8-param function, similar-code with cursor-proxy.mjs) into a thin 339-line facade plus six single-responsibility sibling modules. After the refactor claude-proxy.mjs and every extracted module report zero qlty smells; repo-wide smell count drops from 109 to 102 (delta = 7, target ≥ 5). processStreamEvent and tryStreamWithAccount each take 2 parameters instead of 8 (state bundled into a session/ctx object), and the SSE event branching becomes a small per-event-type handler dispatch table. The shared proxy-provider-models.mjs helper eliminates the cross-file 20-line duplicate flagged between claude-proxy and cursor-proxy. Public surface (startClaudeProxy, getClaudeProxyPort, registerClaudeProvider) is byte-identical and 28 characterisation assertions exercise the rate-limit detection, account env wiring, message parsing, agent/model resolution, args building, JSON response shape, and every stream-event handler.

## Files Changed

.agents/plugins/opencode-aidevops/claude-proxy-context.mjs,.agents/plugins/opencode-aidevops/claude-proxy-jsonpath.mjs,.agents/plugins/opencode-aidevops/claude-proxy-retry.mjs,.agents/plugins/opencode-aidevops/claude-proxy-stream.mjs,.agents/plugins/opencode-aidevops/claude-proxy-streaming.mjs,.agents/plugins/opencode-aidevops/claude-proxy.mjs,.agents/plugins/opencode-aidevops/proxy-provider-models.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bun import-smoke for all 7 modules (no syntax/resolution errors, oauth-pool init log appears as expected); bun characterisation harness with 28 assertions covering rate-limit detection (json + stream), buildChildEnvWithToken, parseChatMessages with directories sanitisation, resolveAgentAndModel for plain/routed/header forms, resolveEffortLevel, buildClaudeArgs JSON+stream variants, buildOpenAIResponse usage mapping, buildProviderModels for both claudecli and google variants, processStreamEvent for text_delta/thinking_delta/tool_use/dedup/message_delta/task_started/task_notification/tool_use_result/unknown-type, isCommitTrigger for content_block_start/delta/message_start variants, and registerClaudeProvider end-to-end. qlty smells delta verified against origin/main HEAD via git stash baseline run.

Resolves #18778


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.24 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 19m and 83,099 tokens on this as a headless worker.