### PR TITLE
GH#19235: GH#19235: ratchet down NESTING_DEPTH_THRESHOLD 286→281 (actual 279 + 2 buffer)

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -126,7 +126,8 @@ FUNCTION_COMPLEXITY_THRESHOLD=28
 # Ratcheted down to 281 (GH#19204): actual violations 279 + 2 buffer
 # Bumped to 286 (GH#19215): proximity guard firing at 279/281 (2 headroom); 279 violations + 7 headroom = 286.
 # Proximity guard (warn_at = 286-5 = 281) fires when violations exceed 281 (i.e., at 282), preventing saturation.
-NESTING_DEPTH_THRESHOLD=286
+# Ratcheted down to 281 (GH#19235): actual violations 279 + 2 buffer
+NESTING_DEPTH_THRESHOLD=281
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Lowered NESTING_DEPTH_THRESHOLD from 286 to 281 in complexity-thresholds.conf. Actual violations: 279, buffer: 2, new threshold: 281. Added audit trail comment per ratchet-down convention.

## Files Changed

.agents/configs/complexity-thresholds.conf

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified threshold updated via grep; confirmed simplification-state.json not staged; CI will verify nesting depth scan passes at new threshold.

Resolves #19235


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.51 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-sonnet-4-6 spent 1m and 2,223 tokens on this as a headless worker.