### PR TITLE
t2053.5: migrate Tier 4 standalone helpers (Phase 5)

### DIFF
--- a/.agents/scripts/colormind-helper.sh
+++ b/.agents/scripts/colormind-helper.sh
@@ -20,12 +20,9 @@ readonly SCRIPT_NAME="colormind-helper"
 readonly API_URL="http://colormind.io/api/"
 readonly ROLES=("background" "surface" "accent" "secondary" "text")
 
-# Colours for terminal output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m'
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=shared-constants.sh
+[[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
 
 print_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
 print_success() { echo -e "${GREEN}[OK]${NC} $1"; }

--- a/.agents/scripts/contest-helper.sh
+++ b/.agents/scripts/contest-helper.sh
@@ -29,13 +29,8 @@ SUPERVISOR_DB="${SUPERVISOR_DIR}/supervisor.db"
 # shellcheck disable=SC2034 # SCORING_DB used by _record_contest_scores
 SCORING_DB="${HOME}/.aidevops/.agent-workspace/response-scoring.db"
 
-# Colours
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-BOLD='\033[1m'
-NC='\033[0m'
+# BOLD fallback — not in shared-constants.sh
+[[ -z "${BOLD+x}" ]] && BOLD='\033[1m'
 
 # Default contest models — top 3 from different providers for diversity
 DEFAULT_CONTEST_MODELS="anthropic/claude-opus-4-6,anthropic/claude-sonnet-4-6,google/gemini-2.5-pro"

--- a/.agents/scripts/design-preview-helper.sh
+++ b/.agents/scripts/design-preview-helper.sh
@@ -24,12 +24,9 @@ readonly MAX_AI_REVIEW_PX=1568
 readonly DEFAULT_VIEWPORT_WIDTH=1440
 readonly DEFAULT_FORMAT="png"
 
-# Colours
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m'
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=shared-constants.sh
+[[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
 
 print_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
 print_success() { echo -e "${GREEN}[OK]${NC} $1"; }

--- a/.agents/scripts/ssh-key-audit-helper.sh
+++ b/.agents/scripts/ssh-key-audit-helper.sh
@@ -1,17 +1,14 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
-set -euo pipefail
+set -Eeuo pipefail
 
 # SSH Key Audit Script
 # Audits and standardizes SSH keys across all servers
 
-# Colors for output
-GREEN='\033[0;32m'
-BLUE='\033[0;34m'
-YELLOW='\033[1;33m'
-RED='\033[0;31m'
-NC='\033[0m' # No Color
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=shared-constants.sh
+[[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
 
 print_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
 print_success() { echo -e "${GREEN}[SUCCESS]${NC} $1"; }
@@ -20,9 +17,9 @@ print_error() { echo -e "${RED}[ERROR]${NC} $1"; }
 
 # SSH keys to test (in order of preference)
 SSH_KEYS=(
-    "$HOME/.ssh/id_ed25519"
-    "$HOME/.ssh/id_rsa"
-    "$HOME/.ssh/id_ecdsa"
+	"$HOME/.ssh/id_ed25519"
+	"$HOME/.ssh/id_rsa"
+	"$HOME/.ssh/id_ecdsa"
 )
 
 # Target key (the one we want all servers to use)
@@ -31,194 +28,194 @@ TARGET_KEY_PUB="$HOME/.ssh/id_ed25519.pub"
 
 # Test SSH key access to a server
 test_ssh_key() {
-    local server_ip="$1"
-    local ssh_key="$2"
-    local username="${3:-root}"
-    
-    # Test SSH connection with specific key
-    ssh -o ConnectTimeout=3 \
-        -o StrictHostKeyChecking=no \
-        -o UserKnownHostsFile=/dev/null \
-        -o LogLevel=ERROR \
-        -o PasswordAuthentication=no \
-        -i "$ssh_key" \
-        "$username@$server_ip" \
-        "echo 'SSH_SUCCESS'" 2>/dev/null | grep -q "SSH_SUCCESS"
-    
-    return $?
-    return 0
+	local server_ip="$1"
+	local ssh_key="$2"
+	local username="${3:-root}"
+
+	# Test SSH connection with specific key
+	ssh -o ConnectTimeout=3 \
+		-o StrictHostKeyChecking=no \
+		-o UserKnownHostsFile=/dev/null \
+		-o LogLevel=ERROR \
+		-o PasswordAuthentication=no \
+		-i "$ssh_key" \
+		"$username@$server_ip" \
+		"echo 'SSH_SUCCESS'" 2>/dev/null | grep -q "SSH_SUCCESS"
+
+	return $?
+	return 0
 }
 
 # Get working SSH key for a server
 get_working_key() {
-    local server_ip="$1"
-    local username="${2:-root}"
-    
-    for key in "${SSH_KEYS[@]}"; do
-        key_path="${key/\~/$HOME}"
-        if [[ -f "$key_path" ]]; then
-            if test_ssh_key "$server_ip" "$key_path" "$username"; then
-                echo "$key_path"
-                return 0
-            fi
-        fi
-    done
-    
-    return 1
+	local server_ip="$1"
+	local username="${2:-root}"
+
+	for key in "${SSH_KEYS[@]}"; do
+		key_path="${key/\~/$HOME}"
+		if [[ -f "$key_path" ]]; then
+			if test_ssh_key "$server_ip" "$key_path" "$username"; then
+				echo "$key_path"
+				return 0
+			fi
+		fi
+	done
+
+	return 1
 }
 
 # Check if target key is installed
 check_target_key_installed() {
-    local server_ip="$1"
-    local working_key="$2"
-    local username="${3:-root}"
-    
-    # Get the target public key content
-    local target_pub_key
-    target_pub_key=$(cat "${TARGET_KEY_PUB/\~/$HOME}" | cut -d' ' -f2)
-    
-    # Check if it's in authorized_keys
-    ssh -o ConnectTimeout=3 \
-        -o StrictHostKeyChecking=no \
-        -o UserKnownHostsFile=/dev/null \
-        -o LogLevel=ERROR \
-        -i "$working_key" \
-        "$username@$server_ip" \
-        "grep -q '$target_pub_key' ~/.ssh/authorized_keys" 2>/dev/null
-    
-    return $?
-    return 0
+	local server_ip="$1"
+	local working_key="$2"
+	local username="${3:-root}"
+
+	# Get the target public key content
+	local target_pub_key
+	target_pub_key=$(cat "${TARGET_KEY_PUB/\~/$HOME}" | cut -d' ' -f2)
+
+	# Check if it's in authorized_keys
+	ssh -o ConnectTimeout=3 \
+		-o StrictHostKeyChecking=no \
+		-o UserKnownHostsFile=/dev/null \
+		-o LogLevel=ERROR \
+		-i "$working_key" \
+		"$username@$server_ip" \
+		"grep -q '$target_pub_key' ~/.ssh/authorized_keys" 2>/dev/null
+
+	return $?
+	return 0
 }
 
 # Install target key on server
 install_target_key() {
-    local server_ip="$1"
-    local working_key="$2"
-    local username="${3:-root}"
-    
-    print_info "Installing target key on $server_ip..."
-    
-    # Get the target public key content
-    local target_pub_key
-    target_pub_key=$(cat "${TARGET_KEY_PUB/\~/$HOME}")
-    
-    # Add the key to authorized_keys
-    ssh -o ConnectTimeout=5 \
-        -o StrictHostKeyChecking=no \
-        -o UserKnownHostsFile=/dev/null \
-        -o LogLevel=ERROR \
-        -i "$working_key" \
-        "$username@$server_ip" \
-        "echo '$target_pub_key' >> ~/.ssh/authorized_keys && sort -u ~/.ssh/authorized_keys -o ~/.ssh/authorized_keys" 2>/dev/null
+	local server_ip="$1"
+	local working_key="$2"
+	local username="${3:-root}"
 
-    if ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -i "$working_key" "$username@$server_ip" "echo '$target_pub_key' >> ~/.ssh/authorized_keys && sort -u ~/.ssh/authorized_keys -o ~/.ssh/authorized_keys" 2>/dev/null; then
-        print_success "Target key installed on $server_ip"
-        return 0
-    else
-        print_error "Failed to install target key on $server_ip"
-        return 1
-    fi
+	print_info "Installing target key on $server_ip..."
+
+	# Get the target public key content
+	local target_pub_key
+	target_pub_key=$(cat "${TARGET_KEY_PUB/\~/$HOME}")
+
+	# Add the key to authorized_keys
+	ssh -o ConnectTimeout=5 \
+		-o StrictHostKeyChecking=no \
+		-o UserKnownHostsFile=/dev/null \
+		-o LogLevel=ERROR \
+		-i "$working_key" \
+		"$username@$server_ip" \
+		"echo '$target_pub_key' >> ~/.ssh/authorized_keys && sort -u ~/.ssh/authorized_keys -o ~/.ssh/authorized_keys" 2>/dev/null
+
+	if ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -i "$working_key" "$username@$server_ip" "echo '$target_pub_key' >> ~/.ssh/authorized_keys && sort -u ~/.ssh/authorized_keys -o ~/.ssh/authorized_keys" 2>/dev/null; then
+		print_success "Target key installed on $server_ip"
+		return 0
+	else
+		print_error "Failed to install target key on $server_ip"
+		return 1
+	fi
 }
 
 # Audit servers from a list
 audit_servers() {
-    local servers_file="$1"
-    local install_mode="$2"
-    
-    if [[ ! -f "$servers_file" ]]; then
-        print_error "Servers file not found: $servers_file"
-        print_info "Create a file with format: server_name,ip_address,username"
-        print_info "Example:"
-        print_info "web-server,192.168.1.10,root"
-        print_info "app-server,192.168.1.11,ubuntu"
-        exit 1
-    fi
-    
-    print_info "Starting SSH key audit..."
-    echo ""
-    
-    echo "=== SSH Key Audit Results ==="
-    echo ""
-    
-    while IFS=',' read -r server_name server_ip username; do
-        # Skip empty lines and comments
-        [[ -z "$server_name" || "$server_name" =~ ^#.*$ ]] && continue
-        
-        username="${username:-root}"
-        
-        echo "Server: $server_name ($server_ip) - User: $username"
-        
-        # Find working key
-        working_key=$(get_working_key "$server_ip" "$username")
-        
-        if [[ -n "$working_key" ]]; then
-            print_success "Access: Working with key $(basename "$working_key")"
-            
-            # Check if target key is installed
-            if check_target_key_installed "$server_ip" "$working_key" "$username"; then
-                print_success "Target key: Already installed ✓"
-            else
-                print_warning "Target key: Not installed"
-                
-                if [[ "$install_mode" == "--install" ]]; then
-                    install_target_key "$server_ip" "$working_key" "$username"
-                else
-                    print_info "Run with --install to add target key"
-                fi
-            fi
-        else
-            print_error "Access: No working SSH key found"
-        fi
-        
-        echo ""
-    done < "$servers_file"
+	local servers_file="$1"
+	local install_mode="$2"
+
+	if [[ ! -f "$servers_file" ]]; then
+		print_error "Servers file not found: $servers_file"
+		print_info "Create a file with format: server_name,ip_address,username"
+		print_info "Example:"
+		print_info "web-server,192.168.1.10,root"
+		print_info "app-server,192.168.1.11,ubuntu"
+		exit 1
+	fi
+
+	print_info "Starting SSH key audit..."
+	echo ""
+
+	echo "=== SSH Key Audit Results ==="
+	echo ""
+
+	while IFS=',' read -r server_name server_ip username; do
+		# Skip empty lines and comments
+		[[ -z "$server_name" || "$server_name" =~ ^#.*$ ]] && continue
+
+		username="${username:-root}"
+
+		echo "Server: $server_name ($server_ip) - User: $username"
+
+		# Find working key
+		working_key=$(get_working_key "$server_ip" "$username")
+
+		if [[ -n "$working_key" ]]; then
+			print_success "Access: Working with key $(basename "$working_key")"
+
+			# Check if target key is installed
+			if check_target_key_installed "$server_ip" "$working_key" "$username"; then
+				print_success "Target key: Already installed ✓"
+			else
+				print_warning "Target key: Not installed"
+
+				if [[ "$install_mode" == "--install" ]]; then
+					install_target_key "$server_ip" "$working_key" "$username"
+				else
+					print_info "Run with --install to add target key"
+				fi
+			fi
+		else
+			print_error "Access: No working SSH key found"
+		fi
+
+		echo ""
+	done <"$servers_file"
 }
 
 # Show target key info
 show_target_key_info() {
-    echo "=== Target SSH Key Information ==="
-    echo "Key: $TARGET_KEY"
-    echo "Type: Ed25519 (modern, secure, fast)"
-    if [[ -f "${TARGET_KEY_PUB/\~/$HOME}" ]]; then
-        echo "Comment: $(ssh-keygen -l -f "${TARGET_KEY_PUB/\~/$HOME}" | cut -d' ' -f3-)"
-        echo "Fingerprint: $(ssh-keygen -l -f "${TARGET_KEY_PUB/\~/$HOME}")"
-    else
-        print_warning "Target key not found. Generate with: ssh-keygen -t ed25519 -C 'your-email@domain.com'"
-    fi
-    echo ""
-    return 0
+	echo "=== Target SSH Key Information ==="
+	echo "Key: $TARGET_KEY"
+	echo "Type: Ed25519 (modern, secure, fast)"
+	if [[ -f "${TARGET_KEY_PUB/\~/$HOME}" ]]; then
+		echo "Comment: $(ssh-keygen -l -f "${TARGET_KEY_PUB/\~/$HOME}" | cut -d' ' -f3-)"
+		echo "Fingerprint: $(ssh-keygen -l -f "${TARGET_KEY_PUB/\~/$HOME}")"
+	else
+		print_warning "Target key not found. Generate with: ssh-keygen -t ed25519 -C 'your-email@domain.com'"
+	fi
+	echo ""
+	return 0
 }
 
 # Main function
 case "$1" in
-    "audit")
-        show_target_key_info
-        audit_servers "$2"
-        ;;
-    "install")
-        show_target_key_info
-        audit_servers "$2" --install
-        ;;
-    "help"|"-h"|"--help"|"")
-        echo "SSH Key Audit Script"
-        echo "Usage: $0 [command] [servers-file]"
-        echo ""
-        echo "Commands:"
-        echo "  audit [file]    - Audit SSH key access on servers in file"
-        echo "  install [file]  - Audit and install target key where missing"
-        echo "  help            - Show this help message"
-        echo ""
-        echo "Servers file format (CSV):"
-        echo "  server_name,ip_address,username"
-        echo "  web-server,192.168.1.10,root"
-        echo "  app-server,192.168.1.11,ubuntu"
-        echo ""
-        echo "Target Key: Ed25519 (modern, secure, fast)"
-        echo "This script will standardize all servers to use the Ed25519 key."
-        ;;
-    *)
-        print_error "Unknown command: $1"
-        print_info "Use '$0 help' for usage information"
-        exit 1
-        ;;
+"audit")
+	show_target_key_info
+	audit_servers "$2"
+	;;
+"install")
+	show_target_key_info
+	audit_servers "$2" --install
+	;;
+"help" | "-h" | "--help" | "")
+	echo "SSH Key Audit Script"
+	echo "Usage: $0 [command] [servers-file]"
+	echo ""
+	echo "Commands:"
+	echo "  audit [file]    - Audit SSH key access on servers in file"
+	echo "  install [file]  - Audit and install target key where missing"
+	echo "  help            - Show this help message"
+	echo ""
+	echo "Servers file format (CSV):"
+	echo "  server_name,ip_address,username"
+	echo "  web-server,192.168.1.10,root"
+	echo "  app-server,192.168.1.11,ubuntu"
+	echo ""
+	echo "Target Key: Ed25519 (modern, secure, fast)"
+	echo "This script will standardize all servers to use the Ed25519 key."
+	;;
+*)
+	print_error "Unknown command: $1"
+	print_info "Use '$0 help' for usage information"
+	exit 1
+	;;
 esac

--- a/.agents/scripts/tabby-helper.sh
+++ b/.agents/scripts/tabby-helper.sh
@@ -24,6 +24,8 @@ set -euo pipefail
 
 # --- Constants ---
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=shared-constants.sh
+[[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
 REPOS_JSON="${HOME}/.config/aidevops/repos.json"
 
 # Tabby config path (platform-aware)
@@ -32,13 +34,6 @@ if [[ "$(uname -s)" == "Darwin" ]]; then
 else
 	TABBY_CONFIG="${HOME}/.config/tabby-terminal/config.yaml"
 fi
-
-# --- Colours ---
-GREEN='\033[0;32m'
-BLUE='\033[0;34m'
-YELLOW='\033[1;33m'
-RED='\033[0;31m'
-NC='\033[0m'
 
 _info() { echo -e "${BLUE}[INFO]${NC} $1"; }
 _success() { echo -e "${GREEN}[OK]${NC} $1"; }


### PR DESCRIPTION
## What

Migrate 5 Tier-4 standalone helpers from unguarded plain color assignments to Pattern A (source `shared-constants.sh`) or Pattern B (`${VAR+x}` guard for non-canonical vars).

## Files changed

1. **EDIT:** `.agents/scripts/design-preview-helper.sh` — add SCRIPT_DIR + source shared-constants.sh; remove `RED/GREEN/YELLOW/BLUE/NC` block (Pattern A)
2. **EDIT:** `.agents/scripts/colormind-helper.sh` — add SCRIPT_DIR + source shared-constants.sh; remove `RED/GREEN/YELLOW/BLUE/NC` block (Pattern A)
3. **EDIT:** `.agents/scripts/contest-helper.sh` — already sources shared-constants.sh; remove redundant canonical color declarations; BOLD → Pattern B guard (`[[ -z "${BOLD+x}" ]] && BOLD='\033[1m'`)
4. **EDIT:** `.agents/scripts/tabby-helper.sh` — add source shared-constants.sh after existing SCRIPT_DIR; remove `GREEN/BLUE/YELLOW/RED/NC` block (Pattern A)
5. **EDIT:** `.agents/scripts/ssh-key-audit-helper.sh` — add SCRIPT_DIR + source shared-constants.sh; remove `GREEN/BLUE/YELLOW/RED/NC` block; upgrade `set -euo` → `set -Eeuo pipefail` (Pattern A)

## Verification

- `shellcheck -S error` passes clean for all 5 files
- No behavioural change — color usage unchanged, sourced from shared-constants.sh at runtime
- Drains the unguarded-plain category for all Tier 4 standalone tools

For #18735
Resolves #19064