### PR TITLE
GH#19093: feat(issue-sync): backfill-sub-issues subcommand (t2114)

### DIFF
--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -1773,12 +1773,276 @@ cmd_relationships() {
 	return 0
 }
 
+# =============================================================================
+# Backfill sub-issue links from GitHub state alone (t2114 — GH#19093)
+# =============================================================================
+# Unlike `cmd_relationships`, which is TODO-driven, and `_gh_auto_link_sub_issue`,
+# which is wrapper-driven, `cmd_backfill_sub_issues` operates purely on GitHub
+# state — title and body of each issue — without requiring a TODO entry or a
+# brief file. It closes the "issue already exists, no TODO, wrapper bypassed"
+# gap that leaves decomposition issues unlinked to their parents.
+#
+# Detection precedence (first match wins):
+#   1. Dot-notation in title — `^(t\d+)\.\d+: ` → parent `t\1` (resolved via
+#      gh search in the same repo). Used when a decomposition child was filed
+#      with the t<parent>.<n> convention.
+#   2. Explicit `Parent:` line in body — `Parent: tNNN` / `Parent: GH#NNN` /
+#      `Parent: #NNN`. Bold-markdown (`**Parent:**`) and backtick-quoted refs
+#      are accepted. Used when the filer names the parent directly.
+#   3. `Blocked by: tNNN` where the referenced task carries the `parent-task`
+#      label on GitHub. This is the only case where the parent-task label
+#      gates the detection — the label indicates the blocker is a roadmap
+#      parent, not a peer dependency.
+
+# Resolve a top-level task ID (e.g., t1873) to its GitHub issue number by
+# searching the repo. Matches only titles of the form "tNNN:" or "tNNN " —
+# subtasks like "tNNN.2:" are deliberately excluded so that parent resolution
+# can never return a sibling.
+#
+# Arguments:
+#   $1 - task_id (e.g., t1873)
+#   $2 - repo slug
+# Echo: issue number on stdout, empty if not found
+_resolve_task_id_via_gh_search() {
+	local task_id="$1" repo="$2"
+	[[ -z "$task_id" || -z "$repo" ]] && return 0
+	# Guard against accidental dotted IDs — caller should pass the top-level.
+	[[ "$task_id" == *.* ]] && {
+		task_id="${task_id%%.*}"
+	}
+
+	local matches
+	matches=$(gh search issues "$task_id" --repo "$repo" --state all \
+		--json number,title --limit 10 2>/dev/null || echo "[]")
+
+	local num
+	num=$(printf '%s' "$matches" | jq -r --arg tid "$task_id" \
+		'.[] | select(.title | test("^" + $tid + "([: ]|$)")) | .number' 2>/dev/null | head -1 || echo "")
+	echo "$num"
+	return 0
+}
+
+# Check whether an issue carries the `parent-task` label.
+# Arguments:
+#   $1 - issue number
+#   $2 - repo slug
+# Returns: 0 if labelled, 1 otherwise
+_issue_has_parent_task_label() {
+	local num="$1" repo="$2"
+	[[ -z "$num" || -z "$repo" ]] && return 1
+
+	local has
+	has=$(gh issue view "$num" --repo "$repo" --json labels \
+		--jq '[.labels[].name] | any(. == "parent-task")' 2>/dev/null || echo "false")
+	[[ "$has" == "true" ]] && return 0
+	return 1
+}
+
+# Detect a parent issue reference from an issue's title and body alone.
+# No TODO.md or brief file is consulted — this is the purely-GH-driven path.
+#
+# Arguments:
+#   $1 - issue title
+#   $2 - issue body
+#   $3 - repo slug
+# Echo: parent issue number on stdout, empty if no parent detected
+_detect_parent_from_gh_state() {
+	local title="$1" body="$2" repo="$3"
+	local parent_num=""
+
+	# Method 1: dot-notation in title — "t1873.2: description" → parent t1873
+	if [[ "$title" =~ ^(t[0-9]+)\.[0-9]+:[[:space:]] ]]; then
+		local dot_parent_tid="${BASH_REMATCH[1]}"
+		parent_num=$(_resolve_task_id_via_gh_search "$dot_parent_tid" "$repo")
+		if [[ -n "$parent_num" ]]; then
+			echo "$parent_num"
+			return 0
+		fi
+	fi
+
+	# Method 2: "Parent:" line in body. Accepts plain ("Parent: tNNN"),
+	# bold-markdown ("**Parent:** `tNNN`"), and either a task ID, a raw
+	# GitHub number ("#NNN"), or the aidevops GH#NNN notation.
+	local parent_ref
+	parent_ref=$(printf '%s\n' "$body" |
+		sed -nE 's/^[[:space:]]*\**Parent:\**[[:space:]]*`?(t[0-9]+|GH#[0-9]+|#[0-9]+)`?.*/\1/p' |
+		head -1 || true)
+	if [[ -n "$parent_ref" ]]; then
+		if [[ "$parent_ref" =~ ^#([0-9]+)$ ]]; then
+			echo "${BASH_REMATCH[1]}"
+			return 0
+		elif [[ "$parent_ref" =~ ^GH#([0-9]+)$ ]]; then
+			echo "${BASH_REMATCH[1]}"
+			return 0
+		elif [[ "$parent_ref" =~ ^(t[0-9]+)$ ]]; then
+			parent_num=$(_resolve_task_id_via_gh_search "${BASH_REMATCH[1]}" "$repo")
+			if [[ -n "$parent_num" ]]; then
+				echo "$parent_num"
+				return 0
+			fi
+		fi
+	fi
+
+	# Method 3: "Blocked by:" line listing task IDs; parent-task label on the
+	# blocker is required. Supports comma-separated multi-blocker lists; the
+	# first parent-tagged blocker wins.
+	local blocker_list
+	blocker_list=$(printf '%s\n' "$body" |
+		sed -nE 's/^[[:space:]]*\**Blocked by:\**[[:space:]]*`?([t0-9.,[:space:]]+)`?.*/\1/p' |
+		head -1 || true)
+	if [[ -n "$blocker_list" ]]; then
+		# Normalise separators so whitespace-tolerant input (comma or space)
+		# parses the same way.
+		local normalised="${blocker_list//,/ }"
+		local blocker_id
+		for blocker_id in $normalised; do
+			blocker_id="${blocker_id// /}"
+			[[ -z "$blocker_id" ]] && continue
+			[[ "$blocker_id" =~ ^t[0-9]+$ ]] || continue
+			local candidate
+			candidate=$(_resolve_task_id_via_gh_search "$blocker_id" "$repo")
+			[[ -z "$candidate" ]] && continue
+			if _issue_has_parent_task_label "$candidate" "$repo"; then
+				echo "$candidate"
+				return 0
+			fi
+		done
+	fi
+
+	return 0
+}
+
+# Link a single child issue as a sub-issue of a detected parent, operating
+# purely on GitHub state (title + body). Idempotent — `_gh_add_sub_issue`
+# suppresses duplicate-relationship errors.
+#
+# Arguments:
+#   $1 - child issue number
+#   $2 - repo slug
+# Returns: 0 on success/skip, 1 on unexpected failure
+# Echoes one of: "LINKED <child>:<parent>", "SKIPPED <child>", "DRY <child>:<parent>"
+_backfill_one_issue() {
+	local num="$1" repo="$2"
+	[[ -z "$num" || -z "$repo" ]] && {
+		echo "SKIPPED $num"
+		return 0
+	}
+
+	local meta
+	meta=$(gh issue view "$num" --repo "$repo" --json title,body 2>/dev/null || echo "{}")
+	local title body
+	title=$(printf '%s' "$meta" | jq -r '.title // ""' 2>/dev/null)
+	body=$(printf '%s' "$meta" | jq -r '.body // ""' 2>/dev/null)
+	if [[ -z "$title" ]]; then
+		echo "SKIPPED $num"
+		return 0
+	fi
+
+	local parent_num
+	parent_num=$(_detect_parent_from_gh_state "$title" "$body" "$repo")
+	if [[ -z "$parent_num" || "$parent_num" == "$num" ]]; then
+		echo "SKIPPED $num"
+		return 0
+	fi
+
+	if [[ "$DRY_RUN" == "true" ]]; then
+		print_info "[DRY-RUN] Would link #$num as sub-issue of #$parent_num"
+		echo "DRY $num:$parent_num"
+		return 0
+	fi
+
+	local child_node parent_node
+	child_node=$(_cached_node_id "$num" "$repo")
+	parent_node=$(_cached_node_id "$parent_num" "$repo")
+	if [[ -z "$child_node" || -z "$parent_node" ]]; then
+		log_verbose "#$num: could not resolve node IDs for $num / $parent_num"
+		echo "SKIPPED $num"
+		return 0
+	fi
+
+	if _gh_add_sub_issue "$parent_node" "$child_node"; then
+		log_verbose "#$num linked as sub-issue of #$parent_num ✓"
+		echo "LINKED $num:$parent_num"
+		return 0
+	fi
+	echo "SKIPPED $num"
+	return 0
+}
+
+# Backfill sub-issue parent-child links for issues in the current repo.
+# Detects parents from title/body only — no TODO.md or brief file required.
+#
+# Usage:
+#   cmd_backfill_sub_issues [--issue N]
+#
+# Without --issue, enumerates open issues in the repo (up to 500) and attempts
+# to link each one to its parent. With --issue, operates on a single issue —
+# this is the entry point used by the t2112 reconciler for one-issue backfill.
+cmd_backfill_sub_issues() {
+	local target_issue=""
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--issue)
+			target_issue="${2:-}"
+			shift 2
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+
+	_init_cmd || return 1
+	local repo="$_CMD_REPO"
+
+	local issue_numbers=()
+	if [[ -n "$target_issue" ]]; then
+		issue_numbers=("$target_issue")
+	else
+		local list_json
+		list_json=$(gh issue list --repo "$repo" --state open --limit 500 \
+			--json number 2>/dev/null || echo "[]")
+		while IFS= read -r _num; do
+			[[ -n "$_num" ]] && issue_numbers+=("$_num")
+		done < <(printf '%s' "$list_json" | jq -r '.[].number' 2>/dev/null || true)
+	fi
+
+	local total="${#issue_numbers[@]}"
+	if [[ $total -eq 0 ]]; then
+		print_info "No issues to backfill in $repo"
+		return 0
+	fi
+
+	print_info "Backfilling sub-issue links for $total issue(s) in $repo"
+
+	local linked=0 skipped=0 processed=0
+	local _num result
+	for _num in "${issue_numbers[@]}"; do
+		processed=$((processed + 1))
+		if [[ $((processed % 25)) -eq 0 || $processed -eq $total ]]; then
+			printf "\r  Progress: %d/%d issues..." "$processed" "$total" >&2
+		fi
+		result=$(_backfill_one_issue "$_num" "$repo" | tail -1)
+		case "$result" in
+		LINKED*) linked=$((linked + 1)) ;;
+		DRY*) linked=$((linked + 1)) ;;
+		*) skipped=$((skipped + 1)) ;;
+		esac
+	done
+	[[ $total -gt 25 ]] && printf "\n" >&2
+
+	printf "\n=== Backfill Sub-Issues ===\nLinked: %d | Skipped: %d | Issues processed: %d\n" \
+		"$linked" "$skipped" "$total"
+	return 0
+}
+
 cmd_help() {
 	cat <<'EOF'
 Issue Sync Helper — stateless TODO.md <-> GitHub Issues sync via gh CLI.
 Usage: issue-sync-helper.sh [command] [options]
 Commands: push [tNNN] | enrich [tNNN] | pull | close [tNNN] | reopen
-          reconcile | relationships [tNNN] | status | help
+          reconcile | relationships [tNNN] | backfill-sub-issues [--issue N]
+          status | help
 Options: --repo SLUG | --dry-run | --verbose | --force (skip evidence on close; bypass enrich body-gate)
          --force-push (allow bulk push outside CI — use with caution, risk of duplicates)
 
@@ -1795,6 +2059,15 @@ Relationships (t1889):
                          issue relationships. Without tNNN, processes all tasks
                          that have ref:GH# plus blocked-by:/blocks: or subtask IDs.
                          Use --dry-run to preview. Idempotent (skips existing).
+
+Sub-issue backfill (t2114):
+  backfill-sub-issues [--issue N] — link decomposition children to their
+                         parents using GitHub state alone (title + body). No
+                         TODO.md or brief file required. Detects parents via:
+                         (1) dot-notation title `tNNN.M: ...`, (2) `Parent: ...`
+                         line in body, (3) `Blocked by: tNNN` where the blocker
+                         carries the `parent-task` label. Idempotent; supports
+                         --dry-run.
 
 Note: Bulk push (no task ID) is CI-only by default to prevent duplicate issues.
       Use 'push <task_id>' for single tasks, or --force-push to override.
@@ -1841,6 +2114,13 @@ main() {
 	push) cmd_push "${positional_args[1]:-}" ;; enrich) cmd_enrich "${positional_args[1]:-}" ;;
 	pull) cmd_pull ;; close) cmd_close "${positional_args[1]:-}" ;; reopen) cmd_reopen ;;
 	reconcile) cmd_reconcile ;; relationships) cmd_relationships "${positional_args[1]:-}" ;;
+	backfill-sub-issues)
+		if [[ ${#positional_args[@]} -gt 1 ]]; then
+			cmd_backfill_sub_issues "${positional_args[@]:1}"
+		else
+			cmd_backfill_sub_issues
+		fi
+		;;
 	status) cmd_status ;; help) cmd_help ;;
 	*)
 		print_error "Unknown command: $command"

--- a/.agents/scripts/tests/test-backfill-sub-issues.sh
+++ b/.agents/scripts/tests/test-backfill-sub-issues.sh
@@ -1,0 +1,362 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-backfill-sub-issues.sh — tests for t2114 (GH#19093)
+#
+# The `backfill-sub-issues` subcommand in issue-sync-helper.sh links a child
+# issue to its parent using GitHub state alone (title + body), without
+# consulting TODO.md or brief files. Three detection mechanisms cover the
+# common cases observed in the wild:
+#
+#   1. Dot-notation in title — "t1873.2: foo" → parent t1873 (resolved via
+#      `gh search issues` against the same repo).
+#   2. Explicit `Parent:` line in body — `Parent: tNNN` / `Parent: GH#NNN` /
+#      `Parent: #NNN`, including bold-markdown and backtick-quoted variants.
+#   3. `Blocked by: tNNN` where the referenced task carries the `parent-task`
+#      label on GitHub. This is the only case that requires the label check —
+#      it prevents peer-dependency blockers from being misread as parents.
+#
+# Test coverage:
+#   Class A — _detect_parent_from_gh_state
+#     1. Dot-notation title resolves to parent issue number
+#     2. `Parent: #NNN` returns the raw number directly
+#     3. `Parent: GH#NNN` returns the raw number
+#     4. `**Parent:** `tNNN`` (bold-markdown) resolves via gh search
+#     5. `Blocked by: tNNN` with parent-task label returns the parent
+#     6. `Blocked by: tNNN` WITHOUT parent-task label returns empty
+#     7. No detection signals returns empty
+#     8. Comma-separated `Blocked by:` — first parent-tagged blocker wins
+#
+#   Class B — cmd_backfill_sub_issues
+#     9. --issue N --dry-run prints "Would link" and does NOT call addSubIssue
+#    10. --issue N (no dry-run) calls addSubIssue mutation
+#    11. --issue N with no parent signal produces "Linked: 0"
+#
+# Strategy:
+#   - Install a stubbed `gh` binary on PATH. The stub inspects its arguments
+#     and returns canned JSON for `gh issue view`, `gh issue list`, and
+#     `gh search issues`. GraphQL mutations are recorded to a log and return
+#     a success payload. Label lookups consult an env-var allowlist.
+#   - Source issue-sync-helper.sh AFTER the stub is on PATH (the helper's
+#     internal PATH-reset at top-of-file is worked around by setting PATH
+#     both before and after the source).
+
+set -u
+
+# Use TEST_-prefixed color vars to avoid colliding with the readonly vars
+# defined by shared-constants.sh when the helper is sourced later.
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_BLUE=$'\033[0;34m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_BLUE="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf '  %sPASS%s %s\n' "$TEST_GREEN" "$TEST_NC" "$1"
+	return 0
+}
+
+fail() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '  %sFAIL%s %s\n' "$TEST_RED" "$TEST_NC" "$1"
+	if [[ -n "${2:-}" ]]; then
+		printf '       %s\n' "$2"
+	fi
+	return 0
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)" || exit 1
+HELPER="${SCRIPTS_DIR}/issue-sync-helper.sh"
+
+if [[ ! -f "$HELPER" ]]; then
+	printf 'test harness cannot find helper at %s\n' "$HELPER" >&2
+	exit 1
+fi
+
+TMP=$(mktemp -d -t t2114-backfill.XXXXXX)
+trap 'rm -rf "$TMP"' EXIT
+
+# -----------------------------------------------------------------------------
+# Stubbed gh binary
+# -----------------------------------------------------------------------------
+# The stub reads its argument pattern and emits canned JSON:
+#   gh issue view <N> ...    → uses GH_ISSUE_<N>_JSON env
+#   gh issue list ...        → uses GH_ISSUE_LIST_JSON env
+#   gh search issues <q> ... → uses GH_SEARCH_<q>_JSON env
+#   gh api graphql -f query=...addSubIssue...  → logged, success payload
+# Any --jq filter is honoured if jq is available.
+
+GH_LOG="${TMP}/gh.log"
+export GH_LOG
+: >"$GH_LOG"
+
+mkdir -p "${TMP}/bin"
+cat >"${TMP}/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${GH_LOG:-/dev/null}"
+
+cmd1="${1:-}"
+cmd2="${2:-}"
+
+_emit() {
+	local payload="$1"
+	local jq_filter=""
+	local prev=""
+	for arg in "$@"; do
+		if [[ "$prev" == "--jq" ]]; then
+			jq_filter="$arg"
+		fi
+		prev="$arg"
+	done
+	if [[ -n "$jq_filter" ]] && command -v jq >/dev/null 2>&1; then
+		printf '%s\n' "$payload" | jq -r "$jq_filter"
+	else
+		printf '%s\n' "$payload"
+	fi
+}
+
+# gh issue view <N> ...
+if [[ "$cmd1" == "issue" && "$cmd2" == "view" ]]; then
+	num="${3:-}"
+	var="GH_ISSUE_${num}_JSON"
+	payload="${!var:-{\"title\":\"\",\"body\":\"\",\"labels\":[]}}"
+	_emit "$payload" "$@"
+	exit 0
+fi
+
+# gh issue list ...
+if [[ "$cmd1" == "issue" && "$cmd2" == "list" ]]; then
+	payload="${GH_ISSUE_LIST_JSON:-[]}"
+	_emit "$payload" "$@"
+	exit 0
+fi
+
+# gh search issues <q> ...
+if [[ "$cmd1" == "search" && "$cmd2" == "issues" ]]; then
+	q="${3:-}"
+	var="GH_SEARCH_${q}_JSON"
+	payload="${!var:-[]}"
+	_emit "$payload" "$@"
+	exit 0
+fi
+
+# gh api graphql -f query=...
+if [[ "$cmd1" == "api" && "$cmd2" == "graphql" ]]; then
+	# Check the mutation name in the query body
+	for arg in "$@"; do
+		if [[ "$arg" == *"addSubIssue"* ]]; then
+			printf '%s\n' '{"data":{"addSubIssue":{"issue":{"number":1}}}}'
+			exit 0
+		fi
+		if [[ "$arg" == *"issue(number"* ]]; then
+			# resolve_gh_node_id query
+			printf '%s\n' 'NODE_STUB_ID'
+			exit 0
+		fi
+	done
+	printf '%s\n' '{}'
+	exit 0
+fi
+
+# gh auth status
+if [[ "$cmd1" == "auth" && "$cmd2" == "status" ]]; then
+	exit 0
+fi
+
+# Default: success, no output
+exit 0
+STUB
+chmod +x "${TMP}/bin/gh"
+
+# Put the stub first on PATH. Source the helper (which resets PATH internally),
+# then prepend again.
+export PATH="${TMP}/bin:${PATH}"
+
+# Stubs for functions called by _init_cmd — we short-circuit _init_cmd itself
+# for Class B by overriding it after sourcing, so these are just defence.
+print_warning() { :; }
+print_info() { printf '%s\n' "$*"; }
+print_error() { printf 'ERROR: %s\n' "$*" >&2; }
+print_success() { :; }
+
+# Minimal fake project root so _init_cmd's call to find_project_root works if
+# we ever let it run. For Class B we override _init_cmd directly.
+FAKE_PROJECT_ROOT="${TMP}/fake-project"
+mkdir -p "$FAKE_PROJECT_ROOT"
+: >"${FAKE_PROJECT_ROOT}/TODO.md"
+
+# shellcheck source=../issue-sync-helper.sh
+source "$HELPER" >/dev/null 2>&1 || true
+export PATH="${TMP}/bin:${PATH}"
+
+# Override _init_cmd for Class B so it doesn't require a real git repo.
+_init_cmd() {
+	_CMD_ROOT="$FAKE_PROJECT_ROOT"
+	_CMD_REPO="owner/repo"
+	_CMD_TODO="${FAKE_PROJECT_ROOT}/TODO.md"
+	return 0
+}
+
+printf '%sRunning backfill-sub-issues tests (t2114)%s\n' "$TEST_BLUE" "$TEST_NC"
+
+# =============================================================================
+# Class A: _detect_parent_from_gh_state
+# =============================================================================
+
+# Parent t1873 lives at issue #100. t1873.2 lives at #200.
+export GH_SEARCH_t1873_JSON='[{"number":100,"title":"t1873: parent task"},{"number":200,"title":"t1873.2: child task"}]'
+# t1874 parent lives at #101 and carries the parent-task label.
+export GH_SEARCH_t1874_JSON='[{"number":101,"title":"t1874: parent with label"}]'
+# t1875 is a peer dependency (no parent-task label).
+export GH_SEARCH_t1875_JSON='[{"number":102,"title":"t1875: peer dependency"}]'
+# t1876 parent carrying parent-task label, used for multi-blocker test.
+export GH_SEARCH_t1876_JSON='[{"number":103,"title":"t1876: parent multi"}]'
+
+# Canned views for label lookups
+export GH_ISSUE_101_JSON='{"title":"t1874: parent with label","body":"","labels":[{"name":"parent-task"},{"name":"enhancement"}]}'
+export GH_ISSUE_102_JSON='{"title":"t1875: peer dependency","body":"","labels":[{"name":"bug"}]}'
+export GH_ISSUE_103_JSON='{"title":"t1876: parent multi","body":"","labels":[{"name":"parent-task"}]}'
+
+# ---- Test 1: dot-notation in title resolves via gh search ----
+result=$(_detect_parent_from_gh_state "t1873.2: child of 1873" "" "owner/repo")
+if [[ "$result" == "100" ]]; then
+	pass "dot-notation title resolves to parent issue number"
+else
+	fail "dot-notation title resolves to parent issue number" "got '$result'"
+fi
+
+# ---- Test 2: Parent: #NNN returns raw number ----
+result=$(_detect_parent_from_gh_state "child foo" "Some preamble
+Parent: #500
+More text" "owner/repo")
+if [[ "$result" == "500" ]]; then
+	pass "Parent: #NNN returns raw issue number"
+else
+	fail "Parent: #NNN returns raw issue number" "got '$result'"
+fi
+
+# ---- Test 3: Parent: GH#NNN returns raw number ----
+result=$(_detect_parent_from_gh_state "child foo" "Parent: GH#501" "owner/repo")
+if [[ "$result" == "501" ]]; then
+	pass "Parent: GH#NNN returns raw issue number"
+else
+	fail "Parent: GH#NNN returns raw issue number" "got '$result'"
+fi
+
+# ---- Test 4: **Parent:** `tNNN` (bold markdown) resolves via gh search ----
+result=$(_detect_parent_from_gh_state "child foo" "**Parent:** \`t1873\`" "owner/repo")
+if [[ "$result" == "100" ]]; then
+	pass "bold-markdown **Parent:** \`tNNN\` resolves via gh search"
+else
+	fail "bold-markdown **Parent:** \`tNNN\` resolves via gh search" "got '$result'"
+fi
+
+# ---- Test 5: Blocked by: tNNN with parent-task label ----
+result=$(_detect_parent_from_gh_state "child foo" "**Blocked by:** \`t1874\`" "owner/repo")
+if [[ "$result" == "101" ]]; then
+	pass "Blocked by: with parent-task label returns the parent"
+else
+	fail "Blocked by: with parent-task label returns the parent" "got '$result'"
+fi
+
+# ---- Test 6: Blocked by: tNNN WITHOUT parent-task label ----
+result=$(_detect_parent_from_gh_state "child foo" "Blocked by: t1875" "owner/repo")
+if [[ -z "$result" ]]; then
+	pass "Blocked by: without parent-task label returns empty"
+else
+	fail "Blocked by: without parent-task label returns empty" "got '$result'"
+fi
+
+# ---- Test 7: No detection signals ----
+result=$(_detect_parent_from_gh_state "plain title" "just a regular body with no parent reference" "owner/repo")
+if [[ -z "$result" ]]; then
+	pass "no detection signals returns empty"
+else
+	fail "no detection signals returns empty" "got '$result'"
+fi
+
+# ---- Test 8: comma-separated Blocked by: — first parent-tagged blocker wins ----
+result=$(_detect_parent_from_gh_state "child foo" "**Blocked by:** \`t1875,t1876\`" "owner/repo")
+if [[ "$result" == "103" ]]; then
+	pass "comma-separated Blocked by: picks the first parent-tagged blocker"
+else
+	fail "comma-separated Blocked by: picks the first parent-tagged blocker" "got '$result'"
+fi
+
+# =============================================================================
+# Class B: cmd_backfill_sub_issues
+# =============================================================================
+
+# Issue #200 is a t1873.2 child; _backfill_one_issue will detect parent #100.
+export GH_ISSUE_200_JSON='{"title":"t1873.2: child of 1873","body":"implementation","labels":[]}'
+# Issue #201 has no parent signal.
+export GH_ISSUE_201_JSON='{"title":"standalone task","body":"nothing here","labels":[]}'
+
+# ---- Test 9: --issue N --dry-run prints "Would link", does not mutate ----
+: >"$GH_LOG"
+DRY_RUN="true" cmd_backfill_sub_issues --issue 200 >"${TMP}/out.9" 2>&1 || true
+DRY_RUN="false"
+
+if grep -q 'Would link #200 as sub-issue of #100' "${TMP}/out.9"; then
+	if ! grep -q 'addSubIssue' "$GH_LOG"; then
+		pass "dry-run prints Would link and skips addSubIssue mutation"
+	else
+		fail "dry-run prints Would link and skips addSubIssue mutation" \
+			"unexpected addSubIssue in gh.log: $(tr '\n' '|' <"$GH_LOG" | head -c 200)"
+	fi
+else
+	fail "dry-run prints Would link and skips addSubIssue mutation" \
+		"missing 'Would link' in output: $(tr '\n' '|' <"${TMP}/out.9" | head -c 200)"
+fi
+
+# ---- Test 10: --issue N (no dry-run) calls addSubIssue ----
+: >"$GH_LOG"
+cmd_backfill_sub_issues --issue 200 >"${TMP}/out.10" 2>&1 || true
+
+if grep -q 'addSubIssue' "$GH_LOG"; then
+	pass "live run calls addSubIssue mutation for detected parent"
+else
+	fail "live run calls addSubIssue mutation for detected parent" \
+		"missing addSubIssue in gh.log: $(tr '\n' '|' <"$GH_LOG" | head -c 200)"
+fi
+
+# ---- Test 11: --issue N with no parent signal → Linked: 0 ----
+: >"$GH_LOG"
+cmd_backfill_sub_issues --issue 201 >"${TMP}/out.11" 2>&1 || true
+
+if grep -q 'Linked: 0' "${TMP}/out.11"; then
+	if ! grep -q 'addSubIssue' "$GH_LOG"; then
+		pass "no parent detected → Linked: 0, no mutation"
+	else
+		fail "no parent detected → Linked: 0, no mutation" \
+			"unexpected addSubIssue in gh.log"
+	fi
+else
+	fail "no parent detected → Linked: 0, no mutation" \
+		"missing 'Linked: 0' in output: $(tr '\n' '|' <"${TMP}/out.11" | head -c 200)"
+fi
+
+# =============================================================================
+# Summary
+# =============================================================================
+
+echo
+echo "============================================"
+printf 'Tests run:    %d\n' "$TESTS_RUN"
+printf 'Tests failed: %d\n' "$TESTS_FAILED"
+echo "============================================"
+
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Added backfill-sub-issues subcommand to issue-sync-helper.sh that links decomposition child issues to their parents using GitHub state alone — dot-notation title, explicit Parent: line in body, or Blocked by: tNNN where the blocker has the parent-task label. No TODO.md or brief file required. Closes the gap between cmd_relationships (TODO-driven) and _gh_auto_link_sub_issue (wrapper-driven).

## Files Changed

.agents/scripts/issue-sync-helper.sh,.agents/scripts/tests/test-backfill-sub-issues.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** New test-backfill-sub-issues.sh harness with stubbed gh binary covers 11 cases across _detect_parent_from_gh_state and cmd_backfill_sub_issues (dot-notation, Parent:#NNN, Parent:GH#NNN, bold-markdown, Blocked by with/without parent-task label, no signal, comma-separated blockers, dry-run, live mutation, no-parent case). All 11 pass. Existing test-issue-sync-tier-extraction.sh continues to pass (no regression). shellcheck clean.

Resolves #19093


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.38 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-opus-4-6 spent 6m and 26,848 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command to automatically link related GitHub issues as parent-child sub-issues based on issue state and metadata.
  * Supports detecting parent references through multiple formats (titles, body text patterns).

* **Tests**
  * Added test coverage for issue backfilling functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->