### PR TITLE
t2146: memory-pressure-monitor bash 3.2 compat + re-exec guard

### DIFF
--- a/.agents/scripts/memory-pressure-monitor.sh
+++ b/.agents/scripts/memory-pressure-monitor.sh
@@ -64,6 +64,29 @@
 
 set -euo pipefail
 
+# --- Bash 3.2 re-exec self-heal (GH#19348, t2146) ----------------------------
+# This script uses `${var,,}` case conversion at lines ~463-466 (bash 4.0+)
+# to avoid `tr` subprocess forks in the pattern-matcher hot path. Running
+# under /bin/bash 3.2 on macOS the script aborts with "bad substitution"
+# before it can do any useful work. The associative-array maps at the old
+# lines 399/508 were already converted to sparse indexed arrays as a first
+# line of defense, but the case-conversion path is the showstopper.
+#
+# Sourcing shared-constants.sh triggers the framework-wide re-exec guard:
+# if this script is invoked under bash < 4 AND a modern bash is available
+# at /opt/homebrew/bin/bash, /usr/local/bin/bash, or linuxbrew, the guard
+# transparently re-execs this script under the modern bash. Transparent
+# self-heal; no behaviour change on bash 4+.
+#
+# If no modern bash is installed (user set AIDEVOPS_AUTO_UPGRADE_BASH=0),
+# the guard falls through and the script fails loudly on the first bash 4+
+# construct — the right signal for a configuration that deliberately opts
+# out of the upgrade path.
+_MEMPRESS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit 1
+# shellcheck source=/dev/null
+source "${_MEMPRESS_DIR}/shared-constants.sh"
+unset _MEMPRESS_DIR
+
 # --- Configuration -----------------------------------------------------------
 
 readonly SCRIPT_NAME="memory-pressure-monitor"
@@ -395,14 +418,15 @@ _batch_get_process_ages() {
 	local ps_age_output
 	ps_age_output=$(ps -p "$pid_csv" -o pid=,etime= 2>/dev/null || true)
 
-	# Build a lookup from the ps output
-	local -A etime_map
+	# Build a PID→etime lookup. PIDs are numeric, so a sparse indexed array
+	# is a drop-in for an associative array and works on bash 3.2 (GH#19348).
+	local -a etime_map=()
 	local p_pid p_etime
 	while IFS= read -r line; do
 		[[ -z "$line" ]] && continue
 		read -r p_pid p_etime <<<"$line"
 		[[ "$p_pid" =~ ^[0-9]+$ ]] || continue
-		etime_map["$p_pid"]="${p_etime:-}"
+		etime_map[$p_pid]="${p_etime:-}"
 	done <<<"$ps_age_output"
 
 	# Convert etime strings to seconds for each requested PID
@@ -504,14 +528,16 @@ _resolve_ages_and_emit() {
 		return 0
 	fi
 
-	# Batch-fetch process ages for all matched PIDs in a single ps call
-	local -A age_map
+	# Batch-fetch process ages for all matched PIDs in a single ps call.
+	# PIDs are numeric, so a sparse indexed array replaces the associative
+	# array (bash 4.0+ only) with identical semantics on bash 3.2 (GH#19348).
+	local -a age_map=()
 	local age_line age_pid age_secs
 	while IFS= read -r age_line; do
 		[[ -z "$age_line" ]] && continue
 		read -r age_pid age_secs <<<"$age_line"
 		[[ "$age_pid" =~ ^[0-9]+$ ]] || continue
-		age_map["$age_pid"]="${age_secs:-0}"
+		age_map[$age_pid]="${age_secs:-0}"
 	done < <(_batch_get_process_ages "${seen_pids[@]}")
 
 	# Emit final rows with ages, then sort by RSS descending

--- a/todo/tasks/t2146-brief.md
+++ b/todo/tasks/t2146-brief.md
@@ -1,0 +1,74 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# t2146: memory-pressure-monitor Bash 3.2 compat + re-exec guard
+
+## Origin
+
+- **Created:** 2026-04-16
+- **Session:** opencode:interactive (claude-opus-4-6)
+- **Created by:** Marcus Quinn (ai-interactive)
+- **Parent task:** n/a
+- **Conversation context:** Investigating a `Code Quality Analysis` failure on PR #19344 (`t2142: harden consolidation gate against unset threshold vars`). The failing job was `Bash 3.2 Compatibility`: 78 violations vs threshold 76. Root cause analysis showed PR #19344 itself introduced zero violations — the drift came from three previously-merged PRs (`memory-pressure-monitor.sh` assoc arrays from 2026-04-08, `pre-dispatch-validator-helper.sh` assoc array from 2026-04-15 via PR #19120). Runtime safety analysis showed `memory-pressure-monitor.sh` is the only one that genuinely needs fixing at runtime: `pre-dispatch-validator-helper.sh` already sources `shared-constants.sh` so the re-exec guard protects it; `memory-pressure-monitor.sh` does NOT and crashes under `/bin/bash` 3.2 on the first `${cmd_name,,}` case-conversion at line 465.
+
+## What
+
+Two orthogonal fixes to `.agents/scripts/memory-pressure-monitor.sh`:
+
+1. **Scanner fix** — convert the two `local -A` PID→value maps to sparse `local -a` indexed arrays. PIDs are numeric, so indexed arrays are a drop-in replacement with identical semantics. Drops the scanner count 78 → 76 (back at threshold).
+2. **Runtime fix** — add `source "${_MEMPRESS_DIR}/shared-constants.sh"` near the top so the framework's re-exec guard transparently upgrades `/bin/bash` 3.2 invocations to modern bash. This is required because the script uses `${cmd_name,,}` case conversion (bash 4+) at lines ~463-466 which the scanner does NOT detect but which crashes on 3.2 with `bad substitution`.
+
+## Why
+
+- Unblocks PR #19344 and every future PR from the same ratchet regression.
+- Fixes a real runtime bug — the script currently fails on macOS `/bin/bash` 3.2 invocations even though it's registered as a launchd agent (which uses `/bin/bash`). Silent breakage that's only masked because users running `setup.sh` get `shared-constants.sh` auto-upgrades on scripts that source it.
+- Parallel indexed arrays vs associative arrays are semantically identical for numeric keys — zero regression risk for bash 4+ users (Linux CI, upgraded macOS).
+
+## Tier
+
+**Selected tier:** `tier:standard`
+
+**Tier rationale:** 1 file (`memory-pressure-monitor.sh`, 1340 lines). File >500 lines disqualifies tier:simple per the default list. The two array-type changes are near-mechanical; the new source block is a copy of the pattern already used by `pre-dispatch-validator-helper.sh:39`.
+
+## PR Conventions
+
+Leaf issue — uses `Resolves #19348`.
+
+## How
+
+### Files Modified
+
+- `EDIT: .agents/scripts/memory-pressure-monitor.sh:65-67` — add re-exec guard source block right after `set -euo pipefail`
+- `EDIT: .agents/scripts/memory-pressure-monitor.sh:417` — `local -A etime_map` → `local -a etime_map=()`
+- `EDIT: .agents/scripts/memory-pressure-monitor.sh:526` — `local -A age_map` → `local -a age_map=()`
+
+### Reference pattern
+
+`pre-dispatch-validator-helper.sh:36-39` — canonical `SCRIPT_DIR` + `source shared-constants.sh` block.
+
+### Verification
+
+1. `shellcheck .agents/scripts/memory-pressure-monitor.sh` — clean ✓
+2. `/bin/bash -n .agents/scripts/memory-pressure-monitor.sh` — parse check passes ✓
+3. `/bin/bash .agents/scripts/memory-pressure-monitor.sh --status` — re-exec fires, full output renders ✓
+4. `/opt/homebrew/bin/bash .agents/scripts/memory-pressure-monitor.sh --status` — direct run, full output ✓
+5. `AIDEVOPS_BASH_REEXECED=1 /bin/bash .agents/scripts/memory-pressure-monitor.sh --status` — guard skipped, fails loudly at line 488 `${cmd_name,,}` as expected (opt-out behaves correctly) ✓
+6. Local scanner run across the tree: `Total violations: 76` — exactly at threshold ✓
+
+## Acceptance criteria
+
+- [ ] Both `local -A` → `local -a` conversions applied
+- [ ] Re-exec guard source block present at top of file
+- [ ] Shellcheck clean
+- [ ] `/bin/bash` smoke test succeeds (re-exec fires)
+- [ ] CI `Bash 3.2 Compatibility` check passes (count ≤ 76)
+- [ ] PR merged
+- [ ] #19348 closed via `Resolves`
+
+## Out of scope
+
+- `pre-dispatch-validator-helper.sh:55` associative array — already protected by re-exec guard (it sources `shared-constants.sh`), low priority.
+- Refactoring the `${var,,}` call sites to `tr '[:upper:]' '[:lower:]'` — not needed, re-exec guard handles this.
+- Ratcheting the threshold 76 → 75 after this merge — tracked as a follow-up when the `pre-dispatch-validator-helper.sh` case is also cleaned.
+
+Resolves #19348


### PR DESCRIPTION
## Summary

Two orthogonal fixes to `.agents/scripts/memory-pressure-monitor.sh`:

1. **Scanner fix** — convert the two `local -A` PID→value maps to sparse `local -a` indexed arrays. PIDs are numeric, so indexed arrays are a drop-in replacement with identical semantics. Drops the bash32-compat scanner count **78 → 76** (back at `.agents/configs/complexity-thresholds.conf:BASH32_COMPAT_THRESHOLD`).

2. **Runtime fix** — add `source "${_MEMPRESS_DIR}/shared-constants.sh"` near the top so the framework's re-exec guard transparently upgrades `/bin/bash` 3.2 invocations to modern bash. Required because the script uses `${cmd_name,,}` case-conversion (bash 4+) at lines ~463-466 which the scanner does NOT detect but which crashes on 3.2 with `bad substitution`. Re-exec pattern established at `pre-dispatch-validator-helper.sh:36-39`.

## Why

- Unblocks PR #19344 and every future PR from the same ratchet regression (`Code Quality Analysis` > `Bash 3.2 Compatibility` was at 78/76 for hours).
- Fixes a real launchd-invocation runtime bug — the script is registered as a launchd agent (`sh.aidevops.memory-pressure-monitor`) which invokes `/bin/bash`. Silent breakage masked only because macOS users running `setup.sh` get auto-installed modern bash and the re-exec guard fires from *other* scripts that source `shared-constants.sh`.
- Parallel indexed arrays vs associative arrays are semantically identical for numeric keys — zero regression risk for bash 4+ users (Linux CI, upgraded macOS).

## Runtime Testing

- **Risk level:** Low (infrastructure script, mechanical swap + established pattern re-use)
- `shellcheck .agents/scripts/memory-pressure-monitor.sh` → clean
- `/bin/bash -n .agents/scripts/memory-pressure-monitor.sh` → parse check passes
- `/bin/bash .agents/scripts/memory-pressure-monitor.sh --status` → re-exec fires, full output renders correctly (18 processes, RSS totals, swap metrics)
- `/opt/homebrew/bin/bash .agents/scripts/memory-pressure-monitor.sh --status` → direct run under bash 5, identical output
- `AIDEVOPS_BASH_REEXECED=1 /bin/bash .agents/scripts/memory-pressure-monitor.sh --status` → guard skipped, fails loudly at line 488 `${cmd_name,,}: bad substitution` (correct opt-out behaviour)
- Local scanner run on full tree: `Total violations: 76` — exactly at threshold

## Files Changed

- `.agents/scripts/memory-pressure-monitor.sh` — 2× `-A` → `-a`, new re-exec guard block
- `todo/tasks/t2146-brief.md` — task brief

Resolves #19348
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.59 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-opus-4-6 spent 14m and 34,505 tokens on this with the user in an interactive session.