### PR TITLE
GH#19109: feat(pulse): dispatch throttle on overlapping file footprints (t2117)

### DIFF
--- a/.agents/scripts/dispatch-dedup-footprint.sh
+++ b/.agents/scripts/dispatch-dedup-footprint.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# dispatch-dedup-footprint.sh — File-footprint overlap throttle for dispatch (t2117/GH#19109)
+#
+# Prevents parallel dispatch of workers whose target file sets overlap.
+# When two issues both modify the same file, whichever PR merges first
+# invalidates the other (merge conflict or semantic conflict). The
+# update-branch salvage path (t2116) rescues trivial cases, but genuine
+# line-conflicting edits still cascade through CONFLICTING-close.
+#
+# This module is sourced by pulse-dispatch-core.sh. Depends on
+# shared-constants.sh being sourced first by the orchestrator.
+#
+# Functions:
+#   - _footprint_extract_paths    — parse file paths from issue body text
+#   - _footprint_get_inflight     — collect file footprints for all in-flight issues
+#   - _footprint_check_overlap    — check if a candidate's files overlap with in-flight
+#
+# Integration point: _dispatch_dedup_check_layers() in pulse-dispatch-core.sh
+# calls _footprint_check_overlap() after the large-file gate and before the
+# 7-layer dedup chain.
+#
+# Decay: natural — the check queries issues with active status labels
+# (status:in-progress, status:in-review, status:claimed). Once the blocking
+# issue's PR merges and labels clear, the overlap disappears.
+
+[[ -n "${_DISPATCH_DEDUP_FOOTPRINT_LOADED:-}" ]] && return 0
+_DISPATCH_DEDUP_FOOTPRINT_LOADED=1
+
+# Cache for in-flight footprints — built once per pulse cycle, not per candidate.
+# Keyed by repo_slug. Format: associative array of file→issue_number mappings.
+# Populated lazily on first call to _footprint_check_overlap for each repo.
+_FOOTPRINT_CACHE_REPO=""
+_FOOTPRINT_CACHE_DATA=""
+_FOOTPRINT_CACHE_EPOCH=0
+
+# Maximum age of the footprint cache in seconds. After this, rebuild.
+_FOOTPRINT_CACHE_TTL=120
+
+#######################################
+# Extract file paths from an issue body.
+#
+# Parses the same formats as the brief template's "Files to Modify" section:
+#   - `EDIT: path/to/file.sh:45-60` — existing file edit
+#   - `NEW: path/to/file.sh` — new file creation
+#   - Backtick-wrapped paths on list items: `- \`path/to/file.sh\``
+#   - Plain paths after "File:" prefix
+#
+# Strips line-number qualifiers (`:NNN` or `:START-END`) since we only care
+# about file-level overlap, not line-level.
+#
+# Args:
+#   $1 = issue body text
+# Output: one file path per line (sorted, unique, no line qualifiers)
+# Exit: always 0
+#######################################
+_footprint_extract_paths() {
+	local issue_body="$1"
+	[[ -n "$issue_body" ]] || return 0
+
+	local paths=""
+
+	# Pattern 1: EDIT:/NEW:/File: prefixed paths (brief template format)
+	local prefixed
+	prefixed=$(printf '%s' "$issue_body" | grep -oE '(EDIT|NEW|File):?\s+[`"]?[^`"[:space:],]+' 2>/dev/null |
+		sed 's/^[A-Z]*:*[[:space:]]*//' | sed 's/^[`"]//' | sed 's/[`"]*$//' | sort -u) || prefixed=""
+
+	# Pattern 2: Backtick-wrapped paths on list items (common in issue bodies)
+	# Match files with common source extensions
+	local backtick_paths
+	backtick_paths=$(printf '%s' "$issue_body" | grep -E '^\s*[-*]\s' 2>/dev/null |
+		grep -oE '`[^`]*\.(sh|py|js|ts|json|yml|yaml|md|conf|toml)[^`]*`' 2>/dev/null |
+		tr -d '`' | grep -v '^#' | sort -u) || backtick_paths=""
+
+	# Pattern 3: "Relevant files:" section — plain paths
+	local relevant_section
+	relevant_section=$(printf '%s' "$issue_body" | sed -n '/[Rr]elevant [Ff]iles/,/^$/p' 2>/dev/null |
+		grep -oE '[-]?\s*[`]?\.?[a-zA-Z][a-zA-Z0-9_./-]+\.(sh|py|js|ts|json|yml|yaml|md|conf|toml)[^`]*' 2>/dev/null |
+		sed 's/^[-[:space:]]*//' | tr -d '`' | sort -u) || relevant_section=""
+
+	# Combine all sources
+	paths=$(printf '%s\n%s\n%s' "$prefixed" "$backtick_paths" "$relevant_section" | sort -u | grep -v '^$' || true)
+
+	# Strip line-number qualifiers — we only care about file-level overlap
+	# Handles: file.sh:45, file.sh:45-60, file.sh:1477
+	printf '%s' "$paths" | sed 's/:[0-9]*\(-[0-9]*\)*$//' | sort -u | grep -v '^$' || true
+	return 0
+}
+
+#######################################
+# Get file footprints for all currently in-flight issues in a repo.
+#
+# "In-flight" = issue has an active status label (status:in-progress,
+# status:in-review, status:claimed) which indicates a worker is currently
+# processing it. Issues with status:queued are not yet dispatched and
+# don't count.
+#
+# Returns a newline-separated list of "file|issue_number" pairs.
+# Uses a TTL-based cache to avoid repeated API calls within a pulse cycle.
+#
+# Args:
+#   $1 = repo_slug (owner/repo)
+#   $2 = (optional) issue to exclude from results (the candidate itself)
+# Output: "file_path|issue_number" pairs, one per line
+# Exit: always 0
+#######################################
+_footprint_get_inflight() {
+	local repo_slug="$1"
+	local exclude_issue="${2:-}"
+
+	local now_epoch
+	now_epoch=$(date +%s)
+
+	# Check cache validity
+	if [[ "$_FOOTPRINT_CACHE_REPO" == "$repo_slug" ]] &&
+		[[ -n "$_FOOTPRINT_CACHE_DATA" ]] &&
+		[[ $((now_epoch - _FOOTPRINT_CACHE_EPOCH)) -lt $_FOOTPRINT_CACHE_TTL ]]; then
+		# Cache hit — filter out excluded issue and return
+		# Use printf '%b' to expand \n sequences stored in cache
+		if [[ -n "$exclude_issue" ]]; then
+			printf '%b' "$_FOOTPRINT_CACHE_DATA" | grep -v "|${exclude_issue}$" | grep -v '^$' || true
+		else
+			printf '%b' "$_FOOTPRINT_CACHE_DATA" | grep -v '^$' || true
+		fi
+		return 0
+	fi
+
+	# Cache miss — rebuild
+	# Query for issues with active worker labels
+	local inflight_issues
+	inflight_issues=$(gh issue list --repo "$repo_slug" \
+		--label "status:in-progress" --state open \
+		--json number,body --limit 50 2>/dev/null) || inflight_issues="[]"
+
+	# Also include status:in-review (worker still running, PR opened)
+	local review_issues
+	review_issues=$(gh issue list --repo "$repo_slug" \
+		--label "status:in-review" --state open \
+		--json number,body --limit 50 2>/dev/null) || review_issues="[]"
+
+	# Also include status:claimed (just dispatched, worker starting)
+	local claimed_issues
+	claimed_issues=$(gh issue list --repo "$repo_slug" \
+		--label "status:claimed" --state open \
+		--json number,body --limit 50 2>/dev/null) || claimed_issues="[]"
+
+	# Merge all three lists into one (jq handles dedup by number)
+	local all_inflight
+	all_inflight=$(printf '%s\n%s\n%s' "$inflight_issues" "$review_issues" "$claimed_issues" |
+		jq -s 'add | unique_by(.number)' 2>/dev/null) || all_inflight="[]"
+
+	local issue_count
+	issue_count=$(printf '%s' "$all_inflight" | jq 'length' 2>/dev/null) || issue_count=0
+	[[ "$issue_count" =~ ^[0-9]+$ ]] || issue_count=0
+
+	local cache_data=""
+	local i=0
+	while [[ "$i" -lt "$issue_count" ]]; do
+		local num body paths
+		num=$(printf '%s' "$all_inflight" | jq -r ".[$i].number // empty" 2>/dev/null)
+		body=$(printf '%s' "$all_inflight" | jq -r ".[$i].body // empty" 2>/dev/null)
+
+		if [[ -n "$num" && -n "$body" ]]; then
+			paths=$(_footprint_extract_paths "$body")
+			if [[ -n "$paths" ]]; then
+				while IFS= read -r p; do
+					[[ -n "$p" ]] || continue
+					cache_data="${cache_data}${p}|${num}\n"
+				done <<<"$paths"
+			fi
+		fi
+		i=$((i + 1))
+	done
+
+	# Store in cache
+	_FOOTPRINT_CACHE_REPO="$repo_slug"
+	_FOOTPRINT_CACHE_DATA="$cache_data"
+	_FOOTPRINT_CACHE_EPOCH="$now_epoch"
+
+	# Return filtered result
+	if [[ -n "$exclude_issue" ]]; then
+		printf '%b' "$cache_data" | grep -v "|${exclude_issue}$" | grep -v '^$' || true
+	else
+		printf '%b' "$cache_data" | grep -v '^$' || true
+	fi
+	return 0
+}
+
+#######################################
+# Check if a candidate issue's file footprint overlaps with any in-flight issue.
+#
+# This is the main entry point called from _dispatch_dedup_check_layers.
+#
+# Args:
+#   $1 = issue_number (candidate being considered for dispatch)
+#   $2 = repo_slug (owner/repo)
+#   $3 = issue_body (body text of the candidate issue)
+# Output: on overlap, prints "FOOTPRINT_OVERLAP (issue=#<blocking> files=<list>)"
+# Exit:
+#   0 = overlap found (do NOT dispatch — defer one cycle)
+#   1 = no overlap (safe to dispatch)
+#######################################
+_footprint_check_overlap() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local issue_body="$3"
+
+	[[ -n "$issue_body" ]] || return 1
+
+	# Extract candidate's file footprint
+	local candidate_files
+	candidate_files=$(_footprint_extract_paths "$issue_body")
+	[[ -n "$candidate_files" ]] || return 1
+
+	# Get in-flight footprints (excluding self)
+	local inflight_data
+	inflight_data=$(_footprint_get_inflight "$repo_slug" "$issue_number")
+	[[ -n "$inflight_data" ]] || return 1
+
+	# Check each candidate file against in-flight footprints
+	local overlapping_files=""
+	local blocking_issue=""
+	while IFS= read -r candidate_file; do
+		[[ -n "$candidate_file" ]] || continue
+
+		# Normalise: strip leading ./ or .agents/ for comparison
+		local norm_candidate
+		norm_candidate=$(printf '%s' "$candidate_file" | sed 's|^\./||' | sed 's|^\.agents/||')
+
+		# Check against each in-flight file
+		while IFS= read -r inflight_entry; do
+			[[ -n "$inflight_entry" ]] || continue
+			local inflight_file="${inflight_entry%|*}"
+			local inflight_issue="${inflight_entry##*|}"
+
+			local norm_inflight
+			norm_inflight=$(printf '%s' "$inflight_file" | sed 's|^\./||' | sed 's|^\.agents/||')
+
+			if [[ "$norm_candidate" == "$norm_inflight" ]]; then
+				overlapping_files="${overlapping_files}${candidate_file}, "
+				blocking_issue="$inflight_issue"
+				break
+			fi
+		done <<<"$inflight_data"
+	done <<<"$candidate_files"
+
+	if [[ -n "$overlapping_files" && -n "$blocking_issue" ]]; then
+		# Trim trailing ", "
+		overlapping_files="${overlapping_files%, }"
+		printf 'FOOTPRINT_OVERLAP (issue=#%s files=%s)\n' "$blocking_issue" "$overlapping_files"
+		return 0
+	fi
+
+	return 1
+}

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -38,6 +38,7 @@
 #   - pulse-dispatch-dedup-layers.sh    — 7-layer dedup chain + stale classifier
 #   - pulse-dispatch-large-file-gate.sh — large-file simplification gate
 #   - pulse-dispatch-worker-launch.sh   — worker launch helpers + orchestrator
+#   - dispatch-dedup-footprint.sh       — file-footprint overlap throttle (t2117)
 #
 # Pure move from pulse-wrapper.sh. Byte-identical function bodies.
 # Phase 12 post-gate simplification: _is_task_committed_to_main split into
@@ -58,6 +59,9 @@ source "${BASH_SOURCE[0]%/*}/pulse-dispatch-dedup-layers.sh"
 source "${BASH_SOURCE[0]%/*}/pulse-dispatch-large-file-gate.sh"
 # shellcheck source=pulse-dispatch-worker-launch.sh
 source "${BASH_SOURCE[0]%/*}/pulse-dispatch-worker-launch.sh"
+# t2117/GH#19109: file-footprint overlap throttle
+# shellcheck source=dispatch-dedup-footprint.sh
+source "${BASH_SOURCE[0]%/*}/dispatch-dedup-footprint.sh"
 
 #######################################
 # Resolve the worker tier from issue labels. When multiple tier:* labels
@@ -823,6 +827,17 @@ _dispatch_dedup_check_layers() {
 	# shouldn't pay the complexity tax of navigating a 12,000-line file.
 	if _issue_targets_large_files "$issue_number" "$repo_slug" "$_dispatch_issue_body" "$repo_path"; then
 		echo "[dispatch_with_dedup] Dispatch deferred for #${issue_number} in ${repo_slug}: targets large file(s), simplification gate" >>"$LOGFILE"
+		return 1
+	fi
+
+	# t2117/GH#19109: File-footprint overlap throttle. If another in-flight
+	# worker is already modifying the same files, defer this dispatch to
+	# prevent CONFLICTING cascades. The check is cheap (cached per repo per
+	# cycle) and decays naturally when the blocking issue's status labels clear.
+	local _footprint_signal=""
+	_footprint_signal=$(_footprint_check_overlap "$issue_number" "$repo_slug" "$_dispatch_issue_body" 2>/dev/null) || true
+	if [[ -n "$_footprint_signal" ]]; then
+		echo "[dispatch_with_dedup] (t2117) Dispatch deferred for #${issue_number} in ${repo_slug}: ${_footprint_signal}" >>"$LOGFILE"
 		return 1
 	fi
 

--- a/.agents/scripts/tests/test-dispatch-footprint-overlap.sh
+++ b/.agents/scripts/tests/test-dispatch-footprint-overlap.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-dispatch-footprint-overlap.sh — t2117 regression guard.
+#
+# Asserts the file-footprint overlap throttle works correctly:
+#
+#   1. _footprint_extract_paths correctly parses EDIT:/NEW:/backtick paths
+#      from issue bodies and strips line qualifiers.
+#   2. _footprint_check_overlap detects overlap between a candidate and
+#      in-flight issues (via mock data).
+#   3. _footprint_check_overlap allows dispatch when file sets are disjoint.
+#   4. _footprint_extract_paths returns empty for issues with no file paths.
+#   5. Overlap detection handles normalisation (stripping .agents/ prefix).
+#
+# Failure history motivating this test: GH#19106 (CONFLICTING cascades
+# from overlapping file edits by parallel workers).
+
+set -uo pipefail
+
+TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_RED=$'\033[0;31m'
+TEST_GREEN=$'\033[0;32m'
+TEST_RESET=$'\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1" rc="$2" extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf '%sPASS%s %s\n' "$TEST_GREEN" "$TEST_RESET" "$name"
+	else
+		printf '%sFAIL%s %s %s\n' "$TEST_RED" "$TEST_RESET" "$name" "$extra"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+# Sandbox HOME so sourcing is side-effect-free
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+export HOME="${TEST_ROOT}/home"
+mkdir -p "${HOME}/.aidevops/logs" "${HOME}/.aidevops/.agent-workspace/supervisor"
+
+# Source the footprint module directly
+# shellcheck source=/dev/null
+source "${TEST_SCRIPTS_DIR}/dispatch-dedup-footprint.sh"
+
+# =============================================================================
+# Test 1 — _footprint_extract_paths parses EDIT/NEW prefix paths
+# =============================================================================
+body_with_edits='## Files to Modify
+
+- `EDIT: .agents/scripts/pulse-wrapper.sh:45-60` — add throttle
+- `NEW: .agents/scripts/dispatch-dedup-footprint.sh` — new module
+- `EDIT: .agents/configs/complexity-thresholds.conf` — update threshold'
+
+result=$(_footprint_extract_paths "$body_with_edits")
+# Should contain all three files, stripped of line qualifiers
+if printf '%s' "$result" | grep -q "pulse-wrapper.sh" &&
+	printf '%s' "$result" | grep -q "dispatch-dedup-footprint.sh" &&
+	printf '%s' "$result" | grep -q "complexity-thresholds.conf"; then
+	print_result "extract_paths: parses EDIT/NEW prefixed paths" 0
+else
+	print_result "extract_paths: parses EDIT/NEW prefixed paths" 1 "(got: ${result})"
+fi
+
+# =============================================================================
+# Test 2 — _footprint_extract_paths strips line qualifiers
+# =============================================================================
+body_with_lines='- `EDIT: scripts/helper.sh:1477` — fix bug
+- `EDIT: scripts/other.sh:221-253` — refactor section'
+
+result=$(_footprint_extract_paths "$body_with_lines")
+# Should NOT contain :1477 or :221-253
+if printf '%s' "$result" | grep -q ":[0-9]"; then
+	print_result "extract_paths: strips line qualifiers" 1 "(line qualifiers still present: ${result})"
+else
+	print_result "extract_paths: strips line qualifiers" 0
+fi
+
+# =============================================================================
+# Test 3 ��� _footprint_extract_paths parses backtick paths on list items
+# =============================================================================
+body_backticks='## Context
+
+Root-cause data and prior fix: GH#19106 / PR #19107. Relevant files:
+- `.agents/scripts/dispatch-dedup-helper.sh` (the dedup ledger)
+- `.agents/scripts/pulse-wrapper.sh` (dispatch caller)
+- `.agents/templates/brief-template.md` (Files to modify section format)'
+
+result=$(_footprint_extract_paths "$body_backticks")
+if printf '%s' "$result" | grep -q "dispatch-dedup-helper.sh" &&
+	printf '%s' "$result" | grep -q "pulse-wrapper.sh" &&
+	printf '%s' "$result" | grep -q "brief-template.md"; then
+	print_result "extract_paths: parses backtick paths on list items" 0
+else
+	print_result "extract_paths: parses backtick paths on list items" 1 "(got: ${result})"
+fi
+
+# =============================================================================
+# Test 4 — _footprint_extract_paths returns empty for no-path body
+# =============================================================================
+body_no_paths='This issue is about improving performance.
+No specific files mentioned here, just a general discussion.'
+
+result=$(_footprint_extract_paths "$body_no_paths")
+if [[ -z "$result" ]]; then
+	print_result "extract_paths: returns empty for body with no file paths" 0
+else
+	print_result "extract_paths: returns empty for body with no file paths" 1 "(got: ${result})"
+fi
+
+# =============================================================================
+# Test 5 — _footprint_check_overlap detects overlap via mock cache
+# =============================================================================
+# Simulate an in-flight issue #100 modifying pulse-wrapper.sh
+_FOOTPRINT_CACHE_REPO="test/repo"
+_FOOTPRINT_CACHE_DATA="scripts/pulse-wrapper.sh|100\nscripts/shared-constants.sh|100\n"
+_FOOTPRINT_CACHE_EPOCH=$(date +%s)
+
+# Candidate issue #200 also targets pulse-wrapper.sh
+candidate_body='## Files to Modify
+- `EDIT: scripts/pulse-wrapper.sh:100-120` — add new feature'
+
+signal=""
+overlap_rc=1
+signal=$(_footprint_check_overlap "200" "test/repo" "$candidate_body") && overlap_rc=0 || overlap_rc=$?
+if [[ "$overlap_rc" -eq 0 ]] && printf '%s' "$signal" | grep -q "FOOTPRINT_OVERLAP"; then
+	print_result "check_overlap: detects overlapping files with in-flight issue" 0
+else
+	print_result "check_overlap: detects overlapping files with in-flight issue" 1 "(rc=${overlap_rc}, signal=${signal})"
+fi
+
+# =============================================================================
+# Test 6 �� _footprint_check_overlap allows disjoint file sets
+# =============================================================================
+# In-flight #100 modifies pulse-wrapper.sh, candidate #201 modifies a different file
+_FOOTPRINT_CACHE_REPO="test/repo"
+_FOOTPRINT_CACHE_DATA="scripts/pulse-wrapper.sh|100\n"
+_FOOTPRINT_CACHE_EPOCH=$(date +%s)
+
+disjoint_body='## Files to Modify
+- `EDIT: scripts/dispatch-claim-helper.sh:50-70` — different file entirely'
+
+signal=""
+overlap_rc=1
+signal=$(_footprint_check_overlap "201" "test/repo" "$disjoint_body") && overlap_rc=0 || overlap_rc=$?
+if [[ "$overlap_rc" -eq 1 ]]; then
+	print_result "check_overlap: allows disjoint file sets" 0
+else
+	print_result "check_overlap: allows disjoint file sets" 1 "(rc=${overlap_rc}, signal=${signal})"
+fi
+
+# =============================================================================
+# Test 7 — _footprint_check_overlap handles .agents/ prefix normalisation
+# =============================================================================
+# In-flight #100 has path without .agents/ prefix
+_FOOTPRINT_CACHE_REPO="test/repo"
+_FOOTPRINT_CACHE_DATA="scripts/pulse-wrapper.sh|100\n"
+_FOOTPRINT_CACHE_EPOCH=$(date +%s)
+
+# Candidate references same file WITH .agents/ prefix
+normalise_body='## Files to Modify
+- `EDIT: .agents/scripts/pulse-wrapper.sh:200-220` — same file, different prefix'
+
+signal=""
+overlap_rc=1
+signal=$(_footprint_check_overlap "202" "test/repo" "$normalise_body") && overlap_rc=0 || overlap_rc=$?
+if [[ "$overlap_rc" -eq 0 ]] && printf '%s' "$signal" | grep -q "FOOTPRINT_OVERLAP"; then
+	print_result "check_overlap: handles .agents/ prefix normalisation" 0
+else
+	print_result "check_overlap: handles .agents/ prefix normalisation" 1 "(rc=${overlap_rc}, signal=${signal})"
+fi
+
+# =============================================================================
+# Test 8 — _footprint_check_overlap excludes self from in-flight check
+# =============================================================================
+# In-flight includes issue #300 itself
+_FOOTPRINT_CACHE_REPO="test/repo"
+_FOOTPRINT_CACHE_DATA="scripts/pulse-wrapper.sh|300\n"
+_FOOTPRINT_CACHE_EPOCH=$(date +%s)
+
+self_body='## Files to Modify
+- `EDIT: scripts/pulse-wrapper.sh:50-60` — same file as self'
+
+signal=""
+overlap_rc=1
+signal=$(_footprint_check_overlap "300" "test/repo" "$self_body") && overlap_rc=0 || overlap_rc=$?
+if [[ "$overlap_rc" -eq 1 ]]; then
+	print_result "check_overlap: excludes self from overlap detection" 0
+else
+	print_result "check_overlap: excludes self from overlap detection" 1 "(rc=${overlap_rc}, signal=${signal})"
+fi
+
+# =============================================================================
+# Summary
+# =============================================================================
+echo ""
+echo "Tests: ${TESTS_RUN} run, ${TESTS_FAILED} failed"
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Introduces a file-footprint overlap check in the dispatch path that defers parallel dispatch of workers targeting the same files. New module dispatch-dedup-footprint.sh extracts file paths from issue bodies and compares them against in-flight workers. Includes TTL-cached per-repo footprint data and 8-assertion regression test.

## Files Changed

.agents/scripts/dispatch-dedup-footprint.sh,.agents/scripts/pulse-dispatch-core.sh,.agents/scripts/tests/test-dispatch-footprint-overlap.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** All 8 regression tests pass (bash .agents/scripts/tests/test-dispatch-footprint-overlap.sh). ShellCheck clean on new files. No changes to existing test contracts.

Resolves #19109


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.37 plugin for [OpenCode](https://opencode.ai) v1.4.4 with claude-opus-4-6 spent 7m and 18,974 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented file-level overlap deduplication for dispatch operations. The system now checks in-flight issues for file overlaps before processing new work. When overlaps are detected, conflicting dispatches are automatically deferred to prevent redundant processing and improve resource efficiency.

* **Tests**
  * Added regression tests for the overlap detection functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->