### PR TITLE
GH#19397: chore: ratchet-down BASH32_COMPAT_THRESHOLD 78→74 (GH#19397)

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -186,7 +186,8 @@ FILE_SIZE_THRESHOLD=59
 # no `declare -A`, and no heredoc-inside-`$()`). Pure drift absorption,
 # identical pattern to t2148. 76 + 2 buffer = 78. Ratchet back down in the
 # next quality sweep.
-BASH32_COMPAT_THRESHOLD=78
+# Ratcheted down to 74 (GH#19397): actual violations 72 + 2 buffer
+BASH32_COMPAT_THRESHOLD=74
 
 # Qlty maintainability smell baseline (t2065, GH#18773). Seed value for
 # the `.github/workflows/qlty-regression.yml` gate. The gate itself uses


### PR DESCRIPTION
## Summary

Ratcheted BASH32_COMPAT_THRESHOLD from 78 to 74 (actual violations 72 + 2 buffer). NESTING_DEPTH_THRESHOLD was already at 283 (no change needed).

## Files Changed

.agents/configs/complexity-thresholds.conf

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** grep BASH32_COMPAT_THRESHOLD .agents/configs/complexity-thresholds.conf returns 74; simplification-state.json not staged.

Resolves #19397


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.63 plugin for [OpenCode](https://opencode.ai) v1.4.7 with claude-sonnet-4-6 spent 2m and 7,353 tokens on this as a headless worker.