### PR TITLE
t2053.8b: BOLD readonly normalization batch 2 (Phase 8b)

### DIFF
--- a/.agents/scripts/runner-helper.sh
+++ b/.agents/scripts/runner-helper.sh
@@ -53,7 +53,7 @@ readonly OPENCODE_PORT="${OPENCODE_PORT:-4096}"
 readonly OPENCODE_HOST="${OPENCODE_HOST:-127.0.0.1}"
 readonly DEFAULT_MODEL="anthropic/claude-sonnet-4-6"
 
-readonly BOLD='\033[1m'
+[[ -z "${BOLD+x}" ]] && BOLD='\033[1m'
 
 # Logging: uses shared log_* from shared-constants.sh with RUNNER prefix
 # shellcheck disable=SC2034  # Used by shared-constants.sh log_* functions

--- a/.agents/scripts/session-checkpoint-helper.sh
+++ b/.agents/scripts/session-checkpoint-helper.sh
@@ -41,7 +41,7 @@ source "${SCRIPT_DIR}/shared-constants.sh"
 readonly CHECKPOINT_DIR="${HOME}/.aidevops/.agent-workspace/tmp"
 readonly CHECKPOINT_FILE="${CHECKPOINT_DIR}/session-checkpoint.md"
 
-readonly BOLD='\033[1m'
+[[ -z "${BOLD+x}" ]] && BOLD='\033[1m'
 
 # Credential patterns to redact from checkpoint content.
 # Focused on secrets (API keys, tokens, passwords, connection strings).

--- a/.agents/scripts/session-review-helper.sh
+++ b/.agents/scripts/session-review-helper.sh
@@ -24,7 +24,7 @@ source "${SCRIPT_DIR}/shared-constants.sh"
 
 set -euo pipefail
 
-readonly BOLD='\033[1m'
+[[ -z "${BOLD+x}" ]] && BOLD='\033[1m'
 
 # =============================================================================
 # Security Summary Data Sources (t1428.5)

--- a/.agents/scripts/session-time-helper.sh
+++ b/.agents/scripts/session-time-helper.sh
@@ -24,7 +24,7 @@ source "${SCRIPT_DIR}/shared-constants.sh"
 
 set -euo pipefail
 
-readonly BOLD='\033[1m'
+[[ -z "${BOLD+x}" ]] && BOLD='\033[1m'
 readonly DIM='\033[2m'
 
 # Defaults

--- a/.agents/scripts/stash-audit-helper.sh
+++ b/.agents/scripts/stash-audit-helper.sh
@@ -36,7 +36,7 @@ source "${SCRIPT_DIR}/shared-constants.sh"
 
 set -euo pipefail
 
-readonly BOLD='\033[1m'
+[[ -z "${BOLD+x}" ]] && BOLD='\033[1m'
 readonly RESET="$NC"            # Alias for NC from shared-constants.sh
 readonly STASH_AGE_THRESHOLD=30 # days
 


### PR DESCRIPTION
## Summary

Migrate 5 production helpers from `readonly BOLD='\033[1m'` to the guarded Pattern B form for framework-wide consistency.

**Files changed (one-line each):**
- `.agents/scripts/runner-helper.sh:56`
- `.agents/scripts/session-checkpoint-helper.sh:44`
- `.agents/scripts/session-review-helper.sh:27`
- `.agents/scripts/session-time-helper.sh:27`
- `.agents/scripts/stash-audit-helper.sh:39`

**Change per file:**
```diff
- readonly BOLD='\033[1m'
+ [[ -z "${BOLD+x}" ]] && BOLD='\033[1m'
```

## Verification

- shellcheck clean on all 5 files (pre-existing SC1091 info notices unrelated to this change)
- 5 files changed, 5 insertions(+), 5 deletions(-) — exactly one-line change per file
- No behavioural change

For #18735