### PR TITLE
t2144: fix consolidation-task cascade (filter regex + backfill guard + grace window)

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -186,6 +186,20 @@ FILE_SIZE_THRESHOLD=59
 # no `declare -A`, and no heredoc-inside-`$()`). Pure drift absorption,
 # identical pattern to t2148. 76 + 2 buffer = 78. Ratchet back down in the
 # next quality sweep.
+# Ratcheted down to 74 (GH#19397, PR #19408): same-day re-ratchet to actual
+# 72 + 2 buffer claimed at the time. However the count was 76, not 72 —
+# main was already failing on every PR after the ratchet landed.
+# Bumped to 78 (GH#19347, t2144): pre-existing drift on main — 76 violations
+# vs threshold 74 (CI failure on this PR's run 24537849835 job 71737011386,
+# AND on every PR opened after PR #19408 merged). PR #19408 over-ratcheted —
+# it dropped the threshold to 74 while main actually has 76. t2144 PR adds
+# ZERO bash32 violations (diff is jq filter additions in pulse-triage.sh
+# regex blocks + grace-window logic + test fixtures — no `local -n`,
+# no `declare -A`, no heredoc-inside-`$()`). Pure drift absorption,
+# identical pattern to t2148/t2150. 76 + 2 buffer = 78. Ratchet back down
+# in the next quality sweep — investigation of the root-cause violations
+# is tracked separately (the offenders are in compare-models-helper.sh,
+# document-creation-helper.sh, and similar — see local check output).
 BASH32_COMPAT_THRESHOLD=78
 
 # Qlty maintainability smell baseline (t2065, GH#18773). Seed value for

--- a/.agents/scripts/pulse-triage.sh
+++ b/.agents/scripts/pulse-triage.sh
@@ -293,11 +293,20 @@ _issue_needs_consolidation() {
 	local min_chars="$ISSUE_CONSOLIDATION_COMMENT_MIN_CHARS"
 	substantive_count=$(printf '%s' "$comments_json" | jq --argjson min "$min_chars" '
 		# Combine all operational-noise patterns into a single regex for efficiency
-		# (1 test() invocation per comment instead of 13).
+		# (1 test() invocation per comment instead of 15).
+		#
+		# t2144: Added ^<!-- WORKER_SUPERSEDED and ^<!-- stale-recovery-tick
+		# patterns. Real recovery comment bodies start with these HTML comment
+		# markers, then contain "**Stale assignment recovered**" later in the
+		# body. The ^(\\*\\*)?Stale... anchor was therefore a no-op — 528-char
+		# recovery comments passed the filter, and two of them on any stuck
+		# issue falsely tripped the ISSUE_CONSOLIDATION_COMMENT_THRESHOLD=2 gate.
 		(
 			"DISPATCH_CLAIM nonce="
 			+ "|^(<!-- ops:start[^>]*-->\\s*)?Dispatching worker"
 			+ "|^<!-- (nmr-hold|aidevops-signed|ops:start|provenance:start)"
+			+ "|^<!-- WORKER_SUPERSEDED"
+			+ "|^<!-- stale-recovery-tick"
 			+ "|CLAIM_RELEASED reason="
 			+ "|^(Worker failed:|## Worker Watchdog Kill)"
 			+ "|^(\\*\\*)?Stale assignment recovered"
@@ -464,30 +473,76 @@ _reevaluate_simplification_labels() {
 }
 
 #######################################
-# t1982: Check whether an open consolidation-task child issue already
-# references this parent. Used by both _issue_needs_consolidation (as a
+# t1982/t2144: Check whether a consolidation-task child issue currently
+# "owns" this parent. Used by both _issue_needs_consolidation (as a
 # pre-filter) and _dispatch_issue_consolidation (as an idempotency guard)
 # so that repeat calls on the same parent do not create duplicate children.
+#
+# A child "owns" the parent if it is either:
+#   (a) currently open, OR
+#   (b) closed within the grace window (CONSOLIDATION_RECENT_CLOSE_GRACE_MIN
+#       minutes, default 30).
+#
+# The grace window exists because closing the consolidation-task child
+# and applying the `consolidated` label to the parent are separate steps —
+# the worker closes the child first, then updates the parent. Between
+# those two API calls the state is {child: closed, parent: still needs-
+# consolidation, no open child}. `_backfill_stale_consolidation_labels`
+# previously saw this as "no child, dispatch a new one" and re-fired,
+# cascading indefinitely (observed: #19321 → #19341 + #19367 cascade on
+# 2026-04-16 across two pulse runners). The grace window collapses that
+# race to a single cycle.
 #
 # Uses GitHub's `in:body` search over the consolidation-task label scope.
 # The child body always contains the literal token "Consolidation target: #NNN"
 # (see _compose_consolidation_child_body) which is the searchable anchor.
 #
-# Returns: 0 if an open child exists, 1 if none (or on lookup failure).
+# Args: $1=parent_num $2=repo_slug [$3=grace_minutes_override]
+# Returns: 0 if an open-or-recently-closed child exists, 1 otherwise.
 #######################################
 _consolidation_child_exists() {
 	local parent_num="$1"
 	local repo_slug="$2"
+	local grace_minutes="${3:-${CONSOLIDATION_RECENT_CLOSE_GRACE_MIN:-30}}"
 
 	[[ -n "$parent_num" && -n "$repo_slug" ]] || return 1
 
-	local child_count
-	child_count=$(gh issue list --repo "$repo_slug" --state open \
+	# Fast path: any open child immediately owns the parent.
+	local open_count
+	open_count=$(gh issue list --repo "$repo_slug" --state open \
 		--label "consolidation-task" \
 		--search "in:body \"Consolidation target: #${parent_num}\"" \
-		--json number --jq 'length' --limit 5 2>/dev/null) || child_count=0
-	[[ "$child_count" =~ ^[0-9]+$ ]] || child_count=0
-	[[ "$child_count" -gt 0 ]]
+		--json number --jq 'length' --limit 5 2>/dev/null) || open_count=0
+	[[ "$open_count" =~ ^[0-9]+$ ]] || open_count=0
+	if [[ "$open_count" -gt 0 ]]; then
+		return 0
+	fi
+
+	# No open child — check for a recently-closed one within the grace
+	# window. grace_minutes=0 disables the window (test hook).
+	[[ "$grace_minutes" =~ ^[0-9]+$ ]] || grace_minutes=30
+	if [[ "$grace_minutes" -eq 0 ]]; then
+		return 1
+	fi
+
+	# Prefer GNU date -d (Linux, coreutils); fall back to BSD date -v (macOS).
+	local cutoff_iso=""
+	cutoff_iso=$(date -u -d "${grace_minutes} minutes ago" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null) || cutoff_iso=""
+	if [[ -z "$cutoff_iso" ]]; then
+		cutoff_iso=$(date -u -v-"${grace_minutes}"M +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null) || cutoff_iso=""
+	fi
+	# If both date variants failed (highly unusual), fall back to open-only
+	# behaviour. This preserves pre-t2144 semantics rather than risking
+	# false negatives from a broken cutoff.
+	[[ -n "$cutoff_iso" ]] || return 1
+
+	local recent_closed_count
+	recent_closed_count=$(gh issue list --repo "$repo_slug" --state closed \
+		--label "consolidation-task" \
+		--search "in:body \"Consolidation target: #${parent_num}\" closed:>${cutoff_iso}" \
+		--json number --jq 'length' --limit 5 2>/dev/null) || recent_closed_count=0
+	[[ "$recent_closed_count" =~ ^[0-9]+$ ]] || recent_closed_count=0
+	[[ "$recent_closed_count" -gt 0 ]]
 }
 
 #######################################
@@ -508,6 +563,12 @@ _consolidation_substantive_comments() {
 
 	local min_chars="$ISSUE_CONSOLIDATION_COMMENT_MIN_CHARS"
 
+	# t2144: Added ^<!-- WORKER_SUPERSEDED and ^<!-- stale-recovery-tick
+	# patterns here too — this helper is used by the dispatch path to compose
+	# the child issue body, so it must stay in lockstep with the predicate in
+	# _issue_needs_consolidation above. Divergence between the two filters
+	# would mean the child ISSUE shows WORKER_SUPERSEDED comments as
+	# "substantive" even though they can no longer trigger dispatch.
 	printf '%s' "$comments_json" | jq --argjson min "$min_chars" '
 		[.[] | select(
 			(.body | length) >= $min
@@ -515,6 +576,8 @@ _consolidation_substantive_comments() {
 			and (.body | test("DISPATCH_CLAIM nonce=") | not)
 			and (.body | test("^(<!-- ops:start[^>]*-->\\s*)?Dispatching worker") | not)
 			and (.body | test("^<!-- (nmr-hold|aidevops-signed|ops:start|provenance:start)") | not)
+			and (.body | test("^<!-- WORKER_SUPERSEDED") | not)
+			and (.body | test("^<!-- stale-recovery-tick") | not)
 			and (.body | test("CLAIM_RELEASED reason=") | not)
 			and (.body | test("^(Worker failed:|## Worker Watchdog Kill)") | not)
 			and (.body | test("^(\\*\\*)?Stale assignment recovered") | not)
@@ -870,28 +933,55 @@ _backfill_stale_consolidation_labels() {
 	[[ -f "$repos_json" ]] || return 0
 
 	local total_backfilled=0
+	local total_cleared_stale=0
 	while IFS='|' read -r slug rpath; do
 		[[ -n "$slug" ]] || continue
 		local issues_json
 		issues_json=$(gh issue list --repo "$slug" --state open \
 			--label "needs-consolidation" \
-			--json number --limit 50 2>/dev/null) || issues_json="[]"
+			--json number,labels --limit 50 2>/dev/null) || issues_json='[]'
 
-		while read -r num; do
+		while IFS='|' read -r num labels_csv; do
 			[[ "$num" =~ ^[0-9]+$ ]] || continue
-			# Skip if a child already exists — the dispatch path is
-			# already idempotent but short-circuiting saves API calls.
-			if _consolidation_child_exists "$num" "$slug"; then
+
+			# t2144 (A3): Defense in depth — skip and auto-clear if the
+			# parent already carries `consolidated`. _issue_needs_consolidation
+			# short-circuits on this label (line ~263), but that function
+			# won't clean up the stale `needs-consolidation` label if both
+			# are present; do it here explicitly.
+			if [[ ",${labels_csv}," == *",consolidated,"* ]]; then
+				gh issue edit "$num" --repo "$slug" \
+					--remove-label "needs-consolidation" >/dev/null 2>&1 || true
+				total_cleared_stale=$((total_cleared_stale + 1))
+				continue
+			fi
+
+			# t2144 (A2): Unify the dispatch guard. Prior to this, backfill
+			# ran a bare label-lookup + open-child-exists check and dispatched
+			# on anything that passed, bypassing the filter that
+			# _issue_needs_consolidation enforces on the main pre-dispatch
+			# path. The delegation here:
+			#   - auto-clears the label when the filter no longer triggers
+			#     (via the was_already_labeled branch inside the helper)
+			#   - short-circuits on an open or recently-closed child via
+			#     _consolidation_child_exists (now grace-windowed, A4)
+			#   - short-circuits on the `consolidated` label
+			# Net effect: backfill only dispatches when dispatch is actually
+			# warranted under the current filter, eliminating the cascade.
+			if ! _issue_needs_consolidation "$num" "$slug"; then
 				continue
 			fi
 			if _dispatch_issue_consolidation "$num" "$slug" "$rpath"; then
 				total_backfilled=$((total_backfilled + 1))
 			fi
-		done < <(printf '%s' "$issues_json" | jq -r '.[].number' 2>/dev/null)
+		done < <(printf '%s' "$issues_json" | jq -r '.[] | "\(.number)|\([.labels[].name] | join(","))"' 2>/dev/null)
 	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | "\(.slug)|\(.path // "")"' "$repos_json" 2>/dev/null)
 
 	if [[ "$total_backfilled" -gt 0 ]]; then
 		echo "[pulse-wrapper] Consolidation backfill: dispatched ${total_backfilled} stale consolidation child issue(s)" >>"$LOGFILE"
+	fi
+	if [[ "$total_cleared_stale" -gt 0 ]]; then
+		echo "[pulse-wrapper] Consolidation backfill: cleared ${total_cleared_stale} stale needs-consolidation label(s) on already-consolidated parents (t2144)" >>"$LOGFILE"
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-consolidation-dispatch.sh
+++ b/.agents/scripts/tests/test-consolidation-dispatch.sh
@@ -408,12 +408,19 @@ fixture_two_worker_superseded_comments() {
 	'
 }
 
-# Fixture: one stale-recovery-tick comment (62 chars — under min_chars 500
-# but we set min to 50 in the stub, so it would otherwise pass and count).
-fixture_stale_recovery_tick_comment() {
+# Fixture: TWO stale-recovery-tick comments — both must be filtered.
+# CodeRabbit flagged (PR #19411): a single-comment fixture is vacuous
+# against THRESHOLD=2 — the test would pass even without the filter fix
+# because 1 comment never meets the threshold. Two comments that clear
+# min_chars BUT are filtered by the ^<!-- stale-recovery-tick prefix
+# exercise the filter directly: pre-t2144 they'd have counted as
+# substantive (substantive_count=2 == threshold=2 → dispatch); post-t2144
+# they're filtered out (substantive_count=0 < threshold → no dispatch).
+fixture_stale_recovery_tick_comments() {
 	cat <<'JSON'
 [
-  {"user": {"login": "marcusquinn", "type": "User"}, "created_at": "2026-04-16T17:06:16Z", "body": "<!-- stale-recovery-tick:1 -->\nStale recovery tick 1/2 (t2008). This padding exists only so the body length clears the test-harness threshold of 50 chars without adding any real scope change."}
+  {"user": {"login": "marcusquinn", "type": "User"}, "created_at": "2026-04-16T17:06:16Z", "body": "<!-- stale-recovery-tick:1 -->\nStale recovery tick 1/2 (t2008). This padding exists only so the body length clears the test-harness threshold of 50 chars without adding any real scope change."},
+  {"user": {"login": "marcusquinn", "type": "User"}, "created_at": "2026-04-16T17:21:30Z", "body": "<!-- stale-recovery-tick:2 -->\nStale recovery tick 2/2 (t2008). This padding exists only so the body length clears the test-harness threshold of 50 chars without adding any real scope change."}
 ]
 JSON
 }
@@ -451,7 +458,7 @@ test_worker_superseded_comments_are_filtered() {
 test_stale_recovery_tick_comments_are_filtered() {
 	setup_gh_stub
 	GH_ISSUE_VIEW_LABELS="bug,tier:standard"
-	GH_API_COMMENTS_JSON=$(fixture_stale_recovery_tick_comment)
+	GH_API_COMMENTS_JSON=$(fixture_stale_recovery_tick_comments)
 	GH_ISSUE_LIST_CHILD_JSON="[]"
 	GH_ISSUE_LIST_CHILD_CLOSED_JSON="[]"
 	export GH_ISSUE_VIEW_LABELS GH_API_COMMENTS_JSON

--- a/.agents/scripts/tests/test-consolidation-dispatch.sh
+++ b/.agents/scripts/tests/test-consolidation-dispatch.sh
@@ -91,18 +91,29 @@ if [[ "$cmd1" == "issue" && "$cmd2" == "view" ]]; then
 fi
 
 if [[ "$cmd1" == "issue" && "$cmd2" == "list" ]]; then
-	# Parse --jq filter if present, so the stub emulates real gh output.
+	# Parse --jq and --state so the stub emulates real gh behaviour.
+	# t2144: added --state dispatch so tests can fixture open and closed
+	# child lists independently (grace-window regression tests).
 	jq_filter=""
+	state_arg="open"
+	prev_arg=""
 	for arg in "$@"; do
 		if [[ "$prev_arg" == "--jq" ]]; then
 			jq_filter="$arg"
 		fi
+		if [[ "$prev_arg" == "--state" ]]; then
+			state_arg="$arg"
+		fi
 		prev_arg="$arg"
 	done
+	list_json="${GH_ISSUE_LIST_CHILD_JSON:-[]}"
+	if [[ "$state_arg" == "closed" ]]; then
+		list_json="${GH_ISSUE_LIST_CHILD_CLOSED_JSON:-[]}"
+	fi
 	if [[ -n "$jq_filter" ]]; then
-		printf '%s\n' "${GH_ISSUE_LIST_CHILD_JSON:-[]}" | jq -r "$jq_filter"
+		printf '%s\n' "$list_json" | jq -r "$jq_filter"
 	else
-		printf '%s\n' "${GH_ISSUE_LIST_CHILD_JSON:-[]}"
+		printf '%s\n' "$list_json"
 	fi
 	exit 0
 fi
@@ -161,6 +172,16 @@ _setup_gh_stub_globals() {
 	# from pulse-wrapper.sh but the consolidation helpers are self-contained.
 	# shellcheck disable=SC1091
 	source "${REPO_ROOT}/.agents/scripts/pulse-triage.sh"
+
+	# t2144: stub the gh_create_issue wrapper (defined in shared-constants.sh,
+	# not sourced here) so _create_consolidation_child_issue actually reaches
+	# the stubbed `gh issue create` on PATH. Without this, the wrapper is
+	# undefined and the dispatch path silently fails — which has been a
+	# pre-existing test flake since t2115 introduced the wrapper. Mirrors
+	# the stub in tests/test-gh-wrapper-guard.sh.
+	gh_create_issue() {
+		gh issue create "$@"
+	}
 	return 0
 }
 
@@ -188,7 +209,8 @@ teardown_gh_stub() {
 	TEST_ROOT=""
 	GH_LOG=""
 	unset GH_ISSUE_VIEW_TITLE GH_ISSUE_VIEW_BODY GH_ISSUE_VIEW_LABELS
-	unset GH_API_COMMENTS_JSON GH_ISSUE_LIST_CHILD_JSON GH_ISSUE_CREATE_URL
+	unset GH_API_COMMENTS_JSON GH_ISSUE_LIST_CHILD_JSON GH_ISSUE_LIST_CHILD_CLOSED_JSON GH_ISSUE_CREATE_URL
+	unset CONSOLIDATION_RECENT_CLOSE_GRACE_MIN
 	return 0
 }
 
@@ -361,12 +383,183 @@ test_needs_consolidation_skips_with_child() {
 	return 0
 }
 
+# ----------------------------------------------------------------------
+# t2144 regression tests — consolidation cascade fix
+#
+# Reference evidence: GH#19347 (investigation), cascades observed on
+# 2026-04-16 where #19321 → #19341 + #19367 and #19275 → #19277 + #19359.
+# ----------------------------------------------------------------------
+
+# Fixture: two WORKER_SUPERSEDED comments of the exact length and shape
+# seen in production (#19321). Before t2144 these passed the filter
+# because the `^(\*\*)?Stale assignment recovered` anchor was a no-op —
+# bodies start with the `<!-- WORKER_SUPERSEDED ...` HTML marker.
+fixture_two_worker_superseded_comments() {
+	local pad='x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x x'
+	local body1="<!-- WORKER_SUPERSEDED runners=marcusquinn ts=2026-04-16T17:06:24Z -->
+**Stale assignment recovered** — prior worker exited without updating status. ${pad}"
+	local body2="<!-- WORKER_SUPERSEDED runners=alex-solovyev ts=2026-04-16T17:35:29Z -->
+**Stale assignment recovered** — prior worker exited without updating status. ${pad}"
+	jq -n --arg b1 "$body1" --arg b2 "$body2" '
+		[
+			{"user": {"login": "marcusquinn", "type": "User"}, "created_at": "2026-04-16T17:06:25Z", "body": $b1},
+			{"user": {"login": "marcusquinn", "type": "User"}, "created_at": "2026-04-16T17:35:30Z", "body": $b2}
+		]
+	'
+}
+
+# Fixture: one stale-recovery-tick comment (62 chars — under min_chars 500
+# but we set min to 50 in the stub, so it would otherwise pass and count).
+fixture_stale_recovery_tick_comment() {
+	cat <<'JSON'
+[
+  {"user": {"login": "marcusquinn", "type": "User"}, "created_at": "2026-04-16T17:06:16Z", "body": "<!-- stale-recovery-tick:1 -->\nStale recovery tick 1/2 (t2008). This padding exists only so the body length clears the test-harness threshold of 50 chars without adding any real scope change."}
+]
+JSON
+}
+
+# t2144 A1 regression: WORKER_SUPERSEDED comments must NOT count as substantive.
+test_worker_superseded_comments_are_filtered() {
+	setup_gh_stub
+	# Restore production-realistic thresholds for this test. The default
+	# stub sets min_chars=50; WORKER_SUPERSEDED comments are ~530 chars so
+	# they'd pass the length gate at either setting. Threshold stays at 2.
+	export ISSUE_CONSOLIDATION_COMMENT_MIN_CHARS=200
+	GH_ISSUE_VIEW_LABELS="bug,tier:standard"
+	GH_API_COMMENTS_JSON=$(fixture_two_worker_superseded_comments)
+	GH_ISSUE_LIST_CHILD_JSON="[]"
+	GH_ISSUE_LIST_CHILD_CLOSED_JSON="[]"
+	export GH_ISSUE_VIEW_LABELS GH_API_COMMENTS_JSON
+	export GH_ISSUE_LIST_CHILD_JSON GH_ISSUE_LIST_CHILD_CLOSED_JSON
+
+	# Before t2144 this returned 0 (needs consolidation) because two 530-char
+	# recovery comments passed the filter. After t2144 the ^<!-- WORKER_SUPERSEDED
+	# pattern filters them out, substantive_count drops to 0, and the helper
+	# returns 1 (no dispatch).
+	if _issue_needs_consolidation 19321 "marcusquinn/aidevops"; then
+		print_result "t2144: WORKER_SUPERSEDED comments are filtered (no false consolidation)" 1 \
+			"_issue_needs_consolidation returned 0 despite only WORKER_SUPERSEDED noise"
+	else
+		print_result "t2144: WORKER_SUPERSEDED comments are filtered (no false consolidation)" 0
+	fi
+
+	teardown_gh_stub
+	return 0
+}
+
+# t2144 A1 regression: stale-recovery-tick comments must NOT count.
+test_stale_recovery_tick_comments_are_filtered() {
+	setup_gh_stub
+	GH_ISSUE_VIEW_LABELS="bug,tier:standard"
+	GH_API_COMMENTS_JSON=$(fixture_stale_recovery_tick_comment)
+	GH_ISSUE_LIST_CHILD_JSON="[]"
+	GH_ISSUE_LIST_CHILD_CLOSED_JSON="[]"
+	export GH_ISSUE_VIEW_LABELS GH_API_COMMENTS_JSON
+	export GH_ISSUE_LIST_CHILD_JSON GH_ISSUE_LIST_CHILD_CLOSED_JSON
+
+	if _issue_needs_consolidation 19999 "marcusquinn/aidevops"; then
+		print_result "t2144: stale-recovery-tick comments are filtered" 1 \
+			"_issue_needs_consolidation returned 0 despite only stale-recovery-tick noise"
+	else
+		print_result "t2144: stale-recovery-tick comments are filtered" 0
+	fi
+
+	teardown_gh_stub
+	return 0
+}
+
+# t2144 A4 regression: a recently-closed child within the grace window
+# still "owns" the parent — _consolidation_child_exists must return 0.
+test_recently_closed_child_blocks_redispatch_within_grace() {
+	setup_gh_stub
+	# Child closed "now" — well inside the 30-min default window.
+	export GH_ISSUE_LIST_CHILD_JSON="[]"
+	export GH_ISSUE_LIST_CHILD_CLOSED_JSON='[{"number": 19341}]'
+
+	if _consolidation_child_exists 19321 "marcusquinn/aidevops"; then
+		print_result "t2144: recently-closed child blocks re-dispatch within grace window" 0
+	else
+		print_result "t2144: recently-closed child blocks re-dispatch within grace window" 1 \
+			"_consolidation_child_exists returned 1 despite recently-closed child"
+	fi
+
+	teardown_gh_stub
+	return 0
+}
+
+# t2144 A4 regression: grace_minutes=0 disables the window — backward-compat
+# check that the legacy open-only semantics are reachable (no breakage for
+# callers that don't want the grace window).
+test_grace_zero_restores_open_only_semantics() {
+	setup_gh_stub
+	export GH_ISSUE_LIST_CHILD_JSON="[]"
+	export GH_ISSUE_LIST_CHILD_CLOSED_JSON='[{"number": 19341}]'
+
+	# Third arg 0 disables grace — closed child must not count.
+	if _consolidation_child_exists 19321 "marcusquinn/aidevops" 0; then
+		print_result "t2144: grace_minutes=0 ignores closed children" 1 \
+			"_consolidation_child_exists returned 0 with grace=0 despite only-closed child"
+	else
+		print_result "t2144: grace_minutes=0 ignores closed children" 0
+	fi
+
+	teardown_gh_stub
+	return 0
+}
+
+# t2144 A3 regression: backfill auto-clears `needs-consolidation` when the
+# parent also carries `consolidated` (race artefact) and does NOT dispatch.
+test_backfill_clears_stale_label_on_consolidated_parent() {
+	setup_gh_stub
+	# Open issue list returns one labelled parent that ALSO has consolidated.
+	export GH_ISSUE_LIST_CHILD_JSON='[{"number": 19321, "labels": [{"name": "needs-consolidation"}, {"name": "consolidated"}]}]'
+	export GH_ISSUE_LIST_CHILD_CLOSED_JSON="[]"
+
+	# repos.json with a single pulse-enabled repo pointing at our stub slug.
+	cat >"${TEST_ROOT}/repos.json" <<'JSON'
+{
+  "initialized_repos": [
+    {"slug": "marcusquinn/aidevops", "path": "/tmp/fake-path", "pulse": true}
+  ]
+}
+JSON
+	export REPOS_JSON="${TEST_ROOT}/repos.json"
+
+	_backfill_stale_consolidation_labels || true
+
+	# Verify: no `gh issue create` (no child dispatched).
+	if grep -q 'issue create' "$GH_LOG" 2>/dev/null; then
+		print_result "t2144: backfill skips dispatch on consolidated parent" 1 \
+			"gh issue create was invoked despite consolidated label"
+	else
+		print_result "t2144: backfill skips dispatch on consolidated parent" 0
+	fi
+
+	# Verify: `gh issue edit --remove-label needs-consolidation` was called.
+	if grep -qE 'issue edit .* --remove-label needs-consolidation' "$GH_LOG" 2>/dev/null; then
+		print_result "t2144: backfill auto-clears stale needs-consolidation label" 0
+	else
+		print_result "t2144: backfill auto-clears stale needs-consolidation label" 1 \
+			"expected remove-label call not found in gh log"
+	fi
+
+	teardown_gh_stub
+	return 0
+}
+
 main() {
 	test_dispatch_creates_child_issue
 	test_child_body_contains_parent_content_and_authors
 	test_dedup_skips_when_child_exists
 	test_consolidation_child_exists_detects_existing
 	test_needs_consolidation_skips_with_child
+
+	# t2144 regression suite
+	test_worker_superseded_comments_are_filtered
+	test_stale_recovery_tick_comments_are_filtered
+	test_recently_closed_child_blocks_redispatch_within_grace
+	test_grace_zero_restores_open_only_semantics
+	test_backfill_clears_stale_label_on_consolidated_parent
 
 	echo
 	echo "============================================"


### PR DESCRIPTION
## Summary

Closes the consolidation-task cascade that produced duplicate children on #19321 → (#19341 + #19367) and #19275 → (#19277 + #19359) on 2026-04-16. Both #19255 (original report, closed not-planned) and the Phase 1/2 hardening (PR #19344 t2142 and PR #19383 t2143) missed the actual mechanism — those were defensive hygiene (threshold defaults) that don't address why the gate was firing.

## Root causes (two compounding bugs, confirmed with production data)

### Bug 1 — filter regex ^ anchor fails against WORKER_SUPERSEDED HTML-comment prefix

\`pulse-triage.sh:303\` and \`:520\` used \`^(\\*\\*)?Stale assignment recovered\`. Real recovery comment bodies start with \`<!-- WORKER_SUPERSEDED runners=... -->\` THEN \`**Stale assignment recovered**\`. The \`^\` anchor therefore failed — 528/530-char WORKER_SUPERSEDED comments passed as \"substantive.\" Two such comments = substantive_count=2 = THRESHOLD=2 = dispatch fires.

Proven by running the production filter against #19321 in isolation: exactly those two WORKER_SUPERSEDED comments pass the regex, nothing else.

### Bug 2 — backfill path bypassed the filter AND raced on closed children

\`_backfill_stale_consolidation_labels\` did NOT call \`_issue_needs_consolidation\`. It checked only \`needs-consolidation\` label + \"no open child\" via \`_consolidation_child_exists\`, then dispatched. \`_consolidation_child_exists\` used \`--state open\` only. After worker closed the child but BEFORE the \`consolidated\` label was applied to the parent, backfill saw \"labelled + no child\" → re-dispatched a duplicate.

## Fixes (four narrow edits in \`pulse-triage.sh\`)

- **A1** — Add \`^<!-- WORKER_SUPERSEDED\` and \`^<!-- stale-recovery-tick\` patterns to BOTH the \`_issue_needs_consolidation\` filter AND \`_consolidation_substantive_comments\` (kept in lockstep so the child body composer stays consistent with the gate).
- **A2** — Backfill now delegates to \`_issue_needs_consolidation\` instead of raw label+open-child check. Unifies the dispatch guard so backfill can never dispatch under weaker criteria than the primary path.
- **A3** — Defense-in-depth short-circuit in backfill loop: when the parent carries both \`needs-consolidation\` and \`consolidated\` (race artefact), auto-clear the stale \`needs-consolidation\` label and skip dispatch.
- **A4** — \`_consolidation_child_exists\` extended with a 30-minute grace window for recently-closed children (env-configurable via \`CONSOLIDATION_RECENT_CLOSE_GRACE_MIN\`). Collapses the worker-close → parent-label race from \"dispatch another child\" to \"grace window absorbs the gap.\" Cross-platform date handling (GNU \`date -d\` then BSD \`date -v\`). \`grace=0\` restores the prior open-only semantics for any caller that explicitly wants it.

## Tests

\`.agents/scripts/tests/test-consolidation-dispatch.sh\` — 12/12 passing (up from 5 original):

- WORKER_SUPERSEDED comments are filtered (A1 regression)
- stale-recovery-tick comments are filtered (A1 regression)
- Recently-closed child blocks re-dispatch within grace window (A4)
- \`grace_minutes=0\` restores open-only semantics (A4 backward compat)
- Backfill auto-clears stale \`needs-consolidation\` on consolidated parent (A3)

Also fixes a pre-existing test flake (\`dispatch creates consolidation-task child issue\`) that was already failing on \`main\` — \`_create_consolidation_child_issue\` uses the \`gh_create_issue\` wrapper from \`shared-constants.sh\` which the test suite does not source. Added a one-line stub in the test's \`_setup_gh_stub_globals\` that mirrors the pattern in \`test-gh-wrapper-guard.sh\`.

Sibling test \`test-consolidation-gate-defaults.sh\` (from t2142/t2143) still passes 4/4 — no regression on earlier hardening.

Shellcheck: clean on both files.

## Scope

Phase A only (immediate cascade prevention). Follow-ups:

- **Phase B** — cross-runner coordination via explicit lock (e.g. \`consolidation-in-progress\` label) for two runners dispatching on the same issue within seconds. #19321 and #19275 cascades crossed runners (marcusquinn + alex-solovyev) but same-runner cases are also proven (#19275 alex→alex 5h later), so same-runner grace-window fix is necessary AND sufficient for most of the damage. Separate issue.
- **Initial-label mystery on #19275** — the issue only had 1 bot comment when alex-solovyev's runner first applied \`needs-consolidation\`. Neither Bug 1 nor Bug 2 explains this. Separate investigation.

## Evidence

- Full findings comment on issue: https://github.com/marcusquinn/aidevops/issues/19347#issuecomment-4263848194
- Cascade timelines for #19321 and #19275 included above, traced via \`gh api repos/.../issues/N/timeline\`.
- Hypothesis ledger: 5 candidates from #19347, 2 confirmed (Bug 1, Bug 2), 1 aggravating (multi-runner), 2 ruled out.

Resolves #19347

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.63 plugin for [OpenCode](https://opencode.ai) v1.4.7 with claude-opus-4-7 spent 35m and 120,000 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced internal issue triage automation to filter additional operational noise types from consolidation decisions.
  * Improved handling of recently-closed child issues in consolidation workflows.
  * Strengthened label management for stale consolidation tracking.
  * Expanded test coverage for consolidation logic to ensure robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->