### PR TITLE
GH#19261: fix: make shared-constants.sh source mandatory in agent-sources, coderabbit, sonarcloud helpers

### DIFF
--- a/.agents/scripts/agent-sources-helper.sh
+++ b/.agents/scripts/agent-sources-helper.sh
@@ -17,9 +17,9 @@
 
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 # shellcheck source=shared-constants.sh
-[[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
+source "${SCRIPT_DIR}/shared-constants.sh"
 
 AGENTS_DIR="${HOME}/.aidevops/agents"
 CUSTOM_DIR="${AGENTS_DIR}/custom"

--- a/.agents/scripts/coderabbit-cli.sh
+++ b/.agents/scripts/coderabbit-cli.sh
@@ -31,7 +31,7 @@ set -euo pipefail
 # Source shared constants (provides sed_inplace, canonical colors, and other utilities)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 # shellcheck source=shared-constants.sh
-[[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
+source "${SCRIPT_DIR}/shared-constants.sh"
 
 # Common constants (ERROR_UNKNOWN_COMMAND is provided by shared-constants.sh)
 # Configuration constants (guarded against re-sourcing)

--- a/.agents/scripts/sonarcloud-autofix.sh
+++ b/.agents/scripts/sonarcloud-autofix.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 # Source shared constants (provides sed_inplace, canonical colors, and other utilities)
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 # shellcheck source=shared-constants.sh
-[[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
+source "${SCRIPT_DIR}/shared-constants.sh"
 
 print_header() { local msg="$1"; echo -e "${PURPLE}$msg${NC}"; return 0; }
 


### PR DESCRIPTION
## Summary

Address gemini-code-assist review suggestions from PR #19187 on three shell scripts.

**Changes:**

- `agent-sources-helper.sh`: Add `|| exit` to `SCRIPT_DIR` assignment (consistency with other scripts) + replace optional `[[ -f ]] && source` with mandatory `source`
- `coderabbit-cli.sh`: Replace optional `[[ -f ]] && source` with mandatory `source`
- `sonarcloud-autofix.sh`: Replace optional `[[ -f ]] && source` with mandatory `source`

**Rationale:** All three scripts use color variables (`BLUE`, `GREEN`, `NC`, `PURPLE`, etc.) from `shared-constants.sh` under `set -u`. The optional guard `[[ -f ]] && source` silently skips the source if the file is missing, causing a cryptic `unbound variable` crash later. Mandatory `source` gives a clear `No such file` error at the source line, which is easier to diagnose and aligns with the framework rule that helpers MUST source `shared-constants.sh`.

Resolves #19261

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.56 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-sonnet-4-6 spent 2m and 8,645 tokens on this as a headless worker.