### PR TITLE
GH#19423: fix: bump BASH32_COMPAT_THRESHOLD 74→78 post-merge correction

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -207,8 +207,10 @@ FILE_SIZE_THRESHOLD=59
 # sweep — investigation of the root-cause violations is tracked separately
 # (the offenders are in compare-models-helper.sh, document-creation-helper.sh,
 # and similar — see local check output).
-# Ratcheted down to 74 (GH#19423): actual violations 72 + 2 buffer
-BASH32_COMPAT_THRESHOLD=74
+# GH#19423 ratcheted to 74 (claimed actual: 72), but CI reported 76 violations
+# against threshold 74 — main drifted from 72 to 76 between issue filing and PR
+# run. Bumped back to 78 (GH#19425 post-merge fix): 76 violations + 2 buffer.
+BASH32_COMPAT_THRESHOLD=78
 
 # Qlty maintainability smell baseline (t2065, GH#18773). Seed value for
 # the `.github/workflows/qlty-regression.yml` gate. The gate itself uses


### PR DESCRIPTION
## Summary

GH#19423 (PR #19425) ratcheted `BASH32_COMPAT_THRESHOLD` from 78 to 74, claiming 72 actual violations. CI against the merged PR reported **76 violations** vs the new threshold 74 — main had drifted from 72 to 76 between issue filing and PR merge.

This causes **every PR on main to fail** the Bash 3.2 compatibility check.

## Fix

Restore `BASH32_COMPAT_THRESHOLD=78` (76 actual violations + 2 buffer), with an audit-trail comment explaining the GH#19423 overshoot.

`NESTING_DEPTH_THRESHOLD=283` from GH#19423 is correct and not reverted.

## Verification

```bash
grep BASH32_COMPAT_THRESHOLD .agents/configs/complexity-thresholds.conf
# Expected: BASH32_COMPAT_THRESHOLD=78
```

Resolves #19423