### PR TITLE
GH#19204: chore: ratchet-down NESTING_DEPTH_THRESHOLD 286 → 281

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -123,7 +123,8 @@ FUNCTION_COMPLEXITY_THRESHOLD=28
 # fix here would require reducing per-file max depth below 9 in multiple scripts — a larger refactor than the
 # proximity warning justifies. Follow the established bump-and-ratchet cadence: headroom now, ratchet down
 # after the next batch of simplification-debt PRs merges.
-NESTING_DEPTH_THRESHOLD=286
+# Ratcheted down to 281 (GH#19204): actual violations 279 + 2 buffer
+NESTING_DEPTH_THRESHOLD=281
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Ratchets down `NESTING_DEPTH_THRESHOLD` from 286 to 281 in `.agents/configs/complexity-thresholds.conf`.

Actual violations measured: 279. New threshold: 279 + 2 buffer = 281.

## Changes

- `EDIT: .agents/configs/complexity-thresholds.conf` — updated `NESTING_DEPTH_THRESHOLD=286` → `281` with ratchet-down audit comment

## Verification

- `simplification-state.json` not staged (confirmed: only complexity-thresholds.conf modified)
- Only `.agents/configs/complexity-thresholds.conf` modified in this PR

Resolves #19204