### PR TITLE
GH#19342: bump NESTING_DEPTH_THRESHOLD from 283 to 288

### DIFF
--- a/.agents/configs/complexity-thresholds-history.md
+++ b/.agents/configs/complexity-thresholds-history.md
@@ -62,6 +62,10 @@ Archives the full change history for `.agents/configs/complexity-thresholds.conf
 | 286 | GH#19086 | proximity guard firing at 279/279 (0 headroom); violations drifted from ratchet baseline 277 up to 279 on main as new helpers landed. 279 violations + 7 headroom = 286; proximity guard (warn_at = 286-5 = 281) fires when violations exceed 281 (i.e., at 282), preventing saturation. A ratchet-down fix would require reducing per-file max depth below 9 in multiple scripts — a larger refactor than the proximity warning justifies; follow the established bump-and-ratchet cadence |
 | 281 | GH#19204 (PR#19207) | ratcheted down — actual violations 279 + 2 buffer |
 | 286 | GH#19215 | proximity guard firing at 279/281 (2 headroom); 279 violations + 7 headroom = 286; proximity guard (warn_at = 286-5 = 281) fires when violations exceed 281 (i.e., at 282), preventing saturation |
+| 281 | GH#19235 | ratcheted down — actual violations 279 + 2 buffer |
+| 288 | GH#19288 | proximity guard firing at 281/281 (0 headroom); 281 violations + 7 headroom = 288; proximity guard (warn_at = 288-5 = 283) fires when violations exceed 283 (i.e., at 284), preventing saturation |
+| 283 | GH#19323 | ratcheted down — actual violations 281 + 2 buffer |
+| 288 | GH#19342 | proximity guard firing at 281/283 (2 headroom); 281 violations + 7 headroom = 288; proximity guard (warn_at = 288-5 = 283) fires when violations exceed 283 (i.e., at 284), preventing saturation |
 
 ## FUNCTION_COMPLEXITY_THRESHOLD History
 

--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -130,7 +130,9 @@ FUNCTION_COMPLEXITY_THRESHOLD=28
 # Bumped to 288 (GH#19288): proximity guard firing at 281/281 (0 headroom); 281 violations + 7 headroom = 288.
 # Proximity guard (warn_at = 288-5 = 283) fires when violations exceed 283 (i.e., at 284), preventing saturation.
 # Ratcheted down to 283 (GH#19323): actual violations 281 + 2 buffer
-NESTING_DEPTH_THRESHOLD=283
+# Bumped to 288 (GH#19342): proximity guard firing at 281/283 (2 headroom); 281 violations + 7 headroom = 288.
+# Proximity guard (warn_at = 288-5 = 283) fires when violations exceed 283 (i.e., at 284), preventing saturation.
+NESTING_DEPTH_THRESHOLD=288
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Bump \`NESTING_DEPTH_THRESHOLD\` from 283 → 288 to restore adequate CI headroom.

The proximity guard fired at 281/283 (2 headroom). Following the established bump-and-ratchet pattern:
- 281 violations + 7 headroom = **288**
- New \`warn_at = 288 - 5 = 283\` → guard fires at 284 violations, preventing saturation

Also backfills 3 missing history table entries in \`complexity-thresholds-history.md\` (GH#19235, GH#19288, GH#19323 were present in the conf file inline comments but absent from the history table).

## Files Changed

- EDIT: \`.agents/configs/complexity-thresholds.conf\` — bumped \`NESTING_DEPTH_THRESHOLD\` 283→288 + added GH#19342 comment
- EDIT: \`.agents/configs/complexity-thresholds-history.md\` — backfilled GH#19235/GH#19288/GH#19323 + added GH#19342 row

## Verification

CI \`Complexity Analysis\` check should pass with \`NESTING_DEPTH_THRESHOLD=288\` and the current 281 violations (7 headroom).

Resolves #19342