### PR TITLE
GH#18872: fix grammar in ubicloud.md — add 'versions' noun after self-hosted

### DIFF
--- a/.agents/services/hosting/ubicloud.md
+++ b/.agents/services/hosting/ubicloud.md
@@ -221,7 +221,7 @@ See https://ubicloud.com/docs/inference/endpoint
 
 ## Hosted (managed SaaS) vs. self-managed (build your own cloud)
 
-Same AGPL v3 codebase runs both the managed service and self-hosted on your own bare metal.
+Same AGPL v3 codebase runs both the managed service and self-hosted versions on your own bare metal.
 
 | Dimension | Managed SaaS (console.ubicloud.com) | Self-managed (build your own cloud) |
 |-----------|-------------------------------------|--------------------------------------|


### PR DESCRIPTION
## Summary

Fix grammatically incomplete sentence in `.agents/services/hosting/ubicloud.md` flagged by gemini-code-assist on PR #18674.

**Before:** `Same AGPL v3 codebase runs both the managed service and self-hosted on your own bare metal.`

**After:** `Same AGPL v3 codebase runs both the managed service and self-hosted versions on your own bare metal.`

`self-hosted` is an adjective; without a noun it leaves the parallel structure incomplete. Adding `versions` completes the parallel (`managed service` ↔ `self-hosted versions`) and makes the sentence grammatically correct.

Resolves #18872