### PR TITLE
GH#19382: chore: ratchet-down NESTING_DEPTH_THRESHOLD 288→283 (GH#19382)

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -135,7 +135,8 @@ FUNCTION_COMPLEXITY_THRESHOLD=28
 # Ratcheted down to 283 (GH#19365): actual violations 281 + 2 buffer
 # Bumped to 288 (GH#19373): proximity guard firing at 281/283 (2 headroom); 281 violations + 7 headroom = 288.
 # Proximity guard (warn_at = 288-5 = 283) fires when violations exceed 283 (i.e., at 284), preventing saturation.
-NESTING_DEPTH_THRESHOLD=288
+# Ratcheted down to 283 (GH#19382): actual violations 281 + 2 buffer
+NESTING_DEPTH_THRESHOLD=283
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Lowered NESTING_DEPTH_THRESHOLD from 288 to 283. Actual violations: 281, buffer: 2. Added ratchet-down audit comment above updated value.

## Files Changed

.agents/configs/complexity-thresholds.conf

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Ran complexity-scan-helper.sh ratchet-check: violations=281, threshold=283, within budget. State file not staged.

Resolves #19382


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.61 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-sonnet-4-6 spent 1m and 3,892 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality threshold configuration to enforce stricter standards for code complexity in the CI pipeline.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->