### PR TITLE
GH#19044: fix(pulse): resolve FD exhaustion causing merge pass cycles to never complete

### DIFF
--- a/.agents/scripts/pulse-simplification-state.sh
+++ b/.agents/scripts/pulse-simplification-state.sh
@@ -218,12 +218,16 @@ _simplification_state_refresh() {
 		current_hash=$(git -C "$repo_path" hash-object "$full_path" 2>/dev/null) || continue
 		# Read hash and passes in a single jq call — spawning jq twice per file
 		# inside a loop is inefficient when the state file can have hundreds of entries (GH#18555).
-		local prev_passes
-		IFS=$'\t' read -r stored_hash prev_passes < <(
-			jq -r --arg fp "$fp" \
-				'.files[$fp] // {"hash": "", "passes": 0} | [(.hash // ""), (.passes // 0 | tostring)] | join("\t")' \
-				"$tmp_state" 2>/dev/null
-		)
+		# GH#19044: replaced process substitution (< <(jq ...)) with command
+		# substitution + here-string to avoid FD leaks in bash 3.2. Process
+		# substitution creates a /dev/fd entry per iteration that bash 3.2
+		# does not reliably close, exhausting the 256 FD soft limit after
+		# ~200 files.
+		local prev_passes _jq_result
+		_jq_result=$(jq -r --arg fp "$fp" \
+			'.files[$fp] // {"hash": "", "passes": 0} | [(.hash // ""), (.passes // 0 | tostring)] | join("\t")' \
+			"$tmp_state" 2>/dev/null) || _jq_result=""
+		IFS=$'\t' read -r stored_hash prev_passes <<<"$_jq_result"
 		[[ -n "$stored_hash" ]] || stored_hash=""
 		[[ "$prev_passes" =~ ^[0-9]+$ ]] || prev_passes=0
 
@@ -623,7 +627,11 @@ _simplification_state_backfill_closed() {
 		local title file_path issue_num
 
 		# Single jq pass for both fields — halves subprocess count per iteration.
-		IFS=$'\t' read -r title issue_num < <(printf '%s\n' "$issue" | jq -r '[.title // "", .number // ""] | @tsv')
+		# GH#19044: command substitution + here-string instead of process
+		# substitution to avoid FD leaks in bash 3.2.
+		local _issue_fields
+		_issue_fields=$(printf '%s\n' "$issue" | jq -r '[.title // "", .number // ""] | @tsv' 2>/dev/null) || _issue_fields=""
+		IFS=$'\t' read -r title issue_num <<<"$_issue_fields"
 		[[ -z "$title" || -z "$issue_num" ]] && continue
 
 		file_path=$(_simplification_backfill_extract_file_path "$title")

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -74,6 +74,31 @@ set -euo pipefail
 export PATH="/bin:/usr/bin:/usr/local/bin:/opt/homebrew/bin:${PATH}"
 
 #######################################
+# FD budget: raise soft limit to avoid exhaustion (GH#19044)
+#
+# The launchd plist inherits macOS default maxfiles (256 soft, unlimited
+# hard). The pulse sources ~20 modules and spawns gh/jq/git subprocesses
+# per repo per cycle — 256 FDs is structurally insufficient. Raise the
+# soft limit to 4096 (well within the hard limit) BEFORE sourcing any
+# modules or spawning any subprocesses.
+#
+# This is the primary fix for the FD exhaustion observed in GH#18787:
+#   pulse-simplification-state.sh: redirection error: cannot duplicate fd: Too many open files
+#
+# Defence-in-depth: setup-modules/schedulers.sh also sets
+# SoftResourceLimits.NumberOfFiles=4096 in the launchd plist, but the
+# ulimit raise here is the runtime safety net in case the plist is stale.
+#######################################
+ulimit -n 4096 2>/dev/null || ulimit -n 1024 2>/dev/null || true
+
+# Regression guard: assert FD budget is adequate. Log loudly if not.
+_pulse_fd_limit=$(ulimit -n 2>/dev/null || echo "256")
+if [[ "$_pulse_fd_limit" =~ ^[0-9]+$ ]] && [[ "$_pulse_fd_limit" -lt 1024 ]]; then
+	printf '[pulse-wrapper] WARNING: FD soft limit is %s (< 1024). Pulse may hit FD exhaustion. Run: ulimit -n 4096 or update the launchd plist SoftResourceLimits.NumberOfFiles (GH#19044)\n' "$_pulse_fd_limit" >&2
+fi
+unset _pulse_fd_limit
+
+#######################################
 # Startup jitter — desynchronise concurrent pulse instances
 #
 # When multiple runners share the same launchd interval (120s), their

--- a/setup-modules/schedulers.sh
+++ b/setup-modules/schedulers.sh
@@ -491,6 +491,11 @@ _generate_pulse_plist_content() {
 		<string>${PULSE_STALE_THRESHOLD_SECONDS}</string>
 		${_headless_xml_env}
 	</dict>
+	<key>SoftResourceLimits</key>
+	<dict>
+		<key>NumberOfFiles</key>
+		<integer>4096</integer>
+	</dict>
 	<key>RunAtLoad</key>
 	<true/>
 	<key>KeepAlive</key>


### PR DESCRIPTION
## Summary

## Root cause

The launchd plist for the supervisor pulse inherited the macOS default soft FD limit of 256. The pulse sources ~20 modules and spawns gh/jq/git subprocesses across multiple repos per cycle — 256 FDs is structurally insufficient. Additionally, `_simplification_state_refresh()` used process substitution (`< <(jq ...)`) inside a per-file while loop, which leaks FDs in bash 3.2 (the `/bin/bash` version on macOS).

**Effect**: FD exhaustion (`cannot duplicate fd: Too many open files`) caused stages to fail silently, the progress watchdog then killed the pulse before `deterministic_merge_pass` could run, leaving worker PRs unmerged.

## Changes

1. **pulse-wrapper.sh**: Added `ulimit -n 4096` at startup (before sourcing modules) to raise the soft FD limit from 256 to 4096. Added a regression guard that warns if the limit is below 1024.

2. **pulse-simplification-state.sh**: Replaced process substitution (`< <(jq ...)`) with command substitution + here-string (`$(...) <<<`) in `_simplification_state_refresh()` and `_simplification_state_backfill_closed()` to eliminate FD leaks in bash 3.2.

3. **setup-modules/schedulers.sh**: Added `SoftResourceLimits.NumberOfFiles=4096` to the launchd plist generation as defence-in-depth.

## Files Changed

.agents/scripts/pulse-simplification-state.sh,.agents/scripts/pulse-wrapper.sh,setup-modules/schedulers.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** - ShellCheck: all 3 modified files pass clean
- test-pulse-wrapper-characterization.sh: 26/26 pass
- test-simplification-spurious-sweep.sh: 10/10 pass
- test-pulse-wrapper-canary.sh: pass

Resolves #19044


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.35 plugin for [OpenCode](https://opencode.ai) v1.4.4 with claude-opus-4-6 spent 6m and 13,668 tokens on this as a headless worker.