### PR TITLE
fix(deploy): auto-restart pulse after agent deployment

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -391,6 +391,11 @@ Git is the audit trail. Procedures: AGENTS.md "Git Workflow" section.
 - `worktree-helper.sh remove` and `wt clean` move the worktree directory to system trash before deregistering from git. Accidental removal (e.g. by cleanup routines) is recoverable — restore from trash and `git worktree add` on the same branch.
 - If trash is unavailable, falls back to permanent `git worktree remove`.
 
+**Pulse restart after deploying pulse script fixes (MANDATORY):**
+- Bash processes load `source` files at startup only. Deploying updated `.sh` files to `~/.aidevops/agents/scripts/` does NOT affect a running pulse — it keeps using the old code in memory. This caused a multi-hour outage where v3.8.41 fixes were deployed but the pulse kept blocking issues with stale logic.
+- After deploying fixes to any sourced pulse script (`pulse-*.sh`, `dispatch-dedup-*.sh`, `headless-runtime-*.sh`, `worker-lifecycle-common.sh`, `pulse-nmr-approval.sh`), restart the pulse: `kill $(grep -oE '[0-9]+' ~/.aidevops/logs/pulse.pid | head -1) 2>/dev/null; sleep 3; nohup ~/.aidevops/agents/scripts/pulse-wrapper.sh >> ~/.aidevops/logs/pulse-wrapper.log 2>&1 &`
+- `setup.sh` and `aidevops update` handle this automatically via `_restart_pulse_if_running`. Interactive sessions deploying hotfixes via `cp` must restart manually.
+
 # Quality Standards
 - ShellCheck zero violations. `local var="$1"` pattern. Explicit returns.
 - Shell helpers MUST source `shared-constants.sh` OR guard color/constant fallbacks with `[[ -z "${VAR+x}" ]] && VAR='…'`. Unguarded top-level assignments of shared variable names (`RED`, `GREEN`, `YELLOW`, `BLUE`, `PURPLE`, `CYAN`, `WHITE`, `NC`) are forbidden; `readonly` on those names outside `shared-constants.sh` is forbidden. See `reference/shell-style-guide.md` (root cause: GH#18702/PR #18728).

--- a/setup-modules/agent-deploy.sh
+++ b/setup-modules/agent-deploy.sh
@@ -8,6 +8,62 @@
 # Shell safety baseline
 set -Eeuo pipefail
 IFS=$'\n\t'
+
+#######################################
+# Restart the pulse process if it's running, so it picks up newly deployed
+# scripts. Bash processes source files at startup only — file changes on
+# disk don't affect a running process. The pulse is long-lived (hours/days)
+# so it would run stale code indefinitely without a restart.
+#
+# The pulse auto-restarts via launchd/cron, so killing it is safe. If no
+# auto-restart mechanism exists, we start it manually.
+#######################################
+_restart_pulse_if_running() {
+	local pid_file="${HOME}/.aidevops/logs/pulse.pid"
+	[[ -f "$pid_file" ]] || return 0
+
+	local pulse_pid=""
+	pulse_pid=$(grep -oE '[0-9]+' "$pid_file" | head -1) || return 0
+	[[ -n "$pulse_pid" ]] || return 0
+
+	# Check if the process is actually alive
+	if ! kill -0 "$pulse_pid" 2>/dev/null; then
+		return 0
+	fi
+
+	print_info "Restarting pulse (PID $pulse_pid) to load updated scripts..."
+	kill "$pulse_pid" 2>/dev/null || true
+
+	# Wait for it to die
+	local wait_count=0
+	while kill -0 "$pulse_pid" 2>/dev/null && [[ "$wait_count" -lt 10 ]]; do
+		sleep 1
+		wait_count=$((wait_count + 1))
+	done
+
+	# Give launchd/cron a moment to restart it
+	sleep 5
+
+	# Check if it auto-restarted
+	if [[ -f "$pid_file" ]]; then
+		local new_pid=""
+		new_pid=$(grep -oE '[0-9]+' "$pid_file" | head -1) || new_pid=""
+		if [[ -n "$new_pid" ]] && kill -0 "$new_pid" 2>/dev/null; then
+			print_success "Pulse restarted (new PID $new_pid)"
+			return 0
+		fi
+	fi
+
+	# No auto-restart — start it manually
+	local pulse_script="${HOME}/.aidevops/agents/scripts/pulse-wrapper.sh"
+	if [[ -x "$pulse_script" ]]; then
+		nohup "$pulse_script" >>"${HOME}/.aidevops/logs/pulse-wrapper.log" 2>&1 &
+		print_success "Pulse started manually (PID $!)"
+	else
+		print_warning "Pulse not restarted — $pulse_script not found"
+	fi
+	return 0
+}
 # shellcheck disable=SC2154  # rc is assigned by $? in the trap string
 trap 'rc=$?; echo "[ERROR] ${BASH_SOURCE[0]}:${LINENO} exit $rc" >&2' ERR
 shopt -s inherit_errexit 2>/dev/null || true
@@ -513,6 +569,14 @@ deploy_aidevops_agents() {
 
 	print_success "Deployed agents to $target_dir"
 	_deploy_agents_post_copy "$target_dir" "$repo_dir" "$source_dir" "$plugins_file"
+
+	# Restart pulse if running — bash processes load source files at startup
+	# and don't re-read them when files change on disk. Without a restart,
+	# fixes to pulse-*.sh, dispatch-dedup-*.sh, headless-runtime-*.sh, and
+	# other sourced scripts don't take effect until the next manual restart.
+	# This was the root cause of a multi-hour outage where deployed fixes
+	# were correct but the running pulse kept using old code in memory.
+	_restart_pulse_if_running
 
 	return 0
 }


### PR DESCRIPTION
## Summary

Bash processes load `source` files at startup only — deploying updated scripts doesn't affect a running pulse. This caused a multi-hour outage where v3.8.38-v3.8.41 fixes were all deployed correctly but the pulse kept using old code in memory, blocking issues with stale logic until manually restarted.

**Two fixes:**
1. `setup-modules/agent-deploy.sh`: `_restart_pulse_if_running()` called after the atomic deploy swap. Kills the running pulse, waits for launchd auto-restart, falls back to manual start.
2. `prompts/build.txt`: Knowledge harness rule teaching interactive sessions to restart the pulse after deploying hotfixes via `cp`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Pulse processes now automatically restart after agent deployments, eliminating manual intervention in most cases.

* **Documentation**
  * Added operational guidance specifying when pulse restart is required after deploying updates to pulse-related scripts, and which deployment methods handle restart automatically versus requiring manual action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->