### PR TITLE
GH#18994: bump NESTING_DEPTH_THRESHOLD 275→281 to restore headroom

### DIFF
--- a/.agents/configs/complexity-thresholds-history.md
+++ b/.agents/configs/complexity-thresholds-history.md
@@ -52,6 +52,8 @@ Archives the full change history for `.agents/configs/complexity-thresholds.conf
 | 279 | GH#18912 | violations at threshold 272/272 (0 headroom); 272 violations + 7 headroom = 279; proximity guard (warn_at = 279-5 = 274) fires when violations exceed 274 (i.e., at 275), preventing saturation |
 | 274 | GH#18928 | ratcheted down — actual violations 272 + 2 buffer |
 | 279 | GH#18938 | proximity guard firing at 272/274 (2 headroom); 272 violations + 7 headroom = 279; proximity guard (warn_at = 279-5 = 274) fires when violations exceed 274 (i.e., at 275), preventing saturation |
+| 275 | GH#18949 | ratcheted down — actual violations 273 + 2 buffer |
+| 281 | GH#18994 | proximity guard firing at 274/275 (1 headroom); 274 violations + 7 headroom = 281; proximity guard (warn_at = 281-5 = 276) fires when violations exceed 276 (i.e., at 277), preventing saturation |
 
 ## FUNCTION_COMPLEXITY_THRESHOLD History
 

--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -95,7 +95,9 @@ FUNCTION_COMPLEXITY_THRESHOLD=26
 # Bumped to 279 (GH#18938): proximity guard firing at 272/274 (2 headroom); 272 violations + 7 headroom = 279.
 # Proximity guard (warn_at = 279-5 = 274) fires when violations exceed 274 (i.e., at 275), preventing saturation.
 # Ratcheted down to 275 (GH#18949): actual violations 273 + 2 buffer
-NESTING_DEPTH_THRESHOLD=275
+# Bumped to 281 (GH#18994): proximity guard firing at 274/275 (1 headroom); 274 violations + 7 headroom = 281.
+# Proximity guard (warn_at = 281-5 = 276) fires when violations exceed 276 (i.e., at 277), preventing saturation.
+NESTING_DEPTH_THRESHOLD=281
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Bump `NESTING_DEPTH_THRESHOLD` from 275 to 281 to restore adequate headroom after the proximity guard fired at 274/275 (1 headroom remaining).

- **Current violations**: 274 (verified by local scan)
- **Old threshold**: 275 (1 headroom)
- **New threshold**: 281 (7 headroom)
- **Proximity guard** (warn_at = 276) fires when violations exceed 276 (i.e., at 277), preventing saturation before CI threshold is hit

Also adds the missing GH#18949 entry to `complexity-thresholds-history.md` (ratcheted down to 275 — was documented in `.conf` comments but omitted from the table).

## Files changed

- EDIT: `.agents/configs/complexity-thresholds.conf:98-100` — bump value + add comment
- EDIT: `.agents/configs/complexity-thresholds-history.md:55-56` — add GH#18949 and GH#18994 rows

## Verification

```
THRESHOLD=281, violations=274, headroom=7 → PASS: within threshold
```

Resolves #18994