### PR TITLE
GH#19323: chore: ratchet-down complexity thresholds

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -129,7 +129,8 @@ FUNCTION_COMPLEXITY_THRESHOLD=28
 # Ratcheted down to 281 (GH#19235): actual violations 279 + 2 buffer
 # Bumped to 288 (GH#19288): proximity guard firing at 281/281 (0 headroom); 281 violations + 7 headroom = 288.
 # Proximity guard (warn_at = 288-5 = 283) fires when violations exceed 283 (i.e., at 284), preventing saturation.
-NESTING_DEPTH_THRESHOLD=288
+# Ratcheted down to 283 (GH#19323): actual violations 281 + 2 buffer
+NESTING_DEPTH_THRESHOLD=283
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)
@@ -150,7 +151,8 @@ FILE_SIZE_THRESHOLD=59
 # new-task-helper.sh, setup/_tools.sh, thumbnail-helper.sh). 73 + 2 buffer = 75.
 # GH#19276: +4 from new heredoc-in-$() check (remote-dispatch-helper.sh x2,
 # seo-export-dataforseo.sh, seo-export-gsc.sh — pre-existing violations). 78 + 2 = 80.
-BASH32_COMPAT_THRESHOLD=80
+# Ratcheted down to 76 (GH#19323): actual violations 74 + 2 buffer
+BASH32_COMPAT_THRESHOLD=76
 
 # Qlty maintainability smell baseline (t2065, GH#18773). Seed value for
 # the `.github/workflows/qlty-regression.yml` gate. The gate itself uses


### PR DESCRIPTION
## Summary

Ratchet-down two complexity thresholds after simplification wins accumulated:

- `NESTING_DEPTH_THRESHOLD`: 288 → 283 (actual violations: 281, gap: 7)
- `BASH32_COMPAT_THRESHOLD`: 80 → 76 (actual violations: 74, gap: 6)

Each updated threshold line has a ratchet-down comment added above it documenting the change (GH#19323, actual violations + 2 buffer). Existing bump history comments are preserved as the audit trail.

## Testing

- Verified thresholds updated: `grep -E 'NESTING_DEPTH_THRESHOLD|BASH32_COMPAT_THRESHOLD' .agents/configs/complexity-thresholds.conf` confirms 283 and 76 respectively.
- Confirmed `simplification-state.json` is NOT staged in this PR (issue guidance: GH#18622).
- Only `.agents/configs/complexity-thresholds.conf` is modified.

Resolves #19323