### PR TITLE
fix: pulse merge-pass field shift — tab delimiter collapse blocks all PR merges

### DIFF
--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -968,9 +968,17 @@ _process_single_ready_pr() {
 
 	local pr_number pr_mergeable pr_review pr_author pr_title
 	# Consolidate into a single jq pass to reduce process-spawn overhead.
-	IFS=$'\t' read -r pr_number pr_mergeable pr_review pr_author pr_title < <(
+	# CRITICAL: use non-whitespace delimiter (ASCII 0x1E record separator)
+	# instead of \t. Bash read collapses consecutive IFS whitespace chars
+	# (tab, space, newline) — if ANY field is empty the subsequent fields
+	# shift left. reviewDecision is routinely "" (empty string, which jq //
+	# does NOT catch — it only triggers on null/false). The field shift
+	# caused pr_author to receive the PR title, breaking the collaborator
+	# check and blocking ALL merges across every repo (GH#awardsapp).
+	local _RS=$'\x1e'
+	IFS="$_RS" read -r pr_number pr_mergeable pr_review pr_author pr_title < <(
 		printf '%s' "$pr_obj" | jq -r \
-			'"\(.number // "")\t\(.mergeable // "")\t\(.reviewDecision // "NONE")\t\(.author.login // "unknown")\t\(.title // "")"'
+			'"\(.number // "")\u001e\(.mergeable // "")\u001e\(if (.reviewDecision | length) == 0 then "NONE" else .reviewDecision end)\u001e\(.author.login // "unknown")\u001e\(.title // "")"'
 	)
 
 	[[ "$pr_number" =~ ^[0-9]+$ ]] || return 1


### PR DESCRIPTION
## Summary

- **Root cause**: `IFS=$'\t' read -r` in `_process_single_ready_pr()` collapses consecutive tab delimiters when `reviewDecision` is `""` (empty string). jq `//` only triggers on `null`/`false`, not empty strings, so `(.reviewDecision // "NONE")` produces `""` → consecutive tabs → Bash collapses them → `pr_author` gets the PR title → `_is_collaborator_author` rejects every PR as "not a collaborator"
- **Impact**: ALL deterministic PR merges across ALL pulse-enabled repos blocked. PRs accumulate indefinitely.
- **Fix**: Replace tab delimiter with ASCII record separator (`\^^` / `0x1E`), a non-whitespace character that Bash never collapses. Also add jq `if-then-else` for `reviewDecision` to properly handle both `null` and empty string.

## Verification

```bash
# Before (Bash 3.2 or modern — same behavior):
# IFS=$'\t' read → pr_review=[marcusquinn] pr_author=[PR TITLE]

# After:
# IFS=$'\x1e' read → pr_review=[NONE] pr_author=[marcusquinn]
```

Tested with `/bin/bash` (3.2) and `/opt/homebrew/bin/bash` (5.x). Fix confirmed by directly sourcing the patched script and calling `_process_single_ready_pr` — successfully merged 3 stuck <webapp> PRs.

Resolves the <webapp>/<webapp> merge blockage (PRs #2500, #2502, #2504 were stuck).