### PR TITLE
t2053.8a: BOLD readonly normalization batch 1 (Phase 8a)

### DIFF
--- a/.agents/scripts/agent-test-helper.sh
+++ b/.agents/scripts/agent-test-helper.sh
@@ -100,7 +100,7 @@ readonly OPENCODE_HOST="${OPENCODE_HOST:-localhost}"
 readonly OPENCODE_PORT="${OPENCODE_PORT:-4096}"
 readonly OPENCODE_URL="http://${OPENCODE_HOST}:${OPENCODE_PORT}" # NOSONAR - localhost dev server, no TLS needed
 
-readonly BOLD='\033[1m'
+[[ -z "${BOLD+x}" ]] && BOLD='\033[1m'
 readonly DIM='\033[2m'
 
 # Logging: uses shared log_* from shared-constants.sh with TEST prefix

--- a/.agents/scripts/cron-helper.sh
+++ b/.agents/scripts/cron-helper.sh
@@ -39,7 +39,7 @@ readonly OPENCODE_INSECURE="${OPENCODE_INSECURE:-}"
 readonly DEFAULT_MODEL="anthropic/claude-sonnet-4-6"
 
 # shellcheck disable=SC2034  # CYAN reserved for future use
-readonly BOLD='\033[1m'
+[[ -z "${BOLD+x}" ]] && BOLD='\033[1m'
 
 # Logging: uses shared log_* from shared-constants.sh with CRON prefix
 # shellcheck disable=SC2034  # Used by shared-constants.sh log_* functions

--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -14,7 +14,7 @@ readonly SCRIPT_DIR
 readonly STATE_DIR=".agents/loop-state"
 readonly STATE_FILE="${STATE_DIR}/full-loop.local.state"
 readonly DEFAULT_MAX_TASK_ITERATIONS=50 DEFAULT_MAX_PREFLIGHT_ITERATIONS=5 DEFAULT_MAX_PR_ITERATIONS=20
-readonly BOLD='\033[1m'
+[[ -z "${BOLD+x}" ]] && BOLD='\033[1m'
 
 HEADLESS="${FULL_LOOP_HEADLESS:-false}"
 _FG_PID_FILE=""

--- a/.agents/scripts/humanise-update-helper.sh
+++ b/.agents/scripts/humanise-update-helper.sh
@@ -28,7 +28,7 @@ readonly CACHE_FILE="${CACHE_DIR}/humanizer-upstream.md"
 readonly CACHE_VERSION_FILE="${CACHE_DIR}/humanizer-version.txt"
 readonly CACHE_TTL=86400 # 24 hours in seconds
 
-readonly BOLD='\033[1m'
+[[ -z "${BOLD+x}" ]] && BOLD='\033[1m'
 
 # Get local version from subagent frontmatter
 get_local_version() {

--- a/.agents/scripts/matrix-dispatch-helper.sh
+++ b/.agents/scripts/matrix-dispatch-helper.sh
@@ -54,7 +54,7 @@ readonly RUNNER_HELPER="$HOME/.aidevops/agents/scripts/runner-helper.sh"
 readonly OPENCODE_PORT="${OPENCODE_PORT:-4096}"
 readonly OPENCODE_HOST="${OPENCODE_HOST:-127.0.0.1}"
 
-readonly BOLD='\033[1m'
+[[ -z "${BOLD+x}" ]] && BOLD='\033[1m'
 
 # Logging: uses shared log_* from shared-constants.sh with MATRIX prefix
 # shellcheck disable=SC2034  # Used by shared-constants.sh log_* functions


### PR DESCRIPTION
## Summary

Replace `readonly BOLD='\033[1m'` with `[[ -z "${BOLD+x}" ]] && BOLD='\033[1m'` (Pattern B) in 5 production helpers, consistent with framework style guide §27/§70.

## Files changed

- **EDIT:** `.agents/scripts/agent-test-helper.sh:103`
- **EDIT:** `.agents/scripts/cron-helper.sh:42`
- **EDIT:** `.agents/scripts/full-loop-helper.sh:17`
- **EDIT:** `.agents/scripts/humanise-update-helper.sh:31`
- **EDIT:** `.agents/scripts/matrix-dispatch-helper.sh:57`

## Verification

- `shellcheck` clean on all 5 files (only pre-existing SC1091 info notices)
- `bash -n` syntax check passes on all 5 files
- No behavioural change — BOLD still renders correctly; guard fires only when BOLD is unset

## Why Pattern B

`${BOLD+x}` distinguishes unset from set-to-empty (style guide §70), ensuring a parent that sets `BOLD=''` intentionally is not overwritten. Removes the theoretical `readonly` re-declaration abort under `set -Eeuo pipefail` when scripts are double-sourced.

For #18735