### PR TITLE
GH#19413: chore: ratchet down BASH32_COMPAT_THRESHOLD 78→74 (GH#19413)

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -204,7 +204,8 @@ FILE_SIZE_THRESHOLD=59
 # sweep — investigation of the root-cause violations is tracked separately
 # (the offenders are in compare-models-helper.sh, document-creation-helper.sh,
 # and similar — see local check output).
-BASH32_COMPAT_THRESHOLD=78
+# Ratcheted down to 74 (GH#19413): actual violations 72 + 2 buffer
+BASH32_COMPAT_THRESHOLD=74
 
 # Qlty maintainability smell baseline (t2065, GH#18773). Seed value for
 # the `.github/workflows/qlty-regression.yml` gate. The gate itself uses


### PR DESCRIPTION
## Summary

Lowered BASH32_COMPAT_THRESHOLD from 78 to 74 (actual violations: 72, buffer: 2). NESTING_DEPTH_THRESHOLD is already at 283 (ratcheted by GH#19412/PR#19418). simplification-state.json was not staged.

## Files Changed

.agents/configs/complexity-thresholds.conf

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** complexity-scan-helper.sh ratchet-check confirms actual bash32 violations=72 within new threshold=74

Resolves #19413


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.63 plugin for [OpenCode](https://opencode.ai) v1.4.7 with claude-sonnet-4-6 spent 2m and 5,724 tokens on this as a headless worker.