### PR TITLE
fix(dispatch): restore gitignored node_modules in worktrees — unblock 15 stuck issues

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -6899,10 +6899,10 @@
       "passes": 1
     },
     ".agents/commands/AGENTS.md": {
-      "hash": "b8caa083de850abb3b9d7e6c87a0d7b53e8304fa",
-      "at": "2026-04-14T20:37:42Z",
+      "hash": "d303426094ed3216688ab932d01c3672016e67b0",
+      "at": "2026-04-15T01:43:50Z",
       "pr": 18117,
-      "passes": 11
+      "passes": 12
     },
     ".agents/workflows/pulse.md": {
       "hash": "ff61825e354fc702e37c4716e1a891698d2b480e",

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -206,6 +206,54 @@ _dlw_resolve_tier_and_model() {
 #
 # Arguments: issue_number, repo_path
 #######################################
+###############################################################################
+# Restore gitignored dependencies (node_modules) in a worktree.
+#
+# Git worktrees only contain tracked files. Directories like node_modules/
+# are gitignored, so they never appear in worktrees — even when the
+# canonical repo has them installed. If a project tool (e.g. .opencode/
+# tool/session-rename.ts) imports from node_modules, the runtime crashes
+# on startup: "Cannot find module '@opencode-ai/plugin'".
+#
+# This caused 100% worker failure rate: 15 of 27 open issues stuck in
+# dispatch-fail loops, 9 falsely escalated to tier:thinking. Workers
+# exited 0 with zero model activity because the tool-loading error
+# prevented the session from starting.
+#
+# Fix: after creating or resetting a worktree, copy node_modules from
+# the canonical repo for any directory that has a package.json tracked
+# in git. This is fast (cp -a), offline, and idempotent.
+#
+# Arguments: worktree_path, repo_path
+###############################################################################
+_dlw_restore_worktree_deps() {
+	local worktree_path="$1"
+	local repo_path="$2"
+
+	[[ -z "$worktree_path" || -z "$repo_path" ]] && return 0
+	[[ ! -d "$worktree_path" || ! -d "$repo_path" ]] && return 0
+
+	# Find directories in the worktree that have a package.json but are
+	# missing node_modules. Only check top-level and one level deep —
+	# deeper nesting is unlikely and find is expensive.
+	local _pkg_dir=""
+	while IFS= read -r _pkg_dir; do
+		local _dir=""
+		_dir=$(dirname "$_pkg_dir") || continue
+		local _rel_dir=""
+		_rel_dir="${_dir#"$worktree_path"}" || continue
+		# _rel_dir is now e.g. "/.opencode" or "" (for root package.json)
+		local _src_nm="${repo_path}${_rel_dir}/node_modules"
+		local _dst_nm="${worktree_path}${_rel_dir}/node_modules"
+		if [[ -d "$_src_nm" && ! -d "$_dst_nm" ]]; then
+			cp -a "$_src_nm" "$_dst_nm" 2>/dev/null || true
+			echo "[dispatch_with_dedup] Restored node_modules: ${_rel_dir:-/} ($(du -sh "$_dst_nm" 2>/dev/null | cut -f1))" >>"$LOGFILE"
+		fi
+	done < <(find "$worktree_path" -maxdepth 3 -name "package.json" -not -path "*/node_modules/*" 2>/dev/null)
+
+	return 0
+}
+
 _dlw_precreate_worktree() {
 	local issue_number="$1"
 	local repo_path="$2"
@@ -244,6 +292,8 @@ _dlw_precreate_worktree() {
 		git -C "$_existing_path" reset --hard "origin/${_main_branch}" 2>/dev/null || true
 		_DLW_WORKTREE_PATH="$_existing_path"
 		_DLW_WORKTREE_BRANCH="$_existing_branch"
+		# Restore gitignored deps that git clean -fd just wiped
+		_dlw_restore_worktree_deps "$_DLW_WORKTREE_PATH" "$repo_path"
 		echo "[dispatch_with_dedup] Reusing existing worktree for #${issue_number}: ${_DLW_WORKTREE_PATH} (branch: ${_DLW_WORKTREE_BRANCH})" >>"$LOGFILE"
 		return 0
 	fi
@@ -267,6 +317,8 @@ _dlw_precreate_worktree() {
 	if [[ -n "$_path" && -d "$_path" ]]; then
 		_DLW_WORKTREE_PATH="$_path"
 		_DLW_WORKTREE_BRANCH="$_branch"
+		# Restore gitignored deps (node_modules) that git doesn't track
+		_dlw_restore_worktree_deps "$_DLW_WORKTREE_PATH" "$repo_path"
 		echo "[dispatch_with_dedup] Pre-created worktree for #${issue_number}: ${_DLW_WORKTREE_PATH} (branch: ${_DLW_WORKTREE_BRANCH})" >>"$LOGFILE"
 	else
 		# GH#18671: emit the raw extracted string on failure so future

--- a/.agents/scripts/worktree-helper.sh
+++ b/.agents/scripts/worktree-helper.sh
@@ -687,6 +687,27 @@ cmd_add() {
 	# Register ownership (t189)
 	register_worktree "$path" "$branch"
 
+	# Restore gitignored dependencies (node_modules) from canonical repo.
+	# Git worktrees only contain tracked files — dirs in .gitignore are
+	# missing. If .opencode/tool/*.ts imports from node_modules, the
+	# runtime crashes on startup. See pulse-dispatch-worker-launch.sh
+	# _dlw_restore_worktree_deps for the full rationale.
+	local _repo_root=""
+	_repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || _repo_root=""
+	if [[ -n "$_repo_root" && -d "$path" ]]; then
+		local _pkg_file=""
+		while IFS= read -r _pkg_file; do
+			local _pdir="" _rel=""
+			_pdir=$(dirname "$_pkg_file") || continue
+			_rel="${_pdir#"$path"}"
+			local _src="${_repo_root}${_rel}/node_modules"
+			local _dst="${path}${_rel}/node_modules"
+			if [[ -d "$_src" && ! -d "$_dst" ]]; then
+				cp -a "$_src" "$_dst" 2>/dev/null || true
+			fi
+		done < <(find "$path" -maxdepth 3 -name "package.json" -not -path "*/node_modules/*" 2>/dev/null)
+	fi
+
 	# t2057: interactive issue auto-claim. When the branch name encodes an
 	# issue number AND this is an interactive session, immediately apply
 	# status:in-review + self-assign so the pulse's dispatch-dedup guard


### PR DESCRIPTION
## Summary

- Fix 100% worker failure rate caused by missing `node_modules/` in git worktrees
- Restore gitignored dependencies after worktree creation/reset in both dispatch and interactive paths
- Reset 8 falsely-escalated `tier:thinking` labels back to `tier:standard`

## Root Cause

`.opencode/tool/session-rename.ts` imports `@opencode-ai/plugin` from `.opencode/node_modules/`. Since `node_modules/` is in `.gitignore`, git worktrees never contain it. OpenCode hits `Cannot find module`, exits 0 with zero model activity, and the lifecycle marks it as `worker_failed`.

15 of 27 open issues stuck in dispatch-fail loops, 9 falsely escalated to `tier:thinking` burning Opus tokens on an infrastructure failure.

## Changes

**`pulse-dispatch-worker-launch.sh`**: New `_dlw_restore_worktree_deps()` — copies `node_modules/` from canonical repo to worktree after creation/reset.

**`worktree-helper.sh`**: Same dep-restore after `register_worktree()` — covers interactive sessions.

**Label cleanup** (applied): Removed `tier:thinking`, added `tier:standard` on 8 issues.

Resolves the systemic dispatch failure affecting all dispatched issues.