### PR TITLE
GH#19158: GH#19158: tighten shell-style-guide.md prose

### DIFF
--- a/.agents/reference/shell-style-guide.md
+++ b/.agents/reference/shell-style-guide.md
@@ -44,9 +44,9 @@ set -Eeuo pipefail
 
 `${VAR+x}` distinguishes *unset* from *set-to-empty* — parent with `shared-constants.sh` wins; standalone picks up fallback. **Do not use `${VAR:-}`** — it treats set-to-empty as unset.
 
-### C — prefixed names (test harnesses and strictly-internal utilities)
+### C — prefixed names (test harnesses and strictly-internal utilities only)
 
-For test harnesses and strictly-internal utilities only. Prefix must be `TEST_`, `_<script_name>_`, or documented in `shared-constants.sh`:
+Prefix must be `TEST_`, `_<script_name>_`, or documented in `shared-constants.sh`:
 
 ```bash
 readonly TEST_RED=$'\033[0;31m'
@@ -54,29 +54,25 @@ readonly TEST_GREEN=$'\033[0;32m'
 readonly TEST_RESET=$'\033[0m'
 ```
 
-`readonly` safe — prefixed names don't collide. **Production helpers: use Pattern A or B** — inconsistent naming forces `TEST_RED`↔`RED` translation.
+`readonly` safe — prefixed names don't collide. **Production helpers: use Pattern A or B.**
 
 ## Banned patterns
 
-**Unguarded plain assignment** (collides with parent `readonly`):
+**Unguarded plain assignment** — collides with parent `readonly`. Fix: Pattern A or B.
 
 ```bash
 # BAD
 RED='\033[0;31m'
 ```
 
-Fix: Pattern A or B.
-
-**Unguarded `readonly` on canonical names** — breaks on re-sourcing:
+**Unguarded `readonly` on canonical names** — breaks on re-sourcing. Fix: Pattern B (production) or Pattern C with prefix (tests).
 
 ```bash
 # WORST
 readonly RED='\033[0;31m'
 ```
 
-Fix: Pattern B (production) or Pattern C with prefix (tests).
-
-**Coarse include-guard** (discouraged, allowed for backward compat):
+**Coarse include-guard** — discouraged, allowed for backward compat. All-or-nothing: colors partially undefined under `set -u` when parent set some without the sentinel; Pattern B handles each independently. Migrate opportunistically.
 
 ```bash
 if [[ -z "${_SHARED_CONSTANTS_LOADED:-}" ]]; then
@@ -84,8 +80,6 @@ if [[ -z "${_SHARED_CONSTANTS_LOADED:-}" ]]; then
     GREEN='\033[0;32m'
 fi
 ```
-
-Problem: all-or-nothing — colors partially undefined under `set -u` when parent set some without the sentinel. Pattern B handles each independently. Existing code may remain; migrate opportunistically.
 
 ## Canonical shared variables
 


### PR DESCRIPTION
## Summary

Tightened .agents/reference/shell-style-guide.md from 141 to 135 lines. Folded standalone 'Fix:' paragraphs after banned-pattern code blocks into heading descriptions, removed redundant standalone prose before Pattern C code block, and folded include-guard 'Problem:' paragraph before its code block. All institutional knowledge preserved: incident references (GH#18702, PR #18728), task IDs (t2053, t1422, GH#18735), audit data table, migration roadmap, and all code examples.

## Files Changed

.agents/reference/shell-style-guide.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** wc -l confirms 135 lines (from 141). All key GH/task references verified present. No code block content changed.

Resolves #19158


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.43 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-sonnet-4-6 spent 3m and 10,040 tokens on this as a headless worker.