### PR TITLE
GH#19152: GH#19152: tighten shell-style-guide.md — move Why section to top (149 → 145 lines)

### DIFF
--- a/.agents/reference/shell-style-guide.md
+++ b/.agents/reference/shell-style-guide.md
@@ -5,6 +5,8 @@
 
 Canonical rules for `.agents/scripts/**/*.sh`: **source `shared-constants.sh` OR use `[[ -z "${VAR+x}" ]]` guards**. Never declare `RED`, `GREEN`, `YELLOW`, `BLUE`, `PURPLE`, `CYAN`, `WHITE`, or `NC` at top level without a guard. Never `readonly` those names outside `shared-constants.sh`. Enforcement: `shell-init-pattern-check.sh` + CI (Phase 2, t2053). Rule in `prompts/build.txt` → Quality Standards.
 
+**Why this rule exists:** On 2026-04-09, `init-routines-helper.sh:22` assigned `GREEN='\033[0;32m'` at top level. `setup.sh` sources it after `shared-constants.sh` (which has `readonly GREEN`). Under `set -Eeuo pipefail`, the re-assignment fatally aborted `setup.sh`, silently skipping `setup_privacy_guard` and `setup_canonical_guard`. **Auto-update was broken for 4 days** (GH#18702, cascade: GH#18693). PR #18728 patched that script; this guide prevents recurrence. Audit (2026-04-15): **18 scripts** with unguarded plain assignments and **2 production scripts** (`sonarcloud-autofix.sh`, `coderabbit-cli.sh`) using `readonly` — all latent repeats of the same outage.
+
 ## Allowed patterns
 
 ### A — source `shared-constants.sh` (preferred)
@@ -67,7 +69,7 @@ RED='\033[0;31m'
 
 Fix: Pattern A or B.
 
-**Unguarded `readonly` on canonical names** — breaks on re-sourcing even without `shared-constants.sh`:
+**Unguarded `readonly` on canonical names** — breaks on re-sourcing:
 
 ```bash
 # WORST
@@ -105,12 +107,6 @@ Colors not in `shared-constants.sh` (e.g., `MAGENTA`, `GRAY`, `BOLD`, `DIM`) are
 3. Replace unguarded assignments with chosen pattern block (after `set -Eeuo pipefail`, before functions).
 4. Test standalone (`bash ./the-script.sh --help`) and sourced (`setup.sh --non-interactive` or pulse). `shellcheck` must pass.
 5. Commit. Phase 2 lint gate (`shell-init-pattern-check.sh`) automates detection and PR enforcement.
-
-## Why this guide exists
-
-On 2026-04-09, `init-routines-helper.sh:22` assigned `GREEN='\033[0;32m'` at top level. `setup.sh` sources it after `shared-constants.sh` (which has `readonly GREEN`). Under `set -Eeuo pipefail`, the re-assignment fatally aborted `setup.sh`, silently skipping `setup_privacy_guard` and `setup_canonical_guard`. **Auto-update was broken for 4 days** (GH#18702, cascade: GH#18693). PR #18728 patched that script; this guide prevents recurrence.
-
-Audit (2026-04-15): **18 scripts** with unguarded plain assignments and **2 production scripts** (`sonarcloud-autofix.sh`, `coderabbit-cli.sh`) using `readonly` — all latent repeats of the same outage.
 
 ## Audit data (2026-04-15)
 


### PR DESCRIPTION
## Summary

Reordered shell-style-guide.md to surface motivation (incident context) before the pattern rules, improving LLM comprehension via primacy effect. The separate '## Why this guide exists' section was removed and its content consolidated into a compact inline paragraph immediately after the intro. Also tightened a redundant qualifier in the banned patterns section. Zero knowledge loss: all GH/task references, code examples, tables, and audit data preserved.

## Files Changed

.agents/reference/shell-style-guide.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Content preserved: all 5 GH/task refs present, code blocks intact, qlty reports 0 smells for this .md file. Line count: 149 → 145.

Resolves #19152


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.37 plugin for [OpenCode](https://opencode.ai) v1.4.4 with claude-sonnet-4-6 spent 4m and 18,174 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced style guide with expanded incident narrative explaining canonical rules
  * Improved clarity on re-sourcing risks and best practices
  * Consolidated related explanatory content for better readability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->