### PR TITLE
GH#19066: refactor: Pattern C color variable rename in 5 test harnesses

### DIFF
--- a/.agents/scripts/tests/test-circuit-breaker.sh
+++ b/.agents/scripts/tests/test-circuit-breaker.sh
@@ -17,9 +17,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 HELPER="${SCRIPT_DIR}/../circuit-breaker-helper.sh"
 
 # Colors
-readonly RED='\033[0;31m'
-readonly GREEN='\033[0;32m'
-readonly YELLOW='\033[1;33m'
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_YELLOW='\033[1;33m'
 readonly RESET='\033[0m'
 
 # Test counters
@@ -47,10 +47,10 @@ print_result() {
 	TESTS_RUN=$((TESTS_RUN + 1))
 
 	if [[ "$result" -eq 0 ]]; then
-		echo -e "${GREEN}PASS${RESET} $test_name"
+		echo -e "${TEST_GREEN}PASS${RESET} $test_name"
 		TESTS_PASSED=$((TESTS_PASSED + 1))
 	else
-		echo -e "${RED}FAIL${RESET} $test_name"
+		echo -e "${TEST_RED}FAIL${RESET} $test_name"
 		if [[ -n "$message" ]]; then
 			echo "       $message"
 		fi
@@ -446,7 +446,7 @@ main() {
 
 	# Prerequisite check
 	if ! command -v jq &>/dev/null; then
-		echo -e "${RED}SKIP${RESET} jq not found — required for circuit breaker"
+		echo -e "${TEST_RED}SKIP${RESET} jq not found — required for circuit breaker"
 		exit 1
 	fi
 
@@ -473,13 +473,13 @@ main() {
 	echo ""
 	echo "=== Results ==="
 	echo "Total:  $TESTS_RUN"
-	echo -e "Passed: ${GREEN}$TESTS_PASSED${RESET}"
+	echo -e "Passed: ${TEST_GREEN}$TESTS_PASSED${RESET}"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then
-		echo -e "Failed: ${RED}$TESTS_FAILED${RESET}"
+		echo -e "Failed: ${TEST_RED}$TESTS_FAILED${RESET}"
 		return 1
 	else
 		echo -e "Failed: $TESTS_FAILED"
-		echo -e "${GREEN}All tests passed!${RESET}"
+		echo -e "${TEST_GREEN}All tests passed!${RESET}"
 		return 0
 	fi
 }

--- a/.agents/scripts/tests/test-command-logger.sh
+++ b/.agents/scripts/tests/test-command-logger.sh
@@ -16,9 +16,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 HELPER="${SCRIPT_DIR}/../command-logger-helper.sh"
 
 # Colors
-readonly RED='\033[0;31m'
-readonly GREEN='\033[0;32m'
-readonly YELLOW='\033[1;33m'
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_YELLOW='\033[1;33m'
 readonly RESET='\033[0m'
 
 # Test counters
@@ -46,10 +46,10 @@ print_result() {
 	TESTS_RUN=$((TESTS_RUN + 1))
 
 	if [[ "$result" -eq 0 ]]; then
-		echo -e "${GREEN}PASS${RESET} $test_name"
+		echo -e "${TEST_GREEN}PASS${RESET} $test_name"
 		TESTS_PASSED=$((TESTS_PASSED + 1))
 	else
-		echo -e "${RED}FAIL${RESET} $test_name"
+		echo -e "${TEST_RED}FAIL${RESET} $test_name"
 		if [[ -n "$message" ]]; then
 			echo "       $message"
 		fi

--- a/.agents/scripts/tests/test-matterbridge-helper.sh
+++ b/.agents/scripts/tests/test-matterbridge-helper.sh
@@ -16,9 +16,9 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 HELPER="${SCRIPT_DIR}/../matterbridge-helper.sh"
 
 # Colors
-readonly RED='\033[0;31m'
-readonly GREEN='\033[0;32m'
-readonly YELLOW='\033[1;33m'
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_YELLOW='\033[1;33m'
 readonly RESET='\033[0m'
 
 # Test counters
@@ -46,10 +46,10 @@ print_result() {
 	TESTS_RUN=$((TESTS_RUN + 1))
 
 	if [[ "$result" -eq 0 ]]; then
-		echo -e "${GREEN}PASS${RESET} $test_name"
+		echo -e "${TEST_GREEN}PASS${RESET} $test_name"
 		TESTS_PASSED=$((TESTS_PASSED + 1))
 	else
-		echo -e "${RED}FAIL${RESET} $test_name"
+		echo -e "${TEST_RED}FAIL${RESET} $test_name"
 		if [[ -n "$message" ]]; then
 			echo "       $message"
 		fi

--- a/.agents/scripts/tests/test-profile-readme-boundary.sh
+++ b/.agents/scripts/tests/test-profile-readme-boundary.sh
@@ -7,8 +7,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 SOURCE_HELPER="${SCRIPT_DIR}/../profile-readme-helper.sh"
 
-readonly RED='\033[0;31m'
-readonly GREEN='\033[0;32m'
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
 readonly RESET='\033[0m'
 
 TESTS_RUN=0
@@ -25,10 +25,10 @@ print_result() {
 	TESTS_RUN=$((TESTS_RUN + 1))
 
 	if [[ "$result" -eq 0 ]]; then
-		echo -e "${GREEN}PASS${RESET} ${test_name}"
+		echo -e "${TEST_GREEN}PASS${RESET} ${test_name}"
 		TESTS_PASSED=$((TESTS_PASSED + 1))
 	else
-		echo -e "${RED}FAIL${RESET} ${test_name}"
+		echo -e "${TEST_RED}FAIL${RESET} ${test_name}"
 		if [[ -n "$message" ]]; then
 			echo "       ${message}"
 		fi

--- a/.agents/scripts/tests/test-sandbox-sensitive-output-guard.sh
+++ b/.agents/scripts/tests/test-sandbox-sensitive-output-guard.sh
@@ -7,8 +7,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 HELPER="${SCRIPT_DIR}/../sandbox-exec-helper.sh"
 
-readonly RED='\033[0;31m'
-readonly GREEN='\033[0;32m'
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
 readonly RESET='\033[0m'
 
 TESTS_RUN=0
@@ -24,11 +24,11 @@ print_result() {
 	TESTS_RUN=$((TESTS_RUN + 1))
 
 	if [[ "$passed" -eq 0 ]]; then
-		printf '%bPASS%b %s\n' "$GREEN" "$RESET" "$test_name"
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$RESET" "$test_name"
 		return 0
 	fi
 
-	printf '%bFAIL%b %s\n' "$RED" "$RESET" "$test_name"
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$RESET" "$test_name"
 	if [[ -n "$message" ]]; then
 		printf '       %s\n' "$message"
 	fi


### PR DESCRIPTION
## Summary

Migrated 5 test harnesses from bare readonly RED/GREEN/YELLOW to Pattern C prefixed TEST_RED/TEST_GREEN/TEST_YELLOW per style guide §72-85. Files: test-circuit-breaker.sh, test-command-logger.sh, test-matterbridge-helper.sh, test-profile-readme-boundary.sh, test-sandbox-sensitive-output-guard.sh. All declarations renamed, all in-file references updated, RESET left unchanged. ShellCheck clean, circuit-breaker test 21/21 PASS.

## Files Changed

.agents/scripts/tests/test-circuit-breaker.sh,.agents/scripts/tests/test-command-logger.sh,.agents/scripts/tests/test-matterbridge-helper.sh,.agents/scripts/tests/test-profile-readme-boundary.sh,.agents/scripts/tests/test-sandbox-sensitive-output-guard.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean on all 5 files; test-circuit-breaker.sh 21/21 PASS; remaining test failures are pre-existing (simplex-bridge infrastructure, SSH passphrase, sandbox environment)

Resolves #19066


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.43 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-opus-4-6 spent 6m and 13,994 tokens on this as a headless worker.