### PR TITLE
GH#19295: fix: use exit 0 for jq SKIP in test-circuit-breaker.sh

### DIFF
--- a/.agents/scripts/tests/test-circuit-breaker.sh
+++ b/.agents/scripts/tests/test-circuit-breaker.sh
@@ -446,7 +446,7 @@ main() {
 	# Prerequisite check
 	if ! command -v jq &>/dev/null; then
 		echo -e "${TEST_YELLOW}SKIP${RESET} jq not found — required for circuit breaker"
-		exit 1
+		exit 0
 	fi
 
 	test_helper_exists


### PR DESCRIPTION
## Summary

Changed exit 1 to exit 0 in the jq prerequisite check of test-circuit-breaker.sh. When jq is absent, the script emits a SKIP (yellow) message — an exit code of 1 (failure) was inconsistent with that semantic. A missing optional dependency is a skip, not a failure. This fixes the logical inconsistency flagged by gemini-code-assist in PR #19282.

## Files Changed

.agents/scripts/tests/test-circuit-breaker.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck passes with zero violations; verified the change at line 449 is exit 0 after SKIP message

Resolves #19295


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.58 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-sonnet-4-6 spent 2m and 3,339 tokens on this as a headless worker.