### PR TITLE
GH#19339: GH#19339: simplify null check in _get_min_edit_lag, harden test main-strip

### DIFF
--- a/.agents/scripts/review-bot-gate-helper.sh
+++ b/.agents/scripts/review-bot-gate-helper.sh
@@ -168,7 +168,7 @@ _get_min_edit_lag() {
 			'first(.initialized_repos[] | select(.slug == $slug)) | (.review_gate.tools[$bot].min_edit_lag_seconds // .review_gate.min_edit_lag_seconds // empty)' \
 			"$repos_json" 2>/dev/null) || lag=""
 		# Reject non-integer or negative values silently (fall through to env).
-		if [[ -n "$lag" && "$lag" != "null" && "$lag" =~ ^[0-9]+$ ]]; then
+		if [[ -n "$lag" && "$lag" =~ ^[0-9]+$ ]]; then
 			printf '%s' "$lag"
 			return 0
 		fi

--- a/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
+++ b/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
@@ -111,8 +111,8 @@ load_helper_functions() {
 	# `main "$@"` line removed.
 	local tmpfile
 	tmpfile=$(mktemp)
-	# Drop the final main invocation line (last non-empty line is `main "$@"`).
-	sed '$d' "$HELPER_SCRIPT" >"$tmpfile"
+	# Drop the final main invocation line using grep for robustness.
+	grep -v '^main "\$@"' "$HELPER_SCRIPT" >"$tmpfile"
 	# shellcheck disable=SC1090
 	source "$tmpfile"
 	rm -f "$tmpfile"


### PR DESCRIPTION
## Summary

Two cleanup fixes from Gemini review of PR #19309: (1) removed redundant `!= "null"` check in `_get_min_edit_lag` since `jq -r` with `// empty` already yields empty string for null values; (2) replaced fragile `sed '$d'` with `grep -v '^main "$@"'` in `load_helper_functions` to reliably strip only the main invocation line.

## Files Changed

.agents/scripts/review-bot-gate-helper.sh,.agents/scripts/tests/test-review-bot-gate-completion-signal.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck passes on both files with zero violations

Resolves #19339


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.60 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-sonnet-4-6 spent 1m and 4,990 tokens on this as a headless worker.