### PR TITLE
GH#19258: fix: address review bot suggestions from PR #19188 — SKIP color and unused TEST_YELLOW

### DIFF
--- a/.agents/scripts/tests/test-circuit-breaker.sh
+++ b/.agents/scripts/tests/test-circuit-breaker.sh
@@ -446,7 +446,7 @@ main() {
 
 	# Prerequisite check
 	if ! command -v jq &>/dev/null; then
-		echo -e "${TEST_RED}SKIP${RESET} jq not found — required for circuit breaker"
+		echo -e "${TEST_YELLOW}SKIP${RESET} jq not found — required for circuit breaker"
 		exit 1
 	fi
 

--- a/.agents/scripts/tests/test-command-logger.sh
+++ b/.agents/scripts/tests/test-command-logger.sh
@@ -18,7 +18,6 @@ HELPER="${SCRIPT_DIR}/../command-logger-helper.sh"
 # Colors
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
-readonly TEST_YELLOW='\033[1;33m'
 readonly RESET='\033[0m'
 
 # Test counters

--- a/.agents/scripts/tests/test-matterbridge-helper.sh
+++ b/.agents/scripts/tests/test-matterbridge-helper.sh
@@ -18,7 +18,6 @@ HELPER="${SCRIPT_DIR}/../matterbridge-helper.sh"
 # Colors
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
-readonly TEST_YELLOW='\033[1;33m'
 readonly RESET='\033[0m'
 
 # Test counters


### PR DESCRIPTION
## Summary

Fixed 3 review bot findings from PR #19188: (1) test-circuit-breaker.sh:449 — SKIP prerequisite message now uses TEST_YELLOW instead of TEST_RED for semantic correctness; (2) test-command-logger.sh:21 — removed unused TEST_YELLOW variable; (3) test-matterbridge-helper.sh:21 — removed unused TEST_YELLOW variable.

## Files Changed

.agents/scripts/tests/test-circuit-breaker.sh,.agents/scripts/tests/test-command-logger.sh,.agents/scripts/tests/test-matterbridge-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck passes on all 3 modified files with zero violations

Resolves #19258


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.56 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-sonnet-4-6 spent 2m and 5,825 tokens on this as a headless worker.