### PR TITLE
t2053.7c: final Pattern C migration + zero-violation audit (Phase 7c, closes t2053)

### DIFF
--- a/.agents/reference/shell-style-guide.md
+++ b/.agents/reference/shell-style-guide.md
@@ -120,6 +120,18 @@ Non-canonical colors (e.g., `MAGENTA`, `GRAY`, `BOLD`, `DIM`) → declare locall
 
 Of the 13 unguarded-readonly: 2 production (`sonarcloud-autofix.sh`, `coderabbit-cli.sh`), 11 test harnesses.
 
+### Phase 7c update (2026-04-15, GH#19068)
+
+Migrated 3 test harnesses with unguarded plain color assignments to Pattern C (`TEST_*` prefixed `readonly`):
+
+- `.agents/scripts/test-pr-task-check.sh` — `RED/GREEN/YELLOW/NC` → `TEST_RED/TEST_GREEN/TEST_YELLOW/TEST_RESET`
+- `.agents/scripts/test-task-id-collision.sh` — `RED/GREEN/YELLOW/BLUE/NC` → `TEST_RED/TEST_GREEN/TEST_YELLOW/TEST_BLUE/TEST_RESET`
+- `.agents/scripts/tests/test-encryption-git-roundtrip.sh` — `RED/GREEN/YELLOW/BLUE/NC` → `TEST_RED/TEST_GREEN/TEST_YELLOW/TEST_BLUE/TEST_RESET`
+
+Remaining violations at Phase 7c merge (28 plain + 14 readonly across 42 files) are tracked in open sibling phases:
+Phase 2 (lint gate), Phase 3 (Tier 1/2), Phase 5 (Tier 4), Phase 6 (banned readonly), Phase 7a/7b (test batches 1–2), Phase 8a/b/c (BOLD readonly).
+Zero-violation state will be reached when all sibling phases merge.
+
 ## Phased migration roadmap (t2053) — each phase its own child task/PR (≤5 files, t1422 cap):
 
 1. **Phase 1** — Foundation: this guide + `prompts/build.txt` rule + `architecture.md` cross-ref.

--- a/.agents/scripts/test-pr-task-check.sh
+++ b/.agents/scripts/test-pr-task-check.sh
@@ -15,11 +15,11 @@ PASS=0
 FAIL=0
 TOTAL=0
 
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[0;33m'
-NC='\033[0m'
+# Colors (Pattern C — prefixed names, test harness only)
+readonly TEST_RED=$'\033[0;31m'
+readonly TEST_GREEN=$'\033[0;32m'
+readonly TEST_YELLOW=$'\033[0;33m'
+readonly TEST_RESET=$'\033[0m'
 
 log() {
 	echo -e "$1"
@@ -27,7 +27,7 @@ log() {
 }
 verbose() {
 	if [[ "$VERBOSE" == "--verbose" ]]; then
-		echo -e "  ${YELLOW}$1${NC}"
+		echo -e "  ${TEST_YELLOW}$1${TEST_RESET}"
 	fi
 	return 0
 }
@@ -110,10 +110,10 @@ check_pr_task_id() {
 
 	if [[ "$result" == "$expected" ]]; then
 		PASS=$((PASS + 1))
-		log "${GREEN}PASS${NC} [$result] title='$pr_title' branch='$pr_branch'"
+		log "${TEST_GREEN}PASS${TEST_RESET} [$result] title='$pr_title' branch='$pr_branch'"
 	else
 		FAIL=$((FAIL + 1))
-		log "${RED}FAIL${NC} expected=$expected got=$result title='$pr_title' branch='$pr_branch'"
+		log "${TEST_RED}FAIL${TEST_RESET} expected=$expected got=$result title='$pr_title' branch='$pr_branch'"
 	fi
 	return 0
 }
@@ -128,7 +128,7 @@ log ""
 TODO_FILE="TODO.md"
 
 if [[ ! -f "$TODO_FILE" ]]; then
-	log "${RED}ERROR: TODO.md not found. Run from repo root.${NC}"
+	log "${TEST_RED}ERROR: TODO.md not found. Run from repo root.${TEST_RESET}"
 	exit 1
 fi
 
@@ -325,13 +325,13 @@ check_pr_task_id \
 # --- Summary ---
 log ""
 log "======================================"
-log "Results: ${GREEN}${PASS} passed${NC}, ${RED}${FAIL} failed${NC}, ${TOTAL} total"
+log "Results: ${TEST_GREEN}${PASS} passed${TEST_RESET}, ${TEST_RED}${FAIL} failed${TEST_RESET}, ${TOTAL} total"
 log ""
 
 if [[ "$FAIL" -gt 0 ]]; then
-	log "${RED}SOME TESTS FAILED${NC}"
+	log "${TEST_RED}SOME TESTS FAILED${TEST_RESET}"
 	exit 1
 else
-	log "${GREEN}ALL TESTS PASSED${NC}"
+	log "${TEST_GREEN}ALL TESTS PASSED${TEST_RESET}"
 	exit 0
 fi

--- a/.agents/scripts/test-task-id-collision.sh
+++ b/.agents/scripts/test-task-id-collision.sh
@@ -35,33 +35,33 @@ trap cleanup_test EXIT
 
 mkdir -p "$TEST_DIR"
 
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m'
+# Colors (Pattern C — prefixed names, test harness only)
+readonly TEST_RED=$'\033[0;31m'
+readonly TEST_GREEN=$'\033[0;32m'
+readonly TEST_YELLOW=$'\033[1;33m'
+readonly TEST_BLUE=$'\033[0;34m'
+readonly TEST_RESET=$'\033[0m'
 
 pass() {
-	echo -e "${GREEN}[PASS]${NC} $1"
+	echo -e "${TEST_GREEN}[PASS]${TEST_RESET} $1"
 	PASS=$((PASS + 1))
 	return 0
 }
 
 fail() {
-	echo -e "${RED}[FAIL]${NC} $1"
+	echo -e "${TEST_RED}[FAIL]${TEST_RESET} $1"
 	FAIL=$((FAIL + 1))
 	return 0
 }
 
 skip() {
-	echo -e "${YELLOW}[SKIP]${NC} $1"
+	echo -e "${TEST_YELLOW}[SKIP]${TEST_RESET} $1"
 	SKIP=$((SKIP + 1))
 	return 0
 }
 
 info() {
-	echo -e "${BLUE}[INFO]${NC} $1"
+	echo -e "${TEST_BLUE}[INFO]${TEST_RESET} $1"
 	return 0
 }
 
@@ -1086,9 +1086,9 @@ echo "============================================="
 echo "  Test Summary"
 echo "============================================="
 echo ""
-echo -e "  ${GREEN}PASS${NC}: $PASS"
-echo -e "  ${RED}FAIL${NC}: $FAIL"
-echo -e "  ${YELLOW}SKIP${NC}: $SKIP"
+echo -e "  ${TEST_GREEN}PASS${TEST_RESET}: $PASS"
+echo -e "  ${TEST_RED}FAIL${TEST_RESET}: $FAIL"
+echo -e "  ${TEST_YELLOW}SKIP${TEST_RESET}: $SKIP"
 echo ""
 
 TOTAL=$((PASS + FAIL + SKIP))
@@ -1096,9 +1096,9 @@ echo "  Total: $TOTAL tests"
 echo ""
 
 if [[ "$FAIL" -eq 0 ]]; then
-	echo -e "${GREEN}All tests passed!${NC}"
+	echo -e "${TEST_GREEN}All tests passed!${TEST_RESET}"
 	exit 0
 else
-	echo -e "${RED}$FAIL test(s) failed${NC}"
+	echo -e "${TEST_RED}$FAIL test(s) failed${TEST_RESET}"
 	exit 1
 fi

--- a/.agents/scripts/tests/test-encryption-git-roundtrip.sh
+++ b/.agents/scripts/tests/test-encryption-git-roundtrip.sh
@@ -45,30 +45,30 @@ trap cleanup_test EXIT
 
 mkdir -p "$TEST_DIR"
 
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m'
+# Colors (Pattern C — prefixed names, test harness only)
+readonly TEST_RED=$'\033[0;31m'
+readonly TEST_GREEN=$'\033[0;32m'
+readonly TEST_YELLOW=$'\033[1;33m'
+readonly TEST_BLUE=$'\033[0;34m'
+readonly TEST_RESET=$'\033[0m'
 
 pass() {
 	local msg="${1:-}"
-	echo -e "${GREEN}[PASS]${NC} $msg"
+	echo -e "${TEST_GREEN}[PASS]${TEST_RESET} $msg"
 	PASS=$((PASS + 1))
 	return 0
 }
 
 fail() {
 	local msg="${1:-}"
-	echo -e "${RED}[FAIL]${NC} $msg"
+	echo -e "${TEST_RED}[FAIL]${TEST_RESET} $msg"
 	FAIL=$((FAIL + 1))
 	return 0
 }
 
 skip() {
 	local msg="${1:-}"
-	echo -e "${YELLOW}[SKIP]${NC} $msg"
+	echo -e "${TEST_YELLOW}[SKIP]${TEST_RESET} $msg"
 	SKIP=$((SKIP + 1))
 	return 0
 }
@@ -76,7 +76,7 @@ skip() {
 info() {
 	local msg="${1:-}"
 	if [[ "$VERBOSE" == "--verbose" ]]; then
-		echo -e "${BLUE}[INFO]${NC} $msg"
+		echo -e "${TEST_BLUE}[INFO]${TEST_RESET} $msg"
 	fi
 	return 0
 }
@@ -1565,9 +1565,9 @@ echo "============================================="
 echo "  Test Summary"
 echo "============================================="
 echo ""
-echo -e "  ${GREEN}PASS${NC}: $PASS"
-echo -e "  ${RED}FAIL${NC}: $FAIL"
-echo -e "  ${YELLOW}SKIP${NC}: $SKIP"
+echo -e "  ${TEST_GREEN}PASS${TEST_RESET}: $PASS"
+echo -e "  ${TEST_RED}FAIL${TEST_RESET}: $FAIL"
+echo -e "  ${TEST_YELLOW}SKIP${TEST_RESET}: $SKIP"
 echo ""
 
 TOTAL=$((PASS + FAIL + SKIP))
@@ -1575,9 +1575,9 @@ echo "  Total: $TOTAL tests"
 echo ""
 
 if [[ "$FAIL" -eq 0 ]]; then
-	echo -e "${GREEN}All tests passed!${NC}"
+	echo -e "${TEST_GREEN}All tests passed!${TEST_RESET}"
 	exit 0
 else
-	echo -e "${RED}$FAIL test(s) failed${NC}"
+	echo -e "${TEST_RED}$FAIL test(s) failed${TEST_RESET}"
 	exit 1
 fi


### PR DESCRIPTION
## Summary

Phase 7c of the t2053 shell init normalization roadmap. Migrates 3 test harnesses with unguarded plain color assignments to Pattern C (`TEST_*` prefixed `readonly`), completing the test harness batch migrations.

## Files changed

- **EDIT:** `.agents/scripts/test-pr-task-check.sh` — `RED/GREEN/YELLOW/NC` → `TEST_RED/TEST_GREEN/TEST_YELLOW/TEST_RESET`
- **EDIT:** `.agents/scripts/test-task-id-collision.sh` — `RED/GREEN/YELLOW/BLUE/NC` → `TEST_RED/TEST_GREEN/TEST_YELLOW/TEST_BLUE/TEST_RESET`
- **EDIT:** `.agents/scripts/tests/test-encryption-git-roundtrip.sh` — `RED/GREEN/YELLOW/BLUE/NC` → `TEST_RED/TEST_GREEN/TEST_YELLOW/TEST_BLUE/TEST_RESET`
- **EDIT:** `.agents/reference/shell-style-guide.md` — Phase 7c audit update section added (lines ~142–153)

## Verification

All 3 files pass `shellcheck` with zero violations:

```
shellcheck .agents/scripts/test-pr-task-check.sh   → exit 0
shellcheck .agents/scripts/test-task-id-collision.sh → exit 0
shellcheck .agents/scripts/tests/test-encryption-git-roundtrip.sh → exit 0
```

Bash syntax check (`bash -n`) clean on all 3.

## Audit output

`shell-init-pattern-check.sh` (Phase 2, GH#19061) is not yet merged, so the following is a manual equivalent scan:

```
$ git ls-files '*.sh' | xargs grep -lE "^(readonly )?(RED|GREEN|YELLOW|BLUE|PURPLE|CYAN|WHITE|NC)='" | grep -v shared-constants.sh | wc -l
42
```

**42 files remaining** with violations. These are all tracked in open sibling phases:

| Phase | Issue | Status |
|-------|-------|--------|
| Phase 2 — lint gate | #19061 | open |
| Phase 3 — Tier 1/2 | #19062 | open |
| Phase 5 — Tier 4 | #19064 | open |
| Phase 6 — banned readonly + production | #19065 | open |
| Phase 7a — test batch 1 | #19066 | open |
| Phase 7b — test batch 2 | #19067 | open |
| Phase 8a/b/c — BOLD readonly | #19071–#19073 | open |

The 3 files targeted by this PR are **no longer** in the violations list (confirmed via grep — no matches for `RED=`, `GREEN=` etc. in those files).

**Note on Acceptance Criteria #4 (zero violations):** The issue was written when Phase 7c was the designated final phase. Phase 8 was subsequently added (see correction comment on #19068). Zero-violation state will be reached when all sibling phases merge.

For #18735
Resolves #19068