### PR TITLE
GH#18949: chore: ratchet-down complexity thresholds (GH#18949)

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -94,7 +94,8 @@ FUNCTION_COMPLEXITY_THRESHOLD=26
 # Ratcheted down to 274 (GH#18928): actual violations 272 + 2 buffer
 # Bumped to 279 (GH#18938): proximity guard firing at 272/274 (2 headroom); 272 violations + 7 headroom = 279.
 # Proximity guard (warn_at = 279-5 = 274) fires when violations exceed 274 (i.e., at 275), preventing saturation.
-NESTING_DEPTH_THRESHOLD=279
+# Ratcheted down to 275 (GH#18949): actual violations 273 + 2 buffer
+NESTING_DEPTH_THRESHOLD=275
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Lowered NESTING_DEPTH_THRESHOLD from 279 to 275 in .agents/configs/complexity-thresholds.conf. Actual violations are 273; new threshold is 273 + 2 buffer = 275. Added ratchet-down comment documenting the change with GH#18949 reference. simplification-state.json was not staged.

## Files Changed

.agents/configs/complexity-thresholds.conf

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified: grep NESTING_DEPTH_THRESHOLD shows 275. git diff --cached --name-only confirms only complexity-thresholds.conf staged. simplification-state.json not modified.

Resolves #18949


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.24 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 59s and 2,237 tokens on this as a headless worker.