### PR TITLE
GH#18899: refactor(claude-proxy): clear Codacy complexity + non-static dispatch findings

### DIFF
--- a/.agents/plugins/opencode-aidevops/claude-proxy-context.mjs
+++ b/.agents/plugins/opencode-aidevops/claude-proxy-context.mjs
@@ -65,6 +65,8 @@ export function getFrameworkPrompt() {
 // Agent file mapping + per-agent prompt cache
 // ---------------------------------------------------------------------------
 
+const AGENTS_DIR = join(homedir(), ".aidevops", "agents");
+
 /**
  * Map of known agent identifiers to their file names in ~/.aidevops/agents/.
  * The proxy selects an agent based on:
@@ -73,7 +75,7 @@ export function getFrameworkPrompt() {
  *      (e.g. `claudecli/seo/opus` → agent="seo")
  *   3. Default: "build-plus" (the primary interactive agent)
  */
-export const AGENT_FILES = {
+export const AGENT_FILES = Object.freeze({
   "build-plus": "build-plus.md",
   "automate": "automate.md",
   "seo": "seo.md",
@@ -81,10 +83,25 @@ export const AGENT_FILES = {
   "research": "research.md",
   "legal": "legal.md",
   "business": "business.md",
-};
+});
+
+/**
+ * Pre-resolved absolute path map. Built once at module load from the static
+ * AGENT_FILES allowlist, so `getAgentPrompt` never feeds user-controlled
+ * input into `path.join` / `fs.readFile` at runtime — the runtime lookup is
+ * a constant-key Map.get on the validated set.
+ */
+const AGENT_FILE_PATHS = new Map(
+  Object.entries(AGENT_FILES).map(([name, fileName]) => [name, join(AGENTS_DIR, fileName)]),
+);
 
 /** @type {Map<string, string>} agent name → cached prompt content */
 const _agentPromptCache = new Map();
+
+/** Resolve an arbitrary input to a known agent name (with fallback). */
+function normaliseAgentName(agentName) {
+  return agentName && AGENT_FILE_PATHS.has(agentName) ? agentName : "build-plus";
+}
 
 /**
  * Load the agent-specific prompt file. Falls back to build-plus.md.
@@ -92,10 +109,10 @@ const _agentPromptCache = new Map();
  * @returns {string}
  */
 export function getAgentPrompt(agentName) {
-  const name = agentName && AGENT_FILES[agentName] ? agentName : "build-plus";
+  const name = normaliseAgentName(agentName);
   if (_agentPromptCache.has(name)) return _agentPromptCache.get(name);
 
-  const filePath = join(homedir(), ".aidevops", "agents", AGENT_FILES[name]);
+  const filePath = AGENT_FILE_PATHS.get(name);
   let content = "";
   try {
     content = readFileSync(filePath, "utf-8").trim();
@@ -117,40 +134,59 @@ export function getAgentPrompt(agentName) {
  *
  * Mirrors the OpenCode pattern: MCPs disabled by default, enabled per-agent.
  */
-const AGENT_MCPS = {
-  "build-plus": ["context7"],
-  "seo": ["context7", "gsc", "dataforseo"],
-  "automate": ["context7"],
-  "content": ["context7"],
-  "research": ["context7"],
-};
+const AGENT_MCPS = new Map([
+  ["build-plus", ["context7"]],
+  ["seo", ["context7", "gsc", "dataforseo"]],
+  ["automate", ["context7"]],
+  ["content", ["context7"]],
+  ["research", ["context7"]],
+]);
 
 /**
  * MCP server definitions in Claude CLI --mcp-config format.
  * Only servers that might be needed per-agent are included here.
  * Claude CLI's global config (~/.claude.json) handles always-on MCPs.
  */
-function getMcpDefinition(name) {
-  const defs = {
-    context7: { command: "npx", args: ["-y", "@upstash/context7-mcp@latest"], type: "stdio" },
-    gsc: {
-      command: "/bin/bash",
-      args: ["-c", "GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS:-~/.config/aidevops/gsc-credentials.json} npx -y mcp-server-gsc"],
-      type: "stdio",
-    },
-    dataforseo: {
-      command: "/bin/bash",
-      args: ["-c", "source ~/.config/aidevops/credentials.sh && DATAFORSEO_USERNAME=$DATAFORSEO_USERNAME DATAFORSEO_PASSWORD=$DATAFORSEO_PASSWORD npx -y dataforseo-mcp-server"],
-      type: "stdio",
-    },
-    shadcn: { command: "npx", args: ["shadcn@latest", "mcp"], type: "stdio" },
-    playwright: { command: "npx", args: ["-y", "@playwright/mcp@latest"], type: "stdio" },
-  };
-  return defs[name] || null;
-}
+const MCP_DEFINITIONS = new Map([
+  ["context7", { command: "npx", args: ["-y", "@upstash/context7-mcp@latest"], type: "stdio" }],
+  ["gsc", {
+    command: "/bin/bash",
+    args: ["-c", "GOOGLE_APPLICATION_CREDENTIALS=${GOOGLE_APPLICATION_CREDENTIALS:-~/.config/aidevops/gsc-credentials.json} npx -y mcp-server-gsc"],
+    type: "stdio",
+  }],
+  ["dataforseo", {
+    command: "/bin/bash",
+    args: ["-c", "source ~/.config/aidevops/credentials.sh && DATAFORSEO_USERNAME=$DATAFORSEO_USERNAME DATAFORSEO_PASSWORD=$DATAFORSEO_PASSWORD npx -y dataforseo-mcp-server"],
+    type: "stdio",
+  }],
+  ["shadcn", { command: "npx", args: ["shadcn@latest", "mcp"], type: "stdio" }],
+  ["playwright", { command: "npx", args: ["-y", "@playwright/mcp@latest"], type: "stdio" }],
+]);
+
+const MCP_CONFIG_DIR = join(homedir(), ".aidevops", ".agent-workspace", "tmp");
+
+/**
+ * Pre-resolved per-agent config-file paths. Built once at module load from
+ * the static AGENT_MCPS allowlist so the runtime never feeds user input
+ * through `path.join` — the lookup is a constant-key Map.get on a
+ * pre-validated key set.
+ */
+const MCP_CONFIG_PATHS = new Map(
+  Array.from(AGENT_MCPS.keys()).map((name) => [name, join(MCP_CONFIG_DIR, `claude-cli-mcp-${name}.json`)]),
+);
 
 /** @type {Map<string, string>} agent name → path to generated MCP config file */
 const _mcpConfigFileCache = new Map();
+
+/** Build the `mcpServers` object for a list of MCP names, dropping unknowns. */
+function collectMcpServers(mcpNames) {
+  const mcpServers = {};
+  for (const mcpName of mcpNames) {
+    const def = MCP_DEFINITIONS.get(mcpName);
+    if (def) mcpServers[mcpName] = def;
+  }
+  return mcpServers;
+}
 
 /**
  * Generate a temporary MCP config JSON file for the given agent.
@@ -159,23 +195,17 @@ const _mcpConfigFileCache = new Map();
  * @returns {string | null}
  */
 export function getMcpConfigForAgent(agentName) {
-  const name = agentName && AGENT_MCPS[agentName] ? agentName : "build-plus";
-  const mcpNames = AGENT_MCPS[name];
+  const name = AGENT_MCPS.has(agentName) ? agentName : "build-plus";
+  const mcpNames = AGENT_MCPS.get(name);
   if (!mcpNames || mcpNames.length === 0) return null;
 
   if (_mcpConfigFileCache.has(name)) return _mcpConfigFileCache.get(name);
 
-  const mcpServers = {};
-  for (const mcpName of mcpNames) {
-    const def = getMcpDefinition(mcpName);
-    if (def) mcpServers[mcpName] = def;
-  }
-
+  const mcpServers = collectMcpServers(mcpNames);
   if (Object.keys(mcpServers).length === 0) return null;
 
-  const configDir = join(homedir(), ".aidevops", ".agent-workspace", "tmp");
-  mkdirSync(configDir, { recursive: true });
-  const configPath = join(configDir, `claude-cli-mcp-${name}.json`);
+  mkdirSync(MCP_CONFIG_DIR, { recursive: true });
+  const configPath = MCP_CONFIG_PATHS.get(name);
   writeFileSync(configPath, JSON.stringify({ mcpServers }, null, 2), "utf-8");
   _mcpConfigFileCache.set(name, configPath);
   console.error(`[aidevops] Claude proxy: generated MCP config for agent=${name} at ${configPath}`);
@@ -241,11 +271,30 @@ export function parseChatMessages(messages) {
 // Agent + model + effort resolution
 // ---------------------------------------------------------------------------
 
-const MODEL_ALIASES = {
-  haiku: "claude-haiku-4-5",
-  sonnet: "claude-sonnet-4-6",
-  opus: "claude-opus-4-6",
-};
+const MODEL_ALIASES = new Map([
+  ["haiku", "claude-haiku-4-5"],
+  ["sonnet", "claude-sonnet-4-6"],
+  ["opus", "claude-opus-4-6"],
+]);
+
+/**
+ * Decode an OpenCode `provider/agent/model` routing string into a
+ * `{ agentName, modelId }` pair. Returns nulls for missing components.
+ * Returns nulls for any non-routing input so the caller can fall through
+ * to header / default resolution.
+ */
+function parseRoutingModelKey(modelKey) {
+  if (typeof modelKey !== "string" || !modelKey.includes("/")) {
+    return { agentName: null, modelId: null };
+  }
+  const parts = modelKey.split("/");
+  const agentCandidate = parts.length >= 2 ? parts[1] : null;
+  const aliasSuffix = parts[parts.length - 1];
+  return {
+    agentName: agentCandidate && AGENT_FILE_PATHS.has(agentCandidate) ? agentCandidate : null,
+    modelId: MODEL_ALIASES.get(aliasSuffix) || null,
+  };
+}
 
 /**
  * Resolve the agent name + concrete model id from an OpenCode request.
@@ -253,19 +302,12 @@ const MODEL_ALIASES = {
  * suffix (e.g. `claudecli/seo/opus` → agent=seo, model=claude-opus-4-6).
  */
 export function resolveAgentAndModel(req, incoming) {
-  let agentName = req.headers.get("x-agent") || null;
-  let resolvedModel = incoming.model;
-
-  if (typeof incoming.model === "string" && incoming.model.includes("/")) {
-    const parts = incoming.model.split("/");
-    if (parts.length >= 2 && AGENT_FILES[parts[1]]) {
-      agentName = agentName || parts[1];
-    }
-    const modelSuffix = parts[parts.length - 1];
-    resolvedModel = MODEL_ALIASES[modelSuffix] || incoming.model;
-  }
-
-  return { agentName: agentName || "build-plus", resolvedModel };
+  const headerAgent = req.headers.get("x-agent") || null;
+  const routed = parseRoutingModelKey(incoming.model);
+  return {
+    agentName: headerAgent || routed.agentName || "build-plus",
+    resolvedModel: routed.modelId || incoming.model,
+  };
 }
 
 /** Extract the OpenAI-style reasoning_effort field if it's a known level. */

--- a/.agents/plugins/opencode-aidevops/claude-proxy-stream.mjs
+++ b/.agents/plugins/opencode-aidevops/claude-proxy-stream.mjs
@@ -44,6 +44,22 @@ export function createOpenAIChunk(id, created, model, delta, finishReason = null
 }
 
 /**
+ * Tool-use input fields included in the status-feed summary, in display
+ * order. Each entry is `{ key, transform? }` — `transform` post-processes
+ * the raw string (e.g. truncation, prefixing). Adding a new tool just means
+ * appending an entry here.
+ */
+const TOOL_INPUT_SUMMARY_FIELDS = [
+  { key: "command" },                                          // Bash
+  { key: "filePath" },                                         // Read / Edit / Write
+  { key: "pattern" },                                          // Glob
+  { key: "regex" },                                            // Grep
+  { key: "description" },                                      // Bash / Task description
+  { key: "prompt", transform: (v) => v.slice(0, 120) },        // Task prompt (truncated)
+  { key: "subagent_type", transform: (v) => `type=${v}` },     // Task subagent type
+];
+
+/**
  * Summarise a tool-use input block into a short single-line label for the
  * status feed. Only the most informative fields are included to keep the
  * stream legible without leaking full prompts.
@@ -51,19 +67,11 @@ export function createOpenAIChunk(id, created, model, delta, finishReason = null
 function summarizeToolInput(input) {
   if (!input || typeof input !== "object") return "";
   const parts = [];
-  // Bash
-  if (typeof input.command === "string") parts.push(input.command);
-  // Read / Edit / Write
-  if (typeof input.filePath === "string") parts.push(input.filePath);
-  // Glob
-  if (typeof input.pattern === "string") parts.push(input.pattern);
-  // Grep
-  if (typeof input.regex === "string") parts.push(input.regex);
-  // Description (Bash, Task)
-  if (typeof input.description === "string") parts.push(input.description);
-  // Task / subagent
-  if (typeof input.prompt === "string") parts.push(input.prompt.slice(0, 120));
-  if (typeof input.subagent_type === "string") parts.push(`type=${input.subagent_type}`);
+  for (const { key, transform } of TOOL_INPUT_SUMMARY_FIELDS) {
+    const raw = input[key];
+    if (typeof raw !== "string") continue;
+    parts.push(transform ? transform(raw) : raw);
+  }
   return parts.filter(Boolean).join(" — ");
 }
 
@@ -168,6 +176,29 @@ function handleSystem(event, ctx) {
   }
 }
 
+/** Extract a printable preview from a tool_use_result payload. */
+function extractToolResultPreview(toolResult) {
+  if (Array.isArray(toolResult.content)) {
+    return toolResult.content.map((item) => item?.text).filter(Boolean).join(" ");
+  }
+  return toolResult.stdout || "";
+}
+
+/** Resolve the tool's friendly name via the dedup map of prior tool_use ids. */
+function resolveToolResultName(event, ctx) {
+  const toolUseId = event.message?.content?.[0]?.tool_use_id;
+  if (toolUseId && ctx.seenToolUseIds.has(toolUseId)) {
+    return ctx.seenToolUseIds.get(toolUseId);
+  }
+  return "unknown";
+}
+
+/** Both the result wrapper and the inner content can flag an error state. */
+function isToolResultError(event, toolResult) {
+  if (toolResult.is_error === true) return true;
+  return event.message?.content?.[0]?.is_error === true;
+}
+
 /**
  * user → tool_use_result preview line. Correlates the tool name via the
  * `tool_use_id` from the message content so the status line reads
@@ -178,15 +209,11 @@ function handleUserToolResult(event, ctx) {
   if (ctx.seenToolResults.has(event.uuid)) return;
   ctx.seenToolResults.add(event.uuid);
 
-  const toolResult = event.tool_use_result;
-  const toolUseId = event.message?.content?.[0]?.tool_use_id;
-  const toolName = (toolUseId && ctx.seenToolUseIds.get(toolUseId)) || "unknown";
-  const isError = toolResult.is_error === true || event.message?.content?.[0]?.is_error === true;
-  const preview = Array.isArray(toolResult.content)
-    ? toolResult.content.map((item) => item?.text).filter(Boolean).join(" ")
-    : (toolResult.stdout || "");
+  const preview = extractToolResultPreview(event.tool_use_result);
   if (!preview) return;
 
+  const toolName = resolveToolResultName(event, ctx);
+  const isError = isToolResultError(event, event.tool_use_result);
   const label = isError ? `Tool error: ${toolName}` : `Tool result: ${toolName}`;
   sendStatusLine(ctx, label, preview.slice(0, 500));
 }
@@ -195,13 +222,17 @@ function handleUserToolResult(event, ctx) {
 // Top-level event dispatcher
 // ---------------------------------------------------------------------------
 
-/** Lookup table: event.type → handler(event, ctx) */
-const EVENT_HANDLERS = {
-  stream_event: handleStreamEvent,
-  assistant: handleAssistant,
-  system: handleSystem,
-  user: handleUserToolResult,
-};
+/**
+ * Lookup table: event.type → handler(event, ctx). Stored as a Map (not a
+ * plain object) so the dispatcher uses safe `.get()` lookup instead of
+ * computed property access on a user-controlled key.
+ */
+const EVENT_HANDLERS = new Map([
+  ["stream_event", handleStreamEvent],
+  ["assistant", handleAssistant],
+  ["system", handleSystem],
+  ["user", handleUserToolResult],
+]);
 
 /**
  * Process a single parsed stream-json event and emit the corresponding
@@ -210,7 +241,8 @@ const EVENT_HANDLERS = {
  * proxy is intentionally permissive about new event types.
  */
 export function processStreamEvent(event, ctx) {
-  const handler = EVENT_HANDLERS[event?.type];
+  if (!event?.type) return;
+  const handler = EVENT_HANDLERS.get(event.type);
   if (handler) handler(event, ctx);
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #18778 (already merged via #18893). After the t2070 decomposition, qlty smells on the new modules dropped to zero but Codacy reported 11 'medium-or-higher' findings (above its ≤ 10 gate). This PR clears the Codacy findings without touching public behaviour.

## Changes

`.agents/plugins/opencode-aidevops/claude-proxy-stream.mjs`:
- `summarizeToolInput`: 7 sequential type checks (cyclomatic 10) → `TOOL_INPUT_SUMMARY_FIELDS` lookup table iterated once (cyclomatic 3). Adding a new tool now means appending a row to the table.
- `handleUserToolResult`: split into `extractToolResultPreview`, `resolveToolResultName`, `isToolResultError`. Parent function drops from cyclomatic 13 to ~5.
- `EVENT_HANDLERS` dispatcher: plain object → `Map`. Dispatcher uses `.get(event.type)` instead of `HANDLERS[event?.type]`. Removes the Codacy 'non-static data into function call' security finding.

`.agents/plugins/opencode-aidevops/claude-proxy-context.mjs`:
- `AGENT_FILES` → `AGENT_FILE_PATHS`: pre-resolved absolute path `Map` built once at module load. `getAgentPrompt` looks up via `Map.get(name)`, eliminating runtime `path.join` with user-controlled input. The validated key set is the only thing that ever reaches `fs.readFile`.
- `AGENT_MCPS` → `MCP_CONFIG_PATHS`: same pattern, second runtime `path.join` injection point removed. `getMcpConfigForAgent` split into `collectMcpServers` helper. Cyclomatic 9 → 5.
- `resolveAgentAndModel`: split into `parseRoutingModelKey` + composer. `MODEL_ALIASES` → `Map`. Cyclomatic 9 → 4.
- `AGENT_FILES` is now `Object.freeze`d.

## Verification

- qlty smells on `claude-proxy-stream.mjs` and `claude-proxy-context.mjs` remain **zero**.
- 14 characterisation assertions pass against the refactored code: `text_delta`, `tool_use` with multi-field input, `tool_use_result` with name lookup, `tool_use_result` error variant, `unknown` event ignored, `null` event ignored, plain model resolution, routed model resolution, routed model with unknown agent, routed model with bogus suffix, header-driven agent, MCP config build-plus path, MCP config unknown→fallback, args minimum.
- Public surface unchanged: `processStreamEvent`, `isCommitTrigger`, `createOpenAIChunk`, `AGENT_FILES`, `getAgentPrompt`, `getMcpConfigForAgent`, `parseChatMessages`, `resolveAgentAndModel`, `resolveEffortLevel`, `buildClaudeArgs`.

## Why a separate PR

The original task #18778 acceptance criteria were qlty-smell based, not Codacy-based, and the parent PR #18893 satisfied them. These changes are quality polish that the parent task didn't require. Splitting them into a separate PR keeps the parent's diff focused on structural decomposition and gives this cleanup its own audit trail.

Resolves #18899


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.24 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 30m and 118,509 tokens on this as a headless worker.