### PR TITLE
GH#19139: docs: remove redundant/self-referential tier:thinking backward compat notes

### DIFF
--- a/.agents/reference/task-taxonomy.md
+++ b/.agents/reference/task-taxonomy.md
@@ -42,7 +42,6 @@ Tiers route tasks to models with appropriate capability. The pulse resolves labe
 **Rules:**
 - Default to `tier:standard` when uncertain. Use `tier:simple` for prescriptive work, `tier:thinking` for deep reasoning.
 - **Cascade dispatch:** The pulse may start at `tier:simple` and escalate through `tier:standard` → `tier:thinking` if the worker fails. Each tier's attempt produces a structured escalation report (see `templates/escalation-report-template.md`) that gives the next tier pre-digested context.
-- **Backward compatibility:** `tier:thinking` is accepted as an alias for `tier:thinking` during transition. Scripts match both labels.
 
 ## Tier Assignment Validation
 

--- a/.agents/workflows/pulse-sweep.md
+++ b/.agents/workflows/pulse-sweep.md
@@ -242,7 +242,7 @@ RESOLVED_MODEL=$(~/.aidevops/agents/scripts/model-availability-helper.sh resolve
 # Pass: --model "$RESOLVED_MODEL"
 ```
 
-Precedence: (1) failure escalation (cascade: `tier:simple` → `tier:standard` → `tier:thinking`) > (2) issue labels (`tier:thinking` → opus, `tier:standard` → sonnet, `tier:simple` → haiku) > (3) bundle defaults > (4) omit (default round-robin). Backward compat: `tier:reasoning` accepted as alias for `tier:thinking`.
+Precedence: (1) failure escalation (cascade: `tier:simple` → `tier:standard` → `tier:thinking`) > (2) issue labels (`tier:thinking` → opus, `tier:standard` → sonnet, `tier:simple` → haiku) > (3) bundle defaults > (4) omit (default round-robin). See [Task Taxonomy](../reference/task-taxonomy.md) for tier purposes.
 
 ### Agent routing from labels
 

--- a/.agents/workflows/pulse.md
+++ b/.agents/workflows/pulse.md
@@ -258,7 +258,7 @@ RESOLVED_MODEL=$(~/.aidevops/agents/scripts/model-availability-helper.sh resolve
 dispatch_with_dedup NUMBER SLUG ... "$RESOLVED_MODEL"
 ```
 
-Precedence: (1) failure escalation (cascade: `tier:simple` → `tier:standard` → `tier:thinking`) > (2) issue labels (`tier:thinking` → opus, `tier:standard` → sonnet, `tier:simple` → haiku) > (3) **omit the 9th parameter** (runtime resolver selects). Backward compat: `tier:thinking` is alias for `tier:thinking`.
+Precedence: (1) failure escalation (cascade: `tier:simple` → `tier:standard` → `tier:thinking`) > (2) issue labels (`tier:thinking` → opus, `tier:standard` → sonnet, `tier:simple` → haiku) > (3) **omit the 9th parameter** (runtime resolver selects). See [Task Taxonomy](../reference/task-taxonomy.md) for tier purposes.
 
 ### Agent routing from labels
 


### PR DESCRIPTION
## Summary

Removed three backward compat notes that were either self-referential (tier:thinking alias for tier:thinking) or misleading (claiming tier:reasoning is accepted as alias when pulse-model-routing.sh does not implement it). Added links to task-taxonomy.md in pulse-sweep.md and pulse.md.

## Files Changed

.agents/reference/task-taxonomy.md,.agents/workflows/pulse-sweep.md,.agents/workflows/pulse.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** markdownlint-cli2 passes with 0 errors on all three modified files

Resolves #19139


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.43 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-sonnet-4-6 spent 3m and 13,658 tokens on this as a headless worker.