### PR TITLE
GH#19019: bump NESTING_DEPTH_THRESHOLD 279→284 to restore headroom

### DIFF
--- a/.agents/configs/complexity-thresholds-history.md
+++ b/.agents/configs/complexity-thresholds-history.md
@@ -55,6 +55,8 @@ Archives the full change history for `.agents/configs/complexity-thresholds.conf
 | 275 | GH#18949 | ratcheted down — actual violations 273 + 2 buffer |
 | 281 | GH#18994 | proximity guard firing at 274/275 (1 headroom); 274 violations + 7 headroom = 281; proximity guard (warn_at = 281-5 = 276) fires when violations exceed 276 (i.e., at 277), preventing saturation |
 | 284 | GH#19003 | proximity guard firing at 277/281 (4 headroom); 277 violations + 7 headroom = 284; proximity guard (warn_at = 284-5 = 279) fires when violations exceed 279 (i.e., at 280), preventing saturation |
+| 279 | GH#19015 | ratcheted down — actual violations 277 + 2 buffer |
+| 284 | GH#19019 | proximity guard firing at 277/279 (2 headroom); 277 violations + 7 headroom = 284; proximity guard (warn_at = 284-5 = 279) fires when violations exceed 279 (i.e., at 280), preventing saturation |
 
 ## FUNCTION_COMPLEXITY_THRESHOLD History
 

--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -101,7 +101,9 @@ FUNCTION_COMPLEXITY_THRESHOLD=29
 # Bumped to 284 (GH#19003): proximity guard firing at 277/281 (4 headroom); 277 violations + 7 headroom = 284.
 # Proximity guard (warn_at = 284-5 = 279) fires when violations exceed 279 (i.e., at 280), preventing saturation.
 # Ratcheted down to 279 (GH#19015): actual violations 277 + 2 buffer
-NESTING_DEPTH_THRESHOLD=279
+# Bumped to 284 (GH#19019): proximity guard firing at 277/279 (2 headroom); 277 violations + 7 headroom = 284.
+# Proximity guard (warn_at = 284-5 = 279) fires when violations exceed 279 (i.e., at 280), preventing saturation.
+NESTING_DEPTH_THRESHOLD=284
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Proximity guard fired at 277/279 (2 headroom remaining). Bumps `NESTING_DEPTH_THRESHOLD` from 279 to 284 following the established pattern: violations (277) + 7 headroom = 284.

**Changes:**
- `.agents/configs/complexity-thresholds.conf`: bump `NESTING_DEPTH_THRESHOLD` 279→284, add inline history entry for GH#19019, add missing GH#19015 ratchet comment
- `.agents/configs/complexity-thresholds-history.md`: add rows for GH#19015 ratchet-down (279) and GH#19019 bump (284)

**Verification:**
- Current violations confirmed: 277 (via CI awk method + `lint_shell_files()`)
- New threshold: 284
- New warn_at: 284-5 = 279 → guard fires when violations exceed 279 (at 280)
- Headroom restored: 7

**Testing:** CI `Shell nesting depth` check will pass with threshold=284 and 277 violations.

Resolves #19019