### PR TITLE
GH#19014: chore: ratchet down NESTING_DEPTH_THRESHOLD 284→279

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -100,7 +100,8 @@ FUNCTION_COMPLEXITY_THRESHOLD=29
 # Proximity guard (warn_at = 281-5 = 276) fires when violations exceed 276 (i.e., at 277), preventing saturation.
 # Bumped to 284 (GH#19003): proximity guard firing at 277/281 (4 headroom); 277 violations + 7 headroom = 284.
 # Proximity guard (warn_at = 284-5 = 279) fires when violations exceed 279 (i.e., at 280), preventing saturation.
-NESTING_DEPTH_THRESHOLD=284
+# Ratcheted down to 279 (GH#19014): actual violations 277 + 2 buffer
+NESTING_DEPTH_THRESHOLD=279
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Ratchet down `NESTING_DEPTH_THRESHOLD` from 284 to 279.

- Actual violations: 277
- New threshold: 277 + 2 buffer = 279
- Adds audit comment above the value per ratchet-down convention

## Changes

- EDIT: `.agents/configs/complexity-thresholds.conf` — lower `NESTING_DEPTH_THRESHOLD` from 284 to 279 and add ratchet-down audit comment

## Verification

```
grep 'NESTING_DEPTH_THRESHOLD' .agents/configs/complexity-thresholds.conf
# → NESTING_DEPTH_THRESHOLD=279
```

`.agents/configs/simplification-state.json` is NOT included in this PR (per worker guidance).

Resolves #19014