### PR TITLE
GH#19260: fix: make shared-constants.sh sourcing mandatory in agent-sources-helper, coderabbit-cli, sonarcloud-autofix

### DIFF
--- a/.agents/scripts/agent-sources-helper.sh
+++ b/.agents/scripts/agent-sources-helper.sh
@@ -17,9 +17,9 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 # shellcheck source=shared-constants.sh
-[[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
+source "${SCRIPT_DIR}/shared-constants.sh"
 
 AGENTS_DIR="${HOME}/.aidevops/agents"
 CUSTOM_DIR="${AGENTS_DIR}/custom"

--- a/.agents/scripts/coderabbit-cli.sh
+++ b/.agents/scripts/coderabbit-cli.sh
@@ -31,7 +31,7 @@ set -euo pipefail
 # Source shared constants (provides sed_inplace, canonical colors, and other utilities)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 # shellcheck source=shared-constants.sh
-[[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
+source "${SCRIPT_DIR}/shared-constants.sh"
 
 # Common constants (ERROR_UNKNOWN_COMMAND is provided by shared-constants.sh)
 # Configuration constants (guarded against re-sourcing)

--- a/.agents/scripts/sonarcloud-autofix.sh
+++ b/.agents/scripts/sonarcloud-autofix.sh
@@ -11,29 +11,34 @@ set -euo pipefail
 # Source shared constants (provides sed_inplace, canonical colors, and other utilities)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 # shellcheck source=shared-constants.sh
-[[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
+source "${SCRIPT_DIR}/shared-constants.sh"
 
-print_header() { local msg="$1"; echo -e "${PURPLE}$msg${NC}"; return 0; }
+print_header() {
+	local msg="$1"
+	echo -e "${PURPLE}$msg${NC}"
+	return 0
+}
 
 # Fix missing return statements (S7682)
 fix_missing_returns() {
-    local file="$1"
-    print_info "Adding missing return statements to: $file"
-    
-    # Add return statements to functions that don't have them
-    # This is a simplified approach - in practice, you'd need more sophisticated parsing
-    
-    # Backup original file
-    cp "$file" "$file.backup"
-    
-    # Add return statements before closing braces of functions
-    # This is a basic implementation - would need more sophisticated logic for production
-    local temp_file
-    temp_file=$(mktemp)
-    _save_cleanup_scope; trap '_run_cleanups' RETURN
-    push_cleanup "rm -f '${temp_file}'"
-    
-    awk '
+	local file="$1"
+	print_info "Adding missing return statements to: $file"
+
+	# Add return statements to functions that don't have them
+	# This is a simplified approach - in practice, you'd need more sophisticated parsing
+
+	# Backup original file
+	cp "$file" "$file.backup"
+
+	# Add return statements before closing braces of functions
+	# This is a basic implementation - would need more sophisticated logic for production
+	local temp_file
+	temp_file=$(mktemp)
+	_save_cleanup_scope
+	trap '_run_cleanups' RETURN
+	push_cleanup "rm -f '${temp_file}'"
+
+	awk '
     /^[a-zA-Z_][a-zA-Z0-9_]*\(\)/ { in_function = 1 }
     /^}$/ && in_function { 
         print "    return 0"
@@ -43,40 +48,40 @@ fix_missing_returns() {
     return 0
     }
     { print }
-    ' "$file" > "$temp_file" && mv "$temp_file" "$file"
-    print_success "Added return statements to $file"
-    return 0
+    ' "$file" >"$temp_file" && mv "$temp_file" "$file"
+	print_success "Added return statements to $file"
+	return 0
 }
 
 # Fix positional parameter assignments (S7679)
 fix_positional_parameters() {
-    local file="$1"
-    print_info "Fixing positional parameter assignments in: $file"
-    
-    # Backup original file
-    cp "$file" "$file.backup"
-    
-    # Replace direct $1, $_arg2, etc. usage with local variable assignments
-    sed_inplace '
+	local file="$1"
+	print_info "Fixing positional parameter assignments in: $file"
+
+	# Backup original file
+	cp "$file" "$file.backup"
+
+	# Replace direct $1, $_arg2, etc. usage with local variable assignments
+	sed_inplace '
         s/echo "\$1"/local param1="$1"; echo "$param1"/g
         s/echo "\$_arg2"/local param2="$_arg2"; echo "$param2"/g
         s/case "\$1"/local command="$1"; case "$command"/g
         s/\[\[ "\$1"/local arg1="$1"; [[ "$arg1"/g
     ' "$file"
-    print_success "Fixed positional parameters in $file"
-    return 0
+	print_success "Fixed positional parameters in $file"
+	return 0
 }
 
 # Add default case to switch statements (S131)
 fix_missing_default_case() {
-    local file="$1"
-    print_info "Adding default cases to switch statements in: $file"
-    
-    # Backup original file
-    cp "$file" "$file.backup"
-    
-    # Add default case before esac if missing
-    sed_inplace '
+	local file="$1"
+	print_info "Adding default cases to switch statements in: $file"
+
+	# Backup original file
+	cp "$file" "$file.backup"
+
+	# Add default case before esac if missing
+	sed_inplace '
         /esac/ {
             i\
         *)\
@@ -85,100 +90,100 @@ fix_missing_default_case() {
             ;;
         }
     ' "$file"
-    print_success "Added default cases to $file"
-    return 0
+	print_success "Added default cases to $file"
+	return 0
 }
 
 # Apply all SonarCloud fixes to a file
 apply_sonarcloud_fixes() {
-    local file="$1"
-    
-    if [[ ! -f "$file" ]]; then
-        print_error "File not found: $file"
-        return 1
-    fi
-    
-    print_header "Applying SonarCloud fixes to: $file"
-    
-    # Apply fixes based on common SonarCloud issues
-    fix_positional_parameters "$file"
-    fix_missing_returns "$file"
-    
-    # Check if file has switch statements and fix them
-    if grep -q "case.*in" "$file"; then
-        fix_missing_default_case "$file"
-    fi
-    
-    print_success "All SonarCloud fixes applied to $file"
-    return 0
+	local file="$1"
+
+	if [[ ! -f "$file" ]]; then
+		print_error "File not found: $file"
+		return 1
+	fi
+
+	print_header "Applying SonarCloud fixes to: $file"
+
+	# Apply fixes based on common SonarCloud issues
+	fix_positional_parameters "$file"
+	fix_missing_returns "$file"
+
+	# Check if file has switch statements and fix them
+	if grep -q "case.*in" "$file"; then
+		fix_missing_default_case "$file"
+	fi
+
+	print_success "All SonarCloud fixes applied to $file"
+	return 0
 }
 
 # Main function
 main() {
-    print_header "SonarCloud Auto-Fix Tool"
-    
-    case "${1:-help}" in
-        "fix")
-            if [[ -z "${2:-}" ]]; then
-                print_error "Please specify a file to fix"
-                print_info "Usage: $0 fix <file>"
-                exit 1
-            fi
-            apply_sonarcloud_fixes "$_arg2"
-            ;;
-        "fix-all")
-            print_info "Applying fixes to all shell scripts with SonarCloud issues..."
-            
-            # Files with known SonarCloud issues
-            local files=(
-                ".agents/scripts/setup-mcp-integrations.sh"
-                ".agents/scripts/validate-mcp-integrations.sh"
-                ".agents/scripts/setup-linters-wizard.sh"
-                ".agents/scripts/setup-wizard-helper.sh"
-            )
-            
-            for file in "${files[@]}"; do
-                if [[ -f "$file" ]]; then
-                    apply_sonarcloud_fixes "$file"
-                    echo
-                else
-                    print_warning "File not found: $file"
-                fi
-            done
-            ;;
-        "restore")
-            if [[ -z "${2:-}" ]]; then
-                print_error "Please specify a file to restore"
-                print_info "Usage: $0 restore <file>"
-                exit 1
-            fi
-            
-            local file="$2"
-            if [[ -f "$file.backup" ]]; then
-                mv "$file.backup" "$file"
-                print_success "Restored $file from backup"
-            else
-                print_error "No backup found for $file"
-                exit 1
-            fi
-            ;;
-        "help"|*)
-            print_header "SonarCloud Auto-Fix Usage"
-            echo "Usage: $0 [command] [file]"
-            echo ""
-            echo "Commands:"
-            echo "  fix <file>    - Apply SonarCloud fixes to specific file"
-            echo "  fix-all       - Apply fixes to all known problematic files"
-            echo "  restore <file> - Restore file from backup"
-            echo "  help          - Show this help"
-            echo ""
-            echo "Common SonarCloud Issues Fixed:"
-            echo "  S7682 - Missing return statements in functions"
-            echo "  S7679 - Direct positional parameter usage"
-            echo "  S131  - Missing default case in switch statements"
-            ;;
-    esac
-    return 0
+	print_header "SonarCloud Auto-Fix Tool"
+
+	case "${1:-help}" in
+	"fix")
+		if [[ -z "${2:-}" ]]; then
+			print_error "Please specify a file to fix"
+			print_info "Usage: $0 fix <file>"
+			exit 1
+		fi
+		apply_sonarcloud_fixes "$_arg2"
+		;;
+	"fix-all")
+		print_info "Applying fixes to all shell scripts with SonarCloud issues..."
+
+		# Files with known SonarCloud issues
+		local files=(
+			".agents/scripts/setup-mcp-integrations.sh"
+			".agents/scripts/validate-mcp-integrations.sh"
+			".agents/scripts/setup-linters-wizard.sh"
+			".agents/scripts/setup-wizard-helper.sh"
+		)
+
+		for file in "${files[@]}"; do
+			if [[ -f "$file" ]]; then
+				apply_sonarcloud_fixes "$file"
+				echo
+			else
+				print_warning "File not found: $file"
+			fi
+		done
+		;;
+	"restore")
+		if [[ -z "${2:-}" ]]; then
+			print_error "Please specify a file to restore"
+			print_info "Usage: $0 restore <file>"
+			exit 1
+		fi
+
+		local file="$2"
+		if [[ -f "$file.backup" ]]; then
+			mv "$file.backup" "$file"
+			print_success "Restored $file from backup"
+		else
+			print_error "No backup found for $file"
+			exit 1
+		fi
+		;;
+	"help" | *)
+		print_header "SonarCloud Auto-Fix Usage"
+		echo "Usage: $0 [command] [file]"
+		echo ""
+		echo "Commands:"
+		echo "  fix <file>    - Apply SonarCloud fixes to specific file"
+		echo "  fix-all       - Apply fixes to all known problematic files"
+		echo "  restore <file> - Restore file from backup"
+		echo "  help          - Show this help"
+		echo ""
+		echo "Common SonarCloud Issues Fixed:"
+		echo "  S7682 - Missing return statements in functions"
+		echo "  S7679 - Direct positional parameter usage"
+		echo "  S131  - Missing default case in switch statements"
+		;;
+	esac
+	return 0
 }
 
 main "$@"


### PR DESCRIPTION
## Summary

Made sourcing of shared-constants.sh mandatory in three scripts (agent-sources-helper.sh, coderabbit-cli.sh, sonarcloud-autofix.sh). Added || exit to SCRIPT_DIR assignment in agent-sources-helper.sh for consistency. Replaced optional [[ -f ... ]] && source guards with direct source calls to fail fast and clearly if shared-constants.sh is missing rather than producing cryptic unbound variable errors later.

## Files Changed

.agents/scripts/agent-sources-helper.sh,.agents/scripts/coderabbit-cli.sh,.agents/scripts/sonarcloud-autofix.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck on all three files passes with zero errors (SC1091 info notice expected, suppressed by shellcheck source directives)

Resolves #19260


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.56 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-sonnet-4-6 spent 3m and 9,122 tokens on this as a headless worker.