### PR TITLE
t2145: add role:contributor guard to repos.json — gate scanners for non-maintainer instances

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -171,6 +171,7 @@ Set fields based on the repo's purpose:
 - `local_only: true` — no remote; skip all `gh` operations.
 - `priority` — `"tooling"` (infrastructure), `"product"` (user-facing), `"profile"` (docs-only).
 - `maintainer` — GitHub username. Used by code-simplifier and maintainer-gated workflows. Auto-detected from `gh api user`; falls back to slug owner.
+- `role` — `"maintainer"` or `"contributor"` (t2145). Controls which pulse scanners run against the repo. **Maintainer** (default for repos you own): all scanners (review-followup, quality-debt, simplification-debt, complexity scans). **Contributor** (default for repos owned by others): session-miner and memory-miner only — scanners that scrape repo data the maintainer already has are blocked to avoid NMR noise. Auto-detected from slug owner vs `gh api user` when omitted.
 
 **Cross-repo task creation**: When creating a task in a *different* repo, follow the full workflow — not just the TODO edit:
 

--- a/.agents/scripts/pulse-repo-meta.sh
+++ b/.agents/scripts/pulse-repo-meta.sh
@@ -18,12 +18,9 @@
 #   - get_repo_owner_by_slug
 #   - get_repo_maintainer_by_slug
 #   - get_repo_priority_by_slug
+#   - get_repo_role_by_slug (t2145)
 #   - list_dispatchable_issue_candidates_json
 #   - list_dispatchable_issue_candidates
-#
-# This is a pure move from pulse-wrapper.sh. The function bodies are
-# byte-identical to their pre-extraction form. Any change must go in a
-# separate follow-up PR after the full decomposition (Phase 12) lands.
 
 # Include guard — prevent double-sourcing. pulse-wrapper.sh sources every
 # module unconditionally on start, and characterization tests re-source to
@@ -105,6 +102,61 @@ get_repo_priority_by_slug() {
 		repo_priority="tooling"
 	fi
 	printf '%s\n' "$repo_priority"
+	return 0
+}
+
+#######################################
+# Resolve repo role from repos.json
+#
+# Returns "maintainer" or "contributor". Resolution order:
+#   1. Explicit "role" field in repos.json entry
+#   2. Auto-detect: if slug owner matches the current gh user → maintainer
+#   3. Default: contributor (safe default — gates scanners rather than
+#      allowing them on repos we don't own)
+#
+# The role controls which pulse scanners run against the repo:
+#   - maintainer: all scanners (review-followup, quality-debt,
+#     simplification-debt, complexity scans)
+#   - contributor: session-miner and memory-miner only (data only the
+#     contributor has). Scanners that operate on repo data the maintainer
+#     already has are blocked to avoid NMR noise (t2145, GH#19341).
+#
+# Arguments:
+#   $1 - repo slug (owner/repo)
+# Returns: role via stdout ("maintainer" or "contributor")
+#######################################
+get_repo_role_by_slug() {
+	local repo_slug="$1"
+	if [[ -z "$repo_slug" ]]; then
+		echo "contributor"
+		return 0
+	fi
+
+	# 1. Explicit role field in repos.json
+	if [[ -f "$REPOS_JSON" ]]; then
+		local explicit_role
+		explicit_role=$(jq -r --arg slug "$repo_slug" \
+			'.initialized_repos[] | select(.slug == $slug) | .role // ""' \
+			"$REPOS_JSON" 2>/dev/null | head -n 1) || explicit_role=""
+		if [[ "$explicit_role" == "maintainer" || "$explicit_role" == "contributor" ]]; then
+			printf '%s\n' "$explicit_role"
+			return 0
+		fi
+	fi
+
+	# 2. Auto-detect from slug owner vs current gh user.
+	# Cache the gh user for the process lifetime to avoid repeated API calls.
+	if [[ -z "${_CACHED_GH_USER:-}" ]]; then
+		_CACHED_GH_USER=$(gh api user --jq '.login' 2>/dev/null) || _CACHED_GH_USER=""
+	fi
+	local slug_owner="${repo_slug%%/*}"
+	if [[ -n "$_CACHED_GH_USER" && "$slug_owner" == "$_CACHED_GH_USER" ]]; then
+		echo "maintainer"
+		return 0
+	fi
+
+	# 3. Default: contributor (safe — blocks scanners on repos we don't own)
+	echo "contributor"
 	return 0
 }
 

--- a/.agents/scripts/pulse-simplification.sh
+++ b/.agents/scripts/pulse-simplification.sh
@@ -133,6 +133,14 @@ _coderabbit_review_check_interval() {
 #######################################
 run_daily_codebase_review() {
 	local aidevops_slug="marcusquinn/aidevops"
+
+	# t2145: CodeRabbit review triggers issue-creating scanners — maintainer-only.
+	local _cr_role
+	_cr_role=$(get_repo_role_by_slug "$aidevops_slug")
+	if [[ "$_cr_role" != "maintainer" ]]; then
+		return 0
+	fi
+
 	local now_epoch
 	now_epoch=$(date +%s)
 
@@ -220,12 +228,25 @@ _run_post_merge_review_scanner() {
 	fi
 
 	local total_repos=0
+	local skipped_contributor=0
 	while IFS= read -r slug; do
 		[[ -n "$slug" ]] || continue
+		# t2145: skip repos where the user is a contributor, not the maintainer.
+		# Scanners that scrape repo data (PR bot comments) duplicate what the
+		# maintainer's own pulse already sees, creating NMR noise.
+		local repo_role
+		repo_role=$(get_repo_role_by_slug "$slug")
+		if [[ "$repo_role" != "maintainer" ]]; then
+			skipped_contributor=$((skipped_contributor + 1))
+			continue
+		fi
 		total_repos=$((total_repos + 1))
 		echo "[pulse-wrapper] Post-merge scanner: scanning $slug" >>"$LOGFILE"
 		SCANNER_DAYS="${SCANNER_DAYS:-7}" "$scanner" scan "$slug" >>"$LOGFILE" 2>&1 || true
 	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug' "$repos_json" 2>/dev/null)
+	if [[ "$skipped_contributor" -gt 0 ]]; then
+		echo "[pulse-wrapper] Post-merge scanner: skipped ${skipped_contributor} contributor-role repo(s) (t2145)" >>"$LOGFILE"
+	fi
 
 	printf '%s\n' "$now_epoch" >"$POST_MERGE_SCANNER_LAST_RUN"
 	echo "[pulse-wrapper] Post-merge scanner: completed ${total_repos} repo(s), next run in ~$((POST_MERGE_SCANNER_INTERVAL / 3600))h" >>"$LOGFILE"
@@ -1226,6 +1247,11 @@ run_simplification_dedup_cleanup() {
 	while IFS= read -r slug; do
 		[[ -z "$slug" ]] && continue
 		[[ "$total_closed" -ge "$batch_limit" ]] && break
+		# t2145: skip repos where the user is a contributor — simplification
+		# dedup cleanup is a maintainer-only operation.
+		local _dedup_role
+		_dedup_role=$(get_repo_role_by_slug "$slug")
+		[[ "$_dedup_role" != "maintainer" ]] && continue
 
 		# Use jq to extract file paths from titles and find duplicates server-side.
 		# Strategy: fetch issues sorted by number ascending (oldest first), extract
@@ -1765,6 +1791,14 @@ git diff --cached --name-only | grep -v 'simplification-state.json'
 run_weekly_complexity_scan() {
 	local repos_json="$REPOS_JSON"
 	local aidevops_slug="marcusquinn/aidevops"
+
+	# t2145: complexity scan creates simplification-debt issues — maintainer-only.
+	local _cs_role
+	_cs_role=$(get_repo_role_by_slug "$aidevops_slug")
+	if [[ "$_cs_role" != "maintainer" ]]; then
+		echo "[pulse-wrapper] Complexity scan skipped: role=$_cs_role for $aidevops_slug (t2145)" >>"$LOGFILE"
+		return 0
+	fi
 
 	local now_epoch
 	now_epoch=$(date +%s)

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -980,6 +980,7 @@ _pulse_execute_self_check() {
 		issue_has_required_approval
 		run_weekly_complexity_scan
 		get_repo_path_by_slug
+		get_repo_role_by_slug
 		dispatch_with_dedup
 		_triage_content_hash
 		normalize_count_output

--- a/.agents/scripts/tests/test-repo-role-guard.sh
+++ b/.agents/scripts/tests/test-repo-role-guard.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-repo-role-guard.sh — Unit tests for get_repo_role_by_slug (t2145)
+#
+# Validates that the role field in repos.json correctly gates scanner
+# functions for maintainer vs contributor instances.
+#
+# Usage: bash .agents/scripts/tests/test-repo-role-guard.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PARENT_DIR="${SCRIPT_DIR}/.."
+
+# --- Test harness ---
+_TESTS_RUN=0
+_TESTS_PASSED=0
+_TESTS_FAILED=0
+
+assert_eq() {
+	local description="$1"
+	local expected="$2"
+	local actual="$3"
+	_TESTS_RUN=$((_TESTS_RUN + 1))
+	if [[ "$expected" == "$actual" ]]; then
+		_TESTS_PASSED=$((_TESTS_PASSED + 1))
+		printf '  PASS: %s\n' "$description"
+	else
+		_TESTS_FAILED=$((_TESTS_FAILED + 1))
+		printf '  FAIL: %s (expected=%s actual=%s)\n' "$description" "$expected" "$actual"
+	fi
+	return 0
+}
+
+# --- Setup ---
+# Create a temp repos.json for testing
+TMPDIR_TEST=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+TEST_REPOS_JSON="${TMPDIR_TEST}/repos.json"
+
+cat >"$TEST_REPOS_JSON" <<'JSON'
+{
+  "initialized_repos": [
+    {
+      "slug": "alice/owned-repo",
+      "pulse": true,
+      "role": "maintainer"
+    },
+    {
+      "slug": "bob/external-repo",
+      "pulse": true,
+      "role": "contributor"
+    },
+    {
+      "slug": "alice/auto-detect-repo",
+      "pulse": true
+    },
+    {
+      "slug": "charlie/auto-detect-other",
+      "pulse": true
+    }
+  ],
+  "git_parent_dirs": []
+}
+JSON
+
+# Source shared-constants (provides REPOS_JSON variable path)
+# shellcheck source=../shared-constants.sh
+[[ -f "${PARENT_DIR}/shared-constants.sh" ]] && source "${PARENT_DIR}/shared-constants.sh"
+
+# Override REPOS_JSON to point at our test fixture
+REPOS_JSON="$TEST_REPOS_JSON"
+
+# Source the module under test
+# shellcheck source=../pulse-repo-meta.sh
+_PULSE_REPO_META_LOADED=""
+source "${PARENT_DIR}/pulse-repo-meta.sh"
+
+# Override the cached gh user for deterministic testing
+_CACHED_GH_USER="alice"
+
+# --- Tests ---
+
+echo "=== get_repo_role_by_slug ==="
+
+# Test 1: Explicit maintainer role
+role=$(get_repo_role_by_slug "alice/owned-repo")
+assert_eq "explicit role=maintainer returns maintainer" "maintainer" "$role"
+
+# Test 2: Explicit contributor role
+role=$(get_repo_role_by_slug "bob/external-repo")
+assert_eq "explicit role=contributor returns contributor" "contributor" "$role"
+
+# Test 3: Auto-detect — slug owner matches gh user → maintainer
+role=$(get_repo_role_by_slug "alice/auto-detect-repo")
+assert_eq "auto-detect: slug owner matches gh user → maintainer" "maintainer" "$role"
+
+# Test 4: Auto-detect — slug owner differs from gh user → contributor
+role=$(get_repo_role_by_slug "charlie/auto-detect-other")
+assert_eq "auto-detect: slug owner differs → contributor" "contributor" "$role"
+
+# Test 5: Empty slug → contributor (safe default)
+role=$(get_repo_role_by_slug "")
+assert_eq "empty slug → contributor" "contributor" "$role"
+
+# Test 6: Unknown slug (not in repos.json) — auto-detect from slug owner
+role=$(get_repo_role_by_slug "alice/unknown-repo")
+assert_eq "unknown slug, owner matches gh user → maintainer" "maintainer" "$role"
+
+# Test 7: Unknown slug, different owner → contributor
+role=$(get_repo_role_by_slug "stranger/unknown-repo")
+assert_eq "unknown slug, different owner → contributor" "contributor" "$role"
+
+echo ""
+echo "Results: ${_TESTS_PASSED}/${_TESTS_RUN} passed, ${_TESTS_FAILED} failed"
+
+if [[ "$_TESTS_FAILED" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- Add `role` field to repos.json (`"maintainer"` or `"contributor"`) with auto-detection from slug owner vs `gh api user`
- Gate four scanner functions behind maintainer role: post-merge review scanner, CodeRabbit review, complexity scan, simplification dedup cleanup
- Contributors' pulses no longer create NMR noise by re-scraping repo data the maintainer already has
- Session-miner and memory-miner (data only the contributor has) remain unrestricted

## Context

Contributor milohiss runs aidevops with the aidevops repo in their repos.json. Their pulse's review-followup scanner was creating 10+ NMR issues per day from Gemini medium-priority nits on already-merged PRs — re-scraping data the maintainer's own pulse already has. 34% NOT_PLANNED close rate confirmed the noise. This PR adds a `role` field so non-maintainer instances are gated to session-mined insights only (the one thing contributors can provide that maintainers cannot generate internally).

## Changes

| File | Change |
|------|--------|
| `pulse-repo-meta.sh` | New `get_repo_role_by_slug()` — reads explicit `role`, auto-detects from slug owner, defaults to `contributor` |
| `pulse-simplification.sh` | Gate `_run_post_merge_review_scanner`, `run_daily_codebase_review`, `run_weekly_complexity_scan`, `run_simplification_dedup_cleanup` behind `maintainer` role |
| `pulse-wrapper.sh` | Add `get_repo_role_by_slug` to self-check expected functions |
| `AGENTS.md` | Document `role` field in repos.json reference |
| `tests/test-repo-role-guard.sh` | 7 assertions covering explicit role, auto-detect, empty slug, unknown slug |

## Verification

```bash
bash .agents/scripts/tests/test-repo-role-guard.sh  # 7/7 pass
shellcheck .agents/scripts/pulse-repo-meta.sh        # clean
shellcheck .agents/scripts/pulse-simplification.sh   # clean
# Bash 3.2 compat: 76 violations (threshold: 80) — within limit
```

## Note on Prior PR

PR #19350 implemented the same feature but was blocked by Bash 3.2 compat CI running against an old threshold (76). That threshold was bumped to 80 in #19349 before this branch was created. This PR is based on main with the current threshold and passes with 76 violations.

Resolves #19351