### PR TITLE
GH#18924: GH#18924: tighten pulse.md — compress intro, merge How-to-Think into Prime Directive, remove redundancy

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -6907,7 +6907,7 @@
     ".agents/workflows/pulse.md": {
       "hash": "56ee27508114a708f99f97132fb0e2903fec69ef",
       "at": "2026-04-14T00:00:00Z",
-      "pr": 18116,
+      "pr": 18930,
       "passes": 3
     },
     ".agents/workflows/pulse-sweep.md": {

--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -6905,10 +6905,10 @@
       "passes": 9
     },
     ".agents/workflows/pulse.md": {
-      "hash": "f13a6f55eeb01caf5bb18ff2a6a22e02df63e952",
-      "at": "2026-04-13T16:28:00Z",
+      "hash": "56ee27508114a708f99f97132fb0e2903fec69ef",
+      "at": "2026-04-14T00:00:00Z",
       "pr": 18116,
-      "passes": 2
+      "passes": 3
     },
     ".agents/workflows/pulse-sweep.md": {
       "hash": "02c55ceede075d7be12c1e0141a6e926d9efb9d6",

--- a/.agents/workflows/pulse.md
+++ b/.agents/workflows/pulse.md
@@ -7,11 +7,7 @@ mode: subagent
 <!-- SPDX-License-Identifier: MIT -->
 <!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
 
-You are the supervisor pulse. The wrapper launches you when the backlog has stalled — **there is no human at the terminal.**
-
-Your Automate agent context contains the dispatch protocol, coordination commands, provider management, and audit trail templates. This document tells you WHAT to do with those tools — dispatch logic, merge triage, and priority ordering.
-
-For daily sweeps (edge-case triage, quality review, mission awareness, repo hygiene), the wrapper uses `/pulse-sweep`. Your job here: dispatch workers and merge ready PRs.
+You are the supervisor pulse — launched by the wrapper when the backlog stalls. **No human is at the terminal.** Your job: dispatch workers, merge ready PRs. For daily sweeps (triage, quality, hygiene), the wrapper uses `/pulse-sweep`.
 
 ## Prime Directive
 
@@ -19,7 +15,7 @@ For daily sweeps (edge-case triage, quality review, mission awareness, repo hygi
 
 Session runs up to 60 minutes. Each monitoring cycle is ~3K tokens. Dispatch → monitor → backfill continuously. Workers finishing mid-session get slots refilled immediately.
 
-**You are the dispatcher, not a worker.** NEVER implement code changes yourself. Dispatch a worker for any coding. The pulse may only: read pre-fetched state, run `gh` commands (merge/comment/label), and dispatch workers.
+**You are the dispatcher, not a worker.** NEVER implement code changes yourself. Dispatch a worker for any coding. The pulse may only: read pre-fetched state, run `gh` commands (merge/comment/label), and dispatch workers. **Speed over thoroughness** — a pulse that dispatches 3 workers in 60 seconds beats one that does perfect analysis for 8 minutes and dispatches nothing. If something is ambiguous, make your best call and move on.
 
 ## Non-Interactive Continuation Contract (MANDATORY)
 
@@ -39,8 +35,6 @@ If `AVAILABLE > 0` and `WORKER_COUNT == 0`, MUST attempt dispatch before sleepin
 If no worker launches, log `NO_DISPATCHABLE_EVIDENCE` with counts/reasons, sleep 60s, continue.
 
 ## Initial Dispatch (DO THIS FIRST)
-
-Read this section, then execute it. Everything below is refinement.
 
 ### 1. Normalise PATH and check capacity
 
@@ -184,11 +178,7 @@ Output a brief summary of total actions taken across all cycles (past tense).
 
 ---
 
-**Everything below adds sophistication to the dispatch and monitoring above. A pulse that only executes the initial dispatch + monitoring loop is a successful pulse. The sections below handle edge cases, priority ordering, and coordination — read them to make better decisions, but never at the cost of not dispatching.**
-
-## How to Think
-
-You are an intelligent supervisor, not a script executor. **Speed over thoroughness.** A pulse that dispatches 3 workers in 60 seconds beats one that does perfect analysis for 8 minutes and dispatches nothing. If something is ambiguous, make your best call and move on — the next monitoring cycle is 60 seconds away.
+**Sections below add sophistication. A pulse executing only initial dispatch + monitoring loop is a successful pulse. Read for better decisions — never at the cost of not dispatching.**
 
 ## Priority Order
 
@@ -242,7 +232,7 @@ When closing any issue, ALWAYS comment first explaining why and linking to the P
 
 NEVER dispatch a worker for an issue with `needs-maintainer-review`. NEVER attempt to remove this label, comment on these issues, or bypass the gate. Approval is cryptographic (t1894) — only `sudo aidevops approve issue <number>` can unlock it. NMR issues are excluded from the LLM state file; if you encounter one, skip it.
 
-**Interactive-session protection (GH#18352):** `dispatch-dedup-helper.sh is-assigned` treats any human assignee as blocking when EITHER (a) the issue carries an active lifecycle label — `status:queued`, `status:in-progress`, `status:in-review`, or `status:claimed` — OR (b) the `origin:interactive` label is present. This is enforced in Layer 6 of `check_dispatch_dedup` and applies to owner/maintainer assignees too. Previously the owner-passive exemption only recognised `status:queued`/`status:in-progress`, so an interactive session using `claim-task-id.sh` (which applies `status:claimed`) could be raced by the pulse. Regression tested in `tests/test-dispatch-dedup-helper-is-assigned.sh`.
+**Interactive-session protection (GH#18352):** `dispatch-dedup-helper.sh is-assigned` treats any human assignee as blocking when: (a) the issue carries an active lifecycle label (`status:queued`, `status:in-progress`, `status:in-review`, or `status:claimed`) OR (b) `origin:interactive` is present. Enforced in Layer 6 of `check_dispatch_dedup`, applies to owner/maintainer assignees too. Regression tested in `tests/test-dispatch-dedup-helper-is-assigned.sh`.
 
 ## Worker Management
 


### PR DESCRIPTION
## Summary

Tightened .agents/workflows/pulse.md from 347 to 337 lines. Removed redundant intro prose, merged 'How to Think' section into Prime Directive, removed 'Read this section...' preamble, compressed separator paragraph, and shortened the GH#18352 inline explanation. All code blocks, task ID references, command examples, and decision rationale preserved. Qlty smells: PASS.

## Files Changed

.agents/configs/simplification-state.json,.agents/workflows/pulse.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** wc -l .agents/workflows/pulse.md returns 337; qlty smells check returns PASS; all GH# and tNNN refs preserved; 15 code blocks intact

Resolves #18924


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.24 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 3m and 9,700 tokens on this as a headless worker.