### PR TITLE
GH#19414: t2151: add cross-runner advisory lock for consolidation dispatch (Phase B)

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -489,7 +489,11 @@ _get_repo_maintainer() {
 #   - a lifecycle status label is set: status:queued, status:in-progress,
 #     status:in-review, or status:claimed, OR
 #   - the origin:interactive label is present (a live human session is
-#     driving the work regardless of status label state)
+#     driving the work regardless of status label state), OR
+#   - the consolidation-in-progress label is present (t2151 — a cross-
+#     runner advisory lock held by a pulse runner that is mid-way through
+#     creating a consolidation-task child issue; treat as an active claim
+#     so unrelated dispatch paths can't sneak past during the write window)
 #
 # Extracted from is_assigned() to keep that function under the 100-line
 # complexity cap after GH#18352 expanded the active-claim signal set
@@ -514,7 +518,7 @@ _has_active_claim() {
 	local issue_meta_json="$1"
 	local result
 	result=$(printf '%s' "$issue_meta_json" | jq -r '
-		.labels? // [] | any(.[].name; . == "status:queued" or . == "status:in-progress" or . == "status:in-review" or . == "status:claimed" or . == "origin:interactive")
+		.labels? // [] | any(.[].name; . == "status:queued" or . == "status:in-progress" or . == "status:in-review" or . == "status:claimed" or . == "origin:interactive" or . == "consolidation-in-progress")
 	' 2>/dev/null) || result="false"
 	[[ "$result" == "true" || "$result" == "false" ]] || result="false"
 	printf '%s' "$result"

--- a/.agents/scripts/label-sync-helper.sh
+++ b/.agents/scripts/label-sync-helper.sh
@@ -122,6 +122,7 @@ SYSTEM_LABELS=(
 	"already-fixed|E4E669|Already fixed by another change"
 	"needs-consolidation|FBCA04|Issue needs comment consolidation before dispatch"
 	"consolidation-task|C5DEF5|Task created from consolidated duplicate issues"
+	"consolidation-in-progress|CFD3D7|Another runner is creating a consolidation child issue (cross-runner advisory lock)"
 	"consolidated|BFD4F2|Original issue consolidated into a task"
 	"needs-simplification|FBCA04|File exceeds complexity threshold"
 	"simplification-debt|D93F0B|File complexity needs reduction"

--- a/.agents/scripts/pulse-triage.sh
+++ b/.agents/scripts/pulse-triage.sh
@@ -41,6 +41,27 @@ _PULSE_TRIAGE_LOADED=1
 : "${ISSUE_CONSOLIDATION_COMMENT_THRESHOLD:=2}"
 : "${ISSUE_CONSOLIDATION_COMMENT_MIN_CHARS:=500}"
 
+# t2151: Cross-runner advisory lock TTL for consolidation dispatch. If a
+# `consolidation-in-progress` label stays applied longer than this many hours
+# without being naturally released (by successful child creation + release,
+# or by release-on-child-close), the backfill pass clears it. Prevents a
+# crashed runner from permanently wedging the parent behind a stale lock.
+#
+# Default 6h: long enough to absorb GitHub API outages, slow runners, and
+# operator intervention windows; short enough that a truly stuck lock gets
+# cleared within one working day rather than accumulating.
+#
+# t2151: Grace period after lock acquisition during which a re-check of
+# the comment-based tiebreaker is suppressed. The tiebreaker comment is
+# posted immediately after the label; a tight re-read racing against the
+# caller's own comment would see its own marker plus the competitor's and
+# pick a winner before either runner has flushed its child-creation API
+# call. 2s is comfortably longer than the single-writer path (label + comment
+# + child-create = ~0.3-0.8s in normal conditions) and short enough that
+# operator latency is imperceptible.
+: "${CONSOLIDATION_LOCK_TTL_HOURS:=6}"
+: "${CONSOLIDATION_LOCK_TIEBREAK_WAIT_SEC:=2}"
+
 # Compute a content hash from issue body + human comments.
 # Excludes github-actions[bot] comments and our own triage reviews
 # (## Review: prefix) so that only author/contributor changes trigger
@@ -473,15 +494,22 @@ _reevaluate_simplification_labels() {
 }
 
 #######################################
-# t1982/t2144: Check whether a consolidation-task child issue currently
+# t1982/t2144/t2151: Check whether a consolidation-task child issue currently
 # "owns" this parent. Used by both _issue_needs_consolidation (as a
 # pre-filter) and _dispatch_issue_consolidation (as an idempotency guard)
 # so that repeat calls on the same parent do not create duplicate children.
 #
-# A child "owns" the parent if it is either:
-#   (a) currently open, OR
-#   (b) closed within the grace window (CONSOLIDATION_RECENT_CLOSE_GRACE_MIN
-#       minutes, default 30).
+# A child "owns" the parent if ANY of:
+#   (a) a consolidation-task child is currently open, OR
+#   (b) a consolidation-task child closed within the grace window
+#       (CONSOLIDATION_RECENT_CLOSE_GRACE_MIN minutes, default 30), OR
+#   (c) (t2151) the parent carries the `consolidation-in-progress` label —
+#       another pulse runner is mid-way through creating a child right now.
+#
+# (a) and (b) cover single-runner cascades (t1982 / t2144).
+# (c) covers the cross-runner race window between "about to create child"
+# and "child exists on GitHub". See `_consolidation_lock_acquire` for the
+# lock protocol.
 #
 # The grace window exists because closing the consolidation-task child
 # and applying the `consolidated` label to the parent are separate steps —
@@ -498,7 +526,8 @@ _reevaluate_simplification_labels() {
 # (see _compose_consolidation_child_body) which is the searchable anchor.
 #
 # Args: $1=parent_num $2=repo_slug [$3=grace_minutes_override]
-# Returns: 0 if an open-or-recently-closed child exists, 1 otherwise.
+# Returns: 0 if an open-or-recently-closed child exists OR lock label is
+#          present, 1 otherwise.
 #######################################
 _consolidation_child_exists() {
 	local parent_num="$1"
@@ -515,6 +544,13 @@ _consolidation_child_exists() {
 		--json number --jq 'length' --limit 5 2>/dev/null) || open_count=0
 	[[ "$open_count" =~ ^[0-9]+$ ]] || open_count=0
 	if [[ "$open_count" -gt 0 ]]; then
+		return 0
+	fi
+
+	# t2151: lock label is a third blocking condition. A competing runner
+	# that has acquired (or is acquiring) the lock owns the parent for the
+	# duration of its critical section. Cheap — one label-read, no search.
+	if _consolidation_lock_label_present "$parent_num" "$repo_slug"; then
 		return 0
 	fi
 
@@ -766,7 +802,236 @@ _ensure_consolidation_labels() {
 		--repo "$repo_slug" \
 		--description "Issue superseded by a consolidated child" \
 		--color "0E8A16" --force 2>/dev/null || true
+	# t2151: cross-runner advisory lock for consolidation dispatch. Applied by
+	# `_consolidation_lock_acquire` before child issue creation; treated as an
+	# active-claim signal by `dispatch-dedup-helper.sh is-assigned` so unrelated
+	# dispatch paths can't sneak past during the write window.
+	gh label create "consolidation-in-progress" \
+		--repo "$repo_slug" \
+		--description "Another runner is creating a consolidation child issue (cross-runner advisory lock)" \
+		--color "CFD3D7" --force 2>/dev/null || true
 	return 0
+}
+
+#######################################
+# t2151: Cross-runner advisory lock — marker comment protocol.
+#
+# Two pulse runners on different hosts can hit the same parent issue within
+# the same consolidation window. Neither sees the other's in-flight gh writes
+# directly, so both pass local `_consolidation_child_exists` and both create
+# a child. Production evidence: parent #19321 → #19341 (marcusquinn) +
+# #19367 (alex-solovyev, 55 min later).
+#
+# Protocol:
+#   1. acquire: apply `consolidation-in-progress` label, post a signed
+#      marker comment (HTML-comment prefix + runner login + ISO timestamp),
+#      wait briefly for any competitor's marker to flush, re-read comments.
+#   2. tiebreak: if multiple markers are present, lexicographic actor-login
+#      comparison picks the single winner. Last-writer-loses when logins are
+#      identical is impossible here (GitHub logins are unique), but if the
+#      same runner somehow posts twice, the older comment wins.
+#   3. release: remove the label and delete our marker comment. Release
+#      happens after successful child creation OR on any failure path.
+#
+# Why a comment marker plus a label, not just the label?
+#   The label alone is not enough for tiebreaking: `gh issue edit --add-label`
+#   is idempotent — after both runners apply the label, we cannot tell from
+#   the label alone who "got there first". A comment with a unique marker
+#   body and a runner-specific signature gives us a deterministic tiebreaker
+#   that works under real concurrent-API-call conditions, and crucially
+#   leaves an audit trail of every lock attempt.
+#
+# Why not rely on `gh issue edit` being atomic?
+#   `--add-label X` is atomic at the API-call surface, but two runners calling
+#   it near-simultaneously both observe their own call as "the label didn't
+#   exist, now it does". GitHub doesn't return a "label was already present"
+#   signal on the REST API. Hence the marker-comment protocol.
+#######################################
+
+# t2151: generate the marker comment text for a lock acquisition.
+# Format: `<!-- consolidation-lock:runner=LOGIN ts=ISO8601 -->` on a single line.
+# The single-line HTML-comment prefix is the stable anchor that filter regexes
+# and grep-style tests can match without ambiguity.
+_consolidation_lock_marker_body() {
+	local self_login="$1"
+	local iso_ts="$2"
+	printf '<!-- consolidation-lock:runner=%s ts=%s -->\n_Cross-runner advisory lock acquired for consolidation dispatch (t2151). This comment will be removed when the lock is released._' \
+		"$self_login" "$iso_ts"
+	return 0
+}
+
+# t2151: fetch all lock marker comments on the parent. Returns a JSON array
+# of {id, login, created_at} objects to stdout, sorted by created_at ascending.
+# Empty array on API failure.
+_consolidation_lock_markers() {
+	local parent_num="$1"
+	local repo_slug="$2"
+	gh api "repos/${repo_slug}/issues/${parent_num}/comments" --paginate \
+		--jq '[.[] | select(.body | test("^<!-- consolidation-lock:runner=[A-Za-z0-9_-]+ ts="))
+			| {id: .id, body: .body, created_at: .created_at,
+				runner: (.body | capture("^<!-- consolidation-lock:runner=(?<r>[A-Za-z0-9_-]+)") | .r)}]
+			| sort_by(.created_at)' 2>/dev/null || printf '[]'
+	return 0
+}
+
+# t2151: determine self login — the current runner's GitHub login. Workers
+# and pulse runners authenticate via `gh auth login`; the login returned by
+# `gh api user` is the same one that appears in comment.user.login. Returns
+# empty on failure; callers MUST treat empty as "cannot acquire lock" and
+# skip dispatch rather than proceed blindly.
+_consolidation_lock_self_login() {
+	# Prefer an explicit override for tests.
+	if [[ -n "${CONSOLIDATION_LOCK_SELF_LOGIN_OVERRIDE:-}" ]]; then
+		printf '%s' "$CONSOLIDATION_LOCK_SELF_LOGIN_OVERRIDE"
+		return 0
+	fi
+	gh api user --jq '.login' 2>/dev/null || true
+	return 0
+}
+
+# t2151: determine if parent currently carries the lock label.
+# Args: $1=parent_num $2=repo_slug
+# Returns: 0 if label is present, 1 otherwise.
+_consolidation_lock_label_present() {
+	local parent_num="$1"
+	local repo_slug="$2"
+	local labels_csv
+	labels_csv=$(gh issue view "$parent_num" --repo "$repo_slug" \
+		--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || labels_csv=""
+	[[ ",${labels_csv}," == *",consolidation-in-progress,"* ]]
+}
+
+# t2151: release the lock — delete our marker comment(s) and remove the label
+# if no other runner's marker is present. Safe to call even if acquire failed
+# (idempotent). Never fails the caller — release best-effort.
+#
+# Args: $1=parent_num $2=repo_slug $3=self_login
+_consolidation_lock_release() {
+	local parent_num="$1"
+	local repo_slug="$2"
+	local self_login="$3"
+
+	[[ -n "$parent_num" && -n "$repo_slug" ]] || return 0
+
+	local markers_json
+	markers_json=$(_consolidation_lock_markers "$parent_num" "$repo_slug")
+	[[ -n "$markers_json" ]] || markers_json="[]"
+
+	# Delete every marker that belongs to us.
+	local self_marker_ids
+	self_marker_ids=$(printf '%s' "$markers_json" |
+		jq -r --arg me "$self_login" '.[] | select(.runner == $me) | .id' 2>/dev/null) || self_marker_ids=""
+	local mid
+	while IFS= read -r mid; do
+		[[ -z "$mid" ]] && continue
+		gh api -X DELETE "repos/${repo_slug}/issues/comments/${mid}" >/dev/null 2>&1 || true
+	done <<<"$self_marker_ids"
+
+	# If no other runner's marker remains, drop the lock label. Otherwise a
+	# competing runner is still inside its own acquire/dispatch window — don't
+	# clear the label out from under them.
+	local other_count
+	other_count=$(printf '%s' "$markers_json" |
+		jq -r --arg me "$self_login" '[.[] | select(.runner != $me)] | length' 2>/dev/null) || other_count=0
+	[[ "$other_count" =~ ^[0-9]+$ ]] || other_count=0
+	if [[ "$other_count" -eq 0 ]]; then
+		gh issue edit "$parent_num" --repo "$repo_slug" \
+			--remove-label "consolidation-in-progress" >/dev/null 2>&1 || true
+	fi
+	return 0
+}
+
+# t2151: acquire the cross-runner lock. See protocol overview above.
+#
+# Args: $1=parent_num $2=repo_slug
+# Returns:
+#   0 — lock acquired, caller MUST proceed with child creation and
+#       call _consolidation_lock_release after (success or failure).
+#   1 — lock held by another runner or self_login unavailable; caller
+#       MUST skip dispatch.
+_consolidation_lock_acquire() {
+	local parent_num="$1"
+	local repo_slug="$2"
+
+	[[ -n "$parent_num" && -n "$repo_slug" ]] || return 1
+
+	local self_login
+	self_login=$(_consolidation_lock_self_login)
+	if [[ -z "$self_login" ]]; then
+		# Cannot lock without knowing our identity — fail-closed: block
+		# dispatch rather than create a duplicate. A transient `gh auth`
+		# issue self-heals within one pulse cycle at zero cost.
+		echo "[pulse-wrapper] Consolidation lock: gh api user failed for #${parent_num} in ${repo_slug} — skipping dispatch (fail-closed)" >>"$LOGFILE"
+		return 1
+	fi
+
+	# Apply label first — cheapest signal for the fast-path competitor
+	# who is about to call `_consolidation_child_exists`.
+	gh issue edit "$parent_num" --repo "$repo_slug" \
+		--add-label "consolidation-in-progress" >/dev/null 2>&1 || true
+
+	# Post our marker. Embed the current ISO timestamp.
+	local iso_ts
+	iso_ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null) || iso_ts=""
+	local marker_body
+	marker_body=$(_consolidation_lock_marker_body "$self_login" "$iso_ts")
+	gh issue comment "$parent_num" --repo "$repo_slug" \
+		--body "$marker_body" >/dev/null 2>&1 || {
+		# Comment post failed — can't tiebreak without our marker being
+		# visible. Roll back by clearing the label and skip dispatch.
+		gh issue edit "$parent_num" --repo "$repo_slug" \
+			--remove-label "consolidation-in-progress" >/dev/null 2>&1 || true
+		echo "[pulse-wrapper] Consolidation lock: marker comment post failed for #${parent_num} in ${repo_slug} — rolled back label, skipping dispatch" >>"$LOGFILE"
+		return 1
+	}
+
+	# Give any concurrent competitor a short window to flush their marker.
+	# `sleep 0` on tiebreak_wait=0 is a no-op — used by unit tests.
+	local wait_sec="${CONSOLIDATION_LOCK_TIEBREAK_WAIT_SEC:-2}"
+	[[ "$wait_sec" =~ ^[0-9]+$ ]] || wait_sec=2
+	if [[ "$wait_sec" -gt 0 ]]; then
+		sleep "$wait_sec" 2>/dev/null || true
+	fi
+
+	# Re-read markers and tiebreak.
+	local markers_json
+	markers_json=$(_consolidation_lock_markers "$parent_num" "$repo_slug")
+	[[ -n "$markers_json" ]] || markers_json="[]"
+
+	# Count distinct runners. If only one (us), we won trivially.
+	local distinct_runners
+	distinct_runners=$(printf '%s' "$markers_json" |
+		jq -r '[.[].runner] | unique | length' 2>/dev/null) || distinct_runners=0
+	[[ "$distinct_runners" =~ ^[0-9]+$ ]] || distinct_runners=0
+
+	if [[ "$distinct_runners" -le 1 ]]; then
+		# No competing runner — we own the lock.
+		echo "[pulse-wrapper] Consolidation lock: acquired by ${self_login} on #${parent_num} in ${repo_slug}" >>"$LOGFILE"
+		return 0
+	fi
+
+	# Tiebreak: lexicographically lowest login wins. Deterministic without
+	# relying on clock skew between runners.
+	local winner_login
+	winner_login=$(printf '%s' "$markers_json" |
+		jq -r '[.[].runner] | unique | sort | .[0]' 2>/dev/null) || winner_login=""
+
+	if [[ "$winner_login" == "$self_login" ]]; then
+		echo "[pulse-wrapper] Consolidation lock: won tiebreaker on #${parent_num} in ${repo_slug} (self=${self_login}, competitors=$(printf '%s' "$markers_json" | jq -r '[.[].runner] | unique | join(",")' 2>/dev/null))" >>"$LOGFILE"
+		return 0
+	fi
+
+	# We lost. Release our marker but leave the label (winner still needs it).
+	echo "[pulse-wrapper] Consolidation lock: lost tiebreaker on #${parent_num} in ${repo_slug} (self=${self_login}, winner=${winner_login}) — rolling back our marker" >>"$LOGFILE"
+	local self_marker_ids
+	self_marker_ids=$(printf '%s' "$markers_json" |
+		jq -r --arg me "$self_login" '.[] | select(.runner == $me) | .id' 2>/dev/null) || self_marker_ids=""
+	local mid
+	while IFS= read -r mid; do
+		[[ -z "$mid" ]] && continue
+		gh api -X DELETE "repos/${repo_slug}/issues/comments/${mid}" >/dev/null 2>&1 || true
+	done <<<"$self_marker_ids"
+	return 1
 }
 
 #######################################
@@ -840,13 +1105,20 @@ _Automated by \`_dispatch_issue_consolidation()\` in \`pulse-triage.sh\` (t1982)
 }
 
 #######################################
-# t1982: Dispatch a consolidation task for an issue with accumulated
+# t1982/t2151: Dispatch a consolidation task for an issue with accumulated
 # substantive comments. Creates a self-contained consolidation-task child
 # issue that the pulse will pick up on the next cycle. The child's body
 # contains the parent's title, body, and substantive comments inline so
 # the worker never needs to read the parent.
 #
-# Idempotent: returns 0 without creating anything if a child already exists.
+# Idempotent: returns 0 without creating anything if a child already exists
+# or if the cross-runner advisory lock is held by another runner.
+#
+# t2151 cross-runner coordination:
+#   Phase A (t2144) closed single-runner cascade vectors. This path adds
+#   the cross-runner guard: acquire `consolidation-in-progress` before
+#   creating the child, release on any exit path (success or failure).
+#   See `_consolidation_lock_acquire` for the full protocol.
 #
 # Reference pattern: `_issue_targets_large_files` at pulse-dispatch-core.sh:685-757
 # which creates simplification-debt child issues the same way.
@@ -861,12 +1133,30 @@ _dispatch_issue_consolidation() {
 
 	# Dedup: if an open consolidation-task already references this parent,
 	# just ensure the parent is flagged and return. Do NOT create a duplicate.
+	# t2151: _consolidation_child_exists also returns 0 when the lock label
+	# is present, so a competing runner's in-flight creation blocks us here
+	# before we ever touch the acquire path.
 	if _consolidation_child_exists "$issue_number" "$repo_slug"; then
 		gh issue edit "$issue_number" --repo "$repo_slug" \
 			--add-label "needs-consolidation" 2>/dev/null || true
 		echo "[pulse-wrapper] Consolidation: child already exists for #${issue_number} in ${repo_slug}; flagged parent and returning" >>"$LOGFILE"
 		return 0
 	fi
+
+	# t2151: acquire the cross-runner advisory lock before any state changes
+	# that would be expensive or visible to cause a partial-state race.
+	# If we don't win the lock, another runner will create the child; we
+	# just need to flag the parent as needing consolidation and return.
+	if ! _consolidation_lock_acquire "$issue_number" "$repo_slug"; then
+		gh issue edit "$issue_number" --repo "$repo_slug" \
+			--add-label "needs-consolidation" 2>/dev/null || true
+		echo "[pulse-wrapper] Consolidation: lock held by another runner for #${issue_number} in ${repo_slug}; flagged parent and yielding" >>"$LOGFILE"
+		return 0
+	fi
+
+	# From this point on, every exit path MUST call _consolidation_lock_release.
+	local self_login
+	self_login=$(_consolidation_lock_self_login)
 
 	# Fetch parent metadata.
 	local parent_title parent_body parent_labels
@@ -903,17 +1193,96 @@ _dispatch_issue_consolidation() {
 		# Still flag parent so it doesn't keep firing every cycle.
 		gh issue edit "$issue_number" --repo "$repo_slug" \
 			--add-label "needs-consolidation" 2>/dev/null || true
+		# t2151: release the lock on failure too — otherwise TTL is the only
+		# way it clears, and another runner would be blocked for 6h.
+		_consolidation_lock_release "$issue_number" "$repo_slug" "$self_login"
 		return 1
 	fi
 
 	# Flag parent and post the idempotent pointer comment.
 	_post_consolidation_dispatch_comment "$issue_number" "$repo_slug" "$child_num" "$authors_csv"
+	# t2151: release the lock — the child now exists on GitHub and
+	# `_consolidation_child_exists` will block subsequent dispatches on
+	# its own, making the lock unnecessary past this point.
+	_consolidation_lock_release "$issue_number" "$repo_slug" "$self_login"
 	echo "[pulse-wrapper] Consolidation: flagged #${issue_number} in ${repo_slug}, dispatched child #${child_num}" >>"$LOGFILE"
 	return 0
 }
 
 #######################################
-# t1982: Backfill pass for stuck needs-consolidation issues.
+# t2151: Clear stale `consolidation-in-progress` lock labels whose oldest
+# lock-marker comment is older than CONSOLIDATION_LOCK_TTL_HOURS. Covers
+# the case where the runner that acquired the lock crashed or lost network
+# between `_consolidation_lock_acquire` and `_consolidation_lock_release`,
+# leaving the lock wedged.
+#
+# Called from _backfill_stale_consolidation_labels so every pulse cycle
+# sweeps all pulse-enabled repos for stuck locks at zero marginal cost.
+#
+# Args: $1=repo_slug, $2=issue_number
+# Returns: 0 if lock was cleared, 1 if lock was fresh (no action taken).
+# Side effect: emits a log line when clearing.
+#######################################
+_consolidation_ttl_sweep_one() {
+	local slug="$1"
+	local num="$2"
+	local ttl_hours="${CONSOLIDATION_LOCK_TTL_HOURS:-6}"
+	[[ "$ttl_hours" =~ ^[0-9]+$ ]] || ttl_hours=6
+
+	# Get the oldest lock-marker timestamp.
+	local markers_json
+	markers_json=$(_consolidation_lock_markers "$num" "$slug")
+	[[ -n "$markers_json" ]] || markers_json="[]"
+
+	local oldest_iso
+	oldest_iso=$(printf '%s' "$markers_json" |
+		jq -r '.[0].created_at // empty' 2>/dev/null) || oldest_iso=""
+
+	if [[ -z "$oldest_iso" ]]; then
+		# Label present but no marker comment — orphaned from a previous
+		# deploy or manual edit. Clear it as well (nothing to tiebreak).
+		gh issue edit "$num" --repo "$slug" \
+			--remove-label "consolidation-in-progress" >/dev/null 2>&1 || true
+		echo "[pulse-wrapper] Consolidation lock TTL sweep: cleared orphan (no marker) on #${num} in ${slug}" >>"$LOGFILE"
+		return 0
+	fi
+
+	# Compute oldest-epoch. Prefer GNU date -d; fall back to BSD date -j.
+	local oldest_epoch=""
+	oldest_epoch=$(date -u -d "$oldest_iso" +'%s' 2>/dev/null) || oldest_epoch=""
+	if [[ -z "$oldest_epoch" ]]; then
+		oldest_epoch=$(TZ=UTC date -j -f '%Y-%m-%dT%H:%M:%SZ' "$oldest_iso" +'%s' 2>/dev/null) || oldest_epoch=""
+	fi
+	# If date parsing fails entirely, fall-open (treat as fresh). A real
+	# stuck lock will trip on the NEXT pulse cycle once the comment-ISO
+	# parser recovers — preferable to false-clearing an in-flight lock.
+	[[ -n "$oldest_epoch" ]] || return 1
+
+	local now_epoch
+	now_epoch=$(date -u +'%s' 2>/dev/null) || now_epoch=0
+	local age_seconds=$((now_epoch - oldest_epoch))
+	local ttl_seconds=$((ttl_hours * 3600))
+
+	if [[ "$age_seconds" -lt "$ttl_seconds" ]]; then
+		return 1
+	fi
+
+	# Lock is stale — clear the label and delete ALL markers (nobody is
+	# coming back for them; the next dispatcher starts from scratch).
+	gh issue edit "$num" --repo "$slug" \
+		--remove-label "consolidation-in-progress" >/dev/null 2>&1 || true
+	local mid
+	while IFS= read -r mid; do
+		[[ -z "$mid" ]] && continue
+		gh api -X DELETE "repos/${slug}/issues/comments/${mid}" >/dev/null 2>&1 || true
+	done < <(printf '%s' "$markers_json" | jq -r '.[].id' 2>/dev/null)
+
+	echo "[pulse-wrapper] Consolidation lock TTL sweep: cleared stale lock on #${num} in ${slug} (age=${age_seconds}s, ttl=${ttl_seconds}s)" >>"$LOGFILE"
+	return 0
+}
+
+#######################################
+# t1982/t2151: Backfill pass for stuck needs-consolidation issues.
 #
 # The re-evaluation pass (_reevaluate_consolidation_labels) only *clears*
 # stale labels when the comment filter no longer triggers. Issues flagged
@@ -923,6 +1292,12 @@ _dispatch_issue_consolidation() {
 #
 # This pass sweeps every open needs-consolidation issue without a linked
 # consolidation-task child and dispatches one retroactively.
+#
+# t2151: Also sweeps every open `consolidation-in-progress` issue and
+# clears the lock label when the oldest lock-marker comment is older than
+# CONSOLIDATION_LOCK_TTL_HOURS (default 6h). Closes the "runner crashed
+# mid-dispatch" failure mode in which the lock would otherwise sit wedged
+# until a human notices.
 #
 # Runs every pulse cycle alongside _reevaluate_consolidation_labels.
 # Cheap: one gh issue list per repo + one child-exists lookup per labelled
@@ -934,8 +1309,27 @@ _backfill_stale_consolidation_labels() {
 
 	local total_backfilled=0
 	local total_cleared_stale=0
+	local total_locks_expired=0
 	while IFS='|' read -r slug rpath; do
 		[[ -n "$slug" ]] || continue
+
+		# t2151: TTL sweep for stuck `consolidation-in-progress` labels.
+		# Separate query from needs-consolidation because a lock can be held
+		# on a parent that already has both labels (lock was acquired before
+		# needs-consolidation was applied) or only the lock (acquire path
+		# where child creation failed after lock but before flag-parent).
+		local locked_issues_json
+		locked_issues_json=$(gh issue list --repo "$slug" --state open \
+			--label "consolidation-in-progress" \
+			--json number --limit 50 2>/dev/null) || locked_issues_json='[]'
+		local locked_num
+		while IFS= read -r locked_num; do
+			[[ "$locked_num" =~ ^[0-9]+$ ]] || continue
+			if _consolidation_ttl_sweep_one "$slug" "$locked_num"; then
+				total_locks_expired=$((total_locks_expired + 1))
+			fi
+		done < <(printf '%s' "$locked_issues_json" | jq -r '.[]?.number // ""' 2>/dev/null)
+
 		local issues_json
 		issues_json=$(gh issue list --repo "$slug" --state open \
 			--label "needs-consolidation" \
@@ -982,6 +1376,9 @@ _backfill_stale_consolidation_labels() {
 	fi
 	if [[ "$total_cleared_stale" -gt 0 ]]; then
 		echo "[pulse-wrapper] Consolidation backfill: cleared ${total_cleared_stale} stale needs-consolidation label(s) on already-consolidated parents (t2144)" >>"$LOGFILE"
+	fi
+	if [[ "$total_locks_expired" -gt 0 ]]; then
+		echo "[pulse-wrapper] Consolidation backfill: cleared ${total_locks_expired} stale consolidation-in-progress lock(s) (t2151 TTL)" >>"$LOGFILE"
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-consolidation-multi-runner.sh
+++ b/.agents/scripts/tests/test-consolidation-multi-runner.sh
@@ -1,0 +1,659 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-consolidation-multi-runner.sh — t2151 regression tests for the
+# cross-runner advisory lock on consolidation dispatch.
+#
+# Covers the race that Phase A (t2144, PR #19411) could not close:
+# two pulse runners on different hosts both pass
+# _consolidation_child_exists at the same moment, and both create a
+# consolidation-task child. Production evidence: parent #19321 dispatched
+# #19341 (marcusquinn pulse) and #19367 (alex-solovyev pulse, 55 min later).
+#
+# Assertions:
+#   1. Happy path — single runner acquires the lock, creates the child,
+#      releases the lock (label removed + marker deleted).
+#   2. Race tiebreaker — two runners post markers; the lexicographically
+#      lowest login wins, the loser rolls back its marker and skips dispatch.
+#   3. Lock label blocks _consolidation_child_exists — a parent carrying
+#      `consolidation-in-progress` is treated as owned even with no open
+#      or recently-closed child.
+#   4. TTL expiry — a lock whose oldest marker is older than
+#      CONSOLIDATION_LOCK_TTL_HOURS is cleared by the backfill sweep.
+#   5. Child-close release semantics — after successful child creation, the
+#      lock label is removed so _consolidation_child_exists (child-scope)
+#      takes over as the blocking signal on subsequent dispatches.
+#   6. dispatch-dedup-helper.sh is-assigned treats the lock label as an
+#      active claim, so unrelated dispatch paths can't sneak past.
+#
+# Strategy: source pulse-triage.sh with a capable `gh` stub on PATH that
+# branches on subcommand + API path and returns canned responses driven
+# by env vars set per test.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+GH_LOG=""
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+# =============================================================================
+# gh stub — capable enough to drive the lock protocol paths.
+# =============================================================================
+#
+# Env vars consumed per test:
+#   GH_SELF_LOGIN                — string returned by `gh api user --jq .login`
+#   GH_LOCK_LABEL_PRESENT        — "true" if parent currently has the lock label
+#   GH_LOCK_MARKERS_JSON         — JSON array returned by the lock-markers jq query
+#   GH_ISSUE_VIEW_LABELS         — CSV returned by --json labels query on parent
+#   GH_API_COMMENTS_JSON         — JSON returned by generic comments fetch
+#   GH_ISSUE_LIST_CHILD_JSON     — existing dedup-check fixture (open children)
+#   GH_ISSUE_LIST_CHILD_CLOSED_JSON — existing dedup-check fixture (closed children)
+#   GH_ISSUE_LIST_LOCK_JSON      — issues returned by `--label consolidation-in-progress`
+#   GH_ISSUE_CREATE_URL          — URL echoed by `gh issue create` on success
+# =============================================================================
+
+_write_gh_stub_binary() {
+	[[ -n "${TEST_ROOT:-}" ]] || {
+		printf 'Error: TEST_ROOT is not set\n' >&2
+		return 1
+	}
+	mkdir -p "${TEST_ROOT}/bin"
+	cat >"${TEST_ROOT}/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+# bash 3.2 compatible capable gh stub for t2151 tests.
+printf '%s\n' "$*" >>"${GH_LOG:-/dev/null}"
+
+cmd1="${1:-}"
+cmd2="${2:-}"
+
+# ---------------- gh api user ----------------
+if [[ "$cmd1" == "api" && "$cmd2" == "user" ]]; then
+	printf '%s\n' "${GH_SELF_LOGIN:-testuser}"
+	exit 0
+fi
+
+# ---------------- gh api -X DELETE repos/.../issues/comments/ID ----------------
+if [[ "$cmd1" == "api" && "$cmd2" == "-X" && "${3:-}" == "DELETE" ]]; then
+	# Just log and succeed — tests verify via gh.log.
+	exit 0
+fi
+
+# ---------------- gh api repos/.../issues/N/comments ----------------
+# Used by both the generic comments fetch (filtered via --jq from caller)
+# and by the lock-markers helper (filtered via --jq for the marker shape).
+# We return GH_LOCK_MARKERS_JSON when the --jq filter contains
+# "consolidation-lock:", otherwise GH_API_COMMENTS_JSON. Callers pass their
+# own --jq expression; we shell out to jq to apply it to the selected JSON.
+if [[ "$cmd1" == "api" ]]; then
+	jq_filter=""
+	prev=""
+	for arg in "$@"; do
+		if [[ "$prev" == "--jq" ]]; then
+			jq_filter="$arg"
+		fi
+		prev="$arg"
+	done
+	# Lock-markers query — path includes /issues/N/comments AND the filter
+	# matches the marker regex.
+	if printf '%s' "$jq_filter" | grep -q 'consolidation-lock'; then
+		src_json="${GH_LOCK_MARKERS_JSON:-[]}"
+		if [[ -n "$jq_filter" ]]; then
+			printf '%s\n' "$src_json" | jq -r "$jq_filter"
+		else
+			printf '%s\n' "$src_json"
+		fi
+		exit 0
+	fi
+	# Generic comments fetch (e.g. substantive-comment scan).
+	src_json="${GH_API_COMMENTS_JSON:-[]}"
+	if [[ -n "$jq_filter" ]]; then
+		printf '%s\n' "$src_json" | jq -r "$jq_filter"
+	else
+		printf '%s\n' "$src_json"
+	fi
+	exit 0
+fi
+
+# ---------------- gh issue view --json labels ----------------
+if [[ "$cmd1" == "issue" && "$cmd2" == "view" ]]; then
+	shift 2
+	local_json=""
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--json)
+			local_json="$2"
+			shift 2
+			;;
+		--jq)
+			shift 2
+			;;
+		*) shift ;;
+		esac
+	done
+	case "$local_json" in
+	title) printf '%s\n' "${GH_ISSUE_VIEW_TITLE:-Parent Title}" ;;
+	body) printf '%s\n' "${GH_ISSUE_VIEW_BODY:-Parent body}" ;;
+	labels) printf '%s\n' "${GH_ISSUE_VIEW_LABELS:-bug,tier:standard}" ;;
+	*) printf '\n' ;;
+	esac
+	exit 0
+fi
+
+# ---------------- gh issue list ----------------
+if [[ "$cmd1" == "issue" && "$cmd2" == "list" ]]; then
+	jq_filter=""
+	state_arg="open"
+	label_arg=""
+	prev=""
+	for arg in "$@"; do
+		if [[ "$prev" == "--jq" ]]; then jq_filter="$arg"; fi
+		if [[ "$prev" == "--state" ]]; then state_arg="$arg"; fi
+		if [[ "$prev" == "--label" ]]; then label_arg="$arg"; fi
+		prev="$arg"
+	done
+	case "$label_arg" in
+	consolidation-in-progress)
+		src_json="${GH_ISSUE_LIST_LOCK_JSON:-[]}"
+		;;
+	consolidation-task)
+		if [[ "$state_arg" == "closed" ]]; then
+			src_json="${GH_ISSUE_LIST_CHILD_CLOSED_JSON:-[]}"
+		else
+			src_json="${GH_ISSUE_LIST_CHILD_JSON:-[]}"
+		fi
+		;;
+	needs-consolidation)
+		src_json="${GH_ISSUE_LIST_NEEDS_JSON:-[]}"
+		;;
+	*)
+		src_json="[]"
+		;;
+	esac
+	if [[ -n "$jq_filter" ]]; then
+		printf '%s\n' "$src_json" | jq -r "$jq_filter"
+	else
+		printf '%s\n' "$src_json"
+	fi
+	exit 0
+fi
+
+# ---------------- gh issue create / edit / comment / label ----------------
+if [[ "$cmd1" == "issue" && "$cmd2" == "create" ]]; then
+	printf '%s\n' "${GH_ISSUE_CREATE_URL:-https://github.com/owner/repo/issues/999}"
+	exit 0
+fi
+if [[ "$cmd1" == "issue" && "$cmd2" == "edit" ]]; then exit 0; fi
+if [[ "$cmd1" == "issue" && "$cmd2" == "comment" ]]; then exit 0; fi
+if [[ "$cmd1" == "label" && "$cmd2" == "create" ]]; then exit 0; fi
+
+printf 'gh stub: unhandled: %s\n' "$*" >&2
+exit 0
+STUB
+	chmod +x "${TEST_ROOT}/bin/gh"
+	return 0
+}
+
+_setup_gh_stub_globals() {
+	[[ -n "${TEST_ROOT:-}" ]] || return 1
+	export PATH="${TEST_ROOT}/bin:${PATH}"
+	export GH_LOG
+	export LOGFILE="${TEST_ROOT}/pulse.log"
+	: >"$LOGFILE"
+
+	export TRIAGE_CACHE_DIR="${TEST_ROOT}/triage-cache"
+	mkdir -p "$TRIAGE_CACHE_DIR"
+	export ISSUE_CONSOLIDATION_COMMENT_MIN_CHARS=50
+	export ISSUE_CONSOLIDATION_COMMENT_THRESHOLD=2
+	export REPOS_JSON="${TEST_ROOT}/repos.json"
+	printf '{"initialized_repos": []}\n' >"$REPOS_JSON"
+	# Tests should never actually sleep during tiebreak re-check.
+	export CONSOLIDATION_LOCK_TIEBREAK_WAIT_SEC=0
+
+	# shellcheck disable=SC1091
+	source "${REPO_ROOT}/.agents/scripts/pulse-triage.sh"
+
+	# Stub the gh_create_issue wrapper (defined in shared-constants.sh, not
+	# sourced here) so _create_consolidation_child_issue reaches the `gh
+	# issue create` path. Mirrors test-consolidation-dispatch.sh.
+	gh_create_issue() {
+		gh issue create "$@"
+	}
+	return 0
+}
+
+setup_gh_stub() {
+	TEST_ROOT=$(mktemp -d -t t2151-lock.XXXXXX)
+	GH_LOG="${TEST_ROOT}/gh.log"
+	: >"$GH_LOG"
+	_write_gh_stub_binary
+	_setup_gh_stub_globals
+	return 0
+}
+
+teardown_gh_stub() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	TEST_ROOT=""
+	GH_LOG=""
+	unset GH_SELF_LOGIN GH_LOCK_LABEL_PRESENT GH_LOCK_MARKERS_JSON
+	unset GH_ISSUE_VIEW_TITLE GH_ISSUE_VIEW_BODY GH_ISSUE_VIEW_LABELS
+	unset GH_API_COMMENTS_JSON
+	unset GH_ISSUE_LIST_CHILD_JSON GH_ISSUE_LIST_CHILD_CLOSED_JSON
+	unset GH_ISSUE_LIST_LOCK_JSON GH_ISSUE_LIST_NEEDS_JSON
+	unset GH_ISSUE_CREATE_URL
+	unset CONSOLIDATION_LOCK_TTL_HOURS
+	return 0
+}
+
+# =============================================================================
+# Fixture helpers
+# =============================================================================
+
+# fixture_two_substantive_comments_t2151 — two human comments clearing the
+# substantive threshold. Keeps _dispatch_issue_consolidation on its child-
+# creation path (not the "no substantive" short-circuit).
+fixture_two_substantive_comments_t2151() {
+	cat <<'JSON'
+[
+  {"user": {"login": "alice", "type": "User"}, "created_at": "2026-04-12T10:00:00Z", "body": "I think we need to add a third failure case for the offline path when the cache is cold."},
+  {"user": {"login": "bob", "type": "User"}, "created_at": "2026-04-12T11:30:00Z", "body": "Agree with alice and also the retry policy should back off exponentially rather than linearly."}
+]
+JSON
+}
+
+# fixture_single_marker <runner> <iso> — one lock-marker JSON record
+# shaped as returned by _consolidation_lock_markers.
+fixture_single_marker() {
+	local runner="$1" ts="$2" id="${3:-100}"
+	jq -n --arg r "$runner" --arg ts "$ts" --argjson id "$id" '
+		[{"id": $id, "body": "<!-- consolidation-lock:runner=\($r) ts=\($ts) -->", "created_at": $ts, "runner": $r}]
+	'
+}
+
+# fixture_two_markers — two lock markers for race tiebreaker test.
+# alice at 10:00:00, bob at 10:00:01. Lexicographic winner = alice.
+fixture_two_markers() {
+	jq -n '
+		[
+			{"id": 101, "body": "<!-- consolidation-lock:runner=alice ts=2026-04-16T10:00:00Z -->", "created_at": "2026-04-16T10:00:00Z", "runner": "alice"},
+			{"id": 102, "body": "<!-- consolidation-lock:runner=bob ts=2026-04-16T10:00:01Z -->",   "created_at": "2026-04-16T10:00:01Z", "runner": "bob"}
+		]
+	'
+}
+
+# =============================================================================
+# Tests
+# =============================================================================
+
+# -------------- 1. Happy path: single runner acquires + releases --------------
+test_single_runner_acquire_create_release() {
+	setup_gh_stub
+	export GH_SELF_LOGIN="alice"
+	# After the post-marker re-read, only our marker is present.
+	export GH_LOCK_MARKERS_JSON
+	GH_LOCK_MARKERS_JSON=$(fixture_single_marker "alice" "2026-04-16T10:00:00Z" 101)
+	export GH_ISSUE_VIEW_TITLE="test parent"
+	export GH_ISSUE_VIEW_BODY="Parent body"
+	export GH_ISSUE_VIEW_LABELS="bug,tier:standard"
+	export GH_API_COMMENTS_JSON
+	GH_API_COMMENTS_JSON=$(fixture_two_substantive_comments_t2151)
+	export GH_ISSUE_LIST_CHILD_JSON="[]"
+	export GH_ISSUE_LIST_CHILD_CLOSED_JSON="[]"
+	export GH_ISSUE_CREATE_URL="https://github.com/owner/repo/issues/9100"
+
+	local rc=0
+	_dispatch_issue_consolidation 100 "owner/repo" "/tmp/fake-path" || rc=$?
+
+	local failures=0 failmsg=""
+	if [[ "$rc" -ne 0 ]]; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | dispatch returned $rc"
+	fi
+	if ! grep -qE 'issue edit .* --add-label consolidation-in-progress' "$GH_LOG" 2>/dev/null; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | acquire did not add-label consolidation-in-progress"
+	fi
+	# Marker comment posted via `gh issue comment --body '<!-- consolidation-lock:...'`
+	if ! grep -qE 'issue comment 100 .* consolidation-lock:runner=alice' "$GH_LOG" 2>/dev/null; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | marker comment not posted"
+	fi
+	if ! grep -q 'issue create' "$GH_LOG" 2>/dev/null; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | child issue was not created"
+	fi
+	if ! grep -qE 'issue edit .* --remove-label consolidation-in-progress' "$GH_LOG" 2>/dev/null; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | release did not remove-label consolidation-in-progress"
+	fi
+	if ! grep -qE 'api -X DELETE .*/issues/comments/101' "$GH_LOG" 2>/dev/null; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | release did not delete our marker comment (id=101)"
+	fi
+
+	if [[ $failures -eq 0 ]]; then
+		print_result "t2151 happy-path: acquire → create child → release" 0
+	else
+		print_result "t2151 happy-path: acquire → create child → release" 1 "$failmsg"
+	fi
+
+	teardown_gh_stub
+	return 0
+}
+
+# -------------- 2. Race tiebreaker: lexicographically lowest wins --------------
+test_race_lexicographic_tiebreaker_loser_yields() {
+	setup_gh_stub
+	# Self is "bob" — two markers exist (alice+bob), alice wins.
+	export GH_SELF_LOGIN="bob"
+	export GH_LOCK_MARKERS_JSON
+	GH_LOCK_MARKERS_JSON=$(fixture_two_markers)
+	export GH_ISSUE_VIEW_LABELS="bug,tier:standard"
+	export GH_API_COMMENTS_JSON
+	GH_API_COMMENTS_JSON=$(fixture_two_substantive_comments_t2151)
+	export GH_ISSUE_LIST_CHILD_JSON="[]"
+	export GH_ISSUE_LIST_CHILD_CLOSED_JSON="[]"
+	export GH_ISSUE_CREATE_URL="https://github.com/owner/repo/issues/SHOULD_NOT_BE_CALLED"
+
+	local rc=0
+	_dispatch_issue_consolidation 100 "owner/repo" "/tmp/fake-path" || rc=$?
+
+	local failures=0 failmsg=""
+	# Loser MUST NOT create the child.
+	if grep -q 'issue create' "$GH_LOG" 2>/dev/null; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | loser (bob) created a child despite losing tiebreaker"
+	fi
+	# Loser MUST delete its own marker (bob's id=102).
+	if ! grep -qE 'api -X DELETE .*/issues/comments/102' "$GH_LOG" 2>/dev/null; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | loser did not delete its marker (id=102)"
+	fi
+	# Loser MUST NOT delete the winner's marker (alice's id=101).
+	if grep -qE 'api -X DELETE .*/issues/comments/101' "$GH_LOG" 2>/dev/null; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | loser incorrectly deleted winner's marker (id=101)"
+	fi
+	# Dispatch MUST still return 0 (yielding is not a failure — parent stays flagged).
+	if [[ "$rc" -ne 0 ]]; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | dispatch returned $rc (expected 0 on lost-race yield)"
+	fi
+
+	if [[ $failures -eq 0 ]]; then
+		print_result "t2151 race tiebreaker: lexicographically lowest login wins, loser yields" 0
+	else
+		print_result "t2151 race tiebreaker: lexicographically lowest login wins, loser yields" 1 "$failmsg"
+	fi
+
+	teardown_gh_stub
+	return 0
+}
+
+# Winner side of the same race — confirms alice both proceeds AND succeeds.
+test_race_lexicographic_tiebreaker_winner_proceeds() {
+	setup_gh_stub
+	export GH_SELF_LOGIN="alice"
+	export GH_LOCK_MARKERS_JSON
+	GH_LOCK_MARKERS_JSON=$(fixture_two_markers)
+	export GH_ISSUE_VIEW_TITLE="test parent"
+	export GH_ISSUE_VIEW_BODY="Parent body"
+	export GH_ISSUE_VIEW_LABELS="bug,tier:standard"
+	export GH_API_COMMENTS_JSON
+	GH_API_COMMENTS_JSON=$(fixture_two_substantive_comments_t2151)
+	export GH_ISSUE_LIST_CHILD_JSON="[]"
+	export GH_ISSUE_LIST_CHILD_CLOSED_JSON="[]"
+	export GH_ISSUE_CREATE_URL="https://github.com/owner/repo/issues/9101"
+
+	local rc=0
+	_dispatch_issue_consolidation 100 "owner/repo" "/tmp/fake-path" || rc=$?
+
+	local failures=0 failmsg=""
+	if [[ "$rc" -ne 0 ]]; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | dispatch returned $rc"
+	fi
+	if ! grep -q 'issue create' "$GH_LOG" 2>/dev/null; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | winner did not create the child"
+	fi
+	# Winner (alice) deletes ONLY her own marker (id=101) on release.
+	if ! grep -qE 'api -X DELETE .*/issues/comments/101' "$GH_LOG" 2>/dev/null; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | winner did not delete her marker (id=101)"
+	fi
+	# Winner MUST NOT clear the label (bob's marker still on the parent).
+	# The release path calls `issue edit --remove-label` only when no
+	# competitor marker remains; GH_LOCK_MARKERS_JSON still contains bob,
+	# so no remove-label call should appear in the log.
+	if grep -qE 'issue edit .* --remove-label consolidation-in-progress' "$GH_LOG" 2>/dev/null; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | winner cleared lock label despite competitor marker still present"
+	fi
+
+	if [[ $failures -eq 0 ]]; then
+		print_result "t2151 race tiebreaker: winner proceeds and leaves label for in-flight competitor" 0
+	else
+		print_result "t2151 race tiebreaker: winner proceeds and leaves label for in-flight competitor" 1 "$failmsg"
+	fi
+
+	teardown_gh_stub
+	return 0
+}
+
+# -------------- 3. Lock label blocks _consolidation_child_exists --------------
+test_lock_label_blocks_child_exists() {
+	setup_gh_stub
+	# No open or closed children, but lock label is on the parent.
+	export GH_ISSUE_LIST_CHILD_JSON="[]"
+	export GH_ISSUE_LIST_CHILD_CLOSED_JSON="[]"
+	export GH_ISSUE_VIEW_LABELS="bug,tier:standard,consolidation-in-progress"
+
+	if _consolidation_child_exists 100 "owner/repo"; then
+		print_result "t2151 lock label makes _consolidation_child_exists return 0" 0
+	else
+		print_result "t2151 lock label makes _consolidation_child_exists return 0" 1 \
+			"returned 1 despite consolidation-in-progress label on parent"
+	fi
+
+	# Sanity: without the label, the same zero-fixture returns 1 (no-child).
+	export GH_ISSUE_VIEW_LABELS="bug,tier:standard"
+	if _consolidation_child_exists 100 "owner/repo"; then
+		print_result "t2151 no-label sanity check: _consolidation_child_exists returns 1 with no children + no lock" 1 \
+			"returned 0 despite empty child lists and no lock label"
+	else
+		print_result "t2151 no-label sanity check: _consolidation_child_exists returns 1 with no children + no lock" 0
+	fi
+
+	teardown_gh_stub
+	return 0
+}
+
+# -------------- 4. TTL expiry: stuck lock is swept --------------
+test_ttl_expiry_clears_stale_lock() {
+	setup_gh_stub
+	# Set TTL to 1 hour for the test; marker age will be 10 hours.
+	export CONSOLIDATION_LOCK_TTL_HOURS=1
+	export GH_LOCK_MARKERS_JSON
+	local old_ts
+	old_ts=$(date -u -d "10 hours ago" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null ||
+		date -u -v-10H +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null ||
+		printf '%s' "2000-01-01T00:00:00Z")
+	GH_LOCK_MARKERS_JSON=$(fixture_single_marker "alice" "$old_ts" 200)
+
+	local rc=0
+	_consolidation_ttl_sweep_one "owner/repo" 100 || rc=$?
+	# Exit 0 signals "cleared".
+	local failures=0 failmsg=""
+	if [[ "$rc" -ne 0 ]]; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | sweep returned $rc (expected 0 for stale lock)"
+	fi
+	if ! grep -qE 'issue edit .* --remove-label consolidation-in-progress' "$GH_LOG" 2>/dev/null; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | sweep did not remove label"
+	fi
+	if ! grep -qE 'api -X DELETE .*/issues/comments/200' "$GH_LOG" 2>/dev/null; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | sweep did not delete stale marker (id=200)"
+	fi
+
+	if [[ $failures -eq 0 ]]; then
+		print_result "t2151 TTL expiry: stale lock cleared by backfill sweep" 0
+	else
+		print_result "t2151 TTL expiry: stale lock cleared by backfill sweep" 1 "$failmsg"
+	fi
+
+	# Sanity: a fresh marker (recently posted) does NOT get cleared.
+	teardown_gh_stub
+	setup_gh_stub
+	export CONSOLIDATION_LOCK_TTL_HOURS=1
+	local fresh_ts
+	fresh_ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+	export GH_LOCK_MARKERS_JSON
+	GH_LOCK_MARKERS_JSON=$(fixture_single_marker "alice" "$fresh_ts" 201)
+
+	rc=0
+	_consolidation_ttl_sweep_one "owner/repo" 101 || rc=$?
+	# Exit 1 signals "lock is fresh".
+	if [[ "$rc" -eq 0 ]]; then
+		print_result "t2151 TTL expiry: fresh lock is NOT cleared" 1 \
+			"sweep returned 0 (cleared) for a freshly-posted marker"
+	else
+		# Verify no remove-label was emitted.
+		if grep -qE 'issue edit .* --remove-label consolidation-in-progress' "$GH_LOG" 2>/dev/null; then
+			print_result "t2151 TTL expiry: fresh lock is NOT cleared" 1 \
+				"sweep emitted remove-label on a fresh lock"
+		else
+			print_result "t2151 TTL expiry: fresh lock is NOT cleared" 0
+		fi
+	fi
+
+	teardown_gh_stub
+	return 0
+}
+
+# -------------- 5. dispatch-dedup-helper is-assigned honors the lock --------------
+#
+# dispatch-dedup-helper.sh is designed to be executed as a subprocess, not
+# sourced (its tail invokes `main "$@"`, which prints help when sourced with
+# no args). We source it in a subshell with output suppressed to extract the
+# _has_active_claim function, then unit-test the label recognition logic.
+test_is_assigned_honors_lock_label() {
+	setup_gh_stub
+
+	# Drive the check via a subshell to contain main's auto-invocation.
+	local res_with res_without
+	res_with=$(
+		# shellcheck disable=SC1091
+		source "${REPO_ROOT}/.agents/scripts/dispatch-dedup-helper.sh" >/dev/null 2>&1 || true
+		_has_active_claim '{"labels":[{"name":"consolidation-in-progress"}]}'
+	)
+	res_without=$(
+		# shellcheck disable=SC1091
+		source "${REPO_ROOT}/.agents/scripts/dispatch-dedup-helper.sh" >/dev/null 2>&1 || true
+		_has_active_claim '{"labels":[{"name":"bug"}]}'
+	)
+
+	local failures=0 failmsg=""
+	if [[ "$res_with" != "true" ]]; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | _has_active_claim with consolidation-in-progress returned '$res_with' (expected 'true')"
+	fi
+	if [[ "$res_without" != "false" ]]; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | _has_active_claim with no active labels returned '$res_without' (expected 'false')"
+	fi
+
+	if [[ $failures -eq 0 ]]; then
+		print_result "t2151 dispatch-dedup: _has_active_claim recognises consolidation-in-progress" 0
+	else
+		print_result "t2151 dispatch-dedup: _has_active_claim recognises consolidation-in-progress" 1 "$failmsg"
+	fi
+
+	teardown_gh_stub
+	return 0
+}
+
+# -------------- 6. Lock release releases label when winner was alone --------------
+test_release_clears_label_when_alone() {
+	setup_gh_stub
+	export GH_SELF_LOGIN="alice"
+	# After our release-path re-read, only our marker is present; release
+	# should delete our marker AND drop the label.
+	export GH_LOCK_MARKERS_JSON
+	GH_LOCK_MARKERS_JSON=$(fixture_single_marker "alice" "2026-04-16T10:00:00Z" 301)
+
+	_consolidation_lock_release 100 "owner/repo" "alice"
+
+	local failures=0 failmsg=""
+	if ! grep -qE 'api -X DELETE .*/issues/comments/301' "$GH_LOG" 2>/dev/null; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | release did not delete our marker (id=301)"
+	fi
+	if ! grep -qE 'issue edit .* --remove-label consolidation-in-progress' "$GH_LOG" 2>/dev/null; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | release did not remove label when alone"
+	fi
+
+	if [[ $failures -eq 0 ]]; then
+		print_result "t2151 release: drops label when no competitor marker remains" 0
+	else
+		print_result "t2151 release: drops label when no competitor marker remains" 1 "$failmsg"
+	fi
+
+	teardown_gh_stub
+	return 0
+}
+
+main() {
+	test_single_runner_acquire_create_release
+	test_race_lexicographic_tiebreaker_loser_yields
+	test_race_lexicographic_tiebreaker_winner_proceeds
+	test_lock_label_blocks_child_exists
+	test_ttl_expiry_clears_stale_lock
+	test_is_assigned_honors_lock_label
+	test_release_clears_label_when_alone
+
+	echo
+	echo "============================================"
+	printf 'Tests run:    %d\n' "$TESTS_RUN"
+	printf 'Tests failed: %d\n' "$TESTS_FAILED"
+	echo "============================================"
+
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		exit 1
+	fi
+	exit 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Adds a cross-runner advisory lock for consolidation dispatch using a `consolidation-in-progress` label + signed marker comment. Phase A (t2144, PR #19411) closed single-runner cascades but the cross-runner race remained: two pulse runners on different hosts both pass `_consolidation_child_exists` at the same moment and both create a child. Production evidence: parent #19321 → child #19341 (marcusquinn pulse) + child #19367 (alex-solovyev pulse, 55 min later).

The lock protocol is:
1. **Acquire** — apply `consolidation-in-progress` label + post a signed marker comment (`<!-- consolidation-lock:runner=LOGIN ts=ISO -->`), brief re-read window, tiebreak by lexicographically-lowest login.
2. **Release** — remove label + delete our marker (conditional on no competitor marker remaining).
3. **TTL safety net** — `_backfill_stale_consolidation_labels` sweeps every pulse cycle and clears locks whose oldest marker is older than `CONSOLIDATION_LOCK_TTL_HOURS` (default 6h). Handles the "runner crashed mid-dispatch" case.

Changes:
- `pulse-triage.sh`: new helpers `_consolidation_lock_{marker_body,markers,self_login,label_present,release,acquire}` and `_consolidation_ttl_sweep_one`. `_dispatch_issue_consolidation` now acquires before child creation and releases on every exit path. `_consolidation_child_exists` extended to treat the lock label as a third blocking condition. `_ensure_consolidation_labels` creates the new label. `_backfill_stale_consolidation_labels` sweeps stale locks per cycle.
- `dispatch-dedup-helper.sh`: `_has_active_claim` recognises `consolidation-in-progress` as active (prevents unrelated dispatch paths sneaking past the lock window).
- `label-sync-helper.sh`: canonical definition of the new label (greyish `CFD3D7`).
- `tests/test-consolidation-multi-runner.sh`: new harness with 9 assertions covering happy-path, race-loser, race-winner, lock-blocks-child-exists, TTL-clears-stale, TTL-preserves-fresh, `_has_active_claim` integration, release label drop.

## Files Changed

.agents/scripts/dispatch-dedup-helper.sh,.agents/scripts/label-sync-helper.sh,.agents/scripts/pulse-triage.sh,.agents/scripts/tests/test-consolidation-multi-runner.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** `shellcheck` clean on all modified files. All 9 assertions in the new test-consolidation-multi-runner.sh pass. All 12 existing test-consolidation-dispatch.sh tests (t1982 + t2144 regression suite) pass without regression. All 4 test-consolidation-gate-defaults.sh tests pass. All 16 test-dispatch-dedup-helper-is-assigned.sh tests pass. All 10 test-dispatch-dedup-multi-operator.sh tests pass. All 8 test-triage-failure-escalation.sh tests pass. All 12 test-triage-output-shape.sh tests pass.

Resolves #19414


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.63 plugin for [OpenCode](https://opencode.ai) v1.4.7 with claude-opus-4-6 spent 13m and 53,711 tokens on this as a headless worker.