### PR TITLE
GH#19263: fix(deploy): use pgrep/pkill for robust pulse restart instead of PID file

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -393,7 +393,7 @@ Git is the audit trail. Procedures: AGENTS.md "Git Workflow" section.
 
 **Pulse restart after deploying pulse script fixes (MANDATORY):**
 - Bash processes load `source` files at startup only. Deploying updated `.sh` files to `~/.aidevops/agents/scripts/` does NOT affect a running pulse — it keeps using the old code in memory. This caused a multi-hour outage where v3.8.41 fixes were deployed but the pulse kept blocking issues with stale logic.
-- After deploying fixes to any sourced pulse script (`pulse-*.sh`, `dispatch-dedup-*.sh`, `headless-runtime-*.sh`, `worker-lifecycle-common.sh`, `pulse-nmr-approval.sh`), restart the pulse: `kill $(grep -oE '[0-9]+' ~/.aidevops/logs/pulse.pid | head -1) 2>/dev/null; sleep 3; nohup ~/.aidevops/agents/scripts/pulse-wrapper.sh >> ~/.aidevops/logs/pulse-wrapper.log 2>&1 &`
+- After deploying fixes to any sourced pulse script (`pulse-*.sh`, `dispatch-dedup-*.sh`, `headless-runtime-*.sh`, `worker-lifecycle-common.sh`, `pulse-nmr-approval.sh`), restart the pulse: `pkill -f pulse-wrapper.sh || true; sleep 3; nohup ~/.aidevops/agents/scripts/pulse-wrapper.sh >> ~/.aidevops/logs/pulse-wrapper.log 2>&1 &`
 - `setup.sh` and `aidevops update` handle this automatically via `_restart_pulse_if_running`. Interactive sessions deploying hotfixes via `cp` must restart manually.
 
 # Quality Standards

--- a/setup-modules/agent-deploy.sh
+++ b/setup-modules/agent-deploy.sh
@@ -19,24 +19,19 @@ IFS=$'\n\t'
 # auto-restart mechanism exists, we start it manually.
 #######################################
 _restart_pulse_if_running() {
-	local pid_file="${HOME}/.aidevops/logs/pulse.pid"
-	[[ -f "$pid_file" ]] || return 0
-
-	local pulse_pid=""
-	pulse_pid=$(grep -oE '[0-9]+' "$pid_file" | head -1) || return 0
-	[[ -n "$pulse_pid" ]] || return 0
-
-	# Check if the process is actually alive
-	if ! kill -0 "$pulse_pid" 2>/dev/null; then
+	if ! pgrep -f pulse-wrapper.sh >/dev/null; then
+		# Not running, nothing to do
 		return 0
 	fi
 
-	print_info "Restarting pulse (PID $pulse_pid) to load updated scripts..."
-	kill "$pulse_pid" 2>/dev/null || true
+	local old_pid
+	old_pid=$(pgrep -f pulse-wrapper.sh | head -1)
+	print_info "Restarting pulse (PID $old_pid) to load updated scripts..."
+	pkill -f pulse-wrapper.sh || true
 
 	# Wait for it to die
 	local wait_count=0
-	while kill -0 "$pulse_pid" 2>/dev/null && [[ "$wait_count" -lt 10 ]]; do
+	while pgrep -f pulse-wrapper.sh >/dev/null && [[ "$wait_count" -lt 10 ]]; do
 		sleep 1
 		wait_count=$((wait_count + 1))
 	done
@@ -45,13 +40,11 @@ _restart_pulse_if_running() {
 	sleep 5
 
 	# Check if it auto-restarted
-	if [[ -f "$pid_file" ]]; then
-		local new_pid=""
-		new_pid=$(grep -oE '[0-9]+' "$pid_file" | head -1) || new_pid=""
-		if [[ -n "$new_pid" ]] && kill -0 "$new_pid" 2>/dev/null; then
-			print_success "Pulse restarted (new PID $new_pid)"
-			return 0
-		fi
+	if pgrep -f pulse-wrapper.sh >/dev/null; then
+		local new_pid
+		new_pid=$(pgrep -f pulse-wrapper.sh | head -1)
+		print_success "Pulse restarted (new PID $new_pid)"
+		return 0
 	fi
 
 	# No auto-restart — start it manually


### PR DESCRIPTION
## Summary

Replaced PID-file-based pulse restart in _restart_pulse_if_running with pgrep/pkill. Updated manual restart docs in build.txt to match.

## Files Changed

.agents/prompts/build.txt,setup-modules/agent-deploy.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck setup-modules/agent-deploy.sh passes with zero violations

Resolves #19263


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.56 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-sonnet-4-6 spent 1m and 5,769 tokens on this as a headless worker.