### PR TITLE
GH#18846: restore pool_ops_token_utils.py with bug fixes

### DIFF
--- a/.agents/scripts/oauth-pool-lib/pool_ops_token_utils.py
+++ b/.agents/scripts/oauth-pool-lib/pool_ops_token_utils.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""
+oauth-pool-lib/pool_ops_token_utils.py — Token extraction/decode/read helpers.
+"""
+from __future__ import annotations
+import json
+import os
+import sys
+
+def cmd_extract_token_fields() -> None:
+    try:
+        d = json.load(sys.stdin)
+        print(d.get('access_token', ''))
+        print(d.get('refresh_token', ''))
+        print(d.get('expires_in', 3600))
+    except Exception:
+        print('')
+        print('')
+        print(3600)
+
+def cmd_extract_token_error() -> None:
+    try:
+        d = json.load(sys.stdin)
+        parts = []
+        for k in ('type', 'error', 'message', 'error_description'):
+            if k in d and d[k]:
+                parts.append(str(d[k]))
+        print(': '.join(parts) if parts else 'unknown')
+    except Exception:
+        print('unknown')
+
+def cmd_openai_read_auth() -> None:
+    path = os.environ['AUTH_PATH']
+    try:
+        with open(path) as f:
+            auth = json.load(f)
+    except Exception:
+        print(''); print(''); print(''); print('')
+        sys.exit(0)
+    entry = auth.get('openai', {}) if isinstance(auth, dict) else {}
+    print(entry.get('access', ''))
+    print(entry.get('refresh', ''))
+    print(entry.get('expires', ''))
+    print(entry.get('accountId', ''))
+
+def cmd_cursor_read_auth() -> None:
+    path = os.environ['AUTH_PATH']
+    try:
+        with open(path) as f:
+            d = json.load(f)
+        print(d.get('accessToken', ''))
+        print(d.get('refreshToken', ''))
+    except Exception:
+        print(''); print('')
+
+def cmd_cursor_decode_jwt() -> None:
+    import base64
+    token = os.environ['ACCESS']
+    parts = token.split('.')
+    if len(parts) >= 2:
+        payload = parts[1] + '=' * ((-len(parts[1])) % 4)
+        try:
+            data = json.loads(base64.urlsafe_b64decode(payload))
+            print(data.get('email', ''))
+            print(data.get('exp', 0))
+        except Exception:
+            print(''); print(0)
+    else:
+        print(''); print(0)
+
+def cmd_google_validate() -> None:
+    from urllib.parse import urlparse
+    from urllib.request import Request, urlopen
+    from urllib.error import HTTPError, URLError
+    token = os.environ['ACCESS']
+    url = os.environ['HEALTH_URL']
+    parsed = urlparse(url)
+    if parsed.scheme != 'https' or not (parsed.hostname or '').endswith('.googleapis.com'):
+        print('INVALID_URL')
+        return
+    try:
+        req = Request(url, method='GET')
+        req.add_header('Authorization', 'Bearer ' + token)
+        urlopen(req, timeout=10)
+        print('OK')
+    except HTTPError as e:
+        print('HTTP_' + str(e.code))
+    except (URLError, OSError):
+        print('NETWORK_ERROR')
+    except Exception:
+        print('ERROR')

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,9 @@ authorized_keys
 !.secretlintignore
 !.agents/scripts/secretlint-helper.sh
 
+# Exception for pool_ops_token_utils (code module, not a credential)
+!.agents/scripts/oauth-pool-lib/pool_ops_token_utils.py
+
 # Exception for worker token helper (manages tokens, doesn't contain them)
 !.agents/scripts/worker-token-helper.sh
 !.agents/secretlint.md


### PR DESCRIPTION
## Summary

Restores the missing `pool_ops_token_utils.py` module from the t2069 decomposition (#18891), with three bug fixes applied over the contributor's original (PR #18846).

## Problem

Every `python3 pool_ops.py <command>` has been failing with `ModuleNotFoundError` since #18891 merged. The `.gitignore` blanket `*token*` pattern silently blocked the file from being committed. All 6 affected commands (`extract-token-fields`, `extract-token-error`, `cursor-decode-jwt`, `cursor-read-auth`, `openai-read-auth`, `google-validate`) were broken, but failures were masked by `2>/dev/null` in the shell caller.

## Bug fixes (over contributor's original)

1. **`cmd_extract_token_fields`** — wrap in try/except to always emit 3 lines (shell caller at `oauth-pool-helper.sh:276` assigns 3 variables from output)
2. **`cursor-decode-jwt`** — fix base64 padding: `(4 - len % 4)` → `((-len) % 4)` (old formula appended 4 `=` chars when `len % 4 == 0`)
3. **`google-validate`** — validate `HEALTH_URL` scheme/hostname (`https` + `.googleapis.com`) before sending bearer token

## Local test results (macOS)

| Test | Result |
|------|--------|
| `oauth-pool-helper.sh status` | Clean — no `ModuleNotFoundError`, all accounts visible |
| `oauth-pool-helper.sh check anthropic` | All 3 accounts healthy, tokens valid |
| `extract-token-fields` bad JSON | Graceful fallback: 3 default lines |
| JWT padding all mod-4 residues | All decode correctly |
| `google-validate` non-googleapis URL | Returns `INVALID_URL`, blocks bearer send |
| Active session routing | Unaffected — Anthropic model routing continued working |

Resolves #18846