### PR TITLE
GH#18964: t2093: route review feedback from stuck worker PRs

### DIFF
--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -38,10 +38,12 @@
 #   - _extract_linked_issue
 #   - _extract_merge_summary
 #   - _close_conflicting_pr
+#   - _build_review_feedback_section           (t2093)
+#   - _dispatch_pr_fix_worker                   (t2093)
 #
-# This is a pure move from pulse-wrapper.sh. The function bodies are
-# byte-identical to their pre-extraction form. Any change must go in a
-# separate follow-up PR after the full decomposition (Phase 12) lands.
+# This was originally a pure move from pulse-wrapper.sh. Later additions
+# (rebase nudges GH#18650/GH#18815, review-feedback routing t2093) live
+# here because they share the _process_single_ready_pr call site.
 
 # Include guard — prevent double-sourcing.
 [[ -n "${_PULSE_MERGE_LOADED:-}" ]] && return 0
@@ -654,8 +656,28 @@ _check_pr_merge_gates() {
 	local pr_review="$4"
 	local linked_issue="$5"
 
-	# Skip CHANGES_REQUESTED — needs a fix worker, not a merge
+	# Skip CHANGES_REQUESTED — needs a fix worker, not a merge.
+	#
+	# t2093: For worker-authored PRs with a linked issue, the "skip and hope"
+	# path leaks stuck PRs indefinitely — no human owns worker PRs, the
+	# dispatch-dedup guard blocks re-dispatch while the PR is open, and the
+	# review-followup pipeline only fires on *merged* PRs. Route the review
+	# feedback to the linked issue body and close the PR so the next pulse
+	# cycle picks the issue up with fresh context. Interactive PRs are
+	# always left alone (their humans own the feedback loop); external
+	# contributors go through their own crypto-approval flow.
 	if [[ "$pr_review" == "CHANGES_REQUESTED" ]]; then
+		if [[ -n "$linked_issue" ]]; then
+			local _cr_pr_labels
+			_cr_pr_labels=$(gh pr view "$pr_number" --repo "$repo_slug" \
+				--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || _cr_pr_labels=""
+			if [[ ",${_cr_pr_labels}," == *",origin:worker,"* &&
+				",${_cr_pr_labels}," != *",origin:interactive,"* &&
+				",${_cr_pr_labels}," != *",external-contributor,"* &&
+				",${_cr_pr_labels}," != *",review-routed-to-issue,"* ]]; then
+				_dispatch_pr_fix_worker "$pr_number" "$repo_slug" "$linked_issue" || true
+			fi
+		fi
 		echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — reviewDecision=CHANGES_REQUESTED" >>"$LOGFILE"
 		return 1
 	fi
@@ -1351,5 +1373,242 @@ _Closed by deterministic merge pass (pulse-wrapper.sh)._" 2>/dev/null || true
 
 		echo "[pulse-wrapper] Deterministic merge: closed conflicting PR #${pr_number} in ${repo_slug}: ${pr_title}" >>"$LOGFILE"
 	fi
+	return 0
+}
+
+#######################################
+# Build the markdown "Review Feedback" section for routing to a linked
+# issue (t2093).
+#
+# Reads already-fetched review + inline-comment JSON arrays and produces a
+# human-readable section with file:line citations. The section is scoped
+# to a single closing PR so the marker in `_dispatch_pr_fix_worker` can
+# prevent duplicate appends if the merge pass re-encounters the same PR
+# before the close propagates.
+#
+# Args:
+#   $1 - pr_number
+#   $2 - repo_slug
+#   $3 - reviews_json    (JSON array of {author,state,body,url})
+#   $4 - inline_json     (JSON array of {author,path,line,body,url})
+#
+# Output: markdown section on stdout (empty string if no content).
+#######################################
+_build_review_feedback_section() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local reviews_json="${3:-[]}"
+	local inline_json="${4:-[]}"
+
+	local reviews_count inline_count
+	reviews_count=$(printf '%s' "$reviews_json" | jq 'length' 2>/dev/null) || reviews_count=0
+	inline_count=$(printf '%s' "$inline_json" | jq 'length' 2>/dev/null) || inline_count=0
+	[[ "$reviews_count" =~ ^[0-9]+$ ]] || reviews_count=0
+	[[ "$inline_count" =~ ^[0-9]+$ ]] || inline_count=0
+
+	if [[ "$reviews_count" -eq 0 && "$inline_count" -eq 0 ]]; then
+		return 0
+	fi
+
+	local header
+	header="## Review Feedback routed from PR #${pr_number} (t2093)
+
+This section was auto-generated when the deterministic merge pass detected
+\`reviewDecision=CHANGES_REQUESTED\` on the linked worker PR. The PR has been
+closed and this issue re-entered the dispatch queue. The next worker should
+address the findings below and open a fresh PR against this issue.
+
+See the original PR for full context: https://github.com/${repo_slug}/pull/${pr_number}
+"
+
+	local reviews_md=""
+	if [[ "$reviews_count" -gt 0 ]]; then
+		reviews_md=$(printf '%s' "$reviews_json" | jq -r '
+			.[] | "- **@\(.author)** (`\(.state)`): \(((.body // "") | gsub("\r"; "") | split("\n")[0])[0:300])\n  [view review](\(.url // ""))"
+		' 2>/dev/null) || reviews_md=""
+	fi
+
+	local inline_md=""
+	if [[ "$inline_count" -gt 0 ]]; then
+		inline_md=$(printf '%s' "$inline_json" | jq -r '
+			.[] | "- **@\(.author)** `\(.path)`:\(.line // "?") — \(((.body // "") | gsub("\r"; "") | split("\n")[0])[0:300])\n  [view comment](\(.url // ""))"
+		' 2>/dev/null) || inline_md=""
+	fi
+
+	printf '%s\n' "$header"
+	if [[ -n "$reviews_md" ]]; then
+		printf '### Top-level reviews\n\n%s\n\n' "$reviews_md"
+	fi
+	if [[ -n "$inline_md" ]]; then
+		printf '### Inline comments (file:line citations)\n\n%s\n\n' "$inline_md"
+	fi
+	return 0
+}
+
+#######################################
+# Route review feedback from a stuck worker PR to its linked issue and
+# close the PR so the dispatch queue can re-pick the task (t2093).
+#
+# Called by `_check_pr_merge_gates` when `reviewDecision=CHANGES_REQUESTED`
+# on a worker-authored PR with a linked issue. Before this helper existed,
+# such PRs accumulated indefinitely: the merge pass skipped them (correctly,
+# since they can't pass the review gate as-is), but nothing dispatched a
+# fresh worker to address the feedback. The PR author is the headless
+# worker account, so no human was notified; the review-followup pipeline
+# only fires on *merged* PRs; and the dispatch-dedup guard treated the
+# open PR as an active claim on the linked issue.
+#
+# This function closes that loop:
+#   1. Fetches bot reviews + inline comments from the stuck PR.
+#   2. Appends a "Review Feedback" section to the linked issue body
+#      (marker-guarded so re-runs are idempotent).
+#   3. Transitions the linked issue to `status:available` and tags it
+#      `source:review-feedback` so the next dispatch cycle picks it up
+#      with the feedback in the prompt.
+#   4. Closes the stuck PR with an explanatory comment and tags it
+#      `review-routed-to-issue` as a belt-and-suspenders idempotency flag.
+#
+# Interactive PRs and external-contributor PRs are filtered out by the
+# caller (`_check_pr_merge_gates`) — they have their own review flows.
+#
+# Fail-open: any API failure is logged and swallowed. The merge pass must
+# continue processing other PRs.
+#
+# Reference patterns:
+#   - `quality-feedback-helper.sh` — bot review comment extraction
+#   - `_close_conflicting_pr`      — close-with-comment boilerplate
+#   - `draft-response-helper.sh`   — issue body append pattern
+#
+# Args:
+#   $1 - pr_number
+#   $2 - repo_slug  (owner/repo)
+#   $3 - linked_issue  (the issue the PR resolves/fixes/closes)
+#######################################
+_dispatch_pr_fix_worker() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local linked_issue="$3"
+
+	[[ "$pr_number" =~ ^[0-9]+$ ]] || return 0
+	[[ -n "$repo_slug" ]] || return 0
+	[[ "$linked_issue" =~ ^[0-9]+$ ]] || return 0
+
+	# Ensure the idempotency + origin labels exist on the repo (idempotent,
+	# --force, swallowed failures). quality-feedback-helper.sh also creates
+	# source:review-feedback — redundant creation is harmless.
+	gh label create "review-routed-to-issue" --repo "$repo_slug" --color "D93F0B" \
+		--description "Worker PR with CHANGES_REQUESTED routed to linked issue for re-dispatch (t2093)" \
+		--force >/dev/null 2>&1 || true
+	gh label create "source:review-feedback" --repo "$repo_slug" --color "C2E0C6" \
+		--description "Issue carries review feedback routed from a closed worker PR" \
+		--force >/dev/null 2>&1 || true
+
+	# --- Fetch bot/human reviews (substantive: CHANGES_REQUESTED or long body) ---
+	local reviews_json
+	reviews_json=$(gh api "repos/${repo_slug}/pulls/${pr_number}/reviews" \
+		--paginate \
+		--jq '[.[] | select(.state == "CHANGES_REQUESTED" or ((.body // "") | length) > 30)
+			| {author: (.user.login // "unknown"), state: .state,
+			   body: (.body // ""), url: (.html_url // "")}]' \
+		2>/dev/null) || reviews_json="[]"
+	[[ -n "$reviews_json" ]] || reviews_json="[]"
+
+	# --- Fetch inline review comments (file:line citations) ---
+	local inline_json
+	inline_json=$(gh api "repos/${repo_slug}/pulls/${pr_number}/comments" \
+		--paginate \
+		--jq '[.[] | {author: (.user.login // "unknown"),
+			path: (.path // ""),
+			line: (.line // .original_line // 0),
+			body: (.body // ""), url: (.html_url // "")}]' \
+		2>/dev/null) || inline_json="[]"
+	[[ -n "$inline_json" ]] || inline_json="[]"
+
+	# --- Build the Review Feedback markdown section ---
+	local feedback_section
+	feedback_section=$(_build_review_feedback_section \
+		"$pr_number" "$repo_slug" "$reviews_json" "$inline_json") || feedback_section=""
+	if [[ -z "$feedback_section" ]]; then
+		echo "[pulse-wrapper] _dispatch_pr_fix_worker: PR #${pr_number} in ${repo_slug} has CHANGES_REQUESTED but no substantive review content — leaving PR open without routing (t2093)" >>"$LOGFILE"
+		return 0
+	fi
+
+	# --- Append to linked issue body (marker-guarded for idempotency) ---
+	local current_body
+	current_body=$(gh issue view "$linked_issue" --repo "$repo_slug" \
+		--json body --jq '.body // ""' 2>/dev/null) || current_body=""
+
+	local marker="<!-- t2093:review-feedback:PR${pr_number} -->"
+	local body_updated="false"
+	if printf '%s' "$current_body" | grep -qF "$marker"; then
+		echo "[pulse-wrapper] _dispatch_pr_fix_worker: issue #${linked_issue} in ${repo_slug} already has routed feedback marker for PR #${pr_number} — skipping body update (t2093)" >>"$LOGFILE"
+		body_updated="true"
+	else
+		local new_body
+		new_body="${current_body}
+
+${marker}
+${feedback_section}"
+		if gh issue edit "$linked_issue" --repo "$repo_slug" \
+			--body "$new_body" >/dev/null 2>&1; then
+			body_updated="true"
+		else
+			echo "[pulse-wrapper] _dispatch_pr_fix_worker: failed to update issue #${linked_issue} body in ${repo_slug} — aborting routing for PR #${pr_number} (t2093)" >>"$LOGFILE"
+			return 1
+		fi
+	fi
+
+	# --- Transition issue status to `available` so it re-enters the
+	# dispatch queue. set_issue_status atomically clears queued/in-progress/
+	# in-review/claimed and adds status:available. Pass-through flag adds
+	# the source:review-feedback marker. ---
+	if declare -F set_issue_status >/dev/null 2>&1; then
+		set_issue_status "$linked_issue" "$repo_slug" "available" \
+			--add-label "source:review-feedback" >/dev/null 2>&1 || true
+	else
+		# Fallback for standalone tests / degraded environments: best-effort
+		# direct label ops. set_issue_status is always present in real
+		# pulse-wrapper.sh runs because shared-constants.sh is sourced at
+		# bootstrap — see the include chain in pulse-wrapper.sh.
+		gh issue edit "$linked_issue" --repo "$repo_slug" \
+			--add-label "status:available" \
+			--add-label "source:review-feedback" \
+			--remove-label "status:queued" \
+			--remove-label "status:in-progress" \
+			--remove-label "status:in-review" \
+			--remove-label "status:claimed" \
+			>/dev/null 2>&1 || true
+	fi
+
+	# --- Close the stuck PR with explanatory comment ---
+	local close_comment
+	close_comment="## Review feedback routed to linked issue #${linked_issue} (t2093)
+
+This worker-authored PR had \`reviewDecision=CHANGES_REQUESTED\`. Rather than let it sit
+indefinitely (no human owns worker PRs and the dispatch-dedup guard treats an open worker
+PR as an active claim), the deterministic merge pass has:
+
+1. Extracted the review feedback (top-level reviews + file:line inline comments) and
+   appended it to the linked issue body as a \"Review Feedback\" section.
+2. Closed this PR so the dispatch queue can re-pick the linked issue.
+3. Transitioned issue #${linked_issue} to \`status:available\` and tagged it
+   \`source:review-feedback\` so the next pulse cycle dispatches a fresh worker with
+   the feedback in its prompt.
+
+The next worker will see the updated issue body, address the review findings, and
+open a fresh PR against issue #${linked_issue}.
+
+_Closed by deterministic merge pass (pulse-merge.sh, t2093)._"
+
+	gh pr close "$pr_number" --repo "$repo_slug" \
+		--comment "$close_comment" >/dev/null 2>&1 || true
+
+	# Mark the PR as routed so any racing merge-pass re-read (via cached
+	# listing) skips re-processing. This is belt-and-suspenders — closed
+	# PRs are already excluded from the merge cycle's open-PR query.
+	gh pr edit "$pr_number" --repo "$repo_slug" \
+		--add-label "review-routed-to-issue" >/dev/null 2>&1 || true
+
+	echo "[pulse-wrapper] _dispatch_pr_fix_worker: routed review feedback from PR #${pr_number} to issue #${linked_issue} in ${repo_slug} (body_updated=${body_updated}, t2093)" >>"$LOGFILE"
 	return 0
 }

--- a/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
@@ -1,0 +1,408 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Tests for _dispatch_pr_fix_worker() and _build_review_feedback_section()
+# (t2093).
+#
+# When a review bot posts CHANGES_REQUESTED on an open worker-authored PR,
+# the pulse merge pass must route the feedback to the linked issue and close
+# the PR so the dispatch queue can re-pick the task. Before t2093, such PRs
+# accumulated indefinitely.
+#
+# These tests exercise the helpers in isolation with a mock `gh` stub. No
+# real repository is touched.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+MERGE_SCRIPT="${SCRIPT_DIR}/../pulse-merge.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+GH_LOG=""
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+# Mock state that each test resets before running.
+reset_mock_state() {
+	: >"$GH_LOG"
+	: >"${TEST_ROOT}/issue-body.txt"
+	: >"${TEST_ROOT}/reviews.json"
+	: >"${TEST_ROOT}/comments.json"
+	# Defaults: populated reviews + comments, empty issue body.
+	cat >"${TEST_ROOT}/reviews.json" <<'EOF'
+[{"user":{"login":"coderabbitai[bot]"},"state":"CHANGES_REQUESTED","body":"Two issues in the new helper. Please address before merge.","html_url":"https://github.com/owner/repo/pull/100#pullrequestreview-1"}]
+EOF
+	cat >"${TEST_ROOT}/comments.json" <<'EOF'
+[{"user":{"login":"coderabbitai[bot]"},"path":".agents/scripts/pulse-merge.sh","line":650,"original_line":650,"body":"This check has an off-by-one.","html_url":"https://github.com/owner/repo/pull/100#discussion_r1"}]
+EOF
+	echo 'Original issue body.' >"${TEST_ROOT}/issue-body.txt"
+}
+
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+	mkdir -p "${TEST_ROOT}/bin"
+	export PATH="${TEST_ROOT}/bin:${PATH}"
+	export LOGFILE="${TEST_ROOT}/pulse.log"
+	: >"$LOGFILE"
+	GH_LOG="${TEST_ROOT}/gh-calls.log"
+	: >"$GH_LOG"
+	export TEST_ROOT GH_LOG
+
+	# Mock gh: logs every call and returns canned data based on the
+	# subcommand. Reads/writes to files under TEST_ROOT so tests can
+	# inspect/alter state between runs.
+	cat >"${TEST_ROOT}/bin/gh" <<'GHEOF'
+#!/usr/bin/env bash
+printf '%s\n' "gh $*" >>"${GH_LOG:-/dev/null}"
+
+# Save the full positional arg array before any shifts.
+_all_args=("$@")
+_subcmd="${1:-} ${2:-}"
+
+case "$_subcmd" in
+"label create")
+	exit 0
+	;;
+"pr view")
+	if [[ "$*" == *"--json labels"* ]]; then
+		printf '%s\n' "origin:worker,auto-dispatch"
+		exit 0
+	fi
+	if [[ "$*" == *"--json headRefName"* ]]; then
+		printf 'fix/worker-branch\n'
+		exit 0
+	fi
+	exit 0
+	;;
+"pr close" | "pr edit")
+	exit 0
+	;;
+"issue view")
+	if [[ "$*" == *"--json body"* ]]; then
+		cat "${TEST_ROOT}/issue-body.txt"
+		exit 0
+	fi
+	exit 0
+	;;
+"issue edit")
+	# Capture the --body argument so subsequent views see the updated body.
+	while [[ $# -gt 0 ]]; do
+		if [[ "$1" == "--body" ]]; then
+			shift
+			printf '%s' "$1" >"${TEST_ROOT}/issue-body.txt"
+			break
+		fi
+		shift
+	done
+	exit 0
+	;;
+esac
+
+# `gh api repos/...` uses the URL as $2, so the simple `case "$1 $2"`
+# pattern above can't match it. Handle api separately.
+if [[ "${1:-}" == "api" ]]; then
+	# Extract the --jq filter so we can simulate real gh's server-side jq.
+	_jq_filter=""
+	for _i in "${!_all_args[@]}"; do
+		if [[ "${_all_args[$_i]}" == "--jq" ]]; then
+			_jq_filter="${_all_args[$((_i + 1))]:-}"
+			break
+		fi
+	done
+	if [[ "$*" == *"/pulls/"*"/reviews"* ]]; then
+		if [[ -n "$_jq_filter" ]]; then
+			jq "$_jq_filter" <"${TEST_ROOT}/reviews.json"
+		else
+			cat "${TEST_ROOT}/reviews.json"
+		fi
+		exit 0
+	fi
+	if [[ "$*" == *"/pulls/"*"/comments"* ]]; then
+		if [[ -n "$_jq_filter" ]]; then
+			jq "$_jq_filter" <"${TEST_ROOT}/comments.json"
+		else
+			cat "${TEST_ROOT}/comments.json"
+		fi
+		exit 0
+	fi
+fi
+
+exit 0
+GHEOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+	return 0
+}
+
+teardown_test_env() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+# Extract helpers under test and eval them in this shell. Same pattern
+# as test-pulse-merge-rebase-nudge.sh.
+define_helpers_under_test() {
+	local build_src
+	build_src=$(awk '
+		/^_build_review_feedback_section\(\) \{/,/^}$/ { print }
+	' "$MERGE_SCRIPT")
+	if [[ -z "$build_src" ]]; then
+		printf 'ERROR: could not extract _build_review_feedback_section from %s\n' "$MERGE_SCRIPT" >&2
+		return 1
+	fi
+	# shellcheck disable=SC1090
+	eval "$build_src"
+
+	local dispatch_src
+	dispatch_src=$(awk '
+		/^_dispatch_pr_fix_worker\(\) \{/,/^}$/ { print }
+	' "$MERGE_SCRIPT")
+	if [[ -z "$dispatch_src" ]]; then
+		printf 'ERROR: could not extract _dispatch_pr_fix_worker from %s\n' "$MERGE_SCRIPT" >&2
+		return 1
+	fi
+	# shellcheck disable=SC1090
+	eval "$dispatch_src"
+	return 0
+}
+
+# =============================================================================
+# Tests
+# =============================================================================
+
+test_build_section_includes_marker_and_citations() {
+	reset_mock_state
+	local reviews_json comments_json section
+	reviews_json=$(jq '[.[] | {author: .user.login, state: .state, body: .body, url: .html_url}]' <"${TEST_ROOT}/reviews.json")
+	comments_json=$(jq '[.[] | {author: .user.login, path: .path, line: (.line // .original_line), body: .body, url: .html_url}]' <"${TEST_ROOT}/comments.json")
+
+	section=$(_build_review_feedback_section "100" "owner/repo" "$reviews_json" "$comments_json")
+
+	if [[ "$section" != *"Review Feedback routed from PR #100"* ]]; then
+		print_result "build section includes header with PR number" 1 \
+			"Expected 'Review Feedback routed from PR #100' in section"
+		return 0
+	fi
+	if [[ "$section" != *"pulse-merge.sh\`:650"* ]]; then
+		print_result "build section includes file:line citation" 1 \
+			"Expected 'pulse-merge.sh:650' citation in section. Got: ${section:0:500}"
+		return 0
+	fi
+	if [[ "$section" != *"coderabbitai[bot]"* ]]; then
+		print_result "build section includes reviewer login" 1 \
+			"Expected 'coderabbitai[bot]' in section"
+		return 0
+	fi
+	if [[ "$section" != *"CHANGES_REQUESTED"* ]]; then
+		print_result "build section includes review state" 1 \
+			"Expected 'CHANGES_REQUESTED' in section"
+		return 0
+	fi
+	print_result "build section includes header, citations, and reviewer" 0
+	return 0
+}
+
+test_build_section_empty_when_no_content() {
+	reset_mock_state
+	local section
+	section=$(_build_review_feedback_section "100" "owner/repo" "[]" "[]")
+	if [[ -n "$section" ]]; then
+		print_result "build section returns empty when no reviews or comments" 1 \
+			"Expected empty, got: ${section:0:200}"
+		return 0
+	fi
+	print_result "build section returns empty when no reviews or comments" 0
+	return 0
+}
+
+test_dispatch_appends_to_issue_body_and_closes_pr() {
+	reset_mock_state
+	_dispatch_pr_fix_worker "100" "owner/repo" "42"
+
+	# Verify issue body was updated with the marker.
+	if ! grep -qF "<!-- t2093:review-feedback:PR100 -->" "${TEST_ROOT}/issue-body.txt"; then
+		print_result "dispatch appends marker to issue body" 1 \
+			"Expected marker in issue-body.txt. Content: $(cat "${TEST_ROOT}/issue-body.txt")"
+		return 0
+	fi
+	# Verify the original body is preserved above the marker.
+	if ! grep -qF "Original issue body." "${TEST_ROOT}/issue-body.txt"; then
+		print_result "dispatch preserves original body" 1 \
+			"Original body missing after append"
+		return 0
+	fi
+	# Verify PR close was called.
+	if ! grep -qF 'gh pr close 100' "$GH_LOG"; then
+		print_result "dispatch calls gh pr close on stuck PR" 1 \
+			"Expected 'gh pr close 100' in call log"
+		return 0
+	fi
+	# Verify review-routed-to-issue label added to PR.
+	if ! grep -qF 'review-routed-to-issue' "$GH_LOG"; then
+		print_result "dispatch adds review-routed-to-issue label to PR" 1 \
+			"Expected 'review-routed-to-issue' label add in call log"
+		return 0
+	fi
+	# Verify source:review-feedback label added to issue.
+	if ! grep -qF 'source:review-feedback' "$GH_LOG"; then
+		print_result "dispatch adds source:review-feedback label to issue" 1 \
+			"Expected 'source:review-feedback' label add in call log"
+		return 0
+	fi
+	# Verify status transition to available (clears active claim labels).
+	if ! grep -qF 'status:available' "$GH_LOG"; then
+		print_result "dispatch transitions issue status to available" 1 \
+			"Expected 'status:available' in call log"
+		return 0
+	fi
+	print_result "dispatch appends body, closes PR, transitions labels" 0
+	return 0
+}
+
+test_dispatch_idempotent_when_marker_already_present() {
+	reset_mock_state
+	# Pre-seed the issue body with the marker.
+	cat >"${TEST_ROOT}/issue-body.txt" <<'EOF'
+Original body.
+
+<!-- t2093:review-feedback:PR100 -->
+Previously routed feedback content.
+EOF
+	: >"$GH_LOG"
+
+	_dispatch_pr_fix_worker "100" "owner/repo" "42"
+
+	# The body should not have been edited again (issue edit --body should
+	# not appear in call log). The PR close + label ops still fire —
+	# idempotency is scoped to the body append only.
+	if grep -qE 'gh issue edit [0-9]+ --repo [^ ]+ --body' "$GH_LOG"; then
+		print_result "dispatch skips body update when marker already present" 1 \
+			"Unexpected 'issue edit --body' call. Log: $(cat "$GH_LOG")"
+		return 0
+	fi
+	# Sanity check: the marker call path was taken (log entry should mention it).
+	if ! grep -qF 'already has routed feedback marker' "$LOGFILE"; then
+		print_result "dispatch skips body update when marker already present" 1 \
+			"Expected idempotency log message in $LOGFILE"
+		return 0
+	fi
+	print_result "dispatch skips body update when marker already present" 0
+	return 0
+}
+
+test_dispatch_noop_when_no_substantive_feedback() {
+	reset_mock_state
+	# Empty reviews and comments -> _build_review_feedback_section returns empty.
+	echo '[]' >"${TEST_ROOT}/reviews.json"
+	echo '[]' >"${TEST_ROOT}/comments.json"
+	: >"$GH_LOG"
+
+	_dispatch_pr_fix_worker "100" "owner/repo" "42"
+
+	# Issue body should be untouched.
+	if [[ "$(cat "${TEST_ROOT}/issue-body.txt")" != "Original issue body." ]]; then
+		print_result "dispatch leaves issue body untouched when no substantive feedback" 1 \
+			"Issue body was modified. Content: $(cat "${TEST_ROOT}/issue-body.txt")"
+		return 0
+	fi
+	# PR close should NOT be called.
+	if grep -qF 'gh pr close 100' "$GH_LOG"; then
+		print_result "dispatch does not close PR when no substantive feedback" 1 \
+			"Unexpected 'gh pr close' in call log"
+		return 0
+	fi
+	print_result "dispatch is a no-op when no substantive feedback" 0
+	return 0
+}
+
+test_dispatch_noop_on_invalid_inputs() {
+	reset_mock_state
+	: >"$GH_LOG"
+
+	_dispatch_pr_fix_worker "not-a-number" "owner/repo" "42"
+	_dispatch_pr_fix_worker "100" "" "42"
+	_dispatch_pr_fix_worker "100" "owner/repo" "not-a-number"
+	_dispatch_pr_fix_worker "100" "owner/repo" ""
+
+	# None of the above should have made any gh calls.
+	if [[ -s "$GH_LOG" ]]; then
+		print_result "dispatch no-ops on invalid inputs" 1 \
+			"Expected zero gh calls. Got: $(wc -l <"$GH_LOG") lines"
+		return 0
+	fi
+	print_result "dispatch no-ops on invalid inputs" 0
+	return 0
+}
+
+test_dispatch_clears_in_progress_labels_as_fallback() {
+	reset_mock_state
+	: >"$GH_LOG"
+	# Force the fallback path: unset set_issue_status for this call.
+	unset -f set_issue_status 2>/dev/null || true
+
+	_dispatch_pr_fix_worker "100" "owner/repo" "42"
+
+	if ! grep -qF -- '--remove-label status:in-progress' "$GH_LOG"; then
+		print_result "dispatch fallback clears status:in-progress" 1 \
+			"Expected '--remove-label status:in-progress' in call log when set_issue_status unavailable"
+		return 0
+	fi
+	if ! grep -qF -- '--remove-label status:in-review' "$GH_LOG"; then
+		print_result "dispatch fallback clears status:in-review" 1 \
+			"Expected '--remove-label status:in-review' in call log"
+		return 0
+	fi
+	print_result "dispatch fallback clears active-claim status labels" 0
+	return 0
+}
+
+main() {
+	trap teardown_test_env EXIT
+	setup_test_env
+
+	if ! define_helpers_under_test; then
+		printf 'FATAL: helper extraction failed\n' >&2
+		return 1
+	fi
+
+	test_build_section_includes_marker_and_citations
+	test_build_section_empty_when_no_content
+	test_dispatch_appends_to_issue_body_and_closes_pr
+	test_dispatch_idempotent_when_marker_already_present
+	test_dispatch_noop_when_no_substantive_feedback
+	test_dispatch_noop_on_invalid_inputs
+	test_dispatch_clears_in_progress_labels_as_fallback
+
+	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

pulse-merge.sh now detects worker PRs with CHANGES_REQUESTED and routes the bot review feedback to the linked issue body, closes the stuck PR, and transitions the issue to status:available so the next pulse cycle picks it up with feedback in the prompt.

## Files Changed

.agents/scripts/pulse-merge.sh,.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Added .agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh — 7 assertions covering section building, marker idempotency, no-content no-op, invalid input no-op, set_issue_status fallback. shellcheck zero violations on pulse-merge.sh.

Resolves #18964


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.28 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-opus-4-6 spent 9m and 36,004 tokens on this as a headless worker.