### PR TITLE
GH#19256: fix: propagate helper failures in _generate_seo_commands wrapper

### DIFF
--- a/.agents/scripts/generate-claude-commands.sh
+++ b/.agents/scripts/generate-claude-commands.sh
@@ -685,8 +685,8 @@ Return a completed KPI baseline scorecard plus top remediation priorities and re
 # helper under the 100-line shell complexity threshold (GH#19198 / t2125).
 # -----------------------------------------------------------------------------
 _generate_seo_commands() {
-	_generate_seo_keyword_commands
-	_generate_seo_ai_commands
+	_generate_seo_keyword_commands || return 1
+	_generate_seo_ai_commands || return 1
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Added `|| return 1` to both helper calls in `_generate_seo_commands()` so non-zero exits from `_generate_seo_keyword_commands` and `_generate_seo_ai_commands` are no longer silently masked by the wrapper's unconditional `return 0`.

## Files Changed

.agents/scripts/generate-claude-commands.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** ShellCheck passes (only pre-existing SC1091 info on source path). Verified the wrapper at generate-claude-commands.sh:687-691 now propagates helper failures correctly.

Resolves #19256


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.56 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-sonnet-4-6 spent 1m and 2,520 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error handling in command generation scripts to ensure failures are properly reported instead of being silently ignored, enhancing system reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->