### PR TITLE
GH#19203: refactor(agent-deploy): extract _atomic_stage_and_deploy_agents() to reduce deploy_aidevops_agents() from 107 to 65 lines

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1,7560 +1,7565 @@
 {
+  ".agents/content/youtube-setup.md": {
+    "hash": "a73a56209534a71e05ed6485880b63e0439f4d3c0cb0abb93dafb55abe2179f5",
+    "lines": 94,
+    "status": "simplified"
+  },
+  ".agents/reference/bash-fd-locking.md": {
+    "action": "tightened",
+    "hash": "79e0a0a74b3e71f24fe2bfcea539a2d300a010a19dd5e5e94d48a516f8f79ba2",
+    "issue": "GH#18711",
+    "lines_after": 54,
+    "lines_before": 58
+  },
+  ".agents/services/hosting/cloudflare-platform-skill/ai-search-patterns.md": {
+    "hash": "867d8ff77f341ac99f155db719644f2190031e9faa7e6668a79b05468b0eae0f",
+    "issue": "GH#17305",
+    "lines": 80,
+    "status": "simplified"
+  },
+  ".agents/tools/credentials/cch-reverse-engineering.md": {
+    "at": "2026-04-04T04:17:32Z",
+    "hash": "6c57da6128787628b2d18755062d669275b3c3e7",
+    "passes": 1,
+    "pr": 17052
+  },
+  ".agents/tools/design/library/brands/claude/04-components.md": {
+    "hash": "9eb6ea4ffeea8ec04d546c77c3cac26f47f6a829ac1e512a5347b65c10d589a8",
+    "issue": "GH#17241",
+    "lines": 47,
+    "status": "simplified"
+  },
+  ".agents/tools/design/library/brands/clickhouse/DESIGN.md": {
+    "action": "split-into-chapters",
+    "chapters": 9,
+    "hash": "9717274b7c2b1cd74aadb4acb865a7ee75667056ad74427552aa817e61aa6ed8",
+    "issue": "GH#16973",
+    "status": "restructured"
+  },
+  ".agents/tools/design/library/brands/ibm/04-components.md": {
+    "at": "2026-04-04T08:10:00Z",
+    "hash": "b402836b6b2f4ba9d95da181a22d3ce596d62b74",
+    "issue": "GH#17202",
+    "lines": 67,
+    "passes": 1,
+    "status": "simplified"
+  },
+  ".agents/tools/design/library/brands/linear/02-colour-palette.md": {
+    "hash": "13573ea17cdd090fbed89523845d463c0803e4d0",
+    "issue": "GH#17279",
+    "lines": 66,
+    "status": "simplified"
+  },
+  ".agents/tools/design/library/brands/resend/04-components.md": {
+    "hash": "3a892bf3ecbfeae70118a269688f23838a595081c9d8449d6143222bf7351bc7",
+    "issue": "GH#17090",
+    "lines": 54,
+    "status": "simplified"
+  },
+  ".agents/tools/design/library/brands/uber/04-components.md": {
+    "action": "tighten-cross-reference",
+    "hash": "4147e5ab87509d6727816c032f7148b2408c5b8b305e041a853ba1e80cbd0344",
+    "issue": "GH#17205",
+    "status": "simplified"
+  },
+  ".agents/tools/design/library/brands/voltagent/02-color-palette.md": {
+    "hash": "5c631b0685456a768ee6eb1b424fae8551e315862ab8e7c14f310d9de19114f0",
+    "issue": "GH#17207",
+    "status": "simplified"
+  },
+  ".agents/tools/design/library/brands/voltagent/04-components.md": {
+    "hash": "5924a4019120998ccd7979d148eab0bc4b7969bd191347ce3cf3049e1ecb2876",
+    "issue": "GH#17239",
+    "lines": 82,
+    "status": "simplified"
+  },
+  ".agents/tools/design/library/styles/agency-feminine/02-colours.md": {
+    "action": "added CSS variables quick-reference section",
+    "hash": "a5a882ed5c947e5745b0f212138c772ec74268d8061d39f6551f8c13a7e3b9fd",
+    "issue": "GH#17255",
+    "simplified_at": "2026-04-04T00:00:00Z"
+  },
+  ".agents/tools/design/library/styles/corporate-traditional/02-colours.md": {
+    "action": "added CSS variables quick-reference section",
+    "hash": "83084b6d85338c961b19752ae5c0e7842d88b14fe7be78121b6d049f2fbf4c3c",
+    "issue": "GH#17122",
+    "simplified_at": "2026-04-04T06:22:35Z"
+  },
+  ".agents/tools/design/library/styles/startup-bold/09-agent-prompts.md": {
+    "at": "2026-04-04T07:30:00Z",
+    "hash": "1b9cf446793ee167529b914a5438353e97c92f4a",
+    "issue": "GH#17125",
+    "lines": 30,
+    "passes": 1,
+    "status": "simplified"
+  },
   "files": {
-    ".agents/tools/design/library/brands/nvidia/08-responsive.md": {
-      "hash": "96c3efbd674eb1018e98362eb46728faf459e014",
-      "at": "2026-04-04T00:00:00Z",
-      "passes": 1,
-      "pr": 0
-    },
     ".agents/aidevops.md": {
-      "hash": "6c034fc8cc954d733a8666b295a66fb3d8c291f5",
       "at": "2026-04-11T17:01:17Z",
+      "hash": "6c034fc8cc954d733a8666b295a66fb3d8c291f5",
       "passes": 3,
       "pr": 13063
     },
     ".agents/aidevops/add-new-mcp-to-aidevops.md": {
-      "hash": "a4b49d28fb6fece79797c4ca8f7f996801a980cd",
       "at": "2026-03-28T16:41:22Z",
+      "hash": "a4b49d28fb6fece79797c4ca8f7f996801a980cd",
       "passes": 1,
       "pr": 12006
     },
     ".agents/aidevops/agent-sources.md": {
-      "hash": "dc7f85473c05587be8aab0df6ed95b74bba38fad",
       "at": "2026-03-31T05:32:40Z",
+      "hash": "dc7f85473c05587be8aab0df6ed95b74bba38fad",
       "passes": 2,
       "pr": 14645
     },
     ".agents/aidevops/api-integrations.md": {
-      "hash": "acac4aadeb69f1e9a336b6c2bdf4b9c8da50c2a1",
       "at": "2026-04-03T11:53:46Z",
+      "hash": "acac4aadeb69f1e9a336b6c2bdf4b9c8da50c2a1",
       "passes": 3,
       "pr": 0
     },
     ".agents/aidevops/architecture.md": {
-      "hash": "4ea26b2697f599fad2e9e6e8d3617b6a04829cb5",
       "at": "2026-04-15T00:40:54Z",
+      "hash": "4ea26b2697f599fad2e9e6e8d3617b6a04829cb5",
       "passes": 3,
       "pr": 13445
     },
     ".agents/aidevops/configs.md": {
-      "hash": "f6a669154e3e66788c660cb236f53155eeb80bf6",
       "at": "2026-03-28T15:30:49Z",
+      "hash": "f6a669154e3e66788c660cb236f53155eeb80bf6",
       "passes": 1,
       "pr": 11897
     },
+    ".agents/aidevops/docs.md": {
+      "at": "2026-04-03T19:14:46Z",
+      "hash": "e0e1c0c4ff9224285ef30fa1f219801fac5a1d65",
+      "passes": 1,
+      "pr": 16822
+    },
     ".agents/aidevops/extension.md": {
-      "hash": "783785e62b1d747edc9d547f29851d2ff2623c70",
       "at": "2026-03-28T08:58:33Z",
+      "hash": "783785e62b1d747edc9d547f29851d2ff2623c70",
       "passes": 1,
       "pr": 11565
     },
+    ".agents/aidevops/graduated-learnings.md": {
+      "at": "2026-04-03T19:14:47Z",
+      "hash": "a8a3e687e971f72f483c8c6ea397dc19f60e0ed8",
+      "passes": 1,
+      "pr": 16754
+    },
     ".agents/aidevops/mcp-integrations.md": {
-      "hash": "56454827b0afc024803b135a6659f4c02cd1d677",
       "at": "2026-03-28T03:53:54Z",
+      "hash": "56454827b0afc024803b135a6659f4c02cd1d677",
       "passes": 2,
       "pr": 11339
     },
     ".agents/aidevops/mcp-troubleshooting.md": {
-      "hash": "e81ce7cf9466f000ef396eed4cfcd755a3c6689b",
       "at": "2026-03-31T08:03:51Z",
+      "hash": "e81ce7cf9466f000ef396eed4cfcd755a3c6689b",
       "passes": 2,
       "pr": 14740
     },
     ".agents/aidevops/onboarding.md": {
-      "hash": "edc0426c99b20b11291975675963c0880b257259",
       "at": "2026-03-29T07:02:21Z",
+      "hash": "edc0426c99b20b11291975675963c0880b257259",
       "passes": 2,
       "pr": 12641
     },
+    ".agents/aidevops/orchestration-analysis.md": {
+      "at": "2026-04-03T13:35:13Z",
+      "hash": "301d67af6b97b0bdad11118129c0fef7082763fb",
+      "passes": 1,
+      "pr": 16584
+    },
     ".agents/aidevops/plugins.md": {
-      "hash": "5a5b25b363591ea8e02ce5b36cf59d4efa48cd31",
       "at": "2026-03-28T14:15:43Z",
+      "hash": "5a5b25b363591ea8e02ce5b36cf59d4efa48cd31",
       "passes": 1,
       "pr": 11894
     },
     ".agents/aidevops/providers.md": {
-      "hash": "61b9f29a8777b192a13599e980e59eeb502e41dc",
       "at": "2026-03-27T21:25:09Z",
+      "hash": "61b9f29a8777b192a13599e980e59eeb502e41dc",
       "passes": 1,
       "pr": 11003
     },
     ".agents/aidevops/recommendations.md": {
-      "hash": "e9e5ec8f6164c76f559470db06dc0454a946a2b9",
       "at": "2026-03-28T03:54:11Z",
+      "hash": "e9e5ec8f6164c76f559470db06dc0454a946a2b9",
       "passes": 1,
       "pr": 11343
     },
     ".agents/aidevops/requirements.md": {
-      "hash": "5bcde624d34af1b444550375db48fa40b85c3790",
       "at": "2026-03-28T11:52:46Z",
+      "hash": "5bcde624d34af1b444550375db48fa40b85c3790",
       "passes": 1,
       "pr": 11770
     },
     ".agents/aidevops/resources.md": {
-      "hash": "ca40e02e1f9d2e8bd3fac560267b6d792bd42fcd",
       "at": "2026-03-28T21:58:59Z",
+      "hash": "ca40e02e1f9d2e8bd3fac560267b6d792bd42fcd",
       "passes": 1,
       "pr": 12244
     },
     ".agents/aidevops/security-requirements.md": {
-      "hash": "205d7c21a93dc50c4026fcf5305ebbb05b81bbf1",
       "at": "2026-03-29T12:37:08Z",
+      "hash": "205d7c21a93dc50c4026fcf5305ebbb05b81bbf1",
       "passes": 1,
       "pr": 12946
     },
     ".agents/aidevops/security.md": {
-      "hash": "abc6f4239c8357fbf4c0073622c66ebdbe916333",
       "at": "2026-04-03T11:54:15Z",
+      "hash": "abc6f4239c8357fbf4c0073622c66ebdbe916333",
       "passes": 1,
       "pr": 16429
     },
     ".agents/aidevops/self-improving-agents.md": {
-      "hash": "ad442435a319c5f76f1260cdf53d65e6a407c37f",
       "at": "2026-04-01T20:59:02Z",
+      "hash": "ad442435a319c5f76f1260cdf53d65e6a407c37f",
       "passes": 1,
       "pr": 15203
     },
     ".agents/aidevops/service-links.md": {
-      "hash": "2e99ce25c7f0d34072534a468468af1bbe9d0ef2",
       "at": "2026-04-03T11:54:16Z",
+      "hash": "2e99ce25c7f0d34072534a468468af1bbe9d0ef2",
       "passes": 1,
       "pr": 16410
     },
     ".agents/aidevops/services.md": {
-      "hash": "222988fe85ded754b7c39d9fd59b6abcc5128146",
       "at": "2026-03-27T21:25:10Z",
+      "hash": "222988fe85ded754b7c39d9fd59b6abcc5128146",
       "passes": 1,
       "pr": 11004
     },
+    ".agents/aidevops/setup.md": {
+      "at": "2026-04-03T19:14:47Z",
+      "hash": "7d116c37d7cf28b5f444bd5b0871e6d5da12a184",
+      "passes": 1,
+      "pr": 16749
+    },
     ".agents/aidevops/troubleshooting.md": {
-      "hash": "6846f0349c36848197345f91e754d3f7d07cc6de",
       "at": "2026-03-28T16:00:22Z",
+      "hash": "6846f0349c36848197345f91e754d3f7d07cc6de",
       "passes": 1,
       "pr": 11982
     },
     ".agents/automate.md": {
-      "hash": "b0865c65a1a0e0f579e68be0db05a8b79d46dbe5",
       "at": "2026-04-11T17:01:18Z",
+      "hash": "b0865c65a1a0e0f579e68be0db05a8b79d46dbe5",
       "passes": 6,
       "pr": 15804
     },
     ".agents/build-plus.md": {
-      "hash": "a157ac23bc7f9d042eefd0c5418af9fb60d82aff",
       "at": "2026-04-11T05:05:43Z",
+      "hash": "a157ac23bc7f9d042eefd0c5418af9fb60d82aff",
       "passes": 3,
       "pr": 13101
     },
     ".agents/business.md": {
-      "hash": "dae5291987de357f73ae79460b5e990b125cf143",
       "at": "2026-04-11T17:01:18Z",
+      "hash": "dae5291987de357f73ae79460b5e990b125cf143",
       "passes": 3,
       "pr": 13055
     },
     ".agents/business/accounts-receipt-ocr.md": {
-      "hash": "85396dc720574178abc734adf590b980ff764355",
       "at": "2026-03-28T16:41:24Z",
+      "hash": "85396dc720574178abc734adf590b980ff764355",
       "passes": 1,
       "pr": 12020
     },
     ".agents/business/accounts-subscription-audit.md": {
-      "hash": "4d9f770ae1085bc698e19b90b4bb3a55aa9f256a",
       "at": "2026-03-29T21:43:19Z",
+      "hash": "4d9f770ae1085bc698e19b90b4bb3a55aa9f256a",
       "passes": 1,
       "pr": 13235
     },
     ".agents/business/company-runners.md": {
-      "hash": "b72e96f07c3612d474e3fccbcfa4b58277ff7e8c",
       "at": "2026-03-28T11:52:25Z",
+      "hash": "b72e96f07c3612d474e3fccbcfa4b58277ff7e8c",
       "passes": 1,
       "pr": 11812
     },
-    ".agents/content.md": {
+    ".agents/commands/AGENTS.md": {
+      "at": "2026-04-15T22:51:44Z",
+      "hash": "ce01ce671b7c7eee80020ba2c94938751f844880",
+      "passes": 14,
+      "pr": 18117
+    },
+    ".agents/commands/aidevops-automate.md": {
+      "at": "2026-04-11T17:01:18Z",
+      "hash": "b0865c65a1a0e0f579e68be0db05a8b79d46dbe5",
+      "passes": 2,
+      "pr": 18162
+    },
+    ".agents/commands/aidevops-build-plus.md": {
+      "at": "2026-04-11T05:06:05Z",
+      "hash": "a157ac23bc7f9d042eefd0c5418af9fb60d82aff",
+      "passes": 1,
+      "pr": 18134
+    },
+    ".agents/commands/aidevops-business.md": {
+      "at": "2026-04-11T17:01:18Z",
+      "hash": "dae5291987de357f73ae79460b5e990b125cf143",
+      "passes": 2,
+      "pr": 18208
+    },
+    ".agents/commands/aidevops-content.md": {
+      "at": "2026-04-11T05:06:05Z",
       "hash": "f7e23347c89761072bb648938dc2cc59d5a8c906",
+      "passes": 1,
+      "pr": 18146
+    },
+    ".agents/commands/aidevops-framework.md": {
+      "at": "2026-04-11T17:01:18Z",
+      "hash": "6c034fc8cc954d733a8666b295a66fb3d8c291f5",
+      "passes": 3,
+      "pr": 18224
+    },
+    ".agents/commands/aidevops-legal.md": {
+      "at": "2026-04-11T17:01:18Z",
+      "hash": "278f1357743e4be7e4c36b0cc98cb3022db7130f",
+      "passes": 3,
+      "pr": 18227
+    },
+    ".agents/commands/aidevops-marketing-sales.md": {
+      "at": "2026-04-11T13:54:28Z",
+      "hash": "1f8a5d943028b36f9ae687dd4e3fd871e1b8753d",
+      "passes": 1,
+      "pr": 18161
+    },
+    ".agents/commands/aidevops-research.md": {
+      "at": "2026-04-11T17:01:18Z",
+      "hash": "e30f6a29668b78be4808c38b12913ffaa49e6562",
+      "passes": 2,
+      "pr": 18272
+    },
+    ".agents/commands/aidevops-seo.md": {
+      "at": "2026-04-11T17:01:18Z",
+      "hash": "5181e08f7fb9475fa9cce94a9359b1ae0c8703ac",
+      "passes": 2,
+      "pr": 18173
+    },
+    ".agents/commands/aidevops.md": {
+      "at": "2026-04-11T17:01:18Z",
+      "hash": "6c034fc8cc954d733a8666b295a66fb3d8c291f5",
+      "passes": 3,
+      "pr": 18223
+    },
+    ".agents/commands/automate.md": {
+      "at": "2026-04-11T17:01:18Z",
+      "hash": "b0865c65a1a0e0f579e68be0db05a8b79d46dbe5",
+      "passes": 3,
+      "pr": 18160
+    },
+    ".agents/commands/build-plus.md": {
+      "at": "2026-04-11T05:05:43Z",
+      "hash": "a157ac23bc7f9d042eefd0c5418af9fb60d82aff",
+      "passes": 2,
+      "pr": 18133
+    },
+    ".agents/commands/business.md": {
+      "at": "2026-04-11T17:01:18Z",
+      "hash": "dae5291987de357f73ae79460b5e990b125cf143",
+      "passes": 3,
+      "pr": 18189
+    },
+    ".agents/commands/content.md": {
       "at": "2026-04-11T06:18:00Z",
+      "hash": "f7e23347c89761072bb648938dc2cc59d5a8c906",
+      "passes": 1,
+      "pr": 18151
+    },
+    ".agents/commands/health.md": {
+      "at": "2026-04-11T16:20:18Z",
+      "hash": "8a06d2322341437c1e6bf9e560339646ba6c7fe0",
+      "passes": 1,
+      "pr": 18292
+    },
+    ".agents/commands/legal.md": {
+      "at": "2026-04-11T17:01:18Z",
+      "hash": "278f1357743e4be7e4c36b0cc98cb3022db7130f",
+      "passes": 2,
+      "pr": 18226
+    },
+    ".agents/commands/marketing-sales.md": {
+      "at": "2026-04-11T10:09:10Z",
+      "hash": "1f8a5d943028b36f9ae687dd4e3fd871e1b8753d",
+      "passes": 1,
+      "pr": 18159
+    },
+    ".agents/commands/research.md": {
+      "at": "2026-04-11T17:01:19Z",
+      "hash": "e30f6a29668b78be4808c38b12913ffaa49e6562",
+      "passes": 2,
+      "pr": 18271
+    },
+    ".agents/commands/seo.md": {
+      "at": "2026-04-11T17:01:19Z",
+      "hash": "5181e08f7fb9475fa9cce94a9359b1ae0c8703ac",
+      "passes": 3,
+      "pr": 18172
+    },
+    ".agents/configs/complexity-thresholds-history.md": {
+      "at": "2026-04-15T22:51:45Z",
+      "hash": "926a520d5bc815afd92ea09c1c54b21f0e45936f",
+      "passes": 17,
+      "pr": 17979
+    },
+    ".agents/content.md": {
+      "at": "2026-04-11T06:18:00Z",
+      "hash": "f7e23347c89761072bb648938dc2cc59d5a8c906",
       "passes": 2,
       "pr": 18151
     },
     ".agents/content/VERIFICATION.md": {
-      "hash": "7655c81844c3caf3331276a85900e09e2341a907",
       "at": "2026-03-30T03:34:30Z",
+      "hash": "7655c81844c3caf3331276a85900e09e2341a907",
       "passes": 1,
       "pr": 13540
     },
     ".agents/content/content-calendar.md": {
-      "hash": "1ba17dca692533f38147394c186253e6a93b089e",
       "at": "2026-03-29T15:50:25Z",
+      "hash": "1ba17dca692533f38147394c186253e6a93b089e",
       "passes": 1,
       "pr": 13052
     },
     ".agents/content/context-templates.md": {
-      "hash": "b2acbf3e06a329fc89741555a45aed23fe3e7941",
       "at": "2026-04-02T04:00:00Z",
+      "hash": "b2acbf3e06a329fc89741555a45aed23fe3e7941",
       "passes": 2,
       "pr": 14934
     },
     ".agents/content/distribution-blog.md": {
-      "hash": "53eed563ee4b0b8531ddb2c98bc79421d329809b",
       "at": "2026-04-03T04:23:06Z",
+      "hash": "53eed563ee4b0b8531ddb2c98bc79421d329809b",
       "passes": 1,
       "pr": 15909
     },
     ".agents/content/distribution-email.md": {
-      "hash": "3e11807e23df145fd09883d0c32275e9e92499a9",
       "at": "2026-03-28T16:00:42Z",
+      "hash": "3e11807e23df145fd09883d0c32275e9e92499a9",
       "passes": 1,
       "pr": 11989
     },
     ".agents/content/distribution-podcast.md": {
-      "hash": "9b972d5e296eae5e1faa574514efb29934932a43",
       "at": "2026-03-29T07:02:57Z",
+      "hash": "9b972d5e296eae5e1faa574514efb29934932a43",
       "passes": 1,
       "pr": 12557
     },
     ".agents/content/distribution-short-form.md": {
-      "hash": "47793561cbf438ff2f77cc86cb5e431f3bf90ead",
       "at": "2026-03-28T20:16:49Z",
+      "hash": "47793561cbf438ff2f77cc86cb5e431f3bf90ead",
       "passes": 1,
       "pr": 12172
     },
     ".agents/content/distribution-social.md": {
-      "hash": "1c701b07899e27c5362c4a10021c092dc4318319",
       "at": "2026-03-28T11:20:38Z",
+      "hash": "1c701b07899e27c5362c4a10021c092dc4318319",
       "passes": 1,
       "pr": 11733
     },
     ".agents/content/distribution-youtube-channel-intel.md": {
-      "hash": "1e0cee3c6182c1359e7c9c510d66fcd5f690e941",
       "at": "2026-03-29T12:37:24Z",
+      "hash": "1e0cee3c6182c1359e7c9c510d66fcd5f690e941",
       "passes": 1,
       "pr": 12791
     },
     ".agents/content/distribution-youtube-optimizer.md": {
-      "hash": "14963989c188f56b64bf31d83d285c63cd2f13f6",
       "at": "2026-03-28T11:20:34Z",
+      "hash": "14963989c188f56b64bf31d83d285c63cd2f13f6",
       "passes": 1,
       "pr": 11731
     },
     ".agents/content/distribution-youtube-pipeline.md": {
-      "hash": "39ee0b7331d9c1e0e2668557af635d5661695a7f",
       "at": "2026-04-03T01:11:18Z",
+      "hash": "39ee0b7331d9c1e0e2668557af635d5661695a7f",
       "passes": 2,
       "pr": 11763
     },
     ".agents/content/distribution-youtube-readme.md": {
-      "hash": "a82973783a3816eedb7316df37b98b3ee2eca647",
       "at": "2026-04-03T01:53:22Z",
+      "hash": "a82973783a3816eedb7316df37b98b3ee2eca647",
       "passes": 1,
       "pr": 15971
     },
     ".agents/content/distribution-youtube-script-writer.md": {
-      "hash": "691b31fc97a8295d0e02c5864cc1e85252bfa742",
       "at": "2026-03-28T08:58:46Z",
+      "hash": "691b31fc97a8295d0e02c5864cc1e85252bfa742",
       "passes": 1,
       "pr": 11603
     },
     ".agents/content/distribution-youtube-topic-research.md": {
-      "hash": "0a1f4176baf13e36e4cf79c9198fee1a2e50ad39",
       "at": "2026-03-28T11:20:29Z",
+      "hash": "0a1f4176baf13e36e4cf79c9198fee1a2e50ad39",
       "passes": 1,
       "pr": 11801
     },
     ".agents/content/distribution-youtube.md": {
-      "hash": "f06682072fe32aa86778df1ca45e035cfcdb18a2",
       "at": "2026-03-29T01:03:19Z",
+      "hash": "f06682072fe32aa86778df1ca45e035cfcdb18a2",
       "passes": 1,
       "pr": 12386
     },
     ".agents/content/editor.md": {
-      "hash": "13188b9eff3d8ea93564930a825b2779e2852d96",
       "at": "2026-04-02T16:30:00Z",
+      "hash": "13188b9eff3d8ea93564930a825b2779e2852d96",
       "passes": 1
     },
     ".agents/content/guidelines.md": {
-      "hash": "e747da391d2bf2597f2b1edfcd3276b511fc6447",
       "at": "2026-04-03T12:15:32Z",
+      "hash": "e747da391d2bf2597f2b1edfcd3276b511fc6447",
       "passes": 1,
       "pr": 16557
     },
     ".agents/content/heygen-skill/rules-assets.md": {
-      "hash": "1c095d030e090e0b351892b7c42dd437ed310a9a",
       "at": "2026-03-29T16:34:55Z",
+      "hash": "1c095d030e090e0b351892b7c42dd437ed310a9a",
       "passes": 1,
       "pr": 13054
     },
     ".agents/content/heygen-skill/rules-authentication.md": {
-      "hash": "59492b2140b65569189f0521bb7831a562d7d0e4",
       "at": "2026-04-03T03:15:28Z",
+      "hash": "59492b2140b65569189f0521bb7831a562d7d0e4",
       "passes": 1,
       "pr": 15871
     },
     ".agents/content/heygen-skill/rules-avatars.md": {
-      "hash": "8c16acf4b6779e01e897446cc870864558db7cdf",
       "at": "2026-03-29T07:02:16Z",
+      "hash": "8c16acf4b6779e01e897446cc870864558db7cdf",
       "passes": 1,
       "pr": 12654
     },
     ".agents/content/heygen-skill/rules-backgrounds.md": {
-      "hash": "f47f567b10adca87685db78c29d6ccfa45a11a79",
       "at": "2026-03-28T09:17:34Z",
+      "hash": "f47f567b10adca87685db78c29d6ccfa45a11a79",
       "passes": 1,
       "pr": 11711
     },
     ".agents/content/heygen-skill/rules-captions.md": {
-      "hash": "c3f274850814a452931d26749c7e0cfabf07a9ea",
       "at": "2026-03-28T09:48:53Z",
+      "hash": "c3f274850814a452931d26749c7e0cfabf07a9ea",
       "passes": 1,
       "pr": 11707
     },
     ".agents/content/heygen-skill/rules-dimensions.md": {
-      "hash": "b03f683109330a6ac902d9c34d5d9e2be395f21e",
       "at": "2026-03-28T08:18:14Z",
+      "hash": "b03f683109330a6ac902d9c34d5d9e2be395f21e",
       "passes": 1,
       "pr": 11610
     },
     ".agents/content/heygen-skill/rules-photo-avatars.md": {
-      "hash": "a8be11a7ccb72cb1e026da01e00f9998d8c8cfb9",
       "at": "2026-03-29T07:03:00Z",
+      "hash": "a8be11a7ccb72cb1e026da01e00f9998d8c8cfb9",
       "passes": 1,
       "pr": 12620
     },
     ".agents/content/heygen-skill/rules-quota.md": {
-      "hash": "ca715a08dbd724e9448b3e6b105b83b55c7dc3e7",
       "at": "2026-03-29T07:02:38Z",
+      "hash": "ca715a08dbd724e9448b3e6b105b83b55c7dc3e7",
       "passes": 1,
       "pr": 12592
     },
     ".agents/content/heygen-skill/rules-remotion-integration.md": {
-      "hash": "69b5d915c1d9336cfab0958633547830567bb205",
       "at": "2026-03-28T10:27:14Z",
+      "hash": "69b5d915c1d9336cfab0958633547830567bb205",
       "passes": 1,
       "pr": 11740
     },
     ".agents/content/heygen-skill/rules-scripts.md": {
-      "hash": "0676ac9fd6c9b9fa5e9154e679dde1739147652c",
       "at": "2026-03-30T04:51:44Z",
+      "hash": "0676ac9fd6c9b9fa5e9154e679dde1739147652c",
       "passes": 2,
       "pr": 13767
     },
+    ".agents/content/heygen-skill/rules-streaming-avatars.md": {
+      "at": "2026-04-03T13:35:13Z",
+      "hash": "e65aa18fda497652c82195557641371fb1db09bd",
+      "passes": 1,
+      "pr": 16581
+    },
     ".agents/content/heygen-skill/rules-templates.md": {
-      "hash": "8ca3b5ac246c71cc2991ebbcce4580154b0e90e2",
       "at": "2026-03-29T08:10:46Z",
+      "hash": "8ca3b5ac246c71cc2991ebbcce4580154b0e90e2",
       "passes": 1,
       "pr": 12738
     },
     ".agents/content/heygen-skill/rules-text-overlays.md": {
-      "hash": "183aa7bdac32f083bd9ecb9309e63c3a9381c876",
       "at": "2026-04-03T04:23:07Z",
+      "hash": "183aa7bdac32f083bd9ecb9309e63c3a9381c876",
       "passes": 1,
       "pr": 15821
     },
     ".agents/content/heygen-skill/rules-video-agent.md": {
-      "hash": "2afd834c014ffe26e7b069d6ea4db7dd83e3428a",
       "at": "2026-03-29T07:31:38Z",
+      "hash": "2afd834c014ffe26e7b069d6ea4db7dd83e3428a",
       "passes": 1,
       "pr": 12706
     },
     ".agents/content/heygen-skill/rules-video-generation.md": {
-      "hash": "c8fb6c04d69c2a44b4d7ca88688b319fb0667405",
       "at": "2026-03-28T10:27:38Z",
+      "hash": "c8fb6c04d69c2a44b4d7ca88688b319fb0667405",
       "passes": 1,
       "pr": 11675
     },
     ".agents/content/heygen-skill/rules-video-status.md": {
-      "hash": "4280f51762bb02a73b52e352d33c3b66949ffa17",
       "at": "2026-04-03T11:54:16Z",
+      "hash": "4280f51762bb02a73b52e352d33c3b66949ffa17",
       "passes": 1,
       "pr": 16409
     },
     ".agents/content/heygen-skill/rules-video-translation.md": {
-      "hash": "9388f6ede19d07045427e82d9c52824a41e44199",
       "at": "2026-03-29T03:15:05Z",
+      "hash": "9388f6ede19d07045427e82d9c52824a41e44199",
       "passes": 1,
       "pr": 12504
     },
     ".agents/content/heygen-skill/rules-voices.md": {
-      "hash": "c2a4cee81c000a0c0b173e2dec32ebed4695d3ae",
       "at": "2026-03-29T07:02:36Z",
+      "hash": "c2a4cee81c000a0c0b173e2dec32ebed4695d3ae",
       "passes": 1,
       "pr": 12577
     },
     ".agents/content/heygen-skill/rules-webhooks.md": {
-      "hash": "b70469b0bb16ef23c7f71ccda772d6b7ed82b30e",
       "at": "2026-03-30T06:49:23Z",
+      "hash": "b70469b0bb16ef23c7f71ccda772d6b7ed82b30e",
       "passes": 1,
       "pr": 13942
     },
     ".agents/content/humanise.md": {
-      "hash": "f1af67e01f2901a1748a37ce5e568b056087443a",
       "at": "2026-03-30T06:03:20Z",
+      "hash": "f1af67e01f2901a1748a37ce5e568b056087443a",
       "passes": 1,
       "pr": 13836
     },
+    ".agents/content/internal-linker.md": {
+      "at": "2026-04-03T16:35:53Z",
+      "hash": "a9bac8ce4b2b37c9335ca62ee29ed9d7e80198a2",
+      "passes": 1,
+      "pr": 16674
+    },
     ".agents/content/meta-creator.md": {
-      "hash": "60c84a76e37070c4ce72ed347867a4c0654a9a40",
       "at": "2026-04-03T01:11:47Z",
+      "hash": "60c84a76e37070c4ce72ed347867a4c0654a9a40",
       "passes": 1,
       "pr": 15781
     },
     ".agents/content/optimization.md": {
-      "hash": "c84ba56a45f99c4f2b2b1625369e73d65e9e18bf",
       "at": "2026-03-29T23:18:03Z",
+      "hash": "c84ba56a45f99c4f2b2b1625369e73d65e9e18bf",
       "passes": 1,
       "pr": 13425
     },
     ".agents/content/platform-personas.md": {
-      "hash": "f5446d15c6fbf451f4fb33db65c7c919a72cc247",
       "at": "2026-04-02T21:19:52Z",
+      "hash": "f5446d15c6fbf451f4fb33db65c7c919a72cc247",
       "passes": 2,
       "pr": 12167
     },
     ".agents/content/production-audio.md": {
-      "hash": "0ec6e212a5b61b28b55d1b9b5a00d30fefe46c5a",
       "at": "2026-03-30T00:32:17Z",
+      "hash": "0ec6e212a5b61b28b55d1b9b5a00d30fefe46c5a",
       "passes": 2,
       "pr": 13478
     },
     ".agents/content/production-characters.md": {
-      "hash": "958dad3a214c09d7dee4bc0ff7b4ce800a108a17",
       "at": "2026-03-28T16:40:48Z",
+      "hash": "958dad3a214c09d7dee4bc0ff7b4ce800a108a17",
       "passes": 1,
       "pr": 12025
     },
     ".agents/content/production-image.md": {
-      "hash": "df6692dd0b7c09660c702c1bc9e6df69406eae65",
       "at": "2026-03-28T16:40:38Z",
+      "hash": "df6692dd0b7c09660c702c1bc9e6df69406eae65",
       "passes": 1,
       "pr": 12023
     },
+    ".agents/content/production-video-02-sora-template.md": {
+      "at": "2026-04-03T19:14:11Z",
+      "hash": "6ed53879e11be03a1f63e996fe507171f0e292ce",
+      "passes": 1
+    },
     ".agents/content/production-video-08-talking-head-pipeline.md": {
-      "hash": "810594526118bfefec00815fd7daa873842a949b",
       "at": "2026-04-02T04:56:45Z",
+      "hash": "810594526118bfefec00815fd7daa873842a949b",
       "passes": 1,
       "pr": 15516
     },
     ".agents/content/production-video.md": {
-      "hash": "a29fa1cb5314a9aa6ef47fc64c622d7fee5c347c",
       "at": "2026-04-03T04:22:44Z",
+      "hash": "a29fa1cb5314a9aa6ef47fc64c622d7fee5c347c",
       "passes": 2,
       "pr": 15699
     },
     ".agents/content/production-writing.md": {
-      "hash": "e1de17f100fc57802741f873c9814bf070a38b7e",
       "at": "2026-03-28T11:20:42Z",
+      "hash": "e1de17f100fc57802741f873c9814bf070a38b7e",
       "passes": 1,
       "pr": 11788
     },
     ".agents/content/research.md": {
-      "hash": "8a949ddc4ca0e483291206cc2f3a53d342b7a0fc",
       "at": "2026-03-28T08:57:54Z",
+      "hash": "8a949ddc4ca0e483291206cc2f3a53d342b7a0fc",
       "passes": 1,
       "pr": 11644
     },
     ".agents/content/seo-writer.md": {
-      "hash": "06a12b22ce1dd6ffb548dd696bb471813a358eec",
       "at": "2026-04-01T22:10:00Z",
+      "hash": "06a12b22ce1dd6ffb548dd696bb471813a358eec",
       "passes": 1,
       "pr": 15339
     },
     ".agents/content/social-bird.md": {
-      "hash": "d85f0e70e5d12f5238e3b44cc777bbeecc7d265f",
       "at": "2026-03-28T05:10:07Z",
+      "hash": "d85f0e70e5d12f5238e3b44cc777bbeecc7d265f",
       "passes": 1,
       "pr": 11354
     },
     ".agents/content/social-linkedin.md": {
-      "hash": "4e220271bc2cee08663b1fba4959f40d6e42274e",
       "at": "2026-04-03T01:11:19Z",
+      "hash": "4e220271bc2cee08663b1fba4959f40d6e42274e",
       "passes": 2,
       "pr": 15493
     },
+    ".agents/content/social-reddit.md": {
+      "at": "2026-04-03T14:06:32Z",
+      "hash": "fdff0bfaf102165f97ea5be8ec39880579374eae",
+      "passes": 1,
+      "pr": 16555
+    },
     ".agents/content/story.md": {
-      "hash": "568354fe6c6c0a76bb0c99a2980296374ae65809",
       "at": "2026-03-29T17:14:35Z",
+      "hash": "568354fe6c6c0a76bb0c99a2980296374ae65809",
       "passes": 1,
       "pr": 13457
     },
     ".agents/content/summarize.md": {
-      "hash": "72a3d3300e29df594fb27d04f6c3bac6f267f731",
       "at": "2026-03-29T07:02:30Z",
+      "hash": "72a3d3300e29df594fb27d04f6c3bac6f267f731",
       "passes": 1,
       "pr": 12578
     },
     ".agents/content/video-director.md": {
-      "hash": "e4c8fae1e0c94f9a8e9988bc802b087f86c279f5",
       "at": "2026-03-29T07:02:22Z",
+      "hash": "e4c8fae1e0c94f9a8e9988bc802b087f86c279f5",
       "passes": 1,
       "pr": 12608
     },
     ".agents/content/video-enhancor.md": {
-      "hash": "4caf267b874e679f9d48d5e474d517ff9a734e6e",
       "at": "2026-03-29T08:49:19Z",
+      "hash": "4caf267b874e679f9d48d5e474d517ff9a734e6e",
       "passes": 1,
       "pr": 12796
     },
     ".agents/content/video-higgsfield-ui.md": {
-      "hash": "31262666171c64fc1a1fc77b426f92888126cf93",
       "at": "2026-03-30T06:49:12Z",
+      "hash": "31262666171c64fc1a1fc77b426f92888126cf93",
       "passes": 2,
       "pr": 13932
     },
     ".agents/content/video-higgsfield.md": {
-      "hash": "a23b492ffec4ee6c6d067d40cc3822c50c6893ea",
       "at": "2026-03-28T16:00:37Z",
+      "hash": "a23b492ffec4ee6c6d067d40cc3822c50c6893ea",
       "passes": 1,
       "pr": 11993
     },
     ".agents/content/video-muapi.md": {
-      "hash": "7dce91876811d2966e5114a8a2a76f853debe426",
       "at": "2026-03-28T11:20:21Z",
+      "hash": "7dce91876811d2966e5114a8a2a76f853debe426",
       "passes": 1,
       "pr": 11800
     },
     ".agents/content/video-real-video-enhancer.md": {
-      "hash": "a2a1ba5c9c1846f71db10779e8d8505296182855",
       "at": "2026-03-30T03:34:21Z",
+      "hash": "a2a1ba5c9c1846f71db10779e8d8505296182855",
       "passes": 1,
       "pr": 13533
     },
     ".agents/content/video-runway.md": {
-      "hash": "382f02f058a8e576a9b81fa3550a080f3386b936",
       "at": "2026-03-28T08:58:00Z",
+      "hash": "382f02f058a8e576a9b81fa3550a080f3386b936",
       "passes": 1,
       "pr": 11646
     },
     ".agents/content/video-wavespeed.md": {
-      "hash": "e2da567a8c76a5e9a8cdbfaebdc8df85f36bef8e",
       "at": "2026-03-28T14:15:41Z",
+      "hash": "e2da567a8c76a5e9a8cdbfaebdc8df85f36bef8e",
       "passes": 1,
       "pr": 11895
     },
+    ".agents/content/youtube-research.md": {
+      "at": "2026-04-11T17:01:20Z",
+      "hash": "83444ef9cf1ad2231ed1ad62d1d5c623f3d00333",
+      "passes": 3,
+      "pr": 18158
+    },
+    ".agents/content/youtube-setup.md": {
+      "at": "2026-04-11T16:20:19Z",
+      "hash": "257a899899f34d5907e2acf338cf587fbeddefa0",
+      "passes": 1,
+      "pr": 18209
+    },
+    ".agents/content/yt-dlp.md": {
+      "at": "2026-04-11T17:01:45Z",
+      "hash": "4dae1ca9bd059d4ab416b421f96766f6188ff7f1",
+      "passes": 1,
+      "pr": 18268
+    },
     ".agents/health.md": {
-      "hash": "8a06d2322341437c1e6bf9e560339646ba6c7fe0",
       "at": "2026-04-11T16:19:56Z",
+      "hash": "8a06d2322341437c1e6bf9e560339646ba6c7fe0",
       "passes": 2,
       "pr": 15249
     },
+    ".agents/hooks/task-id-collision-guard.sh": {
+      "at": "2026-04-15T03:59:21Z",
+      "hash": "7af29498bf5df56b0743eee15a76e71bfa598688",
+      "passes": 2,
+      "pr": 18718
+    },
     ".agents/legal.md": {
-      "hash": "278f1357743e4be7e4c36b0cc98cb3022db7130f",
       "at": "2026-04-11T17:01:20Z",
+      "hash": "278f1357743e4be7e4c36b0cc98cb3022db7130f",
       "passes": 3,
       "pr": 16526
     },
     ".agents/marketing-sales.md": {
-      "hash": "1f8a5d943028b36f9ae687dd4e3fd871e1b8753d",
       "at": "2026-04-11T10:08:49Z",
+      "hash": "1f8a5d943028b36f9ae687dd4e3fd871e1b8753d",
       "passes": 2,
       "pr": 13839
     },
     ".agents/marketing-sales/ad-creative-ai-tools-reference.md": {
-      "hash": "823c24bea5c79e2bd129f66c356fabdb1d98a3d4",
       "at": "2026-03-28T20:56:07Z",
+      "hash": "823c24bea5c79e2bd129f66c356fabdb1d98a3d4",
       "passes": 1,
       "pr": 12183
     },
     ".agents/marketing-sales/ad-creative-campaign-management.md": {
-      "hash": "5d2f01da95a1b688323cfb5155987ad19ed5b7b2",
       "at": "2026-03-28T16:00:35Z",
+      "hash": "5d2f01da95a1b688323cfb5155987ad19ed5b7b2",
       "passes": 1,
       "pr": 11974
     },
     ".agents/marketing-sales/ad-creative-chapter-01.md": {
-      "hash": "c0428f6d86637bd398e8f960433d03f0677dc6b5",
       "at": "2026-03-28T23:05:56Z",
+      "hash": "c0428f6d86637bd398e8f960433d03f0677dc6b5",
       "passes": 1,
       "pr": 12325
     },
     ".agents/marketing-sales/ad-creative-chapter-02.md": {
-      "hash": "51e7f668fefa02e3864158bd57087adb8cf3c418",
       "at": "2026-03-28T07:37:37Z",
+      "hash": "51e7f668fefa02e3864158bd57087adb8cf3c418",
       "passes": 1,
       "pr": 11539
     },
     ".agents/marketing-sales/ad-creative-chapter-03.md": {
-      "hash": "54a73c2e1b42bb10cad27baee9bd8f47c4610ed6",
       "at": "2026-03-28T15:30:26Z",
+      "hash": "54a73c2e1b42bb10cad27baee9bd8f47c4610ed6",
       "passes": 1,
       "pr": 11936
     },
     ".agents/marketing-sales/ad-creative-chapter-04.md": {
-      "hash": "85f0c1fe2fe240123e4757ac6be377a05d96fca8",
       "at": "2026-03-29T07:02:10Z",
+      "hash": "85f0c1fe2fe240123e4757ac6be377a05d96fca8",
       "passes": 1,
       "pr": 12662
     },
     ".agents/marketing-sales/ad-creative-chapter-05.md": {
-      "hash": "a8935951742ad5cf2d19fad7accb83137439c3b6",
       "at": "2026-03-28T08:18:28Z",
+      "hash": "a8935951742ad5cf2d19fad7accb83137439c3b6",
       "passes": 1,
       "pr": 11555
     },
     ".agents/marketing-sales/ad-creative-chapter-06.md": {
-      "hash": "9264018161cfe07b708c4b1a595e5634199ab279",
       "at": "2026-03-28T05:09:55Z",
+      "hash": "9264018161cfe07b708c4b1a595e5634199ab279",
       "passes": 1,
       "pr": 11414
     },
     ".agents/marketing-sales/ad-creative-chapter-07.md": {
-      "hash": "f6bc82d10ab2308fea1f55ebb59dc2fcb1014801",
       "at": "2026-03-29T01:33:56Z",
+      "hash": "f6bc82d10ab2308fea1f55ebb59dc2fcb1014801",
       "passes": 1,
       "pr": 12442
     },
     ".agents/marketing-sales/ad-creative-chapter-08.md": {
-      "hash": "a978b05fe0adbb7382519df9dcdde86cedc647eb",
       "at": "2026-03-29T01:04:19Z",
+      "hash": "a978b05fe0adbb7382519df9dcdde86cedc647eb",
       "passes": 1,
       "pr": 12398
     },
     ".agents/marketing-sales/ad-creative-chapter-09.md": {
-      "hash": "1237ece0a2a602d8216235f3077791cfb799908e",
       "at": "2026-03-29T16:34:21Z",
+      "hash": "1237ece0a2a602d8216235f3077791cfb799908e",
       "passes": 1,
       "pr": 13110
     },
     ".agents/marketing-sales/ad-creative-chapter-10.md": {
-      "hash": "c42dc7de0cb31c3a82d1e6c9207db3b191c61b90",
       "at": "2026-03-28T05:10:32Z",
+      "hash": "c42dc7de0cb31c3a82d1e6c9207db3b191c61b90",
       "passes": 1,
       "pr": 11315
     },
     ".agents/marketing-sales/ad-creative-chapter-11.md": {
-      "hash": "31d9e387ec5cf5f915a08e961ea8cdab31dfd102",
       "at": "2026-03-29T20:54:11Z",
+      "hash": "31d9e387ec5cf5f915a08e961ea8cdab31dfd102",
       "passes": 1,
       "pr": 13222
     },
     ".agents/marketing-sales/ad-creative-chapter-12.md": {
-      "hash": "38eb38d251286defadcfc7714309f4ae443dd670",
       "at": "2026-03-29T03:15:08Z",
+      "hash": "38eb38d251286defadcfc7714309f4ae443dd670",
       "passes": 1,
       "pr": 12503
     },
     ".agents/marketing-sales/ad-creative-chapters.md": {
-      "hash": "f6d36964afc57d9024138cdf8ea3792e04d09a9c",
       "at": "2026-03-28T23:05:56Z",
+      "hash": "f6d36964afc57d9024138cdf8ea3792e04d09a9c",
       "passes": 1,
       "pr": 12325
     },
     ".agents/marketing-sales/ad-creative-copywriting.md": {
-      "hash": "2db79cbe873dc8753b611a4596caf2695db54da6",
       "at": "2026-03-28T21:14:35Z",
+      "hash": "2db79cbe873dc8753b611a4596caf2695db54da6",
       "passes": 1,
       "pr": 12018
     },
     ".agents/marketing-sales/ad-creative-offers-landing.md": {
-      "hash": "9ff345359852873a70993c59058fb93b7d18ebd7",
       "at": "2026-03-28T05:50:34Z",
+      "hash": "9ff345359852873a70993c59058fb93b7d18ebd7",
       "passes": 1,
       "pr": 11415
     },
     ".agents/marketing-sales/ad-creative-platform-google.md": {
-      "hash": "d1b7064c11257d4ee8d4a4a01d685b138757ecc4",
       "at": "2026-03-28T15:30:26Z",
+      "hash": "d1b7064c11257d4ee8d4a4a01d685b138757ecc4",
       "passes": 1,
       "pr": 11936
     },
     ".agents/marketing-sales/ad-creative-platform-meta.md": {
-      "hash": "24789ea9f3dc779465b62c6641b7554e348bef84",
       "at": "2026-03-28T08:58:35Z",
+      "hash": "24789ea9f3dc779465b62c6641b7554e348bef84",
       "passes": 1,
       "pr": 11574
     },
     ".agents/marketing-sales/ad-creative-psychology-targeting.md": {
-      "hash": "3871d0b30f2c9a1d4594f6242a7eb116b203bbca",
       "at": "2026-03-28T10:27:52Z",
+      "hash": "3871d0b30f2c9a1d4594f6242a7eb116b203bbca",
       "passes": 1,
       "pr": 11655
     },
     ".agents/marketing-sales/ad-creative-testing-optimization.md": {
-      "hash": "5bc2bdf9cefeb9a52afb78258aef156613edcfb0",
       "at": "2026-03-28T08:58:01Z",
+      "hash": "5bc2bdf9cefeb9a52afb78258aef156613edcfb0",
       "passes": 1,
       "pr": 11614
     },
     ".agents/marketing-sales/ad-creative-video-ugc.md": {
-      "hash": "9cc5b59b41d0c49af0d8d982023b249d4b223797",
       "at": "2026-03-30T04:52:01Z",
+      "hash": "9cc5b59b41d0c49af0d8d982023b249d4b223797",
       "passes": 1,
       "pr": 13723
     },
     ".agents/marketing-sales/ad-creative.md": {
-      "hash": "6f38a1299799861d56ff89107feb3dbe886249ea",
       "at": "2026-03-29T03:31:36Z",
+      "hash": "6f38a1299799861d56ff89107feb3dbe886249ea",
       "passes": 1,
       "pr": 12505
     },
     ".agents/marketing-sales/cro-chapter-01.md": {
-      "hash": "49416bb6391ac7ea5c62c26fe871f187271e5b8e",
       "at": "2026-03-29T20:54:07Z",
+      "hash": "49416bb6391ac7ea5c62c26fe871f187271e5b8e",
       "passes": 1,
       "pr": 13294
     },
     ".agents/marketing-sales/cro-chapter-02.md": {
-      "hash": "a7a251b26d952132177a661bfb8f6481f36320a1",
       "at": "2026-04-01T20:59:14Z",
+      "hash": "a7a251b26d952132177a661bfb8f6481f36320a1",
       "passes": 1,
       "pr": 15223
     },
     ".agents/marketing-sales/cro-chapter-02/01-conversion-rate-formulas.md": {
-      "hash": "5b4fb99dcd5297583fd3812c581f38e1a4bf428f",
       "at": "2026-04-01T20:59:14Z",
+      "hash": "5b4fb99dcd5297583fd3812c581f38e1a4bf428f",
       "passes": 1,
       "pr": 15223
     },
     ".agents/marketing-sales/cro-chapter-02/02-psychology-of-conversion.md": {
-      "hash": "b78eb920d0d205d3a7a16c0a231e603b3c76f0f6",
       "at": "2026-04-01T20:59:14Z",
+      "hash": "b78eb920d0d205d3a7a16c0a231e603b3c76f0f6",
       "passes": 1,
       "pr": 15223
     },
     ".agents/marketing-sales/cro-chapter-02/03-conversion-funnel.md": {
-      "hash": "54e22a3eab9c904681bb1e4398c78b98e887e5b8",
       "at": "2026-04-01T20:59:14Z",
+      "hash": "54e22a3eab9c904681bb1e4398c78b98e887e5b8",
       "passes": 1,
       "pr": 15223
     },
     ".agents/marketing-sales/cro-chapter-02/04-attribution-models.md": {
-      "hash": "09ae1f6da6c26f5374b737d5c44b36c402055e49",
       "at": "2026-04-01T20:59:15Z",
+      "hash": "09ae1f6da6c26f5374b737d5c44b36c402055e49",
       "passes": 1,
       "pr": 15223
     },
     ".agents/marketing-sales/cro-chapter-02/05-website-elements.md": {
-      "hash": "d442a988c8a0bc91965348495889d82a26b059a7",
       "at": "2026-04-01T20:59:15Z",
+      "hash": "d442a988c8a0bc91965348495889d82a26b059a7",
       "passes": 1,
       "pr": 15223
     },
     ".agents/marketing-sales/cro-chapter-02/06-conversion-friction.md": {
-      "hash": "2d1ab8b2d766ca0d85d5f11f13c3c0271d8c6736",
       "at": "2026-04-01T20:59:15Z",
+      "hash": "2d1ab8b2d766ca0d85d5f11f13c3c0271d8c6736",
       "passes": 1,
       "pr": 15223
     },
     ".agents/marketing-sales/cro-chapter-02/07-data-foundation.md": {
-      "hash": "3cd8203a02abb87973eaf7596938b3b7a127a738",
       "at": "2026-04-01T20:59:15Z",
+      "hash": "3cd8203a02abb87973eaf7596938b3b7a127a738",
       "passes": 1,
       "pr": 15223
     },
     ".agents/marketing-sales/cro-chapter-03.md": {
-      "hash": "22df9a1f73996bf3eeb1f26c828bc33c6ef07d2d",
       "at": "2026-03-29T12:37:09Z",
+      "hash": "22df9a1f73996bf3eeb1f26c828bc33c6ef07d2d",
       "passes": 1,
       "pr": 12954
     },
     ".agents/marketing-sales/cro-chapter-04.md": {
-      "hash": "d160cb66e8ee128912485b5f9803517a2e3f2a99",
       "at": "2026-03-29T07:02:12Z",
+      "hash": "d160cb66e8ee128912485b5f9803517a2e3f2a99",
       "passes": 1,
       "pr": 12665
     },
     ".agents/marketing-sales/cro-chapter-05.md": {
-      "hash": "86667f67cd615551c83a662e804b1d298e057dd2",
       "at": "2026-03-29T09:20:58Z",
+      "hash": "86667f67cd615551c83a662e804b1d298e057dd2",
       "passes": 1,
       "pr": 12824
     },
     ".agents/marketing-sales/cro-chapter-07.md": {
-      "hash": "766a7f74e69b6daf61593126595f0d09fee0bf59",
       "at": "2026-03-29T02:36:03Z",
+      "hash": "766a7f74e69b6daf61593126595f0d09fee0bf59",
       "passes": 1,
       "pr": 12463
     },
     ".agents/marketing-sales/cro-chapter-08.md": {
-      "hash": "55e3b076d031d5331f12a34f5e52956e4a98247d",
       "at": "2026-03-30T06:49:54Z",
+      "hash": "55e3b076d031d5331f12a34f5e52956e4a98247d",
       "passes": 1,
       "pr": 13773
     },
     ".agents/marketing-sales/cro-chapter-09.md": {
-      "hash": "39a0d0bfad48732c92e57659b616fbd0d288bd73",
       "at": "2026-03-28T08:17:36Z",
+      "hash": "39a0d0bfad48732c92e57659b616fbd0d288bd73",
       "passes": 1,
       "pr": 11561
     },
     ".agents/marketing-sales/cro-chapter-10.md": {
-      "hash": "79f622376140223bce9c967b991ac8d86dd67523",
       "at": "2026-03-27T21:25:12Z",
+      "hash": "79f622376140223bce9c967b991ac8d86dd67523",
       "passes": 1,
       "pr": 11005
     },
     ".agents/marketing-sales/cro-chapter-11.md": {
-      "hash": "fbd2be3a087737ebd1063e5a5bc157f60e295cdd",
       "at": "2026-04-01T22:00:00Z",
+      "hash": "fbd2be3a087737ebd1063e5a5bc157f60e295cdd",
       "passes": 1,
       "pr": 14514
     },
     ".agents/marketing-sales/cro-chapter-12.md": {
-      "hash": "985a41f66590964d3d0036a59d7a4d9fedb36e6d",
       "at": "2026-03-28T16:00:24Z",
+      "hash": "985a41f66590964d3d0036a59d7a4d9fedb36e6d",
       "passes": 1,
       "pr": 11988
     },
     ".agents/marketing-sales/cro-chapter-13.md": {
-      "hash": "eaca2ea88732d3edcc7c235a3486f5860259fd15",
       "at": "2026-03-29T03:15:02Z",
+      "hash": "eaca2ea88732d3edcc7c235a3486f5860259fd15",
       "passes": 1,
       "pr": 12499
     },
     ".agents/marketing-sales/cro-chapter-14.md": {
-      "hash": "4baaaf18ffdd314b3b6412dd32fe1d9b2199bc54",
       "at": "2026-03-28T16:40:42Z",
+      "hash": "4baaaf18ffdd314b3b6412dd32fe1d9b2199bc54",
       "passes": 1,
       "pr": 12027
     },
     ".agents/marketing-sales/cro-chapter-15/01-personalization-types.md": {
-      "hash": "94bf638954afb74b6dfdf5683fc380aa4be2f130",
       "at": "2026-04-03T01:53:23Z",
+      "hash": "94bf638954afb74b6dfdf5683fc380aa4be2f130",
       "passes": 1,
       "pr": 15873
     },
     ".agents/marketing-sales/cro-chapter-16.md": {
-      "hash": "17dafce90058df29ff130988e305680bc32b6647",
       "at": "2026-03-28T04:30:24Z",
+      "hash": "17dafce90058df29ff130988e305680bc32b6647",
       "passes": 1,
       "pr": 11374
     },
     ".agents/marketing-sales/cro-chapter-17.md": {
-      "hash": "fc85ae409ef61c388725c6c5a4a27d932f9f29ae",
       "at": "2026-03-29T21:43:12Z",
+      "hash": "fc85ae409ef61c388725c6c5a4a27d932f9f29ae",
       "passes": 1,
       "pr": 13339
     },
     ".agents/marketing-sales/cro-chapter-18.md": {
-      "hash": "3f5985e03f55e8161d42ee1268926a66e2d54b33",
       "at": "2026-04-01T20:59:11Z",
+      "hash": "3f5985e03f55e8161d42ee1268926a66e2d54b33",
       "passes": 1,
       "pr": 15220
     },
     ".agents/marketing-sales/cro-chapter-19.md": {
-      "hash": "9f4a9519b229255c8678d9e9ca6c278c76d357ca",
       "at": "2026-04-02T21:19:54Z",
+      "hash": "9f4a9519b229255c8678d9e9ca6c278c76d357ca",
       "passes": 2
     },
     ".agents/marketing-sales/cro-chapter-20.md": {
-      "hash": "41c86217378cccf8516956d15cedbdd195543226",
       "at": "2026-03-29T16:34:29Z",
+      "hash": "41c86217378cccf8516956d15cedbdd195543226",
       "passes": 1,
       "pr": 13105
     },
     ".agents/marketing-sales/cro-chapter-21.md": {
-      "hash": "fb214d62abf08ccd0274e00106a47ad2754ef987",
       "at": "2026-04-03T11:54:13Z",
+      "hash": "fb214d62abf08ccd0274e00106a47ad2754ef987",
       "passes": 1,
       "pr": 16514
     },
     ".agents/marketing-sales/cro-chapter-22.md": {
-      "hash": "11cd3ab105807870c48f14ff6a4c93d8707840ac",
       "at": "2026-04-01T20:58:50Z",
+      "hash": "11cd3ab105807870c48f14ff6a4c93d8707840ac",
       "passes": 1,
       "pr": 15257
     },
+    ".agents/marketing-sales/cro-chapter-23.md": {
+      "at": "2026-04-03T16:35:53Z",
+      "hash": "db5fb34d74b6f8f20ddc287c19ac7772d95e18e8",
+      "passes": 1,
+      "pr": 16672
+    },
+    ".agents/marketing-sales/cro-chapter-24.md": {
+      "at": "2026-04-04T14:54:10Z",
+      "hash": "408af22ccf4cf16d851c70a31d946b7cd014b330",
+      "passes": 1,
+      "pr": 17313
+    },
     ".agents/marketing-sales/cro-chapter-25.md": {
-      "hash": "4b1136509b767812746ea5493f7c384b2f6861ce",
       "at": "2026-04-03T03:15:07Z",
+      "hash": "4b1136509b767812746ea5493f7c384b2f6861ce",
       "passes": 3,
       "pr": 15276
     },
     ".agents/marketing-sales/cro-chapters.md": {
-      "hash": "b27b566a67aa1ed56083c518267abe3bf9a479c8",
       "at": "2026-03-30T00:32:32Z",
+      "hash": "b27b566a67aa1ed56083c518267abe3bf9a479c8",
       "passes": 1,
       "pr": 13457
     },
     ".agents/marketing-sales/cro.md": {
-      "hash": "badb49d10e2134db71be6a1a8fb46c2f3837b565",
       "at": "2026-03-29T08:10:36Z",
+      "hash": "badb49d10e2134db71be6a1a8fb46c2f3837b565",
       "passes": 1,
       "pr": 12753
     },
+    ".agents/marketing-sales/direct-response-copy-checklists-headline-testing.md": {
+      "at": "2026-04-03T19:14:14Z",
+      "hash": "db3a14db885f9d327079a5f92d004c8f8ecd5045",
+      "passes": 2,
+      "pr": "pending"
+    },
     ".agents/marketing-sales/direct-response-copy-checklists-offer-optimization.md": {
-      "hash": "08afe4f712ecf31659d6350e5eb51bf48ff3bf57",
       "at": "2026-04-03T01:53:26Z",
+      "hash": "08afe4f712ecf31659d6350e5eb51bf48ff3bf57",
       "passes": 1,
       "pr": 15696
     },
     ".agents/marketing-sales/direct-response-copy-checklists-pre-publish.md": {
-      "hash": "b669ec66e78df5e523d9d0560fe3eb1564d7c7b2",
       "at": "2026-04-01T20:59:28Z",
+      "hash": "b669ec66e78df5e523d9d0560fe3eb1564d7c7b2",
       "passes": 1,
       "pr": 14996
     },
     ".agents/marketing-sales/direct-response-copy-frameworks-email-sequences.md": {
-      "hash": "e47ff4f9e42596ff26ae118b657c60210f4aa26d",
       "at": "2026-04-03T11:54:15Z",
+      "hash": "e47ff4f9e42596ff26ae118b657c60210f4aa26d",
       "passes": 1,
       "pr": 16443
     },
     ".agents/marketing-sales/direct-response-copy-frameworks-headline-formulas.md": {
-      "hash": "4cea6f4fd6faf7fc618e5c5c07684983377a0af9",
       "at": "2026-03-28T08:58:42Z",
+      "hash": "4cea6f4fd6faf7fc618e5c5c07684983377a0af9",
       "passes": 1,
       "pr": 11548
     },
     ".agents/marketing-sales/direct-response-copy-frameworks-landing-page-structure.md": {
-      "hash": "06520e5176a3720c076a2d615d8200d87437a0ec",
       "at": "2026-04-03T21:02:15Z",
+      "hash": "06520e5176a3720c076a2d615d8200d87437a0ec",
       "passes": 2,
       "pr": 16856
     },
     ".agents/marketing-sales/direct-response-copy-frameworks-objection-handling.md": {
-      "hash": "6b7d69c72f03c146ea6a8956fc34ee4dffa152ba",
       "at": "2026-03-28T08:17:37Z",
+      "hash": "6b7d69c72f03c146ea6a8956fc34ee4dffa152ba",
       "passes": 1,
       "pr": 11571
     },
     ".agents/marketing-sales/direct-response-copy-frameworks-offer-construction.md": {
-      "hash": "0ba79ac1663fa0f81bd21bf2ae433e145dd39784",
       "at": "2026-03-28T05:51:09Z",
+      "hash": "0ba79ac1663fa0f81bd21bf2ae433e145dd39784",
       "passes": 1,
       "pr": 11363
     },
     ".agents/marketing-sales/direct-response-copy-swipe-file-ads.md": {
-      "hash": "ddf1f8c4971142867ef95e50488ea607ff944cd1",
       "at": "2026-03-28T05:50:32Z",
+      "hash": "ddf1f8c4971142867ef95e50488ea607ff944cd1",
       "passes": 1,
       "pr": 11411
     },
     ".agents/marketing-sales/direct-response-copy-swipe-file-emails-02-nurture.md": {
-      "hash": "9dfe07ad104eab3588dbf23b3e2a6e2a951b87bd",
       "at": "2026-03-31T05:42:16Z",
+      "hash": "9dfe07ad104eab3588dbf23b3e2a6e2a951b87bd",
       "passes": 2,
       "pr": 14662
     },
     ".agents/marketing-sales/direct-response-copy-swipe-file-emails-03-sales-06-ramit-sethi-launch.md": {
-      "hash": "5ac94a1c3980e01b044af3cd92ad19015df407d7",
       "at": "2026-04-01T20:59:17Z",
+      "hash": "5ac94a1c3980e01b044af3cd92ad19015df407d7",
       "passes": 1,
       "pr": 15150
     },
     ".agents/marketing-sales/direct-response-copy-swipe-file-emails-03-sales-07-saas-trial-expiry.md": {
-      "hash": "289276865047adfdfcd65b64aa60591f2cc882cd",
       "at": "2026-04-01T20:59:17Z",
+      "hash": "289276865047adfdfcd65b64aa60591f2cc882cd",
       "passes": 1,
       "pr": 15150
     },
     ".agents/marketing-sales/direct-response-copy-swipe-file-emails-03-sales-08-cart-abandonment.md": {
-      "hash": "29594e33f91412b23177ffa89fbf2a62fc12cb57",
       "at": "2026-04-01T20:59:17Z",
+      "hash": "29594e33f91412b23177ffa89fbf2a62fc12cb57",
       "passes": 1,
       "pr": 15150
     },
     ".agents/marketing-sales/direct-response-copy-swipe-file-emails-03-sales-09-webinar-invite.md": {
-      "hash": "bce0481b5dc11dcdfe06360bc44595509ec7fca1",
       "at": "2026-04-01T20:59:17Z",
+      "hash": "bce0481b5dc11dcdfe06360bc44595509ec7fca1",
       "passes": 1,
       "pr": 15150
     },
     ".agents/marketing-sales/direct-response-copy-swipe-file-emails-03-sales.md": {
-      "hash": "24fa859bb89238c6647bda8428b9151dbd4e24c3",
       "at": "2026-04-01T20:59:18Z",
+      "hash": "24fa859bb89238c6647bda8428b9151dbd4e24c3",
       "passes": 1,
       "pr": 15150
     },
     ".agents/marketing-sales/direct-response-copy-swipe-file-emails-06-templates.md": {
-      "hash": "078c8a33913360dfc87775553fc78dfd96ddbad8",
       "at": "2026-04-02T04:56:54Z",
+      "hash": "078c8a33913360dfc87775553fc78dfd96ddbad8",
       "passes": 1,
       "pr": 15526
     },
     ".agents/marketing-sales/direct-response-copy-swipe-file-headlines.md": {
-      "hash": "0c0de706e0631d22bdeb54364633a0d53bf981af",
       "at": "2026-03-28T15:30:24Z",
+      "hash": "0c0de706e0631d22bdeb54364633a0d53bf981af",
       "passes": 1,
       "pr": 11945
     },
+    ".agents/marketing-sales/direct-response-copy-swipe-file-landing-pages-01-saas-examples.md": {
+      "at": "2026-04-03T16:35:54Z",
+      "hash": "b8e956f50f59b28fd65d94290a863552f472b6b1",
+      "passes": 1,
+      "pr": 16636
+    },
     ".agents/marketing-sales/direct-response-copy-swipe-file-landing-pages.md": {
-      "hash": "4bcab5c416e20100ed30495f2884d8bcb1f305d0",
       "at": "2026-04-02T20:39:23Z",
+      "hash": "4bcab5c416e20100ed30495f2884d8bcb1f305d0",
       "passes": 1
     },
     ".agents/marketing-sales/direct-response-copy-swipe-file-vsl-scripts-example.md": {
-      "hash": "08381f03d1ca0ee90eae881d8cb5f9547ecded53",
       "at": "2026-03-28T08:58:28Z",
+      "hash": "08381f03d1ca0ee90eae881d8cb5f9547ecded53",
       "passes": 1,
       "pr": 11597
     },
     ".agents/marketing-sales/direct-response-copy-swipe-file-vsl-scripts-pastor-framework.md": {
-      "hash": "22d0675cd4045a7606a176bfa6890673b87542f9",
       "at": "2026-03-28T08:58:28Z",
+      "hash": "22d0675cd4045a7606a176bfa6890673b87542f9",
       "passes": 1,
       "pr": 11597
     },
     ".agents/marketing-sales/direct-response-copy-swipe-file-vsl-scripts.md": {
-      "hash": "c355023a24e3bcdfbdba82c823d619d970d98d8e",
       "at": "2026-03-28T08:57:56Z",
+      "hash": "c355023a24e3bcdfbdba82c823d619d970d98d8e",
       "passes": 1,
       "pr": 11647
     },
     ".agents/marketing-sales/direct-response-copy-templates-ad-copy-01-facebook-instagram.md": {
-      "hash": "2929b81aec4e646849eaf715240391db4dbe39b7",
       "at": "2026-03-28T08:17:45Z",
+      "hash": "2929b81aec4e646849eaf715240391db4dbe39b7",
       "passes": 1,
       "pr": 11593
     },
     ".agents/marketing-sales/direct-response-copy-templates-ad-copy-02-google-search.md": {
-      "hash": "287e4be45d15a0c187375416228e393ad6cf0134",
       "at": "2026-03-28T08:17:45Z",
+      "hash": "287e4be45d15a0c187375416228e393ad6cf0134",
       "passes": 1,
       "pr": 11593
     },
     ".agents/marketing-sales/direct-response-copy-templates-ad-copy-03-linkedin.md": {
-      "hash": "2d6eb5c549a2853e453757b8d90f60c54cde70a5",
       "at": "2026-03-28T08:17:45Z",
+      "hash": "2d6eb5c549a2853e453757b8d90f60c54cde70a5",
       "passes": 1,
       "pr": 11593
     },
     ".agents/marketing-sales/direct-response-copy-templates-ad-copy-04-twitter.md": {
-      "hash": "749e973234351c43f8d38ed6e5f17b0d41fdca49",
       "at": "2026-03-28T08:17:45Z",
+      "hash": "749e973234351c43f8d38ed6e5f17b0d41fdca49",
       "passes": 1,
       "pr": 11593
     },
     ".agents/marketing-sales/direct-response-copy-templates-ad-copy-05-reference.md": {
-      "hash": "eff65a3d5ff65725bb93094acd8a49ebf4fb064c",
       "at": "2026-03-28T08:17:45Z",
+      "hash": "eff65a3d5ff65725bb93094acd8a49ebf4fb064c",
       "passes": 1,
       "pr": 11593
     },
     ".agents/marketing-sales/direct-response-copy-templates-ad-copy.md": {
-      "hash": "7222ae3d8493e6dec91988e41f2d479e29a9b384",
       "at": "2026-03-28T08:17:45Z",
+      "hash": "7222ae3d8493e6dec91988e41f2d479e29a9b384",
       "passes": 1,
       "pr": 11593
     },
     ".agents/marketing-sales/direct-response-copy-templates-email-sequences-01-shared-patterns.md": {
-      "hash": "8ac8ac73d9984ec320006aac8b96e087c5b44dcc",
       "at": "2026-04-02T12:00:00Z",
+      "hash": "8ac8ac73d9984ec320006aac8b96e087c5b44dcc",
       "passes": 2,
       "pr": 15046
     },
     ".agents/marketing-sales/direct-response-copy-templates-email-sequences-02-welcome.md": {
-      "hash": "e4b4b0a998042c6971c3e27c8a936dcc54b3285a",
       "at": "2026-04-02T12:00:00Z",
+      "hash": "e4b4b0a998042c6971c3e27c8a936dcc54b3285a",
       "passes": 2,
       "pr": 15046
     },
     ".agents/marketing-sales/direct-response-copy-templates-email-sequences-03-cart-abandonment.md": {
-      "hash": "71d45babe4902dac466b7ca9d4b5cd80ff81cc08",
       "at": "2026-04-02T12:00:00Z",
+      "hash": "71d45babe4902dac466b7ca9d4b5cd80ff81cc08",
       "passes": 2,
       "pr": 15046
     },
     ".agents/marketing-sales/direct-response-copy-templates-email-sequences-04-saas-trial.md": {
-      "hash": "9f151c2dcd7c4e73e944d84d36fdfe4508ec271b",
       "at": "2026-04-02T12:00:00Z",
+      "hash": "9f151c2dcd7c4e73e944d84d36fdfe4508ec271b",
       "passes": 2,
       "pr": 15046
     },
     ".agents/marketing-sales/direct-response-copy-templates-email-sequences-05-launch.md": {
-      "hash": "21ffb90d31339033afc234b21de06455f55075a0",
       "at": "2026-04-02T12:00:00Z",
+      "hash": "21ffb90d31339033afc234b21de06455f55075a0",
       "passes": 2,
       "pr": 15046
     },
     ".agents/marketing-sales/direct-response-copy-templates-email-sequences-06-subject-lines.md": {
-      "hash": "cc2f6ea86b1a3709a6b09b9c317df3a3bc4adae6",
       "at": "2026-04-02T12:00:00Z",
+      "hash": "cc2f6ea86b1a3709a6b09b9c317df3a3bc4adae6",
       "passes": 2,
       "pr": 15046
     },
     ".agents/marketing-sales/direct-response-copy-templates-email-sequences.md": {
-      "hash": "db945ec6df7472d5c4909e49847bab4b2804a7e3",
       "at": "2026-04-02T12:00:00Z",
+      "hash": "db945ec6df7472d5c4909e49847bab4b2804a7e3",
       "passes": 2,
       "pr": 15046
     },
     ".agents/marketing-sales/direct-response-copy-templates-landing-page.md": {
-      "hash": "21f6a6f365f657c85dfa0163690961fc91e85c3a",
       "at": "2026-03-28T13:37:36Z",
+      "hash": "21f6a6f365f657c85dfa0163690961fc91e85c3a",
       "passes": 1,
       "pr": 11840
     },
     ".agents/marketing-sales/direct-response-copy-templates-readme.md": {
-      "hash": "6b9c5aafab1727da1f864e1fddb6d90954a6d64c",
       "at": "2026-03-28T08:17:38Z",
+      "hash": "6b9c5aafab1727da1f864e1fddb6d90954a6d64c",
       "passes": 1,
       "pr": 11571
     },
     ".agents/marketing-sales/direct-response-copy-templates-vsl-script.md": {
-      "hash": "ee681e45d3b36775fc0fc43b31666c3894406576",
       "at": "2026-03-28T08:17:46Z",
+      "hash": "ee681e45d3b36775fc0fc43b31666c3894406576",
       "passes": 1,
       "pr": 11591
     },
     ".agents/marketing-sales/direct-response-copy.md": {
-      "hash": "13d959f10b6d7682d233b5c8c21829fc05ec7fef",
       "at": "2026-03-30T02:30:17Z",
+      "hash": "13d959f10b6d7682d233b5c8c21829fc05ec7fef",
       "passes": 1,
       "pr": 13597
     },
     ".agents/marketing-sales/meta-ads-audiences-first-party-data.md": {
-      "hash": "69604f0dac77e13db2fce4dc12a3da63ee7fa7bf",
       "at": "2026-03-28T08:18:20Z",
+      "hash": "69604f0dac77e13db2fce4dc12a3da63ee7fa7bf",
       "passes": 1,
       "pr": 11536
     },
     ".agents/marketing-sales/meta-ads-audiences-retargeting-setup.md": {
-      "hash": "5741030dfe4116be372b09983c0fc86d27a9b440",
       "at": "2026-03-29T03:15:24Z",
+      "hash": "5741030dfe4116be372b09983c0fc86d27a9b440",
       "passes": 1,
       "pr": 12514
     },
     ".agents/marketing-sales/meta-ads-audiences-targeting-strategies.md": {
-      "hash": "9c61292876f2650dff55995a6dc728118ed254e5",
       "at": "2026-03-28T11:20:14Z",
+      "hash": "9c61292876f2650dff55995a6dc728118ed254e5",
       "passes": 1,
       "pr": 11791
     },
     ".agents/marketing-sales/meta-ads-campaigns-advantage-plus.md": {
-      "hash": "fedf83638b0dad1cdd15831c9b1ef2101ff528e8",
       "at": "2026-03-30T04:52:40Z",
+      "hash": "fedf83638b0dad1cdd15831c9b1ef2101ff528e8",
       "passes": 1,
       "pr": 13779
     },
     ".agents/marketing-sales/meta-ads-campaigns-decision-trees.md": {
-      "hash": "a51316617e734f73d0b0726f7950d682cdd44edb",
       "at": "2026-03-28T04:30:25Z",
+      "hash": "a51316617e734f73d0b0726f7950d682cdd44edb",
       "passes": 1,
       "pr": 11381
     },
     ".agents/marketing-sales/meta-ads-campaigns-retargeting.md": {
-      "hash": "60c918f769b15d382d3a7a068a9b28509d2f0abb",
       "at": "2026-03-28T11:52:21Z",
+      "hash": "60c918f769b15d382d3a7a068a9b28509d2f0abb",
       "passes": 1,
       "pr": 11822
     },
     ".agents/marketing-sales/meta-ads-campaigns-scaling-cbo.md": {
-      "hash": "43db704641af3a33b15a004bb0cd2a5bd38f20e1",
       "at": "2026-03-29T21:42:59Z",
+      "hash": "43db704641af3a33b15a004bb0cd2a5bd38f20e1",
       "passes": 1,
       "pr": 13263
     },
     ".agents/marketing-sales/meta-ads-campaigns-testing-abo.md": {
-      "hash": "22c4c5f56611ef00c21f9d53d3cecd20a5a3562b",
       "at": "2026-03-29T01:04:17Z",
+      "hash": "22c4c5f56611ef00c21f9d53d3cecd20a5a3562b",
       "passes": 1,
       "pr": 12395
     },
     ".agents/marketing-sales/meta-ads-checklists-campaign-launch.md": {
-      "hash": "131b97215679562db54becb1d461dc5fe6d9626d",
       "at": "2026-04-01T20:59:20Z",
+      "hash": "131b97215679562db54becb1d461dc5fe6d9626d",
       "passes": 1,
       "pr": 15149
     },
     ".agents/marketing-sales/meta-ads-checklists-creative-review.md": {
-      "hash": "c984e64836be4dc89bcd43b769b0a5142d139580",
       "at": "2026-03-30T03:33:54Z",
+      "hash": "c984e64836be4dc89bcd43b769b0a5142d139580",
       "passes": 1,
       "pr": 13666
     },
     ".agents/marketing-sales/meta-ads-checklists-scaling-checklist.md": {
-      "hash": "a3849d21e49e77b962dabbd475e730e0ec8190ba",
       "at": "2026-04-03T01:11:48Z",
+      "hash": "a3849d21e49e77b962dabbd475e730e0ec8190ba",
       "passes": 1,
       "pr": 15723
     },
     ".agents/marketing-sales/meta-ads-checklists-weekly-review.md": {
-      "hash": "beaae9ef8ea37dfaaa232d98a7a3ac04a5c701d5",
       "at": "2026-03-29T12:36:27Z",
+      "hash": "beaae9ef8ea37dfaaa232d98a7a3ac04a5c701d5",
       "passes": 1,
       "pr": 12947
     },
     ".agents/marketing-sales/meta-ads-creative-briefs-founder-video-brief.md": {
-      "hash": "0d379470c6bcaf66ab62dbec48152db59dad811a",
       "at": "2026-03-31T06:30:29Z",
+      "hash": "0d379470c6bcaf66ab62dbec48152db59dad811a",
       "passes": 2,
       "pr": 14701
     },
     ".agents/marketing-sales/meta-ads-creative-briefs-testimonial-brief.md": {
-      "hash": "b4c6c3a0a4a1cf30514b9b6d0cc2a021383ad013",
       "at": "2026-03-29T15:50:34Z",
+      "hash": "b4c6c3a0a4a1cf30514b9b6d0cc2a021383ad013",
       "passes": 2,
       "pr": 13064
     },
     ".agents/marketing-sales/meta-ads-creative-briefs-ugc-brief.md": {
-      "hash": "87a09045aca222c3377b0e553c6fcd49e157cc1c",
       "at": "2026-03-28T21:27:17Z",
+      "hash": "87a09045aca222c3377b0e553c6fcd49e157cc1c",
       "passes": 1,
       "pr": 12217
     },
     ".agents/marketing-sales/meta-ads-creative-formats.md": {
-      "hash": "cbb3e4e036fc61f76903b715714318d31148aad1",
       "at": "2026-03-28T06:39:54Z",
+      "hash": "cbb3e4e036fc61f76903b715714318d31148aad1",
       "passes": 1,
       "pr": 11410
     },
     ".agents/marketing-sales/meta-ads-creative-frameworks.md": {
-      "hash": "bac8c0f9a4972303482f7f9fe788d90d037f6812",
       "at": "2026-04-03T03:15:28Z",
+      "hash": "bac8c0f9a4972303482f7f9fe788d90d037f6812",
       "passes": 1,
       "pr": 15906
     },
     ".agents/marketing-sales/meta-ads-creative-hooks.md": {
-      "hash": "3a892f7c5a749cff48c344a42517c56370634192",
       "at": "2026-03-27T21:25:06Z",
+      "hash": "3a892f7c5a749cff48c344a42517c56370634192",
       "passes": 1,
       "pr": 11016
     },
     ".agents/marketing-sales/meta-ads-creative-psychology.md": {
-      "hash": "bdea05241c41b138ac15a9861b3e3585fade0882",
       "at": "2026-03-30T04:52:02Z",
+      "hash": "bdea05241c41b138ac15a9861b3e3585fade0882",
       "passes": 1,
       "pr": 13729
     },
     ".agents/marketing-sales/meta-ads-creative-scripts.md": {
-      "hash": "3bf57bb61454673b49952c27f186e8b19e00a80b",
       "at": "2026-03-28T03:10:39Z",
+      "hash": "3bf57bb61454673b49952c27f186e8b19e00a80b",
       "passes": 1,
       "pr": 11297
     },
     ".agents/marketing-sales/meta-ads-foundations-account-structure.md": {
-      "hash": "e719c5ec6fc041b1cbef279023f4b87816b0d540",
       "at": "2026-03-29T21:43:00Z",
+      "hash": "e719c5ec6fc041b1cbef279023f4b87816b0d540",
       "passes": 1,
       "pr": 13333
     },
     ".agents/marketing-sales/meta-ads-foundations-algorithm.md": {
-      "hash": "69954101359c50c16df52841a3e53570980796c2",
       "at": "2026-04-01T20:59:13Z",
+      "hash": "69954101359c50c16df52841a3e53570980796c2",
       "passes": 1,
       "pr": 15138
     },
     ".agents/marketing-sales/meta-ads-foundations-attribution.md": {
-      "hash": "9a3a60eb59f935f1574e8126a44d5ea61b201250",
       "at": "2026-03-29T11:51:45Z",
+      "hash": "9a3a60eb59f935f1574e8126a44d5ea61b201250",
       "passes": 1,
       "pr": 12920
     },
     ".agents/marketing-sales/meta-ads-foundations-glossary.md": {
-      "hash": "96b53fe0267257b1b82d117e1e157de7f0cb2d16",
       "at": "2026-03-30T03:33:50Z",
+      "hash": "96b53fe0267257b1b82d117e1e157de7f0cb2d16",
       "passes": 1,
       "pr": 13691
     },
     ".agents/marketing-sales/meta-ads-optimization-automation-rules.md": {
-      "hash": "68c2fc51c77fb8de9f6e2a588c94d2308730c206",
       "at": "2026-03-29T15:50:44Z",
+      "hash": "68c2fc51c77fb8de9f6e2a588c94d2308730c206",
       "passes": 1,
       "pr": 13078
     },
     ".agents/marketing-sales/meta-ads-optimization-metrics.md": {
-      "hash": "ea2d1d3f0d8bf321e27c3bfbe7378903facc08b2",
       "at": "2026-03-30T06:49:39Z",
+      "hash": "ea2d1d3f0d8bf321e27c3bfbe7378903facc08b2",
       "passes": 1,
       "pr": 13940
     },
     ".agents/marketing-sales/meta-ads-optimization-scaling.md": {
-      "hash": "61d34f73361ab7d37b5e898279d12fe9bed4ad50",
       "at": "2026-03-28T08:17:40Z",
+      "hash": "61d34f73361ab7d37b5e898279d12fe9bed4ad50",
       "passes": 1,
       "pr": 11564
     },
     ".agents/marketing-sales/meta-ads-optimization-troubleshooting.md": {
-      "hash": "8e6917f00c023eaf1c57376a86b322fd6ac5f3a3",
       "at": "2026-03-28T08:17:40Z",
+      "hash": "8e6917f00c023eaf1c57376a86b322fd6ac5f3a3",
       "passes": 1,
       "pr": 11564
     },
     ".agents/marketing-sales/meta-ads.md": {
-      "hash": "5d272acd288aaaaeab3682493a76a69a8639839e",
       "at": "2026-03-28T16:40:30Z",
+      "hash": "5d272acd288aaaaeab3682493a76a69a8639839e",
       "passes": 1,
       "pr": 12024
     },
     ".agents/product/analytics.md": {
-      "hash": "13b12be37a613f3b0112d4b32ec9d813d158e89c",
       "at": "2026-03-29T23:53:58Z",
+      "hash": "13b12be37a613f3b0112d4b32ec9d813d158e89c",
       "passes": 1,
       "pr": 13415
     },
     ".agents/product/growth.md": {
-      "hash": "de6ce77c22a898f11ed9558c4070e8c6fd08f236",
       "at": "2026-03-28T16:40:15Z",
+      "hash": "de6ce77c22a898f11ed9558c4070e8c6fd08f236",
       "passes": 1,
       "pr": 12037
     },
     ".agents/product/monetisation.md": {
-      "hash": "a249780012f6a789b73d22eecc1691d8b0ff81da",
       "at": "2026-04-03T01:52:56Z",
+      "hash": "a249780012f6a789b73d22eecc1691d8b0ff81da",
       "passes": 2,
       "pr": 16017
     },
     ".agents/product/onboarding.md": {
-      "hash": "9b9c596dfa9f5c8dd13af582f793dc28071c2e3c",
       "at": "2026-03-29T23:54:00Z",
+      "hash": "9b9c596dfa9f5c8dd13af582f793dc28071c2e3c",
       "passes": 1,
       "pr": 13399
     },
     ".agents/product/ui-design.md": {
-      "hash": "b99b31785175b130458463dd39d6846f22ab35db",
       "at": "2026-04-03T22:25:09Z",
+      "hash": "b99b31785175b130458463dd39d6846f22ab35db",
       "passes": 2,
       "pr": 13539
     },
     ".agents/product/validation.md": {
-      "hash": "edd0ff2aca3ea4dae6a54da8cde686ee11312db7",
       "at": "2026-03-29T12:37:13Z",
+      "hash": "edd0ff2aca3ea4dae6a54da8cde686ee11312db7",
       "passes": 1,
       "pr": 12910
     },
     ".agents/prompts/worker-efficiency-protocol.md": {
-      "hash": "ad80bbd159a7ed21eeca89e99008a11bfe8a0649",
       "at": "2026-04-09T07:31:59Z",
+      "hash": "ad80bbd159a7ed21eeca89e99008a11bfe8a0649",
       "passes": 4,
       "pr": 14943
     },
     ".agents/reference/agent-routing.md": {
-      "hash": "36bb34cdce4480e14cb39a1c8a76bdace2f6309b",
       "at": "2026-03-31T05:34:14Z",
+      "hash": "36bb34cdce4480e14cb39a1c8a76bdace2f6309b",
       "passes": 1,
       "pr": 14650
     },
+    ".agents/reference/attribution-monitoring.md": {
+      "at": "2026-04-04T14:54:09Z",
+      "hash": "bf262309ae04f51cc53f5ffaf44fb65b9ee5f60e",
+      "passes": 1,
+      "pr": 17331
+    },
     ".agents/reference/auto-update.md": {
-      "hash": "c69c8a6aa5c31c062d2973ba308a9f86cf28ef6e",
       "at": "2026-04-01T23:23:47Z",
+      "hash": "c69c8a6aa5c31c062d2973ba308a9f86cf28ef6e",
       "passes": 1,
       "pr": 15301
     },
+    ".agents/reference/bash-compat.md": {
+      "at": "2026-04-14T20:16:56Z",
+      "hash": "2349fcdc14f5b7aa6a1c7c23008e38f8ef558240",
+      "passes": 3,
+      "pr": 16580
+    },
+    ".agents/reference/bash-fd-locking.md": {
+      "at": "2026-04-13T20:41:46Z",
+      "hash": "79fdafdb8ba9765b398538f513272a710e2f696a",
+      "passes": 1,
+      "pr": 18711
+    },
     ".agents/reference/configuration.md": {
-      "hash": "7a16abf44544a2831983c860798f72ab552c09ac",
       "at": "2026-03-28T04:30:48Z",
+      "hash": "7a16abf44544a2831983c860798f72ab552c09ac",
       "passes": 1,
       "pr": 11321
     },
     ".agents/reference/contribution-watch.md": {
-      "hash": "2ab40e0aa646a7250cedc1f3f31d24096cece8f5",
       "at": "2026-04-01T23:23:47Z",
+      "hash": "2ab40e0aa646a7250cedc1f3f31d24096cece8f5",
       "passes": 1,
       "pr": 15301
     },
+    ".agents/reference/cross-runner-coordination.md": {
+      "at": "2026-04-14T08:25:14Z",
+      "hash": "c90bb1c6df51bb3a23625fc628f41d4952227aa6",
+      "passes": 2,
+      "pr": 18658
+    },
+    ".agents/reference/customization.md": {
+      "at": "2026-04-05T19:44:17Z",
+      "hash": "f0eacffbaf909a5f1849f7bf5668c92a81ba252d",
+      "passes": 1,
+      "pr": 17436
+    },
     ".agents/reference/define-probes/bugfix.md": {
-      "hash": "7ecba470ce2f414ad551be59bae4434ea756b235",
       "at": "2026-04-01T23:23:39Z",
+      "hash": "7ecba470ce2f414ad551be59bae4434ea756b235",
       "passes": 1,
       "pr": 15334
     },
+    ".agents/reference/define-probes/docs.md": {
+      "at": "2026-04-03T16:35:53Z",
+      "hash": "05d9d70bca6d602485ce4081c5810c9f76533ceb",
+      "passes": 1,
+      "pr": 16671
+    },
     ".agents/reference/define-probes/feature.md": {
-      "hash": "7e6bc74adde5459ac1d2500a93e53884c8385144",
       "at": "2026-04-03T11:54:15Z",
+      "hash": "7e6bc74adde5459ac1d2500a93e53884c8385144",
       "passes": 1,
       "pr": 16447
     },
+    ".agents/reference/define-probes/refactor.md": {
+      "at": "2026-04-03T13:35:14Z",
+      "hash": "fcdb563754db4003c7785b9f5140cd848f959f8b",
+      "passes": 1,
+      "pr": 16571
+    },
     ".agents/reference/define-probes/research.md": {
-      "hash": "3d07139065208b857d15784e0829d1d8cbc5071c",
       "at": "2026-04-03T11:54:13Z",
+      "hash": "3d07139065208b857d15784e0829d1d8cbc5071c",
       "passes": 1,
       "pr": 16538
     },
     ".agents/reference/entity-memory-architecture.md": {
-      "hash": "e4c5814ced065f547736ac07d836d58f22c9fc35",
       "at": "2026-04-02T00:00:00Z",
+      "hash": "e4c5814ced065f547736ac07d836d58f22c9fc35",
       "passes": 1,
       "pr": 15488
     },
+    ".agents/reference/external-repo-submissions.md": {
+      "at": "2026-04-04T00:00:00Z",
+      "hash": "272ce05104d2393a198de590e77619a4ac31a694",
+      "passes": 1,
+      "pr": 17146
+    },
     ".agents/reference/foss-contributions.md": {
-      "hash": "a841f4c5b8c039fd5b1b21feb76527b033fc978c",
       "at": "2026-03-30T02:30:24Z",
+      "hash": "a841f4c5b8c039fd5b1b21feb76527b033fc978c",
       "passes": 1,
       "pr": 13561
     },
     ".agents/reference/hashline-edit-format.md": {
-      "hash": "593ef8f0f9a2f3b343b956f159d1351f3f83b1b7",
       "at": "2026-04-01T23:23:50Z",
+      "hash": "593ef8f0f9a2f3b343b956f159d1351f3f83b1b7",
       "passes": 1,
       "pr": 15277
     },
     ".agents/reference/high-stakes-operations.md": {
-      "hash": "fc06e06d1a03b8f3cd9a9b38af4442488e0ca0a7",
       "at": "2026-03-27T21:25:17Z",
+      "hash": "fc06e06d1a03b8f3cd9a9b38af4442488e0ca0a7",
       "passes": 1,
       "pr": 11012
     },
     ".agents/reference/memory.md": {
-      "hash": "144440151c1f9123e869a96273261c190908510f",
       "at": "2026-03-28T07:37:36Z",
+      "hash": "144440151c1f9123e869a96273261c190908510f",
       "passes": 1,
       "pr": 11538
     },
     ".agents/reference/orchestration.md": {
-      "hash": "e49bf3246dfe83a427b476e4c4d7bdcf88865d26",
       "at": "2026-04-03T11:54:15Z",
+      "hash": "e49bf3246dfe83a427b476e4c4d7bdcf88865d26",
       "passes": 1,
       "pr": 16427
     },
     ".agents/reference/planning-detail.md": {
-      "hash": "0565ca86e1081286e587617bd770da53a6149ba6",
       "at": "2026-04-09T07:32:00Z",
+      "hash": "0565ca86e1081286e587617bd770da53a6149ba6",
       "passes": 2,
       "pr": 12780
     },
     ".agents/reference/platform-support.md": {
-      "hash": "d7636c30409fac6e94715ebc30d9704bc01e773d",
       "at": "2026-04-03T00:48:09Z",
+      "hash": "d7636c30409fac6e94715ebc30d9704bc01e773d",
       "passes": 1,
       "pr": "GH#16007"
     },
     ".agents/reference/repo-sync.md": {
-      "hash": "956d314b65f7121e5b484fc97eb35b338a7e5c3d",
       "at": "2026-04-01T23:23:47Z",
+      "hash": "956d314b65f7121e5b484fc97eb35b338a7e5c3d",
       "passes": 1,
       "pr": 15301
     },
+    ".agents/reference/routines.md": {
+      "at": "2026-04-09T07:32:15Z",
+      "hash": "6327d4259cc6c85d5173c1b3a9e4b0fa28f29b27",
+      "passes": 1,
+      "pr": 17783
+    },
     ".agents/reference/secret-handling.md": {
-      "hash": "88888df5299cf3aa75283d4ef89f5f5d25e6b1ce",
       "at": "2026-04-03T02:08:59Z",
+      "hash": "88888df5299cf3aa75283d4ef89f5f5d25e6b1ce",
       "passes": 2,
       "pr": 15664
     },
     ".agents/reference/services.md": {
-      "hash": "bf72ff4d5cf651b21ff68509a25cf7d2820da819",
       "at": "2026-04-01T23:23:47Z",
+      "hash": "bf72ff4d5cf651b21ff68509a25cf7d2820da819",
       "passes": 1,
       "pr": 15301
     },
     ".agents/reference/session.md": {
-      "hash": "10f59fce435f670e30498c4df26d50fb6dacfcb6",
       "at": "2026-04-03T11:54:15Z",
+      "hash": "10f59fce435f670e30498c4df26d50fb6dacfcb6",
       "passes": 1,
       "pr": 16417
     },
     ".agents/reference/settings.md": {
-      "hash": "c3ac6ca2fff10f61d59aec97ceb51a4f0a6e9d72",
       "at": "2026-03-30T03:34:12Z",
+      "hash": "c3ac6ca2fff10f61d59aec97ceb51a4f0a6e9d72",
       "passes": 1,
       "pr": 13637
     },
+    ".agents/reference/task-taxonomy.md": {
+      "at": "2026-04-14T08:25:15Z",
+      "hash": "7558ca4b07e906fe0dd9895a8202609fdcfea974",
+      "passes": 6,
+      "pr": "pending"
+    },
+    ".agents/reference/worker-diagnostics.md": {
+      "at": "2026-04-13T16:27:30Z",
+      "hash": "5b00c40cfd173d9d69aad52b4c757b0a9a976133",
+      "passes": 2,
+      "pr": 17659
+    },
     ".agents/research.md": {
-      "hash": "e30f6a29668b78be4808c38b12913ffaa49e6562",
       "at": "2026-04-11T17:01:23Z",
+      "hash": "e30f6a29668b78be4808c38b12913ffaa49e6562",
       "passes": 3,
       "pr": 14996
     },
     ".agents/scripts/anti-detect-helper.sh": {
-      "hash": "730469e80477587a80574ef900b64911a8cd04f7",
       "at": "2026-04-03T12:15:33Z",
+      "hash": "730469e80477587a80574ef900b64911a8cd04f7",
       "passes": 1,
       "pr": 16548
     },
+    ".agents/scripts/approval-helper.sh": {
+      "at": "2026-04-14T08:25:15Z",
+      "hash": "5e11b9ad67f1c65ca3f599af558ef858cb1b4132",
+      "passes": 5,
+      "pr": 17454
+    },
+    ".agents/scripts/attribution-detection-helper.sh": {
+      "at": "2026-04-09T07:32:00Z",
+      "hash": "5990dd296001d54709e73b55f692043adaaa3c15",
+      "passes": 3,
+      "pr": 0
+    },
     ".agents/scripts/backfill-origin-labels.sh": {
-      "hash": "c96eaf8780e1c755ad1ce894d16917f44496c073",
       "at": "2026-04-02T21:58:18Z",
+      "hash": "c96eaf8780e1c755ad1ce894d16917f44496c073",
       "passes": 1,
       "pr": 15661
     },
+    ".agents/scripts/brief-tier-test-helper.sh": {
+      "at": "2026-04-09T07:32:16Z",
+      "hash": "e856d04a2fead9fcf07c4e5ca80ab1ce792e6348",
+      "passes": 1,
+      "pr": 17646
+    },
     ".agents/scripts/browser-qa-helper.sh": {
-      "hash": "a3f28b9757f0eec9127bffad3c49b93b450e7c5a",
       "at": "2026-04-03T03:15:27Z",
+      "hash": "a3f28b9757f0eec9127bffad3c49b93b450e7c5a",
       "passes": 1,
       "pr": 16086
     },
     ".agents/scripts/budget-analysis-helper.sh": {
-      "hash": "3c8856bf28b1ff5217a909957423463581d8ebf5",
       "at": "2026-04-03T03:15:27Z",
+      "hash": "3c8856bf28b1ff5217a909957423463581d8ebf5",
       "passes": 1,
       "pr": 16085
     },
-    ".agents/scripts/commands/budget-analysis.md": {
-      "hash": "569615974642992d98d6c17889d1e88d55ace376",
+    ".agents/scripts/claim-task-id.sh": {
+      "at": "2026-04-15T19:03:23Z",
+      "hash": "f8f3af654bf30e0b9160bd71c2de7ffa3e66c56b",
+      "passes": 6,
+      "pr": 17531
+    },
+    ".agents/scripts/commands/add-skill.md": {
       "at": "2026-04-11T17:01:24Z",
+      "hash": "c52915c7f433ba906fd87135e8620e784aa90c85",
+      "passes": 3,
+      "pr": 16634
+    },
+    ".agents/scripts/commands/autoagent.md": {
+      "at": "2026-04-11T17:01:24Z",
+      "hash": "b0099a8d2c81d616a46b25570bfcae141ee0206a",
+      "passes": 3,
+      "pr": 16700
+    },
+    ".agents/scripts/commands/autoresearch.md": {
+      "at": "2026-04-11T03:27:09Z",
+      "hash": "f6c9df3d4d0f41acbccf1714eaa890ea59bcb0b3",
+      "passes": 3,
+      "pr": 16569
+    },
+    ".agents/scripts/commands/budget-analysis.md": {
+      "at": "2026-04-11T17:01:24Z",
+      "hash": "569615974642992d98d6c17889d1e88d55ace376",
       "passes": 2,
       "pr": 15257
     },
+    ".agents/scripts/commands/build-agent.md": {
+      "at": "2026-04-13T17:44:12Z",
+      "hash": "72256f1cd59db2f7f0ce47ddce039ffad91193f3",
+      "passes": 1,
+      "pr": 18660
+    },
     ".agents/scripts/commands/cross-review.md": {
-      "hash": "9abe6822cceedcdf15d2bef80e5f6f3329c6ffa3",
       "at": "2026-04-11T16:20:00Z",
+      "hash": "9abe6822cceedcdf15d2bef80e5f6f3329c6ffa3",
       "passes": 2,
       "pr": 16528
     },
     ".agents/scripts/commands/dashboard.md": {
-      "hash": "5bbcdea5ff2f11645d298870cd6385b131ecd48f",
       "at": "2026-04-11T17:01:24Z",
+      "hash": "5bbcdea5ff2f11645d298870cd6385b131ecd48f",
       "passes": 4,
       "pr": 13338
     },
     ".agents/scripts/commands/define.md": {
-      "hash": "50fedc89674fa998b1a1a7e3fae138649473a8f2",
       "at": "2026-04-15T03:00:29Z",
+      "hash": "50fedc89674fa998b1a1a7e3fae138649473a8f2",
       "passes": 7,
       "pr": 13131
     },
-    ".agents/scripts/commands/email-outreach.md": {
-      "hash": "eec3a0cfbb715b4d281fbde029654c8e157facbf",
+    ".agents/scripts/commands/email-campaign.md": {
+      "at": "2026-04-03T19:14:46Z",
+      "hash": "a04ab6e1ffb2b87702ad037a773e7e330cee05ea",
+      "passes": 1,
+      "pr": 16804
+    },
+    ".agents/scripts/commands/email-delivery-test.md": {
+      "at": "2026-04-11T03:27:26Z",
+      "hash": "351ce5d6596112769560bdd68ceab2b955e374d0",
+      "passes": 1,
+      "pr": 18118
+    },
+    ".agents/scripts/commands/email-design-test.md": {
+      "at": "2026-04-11T07:23:25Z",
+      "hash": "2055f755f4558bb21f4ac9714e6f1011b2745ec4",
+      "passes": 1,
+      "pr": 18170
+    },
+    ".agents/scripts/commands/email-health-check.md": {
+      "at": "2026-04-11T02:40:55Z",
+      "hash": "e558738cbf896c8ecf3dc22b981a175b95f43521",
+      "passes": 2,
+      "pr": 16709
+    },
+    ".agents/scripts/commands/email-inbox.md": {
       "at": "2026-04-11T16:20:00Z",
+      "hash": "4f1ca21839cf5220d8b32c732671288f83ac5c72",
+      "passes": 2,
+      "pr": 16588
+    },
+    ".agents/scripts/commands/email-outreach.md": {
+      "at": "2026-04-11T16:20:00Z",
+      "hash": "eec3a0cfbb715b4d281fbde029654c8e157facbf",
       "passes": 2,
       "pr": 15480
     },
+    ".agents/scripts/commands/findings-to-tasks.md": {
+      "at": "2026-04-03T22:25:11Z",
+      "hash": "8803d261cda3f68f7a2a94d29d29a91d88a38c3b",
+      "passes": 2,
+      "pr": 16797
+    },
     ".agents/scripts/commands/full-loop.md": {
-      "hash": "dda139893758fd40ed3195ea4cd58d4287c61bdc",
       "at": "2026-04-15T03:00:29Z",
+      "hash": "dda139893758fd40ed3195ea4cd58d4287c61bdc",
       "passes": 13,
       "pr": 14590
     },
+    ".agents/scripts/commands/init-routines.md": {
+      "at": "2026-04-09T07:32:15Z",
+      "hash": "bd1fec1da0b4e9aa2b45fe74a613d86d7f81106a",
+      "passes": 1,
+      "pr": 17819
+    },
     ".agents/scripts/commands/ip-check.md": {
-      "hash": "a802627084e3cfeb82ac91c49cbdcff51205c98e",
       "at": "2026-03-31T02:20:51Z",
+      "hash": "a802627084e3cfeb82ac91c49cbdcff51205c98e",
       "passes": 2,
       "pr": 14484
     },
     ".agents/scripts/commands/list-todo.md": {
-      "hash": "95c0b8090f68c9cb4f17a6516af5a511067393ed",
       "at": "2026-04-11T16:20:01Z",
+      "hash": "95c0b8090f68c9cb4f17a6516af5a511067393ed",
       "passes": 2,
       "pr": 14898
     },
     ".agents/scripts/commands/list-verify.md": {
-      "hash": "5d5d52ede7bbc513f44dc72fe352d885b809a8ad",
       "at": "2026-04-11T17:01:24Z",
+      "hash": "5d5d52ede7bbc513f44dc72fe352d885b809a8ad",
       "passes": 2,
       "pr": 15514
     },
     ".agents/scripts/commands/log-issue-aidevops.md": {
-      "hash": "0cfc454fb3c066b686fca341a058bbb712865c85",
       "at": "2026-04-11T17:01:24Z",
+      "hash": "0cfc454fb3c066b686fca341a058bbb712865c85",
       "passes": 5,
       "pr": 11007
     },
     ".agents/scripts/commands/memory-log.md": {
-      "hash": "6a3163963518347ca2f44ea5d69e4464f2ac1258",
       "at": "2026-04-11T16:20:01Z",
+      "hash": "6a3163963518347ca2f44ea5d69e4464f2ac1258",
       "passes": 2,
       "pr": 15701
     },
     ".agents/scripts/commands/mission.md": {
-      "hash": "a375e9f6438301448a509e2b5a75c933fbb05c31",
       "at": "2026-04-11T04:09:31Z",
+      "hash": "a375e9f6438301448a509e2b5a75c933fbb05c31",
       "passes": 2,
       "pr": 12959
     },
+    ".agents/scripts/commands/models-pool-check.md": {
+      "at": "2026-04-11T16:20:01Z",
+      "hash": "72b94302544b07cfb930b8f97e3d55a6fe6b4c6f",
+      "passes": 2,
+      "pr": 16633
+    },
     ".agents/scripts/commands/neuronwriter.md": {
-      "hash": "6d9d9b9ff1e61097f415362a55ce4444a5cabd74",
       "at": "2026-04-11T02:40:55Z",
+      "hash": "6d9d9b9ff1e61097f415362a55ce4444a5cabd74",
       "passes": 2,
       "pr": 12588
     },
     ".agents/scripts/commands/new-task.md": {
-      "hash": "f26544a937d7a831ee1e0b954a63a093194cd9d6",
       "at": "2026-04-13T16:27:31Z",
+      "hash": "f26544a937d7a831ee1e0b954a63a093194cd9d6",
       "passes": 5,
       "pr": 13489
     },
+    ".agents/scripts/commands/optimize-tiers.md": {
+      "at": "2026-04-09T07:32:16Z",
+      "hash": "066bd6b47e328dbd06fdda6e003d447d060aa816",
+      "passes": 1,
+      "pr": 17660
+    },
     ".agents/scripts/commands/performance.md": {
-      "hash": "e5ce4d702b99f2e0d80a5cdea995e0c5fabf4706",
       "at": "2026-04-11T16:20:01Z",
+      "hash": "e5ce4d702b99f2e0d80a5cdea995e0c5fabf4706",
       "passes": 2,
       "pr": 16527
     },
     ".agents/scripts/commands/postflight-loop.md": {
-      "hash": "1db90c094b167be0bc0ce7e08348f8807e8f5bd1",
       "at": "2026-04-11T17:01:24Z",
+      "hash": "1db90c094b167be0bc0ce7e08348f8807e8f5bd1",
       "passes": 2,
       "pr": 14942
     },
     ".agents/scripts/commands/pr-loop.md": {
-      "hash": "4a8ff788d897a07739b9e729d6fd4945b62e1984",
       "at": "2026-04-13T16:27:31Z",
+      "hash": "4a8ff788d897a07739b9e729d6fd4945b62e1984",
       "passes": 3,
       "pr": 15682
     },
     ".agents/scripts/commands/pulse-sweep.md": {
-      "hash": "a53224a50e1a86cc16c371dab21f300bca4c2650",
       "at": "2026-04-14T09:59:01Z",
+      "hash": "a53224a50e1a86cc16c371dab21f300bca4c2650",
       "passes": 7,
       "pr": 16472
     },
     ".agents/scripts/commands/pulse.md": {
-      "hash": "ff61825e354fc702e37c4716e1a891698d2b480e",
       "at": "2026-04-14T09:59:01Z",
+      "hash": "ff61825e354fc702e37c4716e1a891698d2b480e",
       "passes": 10,
       "pr": 13117
     },
+    ".agents/scripts/commands/readme.md": {
+      "at": "2026-04-04T14:54:13Z",
+      "hash": "649a3483e9e073b8f1f1d2cffbe07b8575f79a92",
+      "passes": 1,
+      "pr": 17278
+    },
     ".agents/scripts/commands/recall.md": {
-      "hash": "1864c208e682156f245e902148bcbd43f125656f",
       "at": "2026-04-02T04:56:44Z",
+      "hash": "1864c208e682156f245e902148bcbd43f125656f",
       "passes": 1,
       "pr": 15515
     },
     ".agents/scripts/commands/remember.md": {
-      "hash": "0ba07b19fe8575b0913278c31909989d6a5804f0",
       "at": "2026-04-11T17:01:25Z",
+      "hash": "0ba07b19fe8575b0913278c31909989d6a5804f0",
       "passes": 3,
       "pr": 12497
     },
     ".agents/scripts/commands/route.md": {
-      "hash": "66757efd8808fa986f6eed5ad94caaf9a785b9c2",
       "at": "2026-03-31T04:45:56Z",
+      "hash": "66757efd8808fa986f6eed5ad94caaf9a785b9c2",
       "passes": 2,
       "pr": 14604
     },
     ".agents/scripts/commands/routine.md": {
-      "hash": "827b42666786545fbfc5c59a1a2d6160645d9288",
       "at": "2026-04-11T05:05:49Z",
+      "hash": "827b42666786545fbfc5c59a1a2d6160645d9288",
       "passes": 4,
       "pr": 14509
     },
     ".agents/scripts/commands/runners-check.md": {
-      "hash": "db8bedaa399aa56da0189ca43d459000c739cfb8",
       "at": "2026-04-11T17:01:25Z",
+      "hash": "db8bedaa399aa56da0189ca43d459000c739cfb8",
       "passes": 3,
       "pr": 16418
     },
     ".agents/scripts/commands/runners.md": {
-      "hash": "30a6c21fa4468a21a6d93f5d5dd68c9803914792",
       "at": "2026-04-11T16:20:01Z",
+      "hash": "30a6c21fa4468a21a6d93f5d5dd68c9803914792",
       "passes": 3,
       "pr": 12326
     },
     ".agents/scripts/commands/save-todo.md": {
-      "hash": "8933761097b52d8a79e7ef85347f2b2d7a9e6b53",
       "at": "2026-04-11T17:01:25Z",
+      "hash": "8933761097b52d8a79e7ef85347f2b2d7a9e6b53",
       "passes": 3,
       "pr": 12521
     },
     ".agents/scripts/commands/security-deps.md": {
-      "hash": "aabd518951d3c4287a249d093b018e0530ebe33e",
       "at": "2026-04-01T20:59:27Z",
+      "hash": "aabd518951d3c4287a249d093b018e0530ebe33e",
       "passes": 1,
       "pr": 14994
     },
     ".agents/scripts/commands/security-history.md": {
-      "hash": "8c7f2962a48b3e5f45ae0270550f54f35c994e0e",
       "at": "2026-04-02T04:56:52Z",
+      "hash": "8c7f2962a48b3e5f45ae0270550f54f35c994e0e",
       "passes": 1,
       "pr": 15487
     },
     ".agents/scripts/commands/security-review.md": {
-      "hash": "86e12ee2f68e13f130b450943844319d47ec13fe",
       "at": "2026-04-11T17:01:25Z",
+      "hash": "86e12ee2f68e13f130b450943844319d47ec13fe",
       "passes": 2,
       "pr": 15535
     },
     ".agents/scripts/commands/seo-analyze.md": {
-      "hash": "ff7673d675ffa71518c0d5df86b1b723605182be",
       "at": "2026-04-02T21:58:20Z",
+      "hash": "ff7673d675ffa71518c0d5df86b1b723605182be",
       "passes": 1,
       "pr": 15502
     },
     ".agents/scripts/commands/seo-audit.md": {
-      "hash": "e04729ef8d0f40b30efc59f9914d8ec420218efa",
       "at": "2026-04-02T03:11:11Z",
+      "hash": "e04729ef8d0f40b30efc59f9914d8ec420218efa",
       "passes": 1,
       "pr": 15477
     },
+    ".agents/scripts/commands/seo-optimize.md": {
+      "at": "2026-04-04T14:54:10Z",
+      "hash": "d4781587585025ddaf8cd43af9117ab3d94f7152",
+      "passes": 1,
+      "pr": 17306
+    },
+    ".agents/scripts/commands/session-review.md": {
+      "at": "2026-04-11T05:06:05Z",
+      "hash": "75539fb19f3e764a723d6534c6b2090709b3b423",
+      "passes": 1,
+      "pr": 18147
+    },
     ".agents/scripts/commands/show-plan.md": {
-      "hash": "21346c11078a086da90e08dffcde74c7421c1ab2",
       "at": "2026-04-11T15:18:08Z",
+      "hash": "21346c11078a086da90e08dffcde74c7421c1ab2",
       "passes": 2,
       "pr": 13285
     },
     ".agents/scripts/commands/skills.md": {
-      "hash": "6f3730d9ef553317a124f1c5b94830356465e9d9",
       "at": "2026-04-11T17:01:25Z",
+      "hash": "6f3730d9ef553317a124f1c5b94830356465e9d9",
       "passes": 3,
       "pr": 12747
     },
     ".agents/scripts/commands/strategic-review.md": {
-      "hash": "43a301d8898d025de92302fabd39fdc8dd63b820",
       "at": "2026-04-11T04:09:32Z",
+      "hash": "43a301d8898d025de92302fabd39fdc8dd63b820",
       "passes": 2,
       "pr": 12756
     },
     ".agents/scripts/commands/tech-stack.md": {
-      "hash": "216e9632f81e8fe92c00cfd33455728869b89705",
       "at": "2026-04-11T13:54:10Z",
+      "hash": "216e9632f81e8fe92c00cfd33455728869b89705",
       "passes": 3
     },
     ".agents/scripts/commands/testing-setup.md": {
-      "hash": "add7056788f9b456c2867f2c6133f6986df52b5f",
       "at": "2026-03-28T16:40:41Z",
+      "hash": "add7056788f9b456c2867f2c6133f6986df52b5f",
       "passes": 1,
       "pr": 12013
     },
     ".agents/scripts/commands/venv-health.md": {
-      "hash": "7dbecf6097302b2ff2d69ddfbe63626306713f91",
       "at": "2026-04-11T16:20:02Z",
+      "hash": "7dbecf6097302b2ff2d69ddfbe63626306713f91",
       "passes": 2,
       "pr": 15577
     },
     ".agents/scripts/commands/worktree-cleanup.md": {
-      "hash": "251971abfb682ca259ec75c0510df2c2dd4102af",
       "at": "2026-04-11T16:20:02Z",
+      "hash": "251971abfb682ca259ec75c0510df2c2dd4102af",
       "passes": 2
     },
     ".agents/scripts/commands/youtube-research.md": {
-      "hash": "83444ef9cf1ad2231ed1ad62d1d5c623f3d00333",
       "at": "2026-04-11T17:01:25Z",
+      "hash": "83444ef9cf1ad2231ed1ad62d1d5c623f3d00333",
       "passes": 3,
       "pr": 12750
     },
     ".agents/scripts/commands/youtube-setup.md": {
-      "hash": "257a899899f34d5907e2acf338cf587fbeddefa0",
       "at": "2026-04-11T16:20:02Z",
+      "hash": "257a899899f34d5907e2acf338cf587fbeddefa0",
       "passes": 2,
       "pr": 12943
     },
     ".agents/scripts/commands/yt-dlp.md": {
-      "hash": "4dae1ca9bd059d4ab416b421f96766f6188ff7f1",
       "at": "2026-04-11T17:01:25Z",
+      "hash": "4dae1ca9bd059d4ab416b421f96766f6188ff7f1",
       "passes": 2,
       "pr": 13544
     },
     ".agents/scripts/compare-models-helper.sh": {
-      "hash": "e4073c02f86fbd1282fc761eabcfffb04794e508",
       "at": "2026-04-15T03:00:31Z",
+      "hash": "e4073c02f86fbd1282fc761eabcfffb04794e508",
       "passes": 2,
       "pr": 15946
     },
+    ".agents/scripts/complexity-scan-helper.sh": {
+      "at": "2026-04-11T17:01:25Z",
+      "hash": "8152194b368fd6ac11c3e76c6dffe05604e48bb9",
+      "passes": 2,
+      "pr": 17713
+    },
     ".agents/scripts/config-helper.sh": {
-      "hash": "12dd983e382f5e3d45151fcb317d547ea4bec6f0",
       "at": "2026-04-05T17:38:48Z",
+      "hash": "12dd983e382f5e3d45151fcb317d547ea4bec6f0",
       "passes": 2,
       "pr": 16084
     },
     ".agents/scripts/cron-helper.sh": {
-      "hash": "2b63d10e39197fd598d801399b64d319a7eb8310",
       "at": "2026-04-15T22:51:53Z",
+      "hash": "2b63d10e39197fd598d801399b64d319a7eb8310",
       "passes": 2,
       "pr": 15920
     },
     ".agents/scripts/dataset-helper.sh": {
-      "hash": "cb1ba7406b8c27b0f40c08241dbd468ded453590",
       "at": "2026-04-03T03:15:27Z",
+      "hash": "cb1ba7406b8c27b0f40c08241dbd468ded453590",
       "passes": 1,
       "pr": 16098
     },
+    ".agents/scripts/design-preview-helper.sh": {
+      "at": "2026-04-15T21:02:38Z",
+      "hash": "fb72927eeb79b85ca1a2ce802de5eebb04871d40",
+      "passes": 4,
+      "pr": 16879
+    },
+    ".agents/scripts/dispatch-dedup-helper.sh": {
+      "at": "2026-04-14T20:16:59Z",
+      "hash": "1c1ba50e50a17b4d2232a1f7620e3b5455a12e96",
+      "passes": 13,
+      "pr": 18917
+    },
     ".agents/scripts/email-agent-helper.sh": {
-      "hash": "91df1fb51aa37de793b891afac677d583208cb4e",
       "at": "2026-04-03T03:15:28Z",
+      "hash": "91df1fb51aa37de793b891afac677d583208cb4e",
       "passes": 1,
       "pr": 15919
     },
     ".agents/scripts/foss-handlers/generic.sh": {
-      "hash": "7412f9cbe91058b1222b48f99b92d40700910d9e",
       "at": "2026-03-29T03:15:47Z",
+      "hash": "7412f9cbe91058b1222b48f99b92d40700910d9e",
       "passes": 1,
       "pr": 12346
     },
     ".agents/scripts/framework-issue-helper.sh": {
-      "hash": "642e29f5e886bbfb0b432f75f3067d763fda7acc",
       "at": "2026-04-02T15:26:33Z",
+      "hash": "642e29f5e886bbfb0b432f75f3067d763fda7acc",
       "passes": 2,
       "pr": 12145
     },
+    ".agents/scripts/full-loop-helper.sh": {
+      "at": "2026-04-15T22:51:54Z",
+      "hash": "d369e2bc2b0e7f9dad45789af18d1132ed306093",
+      "passes": 8,
+      "pr": 19046
+    },
+    ".agents/scripts/generate-claude-commands.sh": {
+      "at": "2026-04-15T22:51:54Z",
+      "hash": "2d23d498eb9145bf0633990c845f71c562e90165",
+      "passes": 2,
+      "pr": 17571
+    },
+    ".agents/scripts/generate-opencode-agents.sh": {
+      "at": "2026-04-13T20:02:42Z",
+      "hash": "e386a288bebdbfca44c0c5e05627c777d153ba32",
+      "passes": 1,
+      "pr": 18709
+    },
+    ".agents/scripts/generate-opencode-commands.sh": {
+      "at": "2026-04-09T07:32:16Z",
+      "hash": "19ac53376024c9ffaf4cd651816b2c5c889eca53",
+      "passes": 1,
+      "pr": 17583
+    },
     ".agents/scripts/generate-runtime-config.sh": {
-      "hash": "f1cc55085d4a477908d4d976c7f101cd37ec0348",
       "at": "2026-04-13T16:27:33Z",
+      "hash": "f1cc55085d4a477908d4d976c7f101cd37ec0348",
       "passes": 5,
       "pr": 15933
     },
     ".agents/scripts/gh-signature-helper.sh": {
-      "hash": "2c9224ad931498e61fafd526fe3495322092c2b5",
       "at": "2026-04-09T07:32:02Z",
+      "hash": "2c9224ad931498e61fafd526fe3495322092c2b5",
       "passes": 4,
       "pr": 13021
     },
     ".agents/scripts/headless-runtime-helper.sh": {
-      "hash": "745f866b490b147cfd645167825a25e365e023b0",
       "at": "2026-04-15T18:19:06Z",
+      "hash": "745f866b490b147cfd645167825a25e365e023b0",
       "passes": 20,
       "pr": 15086
     },
+    ".agents/scripts/headless-runtime-lib.sh": {
+      "at": "2026-04-15T18:19:06Z",
+      "hash": "cdb4aa53f178687550d6ca7504c281b374b23eed",
+      "passes": 4,
+      "pr": 18707
+    },
+    ".agents/scripts/interactive-session-helper.sh": {
+      "at": "2026-04-15T00:41:03Z",
+      "hash": "4a62f8f22b887223c9aa5c730d10f74d6350eef5",
+      "passes": 2,
+      "pr": 18843
+    },
+    ".agents/scripts/issue-sync-helper.sh": {
+      "at": "2026-04-15T19:03:28Z",
+      "hash": "5a6a3475e4b68052301dc60e5e65b8e80bfc5670",
+      "passes": 8,
+      "pr": 18706
+    },
     ".agents/scripts/issue-sync-lib.sh": {
-      "hash": "32cffbbb037d2750c9cd5c2cf751e68ddc696393",
       "at": "2026-04-15T03:00:31Z",
+      "hash": "32cffbbb037d2750c9cd5c2cf751e68ddc696393",
       "passes": 9,
       "pr": 16471
     },
+    ".agents/scripts/linters-local.sh": {
+      "at": "2026-04-15T03:00:31Z",
+      "hash": "73f92584b2779e28603e2251676c8c749a6524ef",
+      "passes": 4,
+      "pr": 17036
+    },
     ".agents/scripts/matrix-dispatch-helper.sh": {
-      "hash": "670ded5a2e120a4dd6cb6551c79bf21499ea9391",
       "at": "2026-04-15T22:51:54Z",
+      "hash": "670ded5a2e120a4dd6cb6551c79bf21499ea9391",
       "passes": 3,
       "pr": 15431
     },
+    ".agents/scripts/memory-pressure-monitor.sh": {
+      "at": "2026-04-15T03:00:32Z",
+      "hash": "8df7dbaf7b29f4c65bf3fbce670d766a31eabb74",
+      "passes": 2,
+      "pr": 17843
+    },
     ".agents/scripts/mission-email-helper.sh": {
-      "hash": "5a354d8ce16167b2d652049827405994264d4633",
       "at": "2026-04-03T03:15:29Z",
+      "hash": "5a354d8ce16167b2d652049827405994264d4633",
       "passes": 1,
       "pr": 15752
     },
+    ".agents/scripts/model-availability-helper.sh": {
+      "at": "2026-04-09T07:32:15Z",
+      "hash": "66d1406c1562ca42e13914a6cc27d2bd0625da3d",
+      "passes": 1,
+      "pr": 17797
+    },
+    ".agents/scripts/new-task-helper.sh": {
+      "at": "2026-04-14T02:22:26Z",
+      "hash": "4c8ce538c2cdbf98f4b247a4d9217aaa5bf67f5b",
+      "passes": 2,
+      "pr": 18705
+    },
+    ".agents/scripts/opencode-db-archive.sh": {
+      "at": "2026-04-15T17:57:19Z",
+      "hash": "2d1b2a3c0aea737a80a7f2d53af6c6e5637b5732",
+      "passes": 2,
+      "pr": 17584
+    },
     ".agents/scripts/opencode-github-setup-helper.sh": {
-      "hash": "0bc532636c20feb570ba6da3568d3b946c301288",
       "at": "2026-04-03T03:15:28Z",
+      "hash": "0bc532636c20feb570ba6da3568d3b946c301288",
       "passes": 1,
       "pr": 15918
     },
     ".agents/scripts/platform-detect.sh": {
-      "hash": "224ea149f5bed21ab2712cfa65c040962826c44b",
       "at": "2026-04-09T07:32:02Z",
+      "hash": "224ea149f5bed21ab2712cfa65c040962826c44b",
       "passes": 2,
       "pr": 15455
     },
+    ".agents/scripts/post-merge-review-scanner.sh": {
+      "at": "2026-04-14T20:17:00Z",
+      "hash": "6fcc33e1df2db4bdf5fe7fae2d5e3ba7b4c05979",
+      "passes": 2,
+      "pr": 18801
+    },
+    ".agents/scripts/profile-readme-helper.sh": {
+      "at": "2026-04-09T07:32:16Z",
+      "hash": "2bc11796eb2d8656da860f9d8cd75abce6224528",
+      "passes": 1,
+      "pr": 17590
+    },
+    ".agents/scripts/pulse-ancillary-dispatch.sh": {
+      "at": "2026-04-15T07:31:55Z",
+      "hash": "ab72fd6b20e25c4e7f8002d79a94fa44e5a71193",
+      "passes": 5,
+      "pr": 18657
+    },
+    ".agents/scripts/pulse-cleanup.sh": {
+      "at": "2026-04-15T02:32:29Z",
+      "hash": "88c7d4f1beba3de5f86421e507fc899b9879a6e6",
+      "passes": 4,
+      "pr": 18704
+    },
+    ".agents/scripts/pulse-dep-graph.sh": {
+      "at": "2026-04-15T18:38:06Z",
+      "hash": "4769810d4bc0232a099939fd5f221f41758b7e95",
+      "passes": 3,
+      "pr": 18796
+    },
+    ".agents/scripts/pulse-dispatch-core.sh": {
+      "at": "2026-04-15T20:05:53Z",
+      "hash": "2f27c838214719f8ee1e4e66b37cf84c95f9cdac",
+      "passes": 7,
+      "pr": 18832
+    },
+    ".agents/scripts/pulse-dispatch-engine.sh": {
+      "at": "2026-04-15T19:03:29Z",
+      "hash": "493094d6b67201c518eadd5f8809afd41a791cfb",
+      "passes": 5,
+      "pr": 18799
+    },
+    ".agents/scripts/pulse-fast-fail.sh": {
+      "at": "2026-04-14T08:25:19Z",
+      "hash": "292f4dfd80d2cb97715a9bda1fe985b5cabf6c80",
+      "passes": 3,
+      "pr": 18692
+    },
+    ".agents/scripts/pulse-instance-lock.sh": {
+      "at": "2026-04-14T07:25:45Z",
+      "hash": "d90500ea38749311fcc3dd3912690504789ce506",
+      "passes": 2,
+      "pr": 18691
+    },
+    ".agents/scripts/pulse-issue-reconcile.sh": {
+      "at": "2026-04-15T19:03:29Z",
+      "hash": "b0bfb72f063df16202865b19e899e55efafd7612",
+      "passes": 3,
+      "pr": 18690
+    },
+    ".agents/scripts/pulse-merge.sh": {
+      "at": "2026-04-15T22:51:54Z",
+      "hash": "c0f5c3e8a65928d25434ce4099cb23e2dd3404b8",
+      "passes": 10,
+      "pr": 18829
+    },
+    ".agents/scripts/pulse-prefetch.sh": {
+      "at": "2026-04-14T20:55:10Z",
+      "hash": "bdc2d29c3356b99a9d243966952a99da908f28b3",
+      "passes": 1,
+      "pr": 18995
+    },
+    ".agents/scripts/pulse-quality-debt.sh": {
+      "at": "2026-04-14T08:25:19Z",
+      "hash": "04957bb5580d2f45b0926bd22b2310916b1ab0da",
+      "passes": 3,
+      "pr": 18681
+    },
+    ".agents/scripts/pulse-simplification-state.sh": {
+      "at": "2026-04-15T02:32:29Z",
+      "hash": "1b044ed90b9140fab14cc33dae6af134816b6a13",
+      "passes": 5,
+      "pr": 18680
+    },
+    ".agents/scripts/pulse-simplification.sh": {
+      "at": "2026-04-15T07:31:56Z",
+      "hash": "b718adc3c87e5eeb6577f8b9dd4fad98d8565855",
+      "passes": 7,
+      "pr": 18653
+    },
+    ".agents/scripts/pulse-triage.sh": {
+      "at": "2026-04-15T03:31:34Z",
+      "hash": "b5ec15b500cac4d38c8d3296436a7b2cb27db94c",
+      "passes": 5,
+      "pr": 18655
+    },
     ".agents/scripts/pulse-wrapper.sh": {
-      "hash": "4379d9476e81f959b147367c8182509210898641",
       "at": "2026-04-15T18:19:07Z",
-      "pr": 18689,
-      "passes": 14
+      "hash": "4379d9476e81f959b147367c8182509210898641",
+      "passes": 14,
+      "pr": 18689
+    },
+    ".agents/scripts/quality-feedback-findings-lib.sh": {
+      "at": "2026-04-14T21:57:01Z",
+      "hash": "80348bed5038f651ffc98da1810e07dd244f2e6a",
+      "passes": 1,
+      "pr": 19009
+    },
+    ".agents/scripts/quality-feedback-helper.sh": {
+      "at": "2026-04-14T21:13:01Z",
+      "hash": "257a7f0e60d5b7b6ce51b93f4e150b0fb2babff7",
+      "passes": 3,
+      "pr": 19000
+    },
+    ".agents/scripts/quality-feedback-issues-lib.sh": {
+      "at": "2026-04-14T22:16:57Z",
+      "hash": "659f27c08e7ad944343d00646a2ccc522fd90bcd",
+      "passes": 1,
+      "pr": 19004
+    },
+    ".agents/scripts/routine-log-helper.sh": {
+      "at": "2026-04-15T03:31:35Z",
+      "hash": "7fb1dd659344d6b04666fcc271264c30004c5e6b",
+      "passes": 3,
+      "pr": 17786
     },
     ".agents/scripts/schema-validator-helper.sh": {
-      "hash": "91041cff94cedcf2b6e9fcaa8373cef9a77608bf",
       "at": "2026-04-03T03:15:29Z",
+      "hash": "91041cff94cedcf2b6e9fcaa8373cef9a77608bf",
       "passes": 1,
       "pr": 15776
     },
     ".agents/scripts/secretlint-helper.sh": {
-      "hash": "114e75b9a62df3ffebe82cdff165c2dd9b84fd51",
       "at": "2026-04-03T11:54:13Z",
+      "hash": "114e75b9a62df3ffebe82cdff165c2dd9b84fd51",
       "passes": 1,
       "pr": 16537
     },
     ".agents/scripts/seo-analysis-helper.sh": {
-      "hash": "03c65915515759a9e6b782087e76683a8439847c",
       "at": "2026-04-03T11:54:13Z",
+      "hash": "03c65915515759a9e6b782087e76683a8439847c",
       "passes": 1,
       "pr": 16536
     },
     ".agents/scripts/session-checkpoint-helper.sh": {
-      "hash": "e5beef2a264250ac84d4c25a9f577f3462ef4afa",
       "at": "2026-04-15T22:51:55Z",
+      "hash": "e5beef2a264250ac84d4c25a9f577f3462ef4afa",
       "passes": 3,
       "pr": 15917
     },
+    ".agents/scripts/session-miner-pulse.sh": {
+      "at": "2026-04-13T16:27:33Z",
+      "hash": "830c39693ed38aaf32579c8cbf498ddb44152cda",
+      "passes": 2,
+      "pr": 16950
+    },
     ".agents/scripts/settings-helper.sh": {
-      "hash": "c2be24f04336481e31e7e65dcb927578c21caa8b",
       "at": "2026-04-03T03:15:28Z",
+      "hash": "c2be24f04336481e31e7e65dcb927578c21caa8b",
       "passes": 1,
       "pr": 15916
     },
+    ".agents/scripts/shared-constants.sh": {
+      "at": "2026-04-15T08:16:49Z",
+      "hash": "316aa5a9199ef65e946ceee79b57f76cda430154",
+      "passes": 6,
+      "pr": 18847
+    },
     ".agents/scripts/stats-functions.sh": {
-      "hash": "6144ef3ed8663dfddb977ab01d686e3fcf22bf7f",
       "at": "2026-04-15T00:41:03Z",
-      "pr": 18808,
-      "passes": 10
+      "hash": "6144ef3ed8663dfddb977ab01d686e3fcf22bf7f",
+      "passes": 10,
+      "pr": 18808
+    },
+    ".agents/scripts/stats-quality-sweep.sh": {
+      "at": "2026-04-14T06:24:41Z",
+      "hash": "6fe05a80fbe9be2c6c0c56f40f40bd3b96f52bf1",
+      "passes": 2,
+      "pr": 18810
+    },
+    ".agents/scripts/tabby-helper.sh": {
+      "at": "2026-04-15T21:02:40Z",
+      "hash": "fcbdba8938e0a37591f2fb3e51fb24062d01356d",
+      "passes": 3,
+      "pr": 17549
+    },
+    ".agents/scripts/tests/test-consolidation-dispatch.sh": {
+      "at": "2026-04-14T07:57:30Z",
+      "hash": "91298b9d37f3ac50fdc71bbddcba460188ff43ee",
+      "passes": 2,
+      "pr": 18679
     },
     ".agents/scripts/tests/test-gh-signature-helper.sh": {
-      "hash": "ca0b55552cf1b7cbc0963325cbd56b0fdf526576",
       "at": "2026-04-09T07:32:02Z",
+      "hash": "ca0b55552cf1b7cbc0963325cbd56b0fdf526576",
       "passes": 4,
       "pr": 12971
     },
     ".agents/scripts/tests/test-quality-feedback-main-verification.sh": {
-      "hash": "129fb3c6863fc864a136908c7ad1cc9f7f7e8130",
       "at": "2026-04-09T07:32:02Z",
+      "hash": "129fb3c6863fc864a136908c7ad1cc9f7f7e8130",
       "passes": 2,
       "pr": 15931
     },
     ".agents/scripts/thumbnail-helper.sh": {
-      "hash": "ddb116b8bcd9fbb353f645a6879275607833148d",
       "at": "2026-04-03T03:15:28Z",
+      "hash": "ddb116b8bcd9fbb353f645a6879275607833148d",
       "passes": 1,
       "pr": 15905
     },
+    ".agents/scripts/validate-version-consistency.sh": {
+      "at": "2026-04-06T14:25:05Z",
+      "hash": "0c91e91529418e35bee2c22d9f0ea1286d60022f",
+      "passes": 1,
+      "pr": 17537
+    },
+    ".agents/scripts/verify-issue-close-helper.sh": {
+      "at": "2026-04-05T07:51:05Z",
+      "hash": "811b3aeb9a94e62bd483f7a13f27ded4e3cbf0ef",
+      "passes": 1,
+      "pr": 17378
+    },
     ".agents/scripts/video-gen-helper.sh": {
-      "hash": "3e19a7aa79953b1c55e24f007f267c93820fb053",
       "at": "2026-04-03T03:15:28Z",
+      "hash": "3e19a7aa79953b1c55e24f007f267c93820fb053",
       "passes": 1,
       "pr": 15904
     },
     ".agents/scripts/watercrawl-helper.sh": {
-      "hash": "fe6720cba1d1b51897de1d20db5fe5155a7415a3",
       "at": "2026-04-02T22:43:46Z",
+      "hash": "fe6720cba1d1b51897de1d20db5fe5155a7415a3",
       "passes": 1
     },
+    ".agents/scripts/worker-lifecycle-common.sh": {
+      "at": "2026-04-15T15:27:41Z",
+      "hash": "15a54c2316949e5f5bcbb52efbf7587f95e87863",
+      "passes": 6,
+      "pr": 17353
+    },
+    ".agents/scripts/worker-watchdog.sh": {
+      "at": "2026-04-15T03:00:33Z",
+      "hash": "135e62ddb97682effe07cb0b1ce2c3235f42e1e5",
+      "passes": 4,
+      "pr": 17393
+    },
+    ".agents/scripts/worktree-helper.sh": {
+      "at": "2026-04-15T21:02:40Z",
+      "hash": "4d554bea9e09f95a3d4929aa6aadc4c0a9539f29",
+      "passes": 2,
+      "pr": 19087
+    },
     ".agents/seo.md": {
-      "hash": "5181e08f7fb9475fa9cce94a9359b1ae0c8703ac",
       "at": "2026-04-11T17:01:26Z",
+      "hash": "5181e08f7fb9475fa9cce94a9359b1ae0c8703ac",
       "passes": 4,
       "pr": 13526
     },
     ".agents/seo/ahrefs.md": {
-      "hash": "8193d884de7ac1b70f8dcdf27215b5709c455393",
       "at": "2026-04-02T03:11:00Z",
+      "hash": "8193d884de7ac1b70f8dcdf27215b5709c455393",
       "passes": 1,
       "pr": 15431
     },
     ".agents/seo/ai-agent-discovery.md": {
-      "hash": "9b2f57356c7b4916049c1560badcc26043d5a6b4",
       "at": "2026-04-03T11:54:12Z",
+      "hash": "9b2f57356c7b4916049c1560badcc26043d5a6b4",
       "passes": 1,
       "pr": 16541
     },
     ".agents/seo/ai-search-kpi-template.md": {
-      "hash": "03b4b2acc3de7d3225178e67cd8f33c1540e040a",
       "at": "2026-04-01T20:59:36Z",
+      "hash": "03b4b2acc3de7d3225178e67cd8f33c1540e040a",
       "passes": 2,
       "pr": 14969
     },
     ".agents/seo/ai-search-readiness.md": {
-      "hash": "52cdbd7bb1c72f7c618ed1ef754c7ebb8689b3fa",
       "at": "2026-04-03T01:11:28Z",
+      "hash": "52cdbd7bb1c72f7c618ed1ef754c7ebb8689b3fa",
       "passes": 2,
       "pr": 15496
     },
     ".agents/seo/analytics-tracking.md": {
-      "hash": "eca2ef2f14042f282df60a52f9af1c78cc0d8900",
       "at": "2026-03-27T21:25:04Z",
+      "hash": "eca2ef2f14042f282df60a52f9af1c78cc0d8900",
       "passes": 1,
       "pr": 11015
     },
     ".agents/seo/backlink-checker.md": {
-      "hash": "7be89eae52361ed8a53fb8cc62efbc32df54e91d",
       "at": "2026-04-02T02:14:59Z",
+      "hash": "7be89eae52361ed8a53fb8cc62efbc32df54e91d",
       "passes": 2
     },
     ".agents/seo/bing-webmaster-tools.md": {
-      "hash": "a7c5a0d4fc5a54c6aab04221b330a652f1913435",
       "at": "2026-04-03T01:11:29Z",
+      "hash": "a7c5a0d4fc5a54c6aab04221b330a652f1913435",
       "passes": 2,
       "pr": 15532
     },
     ".agents/seo/content-analyzer.md": {
-      "hash": "1de62234174d8c6c0f62dd304458405b652eaf35",
       "at": "2026-04-02T04:56:49Z",
+      "hash": "1de62234174d8c6c0f62dd304458405b652eaf35",
       "passes": 1,
       "pr": 15478
     },
     ".agents/seo/contentking.md": {
-      "hash": "615a784c54474585d57be803b715d5770a4f8c8f",
       "at": "2026-03-28T13:37:31Z",
+      "hash": "615a784c54474585d57be803b715d5770a4f8c8f",
       "passes": 1,
       "pr": 11845
     },
     ".agents/seo/data-export.md": {
-      "hash": "c23c93d7c407536c235984313c8829db59585557",
       "at": "2026-03-27T21:25:21Z",
+      "hash": "c23c93d7c407536c235984313c8829db59585557",
       "passes": 1,
       "pr": 11019
     },
     ".agents/seo/dataforseo.md": {
-      "hash": "6822378ee33b4c72ef4364c26b9d43fd00001ca6",
       "at": "2026-03-28T17:11:12Z",
+      "hash": "6822378ee33b4c72ef4364c26b9d43fd00001ca6",
       "passes": 1,
       "pr": 12053
     },
     ".agents/seo/debug-favicon.md": {
-      "hash": "f5ce2a14bbe1ee219e11e4bc54760239a06bc348",
       "at": "2026-03-29T22:09:18Z",
+      "hash": "f5ce2a14bbe1ee219e11e4bc54760239a06bc348",
       "passes": 1,
       "pr": 13323
     },
     ".agents/seo/debug-opengraph.md": {
-      "hash": "84575e316c4fd543662bf475cea9550cd2a60c41",
       "at": "2026-03-28T14:15:42Z",
+      "hash": "84575e316c4fd543662bf475cea9550cd2a60c41",
       "passes": 1,
       "pr": 11898
     },
     ".agents/seo/domain-research-api-reference.md": {
-      "hash": "92d15301b9ffcb8efa4faadbe8c7ef0b08ad6150",
       "at": "2026-03-28T17:11:07Z",
+      "hash": "92d15301b9ffcb8efa4faadbe8c7ef0b08ad6150",
       "passes": 1,
       "pr": 12056
     },
     ".agents/seo/domain-research.md": {
-      "hash": "86d0653bd61c04e4cc5d6ca398f6e7df38e839ac",
       "at": "2026-03-28T17:11:08Z",
+      "hash": "86d0653bd61c04e4cc5d6ca398f6e7df38e839ac",
       "passes": 1,
       "pr": 12056
     },
     ".agents/seo/eeat-score.md": {
-      "hash": "2e2b17d409d5af853c7120582aa42c7c66a44123",
       "at": "2026-03-28T20:56:08Z",
+      "hash": "2e2b17d409d5af853c7120582aa42c7c66a44123",
       "passes": 1,
       "pr": 12181
     },
+    ".agents/seo/geo-strategy.md": {
+      "at": "2026-04-03T20:00:32Z",
+      "hash": "c1018d8590e58e3fd4852c1014fa58de1320d3cf",
+      "passes": 3,
+      "pr": "pending"
+    },
     ".agents/seo/google-search-console.md": {
-      "hash": "b2f2227da4369870bf8c6acfcd3c43c50479c30d",
       "at": "2026-03-30T06:49:36Z",
+      "hash": "b2f2227da4369870bf8c6acfcd3c43c50479c30d",
       "passes": 1,
       "pr": 13900
     },
     ".agents/seo/gsc-sitemaps.md": {
-      "hash": "d5143fe4cf1d7e5c396fc1c8049b033c366162dd",
       "at": "2026-03-28T11:52:39Z",
+      "hash": "d5143fe4cf1d7e5c396fc1c8049b033c366162dd",
       "passes": 1,
       "pr": 11821
     },
     ".agents/seo/image-seo.md": {
-      "hash": "fbcc7f4cd0c8d5405472d9f6ee99fc25a11b4da1",
       "at": "2026-03-30T03:34:23Z",
+      "hash": "fbcc7f4cd0c8d5405472d9f6ee99fc25a11b4da1",
       "passes": 1,
       "pr": 13530
     },
     ".agents/seo/keyword-mapper.md": {
-      "hash": "9c5b11b99cc3579c8e54bca62df6e9319deb3b41",
       "at": "2026-04-02T05:10:00Z",
+      "hash": "9c5b11b99cc3579c8e54bca62df6e9319deb3b41",
       "passes": 1
     },
     ".agents/seo/keyword-research.md": {
-      "hash": "bf63ccdd2e86fb2b7b2d46cae7f4f69870a39d8b",
       "at": "2026-03-28T21:27:18Z",
+      "hash": "bf63ccdd2e86fb2b7b2d46cae7f4f69870a39d8b",
       "passes": 1,
       "pr": 12220
     },
     ".agents/seo/mom-test-ux.md": {
-      "hash": "cbf59a95974e3ba4c2953c01309b94597e31f801",
       "at": "2026-03-30T03:34:17Z",
+      "hash": "cbf59a95974e3ba4c2953c01309b94597e31f801",
       "passes": 1,
       "pr": 13524
     },
     ".agents/seo/moondream.md": {
-      "hash": "739dcf1865154a126ac404a4d0af88bb17929323",
       "at": "2026-03-30T03:33:44Z",
+      "hash": "739dcf1865154a126ac404a4d0af88bb17929323",
       "passes": 1,
       "pr": 13663
     },
     ".agents/seo/neuronwriter.md": {
-      "hash": "6d9d9b9ff1e61097f415362a55ce4444a5cabd74",
       "at": "2026-03-28T03:54:21Z",
+      "hash": "6d9d9b9ff1e61097f415362a55ce4444a5cabd74",
       "passes": 1,
       "pr": 11350
     },
     ".agents/seo/programmatic-seo.md": {
-      "hash": "0df348b7b8ba74ca274dbe32a43e3404c21d3a3b",
       "at": "2026-04-02T21:20:03Z",
+      "hash": "0df348b7b8ba74ca274dbe32a43e3404c21d3a3b",
       "passes": 2,
       "pr": 13301
     },
     ".agents/seo/query-fanout-research.md": {
-      "hash": "99b875c1eeb2e7c380b03d8068091f9e14ebc994",
       "at": "2026-04-03T11:54:14Z",
+      "hash": "99b875c1eeb2e7c380b03d8068091f9e14ebc994",
       "passes": 1,
       "pr": 16495
     },
+    ".agents/seo/ranking-opportunities.md": {
+      "at": "2026-04-03T16:35:52Z",
+      "hash": "798c09f0ea175ef5dcce3f5a148c25e509d5ed70",
+      "passes": 1,
+      "pr": 16713
+    },
     ".agents/seo/rich-results.md": {
-      "hash": "68907e4d92d42466ef2285b68d75d6c6f8b10f31",
       "at": "2026-04-02T22:44:04Z",
+      "hash": "68907e4d92d42466ef2285b68d75d6c6f8b10f31",
       "passes": 1,
       "pr": 15665
     },
+    ".agents/seo/schema-validator.md": {
+      "at": "2026-04-03T19:14:46Z",
+      "hash": "b9d51a4ed48477ce7053839e3a9561dc9cdaaca5",
+      "passes": 1,
+      "pr": 16757
+    },
     ".agents/seo/semrush.md": {
-      "hash": "eabd69f707783c0422cbc5abdc58f459fe9417c8",
       "at": "2026-03-27T21:25:11Z",
+      "hash": "eabd69f707783c0422cbc5abdc58f459fe9417c8",
       "passes": 1,
       "pr": 11006
     },
     ".agents/seo/seo-audit-skill.md": {
-      "hash": "3638cde2b0ebb0b1bb163a6a1c586cb3b0a5228c",
       "at": "2026-03-29T12:37:05Z",
+      "hash": "3638cde2b0ebb0b1bb163a6a1c586cb3b0a5228c",
       "passes": 1,
       "pr": 12948
     },
     ".agents/seo/seo-audit-skill/aeo-geo-patterns.md": {
-      "hash": "7be27e641bc7bebba5276f5f02c0fb80310cc950",
       "at": "2026-04-02T21:20:03Z",
+      "hash": "7be27e641bc7bebba5276f5f02c0fb80310cc950",
       "passes": 2,
       "pr": 0
     },
+    ".agents/seo/seo-audit-skill/aeo-geo-patterns/01-aeo-patterns.md": {
+      "at": "2026-04-03T16:35:53Z",
+      "hash": "adc6a8b7b331b0a3cfdfa9131664fef37d0b5d02",
+      "passes": 1,
+      "pr": 16670
+    },
     ".agents/seo/seo-audit-skill/aeo-geo-patterns/02-geo-patterns.md": {
-      "hash": "889299f66ae8ca80bd56989c36bedf869b799664",
       "at": "2026-04-02T21:58:19Z",
+      "hash": "889299f66ae8ca80bd56989c36bedf869b799664",
       "passes": 1,
       "pr": 15568
     },
     ".agents/seo/seo-audit-skill/ai-writing-detection.md": {
-      "hash": "76aeb3a7f644ea3f5b075073745abc1b1b956a6b",
       "at": "2026-03-29T23:53:50Z",
+      "hash": "76aeb3a7f644ea3f5b075073745abc1b1b956a6b",
       "passes": 1,
       "pr": 13444
     },
+    ".agents/seo/seo-audit.md": {
+      "at": "2026-04-11T13:54:28Z",
+      "hash": "e04729ef8d0f40b30efc59f9914d8ec420218efa",
+      "passes": 1,
+      "pr": 18210
+    },
+    ".agents/seo/seo-optimizer.md": {
+      "at": "2026-04-03T13:35:13Z",
+      "hash": "6ea5959df1ec6ca83ebcbcbc08153fc8e2716e92",
+      "passes": 1,
+      "pr": 16579
+    },
     ".agents/seo/seo-regex.md": {
-      "hash": "5f9371010f691167e387f4b62548cf84688ee02c",
       "at": "2026-03-29T22:09:17Z",
+      "hash": "5f9371010f691167e387f4b62548cf84688ee02c",
       "passes": 1,
       "pr": 13325
     },
+    ".agents/seo/serper.md": {
+      "at": "2026-04-03T19:14:22Z",
+      "hash": "7f19897bff63bea81a0247a5687370484a99f05b",
+      "passes": 1
+    },
     ".agents/seo/site-crawler.md": {
-      "hash": "521a85679039d0652c9211df6ed9a111dab92a70",
       "at": "2026-03-28T08:58:48Z",
+      "hash": "521a85679039d0652c9211df6ed9a111dab92a70",
       "passes": 1,
       "pr": 11598
     },
+    ".agents/seo/sro-grounding.md": {
+      "at": "2026-04-03T19:14:47Z",
+      "hash": "32473a58d5d1db494a426ec744b5998eaaa56a4f",
+      "passes": 1,
+      "pr": 16734
+    },
     ".agents/seo/tech-stack.md": {
-      "hash": "99d8353a7c96d313a97a3a7dc1e04dee44d72597",
       "at": "2026-03-30T03:34:18Z",
+      "hash": "99d8353a7c96d313a97a3a7dc1e04dee44d72597",
       "passes": 1,
       "pr": 13531
     },
+    ".agents/seo/upscale.md": {
+      "at": "2026-04-03T16:35:55Z",
+      "hash": "9c9fd44ad9199fa426629726def1e5dde95be2c3",
+      "passes": 1,
+      "pr": 16627
+    },
     ".agents/services/accounting/quickfile.md": {
-      "hash": "9f310f63bdf6101feeec1b6ad0503fc123645b97",
       "at": "2026-03-29T07:02:24Z",
+      "hash": "9f310f63bdf6101feeec1b6ad0503fc123645b97",
       "passes": 1,
       "pr": 12699
     },
     ".agents/services/analytics/google-analytics.md": {
-      "hash": "376580764f2caa3c3c7cb954fa5ecc78d18a3ad0",
       "at": "2026-03-29T12:36:33Z",
+      "hash": "376580764f2caa3c3c7cb954fa5ecc78d18a3ad0",
       "passes": 1,
       "pr": 12950
     },
     ".agents/services/communications/bitchat.md": {
-      "hash": "7c64eda23ec20fd43406ea967c2481fc2d6ccb6d",
       "at": "2026-03-29T20:53:59Z",
+      "hash": "7c64eda23ec20fd43406ea967c2481fc2d6ccb6d",
       "passes": 1,
       "pr": 13287
     },
     ".agents/services/communications/convos-bridge-template.sh": {
-      "hash": "7f5eebcc77380acdfc212613b6672165396fb2ad",
       "at": "2026-03-28T08:57:52Z",
+      "hash": "7f5eebcc77380acdfc212613b6672165396fb2ad",
       "passes": 1,
       "pr": 11688
     },
     ".agents/services/communications/convos.md": {
-      "hash": "faeb69cdcee421e38323cf379c2e049cb4add245",
       "at": "2026-03-28T08:57:52Z",
+      "hash": "faeb69cdcee421e38323cf379c2e049cb4add245",
       "passes": 1,
       "pr": 11688
     },
+    ".agents/services/communications/cross-channel-conversation-continuity.md": {
+      "at": "2026-04-03T16:35:53Z",
+      "hash": "c33ae68330c28c43c9f4ff173687addf27c3e9dc",
+      "passes": 1,
+      "pr": 16669
+    },
     ".agents/services/communications/discord.md": {
-      "hash": "9c3cb04fa4c05e27da9fda8b12772c913d376bf5",
       "at": "2026-03-28T03:53:47Z",
+      "hash": "9c3cb04fa4c05e27da9fda8b12772c913d376bf5",
       "passes": 1,
       "pr": 11287
     },
     ".agents/services/communications/google-chat.md": {
-      "hash": "215902519386508242b838d6823ff6c477d0c8b5",
       "at": "2026-04-03T01:11:30Z",
+      "hash": "215902519386508242b838d6823ff6c477d0c8b5",
       "passes": 2,
       "pr": 13658
     },
     ".agents/services/communications/imessage.md": {
-      "hash": "eeeb3c6e0cea98597d4f7d37d0c264a9dfe77d78",
       "at": "2026-03-30T00:32:20Z",
+      "hash": "eeeb3c6e0cea98597d4f7d37d0c264a9dfe77d78",
       "passes": 2,
       "pr": 13468
     },
     ".agents/services/communications/matrix-bot.md": {
-      "hash": "425e1519257ae554c0dda57be6e8c28cf0eb3a80",
       "at": "2026-04-03T01:11:47Z",
+      "hash": "425e1519257ae554c0dda57be6e8c28cf0eb3a80",
       "passes": 1,
       "pr": 15801
     },
     ".agents/services/communications/matterbridge.md": {
-      "hash": "9d1ce2f42c017f5640c045206b46c238f6246de3",
       "at": "2026-03-29T01:04:18Z",
+      "hash": "9d1ce2f42c017f5640c045206b46c238f6246de3",
       "passes": 1,
       "pr": 12399
     },
     ".agents/services/communications/msteams.md": {
-      "hash": "5ce90755ef20ebd5ad5dfb93d59fb63e50c66207",
       "at": "2026-03-28T03:54:15Z",
+      "hash": "5ce90755ef20ebd5ad5dfb93d59fb63e50c66207",
       "passes": 1,
       "pr": 11346
     },
     ".agents/services/communications/nextcloud-talk.md": {
-      "hash": "65964b0e9b665148a5f2eb412fe67827ba18dae0",
       "at": "2026-03-28T03:54:35Z",
+      "hash": "65964b0e9b665148a5f2eb412fe67827ba18dae0",
       "passes": 1,
       "pr": 11360
     },
     ".agents/services/communications/nostr.md": {
-      "hash": "ad501386d53c730981695373e7d92aa1a1e9708e",
       "at": "2026-03-28T09:17:35Z",
+      "hash": "ad501386d53c730981695373e7d92aa1a1e9708e",
       "passes": 1,
       "pr": 11715
     },
     ".agents/services/communications/privacy-comparison.md": {
-      "hash": "b22181f832cbfe42275227024a3c6367adc154be",
       "at": "2026-03-28T20:16:54Z",
+      "hash": "b22181f832cbfe42275227024a3c6367adc154be",
       "passes": 1,
       "pr": 12169
     },
     ".agents/services/communications/signal.md": {
-      "hash": "ab032dd4f30c9b61a9fce2b8186433ac19c65c9c",
       "at": "2026-03-28T08:58:53Z",
+      "hash": "ab032dd4f30c9b61a9fce2b8186433ac19c65c9c",
       "passes": 1,
       "pr": 11620
     },
     ".agents/services/communications/simplex.md": {
-      "hash": "dfe1ab5ef27d33e446cc785cbf5e4b8e83fe5d6f",
       "at": "2026-03-28T20:16:50Z",
+      "hash": "dfe1ab5ef27d33e446cc785cbf5e4b8e83fe5d6f",
       "passes": 1,
       "pr": 12168
     },
     ".agents/services/communications/slack.md": {
-      "hash": "f35f1b82543e3ad7112e1416b39e2fc3ba0bff21",
       "at": "2026-03-30T03:34:27Z",
+      "hash": "f35f1b82543e3ad7112e1416b39e2fc3ba0bff21",
       "passes": 1,
       "pr": 13545
     },
     ".agents/services/communications/telegram.md": {
-      "hash": "d37e1cf8acd54e3fdec7c7384f8823cd0ae469fd",
       "at": "2026-03-28T21:58:54Z",
+      "hash": "d37e1cf8acd54e3fdec7c7384f8823cd0ae469fd",
       "passes": 1,
       "pr": 12233
     },
     ".agents/services/communications/telfon.md": {
-      "hash": "a02171ef69e2b94def8a8b01cec8c37bf34c4dc8",
       "at": "2026-03-31T04:46:03Z",
+      "hash": "a02171ef69e2b94def8a8b01cec8c37bf34c4dc8",
       "passes": 2,
       "pr": 14595
     },
     ".agents/services/communications/twilio.md": {
-      "hash": "74e9b0f83ba61cd273ddd22e98ccd7953e10104b",
       "at": "2026-03-28T14:15:37Z",
+      "hash": "74e9b0f83ba61cd273ddd22e98ccd7953e10104b",
       "passes": 1,
       "pr": 11900
     },
     ".agents/services/communications/urbit.md": {
-      "hash": "b45adefce098f82c59017d6a8314f8ccaa7fa2e3",
       "at": "2026-03-29T12:37:15Z",
+      "hash": "b45adefce098f82c59017d6a8314f8ccaa7fa2e3",
       "passes": 1,
       "pr": 12911
     },
     ".agents/services/communications/whatsapp.md": {
-      "hash": "50447fe7f8ba72c9e14cf121ef25d1b309e3ec94",
       "at": "2026-03-29T12:37:29Z",
+      "hash": "50447fe7f8ba72c9e14cf121ef25d1b309e3ec94",
       "passes": 1,
       "pr": 12821
     },
     ".agents/services/communications/xmtp.md": {
-      "hash": "76bc4008c756a2efd34895be811e5e4f0233d7fb",
       "at": "2026-03-27T21:25:14Z",
+      "hash": "76bc4008c756a2efd34895be811e5e4f0233d7fb",
       "passes": 1,
       "pr": 11009
     },
     ".agents/services/crm/fluentcrm.md": {
-      "hash": "c06b3e417387d14e0cf570d1d4b4d76f8573471d",
       "at": "2026-03-29T15:51:03Z",
+      "hash": "c06b3e417387d14e0cf570d1d4b4d76f8573471d",
       "passes": 1,
       "pr": 13048
     },
     ".agents/services/database/multi-org-isolation.md": {
-      "hash": "1ecdd6aa2b10df303263e2e4384280fdbeb3d998",
       "at": "2026-03-28T21:59:22Z",
+      "hash": "1ecdd6aa2b10df303263e2e4384280fdbeb3d998",
       "passes": 1,
       "pr": 12249
     },
     ".agents/services/database/postgres-drizzle-skill.md": {
-      "hash": "bf71c33806b6bc0b1e576fff008c43d6959211c8",
       "at": "2026-04-03T11:54:15Z",
+      "hash": "bf71c33806b6bc0b1e576fff008c43d6959211c8",
       "passes": 1,
       "pr": 16450
     },
     ".agents/services/database/postgres-drizzle-skill/cheatsheet-config.md": {
-      "hash": "edf8b0079744cbd5d3ec043d573197fe988d8319",
       "at": "2026-03-31T00:00:00Z",
+      "hash": "edf8b0079744cbd5d3ec043d573197fe988d8319",
       "passes": 1,
       "pr": 14577
     },
     ".agents/services/database/postgres-drizzle-skill/cheatsheet-mutations.md": {
-      "hash": "bc05b6d55e75eec9bf73df2e11c3ecea5f0c46aa",
       "at": "2026-03-31T06:23:12Z",
+      "hash": "bc05b6d55e75eec9bf73df2e11c3ecea5f0c46aa",
       "passes": 2,
       "pr": 14691
     },
     ".agents/services/database/postgres-drizzle-skill/cheatsheet-schema.md": {
-      "hash": "dd0c33c05c70eb12da25a9f42be43a0c37c7078e",
       "at": "2026-04-02T00:00:00Z",
+      "hash": "dd0c33c05c70eb12da25a9f42be43a0c37c7078e",
       "passes": 1,
       "pr": 0
     },
     ".agents/services/database/postgres-drizzle-skill/cheatsheet.md": {
-      "hash": "7a73fa2713d5f214dba306d2006ea6de826b6cca",
       "at": "2026-03-28T10:27:24Z",
+      "hash": "7a73fa2713d5f214dba306d2006ea6de826b6cca",
       "passes": 2,
       "pr": 11709
     },
     ".agents/services/database/postgres-drizzle-skill/migrations.md": {
-      "hash": "876cc6a7bc5debdbdf0dd1fe0ac7e2db55512c54",
       "at": "2026-03-28T16:00:44Z",
+      "hash": "876cc6a7bc5debdbdf0dd1fe0ac7e2db55512c54",
       "passes": 1,
       "pr": 11966
     },
     ".agents/services/database/postgres-drizzle-skill/performance-caching.md": {
-      "hash": "c913579a4d4e3423ab6105a7ada526d01da58e24",
       "at": "2026-03-29T15:08:44Z",
+      "hash": "c913579a4d4e3423ab6105a7ada526d01da58e24",
       "passes": 1,
       "pr": 13034
     },
     ".agents/services/database/postgres-drizzle-skill/performance-explain.md": {
-      "hash": "e30b41ee9d586aed02513b262308454e1582a157",
       "at": "2026-03-29T15:08:44Z",
+      "hash": "e30b41ee9d586aed02513b262308454e1582a157",
       "passes": 1,
       "pr": 13034
     },
     ".agents/services/database/postgres-drizzle-skill/performance-indexing.md": {
-      "hash": "a05593a14716c339aa20762bd58c1f2fd3524632",
       "at": "2026-03-29T15:08:44Z",
+      "hash": "a05593a14716c339aa20762bd58c1f2fd3524632",
       "passes": 1,
       "pr": 13034
     },
     ".agents/services/database/postgres-drizzle-skill/performance-monitoring.md": {
-      "hash": "6bea6117b5d890a1488f104180ec836232aff0d5",
       "at": "2026-03-29T15:08:44Z",
+      "hash": "6bea6117b5d890a1488f104180ec836232aff0d5",
       "passes": 1,
       "pr": 13034
     },
     ".agents/services/database/postgres-drizzle-skill/performance-pagination.md": {
-      "hash": "f9e3947bc34450d7c0eec8331387598fa0c3df27",
       "at": "2026-03-29T15:08:44Z",
+      "hash": "f9e3947bc34450d7c0eec8331387598fa0c3df27",
       "passes": 1,
       "pr": 13034
     },
     ".agents/services/database/postgres-drizzle-skill/performance-pooling.md": {
-      "hash": "6a8410cfe9fa14ffbd5eb664e325b32b659d6efe",
       "at": "2026-03-29T15:08:45Z",
+      "hash": "6a8410cfe9fa14ffbd5eb664e325b32b659d6efe",
       "passes": 1,
       "pr": 13034
     },
     ".agents/services/database/postgres-drizzle-skill/performance-queries.md": {
-      "hash": "f1407412c73dc5a603a8c1211ae033e1c41e894f",
       "at": "2026-03-29T15:08:45Z",
+      "hash": "f1407412c73dc5a603a8c1211ae033e1c41e894f",
       "passes": 1,
       "pr": 13034
     },
     ".agents/services/database/postgres-drizzle-skill/performance.md": {
-      "hash": "8cc1d6de992385ce08c37a47731b39a4c61b6190",
       "at": "2026-03-29T15:08:45Z",
+      "hash": "8cc1d6de992385ce08c37a47731b39a4c61b6190",
       "passes": 1,
       "pr": 13034
     },
     ".agents/services/database/postgres-drizzle-skill/postgres.md": {
-      "hash": "7761d7e4aa275d19e1ef37cdb18070faca39b5d8",
       "at": "2026-03-28T05:50:57Z",
+      "hash": "7761d7e4aa275d19e1ef37cdb18070faca39b5d8",
       "passes": 1,
       "pr": 11448
     },
     ".agents/services/database/postgres-drizzle-skill/queries.md": {
-      "hash": "1f67659dffa5fc17c34bdb646729cb3863bdb14b",
       "at": "2026-03-28T06:40:05Z",
+      "hash": "1f67659dffa5fc17c34bdb646729cb3863bdb14b",
       "passes": 2,
       "pr": 11416
     },
     ".agents/services/database/postgres-drizzle-skill/relations.md": {
-      "hash": "6d097bd81f94343797825f87b42eb2c18337248a",
       "at": "2026-03-28T09:48:57Z",
+      "hash": "6d097bd81f94343797825f87b42eb2c18337248a",
       "passes": 1,
       "pr": 11717
     },
     ".agents/services/database/postgres-drizzle-skill/schema.md": {
-      "hash": "e71b23f404365b5c635f7989cd75b24db99434d9",
       "at": "2026-03-28T10:27:24Z",
+      "hash": "e71b23f404365b5c635f7989cd75b24db99434d9",
       "passes": 1,
       "pr": 11709
     },
     ".agents/services/document-processing/unstract.md": {
-      "hash": "196b638373c87a41fbf78742b642095702f69e59",
       "at": "2026-03-30T04:51:58Z",
+      "hash": "196b638373c87a41fbf78742b642095702f69e59",
       "passes": 1,
       "pr": 13720
     },
+    ".agents/services/ecommerce/shopify.md": {
+      "at": "2026-04-13T17:44:12Z",
+      "hash": "1c057fa35263b57612d3e8cb096fb5b2290f42c5",
+      "passes": 1,
+      "pr": 18661
+    },
     ".agents/services/email/email-actions.md": {
-      "hash": "fa704173cc978af04a0dc836cc56d745e2538ef9",
       "at": "2026-03-28T16:40:11Z",
+      "hash": "fa704173cc978af04a0dc836cc56d745e2538ef9",
       "passes": 1,
       "pr": 12039
     },
     ".agents/services/email/email-agent.md": {
-      "hash": "9f16d7c7d14a9a361a5090c445d7ca2381538a82",
       "at": "2026-03-28T20:16:44Z",
+      "hash": "9f16d7c7d14a9a361a5090c445d7ca2381538a82",
       "passes": 1,
       "pr": 12163
     },
     ".agents/services/email/email-composition.md": {
-      "hash": "3bf60dea68b02aea395b90e32e4131a452e75022",
       "at": "2026-03-30T06:03:17Z",
+      "hash": "3bf60dea68b02aea395b90e32e4131a452e75022",
       "passes": 1,
       "pr": 13837
     },
     ".agents/services/email/email-delivery-test.md": {
-      "hash": "351ce5d6596112769560bdd68ceab2b955e374d0",
       "at": "2026-04-11T03:27:14Z",
+      "hash": "351ce5d6596112769560bdd68ceab2b955e374d0",
       "passes": 2,
       "pr": 12041
     },
     ".agents/services/email/email-design-test.md": {
-      "hash": "2055f755f4558bb21f4ac9714e6f1011b2745ec4",
       "at": "2026-04-11T07:23:11Z",
+      "hash": "2055f755f4558bb21f4ac9714e6f1011b2745ec4",
       "passes": 2,
       "pr": 13324
     },
     ".agents/services/email/email-health-check.md": {
-      "hash": "e558738cbf896c8ecf3dc22b981a175b95f43521",
       "at": "2026-03-30T02:30:20Z",
+      "hash": "e558738cbf896c8ecf3dc22b981a175b95f43521",
       "passes": 1,
       "pr": 13593
     },
     ".agents/services/email/email-inbound-commands.md": {
-      "hash": "df869cc536c8326141155f70db7d9786542cc75c",
       "at": "2026-04-03T01:11:48Z",
+      "hash": "df869cc536c8326141155f70db7d9786542cc75c",
       "passes": 1,
       "pr": 15725
     },
+    ".agents/services/email/email-inbox.md": {
+      "at": "2026-04-11T16:20:18Z",
+      "hash": "4f1ca21839cf5220d8b32c732671288f83ac5c72",
+      "passes": 1,
+      "pr": 18280
+    },
     ".agents/services/email/email-intelligence.md": {
-      "hash": "1c75f479f00d3c5ab14d549ee23287be2430214c",
       "at": "2026-03-29T12:37:18Z",
+      "hash": "1c75f479f00d3c5ab14d549ee23287be2430214c",
       "passes": 1,
       "pr": 12912
     },
     ".agents/services/email/email-mailbox-search.md": {
-      "hash": "c4df3c67b7ce78c391247aa7865ef9991894cfb6",
       "at": "2026-03-28T13:37:26Z",
+      "hash": "c4df3c67b7ce78c391247aa7865ef9991894cfb6",
       "passes": 1,
       "pr": 11869
     },
     ".agents/services/email/email-mailbox.md": {
-      "hash": "a2b6ff6415cbfd49b84fa338c98368f341da1670",
       "at": "2026-03-29T07:02:18Z",
+      "hash": "a2b6ff6415cbfd49b84fa338c98368f341da1670",
       "passes": 1,
       "pr": 12624
     },
+    ".agents/services/email/email-outreach.md": {
+      "at": "2026-04-11T16:20:18Z",
+      "hash": "eec3a0cfbb715b4d281fbde029654c8e157facbf",
+      "passes": 1,
+      "pr": 18279
+    },
     ".agents/services/email/email-providers.md": {
-      "hash": "efa3b65f66e733de7caeded90acbab3cf0ab5275",
       "at": "2026-03-30T06:49:37Z",
+      "hash": "efa3b65f66e733de7caeded90acbab3cf0ab5275",
       "passes": 2,
       "pr": 13859
     },
     ".agents/services/email/email-security.md": {
-      "hash": "5f1c5280780f01282cf96fb5ba38a6b7cbd4e6e1",
       "at": "2026-03-29T21:43:14Z",
+      "hash": "5f1c5280780f01282cf96fb5ba38a6b7cbd4e6e1",
       "passes": 1,
       "pr": 13343
     },
     ".agents/services/email/email-testing.md": {
-      "hash": "cb30278c5d835afdee3e0e28732744e76560a493",
       "at": "2026-04-03T11:53:57Z",
+      "hash": "cb30278c5d835afdee3e0e28732744e76560a493",
       "passes": 2,
       "pr": 15839
     },
     ".agents/services/email/email-verification.md": {
-      "hash": "4d105edb4125e4bde0c0efb5e75ea47f25002a6c",
       "at": "2026-03-31T09:57:12Z",
+      "hash": "4d105edb4125e4bde0c0efb5e75ea47f25002a6c",
       "passes": 2,
       "pr": 14757
     },
     ".agents/services/email/google-workspace.md": {
-      "hash": "fe9159fc65fdf4963b3d86a28479b564a99feef5",
       "at": "2026-03-28T08:58:52Z",
+      "hash": "fe9159fc65fdf4963b3d86a28479b564a99feef5",
       "passes": 1,
       "pr": 11613
     },
     ".agents/services/email/letter-post-bridge.md": {
-      "hash": "1cb4672a67ef54e960db1c10718d85878e7082a8",
       "at": "2026-03-31T05:33:36Z",
+      "hash": "1cb4672a67ef54e960db1c10718d85878e7082a8",
       "passes": 1,
       "pr": 14646
     },
     ".agents/services/email/microsoft-graph.md": {
-      "hash": "839d068a11e5b6d2d18b56542443963cd88a3019",
       "at": "2026-03-28T21:27:21Z",
+      "hash": "839d068a11e5b6d2d18b56542443963cd88a3019",
       "passes": 1,
       "pr": 12218
     },
     ".agents/services/email/mission-email.md": {
-      "hash": "12e0b28773ed6ad240f2a49a4f2a2a3a63ace686",
       "at": "2026-03-28T13:37:15Z",
+      "hash": "12e0b28773ed6ad240f2a49a4f2a2a3a63ace686",
       "passes": 1,
       "pr": 11889
     },
     ".agents/services/email/openpgp-setup.md": {
-      "hash": "f79e44c602bcff7661bec0946a24d006fc7c03bb",
       "at": "2026-03-28T16:40:18Z",
+      "hash": "f79e44c602bcff7661bec0946a24d006fc7c03bb",
       "passes": 1,
       "pr": 12040
     },
     ".agents/services/email/ses.md": {
-      "hash": "2d7774b0535d78bb21a4d5a7aba4c7ace1a53f74",
       "at": "2026-04-03T11:53:57Z",
+      "hash": "2d7774b0535d78bb21a4d5a7aba4c7ace1a53f74",
       "passes": 2,
       "pr": "pending"
     },
     ".agents/services/email/smime-setup.md": {
-      "hash": "302a1a67bfdf371fe2f193b7e6ab48d06add5c0b",
       "at": "2026-03-30T06:50:00Z",
+      "hash": "302a1a67bfdf371fe2f193b7e6ab48d06add5c0b",
       "passes": 1,
       "pr": 13915
     },
     ".agents/services/email/thunderbird.md": {
-      "hash": "8ce3cae515291871875e82e1e2e38e5f9e45b139",
       "at": "2026-03-29T07:02:32Z",
+      "hash": "8ce3cae515291871875e82e1e2e38e5f9e45b139",
       "passes": 1,
       "pr": 12582
     },
     ".agents/services/hosting/101domains.md": {
-      "hash": "a65d8cccef3d95f6fd26e74ac5b51f986d131de5",
       "at": "2026-03-28T08:18:27Z",
+      "hash": "a65d8cccef3d95f6fd26e74ac5b51f986d131de5",
       "passes": 1,
       "pr": 11633
     },
     ".agents/services/hosting/closte.md": {
-      "hash": "9d47185b599d5e27587077f8fe3142f9c73e4755",
       "at": "2026-03-28T21:27:23Z",
+      "hash": "9d47185b599d5e27587077f8fe3142f9c73e4755",
       "passes": 1,
       "pr": 12219
     },
     ".agents/services/hosting/cloudflare-platform-skill.md": {
-      "hash": "c2348b9ce4951c13a499a2bccf747b5b1663aa35",
       "at": "2026-03-28T20:16:45Z",
+      "hash": "c2348b9ce4951c13a499a2bccf747b5b1663aa35",
       "passes": 1,
       "pr": 12162
     },
     ".agents/services/hosting/cloudflare-platform-skill/agents-sdk-gotchas.md": {
-      "hash": "4524936cd4976bcb84eff9664b771619ee3d7aab",
       "at": "2026-04-03T21:12:08Z",
+      "hash": "4524936cd4976bcb84eff9664b771619ee3d7aab",
       "passes": 5,
       "pr": 15053
     },
     ".agents/services/hosting/cloudflare-platform-skill/agents-sdk-patterns.md": {
-      "hash": "79b87432dd132648031b5c042f3bb844b0720976",
       "at": "2026-04-02T21:20:06Z",
+      "hash": "79b87432dd132648031b5c042f3bb844b0720976",
       "passes": 2,
       "pr": 0
     },
     ".agents/services/hosting/cloudflare-platform-skill/ai-gateway.md": {
-      "hash": "0d34b16961ad2939e6abd9f69f645841a4eef8dd",
       "at": "2026-03-28T05:50:52Z",
+      "hash": "0d34b16961ad2939e6abd9f69f645841a4eef8dd",
       "passes": 1,
       "pr": 11443
     },
+    ".agents/services/hosting/cloudflare-platform-skill/ai-search-gotchas.md": {
+      "at": "2026-04-04T14:54:13Z",
+      "hash": "2c7d77810b23fc6ed30a09a74e72a27273282311",
+      "passes": 1,
+      "pr": 17263
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/ai-search-patterns.md": {
+      "at": "2026-04-04T14:54:10Z",
+      "hash": "fad7c34adae6b1e75cf375aa6cf179aae4e71421",
+      "passes": 1,
+      "pr": 17305
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/api-patterns.md": {
+      "at": "2026-04-04T14:54:16Z",
+      "hash": "2d22fd57bd06f00a7615b4632189fcae857e3496",
+      "passes": 1,
+      "pr": 17221
+    },
     ".agents/services/hosting/cloudflare-platform-skill/api-shield-patterns.md": {
-      "hash": "3f829b32fe8b4864f8ac2d453d0276ec48446a08",
       "at": "2026-04-03T11:54:14Z",
+      "hash": "3f829b32fe8b4864f8ac2d453d0276ec48446a08",
       "passes": 1,
       "pr": 16481
     },
+    ".agents/services/hosting/cloudflare-platform-skill/argo-smart-routing-patterns.md": {
+      "at": "2026-04-04T16:52:36Z",
+      "hash": "a870e621cfc06b222513a0bc271789431937b860",
+      "passes": 2,
+      "pr": 17220
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/bindings-patterns.md": {
+      "at": "2026-04-04T14:54:17Z",
+      "hash": "f119c69a039a7367b648aa287aa44fda708a497f",
+      "passes": 1,
+      "pr": 17219
+    },
     ".agents/services/hosting/cloudflare-platform-skill/bot-management-gotchas.md": {
-      "hash": "e2bcb7bc28c99f06109a612403bcbb3b41ce1bec",
       "at": "2026-04-02T12:50:00Z",
+      "hash": "e2bcb7bc28c99f06109a612403bcbb3b41ce1bec",
       "passes": 1,
       "pr": 15047
     },
+    ".agents/services/hosting/cloudflare-platform-skill/bot-management-patterns.md": {
+      "at": "2026-04-03T14:06:30Z",
+      "hash": "ccd3dbab23b29fd35903db9431c360e0b3e926c4",
+      "passes": 1,
+      "pr": 16612
+    },
+    ".agents/services/hosting/cloudflare-platform-skill/bot-management.md": {
+      "at": "2026-04-03T13:35:13Z",
+      "hash": "a7e3417849a22cd576f30c329661caaecb042fd9",
+      "passes": 1,
+      "pr": 16587
+    },
     ".agents/services/hosting/cloudflare-platform-skill/c3.md": {
-      "hash": "8d6159123183cac3b3f52706938d61486856dcb8",
       "at": "2026-03-28T15:30:18Z",
+      "hash": "8d6159123183cac3b3f52706938d61486856dcb8",
       "passes": 1,
       "pr": 11962
     },
     ".agents/services/hosting/cloudflare-platform-skill/cache-reserve-gotchas.md": {
-      "hash": "f1069619c443912dbb83f5eae2feb951c99a7958",
       "at": "2026-03-29T22:09:42Z",
+      "hash": "f1069619c443912dbb83f5eae2feb951c99a7958",
       "passes": 2,
       "pr": 13253
     },
     ".agents/services/hosting/cloudflare-platform-skill/cache-reserve-patterns.md": {
-      "hash": "4e0caf46c1a87978a862ac8231323ac26a22ccb9",
       "at": "2026-04-04T14:53:11Z",
+      "hash": "4e0caf46c1a87978a862ac8231323ac26a22ccb9",
       "passes": 2,
       "pr": 12779
     },
+    ".agents/services/hosting/cloudflare-platform-skill/cache-reserve.md": {
+      "at": "2026-04-04T14:54:10Z",
+      "hash": "3fe0b9baeb496344edd2cae2361ea302bcb7add9",
+      "passes": 1,
+      "pr": 17307
+    },
     ".agents/services/hosting/cloudflare-platform-skill/cron-triggers-gotchas.md": {
-      "hash": "4dc59ffae6aeb897a78aaf6da9cafa982601df8d",
       "at": "2026-04-03T01:11:32Z",
+      "hash": "4dc59ffae6aeb897a78aaf6da9cafa982601df8d",
       "passes": 3,
       "pr": 15606
     },
     ".agents/services/hosting/cloudflare-platform-skill/cron-triggers-patterns.md": {
-      "hash": "9f3a1d8924fe08976dbf41f8741677d1af0c70d9",
       "at": "2026-04-03T00:57:59Z",
+      "hash": "9f3a1d8924fe08976dbf41f8741677d1af0c70d9",
       "passes": 3,
       "pr": 16020
     },
     ".agents/services/hosting/cloudflare-platform-skill/cron-triggers.md": {
-      "hash": "ffa34a57142a44a73c22a6ad451b8928325a54f8",
       "at": "2026-04-03T11:54:15Z",
+      "hash": "ffa34a57142a44a73c22a6ad451b8928325a54f8",
       "passes": 1,
       "pr": 16445
     },
+    ".agents/services/hosting/cloudflare-platform-skill/d1-gotchas.md": {
+      "at": "2026-04-03T16:35:54Z",
+      "hash": "7383e491900c1eeef59699a160c5529e0972c9b5",
+      "passes": 1,
+      "pr": 16655
+    },
     ".agents/services/hosting/cloudflare-platform-skill/d1-patterns.md": {
-      "hash": "bd28a3df50f49f6adc255240c281fb8d8481be88",
       "at": "2026-03-29T21:43:01Z",
+      "hash": "bd28a3df50f49f6adc255240c281fb8d8481be88",
       "passes": 1,
       "pr": 13296
     },
+    ".agents/services/hosting/cloudflare-platform-skill/d1.md": {
+      "at": "2026-04-03T19:14:47Z",
+      "hash": "65df3b4237c75add161b1a2131383cc265d23dc8",
+      "passes": 1,
+      "pr": 16730
+    },
     ".agents/services/hosting/cloudflare-platform-skill/ddos-gotchas.md": {
-      "hash": "20abac5f270527a2633adc1e8785de395f3d06ee",
       "at": "2026-04-02T21:20:06Z",
+      "hash": "20abac5f270527a2633adc1e8785de395f3d06ee",
       "passes": 2,
       "pr": 0
     },
     ".agents/services/hosting/cloudflare-platform-skill/ddos-patterns.md": {
-      "hash": "3d2b1c39215599f79f59aa70bf54e21e2a998d6a",
       "at": "2026-03-30T02:30:53Z",
+      "hash": "3d2b1c39215599f79f59aa70bf54e21e2a998d6a",
       "passes": 1,
       "pr": 13494
     },
     ".agents/services/hosting/cloudflare-platform-skill/do-storage-gotchas.md": {
-      "hash": "7887b0627d38548d8579599fb49ff567f245b8aa",
       "at": "2026-04-03T01:53:26Z",
+      "hash": "7887b0627d38548d8579599fb49ff567f245b8aa",
       "passes": 1,
       "pr": 15694
     },
     ".agents/services/hosting/cloudflare-platform-skill/do-storage.md": {
-      "hash": "d65784cbb919f256120c6ec42d11eab0d01ae0ff",
       "at": "2026-04-02T21:58:19Z",
+      "hash": "d65784cbb919f256120c6ec42d11eab0d01ae0ff",
       "passes": 1,
       "pr": 15569
     },
     ".agents/services/hosting/cloudflare-platform-skill/durable-objects-gotchas.md": {
-      "hash": "2cc8c27d03e723eee00c9c57796609b1ea387717",
       "at": "2026-03-29T11:19:55Z",
+      "hash": "2cc8c27d03e723eee00c9c57796609b1ea387717",
       "passes": 1,
       "pr": 12890
     },
     ".agents/services/hosting/cloudflare-platform-skill/durable-objects-patterns.md": {
-      "hash": "12f19d53cf5233e3e3c4a4398a2af707981a2d77",
       "at": "2026-03-28T21:50:53Z",
+      "hash": "12f19d53cf5233e3e3c4a4398a2af707981a2d77",
       "passes": 1,
       "pr": 12192
     },
     ".agents/services/hosting/cloudflare-platform-skill/durable-objects.md": {
-      "hash": "e9f2ba688c48cfcf6db2380054b3798edb24678b",
       "at": "2026-04-03T11:53:58Z",
+      "hash": "e9f2ba688c48cfcf6db2380054b3798edb24678b",
       "passes": 2,
       "pr": 15663
     },
     ".agents/services/hosting/cloudflare-platform-skill/email-workers.md": {
-      "hash": "171394652ef8555d8c0bdaca1c925ea5af6fc71a",
       "at": "2026-03-29T03:15:00Z",
+      "hash": "171394652ef8555d8c0bdaca1c925ea5af6fc71a",
       "passes": 1,
       "pr": 12502
     },
     ".agents/services/hosting/cloudflare-platform-skill/hyperdrive-gotchas.md": {
-      "hash": "5c65b5de5da91cb981c5af0b5756ae8d0c35bc27",
       "at": "2026-04-03T04:23:06Z",
+      "hash": "5c65b5de5da91cb981c5af0b5756ae8d0c35bc27",
       "passes": 1,
       "pr": 15925
     },
     ".agents/services/hosting/cloudflare-platform-skill/hyperdrive-patterns.md": {
-      "hash": "5c907ac130712ea91879dad7551a8bb291dae468",
       "at": "2026-04-03T11:54:15Z",
+      "hash": "5c907ac130712ea91879dad7551a8bb291dae468",
       "passes": 1,
       "pr": 16441
     },
     ".agents/services/hosting/cloudflare-platform-skill/hyperdrive.md": {
-      "hash": "6234e68410206bd40d52cfab5f04e0f6ceb8b41f",
       "at": "2026-04-02T04:56:50Z",
+      "hash": "6234e68410206bd40d52cfab5f04e0f6ceb8b41f",
       "passes": 1,
       "pr": 15481
     },
     ".agents/services/hosting/cloudflare-platform-skill/kv-gotchas.md": {
-      "hash": "bc524d087703ca8ea0436823dea776016af03416",
       "at": "2026-04-03T11:53:58Z",
+      "hash": "bc524d087703ca8ea0436823dea776016af03416",
       "passes": 2,
       "pr": 15645
     },
     ".agents/services/hosting/cloudflare-platform-skill/kv-patterns.md": {
-      "hash": "74f2384c1866ceaaa011e4d2fd8a3420ebb0afcb",
       "at": "2026-03-29T22:09:11Z",
+      "hash": "74f2384c1866ceaaa011e4d2fd8a3420ebb0afcb",
       "passes": 1,
       "pr": 13321
     },
     ".agents/services/hosting/cloudflare-platform-skill/miniflare-gotchas.md": {
-      "hash": "ed35ce7ce12b09d5d0e17ab817e539765d005d85",
       "at": "2026-03-29T07:02:46Z",
+      "hash": "ed35ce7ce12b09d5d0e17ab817e539765d005d85",
       "passes": 1,
       "pr": 12586
     },
     ".agents/services/hosting/cloudflare-platform-skill/miniflare-patterns.md": {
-      "hash": "26584e0aa4ebf557529d784b35630d922fa9f050",
       "at": "2026-03-29T14:29:37Z",
+      "hash": "26584e0aa4ebf557529d784b35630d922fa9f050",
       "passes": 1,
       "pr": 13020
     },
     ".agents/services/hosting/cloudflare-platform-skill/miniflare.md": {
-      "hash": "462fd5b10d3f24fda9cb5d16f74220e2a0f7c1b7",
       "at": "2026-04-02T21:58:19Z",
+      "hash": "462fd5b10d3f24fda9cb5d16f74220e2a0f7c1b7",
       "passes": 1,
       "pr": 15561
     },
     ".agents/services/hosting/cloudflare-platform-skill/network-interconnect-gotchas.md": {
-      "hash": "68e28829465b2b660b97664ccffe2f7096e330ae",
       "at": "2026-03-29T12:36:58Z",
+      "hash": "68e28829465b2b660b97664ccffe2f7096e330ae",
       "passes": 1,
       "pr": 12944
     },
     ".agents/services/hosting/cloudflare-platform-skill/network-interconnect-patterns.md": {
-      "hash": "c6cb91d0f6b75d1d308b590c10c9c168b8dda6c8",
       "at": "2026-03-29T12:37:11Z",
+      "hash": "c6cb91d0f6b75d1d308b590c10c9c168b8dda6c8",
       "passes": 1,
       "pr": 12909
     },
     ".agents/services/hosting/cloudflare-platform-skill/network-interconnect.md": {
-      "hash": "565d1191601a71f39931fc20f3721ccdf9373828",
       "at": "2026-04-02T23:13:23Z",
+      "hash": "565d1191601a71f39931fc20f3721ccdf9373828",
       "passes": 2,
       "pr": 14916
     },
     ".agents/services/hosting/cloudflare-platform-skill/pages-functions-gotchas.md": {
-      "hash": "f699f2e3f628d345b43247570d7499db8d4fd5f0",
       "at": "2026-04-03T11:53:58Z",
+      "hash": "f699f2e3f628d345b43247570d7499db8d4fd5f0",
       "passes": 2,
       "pr": 15646
     },
     ".agents/services/hosting/cloudflare-platform-skill/pages-functions-patterns.md": {
-      "hash": "cc60310c7957b55385fde646cfce011c84f8ce00",
       "at": "2026-03-30T06:49:10Z",
+      "hash": "cc60310c7957b55385fde646cfce011c84f8ce00",
       "passes": 2,
       "pr": 13929
     },
+    ".agents/services/hosting/cloudflare-platform-skill/pages-functions.md": {
+      "at": "2026-04-04T14:54:12Z",
+      "hash": "4dbb56cad0d43f81be292f70d1a0986262a9b087",
+      "passes": 1,
+      "pr": 17281
+    },
     ".agents/services/hosting/cloudflare-platform-skill/pages-gotchas.md": {
-      "hash": "061e37ccd190973ca588ff3f19114e99cf14626e",
       "at": "2026-03-30T03:33:53Z",
+      "hash": "061e37ccd190973ca588ff3f19114e99cf14626e",
       "passes": 1,
       "pr": 13667
     },
     ".agents/services/hosting/cloudflare-platform-skill/pages-patterns.md": {
-      "hash": "cee6ccd4100730c8a5d9f649222b9f36355c9c34",
       "at": "2026-03-30T02:30:18Z",
+      "hash": "cee6ccd4100730c8a5d9f649222b9f36355c9c34",
       "passes": 1,
       "pr": 13595
     },
     ".agents/services/hosting/cloudflare-platform-skill/pages.md": {
-      "hash": "8cffa03b67b701cb42358168762f3895152eae7d",
       "at": "2026-04-03T01:24:39Z",
+      "hash": "8cffa03b67b701cb42358168762f3895152eae7d",
       "passes": 1,
       "pr": "16041"
     },
     ".agents/services/hosting/cloudflare-platform-skill/pipelines.md": {
-      "hash": "ec510e191ca9f1d806025105de5af5fa0bc81eb6",
       "at": "2026-04-03T11:54:14Z",
+      "hash": "ec510e191ca9f1d806025105de5af5fa0bc81eb6",
       "passes": 1,
       "pr": 16475
     },
     ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas.md": {
-      "hash": "607081308bdfbd7b403de8421570d30685a74e67",
       "at": "2026-03-31T07:50:54Z",
+      "hash": "607081308bdfbd7b403de8421570d30685a74e67",
       "passes": 2,
       "pr": 14717
     },
     ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/best-practices.md": {
-      "hash": "63d19b94fe11c4f82e2399096556c9ec85a1724e",
       "at": "2026-03-31T07:50:54Z",
+      "hash": "63d19b94fe11c4f82e2399096556c9ec85a1724e",
       "passes": 2,
       "pr": 14717
     },
     ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/ci-cd.md": {
-      "hash": "06de52d33dae48df2bb22fbe72f627111675070c",
       "at": "2026-03-31T07:50:54Z",
+      "hash": "06de52d33dae48df2bb22fbe72f627111675070c",
       "passes": 2,
       "pr": 14717
     },
     ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/common-errors.md": {
-      "hash": "aa1e9597323dc9012049d750165fd7aedc8f57a4",
       "at": "2026-03-31T07:50:54Z",
+      "hash": "aa1e9597323dc9012049d750165fd7aedc8f57a4",
       "passes": 2,
       "pr": 14717
     },
     ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/debugging.md": {
-      "hash": "740bc566d298e977d2b91988e048d0bb3c13d16f",
       "at": "2026-03-31T07:50:54Z",
+      "hash": "740bc566d298e977d2b91988e048d0bb3c13d16f",
       "passes": 2,
       "pr": 14717
     },
     ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/migration.md": {
-      "hash": "f4f794d6850b5159cd24d48cc145e78e0407d012",
       "at": "2026-03-31T07:50:54Z",
+      "hash": "f4f794d6850b5159cd24d48cc145e78e0407d012",
       "passes": 2,
       "pr": 14717
     },
     ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/performance.md": {
-      "hash": "f28956202d6024d11b94149c62473fa13de5ff83",
       "at": "2026-03-31T07:50:54Z",
+      "hash": "f28956202d6024d11b94149c62473fa13de5ff83",
       "passes": 2,
       "pr": 14717
     },
     ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/resources.md": {
-      "hash": "1b24fc41d86e042e080f67d3cb478444042b48fa",
       "at": "2026-03-31T07:50:54Z",
+      "hash": "1b24fc41d86e042e080f67d3cb478444042b48fa",
       "passes": 2,
       "pr": 14717
     },
     ".agents/services/hosting/cloudflare-platform-skill/pulumi-gotchas/security.md": {
-      "hash": "1e89bfa26f2fb697ed885f7e1c6b279fdf94d71f",
       "at": "2026-03-31T07:50:54Z",
+      "hash": "1e89bfa26f2fb697ed885f7e1c6b279fdf94d71f",
       "passes": 2,
       "pr": 14717
     },
     ".agents/services/hosting/cloudflare-platform-skill/pulumi-patterns.md": {
-      "hash": "0d75c88cc9ae0ca4eddd2d63ed2c3607ab3a5356",
       "at": "2026-03-29T22:09:12Z",
+      "hash": "0d75c88cc9ae0ca4eddd2d63ed2c3607ab3a5356",
       "passes": 1,
       "pr": 13329
     },
     ".agents/services/hosting/cloudflare-platform-skill/pulumi.md": {
-      "hash": "578aa41b94198069f3122785c49c9b28328d793f",
       "at": "2026-04-03T01:53:04Z",
+      "hash": "578aa41b94198069f3122785c49c9b28328d793f",
       "passes": 2,
       "pr": 15823
     },
     ".agents/services/hosting/cloudflare-platform-skill/queues-gotchas.md": {
-      "hash": "8b22c10bba3be258464227e4f12445fd1954a871",
       "at": "2026-04-03T11:54:13Z",
+      "hash": "8b22c10bba3be258464227e4f12445fd1954a871",
       "passes": 1,
       "pr": 16501
     },
     ".agents/services/hosting/cloudflare-platform-skill/queues-patterns.md": {
-      "hash": "7c1309c9011dc45b0317a0516c8b075fc39037b2",
       "at": "2026-03-30T04:51:49Z",
+      "hash": "7c1309c9011dc45b0317a0516c8b075fc39037b2",
       "passes": 1,
       "pr": 13735
     },
     ".agents/services/hosting/cloudflare-platform-skill/r2-gotchas.md": {
-      "hash": "ffd5cc6c8a1c9d0b9c635cb3d25cdf7ea3d35753",
       "at": "2026-04-02T15:27:02Z",
+      "hash": "ffd5cc6c8a1c9d0b9c635cb3d25cdf7ea3d35753",
       "passes": 2,
       "pr": 15629
     },
     ".agents/services/hosting/cloudflare-platform-skill/r2-patterns.md": {
-      "hash": "47f2eee88b7bc4ab3ee656a89f811bf6d95b9848",
       "at": "2026-04-03T03:15:28Z",
+      "hash": "47f2eee88b7bc4ab3ee656a89f811bf6d95b9848",
       "passes": 1,
       "pr": 15908
     },
     ".agents/services/hosting/cloudflare-platform-skill/r2-sql.md": {
-      "hash": "26833d21a143317c3d71ac271493990ce482aa3d",
       "at": "2026-03-28T16:00:25Z",
+      "hash": "26833d21a143317c3d71ac271493990ce482aa3d",
       "passes": 1,
       "pr": 11985
     },
     ".agents/services/hosting/cloudflare-platform-skill/r2.md": {
-      "hash": "6b3a34027b066a28b2e45ac90a20151973116bbd",
       "at": "2026-04-02T23:13:24Z",
+      "hash": "6b3a34027b066a28b2e45ac90a20151973116bbd",
       "passes": 2,
       "pr": 14914
     },
     ".agents/services/hosting/cloudflare-platform-skill/realtime-sfu-gotchas.md": {
-      "hash": "bb81f971213273755fbcfc3ff5330bad5434cdcb",
       "at": "2026-04-03T11:54:13Z",
+      "hash": "bb81f971213273755fbcfc3ff5330bad5434cdcb",
       "passes": 1,
       "pr": 16502
     },
     ".agents/services/hosting/cloudflare-platform-skill/realtime-sfu-patterns.md": {
-      "hash": "578b93b77de2fd438e0b7641b030f41d130fe158",
       "at": "2026-04-03T11:54:14Z",
+      "hash": "578b93b77de2fd438e0b7641b030f41d130fe158",
       "passes": 1,
       "pr": 16477
     },
     ".agents/services/hosting/cloudflare-platform-skill/realtimekit-gotchas.md": {
-      "hash": "02a71d5d8b3cdc0bd61a64e40716b2d5064bef53",
       "at": "2026-04-02T15:00:00Z",
+      "hash": "02a71d5d8b3cdc0bd61a64e40716b2d5064bef53",
       "passes": 1,
       "pr": 15651
     },
     ".agents/services/hosting/cloudflare-platform-skill/realtimekit-patterns.md": {
-      "hash": "def466c71134e60283819167fb3440d728d57286",
       "at": "2026-03-30T03:33:46Z",
+      "hash": "def466c71134e60283819167fb3440d728d57286",
       "passes": 1,
       "pr": 13654
     },
+    ".agents/services/hosting/cloudflare-platform-skill/realtimekit.md": {
+      "at": "2026-04-03T13:35:13Z",
+      "hash": "e00af10a47219d972f6551086fd1c6d6271a34e5",
+      "passes": 1,
+      "pr": 16586
+    },
     ".agents/services/hosting/cloudflare-platform-skill/sandbox-gotchas.md": {
-      "hash": "281fda964e2f6443bbcb9c64ebd2fbeef3f80f6a",
       "at": "2026-03-30T06:49:26Z",
+      "hash": "281fda964e2f6443bbcb9c64ebd2fbeef3f80f6a",
       "passes": 1,
       "pr": 13938
     },
     ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns.md": {
-      "hash": "7a2639bf83fbae43ce58a809ea048791c0097084",
       "at": "2026-04-01T23:23:23Z",
+      "hash": "7a2639bf83fbae43ce58a809ea048791c0097084",
       "passes": 1,
       "pr": 15353
     },
     ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/01-ai-code-execution.md": {
-      "hash": "f21b3dc2fda79db87d6fcbf46f4a6b4f2cdc197c",
       "at": "2026-04-01T23:23:23Z",
+      "hash": "f21b3dc2fda79db87d6fcbf46f4a6b4f2cdc197c",
       "passes": 1,
       "pr": 15353
     },
     ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/02-interactive-dev-environment.md": {
-      "hash": "6a6b3bfac3b522de212f1addf373380c2a7ac191",
       "at": "2026-04-01T23:23:23Z",
+      "hash": "6a6b3bfac3b522de212f1addf373380c2a7ac191",
       "passes": 1,
       "pr": 15353
     },
     ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/03-ci-cd-pipeline.md": {
-      "hash": "d2e73f986d566c00b0405fb5aeb5d6189e5ff2a3",
       "at": "2026-04-01T23:23:24Z",
+      "hash": "d2e73f986d566c00b0405fb5aeb5d6189e5ff2a3",
       "passes": 1,
       "pr": 15353
     },
     ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/04-multi-language-code-runner.md": {
-      "hash": "2d167baa254157c364591e9ce677d1446b6f9077",
       "at": "2026-04-01T23:23:24Z",
+      "hash": "2d167baa254157c364591e9ce677d1446b6f9077",
       "passes": 1,
       "pr": 15353
     },
     ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/05-multi-tenant.md": {
-      "hash": "e1310638bf36c0c98fba66da79dea72345ad8d13",
       "at": "2026-04-01T23:23:24Z",
+      "hash": "e1310638bf36c0c98fba66da79dea72345ad8d13",
       "passes": 1,
       "pr": 15353
     },
     ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/06-jupyter-integration.md": {
-      "hash": "b102674d44ab9fc5741824d5d20b3423f526b6fb",
       "at": "2026-04-01T23:23:24Z",
+      "hash": "b102674d44ab9fc5741824d5d20b3423f526b6fb",
       "passes": 1,
       "pr": 15353
     },
     ".agents/services/hosting/cloudflare-platform-skill/sandbox-patterns/07-git-operations.md": {
-      "hash": "978634c7700d0dc195885c0364339803431d08fe",
       "at": "2026-04-01T23:23:24Z",
+      "hash": "978634c7700d0dc195885c0364339803431d08fe",
       "passes": 1,
       "pr": 15353
     },
     ".agents/services/hosting/cloudflare-platform-skill/sandbox.md": {
-      "hash": "e1b81462763bbec325b03c7da48596cf7704f303",
       "at": "2026-04-02T22:12:27Z",
+      "hash": "e1b81462763bbec325b03c7da48596cf7704f303",
       "passes": 1
     },
     ".agents/services/hosting/cloudflare-platform-skill/smart-placement-patterns.md": {
-      "hash": "f58917dff65644764fed968a87bb04fd3570a33f",
       "at": "2026-03-30T02:54:22Z",
+      "hash": "f58917dff65644764fed968a87bb04fd3570a33f",
       "passes": 1,
       "pr": 13564
     },
+    ".agents/services/hosting/cloudflare-platform-skill/smart-placement.md": {
+      "at": "2026-04-03T13:35:14Z",
+      "hash": "81220dc4f64d47000f38aa5398d7539a34695f09",
+      "passes": 1,
+      "pr": 16573
+    },
     ".agents/services/hosting/cloudflare-platform-skill/stream-gotchas.md": {
-      "hash": "c6ad267ec63ad88eec67dff6310f10375b36e6b4",
       "at": "2026-04-02T21:20:07Z",
+      "hash": "c6ad267ec63ad88eec67dff6310f10375b36e6b4",
       "passes": 2,
       "pr": 13254
     },
     ".agents/services/hosting/cloudflare-platform-skill/stream-patterns.md": {
-      "hash": "5c6a30722d983f23409725cecff809bddebcb159",
       "at": "2026-03-30T06:03:15Z",
+      "hash": "5c6a30722d983f23409725cecff809bddebcb159",
       "passes": 1,
       "pr": 13844
     },
+    ".agents/services/hosting/cloudflare-platform-skill/stream.md": {
+      "at": "2026-04-03T13:35:13Z",
+      "hash": "eb852067b0a3c17b56e251ef4610ecde7519edf2",
+      "passes": 1,
+      "pr": 16585
+    },
     ".agents/services/hosting/cloudflare-platform-skill/tail-workers.md": {
-      "hash": "9d7865ae508292cbdca66d5a9b6c42c715648875",
       "at": "2026-03-28T08:17:39Z",
+      "hash": "9d7865ae508292cbdca66d5a9b6c42c715648875",
       "passes": 1,
       "pr": 11562
     },
     ".agents/services/hosting/cloudflare-platform-skill/terraform-gotchas.md": {
-      "hash": "c9f05e401af4147cafaa757546107bcafef062a4",
       "at": "2026-03-28T23:05:57Z",
+      "hash": "c9f05e401af4147cafaa757546107bcafef062a4",
       "passes": 1,
       "pr": 12324
     },
     ".agents/services/hosting/cloudflare-platform-skill/terraform-patterns.md": {
-      "hash": "a03a4fa1e8a663627e5128cb93126488a97a2d54",
       "at": "2026-03-30T03:34:24Z",
+      "hash": "a03a4fa1e8a663627e5128cb93126488a97a2d54",
       "passes": 1,
       "pr": 13534
     },
+    ".agents/services/hosting/cloudflare-platform-skill/terraform.md": {
+      "at": "2026-04-03T16:35:52Z",
+      "hash": "b92546d9d4760c1b52f896aa0490fb623bb4b147",
+      "passes": 1,
+      "pr": 16710
+    },
     ".agents/services/hosting/cloudflare-platform-skill/tunnel-gotchas.md": {
-      "hash": "6dc8f07ccc509831eb9944f1b93b60339444395b",
       "at": "2026-04-02T22:44:04Z",
+      "hash": "6dc8f07ccc509831eb9944f1b93b60339444395b",
       "passes": 1,
       "pr": 15666
     },
     ".agents/services/hosting/cloudflare-platform-skill/tunnel-patterns.md": {
-      "hash": "725118a54a49f8b3f29f2fc0d78f3ed14c6a34a7",
       "at": "2026-03-29T12:36:34Z",
+      "hash": "725118a54a49f8b3f29f2fc0d78f3ed14c6a34a7",
       "passes": 1,
       "pr": 12955
     },
+    ".agents/services/hosting/cloudflare-platform-skill/tunnel.md": {
+      "at": "2026-04-03T16:35:54Z",
+      "hash": "dbd3d5267226019619b2487f0c0ded3c8d1573c2",
+      "passes": 1,
+      "pr": 16654
+    },
     ".agents/services/hosting/cloudflare-platform-skill/turn.md": {
-      "hash": "a8015065b74a18ac216dac46ea18e41694251ad4",
       "at": "2026-03-29T08:50:09Z",
+      "hash": "a8015065b74a18ac216dac46ea18e41694251ad4",
       "passes": 1,
       "pr": 12801
     },
     ".agents/services/hosting/cloudflare-platform-skill/vectorize-gotchas.md": {
-      "hash": "e2e7b0fbda9b7f737b017f3fa33bcfbe4936400f",
       "at": "2026-03-28T08:18:21Z",
+      "hash": "e2e7b0fbda9b7f737b017f3fa33bcfbe4936400f",
       "passes": 1,
       "pr": 11631
     },
     ".agents/services/hosting/cloudflare-platform-skill/vectorize-patterns.md": {
-      "hash": "e9f6d3a607e9aa98a6e0dd3ee96509ecc3429baa",
       "at": "2026-03-28T08:18:21Z",
+      "hash": "e9f6d3a607e9aa98a6e0dd3ee96509ecc3429baa",
       "passes": 1,
       "pr": 11631
     },
     ".agents/services/hosting/cloudflare-platform-skill/vectorize.md": {
-      "hash": "fa0c8067155086cb38192b3afe47c87d93f030cb",
       "at": "2026-03-28T08:18:21Z",
+      "hash": "fa0c8067155086cb38192b3afe47c87d93f030cb",
       "passes": 1,
       "pr": 11631
     },
     ".agents/services/hosting/cloudflare-platform-skill/web-analytics-patterns.md": {
-      "hash": "97752da4b4c0560f21c9415189144e27d3869e25",
       "at": "2026-03-31T03:46:07Z",
+      "hash": "97752da4b4c0560f21c9415189144e27d3869e25",
       "passes": 2,
       "pr": 14541
     },
     ".agents/services/hosting/cloudflare-platform-skill/workerd-gotchas.md": {
-      "hash": "59260c97a4c5a8947c8aa606d58d901fd84bb89b",
       "at": "2026-03-30T03:34:13Z",
+      "hash": "59260c97a4c5a8947c8aa606d58d901fd84bb89b",
       "passes": 1,
       "pr": 13636
     },
     ".agents/services/hosting/cloudflare-platform-skill/workerd-patterns.md": {
-      "hash": "f73104f9828a54f94b380d6a627d5262984890a6",
       "at": "2026-04-03T01:53:23Z",
+      "hash": "f73104f9828a54f94b380d6a627d5262984890a6",
       "passes": 1,
       "pr": 15869
     },
     ".agents/services/hosting/cloudflare-platform-skill/workers-for-platforms-gotchas.md": {
-      "hash": "86f2fdf818faa639bde42b287f7ada2d33a156cd",
       "at": "2026-03-29T20:53:54Z",
+      "hash": "86f2fdf818faa639bde42b287f7ada2d33a156cd",
       "passes": 1,
       "pr": 13291
     },
     ".agents/services/hosting/cloudflare-platform-skill/workers-for-platforms-patterns.md": {
-      "hash": "82bb0fa830bee3c4dac48748103f701eade3e94f",
       "at": "2026-03-29T07:02:06Z",
+      "hash": "82bb0fa830bee3c4dac48748103f701eade3e94f",
       "passes": 1,
       "pr": 12686
     },
     ".agents/services/hosting/cloudflare-platform-skill/workers-gotchas.md": {
-      "hash": "3c6fdf9198767eeacd7c8287ede693cc705411fc",
       "at": "2026-04-03T12:15:32Z",
+      "hash": "3c6fdf9198767eeacd7c8287ede693cc705411fc",
       "passes": 1,
       "pr": 16556
     },
     ".agents/services/hosting/cloudflare-platform-skill/workers-patterns.md": {
-      "hash": "c9d0716065aa09e381335f515b72c2b8ba9e7786",
       "at": "2026-04-03T11:54:14Z",
+      "hash": "c9d0716065aa09e381335f515b72c2b8ba9e7786",
       "passes": 1,
       "pr": 16474
     },
     ".agents/services/hosting/cloudflare-platform-skill/workers-vpc.md": {
-      "hash": "3652b72297129255c760f2e656675c3533ea7c2a",
       "at": "2026-03-28T08:57:49Z",
+      "hash": "3652b72297129255c760f2e656675c3533ea7c2a",
       "passes": 1,
       "pr": 11677
     },
     ".agents/services/hosting/cloudflare-platform-skill/workers.md": {
-      "hash": "fc1f3e37345f307c42d05e16f4887a80e9e55af9",
       "at": "2026-03-31T09:29:58Z",
+      "hash": "fc1f3e37345f307c42d05e16f4887a80e9e55af9",
       "passes": 2,
       "pr": 14792
     },
     ".agents/services/hosting/cloudflare-platform-skill/workflows-gotchas.md": {
-      "hash": "c40502a0c4ca3853474df2d11d52c73ee5929239",
       "at": "2026-03-29T21:43:20Z",
+      "hash": "c40502a0c4ca3853474df2d11d52c73ee5929239",
       "passes": 1,
       "pr": 13342
     },
     ".agents/services/hosting/cloudflare-platform-skill/workflows-patterns.md": {
-      "hash": "7009f8eb920f115caabbd2e6f4337875e981b386",
       "at": "2026-03-29T21:43:21Z",
+      "hash": "7009f8eb920f115caabbd2e6f4337875e981b386",
       "passes": 1,
       "pr": 13342
     },
     ".agents/services/hosting/cloudflare-platform-skill/workflows.md": {
-      "hash": "d1b0e06d49e189b1815b353560235a3d5cb29600",
       "at": "2026-03-29T21:43:21Z",
+      "hash": "d1b0e06d49e189b1815b353560235a3d5cb29600",
       "passes": 1,
       "pr": 13342
     },
+    ".agents/services/hosting/cloudflare-platform-skill/wrangler-gotchas.md": {
+      "at": "2026-04-03T19:14:46Z",
+      "hash": "7c65f8f17378978898a8ff6d08e128a98e1a7011",
+      "passes": 1,
+      "pr": 16803
+    },
     ".agents/services/hosting/cloudflare-platform-skill/wrangler-patterns.md": {
-      "hash": "bc026973544d8ed4ec609ee75a7dfd226c2f95e9",
       "at": "2026-04-01T23:23:38Z",
+      "hash": "bc026973544d8ed4ec609ee75a7dfd226c2f95e9",
       "passes": 1,
       "pr": 15335
     },
     ".agents/services/hosting/cloudflare-platform-skill/wrangler.md": {
-      "hash": "3f9482894c4bcf0b711d7cdf5407b2173976c02a",
       "at": "2026-04-03T11:53:59Z",
+      "hash": "3f9482894c4bcf0b711d7cdf5407b2173976c02a",
       "passes": 2
     },
+    ".agents/services/hosting/cloudflare-platform-skill/zaraz-patterns.md": {
+      "at": "2026-04-03T19:14:46Z",
+      "hash": "f77677b3bd3fa9125f7952b43ab3c7f366ba8c24",
+      "passes": 1,
+      "pr": 16799
+    },
     ".agents/services/hosting/cloudflare-platform-skill/zaraz.md": {
-      "hash": "7af371b239bf532c60f9283c32dae6630adcf7c1",
       "at": "2026-04-02T21:20:08Z",
+      "hash": "7af371b239bf532c60f9283c32dae6630adcf7c1",
       "passes": 2,
       "pr": 0
     },
     ".agents/services/hosting/cloudflare.md": {
-      "hash": "349fbff5ca739505617828955c9e4026630db480",
       "at": "2026-03-28T16:00:49Z",
+      "hash": "349fbff5ca739505617828955c9e4026630db480",
       "passes": 1,
       "pr": 11992
     },
     ".agents/services/hosting/cloudron.md": {
-      "hash": "20969188ce22920351263201c9754753bfa617c2",
       "at": "2026-03-28T16:40:22Z",
+      "hash": "20969188ce22920351263201c9754753bfa617c2",
       "passes": 1,
       "pr": 12046
     },
     ".agents/services/hosting/dns-providers.md": {
-      "hash": "30179f7017cd79d4f6ae86265b17eb8d41b166ae",
       "at": "2026-03-30T03:33:45Z",
+      "hash": "30179f7017cd79d4f6ae86265b17eb8d41b166ae",
       "passes": 1,
       "pr": 13668
     },
     ".agents/services/hosting/domain-purchasing.md": {
-      "hash": "4713f407fe0986175b41fdb0806bb56af5a276f9",
       "at": "2026-03-29T10:47:23Z",
+      "hash": "4713f407fe0986175b41fdb0806bb56af5a276f9",
       "passes": 1,
       "pr": 12867
     },
     ".agents/services/hosting/hetzner.md": {
-      "hash": "3778dae5152cff8fad4fe4e646c4a077cd3ed76c",
       "at": "2026-04-13T16:27:41Z",
+      "hash": "3778dae5152cff8fad4fe4e646c4a077cd3ed76c",
       "passes": 2,
       "pr": 12687
     },
     ".agents/services/hosting/hostinger.md": {
-      "hash": "3cdeab2fa1dc49801954a691863b7a81edf4ffe2",
       "at": "2026-03-28T11:20:19Z",
+      "hash": "3cdeab2fa1dc49801954a691863b7a81edf4ffe2",
       "passes": 1,
       "pr": 11804
     },
     ".agents/services/hosting/local-hosting.md": {
-      "hash": "922fa4846c8b00ed78f60ca0942aceced12d9ab6",
       "at": "2026-03-28T16:41:15Z",
+      "hash": "922fa4846c8b00ed78f60ca0942aceced12d9ab6",
       "passes": 1,
       "pr": 12026
     },
     ".agents/services/hosting/proxmox-full-skill.md": {
-      "hash": "c3dba0fbac32dc6eb73eeca99d43dacb7583ebaa",
       "at": "2026-03-30T06:49:37Z",
+      "hash": "c3dba0fbac32dc6eb73eeca99d43dacb7583ebaa",
       "passes": 1,
       "pr": 13859
     },
     ".agents/services/hosting/spaceship.md": {
-      "hash": "f48acd129bafb3d09918ee3a0e4d41d8806a0091",
       "at": "2026-04-03T01:11:34Z",
+      "hash": "f48acd129bafb3d09918ee3a0e4d41d8806a0091",
       "passes": 2,
       "pr": 15494
     },
+    ".agents/services/hosting/ubicloud.md": {
+      "at": "2026-04-14T07:25:44Z",
+      "hash": "e937e719eb2c5f90fb1495ac31a9da670c7e1550",
+      "passes": 3,
+      "pr": 18797
+    },
     ".agents/services/hosting/webhosting.md": {
-      "hash": "ead335f6fae565fb015276d2927ec8253dafefb1",
       "at": "2026-03-28T03:54:32Z",
+      "hash": "ead335f6fae565fb015276d2927ec8253dafefb1",
       "passes": 1,
       "pr": 11352
     },
     ".agents/services/monitoring/langwatch.md": {
-      "hash": "b5c77d793b369ba27052c61bb880b7a292bb46b3",
       "at": "2026-03-28T16:00:51Z",
+      "hash": "b5c77d793b369ba27052c61bb880b7a292bb46b3",
       "passes": 1,
       "pr": 11994
     },
-    ".agents/services/monitoring/socket.md": {
-      "hash": "5dbb22acfee783c79152d04e9224e9dab6cd8005",
+    ".agents/services/monitoring/sentry.md": {
       "at": "2026-04-13T16:27:41Z",
+      "hash": "7a4028ba64d1cdc2727e95af25b070c76b16bec4",
+      "passes": 2,
+      "pr": 16651
+    },
+    ".agents/services/monitoring/socket.md": {
+      "at": "2026-04-13T16:27:41Z",
+      "hash": "5dbb22acfee783c79152d04e9224e9dab6cd8005",
       "passes": 2,
       "pr": 14896
     },
     ".agents/services/networking/netbird.md": {
-      "hash": "8615a08e63ca15cc79d4057daf42738885a671b4",
       "at": "2026-03-29T01:33:20Z",
+      "hash": "8615a08e63ca15cc79d4057daf42738885a671b4",
       "passes": 1,
       "pr": 12453
     },
     ".agents/services/networking/tailscale.md": {
-      "hash": "f6f0f540914813c95e04ab8d1f220df2ae34c7d2",
       "at": "2026-03-29T02:36:04Z",
+      "hash": "f6f0f540914813c95e04ab8d1f220df2ae34c7d2",
       "passes": 1,
       "pr": 12461
     },
+    ".agents/services/outreach/cold-outreach.md": {
+      "at": "2026-04-03T16:35:54Z",
+      "hash": "9d11fb2e7b2152aa011c6093fd0d61a1854751d6",
+      "passes": 1,
+      "pr": 16635
+    },
     ".agents/services/outreach/infraforge.md": {
-      "hash": "aaccc34349b2eb5eac809a705ee22d80c7503e95",
       "at": "2026-03-31T05:38:33Z",
+      "hash": "aaccc34349b2eb5eac809a705ee22d80c7503e95",
       "passes": 1,
       "pr": 14659
     },
     ".agents/services/outreach/instantly.md": {
-      "hash": "e424e80fe086b2454d225cd5bc26ec8f000da6af",
       "at": "2026-03-31T05:36:34Z",
+      "hash": "e424e80fe086b2454d225cd5bc26ec8f000da6af",
       "passes": 3,
       "pr": 14656
     },
+    ".agents/services/outreach/leadsforge.md": {
+      "at": "2026-04-03T16:35:52Z",
+      "hash": "7ddf2a120e2fd9c040b6a9882eec470ed2b723db",
+      "passes": 1,
+      "pr": 16708
+    },
     ".agents/services/outreach/manyreach.md": {
-      "hash": "9348c08419032d5e1c66c6e9073ff7e54c291cb7",
       "at": "2026-03-29T07:02:27Z",
+      "hash": "9348c08419032d5e1c66c6e9073ff7e54c291cb7",
       "passes": 1,
       "pr": 12581
     },
     ".agents/services/outreach/smartlead.md": {
-      "hash": "2a3d0559cecd97adb64dfe6f5572c6cedd25a7f1",
       "at": "2026-03-28T03:54:38Z",
+      "hash": "2a3d0559cecd97adb64dfe6f5572c6cedd25a7f1",
       "passes": 1,
       "pr": 11357
     },
     ".agents/services/payments/procurement.md": {
-      "hash": "bf529bd7701a6e8cae513a1b00b9f3fe7ff87b85",
       "at": "2026-03-28T09:48:49Z",
+      "hash": "bf529bd7701a6e8cae513a1b00b9f3fe7ff87b85",
       "passes": 1,
       "pr": 11713
     },
     ".agents/services/payments/revenuecat.md": {
-      "hash": "4bac8db78256a3ded4636d7411a56314440f5d55",
       "at": "2026-04-02T21:58:18Z",
+      "hash": "4bac8db78256a3ded4636d7411a56314440f5d55",
       "passes": 1,
       "pr": 15693
     },
     ".agents/services/payments/stripe.md": {
-      "hash": "5eb3fa01b0d9ea319bab9243dfe789079d4d16d7",
       "at": "2026-03-29T03:15:16Z",
+      "hash": "5eb3fa01b0d9ea319bab9243dfe789079d4d16d7",
       "passes": 1,
       "pr": 12511
     },
     ".agents/services/payments/superwall.md": {
-      "hash": "4108d4166dae90810bf63549e7d9cc53a13d7c3c",
       "at": "2026-03-29T12:36:44Z",
+      "hash": "4108d4166dae90810bf63549e7d9cc53a13d7c3c",
       "passes": 1,
       "pr": 12952
     },
+    ".agents/tests/comprehension/pilot-results.md": {
+      "at": "2026-04-03T14:06:30Z",
+      "hash": "d9b46d34968b33800bb8cc0316a5773e939127ce",
+      "passes": 1,
+      "pr": 16630
+    },
     ".agents/tools/accessibility/accessibility-audit.md": {
-      "hash": "03cb044f093ae10bae8aabde64d83febbcdd1af6",
       "at": "2026-03-28T08:18:26Z",
+      "hash": "03cb044f093ae10bae8aabde64d83febbcdd1af6",
       "passes": 1,
       "pr": 11634
     },
     ".agents/tools/accessibility/accessibility.md": {
-      "hash": "a060a7ad130a6ab7bf85b76f8aaa4f219c8136f3",
       "at": "2026-04-03T02:21:04Z",
+      "hash": "a060a7ad130a6ab7bf85b76f8aaa4f219c8136f3",
       "passes": 3,
       "pr": 14053
     },
     ".agents/tools/ai-assistants/agno.md": {
-      "hash": "bf659c50ed55387198f25dc4ef2a6d9bd0080034",
       "at": "2026-03-29T08:10:32Z",
+      "hash": "bf659c50ed55387198f25dc4ef2a6d9bd0080034",
       "passes": 1,
       "pr": 12746
     },
     ".agents/tools/ai-assistants/capsolver.md": {
-      "hash": "3811702780b4ad5727ca28354c525a00c010e918",
       "at": "2026-03-29T12:36:41Z",
+      "hash": "3811702780b4ad5727ca28354c525a00c010e918",
       "passes": 1,
       "pr": 12953
     },
     ".agents/tools/ai-assistants/claude-code.md": {
-      "hash": "25a1bb10d6283ccab2b680e2666d2e05d39d2e78",
       "at": "2026-04-13T16:27:42Z",
+      "hash": "25a1bb10d6283ccab2b680e2666d2e05d39d2e78",
       "passes": 2,
       "pr": 15204
     },
     ".agents/tools/ai-assistants/compare-models.md": {
-      "hash": "e8dcca87c88f298e1c83fa6a5909bf8d125b4693",
       "at": "2026-03-29T14:29:46Z",
+      "hash": "e8dcca87c88f298e1c83fa6a5909bf8d125b4693",
       "passes": 1,
       "pr": 13017
     },
     ".agents/tools/ai-assistants/datasets.md": {
-      "hash": "9d4e1d98f9bfed78c920b554806bb0456c0ba023",
       "at": "2026-04-02T12:00:00Z",
+      "hash": "9d4e1d98f9bfed78c920b554806bb0456c0ba023",
       "passes": 1,
       "pr": 15336
     },
     ".agents/tools/ai-assistants/fallback-chains.md": {
-      "hash": "3ebd8948a273bc6ffbe26fc653fddffe3356c3c8",
       "at": "2026-04-02T21:58:20Z",
+      "hash": "3ebd8948a273bc6ffbe26fc653fddffe3356c3c8",
       "passes": 1,
       "pr": 15534
     },
     ".agents/tools/ai-assistants/headless-dispatch.md": {
-      "hash": "cabd19d2410df661bc4dc7cd0857d952bc3043f9",
       "at": "2026-04-09T07:32:07Z",
+      "hash": "cabd19d2410df661bc4dc7cd0857d952bc3043f9",
       "passes": 2,
       "pr": 12352
     },
     ".agents/tools/ai-assistants/models-README.md": {
-      "hash": "8baf0827e7ee528c36e909114d5bac261fb4f3e9",
       "at": "2026-04-10T01:33:08Z",
+      "hash": "8baf0827e7ee528c36e909114d5bac261fb4f3e9",
       "passes": 4,
       "pr": 15227
     },
+    ".agents/tools/ai-assistants/models-haiku.md": {
+      "at": "2026-04-04T16:52:41Z",
+      "hash": "e19a01fb3e479ce82ed89c2e0111bc8e72606c09",
+      "passes": 2,
+      "pr": 17218
+    },
+    ".agents/tools/ai-assistants/models-opus.md": {
+      "at": "2026-04-03T20:00:54Z",
+      "hash": "1594303319230800e8af3bdf93a94a6051a6b038",
+      "passes": 1,
+      "pr": 16821
+    },
     ".agents/tools/ai-assistants/models-sonnet.md": {
-      "hash": "c510f62024ae172a790410d75e71d5a744d58384",
       "at": "2026-04-09T07:32:07Z",
+      "hash": "c510f62024ae172a790410d75e71d5a744d58384",
       "passes": 3,
       "pr": 14913
     },
     ".agents/tools/ai-assistants/openclaw.md": {
-      "hash": "46df076f048472198f129c26d8611b0936c4ed2c",
       "at": "2026-03-28T14:15:40Z",
+      "hash": "46df076f048472198f129c26d8611b0936c4ed2c",
       "passes": 1,
       "pr": 11901
     },
     ".agents/tools/ai-assistants/opencode-server.md": {
-      "hash": "7397205dd0d70326f5237b9fecb3c0c5a628a5ea",
       "at": "2026-03-28T03:53:56Z",
+      "hash": "7397205dd0d70326f5237b9fecb3c0c5a628a5ea",
       "passes": 1,
       "pr": 11345
     },
+    ".agents/tools/ai-assistants/overview.md": {
+      "at": "2026-04-03T16:35:51Z",
+      "hash": "d28a6855ea958f0d413f7045829ecf6b2fbb1245",
+      "passes": 1,
+      "pr": 16716
+    },
     ".agents/tools/ai-assistants/response-scoring.md": {
-      "hash": "645cb336ea66f26637bd51fcaf17abda782697db",
       "at": "2026-03-29T15:50:37Z",
+      "hash": "645cb336ea66f26637bd51fcaf17abda782697db",
       "passes": 2,
       "pr": 13072
     },
+    ".agents/tools/ai-assistants/runners-code-reviewer.md": {
+      "at": "2026-04-03T13:35:13Z",
+      "hash": "d959a8122b1527468e242cc74f6d38c001386c72",
+      "passes": 1,
+      "pr": 16583
+    },
     ".agents/tools/ai-assistants/runners-seo-analyst.md": {
-      "hash": "ec1c0aa51df87d61e035fe8c70814805a3ed5e61",
       "at": "2026-04-03T04:23:06Z",
+      "hash": "ec1c0aa51df87d61e035fe8c70814805a3ed5e61",
       "passes": 1,
       "pr": 16010
     },
     ".agents/tools/ai-generation/comfy-cli.md": {
-      "hash": "a48bbc3532e5dd971e6b7946cafde96cf3304d14",
       "at": "2026-03-27T21:25:22Z",
+      "hash": "a48bbc3532e5dd971e6b7946cafde96cf3304d14",
       "passes": 2,
       "pr": 11014
     },
     ".agents/tools/ai-orchestration/autogen.md": {
-      "hash": "27355da3f0f22a7d59a47591700573fe08042c22",
       "at": "2026-03-30T02:54:16Z",
+      "hash": "27355da3f0f22a7d59a47591700573fe08042c22",
       "passes": 1,
       "pr": 13600
     },
     ".agents/tools/ai-orchestration/crewai.md": {
-      "hash": "d3d3072d4024699fbbe9f7882d0373958b6d3931",
       "at": "2026-03-28T02:50:59Z",
+      "hash": "d3d3072d4024699fbbe9f7882d0373958b6d3931",
       "passes": 1,
       "pr": 11274
     },
     ".agents/tools/ai-orchestration/langflow.md": {
-      "hash": "7c76b2a427e338a6bdb8b931c08d4173e55dfbae",
       "at": "2026-03-30T06:49:09Z",
+      "hash": "7c76b2a427e338a6bdb8b931c08d4173e55dfbae",
       "passes": 2,
       "pr": 13930
     },
     ".agents/tools/ai-orchestration/openprose.md": {
-      "hash": "670802c28c4644d8b3363619166ae573c5c57e96",
       "at": "2026-03-29T14:29:04Z",
+      "hash": "670802c28c4644d8b3363619166ae573c5c57e96",
       "passes": 1,
       "pr": 13007
     },
     ".agents/tools/ai-orchestration/overview.md": {
-      "hash": "1ffa494a52d97242498144f487a77d27b622007a",
       "at": "2026-04-03T01:53:08Z",
+      "hash": "1ffa494a52d97242498144f487a77d27b622007a",
       "passes": 2,
       "pr": 11793
     },
     ".agents/tools/ai-orchestration/packaging.md": {
-      "hash": "b528b78fbcdb878e34459c23ed07d309f60c74d6",
       "at": "2026-03-28T03:53:52Z",
+      "hash": "b528b78fbcdb878e34459c23ed07d309f60c74d6",
       "passes": 1,
       "pr": 11296
     },
     ".agents/tools/animation/animejs.md": {
-      "hash": "d988b1d0126acc81871186cf85dac6e8221e6b52",
       "at": "2026-03-29T08:11:02Z",
+      "hash": "d988b1d0126acc81871186cf85dac6e8221e6b52",
       "passes": 1,
       "pr": 12745
     },
     ".agents/tools/api/better-auth.md": {
-      "hash": "ae42f1dfa7232723dd23bfdfeddd7aaf26bc4000",
       "at": "2026-03-28T08:58:32Z",
+      "hash": "ae42f1dfa7232723dd23bfdfeddd7aaf26bc4000",
       "passes": 1,
       "pr": 11566
     },
     ".agents/tools/api/cloudflare-mcp.md": {
-      "hash": "a8dc2d7131ce0a1fd7be7b7589cf31858570aaac",
       "at": "2026-04-13T16:27:43Z",
+      "hash": "a8dc2d7131ce0a1fd7be7b7589cf31858570aaac",
       "passes": 2,
       "pr": 16551
     },
     ".agents/tools/api/drizzle.md": {
-      "hash": "342daceaab3776e1c8104e429663a1f4f224978a",
       "at": "2026-03-30T04:52:00Z",
+      "hash": "342daceaab3776e1c8104e429663a1f4f224978a",
       "passes": 2,
       "pr": 13718
     },
     ".agents/tools/api/hono.md": {
-      "hash": "7bb78c4ecc5900225ea1e046369e48b583f6bb35",
       "at": "2026-03-29T07:02:20Z",
+      "hash": "7bb78c4ecc5900225ea1e046369e48b583f6bb35",
       "passes": 1,
       "pr": 12607
     },
     ".agents/tools/api/vercel-ai-sdk.md": {
-      "hash": "f9deaca26dc7ea2979bf8d8410c338c5d45dfb5f",
       "at": "2026-03-28T11:20:15Z",
+      "hash": "f9deaca26dc7ea2979bf8d8410c338c5d45dfb5f",
       "passes": 1,
       "pr": 11792
     },
     ".agents/tools/architecture/clean-ddd-hexagonal-skill.md": {
-      "hash": "b3640231f92ee8c22e24c89fce09c1ef566c739e",
       "at": "2026-04-03T01:53:26Z",
+      "hash": "b3640231f92ee8c22e24c89fce09c1ef566c739e",
       "passes": 1,
       "pr": 15695
     },
     ".agents/tools/architecture/clean-ddd-hexagonal-skill/cheatsheet.md": {
-      "hash": "0aff7409e32b870ac31fdcf1c43a5486f12d5fb3",
       "at": "2026-03-28T05:10:19Z",
+      "hash": "0aff7409e32b870ac31fdcf1c43a5486f12d5fb3",
       "passes": 1,
       "pr": 11393
     },
     ".agents/tools/architecture/clean-ddd-hexagonal-skill/cqrs-events.md": {
-      "hash": "ce212a1402e90558c412e02dd54859eb37e4db16",
       "at": "2026-03-30T04:51:54Z",
+      "hash": "ce212a1402e90558c412e02dd54859eb37e4db16",
       "passes": 2,
       "pr": 13768
     },
     ".agents/tools/architecture/clean-ddd-hexagonal-skill/ddd-strategic.md": {
-      "hash": "1706368184eba55521667a3f2e3e845e19efe6e4",
       "at": "2026-03-28T11:20:20Z",
+      "hash": "1706368184eba55521667a3f2e3e845e19efe6e4",
       "passes": 1,
       "pr": 11805
     },
     ".agents/tools/architecture/clean-ddd-hexagonal-skill/ddd-tactical.md": {
-      "hash": "1227f41a5aa385a0ae2106c0493d974156ebd694",
       "at": "2026-03-28T11:20:40Z",
+      "hash": "1227f41a5aa385a0ae2106c0493d974156ebd694",
       "passes": 1,
       "pr": 11734
     },
     ".agents/tools/architecture/clean-ddd-hexagonal-skill/hexagonal.md": {
-      "hash": "b8b36575ecc73cce041d4389633636be3b6acb6a",
       "at": "2026-03-30T06:49:15Z",
+      "hash": "b8b36575ecc73cce041d4389633636be3b6acb6a",
       "passes": 2,
       "pr": 13931
     },
     ".agents/tools/architecture/clean-ddd-hexagonal-skill/layers.md": {
-      "hash": "6aaf111524bd845c5a5720997556c8837483d638",
       "at": "2026-03-28T21:58:55Z",
+      "hash": "6aaf111524bd845c5a5720997556c8837483d638",
       "passes": 1,
       "pr": 12236
     },
     ".agents/tools/architecture/clean-ddd-hexagonal-skill/testing.md": {
-      "hash": "df7464ac6a848d34507f008290abcbffa6cd50b0",
       "at": "2026-03-28T13:38:11Z",
+      "hash": "df7464ac6a848d34507f008290abcbffa6cd50b0",
       "passes": 1,
       "pr": 11790
     },
     ".agents/tools/architecture/feature-slicing-skill.md": {
-      "hash": "24a480a29f65a65dc86b71125a3544fbfd9b68c2",
       "at": "2026-03-27T21:25:18Z",
+      "hash": "24a480a29f65a65dc86b71125a3544fbfd9b68c2",
       "passes": 2,
       "pr": 11010
     },
     ".agents/tools/architecture/feature-slicing-skill/cheatsheet.md": {
-      "hash": "2801fb8f7a2dedb07cf0045d3aa6b474c01e3b06",
       "at": "2026-03-27T21:25:23Z",
+      "hash": "2801fb8f7a2dedb07cf0045d3aa6b474c01e3b06",
       "passes": 1,
       "pr": 11018
     },
     ".agents/tools/architecture/feature-slicing-skill/implementation.md": {
-      "hash": "c3c7177c0b01ac610ed7c48736b3803c6d0f5a2d",
       "at": "2026-03-28T20:16:39Z",
+      "hash": "c3c7177c0b01ac610ed7c48736b3803c6d0f5a2d",
       "passes": 1,
       "pr": 12160
     },
     ".agents/tools/architecture/feature-slicing-skill/layers.md": {
-      "hash": "6915c7e84600a9f43d40e1647996a21ef474973d",
       "at": "2026-03-28T08:18:16Z",
+      "hash": "6915c7e84600a9f43d40e1647996a21ef474973d",
       "passes": 1,
       "pr": 11537
     },
     ".agents/tools/architecture/feature-slicing-skill/migration.md": {
-      "hash": "9287b33c7d73c0049c7552d42bcfbb0e406bc90b",
       "at": "2026-03-30T00:32:19Z",
+      "hash": "9287b33c7d73c0049c7552d42bcfbb0e406bc90b",
       "passes": 2,
       "pr": 13466
     },
     ".agents/tools/architecture/feature-slicing-skill/nextjs.md": {
-      "hash": "6cab12565b8e693c09f6b057bc0b532508cade6c",
       "at": "2026-03-28T06:59:34Z",
+      "hash": "6cab12565b8e693c09f6b057bc0b532508cade6c",
       "passes": 1,
       "pr": 11437
     },
     ".agents/tools/architecture/feature-slicing-skill/public-api.md": {
-      "hash": "bd3aa8714f43491e51ca08675071037af4362b8d",
       "at": "2026-03-28T16:40:13Z",
+      "hash": "bd3aa8714f43491e51ca08675071037af4362b8d",
       "passes": 1,
       "pr": 12030
     },
-    ".agents/tools/automation/cron-agent.md": {
-      "hash": "ab3205565f478339b10ddd7f692f244095c28941",
-      "at": "2026-03-28T20:56:11Z",
-      "passes": 1,
-      "pr": 12184
-    },
-    ".agents/tools/automation/mac.md": {
-      "hash": "d83b7d0243755da08de58680b878867cb909f29b",
-      "at": "2026-04-01T20:58:52Z",
-      "passes": 1,
-      "pr": 15253
-    },
-    ".agents/tools/automation/macos-automator.md": {
-      "hash": "2fd0ee55ab51d718fbe297a8789d74048f495480",
-      "at": "2026-03-27T21:25:19Z",
-      "passes": 1,
-      "pr": 11011
-    },
-    ".agents/tools/browser/agent-browser.md": {
-      "hash": "c5032f5b38edf7e914678270da2c80a0369cc56a",
-      "at": "2026-04-03T03:15:28Z",
-      "passes": 1,
-      "pr": 15892
-    },
-    ".agents/tools/browser/anti-detect-browser.md": {
-      "hash": "1adf6b7cc211d6453f91177501ffcc0259791e90",
-      "at": "2026-03-27T21:25:25Z",
-      "passes": 1,
-      "pr": 11017
-    },
-    ".agents/tools/browser/browser-automation.md": {
-      "hash": "a70f670d6d769c208efd9922a653a57ce0d1ce31",
-      "at": "2026-03-30T04:51:56Z",
-      "passes": 2,
-      "pr": 13719
-    },
-    ".agents/tools/browser/browser-benchmark-scripts-01-playwright.md": {
-      "hash": "56d7fd4609a7f87d460e99cf4c53899fb367292e",
-      "at": "2026-04-03T11:54:13Z",
-      "passes": 1,
-      "pr": 16500
-    },
-    ".agents/tools/browser/browser-benchmark-scripts-05-stagehand.md": {
-      "hash": "4ff8a6b67ed3b0237f2cd22486b424de06472ebd",
-      "at": "2026-04-01T12:00:00Z",
-      "passes": 1,
-      "pr": 15176
-    },
-    ".agents/tools/browser/browser-profiles.md": {
-      "hash": "7b038d0c2776b834cf28f1983514c62a77488372",
-      "at": "2026-04-03T12:15:23Z",
-      "passes": 2,
-      "pr": 12501
-    },
-    ".agents/tools/browser/browser-qa.md": {
-      "hash": "c3104e46ab671b2f7948ac29b465ee9c22a1c3ef",
-      "at": "2026-03-28T20:17:06Z",
-      "passes": 1,
-      "pr": 12171
-    },
-    ".agents/tools/browser/browser-use.md": {
-      "hash": "0ca443d3cf09a730b26457d0c2ece044144ce8a0",
-      "at": "2026-03-29T07:03:02Z",
-      "passes": 1,
-      "pr": 12616
-    },
-    ".agents/tools/browser/chrome-devtools.md": {
-      "hash": "05c28f2b318a798e29c7333fb42f3313823bb102",
-      "at": "2026-04-13T16:27:44Z",
-      "passes": 2,
-      "pr": 12310
-    },
-    ".agents/tools/browser/chrome-webstore-release.md": {
-      "hash": "d480d6719f22c2ea6fafefd21e49a99a0f4c6e2f",
-      "at": "2026-03-30T06:49:23Z",
-      "passes": 1,
-      "pr": 13942
-    },
-    ".agents/tools/browser/chromium-debug-use.md": {
-      "hash": "aa9bbc8cba0fa64aee7d94c5f1fa8fd0141ef704",
-      "at": "2026-04-03T11:54:14Z",
-      "passes": 1,
-      "pr": 16473
-    },
-    ".agents/tools/browser/crawl4ai-integration.md": {
-      "hash": "2218327e7d764c22a6c66a55bedb643d78a50597",
-      "at": "2026-04-02T19:17:13Z",
-      "passes": 2,
-      "pr": 15463
-    },
-    ".agents/tools/browser/crawl4ai-resources.md": {
-      "hash": "9e751cfa89e483f3cc52d54438d39dc5796d5f94",
-      "at": "2026-03-28T13:37:22Z",
-      "passes": 1,
-      "pr": 11858
-    },
-    ".agents/tools/browser/crawl4ai-usage.md": {
-      "hash": "0a12dd6983cc36552152e54f6ee4cf27b98c3881",
-      "at": "2026-04-03T01:11:47Z",
-      "passes": 1,
-      "pr": 15802
-    },
-    ".agents/tools/browser/crawl4ai.md": {
-      "hash": "f902bbe5c1df5e39ff391f09c01dce2a10fbc71c",
-      "at": "2026-03-28T08:17:51Z",
-      "passes": 1,
-      "pr": 11599
-    },
-    ".agents/tools/browser/curl-copy.md": {
-      "hash": "6e50a9becdbef4af341c2950c78e788a1b443a3b",
-      "at": "2026-04-01T21:56:13Z",
-      "passes": 2
-    },
-    ".agents/tools/browser/dev-browser.md": {
-      "hash": "ad68e794a7f47eca0fc81085cce62418ddbb5740",
-      "at": "2026-04-03T21:42:06Z",
-      "passes": 3,
-      "pr": 11921
-    },
-    ".agents/tools/browser/extension-dev.md": {
-      "hash": "397ff57e80711c71e67d63a4add48367d6ad2512",
-      "at": "2026-03-29T22:09:34Z",
-      "passes": 1,
-      "pr": 13330
-    },
-    ".agents/tools/browser/extension-dev/development.md": {
-      "hash": "62052fb74fe679e3587757a452c2ab4ced38afd5",
-      "at": "2026-03-30T04:52:04Z",
-      "passes": 1,
-      "pr": 13722
-    },
-    ".agents/tools/browser/extension-dev/publishing.md": {
-      "hash": "513d106e23df5308b941e15086d306aefed729d4",
-      "at": "2026-03-29T11:20:06Z",
-      "passes": 1,
-      "pr": 12884
-    },
-    ".agents/tools/browser/extension-dev/testing.md": {
-      "hash": "373ab0b0f67d5708464721b01409849320abe0ba",
-      "at": "2026-03-30T04:51:57Z",
-      "passes": 1,
-      "pr": 13717
-    },
-    ".agents/tools/browser/fingerprint-profiles.md": {
-      "hash": "e14427c10717d69f04d8e5727002c4758a71b059",
-      "at": "2026-03-28T17:30:27Z",
-      "passes": 1,
-      "pr": 12070
-    },
-    ".agents/tools/browser/pagespeed.md": {
-      "hash": "e98367b4b75ea7698feaddc1a3a4a17a469bceec",
-      "at": "2026-03-28T03:53:49Z",
-      "passes": 1,
-      "pr": 11295
-    },
-    ".agents/tools/browser/peekaboo.md": {
-      "hash": "cc607229908282fe9c9093dc5b76203e4b5ecf2b",
-      "at": "2026-03-28T03:54:17Z",
-      "passes": 1,
-      "pr": 11348
-    },
-    ".agents/tools/browser/playwright-cli.md": {
-      "hash": "40f7f25f8754a6cbe9b43f95e12c378638092c22",
-      "at": "2026-03-28T11:20:22Z",
-      "passes": 1,
-      "pr": 11802
-    },
-    ".agents/tools/browser/playwright-emulation.md": {
-      "hash": "d67caf9cb477e4faf5c60a239a492efa85c12ebb",
-      "at": "2026-04-02T22:44:04Z",
-      "passes": 1,
-      "pr": 15692
-    },
-    ".agents/tools/browser/playwright.md": {
-      "hash": "97668ce72605992d0eb984f910fecae8e4f7d8d9",
-      "at": "2026-04-13T16:27:44Z",
-      "passes": 2,
-      "pr": 16512
-    },
-    ".agents/tools/browser/playwriter.md": {
-      "hash": "f18ea8318e325896fb6a5bd5249f3b87b2da2bf2",
-      "at": "2026-03-29T03:31:38Z",
-      "passes": 1,
-      "pr": 12516
-    },
-    ".agents/tools/browser/proxy-integration.md": {
-      "hash": "fe6e091defe1344cbc9bfed4f6ef699373d028ae",
-      "at": "2026-03-29T15:08:41Z",
-      "passes": 1,
-      "pr": 13032
-    },
-    ".agents/tools/browser/skyvern.md": {
-      "hash": "fc60443927a977239b669a011981ecd7d17e8064",
-      "at": "2026-03-28T17:11:10Z",
-      "passes": 1,
-      "pr": 12055
-    },
-    ".agents/tools/browser/stagehand-examples.md": {
-      "hash": "458715b78cf7cb477a67c523977b47013141dcb5",
-      "at": "2026-03-28T14:15:24Z",
-      "passes": 1,
-      "pr": 11899
-    },
-    ".agents/tools/browser/stagehand-python.md": {
-      "hash": "05ae9d0f7d2962ca19effaa5b02ee3ad9048d8eb",
-      "at": "2026-03-30T02:31:00Z",
-      "passes": 1,
-      "pr": 13486
-    },
-    ".agents/tools/browser/stagehand.md": {
-      "hash": "c0dfc858fe1be14022452a3f5bc162d6bb2140d8",
-      "at": "2026-03-29T03:15:18Z",
-      "passes": 1,
-      "pr": 12513
-    },
-    ".agents/tools/browser/stealth-patches.md": {
-      "hash": "354afd4d24b76c5621ea61d23a8da71e811beeea",
-      "at": "2026-04-03T04:23:06Z",
-      "passes": 1,
-      "pr": 15948
-    },
-    ".agents/tools/browser/sweet-cookie.md": {
-      "hash": "753778b00a581b7c9d4e3275eba8a458dba17419",
-      "at": "2026-03-29T22:09:35Z",
-      "passes": 1,
-      "pr": 13328
-    },
-    ".agents/tools/browser/watercrawl.md": {
-      "hash": "f8675a206f700e545c65016e4b42de578f9cefd8",
-      "at": "2026-03-28T19:15:30Z",
-      "passes": 1,
-      "pr": 12117
-    },
-    ".agents/tools/build-agent/add-skill.md": {
-      "hash": "d9532305ae4da82d51cb56e724e816269a2cc70f",
-      "at": "2026-03-29T01:03:17Z",
-      "passes": 1,
-      "pr": 12376
-    },
-    ".agents/tools/build-agent/agent-testing.md": {
-      "hash": "c6eba87c8204a064a3d05820dbefd5f7643fae3d",
-      "at": "2026-04-03T11:54:02Z",
-      "passes": 2,
-      "pr": 15662
-    },
-    ".agents/tools/build-agent/build-agent.md": {
-      "hash": "fa6700980ed34d1f45246b8862de1587d24d39a7",
-      "at": "2026-04-15T03:00:44Z",
-      "passes": 4,
-      "pr": 12957
-    },
-    ".agents/tools/build-mcp/aidevops-plugin.md": {
-      "hash": "dddbf102af3d7699e1178c83bc7d2d59db416e72",
-      "at": "2026-04-02T14:42:10Z",
-      "passes": 3,
-      "pr": 14775
-    },
-    ".agents/tools/build-mcp/api-wrapper.md": {
-      "hash": "f0f868a60d97dec2f6f7e21fcdfe4821367aa852",
-      "at": "2026-03-28T02:51:01Z",
-      "passes": 1,
-      "pr": 11276
-    },
-    ".agents/tools/build-mcp/api-wrapper/patterns.md": {
-      "hash": "61c725143000dbb9b43f0b3a716a095203b803df",
-      "at": "2026-03-28T02:51:01Z",
-      "passes": 1,
-      "pr": 11276
-    },
-    ".agents/tools/build-mcp/build-mcp.md": {
-      "hash": "873079bdda167247bcb21398a82608b824779a12",
-      "at": "2026-03-28T13:37:27Z",
-      "passes": 1,
-      "pr": 11844
-    },
-    ".agents/tools/build-mcp/deployment.md": {
-      "hash": "4b975e408909bcf0b78773cb3cbfbf8c2a52f70b",
-      "at": "2026-03-28T22:39:22Z",
-      "passes": 1,
-      "pr": 12311
-    },
-    ".agents/tools/build-mcp/server-patterns.md": {
-      "hash": "bfc7c19fae70a1c4cbbd848769ffb0dcaecdda62",
-      "at": "2026-03-28T10:27:33Z",
-      "passes": 1,
-      "pr": 11679
-    },
-    ".agents/tools/build-mcp/transports.md": {
-      "hash": "7a3f2b50284606d40d5a0054f2616eaf28d45fcc",
-      "at": "2026-03-29T01:04:08Z",
-      "passes": 1,
-      "pr": 12394
-    },
-    ".agents/tools/code-review/auditing.md": {
-      "hash": "786995df145bebba3410fe18838234626e07c6d4",
-      "at": "2026-04-02T21:20:13Z",
-      "passes": 2,
-      "pr": 0
-    },
-    ".agents/tools/code-review/best-practices.md": {
-      "hash": "0c29ade476d3841f62cb9533712d681da6ae2595",
-      "at": "2026-03-28T13:38:46Z",
-      "passes": 1,
-      "pr": 11771
-    },
-    ".agents/tools/code-review/codacy.md": {
-      "hash": "01aafc8caf20256e88f011e8a1a051e7357555aa",
-      "at": "2026-03-29T22:09:31Z",
-      "passes": 1,
-      "pr": 13314
-    },
-    ".agents/tools/code-review/code-simplifier.md": {
-      "hash": "48d6c06a8c37b58a88387c2eae0a746a23e2509b",
-      "at": "2026-04-15T03:00:44Z",
-      "passes": 9
-    },
-    ".agents/tools/code-review/code-standards.md": {
-      "hash": "9b1170909ea6121b1f294bd5346d832a06779205",
-      "at": "2026-04-04T03:31:00Z",
-      "passes": 2,
-      "pr": 11944
-    },
-    ".agents/tools/code-review/coderabbit.md": {
-      "hash": "69d1f87e48275fa971a0f6dec502bebe0cc50db6",
-      "at": "2026-03-29T07:02:31Z",
-      "passes": 1,
-      "pr": 12589
-    },
-    ".agents/tools/code-review/management.md": {
-      "hash": "ddb7983369dfdca33cefc3baa63482c6d0f2e4ac",
-      "at": "2026-04-03T11:54:03Z",
-      "passes": 1
-    },
-    ".agents/tools/code-review/qlty.md": {
-      "hash": "1efd73666b9aece920bc691fccdca683ad78e3ac",
-      "at": "2026-03-28T18:36:46Z",
-      "passes": 1,
-      "pr": 12114
-    },
-    ".agents/tools/code-review/runtime-patterns.md": {
-      "hash": "901ab8ff5a2453bd2b806a84df722327e4a6ab2f",
-      "at": "2026-03-28T13:38:47Z",
-      "passes": 1,
-      "pr": 11771
-    },
-    ".agents/tools/code-review/secretlint.md": {
-      "hash": "e4a6d6a16259bb97999ac06cde99bbe904be756e",
-      "at": "2026-03-28T16:00:52Z",
-      "passes": 1,
-      "pr": 11991
-    },
-    ".agents/tools/code-review/security-analysis.md": {
-      "hash": "6240be63597ac67fffdcb5677c62e68a53ba44f0",
-      "at": "2026-03-30T00:32:18Z",
-      "passes": 2,
-      "pr": 13467
-    },
-    ".agents/tools/code-review/security-audit.md": {
-      "hash": "9f9ca79db38da586d60dd90538e05b7b050162be",
-      "at": "2026-03-28T17:11:18Z",
-      "passes": 1,
-      "pr": 12029
-    },
-    ".agents/tools/code-review/skill-scanner.md": {
-      "hash": "578ab9fcc61d69038a6065ff7cac8bc2a648fee5",
-      "at": "2026-04-03T11:54:13Z",
-      "passes": 1,
-      "pr": 16525
-    },
-    ".agents/tools/code-review/snyk.md": {
-      "hash": "d249aca9ad416fd98854134a3c37503413d83850",
-      "at": "2026-03-27T21:25:26Z",
-      "passes": 1,
-      "pr": 11013
-    },
-    ".agents/tools/code-review/tools.md": {
-      "hash": "f1bda83d2e6ee95af187c2c23b7ef25b91937c3f",
-      "at": "2026-04-03T11:54:15Z",
-      "passes": 1,
-      "pr": 16449
-    },
-    ".agents/tools/containers/remote-dispatch.md": {
-      "hash": "792e35ec950c092145e18222d3afd1f77a380eac",
-      "at": "2026-03-30T04:52:23Z",
-      "passes": 2,
-      "pr": 13733
-    },
-    ".agents/tools/context/augment-context-engine.md": {
-      "hash": "2c75ffb734e667ee415180e4bf754800d08a00fe",
-      "at": "2026-03-28T16:40:32Z",
-      "passes": 1,
-      "pr": 12015
-    },
-    ".agents/tools/context/context-builder.md": {
-      "hash": "6f1d7629b3d1df84f79bca62005fcc5e8c5d394a",
-      "at": "2026-03-29T20:54:03Z",
-      "passes": 1,
-      "pr": 13297
-    },
-    ".agents/tools/context/context-guardrails.md": {
-      "hash": "2d4fd932a5b9b6fdeac7c2c8ecc1c40f2e52f103",
-      "at": "2026-03-30T06:49:16Z",
-      "passes": 1,
-      "pr": 13956
-    },
-    ".agents/tools/context/context7.md": {
-      "hash": "edd95da6e383415d7ef6e8b7b0e14dbe6ee90414",
-      "at": "2026-04-13T16:27:46Z",
-      "passes": 2,
-      "pr": 12182
-    },
-    ".agents/tools/context/dspy.md": {
-      "hash": "7f9a09f389697c83217d683b872bd784186f29e6",
-      "at": "2026-03-29T20:53:49Z",
-      "passes": 1,
-      "pr": 13289
-    },
-    ".agents/tools/context/dspyground.md": {
-      "hash": "4aebe68d698c70d88f8e8ac42c653109df99bb73",
-      "at": "2026-04-03T11:54:14Z",
-      "passes": 1,
-      "pr": 16494
-    },
-    ".agents/tools/context/github-search.md": {
-      "hash": "860a4da0e589a63c461aa66f67fa3625fc22ce62",
-      "at": "2026-03-29T16:34:35Z",
-      "passes": 1,
-      "pr": 13106
-    },
-    ".agents/tools/context/mcp-discovery.md": {
-      "hash": "734cc02079eb0568b46be5797268d143006b84ad",
-      "at": "2026-03-28T03:53:59Z",
-      "passes": 1,
-      "pr": 11338
-    },
-    ".agents/tools/context/model-routing.md": {
-      "hash": "3e0983c04ec7097672966a5dbbd11b9e72960a0c",
-      "at": "2026-04-15T03:00:45Z",
-      "passes": 4,
-      "pr": 13255
-    },
-    ".agents/tools/context/openapi-search.md": {
-      "hash": "212dcdecb048f6ca5fb0f7181cfbfc19b13807d6",
-      "at": "2026-04-03T11:54:13Z",
-      "passes": 1,
-      "pr": 16513
-    },
-    ".agents/tools/context/prompt-optimization.md": {
-      "hash": "fbfa0b2016051c28ea3824e220bc0120bf42d0f1",
-      "at": "2026-03-29T08:10:39Z",
-      "passes": 1,
-      "pr": 12749
-    },
-    ".agents/tools/context/rapidfuzz.md": {
-      "hash": "d16b8b5bc318eaa7bbad698ecec8d690a707cd98",
-      "at": "2026-04-03T01:53:12Z",
-      "passes": 3,
-      "pr": 0
-    },
-    ".agents/tools/conversion/mineru.md": {
-      "hash": "75930d518ec83bb6d0c754b0dedd6c37b979bea0",
-      "at": "2026-03-28T16:40:36Z",
-      "passes": 1,
-      "pr": 12012
-    },
-    ".agents/tools/conversion/pandoc.md": {
-      "hash": "d9421beead37a901c86d9bc71e0439d9719b83ab",
-      "at": "2026-03-28T08:17:47Z",
-      "passes": 1,
-      "pr": 11595
-    },
-    ".agents/tools/credentials/api-key-setup.md": {
-      "hash": "e9cf962d2aeca82d03509b87cf40e9ba19e258d3",
-      "at": "2026-03-29T20:53:50Z",
-      "passes": 1,
-      "pr": 13279
-    },
-    ".agents/tools/credentials/bitwarden.md": {
-      "hash": "618c25febf09882ac5a02746ecaf46b787dbeace",
-      "at": "2026-04-02T04:56:56Z",
-      "passes": 1,
-      "pr": 15468
-    },
-    ".agents/tools/credentials/encryption-stack.md": {
-      "hash": "0e132ab131599566cb025d3316b3b69623f0b3f3",
-      "at": "2026-04-03T01:11:47Z",
-      "passes": 1,
-      "pr": 15780
-    },
-    ".agents/tools/credentials/environment-variables.md": {
-      "hash": "12e46584ed8b1b904240cf6af8e8d9760c9cefee",
-      "at": "2026-03-29T08:10:40Z",
-      "passes": 1,
-      "pr": 12751
-    },
-    ".agents/tools/credentials/gocryptfs.md": {
-      "hash": "3ee75226230f5c793309a7ea7f3e41f4d835a5c0",
-      "at": "2026-03-28T11:20:36Z",
-      "passes": 1,
-      "pr": 11730
-    },
-    ".agents/tools/credentials/gopass.md": {
-      "hash": "59ff08b87e1a0ba820fda337b644b514b6cee226",
-      "at": "2026-03-27T21:25:05Z",
-      "passes": 1,
-      "pr": 11021
-    },
-    ".agents/tools/credentials/multi-tenant.md": {
-      "hash": "8ac890ca5a17ff43199605c1535cf9c75dfea959",
-      "at": "2026-03-27T21:25:16Z",
-      "passes": 1,
-      "pr": 11008
-    },
-    ".agents/tools/credentials/psst.md": {
-      "hash": "8eab2c11c431a98847a9928effe9d80b9e4c3d4a",
-      "at": "2026-03-31T06:15:51Z",
-      "passes": 2,
-      "pr": 14687
-    },
-    ".agents/tools/credentials/sops.md": {
-      "hash": "242c935bf4572435bea49c1651349fc42458644a",
-      "at": "2026-03-28T08:58:29Z",
-      "passes": 1,
-      "pr": 11560
-    },
-    ".agents/tools/credentials/vaultwarden.md": {
-      "hash": "b536921e7faf02fe400ba6c678a36bbd7765b725",
-      "at": "2026-03-29T12:36:43Z",
-      "passes": 1,
-      "pr": 12951
-    },
-    ".agents/tools/data-extraction/outscraper.md": {
-      "hash": "a83bf48997b1e46e3a8038fb30fd21e75d28a70e",
-      "at": "2026-03-28T16:41:16Z",
-      "passes": 1,
-      "pr": 12021
-    },
-    ".agents/tools/database/pglite-local-first.md": {
-      "hash": "4f8f1fd157711a0f805aa897d7510fe5c7e833fa",
-      "at": "2026-03-28T15:30:29Z",
-      "passes": 1,
-      "pr": 11920
-    },
-    ".agents/tools/database/vector-search.md": {
-      "hash": "1bdab72f7af2a4287447f77c2b078cd7c0e3d7a0",
-      "at": "2026-03-28T03:54:19Z",
-      "passes": 1,
-      "pr": 11351
-    },
-    ".agents/tools/database/vector-search/per-tenant-rag.md": {
-      "hash": "c6eb07a518cd007412e5e958ffee877911ea34bc",
-      "at": "2026-03-28T06:40:00Z",
-      "passes": 1,
-      "pr": 11417
-    },
-    ".agents/tools/database/vector-search/zvec.md": {
-      "hash": "74a17ede0fa42057c6e982a7cf383fe0ca139022",
-      "at": "2026-03-28T08:17:41Z",
-      "passes": 1,
-      "pr": 11570
-    },
-    ".agents/tools/deployment/agent-skills.md": {
-      "hash": "ec5297839376b1dc877db00180c3ca671de341d8",
-      "at": "2026-04-03T11:54:13Z",
-      "passes": 1,
-      "pr": 16540
-    },
-    ".agents/tools/deployment/cloudron-app-packaging-skill.md": {
-      "hash": "1f64ebaf8c35b127e676cfe1dce1c08af1815168",
-      "at": "2026-04-02T20:39:36Z",
-      "passes": 2,
-      "pr": 14880
-    },
-    ".agents/tools/deployment/cloudron-app-packaging-skill/addons-ref.md": {
-      "hash": "b6b3597fddd766dd20cd018daf7732311dc89bdb",
-      "at": "2026-03-29T10:18:21Z",
-      "passes": 1,
-      "pr": 12844
-    },
-    ".agents/tools/deployment/cloudron-app-packaging-skill/manifest-ref.md": {
-      "hash": "0767ed536252969006d7448901799141cb4c1799",
-      "at": "2026-04-02T00:00:00Z",
-      "passes": 1,
-      "pr": 0
-    },
-    ".agents/tools/deployment/cloudron-app-packaging.md": {
-      "hash": "ee098e42ce7866f6c6c80dd0cf0a9bbd8d3f789d",
-      "at": "2026-03-28T03:54:01Z",
-      "passes": 1,
-      "pr": 11344
-    },
-    ".agents/tools/deployment/cloudron-app-publishing-skill.md": {
-      "hash": "89ac1588620c0c72f3589b63f83cc231bed32c3e",
-      "at": "2026-04-03T04:22:59Z",
-      "passes": 2,
-      "pr": 15497
-    },
-    ".agents/tools/deployment/cloudron-git-reference.md": {
-      "hash": "8858d1a860bcd9c844956e15fd2da3f5e703bacf",
-      "at": "2026-04-03T11:54:14Z",
-      "passes": 1,
-      "pr": 16478
-    },
-    ".agents/tools/deployment/cloudron-server-ops-skill.md": {
-      "hash": "2b286bda289b02298ca6d38aaf97440394e6c99f",
-      "at": "2026-03-30T03:33:52Z",
-      "passes": 2,
-      "pr": 13678
-    },
-    ".agents/tools/deployment/coolify-cli.md": {
-      "hash": "9653a4527f1f3f96d745aef5be254e8419264be1",
-      "at": "2026-03-30T04:52:05Z",
-      "passes": 1,
-      "pr": 13734
-    },
-    ".agents/tools/deployment/coolify-setup.md": {
-      "hash": "8e2e94d8af3faaea2e154da1b521c297f7a4415b",
-      "at": "2026-03-29T15:50:41Z",
-      "passes": 2,
-      "pr": 13067
-    },
-    ".agents/tools/deployment/coolify.md": {
-      "hash": "e87e98b92f8842f559c924b04290b1f76a3ebddb",
-      "at": "2026-03-29T08:10:34Z",
-      "passes": 1,
-      "pr": 12748
-    },
-    ".agents/tools/deployment/daytona.md": {
-      "hash": "d3aeca4a230f561753082a4a9d5943d119c7735a",
-      "at": "2026-03-28T13:37:28Z",
-      "passes": 1,
-      "pr": 11846
-    },
-    ".agents/tools/deployment/fly-io.md": {
-      "hash": "706bc0d44992fe77a378eb081e8dc5bded66eaec",
-      "at": "2026-03-30T02:30:21Z",
-      "passes": 1,
-      "pr": 13596
-    },
-    ".agents/tools/deployment/hosting-comparison.md": {
-      "hash": "5ec33ae6dd9e7bd05662585559f09e44e210fc3c",
-      "at": "2026-03-29T07:02:09Z",
-      "passes": 1,
-      "pr": 12661
-    },
-    ".agents/tools/deployment/uncloud.md": {
-      "hash": "7686567bc178c7e1f996de62a1d8dca5c2dc8765",
-      "at": "2026-03-28T09:17:40Z",
-      "passes": 1,
-      "pr": 11712
-    },
-    ".agents/tools/deployment/vercel.md": {
-      "hash": "2cf1aacf6259cd4f4317ed37ab17304e8def432e",
-      "at": "2026-03-28T08:58:54Z",
-      "passes": 1,
-      "pr": 11615
-    },
-    ".agents/tools/design/brand-identity.md": {
-      "hash": "fd3c844341eee1331678b371b5a8103797924c7e",
-      "at": "2026-04-03T22:25:45Z",
-      "passes": 2,
-      "pr": 13093
-    },
-    ".agents/tools/design/design-inspiration.md": {
-      "hash": "ca5f75dc5368e75e87e0774fb75cf1bf72a1284b",
-      "at": "2026-04-03T22:25:45Z",
-      "passes": 2,
-      "pr": 12754
-    },
-    ".agents/tools/design/ui-ux-inspiration.md": {
-      "hash": "5a3b8bd40244c1e7b1606f0a7cea2409a913a811",
-      "at": "2026-04-03T22:25:45Z",
-      "passes": 2,
-      "pr": 11590
-    },
-    ".agents/tools/diagrams/mermaid-diagrams-skill.md": {
-      "hash": "f80fbd3fe10e749b96a8bca35c699411af73a8d7",
-      "at": "2026-03-28T15:30:35Z",
-      "passes": 1,
-      "pr": 11935
-    },
-    ".agents/tools/diagrams/mermaid-diagrams-skill/advanced.md": {
-      "hash": "8d503a6cd73cf42489b18f7a5664f2b322d8673a",
-      "at": "2026-03-29T11:51:51Z",
-      "passes": 1,
-      "pr": 12922
-    },
-    ".agents/tools/diagrams/mermaid-diagrams-skill/architecture.md": {
-      "hash": "69321b2bc44bba8fe56ee85836144b038b947e40",
-      "at": "2026-03-28T16:00:33Z",
-      "passes": 1,
-      "pr": 11987
-    },
-    ".agents/tools/diagrams/mermaid-diagrams-skill/cheatsheet.md": {
-      "hash": "568e7a49215a4fcd8b2487d7c6455e27e698e343",
-      "at": "2026-03-29T21:43:04Z",
-      "passes": 1,
-      "pr": 13300
-    },
-    ".agents/tools/diagrams/mermaid-diagrams-skill/class-er.md": {
-      "hash": "cac152d5a323a68222a3b72869b48b6ac00a1fd9",
-      "at": "2026-03-28T08:17:42Z",
-      "passes": 1,
-      "pr": 11589
-    },
-    ".agents/tools/diagrams/mermaid-diagrams-skill/data-charts.md": {
-      "hash": "4006f122f01a479c9f18cf811f4518cd84b43bea",
-      "at": "2026-03-28T08:58:03Z",
-      "passes": 1,
-      "pr": 11602
-    },
-    ".agents/tools/diagrams/mermaid-diagrams-skill/flowcharts.md": {
-      "hash": "aa40ff75d4ee501fc82db4dbce013fcf8ccbfe05",
-      "at": "2026-03-30T04:52:39Z",
-      "passes": 1,
-      "pr": 13784
-    },
-    ".agents/tools/diagrams/mermaid-diagrams-skill/sequence.md": {
-      "hash": "321dcb7f9abbc8ebfeec457313dabbd52227f242",
-      "at": "2026-03-28T05:10:17Z",
-      "passes": 1,
-      "pr": 11392
-    },
-    ".agents/tools/diagrams/mermaid-diagrams-skill/state-journey.md": {
-      "hash": "cfd8bd062a27912784b2f79040783472553deafc",
-      "at": "2026-03-29T08:11:29Z",
-      "passes": 1,
-      "pr": 12755
-    },
-    ".agents/tools/document/docstrange.md": {
-      "hash": "356dc36b0eeaae56c2ae1b5ad27e2442f58d8725",
-      "at": "2026-03-29T16:34:31Z",
-      "passes": 1,
-      "pr": 13102
-    },
-    ".agents/tools/document/document-creation.md": {
-      "hash": "53e7dcdaf54df67fbfe51ad5267b549131b964fd",
-      "at": "2026-03-28T08:17:34Z",
-      "passes": 1,
-      "pr": 11592
-    },
-    ".agents/tools/document/document-extraction.md": {
-      "hash": "c9bbb8f8fe6fb0de72fd58043e65e30163a2c14f",
-      "at": "2026-03-28T15:30:30Z",
-      "passes": 1,
-      "pr": 11919
-    },
-    ".agents/tools/document/extraction-schemas.md": {
-      "hash": "77b777bd9e30c46b1e93c7679e60d542c9552d0d",
-      "at": "2026-03-28T08:58:45Z",
-      "passes": 1,
-      "pr": 11601
-    },
-    ".agents/tools/document/extraction-schemas/01-design-principles.md": {
-      "hash": "a3a0d1fd2f30d250bf138d264159971ca3da3c9d",
-      "at": "2026-03-28T08:58:45Z",
-      "passes": 1,
-      "pr": 11601
-    },
-    ".agents/tools/document/extraction-schemas/02-purchase-invoice.md": {
-      "hash": "f68e6908fc7390cf14b98ae52f50753ef4bd46cb",
-      "at": "2026-03-28T08:58:45Z",
-      "passes": 1,
-      "pr": 11601
-    },
-    ".agents/tools/document/extraction-schemas/03-expense-receipt.md": {
-      "hash": "2d72e593cba84bb9a33214078871dea9702ce3ee",
-      "at": "2026-03-28T08:58:45Z",
-      "passes": 1,
-      "pr": 11601
-    },
-    ".agents/tools/document/extraction-schemas/04-credit-note.md": {
-      "hash": "46e215fdc8d4c0c64b74c204784a78c719837800",
-      "at": "2026-03-28T08:58:45Z",
-      "passes": 1,
-      "pr": 11601
-    },
-    ".agents/tools/document/extraction-schemas/05-sales-invoice.md": {
-      "hash": "a0a2a210e6f6e6d0d2ee3bc9573c85032fc7de88",
-      "at": "2026-03-28T08:58:45Z",
-      "passes": 1,
-      "pr": 11601
-    },
-    ".agents/tools/document/extraction-schemas/06-generic-receipt.md": {
-      "hash": "d209d3647c51956a81ec36fd1d22308b84ffe128",
-      "at": "2026-03-28T08:58:45Z",
-      "passes": 1,
-      "pr": 11601
-    },
-    ".agents/tools/document/extraction-schemas/07-quickfile-mapping.md": {
-      "hash": "0431f2b5ad2409dd19415486d9af2710425fae18",
-      "at": "2026-03-28T08:58:45Z",
-      "passes": 1,
-      "pr": 11601
-    },
-    ".agents/tools/document/extraction-schemas/08-vat-handling.md": {
-      "hash": "3b1eee6832b72d5d129d64c516d6d062534b79b9",
-      "at": "2026-03-28T08:58:45Z",
-      "passes": 1,
-      "pr": 11601
-    },
-    ".agents/tools/document/extraction-schemas/09-nominal-codes.md": {
-      "hash": "f891a367d31eaf333fbdfbcf40901718799372c9",
-      "at": "2026-03-28T08:58:45Z",
-      "passes": 1,
-      "pr": 11601
-    },
-    ".agents/tools/document/extraction-schemas/10-classification.md": {
-      "hash": "86b35abc7b402fd23ca0fd1c363fcf52afcbd65f",
-      "at": "2026-03-28T08:58:45Z",
-      "passes": 1,
-      "pr": 11601
-    },
-    ".agents/tools/document/extraction-schemas/11-pipeline-integration.md": {
-      "hash": "8f2f4de0c38926814a5e82f04d4edacbcd655c8f",
-      "at": "2026-03-28T08:58:45Z",
-      "passes": 1,
-      "pr": 11601
-    },
-    ".agents/tools/document/extraction-schemas/12-validation.md": {
-      "hash": "2b3e56e1b3869978279bf8ac954c875d4deae23d",
-      "at": "2026-03-28T08:58:45Z",
-      "passes": 1,
-      "pr": 11601
-    },
-    ".agents/tools/document/extraction-workflow.md": {
-      "hash": "1712dd51c2ac3747cbf0e90327bc627e9975427f",
-      "at": "2026-04-01T23:23:22Z",
-      "passes": 1,
-      "pr": 15350
-    },
-    ".agents/tools/git.md": {
-      "hash": "a293bc257df92a1e036c854b84028070cb062741",
-      "at": "2026-04-03T11:54:15Z",
-      "passes": 1,
-      "pr": 16428
-    },
-    ".agents/tools/git/authentication.md": {
-      "hash": "87e4955172cb561376c873c51045ef8a3b98b502",
-      "at": "2026-03-30T02:30:25Z",
-      "passes": 1,
-      "pr": 13538
-    },
-    ".agents/tools/git/conflict-resolution.md": {
-      "hash": "78a3f531ef115f702a0833bd3eb6c28db9e2bd80",
-      "at": "2026-03-28T14:15:35Z",
-      "passes": 1,
-      "pr": 11909
-    },
-    ".agents/tools/git/git-security.md": {
-      "hash": "ebf3356f9a187064ca7cba0c5e0270bb25190fb0",
-      "at": "2026-04-03T11:54:15Z",
-      "passes": 1,
-      "pr": 16442
-    },
-    ".agents/tools/git/gitea-cli.md": {
-      "hash": "b680d568b76c2dfbd45fb2f5c6bfd96338e87464",
-      "at": "2026-03-29T07:02:58Z",
-      "passes": 1,
-      "pr": 12618
-    },
-    ".agents/tools/git/github-actions.md": {
-      "hash": "094b1d3e1fb0638c2affb4c2fbaeb66822d80a8c",
-      "at": "2026-04-13T16:27:52Z",
-      "passes": 2,
-      "pr": 16558
-    },
-    ".agents/tools/git/github-cli.md": {
-      "hash": "754748cc0ca046b171831582ec5f7f2fdf14a9bd",
-      "at": "2026-04-03T11:54:14Z",
-      "passes": 1,
-      "pr": 16499
-    },
-    ".agents/tools/git/gitlab-cli.md": {
-      "hash": "bf41a9566d8aeaa20a15165b3202206c779785ba",
-      "at": "2026-03-29T03:15:01Z",
-      "passes": 1,
-      "pr": 12498
-    },
-    ".agents/tools/git/jujutsu.md": {
-      "hash": "3423735a65d6834f352f94036e55ab92a12cbab5",
-      "at": "2026-04-03T12:15:32Z",
-      "passes": 1,
-      "pr": 16553
-    },
-    ".agents/tools/git/lumen.md": {
-      "hash": "0b7664a56ac46dcc62198dff1578abab24bd1b07",
-      "at": "2026-04-01T23:23:19Z",
-      "passes": 1,
-      "pr": 15327
-    },
-    ".agents/tools/git/opencode-github-security.md": {
-      "hash": "433293616dc956ef4fec53349c3f5c94b4318746",
-      "at": "2026-03-28T22:39:20Z",
-      "passes": 1,
-      "pr": 12309
-    },
-    ".agents/tools/git/opencode-github.md": {
-      "hash": "064220aa37037434a1a4d977c034401ca840cabe",
-      "at": "2026-03-28T03:54:27Z",
-      "passes": 1,
-      "pr": 11349
-    },
-    ".agents/tools/git/opencode-gitlab.md": {
-      "hash": "2da12edc7a2cf6301d8a4a221729427a757dead4",
-      "at": "2026-03-29T20:54:06Z",
-      "passes": 1,
-      "pr": 13295
-    },
-    ".agents/tools/git/worktrunk.md": {
-      "hash": "9c7625f2eb39def77a28308703f7f5259d97c49a",
-      "at": "2026-03-28T10:27:11Z",
-      "passes": 1,
-      "pr": 11760
-    },
-    ".agents/tools/infrastructure/cloud-gpu.md": {
-      "hash": "1109c625814843b489309ff6178c4ab66bde2971",
-      "at": "2026-03-29T21:43:22Z",
-      "passes": 1,
-      "pr": 13346
-    },
-    ".agents/tools/infrastructure/cloudflare-ai.md": {
-      "hash": "e9c0fcec44422a0d14b251e61906c9ad5ae745c7",
-      "at": "2026-04-01T20:50:00Z",
-      "passes": 2,
-      "pr": 15091
-    },
-    ".agents/tools/infrastructure/fireworks.md": {
-      "hash": "b7bb09d0ec09ef4e07a5e922f902bd3ce641bffe",
-      "at": "2026-03-28T11:52:26Z",
-      "passes": 1,
-      "pr": 11813
-    },
-    ".agents/tools/infrastructure/nearai.md": {
-      "hash": "a65b3460482fc02b4a5e0d440590bc14293371c5",
-      "at": "2026-03-29T10:47:24Z",
-      "passes": 1,
-      "pr": 12869
-    },
-    ".agents/tools/infrastructure/nvidia-cloud.md": {
-      "hash": "92d1dae09af45e0d44074130c1d122bd6f4cfcb6",
-      "at": "2026-03-29T08:49:20Z",
-      "passes": 1,
-      "pr": 12776
-    },
-    ".agents/tools/infrastructure/together.md": {
-      "hash": "dbec4e9bd18b8affb94573477a97f94053bd9c40",
-      "at": "2026-03-29T17:15:24Z",
-      "passes": 1,
-      "pr": 13113
-    },
-    ".agents/tools/local-models/huggingface.md": {
-      "hash": "0a5d1f688f414c7ad20dce124a66b9a45bbda39d",
-      "at": "2026-04-03T11:54:14Z",
-      "passes": 1,
-      "pr": 16479
-    },
-    ".agents/tools/local-models/local-models.md": {
-      "hash": "40e9aa225567860343520e0004099aa451d3f1c1",
-      "at": "2026-04-03T21:42:12Z",
-      "passes": 2,
-      "pr": 12758
-    },
-    ".agents/tools/mcp-toolkit/mcporter.md": {
-      "hash": "302f204927b866cd10328ef0e14410a64c56dcbb",
-      "at": "2026-03-28T14:16:17Z",
-      "passes": 1,
-      "pr": 11906
-    },
-    ".agents/tools/mcp/cloudflare-code-mode.md": {
-      "hash": "ae50d4c729eab4eea5b4f4f50e930b9c4be78108",
-      "at": "2026-03-29T23:54:08Z",
-      "passes": 1,
-      "pr": 13428
-    },
-    ".agents/tools/mobile/agent-device.md": {
-      "hash": "80d8f534052cc4a569f014277d60a7c7d37d5163",
-      "at": "2026-03-29T08:49:16Z",
-      "passes": 1,
-      "pr": 12788
-    },
-    ".agents/tools/mobile/app-dev-assets.md": {
-      "hash": "8f76e90204fd0b7026215b94a921c93725ccb49a",
-      "at": "2026-03-29T16:34:32Z",
-      "passes": 1,
-      "pr": 13108
-    },
-    ".agents/tools/mobile/app-dev-backend.md": {
-      "hash": "5f71ae0bae38bd26b8c8c17334f67f94f5519118",
-      "at": "2026-03-29T20:54:10Z",
-      "passes": 1,
-      "pr": 13293
-    },
-    ".agents/tools/mobile/app-dev-expo.md": {
-      "hash": "88b9790e15b5b59fde8864acf694675a04ea868b",
-      "at": "2026-03-30T03:34:14Z",
-      "passes": 1,
-      "pr": 13609
-    },
-    ".agents/tools/mobile/app-dev-notifications.md": {
-      "hash": "91e194cf38a56b23b49c55c4a35aa4bd298301c5",
-      "at": "2026-03-29T16:34:38Z",
-      "passes": 1,
-      "pr": 13111
-    },
-    ".agents/tools/mobile/app-dev-publishing.md": {
-      "hash": "7e85e545bfde087a1ad9aeb7535bd1df9f04b2f6",
-      "at": "2026-03-29T08:11:31Z",
-      "passes": 2,
-      "pr": 12760
-    },
-    ".agents/tools/mobile/app-dev-swift.md": {
-      "hash": "d3b5663bc33b6383bc1ed7bcefe4a08f28f7f601",
-      "at": "2026-03-29T07:03:03Z",
-      "passes": 1,
-      "pr": 12506
-    },
-    ".agents/tools/mobile/app-dev-testing.md": {
-      "hash": "f552829f8040483a2661eceff47f7ae2b5340a1b",
-      "at": "2026-04-01T20:59:09Z",
-      "passes": 1,
-      "pr": 15219
-    },
-    ".agents/tools/mobile/app-dev.md": {
-      "hash": "7e95c86a1ff47fc03e63be9444379acd7960229f",
-      "at": "2026-03-29T08:10:35Z",
-      "passes": 1,
-      "pr": 12752
-    },
-    ".agents/tools/mobile/app-store-connect.md": {
-      "hash": "39b15510cf46404a8656dc67ec4a66404245258c",
-      "at": "2026-03-29T07:02:17Z",
-      "passes": 1,
-      "pr": 12625
-    },
-    ".agents/tools/mobile/ios-simulator-mcp.md": {
-      "hash": "33fdb9ed9ce6eb6d817e314a40872de61de2681b",
-      "at": "2026-03-29T20:53:56Z",
-      "passes": 1,
-      "pr": 13299
-    },
-    ".agents/tools/mobile/maestro.md": {
-      "hash": "dc5dbec1ecee73a26cd076ffa2891af198e623c6",
-      "at": "2026-03-30T03:34:20Z",
-      "passes": 1,
-      "pr": 13525
-    },
-    ".agents/tools/mobile/minisim.md": {
-      "hash": "d208b0be4c1a2b820cd1956c0ddfc52cd981d64f",
-      "at": "2026-03-29T21:43:16Z",
-      "passes": 1,
-      "pr": 13340
-    },
-    ".agents/tools/mobile/xcodebuild-mcp.md": {
-      "hash": "2edbe988a06f60f5a4d742cc9837530d70e5a815",
-      "at": "2026-04-03T11:54:13Z",
-      "passes": 1,
-      "pr": 16539
-    },
-    ".agents/tools/monorepo/turborepo.md": {
-      "hash": "cfe5067e6064e097d19bd7538172ac0201c72b65",
-      "at": "2026-03-30T06:49:45Z",
-      "passes": 2,
-      "pr": 13795
-    },
-    ".agents/tools/ocr/glm-ocr.md": {
-      "hash": "39abe93658ecd1376746e7397818f841e8d5bd7b",
-      "at": "2026-04-03T12:15:32Z",
-      "passes": 1,
-      "pr": 16554
-    },
-    ".agents/tools/ocr/ocr-research.md": {
-      "hash": "17f55fa81ce7e4925886667b0579540dd77b40cf",
-      "at": "2026-03-28T13:37:30Z",
-      "passes": 1,
-      "pr": 11857
-    },
-    ".agents/tools/ocr/paddleocr.md": {
-      "hash": "e645b46e9c78fc416a8a4b71becd8d082188afc7",
-      "at": "2026-03-30T06:49:51Z",
-      "passes": 1,
-      "pr": 13765
-    },
-    ".agents/tools/opencode/opencode-anthropic-auth.md": {
-      "hash": "4e8c39e779a42ac6cf7b6726bd6fe78313534e51",
-      "at": "2026-03-29T03:15:28Z",
-      "passes": 1,
-      "pr": 12522
-    },
-    ".agents/tools/opencode/opencode.md": {
-      "hash": "696fc30d6e79a81dbc4c654ef71a347506c9b5a7",
-      "at": "2026-03-29T11:20:16Z",
-      "passes": 1,
-      "pr": 12843
-    },
-    ".agents/tools/pdf/libpdf.md": {
-      "hash": "df32e4457c96dc0a0e30f99129e8f690a122a2c4",
-      "at": "2026-03-28T20:16:42Z",
-      "passes": 1,
-      "pr": 12161
-    },
-    ".agents/tools/performance/performance.md": {
-      "hash": "bf97d384c4870c4bd126c114e1a4b7dafe0cf881",
-      "at": "2026-03-28T16:00:21Z",
-      "passes": 1,
-      "pr": 11983
-    },
-    ".agents/tools/performance/webpagetest.md": {
-      "hash": "90e0b779107ce16e7186685c87c0391b88b137ef",
-      "at": "2026-03-28T08:17:50Z",
-      "passes": 1,
-      "pr": 11594
-    },
-    ".agents/tools/productivity/notes.md": {
-      "hash": "0fcae0745258f4d6e4f3d9420f33b39d1eab9112",
-      "at": "2026-04-03T12:15:32Z",
-      "passes": 1,
-      "pr": 16552
-    },
-    ".agents/tools/programming/modern-javascript-skill.md": {
-      "hash": "47b55328e048c60d654647f946df59c3836e5fa1",
-      "at": "2026-04-01T20:59:25Z",
-      "passes": 1,
-      "pr": 15131
-    },
-    ".agents/tools/programming/modern-javascript-skill/01-decision-trees.md": {
-      "hash": "241f4a3b8466d306e07aa80178d184e9dfb89813",
-      "at": "2026-04-01T20:59:25Z",
-      "passes": 1,
-      "pr": 15131
-    },
-    ".agents/tools/programming/modern-javascript-skill/02-es-versions.md": {
-      "hash": "4c8efb98765918aeb91c6c27468322860f85ebdf",
-      "at": "2026-04-01T20:59:25Z",
-      "passes": 1,
-      "pr": 15131
-    },
-    ".agents/tools/programming/modern-javascript-skill/cheatsheet.md": {
-      "hash": "b159f4fa6de09be8185323ca9d0f05c14a9a012d",
-      "at": "2026-03-28T16:40:20Z",
-      "passes": 1,
-      "pr": 12042
-    },
-    ".agents/tools/programming/modern-javascript-skill/composition.md": {
-      "hash": "b46fc38d6db3ad25a0f493a62c9db380f0af72ea",
-      "at": "2026-03-28T03:53:07Z",
-      "passes": 1,
-      "pr": 11328
-    },
-    ".agents/tools/programming/modern-javascript-skill/concurrency.md": {
-      "hash": "896412638b06c7e34f990bb930129a819979db56",
-      "at": "2026-03-29T22:50:16Z",
-      "passes": 2,
-      "pr": 13349
-    },
-    ".agents/tools/programming/modern-javascript-skill/es2016-es2017.md": {
-      "hash": "77b181e2b0e95ddde4d4d1a01d1e176066b30306",
-      "at": "2026-04-03T01:11:46Z",
-      "passes": 1,
-      "pr": 15969
-    },
-    ".agents/tools/programming/modern-javascript-skill/es2018-es2019.md": {
-      "hash": "ac1032b10ca7a6d010e5c0075774e7679edbe2ec",
-      "at": "2026-03-28T05:50:55Z",
-      "passes": 1,
-      "pr": 11439
-    },
-    ".agents/tools/programming/modern-javascript-skill/es2022-es2023.md": {
-      "hash": "608d6037a22cbc948bb9fe7739be906b2786fb03",
-      "at": "2026-03-28T03:53:13Z",
-      "passes": 1,
-      "pr": 11337
-    },
-    ".agents/tools/programming/modern-javascript-skill/es2024.md": {
-      "hash": "7013a082c06d9066d8f79a83bbb8e8aa29829b27",
-      "at": "2026-03-27T21:25:08Z",
-      "passes": 1,
-      "pr": 11002
-    },
-    ".agents/tools/programming/modern-javascript-skill/es2025.md": {
-      "hash": "ce555c928cfb853d3497544a6bc730c6da40fcbc",
-      "at": "2026-03-28T21:58:57Z",
-      "passes": 1,
-      "pr": 12234
-    },
-    ".agents/tools/programming/modern-javascript-skill/immutability.md": {
-      "hash": "5b23af121a1ea49028004359340334bc9b8a6105",
-      "at": "2026-04-03T11:54:14Z",
-      "passes": 1,
-      "pr": 16493
-    },
-    ".agents/tools/programming/modern-javascript-skill/upcoming.md": {
-      "hash": "ee06c980e465703b5763d6f3e04456ec44b8755a",
-      "at": "2026-03-29T07:02:28Z",
-      "passes": 1,
-      "pr": 12584
-    },
-    ".agents/tools/research/providers/crft-lookup.md": {
-      "hash": "9f5ee39030396bec4256a2eb2db92fdd603107bd",
-      "at": "2026-03-30T03:34:28Z",
-      "passes": 1,
-      "pr": 13542
-    },
-    ".agents/tools/research/providers/openexplorer.md": {
-      "hash": "d7f1854232803e4216f38d611ade45b7014b2415",
-      "at": "2026-04-03T01:53:17Z",
-      "passes": 2,
-      "pr": 15822
-    },
-    ".agents/tools/research/providers/unbuilt.md": {
-      "hash": "07ac398ca7f3b49945420b8fe81b3d30902a09d9",
-      "at": "2026-03-29T12:36:25Z",
-      "passes": 1,
-      "pr": 12945
-    },
-    ".agents/tools/research/providers/wappalyzer.md": {
-      "hash": "a28977b2b192caa441b52416400d08a51f188a6a",
-      "at": "2026-03-28T20:17:04Z",
-      "passes": 1,
-      "pr": 12115
-    },
-    ".agents/tools/research/tech-stack-lookup.md": {
-      "hash": "ddb13dc4cc1476d6756b10b07641e96dc1d3a6f8",
-      "at": "2026-03-29T07:02:42Z",
-      "passes": 1,
-      "pr": 12579
-    },
-    ".agents/tools/security/cdn-origin-ip.md": {
-      "hash": "eebbe1d1794c065ac7d266ac98e78e5faccb85de",
-      "at": "2026-03-29T20:53:57Z",
-      "passes": 1,
-      "pr": 13290
-    },
-    ".agents/tools/security/ip-reputation.md": {
-      "hash": "23d8e2625cd6d45b1802fb546022825e885a79e5",
-      "at": "2026-03-28T03:54:03Z",
-      "passes": 1,
-      "pr": 11342
-    },
-    ".agents/tools/security/opsec.md": {
-      "hash": "b0ef81cdddb719b70c07c0fc5c16d74dc7557243",
-      "at": "2026-03-29T03:15:14Z",
-      "passes": 1,
-      "pr": 12507
-    },
-    ".agents/tools/security/privacy-filter.md": {
-      "hash": "79159cf02baf9a0d43e8bb9626c762e100880c87",
-      "at": "2026-03-28T16:41:02Z",
-      "passes": 1,
-      "pr": 12014
-    },
-    ".agents/tools/security/prompt-injection-defender.md": {
-      "hash": "a185d5fcfb43a0b03c383cdb790991b4e4171bce",
-      "at": "2026-03-28T17:11:06Z",
-      "passes": 1,
-      "pr": 12057
-    },
-    ".agents/tools/security/shannon.md": {
-      "hash": "8380ca95494e14863da36405e461ea018879f0ab",
-      "at": "2026-03-28T16:41:03Z",
-      "passes": 1,
-      "pr": 12016
-    },
-    ".agents/tools/security/tamper-evident-audit.md": {
-      "hash": "29868770e5c148bbbc70a6262085dccfa2a7e4fa",
-      "at": "2026-03-29T21:43:17Z",
-      "passes": 1,
-      "pr": 13316
-    },
-    ".agents/tools/security/tirith.md": {
-      "hash": "0e5a61217d3b30eac5bdf6f41d05d81970e5dcf3",
-      "at": "2026-04-03T04:23:07Z",
-      "passes": 1,
-      "pr": 15777
-    },
-    ".agents/tools/task-management/beads.md": {
-      "hash": "31711547e5dfdff7c67c16eeda61a862e616759f",
-      "at": "2026-03-29T09:39:21Z",
-      "passes": 1,
-      "pr": 12830
-    },
-    ".agents/tools/terminal/terminal-optimization.md": {
-      "hash": "1d87a2f26445285a961b77051d6dcb6b55492d2c",
-      "at": "2026-03-29T03:15:29Z",
-      "passes": 1,
-      "pr": 12526
-    },
-    ".agents/tools/terminal/terminal-title.md": {
-      "hash": "ad3e1b06bf9ac74cf8c72a538adcfc5c3f2cea4f",
-      "at": "2026-04-03T01:11:48Z",
-      "passes": 1,
-      "pr": 15726
-    },
-    ".agents/tools/ui/ai-chat-sidebar.md": {
-      "hash": "0cf217206160855614dabf37336b3e28a8a06b08",
-      "at": "2026-04-02T15:28:13Z",
-      "passes": 3,
-      "pr": 13958
-    },
-    ".agents/tools/ui/frontend-debugging.md": {
-      "hash": "a6d23658a56048f995610f91ce49c03f0e5cccf9",
-      "at": "2026-03-28T03:54:06Z",
-      "passes": 1,
-      "pr": 11340
-    },
-    ".agents/tools/ui/i18next.md": {
-      "hash": "8608931754506274f61d74ebd5803aae0cc20e16",
-      "at": "2026-03-28T10:27:25Z",
-      "passes": 1,
-      "pr": 11710
-    },
-    ".agents/tools/ui/nextjs-layouts.md": {
-      "hash": "c88cf42ea60d680edf13302ecb87e549a2cadd93",
-      "at": "2026-03-28T11:20:37Z",
-      "passes": 1,
-      "pr": 11732
-    },
-    ".agents/tools/ui/nothing-design-skill.md": {
-      "hash": "6fb72c3e38d18425604475b434c2c66a57481e5e",
-      "at": "2026-04-03T22:25:52Z",
-      "passes": 2,
-      "pr": 15566
-    },
-    ".agents/tools/ui/nothing-design-skill/01-philosophy.md": {
-      "hash": "92d9534084a0bedcee771becb6216b9e392920fd",
-      "at": "2026-04-02T13:10:58Z",
-      "passes": 1,
-      "pr": 15566
-    },
-    ".agents/tools/ui/nothing-design-skill/02-craft-rules.md": {
-      "hash": "950df66a0b8636e3de10aa7f0dc4b8840f5b3bba",
-      "at": "2026-04-02T13:10:58Z",
-      "passes": 1,
-      "pr": 15566
-    },
-    ".agents/tools/ui/nothing-design-skill/03-anti-patterns.md": {
-      "hash": "e4e29fac7359f13548074a9ba85ed9f93c968e21",
-      "at": "2026-04-02T13:10:58Z",
-      "passes": 1,
-      "pr": 15566
-    },
-    ".agents/tools/ui/nothing-design-skill/04-workflow.md": {
-      "hash": "3d2d94a8a4cdf5037c03348f2f207bc4db2f2da5",
-      "at": "2026-04-02T13:10:58Z",
-      "passes": 1,
-      "pr": 15566
-    },
-    ".agents/tools/ui/nothing-design-skill/components.md": {
-      "hash": "f9bd742a9999b599e25ab3485f29e113cea87cc4",
-      "at": "2026-04-03T03:15:24Z",
-      "passes": 1
-    },
-    ".agents/tools/ui/nothing-design-skill/tokens.md": {
-      "hash": "a7e497864d35b71b11bc7edc1e8a745e558aa7d8",
-      "at": "2026-04-03T12:15:29Z",
-      "passes": 4,
-      "pr": 16561
-    },
-    ".agents/tools/ui/react-context.md": {
-      "hash": "936299600e06ee59b65ffc61205f3134e1826fa9",
-      "at": "2026-03-30T06:49:50Z",
-      "passes": 1,
-      "pr": 13766
-    },
-    ".agents/tools/ui/react-email.md": {
-      "hash": "618f641bce738c3da28d99bdc78f80b807a565f7",
-      "at": "2026-03-29T07:02:59Z",
-      "passes": 1,
-      "pr": 12619
-    },
-    ".agents/tools/ui/shadcn.md": {
-      "hash": "c660b4e8b133c31ecc094440e8ea6934613d5ecc",
-      "at": "2026-04-13T16:27:56Z",
-      "passes": 2,
-      "pr": 12590
-    },
-    ".agents/tools/ui/tailwind-css.md": {
-      "hash": "3258af59be822e141f3fd64a3790e77b12af82ab",
-      "at": "2026-03-29T07:02:43Z",
-      "passes": 1,
-      "pr": 12576
-    },
-    ".agents/tools/ui/wxt.md": {
-      "hash": "6b2ef27f2ab2380af002ec8e111519683fb5d70e",
-      "at": "2026-03-28T13:37:50Z",
-      "passes": 1,
-      "pr": 11870
-    },
-    ".agents/tools/verification/parallel-verify.md": {
-      "hash": "c2b049c2ad6b6d75c1b5e2e0c113f922504f3aec",
-      "at": "2026-03-29T10:19:07Z",
-      "passes": 1,
-      "pr": 12849
-    },
-    ".agents/tools/video/remotion-3d.md": {
-      "hash": "69bbc032fa20923b0526133ce8bccb63592bd16f",
-      "at": "2026-04-01T20:59:48Z",
-      "passes": 1,
-      "pr": 14897
-    },
-    ".agents/tools/video/remotion-audio.md": {
-      "hash": "a96f93cceea0be4a6279296651b339612a04a429",
-      "at": "2026-03-29T12:37:07Z",
-      "passes": 1,
-      "pr": 12942
-    },
-    ".agents/tools/video/remotion-calculate-metadata.md": {
-      "hash": "559372573df68d1471de5ff59427e92da89e507c",
-      "at": "2026-04-03T03:37:02Z",
-      "passes": 1,
-      "pr": 16141
-    },
-    ".agents/tools/video/remotion-compositions.md": {
-      "hash": "245f9ae2d7a3c862020c55d3953efeaebe654cba",
-      "at": "2026-03-29T23:18:01Z",
-      "passes": 1,
-      "pr": 13427
-    },
-    ".agents/tools/video/remotion-display-captions.md": {
-      "hash": "30dfd1f7f74f06a5fabeb31738215d6664495db1",
-      "at": "2026-04-03T11:54:14Z",
-      "passes": 1,
-      "pr": 16476
-    },
-    ".agents/tools/video/remotion-extract-frames.md": {
-      "hash": "6eba160e3ad199ce14c43c2c660566e6231f6b77",
-      "at": "2026-04-03T03:15:28Z",
-      "passes": 1,
-      "pr": 15907
-    },
-    ".agents/tools/video/remotion-fonts.md": {
-      "hash": "8d38c741d9b22c3ee0ff8682974dafde8e34330d",
-      "at": "2026-04-02T14:42:45Z",
-      "passes": 1,
-      "pr": 15615
-    },
-    ".agents/tools/video/remotion-gifs.md": {
-      "hash": "9e7bbe6e88a22b26d83f1ccd0a44ab0d97e9d88c",
-      "at": "2026-03-29T22:09:13Z",
-      "passes": 1,
-      "pr": 13322
-    },
-    ".agents/tools/video/remotion-images.md": {
-      "hash": "578ef1f246353a9f9ae8a39d8cde58595c64f8c0",
-      "at": "2026-03-30T03:34:15Z",
-      "passes": 1,
-      "pr": 13527
-    },
-    ".agents/tools/video/remotion-import-srt-captions.md": {
-      "hash": "606680df401fd919db10f04405b81f470ad1446b",
-      "at": "2026-04-02T04:56:51Z",
-      "passes": 1,
-      "pr": 15490
-    },
-    ".agents/tools/video/remotion-lottie.md": {
-      "hash": "11ee56fb503d2334f3cf622177037e1370fbe09c",
-      "at": "2026-04-02T04:56:53Z",
-      "passes": 1,
-      "pr": 15525
-    },
-    ".agents/tools/video/remotion-measuring-text.md": {
-      "hash": "6dfb73e67655a15396a73674bf1a1b5388ca5116",
-      "at": "2026-03-29T21:43:06Z",
-      "passes": 1,
-      "pr": 13315
-    },
-    ".agents/tools/video/remotion-sequencing.md": {
-      "hash": "23470ff9e1f0c3f6764d1517bcb0dafe4042b300",
-      "at": "2026-04-02T21:58:20Z",
-      "passes": 1,
-      "pr": 15533
-    },
-    ".agents/tools/video/remotion-timing.md": {
-      "hash": "bc2abb8553753b3391da3c11a404c3adacbdadea",
-      "at": "2026-04-01T20:59:53Z",
-      "passes": 1,
-      "pr": 14881
-    },
-    ".agents/tools/video/remotion-transitions.md": {
-      "hash": "48bc0dec968b15216a1b065cb874f447e7f4137b",
-      "at": "2026-04-02T20:04:38Z",
-      "passes": 2,
-      "pr": 14883
-    },
-    ".agents/tools/video/remotion-videos.md": {
-      "hash": "c9316942e8d0e8d5b3cec51ef8dfd7344c07aa65",
-      "at": "2026-04-03T01:53:23Z",
-      "passes": 1,
-      "pr": 15852
-    },
-    ".agents/tools/video/remotion.md": {
-      "hash": "db4fcbfea61d62e978c485196a05fb5e74a8001b",
-      "at": "2026-03-28T15:30:25Z",
-      "passes": 1,
-      "pr": 11961
-    },
-    ".agents/tools/video/video-prompt-design.md": {
-      "hash": "458ca99814ee1870364630490b09c589ee92b9af",
-      "at": "2026-03-28T17:30:25Z",
-      "passes": 1,
-      "pr": 12071
-    },
-    ".agents/tools/video/yt-dlp.md": {
-      "hash": "4d389eb0516525018dbfd3037cc7038c8d651d51",
-      "at": "2026-03-28T11:20:27Z",
-      "passes": 1,
-      "pr": 11752
-    },
-    ".agents/tools/vision/image-editing.md": {
-      "hash": "b8279ff67535093f7f5d04a0c4df6a57a5936437",
-      "at": "2026-03-29T21:43:18Z",
-      "passes": 1,
-      "pr": 13236
-    },
-    ".agents/tools/vision/image-generation.md": {
-      "hash": "dc2750c7486e0b13d7163564fddd132dc416c9cd",
-      "at": "2026-03-29T19:51:31Z",
-      "passes": 1,
-      "pr": 13249
-    },
-    ".agents/tools/vision/image-understanding.md": {
-      "hash": "8aa3bede872ab8ae73db072bcd02cd723d3feaae",
-      "at": "2026-03-29T23:53:56Z",
-      "passes": 1,
-      "pr": 13458
-    },
-    ".agents/tools/vision/overview.md": {
-      "hash": "e81b419a1b0d6ec94e7fc6ce1646e6a010eb0c15",
-      "at": "2026-04-01T20:59:38Z",
-      "passes": 1,
-      "pr": 14932
-    },
-    ".agents/tools/voice/cloud-tts-apis.md": {
-      "hash": "ff89512f470bdac79cfdfb0ad809060890f4d6f6",
-      "at": "2026-03-28T08:18:23Z",
-      "passes": 1,
-      "pr": 11637
-    },
-    ".agents/tools/voice/cloud-voice-agents.md": {
-      "hash": "e175ad6af6ffb8f158ef7b30c87c58a3d7bbd49a",
-      "at": "2026-03-28T16:40:25Z",
-      "passes": 1,
-      "pr": 12005
-    },
-    ".agents/tools/voice/hyprwhspr.md": {
-      "hash": "7bd3dc0581791068ee8bf6d8d868193eaf07c7d5",
-      "at": "2026-03-29T16:34:36Z",
-      "passes": 1,
-      "pr": 13103
-    },
-    ".agents/tools/voice/ios-shortcut.md": {
-      "hash": "c6d9c528093a67e0419180f6cad49c72defe1e92",
-      "at": "2026-03-29T20:53:52Z",
-      "passes": 1,
-      "pr": 13286
-    },
-    ".agents/tools/voice/local-tts-models.md": {
-      "hash": "e1ba9b3c2d19f39753d51272af8e15c119bae160",
-      "at": "2026-03-28T08:18:24Z",
-      "passes": 1,
-      "pr": 11637
-    },
-    ".agents/tools/voice/pipecat-opencode.md": {
-      "hash": "e7a6896a9e9d2fd7072fdf2d32db8ccc41114c85",
-      "at": "2026-03-28T16:40:27Z",
-      "passes": 1,
-      "pr": 12019
-    },
-    ".agents/tools/voice/qwen3-tts.md": {
-      "hash": "5c96c2f2bc41084437754a44b1e5ea3377c42574",
-      "at": "2026-03-29T19:05:52Z",
-      "passes": 1,
-      "pr": 13190
-    },
-    ".agents/tools/voice/speech-to-speech.md": {
-      "hash": "b82177ce888ec4aa5f1bd546886b0ae5c8b92f52",
-      "at": "2026-03-29T14:29:05Z",
-      "passes": 1,
-      "pr": 13005
-    },
-    ".agents/tools/voice/transcription.md": {
-      "hash": "be64061a20cfdfbf8635ac4c2d83b15583a75589",
-      "at": "2026-03-29T07:02:26Z",
-      "passes": 1,
-      "pr": 12638
-    },
-    ".agents/tools/voice/voice-models.md": {
-      "hash": "c02a9a4c714f285968649b21c955f9ad842b7b84",
-      "at": "2026-03-28T08:18:24Z",
-      "passes": 1,
-      "pr": 11637
-    },
-    ".agents/tools/voice/voiceink-shortcut.md": {
-      "hash": "6b28ebfcd62b8fc97f7a47ee918c848e1ccfaa93",
-      "at": "2026-03-28T16:40:39Z",
-      "passes": 1,
-      "pr": 12017
-    },
-    ".agents/tools/wordpress/localwp.md": {
-      "hash": "046bf8face3ec8929723c2a265ac370954ed227b",
-      "at": "2026-04-13T16:27:58Z",
-      "passes": 2,
-      "pr": 11563
-    },
-    ".agents/tools/wordpress/mainwp.md": {
-      "hash": "3ca000f7bb9497bce6d58c24ef53362c3ba189ed",
-      "at": "2026-03-28T11:20:17Z",
-      "passes": 1,
-      "pr": 11794
-    },
-    ".agents/tools/wordpress/scf.md": {
-      "hash": "80e8fa1c499ab170936e5db5f4c6d51aed480c82",
-      "at": "2026-03-28T16:40:07Z",
-      "passes": 1,
-      "pr": 12035
-    },
-    ".agents/tools/wordpress/wp-admin.md": {
-      "hash": "ec39f27d75293bccb4434b85622ce978ab5709f7",
-      "at": "2026-03-28T08:17:43Z",
-      "passes": 1,
-      "pr": 11587
-    },
-    ".agents/tools/wordpress/wp-cli-reference.md": {
-      "hash": "2fcf819eb80e07eff90b43bead554a47091793eb",
-      "at": "2026-03-28T08:17:43Z",
-      "passes": 1,
-      "pr": 11587
-    },
-    ".agents/tools/wordpress/wp-dev.md": {
-      "hash": "bfb49264d8380d603b517b0297a9270e6ef6b3b0",
-      "at": "2026-03-29T22:09:16Z",
-      "passes": 1,
-      "pr": 13341
-    },
-    ".agents/tools/wordpress/wp-preferred.md": {
-      "hash": "d9b4ffa6e03c98b1c239a44c9bcee6971acfba79",
-      "at": "2026-03-28T03:54:25Z",
-      "passes": 1,
-      "pr": 11353
-    },
-    ".agents/workflows/branch.md": {
-      "hash": "8a407f752bf203868cb2fd7a00bdace9d80a8512",
-      "at": "2026-04-03T11:54:15Z",
-      "passes": 1,
-      "pr": 16416
-    },
-    ".agents/workflows/branch/bugfix.md": {
-      "hash": "e748778290a204b0f79b9fa88e66fd3f3fd891fb",
-      "at": "2026-04-02T04:56:46Z",
-      "passes": 1,
-      "pr": 15517
-    },
-    ".agents/workflows/branch/experiment.md": {
-      "hash": "3fdeaf05d52c8e879538868b432ec953d63e615d",
-      "at": "2026-04-02T21:20:20Z",
-      "passes": 2,
-      "pr": 0
-    },
-    ".agents/workflows/branch/hotfix.md": {
-      "hash": "6b9ec688065c9e9250ed8f63196737af153a66fe",
-      "at": "2026-04-01T20:59:04Z",
-      "passes": 1,
-      "pr": 15209
-    },
-    ".agents/workflows/browser-qa.md": {
-      "hash": "98ad6337f860e081d42a943f5152feb9e148c6b0",
-      "at": "2026-04-03T04:23:07Z",
-      "passes": 1,
-      "pr": 15835
-    },
-    ".agents/workflows/bug-fixing.md": {
-      "hash": "dfc99d84d7f2e8e69167c1c132a846c2c68f7940",
-      "at": "2026-03-29T16:34:52Z",
-      "passes": 1,
-      "pr": 13056
-    },
-    ".agents/workflows/code-audit-remote.md": {
-      "hash": "0d8d85fd5910f64d690a3ff21462496ac7ae0554",
-      "at": "2026-03-28T15:31:24Z",
-      "passes": 1,
-      "pr": 11825
-    },
-    ".agents/workflows/error-feedback.md": {
-      "hash": "ca757bf1c3449bd7fd8c42d85afb9743e1410324",
-      "at": "2026-04-03T01:11:46Z",
-      "passes": 1,
-      "pr": 15970
-    },
-    ".agents/workflows/feature-development.md": {
-      "hash": "f4e607a4441fd8da90298eafef9743d8039c4ba7",
-      "at": "2026-03-29T16:31:49Z",
-      "passes": 1,
-      "pr": 13065
-    },
-    ".agents/workflows/git-workflow.md": {
-      "hash": "8b1c4557393fefcee67608abe5f50936b1a12431",
-      "at": "2026-03-29T08:49:32Z",
-      "passes": 1,
-      "pr": 12777
-    },
-    ".agents/workflows/milestone-validation.md": {
-      "hash": "9474ccd7f66e7948125d76ae221086ea8f47870e",
-      "at": "2026-03-28T03:53:42Z",
-      "passes": 1,
-      "pr": 11286
-    },
-    ".agents/workflows/mission-orchestrator.md": {
-      "hash": "78a33b982d7a70d210df2f802519ef66f8632742",
-      "at": "2026-03-30T06:49:53Z",
-      "passes": 1,
-      "pr": 13841
-    },
-    ".agents/workflows/mission-skill-learning.md": {
-      "hash": "d18fd0b438f42e4e240326848f3d3463fa986480",
-      "at": "2026-04-03T11:54:11Z",
-      "passes": 2,
-      "pr": 14996
-    },
-    ".agents/workflows/multi-repo-workspace.md": {
-      "hash": "f6e8316bed9e00e964afae0025f4ed6b37f3fa4c",
-      "at": "2026-03-28T16:00:32Z",
-      "passes": 1,
-      "pr": 11984
-    },
-    ".agents/workflows/plans.md": {
-      "hash": "3abaef28c0f03fa97774b22e8681b32f27350d24",
-      "at": "2026-04-06T15:39:38Z",
-      "passes": 2,
-      "pr": 12235
-    },
-    ".agents/workflows/postflight.md": {
-      "hash": "b06e3b3e0aa4706319eb0b05bf54367ea0e92569",
-      "at": "2026-03-28T10:27:12Z",
-      "passes": 1,
-      "pr": 11739
-    },
-    ".agents/workflows/pr.md": {
-      "hash": "08162913df92f899457e4d1495cfc54bee8a49fe",
-      "at": "2026-04-09T07:32:14Z",
-      "passes": 2,
-      "pr": 13014
-    },
-    ".agents/workflows/preflight.md": {
-      "hash": "81a7f51d2e0863d7db395809f306cfad572060f4",
-      "at": "2026-03-28T03:54:08Z",
-      "passes": 1,
-      "pr": 11341
-    },
-    ".agents/workflows/ralph-loop.md": {
-      "hash": "fc13521cf4f2d8477be2c37928bc684dc88901f6",
-      "at": "2026-03-28T11:20:12Z",
-      "passes": 1,
-      "pr": 11789
-    },
-    ".agents/workflows/readme-create-update.md": {
-      "hash": "0b1c731168591b51353e46c85c9fdcacfac2daec",
-      "at": "2026-03-28T16:40:10Z",
-      "passes": 1,
-      "pr": 12038
-    },
-    ".agents/workflows/release.md": {
-      "hash": "e74fead69d8b3756f99b09401b52d5a6a44ac456",
-      "at": "2026-03-29T22:51:16Z",
-      "passes": 2,
-      "pr": 13318
-    },
-    ".agents/workflows/review-issue-pr.md": {
-      "hash": "555ce0c4248605489eab19b1f421279ab211455d",
-      "at": "2026-04-15T03:00:56Z",
-      "passes": 5,
-      "pr": 12308
-    },
-    ".agents/workflows/session-manager.md": {
-      "hash": "186b8c1b21b241174337dc1aa8f71e6560677037",
-      "at": "2026-03-29T23:53:41Z",
-      "passes": 1,
-      "pr": 13443
-    },
-    ".agents/workflows/session-review.md": {
-      "hash": "75539fb19f3e764a723d6534c6b2090709b3b423",
-      "at": "2026-04-11T05:06:04Z",
-      "passes": 2,
-      "pr": 12889
-    },
-    ".agents/workflows/sql-migrations.md": {
-      "hash": "62f8b3740980fa962ecb492ce2aed2df50e57838",
-      "at": "2026-03-30T06:03:19Z",
-      "passes": 1,
-      "pr": 13838
-    },
-    ".agents/workflows/ui-verification.md": {
-      "hash": "136b7d726ea067a3ae9c76819b576296d5da2749",
-      "at": "2026-03-29T07:31:37Z",
-      "passes": 1,
-      "pr": 12705
-    },
-    ".agents/workflows/version-bump.md": {
-      "hash": "2c2f323754934a7e0baf9143baf76f444499efde",
-      "at": "2026-03-28T16:00:36Z",
-      "passes": 1,
-      "pr": 11986
-    },
-    ".agents/workflows/wiki-update.md": {
-      "hash": "578eed449c48071e3e67c447f8f107595193a069",
-      "at": "2026-03-30T02:30:16Z",
-      "passes": 1,
-      "pr": 13594
-    },
-    ".agents/workflows/worktree.md": {
-      "hash": "737a99c16c2572014f5786ac591db5b95631608b",
-      "at": "2026-04-03T11:54:16Z",
-      "passes": 1,
-      "pr": 16415
-    },
-    "TODO.md": {
-      "hash": "8d1ce0ca9a629bb98802d46b14331bdd1691d800",
-      "at": "2026-04-15T22:52:18Z",
-      "passes": 21,
-      "pr": 15490
-    },
-    "aidevops.sh": {
-      "hash": "757881f069c802f24ab496f6c73c4196b078b8bf",
-      "at": "2026-04-15T22:52:18Z",
-      "pr": 19029,
-      "passes": 64
-    },
-    "setup.sh": {
-      "hash": "0343addb91e60c491511d9d85163c07d93d6baeb",
-      "at": "2026-04-15T22:52:18Z",
-      "passes": 62,
-      "pr": 15470
-    },
-    "todo/tasks/GH#15363-brief.md": {
-      "hash": "37de48d4fe8a443c8c5f4fa3d8d9aaf6c25681cd",
-      "at": "2026-04-02T13:10:59Z",
-      "passes": 1,
-      "pr": 15566
-    },
-    "todo/tasks/GH-14990-brief.md": {
-      "hash": "800d9eea6d4954e52e676b597ac1ca9264385f1e",
-      "at": "2026-04-01T20:59:29Z",
-      "passes": 1,
-      "pr": 14996
-    },
-    "todo/tasks/t15173-brief.md": {
-      "hash": "d19107141234f84909e7932acf9d7a6fb2e5590f",
-      "at": "2026-04-01T20:58:50Z",
-      "passes": 1,
-      "pr": 15257
-    },
-    "todo/tasks/t15364-brief.md": {
-      "hash": "98bb137e0bf45a14a8d499b17e20d1432d6a84a9",
-      "at": "2026-04-02T13:11:00Z",
-      "passes": 1,
-      "pr": 15566
-    },
-    "todo/tasks/t15448-brief.md": {
-      "hash": "06817a5177d926d96000b713b4638f679790d824",
-      "at": "2026-04-02T04:56:58Z",
-      "passes": 1,
-      "pr": 15463
-    },
-    "todo/tasks/t15450-brief.md": {
-      "hash": "7eb8a85ef2c9c4c856ce7cc8ba3d51a55dcac764",
-      "at": "2026-04-02T04:56:56Z",
-      "passes": 1,
-      "pr": 15468
-    },
-    "todo/tasks/t15472-brief.md": {
-      "hash": "1fa1551004bd0fbf798f57791aa5e7941b6f2606",
-      "at": "2026-04-02T04:56:51Z",
-      "passes": 1,
-      "pr": 15490
-    },
-    "todo/tasks/t1727-brief.md": {
-      "hash": "b4d74cfce669e4c678f2439ef7673de9a9c3feba",
-      "at": "2026-04-02T03:11:00Z",
-      "passes": 1,
-      "pr": 15431
-    },
-    "todo/tasks/t1737-brief.md": {
-      "hash": "f5acb5d720b3da605eea4b673b2391a6303d03d1",
-      "at": "2026-04-01T20:59:15Z",
-      "passes": 1,
-      "pr": 15223
-    },
-    "todo/tasks/t2052-brief.md": {
-      "hash": "89edb8ff09173143446da68fb9104c16ac400b1c",
-      "at": "2026-04-02T04:56:57Z",
-      "passes": 1,
-      "pr": 15470
-    },
-    ".agents/scripts/commands/email-inbox.md": {
-      "hash": "4f1ca21839cf5220d8b32c732671288f83ac5c72",
-      "at": "2026-04-11T16:20:00Z",
-      "passes": 2,
-      "pr": 16588
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/bot-management.md": {
-      "hash": "a7e3417849a22cd576f30c329661caaecb042fd9",
-      "at": "2026-04-03T13:35:13Z",
-      "passes": 1,
-      "pr": 16587
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/realtimekit.md": {
-      "hash": "e00af10a47219d972f6551086fd1c6d6271a34e5",
-      "at": "2026-04-03T13:35:13Z",
-      "passes": 1,
-      "pr": 16586
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/stream.md": {
-      "hash": "eb852067b0a3c17b56e251ef4610ecde7519edf2",
-      "at": "2026-04-03T13:35:13Z",
-      "passes": 1,
-      "pr": 16585
-    },
-    ".agents/aidevops/orchestration-analysis.md": {
-      "hash": "301d67af6b97b0bdad11118129c0fef7082763fb",
-      "at": "2026-04-03T13:35:13Z",
-      "passes": 1,
-      "pr": 16584
-    },
-    ".agents/tools/ai-assistants/runners-code-reviewer.md": {
-      "hash": "d959a8122b1527468e242cc74f6d38c001386c72",
-      "at": "2026-04-03T13:35:13Z",
-      "passes": 1,
-      "pr": 16583
-    },
-    ".agents/tools/credentials/auth-troubleshooting.md": {
-      "hash": "d1dcacfa938afdbf4ce81c8da0c444354b2576f1",
-      "at": "2026-04-09T07:32:10Z",
-      "passes": 2,
-      "pr": 16582
-    },
-    ".agents/content/heygen-skill/rules-streaming-avatars.md": {
-      "hash": "e65aa18fda497652c82195557641371fb1db09bd",
-      "at": "2026-04-03T13:35:13Z",
-      "passes": 1,
-      "pr": 16581
-    },
-    ".agents/seo/seo-optimizer.md": {
-      "hash": "6ea5959df1ec6ca83ebcbcbc08153fc8e2716e92",
-      "at": "2026-04-03T13:35:13Z",
-      "passes": 1,
-      "pr": 16579
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/smart-placement.md": {
-      "hash": "81220dc4f64d47000f38aa5398d7539a34695f09",
-      "at": "2026-04-03T13:35:14Z",
-      "passes": 1,
-      "pr": 16573
-    },
-    ".agents/tools/context/toon.md": {
-      "hash": "4fda8b1d3df42a7e5594d8ea1e56fb1f0672e192",
-      "at": "2026-04-03T13:35:14Z",
-      "passes": 1,
-      "pr": 16572
-    },
-    ".agents/reference/define-probes/refactor.md": {
-      "hash": "fcdb563754db4003c7785b9f5140cd848f959f8b",
-      "at": "2026-04-03T13:35:14Z",
-      "passes": 1,
-      "pr": 16571
-    },
-    ".agents/tools/autoresearch/autoresearch/loop.md": {
-      "hash": "310471e2c6f7a270c38a4a57442cea1110aa232c",
-      "at": "2026-04-03T16:35:36Z",
-      "passes": 2,
-      "pr": 16570
-    },
-    ".agents/scripts/commands/autoresearch.md": {
-      "hash": "f6c9df3d4d0f41acbccf1714eaa890ea59bcb0b3",
-      "at": "2026-04-11T03:27:09Z",
-      "passes": 3,
-      "pr": 16569
-    },
-    ".agents/tools/productivity/contacts.md": {
-      "hash": "a9fdc1de8d5532ac02b21837b470f091eb270ecf",
-      "at": "2026-04-03T13:35:15Z",
-      "passes": 1,
-      "pr": 16497
-    },
-    ".agents/scripts/commands/add-skill.md": {
-      "hash": "c52915c7f433ba906fd87135e8620e784aa90c85",
-      "at": "2026-04-11T17:01:24Z",
-      "passes": 3,
-      "pr": 16634
-    },
-    ".agents/scripts/commands/models-pool-check.md": {
-      "hash": "72b94302544b07cfb930b8f97e3d55a6fe6b4c6f",
-      "at": "2026-04-11T16:20:01Z",
-      "passes": 2,
-      "pr": 16633
-    },
-    ".agents/tools/browser/browser-benchmark.md": {
-      "hash": "7a6bfc02cbcc76f0dc2041496f735badda66353d",
-      "at": "2026-04-03T14:06:30Z",
-      "passes": 1,
-      "pr": 16631
-    },
-    ".agents/tests/comprehension/pilot-results.md": {
-      "hash": "d9b46d34968b33800bb8cc0316a5773e939127ce",
-      "at": "2026-04-03T14:06:30Z",
-      "passes": 1,
-      "pr": 16630
-    },
-    ".agents/tools/autoresearch/autoresearch/agent-optimization.md": {
-      "hash": "d328b1bf0a01f032d335b17fa8aef28329d3735e",
-      "at": "2026-04-03T14:06:30Z",
-      "passes": 1,
-      "pr": 16629
-    },
-    ".agents/tools/code-review/automation.md": {
-      "hash": "b4163a45b9055fce5e2a982235dcc5f352263bad",
-      "at": "2026-04-03T16:35:38Z",
-      "passes": 2,
-      "pr": 16628
-    },
-    ".agents/tools/productivity/apple-reminders.md": {
-      "hash": "0bf76947cbd404359a53093f28e6ff10ee767eb2",
-      "at": "2026-04-03T14:06:30Z",
-      "passes": 1,
-      "pr": 16613
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/bot-management-patterns.md": {
-      "hash": "ccd3dbab23b29fd35903db9431c360e0b3e926c4",
-      "at": "2026-04-03T14:06:30Z",
-      "passes": 1,
-      "pr": 16612
-    },
-    ".agents/tools/autoresearch/autoresearch/logging.md": {
-      "hash": "e549c2ad79bfd57ff857709068f925b9135dfa03",
-      "at": "2026-04-03T16:35:36Z",
-      "passes": 2,
-      "pr": 16611
-    },
-    ".agents/tools/autoresearch/autoresearch/completion.md": {
-      "hash": "cec121464b5934a11b226c825decd53b4c243712",
-      "at": "2026-04-09T07:32:08Z",
-      "passes": 2,
-      "pr": 16610
-    },
-    ".agents/tools/autoresearch/autoresearch.md": {
-      "hash": "db22f20f88ddafb34775fe8bdf3c3ddb5b36630c",
-      "at": "2026-04-03T21:12:14Z",
-      "passes": 3,
-      "pr": 16609
-    },
-    ".agents/reference/bash-compat.md": {
-      "hash": "2349fcdc14f5b7aa6a1c7c23008e38f8ef558240",
-      "at": "2026-04-14T20:16:56Z",
-      "passes": 3,
-      "pr": 16580
-    },
-    ".agents/content/social-reddit.md": {
-      "hash": "fdff0bfaf102165f97ea5be8ec39880579374eae",
-      "at": "2026-04-03T14:06:32Z",
-      "passes": 1,
-      "pr": 16555
-    },
-    ".agents/tools/containers/orbstack.md": {
-      "hash": "3fcc1ac93fecc22999176d6cdd04dc4bf6a5aea0",
-      "at": "2026-04-03T14:06:32Z",
-      "passes": 1,
-      "pr": 16542
-    },
-    ".agents/tools/ai-assistants/overview.md": {
-      "hash": "d28a6855ea958f0d413f7045829ecf6b2fbb1245",
-      "at": "2026-04-03T16:35:51Z",
-      "passes": 1,
-      "pr": 16716
-    },
-    ".agents/tools/video/remotion-get-video-dimensions.md": {
-      "hash": "40001abb1d76fb6732a7aeff81ff93865bbd0714",
-      "at": "2026-04-03T16:35:51Z",
-      "passes": 1,
-      "pr": 16715
-    },
-    ".agents/workflows/conversation-starter.md": {
-      "hash": "e1981dcc5c3ba7b6b886e8860e847239ced37000",
-      "at": "2026-04-03T16:35:51Z",
-      "passes": 1,
-      "pr": 16714
-    },
-    ".agents/reference/task-taxonomy.md": {
-      "hash": "7558ca4b07e906fe0dd9895a8202609fdcfea974",
-      "at": "2026-04-14T08:25:15Z",
-      "passes": 6,
-      "pr": "pending"
-    },
-    ".agents/seo/ranking-opportunities.md": {
-      "hash": "798c09f0ea175ef5dcce3f5a148c25e509d5ed70",
-      "at": "2026-04-03T16:35:52Z",
-      "passes": 1,
-      "pr": 16713
-    },
-    ".agents/tools/browser/browser-benchmark-scripts-04-crawl4ai.md": {
-      "hash": "ddee7bb8e71277877e965d5700f35f43dd85473a",
-      "at": "2026-04-03T16:35:52Z",
-      "passes": 1,
-      "pr": 16712
-    },
-    ".agents/tools/build-agent/agent-review.md": {
-      "hash": "cd916353cc7af31d6abe65aaf687986ae1fe2937",
-      "at": "2026-04-03T16:35:52Z",
-      "passes": 1,
-      "pr": 16711
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/terraform.md": {
-      "hash": "b92546d9d4760c1b52f896aa0490fb623bb4b147",
-      "at": "2026-04-03T16:35:52Z",
-      "passes": 1,
-      "pr": 16710
-    },
-    ".agents/scripts/commands/email-health-check.md": {
-      "hash": "e558738cbf896c8ecf3dc22b981a175b95f43521",
-      "at": "2026-04-11T02:40:55Z",
-      "passes": 2,
-      "pr": 16709
-    },
-    ".agents/services/outreach/leadsforge.md": {
-      "hash": "7ddf2a120e2fd9c040b6a9882eec470ed2b723db",
-      "at": "2026-04-03T16:35:52Z",
-      "passes": 1,
-      "pr": 16708
-    },
-    ".agents/tools/autoagent/autoagent/safety.md": {
-      "hash": "fa28a6f0dbf686ac97858881a6d3074b2d10f925",
-      "at": "2026-04-03T16:35:52Z",
-      "passes": 1,
-      "pr": 16707
-    },
-    ".agents/scripts/commands/autoagent.md": {
-      "hash": "b0099a8d2c81d616a46b25570bfcae141ee0206a",
-      "at": "2026-04-11T17:01:24Z",
-      "passes": 3,
-      "pr": 16700
-    },
-    ".agents/tools/autoagent/autoagent/signal-mining.md": {
-      "hash": "4e6fafdabe29a3c11a7ffca50264f998a551ac25",
-      "at": "2026-04-03T19:14:32Z",
-      "passes": 2,
-      "pr": 16699
-    },
-    ".agents/tools/autoagent/autoagent/hypothesis-types.md": {
-      "hash": "db1530fe0579f34acec0806c7934db58b1e3720e",
-      "at": "2026-04-03T16:35:52Z",
-      "passes": 1,
-      "pr": 16698
-    },
     ".agents/tools/autoagent/autoagent.md": {
-      "hash": "d047aa843fd1b7898cecfa3cfe25b42e9f5c84dd",
       "at": "2026-04-09T07:32:08Z",
+      "hash": "d047aa843fd1b7898cecfa3cfe25b42e9f5c84dd",
       "passes": 2,
       "pr": 16697
     },
     ".agents/tools/autoagent/autoagent/evaluation.md": {
-      "hash": "dc19ee799288cc7c92cbeb8751c6f208731a42f5",
       "at": "2026-04-03T16:35:53Z",
+      "hash": "dc19ee799288cc7c92cbeb8751c6f208731a42f5",
       "passes": 1,
       "pr": 16696
     },
-    ".agents/tools/voice/buzz.md": {
-      "hash": "ca79f7c8c14b2f8087d4516a1894867f9569b9ca",
-      "at": "2026-04-03T16:35:53Z",
+    ".agents/tools/autoagent/autoagent/hypothesis-types.md": {
+      "at": "2026-04-03T16:35:52Z",
+      "hash": "db1530fe0579f34acec0806c7934db58b1e3720e",
       "passes": 1,
-      "pr": 16677
+      "pr": 16698
     },
-    ".agents/workflows/branch/refactor.md": {
-      "hash": "db41908442790de7971e5be0377f2d1ea2479d8f",
-      "at": "2026-04-03T16:35:53Z",
+    ".agents/tools/autoagent/autoagent/safety.md": {
+      "at": "2026-04-03T16:35:52Z",
+      "hash": "fa28a6f0dbf686ac97858881a6d3074b2d10f925",
       "passes": 1,
-      "pr": 16676
+      "pr": 16707
     },
-    ".agents/workflows/branch/release.md": {
-      "hash": "a39e09b0127ed9312aa3da6b18d970df35c841b1",
-      "at": "2026-04-03T16:35:53Z",
-      "passes": 1,
-      "pr": 16675
+    ".agents/tools/autoagent/autoagent/signal-mining.md": {
+      "at": "2026-04-03T19:14:32Z",
+      "hash": "4e6fafdabe29a3c11a7ffca50264f998a551ac25",
+      "passes": 2,
+      "pr": 16699
     },
-    ".agents/content/internal-linker.md": {
-      "hash": "a9bac8ce4b2b37c9335ca62ee29ed9d7e80198a2",
-      "at": "2026-04-03T16:35:53Z",
+    ".agents/tools/automation/cron-agent.md": {
+      "at": "2026-03-28T20:56:11Z",
+      "hash": "ab3205565f478339b10ddd7f692f244095c28941",
       "passes": 1,
-      "pr": 16674
+      "pr": 12184
     },
-    ".agents/tools/ui/nothing-design-skill/platform-mapping.md": {
-      "hash": "2cfa6df71658fb20a6ad4298e4a3ba553332103f",
-      "at": "2026-04-03T16:35:53Z",
+    ".agents/tools/automation/mac.md": {
+      "at": "2026-04-01T20:58:52Z",
+      "hash": "d83b7d0243755da08de58680b878867cb909f29b",
       "passes": 1,
-      "pr": 16673
+      "pr": 15253
     },
-    ".agents/marketing-sales/cro-chapter-23.md": {
-      "hash": "db5fb34d74b6f8f20ddc287c19ac7772d95e18e8",
-      "at": "2026-04-03T16:35:53Z",
+    ".agents/tools/automation/macos-automator.md": {
+      "at": "2026-03-27T21:25:19Z",
+      "hash": "2fd0ee55ab51d718fbe297a8789d74048f495480",
       "passes": 1,
-      "pr": 16672
+      "pr": 11011
     },
-    ".agents/reference/define-probes/docs.md": {
-      "hash": "05d9d70bca6d602485ce4081c5810c9f76533ceb",
-      "at": "2026-04-03T16:35:53Z",
-      "passes": 1,
-      "pr": 16671
+    ".agents/tools/autoresearch/autoresearch.md": {
+      "at": "2026-04-03T21:12:14Z",
+      "hash": "db22f20f88ddafb34775fe8bdf3c3ddb5b36630c",
+      "passes": 3,
+      "pr": 16609
     },
-    ".agents/seo/seo-audit-skill/aeo-geo-patterns/01-aeo-patterns.md": {
-      "hash": "adc6a8b7b331b0a3cfdfa9131664fef37d0b5d02",
-      "at": "2026-04-03T16:35:53Z",
+    ".agents/tools/autoresearch/autoresearch/agent-optimization.md": {
+      "at": "2026-04-03T14:06:30Z",
+      "hash": "d328b1bf0a01f032d335b17fa8aef28329d3735e",
       "passes": 1,
-      "pr": 16670
+      "pr": 16629
     },
-    ".agents/services/communications/cross-channel-conversation-continuity.md": {
-      "hash": "c33ae68330c28c43c9f4ff173687addf27c3e9dc",
-      "at": "2026-04-03T16:35:53Z",
-      "passes": 1,
-      "pr": 16669
+    ".agents/tools/autoresearch/autoresearch/completion.md": {
+      "at": "2026-04-09T07:32:08Z",
+      "hash": "cec121464b5934a11b226c825decd53b4c243712",
+      "passes": 2,
+      "pr": 16610
     },
-    ".agents/tools/voice/voice-ai-models.md": {
-      "hash": "0537d6bce2fd2a72f5d9122c149848d8a7d71237",
-      "at": "2026-04-03T16:35:54Z",
-      "passes": 1,
-      "pr": 16668
+    ".agents/tools/autoresearch/autoresearch/logging.md": {
+      "at": "2026-04-03T16:35:36Z",
+      "hash": "e549c2ad79bfd57ff857709068f925b9135dfa03",
+      "passes": 2,
+      "pr": 16611
     },
-    ".agents/services/hosting/cloudflare-platform-skill/d1-gotchas.md": {
-      "hash": "7383e491900c1eeef59699a160c5529e0972c9b5",
-      "at": "2026-04-03T16:35:54Z",
-      "passes": 1,
-      "pr": 16655
+    ".agents/tools/autoresearch/autoresearch/loop.md": {
+      "at": "2026-04-03T16:35:36Z",
+      "hash": "310471e2c6f7a270c38a4a57442cea1110aa232c",
+      "passes": 2,
+      "pr": 16570
     },
-    ".agents/services/hosting/cloudflare-platform-skill/tunnel.md": {
-      "hash": "dbd3d5267226019619b2487f0c0ded3c8d1573c2",
-      "at": "2026-04-03T16:35:54Z",
+    ".agents/tools/browser/agent-browser.md": {
+      "at": "2026-04-03T03:15:28Z",
+      "hash": "c5032f5b38edf7e914678270da2c80a0369cc56a",
       "passes": 1,
-      "pr": 16654
+      "pr": 15892
+    },
+    ".agents/tools/browser/anti-detect-browser.md": {
+      "at": "2026-03-27T21:25:25Z",
+      "hash": "1adf6b7cc211d6453f91177501ffcc0259791e90",
+      "passes": 1,
+      "pr": 11017
+    },
+    ".agents/tools/browser/browser-automation.md": {
+      "at": "2026-03-30T04:51:56Z",
+      "hash": "a70f670d6d769c208efd9922a653a57ce0d1ce31",
+      "passes": 2,
+      "pr": 13719
+    },
+    ".agents/tools/browser/browser-benchmark-scripts-01-playwright.md": {
+      "at": "2026-04-03T11:54:13Z",
+      "hash": "56d7fd4609a7f87d460e99cf4c53899fb367292e",
+      "passes": 1,
+      "pr": 16500
+    },
+    ".agents/tools/browser/browser-benchmark-scripts-04-crawl4ai.md": {
+      "at": "2026-04-03T16:35:52Z",
+      "hash": "ddee7bb8e71277877e965d5700f35f43dd85473a",
+      "passes": 1,
+      "pr": 16712
+    },
+    ".agents/tools/browser/browser-benchmark-scripts-05-stagehand.md": {
+      "at": "2026-04-01T12:00:00Z",
+      "hash": "4ff8a6b67ed3b0237f2cd22486b424de06472ebd",
+      "passes": 1,
+      "pr": 15176
+    },
+    ".agents/tools/browser/browser-benchmark.md": {
+      "at": "2026-04-03T14:06:30Z",
+      "hash": "7a6bfc02cbcc76f0dc2041496f735badda66353d",
+      "passes": 1,
+      "pr": 16631
+    },
+    ".agents/tools/browser/browser-profiles.md": {
+      "at": "2026-04-03T12:15:23Z",
+      "hash": "7b038d0c2776b834cf28f1983514c62a77488372",
+      "passes": 2,
+      "pr": 12501
+    },
+    ".agents/tools/browser/browser-qa.md": {
+      "at": "2026-03-28T20:17:06Z",
+      "hash": "c3104e46ab671b2f7948ac29b465ee9c22a1c3ef",
+      "passes": 1,
+      "pr": 12171
+    },
+    ".agents/tools/browser/browser-use.md": {
+      "at": "2026-03-29T07:03:02Z",
+      "hash": "0ca443d3cf09a730b26457d0c2ece044144ce8a0",
+      "passes": 1,
+      "pr": 12616
+    },
+    ".agents/tools/browser/chrome-devtools.md": {
+      "at": "2026-04-13T16:27:44Z",
+      "hash": "05c28f2b318a798e29c7333fb42f3313823bb102",
+      "passes": 2,
+      "pr": 12310
+    },
+    ".agents/tools/browser/chrome-webstore-release.md": {
+      "at": "2026-03-30T06:49:23Z",
+      "hash": "d480d6719f22c2ea6fafefd21e49a99a0f4c6e2f",
+      "passes": 1,
+      "pr": 13942
+    },
+    ".agents/tools/browser/chromium-debug-use.md": {
+      "at": "2026-04-03T11:54:14Z",
+      "hash": "aa9bbc8cba0fa64aee7d94c5f1fa8fd0141ef704",
+      "passes": 1,
+      "pr": 16473
+    },
+    ".agents/tools/browser/chromium-debug-use/SKILL.md": {
+      "at": "2026-04-04T14:54:12Z",
+      "hash": "4c95ad2b5c1fd7e7deed50ff5d128f2af631adce",
+      "passes": 1,
+      "pr": 17280
+    },
+    ".agents/tools/browser/crawl4ai-integration.md": {
+      "at": "2026-04-02T19:17:13Z",
+      "hash": "2218327e7d764c22a6c66a55bedb643d78a50597",
+      "passes": 2,
+      "pr": 15463
+    },
+    ".agents/tools/browser/crawl4ai-resources.md": {
+      "at": "2026-03-28T13:37:22Z",
+      "hash": "9e751cfa89e483f3cc52d54438d39dc5796d5f94",
+      "passes": 1,
+      "pr": 11858
+    },
+    ".agents/tools/browser/crawl4ai-usage.md": {
+      "at": "2026-04-03T01:11:47Z",
+      "hash": "0a12dd6983cc36552152e54f6ee4cf27b98c3881",
+      "passes": 1,
+      "pr": 15802
+    },
+    ".agents/tools/browser/crawl4ai.md": {
+      "at": "2026-03-28T08:17:51Z",
+      "hash": "f902bbe5c1df5e39ff391f09c01dce2a10fbc71c",
+      "passes": 1,
+      "pr": 11599
+    },
+    ".agents/tools/browser/curl-copy.md": {
+      "at": "2026-04-01T21:56:13Z",
+      "hash": "6e50a9becdbef4af341c2950c78e788a1b443a3b",
+      "passes": 2
+    },
+    ".agents/tools/browser/dev-browser.md": {
+      "at": "2026-04-03T21:42:06Z",
+      "hash": "ad68e794a7f47eca0fc81085cce62418ddbb5740",
+      "passes": 3,
+      "pr": 11921
+    },
+    ".agents/tools/browser/extension-dev.md": {
+      "at": "2026-03-29T22:09:34Z",
+      "hash": "397ff57e80711c71e67d63a4add48367d6ad2512",
+      "passes": 1,
+      "pr": 13330
+    },
+    ".agents/tools/browser/extension-dev/development.md": {
+      "at": "2026-03-30T04:52:04Z",
+      "hash": "62052fb74fe679e3587757a452c2ab4ced38afd5",
+      "passes": 1,
+      "pr": 13722
+    },
+    ".agents/tools/browser/extension-dev/publishing.md": {
+      "at": "2026-03-29T11:20:06Z",
+      "hash": "513d106e23df5308b941e15086d306aefed729d4",
+      "passes": 1,
+      "pr": 12884
+    },
+    ".agents/tools/browser/extension-dev/testing.md": {
+      "at": "2026-03-30T04:51:57Z",
+      "hash": "373ab0b0f67d5708464721b01409849320abe0ba",
+      "passes": 1,
+      "pr": 13717
+    },
+    ".agents/tools/browser/fingerprint-profiles.md": {
+      "at": "2026-03-28T17:30:27Z",
+      "hash": "e14427c10717d69f04d8e5727002c4758a71b059",
+      "passes": 1,
+      "pr": 12070
+    },
+    ".agents/tools/browser/pagespeed.md": {
+      "at": "2026-03-28T03:53:49Z",
+      "hash": "e98367b4b75ea7698feaddc1a3a4a17a469bceec",
+      "passes": 1,
+      "pr": 11295
+    },
+    ".agents/tools/browser/peekaboo.md": {
+      "at": "2026-03-28T03:54:17Z",
+      "hash": "cc607229908282fe9c9093dc5b76203e4b5ecf2b",
+      "passes": 1,
+      "pr": 11348
+    },
+    ".agents/tools/browser/playwright-cli.md": {
+      "at": "2026-03-28T11:20:22Z",
+      "hash": "40f7f25f8754a6cbe9b43f95e12c378638092c22",
+      "passes": 1,
+      "pr": 11802
+    },
+    ".agents/tools/browser/playwright-emulation.md": {
+      "at": "2026-04-02T22:44:04Z",
+      "hash": "d67caf9cb477e4faf5c60a239a492efa85c12ebb",
+      "passes": 1,
+      "pr": 15692
+    },
+    ".agents/tools/browser/playwright.md": {
+      "at": "2026-04-13T16:27:44Z",
+      "hash": "97668ce72605992d0eb984f910fecae8e4f7d8d9",
+      "passes": 2,
+      "pr": 16512
+    },
+    ".agents/tools/browser/playwriter.md": {
+      "at": "2026-03-29T03:31:38Z",
+      "hash": "f18ea8318e325896fb6a5bd5249f3b87b2da2bf2",
+      "passes": 1,
+      "pr": 12516
+    },
+    ".agents/tools/browser/proxy-integration.md": {
+      "at": "2026-03-29T15:08:41Z",
+      "hash": "fe6e091defe1344cbc9bfed4f6ef699373d028ae",
+      "passes": 1,
+      "pr": 13032
+    },
+    ".agents/tools/browser/skyvern.md": {
+      "at": "2026-03-28T17:11:10Z",
+      "hash": "fc60443927a977239b669a011981ecd7d17e8064",
+      "passes": 1,
+      "pr": 12055
+    },
+    ".agents/tools/browser/stagehand-examples.md": {
+      "at": "2026-03-28T14:15:24Z",
+      "hash": "458715b78cf7cb477a67c523977b47013141dcb5",
+      "passes": 1,
+      "pr": 11899
+    },
+    ".agents/tools/browser/stagehand-python.md": {
+      "at": "2026-03-30T02:31:00Z",
+      "hash": "05ae9d0f7d2962ca19effaa5b02ee3ad9048d8eb",
+      "passes": 1,
+      "pr": 13486
+    },
+    ".agents/tools/browser/stagehand.md": {
+      "at": "2026-03-29T03:15:18Z",
+      "hash": "c0dfc858fe1be14022452a3f5bc162d6bb2140d8",
+      "passes": 1,
+      "pr": 12513
+    },
+    ".agents/tools/browser/stealth-patches.md": {
+      "at": "2026-04-03T04:23:06Z",
+      "hash": "354afd4d24b76c5621ea61d23a8da71e811beeea",
+      "passes": 1,
+      "pr": 15948
+    },
+    ".agents/tools/browser/sweet-cookie.md": {
+      "at": "2026-03-29T22:09:35Z",
+      "hash": "753778b00a581b7c9d4e3275eba8a458dba17419",
+      "passes": 1,
+      "pr": 13328
+    },
+    ".agents/tools/browser/watercrawl.md": {
+      "at": "2026-03-28T19:15:30Z",
+      "hash": "f8675a206f700e545c65016e4b42de578f9cefd8",
+      "passes": 1,
+      "pr": 12117
+    },
+    ".agents/tools/build-agent/add-skill.md": {
+      "at": "2026-03-29T01:03:17Z",
+      "hash": "d9532305ae4da82d51cb56e724e816269a2cc70f",
+      "passes": 1,
+      "pr": 12376
+    },
+    ".agents/tools/build-agent/agent-review.md": {
+      "at": "2026-04-03T16:35:52Z",
+      "hash": "cd916353cc7af31d6abe65aaf687986ae1fe2937",
+      "passes": 1,
+      "pr": 16711
+    },
+    ".agents/tools/build-agent/agent-testing.md": {
+      "at": "2026-04-03T11:54:02Z",
+      "hash": "c6eba87c8204a064a3d05820dbefd5f7643fae3d",
+      "passes": 2,
+      "pr": 15662
+    },
+    ".agents/tools/build-agent/build-agent.md": {
+      "at": "2026-04-15T03:00:44Z",
+      "hash": "fa6700980ed34d1f45246b8862de1587d24d39a7",
+      "passes": 4,
+      "pr": 12957
+    },
+    ".agents/tools/build-mcp/aidevops-plugin.md": {
+      "at": "2026-04-02T14:42:10Z",
+      "hash": "dddbf102af3d7699e1178c83bc7d2d59db416e72",
+      "passes": 3,
+      "pr": 14775
+    },
+    ".agents/tools/build-mcp/api-wrapper.md": {
+      "at": "2026-03-28T02:51:01Z",
+      "hash": "f0f868a60d97dec2f6f7e21fcdfe4821367aa852",
+      "passes": 1,
+      "pr": 11276
+    },
+    ".agents/tools/build-mcp/api-wrapper/patterns.md": {
+      "at": "2026-03-28T02:51:01Z",
+      "hash": "61c725143000dbb9b43f0b3a716a095203b803df",
+      "passes": 1,
+      "pr": 11276
+    },
+    ".agents/tools/build-mcp/build-mcp.md": {
+      "at": "2026-03-28T13:37:27Z",
+      "hash": "873079bdda167247bcb21398a82608b824779a12",
+      "passes": 1,
+      "pr": 11844
+    },
+    ".agents/tools/build-mcp/deployment.md": {
+      "at": "2026-03-28T22:39:22Z",
+      "hash": "4b975e408909bcf0b78773cb3cbfbf8c2a52f70b",
+      "passes": 1,
+      "pr": 12311
+    },
+    ".agents/tools/build-mcp/server-patterns.md": {
+      "at": "2026-03-28T10:27:33Z",
+      "hash": "bfc7c19fae70a1c4cbbd848769ffb0dcaecdda62",
+      "passes": 1,
+      "pr": 11679
+    },
+    ".agents/tools/build-mcp/transports.md": {
+      "at": "2026-03-29T01:04:08Z",
+      "hash": "7a3f2b50284606d40d5a0054f2616eaf28d45fcc",
+      "passes": 1,
+      "pr": 12394
+    },
+    ".agents/tools/code-review/auditing.md": {
+      "at": "2026-04-02T21:20:13Z",
+      "hash": "786995df145bebba3410fe18838234626e07c6d4",
+      "passes": 2,
+      "pr": 0
+    },
+    ".agents/tools/code-review/automation.md": {
+      "at": "2026-04-03T16:35:38Z",
+      "hash": "b4163a45b9055fce5e2a982235dcc5f352263bad",
+      "passes": 2,
+      "pr": 16628
+    },
+    ".agents/tools/code-review/best-practices.md": {
+      "at": "2026-03-28T13:38:46Z",
+      "hash": "0c29ade476d3841f62cb9533712d681da6ae2595",
+      "passes": 1,
+      "pr": 11771
+    },
+    ".agents/tools/code-review/codacy.md": {
+      "at": "2026-03-29T22:09:31Z",
+      "hash": "01aafc8caf20256e88f011e8a1a051e7357555aa",
+      "passes": 1,
+      "pr": 13314
+    },
+    ".agents/tools/code-review/code-simplifier.md": {
+      "at": "2026-04-15T03:00:44Z",
+      "hash": "48d6c06a8c37b58a88387c2eae0a746a23e2509b",
+      "passes": 9
+    },
+    ".agents/tools/code-review/code-standards.md": {
+      "at": "2026-04-04T03:31:00Z",
+      "hash": "9b1170909ea6121b1f294bd5346d832a06779205",
+      "passes": 2,
+      "pr": 11944
+    },
+    ".agents/tools/code-review/coderabbit.md": {
+      "at": "2026-03-29T07:02:31Z",
+      "hash": "69d1f87e48275fa971a0f6dec502bebe0cc50db6",
+      "passes": 1,
+      "pr": 12589
+    },
+    ".agents/tools/code-review/management.md": {
+      "at": "2026-04-03T11:54:03Z",
+      "hash": "ddb7983369dfdca33cefc3baa63482c6d0f2e4ac",
+      "passes": 1
+    },
+    ".agents/tools/code-review/qlty.md": {
+      "at": "2026-03-28T18:36:46Z",
+      "hash": "1efd73666b9aece920bc691fccdca683ad78e3ac",
+      "passes": 1,
+      "pr": 12114
+    },
+    ".agents/tools/code-review/review-categories.md": {
+      "at": "2026-04-04T03:31:30Z",
+      "hash": "90c3b475500548147e736db43a54aa6aec466561",
+      "passes": 1,
+      "pr": 16977
+    },
+    ".agents/tools/code-review/runtime-patterns.md": {
+      "at": "2026-03-28T13:38:47Z",
+      "hash": "901ab8ff5a2453bd2b806a84df722327e4a6ab2f",
+      "passes": 1,
+      "pr": 11771
+    },
+    ".agents/tools/code-review/secretlint.md": {
+      "at": "2026-03-28T16:00:52Z",
+      "hash": "e4a6d6a16259bb97999ac06cde99bbe904be756e",
+      "passes": 1,
+      "pr": 11991
+    },
+    ".agents/tools/code-review/security-analysis.md": {
+      "at": "2026-03-30T00:32:18Z",
+      "hash": "6240be63597ac67fffdcb5677c62e68a53ba44f0",
+      "passes": 2,
+      "pr": 13467
+    },
+    ".agents/tools/code-review/security-audit.md": {
+      "at": "2026-03-28T17:11:18Z",
+      "hash": "9f9ca79db38da586d60dd90538e05b7b050162be",
+      "passes": 1,
+      "pr": 12029
+    },
+    ".agents/tools/code-review/setup.md": {
+      "at": "2026-04-04T15:34:57Z",
+      "hash": "fb0d5288be7a808f9dc232d229f4dca354745323",
+      "passes": 1,
+      "pr": 17343
+    },
+    ".agents/tools/code-review/skill-scanner.md": {
+      "at": "2026-04-03T11:54:13Z",
+      "hash": "578ab9fcc61d69038a6065ff7cac8bc2a648fee5",
+      "passes": 1,
+      "pr": 16525
+    },
+    ".agents/tools/code-review/snyk.md": {
+      "at": "2026-03-27T21:25:26Z",
+      "hash": "d249aca9ad416fd98854134a3c37503413d83850",
+      "passes": 1,
+      "pr": 11013
+    },
+    ".agents/tools/code-review/tools.md": {
+      "at": "2026-04-03T11:54:15Z",
+      "hash": "f1bda83d2e6ee95af187c2c23b7ef25b91937c3f",
+      "passes": 1,
+      "pr": 16449
+    },
+    ".agents/tools/containers/orbstack.md": {
+      "at": "2026-04-03T14:06:32Z",
+      "hash": "3fcc1ac93fecc22999176d6cdd04dc4bf6a5aea0",
+      "passes": 1,
+      "pr": 16542
+    },
+    ".agents/tools/containers/remote-dispatch.md": {
+      "at": "2026-03-30T04:52:23Z",
+      "hash": "792e35ec950c092145e18222d3afd1f77a380eac",
+      "passes": 2,
+      "pr": 13733
+    },
+    ".agents/tools/context/augment-context-engine.md": {
+      "at": "2026-03-28T16:40:32Z",
+      "hash": "2c75ffb734e667ee415180e4bf754800d08a00fe",
+      "passes": 1,
+      "pr": 12015
+    },
+    ".agents/tools/context/context-builder.md": {
+      "at": "2026-03-29T20:54:03Z",
+      "hash": "6f1d7629b3d1df84f79bca62005fcc5e8c5d394a",
+      "passes": 1,
+      "pr": 13297
+    },
+    ".agents/tools/context/context-guardrails.md": {
+      "at": "2026-03-30T06:49:16Z",
+      "hash": "2d4fd932a5b9b6fdeac7c2c8ecc1c40f2e52f103",
+      "passes": 1,
+      "pr": 13956
+    },
+    ".agents/tools/context/context7-cli.md": {
+      "at": "2026-04-03T19:14:47Z",
+      "hash": "da88cdcbbc81eb432f7585765ba987a57013191f",
+      "passes": 1,
+      "pr": 16756
+    },
+    ".agents/tools/context/context7.md": {
+      "at": "2026-04-13T16:27:46Z",
+      "hash": "edd95da6e383415d7ef6e8b7b0e14dbe6ee90414",
+      "passes": 2,
+      "pr": 12182
+    },
+    ".agents/tools/context/dspy.md": {
+      "at": "2026-03-29T20:53:49Z",
+      "hash": "7f9a09f389697c83217d683b872bd784186f29e6",
+      "passes": 1,
+      "pr": 13289
+    },
+    ".agents/tools/context/dspyground.md": {
+      "at": "2026-04-03T11:54:14Z",
+      "hash": "4aebe68d698c70d88f8e8ac42c653109df99bb73",
+      "passes": 1,
+      "pr": 16494
+    },
+    ".agents/tools/context/github-search.md": {
+      "at": "2026-03-29T16:34:35Z",
+      "hash": "860a4da0e589a63c461aa66f67fa3625fc22ce62",
+      "passes": 1,
+      "pr": 13106
+    },
+    ".agents/tools/context/mcp-discovery.md": {
+      "at": "2026-03-28T03:53:59Z",
+      "hash": "734cc02079eb0568b46be5797268d143006b84ad",
+      "passes": 1,
+      "pr": 11338
+    },
+    ".agents/tools/context/model-routing.md": {
+      "at": "2026-04-15T03:00:45Z",
+      "hash": "3e0983c04ec7097672966a5dbbd11b9e72960a0c",
+      "passes": 4,
+      "pr": 13255
+    },
+    ".agents/tools/context/openapi-search.md": {
+      "at": "2026-04-03T11:54:13Z",
+      "hash": "212dcdecb048f6ca5fb0f7181cfbfc19b13807d6",
+      "passes": 1,
+      "pr": 16513
+    },
+    ".agents/tools/context/pageindex.md": {
+      "at": "2026-04-09T07:32:15Z",
+      "hash": "0e5ba2c8f16ab6362aa6de09ab2e704d534eaf27",
+      "passes": 1,
+      "pr": 17759
+    },
+    ".agents/tools/context/prompt-optimization.md": {
+      "at": "2026-03-29T08:10:39Z",
+      "hash": "fbfa0b2016051c28ea3824e220bc0120bf42d0f1",
+      "passes": 1,
+      "pr": 12749
+    },
+    ".agents/tools/context/rapidfuzz.md": {
+      "at": "2026-04-03T01:53:12Z",
+      "hash": "d16b8b5bc318eaa7bbad698ecec8d690a707cd98",
+      "passes": 3,
+      "pr": 0
+    },
+    ".agents/tools/context/toon.md": {
+      "at": "2026-04-03T13:35:14Z",
+      "hash": "4fda8b1d3df42a7e5594d8ea1e56fb1f0672e192",
+      "passes": 1,
+      "pr": 16572
+    },
+    ".agents/tools/conversion/mineru.md": {
+      "at": "2026-03-28T16:40:36Z",
+      "hash": "75930d518ec83bb6d0c754b0dedd6c37b979bea0",
+      "passes": 1,
+      "pr": 12012
+    },
+    ".agents/tools/conversion/pandoc.md": {
+      "at": "2026-03-28T08:17:47Z",
+      "hash": "d9421beead37a901c86d9bc71e0439d9719b83ab",
+      "passes": 1,
+      "pr": 11595
+    },
+    ".agents/tools/credentials/api-key-management.md": {
+      "at": "2026-04-03T19:14:47Z",
+      "hash": "c72e79807f40dac55d2d3ebf11f029a97016c4ba",
+      "passes": 1,
+      "pr": 16751
+    },
+    ".agents/tools/credentials/api-key-setup.md": {
+      "at": "2026-03-29T20:53:50Z",
+      "hash": "e9cf962d2aeca82d03509b87cf40e9ba19e258d3",
+      "passes": 1,
+      "pr": 13279
+    },
+    ".agents/tools/credentials/auth-troubleshooting.md": {
+      "at": "2026-04-09T07:32:10Z",
+      "hash": "d1dcacfa938afdbf4ce81c8da0c444354b2576f1",
+      "passes": 2,
+      "pr": 16582
+    },
+    ".agents/tools/credentials/bitwarden.md": {
+      "at": "2026-04-02T04:56:56Z",
+      "hash": "618c25febf09882ac5a02746ecaf46b787dbeace",
+      "passes": 1,
+      "pr": 15468
+    },
+    ".agents/tools/credentials/cch-reverse-engineering.md": {
+      "at": "2026-04-13T16:27:47Z",
+      "hash": "f5455c7d7ef29929c53715de3403db074ac216f0",
+      "passes": 2,
+      "pr": 17294
+    },
+    ".agents/tools/credentials/encryption-stack.md": {
+      "at": "2026-04-03T01:11:47Z",
+      "hash": "0e132ab131599566cb025d3316b3b69623f0b3f3",
+      "passes": 1,
+      "pr": 15780
     },
     ".agents/tools/credentials/enpass.md": {
-      "hash": "2441c12e09f8a53e99673b6f7501d46625699360",
       "at": "2026-04-03T16:35:54Z",
+      "hash": "2441c12e09f8a53e99673b6f7501d46625699360",
       "passes": 1,
       "pr": 16653
     },
+    ".agents/tools/credentials/environment-variables.md": {
+      "at": "2026-03-29T08:10:40Z",
+      "hash": "12e46584ed8b1b904240cf6af8e8d9760c9cefee",
+      "passes": 1,
+      "pr": 12751
+    },
+    ".agents/tools/credentials/gocryptfs.md": {
+      "at": "2026-03-28T11:20:36Z",
+      "hash": "3ee75226230f5c793309a7ea7f3e41f4d835a5c0",
+      "passes": 1,
+      "pr": 11730
+    },
+    ".agents/tools/credentials/gopass.md": {
+      "at": "2026-03-27T21:25:05Z",
+      "hash": "59ff08b87e1a0ba820fda337b644b514b6cee226",
+      "passes": 1,
+      "pr": 11021
+    },
     ".agents/tools/credentials/list-keys.md": {
-      "hash": "d21c7c76cde04225ad1ce83b85dfc9403dac6fdd",
       "at": "2026-04-03T16:35:54Z",
+      "hash": "d21c7c76cde04225ad1ce83b85dfc9403dac6fdd",
       "passes": 1,
       "pr": 16652
     },
-    ".agents/services/monitoring/sentry.md": {
-      "hash": "7a4028ba64d1cdc2727e95af25b070c76b16bec4",
-      "at": "2026-04-13T16:27:41Z",
+    ".agents/tools/credentials/multi-tenant.md": {
+      "at": "2026-03-27T21:25:16Z",
+      "hash": "8ac890ca5a17ff43199605c1535cf9c75dfea959",
+      "passes": 1,
+      "pr": 11008
+    },
+    ".agents/tools/credentials/psst.md": {
+      "at": "2026-03-31T06:15:51Z",
+      "hash": "8eab2c11c431a98847a9928effe9d80b9e4c3d4a",
       "passes": 2,
-      "pr": 16651
+      "pr": 14687
     },
-    ".agents/scripts/dispatch-dedup-helper.sh": {
-      "hash": "1c1ba50e50a17b4d2232a1f7620e3b5455a12e96",
-      "at": "2026-04-14T20:16:59Z",
-      "pr": 18917,
-      "passes": 13
-    },
-    ".agents/tools/ocr/overview.md": {
-      "hash": "6dedb5ff5ef2e5d4288b956494a2bfc34b15b864",
-      "at": "2026-04-03T16:35:54Z",
+    ".agents/tools/credentials/sops.md": {
+      "at": "2026-03-28T08:58:29Z",
+      "hash": "242c935bf4572435bea49c1651349fc42458644a",
       "passes": 1,
-      "pr": 16637
+      "pr": 11560
     },
-    ".agents/marketing-sales/direct-response-copy-swipe-file-landing-pages-01-saas-examples.md": {
-      "hash": "b8e956f50f59b28fd65d94290a863552f472b6b1",
-      "at": "2026-04-03T16:35:54Z",
+    ".agents/tools/credentials/vaultwarden.md": {
+      "at": "2026-03-29T12:36:43Z",
+      "hash": "b536921e7faf02fe400ba6c678a36bbd7765b725",
       "passes": 1,
-      "pr": 16636
+      "pr": 12951
     },
-    ".agents/services/outreach/cold-outreach.md": {
-      "hash": "9d11fb2e7b2152aa011c6093fd0d61a1854751d6",
-      "at": "2026-04-03T16:35:54Z",
+    ".agents/tools/data-extraction/outscraper.md": {
+      "at": "2026-03-28T16:41:16Z",
+      "hash": "a83bf48997b1e46e3a8038fb30fd21e75d28a70e",
       "passes": 1,
-      "pr": 16635
+      "pr": 12021
     },
-    ".agents/seo/upscale.md": {
-      "hash": "9c9fd44ad9199fa426629726def1e5dde95be2c3",
-      "at": "2026-04-03T16:35:55Z",
+    ".agents/tools/database/pglite-local-first.md": {
+      "at": "2026-03-28T15:30:29Z",
+      "hash": "4f8f1fd157711a0f805aa897d7510fe5c7e833fa",
       "passes": 1,
-      "pr": 16627
+      "pr": 11920
     },
-    ".agents/content/production-video-02-sora-template.md": {
-      "hash": "6ed53879e11be03a1f63e996fe507171f0e292ce",
-      "at": "2026-04-03T19:14:11Z",
-      "passes": 1
+    ".agents/tools/database/vector-search.md": {
+      "at": "2026-03-28T03:54:19Z",
+      "hash": "1bdab72f7af2a4287447f77c2b078cd7c0e3d7a0",
+      "passes": 1,
+      "pr": 11351
     },
-    ".agents/marketing-sales/direct-response-copy-checklists-headline-testing.md": {
-      "hash": "db3a14db885f9d327079a5f92d004c8f8ecd5045",
-      "at": "2026-04-03T19:14:14Z",
+    ".agents/tools/database/vector-search/per-tenant-rag.md": {
+      "at": "2026-03-28T06:40:00Z",
+      "hash": "c6eb07a518cd007412e5e958ffee877911ea34bc",
+      "passes": 1,
+      "pr": 11417
+    },
+    ".agents/tools/database/vector-search/zvec.md": {
+      "at": "2026-03-28T08:17:41Z",
+      "hash": "74a17ede0fa42057c6e982a7cf383fe0ca139022",
+      "passes": 1,
+      "pr": 11570
+    },
+    ".agents/tools/deployment/agent-skills.md": {
+      "at": "2026-04-03T11:54:13Z",
+      "hash": "ec5297839376b1dc877db00180c3ca671de341d8",
+      "passes": 1,
+      "pr": 16540
+    },
+    ".agents/tools/deployment/cloudron-app-packaging-skill.md": {
+      "at": "2026-04-02T20:39:36Z",
+      "hash": "1f64ebaf8c35b127e676cfe1dce1c08af1815168",
       "passes": 2,
-      "pr": "pending"
+      "pr": 14880
     },
-    ".agents/seo/geo-strategy.md": {
-      "hash": "c1018d8590e58e3fd4852c1014fa58de1320d3cf",
-      "at": "2026-04-03T20:00:32Z",
-      "passes": 3,
-      "pr": "pending"
-    },
-    ".agents/seo/serper.md": {
-      "hash": "7f19897bff63bea81a0247a5687370484a99f05b",
-      "at": "2026-04-03T19:14:22Z",
-      "passes": 1
-    },
-    ".agents/tools/pdf/overview.md": {
-      "hash": "babee66734537f444f3fdc63ff198e1738493924",
-      "at": "2026-04-03T19:14:40Z",
-      "passes": 1
-    },
-    ".agents/tools/ui/ui-skills.md": {
-      "hash": "523286e313aee9bc39321d092c06aca4a062dee0",
-      "at": "2026-04-03T22:25:53Z",
-      "passes": 3,
-      "pr": 16281
-    },
-    ".agents/workflows/pre-edit.md": {
-      "hash": "6b0e3f4690afdb4c0d13d0d429d704c4e9544074",
-      "at": "2026-04-03T20:43:55Z",
-      "passes": 2
-    },
-    ".agents/tools/video/remotion-trimming.md": {
-      "hash": "980b73f9ec656bf4cd9bc0f0ce6c07a86da00773",
-      "at": "2026-04-03T19:14:42Z",
-      "passes": 2,
-      "pr": null,
-      "issue": 16798
-    },
-    ".agents/aidevops/docs.md": {
-      "hash": "e0e1c0c4ff9224285ef30fa1f219801fac5a1d65",
-      "at": "2026-04-03T19:14:46Z",
-      "pr": 16822,
-      "passes": 1
-    },
-    ".agents/tools/video/remotion-get-video-duration.md": {
-      "hash": "ad13f0e40374ea952fc79fa32b86880669d9da67",
-      "at": "2026-04-03T19:14:46Z",
-      "pr": 16805,
-      "passes": 1
-    },
-    ".agents/scripts/commands/email-campaign.md": {
-      "hash": "a04ab6e1ffb2b87702ad037a773e7e330cee05ea",
-      "at": "2026-04-03T19:14:46Z",
-      "pr": 16804,
-      "passes": 1
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/wrangler-gotchas.md": {
-      "hash": "7c65f8f17378978898a8ff6d08e128a98e1a7011",
-      "at": "2026-04-03T19:14:46Z",
-      "pr": 16803,
-      "passes": 1
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/zaraz-patterns.md": {
-      "hash": "f77677b3bd3fa9125f7952b43ab3c7f366ba8c24",
-      "at": "2026-04-03T19:14:46Z",
-      "pr": 16799,
-      "passes": 1
-    },
-    ".agents/scripts/commands/findings-to-tasks.md": {
-      "hash": "8803d261cda3f68f7a2a94d29d29a91d88a38c3b",
-      "at": "2026-04-03T22:25:11Z",
-      "pr": 16797,
-      "passes": 2
-    },
-    ".agents/tools/mobile/axe-cli.md": {
-      "hash": "3d0cf750b1b76b4881c685db8feb0be255e098fe",
-      "at": "2026-04-03T19:14:46Z",
-      "pr": 16795,
-      "passes": 1
-    },
-    ".agents/tools/productivity/calendar.md": {
-      "hash": "55583a8d44bdfd776d1c3e956813dedeebd04c27",
-      "at": "2026-04-03T19:14:46Z",
-      "pr": 16790,
-      "passes": 1
-    },
-    ".agents/seo/schema-validator.md": {
-      "hash": "b9d51a4ed48477ce7053839e3a9561dc9cdaaca5",
-      "at": "2026-04-03T19:14:46Z",
-      "pr": 16757,
-      "passes": 1
-    },
-    ".agents/tools/context/context7-cli.md": {
-      "hash": "da88cdcbbc81eb432f7585765ba987a57013191f",
-      "at": "2026-04-03T19:14:47Z",
-      "pr": 16756,
-      "passes": 1
-    },
-    ".agents/tools/wordpress.md": {
-      "hash": "1cf0fd554e77ed5b826566a63c93a52ee9911cbb",
-      "at": "2026-04-03T19:14:47Z",
-      "pr": 16755,
-      "passes": 1
-    },
-    ".agents/aidevops/graduated-learnings.md": {
-      "hash": "a8a3e687e971f72f483c8c6ea397dc19f60e0ed8",
-      "at": "2026-04-03T19:14:47Z",
-      "pr": 16754,
-      "passes": 1
-    },
-    ".agents/tools/video/remotion-can-decode.md": {
-      "hash": "cf254acfb0dd412f218fed7fd587ad63ab877592",
-      "at": "2026-04-03T19:14:47Z",
-      "pr": 16753,
-      "passes": 1
-    },
-    ".agents/tools/credentials/api-key-management.md": {
-      "hash": "c72e79807f40dac55d2d3ebf11f029a97016c4ba",
-      "at": "2026-04-03T19:14:47Z",
-      "pr": 16751,
-      "passes": 1
-    },
-    ".agents/tools/productivity/caldav-calendar-skill.md": {
-      "hash": "e4b4104505e1bee3c23b7aecb805ef5fad38252b",
-      "at": "2026-04-03T19:14:47Z",
-      "pr": 16750,
-      "passes": 1
-    },
-    ".agents/aidevops/setup.md": {
-      "hash": "7d116c37d7cf28b5f444bd5b0871e6d5da12a184",
-      "at": "2026-04-03T19:14:47Z",
-      "pr": 16749,
-      "passes": 1
-    },
-    ".agents/seo/sro-grounding.md": {
-      "hash": "32473a58d5d1db494a426ec744b5998eaaa56a4f",
-      "at": "2026-04-03T19:14:47Z",
-      "pr": 16734,
-      "passes": 1
-    },
-    ".agents/workflows/changelog.md": {
-      "hash": "58549e6adba56863232aab40ac34c1a2e51822de",
-      "at": "2026-04-03T19:14:47Z",
-      "pr": 16733,
-      "passes": 1
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/d1.md": {
-      "hash": "65df3b4237c75add161b1a2131383cc265d23dc8",
-      "at": "2026-04-03T19:14:47Z",
-      "pr": 16730,
-      "passes": 1
-    },
-    ".agents/tools/ai-assistants/models-opus.md": {
-      "hash": "1594303319230800e8af3bdf93a94a6051a6b038",
-      "at": "2026-04-03T20:00:54Z",
-      "pr": 16821,
-      "passes": 1
-    },
-    ".agents/tools/opencode/opencode-openai-auth.md": {
-      "hash": "954661f8ba7b46b129a1a1e2f2a25e1d41a91545",
-      "at": "2026-04-03T20:28:52Z",
-      "pr": 16788,
-      "passes": 1
-    },
-    ".agents/workflows/branch/feature.md": {
-      "hash": "81462109adc9e74e968d80c9bb2d2cefad077c04",
-      "at": "2026-04-03T22:25:55Z",
-      "pr": 16865,
-      "passes": 1
-    },
-    ".agents/tools/design/library/styles/corporate-friendly/DESIGN.md": {
-      "hash": "da743c5d75b2effed47d4ce0d239807614c580c3",
-      "at": "2026-04-03T22:56:47Z",
-      "status": "simplified",
-      "issue": 16884,
-      "passes": 1
-    },
-    ".agents/tools/design/library/styles/luxury-premium/DESIGN.md": {
-      "hash": "2d625cf22e63e62d0d04198763b2834244b54a3e",
-      "at": "2026-04-03T22:57:35Z",
-      "pr": 16883,
-      "passes": 1
-    },
-    ".agents/tools/design/library/styles/editorial-clean/DESIGN.md": {
-      "hash": "23c64b436b3b80a49b2451f890de202f9357e4d5",
-      "at": "2026-04-03T22:57:36Z",
-      "pr": 16882,
-      "passes": 1
-    },
-    ".agents/scripts/design-preview-helper.sh": {
-      "hash": "fb72927eeb79b85ca1a2ce802de5eebb04871d40",
-      "at": "2026-04-15T21:02:38Z",
-      "pr": 16879,
-      "passes": 4
-    },
-    ".agents/tools/design/library/styles/playful-vibrant/DESIGN.md": {
-      "hash": "f42502be75dfeee3f716f54b3ea2d8e6697414a6",
-      "at": "2026-04-03T23:09:04Z",
-      "pr": "16889",
-      "passes": 3
-    },
-    ".agents/tools/design/library/styles/startup-bold/DESIGN.md": {
-      "hash": "277fd4c89e051686308cba0124c8c0559b5cb7be",
-      "at": "2026-04-04T00:16:00Z",
+    ".agents/tools/deployment/cloudron-app-packaging-skill/addons-ref.md": {
+      "at": "2026-03-29T10:18:21Z",
+      "hash": "b6b3597fddd766dd20cd018daf7732311dc89bdb",
       "passes": 1,
-      "pr": 16893
+      "pr": 12844
     },
-    ".agents/tools/design/library/brands/vercel/DESIGN.md": {
-      "hash": "71545bb65f1d5af4909bd639b88c17f4592ecba9",
-      "at": "2026-04-04T01:35:11Z",
-      "status": "restructured",
-      "issue": 16956,
-      "pr": 16947,
-      "passes": 1
-    },
-    ".agents/tools/design/library/brands/cursor/DESIGN.md": {
-      "hash": "d22ec9638e3618818b7fc475d6552d73eb025971",
-      "at": "2026-04-04T00:00:00Z",
+    ".agents/tools/deployment/cloudron-app-packaging-skill/manifest-ref.md": {
+      "at": "2026-04-02T00:00:00Z",
+      "hash": "0767ed536252969006d7448901799141cb4c1799",
       "passes": 1,
       "pr": 0
     },
+    ".agents/tools/deployment/cloudron-app-packaging.md": {
+      "at": "2026-03-28T03:54:01Z",
+      "hash": "ee098e42ce7866f6c6c80dd0cf0a9bbd8d3f789d",
+      "passes": 1,
+      "pr": 11344
+    },
+    ".agents/tools/deployment/cloudron-app-publishing-skill.md": {
+      "at": "2026-04-03T04:22:59Z",
+      "hash": "89ac1588620c0c72f3589b63f83cc231bed32c3e",
+      "passes": 2,
+      "pr": 15497
+    },
+    ".agents/tools/deployment/cloudron-git-reference.md": {
+      "at": "2026-04-03T11:54:14Z",
+      "hash": "8858d1a860bcd9c844956e15fd2da3f5e703bacf",
+      "passes": 1,
+      "pr": 16478
+    },
+    ".agents/tools/deployment/cloudron-server-ops-skill.md": {
+      "at": "2026-03-30T03:33:52Z",
+      "hash": "2b286bda289b02298ca6d38aaf97440394e6c99f",
+      "passes": 2,
+      "pr": 13678
+    },
+    ".agents/tools/deployment/coolify-cli.md": {
+      "at": "2026-03-30T04:52:05Z",
+      "hash": "9653a4527f1f3f96d745aef5be254e8419264be1",
+      "passes": 1,
+      "pr": 13734
+    },
+    ".agents/tools/deployment/coolify-setup.md": {
+      "at": "2026-03-29T15:50:41Z",
+      "hash": "8e2e94d8af3faaea2e154da1b521c297f7a4415b",
+      "passes": 2,
+      "pr": 13067
+    },
+    ".agents/tools/deployment/coolify.md": {
+      "at": "2026-03-29T08:10:34Z",
+      "hash": "e87e98b92f8842f559c924b04290b1f76a3ebddb",
+      "passes": 1,
+      "pr": 12748
+    },
+    ".agents/tools/deployment/daytona.md": {
+      "at": "2026-03-28T13:37:28Z",
+      "hash": "d3aeca4a230f561753082a4a9d5943d119c7735a",
+      "passes": 1,
+      "pr": 11846
+    },
+    ".agents/tools/deployment/fly-io.md": {
+      "at": "2026-03-30T02:30:21Z",
+      "hash": "706bc0d44992fe77a378eb081e8dc5bded66eaec",
+      "passes": 1,
+      "pr": 13596
+    },
+    ".agents/tools/deployment/hosting-comparison.md": {
+      "at": "2026-03-29T07:02:09Z",
+      "hash": "5ec33ae6dd9e7bd05662585559f09e44e210fc3c",
+      "passes": 1,
+      "pr": 12661
+    },
+    ".agents/tools/deployment/uncloud.md": {
+      "at": "2026-03-28T09:17:40Z",
+      "hash": "7686567bc178c7e1f996de62a1d8dca5c2dc8765",
+      "passes": 1,
+      "pr": 11712
+    },
+    ".agents/tools/deployment/vercel.md": {
+      "at": "2026-03-28T08:58:54Z",
+      "hash": "2cf1aacf6259cd4f4317ed37ab17304e8def432e",
+      "passes": 1,
+      "pr": 11615
+    },
+    ".agents/tools/design/brand-identity.md": {
+      "at": "2026-04-03T22:25:45Z",
+      "hash": "fd3c844341eee1331678b371b5a8103797924c7e",
+      "passes": 2,
+      "pr": 13093
+    },
+    ".agents/tools/design/colour-palette.md": {
+      "at": "2026-04-04T03:31:29Z",
+      "hash": "dc89ad0ba62b65a9e4c2456f496e30182777754a",
+      "passes": 1,
+      "pr": 17012
+    },
+    ".agents/tools/design/design-inspiration.md": {
+      "at": "2026-04-03T22:25:45Z",
+      "hash": "ca5f75dc5368e75e87e0774fb75cf1bf72a1284b",
+      "passes": 2,
+      "pr": 12754
+    },
     ".agents/tools/design/design-md.md": {
-      "hash": "000ee246227aa79c49c6e269b6a23cea15f573e2",
       "at": "2026-04-04T02:30:00Z",
+      "hash": "000ee246227aa79c49c6e269b6a23cea15f573e2",
       "issue": 16952,
       "passes": 1,
       "pr": 16966
     },
-    ".agents/tools/design/library/brands/cal/DESIGN.md": {
-      "hash": "773908bca73a38fffe6dcf14563b467e32003573",
-      "at": "2026-04-04T02:13:59Z",
-      "passes": 3,
-      "pr": 0
-    },
-    ".agents/tools/design/library/brands/mistral.ai/DESIGN.md": {
-      "hash": "90dfb4cb476a4dbe1b834f4c8d1413dec911bd73",
-      "at": "2026-04-04T02:13:59Z",
-      "passes": 3,
-      "pr": 0
-    },
-    ".agents/tools/design/library/brands/replicate/DESIGN.md": {
-      "hash": "69fe4364e6000a2cdba3b787a1ddd592cbf5fb01",
-      "at": "2026-04-04T02:13:59Z",
-      "passes": 3,
-      "pr": 0
-    },
-    ".agents/tools/design/library/brands/posthog/DESIGN.md": {
-      "hash": "67af9d87c4957feb2584c091a6010807d5c596ea",
-      "at": "2026-04-04T02:13:59Z",
-      "passes": 3,
-      "pr": 0
-    },
-    ".agents/tools/design/library/brands/sentry/DESIGN.md": {
-      "hash": "1eadfe81abf8cf4d0571dbd4a2559783bfd59007",
-      "at": "2026-04-04T02:13:59Z",
-      "passes": 3,
-      "pr": 0
-    },
-    ".agents/tools/design/library/brands/ollama/DESIGN.md": {
-      "hash": "1a25915c009a0aff5baa089de809075c1ea5b72c",
-      "at": "2026-04-04T02:13:59Z",
-      "passes": 3,
-      "pr": 0
-    },
-    ".agents/tools/design/library/brands/cohere/DESIGN.md": {
-      "hash": "922c332329a8b625d53e6c92a64e2157b121c08d",
-      "at": "2026-04-04T02:13:59Z",
-      "passes": 3,
-      "pr": 0
-    },
-    ".agents/tools/design/library/brands/mongodb/DESIGN.md": {
-      "hash": "50e54841e0a51bafa2b6aaf1a75ec9da72e4e985",
-      "at": "2026-04-04T02:13:59Z",
-      "passes": 3,
-      "pr": 0
-    },
-    ".agents/tools/design/library/brands/elevenlabs/DESIGN.md": {
-      "hash": "1553bc7c52cdb835dec52db1b9437d1e38fe45e2",
-      "at": "2026-04-04T02:13:59Z",
-      "passes": 3,
-      "pr": 0
-    },
-    ".agents/tools/design/library/brands/together.ai/DESIGN.md": {
-      "hash": "f68d7a7121d535b45a2ad53733af9ab6f59415d5",
-      "at": "2026-04-04T02:13:59Z",
-      "passes": 3,
-      "pr": 0
-    },
-    ".agents/tools/design/library/styles/developer-dark/DESIGN.md": {
-      "hash": "219549468a3add04b6431c9945c9aebe563fe425",
-      "at": "2026-04-04T14:53:40Z",
-      "passes": 4,
-      "pr": 0
-    },
     ".agents/tools/design/library/brands/airbnb/DESIGN.md": {
-      "hash": "e92d62859150529fbe91d712c93b795de4859a42",
       "at": "2026-04-04T02:14:32Z",
+      "hash": "e92d62859150529fbe91d712c93b795de4859a42",
       "passes": 3,
       "pr": 0
     },
     ".agents/tools/design/library/brands/airtable/DESIGN.md": {
-      "hash": "673d75d2eb66d16bddbeca11d86cae48feb34e85",
       "at": "2026-04-04T02:14:32Z",
+      "hash": "673d75d2eb66d16bddbeca11d86cae48feb34e85",
       "passes": 3,
       "pr": 0
+    },
+    ".agents/tools/design/library/brands/apple/04-components.md": {
+      "at": "2026-04-04T04:52:51Z",
+      "hash": "96cd94a2148c4754612187b74473c3b55d3f7d0c",
+      "passes": 1,
+      "pr": "17061"
+    },
+    ".agents/tools/design/library/brands/apple/DESIGN.md": {
+      "at": "2026-04-04T03:31:32Z",
+      "hash": "3a05d16ee4ac4f6e7ce5563014e60d0a58942c36",
+      "passes": 1,
+      "pr": 16935
     },
     ".agents/tools/design/library/brands/bmw/DESIGN.md": {
-      "hash": "6d8d96a4e6c1eec4a133fa3c15b6a35dbd42cac9",
       "at": "2026-04-04T02:14:32Z",
+      "hash": "6d8d96a4e6c1eec4a133fa3c15b6a35dbd42cac9",
       "passes": 3,
       "pr": 0
     },
+    ".agents/tools/design/library/brands/cal/DESIGN.md": {
+      "at": "2026-04-04T02:13:59Z",
+      "hash": "773908bca73a38fffe6dcf14563b467e32003573",
+      "passes": 3,
+      "pr": 0
+    },
+    ".agents/tools/design/library/brands/claude/04-components.md": {
+      "at": "2026-04-04T14:54:16Z",
+      "hash": "af40eeaf62adcd487b783d345ae02cbf61805789",
+      "passes": 1,
+      "pr": 17241
+    },
+    ".agents/tools/design/library/brands/claude/05-layout.md": {
+      "at": "2026-04-04T14:54:15Z",
+      "hash": "2ee2025b7d167573809f27095b93cd2bf2bc1937",
+      "passes": 1,
+      "pr": 17251
+    },
+    ".agents/tools/design/library/brands/claude/DESIGN.md": {
+      "at": "2026-04-04T03:31:32Z",
+      "hash": "0ddd5acd4ddb0c16133b3f50c7d785fa66a7686e",
+      "passes": 1,
+      "pr": 16934
+    },
+    ".agents/tools/design/library/brands/clay/02-color-palette.md": {
+      "at": "2026-04-04T14:54:15Z",
+      "hash": "e1dd3a054cbfc5c78d9c4ee208413787b46330ed",
+      "passes": 1,
+      "pr": 17252
+    },
+    ".agents/tools/design/library/brands/clay/04-components.md": {
+      "at": "2026-04-04T14:53:34Z",
+      "hash": "61aad30e636ccaa3c9ac886b17e8cf8e2ab1ab6c",
+      "passes": 2,
+      "pr": 17267
+    },
+    ".agents/tools/design/library/brands/clay/DESIGN.md": {
+      "at": "2026-04-04T03:31:31Z",
+      "hash": "f8e6eaba04542bc4c2fceb6da793b9a83713ea5d",
+      "passes": 1,
+      "pr": 16954
+    },
+    ".agents/tools/design/library/brands/clickhouse/04-components.md": {
+      "at": "2026-04-04T14:53:34Z",
+      "hash": "e4d0797834ea9ca4d5fbbad24fbee6030f51c094",
+      "issue": "GH#17237",
+      "lines_after": 57,
+      "lines_before": 89,
+      "passes": 1
+    },
     ".agents/tools/design/library/brands/clickhouse/DESIGN.md": {
-      "hash": "3b575d72112d1c24f4cb1d78571498b503060f5d",
       "at": "2026-04-04T02:14:32Z",
+      "hash": "3b575d72112d1c24f4cb1d78571498b503060f5d",
+      "passes": 3,
+      "pr": 0
+    },
+    ".agents/tools/design/library/brands/cohere/DESIGN.md": {
+      "at": "2026-04-04T02:13:59Z",
+      "hash": "922c332329a8b625d53e6c92a64e2157b121c08d",
       "passes": 3,
       "pr": 0
     },
     ".agents/tools/design/library/brands/coinbase/DESIGN.md": {
-      "hash": "4149e3bf1989d528b47e2d79ddd91e6a9268d471",
       "at": "2026-04-04T02:14:32Z",
+      "hash": "4149e3bf1989d528b47e2d79ddd91e6a9268d471",
       "passes": 3,
       "pr": 0
     },
+    ".agents/tools/design/library/brands/composio/04-components.md": {
+      "at": "2026-04-04T15:34:57Z",
+      "hash": "0c5045bca1d19159413918d402960e4735ae7cca",
+      "passes": 1,
+      "pr": 17341
+    },
+    ".agents/tools/design/library/brands/composio/DESIGN.md": {
+      "at": "2026-04-04T03:31:31Z",
+      "hash": "dc7159b2ad198b911677cf16f313432aeadd0012",
+      "passes": 1,
+      "pr": 16951
+    },
+    ".agents/tools/design/library/brands/cursor/DESIGN.md": {
+      "at": "2026-04-04T00:00:00Z",
+      "hash": "d22ec9638e3618818b7fc475d6552d73eb025971",
+      "passes": 1,
+      "pr": 0
+    },
+    ".agents/tools/design/library/brands/elevenlabs/DESIGN.md": {
+      "at": "2026-04-04T02:13:59Z",
+      "hash": "1553bc7c52cdb835dec52db1b9437d1e38fe45e2",
+      "passes": 3,
+      "pr": 0
+    },
+    ".agents/tools/design/library/brands/expo/04-components.md": {
+      "at": "2026-04-04T14:53:35Z",
+      "hash": "f63874cc01ae8e6248a0ca8c870ad58a18503a82",
+      "issue": "GH#17088",
+      "lines": 82,
+      "passes": 1
+    },
+    ".agents/tools/design/library/brands/expo/DESIGN.md": {
+      "at": "2026-04-04T03:31:30Z",
+      "hash": "9ee9e2d9a995347973d7caf44e828f08aa1139ed",
+      "passes": 1,
+      "pr": 16960
+    },
     ".agents/tools/design/library/brands/figma/DESIGN.md": {
-      "hash": "51e4caca304033bbab4e1eb92bd22bac3575f63d",
       "at": "2026-04-04T02:14:32Z",
+      "hash": "51e4caca304033bbab4e1eb92bd22bac3575f63d",
       "passes": 3,
       "pr": 0
     },
     ".agents/tools/design/library/brands/framer/DESIGN.md": {
-      "hash": "127dd4e4b8fd460bb1a72d3db3fbb797801043a5",
       "at": "2026-04-04T02:14:32Z",
+      "hash": "127dd4e4b8fd460bb1a72d3db3fbb797801043a5",
       "passes": 3,
       "pr": 0
     },
+    ".agents/tools/design/library/brands/hashicorp/04-components.md": {
+      "at": "2026-04-04T14:53:35Z",
+      "hash": "3fd463f6862b32fb06907f77eb9f4b9d67defd53",
+      "passes": 2
+    },
+    ".agents/tools/design/library/brands/hashicorp/DESIGN.md": {
+      "at": "2026-04-04T03:31:30Z",
+      "hash": "ac7c8e37a0a70bc23e49a7c76113e0c9168a8554",
+      "passes": 1,
+      "pr": 16974
+    },
+    ".agents/tools/design/library/brands/ibm/04-components.md": {
+      "at": "2026-04-04T14:54:08Z",
+      "hash": "2ea28505b2fd0a5fd905570cc9911cd6e8f8cdfc",
+      "passes": 1,
+      "pr": 17332
+    },
     ".agents/tools/design/library/brands/intercom/DESIGN.md": {
-      "hash": "9bc6b0900d396f11125966ff7041fa918d027cfd",
       "at": "2026-04-04T02:14:32Z",
+      "hash": "9bc6b0900d396f11125966ff7041fa918d027cfd",
       "passes": 3,
       "pr": 0
     },
     ".agents/tools/design/library/brands/kraken/DESIGN.md": {
-      "hash": "ab3ae55ac4f773c9757c55d186beea22857c5d4b",
       "at": "2026-04-04T02:14:32Z",
+      "hash": "ab3ae55ac4f773c9757c55d186beea22857c5d4b",
       "passes": 3,
       "pr": 0
+    },
+    ".agents/tools/design/library/brands/linear/02-colour-palette.md": {
+      "at": "2026-04-04T14:54:13Z",
+      "hash": "899a584bd0b79aaa333c96504a162f457638eda5",
+      "passes": 1,
+      "pr": 17279
+    },
+    ".agents/tools/design/library/brands/linear/04-components.md": {
+      "at": "2026-04-04T14:54:11Z",
+      "hash": "fa506cfae29a0ffc90af44e498d4e3bbbf6ac4c1",
+      "passes": 1,
+      "pr": 17297
+    },
+    ".agents/tools/design/library/brands/lovable/04-components.md": {
+      "at": "2026-04-04T14:54:09Z",
+      "hash": "7d5356d99a15fa19ad48c85f1d0dfef5d0f0567b",
+      "passes": 1,
+      "pr": 17318
+    },
+    ".agents/tools/design/library/brands/lovable/DESIGN.md": {
+      "at": "2026-04-04T03:31:30Z",
+      "hash": "52d048d030d625aea29bc383e09f7fa50c389ed7",
+      "passes": 1,
+      "pr": 16955
     },
     ".agents/tools/design/library/brands/minimax/DESIGN.md": {
-      "hash": "9d56e31074033fd01041d10c1b5843cda478d2be",
       "at": "2026-04-04T02:14:32Z",
+      "hash": "9d56e31074033fd01041d10c1b5843cda478d2be",
       "passes": 3,
       "pr": 0
     },
+    ".agents/tools/design/library/brands/mintlify/04-components.md": {
+      "at": "2026-04-04T14:53:36Z",
+      "hash": "a841d19a09e3cb6e80b676ce8a479db679cfe892",
+      "passes": 2,
+      "pr": 17022
+    },
+    ".agents/tools/design/library/brands/mintlify/DESIGN.md": {
+      "at": "2026-04-04T03:31:32Z",
+      "hash": "4696cd2a55691cc59382d332230b1769f55c9723",
+      "passes": 1,
+      "pr": 16929
+    },
     ".agents/tools/design/library/brands/miro/DESIGN.md": {
-      "hash": "0e149867f3ec01c4a54a50baf685923835f23cdd",
       "at": "2026-04-04T02:14:32Z",
+      "hash": "0e149867f3ec01c4a54a50baf685923835f23cdd",
       "passes": 3,
+      "pr": 0
+    },
+    ".agents/tools/design/library/brands/mistral.ai/DESIGN.md": {
+      "at": "2026-04-04T02:13:59Z",
+      "hash": "90dfb4cb476a4dbe1b834f4c8d1413dec911bd73",
+      "passes": 3,
+      "pr": 0
+    },
+    ".agents/tools/design/library/brands/mongodb/04-components.md": {
+      "at": "2026-04-04T14:54:14Z",
+      "hash": "313a10856fb179b870a63e63b645b324990711a2",
+      "passes": 1,
+      "pr": 17254
+    },
+    ".agents/tools/design/library/brands/mongodb/DESIGN.md": {
+      "at": "2026-04-04T02:13:59Z",
+      "hash": "50e54841e0a51bafa2b6aaf1a75ec9da72e4e985",
+      "passes": 3,
+      "pr": 0
+    },
+    ".agents/tools/design/library/brands/notion/DESIGN.md": {
+      "at": "2026-04-04T03:31:32Z",
+      "hash": "d1d2796c5063493ff760008a732c0b1f51a63a6c",
+      "passes": 1,
+      "pr": 16938
+    },
+    ".agents/tools/design/library/brands/nvidia/02-color-palette.md": {
+      "at": "2026-04-04T14:54:12Z",
+      "hash": "3b5ff6b20e796af78ef3d2ddb3e0442148a59be6",
+      "passes": 1,
+      "pr": 17296
+    },
+    ".agents/tools/design/library/brands/nvidia/04-components.md": {
+      "at": "2026-04-04T14:54:15Z",
+      "hash": "b387cc195bceb43163a9230e6efd4e67dcab755a",
+      "passes": 1,
+      "pr": 17253
+    },
+    ".agents/tools/design/library/brands/nvidia/08-responsive.md": {
+      "at": "2026-04-04T00:00:00Z",
+      "hash": "96c3efbd674eb1018e98362eb46728faf459e014",
+      "passes": 1,
       "pr": 0
     },
     ".agents/tools/design/library/brands/nvidia/DESIGN.md": {
-      "hash": "5d7682148fb0a7b7ee6d9e1b695361c80a27b5ff",
       "at": "2026-04-04T02:14:32Z",
+      "hash": "5d7682148fb0a7b7ee6d9e1b695361c80a27b5ff",
       "passes": 3,
       "pr": 0
+    },
+    ".agents/tools/design/library/brands/ollama/DESIGN.md": {
+      "at": "2026-04-04T02:13:59Z",
+      "hash": "1a25915c009a0aff5baa089de809075c1ea5b72c",
+      "passes": 3,
+      "pr": 0
+    },
+    ".agents/tools/design/library/brands/opencode.ai/04-components.md": {
+      "at": "2026-04-04T14:54:14Z",
+      "hash": "d37acef0834027b351417bb9cc6fdaaead2399a6",
+      "passes": 1,
+      "pr": 17257
+    },
+    ".agents/tools/design/library/brands/opencode.ai/DESIGN.md": {
+      "at": "2026-04-04T03:31:30Z",
+      "hash": "5b1caeaf558eb80580b9ee11b135c5bd1ad1e7cb",
+      "passes": 1,
+      "pr": 16959
     },
     ".agents/tools/design/library/brands/pinterest/DESIGN.md": {
-      "hash": "cfaad31220f6f4d18ecbbea8190e98438b398ec5",
       "at": "2026-04-04T02:14:32Z",
+      "hash": "cfaad31220f6f4d18ecbbea8190e98438b398ec5",
       "passes": 3,
       "pr": 0
     },
+    ".agents/tools/design/library/brands/posthog/DESIGN.md": {
+      "at": "2026-04-04T02:13:59Z",
+      "hash": "67af9d87c4957feb2584c091a6010807d5c596ea",
+      "passes": 3,
+      "pr": 0
+    },
+    ".agents/tools/design/library/brands/raycast/02-color-palette.md": {
+      "at": "2026-04-04T08:33:25Z",
+      "hash": "da9e213d371ef3f75249eacd1017d83106328799",
+      "passes": 1,
+      "pr": "17227"
+    },
+    ".agents/tools/design/library/brands/raycast/04-components.md": {
+      "at": "2026-04-04T14:54:11Z",
+      "hash": "85c7855f640acea135d7da05dff11e1c68a91501",
+      "passes": 1,
+      "pr": 17300
+    },
+    ".agents/tools/design/library/brands/raycast/DESIGN.md": {
+      "at": "2026-04-04T03:31:30Z",
+      "hash": "3b3e7278569d67af46d911ff210cc1ee605a2243",
+      "passes": 1,
+      "pr": 16975
+    },
+    ".agents/tools/design/library/brands/replicate/DESIGN.md": {
+      "at": "2026-04-04T02:13:59Z",
+      "hash": "69fe4364e6000a2cdba3b787a1ddd592cbf5fb01",
+      "passes": 3,
+      "pr": 0
+    },
+    ".agents/tools/design/library/brands/resend/02-color-palette.md": {
+      "at": "2026-04-04T14:54:14Z",
+      "hash": "510e71a96285289e17ee81a6b84623e2f5fc5b69",
+      "passes": 1,
+      "pr": 17258
+    },
+    ".agents/tools/design/library/brands/resend/04-components.md": {
+      "at": "2026-04-04T14:53:38Z",
+      "hash": "2cec7a92b5b678822b2fb66cef29d22e4a863c5f",
+      "passes": 2,
+      "pr": 0
+    },
+    ".agents/tools/design/library/brands/resend/DESIGN.md": {
+      "at": "2026-04-04T03:31:31Z",
+      "hash": "0aa0041bab83ab6b79b39f6c0f3ad5a2f4c55755",
+      "passes": 1,
+      "pr": 16953
+    },
     ".agents/tools/design/library/brands/revolut/DESIGN.md": {
-      "hash": "61e0515b0199ea31b4df4a67ac57543a670d1f24",
       "at": "2026-04-04T02:14:32Z",
+      "hash": "61e0515b0199ea31b4df4a67ac57543a670d1f24",
       "passes": 3,
       "pr": 0
     },
     ".agents/tools/design/library/brands/runwayml/DESIGN.md": {
-      "hash": "475c5b1cbaba7ab330f4b4083d933bee39e81500",
       "at": "2026-04-04T02:14:32Z",
+      "hash": "475c5b1cbaba7ab330f4b4083d933bee39e81500",
+      "passes": 3,
+      "pr": 0
+    },
+    ".agents/tools/design/library/brands/sentry/DESIGN.md": {
+      "at": "2026-04-04T02:13:59Z",
+      "hash": "1eadfe81abf8cf4d0571dbd4a2559783bfd59007",
       "passes": 3,
       "pr": 0
     },
     ".agents/tools/design/library/brands/spacex/DESIGN.md": {
-      "hash": "30de4b47a68afe61203205f1452be9f6f1421b24",
       "at": "2026-04-04T02:14:32Z",
+      "hash": "30de4b47a68afe61203205f1452be9f6f1421b24",
       "passes": 3,
       "pr": 0
     },
     ".agents/tools/design/library/brands/spotify/DESIGN.md": {
-      "hash": "d5ef76d874a51c2e6278c1f6f57193ac7d664a6b",
       "at": "2026-04-04T02:14:32Z",
+      "hash": "d5ef76d874a51c2e6278c1f6f57193ac7d664a6b",
       "passes": 3,
       "pr": 0
     },
+    ".agents/tools/design/library/brands/stripe/02-color-palette.md": {
+      "at": "2026-04-04T14:54:14Z",
+      "hash": "33f19762a6d943289c75a2395c91af6646d0e381",
+      "passes": 1,
+      "pr": 17260
+    },
+    ".agents/tools/design/library/brands/stripe/DESIGN.md": {
+      "at": "2026-04-04T03:31:33Z",
+      "hash": "0f154e30eedab5741aea05a5becf96f783fe0fd1",
+      "passes": 1,
+      "pr": 16928
+    },
     ".agents/tools/design/library/brands/supabase/DESIGN.md": {
-      "hash": "5cf514aec9810ef6d6d790bd1f4559cee350de6b",
       "at": "2026-04-04T02:14:32Z",
+      "hash": "5cf514aec9810ef6d6d790bd1f4559cee350de6b",
       "passes": 3,
       "pr": 0
     },
     ".agents/tools/design/library/brands/superhuman/DESIGN.md": {
-      "hash": "94fa3144326384a5b0479a049ddbf80849de7927",
       "at": "2026-04-04T02:14:32Z",
+      "hash": "94fa3144326384a5b0479a049ddbf80849de7927",
       "passes": 3,
       "pr": 0
     },
+    ".agents/tools/design/library/brands/together.ai/DESIGN.md": {
+      "at": "2026-04-04T02:13:59Z",
+      "hash": "f68d7a7121d535b45a2ad53733af9ab6f59415d5",
+      "passes": 3,
+      "pr": 0
+    },
+    ".agents/tools/design/library/brands/uber/04-components.md": {
+      "at": "2026-04-04T15:34:57Z",
+      "hash": "4ec6802a7a92580fb74e4b230ec84fe570cb89ff",
+      "passes": 1,
+      "pr": 17340
+    },
+    ".agents/tools/design/library/brands/uber/DESIGN.md": {
+      "at": "2026-04-04T03:31:30Z",
+      "hash": "16a22b18bb94629076166fb94f9295baf03daa96",
+      "passes": 1,
+      "pr": 16957
+    },
+    ".agents/tools/design/library/brands/vercel/02-color-palette.md": {
+      "at": "2026-04-04T14:54:11Z",
+      "hash": "43bfb525bb16396e8b453a5e92926c34919dc094",
+      "passes": 1,
+      "pr": 17299
+    },
+    ".agents/tools/design/library/brands/vercel/04-components.md": {
+      "at": "2026-04-04T14:54:15Z",
+      "hash": "1012934f5582c4f4118ddd2ebdaee4c4e6380630",
+      "passes": 1,
+      "pr": 17242
+    },
+    ".agents/tools/design/library/brands/vercel/DESIGN.md": {
+      "at": "2026-04-04T01:35:11Z",
+      "hash": "71545bb65f1d5af4909bd639b88c17f4592ecba9",
+      "issue": 16956,
+      "passes": 1,
+      "pr": 16947,
+      "status": "restructured"
+    },
+    ".agents/tools/design/library/brands/voltagent/02-color-palette.md": {
+      "at": "2026-04-04T14:54:08Z",
+      "hash": "40ae0c8eec93283421615932a8ffd9caa72301f6",
+      "passes": 1,
+      "pr": 17342
+    },
+    ".agents/tools/design/library/brands/voltagent/04-components.md": {
+      "at": "2026-04-04T14:54:16Z",
+      "hash": "455d06dbc2ad5ac0899103635d546b337a341af3",
+      "passes": 1,
+      "pr": 17239
+    },
     ".agents/tools/design/library/brands/voltagent/DESIGN.md": {
-      "hash": "a197aa1fdb88a15d60ae724a862a02f978402a3f",
       "at": "2026-04-04T02:14:32Z",
+      "hash": "a197aa1fdb88a15d60ae724a862a02f978402a3f",
       "passes": 3,
       "pr": 0
     },
     ".agents/tools/design/library/brands/warp/DESIGN.md": {
-      "hash": "bfd031a6a6275342d696397a1e23aadac6767df2",
       "at": "2026-04-04T02:14:32Z",
+      "hash": "bfd031a6a6275342d696397a1e23aadac6767df2",
       "passes": 3,
       "pr": 0
     },
     ".agents/tools/design/library/brands/webflow/DESIGN.md": {
-      "hash": "912d68dc758820d68b67bee6f925f08ccf2f5f97",
       "at": "2026-04-04T02:14:32Z",
+      "hash": "912d68dc758820d68b67bee6f925f08ccf2f5f97",
       "passes": 3,
       "pr": 0
     },
     ".agents/tools/design/library/brands/wise/DESIGN.md": {
-      "hash": "149eff7da778f6605ce9f9ec5932986c11c83bc6",
       "at": "2026-04-04T02:14:32Z",
+      "hash": "149eff7da778f6605ce9f9ec5932986c11c83bc6",
       "passes": 3,
       "pr": 0
     },
     ".agents/tools/design/library/brands/x.ai/DESIGN.md": {
-      "hash": "f1264f6138dd4c310a921b8b306c313923d5d02d",
       "at": "2026-04-04T02:14:32Z",
+      "hash": "f1264f6138dd4c310a921b8b306c313923d5d02d",
       "passes": 3,
       "pr": 0
     },
-    ".agents/scripts/linters-local.sh": {
-      "hash": "73f92584b2779e28603e2251676c8c749a6524ef",
-      "at": "2026-04-15T03:00:31Z",
-      "pr": 17036,
-      "passes": 4
-    },
-    ".agents/tools/design/library/styles/startup-bold/04-components.md": {
-      "hash": "1bbe4ae1ba55faad4da3db040ac2a07107b23b30",
-      "at": "2026-04-04T03:31:28Z",
-      "pr": 17021,
-      "passes": 1
-    },
-    ".agents/tools/design/library/styles/startup-minimal/04-components.md": {
-      "hash": "3c267f5c0b0ce06a90dcc751d3b59adf2889e13a",
-      "at": "2026-04-04T03:31:28Z",
-      "pr": 17020,
-      "passes": 1
-    },
-    ".agents/tools/design/library/styles/corporate-modern/04-components.md": {
-      "hash": "0d27460862c59aaa1af2cf42f99418e179a7f396",
-      "at": "2026-04-04T03:31:28Z",
-      "pr": 17019,
-      "passes": 1
-    },
-    ".agents/tools/design/library/styles/corporate-traditional/04-components.md": {
-      "hash": "3d52e7732effbedfb5f2cfe12e3ff0956793e803",
-      "at": "2026-04-04T03:31:28Z",
-      "pr": 17016,
-      "passes": 1
-    },
-    ".agents/tools/design/library/styles/corporate-friendly/04-components.md": {
-      "hash": "7e5d7b58f18d0edc7353b324264f3567795020bd",
-      "at": "2026-04-04T03:31:28Z",
-      "pr": 17015,
-      "passes": 1
-    },
-    ".agents/tools/design/library/styles/editorial-clean/04-components.md": {
-      "hash": "5524379ea81c5fad972fef3866222696daf89a09",
-      "at": "2026-04-04T03:31:28Z",
-      "pr": 17014,
-      "passes": 1
-    },
-    ".agents/tools/design/library/styles/playful-vibrant/04-components.md": {
-      "hash": "64ad55ddd8886c16fef7b021049ce32cd067a07a",
-      "at": "2026-04-04T03:31:29Z",
-      "pr": 17013,
-      "passes": 1
-    },
-    ".agents/tools/design/colour-palette.md": {
-      "hash": "dc89ad0ba62b65a9e4c2456f496e30182777754a",
-      "at": "2026-04-04T03:31:29Z",
-      "pr": 17012,
-      "passes": 1
-    },
-    ".agents/tools/code-review/review-categories.md": {
-      "hash": "90c3b475500548147e736db43a54aa6aec466561",
-      "at": "2026-04-04T03:31:30Z",
-      "pr": 16977,
-      "passes": 1
-    },
-    ".agents/tools/design/library/brands/raycast/DESIGN.md": {
-      "hash": "3b3e7278569d67af46d911ff210cc1ee605a2243",
-      "at": "2026-04-04T03:31:30Z",
-      "pr": 16975,
-      "passes": 1
-    },
-    ".agents/tools/design/library/brands/hashicorp/DESIGN.md": {
-      "hash": "ac7c8e37a0a70bc23e49a7c76113e0c9168a8554",
-      "at": "2026-04-04T03:31:30Z",
-      "pr": 16974,
-      "passes": 1
-    },
-    ".agents/tools/design/library/brands/hashicorp/04-components.md": {
-      "hash": "3fd463f6862b32fb06907f77eb9f4b9d67defd53",
-      "at": "2026-04-04T14:53:35Z",
-      "passes": 2
-    },
-    ".agents/tools/design/library/brands/expo/DESIGN.md": {
-      "hash": "9ee9e2d9a995347973d7caf44e828f08aa1139ed",
-      "at": "2026-04-04T03:31:30Z",
-      "pr": 16960,
-      "passes": 1
-    },
-    ".agents/tools/design/library/brands/opencode.ai/DESIGN.md": {
-      "hash": "5b1caeaf558eb80580b9ee11b135c5bd1ad1e7cb",
-      "at": "2026-04-04T03:31:30Z",
-      "pr": 16959,
-      "passes": 1
-    },
-    ".agents/tools/design/library/brands/uber/DESIGN.md": {
-      "hash": "16a22b18bb94629076166fb94f9295baf03daa96",
-      "at": "2026-04-04T03:31:30Z",
-      "pr": 16957,
-      "passes": 1
-    },
-    ".agents/tools/design/library/brands/lovable/DESIGN.md": {
-      "hash": "52d048d030d625aea29bc383e09f7fa50c389ed7",
-      "at": "2026-04-04T03:31:30Z",
-      "pr": 16955,
-      "passes": 1
-    },
-    ".agents/tools/design/library/brands/clay/DESIGN.md": {
-      "hash": "f8e6eaba04542bc4c2fceb6da793b9a83713ea5d",
-      "at": "2026-04-04T03:31:31Z",
-      "pr": 16954,
-      "passes": 1
-    },
-    ".agents/tools/design/library/brands/resend/DESIGN.md": {
-      "hash": "0aa0041bab83ab6b79b39f6c0f3ad5a2f4c55755",
-      "at": "2026-04-04T03:31:31Z",
-      "pr": 16953,
-      "passes": 1
-    },
-    ".agents/tools/design/library/brands/composio/DESIGN.md": {
-      "hash": "dc7159b2ad198b911677cf16f313432aeadd0012",
-      "at": "2026-04-04T03:31:31Z",
-      "pr": 16951,
-      "passes": 1
-    },
-    ".agents/scripts/session-miner-pulse.sh": {
-      "hash": "830c39693ed38aaf32579c8cbf498ddb44152cda",
-      "at": "2026-04-13T16:27:33Z",
-      "pr": 16950,
-      "passes": 2
-    },
-    ".agents/tools/design/library/brands/notion/DESIGN.md": {
-      "hash": "d1d2796c5063493ff760008a732c0b1f51a63a6c",
-      "at": "2026-04-04T03:31:32Z",
-      "pr": 16938,
-      "passes": 1
-    },
-    ".agents/tools/design/library/brands/apple/DESIGN.md": {
-      "hash": "3a05d16ee4ac4f6e7ce5563014e60d0a58942c36",
-      "at": "2026-04-04T03:31:32Z",
-      "pr": 16935,
-      "passes": 1
-    },
-    ".agents/tools/design/library/brands/claude/DESIGN.md": {
-      "hash": "0ddd5acd4ddb0c16133b3f50c7d785fa66a7686e",
-      "at": "2026-04-04T03:31:32Z",
-      "pr": 16934,
-      "passes": 1
-    },
-    ".agents/tools/design/library/brands/mintlify/04-components.md": {
-      "hash": "a841d19a09e3cb6e80b676ce8a479db679cfe892",
-      "at": "2026-04-04T14:53:36Z",
-      "pr": 17022,
-      "passes": 2
-    },
-    ".agents/tools/design/library/brands/mintlify/DESIGN.md": {
-      "hash": "4696cd2a55691cc59382d332230b1769f55c9723",
-      "at": "2026-04-04T03:31:32Z",
-      "pr": 16929,
-      "passes": 1
-    },
-    ".agents/tools/design/library/brands/stripe/DESIGN.md": {
-      "hash": "0f154e30eedab5741aea05a5becf96f783fe0fd1",
-      "at": "2026-04-04T03:31:33Z",
-      "pr": 16928,
-      "passes": 1
+    ".agents/tools/design/library/styles/agency-creative/02-colours.md": {
+      "at": "2026-04-04T14:54:14Z",
+      "hash": "ff44198fa17972cfd740258291dc507f8505004b",
+      "passes": 1,
+      "pr": 17256
     },
     ".agents/tools/design/library/styles/agency-creative/04-components.md": {
-      "hash": "b130d4a6d1824660f12a91abf4cf3234a81e52c2",
       "at": "2026-04-04T14:53:39Z",
-      "passes": 2,
-      "issue": 17040
+      "hash": "b130d4a6d1824660f12a91abf4cf3234a81e52c2",
+      "issue": 17040,
+      "passes": 2
     },
-    ".agents/tools/design/library/brands/apple/04-components.md": {
-      "hash": "96cd94a2148c4754612187b74473c3b55d3f7d0c",
-      "at": "2026-04-04T04:52:51Z",
-      "pr": "17061",
-      "passes": 1
-    },
-    ".agents/tools/design/library/brands/expo/04-components.md": {
-      "hash": "f63874cc01ae8e6248a0ca8c870ad58a18503a82",
-      "at": "2026-04-04T14:53:35Z",
-      "lines": 82,
-      "issue": "GH#17088",
-      "passes": 1
-    },
-    ".agents/tools/design/library/styles/startup-minimal/02-colours.md": {
-      "hash": "e60ac8a79bbeff247b7bb88c2514f06b1a03e037",
-      "at": "2026-04-04T14:53:43Z",
-      "passes": 2,
+    ".agents/tools/design/library/styles/agency-feminine/02-colours.md": {
+      "at": "2026-04-04T09:40:00Z",
+      "hash": "be82e405e45430e53f12a26dbfab5547407c58e2",
+      "passes": 1,
       "pr": 0
     },
-    ".agents/tools/design/library/styles/startup-bold/02-colours.md": {
-      "hash": "abed90de8c87b3704b45ef5aaa6241d3872e73c5",
-      "at": "2026-04-04T14:53:43Z",
+    ".agents/tools/design/library/styles/agency-feminine/04-components.md": {
+      "at": "2026-04-04T16:52:50Z",
+      "hash": "5f1bd3b67c5520a45522414e833317cb18ee4f10",
       "passes": 2,
-      "pr": 0
+      "pr": 17217
     },
     ".agents/tools/design/library/styles/agency-techie/02-colours.md": {
-      "hash": "46c01cd964c9b3559c47200a847872c21f700137",
       "at": "2026-04-04T06:15:00Z",
+      "hash": "46c01cd964c9b3559c47200a847872c21f700137",
       "passes": 1,
       "pr": 0
     },
-    ".agents/reference/external-repo-submissions.md": {
-      "hash": "272ce05104d2393a198de590e77619a4ac31a694",
-      "at": "2026-04-04T00:00:00Z",
+    ".agents/tools/design/library/styles/agency-techie/04-components.md": {
+      "at": "2026-04-04T14:54:09Z",
+      "hash": "dd244e9d27c0ef7c55976cf7387e65a45bc7ea08",
       "passes": 1,
-      "pr": 17146
+      "pr": 17319
     },
-    ".agents/tools/multimodal-evaluation.md": {
-      "hash": "da3da79d8c549978225657036561d1a67fed9b71",
-      "at": "2026-04-04T06:18:00Z",
+    ".agents/tools/design/library/styles/corporate-friendly/02-colour-palette.md": {
+      "at": "2026-04-04T14:54:12Z",
+      "hash": "5d6d4238a9f4801fc21d5abc5d9caf57ce0901f3",
       "passes": 1,
-      "pr": 17142
+      "pr": 17295
+    },
+    ".agents/tools/design/library/styles/corporate-friendly/04-components.md": {
+      "at": "2026-04-04T03:31:28Z",
+      "hash": "7e5d7b58f18d0edc7353b324264f3567795020bd",
+      "passes": 1,
+      "pr": 17015
+    },
+    ".agents/tools/design/library/styles/corporate-friendly/DESIGN.md": {
+      "at": "2026-04-03T22:56:47Z",
+      "hash": "da743c5d75b2effed47d4ce0d239807614c580c3",
+      "issue": 16884,
+      "passes": 1,
+      "status": "simplified"
+    },
+    ".agents/tools/design/library/styles/corporate-modern/04-components.md": {
+      "at": "2026-04-04T03:31:28Z",
+      "hash": "0d27460862c59aaa1af2cf42f99418e179a7f396",
+      "passes": 1,
+      "pr": 17019
+    },
+    ".agents/tools/design/library/styles/corporate-traditional/02-colours.md": {
+      "action": "consolidated 6 group tables + CSS block into single unified table with CSS variable column (94\u219228 lines)",
+      "at": "2026-04-04T14:53:40Z",
+      "hash": "476c989fca56149f90f1eefc2b02cafdc5a6e0d5",
+      "issue": "GH#17250",
+      "passes": 1,
+      "simplified_at": "2026-04-04T09:17:13Z"
+    },
+    ".agents/tools/design/library/styles/corporate-traditional/04-components.md": {
+      "at": "2026-04-04T03:31:28Z",
+      "hash": "3d52e7732effbedfb5f2cfe12e3ff0956793e803",
+      "passes": 1,
+      "pr": 17016
+    },
+    ".agents/tools/design/library/styles/developer-dark/04-components.md": {
+      "at": "2026-04-04T14:54:10Z",
+      "hash": "8fb82a7b1163431a819d14f5d1903618825b7bdc",
+      "passes": 1,
+      "pr": 17312
+    },
+    ".agents/tools/design/library/styles/developer-dark/DESIGN.md": {
+      "at": "2026-04-04T14:53:40Z",
+      "hash": "219549468a3add04b6431c9945c9aebe563fe425",
+      "passes": 4,
+      "pr": 0
+    },
+    ".agents/tools/design/library/styles/editorial-clean/04-components.md": {
+      "at": "2026-04-04T03:31:28Z",
+      "hash": "5524379ea81c5fad972fef3866222696daf89a09",
+      "passes": 1,
+      "pr": 17014
     },
     ".agents/tools/design/library/styles/editorial-clean/05-layout.md": {
-      "hash": "6e4433cec2956492e21fe47e6212ee26d6d09bfd",
       "at": "2026-04-04T14:53:42Z",
+      "hash": "6e4433cec2956492e21fe47e6212ee26d6d09bfd",
       "passes": 2,
       "pr": 17183,
       "status": "converged"
     },
+    ".agents/tools/design/library/styles/editorial-clean/DESIGN.md": {
+      "at": "2026-04-03T22:57:36Z",
+      "hash": "23c64b436b3b80a49b2451f890de202f9357e4d5",
+      "passes": 1,
+      "pr": 16882
+    },
+    ".agents/tools/design/library/styles/luxury-premium/DESIGN.md": {
+      "at": "2026-04-03T22:57:35Z",
+      "hash": "2d625cf22e63e62d0d04198763b2834244b54a3e",
+      "passes": 1,
+      "pr": 16883
+    },
+    ".agents/tools/design/library/styles/playful-vibrant/02-colour-palette.md": {
+      "at": "2026-04-04T14:54:16Z",
+      "hash": "c3934e0177fbe5118d2b5b6c77144293a467ed7d",
+      "passes": 1,
+      "pr": 17240
+    },
+    ".agents/tools/design/library/styles/playful-vibrant/04-components.md": {
+      "at": "2026-04-04T03:31:29Z",
+      "hash": "64ad55ddd8886c16fef7b021049ce32cd067a07a",
+      "passes": 1,
+      "pr": 17013
+    },
+    ".agents/tools/design/library/styles/playful-vibrant/05-layout.md": {
+      "at": "2026-04-04T14:54:09Z",
+      "hash": "e43fd8c8ee2db2961e134fe365c20121f64eecb8",
+      "passes": 1,
+      "pr": 17321
+    },
+    ".agents/tools/design/library/styles/playful-vibrant/DESIGN.md": {
+      "at": "2026-04-03T23:09:04Z",
+      "hash": "f42502be75dfeee3f716f54b3ea2d8e6697414a6",
+      "passes": 3,
+      "pr": "16889"
+    },
+    ".agents/tools/design/library/styles/startup-bold/02-colours.md": {
+      "at": "2026-04-04T14:53:43Z",
+      "hash": "abed90de8c87b3704b45ef5aaa6241d3872e73c5",
+      "passes": 2,
+      "pr": 0
+    },
+    ".agents/tools/design/library/styles/startup-bold/04-components.md": {
+      "at": "2026-04-04T03:31:28Z",
+      "hash": "1bbe4ae1ba55faad4da3db040ac2a07107b23b30",
+      "passes": 1,
+      "pr": 17021
+    },
+    ".agents/tools/design/library/styles/startup-bold/05-layout.md": {
+      "at": "2026-04-04T14:54:11Z",
+      "hash": "b6ca30e0a3b04bc92f1141517fe39f8f4f30fe6c",
+      "passes": 1,
+      "pr": 17298
+    },
+    ".agents/tools/design/library/styles/startup-bold/DESIGN.md": {
+      "at": "2026-04-04T00:16:00Z",
+      "hash": "277fd4c89e051686308cba0124c8c0559b5cb7be",
+      "passes": 1,
+      "pr": 16893
+    },
+    ".agents/tools/design/library/styles/startup-minimal/02-colours.md": {
+      "at": "2026-04-04T14:53:43Z",
+      "hash": "e60ac8a79bbeff247b7bb88c2514f06b1a03e037",
+      "passes": 2,
+      "pr": 0
+    },
+    ".agents/tools/design/library/styles/startup-minimal/04-components.md": {
+      "at": "2026-04-04T03:31:28Z",
+      "hash": "3c267f5c0b0ce06a90dcc751d3b59adf2889e13a",
+      "passes": 1,
+      "pr": 17020
+    },
     ".agents/tools/design/library/styles/startup-minimal/05-layout.md": {
-      "hash": "04aaeb71fcd0393a6446aac9d0f009eba9fec19c",
       "at": "2026-04-04T14:53:44Z",
+      "hash": "04aaeb71fcd0393a6446aac9d0f009eba9fec19c",
       "passes": 2,
       "status": "converged"
     },
-    ".agents/tools/design/library/brands/raycast/02-color-palette.md": {
-      "hash": "da9e213d371ef3f75249eacd1017d83106328799",
-      "at": "2026-04-04T08:33:25Z",
-      "pr": "17227",
-      "passes": 1
-    },
-    ".agents/tools/design/library/brands/clickhouse/04-components.md": {
-      "hash": "e4d0797834ea9ca4d5fbbad24fbee6030f51c094",
-      "at": "2026-04-04T14:53:34Z",
-      "issue": "GH#17237",
-      "lines_before": 89,
-      "lines_after": 57,
-      "passes": 1
-    },
-    ".agents/tools/design/library/brands/resend/04-components.md": {
-      "hash": "2cec7a92b5b678822b2fb66cef29d22e4a863c5f",
-      "at": "2026-04-04T14:53:38Z",
-      "pr": 0,
-      "passes": 2
-    },
-    ".agents/tools/design/library/brands/clay/04-components.md": {
-      "hash": "61aad30e636ccaa3c9ac886b17e8cf8e2ab1ab6c",
-      "at": "2026-04-04T14:53:34Z",
+    ".agents/tools/design/ui-ux-inspiration.md": {
+      "at": "2026-04-03T22:25:45Z",
+      "hash": "5a3b8bd40244c1e7b1606f0a7cea2409a913a811",
       "passes": 2,
-      "pr": 17267
+      "pr": 11590
     },
-    ".agents/tools/design/library/styles/agency-feminine/02-colours.md": {
-      "hash": "be82e405e45430e53f12a26dbfab5547407c58e2",
-      "at": "2026-04-04T09:40:00Z",
+    ".agents/tools/diagrams/mermaid-diagrams-skill.md": {
+      "at": "2026-03-28T15:30:35Z",
+      "hash": "f80fbd3fe10e749b96a8bca35c699411af73a8d7",
       "passes": 1,
-      "pr": 0
+      "pr": 11935
     },
-    ".agents/tools/design/library/styles/corporate-traditional/02-colours.md": {
-      "hash": "476c989fca56149f90f1eefc2b02cafdc5a6e0d5",
-      "simplified_at": "2026-04-04T09:17:13Z",
-      "issue": "GH#17250",
-      "action": "consolidated 6 group tables + CSS block into single unified table with CSS variable column (94→28 lines)",
-      "at": "2026-04-04T14:53:40Z",
+    ".agents/tools/diagrams/mermaid-diagrams-skill/advanced.md": {
+      "at": "2026-03-29T11:51:51Z",
+      "hash": "8d503a6cd73cf42489b18f7a5664f2b322d8673a",
+      "passes": 1,
+      "pr": 12922
+    },
+    ".agents/tools/diagrams/mermaid-diagrams-skill/architecture.md": {
+      "at": "2026-03-28T16:00:33Z",
+      "hash": "69321b2bc44bba8fe56ee85836144b038b947e40",
+      "passes": 1,
+      "pr": 11987
+    },
+    ".agents/tools/diagrams/mermaid-diagrams-skill/cheatsheet.md": {
+      "at": "2026-03-29T21:43:04Z",
+      "hash": "568e7a49215a4fcd8b2487d7c6455e27e698e343",
+      "passes": 1,
+      "pr": 13300
+    },
+    ".agents/tools/diagrams/mermaid-diagrams-skill/class-er.md": {
+      "at": "2026-03-28T08:17:42Z",
+      "hash": "cac152d5a323a68222a3b72869b48b6ac00a1fd9",
+      "passes": 1,
+      "pr": 11589
+    },
+    ".agents/tools/diagrams/mermaid-diagrams-skill/data-charts.md": {
+      "at": "2026-03-28T08:58:03Z",
+      "hash": "4006f122f01a479c9f18cf811f4518cd84b43bea",
+      "passes": 1,
+      "pr": 11602
+    },
+    ".agents/tools/diagrams/mermaid-diagrams-skill/flowcharts.md": {
+      "at": "2026-03-30T04:52:39Z",
+      "hash": "aa40ff75d4ee501fc82db4dbce013fcf8ccbfe05",
+      "passes": 1,
+      "pr": 13784
+    },
+    ".agents/tools/diagrams/mermaid-diagrams-skill/sequence.md": {
+      "at": "2026-03-28T05:10:17Z",
+      "hash": "321dcb7f9abbc8ebfeec457313dabbd52227f242",
+      "passes": 1,
+      "pr": 11392
+    },
+    ".agents/tools/diagrams/mermaid-diagrams-skill/state-journey.md": {
+      "at": "2026-03-29T08:11:29Z",
+      "hash": "cfd8bd062a27912784b2f79040783472553deafc",
+      "passes": 1,
+      "pr": 12755
+    },
+    ".agents/tools/document/docstrange.md": {
+      "at": "2026-03-29T16:34:31Z",
+      "hash": "356dc36b0eeaae56c2ae1b5ad27e2442f58d8725",
+      "passes": 1,
+      "pr": 13102
+    },
+    ".agents/tools/document/document-creation.md": {
+      "at": "2026-03-28T08:17:34Z",
+      "hash": "53e7dcdaf54df67fbfe51ad5267b549131b964fd",
+      "passes": 1,
+      "pr": 11592
+    },
+    ".agents/tools/document/document-extraction.md": {
+      "at": "2026-03-28T15:30:30Z",
+      "hash": "c9bbb8f8fe6fb0de72fd58043e65e30163a2c14f",
+      "passes": 1,
+      "pr": 11919
+    },
+    ".agents/tools/document/extraction-schemas.md": {
+      "at": "2026-03-28T08:58:45Z",
+      "hash": "77b777bd9e30c46b1e93c7679e60d542c9552d0d",
+      "passes": 1,
+      "pr": 11601
+    },
+    ".agents/tools/document/extraction-schemas/01-design-principles.md": {
+      "at": "2026-03-28T08:58:45Z",
+      "hash": "a3a0d1fd2f30d250bf138d264159971ca3da3c9d",
+      "passes": 1,
+      "pr": 11601
+    },
+    ".agents/tools/document/extraction-schemas/02-purchase-invoice.md": {
+      "at": "2026-03-28T08:58:45Z",
+      "hash": "f68e6908fc7390cf14b98ae52f50753ef4bd46cb",
+      "passes": 1,
+      "pr": 11601
+    },
+    ".agents/tools/document/extraction-schemas/03-expense-receipt.md": {
+      "at": "2026-03-28T08:58:45Z",
+      "hash": "2d72e593cba84bb9a33214078871dea9702ce3ee",
+      "passes": 1,
+      "pr": 11601
+    },
+    ".agents/tools/document/extraction-schemas/04-credit-note.md": {
+      "at": "2026-03-28T08:58:45Z",
+      "hash": "46e215fdc8d4c0c64b74c204784a78c719837800",
+      "passes": 1,
+      "pr": 11601
+    },
+    ".agents/tools/document/extraction-schemas/05-sales-invoice.md": {
+      "at": "2026-03-28T08:58:45Z",
+      "hash": "a0a2a210e6f6e6d0d2ee3bc9573c85032fc7de88",
+      "passes": 1,
+      "pr": 11601
+    },
+    ".agents/tools/document/extraction-schemas/06-generic-receipt.md": {
+      "at": "2026-03-28T08:58:45Z",
+      "hash": "d209d3647c51956a81ec36fd1d22308b84ffe128",
+      "passes": 1,
+      "pr": 11601
+    },
+    ".agents/tools/document/extraction-schemas/07-quickfile-mapping.md": {
+      "at": "2026-03-28T08:58:45Z",
+      "hash": "0431f2b5ad2409dd19415486d9af2710425fae18",
+      "passes": 1,
+      "pr": 11601
+    },
+    ".agents/tools/document/extraction-schemas/08-vat-handling.md": {
+      "at": "2026-03-28T08:58:45Z",
+      "hash": "3b1eee6832b72d5d129d64c516d6d062534b79b9",
+      "passes": 1,
+      "pr": 11601
+    },
+    ".agents/tools/document/extraction-schemas/09-nominal-codes.md": {
+      "at": "2026-03-28T08:58:45Z",
+      "hash": "f891a367d31eaf333fbdfbcf40901718799372c9",
+      "passes": 1,
+      "pr": 11601
+    },
+    ".agents/tools/document/extraction-schemas/10-classification.md": {
+      "at": "2026-03-28T08:58:45Z",
+      "hash": "86b35abc7b402fd23ca0fd1c363fcf52afcbd65f",
+      "passes": 1,
+      "pr": 11601
+    },
+    ".agents/tools/document/extraction-schemas/11-pipeline-integration.md": {
+      "at": "2026-03-28T08:58:45Z",
+      "hash": "8f2f4de0c38926814a5e82f04d4edacbcd655c8f",
+      "passes": 1,
+      "pr": 11601
+    },
+    ".agents/tools/document/extraction-schemas/12-validation.md": {
+      "at": "2026-03-28T08:58:45Z",
+      "hash": "2b3e56e1b3869978279bf8ac954c875d4deae23d",
+      "passes": 1,
+      "pr": 11601
+    },
+    ".agents/tools/document/extraction-workflow.md": {
+      "at": "2026-04-01T23:23:22Z",
+      "hash": "1712dd51c2ac3747cbf0e90327bc627e9975427f",
+      "passes": 1,
+      "pr": 15350
+    },
+    ".agents/tools/git.md": {
+      "at": "2026-04-03T11:54:15Z",
+      "hash": "a293bc257df92a1e036c854b84028070cb062741",
+      "passes": 1,
+      "pr": 16428
+    },
+    ".agents/tools/git/authentication.md": {
+      "at": "2026-03-30T02:30:25Z",
+      "hash": "87e4955172cb561376c873c51045ef8a3b98b502",
+      "passes": 1,
+      "pr": 13538
+    },
+    ".agents/tools/git/conflict-resolution.md": {
+      "at": "2026-03-28T14:15:35Z",
+      "hash": "78a3f531ef115f702a0833bd3eb6c28db9e2bd80",
+      "passes": 1,
+      "pr": 11909
+    },
+    ".agents/tools/git/git-security.md": {
+      "at": "2026-04-03T11:54:15Z",
+      "hash": "ebf3356f9a187064ca7cba0c5e0270bb25190fb0",
+      "passes": 1,
+      "pr": 16442
+    },
+    ".agents/tools/git/gitea-cli.md": {
+      "at": "2026-03-29T07:02:58Z",
+      "hash": "b680d568b76c2dfbd45fb2f5c6bfd96338e87464",
+      "passes": 1,
+      "pr": 12618
+    },
+    ".agents/tools/git/github-actions.md": {
+      "at": "2026-04-13T16:27:52Z",
+      "hash": "094b1d3e1fb0638c2affb4c2fbaeb66822d80a8c",
+      "passes": 2,
+      "pr": 16558
+    },
+    ".agents/tools/git/github-cli.md": {
+      "at": "2026-04-03T11:54:14Z",
+      "hash": "754748cc0ca046b171831582ec5f7f2fdf14a9bd",
+      "passes": 1,
+      "pr": 16499
+    },
+    ".agents/tools/git/gitlab-cli.md": {
+      "at": "2026-03-29T03:15:01Z",
+      "hash": "bf41a9566d8aeaa20a15165b3202206c779785ba",
+      "passes": 1,
+      "pr": 12498
+    },
+    ".agents/tools/git/jujutsu.md": {
+      "at": "2026-04-03T12:15:32Z",
+      "hash": "3423735a65d6834f352f94036e55ab92a12cbab5",
+      "passes": 1,
+      "pr": 16553
+    },
+    ".agents/tools/git/lumen.md": {
+      "at": "2026-04-01T23:23:19Z",
+      "hash": "0b7664a56ac46dcc62198dff1578abab24bd1b07",
+      "passes": 1,
+      "pr": 15327
+    },
+    ".agents/tools/git/opencode-github-security.md": {
+      "at": "2026-03-28T22:39:20Z",
+      "hash": "433293616dc956ef4fec53349c3f5c94b4318746",
+      "passes": 1,
+      "pr": 12309
+    },
+    ".agents/tools/git/opencode-github.md": {
+      "at": "2026-03-28T03:54:27Z",
+      "hash": "064220aa37037434a1a4d977c034401ca840cabe",
+      "passes": 1,
+      "pr": 11349
+    },
+    ".agents/tools/git/opencode-gitlab.md": {
+      "at": "2026-03-29T20:54:06Z",
+      "hash": "2da12edc7a2cf6301d8a4a221729427a757dead4",
+      "passes": 1,
+      "pr": 13295
+    },
+    ".agents/tools/git/worktrunk.md": {
+      "at": "2026-03-28T10:27:11Z",
+      "hash": "9c7625f2eb39def77a28308703f7f5259d97c49a",
+      "passes": 1,
+      "pr": 11760
+    },
+    ".agents/tools/infrastructure/cloud-gpu.md": {
+      "at": "2026-03-29T21:43:22Z",
+      "hash": "1109c625814843b489309ff6178c4ab66bde2971",
+      "passes": 1,
+      "pr": 13346
+    },
+    ".agents/tools/infrastructure/cloudflare-ai.md": {
+      "at": "2026-04-01T20:50:00Z",
+      "hash": "e9c0fcec44422a0d14b251e61906c9ad5ae745c7",
+      "passes": 2,
+      "pr": 15091
+    },
+    ".agents/tools/infrastructure/fireworks.md": {
+      "at": "2026-03-28T11:52:26Z",
+      "hash": "b7bb09d0ec09ef4e07a5e922f902bd3ce641bffe",
+      "passes": 1,
+      "pr": 11813
+    },
+    ".agents/tools/infrastructure/nearai.md": {
+      "at": "2026-03-29T10:47:24Z",
+      "hash": "a65b3460482fc02b4a5e0d440590bc14293371c5",
+      "passes": 1,
+      "pr": 12869
+    },
+    ".agents/tools/infrastructure/nvidia-cloud.md": {
+      "at": "2026-03-29T08:49:20Z",
+      "hash": "92d1dae09af45e0d44074130c1d122bd6f4cfcb6",
+      "passes": 1,
+      "pr": 12776
+    },
+    ".agents/tools/infrastructure/together.md": {
+      "at": "2026-03-29T17:15:24Z",
+      "hash": "dbec4e9bd18b8affb94573477a97f94053bd9c40",
+      "passes": 1,
+      "pr": 13113
+    },
+    ".agents/tools/local-models/huggingface.md": {
+      "at": "2026-04-03T11:54:14Z",
+      "hash": "0a5d1f688f414c7ad20dce124a66b9a45bbda39d",
+      "passes": 1,
+      "pr": 16479
+    },
+    ".agents/tools/local-models/local-models.md": {
+      "at": "2026-04-03T21:42:12Z",
+      "hash": "40e9aa225567860343520e0004099aa451d3f1c1",
+      "passes": 2,
+      "pr": 12758
+    },
+    ".agents/tools/mcp-toolkit/mcporter.md": {
+      "at": "2026-03-28T14:16:17Z",
+      "hash": "302f204927b866cd10328ef0e14410a64c56dcbb",
+      "passes": 1,
+      "pr": 11906
+    },
+    ".agents/tools/mcp/cloudflare-code-mode.md": {
+      "at": "2026-03-29T23:54:08Z",
+      "hash": "ae50d4c729eab4eea5b4f4f50e930b9c4be78108",
+      "passes": 1,
+      "pr": 13428
+    },
+    ".agents/tools/mobile/agent-device.md": {
+      "at": "2026-03-29T08:49:16Z",
+      "hash": "80d8f534052cc4a569f014277d60a7c7d37d5163",
+      "passes": 1,
+      "pr": 12788
+    },
+    ".agents/tools/mobile/app-dev-assets.md": {
+      "at": "2026-03-29T16:34:32Z",
+      "hash": "8f76e90204fd0b7026215b94a921c93725ccb49a",
+      "passes": 1,
+      "pr": 13108
+    },
+    ".agents/tools/mobile/app-dev-backend.md": {
+      "at": "2026-03-29T20:54:10Z",
+      "hash": "5f71ae0bae38bd26b8c8c17334f67f94f5519118",
+      "passes": 1,
+      "pr": 13293
+    },
+    ".agents/tools/mobile/app-dev-expo.md": {
+      "at": "2026-03-30T03:34:14Z",
+      "hash": "88b9790e15b5b59fde8864acf694675a04ea868b",
+      "passes": 1,
+      "pr": 13609
+    },
+    ".agents/tools/mobile/app-dev-notifications.md": {
+      "at": "2026-03-29T16:34:38Z",
+      "hash": "91e194cf38a56b23b49c55c4a35aa4bd298301c5",
+      "passes": 1,
+      "pr": 13111
+    },
+    ".agents/tools/mobile/app-dev-publishing.md": {
+      "at": "2026-03-29T08:11:31Z",
+      "hash": "7e85e545bfde087a1ad9aeb7535bd1df9f04b2f6",
+      "passes": 2,
+      "pr": 12760
+    },
+    ".agents/tools/mobile/app-dev-swift.md": {
+      "at": "2026-03-29T07:03:03Z",
+      "hash": "d3b5663bc33b6383bc1ed7bcefe4a08f28f7f601",
+      "passes": 1,
+      "pr": 12506
+    },
+    ".agents/tools/mobile/app-dev-testing.md": {
+      "at": "2026-04-01T20:59:09Z",
+      "hash": "f552829f8040483a2661eceff47f7ae2b5340a1b",
+      "passes": 1,
+      "pr": 15219
+    },
+    ".agents/tools/mobile/app-dev.md": {
+      "at": "2026-03-29T08:10:35Z",
+      "hash": "7e95c86a1ff47fc03e63be9444379acd7960229f",
+      "passes": 1,
+      "pr": 12752
+    },
+    ".agents/tools/mobile/app-store-connect.md": {
+      "at": "2026-03-29T07:02:17Z",
+      "hash": "39b15510cf46404a8656dc67ec4a66404245258c",
+      "passes": 1,
+      "pr": 12625
+    },
+    ".agents/tools/mobile/axe-cli.md": {
+      "at": "2026-04-03T19:14:46Z",
+      "hash": "3d0cf750b1b76b4881c685db8feb0be255e098fe",
+      "passes": 1,
+      "pr": 16795
+    },
+    ".agents/tools/mobile/ios-simulator-mcp.md": {
+      "at": "2026-03-29T20:53:56Z",
+      "hash": "33fdb9ed9ce6eb6d817e314a40872de61de2681b",
+      "passes": 1,
+      "pr": 13299
+    },
+    ".agents/tools/mobile/maestro.md": {
+      "at": "2026-03-30T03:34:20Z",
+      "hash": "dc5dbec1ecee73a26cd076ffa2891af198e623c6",
+      "passes": 1,
+      "pr": 13525
+    },
+    ".agents/tools/mobile/minisim.md": {
+      "at": "2026-03-29T21:43:16Z",
+      "hash": "d208b0be4c1a2b820cd1956c0ddfc52cd981d64f",
+      "passes": 1,
+      "pr": 13340
+    },
+    ".agents/tools/mobile/xcodebuild-mcp.md": {
+      "at": "2026-04-03T11:54:13Z",
+      "hash": "2edbe988a06f60f5a4d742cc9837530d70e5a815",
+      "passes": 1,
+      "pr": 16539
+    },
+    ".agents/tools/monorepo/turborepo.md": {
+      "at": "2026-03-30T06:49:45Z",
+      "hash": "cfe5067e6064e097d19bd7538172ac0201c72b65",
+      "passes": 2,
+      "pr": 13795
+    },
+    ".agents/tools/multimodal-evaluation.md": {
+      "at": "2026-04-04T06:18:00Z",
+      "hash": "da3da79d8c549978225657036561d1a67fed9b71",
+      "passes": 1,
+      "pr": 17142
+    },
+    ".agents/tools/ocr/glm-ocr.md": {
+      "at": "2026-04-03T12:15:32Z",
+      "hash": "39abe93658ecd1376746e7397818f841e8d5bd7b",
+      "passes": 1,
+      "pr": 16554
+    },
+    ".agents/tools/ocr/ocr-research.md": {
+      "at": "2026-03-28T13:37:30Z",
+      "hash": "17f55fa81ce7e4925886667b0579540dd77b40cf",
+      "passes": 1,
+      "pr": 11857
+    },
+    ".agents/tools/ocr/overview.md": {
+      "at": "2026-04-03T16:35:54Z",
+      "hash": "6dedb5ff5ef2e5d4288b956494a2bfc34b15b864",
+      "passes": 1,
+      "pr": 16637
+    },
+    ".agents/tools/ocr/paddleocr.md": {
+      "at": "2026-03-30T06:49:51Z",
+      "hash": "e645b46e9c78fc416a8a4b71becd8d082188afc7",
+      "passes": 1,
+      "pr": 13765
+    },
+    ".agents/tools/opencode/opencode-anthropic-auth.md": {
+      "at": "2026-03-29T03:15:28Z",
+      "hash": "4e8c39e779a42ac6cf7b6726bd6fe78313534e51",
+      "passes": 1,
+      "pr": 12522
+    },
+    ".agents/tools/opencode/opencode-openai-auth.md": {
+      "at": "2026-04-03T20:28:52Z",
+      "hash": "954661f8ba7b46b129a1a1e2f2a25e1d41a91545",
+      "passes": 1,
+      "pr": 16788
+    },
+    ".agents/tools/opencode/opencode.md": {
+      "at": "2026-03-29T11:20:16Z",
+      "hash": "696fc30d6e79a81dbc4c654ef71a347506c9b5a7",
+      "passes": 1,
+      "pr": 12843
+    },
+    ".agents/tools/pdf/libpdf.md": {
+      "at": "2026-03-28T20:16:42Z",
+      "hash": "df32e4457c96dc0a0e30f99129e8f690a122a2c4",
+      "passes": 1,
+      "pr": 12161
+    },
+    ".agents/tools/pdf/overview.md": {
+      "at": "2026-04-03T19:14:40Z",
+      "hash": "babee66734537f444f3fdc63ff198e1738493924",
       "passes": 1
+    },
+    ".agents/tools/performance/performance.md": {
+      "at": "2026-03-28T16:00:21Z",
+      "hash": "bf97d384c4870c4bd126c114e1a4b7dafe0cf881",
+      "passes": 1,
+      "pr": 11983
+    },
+    ".agents/tools/performance/webpagetest.md": {
+      "at": "2026-03-28T08:17:50Z",
+      "hash": "90e0b779107ce16e7186685c87c0391b88b137ef",
+      "passes": 1,
+      "pr": 11594
+    },
+    ".agents/tools/productivity/apple-reminders.md": {
+      "at": "2026-04-03T14:06:30Z",
+      "hash": "0bf76947cbd404359a53093f28e6ff10ee767eb2",
+      "passes": 1,
+      "pr": 16613
+    },
+    ".agents/tools/productivity/caldav-calendar-skill.md": {
+      "at": "2026-04-03T19:14:47Z",
+      "hash": "e4b4104505e1bee3c23b7aecb805ef5fad38252b",
+      "passes": 1,
+      "pr": 16750
+    },
+    ".agents/tools/productivity/calendar.md": {
+      "at": "2026-04-03T19:14:46Z",
+      "hash": "55583a8d44bdfd776d1c3e956813dedeebd04c27",
+      "passes": 1,
+      "pr": 16790
+    },
+    ".agents/tools/productivity/contacts.md": {
+      "at": "2026-04-03T13:35:15Z",
+      "hash": "a9fdc1de8d5532ac02b21837b470f091eb270ecf",
+      "passes": 1,
+      "pr": 16497
+    },
+    ".agents/tools/productivity/notes.md": {
+      "at": "2026-04-03T12:15:32Z",
+      "hash": "0fcae0745258f4d6e4f3d9420f33b39d1eab9112",
+      "passes": 1,
+      "pr": 16552
+    },
+    ".agents/tools/programming/modern-javascript-skill.md": {
+      "at": "2026-04-01T20:59:25Z",
+      "hash": "47b55328e048c60d654647f946df59c3836e5fa1",
+      "passes": 1,
+      "pr": 15131
+    },
+    ".agents/tools/programming/modern-javascript-skill/01-decision-trees.md": {
+      "at": "2026-04-01T20:59:25Z",
+      "hash": "241f4a3b8466d306e07aa80178d184e9dfb89813",
+      "passes": 1,
+      "pr": 15131
+    },
+    ".agents/tools/programming/modern-javascript-skill/02-es-versions.md": {
+      "at": "2026-04-01T20:59:25Z",
+      "hash": "4c8efb98765918aeb91c6c27468322860f85ebdf",
+      "passes": 1,
+      "pr": 15131
+    },
+    ".agents/tools/programming/modern-javascript-skill/cheatsheet.md": {
+      "at": "2026-03-28T16:40:20Z",
+      "hash": "b159f4fa6de09be8185323ca9d0f05c14a9a012d",
+      "passes": 1,
+      "pr": 12042
+    },
+    ".agents/tools/programming/modern-javascript-skill/composition.md": {
+      "at": "2026-03-28T03:53:07Z",
+      "hash": "b46fc38d6db3ad25a0f493a62c9db380f0af72ea",
+      "passes": 1,
+      "pr": 11328
+    },
+    ".agents/tools/programming/modern-javascript-skill/concurrency.md": {
+      "at": "2026-03-29T22:50:16Z",
+      "hash": "896412638b06c7e34f990bb930129a819979db56",
+      "passes": 2,
+      "pr": 13349
+    },
+    ".agents/tools/programming/modern-javascript-skill/es2016-es2017.md": {
+      "at": "2026-04-03T01:11:46Z",
+      "hash": "77b181e2b0e95ddde4d4d1a01d1e176066b30306",
+      "passes": 1,
+      "pr": 15969
+    },
+    ".agents/tools/programming/modern-javascript-skill/es2018-es2019.md": {
+      "at": "2026-03-28T05:50:55Z",
+      "hash": "ac1032b10ca7a6d010e5c0075774e7679edbe2ec",
+      "passes": 1,
+      "pr": 11439
+    },
+    ".agents/tools/programming/modern-javascript-skill/es2022-es2023.md": {
+      "at": "2026-03-28T03:53:13Z",
+      "hash": "608d6037a22cbc948bb9fe7739be906b2786fb03",
+      "passes": 1,
+      "pr": 11337
+    },
+    ".agents/tools/programming/modern-javascript-skill/es2024.md": {
+      "at": "2026-03-27T21:25:08Z",
+      "hash": "7013a082c06d9066d8f79a83bbb8e8aa29829b27",
+      "passes": 1,
+      "pr": 11002
+    },
+    ".agents/tools/programming/modern-javascript-skill/es2025.md": {
+      "at": "2026-03-28T21:58:57Z",
+      "hash": "ce555c928cfb853d3497544a6bc730c6da40fcbc",
+      "passes": 1,
+      "pr": 12234
+    },
+    ".agents/tools/programming/modern-javascript-skill/immutability.md": {
+      "at": "2026-04-03T11:54:14Z",
+      "hash": "5b23af121a1ea49028004359340334bc9b8a6105",
+      "passes": 1,
+      "pr": 16493
+    },
+    ".agents/tools/programming/modern-javascript-skill/upcoming.md": {
+      "at": "2026-03-29T07:02:28Z",
+      "hash": "ee06c980e465703b5763d6f3e04456ec44b8755a",
+      "passes": 1,
+      "pr": 12584
+    },
+    ".agents/tools/research/providers/crft-lookup.md": {
+      "at": "2026-03-30T03:34:28Z",
+      "hash": "9f5ee39030396bec4256a2eb2db92fdd603107bd",
+      "passes": 1,
+      "pr": 13542
+    },
+    ".agents/tools/research/providers/openexplorer.md": {
+      "at": "2026-04-03T01:53:17Z",
+      "hash": "d7f1854232803e4216f38d611ade45b7014b2415",
+      "passes": 2,
+      "pr": 15822
+    },
+    ".agents/tools/research/providers/unbuilt.md": {
+      "at": "2026-03-29T12:36:25Z",
+      "hash": "07ac398ca7f3b49945420b8fe81b3d30902a09d9",
+      "passes": 1,
+      "pr": 12945
+    },
+    ".agents/tools/research/providers/wappalyzer.md": {
+      "at": "2026-03-28T20:17:04Z",
+      "hash": "a28977b2b192caa441b52416400d08a51f188a6a",
+      "passes": 1,
+      "pr": 12115
+    },
+    ".agents/tools/research/tech-stack-lookup.md": {
+      "at": "2026-03-29T07:02:42Z",
+      "hash": "ddb13dc4cc1476d6756b10b07641e96dc1d3a6f8",
+      "passes": 1,
+      "pr": 12579
+    },
+    ".agents/tools/security/cdn-origin-ip.md": {
+      "at": "2026-03-29T20:53:57Z",
+      "hash": "eebbe1d1794c065ac7d266ac98e78e5faccb85de",
+      "passes": 1,
+      "pr": 13290
+    },
+    ".agents/tools/security/ip-reputation.md": {
+      "at": "2026-03-28T03:54:03Z",
+      "hash": "23d8e2625cd6d45b1802fb546022825e885a79e5",
+      "passes": 1,
+      "pr": 11342
+    },
+    ".agents/tools/security/opsec.md": {
+      "at": "2026-03-29T03:15:14Z",
+      "hash": "b0ef81cdddb719b70c07c0fc5c16d74dc7557243",
+      "passes": 1,
+      "pr": 12507
+    },
+    ".agents/tools/security/privacy-filter.md": {
+      "at": "2026-03-28T16:41:02Z",
+      "hash": "79159cf02baf9a0d43e8bb9626c762e100880c87",
+      "passes": 1,
+      "pr": 12014
+    },
+    ".agents/tools/security/prompt-injection-defender.md": {
+      "at": "2026-03-28T17:11:06Z",
+      "hash": "a185d5fcfb43a0b03c383cdb790991b4e4171bce",
+      "passes": 1,
+      "pr": 12057
+    },
+    ".agents/tools/security/security-review.md": {
+      "at": "2026-04-11T17:01:44Z",
+      "hash": "86e12ee2f68e13f130b450943844319d47ec13fe",
+      "passes": 1,
+      "pr": 18317
+    },
+    ".agents/tools/security/shannon.md": {
+      "at": "2026-03-28T16:41:03Z",
+      "hash": "8380ca95494e14863da36405e461ea018879f0ab",
+      "passes": 1,
+      "pr": 12016
+    },
+    ".agents/tools/security/tamper-evident-audit.md": {
+      "at": "2026-03-29T21:43:17Z",
+      "hash": "29868770e5c148bbbc70a6262085dccfa2a7e4fa",
+      "passes": 1,
+      "pr": 13316
+    },
+    ".agents/tools/security/tirith.md": {
+      "at": "2026-04-03T04:23:07Z",
+      "hash": "0e5a61217d3b30eac5bdf6f41d05d81970e5dcf3",
+      "passes": 1,
+      "pr": 15777
+    },
+    ".agents/tools/task-management/beads.md": {
+      "at": "2026-03-29T09:39:21Z",
+      "hash": "31711547e5dfdff7c67c16eeda61a862e616759f",
+      "passes": 1,
+      "pr": 12830
+    },
+    ".agents/tools/terminal/terminal-optimization.md": {
+      "at": "2026-03-29T03:15:29Z",
+      "hash": "1d87a2f26445285a961b77051d6dcb6b55492d2c",
+      "passes": 1,
+      "pr": 12526
+    },
+    ".agents/tools/terminal/terminal-title.md": {
+      "at": "2026-04-03T01:11:48Z",
+      "hash": "ad3e1b06bf9ac74cf8c72a538adcfc5c3f2cea4f",
+      "passes": 1,
+      "pr": 15726
+    },
+    ".agents/tools/testing-setup.md": {
+      "at": "2026-04-11T13:54:28Z",
+      "hash": "add7056788f9b456c2867f2c6133f6986df52b5f",
+      "passes": 1,
+      "pr": 18171
+    },
+    ".agents/tools/ui/ai-chat-sidebar.md": {
+      "at": "2026-04-02T15:28:13Z",
+      "hash": "0cf217206160855614dabf37336b3e28a8a06b08",
+      "passes": 3,
+      "pr": 13958
+    },
+    ".agents/tools/ui/frontend-debugging.md": {
+      "at": "2026-03-28T03:54:06Z",
+      "hash": "a6d23658a56048f995610f91ce49c03f0e5cccf9",
+      "passes": 1,
+      "pr": 11340
+    },
+    ".agents/tools/ui/i18next.md": {
+      "at": "2026-03-28T10:27:25Z",
+      "hash": "8608931754506274f61d74ebd5803aae0cc20e16",
+      "passes": 1,
+      "pr": 11710
+    },
+    ".agents/tools/ui/nextjs-layouts.md": {
+      "at": "2026-03-28T11:20:37Z",
+      "hash": "c88cf42ea60d680edf13302ecb87e549a2cadd93",
+      "passes": 1,
+      "pr": 11732
+    },
+    ".agents/tools/ui/nothing-design-skill.md": {
+      "at": "2026-04-03T22:25:52Z",
+      "hash": "6fb72c3e38d18425604475b434c2c66a57481e5e",
+      "passes": 2,
+      "pr": 15566
+    },
+    ".agents/tools/ui/nothing-design-skill/01-philosophy.md": {
+      "at": "2026-04-02T13:10:58Z",
+      "hash": "92d9534084a0bedcee771becb6216b9e392920fd",
+      "passes": 1,
+      "pr": 15566
+    },
+    ".agents/tools/ui/nothing-design-skill/02-craft-rules.md": {
+      "at": "2026-04-02T13:10:58Z",
+      "hash": "950df66a0b8636e3de10aa7f0dc4b8840f5b3bba",
+      "passes": 1,
+      "pr": 15566
+    },
+    ".agents/tools/ui/nothing-design-skill/03-anti-patterns.md": {
+      "at": "2026-04-02T13:10:58Z",
+      "hash": "e4e29fac7359f13548074a9ba85ed9f93c968e21",
+      "passes": 1,
+      "pr": 15566
+    },
+    ".agents/tools/ui/nothing-design-skill/04-workflow.md": {
+      "at": "2026-04-02T13:10:58Z",
+      "hash": "3d2d94a8a4cdf5037c03348f2f207bc4db2f2da5",
+      "passes": 1,
+      "pr": 15566
+    },
+    ".agents/tools/ui/nothing-design-skill/components.md": {
+      "at": "2026-04-03T03:15:24Z",
+      "hash": "f9bd742a9999b599e25ab3485f29e113cea87cc4",
+      "passes": 1
+    },
+    ".agents/tools/ui/nothing-design-skill/platform-mapping.md": {
+      "at": "2026-04-03T16:35:53Z",
+      "hash": "2cfa6df71658fb20a6ad4298e4a3ba553332103f",
+      "passes": 1,
+      "pr": 16673
+    },
+    ".agents/tools/ui/nothing-design-skill/tokens.md": {
+      "at": "2026-04-03T12:15:29Z",
+      "hash": "a7e497864d35b71b11bc7edc1e8a745e558aa7d8",
+      "passes": 4,
+      "pr": 16561
     },
     ".agents/tools/ui/nothing-design-skill/tokens/02-color.md": {
-      "hash": "1c7e2fd573d7671682df3587ac932f0f3f089390",
       "at": "2026-04-04T14:53:57Z",
+      "hash": "1c7e2fd573d7671682df3587ac932f0f3f089390",
       "passes": 2,
       "pr": null
     },
-    ".agents/scripts/attribution-detection-helper.sh": {
-      "hash": "5990dd296001d54709e73b55f692043adaaa3c15",
-      "at": "2026-04-09T07:32:00Z",
+    ".agents/tools/ui/react-context.md": {
+      "at": "2026-03-30T06:49:50Z",
+      "hash": "936299600e06ee59b65ffc61205f3134e1826fa9",
+      "passes": 1,
+      "pr": 13766
+    },
+    ".agents/tools/ui/react-email.md": {
+      "at": "2026-03-29T07:02:59Z",
+      "hash": "618f641bce738c3da28d99bdc78f80b807a565f7",
+      "passes": 1,
+      "pr": 12619
+    },
+    ".agents/tools/ui/shadcn.md": {
+      "at": "2026-04-13T16:27:56Z",
+      "hash": "c660b4e8b133c31ecc094440e8ea6934613d5ecc",
+      "passes": 2,
+      "pr": 12590
+    },
+    ".agents/tools/ui/tailwind-css.md": {
+      "at": "2026-03-29T07:02:43Z",
+      "hash": "3258af59be822e141f3fd64a3790e77b12af82ab",
+      "passes": 1,
+      "pr": 12576
+    },
+    ".agents/tools/ui/ui-skills.md": {
+      "at": "2026-04-03T22:25:53Z",
+      "hash": "523286e313aee9bc39321d092c06aca4a062dee0",
       "passes": 3,
-      "pr": 0
+      "pr": 16281
+    },
+    ".agents/tools/ui/wxt.md": {
+      "at": "2026-03-28T13:37:50Z",
+      "hash": "6b2ef27f2ab2380af002ec8e111519683fb5d70e",
+      "passes": 1,
+      "pr": 11870
+    },
+    ".agents/tools/verification/parallel-verify.md": {
+      "at": "2026-03-29T10:19:07Z",
+      "hash": "c2b049c2ad6b6d75c1b5e2e0c113f922504f3aec",
+      "passes": 1,
+      "pr": 12849
+    },
+    ".agents/tools/video/remotion-3d.md": {
+      "at": "2026-04-01T20:59:48Z",
+      "hash": "69bbc032fa20923b0526133ce8bccb63592bd16f",
+      "passes": 1,
+      "pr": 14897
+    },
+    ".agents/tools/video/remotion-audio.md": {
+      "at": "2026-03-29T12:37:07Z",
+      "hash": "a96f93cceea0be4a6279296651b339612a04a429",
+      "passes": 1,
+      "pr": 12942
+    },
+    ".agents/tools/video/remotion-calculate-metadata.md": {
+      "at": "2026-04-03T03:37:02Z",
+      "hash": "559372573df68d1471de5ff59427e92da89e507c",
+      "passes": 1,
+      "pr": 16141
+    },
+    ".agents/tools/video/remotion-can-decode.md": {
+      "at": "2026-04-03T19:14:47Z",
+      "hash": "cf254acfb0dd412f218fed7fd587ad63ab877592",
+      "passes": 1,
+      "pr": 16753
     },
     ".agents/tools/video/remotion-charts.md": {
-      "hash": "08ae4026fa5517f2f86b8c66f8128e9906b8f716",
       "at": "2026-04-04T14:53:58Z",
+      "hash": "08ae4026fa5517f2f86b8c66f8128e9906b8f716",
       "passes": 2,
       "pr": 0
     },
-    ".agents/tools/design/library/brands/voltagent/02-color-palette.md": {
-      "hash": "40ae0c8eec93283421615932a8ffd9caa72301f6",
-      "at": "2026-04-04T14:54:08Z",
-      "pr": 17342,
-      "passes": 1
-    },
-    ".agents/tools/design/library/brands/ibm/04-components.md": {
-      "hash": "2ea28505b2fd0a5fd905570cc9911cd6e8f8cdfc",
-      "at": "2026-04-04T14:54:08Z",
-      "pr": 17332,
-      "passes": 1
-    },
-    ".agents/reference/attribution-monitoring.md": {
-      "hash": "bf262309ae04f51cc53f5ffaf44fb65b9ee5f60e",
-      "at": "2026-04-04T14:54:09Z",
-      "pr": 17331,
-      "passes": 1
-    },
-    ".agents/tools/design/library/styles/playful-vibrant/05-layout.md": {
-      "hash": "e43fd8c8ee2db2961e134fe365c20121f64eecb8",
-      "at": "2026-04-04T14:54:09Z",
-      "pr": 17321,
-      "passes": 1
-    },
-    ".agents/tools/design/library/styles/agency-techie/04-components.md": {
-      "hash": "dd244e9d27c0ef7c55976cf7387e65a45bc7ea08",
-      "at": "2026-04-04T14:54:09Z",
-      "pr": 17319,
-      "passes": 1
-    },
-    ".agents/tools/design/library/brands/lovable/04-components.md": {
-      "hash": "7d5356d99a15fa19ad48c85f1d0dfef5d0f0567b",
-      "at": "2026-04-04T14:54:09Z",
-      "pr": 17318,
-      "passes": 1
-    },
-    ".agents/marketing-sales/cro-chapter-24.md": {
-      "hash": "408af22ccf4cf16d851c70a31d946b7cd014b330",
-      "at": "2026-04-04T14:54:10Z",
-      "pr": 17313,
-      "passes": 1
-    },
-    ".agents/tools/design/library/styles/developer-dark/04-components.md": {
-      "hash": "8fb82a7b1163431a819d14f5d1903618825b7bdc",
-      "at": "2026-04-04T14:54:10Z",
-      "pr": 17312,
-      "passes": 1
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/cache-reserve.md": {
-      "hash": "3fe0b9baeb496344edd2cae2361ea302bcb7add9",
-      "at": "2026-04-04T14:54:10Z",
-      "pr": 17307,
-      "passes": 1
-    },
-    ".agents/scripts/commands/seo-optimize.md": {
-      "hash": "d4781587585025ddaf8cd43af9117ab3d94f7152",
-      "at": "2026-04-04T14:54:10Z",
-      "pr": 17306,
-      "passes": 1
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/ai-search-patterns.md": {
-      "hash": "fad7c34adae6b1e75cf375aa6cf179aae4e71421",
-      "at": "2026-04-04T14:54:10Z",
-      "pr": 17305,
-      "passes": 1
-    },
-    ".agents/tools/design/library/brands/raycast/04-components.md": {
-      "hash": "85c7855f640acea135d7da05dff11e1c68a91501",
-      "at": "2026-04-04T14:54:11Z",
-      "pr": 17300,
-      "passes": 1
-    },
-    ".agents/tools/design/library/brands/vercel/02-color-palette.md": {
-      "hash": "43bfb525bb16396e8b453a5e92926c34919dc094",
-      "at": "2026-04-04T14:54:11Z",
-      "pr": 17299,
-      "passes": 1
-    },
-    ".agents/tools/design/library/styles/startup-bold/05-layout.md": {
-      "hash": "b6ca30e0a3b04bc92f1141517fe39f8f4f30fe6c",
-      "at": "2026-04-04T14:54:11Z",
-      "pr": 17298,
-      "passes": 1
-    },
-    ".agents/tools/design/library/brands/linear/04-components.md": {
-      "hash": "fa506cfae29a0ffc90af44e498d4e3bbbf6ac4c1",
-      "at": "2026-04-04T14:54:11Z",
-      "pr": 17297,
-      "passes": 1
-    },
-    ".agents/tools/design/library/brands/nvidia/02-color-palette.md": {
-      "hash": "3b5ff6b20e796af78ef3d2ddb3e0442148a59be6",
-      "at": "2026-04-04T14:54:12Z",
-      "pr": 17296,
-      "passes": 1
-    },
-    ".agents/tools/design/library/styles/corporate-friendly/02-colour-palette.md": {
-      "hash": "5d6d4238a9f4801fc21d5abc5d9caf57ce0901f3",
-      "at": "2026-04-04T14:54:12Z",
-      "pr": 17295,
-      "passes": 1
-    },
-    ".agents/tools/credentials/cch-reverse-engineering.md": {
-      "hash": "f5455c7d7ef29929c53715de3403db074ac216f0",
-      "at": "2026-04-13T16:27:47Z",
-      "pr": 17294,
-      "passes": 2
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/pages-functions.md": {
-      "hash": "4dbb56cad0d43f81be292f70d1a0986262a9b087",
-      "at": "2026-04-04T14:54:12Z",
-      "pr": 17281,
-      "passes": 1
-    },
-    ".agents/tools/browser/chromium-debug-use/SKILL.md": {
-      "hash": "4c95ad2b5c1fd7e7deed50ff5d128f2af631adce",
-      "at": "2026-04-04T14:54:12Z",
-      "pr": 17280,
-      "passes": 1
-    },
-    ".agents/tools/design/library/brands/linear/02-colour-palette.md": {
-      "hash": "899a584bd0b79aaa333c96504a162f457638eda5",
-      "at": "2026-04-04T14:54:13Z",
-      "pr": 17279,
-      "passes": 1
-    },
-    ".agents/scripts/commands/readme.md": {
-      "hash": "649a3483e9e073b8f1f1d2cffbe07b8575f79a92",
-      "at": "2026-04-04T14:54:13Z",
-      "pr": 17278,
-      "passes": 1
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/ai-search-gotchas.md": {
-      "hash": "2c7d77810b23fc6ed30a09a74e72a27273282311",
-      "at": "2026-04-04T14:54:13Z",
-      "pr": 17263,
-      "passes": 1
-    },
-    ".agents/tools/design/library/brands/stripe/02-color-palette.md": {
-      "hash": "33f19762a6d943289c75a2395c91af6646d0e381",
-      "at": "2026-04-04T14:54:14Z",
-      "pr": 17260,
-      "passes": 1
-    },
-    ".agents/tools/design/library/brands/resend/02-color-palette.md": {
-      "hash": "510e71a96285289e17ee81a6b84623e2f5fc5b69",
-      "at": "2026-04-04T14:54:14Z",
-      "pr": 17258,
-      "passes": 1
-    },
-    ".agents/tools/design/library/brands/opencode.ai/04-components.md": {
-      "hash": "d37acef0834027b351417bb9cc6fdaaead2399a6",
-      "at": "2026-04-04T14:54:14Z",
-      "pr": 17257,
-      "passes": 1
-    },
-    ".agents/tools/design/library/styles/agency-creative/02-colours.md": {
-      "hash": "ff44198fa17972cfd740258291dc507f8505004b",
-      "at": "2026-04-04T14:54:14Z",
-      "pr": 17256,
-      "passes": 1
-    },
-    ".agents/tools/design/library/brands/mongodb/04-components.md": {
-      "hash": "313a10856fb179b870a63e63b645b324990711a2",
-      "at": "2026-04-04T14:54:14Z",
-      "pr": 17254,
-      "passes": 1
-    },
-    ".agents/tools/design/library/brands/nvidia/04-components.md": {
-      "hash": "b387cc195bceb43163a9230e6efd4e67dcab755a",
-      "at": "2026-04-04T14:54:15Z",
-      "pr": 17253,
-      "passes": 1
-    },
-    ".agents/tools/design/library/brands/clay/02-color-palette.md": {
-      "hash": "e1dd3a054cbfc5c78d9c4ee208413787b46330ed",
-      "at": "2026-04-04T14:54:15Z",
-      "pr": 17252,
-      "passes": 1
-    },
-    ".agents/tools/design/library/brands/claude/05-layout.md": {
-      "hash": "2ee2025b7d167573809f27095b93cd2bf2bc1937",
-      "at": "2026-04-04T14:54:15Z",
-      "pr": 17251,
-      "passes": 1
-    },
-    ".agents/tools/design/library/brands/vercel/04-components.md": {
-      "hash": "1012934f5582c4f4118ddd2ebdaee4c4e6380630",
-      "at": "2026-04-04T14:54:15Z",
-      "pr": 17242,
-      "passes": 1
-    },
-    ".agents/tools/design/library/brands/claude/04-components.md": {
-      "hash": "af40eeaf62adcd487b783d345ae02cbf61805789",
-      "at": "2026-04-04T14:54:16Z",
-      "pr": 17241,
-      "passes": 1
-    },
-    ".agents/tools/design/library/styles/playful-vibrant/02-colour-palette.md": {
-      "hash": "c3934e0177fbe5118d2b5b6c77144293a467ed7d",
-      "at": "2026-04-04T14:54:16Z",
-      "pr": 17240,
-      "passes": 1
-    },
-    ".agents/tools/design/library/brands/voltagent/04-components.md": {
-      "hash": "455d06dbc2ad5ac0899103635d546b337a341af3",
-      "at": "2026-04-04T14:54:16Z",
-      "pr": 17239,
-      "passes": 1
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/api-patterns.md": {
-      "hash": "2d22fd57bd06f00a7615b4632189fcae857e3496",
-      "at": "2026-04-04T14:54:16Z",
-      "pr": 17221,
-      "passes": 1
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/argo-smart-routing-patterns.md": {
-      "hash": "a870e621cfc06b222513a0bc271789431937b860",
-      "at": "2026-04-04T16:52:36Z",
-      "pr": 17220,
-      "passes": 2
-    },
-    ".agents/services/hosting/cloudflare-platform-skill/bindings-patterns.md": {
-      "hash": "f119c69a039a7367b648aa287aa44fda708a497f",
-      "at": "2026-04-04T14:54:17Z",
-      "pr": 17219,
-      "passes": 1
-    },
-    ".agents/tools/ai-assistants/models-haiku.md": {
-      "hash": "e19a01fb3e479ce82ed89c2e0111bc8e72606c09",
-      "at": "2026-04-04T16:52:41Z",
-      "pr": 17218,
-      "passes": 2
-    },
-    ".agents/tools/design/library/styles/agency-feminine/04-components.md": {
-      "hash": "5f1bd3b67c5520a45522414e833317cb18ee4f10",
-      "at": "2026-04-04T16:52:50Z",
-      "pr": 17217,
-      "passes": 2
-    },
-    ".agents/scripts/worker-lifecycle-common.sh": {
-      "hash": "15a54c2316949e5f5bcbb52efbf7587f95e87863",
-      "at": "2026-04-15T15:27:41Z",
-      "pr": 17353,
-      "passes": 6
-    },
-    ".agents/tools/code-review/setup.md": {
-      "hash": "fb0d5288be7a808f9dc232d229f4dca354745323",
-      "at": "2026-04-04T15:34:57Z",
-      "pr": 17343,
-      "passes": 1
-    },
-    ".agents/tools/design/library/brands/composio/04-components.md": {
-      "hash": "0c5045bca1d19159413918d402960e4735ae7cca",
-      "at": "2026-04-04T15:34:57Z",
-      "pr": 17341,
-      "passes": 1
-    },
-    ".agents/tools/design/library/brands/uber/04-components.md": {
-      "hash": "4ec6802a7a92580fb74e4b230ec84fe570cb89ff",
-      "at": "2026-04-04T15:34:57Z",
-      "pr": 17340,
-      "passes": 1
-    },
-    ".agents/scripts/worker-watchdog.sh": {
-      "hash": "135e62ddb97682effe07cb0b1ce2c3235f42e1e5",
-      "at": "2026-04-15T03:00:33Z",
-      "pr": 17393,
-      "passes": 4
-    },
-    ".agents/scripts/verify-issue-close-helper.sh": {
-      "hash": "811b3aeb9a94e62bd483f7a13f27ded4e3cbf0ef",
-      "at": "2026-04-05T07:51:05Z",
-      "pr": 17378,
-      "passes": 1
-    },
-    ".agents/scripts/approval-helper.sh": {
-      "hash": "5e11b9ad67f1c65ca3f599af558ef858cb1b4132",
-      "at": "2026-04-14T08:25:15Z",
-      "pr": 17454,
-      "passes": 5
-    },
-    ".agents/reference/customization.md": {
-      "hash": "f0eacffbaf909a5f1849f7bf5668c92a81ba252d",
-      "at": "2026-04-05T19:44:17Z",
-      "pr": 17436,
-      "passes": 1
-    },
-    ".agents/workflows/triage-review.md": {
-      "hash": "9c35be6b80b3dfa780f30347eaceae676d42776f",
-      "at": "2026-04-15T03:00:56Z",
-      "pr": 17494,
-      "passes": 4
-    },
-    ".agents/scripts/validate-version-consistency.sh": {
-      "hash": "0c91e91529418e35bee2c22d9f0ea1286d60022f",
-      "at": "2026-04-06T14:25:05Z",
-      "pr": 17537,
-      "passes": 1
-    },
-    ".agents/scripts/claim-task-id.sh": {
-      "hash": "f8f3af654bf30e0b9160bd71c2de7ffa3e66c56b",
-      "at": "2026-04-15T19:03:23Z",
-      "pr": 17531,
-      "passes": 6
-    },
-    ".agents/scripts/quality-feedback-helper.sh": {
-      "hash": "257a7f0e60d5b7b6ce51b93f4e150b0fb2babff7",
-      "at": "2026-04-14T21:13:01Z",
-      "pr": 19000,
-      "passes": 3
-    },
-    ".agents/scripts/tabby-helper.sh": {
-      "hash": "fcbdba8938e0a37591f2fb3e51fb24062d01356d",
-      "at": "2026-04-15T21:02:40Z",
-      "pr": 17549,
-      "passes": 3
-    },
-    ".agents/configs/complexity-thresholds-history.md": {
-      "hash": "926a520d5bc815afd92ea09c1c54b21f0e45936f",
-      "at": "2026-04-15T22:51:45Z",
-      "pr": 17979,
-      "passes": 17
-    },
-    ".agents/scripts/memory-pressure-monitor.sh": {
-      "hash": "8df7dbaf7b29f4c65bf3fbce670d766a31eabb74",
-      "at": "2026-04-15T03:00:32Z",
-      "pr": 17843,
-      "passes": 2
-    },
-    ".agents/scripts/commands/init-routines.md": {
-      "hash": "bd1fec1da0b4e9aa2b45fe74a613d86d7f81106a",
-      "at": "2026-04-09T07:32:15Z",
-      "pr": 17819,
-      "passes": 1
-    },
-    ".agents/scripts/model-availability-helper.sh": {
-      "hash": "66d1406c1562ca42e13914a6cc27d2bd0625da3d",
-      "at": "2026-04-09T07:32:15Z",
-      "pr": 17797,
-      "passes": 1
-    },
-    ".agents/scripts/routine-log-helper.sh": {
-      "hash": "7fb1dd659344d6b04666fcc271264c30004c5e6b",
-      "at": "2026-04-15T03:31:35Z",
-      "pr": 17786,
-      "passes": 3
-    },
-    ".agents/reference/routines.md": {
-      "hash": "6327d4259cc6c85d5173c1b3a9e4b0fa28f29b27",
-      "at": "2026-04-09T07:32:15Z",
-      "pr": 17783,
-      "passes": 1
-    },
-    ".agents/tools/context/pageindex.md": {
-      "hash": "0e5ba2c8f16ab6362aa6de09ab2e704d534eaf27",
-      "at": "2026-04-09T07:32:15Z",
-      "pr": 17759,
-      "passes": 1
-    },
-    ".agents/scripts/complexity-scan-helper.sh": {
-      "hash": "8152194b368fd6ac11c3e76c6dffe05604e48bb9",
-      "at": "2026-04-11T17:01:25Z",
-      "pr": 17713,
-      "passes": 2
-    },
-    ".agents/workflows/brief/tier-standard.md": {
-      "hash": "ebc81028afe68e02bef6687b0ce0ce66e2ee622c",
-      "at": "2026-04-15T08:17:12Z",
-      "pr": 18940,
-      "passes": 3
-    },
-    ".agents/scripts/commands/optimize-tiers.md": {
-      "hash": "066bd6b47e328dbd06fdda6e003d447d060aa816",
-      "at": "2026-04-09T07:32:16Z",
-      "pr": 17660,
-      "passes": 1
-    },
-    ".agents/reference/worker-diagnostics.md": {
-      "hash": "5b00c40cfd173d9d69aad52b4c757b0a9a976133",
-      "at": "2026-04-13T16:27:30Z",
-      "pr": 17659,
-      "passes": 2
-    },
-    ".agents/workflows/brief/templates.md": {
-      "hash": "8f1ca1ac6cf9ab689d00af0945eb3af6ca039c80",
-      "at": "2026-04-15T03:59:49Z",
-      "pr": 17658,
-      "passes": 3
-    },
-    ".agents/workflows/brief.md": {
-      "hash": "0f13cdc0577cd473600fbb0a609536ad21c0a411",
-      "at": "2026-04-15T03:32:04Z",
-      "pr": 18927,
-      "passes": 4
-    },
-    ".agents/scripts/brief-tier-test-helper.sh": {
-      "hash": "e856d04a2fead9fcf07c4e5ca80ab1ce792e6348",
-      "at": "2026-04-09T07:32:16Z",
-      "pr": 17646,
-      "passes": 1
-    },
-    ".agents/scripts/profile-readme-helper.sh": {
-      "hash": "2bc11796eb2d8656da860f9d8cd75abce6224528",
-      "at": "2026-04-09T07:32:16Z",
-      "pr": 17590,
-      "passes": 1
-    },
-    ".agents/scripts/opencode-db-archive.sh": {
-      "hash": "2d1b2a3c0aea737a80a7f2d53af6c6e5637b5732",
-      "at": "2026-04-15T17:57:19Z",
-      "pr": 17584,
-      "passes": 2
-    },
-    ".agents/scripts/generate-opencode-commands.sh": {
-      "hash": "19ac53376024c9ffaf4cd651816b2c5c889eca53",
-      "at": "2026-04-09T07:32:16Z",
-      "pr": 17583,
-      "passes": 1
-    },
-    ".agents/scripts/generate-claude-commands.sh": {
-      "hash": "2d23d498eb9145bf0633990c845f71c562e90165",
-      "at": "2026-04-15T22:51:54Z",
-      "pr": 17571,
-      "passes": 2
-    },
-    ".agents/scripts/full-loop-helper.sh": {
-      "hash": "d369e2bc2b0e7f9dad45789af18d1132ed306093",
-      "at": "2026-04-15T22:51:54Z",
-      "pr": 19046,
-      "passes": 8
+    ".agents/tools/video/remotion-compositions.md": {
+      "at": "2026-03-29T23:18:01Z",
+      "hash": "245f9ae2d7a3c862020c55d3953efeaebe654cba",
+      "passes": 1,
+      "pr": 13427
+    },
+    ".agents/tools/video/remotion-display-captions.md": {
+      "at": "2026-04-03T11:54:14Z",
+      "hash": "30dfd1f7f74f06a5fabeb31738215d6664495db1",
+      "passes": 1,
+      "pr": 16476
+    },
+    ".agents/tools/video/remotion-extract-frames.md": {
+      "at": "2026-04-03T03:15:28Z",
+      "hash": "6eba160e3ad199ce14c43c2c660566e6231f6b77",
+      "passes": 1,
+      "pr": 15907
+    },
+    ".agents/tools/video/remotion-fonts.md": {
+      "at": "2026-04-02T14:42:45Z",
+      "hash": "8d38c741d9b22c3ee0ff8682974dafde8e34330d",
+      "passes": 1,
+      "pr": 15615
+    },
+    ".agents/tools/video/remotion-get-video-dimensions.md": {
+      "at": "2026-04-03T16:35:51Z",
+      "hash": "40001abb1d76fb6732a7aeff81ff93865bbd0714",
+      "passes": 1,
+      "pr": 16715
+    },
+    ".agents/tools/video/remotion-get-video-duration.md": {
+      "at": "2026-04-03T19:14:46Z",
+      "hash": "ad13f0e40374ea952fc79fa32b86880669d9da67",
+      "passes": 1,
+      "pr": 16805
+    },
+    ".agents/tools/video/remotion-gifs.md": {
+      "at": "2026-03-29T22:09:13Z",
+      "hash": "9e7bbe6e88a22b26d83f1ccd0a44ab0d97e9d88c",
+      "passes": 1,
+      "pr": 13322
+    },
+    ".agents/tools/video/remotion-images.md": {
+      "at": "2026-03-30T03:34:15Z",
+      "hash": "578ef1f246353a9f9ae8a39d8cde58595c64f8c0",
+      "passes": 1,
+      "pr": 13527
+    },
+    ".agents/tools/video/remotion-import-srt-captions.md": {
+      "at": "2026-04-02T04:56:51Z",
+      "hash": "606680df401fd919db10f04405b81f470ad1446b",
+      "passes": 1,
+      "pr": 15490
+    },
+    ".agents/tools/video/remotion-lottie.md": {
+      "at": "2026-04-02T04:56:53Z",
+      "hash": "11ee56fb503d2334f3cf622177037e1370fbe09c",
+      "passes": 1,
+      "pr": 15525
+    },
+    ".agents/tools/video/remotion-measuring-text.md": {
+      "at": "2026-03-29T21:43:06Z",
+      "hash": "6dfb73e67655a15396a73674bf1a1b5388ca5116",
+      "passes": 1,
+      "pr": 13315
+    },
+    ".agents/tools/video/remotion-sequencing.md": {
+      "at": "2026-04-02T21:58:20Z",
+      "hash": "23470ff9e1f0c3f6764d1517bcb0dafe4042b300",
+      "passes": 1,
+      "pr": 15533
+    },
+    ".agents/tools/video/remotion-timing.md": {
+      "at": "2026-04-01T20:59:53Z",
+      "hash": "bc2abb8553753b3391da3c11a404c3adacbdadea",
+      "passes": 1,
+      "pr": 14881
+    },
+    ".agents/tools/video/remotion-transitions.md": {
+      "at": "2026-04-02T20:04:38Z",
+      "hash": "48bc0dec968b15216a1b065cb874f447e7f4137b",
+      "passes": 2,
+      "pr": 14883
+    },
+    ".agents/tools/video/remotion-trimming.md": {
+      "at": "2026-04-03T19:14:42Z",
+      "hash": "980b73f9ec656bf4cd9bc0f0ce6c07a86da00773",
+      "issue": 16798,
+      "passes": 2,
+      "pr": null
+    },
+    ".agents/tools/video/remotion-videos.md": {
+      "at": "2026-04-03T01:53:23Z",
+      "hash": "c9316942e8d0e8d5b3cec51ef8dfd7344c07aa65",
+      "passes": 1,
+      "pr": 15852
+    },
+    ".agents/tools/video/remotion.md": {
+      "at": "2026-03-28T15:30:25Z",
+      "hash": "db4fcbfea61d62e978c485196a05fb5e74a8001b",
+      "passes": 1,
+      "pr": 11961
+    },
+    ".agents/tools/video/video-prompt-design.md": {
+      "at": "2026-03-28T17:30:25Z",
+      "hash": "458ca99814ee1870364630490b09c589ee92b9af",
+      "passes": 1,
+      "pr": 12071
+    },
+    ".agents/tools/video/yt-dlp.md": {
+      "at": "2026-03-28T11:20:27Z",
+      "hash": "4d389eb0516525018dbfd3037cc7038c8d651d51",
+      "passes": 1,
+      "pr": 11752
+    },
+    ".agents/tools/vision/image-editing.md": {
+      "at": "2026-03-29T21:43:18Z",
+      "hash": "b8279ff67535093f7f5d04a0c4df6a57a5936437",
+      "passes": 1,
+      "pr": 13236
+    },
+    ".agents/tools/vision/image-generation.md": {
+      "at": "2026-03-29T19:51:31Z",
+      "hash": "dc2750c7486e0b13d7163564fddd132dc416c9cd",
+      "passes": 1,
+      "pr": 13249
+    },
+    ".agents/tools/vision/image-understanding.md": {
+      "at": "2026-03-29T23:53:56Z",
+      "hash": "8aa3bede872ab8ae73db072bcd02cd723d3feaae",
+      "passes": 1,
+      "pr": 13458
+    },
+    ".agents/tools/vision/overview.md": {
+      "at": "2026-04-01T20:59:38Z",
+      "hash": "e81b419a1b0d6ec94e7fc6ce1646e6a010eb0c15",
+      "passes": 1,
+      "pr": 14932
+    },
+    ".agents/tools/voice/buzz.md": {
+      "at": "2026-04-03T16:35:53Z",
+      "hash": "ca79f7c8c14b2f8087d4516a1894867f9569b9ca",
+      "passes": 1,
+      "pr": 16677
+    },
+    ".agents/tools/voice/cloud-tts-apis.md": {
+      "at": "2026-03-28T08:18:23Z",
+      "hash": "ff89512f470bdac79cfdfb0ad809060890f4d6f6",
+      "passes": 1,
+      "pr": 11637
+    },
+    ".agents/tools/voice/cloud-voice-agents.md": {
+      "at": "2026-03-28T16:40:25Z",
+      "hash": "e175ad6af6ffb8f158ef7b30c87c58a3d7bbd49a",
+      "passes": 1,
+      "pr": 12005
+    },
+    ".agents/tools/voice/hyprwhspr.md": {
+      "at": "2026-03-29T16:34:36Z",
+      "hash": "7bd3dc0581791068ee8bf6d8d868193eaf07c7d5",
+      "passes": 1,
+      "pr": 13103
+    },
+    ".agents/tools/voice/ios-shortcut.md": {
+      "at": "2026-03-29T20:53:52Z",
+      "hash": "c6d9c528093a67e0419180f6cad49c72defe1e92",
+      "passes": 1,
+      "pr": 13286
+    },
+    ".agents/tools/voice/local-tts-models.md": {
+      "at": "2026-03-28T08:18:24Z",
+      "hash": "e1ba9b3c2d19f39753d51272af8e15c119bae160",
+      "passes": 1,
+      "pr": 11637
+    },
+    ".agents/tools/voice/pipecat-opencode.md": {
+      "at": "2026-03-28T16:40:27Z",
+      "hash": "e7a6896a9e9d2fd7072fdf2d32db8ccc41114c85",
+      "passes": 1,
+      "pr": 12019
+    },
+    ".agents/tools/voice/qwen3-tts.md": {
+      "at": "2026-03-29T19:05:52Z",
+      "hash": "5c96c2f2bc41084437754a44b1e5ea3377c42574",
+      "passes": 1,
+      "pr": 13190
+    },
+    ".agents/tools/voice/speech-to-speech.md": {
+      "at": "2026-03-29T14:29:05Z",
+      "hash": "b82177ce888ec4aa5f1bd546886b0ae5c8b92f52",
+      "passes": 1,
+      "pr": 13005
+    },
+    ".agents/tools/voice/transcription.md": {
+      "at": "2026-03-29T07:02:26Z",
+      "hash": "be64061a20cfdfbf8635ac4c2d83b15583a75589",
+      "passes": 1,
+      "pr": 12638
+    },
+    ".agents/tools/voice/voice-ai-models.md": {
+      "at": "2026-04-03T16:35:54Z",
+      "hash": "0537d6bce2fd2a72f5d9122c149848d8a7d71237",
+      "passes": 1,
+      "pr": 16668
+    },
+    ".agents/tools/voice/voice-models.md": {
+      "at": "2026-03-28T08:18:24Z",
+      "hash": "c02a9a4c714f285968649b21c955f9ad842b7b84",
+      "passes": 1,
+      "pr": 11637
+    },
+    ".agents/tools/voice/voiceink-shortcut.md": {
+      "at": "2026-03-28T16:40:39Z",
+      "hash": "6b28ebfcd62b8fc97f7a47ee918c848e1ccfaa93",
+      "passes": 1,
+      "pr": 12017
+    },
+    ".agents/tools/wordpress.md": {
+      "at": "2026-04-03T19:14:47Z",
+      "hash": "1cf0fd554e77ed5b826566a63c93a52ee9911cbb",
+      "passes": 1,
+      "pr": 16755
+    },
+    ".agents/tools/wordpress/localwp.md": {
+      "at": "2026-04-13T16:27:58Z",
+      "hash": "046bf8face3ec8929723c2a265ac370954ed227b",
+      "passes": 2,
+      "pr": 11563
+    },
+    ".agents/tools/wordpress/mainwp.md": {
+      "at": "2026-03-28T11:20:17Z",
+      "hash": "3ca000f7bb9497bce6d58c24ef53362c3ba189ed",
+      "passes": 1,
+      "pr": 11794
+    },
+    ".agents/tools/wordpress/scf.md": {
+      "at": "2026-03-28T16:40:07Z",
+      "hash": "80e8fa1c499ab170936e5db5f4c6d51aed480c82",
+      "passes": 1,
+      "pr": 12035
+    },
+    ".agents/tools/wordpress/wp-admin.md": {
+      "at": "2026-03-28T08:17:43Z",
+      "hash": "ec39f27d75293bccb4434b85622ce978ab5709f7",
+      "passes": 1,
+      "pr": 11587
+    },
+    ".agents/tools/wordpress/wp-cli-reference.md": {
+      "at": "2026-03-28T08:17:43Z",
+      "hash": "2fcf819eb80e07eff90b43bead554a47091793eb",
+      "passes": 1,
+      "pr": 11587
+    },
+    ".agents/tools/wordpress/wp-dev.md": {
+      "at": "2026-03-29T22:09:16Z",
+      "hash": "bfb49264d8380d603b517b0297a9270e6ef6b3b0",
+      "passes": 1,
+      "pr": 13341
+    },
+    ".agents/tools/wordpress/wp-preferred.md": {
+      "at": "2026-03-28T03:54:25Z",
+      "hash": "d9b4ffa6e03c98b1c239a44c9bcee6971acfba79",
+      "passes": 1,
+      "pr": 11353
+    },
+    ".agents/workflows/add-skill.md": {
+      "at": "2026-04-11T17:01:41Z",
+      "hash": "c52915c7f433ba906fd87135e8620e784aa90c85",
+      "passes": 2,
+      "pr": 18270
+    },
+    ".agents/workflows/autoagent.md": {
+      "at": "2026-04-11T17:01:41Z",
+      "hash": "b0099a8d2c81d616a46b25570bfcae141ee0206a",
+      "passes": 2,
+      "pr": 18188
     },
     ".agents/workflows/autoresearch.md": {
+      "at": "2026-04-11T03:27:26Z",
       "hash": "f6c9df3d4d0f41acbccf1714eaa890ea59bcb0b3",
-      "at": "2026-04-11T03:27:26Z",
-      "pr": 18119,
-      "passes": 1
+      "passes": 1,
+      "pr": 18119
     },
-    ".agents/scripts/commands/email-delivery-test.md": {
-      "hash": "351ce5d6596112769560bdd68ceab2b955e374d0",
-      "at": "2026-04-11T03:27:26Z",
-      "pr": 18118,
-      "passes": 1
+    ".agents/workflows/branch.md": {
+      "at": "2026-04-03T11:54:15Z",
+      "hash": "8a407f752bf203868cb2fd7a00bdace9d80a8512",
+      "passes": 1,
+      "pr": 16416
     },
-    ".agents/commands/AGENTS.md": {
-      "hash": "ce01ce671b7c7eee80020ba2c94938751f844880",
-      "at": "2026-04-15T22:51:44Z",
-      "pr": 18117,
-      "passes": 14
+    ".agents/workflows/branch/bugfix.md": {
+      "at": "2026-04-02T04:56:46Z",
+      "hash": "e748778290a204b0f79b9fa88e66fd3f3fd891fb",
+      "passes": 1,
+      "pr": 15517
     },
-    ".agents/workflows/pulse.md": {
-      "hash": "ff61825e354fc702e37c4716e1a891698d2b480e",
-      "at": "2026-04-14T09:06:31Z",
-      "pr": 18924,
-      "passes": 4
+    ".agents/workflows/branch/experiment.md": {
+      "at": "2026-04-02T21:20:20Z",
+      "hash": "3fdeaf05d52c8e879538868b432ec953d63e615d",
+      "passes": 2,
+      "pr": 0
     },
-    ".agents/workflows/pulse-sweep.md": {
-      "hash": "a53224a50e1a86cc16c371dab21f300bca4c2650",
-      "at": "2026-04-14T09:37:48Z",
-      "pr": 18923,
-      "passes": 4
+    ".agents/workflows/branch/feature.md": {
+      "at": "2026-04-03T22:25:55Z",
+      "hash": "81462109adc9e74e968d80c9bb2d2cefad077c04",
+      "passes": 1,
+      "pr": 16865
     },
-    ".agents/commands/build-plus.md": {
-      "hash": "a157ac23bc7f9d042eefd0c5418af9fb60d82aff",
-      "at": "2026-04-11T05:05:43Z",
-      "pr": 18133,
-      "passes": 2
+    ".agents/workflows/branch/hotfix.md": {
+      "at": "2026-04-01T20:59:04Z",
+      "hash": "6b9ec688065c9e9250ed8f63196737af153a66fe",
+      "passes": 1,
+      "pr": 15209
     },
-    ".agents/commands/content.md": {
-      "hash": "f7e23347c89761072bb648938dc2cc59d5a8c906",
-      "at": "2026-04-11T06:18:00Z",
-      "pr": 18151,
-      "passes": 1
+    ".agents/workflows/branch/refactor.md": {
+      "at": "2026-04-03T16:35:53Z",
+      "hash": "db41908442790de7971e5be0377f2d1ea2479d8f",
+      "passes": 1,
+      "pr": 16676
     },
-    ".agents/workflows/mission.md": {
-      "hash": "a375e9f6438301448a509e2b5a75c933fbb05c31",
-      "at": "2026-04-11T04:09:50Z",
-      "pr": 18132,
-      "passes": 1
+    ".agents/workflows/branch/release.md": {
+      "at": "2026-04-03T16:35:53Z",
+      "hash": "a39e09b0127ed9312aa3da6b18d970df35c841b1",
+      "passes": 1,
+      "pr": 16675
     },
-    ".agents/workflows/strategic-review.md": {
-      "hash": "43a301d8898d025de92302fabd39fdc8dd63b820",
-      "at": "2026-04-11T04:09:50Z",
-      "pr": 18131,
-      "passes": 1
+    ".agents/workflows/brief.md": {
+      "at": "2026-04-15T03:32:04Z",
+      "hash": "0f13cdc0577cd473600fbb0a609536ad21c0a411",
+      "passes": 4,
+      "pr": 18927
+    },
+    ".agents/workflows/brief/templates.md": {
+      "at": "2026-04-15T03:59:49Z",
+      "hash": "8f1ca1ac6cf9ab689d00af0945eb3af6ca039c80",
+      "passes": 3,
+      "pr": 17658
+    },
+    ".agents/workflows/brief/tier-standard.md": {
+      "at": "2026-04-15T08:17:12Z",
+      "hash": "ebc81028afe68e02bef6687b0ce0ce66e2ee622c",
+      "passes": 3,
+      "pr": 18940
+    },
+    ".agents/workflows/browser-qa.md": {
+      "at": "2026-04-03T04:23:07Z",
+      "hash": "98ad6337f860e081d42a943f5152feb9e148c6b0",
+      "passes": 1,
+      "pr": 15835
+    },
+    ".agents/workflows/budget-analysis.md": {
+      "at": "2026-04-11T17:01:44Z",
+      "hash": "569615974642992d98d6c17889d1e88d55ace376",
+      "passes": 1,
+      "pr": 18316
+    },
+    ".agents/workflows/bug-fixing.md": {
+      "at": "2026-03-29T16:34:52Z",
+      "hash": "dfc99d84d7f2e8e69167c1c132a846c2c68f7940",
+      "passes": 1,
+      "pr": 13056
+    },
+    ".agents/workflows/changelog.md": {
+      "at": "2026-04-03T19:14:47Z",
+      "hash": "58549e6adba56863232aab40ac34c1a2e51822de",
+      "passes": 1,
+      "pr": 16733
+    },
+    ".agents/workflows/code-audit-remote.md": {
+      "at": "2026-03-28T15:31:24Z",
+      "hash": "0d8d85fd5910f64d690a3ff21462496ac7ae0554",
+      "passes": 1,
+      "pr": 11825
+    },
+    ".agents/workflows/conversation-starter.md": {
+      "at": "2026-04-03T16:35:51Z",
+      "hash": "e1981dcc5c3ba7b6b886e8860e847239ced37000",
+      "passes": 1,
+      "pr": 16714
+    },
+    ".agents/workflows/cross-review.md": {
+      "at": "2026-04-11T16:20:18Z",
+      "hash": "9abe6822cceedcdf15d2bef80e5f6f3329c6ffa3",
+      "passes": 1,
+      "pr": 18290
+    },
+    ".agents/workflows/dashboard.md": {
+      "at": "2026-04-11T17:01:41Z",
+      "hash": "5bbcdea5ff2f11645d298870cd6385b131ecd48f",
+      "passes": 3,
+      "pr": 18241
+    },
+    ".agents/workflows/define.md": {
+      "at": "2026-04-15T02:32:29Z",
+      "hash": "50fedc89674fa998b1a1a7e3fae138649473a8f2",
+      "passes": 4,
+      "pr": 18926
+    },
+    ".agents/workflows/error-feedback.md": {
+      "at": "2026-04-03T01:11:46Z",
+      "hash": "ca757bf1c3449bd7fd8c42d85afb9743e1410324",
+      "passes": 1,
+      "pr": 15970
+    },
+    ".agents/workflows/feature-development.md": {
+      "at": "2026-03-29T16:31:49Z",
+      "hash": "f4e607a4441fd8da90298eafef9743d8039c4ba7",
+      "passes": 1,
+      "pr": 13065
     },
     ".agents/workflows/full-loop.md": {
-      "hash": "dda139893758fd40ed3195ea4cd58d4287c61bdc",
       "at": "2026-04-15T02:35:00Z",
-      "pr": 19047,
-      "passes": 2
+      "hash": "dda139893758fd40ed3195ea4cd58d4287c61bdc",
+      "passes": 2,
+      "pr": 19047
     },
-    ".agents/scripts/commands/session-review.md": {
-      "hash": "75539fb19f3e764a723d6534c6b2090709b3b423",
-      "at": "2026-04-11T05:06:05Z",
-      "pr": 18147,
-      "passes": 1
+    ".agents/workflows/git-workflow.md": {
+      "at": "2026-03-29T08:49:32Z",
+      "hash": "8b1c4557393fefcee67608abe5f50936b1a12431",
+      "passes": 1,
+      "pr": 12777
     },
-    ".agents/commands/aidevops-content.md": {
-      "hash": "f7e23347c89761072bb648938dc2cc59d5a8c906",
-      "at": "2026-04-11T05:06:05Z",
-      "pr": 18146,
-      "passes": 1
+    ".agents/workflows/init-routines.md": {
+      "at": "2026-04-11T13:54:27Z",
+      "hash": "bd1fec1da0b4e9aa2b45fe74a613d86d7f81106a",
+      "passes": 1,
+      "pr": 18240
     },
-    ".agents/workflows/routine.md": {
-      "hash": "827b42666786545fbfc5c59a1a2d6160645d9288",
-      "at": "2026-04-11T05:06:05Z",
-      "pr": 18144,
-      "passes": 1
+    ".agents/workflows/list-todo.md": {
+      "at": "2026-04-11T16:20:18Z",
+      "hash": "95c0b8090f68c9cb4f17a6516af5a511067393ed",
+      "passes": 1,
+      "pr": 18278
     },
-    ".agents/commands/aidevops-build-plus.md": {
-      "hash": "a157ac23bc7f9d042eefd0c5418af9fb60d82aff",
-      "at": "2026-04-11T05:06:05Z",
-      "pr": 18134,
-      "passes": 1
+    ".agents/workflows/list-verify.md": {
+      "at": "2026-04-11T17:01:44Z",
+      "hash": "5d5d52ede7bbc513f44dc72fe352d885b809a8ad",
+      "passes": 1,
+      "pr": 18318
     },
-    ".agents/scripts/commands/email-design-test.md": {
-      "hash": "2055f755f4558bb21f4ac9714e6f1011b2745ec4",
-      "at": "2026-04-11T07:23:25Z",
-      "pr": 18170,
-      "passes": 1
+    ".agents/workflows/log-issue-aidevops.md": {
+      "at": "2026-04-11T17:01:42Z",
+      "hash": "0cfc454fb3c066b686fca341a058bbb712865c85",
+      "passes": 2,
+      "pr": 18148
     },
-    ".agents/commands/seo.md": {
-      "hash": "5181e08f7fb9475fa9cce94a9359b1ae0c8703ac",
-      "at": "2026-04-11T17:01:19Z",
-      "pr": 18172,
-      "passes": 3
+    ".agents/workflows/memory-log.md": {
+      "at": "2026-04-11T16:20:18Z",
+      "hash": "6a3163963518347ca2f44ea5d69e4464f2ac1258",
+      "passes": 1,
+      "pr": 18289
+    },
+    ".agents/workflows/milestone-validation.md": {
+      "at": "2026-03-28T03:53:42Z",
+      "hash": "9474ccd7f66e7948125d76ae221086ea8f47870e",
+      "passes": 1,
+      "pr": 11286
+    },
+    ".agents/workflows/mission-orchestrator.md": {
+      "at": "2026-03-30T06:49:53Z",
+      "hash": "78a33b982d7a70d210df2f802519ef66f8632742",
+      "passes": 1,
+      "pr": 13841
+    },
+    ".agents/workflows/mission-skill-learning.md": {
+      "at": "2026-04-03T11:54:11Z",
+      "hash": "d18fd0b438f42e4e240326848f3d3463fa986480",
+      "passes": 2,
+      "pr": 14996
+    },
+    ".agents/workflows/mission.md": {
+      "at": "2026-04-11T04:09:50Z",
+      "hash": "a375e9f6438301448a509e2b5a75c933fbb05c31",
+      "passes": 1,
+      "pr": 18132
+    },
+    ".agents/workflows/models-pool-check.md": {
+      "at": "2026-04-11T16:20:18Z",
+      "hash": "72b94302544b07cfb930b8f97e3d55a6fe6b4c6f",
+      "passes": 1,
+      "pr": 18276
+    },
+    ".agents/workflows/multi-repo-workspace.md": {
+      "at": "2026-03-28T16:00:32Z",
+      "hash": "f6e8316bed9e00e964afae0025f4ed6b37f3fa4c",
+      "passes": 1,
+      "pr": 11984
     },
     ".agents/workflows/new-task.md": {
-      "hash": "f26544a937d7a831ee1e0b954a63a093194cd9d6",
       "at": "2026-04-13T16:27:59Z",
-      "pr": 18169,
-      "passes": 2
+      "hash": "f26544a937d7a831ee1e0b954a63a093194cd9d6",
+      "passes": 2,
+      "pr": 18169
     },
-    ".agents/commands/automate.md": {
-      "hash": "b0865c65a1a0e0f579e68be0db05a8b79d46dbe5",
-      "at": "2026-04-11T17:01:18Z",
-      "pr": 18160,
-      "passes": 3
+    ".agents/workflows/optimize-tiers.md": {
+      "at": "2026-04-11T13:54:28Z",
+      "hash": "066bd6b47e328dbd06fdda6e003d447d060aa816",
+      "passes": 1,
+      "pr": 18185
     },
-    ".agents/commands/marketing-sales.md": {
-      "hash": "1f8a5d943028b36f9ae687dd4e3fd871e1b8753d",
-      "at": "2026-04-11T10:09:10Z",
-      "pr": 18159,
-      "passes": 1
+    ".agents/workflows/performance.md": {
+      "at": "2026-04-11T16:20:18Z",
+      "hash": "e5ce4d702b99f2e0d80a5cdea995e0c5fabf4706",
+      "passes": 1,
+      "pr": 18277
+    },
+    ".agents/workflows/plans.md": {
+      "at": "2026-04-06T15:39:38Z",
+      "hash": "3abaef28c0f03fa97774b22e8681b32f27350d24",
+      "passes": 2,
+      "pr": 12235
+    },
+    ".agents/workflows/postflight-loop.md": {
+      "at": "2026-04-11T17:01:44Z",
+      "hash": "1db90c094b167be0bc0ce7e08348f8807e8f5bd1",
+      "passes": 1,
+      "pr": 18319
+    },
+    ".agents/workflows/postflight.md": {
+      "at": "2026-03-28T10:27:12Z",
+      "hash": "b06e3b3e0aa4706319eb0b05bf54367ea0e92569",
+      "passes": 1,
+      "pr": 11739
     },
     ".agents/workflows/pr-loop.md": {
-      "hash": "4a8ff788d897a07739b9e729d6fd4945b62e1984",
       "at": "2026-04-13T16:28:00Z",
+      "hash": "4a8ff788d897a07739b9e729d6fd4945b62e1984",
       "passes": 3,
       "pr": 18249
     },
+    ".agents/workflows/pr.md": {
+      "at": "2026-04-09T07:32:14Z",
+      "hash": "08162913df92f899457e4d1495cfc54bee8a49fe",
+      "passes": 2,
+      "pr": 13014
+    },
+    ".agents/workflows/pre-edit.md": {
+      "at": "2026-04-03T20:43:55Z",
+      "hash": "6b0e3f4690afdb4c0d13d0d429d704c4e9544074",
+      "passes": 2
+    },
+    ".agents/workflows/preflight.md": {
+      "at": "2026-03-28T03:54:08Z",
+      "hash": "81a7f51d2e0863d7db395809f306cfad572060f4",
+      "passes": 1,
+      "pr": 11341
+    },
+    ".agents/workflows/pulse-sweep.md": {
+      "at": "2026-04-14T09:37:48Z",
+      "hash": "a53224a50e1a86cc16c371dab21f300bca4c2650",
+      "passes": 4,
+      "pr": 18923
+    },
+    ".agents/workflows/pulse.md": {
+      "at": "2026-04-14T09:06:31Z",
+      "hash": "ff61825e354fc702e37c4716e1a891698d2b480e",
+      "passes": 4,
+      "pr": 18924
+    },
+    ".agents/workflows/ralph-loop.md": {
+      "at": "2026-03-28T11:20:12Z",
+      "hash": "fc13521cf4f2d8477be2c37928bc684dc88901f6",
+      "passes": 1,
+      "pr": 11789
+    },
+    ".agents/workflows/readme-create-update.md": {
+      "at": "2026-03-28T16:40:10Z",
+      "hash": "0b1c731168591b51353e46c85c9fdcacfac2daec",
+      "passes": 1,
+      "pr": 12038
+    },
+    ".agents/workflows/release.md": {
+      "at": "2026-03-29T22:51:16Z",
+      "hash": "e74fead69d8b3756f99b09401b52d5a6a44ac456",
+      "passes": 2,
+      "pr": 13318
+    },
     ".agents/workflows/remember.md": {
+      "at": "2026-04-11T17:01:42Z",
       "hash": "0ba07b19fe8575b0913278c31909989d6a5804f0",
-      "at": "2026-04-11T17:01:42Z",
-      "pr": 18242,
-      "passes": 3
+      "passes": 3,
+      "pr": 18242
     },
-    ".agents/workflows/dashboard.md": {
-      "hash": "5bbcdea5ff2f11645d298870cd6385b131ecd48f",
-      "at": "2026-04-11T17:01:41Z",
-      "pr": 18241,
-      "passes": 3
+    ".agents/workflows/review-issue-pr.md": {
+      "at": "2026-04-15T03:00:56Z",
+      "hash": "555ce0c4248605489eab19b1f421279ab211455d",
+      "passes": 5,
+      "pr": 12308
     },
-    ".agents/workflows/init-routines.md": {
-      "hash": "bd1fec1da0b4e9aa2b45fe74a613d86d7f81106a",
-      "at": "2026-04-11T13:54:27Z",
-      "pr": 18240,
-      "passes": 1
-    },
-    ".agents/workflows/skills.md": {
-      "hash": "6f3730d9ef553317a124f1c5b94830356465e9d9",
-      "at": "2026-04-11T17:01:42Z",
-      "pr": 18239,
-      "passes": 3
-    },
-    ".agents/commands/aidevops-legal.md": {
-      "hash": "278f1357743e4be7e4c36b0cc98cb3022db7130f",
-      "at": "2026-04-11T17:01:18Z",
-      "pr": 18227,
-      "passes": 3
+    ".agents/workflows/routine.md": {
+      "at": "2026-04-11T05:06:05Z",
+      "hash": "827b42666786545fbfc5c59a1a2d6160645d9288",
+      "passes": 1,
+      "pr": 18144
     },
     ".agents/workflows/runners-check.md": {
+      "at": "2026-04-11T17:01:42Z",
       "hash": "db8bedaa399aa56da0189ca43d459000c739cfb8",
-      "at": "2026-04-11T17:01:42Z",
-      "pr": 18225,
-      "passes": 3
-    },
-    ".agents/commands/aidevops-framework.md": {
-      "hash": "6c034fc8cc954d733a8666b295a66fb3d8c291f5",
-      "at": "2026-04-11T17:01:18Z",
-      "pr": 18224,
-      "passes": 3
-    },
-    ".agents/commands/aidevops.md": {
-      "hash": "6c034fc8cc954d733a8666b295a66fb3d8c291f5",
-      "at": "2026-04-11T17:01:18Z",
-      "pr": 18223,
-      "passes": 3
-    },
-    ".agents/workflows/tech-stack.md": {
-      "hash": "216e9632f81e8fe92c00cfd33455728869b89705",
-      "at": "2026-04-11T13:54:28Z",
-      "pr": 18213,
-      "passes": 1
-    },
-    ".agents/seo/seo-audit.md": {
-      "hash": "e04729ef8d0f40b30efc59f9914d8ec420218efa",
-      "at": "2026-04-11T13:54:28Z",
-      "pr": 18210,
-      "passes": 1
-    },
-    ".agents/commands/business.md": {
-      "hash": "dae5291987de357f73ae79460b5e990b125cf143",
-      "at": "2026-04-11T17:01:18Z",
-      "pr": 18189,
-      "passes": 3
-    },
-    ".agents/workflows/save-todo.md": {
-      "hash": "8933761097b52d8a79e7ef85347f2b2d7a9e6b53",
-      "at": "2026-04-11T17:01:42Z",
-      "pr": 18187,
-      "passes": 3
-    },
-    ".agents/workflows/define.md": {
-      "hash": "50fedc89674fa998b1a1a7e3fae138649473a8f2",
-      "at": "2026-04-15T02:32:29Z",
-      "pr": 18926,
-      "passes": 4
-    },
-    ".agents/workflows/optimize-tiers.md": {
-      "hash": "066bd6b47e328dbd06fdda6e003d447d060aa816",
-      "at": "2026-04-11T13:54:28Z",
-      "pr": 18185,
-      "passes": 1
-    },
-    ".agents/tools/testing-setup.md": {
-      "hash": "add7056788f9b456c2867f2c6133f6986df52b5f",
-      "at": "2026-04-11T13:54:28Z",
-      "pr": 18171,
-      "passes": 1
-    },
-    ".agents/commands/aidevops-marketing-sales.md": {
-      "hash": "1f8a5d943028b36f9ae687dd4e3fd871e1b8753d",
-      "at": "2026-04-11T13:54:28Z",
-      "pr": 18161,
-      "passes": 1
-    },
-    ".agents/content/youtube-research.md": {
-      "hash": "83444ef9cf1ad2231ed1ad62d1d5c623f3d00333",
-      "at": "2026-04-11T17:01:20Z",
-      "pr": 18158,
-      "passes": 3
-    },
-    ".agents/workflows/show-plan.md": {
-      "hash": "21346c11078a086da90e08dffcde74c7421c1ab2",
-      "at": "2026-04-11T15:18:24Z",
-      "pr": 18269,
-      "passes": 1
-    },
-    ".agents/commands/health.md": {
-      "hash": "8a06d2322341437c1e6bf9e560339646ba6c7fe0",
-      "at": "2026-04-11T16:20:18Z",
-      "pr": 18292,
-      "passes": 1
-    },
-    ".agents/workflows/worktree-cleanup.md": {
-      "hash": "251971abfb682ca259ec75c0510df2c2dd4102af",
-      "at": "2026-04-11T16:20:18Z",
-      "pr": 18291,
-      "passes": 1
-    },
-    ".agents/workflows/cross-review.md": {
-      "hash": "9abe6822cceedcdf15d2bef80e5f6f3329c6ffa3",
-      "at": "2026-04-11T16:20:18Z",
-      "pr": 18290,
-      "passes": 1
-    },
-    ".agents/workflows/memory-log.md": {
-      "hash": "6a3163963518347ca2f44ea5d69e4464f2ac1258",
-      "at": "2026-04-11T16:20:18Z",
-      "pr": 18289,
-      "passes": 1
-    },
-    ".agents/workflows/venv-health.md": {
-      "hash": "7dbecf6097302b2ff2d69ddfbe63626306713f91",
-      "at": "2026-04-11T16:20:18Z",
-      "pr": 18288,
-      "passes": 1
-    },
-    ".agents/services/email/email-inbox.md": {
-      "hash": "4f1ca21839cf5220d8b32c732671288f83ac5c72",
-      "at": "2026-04-11T16:20:18Z",
-      "pr": 18280,
-      "passes": 1
-    },
-    ".agents/services/email/email-outreach.md": {
-      "hash": "eec3a0cfbb715b4d281fbde029654c8e157facbf",
-      "at": "2026-04-11T16:20:18Z",
-      "pr": 18279,
-      "passes": 1
-    },
-    ".agents/workflows/list-todo.md": {
-      "hash": "95c0b8090f68c9cb4f17a6516af5a511067393ed",
-      "at": "2026-04-11T16:20:18Z",
-      "pr": 18278,
-      "passes": 1
-    },
-    ".agents/workflows/performance.md": {
-      "hash": "e5ce4d702b99f2e0d80a5cdea995e0c5fabf4706",
-      "at": "2026-04-11T16:20:18Z",
-      "pr": 18277,
-      "passes": 1
-    },
-    ".agents/workflows/models-pool-check.md": {
-      "hash": "72b94302544b07cfb930b8f97e3d55a6fe6b4c6f",
-      "at": "2026-04-11T16:20:18Z",
-      "pr": 18276,
-      "passes": 1
-    },
-    ".agents/commands/aidevops-research.md": {
-      "hash": "e30f6a29668b78be4808c38b12913ffaa49e6562",
-      "at": "2026-04-11T17:01:18Z",
-      "pr": 18272,
-      "passes": 2
-    },
-    ".agents/commands/research.md": {
-      "hash": "e30f6a29668b78be4808c38b12913ffaa49e6562",
-      "at": "2026-04-11T17:01:19Z",
-      "pr": 18271,
-      "passes": 2
-    },
-    ".agents/workflows/add-skill.md": {
-      "hash": "c52915c7f433ba906fd87135e8620e784aa90c85",
-      "at": "2026-04-11T17:01:41Z",
-      "pr": 18270,
-      "passes": 2
-    },
-    ".agents/commands/legal.md": {
-      "hash": "278f1357743e4be7e4c36b0cc98cb3022db7130f",
-      "at": "2026-04-11T17:01:18Z",
-      "pr": 18226,
-      "passes": 2
+      "passes": 3,
+      "pr": 18225
     },
     ".agents/workflows/runners.md": {
+      "at": "2026-04-11T16:20:19Z",
       "hash": "30a6c21fa4468a21a6d93f5d5dd68c9803914792",
-      "at": "2026-04-11T16:20:19Z",
-      "pr": 18211,
-      "passes": 1
+      "passes": 1,
+      "pr": 18211
     },
-    ".agents/content/youtube-setup.md": {
-      "hash": "257a899899f34d5907e2acf338cf587fbeddefa0",
-      "at": "2026-04-11T16:20:19Z",
-      "pr": 18209,
-      "passes": 1
-    },
-    ".agents/commands/aidevops-business.md": {
-      "hash": "dae5291987de357f73ae79460b5e990b125cf143",
-      "at": "2026-04-11T17:01:18Z",
-      "pr": 18208,
-      "passes": 2
-    },
-    ".agents/workflows/autoagent.md": {
-      "hash": "b0099a8d2c81d616a46b25570bfcae141ee0206a",
-      "at": "2026-04-11T17:01:41Z",
-      "pr": 18188,
-      "passes": 2
-    },
-    ".agents/commands/aidevops-seo.md": {
-      "hash": "5181e08f7fb9475fa9cce94a9359b1ae0c8703ac",
-      "at": "2026-04-11T17:01:18Z",
-      "pr": 18173,
-      "passes": 2
-    },
-    ".agents/commands/aidevops-automate.md": {
-      "hash": "b0865c65a1a0e0f579e68be0db05a8b79d46dbe5",
-      "at": "2026-04-11T17:01:18Z",
-      "pr": 18162,
-      "passes": 2
-    },
-    ".agents/workflows/log-issue-aidevops.md": {
-      "hash": "0cfc454fb3c066b686fca341a058bbb712865c85",
+    ".agents/workflows/save-todo.md": {
       "at": "2026-04-11T17:01:42Z",
-      "pr": 18148,
-      "passes": 2
+      "hash": "8933761097b52d8a79e7ef85347f2b2d7a9e6b53",
+      "passes": 3,
+      "pr": 18187
     },
-    ".agents/workflows/postflight-loop.md": {
-      "hash": "1db90c094b167be0bc0ce7e08348f8807e8f5bd1",
-      "at": "2026-04-11T17:01:44Z",
-      "pr": 18319,
-      "passes": 1
+    ".agents/workflows/session-manager.md": {
+      "at": "2026-03-29T23:53:41Z",
+      "hash": "186b8c1b21b241174337dc1aa8f71e6560677037",
+      "passes": 1,
+      "pr": 13443
     },
-    ".agents/workflows/list-verify.md": {
-      "hash": "5d5d52ede7bbc513f44dc72fe352d885b809a8ad",
-      "at": "2026-04-11T17:01:44Z",
-      "pr": 18318,
-      "passes": 1
+    ".agents/workflows/session-review.md": {
+      "at": "2026-04-11T05:06:04Z",
+      "hash": "75539fb19f3e764a723d6534c6b2090709b3b423",
+      "passes": 2,
+      "pr": 12889
     },
-    ".agents/tools/security/security-review.md": {
-      "hash": "86e12ee2f68e13f130b450943844319d47ec13fe",
-      "at": "2026-04-11T17:01:44Z",
-      "pr": 18317,
-      "passes": 1
+    ".agents/workflows/show-plan.md": {
+      "at": "2026-04-11T15:18:24Z",
+      "hash": "21346c11078a086da90e08dffcde74c7421c1ab2",
+      "passes": 1,
+      "pr": 18269
     },
-    ".agents/workflows/budget-analysis.md": {
-      "hash": "569615974642992d98d6c17889d1e88d55ace376",
-      "at": "2026-04-11T17:01:44Z",
-      "pr": 18316,
-      "passes": 1
+    ".agents/workflows/skills.md": {
+      "at": "2026-04-11T17:01:42Z",
+      "hash": "6f3730d9ef553317a124f1c5b94830356465e9d9",
+      "passes": 3,
+      "pr": 18239
     },
-    ".agents/content/yt-dlp.md": {
-      "hash": "4dae1ca9bd059d4ab416b421f96766f6188ff7f1",
-      "at": "2026-04-11T17:01:45Z",
-      "pr": 18268,
-      "passes": 1
+    ".agents/workflows/sql-migrations.md": {
+      "at": "2026-03-30T06:03:19Z",
+      "hash": "62f8b3740980fa962ecb492ce2aed2df50e57838",
+      "passes": 1,
+      "pr": 13838
     },
-    ".agents/services/ecommerce/shopify.md": {
-      "hash": "1c057fa35263b57612d3e8cb096fb5b2290f42c5",
-      "at": "2026-04-13T17:44:12Z",
-      "pr": 18661,
-      "passes": 1
+    ".agents/workflows/strategic-review.md": {
+      "at": "2026-04-11T04:09:50Z",
+      "hash": "43a301d8898d025de92302fabd39fdc8dd63b820",
+      "passes": 1,
+      "pr": 18131
     },
-    ".agents/scripts/commands/build-agent.md": {
-      "hash": "72256f1cd59db2f7f0ce47ddce039ffad91193f3",
-      "at": "2026-04-13T17:44:12Z",
-      "pr": 18660,
-      "passes": 1
+    ".agents/workflows/tech-stack.md": {
+      "at": "2026-04-11T13:54:28Z",
+      "hash": "216e9632f81e8fe92c00cfd33455728869b89705",
+      "passes": 1,
+      "pr": 18213
     },
-    ".agents/services/hosting/ubicloud.md": {
-      "hash": "e937e719eb2c5f90fb1495ac31a9da670c7e1550",
-      "at": "2026-04-14T07:25:44Z",
-      "pr": 18797,
-      "passes": 3
+    ".agents/workflows/triage-review.md": {
+      "at": "2026-04-15T03:00:56Z",
+      "hash": "9c35be6b80b3dfa780f30347eaceae676d42776f",
+      "passes": 4,
+      "pr": 17494
     },
-    ".agents/scripts/pulse-triage.sh": {
-      "hash": "b5ec15b500cac4d38c8d3296436a7b2cb27db94c",
-      "at": "2026-04-15T03:31:34Z",
-      "pr": 18655,
-      "passes": 5
+    ".agents/workflows/ui-verification.md": {
+      "at": "2026-03-29T07:31:37Z",
+      "hash": "136b7d726ea067a3ae9c76819b576296d5da2749",
+      "passes": 1,
+      "pr": 12705
     },
-    ".agents/scripts/pulse-simplification.sh": {
-      "hash": "b718adc3c87e5eeb6577f8b9dd4fad98d8565855",
-      "at": "2026-04-15T07:31:56Z",
-      "pr": 18653,
-      "passes": 7
+    ".agents/workflows/venv-health.md": {
+      "at": "2026-04-11T16:20:18Z",
+      "hash": "7dbecf6097302b2ff2d69ddfbe63626306713f91",
+      "passes": 1,
+      "pr": 18288
     },
-    ".agents/scripts/tests/test-consolidation-dispatch.sh": {
-      "hash": "91298b9d37f3ac50fdc71bbddcba460188ff43ee",
-      "at": "2026-04-14T07:57:30Z",
-      "pr": 18679,
-      "passes": 2
+    ".agents/workflows/version-bump.md": {
+      "at": "2026-03-28T16:00:36Z",
+      "hash": "2c2f323754934a7e0baf9143baf76f444499efde",
+      "passes": 1,
+      "pr": 11986
     },
-    ".agents/scripts/pulse-instance-lock.sh": {
-      "hash": "d90500ea38749311fcc3dd3912690504789ce506",
-      "at": "2026-04-14T07:25:45Z",
-      "pr": 18691,
-      "passes": 2
+    ".agents/workflows/wiki-update.md": {
+      "at": "2026-03-30T02:30:16Z",
+      "hash": "578eed449c48071e3e67c447f8f107595193a069",
+      "passes": 1,
+      "pr": 13594
     },
-    ".agents/scripts/pulse-issue-reconcile.sh": {
-      "hash": "b0bfb72f063df16202865b19e899e55efafd7612",
-      "at": "2026-04-15T19:03:29Z",
-      "pr": 18690,
-      "passes": 3
+    ".agents/workflows/worktree-cleanup.md": {
+      "at": "2026-04-11T16:20:18Z",
+      "hash": "251971abfb682ca259ec75c0510df2c2dd4102af",
+      "passes": 1,
+      "pr": 18291
     },
-    ".agents/scripts/pulse-merge.sh": {
-      "hash": "c0f5c3e8a65928d25434ce4099cb23e2dd3404b8",
-      "at": "2026-04-15T22:51:54Z",
-      "pr": 18829,
-      "passes": 10
+    ".agents/workflows/worktree.md": {
+      "at": "2026-04-03T11:54:16Z",
+      "hash": "737a99c16c2572014f5786ac591db5b95631608b",
+      "passes": 1,
+      "pr": 16415
     },
-    ".agents/scripts/pulse-quality-debt.sh": {
-      "hash": "04957bb5580d2f45b0926bd22b2310916b1ab0da",
-      "at": "2026-04-14T08:25:19Z",
-      "pr": 18681,
-      "passes": 3
+    "TODO.md": {
+      "at": "2026-04-15T22:52:18Z",
+      "hash": "8d1ce0ca9a629bb98802d46b14331bdd1691d800",
+      "passes": 21,
+      "pr": 15490
     },
-    ".agents/scripts/pulse-ancillary-dispatch.sh": {
-      "hash": "ab72fd6b20e25c4e7f8002d79a94fa44e5a71193",
-      "at": "2026-04-15T07:31:55Z",
-      "pr": 18657,
-      "passes": 5
+    "aidevops.sh": {
+      "at": "2026-04-15T22:52:18Z",
+      "hash": "757881f069c802f24ab496f6c73c4196b078b8bf",
+      "passes": 64,
+      "pr": 19029
     },
-    ".agents/scripts/generate-opencode-agents.sh": {
-      "hash": "e386a288bebdbfca44c0c5e05627c777d153ba32",
-      "at": "2026-04-13T20:02:42Z",
-      "pr": 18709,
-      "passes": 1
+    "setup.sh": {
+      "at": "2026-04-15T22:52:18Z",
+      "hash": "0343addb91e60c491511d9d85163c07d93d6baeb",
+      "passes": 62,
+      "pr": 15470
     },
-    ".agents/scripts/headless-runtime-lib.sh": {
-      "hash": "cdb4aa53f178687550d6ca7504c281b374b23eed",
-      "at": "2026-04-15T18:19:06Z",
-      "pr": 18707,
-      "passes": 4
+    "todo/tasks/GH#15363-brief.md": {
+      "at": "2026-04-02T13:10:59Z",
+      "hash": "37de48d4fe8a443c8c5f4fa3d8d9aaf6c25681cd",
+      "passes": 1,
+      "pr": 15566
     },
-    ".agents/scripts/issue-sync-helper.sh": {
-      "hash": "5a6a3475e4b68052301dc60e5e65b8e80bfc5670",
-      "at": "2026-04-15T19:03:28Z",
-      "pr": 18706,
-      "passes": 8
+    "todo/tasks/GH-14990-brief.md": {
+      "at": "2026-04-01T20:59:29Z",
+      "hash": "800d9eea6d4954e52e676b597ac1ca9264385f1e",
+      "passes": 1,
+      "pr": 14996
     },
-    ".agents/scripts/pulse-fast-fail.sh": {
-      "hash": "292f4dfd80d2cb97715a9bda1fe985b5cabf6c80",
-      "at": "2026-04-14T08:25:19Z",
-      "pr": 18692,
-      "passes": 3
+    "todo/tasks/t15173-brief.md": {
+      "at": "2026-04-01T20:58:50Z",
+      "hash": "d19107141234f84909e7932acf9d7a6fb2e5590f",
+      "passes": 1,
+      "pr": 15257
     },
-    ".agents/scripts/pulse-simplification-state.sh": {
-      "hash": "1b044ed90b9140fab14cc33dae6af134816b6a13",
-      "at": "2026-04-15T02:32:29Z",
-      "pr": 18680,
-      "passes": 5
+    "todo/tasks/t15364-brief.md": {
+      "at": "2026-04-02T13:11:00Z",
+      "hash": "98bb137e0bf45a14a8d499b17e20d1432d6a84a9",
+      "passes": 1,
+      "pr": 15566
     },
-    ".agents/reference/bash-fd-locking.md": {
-      "hash": "79fdafdb8ba9765b398538f513272a710e2f696a",
-      "at": "2026-04-13T20:41:46Z",
-      "pr": 18711,
-      "passes": 1
+    "todo/tasks/t15448-brief.md": {
+      "at": "2026-04-02T04:56:58Z",
+      "hash": "06817a5177d926d96000b713b4638f679790d824",
+      "passes": 1,
+      "pr": 15463
     },
-    ".agents/hooks/task-id-collision-guard.sh": {
-      "hash": "7af29498bf5df56b0743eee15a76e71bfa598688",
-      "at": "2026-04-15T03:59:21Z",
-      "pr": 18718,
-      "passes": 2
+    "todo/tasks/t15450-brief.md": {
+      "at": "2026-04-02T04:56:56Z",
+      "hash": "7eb8a85ef2c9c4c856ce7cc8ba3d51a55dcac764",
+      "passes": 1,
+      "pr": 15468
     },
-    ".agents/scripts/new-task-helper.sh": {
-      "hash": "4c8ce538c2cdbf98f4b247a4d9217aaa5bf67f5b",
-      "at": "2026-04-14T02:22:26Z",
-      "pr": 18705,
-      "passes": 2
+    "todo/tasks/t15472-brief.md": {
+      "at": "2026-04-02T04:56:51Z",
+      "hash": "1fa1551004bd0fbf798f57791aa5e7941b6f2606",
+      "passes": 1,
+      "pr": 15490
     },
-    ".agents/scripts/pulse-cleanup.sh": {
-      "hash": "88c7d4f1beba3de5f86421e507fc899b9879a6e6",
-      "at": "2026-04-15T02:32:29Z",
-      "pr": 18704,
-      "passes": 4
+    "todo/tasks/t1727-brief.md": {
+      "at": "2026-04-02T03:11:00Z",
+      "hash": "b4d74cfce669e4c678f2439ef7673de9a9c3feba",
+      "passes": 1,
+      "pr": 15431
     },
-    ".agents/scripts/pulse-dep-graph.sh": {
-      "hash": "4769810d4bc0232a099939fd5f221f41758b7e95",
-      "at": "2026-04-15T18:38:06Z",
-      "pr": 18796,
-      "passes": 3
+    "todo/tasks/t1737-brief.md": {
+      "at": "2026-04-01T20:59:15Z",
+      "hash": "f5acb5d720b3da605eea4b673b2391a6303d03d1",
+      "passes": 1,
+      "pr": 15223
     },
-    ".agents/reference/cross-runner-coordination.md": {
-      "hash": "c90bb1c6df51bb3a23625fc628f41d4952227aa6",
-      "at": "2026-04-14T08:25:14Z",
-      "pr": 18658,
-      "passes": 2
-    },
-    ".agents/scripts/pulse-dispatch-engine.sh": {
-      "hash": "493094d6b67201c518eadd5f8809afd41a791cfb",
-      "at": "2026-04-15T19:03:29Z",
-      "pr": 18799,
-      "passes": 5
-    },
-    ".agents/scripts/pulse-dispatch-core.sh": {
-      "hash": "2f27c838214719f8ee1e4e66b37cf84c95f9cdac",
-      "at": "2026-04-15T20:05:53Z",
-      "pr": 18832,
-      "passes": 7
-    },
-    ".agents/scripts/stats-quality-sweep.sh": {
-      "hash": "6fe05a80fbe9be2c6c0c56f40f40bd3b96f52bf1",
-      "at": "2026-04-14T06:24:41Z",
-      "pr": 18810,
-      "passes": 2
-    },
-    ".agents/scripts/shared-constants.sh": {
-      "hash": "316aa5a9199ef65e946ceee79b57f76cda430154",
-      "at": "2026-04-15T08:16:49Z",
-      "pr": 18847,
-      "passes": 6
-    },
-    ".agents/scripts/interactive-session-helper.sh": {
-      "hash": "4a62f8f22b887223c9aa5c730d10f74d6350eef5",
-      "at": "2026-04-15T00:41:03Z",
-      "pr": 18843,
-      "passes": 2
-    },
-    ".agents/scripts/post-merge-review-scanner.sh": {
-      "hash": "6fcc33e1df2db4bdf5fe7fae2d5e3ba7b4c05979",
-      "at": "2026-04-14T20:17:00Z",
-      "pr": 18801,
-      "passes": 2
-    },
-    ".agents/scripts/pulse-prefetch.sh": {
-      "hash": "bdc2d29c3356b99a9d243966952a99da908f28b3",
-      "at": "2026-04-14T20:55:10Z",
-      "pr": 18995,
-      "passes": 1
-    },
-    ".agents/scripts/quality-feedback-findings-lib.sh": {
-      "hash": "80348bed5038f651ffc98da1810e07dd244f2e6a",
-      "at": "2026-04-14T21:57:01Z",
-      "pr": 19009,
-      "passes": 1
-    },
-    ".agents/scripts/quality-feedback-issues-lib.sh": {
-      "hash": "659f27c08e7ad944343d00646a2ccc522fd90bcd",
-      "at": "2026-04-14T22:16:57Z",
-      "pr": 19004,
-      "passes": 1
-    },
-    ".agents/scripts/worktree-helper.sh": {
-      "hash": "4d554bea9e09f95a3d4929aa6aadc4c0a9539f29",
-      "at": "2026-04-15T21:02:40Z",
-      "pr": 19087,
-      "passes": 2
+    "todo/tasks/t2052-brief.md": {
+      "at": "2026-04-02T04:56:57Z",
+      "hash": "89edb8ff09173143446da68fb9104c16ac400b1c",
+      "passes": 1,
+      "pr": 15470
     }
   },
-  ".agents/tools/design/library/brands/clickhouse/DESIGN.md": {
-    "hash": "9717274b7c2b1cd74aadb4acb865a7ee75667056ad74427552aa817e61aa6ed8",
-    "status": "restructured",
-    "action": "split-into-chapters",
-    "chapters": 9,
-    "issue": "GH#16973"
-  },
-  ".agents/tools/credentials/cch-reverse-engineering.md": {
-    "hash": "6c57da6128787628b2d18755062d669275b3c3e7",
-    "at": "2026-04-04T04:17:32Z",
-    "passes": 1,
-    "pr": 17052
-  },
-  ".agents/tools/design/library/brands/resend/04-components.md": {
-    "hash": "3a892bf3ecbfeae70118a269688f23838a595081c9d8449d6143222bf7351bc7",
-    "lines": 54,
-    "status": "simplified",
-    "issue": "GH#17090"
-  },
-  ".agents/tools/design/library/brands/voltagent/04-components.md": {
-    "hash": "5924a4019120998ccd7979d148eab0bc4b7969bd191347ce3cf3049e1ecb2876",
-    "lines": 82,
-    "status": "simplified",
-    "issue": "GH#17239"
-  },
-  ".agents/tools/design/library/styles/corporate-traditional/02-colours.md": {
-    "hash": "83084b6d85338c961b19752ae5c0e7842d88b14fe7be78121b6d049f2fbf4c3c",
-    "simplified_at": "2026-04-04T06:22:35Z",
-    "issue": "GH#17122",
-    "action": "added CSS variables quick-reference section"
-  },
-  ".agents/tools/design/library/styles/startup-bold/09-agent-prompts.md": {
-    "hash": "1b9cf446793ee167529b914a5438353e97c92f4a",
-    "at": "2026-04-04T07:30:00Z",
-    "passes": 1,
-    "lines": 30,
-    "status": "simplified",
-    "issue": "GH#17125"
-  },
-  ".agents/tools/design/library/brands/ibm/04-components.md": {
-    "hash": "b402836b6b2f4ba9d95da181a22d3ce596d62b74",
-    "at": "2026-04-04T08:10:00Z",
-    "passes": 1,
-    "lines": 67,
-    "status": "simplified",
-    "issue": "GH#17202"
-  },
-  ".agents/tools/design/library/brands/uber/04-components.md": {
-    "hash": "4147e5ab87509d6727816c032f7148b2408c5b8b305e041a853ba1e80cbd0344",
-    "status": "simplified",
-    "action": "tighten-cross-reference",
-    "issue": "GH#17205"
-  },
-  ".agents/tools/design/library/brands/voltagent/02-color-palette.md": {
-    "hash": "5c631b0685456a768ee6eb1b424fae8551e315862ab8e7c14f310d9de19114f0",
-    "status": "simplified",
-    "issue": "GH#17207"
-  },
-  ".agents/tools/design/library/styles/agency-feminine/02-colours.md": {
-    "hash": "a5a882ed5c947e5745b0f212138c772ec74268d8061d39f6551f8c13a7e3b9fd",
-    "simplified_at": "2026-04-04T00:00:00Z",
-    "issue": "GH#17255",
-    "action": "added CSS variables quick-reference section"
-  },
-  ".agents/tools/design/library/brands/claude/04-components.md": {
-    "hash": "9eb6ea4ffeea8ec04d546c77c3cac26f47f6a829ac1e512a5347b65c10d589a8",
-    "lines": 47,
-    "status": "simplified",
-    "issue": "GH#17241"
-  },
-  ".agents/tools/design/library/brands/linear/02-colour-palette.md": {
-    "hash": "13573ea17cdd090fbed89523845d463c0803e4d0",
-    "lines": 66,
-    "status": "simplified",
-    "issue": "GH#17279"
-  },
-  ".agents/services/hosting/cloudflare-platform-skill/ai-search-patterns.md": {
-    "hash": "867d8ff77f341ac99f155db719644f2190031e9faa7e6668a79b05468b0eae0f",
-    "lines": 80,
-    "status": "simplified",
-    "issue": "GH#17305"
-  },
-  ".agents/content/youtube-setup.md": {
-    "hash": "a73a56209534a71e05ed6485880b63e0439f4d3c0cb0abb93dafb55abe2179f5",
-    "status": "simplified",
-    "lines": 94
-  },
-  ".agents/reference/bash-fd-locking.md": {
-    "hash": "79e0a0a74b3e71f24fe2bfcea539a2d300a010a19dd5e5e94d48a516f8f79ba2",
-    "lines_before": 58,
-    "lines_after": 54,
-    "action": "tightened",
-    "issue": "GH#18711"
+  "setup-modules/agent-deploy.sh": {
+    "hash": "c95a514b4e3a08d298efad5476f8ed723a42590bc0f32b251de4a626e7c61ac6",
+    "note": "Extracted _atomic_stage_and_deploy_agents() from deploy_aidevops_agents() (GH#19203)",
+    "status": "simplified"
   }
 }

--- a/setup-modules/agent-deploy.sh
+++ b/setup-modules/agent-deploy.sh
@@ -334,6 +334,67 @@ _install_opencode_plugin_deps() {
 	return 0
 }
 
+# _atomic_stage_and_deploy_agents source_dir target_dir [plugin_namespaces...]
+# Stages a copy in target_dir.staging, carries over preserved dirs (custom/,
+# draft/, and any plugin namespaces), then atomically swaps staging into place.
+# Returns 0 on success, 1 on failure.
+_atomic_stage_and_deploy_agents() {
+	local source_dir="$1"
+	local target_dir="$2"
+	shift 2
+	local -a plugin_namespaces=("$@")
+
+	# Atomic deploy: build a staging directory, then swap it into place.
+	# Previously, clean + copy happened in-place, creating a window where
+	# scripts were missing. The pulse could dispatch workers mid-deploy,
+	# hitting "No such file or directory" errors. Now we:
+	#   1. rsync into a staging dir (target_dir.staging)
+	#   2. Move preserved dirs (custom/, draft/, plugins) from live to staging
+	#   3. mv live → .old, mv staging → live (atomic on same filesystem)
+	#   4. rm .old
+	local staging_dir="${target_dir}.staging"
+	local old_dir="${target_dir}.old"
+	rm -rf "$staging_dir" "$old_dir"
+	mkdir -p "$staging_dir"
+
+	# Copy source into staging
+	local copy_rc
+	if [[ ${#plugin_namespaces[@]} -gt 0 ]]; then
+		_deploy_agents_copy "$source_dir" "$staging_dir" "${plugin_namespaces[@]}"
+		copy_rc=$?
+	else
+		_deploy_agents_copy "$source_dir" "$staging_dir"
+		copy_rc=$?
+	fi
+	if [[ "$copy_rc" -ne 0 ]]; then
+		print_error "Failed to deploy agents to staging directory"
+		rm -rf "$staging_dir"
+		return 1
+	fi
+
+	# Carry over preserved directories from live target to staging
+	local -a preserved_dirs=("custom" "draft")
+	if [[ ${#plugin_namespaces[@]} -gt 0 ]]; then
+		for pns in "${plugin_namespaces[@]}"; do
+			preserved_dirs+=("$pns")
+		done
+	fi
+	for pdir in "${preserved_dirs[@]}"; do
+		if [[ -d "$target_dir/$pdir" ]]; then
+			# Copy user dirs into staging so they survive the swap
+			cp -a "$target_dir/$pdir" "$staging_dir/$pdir" 2>/dev/null || true
+		fi
+	done
+
+	# Atomic swap: mv is atomic on the same filesystem (POSIX rename())
+	if [[ -d "$target_dir" ]]; then
+		mv "$target_dir" "$old_dir"
+	fi
+	mv "$staging_dir" "$target_dir"
+	rm -rf "$old_dir"
+	return 0
+}
+
 # _deploy_version_file target_dir repo_dir
 # Copies VERSION file from repo root to the deployed agents directory.
 _deploy_version_file() {
@@ -518,54 +579,12 @@ deploy_aidevops_agents() {
 
 	mkdir -p "$target_dir"
 
-	# Atomic deploy: build a staging directory, then swap it into place.
-	# Previously, clean + copy happened in-place, creating a window where
-	# scripts were missing. The pulse could dispatch workers mid-deploy,
-	# hitting "No such file or directory" errors. Now we:
-	#   1. rsync into a staging dir (target_dir.staging)
-	#   2. Move preserved dirs (custom/, draft/, plugins) from live to staging
-	#   3. mv live → .old, mv staging → live (atomic on same filesystem)
-	#   4. rm .old
-	local staging_dir="${target_dir}.staging"
-	local old_dir="${target_dir}.old"
-	rm -rf "$staging_dir" "$old_dir"
-	mkdir -p "$staging_dir"
-
-	# Copy source into staging
-	local copy_rc
+	# Atomically copy source to staging, carry over user dirs, then swap.
 	if [[ ${#plugin_namespaces[@]} -gt 0 ]]; then
-		_deploy_agents_copy "$source_dir" "$staging_dir" "${plugin_namespaces[@]}"
-		copy_rc=$?
+		_atomic_stage_and_deploy_agents "$source_dir" "$target_dir" "${plugin_namespaces[@]}" || return 1
 	else
-		_deploy_agents_copy "$source_dir" "$staging_dir"
-		copy_rc=$?
+		_atomic_stage_and_deploy_agents "$source_dir" "$target_dir" || return 1
 	fi
-	if [[ "$copy_rc" -ne 0 ]]; then
-		print_error "Failed to deploy agents to staging directory"
-		rm -rf "$staging_dir"
-		return 1
-	fi
-
-	# Carry over preserved directories from live target to staging
-	local -a preserved_dirs=("custom" "draft")
-	if [[ ${#plugin_namespaces[@]} -gt 0 ]]; then
-		for pns in "${plugin_namespaces[@]}"; do
-			preserved_dirs+=("$pns")
-		done
-	fi
-	for pdir in "${preserved_dirs[@]}"; do
-		if [[ -d "$target_dir/$pdir" ]]; then
-			# Move user dirs into staging so they survive the swap
-			cp -a "$target_dir/$pdir" "$staging_dir/$pdir" 2>/dev/null || true
-		fi
-	done
-
-	# Atomic swap: mv is atomic on the same filesystem (POSIX rename())
-	if [[ -d "$target_dir" ]]; then
-		mv "$target_dir" "$old_dir"
-	fi
-	mv "$staging_dir" "$target_dir"
-	rm -rf "$old_dir"
 
 	print_success "Deployed agents to $target_dir"
 	_deploy_agents_post_copy "$target_dir" "$repo_dir" "$source_dir" "$plugins_file"


### PR DESCRIPTION
## Summary

Extracted the 48-line atomic staging+swap block from deploy_aidevops_agents() into a new _atomic_stage_and_deploy_agents() helper. The main function is now 65 lines (was 107). No behaviour change — same logic, same error handling, same preserved-dir semantics. bash -n and shellcheck pass with zero violations.

## Files Changed

.agents/configs/simplification-state.json,setup-modules/agent-deploy.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash -n setup-modules/agent-deploy.sh && shellcheck setup-modules/agent-deploy.sh

Resolves #19203


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.44 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-sonnet-4-6 spent 4m and 17,912 tokens on this as a headless worker.