### PR TITLE
chore: bump FUNCTION_COMPLEXITY_THRESHOLD 28→31 (GH#19452 drift)

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -44,7 +44,20 @@
 # (4 calls) and _generate_seo_ai_commands (7 calls), with the original becoming
 # a 3-line wrapper. Net violations: 26. 26 + 2 buffer = 28. Behavioural no-op —
 # the split exists purely to bring a 101-line function under the 100-line gate.
-FUNCTION_COMPLEXITY_THRESHOLD=28
+# Bumped to 31 (GH#19452): pre-existing drift on main — 29 violations vs threshold
+# 28. Every PR opened against main since 2026-04-17 ~00:46Z (5 consecutive failures
+# observed: code-quality runs 24541744895, 24541756977, 24541769836, 24541780357,
+# 24541783024) is failing this check. The blocked PR (GH#19452, drift discovered
+# while opening PR #19456) adds zero shell function additions — the diff is
+# todo/tasks/*-brief.md + TODO.md only, no scripts touched. Pure drift absorption.
+# 29 + 2 buffer = 31. Largest current offenders (sample): opencode-db-archive.sh
+# cmd_archive (237), headless-runtime-helper.sh _execute_run_attempt (171),
+# complexity-scan-helper.sh cmd_ratchet_check (170). Systemic followup tracked
+# in t2159 (GH-issue TBD): replace this bump-and-ratchet treadmill with a
+# per-function regression check (PR base vs head set-difference, same model as
+# qlty-regression.yml t2065/GH#18773), so PRs only fail for NEW violations
+# they introduce — not for total drift accumulated by other merges.
+FUNCTION_COMPLEXITY_THRESHOLD=31
 
 # Shell nesting depth: files with >8 levels of nesting
 # NOTE: pulse-wrapper.sh has a proximity guard (GH#17808) that warns when


### PR DESCRIPTION
## Summary

Pre-existing drift on main — **29 violations vs threshold 28**. Every PR opened against main since 2026-04-17 ~00:46Z is failing this check.

5 consecutive failures observed on main:
- run 24541744895 (HEAD: 69af2316)
- run 24541756977 (HEAD: a79d8e52)
- run 24541769836 (HEAD: 993a24e8)
- run 24541780357 (HEAD: 52140be9)
- run 24541783024 (HEAD: 8e01f22d)

Bump 28 → 31 unblocks the queue. Ref #19452.

## Pure drift absorption

This PR adds zero shell function changes. The diff is one line in `.agents/configs/complexity-thresholds.conf` plus history comment.

## Largest current offenders

| File | Function | Lines |
|------|----------|------:|
| opencode-db-archive.sh | cmd_archive | 237 |
| headless-runtime-helper.sh | _execute_run_attempt | 171 |
| complexity-scan-helper.sh | cmd_ratchet_check | 170 |
| headless-runtime-helper.sh | cmd_run | 168 |
| pulse-issue-reconcile.sh | reconcile_labelless_aidevops_issues | 162 |
| pulse-merge.sh | _process_single_ready_pr | 156 |

## Systemic followup (t2159)

The 35+ entries in `complexity-thresholds.conf` for FUNCTION_COMPLEXITY_THRESHOLD show a clear bump-and-ratchet treadmill. The systemic fix is to convert this check from a total-count gate to a per-function regression gate (PR base vs head set-difference, same model as `qlty-regression.yml` in t2065/GH#18773), so PRs only fail for NEW violations they introduce — not for total drift accumulated by other merges.

Tracked in t2159 (issue to be filed).

## Verification

- Local count: `source .agents/scripts/lint-file-discovery.sh && lint_shell_files` then awk-scan over `$LINT_SH_FILES` returns 29 violations.
- Bump matches established convention (every recent bump in git log: `chore: bump <THRESHOLD> N→M (GH#NNN)`).

Ref #19452

---

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.63 plugin for [OpenCode](https://opencode.ai) v1.4.7 with claude-opus-4-7 spent 2h 49m and 397,346 tokens on this with the user in an interactive session.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code complexity configuration thresholds to align with current project codebase standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->