### PR TITLE
t2109: fix(task-id-guard): read counter from origin/main tip instead of merge-base

### DIFF
--- a/.agents/hooks/task-id-collision-guard.sh
+++ b/.agents/hooks/task-id-collision-guard.sh
@@ -78,6 +78,45 @@ _read_counter_at_ref() {
 }
 
 # ---------------------------------------------------------------------------
+# Resolve the current task counter by taking the MAX across multiple known-good
+# sources. .task-counter is monotonically increasing so max == most current.
+#
+# This prevents stale-worktree false positives: when a worktree is created
+# before a subsequent claim-task-id.sh run bumps the counter on origin/main,
+# the merge-base holds a stale value. Reading from origin/main tip directly
+# returns the authoritative counter, regardless of merge-base age.
+#
+# Returns the integer counter string (no newline), or empty string on failure.
+# ---------------------------------------------------------------------------
+_resolve_current_counter() {
+	local best=""
+	local val ref
+	# Priority sources, highest-freshness first. We take the MAX across all,
+	# not the first — .task-counter is monotonic so max == most current.
+	for ref in "origin/main" "origin/master" "main" "master" "HEAD"; do
+		if git rev-parse --verify "$ref" >/dev/null 2>&1; then
+			val=$(git show "${ref}:.task-counter" 2>/dev/null | tr -d '[:space:]')
+			if [[ "$val" =~ ^[0-9]+$ ]]; then
+				if [[ -z "$best" || "$val" -gt "$best" ]]; then
+					best="$val"
+				fi
+			fi
+		fi
+	done
+	# Also consider working copy (covers detached-HEAD / no-remote edge cases)
+	if [[ -f .task-counter ]]; then
+		val=$(tr -d '[:space:]' <.task-counter)
+		if [[ "$val" =~ ^[0-9]+$ ]]; then
+			if [[ -z "$best" || "$val" -gt "$best" ]]; then
+				best="$val"
+			fi
+		fi
+	fi
+	[[ -n "$best" ]] && printf '%s' "$best"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
 # Determine the merge base between HEAD and the default branch (main/master).
 # Falls back to the root commit.
 # ---------------------------------------------------------------------------
@@ -200,14 +239,12 @@ _report_violations() {
 # Core check: given a commit message, check if any t\d+ reference is invented.
 # Args:
 #   $1 = full commit message text
-#   $2 = merge-base git ref (for reading .task-counter)
-#   $3 = commit subject (for display in errors), optional
+#   $2 = commit subject (for display in errors), optional
 # Returns 0 (clean), 1 (violation found), 2 (fail-open — skip).
 # ---------------------------------------------------------------------------
 _check_message() {
 	local msg="${1:-}"
-	local merge_base="${2:-}"
-	local subject="${3:-<unknown>}"
+	local subject="${2:-<unknown>}"
 
 	if [[ -z "$msg" ]]; then
 		_debug "Empty commit message — allowing"
@@ -228,13 +265,13 @@ _check_message() {
 	_debug "Found t-IDs: $(printf '%s' "$tids" | tr '\n' ' ')"
 
 	local counter=""
-	[[ -n "$merge_base" ]] && counter=$(_read_counter_at_ref "$merge_base")
+	counter=$(_resolve_current_counter)
 	if [[ -z "$counter" ]]; then
-		_warn ".task-counter not readable at merge base '${merge_base}' — fail-open"
+		_warn ".task-counter not readable from any source — fail-open"
 		return 2
 	fi
 
-	_debug "Merge-base counter value: $counter"
+	_debug "Current counter value: $counter"
 
 	local closing_issues
 	closing_issues=$(_extract_closing_issues "$msg")
@@ -296,12 +333,8 @@ _run_hook() {
 		return 0
 	fi
 
-	local merge_base
-	merge_base=$(_find_merge_base)
-	_debug "Merge base: $merge_base"
-
 	local rc
-	_check_message "$msg" "$merge_base" "$subject"
+	_check_message "$msg" "$subject"
 	rc=$?
 
 	if [[ "$rc" -eq 2 ]]; then
@@ -357,7 +390,7 @@ _run_check_pr() {
 		fi
 
 		local rc
-		_check_message "$commit_msg" "$merge_base" "$subject"
+		_check_message "$commit_msg" "$subject"
 		rc=$?
 		if [[ "$rc" -eq 1 ]]; then
 			printf '[task-id-guard][VIOLATION] commit %s\n' "$commit_hash" >&2

--- a/.agents/scripts/tests/test-task-id-collision-guard.sh
+++ b/.agents/scripts/tests/test-task-id-collision-guard.sh
@@ -4,7 +4,7 @@
 #
 # test-task-id-collision-guard.sh — Test harness for task-id-collision-guard.sh
 #
-# Covers all 7 acceptance criteria cases:
+# Covers all 8 acceptance criteria cases:
 #   1. Reject: t-ID > counter AND not in linked issue title
 #   2. Allow: t-ID ≤ counter (claimed)
 #   3. Allow: cross-reference confirmed via linked issue title
@@ -12,6 +12,7 @@
 #   5. Allow: fail-open on gh API failure / offline
 #   6. Allow (bypass): --no-verify / TASK_ID_GUARD_DISABLE=1
 #   7. CI mode: check-pr scans range and finds violations
+#   8. Allow: stale-worktree — t-IDs claimed after worktree creation (GH#19054)
 
 set -u
 
@@ -289,6 +290,86 @@ test_check_pr_mode() {
 }
 
 # ---------------------------------------------------------------------------
+# Case 8: Allow — stale-worktree scenario (GH#19054)
+#
+# Simulates the observed failure:
+#   1. Worktree created at main tip X (counter=10)
+#   2. Two more claims pushed to origin/main → counter=12
+#   3. Commit in the worktree references t11 and t12
+#
+# With the OLD guard: merge-base=X → counter=10 → t11,t12 > 10 → BLOCK (wrong)
+# With the NEW guard: _resolve_current_counter reads origin/main → 12 → ALLOW (correct)
+# ---------------------------------------------------------------------------
+test_stale_worktree_scenario() {
+	local name="case-8: allows t-IDs claimed after worktree creation (stale-worktree)"
+
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir'" RETURN
+
+	# Create the "origin" repo with counter=10 on main
+	local base_repo="${tmpdir}/base"
+	mkdir -p "$base_repo"
+	git -C "$base_repo" init -q
+	git -C "$base_repo" config user.email "test@test.local"
+	git -C "$base_repo" config user.name "Test"
+	git -C "$base_repo" config commit.gpgsign false
+	git -C "$base_repo" config tag.gpgsign false
+	printf '10' >"${base_repo}/.task-counter"
+	git -C "$base_repo" add .task-counter
+	git -C "$base_repo" commit -q -m "init: counter=10"
+
+	# Clone to simulate a worktree created at counter=10
+	local work_repo="${tmpdir}/work"
+	git clone -q "$base_repo" "$work_repo" 2>/dev/null
+	git -C "$work_repo" config user.email "test@test.local"
+	git -C "$work_repo" config user.name "Test"
+	git -C "$work_repo" config commit.gpgsign false
+	git -C "$work_repo" config tag.gpgsign false
+
+	# Add a WIP commit to work_repo so HEAD diverges from origin/main
+	printf 'impl' >"${work_repo}/impl.txt"
+	git -C "$work_repo" add impl.txt
+	git -C "$work_repo" commit -q -m "wip: implementation placeholder"
+
+	# Simulate two more claim-task-id.sh runs on origin/main (counter → 11 → 12)
+	printf '11' >"${base_repo}/.task-counter"
+	git -C "$base_repo" add .task-counter
+	git -C "$base_repo" commit -q -m "chore: claim t11 — counter=11"
+	printf '12' >"${base_repo}/.task-counter"
+	git -C "$base_repo" add .task-counter
+	git -C "$base_repo" commit -q -m "chore: claim t12 — counter=12"
+
+	# Fetch so work_repo's origin/main reflects counter=12
+	git -C "$work_repo" fetch -q origin 2>/dev/null
+
+	# Write a commit message referencing t11 and t12 (both legitimately claimed)
+	local msg="feat(t2109): implement stale-worktree fix t11 t12"
+	local msg_file="${tmpdir}/COMMIT_EDITMSG"
+	printf '%s' "$msg" >"$msg_file"
+
+	# Stub gh to fail — guard must rely on counter comparison alone
+	local fake_bin="${tmpdir}/bin"
+	mkdir -p "$fake_bin"
+	printf '#!/usr/bin/env bash\nexit 1\n' >"${fake_bin}/gh"
+	chmod +x "${fake_bin}/gh"
+
+	local rc
+	PATH="${fake_bin}:$PATH" \
+		GIT_DIR="${work_repo}/.git" \
+		bash "$GUARD" "$msg_file" 2>/dev/null
+	rc=$?
+
+	if [[ "$rc" -eq 0 ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected exit 0 (t11,t12 ≤ origin/main counter 12), got $rc"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
 main() {
@@ -301,6 +382,7 @@ main() {
 	test_bypass_env_var
 	test_skips_merge_commits
 	test_check_pr_mode
+	test_stale_worktree_scenario
 
 	printf '\n'
 	printf 'Results: %s passed, %s failed\n' "$PASS" "$FAIL"


### PR DESCRIPTION
## Summary

Fixes stale-worktree false positives in `task-id-collision-guard.sh` where legitimately claimed t-IDs were blocked because the guard read `.task-counter` from the merge-base (stale) rather than `origin/main` tip (authoritative).

## What changed

**`.agents/hooks/task-id-collision-guard.sh`**

- Added `_resolve_current_counter()` helper that reads `.task-counter` from multiple sources (`origin/main`, `origin/master`, `main`, `master`, `HEAD`, working copy) and returns the **maximum** value. Since `.task-counter` is monotonically increasing, max = most current.
- `_check_message()`: replaced `_read_counter_at_ref "$merge_base"` with `_resolve_current_counter()`. The `merge_base` parameter is removed from the function signature.
- `_run_hook()`: removed now-unnecessary `_find_merge_base()` call (merge_base is no longer passed to `_check_message`).
- `_run_check_pr()`: kept `_find_merge_base()` for commit-range calculation (`merge_base..HEAD`), but updated the `_check_message` call to drop the removed parameter.
- `_find_merge_base()` and `_read_counter_at_ref()` are retained — the former is still used in CI mode for range determination.

**`.agents/scripts/tests/test-task-id-collision-guard.sh`**

- Added **case-8**: stale-worktree regression test. Reproduces the exact scenario from session `a6ad2ada`: worktree at counter=10, two claims push origin/main to counter=12, commit referencing t11 and t12 must be allowed.

## Test results

```
Results: 8 passed, 0 failed
```

All 7 existing cases still pass. New case-8 validates the fix.

## Verification

```bash
bash .agents/scripts/tests/test-task-id-collision-guard.sh
shellcheck .agents/hooks/task-id-collision-guard.sh
shellcheck .agents/scripts/tests/test-task-id-collision-guard.sh
```

Resolves #19054