### PR TITLE
fix: use Response.json() in proxy handlers to avoid Bun _Response type mismatch

### DIFF
--- a/.agents/plugins/opencode-aidevops/claude-proxy.mjs
+++ b/.agents/plugins/opencode-aidevops/claude-proxy.mjs
@@ -50,6 +50,35 @@ const SSE_HEADERS = {
   Connection: "keep-alive",
 };
 
+// ---------------------------------------------------------------------------
+// Response helpers — cross-realm safety
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a JSON HTTP response. OpenCode's Bun plugin loader may rebind the
+ * `Response` constructor to a realm-local `_Response` class that Bun.serve
+ * rejects with "Expected a Response object, but received '_Response'".
+ *
+ * `Response.json()` (Fetch API static method, Bun ≥1.0) constructs the
+ * response through Bun's native internal path, bypassing the mismatch.
+ * Falls back to `new Response()` for runtimes without `Response.json()`.
+ */
+function jsonResponse(data, init = {}) {
+  if (typeof Response.json === "function") {
+    return Response.json(data, init);
+  }
+  return new Response(JSON.stringify(data), {
+    ...init,
+    headers: { "Content-Type": "application/json", ...init.headers },
+  });
+}
+
+/** Plain-text response (404, etc.). No cross-realm workaround needed — these
+ *  are simple enough that Bun.serve generally handles them. */
+function textResponse(body, init = {}) {
+  return new Response(body, init);
+}
+
 /** @type {ReturnType<Bun["serve"]> | null} */
 let proxyServer = null;
 /** @type {number | null} */
@@ -225,22 +254,18 @@ async function handleChatCompletions(req, directory) {
     // Thread the fetch Request's abort signal into the JSON path so client
     // disconnect terminates the child immediately (GH#18621 Finding 1).
     const result = await runClaudeJson(body, directory, req.signal);
-    return new Response(JSON.stringify(buildOpenAIResponse(body, result.content, result.usage)), {
-      headers: { "Content-Type": "application/json" },
-    });
+    return jsonResponse(buildOpenAIResponse(body, result.content, result.usage));
   }
 
-  return new Response(streamClaudeResponse(body, directory), {
+  return textResponse(streamClaudeResponse(body, directory), {
     headers: SSE_HEADERS,
   });
 }
 
 function buildModelsListResponse() {
-  return new Response(JSON.stringify({
+  return jsonResponse({
     object: "list",
     data: getClaudeProxyModels().map((model) => ({ id: model.id, object: "model", owned_by: "claude-cli" })),
-  }), {
-    headers: { "Content-Type": "application/json" },
   });
 }
 
@@ -249,12 +274,10 @@ async function handleChatCompletionsWithErrorWrap(req, directory) {
     return await handleChatCompletions(req, directory);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    return new Response(JSON.stringify({
-      error: { message, type: "server_error", code: "internal_error" },
-    }), {
-      status: 500,
-      headers: { "Content-Type": "application/json" },
-    });
+    return jsonResponse(
+      { error: { message, type: "server_error", code: "internal_error" } },
+      { status: 500 },
+    );
   }
 }
 
@@ -270,7 +293,7 @@ async function routeProxyRequest(req, directory) {
   if (req.method === "POST" && url.pathname === "/v1/chat/completions") {
     return handleChatCompletionsWithErrorWrap(req, directory);
   }
-  return new Response("Not Found", { status: 404 });
+  return textResponse("Not Found", { status: 404 });
 }
 
 // ---------------------------------------------------------------------------

--- a/.agents/plugins/opencode-aidevops/google-proxy.mjs
+++ b/.agents/plugins/opencode-aidevops/google-proxy.mjs
@@ -28,6 +28,25 @@
 import { join } from "path";
 import { getAccounts, ensureValidToken, patchAccount } from "./oauth-pool.mjs";
 export { buildGoogleProviderModels, registerGoogleProvider, persistGoogleProvider, discoverGoogleModels } from "./google-proxy-config.mjs";
+
+// ---------------------------------------------------------------------------
+// Response helpers — cross-realm safety (same as claude-proxy.mjs)
+// ---------------------------------------------------------------------------
+
+/** See claude-proxy.mjs for full rationale on the _Response type mismatch. */
+function jsonResponse(data, init = {}) {
+  if (typeof Response.json === "function") {
+    return Response.json(data, init);
+  }
+  return new Response(JSON.stringify(data), {
+    ...init,
+    headers: { "Content-Type": "application/json", ...init.headers },
+  });
+}
+
+function textResponse(body, init = {}) {
+  return new Response(body, init);
+}
 import { persistGoogleProvider, discoverGoogleModels } from "./google-proxy-config.mjs";
 
 // ---------------------------------------------------------------------------
@@ -214,9 +233,10 @@ async function forwardToGoogleApi(req, url) {
     accessToken = result.token;
     accountEmail = result.email;
   } catch (err) {
-    return new Response(JSON.stringify({
-      error: { message: `Google proxy: ${err.message}`, status: "UNAVAILABLE" },
-    }), { status: 503, headers: { "Content-Type": "application/json" } });
+    return jsonResponse(
+      { error: { message: `Google proxy: ${err.message}`, status: "UNAVAILABLE" } },
+      { status: 503 },
+    );
   }
 
   const forwardHeaders = buildGoogleForwardHeaders(req, accessToken);
@@ -236,7 +256,7 @@ async function forwardToGoogleApi(req, url) {
   }
 
   // Pipe the response back — preserves SSE streaming for streamGenerateContent
-  return new Response(response.body, {
+  return textResponse(response.body, {
     status: response.status,
     statusText: response.statusText,
     headers: response.headers,
@@ -252,18 +272,17 @@ async function handleGoogleProxyFetch(req) {
   const url = new URL(req.url);
 
   if (url.pathname === "/health") {
-    return new Response(JSON.stringify({ status: "ok", provider: "google" }), {
-      headers: { "Content-Type": "application/json" },
-    });
+    return jsonResponse({ status: "ok", provider: "google" });
   }
 
   try {
     return await forwardToGoogleApi(req, url);
   } catch (err) {
     console.error(`[aidevops] Google proxy: request error: ${err.message}`);
-    return new Response(JSON.stringify({
-      error: { message: `Google proxy error: ${err.message}`, status: "INTERNAL" },
-    }), { status: 502, headers: { "Content-Type": "application/json" } });
+    return jsonResponse(
+      { error: { message: `Google proxy error: ${err.message}`, status: "INTERNAL" } },
+      { status: 502 },
+    );
   }
 }
 
@@ -289,7 +308,7 @@ async function handleGoogleProxyFetch(req) {
 /** Bun.serve error handler for the Google proxy. */
 function handleGoogleProxyServerError(err) {
   console.error(`[aidevops] Google proxy: server error: ${err.message}`);
-  return new Response("Internal Server Error", { status: 500 });
+  return textResponse("Internal Server Error", { status: 500 });
 }
 
 /** Discover models and start proxy; throws on failure (caller wraps in try/catch). */


### PR DESCRIPTION
## Summary

- Replace `new Response(JSON.stringify(...))` with `Response.json()` in both `claude-proxy.mjs` and `google-proxy.mjs` to avoid Bun's cross-realm `_Response` type rejection
- OpenCode's plugin loader rebinds the `Response` constructor to a realm-local `_Response` class; `Bun.serve` then rejects it with `Expected a Response object, but received '_Response'`
- `Response.json()` (Fetch API static method) constructs through Bun's native internal path, bypassing the mismatch
- Falls back to `new Response()` for runtimes without `Response.json()`

For #19175 (tracks the full `_Response` fix family — this PR is the claude/google half; #19181 extends the same pattern to cursor and provider-auth)

## Evidence

Before fix — error spamming every few minutes in `opencode-web.service` journal:
```
error: Expected a Response object, but received '_Response {
  [Symbol(cache)]: [ 200, "{\"object\":\"list\",\"data\":[...]}" ...
}'
```

After fix — 42 min runtime, zero errors, `/v1/models` returns clean JSON.

## Files changed

- `EDIT: .agents/plugins/opencode-aidevops/claude-proxy.mjs` — add `jsonResponse()`/`textResponse()` helpers, replace 5 `new Response()` call sites
- `EDIT: .agents/plugins/opencode-aidevops/google-proxy.mjs` — same pattern, replace 5 `new Response()` call sites

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized response construction across proxy services to improve code consistency and cross-environment compatibility.

---

*Note: These are internal infrastructure improvements with no changes to user-facing functionality or behavior.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
