### PR TITLE
GH#19125: fix: harden bash re-exec guard and advisory dismiss (GH#19125)

### DIFF
--- a/.agents/scripts/bash-upgrade-helper.sh
+++ b/.agents/scripts/bash-upgrade-helper.sh
@@ -171,8 +171,10 @@ _bu_dismiss_advisory_if_resolved() {
 	# Also remove from dismissed.txt if the user previously dismissed it;
 	# a fresh advisory should fire on next drift.
 	if [[ -f "$dismissed_file" ]] && grep -qxF "bash-3.2-upgrade" "$dismissed_file" 2>/dev/null; then
-		grep -vxF "bash-3.2-upgrade" "$dismissed_file" >"${dismissed_file}.tmp" 2>/dev/null || true
-		mv "${dismissed_file}.tmp" "$dismissed_file" 2>/dev/null || rm -f "${dismissed_file}.tmp"
+		grep -vxF "bash-3.2-upgrade" "$dismissed_file" >"${dismissed_file}.tmp" || true
+		if [[ -f "${dismissed_file}.tmp" ]]; then
+			mv "${dismissed_file}.tmp" "$dismissed_file" || rm -f "${dismissed_file}.tmp"
+		fi
 	fi
 	return 0
 }

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -44,8 +44,8 @@ _SHARED_CONSTANTS_LOADED=1
 if [[ "${BASH_VERSINFO[0]:-0}" -lt 4 ]] &&
 	[[ -z "${AIDEVOPS_BASH_REEXECED:-}" ]] &&
 	[[ -n "${BASH_SOURCE[1]:-}" ]]; then
-	for _aidevops_bash_candidate in /opt/homebrew/bin/bash /usr/local/bin/bash /home/linuxbrew/.linuxbrew/bin/bash; do
-		if [[ -x "$_aidevops_bash_candidate" ]]; then
+	for _aidevops_bash_candidate in /opt/homebrew/bin/bash /usr/local/bin/bash /home/linuxbrew/.linuxbrew/bin/bash "$(command -v bash 2>/dev/null || true)"; do
+		if [[ -n "$_aidevops_bash_candidate" && -f "$_aidevops_bash_candidate" && -x "$_aidevops_bash_candidate" && "$_aidevops_bash_candidate" != "/bin/bash" ]]; then
 			export AIDEVOPS_BASH_REEXECED=1
 			exec "$_aidevops_bash_candidate" "${BASH_SOURCE[1]}" "$@"
 		fi


### PR DESCRIPTION
## Summary

Applied two robustness fixes from Gemini review of PR #18954: (1) shared-constants.sh re-exec guard now includes PATH-based bash detection via 'command -v', adds -f check alongside -x to avoid executing directories, and excludes /bin/bash to prevent loops; (2) bash-upgrade-helper.sh _bu_dismiss_advisory_if_resolved now guards the mv with [[ -f tmp ]] before overwriting dismissed.txt and removes 2>/dev/null to surface genuine write errors.

## Files Changed

.agents/scripts/bash-upgrade-helper.sh,.agents/scripts/shared-constants.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck on both files: zero new violations (only pre-existing SC2016 info warnings for intentional single-quote bash expressions)

Resolves #19125


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.37 plugin for [OpenCode](https://opencode.ai) v1.4.4 with claude-sonnet-4-6 spent 2m and 6,306 tokens on this as a headless worker.