### PR TITLE
GH#19395: chore: ratchet-down complexity thresholds

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -138,7 +138,8 @@ FUNCTION_COMPLEXITY_THRESHOLD=28
 # Ratcheted down to 283 (GH#19382): actual violations 281 + 2 buffer
 # Bumped to 288 (GH#19390): proximity guard firing at 281/283 (2 headroom); 281 violations + 7 headroom = 288.
 # Proximity guard (warn_at = 288-5 = 283) fires when violations exceed 283 (i.e., at 284), preventing saturation.
-NESTING_DEPTH_THRESHOLD=288
+# Ratcheted down to 283 (GH#19395): actual violations 281 + 2 buffer
+NESTING_DEPTH_THRESHOLD=283
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)
@@ -174,7 +175,8 @@ FILE_SIZE_THRESHOLD=59
 # shell in interactive-session-helper.sh + pulse-issue-reconcile.sh; all new
 # heredocs are plain `cat >file <<EOF`, not `$(cat <<…)` form). Pure drift
 # absorption. 76 + 2 buffer = 78. Ratchet back down in the next quality sweep.
-BASH32_COMPAT_THRESHOLD=78
+# Ratcheted down to 74 (GH#19395): actual violations 72 + 2 buffer
+BASH32_COMPAT_THRESHOLD=74
 
 # Qlty maintainability smell baseline (t2065, GH#18773). Seed value for
 # the `.github/workflows/qlty-regression.yml` gate. The gate itself uses


### PR DESCRIPTION
## Summary

Automated ratchet-down of complexity thresholds following simplification wins:

- **NESTING_DEPTH_THRESHOLD**: 288 → 283 (actual violations: 281, +2 buffer)
- **BASH32_COMPAT_THRESHOLD**: 78 → 74 (actual violations: 72, +2 buffer)

## Changes

- EDIT: `.agents/configs/complexity-thresholds.conf` — lowered both thresholds, added ratchet-down audit comments above each updated value
- `simplification-state.json` is NOT included in this PR (per issue guidance)

## Verification

```bash
grep -E 'NESTING_DEPTH_THRESHOLD|BASH32_COMPAT_THRESHOLD' .agents/configs/complexity-thresholds.conf
# NESTING_DEPTH_THRESHOLD=283
# BASH32_COMPAT_THRESHOLD=74
```

Resolves #19395