### PR TITLE
GH#19363: GH#19363: tighten pre-dispatch-validators.md prose (84→82 lines)

### DIFF
--- a/.agents/reference/pre-dispatch-validators.md
+++ b/.agents/reference/pre-dispatch-validators.md
@@ -1,10 +1,10 @@
 # Pre-Dispatch Validators
 
-Run **after** dedup checks and **before** worker spawn for auto-generated issues, verifying the premise still holds (GH#19118). Root causes: GH#19036, GH#19037; post-mortem: GH#19024.
+Runs **after** dedup checks and **before** worker spawn for auto-generated issues — verifies the premise still holds (GH#19118). Root causes: GH#19036, GH#19037; post-mortem: GH#19024.
 
 ## Architecture
 
-Auto-generated issues embed `<!-- aidevops:generator=<name> -->` in the body (parsed with grep — not title/labels, which change; markers survive). `pre-dispatch-validator-helper.sh` maintains `_VALIDATOR_REGISTRY` (populated by `_register_validators()`). Unregistered generators exit 0.
+Auto-generated issues embed `<!-- aidevops:generator=<name> -->` in the body (markers parsed with grep — survive title/label changes). `pre-dispatch-validator-helper.sh` maps generators to validators via `_VALIDATOR_REGISTRY` (populated by `_register_validators()`). Unregistered generators, missing helper, or unexpected exit code → exit 0 (dispatch proceeds).
 
 ### Exit codes
 
@@ -22,8 +22,6 @@ _ensure_issue_body_has_brief()   ← t2063 freshness guard
 _run_predispatch_validator()     ← GH#19118 ← HERE
 _dispatch_launch_worker()        ← worker spawn
 ```
-
-Non-fatal: missing helper or unexpected exit code → dispatch proceeds.
 
 ## Bypass
 


### PR DESCRIPTION
## Summary

Tightened prose in .agents/reference/pre-dispatch-validators.md: fixed verb form in opening sentence, simplified Architecture paragraph parenthetical, and merged the orphaned 'Non-fatal' note (previously floating after the hook-point code block) inline into the Architecture sentence. 84→82 lines, all institutional knowledge preserved.

## Files Changed

.agents/reference/pre-dispatch-validators.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Content preservation verified: all GH# refs (GH#19118, GH#19024, GH#19036, GH#19037, t2063), all code blocks, all command examples, all section headings present before and after. No broken references. Qlty smells check: no smells on target file.

Resolves #19363


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.60 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-sonnet-4-6 spent 2m and 6,674 tokens on this as a headless worker.