### PR TITLE
GH#19015: chore: ratchet down NESTING_DEPTH_THRESHOLD 284→279 (GH#19015)

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -100,7 +100,8 @@ FUNCTION_COMPLEXITY_THRESHOLD=29
 # Proximity guard (warn_at = 281-5 = 276) fires when violations exceed 276 (i.e., at 277), preventing saturation.
 # Bumped to 284 (GH#19003): proximity guard firing at 277/281 (4 headroom); 277 violations + 7 headroom = 284.
 # Proximity guard (warn_at = 284-5 = 279) fires when violations exceed 279 (i.e., at 280), preventing saturation.
-NESTING_DEPTH_THRESHOLD=284
+# Ratcheted down to 279 (GH#19015): actual violations 277 + 2 buffer
+NESTING_DEPTH_THRESHOLD=279
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Lowered NESTING_DEPTH_THRESHOLD from 284 to 279 in .agents/configs/complexity-thresholds.conf. Actual violations: 277; new threshold: 277 + 2 buffer = 279. Added ratchet-down audit comment.

## Files Changed

.agents/configs/complexity-thresholds.conf

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** complexity-scan-helper.sh ratchet-check confirms nest:277 violations vs nest:279 threshold (2-unit gap, within buffer). simplification-state.json not staged.

Resolves #19015


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.30 plugin for [OpenCode](https://opencode.ai) v1.4.3 with claude-sonnet-4-6 spent 1m and 3,067 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined internal code quality validation standards to enforce stricter complexity thresholds in the continuous integration pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->