### PR TITLE
GH#19112: simplification: tighten shell-style-guide.md (155 → 153 lines)

### DIFF
--- a/.agents/reference/shell-style-guide.md
+++ b/.agents/reference/shell-style-guide.md
@@ -65,7 +65,6 @@ The lint gate (Phase 2) rejects these:
 ```bash
 # BAD
 RED='\033[0;31m'
-GREEN='\033[0;32m'
 ```
 
 Fix: Pattern A or B.
@@ -75,7 +74,6 @@ Fix: Pattern A or B.
 ```bash
 # WORST
 readonly RED='\033[0;31m'
-readonly GREEN='\033[0;32m'
 ```
 
 Fix: Pattern B (production) or Pattern C with prefix (tests).
@@ -130,9 +128,11 @@ Audit (2026-04-15): **18 scripts** with unguarded plain assignments and **2 prod
 | Include guard (`if [[ -z "${_SHARED_CONSTANTS_LOADED:-}" ]]`) | 6 | Safe but coarse | migrate |
 | Prefixed vars (`TEST_RED`, `C_GREEN`) | 50 | Safe (Pattern C) | normalise Phase 7 |
 
-Of the 13 unguarded-readonly, only 2 are production (`sonarcloud-autofix.sh`, `coderabbit-cli.sh`); remaining 11 are test harnesses (bare `RED` instead of `TEST_RED`).
+Of the 13 unguarded-readonly: 2 production (`sonarcloud-autofix.sh`, `coderabbit-cli.sh`), 11 test harnesses.
 
 ## Phased migration roadmap (t2053)
+
+Each phase ships as its own child task/PR (≤5 files per PR, t1422 quality-debt cap):
 
 1. **Phase 1** — Foundation: this guide + `prompts/build.txt` rule + `architecture.md` cross-ref.
 2. **Phase 2** — Lint gate: `shell-init-pattern-check.sh` + CI + unit test. Must land before Phase 3.
@@ -142,8 +142,6 @@ Of the 13 unguarded-readonly, only 2 are production (`sonarcloud-autofix.sh`, `c
 6. **Phase 6** — Eliminate banned `readonly`: `sonarcloud-autofix.sh`, `coderabbit-cli.sh`, `agent-sources-helper.sh` + test harness prefix normalisation. Final: zero violations.
 7. **Phase 7** — Prefixed-var normalisation (optional): consolidate `C_`, `LC_`, `TEST_` conventions.
 8. **Phase 8** — Extend to other shared-variable categories (optional): `SCRIPT_DIR`, `REPO_ROOT`, `set -E`, error-print helpers.
-
-Each phase ships as its own child task/PR, respecting t1422 quality-debt cap of ≤5 files per PR.
 
 ## Related
 


### PR DESCRIPTION
## Summary

Tighten `.agents/reference/shell-style-guide.md` per GH#19112 simplification scan.

**Classification:** Instruction doc (not a reference corpus) — tighten prose, preserve all institutional knowledge.

**Changes:**
- Banned-pattern code blocks reduced from 2 variables to 1 each — one example is sufficient to illustrate the anti-pattern (RED and GREEN is redundant; RED alone communicates the rule)
- Audit data summary sentence tightened (same data, fewer words)
- Roadmap capacity note (`≤5 files per PR, t1422`) moved before the phase list where it serves as an intro rather than a footnote

**Verification:**
- 155 → 153 lines
- All code blocks present: 6 blocks (12 fences) — unchanged
- All task/issue refs preserved: t2053, t1422, GH#18702, GH#18693, GH#18735, PR #18728
- Qlty: 0 smells (markdown file — no qlty analysis applicable)

Resolves #19112

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated shell style guide with tightened examples and clearer guidance on banned patterns
  * Refined audit section information for improved clarity
  * Enhanced migration roadmap with explicit constraints for phased delivery

<!-- end of auto-generated comment: release notes by coderabbit.ai -->