### PR TITLE
GH#19118: pre-dispatch no-op validator for auto-generated issues

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -245,6 +245,8 @@ Not every task is code. Full routing table, rules, and dispatch examples: `refer
 
 Headless workers failing, stalling, or stuck in dispatch loops: `reference/worker-diagnostics.md`. Covers lifecycle (version guard → canary → dispatch → DB isolation → watchdog → recovery), architecture rationale, and a diagnostic quick reference.
 
+**Pre-dispatch validators** (GH#19118): Auto-generated issues carry a `<!-- aidevops:generator=<name> -->` marker. Before worker spawn, `pre-dispatch-validator-helper.sh validate <issue> <slug>` checks whether the premise still holds. Exit 10 closes the issue instead of dispatching. Architecture, bypass, and extension guide: `reference/pre-dispatch-validators.md`.
+
 ## Self-Improvement
 
 Every agent session should improve the system, not just complete its task. Full guidance: `reference/self-improvement.md`.

--- a/.agents/reference/pre-dispatch-validators.md
+++ b/.agents/reference/pre-dispatch-validators.md
@@ -1,0 +1,136 @@
+# Pre-Dispatch Validators
+
+Pre-dispatch validators run **after** dedup checks and **before** worker spawn for auto-generated issues. They verify the issue premise is still true before a worker is dispatched — catching stale auto-generated issues deterministically rather than relying on model self-triage.
+
+This is Fix 3 of the [#19024 post-mortem](https://github.com/marcusquinn/aidevops/issues/19024). Fixes 1 and 2 (GH#19036, GH#19037) address the ratchet-down bug at its source; this adds a generalisable safety net for the whole class of "premise stale at dispatch time" failures.
+
+## Architecture
+
+### Generator identification
+
+Auto-generated issues embed a hidden HTML comment marker in their body:
+
+```
+<!-- aidevops:generator=<name> -->
+```
+
+The validator extracts this marker with `grep -oE '<!-- aidevops:generator=[a-z-]+ -->'`. Parsing titles or labels is explicitly rejected as too brittle — markers are unambiguous and survive editorial changes to human-visible fields.
+
+### Registry
+
+`pre-dispatch-validator-helper.sh` maintains an internal registry (`_VALIDATOR_REGISTRY`) mapping generator names to validator functions. The registry is populated by `_register_validators()`. Unregistered generators fall through to exit 0 (dispatch proceeds).
+
+### Exit-code contract
+
+| Code | Meaning | Action |
+|------|---------|--------|
+| `0`  | Dispatch proceeds — premise holds or no validator registered | Worker is spawned normally |
+| `10` | Premise falsified — the auto-generated issue is stale | Helper posts rationale comment + closes issue as `not planned`; no worker spawned |
+| `20` | Validator error — unexpected failure during validation | Warning logged; dispatch proceeds (never block on validator bugs) |
+
+### Hook point
+
+The validator runs inside `dispatch_with_dedup()` in `pulse-dispatch-core.sh`, via `_run_predispatch_validator()`. Placement:
+
+```
+_dispatch_dedup_check_layers()   ← all dedup gates
+_ensure_issue_body_has_brief()   ← t2063 freshness guard
+_run_predispatch_validator()     ← GH#19118 ← HERE
+_dispatch_launch_worker()        ← worker spawn
+```
+
+`_run_predispatch_validator()` is non-fatal: if `pre-dispatch-validator-helper.sh` is missing or returns an unexpected code, dispatch proceeds.
+
+## Bypass mechanism
+
+Set `AIDEVOPS_SKIP_PREDISPATCH_VALIDATOR=1` to skip all validators unconditionally:
+
+```bash
+AIDEVOPS_SKIP_PREDISPATCH_VALIDATOR=1 ./pulse-wrapper.sh
+```
+
+Intended use: emergency recovery when a validator has a bug that is blocking legitimate dispatches. The bypass is logged. Do not leave it set permanently — validators exist to prevent wasted worker sessions.
+
+## Closure comment format
+
+When a validator returns exit 10, the helper posts a comment of the form:
+
+```
+> Premise falsified. Pre-dispatch validator for generator `<name>` determined
+> the issue premise is no longer true. The `<name>` check reports no actionable
+> work is available. Not dispatching a worker.
+
+The issue was closed automatically by the pre-dispatch validator (GH#19118).
+If conditions change … a new issue will be created by the next pulse cycle.
+
+---
+[signature footer]
+```
+
+The issue is then closed with `gh issue close --reason "not planned"`.
+
+## Registered validators
+
+### `ratchet-down`
+
+**Generator:** `_complexity_scan_ratchet_check` in `pulse-simplification.sh`
+
+**Marker:** `<!-- aidevops:generator=ratchet-down -->`
+
+**Logic:**
+
+1. Clone the target repo into a scratch directory (`mktemp -d`, cleaned on exit via `trap`)
+2. Run `complexity-scan-helper.sh ratchet-check <clone> 5`
+3. If output contains `No ratchet-down available` → exit 10 (premise falsified)
+4. Any other error with empty output → exit 20 (validator error)
+5. Otherwise → exit 0 (proposals available, dispatch)
+
+**Motivation:** The ratchet-down scan is computed at issue creation time. By dispatch time, simplification work may have already closed the gap. Without this validator, a worker is spawned, reads the complexity state, discovers no ratchet-down is possible, and exits silently — exactly the failure mode documented in the #19024 post-mortem.
+
+## How to add a new validator
+
+1. **Define the generator function** in `pulse-simplification.sh` or whichever script creates auto-generated issues for your generator type.
+
+2. **Emit the marker** in the issue body template:
+   ```bash
+   # In the issue body string
+   "...issue content...\n\n<!-- aidevops:generator=my-generator -->"
+   ```
+
+3. **Implement the validator function** in `pre-dispatch-validator-helper.sh`:
+   ```bash
+   _validator_my_generator() {
+       local slug="$1"
+       # Use $SCRATCH_DIR for temp files — trap cleanup is already set
+       # Return: 0 = dispatch, 10 = falsified, 20 = error
+       return 0
+   }
+   ```
+
+4. **Register the validator** in `_register_validators()`:
+   ```bash
+   _VALIDATOR_REGISTRY["my-generator"]="_validator_my_generator"
+   ```
+
+5. **Add a test case** in `tests/test-pre-dispatch-validator.sh` covering at minimum the falsified and legitimate paths.
+
+6. **Run shellcheck**: `shellcheck .agents/scripts/pre-dispatch-validator-helper.sh`
+
+## Testing
+
+```bash
+# Run the test harness
+bash .agents/scripts/tests/test-pre-dispatch-validator.sh
+
+# Manual smoke test (requires gh auth)
+.agents/scripts/pre-dispatch-validator-helper.sh validate <issue-number> marcusquinn/aidevops
+```
+
+The test harness uses stub `gh`, `git`, and `complexity-scan-helper.sh` binaries injected via `PATH` and `COMPLEXITY_SCAN_HELPER` env var — no network access required.
+
+## Related
+
+- `pulse-dispatch-core.sh` — `dispatch_with_dedup`, `_run_predispatch_validator`
+- `pulse-simplification.sh` — `_complexity_scan_ratchet_check` (ratchet-down generator)
+- `reference/worker-diagnostics.md` — full worker lifecycle and diagnostic reference
+- GH#19118, GH#19024 (post-mortem), GH#19036, GH#19037

--- a/.agents/scripts/pre-dispatch-validator-helper.sh
+++ b/.agents/scripts/pre-dispatch-validator-helper.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# pre-dispatch-validator-helper.sh — Pre-dispatch no-op validator for auto-generated issues (GH#19118)
+#
+# Before the pulse spawns a worker for an auto-generated issue, this helper
+# fetches the issue body, extracts the generator marker, and runs the
+# registered validator for that generator type. The result determines whether
+# dispatch proceeds, is blocked with a rationale comment, or falls back with
+# a warning.
+#
+# Generator identification uses hidden HTML comment markers of the form:
+#   <!-- aidevops:generator=<name> -->
+# Parsing titles or labels is explicitly rejected as too brittle.
+#
+# Exit codes (returned by the `validate` subcommand):
+#   0  — dispatch proceeds (premise holds, or no validator registered)
+#   10 — premise falsified; caller closes the issue with a rationale comment
+#   20 — validator error; dispatch proceeds with a warning log
+#
+# Usage:
+#   pre-dispatch-validator-helper.sh validate <issue-number> <slug>
+#   pre-dispatch-validator-helper.sh help
+#
+# Emergency bypass:
+#   AIDEVOPS_SKIP_PREDISPATCH_VALIDATOR=1 — exit 0 immediately (with log)
+#
+# Extension: to add a new validator, define a function named
+#   _validator_<generator-name>()
+# and register it in _register_validators(). The function receives no
+# arguments and must exit with 0 (valid), 10 (falsified), or 20 (error).
+# It may use $SCRATCH_DIR for temporary files; cleanup is handled by trap.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit 1
+
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/shared-constants.sh"
+
+# ---------------------------------------------------------------------------
+# Logging
+# ---------------------------------------------------------------------------
+_log() {
+	local level="$1"
+	shift
+	printf '[pre-dispatch-validator] %s: %s\n' "$level" "$*" >&2
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Registry — maps generator name → validator function name
+# Add new validators here by calling _register_validators() pattern.
+# ---------------------------------------------------------------------------
+declare -A _VALIDATOR_REGISTRY=()
+
+_register_validators() {
+	_VALIDATOR_REGISTRY["ratchet-down"]="_validator_ratchet_down"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Ratchet-down validator
+#
+# Clones the target repo into a scratch directory and runs:
+#   complexity-scan-helper.sh ratchet-check . 5
+# If the output contains "No ratchet-down available" the premise is falsified.
+# ---------------------------------------------------------------------------
+_validator_ratchet_down() {
+	local slug="$1"
+
+	_log "INFO" "ratchet-down validator: running ratchet-check on ${slug}"
+
+	# Allow test override via env var; fall back to co-located script.
+	local scan_helper="${COMPLEXITY_SCAN_HELPER:-${SCRIPT_DIR}/complexity-scan-helper.sh}"
+	if [[ ! -x "$scan_helper" ]]; then
+		_log "WARN" "ratchet-down validator: complexity-scan-helper.sh not found at ${scan_helper}"
+		return 20
+	fi
+
+	# Clone repo into scratch dir for a fresh read (avoids stale worktree reads)
+	local clone_url
+	clone_url="https://github.com/${slug}.git"
+
+	if ! git clone --depth 1 --quiet "$clone_url" "${SCRATCH_DIR}/repo" 2>/dev/null; then
+		_log "WARN" "ratchet-down validator: git clone failed for ${slug} — treating as validator error"
+		return 20
+	fi
+
+	local ratchet_output
+	local ratchet_rc=0
+	ratchet_output=$("$scan_helper" ratchet-check "${SCRATCH_DIR}/repo" 5 2>/dev/null) || ratchet_rc=$?
+
+	# ratchet-check exits 0 with output when proposals available,
+	# exits non-zero when thresholds are already tight (no proposals).
+	# Both cases: check the output text for the no-op sentinel.
+	if printf '%s' "$ratchet_output" | grep -q "No ratchet-down available"; then
+		_log "INFO" "ratchet-down validator: premise falsified — no ratchet-down available"
+		return 10
+	fi
+
+	if [[ "$ratchet_rc" -ne 0 ]] && [[ -z "$ratchet_output" ]]; then
+		# scan errored without a meaningful result — treat as validator error
+		_log "WARN" "ratchet-down validator: ratchet-check exited ${ratchet_rc} with empty output — validator error"
+		return 20
+	fi
+
+	_log "INFO" "ratchet-down validator: premise holds — ratchet-down proposals available"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Compose and post the falsified-premise closure comment, then close the issue.
+# ---------------------------------------------------------------------------
+_close_with_rationale() {
+	local issue_number="$1"
+	local slug="$2"
+	local generator="$3"
+
+	local sig_footer=""
+	if [[ -x "${SCRIPT_DIR}/gh-signature-helper.sh" ]]; then
+		sig_footer=$("${SCRIPT_DIR}/gh-signature-helper.sh" footer --issue "${slug}#${issue_number}" 2>/dev/null || true)
+	fi
+
+	local comment_body
+	comment_body=$(
+		cat <<EOF
+> Premise falsified. Pre-dispatch validator for generator \`${generator}\` determined the issue premise is no longer true. The \`${generator}\` check reports no actionable work is available. Not dispatching a worker.
+
+The issue was closed automatically by the pre-dispatch validator (GH#19118). If conditions change and ratchet-down proposals become available again, a new issue will be created by the next pulse cycle.
+
+${sig_footer}
+EOF
+	)
+
+	# Post rationale comment
+	gh issue comment "$issue_number" --repo "$slug" --body "$comment_body" >/dev/null 2>&1 ||
+		_log "WARN" "Failed to post rationale comment on #${issue_number}"
+
+	# Close the issue with reason "not planned"
+	gh issue close "$issue_number" --repo "$slug" --reason "not planned" >/dev/null 2>&1 ||
+		_log "WARN" "Failed to close issue #${issue_number}"
+
+	_log "INFO" "Closed issue #${issue_number} in ${slug} as not planned (premise falsified)"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# validate — main subcommand
+#
+# Arguments:
+#   $1 - issue_number
+#   $2 - slug (owner/repo)
+#
+# Exit codes:
+#   0  — dispatch proceeds
+#   10 — premise falsified (caller should close issue; this function already did)
+#   20 — validator error (dispatch proceeds with warning)
+# ---------------------------------------------------------------------------
+cmd_validate() {
+	local issue_number="$1"
+	local slug="$2"
+
+	# Bypass guard — emergency exit
+	if [[ "${AIDEVOPS_SKIP_PREDISPATCH_VALIDATOR:-}" == "1" ]]; then
+		_log "INFO" "AIDEVOPS_SKIP_PREDISPATCH_VALIDATOR=1 — skipping validator for #${issue_number}"
+		return 0
+	fi
+
+	if [[ -z "$issue_number" || -z "$slug" ]]; then
+		_log "ERROR" "validate requires <issue-number> <slug>"
+		return 20
+	fi
+
+	# Fetch issue body
+	local issue_body
+	issue_body=$(gh api "repos/${slug}/issues/${issue_number}" --jq '.body // ""' 2>/dev/null) || {
+		_log "WARN" "Failed to fetch issue body for #${issue_number} — proceeding (validator error)"
+		return 20
+	}
+
+	# Extract generator marker
+	local generator
+	generator=$(printf '%s' "$issue_body" | grep -oE '<!-- aidevops:generator=[a-z-]+ -->' | head -1 |
+		sed 's/<!-- aidevops:generator=//;s/ -->//' 2>/dev/null) || generator=""
+
+	if [[ -z "$generator" ]]; then
+		_log "INFO" "#${issue_number}: no generator marker found — unregistered generator, dispatch proceeds"
+		return 0
+	fi
+
+	_log "INFO" "#${issue_number}: generator=${generator}"
+
+	# Look up validator
+	_register_validators
+	local validator_fn="${_VALIDATOR_REGISTRY[$generator]:-}"
+	if [[ -z "$validator_fn" ]]; then
+		_log "INFO" "#${issue_number}: generator '${generator}' has no registered validator — dispatch proceeds"
+		return 0
+	fi
+
+	# Set up scratch dir with cleanup trap
+	SCRATCH_DIR=$(mktemp -d 2>/dev/null) || {
+		_log "WARN" "Failed to create scratch dir — treating as validator error"
+		return 20
+	}
+	# shellcheck disable=SC2064
+	trap "rm -rf '${SCRATCH_DIR}'" EXIT
+
+	# Run validator
+	local validator_rc=0
+	"$validator_fn" "$slug" || validator_rc=$?
+
+	case "$validator_rc" in
+	0)
+		_log "INFO" "#${issue_number}: validator passed — dispatch proceeds"
+		return 0
+		;;
+	10)
+		_log "INFO" "#${issue_number}: premise falsified by validator — closing issue"
+		_close_with_rationale "$issue_number" "$slug" "$generator"
+		return 10
+		;;
+	*)
+		_log "WARN" "#${issue_number}: validator returned rc=${validator_rc} (error) — dispatch proceeds"
+		return 20
+		;;
+	esac
+}
+
+# ---------------------------------------------------------------------------
+# Main dispatcher
+# ---------------------------------------------------------------------------
+_usage() {
+	cat <<EOF
+Usage:
+  pre-dispatch-validator-helper.sh validate <issue-number> <slug>
+  pre-dispatch-validator-helper.sh help
+
+Exit codes (validate):
+  0  — dispatch proceeds
+  10 — premise falsified; issue closed with rationale comment
+  20 — validator error; dispatch proceeds with warning
+
+Environment:
+  AIDEVOPS_SKIP_PREDISPATCH_VALIDATOR=1  — bypass all validators (exit 0)
+EOF
+	return 0
+}
+
+case "${1:-help}" in
+validate) cmd_validate "${2:-}" "${3:-}" ;;
+help | --help | -h) _usage ;;
+*)
+	_log "ERROR" "Unknown subcommand: ${1:-}"
+	_usage
+	exit 1
+	;;
+esac

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -928,6 +928,21 @@ dispatch_with_dedup() {
 	# and issue-sync-helper.sh. Non-fatal — dispatch proceeds even if enrich fails.
 	_ensure_issue_body_has_brief "$issue_number" "$repo_slug" "$repo_path" "$issue_title"
 
+	# GH#19118: Pre-dispatch validator — runs after dedup, before worker spawn.
+	# Checks generator-tagged auto-generated issues to verify the premise is
+	# still true. Exit 0 = dispatch proceeds; exit 10 = premise falsified
+	# (issue already closed by validator); exit 20 = validator error (dispatch
+	# proceeds with warning). Never blocks on validator bugs.
+	_run_predispatch_validator "$issue_number" "$repo_slug"
+	local _validator_rc=$?
+	if [[ "$_validator_rc" -eq 10 ]]; then
+		echo "[dispatch_with_dedup] Pre-dispatch validator falsified premise for #${issue_number} in ${repo_slug} — issue closed, not dispatching" >>"$LOGFILE"
+		return 1
+	fi
+	if [[ "$_validator_rc" -eq 20 ]]; then
+		echo "[dispatch_with_dedup] Pre-dispatch validator error for #${issue_number} in ${repo_slug} (rc=${_validator_rc}) — proceeding with dispatch" >>"$LOGFILE"
+	fi
+
 	# All checks passed — launch the worker.
 	_dispatch_launch_worker \
 		"$issue_number" "$repo_slug" "$dispatch_title" "$issue_title" \
@@ -999,6 +1014,38 @@ _ensure_issue_body_has_brief() {
 		}
 	fi
 	return 0
+}
+
+#######################################
+# GH#19118: Run the pre-dispatch validator for auto-generated issues.
+#
+# Delegates to pre-dispatch-validator-helper.sh validate <issue> <slug>.
+# Non-fatal wrapper: if the helper is missing or fails unexpectedly, logs
+# a warning and returns 0 (validator error semantics = dispatch proceeds).
+#
+# Arguments:
+#   $1 - issue_number
+#   $2 - repo_slug (owner/repo)
+#
+# Exit codes:
+#   0  — dispatch proceeds (validator passed, unregistered generator, or helper missing)
+#   10 — premise falsified; caller must NOT dispatch (issue already closed by validator)
+#   20 — validator error; caller should log warning and continue dispatch
+#######################################
+_run_predispatch_validator() {
+	local issue_number="$1"
+	local repo_slug="$2"
+
+	local validator_helper
+	validator_helper="$(dirname "${BASH_SOURCE[0]}")/pre-dispatch-validator-helper.sh"
+	if [[ ! -x "$validator_helper" ]]; then
+		echo "[dispatch_with_dedup] GH#19118: pre-dispatch-validator-helper.sh not found — skipping (dispatch proceeds)" >>"$LOGFILE"
+		return 0
+	fi
+
+	local validator_rc=0
+	"$validator_helper" validate "$issue_number" "$repo_slug" >>"$LOGFILE" 2>&1 || validator_rc=$?
+	return "$validator_rc"
 }
 
 #######################################

--- a/.agents/scripts/pulse-simplification.sh
+++ b/.agents/scripts/pulse-simplification.sh
@@ -1743,7 +1743,9 @@ grep -E 'FUNCTION_COMPLEXITY_THRESHOLD|NESTING_DEPTH_THRESHOLD|FILE_SIZE_THRESHO
 .agents/scripts/complexity-scan-helper.sh ratchet-check . 5
 # Confirm state file is NOT staged in the PR commit
 git diff --cached --name-only | grep -v 'simplification-state.json'
-\`\`\`" >/dev/null 2>&1 || true
+\`\`\`
+
+<!-- aidevops:generator=ratchet-down -->" >/dev/null 2>&1 || true
 		else
 			echo "[pulse-wrapper] ratchet-check: ratchet-down PR already open, skipping issue creation" >>"$LOGFILE"
 		fi

--- a/.agents/scripts/tests/test-pre-dispatch-validator.sh
+++ b/.agents/scripts/tests/test-pre-dispatch-validator.sh
@@ -1,0 +1,348 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-pre-dispatch-validator.sh — Test harness for pre-dispatch-validator-helper.sh (GH#19118)
+#
+# Tests:
+#   test_ratchet_down_falsified     — validator returns exit 10 when scan reports no proposals
+#   test_ratchet_down_legitimate    — validator returns exit 0 when scan reports proposals
+#   test_unregistered_generator     — issue without marker returns exit 0
+#   test_validator_error            — scan fails unexpectedly → exit 20
+#   test_bypass_env_var             — AIDEVOPS_SKIP_PREDISPATCH_VALIDATOR=1 → exit 0
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+HELPER_SCRIPT="${SCRIPT_DIR}/../pre-dispatch-validator-helper.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+
+# ---------------------------------------------------------------------------
+# Test framework helpers
+# ---------------------------------------------------------------------------
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+	mkdir -p "${TEST_ROOT}/bin"
+	export PATH="${TEST_ROOT}/bin:${PATH}"
+	return 0
+}
+
+teardown_test_env() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Stub factories
+# ---------------------------------------------------------------------------
+
+# Create a `gh` stub that returns a specific issue body.
+create_gh_stub_with_body() {
+	local issue_body_file="$1"
+
+	cat >"${TEST_ROOT}/bin/gh" <<'GHEOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+# gh api repos/<slug>/issues/<num> --jq '.body // ""'
+if [[ "${1:-}" == "api" ]] && printf '%s' "${2:-}" | grep -qE '/issues/[0-9]+$'; then
+	# Output a JSON object with the body from the file
+	body_file="BODY_FILE_PLACEHOLDER"
+	body=$(cat "$body_file" 2>/dev/null || echo "")
+	printf '{"body": "%s"}\n' "$(printf '%s' "$body" | sed 's/"/\\"/g; s/\n/\\n/g')"
+	exit 0
+fi
+
+# gh issue comment / gh issue close — succeed silently
+if [[ "${1:-}" == "issue" ]]; then
+	exit 0
+fi
+
+printf 'unsupported gh invocation in test stub: %s\n' "$*" >&2
+exit 1
+GHEOF
+
+	# Replace the placeholder with the actual path
+	sed -i "s|BODY_FILE_PLACEHOLDER|${issue_body_file}|g" "${TEST_ROOT}/bin/gh"
+	chmod +x "${TEST_ROOT}/bin/gh"
+	return 0
+}
+
+# Create a `gh` stub that returns a body with a ratchet-down generator marker.
+# Uses a Python-based stub for reliable JSON escaping.
+create_gh_stub_ratchet_body() {
+	local marker_present="${1:-true}"
+
+	local body_file="${TEST_ROOT}/issue_body.txt"
+	if [[ "$marker_present" == "true" ]]; then
+		printf '<!-- aidevops:generator=ratchet-down -->\n## Automated ratchet-down (t1913)\n' >"$body_file"
+	else
+		printf '## Some issue without a generator marker\n' >"$body_file"
+	fi
+
+	# Create a gh stub that uses python3 to safely JSON-encode the body
+	cat >"${TEST_ROOT}/bin/gh" <<GHEOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+# gh api repos/<slug>/issues/<num> with --jq '.body // ""'
+if [[ "\${1:-}" == "api" ]] && printf '%s' "\${2:-}" | grep -qE '/issues/[0-9]+\$'; then
+	# Use --jq style: the helper calls gh api ... --jq '.body // ""'
+	# so our stub must handle both "output the raw json" and "output the jq result"
+	# We output the body directly as a JSON-encoded string
+	body_file="${body_file}"
+	python3 -c "
+import json, sys
+body = open('${body_file}').read()
+# When --jq is used, gh outputs the jq result directly (unquoted string)
+# Simulate that by printing the raw body
+sys.stdout.write(body)
+" 2>/dev/null
+	exit 0
+fi
+
+# gh issue comment / gh issue close — succeed silently
+if [[ "\${1:-}" == "issue" ]]; then
+	exit 0
+fi
+
+printf 'unsupported gh invocation: %s\n' "\$*" >&2
+exit 1
+GHEOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+	return 0
+}
+
+# Create a `complexity-scan-helper.sh` stub with configurable ratchet-check output.
+create_scan_stub() {
+	local mode="$1" # "no-proposals", "proposals", "error"
+
+	cat >"${TEST_ROOT}/bin/complexity-scan-helper.sh" <<SCANEOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "\${1:-}" == "ratchet-check" ]]; then
+	case "${mode}" in
+		no-proposals)
+			printf 'No ratchet-down available: all thresholds within gap of 5\n'
+			exit 1
+			;;
+		proposals)
+			printf 'FUNCTION_COMPLEXITY_THRESHOLD 120 → 110\n'
+			exit 0
+			;;
+		error)
+			printf '' >&2
+			exit 2
+			;;
+	esac
+fi
+
+printf 'unsupported subcommand: %s\n' "\$*" >&2
+exit 1
+SCANEOF
+	chmod +x "${TEST_ROOT}/bin/complexity-scan-helper.sh"
+	return 0
+}
+
+# Create a `git` stub that simulates a successful shallow clone.
+create_git_stub() {
+	local mode="${1:-success}"
+
+	cat >"${TEST_ROOT}/bin/git" <<GITEOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "\${1:-}" == "clone" ]]; then
+	# Find the target directory (last non-flag argument)
+	_target=""
+	for _arg in "\$@"; do
+		[[ "\$_arg" == --* ]] && continue
+		_target="\$_arg"
+	done
+	if [[ "${mode}" == "success" ]]; then
+		mkdir -p "\$_target"
+		exit 0
+	else
+		printf 'fatal: repository not found\n' >&2
+		exit 128
+	fi
+fi
+
+# Pass-through for other git commands
+/usr/bin/git "\$@"
+GITEOF
+	chmod +x "${TEST_ROOT}/bin/git"
+	return 0
+}
+
+# Create a stub complexity-scan-helper.sh and export COMPLEXITY_SCAN_HELPER
+# so the validator function uses it (via the env-override path).
+setup_scan_stub_at_helper_path() {
+	local mode="$1"
+	create_scan_stub "$mode"
+	export COMPLEXITY_SCAN_HELPER="${TEST_ROOT}/bin/complexity-scan-helper.sh"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+# test_ratchet_down_falsified — stub scan returns "No ratchet-down available"
+# Expected: validator exits 10
+test_ratchet_down_falsified() {
+	setup_test_env
+	create_gh_stub_ratchet_body "true"
+	create_git_stub "success"
+	setup_scan_stub_at_helper_path "no-proposals"
+
+	local rc=0
+	"$HELPER_SCRIPT" validate "42" "marcusquinn/aidevops" >/dev/null 2>&1 || rc=$?
+
+	if [[ "$rc" -eq 10 ]]; then
+		print_result "ratchet_down_falsified exits 10" 0
+	else
+		print_result "ratchet_down_falsified exits 10" 1 "Expected exit 10, got ${rc}"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
+# test_ratchet_down_legitimate — stub scan returns real proposals
+# Expected: validator exits 0
+test_ratchet_down_legitimate() {
+	setup_test_env
+	create_gh_stub_ratchet_body "true"
+	create_git_stub "success"
+	setup_scan_stub_at_helper_path "proposals"
+
+	local rc=0
+	"$HELPER_SCRIPT" validate "43" "marcusquinn/aidevops" >/dev/null 2>&1 || rc=$?
+
+	if [[ "$rc" -eq 0 ]]; then
+		print_result "ratchet_down_legitimate exits 0" 0
+	else
+		print_result "ratchet_down_legitimate exits 0" 1 "Expected exit 0, got ${rc}"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
+# test_unregistered_generator — issue body without any generator marker
+# Expected: validator exits 0 (unregistered generator fallback)
+test_unregistered_generator() {
+	setup_test_env
+	create_gh_stub_ratchet_body "false"
+
+	local rc=0
+	"$HELPER_SCRIPT" validate "44" "marcusquinn/aidevops" >/dev/null 2>&1 || rc=$?
+
+	if [[ "$rc" -eq 0 ]]; then
+		print_result "unregistered_generator exits 0" 0
+	else
+		print_result "unregistered_generator exits 0" 1 "Expected exit 0, got ${rc}"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
+# test_validator_error — stub scan fails with non-zero and empty output
+# Expected: validator exits 20
+test_validator_error() {
+	setup_test_env
+	create_gh_stub_ratchet_body "true"
+	create_git_stub "success"
+	setup_scan_stub_at_helper_path "error"
+
+	local rc=0
+	"$HELPER_SCRIPT" validate "45" "marcusquinn/aidevops" >/dev/null 2>&1 || rc=$?
+
+	if [[ "$rc" -eq 20 ]]; then
+		print_result "validator_error exits 20" 0
+	else
+		print_result "validator_error exits 20" 1 "Expected exit 20, got ${rc}"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
+# test_bypass_env_var — AIDEVOPS_SKIP_PREDISPATCH_VALIDATOR=1
+# Expected: exits 0 regardless of issue content
+test_bypass_env_var() {
+	setup_test_env
+	create_gh_stub_ratchet_body "true"
+	create_git_stub "success"
+	setup_scan_stub_at_helper_path "no-proposals"
+
+	local rc=0
+	AIDEVOPS_SKIP_PREDISPATCH_VALIDATOR=1 "$HELPER_SCRIPT" validate "46" "marcusquinn/aidevops" >/dev/null 2>&1 || rc=$?
+
+	if [[ "$rc" -eq 0 ]]; then
+		print_result "bypass_env_var exits 0" 0
+	else
+		print_result "bypass_env_var exits 0" 1 "Expected exit 0, got ${rc}"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+	printf 'Running pre-dispatch-validator tests (GH#19118)...\n\n'
+
+	if [[ ! -x "$HELPER_SCRIPT" ]]; then
+		printf '%bERROR%b: Helper script not found or not executable: %s\n' \
+			"$TEST_RED" "$TEST_RESET" "$HELPER_SCRIPT" >&2
+		exit 1
+	fi
+
+	test_ratchet_down_falsified
+	test_ratchet_down_legitimate
+	test_unregistered_generator
+	test_validator_error
+	test_bypass_env_var
+
+	printf '\n%d test(s) run, %d failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		exit 1
+	fi
+	exit 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Implements Fix 3 of the #19024 post-mortem: a deterministic pre-dispatch validator that checks whether an auto-generated issue's premise is still true before spawning a worker.

## What

- New `pre-dispatch-validator-helper.sh` with `validate <issue> <slug>` subcommand and internal registry keyed by `<!-- aidevops:generator=X -->` markers
- Ratchet-down validator: clones repo fresh, runs `complexity-scan-helper.sh ratchet-check`, returns exit 10 when no proposals available
- Integration hook in `dispatch_with_dedup` (after dedup, before worker spawn) via `_run_predispatch_validator()`
- Generator marker `<!-- aidevops:generator=ratchet-down -->` added to ratchet-down issue body template
- `AIDEVOPS_SKIP_PREDISPATCH_VALIDATOR=1` bypass guard
- 5-case test harness (all passing)
- `reference/pre-dispatch-validators.md` documentation with extension guide
- Worker Diagnostics link in `AGENTS.md`

## Exit-code contract

| Code | Meaning | Action |
|------|---------|--------|
| `0`  | Premise holds / no validator registered | Dispatch proceeds |
| `10` | Premise falsified | Helper closes issue as `not planned`; no worker |
| `20` | Validator error | Warning logged; dispatch proceeds |

## Verification

```bash
bash .agents/scripts/tests/test-pre-dispatch-validator.sh
# Expected: 5 test(s) run, 0 failed
```

Resolves #19118