### PR TITLE
GH#19298: fix: remove duplicate SSH command and unreachable returns in ssh-key-audit-helper.sh

### DIFF
--- a/.agents/scripts/ssh-key-audit-helper.sh
+++ b/.agents/scripts/ssh-key-audit-helper.sh
@@ -43,7 +43,6 @@ test_ssh_key() {
 		"echo 'SSH_SUCCESS'" 2>/dev/null | grep -q "SSH_SUCCESS"
 
 	return $?
-	return 0
 }
 
 # Get working SSH key for a server
@@ -84,7 +83,6 @@ check_target_key_installed() {
 		"grep -q '$target_pub_key' ~/.ssh/authorized_keys" 2>/dev/null
 
 	return $?
-	return 0
 }
 
 # Install target key on server
@@ -99,6 +97,7 @@ install_target_key() {
 	local target_pub_key
 	target_pub_key=$(cat "${TARGET_KEY_PUB/\~/$HOME}")
 
+	local ssh_rc
 	# Add the key to authorized_keys
 	ssh -o ConnectTimeout=5 \
 		-o StrictHostKeyChecking=no \
@@ -106,9 +105,10 @@ install_target_key() {
 		-o LogLevel=ERROR \
 		-i "$working_key" \
 		"$username@$server_ip" \
-		"echo '$target_pub_key' >> ~/.ssh/authorized_keys && sort -u ~/.ssh/authorized_keys -o ~/.ssh/authorized_keys" 2>/dev/null
+		"echo '$target_pub_key' >> ~/.ssh/authorized_keys && sort -u ~/.ssh/authorized_keys -o ~/.ssh/authorized_keys"
+	ssh_rc=$?
 
-	if ssh -o ConnectTimeout=5 -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -o LogLevel=ERROR -i "$working_key" "$username@$server_ip" "echo '$target_pub_key' >> ~/.ssh/authorized_keys && sort -u ~/.ssh/authorized_keys -o ~/.ssh/authorized_keys" 2>/dev/null; then
+	if [[ $ssh_rc -eq 0 ]]; then
 		print_success "Target key installed on $server_ip"
 		return 0
 	else


### PR DESCRIPTION
## Summary

Fixed three issues in .agents/scripts/ssh-key-audit-helper.sh flagged by gemini-code-assist in PR #19176: (1) install_target_key executed the SSH key-installation command twice (appending key twice to authorized_keys); now runs once with exit code captured in local ssh_rc; (2) test_ssh_key had unreachable 'return 0' after 'return $?'; removed; (3) check_target_key_installed had same unreachable 'return 0'; removed.

## Files Changed

.agents/scripts/ssh-key-audit-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/ssh-key-audit-helper.sh — zero violations (SC1091 info is expected for sourced file)

Resolves #19298


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.58 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-sonnet-4-6 spent 2m and 6,441 tokens on this as a headless worker.