### PR TITLE
GH#19296: remove ineffective || return 1 from _generate_seo_commands

### DIFF
--- a/.agents/scripts/generate-claude-commands.sh
+++ b/.agents/scripts/generate-claude-commands.sh
@@ -685,8 +685,8 @@ Return a completed KPI baseline scorecard plus top remediation priorities and re
 # helper under the 100-line shell complexity threshold (GH#19198 / t2125).
 # -----------------------------------------------------------------------------
 _generate_seo_commands() {
-	_generate_seo_keyword_commands || return 1
-	_generate_seo_ai_commands || return 1
+	_generate_seo_keyword_commands
+	_generate_seo_ai_commands
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Removes the `|| return 1` pattern added to `_generate_seo_commands` in PR #19281, which was ineffective and actively masked failures.

## Root Cause

Per the bash spec: when a function is called as `fn || return 1`, `set -e` is suppressed for **all commands within `fn`'s body** — not just the function call itself. Both `_generate_seo_keyword_commands` and `_generate_seo_ai_commands` also end with explicit `return 0`, meaning they always return success regardless of any internal failures (e.g., a failed file write in `write_command`).

The net effect: the `|| return 1` in PR #19281 suppressed `set -euo pipefail` within the sub-functions while providing no compensating propagation. Failures were masked.

## Fix

Call the sub-functions directly and rely on `set -euo pipefail` (line 38) to propagate failures naturally — which is what the code did before PR #19281. This is the correct pattern when the sub-functions themselves use `set -e` semantics rather than explicit error returns.

## Verification

- `shellcheck` passes (no new violations)
- `_generate_seo_commands` now correctly propagates any failure from its sub-functions via `set -e`

Resolves #19296