### PR TITLE
GH#19132: GH#19132: clarify Done When is a single section, not per-file reference

### DIFF
--- a/.agents/workflows/brief/tier-standard.md
+++ b/.agents/workflows/brief/tier-standard.md
@@ -44,7 +44,7 @@ export function handleAuth(req: Request): Response {
 
 ## Recovery paths (mandatory)
 
-Include a `### Done When` condition and fallback searches for each file/function reference — workers stop on first miss without them.
+Include a `### Done When` section to prevent indefinite exploration, and provide fallback searches for each file/function reference; workers stop on first miss without them.
 
 For each implementation step:
 


### PR DESCRIPTION
## Summary

Clarified the phrasing in tier-standard.md to distinguish that ### Done When is a single section preventing indefinite exploration, separate from per-file/function fallback searches. Addresses gemini-code-assist review feedback on PR #18941.

## Files Changed

.agents/workflows/brief/tier-standard.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified the file reads correctly at line 47; no shell scripts modified so no shellcheck needed; markdown linter not available locally but the change is a single prose line with no structural markdown issues.

Resolves #19132


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.37 plugin for [OpenCode](https://opencode.ai) v1.4.4 with claude-sonnet-4-6 spent 1m and 3,095 tokens on this as a headless worker.