### PR TITLE
GH#19404: fix: pass display_to_filename to validate_subagent_refs

### DIFF
--- a/.agents/scripts/agent-discovery.py
+++ b/.agents/scripts/agent-discovery.py
@@ -7,7 +7,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'lib'))
 from discovery_utils import atomic_json_write
 from agent_config import (
     discover_primary_agents, validate_subagent_refs,
-    apply_disabled_agents, sort_key,
+    apply_disabled_agents, sort_key, display_to_filename,
 )
 from mcp_config import (
     apply_mcp_loading_policy, remove_deprecated_mcps,
@@ -25,7 +25,7 @@ agents_dir = os.path.expanduser("~/.aidevops/agents")
 primary_agents, sorted_agents, subagent_filtered_count = discover_primary_agents(agents_dir)
 
 # Validate subagent references
-missing_refs = validate_subagent_refs(primary_agents, agents_dir)
+missing_refs = validate_subagent_refs(primary_agents, agents_dir, display_to_filename)
 if missing_refs:
     for agent, ref in missing_refs:
         print(f"  Warning: {agent} references subagent '{ref}' but no {ref}.md found", file=sys.stderr)

--- a/.agents/scripts/opencode-agent-discovery.py
+++ b/.agents/scripts/opencode-agent-discovery.py
@@ -7,7 +7,7 @@ sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'lib'))
 from discovery_utils import atomic_json_write
 from agent_config import (
     discover_primary_agents, validate_subagent_refs,
-    apply_disabled_agents,
+    apply_disabled_agents, display_to_filename,
 )
 from mcp_config import (
     apply_mcp_loading_policy, remove_deprecated_mcps,
@@ -36,7 +36,7 @@ except (OSError, json.JSONDecodeError) as e:
 primary_agents, sorted_agents, subagent_filtered_count = discover_primary_agents(agents_dir)
 
 # Validate subagent references
-missing_refs = validate_subagent_refs(primary_agents, agents_dir)
+missing_refs = validate_subagent_refs(primary_agents, agents_dir, display_to_filename)
 if missing_refs:
     for agent, ref in missing_refs:
         print(f"  Warning: {agent} references subagent '{ref}' but no {ref}.md found", file=sys.stderr)


### PR DESCRIPTION
## Summary

Fixed signature drift in agent-discovery.py and opencode-agent-discovery.py by importing and passing the display_to_filename function to validate_subagent_refs(). This unblocks end-to-end config regeneration for OpenCode.

## Files Changed

.agents/scripts/agent-discovery.py,.agents/scripts/opencode-agent-discovery.py

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified: ~/.aidevops/agents/scripts/generate-runtime-config.sh agents --runtime opencode completes without TypeError

Resolves #19404


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.62 plugin for [OpenCode](https://opencode.ai) v1.4.7 with claude-haiku-4-5 spent 2m and 2,814 tokens on this as a headless worker.