### PR TITLE
GH#19061: t2053.2: shell init pattern lint gate (Phase 2)

### DIFF
--- a/.agents/scripts/shell-init-pattern-check.sh
+++ b/.agents/scripts/shell-init-pattern-check.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# shell-init-pattern-check.sh — CI lint gate for shell helper init patterns (t2053 Phase 2)
+#
+# Enforces canonical patterns from .agents/reference/shell-style-guide.md.
+# Prevents unguarded assignments to RED/GREEN/YELLOW/BLUE/PURPLE/CYAN/WHITE/NC
+# which caused the GH#18702 outage (auto-update broken for 4 days).
+#
+# Usage:
+#   shell-init-pattern-check.sh --scan-files <file1> [file2 ...]
+#   shell-init-pattern-check.sh --scan-all
+#   shell-init-pattern-check.sh --fix-hint
+#   shell-init-pattern-check.sh --help
+#
+# Options:
+#   --scan-files <file1> [file2 ...]  Scan explicit files (used by CI on PR diffs)
+#   --scan-all                        Scan every *.sh under .agents/scripts/
+#   --fix-hint                        Print a remediation snippet per pattern
+#   -h, --help                        Show this help and exit 0
+#
+# Flags (combinable with --scan-files or --scan-all):
+#   --fix-hint    Also print fix hints alongside violation output
+#
+# Exit codes:
+#   0 — clean, no violations found
+#   1 — one or more violations found
+#   2 — usage error
+#
+# Detection rules:
+#   Banned pattern 1: unguarded top-level assignment to canonical color name
+#     (column-0, no leading whitespace — inside function/block = indented = safe)
+#   Banned pattern 2: readonly on canonical name outside shared-constants.sh
+#   Canonical names: RED GREEN YELLOW BLUE PURPLE CYAN WHITE NC
+#   Safe: [[ -z "${VAR+x}" ]] guard on same line or immediately preceding line
+#   Exempt: shared-constants.sh (defines the canonical values)
+#
+# This helper follows Pattern A (sources shared-constants.sh) — the enforcement
+# script cannot violate its own rule.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=shared-constants.sh
+# shellcheck disable=SC1091
+[[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
+
+SCRIPT_NAME=$(basename "$0")
+
+# Pattern B fallback colors for bootstrap contexts where shared-constants.sh
+# is not yet available (e.g. early CI steps before the repo is fully set up).
+[[ -z "${RED+x}" ]] && RED='\033[0;31m'
+[[ -z "${GREEN+x}" ]] && GREEN='\033[0;32m'
+[[ -z "${YELLOW+x}" ]] && YELLOW='\033[1;33m'
+[[ -z "${NC+x}" ]] && NC='\033[0m'
+
+# Canonical color variable names declared readonly in shared-constants.sh.
+# This list is the source of truth for what is banned at top level.
+CANONICAL_NAMES_PATTERN="^(RED|GREEN|YELLOW|BLUE|PURPLE|CYAN|WHITE|NC)="
+CANONICAL_READONLY_PATTERN="^[[:space:]]*readonly[[:space:]]+(RED|GREEN|YELLOW|BLUE|PURPLE|CYAN|WHITE|NC)="
+GUARD_PATTERN='\[\[ -z "\$\{[A-Z_]+\+x\}" \]\]'
+
+# ── helpers ─────────────────────────────────────────────────────────────────
+
+usage() {
+	sed -n '4,40p' "$0" | sed 's/^# \{0,1\}//'
+	return 0
+}
+
+die() {
+	local _msg="$1"
+	printf '[%s] ERROR: %s\n' "$SCRIPT_NAME" "$_msg" >&2
+	exit 2
+}
+
+log_violation() {
+	local _file="$1"
+	local _lineno="$2"
+	local _type="$3"
+	local _content="$4"
+	printf '%b[VIOLATION]%b %s:%s\n' "${RED}" "${NC}" "$_file" "$_lineno" >&2
+	printf '  Type: %s\n' "$_type" >&2
+	printf '  Line: %s\n' "$_content" >&2
+	return 0
+}
+
+# line_has_guard <line>: returns 0 if line contains a [[ -z "${VAR+x}" ]] guard
+line_has_guard() {
+	local _line="$1"
+	printf '%s' "$_line" | grep -qE "${GUARD_PATTERN}"
+	return $?
+}
+
+print_fix_hint() {
+	printf '\n%b── Fix Hint: Shell Init Pattern Guide ──%b\n' "${YELLOW}" "${NC}"
+	printf 'Reference: .agents/reference/shell-style-guide.md\n\n'
+	printf '%bPattern A (preferred — scripts inside .agents/scripts/):%b\n' "${GREEN}" "${NC}"
+	# shellcheck disable=SC2016
+	printf '  SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"\n'
+	printf '  # shellcheck source=shared-constants.sh\n'
+	# shellcheck disable=SC2016
+	printf '  [[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"\n\n'
+	printf '%bPattern B (fallback — bootstrap/standalone/curl-distributed):%b\n' "${GREEN}" "${NC}"
+	# shellcheck disable=SC2016
+	printf '  [[ -z "${RED+x}" ]]    && RED='\''\033[0;31m'\''\n'
+	# shellcheck disable=SC2016
+	printf '  [[ -z "${GREEN+x}" ]]  && GREEN='\''\033[0;32m'\''\n'
+	# shellcheck disable=SC2016
+	printf '  [[ -z "${YELLOW+x}" ]] && YELLOW='\''\033[1;33m'\''\n'
+	# shellcheck disable=SC2016
+	printf '  [[ -z "${NC+x}" ]]     && NC='\''\033[0m'\''\n\n'
+	printf '%bPattern C (test harnesses and strictly-internal utilities only):%b\n' "${GREEN}" "${NC}"
+	printf '  readonly TEST_RED=$'"'"'\033[0;31m'"'"'\n'
+	printf '  readonly TEST_GREEN=$'"'"'\033[0;32m'"'"'\n'
+	printf '  readonly TEST_RESET=$'"'"'\033[0m'"'"'\n\n'
+	printf 'NEVER: %breadonly RED=%b or unguarded %bRED=%b at column 0.\n\n' "${RED}" "${NC}" "${RED}" "${NC}"
+	return 0
+}
+
+# ── scanner ──────────────────────────────────────────────────────────────────
+
+# scan_file <path> <violations_file>
+# Appends violation records to <violations_file>, one per line:
+#   <file>:<lineno>:<type>:<content>
+scan_file() {
+	local _file="$1"
+	local _vfile="$2"
+	local _basename
+
+	_basename=$(basename "$_file")
+
+	# shared-constants.sh is unconditionally exempt
+	if [[ "$_basename" == "shared-constants.sh" ]]; then
+		return 0
+	fi
+
+	local _lineno=0
+	local _prev_line=""
+	local _line
+
+	while IFS= read -r _line || [[ -n "${_line}" ]]; do
+		_lineno=$((_lineno + 1))
+
+		# Banned pattern 2: readonly on canonical name (any indentation)
+		if printf '%s' "${_line}" | grep -qE "${CANONICAL_READONLY_PATTERN}"; then
+			printf '%s\n' "${_file}:${_lineno}:readonly on canonical name (breaks on re-sourcing — Banned pattern 2):${_line}" >>"${_vfile}"
+			_prev_line="${_line}"
+			continue
+		fi
+
+		# Banned pattern 1: unguarded top-level assignment (column 0, no leading whitespace)
+		if printf '%s' "${_line}" | grep -qE "${CANONICAL_NAMES_PATTERN}"; then
+			# Safe if guarded on same line or previous line
+			if line_has_guard "${_line}" || line_has_guard "${_prev_line}"; then
+				: # guarded — allowed
+			else
+				printf '%s\n' "${_file}:${_lineno}:unguarded top-level assignment (collides with parent readonly — Banned pattern 1):${_line}" >>"${_vfile}"
+			fi
+		fi
+
+		_prev_line="${_line}"
+	done <"${_file}"
+
+	return 0
+}
+
+# ── main ─────────────────────────────────────────────────────────────────────
+
+MODE=""
+SHOW_FIX_HINT=0
+SCAN_FILES=()
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+	--scan-all)
+		MODE="scan-all"
+		shift
+		;;
+	--scan-files)
+		MODE="scan-files"
+		shift
+		while [[ $# -gt 0 ]] && [[ "$1" != --* ]]; do
+			SCAN_FILES+=("$1")
+			shift
+		done
+		;;
+	--fix-hint)
+		SHOW_FIX_HINT=1
+		shift
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*)
+		die "Unknown argument: $1 — use --help for usage"
+		;;
+	esac
+done
+
+# Validate: at least one mode or --fix-hint standalone
+if [[ -z "${MODE}" && "${SHOW_FIX_HINT}" -eq 0 ]]; then
+	die "No mode specified. Use --scan-all, --scan-files <files...>, or --fix-hint."
+fi
+
+# Standalone --fix-hint (no scan mode)
+if [[ -z "${MODE}" && "${SHOW_FIX_HINT}" -eq 1 ]]; then
+	print_fix_hint
+	exit 0
+fi
+
+if [[ "${MODE}" == "scan-files" && "${#SCAN_FILES[@]}" -eq 0 ]]; then
+	die "--scan-files requires at least one file argument."
+fi
+
+# Build file list
+FILES_TO_SCAN=()
+if [[ "${MODE}" == "scan-all" ]]; then
+	while IFS= read -r -d '' _f; do
+		FILES_TO_SCAN+=("${_f}")
+	done < <(find "${SCRIPT_DIR}" -name "*.sh" -type f -print0 2>/dev/null | sort -z)
+else
+	FILES_TO_SCAN=("${SCAN_FILES[@]}")
+fi
+
+# Scan files and collect violations in a temp file
+VIOLATIONS_FILE=$(mktemp)
+trap 'rm -f "${VIOLATIONS_FILE}"' EXIT
+
+FILES_SCANNED=0
+FILES_SKIPPED=0
+
+for _f in "${FILES_TO_SCAN[@]}"; do
+	if [[ ! -f "${_f}" ]]; then
+		printf '[%s] WARNING: skipping (not found): %s\n' "${SCRIPT_NAME}" "${_f}" >&2
+		FILES_SKIPPED=$((FILES_SKIPPED + 1))
+		continue
+	fi
+	if [[ "${_f}" != *.sh ]]; then
+		continue
+	fi
+	scan_file "${_f}" "${VIOLATIONS_FILE}"
+	FILES_SCANNED=$((FILES_SCANNED + 1))
+done
+
+TOTAL_VIOLATIONS=$(wc -l <"${VIOLATIONS_FILE}" | tr -d ' ')
+
+# Report violations
+if [[ "${TOTAL_VIOLATIONS}" -gt 0 ]]; then
+	printf '%b[FAIL]%b shell-init-pattern-check: %d violation(s) across %d file(s) scanned\n' \
+		"${RED}" "${NC}" "${TOTAL_VIOLATIONS}" "${FILES_SCANNED}"
+	printf '\n'
+	while IFS= read -r _vline; do
+		# Format: file:lineno:type:content
+		_vfile="${_vline%%:*}"
+		_rest="${_vline#*:}"
+		_vlineno="${_rest%%:*}"
+		_rest="${_rest#*:}"
+		_vtype="${_rest%%:*}"
+		_vcontent="${_rest#*:}"
+		log_violation "${_vfile}" "${_vlineno}" "${_vtype}" "${_vcontent}"
+	done <"${VIOLATIONS_FILE}"
+	if [[ "${SHOW_FIX_HINT}" -eq 1 ]]; then
+		print_fix_hint
+	else
+		printf '\nRun with --fix-hint for remediation guidance.\n' >&2
+	fi
+	exit 1
+fi
+
+printf '%b[OK]%b shell-init-pattern-check: no violations in %d file(s) scanned\n' \
+	"${GREEN}" "${NC}" "${FILES_SCANNED}"
+if [[ "${SHOW_FIX_HINT}" -eq 1 ]]; then
+	print_fix_hint
+fi
+exit 0

--- a/.agents/scripts/tests/test-shell-init-pattern-check.sh
+++ b/.agents/scripts/tests/test-shell-init-pattern-check.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-shell-init-pattern-check.sh — regression tests for the t2053 Phase 2
+# shell init pattern lint gate (shell-init-pattern-check.sh).
+#
+# Failure history motivating this gate: GH#18702 — unguarded GREEN= in
+# init-routines-helper.sh collided with readonly GREEN in shared-constants.sh,
+# aborting setup.sh under set -Eeuo pipefail. Auto-update broken for 4 days.
+#
+# Coverage:
+#   (a) plain unguarded RED='...' at column 0 → violation (Banned pattern 1)
+#   (b) readonly RED='...' outside shared-constants.sh → violation (Banned pattern 2)
+#   (c) Pattern A (source shared-constants.sh) → clean
+#   (d) Pattern B ([[ -z "${VAR+x}" ]] &&) → clean
+#   (e) Pattern C (TEST_RED=...) → clean (prefixed names are not canonical)
+#   (f) unguarded BOLD= → clean (not a canonical color per style guide §99)
+#   (g) canonical set is RED/GREEN/YELLOW/BLUE/PURPLE/CYAN/WHITE/NC only
+#   (h) shared-constants.sh is unconditionally exempt (even with bare assigns)
+#   (i) indented assignment (inside function) → clean (not top-level)
+#   (j) same-line guard: RED= on same line as [[ -z "${RED+x}" ]] → clean
+
+# NOTE: not using set -e intentionally — negative assertions rely on
+# capturing non-zero exits from the scanner. Each assertion explicitly
+# checks exit codes via `if ...; then ...; fi`.
+set -uo pipefail
+
+TESTS_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# Pattern C test colors — prefixed names to avoid collision when this test
+# script is sourced by other test runners.
+TEST_RED=$'\033[0;31m'
+TEST_GREEN=$'\033[0;32m'
+TEST_RESET=$'\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+SCANNER="${TESTS_SCRIPTS_DIR}/shell-init-pattern-check.sh"
+
+# ── test infrastructure ────────────────────────────────────────────────────
+
+print_result() {
+	local _name="$1"
+	local _rc="$2"
+	local _extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "${_rc}" -eq 0 ]]; then
+		printf '%sPASS%s %s\n' "${TEST_GREEN}" "${TEST_RESET}" "${_name}"
+	else
+		printf '%sFAIL%s %s %s\n' "${TEST_RED}" "${TEST_RESET}" "${_name}" "${_extra}"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+assert_violation() {
+	local _desc="$1"
+	local _fixture="$2"
+	local _rc
+	"${SCANNER}" --scan-files "${_fixture}" >/dev/null 2>&1
+	_rc=$?
+	if [[ "${_rc}" -eq 1 ]]; then
+		print_result "${_desc}" 0
+	else
+		print_result "${_desc}" 1 "(expected exit 1 for violation, got ${_rc})"
+	fi
+	return 0
+}
+
+assert_clean() {
+	local _desc="$1"
+	local _fixture="$2"
+	local _rc
+	"${SCANNER}" --scan-files "${_fixture}" >/dev/null 2>&1
+	_rc=$?
+	if [[ "${_rc}" -eq 0 ]]; then
+		print_result "${_desc}" 0
+	else
+		print_result "${_desc}" 1 "(expected exit 0 for clean, got ${_rc})"
+	fi
+	return 0
+}
+
+# Create scratch directory for fixture files
+SCRATCH=$(mktemp -d)
+trap 'rm -rf "${SCRATCH}"' EXIT
+
+# ── fixtures ──────────────────────────────────────────────────────────────
+
+# (a) Banned pattern 1: unguarded plain assignment at column 0
+cat >"${SCRATCH}/fixture_a_unguarded_plain.sh" <<'EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+echo "hello"
+EOF
+
+# (b) Banned pattern 2: readonly on canonical name outside shared-constants.sh
+cat >"${SCRATCH}/fixture_b_readonly.sh" <<'EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+readonly RED='\033[0;31m'
+echo "hello"
+EOF
+
+# (c) Pattern A — source shared-constants.sh (clean)
+cat >"${SCRATCH}/fixture_c_pattern_a.sh" <<'EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=shared-constants.sh
+[[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
+echo "${GREEN}[OK]${NC} hello"
+EOF
+
+# (d) Pattern B — [[ -z "${VAR+x}" ]] guard on previous line (clean)
+cat >"${SCRATCH}/fixture_d_pattern_b.sh" <<'EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+[[ -z "${RED+x}" ]]    && RED='\033[0;31m'
+[[ -z "${GREEN+x}" ]]  && GREEN='\033[0;32m'
+[[ -z "${YELLOW+x}" ]] && YELLOW='\033[1;33m'
+[[ -z "${NC+x}" ]]     && NC='\033[0m'
+echo "hello"
+EOF
+
+# (e) Pattern C — prefixed names like TEST_RED (clean — not canonical names)
+cat >"${SCRATCH}/fixture_e_pattern_c.sh" <<'EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+TEST_RED=$'\033[0;31m'
+TEST_GREEN=$'\033[0;32m'
+TEST_RESET=$'\033[0m'
+echo "hello"
+EOF
+
+# (f) Non-canonical color BOLD= (clean — not in the banned set)
+cat >"${SCRATCH}/fixture_f_bold.sh" <<'EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+BOLD='\033[1m'
+DIM='\033[2m'
+MAGENTA='\033[0;35m'
+echo "hello"
+EOF
+
+# (g) All 8 canonical names — each should trigger independently (one violation each)
+for _varname in RED GREEN YELLOW BLUE PURPLE CYAN WHITE NC; do
+	cat >"${SCRATCH}/fixture_g_${_varname}.sh" <<EOF
+#!/usr/bin/env bash
+set -uo pipefail
+${_varname}='\\033[0;31m'
+echo "hello"
+EOF
+done
+
+# (h) shared-constants.sh is unconditionally exempt (even with bare assigns + readonly)
+cat >"${SCRATCH}/shared-constants.sh" <<'EOF'
+#!/usr/bin/env bash
+# This is a fake shared-constants.sh — exempt from all checks
+[[ -n "${_SHARED_CONSTANTS_LOADED:-}" ]] && return 0
+_SHARED_CONSTANTS_LOADED=1
+readonly RED='\033[0;31m'
+readonly GREEN='\033[0;32m'
+GREEN='\033[0;32m'
+EOF
+
+# (i) Indented assignment inside function body (clean — not top-level)
+cat >"${SCRATCH}/fixture_i_indented.sh" <<'EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+setup_colors() {
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+}
+echo "hello"
+EOF
+
+# (j) Same-line guard: [[ -z "${RED+x}" ]] && RED= (clean)
+cat >"${SCRATCH}/fixture_j_sameline_guard.sh" <<'EOF'
+#!/usr/bin/env bash
+set -uo pipefail
+[[ -z "${RED+x}" ]] && RED='\033[0;31m'
+echo "hello"
+EOF
+
+# ── assertions ────────────────────────────────────────────────────────────
+
+printf '\n=== shell-init-pattern-check tests ===\n\n'
+
+# (a) unguarded plain assignment → violation
+assert_violation "(a) unguarded plain RED= at column 0 fails" \
+	"${SCRATCH}/fixture_a_unguarded_plain.sh"
+
+# (b) readonly on canonical name → violation
+assert_violation "(b) readonly RED= outside shared-constants.sh fails" \
+	"${SCRATCH}/fixture_b_readonly.sh"
+
+# (c) Pattern A (source shared-constants.sh) → clean
+assert_clean "(c) Pattern A (source shared-constants.sh) passes" \
+	"${SCRATCH}/fixture_c_pattern_a.sh"
+
+# (d) Pattern B (guarded [[ -z "${VAR+x}" ]]) → clean
+assert_clean "(d) Pattern B ([[ -z \\${VAR+x} ]] guard) passes" \
+	"${SCRATCH}/fixture_d_pattern_b.sh"
+
+# (e) Pattern C (prefixed TEST_RED) → clean
+assert_clean "(e) Pattern C (TEST_RED prefixed names) passes" \
+	"${SCRATCH}/fixture_e_pattern_c.sh"
+
+# (f) BOLD= is not in the canonical set → clean
+assert_clean "(f) BOLD= (non-canonical) passes" \
+	"${SCRATCH}/fixture_f_bold.sh"
+
+# (g) All 8 canonical names individually trigger violations
+for _varname in RED GREEN YELLOW BLUE PURPLE CYAN WHITE NC; do
+	assert_violation "(g) canonical ${_varname}= at column 0 fails" \
+		"${SCRATCH}/fixture_g_${_varname}.sh"
+done
+
+# (h) shared-constants.sh exempt even with bare assigns and readonly
+assert_clean "(h) shared-constants.sh unconditionally exempt" \
+	"${SCRATCH}/shared-constants.sh"
+
+# (i) indented assignment (inside function) → clean
+assert_clean "(i) indented assignment inside function passes" \
+	"${SCRATCH}/fixture_i_indented.sh"
+
+# (j) same-line guard → clean
+assert_clean "(j) same-line [[ -z \\${VAR+x} ]] && VAR= guard passes" \
+	"${SCRATCH}/fixture_j_sameline_guard.sh"
+
+# ── scanner self-check (scanner follows Pattern A) ────────────────────────
+
+assert_clean "(self) scanner itself is violation-free (Pattern A compliance)" \
+	"${SCANNER}"
+
+# ── --fix-hint flag exits 0 and prints hint ───────────────────────────────
+
+TESTS_RUN=$((TESTS_RUN + 1))
+fix_hint_out=$("${SCANNER}" --fix-hint 2>&1)
+fix_hint_rc=$?
+if [[ "${fix_hint_rc}" -eq 0 ]] && printf '%s' "${fix_hint_out}" | grep -q "Pattern A"; then
+	printf '%sPASS%s (fix-hint) --fix-hint exits 0 and prints remediation text\n' \
+		"${TEST_GREEN}" "${TEST_RESET}"
+else
+	printf '%sFAIL%s (fix-hint) --fix-hint expected exit 0 and "Pattern A" text (rc=%d)\n' \
+		"${TEST_RED}" "${TEST_RESET}" "${fix_hint_rc}"
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+
+# ── --scan-all exits 0 on clean temp dir ─────────────────────────────────
+
+CLEAN_DIR=$(mktemp -d)
+trap 'rm -rf "${CLEAN_DIR}" "${SCRATCH}"' EXIT
+cat >"${CLEAN_DIR}/clean.sh" <<'EOF'
+#!/usr/bin/env bash
+[[ -z "${RED+x}" ]] && RED='\033[0;31m'
+echo "hello"
+EOF
+
+TESTS_RUN=$((TESTS_RUN + 1))
+scan_all_rc=0
+# Temporarily point scanner's SCRIPT_DIR equivalent to the clean dir
+# by creating a fake shared-constants.sh target and scanning the clean dir.
+# We scan the clean file directly since --scan-all uses SCRIPT_DIR.
+"${SCANNER}" --scan-files "${CLEAN_DIR}/clean.sh" >/dev/null 2>&1
+scan_all_rc=$?
+if [[ "${scan_all_rc}" -eq 0 ]]; then
+	printf '%sPASS%s (scan-all-clean) --scan-files on clean file exits 0\n' \
+		"${TEST_GREEN}" "${TEST_RESET}"
+else
+	printf '%sFAIL%s (scan-all-clean) --scan-files on clean file expected exit 0, got %d\n' \
+		"${TEST_RED}" "${TEST_RESET}" "${scan_all_rc}"
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+
+rm -rf "${CLEAN_DIR}"
+
+# ── summary ───────────────────────────────────────────────────────────────
+
+printf '\n'
+if [[ "${TESTS_FAILED}" -eq 0 ]]; then
+	printf '%sAll %d tests passed.%s\n' "${TEST_GREEN}" "${TESTS_RUN}" "${TEST_RESET}"
+	exit 0
+else
+	printf '%s%d of %d tests FAILED.%s\n' "${TEST_RED}" "${TESTS_FAILED}" "${TESTS_RUN}" "${TEST_RESET}"
+	exit 1
+fi

--- a/.github/workflows/shell-init-pattern-check.yml
+++ b/.github/workflows/shell-init-pattern-check.yml
@@ -1,0 +1,146 @@
+name: Shell Init Pattern Gate
+
+# t2053 Phase 2: enforce canonical shell helper init patterns from
+# .agents/reference/shell-style-guide.md.
+#
+# Scans only .sh files CHANGED in the PR (Option A from the issue — diff-scoped)
+# so pre-existing violations on main do not block unrelated work. Phases 3–6
+# drain the known violation list file-by-file as each script migrates.
+#
+# Banned patterns detected:
+#   1. Unguarded top-level assignment to RED/GREEN/YELLOW/BLUE/PURPLE/CYAN/WHITE/NC
+#      (collides with `readonly` in shared-constants.sh under set -Eeuo pipefail)
+#   2. `readonly <canonical-name>=` outside shared-constants.sh
+#      (breaks on re-sourcing)
+#
+# Originating incident: GH#18702 — unguarded GREEN= in init-routines-helper.sh
+# collided with readonly GREEN, aborting setup.sh, breaking auto-update for 4 days.
+
+on:
+  pull_request:
+    paths:
+      - '.agents/scripts/**/*.sh'
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  detect-changed-sh:
+    name: Detect changed shell files
+    runs-on: ubuntu-latest
+    outputs:
+      has_sh_changes: ${{ steps.detect.outputs.has_sh_changes }}
+      changed_files: ${{ steps.detect.outputs.changed_files }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect changed .sh files under .agents/scripts/
+        id: detect
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          changed=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" 2>/dev/null \
+            | grep -E '^\.agents/scripts/.*\.sh$' || true)
+
+          if [ -z "$changed" ]; then
+            printf 'No .agents/scripts/**/*.sh files changed; skipping init-pattern check.\n'
+            echo "has_sh_changes=false" >> "$GITHUB_OUTPUT"
+            echo "changed_files=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          printf 'Changed shell files to scan:\n%s\n' "$changed"
+          echo "has_sh_changes=true" >> "$GITHUB_OUTPUT"
+          # Space-separated list for passing to the helper
+          {
+            printf 'changed_files='
+            printf '%s' "$changed" | tr '\n' ' '
+            printf '\n'
+          } >> "$GITHUB_OUTPUT"
+
+  scan:
+    name: Shell Init Pattern Check
+    runs-on: ubuntu-latest
+    needs: detect-changed-sh
+    if: needs.detect-changed-sh.outputs.has_sh_changes == 'true'
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Make scanner executable
+        run: chmod +x .agents/scripts/shell-init-pattern-check.sh
+
+      - name: Run init-pattern scanner on changed files
+        id: scan
+        env:
+          CHANGED_FILES: ${{ needs.detect-changed-sh.outputs.changed_files }}
+        run: |
+          set +e
+          # shellcheck disable=SC2086
+          .agents/scripts/shell-init-pattern-check.sh --scan-files $CHANGED_FILES \
+            --fix-hint > /tmp/shell-init-pattern-report.txt 2>&1
+          exit_code=$?
+          set -e
+          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+          printf '---- report ----\n'
+          cat /tmp/shell-init-pattern-report.txt || true
+
+      - name: Post PR comment on violation
+        if: steps.scan.outputs.exit_code == '1'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          # Build comment body from report, prepend header and style-guide link
+          {
+            printf '<!-- shell-init-pattern-gate -->\n'
+            printf '## Shell Init Pattern Gate: violations found\n\n'
+            printf 'The following changed files introduce banned shell init patterns.\n'
+            printf 'See [shell-style-guide.md](.agents/reference/shell-style-guide.md) for Pattern A/B/C.\n\n'
+            printf '```\n'
+            cat /tmp/shell-init-pattern-report.txt
+            printf '```\n'
+          } > /tmp/shell-init-pattern-comment.md
+
+          marker='<!-- shell-init-pattern-gate -->'
+          existing=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --jq "[.[] | select(.body | contains(\"$marker\")) | .id] | .[0] // empty" \
+            2>/dev/null || true)
+          if [ -n "$existing" ]; then
+            gh api "repos/${REPO}/issues/comments/${existing}" \
+              --method PATCH -F body=@/tmp/shell-init-pattern-comment.md >/dev/null 2>&1 || true
+          else
+            gh pr comment "$PR_NUMBER" --repo "$REPO" \
+              --body-file /tmp/shell-init-pattern-comment.md >/dev/null 2>&1 || true
+          fi
+
+      - name: Enforce gate
+        env:
+          EXIT_CODE: ${{ steps.scan.outputs.exit_code }}
+        run: |
+          set -euo pipefail
+          if [ "$EXIT_CODE" = "0" ]; then
+            printf 'Shell init pattern gate: all changed files are clean.\n'
+            exit 0
+          fi
+          if [ "$EXIT_CODE" != "1" ]; then
+            printf '::error::Scanner exited with unexpected code: %s\n' "$EXIT_CODE"
+            exit 1
+          fi
+          printf '::error::Shell init pattern violations found in changed files.\n'
+          printf '::error::Fix with Pattern A (source shared-constants.sh) or Pattern B ([[ -z "${VAR+x}" ]] guard).\n'
+          printf '::error::Reference: .agents/reference/shell-style-guide.md\n'
+          exit 1


### PR DESCRIPTION
## Summary

Ship Phase 2 of the t2053 shell helper init consolidation roadmap: CI lint gate that enforces canonical patterns from shell-style-guide.md. 3 new files: scanner helper (shell-init-pattern-check.sh), GitHub Actions workflow (shell-init-pattern-check.yml), and regression test harness (test-shell-init-pattern-check.sh) with 20 passing assertions.

## Files Changed

.agents/scripts/shell-init-pattern-check.sh,.agents/scripts/tests/test-shell-init-pattern-check.sh,.github/workflows/shell-init-pattern-check.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-shell-init-pattern-check.sh — all 20 tests pass. shellcheck .agents/scripts/shell-init-pattern-check.sh — clean (exit 0).

Resolves #19061


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.43 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-sonnet-4-6 spent 8m and 25,415 tokens on this as a headless worker.