### PR TITLE
GH#19137: fix(dispatch-dedup-cost): broaden token-spend sed pattern for any prefix and time format

### DIFF
--- a/.agents/scripts/dispatch-dedup-cost.sh
+++ b/.agents/scripts/dispatch-dedup-cost.sh
@@ -108,10 +108,11 @@ _sum_issue_token_spend() {
 	fi
 
 	# Match signature footer patterns. The footer can take several shapes:
-	#   "spent 30,000 tokens"            (no time)
-	#   "spent 4m and 30,000 tokens"     (with session time)
-	#   "spent 1h 30m and 30,000 tokens" (with hours+minutes)
-	#   "has used 30,000 tokens"         (historical wording)
+	#   "spent 30,000 tokens"                  (no time)
+	#   "spent 4m and 30,000 tokens"           (with session time)
+	#   "spent 1h 30m and 30,000 tokens"       (with hours+minutes)
+	#   "spent 2d 3h 15m and 30,000 tokens"    (with days+hours+minutes)
+	#   "has used 30,000 tokens"               (historical wording)
 	#
 	# Strategy: collapse the optional "<time> and " infix so all variants
 	# reduce to "(spent|has used) N tokens", then extract N. The cumulative
@@ -120,7 +121,7 @@ _sum_issue_token_spend() {
 	# every time a new worker reports its own per-comment spend.
 	local raw_vals
 	raw_vals=$(printf '%s' "$bodies" |
-		sed -E 's/(spent )[0-9]+[dhms]( [0-9]+[mh])? and /\1/g' |
+		sed -E 's/(spent|has used) (.* and )?([0-9,]+ tokens)/\1 \3/g' |
 		grep -oE '(spent|has used) [0-9,]+ tokens' |
 		grep -oE '[0-9,]+' |
 		tr -d ',' || true)


### PR DESCRIPTION
## Summary

Addresses review bot feedback from PR #18931: the sed pattern used to normalize token-spend footer strings in `_sum_issue_token_spend` was fragile — it only stripped time infixes for the `spent` prefix and was limited to 1-2 time units (`[0-9]+[dhms]( [0-9]+[mh])?`).

**Change:** Replace the narrow infix-stripping sed pattern with a broader one that:
- Handles both `spent` and `has used` prefixes
- Handles any time format (including days+hours+minutes), using `(.* and )?` to match the optional infix
- Keeps the subsequent `grep -oE '(spent|has used) [0-9,]+ tokens'` extraction intact

**Before:**
```
sed -E 's/(spent )[0-9]+[dhms]( [0-9]+[mh])? and /\1/g'
```

**After:**
```
sed -E 's/(spent|has used) (.* and )?([0-9,]+ tokens)/\1 \3/g'
```

Also updated the inline comment to document the `2d 3h 15m` multi-unit time format example.

## Verification

- `shellcheck .agents/scripts/dispatch-dedup-cost.sh` — zero violations
- Logic verified manually against all four documented footer shapes: no-time, minutes, hours+minutes, historical `has used` wording.

Resolves #19137

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.37 plugin for [OpenCode](https://opencode.ai) v1.4.4 with claude-sonnet-4-6 spent 2m and 7,728 tokens on this as a headless worker.