### PR TITLE
t2107: fix(ci): trigger qlty-regression on pull_request.labeled so ratchet-bump re-runs without empty commits

### DIFF
--- a/.github/workflows/qlty-new-file-gate.yml
+++ b/.github/workflows/qlty-new-file-gate.yml
@@ -42,8 +42,19 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_ACTION: ${{ github.event.action }}
+          LABEL_NAME: ${{ github.event.label.name }}
         run: |
           set -euo pipefail
+          # Guard: skip re-scan on label/unlabel events unrelated to 'new-file-smell-ok'.
+          # Only adding or removing 'new-file-smell-ok' warrants a rescan; other label
+          # changes (e.g. 'status:in-review', 'origin:worker') are noise.
+          if { [ "${EVENT_ACTION}" = "labeled" ] || [ "${EVENT_ACTION}" = "unlabeled" ]; } && \
+             [ "${LABEL_NAME}" != "new-file-smell-ok" ]; then
+            echo "Skipping: ${EVENT_ACTION} event for '${LABEL_NAME}' is not 'new-file-smell-ok' — no rescan needed."
+            echo "has_new_source=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           added=$(git diff --name-only --diff-filter=A "$BASE_SHA" "$HEAD_SHA" || true)
           if [ -z "$added" ]; then
             echo "No added files; skipping new-file gate."

--- a/.github/workflows/qlty-regression.yml
+++ b/.github/workflows/qlty-regression.yml
@@ -12,7 +12,7 @@ name: Qlty Regression Gate
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, synchronize, reopened, labeled]
 
 permissions:
   pull-requests: write
@@ -39,8 +39,18 @@ jobs:
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          EVENT_ACTION: ${{ github.event.action }}
+          LABEL_NAME: ${{ github.event.label.name }}
         run: |
           set -euo pipefail
+          # Guard: skip full re-scan when an unrelated label is applied.
+          # Applying labels like 'status:in-review' or 'origin:worker' would
+          # otherwise trigger a full Qlty scan. Only 'ratchet-bump' needs a rescan.
+          if [ "${EVENT_ACTION}" = "labeled" ] && [ "${LABEL_NAME}" != "ratchet-bump" ]; then
+            echo "Skipping: labeled event for '${LABEL_NAME}' is not 'ratchet-bump' — no rescan needed."
+            echo "should_scan=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           echo "Base: $BASE_SHA"
           echo "Head: $HEAD_SHA"
           changed=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" || true)


### PR DESCRIPTION
## Summary

- Add `labeled` to `on.pull_request.types` in `qlty-regression.yml` so applying the `ratchet-bump` label automatically triggers a workflow re-run, eliminating the need for empty "trigger" commits.
- Add label-name guards to both `qlty-regression.yml` and `qlty-new-file-gate.yml` to skip re-scans on unrelated label events (e.g. `status:in-review`, `origin:worker`). Only `ratchet-bump` / `new-file-smell-ok` trigger a rescan.
- `qlty-new-file-gate.yml` already had `labeled`/`unlabeled` in its trigger types; this PR adds the matching guard to avoid wasteful re-scans there too.

## Changes

- **EDIT**: `.github/workflows/qlty-regression.yml` — add `labeled` to `on.pull_request.types`; add `EVENT_ACTION`/`LABEL_NAME` env vars; add early-exit guard for non-`ratchet-bump` label events in `Determine scope` step
- **EDIT**: `.github/workflows/qlty-new-file-gate.yml` — add `EVENT_ACTION`/`LABEL_NAME` env vars; add early-exit guard for non-`new-file-smell-ok` label/unlabel events in `Count new source files` step

## Verification

1. Applying `ratchet-bump` to a failing PR now re-runs Qlty Smell Regression without a push.
2. Applying an unrelated label (e.g. `status:in-review`) skips the scan with `"Skipping: labeled event for '...' is not 'ratchet-bump' — no rescan needed."` in logs.
3. Same pattern for `qlty-new-file-gate.yml` with `new-file-smell-ok`.

## Context

- Root cause: PR #19023 (GH#18787) — worker pushed 2 empty commits to trigger CI re-eval after applying `ratchet-bump`
- Observed: `commits 93febaef, 40ff76eb6` with message `ci: trigger re-run after ratchet-bump label [no-op]`
- Related: t2065 (GH#18773) original Qlty regression gate, t2068 new-file gate

Resolves #19045