### PR TITLE
GH#19346: t2143: refactor(pulse-triage): centralize consolidation gate defaults at module top

### DIFF
--- a/.agents/scripts/pulse-triage.sh
+++ b/.agents/scripts/pulse-triage.sh
@@ -33,6 +33,14 @@
 [[ -n "${_PULSE_TRIAGE_LOADED:-}" ]] && return 0
 _PULSE_TRIAGE_LOADED=1
 
+# Module-level defaults — single source of truth for consolidation gate thresholds.
+# := form: env overrides set before sourcing this module still take effect;
+# these only apply when the variable is unset. Avoids duplicate-default drift
+# between pulse-wrapper.sh and inline guards. Aligns all call sites to the same
+# 500-char minimum and threshold=2, eliminating the 200-vs-500 mismatch.
+: "${ISSUE_CONSOLIDATION_COMMENT_THRESHOLD:=2}"
+: "${ISSUE_CONSOLIDATION_COMMENT_MIN_CHARS:=500}"
+
 # Compute a content hash from issue body + human comments.
 # Excludes github-actions[bot] comments and our own triage reviews
 # (## Review: prefix) so that only author/contributor changes trigger
@@ -280,11 +288,9 @@ _issue_needs_consolidation() {
 		--paginate --jq '.' 2>/dev/null) || comments_json="[]"
 
 	local substantive_count=0
-	# Defensive defaults match pulse-wrapper.sh:816-817 source of truth.
-	# Guards against unset env when pulse-triage.sh is sourced standalone
-	# (tests, one-off scripts, future sourcing paths). Bash 5.x [[ N -ge "" ]]
-	# evaluates TRUE for any N, so unset threshold would silently break the gate.
-	local min_chars="${ISSUE_CONSOLIDATION_COMMENT_MIN_CHARS:-500}"
+	# Defaults are set at module level (: "${VAR:=value}" block above).
+	# Bare $VAR reference is safe; the module-level block guarantees non-empty.
+	local min_chars="$ISSUE_CONSOLIDATION_COMMENT_MIN_CHARS"
 	substantive_count=$(printf '%s' "$comments_json" | jq --argjson min "$min_chars" '
 		# Combine all operational-noise patterns into a single regex for efficiency
 		# (1 test() invocation per comment instead of 13).
@@ -310,7 +316,7 @@ _issue_needs_consolidation() {
 		)] | length
 	' 2>/dev/null) || substantive_count=0
 
-	if [[ "$substantive_count" -ge "${ISSUE_CONSOLIDATION_COMMENT_THRESHOLD:-2}" ]]; then
+	if [[ "$substantive_count" -ge "$ISSUE_CONSOLIDATION_COMMENT_THRESHOLD" ]]; then
 		return 0
 	fi
 
@@ -320,7 +326,7 @@ _issue_needs_consolidation() {
 	if [[ "$was_already_labeled" == "true" ]]; then
 		gh issue edit "$issue_number" --repo "$repo_slug" \
 			--remove-label "needs-consolidation" >/dev/null 2>&1 || true
-		echo "[pulse-wrapper] Consolidation gate cleared for #${issue_number} (${repo_slug}) — substantive_count=${substantive_count} below threshold=${ISSUE_CONSOLIDATION_COMMENT_THRESHOLD:-2}" >>"$LOGFILE"
+		echo "[pulse-wrapper] Consolidation gate cleared for #${issue_number} (${repo_slug}) — substantive_count=${substantive_count} below threshold=${ISSUE_CONSOLIDATION_COMMENT_THRESHOLD}" >>"$LOGFILE"
 	fi
 	return 1
 }
@@ -500,7 +506,7 @@ _consolidation_substantive_comments() {
 	comments_json=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
 		--paginate --jq '.' 2>/dev/null) || comments_json="[]"
 
-	local min_chars="${ISSUE_CONSOLIDATION_COMMENT_MIN_CHARS:-200}"
+	local min_chars="$ISSUE_CONSOLIDATION_COMMENT_MIN_CHARS"
 
 	printf '%s' "$comments_json" | jq --argjson min "$min_chars" '
 		[.[] | select(

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -812,9 +812,11 @@ TRIAGE_MAX_RETRIES="${TRIAGE_MAX_RETRIES:-1}"
 #
 # Arguments: $1 issue_number, $2 repo_slug
 # Returns: 0 if consolidation is needed, 1 if not
+#
+# Defaults are owned by pulse-triage.sh (module-level := block) which is
+# sourced above. Declarations removed from here to eliminate duplicate-default
+# drift (t2143). Override via env before sourcing pulse-triage.sh if needed.
 #######################################
-ISSUE_CONSOLIDATION_COMMENT_THRESHOLD="${ISSUE_CONSOLIDATION_COMMENT_THRESHOLD:-2}"
-ISSUE_CONSOLIDATION_COMMENT_MIN_CHARS="${ISSUE_CONSOLIDATION_COMMENT_MIN_CHARS:-500}"
 
 #######################################
 # Large-file simplification gate: check if an issue body references

--- a/.agents/scripts/tests/test-consolidation-gate-defaults.sh
+++ b/.agents/scripts/tests/test-consolidation-gate-defaults.sh
@@ -147,6 +147,11 @@ teardown_test_env() {
 	TEST_ROOT=""
 	GH_LOG=""
 	unset GH_ISSUE_VIEW_LABELS GH_API_COMMENTS_JSON GH_ISSUE_LIST_CHILD_JSON
+	# t2143: Reset the module-load guard so the next setup_test_env re-sources
+	# pulse-triage.sh and re-runs the := defaults block. Without this, the
+	# second test's `unset ISSUE_CONSOLIDATION_COMMENT_*` leaves the vars unset
+	# and the guard prevents re-initialization → unbound variable on bash -u.
+	unset _PULSE_TRIAGE_LOADED
 	return 0
 }
 
@@ -246,10 +251,46 @@ test_min_chars_default_filters_short_comments() {
 	return 0
 }
 
+# t2143: Verify that _consolidation_substantive_comments also uses the module
+# default min_chars=500, not the prior stale fallback of 200. A comment with
+# 350 chars (above 200 but below 500) must NOT be returned by the helper when
+# ISSUE_CONSOLIDATION_COMMENT_MIN_CHARS is unset (module default=500 applies).
+test_substantive_comments_helper_uses_500_not_200() {
+	setup_test_env
+
+	# A comment between 200 and 500 chars — should be filtered by 500, not by 200.
+	# printf '%350s' '' | tr ' ' 'A' produces exactly 350 'A' characters.
+	local mid_body
+	mid_body=$(printf '%350s' '' | tr ' ' 'A') # exactly 350 chars: above 200, below 500
+	local comments_json
+	comments_json=$(jq -n --arg body "$mid_body" '[
+		{user: {login: "alice", type: "User"}, body: $body}
+	]')
+	GH_API_COMMENTS_JSON="$comments_json"
+	export GH_API_COMMENTS_JSON
+
+	local result
+	result=$(_consolidation_substantive_comments 123 "owner/repo" 2>/dev/null)
+	local count
+	count=$(printf '%s' "$result" | jq 'length' 2>/dev/null) || count=0
+
+	# With min_chars=500 (module default), a 350-char comment is NOT substantive.
+	if [[ "$count" -eq 0 ]]; then
+		print_result "_consolidation_substantive_comments: 350-char comment filtered (module default=500, not stale 200)" 0
+	else
+		print_result "_consolidation_substantive_comments: 350-char comment filtered (module default=500, not stale 200)" 1 \
+			"expected count=0 (filtered by 500), got count=${count} — stale 200 fallback may still be in effect"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
 main() {
 	test_below_threshold_returns_one
 	test_meets_threshold_returns_zero
 	test_min_chars_default_filters_short_comments
+	test_substantive_comments_helper_uses_500_not_200
 
 	echo
 	echo "============================================"


### PR DESCRIPTION
## Summary

Moved ISSUE_CONSOLIDATION_COMMENT_THRESHOLD=2 and MIN_CHARS=500 to a single module-level := block at the top of pulse-triage.sh. Simplified all three Phase 1 inline guards back to bare $VAR. Aligned _consolidation_substantive_comments fallback from 200→500 (was a latent inconsistency). Removed duplicate declarations from pulse-wrapper.sh:816-817 (sourcing order verified: pulse-triage.sh sourced at line 211, before line 816). Added test assertion for the 200→500 alignment with teardown fix for _PULSE_TRIAGE_LOADED guard.

## Files Changed

.agents/scripts/pulse-triage.sh,.agents/scripts/pulse-wrapper.sh,.agents/scripts/tests/test-consolidation-gate-defaults.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-triage.sh .agents/scripts/pulse-wrapper.sh clean. bash .agents/scripts/tests/test-consolidation-gate-defaults.sh 4/4 pass. bash .agents/scripts/tests/test-consolidation-dispatch.sh 5/6 pass (1 pre-existing failure tracked).

Resolves #19346


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.61 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-sonnet-4-6 spent 6m and 17,112 tokens on this as a headless worker.