### PR TITLE
GH#18938: bump NESTING_DEPTH_THRESHOLD 274→279 (proximity guard 272/274)

### DIFF
--- a/.agents/configs/complexity-thresholds-history.md
+++ b/.agents/configs/complexity-thresholds-history.md
@@ -50,6 +50,8 @@ Archives the full change history for `.agents/configs/complexity-thresholds.conf
 | 276 | GH#18807 | proximity guard fired at 268/272 (4 headroom at filing time); subsequent ratchet to 269 reduced headroom to 0 as violations drifted to 269. 269 violations + 7 headroom = 276; proximity guard (warn_at = 276-5 = 271) fires when violations exceed 271 (i.e., at 272), preventing saturation |
 | 272 | GH#18845 | ratcheted down — actual violations 270 + 2 buffer |
 | 279 | GH#18912 | violations at threshold 272/272 (0 headroom); 272 violations + 7 headroom = 279; proximity guard (warn_at = 279-5 = 274) fires when violations exceed 274 (i.e., at 275), preventing saturation |
+| 274 | GH#18928 | ratcheted down — actual violations 272 + 2 buffer |
+| 279 | GH#18938 | proximity guard firing at 272/274 (2 headroom); 272 violations + 7 headroom = 279; proximity guard (warn_at = 279-5 = 274) fires when violations exceed 274 (i.e., at 275), preventing saturation |
 
 ## FUNCTION_COMPLEXITY_THRESHOLD History
 

--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -92,7 +92,9 @@ FUNCTION_COMPLEXITY_THRESHOLD=26
 # Bumped to 279 (GH#18912): violations at threshold 272/272 (0 headroom); 272 violations + 7 headroom = 279.
 # Proximity guard (warn_at = 279-5 = 274) fires when violations exceed 274 (i.e., at 275), preventing saturation.
 # Ratcheted down to 274 (GH#18928): actual violations 272 + 2 buffer
-NESTING_DEPTH_THRESHOLD=274
+# Bumped to 279 (GH#18938): proximity guard firing at 272/274 (2 headroom); 272 violations + 7 headroom = 279.
+# Proximity guard (warn_at = 279-5 = 274) fires when violations exceed 274 (i.e., at 275), preventing saturation.
+NESTING_DEPTH_THRESHOLD=279
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Bump `NESTING_DEPTH_THRESHOLD` from 274 to 279 to restore headroom after proximity guard fired at 272/274 (2 headroom remaining).

## What

- `NESTING_DEPTH_THRESHOLD`: 274 → 279 in `.agents/configs/complexity-thresholds.conf`
- Added GH#18928 ratchet entry and GH#18938 bump entry to `.agents/configs/complexity-thresholds-history.md`

## Why

The proximity guard in `pulse-simplification.sh` fires when violations exceed `threshold - 5`. With threshold=274 and violations=272:
- `warn_at = 274 - 5 = 269`
- `272 > 269` → guard fires → issue #18938 created

With threshold=279:
- `warn_at = 279 - 5 = 274`
- `272 ≤ 274` → guard does NOT fire
- Headroom: 7 (before guard fires at 275+)

## Pattern

Follows the established ratchet pattern (documented in history file). The threshold was just ratcheted from 279→274 in GH#18928 (actual violations 272 + 2 buffer). This bump restores the +7 headroom buffer that allows in-flight PRs to land without triggering CI failures.

## Verification

- `grep NESTING_DEPTH_THRESHOLD .agents/configs/complexity-thresholds.conf` → 279
- CI "Shell nesting depth" check: 272 violations < 279 threshold → PASS

Resolves #18938

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated code complexity threshold configuration to align with codebase standards.
  * Increased nesting depth limit in CI quality gates to accommodate current code structure.
  * Updated audit trail documentation to track configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->