### PR TITLE
GH#19049: chore: ratchet-down FUNCTION_COMPLEXITY_THRESHOLD 29→26 (GH#19049)

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -32,7 +32,8 @@
 # Ratcheted down to 23 (GH#18802): actual violations 21 + 2 buffer
 # Bumped to 26 (GH#18807): pre-existing regression on main — 24 violations vs threshold 23; 24 + 2 buffer = 26
 # Bumped to 29 (GH#18987): pre-existing regression on main — 27 violations vs threshold 26; 27 + 2 buffer = 29
-FUNCTION_COMPLEXITY_THRESHOLD=29
+# Ratcheted down to 26 (GH#19049): actual violations 24 + 2 buffer
+FUNCTION_COMPLEXITY_THRESHOLD=26
 
 # Shell nesting depth: files with >8 levels of nesting
 # NOTE: pulse-wrapper.sh has a proximity guard (GH#17808) that warns when


### PR DESCRIPTION
## Summary

Lowered FUNCTION_COMPLEXITY_THRESHOLD from 29 to 26. Actual violations: 24, new threshold: 26 (24 + 2 buffer). The NESTING_DEPTH_THRESHOLD target from the original issue was already addressed by GH#19056/PR#19084 (280, at minimum buffer with 278 actual violations). This ratchet eliminates the remaining headroom gap identified by the ratchet-check scan.

## Files Changed

.agents/configs/complexity-thresholds.conf

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Ran .agents/scripts/complexity-scan-helper.sh ratchet-check . 5 — output: func:24 nest:278 size:56 bash32:71 vs thresholds func:26 nest:280 size:59 bash32:72. No further ratchet-down available. Confirmed simplification-state.json not staged.

Resolves #19049


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.35 plugin for [OpenCode](https://opencode.ai) v1.4.4 with claude-sonnet-4-6 spent 2m and 6,036 tokens on this as a headless worker.