### PR TITLE
feat(pulse): auto-close parent-task issues when all children resolved

### DIFF
--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -1177,6 +1177,9 @@ _preflight_ownership_reconcile() {
 	# Catches issues left open after --admin merges, GitHub merge button, etc.
 	run_stage_with_timeout "reconcile_merged_pr_close" "$PRE_RUN_STAGE_TIMEOUT" reconcile_open_issues_with_merged_prs || true
 
+	# Close parent-task issues when all children are resolved.
+	run_stage_with_timeout "reconcile_parent_tasks" "$PRE_RUN_STAGE_TIMEOUT" reconcile_completed_parent_tasks || true
+
 	# Backfill labelless aidevops-shaped issues (t2112). Heals issues that
 	# were created via bare `gh issue create` outside the `gh_create_issue`
 	# wrapper — applies origin/tier defaults + body-tag labels + sub-issue

--- a/.agents/scripts/pulse-issue-reconcile.sh
+++ b/.agents/scripts/pulse-issue-reconcile.sh
@@ -949,6 +949,114 @@ reconcile_open_issues_with_merged_prs() {
 }
 
 #######################################
+# Close parent-task issues when all child issues are resolved.
+#
+# Parent-task issues block dispatch unconditionally — they exist as
+# planning trackers. When all their children are closed, the parent
+# should close automatically with a summary comment listing each child.
+#
+# Child detection: extracts #NNN references from the parent's body that
+# are NOT self-references. Checks each against GH API for closed state.
+# Only closes if ALL children are closed and there are at least 1.
+#
+# Max 5 closes per cycle to limit API usage.
+#######################################
+reconcile_completed_parent_tasks() {
+	local repos_json="$REPOS_JSON"
+	[[ -f "$repos_json" ]] || return 0
+
+	local total_closed=0
+	local max_closes=5
+
+	while IFS= read -r slug; do
+		[[ -n "$slug" ]] || continue
+		[[ "$total_closed" -lt "$max_closes" ]] || break
+
+		local issues_json
+		issues_json=$(gh issue list --repo "$slug" --state open \
+			--label "parent-task" \
+			--json number,title,body --limit 10 2>/dev/null) || issues_json="[]"
+		[[ -n "$issues_json" && "$issues_json" != "null" ]] || continue
+
+		local issue_count
+		issue_count=$(printf '%s' "$issues_json" | jq 'length' 2>/dev/null) || issue_count=0
+		[[ "$issue_count" -gt 0 ]] || continue
+
+		local i=0
+		while [[ "$i" -lt "$issue_count" ]] && [[ "$total_closed" -lt "$max_closes" ]]; do
+			local issue_num issue_title issue_body
+			issue_num=$(printf '%s' "$issues_json" | jq -r --argjson i "$i" '.[$i].number // ""') || true
+			issue_title=$(printf '%s' "$issues_json" | jq -r --argjson i "$i" '.[$i].title // ""') || true
+			issue_body=$(printf '%s' "$issues_json" | jq -r --argjson i "$i" '.[$i].body // ""') || true
+			i=$((i + 1))
+			[[ "$issue_num" =~ ^[0-9]+$ ]] || continue
+
+			# Extract child issue numbers from body (#NNN patterns, excluding self)
+			local child_nums
+			child_nums=$(printf '%s' "$issue_body" | grep -oE '#[0-9]+' | grep -oE '[0-9]+' | sort -un | grep -v "^${issue_num}$") || child_nums=""
+			[[ -n "$child_nums" ]] || continue
+
+			# Check if ALL children are closed
+			local all_closed="true"
+			local child_summary=""
+			local child_count=0
+			while IFS= read -r child_num; do
+				[[ -n "$child_num" && "$child_num" =~ ^[0-9]+$ ]] || continue
+				local child_state child_title_line
+				child_state=$(gh api "repos/${slug}/issues/${child_num}" \
+					--jq '.state // "unknown"' 2>/dev/null) || child_state="unknown"
+				child_title_line=$(gh api "repos/${slug}/issues/${child_num}" \
+					--jq '.title // ""' 2>/dev/null) || child_title_line=""
+
+				# Skip references that aren't real child issues (PRs, external refs)
+				if [[ "$child_state" == "unknown" ]]; then
+					continue
+				fi
+
+				child_count=$((child_count + 1))
+				if [[ "$child_state" == "closed" ]]; then
+					child_summary="${child_summary}
+- #${child_num}: ${child_title_line} — ✅ CLOSED"
+				else
+					child_summary="${child_summary}
+- #${child_num}: ${child_title_line} — ⏳ OPEN"
+					all_closed="false"
+				fi
+			done <<<"$child_nums"
+
+			# Need at least 2 children to be a real parent (1 child = probably just a reference)
+			if [[ "$child_count" -lt 2 ]]; then
+				continue
+			fi
+
+			if [[ "$all_closed" != "true" ]]; then
+				continue
+			fi
+
+			# All children closed — close the parent
+			gh issue close "$issue_num" --repo "$slug" \
+				--comment "## All child tasks completed — closing parent tracker
+
+${child_summary}
+
+All ${child_count} child issues are resolved. Parent tracker closed automatically.
+
+_Detected by reconcile_completed_parent_tasks (pulse-issue-reconcile.sh)._" \
+				>/dev/null 2>&1 || continue
+
+			echo "[pulse-wrapper] Reconcile parent-task: closed #${issue_num} in ${slug} — all ${child_count} children closed" >>"$LOGFILE"
+			total_closed=$((total_closed + 1))
+		done
+	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug // ""' "$repos_json" || true)
+
+	if [[ "$total_closed" -gt 0 ]]; then
+		echo "[pulse-wrapper] Reconcile completed parent tasks: closed=${total_closed}" >>"$LOGFILE"
+	fi
+
+	return 0
+}
+
+#######################################
 # t2112: backfill labelless aidevops-shaped issues.
 #
 # Scans each pulse:true repo for open issues whose titles match the aidevops


### PR DESCRIPTION
## Summary

Parent-task issues block dispatch and exist as planning trackers. When all children close, nothing closed the parent — it sat open indefinitely. Example: #19035 had 3 closed children but stayed open until manually closed.

New `reconcile_completed_parent_tasks` stage: scans open `parent-task` issues, extracts `#NNN` child references from the body, checks if all are closed, and posts a summary comment before closing.

Safeguards: requires 2+ children (prevents single-reference false positives), max 5 per cycle, skips unknown/external references.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Parent task issues now automatically close with a summary comment when all associated child issues are resolved, streamlining issue management and improving workflow visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->