### PR TITLE
t2140: register claude-opus-4-7 as opt-in model

### DIFF
--- a/.agents/plugins/opencode-aidevops/claude-proxy.mjs
+++ b/.agents/plugins/opencode-aidevops/claude-proxy.mjs
@@ -112,6 +112,16 @@ function getClaudeProxyModels() {
       contextWindow: 1000000,
       maxTokens: 64000,
     },
+    {
+      // Opus 4.7 — opt-in only. Framework defaults stay on 4.6.
+      // Context capped at 200K (not 1M API ceiling) due to MRCR v2 regression:
+      // 256K 91.9% -> 59.2%, 1M 78.3% -> 32.2%. See models-opus.md.
+      id: "claude-opus-4-7",
+      name: "Claude Opus 4.7 (via Claude CLI)",
+      reasoning: true,
+      contextWindow: 200000,
+      maxTokens: 64000,
+    },
   ];
 }
 

--- a/.agents/plugins/opencode-aidevops/config-hook.mjs
+++ b/.agents/plugins/opencode-aidevops/config-hook.mjs
@@ -42,6 +42,11 @@ const CLAUDE_MODEL_LIMITS = {
   "claude-sonnet-4-6": { context: 1000000, output: 64000 },
   "claude-opus-4-5":   { context:  200000, output: 64000 },
   "claude-opus-4-6":   { context: 1000000, output: 64000 },
+  // Opus 4.7 context intentionally capped at 200K (not the 1M API ceiling).
+  // Anthropic's own MRCR v2 8-needle data shows long-context retrieval collapse:
+  // 256K drops 91.9% -> 59.2%, 1M drops 78.3% -> 32.2%. Users opting into 4.7
+  // should stay inside the still-functional window. See models-opus.md "Opus 4.7 (opt-in)".
+  "claude-opus-4-7":   { context:  200000, output: 64000 },
 };
 
 /**
@@ -66,6 +71,7 @@ const ANTHROPIC_MODELS = buildClaudeModelMap({
   "claude-sonnet-4-6": "Claude Sonnet 4.6 (via aidevops)",
   "claude-opus-4-5":   "Claude Opus 4.5 (via aidevops)",
   "claude-opus-4-6":   "Claude Opus 4.6 (via aidevops)",
+  "claude-opus-4-7":   "Claude Opus 4.7 (via aidevops)",
 });
 
 /** Models registered under the claudecli provider (via Claude CLI proxy). */
@@ -75,6 +81,7 @@ const CLAUDECLI_MODELS = buildClaudeModelMap({
   "claude-sonnet-4-6": "Claude Sonnet 4.6 (via CLI)",
   "claude-opus-4-5":   "Claude Opus 4.5 (via CLI)",
   "claude-opus-4-6":   "Claude Opus 4.6 (via CLI)",
+  "claude-opus-4-7":   "Claude Opus 4.7 (via CLI)",
 });
 
 /**

--- a/.agents/scripts/compare-models-helper.sh
+++ b/.agents/scripts/compare-models-helper.sh
@@ -148,10 +148,11 @@ get_all_tier_patterns() {
 # Model Database (embedded reference data)
 # =============================================================================
 # Format: model_id|provider|display_name|context_window|input_price_per_1m|output_price_per_1m|tier|capabilities|best_for
-# Prices in USD per 1M tokens. Last updated: 2026-02-18.
+# Prices in USD per 1M tokens. Last updated: 2026-04-16.
 # Sources: Anthropic, OpenAI, Google official pricing pages.
 
 readonly MODEL_DATA="claude-opus-4-6|Anthropic|Claude Opus 4.6|200000|5.00|25.00|high|code,reasoning,architecture,vision,tools|Architecture decisions, novel problems, complex multi-step reasoning
+claude-opus-4-7|Anthropic|Claude Opus 4.7|200000|5.00|25.00|high|code,reasoning,architecture,vision,tools|Opt-in. Higher SWE-Bench but long-context regression (MRCR 256K 92%->59%, 1M 78%->32%) and +20-60% tokenizer cost vs 4.6 — framework defaults stay on 4.6
 claude-sonnet-4-6|Anthropic|Claude Sonnet 4.6|200000|3.00|15.00|medium|code,reasoning,vision,tools|Code implementation, review, most development tasks
 claude-haiku-4-5|Anthropic|Claude Haiku 4.5|200000|1.00|5.00|low|code,reasoning,vision,tools|Triage, classification, simple transforms, formatting
 gpt-4.1|OpenAI|GPT-4.1|1048576|2.00|8.00|medium|code,reasoning,vision,tools,search|Coding, instruction following, long context
@@ -2495,6 +2496,7 @@ _api_model_string() {
 	local model_id="$1"
 	case "$model_id" in
 	claude-opus-4-6) echo "claude-opus-4-20250514" ;;
+	claude-opus-4-7) echo "claude-opus-4-7" ;;
 	claude-sonnet-4-6) echo "claude-sonnet-4-20250514" ;;
 	claude-haiku-4-5) echo "claude-haiku-4-20250414" ;;
 	gpt-4.1) echo "gpt-4.1" ;;

--- a/.agents/tools/ai-assistants/models-opus.md
+++ b/.agents/tools/ai-assistants/models-opus.md
@@ -58,3 +58,32 @@ Highest-capability tier for tasks where stronger reasoning materially changes th
 | Input cost | $5.00/1M tokens |
 | Output cost | $25.00/1M tokens |
 | Tier | opus (highest capability, highest cost) |
+
+## Opus 4.7 (opt-in)
+
+Available as `claude-opus-4-7` in the OpenCode model picker (released 2026-04-16). Not wired as the default for any tier — framework defaults remain on `claude-opus-4-6`. Opt in explicitly via `custom/configs/model-routing-table.json` if you want to route specific tiers or agents to 4.7.
+
+The framework registers 4.7 with a **200K context limit** even though the API accepts 1M, because the 1M window is functionally broken for retrieval tasks (see tradeoffs below).
+
+### Tradeoffs vs 4.6
+
+- **Long-context retrieval regression** (MRCR v2 8-needle, Anthropic's own system card §8.7.2):
+  - 256K: 91.9% → 59.2% (−32.7 pts)
+  - 1M: 78.3% → 32.2% (−46.1 pts)
+  - For any worker that ingests large context (full-loop, cross-file refactors, whole-repo audits), this is a functional regression. Do not use 4.7 for long-session or large-codebase work.
+- **Tokenizer bloat** (same paragraph, new 4.7-only tokenizer):
+  - English: +58.8% tokens vs 4.6 (135 vs 85)
+  - French: +34.0%, Python: +21.4%, mixed multilingual: +22.8%
+  - CJK (Korean/Japanese/Chinese): +4-6% (minor — old tokenizer was already inefficient there)
+  - At identical per-token pricing ($5/$25), this is a 20-60% effective cost increase on English-heavy prompts. Framework prompts and issue bodies are English-heavy.
+- **Stricter literal instruction-following**: prompts tuned for 4.6's looser interpretation may behave unexpectedly. Re-tune prompts before using 4.7 for agentic workloads. Anthropic's migration guide acknowledges this explicitly.
+
+### When 4.7 may be worth it
+
+- Short-context, well-structured one-shot coding tasks where long-context regression doesn't apply (strong SWE-Bench gains reported).
+- Tasks that benefit from the new `xhigh` effort level.
+- Vision work on high-resolution images (4.7 supports up to 2576px on long edge, ~3.75MP — more than 3× prior Claude models).
+
+### Migration guide
+
+<https://platform.claude.com/docs/en/about-claude/models/migration-guide#migrating-to-claude-opus-4-7>

--- a/todo/tasks/t2140-brief.md
+++ b/todo/tasks/t2140-brief.md
@@ -1,0 +1,150 @@
+---
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+# t2140: Register claude-opus-4-7 as opt-in model (defaults stay on 4.6)
+
+## Origin
+
+- **Created:** 2026-04-16
+- **Session:** claude-code:interactive
+- **Created by:** marcus (human)
+- **Conversation context:** Anthropic released Opus 4.7 on 2026-04-16. User asked to add it as an option in the aidevops plugin, explicitly noting documented tradeoffs (Anthropic's own migration guide: 1.0-1.35x tokenizer expansion, more output tokens, stricter literal instruction-following) plus third-party data (MRCR v2 long-context collapse: 256K 91.9%->59.2%, 1M 78.3%->32.2%; English tokenizer +58.8% vs 4.6 on paragraph samples). Decision: register 4.7 so it's selectable but keep every default on 4.6 until we've validated it against the framework's agentic workloads.
+
+## What
+
+- Users can select `claude-opus-4-7` from the OpenCode model picker (both the `anthropic` built-in provider and the `claudecli` proxy provider).
+- The model is registered in the `compare-models-helper.sh` MODEL_DATA registry with correct pricing ($5/$25) and a realistic context window (200K, not 1M — see tradeoffs below).
+- `models-opus.md` documents an "Opus 4.7 (opt-in)" section with the three concrete regressions so users can make an informed choice.
+- **No default tier mappings change.** `opus`, `coding`, and all fallback chains continue to route to `claude-opus-4-6`. Users who want to try 4.7 override via `custom/configs/model-routing-table.json`.
+
+## Why
+
+Anthropic shipped a new flagship. The framework needs to know the model exists so users can opt in, and so `compare-models` / registry sync / label helpers don't get out-of-sync when users select it. But the documented regressions make flipping the default premature:
+
+- **Long-context retrieval collapse** (MRCR v2 8-needle, Anthropic's own system card): 4.7 drops from 91.9% to 59.2% at 256K and 78.3% to 32.2% at 1M. For any worker that ingests large context (full-loop, cross-file refactors, whole-repo audits), this is a functional regression.
+- **Tokenizer bloat on Latin scripts**: English +58.8%, French +34%, Python code +21.4%, mixed multilingual +22.8%. At identical per-token pricing this is a 20-60% real cost increase on the framework's English-heavy prompts.
+- **Stricter literal instruction-following**: existing prompts tuned for 4.6's looser interpretation may misbehave. The framework has 50+ headless dispatch scripts with prompts not specifically audited for literal-mode safety.
+
+Registering at **200K context** (not the 1M API ceiling) is deliberate: the 1M window is functionally broken per MRCR, and the framework already has a `/compact` soft-prompt at 200K. Advertising 1M would route users into a dead zone.
+
+## Tier
+
+### Tier checklist
+
+- [x] 2 or fewer files to modify? **No** — 4 files
+- [x] Every target file under 500 lines? **No** — `compare-models-helper.sh` is 3400+ lines
+- [x] Exact `oldString`/`newString` for every edit? **Yes** (provided below)
+- [x] No judgment or design decisions? **Yes** — decisions made in this brief
+- [x] No error handling or fallback logic to design? **Yes**
+- [x] No cross-package or cross-module changes? **Yes** — all within `.agents/plugins/` and `.agents/scripts/` and `.agents/tools/ai-assistants/`
+- [x] Estimate 1h or less? **Yes**
+- [x] 4 or fewer acceptance criteria? **Yes** — 4
+
+**Selected tier:** `tier:simple`
+
+**Tier rationale:** Four files, all edits are exact oldString/newString additions of a new model entry following existing patterns (4-6 entries as models). `compare-models-helper.sh` is large but the edit is a single-line append to a readonly string and one case branch addition — both mechanical.
+
+## PR Conventions
+
+Leaf task, not a parent-task. PR body uses `Resolves #NNN`.
+
+## How (Approach)
+
+### Files to Modify
+
+- EDIT: `.agents/plugins/opencode-aidevops/config-hook.mjs` — add `claude-opus-4-7` entry to `CLAUDE_MODEL_LIMITS` and both name maps
+- EDIT: `.agents/plugins/opencode-aidevops/claude-proxy.mjs` — add `claude-opus-4-7` entry to `getClaudeProxyModels()`
+- EDIT: `.agents/scripts/compare-models-helper.sh` — add entry to `MODEL_DATA` and `_api_model_string`
+- EDIT: `.agents/tools/ai-assistants/models-opus.md` — add "Opus 4.7 (opt-in)" section
+
+### Implementation Steps
+
+1. **config-hook.mjs** — Add after the `claude-opus-4-6` line in `CLAUDE_MODEL_LIMITS`:
+   ```js
+   "claude-opus-4-7":   { context:  200000, output: 64000 },
+   ```
+   And to both `ANTHROPIC_MODELS` and `CLAUDECLI_MODELS` name maps:
+   ```js
+   "claude-opus-4-7":   "Claude Opus 4.7 (via aidevops)",
+   "claude-opus-4-7":   "Claude Opus 4.7 (via CLI)",
+   ```
+   Context window intentionally capped at 200K, not 1M — see brief "Why" for MRCR data.
+
+2. **claude-proxy.mjs** — Append to `getClaudeProxyModels()` array:
+   ```js
+   {
+     id: "claude-opus-4-7",
+     name: "Claude Opus 4.7 (via Claude CLI)",
+     reasoning: true,
+     contextWindow: 200000,
+     maxTokens: 64000,
+   },
+   ```
+
+3. **compare-models-helper.sh** — Add after the `claude-opus-4-6` line in `MODEL_DATA` (line 154):
+   ```
+   claude-opus-4-7|Anthropic|Claude Opus 4.7|200000|5.00|25.00|high|code,reasoning,architecture,vision,tools|Higher coding scores but long-context regression and +20-60% tokenizer cost vs 4.6 — opt-in only
+   ```
+   And to `_api_model_string` case branch (line 2497):
+   ```bash
+   claude-opus-4-7) echo "claude-opus-4-7" ;;
+   ```
+   (No dated suffix is documented yet; the short ID is the canonical form per the Anthropic blog.)
+
+4. **models-opus.md** — Append new section after "Model Details" table:
+
+   ```markdown
+   ## Opus 4.7 (opt-in)
+
+   Available as `claude-opus-4-7` in the OpenCode model picker. Not wired as the default
+   for any tier — opt in explicitly via `custom/configs/model-routing-table.json`.
+
+   ### Tradeoffs vs 4.6
+
+   - **Long-context retrieval regression** (MRCR v2 8-needle, Anthropic system card):
+     - 256K: 91.9% -> 59.2% (-32.7 pts)
+     - 1M: 78.3% -> 32.2% (-46.1 pts)
+     - Framework registers 4.7 at 200K context only to keep users inside the
+       still-functional window. Do not use 4.7 for whole-repo or long-session work.
+   - **Tokenizer bloat** (same paragraph, new tokenizer):
+     - English: +58.8% tokens vs 4.6
+     - French: +34%, Python: +21.4%, mixed multilingual: +22.8%
+     - CJK: +4-6% (minor — old tokenizer was already inefficient there)
+     - At identical per-token pricing this is a 20-60% effective cost increase on
+       English-heavy prompts.
+   - **Stricter literal instruction-following**: prompts tuned for 4.6's looser
+     interpretation may behave unexpectedly. Re-tune prompts before using 4.7 for
+     agentic workloads.
+
+   ### When 4.7 may be worth it
+
+   - Short-context, well-structured one-shot coding tasks (strong SWE-Bench gains)
+     where the regressions above don't apply.
+   - Tasks that benefit from the new `xhigh` effort level.
+   - Vision work on high-resolution images (4.7 supports up to 2576px on long edge).
+   ```
+
+### Verification
+
+1. `jq '.[]' /dev/null < .agents/configs/model-routing-table.json && bash -n .agents/scripts/compare-models-helper.sh` — syntax clean
+2. `.agents/scripts/compare-models-helper.sh list | grep -c "claude-opus-4-7"` — returns 1
+3. `grep -c "claude-opus-4-7" .agents/plugins/opencode-aidevops/config-hook.mjs` — returns 3 (limits + 2 name maps)
+4. `grep -c "claude-opus-4-6" .agents/configs/model-routing-table.json` — returns 2 (opus + coding tiers, unchanged — confirms defaults were NOT flipped)
+5. `shellcheck .agents/scripts/compare-models-helper.sh` — no new violations
+
+## Acceptance Criteria
+
+- [ ] `claude-opus-4-7` appears in OpenCode's model picker via both `anthropic` and `claudecli` providers
+- [ ] `compare-models-helper.sh list` shows the new model with $5/$25 pricing and 200K context
+- [ ] `model-routing-table.json` and all other tier mappings still point to `claude-opus-4-6` (defaults unchanged)
+- [ ] `models-opus.md` documents the three tradeoffs with concrete numbers
+
+## Context
+
+- Anthropic announcement: <https://www.anthropic.com/news/claude-opus-4-7>
+- Migration guide tradeoffs: tokenizer 1.0-1.35x expansion, stricter instructions
+- MRCR v2 data: Anthropic system card section 8.7.2 (user-supplied screenshot)
+- Tokenizer comparison: third-party analysis of paragraph-level token counts (user-supplied screenshot)


### PR DESCRIPTION
## Summary

Register Claude Opus 4.7 as a selectable option in the aidevops OpenCode plugin. **No default tier mappings change** — `opus`, `coding`, and all fallback chains continue to route to `claude-opus-4-6`. Users opt in via `custom/configs/model-routing-table.json`.

## Why opt-in only (not the new default)

Three concrete regressions vs 4.6:

- **Long-context retrieval collapse** (MRCR v2 8-needle, Anthropic system card §8.7.2):
  - 256K: 91.9% → 59.2% (−32.7 pts)
  - 1M: 78.3% → 32.2% (−46.1 pts)
  - Unsuitable for full-loop workers, cross-file refactors, whole-repo audits.
- **Tokenizer bloat**: English +58.8%, Python +21.4%, mixed multilingual +22.8% (same paragraph, new tokenizer). At identical per-token pricing = 20-60% effective cost increase on our English-heavy prompts.
- **Stricter literal instruction-following** (Anthropic migration guide): prompts tuned for 4.6's looser interpretation may misbehave. Our 50+ headless dispatch scripts aren't yet audited for literal-mode safety.

## Design decision: 200K context, not 1M

4.7 is registered with a 200K context window in `config-hook.mjs` and `claude-proxy.mjs`, even though the API accepts 1M. The 1M window is functionally broken for retrieval per MRCR — advertising it would route users into a dead zone. The existing `/compact` soft-prompt at 200K+ now does the right thing for 4.7 automatically.

## Files changed

- `.agents/plugins/opencode-aidevops/config-hook.mjs` — `CLAUDE_MODEL_LIMITS` + both provider name maps
- `.agents/plugins/opencode-aidevops/claude-proxy.mjs` — `getClaudeProxyModels()` array
- `.agents/scripts/compare-models-helper.sh` — `MODEL_DATA` registry + `_api_model_string` case
- `.agents/tools/ai-assistants/models-opus.md` — new "Opus 4.7 (opt-in)" section with the three tradeoffs

## Verification

- `bash -n .agents/scripts/compare-models-helper.sh` — SYNTAX_OK
- `node --check` on both `.mjs` files — clean
- `compare-models-helper.sh list` shows new entry with $5/$25 pricing and 200K context
- `grep claude-opus-4-6` in all tier-config files returns the same counts as before the PR — defaults unchanged

Resolves #19324


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.59 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-opus-4-6 spent 37m and 225 tokens on this with the user in an interactive session. Overall, 34s since this issue was created.