### PR TITLE
t2009: docs(cross-runner): complete issue closure with Related Issues table improvements

### DIFF
--- a/.agents/reference/cross-runner-coordination.md
+++ b/.agents/reference/cross-runner-coordination.md
@@ -447,10 +447,15 @@ SCRIPT=~/.aidevops/agents/scripts/dispatch-dedup-helper.sh
 
 | Reference | What it fixed |
 |---|---|
+| GH#6696 | Layer 1 dispatch ledger — catches workers in 10–15 min pre-PR gap |
 | GH#6891 | Layer 6 cross-machine assignee guard (original) |
+| GH#10521 | Maintainer passive assignment starvation — combined-signal rule origin |
 | GH#11086 | Layer 7 claim comment as mandatory code path (not LLM-instructed) |
 | GH#11141 | Layer 5 cross-machine dispatch comment |
 | GH#17503 | Token cost runaway with multiple runners (stale-recovery loop evidence) |
 | GH#18352 (t1961) | `origin:interactive` blocks pulse dispatch on owner-assigned issues |
+| GH#18356 | Parent-task dispatch loop incident — t1962 parent dispatched with opus-4-6 |
+| GH#18367 | Interactive-claim race incident — pulse dispatched while interactive session active |
 | GH#18371 (PR#18374, t1970) | Interactive-claim race via push path missing auto-assign |
 | GH#18399 (PR#18419, t1986) | Parent-task 4-hole fix + test harness |
+| GH#18458 | Fail-open dedup bug — jq null-handling allowed dispatch to parent-task issues |


### PR DESCRIPTION
## Summary

- The core implementation (`.agents/reference/cross-runner-coordination.md`, AGENTS.md pointer, worker-diagnostics.md see-also) was already completed in PR #18465 (merged 2026-04-12)
- GH#19444 was auto-created by issue-sync because TODO.md t2009 had no `ref:GH#` link (the original PR resolved a different issue number, GH#18457)
- This PR adds 5 missing issue references to the Related Issues table in §7 (GH#6696, GH#10521, GH#18356, GH#18367, GH#18458 were referenced in the doc body but absent from the table)

## Verification

- All 7 sections present in cross-runner-coordination.md ✅
- 4 race scenarios documented (§4.1–4.4) ✅
- AGENTS.md cross-references the doc (line 185) ✅
- No code changes — docs only
- `test-parent-task-guard.sh` → 22 tests passed ✅
- `test-dispatch-dedup-multi-operator.sh` → 10 tests passed ✅

<!-- MERGE_SUMMARY -->
## Merge Summary

**What was done:** Completed closure of t2009 tracking issue. The main doc (`.agents/reference/cross-runner-coordination.md`) was already created in PR #18465. This PR adds 5 missing issue references to the Related Issues table that were cited in the doc body but absent from the table: GH#6696 (Layer 1 dispatch ledger), GH#10521 (combined-signal rule origin), GH#18356 (parent-task loop incident), GH#18367 (interactive-claim race incident), GH#18458 (fail-open jq bug).

**How verified:** Existing test suites pass (22 parent-task-guard tests, 10 multi-operator dedup tests). Doc-only change.
<!-- /MERGE_SUMMARY -->

Resolves #19444