### PR TITLE
t2095: add claude-sonnet-4-5 and claude-opus-4-5 to claudecli proxy model list

### DIFF
--- a/.agents/plugins/opencode-aidevops/claude-proxy-context.mjs
+++ b/.agents/plugins/opencode-aidevops/claude-proxy-context.mjs
@@ -272,9 +272,11 @@ export function parseChatMessages(messages) {
 // ---------------------------------------------------------------------------
 
 const MODEL_ALIASES = new Map([
-  ["haiku", "claude-haiku-4-5"],
-  ["sonnet", "claude-sonnet-4-6"],
-  ["opus", "claude-opus-4-6"],
+  ["haiku",    "claude-haiku-4-5"],
+  ["sonnet45", "claude-sonnet-4-5"],
+  ["sonnet",   "claude-sonnet-4-6"],
+  ["opus45",   "claude-opus-4-5"],
+  ["opus",     "claude-opus-4-6"],
 ]);
 
 /**

--- a/.agents/plugins/opencode-aidevops/claude-proxy.mjs
+++ b/.agents/plugins/opencode-aidevops/claude-proxy.mjs
@@ -84,10 +84,24 @@ function getClaudeProxyModels() {
       maxTokens: 32000,
     },
     {
+      id: "claude-sonnet-4-5",
+      name: "Claude Sonnet 4.5 (via Claude CLI)",
+      reasoning: true,
+      contextWindow: 200000,
+      maxTokens: 64000,
+    },
+    {
       id: "claude-sonnet-4-6",
       name: "Claude Sonnet 4.6 (via Claude CLI)",
       reasoning: true,
       contextWindow: 1000000,
+      maxTokens: 64000,
+    },
+    {
+      id: "claude-opus-4-5",
+      name: "Claude Opus 4.5 (via Claude CLI)",
+      reasoning: true,
+      contextWindow: 200000,
       maxTokens: 64000,
     },
     {

--- a/.agents/plugins/opencode-aidevops/config-hook.mjs
+++ b/.agents/plugins/opencode-aidevops/config-hook.mjs
@@ -38,7 +38,9 @@ function claudeModelDef(overrides) {
  */
 const CLAUDE_MODEL_LIMITS = {
   "claude-haiku-4-5":  { context: 1000000, output: 32000 },
+  "claude-sonnet-4-5": { context:  200000, output: 64000 },
   "claude-sonnet-4-6": { context: 1000000, output: 64000 },
+  "claude-opus-4-5":   { context:  200000, output: 64000 },
   "claude-opus-4-6":   { context: 1000000, output: 64000 },
 };
 
@@ -60,14 +62,18 @@ function buildClaudeModelMap(names) {
 /** Models registered under the built-in anthropic provider (via aidevops OAuth pool). */
 const ANTHROPIC_MODELS = buildClaudeModelMap({
   "claude-haiku-4-5":  "Claude Haiku 4.5 (via aidevops)",
+  "claude-sonnet-4-5": "Claude Sonnet 4.5 (via aidevops)",
   "claude-sonnet-4-6": "Claude Sonnet 4.6 (via aidevops)",
+  "claude-opus-4-5":   "Claude Opus 4.5 (via aidevops)",
   "claude-opus-4-6":   "Claude Opus 4.6 (via aidevops)",
 });
 
 /** Models registered under the claudecli provider (via Claude CLI proxy). */
 const CLAUDECLI_MODELS = buildClaudeModelMap({
   "claude-haiku-4-5":  "Claude Haiku 4.5 (via CLI)",
+  "claude-sonnet-4-5": "Claude Sonnet 4.5 (via CLI)",
   "claude-sonnet-4-6": "Claude Sonnet 4.6 (via CLI)",
+  "claude-opus-4-5":   "Claude Opus 4.5 (via CLI)",
   "claude-opus-4-6":   "Claude Opus 4.6 (via CLI)",
 });
 


### PR DESCRIPTION
## Problem

The \`claudecli\` provider in the opencode \`/models\` selector only showed 3 hardcoded models (haiku-4-5, sonnet-4-6, opus-4-6). The opencode anthropic models cache (\`~/.cache/opencode/models.json\`) contains additional current Claude 4.x models — specifically \`claude-sonnet-4-5\` and \`claude-opus-4-5\` — that the Claude CLI supports but that were absent from the claudecli provider, making them invisible to users wanting to use those model versions via the CLI proxy.

The t2070 refactor (same day) did not cause this — the list was always 3 models. The cache was updated by opencode with new model entries that we weren't mirroring.

## Changes

- **\`claude-proxy.mjs\`** — \`getClaudeProxyModels()\`: add sonnet-4-5 (200K/64K) and opus-4-5 (200K/64K)
- **\`config-hook.mjs\`** — \`CLAUDE_MODEL_LIMITS\`, \`ANTHROPIC_MODELS\`, \`CLAUDECLI_MODELS\`: add the same two models so the config-hook registration path stays in sync
- **\`claude-proxy-context.mjs\`** — \`MODEL_ALIASES\`: add \`sonnet45 → claude-sonnet-4-5\` and \`opus45 → claude-opus-4-5\` short aliases for the \`claudecli/agent/model\` routing key

## Verification

Restart opencode and check \`/models\` — the claudecli provider should now show 5 models (haiku-4-5, sonnet-4-5, sonnet-4-6, opus-4-5, opus-4-6). The proxy \`/v1/models\` endpoint on port 32125 also returns the expanded list immediately after deploy without restart.

\`\`\`
curl -s http://127.0.0.1:32125/v1/models | python3 -m json.tool
\`\`\`


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.27 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 19m and 53,747 tokens on this with the user in an interactive session.