### PR TITLE
t2080: add canary test for pulse-wrapper.sh main() runtime execution

### DIFF
--- a/.agents/scripts/linters-local.sh
+++ b/.agents/scripts/linters-local.sh
@@ -1284,6 +1284,42 @@ check_secret_policy() {
 }
 
 # =============================================================================
+# Pulse Wrapper Canary (GH#18790)
+# =============================================================================
+# Runs pulse-wrapper.sh --canary in a sandboxed HOME. Catches the set -e
+# exit-code propagation regression class (GH#18770) that static analysis
+# cannot detect. Fast: exits after acquire_instance_lock, no side effects.
+
+check_pulse_canary() {
+	echo -e "${BLUE}Checking Pulse Wrapper Canary (GH#18790)...${NC}"
+
+	local wrapper_script=".agents/scripts/pulse-wrapper.sh"
+	if [[ ! -f "$wrapper_script" ]]; then
+		print_error "pulse-wrapper.sh not found at $wrapper_script"
+		return 1
+	fi
+
+	local sandbox rc output
+	sandbox=$(mktemp -d)
+	output=$(
+		HOME="${sandbox}/home" \
+			FULL_LOOP_HEADLESS=1 \
+			timeout 30 bash "$wrapper_script" --canary 2>&1
+	)
+	rc=$?
+	rm -rf "$sandbox"
+
+	if [[ "$rc" -eq 0 ]]; then
+		print_success "Pulse canary: ok (sourcing + _pulse_handle_self_check + acquire_instance_lock)"
+		return 0
+	fi
+
+	print_error "Pulse canary failed (exit $rc). Output: ${output}"
+	print_info "This indicates a set -e exit-code regression in pulse-wrapper.sh (see GH#18770)."
+	return 1
+}
+
+# =============================================================================
 # Bash 3.2 Compatibility Check
 # =============================================================================
 # macOS ships bash 3.2.57. Bash 4.0+ features silently crash or produce wrong
@@ -1852,6 +1888,11 @@ _run_gate_checks_static() {
 
 	if ! should_skip_gate "secret-policy"; then
 		check_secret_policy || exit_code=1
+		echo ""
+	fi
+
+	if ! should_skip_gate "pulse-canary"; then
+		check_pulse_canary || exit_code=1
 		echo ""
 	fi
 

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1277,6 +1277,32 @@ _pulse_setup_dry_run_mode() {
 	return 0
 }
 
+# ---------------------------------------------------------------------------
+# _pulse_setup_canary_mode
+#
+# Phase 0 (GH#18790): --canary flag sets PULSE_CANARY_MODE=1 so main()
+# can short-circuit after acquire_instance_lock. This exercises:
+#   1. Script sourcing under set -euo pipefail (all top-level declarations)
+#   2. _pulse_handle_self_check — the exact function GH#18770 broke
+#   3. acquire_instance_lock — the next downstream function
+# and exits 0 without entering the pulse loop, dispatching workers, or
+# making any GitHub API calls.
+#
+# Scans "$@" for --canary (position-independent).
+# Exit code: always 0
+# ---------------------------------------------------------------------------
+_pulse_setup_canary_mode() {
+	local _can_arg
+	for _can_arg in "$@"; do
+		if [[ "$_can_arg" == "--canary" ]]; then
+			export PULSE_CANARY_MODE=1
+			break
+		fi
+	done
+	unset _can_arg
+	return 0
+}
+
 main() {
 	# GH#18670: declare this process as headless BEFORE anything else runs
 	# so every child shell stage sees AIDEVOPS_HEADLESS and
@@ -1305,6 +1331,7 @@ main() {
 	_pulse_handle_self_check "$@" || _sc_rc=$?
 	[[ "$_sc_rc" -ne 2 ]] && return "$_sc_rc"
 	_pulse_setup_dry_run_mode "$@"
+	_pulse_setup_canary_mode "$@"
 
 	# GH#4513: Acquire exclusive instance lock FIRST — before any other
 	# check. Uses mkdir atomicity as the ONLY primitive (POSIX-guaranteed,
@@ -1322,6 +1349,15 @@ main() {
 	trap 'release_instance_lock' EXIT
 
 	if ! acquire_instance_lock; then
+		return 0
+	fi
+
+	# --canary short-circuit (GH#18790): sourcing, _pulse_handle_self_check,
+	# and acquire_instance_lock have all passed cleanly. The EXIT trap releases
+	# the lock. Return 0 without entering the pulse loop, session gate, dedup,
+	# log rotation, or any side-effecting stage.
+	if [[ "${PULSE_CANARY_MODE:-0}" == "1" ]]; then
+		printf 'canary: ok (sourcing + _pulse_handle_self_check + acquire_instance_lock passed)\n'
 		return 0
 	fi
 

--- a/.agents/scripts/tests/test-pulse-wrapper-canary.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-canary.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Canary test for pulse-wrapper.sh main() runtime execution (GH#18790).
+#
+# Purpose: Catch set -e exit-code propagation regressions (GH#18770 class)
+# that static analysis cannot detect. The test actually runs pulse-wrapper.sh
+# under bash -e and asserts it reaches a known checkpoint without crashing.
+#
+# What is exercised:
+#   1. Script sourcing under set -euo pipefail (all top-level declarations)
+#   2. _pulse_handle_self_check — the exact function GH#18770 broke
+#      (returned non-zero under normal operation, killing the script via set -e)
+#   3. acquire_instance_lock — the next downstream function
+#
+# What is NOT exercised (to keep the test fast and side-effect-free):
+#   - check_session_gate, check_dedup (skipped via --canary short-circuit)
+#   - Preflight stages, merge pass, LLM supervisor, worker dispatch
+#   - Any GitHub API calls
+#
+# Regression verification:
+#   Against the pre-GH#18770 fix (PR #18712), this test would have failed with
+#   exit 2 — the "not a self-check invocation" signal from
+#   _pulse_handle_self_check propagated through the unchecked pattern
+#   `_sc_rc=$?` and killed the script before main() could continue.
+#
+# See also:
+#   - test-pulse-wrapper-headless-export.sh  (AIDEVOPS_HEADLESS scoping)
+#   - test-pulse-systemd-timeout.sh          (grep-based unit-file checks)
+#   - .agents/reference/bash-compat.md       (pre-merge checklist item 4)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+WRAPPER_SCRIPT="${SCRIPT_DIR}/../pulse-wrapper.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+# Test 1: pulse-wrapper.sh --canary exits 0 in a sandboxed HOME.
+#
+# This is the core regression guard. If _pulse_handle_self_check returns
+# non-zero under set -e and the call site does not use `|| _sc_rc=$?` to
+# capture the code, the script dies at the call site and this test fails.
+#
+# Sandbox rationale: acquire_instance_lock writes to $HOME/.aidevops/run/.
+# A sandboxed HOME prevents lock directory collisions with a live pulse and
+# ensures the test is fully isolated.
+test_canary_exits_zero() {
+	local sandbox rc output
+	sandbox=$(mktemp -d)
+	mkdir -p "${sandbox}/home"
+
+	output=$(
+		HOME="${sandbox}/home" \
+			FULL_LOOP_HEADLESS=1 \
+			timeout 30 bash "$WRAPPER_SCRIPT" --canary 2>&1
+	)
+	rc=$?
+	rm -rf "$sandbox"
+
+	if [[ "$rc" -eq 0 ]]; then
+		print_result "--canary exits 0 (sourcing + self-check + lock passed)" 0
+		return 0
+	fi
+	print_result "--canary exits 0 (sourcing + self-check + lock passed)" 1 \
+		"Expected exit 0, got $rc. Output: ${output}"
+	return 0
+}
+
+# Test 2: --canary prints the expected checkpoint line.
+#
+# Confirms the short-circuit fires at the right point in main() — after
+# acquire_instance_lock, before check_session_gate. If the checkpoint line is
+# absent the canary exited early (e.g. via --self-check handling) or the
+# printf was removed.
+test_canary_prints_checkpoint() {
+	local sandbox rc output
+	sandbox=$(mktemp -d)
+	mkdir -p "${sandbox}/home"
+
+	output=$(
+		HOME="${sandbox}/home" \
+			FULL_LOOP_HEADLESS=1 \
+			timeout 30 bash "$WRAPPER_SCRIPT" --canary 2>&1
+	)
+	rc=$?
+	rm -rf "$sandbox"
+
+	if printf '%s' "$output" | grep -q "^canary: ok"; then
+		print_result "--canary prints 'canary: ok' checkpoint" 0
+		return 0
+	fi
+	print_result "--canary prints 'canary: ok' checkpoint" 1 \
+		"Expected line starting with 'canary: ok'. Exit $rc. Output: ${output}"
+	return 0
+}
+
+# Test 3: Static check — _pulse_setup_canary_mode function exists in the wrapper.
+#
+# Guards against the function being accidentally removed during refactoring.
+# Catches the regression before runtime.
+test_canary_function_exists() {
+	if grep -q "^_pulse_setup_canary_mode()" "$WRAPPER_SCRIPT"; then
+		print_result "_pulse_setup_canary_mode() defined in pulse-wrapper.sh" 0
+		return 0
+	fi
+	print_result "_pulse_setup_canary_mode() defined in pulse-wrapper.sh" 1 \
+		"Function _pulse_setup_canary_mode() not found in $WRAPPER_SCRIPT"
+	return 0
+}
+
+# Test 4: Static check — --canary short-circuit is AFTER acquire_instance_lock.
+#
+# The canary must exercise acquire_instance_lock to be useful. If the
+# short-circuit is accidentally moved before the lock acquisition, the test
+# would still pass but would no longer catch lock-related regressions.
+test_canary_short_circuit_after_lock() {
+	local lock_line canary_line
+	lock_line=$(grep -n "if ! acquire_instance_lock" "$WRAPPER_SCRIPT" | head -1 | cut -d: -f1)
+	canary_line=$(grep -n 'PULSE_CANARY_MODE:-0.*== "1"' "$WRAPPER_SCRIPT" | head -1 | cut -d: -f1)
+
+	if [[ -z "$lock_line" || -z "$canary_line" ]]; then
+		print_result "canary short-circuit is after acquire_instance_lock" 1 \
+			"Could not find lock_line=${lock_line:-<missing>} or canary_line=${canary_line:-<missing>}"
+		return 0
+	fi
+
+	if [[ "$canary_line" -gt "$lock_line" ]]; then
+		print_result "canary short-circuit is after acquire_instance_lock" 0
+		return 0
+	fi
+	print_result "canary short-circuit is after acquire_instance_lock" 1 \
+		"canary short-circuit at line $canary_line is BEFORE acquire_instance_lock at line $lock_line"
+	return 0
+}
+
+main_test() {
+	test_canary_exits_zero
+	test_canary_prints_checkpoint
+	test_canary_function_exists
+	test_canary_short_circuit_after_lock
+
+	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main_test "$@"

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -300,6 +300,12 @@ jobs:
         bash .agents/scripts/stats-wrapper.sh --self-check
         echo "Stats characterization tests passed"
 
+    - name: Pulse Wrapper Canary (GH#18790)
+      run: |
+        echo "Running pulse-wrapper.sh canary test (catches set -e regression class GH#18770)..."
+        bash .agents/scripts/tests/test-pulse-wrapper-canary.sh
+        echo "Pulse wrapper canary test passed"
+
   complexity-check:
     # IMPORTANT: This job's `name:` is a required status check on main (GH#18393).
     # Renaming it requires updating branch protection: gh api -X PATCH


### PR DESCRIPTION
## Summary

Adds a `--canary` mode to `pulse-wrapper.sh` and a companion test that catches the `set -e` exit-code propagation regression class (GH#18770) that static analysis cannot detect.

The GH#18770 regression (`_pulse_handle_self_check` returning non-zero under normal operation, killing the pulse via `set -e` on every launchd restart for 27 hours) was invisible to ShellCheck, SonarCloud, CodeRabbit, and the existing grep-based test suite. The only way to catch this class of bug is to **actually run the script**.

## Changes

- **`pulse-wrapper.sh`**: Add `_pulse_setup_canary_mode()` helper and `--canary` short-circuit in `main()` after `acquire_instance_lock` (before `check_session_gate`). The canary exercises sourcing, `_pulse_handle_self_check`, and `acquire_instance_lock` under `set -euo pipefail`, then exits 0 without entering the pulse loop or making any GitHub API calls.

- **`tests/test-pulse-wrapper-canary.sh`**: 4 tests — runtime exit 0 in sandboxed `HOME` (30s timeout), checkpoint line present, `_pulse_setup_canary_mode()` function exists, and canary short-circuit is after `acquire_instance_lock`.

- **`.github/workflows/code-quality.yml`**: Add `Pulse Wrapper Canary (GH#18790)` CI step to the existing quality job.

- **`linters-local.sh`**: Add `check_pulse_canary()` gated by `pulse-canary` gate for pre-push developer execution.

## Verification

```
bash .agents/scripts/tests/test-pulse-wrapper-canary.sh
# PASS --canary exits 0 (sourcing + self-check + lock passed)
# PASS --canary prints 'canary: ok' checkpoint
# PASS _pulse_setup_canary_mode() defined in pulse-wrapper.sh
# PASS canary short-circuit is after acquire_instance_lock
# Ran 4 tests, 0 failed.
```

ShellCheck zero violations on all 3 modified shell files.

## New File Smell Justification

`test-pulse-wrapper-canary.sh` is a test file (`tests/` directory) excluded from the qlty smell gate by the eligibility filter in `qlty-new-file-gate.yml`.

Resolves #18790