### PR TITLE
GH#19292: fix(deploy): use anchored pgrep/pkill pattern and verify PID change on restart

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -393,7 +393,7 @@ Git is the audit trail. Procedures: AGENTS.md "Git Workflow" section.
 
 **Pulse restart after deploying pulse script fixes (MANDATORY):**
 - Bash processes load `source` files at startup only. Deploying updated `.sh` files to `~/.aidevops/agents/scripts/` does NOT affect a running pulse — it keeps using the old code in memory. This caused a multi-hour outage where v3.8.41 fixes were deployed but the pulse kept blocking issues with stale logic.
-- After deploying fixes to any sourced pulse script (`pulse-*.sh`, `dispatch-dedup-*.sh`, `headless-runtime-*.sh`, `worker-lifecycle-common.sh`, `pulse-nmr-approval.sh`), restart the pulse: `pkill -f pulse-wrapper.sh || true; sleep 3; nohup ~/.aidevops/agents/scripts/pulse-wrapper.sh >> ~/.aidevops/logs/pulse-wrapper.log 2>&1 &`
+- After deploying fixes to any sourced pulse script (`pulse-*.sh`, `dispatch-dedup-*.sh`, `headless-runtime-*.sh`, `worker-lifecycle-common.sh`, `pulse-nmr-approval.sh`), restart the pulse: `pkill -f "(^|/)pulse-wrapper\.sh( |$)" || true; sleep 3; nohup ~/.aidevops/agents/scripts/pulse-wrapper.sh >> ~/.aidevops/logs/pulse-wrapper.log 2>&1 &`
 - `setup.sh` and `aidevops update` handle this automatically via `_restart_pulse_if_running`. Interactive sessions deploying hotfixes via `cp` must restart manually.
 
 # Quality Standards

--- a/setup-modules/agent-deploy.sh
+++ b/setup-modules/agent-deploy.sh
@@ -19,19 +19,26 @@ IFS=$'\n\t'
 # auto-restart mechanism exists, we start it manually.
 #######################################
 _restart_pulse_if_running() {
-	if ! pgrep -f pulse-wrapper.sh >/dev/null; then
+	# Anchor the pattern so it only matches the running script, not editors or
+	# grep commands that happen to contain "pulse-wrapper.sh" in their argv.
+	local pattern="(^|/)pulse-wrapper\\.sh( |$)"
+
+	if ! pgrep -f "$pattern" >/dev/null; then
 		# Not running, nothing to do
 		return 0
 	fi
 
 	local old_pid
-	old_pid=$(pgrep -f pulse-wrapper.sh | head -1)
+	old_pid=$(pgrep -f "$pattern" | tail -1)
+	if [[ -z "$old_pid" ]]; then
+		return 0
+	fi
 	print_info "Restarting pulse (PID $old_pid) to load updated scripts..."
-	pkill -f pulse-wrapper.sh || true
+	pkill -f "$pattern" || true
 
 	# Wait for it to die
 	local wait_count=0
-	while pgrep -f pulse-wrapper.sh >/dev/null && [[ "$wait_count" -lt 10 ]]; do
+	while pgrep -f "$pattern" >/dev/null && [[ "$wait_count" -lt 10 ]]; do
 		sleep 1
 		wait_count=$((wait_count + 1))
 	done
@@ -39,12 +46,15 @@ _restart_pulse_if_running() {
 	# Give launchd/cron a moment to restart it
 	sleep 5
 
-	# Check if it auto-restarted
-	if pgrep -f pulse-wrapper.sh >/dev/null; then
+	# Check if it auto-restarted with a different PID (guards against false
+	# success if the old process failed to terminate).
+	if pgrep -f "$pattern" >/dev/null; then
 		local new_pid
-		new_pid=$(pgrep -f pulse-wrapper.sh | head -1)
-		print_success "Pulse restarted (new PID $new_pid)"
-		return 0
+		new_pid=$(pgrep -f "$pattern" | tail -1)
+		if [[ -n "$new_pid" ]] && [[ "$new_pid" != "$old_pid" ]]; then
+			print_success "Pulse restarted (new PID $new_pid)"
+			return 0
+		fi
 	fi
 
 	# No auto-restart — start it manually


### PR DESCRIPTION
## Summary

Hardened _restart_pulse_if_running in setup-modules/agent-deploy.sh: anchored pgrep/pkill pattern to avoid false matches on editors or grep commands; added empty PID guard; switched head-1 to tail-1; added new_pid != old_pid check to prevent false-success reports. Updated build.txt manual restart command to match.

## Files Changed

.agents/prompts/build.txt,setup-modules/agent-deploy.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck setup-modules/agent-deploy.sh passes with zero violations

Resolves #19292


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.59 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-sonnet-4-6 spent 2m and 8,022 tokens on this as a headless worker.