### PR TITLE
GH#19119: GH#19119: simplification: tighten shell-style-guide.md (153 → 149 lines)

### DIFF
--- a/.agents/reference/shell-style-guide.md
+++ b/.agents/reference/shell-style-guide.md
@@ -42,7 +42,7 @@ set -Eeuo pipefail
 
 `${VAR+x}` distinguishes *unset* from *set-to-empty* — parent with `shared-constants.sh` wins; standalone picks up fallback. **Do not use `${VAR:-}`** — it treats set-to-empty as unset.
 
-### C — prefixed names (test harnesses only)
+### C — prefixed names (test harnesses and strictly-internal utilities)
 
 For test harnesses and strictly-internal utilities only. Prefix must be `TEST_`, `_<script_name>_`, or documented in `shared-constants.sh`:
 

--- a/.agents/reference/shell-style-guide.md
+++ b/.agents/reference/shell-style-guide.md
@@ -3,13 +3,11 @@
 
 # Shell Helper Style Guide
 
-Canonical rules for `.agents/scripts/**/*.sh`: **source `shared-constants.sh` OR use `[[ -z "${VAR+x}" ]]` guards**. Never declare `RED`, `GREEN`, `YELLOW`, `BLUE`, `PURPLE`, `CYAN`, `WHITE`, or `NC` at top level without a guard. Never `readonly` those names outside `shared-constants.sh`.
-
-Enforcement: `shell-init-pattern-check.sh` + CI workflow (Phase 2 of t2053). Rule in `prompts/build.txt` → Quality Standards.
+Canonical rules for `.agents/scripts/**/*.sh`: **source `shared-constants.sh` OR use `[[ -z "${VAR+x}" ]]` guards**. Never declare `RED`, `GREEN`, `YELLOW`, `BLUE`, `PURPLE`, `CYAN`, `WHITE`, or `NC` at top level without a guard. Never `readonly` those names outside `shared-constants.sh`. Enforcement: `shell-init-pattern-check.sh` + CI (Phase 2, t2053). Rule in `prompts/build.txt` → Quality Standards.
 
 ## Allowed patterns
 
-### Pattern A — Preferred: source `shared-constants.sh`
+### A — source `shared-constants.sh` (preferred)
 
 For scripts inside `.agents/scripts/` with a stable path to `shared-constants.sh`:
 
@@ -26,7 +24,7 @@ echo -e "${GREEN}[OK]${NC} sourced shared constants"
 
 Use `${RED}`, `${GREEN}`, etc. directly — no local declarations needed. Subdirectory scripts: `source "${SCRIPT_DIR}/../shared-constants.sh"`.
 
-### Pattern B — Fallback: granular `${VAR+x}` guard
+### B — granular `${VAR+x}` guard (fallback)
 
 For scripts runnable without `shared-constants.sh` (early bootstrap, standalone CLIs, `bash <(curl …)` distribution):
 
@@ -44,7 +42,7 @@ set -Eeuo pipefail
 
 `${VAR+x}` distinguishes *unset* from *set-to-empty* — parent with `shared-constants.sh` wins; standalone picks up fallback. **Do not use `${VAR:-}`** — it treats set-to-empty as unset.
 
-### Pattern C — Private internal: prefixed names
+### C — prefixed names (test harnesses only)
 
 For test harnesses and strictly-internal utilities only. Prefix must be `TEST_`, `_<script_name>_`, or documented in `shared-constants.sh`:
 
@@ -101,8 +99,6 @@ Problem: all-or-nothing — if parent set *some* colors without the sentinel, ch
 Colors not in `shared-constants.sh` (e.g., `MAGENTA`, `GRAY`, `BOLD`, `DIM`) are safe to declare locally but should follow Pattern B for consistency. New canonical colors → add to `shared-constants.sh` in a separate PR first.
 
 ## Migration checklist
-
-When converting a helper to Pattern A or B:
 
 1. Identify current pattern (plain, readonly, include-guard, or prefixed).
 2. Choose target — A (inside `.agents/scripts/`, stable path), B (standalone bootstrap), C (test harness only).


### PR DESCRIPTION
## Summary

Tighten shell-style-guide.md from 153 to 149 lines. Changes: merged 2-paragraph intro into 1 sentence (saves 2 lines), removed redundant 'When converting...' preamble in migration checklist (saves 2 lines), shortened pattern subsection headings from 'Pattern A — Preferred:' to 'A — ... (preferred)'. All code blocks, task IDs (t2053, t1422, GH#18702, GH#18693, GH#18735, PR #18728), audit data, and roadmap phases preserved.

## Files Changed

.agents/reference/shell-style-guide.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** wc -l: 149 lines (was 153). All refs verified: t2053, t1422, GH#18702, GH#18693, GH#18735, PR #18728 present. Code blocks: 6 (unchanged). Qlty: markdown-only, no smells applicable.

Resolves #19119


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.37 plugin for [OpenCode](https://opencode.ai) v1.4.4 with claude-sonnet-4-6 spent 6m and 23,819 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated shell style guide documentation with improved readability and clarity in section headings and enforcement references.
  * Refined pattern descriptions for better specificity.
  * Streamlined migration checklist formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->