### PR TITLE
GH#19373: bump NESTING_DEPTH_THRESHOLD 283→288 (281 violations, 2 headroom)

### DIFF
--- a/.agents/configs/complexity-thresholds-history.md
+++ b/.agents/configs/complexity-thresholds-history.md
@@ -66,6 +66,8 @@ Archives the full change history for `.agents/configs/complexity-thresholds.conf
 | 288 | GH#19288 | proximity guard firing at 281/281 (0 headroom); 281 violations + 7 headroom = 288; proximity guard (warn_at = 288-5 = 283) fires when violations exceed 283 (i.e., at 284), preventing saturation |
 | 283 | GH#19323 | ratcheted down — actual violations 281 + 2 buffer |
 | 288 | GH#19342 | proximity guard firing at 281/283 (2 headroom); 281 violations + 7 headroom = 288; proximity guard (warn_at = 288-5 = 283) fires when violations exceed 283 (i.e., at 284), preventing saturation |
+| 283 | GH#19365 | ratcheted down — actual violations 281 + 2 buffer |
+| 288 | GH#19373 | proximity guard firing at 281/283 (2 headroom); 281 violations + 7 headroom = 288; proximity guard (warn_at = 288-5 = 283) fires when violations exceed 283 (i.e., at 284), preventing saturation |
 
 ## FUNCTION_COMPLEXITY_THRESHOLD History
 

--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -133,7 +133,9 @@ FUNCTION_COMPLEXITY_THRESHOLD=28
 # Bumped to 288 (GH#19342): proximity guard firing at 281/283 (2 headroom); 281 violations + 7 headroom = 288.
 # Proximity guard (warn_at = 288-5 = 283) fires when violations exceed 283 (i.e., at 284), preventing saturation.
 # Ratcheted down to 283 (GH#19365): actual violations 281 + 2 buffer
-NESTING_DEPTH_THRESHOLD=283
+# Bumped to 288 (GH#19373): proximity guard firing at 281/283 (2 headroom); 281 violations + 7 headroom = 288.
+# Proximity guard (warn_at = 288-5 = 283) fires when violations exceed 283 (i.e., at 284), preventing saturation.
+NESTING_DEPTH_THRESHOLD=288
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Proximity guard fired at 281/283 (2 headroom). Bumps `NESTING_DEPTH_THRESHOLD` from 283 to 288 following the established bump-and-ratchet pattern.

- **Current violations**: 281 (verified with same awk method as CI)
- **Old threshold**: 283 (set by GH#19365 ratchet-down)
- **New threshold**: 288 (281 violations + 7 headroom)
- **Proximity guard warn_at**: 283 (fires when violations exceed 283, i.e., at 284+)

Also adds the missing `GH#19365` entry to `complexity-thresholds-history.md` (the conf file had the entry but the history table was missing it).

## Files Changed

- EDIT: `.agents/configs/complexity-thresholds.conf` — bump `NESTING_DEPTH_THRESHOLD=283` → `=288`, add bump comment
- EDIT: `.agents/configs/complexity-thresholds-history.md` — add GH#19365 ratchet-down row + GH#19373 bump row

## Verification

Ran CI's exact counting method locally:

```
Total violations: 281
Old threshold: 283
New threshold: 288
New headroom: 7
```

Resolves #19373


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.61 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-sonnet-4-6 spent 2m and 7,237 tokens on this as a headless worker.