### PR TITLE
t2088: exempt parent-task/meta issues from large-file simplification gate

### DIFF
--- a/.agents/scripts/pulse-dispatch-large-file-gate.sh
+++ b/.agents/scripts/pulse-dispatch-large-file-gate.sh
@@ -65,6 +65,30 @@ _large_file_gate_precheck_labels() {
 		return 1
 	fi
 
+	# t2088: Never gate parent-task / meta issues behind the large-file gate.
+	# Parent tasks are never dispatched directly — dispatch is unconditionally
+	# blocked by _is_assigned_check_parent_task() in dispatch-dedup-helper.sh
+	# (t1986). Applying needs-simplification to them creates confusing label
+	# churn: the label is re-added every cycle even after manual removal because
+	# the target file is still large, misleading maintainers into thinking
+	# simplification is the only remaining gate when in fact the parent-task
+	# block is permanent and independent of file size.
+	# If the label was already applied (e.g., before this fix), auto-clear it.
+	if [[ ",$issue_labels," == *",parent-task,"* ]] ||
+		[[ ",$issue_labels," == *",meta,"* ]]; then
+		if [[ ",$issue_labels," == *",needs-simplification,"* ]]; then
+			if gh issue edit "$issue_number" --repo "$repo_slug" \
+				--remove-label "needs-simplification" >/dev/null 2>&1; then
+				echo "[pulse-wrapper] Simplification gate auto-cleared for #${issue_number} (${repo_slug}) — issue is a parent-task/meta, never dispatched directly (t2088)" >>"$LOGFILE"
+			else
+				echo "[pulse-wrapper] WARN: failed to remove needs-simplification label from #${issue_number} (${repo_slug}); will retry next cycle (t2088)" >>"$LOGFILE"
+			fi
+		fi
+		# Always return 1 (don't gate) — parent tasks are never dispatched
+		# directly, regardless of whether the label removal succeeded.
+		return 1
+	fi
+
 	# Skip if already labeled (avoid re-checking every cycle).
 	# EXCEPTION (t1998): when called from _reevaluate_simplification_labels,
 	# force_recheck is "true" and we bypass this short-circuit. Without the


### PR DESCRIPTION
## Summary

- The large-file gate (`_large_file_gate_precheck_labels`) was re-adding `needs-simplification` to `parent-task`/`meta` issues every pulse cycle, even after manual removal, because the target file remained above the 2000-line threshold
- `parent-task` issues are unconditionally blocked from dispatch by `_is_assigned_check_parent_task()` (t1986) regardless of `needs-simplification` — the gate was pure noise
- Adds the same exemption pattern already used for `simplification-debt` issues (GH#18042): short-circuit on `parent-task`/`meta` label + auto-clear any stale label already present

## Root Cause

`_large_file_gate_precheck_labels()` had no `parent-task` exemption. On each pulse cycle:
1. `needs-simplification` removed manually → gate re-runs → file still large → label re-added
2. Misleading "Held from dispatch" comment implied simplification was the only remaining gate
3. Actual blocker (`parent-task`) is permanent and independent of file size

## Test

`shellcheck .agents/scripts/pulse-dispatch-large-file-gate.sh` — zero new violations (pre-existing SC2016 info notices on regex patterns are unrelated to this change).

Next pulse cycle on GH#18735: `needs-simplification` will be auto-cleared and not re-added.

Fixes #18951
For #18735


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.24 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 5m and 16,966 tokens on this as a headless worker.
