### PR TITLE
GH#18978: fix(gh-failure-miner): exclude signature_not_fetched from systemic clusters

### DIFF
--- a/.agents/scripts/gh-failure-miner-helper.sh
+++ b/.agents/scripts/gh-failure-miner-helper.sh
@@ -455,19 +455,38 @@ emit_event_json() {
 # The exclusion list uses substring matching so minor name variations are still caught.
 filter_failed_check_runs() {
 	local checks_json="$1"
-	printf '%s\n' "$checks_json" | jq '[.check_runs[] | select(
-		(
-			((.conclusion // "" | ascii_downcase) as $c |
-				["failure","cancelled","timed_out","startup_failure"] | index($c))
-			or
-			((.conclusion // "" | ascii_downcase) == "action_required"
-				and (.app.slug // "" | ascii_downcase) == "github-actions")
+	# Select failed/cancelled check runs, then deduplicate cancelled-only groups by name.
+	# When cancel-in-progress: true fires on multiple rapid events (label changes, synchronize),
+	# GitHub records N identical cancelled check runs for the same commit — one per workflow
+	# trigger. Without deduplication they exhaust the log-fetch budget (max_run_logs) and cause
+	# subsequent genuine failures to emit "signature_not_fetched" clusters. (GH#18978)
+	printf '%s\n' "$checks_json" | jq '
+		[.check_runs[] | select(
+			(
+				((.conclusion // "" | ascii_downcase) as $c |
+					["failure","cancelled","timed_out","startup_failure"] | index($c))
+				or
+				((.conclusion // "" | ascii_downcase) == "action_required"
+					and (.app.slug // "" | ascii_downcase) == "github-actions")
+			)
+			and
+			# Exclude policy gate checks — these fail by design when policy is not met,
+			# not because of a tooling defect. (GH#17831)
+			((.name // "") | ascii_downcase | test("maintainer.*review|maintainer.*gate|assignee.*gate") | not)
+		)]
+		# Deduplicate: for each check name where EVERY entry is cancelled (i.e. the job
+		# never ran in any attempt), keep only the latest-completed entry. This collapses
+		# N rapid-cancellation duplicates into one, preventing budget exhaustion.
+		| group_by(.name)
+		| map(
+			if all(.conclusion == "cancelled") and length > 1 then
+				[sort_by(.completed_at // "") | last]
+			else
+				.
+			end
 		)
-		and
-		# Exclude policy gate checks — these fail by design when policy is not met,
-		# not because of a tooling defect. (GH#17831)
-		((.name // "") | ascii_downcase | test("maintainer.*review|maintainer.*gate|assignee.*gate") | not)
-	)]'
+		| add // []
+	'
 	return 0
 }
 
@@ -503,7 +522,12 @@ process_failed_runs() {
 
 		local signature
 		signature=$(resolve_check_signature "$run_json" "$run_id" "$repo_slug" "$include_logs" "$run_logs_checked" "$max_run_logs")
-		if [[ "$include_logs" == "true" ]] && [[ -n "$run_id" ]] && [[ "$run_logs_checked" -lt "$max_run_logs" ]]; then
+		# Only charge the log-fetch budget when a real log fetch was attempted.
+		# job_not_started (0-step cancelled jobs) and billing_outage (annotation-detected,
+		# no gh run view call) both short-circuit before fetching any logs — counting them
+		# exhausts the budget for genuine failures in other PRs. (GH#18978)
+		if [[ "$include_logs" == "true" ]] && [[ -n "$run_id" ]] && [[ "$run_logs_checked" -lt "$max_run_logs" ]] &&
+			[[ "$signature" != "job_not_started" ]] && [[ "$signature" != "billing_outage" ]]; then
 			run_logs_checked=$((run_logs_checked + 1))
 		fi
 
@@ -930,13 +954,17 @@ create_systemic_issues() {
 	done <<<"$infra_repos"
 
 	# --- Code-defect cluster pass ---
-	# Only process non-infra clusters. Exclude billing/job_not_started signatures.
+	# Only process non-infra clusters. Exclude known sentinel / expected-behaviour signatures:
+	# - "billing_outage": GitHub Actions billing exhausted — infrastructure, not code defect.
+	# - "job_not_started": job cancelled before any step ran (cancel-in-progress: true race).
+	# - "signature_not_fetched": log fetch budget exhausted — internal sentinel, not a real
+	#   error signature. Treating it as systemic creates false-positive issues (GH#18978).
 	local candidate_file
 	candidate_file=$(mktemp)
 	printf '%s\n' "$clusters_json" | jq --argjson min_count "$systemic_threshold" '[.[] | select(
 		.count >= $min_count
 		and (.is_infra // false) == false
-		and ((.signature // "") as $signature | ["billing_outage","job_not_started"] | index($signature) | not)
+		and ((.signature // "") as $signature | ["billing_outage","job_not_started","signature_not_fetched"] | index($signature) | not)
 	)]' >"$candidate_file"
 
 	local candidate_count


### PR DESCRIPTION
## Summary

Fixes the false-positive systemic cluster issues caused by `signature_not_fetched` being treated as a real CI failure signature.

**Root cause**: The `signature_not_fetched` value is an *internal sentinel* in `gh-failure-miner-helper.sh` returned when the log-fetch budget (`max_run_logs`) is exhausted. When `cancel-in-progress: true` fires on N rapid events (label changes, synchronize on the same commit), GitHub records N identical cancelled check runs. Without deduplication, these exhaust the budget for genuine failures — causing subsequent real failures to be recorded with the `signature_not_fetched` sentinel, which then appears to cluster systemically.

## Changes

**`.agents/scripts/gh-failure-miner-helper.sh`**:

1. **`filter_failed_check_runs()`**: Added deduplication of cancelled-only check groups by name. When every entry for a given check name is cancelled (i.e. the job never ran in any attempt), keeps only the latest-completed entry. This collapses N rapid-cancellation duplicates into one, preventing budget exhaustion.

2. **`process_failed_runs()`**: Log-fetch budget counter is no longer charged for `job_not_started` or `billing_outage` signatures — both short-circuit before issuing any `gh run view` call.

3. **`create_systemic_issues()`**: Added `signature_not_fetched` to the sentinel exclusion list alongside `billing_outage` and `job_not_started`.

## Verification

- ShellCheck: zero violations
- All three changes are targeted and minimal — no logic changes to the happy path
- The previous attempt (PR #18988) was closed due to merge conflicts; this is a clean re-implementation on the current main

Resolves #18978


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.30 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 4m and 10,871 tokens on this as a headless worker.