### PR TITLE
GH#18869: fix(GH#18869): guard getent empty output in real-home resolvers

### DIFF
--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -31,10 +31,14 @@ set -euo pipefail
 # Security: no escalation — root already has full filesystem access.
 _resolve_real_home() {
 	if [[ -n "${SUDO_USER:-}" && "$(id -u)" -eq 0 ]] && command -v getent &>/dev/null; then
-		getent passwd "$SUDO_USER" | cut -d: -f6
-	else
-		printf '%s' "$HOME"
+		local real_home
+		real_home=$(getent passwd "$SUDO_USER" | cut -d: -f6)
+		if [[ -n "$real_home" ]]; then
+			printf '%s' "$real_home"
+			return 0
+		fi
 	fi
+	printf '%s' "$HOME"
 	return 0
 }
 

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -27,10 +27,12 @@ NC='\033[0m' # No Color
 # under `set -euo pipefail` on any BSD system and breaks sudo aidevops approve.
 # Mirrors the pattern in .agents/scripts/approval-helper.sh:_resolve_real_home().
 # Security: no escalation — root already has full filesystem access.
+_AIDEVOPS_REAL_HOME="$HOME"
 if [[ -n "${SUDO_USER:-}" && "$(id -u)" -eq 0 ]] && command -v getent &>/dev/null; then
-	_AIDEVOPS_REAL_HOME=$(getent passwd "$SUDO_USER" | cut -d: -f6)
-else
-	_AIDEVOPS_REAL_HOME="$HOME"
+	_tmp_real_home=$(getent passwd "$SUDO_USER" | cut -d: -f6)
+	if [[ -n "$_tmp_real_home" ]]; then
+		_AIDEVOPS_REAL_HOME="$_tmp_real_home"
+	fi
 fi
 INSTALL_DIR="$_AIDEVOPS_REAL_HOME/Git/aidevops"
 AGENTS_DIR="$_AIDEVOPS_REAL_HOME/.aidevops/agents"


### PR DESCRIPTION
## Summary

Adds empty-output guard to getent calls in both aidevops.sh and approval-helper.sh. If getent succeeds but returns an empty home dir (malformed passwd entry), both resolvers now fall back to $HOME instead of propagating an empty string into path variables.

## Files Changed

.agents/scripts/approval-helper.sh,aidevops.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck aidevops.sh && shellcheck .agents/scripts/approval-helper.sh — both clean

Resolves #18869


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.24 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 1m and 3,326 tokens on this as a headless worker.