### PR TITLE
GH#18854: consolidate triple jq calls into single pass in _ff_parse_entry

### DIFF
--- a/.agents/scripts/pulse-fast-fail.sh
+++ b/.agents/scripts/pulse-fast-fail.sh
@@ -210,9 +210,11 @@ _ff_parse_entry() {
 	local now="$3"
 
 	local existing_ts existing_count existing_backoff
-	existing_ts=$(printf '%s' "$state" | jq -r --arg k "$key" '.[$k].ts // 0' 2>/dev/null) || existing_ts=0
-	existing_count=$(printf '%s' "$state" | jq -r --arg k "$key" '.[$k].count // 0' 2>/dev/null) || existing_count=0
-	existing_backoff=$(printf '%s' "$state" | jq -r --arg k "$key" '.[$k].backoff_secs // 0' 2>/dev/null) || existing_backoff=0
+	IFS=$'\t' read -r existing_ts existing_count existing_backoff < <(
+		printf '%s' "$state" | jq -r --arg k "$key" \
+			'.[$k] // {} | "\(.ts // 0)\t\(.count // 0)\t\(.backoff_secs // 0)"' ||
+			printf '0\t0\t0\n'
+	)
 	[[ "$existing_ts" =~ ^[0-9]+$ ]] || existing_ts=0
 	[[ "$existing_count" =~ ^[0-9]+$ ]] || existing_count=0
 	[[ "$existing_backoff" =~ ^[0-9]+$ ]] || existing_backoff=0


### PR DESCRIPTION
## Summary

Consolidates the three separate `jq` invocations in `_ff_parse_entry` (`.agents/scripts/pulse-fast-fail.sh`) into a single `jq` call, reducing process forks from 3 to 1.

## Change

**Before:** three `jq` subshells, each parsing the same JSON state blob, with stderr suppressed:

```bash
existing_ts=$(printf '%s' "$state" | jq -r --arg k "$key" '.[$k].ts // 0' 2>/dev/null) || existing_ts=0
existing_count=$(printf '%s' "$state" | jq -r --arg k "$key" '.[$k].count // 0' 2>/dev/null) || existing_count=0
existing_backoff=$(printf '%s' "$state" | jq -r --arg k "$key" '.[$k].backoff_secs // 0' 2>/dev/null) || existing_backoff=0
```

**After:** single `jq` call producing a TAB-delimited triple, read in one `IFS` split; stderr now visible:

```bash
IFS=$'\t' read -r existing_ts existing_count existing_backoff < <(
    printf '%s' "$state" | jq -r --arg k "$key" \
        '.[$k] // {} | "\(.ts // 0)\t\(.count // 0)\t\(.backoff_secs // 0)"' ||
        printf '0\t0\t0\n'
)
```

Validation gates (regex normalisation and expiry reset) are unchanged.

## Verification

- `bash -n .agents/scripts/pulse-fast-fail.sh` — syntax OK
- `shellcheck .agents/scripts/pulse-fast-fail.sh` — zero violations

Resolves #18854