### PR TITLE
GH#18960: fix(t2090): dedup recently-closed simplification-debt issues before re-filing

### DIFF
--- a/.agents/scripts/pulse-dispatch-large-file-gate.sh
+++ b/.agents/scripts/pulse-dispatch-large-file-gate.sh
@@ -284,6 +284,26 @@ _large_file_gate_create_debt_issue() {
 		return 0
 	fi
 
+	# Check recently-closed simplification-debt issues for this file (GH#18960)
+	# If a partial-simplification PR merged and closed the debt issue recently,
+	# return a reference to it instead of re-filing an identical issue.
+	# Configurable via LFG_DEBT_REOPEN_DAYS (default 30).
+	local _reopen_days="${LFG_DEBT_REOPEN_DAYS:-30}"
+	local _recent_date
+	_recent_date=$(date -u "-v-${_reopen_days}d" "+%Y-%m-%d" 2>/dev/null ||
+		date -u -d "${_reopen_days} days ago" "+%Y-%m-%d" 2>/dev/null || true)
+	if [[ -n "$_recent_date" ]]; then
+		_existing=$(gh issue list --repo "$repo_slug" \
+			--state closed --label "simplification-debt" \
+			--search "$_lf_basename closed:>$_recent_date" \
+			--json number --jq '.[0].number // empty' \
+			--limit 5 2>/dev/null) || _existing=""
+	fi
+	if [[ -n "$_existing" ]]; then
+		printf '#%s (recently-closed — continuation)' "$_existing"
+		return 0
+	fi
+
 	# GH#18644: ensure the `simplification-debt` label exists before the
 	# create call. Without this, a first-use of the gate in any repo that
 	# doesn't already have the label fails with "could not add label:


### PR DESCRIPTION
## Summary

Added recently-closed issue dedup check in _large_file_gate_create_debt_issue(). After the existing open-issue check, the function now also checks for closed simplification-debt issues within the past LFG_DEBT_REOPEN_DAYS (default 30) days. If found, it returns the existing reference instead of creating a new identical issue.

## Files Changed

.agents/scripts/pulse-dispatch-large-file-gate.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck --severity=warning passes zero violations on modified file. Logic: open-issue check → recently-closed check (configurable window) → create new issue.

Resolves #18960


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.28 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 2m and 7,086 tokens on this as a headless worker.