### PR TITLE
t2053.8c: BOLD readonly normalization batch 3 (Phase 8c)

### DIFF
--- a/.agents/scripts/tool-version-check.sh
+++ b/.agents/scripts/tool-version-check.sh
@@ -18,7 +18,7 @@ source "${SCRIPT_DIR}/shared-constants.sh"
 
 set -euo pipefail
 
-readonly BOLD='\033[1m'
+[[ -z "${BOLD+x}" ]] && BOLD='\033[1m'
 
 # Parse arguments
 AUTO_UPDATE=false

--- a/.agents/scripts/venv-health-check-helper.sh
+++ b/.agents/scripts/venv-health-check-helper.sh
@@ -29,8 +29,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 # shellcheck source=shared-constants.sh
 source "${SCRIPT_DIR}/shared-constants.sh"
 
-# BOLD is not in shared-constants.sh — define locally
-readonly BOLD='\033[1m'
+[[ -z "${BOLD+x}" ]] && BOLD='\033[1m'
 
 readonly REPOS_JSON="${HOME}/.config/aidevops/repos.json"
 

--- a/.agents/scripts/worktree-helper.sh
+++ b/.agents/scripts/worktree-helper.sh
@@ -35,7 +35,7 @@ source "${SCRIPT_DIR}/shared-constants.sh"
 
 set -euo pipefail
 
-readonly BOLD='\033[1m'
+[[ -z "${BOLD+x}" ]] && BOLD='\033[1m'
 
 # nice — ownership registry functions are centralised in shared-constants.sh (t189):
 #   register_worktree, unregister_worktree, check_worktree_owner,

--- a/.agents/scripts/worktree-sessions.sh
+++ b/.agents/scripts/worktree-sessions.sh
@@ -25,7 +25,7 @@ source "${SCRIPT_DIR}/shared-constants.sh"
 
 set -euo pipefail
 
-readonly BOLD='\033[1m'
+[[ -z "${BOLD+x}" ]] && BOLD='\033[1m'
 readonly DIM='\033[2m'
 
 # OpenCode session storage


### PR DESCRIPTION
## Summary

Replace `readonly BOLD='\033[1m'` with the guarded form `[[ -z "${BOLD+x}" ]] && BOLD='\033[1m'` in the final 4 production helpers. Finishes Phase 8 of the t2053 BOLD readonly normalization roadmap.

## Files Changed

- **EDIT:** `.agents/scripts/tool-version-check.sh:21`
- **EDIT:** `.agents/scripts/venv-health-check-helper.sh:33`
- **EDIT:** `.agents/scripts/worktree-helper.sh:38`
- **EDIT:** `.agents/scripts/worktree-sessions.sh:28`

## Verification

**Syntax checks — all clean:**
```
bash -n tool-version-check.sh    → OK
bash -n venv-health-check-helper.sh → OK
bash -n worktree-helper.sh       → OK
bash -n worktree-sessions.sh     → OK
```

**ShellCheck** — SC1091 info warnings are pre-existing (present before this PR), not introduced by this change.

**worktree-helper.sh --help** — BOLD renders correctly after migration.

**Zero `readonly BOLD=` outside shared-constants.sh** (4 files in scope — other files with `readonly BOLD=` are in separate sibling batches 8a/8b):
```
rg "^readonly BOLD=" .agents/scripts/ --glob '*.sh'
```
(The 4 files in this batch now return no matches; remaining matches are in other batches.)

## Parent Task

For #18735

## Closes

Resolves #19073

---