### PR TITLE
GH#19215: fix: bump NESTING_DEPTH_THRESHOLD 281→286 to restore headroom (GH#19215)

### DIFF
--- a/.agents/configs/complexity-thresholds-history.md
+++ b/.agents/configs/complexity-thresholds-history.md
@@ -60,6 +60,8 @@ Archives the full change history for `.agents/configs/complexity-thresholds.conf
 | 280 | GH#19056 | ratcheted down — actual violations 278 + 2 buffer |
 | 279 | GH#19031 | ratcheted down — actual violations 277 + 2 buffer |
 | 286 | GH#19086 | proximity guard firing at 279/279 (0 headroom); violations drifted from ratchet baseline 277 up to 279 on main as new helpers landed. 279 violations + 7 headroom = 286; proximity guard (warn_at = 286-5 = 281) fires when violations exceed 281 (i.e., at 282), preventing saturation. A ratchet-down fix would require reducing per-file max depth below 9 in multiple scripts — a larger refactor than the proximity warning justifies; follow the established bump-and-ratchet cadence |
+| 281 | GH#19204 (PR#19207) | ratcheted down — actual violations 279 + 2 buffer |
+| 286 | GH#19215 | proximity guard firing at 279/281 (2 headroom); 279 violations + 7 headroom = 286; proximity guard (warn_at = 286-5 = 281) fires when violations exceed 281 (i.e., at 282), preventing saturation |
 
 ## FUNCTION_COMPLEXITY_THRESHOLD History
 

--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -124,7 +124,9 @@ FUNCTION_COMPLEXITY_THRESHOLD=28
 # proximity warning justifies. Follow the established bump-and-ratchet cadence: headroom now, ratchet down
 # after the next batch of simplification-debt PRs merges.
 # Ratcheted down to 281 (GH#19204): actual violations 279 + 2 buffer
-NESTING_DEPTH_THRESHOLD=281
+# Bumped to 286 (GH#19215): proximity guard firing at 279/281 (2 headroom); 279 violations + 7 headroom = 286.
+# Proximity guard (warn_at = 286-5 = 281) fires when violations exceed 281 (i.e., at 282), preventing saturation.
+NESTING_DEPTH_THRESHOLD=286
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Bumped NESTING_DEPTH_THRESHOLD from 281 to 286 (279 violations + 7 headroom) following the established bump-and-ratchet pattern. Also added the missing GH#19204 ratchet-down entry to complexity-thresholds-history.md.

## Files Changed

.agents/configs/complexity-thresholds-history.md,.agents/configs/complexity-thresholds.conf

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified NESTING_DEPTH_THRESHOLD=286 in complexity-thresholds.conf. CI Complexity Analysis check should pass with 279 violations against 286 threshold (7 headroom). Proximity guard will fire at 282+ violations (286-5=281), preventing future saturation.

Resolves #19215


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.49 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-sonnet-4-6 spent 2m and 6,735 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI code quality thresholds to enhance code maintainability standards and proximity-guard mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->