### PR TITLE
t2110: fix _label_issue_in_review missing self-assign

### DIFF
--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -848,7 +848,11 @@ _post_merge_summary() {
 	return 0
 }
 
-# Label the linked issue as in-review, removing all sibling status labels (t2033).
+# Label the linked issue as in-review + self-assign, removing all sibling
+# status labels (t2033). Defence-in-depth for t2056/t2110: even if the
+# interactive-session-helper.sh claim was skipped or failed, the PR-open
+# path ensures the assignee is set — preventing the status:in-review +
+# zero-assignees degraded state that breaks dispatch dedup.
 # Arguments: issue_number, repo
 _label_issue_in_review() {
 	local issue_number="$1" repo="$2"
@@ -856,7 +860,15 @@ _label_issue_in_review() {
 	local issue_state=""
 	issue_state=$(gh issue view "$issue_number" --repo "$repo" --json state -q '.state' 2>/dev/null || echo "")
 	if [[ "$issue_state" == "OPEN" ]]; then
-		set_issue_status "$issue_number" "$repo" "in-review" >/dev/null 2>&1 || true
+		# Resolve the current gh user for self-assignment (best-effort)
+		local current_user=""
+		current_user=$(gh api user --jq '.login' 2>/dev/null || echo "")
+		if [[ -n "$current_user" && "$current_user" != "null" ]]; then
+			set_issue_status "$issue_number" "$repo" "in-review" \
+				--add-assignee "$current_user" >/dev/null 2>&1 || true
+		else
+			set_issue_status "$issue_number" "$repo" "in-review" >/dev/null 2>&1 || true
+		fi
 	fi
 	return 0
 }


### PR DESCRIPTION
## Summary

- **Bug**: `_label_issue_in_review()` in `full-loop-helper.sh` applied `status:in-review` without `--add-assignee`, leaving issues in a degraded state (label set, zero assignees) that breaks dispatch dedup
- **Evidence**: <webapp>/<webapp>#2385 and #2386 both show `status:in-review` + `origin:interactive` but zero assignees — timeline confirms no `assigned` event ever fired
- **Root cause**: The function was the last-chance code path at PR-open time (`commit-and-pr` → `_label_issue_in_review`), but it only set the label. The `interactive-session-helper.sh claim` does both correctly, but Alex's session never called it — so the fallback path was the only one that ran, and it missed the assignee.

## Fix

`_label_issue_in_review()` now resolves the current `gh` user and passes `--add-assignee` to `set_issue_status`. Falls back to label-only if the user can't be resolved (best-effort, matching the existing `|| true` convention).

## Files Changed

- `.agents/scripts/full-loop-helper.sh:857` — `_label_issue_in_review()`

## Testing

- ShellCheck clean (only SC1091 source-follow info)
- Logic verified: `set_issue_status` already supports `--add-assignee` passthrough (line 1139 of `shared-constants.sh`)

Resolves the defence-in-depth gap identified in t2056/t2110.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.32 plugin for [OpenCode](https://opencode.ai) v1.4.4 with claude-opus-4-6 spent 7m and 8,258 tokens on this with the user in an interactive session.