### PR TITLE
GH#19300: guard auto-approve log and counter behind edit exit code

### DIFF
--- a/.agents/scripts/pulse-nmr-approval.sh
+++ b/.agents/scripts/pulse-nmr-approval.sh
@@ -467,9 +467,14 @@ Auto-approved: ${approval_reason}. Stale recovery tick reset." \
 
 				gh issue edit "$issue_num" --repo "$slug" \
 					--remove-label "needs-maintainer-review" \
-					--add-label "auto-dispatch" >/dev/null 2>&1 || true
-				echo "[pulse-wrapper] Auto-approved #${issue_num} in ${slug} — ${approval_reason} (locked + approval marker + tick reset)" >>"$LOGFILE"
-				total_approved=$((total_approved + 1))
+					--add-label "auto-dispatch" >/dev/null 2>&1
+				local edit_exit=$?
+				if [[ "$edit_exit" -eq 0 ]]; then
+					echo "[pulse-wrapper] Auto-approved #${issue_num} in ${slug} — ${approval_reason} (locked + approval marker + tick reset)" >>"$LOGFILE"
+					total_approved=$((total_approved + 1))
+				else
+					echo "[pulse-wrapper] Auto-approve label update FAILED for #${issue_num} in ${slug} (exit: ${edit_exit}) — approval marker posted but labels unchanged" >>"$LOGFILE"
+				fi
 			fi
 		done
 	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | "\(.slug)|\(.maintainer // (.slug | split("/")[0]))"' "$repos_json" 2>/dev/null)


### PR DESCRIPTION
## Summary

When `gh issue edit` fails to update labels (race condition, permission error, etc.), the previous code silently treated it as a success via `|| true`, logging an "Auto-approved" entry and incrementing `total_approved`. This produced false approval counts.

## Change

Capture the exit code from `gh issue edit` and make the log message and `total_approved` increment conditional on success (`exit_code == 0`). On failure, log a warning instead so the condition is visible.

**File:** `.agents/scripts/pulse-nmr-approval.sh` around line 468

**Before:**
```bash
gh issue edit "$issue_num" --repo "$slug" \
    --remove-label "needs-maintainer-review" \
    --add-label "auto-dispatch" >/dev/null 2>&1 || true
echo "[pulse-wrapper] Auto-approved #${issue_num} ..." >>"$LOGFILE"
total_approved=$((total_approved + 1))
```

**After:**
```bash
gh issue edit "$issue_num" --repo "$slug" \
    --remove-label "needs-maintainer-review" \
    --add-label "auto-dispatch" >/dev/null 2>&1
local edit_exit=$?
if [[ "$edit_exit" -eq 0 ]]; then
    echo "[pulse-wrapper] Auto-approved #${issue_num} ..." >>"$LOGFILE"
    total_approved=$((total_approved + 1))
else
    echo "[pulse-wrapper] Auto-approve label update FAILED for #${issue_num} ..." >>"$LOGFILE"
fi
```

## Verification

- `shellcheck .agents/scripts/pulse-nmr-approval.sh` — zero violations
- The comment (approval marker + tick reset) is still posted BEFORE the edit, as required by `maintainer-gate.yml` ordering
- Only the log and counter are now gated on edit success

Resolves #19300