### PR TITLE
GH#19056: chore: ratchet-down NESTING_DEPTH_THRESHOLD 284→280

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -103,7 +103,8 @@ FUNCTION_COMPLEXITY_THRESHOLD=29
 # Ratcheted down to 279 (GH#19015): actual violations 277 + 2 buffer
 # Bumped to 284 (GH#19019): proximity guard firing at 277/279 (2 headroom); 277 violations + 7 headroom = 284.
 # Proximity guard (warn_at = 284-5 = 279) fires when violations exceed 279 (i.e., at 280), preventing saturation.
-NESTING_DEPTH_THRESHOLD=284
+# Ratcheted down to 280 (GH#19056): actual violations 278 + 2 buffer
+NESTING_DEPTH_THRESHOLD=280
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Ratchet down `NESTING_DEPTH_THRESHOLD` from 284 to 280.

- Actual violations: 278
- New threshold: 278 + 2 buffer = 280
- Gap available: 6 (issue reported actual: 278, headroom: 6)

## Changes

- `EDIT: .agents/configs/complexity-thresholds.conf` — lowered `NESTING_DEPTH_THRESHOLD` from 284 to 280, added audit comment per ratchet-down convention

## Verification

```
NESTING_DEPTH_THRESHOLD=280
```

`simplification-state.json` is NOT included in this PR (pulse refreshes it automatically after merge).

Resolves #19056