### PR TITLE
GH#18943: chore: ratchet-down NESTING_DEPTH_THRESHOLD 279→274

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -94,7 +94,8 @@ FUNCTION_COMPLEXITY_THRESHOLD=26
 # Ratcheted down to 274 (GH#18928): actual violations 272 + 2 buffer
 # Bumped to 279 (GH#18938): proximity guard firing at 272/274 (2 headroom); 272 violations + 7 headroom = 279.
 # Proximity guard (warn_at = 279-5 = 274) fires when violations exceed 274 (i.e., at 275), preventing saturation.
-NESTING_DEPTH_THRESHOLD=279
+# Ratcheted down to 274 (GH#18943): actual violations 272 + 2 buffer
+NESTING_DEPTH_THRESHOLD=274
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Lowers `NESTING_DEPTH_THRESHOLD` from 279 to 274 as simplification wins have accumulated.

- Actual nesting violations: 272
- New threshold: 272 + 2 buffer = **274**
- Added ratchet-down audit comment to `.agents/configs/complexity-thresholds.conf`

## Verification

```
[complexity-scan] INFO: Actual violations — func:23 nest:272 size:57 bash32:71
[complexity-scan] INFO: Current thresholds — func:26 nest:274 size:59 bash32:72
[complexity-scan] INFO: No ratchet-down available: all thresholds within gap of 5
```

CI will pass: 272 violations < 274 threshold. `simplification-state.json` not staged (per issue guidance).

Resolves #18943

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality gate thresholds to maintain development standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->