### PR TITLE
GH#18998: fix review-followup scanner to skip empty bot reviews

### DIFF
--- a/.agents/scripts/pulse-ancillary-dispatch.sh
+++ b/.agents/scripts/pulse-ancillary-dispatch.sh
@@ -641,11 +641,41 @@ _extract_and_post_triage_review() {
 				printf 'POSTED\n'
 			fi
 		elif [[ "$has_infra_markers" == "true" ]]; then
-			# No review header AND infra markers present — raw sandbox output
-			echo "[pulse-wrapper] SECURITY: triage review for #${issue_num} was raw sandbox output — suppressed (${#review_text} chars)" >>"$LOGFILE"
-			_log_suppressed_triage_output "$issue_num" "$repo_slug" \
-				"raw-sandbox-output" "$output_chars" "$raw_sample"
-			printf 'FAILED:raw-sandbox-output\n'
+			# No ## Review header found in the extracted text, but infra markers ARE present.
+			# GH#18998: Before classifying as raw-sandbox-output, check if the first
+			# non-empty line of review_text is a valid ## Review: header. This handles
+			# the case where the worker correctly starts its response with "## Review: Decline"
+			# but surrounding log lines (timing, exec metadata) confuse the sed extraction
+			# (e.g., CRLF endings, BOM prefix, or the JSON extractor emitting raw content).
+			# If the first non-empty line IS a valid header, re-extract from that line and
+			# post it — the infra tokens in the preamble do not invalidate a valid review.
+			local first_nonempty_line=""
+			first_nonempty_line=$(printf '%s' "$review_text" | grep -m1 '[^[:space:]]' 2>/dev/null) || first_nonempty_line=""
+			local header_first_review=""
+			if printf '%s' "$first_nonempty_line" | grep -qE '^## Review:'; then
+				# Valid ## Review: header is the first non-empty line — extract from it
+				header_first_review=$(printf '%s' "$review_text" | sed -n '/^## Review:/,$ p')
+			fi
+			if [[ -n "$header_first_review" ]]; then
+				# Belt-and-suspenders: re-check only the extracted portion for infra leaks
+				if echo "$header_first_review" | grep -qE '\[SANDBOX\]|\[INFO\] Executing|timeout=[0-9]+s|network_blocked=|sandbox-exec-helper'; then
+					echo "[pulse-wrapper] SECURITY: triage review for #${issue_num} header-first but extracted review still contains infra markers — suppressed" >>"$LOGFILE"
+					_log_suppressed_triage_output "$issue_num" "$repo_slug" \
+						"infra-markers-after-extraction" "$output_chars" "$raw_sample"
+					printf 'FAILED:infra-markers-after-extraction\n'
+				else
+					gh issue comment "$issue_num" --repo "$repo_slug" \
+						--body "$header_first_review" >/dev/null 2>&1 || true
+					echo "[pulse-wrapper] Posted header-first triage review for #${issue_num} in ${repo_slug} (${output_chars} chars, GH#18998 path)" >>"$LOGFILE"
+					printf 'POSTED\n'
+				fi
+			else
+				# No review header AND infra markers present — raw sandbox output
+				echo "[pulse-wrapper] SECURITY: triage review for #${issue_num} was raw sandbox output — suppressed (${#review_text} chars)" >>"$LOGFILE"
+				_log_suppressed_triage_output "$issue_num" "$repo_slug" \
+					"raw-sandbox-output" "$output_chars" "$raw_sample"
+				printf 'FAILED:raw-sandbox-output\n'
+			fi
 		else
 			echo "[pulse-wrapper] Triage review for #${issue_num} had no review header (## *Review*) and no infra markers — suppressed to be safe (${#review_text} chars extracted / ${raw_output_chars} raw)" >>"$LOGFILE"
 			_log_suppressed_triage_output "$issue_num" "$repo_slug" \

--- a/.agents/scripts/quality-feedback-findings-lib.sh
+++ b/.agents/scripts/quality-feedback-findings-lib.sh
@@ -369,6 +369,44 @@ _scan_single_pr() {
 		from_entries
 	') || inline_counts_json="{}"
 
+	# GH#18998: PR-level empty-review guard — bail out early when the PR has
+	# zero inline comments from ANY reviewer AND every review body matches a
+	# negative-finding phrase. This prevents noise issues from "no feedback"
+	# bot summaries that survive the per-reviewer summary_only filter (e.g.,
+	# when state=APPROVED instead of COMMENTED, or when the bot login does not
+	# match the reviewer regex but the body is clearly "no feedback").
+	# When --include-positive is set, this guard is bypassed for debugging.
+	if [[ "$include_positive" != "true" ]]; then
+		local total_inline_count
+		total_inline_count=$(printf '%s' "$comments" | jq 'length') || total_inline_count=0
+
+		if [[ "$total_inline_count" -eq 0 ]]; then
+			local all_negative
+			all_negative=$(printf '%s' "$reviews" | jq '
+				if length == 0 then true
+				else
+					[.[] |
+					select(.body != null and (.body | length) > 0) |
+					.body |
+					test(
+						"no feedback|no review comments|no issues found|lgtm|looks good to me|" +
+						"nothing to flag|no further|no comments|nothing actionable|" +
+						"i have no (feedback|issues|comments|concerns)|" +
+						"no (issues|problems|concerns|suggestions|recommendations) (found|detected|identified)|" +
+						"(found|identified|detected) no (issues|problems|concerns|suggestions)";
+						"i")
+					] | all
+				end
+			') || all_negative="false"
+
+			if [[ "$all_negative" == "true" ]]; then
+				echo "[quality-feedback] skip: empty-review PR#${pr_num} in ${repo_slug} (0 inline comments, all summaries negative)" >&2
+				echo "[]"
+				return 0
+			fi
+		fi
+	fi
+
 	# Process review bodies (for substantive reviews with body content)
 	local review_findings
 	review_findings=$(_build_review_findings \

--- a/.agents/scripts/tests/test-quality-feedback-main-verification.sh
+++ b/.agents/scripts/tests/test-quality-feedback-main-verification.sh
@@ -1703,6 +1703,232 @@ test_scan_single_pr_filters_pr5637_merge_comment() {
 	return 0
 }
 
+# GH#18998: Empty-review guard — Gemini "no feedback" summary with no inline
+# comments should produce zero findings (fixture: issue #18834 incident).
+test_empty_review_guard_gemini_no_feedback() {
+	reset_mock_state
+
+	gh() {
+		local command="$1"
+		shift
+		case "$command" in
+		api)
+			while [[ $# -gt 0 ]]; do
+				case "$1" in
+				repos/*/pulls/*/comments)
+					# Zero inline file comments on this PR
+					echo "[]"
+					return 0
+					;;
+				repos/*/pulls/*/reviews)
+					# Gemini APPROVED review stating explicitly "no feedback"
+					echo '[{"id":1,"user":{"login":"gemini-code-assist[bot]"},"state":"APPROVED","body":"I have no feedback to provide as there were no review comments on this pull request.","submitted_at":"2024-01-01T00:00:00Z","html_url":"https://github.com/example/repo/pull/1#pullrequestreview-1"}]'
+					return 0
+					;;
+				repos/*/git/trees/*)
+					echo '{"tree":[]}'
+					return 0
+					;;
+				repos/*)
+					echo "main"
+					return 0
+					;;
+				esac
+				shift
+			done
+			echo "[]"
+			return 0
+			;;
+		label | pr) return 0 ;;
+		esac
+		echo "[]"
+		return 0
+	}
+
+	local findings
+	findings=$(_scan_single_pr "owner/repo" "1" "medium" "false" 2>/dev/null)
+	local count
+	count=$(printf '%s' "$findings" | jq 'length' 2>/dev/null || echo "0")
+
+	if [[ "$count" -eq 0 ]]; then
+		print_result "GH#18998: Gemini 'no feedback' APPROVED review with 0 inline comments → 0 findings" 0
+	else
+		print_result "GH#18998: Gemini 'no feedback' APPROVED review with 0 inline comments → 0 findings" 1 \
+			"expected 0 findings, got ${count} — would have filed false-positive issue (GH#18834 regression)"
+	fi
+
+	gh() {
+		local command="$1"
+		shift
+		case "$command" in
+		api)
+			_mock_gh_api "$@"
+			return $?
+			;;
+		label) return 0 ;;
+		issue)
+			_mock_gh_issue "$@"
+			return $?
+			;;
+		esac
+		echo "unexpected gh call: ${command}" >&2
+		return 1
+	}
+	return 0
+}
+
+# GH#18998: Multiple bots all say "no issues" with zero inline comments → 0 findings
+test_empty_review_guard_skips_when_all_summaries_negative() {
+	reset_mock_state
+
+	gh() {
+		local command="$1"
+		shift
+		case "$command" in
+		api)
+			while [[ $# -gt 0 ]]; do
+				case "$1" in
+				repos/*/pulls/*/comments)
+					echo "[]"
+					return 0
+					;;
+				repos/*/pulls/*/reviews)
+					echo '[
+						{"id":1,"user":{"login":"gemini-code-assist[bot]"},"state":"APPROVED","body":"I have no feedback to provide as there were no review comments.","submitted_at":"2024-01-01T00:00:00Z","html_url":"https://github.com/example/repo/pull/1#r1"},
+						{"id":2,"user":{"login":"coderabbitai[bot]"},"state":"COMMENTED","body":"No issues found. LGTM!","submitted_at":"2024-01-01T00:00:01Z","html_url":"https://github.com/example/repo/pull/1#r2"}
+					]'
+					return 0
+					;;
+				repos/*/git/trees/*)
+					echo '{"tree":[]}'
+					return 0
+					;;
+				repos/*)
+					echo "main"
+					return 0
+					;;
+				esac
+				shift
+			done
+			echo "[]"
+			return 0
+			;;
+		label | pr) return 0 ;;
+		esac
+		echo "[]"
+		return 0
+	}
+
+	local findings
+	findings=$(_scan_single_pr "owner/repo" "1" "medium" "false" 2>/dev/null)
+	local count
+	count=$(printf '%s' "$findings" | jq 'length' 2>/dev/null || echo "0")
+
+	if [[ "$count" -eq 0 ]]; then
+		print_result "GH#18998: All bot summaries negative, 0 inline comments → 0 findings" 0
+	else
+		print_result "GH#18998: All bot summaries negative, 0 inline comments → 0 findings" 1 \
+			"expected 0 findings, got ${count} — GH#18998 empty-review guard not firing"
+	fi
+
+	gh() {
+		local command="$1"
+		shift
+		case "$command" in
+		api)
+			_mock_gh_api "$@"
+			return $?
+			;;
+		label) return 0 ;;
+		issue)
+			_mock_gh_issue "$@"
+			return $?
+			;;
+		esac
+		echo "unexpected gh call: ${command}" >&2
+		return 1
+	}
+	return 0
+}
+
+# GH#18998: Negative summary review + inline comments → guard must NOT fire
+# (inline comments may have actionable findings even if top-level summary is "LGTM").
+test_empty_review_guard_does_not_skip_with_inline_comments() {
+	reset_mock_state
+
+	gh() {
+		local command="$1"
+		shift
+		case "$command" in
+		api)
+			while [[ $# -gt 0 ]]; do
+				case "$1" in
+				repos/*/pulls/*/comments)
+					# One inline comment with an actionable finding
+					# Note: "line" field required to pass the resolved-comment filter
+					# in _build_inline_findings (select .position or .line or .original_line)
+					echo '[{"id":1,"user":{"login":"coderabbitai[bot]"},"path":"src/foo.sh","line":10,"body":"**Medium:** This function should validate its input before use.","created_at":"2024-01-01T00:00:00Z","html_url":"https://github.com/example/repo/pull/1#r1"}]'
+					return 0
+					;;
+				repos/*/pulls/*/reviews)
+					# Top-level summary says "no issues" but inline comment has finding
+					echo '[{"id":1,"user":{"login":"coderabbitai[bot]"},"state":"COMMENTED","body":"LGTM! No issues found.","submitted_at":"2024-01-01T00:00:00Z","html_url":"https://github.com/example/repo/pull/1#r1"}]'
+					return 0
+					;;
+				repos/*/git/trees/*)
+					# Return the jq-filtered result directly (--jq '[.tree[].path]'
+					# is stripped by the mock, so return what gh api would have output)
+					echo '["src/foo.sh"]'
+					return 0
+					;;
+				repos/*)
+					echo "main"
+					return 0
+					;;
+				esac
+				shift
+			done
+			echo "[]"
+			return 0
+			;;
+		label | pr) return 0 ;;
+		esac
+		echo "[]"
+		return 0
+	}
+
+	local findings
+	findings=$(_scan_single_pr "owner/repo" "1" "medium" "false" 2>/dev/null)
+	local count
+	count=$(printf '%s' "$findings" | jq 'length' 2>/dev/null || echo "0")
+
+	if [[ "$count" -gt 0 ]]; then
+		print_result "GH#18998: Negative top-level summary + inline comments → findings kept (guard does not fire)" 0
+	else
+		print_result "GH#18998: Negative top-level summary + inline comments → findings kept (guard does not fire)" 1 \
+			"expected >0 findings (inline comment should be kept), got ${count} — guard over-firing"
+	fi
+
+	gh() {
+		local command="$1"
+		shift
+		case "$command" in
+		api)
+			_mock_gh_api "$@"
+			return $?
+			;;
+		label) return 0 ;;
+		issue)
+			_mock_gh_issue "$@"
+			return $?
+			;;
+		esac
+		echo "unexpected gh call: ${command}" >&2
+		return 1
+	}
+	return 0
+}
+
 main() {
 	source "$HELPER"
 
@@ -1767,6 +1993,12 @@ main() {
 	test_skips_pr5637_pulse_supervisor_merge_comment
 	test_keeps_human_changes_requested_review_gh5668
 	test_scan_single_pr_filters_pr5637_merge_comment
+
+	echo ""
+	echo "Running empty-review guard tests (GH#18998)"
+	test_empty_review_guard_gemini_no_feedback
+	test_empty_review_guard_skips_when_all_summaries_negative
+	test_empty_review_guard_does_not_skip_with_inline_comments
 
 	echo "Results: ${TESTS_PASSED}/${TESTS_RUN} passed, ${TESTS_FAILED} failed"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Fixes two related issues that create noise in the review-followup pipeline:

1. **Empty-review guard** (`quality-feedback-findings-lib.sh`): the scanner fires on PRs where bots post "no feedback" summaries with zero actionable inline comments, creating false-positive quality-debt issues (incident: GH#18834).

2. **raw-sandbox-output over-suppression** (`pulse-ancillary-dispatch.sh`): a triage worker's valid `## Review: Decline` header was suppressed as `raw-sandbox-output` because surrounding log lines confused the sed extraction, preventing the closing comment from being posted.

## Changes

### Fix 1 — PR-level empty-review guard in `_scan_single_pr`

Adds a check AFTER computing `inline_counts_json`: if total inline comment count across all reviewers is 0 **and** every review body matches a negative-finding regex (`no feedback|no review comments|no issues found|lgtm|looks good to me|nothing to flag|...`), return `[]` immediately with a `skip: empty-review PR#N` log line.

- Bypassed when `--include-positive` is set (debugging mode)
- Belt-and-suspenders: the existing per-reviewer `summary_only` filter still runs; this guard catches the case where `state=APPROVED` (not `COMMENTED`) slips through

### Fix 2 — Tighten `raw-sandbox-output` classification

Before classifying as `raw-sandbox-output` (no `## Review` header + infra markers), check if the first non-empty line of `review_text` is `^## Review:`. If it is, re-extract from that line and post (with the normal post-extraction infra check). This handles encoding quirks (CRLF, BOM, raw-mode output) that prevent the existing sed pattern from matching.

## Testing

- 3 new unit tests in `test-quality-feedback-main-verification.sh`:
  - Gemini APPROVED `"no feedback"` + 0 inline comments → 0 findings (GH#18834 regression)
  - Multiple bots all negative + 0 inline → 0 findings
  - Negative top-level summary + inline comments → guard does **not** fire (no over-suppression)
- All 3 pass; only pre-existing `transient API error` test still fails (unrelated, pre-dated this PR)
- ShellCheck: zero violations on all 3 modified files

Resolves #18998

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved review extraction handling for edge cases with better recovery logic.
  * Enhanced efficiency by skipping processing for pull requests with no actionable feedback.

* **Tests**
  * Added integration tests for review extraction and filtering edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->