### PR TITLE
GH#19430: bump NESTING_DEPTH_THRESHOLD 283→288 (proximity guard)

### DIFF
--- a/.agents/configs/complexity-thresholds-history.md
+++ b/.agents/configs/complexity-thresholds-history.md
@@ -74,6 +74,8 @@ Archives the full change history for `.agents/configs/complexity-thresholds.conf
 | 288 | GH#19405 | proximity guard firing at 281/283 (2 headroom); 281 violations + 7 headroom = 288; proximity guard (warn_at = 288-5 = 283) fires when violations exceed 283 (i.e., at 284), preventing saturation |
 | 283 | GH#19412 | ratcheted down — actual violations 281 + 2 buffer |
 | 288 | GH#19419 | proximity guard firing at 281/283 (2 headroom); 281 violations + 7 headroom = 288; proximity guard (warn_at = 288-5 = 283) fires when violations exceed 283 (i.e., at 284), preventing saturation |
+| 283 | GH#19423 | ratcheted down — actual violations 281 + 2 buffer |
+| 288 | GH#19430 | proximity guard firing at 281/283 (2 headroom); 281 violations + 7 headroom = 288; proximity guard (warn_at = 288-5 = 283) fires when violations exceed 283 (i.e., at 284), preventing saturation |
 
 ## FUNCTION_COMPLEXITY_THRESHOLD History
 

--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -145,7 +145,9 @@ FUNCTION_COMPLEXITY_THRESHOLD=28
 # Bumped to 288 (GH#19419): proximity guard firing at 281/283 (2 headroom); 281 violations + 7 headroom = 288.
 # Proximity guard (warn_at = 288-5 = 283) fires when violations exceed 283 (i.e., at 284), preventing saturation.
 # Ratcheted down to 283 (GH#19423): actual violations 281 + 2 buffer
-NESTING_DEPTH_THRESHOLD=283
+# Bumped to 288 (GH#19430): proximity guard firing at 281/283 (2 headroom); 281 violations + 7 headroom = 288.
+# Proximity guard (warn_at = 288-5 = 283) fires when violations exceed 283 (i.e., at 284), preventing saturation.
+NESTING_DEPTH_THRESHOLD=288
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Proximity guard fired at 281/283 violations (2 headroom remaining). Bumping threshold to 288 per the established bump-and-ratchet cadence.

- **Violations (verified locally):** 281
- **Old threshold:** 283
- **New threshold:** 288 (281 violations + 7 headroom)
- **New proximity guard warn_at:** 283 (fires when violations exceed 283, i.e., at 284)

Also adds the missing GH#19423 ratchet-down entry to `complexity-thresholds-history.md`.

## Files Changed

- EDIT: `.agents/configs/complexity-thresholds.conf` — bump `NESTING_DEPTH_THRESHOLD` 283→288, add GH#19430 comment
- EDIT: `.agents/configs/complexity-thresholds-history.md` — add GH#19423 and GH#19430 entries

## Verification

Local violation count verified by running the same awk scan as CI:
```
source .agents/scripts/lint-file-discovery.sh && lint_shell_files
# Violations: 281 (< 288 threshold) ✓
```

Resolves #19430