### PR TITLE
GH#19390: bump NESTING_DEPTH_THRESHOLD 283→288 (proximity guard at 281/283)

### DIFF
--- a/.agents/configs/complexity-thresholds-history.md
+++ b/.agents/configs/complexity-thresholds-history.md
@@ -68,6 +68,8 @@ Archives the full change history for `.agents/configs/complexity-thresholds.conf
 | 288 | GH#19342 | proximity guard firing at 281/283 (2 headroom); 281 violations + 7 headroom = 288; proximity guard (warn_at = 288-5 = 283) fires when violations exceed 283 (i.e., at 284), preventing saturation |
 | 283 | GH#19365 | ratcheted down — actual violations 281 + 2 buffer |
 | 288 | GH#19373 | proximity guard firing at 281/283 (2 headroom); 281 violations + 7 headroom = 288; proximity guard (warn_at = 288-5 = 283) fires when violations exceed 283 (i.e., at 284), preventing saturation |
+| 283 | GH#19382 | ratcheted down — actual violations 281 + 2 buffer |
+| 288 | GH#19390 | proximity guard firing at 281/283 (2 headroom); 281 violations + 7 headroom = 288; proximity guard (warn_at = 288-5 = 283) fires when violations exceed 283 (i.e., at 284), preventing saturation |
 
 ## FUNCTION_COMPLEXITY_THRESHOLD History
 

--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -136,7 +136,9 @@ FUNCTION_COMPLEXITY_THRESHOLD=28
 # Bumped to 288 (GH#19373): proximity guard firing at 281/283 (2 headroom); 281 violations + 7 headroom = 288.
 # Proximity guard (warn_at = 288-5 = 283) fires when violations exceed 283 (i.e., at 284), preventing saturation.
 # Ratcheted down to 283 (GH#19382): actual violations 281 + 2 buffer
-NESTING_DEPTH_THRESHOLD=283
+# Bumped to 288 (GH#19390): proximity guard firing at 281/283 (2 headroom); 281 violations + 7 headroom = 288.
+# Proximity guard (warn_at = 288-5 = 283) fires when violations exceed 283 (i.e., at 284), preventing saturation.
+NESTING_DEPTH_THRESHOLD=288
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Bumps `NESTING_DEPTH_THRESHOLD` from 283 to 288, following the established bump-and-ratchet cadence documented in `complexity-thresholds.conf`.

- **Current violations**: 281 (verified by running the same awk logic as CI against `lint_shell_files()`)
- **Previous threshold**: 283 (headroom: 2)
- **New threshold**: 288 (headroom: 7)
- **Proximity guard**: `warn_at = 288-5 = 283`, fires when violations exceed 283 (i.e., at 284), preventing saturation

## Changes

- EDIT: `.agents/configs/complexity-thresholds.conf` — bump `NESTING_DEPTH_THRESHOLD` 283→288, add GH#19390 comment
- EDIT: `.agents/configs/complexity-thresholds-history.md` — add GH#19382 ratchet-down entry (was missing) and GH#19390 bump entry

## Rationale

This is identical to GH#19288, GH#19342, and GH#19373 — the proximity guard keeps firing at 281/283. The violation count has held at 281 for multiple cycles; a dedicated simplification sweep (refactoring scripts with max nesting > 8 to use early-return patterns and extracted helpers) would be needed to ratchet this down. The bump-with-7-headroom pattern provides breathing room for in-flight PRs without blocking CI.

## Verification

CI `Shell nesting depth` job will pass: violations (281) ≤ new threshold (288).

Resolves #19390