### PR TITLE
t2102: fix(pulse-simplification): pull aidevops worktree fresh before ratchet-check

### DIFF
--- a/.agents/scripts/pulse-simplification.sh
+++ b/.agents/scripts/pulse-simplification.sh
@@ -1675,6 +1675,19 @@ _complexity_scan_ratchet_check() {
 	local aidevops_path="$2"
 	local aidevops_slug="$3"
 
+	# t2102: Pull aidevops worktree fresh before ratchet-check to avoid stale reads.
+	# If HEAD is not main, offline, or the pull fails, skip this cycle — never crash the pulse.
+	local current_branch
+	current_branch=$(git -C "$aidevops_path" rev-parse --abbrev-ref HEAD 2>/dev/null) || current_branch=""
+	if [[ "$current_branch" != "main" ]]; then
+		echo "[pulse-wrapper] ratchet-check: skipping — aidevops worktree HEAD is '${current_branch}', not main" >>"$LOGFILE"
+		return 0
+	fi
+	if ! git -C "$aidevops_path" pull --ff-only origin main >>"$LOGFILE" 2>&1; then
+		echo "[pulse-wrapper] ratchet-check: skipping — git pull --ff-only failed (offline or conflict)" >>"$LOGFILE"
+		return 0
+	fi
+
 	# Phase 5: Ratchet-check — lower thresholds when simplification wins accumulate (t1913)
 	# Runs after backfill so closed issues are reflected in violation counts.
 	# Creates a chore/ratchet-down PR when gap >= 5 (default).


### PR DESCRIPTION
## Summary

- Adds `git pull --ff-only origin main` immediately before the `_complexity_scan_ratchet_check` ratchet-check invocation in `pulse-simplification.sh`
- Prevents stale workspace reads from proposing ratchet-down thresholds that have already landed on `main` (secondary cause of #19024 duplicate)
- Three safety gates: non-main HEAD → skip+log, pull failure (offline/conflict) → skip+log, never crashes the pulse

## Changes

- **EDIT: `.agents/scripts/pulse-simplification.sh`** — lines 1678-1689: added branch check + `git pull --ff-only` guard before `ratchet_output=` invocation

## Verification

- `shellcheck .agents/scripts/pulse-simplification.sh` — zero violations

## Acceptance criteria

- [x] `git pull --ff-only origin main` called before ratchet-check
- [x] Pull failure logged and causes skip-with-return-0 (never crash the pulse)
- [x] Branch safety check: if HEAD isn't main, skip and log
- [x] Shellcheck clean

Resolves #19037

---
<!-- MERGE_SUMMARY -->
**MERGE_SUMMARY**: Fixed stale ratchet-check reads in pulse-simplification by adding `git pull --ff-only origin main` before `_complexity_scan_ratchet_check`. Non-main HEAD and pull failures are logged and skip the cycle gracefully. Shellcheck clean. Resolves the secondary cause of #19024 duplicate ratchet-down proposals.