### PR TITLE
GH#18926: GH#18926: tighten define.md workflow doc (122→120 lines)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -6432,7 +6432,7 @@
       "hash": "476c989fca56149f90f1eefc2b02cafdc5a6e0d5",
       "simplified_at": "2026-04-04T09:17:13Z",
       "issue": "GH#17250",
-      "action": "consolidated 6 group tables + CSS block into single unified table with CSS variable column (94→28 lines)",
+      "action": "consolidated 6 group tables + CSS block into single unified table with CSS variable column (94\u219228 lines)",
       "at": "2026-04-04T14:53:40Z",
       "passes": 1
     },
@@ -7079,10 +7079,10 @@
       "passes": 3
     },
     ".agents/workflows/define.md": {
-      "hash": "f6676059a6925261e7893072631126f1fc8778e5",
-      "at": "2026-04-11T13:54:28Z",
-      "pr": 18186,
-      "passes": 1
+      "hash": "95da6084ccfee741bfa75a6686adf664a6064e81",
+      "at": "2026-04-14T09:37:00Z",
+      "pr": 18926,
+      "passes": 2
     },
     ".agents/workflows/optimize-tiers.md": {
       "hash": "066bd6b47e328dbd06fdda6e003d447d060aa816",

--- a/.agents/workflows/define.md
+++ b/.agents/workflows/define.md
@@ -30,15 +30,13 @@ Topic: $ARGUMENTS
 
 Also classify **agent domain** and **model tier** using `reference/task-taxonomy.md`. Include domain tag (e.g., `#seo`) in TODO.md entry and as GitHub label. Omit for code tasks.
 
-**Tier classification (cascade dispatch):**
+**Tier (cascade dispatch):** Default to `tier:simple` for review feedback and single-file fixes — Haiku succeeds when briefs provide exact code blocks; only escalate when judgment is required.
 
-- `tier:simple` — single-file, <100 lines changed, pattern-following. Brief MUST provide verbatim oldString/newString for every edit.
+- `tier:simple` — single-file, <100 lines, pattern-following. Brief MUST provide verbatim oldString/newString for every edit.
 - `tier:standard` — multi-file, structural refactoring, >100 lines, approach depends on reading codebase state.
 - `tier:thinking` — architecture decisions, novel design, complex multi-system trade-offs, security audits.
 
-**Default to `tier:simple` for review feedback and single-file fixes.** Haiku achieves 100% success when briefs provide exact code blocks. Only escalate when the task genuinely requires judgment.
-
-If ambiguous, ask with numbered options (1–5 matching table above), recommend based on description.
+If task type is ambiguous, offer numbered options (1–5 matching table) with a recommendation.
 
 ### Step 2: Structured Interview (3–5 questions)
 
@@ -86,7 +84,7 @@ Read `templates/brief-template.md` and format using `workflows/brief.md` for the
 | Pre-mortem / negative space | **Acceptance Criteria** (negative criteria) |
 | Files mentioned | **Relevant Files** |
 
-**Code scaffolding (t1901 — MANDATORY for code tasks):** For each file in Files to Modify, read the reference pattern and draft a code skeleton or diff in the Implementation Steps as fenced code blocks. New files: complete skeleton with imports, function signatures, and inline comments. Edits: exact code block with surrounding context showing insertion point.
+**Code scaffolding (t1901 — MANDATORY for code tasks):** For each file in Files to Modify, draft a code skeleton or diff in Implementation Steps as fenced code blocks. New files: complete skeleton with imports, function signatures, and inline comments. Edits: exact block with surrounding context showing insertion point.
 
 ### Step 6: Present and Confirm
 


### PR DESCRIPTION
## Summary

Compress tier classification section by merging standalone paragraph into header line. Tighten code scaffolding prose. Update simplification-state.json hash (passes: 1→2). Net: 122→120 lines.

## Files Changed

.agents/configs/simplification-state.json,.agents/workflows/define.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** wc -l .agents/workflows/define.md returns 120; all code blocks, URLs, task ID refs (t1901, GH#NNN), command examples present before and after; Qlty smells check skipped (not installed); simplification-state.json hash updated.

Resolves #18926


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.24 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 3m and 12,947 tokens on this as a headless worker.