### PR TITLE
GH#19331: GH#19331: tighten pre-dispatch-validators.md (108→90 lines)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -2255,15 +2255,15 @@
       "pr": 12145
     },
     ".agents/scripts/full-loop-helper.sh": {
-      "at": "2026-04-15T22:51:54Z",
-      "hash": "d369e2bc2b0e7f9dad45789af18d1132ed306093",
-      "passes": 8,
+      "at": "2026-04-16T16:56:57Z",
+      "hash": "4ab7ca91610ae34dd1e863332a3094decc2b31a1",
+      "passes": 9,
       "pr": 19046
     },
     ".agents/scripts/generate-claude-commands.sh": {
-      "at": "2026-04-16T14:49:35Z",
-      "hash": "1712034170f75ae5d6f6c41c5bd2c3a67f822000",
-      "passes": 3,
+      "at": "2026-04-16T16:56:57Z",
+      "hash": "f765036b6fbf0bceea3934d747fcb902ca3c4635",
+      "passes": 4,
       "pr": 17571
     },
     ".agents/scripts/generate-opencode-agents.sh": {
@@ -2405,9 +2405,9 @@
       "pr": 18796
     },
     ".agents/scripts/pulse-dispatch-core.sh": {
-      "at": "2026-04-15T20:05:53Z",
-      "hash": "2f27c838214719f8ee1e4e66b37cf84c95f9cdac",
-      "passes": 7,
+      "at": "2026-04-16T16:56:58Z",
+      "hash": "92e246c27564e55db18971606fe98d3f951f2e4b",
+      "passes": 8,
       "pr": 18832
     },
     ".agents/scripts/pulse-dispatch-engine.sh": {
@@ -7479,21 +7479,21 @@
       "pr": 16415
     },
     "TODO.md": {
-      "at": "2026-04-16T16:36:31Z",
-      "hash": "dbc3ab67c160b6f40e73ce928617946714911fa0",
-      "passes": 23,
+      "at": "2026-04-16T16:57:29Z",
+      "hash": "d329f08965b00c17033aaa11f9e90379f9c83e16",
+      "passes": 24,
       "pr": 15490
     },
     "aidevops.sh": {
-      "at": "2026-04-16T16:36:31Z",
-      "hash": "e4ad536d7f2a041461b47a6cd0895aa43f661ad2",
-      "passes": 68,
+      "at": "2026-04-16T16:57:29Z",
+      "hash": "f5d4b6d4a636b75f1dbb87c4a7a73104029f22ac",
+      "passes": 69,
       "pr": 19029
     },
     "setup.sh": {
-      "at": "2026-04-16T16:36:32Z",
-      "hash": "8603ac191ccbd775170f948cb474d23db0c57988",
-      "passes": 66,
+      "at": "2026-04-16T16:57:29Z",
+      "hash": "e01a53a289b8ec121e168acf6dc79d2f13876b5f",
+      "passes": 67,
       "pr": 15470
     },
     "todo/tasks/GH#15363-brief.md": {

--- a/.agents/reference/pre-dispatch-validators.md
+++ b/.agents/reference/pre-dispatch-validators.md
@@ -4,23 +4,23 @@ Pre-dispatch validators run **after** dedup checks and **before** worker spawn f
 
 ## Architecture
 
-Auto-generated issues embed a hidden marker — parsed with `grep -oE '<!-- aidevops:generator=[a-z-]+ -->'`. Parsing titles or labels is rejected; markers survive editorial changes to human-visible fields.
+Auto-generated issues embed a hidden marker parsed with `grep -oE '<!-- aidevops:generator=[a-z-]+ -->'`. Titles and labels are rejected (they change; markers survive). Format:
 
 ```text
 <!-- aidevops:generator=<name> -->
 ```
 
-`pre-dispatch-validator-helper.sh` maintains `_VALIDATOR_REGISTRY` mapping generator names to validator functions, populated by `_register_validators()`. Unregistered generators exit 0 (dispatch proceeds).
+`pre-dispatch-validator-helper.sh` maintains `_VALIDATOR_REGISTRY` (populated by `_register_validators()`). Unregistered generators exit 0.
 
-### Exit-code contract
+### Exit codes
 
 | Code | Meaning | Action |
 |------|---------|--------|
-| `0`  | Dispatch proceeds — premise holds or no validator registered | Worker spawned normally |
-| `10` | Premise falsified — issue is stale | Rationale comment posted + issue closed as `not planned`; no worker |
+| `0`  | Premise holds or no validator registered | Worker spawned |
+| `10` | Premise falsified | Comment posted (`> Premise falsified`, citing GH#19118) + `gh issue close --reason "not planned"` |
 | `20` | Validator error | Warning logged; dispatch proceeds (never block on validator bugs) |
 
-### Hook point in `dispatch_with_dedup()` (`pulse-dispatch-core.sh`)
+### Hook point (`pulse-dispatch-core.sh`)
 
 ```text
 _dispatch_dedup_check_layers()   ← all dedup gates
@@ -29,7 +29,7 @@ _run_predispatch_validator()     ← GH#19118 ← HERE
 _dispatch_launch_worker()        ← worker spawn
 ```
 
-Non-fatal: if the helper is missing or returns an unexpected code, dispatch proceeds.
+Non-fatal: missing helper or unexpected exit code → dispatch proceeds.
 
 ## Bypass
 
@@ -37,11 +37,7 @@ Non-fatal: if the helper is missing or returns an unexpected code, dispatch proc
 AIDEVOPS_SKIP_PREDISPATCH_VALIDATOR=1 ./pulse-wrapper.sh
 ```
 
-Emergency recovery when a validator bug blocks legitimate dispatches. Bypass is logged. Do not leave set permanently.
-
-## On exit 10
-
-Posts a `> Premise falsified` blockquote naming the generator, noting no actionable work, and citing GH#19118. Closes with `gh issue close --reason "not planned"`. A new issue is created if conditions change on the next pulse cycle.
+Emergency recovery when a validator bug blocks legitimate dispatches. Bypass is logged; do not leave set permanently.
 
 ## Registered validators
 
@@ -50,59 +46,45 @@ Posts a `> Premise falsified` blockquote naming the generator, noting no actiona
 **Generator:** `_complexity_scan_ratchet_check` in `pulse-simplification.sh`
 **Marker:** `<!-- aidevops:generator=ratchet-down -->`
 
-1. Clone the target repo into `mktemp -d` (trap-cleaned on exit)
+1. Clone target repo into `mktemp -d` (trap-cleaned)
 2. Run `complexity-scan-helper.sh ratchet-check <clone> 5`
-3. `No ratchet-down available` in output → exit 10 (premise falsified)
+3. `No ratchet-down available` in output → exit 10 (falsified)
 4. Empty output + any error → exit 20 (validator error)
 5. Otherwise → exit 0 (proposals available, dispatch)
 
-Without this check, workers spawn only to discover no ratchet-down work exists (GH#19024 failure mode).
+Without this, workers spawn only to find no ratchet-down work exists (GH#19024).
 
 ## Adding a validator
 
-1. **Define the generator function** in `pulse-simplification.sh` or the issue-creation script.
-
-2. **Emit the marker** in the issue body template:
-
-   ```bash
-   "...issue content...\n\n<!-- aidevops:generator=my-generator -->"
-   ```
-
-3. **Implement the validator** in `pre-dispatch-validator-helper.sh`:
-
+1. Define the generator function in `pulse-simplification.sh` or the issue-creation script.
+2. Emit the marker in the issue body: `<!-- aidevops:generator=my-generator -->`
+3. Implement in `pre-dispatch-validator-helper.sh`:
    ```bash
    _validator_my_generator() {
        local slug="$1"
-       # Use $SCRATCH_DIR for temp files — trap cleanup is already set
-       # Return: 0 = dispatch, 10 = falsified, 20 = error
-       return 0
+       # Use $SCRATCH_DIR for temp files — trap cleanup already set
+       return 0  # 0=dispatch, 10=falsified, 20=error
    }
    ```
-
-4. **Register** in `_register_validators()`:
-
+4. Register in `_register_validators()`:
    ```bash
    _VALIDATOR_REGISTRY["my-generator"]="_validator_my_generator"
    ```
-
-5. **Add test cases** in `tests/test-pre-dispatch-validator.sh` covering the falsified and legitimate paths.
-
-6. **Run shellcheck**: `shellcheck .agents/scripts/pre-dispatch-validator-helper.sh`
+5. Add test cases in `tests/test-pre-dispatch-validator.sh` (falsified + legitimate paths).
+6. Run `shellcheck .agents/scripts/pre-dispatch-validator-helper.sh`.
 
 ## Testing
 
 ```bash
-# Run the test harness
 bash .agents/scripts/tests/test-pre-dispatch-validator.sh
-# Manual smoke test (requires gh auth)
 .agents/scripts/pre-dispatch-validator-helper.sh validate <issue-number> marcusquinn/aidevops
 ```
 
-Stub `gh`, `git`, and `complexity-scan-helper.sh` binaries are injected via `PATH` and `COMPLEXITY_SCAN_HELPER` — no network access required.
+`gh`, `git`, and `complexity-scan-helper.sh` are stubbed via `PATH` and `COMPLEXITY_SCAN_HELPER` — no network required.
 
 ## Related
 
 - `pulse-dispatch-core.sh` — `dispatch_with_dedup`, `_run_predispatch_validator`
 - `pulse-simplification.sh` — `_complexity_scan_ratchet_check` (ratchet-down generator)
-- `reference/worker-diagnostics.md` — full worker lifecycle and diagnostic reference
+- `reference/worker-diagnostics.md` — full worker lifecycle
 - GH#19118, GH#19024 (post-mortem), GH#19036, GH#19037


### PR DESCRIPTION
## Summary

Tightened pre-dispatch-validators.md from 108 to 90 lines (-17%). Merged redundant 'On exit 10' section into exit-code table Action column, compressed verbose prose in Architecture/hook-point/ratchet-down sections, tightened 'Adding a validator' steps. All GH refs (GH#19118, GH#19024, GH#19036, GH#19037), exit codes, bypass env var, code examples, and test commands preserved.

## Files Changed

.agents/configs/simplification-state.json,.agents/reference/pre-dispatch-validators.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** wc -l confirms 90 lines; rg verified all GH refs, exit codes, commands, and code blocks present; content matches original knowledge structure

Resolves #19331


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.59 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-sonnet-4-6 spent 2m and 6,788 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified validator specifications and exit code behavior in reference documentation.

* **Chores**
  * Updated internal configuration metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->