### PR TITLE
GH#19122: refactor: extract canary failure regex into named local variable (GH#19122)

### DIFF
--- a/.agents/scripts/pulse-ancillary-dispatch.sh
+++ b/.agents/scripts/pulse-ancillary-dispatch.sh
@@ -765,6 +765,10 @@ _dispatch_triage_review_worker() {
 	local model_flag=""
 	[[ -n "$resolved_model" ]] && model_flag="--model $resolved_model"
 
+	# t2089: Named pattern for canary-failure detection (see usage below).
+	# Centralised here so future canary exit messages only need one update.
+	local canary_failure_pattern='Canary test FAILED|Canary failed.*aborting dispatch'
+
 	# ── Launch sandboxed agent (no Bash, no gh, no network) ──
 	# t2019: We now pass `--agent triage-review` explicitly. Before this
 	# fix the flag was omitted, so:
@@ -827,7 +831,7 @@ _dispatch_triage_review_worker() {
 	# Infrastructure unavailability is NOT a triage failure: the issue itself
 	# is fine. Detect it early and route to a separate non-counting path.
 	local canary_failed="false"
-	if printf '%s' "$raw_sample" | grep -qE 'Canary test FAILED|Canary failed.*aborting dispatch' 2>/dev/null; then
+	if printf '%s' "$raw_sample" | grep -qE "$canary_failure_pattern" 2>/dev/null; then
 		canary_failed="true"
 		echo "[pulse-wrapper] Triage canary failed for #${issue_num} in ${repo_slug} — infrastructure unavailability, not a review failure (t2089)" >>"$LOGFILE"
 	fi


### PR DESCRIPTION
## Summary

Extracted the inline canary-failure detection regex 'Canary test FAILED|Canary failed.*aborting dispatch' into a named local variable `canary_failure_pattern` near the top of `_dispatch_triage_review_worker()` in pulse-ancillary-dispatch.sh. The grep call at the detection site now references the variable. ShellCheck passes with zero violations.

## Files Changed

.agents/scripts/pulse-ancillary-dispatch.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-ancillary-dispatch.sh — zero violations

Resolves #19122


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.37 plugin for [OpenCode](https://opencode.ai) v1.4.4 with claude-sonnet-4-6 spent 1m and 3,223 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code optimization: Centralized a pattern definition to improve maintainability.

**Note:** This release contains no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->