### PR TITLE
GH#19371: GH#19371: tighten pre-dispatch-validators.md (82→79 lines)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -11,6 +11,13 @@
     "lines_after": 54,
     "lines_before": 58
   },
+  ".agents/reference/pre-dispatch-validators.md": {
+    "action": "tightened",
+    "hash": "fc3793612c26775ea0269868215c107f810447254ab2424e59bbe48558195a08",
+    "issue": "GH#19371",
+    "lines_after": 79,
+    "lines_before": 82
+  },
   ".agents/services/hosting/cloudflare-platform-skill/ai-search-patterns.md": {
     "hash": "867d8ff77f341ac99f155db719644f2190031e9faa7e6668a79b05468b0eae0f",
     "issue": "GH#17305",
@@ -5828,7 +5835,7 @@
       "pr": 17019
     },
     ".agents/tools/design/library/styles/corporate-traditional/02-colours.md": {
-      "action": "consolidated 6 group tables + CSS block into single unified table with CSS variable column (94→28 lines)",
+      "action": "consolidated 6 group tables + CSS block into single unified table with CSS variable column (94\u219228 lines)",
       "at": "2026-04-04T14:53:40Z",
       "hash": "476c989fca56149f90f1eefc2b02cafdc5a6e0d5",
       "issue": "GH#17250",
@@ -7490,6 +7497,12 @@
       "passes": 71,
       "pr": 19029
     },
+    "setup-modules/agent-deploy.sh": {
+      "at": "2026-04-16T18:00:14Z",
+      "hash": "46d74c0f0720a3deb8b01f9bab0f1cff7f2a8258",
+      "passes": 3,
+      "pr": 19203
+    },
     "setup.sh": {
       "at": "2026-04-16T19:25:49Z",
       "hash": "9d8b159588006978153fa2efba94d5f357fd7fbc",
@@ -7555,12 +7568,6 @@
       "hash": "89edb8ff09173143446da68fb9104c16ac400b1c",
       "passes": 1,
       "pr": 15470
-    },
-    "setup-modules/agent-deploy.sh": {
-      "hash": "46d74c0f0720a3deb8b01f9bab0f1cff7f2a8258",
-      "at": "2026-04-16T18:00:14Z",
-      "pr": 19203,
-      "passes": 3
     }
   },
   "setup-modules/agent-deploy.sh": {

--- a/.agents/reference/pre-dispatch-validators.md
+++ b/.agents/reference/pre-dispatch-validators.md
@@ -4,7 +4,7 @@ Runs **after** dedup checks and **before** worker spawn for auto-generated issue
 
 ## Architecture
 
-Auto-generated issues embed `<!-- aidevops:generator=<name> -->` in the body (markers parsed with grep — survive title/label changes). `pre-dispatch-validator-helper.sh` maps generators to validators via `_VALIDATOR_REGISTRY` (populated by `_register_validators()`). Unregistered generators, missing helper, or unexpected exit code → exit 0 (dispatch proceeds).
+Auto-generated issues embed `<!-- aidevops:generator=<name> -->` in the body (HTML comments survive title/label changes). `pre-dispatch-validator-helper.sh` maps generators to validators via `_VALIDATOR_REGISTRY` (populated by `_register_validators()`). Unregistered generators, missing helper, or unexpected exit code → exit 0 (dispatch proceeds).
 
 ### Exit codes
 
@@ -38,11 +38,8 @@ Emergency recovery when a validator bug blocks legitimate dispatches. Bypass is 
 **Generator:** `_complexity_scan_ratchet_check` in `pulse-simplification.sh`
 **Marker:** `<!-- aidevops:generator=ratchet-down -->`
 
-1. Clone target repo into `mktemp -d` (trap-cleaned)
-2. Run `complexity-scan-helper.sh ratchet-check <clone> 5`
-3. `No ratchet-down available` in output → exit 10 (falsified)
-4. Empty output + any error → exit 20 (validator error)
-5. Otherwise → exit 0 (proposals available, dispatch)
+1. Clone target repo into `mktemp -d` (trap-cleaned); run `complexity-scan-helper.sh ratchet-check <clone> 5`.
+2. `No ratchet-down available` in output → exit 10 (falsified); empty output + any error → exit 20; otherwise → exit 0.
 
 Prevents workers spawning only to find no ratchet-down work exists (GH#19024).
 
@@ -72,7 +69,7 @@ bash .agents/scripts/tests/test-pre-dispatch-validator.sh
 .agents/scripts/pre-dispatch-validator-helper.sh validate <issue-number> marcusquinn/aidevops
 ```
 
-`gh`, `git`, and `complexity-scan-helper.sh` are stubbed via `PATH` and `COMPLEXITY_SCAN_HELPER` — no network required.
+`gh`, `git`, and `complexity-scan-helper.sh` stubbed via `PATH` and `COMPLEXITY_SCAN_HELPER` — no network required.
 
 ## Related
 


### PR DESCRIPTION
## Summary

Tightened .agents/reference/pre-dispatch-validators.md from 82 to 79 lines. Changes: compressed 5-step ratchet-down validator procedure into 2 steps (same info, more compact); removed grep implementation detail from Architecture prose; minor prose tightening in Testing section. All GH refs, task IDs, code blocks, exit codes, and command examples preserved.

## Files Changed

.agents/configs/simplification-state.json,.agents/reference/pre-dispatch-validators.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Content verification: all GH#19118, GH#19024, GH#19036, GH#19037, t2063 references present; all code blocks and command examples intact; no broken internal links. Line count: 82 → 79.

Resolves #19371


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.61 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-sonnet-4-6 spent 3m and 11,043 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified documentation on validator behavior and how auto-generated issue markers are handled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->