### PR TITLE
GH#19419: chore: bump NESTING_DEPTH_THRESHOLD to 288 for GH#19419

### DIFF
--- a/.agents/configs/complexity-thresholds-history.md
+++ b/.agents/configs/complexity-thresholds-history.md
@@ -72,6 +72,8 @@ Archives the full change history for `.agents/configs/complexity-thresholds.conf
 | 288 | GH#19390 | proximity guard firing at 281/283 (2 headroom); 281 violations + 7 headroom = 288; proximity guard (warn_at = 288-5 = 283) fires when violations exceed 283 (i.e., at 284), preventing saturation |
 | 283 | GH#19395 | ratcheted down — actual violations 281 + 2 buffer |
 | 288 | GH#19405 | proximity guard firing at 281/283 (2 headroom); 281 violations + 7 headroom = 288; proximity guard (warn_at = 288-5 = 283) fires when violations exceed 283 (i.e., at 284), preventing saturation |
+| 283 | GH#19412 | ratcheted down — actual violations 281 + 2 buffer |
+| 288 | GH#19419 | proximity guard firing at 281/283 (2 headroom); 281 violations + 7 headroom = 288; proximity guard (warn_at = 288-5 = 283) fires when violations exceed 283 (i.e., at 284), preventing saturation |
 
 ## FUNCTION_COMPLEXITY_THRESHOLD History
 

--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -142,7 +142,9 @@ FUNCTION_COMPLEXITY_THRESHOLD=28
 # Bumped to 288 (GH#19405): proximity guard firing at 281/283 (2 headroom); 281 violations + 7 headroom = 288.
 # Proximity guard (warn_at = 288-5 = 283) fires when violations exceed 283 (i.e., at 284), preventing saturation.
 # Ratcheted down to 283 (GH#19412): actual violations 281 + 2 buffer
-NESTING_DEPTH_THRESHOLD=283
+# Bumped to 288 (GH#19419): proximity guard firing at 281/283 (2 headroom); 281 violations + 7 headroom = 288.
+# Proximity guard (warn_at = 288-5 = 283) fires when violations exceed 283 (i.e., at 284), preventing saturation.
+NESTING_DEPTH_THRESHOLD=288
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Bumped NESTING_DEPTH_THRESHOLD from 283 to 288 (281 violations + 7 headroom) following the established bump-and-ratchet cadence. The proximity guard fired at 281/283 (2 headroom remaining). Also added missing GH#19412 ratchet-down entry and new GH#19419 bump entry to complexity-thresholds-history.md.

## Files Changed

.agents/configs/complexity-thresholds-history.md,.agents/configs/complexity-thresholds.conf

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** CI code-quality check will pass with NESTING_DEPTH_THRESHOLD=288 against current 281 violations (7 headroom). Proximity guard (warn_at = 288-5 = 283) will fire when violations exceed 283, preventing future saturation.

Resolves #19419


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.63 plugin for [OpenCode](https://opencode.ai) v1.4.7 with claude-sonnet-4-6 spent 1m and 5,567 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code complexity thresholds and related documentation to maintain consistency with current code quality standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->