### PR TITLE
GH#18925: tighten brief/templates.md prose

### DIFF
--- a/.agents/workflows/brief/templates.md
+++ b/.agents/workflows/brief/templates.md
@@ -36,13 +36,13 @@ When creating issues via `gh issue create`, wrap the appropriate tier content in
 
 Always include a tier label: `tier:simple`, `tier:standard`, or `tier:thinking`.
 
-**Why "Done When" matters:** Workers that lack a concrete completion signal exhibit two failure modes: (1) stop after setup/exploration without implementing anything (observed on #17642, #17643), or (2) stop after PR creation without merging or posting closing comments. "Done When" gives the model a checklist to drive toward instead of an open-ended goal.
+**Why "Done When" matters:** Workers without a concrete completion signal fail in two ways: stop after exploration without implementing (#17642, #17643), or stop after PR creation without merging. "Done When" is the checklist that drives toward verified completion.
 
 ## Comment Templates
 
 ### Dispatch comment (pulse → worker)
 
-Use when the pulse dispatches a worker. Include enough context to avoid re-reading the full issue:
+For pulse-dispatched workers. Include enough context to avoid re-reading the full issue:
 
 ```markdown
 ## Dispatching: {issue_title}
@@ -84,15 +84,11 @@ _Killed by watchdog at {timestamp}_
 
 ### Escalation comment (cascade dispatch)
 
-See `templates/escalation-report-template.md`. Include:
-1. What was attempted (files read, code tried)
-2. Structured reason code (see the template taxonomy)
-3. Discoveries reusable by the next tier
-4. Brief gaps (what was missing or unclear)
+See `templates/escalation-report-template.md` for the full template and reason code taxonomy. Include: what was attempted, structured reason code, reusable discoveries, and brief gaps.
 
 ## PR Description Template
 
-Workers creating PRs use this structure. It serves the review bot and the human reviewer.
+Use for all worker-created PRs. Serves the review bot and human reviewer.
 
 ```markdown
 ## Summary


### PR DESCRIPTION
## Summary

- Tightened prose in `.agents/workflows/brief/templates.md` (140→136 lines)
- Condensed "Why Done When matters" explanation (3 sentences → 2 tighter sentences)
- Simplified dispatch comment intro, escalation section list to inline, and PR description intro
- All institutional knowledge preserved (task ID refs #17642/#17643, tier labels, `MERGE_SUMMARY` requirement, PR keyword rules)

## Changes

- `.agents/workflows/brief/templates.md` — 4 prose tightening edits, -4 net lines

## Verification

- `wc -l` returns 136 (was 140)
- Qlty smells: 0 results for file
- All code blocks, task ID refs, and command examples present
- Content preservation: `tier:simple`/`tier:standard`/`tier:thinking` labels, `#17642`/`#17643` refs, `MERGE_SUMMARY`, `Closes #NNN` rules all intact

## Linked Issue

Resolves #18925

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified workflow completion verification criteria ("Done When") by removing ambiguous language about failure cases and outcomes
  * Streamlined escalation procedures with consolidated guidance referencing comprehensive reason code taxonomies and templates
  * Updated pull request creation instructions to standardize guidance across all worker-created contributions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->