### PR TITLE
GH#19288: fix: bump NESTING_DEPTH_THRESHOLD 281→288 to restore headroom (GH#19288)

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -127,7 +127,9 @@ FUNCTION_COMPLEXITY_THRESHOLD=28
 # Bumped to 286 (GH#19215): proximity guard firing at 279/281 (2 headroom); 279 violations + 7 headroom = 286.
 # Proximity guard (warn_at = 286-5 = 281) fires when violations exceed 281 (i.e., at 282), preventing saturation.
 # Ratcheted down to 281 (GH#19235): actual violations 279 + 2 buffer
-NESTING_DEPTH_THRESHOLD=281
+# Bumped to 288 (GH#19288): proximity guard firing at 281/281 (0 headroom); 281 violations + 7 headroom = 288.
+# Proximity guard (warn_at = 288-5 = 283) fires when violations exceed 283 (i.e., at 284), preventing saturation.
+NESTING_DEPTH_THRESHOLD=288
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Bumped NESTING_DEPTH_THRESHOLD from 281 to 288 in .agents/configs/complexity-thresholds.conf. Violations reached 281 at threshold 281 (0 headroom), triggering the proximity guard. New threshold = 281 violations + 7 headroom = 288. Proximity guard fires at 284+ (warn_at = 283), preventing saturation.

## Files Changed

.agents/configs/complexity-thresholds.conf

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** CI Complexity Analysis check will pass with the new threshold. Violation count 281 < 288.

Resolves #19288


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.56 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-sonnet-4-6 spent 2m and 6,211 tokens on this as a headless worker.