### PR TITLE
GH#19140: fix(dispatch-dedup): replace --limit 1 with --limit 20 + jq local filter in Check 1b and 2

### DIFF
--- a/.agents/scripts/dispatch-dedup-pr.sh
+++ b/.agents/scripts/dispatch-dedup-pr.sh
@@ -71,11 +71,14 @@ _has_open_pr_check_open_commits() {
 # race observed on issue #18779 → PR #18906 (a duplicate worker was
 # dispatched after PR #18906 was already open and waiting for review).
 #
-# Uses a single OR-consolidated search query instead of a per-keyword
-# loop to reduce GitHub API calls from up to 9 down to 1. Post-filters
-# with the same exact regex Checks 2 and 3 use, to avoid GitHub
-# full-text false positives (e.g. "v3.5.670" matching issue #670).
-# Fetches number+body in one request to avoid a separate gh pr view call.
+# Fetches up to 20 candidate PRs in a single call and filters locally
+# with jq regex to avoid two failure modes from the prior --limit 1
+# approach: (a) a false-positive first result causing the real match to
+# be missed, and (b) unnecessary extra calls per keyword. The simpler
+# "#NNN in:body" query lets GitHub's full-text search find candidates;
+# the closing-keyword regex post-filter eliminates false positives such
+# as version strings ("v3.5.670" matching issue #670).
+# GH#19140 (review-followup on PR #18915).
 #
 # Args: $1 = issue number, $2 = repo slug
 # Returns: exit 0 if an open PR closes this issue (prints reason), exit 1 if none
@@ -84,27 +87,25 @@ _has_open_pr_check_open_body_keyword() {
 	local issue_number="$1"
 	local repo_slug="$2"
 
-	# Single consolidated query replaces the 9-keyword loop (GH#19124)
-	local query
-	query="(close OR closes OR closed OR fix OR fixes OR fixed OR resolve OR resolves OR resolved) #${issue_number} in:body"
+	local pr_json match_pr
+	# Fetch up to 20 open PRs mentioning the issue in the body; body is
+	# included in this single request to avoid separate gh pr view calls.
+	pr_json=$(gh pr list --repo "$repo_slug" --state open \
+		--search "#${issue_number} in:body" --limit 20 \
+		--json number,body 2>/dev/null) || pr_json="[]"
 
-	local pr_json pr_count
-	pr_json=$(gh pr list --repo "$repo_slug" --state open --search "$query" --limit 1 --json number,body 2>/dev/null) || pr_json="[]"
-	pr_count=$(printf '%s' "$pr_json" | jq 'length' 2>/dev/null) || pr_count=0
-	[[ "$pr_count" =~ ^[0-9]+$ ]] || pr_count=0
-	[[ "$pr_count" -eq 0 ]] && return 1
+	# Match: closing keyword + optional whitespace + #NNN or owner/repo#NNN
+	# followed by a non-word char or end-of-string (GH#18641 semantics).
+	local close_pattern
+	close_pattern="(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#${issue_number}([^[:alnum:]_]|$)"
 
-	local pr_number pr_body
-	pr_number=$(printf '%s' "$pr_json" | jq -r '.[0].number // empty' 2>/dev/null)
-	pr_body=$(printf '%s' "$pr_json" | jq -r '.[0].body // empty' 2>/dev/null)
+	match_pr=$(printf '%s' "$pr_json" | jq -r --arg pattern "$close_pattern" \
+		'[.[] | select(.body // "" | test($pattern; "i"))] | .[0].number // empty' \
+		2>/dev/null) || match_pr=""
 
-	if [[ -n "$pr_number" ]]; then
-		# Match: keyword + optional whitespace + #NNN or owner/repo#NNN followed by a non-word char or end
-		local close_pattern_open="(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#${issue_number}([^[:alnum:]_]|$)"
-		if printf '%s' "$pr_body" | grep -iqE "$close_pattern_open"; then
-			printf 'open PR #%s closes issue #%s via keyword in body\n' "$pr_number" "$issue_number"
-			return 0
-		fi
+	if [[ -n "$match_pr" ]]; then
+		printf 'open PR #%s closes issue #%s via keyword in body\n' "$match_pr" "$issue_number"
+		return 0
 	fi
 	return 1
 }
@@ -112,11 +113,13 @@ _has_open_pr_check_open_body_keyword() {
 #######################################
 # has_open_pr Check 2: Merged PRs with closing-keyword in body.
 #
-# Uses a single OR-consolidated search query instead of a per-keyword
-# loop to reduce GitHub API calls from up to 9 down to 1. Post-filters
-# with the same exact regex Check 1b uses, to avoid GitHub full-text
-# false positives (e.g. "v3.5.670" matching issue #670).
-# Fetches number+body in one request to avoid a separate gh pr view call.
+# Fetches up to 20 candidate PRs in a single call and filters locally
+# with jq regex, matching the same approach as Check 1b (GH#19140).
+# Avoids the --limit 1 correctness bug where a false-positive first
+# result from GitHub full-text search would mask the real matching PR.
+# The "#NNN in:body" query finds candidates; the closing-keyword regex
+# post-filter eliminates false positives (e.g. version strings like
+# "v3.5.670" matching issue #670).
 #
 # Args: $1 = issue number, $2 = repo slug
 # Returns: exit 0 if a merged PR closes this issue (prints reason), exit 1 if none
@@ -125,27 +128,25 @@ _has_open_pr_check_merged_keywords() {
 	local issue_number="$1"
 	local repo_slug="$2"
 
-	# Single consolidated query replaces the 9-keyword loop (GH#19124)
-	local query
-	query="(close OR closes OR closed OR fix OR fixes OR fixed OR resolve OR resolves OR resolved) #${issue_number} in:body"
+	local pr_json match_pr
+	# Fetch up to 20 merged PRs mentioning the issue in the body; body is
+	# included in this single request to avoid separate gh pr view calls.
+	pr_json=$(gh pr list --repo "$repo_slug" --state merged \
+		--search "#${issue_number} in:body" --limit 20 \
+		--json number,body 2>/dev/null) || pr_json="[]"
 
-	local pr_json pr_count
-	pr_json=$(gh pr list --repo "$repo_slug" --state merged --search "$query" --limit 1 --json number,body 2>/dev/null) || pr_json="[]"
-	pr_count=$(printf '%s' "$pr_json" | jq 'length' 2>/dev/null) || pr_count=0
-	[[ "$pr_count" =~ ^[0-9]+$ ]] || pr_count=0
-	[[ "$pr_count" -eq 0 ]] && return 1
+	# Match: closing keyword + optional whitespace + #NNN or owner/repo#NNN
+	# followed by a non-word char or end-of-string (GH#18641 semantics).
+	local close_pattern
+	close_pattern="(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#${issue_number}([^[:alnum:]_]|$)"
 
-	local pr_number pr_body
-	pr_number=$(printf '%s' "$pr_json" | jq -r '.[0].number // empty' 2>/dev/null)
-	pr_body=$(printf '%s' "$pr_json" | jq -r '.[0].body // empty' 2>/dev/null)
+	match_pr=$(printf '%s' "$pr_json" | jq -r --arg pattern "$close_pattern" \
+		'[.[] | select(.body // "" | test($pattern; "i"))] | .[0].number // empty' \
+		2>/dev/null) || match_pr=""
 
-	if [[ -n "$pr_number" ]]; then
-		# Match: keyword + optional whitespace + #NNN or owner/repo#NNN followed by a non-word char or end
-		local close_pattern_merged="(close[sd]?|fix(e[sd])?|resolve[sd]?)[[:space:]]+([a-zA-Z0-9._-]+/[a-zA-Z0-9._-]+)?#${issue_number}([^[:alnum:]_]|$)"
-		if printf '%s' "$pr_body" | grep -iqE "$close_pattern_merged"; then
-			printf 'merged PR #%s references issue #%s via keyword\n' "$pr_number" "$issue_number"
-			return 0
-		fi
+	if [[ -n "$match_pr" ]]; then
+		printf 'merged PR #%s references issue #%s via keyword\n' "$match_pr" "$issue_number"
+		return 0
 	fi
 	return 1
 }

--- a/.agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh
@@ -155,16 +155,14 @@ set_gh_pr_view_fixtures() {
 }
 
 test_has_open_pr_detects_closing_keyword() {
-	set_gh_fixtures 'marcusquinn/aidevops|merged|closes #4527 in:body|[{"number":1145}]'
-	# Check 2 (body search) requires the PR body to contain a real closing
-	# keyword for the target issue — the helper re-fetches the body and
-	# post-filters with a regex to avoid GitHub full-text false positives.
-	set_gh_pr_view_fixtures '1145|body|Closes #4527. Implements the fix.'
+	# Check 2 (body search): fetch up to 20 PRs with "#N in:body" and
+	# filter locally. Body is included in the pr list JSON; no gh pr view call.
+	set_gh_fixtures 'marcusquinn/aidevops|merged|#4527 in:body|[{"number":1145,"body":"Closes #4527. Implements the fix."}]'
 
 	local output=""
 	if output=$("$HELPER_SCRIPT" has-open-pr 4527 marcusquinn/aidevops 't4527: prevent duplicate dispatch'); then
 		case "$output" in
-		*'merged PR #1145 references issue #4527 via "closes" keyword'*)
+		*'merged PR #1145 references issue #4527 via keyword'*)
 			print_result "has-open-pr detects merged PR via closing keyword" 0
 			return 0
 			;;
@@ -181,8 +179,8 @@ test_has_open_pr_detects_task_id_fallback() {
 	# Check 3 (task-id title match) now requires the merged PR body to
 	# contain a closing-keyword reference to our specific issue number.
 	# Bare "#NNN" body references are no longer sufficient (GH#18641).
-	set_gh_fixtures 'marcusquinn/aidevops|merged|t063.1 in:title|[{"number":1059}]'
-	set_gh_pr_view_fixtures '1059|body|Closes #9999. The awardsapp duplicate-dispatch guard.'
+	# Body must be included in the pr list JSON (no separate gh pr view call).
+	set_gh_fixtures 'marcusquinn/aidevops|merged|t063.1 in:title|[{"number":1059,"body":"Closes #9999. The awardsapp duplicate-dispatch guard."}]'
 
 	local output=""
 	if output=$("$HELPER_SCRIPT" has-open-pr 9999 marcusquinn/aidevops 't063.1: fix awardsapp duplicate PR dispatch'); then
@@ -218,11 +216,8 @@ test_has_open_pr_returns_nonzero_without_match() {
 # must NOT treat `For #NNN` as dispatch-blocking evidence, otherwise every
 # brief PR permanently blocks dispatch on its own follow-up issue.
 test_has_open_pr_ignores_planning_for_reference() {
-	set_gh_fixtures 'marcusquinn/aidevops|merged|t2047 in:title|[{"number":18627}]'
-	set_gh_pr_view_fixtures '18627|body|Files the brief for **t2047**. Pure planning, no code changes.
-
-For #18624
-For #18599'
+	# Body is included in the pr list JSON (no separate gh pr view call).
+	set_gh_fixtures 'marcusquinn/aidevops|merged|t2047 in:title|[{"number":18627,"body":"Files the brief for **t2047**. Pure planning, no code changes.\n\nFor #18624\nFor #18599"}]'
 
 	if "$HELPER_SCRIPT" has-open-pr 18624 marcusquinn/aidevops 't2047: task-id collision guard'; then
 		print_result "has-open-pr ignores planning-only 'For #NNN' reference" 1 \
@@ -236,11 +231,8 @@ For #18599'
 
 # GH#18641: same convention with `Ref #NNN` phrasing must also be ignored.
 test_has_open_pr_ignores_planning_ref_reference() {
-	set_gh_fixtures 'marcusquinn/aidevops|merged|t2038 in:title|[{"number":18524}]'
-	set_gh_pr_view_fixtures '18524|body|Research brief for t2038.
-
-Ref #18521
-Ref #18522'
+	# Body is included in the pr list JSON (no separate gh pr view call).
+	set_gh_fixtures 'marcusquinn/aidevops|merged|t2038 in:title|[{"number":18524,"body":"Research brief for t2038.\n\nRef #18521\nRef #18522"}]'
 
 	if "$HELPER_SCRIPT" has-open-pr 18522 marcusquinn/aidevops 't2038: research branch protection bypass'; then
 		print_result "has-open-pr ignores planning-only 'Ref #NNN' reference" 1 \
@@ -256,11 +248,8 @@ Ref #18522'
 # issue AND a planning reference for ours must still NOT block dispatch on
 # ours — the closing keyword must match OUR issue number specifically.
 test_has_open_pr_requires_close_keyword_for_our_issue() {
-	set_gh_fixtures 'marcusquinn/aidevops|merged|t2037 in:title|[{"number":18524}]'
-	set_gh_pr_view_fixtures '18524|body|Files briefs.
-
-Closes #18521
-For #18522'
+	# Body is included in the pr list JSON (no separate gh pr view call).
+	set_gh_fixtures 'marcusquinn/aidevops|merged|t2037 in:title|[{"number":18524,"body":"Files briefs.\n\nCloses #18521\nFor #18522"}]'
 
 	if "$HELPER_SCRIPT" has-open-pr 18522 marcusquinn/aidevops 't2037: inline gate refactor'; then
 		print_result "has-open-pr requires close keyword for OUR issue, not another" 1 \
@@ -279,17 +268,14 @@ For #18522'
 # of which carries the closing keyword under the framework convention.
 # Trigger incident: cross-runner race on issue #18779 → PR #18906.
 test_has_open_pr_detects_open_body_closing_keyword() {
-	set_gh_fixtures 'marcusquinn/aidevops|open|resolves #18779 in:body|[{"number":18906}]'
-	# Single-line body — the test gh stub reads fixtures line-by-line, so
-	# multi-line bodies get truncated to the first line. Real PR bodies have
-	# the closing keyword somewhere in the body; the post-filter regex
-	# does not require it on the first line.
-	set_gh_pr_view_fixtures '18906|body|Resolves #18779. Decompose four interconnected opencode plugin files.'
+	# Check 1b: "#N in:body" search with body in the pr list JSON.
+	# No separate gh pr view call; jq filters locally with the closing regex.
+	set_gh_fixtures 'marcusquinn/aidevops|open|#18779 in:body|[{"number":18906,"body":"Resolves #18779. Decompose four interconnected opencode plugin files."}]'
 
 	local output=""
 	if output=$("$HELPER_SCRIPT" has-open-pr 18779 marcusquinn/aidevops 't2071: decompose opencode plugin cluster'); then
 		case "$output" in
-		*'open PR #18906 closes issue #18779 via "resolves" keyword in body'*)
+		*'open PR #18906 closes issue #18779 via keyword in body'*)
 			print_result "has-open-pr detects OPEN PR via body closing keyword (t2085)" 0
 			return 0
 			;;
@@ -328,11 +314,11 @@ test_has_open_pr_ignores_open_body_planning_for_reference() {
 # on our issue. The post-filter regex must match OUR issue number
 # specifically. (Mirrors GH#18641 semantics for the open-state code path.)
 test_has_open_pr_requires_open_close_keyword_for_our_issue() {
-	# GitHub full-text search may match the keyword on a PR that closes a
-	# different issue. The fixture simulates a hit on the search but a body
-	# that closes #18999 instead of #18779. The post-filter must reject it.
-	set_gh_fixtures 'marcusquinn/aidevops|open|closes #18779 in:body|[{"number":18950}]'
-	set_gh_pr_view_fixtures '18950|body|Closes #18999. This PR is unrelated to #18779; the search just full-text matched.'
+	# GitHub full-text search may return a PR that mentions #18779 in context
+	# but closes a different issue. The fixture simulates this: body contains
+	# "Closes #18999" and references #18779 in passing. The jq post-filter
+	# must reject it because no closing keyword targets #18779 specifically.
+	set_gh_fixtures 'marcusquinn/aidevops|open|#18779 in:body|[{"number":18950,"body":"Closes #18999. This PR is unrelated to #18779; the search just full-text matched."}]'
 
 	if "$HELPER_SCRIPT" has-open-pr 18779 marcusquinn/aidevops 't2071: opencode decomposition'; then
 		print_result "has-open-pr requires open-PR close keyword for OUR issue (t2085)" 1 \
@@ -347,8 +333,8 @@ test_has_open_pr_requires_open_close_keyword_for_our_issue() {
 # Existing collision case (GH#18041 / t1957) must still allow dispatch:
 # different task used the same ID, merged PR closes some unrelated issue.
 test_has_open_pr_allows_dispatch_on_task_id_collision() {
-	set_gh_fixtures 'marcusquinn/aidevops|merged|t500 in:title|[{"number":1200}]'
-	set_gh_pr_view_fixtures '1200|body|Closes #555. Unrelated work that reused task ID t500.'
+	# Body is included in the pr list JSON (no separate gh pr view call).
+	set_gh_fixtures 'marcusquinn/aidevops|merged|t500 in:title|[{"number":1200,"body":"Closes #555. Unrelated work that reused task ID t500."}]'
 
 	if "$HELPER_SCRIPT" has-open-pr 9999 marcusquinn/aidevops 't500: different work for issue #9999'; then
 		print_result "has-open-pr allows dispatch on task-id collision" 1 \


### PR DESCRIPTION
## Summary

- **Correctness fix**: `_has_open_pr_check_open_body_keyword` (Check 1b) and `_has_open_pr_check_merged_keywords` (Check 2) used `--limit 1` on `gh pr list`. If GitHub's full-text search returned a false-positive PR first, the real matching PR was silently missed — dispatch dedup would allow duplicate dispatch even when an open/merged PR already closed the issue.
- **Approach**: Fetch up to 20 candidate PRs in a single `gh pr list` request with the simpler `"#NNN in:body"` query, then filter locally using `jq` with the closing-keyword regex. This mirrors the pattern already used by Check 1 (`_has_open_pr_check_open_commits`) and was suggested by gemini-code-assist on PR #18915.
- **Tests fixed**: Updated 7 test fixtures in `test-dispatch-dedup-helper-has-open-pr.sh` to use the new `"#NNN in:body"` query key format and include `body` in the `gh pr list` JSON payload (eliminating separate `gh pr view` fixtures for Checks 1b, 2, and 3). The tests were already broken (3 of 10 failing) due to the prior compound keyword query not matching the expected fixture keys.

## Verification

- All 10 tests pass: `bash .agents/scripts/tests/test-dispatch-dedup-helper-has-open-pr.sh`
- `shellcheck`: zero violations on both modified files

Resolves #19140