### PR TITLE
GH#18864: fix(build.txt): show full --confidence high|medium|low in memory-helper store example

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -113,7 +113,7 @@ Before non-trivial tasks, restate: (1) actual goal, (2) constraints that must ho
 - If the query returns nothing, proceed — but the cost of checking was still seconds.
 - This recall is independent from the t2046 git/gh discovery pass. Run BOTH. Git tells you about in-flight code; memory tells you about accumulated lessons. They are complementary, not overlapping.
 - Exception: purely conversational exchanges (greetings, status questions, "what does this do") do not require a recall. Any exchange that will result in a file edit, a git operation, a gh command with side effects, or a non-trivial recommendation DOES require one.
-- Store new lessons at the end of any session that produced one. Use `memory-helper.sh store --content "<lesson>" --confidence high` for hard-won insights, medium for likely-general patterns, low for speculative. The store call is cheap; omitting it wastes the lesson.
+- Store new lessons at the end of any session that produced one. Use `memory-helper.sh store --content "<lesson>" --confidence high|medium|low` for hard-won insights, medium for likely-general patterns, low for speculative. The store call is cheap; omitting it wastes the lesson.
 
 # Claim discipline (turn-end gate)
 - Never present future intent as completed work.


### PR DESCRIPTION
## Summary

Fixes an inconsistency in `.agents/prompts/build.txt` where the `memory-helper.sh store` example hard-coded `--confidence high` but the surrounding prose described all three options (high, medium, low). The example now shows `high|medium|low` to make the choice explicit.

## Triage outcome

Two inline suggestions from gemini-code-assist on PR #18698 were assessed:

**`.agents/AGENTS.md:278`** — **Outcome A (Premise falsified).** The bot suggested removing backtick code formatting from the shell command and file reference. The current text already correctly shows `high|medium|low`; removing backtick formatting from a shell command in a Markdown file would make the documentation less readable and inconsistent with the rest of the file. No change made.

**`.agents/prompts/build.txt:116`** — **Outcome B (Premise correct, fix applied).** The example showed `--confidence high` while the surrounding prose mentions `medium` and `low` as valid values. Changed to `--confidence high|medium|low` to match the existing correct form in AGENTS.md and make the option set explicit. Backtick formatting retained (consistent with the file's convention).

## Verification

- `markdownlint-cli2` not applicable (`.txt` file)
- Change is a one-line doc fix; no functional code affected

Resolves #18864

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated guidance for lesson storage confidence level options, now clarifying support for high, medium, and low confidence levels when storing new lessons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->