### PR TITLE
GH#19374: chore: ratchet down BASH32_COMPAT_THRESHOLD 78→74 (GH#19374)

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -162,7 +162,8 @@ FILE_SIZE_THRESHOLD=59
 # next quality sweep.
 # Ratcheted down to 78 (GH#19365): actual violations 76 + 2 buffer
 # (violations drifted from 72 to 76 between issue filing and worker run; 76 + 2 = 78)
-BASH32_COMPAT_THRESHOLD=78
+# Ratcheted down to 74 (GH#19374): actual violations 72 + 2 buffer
+BASH32_COMPAT_THRESHOLD=74
 
 # Qlty maintainability smell baseline (t2065, GH#18773). Seed value for
 # the `.github/workflows/qlty-regression.yml` gate. The gate itself uses


### PR DESCRIPTION
## Summary

Lowered BASH32_COMPAT_THRESHOLD from 78 to 74 in complexity-thresholds.conf. Actual violations: 72, new threshold: 72 + 2 buffer = 74.

## Files Changed

.agents/configs/complexity-thresholds.conf

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** grep BASH32_COMPAT_THRESHOLD .agents/configs/complexity-thresholds.conf confirms 74; simplification-state.json not staged.

Resolves #19374


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.61 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-sonnet-4-6 spent 54s and 2,056 tokens on this as a headless worker.