### PR TITLE
GH#18870: fix(review-followup) remove redundant null check + extend label exclusion in consolidation instructions

### DIFF
--- a/.agents/scripts/cleanup-mistagged-origin-interactive.sh
+++ b/.agents/scripts/cleanup-mistagged-origin-interactive.sh
@@ -157,7 +157,7 @@ fix_issue() {
 
 	local action_summary="#${issue_number}: remove origin:interactive, add origin:worker"
 	local -a assignees_arr=()
-	if [[ -n "$assignees_csv" && "$assignees_csv" != "null" ]]; then
+	if [[ -n "$assignees_csv" ]]; then
 		# shellcheck disable=SC2034  # assignees_arr is populated here and iterated below
 		IFS=',' read -ra assignees_arr <<<"$assignees_csv"
 	fi

--- a/.agents/scripts/pulse-triage.sh
+++ b/.agents/scripts/pulse-triage.sh
@@ -578,7 +578,7 @@ _compose_consolidation_worker_instructions() {
 \`\`\`bash
 gh issue create --repo "${repo_slug}" \\
   --title "consolidated: <concise description derived from the merged spec>" \\
-  --label "consolidated,origin:worker,<copy relevant labels from parent, excluding needs-consolidation and consolidation-task>" \\
+  --label "consolidated,origin:worker,<copy relevant labels from parent, excluding needs-consolidation, consolidation-task, and origin:interactive>" \\
   --body "<merged body from step 2>"
 \`\`\`
 


### PR DESCRIPTION
## Summary

Two unaddressed review bot suggestions from PR #18676 verified and applied.

### Fix 1 — `cleanup-mistagged-origin-interactive.sh:160`

Removes the redundant `&& "$assignees_csv" != "null"` check.

**Premise check:** `assignees_csv` is set at line 237 via `jq -r '.assignees | join(",")'` on an array constructed as `[.assignees[].login]`. `jq join(",")` on an array produces `""` for empty and a CSV string for non-empty — never the literal string `"null"`. The bot's claim is correct.

**Fix:** `[[ -n "$assignees_csv" ]]` is sufficient.

### Fix 2 — `pulse-triage.sh:581`

Extends the label exclusion list in the consolidation worker instructions to include `origin:interactive`.

**Premise check:** The prior exclusion list only mentioned `needs-consolidation` and `consolidation-task`. A parent issue may carry `origin:interactive` from the pre-Fix-7 bug (GH#18670). Without explicit exclusion, a worker following these instructions would copy that label to the new consolidated issue, re-introducing the exact mislabeling this cleanup was designed to fix.

**Fix:** adds `origin:interactive` to the exclusion list in the template label string.

## Verification

- `shellcheck .agents/scripts/cleanup-mistagged-origin-interactive.sh` — clean
- `shellcheck .agents/scripts/pulse-triage.sh` — clean

Resolves #18870


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.24 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 1m and 4,145 tokens on this as a headless worker.