### PR TITLE
t2053.7b: test harness Pattern C batch 2 (Phase 7b)

### DIFF
--- a/.agents/scripts/tests/test-secret-helper.sh
+++ b/.agents/scripts/tests/test-secret-helper.sh
@@ -7,8 +7,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 HELPER="${SCRIPT_DIR}/../secret-helper.sh"
 
-readonly RED='\033[0;31m'
-readonly GREEN='\033[0;32m'
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
 readonly RESET='\033[0m'
 
 TESTS_RUN=0
@@ -26,10 +26,10 @@ print_result() {
 	TESTS_RUN=$((TESTS_RUN + 1))
 
 	if [[ "$result" -eq 0 ]]; then
-		echo -e "${GREEN}PASS${RESET} $test_name"
+		echo -e "${TEST_GREEN}PASS${RESET} $test_name"
 		TESTS_PASSED=$((TESTS_PASSED + 1))
 	else
-		echo -e "${RED}FAIL${RESET} $test_name"
+		echo -e "${TEST_RED}FAIL${RESET} $test_name"
 		if [[ -n "$message" ]]; then
 			echo "       $message"
 		fi

--- a/.agents/scripts/tests/test-simplex-integration.sh
+++ b/.agents/scripts/tests/test-simplex-integration.sh
@@ -20,10 +20,10 @@ HELPER="${SCRIPT_DIR}/../simplex-helper.sh"
 readonly HELPER
 
 # Colors
-readonly RED='\033[0;31m'
-readonly GREEN='\033[0;32m'
-readonly YELLOW='\033[1;33m'
-readonly CYAN='\033[0;36m'
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_YELLOW='\033[1;33m'
+readonly TEST_CYAN='\033[0;36m'
 readonly RESET='\033[0m'
 
 # Test counters
@@ -49,13 +49,13 @@ print_result() {
 	TESTS_RUN=$((TESTS_RUN + 1))
 
 	if [[ "$result" -eq 0 ]]; then
-		echo -e "${GREEN}PASS${RESET} $test_name"
+		echo -e "${TEST_GREEN}PASS${RESET} $test_name"
 		TESTS_PASSED=$((TESTS_PASSED + 1))
 	elif [[ "$result" -eq 2 ]]; then
-		echo -e "${YELLOW}SKIP${RESET} $test_name"
+		echo -e "${TEST_YELLOW}SKIP${RESET} $test_name"
 		TESTS_SKIPPED=$((TESTS_SKIPPED + 1))
 	else
-		echo -e "${RED}FAIL${RESET} $test_name"
+		echo -e "${TEST_RED}FAIL${RESET} $test_name"
 		if [[ -n "$message" ]]; then
 			echo "       $message"
 		fi
@@ -83,7 +83,7 @@ assert_contains() {
 
 section_file_existence() {
 	echo ""
-	echo -e "${CYAN}=== File Existence Tests ===${RESET}"
+	echo -e "${TEST_CYAN}=== File Existence Tests ===${RESET}"
 
 	# simplex.md subagent doc
 	if [[ -f "${AGENTS_DIR}/services/communications/simplex.md" ]]; then
@@ -153,7 +153,7 @@ section_file_existence() {
 
 section_helper_script() {
 	echo ""
-	echo -e "${CYAN}=== simplex-helper.sh Tests ===${RESET}"
+	echo -e "${TEST_CYAN}=== simplex-helper.sh Tests ===${RESET}"
 
 	if [[ ! -f "$HELPER" ]]; then
 		print_result "helper script available" 1 "simplex-helper.sh not found"
@@ -223,7 +223,7 @@ section_helper_script() {
 
 section_subagent_index() {
 	echo ""
-	echo -e "${CYAN}=== Subagent Index Tests ===${RESET}"
+	echo -e "${TEST_CYAN}=== Subagent Index Tests ===${RESET}"
 
 	local index_file="${AGENTS_DIR}/subagent-index.toon"
 
@@ -262,7 +262,7 @@ section_subagent_index() {
 
 section_agents_md() {
 	echo ""
-	echo -e "${CYAN}=== AGENTS.md Tests ===${RESET}"
+	echo -e "${TEST_CYAN}=== AGENTS.md Tests ===${RESET}"
 
 	local agents_file="${AGENTS_DIR}/AGENTS.md"
 
@@ -301,7 +301,7 @@ section_agents_md() {
 
 section_markdown_structure() {
 	echo ""
-	echo -e "${CYAN}=== Markdown Structure Tests ===${RESET}"
+	echo -e "${TEST_CYAN}=== Markdown Structure Tests ===${RESET}"
 
 	local simplex_md="${AGENTS_DIR}/services/communications/simplex.md"
 
@@ -374,7 +374,7 @@ section_markdown_structure() {
 
 section_bot_framework() {
 	echo ""
-	echo -e "${CYAN}=== Bot Framework Scaffold Tests ===${RESET}"
+	echo -e "${TEST_CYAN}=== Bot Framework Scaffold Tests ===${RESET}"
 
 	local bot_dir="${AGENTS_DIR}/scripts/simplex-bot"
 
@@ -467,7 +467,7 @@ section_bot_framework() {
 
 section_shellcheck() {
 	echo ""
-	echo -e "${CYAN}=== ShellCheck Tests ===${RESET}"
+	echo -e "${TEST_CYAN}=== ShellCheck Tests ===${RESET}"
 
 	if ! command -v shellcheck &>/dev/null; then
 		print_result "shellcheck available" 2 "shellcheck not installed"
@@ -526,7 +526,7 @@ main() {
 
 	echo ""
 	echo "============================================="
-	echo -e "Results: ${GREEN}${TESTS_PASSED} passed${RESET}, ${RED}${TESTS_FAILED} failed${RESET}, ${YELLOW}${TESTS_SKIPPED} skipped${RESET} (${TESTS_RUN} total)"
+	echo -e "Results: ${TEST_GREEN}${TESTS_PASSED} passed${RESET}, ${TEST_RED}${TESTS_FAILED} failed${RESET}, ${TEST_YELLOW}${TESTS_SKIPPED} skipped${RESET} (${TESTS_RUN} total)"
 	echo "============================================="
 
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-stash-audit.sh
+++ b/.agents/scripts/tests/test-stash-audit.sh
@@ -18,9 +18,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 STASH_HELPER="${SCRIPT_DIR}/../stash-audit-helper.sh"
 
 # Colors
-readonly RED='\033[0;31m'
-readonly GREEN='\033[0;32m'
-readonly YELLOW='\033[1;33m'
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_YELLOW='\033[1;33m'
 readonly RESET='\033[0m'
 
 # Test counters
@@ -45,10 +45,10 @@ print_result() {
     TESTS_RUN=$((TESTS_RUN + 1))
     
     if [[ "$result" -eq 0 ]]; then
-        echo -e "${GREEN}✓${RESET} $test_name"
+        echo -e "${TEST_GREEN}✓${RESET} $test_name"
         TESTS_PASSED=$((TESTS_PASSED + 1))
     else
-        echo -e "${RED}✗${RESET} $test_name"
+        echo -e "${TEST_RED}✗${RESET} $test_name"
         if [[ -n "$message" ]]; then
             echo "  $message"
         fi
@@ -323,7 +323,7 @@ main() {
     
     # Check if stash helper exists
     if [[ ! -f "$STASH_HELPER" ]]; then
-        echo -e "${RED}Error: stash-audit-helper.sh not found at $STASH_HELPER${RESET}"
+        echo -e "${TEST_RED}Error: stash-audit-helper.sh not found at $STASH_HELPER${RESET}"
         return 1
     fi
     
@@ -353,9 +353,9 @@ main() {
     echo ""
     echo "========================================="
     echo "Tests run:    $TESTS_RUN"
-    echo -e "Tests passed: ${GREEN}$TESTS_PASSED${RESET}"
+    echo -e "Tests passed: ${TEST_GREEN}$TESTS_PASSED${RESET}"
     if [[ "$TESTS_FAILED" -gt 0 ]]; then
-        echo -e "Tests failed: ${RED}$TESTS_FAILED${RESET}"
+        echo -e "Tests failed: ${TEST_RED}$TESTS_FAILED${RESET}"
     else
         echo "Tests failed: $TESTS_FAILED"
     fi

--- a/.agents/scripts/tests/test-task-decompose.sh
+++ b/.agents/scripts/tests/test-task-decompose.sh
@@ -26,10 +26,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 HELPER="${SCRIPT_DIR}/../task-decompose-helper.sh"
 
 # Colors
-readonly RED='\033[0;31m'
-readonly GREEN='\033[0;32m'
-readonly YELLOW='\033[1;33m'
-readonly CYAN='\033[0;36m'
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_YELLOW='\033[1;33m'
+readonly TEST_CYAN='\033[0;36m'
 readonly RESET='\033[0m'
 
 # Test counters
@@ -62,13 +62,13 @@ print_result() {
 	TESTS_RUN=$((TESTS_RUN + 1))
 
 	if [[ "$result" -eq 0 ]]; then
-		echo -e "${GREEN}PASS${RESET} $test_name"
+		echo -e "${TEST_GREEN}PASS${RESET} $test_name"
 		TESTS_PASSED=$((TESTS_PASSED + 1))
 	elif [[ "$result" -eq 2 ]]; then
-		echo -e "${YELLOW}SKIP${RESET} $test_name"
+		echo -e "${TEST_YELLOW}SKIP${RESET} $test_name"
 		TESTS_SKIPPED=$((TESTS_SKIPPED + 1))
 	else
-		echo -e "${RED}FAIL${RESET} $test_name"
+		echo -e "${TEST_RED}FAIL${RESET} $test_name"
 		if [[ -n "$message" ]]; then
 			echo "       $message"
 		fi
@@ -454,9 +454,9 @@ test_classify_llm_real_tasks() {
 		kind=$(echo "$output" | sed -n 's/.*"kind"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
 
 		if [[ "$kind" == "$expected" ]]; then
-			echo -e "  ${GREEN}OK${RESET} '${desc:0:60}...' -> $kind"
+			echo -e "  ${TEST_GREEN}OK${RESET} '${desc:0:60}...' -> $kind"
 		else
-			echo -e "  ${RED}MISMATCH${RESET} '${desc:0:60}...' -> $kind (expected $expected)"
+			echo -e "  ${TEST_RED}MISMATCH${RESET} '${desc:0:60}...' -> $kind (expected $expected)"
 			all_pass=false
 		fi
 
@@ -605,7 +605,7 @@ test_decompose_llm_quality() {
 
 	# exit_code 2 = API unavailable, heuristic used
 	if [[ "$exit_code" -eq 2 ]]; then
-		echo -e "  ${YELLOW}NOTE${RESET}: API unavailable, testing heuristic fallback quality"
+		echo -e "  ${TEST_YELLOW}NOTE${RESET}: API unavailable, testing heuristic fallback quality"
 	fi
 
 	if command -v jq &>/dev/null; then
@@ -643,7 +643,7 @@ test_decompose_llm_quality() {
 			print_result "decompose LLM: produces quality subtasks ($count items, $source)" 0
 			# Show the subtasks for inspection
 			echo "$output" | jq -r '.subtasks[].description' 2>/dev/null | while read -r line; do
-				echo -e "  ${CYAN}>${RESET} $line"
+				echo -e "  ${TEST_CYAN}>${RESET} $line"
 			done
 		else
 			print_result "decompose LLM: produces quality subtasks" 1 "count_ok=$count_ok quality_ok=$quality_ok output=$output"
@@ -667,7 +667,7 @@ test_decompose_llm_dependencies() {
 	# Heuristic fallback doesn't produce dependency edges — that's expected
 	if [[ "$exit_code" -eq 2 ]]; then
 		print_result "decompose LLM: dependency edges (heuristic fallback, no deps expected)" 0
-		echo -e "  ${YELLOW}NOTE${RESET}: API unavailable, heuristic doesn't produce dependency edges"
+		echo -e "  ${TEST_YELLOW}NOTE${RESET}: API unavailable, heuristic doesn't produce dependency edges"
 		return 0
 	fi
 
@@ -1113,20 +1113,20 @@ main() {
 	echo ""
 
 	if [[ "$WITH_LLM" == true ]]; then
-		echo -e "${CYAN}Mode: Full (with LLM tests)${RESET}"
+		echo -e "${TEST_CYAN}Mode: Full (with LLM tests)${RESET}"
 	else
-		echo -e "${CYAN}Mode: Heuristic only (use --with-llm for LLM tests)${RESET}"
+		echo -e "${TEST_CYAN}Mode: Heuristic only (use --with-llm for LLM tests)${RESET}"
 	fi
 	echo ""
 
 	# Check prerequisites
 	if [[ ! -x "$HELPER" ]]; then
-		echo -e "${RED}ERROR: Helper script not found or not executable: $HELPER${RESET}"
+		echo -e "${TEST_RED}ERROR: Helper script not found or not executable: $HELPER${RESET}"
 		return 1
 	fi
 
 	if ! command -v jq &>/dev/null; then
-		echo -e "${YELLOW}WARNING: jq not found, some tests will be skipped${RESET}"
+		echo -e "${TEST_YELLOW}WARNING: jq not found, some tests will be skipped${RESET}"
 	fi
 
 	setup
@@ -1140,7 +1140,7 @@ main() {
 
 	# Summary
 	echo "============================================="
-	echo -e " Results: ${GREEN}${TESTS_PASSED} passed${RESET}, ${RED}${TESTS_FAILED} failed${RESET}, ${YELLOW}${TESTS_SKIPPED} skipped${RESET} / ${TESTS_RUN} total"
+	echo -e " Results: ${TEST_GREEN}${TESTS_PASSED} passed${RESET}, ${TEST_RED}${TESTS_FAILED} failed${RESET}, ${TEST_YELLOW}${TESTS_SKIPPED} skipped${RESET} / ${TESTS_RUN} total"
 	echo "============================================="
 
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-tier3-simplified.sh
+++ b/.agents/scripts/tests/test-tier3-simplified.sh
@@ -21,9 +21,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 SCRIPTS_DIR="${SCRIPT_DIR}/.."
 
 # Colors
-readonly RED='\033[0;31m'
-readonly GREEN='\033[0;32m'
-readonly NC='\033[0m'
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
 
 # Test counters
 TESTS_RUN=0
@@ -45,10 +45,10 @@ print_result() {
 	TESTS_RUN=$((TESTS_RUN + 1))
 
 	if [[ "$result" -eq 0 ]]; then
-		echo -e "${GREEN}PASS${NC} $test_name"
+		echo -e "${TEST_GREEN}PASS${TEST_RESET} $test_name"
 		TESTS_PASSED=$((TESTS_PASSED + 1))
 	else
-		echo -e "${RED}FAIL${NC} $test_name"
+		echo -e "${TEST_RED}FAIL${TEST_RESET} $test_name"
 		[[ -n "$message" ]] && echo "       $message"
 		TESTS_FAILED=$((TESTS_FAILED + 1))
 	fi
@@ -690,10 +690,10 @@ main() {
 	echo "================================================================"
 
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then
-		echo -e "${RED}FAILED${NC}"
+		echo -e "${TEST_RED}FAILED${TEST_RESET}"
 		return 1
 	else
-		echo -e "${GREEN}ALL TESTS PASSED${NC}"
+		echo -e "${TEST_GREEN}ALL TESTS PASSED${TEST_RESET}"
 		return 0
 	fi
 }


### PR DESCRIPTION
## Summary

Rename `readonly` color variables in 5 test harnesses from bare names to `TEST_*` Pattern C prefix (t2053 Phase 7b of 7, batch 2 of 3).

### Files changed

- **EDIT:** `.agents/scripts/tests/test-secret-helper.sh` — `RED/GREEN` → `TEST_RED/TEST_GREEN`
- **EDIT:** `.agents/scripts/tests/test-simplex-integration.sh` — `RED/GREEN/YELLOW/CYAN` → `TEST_RED/TEST_GREEN/TEST_YELLOW/TEST_CYAN`
- **EDIT:** `.agents/scripts/tests/test-stash-audit.sh` — `RED/GREEN/YELLOW` → `TEST_RED/TEST_GREEN/TEST_YELLOW`
- **EDIT:** `.agents/scripts/tests/test-task-decompose.sh` — `RED/GREEN/YELLOW/CYAN` → `TEST_RED/TEST_GREEN/TEST_YELLOW/TEST_CYAN`
- **EDIT:** `.agents/scripts/tests/test-tier3-simplified.sh` — `RED/GREEN/NC` → `TEST_RED/TEST_GREEN/TEST_RESET` (NC → TEST_RESET per style-guide §76-81)

### Verification

- All 5 files: `shellcheck` clean (zero violations)
- `test-secret-helper.sh`: 3/3 passed
- `test-task-decompose.sh`: 35/40 passed, 5 skipped (pre-existing API skips)
- `test-simplex-integration.sh`: 53/59 passed (6 pre-existing doc/infra failures)
- `test-tier3-simplified.sh`: 65/83 passed (18 pre-existing line-count regressions)
- `test-stash-audit.sh`: passes syntax check (SSH key passphrase blocks git ops in environment)

For #18735

---
[aidevops.sh](https://aidevops.sh) worker session for issue #19067