### PR TITLE
t2149: resolve agent basename collisions deterministically (GH#19399)

### DIFF
--- a/.agents/scripts/generate-runtime-config.sh
+++ b/.agents/scripts/generate-runtime-config.sh
@@ -318,6 +318,78 @@ _clean_generated_subagents() {
 	return 0
 }
 
+# GH#19399 / t2149: Resolve basename collisions deterministically.
+#
+# Multiple source files with the same basename (e.g. `aidevops/architecture.md`
+# vs `tools/diagrams/mermaid-diagrams-skill/architecture.md`) previously fed
+# the parallel `xargs -P` write loop, where whichever subshell won the race
+# wrote the deployed stub. When the permissive sibling won, the sandboxed
+# source's `bash: false` / `webfetch: false` intent was silently lost.
+#
+# This function enumerates the same candidate set as the generator, groups by
+# basename, and emits one path per basename:
+#   - If any candidate declares `bash: false`, that one wins (restrictive
+#     default — preserves the sandbox the source maintainer expressed).
+#   - Otherwise the alphabetically-first path wins (deterministic tiebreak).
+#   - Every losing sibling is logged as a warning to stderr.
+#
+# Reads: AGENTS_DIR
+# Writes: NUL-delimited list of winning source paths to stdout
+#         Human-readable collision warnings to stderr
+# Bash 3.2 compatible (no associative arrays; uses sort/awk).
+_resolve_basename_collisions_for_generate() {
+	local tmpfile
+	tmpfile=$(mktemp 2>/dev/null || mktemp -t generate-runtime-config.XXXXXX)
+
+	# For each candidate source: record name, priority (0=restrictive, 1=permissive), path.
+	# Priority 0 wins via ascending sort.
+	find "$AGENTS_DIR" -mindepth 2 -name "*.md" -type f \
+		-not -path "*/loop-state/*" -not -name "*-skill.md" -print0 |
+		while IFS= read -r -d '' f; do
+			local name priority
+			name=$(basename "$f" .md)
+			[[ "$name" == "AGENTS" || "$name" == "README" ]] && continue
+			priority=1
+			if awk '/^---$/ { fm++; next } fm == 1 && /bash:[[:space:]]*false/ { print; exit } fm == 2 { exit }' "$f" 2>/dev/null | grep -q .; then
+				priority=0
+			fi
+			printf '%s\t%d\t%s\n' "$name" "$priority" "$f" >>"$tmpfile"
+		done
+
+	# Sort: name asc, priority asc (restrictive first), path asc (alphabetical tiebreak).
+	# Awk pass:
+	#   - First row per name wins; emit the path to stdout (NUL-delimited).
+	#   - Subsequent rows are collision losers.
+	#   - Only emit a warning when the sandbox bug class applies: the winner
+	#     has `bash: false` (priority 0) AND a loser doesn't, OR vice versa.
+	#     Collisions between equally-permissive sources are noise (e.g. the
+	#     numbered content files under tools/design/library/brands/*/*.md).
+	#
+	# Note on NUL emission: macOS awk (BSD, stock on Darwin) does NOT interpret
+	# `\0` or embed NUL bytes via `%s` in printf. We use `printf "%c", 0` which
+	# works on both GNU awk and macOS awk.
+	sort -t$'\t' -k1,1 -k2,2n -k3,3 "$tmpfile" | awk -F'\t' '
+		$1 != prev_name {
+			printf "%s", $3
+			printf "%c", 0
+			winner = $3
+			winner_priority = $2
+			prev_name = $1
+			next
+		}
+		{
+			# Warn only when sandbox-intent is mixed across the collision set.
+			if (winner_priority != $2) {
+				printf "[WARN] basename collision for %s: %s (bash:%s) loses to %s (bash:%s)\n", \
+					$1, $3, ($2 == 0 ? "false" : "default"), winner, (winner_priority == 0 ? "false" : "default") > "/dev/stderr"
+			}
+		}
+	'
+
+	rm -f "$tmpfile"
+	return 0
+}
+
 # Generate subagent markdown stubs for OpenCode
 _generate_subagents_opencode() {
 	local agent_dir="$1"
@@ -335,7 +407,9 @@ _generate_subagents_opencode() {
 	_ncpu=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
 	local _parallel_jobs=$((_ncpu > 4 ? _ncpu : 4))
 	local subagent_count
-	subagent_count=$(find "$AGENTS_DIR" -mindepth 2 -name "*.md" -type f -not -path "*/loop-state/*" -not -name "*-skill.md" -print0 |
+	# GH#19399: collision-resolver emits one path per basename (restrictive source wins).
+	# Warnings to stderr surface any collisions; they're not fatal.
+	subagent_count=$(_resolve_basename_collisions_for_generate |
 		xargs -0 -P "$_parallel_jobs" -I {} bash -c '_write_subagent_stub "$@"' _ {} |
 		awk '{sum+=$1} END {print sum+0}')
 

--- a/.agents/scripts/tests/test-basename-collision-resolver.sh
+++ b/.agents/scripts/tests/test-basename-collision-resolver.sh
@@ -1,0 +1,215 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-basename-collision-resolver.sh — t2149 / GH#19399 regression guard.
+#
+# Verifies that `_resolve_basename_collisions_for_generate` in
+# generate-runtime-config.sh:
+#
+#   1. When two source files share a basename and exactly one declares
+#      `bash: false` in its YAML frontmatter, the restrictive source wins.
+#
+#   2. When two permissive sources share a basename (no `bash: false` in
+#      either), the alphabetically-first path wins — deterministic tiebreak.
+#
+#   3. A warning is emitted to stderr only when the winner's sandbox intent
+#      differs from a loser's. Equally-permissive collisions produce no
+#      warning (would be noise — the design-library numeric filenames
+#      collide by the dozen and all have identical permissions).
+#
+#   4. The subagent deploy loop, driven by this resolver, no longer races:
+#      re-running twice produces the same deployed stub both times.
+#
+# Failure history: GH#18509 fixed single-file sandbox shadowing but the
+# loop still iterated per-source, so a later commit that introduced a
+# permissive basename collision with an older sandboxed source would
+# silently downgrade it based on xargs -P scheduling. GH#19399 / t2149
+# generalises the GH#18509 invariant across basenames.
+
+set -uo pipefail
+
+TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_RED=$'\033[0;31m'
+TEST_GREEN=$'\033[0;32m'
+TEST_RESET=$'\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1" rc="$2" extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf '%sPASS%s %s\n' "$TEST_GREEN" "$TEST_RESET" "$name"
+	else
+		printf '%sFAIL%s %s %s\n' "$TEST_RED" "$TEST_RESET" "$name" "$extra"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+# Build a throwaway AGENTS_DIR with three synthetic subtrees:
+#   aidevops/architecture.md          — declares bash: false
+#   mermaid-diagrams-skill/arch.md    — no frontmatter (permissive)
+#   a/shared.md, b/shared.md          — equally permissive collision
+#   c/single.md                       — no collision, no frontmatter
+build_fixture_agents_dir() {
+	local dir="$1"
+	mkdir -p "$dir/aidevops" "$dir/mermaid-diagrams-skill" "$dir/a" "$dir/b" "$dir/c"
+
+	cat >"$dir/aidevops/architecture.md" <<'EOF'
+---
+description: Sandboxed architecture agent
+mode: subagent
+tools:
+  read: true
+  bash: false
+  webfetch: false
+---
+
+Sandboxed content.
+EOF
+
+	cat >"$dir/mermaid-diagrams-skill/architecture.md" <<'EOF'
+Permissive content — no frontmatter.
+EOF
+
+	cat >"$dir/a/shared.md" <<'EOF'
+---
+description: A shared permissive
+mode: subagent
+---
+
+From a/.
+EOF
+
+	cat >"$dir/b/shared.md" <<'EOF'
+---
+description: B shared permissive
+mode: subagent
+---
+
+From b/.
+EOF
+
+	cat >"$dir/c/single.md" <<'EOF'
+---
+description: Single non-colliding permissive
+mode: subagent
+---
+
+Alone.
+EOF
+
+	return 0
+}
+
+# --- Setup ---
+FIXTURE_DIR=$(mktemp -d 2>/dev/null || mktemp -d -t t2149)
+trap 'rm -rf "$FIXTURE_DIR"' EXIT
+
+build_fixture_agents_dir "$FIXTURE_DIR"
+
+# Source the generator (library mode — won't run top-level `main` because
+# the script routes subcommands via a case; sourcing at script scope
+# defines the functions).
+# shellcheck disable=SC1091
+source "$TEST_SCRIPTS_DIR/shared-constants.sh"
+# generate-runtime-config.sh has `set -euo pipefail` at top; sourcing it
+# will apply those set options to this shell. Capture and restore.
+set +e
+# shellcheck disable=SC1091
+source "$TEST_SCRIPTS_DIR/generate-runtime-config.sh" 2>/dev/null || true
+set +e
+
+if ! declare -F _resolve_basename_collisions_for_generate >/dev/null; then
+	echo "FAIL: _resolve_basename_collisions_for_generate not defined after sourcing"
+	exit 1
+fi
+
+# --- Run resolver against fixture ---
+export AGENTS_DIR="$FIXTURE_DIR"
+stderr_log=$(mktemp)
+winners_raw=$(mktemp)
+_resolve_basename_collisions_for_generate 2>"$stderr_log" >"$winners_raw"
+# Convert NUL-delimited output to newline-delimited for assertions
+winners=$(tr '\0' '\n' <"$winners_raw" | grep -v '^$' | sort)
+
+# --- Assertions ---
+
+# 1. architecture collision: sandboxed aidevops/ wins over permissive skill/.
+if echo "$winners" | grep -qE "/aidevops/architecture\\.md$" &&
+	! echo "$winners" | grep -qE "/mermaid-diagrams-skill/architecture\\.md$"; then
+	print_result "sandboxed source wins over permissive sibling" 0
+else
+	print_result "sandboxed source wins over permissive sibling" 1 \
+		"winners:\n$winners"
+fi
+
+# 2. shared.md collision: alphabetical tiebreak → a/ wins over b/.
+if echo "$winners" | grep -qE "/a/shared\\.md$" &&
+	! echo "$winners" | grep -qE "/b/shared\\.md$"; then
+	print_result "alphabetical tiebreak picks first path deterministically" 0
+else
+	print_result "alphabetical tiebreak picks first path deterministically" 1 \
+		"winners:\n$winners"
+fi
+
+# 3. single.md: no collision, included as-is.
+if echo "$winners" | grep -qE "/c/single\\.md$"; then
+	print_result "non-colliding source included" 0
+else
+	print_result "non-colliding source included" 1 "winners:\n$winners"
+fi
+
+# 4. Exactly one warning: the sandboxed-vs-permissive architecture case.
+warn_count=$(grep -cE '^\[WARN\] basename collision' "$stderr_log" || echo 0)
+# Strip any whitespace/newlines from wc output
+warn_count=$(printf '%s' "$warn_count" | tr -d '[:space:]')
+if [[ "$warn_count" == "1" ]]; then
+	print_result "warning emitted only for mixed-sandbox collision" 0
+else
+	print_result "warning emitted only for mixed-sandbox collision" 1 \
+		"expected 1 warning, got $warn_count. stderr:\n$(cat "$stderr_log")"
+fi
+
+# 5. The warning describes the architecture basename and identifies sandbox vs default.
+if grep -qE 'architecture.*bash:default.*loses to.*bash:false' "$stderr_log"; then
+	print_result "warning describes bash intent mix" 0
+else
+	print_result "warning describes bash intent mix" 1 \
+		"stderr:\n$(cat "$stderr_log")"
+fi
+
+# 6. Winner count: 4 unique basenames (architecture, shared, single — plus
+#    the fixture also includes c/single.md which is alone). Expect exactly 3.
+winner_count=$(printf '%s\n' "$winners" | wc -l | tr -d '[:space:]')
+if [[ "$winner_count" == "3" ]]; then
+	print_result "one winner per unique basename (no duplicates)" 0
+else
+	print_result "one winner per unique basename (no duplicates)" 1 \
+		"expected 3 winners, got $winner_count:\n$winners"
+fi
+
+# 7. Determinism: running the resolver twice yields the same output.
+second_run=$(_resolve_basename_collisions_for_generate 2>/dev/null |
+	tr '\0' '\n' | grep -v '^$' | sort)
+if [[ "$winners" == "$second_run" ]]; then
+	print_result "resolver output is deterministic across runs" 0
+else
+	print_result "resolver output is deterministic across runs" 1 \
+		"first:\n$winners\nsecond:\n$second_run"
+fi
+
+rm -f "$stderr_log" "$winners_raw"
+
+# --- Summary ---
+echo ""
+echo "Tests run: $TESTS_RUN"
+echo "Failed:    $TESTS_FAILED"
+
+if [[ "$TESTS_FAILED" -eq 0 ]]; then
+	exit 0
+fi
+exit 1


### PR DESCRIPTION
## Summary

Resolves a regression of the GH#18509 invariant reported in GH#19399: when two source agent files share a basename, the permissive sibling could silently overwrite the sandboxed source's deployed stub, gaining `bash: true` + `external_directory: allow` that the source explicitly denied.

Reported by @superdav42. Reproduced on this machine before the fix (5 of 6 basenames landed with the wrong permissions); clean after.

## Root cause

`_write_subagent_stub` in `generate-runtime-config.sh` decided sandbox-vs-permissive per source file, not per deployed basename. The outer loop was `find ... | xargs -P` — parallel, race-driven, last-writer-wins. GH#18509 fixed the single-source case; this PR generalises the invariant across basenames.

## Fix

1. **`_resolve_basename_collisions_for_generate`** — new helper that:
   - Enumerates the same candidate set the generator uses.
   - Groups by basename.
   - Picks the source with `bash: false` (restrictive default) when sandbox intent differs across candidates.
   - Falls back to alphabetical-first when intent matches (deterministic tiebreak).
   - Emits a warning to stderr only when sandbox intent is mixed — equally-permissive collisions (e.g. the numbered files under `tools/design/library/brands/*`) are noise and stay silent.
2. **`_generate_subagents_opencode`** now drives `xargs -P` off the resolver output, not raw `find`. One path per basename reaches the write step, so the race disappears.
3. macOS/BSD awk needs `printf "%c", 0` for NUL output (`%s` / `\0` are silently dropped) — noted in the function comment.

## Test coverage

`.agents/scripts/tests/test-basename-collision-resolver.sh` — 7 assertions:

- Sandboxed source wins over permissive sibling
- Alphabetical tiebreak picks first path deterministically
- Non-colliding source included
- Warning emitted only for mixed-sandbox collision (no noise on equally-permissive collisions)
- Warning describes `bash` intent mix
- One winner per unique basename
- Resolver output is deterministic across runs

All pass.

## End-to-end verification on this machine

Before the fix, `audit-agent-deployment.sh` was flaky (results depended on xargs race). After the fix, all 7 mixed-intent collisions resolve to their sandboxed source and audit reports clean:

```
[WARN] basename collision for architecture: .../mermaid-diagrams-skill/architecture.md (bash:default) loses to .../aidevops/architecture.md (bash:false)
[WARN] basename collision for best-practices: .../pulumi-gotchas/best-practices.md (bash:default) loses to .../tools/code-review/best-practices.md (bash:false)
[WARN] basename collision for docs: .../define-probes/docs.md (bash:default) loses to .../aidevops/docs.md (bash:false)
[WARN] basename collision for humanise: .../workflows/humanise.md (bash:default) loses to .../content/humanise.md (bash:false)
[WARN] basename collision for onboarding: .../aidevops/onboarding.md (bash:default) loses to .../product/onboarding.md (bash:false)
[WARN] basename collision for resources: .../pulumi-gotchas/resources.md (bash:default) loses to .../aidevops/resources.md (bash:false)
[WARN] basename collision for security: .../pulumi-gotchas/security.md (bash:default) loses to .../aidevops/security.md (bash:false)
...
All restricted agents are correctly deployed.
```

Interesting side-finding: the reporter listed 6 basenames; the resolver surfaced a 7th (`humanise`) with the same mixed-intent pattern, now also fixed.

## Runtime Testing

`self-assessed` — this is deploy-tooling code. Behaviour is verified by:

1. The new test suite (7 assertions, all pass).
2. Running `_generate_subagents_opencode` directly on this machine against the real `~/.aidevops/agents` tree: 1227 subagent files deployed, 7 sandbox-mixed collisions warned, `audit-agent-deployment.sh` reports clean.
3. `shellcheck` is clean on both modified files (only pre-existing SC1091 info notices for sourced files).

## Scope

- `.agents/scripts/generate-runtime-config.sh` — one new function, one rewired loop.
- `.agents/scripts/tests/test-basename-collision-resolver.sh` — new test.

No changes to `audit-agent-deployment.sh` — it already enforces the invariant; this PR just makes the generator produce deployments the audit will always accept.

## Follow-up noted

During testing I noticed `.agents/scripts/agent-discovery.py:28` calls `validate_subagent_refs(primary_agents, agents_dir)` but the library function signature requires a third `display_to_filename_fn` argument. This causes `generate-runtime-config.sh agents` to exit non-zero before the subagent deploy step, which is why the effect of this bug was masked on `aidevops update` runs that called the `agents` subcommand (but NOT on full `setup.sh` runs, which is why @superdav42 saw the bug in the wild). That Python signature drift is a separate pre-existing bug on main — I'll file it as a follow-up issue.

Resolves #19399


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.61 plugin for [OpenCode](https://opencode.ai) v1.4.7 with claude-opus-4-7 spent 17m and 36,821 tokens on this with the user in an interactive session.
