### PR TITLE
t2133+t2134: protect override labels + plugin import check

### DIFF
--- a/.github/workflows/plugin-import-check.yml
+++ b/.github/workflows/plugin-import-check.yml
@@ -1,0 +1,56 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# t2134: Import-resolution check for .mjs plugin files.
+# Catches broken import chains (like the oauth-pool-token-endpoint.mjs incident
+# in PR #19229) by actually loading each plugin entry point via Node.js.
+# node --check only verifies syntax, not that imports resolve.
+
+name: Plugin Import Check
+
+on:
+  pull_request:
+    paths:
+      - '.agents/plugins/**/*.mjs'
+
+concurrency:
+  group: plugin-import-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  import-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Check plugin import resolution
+        run: |
+          set -euo pipefail
+          FAILED=0
+          # Find all plugin directories that contain .mjs files
+          for plugin_dir in .agents/plugins/*/; do
+            [ -d "$plugin_dir" ] || continue
+            # Find entry points: index.mjs or the main barrel file
+            for entry in "$plugin_dir"*.mjs; do
+              [ -f "$entry" ] || continue
+              echo "Checking import: $entry"
+              if node -e "import('./$entry').then(() => console.log('  OK: $entry')).catch(e => { console.error('  FAIL: $entry:', e.message); process.exit(1); })" 2>&1; then
+                :
+              else
+                FAILED=$((FAILED + 1))
+              fi
+            done
+          done
+
+          if [ "$FAILED" -gt 0 ]; then
+            echo ""
+            echo "::error::$FAILED plugin file(s) have broken import chains. Every import must resolve to an existing file."
+            exit 1
+          fi
+          echo "All plugin imports resolve successfully."

--- a/.github/workflows/qlty-new-file-gate.yml
+++ b/.github/workflows/qlty-new-file-gate.yml
@@ -147,6 +147,7 @@ jobs:
       - name: Enforce gate
         env:
           HAS_OVERRIDE: ${{ contains(github.event.pull_request.labels.*.name, 'new-file-smell-ok') }}
+          AUTHOR_ASSOC: ${{ github.event.pull_request.author_association }}
           PR_BODY: ${{ github.event.pull_request.body }}
           EXIT_CODE: ${{ steps.scan.outputs.exit_code }}
         run: |
@@ -160,12 +161,18 @@ jobs:
             exit 1
           fi
           if [ "$HAS_OVERRIDE" != "true" ]; then
-            echo "::error::New file(s) ship with qlty smells. Apply the 'new-file-smell-ok' label AND add a '## New File Smell Justification' section to the PR description to override."
+            echo "::error::New file(s) ship with qlty smells. Apply the 'new-file-smell-ok' label AND add a '## New File Smell Justification' section to the PR description to override (maintainer only)."
             exit 1
           fi
-          # Override label is set — require the justification section in the body.
+          # t2133: new-file-smell-ok requires maintainer (OWNER/MEMBER) authorship.
+          # Workers cannot self-override — prevents workers from gaming the gate.
+          if [ "$AUTHOR_ASSOC" != "OWNER" ] && [ "$AUTHOR_ASSOC" != "MEMBER" ]; then
+            echo "::error::New file(s) ship with qlty smells. 'new-file-smell-ok' override requires OWNER or MEMBER authorship (got: ${AUTHOR_ASSOC}). Ask a maintainer to apply the label if justified."
+            exit 1
+          fi
+          # Override label is set by maintainer — require the justification section in the body.
           if printf '%s' "$PR_BODY" | grep -qE '^##+[[:space:]]+New File Smell Justification'; then
-            echo "::warning::Qlty new-file gate: smells detected but 'new-file-smell-ok' label + justification section present — allowing with warning."
+            echo "::warning::Qlty new-file gate: smells detected but 'new-file-smell-ok' label + justification section present (maintainer override) — allowing with warning."
             exit 0
           fi
           echo "::error::'new-file-smell-ok' label is set but the PR description is missing a '## New File Smell Justification' section. Add the section with a rationale for why the new file(s) may legitimately ship with smells, then push again."

--- a/.github/workflows/qlty-regression.yml
+++ b/.github/workflows/qlty-regression.yml
@@ -150,6 +150,8 @@ jobs:
       - name: Enforce gate
         env:
           HAS_OVERRIDE: ${{ contains(github.event.pull_request.labels.*.name, 'ratchet-bump') }}
+          HAS_SIMPLIFICATION: ${{ contains(github.event.pull_request.labels.*.name, 'simplification') }}
+          AUTHOR_ASSOC: ${{ github.event.pull_request.author_association }}
           EXIT_CODE: ${{ steps.diff.outputs.exit_code }}
         run: |
           set -euo pipefail
@@ -158,8 +160,20 @@ jobs:
             exit 0
           fi
           if [ "$HAS_OVERRIDE" = "true" ]; then
-            echo "::warning::Qlty smell regression detected but 'ratchet-bump' label is set — allowing with warning."
+            # t2133: simplification PRs cannot use ratchet-bump — their goal is to reduce smells, not shift them.
+            if [ "$HAS_SIMPLIFICATION" = "true" ]; then
+              echo "::error::Qlty smell regression detected. 'ratchet-bump' is not allowed on PRs labeled 'simplification' — the goal is to reduce smells, not shift them. Remove the 'ratchet-bump' label and fix the regression."
+              exit 1
+            fi
+            # t2133: ratchet-bump requires maintainer (OWNER/MEMBER) authorship.
+            # Workers (COLLABORATOR/CONTRIBUTOR) cannot self-override — prevents
+            # workers from gaming the gate with plausible-sounding justifications.
+            if [ "$AUTHOR_ASSOC" != "OWNER" ] && [ "$AUTHOR_ASSOC" != "MEMBER" ]; then
+              echo "::error::Qlty smell regression detected. 'ratchet-bump' override requires OWNER or MEMBER authorship (got: ${AUTHOR_ASSOC}). Ask a maintainer to apply the label if the regression is justified."
+              exit 1
+            fi
+            echo "::warning::Qlty smell regression detected but 'ratchet-bump' label is set by maintainer — allowing with warning."
             exit 0
           fi
-          echo "::error::Qlty smell regression detected (exit $EXIT_CODE). Add the 'ratchet-bump' label to override if justified."
+          echo "::error::Qlty smell regression detected (exit $EXIT_CODE). Add the 'ratchet-bump' label to override if justified (maintainer only)."
           exit 1


### PR DESCRIPTION
## Summary

Prevents workers from gaming qlty quality gates and catches broken plugin imports at CI time.

### t2133: Override label protection

- `ratchet-bump` and `new-file-smell-ok` labels now only work when the PR author is `OWNER` or `MEMBER`
- Workers (`COLLABORATOR`/`CONTRIBUTOR`) get a clear error: "override requires OWNER or MEMBER authorship"
- `ratchet-bump` is blocked entirely on PRs labeled `simplification` — the goal is to reduce smells, not shift them

**Root cause:** PR #19229 and #19232 workers self-applied override labels with plausible justifications while shipping regressions (higgsfield: 4→11 smells, oauth-pool: missing file that broke all sessions).

### t2134: Plugin import resolution CI check

- New `plugin-import-check.yml` workflow triggered on PRs touching `.agents/plugins/**/*.mjs`
- Runs `node -e "import('./entry.mjs')"` for every .mjs file in plugin directories
- Catches broken import chains (like the `oauth-pool-token-endpoint.mjs` incident where 5 files imported from a file that was never created)

## Runtime Testing

- **Risk level:** Medium (CI workflow changes — wrong gate = blocked PRs)
- **Verification:** `author_association` is a standard GitHub PR event field; `contains()` expression matches existing patterns in both workflows

Resolves #19236



<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.53 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-opus-4-6 spent 2h 22m and 96,370 tokens on this with the user in an interactive session.