### PR TITLE
GH#19267: GH#19267: add || exit guard to SCRIPT_DIR definitions in 4 scripts

### DIFF
--- a/.agents/scripts/deploy-agents-on-merge.sh
+++ b/.agents/scripts/deploy-agents-on-merge.sh
@@ -27,7 +27,7 @@ set -euo pipefail
 #   2 - Nothing to deploy (no changes detected)
 
 # Colors — sourced from shared-constants.sh (Pattern A, t2053.3)
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 # shellcheck source=shared-constants.sh
 [[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
 

--- a/.agents/scripts/doctor-helper.sh
+++ b/.agents/scripts/doctor-helper.sh
@@ -16,7 +16,7 @@
 set -euo pipefail
 
 # Colors — sourced from shared-constants.sh (Pattern A, t2053.3)
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 # shellcheck source=shared-constants.sh
 [[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
 # BOLD and DIM are not in shared-constants.sh — Pattern B fallback

--- a/.agents/scripts/install-hooks-helper.sh
+++ b/.agents/scripts/install-hooks-helper.sh
@@ -19,7 +19,7 @@
 set -euo pipefail
 
 # Colors — sourced from shared-constants.sh (Pattern A, t2053.3)
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 # shellcheck source=shared-constants.sh
 [[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
 

--- a/.agents/scripts/pre-edit-check.sh
+++ b/.agents/scripts/pre-edit-check.sh
@@ -46,7 +46,7 @@
 set -euo pipefail
 
 # Colors — sourced from shared-constants.sh (Pattern A, t2053.3)
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 # shellcheck source=shared-constants.sh
 [[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
 # BOLD is not in shared-constants.sh — Pattern B fallback


### PR DESCRIPTION
## Summary

Added `|| exit` guard to SCRIPT_DIR definitions in deploy-agents-on-merge.sh, doctor-helper.sh, install-hooks-helper.sh, and pre-edit-check.sh (line 49). This ensures each script exits safely if the subshell command to resolve its own directory fails, matching the pattern already used at pre-edit-check.sh:749.

## Files Changed

.agents/scripts/deploy-agents-on-merge.sh,.agents/scripts/doctor-helper.sh,.agents/scripts/install-hooks-helper.sh,.agents/scripts/pre-edit-check.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck passes (exit 0) on all 4 modified files. SC1091 info notices are pre-existing and unrelated.

Resolves #19267


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.56 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-sonnet-4-6 spent 1m and 4,682 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced error handling in deployment and setup scripts to ensure immediate failure when script initialization encounters issues, improving overall reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->