### PR TITLE
GH#19086: fix: bump NESTING_DEPTH_THRESHOLD 279→286 to restore headroom (GH#19086)

### DIFF
--- a/.agents/configs/complexity-thresholds-history.md
+++ b/.agents/configs/complexity-thresholds-history.md
@@ -57,6 +57,9 @@ Archives the full change history for `.agents/configs/complexity-thresholds.conf
 | 284 | GH#19003 | proximity guard firing at 277/281 (4 headroom); 277 violations + 7 headroom = 284; proximity guard (warn_at = 284-5 = 279) fires when violations exceed 279 (i.e., at 280), preventing saturation |
 | 279 | GH#19015 | ratcheted down — actual violations 277 + 2 buffer |
 | 284 | GH#19019 | proximity guard firing at 277/279 (2 headroom); 277 violations + 7 headroom = 284; proximity guard (warn_at = 284-5 = 279) fires when violations exceed 279 (i.e., at 280), preventing saturation |
+| 280 | GH#19056 | ratcheted down — actual violations 278 + 2 buffer |
+| 279 | GH#19031 | ratcheted down — actual violations 277 + 2 buffer |
+| 286 | GH#19086 | proximity guard firing at 279/279 (0 headroom); violations drifted from ratchet baseline 277 up to 279 on main as new helpers landed. 279 violations + 7 headroom = 286; proximity guard (warn_at = 286-5 = 281) fires when violations exceed 281 (i.e., at 282), preventing saturation. A ratchet-down fix would require reducing per-file max depth below 9 in multiple scripts — a larger refactor than the proximity warning justifies; follow the established bump-and-ratchet cadence |
 
 ## FUNCTION_COMPLEXITY_THRESHOLD History
 

--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -106,7 +106,13 @@ FUNCTION_COMPLEXITY_THRESHOLD=26
 # Proximity guard (warn_at = 284-5 = 279) fires when violations exceed 279 (i.e., at 280), preventing saturation.
 # Ratcheted down to 280 (GH#19056): actual violations 278 + 2 buffer
 # Ratcheted down to 279 (GH#19031): actual violations 277 + 2 buffer
-NESTING_DEPTH_THRESHOLD=279
+# Bumped to 286 (GH#19086): proximity guard firing at 279/279 (0 headroom); 279 violations + 7 headroom = 286.
+# Proximity guard (warn_at = 286-5 = 281) fires when violations exceed 281 (i.e., at 282), preventing saturation.
+# Violations drifted from the ratchet baseline (277) up to 279 as new helpers landed on main. A ratchet-down
+# fix here would require reducing per-file max depth below 9 in multiple scripts — a larger refactor than the
+# proximity warning justifies. Follow the established bump-and-ratchet cadence: headroom now, ratchet down
+# after the next batch of simplification-debt PRs merges.
+NESTING_DEPTH_THRESHOLD=286
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Bumped NESTING_DEPTH_THRESHOLD from 279 to 286. CI scan shows 279 violations against a 279 threshold (0 headroom), so the proximity guard (warn_at = threshold - 5) was firing with no slack. 279 violations + 7 headroom = 286. Proximity guard (warn_at = 281) now fires at 282 violations, preventing saturation on the next drift PR. Documented rationale in both complexity-thresholds.conf (inline comment) and complexity-thresholds-history.md (audit trail, plus backfilled missing GH#19056/GH#19031 ratchet-down entries). Violations drifted from the last ratchet baseline (277) up to 279 as new helpers landed on main between GH#19031 and today; a ratchet-down fix would require lowering per-file max depth below 9 in multiple scripts — a larger refactor than the proximity warning justifies. Follow the established bump-and-ratchet cadence: headroom now, ratchet down after the next batch of simplification-debt PRs.

## Files Changed

.agents/configs/complexity-thresholds-history.md,.agents/configs/complexity-thresholds.conf

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Re-ran the CI-equivalent nesting scan locally (source lint-file-discovery.sh; same awk counter as .github/workflows/code-quality.yml lines 369-408) after the bump: 279 violations against threshold 286, 7 headroom. Shellcheck not required (config file change only).

Resolves #19086


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.43 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-opus-4-6 spent 4m and 8,096 tokens on this as a headless worker.