### PR TITLE
GH#19042: fix dispatch worktree accumulation — link branch names to issues, reuse existing

### DIFF
--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -277,8 +277,12 @@ _evaluate_worktree_removal() {
 #   "overwhelmed": dirty files, OR issue-named branch with no commits.
 #                  Model attempted real work but couldn't produce commits.
 #                  Pattern: "read files, created worktree, couldn't close the loop".
-#   "no_work":     auto-named feature/auto-* branch with clean worktree.
+#   "no_work":     auto-named feature/auto-*-gh<N> branch with clean worktree.
 #                  Worker never got past setup — likely infra/transient.
+#
+# Since GH#19042, feature/auto-* branches include the issue number
+# (feature/auto-YYYYMMDD-HHMMSS-gh<N>), so the gh[-]?([0-9]+) regex
+# now matches them. Legacy branches without issue numbers are skipped.
 #
 # Args:
 #   $1 - wt_branch_age: branch name (non-empty; caller checks)
@@ -295,8 +299,9 @@ _record_orphan_crash_classification() {
 	if [[ "$wt_branch_age" =~ gh[-]?([0-9]+) ]]; then
 		orphan_issue_num="${BASH_REMATCH[1]}"
 	fi
-	# Auto-named branches without an embedded issue number can't be
-	# recovered — the worker never parsed the issue, nothing to clear.
+	# Branches without an embedded issue number can't be recovered.
+	# Since GH#19042, new feature/auto-* branches include gh<N>, but
+	# legacy ones (pre-fix) still lack it — skip those gracefully.
 	if [[ -z "$orphan_issue_num" ]]; then
 		return 0
 	fi

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -184,28 +184,25 @@ _dlw_resolve_tier_and_model() {
 #   _DLW_WORKTREE_BRANCH  — branch name on success, empty on failure
 # Both are reset on entry so the orchestrator always sees the fresh state.
 #
-# The worktree is idempotent — if a previous worker already created it,
-# `worktree-helper.sh add` returns the existing path. On failure, the
-# worker falls back to creating its own via full-loop-helper.sh.
+# Issue-linked branch naming (GH#19042):
+#   Branch format: feature/auto-YYYYMMDD-HHMMSS-gh<issue_number>
+#   The -gh<N> suffix enables cleanup traceability (pulse-cleanup.sh
+#   regex gh[-]?([0-9]+)), dedup branch scanning, and worktree reuse.
+#   Previously branches were timestamp-only (feature/auto-YYYYMMDD-HHMMSS)
+#   making orphaned worktrees untraceable — 57 accumulated in 24h on one
+#   machine (2.2 GB wasted).
 #
-# GH#18671: worktree-helper.sh emits ANSI color codes on the "Path:" line.
-# The path-extraction grep `/[^ ]*Git/[^ ]*` matches up to the next
-# whitespace but ANSI reset sequences (\x1b[0m) contain no whitespace, so
-# the captured path ends up with a trailing `\x1b[0m` suffix. The subsequent
-# `[[ -d "$worker_worktree_path" ]]` check then fails because no such
-# directory exists — the REAL path is the same string without the reset
-# code. Result: pre-creation was silently marked "failed" on every dispatch,
-# the worktree was successfully created but orphaned (27 leftover
-# feature/auto-* directories observed in ~/Git/), the worker was launched
-# without WORKER_WORKTREE_PATH, and its self-setup path crashed in ~17s
-# with crash_type=no_work. That fed the t2008 stale-recovery escalation
-# path, which applied needs-maintainer-review after 2 failed attempts,
-# which then drained the dispatch queue to zero.
+# Reuse-before-create:
+#   Before creating a new worktree, scans existing worktrees for one
+#   already linked to this issue (branch contains gh<N>). If found,
+#   resets it to latest main and returns it — preventing accumulation
+#   of duplicate worktrees when the same issue is dispatched repeatedly.
 #
-# Fix: strip ANSI CSI sequences before the path grep so the captured string
-# is a clean filesystem path. The sed pattern matches the standard CSI form
-# ESC[ ... m. The $'...' quoting evaluates \x1b (ESC, 0x1B) at parse time
-# in bash.
+# On failure, the worker falls back to creating its own via
+# full-loop-helper.sh.
+#
+# GH#18671: ANSI stripping — strip CSI sequences from worktree-helper.sh
+# output before path extraction to avoid phantom directory suffixes.
 #
 # Arguments: issue_number, repo_path
 #######################################
@@ -220,9 +217,47 @@ _dlw_precreate_worktree() {
 		return 0
 	fi
 
-	# Derive branch name from timestamp (deterministic, collision-free)
+	# --- Reuse check: scan for an existing worktree for this issue ---
+	# Prevents accumulation of multiple dead worktrees when the same issue
+	# is dispatched repeatedly (GH#19042). Matches branch names containing
+	# gh<N> or gh-<N> (the pattern used by this function and cleanup regex).
+	local _existing_path="" _existing_branch=""
+	local _wt_line=""
+	while IFS= read -r _wt_line; do
+		local _wt_p="" _wt_b=""
+		_wt_p=$(printf '%s' "$_wt_line" | awk '{print $1}') || _wt_p=""
+		_wt_b=$(printf '%s' "$_wt_line" | awk '{print $3}' | sed 's/^\[//;s/\]$//') || _wt_b=""
+		# Match branches with embedded issue number: gh19014 or gh-19014
+		if [[ "$_wt_b" =~ gh-?${issue_number}([^0-9]|$) && -d "$_wt_p" ]]; then
+			_existing_path="$_wt_p"
+			_existing_branch="$_wt_b"
+			break
+		fi
+	done < <(git -C "$repo_path" worktree list 2>/dev/null)
+
+	if [[ -n "$_existing_path" ]]; then
+		# Reset to latest main so the worker starts from a clean base
+		git -C "$_existing_path" checkout -- . 2>/dev/null || true
+		git -C "$_existing_path" clean -fd 2>/dev/null || true
+		local _main_branch=""
+		_main_branch=$(git -C "$repo_path" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||') || _main_branch="main"
+		git -C "$_existing_path" reset --hard "origin/${_main_branch}" 2>/dev/null || true
+		_DLW_WORKTREE_PATH="$_existing_path"
+		_DLW_WORKTREE_BRANCH="$_existing_branch"
+		echo "[dispatch_with_dedup] Reusing existing worktree for #${issue_number}: ${_DLW_WORKTREE_PATH} (branch: ${_DLW_WORKTREE_BRANCH})" >>"$LOGFILE"
+		return 0
+	fi
+
+	# --- Create new worktree with issue-linked branch name ---
+	# Format: feature/auto-YYYYMMDD-HHMMSS-gh<N>
+	# The -gh<N> suffix enables:
+	#   1. pulse-cleanup.sh crash classification (regex: gh[-]?([0-9]+))
+	#   2. dispatch-dedup-layers.sh remote branch scan (regex: (t|gh-?)N)
+	#   3. Reuse check above on subsequent dispatches for the same issue
+	# Without it, orphaned worktrees are untraceable and accumulate (57
+	# observed on one machine in 24h, 2.2 GB wasted).
 	local _branch _wt_output=""
-	_branch="feature/auto-$(date +%Y%m%d-%H%M%S)"
+	_branch="feature/auto-$(date +%Y%m%d-%H%M%S)-gh${issue_number}"
 	# Run from repo_path — worktree-helper.sh uses git commands that need
 	# to be inside the repo. The pulse-wrapper's cwd is typically / (launchd).
 	_wt_output=$(cd "$repo_path" && "$_wt_helper" add "$_branch" 2>&1) || true


### PR DESCRIPTION
## Summary

- **Branch names now include issue number**: `feature/auto-YYYYMMDD-HHMMSS-gh<N>` instead of opaque `feature/auto-YYYYMMDD-HHMMSS`
- **Reuse-before-create**: scans existing worktrees for one already linked to the same issue before creating a new one — prevents accumulation on repeated dispatch
- **Zero downstream changes**: existing cleanup regex `gh[-]?([0-9]+)` and dedup regex `(t|gh-?)N` already match the new format

## Problem

`_dlw_precreate_worktree()` received `issue_number` as `$1` but created timestamp-only branch names, causing a three-part failure cascade:

1. **Untraceable orphans**: cleanup couldn't extract issue numbers from branch names → skipped crash classification → couldn't clear dedup guard
2. **No reuse**: every dispatch for the same issue created a new worktree (57 accumulated in 24h, 2.2 GB wasted)
3. **Invisible to dedup**: branch scanning couldn't detect prior dispatch attempts

## Verification

- `shellcheck -x` passes clean on both modified files
- Cleanup regex `gh[-]?([0-9]+)` matches `gh19014` in `feature/auto-20260414-210053-gh19014` ✓
- Dedup regex `(t|gh-?)${issue_number}([^0-9]|$)` matches `gh19014` at end-of-string ✓
- Local cleanup of 37 dead worktrees (0 commits) reclaimed 1.3 GB ✓

Resolves #19042

---
`origin:interactive`