### PR TITLE
GH#19293: GH#19293: use null-safe iterator in _get_rate_limit_behavior jq filter

### DIFF
--- a/.agents/scripts/review-bot-gate-helper.sh
+++ b/.agents/scripts/review-bot-gate-helper.sh
@@ -141,7 +141,7 @@ _get_rate_limit_behavior() {
 		# stderr is not suppressed so JSON syntax errors surface during debugging.
 		local behavior=""
 		behavior=$(jq -r --arg slug "$repo_slug" --arg bot "$bot_login" \
-			'first(.initialized_repos[] | select(.slug == $slug)) | (.review_gate.tools[$bot].rate_limit_behavior // .review_gate.rate_limit_behavior // empty)' \
+			'first(.initialized_repos[]? | select(.slug == $slug)) | (.review_gate.tools[$bot].rate_limit_behavior // .review_gate.rate_limit_behavior // empty)' \
 			"$repos_json") || behavior=""
 		if [[ -n "$behavior" ]]; then
 			printf '%s' "$behavior"


### PR DESCRIPTION
## Summary

Changed .initialized_repos[] to .initialized_repos[]? in the jq filter in _get_rate_limit_behavior (review-bot-gate-helper.sh:144). This prevents spurious stderr output when initialized_repos is null or missing from repos.json, while actual JSON parse errors still surface (2>/dev/null was intentionally removed in PR #19285). ShellCheck passes with zero violations.

## Files Changed

.agents/scripts/review-bot-gate-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/review-bot-gate-helper.sh — zero violations

Resolves #19293


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.58 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-sonnet-4-6 spent 1m and 3,229 tokens on this as a headless worker.