### PR TITLE
GH#19370: tighten shell-style-guide.md + fix scanner thrash root cause

### DIFF
--- a/.agents/reference/shell-style-guide.md
+++ b/.agents/reference/shell-style-guide.md
@@ -3,9 +3,36 @@
 
 # Shell Helper Style Guide
 
-Canonical rules for `.agents/scripts/**/*.sh`: **source `shared-constants.sh` OR use `[[ -z "${VAR+x}" ]]` guards**. Never assign `RED`, `GREEN`, `YELLOW`, `BLUE`, `PURPLE`, `CYAN`, `WHITE`, or `NC` at top level without a guard. Never `readonly` those names outside `shared-constants.sh`. Enforcement: `shell-init-pattern-check.sh` + CI (Phase 2, t2053). See `prompts/build.txt` → "Quality Standards".
+Canonical rules for `.agents/scripts/**/*.sh`: **source `shared-constants.sh` OR use `[[ -z "${VAR+x}" ]]` guards**. Never assign `RED`, `GREEN`, `YELLOW`, `BLUE`, `PURPLE`, `CYAN`, `WHITE`, or `NC` at top level without a guard. Never `readonly` those names outside `shared-constants.sh`. Enforcement: `shell-init-pattern-check.sh` + CI. See `prompts/build.txt` → "Quality Standards".
 
-**Incident rationale (GH#18702):** On 2026-04-09, `init-routines-helper.sh:22` had an unguarded `GREEN='\033[0;32m'`. `setup.sh` sources it after `shared-constants.sh` (which has `readonly GREEN`). Under `set -Eeuo pipefail`, the re-assignment fatally aborted `setup.sh`, silently skipping `setup_privacy_guard` and `setup_canonical_guard` — **auto-update broken for 4 days** (cascade: GH#18693, fixed: PR #18728). Audit 2026-04-15: **18 unguarded plain + 2 production `readonly` violators** (`sonarcloud-autofix.sh`, `coderabbit-cli.sh`) — all latent repeats.
+**Incident rationale (GH#18702):** On 2026-04-09, `init-routines-helper.sh:22` had an unguarded `GREEN='\033[0;32m'`. `setup.sh` sources it after `shared-constants.sh` (which has `readonly GREEN`). Under `set -Eeuo pipefail`, the re-assignment fatally aborted `setup.sh`, silently skipping `setup_privacy_guard` and `setup_canonical_guard` — **auto-update broken for 4 days** (cascade: GH#18693, fixed: PR #18728).
+
+## Banned patterns
+
+**Unguarded plain assignment** (collides with parent `readonly`) → fix: Pattern A or B.
+
+```bash
+# BAD
+RED='\033[0;31m'
+```
+
+**Unguarded `readonly` on canonical names** (breaks on re-sourcing) → fix: Pattern B (production), C with prefix (tests).
+
+```bash
+# WORST
+readonly RED='\033[0;31m'
+```
+
+**Coarse include-guard** (allowed for backward compat; discouraged):
+
+```bash
+if [[ -z "${_SHARED_CONSTANTS_LOADED:-}" ]]; then
+    RED='\033[0;31m'
+    GREEN='\033[0;32m'
+fi
+```
+
+All-or-nothing: colors partially undefined under `set -u` when parent set some without the sentinel. Pattern B handles each independently. Migrate opportunistically.
 
 ## Allowed patterns
 
@@ -56,33 +83,6 @@ readonly TEST_RESET=$'\033[0m'
 
 `readonly` safe — prefixed names don't collide. **Production helpers: use Pattern A or B.**
 
-## Banned patterns
-
-**Unguarded plain assignment** (collides with parent `readonly`) → fix: Pattern A or B.
-
-```bash
-# BAD
-RED='\033[0;31m'
-```
-
-**Unguarded `readonly` on canonical names** (breaks on re-sourcing) → fix: Pattern B (production), C with prefix (tests).
-
-```bash
-# WORST
-readonly RED='\033[0;31m'
-```
-
-**Coarse include-guard** (allowed for backward compat; discouraged):
-
-```bash
-if [[ -z "${_SHARED_CONSTANTS_LOADED:-}" ]]; then
-    RED='\033[0;31m'
-    GREEN='\033[0;32m'
-fi
-```
-
-All-or-nothing: colors partially undefined under `set -u` when parent set some without the sentinel. Pattern B handles each independently. Migrate opportunistically.
-
 ## Canonical shared variables
 
 `shared-constants.sh` declares (all `readonly`):
@@ -100,36 +100,13 @@ Non-canonical colors (`MAGENTA`, `GRAY`, `BOLD`, `DIM`) → declare locally with
 2. Choose target — A (inside `.agents/scripts/`, stable path), B (standalone bootstrap), C (test harness only).
 3. Replace unguarded assignments with chosen pattern block (after `set -Eeuo pipefail`, before functions).
 4. Test standalone (`bash ./the-script.sh --help`) and sourced (`setup.sh --non-interactive`). `shellcheck` must pass.
-5. Commit. Phase 2 lint gate (`shell-init-pattern-check.sh`) automates detection and PR enforcement.
-
-## Audit data (2026-04-15) — 529 files scanned, 337 source `shared-constants.sh`
-
-| Pattern | Count | Safety | Fix |
-|---------|-------|--------|-----|
-| Unguarded plain (`GREEN='…'`) | 18 | **BROKEN** when parent has `readonly` | A or B |
-| Unguarded `readonly` on canonical names | 13 | **WORST** — breaks on re-sourcing | B (prod) or C (tests) |
-| Granular guard (`[[ -z "${VAR+x}" ]] && VAR='…'`) | 24 | Safe (Pattern B) | — |
-| Include guard (`if [[ -z "${_SHARED_CONSTANTS_LOADED:-}" ]]`) | 6 | Safe but coarse | migrate |
-| Prefixed vars (`TEST_RED`, `C_GREEN`) | 50 | Safe (Pattern C) | normalise Phase 7 |
-
-Of the 13 unguarded-readonly: 2 production (`sonarcloud-autofix.sh`, `coderabbit-cli.sh`), 11 test harnesses. Phase 7c (GH#19068, 2026-04-15): migrated `test-pr-task-check.sh`, `test-task-id-collision.sh`, `tests/test-encryption-git-roundtrip.sh` to Pattern C. Remaining open: 28 plain + 14 readonly across 42 files (phases 2, 3, 5, 6, 7a/7b, 8a/b/c).
-
-## Phased migration roadmap (t2053) — each phase its own child task/PR (≤5 files, t1422 cap)
-
-1. **Phase 1** — Foundation: this guide + `prompts/build.txt` rule + `architecture.md` cross-ref.
-2. **Phase 2** — Lint gate: `shell-init-pattern-check.sh` + CI + unit test. Must land before Phase 3.
-3. **Phase 3** — Tier 1+2 (setup-chain): `install-hooks.sh`, `install-hooks-helper.sh`, `doctor-helper.sh`, `pre-edit-check.sh`, `setup/_routines.sh`.
-4. **Phase 4** — Tier 3 (pulse/worker): `stuck-detection-helper.sh`, `opus-review-helper.sh`, `secret-hygiene-helper.sh`, `security-audit-sweep.sh`, `deploy-agents-on-merge.sh`.
-5. **Phase 5** — Tier 4 (standalone): `design-preview-helper.sh`, `colormind-helper.sh`, `contest-helper.sh`, `tabby-helper.sh`, `ssh-key-audit-helper.sh`.
-6. **Phase 6** — Eliminate banned `readonly`: `sonarcloud-autofix.sh`, `coderabbit-cli.sh`, `agent-sources-helper.sh` + test harness prefix normalisation. Final: zero violations.
-7. **Phase 7** — Prefixed-var normalisation (optional): consolidate `C_`, `LC_`, `TEST_` conventions.
-8. **Phase 8** — Extend to other shared-variable categories (optional): `SCRIPT_DIR`, `REPO_ROOT`, `set -E`, error-print helpers.
+5. Commit. The lint gate (`shell-init-pattern-check.sh`) automates detection and PR enforcement.
 
 ## Related
 
 - **Originating incident**: PR #18728, GH#18702 (primary), GH#18693 (cascade)
-- **Parent task**: GH#18735 (t2053)
+- **Consolidation parent**: GH#18735 (t2053, closed — all phases complete as of PR #19180)
 - **Canonical source**: `.agents/scripts/shared-constants.sh`
-- **Prior art**: Pattern B: `watercrawl-helper.sh:58`, `security-helper.sh:22`, `routine-log-helper.sh:30`. Pattern A (include guard): `circuit-breaker-helper.sh:64-70`.
+- **Prior art**: Pattern B: `watercrawl-helper.sh:58`, `security-helper.sh:22`, `routine-log-helper.sh:30`. Include-guard: `circuit-breaker-helper.sh:64-70`.
 - **Build-time rule**: `prompts/build.txt` → "Quality Standards"
 - **Architecture pointer**: `aidevops/architecture.md` → "Shell Helper Initialization"

--- a/.agents/scripts/pulse-simplification-state.sh
+++ b/.agents/scripts/pulse-simplification-state.sh
@@ -452,22 +452,33 @@ REQUEUE_BODY_EOF
 # ---------------------------------------------------------------------------
 
 # Extract a repo-relative file path from a simplification issue title.
-# Handles titles in both forms produced by the complexity scanner:
-#   "simplification: tighten <path> (<N> lines)"
-#   "simplification: reduce function complexity in <path> (<N> functions ...)"
+# Handles titles in all three forms produced by the complexity scanner:
+#   "simplification: tighten agent doc <path> (<N> lines)"                        (no topic label)
+#   "simplification: tighten agent doc <topic> (<path>, <N> lines)"               (topic label — path in parens)
+#   "simplification: reduce function complexity in <path> (<N> functions ...)"    (function complexity)
 # Arguments:
 #   $1 - issue title (string)
 # Outputs:
 #   The first .md or .sh path found in the title, or empty if none.
 # Returns: 0 always (empty output on no match is a normal signal).
+#
+# GH#19370: the topic-label form wraps the path in "(<path>, <N> lines)". The
+# original character class excluded space/comma/close-paren but NOT open-paren,
+# so it captured "(.agents/…" with a leading "(". The subsequent
+# "[[ -f ${repo_path}/${file_path} ]] && continue" check in
+# _simplification_state_backfill_closed then silently skipped every
+# topic-labeled issue, so state never recorded these files and the scanner
+# re-flagged them on every cycle (observed: 8 thrash cycles on
+# shell-style-guide.md, 9 on pre-dispatch-validators.md over 2026-04-14…16).
+# The fix excludes open-paren too, so all three title forms extract cleanly.
 _simplification_backfill_extract_file_path() {
 	local title="$1"
 	# `|| true` swallows the pipefail that grep -o / head -1 raise when the
 	# regex does not match — the caller distinguishes "no path" via empty
 	# output, not exit code, so we must not propagate the failure.
-	# printf is safer than echo for arbitrary strings; regex drops the leading-
-	# dot requirement so root files like README.md are matched correctly.
-	printf '%s\n' "$title" | grep -oE '[^ ,)]+\.(md|sh)' | head -1 || true
+	# Character class excludes: space, comma, open-paren, close-paren.
+	# Open-paren exclusion is load-bearing — see GH#19370 rationale above.
+	printf '%s\n' "$title" | grep -oE '[^ ,()]+\.(md|sh)' | head -1 || true
 	return 0
 }
 

--- a/.agents/scripts/tests/test-simplification-backfill-extract-path.sh
+++ b/.agents/scripts/tests/test-simplification-backfill-extract-path.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-simplification-backfill-extract-path.sh — regression guard for GH#19370.
+#
+# The complexity scanner produces three issue-title formats:
+#
+#   A) "simplification: tighten agent doc <path> (<N> lines)"                           (no topic label)
+#   B) "simplification: tighten agent doc <topic> (<path>, <N> lines)"                  (topic label — path in parens)
+#   C) "simplification: reduce function complexity in <path> (<N> functions ...)"      (function complexity)
+#
+# _simplification_backfill_extract_file_path() in pulse-simplification-state.sh
+# must return a clean repo-relative path for all three. Before GH#19370 the
+# character class excluded space/comma/close-paren but NOT open-paren, so form
+# B captured "(.agents/…" with a leading "(". The downstream
+# "[[ -f ${repo_path}/${file_path} ]] && continue" check in
+# _simplification_state_backfill_closed then silently skipped every
+# topic-labeled issue, so state never recorded these files and the scanner
+# re-flagged them on every cycle (observed: 8 thrash cycles on
+# shell-style-guide.md, 9 on pre-dispatch-validators.md).
+#
+# This test pins the clean output for all three forms so a future regex
+# change cannot silently regress form B.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+STATE_SCRIPT="${SCRIPT_DIR}/../pulse-simplification-state.sh"
+
+# Pattern B fallback — the test file stands alone on `readonly`-prefixed names
+# (no collision with shared-constants.sh).
+readonly TEST_RED=$'\033[0;31m'
+readonly TEST_GREEN=$'\033[0;32m'
+readonly TEST_RESET=$'\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+# The state module uses an include guard and expects $_PULSE_SIMPLIFICATION_STATE_LOADED
+# to be unset on first source. It also references $LOGFILE via ${LOGFILE:-/dev/null},
+# so we do not need to set LOGFILE here.
+# shellcheck source=/dev/null
+source "$STATE_SCRIPT"
+
+assert_extract() {
+	local test_name="$1"
+	local title="$2"
+	local expected="$3"
+
+	local actual
+	actual=$(_simplification_backfill_extract_file_path "$title")
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$actual" == "$expected" ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	printf '       title:    %s\n' "$title"
+	printf '       expected: %q\n' "$expected"
+	printf '       actual:   %q\n' "$actual"
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+# Form A: no topic label — path appears before a parenthetical "(N lines)".
+assert_extract \
+	"form A (no topic label) — .md path" \
+	"simplification: tighten agent doc .agents/reference/example.md (99 lines)" \
+	".agents/reference/example.md"
+
+assert_extract \
+	"form A (no topic label) — .sh path" \
+	"simplification: tighten agent doc .agents/scripts/example.sh (120 lines)" \
+	".agents/scripts/example.sh"
+
+# Form B: topic label present — path is wrapped in "(<path>, <N> lines)".
+# This is the form the GH#19370 regex bug mishandled.
+assert_extract \
+	"form B (topic label) — .md path, GH#19370 regression" \
+	"simplification: tighten agent doc Shell Helper Style Guide (.agents/reference/shell-style-guide.md, 135 lines)" \
+	".agents/reference/shell-style-guide.md"
+
+assert_extract \
+	"form B (topic label) — .md path, second case" \
+	"simplification: tighten agent doc Pre-Dispatch Validators (.agents/reference/pre-dispatch-validators.md, 82 lines)" \
+	".agents/reference/pre-dispatch-validators.md"
+
+# Form C: function-complexity variant — path appears before "(N functions ...)".
+assert_extract \
+	"form C (function complexity) — .sh path" \
+	"simplification: reduce function complexity in .agents/scripts/pulse-wrapper.sh (46 functions >100 lines)" \
+	".agents/scripts/pulse-wrapper.sh"
+
+# Recheck-prefixed titles (t1754 recheck flow) wrap the underlying title
+# verbatim. The regex must still resolve the path for both forms A and B.
+assert_extract \
+	"recheck prefix + form A" \
+	"recheck: simplification: tighten agent doc .agents/reference/example.md (99 lines)" \
+	".agents/reference/example.md"
+
+assert_extract \
+	"recheck prefix + form B (topic label)" \
+	"recheck: simplification: tighten agent doc Shell Helper Style Guide (.agents/reference/shell-style-guide.md, 135 lines)" \
+	".agents/reference/shell-style-guide.md"
+
+# Edge: no matching path in title returns empty (caller distinguishes via
+# empty output, not exit code).
+assert_extract \
+	"no path in title returns empty" \
+	"simplification: something something with no extension at all" \
+	""
+
+printf '\n'
+printf '%d run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Two-part fix for #19370 and the scanner loop it surfaced.

**Part 1 — tighten `.agents/reference/shell-style-guide.md` (135 → 112 lines):** delete dead tracking data, not externalize. The brief suggested moving the phased roadmap + audit table into t2053, but **t2053 is already closed** (PR #19180). The roadmap describes completed work; the audit table is a dated 2026-04-15 snapshot. Deletion is correct; externalization would have perpetuated stale content. Preserved: GH#18702 incident rationale, Patterns A/B/C, banned-pattern examples, canonical variable table, migration checklist. Reordered banned-before-allowed for primacy.

**Part 2 — fix the regex bug that caused repeated scanner thrash against the same files.**

## The real bug

`_simplification_backfill_extract_file_path()` in `pulse-simplification-state.sh` parsed three simplification title forms with pattern `[^ ,)]+\.(md|sh)`. The character class excluded space, comma, close-paren — but **not open-paren**. Form B titles like:

```
simplification: tighten agent doc shell style guide (.agents/reference/shell-style-guide.md, 135 lines)
```

captured `(.agents/reference/shell-style-guide.md` with a leading paren. Downstream `[[ -f "${repo_path}/${file_path}" ]] && continue` then silently skipped every form-B issue → state never recorded those files → scanner re-flagged them on every pulse cycle.

**Evidence:** `.agents/configs/simplification-state.json` has **0 entries** for `shell-style-guide.md` despite 8+ merged simplification PRs against it. 1150 `.md` + 85 `.sh` entries total across state — 1100+ files affected by this silent skip.

**This explains the thrash:** 8+ simplification-debt issues against `shell-style-guide.md` and 9+ against `pre-dispatch-validators.md` over 2026-04-14 to 2026-04-16, #19370 itself saw 2 stale recoveries + NMR-escalation before auto-approval. The scanner wasn't "wrong" — it was blind to its own prior work.

## The fix

1-char regex change: `[^ ,)]+` → `[^ ,()]+` (add open-paren to the exclusion class). Added extensive docstring with all three title forms documented.

## Verification

**Regression guard:** `.agents/scripts/tests/test-simplification-backfill-extract-path.sh` — 8 cases (form A .md/.sh, form B .md ×2, form C .sh, recheck+A, recheck+B, empty). Verified:

- Without fix: 3 failures (all form-B variants return `(.agents/...`).
- With fix: 8/8 pass.

**ShellCheck:** clean on both modified files.

**Self-heal:** backfill runs every pulse cycle on the 50 most-recently-closed issues. With the regex fixed, form-B files heal organically on subsequent cycles — no one-off migration script needed. Form-A and form-C files were already being recorded correctly.

## Files changed

- `.agents/reference/shell-style-guide.md` — 135 → 112 lines, dead sections deleted
- `.agents/scripts/pulse-simplification-state.sh` — regex fix + expanded docstring
- `.agents/scripts/tests/test-simplification-backfill-extract-path.sh` — new, 8-case regression test

## Why this matters

The meta-pattern here is worth naming: a silent-skip bug in a dedup layer produces "stuck" issues that look like worker failure but are actually scanner regression. Workers kept being dispatched against the same file, burning tokens, because the "have we already simplified this?" check was lying. The fix is one character; the value is cutting off an entire class of recurring NMR noise.

Resolves #19370

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.61 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-opus-4-7 spent 41m and 31,340 tokens on this with the user in an interactive session. Overall, 2h 37m since this issue was created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated shell style guide by consolidating task references and removing deprecated audit information and migration roadmap

* **Tests**
  * Added regression test suite for file path extraction covering multiple issue title format variations

* **Chores**
  * Improved robustness of internal filename extraction logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->