### PR TITLE
t2119: feat(worker-reliability): plist drift regen + no_work escalation guard + no_activity output preservation

### DIFF
--- a/.agents/scripts/auto-update-helper.sh
+++ b/.agents/scripts/auto-update-helper.sh
@@ -439,6 +439,95 @@ run_freshness_checks() {
 	check_tool_freshness
 	check_upstream_watch
 	check_venv_health
+	# t2119: closes the deployment gap where setup-modules/schedulers.sh
+	# gets updated in-place (via git pull) without a VERSION bump, so the
+	# "up to date" branch of cmd_check never re-runs setup.sh and the
+	# installed launchd plists stay stale. PR #19079 was invisible to
+	# users for hours for exactly this reason.
+	check_launchd_plist_drift
+}
+
+#######################################
+# t2119: Detect drift between the installed launchd plists and the
+# current setup-modules/schedulers.sh template, then auto-repair by
+# re-running setup.sh --non-interactive.
+#
+# Strategy: hash setup-modules/schedulers.sh itself and compare against
+# the hash recorded by the last setup.sh run. Whole-file hash is the
+# simplest signal that any plist-generating change has occurred (FD
+# limits, env vars, StartInterval, labels) — no per-plist hashing or
+# subshell sourcing needed, and it naturally covers every LaunchAgent
+# that schedulers.sh installs (supervisor-pulse, process-guard,
+# memory-pressure, etc.).
+#
+# Bootstrap case: when no stored hash exists, we treat the state as
+# drifted on first run. This self-heals existing installs that pre-date
+# t2119 without requiring a user action.
+#
+# Rate-limited to once per 6 hours so auto-update cycles don't
+# repeatedly run setup.sh — setup.sh is idempotent but does ~20
+# scheduler operations per run and isn't free.
+#
+# macOS only — systemd-user and cron paths don't have the same
+# deployment gap (setup.sh regenerates unit files on every run and
+# users typically restart them explicitly).
+#######################################
+check_launchd_plist_drift() {
+	[[ "$(uname -s)" == "Darwin" ]] || return 0
+
+	local state_dir="$HOME/.aidevops/.agent-workspace/tmp"
+	local check_stamp="$state_dir/plist-drift-check.stamp"
+	mkdir -p "$state_dir" 2>/dev/null || return 0
+
+	# Rate-limit to once per 6 hours. Overridable via env for tests and
+	# opt-out scenarios.
+	local drift_check_interval="${AIDEVOPS_PLIST_DRIFT_CHECK_INTERVAL:-21600}"
+	if [[ -f "$check_stamp" ]]; then
+		local last_check now
+		last_check=$(cat "$check_stamp" 2>/dev/null || echo 0)
+		now=$(date +%s)
+		if ((now - last_check < drift_check_interval)); then
+			return 0
+		fi
+	fi
+
+	local schedulers_src="$INSTALL_DIR/setup-modules/schedulers.sh"
+	local hash_state="$state_dir/schedulers-template-hash.state"
+
+	if [[ ! -f "$schedulers_src" ]]; then
+		date +%s >"$check_stamp"
+		return 0
+	fi
+
+	local current_hash
+	current_hash=$(shasum -a 256 "$schedulers_src" 2>/dev/null | awk '{print $1}')
+	if [[ -z "$current_hash" ]]; then
+		log_warn "Plist drift check: failed to hash $schedulers_src — skipping"
+		date +%s >"$check_stamp"
+		return 0
+	fi
+
+	local stored_hash=""
+	if [[ -f "$hash_state" ]]; then
+		stored_hash=$(cat "$hash_state" 2>/dev/null || echo "")
+	fi
+
+	if [[ -n "$stored_hash" && "$current_hash" == "$stored_hash" ]]; then
+		log_info "Plist drift check: template hash unchanged (${current_hash:0:12}) — no drift"
+		date +%s >"$check_stamp"
+		return 0
+	fi
+
+	log_info "Plist drift detected: stored='${stored_hash:-<none>}' current='${current_hash:0:12}' — running setup.sh --non-interactive to regenerate (t2119)"
+	local _setup_exit=0
+	bash "$INSTALL_DIR/setup.sh" --non-interactive >>"$LOG_FILE" 2>&1 || _setup_exit=$?
+	if [[ "$_setup_exit" -eq 0 ]]; then
+		log_info "Plist drift repaired via setup.sh --non-interactive (t2119)"
+	else
+		log_warn "Plist drift repair: setup.sh --non-interactive exited $_setup_exit"
+	fi
+	date +%s >"$check_stamp"
+	return 0
 }
 
 #######################################

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -480,6 +480,93 @@ _invoke_claude() {
 # Result handling and run execution
 # =============================================================================
 
+#######################################
+# t2119: Preserve a worker output file on no_activity failure so operators
+# can diagnose why the runtime exited without ever producing JSON events.
+#
+# Before t2119, _handle_run_result unconditionally `rm -f "$output_file"`
+# on the no_activity path, erasing the only forensic evidence (opencode
+# stderr via tee, plugin startup log lines, sandbox exec trace). This
+# left the residual 30s failures observed in the t2116 session with zero
+# diagnostic surface.
+#
+# Strategy: move (not copy — keeps disk usage bounded) the output file
+# to ~/.aidevops/logs/worker-no-activity/<session>-<ts>.log. Size-cap
+# each preserved file to 256KB (worker output files rarely exceed this;
+# truncation is fine for forensic purposes). Retention-cap the directory
+# to the 50 most recent files so the log directory doesn't grow
+# unbounded on a looping failure.
+#
+# Best-effort throughout — a preservation failure must never propagate
+# into the caller's error-handling path. The goal is forensics, not
+# hard-guaranteed persistence.
+#
+# Args:
+#   $1 - output_file path
+#   $2 - session_key (e.g. issue-19114 or pulse)
+#   $3 - model (for filename disambiguation; slashes stripped)
+#######################################
+_preserve_no_activity_output() {
+	local output_file="$1"
+	local session_key="${2:-unknown}"
+	local model="${3:-unknown}"
+
+	if [[ -z "$output_file" || ! -f "$output_file" ]]; then
+		return 0
+	fi
+
+	local diag_dir="${HOME}/.aidevops/logs/worker-no-activity"
+	if ! mkdir -p "$diag_dir" 2>/dev/null; then
+		# Fall back to the original delete behaviour if the diagnostic
+		# directory can't be created — we must not keep tmp files around.
+		rm -f "$output_file" 2>/dev/null || true
+		return 0
+	fi
+
+	# Sanitize session + model for use in a filename.
+	local safe_session safe_model
+	safe_session=$(printf '%s' "$session_key" | tr '/ ' '__' | tr -cd 'A-Za-z0-9._-' | cut -c1-64)
+	safe_model=$(printf '%s' "$model" | tr '/ ' '__' | tr -cd 'A-Za-z0-9._-' | cut -c1-32)
+	[[ -n "$safe_session" ]] || safe_session="unknown"
+	[[ -n "$safe_model" ]] || safe_model="unknown"
+
+	local ts
+	ts=$(date -u +%Y%m%dT%H%M%SZ 2>/dev/null || date +%s)
+	local dest="${diag_dir}/${ts}-${safe_session}-${safe_model}.log"
+
+	# Size-cap: take the first 256KB of the output. For the no_activity
+	# failure mode the interesting content (plugin init errors, opencode
+	# startup logs, migration output, auth refresh messages) always
+	# lands in the first few KB; anything past 256KB is noise.
+	local max_bytes=262144
+	if head -c "$max_bytes" "$output_file" >"$dest" 2>/dev/null; then
+		local orig_size
+		orig_size=$(wc -c <"$output_file" 2>/dev/null | tr -d ' ') || orig_size=0
+		if [[ "$orig_size" -gt "$max_bytes" ]]; then
+			printf '\n\n[...t2119 TRUNCATED at %d bytes, original %d bytes...]\n' \
+				"$max_bytes" "$orig_size" >>"$dest" 2>/dev/null || true
+		fi
+	fi
+
+	rm -f "$output_file" 2>/dev/null || true
+
+	# Retention cap: keep the 50 most recent preserved files.
+	# ls -t returns newest first; tail -n +51 selects everything beyond the cap.
+	# Using find -print0 | sort would be more robust but ls is enough for
+	# our flat directory of predictable filenames.
+	local keep=50
+	local prune_list
+	prune_list=$(cd "$diag_dir" 2>/dev/null && ls -1t -- *.log 2>/dev/null | tail -n +$((keep + 1))) || prune_list=""
+	if [[ -n "$prune_list" ]]; then
+		while IFS= read -r _victim; do
+			[[ -n "$_victim" ]] || continue
+			rm -f "${diag_dir}/${_victim}" 2>/dev/null || true
+		done <<<"$prune_list"
+	fi
+
+	return 0
+}
+
 # _handle_run_result: process output_file after opencode exits.
 # Args: exit_code output_file role provider session_key selected_model
 # Sets caller variable _run_failure_reason on failure.
@@ -507,8 +594,18 @@ _handle_run_result() {
 			# here falsely flags healthy providers as rate-limited, causing the
 			# pre-dispatch check to skip them and starve the worker pool.
 			# The activity watchdog (exit 124) handles genuine provider failures.
-			rm -f "$output_file"
-			print_warning "$selected_model returned exit 0 without any model activity (no backoff recorded — may be local issue)"
+			#
+			# t2119: preserve the output file for post-mortem forensics instead
+			# of deleting it. Workers that die in setup with exit 0 + no JSON
+			# events leave no other trace of WHY they died — not in observability
+			# DB (never reached the model), not in pulse.log, not in the
+			# session DB (never created one). The output file captured by tee is
+			# the only place plugin/runtime stderr lands. Moving it to a
+			# retention-capped diagnostics dir lets operators actually diagnose
+			# the residual 30s no_activity failures that the t2116-session
+			# plist-reload fix didn't fully resolve.
+			_preserve_no_activity_output "$output_file" "$session_key" "$selected_model"
+			print_warning "$selected_model returned exit 0 without any model activity (no backoff recorded — forensic copy preserved via t2119)"
 			return 75
 		fi
 		# Store session ID for potential continuation (before deleting output)

--- a/.agents/scripts/tests/test-worker-reliability-self-heal.sh
+++ b/.agents/scripts/tests/test-worker-reliability-self-heal.sh
@@ -1,0 +1,440 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression tests for t2119 worker reliability self-heal bundle:
+#
+#   Part A — check_launchd_plist_drift:
+#     - No drift: stored hash matches current schedulers.sh hash → no-op.
+#     - Drift: stored hash differs → runs setup.sh and updates stamp.
+#     - Bootstrap: no stored hash → treated as drift (self-heals pre-t2119 installs).
+#     - Rate limit: stamp newer than interval → skipped without work.
+#
+#   Part B — escalate_issue_tier body-quality gate skip:
+#     - When crash_type="no_work", _escalate_body_quality_gate must NOT be
+#       called regardless of body content (structural assertion on source).
+#
+#   Part C — _preserve_no_activity_output:
+#     - Moves the output file to the diagnostics dir instead of deleting.
+#     - Size-caps at 256KB with truncation marker on overflow.
+#     - Retention-caps the diagnostic directory to 50 files.
+#     - Handles missing/empty output_file without erroring.
+#
+# Pattern matches .agents/scripts/tests/test-pulse-merge-update-branch.sh:
+# extract the helper source from the real script via awk, eval it into the
+# test shell, and drive the function with controlled inputs + stubs.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+AUTO_UPDATE_SCRIPT="${REPO_ROOT}/.agents/scripts/auto-update-helper.sh"
+HEADLESS_SCRIPT="${REPO_ROOT}/.agents/scripts/headless-runtime-helper.sh"
+LIFECYCLE_SCRIPT="${REPO_ROOT}/.agents/scripts/worker-lifecycle-common.sh"
+SCHEDULERS_SCRIPT="${REPO_ROOT}/setup-modules/schedulers.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+	mkdir -p "${TEST_ROOT}/bin"
+	mkdir -p "${TEST_ROOT}/home/.aidevops/.agent-workspace/tmp"
+	mkdir -p "${TEST_ROOT}/home/.aidevops/logs"
+	mkdir -p "${TEST_ROOT}/install/.agents/scripts"
+	mkdir -p "${TEST_ROOT}/install/setup-modules"
+	# Install a fake schedulers.sh so drift detection has something to hash
+	printf '#!/usr/bin/env bash\n# fake schedulers v1\n' >"${TEST_ROOT}/install/setup-modules/schedulers.sh"
+	# Install a fake setup.sh so drift detection can "run" it
+	cat >"${TEST_ROOT}/install/setup.sh" <<'FSETUP'
+#!/usr/bin/env bash
+# Fake setup.sh for t2119 tests — records the invocation and succeeds.
+printf '%s\n' "FAKE_SETUP_INVOKED $*" >>"${TEST_SETUP_LOG:-/tmp/fake-setup.log}"
+exit 0
+FSETUP
+	chmod +x "${TEST_ROOT}/install/setup.sh"
+
+	export HOME="${TEST_ROOT}/home"
+	export INSTALL_DIR="${TEST_ROOT}/install"
+	export LOG_FILE="${TEST_ROOT}/home/.aidevops/logs/auto-update.log"
+	: >"$LOG_FILE"
+	TEST_SETUP_LOG="${TEST_ROOT}/fake-setup.log"
+	export TEST_SETUP_LOG
+	: >"$TEST_SETUP_LOG"
+	return 0
+}
+
+teardown_test_env() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+# Stub logging functions so extracted helpers can run standalone.
+_install_log_stubs() {
+	log_info() { printf '[info] %s\n' "$*" >>"$LOG_FILE" 2>/dev/null || true; }
+	log_warn() { printf '[warn] %s\n' "$*" >>"$LOG_FILE" 2>/dev/null || true; }
+	log_error() { printf '[error] %s\n' "$*" >>"$LOG_FILE" 2>/dev/null || true; }
+	return 0
+}
+
+# Extract + eval the check_launchd_plist_drift function from auto-update-helper.sh
+define_drift_helper() {
+	local helper_src
+	helper_src=$(awk '
+		/^check_launchd_plist_drift\(\) \{/,/^}$/ { print }
+	' "$AUTO_UPDATE_SCRIPT")
+	if [[ -z "$helper_src" ]]; then
+		printf 'ERROR: could not extract check_launchd_plist_drift\n' >&2
+		return 1
+	fi
+	# shellcheck disable=SC1090
+	eval "$helper_src"
+	return 0
+}
+
+define_preserve_helper() {
+	local helper_src
+	helper_src=$(awk '
+		/^_preserve_no_activity_output\(\) \{/,/^}$/ { print }
+	' "$HEADLESS_SCRIPT")
+	if [[ -z "$helper_src" ]]; then
+		printf 'ERROR: could not extract _preserve_no_activity_output\n' >&2
+		return 1
+	fi
+	# shellcheck disable=SC1090
+	eval "$helper_src"
+	return 0
+}
+
+# -----------------------------------------------------------------
+# Part A — plist drift tests
+# -----------------------------------------------------------------
+
+test_drift_bootstrap_triggers_setup() {
+	# No stored hash → treat as drift → must run setup.sh
+	rm -f "${HOME}/.aidevops/.agent-workspace/tmp/schedulers-template-hash.state"
+	rm -f "${HOME}/.aidevops/.agent-workspace/tmp/plist-drift-check.stamp"
+	: >"$TEST_SETUP_LOG"
+
+	check_launchd_plist_drift
+
+	if ! grep -q "FAKE_SETUP_INVOKED" "$TEST_SETUP_LOG"; then
+		print_result "drift: bootstrap (no stored hash) runs setup.sh" 1 \
+			"Expected setup.sh invocation; LOG_FILE: $(cat "$LOG_FILE" | tail -5)"
+		return 0
+	fi
+	print_result "drift: bootstrap (no stored hash) runs setup.sh" 0
+	return 0
+}
+
+test_drift_match_skips_setup() {
+	# Pre-seed a matching hash → no drift → setup must NOT run
+	local current_hash
+	current_hash=$(shasum -a 256 "${INSTALL_DIR}/setup-modules/schedulers.sh" | awk '{print $1}')
+	printf '%s\n' "$current_hash" >"${HOME}/.aidevops/.agent-workspace/tmp/schedulers-template-hash.state"
+	rm -f "${HOME}/.aidevops/.agent-workspace/tmp/plist-drift-check.stamp"
+	: >"$TEST_SETUP_LOG"
+
+	check_launchd_plist_drift
+
+	if grep -q "FAKE_SETUP_INVOKED" "$TEST_SETUP_LOG"; then
+		print_result "drift: matching hash skips setup.sh" 1 \
+			"setup.sh was invoked unexpectedly"
+		return 0
+	fi
+	print_result "drift: matching hash skips setup.sh" 0
+	return 0
+}
+
+test_drift_mismatch_triggers_setup() {
+	# Stored hash differs → drift → must run setup.sh
+	printf '%s\n' "deadbeefdeadbeefdeadbeefdeadbeef" \
+		>"${HOME}/.aidevops/.agent-workspace/tmp/schedulers-template-hash.state"
+	rm -f "${HOME}/.aidevops/.agent-workspace/tmp/plist-drift-check.stamp"
+	: >"$TEST_SETUP_LOG"
+
+	check_launchd_plist_drift
+
+	if ! grep -q "FAKE_SETUP_INVOKED" "$TEST_SETUP_LOG"; then
+		print_result "drift: mismatched hash runs setup.sh" 1 \
+			"setup.sh was NOT invoked on drift"
+		return 0
+	fi
+	print_result "drift: mismatched hash runs setup.sh" 0
+	return 0
+}
+
+test_drift_rate_limit_suppresses_check() {
+	# Fresh stamp + mismatched hash → should skip due to rate limit
+	printf '%s\n' "deadbeefdeadbeefdeadbeefdeadbeef" \
+		>"${HOME}/.aidevops/.agent-workspace/tmp/schedulers-template-hash.state"
+	date +%s >"${HOME}/.aidevops/.agent-workspace/tmp/plist-drift-check.stamp"
+	: >"$TEST_SETUP_LOG"
+
+	check_launchd_plist_drift
+
+	if grep -q "FAKE_SETUP_INVOKED" "$TEST_SETUP_LOG"; then
+		print_result "drift: rate-limit stamp suppresses check" 1 \
+			"setup.sh was invoked despite fresh stamp"
+		return 0
+	fi
+	print_result "drift: rate-limit stamp suppresses check" 0
+	return 0
+}
+
+test_drift_stores_stamp_after_run() {
+	# After a drift-triggered run, stamp must exist and be recent
+	rm -f "${HOME}/.aidevops/.agent-workspace/tmp/schedulers-template-hash.state"
+	rm -f "${HOME}/.aidevops/.agent-workspace/tmp/plist-drift-check.stamp"
+
+	check_launchd_plist_drift
+
+	local stamp="${HOME}/.aidevops/.agent-workspace/tmp/plist-drift-check.stamp"
+	if [[ ! -f "$stamp" ]]; then
+		print_result "drift: stamp written after check" 1 \
+			"stamp file not created"
+		return 0
+	fi
+	local age=$(($(date +%s) - $(cat "$stamp")))
+	if [[ "$age" -gt 5 ]]; then
+		print_result "drift: stamp written after check" 1 \
+			"stamp is stale (age=${age}s)"
+		return 0
+	fi
+	print_result "drift: stamp written after check" 0
+	return 0
+}
+
+# -----------------------------------------------------------------
+# Part B — escalation skip for no_work crash_type
+# Structural assertion: the guard comparing crash_type must appear
+# before the _escalate_body_quality_gate call in escalate_issue_tier.
+# -----------------------------------------------------------------
+
+test_escalate_skips_body_gate_on_no_work() {
+	# Extract escalate_issue_tier function source
+	local fn_src
+	fn_src=$(awk '
+		/^escalate_issue_tier\(\) \{/,/^}$/ { print }
+	' "$LIFECYCLE_SCRIPT")
+
+	if [[ -z "$fn_src" ]]; then
+		print_result "escalate: no_work guard present (structural)" 1 \
+			"could not extract escalate_issue_tier"
+		return 0
+	fi
+
+	# Assertion 1: the function contains a no_work guard before the gate call
+	local guard_pos gate_pos
+	# shellcheck disable=SC2016  # matching literal source text, not expanding
+	guard_pos=$(printf '%s\n' "$fn_src" | grep -n '"\$crash_type" != "no_work"' | head -1 | cut -d: -f1)
+	gate_pos=$(printf '%s\n' "$fn_src" | grep -n '_escalate_body_quality_gate' | head -1 | cut -d: -f1)
+
+	if [[ -z "$guard_pos" || -z "$gate_pos" ]]; then
+		print_result "escalate: no_work guard present (structural)" 1 \
+			"missing guard_pos=${guard_pos} or gate_pos=${gate_pos}"
+		return 0
+	fi
+
+	# Assertion 2: the guard appears BEFORE the gate call line
+	if [[ "$guard_pos" -ge "$gate_pos" ]]; then
+		print_result "escalate: no_work guard present (structural)" 1 \
+			"guard at line ${guard_pos} must precede gate at line ${gate_pos}"
+		return 0
+	fi
+
+	print_result "escalate: no_work guard present (structural)" 0
+	return 0
+}
+
+# -----------------------------------------------------------------
+# Part C — _preserve_no_activity_output tests
+# -----------------------------------------------------------------
+
+test_preserve_moves_to_diag_dir() {
+	local src
+	src=$(mktemp)
+	printf 'synthetic worker output for test\n' >"$src"
+
+	_preserve_no_activity_output "$src" "issue-99999" "anthropic/claude-sonnet-4-6"
+
+	if [[ -f "$src" ]]; then
+		print_result "preserve: source file removed after move" 1 \
+			"source still exists at $src"
+		return 0
+	fi
+
+	local diag_dir="${HOME}/.aidevops/logs/worker-no-activity"
+	local found
+	found=$(find "$diag_dir" -type f -name "*issue-99999*" 2>/dev/null | head -1)
+	if [[ -z "$found" ]]; then
+		print_result "preserve: source file removed after move" 1 \
+			"no preserved file found in $diag_dir"
+		return 0
+	fi
+
+	if ! grep -q "synthetic worker output for test" "$found"; then
+		print_result "preserve: source file removed after move" 1 \
+			"preserved file missing expected content"
+		return 0
+	fi
+
+	print_result "preserve: source file removed after move" 0
+	return 0
+}
+
+test_preserve_size_caps_at_256kb() {
+	local src
+	src=$(mktemp)
+	# Generate 300KB of content — force truncation.
+	# Avoid `yes | head` because SIGPIPE trips set -e. Use dd with bs=300 count=1024.
+	dd if=/dev/zero of="$src" bs=300 count=1024 2>/dev/null || true
+
+	_preserve_no_activity_output "$src" "issue-11111" "model-large"
+
+	local diag_dir="${HOME}/.aidevops/logs/worker-no-activity"
+	local found
+	found=$(find "$diag_dir" -type f -name "*issue-11111*" 2>/dev/null | head -1)
+
+	if [[ -z "$found" ]]; then
+		print_result "preserve: size cap at 256KB with truncation marker" 1 \
+			"no preserved file found"
+		return 0
+	fi
+
+	local sz
+	sz=$(wc -c <"$found" | tr -d ' ')
+	# 256KB content + truncation marker ~ 262144 + ~80 bytes
+	if [[ "$sz" -lt 262144 || "$sz" -gt 262300 ]]; then
+		print_result "preserve: size cap at 256KB with truncation marker" 1 \
+			"size ${sz} out of expected range (262144-262300)"
+		return 0
+	fi
+
+	if ! grep -q "t2119 TRUNCATED" "$found"; then
+		print_result "preserve: size cap at 256KB with truncation marker" 1 \
+			"truncation marker missing from capped file"
+		return 0
+	fi
+
+	print_result "preserve: size cap at 256KB with truncation marker" 0
+	return 0
+}
+
+test_preserve_retention_cap() {
+	local diag_dir="${HOME}/.aidevops/logs/worker-no-activity"
+	# Pre-populate with 55 old files
+	local i
+	for i in $(seq 1 55); do
+		printf '%s\n' "old content $i" >"${diag_dir}/20200101T00000${i}Z-old-${i}-old.log"
+		# Stagger mtimes so ls -t ordering is deterministic
+		touch -d "2020-01-01 00:00:$(printf '%02d' $((i % 60)))" \
+			"${diag_dir}/20200101T00000${i}Z-old-${i}-old.log" 2>/dev/null || true
+	done
+
+	# Add one more new file → total 56, retention cap 50 → 6 should be pruned
+	local src
+	src=$(mktemp)
+	printf 'newest\n' >"$src"
+	_preserve_no_activity_output "$src" "issue-retention" "test"
+
+	local remaining
+	remaining=$(find "$diag_dir" -type f -name "*.log" 2>/dev/null | wc -l | tr -d ' ')
+
+	# We asked to keep 50. Allow a small slack because ls ordering by
+	# identical-second mtimes is non-deterministic on some filesystems.
+	if [[ "$remaining" -gt 52 ]]; then
+		print_result "preserve: retention cap prunes old files" 1 \
+			"expected ~50 files, found ${remaining}"
+		return 0
+	fi
+	if [[ "$remaining" -lt 48 ]]; then
+		print_result "preserve: retention cap prunes old files" 1 \
+			"pruned too aggressively, found ${remaining}"
+		return 0
+	fi
+
+	print_result "preserve: retention cap prunes old files" 0
+	return 0
+}
+
+test_preserve_noops_on_missing_output_file() {
+	# Non-existent path must not error
+	_preserve_no_activity_output "/nonexistent/path/that/does/not/exist" \
+		"issue-nofile" "test" || {
+		print_result "preserve: no-ops on missing output file" 1 \
+			"function returned non-zero"
+		return 0
+	}
+	print_result "preserve: no-ops on missing output file" 0
+	return 0
+}
+
+main() {
+	trap teardown_test_env EXIT
+	setup_test_env
+	_install_log_stubs
+
+	if ! define_drift_helper; then
+		printf 'FATAL: drift helper extraction failed\n' >&2
+		return 1
+	fi
+
+	if ! define_preserve_helper; then
+		printf 'FATAL: preserve helper extraction failed\n' >&2
+		return 1
+	fi
+
+	# Part A: drift tests
+	test_drift_bootstrap_triggers_setup
+	test_drift_match_skips_setup
+	test_drift_mismatch_triggers_setup
+	test_drift_rate_limit_suppresses_check
+	test_drift_stores_stamp_after_run
+
+	# Part B: structural assertion
+	test_escalate_skips_body_gate_on_no_work
+
+	# Part C: preserve tests — clean out any pollution from Part A first
+	rm -rf "${HOME}/.aidevops/logs/worker-no-activity" 2>/dev/null || true
+	mkdir -p "${HOME}/.aidevops/logs/worker-no-activity" 2>/dev/null || true
+	test_preserve_moves_to_diag_dir
+	test_preserve_size_caps_at_256kb
+	# Clean again before retention test so we control the file count
+	rm -rf "${HOME}/.aidevops/logs/worker-no-activity" 2>/dev/null || true
+	mkdir -p "${HOME}/.aidevops/logs/worker-no-activity" 2>/dev/null || true
+	test_preserve_retention_cap
+	test_preserve_noops_on_missing_output_file
+
+	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/worker-lifecycle-common.sh
+++ b/.agents/scripts/worker-lifecycle-common.sh
@@ -882,11 +882,24 @@ escalate_issue_tier() {
 	# context before escalating. If the body lacks file paths, the root cause
 	# is a vague issue — not model capability. Escalating wastes a more
 	# expensive model on the same exploration problem.
+	#
+	# t2119 guard: skip the body-quality gate entirely when crash_type is
+	# "no_work". In that case the worker died during infrastructure setup
+	# (FD exhaustion, plugin init crash, auth refresh race — see t2116
+	# session memory) BEFORE ever reading the brief. Blaming the brief in
+	# that case is a false positive that wrongly froze good issues like
+	# #19037, #19038, #19099, #19110 while the real cause was #19079 FD
+	# exhaustion. The body-quality gate only makes sense when the model
+	# actually engaged with the brief — i.e. `overwhelmed` or `partial`
+	# crash types, or unclassified failures where we at least have
+	# evidence the worker started a real session.
 	local issue_body
 	issue_body=$(gh issue view "$issue_number" --repo "$repo_slug" \
 		--json body --jq '.body // ""' 2>/dev/null) || issue_body=""
-	_escalate_body_quality_gate "$issue_number" "$repo_slug" \
-		"$failure_count" "$threshold" "$issue_body" || return 0
+	if [[ "$crash_type" != "no_work" ]]; then
+		_escalate_body_quality_gate "$issue_number" "$repo_slug" \
+			"$failure_count" "$threshold" "$issue_body" || return 0
+	fi
 
 	# Create next tier label (creates label if needed)
 	local label_desc=""

--- a/setup-modules/schedulers.sh
+++ b/setup-modules/schedulers.sh
@@ -349,8 +349,39 @@ _install_supervisor_pulse() {
 # macOS: launchd plist invoking wrapper | Linux: cron entry invoking wrapper
 # The plist is ALWAYS regenerated on setup.sh to pick up config changes (env vars,
 # thresholds). Only the first-install prompt is gated on consent state.
+#######################################
+# t2119: Record the schedulers.sh template hash to the shared state
+# directory. auto-update-helper.sh's check_launchd_plist_drift compares
+# this against the current hash on every update cycle — whenever
+# schedulers.sh changes without a VERSION bump (PR #19079 scenario),
+# drift is detected and setup.sh --non-interactive is re-run to
+# regenerate the installed plists.
+#
+# Called from setup_supervisor_pulse unconditionally so the hash is
+# kept current on every setup.sh run, whether pulse is installed,
+# upgraded, or disabled. Whole-file hash is the simplest signal that
+# any plist-generating change has occurred.
+#######################################
+_schedulers_record_template_hash() {
+	local state_dir="$HOME/.aidevops/.agent-workspace/tmp"
+	mkdir -p "$state_dir" 2>/dev/null || return 0
+	local hash_file="$state_dir/schedulers-template-hash.state"
+	local schedulers_src="${BASH_SOURCE[0]:-}"
+	[[ -f "$schedulers_src" ]] || return 0
+	if command -v shasum >/dev/null 2>&1; then
+		shasum -a 256 "$schedulers_src" 2>/dev/null | awk '{print $1}' >"$hash_file" 2>/dev/null || true
+	elif command -v sha256sum >/dev/null 2>&1; then
+		sha256sum "$schedulers_src" 2>/dev/null | awk '{print $1}' >"$hash_file" 2>/dev/null || true
+	fi
+	return 0
+}
+
 setup_supervisor_pulse() {
 	local _os="$1"
+
+	# Record template hash so auto-update can detect drift between
+	# schedulers.sh and the installed plists on macOS (t2119).
+	_schedulers_record_template_hash
 
 	# Ensure crontab has a global PATH= line (Linux only; macOS uses launchd env).
 	# Must run before any cron entries are installed so they inherit the PATH.


### PR DESCRIPTION
Resolves #19160

## Summary

Bundled worker reliability self-heal covering three distinct gaps discovered during the t2116 session investigation (session memory `mem_20260415053833`). Each part is separately scoped but tightly coupled to the same symptom — workers dying at ~30s with `result:"no_activity" exit_code:75` — so they ship as one audit-trail-coherent PR.

## Part A — `aidevops update` regenerates drifted launchd plists

**Problem.** PR #19079 (merged 02:08 UTC, 15 Apr) added `SoftResourceLimits: NumberOfFiles: 4096` to `setup-modules/schedulers.sh` to fix FD exhaustion killing pulse workers. The code landed, but the fix stayed **invisible to users for hours** because `auto-update-helper.sh` syncs scripts but never touches `~/Library/LaunchAgents/*.plist`. Users kept hitting the 256-FD launchd default until someone ran `setup.sh --non-interactive` manually. On my own machine the t2116 session exposed this: running setup.sh regenerated the plist, the next pulse cycle raised `maxfiles → 4096`, and the next worker for #19109 went from 30s-no-activity deaths to a 572s productive run that completed successfully.

**Fix.** In `auto-update-helper.sh`, add `check_launchd_plist_drift()` called from `run_freshness_checks`. It hashes `setup-modules/schedulers.sh` and compares against the hash recorded by the last setup.sh run. On mismatch (including the bootstrap case where no hash exists), it re-runs `setup.sh --non-interactive` to regenerate all installed plists. Rate-limited to once per 6 hours so auto-update cycles don't repeatedly re-run setup.

In `setup-modules/schedulers.sh`, add `_schedulers_record_template_hash()` called unconditionally from `setup_supervisor_pulse`. Whole-file hashing is the simplest signal that any plist-generating change has occurred (FD limits, env vars, StartInterval, labels, any LaunchAgent schedulers.sh touches).

Self-healing: existing installs pre-dating t2119 have no stored hash, so the first post-t2119 auto-update cycle treats them as drifted and regenerates the plists automatically. No user action required.

## Part B — Suppress false-positive escalation blocks on infrastructure deaths

**Problem.** `worker-lifecycle-common.sh` `escalate_issue_tier()` posts "Escalation Blocked: Missing Implementation Context" when two consecutive workers fail at the same tier and the issue body lacks `## How` / file paths. During the t2116 investigation I found this gate firing on issues where the workers died in setup (FD exhaustion, plugin init crash, auth refresh race) BEFORE ever reading the brief — wrongly blaming the brief and freezing issues #19037, #19038, #19099, #19110 that had perfectly good content. The gate logic only made sense when the model actually engaged with the content.

**Fix.** `crash_type` is already plumbed through to `escalate_issue_tier`. `"no_work"` specifically means "worker exited during setup without reading target files" — which is exactly the false-positive case. Guard the body-quality gate call with `if [[ "$crash_type" != "no_work" ]]`. For `no_work`, skip the gate entirely and let the normal tier escalation (or no escalation, if already at tier:thinking) proceed.

## Part C — Preserve worker output on `no_activity` for post-mortem diagnostics

**Problem.** `_handle_run_result` unconditionally `rm -f "$output_file"` on the no_activity path. This erases the only forensic evidence of WHY the worker exited without producing any JSON events — opencode stderr via tee, plugin init errors, sandbox exec trace, SQLite migration output, auth refresh messages. The t2116 session had to reproduce failures manually because no preserved artifacts existed. Even after fixing the FD gap, the residual 30s failures I observed on #19114 post-reload couldn't be diagnosed further without real output.

**Fix.** Replace the unconditional delete with `_preserve_no_activity_output` that:
- Moves (not copies — disk-bounded) the output file to `~/.aidevops/logs/worker-no-activity/<ts>-<session>-<model>.log`
- Size-caps at 256 KB with a truncation marker on overflow (interesting content always lands in the first few KB for this failure mode)
- Retention-caps the diagnostic directory to 50 files (bounded even on a looping failure)
- Best-effort throughout — a preservation failure never propagates into the caller's error handling

Operators can now read the actual opencode stderr for every no_activity failure and fix the underlying cause instead of guessing.

## Files changed

- `.agents/scripts/auto-update-helper.sh` — new `check_launchd_plist_drift()` + hook in `run_freshness_checks`
- `setup-modules/schedulers.sh` — new `_schedulers_record_template_hash()` + unconditional call from `setup_supervisor_pulse`
- `.agents/scripts/worker-lifecycle-common.sh` — `escalate_issue_tier` skips body-quality gate when `crash_type="no_work"`
- `.agents/scripts/headless-runtime-helper.sh` — new `_preserve_no_activity_output()` + `_handle_run_result` calls it instead of `rm -f` on the no_activity path
- `.agents/scripts/tests/test-worker-reliability-self-heal.sh` — 10 regression tests across all three parts

## Verification

- **10 new regression tests pass** (5 drift + 1 structural escalation + 4 preservation)
- **All 6 existing pulse-merge test suites pass** (51 tests, 0 regressions)
- **shellcheck**: zero violations on the four modified files and the new test file (pre-existing SC1091/SC2016/SC2027 noise in auto-update-helper.sh untouched — those lines are unchanged by this PR)
- **bash -n**: syntax clean on all changed files
- **End-to-end verification pending on merge**: next pulse cycle after this lands should pick up the drift check during `run_freshness_checks` and leave the stamp recorded; future plist-level PRs will auto-deploy within 10 minutes instead of sitting inert for hours

## Why one PR instead of three

All three parts reinforce each other during on-call debugging:
1. Part A closes the gap that kept #19079 inert (the immediate cause of the observed failures)
2. Part B stops the feedback loop from wrongly blaming good briefs while that gap exists
3. Part C gives operators actual evidence the next time the gap re-opens for a different reason

Shipping them separately would mean three PRs against the same observed symptom with overlapping context, and the user explicitly asked for all three "within this session" so the audit trail stays coherent.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS system stability detection and self-recovery mechanism for scheduler configurations with configurable rate limiting.
  * Enhanced crash type handling to refine escalation logic for specific failure scenarios.

* **Improvements**
  * Diagnostic output from no-activity runs is now preserved with automatic retention management instead of being discarded.

* **Tests**
  * Added comprehensive regression test suite covering self-healing behavior, crash handling, and diagnostics preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->