### PR TITLE
GH#19412: chore: ratchet down NESTING_DEPTH_THRESHOLD 288→283

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -141,7 +141,8 @@ FUNCTION_COMPLEXITY_THRESHOLD=28
 # Ratcheted down to 283 (GH#19395): actual violations 281 + 2 buffer
 # Bumped to 288 (GH#19405): proximity guard firing at 281/283 (2 headroom); 281 violations + 7 headroom = 288.
 # Proximity guard (warn_at = 288-5 = 283) fires when violations exceed 283 (i.e., at 284), preventing saturation.
-NESTING_DEPTH_THRESHOLD=288
+# Ratcheted down to 283 (GH#19412): actual violations 281 + 2 buffer
+NESTING_DEPTH_THRESHOLD=283
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Lowered NESTING_DEPTH_THRESHOLD from 288 to 283 in complexity-thresholds.conf. Actual nesting violations: 281; 281 + 2 buffer = 283. Ratchet-down comment added above the threshold line per audit trail convention.

## Files Changed

.agents/configs/complexity-thresholds.conf

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified threshold value updated to 283. Confirmed simplification-state.json is NOT staged. Change matches the ratchet-down pattern: actual 281 violations + 2 buffer = 283.

Resolves #19412


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.63 plugin for [OpenCode](https://opencode.ai) v1.4.7 with claude-sonnet-4-6 spent 1m and 2,168 tokens on this as a headless worker.