### PR TITLE
GH#19299: GH#19299: route claude-proxy and google-proxy through shared response-helpers.mjs

### DIFF
--- a/.agents/plugins/opencode-aidevops/claude-proxy.mjs
+++ b/.agents/plugins/opencode-aidevops/claude-proxy.mjs
@@ -38,6 +38,7 @@ import {
 } from "./claude-proxy-jsonpath.mjs";
 import { streamClaudeResponse } from "./claude-proxy-streaming.mjs";
 import { buildProviderModels } from "./proxy-provider-models.mjs";
+import { jsonResponse, textResponse } from "./response-helpers.mjs";
 
 const CLAUDE_PROXY_DEFAULT_PORT = parseInt(process.env.CLAUDE_PROXY_PORT || "32125", 10);
 const CLAUDE_PROVIDER_ID = "claudecli";
@@ -49,35 +50,6 @@ const SSE_HEADERS = {
   "Cache-Control": "no-cache",
   Connection: "keep-alive",
 };
-
-// ---------------------------------------------------------------------------
-// Response helpers — cross-realm safety
-// ---------------------------------------------------------------------------
-
-/**
- * Create a JSON HTTP response. OpenCode's Bun plugin loader may rebind the
- * `Response` constructor to a realm-local `_Response` class that Bun.serve
- * rejects with "Expected a Response object, but received '_Response'".
- *
- * `Response.json()` (Fetch API static method, Bun ≥1.0) constructs the
- * response through Bun's native internal path, bypassing the mismatch.
- * Falls back to `new Response()` for runtimes without `Response.json()`.
- */
-function jsonResponse(data, init = {}) {
-  if (typeof Response.json === "function") {
-    return Response.json(data, init);
-  }
-  return new Response(JSON.stringify(data), {
-    ...init,
-    headers: { "Content-Type": "application/json", ...init.headers },
-  });
-}
-
-/** Plain-text response (404, etc.). No cross-realm workaround needed — these
- *  are simple enough that Bun.serve generally handles them. */
-function textResponse(body, init = {}) {
-  return new Response(body, init);
-}
 
 /** @type {ReturnType<Bun["serve"]> | null} */
 let proxyServer = null;

--- a/.agents/plugins/opencode-aidevops/google-proxy.mjs
+++ b/.agents/plugins/opencode-aidevops/google-proxy.mjs
@@ -27,27 +27,8 @@
 
 import { join } from "path";
 import { getAccounts, ensureValidToken, patchAccount } from "./oauth-pool.mjs";
+import { jsonResponse, textResponse } from "./response-helpers.mjs";
 export { buildGoogleProviderModels, registerGoogleProvider, persistGoogleProvider, discoverGoogleModels } from "./google-proxy-config.mjs";
-
-// ---------------------------------------------------------------------------
-// Response helpers — cross-realm safety (same as claude-proxy.mjs)
-// ---------------------------------------------------------------------------
-
-/** See claude-proxy.mjs for full rationale on the _Response type mismatch. */
-function jsonResponse(data, init = {}) {
-  if (typeof Response.json === "function") {
-    return Response.json(data, init);
-  }
-  return new Response(JSON.stringify(data), {
-    ...init,
-    headers: { "Content-Type": "application/json", ...init.headers },
-  });
-}
-
-function textResponse(body, init = {}) {
-  return new Response(body, init);
-}
-import { persistGoogleProvider, discoverGoogleModels } from "./google-proxy-config.mjs";
 
 // ---------------------------------------------------------------------------
 // Constants

--- a/tests/test-opencode-response-helpers.sh
+++ b/tests/test-opencode-response-helpers.sh
@@ -54,12 +54,14 @@ fi
 if command -v node >/dev/null 2>&1; then
 	for f in \
 		"$PLUGIN_DIR/response-helpers.mjs" \
+		"$PLUGIN_DIR/claude-proxy.mjs" \
+		"$PLUGIN_DIR/google-proxy.mjs" \
 		"$PLUGIN_DIR/cursor/proxy.js" \
 		"$PLUGIN_DIR/cursor/proxy-stream.js" \
 		"$PLUGIN_DIR/provider-auth-request.mjs"; do
 		node --check "$f" || fail "node --check failed on $f"
 	done
-	pass "syntax check on response-helpers.mjs + 3 importers"
+	pass "syntax check on response-helpers.mjs + 5 importers"
 fi
 
 # --- 2. Runtime behaviour -------------------------------------------------


### PR DESCRIPTION
## Summary

Routes jsonResponse/textResponse in claude-proxy.mjs and google-proxy.mjs through the shared response-helpers.mjs module (introduced in t2122/#19181). Eliminates duplicate local helper definitions with the fragile ...init.headers spread fallback, removes a stray duplicate import in google-proxy.mjs, and extends the syntax-check test to cover both files.

## Files Changed

.agents/plugins/opencode-aidevops/claude-proxy.mjs,.agents/plugins/opencode-aidevops/google-proxy.mjs,tests/test-opencode-response-helpers.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash tests/test-opencode-response-helpers.sh — all assertions pass (syntax check on 5 importers + runtime behaviour)

Resolves #19299


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.58 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-sonnet-4-6 spent 4m and 11,658 tokens on this as a headless worker.