### PR TITLE
GH#19003: bump NESTING_DEPTH_THRESHOLD 281→284 to restore headroom

### DIFF
--- a/.agents/configs/complexity-thresholds-history.md
+++ b/.agents/configs/complexity-thresholds-history.md
@@ -54,6 +54,7 @@ Archives the full change history for `.agents/configs/complexity-thresholds.conf
 | 279 | GH#18938 | proximity guard firing at 272/274 (2 headroom); 272 violations + 7 headroom = 279; proximity guard (warn_at = 279-5 = 274) fires when violations exceed 274 (i.e., at 275), preventing saturation |
 | 275 | GH#18949 | ratcheted down — actual violations 273 + 2 buffer |
 | 281 | GH#18994 | proximity guard firing at 274/275 (1 headroom); 274 violations + 7 headroom = 281; proximity guard (warn_at = 281-5 = 276) fires when violations exceed 276 (i.e., at 277), preventing saturation |
+| 284 | GH#19003 | proximity guard firing at 277/281 (4 headroom); 277 violations + 7 headroom = 284; proximity guard (warn_at = 284-5 = 279) fires when violations exceed 279 (i.e., at 280), preventing saturation |
 
 ## FUNCTION_COMPLEXITY_THRESHOLD History
 

--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -98,7 +98,9 @@ FUNCTION_COMPLEXITY_THRESHOLD=29
 # Ratcheted down to 275 (GH#18949): actual violations 273 + 2 buffer
 # Bumped to 281 (GH#18994): proximity guard firing at 274/275 (1 headroom); 274 violations + 7 headroom = 281.
 # Proximity guard (warn_at = 281-5 = 276) fires when violations exceed 276 (i.e., at 277), preventing saturation.
-NESTING_DEPTH_THRESHOLD=281
+# Bumped to 284 (GH#19003): proximity guard firing at 277/281 (4 headroom); 277 violations + 7 headroom = 284.
+# Proximity guard (warn_at = 284-5 = 279) fires when violations exceed 279 (i.e., at 280), preventing saturation.
+NESTING_DEPTH_THRESHOLD=284
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Bumps `NESTING_DEPTH_THRESHOLD` from 281 to 284 to restore adequate headroom after the proximity guard fired at 277/281 (4 headroom remaining).

- **Current violations**: 277 (verified locally via CI awk method)
- **Previous threshold**: 281
- **New threshold**: 284 (277 violations + 7 headroom)
- **New proximity guard fires at**: 280 violations (warn_at = 284 - 5 = 279)

The standard bump formula applies: `actual_violations + 7 = headroom`. This ensures the proximity guard fires before CI saturation on the next PR that adds nesting depth.

## Changes

- EDIT: `.agents/configs/complexity-thresholds.conf` — bump `NESTING_DEPTH_THRESHOLD` 281→284 with inline history comment
- EDIT: `.agents/configs/complexity-thresholds-history.md` — append audit trail entry for GH#19003

## Verification

```bash
grep NESTING_DEPTH_THRESHOLD .agents/configs/complexity-thresholds.conf
# Expected: NESTING_DEPTH_THRESHOLD=284
```

CI `Shell nesting depth` check will pass: 277 violations < 284 threshold.

Resolves #19003