### PR TITLE
GH#18925: tighten brief composition templates prose

### DIFF
--- a/.agents/workflows/brief/templates.md
+++ b/.agents/workflows/brief/templates.md
@@ -7,7 +7,7 @@ Reference templates for GitHub-written content. Use `workflows/brief.md` for the
 
 ## Issue Body Template
 
-When creating issues via `gh issue create`, wrap the appropriate tier content in this structure:
+Wrap the appropriate tier content in this structure for `gh issue create`:
 
 ```markdown
 ## Description
@@ -36,13 +36,13 @@ When creating issues via `gh issue create`, wrap the appropriate tier content in
 
 Always include a tier label: `tier:simple`, `tier:standard`, or `tier:thinking`.
 
-**Why "Done When" matters:** Workers that lack a concrete completion signal exhibit two failure modes: (1) stop after setup/exploration without implementing anything (observed on #17642, #17643), or (2) stop after PR creation without merging or posting closing comments. "Done When" gives the model a checklist to drive toward instead of an open-ended goal.
+**Why "Done When" matters:** Workers without a concrete completion signal fail in two ways: (1) stop after exploration without implementing (#17642, #17643), or (2) stop after PR creation without completing closure steps (merge, closing comments). The checklist drives toward verified completion instead of an open-ended goal.
 
 ## Comment Templates
 
 ### Dispatch comment (pulse → worker)
 
-Use when the pulse dispatches a worker. Include enough context to avoid re-reading the full issue:
+For pulse-dispatched workers. Include enough context to avoid re-reading the full issue:
 
 ```markdown
 ## Dispatching: {issue_title}
@@ -62,7 +62,7 @@ _Dispatched by pulse at {timestamp}_
 
 ### Kill/timeout comment (watchdog → issue)
 
-Use when a worker is killed. Explain what happened and what the next worker should do differently:
+For killed workers. Explain what happened and guide the next attempt:
 
 ```markdown
 ## Worker killed: {reason}
@@ -92,7 +92,7 @@ See `templates/escalation-report-template.md`. Include:
 
 ## PR Description Template
 
-Workers creating PRs use this structure. It serves the review bot and the human reviewer.
+For all worker-created PRs. Serves review bots and human reviewers.
 
 ```markdown
 ## Summary


### PR DESCRIPTION
## Summary

- Tighten introductory prose in brief composition templates while preserving all institutional knowledge
- Incorporate review feedback from failed PR #18929 (CodeRabbit + Gemini): keep closing-comments failure mode, keep escalation numbered list, align "Done When" wording with checklist

## Changes

- `.agents/workflows/brief/templates.md` — compress 5 introductory sentences without removing issue refs (#17642, #17643), failure modes, or template structures

## Verification

- Content preservation: all code blocks, URLs, task ID references present before and after
- Qlty smells: 0 for target file
- No broken internal links or references
- Escalation list format retained (per Gemini review feedback)
- "closure steps (merge, closing comments)" wording addresses both CodeRabbit checklist-alignment and Gemini institutional-memory concerns

## Runtime Testing

- **Risk:** Low (docs-only change, no code logic)
- **Assessment:** self-assessed

Resolves #18925


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.30 plugin for [OpenCode](https://opencode.ai) v1.4.4 with claude-opus-4-6 spent 3m and 4,592 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Refined workflow template instructions for improved clarity and consistency in issue creation, task completion guidance, PR descriptions, and comment templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->