### PR TITLE
t2053.4: migrate Tier 3 pulse/worker helpers (Phase 4)

### DIFF
--- a/.agents/scripts/opus-review-helper.sh
+++ b/.agents/scripts/opus-review-helper.sh
@@ -40,10 +40,9 @@ STATE_FILE="${STATE_DIR}/.opus-review-last"
 # COLOURS
 # ============================================================
 
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m'
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=shared-constants.sh
+[[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
 
 # ============================================================
 # FUNCTIONS

--- a/.agents/scripts/secret-hygiene-helper.sh
+++ b/.agents/scripts/secret-hygiene-helper.sh
@@ -37,13 +37,11 @@ readonly ADVISORIES_DIR="$HOME/.aidevops/advisories"
 readonly DISMISSED_FILE="$ADVISORIES_DIR/dismissed.txt"
 readonly VERSION="1.0.0"
 
-# Colours
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-BOLD='\033[1m'
-NC='\033[0m'
+# Colours — sourced from shared-constants.sh (Pattern A)
+# shellcheck source=shared-constants.sh
+[[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
+# BOLD not in shared-constants.sh — Pattern B fallback
+[[ -z "${BOLD+x}" ]] && BOLD='\033[1m'
 
 # Counters
 FINDINGS_HIGH=0

--- a/.agents/scripts/security-audit-sweep.sh
+++ b/.agents/scripts/security-audit-sweep.sh
@@ -26,14 +26,11 @@ readonly REPOS_JSON="${HOME}/.config/aidevops/repos.json"
 readonly POSTURE_HELPER="${SCRIPT_DIR}/security-posture-helper.sh"
 readonly VERSION="1.0.0"
 
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-CYAN='\033[0;36m'
-BOLD='\033[1m'
-NC='\033[0m'
+# Colors — sourced from shared-constants.sh (Pattern A)
+# shellcheck source=shared-constants.sh
+[[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
+# BOLD not in shared-constants.sh — Pattern B fallback
+[[ -z "${BOLD+x}" ]] && BOLD='\033[1m'
 
 # AI/LLM dependency patterns (npm, pip, cargo)
 readonly AI_DEPS_NPM='openai|anthropic|^ai$|@ai-sdk|langchain|@langchain|vercel.*ai|@stackone/defender|llama|ollama'

--- a/.agents/scripts/stuck-detection-helper.sh
+++ b/.agents/scripts/stuck-detection-helper.sh
@@ -53,11 +53,9 @@ SD_REPO="${SUPERVISOR_STUCK_DETECTION_REPO:-}"
 # COLOURS (stderr output)
 # ============================================================
 
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m'
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=shared-constants.sh
+[[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
 
 # ============================================================
 # STATE FILE


### PR DESCRIPTION
## Summary

Migrate 4 Tier 3 (pulse/worker-adjacent) helpers from unguarded plain color variable assignments to canonical Pattern A (source from `shared-constants.sh`) with Pattern B fallback for BOLD.

## Files Changed

- **EDIT:** `.agents/scripts/stuck-detection-helper.sh` — replaced `RED/GREEN/YELLOW/BLUE/NC` block with Pattern A (`SCRIPT_DIR` + conditional source)
- **EDIT:** `.agents/scripts/opus-review-helper.sh` — replaced `GREEN/YELLOW/BLUE/NC` block with Pattern A (`SCRIPT_DIR` + conditional source)
- **EDIT:** `.agents/scripts/secret-hygiene-helper.sh` — replaced `RED/GREEN/YELLOW/BLUE/BOLD/NC` block with Pattern A source + Pattern B BOLD fallback (SCRIPT_DIR already existed)
- **EDIT:** `.agents/scripts/security-audit-sweep.sh` — replaced `RED/GREEN/YELLOW/BLUE/CYAN/BOLD/NC` block with Pattern A source + Pattern B BOLD fallback (SCRIPT_DIR already existed)

## Verification

- `shellcheck` clean on all 4 files (SC1091 info notices are pre-existing in all Pattern A files, not new violations)
- No behavioural change — colors still render correctly via shared-constants.sh
- Eliminates readonly collision risk on the pulse/worker lifecycle path

## PR Conventions

For #18735

Resolves #19063