### PR TITLE
t2056: harden interactive full-loop with structural issue claim

### DIFF
--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -236,6 +236,52 @@ _check_linked_issue_gate() {
 	return 0
 }
 
+# Interactive claim (t2056 hardening): structurally enforce issue ownership
+# when an interactive session starts a full-loop. Extracts issue number from
+# the prompt and calls interactive-session-helper.sh claim, which applies
+# status:in-review + self-assigns + posts a claim comment. This replaces
+# prompt-only enforcement that was missed in practice (GH#18775 incident).
+#
+# Skips silently when:
+#   - Headless mode (workers have their own dispatch claim)
+#   - No issue number in prompt
+#   - interactive-session-helper.sh not available
+#
+# Always returns 0 — claim failure is non-blocking (warn-and-continue).
+_auto_claim_interactive() {
+	local prompt="$1"
+
+	# Skip in headless — workers use dispatch claims, not interactive claims
+	if is_headless; then
+		return 0
+	fi
+
+	# Extract issue number (same pattern as _check_linked_issue_gate)
+	local issue_num
+	issue_num=$(echo "$prompt" | grep -oE '#[0-9]+' | head -1 | grep -oE '[0-9]+' || true)
+	if [[ -z "$issue_num" ]]; then
+		return 0
+	fi
+
+	# Resolve repo slug
+	local repo
+	repo=$(git remote get-url origin 2>/dev/null | sed -E 's|.*github\.com[:/]||;s|\.git$||' || true)
+	if [[ -z "$repo" ]]; then
+		return 0
+	fi
+
+	# Call the interactive claim helper — it handles offline, idempotency,
+	# self-assign, status label, stamp, and claim comment internally.
+	local helper="${SCRIPT_DIR}/interactive-session-helper.sh"
+	if [[ -x "$helper" ]]; then
+		"$helper" claim "$issue_num" "$repo" --worktree "$(pwd)" || true
+		print_info "Interactive claim: #${issue_num} in ${repo} — pulse dispatch blocked"
+	else
+		print_warning "interactive-session-helper.sh not found — skipping interactive claim"
+	fi
+	return 0
+}
+
 # Initialize option variables with defaults so set -u doesn't crash on
 # export when flags are not passed.
 _init_start_defaults() {
@@ -349,6 +395,12 @@ cmd_start() {
 	# .github/workflows/maintainer-gate.yml so workers fail fast locally
 	# instead of creating PRs that will always fail CI.
 	_check_linked_issue_gate "$prompt" || return 1
+
+	# Interactive claim (t2056 hardening): when not headless, automatically
+	# claim the linked issue so the pulse cannot dispatch a parallel worker
+	# during the window between start and PR creation. This closes the race
+	# that prompt-only enforcement missed (GH#18775 incident).
+	_auto_claim_interactive "$prompt"
 
 	printf "\n${BOLD}${BLUE}=== FULL DEVELOPMENT LOOP - STARTING ===${NC}\n  Task: %s\n  Branch: %s | Headless: %s\n\n" \
 		"$prompt" "$(get_current_branch)" "$HEADLESS"

--- a/.agents/scripts/interactive-session-helper.sh
+++ b/.agents/scripts/interactive-session-helper.sh
@@ -198,6 +198,43 @@ _isc_delete_stamp() {
 	return 0
 }
 
+# Post a claim comment on the issue for audit trail visibility.
+# Mirrors worker dispatch comments but for interactive sessions.
+# Best-effort — all errors are swallowed so the caller never stalls.
+#
+# Arguments:
+#   $1 = issue number, $2 = repo slug, $3 = user login, $4 = worktree path
+_isc_post_claim_comment() {
+	local issue="$1"
+	local slug="$2"
+	local user="$3"
+	local worktree_path="$4"
+
+	local hostname
+	hostname=$(hostname 2>/dev/null || echo "unknown")
+	local worktree_note=""
+	if [[ -n "$worktree_path" ]]; then
+		worktree_note=" in \`${worktree_path##*/}\`"
+	fi
+
+	# <!-- ops:start --> / <!-- ops:end --> markers let the agent skip this
+	# comment when reading issue threads (see build.txt 8d).
+	local body
+	body=$(
+		cat <<EOF
+<!-- ops:start -->
+> Interactive session claimed by @${user}${worktree_note} on ${hostname}.
+> Pulse dispatch blocked via \`status:in-review\` + self-assignment.
+<!-- ops:end -->
+EOF
+	)
+
+	gh issue comment "$issue" --repo "$slug" --body "$body" >/dev/null 2>&1 || {
+		_isc_warn "claim comment failed on #$issue — continuing (audit trail incomplete)"
+	}
+	return 0
+}
+
 # -----------------------------------------------------------------------------
 # Subcommand: claim
 # -----------------------------------------------------------------------------
@@ -293,6 +330,9 @@ _isc_cmd_claim() {
 	if set_issue_status "$issue" "$slug" "in-review" --add-assignee "$user" >/dev/null 2>&1; then
 		_isc_info "claim: #$issue in $slug → status:in-review + assigned $user"
 		_isc_write_stamp "$issue" "$slug" "$worktree_path" "$user"
+		# Post a claim comment for audit trail visibility (like worker dispatch
+		# comments but for interactive sessions). Best-effort — swallow errors.
+		_isc_post_claim_comment "$issue" "$slug" "$user" "$worktree_path"
 		return 0
 	fi
 

--- a/.agents/workflows/full-loop.md
+++ b/.agents/workflows/full-loop.md
@@ -34,6 +34,7 @@ Extract first positional arg; if ` -- ` present, use suffix (t158). Resolve `t\d
 
 **Implementation context (t1901 — read BEFORE exploring):** Read the issue body. Look for "Worker Guidance" or "How" section — follow file paths, implementation steps, and verification commands directly. Read only referenced files. If absent, exit BLOCKED: "missing implementation context". Do NOT explore broadly to compensate.
 
+- **Interactive claim (t2056 — STRUCTURAL):** `full-loop-helper.sh start` automatically calls `interactive-session-helper.sh claim` for non-headless sessions when an issue number is present in the prompt. This applies `status:in-review` + self-assigns + posts a claim comment, blocking pulse dispatch for the entire window between start and PR creation. No agent action required; the helper handles it.
 - **Maintainer gate pre-check (GH#17810 — MANDATORY):** Verify issue lacks `needs-maintainer-review` and has an assignee. `full-loop-helper.sh start` enforces this — exit BLOCKED if either fails. Do NOT create a PR for an issue that will fail the CI maintainer gate.
 - **Decomposition (t1408.2):** Skip if `--no-decompose` or has subtasks. `task-decompose-helper.sh classify "$TASK_DESC"`. Composite headless → auto-decompose, exit `DECOMPOSED: ...`. Max depth 3.
 - **Claim (t1017):** Add `assignee:<identity> started:<ISO>` to TODO.md. Push rejection = claimed → **STOP**.


### PR DESCRIPTION
## Summary

- `full-loop-helper.sh start` now **automatically claims the linked issue** for interactive sessions, closing the race window where the pulse could dispatch a duplicate worker
- `interactive-session-helper.sh claim` now **posts a claim comment** on the issue for audit trail visibility
- `full-loop.md` Step 0 documents the structural enforcement

### The problem

When an interactive session runs `/full-loop` on an issue, the claim was prompt-only — the AI had to remember to call `interactive-session-helper.sh claim`. In the GH#18775 session, it was missed. The pulse could have dispatched a duplicate worker during the ~30 minute window between "start working" and "PR created".

### The fix

Three enforcement layers:

| Layer | File | What |
|-------|------|------|
| **Structural** | `full-loop-helper.sh` | `_auto_claim_interactive()` — extracts issue number from prompt, calls `interactive-session-helper.sh claim` automatically. Skips for headless (workers have their own dispatch claims) and no-issue tasks. |
| **Visibility** | `interactive-session-helper.sh` | `_isc_post_claim_comment()` — posts an `<!-- ops:start/end -->` tagged comment: "Interactive session claimed by @user on hostname". |
| **Docs** | `full-loop.md` | Step 0 now documents the structural enforcement so AI agents see it in the workflow. |

### Verification

- `shellcheck` clean on both scripts
- All 18 existing `test-interactive-session-claim.sh` tests pass
- The claim is best-effort (warn-and-continue) — never blocks the full-loop on gh failures

Resolves #19016