### PR TITLE
GH#18914: t2085: fix(dispatch-dedup): detect open PRs by body closing-keyword (race on #18779)

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -1583,6 +1583,59 @@ _has_open_pr_check_open_commits() {
 }
 
 #######################################
+# has_open_pr Check 1b: OPEN PRs with closing-keyword in body (t2085).
+#
+# Mirrors Check 2 but scans --state open. Catches the standard framework
+# convention where `full-loop-helper.sh commit-and-pr` writes
+# `Resolves #NNN` into the PR body — Check 1's commit-subject matcher
+# does NOT see this because the framework convention does not put
+# closing keywords in commit subjects.
+#
+# Without this check, every routine implementation PR was invisible to
+# `has_open_pr`, which left Layer 4 dedup blind to in-flight work and
+# caused the marcusquinn-vs-alex-solovyev cross-runner duplicate-dispatch
+# race observed on issue #18779 → PR #18906 (a duplicate worker was
+# dispatched after PR #18906 was already open and waiting for review).
+#
+# Each candidate hit is post-filtered with the same exact regex Checks 2
+# and 3 use, to avoid GitHub full-text false positives (a PR mentioning
+# "v3.5.670" would otherwise falsely match issue #670 on the keyword
+# search alone).
+#
+# Args: $1 = issue number, $2 = repo slug
+# Returns: exit 0 if an open PR closes this issue (prints reason), exit 1 if none
+#######################################
+_has_open_pr_check_open_body_keyword() {
+	local issue_number="$1"
+	local repo_slug="$2"
+
+	local query pr_json pr_count pr_number
+	for keyword in close closes closed fix fixes fixed resolve resolves resolved; do
+		query="${keyword} #${issue_number} in:body"
+		pr_json=$(gh pr list --repo "$repo_slug" --state open --search "$query" --limit 1 --json number 2>/dev/null) || pr_json="[]"
+		pr_count=$(printf '%s' "$pr_json" | jq 'length' 2>/dev/null) || pr_count=0
+		[[ "$pr_count" =~ ^[0-9]+$ ]] || pr_count=0
+		[[ "$pr_count" -eq 0 ]] && continue
+
+		pr_number=$(printf '%s' "$pr_json" | jq -r '.[0].number // empty' 2>/dev/null)
+		if [[ -n "$pr_number" ]]; then
+			local pr_body
+			pr_body=$(gh pr view "$pr_number" --repo "$repo_slug" --json body --jq '.body' 2>/dev/null) || pr_body=""
+			# Match: keyword + optional whitespace + #NNN or owner/repo#NNN followed by a non-word char or end
+			local close_pattern_open="(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#${issue_number}([^[:alnum:]_]|$)"
+			if ! printf '%s' "$pr_body" | grep -iqE "$close_pattern_open"; then
+				continue
+			fi
+			printf 'open PR #%s closes issue #%s via "%s" keyword in body\n' "$pr_number" "$issue_number" "$keyword"
+		else
+			printf 'open PR closes issue #%s via "%s" keyword in body\n' "$issue_number" "$keyword"
+		fi
+		return 0
+	done
+	return 1
+}
+
+#######################################
 # has_open_pr Check 2: Merged PRs with closing-keyword in body.
 #
 # Loops through all closing keyword variants and searches merged PRs via
@@ -1722,6 +1775,14 @@ has_open_pr() {
 
 	# Check 1: open PRs whose commits reference this issue.
 	_has_open_pr_check_open_commits "$issue_number" "$repo_slug" && return 0
+
+	# Check 1b (t2085): open PRs with closing-keyword in body. Required because
+	# the framework convention writes `Resolves #NNN` in the PR body, not in
+	# commit subjects — so Check 1's commit-subject matcher misses every
+	# routine implementation PR. Without this, Layer 4 dedup is blind to
+	# in-flight work and produces cross-runner duplicate dispatch (the
+	# marcusquinn-vs-alex-solovyev race on issue #18779 → PR #18906).
+	_has_open_pr_check_open_body_keyword "$issue_number" "$repo_slug" && return 0
 
 	# Check 2: merged PRs with closing-keyword in body.
 	_has_open_pr_check_merged_keywords "$issue_number" "$repo_slug" && return 0

--- a/.agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh
@@ -272,6 +272,78 @@ For #18522'
 	return 0
 }
 
+# t2085: Layer 4 dedup must detect OPEN PRs that put `Resolves #N` in the
+# PR body (the framework convention via full-loop-helper.sh commit-and-pr).
+# Without this check, the dedup helper is blind to every routine
+# implementation PR — Check 1 matches commit subjects + PR title, neither
+# of which carries the closing keyword under the framework convention.
+# Trigger incident: cross-runner race on issue #18779 → PR #18906.
+test_has_open_pr_detects_open_body_closing_keyword() {
+	set_gh_fixtures 'marcusquinn/aidevops|open|resolves #18779 in:body|[{"number":18906}]'
+	# Single-line body — the test gh stub reads fixtures line-by-line, so
+	# multi-line bodies get truncated to the first line. Real PR bodies have
+	# the closing keyword somewhere in the body; the post-filter regex
+	# does not require it on the first line.
+	set_gh_pr_view_fixtures '18906|body|Resolves #18779. Decompose four interconnected opencode plugin files.'
+
+	local output=""
+	if output=$("$HELPER_SCRIPT" has-open-pr 18779 marcusquinn/aidevops 't2071: decompose opencode plugin cluster'); then
+		case "$output" in
+		*'open PR #18906 closes issue #18779 via "resolves" keyword in body'*)
+			print_result "has-open-pr detects OPEN PR via body closing keyword (t2085)" 0
+			return 0
+			;;
+		esac
+		print_result "has-open-pr detects OPEN PR via body closing keyword (t2085)" 1 "Unexpected output: ${output}"
+		return 0
+	fi
+
+	print_result "has-open-pr detects OPEN PR via body closing keyword (t2085)" 1 "Expected open PR evidence for issue #18779"
+	return 0
+}
+
+# t2085: planning-only OPEN PR bodies use `For #N` / `Ref #N` instead of a
+# closing keyword. The new open-body check must NOT treat those as evidence,
+# matching the existing planning-aware semantics already enforced by
+# Check 3 for merged PRs (GH#18641).
+test_has_open_pr_ignores_open_body_planning_for_reference() {
+	# No keyword-search hits at all — the brief PR body uses "For #18779" not
+	# any closing keyword, so the gh search-by-keyword stage finds nothing.
+	# Verify that none of the keyword variants produce a positive match.
+	set_gh_fixtures ''
+	set_gh_pr_view_fixtures ''
+
+	if "$HELPER_SCRIPT" has-open-pr 18779 marcusquinn/aidevops 't2071: planning brief'; then
+		print_result "has-open-pr ignores OPEN PR with planning-only 'For #N' (t2085)" 1 \
+			"Expected exit 1: a brief PR with only 'For #18779' must not block dispatch"
+		return 0
+	fi
+
+	print_result "has-open-pr ignores OPEN PR with planning-only 'For #N' (t2085)" 0
+	return 0
+}
+
+# t2085: a PR whose body contains a closing keyword for a DIFFERENT issue
+# but mentions our issue without a closing keyword must NOT block dispatch
+# on our issue. The post-filter regex must match OUR issue number
+# specifically. (Mirrors GH#18641 semantics for the open-state code path.)
+test_has_open_pr_requires_open_close_keyword_for_our_issue() {
+	# GitHub full-text search may match the keyword on a PR that closes a
+	# different issue. The fixture simulates a hit on the search but a body
+	# that closes #18999 instead of #18779. The post-filter must reject it.
+	set_gh_fixtures 'marcusquinn/aidevops|open|closes #18779 in:body|[{"number":18950}]'
+	set_gh_pr_view_fixtures '18950|body|Closes #18999. This PR is unrelated to #18779; the search just full-text matched.'
+
+	if "$HELPER_SCRIPT" has-open-pr 18779 marcusquinn/aidevops 't2071: opencode decomposition'; then
+		print_result "has-open-pr requires open-PR close keyword for OUR issue (t2085)" 1 \
+			"Expected exit 1: PR closes #18999, not #18779; full-text search hit must be filtered"
+		return 0
+	fi
+
+	print_result "has-open-pr requires open-PR close keyword for OUR issue (t2085)" 0
+	return 0
+}
+
 # Existing collision case (GH#18041 / t1957) must still allow dispatch:
 # different task used the same ID, merged PR closes some unrelated issue.
 test_has_open_pr_allows_dispatch_on_task_id_collision() {
@@ -299,6 +371,9 @@ main() {
 	test_has_open_pr_ignores_planning_ref_reference
 	test_has_open_pr_requires_close_keyword_for_our_issue
 	test_has_open_pr_allows_dispatch_on_task_id_collision
+	test_has_open_pr_detects_open_body_closing_keyword
+	test_has_open_pr_ignores_open_body_planning_for_reference
+	test_has_open_pr_requires_open_close_keyword_for_our_issue
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Adds `_has_open_pr_check_open_body_keyword` to dispatch-dedup-helper.sh — a new Check 1b mirroring the existing `_has_open_pr_check_merged_keywords` pattern but for `--state open`. Wires it into `has_open_pr` between Check 1 and Check 2.

The framework convention writes `Resolves #NNN` in the PR body (template-generated by `full-loop-helper.sh commit-and-pr`), NOT in commit subjects. The existing Check 1 (`_has_open_pr_check_open_commits`) only matches commit subjects + PR title — so it missed virtually every routine implementation PR. With Layer 4 dedup blind to in-flight open PRs, the cross-runner race observed on issue #18779 → PR #18906 dispatched a duplicate worker even though the implementation was already complete and waiting for review.

Trigger incident timeline:
- 04:28 alex-solovyev runner dispatched a worker on #18779
- 06:32 escalated to opus tier
- 07:14 PR #18906 opened with `Resolves #18779` in body, all 12+ technical CI checks pass
- 07:19 marcusquinn runner stale-recovered the alex-solovyev claim (2737s old) and dispatched a duplicate worker — Layer 4 missed PR #18906 because its commit subject was `t2071: decompose…` (no closing keyword) and its title had no `#18779`

The duplicate worker (this session) detected the situation in its t2046 discovery pass, declined to duplicate the 16-file refactor, and instead implemented the framework fix that prevents the race.

## Files Changed

.agents/scripts/dispatch-dedup-helper.sh,.agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 1. `bash .agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh` — 10/10 pass (7 existing + 3 new t2085 cases covering happy-path open-PR detection, planning-only `For #N` rejection, and post-filter regex on the wrong issue number).
2. `bash .agents/scripts/tests/test-dispatch-dedup-helper-is-assigned.sh` — 16/16 pass, no regression on dispatch dedup combined-rule semantics.
3. `bash .agents/scripts/tests/test-dispatch-dedup-multi-operator.sh` — 8/8 pass, no regression on cross-runner race coverage.
4. `bash .agents/scripts/tests/test-stale-recovery-escalation.sh` — 11/11 pass, no regression on the existing tick-counter / escalation behaviour.
5. `shellcheck .agents/scripts/dispatch-dedup-helper.sh .agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh` — clean.

This PR does NOT touch issue #18779 (the opencode plugin decomposition) — that work is already complete in PR #18906 by the alex-solovyev runner and is just waiting for human review. A separate comment is posted on #18779 documenting the race.

Resolves #18914


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.24 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 12m and 43,458 tokens on this as a headless worker.