### PR TITLE
GH#18863: optimise enrichment helpers in pulse-quality-debt.sh

### DIFF
--- a/.agents/scripts/pulse-quality-debt.sh
+++ b/.agents/scripts/pulse-quality-debt.sh
@@ -190,11 +190,11 @@ _enrichment_fetch_issue_data() {
 	local issue_number="$1"
 	local repo_slug="$2"
 
-	local issue_body issue_title issue_comments
-	issue_body=$(gh issue view "$issue_number" --repo "$repo_slug" \
-		--json body --jq '.body // ""' 2>/dev/null) || issue_body=""
-	issue_title=$(gh issue view "$issue_number" --repo "$repo_slug" \
-		--json title --jq '.title // ""' 2>/dev/null) || issue_title=""
+	local issue_json issue_body issue_title issue_comments
+	issue_json=$(gh issue view "$issue_number" --repo "$repo_slug" \
+		--json title,body 2>/dev/null) || issue_json="{}"
+	issue_title=$(printf '%s' "$issue_json" | jq -r '.title // ""')
+	issue_body=$(printf '%s' "$issue_json" | jq -r '.body // ""')
 
 	# Get kill/dispatch comments for failure context
 	issue_comments=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
@@ -303,8 +303,13 @@ _enrichment_run_worker() {
 	local repo_path="$4"
 	local resolved_model="$5"
 
+	_save_cleanup_scope
+	trap '_run_cleanups' RETURN
+
 	local enrichment_output
 	enrichment_output=$(mktemp)
+	push_cleanup "rm -f '${enrichment_output}'"
+	push_cleanup "rm -f '${prompt_file}'"
 
 	# shellcheck disable=SC2086
 	"$HEADLESS_RUNTIME_HELPER" run \
@@ -316,7 +321,6 @@ _enrichment_run_worker() {
 		--prompt-file "$prompt_file" </dev/null >"$enrichment_output" 2>&1
 
 	local enrichment_exit=$?
-	rm -f "$prompt_file" "$enrichment_output"
 
 	# Check if enrichment succeeded (issue body was edited)
 	local post_body


### PR DESCRIPTION
## Summary

Addresses two unresolved review bot findings from PR #18699.

**Fix 1 — `_enrichment_fetch_issue_data` (line 197):** Combines two separate `gh issue view` API calls for `title` and `body` into a single call with `--json title,body`, then extracts each field with `jq -r`. Reduces GitHub API calls from 2 to 1 per enrichment cycle. Avoids `eval` (the bot's suggestion) in favour of two safe `jq -r` extractions.

**Fix 2 — `_enrichment_run_worker` (line 333):** Adds `_save_cleanup_scope` / `push_cleanup` / `trap '_run_cleanups' RETURN` pattern for robust temp file cleanup on all exit paths. Removes the manual `rm -f` which was only on the linear path. Follows the project convention used in `loop-common.sh`, `matrix-dispatch-helper.sh`, `codacy-collector-helper.sh`, and `sonarscanner-cli.sh`.

**Verification:** `shellcheck .agents/scripts/pulse-quality-debt.sh` passes with zero violations.

Resolves #18863

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal script efficiency and resource cleanup handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->