### PR TITLE
GH#19301: fix(dedup): escape regex dots in task_id_match for grep pattern safety

### DIFF
--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -339,7 +339,7 @@ _task_id_in_recent_commits() {
 	# Subtask decimal suffix preserved (GH#19165) — t2053.2 must NOT match parent t2053 commits.
 	local -a subject_patterns=()
 	local task_id_match
-	task_id_match=$(printf '%s' "$issue_title" | grep -oE '^t[0-9]+(\.[0-9a-z]+)*' | head -1) || task_id_match=""
+	task_id_match=$(printf '%s' "$issue_title" | grep -oE '^t[0-9]+(\.[0-9a-z]+)*' | head -1 | sed 's/[.]/\\./g') || task_id_match=""
 	if [[ -n "$task_id_match" ]]; then
 		subject_patterns+=("$task_id_match")
 	fi
@@ -458,7 +458,7 @@ _task_id_in_changed_files() {
 
 	# Check for tNNN or tNNN.X completion marker: "- [x] tNNN ..."
 	local task_id_match
-	task_id_match=$(printf '%s' "$issue_title" | grep -oE '^t[0-9]+(\.[0-9a-z]+)*' | head -1) || task_id_match=""
+	task_id_match=$(printf '%s' "$issue_title" | grep -oE '^t[0-9]+(\.[0-9a-z]+)*' | head -1 | sed 's/[.]/\\./g') || task_id_match=""
 	if [[ -n "$task_id_match" ]]; then
 		if printf '%s' "$todo_content" | grep -qE "^\s*-\s*\[x\]\s+${task_id_match}(\s|$)"; then
 			echo "[pulse-wrapper] _task_id_in_changed_files: found completed '${task_id_match}' in TODO.md on origin/main" >>"$LOGFILE"


### PR DESCRIPTION
## Summary

Escaped dots in task_id_match with sed 's/[.]/\\./g' in both _task_id_in_recent_commits (line 342) and _task_id_in_changed_files (line 461). Dots from subtask IDs like t2053.2 were used raw in grep -wE/grep -qE patterns where they act as wildcards. Fix ensures t2053.2 only matches t2053.2, not t2053x2.

## Files Changed

.agents/scripts/pulse-dispatch-core.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck passes (SC1091 info warnings only, pre-existing). Manual verification: t2053.2 → t2053\.2 via sed, grep -wE confirms exact dot match and rejects false positives.

Resolves #19301


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.58 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-sonnet-4-6 spent 2m and 5,892 tokens on this as a headless worker.