### PR TITLE
t2147: contributor insight pipeline — session-miner upstream issue filing with privacy sanitization

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -171,6 +171,7 @@ Set fields based on the repo's purpose:
 - `local_only: true` — no remote; skip all `gh` operations.
 - `priority` — `"tooling"` (infrastructure), `"product"` (user-facing), `"profile"` (docs-only).
 - `maintainer` — GitHub username. Used by code-simplifier and maintainer-gated workflows. Auto-detected from `gh api user`; falls back to slug owner.
+- `role` — `"maintainer"` or `"contributor"` (t2145/t2147). Controls which pulse scanners run against the repo. **Maintainer** (default for repos you own): all scanners. **Contributor** (default for repos owned by others): session-miner insights only — the session-miner files sanitized `contributor-insight` issues upstream from instruction candidates and error patterns detected in the contributor's own sessions. Privacy: strips private repo slugs, local file paths, credentials, and email addresses. Auto-detected from slug owner vs `gh api user` when omitted.
 
 **Cross-repo task creation**: When creating a task in a *different* repo, follow the full workflow — not just the TODO edit:
 

--- a/.agents/scripts/contributor-insight-helper.sh
+++ b/.agents/scripts/contributor-insight-helper.sh
@@ -1,0 +1,348 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# contributor-insight-helper.sh — File privacy-sanitized upstream issues from
+# session-miner output for contributor-role repos (t2147).
+#
+# When a contributor runs aidevops with a repo they don't own in repos.json
+# (role: contributor), the session-miner still runs locally and detects
+# instruction candidates, steerage patterns, and error trends. This helper
+# takes the compressed_signals.json output and:
+#   1. Filters for framework-relevant signals (not project-specific)
+#   2. Privacy-sanitizes: strips private repo slugs, file paths outside
+#      ~/.aidevops/agents/, client/project names, credential patterns
+#   3. Deduplicates against existing open issues on the target repo
+#   4. Files upstream issues tagged origin:contributor-insight
+#
+# Usage:
+#   contributor-insight-helper.sh file <compressed_signals.json> <target_slug>
+#   contributor-insight-helper.sh file --dry-run <compressed_signals.json> <target_slug>
+#   contributor-insight-helper.sh sanitize <text>    # test sanitization
+#
+# Env:
+#   CONTRIBUTOR_INSIGHT_MAX_ISSUES (default 3) — cap per run
+#   CONTRIBUTOR_INSIGHT_MIN_CONFIDENCE (default 0.65) — instruction candidate threshold
+#
+# Called by: session-miner-pulse.sh (for contributor-role repos)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit 1
+# shellcheck source=shared-constants.sh
+[[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
+
+REPOS_JSON="${REPOS_JSON:-${HOME}/.config/aidevops/repos.json}"
+MAX_ISSUES="${CONTRIBUTOR_INSIGHT_MAX_ISSUES:-3}"
+MIN_CONFIDENCE="${CONTRIBUTOR_INSIGHT_MIN_CONFIDENCE:-0.65}"
+
+# --- Logging ---
+
+_ci_log() {
+	local level="$1"
+	local msg="$2"
+	printf '[contributor-insight] %s: %s\n' "$level" "$msg" >&2
+	return 0
+}
+
+# --- Privacy sanitization ---
+
+# _load_private_slugs outputs one slug per line from repos.json entries
+# that have mirror_upstream or local_only (same logic as privacy-guard).
+_load_private_slugs() {
+	if [[ ! -f "$REPOS_JSON" ]]; then
+		return 0
+	fi
+	jq -r '.initialized_repos[]
+		| select((.mirror_upstream // false) == true or (.local_only // false) == true)
+		| .slug // empty' "$REPOS_JSON" 2>/dev/null || true
+	# Also load extra slugs file if present
+	local extras="${HOME}/.aidevops/configs/privacy-guard-extra-slugs.txt"
+	if [[ -f "$extras" ]]; then
+		grep -v '^#' "$extras" 2>/dev/null | grep -v '^$' || true
+	fi
+	return 0
+}
+
+# sanitize_text strips private slugs, non-framework file paths,
+# credential patterns, and home directory references from text.
+# Arguments: $1 — text to sanitize
+# Outputs: sanitized text to stdout
+sanitize_text() {
+	local text="$1"
+
+	# 1. Strip private repo slugs
+	local slug
+	while IFS= read -r slug; do
+		[[ -z "$slug" ]] && continue
+		# Escape for sed
+		local escaped
+		escaped=$(printf '%s' "$slug" | sed 's/[.[\/*^$]/\\&/g')
+		text=$(printf '%s' "$text" | sed "s|${escaped}|[private-repo]|g")
+	done < <(_load_private_slugs)
+
+	# 2. Strip absolute file paths outside .agents/ (user project paths)
+	text=$(printf '%s' "$text" | sed -E 's|/Users/[^ ]*|[local-path]|g')
+	text=$(printf '%s' "$text" | sed -E 's|/home/[^ ]*|[local-path]|g')
+	text=$(printf '%s' "$text" | sed -E 's|~/Git/[^ ]*|[local-path]|g')
+
+	# 3. Strip credential patterns (API keys, tokens)
+	text=$(printf '%s' "$text" | sed -E 's/(sk-|ghp_|gho_|ghs_|ghu_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}/[redacted-credential]/g')
+
+	# 4. Strip email addresses
+	text=$(printf '%s' "$text" | sed -E 's/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/[email]/g')
+
+	printf '%s' "$text"
+	return 0
+}
+
+# --- Issue body composition ---
+
+# _compose_instruction_issue builds an issue body from instruction candidates.
+# Arguments: $1 — JSON array of candidates (from jq), $2 — contributor gh user
+_compose_instruction_issue() {
+	local candidates_json="$1"
+	local contributor_user="$2"
+
+	local body=""
+	body+="## Contributor Insight: Instruction Candidates"$'\n\n'
+	body+="Detected from real usage sessions by contributor \`${contributor_user}\`."$'\n'
+	body+="These patterns were flagged as persistent guidance that may benefit all users."$'\n\n'
+	body+="<!-- aidevops:generator=contributor-insight-helper -->"$'\n\n'
+
+	# Parse candidates and append
+	local count
+	count=$(printf '%s' "$candidates_json" | jq -r 'length' 2>/dev/null) || count=0
+	local i=0
+	while [[ "$i" -lt "$count" && "$i" -lt 10 ]]; do
+		local conf cat text
+		conf=$(printf '%s' "$candidates_json" | jq -r ".[$i].confidence // 0" 2>/dev/null) || conf="0"
+		cat=$(printf '%s' "$candidates_json" | jq -r ".[$i].category // \"general\"" 2>/dev/null) || cat="general"
+		text=$(printf '%s' "$candidates_json" | jq -r ".[$i].text // \"\"" 2>/dev/null) || text=""
+		[[ -z "$text" ]] && {
+			i=$((i + 1))
+			continue
+		}
+
+		# Sanitize the candidate text
+		text=$(sanitize_text "$text")
+		# Truncate for readability
+		[[ ${#text} -gt 300 ]] && text="${text:0:300}..."
+
+		body+="### ${cat} (confidence: ${conf})"$'\n\n'
+		body+="> ${text}"$'\n\n'
+		i=$((i + 1))
+	done
+
+	body+="---"$'\n'
+	body+="*Filed automatically by contributor-insight-helper.sh (t2147).*"$'\n'
+	body+="*Review these for inclusion in AGENTS.md or build.txt.*"
+
+	printf '%s' "$body"
+	return 0
+}
+
+# _compose_error_pattern_issue builds an issue body from error patterns.
+_compose_error_pattern_issue() {
+	local patterns_json="$1"
+	local contributor_user="$2"
+
+	local body=""
+	body+="## Contributor Insight: Error Patterns"$'\n\n'
+	body+="Detected from real usage sessions by contributor \`${contributor_user}\`."$'\n'
+	body+="These recurring tool failure patterns may indicate framework gaps."$'\n\n'
+	body+="<!-- aidevops:generator=contributor-insight-helper -->"$'\n\n'
+
+	local count
+	count=$(printf '%s' "$patterns_json" | jq -r 'length' 2>/dev/null) || count=0
+	local i=0
+	while [[ "$i" -lt "$count" && "$i" -lt 10 ]]; do
+		local tool category pcount models
+		tool=$(printf '%s' "$patterns_json" | jq -r ".[$i].tool // \"unknown\"" 2>/dev/null) || tool="unknown"
+		category=$(printf '%s' "$patterns_json" | jq -r ".[$i].error_category // \"other\"" 2>/dev/null) || category="other"
+		pcount=$(printf '%s' "$patterns_json" | jq -r ".[$i].count // 0" 2>/dev/null) || pcount=0
+		models=$(printf '%s' "$patterns_json" | jq -r ".[$i].model_count // 0" 2>/dev/null) || models=0
+
+		body+="- \`${tool}:${category}\` — ${pcount}x across ${models} model(s)"$'\n'
+		i=$((i + 1))
+	done
+
+	body+=$'\n'"---"$'\n'
+	body+="*Filed automatically by contributor-insight-helper.sh (t2147).*"
+
+	printf '%s' "$body"
+	return 0
+}
+
+# --- Dedup ---
+
+# _issue_exists checks if a similar contributor-insight issue already exists.
+# Arguments: $1 — target slug, $2 — search query
+_issue_exists() {
+	local slug="$1"
+	local query="$2"
+
+	local existing
+	existing=$(gh issue list --repo "$slug" --state open \
+		--label "contributor-insight" \
+		--search "$query" \
+		--limit 1 --json number --jq 'length' 2>/dev/null) || existing="0"
+	[[ "$existing" != "0" ]]
+	return $?
+}
+
+# --- Main commands ---
+
+cmd_file() {
+	local dry_run=false
+	if [[ "${1:-}" == "--dry-run" ]]; then
+		dry_run=true
+		shift
+	fi
+
+	local compressed_file="${1:-}"
+	local target_slug="${2:-}"
+
+	if [[ -z "$compressed_file" || -z "$target_slug" ]]; then
+		_ci_log ERROR "Usage: contributor-insight-helper.sh file [--dry-run] <compressed_signals.json> <target_slug>"
+		return 1
+	fi
+
+	if [[ ! -f "$compressed_file" ]]; then
+		_ci_log ERROR "Compressed signals file not found: ${compressed_file}"
+		return 1
+	fi
+
+	if ! command -v gh >/dev/null 2>&1; then
+		_ci_log ERROR "gh CLI not found"
+		return 1
+	fi
+
+	local contributor_user
+	contributor_user=$(gh api user --jq '.login' 2>/dev/null) || contributor_user="unknown"
+
+	local issues_created=0
+
+	# --- Instruction candidates ---
+	# Extract high-confidence candidates targeting build.txt or AGENTS.md
+	local candidates
+	candidates=$(jq -c '
+		[
+			.instruction_candidates
+			| to_entries[]
+			| .value[]
+			| select(.confidence >= '"$MIN_CONFIDENCE"')
+		]
+		| sort_by(-.confidence)
+		| .[:10]
+	' "$compressed_file" 2>/dev/null) || candidates="[]"
+
+	local candidate_count
+	candidate_count=$(printf '%s' "$candidates" | jq -r 'length' 2>/dev/null) || candidate_count=0
+
+	if [[ "$candidate_count" -gt 0 && "$issues_created" -lt "$MAX_ISSUES" ]]; then
+		local title="Contributor insight: ${candidate_count} instruction candidate(s) from ${contributor_user}"
+
+		if _issue_exists "$target_slug" "instruction candidate"; then
+			_ci_log INFO "Instruction candidates issue already exists — skipping"
+		else
+			local body
+			body=$(_compose_instruction_issue "$candidates" "$contributor_user")
+
+			if [[ "$dry_run" == true ]]; then
+				_ci_log INFO "DRY RUN: would create issue: ${title}"
+				printf '%s\n' "$body"
+			else
+				if gh issue create --repo "$target_slug" \
+					--title "$title" \
+					--body "$body" \
+					--label "contributor-insight" 2>/dev/null; then
+					_ci_log INFO "Created issue: ${title}"
+					issues_created=$((issues_created + 1))
+				else
+					_ci_log ERROR "Failed to create instruction candidates issue"
+				fi
+			fi
+		fi
+	fi
+
+	# --- Error patterns (high-frequency, cross-model) ---
+	local error_patterns
+	error_patterns=$(jq -c '
+		[
+			.errors.patterns[]
+			| select(.count >= 20 and .model_count >= 2)
+		]
+		| sort_by(-.count)
+		| .[:10]
+	' "$compressed_file" 2>/dev/null) || error_patterns="[]"
+
+	local error_count
+	error_count=$(printf '%s' "$error_patterns" | jq -r 'length' 2>/dev/null) || error_count=0
+
+	if [[ "$error_count" -gt 0 && "$issues_created" -lt "$MAX_ISSUES" ]]; then
+		local error_title="Contributor insight: ${error_count} recurring error pattern(s) from ${contributor_user}"
+
+		if _issue_exists "$target_slug" "error pattern"; then
+			_ci_log INFO "Error patterns issue already exists — skipping"
+		else
+			local error_body
+			error_body=$(_compose_error_pattern_issue "$error_patterns" "$contributor_user")
+
+			if [[ "$dry_run" == true ]]; then
+				_ci_log INFO "DRY RUN: would create issue: ${error_title}"
+				printf '%s\n' "$error_body"
+			else
+				if gh issue create --repo "$target_slug" \
+					--title "$error_title" \
+					--body "$error_body" \
+					--label "contributor-insight" 2>/dev/null; then
+					_ci_log INFO "Created issue: ${error_title}"
+					issues_created=$((issues_created + 1))
+				else
+					_ci_log ERROR "Failed to create error patterns issue"
+				fi
+			fi
+		fi
+	fi
+
+	_ci_log INFO "Complete: ${issues_created} issue(s) created (cap=${MAX_ISSUES})"
+	return 0
+}
+
+cmd_sanitize() {
+	local text="${1:-}"
+	if [[ -z "$text" ]]; then
+		_ci_log ERROR "Usage: contributor-insight-helper.sh sanitize <text>"
+		return 1
+	fi
+	sanitize_text "$text"
+	printf '\n'
+	return 0
+}
+
+# --- Entry point ---
+
+main() {
+	local cmd="${1:-help}"
+	shift || true
+
+	case "$cmd" in
+	file)
+		cmd_file "$@"
+		;;
+	sanitize)
+		cmd_sanitize "$@"
+		;;
+	help | --help | -h)
+		printf 'Usage: contributor-insight-helper.sh {file|sanitize|help}\n'
+		printf '  file [--dry-run] <compressed_signals.json> <target_slug>\n'
+		printf '  sanitize <text>\n'
+		return 0
+		;;
+	*)
+		_ci_log ERROR "Unknown command: ${cmd}"
+		return 1
+		;;
+	esac
+}
+
+main "$@"

--- a/.agents/scripts/session-miner-pulse.sh
+++ b/.agents/scripts/session-miner-pulse.sh
@@ -764,6 +764,8 @@ output_results() {
 		if [[ "${create_issues}" == true ]]; then
 			create_feedback_issues "${_feedback_actions_file}" "${dry_run}" || true
 		fi
+		# t2147: file contributor insights for contributor-role repos
+		file_contributor_insights "${dry_run}" || true
 		echo "--- Would log TODO suggestions to relevant repos ---"
 	else
 		echo "${summary}"
@@ -771,6 +773,8 @@ output_results() {
 		if [[ "${create_issues}" == true ]]; then
 			create_feedback_issues "${_feedback_actions_file}" "${dry_run}" || true
 		fi
+		# t2147: file contributor insights for contributor-role repos
+		file_contributor_insights "${dry_run}" || true
 		record_pulse
 		log_info "Pulse complete. Output: ${_output_dir}"
 		log_info "Compressed signals: ${_compressed_file}"
@@ -778,6 +782,63 @@ output_results() {
 		log_info "Feedback report: ${_feedback_report_file}"
 		log_info "Run 'opencode run --dir ~/Git/REPO --title \"Session miner analysis\" \"Analyse ${_compressed_file} against the current harness and suggest improvements\"' for deep analysis."
 	fi
+	return 0
+}
+
+# file_contributor_insights files sanitized upstream issues for repos where
+# the user is a contributor (role != maintainer). Uses compressed signals
+# from the current pulse run. Skips if no contributor-role repos found.
+# Arguments: $1 — dry_run (true/false)
+file_contributor_insights() {
+	local dry_run="$1"
+
+	local insight_helper="${SCRIPT_DIR}/contributor-insight-helper.sh"
+	if [[ ! -x "$insight_helper" ]]; then
+		return 0
+	fi
+
+	local repos_json="${HOME}/.config/aidevops/repos.json"
+	if [[ ! -f "$repos_json" ]]; then
+		return 0
+	fi
+
+	if ! command -v jq >/dev/null 2>&1; then
+		return 0
+	fi
+
+	# Get current gh user for auto-detect
+	local gh_user
+	gh_user=$(gh api user --jq '.login' 2>/dev/null) || gh_user=""
+
+	# Find contributor-role repos (explicit or auto-detected)
+	local slug
+	while IFS= read -r slug; do
+		[[ -n "$slug" ]] || continue
+
+		# Check explicit role first
+		local explicit_role
+		explicit_role=$(jq -r --arg s "$slug" '.initialized_repos[] | select(.slug == $s) | .role // ""' "$repos_json" 2>/dev/null) || explicit_role=""
+
+		local is_contributor=false
+		if [[ "$explicit_role" == "contributor" ]]; then
+			is_contributor=true
+		elif [[ -z "$explicit_role" && -n "$gh_user" ]]; then
+			# Auto-detect: different owner = contributor
+			local owner="${slug%%/*}"
+			if [[ "$owner" != "$gh_user" ]]; then
+				is_contributor=true
+			fi
+		fi
+
+		if [[ "$is_contributor" == true ]]; then
+			log_info "Filing contributor insights for ${slug}..."
+			local dr_flag=""
+			[[ "$dry_run" == true ]] && dr_flag="--dry-run"
+			# shellcheck disable=SC2086
+			"$insight_helper" file $dr_flag "${_compressed_file}" "$slug" 2>&1 || true
+		fi
+	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug' "$repos_json" 2>/dev/null)
+
 	return 0
 }
 

--- a/.agents/scripts/tests/test-contributor-insight-helper.sh
+++ b/.agents/scripts/tests/test-contributor-insight-helper.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-contributor-insight-helper.sh — Unit tests for contributor-insight-helper.sh (t2147)
+#
+# Tests privacy sanitization, issue body composition, and dry-run filing.
+#
+# Usage: bash .agents/scripts/tests/test-contributor-insight-helper.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PARENT_DIR="${SCRIPT_DIR}/.."
+HELPER="${PARENT_DIR}/contributor-insight-helper.sh"
+
+# --- Test harness ---
+_TESTS_RUN=0
+_TESTS_PASSED=0
+_TESTS_FAILED=0
+
+assert_eq() {
+	local description="$1"
+	local expected="$2"
+	local actual="$3"
+	_TESTS_RUN=$((_TESTS_RUN + 1))
+	if [[ "$expected" == "$actual" ]]; then
+		_TESTS_PASSED=$((_TESTS_PASSED + 1))
+		printf '  PASS: %s\n' "$description"
+	else
+		_TESTS_FAILED=$((_TESTS_FAILED + 1))
+		printf '  FAIL: %s\n    expected: %s\n    actual:   %s\n' "$description" "$expected" "$actual"
+	fi
+	return 0
+}
+
+assert_contains() {
+	local description="$1"
+	local needle="$2"
+	local haystack="$3"
+	_TESTS_RUN=$((_TESTS_RUN + 1))
+	if [[ "$haystack" == *"$needle"* ]]; then
+		_TESTS_PASSED=$((_TESTS_PASSED + 1))
+		printf '  PASS: %s\n' "$description"
+	else
+		_TESTS_FAILED=$((_TESTS_FAILED + 1))
+		printf '  FAIL: %s (needle not found in output)\n    needle: %s\n' "$description" "$needle"
+	fi
+	return 0
+}
+
+assert_not_contains() {
+	local description="$1"
+	local needle="$2"
+	local haystack="$3"
+	_TESTS_RUN=$((_TESTS_RUN + 1))
+	if [[ "$haystack" != *"$needle"* ]]; then
+		_TESTS_PASSED=$((_TESTS_PASSED + 1))
+		printf '  PASS: %s\n' "$description"
+	else
+		_TESTS_FAILED=$((_TESTS_FAILED + 1))
+		printf '  FAIL: %s (needle should NOT be present but was found)\n    needle: %s\n' "$description" "$needle"
+	fi
+	return 0
+}
+
+# --- Setup ---
+TMPDIR_TEST=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+# Create test repos.json with a private repo
+TEST_REPOS_JSON="${TMPDIR_TEST}/repos.json"
+cat >"$TEST_REPOS_JSON" <<'JSON'
+{
+  "initialized_repos": [
+    {
+      "slug": "secret-corp/private-api",
+      "local_only": true,
+      "pulse": false
+    },
+    {
+      "slug": "client/secret-project",
+      "mirror_upstream": true,
+      "pulse": false
+    }
+  ],
+  "git_parent_dirs": []
+}
+JSON
+
+# Create test compressed_signals.json
+TEST_SIGNALS="${TMPDIR_TEST}/compressed_signals.json"
+cat >"$TEST_SIGNALS" <<'JSON'
+{
+  "instruction_candidates": {
+    ".agents/prompts/build.txt": [
+      {
+        "text": "we should always use worktrees, never branches directly at /Users/testuser/Git/secret-corp/private-api",
+        "confidence": 0.80,
+        "category": "git_workflow",
+        "session_title": "Working on secret-corp/private-api feature"
+      },
+      {
+        "text": "prefer printf over echo -e for bash 3.2 compat",
+        "confidence": 0.75,
+        "category": "code_style",
+        "session_title": "Shell hardening session"
+      },
+      {
+        "text": "low confidence throwaway",
+        "confidence": 0.40,
+        "category": "general",
+        "session_title": "Random session"
+      }
+    ]
+  },
+  "errors": {
+    "patterns": [
+      {
+        "tool": "edit",
+        "error_category": "not_read_first",
+        "count": 50,
+        "model_count": 3,
+        "models": ["sonnet", "haiku", "opus"],
+        "severity": "high"
+      },
+      {
+        "tool": "bash",
+        "error_category": "file_not_found",
+        "count": 200,
+        "model_count": 4,
+        "models": ["sonnet", "haiku", "opus", "gpt-4o"],
+        "severity": "medium"
+      },
+      {
+        "tool": "glob",
+        "error_category": "other",
+        "count": 5,
+        "model_count": 1,
+        "models": ["sonnet"],
+        "severity": "low"
+      }
+    ]
+  },
+  "steerage": {}
+}
+JSON
+
+echo "=== Sanitization Tests ==="
+
+# Override REPOS_JSON for the helper
+export REPOS_JSON="$TEST_REPOS_JSON"
+
+# Source the helper functions for direct testing
+# We can't source the whole file (it has main "$@"), so test via the CLI
+
+# Test 1: Private slugs are redacted
+result=$(bash "$HELPER" sanitize "Check secret-corp/private-api and client/secret-project repos")
+assert_not_contains "private slug 1 redacted" "secret-corp/private-api" "$result"
+assert_not_contains "private slug 2 redacted" "client/secret-project" "$result"
+assert_contains "replacement present" "[private-repo]" "$result"
+
+# Test 2: Home directory paths are redacted
+result=$(bash "$HELPER" sanitize "Error at /Users/marcusquinn/Git/myproject/src/main.rs:42")
+assert_not_contains "home path redacted" "/Users/marcusquinn" "$result"
+assert_contains "path replacement present" "[local-path]" "$result"
+
+# Test 3: API keys are redacted
+result=$(bash "$HELPER" sanitize "Set OPENAI_API_KEY=sk-abc123def456ghi789jkl012mno345pqr678stu901vwx in your env")
+assert_not_contains "API key redacted" "sk-abc123" "$result"
+assert_contains "credential replacement present" "[redacted-credential]" "$result"
+
+# Test 4: GitHub tokens are redacted
+result=$(bash "$HELPER" sanitize "Use ghp_1234567890abcdefghijklmnop for auth")
+assert_not_contains "GH token redacted" "ghp_1234567890" "$result"
+
+# Test 5: Email addresses are redacted
+result=$(bash "$HELPER" sanitize "Contact user@company.com for access")
+assert_not_contains "email redacted" "user@company.com" "$result"
+assert_contains "email replacement present" "[email]" "$result"
+
+# Test 6: Safe text passes through unchanged
+result=$(bash "$HELPER" sanitize "always use worktrees instead of branches")
+assert_eq "safe text unchanged" "always use worktrees instead of branches" "$result"
+
+echo ""
+echo "=== Dry-Run Filing Tests ==="
+
+# Test 7: dry-run with instruction candidates
+output=$(bash "$HELPER" file --dry-run "$TEST_SIGNALS" "marcusquinn/aidevops" 2>&1) || true
+assert_contains "dry-run mentions instruction candidates" "instruction candidate" "$output"
+assert_contains "dry-run creates issue" "DRY RUN" "$output"
+
+# Test 8: dry-run sanitizes content in issue body
+assert_not_contains "issue body has no private slugs" "secret-corp/private-api" "$output"
+assert_not_contains "issue body has no home paths" "/Users/testuser" "$output"
+
+# Test 9: low-confidence candidates filtered out
+assert_not_contains "low confidence filtered" "low confidence throwaway" "$output"
+
+# Test 10: high-confidence candidates included
+assert_contains "high confidence included" "worktrees" "$output"
+assert_contains "bash compat included" "printf" "$output"
+
+echo ""
+echo "=== Error Pattern Tests ==="
+
+# Test 11: high-frequency error patterns are included
+assert_contains "edit:not_read_first in output" "not_read_first" "$output"
+assert_contains "bash:file_not_found in output" "file_not_found" "$output"
+
+# Test 12: low-frequency errors filtered (count < 20 or model_count < 2)
+assert_not_contains "low-freq glob:other filtered" "glob:other" "$output"
+
+echo ""
+echo "=== Help Command ==="
+
+# Test 13: help command works
+help_output=$(bash "$HELPER" help 2>&1) || true
+assert_contains "help shows usage" "Usage:" "$help_output"
+
+echo ""
+echo "Results: ${_TESTS_PASSED}/${_TESTS_RUN} passed, ${_TESTS_FAILED} failed"
+
+if [[ "$_TESTS_FAILED" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- New `contributor-insight-helper.sh` — takes session-miner output and files privacy-sanitized issues upstream for contributor-role repos
- Privacy sanitization layer strips private slugs, local paths, credentials, and emails before any content leaves the contributor's machine
- Integrated into `session-miner-pulse.sh` — runs automatically after the existing feedback loop for contributor-role repos
- 22/22 test assertions covering sanitization, dry-run filing, confidence filtering, and error pattern thresholds

## Context

Companion to PR #19350 (t2145: role guard). That PR gates scanners that re-scrape repo data the maintainer already has. This PR builds the value channel in the opposite direction: contributors surface insights from their own usage sessions that only they can observe — instruction candidates ("always use worktrees!"), recurring error patterns, and workflow friction — sanitized and filed upstream as `contributor-insight` issues.

## How it works

1. Session-miner runs locally (same as today) — mines steerage, errors, instruction candidates
2. `file_contributor_insights()` in session-miner-pulse.sh iterates repos.json for contributor-role entries
3. For each, calls `contributor-insight-helper.sh file <compressed_signals.json> <target_slug>`
4. Helper filters for framework-relevant signals (instruction candidates >= 0.65 confidence, error patterns >= 20 occurrences + 2 models)
5. Privacy sanitizes all content before filing
6. Deduplicates against existing open `contributor-insight` issues
7. Files up to 3 issues per run, tagged `contributor-insight`

## Files changed

| File | Change |
|------|--------|
| `contributor-insight-helper.sh` (NEW) | Privacy sanitization + issue composition + dedup + filing |
| `session-miner-pulse.sh` | Add `file_contributor_insights()`, wire into `output_results()` |
| `AGENTS.md` | Document `role` field contributor behaviour |
| `tests/test-contributor-insight-helper.sh` (NEW) | 22 assertions |

## Verification

```bash
bash .agents/scripts/tests/test-contributor-insight-helper.sh  # 22/22 pass
shellcheck .agents/scripts/contributor-insight-helper.sh       # clean
shellcheck .agents/scripts/session-miner-pulse.sh              # clean
```

Resolves #19352