### PR TITLE
GH#18868: GH#18868: add TEST_ROOT guard clauses to _write_gh_stub_binary and _setup_gh_stub_globals

### DIFF
--- a/.agents/scripts/tests/test-consolidation-dispatch.sh
+++ b/.agents/scripts/tests/test-consolidation-dispatch.sh
@@ -51,6 +51,10 @@ print_result() {
 # _write_gh_stub_binary: write the stubbed gh binary to TEST_ROOT/bin/gh.
 # Requires TEST_ROOT to be set. Called by setup_gh_stub.
 _write_gh_stub_binary() {
+	if [[ -z "${TEST_ROOT:-}" ]]; then
+		printf 'Error: TEST_ROOT is not set\n' >&2
+		return 1
+	fi
 	mkdir -p "${TEST_ROOT}/bin"
 	cat >"${TEST_ROOT}/bin/gh" <<'STUB'
 #!/usr/bin/env bash
@@ -136,6 +140,10 @@ STUB
 # _setup_gh_stub_globals: export PATH and pulse-triage globals, then source the script.
 # Requires TEST_ROOT and GH_LOG to be set. Called by setup_gh_stub.
 _setup_gh_stub_globals() {
+	if [[ -z "${TEST_ROOT:-}" ]]; then
+		printf 'Error: TEST_ROOT is not set\n' >&2
+		return 1
+	fi
 	export PATH="${TEST_ROOT}/bin:${PATH}"
 	export GH_LOG
 	export LOGFILE="${TEST_ROOT}/pulse.log"


### PR DESCRIPTION
## Summary

Added guard clauses to _write_gh_stub_binary and _setup_gh_stub_globals in test-consolidation-dispatch.sh to check TEST_ROOT is set before use, preventing accidental operations on the root filesystem if called without setup_gh_stub.

## Files Changed

.agents/scripts/tests/test-consolidation-dispatch.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck passes clean on the modified file

Resolves #18868


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.24 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 1m and 3,749 tokens on this as a headless worker.