### PR TITLE
GH#18858: restore check_dedup docblock and PID file sentinel protocol

### DIFF
--- a/.agents/scripts/pulse-instance-lock.sh
+++ b/.agents/scripts/pulse-instance-lock.sh
@@ -266,6 +266,16 @@ _handle_running_pulse_pid() {
 	return 1
 }
 
+#######################################
+# Check for stale PID file and clean up
+# Returns: 0 if safe to proceed, 1 if another pulse is genuinely running
+#
+# PID file sentinel protocol (GH#4324):
+#   The PID file is never deleted — only overwritten. Valid states:
+#     <numeric PID>  — a pulse may be running; verify with ps
+#     IDLE:<ts>      — last run completed normally; safe to proceed
+#     empty / other  — treat as safe to proceed (first run or corrupt)
+#######################################
 check_dedup() {
 	if [[ ! -f "$PIDFILE" ]]; then
 		return 0


### PR DESCRIPTION
## Summary

Restores the documentation block that was inadvertently removed from `pulse-instance-lock.sh` in PR #18701. The `check_dedup` function lacked its docblock describing the PID file sentinel protocol (GH#4324), which is critical institutional knowledge for maintainers.

## Change

Added the missing docblock immediately before the `check_dedup` function (line 269), documenting:
- Function purpose and return values
- The PID file sentinel protocol — valid states and their meaning

No logic change. Documentation-only restore.

## Verification

- `shellcheck .agents/scripts/pulse-instance-lock.sh` — passes clean

Resolves #18858