### PR TITLE
chore: bump BASH32_COMPAT_THRESHOLD 76→80 to absorb pre-existing drift

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -152,7 +152,12 @@ FILE_SIZE_THRESHOLD=59
 # GH#19276: +4 from new heredoc-in-$() check (remote-dispatch-helper.sh x2,
 # seo-export-dataforseo.sh, seo-export-gsc.sh — pre-existing violations). 78 + 2 = 80.
 # Ratcheted down to 76 (GH#19323): actual violations 74 + 2 buffer
-BASH32_COMPAT_THRESHOLD=76
+# Bumped to 80 (GH#19343): pre-existing drift on main — 78 violations vs
+# threshold 76 (CI failure on PR #19344 run 24526084346). PR #19344 added zero
+# bash32 violations (inline `${VAR:-default}` guards + bash 3.2-compatible test).
+# Unblocking other in-flight PRs. 78 + 2 buffer = 80. Ratchet back down in the
+# next quality sweep.
+BASH32_COMPAT_THRESHOLD=80
 
 # Qlty maintainability smell baseline (t2065, GH#18773). Seed value for
 # the `.github/workflows/qlty-regression.yml` gate. The gate itself uses


### PR DESCRIPTION
## Summary

Bump `BASH32_COMPAT_THRESHOLD` in `.agents/configs/complexity-thresholds.conf` from 76 to 80. Main currently has 78 violations (observed on PR #19344 run 24526084346 before its merge bypassed the check). Any new PR hits the same gate.

This is a pure ratchet bump — no code changes.

## Why

- Main has drifted 2 above the current ratchet. The last ratchet-down was #19323 (76 from 74+2).
- PR #19344 (just merged) added zero bash32 violations but still failed this check because of the drift.
- Subsequent in-flight PRs will trip the same gate for no reason related to their own changes.
- Same pattern as previous drift-absorption bumps already logged in the file (GH#17830, #19087, #19276).

## Change

```diff
-BASH32_COMPAT_THRESHOLD=76
+BASH32_COMPAT_THRESHOLD=80
```

78 + 2 buffer = 80. Next quality sweep should ratchet back down toward the actual violation count.

## Testing

Config-only change. The `.github/workflows/code-quality.yml` bash32-compat job reads this value and compares against measured violations.

## Runtime Testing

- **Risk level:** Low (CI config-only change)
- **Verification:** No code paths touched; threshold increase loosens a gate without removing it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration thresholds for code quality checks.

---

**Note:** This release contains no user-facing features or changes. Updates are internal infrastructure adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

Ref #19343