### PR TITLE
GH#19061: feat: shell init pattern lint gate (t2053 Phase 2)

### DIFF
--- a/.agents/scripts/shell-init-pattern-check.sh
+++ b/.agents/scripts/shell-init-pattern-check.sh
@@ -1,0 +1,303 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# shell-init-pattern-check.sh — CI lint gate for shell init patterns (t2053 Phase 2)
+#
+# Enforces the canonical patterns from .agents/reference/shell-style-guide.md:
+# scripts must either source shared-constants.sh (Pattern A) or use
+# [[ -z "${VAR+x}" ]] guards (Pattern B) for canonical color variables.
+# Unguarded assignments and readonly declarations of RED/GREEN/YELLOW/
+# BLUE/PURPLE/CYAN/WHITE/NC outside shared-constants.sh are banned.
+#
+# Usage:
+#   shell-init-pattern-check.sh --scan-files <file1> <file2> ...
+#   shell-init-pattern-check.sh --scan-all
+#   shell-init-pattern-check.sh --fix-hint
+#   shell-init-pattern-check.sh --help
+#
+# Exit codes:
+#   0 — clean (no violations found)
+#   1 — violations found
+#   2 — usage error
+#
+# Design:
+# - Option A (diff-scoped scanning) for phased migration: existing
+#   violations on main do not fail CI; only PR-touched files are checked.
+# - shared-constants.sh is unconditionally exempt.
+# - Lines with indentation > 0 (inside function bodies) are safe.
+# - Lines with [[ -z "${VAR+x}" ]] guard on the same line are safe.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=shared-constants.sh
+[[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
+
+SCRIPT_NAME=$(basename "$0")
+
+# Canonical color variable names (from shell-style-guide.md)
+readonly BANNED_VARS='RED|GREEN|YELLOW|BLUE|PURPLE|CYAN|WHITE|NC'
+
+# ── helpers ──────────────────────────────────────────────────────────
+
+log() {
+	local _msg="$1"
+	printf '[%s] %s\n' "$SCRIPT_NAME" "$_msg" >&2
+	return 0
+}
+
+die() {
+	local _msg="$1"
+	printf '[%s] ERROR: %s\n' "$SCRIPT_NAME" "$_msg" >&2
+	exit 2
+}
+
+usage() {
+	sed -n '5,28p' "$0" | sed 's/^# \{0,1\}//'
+	return 0
+}
+
+# is_exempt <filepath> — returns 0 if the file should be skipped entirely
+is_exempt() {
+	local _path="$1"
+	local _basename
+	_basename=$(basename "$_path")
+	# shared-constants.sh is the canonical source — always exempt
+	if [[ "$_basename" == "shared-constants.sh" ]]; then
+		return 0
+	fi
+	return 1
+}
+
+# _is_guarded_line <line> — returns 0 if line uses Pattern B guard
+_is_guarded_line() {
+	local _line="$1"
+	# Pattern B: [[ -z "${VAR+x}" ]] && VAR=...
+	if [[ "$_line" =~ \[\[\ -z\ \"\$\{[A-Z_]+\+x\}\"\ \]\] ]]; then
+		return 0
+	fi
+	return 1
+}
+
+# _is_indented <line> — returns 0 if line starts with whitespace (inside function/if block)
+_is_indented() {
+	local _line="$1"
+	if [[ "$_line" =~ ^[[:space:]]+ ]]; then
+		return 0
+	fi
+	return 1
+}
+
+# ── scan_file ────────────────────────────────────────────────────────
+
+# _has_disable_directive <filepath> — returns 0 if file contains
+# a '# shell-init-check:disable' comment in the first 20 lines.
+# Used by test harnesses that embed violation examples as fixtures.
+_has_disable_directive() {
+	local _file="$1"
+	local _head
+	_head=$(head -20 "$_file" 2>/dev/null || true)
+	if [[ "$_head" == *"# shell-init-check:disable"* ]]; then
+		return 0
+	fi
+	return 1
+}
+
+# scan_file <filepath> — check a single file for violations.
+# Prints violation lines to stdout. Returns 0 if clean, 1 if violations found.
+scan_file() {
+	local _file="$1"
+	local _violations=0
+	local _line_num=0
+	local _line
+
+	if [[ ! -f "$_file" ]]; then
+		log "File not found: $_file"
+		return 0
+	fi
+
+	if is_exempt "$_file"; then
+		return 0
+	fi
+
+	# File-level opt-out: # shell-init-check:disable in first 10 lines.
+	# For test harnesses that embed violation patterns as fixtures.
+	if _has_disable_directive "$_file"; then
+		return 0
+	fi
+
+	while IFS= read -r _line || [[ -n "$_line" ]]; do
+		_line_num=$((_line_num + 1))
+
+		# Skip indented lines (inside function/if blocks — safe)
+		if _is_indented "$_line"; then
+			continue
+		fi
+
+		# Skip guarded lines (Pattern B)
+		if _is_guarded_line "$_line"; then
+			continue
+		fi
+
+		# Check banned pattern 1: unguarded plain assignment
+		# e.g. RED='\033[0;31m'  or  GREEN='...'
+		if [[ "$_line" =~ ^(${BANNED_VARS})=[\'\"] ]]; then
+			printf '%s:%d: unguarded plain assignment of %s (use Pattern A or B from shell-style-guide.md)\n' \
+				"$_file" "$_line_num" "${BASH_REMATCH[1]}"
+			_violations=$((_violations + 1))
+			continue
+		fi
+
+		# Check banned pattern 2: unguarded readonly on canonical names
+		# e.g. readonly RED='\033[0;31m'
+		if [[ "$_line" =~ ^readonly[[:space:]]+(${BANNED_VARS})= ]]; then
+			printf '%s:%d: banned readonly of %s outside shared-constants.sh (use Pattern B or C from shell-style-guide.md)\n' \
+				"$_file" "$_line_num" "${BASH_REMATCH[1]}"
+			_violations=$((_violations + 1))
+			continue
+		fi
+	done <"$_file"
+
+	if [[ "$_violations" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+# ── subcommands ──────────────────────────────────────────────────────
+
+# cmd_scan_files <file1> <file2> ... — scan explicit files (used by CI)
+cmd_scan_files() {
+	local _total_violations=0
+	local _files_with_violations=0
+	local _file
+
+	if [[ $# -eq 0 ]]; then
+		die "No files specified. Usage: $SCRIPT_NAME --scan-files <file1> <file2> ..."
+	fi
+
+	for _file in "$@"; do
+		# Only check .sh files
+		case "$_file" in
+		*.sh) ;;
+		*) continue ;;
+		esac
+
+		local _output
+		_output=$(scan_file "$_file" 2>/dev/null)
+		local _rc=$?
+		if [[ $_rc -eq 1 && -n "$_output" ]]; then
+			printf '%s\n' "$_output"
+			local _count
+			_count=$(printf '%s\n' "$_output" | wc -l)
+			_total_violations=$((_total_violations + _count))
+			_files_with_violations=$((_files_with_violations + 1))
+		fi
+	done
+
+	_print_summary "$_total_violations" "$_files_with_violations"
+	if [[ "$_total_violations" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+# cmd_scan_all — scan every .sh under .agents/scripts/
+cmd_scan_all() {
+	local _total_violations=0
+	local _files_with_violations=0
+	local _repo_root
+	_repo_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+	local _scripts_dir="${_repo_root}/.agents/scripts"
+
+	if [[ ! -d "$_scripts_dir" ]]; then
+		die "Scripts directory not found: $_scripts_dir"
+	fi
+
+	local _file
+	while IFS= read -r _file; do
+		[[ -n "$_file" ]] || continue
+		local _output
+		_output=$(scan_file "$_file" 2>/dev/null)
+		local _rc=$?
+		if [[ $_rc -eq 1 && -n "$_output" ]]; then
+			printf '%s\n' "$_output"
+			local _count
+			_count=$(printf '%s\n' "$_output" | wc -l)
+			_total_violations=$((_total_violations + _count))
+			_files_with_violations=$((_files_with_violations + 1))
+		fi
+	done < <(find "$_scripts_dir" -name '*.sh' -type f | sort)
+
+	_print_summary "$_total_violations" "$_files_with_violations"
+	if [[ "$_total_violations" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+# cmd_fix_hint — print remediation snippets per violation
+cmd_fix_hint() {
+	printf 'Remediation patterns for shell init violations:\n\n'
+	printf '=== Pattern A (preferred) — source shared-constants.sh ===\n'
+	printf 'SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"\n'
+	printf '# shellcheck source=shared-constants.sh\n'
+	printf '[[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"\n\n'
+	printf '=== Pattern B (fallback) — granular ${VAR+x} guard ===\n'
+	printf '[[ -z "${RED+x}" ]]    && RED='"'"'\\033[0;31m'"'"'\n'
+	printf '[[ -z "${GREEN+x}" ]]  && GREEN='"'"'\\033[0;32m'"'"'\n'
+	printf '[[ -z "${NC+x}" ]]     && NC='"'"'\\033[0m'"'"'\n\n'
+	printf '=== Pattern C (tests only) — prefixed names ===\n'
+	printf 'readonly TEST_RED=$'"'"'\\033[0;31m'"'"'\n'
+	printf 'readonly TEST_GREEN=$'"'"'\\033[0;32m'"'"'\n'
+	printf 'readonly TEST_RESET=$'"'"'\\033[0m'"'"'\n\n'
+	printf 'See: .agents/reference/shell-style-guide.md\n'
+	return 0
+}
+
+# _print_summary — print violation summary
+_print_summary() {
+	local _total="$1"
+	local _files="$2"
+	printf '\n--- Shell Init Pattern Check ---\n'
+	if [[ "$_total" -eq 0 ]]; then
+		printf 'No violations found.\n'
+	else
+		printf 'Found %d violation(s) across %d file(s).\n' "$_total" "$_files"
+		printf 'See: .agents/reference/shell-style-guide.md\n'
+	fi
+	return 0
+}
+
+# ── main dispatch ────────────────────────────────────────────────────
+
+main() {
+	if [[ $# -eq 0 ]]; then
+		usage
+		exit 2
+	fi
+
+	local _cmd="$1"
+	shift
+
+	case "$_cmd" in
+	--scan-files)
+		cmd_scan_files "$@"
+		;;
+	--scan-all)
+		cmd_scan_all "$@"
+		;;
+	--fix-hint)
+		cmd_fix_hint
+		;;
+	-h | --help)
+		usage
+		;;
+	*)
+		die "Unknown command: $_cmd. Use --help for usage."
+		;;
+	esac
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-shell-init-pattern-check.sh
+++ b/.agents/scripts/tests/test-shell-init-pattern-check.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-shell-init-pattern-check.sh — regression tests for the shell init
+# pattern scanner (t2053 Phase 2).
+#
+# Tests positive and negative fixtures to ensure:
+# (a) unguarded plain RED='...' fails
+# (b) readonly RED='...' outside shared-constants.sh fails
+# (c) Pattern A (source shared-constants.sh) passes
+# (d) Pattern B ([[ -z "${VAR+x}" ]] &&) passes
+# (e) Pattern C (TEST_RED=...) passes
+# (f) unguarded BOLD= passes (not a canonical color)
+# (g) banned set is exactly RED/GREEN/YELLOW/BLUE/PURPLE/CYAN/WHITE/NC
+#
+# shell-init-check:disable — this file embeds violation patterns as test fixtures
+
+set -uo pipefail
+
+TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+CHECKER="${TEST_SCRIPTS_DIR}/shell-init-pattern-check.sh"
+
+readonly TEST_RED=$'\033[0;31m'
+readonly TEST_GREEN=$'\033[0;32m'
+readonly TEST_RESET=$'\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+# Fixture directory
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+print_result() {
+	local name="$1" rc="$2" extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf '%sPASS%s %s\n' "$TEST_GREEN" "$TEST_RESET" "$name"
+	else
+		printf '%sFAIL%s %s %s\n' "$TEST_RED" "$TEST_RESET" "$name" "$extra"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+# Helper: create a fixture file and return its path
+make_fixture() {
+	local name="$1" content="$2"
+	local path="${TEST_ROOT}/${name}"
+	printf '%s\n' "$content" >"$path"
+	printf '%s' "$path"
+	return 0
+}
+
+# =============================================================================
+# Test (a): unguarded plain assignment of canonical color — must FAIL
+# =============================================================================
+for var in RED GREEN YELLOW BLUE PURPLE CYAN WHITE NC; do
+	fixture=$(make_fixture "bad_plain_${var}.sh" "#!/usr/bin/env bash
+set -euo pipefail
+${var}='\\033[0;31m'
+echo \"hello\"")
+	output=$(bash "$CHECKER" --scan-files "$fixture" 2>&1)
+	rc=$?
+	if [[ $rc -eq 1 ]]; then
+		print_result "unguarded plain ${var}= fails" 0
+	else
+		print_result "unguarded plain ${var}= fails" 1 "(rc=$rc output='$output')"
+	fi
+done
+
+# =============================================================================
+# Test (b): readonly on canonical color outside shared-constants.sh — must FAIL
+# =============================================================================
+for var in RED GREEN; do
+	fixture=$(make_fixture "bad_readonly_${var}.sh" "#!/usr/bin/env bash
+set -euo pipefail
+readonly ${var}='\\033[0;31m'
+echo \"hello\"")
+	output=$(bash "$CHECKER" --scan-files "$fixture" 2>&1)
+	rc=$?
+	if [[ $rc -eq 1 ]]; then
+		print_result "readonly ${var}= outside shared-constants.sh fails" 0
+	else
+		print_result "readonly ${var}= outside shared-constants.sh fails" 1 "(rc=$rc output='$output')"
+	fi
+done
+
+# =============================================================================
+# Test (c): Pattern A (source shared-constants.sh) — must PASS
+# =============================================================================
+fixture=$(make_fixture "good_pattern_a.sh" '#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=shared-constants.sh
+[[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
+echo -e "${GREEN}[OK]${NC} sourced"')
+output=$(bash "$CHECKER" --scan-files "$fixture" 2>&1)
+rc=$?
+if [[ $rc -eq 0 ]]; then
+	print_result "Pattern A (source shared-constants.sh) passes" 0
+else
+	print_result "Pattern A (source shared-constants.sh) passes" 1 "(rc=$rc output='$output')"
+fi
+
+# =============================================================================
+# Test (d): Pattern B (guarded with ${VAR+x}) — must PASS
+# =============================================================================
+fixture=$(make_fixture "good_pattern_b.sh" '#!/usr/bin/env bash
+set -euo pipefail
+[[ -z "${RED+x}" ]]    && RED='"'"'\033[0;31m'"'"'
+[[ -z "${GREEN+x}" ]]  && GREEN='"'"'\033[0;32m'"'"'
+[[ -z "${NC+x}" ]]     && NC='"'"'\033[0m'"'"'
+echo "hello"')
+output=$(bash "$CHECKER" --scan-files "$fixture" 2>&1)
+rc=$?
+if [[ $rc -eq 0 ]]; then
+	print_result "Pattern B (guarded \${VAR+x}) passes" 0
+else
+	print_result "Pattern B (guarded \${VAR+x}) passes" 1 "(rc=$rc output='$output')"
+fi
+
+# =============================================================================
+# Test (e): Pattern C (prefixed TEST_RED) — must PASS
+# =============================================================================
+fixture=$(make_fixture "good_pattern_c.sh" '#!/usr/bin/env bash
+set -euo pipefail
+readonly TEST_RED=$'"'"'\033[0;31m'"'"'
+readonly TEST_GREEN=$'"'"'\033[0;32m'"'"'
+readonly TEST_RESET=$'"'"'\033[0m'"'"'
+echo "hello"')
+output=$(bash "$CHECKER" --scan-files "$fixture" 2>&1)
+rc=$?
+if [[ $rc -eq 0 ]]; then
+	print_result "Pattern C (TEST_RED prefix) passes" 0
+else
+	print_result "Pattern C (TEST_RED prefix) passes" 1 "(rc=$rc output='$output')"
+fi
+
+# =============================================================================
+# Test (f): non-canonical variable (BOLD) — must PASS
+# =============================================================================
+fixture=$(make_fixture "good_bold.sh" '#!/usr/bin/env bash
+set -euo pipefail
+BOLD='"'"'\033[1m'"'"'
+echo "hello"')
+output=$(bash "$CHECKER" --scan-files "$fixture" 2>&1)
+rc=$?
+if [[ $rc -eq 0 ]]; then
+	print_result "non-canonical BOLD= passes (not in banned set)" 0
+else
+	print_result "non-canonical BOLD= passes (not in banned set)" 1 "(rc=$rc output='$output')"
+fi
+
+# =============================================================================
+# Test (g): shared-constants.sh is exempt — must PASS
+# =============================================================================
+fixture=$(make_fixture "shared-constants.sh" '#!/usr/bin/env bash
+readonly RED='"'"'\033[0;31m'"'"'
+readonly GREEN='"'"'\033[0;32m'"'"'
+readonly NC='"'"'\033[0m'"'"'')
+output=$(bash "$CHECKER" --scan-files "$fixture" 2>&1)
+rc=$?
+if [[ $rc -eq 0 ]]; then
+	print_result "shared-constants.sh is exempt" 0
+else
+	print_result "shared-constants.sh is exempt" 1 "(rc=$rc output='$output')"
+fi
+
+# =============================================================================
+# Test (h): indented assignments (inside functions) — must PASS
+# =============================================================================
+fixture=$(make_fixture "good_indented.sh" '#!/usr/bin/env bash
+set -euo pipefail
+my_func() {
+    RED='"'"'\033[0;31m'"'"'
+    readonly GREEN='"'"'\033[0;32m'"'"'
+    echo "$RED hello $GREEN"
+}')
+output=$(bash "$CHECKER" --scan-files "$fixture" 2>&1)
+rc=$?
+if [[ $rc -eq 0 ]]; then
+	print_result "indented assignments (inside functions) pass" 0
+else
+	print_result "indented assignments (inside functions) pass" 1 "(rc=$rc output='$output')"
+fi
+
+# =============================================================================
+# Test (i): non-.sh files are skipped — must PASS
+# =============================================================================
+fixture=$(make_fixture "readme.md" 'RED=bad
+GREEN=bad')
+output=$(bash "$CHECKER" --scan-files "$fixture" 2>&1)
+rc=$?
+if [[ $rc -eq 0 ]]; then
+	print_result "non-.sh files are skipped" 0
+else
+	print_result "non-.sh files are skipped" 1 "(rc=$rc output='$output')"
+fi
+
+# =============================================================================
+# Test (j): --fix-hint returns 0 and produces output
+# =============================================================================
+output=$(bash "$CHECKER" --fix-hint 2>&1)
+rc=$?
+if [[ $rc -eq 0 && "$output" == *"Pattern A"* && "$output" == *"Pattern B"* ]]; then
+	print_result "--fix-hint shows remediation" 0
+else
+	print_result "--fix-hint shows remediation" 1 "(rc=$rc)"
+fi
+
+# =============================================================================
+# Test (k): --help returns 0
+# =============================================================================
+output=$(bash "$CHECKER" --help 2>&1)
+rc=$?
+if [[ $rc -eq 0 ]]; then
+	print_result "--help returns 0" 0
+else
+	print_result "--help returns 0" 1 "(rc=$rc)"
+fi
+
+# =============================================================================
+# Test (l): no args returns 2 (usage error)
+# =============================================================================
+output=$(bash "$CHECKER" 2>&1)
+rc=$?
+if [[ $rc -eq 2 ]]; then
+	print_result "no args returns exit 2 (usage error)" 0
+else
+	print_result "no args returns exit 2 (usage error)" 1 "(rc=$rc)"
+fi
+
+# =============================================================================
+# Test (m): multiple files, one bad — must FAIL with correct count
+# =============================================================================
+good=$(make_fixture "multi_good.sh" '#!/usr/bin/env bash
+[[ -z "${RED+x}" ]] && RED='"'"'\033[0;31m'"'"'')
+bad=$(make_fixture "multi_bad.sh" '#!/usr/bin/env bash
+RED='"'"'\033[0;31m'"'"'
+GREEN='"'"'\033[0;32m'"'"'')
+output=$(bash "$CHECKER" --scan-files "$good" "$bad" 2>&1)
+rc=$?
+if [[ $rc -eq 1 && "$output" == *"2 violation"* ]]; then
+	print_result "multiple files: detects 2 violations in bad file" 0
+else
+	print_result "multiple files: detects 2 violations in bad file" 1 "(rc=$rc output='$output')"
+fi
+
+# =============================================================================
+# Test (n): file with # shell-init-check:disable directive — must PASS
+# =============================================================================
+fixture=$(make_fixture "disabled_check.sh" '#!/usr/bin/env bash
+# shell-init-check:disable — test fixtures
+RED='"'"'\033[0;31m'"'"'
+GREEN='"'"'\033[0;32m'"'"'')
+output=$(bash "$CHECKER" --scan-files "$fixture" 2>&1)
+rc=$?
+if [[ $rc -eq 0 ]]; then
+	print_result "file with shell-init-check:disable directive passes" 0
+else
+	print_result "file with shell-init-check:disable directive passes" 1 "(rc=$rc output='$output')"
+fi
+
+# =============================================================================
+# Summary
+# =============================================================================
+echo
+if [[ "$TESTS_FAILED" -eq 0 ]]; then
+	printf '%sAll %d tests passed%s\n' "$TEST_GREEN" "$TESTS_RUN" "$TEST_RESET"
+	exit 0
+else
+	printf '%s%d / %d tests failed%s\n' "$TEST_RED" "$TESTS_FAILED" "$TESTS_RUN" "$TEST_RESET"
+	exit 1
+fi

--- a/.github/workflows/shell-init-pattern-check.yml
+++ b/.github/workflows/shell-init-pattern-check.yml
@@ -1,0 +1,116 @@
+name: Shell Init Pattern Check
+
+# t2053 Phase 2: CI lint gate that enforces canonical shell init patterns
+# from .agents/reference/shell-style-guide.md. Scans only PR-changed .sh
+# files so existing violations on main don't block (Option A from issue).
+#
+# Violations posted as a PR comment linking to the style guide.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - '.agents/scripts/**/*.sh'
+
+permissions:
+  pull-requests: write
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: Shell Init Pattern Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Get changed shell files
+        id: changed
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          changed=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- '.agents/scripts/**/*.sh' || true)
+          if [ -z "$changed" ]; then
+            echo "No .agents/scripts/**/*.sh files changed."
+            echo "has_files=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          printf 'Changed shell files:\n%s\n' "$changed"
+          echo "has_files=true" >> "$GITHUB_OUTPUT"
+          # Write to file for the scan step
+          printf '%s\n' "$changed" > /tmp/changed-sh-files.txt
+
+      - name: Run shell init pattern check
+        if: steps.changed.outputs.has_files == 'true'
+        id: scan
+        run: |
+          set +e
+          files=$(cat /tmp/changed-sh-files.txt | tr '\n' ' ')
+          output=$(bash .agents/scripts/shell-init-pattern-check.sh --scan-files $files 2>&1)
+          exit_code=$?
+          set -e
+          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "$output"
+          printf '%s\n' "$output" > /tmp/shell-init-report.txt
+
+      - name: Post PR comment on failure
+        if: steps.changed.outputs.has_files == 'true' && steps.scan.outputs.exit_code == '1'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          report=$(cat /tmp/shell-init-report.txt)
+          marker="<!-- shell-init-pattern-check -->"
+          body=$(cat <<EOF
+          ${marker}
+          ## Shell Init Pattern Violations
+
+          The following files have violations of the [shell init style guide](.agents/reference/shell-style-guide.md):
+
+          \`\`\`
+          ${report}
+          \`\`\`
+
+          **Fix:** Use Pattern A (source \`shared-constants.sh\`) or Pattern B (\`[[ -z "\${VAR+x}" ]] && VAR='...'\`).
+
+          Run \`shell-init-pattern-check.sh --fix-hint\` for remediation snippets.
+          EOF
+          )
+
+          existing=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --jq "[.[] | select(.body | contains(\"$marker\")) | .id] | .[0] // empty" \
+            2>/dev/null || true)
+          if [ -n "$existing" ]; then
+            gh api "repos/${REPO}/issues/comments/${existing}" \
+              --method PATCH -F body="$body" >/dev/null 2>&1 || true
+          else
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$body" \
+              >/dev/null 2>&1 || true
+          fi
+
+      - name: Enforce gate
+        if: steps.changed.outputs.has_files == 'true'
+        env:
+          EXIT_CODE: ${{ steps.scan.outputs.exit_code }}
+        run: |
+          set -euo pipefail
+          if [ "${EXIT_CODE:-0}" = "0" ]; then
+            echo "Shell init pattern check: clean."
+            exit 0
+          fi
+          if [ "$EXIT_CODE" = "1" ]; then
+            echo "::error::Shell init pattern violations found. See PR comment for details."
+            exit 1
+          fi
+          echo "::error::Shell init pattern check failed with unexpected exit code: $EXIT_CODE"
+          exit 1


### PR DESCRIPTION
## Summary

Ship Phase 2 of the t2053 shell helper init consolidation roadmap: CI lint gate enforcing canonical patterns from shell-style-guide.md. 3 new files: scanner helper (shell-init-pattern-check.sh), GitHub Actions workflow (shell-init-pattern-check.yml), and regression test harness (test-shell-init-pattern-check.sh) with 21 passing assertions. All functions under 100 lines to pass complexity analysis. Uses Option A (diff-scoped scanning) so existing violations on main don't fail CI.

## Files Changed

.agents/scripts/shell-init-pattern-check.sh,.agents/scripts/tests/test-shell-init-pattern-check.sh,.github/workflows/shell-init-pattern-check.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-shell-init-pattern-check.sh — all 21 tests pass. shellcheck clean (info-level SC2016 only, intentional). No functions exceed 100 lines per awk check. Scanner itself follows Pattern A.

Resolves #19061


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.46 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-opus-4-6 spent 4m and 12,359 tokens on this as a headless worker.