### PR TITLE
GH#18866: fix(pulse-merge): jq null-fallback and single-pass consolidation

### DIFF
--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -624,7 +624,7 @@ _resolve_pr_mergeable_status() {
 		# Separate local declaration from assignment to preserve exit code (SC2181).
 		local _retry_output _retry_exit
 		_retry_output=$(gh pr view "$pr_number" --repo "$repo_slug" \
-			--json mergeable --jq '.mergeable' 2>/dev/null)
+			--json mergeable --jq '.mergeable // ""')
 		_retry_exit=$?
 		[[ $_retry_exit -eq 0 && -n "$_retry_output" ]] && pr_mergeable="$_retry_output" || pr_mergeable="UNKNOWN"
 		if [[ "$pr_mergeable" == "MERGEABLE" ]]; then
@@ -812,11 +812,11 @@ _process_single_ready_pr() {
 	local pr_obj="$2"
 
 	local pr_number pr_mergeable pr_review pr_author pr_title
-	pr_number=$(printf '%s' "$pr_obj" | jq -r '.number' 2>/dev/null)
-	pr_mergeable=$(printf '%s' "$pr_obj" | jq -r '.mergeable' 2>/dev/null)
-	pr_review=$(printf '%s' "$pr_obj" | jq -r '.reviewDecision // "NONE"' 2>/dev/null)
-	pr_author=$(printf '%s' "$pr_obj" | jq -r '.author.login // "unknown"' 2>/dev/null)
-	pr_title=$(printf '%s' "$pr_obj" | jq -r '.title // ""' 2>/dev/null)
+	# Consolidate into a single jq pass to reduce process-spawn overhead.
+	IFS=$'\t' read -r pr_number pr_mergeable pr_review pr_author pr_title < <(
+		printf '%s' "$pr_obj" | jq -r \
+			'"\(.number // "")\t\(.mergeable // "")\t\(.reviewDecision // "NONE")\t\(.author.login // "unknown")\t\(.title // "")"'
+	)
 
 	[[ "$pr_number" =~ ^[0-9]+$ ]] || return 1
 


### PR DESCRIPTION
## Summary

Address unresolved Gemini review bot feedback from PR #18694 in `pulse-merge.sh`:

- **`_resolve_pr_mergeable_status` (line ~627):** Add `// ""` null fallback to `.mergeable` jq query so a null API response yields an empty string (not the literal string `"null"`), consistent with the project-wide pattern. Remove `2>/dev/null` so `gh` errors surface for debugging.
- **`_process_single_ready_pr` (line ~819):** Consolidate five separate `jq` spawns into a single tab-delimited read, following the GH#18854 pattern established in `pulse-fast-fail.sh`. Remove `2>/dev/null` on the consolidated call.

## Testing

- `shellcheck .agents/scripts/pulse-merge.sh` — zero violations.
- Logic unchanged: existing `[[ "$pr_number" =~ ^[0-9]+$ ]]` guard handles parse failures; `[[ $_retry_exit -eq 0 && -n "$_retry_output" ]]` still handles retry failures.

Resolves #18866


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.24 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 3m and 12,048 tokens on this as a headless worker.