### PR TITLE
GH#18945: chore: ratchet-down NESTING_DEPTH_THRESHOLD 279→274

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -94,7 +94,8 @@ FUNCTION_COMPLEXITY_THRESHOLD=26
 # Ratcheted down to 274 (GH#18928): actual violations 272 + 2 buffer
 # Bumped to 279 (GH#18938): proximity guard firing at 272/274 (2 headroom); 272 violations + 7 headroom = 279.
 # Proximity guard (warn_at = 279-5 = 274) fires when violations exceed 274 (i.e., at 275), preventing saturation.
-NESTING_DEPTH_THRESHOLD=279
+# Ratcheted down to 274 (GH#18945): actual violations 272 + 2 buffer
+NESTING_DEPTH_THRESHOLD=274
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Ratcheted down `NESTING_DEPTH_THRESHOLD` from 279 to 274.

- Actual violations: 272
- New threshold: 272 + 2 buffer = 274
- Added ratchet-down history comment per established convention

## Verification

```
grep NESTING_DEPTH_THRESHOLD .agents/configs/complexity-thresholds.conf
# → NESTING_DEPTH_THRESHOLD=274
```

- Only `.agents/configs/complexity-thresholds.conf` modified
- `simplification-state.json` NOT staged (per worker guidance)

Resolves #18945