### PR TITLE
GH#19197: fix(ci): linked-issue-check workflow fails with 403 on external contributor PRs

### DIFF
--- a/.github/workflows/linked-issue-check.yml
+++ b/.github/workflows/linked-issue-check.yml
@@ -52,7 +52,8 @@ jobs:
             // Safety guard: skip if this is an external bot PR from a fork
             // pull_request_target runs in base repo context, but we should not
             // process PRs from non-User accounts in forks
-            if (pr.head.repo.full_name !== pr.base.repo.full_name && pr.user.type !== 'User') {
+            const isFork = Boolean(pr.head.repo) && pr.head.repo.full_name !== pr.base.repo.full_name;
+            if (isFork && pr.user.type === 'Bot') {
               console.log(`External bot PR from fork — skipping linked-issue check`);
               await github.rest.repos.createCommitStatus({
                 owner: repo.owner,

--- a/.github/workflows/linked-issue-check.yml
+++ b/.github/workflows/linked-issue-check.yml
@@ -22,7 +22,7 @@
 name: Linked Issue Check
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, edited, synchronize, reopened]
 
 permissions:
@@ -48,6 +48,22 @@ jobs:
             const title = pr.title || '';
             const headSha = pr.head.sha;
             const repo = context.repo;
+
+            // Safety guard: skip if this is an external bot PR from a fork
+            // pull_request_target runs in base repo context, but we should not
+            // process PRs from non-User accounts in forks
+            if (pr.head.repo.full_name !== pr.base.repo.full_name && pr.user.type !== 'User') {
+              console.log(`External bot PR from fork — skipping linked-issue check`);
+              await github.rest.repos.createCommitStatus({
+                owner: repo.owner,
+                repo: repo.repo,
+                sha: headSha,
+                state: 'success',
+                context: 'linked-issue-check',
+                description: 'External bot PR — skipped'
+              });
+              return;
+            }
 
             // Bot accounts are exempt
             if (pr.user.type === 'Bot') {


### PR DESCRIPTION
## Summary

Switch trigger from 'pull_request' to 'pull_request_target' to enable write-scoped token for fork PRs. Add safety guard with null check for pr.head.repo and explicit bot-type check to skip external bot PRs from forks.

## Files Changed

.github/workflows/linked-issue-check.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified workflow syntax and logic flow. Added null check for pr.head.repo before dereferencing. Changed condition to use explicit bot-type check (=== 'Bot') instead of negation check (!== 'User'). All checks passing.

Resolves #19197


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.45 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-haiku-4-5 spent 21m and 2,251 tokens on this as a headless worker.