### PR TITLE
fix(t2095): probe existing proxy before launch — survive hot-reload

### DIFF
--- a/.agents/plugins/opencode-aidevops/claude-proxy.mjs
+++ b/.agents/plugins/opencode-aidevops/claude-proxy.mjs
@@ -294,17 +294,36 @@ async function registerProxyAuth(client) {
 }
 
 /**
+ * Probe whether a proxy server is already listening on CLAUDE_PROXY_DEFAULT_PORT.
+ * Used to adopt an existing server after plugin hot-reload (where the module
+ * scope resets but the Bun.serve instance from the previous load lives on) or
+ * when the plugin runs in a non-Bun JS runtime that cannot call Bun.serve.
+ *
+ * Returns the port number on success, null if no server is reachable.
+ */
+async function probeExistingProxy() {
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 1000);
+    const res = await fetch(
+      `http://127.0.0.1:${CLAUDE_PROXY_DEFAULT_PORT}/v1/models`,
+      { signal: controller.signal },
+    );
+    clearTimeout(timer);
+    if (res.ok) return CLAUDE_PROXY_DEFAULT_PORT;
+  } catch {
+    // not running or not reachable
+  }
+  return null;
+}
+
+/**
  * Pre-flight gate for `startClaudeProxy`. Returns:
  *   - `null` if the proxy should be skipped (no Bun, no claude CLI, race)
  *   - `{ port, models }` if the proxy is already running (fast-path)
  *   - `undefined` if the caller should proceed with a full launch
  */
 function checkProxyPreconditions() {
-  if (typeof globalThis.Bun === "undefined") {
-    console.error("[aidevops] Claude proxy: skipped (not running under Bun)");
-    return null;
-  }
-  if (!isClaudeCliAvailable()) return null;
   if (proxyStarting) return null;
   if (proxyPort) return { port: proxyPort, models: getClaudeProxyModels() };
   return undefined;
@@ -335,6 +354,23 @@ async function launchProxyServer(client, directory) {
 export async function startClaudeProxy(client, directory) {
   const earlyExit = checkProxyPreconditions();
   if (earlyExit !== undefined) return earlyExit;
+
+  // Probe first: adopt any existing proxy (handles hot-reload and non-Bun runtimes).
+  // This avoids the module-scope reset issue where proxyPort is null after a
+  // plugin reload but the Bun.serve instance from the previous load is still live.
+  const existingPort = await probeExistingProxy();
+  if (existingPort) {
+    proxyPort = existingPort;
+    console.error(`[aidevops] Claude proxy: adopted existing server on port ${proxyPort}`);
+    return { port: proxyPort, models: getClaudeProxyModels() };
+  }
+
+  // No existing proxy — try to launch a new Bun.serve instance.
+  if (typeof globalThis.Bun === "undefined") {
+    console.error("[aidevops] Claude proxy: skipped (not running under Bun and no existing proxy found)");
+    return null;
+  }
+  if (!isClaudeCliAvailable()) return null;
 
   proxyStarting = true;
   let result = null;


### PR DESCRIPTION
## Problem

After deploying updated plugin files (hot-reload), the new `claude-proxy.mjs` module has its own fresh scope with `proxyPort = null`. When `startClaudeProxy` tries to launch `Bun.serve` on port 32125, it gets EADDRINUSE (the old module's server is still live), throws, and returns `null`. The config hook then sees `getClaudeProxyPort() === null` and deletes `config.provider.claudecli` — wiping all claudecli models from the \`/models\` selector.

The same failure mode applies if opencode's plugin runtime is not Bun: the Bun check returned \`null\` immediately, leaving no path to adopt an existing proxy.

## Fix

Add `probeExistingProxy()` — a 1-second fetch to \`http://127.0.0.1:32125/v1/models\`. Called at the top of `startClaudeProxy` before the Bun check or any launch attempt. If the probe succeeds, set `proxyPort` and return (adopt). Only attempt `Bun.serve` if no existing proxy is found.

This makes the Bun check a launch gate (not an availability gate): the proxy can be running and usable even when this module instance didn't start it.

## Changes

- `claude-proxy.mjs`: `probeExistingProxy()` + updated `startClaudeProxy` flow

## Verification

1. Start opencode with the plugin loaded (proxy starts on 32125)
2. Deploy updated plugin files while opencode is running (hot-reload)
3. Open a new opencode session — claudecli models should appear in \`/models\` selector
4. Logs should show: \`[aidevops] Claude proxy: adopted existing server on port 32125\`


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.28 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 44m and 71,874 tokens on this with the user in an interactive session.