### PR TITLE
t2086: fix(post-merge-review-scanner): add NOOP_RE deny-list to suppress Gemini LGTM reviews

### DIFF
--- a/.agents/scripts/post-merge-review-scanner.sh
+++ b/.agents/scripts/post-merge-review-scanner.sh
@@ -110,7 +110,7 @@ ACT_RE="should|consider|fix|change|update|refactor|missing|add"
 # fetch_review_summaries_md BEFORE the ACT_RE check. The phrases are specific
 # enough that false positives (a real review that also contains "no feedback to
 # provide" in a sub-clause) are rare in practice.
-NOOP_RE="I have no feedback to provide|no feedback to provide|have no feedback|have no suggestions|no actionable feedback|no actionable suggestions|no further feedback|no issues to report|no suggestions to (add|provide|make)"
+NOOP_RE="(I have no feedback to provide|no feedback to provide|have no feedback|have no suggestions|no actionable feedback|no actionable suggestions|no further feedback|no issues to report|no suggestions to (add|provide|make))[[:space:][:punct:]]*$"
 
 log() { echo "[scanner] $*" >&2; }
 

--- a/.agents/scripts/post-merge-review-scanner.sh
+++ b/.agents/scripts/post-merge-review-scanner.sh
@@ -101,6 +101,16 @@ BOT_RE="coderabbitai|gemini-code-assist|claude-review|gpt-review"
 # comments the thread-resolution filter is the canonical signal — every
 # unresolved review thread is by definition a finding worth surfacing.
 ACT_RE="should|consider|fix|change|update|refactor|missing|add"
+# NOOP_RE matches review bodies that are LGTM/no-feedback statements even when
+# they incidentally contain ACT_RE keywords. The canonical false-positive pattern
+# (awardsapp/awardsapp#2349, Gemini on PR #2308): bot writes a PR description
+# containing "refactors" (matches ACT_RE "refactor"), then concludes with "I have
+# no feedback to provide." — the entire body is a description + LGTM, not an
+# actionable suggestion. NOOP_RE is applied as a deny-list in
+# fetch_review_summaries_md BEFORE the ACT_RE check. The phrases are specific
+# enough that false positives (a real review that also contains "no feedback to
+# provide" in a sub-clause) are rare in practice.
+NOOP_RE="I have no feedback to provide|no feedback to provide|have no feedback|have no suggestions|no actionable feedback|no actionable suggestions|no further feedback|no issues to report|no suggestions to (add|provide|make)"
 
 log() { echo "[scanner] $*" >&2; }
 
@@ -269,6 +279,11 @@ fetch_inline_comments_md() {
 #     findings — the per-thread findings themselves appear via
 #     fetch_inline_comments_md. Including the summary duplicates content
 #     and adds <details> wrapper noise.
+#   - Body must NOT match NOOP_RE (deny-list of no-feedback terminal phrases).
+#     Applied before ACT_RE to catch Gemini's "PR description + I have no
+#     feedback to provide." pattern, where the description accidentally
+#     contains ACT_RE keywords (e.g. "refactors") even though the review
+#     is a LGTM. See awardsapp/awardsapp#2349 for the canonical false-positive.
 #   - Body must contain at least one ACT_RE keyword (cheap noise filter
 #     against "LGTM"/"Reviewed" acks).
 #
@@ -286,6 +301,7 @@ fetch_review_summaries_md() {
 	local out
 	out=$(printf '%s' "$resp" | jq -r \
 		--arg bots "$BOT_RE" \
+		--arg noop "$NOOP_RE" \
 		--arg acts "$ACT_RE" \
 		--argjson cap "$SCANNER_MAX_COMMENTS" '
 			[.[]?
@@ -296,6 +312,11 @@ fetch_review_summaries_md() {
 				# per-thread findings and pollute the issue body with
 				# boilerplate <details> wrappers.
 				| select(((.body // "")) | test("^\\*\\*Actionable comments posted:|^Actionable comments posted:"; "i") | not)
+				# Drop LGTM/no-feedback reviews even when they incidentally
+				# contain ACT_RE keywords (e.g. Gemini "refactors X. I have
+				# no feedback to provide." — "refactors" matches ACT_RE but
+				# the review is a description + LGTM, not a suggestion).
+				| select(((.body // "")) | test($noop; "i") | not)
 				# Keep only bodies containing at least one actionable keyword
 				| select(((.body // "")) | test($acts; "i"))
 			]


### PR DESCRIPTION
## Problem

`fetch_review_summaries_md` was creating review-followup issues for PRs where Gemini posted a LGTM/no-feedback review. The canonical case (<webapp>/<webapp>#2349, Gemini on PR #2308):

> "This pull request **refactors** the security header application… I have no feedback to provide."

The word "refactors" substring-matches `refactor` in `ACT_RE`, so the review passed the actionability filter and a follow-up issue was created with no real findings. A worker cycle was burned to close it as "Premise falsified."

## Root cause

`ACT_RE` matches code-related verbs anywhere in a review body. Gemini routinely writes a PR description (which naturally uses those verbs) and then appends "I have no feedback to provide." There was no way for the old filter to distinguish _describing what the PR does_ from _suggesting a change_.

## Fix

Add `NOOP_RE` — a deny-list of no-feedback terminal phrases — and apply it in `fetch_review_summaries_md` **before** the `ACT_RE` check. If a review body matches `NOOP_RE`, it is excluded regardless of ACT_RE hits.

```
NOOP_RE="I have no feedback to provide|no feedback to provide|have no feedback|have no suggestions|no actionable feedback|no actionable suggestions|no further feedback|no issues to report|no suggestions to (add|provide|make)"
```

## Files changed

- EDIT: `.agents/scripts/post-merge-review-scanner.sh` — add `NOOP_RE` constant (~line 103) and apply it in `fetch_review_summaries_md` jq filter chain

## Verification

Smoke test against the exact Gemini body from PR #2308:

```
Old pipeline (ACT_RE only):      PASSES filter — would create issue
New pipeline (NOOP_RE + ACT_RE): blocked by NOOP_RE — no issue created
```
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.24 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 6m and 17,376 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced review filtering to exclude non-actionable feedback comments while preserving detection of actionable items, delivering more accurate and focused review summaries for post-merge analysis workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->