### PR TITLE
GH#19443: fix(test): fix SC2002 shellcheck violations in test-stale-recovery-escalation.sh

### DIFF
--- a/.agents/scripts/tests/test-stale-recovery-escalation.sh
+++ b/.agents/scripts/tests/test-stale-recovery-escalation.sh
@@ -147,7 +147,7 @@ fi
 if grep -q "^issue comment" "$GH_CALLS_FILE" 2>/dev/null; then
 	print_result "Tick 1: tick comment call posted" 0
 else
-	print_result "Tick 1: tick comment call posted" 1 "(gh calls: $(cat "$GH_CALLS_FILE" 2>/dev/null | head -5))"
+	print_result "Tick 1: tick comment call posted" 1 "(gh calls: $(head -5 "$GH_CALLS_FILE" 2>/dev/null))"
 fi
 
 # =============================================================================
@@ -185,7 +185,7 @@ fi
 if grep -q "needs-maintainer-review" "$GH_CALLS_FILE" 2>/dev/null; then
 	print_result "Escalation: needs-maintainer-review label applied" 0
 else
-	print_result "Escalation: needs-maintainer-review label applied" 1 "(gh calls: $(cat "$GH_CALLS_FILE" 2>/dev/null | head -10))"
+	print_result "Escalation: needs-maintainer-review label applied" 1 "(gh calls: $(head -10 "$GH_CALLS_FILE" 2>/dev/null))"
 fi
 
 # status:available must NOT be --add-label'd in escalation path
@@ -219,7 +219,7 @@ fi
 if grep -q "^issue comment" "$GH_CALLS_FILE" 2>/dev/null; then
 	print_result "Reset path: reset comment call made" 0
 else
-	print_result "Reset path: reset comment call made" 1 "(gh calls: $(cat "$GH_CALLS_FILE" 2>/dev/null | head -5))"
+	print_result "Reset path: reset comment call made" 1 "(gh calls: $(head -5 "$GH_CALLS_FILE" 2>/dev/null))"
 fi
 
 # =============================================================================


### PR DESCRIPTION
## Summary

The t2008 stale-recovery escalation feature was already fully implemented and merged in PR #18462 (2026-04-12). This PR closes the re-dispatched tracking issue (#19443) and applies a minor ShellCheck quality fix (SC2002) in the test file: replaced 3 useless cat-into-head pipelines in diagnostic error strings with direct head file reads.

## Files Changed

.agents/scripts/tests/test-stale-recovery-escalation.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tests/test-stale-recovery-escalation.sh (zero violations); bash .agents/scripts/tests/test-stale-recovery-escalation.sh (11/11 PASS); bash .agents/scripts/tests/test-parent-task-guard.sh (22/22 PASS)

Resolves #19443


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.63 plugin for [OpenCode](https://opencode.ai) v1.4.7 with claude-sonnet-4-6 spent 4m and 9,261 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved diagnostic output formatting in test scripts for stale recovery escalation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->