### PR TITLE
GH#19128: GH#19128: fix review followup — stream downloads, flexible credential regex, single JSON parse, remove redundant Date.now in filenames, cache qlty sarif output

### DIFF
--- a/.agents/scripts/higgsfield/higgsfield-api-client.mjs
+++ b/.agents/scripts/higgsfield/higgsfield-api-client.mjs
@@ -2,9 +2,11 @@
 // Holds: credential loading, fetch + retry, file upload/download, status polling.
 // High-level commands live in higgsfield-api.mjs.
 
-import { readFileSync, existsSync, writeFileSync } from 'fs';
+import { readFileSync, existsSync, createWriteStream, statSync } from 'fs';
 import { join, extname, basename } from 'path';
 import { homedir } from 'os';
+import { Readable } from 'stream';
+import { pipeline } from 'stream/promises';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -22,8 +24,8 @@ export function loadApiCredentials() {
   const credFile = join(homedir(), '.config', 'aidevops', 'credentials.sh');
   if (!existsSync(credFile)) return null;
   const content = readFileSync(credFile, 'utf-8');
-  const apiKey = content.match(/HF_API_KEY="([^"]+)"/)?.[1];
-  const apiSecret = content.match(/HF_API_SECRET="([^"]+)"/)?.[1];
+  const apiKey = content.match(/HF_API_KEY\s*=\s*["']([^"']+)["']/)?.[1];
+  const apiSecret = content.match(/HF_API_SECRET\s*=\s*["']([^"']+)["']/)?.[1];
   if (!apiKey || !apiSecret) return null;
   return { apiKey, apiSecret };
 }
@@ -54,7 +56,10 @@ export async function apiExecuteFetch(url, fetchOpts, timeout) {
 }
 
 export function parseApiErrorDetail(text) {
-  try { return JSON.parse(text).detail || JSON.parse(text).message || text; } catch {}
+  try {
+    const data = JSON.parse(text);
+    return data.detail || data.message || text;
+  } catch {}
   return text;
 }
 
@@ -166,9 +171,9 @@ export async function apiUploadFile(filePath, creds) {
 export async function apiDownloadFile(url, outputPath) {
   const response = await fetch(url);
   if (!response.ok) throw new Error(`Download failed: ${response.status}`);
-  const buffer = Buffer.from(await response.arrayBuffer());
-  writeFileSync(outputPath, buffer);
-  return buffer.length;
+  const dest = createWriteStream(outputPath);
+  await pipeline(Readable.fromWeb(response.body), dest);
+  return statSync(outputPath).size;
 }
 
 // ---------------------------------------------------------------------------

--- a/.agents/scripts/higgsfield/higgsfield-video.mjs
+++ b/.agents/scripts/higgsfield/higgsfield-video.mjs
@@ -490,7 +490,7 @@ function logCloudfrontDownloadOutcome(httpCode, size, videoUrl) {
 }
 
 function tryCloudfrontDownload(videoUrl, outputDir, combinedMeta, options) {
-  const filename = buildDescriptiveFilename(combinedMeta, `higgsfield-video-${Date.now()}.mp4`, 0);
+  const filename = buildDescriptiveFilename(combinedMeta, 'higgsfield-video.mp4', 0);
   const savePath = safeJoin(outputDir, sanitizePathSegment(filename, 'video.mp4'));
   try {
     const { httpCode, size } = curlDownload(videoUrl, savePath, { withHttpCode: true });
@@ -529,7 +529,7 @@ async function downloadVideoViaCdnFallback(page, outputDir, combinedMeta, option
 
   if (!videoSrc) return null;
 
-  const filename = buildDescriptiveFilename(combinedMeta, `higgsfield-video-${Date.now()}.mp4`, 0);
+  const filename = buildDescriptiveFilename(combinedMeta, 'higgsfield-video.mp4', 0);
   const savePath = safeJoin(outputDir, sanitizePathSegment(filename, 'video.mp4'));
   try {
     curlDownload(videoSrc, savePath);
@@ -1176,7 +1176,7 @@ function downloadSingleMatchedVideo(job, bestMatch, matchMethod, outputDir, resu
 
   const videoUrl = completedJob.results.raw.url;
   const meta = { model: job.model, promptSnippet: job.promptPrefix };
-  const filename = buildDescriptiveFilename(meta, `scene-${job.sceneIndex + 1}-${Date.now()}.mp4`, job.sceneIndex);
+  const filename = buildDescriptiveFilename(meta, `scene-${job.sceneIndex + 1}.mp4`, job.sceneIndex);
   const savePath = safeJoin(outputDir, sanitizePathSegment(filename, `scene-${job.sceneIndex + 1}.mp4`));
 
   try {

--- a/.agents/scripts/higgsfield/verify-cluster.sh
+++ b/.agents/scripts/higgsfield/verify-cluster.sh
@@ -98,12 +98,14 @@ fi
 echo
 echo "=== 4. qlty smells in cluster ==="
 if command -v ~/.qlty/bin/qlty >/dev/null 2>&1; then
-	count=$(cd "$(git rev-parse --show-toplevel)" && ~/.qlty/bin/qlty smells --all --sarif --no-snippets --quiet 2>/dev/null |
-		jq '[.runs[0].results[] | select(.locations[0].physicalLocation.artifactLocation.uri | test("higgsfield/"))] | length')
-	echo "qlty smells in higgsfield/: $count"
-	if [ "$count" -gt 0 ]; then
-		cd "$(git rev-parse --show-toplevel)" && ~/.qlty/bin/qlty smells --all --sarif --no-snippets --quiet 2>/dev/null |
-			jq -r '.runs[0].results[] | select(.locations[0].physicalLocation.artifactLocation.uri | test("higgsfield/")) | "\(.locations[0].physicalLocation.artifactLocation.uri):\(.locations[0].physicalLocation.region.startLine)\t\(.ruleId)\t\(.message.text)"'
+	sarif=$(cd "$(git rev-parse --show-toplevel)" && ~/.qlty/bin/qlty smells --all --sarif --no-snippets --quiet 2>/dev/null)
+	if [[ -n "$sarif" ]]; then
+		results=$(echo "$sarif" | jq '[.runs[0].results[] | select(.locations[0].physicalLocation.artifactLocation.uri | test("higgsfield/"))]')
+		count=$(echo "$results" | jq 'length')
+		echo "qlty smells in higgsfield/: ${count:-0}"
+		if [[ "${count:-0}" -gt 0 ]]; then
+			echo "$results" | jq -r '.[] | "\(.locations[0].physicalLocation.artifactLocation.uri):\(.locations[0].physicalLocation.region.startLine)\t\(.ruleId)\t\(.message.text)"'
+		fi
 	fi
 fi
 


### PR DESCRIPTION
## Summary

Applied all 6 unaddressed review bot suggestions from PR #18948: (1) stream apiDownloadFile to avoid OOM on large videos, (2) flexible credential regex supporting single/double quotes and spaces, (3) eliminate double JSON.parse in parseApiErrorDetail, (4+5) remove redundant Date.now() from buildDescriptiveFilename calls in higgsfield-video.mjs (function already appends timestamps), (6) cache qlty smells SARIF output in verify-cluster.sh to avoid running the tool twice.

## Files Changed

.agents/scripts/higgsfield/higgsfield-api-client.mjs,.agents/scripts/higgsfield/higgsfield-video.mjs,.agents/scripts/higgsfield/verify-cluster.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck verify-cluster.sh passes with zero violations; all old patterns verified absent from modified files; streaming download uses pipeline+Readable.fromWeb (Node.js 18+ native); credential regex verified against higgsfield-common.mjs timestamp evidence

Resolves #19128


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.37 plugin for [OpenCode](https://opencode.ai) v1.4.4 with claude-sonnet-4-6 spent 2m and 9,252 tokens on this as a headless worker.