### PR TITLE
t2053.3: migrate Tier 1/2 setup-chain helpers (Phase 3)

### DIFF
--- a/.agents/scripts/deploy-agents-on-merge.sh
+++ b/.agents/scripts/deploy-agents-on-merge.sh
@@ -26,12 +26,10 @@ set -euo pipefail
 #   1 - Deploy failed
 #   2 - Nothing to deploy (no changes detected)
 
-# Colors
-GREEN='\033[0;32m'
-BLUE='\033[0;34m'
-YELLOW='\033[1;33m'
-RED='\033[0;31m'
-NC='\033[0m'
+# Colors — sourced from shared-constants.sh (Pattern A, t2053.3)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=shared-constants.sh
+[[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
 
 QUIET=false
 

--- a/.agents/scripts/doctor-helper.sh
+++ b/.agents/scripts/doctor-helper.sh
@@ -15,15 +15,13 @@
 
 set -euo pipefail
 
-# Colors
-GREEN='\033[0;32m'
-BLUE='\033[0;34m'
-YELLOW='\033[1;33m'
-RED='\033[0;31m'
-CYAN='\033[0;36m'
-BOLD='\033[1m'
-DIM='\033[2m'
-NC='\033[0m'
+# Colors — sourced from shared-constants.sh (Pattern A, t2053.3)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=shared-constants.sh
+[[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
+# BOLD and DIM are not in shared-constants.sh — Pattern B fallback
+[[ -z "${BOLD+x}" ]] && BOLD='\033[1m'
+[[ -z "${DIM+x}" ]] && DIM='\033[2m'
 
 # Globals
 CONFLICTS_FOUND=0

--- a/.agents/scripts/install-hooks-helper.sh
+++ b/.agents/scripts/install-hooks-helper.sh
@@ -18,12 +18,10 @@
 #
 set -euo pipefail
 
-# Colors
-GREEN='\033[0;32m'
-BLUE='\033[0;34m'
-YELLOW='\033[1;33m'
-RED='\033[0;31m'
-NC='\033[0m'
+# Colors — sourced from shared-constants.sh (Pattern A, t2053.3)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=shared-constants.sh
+[[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
 
 HOOKS_DIR="$HOME/.aidevops/hooks"
 HOOK_SCRIPT="$HOOKS_DIR/git_safety_guard.py"

--- a/.agents/scripts/install-hooks.sh
+++ b/.agents/scripts/install-hooks.sh
@@ -22,12 +22,9 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 HOOK_SOURCE="${SCRIPT_DIR}/../hooks/git_safety_guard.py"
 
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-NC='\033[0m'
+# Colors — sourced from shared-constants.sh (Pattern A, t2053.3)
+# shellcheck source=shared-constants.sh
+[[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
 
 # Test counters — set by run_test(), incremented by run_case()
 _TEST_PASS=0

--- a/.agents/scripts/pre-edit-check.sh
+++ b/.agents/scripts/pre-edit-check.sh
@@ -45,6 +45,13 @@
 
 set -euo pipefail
 
+# Colors — sourced from shared-constants.sh (Pattern A, t2053.3)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=shared-constants.sh
+[[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
+# BOLD is not in shared-constants.sh — Pattern B fallback
+[[ -z "${BOLD+x}" ]] && BOLD='\033[1m'
+
 # =============================================================================
 # Fast-path for headless workers with pre-created worktrees
 # =============================================================================
@@ -392,12 +399,6 @@ if [[ -n "$CHECK_COMMAND" ]]; then
 		exit 0
 	fi
 fi
-
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m'
-BOLD='\033[1m'
 
 # =============================================================================
 # Operation Verification (t1364.3)


### PR DESCRIPTION
## Summary

Phase 3 of the t2053 shell helper init pattern migration roadmap. Migrates 5 setup-chain-adjacent helpers from unguarded plain color assignments to canonical Pattern A (source `shared-constants.sh`) with Pattern B fallbacks for non-canonical colors (`BOLD`, `DIM`). Net -8 lines. Exactly at the t1422 five-file cap.

## Files

1. **`.agents/scripts/install-hooks.sh`** — reuse existing `SCRIPT_DIR`, source `shared-constants.sh`.
2. **`.agents/scripts/install-hooks-helper.sh`** — add `SCRIPT_DIR` + source block.
3. **`.agents/scripts/doctor-helper.sh`** — add `SCRIPT_DIR` + source; Pattern B fallback for non-canonical `BOLD` and `DIM`.
4. **`.agents/scripts/pre-edit-check.sh`** — add Pattern A source block at top (after `set -euo pipefail`); remove the late top-level color block at lines 396-400 which would otherwise conflict with readonly declarations from `shared-constants.sh`. Pattern B fallback for `BOLD`. The existing late source at line 750 is left in place and remains idempotent via the `_SHARED_CONSTANTS_LOADED` include guard.
5. **`.agents/scripts/deploy-agents-on-merge.sh`** — add `SCRIPT_DIR` + source block.

## Why

These 5 helpers live on or adjacent to the `setup.sh` sourcing chain:

- `install-hooks.sh` / `install-hooks-helper.sh` run as part of `setup.sh`
- `pre-edit-check.sh` runs on every edit in the framework
- `deploy-agents-on-merge.sh` runs on merge (lifecycle-critical path)
- `doctor-helper.sh` is invoked by `aidevops doctor`

Each was a latent repeat of the GH#18702 four-day auto-update outage waiting for a future sourcing order change to trigger it. Fixing them in one batch eliminates the highest-severity risk in the t2053 roadmap.

## Verification

- `bash -n` syntax OK on all 5 files
- `shellcheck --severity=warning` clean on all 5 files (SC1091 `info` on the dynamic source path is expected — matches Phase 4 / Phase 5 precedent in PRs #19090 and #19176)
- Standalone smoke tests confirm colors still render correctly:
  - `install-hooks.sh --help`
  - `install-hooks-helper.sh status` (output includes `[0;32m[OK][0m` green markers)
  - `doctor-helper.sh --quiet` (exit 0)
  - `deploy-agents-on-merge.sh --help`
  - `pre-edit-check.sh --loop-mode --file <path>` (output includes `[0;32mOK[0m` green + `[1m...[0m` bold markers)

## Acceptance

1. ✅ All 5 files use Pattern A for canonical colors, Pattern B for non-canonical (`BOLD`, `DIM`).
2. ✅ `shellcheck --severity=warning` clean on all 5 files.
3. ⚠️ `setup.sh --non-interactive` was not run end-to-end in this headless worker to avoid side effects on the scratch environment; colors-only changes are low risk and each script's entry point was smoke-tested standalone.
4. ⚠️ Phase 2 lint gate (`shell-init-pattern-check.sh`) has not landed yet, so the `--scan-files` verification is deferred to a later phase.
5. ✅ No behavioural change — colors still render correctly when invoked standalone.

For #18735

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.42 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-opus-4-6 spent 6m and 16,085 tokens on this as a headless worker.
