### PR TITLE
GH#19394: GH#19394: tighten pre-dispatch-validators.md (79→75 lines)

### DIFF
--- a/.agents/reference/pre-dispatch-validators.md
+++ b/.agents/reference/pre-dispatch-validators.md
@@ -1,12 +1,8 @@
 # Pre-Dispatch Validators
 
-Runs **after** dedup checks and **before** worker spawn for auto-generated issues — verifies the premise still holds (GH#19118).
+Runs **after** dedup checks and **before** worker spawn for auto-generated issues — verifies the premise still holds (GH#19118). Issues embed `<!-- aidevops:generator=<name> -->` in the body (HTML comments survive title/label changes). `pre-dispatch-validator-helper.sh` maps generators to validators via `_VALIDATOR_REGISTRY`. Unregistered generators, missing helper, or unexpected exit code → exit 0 (dispatch proceeds).
 
-## Architecture
-
-Auto-generated issues embed `<!-- aidevops:generator=<name> -->` in the body (HTML comments survive title/label changes). `pre-dispatch-validator-helper.sh` maps generators to validators via `_VALIDATOR_REGISTRY`. Unregistered generators, missing helper, or unexpected exit code → exit 0 (dispatch proceeds).
-
-### Exit codes
+## Exit codes
 
 | Code | Meaning | Action |
 |------|---------|--------|
@@ -14,7 +10,7 @@ Auto-generated issues embed `<!-- aidevops:generator=<name> -->` in the body (HT
 | `10` | Premise falsified | Comment posted (`> Premise falsified`, citing GH#19118) + `gh issue close --reason "not planned"` |
 | `20` | Validator error | Warning logged; dispatch proceeds (never block on validator bugs) |
 
-### Hook point (`pulse-dispatch-core.sh`)
+## Hook point (`pulse-dispatch-core.sh`)
 
 ```text
 _dispatch_dedup_check_layers()   ← all dedup gates


### PR DESCRIPTION
## Summary

Removed redundant Architecture heading; folded prose into intro; promoted Exit codes and Hook point from sub-sections to top-level headings. Reduces nesting depth while preserving all institutional knowledge, GH references, code blocks, and command examples.

## Files Changed

.agents/reference/pre-dispatch-validators.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** wc -l confirms 75 lines (from 79); all code blocks, GH#19118/19024/19036/19037/t2063 references, and command examples present; no Qlty smells (qlty returned 0).

Resolves #19394


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.61 plugin for [OpenCode](https://opencode.ai) v1.4.6 with claude-sonnet-4-6 spent 1m and 4,595 tokens on this as a headless worker.