### PR TITLE
t2137: fix(issue-sync): skip parent-task title-fallback hygiene + atomic status:done mutation

### DIFF
--- a/.agents/scripts/tests/test-label-invariants.sh
+++ b/.agents/scripts/tests/test-label-invariants.sh
@@ -382,6 +382,106 @@ if [[ -f "$COUNTER_FILE" ]]; then
 fi
 
 # =============================================================================
+# Part 4 — issue-sync.yml workflow atomicity guard (t2137)
+# =============================================================================
+# The bash helper path (_mark_issue_done) and the GitHub Actions workflow
+# path (.github/workflows/issue-sync.yml `sync-on-pr-merge` job) both mutate
+# status:* labels on PR merge. t2040 fixed atomicity in the bash helper but
+# the workflow carried a duplicated non-atomic implementation (1 add call +
+# 7 remove calls in a loop = 8 sequential API calls = ~5s race window).
+# This guard parses the workflow yaml directly and asserts the status label
+# mutation block uses a single `gh issue edit` call with the full flag set.
+WORKFLOW_FILE="$(cd "${TEST_SCRIPTS_DIR}/../.." && pwd)/.github/workflows/issue-sync.yml"
+
+if [[ ! -f "$WORKFLOW_FILE" ]]; then
+	print_result "issue-sync.yml exists (for atomicity guard)" 1 "(not found at $WORKFLOW_FILE)"
+else
+	print_result "issue-sync.yml exists (for atomicity guard)" 0
+
+	# Extract the `Apply closing hygiene to linked issues` step body — from
+	# the step name to the next `- name:` line. awk handles this cleanly.
+	hygiene_block=$(awk '
+		/- name: Apply closing hygiene to linked issues/ { in_block=1 }
+		in_block && /^      - name:/ && !/Apply closing hygiene/ { in_block=0 }
+		in_block { print }
+	' "$WORKFLOW_FILE")
+
+	if [[ -z "$hygiene_block" ]]; then
+		print_result "found 'Apply closing hygiene' step in workflow" 1
+	else
+		print_result "found 'Apply closing hygiene' step in workflow" 0
+
+		# Count `gh issue edit` invocations inside the hygiene block. The atomic
+		# implementation has exactly ONE (the status:done mutation). Any more
+		# means the loop-of-remove-calls fossil has been reintroduced.
+		# Note: the multi-line `gh issue edit ... \` counts as one invocation.
+		edit_count=$(echo "$hygiene_block" | grep -cE '^[[:space:]]+gh issue edit[[:space:]]' || echo 0)
+		edit_count="${edit_count//[^0-9]/}"
+		edit_count="${edit_count:-0}"
+		if [[ "$edit_count" -eq 1 ]]; then
+			print_result "workflow status mutation is atomic (exactly 1 gh issue edit)" 0
+		else
+			print_result "workflow status mutation is atomic (exactly 1 gh issue edit)" 1 \
+				"(got $edit_count gh issue edit invocations in hygiene block)"
+		fi
+
+		# The single invocation must add status:done and remove every sibling.
+		# Check for the flags in the combined block (flags may span continuation lines).
+		if echo "$hygiene_block" | grep -q -- '--add-label "status:done"'; then
+			print_result "workflow hygiene adds status:done" 0
+		else
+			print_result "workflow hygiene adds status:done" 1
+		fi
+
+		missing_removals=""
+		for sibling in status:available status:queued status:claimed \
+			status:in-review status:in-progress status:blocked status:verify-failed; do
+			if ! echo "$hygiene_block" | grep -q -- "--remove-label \"$sibling\""; then
+				missing_removals="$missing_removals $sibling"
+			fi
+		done
+		if [[ -z "$missing_removals" ]]; then
+			print_result "workflow hygiene removes all sibling status labels" 0
+		else
+			print_result "workflow hygiene removes all sibling status labels" 1 \
+				"(missing:$missing_removals)"
+		fi
+
+		# Non-atomic fossil detection: a `for STALE_LABEL in status:*` loop with
+		# an internal `gh issue edit --remove-label` is the exact pattern that
+		# caused the drift. Reject any reintroduction.
+		if echo "$hygiene_block" | grep -qE 'for[[:space:]]+STALE_LABEL[[:space:]]+in[[:space:]]+"status:'; then
+			print_result "workflow hygiene has no STALE_LABEL remove-loop (fossil)" 1 \
+				"(the non-atomic loop pattern has been reintroduced)"
+		else
+			print_result "workflow hygiene has no STALE_LABEL remove-loop (fossil)" 0
+		fi
+	fi
+
+	# Parent-task title-fallback guard: the `Find issue by task ID (fallback)`
+	# step must probe the parent-task label and skip when present. Guards
+	# against the t2137 regression where planning PRs on parent-tasks
+	# incorrectly flipped the parent to status:done via title-matching.
+	find_block=$(awk '
+		/- name: Find issue by task ID \(fallback\)/ { in_block=1 }
+		in_block && /^      - name:/ && !/Find issue by task ID/ { in_block=0 }
+		in_block { print }
+	' "$WORKFLOW_FILE")
+
+	# Skip signature: parent-task label probe inside the find-issue step AND
+	# (within the same step) an `echo "found_issues="` that emits empty output
+	# when the probe matches. Both indicators together prove the skip path
+	# exists and is wired into GITHUB_OUTPUT correctly.
+	if echo "$find_block" | grep -qE 'parent-task' &&
+		echo "$find_block" | grep -qE 'echo[[:space:]]+"found_issues="'; then
+		print_result "find-issue step skips parent-task title-fallback matches (t2137)" 0
+	else
+		print_result "find-issue step skips parent-task title-fallback matches (t2137)" 1 \
+			"(expected parent-task label probe + empty found_issues emission)"
+	fi
+fi
+
+# =============================================================================
 # Summary
 # =============================================================================
 echo

--- a/.github/workflows/issue-sync.yml
+++ b/.github/workflows/issue-sync.yml
@@ -341,13 +341,26 @@ jobs:
           REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          # If no explicit Closes #NNN in PR body, search for the issue by task ID in title
+          # If no explicit Closes #NNN in PR body, search for the issue by task ID in title.
+          # t2137: skip title-fallback matches on parent-task issues. Explicit
+          # Closes/Fixes/Resolves is respected (either a legitimate terminal-phase
+          # close or a maintainer override); title-matching alone is too weak a
+          # signal to flip a parent's status:done — it fires on every planning PR
+          # whose title shares the parent's task ID prefix (t2046 For/Ref
+          # convention makes this the common case).
           if [[ -z "$LINKED_ISSUES" ]]; then
             FOUND=$(gh issue list --repo "$REPO" --state all --search "${TASK_ID}:" --json number,title --limit 5 \
               | jq -r --arg tid "$TASK_ID" '[.[] | select(.title | test("^" + $tid + "[.:\\s]"))] | .[0].number // empty')
             if [[ -n "$FOUND" && "$FOUND" != "null" ]]; then
-              echo "found_issues=$FOUND" >> "$GITHUB_OUTPUT"
-              echo "Found issue #$FOUND for task $TASK_ID"
+              # t2137: probe parent-task label before accepting the fallback match.
+              FOUND_LABELS=$(gh api "repos/${REPO}/issues/${FOUND}" --jq '[.labels[].name] | join(" ")' 2>/dev/null || echo "")
+              if echo "$FOUND_LABELS" | grep -qw "parent-task"; then
+                echo "found_issues=" >> "$GITHUB_OUTPUT"
+                echo "Found issue #$FOUND for task $TASK_ID is a parent-task — skipping title-fallback hygiene (use explicit Closes #NNN on the terminal-phase PR to close a parent)"
+              else
+                echo "found_issues=$FOUND" >> "$GITHUB_OUTPUT"
+                echo "Found issue #$FOUND for task $TASK_ID"
+              fi
             else
               echo "found_issues=" >> "$GITHUB_OUTPUT"
               echo "No issue found for task $TASK_ID"
@@ -440,16 +453,28 @@ jobs:
               continue
             fi
 
-            # Apply status:done label (create if needed)
+            # Apply status:done label atomically (create if needed).
+            # t2137: collapse add+remove into a single `gh issue edit` call so the
+            # labeled/unlabeled events are emitted together. The previous
+            # implementation issued 1 add + 7 remove calls in sequence (8
+            # round-trips over ~5s observed), which violated the t2040 atomicity
+            # contract and left a race window where the reconciler's
+            # label-invariant pass could see two status labels and pick the wrong
+            # survivor. The bash helper `_mark_issue_done` was fixed in t2040;
+            # this closes the drifted workflow copy.
             gh label create "status:done" --color "6F42C1" --description "Task is complete" --repo "$REPO" --force 2>/dev/null || true
-            gh issue edit "$ISSUE_NUM" --repo "$REPO" --add-label "status:done" 2>/dev/null || true
+            gh issue edit "$ISSUE_NUM" --repo "$REPO" \
+              --add-label "status:done" \
+              --remove-label "status:available" \
+              --remove-label "status:queued" \
+              --remove-label "status:claimed" \
+              --remove-label "status:in-review" \
+              --remove-label "status:in-progress" \
+              --remove-label "status:blocked" \
+              --remove-label "status:verify-failed" \
+              2>/dev/null || true
 
-            # Remove stale status labels
-            for STALE_LABEL in "status:available" "status:queued" "status:claimed" "status:in-review" "status:in-progress" "status:blocked" "status:verify-failed"; do
-              gh issue edit "$ISSUE_NUM" --repo "$REPO" --remove-label "$STALE_LABEL" 2>/dev/null || true
-            done
-
-            echo "Updated labels on #$ISSUE_NUM (added status:done, removed stale)"
+            echo "Updated labels on #$ISSUE_NUM atomically (added status:done, removed stale in one edit)"
           done
 
           if [[ "$COMMENT_FAILED" -eq 1 ]]; then

--- a/todo/tasks/t2137-brief.md
+++ b/todo/tasks/t2137-brief.md
@@ -1,0 +1,156 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# t2137 — fix(issue-sync): skip closing hygiene on parent-task issues + atomic status:done mutation
+
+## Session Origin
+
+Interactive session, 2026-04-16. Surfaced while merging PR #19228 (t2126 plan
+PR). Observed two systemic defects in `.github/workflows/issue-sync.yml` that
+affect every PR merge:
+
+1. Parent-task issue #19222 received `status:done` despite PR using the
+   `For #19222` keyword (t2046 parent-task convention), because the
+   workflow's title-fallback `tNNN:` search ignored the `parent-task` label.
+2. `status:done` was added and `status:in-review` was removed in two separate
+   `gh issue edit` calls ~5 seconds apart — violates the atomicity contract
+   the framework established in t2040 (`_mark_issue_done`) for the bash helper
+   path, but the workflow was never updated to match.
+
+## What
+
+Two surgical edits to `.github/workflows/issue-sync.yml` `sync-on-pr-merge`
+job, plus test coverage.
+
+### Fix 1: skip parent-task issues in title-fallback
+
+In the `find-issue` step (around line 335-358), after a title-based
+`tNNN:` search returns a candidate issue, check whether that issue carries
+the `parent-task` label. If yes, drop it from `found_issues` output with a
+clear log line.
+
+**Why title-fallback only, not the Closes/Fixes/Resolves path:** explicit
+Closes/Fixes/Resolves on a parent-task is either (a) the legitimate terminal
+phase closing the parent, or (b) already prevented by
+`parent-task-keyword-check.yml`. Respecting the keyword is correct
+behaviour in both cases. The title-fallback is the gap where intent is
+ambiguous — a planning PR with title `t2126:` legitimately references the
+parent but isn't closing it.
+
+### Fix 2: atomic label mutation
+
+In the `Apply closing hygiene` step (lines 443-450), collapse the 1
+`--add-label` call + 7 `--remove-label` calls (8 sequential API calls) into
+a single `gh issue edit` invocation with repeated flags.
+
+GitHub's issue edit API supports multiple `--add-label` and `--remove-label`
+on one call; the resulting `labeled`/`unlabeled` events carry identical
+timestamps, closing the race window entirely.
+
+### Test coverage
+
+Extend `.agents/scripts/tests/test-label-invariants.sh` (or add a sibling
+test) with a case that extracts the gh invocation list from the workflow
+yaml (by parsing the `Apply closing hygiene` step) and asserts exactly one
+`gh issue edit` call in the status-mutation block.
+
+## Why
+
+- Every parent-task planning PR has silently flipped its parent to
+  `status:done` since parent-task convention was introduced. Parents with
+  verification work still to do are incorrectly categorised, affecting
+  triage, dispatch dedup, and the status-label state machine. Observed on
+  #19222 after PR #19228 merged — all 5 children coincidentally closed too,
+  so the false positive wasn't caught earlier.
+- The non-atomic window is narrow (5s observed) but arbitrary under API
+  latency; t2040's own code comment explicitly warns *"the reconciler's
+  label-invariant pass would see two status labels and could pick the wrong
+  survivor, potentially losing `done`"*. The framework already acknowledges
+  this as a known risk class.
+- Duplicated logic between the bash helper and the workflow is the root
+  cause of the divergence — t2040 fixed one copy, the other drifted.
+
+## How
+
+### Files to modify
+
+- **EDIT:** `.github/workflows/issue-sync.yml`
+  - Lines ~335-358 (`find-issue` step): add parent-task label probe before
+    writing `found_issues` output.
+  - Lines ~443-450 (label mutation block): collapse to one `gh issue edit`
+    call.
+- **NEW or EDIT:** `.agents/scripts/tests/test-label-invariants.sh` (or
+  new `test-workflow-label-atomicity.sh`): assert single-edit invariant.
+
+### Reference patterns
+
+- **Existing skip-hygiene pattern:** lines 384-402 in the same file
+  (`IS_REJECTED` path for rejection labels — `invalid`, `not-planned`,
+  `wontfix`, `duplicate`). My parent-task skip follows the identical shape.
+  Prior art: PR #17986 established this pattern.
+- **Atomic bash helper:** `_mark_issue_done` → `set_issue_status` in
+  `.agents/scripts/issue-sync-helper.sh:374`. Do not call this from the
+  workflow (requires sourcing the whole helper); instead inline a single
+  `gh issue edit` with the equivalent flag set.
+
+### Verification
+
+- **Shellcheck:** `shellcheck .github/workflows/issue-sync.yml` (via
+  `actionlint` if available; otherwise the embedded `run:` blocks should
+  pass manual review).
+- **Test:** `bash .agents/scripts/tests/test-label-invariants.sh` must
+  remain green; new workflow-atomicity test must assert single-edit invariant.
+- **Dry-run reasoning:** trace the workflow logic against the t2126/19228
+  scenario — parent-task issue #19222 with `For #19222` should produce
+  `LINKED_ISSUES=""`, `FOUND_ISSUES=""` (because parent-task skip), therefore
+  `ALL_ISSUES=""`, therefore early exit at line 376-378. No comment, no label
+  mutation. Correct.
+
+## Acceptance criteria
+
+- [ ] Parent-task issue with `For #NNN`-only PR merge does NOT receive
+  `status:done` label or "Completed via" comment.
+- [ ] Non-parent issue with `Closes/Fixes/Resolves #NNN` PR merge still
+  receives full closing hygiene (comment + atomic label edit). Baseline
+  behaviour preserved.
+- [ ] Label mutation is a single `gh issue edit` call — measurable by the
+  timestamp of the resulting `labeled`/`unlabeled` events (<1s apart).
+- [ ] `test-label-invariants.sh` (or equivalent new test) green.
+- [ ] No new shellcheck findings on the workflow `run:` blocks.
+
+## Context
+
+- **Parent-task convention:** `prompts/build.txt` "Parent-task PR keyword
+  rule (t2046)" and `templates/brief-template.md` "PR Conventions".
+- **t2040 atomicity fix:** `.agents/scripts/issue-sync-helper.sh:360-378`
+  (commented explicitly — useful reference for the why).
+- **Existing closing-hygiene skip pattern (prior art):** PR #17986.
+- **Observation session:** merge of PR #19238 then PR #19228 on 2026-04-16.
+  Event timeline on #19222: `status:done` added at `03:12:20Z`,
+  `status:in-review` removed at `03:12:25Z` (5s gap → 8 sequential
+  `gh issue edit` calls).
+
+## Tier checklist
+
+- [x] Single-file surgical change in one workflow + one test → would fit
+  `tier:simple` except brief needs narrative trade-off reasoning
+- [ ] Default `tier:standard` because bug-fix touching CI behaviour requires
+  context-aware verification (won't ship if downstream workflows break)
+- [x] Estimate ~45min (diff ~30 lines + test) — dispatchable as standard
+
+## CI/CD consequence audit
+
+The user explicitly flagged "ensuring no unintended undesirable consequences
+for our CI/CD needs and aims". Changes audited against aims:
+
+| Aim | Current | After fix | Risk |
+|---|---|---|---|
+| Mark issues done on merge | Works for leaf issues; over-applies to parent-tasks | Works for leaf issues; correctly skips parent-tasks | None |
+| Post closing comment audit trail | Posts "Completed via…" on all linked | Still posts on leaf; skips on parent (incorrect "Completed via" message) | Audit trail on parent moves to the existing "Parent-task phase nudge" step (line 460+) which is more accurate |
+| Remove stale status labels | 7 separate API calls, 5s window | Single atomic call | Downstream `issues.labeled` triggers still fire — event semantics unchanged |
+| Support rejection labels (not-planned/wontfix) | Skip hygiene path at line 400 | Unchanged | None — my skip is additive |
+| Support `Closes/Fixes/Resolves` → parent-task (terminal phase) | Hygiene runs (correct) | Hygiene runs (correct) | None — skip only applies to title-fallback |
+| Concurrency across multiple PRs merging | `concurrency: group: issue-sync-pr-<PR>` serialises | Unchanged | None |
+
+**Net:** strictly corrective. No new failure modes introduced, one false-positive
+class eliminated, one atomicity race closed.


### PR DESCRIPTION
## Summary

Two systemic fixes to .github/workflows/issue-sync.yml sync-on-pr-merge job:

1. **Skip parent-task issues in title-fallback** — the find-issue step's tNNN: title search now probes the parent-task label on the matched candidate. If present, the match is dropped from found_issues output with a clear log line. Explicit Closes/Fixes/Resolves references remain fully respected (terminal-phase close or maintainer override).

2. **Atomic label mutation** — the previous 1 add + 7 remove calls (8 sequential gh edit invocations, ~5s observed window) are collapsed into a single gh issue edit with all add/remove flags on one call. Matches the t2040 atomicity contract that was already applied to the bash helper _mark_issue_done but had drifted from the workflow copy.

Observed on issue #19222 after PR #19228 merged: status:done incorrectly applied to the open parent-task, then status:in-review removed 5s later — race window for the reconciler's label-invariant pass.

## Files Changed

.agents/scripts/tests/test-label-invariants.sh,.github/workflows/issue-sync.yml,todo/tasks/t2137-brief.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** - bash .agents/scripts/tests/test-label-invariants.sh: 26/26 pass (7 new cases added for Part 4: workflow atomicity guard)
- actionlint .github/workflows/issue-sync.yml: clean
- shellcheck .agents/scripts/tests/test-label-invariants.sh: clean
- Python yaml parse: OK

Resolves #19247


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.54 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-opus-4-6 spent 35m and 59,380 tokens on this with the user in an interactive session.