### PR TITLE
GH#19431: chore: ratchet-down BASH32_COMPAT_THRESHOLD 78→74 (GH#19431)

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -212,7 +212,8 @@ FILE_SIZE_THRESHOLD=59
 # GH#19423 ratcheted to 74 (claimed actual: 72), but CI reported 76 violations
 # against threshold 74 — main drifted from 72 to 76 between issue filing and PR
 # run. Bumped back to 78 (GH#19425 post-merge fix): 76 violations + 2 buffer.
-BASH32_COMPAT_THRESHOLD=78
+# Ratcheted down to 74 (GH#19431): actual violations 72 + 2 buffer
+BASH32_COMPAT_THRESHOLD=74
 
 # Qlty maintainability smell baseline (t2065, GH#18773). Seed value for
 # the `.github/workflows/qlty-regression.yml` gate. The gate itself uses


### PR DESCRIPTION
## Summary

Lowered BASH32_COMPAT_THRESHOLD from 78 to 74 in complexity-thresholds.conf. Actual violations: 72, new threshold: 72 + 2 buffer = 74. Simplification wins have accumulated, enabling this ratchet-down.

## Files Changed

.agents/configs/complexity-thresholds.conf

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified grep shows BASH32_COMPAT_THRESHOLD=74 and the ratchet-down comment (GH#19431) in complexity-thresholds.conf. simplification-state.json was NOT staged.

Resolves #19431


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.63 plugin for [OpenCode](https://opencode.ai) v1.4.7 with claude-sonnet-4-6 spent 59s and 2,438 tokens on this as a headless worker.