### PR TITLE
t2071: Decompose opencode plugin cluster (cursor/proxy.js, ttsr.mjs, provider-auth.mjs, google-proxy.mjs) — 15 smells incl. cyclomatic 125

### DIFF
--- a/.agents/plugins/opencode-aidevops/cursor-proxy.mjs
+++ b/.agents/plugins/opencode-aidevops/cursor-proxy.mjs
@@ -229,9 +229,9 @@ export function getCursorProxyPort() {
  * @returns {Record<string, object>}
  */
 export function buildCursorProviderModels(models, port) {
-  const entries = {};
-  for (const model of models) {
-    entries[model.id] = {
+  return Object.fromEntries(models.map((model) => [
+    model.id,
+    {
       name: model.name,
       attachment: false,
       tool_call: false,
@@ -239,14 +239,10 @@ export function buildCursorProviderModels(models, port) {
       reasoning: model.reasoning || false,
       modalities: { input: ["text"], output: ["text"] },
       cost: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
-      limit: {
-        context: model.contextWindow || 200000,
-        output: model.maxTokens || 64000,
-      },
+      limit: { context: model.contextWindow || 200000, output: model.maxTokens || 64000 },
       family: "cursor",
-    };
-  }
-  return entries;
+    },
+  ]));
 }
 
 /**

--- a/.agents/plugins/opencode-aidevops/cursor/proxy-bridge.js
+++ b/.agents/plugins/opencode-aidevops/cursor/proxy-bridge.js
@@ -1,0 +1,129 @@
+/**
+ * Bridge spawn / transport utilities for cursor/proxy.js.
+ * Extracted to keep per-file complexity below the threshold.
+ */
+
+import { resolve as pathResolve } from "node:path";
+
+export const CURSOR_API_URL = process.env.CURSOR_API_URL ?? "https://api2.cursor.sh";
+export const CONNECT_END_STREAM_FLAG = 0b00000010;
+export const BRIDGE_PATH = pathResolve(import.meta.dir, "h2-bridge.mjs");
+
+// Tool name alias map (t1553)
+export const TOOL_NAME_ALIASES = new Map([
+  ["runcommand", "bash"], ["executecommand", "bash"], ["runterminalcommand", "bash"],
+  ["terminalcommand", "bash"], ["shellcommand", "bash"], ["shell", "bash"],
+  ["terminal", "bash"], ["bashcommand", "bash"], ["runbash", "bash"],
+  ["executebash", "bash"],
+  ["readfile", "read"], ["getfile", "read"], ["filecontent", "read"],
+  ["readfilecontent", "read"],
+  ["writefile", "write"], ["createfile", "write"], ["savefile", "write"],
+  ["editfile", "edit"], ["modifyfile", "edit"], ["updatefile", "edit"],
+  ["replaceinfile", "edit"],
+  ["searchcontent", "grep"], ["searchcode", "grep"], ["findcontent", "grep"],
+  ["grepfiles", "grep"], ["searchfiles", "grep"],
+  ["findfiles", "glob"], ["globfiles", "glob"], ["fileglob", "glob"],
+  ["matchfiles", "glob"],
+  ["listdirectory", "ls"], ["listfiles", "ls"], ["listdir", "ls"],
+  ["readdir", "ls"],
+]);
+
+/** Resolve a tool name through the alias map. */
+export function resolveToolAlias(name) {
+  if (!name) return name;
+  const lower = name.toLowerCase().replace(/[_\-\s]/g, "");
+  return TOOL_NAME_ALIASES.get(lower) || name;
+}
+
+/** Length-prefix a message: [4-byte BE length][payload] */
+export function lpEncode(data) {
+  const buf = Buffer.alloc(4 + data.length);
+  buf.writeUInt32BE(data.length, 0);
+  buf.set(data, 4);
+  return buf;
+}
+
+/** Connect protocol frame: [1-byte flags][4-byte BE length][payload] */
+export function frameConnectMessage(data, flags = 0) {
+  const frame = Buffer.alloc(5 + data.length);
+  frame[0] = flags;
+  frame.writeUInt32BE(data.length, 1);
+  frame.set(data, 5);
+  return frame;
+}
+
+/** Read length-prefixed frames from the bridge stdout and dispatch to callbacks. */
+export async function readBridgeOutput(proc, cbs) {
+  const reader = proc.stdout.getReader();
+  let pending = Buffer.alloc(0);
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      pending = Buffer.concat([pending, Buffer.from(value)]);
+      while (pending.length >= 4) {
+        const len = pending.readUInt32BE(0);
+        if (pending.length < 4 + len) break;
+        const payload = pending.subarray(4, 4 + len);
+        pending = pending.subarray(4 + len);
+        cbs.data?.(Buffer.from(payload));
+      }
+    }
+  } catch {
+    // Stream ended
+  }
+}
+
+/** Spawn an h2-bridge child process and return a bridge handle. */
+export function spawnBridge(options) {
+  const proc = Bun.spawn(["node", BRIDGE_PATH], {
+    stdin: "pipe", stdout: "pipe", stderr: "ignore",
+  });
+  const config = JSON.stringify({
+    accessToken: options.accessToken,
+    url: options.url ?? CURSOR_API_URL,
+    path: options.rpcPath,
+  });
+  proc.stdin.write(lpEncode(new TextEncoder().encode(config)));
+  const cbs = { data: null, close: null };
+  let exited = false;
+  let exitCode = 1;
+  (async () => {
+    await readBridgeOutput(proc, cbs);
+    const code = await proc.exited ?? 1;
+    exited = true;
+    exitCode = code;
+    cbs.close?.(code);
+  })();
+  return {
+    proc,
+    get alive() { return !exited; },
+    write(data) { try { proc.stdin.write(lpEncode(data)); } catch { } },
+    end() { try { proc.stdin.write(lpEncode(new Uint8Array(0))); proc.stdin.end(); } catch { } },
+    onData(cb) { cbs.data = cb; },
+    onClose(cb) {
+      if (exited) { queueMicrotask(() => cb(exitCode)); }
+      else { cbs.close = cb; }
+    },
+  };
+}
+
+/** Execute a single unary RPC over the bridge and return the response bytes. */
+export async function callCursorUnaryRpc(options) {
+  const bridge = spawnBridge({ accessToken: options.accessToken, rpcPath: options.rpcPath, url: options.url });
+  const chunks = [];
+  const { promise, resolve } = Promise.withResolvers();
+  let timedOut = false;
+  const timeoutMs = options.timeoutMs ?? 5_000;
+  const timeout = timeoutMs > 0
+    ? setTimeout(() => { timedOut = true; try { bridge.proc.kill(); } catch { } }, timeoutMs)
+    : undefined;
+  bridge.onData((chunk) => { chunks.push(Buffer.from(chunk)); });
+  bridge.onClose((exitCode) => {
+    if (timeout) clearTimeout(timeout);
+    resolve({ body: Buffer.concat(chunks), exitCode, timedOut });
+  });
+  bridge.write(frameConnectMessage(options.requestBody));
+  bridge.end();
+  return promise;
+}

--- a/.agents/plugins/opencode-aidevops/cursor/proxy-handlers.js
+++ b/.agents/plugins/opencode-aidevops/cursor/proxy-handlers.js
@@ -1,0 +1,208 @@
+/**
+ * Server message dispatching and exec rejection for cursor/proxy.js.
+ * Extracted to keep per-file complexity below the threshold.
+ */
+
+import { create, toBinary, fromBinary } from "@bufbuild/protobuf";
+import {
+  AgentClientMessageSchema, AgentServerMessageSchema,
+  ExecClientMessageSchema, KvClientMessageSchema,
+  GetBlobResultSchema, SetBlobResultSchema,
+  RequestContextSchema, RequestContextResultSchema, RequestContextSuccessSchema,
+  McpResultSchema, McpSuccessSchema, McpErrorSchema, McpTextContentSchema, McpToolResultContentItemSchema,
+  BackgroundShellSpawnResultSchema, DeleteResultSchema, DeleteRejectedSchema,
+  DiagnosticsResultSchema, FetchErrorSchema, FetchResultSchema,
+  GrepErrorSchema, GrepResultSchema, LsRejectedSchema, LsResultSchema,
+  ReadRejectedSchema, ReadResultSchema, ShellRejectedSchema, ShellResultSchema,
+  WriteRejectedSchema, WriteResultSchema, WriteShellStdinErrorSchema, WriteShellStdinResultSchema,
+  ConversationStateStructureSchema,
+} from "./proto/agent_pb.js";
+import { frameConnectMessage } from "./proxy-bridge.js";
+import { decodeMcpArgsMap } from "./proxy-messages.js";
+import { resolveToolAlias } from "./proxy-bridge.js";
+
+export { AgentServerMessageSchema, ConversationStateStructureSchema };
+
+/** Send an exec client message back to Cursor. */
+export function sendExecResult(execMsg, messageCase, value, sendFrame) {
+  const execClientMessage = create(ExecClientMessageSchema, {
+    id: execMsg.id, execId: execMsg.execId,
+    message: { case: messageCase, value },
+  });
+  const clientMessage = create(AgentClientMessageSchema, {
+    message: { case: "execClientMessage", value: execClientMessage },
+  });
+  sendFrame(frameConnectMessage(toBinary(AgentClientMessageSchema, clientMessage)));
+}
+
+/** Send a KV client response back to Cursor. */
+function sendKvResponse(kvMsg, messageCase, value, sendFrame) {
+  const response = create(KvClientMessageSchema, {
+    id: kvMsg.id, message: { case: messageCase, value },
+  });
+  const clientMsg = create(AgentClientMessageSchema, {
+    message: { case: "kvClientMessage", value: response },
+  });
+  sendFrame(frameConnectMessage(toBinary(AgentClientMessageSchema, clientMsg)));
+}
+
+export function handleInteractionUpdate(update, onText) {
+  const updateCase = update.message?.case;
+  if (updateCase === "textDelta") {
+    const delta = update.message.value.text || "";
+    if (delta) onText(delta, false);
+  } else if (updateCase === "thinkingDelta") {
+    const delta = update.message.value.text || "";
+    if (delta) onText(delta, true);
+  }
+}
+
+export function handleKvMessage(kvMsg, blobStore, sendFrame) {
+  const kvCase = kvMsg.message.case;
+  if (kvCase === "getBlobArgs") {
+    const blobId = kvMsg.message.value.blobId;
+    const blobData = blobStore.get(Buffer.from(blobId).toString("hex"));
+    sendKvResponse(kvMsg, "getBlobResult", create(GetBlobResultSchema, blobData ? { blobData } : {}), sendFrame);
+  } else if (kvCase === "setBlobArgs") {
+    const { blobId, blobData } = kvMsg.message.value;
+    blobStore.set(Buffer.from(blobId).toString("hex"), blobData);
+    sendKvResponse(kvMsg, "setBlobResult", create(SetBlobResultSchema, {}), sendFrame);
+  }
+}
+
+export function handleRequestContext(execMsg, mcpTools, sendFrame) {
+  console.error(`[proxy] requestContextArgs: providing ${mcpTools.length} MCP tools to Cursor`);
+  const requestContext = create(RequestContextSchema, {
+    rules: [], repositoryInfo: [], tools: mcpTools, gitRepos: [],
+    projectLayouts: [], mcpInstructions: [], fileContents: {}, customSubagents: [],
+  });
+  const result = create(RequestContextResultSchema, {
+    result: { case: "success", value: create(RequestContextSuccessSchema, { requestContext }) },
+  });
+  sendExecResult(execMsg, "requestContextResult", result, sendFrame);
+}
+
+export function handleMcpArgs(execMsg, onMcpExec) {
+  const mcpArgs = execMsg.message.value;
+  const decoded = decodeMcpArgsMap(mcpArgs.args ?? {});
+  const rawToolName = mcpArgs.toolName || mcpArgs.name;
+  const resolvedToolName = resolveToolAlias(rawToolName);
+  onMcpExec({
+    execId: execMsg.execId, execMsgId: execMsg.id,
+    toolCallId: mcpArgs.toolCallId || crypto.randomUUID(),
+    toolName: resolvedToolName, decodedArgs: JSON.stringify(decoded),
+  });
+}
+
+const PATH_REJECTIONS = {
+  readArgs:   { resultCase: "readResult",   resultSchema: ReadResultSchema,   rejectedSchema: ReadRejectedSchema },
+  lsArgs:     { resultCase: "lsResult",     resultSchema: LsResultSchema,     rejectedSchema: LsRejectedSchema },
+  writeArgs:  { resultCase: "writeResult",  resultSchema: WriteResultSchema,  rejectedSchema: WriteRejectedSchema },
+  deleteArgs: { resultCase: "deleteResult", resultSchema: DeleteResultSchema, rejectedSchema: DeleteRejectedSchema },
+};
+const SHELL_REJECTIONS = {
+  shellArgs:                { resultCase: "shellResult",                resultSchema: ShellResultSchema },
+  shellStreamArgs:          { resultCase: "shellResult",                resultSchema: ShellResultSchema },
+  backgroundShellSpawnArgs: { resultCase: "backgroundShellSpawnResult", resultSchema: BackgroundShellSpawnResultSchema },
+};
+const ERROR_REJECTIONS = {
+  grepArgs:            { resultCase: "grepResult",           resultSchema: GrepResultSchema,           errorSchema: GrepErrorSchema },
+  writeShellStdinArgs: { resultCase: "writeShellStdinResult", resultSchema: WriteShellStdinResultSchema, errorSchema: WriteShellStdinErrorSchema },
+};
+const MISC_RESULT_CASES = {
+  listMcpResourcesExecArgs: "listMcpResourcesExecResult",
+  readMcpResourceExecArgs:  "readMcpResourceExecResult",
+  recordScreenArgs:         "recordScreenResult",
+  computerUseArgs:          "computerUseResult",
+};
+
+function rejectPathTool(execMsg, schemas, reason, sendFrame) {
+  const args = execMsg.message.value;
+  const result = create(schemas.resultSchema, {
+    result: { case: "rejected", value: create(schemas.rejectedSchema, { path: args.path, reason }) },
+  });
+  sendExecResult(execMsg, schemas.resultCase, result, sendFrame);
+}
+
+function rejectShellTool(execMsg, schemas, reason, sendFrame) {
+  const args = execMsg.message.value;
+  const result = create(schemas.resultSchema, {
+    result: { case: "rejected", value: create(ShellRejectedSchema, {
+      command: args.command ?? "", workingDirectory: args.workingDirectory ?? "",
+      reason, isReadonly: false,
+    })},
+  });
+  sendExecResult(execMsg, schemas.resultCase, result, sendFrame);
+}
+
+function rejectErrorTool(execMsg, schemas, errorFields, sendFrame) {
+  const result = create(schemas.resultSchema, {
+    result: { case: "error", value: create(schemas.errorSchema, errorFields) },
+  });
+  sendExecResult(execMsg, schemas.resultCase, result, sendFrame);
+}
+
+function handleMiscExecRejection(execCase, execMsg, sendFrame, reason) {
+  const errorEntry = ERROR_REJECTIONS[execCase];
+  if (errorEntry) { rejectErrorTool(execMsg, errorEntry, { error: reason }, sendFrame); return true; }
+  if (execCase === "fetchArgs") {
+    const args = execMsg.message.value;
+    rejectErrorTool(execMsg, { resultCase: "fetchResult", resultSchema: FetchResultSchema, errorSchema: FetchErrorSchema }, { url: args.url ?? "", error: reason }, sendFrame);
+    return true;
+  }
+  if (execCase === "diagnosticsArgs") {
+    sendExecResult(execMsg, "diagnosticsResult", create(DiagnosticsResultSchema, {}), sendFrame);
+    return true;
+  }
+  const miscResultCase = MISC_RESULT_CASES[execCase];
+  if (miscResultCase) { sendExecResult(execMsg, miscResultCase, create(McpResultSchema, {}), sendFrame); return true; }
+  return false;
+}
+
+export function rejectNativeCursorTool(execCase, execMsg, sendFrame) {
+  const REJECT_REASON = "Tool not available in this environment. Use the MCP tools provided instead.";
+  const pathEntry = PATH_REJECTIONS[execCase];
+  if (pathEntry) { rejectPathTool(execMsg, pathEntry, REJECT_REASON, sendFrame); return true; }
+  const shellEntry = SHELL_REJECTIONS[execCase];
+  if (shellEntry) { rejectShellTool(execMsg, shellEntry, REJECT_REASON, sendFrame); return true; }
+  return handleMiscExecRejection(execCase, execMsg, sendFrame, REJECT_REASON);
+}
+
+export function processServerMessage(msg, transport, handlers) {
+  const { blobStore, mcpTools, sendFrame } = transport;
+  const { onText, onMcpExec, onCheckpoint } = handlers;
+  const msgCase = msg.message.case;
+  if (msgCase === "interactionUpdate") {
+    handleInteractionUpdate(msg.message.value, onText);
+  } else if (msgCase === "kvServerMessage") {
+    handleKvMessage(msg.message.value, blobStore, sendFrame);
+  } else if (msgCase === "execServerMessage") {
+    handleExecMessage(msg.message.value, mcpTools, sendFrame, onMcpExec);
+  } else if (msgCase === "conversationCheckpointUpdate" && onCheckpoint) {
+    onCheckpoint(toBinary(ConversationStateStructureSchema, msg.message.value));
+  }
+}
+
+export function handleExecMessage(execMsg, mcpTools, sendFrame, onMcpExec) {
+  const execCase = execMsg.message.case;
+  console.error(`[proxy] execMessage: case=${execCase}`);
+  if (execCase === "requestContextArgs") { handleRequestContext(execMsg, mcpTools, sendFrame); return; }
+  if (execCase === "mcpArgs") { handleMcpArgs(execMsg, onMcpExec); return; }
+  if (rejectNativeCursorTool(execCase, execMsg, sendFrame)) return;
+  console.error(`[proxy] unhandled exec: ${execCase}`);
+}
+
+/** Build MCP result messages for tool results to resume a bridge. */
+export function buildMcpResults(pendingExecs, toolResults) {
+  const { McpResultSchema: MRS, McpSuccessSchema: MSS, McpErrorSchema: MES } = { McpResultSchema, McpSuccessSchema, McpErrorSchema };
+  return pendingExecs.map((exec) => {
+    const result = toolResults.find((r) => r.toolCallId === exec.toolCallId);
+    return result
+      ? create(MRS, { result: { case: "success", value: create(MSS, {
+          content: [create(McpToolResultContentItemSchema, {
+            content: { case: "text", value: create(McpTextContentSchema, { text: result.content }) },
+          })], isError: false,
+        })}})
+      : create(MRS, { result: { case: "error", value: create(MES, { error: "Tool result not provided" }) }});
+  });
+}

--- a/.agents/plugins/opencode-aidevops/cursor/proxy-messages.js
+++ b/.agents/plugins/opencode-aidevops/cursor/proxy-messages.js
@@ -1,0 +1,190 @@
+/**
+ * Message parsing, protobuf encoding, and request building for cursor/proxy.js.
+ * Extracted to keep per-file complexity below the threshold.
+ */
+
+import { create, fromBinary, toBinary, toJson, fromJson } from "@bufbuild/protobuf";
+import { ValueSchema } from "@bufbuild/protobuf/wkt";
+import {
+  AgentClientMessageSchema, AgentRunRequestSchema, AgentServerMessageSchema,
+  ClientHeartbeatSchema, ConversationActionSchema, ConversationStateStructureSchema,
+  ConversationStepSchema, AgentConversationTurnStructureSchema,
+  ConversationTurnStructureSchema, AssistantMessageSchema,
+  McpToolDefinitionSchema, ModelDetailsSchema,
+  UserMessageActionSchema, UserMessageSchema,
+} from "./proto/agent_pb.js";
+import { createHash } from "node:crypto";
+import { frameConnectMessage, CONNECT_END_STREAM_FLAG } from "./proxy-bridge.js";
+
+export { AgentServerMessageSchema };
+
+/** Normalize OpenAI message content to a plain string. */
+export function textContent(content) {
+  if (content == null) return "";
+  if (typeof content === "string") return content;
+  return content.filter((p) => p.type === "text" && p.text).map((p) => p.text).join("\n");
+}
+
+/** Parse OpenAI messages array into system/turns/userText/toolResults. */
+export function parseMessages(messages) {
+  let systemPrompt = "You are a helpful assistant.";
+  const pairs = [];
+  const toolResults = [];
+  const systemParts = messages.filter((m) => m.role === "system").map((m) => textContent(m.content));
+  if (systemParts.length > 0) systemPrompt = systemParts.join("\n");
+  const nonSystem = messages.filter((m) => m.role !== "system");
+  let pendingUser = "";
+  for (const msg of nonSystem) {
+    if (msg.role === "tool") {
+      toolResults.push({ toolCallId: msg.tool_call_id ?? "", content: textContent(msg.content) });
+    } else if (msg.role === "user") {
+      if (pendingUser) pairs.push({ userText: pendingUser, assistantText: "" });
+      pendingUser = textContent(msg.content);
+    } else if (msg.role === "assistant") {
+      const text = textContent(msg.content);
+      if (pendingUser) { pairs.push({ userText: pendingUser, assistantText: text }); pendingUser = ""; }
+    }
+  }
+  let lastUserText = "";
+  if (pendingUser) {
+    lastUserText = pendingUser;
+  } else if (pairs.length > 0 && toolResults.length === 0) {
+    const last = pairs.pop();
+    lastUserText = last.userText;
+  }
+  return { systemPrompt, userText: lastUserText, turns: pairs, toolResults };
+}
+
+/** Convert OpenAI tool definitions to Cursor's MCP tool protobuf format. */
+export function buildMcpToolDefinitions(tools) {
+  return tools.map((t) => {
+    const fn = t.function;
+    const jsonSchema = fn.parameters && typeof fn.parameters === "object"
+      ? fn.parameters : { type: "object", properties: {}, required: [] };
+    const inputSchema = toBinary(ValueSchema, fromJson(ValueSchema, jsonSchema));
+    return create(McpToolDefinitionSchema, {
+      name: fn.name, description: fn.description || "",
+      providerIdentifier: "opencode", toolName: fn.name, inputSchema,
+    });
+  });
+}
+
+/** Decode a Cursor MCP arg value (protobuf Value bytes) to a JS value. */
+export function decodeMcpArgValue(value) {
+  try { const parsed = fromBinary(ValueSchema, value); return toJson(ValueSchema, parsed); } catch { }
+  return new TextDecoder().decode(value);
+}
+
+/** Decode a map of MCP arg values. */
+export function decodeMcpArgsMap(args) {
+  const decoded = {};
+  for (const [key, value] of Object.entries(args)) decoded[key] = decodeMcpArgValue(value);
+  return decoded;
+}
+
+/** Encode a single conversation turn (user + optional assistant) to bytes. */
+export function encodeTurn(turn) {
+  const userMsg = create(UserMessageSchema, { text: turn.userText, messageId: crypto.randomUUID() });
+  const userMsgBytes = toBinary(UserMessageSchema, userMsg);
+  const stepBytes = [];
+  if (turn.assistantText) {
+    const step = create(ConversationStepSchema, {
+      message: { case: "assistantMessage", value: create(AssistantMessageSchema, { text: turn.assistantText }) },
+    });
+    stepBytes.push(toBinary(ConversationStepSchema, step));
+  }
+  const agentTurn = create(AgentConversationTurnStructureSchema, { userMessage: userMsgBytes, steps: stepBytes });
+  const turnStructure = create(ConversationTurnStructureSchema, {
+    turn: { case: "agentConversationTurn", value: agentTurn },
+  });
+  return toBinary(ConversationTurnStructureSchema, turnStructure);
+}
+
+/** Build or restore a ConversationStateStructure. */
+export function buildConversationState(turns, systemBlobId, checkpoint) {
+  if (checkpoint) return fromBinary(ConversationStateStructureSchema, checkpoint);
+  return create(ConversationStateStructureSchema, {
+    rootPromptMessagesJson: [systemBlobId], turns: turns.map(encodeTurn),
+    todos: [], pendingToolCalls: [], previousWorkspaceUris: [],
+    fileStates: {}, fileStatesV2: {}, summaryArchives: [], turnTimings: [],
+    subagentStates: {}, selfSummaryCount: 0, readPaths: [],
+  });
+}
+
+/** Build a Cursor AgentRunRequest payload. */
+export function buildCursorRequest(req, ctx) {
+  const { modelId, systemPrompt, userText, turns } = req;
+  const blobStore = new Map(ctx.blobStore ?? []);
+  const systemJson = JSON.stringify({ role: "system", content: systemPrompt });
+  const systemBytes = new TextEncoder().encode(systemJson);
+  const systemBlobId = new Uint8Array(createHash("sha256").update(systemBytes).digest());
+  blobStore.set(Buffer.from(systemBlobId).toString("hex"), systemBytes);
+  const conversationState = buildConversationState(turns, systemBlobId, ctx.checkpoint);
+  const userMessage = create(UserMessageSchema, { text: userText, messageId: crypto.randomUUID() });
+  const action = create(ConversationActionSchema, {
+    action: { case: "userMessageAction", value: create(UserMessageActionSchema, { userMessage }) },
+  });
+  const modelDetails = create(ModelDetailsSchema, { modelId, displayModelId: modelId, displayName: modelId });
+  const runRequest = create(AgentRunRequestSchema, {
+    conversationState, action, modelDetails, conversationId: ctx.conversationId,
+  });
+  const clientMessage = create(AgentClientMessageSchema, {
+    message: { case: "runRequest", value: runRequest },
+  });
+  return { requestBytes: toBinary(AgentClientMessageSchema, clientMessage), blobStore, mcpTools: [] };
+}
+
+/** Derive a stable key to associate a bridge with a conversation. */
+export function deriveBridgeKey(modelId, messages) {
+  const firstUserMsg = messages.find((m) => m.role === "user");
+  const firstUserText = firstUserMsg ? textContent(firstUserMsg.content) : "";
+  return createHash("sha256")
+    .update(`${modelId}:${firstUserText.slice(0, 200)}`)
+    .digest("hex")
+    .slice(0, 16);
+}
+
+/** Parse a Connect end-stream payload for errors. */
+export function parseConnectEndStream(data) {
+  try {
+    const payload = JSON.parse(new TextDecoder().decode(data));
+    const error = payload?.error;
+    if (error) return new Error(`Connect error ${error.code ?? "unknown"}: ${error.message ?? "Unknown error"}`);
+    return null;
+  } catch {
+    return new Error("Failed to parse Connect end stream");
+  }
+}
+
+/** Build a ClientHeartbeat frame for keepalive. */
+export function makeHeartbeatBytes() {
+  const heartbeat = create(AgentClientMessageSchema, {
+    message: { case: "clientHeartbeat", value: create(ClientHeartbeatSchema, {}) },
+  });
+  return frameConnectMessage(toBinary(AgentClientMessageSchema, heartbeat));
+}
+
+/**
+ * Create a stateful parser for Connect protocol frames.
+ * @param {Function} onMessage @param {Function} onEndStream
+ */
+export function createConnectFrameParser(onMessage, onEndStream) {
+  let pending = Buffer.alloc(0);
+  return (incoming) => {
+    pending = Buffer.concat([pending, incoming]);
+    while (pending.length >= 5) {
+      const flags = pending[0];
+      const msgLen = pending.readUInt32BE(1);
+      if (pending.length < 5 + msgLen) break;
+      const messageBytes = pending.subarray(5, 5 + msgLen);
+      pending = pending.subarray(5 + msgLen);
+      if (flags & CONNECT_END_STREAM_FLAG) onEndStream(messageBytes);
+      else onMessage(messageBytes);
+    }
+  };
+}
+
+/** Build OpenAI model list from proxy models array. */
+export function buildOpenAIModelList(models) {
+  return models.map((model) => ({ id: model.id, object: "model", created: 0, owned_by: "cursor" }));
+}

--- a/.agents/plugins/opencode-aidevops/cursor/proxy-sse.js
+++ b/.agents/plugins/opencode-aidevops/cursor/proxy-sse.js
@@ -1,0 +1,93 @@
+/**
+ * Thinking-tag filter and SSE streaming helpers for cursor/proxy.js.
+ * Extracted to keep per-file complexity below the threshold.
+ */
+
+const THINKING_TAG_NAMES = ['think', 'thinking', 'reasoning', 'thought', 'think_intent'];
+const MAX_THINKING_TAG_LEN = 16;
+const THINKING_TAG_RE_SRC = `<(/?)(?:${THINKING_TAG_NAMES.join('|')})\\s*>`;
+
+export const SSE_HEADERS = {
+  "Content-Type": "text/event-stream",
+  "Cache-Control": "no-cache",
+  Connection: "keep-alive",
+};
+
+/**
+ * Scan a string for thinking-tag boundaries.
+ * @param {string} input @param {boolean} initialInThinking
+ */
+export function classifyTagSections(input, initialInThinking) {
+  let content = '';
+  let reasoning = '';
+  let lastIdx = 0;
+  let inThinking = initialInThinking;
+  const re = new RegExp(THINKING_TAG_RE_SRC, 'gi');
+  let match;
+  while ((match = re.exec(input)) !== null) {
+    const before = input.slice(lastIdx, match.index);
+    if (inThinking) reasoning += before;
+    else content += before;
+    inThinking = match[1] !== '/';
+    lastIdx = re.lastIndex;
+  }
+  return { content, reasoning, rest: input.slice(lastIdx), inThinking };
+}
+
+/**
+ * Check whether the trailing portion of a string looks like a partial thinking tag.
+ * @param {string} rest
+ */
+export function checkForPartialTag(rest) {
+  const ltPos = rest.lastIndexOf('<');
+  if (ltPos >= 0 && rest.length - ltPos < MAX_THINKING_TAG_LEN && /^<\/?[a-z_]*$/i.test(rest.slice(ltPos))) {
+    return { buffer: rest.slice(ltPos), before: rest.slice(0, ltPos) };
+  }
+  return { buffer: '', before: rest };
+}
+
+/** Create a stateful thinking-tag filter for streamed text. */
+export function createThinkingTagFilter() {
+  let buffer = '';
+  let inThinking = false;
+  return {
+    process(text) {
+      const input = buffer + text;
+      buffer = '';
+      const sections = classifyTagSections(input, inThinking);
+      inThinking = sections.inThinking;
+      const { buffer: newBuf, before } = checkForPartialTag(sections.rest);
+      buffer = newBuf;
+      const content = sections.content + (inThinking ? '' : before);
+      const reasoning = sections.reasoning + (inThinking ? before : '');
+      return { content, reasoning };
+    },
+    flush() {
+      const b = buffer;
+      buffer = '';
+      if (!b) return { content: '', reasoning: '' };
+      return inThinking ? { content: '', reasoning: b } : { content: b, reasoning: '' };
+    },
+  };
+}
+
+/** Build SSE sender helpers bound to a ReadableStream controller. */
+export function createSSESenders(controller, completionId, created, modelId) {
+  const encoder = new TextEncoder();
+  let closed = false;
+  const sendSSE = (data) => { if (!closed) controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`)); };
+  const sendDone = () => { if (!closed) controller.enqueue(encoder.encode("data: [DONE]\n\n")); };
+  const closeController = () => { if (!closed) { closed = true; controller.close(); } };
+  const makeChunk = (delta, finishReason = null) => ({
+    id: completionId, object: "chat.completion.chunk", created, model: modelId,
+    choices: [{ index: 0, delta, finish_reason: finishReason }],
+  });
+  return { sendSSE, sendDone, closeController, makeChunk };
+}
+
+/** Flush tag filter and send any buffered reasoning/content as SSE. */
+export function flushTagFilterToSSE(tagFilter, makeChunk, sendSSE) {
+  const flushed = tagFilter.flush();
+  if (flushed.reasoning) sendSSE(makeChunk({ reasoning_content: flushed.reasoning }));
+  if (flushed.content) sendSSE(makeChunk({ content: flushed.content }));
+}

--- a/.agents/plugins/opencode-aidevops/cursor/proxy-stream.js
+++ b/.agents/plugins/opencode-aidevops/cursor/proxy-stream.js
@@ -1,0 +1,180 @@
+/**
+ * Bridge streaming and response collection for cursor/proxy.js.
+ * Extracted to keep per-file complexity below the threshold.
+ */
+
+import { create, fromBinary, toBinary } from "@bufbuild/protobuf";
+import {
+  AgentClientMessageSchema, AgentServerMessageSchema, ExecClientMessageSchema,
+  McpResultSchema, McpSuccessSchema, McpErrorSchema, McpTextContentSchema, McpToolResultContentItemSchema,
+  ConversationStateStructureSchema,
+} from "./proto/agent_pb.js";
+import { frameConnectMessage } from "./proxy-bridge.js";
+import { processServerMessage } from "./proxy-handlers.js";
+import { createConnectFrameParser, makeHeartbeatBytes, parseConnectEndStream } from "./proxy-messages.js";
+import { createThinkingTagFilter, createSSESenders, flushTagFilterToSSE, SSE_HEADERS } from "./proxy-sse.js";
+
+/** Merge blobStore entries into stored conversation state. */
+export function mergeBlobStoreIntoState(bridgeKey, blobStore, conversationStates) {
+  const stored = conversationStates.get(bridgeKey);
+  if (stored) {
+    for (const [k, v] of blobStore) stored.blobStore.set(k, v);
+    stored.lastAccessMs = Date.now();
+  }
+}
+
+/** Spawn a bridge, send initial request frame, and start heartbeat. */
+export function startBridge(accessToken, requestBytes, spawnBridgeFn) {
+  const bridge = spawnBridgeFn({ accessToken, rpcPath: "/agent.v1.AgentService/Run" });
+  bridge.write(frameConnectMessage(requestBytes));
+  const heartbeatTimer = setInterval(() => bridge.write(makeHeartbeatBytes()), 5_000);
+  return { bridge, heartbeatTimer };
+}
+
+/**
+ * Create an SSE streaming Response that reads from a live bridge.
+ * @param {{ bridge, heartbeatTimer, blobStore, mcpTools }} bridgeCtx
+ * @param {string} modelId
+ * @param {string} bridgeKey
+ * @param {{ conversationStates: Map, activeBridges: Map }} proxyState
+ */
+export function createBridgeStreamResponse(bridgeCtx, modelId, bridgeKey, proxyState) {
+  const { bridge, heartbeatTimer, blobStore, mcpTools } = bridgeCtx;
+  const completionId = `chatcmpl-${crypto.randomUUID().replace(/-/g, "").slice(0, 28)}`;
+  const created = Math.floor(Date.now() / 1000);
+  const stream = new ReadableStream({
+    start(controller) {
+      const { sendSSE, sendDone, closeController, makeChunk } = createSSESenders(controller, completionId, created, modelId);
+      const state = { toolCallIndex: 0, pendingExecs: [] };
+      const tagFilter = createThinkingTagFilter();
+      let mcpExecReceived = false;
+      const processChunk = createConnectFrameParser((messageBytes) => {
+        try {
+          const serverMessage = fromBinary(AgentServerMessageSchema, messageBytes);
+          processServerMessage(serverMessage, { blobStore, mcpTools, sendFrame: (data) => bridge.write(data) }, {
+            onText(text, isThinking) {
+              if (isThinking) { sendSSE(makeChunk({ reasoning_content: text })); return; }
+              const { content, reasoning } = tagFilter.process(text);
+              if (reasoning) sendSSE(makeChunk({ reasoning_content: reasoning }));
+              if (content) sendSSE(makeChunk({ content }));
+            },
+            onMcpExec(exec) {
+              state.pendingExecs.push(exec);
+              mcpExecReceived = true;
+              flushTagFilterToSSE(tagFilter, makeChunk, sendSSE);
+              const toolCallIndex = state.toolCallIndex++;
+              sendSSE(makeChunk({ tool_calls: [{ index: toolCallIndex, id: exec.toolCallId, type: "function", function: { name: exec.toolName, arguments: exec.decodedArgs } }] }));
+              proxyState.activeBridges.set(bridgeKey, { bridge, heartbeatTimer, blobStore, mcpTools, pendingExecs: state.pendingExecs });
+              sendSSE(makeChunk({}, "tool_calls"));
+              sendDone();
+              closeController();
+            },
+            onCheckpoint(checkpointBytes) {
+              const stored = proxyState.conversationStates.get(bridgeKey);
+              if (stored) { stored.checkpoint = checkpointBytes; stored.lastAccessMs = Date.now(); }
+            },
+          });
+        } catch { /* Skip unparseable messages */ }
+      }, (endStreamBytes) => {
+        const endError = parseConnectEndStream(endStreamBytes);
+        if (endError) sendSSE(makeChunk({ content: `\n[Error: ${endError.message}]` }));
+      });
+      bridge.onData(processChunk);
+      bridge.onClose((code) => {
+        clearInterval(heartbeatTimer);
+        mergeBlobStoreIntoState(bridgeKey, blobStore, proxyState.conversationStates);
+        if (!mcpExecReceived) {
+          flushTagFilterToSSE(tagFilter, makeChunk, sendSSE);
+          sendSSE(makeChunk({}, "stop"));
+          sendDone();
+          closeController();
+        } else if (code !== 0) {
+          sendSSE(makeChunk({ content: "\n[Error: bridge connection lost]" }));
+          sendSSE(makeChunk({}, "stop"));
+          sendDone();
+          closeController();
+          proxyState.activeBridges.delete(bridgeKey);
+        }
+      });
+    },
+  });
+  return new Response(stream, { headers: SSE_HEADERS });
+}
+
+/** Resume a paused bridge by sending MCP results and continuing to stream. */
+export function handleToolResultResume(active, toolResults, modelId, bridgeKey, proxyState) {
+  const { bridge, heartbeatTimer, blobStore, mcpTools, pendingExecs } = active;
+  for (const exec of pendingExecs) {
+    const result = toolResults.find((r) => r.toolCallId === exec.toolCallId);
+    const mcpResult = result
+      ? create(McpResultSchema, { result: { case: "success", value: create(McpSuccessSchema, {
+          content: [create(McpToolResultContentItemSchema, { content: { case: "text", value: create(McpTextContentSchema, { text: result.content }) } })],
+          isError: false,
+        })}})
+      : create(McpResultSchema, { result: { case: "error", value: create(McpErrorSchema, { error: "Tool result not provided" }) }});
+    const execClientMessage = create(ExecClientMessageSchema, {
+      id: exec.execMsgId, execId: exec.execId,
+      message: { case: "mcpResult", value: mcpResult },
+    });
+    const clientMessage = create(AgentClientMessageSchema, { message: { case: "execClientMessage", value: execClientMessage } });
+    bridge.write(frameConnectMessage(toBinary(AgentClientMessageSchema, clientMessage)));
+  }
+  return createBridgeStreamResponse({ bridge, heartbeatTimer, blobStore, mcpTools }, modelId, bridgeKey, proxyState);
+}
+
+/** Handle a tool call exec during non-streaming response collection. */
+export function handleNonStreamToolCall(exec, bridgeCtx, collectCtx) {
+  const { bridge, heartbeatTimer, payload, bridgeKey, proxyState } = bridgeCtx;
+  const { state, tagFilter, fullTextRef, resolve } = collectCtx;
+  state.pendingExecs.push(exec);
+  const flushed = tagFilter.flush();
+  fullTextRef.value += flushed.content;
+  state.toolCallIndex++;
+  const toolCalls = [{ id: exec.toolCallId, type: "function", function: { name: exec.toolName, arguments: exec.decodedArgs } }];
+  proxyState.activeBridges.set(bridgeKey, {
+    bridge, heartbeatTimer, blobStore: payload.blobStore, mcpTools: payload.mcpTools, pendingExecs: state.pendingExecs,
+  });
+  resolve({ text: fullTextRef.value, toolCalls });
+}
+
+/** Collect a full (non-streaming) response from the bridge. */
+export async function collectFullResponse(payload, accessToken, bridgeKey, proxyState, spawnBridgeFn) {
+  const { promise, resolve } = Promise.withResolvers();
+  const fullTextRef = { value: "" };
+  let resolved = false;
+  const { bridge, heartbeatTimer } = startBridge(accessToken, payload.requestBytes, spawnBridgeFn);
+  const state = { toolCallIndex: 0, pendingExecs: [] };
+  const tagFilter = createThinkingTagFilter();
+  bridge.onData(createConnectFrameParser((messageBytes) => {
+    try {
+      const serverMessage = fromBinary(AgentServerMessageSchema, messageBytes);
+      processServerMessage(serverMessage, { blobStore: payload.blobStore, mcpTools: payload.mcpTools, sendFrame: (data) => bridge.write(data) }, {
+        onText(text, isThinking) {
+          if (isThinking) return;
+          const { content } = tagFilter.process(text);
+          fullTextRef.value += content;
+        },
+        onMcpExec(exec) {
+          if (resolved) return;
+          resolved = true;
+          handleNonStreamToolCall(exec, { bridge, heartbeatTimer, payload, bridgeKey, proxyState }, { state, tagFilter, fullTextRef, resolve });
+        },
+        onCheckpoint(checkpointBytes) {
+          const stored = proxyState.conversationStates.get(bridgeKey);
+          if (stored) { stored.checkpoint = checkpointBytes; stored.lastAccessMs = Date.now(); }
+        },
+      });
+    } catch { /* Skip */ }
+  }, () => { }));
+  bridge.onClose(() => {
+    clearInterval(heartbeatTimer);
+    mergeBlobStoreIntoState(bridgeKey, payload.blobStore, proxyState.conversationStates);
+    if (!resolved) {
+      resolved = true;
+      const flushed = tagFilter.flush();
+      fullTextRef.value += flushed.content;
+      resolve({ text: fullTextRef.value, toolCalls: null });
+    }
+  });
+  return promise;
+}

--- a/.agents/plugins/opencode-aidevops/cursor/proxy.js
+++ b/.agents/plugins/opencode-aidevops/cursor/proxy.js
@@ -1,1245 +1,181 @@
 /**
  * Local OpenAI-compatible proxy that translates requests to Cursor's gRPC protocol.
  *
- * Accepts POST /v1/chat/completions in OpenAI format, translates to Cursor's
- * protobuf/HTTP2 Connect protocol, and streams back OpenAI-format SSE.
- *
- * Tool calling uses Cursor's native MCP tool protocol:
- * - OpenAI tool defs → McpToolDefinition in RequestContext
- * - Cursor toolCallStarted/Delta/Completed → OpenAI tool_calls SSE chunks
- * - mcpArgs exec → pause stream, return tool_calls to caller
- * - Follow-up request with tool results → resume bridge with mcpResult
- *
- * HTTP/2 transport is delegated to a Node child process (h2-bridge.mjs)
- * because Bun's node:http2 module is broken.
+ * Implementation is split across sibling files for complexity management:
+ *   proxy-bridge.js   — bridge spawn, frame encoding, tool alias resolution
+ *   proxy-messages.js — protobuf message building, request parsing, frame parsing
+ *   proxy-handlers.js — server message dispatching, exec rejection
+ *   proxy-sse.js      — thinking-tag filter, SSE sender helpers
+ *   proxy-stream.js   — bridge streaming, response collection
  */
-import { create, fromBinary, fromJson, toBinary, toJson } from "@bufbuild/protobuf";
-import { ValueSchema } from "@bufbuild/protobuf/wkt";
-import { AgentClientMessageSchema, AgentRunRequestSchema, AgentServerMessageSchema, ClientHeartbeatSchema, ConversationActionSchema, ConversationStateStructureSchema, ConversationStepSchema, AgentConversationTurnStructureSchema, ConversationTurnStructureSchema, AssistantMessageSchema, BackgroundShellSpawnResultSchema, DeleteResultSchema, DeleteRejectedSchema, DiagnosticsResultSchema, ExecClientMessageSchema, FetchErrorSchema, FetchResultSchema, GetBlobResultSchema, GrepErrorSchema, GrepResultSchema, KvClientMessageSchema, LsRejectedSchema, LsResultSchema, McpErrorSchema, McpResultSchema, McpSuccessSchema, McpTextContentSchema, McpToolDefinitionSchema, McpToolResultContentItemSchema, ModelDetailsSchema, ReadRejectedSchema, ReadResultSchema, RequestContextResultSchema, RequestContextSchema, RequestContextSuccessSchema, SetBlobResultSchema, ShellRejectedSchema, ShellResultSchema, UserMessageActionSchema, UserMessageSchema, WriteRejectedSchema, WriteResultSchema, WriteShellStdinErrorSchema, WriteShellStdinResultSchema, } from "./proto/agent_pb.js";
-import { createHash } from "node:crypto";
-import { resolve as pathResolve } from "node:path";
-const CURSOR_API_URL = process.env.CURSOR_API_URL ?? "https://api2.cursor.sh";
-const CONNECT_END_STREAM_FLAG = 0b00000010;
-const BRIDGE_PATH = pathResolve(import.meta.dir, "h2-bridge.mjs");
-const SSE_HEADERS = {
-    "Content-Type": "text/event-stream",
-    "Cache-Control": "no-cache",
-    Connection: "keep-alive",
-};
-// Active bridges keyed by a session token (derived from conversation state).
-// When tool_calls are returned, the bridge stays alive. The next request
-// with tool results looks up the bridge and sends mcpResult messages.
+import { callCursorUnaryRpc, spawnBridge } from "./proxy-bridge.js";
+import {
+  buildCursorRequest, parseMessages, deriveBridgeKey, buildOpenAIModelList,
+} from "./proxy-messages.js";
+import {
+  createBridgeStreamResponse, startBridge, handleToolResultResume, collectFullResponse,
+} from "./proxy-stream.js";
+
+export { callCursorUnaryRpc };
+
+const CONVERSATION_TTL_MS = 30 * 60 * 1000;
+const MAX_TOOL_ROUNDS = 25;
+
+// Shared mutable state for session/bridge management.
 const activeBridges = new Map();
 const conversationStates = new Map();
-const CONVERSATION_TTL_MS = 30 * 60 * 1000; // 30 minutes
-// Tool loop guard (t1553) — prevent infinite tool call loops.
-// If a conversation exceeds this many tool call rounds, the proxy stops
-// forwarding tools and lets the model generate a text-only response.
-const MAX_TOOL_ROUNDS = 25;
-// Tool name alias map (t1553) — Cursor models may use variant names for tools.
-// Ported from Nomadcxx/opencode-cursor src/proxy/tool-loop.ts TOOL_NAME_ALIASES.
-// Keys are lowercased; values are the canonical OpenCode tool names.
-const TOOL_NAME_ALIASES = new Map([
-    // bash aliases
-    ["runcommand", "bash"], ["executecommand", "bash"], ["runterminalcommand", "bash"],
-    ["terminalcommand", "bash"], ["shellcommand", "bash"], ["shell", "bash"],
-    ["terminal", "bash"], ["bashcommand", "bash"], ["runbash", "bash"],
-    ["executebash", "bash"],
-    // read aliases
-    ["readfile", "read"], ["getfile", "read"], ["filecontent", "read"],
-    ["readfilecontent", "read"],
-    // write aliases
-    ["writefile", "write"], ["createfile", "write"], ["savefile", "write"],
-    // edit aliases
-    ["editfile", "edit"], ["modifyfile", "edit"], ["updatefile", "edit"],
-    ["replaceinfile", "edit"],
-    // grep aliases
-    ["searchcontent", "grep"], ["searchcode", "grep"], ["findcontent", "grep"],
-    ["grepfiles", "grep"], ["searchfiles", "grep"],
-    // glob aliases
-    ["findfiles", "glob"], ["globfiles", "glob"], ["fileglob", "glob"],
-    ["matchfiles", "glob"],
-    // ls aliases
-    ["listdirectory", "ls"], ["listfiles", "ls"], ["listdir", "ls"],
-    ["readdir", "ls"],
-]);
-/**
- * Resolve a tool name through the alias map.
- * Returns the canonical name if an alias matches, otherwise the original name.
- * @param {string} name - Tool name from Cursor's response
- * @returns {string} Resolved canonical tool name
- */
-function resolveToolAlias(name) {
-    if (!name) return name;
-    const lower = name.toLowerCase().replace(/[_\-\s]/g, "");
-    return TOOL_NAME_ALIASES.get(lower) || name;
-}
-function evictStaleConversations() {
-    const now = Date.now();
-    for (const [key, stored] of conversationStates) {
-        if (now - stored.lastAccessMs > CONVERSATION_TTL_MS) {
-            conversationStates.delete(key);
-        }
-    }
-}
-/** Length-prefix a message: [4-byte BE length][payload] */
-function lpEncode(data) {
-    const buf = Buffer.alloc(4 + data.length);
-    buf.writeUInt32BE(data.length, 0);
-    buf.set(data, 4);
-    return buf;
-}
-/** Connect protocol frame: [1-byte flags][4-byte BE length][payload] */
-function frameConnectMessage(data, flags = 0) {
-    const frame = Buffer.alloc(5 + data.length);
-    frame[0] = flags;
-    frame.writeUInt32BE(data.length, 1);
-    frame.set(data, 5);
-    return frame;
-}
-/** Read length-prefixed frames from the bridge stdout and dispatch to callbacks. */
-async function readBridgeOutput(proc, cbs) {
-    const reader = proc.stdout.getReader();
-    let pending = Buffer.alloc(0);
-    try {
-        while (true) {
-            const { done, value } = await reader.read();
-            if (done)
-                break;
-            pending = Buffer.concat([pending, Buffer.from(value)]);
-            while (pending.length >= 4) {
-                const len = pending.readUInt32BE(0);
-                if (pending.length < 4 + len)
-                    break;
-                const payload = pending.subarray(4, 4 + len);
-                pending = pending.subarray(4 + len);
-                cbs.data?.(Buffer.from(payload));
-            }
-        }
-    }
-    catch {
-        // Stream ended
-    }
-}
-function spawnBridge(options) {
-    const proc = Bun.spawn(["node", BRIDGE_PATH], {
-        stdin: "pipe",
-        stdout: "pipe",
-        stderr: "ignore",
-    });
-    const config = JSON.stringify({
-        accessToken: options.accessToken,
-        url: options.url ?? CURSOR_API_URL,
-        path: options.rpcPath,
-    });
-    proc.stdin.write(lpEncode(new TextEncoder().encode(config)));
-    const cbs = {
-        data: null,
-        close: null,
-    };
-    // Track exit state so late onClose registrations fire immediately.
-    let exited = false;
-    let exitCode = 1;
-    (async () => {
-        await readBridgeOutput(proc, cbs);
-        const code = await proc.exited ?? 1;
-        exited = true;
-        exitCode = code;
-        cbs.close?.(code);
-    })();
-    return {
-        proc,
-        get alive() { return !exited; },
-        write(data) {
-            try {
-                proc.stdin.write(lpEncode(data));
-            }
-            catch { }
-        },
-        end() {
-            try {
-                proc.stdin.write(lpEncode(new Uint8Array(0)));
-                proc.stdin.end();
-            }
-            catch { }
-        },
-        onData(cb) { cbs.data = cb; },
-        onClose(cb) {
-            if (exited) {
-                // Process already exited — invoke immediately so streams don't hang.
-                queueMicrotask(() => cb(exitCode));
-            }
-            else {
-                cbs.close = cb;
-            }
-        },
-    };
-}
-export async function callCursorUnaryRpc(options) {
-    const bridge = spawnBridge({
-        accessToken: options.accessToken,
-        rpcPath: options.rpcPath,
-        url: options.url,
-    });
-    const chunks = [];
-    const { promise, resolve } = Promise.withResolvers();
-    let timedOut = false;
-    const timeoutMs = options.timeoutMs ?? 5_000;
-    const timeout = timeoutMs > 0
-        ? setTimeout(() => {
-            timedOut = true;
-            try {
-                bridge.proc.kill();
-            }
-            catch { }
-        }, timeoutMs)
-        : undefined;
-    bridge.onData((chunk) => {
-        chunks.push(Buffer.from(chunk));
-    });
-    bridge.onClose((exitCode) => {
-        if (timeout)
-            clearTimeout(timeout);
-        resolve({
-            body: Buffer.concat(chunks),
-            exitCode,
-            timedOut,
-        });
-    });
-    bridge.write(frameConnectMessage(options.requestBody));
-    bridge.end();
-    return promise;
-}
+const proxyState = { activeBridges, conversationStates };
+
 let proxyServer;
 let proxyPort;
 let proxyAccessTokenProvider;
 let proxyModels = [];
-function buildOpenAIModelList(models) {
-    return models.map((model) => ({
-        id: model.id,
-        object: "model",
-        created: 0,
-        owned_by: "cursor",
-    }));
+
+function evictStaleConversations() {
+  const now = Date.now();
+  for (const [key, stored] of conversationStates) {
+    if (now - stored.lastAccessMs > CONVERSATION_TTL_MS) conversationStates.delete(key);
+  }
 }
-export function getProxyPort() {
-    return proxyPort;
-}
-export async function startProxy(getAccessToken, models = []) {
-    proxyAccessTokenProvider = getAccessToken;
-    proxyModels = models.map((model) => ({
-        id: model.id,
-        name: model.name,
-    }));
-    if (proxyServer && proxyPort)
-        return proxyPort;
-    // Clear stale conversation states from previous sessions (t1553).
-    // Stale checkpoints reference blobs that Cursor's server has evicted,
-    // causing "Blob not found" errors on the first request.
-    conversationStates.clear();
-    activeBridges.clear();
-    proxyServer = Bun.serve({
-        port: parseInt(process.env.CURSOR_PROXY_PORT || "32123", 10),
-        idleTimeout: 255, // max — Cursor responses can take 30s+
-        async fetch(req) {
-            const url = new URL(req.url);
-            if (req.method === "GET" && url.pathname === "/v1/models") {
-                return new Response(JSON.stringify({
-                    object: "list",
-                    data: buildOpenAIModelList(proxyModels),
-                }), { headers: { "Content-Type": "application/json" } });
-            }
-            if (req.method === "POST" && url.pathname === "/v1/chat/completions") {
-                try {
-                    const body = (await req.json());
-                    if (!proxyAccessTokenProvider) {
-                        throw new Error("Cursor proxy access token provider not configured");
-                    }
-                    const accessToken = await proxyAccessTokenProvider();
-                    return handleChatCompletion(body, accessToken);
-                }
-                catch (err) {
-                    const message = err instanceof Error ? err.message : String(err);
-                    return new Response(JSON.stringify({
-                        error: { message, type: "server_error", code: "internal_error" },
-                    }), { status: 500, headers: { "Content-Type": "application/json" } });
-                }
-            }
-            return new Response("Not Found", { status: 404 });
-        },
-    });
-    proxyPort = proxyServer.port;
-    if (!proxyPort)
-        throw new Error("Failed to bind proxy to a port");
-    return proxyPort;
-}
-export function stopProxy() {
-    if (proxyServer) {
-        proxyServer.stop();
-        proxyServer = undefined;
-        proxyPort = undefined;
-        proxyAccessTokenProvider = undefined;
-        proxyModels = [];
-    }
-    // Clean up any lingering bridges
-    for (const active of activeBridges.values()) {
-        clearInterval(active.heartbeatTimer);
-        active.bridge.end();
-    }
-    activeBridges.clear();
-    conversationStates.clear();
-}
-/**
- * Try to resume an active bridge with tool results.
- * Returns a Response if the bridge was successfully resumed, or null if
- * the caller should fall through to start a fresh bridge.
- */
+
 function tryResumeBridge(bridgeKey, activeBridge, toolResults, modelId) {
-    activeBridges.delete(bridgeKey);
-    // Tool loop guard (t1553): increment round counter for resume path.
-    const resumeState = conversationStates.get(bridgeKey);
-    if (resumeState) {
-        resumeState.toolRounds = (resumeState.toolRounds || 0) + 1;
-    }
-    const loopGuardTripped = resumeState && resumeState.toolRounds >= MAX_TOOL_ROUNDS;
-    if (loopGuardTripped) {
-        console.error(`[proxy] Tool loop guard: conversation ${bridgeKey} exceeded ${MAX_TOOL_ROUNDS} tool rounds on resume, killing bridge`);
-    }
-    if (!loopGuardTripped && activeBridge.bridge.alive) {
-        return handleToolResultResume(activeBridge, toolResults, modelId, bridgeKey);
-    }
-    // Bridge died, or loop guard tripped — clean up and fall through.
+  activeBridges.delete(bridgeKey);
+  const resumeState = conversationStates.get(bridgeKey);
+  if (resumeState) resumeState.toolRounds = (resumeState.toolRounds || 0) + 1;
+  const loopGuardTripped = resumeState && resumeState.toolRounds >= MAX_TOOL_ROUNDS;
+  if (loopGuardTripped) console.error(`[proxy] Tool loop guard: conversation ${bridgeKey} exceeded ${MAX_TOOL_ROUNDS} tool rounds on resume, killing bridge`);
+  if (!loopGuardTripped && activeBridge.bridge.alive) {
+    return handleToolResultResume(activeBridge, toolResults, modelId, bridgeKey, proxyState);
+  }
+  clearInterval(activeBridge.heartbeatTimer);
+  activeBridge.bridge.end();
+  return null;
+}
+
+function cleanupStaleBridge(bridgeKey, activeBridge) {
+  if (activeBridge && activeBridges.has(bridgeKey)) {
     clearInterval(activeBridge.heartbeatTimer);
     activeBridge.bridge.end();
-    return null;
+    activeBridges.delete(bridgeKey);
+  }
 }
-/** Clean up a stale bridge that has no pending tool results. */
-function cleanupStaleBridge(bridgeKey, activeBridge) {
-    if (activeBridge && activeBridges.has(bridgeKey)) {
-        clearInterval(activeBridge.heartbeatTimer);
-        activeBridge.bridge.end();
-        activeBridges.delete(bridgeKey);
-    }
-}
-/** Get or create conversation state for a bridge key. */
+
 function getOrCreateConversationState(bridgeKey) {
-    let stored = conversationStates.get(bridgeKey);
-    if (!stored) {
-        stored = {
-            conversationId: crypto.randomUUID(),
-            checkpoint: null,
-            blobStore: new Map(),
-            lastAccessMs: Date.now(),
-            toolRounds: 0,
-        };
-        conversationStates.set(bridgeKey, stored);
-    }
-    stored.lastAccessMs = Date.now();
-    return stored;
+  let stored = conversationStates.get(bridgeKey);
+  if (!stored) {
+    stored = { conversationId: crypto.randomUUID(), checkpoint: null, blobStore: new Map(), lastAccessMs: Date.now(), toolRounds: 0 };
+    conversationStates.set(bridgeKey, stored);
+  }
+  stored.lastAccessMs = Date.now();
+  return stored;
 }
-/**
- * Update tool round counter for the loop guard (t1553).
- * A new user message resets the counter. Tool results without an active
- * bridge (dead bridge fallthrough) increment it.
- */
+
 function updateToolRoundCounter(stored, toolResults, userText, hadActiveBridge) {
-    if (toolResults.length > 0 && !hadActiveBridge) {
-        stored.toolRounds = (stored.toolRounds || 0) + 1;
-    } else if (userText && toolResults.length === 0) {
-        stored.toolRounds = 0;
-    }
+  if (toolResults.length > 0 && !hadActiveBridge) {
+    stored.toolRounds = (stored.toolRounds || 0) + 1;
+  } else if (userText && toolResults.length === 0) {
+    stored.toolRounds = 0;
+  }
 }
+
 function handleChatCompletion(body, accessToken) {
-    const { systemPrompt, userText, turns, toolResults } = parseMessages(body.messages);
-    const modelId = body.model;
-    const tools = body.tools ?? [];
-    // Debug logging (t1553) — log what OpenCode sends us
-    console.error(`[proxy] handleChatCompletion: model=${modelId}, tools=${tools.length}, toolNames=[${tools.map(t => t.function?.name || '?').join(',')}], userText=${(userText || '').slice(0, 80)}, toolResults=${toolResults.length}, messages=${body.messages?.length || 0}, stream=${body.stream}`);
-    if (!userText && toolResults.length === 0) {
-        return new Response(JSON.stringify({
-            error: {
-                message: "No user message found",
-                type: "invalid_request_error",
-            },
-        }), { status: 400, headers: { "Content-Type": "application/json" } });
-    }
-    const bridgeKey = deriveBridgeKey(modelId, body.messages);
-    const activeBridge = activeBridges.get(bridgeKey);
-    // Try to resume an active bridge waiting for tool results.
-    if (activeBridge && toolResults.length > 0) {
-        const resumed = tryResumeBridge(bridgeKey, activeBridge, toolResults, modelId);
-        if (resumed) return resumed;
-    }
-    cleanupStaleBridge(bridgeKey, activeBridge);
-    const stored = getOrCreateConversationState(bridgeKey);
-    evictStaleConversations();
-    updateToolRoundCounter(stored, toolResults, userText, !!activeBridge);
-    // Tool loop guard (t1553): if rounds exceeded, disable tools so the
-    // model generates a text-only response.
-    const toolsExhausted = (stored.toolRounds || 0) >= MAX_TOOL_ROUNDS;
-    if (toolsExhausted) {
-        console.error(`[proxy] Tool loop guard: conversation ${bridgeKey} exceeded ${MAX_TOOL_ROUNDS} tool rounds, disabling tools`);
-    }
-    // Do NOT forward OpenAI tools to Cursor as MCP tools (t1553 finding).
-    // Sending MCP tools via RequestContext causes Cursor's gRPC agent to
-    // enter a tool execution loop that hangs indefinitely — the server
-    // sends native tool exec messages (readArgs, shellArgs, etc.), we
-    // reject them, but the server never falls through to text generation.
-    // Tool calling for Cursor models requires a different approach (e.g.,
-    // Nomadcxx-style text prompt flattening with structured text parsing).
-    const mcpTools = [];
-    console.error(`[proxy] tools from OpenCode: ${tools.length}, mcpTools forwarded: ${mcpTools.length} (MCP forwarding disabled — causes gRPC hang)`);
-    const effectiveUserText = userText || (toolResults.length > 0
-        ? toolResults.map((r) => r.content).join("\n")
-        : "");
-    const payload = buildCursorRequest(
-        { modelId, systemPrompt, userText: effectiveUserText, turns },
-        { conversationId: stored.conversationId, checkpoint: stored.checkpoint, blobStore: stored.blobStore }
-    );
-    payload.mcpTools = mcpTools;
-    if (body.stream === false) {
-        return handleNonStreamingResponse(payload, accessToken, modelId, bridgeKey);
-    }
-    return handleStreamingResponse(payload, accessToken, modelId, bridgeKey);
+  const { systemPrompt, userText, turns, toolResults } = parseMessages(body.messages);
+  const modelId = body.model;
+  const tools = body.tools ?? [];
+  console.error(`[proxy] handleChatCompletion: model=${modelId}, tools=${tools.length}, userText=${(userText || '').slice(0, 80)}, toolResults=${toolResults.length}`);
+  if (!userText && toolResults.length === 0) {
+    return new Response(JSON.stringify({ error: { message: "No user message found", type: "invalid_request_error" } }), { status: 400, headers: { "Content-Type": "application/json" } });
+  }
+  const bridgeKey = deriveBridgeKey(modelId, body.messages);
+  const activeBridge = activeBridges.get(bridgeKey);
+  if (activeBridge && toolResults.length > 0) {
+    const resumed = tryResumeBridge(bridgeKey, activeBridge, toolResults, modelId);
+    if (resumed) return resumed;
+  }
+  cleanupStaleBridge(bridgeKey, activeBridge);
+  const stored = getOrCreateConversationState(bridgeKey);
+  evictStaleConversations();
+  updateToolRoundCounter(stored, toolResults, userText, !!activeBridge);
+  const toolsExhausted = (stored.toolRounds || 0) >= MAX_TOOL_ROUNDS;
+  if (toolsExhausted) console.error(`[proxy] Tool loop guard: conversation ${bridgeKey} exceeded ${MAX_TOOL_ROUNDS} tool rounds, disabling tools`);
+  const mcpTools = [];
+  const effectiveUserText = userText || (toolResults.length > 0 ? toolResults.map((r) => r.content).join("\n") : "");
+  const payload = buildCursorRequest(
+    { modelId, systemPrompt, userText: effectiveUserText, turns },
+    { conversationId: stored.conversationId, checkpoint: stored.checkpoint, blobStore: stored.blobStore }
+  );
+  payload.mcpTools = mcpTools;
+  if (body.stream === false) return handleNonStreamingResponse(payload, accessToken, modelId, bridgeKey);
+  return handleStreamingResponse(payload, accessToken, modelId, bridgeKey);
 }
-/** Normalize OpenAI message content to a plain string. */
-function textContent(content) {
-    if (content == null)
-        return "";
-    if (typeof content === "string")
-        return content;
-    return content
-        .filter((p) => p.type === "text" && p.text)
-        .map((p) => p.text)
-        .join("\n");
-}
-function parseMessages(messages) {
-    let systemPrompt = "You are a helpful assistant.";
-    const pairs = [];
-    const toolResults = [];
-    // Collect system messages
-    const systemParts = messages
-        .filter((m) => m.role === "system")
-        .map((m) => textContent(m.content));
-    if (systemParts.length > 0) {
-        systemPrompt = systemParts.join("\n");
-    }
-    // Separate tool results from conversation turns
-    const nonSystem = messages.filter((m) => m.role !== "system");
-    let pendingUser = "";
-    for (const msg of nonSystem) {
-        if (msg.role === "tool") {
-            toolResults.push({
-                toolCallId: msg.tool_call_id ?? "",
-                content: textContent(msg.content),
-            });
-        }
-        else if (msg.role === "user") {
-            if (pendingUser) {
-                pairs.push({ userText: pendingUser, assistantText: "" });
-            }
-            pendingUser = textContent(msg.content);
-        }
-        else if (msg.role === "assistant") {
-            // Skip assistant messages that are just tool_calls with no text
-            const text = textContent(msg.content);
-            if (pendingUser) {
-                pairs.push({ userText: pendingUser, assistantText: text });
-                pendingUser = "";
-            }
-        }
-    }
-    let lastUserText = "";
-    if (pendingUser) {
-        lastUserText = pendingUser;
-    }
-    else if (pairs.length > 0 && toolResults.length === 0) {
-        const last = pairs.pop();
-        lastUserText = last.userText;
-    }
-    return { systemPrompt, userText: lastUserText, turns: pairs, toolResults };
-}
-/** Convert OpenAI tool definitions to Cursor's MCP tool protobuf format. */
-function buildMcpToolDefinitions(tools) {
-    return tools.map((t) => {
-        const fn = t.function;
-        const jsonSchema = fn.parameters && typeof fn.parameters === "object"
-            ? fn.parameters
-            : { type: "object", properties: {}, required: [] };
-        const inputSchema = toBinary(ValueSchema, fromJson(ValueSchema, jsonSchema));
-        return create(McpToolDefinitionSchema, {
-            name: fn.name,
-            description: fn.description || "",
-            providerIdentifier: "opencode",
-            toolName: fn.name,
-            inputSchema,
-        });
-    });
-}
-/** Decode a Cursor MCP arg value (protobuf Value bytes) to a JS value. */
-function decodeMcpArgValue(value) {
-    try {
-        const parsed = fromBinary(ValueSchema, value);
-        return toJson(ValueSchema, parsed);
-    }
-    catch { }
-    return new TextDecoder().decode(value);
-}
-/** Decode a map of MCP arg values. */
-function decodeMcpArgsMap(args) {
-    const decoded = {};
-    for (const [key, value] of Object.entries(args)) {
-        decoded[key] = decodeMcpArgValue(value);
-    }
-    return decoded;
-}
-/** Encode a single conversation turn (user + optional assistant) to bytes. */
-function encodeTurn(turn) {
-    const userMsg = create(UserMessageSchema, {
-        text: turn.userText,
-        messageId: crypto.randomUUID(),
-    });
-    const userMsgBytes = toBinary(UserMessageSchema, userMsg);
-    const stepBytes = [];
-    if (turn.assistantText) {
-        const step = create(ConversationStepSchema, {
-            message: {
-                case: "assistantMessage",
-                value: create(AssistantMessageSchema, { text: turn.assistantText }),
-            },
-        });
-        stepBytes.push(toBinary(ConversationStepSchema, step));
-    }
-    const agentTurn = create(AgentConversationTurnStructureSchema, {
-        userMessage: userMsgBytes,
-        steps: stepBytes,
-    });
-    const turnStructure = create(ConversationTurnStructureSchema, {
-        turn: { case: "agentConversationTurn", value: agentTurn },
-    });
-    return toBinary(ConversationTurnStructureSchema, turnStructure);
-}
-/** Build or restore a ConversationStateStructure from turns or a checkpoint. */
-function buildConversationState(turns, systemBlobId, checkpoint) {
-    if (checkpoint) {
-        return fromBinary(ConversationStateStructureSchema, checkpoint);
-    }
-    return create(ConversationStateStructureSchema, {
-        rootPromptMessagesJson: [systemBlobId],
-        turns: turns.map(encodeTurn),
-        todos: [],
-        pendingToolCalls: [],
-        previousWorkspaceUris: [],
-        fileStates: {},
-        fileStatesV2: {},
-        summaryArchives: [],
-        turnTimings: [],
-        subagentStates: {},
-        selfSummaryCount: 0,
-        readPaths: [],
-    });
-}
-/**
- * Build a Cursor AgentRunRequest payload.
- * @param {{ modelId: string, systemPrompt: string, userText: string, turns: Array }} req
- * @param {{ conversationId: string, checkpoint: Uint8Array|null, blobStore: Map }} ctx
- */
-function buildCursorRequest(req, ctx) {
-    const { modelId, systemPrompt, userText, turns } = req;
-    const blobStore = new Map(ctx.blobStore ?? []);
-    // System prompt → blob store (Cursor requests it back via KV handshake)
-    const systemJson = JSON.stringify({ role: "system", content: systemPrompt });
-    const systemBytes = new TextEncoder().encode(systemJson);
-    const systemBlobId = new Uint8Array(createHash("sha256").update(systemBytes).digest());
-    blobStore.set(Buffer.from(systemBlobId).toString("hex"), systemBytes);
-    const conversationState = buildConversationState(turns, systemBlobId, ctx.checkpoint);
-    const userMessage = create(UserMessageSchema, {
-        text: userText,
-        messageId: crypto.randomUUID(),
-    });
-    const action = create(ConversationActionSchema, {
-        action: {
-            case: "userMessageAction",
-            value: create(UserMessageActionSchema, { userMessage }),
-        },
-    });
-    const modelDetails = create(ModelDetailsSchema, {
-        modelId,
-        displayModelId: modelId,
-        displayName: modelId,
-    });
-    const runRequest = create(AgentRunRequestSchema, {
-        conversationState,
-        action,
-        modelDetails,
-        conversationId: ctx.conversationId,
-    });
-    const clientMessage = create(AgentClientMessageSchema, {
-        message: { case: "runRequest", value: runRequest },
-    });
-    return {
-        requestBytes: toBinary(AgentClientMessageSchema, clientMessage),
-        blobStore,
-        mcpTools: [],
-    };
-}
-function parseConnectEndStream(data) {
-    try {
-        const payload = JSON.parse(new TextDecoder().decode(data));
-        const error = payload?.error;
-        if (error) {
-            const code = error.code ?? "unknown";
-            const message = error.message ?? "Unknown error";
-            return new Error(`Connect error ${code}: ${message}`);
-        }
-        return null;
-    }
-    catch {
-        return new Error("Failed to parse Connect end stream");
-    }
-}
-function makeHeartbeatBytes() {
-    const heartbeat = create(AgentClientMessageSchema, {
-        message: {
-            case: "clientHeartbeat",
-            value: create(ClientHeartbeatSchema, {}),
-        },
-    });
-    return frameConnectMessage(toBinary(AgentClientMessageSchema, heartbeat));
-}
-/**
- * Create a stateful parser for Connect protocol frames.
- * Handles buffering partial data across chunks.
- */
-function createConnectFrameParser(onMessage, onEndStream) {
-    let pending = Buffer.alloc(0);
-    return (incoming) => {
-        pending = Buffer.concat([pending, incoming]);
-        while (pending.length >= 5) {
-            const flags = pending[0];
-            const msgLen = pending.readUInt32BE(1);
-            if (pending.length < 5 + msgLen)
-                break;
-            const messageBytes = pending.subarray(5, 5 + msgLen);
-            pending = pending.subarray(5 + msgLen);
-            if (flags & CONNECT_END_STREAM_FLAG) {
-                onEndStream(messageBytes);
-            }
-            else {
-                onMessage(messageBytes);
-            }
-        }
-    };
-}
-const THINKING_TAG_NAMES = ['think', 'thinking', 'reasoning', 'thought', 'think_intent'];
-const MAX_THINKING_TAG_LEN = 16; // </think_intent> is 15 chars
-/**
- * Strip thinking tags from streamed text, routing tagged content to reasoning.
- * Buffers partial tags across chunk boundaries.
- */
-function createThinkingTagFilter() {
-    let buffer = '';
-    let inThinking = false;
-    return {
-        process(text) {
-            const input = buffer + text;
-            buffer = '';
-            let content = '';
-            let reasoning = '';
-            let lastIdx = 0;
-            const re = new RegExp(`<(/?)(?:${THINKING_TAG_NAMES.join('|')})\\s*>`, 'gi');
-            let match;
-            while ((match = re.exec(input)) !== null) {
-                const before = input.slice(lastIdx, match.index);
-                if (inThinking)
-                    reasoning += before;
-                else
-                    content += before;
-                inThinking = match[1] !== '/';
-                lastIdx = re.lastIndex;
-            }
-            const rest = input.slice(lastIdx);
-            // Buffer a trailing '<' that could be the start of a thinking tag.
-            const ltPos = rest.lastIndexOf('<');
-            if (ltPos >= 0 && rest.length - ltPos < MAX_THINKING_TAG_LEN && /^<\/?[a-z_]*$/i.test(rest.slice(ltPos))) {
-                buffer = rest.slice(ltPos);
-                const before = rest.slice(0, ltPos);
-                if (inThinking)
-                    reasoning += before;
-                else
-                    content += before;
-            }
-            else {
-                if (inThinking)
-                    reasoning += rest;
-                else
-                    content += rest;
-            }
-            return { content, reasoning };
-        },
-        flush() {
-            const b = buffer;
-            buffer = '';
-            if (!b)
-                return { content: '', reasoning: '' };
-            return inThinking ? { content: '', reasoning: b } : { content: b, reasoning: '' };
-        },
-    };
-}
-/**
- * @param {object} msg - AgentServerMessage
- * @param {{ blobStore: Map, mcpTools: Array, sendFrame: Function }} transport
- * @param {{ onText: Function, onMcpExec: Function, onCheckpoint: Function }} handlers
- */
-function processServerMessage(msg, transport, handlers) {
-    const { blobStore, mcpTools, sendFrame } = transport;
-    const { onText, onMcpExec, onCheckpoint } = handlers;
-    const msgCase = msg.message.case;
-    if (msgCase === "interactionUpdate") {
-        handleInteractionUpdate(msg.message.value, onText);
-    }
-    else if (msgCase === "kvServerMessage") {
-        handleKvMessage(msg.message.value, blobStore, sendFrame);
-    }
-    else if (msgCase === "execServerMessage") {
-        handleExecMessage(msg.message.value, mcpTools, sendFrame, onMcpExec);
-    }
-    else if (msgCase === "conversationCheckpointUpdate" && onCheckpoint) {
-        onCheckpoint(toBinary(ConversationStateStructureSchema, msg.message.value));
-    }
-}
-function handleInteractionUpdate(update, onText) {
-    const updateCase = update.message?.case;
-    if (updateCase === "textDelta") {
-        const delta = update.message.value.text || "";
-        if (delta)
-            onText(delta, false);
-    }
-    else if (updateCase === "thinkingDelta") {
-        const delta = update.message.value.text || "";
-        if (delta)
-            onText(delta, true);
-    }
-    // toolCallStarted, partialToolCall, toolCallDelta, toolCallCompleted
-    // are intentionally ignored. MCP tool calls flow through the exec
-    // message path (mcpArgs → mcpResult), not interaction updates.
-}
-/** Send a KV client response back to Cursor. */
-function sendKvResponse(kvMsg, messageCase, value, sendFrame) {
-    const response = create(KvClientMessageSchema, {
-        id: kvMsg.id,
-        message: { case: messageCase, value: value },
-    });
-    const clientMsg = create(AgentClientMessageSchema, {
-        message: { case: "kvClientMessage", value: response },
-    });
-    sendFrame(frameConnectMessage(toBinary(AgentClientMessageSchema, clientMsg)));
-}
-function handleKvMessage(kvMsg, blobStore, sendFrame) {
-    const kvCase = kvMsg.message.case;
-    if (kvCase === "getBlobArgs") {
-        const blobId = kvMsg.message.value.blobId;
-        const blobIdKey = Buffer.from(blobId).toString("hex");
-        const blobData = blobStore.get(blobIdKey);
-        sendKvResponse(kvMsg, "getBlobResult", create(GetBlobResultSchema, blobData ? { blobData } : {}), sendFrame);
-    }
-    else if (kvCase === "setBlobArgs") {
-        const { blobId, blobData } = kvMsg.message.value;
-        blobStore.set(Buffer.from(blobId).toString("hex"), blobData);
-        sendKvResponse(kvMsg, "setBlobResult", create(SetBlobResultSchema, {}), sendFrame);
-    }
-}
-/** Handle requestContextArgs — provide MCP tools to Cursor. */
-function handleRequestContext(execMsg, mcpTools, sendFrame) {
-    console.error(`[proxy] requestContextArgs: providing ${mcpTools.length} MCP tools to Cursor`);
-    const requestContext = create(RequestContextSchema, {
-        rules: [],
-        repositoryInfo: [],
-        tools: mcpTools,
-        gitRepos: [],
-        projectLayouts: [],
-        mcpInstructions: [],
-        fileContents: {},
-        customSubagents: [],
-    });
-    const result = create(RequestContextResultSchema, {
-        result: {
-            case: "success",
-            value: create(RequestContextSuccessSchema, { requestContext }),
-        },
-    });
-    sendExecResult(execMsg, "requestContextResult", result, sendFrame);
-}
-/** Handle mcpArgs — forward tool call to the caller via onMcpExec. */
-function handleMcpArgs(execMsg, onMcpExec) {
-    const mcpArgs = execMsg.message.value;
-    const decoded = decodeMcpArgsMap(mcpArgs.args ?? {});
-    // Resolve tool name aliases (t1553) — Cursor models may use variant
-    // names like "runcommand" instead of "bash". The alias map normalises
-    // these back to the canonical OpenCode tool names that OpenCode's
-    // ai-sdk layer expects in the tool_calls response.
-    const rawToolName = mcpArgs.toolName || mcpArgs.name;
-    const resolvedToolName = resolveToolAlias(rawToolName);
-    onMcpExec({
-        execId: execMsg.execId,
-        execMsgId: execMsg.id,
-        toolCallId: mcpArgs.toolCallId || crypto.randomUUID(),
-        toolName: resolvedToolName,
-        decodedArgs: JSON.stringify(decoded),
-    });
-}
-/**
- * Reject a native Cursor tool with a "path"-based rejection message.
- * Used for read, ls, write, delete exec types.
- * @param {{ resultCase: string, resultSchema: object, rejectedSchema: object }} schemas
- */
-function rejectPathTool(execMsg, schemas, reason, sendFrame) {
-    const args = execMsg.message.value;
-    const result = create(schemas.resultSchema, {
-        result: { case: "rejected", value: create(schemas.rejectedSchema, { path: args.path, reason }) },
-    });
-    sendExecResult(execMsg, schemas.resultCase, result, sendFrame);
-}
-/**
- * Reject a shell-type exec with command/workingDirectory fields.
- * @param {{ resultCase: string, resultSchema: object }} schemas
- */
-function rejectShellTool(execMsg, schemas, reason, sendFrame) {
-    const args = execMsg.message.value;
-    const result = create(schemas.resultSchema, {
-        result: {
-            case: "rejected",
-            value: create(ShellRejectedSchema, {
-                command: args.command ?? "",
-                workingDirectory: args.workingDirectory ?? "",
-                reason,
-                isReadonly: false,
-            }),
-        },
-    });
-    sendExecResult(execMsg, schemas.resultCase, result, sendFrame);
-}
-/**
- * Reject an exec with an error-type result (grep, writeShellStdin, fetch).
- * @param {{ resultCase: string, resultSchema: object, errorSchema: object }} schemas
- */
-function rejectErrorTool(execMsg, schemas, errorFields, sendFrame) {
-    const result = create(schemas.resultSchema, {
-        result: { case: "error", value: create(schemas.errorSchema, errorFields) },
-    });
-    sendExecResult(execMsg, schemas.resultCase, result, sendFrame);
-}
-/**
- * Reject native Cursor tools so the model falls back to MCP tools.
- * Returns true if the exec was handled, false otherwise.
- */
-// Static rejection tables — defined once, reused per call.
-const PATH_REJECTIONS = {
-    readArgs:   { resultCase: "readResult",   resultSchema: ReadResultSchema,   rejectedSchema: ReadRejectedSchema },
-    lsArgs:     { resultCase: "lsResult",     resultSchema: LsResultSchema,     rejectedSchema: LsRejectedSchema },
-    writeArgs:  { resultCase: "writeResult",  resultSchema: WriteResultSchema,  rejectedSchema: WriteRejectedSchema },
-    deleteArgs: { resultCase: "deleteResult", resultSchema: DeleteResultSchema, rejectedSchema: DeleteRejectedSchema },
-};
-const SHELL_REJECTIONS = {
-    shellArgs:                 { resultCase: "shellResult",                resultSchema: ShellResultSchema },
-    shellStreamArgs:           { resultCase: "shellResult",                resultSchema: ShellResultSchema },
-    backgroundShellSpawnArgs:  { resultCase: "backgroundShellSpawnResult", resultSchema: BackgroundShellSpawnResultSchema },
-};
-const ERROR_REJECTIONS = {
-    grepArgs:           { resultCase: "grepResult",           resultSchema: GrepResultSchema,           errorSchema: GrepErrorSchema },
-    writeShellStdinArgs:{ resultCase: "writeShellStdinResult", resultSchema: WriteShellStdinResultSchema, errorSchema: WriteShellStdinErrorSchema },
-};
-const MISC_RESULT_CASES = {
-    listMcpResourcesExecArgs: "listMcpResourcesExecResult",
-    readMcpResourceExecArgs:  "readMcpResourceExecResult",
-    recordScreenArgs:         "recordScreenResult",
-    computerUseArgs:          "computerUseResult",
-};
-/**
- * Reject native Cursor tools so the model falls back to MCP tools.
- * Returns true if the exec was handled, false otherwise.
- */
-function rejectNativeCursorTool(execCase, execMsg, sendFrame) {
-    const REJECT_REASON = "Tool not available in this environment. Use the MCP tools provided instead.";
-    const pathEntry = PATH_REJECTIONS[execCase];
-    if (pathEntry) { rejectPathTool(execMsg, pathEntry, REJECT_REASON, sendFrame); return true; }
-    const shellEntry = SHELL_REJECTIONS[execCase];
-    if (shellEntry) { rejectShellTool(execMsg, shellEntry, REJECT_REASON, sendFrame); return true; }
-    const errorEntry = ERROR_REJECTIONS[execCase];
-    if (errorEntry) { rejectErrorTool(execMsg, errorEntry, { error: REJECT_REASON }, sendFrame); return true; }
-    if (execCase === "fetchArgs") {
-        const args = execMsg.message.value;
-        rejectErrorTool(execMsg, { resultCase: "fetchResult", resultSchema: FetchResultSchema, errorSchema: FetchErrorSchema }, { url: args.url ?? "", error: REJECT_REASON }, sendFrame);
-        return true;
-    }
-    // Diagnostics — return empty result (not a rejection)
-    if (execCase === "diagnosticsArgs") {
-        sendExecResult(execMsg, "diagnosticsResult", create(DiagnosticsResultSchema, {}), sendFrame);
-        return true;
-    }
-    const miscResultCase = MISC_RESULT_CASES[execCase];
-    if (miscResultCase) { sendExecResult(execMsg, miscResultCase, create(McpResultSchema, {}), sendFrame); return true; }
-    return false;
-}
-function handleExecMessage(execMsg, mcpTools, sendFrame, onMcpExec) {
-    const execCase = execMsg.message.case;
-    console.error(`[proxy] execMessage: case=${execCase}`);
-    if (execCase === "requestContextArgs") {
-        handleRequestContext(execMsg, mcpTools, sendFrame);
-        return;
-    }
-    if (execCase === "mcpArgs") {
-        handleMcpArgs(execMsg, onMcpExec);
-        return;
-    }
-    if (rejectNativeCursorTool(execCase, execMsg, sendFrame)) {
-        return;
-    }
-    // Unknown exec type — log and ignore
-    console.error(`[proxy] unhandled exec: ${execCase}`);
-}
-/** Send an exec client message back to Cursor. */
-function sendExecResult(execMsg, messageCase, value, sendFrame) {
-    const execClientMessage = create(ExecClientMessageSchema, {
-        id: execMsg.id,
-        execId: execMsg.execId,
-        message: { case: messageCase, value: value },
-    });
-    const clientMessage = create(AgentClientMessageSchema, {
-        message: { case: "execClientMessage", value: execClientMessage },
-    });
-    sendFrame(frameConnectMessage(toBinary(AgentClientMessageSchema, clientMessage)));
-}
-/** Derive a stable key to associate a bridge with a conversation. */
-function deriveBridgeKey(modelId, messages) {
-    // Stable key from model + first user message text.
-    const firstUserMsg = messages.find((m) => m.role === "user");
-    const firstUserText = firstUserMsg ? textContent(firstUserMsg.content) : "";
-    return createHash("sha256")
-        .update(`${modelId}:${firstUserText.slice(0, 200)}`)
-        .digest("hex")
-        .slice(0, 16);
-}
-/** Build SSE sender helpers bound to a ReadableStream controller. */
-function createSSESenders(controller, completionId, created, modelId) {
-    const encoder = new TextEncoder();
-    let closed = false;
-    const sendSSE = (data) => {
-        if (closed)
-            return;
-        controller.enqueue(encoder.encode(`data: ${JSON.stringify(data)}\n\n`));
-    };
-    const sendDone = () => {
-        if (closed)
-            return;
-        controller.enqueue(encoder.encode("data: [DONE]\n\n"));
-    };
-    const closeController = () => {
-        if (closed)
-            return;
-        closed = true;
-        controller.close();
-    };
-    const makeChunk = (delta, finishReason = null) => ({
-        id: completionId,
-        object: "chat.completion.chunk",
-        created,
-        model: modelId,
-        choices: [{ index: 0, delta, finish_reason: finishReason }],
-    });
-    return { sendSSE, sendDone, closeController, makeChunk };
-}
-/** Flush tag filter output and send any buffered reasoning/content as SSE. */
-function flushTagFilterToSSE(tagFilter, makeChunk, sendSSE) {
-    const flushed = tagFilter.flush();
-    if (flushed.reasoning)
-        sendSSE(makeChunk({ reasoning_content: flushed.reasoning }));
-    if (flushed.content)
-        sendSSE(makeChunk({ content: flushed.content }));
-}
-/** Merge blobStore entries into stored conversation state. */
-function mergeBlobStoreIntoState(bridgeKey, blobStore) {
-    const stored = conversationStates.get(bridgeKey);
-    if (stored) {
-        for (const [k, v] of blobStore)
-            stored.blobStore.set(k, v);
-        stored.lastAccessMs = Date.now();
-    }
-}
-/**
- * Create an SSE streaming Response that reads from a live bridge.
- * @param {{ bridge: object, heartbeatTimer: number, blobStore: Map, mcpTools: Array }} bridgeCtx
- * @param {string} modelId
- * @param {string} bridgeKey
- */
-function createBridgeStreamResponse(bridgeCtx, modelId, bridgeKey) {
-    const { bridge, heartbeatTimer, blobStore, mcpTools } = bridgeCtx;
-    const completionId = `chatcmpl-${crypto.randomUUID().replace(/-/g, "").slice(0, 28)}`;
-    const created = Math.floor(Date.now() / 1000);
-    const stream = new ReadableStream({
-        start(controller) {
-            const { sendSSE, sendDone, closeController, makeChunk } = createSSESenders(controller, completionId, created, modelId);
-            const state = {
-                toolCallIndex: 0,
-                pendingExecs: [],
-            };
-            const tagFilter = createThinkingTagFilter();
-            let mcpExecReceived = false;
-            const processChunk = createConnectFrameParser((messageBytes) => {
-                try {
-                    const serverMessage = fromBinary(AgentServerMessageSchema, messageBytes);
-                    processServerMessage(serverMessage, { blobStore, mcpTools, sendFrame: (data) => bridge.write(data) }, {
-                        onText(text, isThinking) {
-                            if (isThinking) {
-                                sendSSE(makeChunk({ reasoning_content: text }));
-                            }
-                            else {
-                                const { content, reasoning } = tagFilter.process(text);
-                                if (reasoning)
-                                    sendSSE(makeChunk({ reasoning_content: reasoning }));
-                                if (content)
-                                    sendSSE(makeChunk({ content }));
-                            }
-                        },
-                        // onMcpExec — the model wants to execute a tool.
-                        onMcpExec(exec) {
-                            state.pendingExecs.push(exec);
-                            mcpExecReceived = true;
-                            flushTagFilterToSSE(tagFilter, makeChunk, sendSSE);
-                            const toolCallIndex = state.toolCallIndex++;
-                            sendSSE(makeChunk({
-                                tool_calls: [{
-                                        index: toolCallIndex,
-                                        id: exec.toolCallId,
-                                        type: "function",
-                                        function: {
-                                            name: exec.toolName,
-                                            arguments: exec.decodedArgs,
-                                        },
-                                    }],
-                            }));
-                            // Keep the bridge alive for tool result continuation.
-                            activeBridges.set(bridgeKey, {
-                                bridge,
-                                heartbeatTimer,
-                                blobStore,
-                                mcpTools,
-                                pendingExecs: state.pendingExecs,
-                            });
-                            sendSSE(makeChunk({}, "tool_calls"));
-                            sendDone();
-                            closeController();
-                        },
-                        onCheckpoint(checkpointBytes) {
-                            const stored = conversationStates.get(bridgeKey);
-                            if (stored) {
-                                stored.checkpoint = checkpointBytes;
-                                stored.lastAccessMs = Date.now();
-                            }
-                        },
-                    });
-                }
-                catch {
-                    // Skip unparseable messages
-                }
-            }, (endStreamBytes) => {
-                const endError = parseConnectEndStream(endStreamBytes);
-                if (endError) {
-                    sendSSE(makeChunk({ content: `\n[Error: ${endError.message}]` }));
-                }
-            });
-            bridge.onData(processChunk);
-            bridge.onClose((code) => {
-                clearInterval(heartbeatTimer);
-                mergeBlobStoreIntoState(bridgeKey, blobStore);
-                if (!mcpExecReceived) {
-                    flushTagFilterToSSE(tagFilter, makeChunk, sendSSE);
-                    sendSSE(makeChunk({}, "stop"));
-                    sendDone();
-                    closeController();
-                }
-                else if (code !== 0) {
-                    // Bridge died while tool calls are pending (timeout, crash, etc.).
-                    // Close the SSE stream so the client doesn't hang forever.
-                    sendSSE(makeChunk({ content: "\n[Error: bridge connection lost]" }));
-                    sendSSE(makeChunk({}, "stop"));
-                    sendDone();
-                    closeController();
-                    // Remove stale entry so the next request doesn't try to resume it.
-                    activeBridges.delete(bridgeKey);
-                }
-            });
-        },
-    });
-    return new Response(stream, { headers: SSE_HEADERS });
-}
-/** Spawn a bridge, send the initial request frame, and start heartbeat. */
-function startBridge(accessToken, requestBytes) {
-    const bridge = spawnBridge({
-        accessToken,
-        rpcPath: "/agent.v1.AgentService/Run",
-    });
-    bridge.write(frameConnectMessage(requestBytes));
-    const heartbeatTimer = setInterval(() => bridge.write(makeHeartbeatBytes()), 5_000);
-    return { bridge, heartbeatTimer };
-}
+
 function handleStreamingResponse(payload, accessToken, modelId, bridgeKey) {
-    const { bridge, heartbeatTimer } = startBridge(accessToken, payload.requestBytes);
-    return createBridgeStreamResponse({ bridge, heartbeatTimer, blobStore: payload.blobStore, mcpTools: payload.mcpTools }, modelId, bridgeKey);
+  const { bridge, heartbeatTimer } = startBridge(accessToken, payload.requestBytes, spawnBridge);
+  return createBridgeStreamResponse({ bridge, heartbeatTimer, blobStore: payload.blobStore, mcpTools: payload.mcpTools }, modelId, bridgeKey, proxyState);
 }
-/** Resume a paused bridge by sending MCP results and continuing to stream. */
-function handleToolResultResume(active, toolResults, modelId, bridgeKey) {
-    const { bridge, heartbeatTimer, blobStore, mcpTools, pendingExecs } = active;
-    // Send mcpResult for each pending exec that has a matching tool result
-    for (const exec of pendingExecs) {
-        const result = toolResults.find((r) => r.toolCallId === exec.toolCallId);
-        const mcpResult = result
-            ? create(McpResultSchema, {
-                result: {
-                    case: "success",
-                    value: create(McpSuccessSchema, {
-                        content: [
-                            create(McpToolResultContentItemSchema, {
-                                content: {
-                                    case: "text",
-                                    value: create(McpTextContentSchema, { text: result.content }),
-                                },
-                            }),
-                        ],
-                        isError: false,
-                    }),
-                },
-            })
-            : create(McpResultSchema, {
-                result: {
-                    case: "error",
-                    value: create(McpErrorSchema, { error: "Tool result not provided" }),
-                },
-            });
-        const execClientMessage = create(ExecClientMessageSchema, {
-            id: exec.execMsgId,
-            execId: exec.execId,
-            message: {
-                case: "mcpResult",
-                value: mcpResult,
-            },
-        });
-        const clientMessage = create(AgentClientMessageSchema, {
-            message: { case: "execClientMessage", value: execClientMessage },
-        });
-        bridge.write(frameConnectMessage(toBinary(AgentClientMessageSchema, clientMessage)));
-    }
-    return createBridgeStreamResponse({ bridge, heartbeatTimer, blobStore, mcpTools }, modelId, bridgeKey);
-}
+
 async function handleNonStreamingResponse(payload, accessToken, modelId, bridgeKey) {
-    const completionId = `chatcmpl-${crypto.randomUUID().replace(/-/g, "").slice(0, 28)}`;
-    const created = Math.floor(Date.now() / 1000);
-    const result = await collectFullResponse(payload, accessToken, bridgeKey);
-    const message = { role: "assistant", content: result.text || "" };
-    let finishReason = "stop";
-    if (result.toolCalls && result.toolCalls.length > 0) {
-        message.tool_calls = result.toolCalls;
-        finishReason = "tool_calls";
-    }
-    return new Response(JSON.stringify({
-        id: completionId,
-        object: "chat.completion",
-        created,
-        model: modelId,
-        choices: [
-            {
-                index: 0,
-                message,
-                finish_reason: finishReason,
-            },
-        ],
-        usage: {
-            prompt_tokens: 0,
-            completion_tokens: 0,
-            total_tokens: 0,
-        },
-    }), { headers: { "Content-Type": "application/json" } });
+  const completionId = `chatcmpl-${crypto.randomUUID().replace(/-/g, "").slice(0, 28)}`;
+  const created = Math.floor(Date.now() / 1000);
+  const result = await collectFullResponse(payload, accessToken, bridgeKey, proxyState, spawnBridge);
+  const message = { role: "assistant", content: result.text || "" };
+  let finishReason = "stop";
+  if (result.toolCalls && result.toolCalls.length > 0) { message.tool_calls = result.toolCalls; finishReason = "tool_calls"; }
+  return new Response(JSON.stringify({
+    id: completionId, object: "chat.completion", created, model: modelId,
+    choices: [{ index: 0, message, finish_reason: finishReason }],
+    usage: { prompt_tokens: 0, completion_tokens: 0, total_tokens: 0 },
+  }), { headers: { "Content-Type": "application/json" } });
 }
-/**
- * Handle a tool call exec during non-streaming response collection.
- * Resolves the promise with tool_calls and parks the bridge for continuation.
- * @param {{ bridge, heartbeatTimer, payload, bridgeKey }} bridgeCtx
- * @param {{ state, tagFilter, fullTextRef, resolve }} collectCtx
- */
-function handleNonStreamToolCall(exec, bridgeCtx, collectCtx) {
-    const { bridge, heartbeatTimer, payload, bridgeKey } = bridgeCtx;
-    const { state, tagFilter, fullTextRef, resolve } = collectCtx;
-    state.pendingExecs.push(exec);
-    const flushed = tagFilter.flush();
-    fullTextRef.value += flushed.content;
-    state.toolCallIndex++;
-    const toolCalls = [{
-        id: exec.toolCallId,
-        type: "function",
-        function: {
-            name: exec.toolName,
-            arguments: exec.decodedArgs,
-        },
-    }];
-    // Keep the bridge alive for tool result continuation.
-    activeBridges.set(bridgeKey, {
-        bridge,
-        heartbeatTimer,
-        blobStore: payload.blobStore,
-        mcpTools: payload.mcpTools,
-        pendingExecs: state.pendingExecs,
-    });
-    resolve({ text: fullTextRef.value, toolCalls });
+
+async function handleChatCompletionsRequest(req) {
+  try {
+    const body = (await req.json());
+    if (!proxyAccessTokenProvider) throw new Error("Cursor proxy access token provider not configured");
+    const accessToken = await proxyAccessTokenProvider();
+    return handleChatCompletion(body, accessToken);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    return new Response(JSON.stringify({ error: { message, type: "server_error", code: "internal_error" } }), { status: 500, headers: { "Content-Type": "application/json" } });
+  }
 }
-async function collectFullResponse(payload, accessToken, bridgeKey) {
-    const { promise, resolve } = Promise.withResolvers();
-    const fullTextRef = { value: "" };
-    let resolved = false;
-    const { bridge, heartbeatTimer } = startBridge(accessToken, payload.requestBytes);
-    const state = {
-        toolCallIndex: 0,
-        pendingExecs: [],
-    };
-    const tagFilter = createThinkingTagFilter();
-    bridge.onData(createConnectFrameParser((messageBytes) => {
-        try {
-            const serverMessage = fromBinary(AgentServerMessageSchema, messageBytes);
-            processServerMessage(serverMessage, { blobStore: payload.blobStore, mcpTools: payload.mcpTools, sendFrame: (data) => bridge.write(data) }, {
-                onText(text, isThinking) {
-                    if (isThinking)
-                        return;
-                    const { content } = tagFilter.process(text);
-                    fullTextRef.value += content;
-                },
-                onMcpExec(exec) {
-                    // Tool call received — resolve immediately with tool_calls
-                    // and keep the bridge alive for tool result continuation.
-                    if (resolved) return;
-                    resolved = true;
-                    handleNonStreamToolCall(exec, { bridge, heartbeatTimer, payload, bridgeKey }, { state, tagFilter, fullTextRef, resolve });
-                },
-                onCheckpoint(checkpointBytes) {
-                    const stored = conversationStates.get(bridgeKey);
-                    if (stored) {
-                        stored.checkpoint = checkpointBytes;
-                        stored.lastAccessMs = Date.now();
-                    }
-                },
-            });
-        }
-        catch {
-            // Skip
-        }
-    }, () => { }));
-    bridge.onClose(() => {
-        clearInterval(heartbeatTimer);
-        mergeBlobStoreIntoState(bridgeKey, payload.blobStore);
-        if (!resolved) {
-            resolved = true;
-            const flushed = tagFilter.flush();
-            fullTextRef.value += flushed.content;
-            resolve({ text: fullTextRef.value, toolCalls: null });
-        }
-    });
-    return promise;
+
+async function handleProxyFetch(req) {
+  const url = new URL(req.url);
+  if (req.method === "GET" && url.pathname === "/v1/models") {
+    return new Response(JSON.stringify({ object: "list", data: buildOpenAIModelList(proxyModels) }), { headers: { "Content-Type": "application/json" } });
+  }
+  if (req.method === "POST" && url.pathname === "/v1/chat/completions") return handleChatCompletionsRequest(req);
+  return new Response("Not Found", { status: 404 });
+}
+
+export function getProxyPort() { return proxyPort; }
+
+export async function startProxy(getAccessToken, models = []) {
+  proxyAccessTokenProvider = getAccessToken;
+  proxyModels = models.map((model) => ({ id: model.id, name: model.name }));
+  if (proxyServer && proxyPort) return proxyPort;
+  conversationStates.clear();
+  activeBridges.clear();
+  proxyServer = Bun.serve({
+    port: parseInt(process.env.CURSOR_PROXY_PORT || "32123", 10),
+    idleTimeout: 255,
+    fetch: handleProxyFetch,
+  });
+  proxyPort = proxyServer.port;
+  if (!proxyPort) throw new Error("Failed to bind proxy to a port");
+  return proxyPort;
+}
+
+export function stopProxy() {
+  if (proxyServer) {
+    proxyServer.stop();
+    proxyServer = undefined;
+    proxyPort = undefined;
+    proxyAccessTokenProvider = undefined;
+    proxyModels = [];
+  }
+  for (const active of activeBridges.values()) { clearInterval(active.heartbeatTimer); active.bridge.end(); }
+  activeBridges.clear();
+  conversationStates.clear();
 }

--- a/.agents/plugins/opencode-aidevops/google-proxy-config.mjs
+++ b/.agents/plugins/opencode-aidevops/google-proxy-config.mjs
@@ -1,0 +1,149 @@
+/**
+ * Google proxy config helpers: model discovery, provider registration, config persistence.
+ * Extracted from google-proxy.mjs to keep that file's complexity below the threshold.
+ */
+
+import { readFileSync, writeFileSync, mkdirSync } from "fs";
+import { join, dirname } from "path";
+import { homedir } from "os";
+
+const GOOGLE_API_BASE = "https://generativelanguage.googleapis.com";
+const OPENCODE_CONFIG_PATH = join(homedir(), ".config", "opencode", "opencode.json");
+
+// ---------------------------------------------------------------------------
+// Model discovery
+// ---------------------------------------------------------------------------
+
+/**
+ * Discover available Gemini models from the Google Generative AI API.
+ * @param {string} accessToken - Valid OAuth access token
+ * @returns {Promise<Array<{ id: string, name: string, contextWindow: number, maxTokens: number }>>}
+ */
+export async function discoverGoogleModels(accessToken) {
+  const models = [];
+  try {
+    const resp = await fetch(`${GOOGLE_API_BASE}/v1beta/models`, {
+      headers: { "Authorization": `Bearer ${accessToken}` },
+    });
+    if (!resp.ok) {
+      console.error(`[aidevops] Google proxy: model discovery failed: HTTP ${resp.status}`);
+      return models;
+    }
+    const data = await resp.json();
+    if (!data.models || !Array.isArray(data.models)) return models;
+    for (const model of data.models) {
+      const methods = model.supportedGenerationMethods || [];
+      if (!methods.includes("generateContent")) continue;
+      const modelId = model.name?.replace(/^models\//, "") || "";
+      if (!modelId) continue;
+      if (modelId.includes("embedding") || modelId.includes("aqa") || modelId.includes("imagen")) continue;
+      models.push({
+        id: modelId,
+        name: model.displayName || modelId,
+        contextWindow: model.inputTokenLimit || 1048576,
+        maxTokens: model.outputTokenLimit || 65536,
+      });
+    }
+    console.error(`[aidevops] Google proxy: discovered ${models.length} models`);
+  } catch (err) {
+    console.error(`[aidevops] Google proxy: model discovery error: ${err.message}`);
+  }
+  return models;
+}
+
+/**
+ * Build OpenCode provider model entries from discovered Google models.
+ * @param {Array<{ id: string, name: string, contextWindow?: number, maxTokens?: number }>} models
+ * @returns {Record<string, object>}
+ */
+export function buildGoogleProviderModels(models) {
+  const entries = {};
+  for (const model of models) {
+    entries[model.id] = {
+      name: model.name,
+      attachment: true,
+      tool_call: true,
+      temperature: true,
+      reasoning: model.id.includes("thinking") || false,
+      modalities: { input: ["text", "image"], output: ["text"] },
+      cost: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
+      limit: {
+        context: model.contextWindow || 1048576,
+        output: model.maxTokens || 65536,
+      },
+      family: "google",
+    };
+  }
+  return entries;
+}
+
+/**
+ * Register the Google provider in OpenCode config with discovered models.
+ * @param {object} config - OpenCode config object (mutable)
+ * @param {number} port - Proxy port
+ * @param {Array<{ id: string, name: string, contextWindow?: number, maxTokens?: number }>} models
+ * @returns {boolean} true if provider was registered/updated
+ */
+export function registerGoogleProvider(config, port, models) {
+  if (!config.provider) config.provider = {};
+
+  const providerModels = buildGoogleProviderModels(models);
+  const baseURL = `http://127.0.0.1:${port}/v1beta`;
+
+  const newProvider = {
+    name: "Google (via aidevops proxy)",
+    npm: "@ai-sdk/google",
+    api: baseURL,
+    models: providerModels,
+  };
+
+  const existing = config.provider.google;
+  if (!existing || JSON.stringify(existing) !== JSON.stringify(newProvider)) {
+    config.provider.google = newProvider;
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Write the Google provider entry (with models) to opencode.json on disk.
+ * @param {number} port - Proxy port
+ * @param {Array<{ id: string, name: string, contextWindow?: number, maxTokens?: number }>} models
+ */
+export function persistGoogleProvider(port, models) {
+  let config = {};
+  try {
+    const raw = readFileSync(OPENCODE_CONFIG_PATH, "utf-8");
+    config = JSON.parse(raw);
+  } catch (err) {
+    if (err.code !== "ENOENT") {
+      console.error(`[aidevops] Google proxy: cannot read opencode.json: ${err.message}`);
+      return;
+    }
+  }
+
+  if (!config.provider) config.provider = {};
+
+  const providerModels = buildGoogleProviderModels(models);
+  const baseURL = `http://127.0.0.1:${port}/v1beta`;
+
+  config.provider.google = {
+    name: "Google (via aidevops proxy)",
+    npm: "@ai-sdk/google",
+    api: baseURL,
+    models: providerModels,
+  };
+
+  if (!process.env.GOOGLE_GENERATIVE_AI_API_KEY) {
+    process.env.GOOGLE_GENERATIVE_AI_API_KEY = "google-pool-proxy";
+  }
+
+  try {
+    mkdirSync(dirname(OPENCODE_CONFIG_PATH), { recursive: true });
+    writeFileSync(OPENCODE_CONFIG_PATH, JSON.stringify(config, null, 2) + "\n", "utf-8");
+    console.error(`[aidevops] Google proxy: persisted ${models.length} models to opencode.json (port ${port})`);
+  } catch (err) {
+    console.error(`[aidevops] Google proxy: failed to write opencode.json: ${err.message}`);
+  }
+}

--- a/.agents/plugins/opencode-aidevops/google-proxy.mjs
+++ b/.agents/plugins/opencode-aidevops/google-proxy.mjs
@@ -25,10 +25,10 @@
  *   - Google Generative AI API: https://ai.google.dev/api/rest
  */
 
-import { readFileSync, writeFileSync, mkdirSync } from "fs";
-import { join, dirname } from "path";
-import { homedir } from "os";
+import { join } from "path";
 import { getAccounts, ensureValidToken, patchAccount } from "./oauth-pool.mjs";
+export { buildGoogleProviderModels, registerGoogleProvider, persistGoogleProvider, discoverGoogleModels } from "./google-proxy-config.mjs";
+import { persistGoogleProvider, discoverGoogleModels } from "./google-proxy-config.mjs";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -154,63 +154,117 @@ async function rotateOnRateLimit(currentEmail) {
   return null;
 }
 
+// discoverGoogleModels — see ./google-proxy-config.mjs (re-exported above)
+
 // ---------------------------------------------------------------------------
-// Model discovery
+// Proxy server — request handler (module-level for complexity isolation)
 // ---------------------------------------------------------------------------
+
+// Hop-by-hop headers and API key header to strip when forwarding.
+const GOOGLE_PROXY_SKIP_HEADERS = new Set(["x-goog-api-key", "host", "connection", "transfer-encoding"]);
 
 /**
- * Discover available Gemini models from the Google Generative AI API.
- * Calls GET /v1beta/models with the OAuth token and returns model metadata.
- *
- * @param {string} accessToken - Valid OAuth access token
- * @returns {Promise<Array<{ id: string, name: string, contextWindow: number, maxTokens: number }>>}
+ * Build forwarded headers: strip API key / hop-by-hop, add Bearer auth.
+ * @param {Request} req
+ * @param {string} accessToken
+ * @returns {Headers}
  */
-export async function discoverGoogleModels(accessToken) {
-  const models = [];
+function buildGoogleForwardHeaders(req, accessToken) {
+  const forwardHeaders = new Headers();
+  for (const [key, value] of req.headers.entries()) {
+    if (!GOOGLE_PROXY_SKIP_HEADERS.has(key.toLowerCase())) {
+      forwardHeaders.set(key, value);
+    }
+  }
+  forwardHeaders.set("Authorization", `Bearer ${accessToken}`);
+  return forwardHeaders;
+}
 
+/**
+ * Retry a forwarded request with a rotated account token after a 429.
+ * Returns the retried Response, or null if no rotation is possible (caller uses original).
+ * @param {string} accountEmail
+ * @param {Headers} forwardHeaders
+ * @param {string} targetUrl
+ * @param {string} method
+ * @param {ArrayBuffer|null} body
+ * @returns {Promise<Response|null>}
+ */
+async function retryWithRotatedGoogleAccount(accountEmail, forwardHeaders, targetUrl, method, body) {
+  console.error("[aidevops] Google proxy: 429 from Google API, attempting rotation");
+  const rotated = await rotateOnRateLimit(accountEmail);
+  if (!rotated) return null;
+  forwardHeaders.set("Authorization", `Bearer ${rotated.token}`);
+  return fetch(targetUrl, { method, headers: forwardHeaders, body });
+}
+
+/**
+ * Forward a non-health-check request to the Google API with auth translation.
+ * @param {Request} req
+ * @param {URL} url
+ * @returns {Promise<Response>}
+ */
+async function forwardToGoogleApi(req, url) {
+  const targetUrl = `${GOOGLE_API_BASE}${url.pathname}${url.search}`;
+
+  let accessToken;
+  let accountEmail;
   try {
-    const resp = await fetch(`${GOOGLE_API_BASE}/v1beta/models`, {
-      headers: {
-        "Authorization": `Bearer ${accessToken}`,
-      },
-    });
-
-    if (!resp.ok) {
-      console.error(`[aidevops] Google proxy: model discovery failed: HTTP ${resp.status}`);
-      return models;
-    }
-
-    const data = await resp.json();
-    if (!data.models || !Array.isArray(data.models)) {
-      return models;
-    }
-
-    for (const model of data.models) {
-      // Only include generateContent-capable models (chat/completion models)
-      const methods = model.supportedGenerationMethods || [];
-      if (!methods.includes("generateContent")) continue;
-
-      // Extract the model ID from the full name (e.g., "models/gemini-2.5-flash" → "gemini-2.5-flash")
-      const modelId = model.name?.replace(/^models\//, "") || "";
-      if (!modelId) continue;
-
-      // Skip embedding models, AQA models, and other non-chat models
-      if (modelId.includes("embedding") || modelId.includes("aqa") || modelId.includes("imagen")) continue;
-
-      models.push({
-        id: modelId,
-        name: model.displayName || modelId,
-        contextWindow: model.inputTokenLimit || 1048576,
-        maxTokens: model.outputTokenLimit || 65536,
-      });
-    }
-
-    console.error(`[aidevops] Google proxy: discovered ${models.length} models`);
+    const result = await getAccessToken();
+    accessToken = result.token;
+    accountEmail = result.email;
   } catch (err) {
-    console.error(`[aidevops] Google proxy: model discovery error: ${err.message}`);
+    return new Response(JSON.stringify({
+      error: { message: `Google proxy: ${err.message}`, status: "UNAVAILABLE" },
+    }), { status: 503, headers: { "Content-Type": "application/json" } });
   }
 
-  return models;
+  const forwardHeaders = buildGoogleForwardHeaders(req, accessToken);
+
+  // Buffer the request body up-front so the 429 retry can reuse it.
+  // req.body is a one-shot ReadableStream per the WHATWG Fetch spec —
+  // once consumed by the first fetch() call, it cannot be read again.
+  const body = (req.method !== "GET" && req.method !== "HEAD")
+    ? await req.arrayBuffer()
+    : null;
+
+  let response = await fetch(targetUrl, { method: req.method, headers: forwardHeaders, body });
+
+  if (response.status === 429) {
+    const rotated = await retryWithRotatedGoogleAccount(accountEmail, forwardHeaders, targetUrl, req.method, body);
+    if (rotated) response = rotated;
+  }
+
+  // Pipe the response back — preserves SSE streaming for streamGenerateContent
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: response.headers,
+  });
+}
+
+/**
+ * Top-level fetch handler for the Google proxy Bun.serve instance.
+ * @param {Request} req
+ * @returns {Promise<Response>}
+ */
+async function handleGoogleProxyFetch(req) {
+  const url = new URL(req.url);
+
+  if (url.pathname === "/health") {
+    return new Response(JSON.stringify({ status: "ok", provider: "google" }), {
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  try {
+    return await forwardToGoogleApi(req, url);
+  } catch (err) {
+    console.error(`[aidevops] Google proxy: request error: ${err.message}`);
+    return new Response(JSON.stringify({
+      error: { message: `Google proxy error: ${err.message}`, status: "INTERNAL" },
+    }), { status: 502, headers: { "Content-Type": "application/json" } });
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -232,13 +286,35 @@ export async function discoverGoogleModels(accessToken) {
  * @param {any} client - OpenCode SDK client (for provider registration)
  * @returns {Promise<{ port: number, models: Array<{ id: string, name: string }> } | null>}
  */
+/** Bun.serve error handler for the Google proxy. */
+function handleGoogleProxyServerError(err) {
+  console.error(`[aidevops] Google proxy: server error: ${err.message}`);
+  return new Response("Internal Server Error", { status: 500 });
+}
+
+/** Discover models and start proxy; throws on failure (caller wraps in try/catch). */
+async function startGoogleProxyServer() {
+  const { token: initialToken } = await getAccessToken();
+  let models;
+  try {
+    models = await discoverGoogleModels(initialToken);
+  } catch (err) {
+    console.error(`[aidevops] Google proxy: model discovery failed (${err.message}), using empty list`);
+    models = [];
+  }
+  const server = Bun.serve({
+    port: GOOGLE_PROXY_DEFAULT_PORT,
+    hostname: "127.0.0.1",
+    fetch: handleGoogleProxyFetch,
+    error: handleGoogleProxyServerError,
+  });
+  return { server, models };
+}
+
 export async function startGoogleProxy(client) {
   const accounts = getAccounts("google");
-  if (accounts.length === 0) {
-    return null;
-  }
+  if (accounts.length === 0) return null;
 
-  // Prevent concurrent startup
   if (proxyStarting) {
     console.error("[aidevops] Google proxy: startup already in progress");
     return null;
@@ -252,122 +328,11 @@ export async function startGoogleProxy(client) {
   proxyStarting = true;
 
   try {
-    // Get an initial valid token for model discovery
-    const { token: initialToken } = await getAccessToken();
-
-    // Discover available models
-    let models;
-    try {
-      models = await discoverGoogleModels(initialToken);
-    } catch (err) {
-      console.error(`[aidevops] Google proxy: model discovery failed (${err.message}), using empty list`);
-      models = [];
-    }
-
-    // Start the HTTP proxy
-    proxyServer = Bun.serve({
-      port: GOOGLE_PROXY_DEFAULT_PORT,
-      hostname: "127.0.0.1",
-
-      async fetch(req) {
-        const url = new URL(req.url);
-
-        // Health check endpoint
-        if (url.pathname === "/health") {
-          return new Response(JSON.stringify({ status: "ok", provider: "google" }), {
-            headers: { "Content-Type": "application/json" },
-          });
-        }
-
-        // Forward all other requests to Google's API
-        try {
-          const targetUrl = `${GOOGLE_API_BASE}${url.pathname}${url.search}`;
-
-          // Get a valid pool token — returns {token, email} so the 429 handler
-          // can mark the correct account without relying on a shared global.
-          let accessToken;
-          let accountEmail;
-          try {
-            const result = await getAccessToken();
-            accessToken = result.token;
-            accountEmail = result.email;
-          } catch (err) {
-            return new Response(JSON.stringify({
-              error: { message: `Google proxy: ${err.message}`, status: "UNAVAILABLE" },
-            }), {
-              status: 503,
-              headers: { "Content-Type": "application/json" },
-            });
-          }
-
-          // Build forwarded headers — strip x-goog-api-key, add Bearer auth
-          const forwardHeaders = new Headers();
-          for (const [key, value] of req.headers.entries()) {
-            const lowerKey = key.toLowerCase();
-            // Skip hop-by-hop headers and the API key header
-            if (lowerKey === "x-goog-api-key") continue;
-            if (lowerKey === "host") continue;
-            if (lowerKey === "connection") continue;
-            if (lowerKey === "transfer-encoding") continue;
-            forwardHeaders.set(key, value);
-          }
-          forwardHeaders.set("Authorization", `Bearer ${accessToken}`);
-
-          // Buffer the request body up-front so the 429 retry can reuse it.
-          // req.body is a one-shot ReadableStream per the WHATWG Fetch spec —
-          // once consumed by the first fetch() call, it cannot be read again.
-          let body = null;
-          if (req.method !== "GET" && req.method !== "HEAD") {
-            body = await req.arrayBuffer();
-          }
-
-          let response = await fetch(targetUrl, {
-            method: req.method,
-            headers: forwardHeaders,
-            body,
-          });
-
-          // Handle 429 — rotate account and retry once with the buffered body
-          if (response.status === 429) {
-            console.error(`[aidevops] Google proxy: 429 from Google API, attempting rotation`);
-            const rotated = await rotateOnRateLimit(accountEmail);
-            if (rotated) {
-              forwardHeaders.set("Authorization", `Bearer ${rotated.token}`);
-              response = await fetch(targetUrl, {
-                method: req.method,
-                headers: forwardHeaders,
-                body,
-              });
-            }
-          }
-
-          // Pipe the response back — preserves SSE streaming for streamGenerateContent
-          return new Response(response.body, {
-            status: response.status,
-            statusText: response.statusText,
-            headers: response.headers,
-          });
-        } catch (err) {
-          console.error(`[aidevops] Google proxy: request error: ${err.message}`);
-          return new Response(JSON.stringify({
-            error: { message: `Google proxy error: ${err.message}`, status: "INTERNAL" },
-          }), {
-            status: 502,
-            headers: { "Content-Type": "application/json" },
-          });
-        }
-      },
-
-      error(err) {
-        console.error(`[aidevops] Google proxy: server error: ${err.message}`);
-        return new Response("Internal Server Error", { status: 500 });
-      },
-    });
-
+    const { server, models } = await startGoogleProxyServer();
+    proxyServer = server;
     proxyPort = proxyServer.port;
     console.error(`[aidevops] Google proxy: started on port ${proxyPort}`);
 
-    // Persist Google provider + models to opencode.json
     if (models.length > 0) {
       try {
         persistGoogleProvider(proxyPort, models);
@@ -409,127 +374,5 @@ export function getGoogleProxyPort() {
   return proxyPort;
 }
 
-// ---------------------------------------------------------------------------
-// Provider registration for OpenCode config
-// ---------------------------------------------------------------------------
-
-/**
- * Build OpenCode provider model entries from discovered Google models.
- * These entries tell OpenCode what models are available and where to route requests.
- *
- * @param {Array<{ id: string, name: string, contextWindow?: number, maxTokens?: number }>} models
- * @returns {Record<string, object>}
- */
-export function buildGoogleProviderModels(models) {
-  const entries = {};
-  for (const model of models) {
-    entries[model.id] = {
-      name: model.name,
-      attachment: true,
-      tool_call: true,
-      temperature: true,
-      reasoning: model.id.includes("thinking") || false,
-      modalities: { input: ["text", "image"], output: ["text"] },
-      cost: { input: 0, output: 0, cache_read: 0, cache_write: 0 },
-      limit: {
-        context: model.contextWindow || 1048576,
-        output: model.maxTokens || 65536,
-      },
-      family: "google",
-    };
-  }
-  return entries;
-}
-
-/**
- * Register the Google provider in OpenCode config with discovered models.
- * Called from the config hook after the proxy has started.
- *
- * @param {object} config - OpenCode config object (mutable)
- * @param {number} port - Proxy port
- * @param {Array<{ id: string, name: string, contextWindow?: number, maxTokens?: number }>} models
- * @returns {boolean} true if provider was registered/updated
- */
-export function registerGoogleProvider(config, port, models) {
-  if (!config.provider) config.provider = {};
-
-  const providerModels = buildGoogleProviderModels(models);
-  const baseURL = `http://127.0.0.1:${port}/v1beta`;
-
-  const newProvider = {
-    name: "Google (via aidevops proxy)",
-    npm: "@ai-sdk/google",
-    api: baseURL,
-    models: providerModels,
-  };
-
-  const existing = config.provider.google;
-  if (!existing || JSON.stringify(existing) !== JSON.stringify(newProvider)) {
-    config.provider.google = newProvider;
-    return true;
-  }
-
-  return false;
-}
-
-// ---------------------------------------------------------------------------
-// Persist Google provider to opencode.json on disk
-// ---------------------------------------------------------------------------
-
-const OPENCODE_CONFIG_PATH = join(homedir(), ".config", "opencode", "opencode.json");
-
-/**
- * Write the Google provider entry (with models) to opencode.json on disk.
- *
- * OpenCode reads opencode.json from disk for the model list — the config hook
- * only modifies the in-memory config. Without this, Google models don't appear
- * in the Ctrl+T model picker.
- *
- * The port is fixed (32124), so this only needs to run when models change.
- * We read-modify-write the JSON file atomically.
- *
- * @param {number} port - Proxy port
- * @param {Array<{ id: string, name: string, contextWindow?: number, maxTokens?: number }>} models
- */
-function persistGoogleProvider(port, models) {
-  // Start from an empty config on first run (ENOENT) so fresh setups get
-  // Google models registered even before opencode.json exists.
-  let config = {};
-  try {
-    const raw = readFileSync(OPENCODE_CONFIG_PATH, "utf-8");
-    config = JSON.parse(raw);
-  } catch (err) {
-    if (err.code !== "ENOENT") {
-      console.error(`[aidevops] Google proxy: cannot read opencode.json: ${err.message}`);
-      return;
-    }
-    // ENOENT — file doesn't exist yet; proceed with empty config
-  }
-
-  if (!config.provider) config.provider = {};
-
-  const providerModels = buildGoogleProviderModels(models);
-  const baseURL = `http://127.0.0.1:${port}/v1beta`;
-
-  config.provider.google = {
-    name: "Google (via aidevops proxy)",
-    npm: "@ai-sdk/google",
-    api: baseURL,
-    models: providerModels,
-  };
-
-  // Also set the placeholder API key env var to prevent SDK "missing key" error
-  // The proxy handles real auth — this is just to satisfy the SDK's key check
-  if (!process.env.GOOGLE_GENERATIVE_AI_API_KEY) {
-    process.env.GOOGLE_GENERATIVE_AI_API_KEY = "google-pool-proxy";
-  }
-
-  try {
-    // Ensure parent directory exists (e.g., ~/.config/opencode/ on first run)
-    mkdirSync(dirname(OPENCODE_CONFIG_PATH), { recursive: true });
-    writeFileSync(OPENCODE_CONFIG_PATH, JSON.stringify(config, null, 2) + "\n", "utf-8");
-    console.error(`[aidevops] Google proxy: persisted ${models.length} models to opencode.json (port ${port})`);
-  } catch (err) {
-    console.error(`[aidevops] Google proxy: failed to write opencode.json: ${err.message}`);
-  }
-}
+// Provider registration and config-persistence are in ./google-proxy-config.mjs
+// (re-exported above for backward compatibility with callers).

--- a/.agents/plugins/opencode-aidevops/provider-auth-cch.mjs
+++ b/.agents/plugins/opencode-aidevops/provider-auth-cch.mjs
@@ -1,0 +1,252 @@
+/**
+ * CCH billing header computation for provider-auth.mjs.
+ * Extracted to keep provider-auth.mjs file complexity below the threshold.
+ *
+ * Replicates the exact billing header that Claude CLI injects into system[0],
+ * including the xxHash64 body hash that the Bun runtime computes natively.
+ */
+
+import { createHash } from "crypto";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { homedir } from "os";
+import { execFileSync } from "child_process";
+import { getAnthropicUserAgent } from "./oauth-pool.mjs";
+
+// ---------------------------------------------------------------------------
+// xxHash64 — pure JavaScript implementation using BigInt
+// ---------------------------------------------------------------------------
+
+const XXH64_PRIME1 = 0x9E3779B185EBCA87n;
+const XXH64_PRIME2 = 0xC2B2AE3D27D4EB4Fn;
+const XXH64_PRIME3 = 0x165667B19E3779F9n;
+const XXH64_PRIME4 = 0x85EBCA77C2B2AE63n;
+const XXH64_PRIME5 = 0x27D4EB2F165667C5n;
+const XXH64_MASK   = 0xFFFFFFFFFFFFFFFFn;
+const XXHASH_SEED  = 0x6E52736AC806831En;
+
+function xxh64Rotl(val, bits) {
+  const b = BigInt(bits);
+  return ((val << b) | (val >> (64n - b))) & XXH64_MASK;
+}
+
+function xxh64Round(acc, input) {
+  acc = (acc + input * XXH64_PRIME2) & XXH64_MASK;
+  acc = xxh64Rotl(acc, 31);
+  return (acc * XXH64_PRIME1) & XXH64_MASK;
+}
+
+function xxh64MergeRound(acc, val) {
+  val = xxh64Round(0n, val);
+  acc = (acc ^ val) & XXH64_MASK;
+  return (acc * XXH64_PRIME1 + XXH64_PRIME4) & XXH64_MASK;
+}
+
+function xxh64ReadU64LE(buf, off) {
+  let v = 0n;
+  for (let i = 7; i >= 0; i--) v = (v << 8n) | BigInt(buf[off + i]);
+  return v;
+}
+
+function xxh64ReadU32LE(buf, off) {
+  return BigInt(buf[off]) | (BigInt(buf[off + 1]) << 8n) |
+         (BigInt(buf[off + 2]) << 16n) | (BigInt(buf[off + 3]) << 24n);
+}
+
+function xxHash64(input, seed) {
+  const len = input.length;
+  let h64;
+  let p = 0;
+
+  if (len >= 32) {
+    let v1 = (seed + XXH64_PRIME1 + XXH64_PRIME2) & XXH64_MASK;
+    let v2 = (seed + XXH64_PRIME2) & XXH64_MASK;
+    let v3 = seed & XXH64_MASK;
+    let v4 = (seed - XXH64_PRIME1) & XXH64_MASK;
+    const limit = len - 31;
+    while (p < limit) {
+      v1 = xxh64Round(v1, xxh64ReadU64LE(input, p)); p += 8;
+      v2 = xxh64Round(v2, xxh64ReadU64LE(input, p)); p += 8;
+      v3 = xxh64Round(v3, xxh64ReadU64LE(input, p)); p += 8;
+      v4 = xxh64Round(v4, xxh64ReadU64LE(input, p)); p += 8;
+    }
+    h64 = (xxh64Rotl(v1, 1) + xxh64Rotl(v2, 7) + xxh64Rotl(v3, 12) + xxh64Rotl(v4, 18)) & XXH64_MASK;
+    h64 = xxh64MergeRound(h64, v1);
+    h64 = xxh64MergeRound(h64, v2);
+    h64 = xxh64MergeRound(h64, v3);
+    h64 = xxh64MergeRound(h64, v4);
+  } else {
+    h64 = (seed + XXH64_PRIME5) & XXH64_MASK;
+  }
+
+  h64 = (h64 + BigInt(len)) & XXH64_MASK;
+
+  while (p + 8 <= len) {
+    const k1 = xxh64Round(0n, xxh64ReadU64LE(input, p));
+    h64 = ((h64 ^ k1) & XXH64_MASK);
+    h64 = (xxh64Rotl(h64, 27) * XXH64_PRIME1 + XXH64_PRIME4) & XXH64_MASK;
+    p += 8;
+  }
+  if (p + 4 <= len) {
+    h64 = (h64 ^ (xxh64ReadU32LE(input, p) * XXH64_PRIME1)) & XXH64_MASK;
+    h64 = (xxh64Rotl(h64, 23) * XXH64_PRIME2 + XXH64_PRIME3) & XXH64_MASK;
+    p += 4;
+  }
+  while (p < len) {
+    h64 = (h64 ^ (BigInt(input[p]) * XXH64_PRIME5)) & XXH64_MASK;
+    h64 = (xxh64Rotl(h64, 11) * XXH64_PRIME1) & XXH64_MASK;
+    p++;
+  }
+
+  h64 = ((h64 ^ (h64 >> 33n)) * XXH64_PRIME2) & XXH64_MASK;
+  h64 = ((h64 ^ (h64 >> 29n)) * XXH64_PRIME3) & XXH64_MASK;
+  return (h64 ^ (h64 >> 32n)) & XXH64_MASK;
+}
+
+// ---------------------------------------------------------------------------
+// Serialization
+// ---------------------------------------------------------------------------
+
+/**
+ * Serialize a parsed request body with deterministic key ordering.
+ * @param {object} parsed
+ * @returns {string}
+ */
+export function serializeWithKeyOrder(parsed) {
+  const ordered = {};
+  const priorityKeys = ["model", "messages", "system", "tools", "metadata",
+    "max_tokens", "thinking", "context_management", "temperature", "top_p",
+    "top_k", "stop_sequences", "stream"];
+  for (const key of priorityKeys) {
+    if (key in parsed) ordered[key] = parsed[key];
+  }
+  for (const key of Object.keys(parsed)) {
+    if (!(key in ordered)) ordered[key] = parsed[key];
+  }
+  return JSON.stringify(ordered);
+}
+
+/**
+ * Compute the 5-char hex body hash matching Claude CLI's Bun runtime.
+ * @param {string} bodyStr
+ * @returns {string}
+ */
+export function computeBodyHash(bodyStr) {
+  const bytes = new TextEncoder().encode(bodyStr);
+  const hash = xxHash64(bytes, XXHASH_SEED);
+  return (hash & 0xFFFFFn).toString(16).padStart(5, "0");
+}
+
+// ---------------------------------------------------------------------------
+// CCH constants loading
+// ---------------------------------------------------------------------------
+
+/** @type {{ version: string, salt: string, charIndices: number[], entrypoint: string } | null} */
+let _cchConstants = null;
+
+function detectLiveCliVersion() {
+  try {
+    const raw = execFileSync("claude", ["--version"], {
+      timeout: 3000, encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+    const m = raw.match(/^(\d+\.\d+\.\d+)/);
+    return m ? m[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+function refreshCCHCache() {
+  const script = join(homedir(), ".aidevops", "agents", "scripts", "cch-extract.sh");
+  try {
+    execFileSync(script, ["--cache"], { timeout: 10000, encoding: "utf-8", stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function tryReadCacheFile(cacheFile) {
+  try { return JSON.parse(readFileSync(cacheFile, "utf-8")); } catch { return null; }
+}
+
+function refreshCacheIfVersionChanged(raw, cacheFile) {
+  if (!raw?.version) return raw;
+  const liveVersion = detectLiveCliVersion();
+  if (!liveVersion || liveVersion === raw.version) return raw;
+  console.error(`[aidevops] CCH: CLI updated ${raw.version} → ${liveVersion}. Re-extracting constants...`);
+  if (!refreshCCHCache()) return raw;
+  const updated = tryReadCacheFile(cacheFile);
+  if (updated?.version) {
+    console.error(`[aidevops] CCH: constants refreshed for v${updated.version}`);
+    return updated;
+  }
+  return raw;
+}
+
+function ensureCacheExists(raw, cacheFile) {
+  if (raw) return raw;
+  console.error("[aidevops] CCH: no cache found. Extracting constants...");
+  if (!refreshCCHCache()) return null;
+  return tryReadCacheFile(cacheFile);
+}
+
+function buildCCHFromRaw(raw) {
+  return { version: raw.version, salt: raw.salt, charIndices: raw.char_indices || [4, 7, 20], entrypoint: raw.entrypoint || "cli" };
+}
+
+function buildCCHDefaults() {
+  return {
+    version: getAnthropicUserAgent().match(/\/([\d.]+)/)?.[1] || "2.1.92",
+    salt: "59cf53e54c78",
+    charIndices: [4, 7, 20],
+    entrypoint: "cli",
+  };
+}
+
+/**
+ * Load CCH signing constants from cache file or fall back to defaults.
+ * @returns {{ version: string, salt: string, charIndices: number[], entrypoint: string }}
+ */
+export function loadCCHConstants() {
+  if (_cchConstants) return _cchConstants;
+  const cacheFile = join(homedir(), ".aidevops", "cch-constants.json");
+  let raw = tryReadCacheFile(cacheFile);
+  raw = refreshCacheIfVersionChanged(raw, cacheFile);
+  raw = ensureCacheExists(raw, cacheFile);
+  _cchConstants = (raw?.version && raw?.salt) ? buildCCHFromRaw(raw) : buildCCHDefaults();
+  return _cchConstants;
+}
+
+// ---------------------------------------------------------------------------
+// Billing header construction
+// ---------------------------------------------------------------------------
+
+function computeVersionSuffix(userMessage) {
+  const { salt, charIndices, version } = loadCCHConstants();
+  const chars = charIndices.map((i) => userMessage[i] || "0").join("");
+  const payload = `${salt}${chars}${version}`;
+  return createHash("sha256").update(payload).digest("hex").slice(0, 3);
+}
+
+/**
+ * Build the complete billing header string for a request body.
+ * @param {object} parsed - parsed JSON request body with system/messages
+ * @returns {string}
+ */
+export function buildBillingHeader(parsed) {
+  const { version, entrypoint } = loadCCHConstants();
+  let firstUserText = "";
+  const messages = parsed.messages || [];
+  for (const msg of messages) {
+    if (msg.role !== "user") continue;
+    if (typeof msg.content === "string") { firstUserText = msg.content; break; }
+    if (Array.isArray(msg.content)) {
+      const textBlock = msg.content.find((b) => b.type === "text");
+      if (textBlock?.text) { firstUserText = textBlock.text; break; }
+    }
+    break;
+  }
+  const suffix = computeVersionSuffix(firstUserText);
+  return `x-anthropic-billing-header: cc_version=${version}.${suffix}; cc_entrypoint=${entrypoint}; cch=00000;`;
+}

--- a/.agents/plugins/opencode-aidevops/provider-auth-pool-recovery.mjs
+++ b/.agents/plugins/opencode-aidevops/provider-auth-pool-recovery.mjs
@@ -1,0 +1,132 @@
+/**
+ * OAuth pool exhaustion recovery helpers for provider-auth.mjs.
+ * Extracted to keep per-file complexity below the threshold.
+ */
+
+import { ensureValidToken, getAccounts, patchAccount, normalizeExpiredCooldowns } from "./oauth-pool.mjs";
+import { injectAccountToken, activateAccount, isOnCooldown, tokenResult } from "./provider-auth-pool.mjs";
+
+/** Default cooldown when rate limited mid-session (ms) */
+export const RATE_LIMIT_COOLDOWN_MS = 5_000;
+/** Default cooldown on auth failure (ms) */
+export const AUTH_FAILURE_COOLDOWN_MS = 300_000;
+/** Max wait when all accounts exhausted (ms) */
+const MAX_EXHAUSTION_WAIT_MS = 15_000;
+/** Poll interval when waiting for cooldowns (ms) */
+const EXHAUSTION_POLL_MS = 5_000;
+
+/**
+ * Parse a Retry-After header value string into milliseconds.
+ * @param {string} raw @returns {number|null}
+ */
+export function parseRetryAfterValue(raw) {
+  const seconds = parseInt(raw, 10);
+  if (Number.isFinite(seconds) && seconds > 0) return seconds * 1000;
+  const date = Date.parse(raw);
+  if (Number.isFinite(date)) return date - Date.now();
+  return null;
+}
+
+/**
+ * Parse Retry-After header into milliseconds. Falls back to RATE_LIMIT_COOLDOWN_MS.
+ * @param {Response} response @returns {number}
+ */
+export function parseRetryAfterMs(response) {
+  const raw = response.headers?.get?.("retry-after");
+  const parsed = raw ? parseRetryAfterValue(raw) : null;
+  return parsed !== null ? Math.max(parsed, RATE_LIMIT_COOLDOWN_MS) : RATE_LIMIT_COOLDOWN_MS;
+}
+
+/** @param {any} client @param {object} account @param {number} waitStart @param {string} logPrefix */
+export async function tryRecoverAccount(client, account, waitStart, logPrefix) {
+  let altToken;
+  try { altToken = await ensureValidToken("anthropic", account); } catch { return null; }
+  if (!altToken) return null;
+  try { await injectAccountToken(client, account); } catch { /* best-effort */ }
+  const elapsed = Math.ceil((Date.now() - waitStart) / 1000);
+  console.error(`[aidevops] provider-auth: ${logPrefix} recovered via ${account.email} after ${elapsed}s wait`);
+  return { token: altToken, email: account.email };
+}
+
+/** @param {object[]} accounts @param {string} currentEmail @param {string} logPrefix @param {number} now */
+export function logExhaustionOnce(accounts, currentEmail, logPrefix, now) {
+  const accountSummary = accounts.map((a) => {
+    const cd = a.cooldownUntil && a.cooldownUntil > now ? ` (${Math.ceil((a.cooldownUntil - now) / 1000)}s)` : "";
+    return `${a.email}[${a.status}${cd}]`;
+  }).join(", ");
+  console.error(`[aidevops] provider-auth: ${logPrefix} for ${currentEmail} — all accounts on cooldown, waiting... ${accountSummary}`);
+}
+
+/** @param {string} logPrefix @returns {{account: object, accounts: object[], now: number}|null} */
+export function findRecoveredAccount(logPrefix) {
+  const now = Date.now();
+  const freshAccounts = getAccounts("anthropic");
+  normalizeExpiredCooldowns("anthropic", freshAccounts);
+  const recovered = freshAccounts.find(
+    (a) => a.status !== "auth-error" && (!a.cooldownUntil || a.cooldownUntil <= now),
+  );
+  return recovered ? { account: recovered, accounts: freshAccounts, now } : null;
+}
+
+/** @param {boolean} firstIteration @param {string} currentEmail @param {string} logPrefix */
+export function maybeLogExhaustion(firstIteration, currentEmail, logPrefix) {
+  if (!firstIteration) return false;
+  const now = Date.now();
+  const freshAccounts = getAccounts("anthropic");
+  logExhaustionOnce(freshAccounts, currentEmail, logPrefix, now);
+  return false;
+}
+
+/** @param {any} client @param {string} currentEmail @param {string} logPrefix */
+export async function waitForCooldownRecovery(client, currentEmail, logPrefix) {
+  const waitStart = Date.now();
+  let firstIteration = true;
+  while (Date.now() - waitStart < MAX_EXHAUSTION_WAIT_MS) {
+    const found = findRecoveredAccount(logPrefix);
+    if (found) {
+      const result = await tryRecoverAccount(client, found.account, waitStart, logPrefix);
+      if (result) return result;
+    }
+    firstIteration = maybeLogExhaustion(firstIteration, currentEmail, logPrefix);
+    await new Promise((r) => setTimeout(r, EXHAUSTION_POLL_MS));
+  }
+  return null;
+}
+
+/** @param {string} logPrefix */
+export function forceClearAllCooldowns(logPrefix) {
+  const accounts = getAccounts("anthropic");
+  for (const acc of accounts) patchAccount("anthropic", acc.email, { status: "idle", cooldownUntil: 0 });
+  console.error(`[aidevops] provider-auth: ${logPrefix} — force-cleared all cooldowns after ${MAX_EXHAUSTION_WAIT_MS / 1000}s. Returning response for opencode retry.`);
+}
+
+/** @param {object[]} accounts @param {string} sessionAccountEmail */
+export function findSessionAccount(accounts, sessionAccountEmail) {
+  const account = accounts.find((a) => a.email === sessionAccountEmail);
+  if (!account || isOnCooldown(account)) return null;
+  return account;
+}
+
+/** @param {any} client @param {object[]} accounts @param {string} sessionAccountEmail */
+export async function refreshSessionOwnAccount(client, accounts, sessionAccountEmail) {
+  const myAccount = findSessionAccount(accounts, sessionAccountEmail);
+  if (!myAccount) return null;
+  const token = await ensureValidToken("anthropic", myAccount);
+  if (!token) return null;
+  try { await injectAccountToken(client, myAccount); } catch { /* best-effort */ }
+  activateAccount(myAccount.email);
+  console.error(`[aidevops] provider-auth: refreshed session account ${myAccount.email}`);
+  return { token, email: myAccount.email };
+}
+
+/** @param {any} client @param {object} auth @param {string|null} sessionAccountEmail */
+export async function recoverFromExhaustion(client, auth, sessionAccountEmail) {
+  const recovered = await waitForCooldownRecovery(client, "all", "exhaustion");
+  if (recovered) {
+    process.env.ANTHROPIC_API_KEY = recovered.token;
+    activateAccount(recovered.email);
+    return tokenResult(recovered);
+  }
+  forceClearAllCooldowns("exhaustion");
+  return { accessToken: auth.access, sessionAccountEmail };
+}

--- a/.agents/plugins/opencode-aidevops/provider-auth-pool.mjs
+++ b/.agents/plugins/opencode-aidevops/provider-auth-pool.mjs
@@ -1,0 +1,153 @@
+/**
+ * OAuth pool account selection and rotation helpers for provider-auth.mjs.
+ * Extracted to keep per-file complexity below the threshold.
+ */
+
+import { ensureValidToken, getAccounts, patchAccount } from "./oauth-pool.mjs";
+
+/** Priority order for account status during pool rotation (lower = tried first). */
+export const STATUS_ORDER = { active: 0, idle: 1, "rate-limited": 2, "auth-error": 3 };
+
+/**
+ * Inject a pool account token into the OpenCode auth store.
+ * @param {any} client
+ * @param {object} account
+ */
+export async function injectAccountToken(client, account) {
+  await client.auth.set({
+    path: { id: "anthropic" },
+    body: { type: "oauth", refresh: account.refresh, access: account.access, expires: account.expires },
+  });
+}
+
+/** @param {object} a @param {object} b */
+export function compareAccountPriority(a, b) {
+  const aOrder = STATUS_ORDER[a.status] ?? 99;
+  const bOrder = STATUS_ORDER[b.status] ?? 99;
+  if (aOrder !== bOrder) return aOrder - bOrder;
+  return new Date(a.lastUsed || 0) - new Date(b.lastUsed || 0);
+}
+
+/** @param {object[]} accounts @returns {object[]} */
+export function sortAccountsByPriority(accounts) {
+  return [...accounts].sort(compareAccountPriority);
+}
+
+/** @param {object} account @param {string} currentEmail @param {number} now */
+export function isEligibleAlternate(account, currentEmail, now) {
+  return (
+    account.email !== currentEmail &&
+    (account.status === "active" || account.status === "idle") &&
+    (!account.cooldownUntil || account.cooldownUntil <= now)
+  );
+}
+
+/** @param {object[]} accounts @param {string} currentEmail @returns {object[]} */
+export function getAvailableAlternates(accounts, currentEmail) {
+  const now = Date.now();
+  return [...accounts]
+    .filter((a) => isEligibleAlternate(a, currentEmail, now))
+    .sort((a, b) => new Date(a.lastUsed || 0) - new Date(b.lastUsed || 0));
+}
+
+/** Activate an account: patch lastUsed/status. Returns email. */
+export function activateAccount(email) {
+  patchAccount("anthropic", email, { lastUsed: new Date().toISOString(), status: "active" });
+  return email;
+}
+
+/** @param {object} account @returns {boolean} */
+export function isOnCooldown(account) {
+  return !!(account.cooldownUntil && account.cooldownUntil > Date.now());
+}
+
+/** @param {any} client @param {object} account @param {boolean} forceRefresh */
+export async function tryGetAndInjectToken(client, account, forceRefresh) {
+  const accountArg = forceRefresh ? { ...account, expires: 0 } : account;
+  let token;
+  try {
+    token = await ensureValidToken("anthropic", accountArg);
+  } catch (err) {
+    console.error(`[aidevops] provider-auth: ensureValidToken failed for ${account.email}: ${err.message}`);
+    return null;
+  }
+  if (!token) return null;
+  try {
+    await injectAccountToken(client, account);
+  } catch (err) {
+    console.error(`[aidevops] provider-auth: failed to inject token for ${account.email}: ${err.message}`);
+    return null;
+  }
+  return token;
+}
+
+/** @param {any} client @param {object[]} alternates @param {boolean} forceRefresh */
+export async function rotateToAlternateAccount(client, alternates, forceRefresh) {
+  for (const alt of alternates) {
+    const token = await tryGetAndInjectToken(client, alt, forceRefresh);
+    if (token) return { token, email: alt.email };
+  }
+  return null;
+}
+
+/** @param {any} client @param {object} account */
+export async function tryActivatePoolAccount(client, account) {
+  const token = await ensureValidToken("anthropic", account);
+  if (!token) return null;
+  try { await injectAccountToken(client, account); } catch { /* best-effort */ }
+  activateAccount(account.email);
+  console.error(`[aidevops] provider-auth: refreshed via pool account ${account.email}`);
+  return { token, email: account.email };
+}
+
+/** @param {any} client @param {object[]} accounts */
+export async function rotatePoolAccounts(client, accounts) {
+  for (const account of sortAccountsByPriority(accounts)) {
+    if (isOnCooldown(account)) {
+      console.error(`[aidevops] provider-auth: skipping ${account.email} — cooldown active`);
+      continue;
+    }
+    const result = await tryActivatePoolAccount(client, account);
+    if (result) return result;
+  }
+  return null;
+}
+
+/** @param {string|null} sessionAccountEmail @param {object} auth */
+export function getSessionAccountToken(sessionAccountEmail, auth) {
+  if (!sessionAccountEmail) return { accessToken: auth.access, accessExpires: auth.expires };
+  const myAccount = getAccounts("anthropic").find((a) => a.email === sessionAccountEmail);
+  if (myAccount?.access && myAccount.expires > Date.now()) {
+    return { accessToken: myAccount.access, accessExpires: myAccount.expires };
+  }
+  return { accessToken: auth.access, accessExpires: auth.expires };
+}
+
+/** @param {string} accessToken @param {string|null} sessionAccountEmail */
+export function resolveSessionEmailFromToken(accessToken, sessionAccountEmail) {
+  if (sessionAccountEmail) return sessionAccountEmail;
+  const owner = getAccounts("anthropic").find((a) => a.access === accessToken);
+  return owner ? owner.email : null;
+}
+
+/** Wrap a token result into { accessToken, sessionAccountEmail }. */
+export function tokenResult(result) {
+  return { accessToken: result.token, sessionAccountEmail: result.email };
+}
+
+/** @param {object[]} accounts @returns {object|null} */
+export function getMostRecentlyUsedAccount(accounts) {
+  if (accounts.length === 0) return null;
+  const mru = [...accounts].sort((a, b) => new Date(b.lastUsed || 0) - new Date(a.lastUsed || 0))[0];
+  console.error(`[aidevops] provider-auth: no token match — assuming ${mru.email} (most recently used)`);
+  return mru;
+}
+
+/** @param {object[]} accounts @param {string|null} sessionAccountEmail @param {string} accessToken */
+export function resolveCurrentAccount(accounts, sessionAccountEmail, accessToken) {
+  if (sessionAccountEmail) {
+    const found = accounts.find((a) => a.email === sessionAccountEmail);
+    if (found) return found;
+  }
+  return accounts.find((a) => a.access === accessToken) ?? getMostRecentlyUsedAccount(accounts);
+}

--- a/.agents/plugins/opencode-aidevops/provider-auth-request.mjs
+++ b/.agents/plugins/opencode-aidevops/provider-auth-request.mjs
@@ -1,0 +1,225 @@
+/**
+ * Request/response transformation helpers for provider-auth.mjs.
+ * Extracted to keep per-file complexity below the threshold.
+ */
+
+import { getAnthropicUserAgent } from "./oauth-pool.mjs";
+import { buildBillingHeader, serializeWithKeyOrder, loadCCHConstants, computeBodyHash } from "./provider-auth-cch.mjs";
+
+// ---------------------------------------------------------------------------
+// Tool name namespace
+// ---------------------------------------------------------------------------
+
+export const TOOL_PREFIX = "mcp__aidevops__";
+
+export const REQUIRED_BETAS = [
+  "oauth-2025-04-20",
+  "interleaved-thinking-2025-05-14",
+  "prompt-caching-scope-2026-01-05",
+  "claude-code-20250219",
+];
+
+export const DEPRECATED_BETAS = new Set([
+  "code-execution-2025-01-24",
+  "extended-cache-ttl-2025-04-11",
+]);
+
+// ---------------------------------------------------------------------------
+// Header building
+// ---------------------------------------------------------------------------
+
+function copyHeadersInstance(target, source) {
+  source.forEach((value, key) => target.set(key, value));
+}
+
+function copyHeadersArray(target, entries) {
+  for (const [key, value] of entries) {
+    if (typeof value !== "undefined") target.set(key, String(value));
+  }
+}
+
+function copyHeadersObject(target, obj) {
+  for (const [key, value] of Object.entries(obj)) {
+    if (typeof value !== "undefined") target.set(key, String(value));
+  }
+}
+
+function mergeInitHeaders(target, initHeaders) {
+  if (!initHeaders) return;
+  if (initHeaders instanceof Headers) copyHeadersInstance(target, initHeaders);
+  else if (Array.isArray(initHeaders)) copyHeadersArray(target, initHeaders);
+  else copyHeadersObject(target, initHeaders);
+}
+
+function mergeBetaHeaders() {
+  return REQUIRED_BETAS.join(",");
+}
+
+/**
+ * Build outgoing request headers with auth, betas, stainless metadata.
+ * @param {Request|string|URL} input @param {RequestInit} init @param {string} accessToken
+ */
+export function buildRequestHeaders(input, init, accessToken) {
+  const requestHeaders = new Headers();
+  if (input instanceof Request) input.headers.forEach((value, key) => requestHeaders.set(key, value));
+  mergeInitHeaders(requestHeaders, init?.headers);
+  requestHeaders.set("authorization", `Bearer ${accessToken}`);
+  requestHeaders.set("anthropic-beta", mergeBetaHeaders());
+  requestHeaders.set("anthropic-dangerous-direct-browser-access", "true");
+  requestHeaders.set("anthropic-version", "2023-06-01");
+  requestHeaders.set("user-agent", getAnthropicUserAgent());
+  requestHeaders.set("x-app", "cli");
+  requestHeaders.set("accept", "application/json");
+  requestHeaders.set("content-type", "application/json");
+  if (!requestHeaders.has("x-claude-code-session-id")) {
+    requestHeaders.set("x-claude-code-session-id", globalThis._claudeCodeSessionId ??= crypto.randomUUID());
+  }
+  requestHeaders.set("x-client-request-id", crypto.randomUUID());
+  const { version } = loadCCHConstants();
+  requestHeaders.set("X-Stainless-Arch", process.arch === "arm64" ? "arm64" : "x64");
+  requestHeaders.set("X-Stainless-Lang", "js");
+  requestHeaders.set("X-Stainless-OS", process.platform === "darwin" ? "Mac OS X" : "Linux");
+  requestHeaders.set("X-Stainless-Package-Version", "0.81.0");
+  requestHeaders.set("X-Stainless-Retry-Count", "0");
+  requestHeaders.set("X-Stainless-Runtime", "node");
+  requestHeaders.set("X-Stainless-Runtime-Version", process.version);
+  requestHeaders.set("X-Stainless-Timeout", "600");
+  requestHeaders.delete("x-api-key");
+  requestHeaders.delete("x-session-affinity");
+  return requestHeaders;
+}
+
+// ---------------------------------------------------------------------------
+// Body transformation
+// ---------------------------------------------------------------------------
+
+const TAG_RENAMES = [
+  [/<directories>/g, "<working_dirs>"],     [/<\/directories>/g, "</working_dirs>"],
+  [/<available_skills>/g, "<skill_list>"],   [/<\/available_skills>/g, "</skill_list>"],
+  [/<env>/g, "<environment>"],               [/<\/env>/g, "</environment>"],
+];
+
+function sanitizeSystemPrompt(system) {
+  return system.map((item) => {
+    if (item.type !== "text" || !item.text) return item;
+    let text = item.text.replace(/OpenCode/g, "Claude Code").replace(/opencode/gi, "Claude");
+    for (const [pattern, replacement] of TAG_RENAMES) text = text.replace(pattern, replacement);
+    return { ...item, text };
+  });
+}
+
+function prefixToolNames(tools) {
+  return tools.map((tool) => {
+    if (!tool.name || tool.name.startsWith("mcp__")) return tool;
+    return { ...tool, name: `${TOOL_PREFIX}${tool.name}` };
+  });
+}
+
+function prefixToolUseBlocks(messages) {
+  return messages.map((msg) => {
+    if (!msg.content || !Array.isArray(msg.content)) return msg;
+    return {
+      ...msg,
+      content: msg.content.map((block) => {
+        if (block.type === "tool_use" && block.name && !block.name.startsWith("mcp__")) {
+          return { ...block, name: `${TOOL_PREFIX}${block.name}` };
+        }
+        return block;
+      }),
+    };
+  });
+}
+
+function isAdaptiveThinkingModel(model) {
+  if (!model) return false;
+  return /claude-[a-z]+-4[-.]6/i.test(model);
+}
+
+function applyBodyTransforms(parsed) {
+  const billingText = buildBillingHeader(parsed);
+  if (!Array.isArray(parsed.system)) parsed.system = [];
+  parsed.system = parsed.system.filter(
+    (b) => !(b.type === "text" && b.text?.startsWith("x-anthropic-billing-header:")),
+  );
+  parsed.system.unshift({ type: "text", text: billingText });
+  parsed.system = sanitizeSystemPrompt(parsed.system);
+  if (Array.isArray(parsed.tools)) parsed.tools = prefixToolNames(parsed.tools);
+  if (Array.isArray(parsed.messages)) parsed.messages = prefixToolUseBlocks(parsed.messages);
+  if (isAdaptiveThinkingModel(parsed.model)) {
+    if (!parsed.thinking || parsed.thinking.type !== "adaptive") parsed.thinking = { type: "adaptive" };
+    if (parsed.temperature !== undefined && parsed.temperature !== 1) parsed.temperature = 1;
+  }
+}
+
+/**
+ * Transform the request body: sanitize system prompt, prefix tool names.
+ * @param {string|null|undefined} body @returns {string|null|undefined}
+ */
+export function transformRequestBody(body) {
+  if (!body || typeof body !== "string") return body;
+  try {
+    const parsed = JSON.parse(body);
+    applyBodyTransforms(parsed);
+    const serialized = serializeWithKeyOrder(parsed);
+    void computeBodyHash;
+    return serialized;
+  } catch {
+    return body;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// URL helpers
+// ---------------------------------------------------------------------------
+
+function parseRequestUrl(input) {
+  try {
+    if (typeof input === "string" || input instanceof URL) return new URL(input.toString());
+    if (input instanceof Request) return new URL(input.url);
+  } catch { /* ignore */ }
+  return null;
+}
+
+function rewriteUrlWithBeta(url, input) {
+  url.searchParams.set("beta", "true");
+  return input instanceof Request ? new Request(url.toString(), input) : url;
+}
+
+/**
+ * Add ?beta=true to /v1/messages requests if not already present.
+ * @param {Request|string|URL} input @returns {Request|URL|string}
+ */
+export function addBetaQueryParam(input) {
+  const requestUrl = parseRequestUrl(input);
+  if (!requestUrl || requestUrl.pathname !== "/v1/messages" || requestUrl.searchParams.has("beta")) return input;
+  return rewriteUrlWithBeta(requestUrl, input);
+}
+
+// ---------------------------------------------------------------------------
+// Response stream transformation
+// ---------------------------------------------------------------------------
+
+function stripMcpPrefix(text) {
+  return text.replace(/"name"\s*:\s*"mcp__aidevops__([^"]+)"/g, '"name":"$1"');
+}
+
+function makeStreamPullHandler(reader, decoder, encoder) {
+  return async function pull(controller) {
+    const { done, value } = await reader.read();
+    if (done) { controller.close(); return; }
+    controller.enqueue(encoder.encode(stripMcpPrefix(decoder.decode(value, { stream: true }))));
+  };
+}
+
+/**
+ * Wrap a response body stream to strip mcp_ prefix from tool names.
+ * @param {Response} response @returns {Response}
+ */
+export function transformResponseStream(response) {
+  if (!response.body) return response;
+  const reader = response.body.getReader();
+  const stream = new ReadableStream({
+    pull: makeStreamPullHandler(reader, new TextDecoder(), new TextEncoder()),
+  });
+  return new Response(stream, { status: response.status, statusText: response.statusText, headers: response.headers });
+}

--- a/.agents/plugins/opencode-aidevops/provider-auth.mjs
+++ b/.agents/plugins/opencode-aidevops/provider-auth.mjs
@@ -9,1101 +9,33 @@
  *   - User-Agent matching current Claude CLI version
  *   - Deprecated beta header filtering
  *   - Pool token injection on session start
- *   - Mid-session 401/403 recovery: on invalid/revoked token, force-refreshes
- *     the current account's token first; if that fails, rotates to next pool
- *     account with force-refresh, and retries once
- *   - Mid-session 429 rotation: on rate limit, marks current account as
- *     rate-limited, rotates to next pool account, and retries once
- *   - Session-level account affinity (t1714): each session remembers its
- *     account in closure memory, preventing cross-session token overwrites
- *     when multiple sessions share the same auth store file
+ *   - Mid-session 401/403 recovery
+ *   - Mid-session 429 rotation
+ *   - Session-level account affinity (t1714)
  *
- * The pool (oauth-pool.mjs) manages multiple account tokens.
- * This module makes the built-in provider use them correctly.
+ * Implementation is split across sibling files for complexity management:
+ *   - provider-auth-cch.mjs: CCH billing header computation (xxHash64, etc.)
+ *   - provider-auth-pool.mjs: pool account selection and rotation
+ *   - provider-auth-pool-recovery.mjs: exhaustion recovery, rate-limit handling
+ *   - provider-auth-request.mjs: request/response transformation
  */
 
-import { ensureValidToken, getAccounts, patchAccount, getAnthropicUserAgent, normalizeExpiredCooldowns } from "./oauth-pool.mjs";
-import { createHash } from "crypto";
-import { readFileSync } from "fs";
-import { join } from "path";
-import { homedir } from "os";
-import { execFileSync } from "child_process";
-
-// ---------------------------------------------------------------------------
-// CCH billing header computation (t1880, t2001)
-//
-// Replicates the exact billing header that Claude CLI injects into system[0],
-// including the xxHash64 body hash that the Bun runtime computes natively.
-//
-// Two-part signing:
-//   Part 1 (version suffix): SHA-256(salt + picked_chars + version)[:3]
-//   Part 2 (body hash):      xxHash64(body_utf8, seed) & 0xFFFFF → 5-char hex
-//
-// Constants are loaded from ~/.aidevops/cch-constants.json (written by
-// cch-extract.sh --cache) or fall back to hardcoded defaults for the
-// currently installed CLI version.
-//
-// On each session start (first loadCCHConstants() call), the cached version
-// is compared against the installed CLI. If the CLI has auto-updated, the
-// cache is re-extracted automatically — no manual intervention needed.
-// ---------------------------------------------------------------------------
-
-// ---------------------------------------------------------------------------
-// xxHash64 — pure JavaScript implementation using BigInt
-//
-// Matches the native xxHash64 in Bun's custom fetch. No external dependency.
-// Reference: https://github.com/Cyan4973/xxHash/blob/dev/doc/xxhash_spec.md
-// ---------------------------------------------------------------------------
-
-const XXH64_PRIME1 = 0x9E3779B185EBCA87n;
-const XXH64_PRIME2 = 0xC2B2AE3D27D4EB4Fn;
-const XXH64_PRIME3 = 0x165667B19E3779F9n;
-const XXH64_PRIME4 = 0x85EBCA77C2B2AE63n;
-const XXH64_PRIME5 = 0x27D4EB2F165667C5n;
-const XXH64_MASK   = 0xFFFFFFFFFFFFFFFFn;
-
-/** @type {bigint} xxHash64 seed from Claude CLI's Bun binary */
-const XXHASH_SEED = 0x6E52736AC806831En;
-
-function xxh64Rotl(val, bits) {
-  const b = BigInt(bits);
-  return ((val << b) | (val >> (64n - b))) & XXH64_MASK;
-}
-
-function xxh64Round(acc, input) {
-  acc = (acc + input * XXH64_PRIME2) & XXH64_MASK;
-  acc = xxh64Rotl(acc, 31);
-  return (acc * XXH64_PRIME1) & XXH64_MASK;
-}
-
-function xxh64MergeRound(acc, val) {
-  val = xxh64Round(0n, val);
-  acc = (acc ^ val) & XXH64_MASK;
-  return (acc * XXH64_PRIME1 + XXH64_PRIME4) & XXH64_MASK;
-}
-
-function xxh64ReadU64LE(buf, off) {
-  let v = 0n;
-  for (let i = 7; i >= 0; i--) v = (v << 8n) | BigInt(buf[off + i]);
-  return v;
-}
-
-function xxh64ReadU32LE(buf, off) {
-  return BigInt(buf[off]) | (BigInt(buf[off + 1]) << 8n) |
-         (BigInt(buf[off + 2]) << 16n) | (BigInt(buf[off + 3]) << 24n);
-}
-
-/**
- * Compute xxHash64 of a Uint8Array with a BigInt seed.
- * @param {Uint8Array} input
- * @param {bigint} seed
- * @returns {bigint}
- */
-function xxHash64(input, seed) {
-  const len = input.length;
-  let h64;
-  let p = 0;
-
-  if (len >= 32) {
-    let v1 = (seed + XXH64_PRIME1 + XXH64_PRIME2) & XXH64_MASK;
-    let v2 = (seed + XXH64_PRIME2) & XXH64_MASK;
-    let v3 = seed & XXH64_MASK;
-    let v4 = (seed - XXH64_PRIME1) & XXH64_MASK;
-
-    const limit = len - 31;
-    while (p < limit) {
-      v1 = xxh64Round(v1, xxh64ReadU64LE(input, p)); p += 8;
-      v2 = xxh64Round(v2, xxh64ReadU64LE(input, p)); p += 8;
-      v3 = xxh64Round(v3, xxh64ReadU64LE(input, p)); p += 8;
-      v4 = xxh64Round(v4, xxh64ReadU64LE(input, p)); p += 8;
-    }
-
-    h64 = (xxh64Rotl(v1, 1) + xxh64Rotl(v2, 7) + xxh64Rotl(v3, 12) + xxh64Rotl(v4, 18)) & XXH64_MASK;
-    h64 = xxh64MergeRound(h64, v1);
-    h64 = xxh64MergeRound(h64, v2);
-    h64 = xxh64MergeRound(h64, v3);
-    h64 = xxh64MergeRound(h64, v4);
-  } else {
-    h64 = (seed + XXH64_PRIME5) & XXH64_MASK;
-  }
-
-  h64 = (h64 + BigInt(len)) & XXH64_MASK;
-
-  while (p + 8 <= len) {
-    const k1 = xxh64Round(0n, xxh64ReadU64LE(input, p));
-    h64 = ((h64 ^ k1) & XXH64_MASK);
-    h64 = (xxh64Rotl(h64, 27) * XXH64_PRIME1 + XXH64_PRIME4) & XXH64_MASK;
-    p += 8;
-  }
-
-  if (p + 4 <= len) {
-    h64 = (h64 ^ (xxh64ReadU32LE(input, p) * XXH64_PRIME1)) & XXH64_MASK;
-    h64 = (xxh64Rotl(h64, 23) * XXH64_PRIME2 + XXH64_PRIME3) & XXH64_MASK;
-    p += 4;
-  }
-
-  while (p < len) {
-    h64 = (h64 ^ (BigInt(input[p]) * XXH64_PRIME5)) & XXH64_MASK;
-    h64 = (xxh64Rotl(h64, 11) * XXH64_PRIME1) & XXH64_MASK;
-    p++;
-  }
-
-  h64 = ((h64 ^ (h64 >> 33n)) * XXH64_PRIME2) & XXH64_MASK;
-  h64 = ((h64 ^ (h64 >> 29n)) * XXH64_PRIME3) & XXH64_MASK;
-  h64 = (h64 ^ (h64 >> 32n)) & XXH64_MASK;
-
-  return h64;
-}
-
-/**
- * Compute the 5-char hex body hash matching Claude CLI's Bun runtime.
- * @param {string} bodyStr - JSON body string containing cch=00000 placeholder
- * @returns {string} 5-char lowercase hex hash
- */
-function computeBodyHash(bodyStr) {
-  const bytes = new TextEncoder().encode(bodyStr);
-  const hash = xxHash64(bytes, XXHASH_SEED);
-  return (hash & 0xFFFFFn).toString(16).padStart(5, "0");
-}
-
-/**
- * Serialize a parsed request body with deterministic key ordering.
- * @param {object} parsed
- * @returns {string}
- */
-function serializeWithKeyOrder(parsed) {
-  // Match real Claude CLI's exact serialization order (captured via MITM)
-  const ordered = {};
-  const priorityKeys = ["model", "messages", "system", "tools", "metadata",
-    "max_tokens", "thinking", "context_management", "temperature", "top_p",
-    "top_k", "stop_sequences", "stream"];
-  for (const key of priorityKeys) {
-    if (key in parsed) ordered[key] = parsed[key];
-  }
-  for (const key of Object.keys(parsed)) {
-    if (!(key in ordered)) ordered[key] = parsed[key];
-  }
-  return JSON.stringify(ordered);
-}
-
-/** @type {{ version: string, salt: string, charIndices: number[], entrypoint: string } | null} */
-let _cchConstants = null;
-
-/**
- * Detect the currently installed Claude CLI version (fast — ~50ms).
- * @returns {string|null}
- */
-function detectLiveCliVersion() {
-  try {
-    const raw = execFileSync("claude", ["--version"], {
-      timeout: 3000, encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"],
-    }).trim();
-    const m = raw.match(/^(\d+\.\d+\.\d+)/);
-    return m ? m[1] : null;
-  } catch {
-    return null;
-  }
-}
-
-/**
- * Re-extract CCH constants from the installed CLI.
- * Runs cch-extract.sh --cache in the background. Returns true on success.
- * @returns {boolean}
- */
-function refreshCCHCache() {
-  const script = join(homedir(), ".aidevops", "agents", "scripts", "cch-extract.sh");
-  try {
-    execFileSync(script, ["--cache"], {
-      timeout: 10000, encoding: "utf-8", stdio: "ignore",
-    });
-    return true;
-  } catch {
-    return false;
-  }
-}
-
-/**
- * Load CCH signing constants from cache file or fall back to defaults.
- * On first call, checks if the cached version matches the installed CLI.
- * If the CLI has auto-updated, re-extracts constants automatically.
- * @returns {{ version: string, salt: string, charIndices: number[], entrypoint: string }}
- */
-function loadCCHConstants() {
-  if (_cchConstants) return _cchConstants;
-  const cacheFile = join(homedir(), ".aidevops", "cch-constants.json");
-  let raw = null;
-
-  try {
-    raw = JSON.parse(readFileSync(cacheFile, "utf-8"));
-  } catch {
-    // No cache — will fall back below
-  }
-
-  // Version-change detection: compare cache against live CLI
-  if (raw?.version) {
-    const liveVersion = detectLiveCliVersion();
-    if (liveVersion && liveVersion !== raw.version) {
-      console.error(
-        `[aidevops] CCH: CLI updated ${raw.version} → ${liveVersion}. Re-extracting constants...`,
-      );
-      if (refreshCCHCache()) {
-        try {
-          raw = JSON.parse(readFileSync(cacheFile, "utf-8"));
-          console.error(`[aidevops] CCH: constants refreshed for v${raw.version}`);
-        } catch {
-          // Use stale cache — better than nothing
-        }
-      }
-    }
-  } else if (!raw) {
-    // No cache at all — try to create one
-    console.error("[aidevops] CCH: no cache found. Extracting constants...");
-    if (refreshCCHCache()) {
-      try { raw = JSON.parse(readFileSync(cacheFile, "utf-8")); } catch { /* ignore */ }
-    }
-  }
-
-  if (raw?.version && raw?.salt) {
-    _cchConstants = {
-      version: raw.version,
-      salt: raw.salt,
-      charIndices: raw.char_indices || [4, 7, 20],
-      entrypoint: raw.entrypoint || "cli",
-    };
-  } else {
-    // Last resort: use detected User-Agent version with known defaults
-    _cchConstants = {
-      version: getAnthropicUserAgent().match(/\/([\d.]+)/)?.[1] || "2.1.92",
-      salt: "59cf53e54c78",
-      charIndices: [4, 7, 20],
-      entrypoint: "cli",
-    };
-  }
-  return _cchConstants;
-}
-
-/**
- * Compute the 3-char hex version suffix from the first user message.
- * sha256(salt + picked_chars + version)[:3]
- * @param {string} userMessage - text of the first user message
- * @returns {string}
- */
-function computeVersionSuffix(userMessage) {
-  const { salt, charIndices, version } = loadCCHConstants();
-  const chars = charIndices.map((i) => userMessage[i] || "0").join("");
-  const payload = `${salt}${chars}${version}`;
-  return createHash("sha256").update(payload).digest("hex").slice(0, 3);
-}
-
-/**
- * Build the complete billing header string for a request body.
- * @param {object} parsed - parsed JSON request body with system/messages
- * @returns {string}
- */
-function buildBillingHeader(parsed) {
-  const { version, entrypoint } = loadCCHConstants();
-  // Extract first user message text (same logic as Claude CLI's HBY/SBY functions)
-  let firstUserText = "";
-  const messages = parsed.messages || [];
-  for (const msg of messages) {
-    if (msg.role !== "user") continue;
-    if (typeof msg.content === "string") { firstUserText = msg.content; break; }
-    if (Array.isArray(msg.content)) {
-      const textBlock = msg.content.find((b) => b.type === "text");
-      if (textBlock?.text) { firstUserText = textBlock.text; break; }
-    }
-    break;
-  }
-  const suffix = computeVersionSuffix(firstUserText);
-  return `x-anthropic-billing-header: cc_version=${version}.${suffix}; cc_entrypoint=${entrypoint}; cch=00000;`;
-}
-
-/** Default cooldown when rate limited mid-session (ms) — 5 seconds.
- *  Anthropic per-minute rate limits reset in seconds. Conservative cooldowns
- *  (60s, then 15s) caused all accounts to appear exhausted simultaneously.
- *  5s is enough to avoid hammering while recovering almost instantly. */
-const RATE_LIMIT_COOLDOWN_MS = 5_000;
-
-/**
- * Parse a Retry-After header value string into milliseconds.
- * Returns null if the value cannot be parsed.
- * @param {string} raw
- * @returns {number|null}
- */
-function parseRetryAfterValue(raw) {
-  const seconds = parseInt(raw, 10);
-  if (Number.isFinite(seconds) && seconds > 0) return seconds * 1000;
-  const date = Date.parse(raw);
-  if (Number.isFinite(date)) return date - Date.now();
-  return null;
-}
-
-/**
- * Parse Retry-After header into milliseconds (t1835).
- * Supports integer seconds and HTTP-date formats. Falls back to default.
- * @param {Response} response
- * @returns {number} cooldown in ms
- */
-function parseRetryAfterMs(response) {
-  const raw = response.headers?.get?.("retry-after");
-  const parsed = raw ? parseRetryAfterValue(raw) : null;
-  return parsed !== null ? Math.max(parsed, RATE_LIMIT_COOLDOWN_MS) : RATE_LIMIT_COOLDOWN_MS;
-}
-
-/** Default cooldown on auth failure (ms) — 5 minutes */
-const AUTH_FAILURE_COOLDOWN_MS = 300_000;
-
-/** Max wait time when all accounts are exhausted before giving up (ms) */
-const MAX_EXHAUSTION_WAIT_MS = 15_000;
-
-/** Poll interval when waiting for cooldowns to expire (ms) */
-const EXHAUSTION_POLL_MS = 5_000;
-
-// Tool name namespace (third-party detection fix, 2026-04-14).
-//
-// Anthropic's third-party-app detection (the "Third-party apps now draw from
-// your extra usage" gate) pattern-matches tool names. Verified by direct API
-// replay against a pool token:
-//
-//   name format                       result
-//   ---------------------------       -----------
-//   PascalCase native (Bash, Read)    200 OK
-//   mcp__<server>__<tool>             200 OK
-//   mcp_<lowercase>  (single _)       400 third-party
-//   lowercase plain (bash, read)      400 third-party
-//
-// The `mcp__<server>__<tool>` form is the real CLI's own MCP tool naming, so
-// Anthropic can't blacklist arbitrary server names without breaking every
-// legitimate MCP integration. That makes it the safest invariant.
-//
-// Alternative considered (not adopted): HYBRID — rename OpenCode's ~10 native
-// tools (bash, read, glob, grep, edit, write, task, webfetch, websearch,
-// todowrite, skill) to real-CLI PascalCase (Bash, Read, ...) and leave the
-// remaining aidevops-specific tools (osgrep, aidevops, aidevops_memory,
-// model-accounts-pool, etc.) in the mcp__aidevops__ namespace. Tested and
-// working, but rejected because (a) the model is trained on real-CLI Bash/Read
-// schemas and renaming creates schema-semantic drift if the OpenCode tool's
-// input_schema differs, and (b) fabricated PascalCase names for custom tools
-// would be exposed to any future tool-name whitelist tightening. Namespacing
-// all tools under a single mcp__<server>__ prefix is structurally invariant.
-const TOOL_PREFIX = "mcp__aidevops__";
-
-const REQUIRED_BETAS = [
-  "oauth-2025-04-20",
-  "interleaved-thinking-2025-05-14",
-  "prompt-caching-scope-2026-01-05",
-  "claude-code-20250219",
-];
-
-const DEPRECATED_BETAS = new Set([
-  "code-execution-2025-01-24",
-  "extended-cache-ttl-2025-04-11",
-]);
-
-/** Priority order for account status during pool rotation (lower = tried first). */
-const STATUS_ORDER = { active: 0, idle: 1, "rate-limited": 2, "auth-error": 3 };
-
-/**
- * Inject a pool account token into the OpenCode auth store.
- * @param {any} client - OpenCode SDK client
- * @param {object} account - pool account with refresh/access/expires
- * @returns {Promise<void>}
- */
-async function injectAccountToken(client, account) {
-  await client.auth.set({
-    path: { id: "anthropic" },
-    body: {
-      type: "oauth",
-      refresh: account.refresh,
-      access: account.access,
-      expires: account.expires,
-    },
-  });
-}
-
-/**
- * Compare two accounts: by status priority first, then least-recently-used.
- * @param {object} a
- * @param {object} b
- * @returns {number}
- */
-function compareAccountPriority(a, b) {
-  const aOrder = STATUS_ORDER[a.status] ?? 99;
-  const bOrder = STATUS_ORDER[b.status] ?? 99;
-  if (aOrder !== bOrder) return aOrder - bOrder;
-  return new Date(a.lastUsed || 0) - new Date(b.lastUsed || 0);
-}
-
-/**
- * Sort pool accounts by status priority then least-recently-used.
- * @param {object[]} accounts
- * @returns {object[]} sorted copy
- */
-function sortAccountsByPriority(accounts) {
-  return [...accounts].sort(compareAccountPriority);
-}
-
-/**
- * Check if an account is eligible as an alternate (active/idle, not on cooldown).
- * @param {object} account
- * @param {string} currentEmail
- * @param {number} now
- * @returns {boolean}
- */
-function isEligibleAlternate(account, currentEmail, now) {
-  return (
-    account.email !== currentEmail &&
-    (account.status === "active" || account.status === "idle") &&
-    (!account.cooldownUntil || account.cooldownUntil <= now)
-  );
-}
-
-/**
- * Get available alternate accounts (not current, not on cooldown, active/idle).
- * @param {object[]} accounts
- * @param {string} currentEmail
- * @returns {object[]}
- */
-function getAvailableAlternates(accounts, currentEmail) {
-  const now = Date.now();
-  return [...accounts]
-    .filter((a) => isEligibleAlternate(a, currentEmail, now))
-    .sort((a, b) => new Date(a.lastUsed || 0) - new Date(b.lastUsed || 0));
-}
-
-/**
- * Activate an account: patch lastUsed/status and update session affinity.
- * Returns the email for use as the new sessionAccountEmail.
- * @param {string} email
- * @returns {string}
- */
-function activateAccount(email) {
-  patchAccount("anthropic", email, {
-    lastUsed: new Date().toISOString(),
-    status: "active",
-  });
-  return email;
-}
-
-/**
- * Try to get a valid token for one account and inject it.
- * Returns the token on success, null on failure.
- * @param {any} client
- * @param {object} account
- * @param {boolean} forceRefresh
- * @returns {Promise<string|null>}
- */
-async function tryGetAndInjectToken(client, account, forceRefresh) {
-  const accountArg = forceRefresh ? { ...account, expires: 0 } : account;
-  let token;
-  try {
-    token = await ensureValidToken("anthropic", accountArg);
-  } catch (err) {
-    console.error(`[aidevops] provider-auth: ensureValidToken failed for ${account.email}: ${err.message}`);
-    return null;
-  }
-  if (!token) return null;
-  try {
-    await injectAccountToken(client, account);
-  } catch (err) {
-    console.error(`[aidevops] provider-auth: failed to inject token for ${account.email}: ${err.message}`);
-    return null;
-  }
-  return token;
-}
-
-/**
- * Rotate to an alternate pool account, injecting its token.
- * Returns { token, email } on success, null on failure.
- * @param {any} client
- * @param {object[]} alternates
- * @param {boolean} forceRefresh
- * @returns {Promise<{token: string, email: string}|null>}
- */
-async function rotateToAlternateAccount(client, alternates, forceRefresh) {
-  for (const alt of alternates) {
-    const token = await tryGetAndInjectToken(client, alt, forceRefresh);
-    if (token) return { token, email: alt.email };
-  }
-  return null;
-}
-
-/**
- * Try to get a valid token from a recovered account.
- * Returns { token, email } on success, null if token unavailable.
- * @param {any} client
- * @param {object} account
- * @param {number} waitStart - for elapsed time logging
- * @param {string} logPrefix
- * @returns {Promise<{token: string, email: string}|null>}
- */
-async function tryRecoverAccount(client, account, waitStart, logPrefix) {
-  let altToken;
-  try {
-    altToken = await ensureValidToken("anthropic", account);
-  } catch {
-    return null;
-  }
-  if (!altToken) return null;
-
-  try { await injectAccountToken(client, account); } catch { /* best-effort */ }
-
-  const elapsed = Math.ceil((Date.now() - waitStart) / 1000);
-  console.error(
-    `[aidevops] provider-auth: ${logPrefix} recovered via ${account.email} after ${elapsed}s wait`,
-  );
-  return { token: altToken, email: account.email };
-}
-
-/**
- * Log exhaustion status once (first iteration only).
- * @param {object[]} accounts
- * @param {string} currentEmail
- * @param {string} logPrefix
- * @param {number} now
- */
-function logExhaustionOnce(accounts, currentEmail, logPrefix, now) {
-  const accountSummary = accounts.map((a) => {
-    const cd = a.cooldownUntil && a.cooldownUntil > now
-      ? ` (${Math.ceil((a.cooldownUntil - now) / 1000)}s)`
-      : "";
-    return `${a.email}[${a.status}${cd}]`;
-  }).join(", ");
-  console.error(
-    `[aidevops] provider-auth: ${logPrefix} for ${currentEmail} — all accounts on cooldown, waiting... ${accountSummary}`,
-  );
-}
-
-/**
- * Find the first account that has recovered from cooldown.
- * @param {string} logPrefix
- * @returns {{account: object, now: number}|null}
- */
-function findRecoveredAccount(logPrefix) {
-  const now = Date.now();
-  const freshAccounts = getAccounts("anthropic");
-  normalizeExpiredCooldowns("anthropic", freshAccounts);
-  const recovered = freshAccounts.find(
-    (a) => a.status !== "auth-error" && (!a.cooldownUntil || a.cooldownUntil <= now),
-  );
-  return recovered ? { account: recovered, accounts: freshAccounts, now } : null;
-}
-
-/**
- * Log exhaustion status on the first poll iteration.
- * @param {boolean} firstIteration
- * @param {string} currentEmail
- * @param {string} logPrefix
- * @returns {boolean} false (to update firstIteration flag)
- */
-function maybeLogExhaustion(firstIteration, currentEmail, logPrefix) {
-  if (!firstIteration) return false;
-  const now = Date.now();
-  const freshAccounts = getAccounts("anthropic");
-  logExhaustionOnce(freshAccounts, currentEmail, logPrefix, now);
-  return false;
-}
-
-async function waitForCooldownRecovery(client, currentEmail, logPrefix) {
-  const waitStart = Date.now();
-  let firstIteration = true;
-
-  while (Date.now() - waitStart < MAX_EXHAUSTION_WAIT_MS) {
-    const found = findRecoveredAccount(logPrefix);
-    if (found) {
-      const result = await tryRecoverAccount(client, found.account, waitStart, logPrefix);
-      if (result) return result;
-    }
-    firstIteration = maybeLogExhaustion(firstIteration, currentEmail, logPrefix);
-    await new Promise((r) => setTimeout(r, EXHAUSTION_POLL_MS));
-  }
-
-  return null;
-}
-
-/**
- * Force-clear all account cooldowns as a last resort.
- * @param {string} logPrefix - for log message
- */
-function forceClearAllCooldowns(logPrefix) {
-  const accounts = getAccounts("anthropic");
-  for (const acc of accounts) {
-    patchAccount("anthropic", acc.email, { status: "idle", cooldownUntil: 0 });
-  }
-  console.error(
-    `[aidevops] provider-auth: ${logPrefix} — force-cleared all cooldowns after ${MAX_EXHAUSTION_WAIT_MS / 1000}s. Returning response for opencode retry.`,
-  );
-}
-
-/**
- * Find the session's own account if it exists and is not on cooldown.
- * @param {object[]} accounts
- * @param {string} sessionAccountEmail
- * @returns {object|null}
- */
-function findSessionAccount(accounts, sessionAccountEmail) {
-  const account = accounts.find((a) => a.email === sessionAccountEmail);
-  if (!account || isOnCooldown(account)) return null;
-  return account;
-}
-
-/**
- * Try to refresh the session's own account token (t1714 affinity).
- * Returns { token, email } on success, null if unavailable or on cooldown.
- * @param {any} client
- * @param {object[]} accounts
- * @param {string} sessionAccountEmail
- * @returns {Promise<{token: string, email: string}|null>}
- */
-async function refreshSessionOwnAccount(client, accounts, sessionAccountEmail) {
-  const myAccount = findSessionAccount(accounts, sessionAccountEmail);
-  if (!myAccount) return null;
-  const token = await ensureValidToken("anthropic", myAccount);
-  if (!token) return null;
-  try { await injectAccountToken(client, myAccount); } catch { /* best-effort */ }
-  activateAccount(myAccount.email);
-  console.error(`[aidevops] provider-auth: refreshed session account ${myAccount.email}`);
-  return { token, email: myAccount.email };
-}
-
-/**
- * Check if an account is currently on cooldown.
- * @param {object} account
- * @returns {boolean}
- */
-function isOnCooldown(account) {
-  return !!(account.cooldownUntil && account.cooldownUntil > Date.now());
-}
-
-/**
- * Try to get a valid token for one account and activate it.
- * Returns { token, email } on success, null on failure.
- * @param {any} client
- * @param {object} account
- * @returns {Promise<{token: string, email: string}|null>}
- */
-async function tryActivatePoolAccount(client, account) {
-  const token = await ensureValidToken("anthropic", account);
-  if (!token) return null;
-  try { await injectAccountToken(client, account); } catch { /* best-effort */ }
-  activateAccount(account.email);
-  console.error(`[aidevops] provider-auth: refreshed via pool account ${account.email}`);
-  return { token, email: account.email };
-}
-
-/**
- * Try each pool account in priority order until one yields a valid token.
- * Returns { token, email } on success, null if all accounts exhausted.
- * @param {any} client
- * @param {object[]} accounts
- * @returns {Promise<{token: string, email: string}|null>}
- */
-async function rotatePoolAccounts(client, accounts) {
-  for (const account of sortAccountsByPriority(accounts)) {
-    if (isOnCooldown(account)) {
-      console.error(`[aidevops] provider-auth: skipping ${account.email} — cooldown active`);
-      continue;
-    }
-    const result = await tryActivatePoolAccount(client, account);
-    if (result) return result;
-  }
-  return null;
-}
-
-/**
- * Get the session account's token from the pool if still valid.
- * Returns the token and expiry, or falls back to auth values.
- * @param {string|null} sessionAccountEmail
- * @param {object} auth
- * @returns {{accessToken: string, accessExpires: number}}
- */
-function getSessionAccountToken(sessionAccountEmail, auth) {
-  if (!sessionAccountEmail) return { accessToken: auth.access, accessExpires: auth.expires };
-  const myAccount = getAccounts("anthropic").find((a) => a.email === sessionAccountEmail);
-  if (myAccount?.access && myAccount.expires > Date.now()) {
-    return { accessToken: myAccount.access, accessExpires: myAccount.expires };
-  }
-  return { accessToken: auth.access, accessExpires: auth.expires };
-}
-
-/**
- * Identify the session account email from a valid access token.
- * @param {string} accessToken
- * @param {string|null} sessionAccountEmail
- * @returns {string|null}
- */
-function resolveSessionEmailFromToken(accessToken, sessionAccountEmail) {
-  if (sessionAccountEmail) return sessionAccountEmail;
-  const owner = getAccounts("anthropic").find((a) => a.access === accessToken);
-  return owner ? owner.email : null;
-}
-
-/**
- * Resolve the current session's access token.
- * Handles session affinity, pool rotation, and exhaustion wait.
- * Returns { accessToken, sessionAccountEmail } (updated values).
- * @param {any} client
- * @param {object} auth - current auth object from getAuth()
- * @param {string|null} sessionAccountEmail
- * @returns {Promise<{accessToken: string|null, sessionAccountEmail: string|null}>}
- */
-/**
- * Wrap a token result into the standard { accessToken, sessionAccountEmail } shape.
- * @param {{token: string, email: string}} result
- * @returns {{accessToken: string, sessionAccountEmail: string}}
- */
-function tokenResult(result) {
-  return { accessToken: result.token, sessionAccountEmail: result.email };
-}
-
-/**
- * Attempt exhaustion recovery: wait for a cooldown to expire, then force-clear as last resort.
- * Returns { accessToken, sessionAccountEmail } or falls back to auth.access.
- * @param {any} client
- * @param {object} auth
- * @param {string|null} sessionAccountEmail
- * @returns {Promise<{accessToken: string, sessionAccountEmail: string|null}>}
- */
-async function recoverFromExhaustion(client, auth, sessionAccountEmail) {
-  const recovered = await waitForCooldownRecovery(client, "all", "exhaustion");
-  if (recovered) {
-    process.env.ANTHROPIC_API_KEY = recovered.token;
-    activateAccount(recovered.email);
-    return tokenResult(recovered);
-  }
-  forceClearAllCooldowns("exhaustion");
-  return { accessToken: auth.access, sessionAccountEmail };
-}
-
-async function resolveAccessToken(client, auth, sessionAccountEmail) {
-  const { accessToken: poolToken, accessExpires } = getSessionAccountToken(sessionAccountEmail, auth);
-
-  if (poolToken && accessExpires >= Date.now()) {
-    return {
-      accessToken: poolToken,
-      sessionAccountEmail: resolveSessionEmailFromToken(poolToken, sessionAccountEmail),
-    };
-  }
-
-  // Token expired or missing — refresh
-  const accounts = getAccounts("anthropic");
-  normalizeExpiredCooldowns("anthropic", accounts);
-
-  if (sessionAccountEmail) {
-    const result = await refreshSessionOwnAccount(client, accounts, sessionAccountEmail);
-    if (result) return tokenResult(result);
-  }
-
-  const poolResult = await rotatePoolAccounts(client, accounts);
-  if (poolResult) return tokenResult(poolResult);
-
-  return recoverFromExhaustion(client, auth, sessionAccountEmail);
-}
-
-/**
- * Copy headers from a Headers instance into target.
- * @param {Headers} target
- * @param {Headers} source
- */
-function copyHeadersInstance(target, source) {
-  source.forEach((value, key) => target.set(key, value));
-}
-
-/**
- * Copy headers from an array of [key, value] pairs into target.
- * @param {Headers} target
- * @param {Array<[string, string]>} entries
- */
-function copyHeadersArray(target, entries) {
-  for (const [key, value] of entries) {
-    if (typeof value !== "undefined") target.set(key, String(value));
-  }
-}
-
-/**
- * Copy headers from a plain object into target.
- * @param {Headers} target
- * @param {Record<string, string>} obj
- */
-function copyHeadersObject(target, obj) {
-  for (const [key, value] of Object.entries(obj)) {
-    if (typeof value !== "undefined") target.set(key, String(value));
-  }
-}
-
-/**
- * Merge init.headers (Headers, array, or plain object) into a Headers instance.
- * @param {Headers} target
- * @param {HeadersInit|undefined} initHeaders
- */
-function mergeInitHeaders(target, initHeaders) {
-  if (!initHeaders) return;
-  if (initHeaders instanceof Headers) {
-    copyHeadersInstance(target, initHeaders);
-  } else if (Array.isArray(initHeaders)) {
-    copyHeadersArray(target, initHeaders);
-  } else {
-    copyHeadersObject(target, initHeaders);
-  }
-}
-
-/**
- * Compute merged anthropic-beta header value: required betas + incoming, minus deprecated.
- * @param {Headers} headers - current headers (reads anthropic-beta from here)
- * @returns {string}
- */
-function mergeBetaHeaders(headers) {
-  return REQUIRED_BETAS.join(",");
-}
-
-/**
- * Build the outgoing request headers: merge input/init headers, set auth/beta/user-agent.
- * @param {Request|string|URL} input
- * @param {RequestInit} init
- * @param {string} accessToken
- * @returns {Headers}
- */
-function buildRequestHeaders(input, init, accessToken) {
-  const requestHeaders = new Headers();
-
-  if (input instanceof Request) {
-    input.headers.forEach((value, key) => requestHeaders.set(key, value));
-  }
-
-  mergeInitHeaders(requestHeaders, init?.headers);
-
-  requestHeaders.set("authorization", `Bearer ${accessToken}`);
-  requestHeaders.set("anthropic-beta", mergeBetaHeaders(requestHeaders));
-  requestHeaders.set("anthropic-dangerous-direct-browser-access", "true");
-  requestHeaders.set("anthropic-version", "2023-06-01");
-  requestHeaders.set("user-agent", getAnthropicUserAgent());
-  requestHeaders.set("x-app", "cli");
-  requestHeaders.set("accept", "application/json");
-  requestHeaders.set("content-type", "application/json");
-  if (!requestHeaders.has("x-claude-code-session-id")) {
-    requestHeaders.set("x-claude-code-session-id", globalThis._claudeCodeSessionId ??= crypto.randomUUID());
-  }
-  requestHeaders.set("x-client-request-id", crypto.randomUUID());
-  const { version } = loadCCHConstants();
-  requestHeaders.set("X-Stainless-Arch", process.arch === "arm64" ? "arm64" : "x64");
-  requestHeaders.set("X-Stainless-Lang", "js");
-  requestHeaders.set("X-Stainless-OS", process.platform === "darwin" ? "Mac OS X" : "Linux");
-  requestHeaders.set("X-Stainless-Package-Version", "0.81.0");
-  requestHeaders.set("X-Stainless-Retry-Count", "0");
-  requestHeaders.set("X-Stainless-Runtime", "node");
-  requestHeaders.set("X-Stainless-Runtime-Version", process.version);
-  requestHeaders.set("X-Stainless-Timeout", "600");
-  requestHeaders.delete("x-api-key");
-  requestHeaders.delete("x-session-affinity");
-
-  return requestHeaders;
-}
-
-/**
- * Sanitize system prompt items: replace OpenCode references with Claude Code.
- * @param {object[]} system
- * @returns {object[]}
- */
-function sanitizeSystemPrompt(system) {
-  const TAG_RENAMES = [
-    [/<directories>/g, "<working_dirs>"],     [/<\/directories>/g, "</working_dirs>"],
-    [/<available_skills>/g, "<skill_list>"],   [/<\/available_skills>/g, "</skill_list>"],
-    [/<env>/g, "<environment>"],               [/<\/env>/g, "</environment>"],
-  ];
-
-  return system.map((item) => {
-    if (item.type !== "text" || !item.text) return item;
-    let text = item.text
-      .replace(/OpenCode/g, "Claude Code")
-      .replace(/opencode/gi, "Claude");
-    for (const [pattern, replacement] of TAG_RENAMES) {
-      text = text.replace(pattern, replacement);
-    }
-    return { ...item, text };
-  });
-}
-
-/**
- * Prefix tool definition names with TOOL_PREFIX.
- * @param {object[]} tools
- * @returns {object[]}
- */
-function prefixToolNames(tools) {
-  return tools.map((tool) => {
-    if (!tool.name) return tool;
-    if (tool.name.startsWith("mcp__")) return tool; // already MCP-namespaced
-    return { ...tool, name: `${TOOL_PREFIX}${tool.name}` };
-  });
-}
-
-/**
- * Prefix tool_use block names in messages with TOOL_PREFIX.
- * @param {object[]} messages
- * @returns {object[]}
- */
-function prefixToolUseBlocks(messages) {
-  return messages.map((msg) => {
-    if (!msg.content || !Array.isArray(msg.content)) return msg;
-    return {
-      ...msg,
-      content: msg.content.map((block) => {
-        if (block.type === "tool_use" && block.name && !block.name.startsWith("mcp__")) {
-          return { ...block, name: `${TOOL_PREFIX}${block.name}` };
-        }
-        return block;
-      }),
-    };
-  });
-}
-
-/**
- * Apply all body transformations to a parsed JSON object in-place.
- * Injects billing header as system[0] to match Claude CLI request format.
- * @param {object} parsed
- */
-function applyBodyTransforms(parsed) {
-  // Inject billing header as first system block (matches Claude CLI GG8 function)
-  const billingText = buildBillingHeader(parsed);
-  if (!Array.isArray(parsed.system)) parsed.system = [];
-  // Remove any existing billing header (idempotent on retries)
-  parsed.system = parsed.system.filter(
-    (b) => !(b.type === "text" && b.text?.startsWith("x-anthropic-billing-header:")),
-  );
-  parsed.system.unshift({ type: "text", text: billingText });
-
-  parsed.system = sanitizeSystemPrompt(parsed.system);
-  if (Array.isArray(parsed.tools)) parsed.tools = prefixToolNames(parsed.tools);
-  if (Array.isArray(parsed.messages)) parsed.messages = prefixToolUseBlocks(parsed.messages);
-
-  // claude-opus-4-6 and claude-sonnet-4-6 require thinking:{type:"adaptive"}.
-  // OpenCode does not send this field; the API rejects requests without it.
-  // Also: temperature must be 1 when thinking is enabled.
-  if (isAdaptiveThinkingModel(parsed.model)) {
-    if (!parsed.thinking || parsed.thinking.type !== "adaptive") {
-      parsed.thinking = { type: "adaptive" };
-    }
-    if (parsed.temperature !== undefined && parsed.temperature !== 1) {
-      parsed.temperature = 1;
-    }
-  }
-}
-
-/**
- * Models that require thinking:{type:"adaptive"}.
- * Matches claude-opus-4-6, claude-sonnet-4-6, and future claude-*-4-6+ variants.
- * @param {string|undefined} model
- * @returns {boolean}
- */
-function isAdaptiveThinkingModel(model) {
-  if (!model) return false;
-  return /claude-[a-z]+-4[-.]6/i.test(model);
-}
-
-/**
- * Transform the request body: sanitize system prompt, prefix tool names.
- * Returns the (possibly modified) body string, or the original if not JSON.
- * @param {string|null|undefined} body
- * @returns {string|null|undefined}
- */
-function transformRequestBody(body) {
-  if (!body || typeof body !== "string") return body;
-  try {
-    const parsed = JSON.parse(body);
-    applyBodyTransforms(parsed);
-    const serialized = serializeWithKeyOrder(parsed);
-    // Real Claude CLI 2.1.105 (Node.js) sends `cch=00000` literally — no body-hash
-    // computation. Previous xxHash64 replacement was a unique third-party
-    // fingerprint; leave the literal 00000 in place. (Detection fix 2026-04-14)
-    void computeBodyHash;
-    return serialized;
-  } catch {
-    return body;
-  }
-}
-
-/**
- * Parse the URL from a request input, returning null on failure.
- * @param {Request|string|URL} input
- * @returns {URL|null}
- */
-function parseRequestUrl(input) {
-  try {
-    if (typeof input === "string" || input instanceof URL) {
-      return new URL(input.toString());
-    }
-    if (input instanceof Request) {
-      return new URL(input.url);
-    }
-  } catch {
-    /* ignore */
-  }
-  return null;
-}
-
-/**
- * Add ?beta=true to /v1/messages requests if not already present.
- * Returns the (possibly modified) input.
- * @param {Request|string|URL} input
- * @returns {Request|URL|string}
- */
-/**
- * Rewrite a URL with ?beta=true added.
- * @param {URL} url
- * @param {Request|string|URL} input - original input for Request wrapping
- * @returns {Request|URL}
- */
-function rewriteUrlWithBeta(url, input) {
-  url.searchParams.set("beta", "true");
-  return input instanceof Request ? new Request(url.toString(), input) : url;
-}
-
-function addBetaQueryParam(input) {
-  const requestUrl = parseRequestUrl(input);
-  if (!requestUrl || requestUrl.pathname !== "/v1/messages" || requestUrl.searchParams.has("beta")) {
-    return input;
-  }
-  return rewriteUrlWithBeta(requestUrl, input);
-}
-
-/**
- * Identify the current pool account from session affinity or token match.
- * Falls back to most-recently-used if no match found (GH#15322).
- * @param {object[]} accounts
- * @param {string|null} sessionAccountEmail
- * @param {string} accessToken
- * @returns {object|null}
- */
-/**
- * Find the most-recently-used account as a fallback when no token match exists.
- * @param {object[]} accounts
- * @returns {object|null}
- */
-function getMostRecentlyUsedAccount(accounts) {
-  if (accounts.length === 0) return null;
-  const mru = [...accounts].sort(
-    (a, b) => new Date(b.lastUsed || 0) - new Date(a.lastUsed || 0),
-  )[0];
-  console.error(
-    `[aidevops] provider-auth: no token match — assuming ${mru.email} (most recently used)`,
-  );
-  return mru;
-}
-
-function resolveCurrentAccount(accounts, sessionAccountEmail, accessToken) {
-  if (sessionAccountEmail) {
-    const found = accounts.find((a) => a.email === sessionAccountEmail);
-    if (found) return found;
-  }
-  return accounts.find((a) => a.access === accessToken) ?? getMostRecentlyUsedAccount(accounts);
-}
+import { ensureValidToken, getAccounts, patchAccount, normalizeExpiredCooldowns } from "./oauth-pool.mjs";
+import {
+  injectAccountToken, activateAccount, tokenResult,
+  getSessionAccountToken, resolveSessionEmailFromToken,
+  rotatePoolAccounts, getAvailableAlternates, rotateToAlternateAccount,
+  resolveCurrentAccount,
+} from "./provider-auth-pool.mjs";
+import {
+  parseRetryAfterMs, AUTH_FAILURE_COOLDOWN_MS,
+  recoverFromExhaustion, refreshSessionOwnAccount,
+} from "./provider-auth-pool-recovery.mjs";
+import { buildRequestHeaders, transformRequestBody, addBetaQueryParam, transformResponseStream } from "./provider-auth-request.mjs";
 
 /**
  * Apply a recovered token to headers/env and retry the request.
- * Returns { response, sessionAccountEmail }.
- * @param {string} token
- * @param {string} email
- * @param {{requestHeaders: Headers, requestInput: Request|string|URL, requestInit: RequestInit, body: string|null|undefined}} ctx
- * @returns {Promise<{response: Response, sessionAccountEmail: string}>}
+ * @param {string} token @param {string} email @param {object} ctx
  */
 async function applyTokenAndRetry(token, email, ctx) {
   ctx.requestHeaders.set("authorization", `Bearer ${token}`);
@@ -1115,11 +47,7 @@ async function applyTokenAndRetry(token, email, ctx) {
 
 /**
  * Try force-refreshing the current account's token.
- * Returns the fresh token on success, null on failure.
- * @param {any} client
- * @param {object|null} currentAccount
- * @param {string} currentEmail
- * @returns {Promise<string|null>}
+ * @param {any} client @param {object|null} currentAccount @param {string} currentEmail
  */
 async function forceRefreshCurrentAccount(client, currentAccount, currentEmail) {
   if (!currentAccount?.refresh) return null;
@@ -1132,12 +60,7 @@ async function forceRefreshCurrentAccount(client, currentAccount, currentEmail) 
 
 /**
  * Mark an account as auth-error and rotate to an alternate.
- * Returns { token, email } on success, null if no alternates available.
- * @param {any} client
- * @param {object[]} accounts
- * @param {object|null} currentAccount
- * @param {string} currentEmail
- * @returns {Promise<{token: string, email: string}|null>}
+ * @param {any} client @param {object[]} accounts @param {object|null} currentAccount @param {string} currentEmail
  */
 async function markAndRotateAccount(client, accounts, currentAccount, currentEmail) {
   console.error(`[aidevops] provider-auth: refresh failed for ${currentEmail} — rotating to next account`);
@@ -1153,9 +76,6 @@ async function markAndRotateAccount(client, accounts, currentAccount, currentEma
 
 /**
  * Resolve the current pool accounts and identify the active account.
- * @param {string|null} sessionAccountEmail
- * @param {string} accessToken
- * @returns {{accounts: object[], currentAccount: object|null, currentEmail: string}}
  */
 function resolvePoolState(sessionAccountEmail, accessToken) {
   const accounts = getAccounts("anthropic");
@@ -1165,30 +85,43 @@ function resolvePoolState(sessionAccountEmail, accessToken) {
 }
 
 /**
+ * Resolve the current session's access token.
+ * Handles session affinity, pool rotation, and exhaustion wait.
+ */
+async function resolveAccessToken(client, auth, sessionAccountEmail) {
+  const { accessToken: poolToken, accessExpires } = getSessionAccountToken(sessionAccountEmail, auth);
+  if (poolToken && accessExpires >= Date.now()) {
+    return {
+      accessToken: poolToken,
+      sessionAccountEmail: resolveSessionEmailFromToken(poolToken, sessionAccountEmail),
+    };
+  }
+  const accounts = getAccounts("anthropic");
+  normalizeExpiredCooldowns("anthropic", accounts);
+  if (sessionAccountEmail) {
+    const result = await refreshSessionOwnAccount(client, accounts, sessionAccountEmail);
+    if (result) return tokenResult(result);
+  }
+  const poolResult = await rotatePoolAccounts(client, accounts);
+  if (poolResult) return tokenResult(poolResult);
+  return recoverFromExhaustion(client, auth, sessionAccountEmail);
+}
+
+/**
  * Handle 401/403 response: try force-refreshing current account, then rotate.
- * @param {any} client
- * @param {Response} response
- * @param {string} accessToken
- * @param {string|null} sessionAccountEmail
- * @param {{requestHeaders: Headers, requestInput: Request|string|URL, requestInit: RequestInit, body: string|null|undefined}} ctx
- * @returns {Promise<{response: Response, sessionAccountEmail: string|null}>}
  */
 async function handle401Recovery(client, response, accessToken, sessionAccountEmail, ctx) {
   const { accounts, currentAccount, currentEmail } = resolvePoolState(sessionAccountEmail, accessToken);
-
   console.error(
     `[aidevops] provider-auth: ${response.status} (invalid/revoked token) for ${currentEmail} — attempting refresh...`,
   );
-
   const freshToken = await forceRefreshCurrentAccount(client, currentAccount, currentEmail);
   if (freshToken) return applyTokenAndRetry(freshToken, currentEmail, ctx);
-
   const rotated = await markAndRotateAccount(client, accounts, currentAccount, currentEmail);
   if (rotated) {
     console.error(`[aidevops] provider-auth: rotated to ${rotated.email} — retrying request once`);
     return applyTokenAndRetry(rotated.token, rotated.email, ctx);
   }
-
   console.error(
     `[aidevops] provider-auth: ${response.status} for ${currentEmail} — all accounts exhausted. ` +
     `Pool has ${accounts.length} account(s). Use /model-accounts-pool to check status.`,
@@ -1197,110 +130,41 @@ async function handle401Recovery(client, response, accessToken, sessionAccountEm
 }
 
 /**
- * Handle 429 response: mark current account rate-limited, rotate to alternate.
- * @param {any} client
- * @param {Response} response
- * @param {string} accessToken
- * @param {string|null} sessionAccountEmail
- * @param {{requestHeaders: Headers, requestInput: Request|string|URL, requestInit: RequestInit, body: string|null|undefined}} ctx
- * @param {Set<string>} [triedEmails] - set of account emails already tried this request cycle, used to prevent infinite rotation when all accounts are rate-limited
- * @returns {Promise<{response: Response, sessionAccountEmail: string|null}>}
+ * Context object for handle429Recovery.
+ * @typedef {{ accessToken: string, sessionAccountEmail: string|null, requestCtx: object, triedEmails: Set<string>|undefined }} Recovery429Ctx
  */
-async function handle429Recovery(client, response, accessToken, sessionAccountEmail, ctx, triedEmails) {
+
+/**
+ * Handle 429 response: mark current account rate-limited, rotate to alternate.
+ * @param {any} client @param {Response} response @param {Recovery429Ctx} ctx429
+ */
+async function handle429Recovery(client, response, ctx429) {
+  const { accessToken, sessionAccountEmail, requestCtx } = ctx429;
   const cooldownMs = parseRetryAfterMs(response);
   const { accounts, currentAccount, currentEmail } = resolvePoolState(sessionAccountEmail, accessToken);
-
   console.error(
     `[aidevops] provider-auth: 429 rate limit hit for ${currentEmail} mid-session (cooldown ${Math.ceil(cooldownMs / 1000)}s) — attempting pool rotation`,
   );
-
-  if (currentAccount) {
-    patchAccount("anthropic", currentEmail, {
-      status: "rate-limited",
-      cooldownUntil: Date.now() + cooldownMs,
-    });
-  }
-
-  // Track tried accounts to prevent infinite rotation across all accounts.
-  const tried = triedEmails ?? new Set();
+  if (currentAccount) patchAccount("anthropic", currentEmail, { status: "rate-limited", cooldownUntil: Date.now() + cooldownMs });
+  const tried = ctx429.triedEmails ?? new Set();
   tried.add(currentEmail);
-
-  // Only rotate to accounts we haven't tried yet this request.
-  const alternates = getAvailableAlternates(accounts, currentEmail)
-    .filter((a) => !tried.has(a.email));
-
+  const alternates = getAvailableAlternates(accounts, currentEmail).filter((a) => !tried.has(a.email));
   if (alternates.length === 0) {
-    // All accounts tried this request — give up immediately without clearing cooldowns.
     console.error(`[aidevops] provider-auth: all ${tried.size} accounts tried — giving up`);
     return { response, sessionAccountEmail };
   }
-
   const rotated = await rotateToAlternateAccount(client, alternates, false);
   if (rotated) {
     tried.add(rotated.email);
     console.error(`[aidevops] provider-auth: rotated to ${rotated.email} — retrying`);
-    const retried = await applyTokenAndRetry(rotated.token, rotated.email, ctx);
+    const retried = await applyTokenAndRetry(rotated.token, rotated.email, requestCtx);
     if (retried.response.status !== 429) return retried;
-    // Also 429 — recurse with updated tried set
-    return handle429Recovery(client, retried.response, accessToken, rotated.email, ctx, tried);
+    return handle429Recovery(client, retried.response, { accessToken, sessionAccountEmail: rotated.email, requestCtx, triedEmails: tried });
   }
-
   console.error(`[aidevops] provider-auth: all accounts rate-limited — giving up`);
   return { response, sessionAccountEmail };
 }
 
-/**
- * Strip the opencode namespace prefix from tool name fields in a text chunk.
- * Must match TOOL_PREFIX exactly so we don't touch other `mcp__server__tool` names.
- * @param {string} text
- * @returns {string}
- */
-function stripMcpPrefix(text) {
-  return text.replace(/"name"\s*:\s*"mcp__aidevops__([^"]+)"/g, '"name":"$1"');
-}
-
-/**
- * Build a ReadableStream pull handler that strips mcp_ tool name prefixes.
- * @param {ReadableStreamDefaultReader} reader
- * @param {TextDecoder} decoder
- * @param {TextEncoder} encoder
- * @returns {(controller: ReadableStreamDefaultController) => Promise<void>}
- */
-function makeStreamPullHandler(reader, decoder, encoder) {
-  return async function pull(controller) {
-    const { done, value } = await reader.read();
-    if (done) {
-      controller.close();
-      return;
-    }
-    controller.enqueue(encoder.encode(stripMcpPrefix(decoder.decode(value, { stream: true }))));
-  };
-}
-
-/**
- * Wrap a response body stream to strip mcp_ prefix from tool names.
- * @param {Response} response
- * @returns {Response}
- */
-function transformResponseStream(response) {
-  if (!response.body) return response;
-
-  const reader = response.body.getReader();
-  const stream = new ReadableStream({
-    pull: makeStreamPullHandler(reader, new TextDecoder(), new TextEncoder()),
-  });
-
-  return new Response(stream, {
-    status: response.status,
-    statusText: response.statusText,
-    headers: response.headers,
-  });
-}
-
-/**
- * Zero out model costs for Max plan accounts.
- * @param {object} provider
- */
 function zeroOutModelCosts(provider) {
   for (const model of Object.values(provider.models)) {
     model.cost = { input: 0, output: 0, cache: { read: 0, write: 0 } };
@@ -1309,79 +173,45 @@ function zeroOutModelCosts(provider) {
 
 /**
  * Execute the authenticated fetch with token resolution, body transform, and error recovery.
- * @param {any} client
- * @param {Function} getAuth
- * @param {Request|string|URL} input
- * @param {RequestInit} init
- * @param {string|null} sessionAccountEmail - mutable via return value
- * @returns {Promise<{response: Response, sessionAccountEmail: string|null}>}
  */
 async function executeAuthenticatedFetch(client, getAuth, input, init, sessionAccountEmail) {
   const auth = await getAuth();
-  if (auth.type !== "oauth") {
-    return { response: await fetch(input, init), sessionAccountEmail };
-  }
-
+  if (auth.type !== "oauth") return { response: await fetch(input, init), sessionAccountEmail };
   const resolved = await resolveAccessToken(client, auth, sessionAccountEmail);
   const accessToken = resolved.accessToken ?? auth.access;
   let currentEmail = resolved.sessionAccountEmail;
-
   const ctx = {
     requestHeaders: buildRequestHeaders(input, init, accessToken),
     body: transformRequestBody(init?.body),
     requestInput: addBetaQueryParam(input),
     requestInit: init ?? {},
   };
-
-  // Track which accounts have been tried this request to prevent infinite rotation.
   const triedEmails = new Set([currentEmail].filter(Boolean));
-
   let response = await fetch(ctx.requestInput, { ...ctx.requestInit, body: ctx.body, headers: ctx.requestHeaders });
-
   if (response.status === 401 || response.status === 403) {
-    ({ response, sessionAccountEmail: currentEmail } = await handle401Recovery(
-      client, response, accessToken, currentEmail, ctx,
-    ));
+    ({ response, sessionAccountEmail: currentEmail } = await handle401Recovery(client, response, accessToken, currentEmail, ctx));
   }
-
   if (response.status === 429) {
-    ({ response, sessionAccountEmail: currentEmail } = await handle429Recovery(
-      client, response, accessToken, currentEmail, ctx, triedEmails,
-    ));
+    ({ response, sessionAccountEmail: currentEmail } = await handle429Recovery(client, response, {
+      accessToken, sessionAccountEmail: currentEmail, requestCtx: ctx, triedEmails,
+    }));
   }
-
   return { response: transformResponseStream(response), sessionAccountEmail: currentEmail };
 }
 
 /**
  * Create the auth hook for the built-in "anthropic" provider.
- * Provides OAuth loader with custom fetch that handles:
- *   - Bearer auth with pool tokens
- *   - Beta headers (required + filtered)
- *   - System prompt sanitization (OpenCode → Claude Code)
- *   - Tool name prefixing (mcp_)
- *   - ?beta=true query param
- *   - Response stream tool name de-prefixing
- *
  * @param {any} client - OpenCode SDK client
  * @returns {import('@opencode-ai/plugin').AuthHook}
  */
 export function createProviderAuthHook(client) {
   return {
     provider: "anthropic",
-
     async loader(getAuth, provider) {
       const auth = await getAuth();
       if (auth.type !== "oauth") return {};
-
       zeroOutModelCosts(provider);
-
-      // Session-level account affinity (t1714): each session's fetch closure
-      // remembers which pool account it's using. This prevents cross-session
-      // token overwrites when multiple OpenCode processes share the same
-      // auth.json file.
       let sessionAccountEmail = null;
-
       return {
         apiKey: "",
         async fetch(input, init) {

--- a/.agents/plugins/opencode-aidevops/ttsr-rules.mjs
+++ b/.agents/plugins/opencode-aidevops/ttsr-rules.mjs
@@ -1,0 +1,230 @@
+/**
+ * TTSR rule definitions, loading, violation scanning, and message processing helpers.
+ * Extracted from ttsr.mjs to keep that file's complexity below the threshold.
+ */
+
+// ---------------------------------------------------------------------------
+// Built-in TTSR rules
+// ---------------------------------------------------------------------------
+
+/**
+ * Built-in TTSR rules — enforced by default.
+ * @type {Array<{id: string, description: string, pattern: string, correction: string, severity: string, systemPrompt: string}>}
+ */
+export const BUILTIN_TTSR_RULES = [
+  {
+    id: "no-glob-for-discovery",
+    description: "Use git ls-files or fd instead of Glob/find for file discovery",
+    pattern: "(?:mcp_glob|Glob tool|use.*\\bGlob\\b.*to find|I'll use Glob)",
+    correction: "Use `git ls-files` or `fd` for file discovery, not Glob. Glob is a last resort when Bash is unavailable.",
+    severity: "warn",
+    systemPrompt: "File discovery: use `git ls-files '<pattern>'` for git-tracked files, `fd` for untracked. NEVER use Glob/find as primary discovery.",
+  },
+  {
+    id: "no-cat-for-reading",
+    description: "Use Read tool instead of cat/head/tail for file reading",
+    pattern: "(?:^|\\s)cat\\s+['\"]?[/~\\w]|\\bhead\\s+-n|\\btail\\s+-n",
+    correction: "Use the Read tool for file reading, not cat/head/tail. These are Bash commands that waste context.",
+    severity: "info",
+    systemPrompt: "Use the Read tool for file reading. Avoid cat/head/tail in Bash — they waste context tokens.",
+  },
+  {
+    id: "read-before-edit",
+    description: "Always Read a file before Edit or Write to existing files",
+    pattern: "(?:I'll edit|Let me edit|I'll write to|Let me write)(?!.*(?:creat|new file|new \\w+ file|generat))(?:(?!I'll read|let me read|I've read|already read).){0,200}$",
+    correction: "ALWAYS Read a file before Edit/Write to an existing file. These tools fail without a prior Read in this conversation. (This rule does not apply when creating new files.)",
+    severity: "error",
+    systemPrompt: "ALWAYS Read a file before Edit or Write to an existing file. These tools FAIL without a prior Read in this conversation. For NEW files, verify the parent directory exists instead.",
+  },
+  {
+    id: "no-credentials-in-output",
+    description: "Never expose credentials, API keys, or secrets in output",
+    pattern: "(?:api[_-]?key|secret|password|token)\\s*[:=]\\s*['\"][A-Za-z0-9+/=_-]{16,}['\"]",
+    correction: "SECURITY: Never expose credentials in output. Use `aidevops secret set NAME` for secure storage.",
+    severity: "error",
+    systemPrompt: "NEVER expose credentials, API keys, or secrets in output or logs.",
+  },
+  {
+    id: "pre-edit-check",
+    description: "Run pre-edit-check.sh before modifying files",
+    pattern: "(?:I'll (?:create|modify|edit|write)|Let me (?:create|modify|edit|write)).*(?:on main|on master)\\b",
+    correction: "Run pre-edit-check.sh before modifying files. NEVER edit on main/master branch.",
+    severity: "error",
+    systemPrompt: "Before ANY file modification: run pre-edit-check.sh. NEVER edit on main/master.",
+  },
+  {
+    id: "shell-explicit-returns",
+    description: "Shell functions must have explicit return statements",
+    pattern: "(?:function\\s+\\w+|\\w+\\s*\\(\\)\\s*\\{)(?:(?!return\\s+[0-9]).){50,}\\}",
+    correction: "Shell functions must have explicit `return 0` or `return 1` statements (SonarCloud S7682).",
+    severity: "warn",
+    systemPrompt: "Shell scripts: every function must have an explicit `return 0` or `return 1`.",
+  },
+  {
+    id: "shell-local-params",
+    description: "Use local var=\"$1\" pattern in shell functions",
+    pattern: "^\\s+(?:echo|printf|return|if|\\[\\[).*(?<!\\\\)\\$[1-9](?![0-9.,])(?!\\/(?:mo(?:nth)?|yr|year|day|week|hr|hour)\\b)(?!\\s+(?:per|mo(?:nth)?|year|yr|day|week|hr|hour|flat|each|off|fee|plan|tier|user|seat|unit|addon|setup|trial|credit|annual|quarterly|monthly)\\b)(?!.*local\\s+\\w+=)",
+    correction: "Use `local var=\"$1\"` pattern — never use positional parameters directly (SonarCloud S7679).",
+    severity: "warn",
+    systemPrompt: "Shell scripts: use `local var=\"$1\"` — never use $1 directly in function bodies.",
+  },
+];
+
+// ---------------------------------------------------------------------------
+// TTSR rule loading
+// ---------------------------------------------------------------------------
+
+/**
+ * Merge user-supplied TTSR rules into the rules array (update existing, append new).
+ * @param {Array<object>} rules
+ * @param {Array<object>} userRules
+ */
+export function mergeUserTtsrRules(rules, userRules) {
+  for (const rule of userRules) {
+    if (!rule.id || !rule.pattern) continue;
+    const existingIdx = rules.findIndex((r) => r.id === rule.id);
+    if (existingIdx >= 0) {
+      rules[existingIdx] = { ...rules[existingIdx], ...rule };
+    } else {
+      rules.push(rule);
+    }
+  }
+}
+
+/**
+ * Load (and cache) TTSR rules from state, merging user overrides if present.
+ * @param {{ ttsrRules: Array|null, ttsrRulesPath: string, readIfExists: Function }} state
+ * @returns {Array<object>}
+ */
+export function loadTtsrRules(state) {
+  if (state.ttsrRules !== null) return state.ttsrRules;
+  state.ttsrRules = [...BUILTIN_TTSR_RULES];
+  const userContent = state.readIfExists(state.ttsrRulesPath);
+  if (userContent) {
+    try {
+      const parsed = JSON.parse(userContent);
+      if (Array.isArray(parsed)) mergeUserTtsrRules(state.ttsrRules, parsed);
+    } catch {
+      console.error("[aidevops] Failed to parse TTSR rules file — using built-in rules only");
+    }
+  }
+  return state.ttsrRules;
+}
+
+// ---------------------------------------------------------------------------
+// Rule violation scanning
+// ---------------------------------------------------------------------------
+
+/**
+ * Test a single rule's pattern against a text string.
+ * @param {string} text
+ * @param {{ pattern: string }} rule
+ * @returns {{ matched: boolean, matches: string[] }}
+ */
+export function checkRule(text, rule) {
+  try {
+    const regex = new RegExp(rule.pattern, "gim");
+    const matches = [];
+    let match;
+    while ((match = regex.exec(text)) !== null) {
+      matches.push(match[0].substring(0, 120));
+      if (matches.length >= 3) break;
+    }
+    return { matched: matches.length > 0, matches };
+  } catch {
+    return { matched: false, matches: [] };
+  }
+}
+
+/**
+ * Scan a text string for all rule violations.
+ * @param {string} text
+ * @param {object} state
+ * @returns {Array<{ rule: object, matches: string[] }>}
+ */
+export function scanForViolations(text, state) {
+  const rules = loadTtsrRules(state);
+  const violations = [];
+  for (const rule of rules) {
+    const result = checkRule(text, rule);
+    if (result.matched) violations.push({ rule, matches: result.matches });
+  }
+  return violations;
+}
+
+// ---------------------------------------------------------------------------
+// Message processing helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract plain text from a message's parts array.
+ * @param {Array<object>} parts
+ * @param {{ excludeToolOutput?: boolean }} [options]
+ * @returns {string}
+ */
+export function extractTextFromParts(parts, options = {}) {
+  if (!Array.isArray(parts)) return "";
+  return parts
+    .filter((p) => {
+      if (!p || typeof p.text !== "string") return false;
+      if (p.type !== "text") return false;
+      if (options.excludeToolOutput && (p.toolCallId || p.toolInvocationId)) return false;
+      return true;
+    })
+    .map((p) => p.text)
+    .join("\n");
+}
+
+/**
+ * Get the most recent N assistant messages, excluding synthetic correction messages.
+ * @param {Array<object>} messages
+ * @param {number} windowSize
+ * @returns {Array<object>}
+ */
+export function getRecentAssistantMessages(messages, windowSize) {
+  return messages
+    .filter((m) => {
+      if (!m.info || m.info.role !== "assistant") return false;
+      if (m.info.id && m.info.id.startsWith("ttsr-correction-")) return false;
+      return true;
+    })
+    .slice(-windowSize);
+}
+
+/**
+ * Collect deduped violations from recent assistant messages.
+ * @param {Array<object>} assistantMessages
+ * @param {object} state
+ * @returns {Array<{ rule: object, matches: string[], msgId: string }>}
+ */
+export function collectDedupedViolations(assistantMessages, state) {
+  const allViolations = [];
+  for (const msg of assistantMessages) {
+    const msgId = msg.info?.id || "";
+    const text = extractTextFromParts(msg.parts, { excludeToolOutput: true });
+    if (!text) continue;
+    const violations = scanForViolations(text, state);
+    for (const v of violations) {
+      const firedOn = state.ttsrFiredState.get(v.rule.id);
+      if (firedOn && firedOn.has(msgId)) continue;
+      if (!allViolations.some((av) => av.rule.id === v.rule.id)) {
+        allViolations.push({ ...v, msgId });
+      }
+    }
+  }
+  return allViolations;
+}
+
+/**
+ * Record which violations fired so they are not re-injected.
+ * @param {Array<{ rule: object, msgId: string }>} violations
+ * @param {Map<string, Set<string>>} ttsrFiredState
+ */
+export function recordFiredViolations(violations, ttsrFiredState) {
+  for (const v of violations) {
+    if (!ttsrFiredState.has(v.rule.id)) ttsrFiredState.set(v.rule.id, new Set());
+    ttsrFiredState.get(v.rule.id).add(v.msgId);
+  }
+}
+
+// buildCorrectionMessage is defined in ttsr.mjs (only called there).

--- a/.agents/plugins/opencode-aidevops/ttsr.mjs
+++ b/.agents/plugins/opencode-aidevops/ttsr.mjs
@@ -1,76 +1,13 @@
 import { existsSync } from "fs";
 import { join } from "path";
-
-/**
- * Built-in TTSR rules — enforced by default.
- * Each rule has:
- *   - id: unique identifier
- *   - description: human-readable explanation
- *   - pattern: regex string to detect violations in assistant output
- *   - correction: message injected when violation is detected
- *   - severity: "error" | "warn" | "info"
- *   - systemPrompt: instruction injected into system prompt (preventative)
- *
- * @type {Array<{id: string, description: string, pattern: string, correction: string, severity: string, systemPrompt: string}>}
- */
-const BUILTIN_TTSR_RULES = [
-  {
-    id: "no-glob-for-discovery",
-    description: "Use git ls-files or fd instead of Glob/find for file discovery",
-    pattern: "(?:mcp_glob|Glob tool|use.*\\bGlob\\b.*to find|I'll use Glob)",
-    correction: "Use `git ls-files` or `fd` for file discovery, not Glob. Glob is a last resort when Bash is unavailable.",
-    severity: "warn",
-    systemPrompt: "File discovery: use `git ls-files '<pattern>'` for git-tracked files, `fd` for untracked. NEVER use Glob/find as primary discovery.",
-  },
-  {
-    id: "no-cat-for-reading",
-    description: "Use Read tool instead of cat/head/tail for file reading",
-    pattern: "(?:^|\\s)cat\\s+['\"]?[/~\\w]|\\bhead\\s+-n|\\btail\\s+-n",
-    correction: "Use the Read tool for file reading, not cat/head/tail. These are Bash commands that waste context.",
-    severity: "info",
-    systemPrompt: "Use the Read tool for file reading. Avoid cat/head/tail in Bash — they waste context tokens.",
-  },
-  {
-    id: "read-before-edit",
-    description: "Always Read a file before Edit or Write to existing files",
-    pattern: "(?:I'll edit|Let me edit|I'll write to|Let me write)(?!.*(?:creat|new file|new \\w+ file|generat))(?:(?!I'll read|let me read|I've read|already read).){0,200}$",
-    correction: "ALWAYS Read a file before Edit/Write to an existing file. These tools fail without a prior Read in this conversation. (This rule does not apply when creating new files.)",
-    severity: "error",
-    systemPrompt: "ALWAYS Read a file before Edit or Write to an existing file. These tools FAIL without a prior Read in this conversation. For NEW files, verify the parent directory exists instead.",
-  },
-  {
-    id: "no-credentials-in-output",
-    description: "Never expose credentials, API keys, or secrets in output",
-    pattern: "(?:api[_-]?key|secret|password|token)\\s*[:=]\\s*['\"][A-Za-z0-9+/=_-]{16,}['\"]",
-    correction: "SECURITY: Never expose credentials in output. Use `aidevops secret set NAME` for secure storage.",
-    severity: "error",
-    systemPrompt: "NEVER expose credentials, API keys, or secrets in output or logs.",
-  },
-  {
-    id: "pre-edit-check",
-    description: "Run pre-edit-check.sh before modifying files",
-    pattern: "(?:I'll (?:create|modify|edit|write)|Let me (?:create|modify|edit|write)).*(?:on main|on master)\\b",
-    correction: "Run pre-edit-check.sh before modifying files. NEVER edit on main/master branch.",
-    severity: "error",
-    systemPrompt: "Before ANY file modification: run pre-edit-check.sh. NEVER edit on main/master.",
-  },
-  {
-    id: "shell-explicit-returns",
-    description: "Shell functions must have explicit return statements",
-    pattern: "(?:function\\s+\\w+|\\w+\\s*\\(\\)\\s*\\{)(?:(?!return\\s+[0-9]).){50,}\\}",
-    correction: "Shell functions must have explicit `return 0` or `return 1` statements (SonarCloud S7682).",
-    severity: "warn",
-    systemPrompt: "Shell scripts: every function must have an explicit `return 0` or `return 1`.",
-  },
-  {
-    id: "shell-local-params",
-    description: "Use local var=\"$1\" pattern in shell functions",
-    pattern: "^\\s+(?:echo|printf|return|if|\\[\\[).*(?<!\\\\)\\$[1-9](?![0-9.,])(?!\\/(?:mo(?:nth)?|yr|year|day|week|hr|hour)\\b)(?!\\s+(?:per|mo(?:nth)?|year|yr|day|week|hr|hour|flat|each|off|fee|plan|tier|user|seat|unit|addon|setup|trial|credit|annual|quarterly|monthly)\\b)(?!.*local\\s+\\w+=)",
-    correction: "Use `local var=\"$1\"` pattern — never use positional parameters directly (SonarCloud S7679).",
-    severity: "warn",
-    systemPrompt: "Shell scripts: use `local var=\"$1\"` — never use $1 directly in function bodies.",
-  },
-];
+import {
+  BUILTIN_TTSR_RULES,
+  loadTtsrRules,
+  scanForViolations,
+  getRecentAssistantMessages,
+  collectDedupedViolations,
+  recordFiredViolations,
+} from "./ttsr-rules.mjs";
 
 // ---------------------------------------------------------------------------
 // Token Cost Advisory
@@ -91,7 +28,6 @@ const TOKEN_ADVISORY_INTERVAL = 50_000;
 
 /**
  * Compute token total from an assistant message's token counts.
- * Matches the calculation in OpenCode's session-context-metrics.ts.
  * @param {object} tokens - { input, output, reasoning, cache: { read, write } }
  * @returns {number}
  */
@@ -103,6 +39,236 @@ function getTokenTotal(tokens) {
     (tokens.cache?.read || 0) +
     (tokens.cache?.write || 0);
 }
+
+// ---------------------------------------------------------------------------
+// TTSR state
+// ---------------------------------------------------------------------------
+
+/**
+ * Create per-session TTSR state.
+ * @param {string} ttsrRulesPath
+ * @param {(path: string) => string} readIfExists
+ * @returns {object}
+ */
+function createTtsrState(ttsrRulesPath, readIfExists) {
+  return {
+    ttsrRulesPath,
+    readIfExists,
+    /** @type {Array<object> | null} */
+    ttsrRules: null,
+    /** @type {Map<string, Set<string>>} */
+    ttsrFiredState: new Map(),
+    /** @type {Map<string, number>} Maps sessionID → highest threshold warned about. */
+    tokenAdvisoryState: new Map(),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Token advisory helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Prune old session entries from the advisory state map.
+ * @param {Map<string, number>} tokenAdvisoryState
+ */
+function pruneAdvisoryState(tokenAdvisoryState) {
+  if (tokenAdvisoryState.size <= 500) return;
+  const keys = Array.from(tokenAdvisoryState.keys());
+  for (const k of keys.slice(0, 250)) tokenAdvisoryState.delete(k);
+}
+
+/**
+ * Check whether the token cost advisory should fire for this message set.
+ * @param {Array<object>} messages
+ * @param {Map<string, number>} tokenAdvisoryState
+ * @returns {{ sessionID: string, totalK: number, total: number } | null}
+ */
+function checkTokenAdvisory(messages, tokenAdvisoryState) {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const info = messages[i].info;
+    if (info?.role !== "assistant" || !info.tokens) continue;
+
+    const total = getTokenTotal(info.tokens);
+    if (total < TOKEN_ADVISORY_INITIAL) return null;
+
+    const sessionID = info.sessionID || "";
+    const lastWarned = tokenAdvisoryState.get(sessionID) || 0;
+    const stepsAboveInitial = Math.floor((total - TOKEN_ADVISORY_INITIAL) / TOKEN_ADVISORY_INTERVAL);
+    const currentThreshold = TOKEN_ADVISORY_INITIAL + stepsAboveInitial * TOKEN_ADVISORY_INTERVAL;
+
+    if (currentThreshold <= lastWarned) return null;
+
+    tokenAdvisoryState.set(sessionID, currentThreshold);
+    pruneAdvisoryState(tokenAdvisoryState);
+    return { sessionID, totalK: Math.round(total / 1000), total };
+  }
+  return null;
+}
+
+/**
+ * Build the synthetic advisory message injected into the message stream.
+ * @param {{ sessionID: string, totalK: number }} advisory
+ * @returns {object}
+ */
+function buildTokenAdvisoryMessage(advisory) {
+  const advisoryId = `token-advisory-${Date.now()}`;
+  const text = [
+    `[TOKEN COST ADVISORY] This session has reached approximately ${advisory.totalK}k tokens.`,
+    "",
+    "Briefly inform the user in your next response:",
+    `The token cost of this session is rising with each interaction \u2014 currently at ~${advisory.totalK}k tokens. ` +
+      "You can use the /compact command to significantly reduce ongoing costs. " +
+      "Compaction preserves full understanding of what we\u2019re working on, so nothing is lost.",
+    "",
+    "Deliver this as a short note at the start of your response, then continue normally.",
+    "Do not repeat this advisory if you have already mentioned it.",
+  ].join("\n");
+
+  return {
+    info: { id: advisoryId, sessionID: advisory.sessionID, role: "user", time: { created: Date.now() }, parentID: "" },
+    parts: [{
+      id: `${advisoryId}-part`,
+      sessionID: advisory.sessionID,
+      messageID: advisoryId,
+      type: "text",
+      text,
+      synthetic: true,
+    }],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Correction message builder (called only from ttsrMessagesTransform)
+// ---------------------------------------------------------------------------
+
+function buildCorrectionMessage(violations, sessionID) {
+  const corrections = violations.map((v) => {
+    const severity = v.rule.severity === "error" ? "ERROR" : "WARNING";
+    return `[${severity}] ${v.rule.id}: ${v.rule.correction}`;
+  });
+  const correctionText = [
+    "[aidevops TTSR] Rule violations detected in recent output:",
+    ...corrections, "",
+    "Apply these corrections in your next response.",
+  ].join("\n");
+  const correctionId = `ttsr-correction-${Date.now()}`;
+  return {
+    info: { id: correctionId, sessionID, role: "user", time: { created: Date.now() }, parentID: "" },
+    parts: [{ id: `${correctionId}-part`, sessionID, messageID: correctionId, type: "text", text: correctionText, synthetic: true }],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Hook implementations (module-level, accept state + deps as parameters)
+// ---------------------------------------------------------------------------
+
+/**
+ * system.transform hook: prepend identity prefix and inject quality rules.
+ */
+async function ttsrSystemTransform(input, output, state, intentField) {
+  if (input.model?.providerID === "anthropic") {
+    const prefix = "You are Claude Code, Anthropic's official CLI for Claude.";
+    output.system.unshift(prefix);
+    if (output.system[1]) output.system[1] = prefix + "\n\n" + output.system[1];
+  }
+
+  const rules = loadTtsrRules(state);
+  const ruleLines = rules.filter((r) => r.systemPrompt).map((r) => `- ${r.systemPrompt}`);
+
+  const intentInstruction = [
+    "## Intent Tracing (observability)",
+    `When calling any tool, include a field named \`${intentField}\` in the tool arguments.`,
+    "Value: one sentence in present participle form describing your intent (e.g., \"Reading the file to understand the existing schema\").",
+    "No trailing period. This field is used for debugging and audit trails — it is stripped before tool execution.",
+  ].join("\n");
+
+  output.system.push(intentInstruction);
+  if (ruleLines.length === 0) return;
+
+  output.system.push([
+    "## aidevops Quality Rules (enforced)",
+    "The following rules are actively enforced. Violations will be flagged.",
+    ...ruleLines,
+  ].join("\n"));
+}
+
+/**
+ * messages.transform hook: inject token advisory and TTSR violation corrections.
+ */
+async function ttsrMessagesTransform(_input, output, state, qualityLog) {
+  if (!output.messages || output.messages.length === 0) return;
+
+  const advisory = checkTokenAdvisory(output.messages, state.tokenAdvisoryState);
+  if (advisory) {
+    output.messages.push(buildTokenAdvisoryMessage(advisory));
+    qualityLog("INFO", `Token advisory: session ${advisory.sessionID} at ~${advisory.totalK}k tokens`);
+  }
+
+  const assistantMessages = getRecentAssistantMessages(output.messages, 3);
+  if (assistantMessages.length === 0) return;
+
+  const allViolations = collectDedupedViolations(assistantMessages, state);
+  if (allViolations.length === 0) return;
+
+  recordFiredViolations(allViolations, state.ttsrFiredState);
+
+  const sessionID = output.messages[0]?.info?.sessionID || "";
+  output.messages.push(buildCorrectionMessage(allViolations, sessionID));
+
+  qualityLog(
+    "INFO",
+    `TTSR messages.transform: injected ${allViolations.length} correction(s): ${allViolations.map((v) => v.rule.id).join(", ")}`,
+  );
+}
+
+/**
+ * Record TTSR violations to the pattern tracker script if available.
+ * @param {Array<{ rule: object }>} violations
+ * @param {{ scriptsDir: string, run: Function }} execDeps
+ */
+function recordViolationsToTracker(violations, execDeps) {
+  const patternTracker = join(execDeps.scriptsDir, "pattern-tracker-helper.sh");
+  if (!existsSync(patternTracker)) return;
+  const ruleIds = violations.map((v) => v.rule.id).join(",");
+  execDeps.run(
+    `bash "${patternTracker}" record "TTSR_VIOLATION" "rules: ${ruleIds}" --tag "ttsr" 2>/dev/null`,
+    5000,
+  );
+}
+
+/**
+ * text.complete hook: scan output text and append TTSR violation markers.
+ * @param {object} input
+ * @param {object} output
+ * @param {object} state
+ * @param {{ scriptsDir: string, run: Function }} execDeps
+ * @param {(level: string, message: string) => void} qualityLog
+ */
+async function ttsrTextComplete(input, output, state, execDeps, qualityLog) {
+  if (!output.text) return;
+
+  const violations = scanForViolations(output.text, state);
+  if (violations.length === 0) return;
+
+  for (const v of violations) {
+    qualityLog(
+      v.rule.severity === "error" ? "ERROR" : "WARN",
+      `TTSR violation [${v.rule.id}]: ${v.rule.description} (session: ${input.sessionID}, message: ${input.messageID})`,
+    );
+  }
+
+  const markers = violations.map((v) => {
+    const severity = v.rule.severity === "error" ? "ERROR" : "WARN";
+    return `<!-- TTSR:${severity}:${v.rule.id} — ${v.rule.correction} -->`;
+  });
+
+  output.text = output.text + "\n" + markers.join("\n");
+  recordViolationsToTracker(violations, execDeps);
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
 
 /**
  * Build TTSR hook functions with injected dependencies from index.mjs.
@@ -118,361 +284,16 @@ function getTokenTotal(tokens) {
 export function createTtsrHooks(deps) {
   const { agentsDir, scriptsDir, readIfExists, qualityLog, run, intentField } = deps;
   const ttsrRulesPath = join(agentsDir, "configs", "ttsr-rules.json");
-
-  /** @type {Array<object> | null} */
-  let ttsrRules = null;
-  /** @type {Map<string, Set<string>>} */
-  const ttsrFiredState = new Map();
-
-  // ---------------------------------------------------------------------------
-  // Token Cost Advisory — per-session state
-  // ---------------------------------------------------------------------------
-  // Maps sessionID → highest threshold that has been warned about.
-  // E.g., after warning at 200k, value is 200000. After 250k, value is 250000.
-  /** @type {Map<string, number>} */
-  const tokenAdvisoryState = new Map();
-
-  /**
-   * Check whether the token cost advisory should fire for this message set.
-   * Looks at the last assistant message with token data and compares against
-   * the threshold schedule (200k, 250k, 300k, ...).
-   *
-   * @param {Array<object>} messages - MessageV2.WithParts[] from the transform hook
-   * @returns {{ sessionID: string, totalK: number, total: number } | null}
-   */
-  function checkTokenAdvisory(messages) {
-    // Walk backwards to find the last assistant message with token data
-    for (let i = messages.length - 1; i >= 0; i--) {
-      const info = messages[i].info;
-      if (info?.role !== "assistant" || !info.tokens) continue;
-
-      const total = getTokenTotal(info.tokens);
-      if (total < TOKEN_ADVISORY_INITIAL) return null;
-
-      const sessionID = info.sessionID || "";
-      const lastWarned = tokenAdvisoryState.get(sessionID) || 0;
-
-      // Calculate which threshold bracket we're in
-      const stepsAboveInitial = Math.floor(
-        (total - TOKEN_ADVISORY_INITIAL) / TOKEN_ADVISORY_INTERVAL,
-      );
-      const currentThreshold =
-        TOKEN_ADVISORY_INITIAL + stepsAboveInitial * TOKEN_ADVISORY_INTERVAL;
-
-      if (currentThreshold <= lastWarned) return null;
-
-      tokenAdvisoryState.set(sessionID, currentThreshold);
-
-      // Prune old sessions to prevent unbounded memory growth
-      if (tokenAdvisoryState.size > 500) {
-        const keys = Array.from(tokenAdvisoryState.keys());
-        for (const k of keys.slice(0, 250)) {
-          tokenAdvisoryState.delete(k);
-        }
-      }
-
-      return { sessionID, totalK: Math.round(total / 1000), total };
-    }
-    return null;
-  }
-
-  /**
-   * Build the synthetic advisory message injected into the message stream.
-   * Phrased as an instruction to the LLM so it naturally informs the user.
-   *
-   * @param {{ sessionID: string, totalK: number }} advisory
-   * @returns {object} MessageV2.WithParts-shaped synthetic message
-   */
-  function buildTokenAdvisoryMessage(advisory) {
-    const advisoryId = `token-advisory-${Date.now()}`;
-
-    const text = [
-      `[TOKEN COST ADVISORY] This session has reached approximately ${advisory.totalK}k tokens.`,
-      "",
-      "Briefly inform the user in your next response:",
-      `The token cost of this session is rising with each interaction \u2014 currently at ~${advisory.totalK}k tokens. ` +
-        "You can use the /compact command to significantly reduce ongoing costs. " +
-        "Compaction preserves full understanding of what we\u2019re working on, so nothing is lost.",
-      "",
-      "Deliver this as a short note at the start of your response, then continue normally.",
-      "Do not repeat this advisory if you have already mentioned it.",
-    ].join("\n");
-
-    return {
-      info: {
-        id: advisoryId,
-        sessionID: advisory.sessionID,
-        role: "user",
-        time: { created: Date.now() },
-        parentID: "",
-      },
-      parts: [
-        {
-          id: `${advisoryId}-part`,
-          sessionID: advisory.sessionID,
-          messageID: advisoryId,
-          type: "text",
-          text,
-          synthetic: true,
-        },
-      ],
-    };
-  }
-
-  function mergeUserTtsrRules(rules, userRules) {
-    for (const rule of userRules) {
-      if (!rule.id || !rule.pattern) continue;
-      const existingIdx = rules.findIndex((r) => r.id === rule.id);
-      if (existingIdx >= 0) {
-        rules[existingIdx] = { ...rules[existingIdx], ...rule };
-      } else {
-        rules.push(rule);
-      }
-    }
-  }
-
-  function loadTtsrRules() {
-    if (ttsrRules !== null) return ttsrRules;
-
-    ttsrRules = [...BUILTIN_TTSR_RULES];
-
-    const userContent = readIfExists(ttsrRulesPath);
-    if (userContent) {
-      try {
-        const parsed = JSON.parse(userContent);
-        if (Array.isArray(parsed)) {
-          mergeUserTtsrRules(ttsrRules, parsed);
-        }
-      } catch {
-        console.error("[aidevops] Failed to parse TTSR rules file — using built-in rules only");
-      }
-    }
-
-    return ttsrRules;
-  }
-
-  function checkRule(text, rule) {
-    try {
-      const regex = new RegExp(rule.pattern, "gim");
-      const matches = [];
-      let match;
-      while ((match = regex.exec(text)) !== null) {
-        matches.push(match[0].substring(0, 120));
-        if (matches.length >= 3) break;
-      }
-      return { matched: matches.length > 0, matches };
-    } catch {
-      return { matched: false, matches: [] };
-    }
-  }
-
-  function scanForViolations(text) {
-    const rules = loadTtsrRules();
-    const violations = [];
-
-    for (const rule of rules) {
-      const result = checkRule(text, rule);
-      if (result.matched) {
-        violations.push({ rule, matches: result.matches });
-      }
-    }
-
-    return violations;
-  }
-
-  async function systemTransformHook(input, output) {
-    // Prepend Claude Code identity for anthropic provider (required by API)
-    if (input.model?.providerID === "anthropic") {
-      const prefix = "You are Claude Code, Anthropic's official CLI for Claude.";
-      output.system.unshift(prefix);
-      if (output.system[1]) {
-        output.system[1] = prefix + "\n\n" + output.system[1];
-      }
-    }
-
-    const rules = loadTtsrRules();
-
-    const ruleLines = rules
-      .filter((r) => r.systemPrompt)
-      .map((r) => `- ${r.systemPrompt}`);
-
-    const intentInstruction = [
-      "## Intent Tracing (observability)",
-      `When calling any tool, include a field named \`${intentField}\` in the tool arguments.`,
-      "Value: one sentence in present participle form describing your intent (e.g., \"Reading the file to understand the existing schema\").",
-      "No trailing period. This field is used for debugging and audit trails — it is stripped before tool execution.",
-    ].join("\n");
-
-    output.system.push(intentInstruction);
-
-    if (ruleLines.length === 0) return;
-
-    output.system.push(
-      [
-        "## aidevops Quality Rules (enforced)",
-        "The following rules are actively enforced. Violations will be flagged.",
-        ...ruleLines,
-      ].join("\n"),
-    );
-  }
-
-  function extractTextFromParts(parts, options = {}) {
-    if (!Array.isArray(parts)) return "";
-    return parts
-      .filter((p) => {
-        if (!p || typeof p.text !== "string") return false;
-        if (p.type !== "text") return false;
-        if (options.excludeToolOutput) {
-          if (p.toolCallId || p.toolInvocationId) return false;
-        }
-        return true;
-      })
-      .map((p) => p.text)
-      .join("\n");
-  }
-
-  function getRecentAssistantMessages(messages, windowSize) {
-    return messages
-      .filter((m) => {
-        if (!m.info || m.info.role !== "assistant") return false;
-        if (m.info.id && m.info.id.startsWith("ttsr-correction-")) return false;
-        return true;
-      })
-      .slice(-windowSize);
-  }
-
-  function collectDedupedViolations(assistantMessages) {
-    const allViolations = [];
-
-    for (const msg of assistantMessages) {
-      const msgId = msg.info?.id || "";
-      const text = extractTextFromParts(msg.parts, { excludeToolOutput: true });
-      if (!text) continue;
-
-      const violations = scanForViolations(text);
-      for (const v of violations) {
-        const ruleId = v.rule.id;
-        const firedOn = ttsrFiredState.get(ruleId);
-        if (firedOn && firedOn.has(msgId)) continue;
-        if (!allViolations.some((av) => av.rule.id === ruleId)) {
-          allViolations.push({ ...v, msgId });
-        }
-      }
-    }
-
-    return allViolations;
-  }
-
-  function recordFiredViolations(violations) {
-    for (const v of violations) {
-      if (!ttsrFiredState.has(v.rule.id)) {
-        ttsrFiredState.set(v.rule.id, new Set());
-      }
-      ttsrFiredState.get(v.rule.id).add(v.msgId);
-    }
-  }
-
-  function buildCorrectionMessage(violations, sessionID) {
-    const corrections = violations.map((v) => {
-      const severity = v.rule.severity === "error" ? "ERROR" : "WARNING";
-      return `[${severity}] ${v.rule.id}: ${v.rule.correction}`;
-    });
-
-    const correctionText = [
-      "[aidevops TTSR] Rule violations detected in recent output:",
-      ...corrections,
-      "",
-      "Apply these corrections in your next response.",
-    ].join("\n");
-
-    const correctionId = `ttsr-correction-${Date.now()}`;
-
-    return {
-      info: {
-        id: correctionId,
-        sessionID,
-        role: "user",
-        time: { created: Date.now() },
-        parentID: "",
-      },
-      parts: [
-        {
-          id: `${correctionId}-part`,
-          sessionID,
-          messageID: correctionId,
-          type: "text",
-          text: correctionText,
-          synthetic: true,
-        },
-      ],
-    };
-  }
-
-  async function messagesTransformHook(_input, output) {
-    if (!output.messages || output.messages.length === 0) return;
-
-    // --- Token cost advisory (fires at 200k, then every 50k above) ---
-    const advisory = checkTokenAdvisory(output.messages);
-    if (advisory) {
-      output.messages.push(buildTokenAdvisoryMessage(advisory));
-      qualityLog(
-        "INFO",
-        `Token advisory: session ${advisory.sessionID} at ~${advisory.totalK}k tokens`,
-      );
-    }
-
-    // --- TTSR rule violation corrections ---
-    const assistantMessages = getRecentAssistantMessages(output.messages, 3);
-    if (assistantMessages.length === 0) return;
-
-    const allViolations = collectDedupedViolations(assistantMessages);
-    if (allViolations.length === 0) return;
-
-    recordFiredViolations(allViolations);
-
-    const sessionID = output.messages[0]?.info?.sessionID || "";
-    output.messages.push(buildCorrectionMessage(allViolations, sessionID));
-
-    qualityLog(
-      "INFO",
-      `TTSR messages.transform: injected ${allViolations.length} correction(s): ${allViolations.map((v) => v.rule.id).join(", ")}`,
-    );
-  }
-
-  async function textCompleteHook(input, output) {
-    if (!output.text) return;
-
-    const violations = scanForViolations(output.text);
-    if (violations.length === 0) return;
-
-    for (const v of violations) {
-      qualityLog(
-        v.rule.severity === "error" ? "ERROR" : "WARN",
-        `TTSR violation [${v.rule.id}]: ${v.rule.description} (session: ${input.sessionID}, message: ${input.messageID})`,
-      );
-    }
-
-    const markers = violations.map((v) => {
-      const severity = v.rule.severity === "error" ? "ERROR" : "WARN";
-      return `<!-- TTSR:${severity}:${v.rule.id} — ${v.rule.correction} -->`;
-    });
-
-    output.text = output.text + "\n" + markers.join("\n");
-
-    const patternTracker = join(scriptsDir, "pattern-tracker-helper.sh");
-    if (existsSync(patternTracker)) {
-      const ruleIds = violations.map((v) => v.rule.id).join(",");
-      run(
-        `bash "${patternTracker}" record "TTSR_VIOLATION" "rules: ${ruleIds}" --tag "ttsr" 2>/dev/null`,
-        5000,
-      );
-    }
-  }
+  const state = createTtsrState(ttsrRulesPath, readIfExists);
+  const execDeps = { scriptsDir, run };
 
   return {
-    loadTtsrRules,
-    systemTransformHook,
-    messagesTransformHook,
-    textCompleteHook,
+    loadTtsrRules: () => loadTtsrRules(state),
+    systemTransformHook: (input, output) => ttsrSystemTransform(input, output, state, intentField),
+    messagesTransformHook: (_input, output) => ttsrMessagesTransform(_input, output, state, qualityLog),
+    textCompleteHook: (input, output) => ttsrTextComplete(input, output, state, execDeps, qualityLog),
   };
 }
+
+// Re-export BUILTIN_TTSR_RULES for callers that access it directly.
+export { BUILTIN_TTSR_RULES };


### PR DESCRIPTION
## Summary

Resolves #18779

Decompose four interconnected opencode plugin files from a combined 15 qlty smells (including a single 125-complexity function) to zero smells. No function exceeds cyclomatic 15 in any modified file.

## Changes

### ttsr.mjs — createTtsrHooks (was 125 → 0)
All 14 inner functions hoisted out of `createTtsrHooks` into module-level functions using a `TtsrState` object for shared state. Rule loading, scanning, and message processing helpers extracted to `ttsr-rules.mjs` (≤49 complexity).

### cursor/proxy.js (was 157 → ≤49)
Extracted to 5 sibling files:
- `proxy-bridge.js` — bridge spawn, frame encoding, tool alias resolution
- `proxy-messages.js` — protobuf message building, request parsing
- `proxy-handlers.js` — server message dispatching, exec rejection tables
- `proxy-sse.js` — thinking-tag filter (`classifyTagSections`/`checkForPartialTag`), SSE helpers
- `proxy-stream.js` — bridge streaming, response collection (passes `proxyState` for shared state)

### provider-auth.mjs (was 170 → ≤49)
Extracted to 4 sibling files:
- `provider-auth-cch.mjs` — CCH billing header, xxHash64, constants loading
- `provider-auth-pool.mjs` — pool account selection, rotation
- `provider-auth-pool-recovery.mjs` — exhaustion recovery, rate-limit handling
- `provider-auth-request.mjs` — request/response transformation, header building

### google-proxy.mjs (was 70 → ≤49)
- Extracted `fetch` handler to `handleGoogleProxyFetch` + `forwardToGoogleApi` + `retryWithRotatedGoogleAccount`
- Extracted model registry and config persistence to `google-proxy-config.mjs`
- `retryWithRotatedGoogleAccount` reduced from 6 to 5 parameters
- `startGoogleProxy` returns reduced from 10 to 5

### Bonus: cursor-proxy.mjs similar-code smell fixed
`buildCursorProviderModels` refactored from `for`+assignment to `Object.fromEntries+map`, eliminating the similar-code smell with `buildClaudeProviderModels`.

## Verification

```bash
~/.qlty/bin/qlty smells --all --sarif --no-snippets --quiet 2>/dev/null \
  | jq '[.runs[0].results[] | select(.locations[0].physicalLocation.artifactLocation.uri | test("opencode-aidevops/(cursor|ttsr|provider-auth|google-proxy)"))] | length'
# Returns: 0
```

All plugin modules load without errors (verified via `node --input-type=module`).

## Plugin-shape convention

The pattern for future opencode plugins is now established across these files:
- Hook factory function creates a state object and returns hook functions as closures that call module-level implementations
- High-complexity dispatch functions extracted to per-event handlers
- Shared state passed explicitly as parameter objects (not module globals where avoidable)

Reference pattern: `ttsr.mjs` (`createTtsrHooks` → `createTtsrState`) and `cursor/proxy-stream.js` (`proxyState` parameter).