### PR TITLE
GH#18859: fix: harden jq filter and pgrep patterns in pulse-issue-reconcile.sh

### DIFF
--- a/.agents/scripts/pulse-issue-reconcile.sh
+++ b/.agents/scripts/pulse-issue-reconcile.sh
@@ -157,7 +157,7 @@ _normalize_stale_get_dispatch_info() {
 		IFS= read -r dispatch_pid
 		IFS= read -r dispatch_created_at
 	} < <(gh api "repos/${slug}/issues/${stale_num}/comments" \
-		--jq '[.[] | select(.body | test("^(<!-- ops:start[^>]*-->\\s*)?Dispatching worker"))] | sort_by(.created_at) | last | if . then ((.body | capture("\\*\\*Worker PID\\*\\*: (?<pid>[0-9]+)") | .pid // ""), .created_at) else empty end' \
+		--jq '[.[] | select(.body | contains("Dispatching worker"))] | sort_by(.created_at) | last | if . then ((.body | capture("\\*\\*Worker PID\\*\\*: (?<pid>[0-9]+)") // {pid: ""} | .pid), (.created_at | sub("\\.[0-9]+Z$"; "Z"))) else empty end' \
 		2>/dev/null) || true
 
 	printf '%s\n%s\n' "$dispatch_pid" "$dispatch_created_at"
@@ -189,7 +189,7 @@ _normalize_stale_should_skip_reset() {
 	local cross_runner_max_runtime="$4"
 
 	# Check 1: local worker process still referencing this issue
-	if pgrep -f "issue.*${stale_num}" >/dev/null 2>&1 || pgrep -f "#${stale_num}" >/dev/null 2>&1; then
+	if pgrep -f "pulse-reconcile.*[^0-9]${stale_num}([^0-9]|$)" >/dev/null 2>&1 || pgrep -f "#${stale_num}([^0-9]|$)" >/dev/null 2>&1; then
 		return 0
 	fi
 


### PR DESCRIPTION
## Summary

Applied two bot review fixes from PR #18700: (1) jq filter in _normalize_stale_get_dispatch_info now uses contains() instead of test('^...'), adds // {pid:""} fallback for capture(), and strips milliseconds from timestamps for BSD date portability; (2) pgrep patterns in _normalize_stale_should_skip_reset tightened to avoid false positives on issue numbers that are substrings of longer numbers.

## Files Changed

.agents/scripts/pulse-issue-reconcile.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-issue-reconcile.sh — zero violations

Resolves #18859


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.24 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 1m and 4,912 tokens on this as a headless worker.