### PR TITLE
GH#18816: fix(dispatch-dedup): fail-CLOSED on comments API error in _is_stale_assignment

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -501,33 +501,35 @@ _get_repo_maintainer() {
 #   exit 0 = stale assignment recovered (safe to dispatch)
 #   exit 1 = assignment is NOT stale (genuine active claim, block dispatch)
 #
-# t2061 audit (2026-04-14):
+# GH#18816 design call (2026-04-14): gh comments API failure path decision
 #
 # Error path classification for _is_stale_assignment:
 #
 #   gh api comments fetch failure (network, auth, rate limit):
-#     → comments_json="[]" → last_dispatch_ts="" and last_activity_ts=""
-#     → "No dispatch comment + no recent activity" branch
-#     → _recover_stale_assignment called → return 0 (stale, allow dispatch)
-#     → FAIL-OPEN (conditional): API failure defaults to "stale". The recovery
-#       write calls (_recover_stale_assignment) will also fail when the API is
-#       down, so no actual unassignment occurs, but is_assigned() receives
-#       return 0 and permits dispatch.
-#     → RATIONALE: this guard prevents permanent dispatch deadlock when workers
-#       crash without cleanup. Permanent deadlock (0 dispatches, all issues
-#       blocked forever) is a worse failure mode than a spurious extra dispatch.
-#       The parent-task and GUARD_UNCERTAIN guards (above this in the call chain)
-#       are the critical safety gates; _is_stale_assignment is a deadlock-recovery
-#       mechanism, not a security gate.
+#     → _comments_rc != 0 → return 1 (NOT stale, block dispatch)
+#     → FAIL-CLOSED: API failure cannot determine staleness. Block this cycle;
+#       the stale check fires again next pulse cycle when the API may be available.
+#     → RATIONALE: a transient API failure is not evidence that the assignment is
+#       stale. The production deadlock scenario (GH#15060: 370 issues orphaned) was
+#       caused by runners going OFFLINE — detectable by old timestamps on the NEXT
+#       working pulse cycle, not by comments API failures. Fail-CLOSED delays
+#       recovery by at most one pulse cycle (10 min); it does NOT prevent recovery.
+#       By contrast, fail-OPEN can dispatch a duplicate worker even when the original
+#       worker is actively running (e.g., worker dispatched 2 min ago, comments API
+#       blips, recovery fires, second worker dispatched to an issue with an active
+#       claim). GH#18816 closed this gap.
 #     → CONTEXT: is_assigned() already successfully fetched issue metadata before
 #       calling this function. An API failure here indicates a partial degradation
-#       (comments endpoint failing while the issue endpoint works). Treating the
-#       assignment as stale in this narrow case is the lesser evil.
+#       (comments endpoint failing while the issue endpoint works). "Unknown" is
+#       not "stale" — block until we know.
 #
 #   jq filter failures (test() regex error, type error on filter):
 #     → || last_dispatch_ts="" or || last_activity_ts="" fallbacks
-#     → same behaviour as gh API failure above
-#     → FAIL-OPEN INTENTIONAL: same rationale (deadlock prevention).
+#     → FAIL-OPEN INTENTIONAL: a jq type error on the timestamp extraction does not
+#       mean the dispatch comment does not exist; it means we cannot parse it.
+#       Treating an unreadable timestamp as absent would permanently block recovery
+#       for issues where the comment format changed. The conservative choice here is
+#       to keep the previous semantics (treat as no dispatch comment found).
 #
 #   _ts_to_epoch parse failure:
 #     → returns "0" (explicit echo "0" fallback in _ts_to_epoch)
@@ -535,10 +537,11 @@ _get_repo_maintainer() {
 #     → FAIL-OPEN INTENTIONAL: unreadable timestamp cannot prove recency.
 #       An unreadable dispatch timestamp should not permanently block dispatch.
 #
-# Summary: _is_stale_assignment is a deadlock-recovery function. Its
-# fail-open defaults prevent permanent orphaned-assignment deadlocks at
-# the cost of allowing rare spurious dispatches. This trade-off was
-# deliberately chosen in GH#15060 and GH#17549.
+# Summary: _is_stale_assignment is a deadlock-recovery function. The gh API
+# failure path is now fail-CLOSED (GH#18816) — API failure → block, not recover.
+# jq and timestamp parse failures remain fail-OPEN — these indicate format changes,
+# not absence of activity. This asymmetry is intentional: network unavailability
+# (transient) is distinct from parse errors (structural, affecting all timestamps).
 #######################################
 STALE_ASSIGNMENT_THRESHOLD_SECONDS="${STALE_ASSIGNMENT_THRESHOLD_SECONDS:-${DISPATCH_COMMENT_MAX_AGE:-600}}" # 10 min (GH#17549: aligned with DISPATCH_COMMENT_MAX_AGE; reduced from 30 min — crash recovery was too slow)
 
@@ -551,10 +554,19 @@ _is_stale_assignment() {
 	# overall activity timestamp. Use --paginate to catch all comments
 	# on issues with long histories, but cap with --jq to only extract
 	# what we need (timestamp + body snippet for matching).
-	local comments_json
+	#
+	# GH#18816: fail-CLOSED on API failure. A transient gh error is NOT evidence
+	# that the assignment is stale — block this pulse cycle and retry next cycle.
+	local comments_json _comments_rc=0
 	comments_json=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
 		--jq '[.[] | {created_at: .created_at, author: .user.login, body_start: (.body[:200])}] | sort_by(.created_at) | reverse' \
-		2>/dev/null) || comments_json="[]"
+		2>/dev/null) || _comments_rc=$?
+
+	if [[ "$_comments_rc" -ne 0 ]]; then
+		# Cannot fetch comments — cannot determine staleness. Fail-CLOSED:
+		# keep the existing assignment protection for this pulse cycle.
+		return 1
+	fi
 
 	# Find the most recent dispatch/claim comment
 	# Matches: "Dispatching worker", "DISPATCH_CLAIM", "Worker (PID"

--- a/.agents/scripts/tests/test-dispatch-dedup-fail-closed.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-fail-closed.sh
@@ -94,6 +94,29 @@ STUB
 	chmod +x "${STUB_DIR}/gh"
 }
 
+# write_stub_gh_issue_ok_comments_fail: stub gh that:
+#   - exits 0 for "gh issue view" with a payload containing blocking assignees
+#   - exits 1 for "gh api repos/.../comments" (comments endpoint failure)
+# This simulates the partial API degradation that GH#18816 addresses:
+# issue metadata is fetchable but the comments endpoint is down.
+write_stub_gh_issue_ok_comments_fail() {
+	local payload="$1"
+	cat >"${STUB_DIR}/gh" <<STUB
+#!/usr/bin/env bash
+# Stub: issue view succeeds, comments api fails (GH#18816 test)
+if [[ "\$1" == "issue" && "\$2" == "view" ]]; then
+	printf '%s\n' '${payload}'
+	exit 0
+fi
+if [[ "\$1" == "api" ]]; then
+	# Simulate comments endpoint failure (network error, rate limit, etc.)
+	exit 1
+fi
+exit 1
+STUB
+	chmod +x "${STUB_DIR}/gh"
+}
+
 OLD_PATH="$PATH"
 export PATH="${STUB_DIR}:${PATH}"
 
@@ -189,6 +212,28 @@ if [[ "$rc" -eq 0 && "$output" == *"GUARD_UNCERTAIN"* && "$output" == *"jq-failu
 	print_result "t2061: internal jq failure (assignees extract) → GUARD_UNCERTAIN, exit 0 (block)" 0
 else
 	print_result "t2061: internal jq failure (assignees extract) → GUARD_UNCERTAIN, exit 0 (block)" 1 \
+		"(rc=$rc output='$output')"
+fi
+
+# =============================================================================
+# Case 7 — _is_stale_assignment: comments API failure + blocking assignee
+#           → NOT stale (return 1, block dispatch) (GH#18816)
+# =============================================================================
+# Simulates: issue metadata fetch succeeds (blocking assignee present), but
+# the comments endpoint fails (network error, rate limit, partial degradation).
+# Prior to GH#18816: comments_json="[]" → treated as "no dispatch comment" →
+# stale recovery fired → is_assigned() returned 1 (allow dispatch) — a
+# spurious dispatch even if the original worker was actively running.
+# After GH#18816: fail-CLOSED → is_assigned() returns 0 (ASSIGNED, block).
+# The issue payload includes a non-self, non-owner assignee ("other-runner")
+# without an active claim label so _is_assigned_compute_blocking returns it
+# as blocking, reaching _is_stale_assignment.
+write_stub_gh_issue_ok_comments_fail '{"state":"OPEN","assignees":[{"login":"other-runner"}],"labels":[{"name":"pulse"},{"name":"tier:standard"}]}'
+run_is_assigned 99996 "owner/repo" "self-login"
+if [[ "$rc" -eq 0 && "$output" == *"ASSIGNED"* ]]; then
+	print_result "GH#18816: comments API fail + blocking assignee → ASSIGNED, exit 0 (block)" 0
+else
+	print_result "GH#18816: comments API fail + blocking assignee → ASSIGNED, exit 0 (block)" 1 \
 		"(rc=$rc output='$output')"
 fi
 


### PR DESCRIPTION
## Summary

Resolves #18816

Makes `_is_stale_assignment()` fail-CLOSED when the gh comments API fails, rather than treating API failure as evidence of a stale assignment.

## Design decision (GH#18816)

Three options were considered:

1. **Fail-OPEN** (prior behaviour): API failure → `comments_json="[]"` → no dispatch comment found → stale recovery fires → `is_assigned()` allows dispatch
2. **Fail-CLOSED** (this PR): API failure → `return 1` → `is_assigned()` blocks dispatch for this pulse cycle
3. **Hybrid** (attempt count + timeout): complex, requires cross-cycle state tracking

**Decision: Option 2 — Fail-CLOSED.**

Rationale:
- A transient comments API failure is **not evidence of staleness**. A worker dispatched 2 minutes ago has a legitimate active claim. Fail-OPEN bypasses that claim on a network blip.
- The production deadlock scenario (GH#15060: 370 orphaned issues) was caused by **runners going offline**, not by comments API failures. Runner-offline is detectable by old timestamps on the next working pulse cycle — fail-CLOSED does not prevent recovery, it delays it by at most one pulse cycle (10 min).
- Fail-CLOSED is consistent with `is_assigned()`'s outer guard (GUARD_UNCERTAIN on issue metadata failure). "Unknown" should mean "block", not "allow".

## Changes

- `dispatch-dedup-helper.sh`: capture `_comments_rc` in `_is_stale_assignment()`, return 1 (block) on non-zero exit; update comment block with GH#18816 decision rationale
- `tests/test-dispatch-dedup-fail-closed.sh`: Case 7 — comments API failure with blocking assignee → `ASSIGNED` (block), not stale recovery; adds `write_stub_gh_issue_ok_comments_fail` stub that differentiates `gh issue view` (success) vs `gh api` (failure) calls

## Testing

All 7 tests pass:

```
PASS fail-closed: gh exit non-zero → GUARD_UNCERTAIN, exit 0 (block)
PASS fail-closed: gh empty response → GUARD_UNCERTAIN, exit 0 (block)
PASS fail-closed: parent-task label → PARENT_TASK_BLOCKED preserved
PASS fail-closed: clean issue → exit 1 (allow dispatch, happy path unaffected)
PASS t2061: internal jq failure (parent-task check) → GUARD_UNCERTAIN, exit 0 (block)
PASS t2061: internal jq failure (assignees extract) → GUARD_UNCERTAIN, exit 0 (block)
PASS GH#18816: comments API fail + blocking assignee → ASSIGNED, exit 0 (block)

All 7 tests passed
```

ShellCheck: zero violations on both modified files.