### PR TITLE
GH#19294: fix: replace undefined $_arg2 with $2 in sonarcloud-autofix.sh fix command

### DIFF
--- a/.agents/scripts/sonarcloud-autofix.sh
+++ b/.agents/scripts/sonarcloud-autofix.sh
@@ -129,7 +129,7 @@ main() {
 			print_info "Usage: $0 fix <file>"
 			exit 1
 		fi
-		apply_sonarcloud_fixes "$_arg2"
+		apply_sonarcloud_fixes "$2"
 		;;
 	"fix-all")
 		print_info "Applying fixes to all shell scripts with SonarCloud issues..."


### PR DESCRIPTION
## Summary

Fixed undefined variable $_arg2 → $2 in the 'fix' subcommand of sonarcloud-autofix.sh (line 132). The fix command correctly validated ${2:-} but then passed the undefined variable $_arg2 to apply_sonarcloud_fixes instead of $2. The restore command used $2 correctly — this was isolated to the fix case.

## Files Changed

.agents/scripts/sonarcloud-autofix.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/sonarcloud-autofix.sh — SC1091 info only (pre-existing, not introduced by this change). No new violations.

Resolves #19294


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.58 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-sonnet-4-6 spent 57s and 1,792 tokens on this as a headless worker.