### PR TITLE
GH#19047: tighten full-loop.md prose — recheck simplification

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -6432,7 +6432,7 @@
       "hash": "476c989fca56149f90f1eefc2b02cafdc5a6e0d5",
       "simplified_at": "2026-04-04T09:17:13Z",
       "issue": "GH#17250",
-      "action": "consolidated 6 group tables + CSS block into single unified table with CSS variable column (94→28 lines)",
+      "action": "consolidated 6 group tables + CSS block into single unified table with CSS variable column (94\u219228 lines)",
       "at": "2026-04-04T14:53:40Z",
       "passes": 1
     },
@@ -6941,10 +6941,10 @@
       "passes": 1
     },
     ".agents/workflows/full-loop.md": {
-      "hash": "7f5d11baa5324a3da964a513d27e5790b0bdea27",
-      "at": "2026-04-11T04:09:50Z",
-      "pr": 18130,
-      "passes": 1
+      "hash": "dda139893758fd40ed3195ea4cd58d4287c61bdc",
+      "at": "2026-04-15T02:35:00Z",
+      "pr": 19047,
+      "passes": 2
     },
     ".agents/scripts/commands/session-review.md": {
       "hash": "75539fb19f3e764a723d6534c6b2090709b3b423",

--- a/.agents/workflows/full-loop.md
+++ b/.agents/workflows/full-loop.md
@@ -32,10 +32,10 @@ Fatal modes: **GH#5317** (exits without PR), **GH#5096** (exits after PR). Do NO
 
 Extract first positional arg; if ` -- ` present, use suffix (t158). Resolve `t\d+` via TODO.md or `gh issue list`. Extract issue number: `sed -En 's/.*[Ii]ssue[[:space:]]*#*([0-9]+).*/\1/p'`.
 
-**Implementation context (t1901 — read BEFORE exploring):** Read the issue body. Look for "Worker Guidance" or "How" section — follow file paths, implementation steps, and verification commands directly. Read only referenced files. If absent, exit BLOCKED: "missing implementation context". Do NOT explore broadly to compensate.
+**Implementation context (t1901):** Read issue body's "Worker Guidance"/"How" section — follow file paths, implementation steps, and verification commands directly. Read only referenced files. If absent, exit BLOCKED: "missing implementation context". Do NOT explore broadly to compensate.
 
 - **Interactive claim (t2056 — STRUCTURAL):** `full-loop-helper.sh start` automatically calls `interactive-session-helper.sh claim` for non-headless sessions when an issue number is present in the prompt. This applies `status:in-review` + self-assigns + posts a claim comment, blocking pulse dispatch for the entire window between start and PR creation. No agent action required; the helper handles it.
-- **Maintainer gate pre-check (GH#17810 — MANDATORY):** Verify issue lacks `needs-maintainer-review` and has an assignee. `full-loop-helper.sh start` enforces this — exit BLOCKED if either fails. Do NOT create a PR for an issue that will fail the CI maintainer gate.
+- **Maintainer gate pre-check (GH#17810 — MANDATORY):** Verify issue lacks `needs-maintainer-review` and has an assignee. `full-loop-helper.sh start` enforces this — exit BLOCKED if either fails.
 - **Decomposition (t1408.2):** Skip if `--no-decompose` or has subtasks. `task-decompose-helper.sh classify "$TASK_DESC"`. Composite headless → auto-decompose, exit `DECOMPOSED: ...`. Max depth 3.
 - **Claim (t1017):** Add `assignee:<identity> started:<ISO>` to TODO.md. Push rejection = claimed → **STOP**.
 - **Issue labels (t1343/#2452):** Guard: state must be `OPEN`. Set `status:in-progress`, remove stale labels. Lifecycle: `available` → `queued` → `in-progress` → `in-review` → `done`. Idempotent (t1687).
@@ -80,7 +80,7 @@ Iterate until emitting `<promise>TASK_COMPLETE</promise>`.
 | **Medium** | UI components, CSS, routes, config, env vars, DB queries | `runtime-verified` if dev env available; `self-assessed` otherwise |
 | **Low** | Docs, comments, types-only, test files, linter/CI config, agent prompts | `self-assessed` |
 
-Detection is intelligence. ANY critical pattern → entire PR requires `runtime-verified`. Critical/high + no runtime → **BLOCK**. Use `.aidevops/testing.json` if present. Record `## Runtime Testing` in PR body.
+ANY critical pattern → entire PR requires `runtime-verified`. Critical/high + no runtime → **BLOCK**. Use `.aidevops/testing.json` if present. Record `## Runtime Testing` in PR body.
 
 **Key rules:** Parallelism (t217) — use Task tool. CI (t1334) — `gh pr checks`, `gh run view --log`. Blast radius (t1422) — quality-debt PRs ≤5 files.
 


### PR DESCRIPTION
## Summary

Three targeted prose improvements to `.agents/workflows/full-loop.md` (recheck after hash drift from PR #18130 simplification):

- **Implementation context note**: Remove `— read BEFORE exploring` parenthetical qualifier; tighten `"Worker Guidance" or "How" section` to `"Worker Guidance"/"How" section`
- **Maintainer gate bullet**: Remove trailing redundant sentence "Do NOT create a PR for an issue that will fail the CI maintainer gate" — already implied by "exit BLOCKED if either fails"  
- **Runtime testing section**: Remove `Detection is intelligence.` meta-commentary — the actionable rule follows directly without needing a preamble

Also updates `simplification-state.json` to record the new hash (pass 2).

## Files changed

- EDIT: `.agents/workflows/full-loop.md` — prose tightening (3 targeted changes)
- EDIT: `.agents/configs/simplification-state.json` — updated hash/pass for `full-loop.md`

## Testing

- Content preservation: all code blocks, task IDs (t5096, GH#5317, t1901, t2056, etc.), and commands present before and after
- No broken internal links
- JSON valid: `python3 -c "import json; json.load(open('.agents/configs/simplification-state.json'))"` ✓

Resolves #19047