### PR TITLE
GH#19271: fix: replace echo -e with printf in test harness logging functions (GH#19271)

### DIFF
--- a/.agents/scripts/test-pr-task-check.sh
+++ b/.agents/scripts/test-pr-task-check.sh
@@ -27,7 +27,7 @@ log() {
 }
 verbose() {
 	if [[ "$VERBOSE" == "--verbose" ]]; then
-		echo -e "  ${TEST_YELLOW}$1${TEST_RESET}"
+		printf "  %s\n" "${TEST_YELLOW}$1${TEST_RESET}"
 	fi
 	return 0
 }

--- a/.agents/scripts/test-task-id-collision.sh
+++ b/.agents/scripts/test-task-id-collision.sh
@@ -43,25 +43,29 @@ readonly TEST_BLUE=$'\033[0;34m'
 readonly TEST_RESET=$'\033[0m'
 
 pass() {
-	echo -e "${TEST_GREEN}[PASS]${TEST_RESET} $1"
+	local msg="$1"
+	printf "%s\n" "${TEST_GREEN}[PASS]${TEST_RESET} $msg"
 	PASS=$((PASS + 1))
 	return 0
 }
 
 fail() {
-	echo -e "${TEST_RED}[FAIL]${TEST_RESET} $1"
+	local msg="$1"
+	printf "%s\n" "${TEST_RED}[FAIL]${TEST_RESET} $msg"
 	FAIL=$((FAIL + 1))
 	return 0
 }
 
 skip() {
-	echo -e "${TEST_YELLOW}[SKIP]${TEST_RESET} $1"
+	local msg="$1"
+	printf "%s\n" "${TEST_YELLOW}[SKIP]${TEST_RESET} $msg"
 	SKIP=$((SKIP + 1))
 	return 0
 }
 
 info() {
-	echo -e "${TEST_BLUE}[INFO]${TEST_RESET} $1"
+	local msg="$1"
+	printf "%s\n" "${TEST_BLUE}[INFO]${TEST_RESET} $msg"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-encryption-git-roundtrip.sh
+++ b/.agents/scripts/tests/test-encryption-git-roundtrip.sh
@@ -54,21 +54,21 @@ readonly TEST_RESET=$'\033[0m'
 
 pass() {
 	local msg="${1:-}"
-	echo -e "${TEST_GREEN}[PASS]${TEST_RESET} $msg"
+	printf "%s\n" "${TEST_GREEN}[PASS]${TEST_RESET} $msg"
 	PASS=$((PASS + 1))
 	return 0
 }
 
 fail() {
 	local msg="${1:-}"
-	echo -e "${TEST_RED}[FAIL]${TEST_RESET} $msg"
+	printf "%s\n" "${TEST_RED}[FAIL]${TEST_RESET} $msg"
 	FAIL=$((FAIL + 1))
 	return 0
 }
 
 skip() {
 	local msg="${1:-}"
-	echo -e "${TEST_YELLOW}[SKIP]${TEST_RESET} $msg"
+	printf "%s\n" "${TEST_YELLOW}[SKIP]${TEST_RESET} $msg"
 	SKIP=$((SKIP + 1))
 	return 0
 }
@@ -76,7 +76,7 @@ skip() {
 info() {
 	local msg="${1:-}"
 	if [[ "$VERBOSE" == "--verbose" ]]; then
-		echo -e "${TEST_BLUE}[INFO]${TEST_RESET} $msg"
+		printf "%s\n" "${TEST_BLUE}[INFO]${TEST_RESET} $msg"
 	fi
 	return 0
 }


### PR DESCRIPTION
## Summary

Replaced non-portable echo -e with printf in pass/fail/skip/info logging helpers across test-pr-task-check.sh, test-task-id-collision.sh, and tests/test-encryption-git-roundtrip.sh. Added local variable declarations in test-task-id-collision.sh functions for repo style consistency. shellcheck passes with zero violations.

## Files Changed

.agents/scripts/test-pr-task-check.sh,.agents/scripts/test-task-id-collision.sh,.agents/scripts/tests/test-encryption-git-roundtrip.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/test-pr-task-check.sh .agents/scripts/test-task-id-collision.sh .agents/scripts/tests/test-encryption-git-roundtrip.sh — all zero violations

Resolves #19271


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.56 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-sonnet-4-6 spent 1m and 5,208 tokens on this as a headless worker.