### PR TITLE
GH#19065: refactor: t2053.6 eliminate banned readonly + final production audit (Phase 6)

### DIFF
--- a/.agents/scripts/agent-sources-helper.sh
+++ b/.agents/scripts/agent-sources-helper.sh
@@ -17,16 +17,13 @@
 
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=shared-constants.sh
+[[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
+
 AGENTS_DIR="${HOME}/.aidevops/agents"
 CUSTOM_DIR="${AGENTS_DIR}/custom"
 CONFIG_FILE="${AGENTS_DIR}/configs/agent-sources.json"
-
-# Colors
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-BLUE='\033[0;34m'
-YELLOW='\033[1;33m'
-NC='\033[0m'
 
 # Print an informational message in blue
 info() {

--- a/.agents/scripts/coderabbit-cli.sh
+++ b/.agents/scripts/coderabbit-cli.sh
@@ -28,22 +28,16 @@ set -euo pipefail
 # Version: 1.2.0
 # License: MIT
 
-# Source shared constants (provides sed_inplace and other utilities)
+# Source shared constants (provides sed_inplace, canonical colors, and other utilities)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
-source "$SCRIPT_DIR/shared-constants.sh" 2>/dev/null || true
+# shellcheck source=shared-constants.sh
+[[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
 
-# Colors for output
-readonly GREEN='\033[0;32m'
-readonly BLUE='\033[0;34m'
-readonly PURPLE='\033[0;35m'
-readonly NC='\033[0m' # No Color
-
-# Common constants
-readonly ERROR_UNKNOWN_COMMAND="Unknown command:"
-# Configuration constants
-readonly CODERABBIT_CLI_INSTALL_URL="https://cli.coderabbit.ai/install.sh"
-readonly CONFIG_DIR="$HOME/.config/coderabbit"
-readonly API_KEY_FILE="$CONFIG_DIR/api_key"
+# Common constants (ERROR_UNKNOWN_COMMAND is provided by shared-constants.sh)
+# Configuration constants (guarded against re-sourcing)
+[[ -z "${CODERABBIT_CLI_INSTALL_URL+x}" ]] && readonly CODERABBIT_CLI_INSTALL_URL="https://cli.coderabbit.ai/install.sh"
+[[ -z "${CONFIG_DIR+x}" ]] && readonly CONFIG_DIR="$HOME/.config/coderabbit"
+[[ -z "${API_KEY_FILE+x}" ]] && readonly API_KEY_FILE="$CONFIG_DIR/api_key"
 
 print_success() {
 	local message="$1"

--- a/.agents/scripts/sonarcloud-autofix.sh
+++ b/.agents/scripts/sonarcloud-autofix.sh
@@ -8,13 +8,10 @@
 
 set -euo pipefail
 
-# Source shared constants (provides sed_inplace and other utilities)
+# Source shared constants (provides sed_inplace, canonical colors, and other utilities)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
-source "$SCRIPT_DIR/shared-constants.sh" 2>/dev/null || true
-
-# Colors for output
-readonly PURPLE='\033[0;35m'
-readonly NC='\033[0m'
+# shellcheck source=shared-constants.sh
+[[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
 
 print_header() { local msg="$1"; echo -e "${PURPLE}$msg${NC}"; return 0; }
 


### PR DESCRIPTION
## Summary

Eliminates the last two banned `readonly` canonical-color declarations in production (`sonarcloud-autofix.sh`, `coderabbit-cli.sh`) and migrates the final unguarded-plain straggler (`agent-sources-helper.sh`) to Pattern A. All three scripts now source `shared-constants.sh` via the canonical `[[ -f ... ]] && source ...` guard block. Phase 6 of t2053 roadmap — For #18735.

## Files Changed

.agents/scripts/agent-sources-helper.sh,.agents/scripts/coderabbit-cli.sh,.agents/scripts/sonarcloud-autofix.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean (exit 0, only SC1091 info-level); standalone smoke tests of all three scripts show colors render correctly (purple headers, blue info, green success); manual audit via `rg '^readonly (RED|GREEN|YELLOW|BLUE|PURPLE|CYAN|WHITE|NC)='` reports zero production hits outside `shared-constants.sh`.

Resolves #19065


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.42 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-opus-4-6 spent 5m and 16,677 tokens on this as a headless worker.