### PR TITLE
t2115: enforce signature footer in gh_create_issue and gh_create_pr wrappers

### DIFF
--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -795,6 +795,7 @@ _validate_worker_claim() {
 # Create the PR and print the PR number to stdout.
 # Arguments: repo, pr_title, pr_body, origin_label; extra_labels passed as remaining args.
 # Returns 1 on failure.
+# t2115: Uses gh_create_pr wrapper (shared-constants.sh) for origin label + signature auto-append.
 _create_pr() {
 	local repo="$1" pr_title="$2" pr_body="$3" origin_label="$4"
 	shift 4
@@ -802,7 +803,9 @@ _create_pr() {
 
 	print_info "Creating PR..."
 	local pr_url=""
-	local -a pr_cmd=(gh pr create --repo "$repo" --title "$pr_title" --body "$pr_body" --label "$origin_label")
+	# t2115: gh_create_pr auto-appends origin label and signature footer.
+	# The explicit --label "$origin_label" is kept for backward compat (GitHub deduplicates).
+	local -a pr_cmd=(gh_create_pr --repo "$repo" --title "$pr_title" --body "$pr_body" --label "$origin_label")
 	for lbl in "${extra_labels[@]+"${extra_labels[@]}"}"; do
 		pr_cmd+=(--label "$lbl")
 	done

--- a/.agents/scripts/pulse-dispatch-large-file-gate.sh
+++ b/.agents/scripts/pulse-dispatch-large-file-gate.sh
@@ -329,7 +329,8 @@ Issue #${parent_issue} is blocked by the large-file gate. Workers dispatched aga
 - Verify: \`wc -l ${lf_path}\` should be below ${LARGE_FILE_LINE_THRESHOLD}
 
 _Created by large-file simplification gate (pulse-dispatch-core.sh)_"
-	_create_combined=$(gh issue create --repo "$repo_slug" \
+	# t2115: Use gh_create_issue wrapper for origin label + signature auto-append.
+	_create_combined=$(gh_create_issue --repo "$repo_slug" \
 		--title "simplification-debt: ${lf_path} exceeds ${LARGE_FILE_LINE_THRESHOLD} lines" \
 		--label "simplification-debt,auto-dispatch,origin:worker" \
 		--body "$_create_body" 2>&1) || true

--- a/.agents/scripts/pulse-triage.sh
+++ b/.agents/scripts/pulse-triage.sh
@@ -717,7 +717,9 @@ _create_consolidation_child_issue() {
 	printf '%s\n' "$child_body" >"$body_file"
 
 	local child_url
-	child_url=$(gh issue create --repo "$repo_slug" \
+	# t2115: Use gh_create_issue wrapper for origin label + signature auto-append.
+	# origin:worker is kept in --label for explicitness (wrapper deduplicates).
+	child_url=$(gh_create_issue --repo "$repo_slug" \
 		--title "consolidation-task: merge thread on #${issue_number} into single spec" \
 		--label "consolidation-task,auto-dispatch,origin:worker,tier:standard" \
 		--body-file "$body_file" 2>/dev/null) || child_url=""

--- a/.agents/scripts/routine-log-helper.sh
+++ b/.agents/scripts/routine-log-helper.sh
@@ -893,7 +893,8 @@ _create_github_issue() {
 	local body="$3"
 
 	local issue_url
-	if ! issue_url=$(gh issue create --repo "$repo_slug" --title "$title" --body "$body" --label "routines" 2>&1); then
+	# t2115: Use gh_create_issue wrapper for origin label + signature auto-append.
+	if ! issue_url=$(gh_create_issue --repo "$repo_slug" --title "$title" --body "$body" --label "routines" 2>&1); then
 		_log_error "Failed to create issue: ${issue_url}"
 		return 1
 	fi

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -908,11 +908,86 @@ _gh_wrapper_auto_assignee() {
 	return 0
 }
 
+# t2115: Auto-append signature footer to --body/--body-file when missing.
+# Populates global _GH_WRAPPER_SIG_MODIFIED_ARGS with the (possibly modified) args.
+# Callers should invoke _gh_wrapper_auto_sig "$@" then
+#   set -- "${_GH_WRAPPER_SIG_MODIFIED_ARGS[@]}"
+# Non-fatal: if signature generation fails, original args are preserved.
+_GH_WRAPPER_SIG_MODIFIED_ARGS=()
+_gh_wrapper_auto_sig() {
+	_GH_WRAPPER_SIG_MODIFIED_ARGS=("$@")
+	local sig_helper
+	sig_helper="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/gh-signature-helper.sh"
+	[[ -x "$sig_helper" ]] || return 0
+
+	local i=0 body_val="" body_idx=-1 is_eq_form=0
+	local body_file_val="" body_file_idx=-1 bf_is_eq=0
+	while [[ $i -lt ${#_GH_WRAPPER_SIG_MODIFIED_ARGS[@]} ]]; do
+		case "${_GH_WRAPPER_SIG_MODIFIED_ARGS[i]}" in
+		--body)
+			body_idx=$i
+			body_val="${_GH_WRAPPER_SIG_MODIFIED_ARGS[i + 1]:-}"
+			is_eq_form=0
+			;;
+		--body=*)
+			body_idx=$i
+			body_val="${_GH_WRAPPER_SIG_MODIFIED_ARGS[i]#--body=}"
+			is_eq_form=1
+			;;
+		--body-file)
+			body_file_idx=$i
+			body_file_val="${_GH_WRAPPER_SIG_MODIFIED_ARGS[i + 1]:-}"
+			bf_is_eq=0
+			;;
+		--body-file=*)
+			body_file_idx=$i
+			body_file_val="${_GH_WRAPPER_SIG_MODIFIED_ARGS[i]#--body-file=}"
+			bf_is_eq=1
+			;;
+		esac
+		i=$((i + 1))
+	done
+
+	# Handle --body case
+	if [[ $body_idx -ge 0 && -n "$body_val" ]]; then
+		# Already signed — skip
+		[[ "$body_val" == *"<!-- aidevops:sig -->"* ]] && return 0
+		local sig_footer
+		sig_footer=$("$sig_helper" footer --body "$body_val" 2>/dev/null || echo "")
+		[[ -z "$sig_footer" ]] && return 0
+		local new_body="${body_val}${sig_footer}"
+		if [[ "$is_eq_form" -eq 1 ]]; then
+			_GH_WRAPPER_SIG_MODIFIED_ARGS[body_idx]="--body=${new_body}"
+		else
+			_GH_WRAPPER_SIG_MODIFIED_ARGS[body_idx + 1]="$new_body"
+		fi
+		return 0
+	fi
+
+	# Handle --body-file case
+	if [[ $body_file_idx -ge 0 && -n "$body_file_val" && -f "$body_file_val" ]]; then
+		local file_content
+		file_content=$(<"$body_file_val") || return 0
+		[[ "$file_content" == *"<!-- aidevops:sig -->"* ]] && return 0
+		local sig_footer
+		sig_footer=$("$sig_helper" footer --body "$file_content" 2>/dev/null || echo "")
+		[[ -z "$sig_footer" ]] && return 0
+		printf '%s' "$sig_footer" >>"$body_file_val"
+		return 0
+	fi
+
+	return 0
+}
+
 gh_create_issue() {
 	local origin_label
 	origin_label=$(session_origin_label)
 	# Ensure labels exist on the target repo (once per repo per process)
 	_ensure_origin_labels_for_args "$@"
+
+	# t2115: auto-append signature footer when body lacks one
+	_gh_wrapper_auto_sig "$@"
+	set -- "${_GH_WRAPPER_SIG_MODIFIED_ARGS[@]}"
 
 	# t2028: auto-assign to the current user when the session is interactive
 	# and the caller did not pass an explicit --assignee. Reaches parity with
@@ -1023,6 +1098,11 @@ gh_create_pr() {
 	local origin_label
 	origin_label=$(session_origin_label)
 	_ensure_origin_labels_for_args "$@"
+
+	# t2115: auto-append signature footer when body lacks one
+	_gh_wrapper_auto_sig "$@"
+	set -- "${_GH_WRAPPER_SIG_MODIFIED_ARGS[@]}"
+
 	gh pr create "$@" --label "$origin_label"
 }
 

--- a/.agents/scripts/tests/test-gh-wrapper-auto-sig.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-auto-sig.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# Tests for _gh_wrapper_auto_sig (t2115) in shared-constants.sh
+# =============================================================================
+# Validates that the gh_create_issue/gh_create_pr wrappers auto-append
+# signature footers to --body/--body-file when missing.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit
+PARENT_DIR="${SCRIPT_DIR}/.."
+
+PASS=0
+FAIL=0
+
+assert_contains() {
+	local test_name="$1"
+	local needle="$2"
+	local haystack="$3"
+	if [[ "$haystack" == *"$needle"* ]]; then
+		echo "  PASS: $test_name"
+		PASS=$((PASS + 1))
+	else
+		echo "  FAIL: $test_name"
+		echo "    expected to contain: $needle"
+		echo "    actual: $haystack"
+		FAIL=$((FAIL + 1))
+	fi
+	return 0
+}
+
+assert_not_contains() {
+	local test_name="$1"
+	local needle="$2"
+	local haystack="$3"
+	if [[ "$haystack" != *"$needle"* ]]; then
+		echo "  PASS: $test_name"
+		PASS=$((PASS + 1))
+	else
+		echo "  FAIL: $test_name"
+		echo "    expected NOT to contain: $needle"
+		echo "    actual: $haystack"
+		FAIL=$((FAIL + 1))
+	fi
+	return 0
+}
+
+assert_eq() {
+	local test_name="$1"
+	local expected="$2"
+	local actual="$3"
+	if [[ "$expected" == "$actual" ]]; then
+		echo "  PASS: $test_name"
+		PASS=$((PASS + 1))
+	else
+		echo "  FAIL: $test_name"
+		echo "    expected: $expected"
+		echo "    actual:   $actual"
+		FAIL=$((FAIL + 1))
+	fi
+	return 0
+}
+
+echo "=== _gh_wrapper_auto_sig tests (t2115) ==="
+echo ""
+
+# Set up a temp dir with a stubbed gh-signature-helper.sh so we control output
+TMPDIR_TEST=$(mktemp -d 2>/dev/null || mktemp -d -t autosig)
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+# Create a stub gh-signature-helper.sh that returns a predictable footer
+cat >"${TMPDIR_TEST}/gh-signature-helper.sh" <<'STUB'
+#!/usr/bin/env bash
+# Stub signature helper for testing
+cmd="$1"; shift
+if [[ "$cmd" == "footer" ]]; then
+    # Skip --body arg parsing for the stub — just emit the footer
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+        --body) shift ;; # skip body value
+        *) ;;
+        esac
+        shift
+    done
+    printf '\n<!-- aidevops:sig -->\n---\n[aidevops.sh](https://aidevops.sh) v0.0.0-test stub footer.\n'
+fi
+exit 0
+STUB
+chmod +x "${TMPDIR_TEST}/gh-signature-helper.sh"
+
+# Copy shared-constants.sh to the temp dir so BASH_SOURCE resolves the stub
+cp "${PARENT_DIR}/shared-constants.sh" "${TMPDIR_TEST}/shared-constants.sh"
+
+# Source with include guard reset to force reload
+unset _SHARED_CONSTANTS_LOADED
+# Prevent the re-exec guard from running by pretending we're already on bash 4+
+export AIDEVOPS_BASH_REEXECED=1
+# shellcheck source=/dev/null
+source "${TMPDIR_TEST}/shared-constants.sh"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 1: --body without signature gets footer appended
+# ─────────────────────────────────────────────────────────────────────────────
+echo "Test 1: --body without signature gets footer appended"
+_gh_wrapper_auto_sig --repo "owner/repo" --title "test" --body "Hello world" --label "bug"
+result="${_GH_WRAPPER_SIG_MODIFIED_ARGS[*]}"
+assert_contains "body now has signature marker" "<!-- aidevops:sig -->" "$result"
+
+# Extract the actual body value (it's the arg after --body)
+body_val=""
+for ((i = 0; i < ${#_GH_WRAPPER_SIG_MODIFIED_ARGS[@]}; i++)); do
+	if [[ "${_GH_WRAPPER_SIG_MODIFIED_ARGS[i]}" == "--body" ]]; then
+		body_val="${_GH_WRAPPER_SIG_MODIFIED_ARGS[i + 1]}"
+		break
+	fi
+done
+assert_contains "body starts with original content" "Hello world" "$body_val"
+assert_contains "body has footer" "stub footer" "$body_val"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 2: --body with existing signature is NOT modified
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Test 2: --body with existing signature is NOT modified"
+original_body="Hello world
+<!-- aidevops:sig -->
+---
+existing signature"
+_gh_wrapper_auto_sig --repo "owner/repo" --title "test" --body "$original_body"
+body_val=""
+for ((i = 0; i < ${#_GH_WRAPPER_SIG_MODIFIED_ARGS[@]}; i++)); do
+	if [[ "${_GH_WRAPPER_SIG_MODIFIED_ARGS[i]}" == "--body" ]]; then
+		body_val="${_GH_WRAPPER_SIG_MODIFIED_ARGS[i + 1]}"
+		break
+	fi
+done
+assert_eq "body unchanged when already signed" "$original_body" "$body_val"
+assert_not_contains "no stub footer appended" "stub footer" "$body_val"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 3: --body=VALUE form (equals syntax)
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Test 3: --body=VALUE form gets footer appended"
+_gh_wrapper_auto_sig --repo "owner/repo" --body="No signature here"
+body_val=""
+for ((i = 0; i < ${#_GH_WRAPPER_SIG_MODIFIED_ARGS[@]}; i++)); do
+	case "${_GH_WRAPPER_SIG_MODIFIED_ARGS[i]}" in
+	--body=*)
+		body_val="${_GH_WRAPPER_SIG_MODIFIED_ARGS[i]#--body=}"
+		break
+		;;
+	esac
+done
+assert_contains "equals-form body has signature" "<!-- aidevops:sig -->" "$body_val"
+assert_contains "equals-form body has original content" "No signature here" "$body_val"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 4: --body-file gets footer appended to file
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Test 4: --body-file gets footer appended"
+body_file="${TMPDIR_TEST}/test-body.md"
+printf 'Issue body from file' >"$body_file"
+_gh_wrapper_auto_sig --repo "owner/repo" --title "test" --body-file "$body_file"
+file_content=$(<"$body_file")
+assert_contains "file body has signature marker" "<!-- aidevops:sig -->" "$file_content"
+assert_contains "file body has original content" "Issue body from file" "$file_content"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 5: --body-file with existing signature is NOT modified
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Test 5: --body-file with existing signature is NOT modified"
+body_file2="${TMPDIR_TEST}/test-body-signed.md"
+printf 'Already signed\n<!-- aidevops:sig -->\n---\nexisting' >"$body_file2"
+original_size=$(wc -c <"$body_file2" | tr -d ' ')
+_gh_wrapper_auto_sig --repo "owner/repo" --body-file "$body_file2"
+new_size=$(wc -c <"$body_file2" | tr -d ' ')
+assert_eq "file size unchanged when already signed" "$original_size" "$new_size"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 6: no --body or --body-file leaves args unchanged
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Test 6: no body args leaves everything unchanged"
+_gh_wrapper_auto_sig --repo "owner/repo" --title "test" --label "bug"
+result="${_GH_WRAPPER_SIG_MODIFIED_ARGS[*]}"
+assert_not_contains "no signature injected without body" "aidevops:sig" "$result"
+assert_contains "args preserved" "--repo owner/repo --title test --label bug" "$result"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 7: other args preserved after body modification
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Test 7: non-body args preserved"
+_gh_wrapper_auto_sig --repo "owner/repo" --title "My Title" --body "content" --label "enhancement"
+# Check that --repo, --title, --label are all still present
+result="${_GH_WRAPPER_SIG_MODIFIED_ARGS[*]}"
+assert_contains "repo preserved" "--repo owner/repo" "$result"
+assert_contains "title preserved" "--title My Title" "$result"
+assert_contains "label preserved" "--label enhancement" "$result"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Summary
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Signature footers were missing from recent issues and PRs because the `gh_create_issue` / `gh_create_pr` wrappers only enforced origin labels — each caller had to independently call `gh-signature-helper.sh footer` and append the result. This opt-in pattern was frequently missed.

## Root Cause

Three failure modes:
1. **Wrapper gap**: `gh_create_issue()` and `gh_create_pr()` in `shared-constants.sh` only added `--label origin:*` but never appended signature footers
2. **Raw `gh` calls**: Scripts like `pulse-triage.sh`, `pulse-dispatch-large-file-gate.sh`, `routine-log-helper.sh` called `gh issue create` directly, bypassing both wrappers and signatures
3. **Full-loop raw PR creation**: `full-loop-helper.sh` used raw `gh pr create` instead of the wrapper

## Fix

- Added `_gh_wrapper_auto_sig()` in `shared-constants.sh` — extracts `--body`/`--body-file` from args, checks for existing `<!-- aidevops:sig -->` marker, and appends via `gh-signature-helper.sh footer` when missing. Integrated into both `gh_create_issue()` and `gh_create_pr()`.
- Converted raw `gh issue create` / `gh pr create` calls to use the wrappers in 4 scripts.
- New test: `test-gh-wrapper-auto-sig.sh` (15 assertions covering `--body`, `--body=`, `--body-file`, dedup, and arg preservation).

## Files Changed

- `shared-constants.sh` — added `_gh_wrapper_auto_sig()`, integrated into both wrappers
- `full-loop-helper.sh` — `_create_pr()` uses `gh_create_pr` wrapper
- `pulse-triage.sh` — consolidation child uses `gh_create_issue`
- `pulse-dispatch-large-file-gate.sh` — debt issue uses `gh_create_issue`
- `routine-log-helper.sh` — issue creation uses `gh_create_issue`
- NEW: `tests/test-gh-wrapper-auto-sig.sh`

## Runtime Testing

- ShellCheck clean on all 6 files (zero warnings)
- 15/15 new test assertions pass
- 56/56 existing signature helper tests pass (no regressions)

Resolves #19100

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.36 plugin for [OpenCode](https://opencode.ai) v1.4.4 with claude-opus-4-6 spent 9m and 24,550 tokens on this as a headless worker.