### PR TITLE
GH#19379: GH#19379: tighten pre-dispatch-validators.md (remove redundant prose)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -13,10 +13,10 @@
   },
   ".agents/reference/pre-dispatch-validators.md": {
     "action": "tightened",
-    "hash": "fc3793612c26775ea0269868215c107f810447254ab2424e59bbe48558195a08",
-    "issue": "GH#19371",
+    "hash": "094ec74824cd93d17e4785197a7c9e6e047e5caca006a4f848e149805e3580f3",
+    "issue": "GH#19379",
     "lines_after": 79,
-    "lines_before": 82
+    "lines_before": 79
   },
   ".agents/services/hosting/cloudflare-platform-skill/ai-search-patterns.md": {
     "hash": "867d8ff77f341ac99f155db719644f2190031e9faa7e6668a79b05468b0eae0f",
@@ -5835,7 +5835,7 @@
       "pr": 17019
     },
     ".agents/tools/design/library/styles/corporate-traditional/02-colours.md": {
-      "action": "consolidated 6 group tables + CSS block into single unified table with CSS variable column (94→28 lines)",
+      "action": "consolidated 6 group tables + CSS block into single unified table with CSS variable column (94\u219228 lines)",
       "at": "2026-04-04T14:53:40Z",
       "hash": "476c989fca56149f90f1eefc2b02cafdc5a6e0d5",
       "issue": "GH#17250",

--- a/.agents/reference/pre-dispatch-validators.md
+++ b/.agents/reference/pre-dispatch-validators.md
@@ -1,10 +1,10 @@
 # Pre-Dispatch Validators
 
-Runs **after** dedup checks and **before** worker spawn for auto-generated issues — verifies the premise still holds (GH#19118). Root causes: GH#19036, GH#19037; post-mortem: GH#19024.
+Runs **after** dedup checks and **before** worker spawn for auto-generated issues — verifies the premise still holds (GH#19118).
 
 ## Architecture
 
-Auto-generated issues embed `<!-- aidevops:generator=<name> -->` in the body (HTML comments survive title/label changes). `pre-dispatch-validator-helper.sh` maps generators to validators via `_VALIDATOR_REGISTRY` (populated by `_register_validators()`). Unregistered generators, missing helper, or unexpected exit code → exit 0 (dispatch proceeds).
+Auto-generated issues embed `<!-- aidevops:generator=<name> -->` in the body (HTML comments survive title/label changes). `pre-dispatch-validator-helper.sh` maps generators to validators via `_VALIDATOR_REGISTRY`. Unregistered generators, missing helper, or unexpected exit code → exit 0 (dispatch proceeds).
 
 ### Exit codes
 
@@ -76,4 +76,4 @@ bash .agents/scripts/tests/test-pre-dispatch-validator.sh
 - `pulse-dispatch-core.sh` — `dispatch_with_dedup`, `_run_predispatch_validator`
 - `pulse-simplification.sh` — `_complexity_scan_ratchet_check` (ratchet-down generator)
 - `reference/worker-diagnostics.md` — full worker lifecycle
-- GH#19118, GH#19024 (post-mortem), GH#19036, GH#19037
+- GH#19118 (feature), GH#19024 (post-mortem), GH#19036, GH#19037 (root causes)


### PR DESCRIPTION
## Summary

Tightened .agents/reference/pre-dispatch-validators.md: removed duplicate GH# root cause references from intro (already in Related section), removed redundant parenthetical about _register_validators() from Architecture description (already shown in step 4 of Adding a validator), and added clarifying labels to Related section GH# entries.

## Files Changed

.agents/configs/simplification-state.json,.agents/reference/pre-dispatch-validators.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** qlty smells check: no smells found. Line count: 79 (unchanged - edits were inline prose removal). All GH# and task ID refs preserved (GH#19118, GH#19024, GH#19036, GH#19037, t2063).

Resolves #19379


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.61 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-sonnet-4-6 spent 3m and 7,800 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal reference documentation and configuration metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->