### PR TITLE
GH#19036: make stale-recovery tick comments visible on GitHub

### DIFF
--- a/.agents/scripts/dispatch-dedup-stale.sh
+++ b/.agents/scripts/dispatch-dedup-stale.sh
@@ -252,7 +252,8 @@ _recover_stale_assignment() {
 	if [[ -n "$_open_pr" ]]; then
 		# Open PR exists — counter resets; post a reset marker and allow normal recovery
 		gh issue comment "$issue_number" --repo "$repo_slug" \
-			--body "<!-- stale-recovery-tick:0 (reset: open PR #${_open_pr} detected) -->" \
+			--body "<!-- stale-recovery-tick:0 (reset: open PR #${_open_pr} detected) -->
+Stale recovery tick reset — open PR #${_open_pr} detected (t2008)" \
 			2>/dev/null || true
 	elif [[ "$_prior_ticks" -ge "$_threshold" ]]; then
 		# Threshold reached — escalate and bail out (no normal recovery)
@@ -262,7 +263,8 @@ _recover_stale_assignment() {
 		# Under threshold — increment tick counter, continue normal recovery
 		local _next_tick=$((_prior_ticks + 1))
 		gh issue comment "$issue_number" --repo "$repo_slug" \
-			--body "<!-- stale-recovery-tick:${_next_tick} -->" \
+			--body "<!-- stale-recovery-tick:${_next_tick} -->
+Stale recovery tick ${_next_tick}/${_threshold} (t2008)" \
 			2>/dev/null || true
 	fi
 	# ── End stale-recovery escalation check ──────────────────────────────


### PR DESCRIPTION
## Summary

- Stale-recovery tick comments (`<!-- stale-recovery-tick:N -->`) were HTML-only, rendering as blank "no description provided" on GitHub
- Added visible plain text after the HTML marker: tick increments show `Stale recovery tick N/threshold (t2008)`, resets show `Stale recovery tick reset — open PR #N detected (t2008)`
- HTML markers preserved for machine parsing by `_stale_recovery_count_ticks()`

## Changes

- EDIT: `.agents/scripts/dispatch-dedup-stale.sh:255,265` — add visible text to tick increment and reset comment bodies

## Verification

- ShellCheck clean
- All 11 `test-stale-recovery-escalation.sh` tests pass

Resolves #19036


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.32 plugin for [OpenCode](https://opencode.ai) v1.4.4 with claude-opus-4-6 spent 2m and 4,336 tokens on this as a headless worker.