### PR TITLE
GH#18852: fix: include crash_type in fast-fail state update path

### DIFF
--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -1279,8 +1279,12 @@ _fast_fail_write_state() {
 			--arg reason "$reason" \
 			--argjson retry_after "$retry_after" \
 			--argjson backoff_secs "$new_backoff" \
-			'.[$k] = {"count": $count, "ts": $ts, "reason": $reason, "retry_after": $retry_after, "backoff_secs": $backoff_secs}' \
-			"$state_file" 2>/dev/null) || updated_state=""
+			--arg crash_type "${crash_type:-}" \
+			'.[$k] = {"count": $count, "ts": $ts, "reason": $reason, "retry_after": $retry_after, "backoff_secs": $backoff_secs, "crash_type": $crash_type}' \
+			"$state_file") || {
+			echo "Error: Failed to update $state_file" >&2
+			updated_state=""
+		}
 	else
 		updated_state=$(printf '{}' | jq --arg k "$key" \
 			--argjson count "$new_count" \


### PR DESCRIPTION
## Summary

Fixes an inconsistency in `_write_fast_fail_state` where `crash_type` was included when creating a new state file but omitted when updating an existing one. After the first failure, `crash_type` was silently dropped from the recorded state on every subsequent write.

Also removes `2>/dev/null` stderr suppression on the update path and adds a diagnostic error message, consistent with the project's file-operation error-reporting rules.

## Changes

- **EDIT: `.agents/scripts/headless-runtime-lib.sh:1276-1283`** — add `--arg crash_type "${crash_type:-}"` and `"crash_type": $crash_type` to the `if` (update) branch jq expression; replace silent `2>/dev/null` suppression with `|| { echo "Error: Failed to update $state_file" >&2; updated_state=""; }`

## Verification

- `shellcheck .agents/scripts/headless-runtime-lib.sh` — passes with zero violations
- Both the `if` (update existing) and `else` (create new) branches now record `crash_type` consistently

Resolves #18852