### PR TITLE
GH#19123: GH#19123: simplify _resolve_scripts_dir comment — one check covers all layouts

### DIFF
--- a/.agents/scripts/tests/test-bash-reexec-guard.sh
+++ b/.agents/scripts/tests/test-bash-reexec-guard.sh
@@ -25,14 +25,13 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-# Resolve repo/agents root — supports both:
-#   - git worktree layout:   $REPO/.agents/scripts/tests/ → $REPO/.agents/scripts/
-#   - deployed layout:       ~/.aidevops/agents/scripts/tests/ → ~/.aidevops/agents/scripts/
-# The test walks up one directory (from tests/ to scripts/) and looks for the
-# sibling files. If both layouts fail, it exits with a clear error.
+# Resolve repo/agents root by walking up one directory (from tests/ to scripts/).
+# A single relative-path step covers all supported layouts:
+#   - git worktree:  $REPO/.agents/scripts/tests/ → $REPO/.agents/scripts/
+#   - deployed:      ~/.aidevops/agents/scripts/tests/ → ~/.aidevops/agents/scripts/
+# If the sibling files are not found, the function exits with a clear error.
 _resolve_scripts_dir() {
 	local candidate
-	# Layout 1: git worktree
 	candidate="$(cd "$SCRIPT_DIR/.." && pwd)"
 	if [[ -f "$candidate/shared-constants.sh" ]] && [[ -f "$candidate/bash-upgrade-helper.sh" ]]; then
 		echo "$candidate"


### PR DESCRIPTION
## Summary

Removed the misleading 'Layout 1: git worktree' inline comment and 'if both layouts fail' phrasing from _resolve_scripts_dir in test-bash-reexec-guard.sh. A single relative-path step (tests/ → scripts/..) already covers both the git-worktree and deployed layouts, so the old multi-layout framing contradicted the single-check implementation. Comments now accurately reflect this.

## Files Changed

.agents/scripts/tests/test-bash-reexec-guard.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-bash-reexec-guard.sh — zero violations

Resolves #19123


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.37 plugin for [OpenCode](https://opencode.ai) v1.4.4 with claude-sonnet-4-6 spent 1m and 3,092 tokens on this as a headless worker.