### PR TITLE
t2138: fix(pulse): reconcile_completed_parent_tasks consults sub-issue graph before body regex

### DIFF
--- a/.agents/scripts/pulse-issue-reconcile.sh
+++ b/.agents/scripts/pulse-issue-reconcile.sh
@@ -994,6 +994,54 @@ _fetch_subissue_numbers() {
 #
 # Max 5 closes per cycle to limit API usage.
 #######################################
+# t2138: extract per-parent close logic. Keeps reconcile_completed_parent_tasks
+# under the 100-line shell-complexity threshold and makes the close decision
+# independently testable. Returns 0 if the parent was closed, 1 if skipped
+# (fewer than 2 known children, any child still open, or close call failed).
+_try_close_parent_tracker() {
+	local slug="$1" parent_num="$2" child_nums="$3" child_source="$4"
+	local all_closed="true" child_summary="" child_count=0
+	local child_num child_state child_title_line
+
+	while IFS= read -r child_num; do
+		[[ -n "$child_num" && "$child_num" =~ ^[0-9]+$ ]] || continue
+		child_state=$(gh api "repos/${slug}/issues/${child_num}" \
+			--jq '.state // "unknown"' 2>/dev/null) || child_state="unknown"
+		child_title_line=$(gh api "repos/${slug}/issues/${child_num}" \
+			--jq '.title // ""' 2>/dev/null) || child_title_line=""
+
+		# Skip references that aren't real child issues (PRs, external refs)
+		[[ "$child_state" == "unknown" ]] && continue
+
+		child_count=$((child_count + 1))
+		if [[ "$child_state" == "closed" ]]; then
+			child_summary="${child_summary}
+- #${child_num}: ${child_title_line} — ✅ CLOSED"
+		else
+			child_summary="${child_summary}
+- #${child_num}: ${child_title_line} — ⏳ OPEN"
+			all_closed="false"
+		fi
+	done <<<"$child_nums"
+
+	# Need at least 2 children (1 = probably just a reference, not a parent).
+	[[ "$child_count" -ge 2 ]] || return 1
+	[[ "$all_closed" == "true" ]] || return 1
+
+	gh issue close "$parent_num" --repo "$slug" \
+		--comment "## All child tasks completed — closing parent tracker
+
+${child_summary}
+
+All ${child_count} child issues are resolved. Parent tracker closed automatically.
+
+_Detected by reconcile_completed_parent_tasks (pulse-issue-reconcile.sh)._" \
+		>/dev/null 2>&1 || return 1
+
+	echo "[pulse-wrapper] Reconcile parent-task: closed #${parent_num} in ${slug} — all ${child_count} children closed (source=${child_source})" >>"$LOGFILE"
+	return 0
+}
+
 reconcile_completed_parent_tasks() {
 	local repos_json="$REPOS_JSON"
 	[[ -f "$repos_json" ]] || return 0
@@ -1017,76 +1065,25 @@ reconcile_completed_parent_tasks() {
 
 		local i=0
 		while [[ "$i" -lt "$issue_count" ]] && [[ "$total_closed" -lt "$max_closes" ]]; do
-			local issue_num issue_title issue_body
+			local issue_num issue_body
 			issue_num=$(printf '%s' "$issues_json" | jq -r --argjson i "$i" '.[$i].number // ""') || true
-			issue_title=$(printf '%s' "$issues_json" | jq -r --argjson i "$i" '.[$i].title // ""') || true
 			issue_body=$(printf '%s' "$issues_json" | jq -r --argjson i "$i" '.[$i].body // ""') || true
 			i=$((i + 1))
 			[[ "$issue_num" =~ ^[0-9]+$ ]] || continue
 
 			# t2138: prefer the sub-issue graph when non-empty; fall back to
-			# body regex for legacy parents that list children inline. Both
-			# paths filter out self-references and sort/dedupe uniformly.
+			# body regex for legacy parents that list children inline.
 			local child_nums child_source="graph"
 			child_nums=$(_fetch_subissue_numbers "$slug" "$issue_num" | sort -un | grep -v "^${issue_num}$" | grep -v '^$' || true)
 			if [[ -z "$child_nums" ]]; then
-				# Fallback: extract child issue numbers from body (#NNN patterns,
-				# excluding self-references).
 				child_nums=$(printf '%s' "$issue_body" | grep -oE '#[0-9]+' | grep -oE '[0-9]+' | sort -un | grep -v "^${issue_num}$") || child_nums=""
 				child_source="body"
 			fi
 			[[ -n "$child_nums" ]] || continue
 
-			# Check if ALL children are closed
-			local all_closed="true"
-			local child_summary=""
-			local child_count=0
-			while IFS= read -r child_num; do
-				[[ -n "$child_num" && "$child_num" =~ ^[0-9]+$ ]] || continue
-				local child_state child_title_line
-				child_state=$(gh api "repos/${slug}/issues/${child_num}" \
-					--jq '.state // "unknown"' 2>/dev/null) || child_state="unknown"
-				child_title_line=$(gh api "repos/${slug}/issues/${child_num}" \
-					--jq '.title // ""' 2>/dev/null) || child_title_line=""
-
-				# Skip references that aren't real child issues (PRs, external refs)
-				if [[ "$child_state" == "unknown" ]]; then
-					continue
-				fi
-
-				child_count=$((child_count + 1))
-				if [[ "$child_state" == "closed" ]]; then
-					child_summary="${child_summary}
-- #${child_num}: ${child_title_line} — ✅ CLOSED"
-				else
-					child_summary="${child_summary}
-- #${child_num}: ${child_title_line} — ⏳ OPEN"
-					all_closed="false"
-				fi
-			done <<<"$child_nums"
-
-			# Need at least 2 children to be a real parent (1 child = probably just a reference)
-			if [[ "$child_count" -lt 2 ]]; then
-				continue
+			if _try_close_parent_tracker "$slug" "$issue_num" "$child_nums" "$child_source"; then
+				total_closed=$((total_closed + 1))
 			fi
-
-			if [[ "$all_closed" != "true" ]]; then
-				continue
-			fi
-
-			# All children closed — close the parent
-			gh issue close "$issue_num" --repo "$slug" \
-				--comment "## All child tasks completed — closing parent tracker
-
-${child_summary}
-
-All ${child_count} child issues are resolved. Parent tracker closed automatically.
-
-_Detected by reconcile_completed_parent_tasks (pulse-issue-reconcile.sh)._" \
-				>/dev/null 2>&1 || continue
-
-			echo "[pulse-wrapper] Reconcile parent-task: closed #${issue_num} in ${slug} — all ${child_count} children closed (source=${child_source})" >>"$LOGFILE"
-			total_closed=$((total_closed + 1))
 		done
 	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug // ""' "$repos_json" || true)
 

--- a/.agents/scripts/pulse-issue-reconcile.sh
+++ b/.agents/scripts/pulse-issue-reconcile.sh
@@ -966,11 +966,24 @@ _fetch_subissue_numbers() {
 	[[ "$issue_num" =~ ^[0-9]+$ ]] || return 0
 
 	local owner="${slug%%/*}" name="${slug##*/}"
+	# t2138: fetch pageInfo alongside nodes so we can fail-closed when
+	# hasNextPage is true. Partial child lists would silently let the
+	# reconciler close parents before the tail children are checked.
+	# The jq filter returns `PAGINATED` (non-numeric) when hasNextPage=true,
+	# which the caller treats as "empty" → falls back to body regex.
+	local graphql_result
 	# shellcheck disable=SC2016  # GraphQL variable markers ($owner/$name/$number) are intentional literals, not bash expansions
-	gh api graphql \
-		-f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){issue(number:$number){subIssues(first:50){nodes{number state}}}}}' \
+	graphql_result=$(gh api graphql \
+		-f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){issue(number:$number){subIssues(first:50){nodes{number state}pageInfo{hasNextPage}}}}}' \
 		-F "owner=$owner" -F "name=$name" -F "number=$issue_num" \
-		--jq '.data.repository.issue.subIssues.nodes // [] | .[] | .number' 2>/dev/null || return 0
+		--jq 'if (.data.repository.issue.subIssues.pageInfo.hasNextPage // false) then "PAGINATED" else (.data.repository.issue.subIssues.nodes // [] | .[] | .number) end' 2>/dev/null) || return 0
+
+	# Fail-closed guard: if hasNextPage, pretend we got nothing so the
+	# caller falls back to body regex (where pagination is not an issue).
+	if [[ "$graphql_result" == "PAGINATED" ]]; then
+		return 0
+	fi
+	printf '%s\n' "$graphql_result"
 	return 0
 }
 

--- a/.agents/scripts/pulse-issue-reconcile.sh
+++ b/.agents/scripts/pulse-issue-reconcile.sh
@@ -949,15 +949,48 @@ reconcile_open_issues_with_merged_prs() {
 }
 
 #######################################
+# Fetch sub-issue numbers via GitHub GraphQL (t2138).
+#
+# Uses the native `subIssues` relationship on the issue node. Returns
+# newline-separated child issue numbers on stdout. Empty output on any
+# failure, empty graph, or feature-not-enabled. Callers must treat empty
+# output as "fall back to body regex", NOT "no children" — the sub-issue
+# feature is a recent GitHub addition and legacy parents may link
+# children only via body text.
+#
+# Args: $1 = slug (owner/name), $2 = issue number
+#######################################
+_fetch_subissue_numbers() {
+	local slug="$1" issue_num="$2"
+	[[ "$slug" == */* ]] || return 0
+	[[ "$issue_num" =~ ^[0-9]+$ ]] || return 0
+
+	local owner="${slug%%/*}" name="${slug##*/}"
+	# shellcheck disable=SC2016  # GraphQL variable markers ($owner/$name/$number) are intentional literals, not bash expansions
+	gh api graphql \
+		-f query='query($owner:String!,$name:String!,$number:Int!){repository(owner:$owner,name:$name){issue(number:$number){subIssues(first:50){nodes{number state}}}}}' \
+		-F "owner=$owner" -F "name=$name" -F "number=$issue_num" \
+		--jq '.data.repository.issue.subIssues.nodes // [] | .[] | .number' 2>/dev/null || return 0
+	return 0
+}
+
+#######################################
 # Close parent-task issues when all child issues are resolved.
 #
 # Parent-task issues block dispatch unconditionally — they exist as
 # planning trackers. When all their children are closed, the parent
 # should close automatically with a summary comment listing each child.
 #
-# Child detection: extracts #NNN references from the parent's body that
-# are NOT self-references. Checks each against GH API for closed state.
-# Only closes if ALL children are closed and there are at least 1.
+# Child detection (t2138 — preference order):
+#   1. GitHub sub-issue graph (GraphQL `subIssues` field) — authoritative
+#      parent-child relationship when the parent was wired via
+#      `issue-sync-helper.sh backfill-sub-issues` or `_gh_add_sub_issue`.
+#   2. Body regex #NNN references (fallback for legacy parents with
+#      children listed only inline in the body).
+#
+# Either source must yield ≥2 children to avoid single-reference false
+# positives. Checks each against GH API for closed state; only closes
+# if ALL children are closed.
 #
 # Max 5 closes per cycle to limit API usage.
 #######################################
@@ -991,9 +1024,17 @@ reconcile_completed_parent_tasks() {
 			i=$((i + 1))
 			[[ "$issue_num" =~ ^[0-9]+$ ]] || continue
 
-			# Extract child issue numbers from body (#NNN patterns, excluding self)
-			local child_nums
-			child_nums=$(printf '%s' "$issue_body" | grep -oE '#[0-9]+' | grep -oE '[0-9]+' | sort -un | grep -v "^${issue_num}$") || child_nums=""
+			# t2138: prefer the sub-issue graph when non-empty; fall back to
+			# body regex for legacy parents that list children inline. Both
+			# paths filter out self-references and sort/dedupe uniformly.
+			local child_nums child_source="graph"
+			child_nums=$(_fetch_subissue_numbers "$slug" "$issue_num" | sort -un | grep -v "^${issue_num}$" | grep -v '^$' || true)
+			if [[ -z "$child_nums" ]]; then
+				# Fallback: extract child issue numbers from body (#NNN patterns,
+				# excluding self-references).
+				child_nums=$(printf '%s' "$issue_body" | grep -oE '#[0-9]+' | grep -oE '[0-9]+' | sort -un | grep -v "^${issue_num}$") || child_nums=""
+				child_source="body"
+			fi
 			[[ -n "$child_nums" ]] || continue
 
 			# Check if ALL children are closed
@@ -1044,7 +1085,7 @@ All ${child_count} child issues are resolved. Parent tracker closed automaticall
 _Detected by reconcile_completed_parent_tasks (pulse-issue-reconcile.sh)._" \
 				>/dev/null 2>&1 || continue
 
-			echo "[pulse-wrapper] Reconcile parent-task: closed #${issue_num} in ${slug} — all ${child_count} children closed" >>"$LOGFILE"
+			echo "[pulse-wrapper] Reconcile parent-task: closed #${issue_num} in ${slug} — all ${child_count} children closed (source=${child_source})" >>"$LOGFILE"
 			total_closed=$((total_closed + 1))
 		done
 	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug // ""' "$repos_json" || true)

--- a/.agents/scripts/tests/test-pulse-reconcile-parent-task-subissue-graph.sh
+++ b/.agents/scripts/tests/test-pulse-reconcile-parent-task-subissue-graph.sh
@@ -72,6 +72,19 @@ case "$1" in
 	api)
 		shift
 		if [[ "${1:-}" == "graphql" ]]; then
+			# Per-scenario override: non-zero exit simulates a GraphQL
+			# failure (auth, rate-limit, network). The helper under test
+			# must treat this as empty and fall back to body regex.
+			if [[ -n "${GH_GRAPHQL_EXIT_CODE:-}" ]]; then
+				exit "${GH_GRAPHQL_EXIT_CODE}"
+			fi
+			# Per-scenario override: hasNextPage=true makes the helper's
+			# jq filter emit "PAGINATED" which the helper maps to empty →
+			# body-regex fallback (fail-closed on partial child lists).
+			if [[ "${GH_GRAPHQL_HAS_NEXT_PAGE:-false}" == "true" ]]; then
+				printf '%s\n' "PAGINATED"
+				exit 0
+			fi
 			# Emit the subIssues nodes list. Matches the jq filter
 			# `.data.repository.issue.subIssues.nodes // [] | .[] | .number`
 			# that the helper uses to pull numbers.
@@ -314,6 +327,75 @@ if grep -q "api graphql" "$GH_CALLS"; then
 else
 	print_result "graph query is always attempted first" 1 \
 		"(expected 'api graphql' invocation; calls: $(tr '\n' '|' <"$GH_CALLS" | head -c 400))"
+fi
+
+# -----------------------------------------------------------------------------
+# Scenario 7 (CodeRabbit review feedback): GraphQL call fails hard (exit 1).
+# Legacy body-ref fallback MUST still close the parent. This mirrors the
+# empty-graph scenario but exercises the error-path branch in the helper.
+# -----------------------------------------------------------------------------
+reset_scenario
+set_parent_list 1000 "t1000: graphql-failure" \
+	"Body has #1001 and #1002 — graph is temporarily broken."
+set_child_states "1001:closed:child-x" "1002:closed:child-y"
+
+GH_GRAPHQL_EXIT_CODE=1 reconcile_completed_parent_tasks >/dev/null 2>&1
+
+if grep -q "issue close 1000" "$GH_CALLS"; then
+	print_result "graphql-error fallback: closes via body regex when GraphQL fails" 0
+else
+	print_result "graphql-error fallback: closes via body regex when GraphQL fails" 1 \
+		"(calls: $(tr '\n' '|' <"$GH_CALLS" | head -c 400))"
+fi
+
+if grep -q "source=body" "$LOGFILE"; then
+	print_result "graphql-error fallback: log tags child_source=body" 0
+else
+	print_result "graphql-error fallback: log tags child_source=body" 1 \
+		"(log: $(cat "$LOGFILE"))"
+fi
+
+# -----------------------------------------------------------------------------
+# Scenario 8 (CodeRabbit review feedback): hasNextPage=true (parent has >50
+# children across pages). Helper MUST fail-closed — treat graph as empty and
+# fall back to body regex so we never close based on a partial child list.
+# -----------------------------------------------------------------------------
+reset_scenario
+set_parent_list 1100 "t1100: paginated" \
+	"Body has #1101 and #1102 as backstop refs."
+set_child_states "1101:closed:a" "1102:closed:b"
+
+GH_GRAPHQL_HAS_NEXT_PAGE=true reconcile_completed_parent_tasks >/dev/null 2>&1
+
+if grep -q "issue close 1100" "$GH_CALLS"; then
+	# Closed via body fallback (graph bailed out)
+	if grep -q "source=body" "$LOGFILE"; then
+		print_result "pagination fail-closed: graph bails, body fallback closes" 0
+	else
+		print_result "pagination fail-closed: graph bails, body fallback closes" 1 \
+			"(closed but source not 'body': $(cat "$LOGFILE"))"
+	fi
+else
+	print_result "pagination fail-closed: graph bails, body fallback closes" 1 \
+		"(expected close via body fallback; calls: $(tr '\n' '|' <"$GH_CALLS" | head -c 400))"
+fi
+
+# -----------------------------------------------------------------------------
+# Scenario 9: hasNextPage=true AND empty body → parent stays open (safe default).
+# The pagination guard must not cause a false negative close when no fallback
+# signal exists either.
+# -----------------------------------------------------------------------------
+reset_scenario
+set_parent_list 1200 "t1200: paginated-no-body" \
+	"Narrative only. No #NNN anywhere."
+
+GH_GRAPHQL_HAS_NEXT_PAGE=true reconcile_completed_parent_tasks >/dev/null 2>&1
+
+if grep -q "issue close 1200" "$GH_CALLS"; then
+	print_result "pagination fail-closed: no body refs = parent stays open" 1 \
+		"(unexpected close with paginated graph + empty body; calls: $(tr '\n' '|' <"$GH_CALLS" | head -c 400))"
+else
+	print_result "pagination fail-closed: no body refs = parent stays open" 0
 fi
 
 # -----------------------------------------------------------------------------

--- a/.agents/scripts/tests/test-pulse-reconcile-parent-task-subissue-graph.sh
+++ b/.agents/scripts/tests/test-pulse-reconcile-parent-task-subissue-graph.sh
@@ -1,0 +1,329 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-pulse-reconcile-parent-task-subissue-graph.sh — t2138 regression guard.
+#
+# Asserts that reconcile_completed_parent_tasks in pulse-issue-reconcile.sh:
+#
+#   1. Queries the sub-issue graph via GraphQL before falling back to body regex.
+#   2. Uses the graph result (authoritative) when non-empty, even if body has
+#      no #NNN references.
+#   3. Falls back to body-regex for legacy parents whose graph is empty.
+#   4. Still requires >=2 children (single-reference guard preserved).
+#   5. Still requires ALL children closed (partial-open no-close preserved).
+#
+# Primary motivating case: #19222 (t2126 parent with 5 closed children wired
+# via GraphQL, zero #NNN in body). Without this fix the parent stays open
+# indefinitely.
+
+set -uo pipefail
+
+TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_RED=$'\033[0;31m'
+TEST_GREEN=$'\033[0;32m'
+TEST_RESET=$'\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1" rc="$2" extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf '%sPASS%s %s\n' "$TEST_GREEN" "$TEST_RESET" "$name"
+	else
+		printf '%sFAIL%s %s %s\n' "$TEST_RED" "$TEST_RESET" "$name" "$extra"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+}
+
+# Sandbox
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+export HOME="${TEST_ROOT}/home"
+mkdir -p "${HOME}/.aidevops/logs"
+export LOGFILE="${HOME}/.aidevops/logs/pulse.log"
+: >"$LOGFILE"
+
+# -----------------------------------------------------------------------------
+# gh stub — configurable per scenario via env files written before each test
+# -----------------------------------------------------------------------------
+# Each scenario writes the following files:
+#   ${TEST_ROOT}/gh-subissues.json   — jq-formatted list of {number, state}
+#                                      returned by the GraphQL subIssues query.
+#                                      Empty "[]" = fallback to body regex.
+#   ${TEST_ROOT}/gh-issue-list.json  — the open-parent-task list returned by
+#                                      `gh issue list --label parent-task`.
+#   ${TEST_ROOT}/gh-child-states.env — key=value pairs mapping
+#                                      ISSUE_<NN>_STATE and ISSUE_<NN>_TITLE
+#                                      for each child lookup.
+
+STUB_DIR="${TEST_ROOT}/stubs"
+mkdir -p "$STUB_DIR"
+GH_CALLS="${TEST_ROOT}/gh-calls.log"
+export GH_CALLS TEST_ROOT
+
+cat >"${STUB_DIR}/gh" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${GH_CALLS}"
+
+case "$1" in
+	api)
+		shift
+		if [[ "${1:-}" == "graphql" ]]; then
+			# Emit the subIssues nodes list. Matches the jq filter
+			# `.data.repository.issue.subIssues.nodes // [] | .[] | .number`
+			# that the helper uses to pull numbers.
+			if [[ -f "${TEST_ROOT}/gh-subissues.json" ]]; then
+				jq '.[] | .number' "${TEST_ROOT}/gh-subissues.json" 2>/dev/null
+			fi
+			exit 0
+		fi
+		# `gh api repos/X/Y/issues/N --jq '.state // "unknown"'` or `--jq '.title // ""'`
+		# Extract the issue number from the path, look up in child-states env.
+		local_path="${1:-}"
+		local_issue=""
+		if [[ "$local_path" =~ /issues/([0-9]+)$ ]]; then
+			local_issue="${BASH_REMATCH[1]}"
+		fi
+		# Find the --jq filter (next arg after the path, or after --jq)
+		local_jq=""
+		while [[ $# -gt 0 ]]; do
+			if [[ "$1" == "--jq" ]]; then
+				shift
+				local_jq="${1:-}"
+				break
+			fi
+			shift
+		done
+		# Load state from env file
+		if [[ -n "$local_issue" && -f "${TEST_ROOT}/gh-child-states.env" ]]; then
+			# shellcheck disable=SC1090
+			source "${TEST_ROOT}/gh-child-states.env"
+			local_state_var="ISSUE_${local_issue}_STATE"
+			local_title_var="ISSUE_${local_issue}_TITLE"
+			if [[ "$local_jq" == *".state"* ]]; then
+				echo "${!local_state_var:-unknown}"
+			elif [[ "$local_jq" == *".title"* ]]; then
+				echo "${!local_title_var:-}"
+			fi
+		fi
+		exit 0
+		;;
+	issue)
+		case "${2:-}" in
+			list)
+				if [[ -f "${TEST_ROOT}/gh-issue-list.json" ]]; then
+					cat "${TEST_ROOT}/gh-issue-list.json"
+				else
+					echo "[]"
+				fi
+				exit 0
+				;;
+			close)
+				# Record the close call; always succeed
+				exit 0
+				;;
+		esac
+		;;
+esac
+exit 0
+STUB
+chmod +x "${STUB_DIR}/gh"
+export PATH="${STUB_DIR}:${PATH}"
+
+# Repos JSON for the function's iteration
+REPOS_JSON_FILE="${TEST_ROOT}/repos.json"
+cat >"$REPOS_JSON_FILE" <<'JSON'
+{
+	"initialized_repos": [
+		{"slug": "test/repo", "pulse": true, "local_only": false}
+	],
+	"git_parent_dirs": []
+}
+JSON
+export REPOS_JSON="$REPOS_JSON_FILE"
+
+# Source the target script. It references $LOGFILE and $REPOS_JSON.
+# shellcheck source=/dev/null
+source "${TEST_SCRIPTS_DIR}/pulse-issue-reconcile.sh" >/dev/null 2>&1
+
+# -----------------------------------------------------------------------------
+# Scenario helpers
+# -----------------------------------------------------------------------------
+reset_scenario() {
+	: >"$GH_CALLS"
+	: >"$LOGFILE"
+	rm -f "${TEST_ROOT}/gh-subissues.json" "${TEST_ROOT}/gh-child-states.env" "${TEST_ROOT}/gh-issue-list.json"
+}
+
+set_parent_list() {
+	# Args: issue_num title body
+	local num="$1" title="$2" body="$3"
+	jq -n --argjson n "$num" --arg t "$title" --arg b "$body" \
+		'[{number:$n, title:$t, body:$b}]' >"${TEST_ROOT}/gh-issue-list.json"
+}
+
+set_subissues() {
+	# Args: pairs of "num:state" space-separated, e.g. "100:CLOSED 101:CLOSED"
+	local pairs=("$@")
+	local json="["
+	local first=1
+	for pair in "${pairs[@]}"; do
+		local num="${pair%%:*}"
+		local state="${pair##*:}"
+		[[ "$first" -eq 1 ]] || json+=","
+		json+="{\"number\":${num},\"state\":\"${state}\"}"
+		first=0
+	done
+	json+="]"
+	printf '%s\n' "$json" >"${TEST_ROOT}/gh-subissues.json"
+}
+
+set_child_states() {
+	# Args: pairs of "num:state:title" space-separated
+	: >"${TEST_ROOT}/gh-child-states.env"
+	for triple in "$@"; do
+		IFS=":" read -r num state title <<<"$triple"
+		{
+			echo "ISSUE_${num}_STATE=${state}"
+			echo "ISSUE_${num}_TITLE=${title}"
+		} >>"${TEST_ROOT}/gh-child-states.env"
+	done
+}
+
+# -----------------------------------------------------------------------------
+# Scenario 1: graph has 5 closed children, body is narrative prose (no #NNN).
+# This is the #19222 case. MUST close via graph path.
+# -----------------------------------------------------------------------------
+reset_scenario
+set_parent_list 19222 "t2126: parent: qlty maintainability A-grade" \
+	"Parent tracker for 5 cluster decomposition tasks. No inline refs."
+set_subissues "19223:CLOSED" "19224:CLOSED" "19225:CLOSED" "19226:CLOSED" "19227:CLOSED"
+set_child_states "19223:closed:t2127" "19224:closed:t2128" "19225:closed:t2129" \
+	"19226:closed:t2130" "19227:closed:t2131"
+
+reconcile_completed_parent_tasks >/dev/null 2>&1
+
+if grep -q "issue close 19222" "$GH_CALLS"; then
+	print_result "graph-only path: closes parent when all 5 subissues CLOSED" 0
+else
+	print_result "graph-only path: closes parent when all 5 subissues CLOSED" 1 \
+		"(calls: $(tr '\n' '|' <"$GH_CALLS" | head -c 400))"
+fi
+
+if grep -q "source=graph" "$LOGFILE"; then
+	print_result "graph-only path: log tags child_source=graph" 0
+else
+	print_result "graph-only path: log tags child_source=graph" 1 \
+		"(log: $(cat "$LOGFILE"))"
+fi
+
+# -----------------------------------------------------------------------------
+# Scenario 2: graph empty, body has 2 closed #NNN references.
+# Legacy path MUST still close.
+# -----------------------------------------------------------------------------
+reset_scenario
+set_parent_list 500 "t500: legacy parent" \
+	"Tracks #501 and #502 as children."
+printf '[]\n' >"${TEST_ROOT}/gh-subissues.json"
+set_child_states "501:closed:child-A" "502:closed:child-B"
+
+reconcile_completed_parent_tasks >/dev/null 2>&1
+
+if grep -q "issue close 500" "$GH_CALLS"; then
+	print_result "body-fallback path: closes legacy parent with #NNN inline refs" 0
+else
+	print_result "body-fallback path: closes legacy parent with #NNN inline refs" 1 \
+		"(calls: $(tr '\n' '|' <"$GH_CALLS" | head -c 400))"
+fi
+
+if grep -q "source=body" "$LOGFILE"; then
+	print_result "body-fallback path: log tags child_source=body" 0
+else
+	print_result "body-fallback path: log tags child_source=body" 1 \
+		"(log: $(cat "$LOGFILE"))"
+fi
+
+# -----------------------------------------------------------------------------
+# Scenario 3: graph has 2 children but one is still OPEN.
+# MUST NOT close.
+# -----------------------------------------------------------------------------
+reset_scenario
+set_parent_list 600 "t600: partial" "Tracker with one child still working."
+set_subissues "601:CLOSED" "602:OPEN"
+set_child_states "601:closed:done-child" "602:open:wip-child"
+
+reconcile_completed_parent_tasks >/dev/null 2>&1
+
+if grep -q "issue close 600" "$GH_CALLS"; then
+	print_result "partial-open: does NOT close parent with an OPEN child" 1 \
+		"(unexpected close: $(tr '\n' '|' <"$GH_CALLS" | head -c 400))"
+else
+	print_result "partial-open: does NOT close parent with an OPEN child" 0
+fi
+
+# -----------------------------------------------------------------------------
+# Scenario 4: graph has only 1 child (below min-2 threshold).
+# MUST NOT close, even if it's closed — single-reference guard.
+# -----------------------------------------------------------------------------
+reset_scenario
+set_parent_list 700 "t700: single-ref" "Only references #701."
+set_subissues "701:CLOSED"
+set_child_states "701:closed:lone-child"
+
+reconcile_completed_parent_tasks >/dev/null 2>&1
+
+if grep -q "issue close 700" "$GH_CALLS"; then
+	print_result "single-child guard: does NOT close parent with 1 subissue" 1 \
+		"(unexpected close: $(tr '\n' '|' <"$GH_CALLS" | head -c 400))"
+else
+	print_result "single-child guard: does NOT close parent with 1 subissue" 0
+fi
+
+# -----------------------------------------------------------------------------
+# Scenario 5: graph empty AND body has no refs. MUST skip silently.
+# -----------------------------------------------------------------------------
+reset_scenario
+set_parent_list 800 "t800: orphan" "No child references at all."
+printf '[]\n' >"${TEST_ROOT}/gh-subissues.json"
+
+reconcile_completed_parent_tasks >/dev/null 2>&1
+
+if grep -q "issue close 800" "$GH_CALLS"; then
+	print_result "no-refs: does NOT close parent with zero children anywhere" 1 \
+		"(unexpected close: $(tr '\n' '|' <"$GH_CALLS" | head -c 400))"
+else
+	print_result "no-refs: does NOT close parent with zero children anywhere" 0
+fi
+
+# -----------------------------------------------------------------------------
+# Scenario 6: GraphQL query is always attempted (precedence).
+# Even when body has #NNN, the helper should try the graph first.
+# -----------------------------------------------------------------------------
+reset_scenario
+set_parent_list 900 "t900: both" "Has graph and #901 #902 in body."
+set_subissues "901:CLOSED" "902:CLOSED"
+set_child_states "901:closed:a" "902:closed:b"
+
+reconcile_completed_parent_tasks >/dev/null 2>&1
+
+if grep -q "api graphql" "$GH_CALLS"; then
+	print_result "graph query is always attempted first" 0
+else
+	print_result "graph query is always attempted first" 1 \
+		"(expected 'api graphql' invocation; calls: $(tr '\n' '|' <"$GH_CALLS" | head -c 400))"
+fi
+
+# -----------------------------------------------------------------------------
+# Summary
+# -----------------------------------------------------------------------------
+echo
+if [[ "$TESTS_FAILED" -eq 0 ]]; then
+	printf '%sAll %d tests passed%s\n' "$TEST_GREEN" "$TESTS_RUN" "$TEST_RESET"
+	exit 0
+else
+	printf '%s%d / %d tests failed%s\n' "$TEST_RED" "$TESTS_FAILED" "$TESTS_RUN" "$TEST_RESET"
+	exit 1
+fi

--- a/todo/tasks/t2138-brief.md
+++ b/todo/tasks/t2138-brief.md
@@ -1,0 +1,147 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# t2138 — fix(pulse): `reconcile_completed_parent_tasks` consults sub-issue graph before body regex
+
+## Session Origin
+
+Interactive session, 2026-04-16. Surfaced while inspecting parent issue
+#19222 (t2126). Parent body is narrative prose with no `#NNN` references;
+its 5 children (#19223-#19227) are all CLOSED and are wired via GitHub's
+GraphQL `subIssues` relationship (per PR #19228's own body: "All 5 children
+are wired as sub-issues of the parent via the GitHub GraphQL API"). The
+reconciler (`pulse-issue-reconcile.sh:reconcile_completed_parent_tasks`,
+shipped in PR #19211) relies on body regex `grep -oE '#[0-9]+'` — which
+finds nothing — so the parent stays open forever.
+
+## What
+
+Upgrade `reconcile_completed_parent_tasks` to prefer GitHub's native
+sub-issue graph. When the graph has children, use that as the authoritative
+source. Fall back to body-regex only when the graph returns empty (legacy
+parents that pre-date sub-issue wiring).
+
+## Why
+
+- **Correctness**: sub-issue graph is the canonical parent-child
+  relationship on GitHub; body regex is a heuristic. When they disagree,
+  the graph wins.
+- **Adoption alignment**: since PR #19098 (t2114), the framework actively
+  backfills sub-issue graph edges via `issue-sync-helper.sh
+  backfill-sub-issues`. Most new parent-tasks use the graph. The reconciler
+  must catch up.
+- **Zero regression for legacy**: body-regex path is preserved as a
+  fallback, so any parent that lists children only inline still closes on
+  cycle.
+- **Closes #19222 and any future parent in the same shape** — no
+  per-parent manual body edits required.
+
+## How
+
+### Files to modify
+
+- **EDIT:** `.agents/scripts/pulse-issue-reconcile.sh`
+  - Function `reconcile_completed_parent_tasks` (~line 964-1057).
+  - Add a helper `_fetch_subissue_numbers "$slug" "$issue_num"` that runs
+    one `gh api graphql` query against the `subIssues` field and emits
+    newline-separated issue numbers. Returns empty string on failure, on
+    missing feature, or on an empty graph.
+  - In the main loop, try the graph first; if non-empty, use those numbers
+    as `child_nums`. Otherwise use the existing body-regex path.
+  - Preserve all existing safeguards: min 2 children, max 5 closes per
+    cycle, skip unknown states, skip parents labelled with rejection
+    labels.
+
+- **EDIT:** `.agents/scripts/tests/test-pulse-reconcile-parent-task-close.sh`
+  (create if absent; if present extend).
+  - Mock `gh api graphql` responses for the `subIssues` query; assert
+    graph-path close.
+  - Mock an empty-graph response + body with `#NNN`; assert fallback-path
+    close.
+  - Mock a graph with one open child; assert no-close.
+  - Mock a graph with <2 children; assert no-close (single-ref guard).
+
+### Reference patterns
+
+- **Existing GraphQL in the file**: `shared-constants.sh:1092` uses
+  `gh api graphql -f query='mutation...addSubIssue...'` — the same
+  invocation style applies for the `query` direction.
+- **Existing reconciler structure**: `pulse-issue-reconcile.sh:964-1057`
+  — body-regex path stays intact as the fallback; only the "collect child
+  numbers" stage gets an earlier attempt.
+- **Existing test idiom**: `tests/test-label-invariants.sh` Part 3 mocks
+  `gh` via `STUB_DIR/gh` and asserts on call log — same pattern applies.
+
+### GraphQL query shape
+
+```graphql
+query($owner: String!, $name: String!, $number: Int!) {
+  repository(owner: $owner, name: $name) {
+    issue(number: $number) {
+      subIssues(first: 50) {
+        nodes { number state }
+      }
+    }
+  }
+}
+```
+
+Note the `subIssues` field is GA on all GitHub tiers where AI DevOps repos
+live; it returns an empty list (not an error) when the feature is unused on
+an issue. Error handling:
+- Non-zero exit → empty list → fall back to body regex.
+- Rate limit / network → empty list → fall back (safe degrade).
+- Feature-not-enabled (enterprise quirk) → empty list → fall back.
+
+### Verification
+
+- **Unit tests**: new `tests/test-pulse-reconcile-parent-task-close.sh` run
+  under `bash` with a stubbed `gh`. Cover: graph-path close, fallback-path
+  close, graph-partial-open no-close, graph-single-child no-close.
+- **Static checks**: `shellcheck` on the modified helper and new test.
+- **Manual integration**: on the actual #19222 after merge, watch the
+  pulse log for `Reconcile parent-task: closed #19222`. If not auto-closed
+  by next cycle, fall back to manual close citing the new logic (smoke
+  test still validates).
+
+## Acceptance criteria
+
+- [ ] `reconcile_completed_parent_tasks` queries the sub-issue graph
+  before body regex.
+- [ ] When graph returns ≥2 children and all are closed, the parent is
+  closed with the existing summary-comment format.
+- [ ] When graph returns empty, legacy body-regex path runs unchanged.
+- [ ] No regression on existing safeguards (min 2 children, max 5/cycle,
+  rejection-label skip, unknown-state skip).
+- [ ] New test file asserts all four scenarios and passes.
+- [ ] `shellcheck` clean on modified files.
+- [ ] #19222 closes on the next pulse cycle post-merge (primary
+  integration signal).
+
+## Context
+
+- **Reconciler shipped**: PR #19211 (`ff80f9523`).
+- **Sub-issue infra**: PR #19098 (t2112+t2113+t2114) — `addSubIssue`
+  mutation + backfill helper + CI wrapper guard.
+- **Primary motivating case**: #19222 — 5 closed children via sub-issue
+  graph, 0 `#NNN` references in body, reconciler can't close it.
+- **GraphQL surface**: used elsewhere in `shared-constants.sh` and
+  `issue-sync-helper.sh` — no new dependency.
+
+## CI/CD consequence audit
+
+| Aim | Current | After fix | Risk |
+|---|---|---|---|
+| Close parent-tasks with all children closed | Only if body has `#NNN` | Any parent with ≥2 closed sub-issues OR ≥2 closed `#NNN` body refs | None — strictly more permissive, both signals still require ALL-closed |
+| Min 2 children safeguard | Enforced | Enforced on whichever source wins | None |
+| Max 5 closes per cycle | Enforced | Enforced | None |
+| Rejection-label skip | Enforced (implicit via body-regex `continue`) | Explicit parity in the graph path | None |
+| GraphQL rate-limits | N/A | Adds 1 query per open parent-task per cycle | Low — parent-task count is bounded (<20 typical); fall-back is safe |
+| Errors on GraphQL failure | N/A | Silent fallback to body regex | None — matches existing error-tolerance pattern |
+| Test coverage | None for this function | New unit test covers 4 scenarios | Improvement |
+
+## Tier checklist
+
+- [x] `tier:standard` — bug-fix with non-trivial logic branch, ~50 LOC
+  in helper + ~80 LOC test + 2 files
+- [x] Estimate ~45min including tests and verification


### PR DESCRIPTION
## Summary

Upgrades reconcile_completed_parent_tasks to prefer GitHub's native GraphQL subIssues relationship over body-regex detection. New helper _fetch_subissue_numbers queries subIssues(first:50); if non-empty, those numbers become child_nums (authoritative). If empty or the query fails, falls back to the existing #NNN body regex (legacy path intact).

Motivating case: #19222 (t2126) has 5 CLOSED children wired only via the sub-issue graph and zero #NNN in body — the reconciler ignored it indefinitely. Now it closes on the next pulse cycle. Any future parent wired the same way (per t2114 backfill-sub-issues) is auto-tracked.

All existing safeguards preserved: min 2 children, max 5 closes per cycle, skip rejection-labelled issues, skip unknown-state refs. Log line now tags source=graph|body for traceability.

## Files Changed

.agents/scripts/pulse-issue-reconcile.sh,.agents/scripts/tests/test-pulse-reconcile-parent-task-subissue-graph.sh,todo/tasks/t2138-brief.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** - bash .agents/scripts/tests/test-pulse-reconcile-parent-task-subissue-graph.sh: 8/8 pass (6 scenarios covering graph-close, body-fallback close, partial-open, single-child, no-refs, graph-precedence)
- bash .agents/scripts/tests/test-label-invariants.sh: 26/26 still green (no regression)
- shellcheck on pulse-issue-reconcile.sh and the new test: clean
- GraphQL query shape verified against live #19222 — returns 5 CLOSED nodes

Resolves #19249


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.55 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-opus-4-6 spent 52m and 90,240 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for sub-issue relationship detection scenarios.

* **Chores**
  * Improved sub-issue detection logic with prioritized data source handling and enhanced logging for better diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->