### PR TITLE
fix(t2095): keep ANTHROPIC_API_KEY for native CLI fallback + rename provider

### DIFF
--- a/.agents/plugins/opencode-aidevops/claude-proxy-retry.mjs
+++ b/.agents/plugins/opencode-aidevops/claude-proxy-retry.mjs
@@ -137,7 +137,7 @@ export function detectRateLimitJson(parsed) {
  * @returns {{ rateLimited: boolean, resetsAt?: string }}
  */
 export function detectRateLimitStream(event) {
-  if (event?.type === "rate_limit_event") {
+  if (event?.type === "rate_limit_event" && event?.rate_limit_info?.status === "rejected") {
     return { rateLimited: true, resetsAt: event?.rate_limit_info?.resetsAt };
   }
   if (event?.type === "assistant" && event?.error === "rate_limit") {

--- a/.agents/plugins/opencode-aidevops/claude-proxy-retry.mjs
+++ b/.agents/plugins/opencode-aidevops/claude-proxy-retry.mjs
@@ -85,20 +85,23 @@ export async function getAvailableAccounts() {
 }
 
 /**
- * Build a child-process env that injects the OAuth token via
- * `CLAUDE_CODE_OAUTH_TOKEN` and strips any inherited `ANTHROPIC_API_KEY`
- * (which would otherwise win precedence in the Claude CLI).
+ * Build a child-process env for a Claude CLI subprocess.
  *
- * When `token` is null, the native CLI auth path is used: both
- * `ANTHROPIC_API_KEY` and `CLAUDE_CODE_OAUTH_TOKEN` are removed so the
- * Claude CLI falls back to its own stored credentials (`~/.claude.json`).
+ * When `token` is a pool OAuth token: inject it via `CLAUDE_CODE_OAUTH_TOKEN`
+ * and strip `ANTHROPIC_API_KEY` so it cannot win precedence.
+ *
+ * When `token` is null (native CLI fallback): clear only `CLAUDE_CODE_OAUTH_TOKEN`
+ * and leave `ANTHROPIC_API_KEY` intact so the CLI can use whatever credential
+ * it has available (env API key, ~/.claude.json OAuth, etc.).
  */
 export function buildChildEnvWithToken(token) {
   const childEnv = { ...process.env };
-  delete childEnv.ANTHROPIC_API_KEY;
   if (token !== null) {
+    // Injecting pool OAuth token — strip API key so it doesn't win precedence.
+    delete childEnv.ANTHROPIC_API_KEY;
     childEnv.CLAUDE_CODE_OAUTH_TOKEN = token;
   } else {
+    // Native CLI auth — clear injected token only; keep ANTHROPIC_API_KEY.
     delete childEnv.CLAUDE_CODE_OAUTH_TOKEN;
   }
   return childEnv;

--- a/.agents/plugins/opencode-aidevops/claude-proxy-streaming.mjs
+++ b/.agents/plugins/opencode-aidevops/claude-proxy-streaming.mjs
@@ -277,11 +277,11 @@ function tryStreamWithAccount(streamCtx, account) {
 /**
  * Emit an "all accounts rate-limited" SSE message and close the stream.
  * Used both when no accounts are available at start and when every account
- * was exhausted mid-iteration.
+ * was exhausted mid-iteration (including the native CLI fallback).
  */
 function emitAllAccountsRateLimited(controller, encoder, completionId, created, model) {
   const errChunk = createOpenAIChunk(completionId, created, model, {
-    content: "[Claude CLI transport: all Anthropic OAuth pool accounts are rate-limited]",
+    content: "[Claude CLI transport: all Anthropic OAuth pool accounts are rate-limited and native CLI fallback also failed]",
   });
   try {
     controller.enqueue(encoder.encode(`data: ${JSON.stringify(errChunk)}\n\n`));


### PR DESCRIPTION
Resolves #19021

## Root cause

The previous native CLI fallback fix (intended to let the CLI use its own credentials when all pool OAuth tokens are rate-limited) was stripping `ANTHROPIC_API_KEY` from the subprocess environment — which is exactly the credential the CLI is currently using:

\`\`\`
claude auth status → { "authMethod": "api_key", "apiKeySource": "ANTHROPIC_API_KEY" }
\`\`\`

\`buildChildEnvWithToken\` unconditionally deleted \`ANTHROPIC_API_KEY\` before the \`if (token !== null)\` branch, so the native fallback path (token = null) also wiped the working credential. The CLI subprocess then had no valid auth and failed.

## Fix

Move the \`delete childEnv.ANTHROPIC_API_KEY\` inside the \`token !== null\` branch so it only fires when injecting a pool OAuth token (where the API key would override the injected token). The native fallback path leaves \`ANTHROPIC_API_KEY\` and \`~/.claude.json\` untouched.

## Also in this PR

- Provider rename: \`"Claude CLI (via aidevops proxy)"\` → \`"Claude CLI"\` (no "via aidevops" bleed into the claudecli label)
- Migration in config-hook for existing opencode.json entries

## Verification

With all pool OAuth accounts rate-limited, a request to a claudecli model should complete via the native CLI auth (API key) rather than showing the rate-limit error. Log should show: \`[aidevops] Claude proxy: trying account native-cli-auth (stream mode)\`.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.28 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 1h 29m and 95,073 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automatic fallback to native CLI credentials when OAuth pool accounts are unavailable or rate-limited.

* **Bug Fixes**
  * Enhanced credential management to support seamless switching between OAuth and native authentication methods.
  * Improved error handling when OAuth pool is exhausted.
  * Updated Claude CLI provider display name for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->