### PR TITLE
GH#19269: extend guarded BOLD pattern to DIM/RESET; remove dead code in stash-audit-helper.sh

### DIFF
--- a/.agents/scripts/session-time-helper.sh
+++ b/.agents/scripts/session-time-helper.sh
@@ -25,7 +25,7 @@ source "${SCRIPT_DIR}/shared-constants.sh"
 set -euo pipefail
 
 [[ -z "${BOLD+x}" ]] && BOLD='\033[1m'
-readonly DIM='\033[2m'
+[[ -z "${DIM+x}" ]] && DIM='\033[2m'
 
 # Defaults
 CLAUDE_DIR="${HOME}/.claude"

--- a/.agents/scripts/stash-audit-helper.sh
+++ b/.agents/scripts/stash-audit-helper.sh
@@ -1,7 +1,6 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
-# shellcheck disable=SC2034,SC2155
 
 # =============================================================================
 # Git Stash Audit Helper Script
@@ -36,9 +35,8 @@ source "${SCRIPT_DIR}/shared-constants.sh"
 
 set -euo pipefail
 
-[[ -z "${BOLD+x}" ]] && BOLD='\033[1m'
-readonly RESET="$NC"            # Alias for NC from shared-constants.sh
-readonly STASH_AGE_THRESHOLD=30 # days
+[[ -z "${RESET+x}" ]] && RESET="$NC" # Alias for NC from shared-constants.sh
+readonly STASH_AGE_THRESHOLD=30      # days
 
 # Color constants are defined in shared-constants.sh
 


### PR DESCRIPTION
## Summary

Review-followup for PR #19182 (t2053.8b). Two unaddressed gemini-code-assist findings:

- **session-time-helper.sh**: `DIM` was still `readonly` while `BOLD` on the line above had already been migrated to a guarded assignment. Inconsistency in the same block.
- **stash-audit-helper.sh**: `RESET` was still `readonly`; `BOLD` was defined but never used (dead code confirmed by grep); the `shellcheck disable=SC2034,SC2155` was only present because of the dead `BOLD` variable.

## Changes

- `session-time-helper.sh:28`: `readonly DIM='\033[2m'` → `[[ -z "${DIM+x}" ]] && DIM='\033[2m'`
- `stash-audit-helper.sh`: remove dead `BOLD` definition, convert `readonly RESET` to guarded assignment, remove now-unnecessary `shellcheck disable=SC2034,SC2155`

## Verification

- Both files pass `shellcheck` with zero errors/warnings (only expected SC1091 info for `source` path)
- Verified `BOLD` is not referenced anywhere in `stash-audit-helper.sh` (grep confirms)
- Verified `DIM` and `RESET` are used in their respective scripts (grep confirms)
- Net change: 3 insertions, 5 deletions

Resolves #19269