### PR TITLE
GH#19423: chore: ratchet-down complexity thresholds

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -144,7 +144,8 @@ FUNCTION_COMPLEXITY_THRESHOLD=28
 # Ratcheted down to 283 (GH#19412): actual violations 281 + 2 buffer
 # Bumped to 288 (GH#19419): proximity guard firing at 281/283 (2 headroom); 281 violations + 7 headroom = 288.
 # Proximity guard (warn_at = 288-5 = 283) fires when violations exceed 283 (i.e., at 284), preventing saturation.
-NESTING_DEPTH_THRESHOLD=288
+# Ratcheted down to 283 (GH#19423): actual violations 281 + 2 buffer
+NESTING_DEPTH_THRESHOLD=283
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)
@@ -206,7 +207,8 @@ FILE_SIZE_THRESHOLD=59
 # sweep — investigation of the root-cause violations is tracked separately
 # (the offenders are in compare-models-helper.sh, document-creation-helper.sh,
 # and similar — see local check output).
-BASH32_COMPAT_THRESHOLD=78
+# Ratcheted down to 74 (GH#19423): actual violations 72 + 2 buffer
+BASH32_COMPAT_THRESHOLD=74
 
 # Qlty maintainability smell baseline (t2065, GH#18773). Seed value for
 # the `.github/workflows/qlty-regression.yml` gate. The gate itself uses


### PR DESCRIPTION
## Summary

Lowered NESTING_DEPTH_THRESHOLD from 288 to 283 (actual 281 + 2 buffer) and BASH32_COMPAT_THRESHOLD from 78 to 74 (actual 72 + 2 buffer) per automated ratchet-down scan. Added audit-trail comments for both changes.

## Files Changed

.agents/configs/complexity-thresholds.conf

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified only complexity-thresholds.conf is modified; simplification-state.json not staged. Grep confirms NESTING_DEPTH_THRESHOLD=283 and BASH32_COMPAT_THRESHOLD=74.

Resolves #19423


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.63 plugin for [OpenCode](https://opencode.ai) v1.4.7 with claude-sonnet-4-6 spent 1m and 2,666 tokens on this as a headless worker.