### PR TITLE
t2096: add linked-issue-check workflow — require issue ref on every PR

### DIFF
--- a/.github/workflows/linked-issue-check.yml
+++ b/.github/workflows/linked-issue-check.yml
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Linked Issue Check
+#
+# Requires every PR to reference a linked issue before it can be merged.
+# Accepts closing keywords (Closes, Fixes, Resolves) and reference keywords
+# (For, Ref) to support parent-task PRs that must not auto-close their issue.
+#
+# Exemptions:
+# - Bot accounts (github-actions[bot], dependabot[bot], etc.)
+# - PRs with a task-ID prefix in the title (tNNN: or GH#NNN:) — these are
+#   already linked to issues via the task system and the maintainer gate's
+#   title-based lookup.
+#
+# This check is intentionally separate from maintainer-gate.yml (which checks
+# the *status* of linked issues). This check is earlier — it gates on whether
+# a link exists at all, regardless of issue status.
+#
+# Required status check: add "linked-issue-check" to branch protection rules.
+
+name: Linked Issue Check
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+permissions:
+  pull-requests: read
+  statuses: write
+
+jobs:
+  check:
+    name: Linked Issue Check
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    concurrency:
+      group: linked-issue-check-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
+
+    steps:
+      - name: Check for linked issue reference
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const body = pr.body || '';
+            const title = pr.title || '';
+            const headSha = pr.head.sha;
+            const repo = context.repo;
+
+            // Bot accounts are exempt
+            if (pr.user.type === 'Bot') {
+              console.log(`Author ${pr.user.login} is a bot — exempt from linked-issue check`);
+              await github.rest.repos.createCommitStatus({
+                owner: repo.owner,
+                repo: repo.repo,
+                sha: headSha,
+                state: 'success',
+                context: 'linked-issue-check',
+                description: 'Bot PR — exempt from linked-issue requirement'
+              });
+              return;
+            }
+
+            // PRs with task-ID prefix are exempt (tNNN: or GH#NNN:)
+            // These are already tracked via the task system / maintainer-gate title lookup
+            if (/^(t\d+(\.\d+)*|GH#\d+)[:\s]/.test(title)) {
+              console.log(`PR "${title}" has task-ID prefix — exempt from linked-issue check`);
+              await github.rest.repos.createCommitStatus({
+                owner: repo.owner,
+                repo: repo.repo,
+                sha: headSha,
+                state: 'success',
+                context: 'linked-issue-check',
+                description: 'Task-ID prefix detected — issue linkage via task system'
+              });
+              return;
+            }
+
+            // Check PR body for issue references (closing and reference keywords)
+            // Closing: Closes, Fixes, Resolves (also plural/past forms)
+            // Reference: For, Ref (for parent-task PRs)
+            const issueRefPattern = /(closes?|fixes?|resolves?|for|ref)[:\s]+#\d+/i;
+            const hasLinkedIssue = issueRefPattern.test(body);
+
+            if (hasLinkedIssue) {
+              const match = body.match(/(closes?|fixes?|resolves?|for|ref)[:\s]+#(\d+)/i);
+              const issueNum = match ? match[2] : 'unknown';
+              console.log(`Found linked issue reference — #${issueNum}`);
+              await github.rest.repos.createCommitStatus({
+                owner: repo.owner,
+                repo: repo.repo,
+                sha: headSha,
+                state: 'success',
+                context: 'linked-issue-check',
+                description: `Linked issue found — #${issueNum}`
+              });
+              return;
+            }
+
+            // No linked issue found — block
+            console.log(`No linked issue reference found in PR body`);
+            await github.rest.repos.createCommitStatus({
+              owner: repo.owner,
+              repo: repo.repo,
+              sha: headSha,
+              state: 'failure',
+              context: 'linked-issue-check',
+              description: 'No linked issue — add Closes/Fixes/Resolves/For #NNN to PR body'
+            });
+
+            core.setFailed(
+              'PR body must reference a linked issue.\n' +
+              'Add one of: `Closes #NNN`, `Fixes #NNN`, `Resolves #NNN`, `For #NNN`, or `Ref #NNN`\n' +
+              'If no issue exists for this change, please create one first.'
+            );


### PR DESCRIPTION
## Summary

Two changes:

1. **Linked issue check workflow** — Adds `.github/workflows/linked-issue-check.yml` that fails any PR which does not reference a linked issue in its body.

2. **Restore pool_ops_token_utils.py** — Restores the missing module from the t2069 decomposition (#18891) with three bug fixes from PR #18846 review:
   - `cmd_extract_token_fields`: try/except to always emit 3 lines (shell caller expects exactly 3)
   - `cursor-decode-jwt`: fix base64 padding formula `(4 - len % 4)` → `((-len) % 4)`
   - `google-validate`: validate HEALTH_URL scheme/hostname before sending bearer token
   - `.gitignore`: add exception for the file (blanket `*token*` was silently blocking it)

## Linked Issue Check

The maintainer gate at `maintainer-gate.yml:204` explicitly passes PRs with no linked issues. The pr-triage-gate posts a comment but doesn't enforce. This workflow adds mechanical enforcement.

- Accepts: `Closes/Fixes/Resolves/For/Ref #NNN` in PR body
- Exempts: bot PRs, PRs with `tNNN:` or `GH#NNN:` title prefix
- Posts `linked-issue-check` commit status for branch protection

### Activation

After merge, add `linked-issue-check` as a required status check in branch protection.

## pool_ops_token_utils.py

Locally tested on macOS:
- `oauth-pool-helper.sh status` — clean, no `ModuleNotFoundError`
- `oauth-pool-helper.sh check anthropic` — all accounts healthy
- `extract-token-fields` with bad JSON — graceful fallback (3 default lines)
- JWT padding with all mod-4 residues — all decode correctly
- `google-validate` with non-googleapis URL — returns `INVALID_URL`

Resolves #18970