### PR TITLE
GH#19265: rename RESET to TEST_RESET in four test harnesses

### DIFF
--- a/.agents/scripts/tests/test-secret-helper.sh
+++ b/.agents/scripts/tests/test-secret-helper.sh
@@ -9,7 +9,7 @@ HELPER="${SCRIPT_DIR}/../secret-helper.sh"
 
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
-readonly RESET='\033[0m'
+readonly TEST_RESET='\033[0m'
 
 TESTS_RUN=0
 TESTS_PASSED=0
@@ -26,10 +26,10 @@ print_result() {
 	TESTS_RUN=$((TESTS_RUN + 1))
 
 	if [[ "$result" -eq 0 ]]; then
-		echo -e "${TEST_GREEN}PASS${RESET} $test_name"
+		echo -e "${TEST_GREEN}PASS${TEST_RESET} $test_name"
 		TESTS_PASSED=$((TESTS_PASSED + 1))
 	else
-		echo -e "${TEST_RED}FAIL${RESET} $test_name"
+		echo -e "${TEST_RED}FAIL${TEST_RESET} $test_name"
 		if [[ -n "$message" ]]; then
 			echo "       $message"
 		fi

--- a/.agents/scripts/tests/test-simplex-integration.sh
+++ b/.agents/scripts/tests/test-simplex-integration.sh
@@ -24,7 +24,7 @@ readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
 readonly TEST_YELLOW='\033[1;33m'
 readonly TEST_CYAN='\033[0;36m'
-readonly RESET='\033[0m'
+readonly TEST_RESET='\033[0m'
 
 # Test counters
 TESTS_RUN=0
@@ -49,13 +49,13 @@ print_result() {
 	TESTS_RUN=$((TESTS_RUN + 1))
 
 	if [[ "$result" -eq 0 ]]; then
-		echo -e "${TEST_GREEN}PASS${RESET} $test_name"
+		echo -e "${TEST_GREEN}PASS${TEST_RESET} $test_name"
 		TESTS_PASSED=$((TESTS_PASSED + 1))
 	elif [[ "$result" -eq 2 ]]; then
-		echo -e "${TEST_YELLOW}SKIP${RESET} $test_name"
+		echo -e "${TEST_YELLOW}SKIP${TEST_RESET} $test_name"
 		TESTS_SKIPPED=$((TESTS_SKIPPED + 1))
 	else
-		echo -e "${TEST_RED}FAIL${RESET} $test_name"
+		echo -e "${TEST_RED}FAIL${TEST_RESET} $test_name"
 		if [[ -n "$message" ]]; then
 			echo "       $message"
 		fi
@@ -83,7 +83,7 @@ assert_contains() {
 
 section_file_existence() {
 	echo ""
-	echo -e "${TEST_CYAN}=== File Existence Tests ===${RESET}"
+	echo -e "${TEST_CYAN}=== File Existence Tests ===${TEST_RESET}"
 
 	# simplex.md subagent doc
 	if [[ -f "${AGENTS_DIR}/services/communications/simplex.md" ]]; then
@@ -153,7 +153,7 @@ section_file_existence() {
 
 section_helper_script() {
 	echo ""
-	echo -e "${TEST_CYAN}=== simplex-helper.sh Tests ===${RESET}"
+	echo -e "${TEST_CYAN}=== simplex-helper.sh Tests ===${TEST_RESET}"
 
 	if [[ ! -f "$HELPER" ]]; then
 		print_result "helper script available" 1 "simplex-helper.sh not found"
@@ -223,7 +223,7 @@ section_helper_script() {
 
 section_subagent_index() {
 	echo ""
-	echo -e "${TEST_CYAN}=== Subagent Index Tests ===${RESET}"
+	echo -e "${TEST_CYAN}=== Subagent Index Tests ===${TEST_RESET}"
 
 	local index_file="${AGENTS_DIR}/subagent-index.toon"
 
@@ -262,7 +262,7 @@ section_subagent_index() {
 
 section_agents_md() {
 	echo ""
-	echo -e "${TEST_CYAN}=== AGENTS.md Tests ===${RESET}"
+	echo -e "${TEST_CYAN}=== AGENTS.md Tests ===${TEST_RESET}"
 
 	local agents_file="${AGENTS_DIR}/AGENTS.md"
 
@@ -301,7 +301,7 @@ section_agents_md() {
 
 section_markdown_structure() {
 	echo ""
-	echo -e "${TEST_CYAN}=== Markdown Structure Tests ===${RESET}"
+	echo -e "${TEST_CYAN}=== Markdown Structure Tests ===${TEST_RESET}"
 
 	local simplex_md="${AGENTS_DIR}/services/communications/simplex.md"
 
@@ -374,7 +374,7 @@ section_markdown_structure() {
 
 section_bot_framework() {
 	echo ""
-	echo -e "${TEST_CYAN}=== Bot Framework Scaffold Tests ===${RESET}"
+	echo -e "${TEST_CYAN}=== Bot Framework Scaffold Tests ===${TEST_RESET}"
 
 	local bot_dir="${AGENTS_DIR}/scripts/simplex-bot"
 
@@ -467,7 +467,7 @@ section_bot_framework() {
 
 section_shellcheck() {
 	echo ""
-	echo -e "${TEST_CYAN}=== ShellCheck Tests ===${RESET}"
+	echo -e "${TEST_CYAN}=== ShellCheck Tests ===${TEST_RESET}"
 
 	if ! command -v shellcheck &>/dev/null; then
 		print_result "shellcheck available" 2 "shellcheck not installed"
@@ -526,7 +526,7 @@ main() {
 
 	echo ""
 	echo "============================================="
-	echo -e "Results: ${TEST_GREEN}${TESTS_PASSED} passed${RESET}, ${TEST_RED}${TESTS_FAILED} failed${RESET}, ${TEST_YELLOW}${TESTS_SKIPPED} skipped${RESET} (${TESTS_RUN} total)"
+	echo -e "Results: ${TEST_GREEN}${TESTS_PASSED} passed${TEST_RESET}, ${TEST_RED}${TESTS_FAILED} failed${TEST_RESET}, ${TEST_YELLOW}${TESTS_SKIPPED} skipped${TEST_RESET} (${TESTS_RUN} total)"
 	echo "============================================="
 
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-stash-audit.sh
+++ b/.agents/scripts/tests/test-stash-audit.sh
@@ -21,7 +21,7 @@ STASH_HELPER="${SCRIPT_DIR}/../stash-audit-helper.sh"
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
 readonly TEST_YELLOW='\033[1;33m'
-readonly RESET='\033[0m'
+readonly TEST_RESET='\033[0m'
 
 # Test counters
 TESTS_RUN=0
@@ -38,24 +38,24 @@ TESTS_FAILED=0
 #   0 always
 #######################################
 print_result() {
-    local test_name="$1"
-    local result="$2"
-    local message="${3:-}"
-    
-    TESTS_RUN=$((TESTS_RUN + 1))
-    
-    if [[ "$result" -eq 0 ]]; then
-        echo -e "${TEST_GREEN}✓${RESET} $test_name"
-        TESTS_PASSED=$((TESTS_PASSED + 1))
-    else
-        echo -e "${TEST_RED}✗${RESET} $test_name"
-        if [[ -n "$message" ]]; then
-            echo "  $message"
-        fi
-        TESTS_FAILED=$((TESTS_FAILED + 1))
-    fi
-    
-    return 0
+	local test_name="$1"
+	local result="$2"
+	local message="${3:-}"
+
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$result" -eq 0 ]]; then
+		echo -e "${TEST_GREEN}✓${TEST_RESET} $test_name"
+		TESTS_PASSED=$((TESTS_PASSED + 1))
+	else
+		echo -e "${TEST_RED}✗${TEST_RESET} $test_name"
+		if [[ -n "$message" ]]; then
+			echo "  $message"
+		fi
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+
+	return 0
 }
 
 #######################################
@@ -68,22 +68,22 @@ print_result() {
 #   Test repo path
 #######################################
 setup_test_repo() {
-    local test_repo
-    test_repo=$(mktemp -d)
-    
-    cd "$test_repo" || return 1
-    
-    git init -q
-    git config user.email "test@example.com"
-    git config user.name "Test User"
-    
-    # Create initial commit
-    echo "initial" > file1.txt
-    git add file1.txt
-    git commit -q -m "Initial commit"
-    
-    echo "$test_repo"
-    return 0
+	local test_repo
+	test_repo=$(mktemp -d)
+
+	cd "$test_repo" || return 1
+
+	git init -q
+	git config user.email "test@example.com"
+	git config user.name "Test User"
+
+	# Create initial commit
+	echo "initial" >file1.txt
+	git add file1.txt
+	git commit -q -m "Initial commit"
+
+	echo "$test_repo"
+	return 0
 }
 
 #######################################
@@ -94,13 +94,13 @@ setup_test_repo() {
 #   0 always
 #######################################
 cleanup_test_repo() {
-    local test_repo="$1"
-    
-    if [[ -d "$test_repo" ]]; then
-        rm -rf "$test_repo"
-    fi
-    
-    return 0
+	local test_repo="$1"
+
+	if [[ -d "$test_repo" ]]; then
+		rm -rf "$test_repo"
+	fi
+
+	return 0
 }
 
 #######################################
@@ -111,32 +111,32 @@ cleanup_test_repo() {
 #   0 on success, 1 on failure
 #######################################
 test_safe_to_drop() {
-    local test_repo
-    test_repo=$(setup_test_repo)
-    
-    cd "$test_repo" || return 1
-    
-    # Make a change and stash it
-    echo "change1" > file1.txt
-    git stash push -q -m "Test stash 1"
-    
-    # Apply the same change to HEAD
-    echo "change1" > file1.txt
-    git add file1.txt
-    git commit -q -m "Apply change"
-    
-    # Audit should classify as safe-to-drop
-    local output
-    output=$("$STASH_HELPER" audit --repo "$test_repo" 2>&1)
-    
-    local result=1
-    if echo "$output" | grep -q "safe-to-drop"; then
-        result=0
-    fi
-    
-    cleanup_test_repo "$test_repo"
-    
-    return $result
+	local test_repo
+	test_repo=$(setup_test_repo)
+
+	cd "$test_repo" || return 1
+
+	# Make a change and stash it
+	echo "change1" >file1.txt
+	git stash push -q -m "Test stash 1"
+
+	# Apply the same change to HEAD
+	echo "change1" >file1.txt
+	git add file1.txt
+	git commit -q -m "Apply change"
+
+	# Audit should classify as safe-to-drop
+	local output
+	output=$("$STASH_HELPER" audit --repo "$test_repo" 2>&1)
+
+	local result=1
+	if echo "$output" | grep -q "safe-to-drop"; then
+		result=0
+	fi
+
+	cleanup_test_repo "$test_repo"
+
+	return $result
 }
 
 #######################################
@@ -147,32 +147,32 @@ test_safe_to_drop() {
 #   0 on success, 1 on failure
 #######################################
 test_needs_review() {
-    local test_repo
-    test_repo=$(setup_test_repo)
-    
-    cd "$test_repo" || return 1
-    
-    # Make a change and stash it
-    echo "unique change" > file1.txt
-    git stash push -q -m "Test stash with unique changes"
-    
-    # Make a different change to HEAD
-    echo "different change" > file1.txt
-    git add file1.txt
-    git commit -q -m "Different change"
-    
-    # Audit should classify as needs-review
-    local output
-    output=$("$STASH_HELPER" audit --repo "$test_repo" 2>&1)
-    
-    local result=1
-    if echo "$output" | grep -q "needs-review"; then
-        result=0
-    fi
-    
-    cleanup_test_repo "$test_repo"
-    
-    return $result
+	local test_repo
+	test_repo=$(setup_test_repo)
+
+	cd "$test_repo" || return 1
+
+	# Make a change and stash it
+	echo "unique change" >file1.txt
+	git stash push -q -m "Test stash with unique changes"
+
+	# Make a different change to HEAD
+	echo "different change" >file1.txt
+	git add file1.txt
+	git commit -q -m "Different change"
+
+	# Audit should classify as needs-review
+	local output
+	output=$("$STASH_HELPER" audit --repo "$test_repo" 2>&1)
+
+	local result=1
+	if echo "$output" | grep -q "needs-review"; then
+		result=0
+	fi
+
+	cleanup_test_repo "$test_repo"
+
+	return $result
 }
 
 #######################################
@@ -183,27 +183,27 @@ test_needs_review() {
 #   0 on success, 1 on failure
 #######################################
 test_list() {
-    local test_repo
-    test_repo=$(setup_test_repo)
-    
-    cd "$test_repo" || return 1
-    
-    # Create a stash
-    echo "change" > file1.txt
-    git stash push -q -m "Test stash"
-    
-    # List should show the stash
-    local output
-    output=$("$STASH_HELPER" list --repo "$test_repo" 2>&1)
-    
-    local result=1
-    if echo "$output" | grep -q "Test stash"; then
-        result=0
-    fi
-    
-    cleanup_test_repo "$test_repo"
-    
-    return $result
+	local test_repo
+	test_repo=$(setup_test_repo)
+
+	cd "$test_repo" || return 1
+
+	# Create a stash
+	echo "change" >file1.txt
+	git stash push -q -m "Test stash"
+
+	# List should show the stash
+	local output
+	output=$("$STASH_HELPER" list --repo "$test_repo" 2>&1)
+
+	local result=1
+	if echo "$output" | grep -q "Test stash"; then
+		result=0
+	fi
+
+	cleanup_test_repo "$test_repo"
+
+	return $result
 }
 
 #######################################
@@ -214,35 +214,35 @@ test_list() {
 #   0 on success, 1 on failure
 #######################################
 test_auto_clean() {
-    local test_repo
-    test_repo=$(setup_test_repo)
-    
-    cd "$test_repo" || return 1
-    
-    # Create a safe-to-drop stash
-    echo "change1" > file1.txt
-    git stash push -q -m "Safe stash"
-    
-    # Apply the same change to HEAD
-    echo "change1" > file1.txt
-    git add file1.txt
-    git commit -q -m "Apply change"
-    
-    # Auto-clean should drop the stash
-    "$STASH_HELPER" auto-clean --repo "$test_repo" >/dev/null 2>&1
-    
-    # Verify stash was dropped
-    local stash_count
-    stash_count=$(git stash list | wc -l)
-    
-    local result=1
-    if [[ "$stash_count" -eq 0 ]]; then
-        result=0
-    fi
-    
-    cleanup_test_repo "$test_repo"
-    
-    return $result
+	local test_repo
+	test_repo=$(setup_test_repo)
+
+	cd "$test_repo" || return 1
+
+	# Create a safe-to-drop stash
+	echo "change1" >file1.txt
+	git stash push -q -m "Safe stash"
+
+	# Apply the same change to HEAD
+	echo "change1" >file1.txt
+	git add file1.txt
+	git commit -q -m "Apply change"
+
+	# Auto-clean should drop the stash
+	"$STASH_HELPER" auto-clean --repo "$test_repo" >/dev/null 2>&1
+
+	# Verify stash was dropped
+	local stash_count
+	stash_count=$(git stash list | wc -l)
+
+	local result=1
+	if [[ "$stash_count" -eq 0 ]]; then
+		result=0
+	fi
+
+	cleanup_test_repo "$test_repo"
+
+	return $result
 }
 
 #######################################
@@ -253,23 +253,23 @@ test_auto_clean() {
 #   0 on success, 1 on failure
 #######################################
 test_no_stashes() {
-    local test_repo
-    test_repo=$(setup_test_repo)
-    
-    cd "$test_repo" || return 1
-    
-    # Audit with no stashes should succeed
-    local output
-    output=$("$STASH_HELPER" audit --repo "$test_repo" 2>&1)
-    
-    local result=1
-    if echo "$output" | grep -q "No stashes found"; then
-        result=0
-    fi
-    
-    cleanup_test_repo "$test_repo"
-    
-    return $result
+	local test_repo
+	test_repo=$(setup_test_repo)
+
+	cd "$test_repo" || return 1
+
+	# Audit with no stashes should succeed
+	local output
+	output=$("$STASH_HELPER" audit --repo "$test_repo" 2>&1)
+
+	local result=1
+	if echo "$output" | grep -q "No stashes found"; then
+		result=0
+	fi
+
+	cleanup_test_repo "$test_repo"
+
+	return $result
 }
 
 #######################################
@@ -280,15 +280,15 @@ test_no_stashes() {
 #   0 on success, 1 on failure
 #######################################
 test_help() {
-    local output
-    output=$("$STASH_HELPER" help 2>&1)
-    
-    local result=1
-    if echo "$output" | grep -q "Usage:"; then
-        result=0
-    fi
-    
-    return $result
+	local output
+	output=$("$STASH_HELPER" help 2>&1)
+
+	local result=1
+	if echo "$output" | grep -q "Usage:"; then
+		result=0
+	fi
+
+	return $result
 }
 
 #######################################
@@ -299,15 +299,15 @@ test_help() {
 #   0 on success, 1 on failure
 #######################################
 test_invalid_repo() {
-    local output
-    output=$("$STASH_HELPER" audit --repo /nonexistent/path 2>&1 || true)
-    
-    local result=1
-    if echo "$output" | grep -q "does not exist"; then
-        result=0
-    fi
-    
-    return $result
+	local output
+	output=$("$STASH_HELPER" audit --repo /nonexistent/path 2>&1 || true)
+
+	local result=1
+	if echo "$output" | grep -q "does not exist"; then
+		result=0
+	fi
+
+	return $result
 }
 
 #######################################
@@ -318,57 +318,57 @@ test_invalid_repo() {
 #   0 if all tests pass, 1 otherwise
 #######################################
 main() {
-    echo "Running stash-audit-helper.sh tests..."
-    echo ""
-    
-    # Check if stash helper exists
-    if [[ ! -f "$STASH_HELPER" ]]; then
-        echo -e "${TEST_RED}Error: stash-audit-helper.sh not found at $STASH_HELPER${RESET}"
-        return 1
-    fi
-    
-    # Run tests
-    test_safe_to_drop
-    print_result "safe-to-drop classification" $?
-    
-    test_needs_review
-    print_result "needs-review classification" $?
-    
-    test_list
-    print_result "list command" $?
-    
-    test_auto_clean
-    print_result "auto-clean command" $?
-    
-    test_no_stashes
-    print_result "no stashes scenario" $?
-    
-    test_help
-    print_result "help command" $?
-    
-    test_invalid_repo
-    print_result "invalid repo path" $?
-    
-    # Print summary
-    echo ""
-    echo "========================================="
-    echo "Tests run:    $TESTS_RUN"
-    echo -e "Tests passed: ${TEST_GREEN}$TESTS_PASSED${RESET}"
-    if [[ "$TESTS_FAILED" -gt 0 ]]; then
-        echo -e "Tests failed: ${TEST_RED}$TESTS_FAILED${RESET}"
-    else
-        echo "Tests failed: $TESTS_FAILED"
-    fi
-    echo "========================================="
-    
-    if [[ "$TESTS_FAILED" -gt 0 ]]; then
-        return 1
-    fi
-    
-    return 0
+	echo "Running stash-audit-helper.sh tests..."
+	echo ""
+
+	# Check if stash helper exists
+	if [[ ! -f "$STASH_HELPER" ]]; then
+		echo -e "${TEST_RED}Error: stash-audit-helper.sh not found at $STASH_HELPER${TEST_RESET}"
+		return 1
+	fi
+
+	# Run tests
+	test_safe_to_drop
+	print_result "safe-to-drop classification" $?
+
+	test_needs_review
+	print_result "needs-review classification" $?
+
+	test_list
+	print_result "list command" $?
+
+	test_auto_clean
+	print_result "auto-clean command" $?
+
+	test_no_stashes
+	print_result "no stashes scenario" $?
+
+	test_help
+	print_result "help command" $?
+
+	test_invalid_repo
+	print_result "invalid repo path" $?
+
+	# Print summary
+	echo ""
+	echo "========================================="
+	echo "Tests run:    $TESTS_RUN"
+	echo -e "Tests passed: ${TEST_GREEN}$TESTS_PASSED${TEST_RESET}"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		echo -e "Tests failed: ${TEST_RED}$TESTS_FAILED${TEST_RESET}"
+	else
+		echo "Tests failed: $TESTS_FAILED"
+	fi
+	echo "========================================="
+
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+
+	return 0
 }
 
 # Run main if executed directly
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-    main "$@"
+	main "$@"
 fi

--- a/.agents/scripts/tests/test-task-decompose.sh
+++ b/.agents/scripts/tests/test-task-decompose.sh
@@ -30,7 +30,7 @@ readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
 readonly TEST_YELLOW='\033[1;33m'
 readonly TEST_CYAN='\033[0;36m'
-readonly RESET='\033[0m'
+readonly TEST_RESET='\033[0m'
 
 # Test counters
 TESTS_RUN=0
@@ -62,13 +62,13 @@ print_result() {
 	TESTS_RUN=$((TESTS_RUN + 1))
 
 	if [[ "$result" -eq 0 ]]; then
-		echo -e "${TEST_GREEN}PASS${RESET} $test_name"
+		echo -e "${TEST_GREEN}PASS${TEST_RESET} $test_name"
 		TESTS_PASSED=$((TESTS_PASSED + 1))
 	elif [[ "$result" -eq 2 ]]; then
-		echo -e "${TEST_YELLOW}SKIP${RESET} $test_name"
+		echo -e "${TEST_YELLOW}SKIP${TEST_RESET} $test_name"
 		TESTS_SKIPPED=$((TESTS_SKIPPED + 1))
 	else
-		echo -e "${TEST_RED}FAIL${RESET} $test_name"
+		echo -e "${TEST_RED}FAIL${TEST_RESET} $test_name"
 		if [[ -n "$message" ]]; then
 			echo "       $message"
 		fi
@@ -454,9 +454,9 @@ test_classify_llm_real_tasks() {
 		kind=$(echo "$output" | sed -n 's/.*"kind"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
 
 		if [[ "$kind" == "$expected" ]]; then
-			echo -e "  ${TEST_GREEN}OK${RESET} '${desc:0:60}...' -> $kind"
+			echo -e "  ${TEST_GREEN}OK${TEST_RESET} '${desc:0:60}...' -> $kind"
 		else
-			echo -e "  ${TEST_RED}MISMATCH${RESET} '${desc:0:60}...' -> $kind (expected $expected)"
+			echo -e "  ${TEST_RED}MISMATCH${TEST_RESET} '${desc:0:60}...' -> $kind (expected $expected)"
 			all_pass=false
 		fi
 
@@ -605,7 +605,7 @@ test_decompose_llm_quality() {
 
 	# exit_code 2 = API unavailable, heuristic used
 	if [[ "$exit_code" -eq 2 ]]; then
-		echo -e "  ${TEST_YELLOW}NOTE${RESET}: API unavailable, testing heuristic fallback quality"
+		echo -e "  ${TEST_YELLOW}NOTE${TEST_RESET}: API unavailable, testing heuristic fallback quality"
 	fi
 
 	if command -v jq &>/dev/null; then
@@ -643,7 +643,7 @@ test_decompose_llm_quality() {
 			print_result "decompose LLM: produces quality subtasks ($count items, $source)" 0
 			# Show the subtasks for inspection
 			echo "$output" | jq -r '.subtasks[].description' 2>/dev/null | while read -r line; do
-				echo -e "  ${TEST_CYAN}>${RESET} $line"
+				echo -e "  ${TEST_CYAN}>${TEST_RESET} $line"
 			done
 		else
 			print_result "decompose LLM: produces quality subtasks" 1 "count_ok=$count_ok quality_ok=$quality_ok output=$output"
@@ -667,7 +667,7 @@ test_decompose_llm_dependencies() {
 	# Heuristic fallback doesn't produce dependency edges — that's expected
 	if [[ "$exit_code" -eq 2 ]]; then
 		print_result "decompose LLM: dependency edges (heuristic fallback, no deps expected)" 0
-		echo -e "  ${TEST_YELLOW}NOTE${RESET}: API unavailable, heuristic doesn't produce dependency edges"
+		echo -e "  ${TEST_YELLOW}NOTE${TEST_RESET}: API unavailable, heuristic doesn't produce dependency edges"
 		return 0
 	fi
 
@@ -1113,20 +1113,20 @@ main() {
 	echo ""
 
 	if [[ "$WITH_LLM" == true ]]; then
-		echo -e "${TEST_CYAN}Mode: Full (with LLM tests)${RESET}"
+		echo -e "${TEST_CYAN}Mode: Full (with LLM tests)${TEST_RESET}"
 	else
-		echo -e "${TEST_CYAN}Mode: Heuristic only (use --with-llm for LLM tests)${RESET}"
+		echo -e "${TEST_CYAN}Mode: Heuristic only (use --with-llm for LLM tests)${TEST_RESET}"
 	fi
 	echo ""
 
 	# Check prerequisites
 	if [[ ! -x "$HELPER" ]]; then
-		echo -e "${TEST_RED}ERROR: Helper script not found or not executable: $HELPER${RESET}"
+		echo -e "${TEST_RED}ERROR: Helper script not found or not executable: $HELPER${TEST_RESET}"
 		return 1
 	fi
 
 	if ! command -v jq &>/dev/null; then
-		echo -e "${TEST_YELLOW}WARNING: jq not found, some tests will be skipped${RESET}"
+		echo -e "${TEST_YELLOW}WARNING: jq not found, some tests will be skipped${TEST_RESET}"
 	fi
 
 	setup
@@ -1140,7 +1140,7 @@ main() {
 
 	# Summary
 	echo "============================================="
-	echo -e " Results: ${TEST_GREEN}${TESTS_PASSED} passed${RESET}, ${TEST_RED}${TESTS_FAILED} failed${RESET}, ${TEST_YELLOW}${TESTS_SKIPPED} skipped${RESET} / ${TESTS_RUN} total"
+	echo -e " Results: ${TEST_GREEN}${TESTS_PASSED} passed${TEST_RESET}, ${TEST_RED}${TESTS_FAILED} failed${TEST_RESET}, ${TEST_YELLOW}${TESTS_SKIPPED} skipped${TEST_RESET} / ${TESTS_RUN} total"
 	echo "============================================="
 
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Renames \`RESET\` → \`TEST_RESET\` in four test harnesses to match the \`TEST_*\` prefix convention established in \`test-tier3-simplified.sh\` (PR #19184). This resolves the inconsistency flagged by gemini-code-assist in the source PR review.

## Files changed

- \`.agents/scripts/tests/test-secret-helper.sh\` — declaration + 2 usages
- \`.agents/scripts/tests/test-simplex-integration.sh\` — declaration + 11 usages
- \`.agents/scripts/tests/test-stash-audit.sh\` — declaration + 5 usages
- \`.agents/scripts/tests/test-task-decompose.sh\` — declaration + 16 usages

## Verification

- \`shellcheck\` passes with zero violations on all four files
- No bare \`RESET\` references remain in any of the modified files

Resolves #19265