### PR TITLE
GH#18912: GH#18912: bump NESTING_DEPTH_THRESHOLD from 272 to 279

### DIFF
--- a/.agents/configs/complexity-thresholds-history.md
+++ b/.agents/configs/complexity-thresholds-history.md
@@ -48,6 +48,8 @@ Archives the full change history for `.agents/configs/complexity-thresholds.conf
 | 254 | GH#18314 | proximity guard firing at 247/249 (2 headroom); bumped to 254 to restore adequate headroom — 247 violations + 7 headroom; proximity guard (warn_at = 254-5 = 249) fires when violations exceed 249 (i.e., at 250), preventing saturation |
 | 269 | GH#18802 | ratcheted down — actual violations 267 + 2 buffer |
 | 276 | GH#18807 | proximity guard fired at 268/272 (4 headroom at filing time); subsequent ratchet to 269 reduced headroom to 0 as violations drifted to 269. 269 violations + 7 headroom = 276; proximity guard (warn_at = 276-5 = 271) fires when violations exceed 271 (i.e., at 272), preventing saturation |
+| 272 | GH#18845 | ratcheted down — actual violations 270 + 2 buffer |
+| 279 | GH#18912 | violations at threshold 272/272 (0 headroom); 272 violations + 7 headroom = 279; proximity guard (warn_at = 279-5 = 274) fires when violations exceed 274 (i.e., at 275), preventing saturation |
 
 ## FUNCTION_COMPLEXITY_THRESHOLD History
 

--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -89,7 +89,9 @@ FUNCTION_COMPLEXITY_THRESHOLD=26
 # 269 (GH#18802) reduced headroom to 0 as violations drifted up to 269. 269 violations + 7 headroom = 276.
 # Proximity guard (warn_at = 276-5 = 271) fires when violations exceed 271 (i.e., at 272), preventing saturation.
 # Ratcheted down to 272 (GH#18845): actual violations 270 + 2 buffer
-NESTING_DEPTH_THRESHOLD=272
+# Bumped to 279 (GH#18912): violations at threshold 272/272 (0 headroom); 272 violations + 7 headroom = 279.
+# Proximity guard (warn_at = 279-5 = 274) fires when violations exceed 274 (i.e., at 275), preventing saturation.
+NESTING_DEPTH_THRESHOLD=279
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Bumped NESTING_DEPTH_THRESHOLD from 272 to 279 (272 violations + 7 headroom). Added missing GH#18845 history entry. Also documents new proximity guard threshold: warn_at=274.

## Files Changed

.agents/configs/complexity-thresholds-history.md,.agents/configs/complexity-thresholds.conf

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Ran CI nesting depth check locally: 272 violations / 279 threshold — PASS. Verified the awk counter using lint_shell_files() methodology identical to code-quality.yml.

Resolves #18912


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.24 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 4m and 7,798 tokens on this as a headless worker.