### PR TITLE
GH#19257: propagate failures in _generate_seo_commands wrapper

### DIFF
--- a/.agents/scripts/generate-claude-commands.sh
+++ b/.agents/scripts/generate-claude-commands.sh
@@ -685,8 +685,8 @@ Return a completed KPI baseline scorecard plus top remediation priorities and re
 # helper under the 100-line shell complexity threshold (GH#19198 / t2125).
 # -----------------------------------------------------------------------------
 _generate_seo_commands() {
-	_generate_seo_keyword_commands
-	_generate_seo_ai_commands
+	_generate_seo_keyword_commands || return 1
+	_generate_seo_ai_commands || return 1
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Add `|| return 1` to the two sub-function calls in `_generate_seo_commands()` so that failures from `_generate_seo_keyword_commands` or `_generate_seo_ai_commands` are not silently masked by the unconditional `return 0`.

## What changed

**EDIT: `.agents/scripts/generate-claude-commands.sh:687-691`**

```diff
 _generate_seo_commands() {
-	_generate_seo_keyword_commands
-	_generate_seo_ai_commands
+	_generate_seo_keyword_commands || return 1
+	_generate_seo_ai_commands || return 1
 	return 0
 }
```

## Why

CodeRabbit flagged the wrapper in PR #19199 — the callers of `_generate_seo_commands` have no way to detect a failure in either helper when both calls are unchained. Explicit `|| return 1` chains are the standard shell pattern and match the rest of the codebase.

## Verification

- `shellcheck` passes (only pre-existing SC1091 info notice for sourced file)
- Change is a 2-line pattern-match fix; no logic changes

Resolves #19257