### PR TITLE
GH#18928: chore: ratchet-down NESTING_DEPTH_THRESHOLD 279→274 (GH#18928)

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -91,7 +91,8 @@ FUNCTION_COMPLEXITY_THRESHOLD=26
 # Ratcheted down to 272 (GH#18845): actual violations 270 + 2 buffer
 # Bumped to 279 (GH#18912): violations at threshold 272/272 (0 headroom); 272 violations + 7 headroom = 279.
 # Proximity guard (warn_at = 279-5 = 274) fires when violations exceed 274 (i.e., at 275), preventing saturation.
-NESTING_DEPTH_THRESHOLD=279
+# Ratcheted down to 274 (GH#18928): actual violations 272 + 2 buffer
+NESTING_DEPTH_THRESHOLD=274
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Lowered NESTING_DEPTH_THRESHOLD from 279 to 274 in .agents/configs/complexity-thresholds.conf. Actual violations: 272. New threshold: 272 + 2 buffer = 274. Added ratchet-down comment with GH#18928 reference. simplification-state.json was not modified or staged.

## Files Changed

.agents/configs/complexity-thresholds.conf

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Ran .agents/scripts/complexity-scan-helper.sh ratchet-check . 5 — confirmed actual violations 272 vs threshold 274. Confirmed simplification-state.json is not staged.

Resolves #18928


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.24 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 1m and 2,722 tokens on this as a headless worker.