### PR TITLE
GH#19032: fix(pulse-merge) skip close on parent-task linked issues

### DIFF
--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -827,6 +827,29 @@ _Merged by deterministic merge pass (pulse-wrapper.sh). Neither MERGE_SUMMARY co
 
 	# Close linked issue with the same closing comment
 	if [[ -n "$linked_issue" ]]; then
+		# t2099 / GH#19032: parent-task close guard. Parent roadmap issues must
+		# stay open until ALL phase children merge (t2046). The PR-body keyword
+		# guard (parent-task-keyword-guard.sh) prevents workers from writing
+		# Closes/Resolves/Fixes against a parent, and they instead use
+		# "For #NNN" / "Ref #NNN". BUT `_extract_linked_issue` also falls back
+		# to matching `GH#NNN:` in the PR title — which is the canonical PR
+		# title format for parent-task phase PRs. Without this check, every
+		# phase PR would silently close its parent on merge.
+		#
+		# Behaviour:
+		#   - Still post the closing comment (it doubles as a phase-merged
+		#     status update on the parent).
+		#   - SKIP the `gh issue close` call.
+		#   - SKIP fast_fail_reset and unlock (both tied to closing).
+		local _parent_task_guard=0
+		local _linked_labels
+		_linked_labels=$(gh api "repos/${repo_slug}/issues/${linked_issue}" \
+			--jq '[.labels[].name] | join(",")' 2>/dev/null) || _linked_labels=""
+		if [[ ",${_linked_labels}," == *",parent-task,"* ]]; then
+			_parent_task_guard=1
+			echo "[pulse-wrapper] Deterministic merge: skipping close of parent-task issue #${linked_issue} (PR #${pr_number} is a phase child; parent stays open until all phases merge) — t2099/GH#19032" >>"$LOGFILE"
+		fi
+
 		# Dedup guard: skip if closing comment for this PR already exists (GH#18098).
 		local _dedup_count
 		_dedup_count=$(gh api "repos/${repo_slug}/issues/${linked_issue}/comments" \
@@ -839,11 +862,14 @@ _Merged by deterministic merge pass (pulse-wrapper.sh). Neither MERGE_SUMMARY co
 			gh issue comment "$linked_issue" --repo "$repo_slug" \
 				--body "$closing_comment" 2>/dev/null || true
 		fi
-		gh issue close "$linked_issue" --repo "$repo_slug" 2>/dev/null || true
-		# Reset fast-fail counter now that the issue is resolved (GH#2076)
-		fast_fail_reset "$linked_issue" "$repo_slug" || true
-		# t1934: Unlock the issue (locked at dispatch time)
-		unlock_issue_after_worker "$linked_issue" "$repo_slug"
+
+		if [[ "$_parent_task_guard" -eq 0 ]]; then
+			gh issue close "$linked_issue" --repo "$repo_slug" 2>/dev/null || true
+			# Reset fast-fail counter now that the issue is resolved (GH#2076)
+			fast_fail_reset "$linked_issue" "$repo_slug" || true
+			# t1934: Unlock the issue (locked at dispatch time)
+			unlock_issue_after_worker "$linked_issue" "$repo_slug"
+		fi
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-pulse-merge-parent-task-close-guard.sh
+++ b/.agents/scripts/tests/test-pulse-merge-parent-task-close-guard.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Tests for t2099 / GH#19032: pulse-merge.sh _handle_post_merge_actions
+# must NOT call `gh issue close` on linked issues that carry the
+# `parent-task` label. Phase-child PRs against parent-roadmap issues
+# (t2046) were silently closing their parents on merge because
+# _extract_linked_issue falls back to matching "GH#NNN:" in the PR title —
+# which is the canonical title format for every phase PR.
+#
+# Root cause: the t2046 parent-task-keyword-guard prevents the PR body
+# from containing Closes/Resolves/Fixes, but the deterministic merge pass
+# (pulse-merge.sh:_handle_post_merge_actions) closes the linked issue
+# unconditionally after posting the closing comment — there was no
+# parent-task label check on that path.
+#
+# Strategy: extract _handle_post_merge_actions from pulse-merge.sh,
+# eval it, and exercise it against a mock `gh` stub that records every
+# subcommand invocation. Assert that `gh issue close` is only called
+# when the linked issue is NOT parent-task.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+MERGE_SCRIPT="${SCRIPT_DIR}/../pulse-merge.sh"
+
+readonly TEST_RED=$'\033[0;31m'
+readonly TEST_GREEN=$'\033[0;32m'
+readonly TEST_RESET=$'\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%sPASS%s %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%sFAIL%s %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+# Prepare a mock `gh` that:
+#   - Returns the label set from $TEST_LINKED_LABELS when asked for issue metadata
+#   - Records every top-level gh invocation to $GH_CALL_LOG
+#   - Stays silent for everything else
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+	mkdir -p "${TEST_ROOT}/bin"
+	export PATH="${TEST_ROOT}/bin:${PATH}"
+	export LOGFILE="${TEST_ROOT}/pulse.log"
+	export GH_CALL_LOG="${TEST_ROOT}/gh-calls.log"
+	export TEST_LINKED_LABELS="parent-task,refactor"
+	: >"$LOGFILE"
+	: >"$GH_CALL_LOG"
+
+	cat >"${TEST_ROOT}/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+# Mock gh for test-pulse-merge-parent-task-close-guard.sh
+# Records every invocation and returns canned data for label queries.
+printf '%s\n' "$*" >>"${GH_CALL_LOG}"
+
+# gh api repos/OWNER/REPO/issues/NNN --jq '[.labels[].name] | join(",")'
+if [[ "$1" == "api" && "$*" == *"/issues/"* && "$*" == *"labels"* && "$*" != *"/comments"* ]]; then
+	printf '%s\n' "${TEST_LINKED_LABELS:-}"
+	exit 0
+fi
+
+# gh api repos/OWNER/REPO/issues/NNN/comments  (dedup check)
+if [[ "$1" == "api" && "$*" == *"/comments"* ]]; then
+	printf '[]\n'
+	exit 0
+fi
+
+# gh issue view/comment/close/pr comment — silent success
+exit 0
+EOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+
+	# Stub external helpers the function calls
+	unlock_issue_after_worker() { return 0; }
+	fast_fail_reset() { return 0; }
+	export -f unlock_issue_after_worker fast_fail_reset 2>/dev/null || true
+
+	# gh-signature-helper.sh is invoked via $_sig_helper — stub it to empty.
+	export AGENTS_DIR="${TEST_ROOT}"
+	mkdir -p "${AGENTS_DIR}/scripts"
+	cat >"${AGENTS_DIR}/scripts/gh-signature-helper.sh" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+	chmod +x "${AGENTS_DIR}/scripts/gh-signature-helper.sh"
+
+	export PULSE_START_EPOCH
+	PULSE_START_EPOCH=$(date +%s)
+	return 0
+}
+
+teardown_test_env() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+# Extract the function under test from pulse-merge.sh and eval it.
+define_function_under_test() {
+	local fn_src
+	fn_src=$(awk '
+		/^_handle_post_merge_actions\(\) \{/,/^}$/ { print }
+	' "$MERGE_SCRIPT")
+	if [[ -z "$fn_src" ]]; then
+		printf 'ERROR: could not extract _handle_post_merge_actions from %s\n' "$MERGE_SCRIPT" >&2
+		return 1
+	fi
+	# shellcheck disable=SC1090  # dynamic source from extracted helper
+	eval "$fn_src"
+	return 0
+}
+
+# Assert that the gh call log contains / does not contain a pattern.
+assert_gh_call_contains() {
+	local pattern="$1"
+	local label="$2"
+	if grep -q -- "$pattern" "$GH_CALL_LOG" 2>/dev/null; then
+		print_result "$label" 0
+	else
+		print_result "$label" 1 "Expected gh call matching: $pattern"
+	fi
+	return 0
+}
+
+assert_gh_call_not_contains() {
+	local pattern="$1"
+	local label="$2"
+	if grep -q -- "$pattern" "$GH_CALL_LOG" 2>/dev/null; then
+		print_result "$label" 1 "Unexpected gh call matching: $pattern"
+	else
+		print_result "$label" 0
+	fi
+	return 0
+}
+
+test_parent_task_issue_close_is_skipped() {
+	: >"$GH_CALL_LOG"
+	: >"$LOGFILE"
+	export TEST_LINKED_LABELS="parent-task,refactor,tier:standard"
+
+	_handle_post_merge_actions "19028" "marcusquinn/aidevops" "18735" "phase 1 merged"
+
+	# Closing comment still posted (the comment doubles as a phase-merged status update).
+	assert_gh_call_contains "issue comment 18735" \
+		"parent-task: closing comment posted to parent on phase merge"
+
+	# gh issue close MUST NOT run against the parent.
+	assert_gh_call_not_contains "issue close 18735" \
+		"parent-task: gh issue close NOT called on parent"
+
+	# The skip must be logged so operators can audit the merge pass.
+	if grep -q "skipping close of parent-task issue #18735" "$LOGFILE"; then
+		print_result "parent-task: skip reason logged" 0
+	else
+		print_result "parent-task: skip reason logged" 1 \
+			"Expected 'skipping close of parent-task issue #18735' in $LOGFILE"
+	fi
+	return 0
+}
+
+test_non_parent_issue_close_still_runs() {
+	: >"$GH_CALL_LOG"
+	: >"$LOGFILE"
+	export TEST_LINKED_LABELS="bug,tier:simple,tooling"
+
+	_handle_post_merge_actions "19028" "marcusquinn/aidevops" "19032" "leaf fix merged"
+
+	# Closing comment posted.
+	assert_gh_call_contains "issue comment 19032" \
+		"non-parent: closing comment posted"
+
+	# gh issue close MUST run for normal leaf issues (regression guard).
+	assert_gh_call_contains "issue close 19032" \
+		"non-parent: gh issue close called as before"
+	return 0
+}
+
+test_empty_labels_does_not_trigger_guard() {
+	: >"$GH_CALL_LOG"
+	: >"$LOGFILE"
+	export TEST_LINKED_LABELS=""
+
+	_handle_post_merge_actions "19028" "marcusquinn/aidevops" "19999" "no-label issue"
+
+	# Empty label set is not parent-task → close still runs (default behaviour).
+	assert_gh_call_contains "issue close 19999" \
+		"empty labels: close still runs (not accidentally treated as parent)"
+	return 0
+}
+
+test_parent_task_substring_false_positive() {
+	# Ensure the guard matches the exact label, not a substring.
+	# `parent-task-something` should NOT trigger the guard.
+	: >"$GH_CALL_LOG"
+	: >"$LOGFILE"
+	export TEST_LINKED_LABELS="parent-task-deprecated,refactor"
+
+	_handle_post_merge_actions "19028" "marcusquinn/aidevops" "19998" "deprecated label"
+
+	# `parent-task-deprecated` is NOT `parent-task` — close should still run.
+	assert_gh_call_contains "issue close 19998" \
+		"parent-task substring: close still runs (exact-match required)"
+	return 0
+}
+
+main() {
+	trap teardown_test_env EXIT
+	setup_test_env
+
+	if ! define_function_under_test; then
+		printf 'FATAL: function extraction failed\n' >&2
+		return 1
+	fi
+
+	test_parent_task_issue_close_is_skipped
+	test_non_parent_issue_close_still_runs
+	test_empty_labels_does_not_trigger_guard
+	test_parent_task_substring_false_positive
+
+	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

pulse-merge.sh was closing parent-task issues on phase-child PR merge because _extract_linked_issue title fallback matches GH#NNN: prefixes. Adds an exact-match parent-task label guard before gh issue close + 7-assertion regression test.

## Files Changed

.agents/scripts/pulse-merge.sh,.agents/scripts/tests/test-pulse-merge-parent-task-close-guard.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean; 7/7 test assertions pass (tests/test-pulse-merge-parent-task-close-guard.sh)

Resolves #19032


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.30 plugin for [OpenCode](https://opencode.ai) v1.4.4 with claude-opus-4-6 spent 13m and 35,668 tokens on this as a headless worker.