### PR TITLE
fix(t2095): native CLI auth fallback + rename claudecli provider

### DIFF
--- a/.agents/plugins/opencode-aidevops/claude-proxy-jsonpath.mjs
+++ b/.agents/plugins/opencode-aidevops/claude-proxy-jsonpath.mjs
@@ -19,6 +19,7 @@ import {
   buildChildEnvWithToken,
   detectRateLimitJson,
   getAvailableAccounts,
+  getNativeCliFallback,
   markAccountRateLimited,
 } from "./claude-proxy-retry.mjs";
 import { buildClaudeArgs } from "./claude-proxy-context.mjs";
@@ -117,11 +118,11 @@ async function runClaudeJsonWithAccount(body, directory, account, abortSignal) {
  */
 export async function runClaudeJson(body, directory, abortSignal) {
   const accounts = await getAvailableAccounts();
-  if (accounts.length === 0) {
-    throw new Error("No Anthropic OAuth pool accounts available (all rate-limited or no valid tokens)");
-  }
+  // Always append native CLI auth as final fallback so requests succeed
+  // even when all OAuth pool accounts are rate-limited.
+  const accountsWithFallback = [...accounts, getNativeCliFallback()];
 
-  for (const account of accounts) {
+  for (const account of accountsWithFallback) {
     if (abortSignal && abortSignal.aborted) throw new Error("Request aborted by client");
     console.error(`[aidevops] Claude proxy: trying account ${account.email} (json mode)`);
     const result = await runClaudeJsonWithAccount(body, directory, account, abortSignal);
@@ -131,7 +132,7 @@ export async function runClaudeJson(body, directory, abortSignal) {
     console.error(`[aidevops] Claude proxy: account ${account.email} rate-limited, trying next...`);
   }
 
-  throw new Error("All Anthropic OAuth pool accounts are rate-limited");
+  throw new Error("All Anthropic OAuth pool accounts and native CLI auth are rate-limited");
 }
 
 /**

--- a/.agents/plugins/opencode-aidevops/claude-proxy-retry.mjs
+++ b/.agents/plugins/opencode-aidevops/claude-proxy-retry.mjs
@@ -88,12 +88,30 @@ export async function getAvailableAccounts() {
  * Build a child-process env that injects the OAuth token via
  * `CLAUDE_CODE_OAUTH_TOKEN` and strips any inherited `ANTHROPIC_API_KEY`
  * (which would otherwise win precedence in the Claude CLI).
+ *
+ * When `token` is null, the native CLI auth path is used: both
+ * `ANTHROPIC_API_KEY` and `CLAUDE_CODE_OAUTH_TOKEN` are removed so the
+ * Claude CLI falls back to its own stored credentials (`~/.claude.json`).
  */
 export function buildChildEnvWithToken(token) {
   const childEnv = { ...process.env };
   delete childEnv.ANTHROPIC_API_KEY;
-  childEnv.CLAUDE_CODE_OAUTH_TOKEN = token;
+  if (token !== null) {
+    childEnv.CLAUDE_CODE_OAUTH_TOKEN = token;
+  } else {
+    delete childEnv.CLAUDE_CODE_OAUTH_TOKEN;
+  }
   return childEnv;
+}
+
+/**
+ * Synthetic "account" representing the Claude CLI's own stored credentials
+ * (`~/.claude.json`). Used as the final fallback when all OAuth pool accounts
+ * are rate-limited or unavailable. `token: null` signals `buildChildEnvWithToken`
+ * to clear injected credentials so the CLI uses its native auth.
+ */
+export function getNativeCliFallback() {
+  return { email: "native-cli-auth", token: null };
 }
 
 /**

--- a/.agents/plugins/opencode-aidevops/claude-proxy-streaming.mjs
+++ b/.agents/plugins/opencode-aidevops/claude-proxy-streaming.mjs
@@ -21,6 +21,7 @@ import {
   buildChildEnvWithToken,
   detectRateLimitStream,
   getAvailableAccounts,
+  getNativeCliFallback,
   markAccountRateLimited,
 } from "./claude-proxy-retry.mjs";
 import {
@@ -353,12 +354,11 @@ export function streamClaudeResponse(body, directory) {
   return new ReadableStream({
     async start(controller) {
       const accounts = await getAvailableAccounts();
-      if (accounts.length === 0) {
-        emitAllAccountsRateLimited(controller, encoder, completionId, created, body.model);
-        return;
-      }
+      // Always append native CLI auth as final fallback so streams succeed
+      // even when all OAuth pool accounts are rate-limited.
+      const accountsWithFallback = [...accounts, getNativeCliFallback()];
       const streamCtx = { controller, encoder, completionId, created, body, directory, abortRef };
-      await iterateAccounts(streamCtx, accounts);
+      await iterateAccounts(streamCtx, accountsWithFallback);
     },
     cancel(reason) {
       handleStreamCancel(abortRef, reason);

--- a/.agents/plugins/opencode-aidevops/claude-proxy.mjs
+++ b/.agents/plugins/opencode-aidevops/claude-proxy.mjs
@@ -133,7 +133,7 @@ function buildClaudeProviderModels(models) {
  */
 function buildClaudeProviderConfig(port, models) {
   return {
-    name: "Claude CLI (via aidevops proxy)",
+    name: "Claude CLI",
     npm: "@ai-sdk/openai-compatible",
     api: `http://127.0.0.1:${port}/v1`,
     models: buildClaudeProviderModels(models),

--- a/.agents/plugins/opencode-aidevops/config-hook.mjs
+++ b/.agents/plugins/opencode-aidevops/config-hook.mjs
@@ -104,8 +104,11 @@ function registerAnthropicModels(config) {
       npm: "@ai-sdk/openai-compatible",
       api: "http://127.0.0.1:32125/v1",
     };
-  } else if (config.provider.claudecli.name === "Claude CLI (coming soon)") {
-    // Migrate legacy provider name
+  } else if (
+    config.provider.claudecli.name === "Claude CLI (coming soon)" ||
+    config.provider.claudecli.name === "Claude CLI (via aidevops proxy)"
+  ) {
+    // Migrate legacy provider names
     config.provider.claudecli.name = "Claude CLI";
   }
   if (!config.provider.claudecli.models) config.provider.claudecli.models = {};


### PR DESCRIPTION
## Problems

**1. Rate-limit error fires even when accounts are available**

The error "Claude CLI transport: all Anthropic OAuth pool accounts are rate-limited" was a hard-fail: if the OAuth pool had no available accounts, the proxy threw immediately with no fallback. But the Claude CLI has its own stored credentials in \`~/.claude.json\` that work independently of the pool. A working session via aidevops OAuth proves at least one account isn't rate-limited, but the pool check and the session check are on separate code paths.

**2. Provider name shows "via aidevops" on the claudecli provider**

\`buildClaudeProviderConfig\` set \`name: "Claude CLI (via aidevops proxy)"\`, which leaks "aidevops" into the claudecli provider label. In the \`/models\` selector status bar this appeared as \`Claude Opus 4.6 (via CLI) · Claude CLI (via aidevops proxy)\`, confusingly conflating the claudecli provider with the direct-Anthropic \`(via aidevops)\` models.

## Changes

- **\`claude-proxy-retry.mjs\`**: \`buildChildEnvWithToken(null)\` now clears both \`ANTHROPIC_API_KEY\` and \`CLAUDE_CODE_OAUTH_TOKEN\` so the CLI falls back to \`~/.claude.json\`. New \`getNativeCliFallback()\` returns a synthetic \`{ email: "native-cli-auth", token: null }\` account.
- **\`claude-proxy-jsonpath.mjs\`**: appends \`getNativeCliFallback()\` to the accounts list before iteration. Hard-fail removed.
- **\`claude-proxy-streaming.mjs\`**: same — native fallback appended; the pre-check that emitted the "all rate-limited" SSE error before any iteration is removed.
- **\`claude-proxy.mjs\`**: provider name changed to \`"Claude CLI"\`.
- **\`config-hook.mjs\`**: migration added for \`"Claude CLI (via aidevops proxy)"\` → \`"Claude CLI"\` so existing \`opencode.json\` entries are cleaned up on next start.

## Verification

- Start opencode, select a claudecli model, and verify the status bar shows \`Claude CLI\` (not \`Claude CLI (via aidevops proxy)\`).
- With all pool accounts rate-limited, a claudecli request should complete via native CLI auth rather than showing the rate-limit error.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.28 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 1h 15m and 84,937 tokens on this with the user in an interactive session.