### PR TITLE
t2160: fix(pulse-routines): cron schedule extraction truncates at first space

### DIFF
--- a/.agents/scripts/pulse-routines.sh
+++ b/.agents/scripts/pulse-routines.sh
@@ -209,8 +209,14 @@ evaluate_routines() {
 			fi
 
 			# Extract repeat: field
+			# Use a variable to hold the regex so bash does not misparse the
+			# literal ')' inside the character class [^)] as the closing '))'
+			# of the [[ ]] compound.  The alternation handles cron(min hr …)
+			# which contains spaces inside the parentheses — a plain
+			# [^[:space:]]+ regex truncates at the first space (bug t2160).
 			local repeat_expr=""
-			if [[ "$line" =~ repeat:([^[:space:]]+) ]]; then
+			local _re_repeat='repeat:(cron\([^)]*\)|[^[:space:]]+)'
+			if [[ "$line" =~ $_re_repeat ]]; then
 				repeat_expr="${BASH_REMATCH[1]}"
 			else
 				continue

--- a/.agents/scripts/tests/test-pulse-routines-cron-extraction.sh
+++ b/.agents/scripts/tests/test-pulse-routines-cron-extraction.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-pulse-routines-cron-extraction.sh — Regression test for t2160
+#
+# Bug: repeat:cron(*/2 * * * *) was truncated to "cron(*/2" because the
+# extraction regex [^[:space:]]+ stopped at the first space inside the
+# cron parentheses.
+#
+# Fix: use the regex 'repeat:(cron\([^)]*\)|[^[:space:]]+)' stored in a
+# variable (avoids bash misparse of literal ')' in [^)]) to capture the
+# full cron expression including internal spaces.
+#
+# Tests:
+#   1. cron with multiple spaces (*/2 * * * *) → full expression captured
+#   2. cron with step syntax (0 */6 * * *)     → full expression captured
+#   3. daily(@19:00) — no spaces               → unchanged
+#   4. weekly(mon@09:00) — no spaces           → unchanged
+#   5. persistent                              → unchanged
+#   6. Disabled routine [ ] is not matched     → empty result
+
+set -euo pipefail
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+assert_eq() {
+	local test_name="$1"
+	local expected="$2"
+	local actual="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$expected" == "$actual" ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	printf '       expected: %s\n' "$expected"
+	printf '       actual:   %s\n' "$actual"
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+# Mirrors the fixed extraction logic from pulse-routines.sh evaluate_routines()
+extract_repeat_expr() {
+	local line="$1"
+	local _re_repeat='repeat:(cron\([^)]*\)|[^[:space:]]+)'
+	local repeat_expr=""
+	if [[ "$line" =~ $_re_repeat ]]; then
+		repeat_expr="${BASH_REMATCH[1]}"
+	fi
+	printf '%s' "$repeat_expr"
+	return 0
+}
+
+# ─── Tests ────────────────────────────────────────────────────────────────────
+
+test_cron_multi_space() {
+	local line="- [x] r901 Supervisor pulse — dispatch tasks across repos repeat:cron(*/2 * * * *) ~1m run:scripts/pulse-wrapper.sh"
+	local got
+	got=$(extract_repeat_expr "$line")
+	assert_eq "cron(*/2 * * * *): full expression captured (regression t2160)" \
+		"cron(*/2 * * * *)" "$got"
+	return 0
+}
+
+test_cron_step_syntax() {
+	local line="- [x] r909 Screen time snapshot repeat:cron(0 */6 * * *) ~10s run:scripts/screen-time-helper.sh"
+	local got
+	got=$(extract_repeat_expr "$line")
+	assert_eq "cron(0 */6 * * *): step syntax captured in full" \
+		"cron(0 */6 * * *)" "$got"
+	return 0
+}
+
+test_cron_single_field() {
+	local line="- [x] r907 Contribution watch repeat:cron(0 * * * *) ~30s run:scripts/contribution-watch-helper.sh scan"
+	local got
+	got=$(extract_repeat_expr "$line")
+	assert_eq "cron(0 * * * *): hourly cron captured in full" \
+		"cron(0 * * * *)" "$got"
+	return 0
+}
+
+test_daily_no_spaces() {
+	local line="- [x] r906 Repo sync — pull latest across repos repeat:daily(@19:00) ~5m run:bin/aidevops-repo-sync check"
+	local got
+	got=$(extract_repeat_expr "$line")
+	assert_eq "daily(@19:00): non-cron schedule unchanged" \
+		"daily(@19:00)" "$got"
+	return 0
+}
+
+test_weekly_no_spaces() {
+	local line="- [x] r099 Weekly report repeat:weekly(mon@09:00) ~10m agent:Build+"
+	local got
+	got=$(extract_repeat_expr "$line")
+	assert_eq "weekly(mon@09:00): weekly schedule unchanged" \
+		"weekly(mon@09:00)" "$got"
+	return 0
+}
+
+test_persistent() {
+	local line="- [x] r912 Dashboard server repeat:persistent ~0s server/index.ts"
+	local got
+	got=$(extract_repeat_expr "$line")
+	assert_eq "persistent: simple keyword unchanged" \
+		"persistent" "$got"
+	return 0
+}
+
+test_disabled_routine_not_matched() {
+	# Disabled routines use [ ] instead of [x]
+	local line="- [ ] r099 Disabled routine repeat:cron(*/5 * * * *) ~5s run:scripts/some-helper.sh"
+	# The extraction function itself does not filter on [x] — the caller does.
+	# But the regex must still extract correctly; the caller's [[ =~ ^...\[x\] ]] guard filters it.
+	# Test only the extraction function here; caller filtering is tested via evaluate_routines.
+	local got
+	got=$(extract_repeat_expr "$line")
+	assert_eq "disabled routine: regex still extracts expression (caller must filter [x])" \
+		"cron(*/5 * * * *)" "$got"
+	return 0
+}
+
+test_no_repeat_field() {
+	local line="- [x] r099 Task without repeat field run:scripts/some-helper.sh"
+	local got
+	got=$(extract_repeat_expr "$line")
+	assert_eq "no repeat: field → empty result" "" "$got"
+	return 0
+}
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
+
+test_cron_multi_space
+test_cron_step_syntax
+test_cron_single_field
+test_daily_no_spaces
+test_weekly_no_spaces
+test_persistent
+test_disabled_routine_not_matched
+test_no_repeat_field
+
+echo ""
+echo "Results: ${TESTS_RUN} tests, $((TESTS_RUN - TESTS_FAILED)) passed, ${TESTS_FAILED} failed"
+
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## What

Fix `evaluate_routines()` in `.agents/scripts/pulse-routines.sh` — the regex that extracts the `repeat:` schedule expression from TODO.md routine lines was truncating cron expressions at the first internal space.

**Bug:** `repeat:cron(*/2 * * * *)` → extracted `cron(*/2` (truncated).
**Fix:** `repeat:cron(*/2 * * * *)` → extracted `cron(*/2 * * * *)` (correct).

## Why

Cron expressions like `cron(*/2 * * * *)` contain spaces inside the parentheses. The old regex `[^[:space:]]+` stopped at the first space, so all cron-scheduled routines (r901–r912, defined in `routines/core-routines.sh`) were being called with a malformed expression, causing `routine-schedule-helper.sh is-due` to receive `cron(*/2` instead of a valid 5-field cron expression. Every cron-based routine would silently never fire or consistently error.

## How

Changed `.agents/scripts/pulse-routines.sh` line 213:

**Before:**
```bash
if [[ "$line" =~ repeat:([^[:space:]]+) ]]; then
    repeat_expr="${BASH_REMATCH[1]}"
```

**After:**
```bash
local _re_repeat='repeat:(cron\([^)]*\)|[^[:space:]]+)'
if [[ "$line" =~ $_re_repeat ]]; then
    repeat_expr="${BASH_REMATCH[1]}"
```

The regex must be stored in a variable because bash misparsing of the literal `)` inside `[^)]` when inlined in a `[[ =~ ... ]]` expression causes a syntax error. The alternation `cron\([^)]*\)|[^[:space:]]+` first tries to match the full `cron(...)` form (consuming spaces inside parens), then falls back to `[^[:space:]]+` for daily/weekly/monthly/persistent formats.

## Verification

New regression test: `.agents/scripts/tests/test-pulse-routines-cron-extraction.sh`

```
PASS cron(*/2 * * * *): full expression captured (regression t2160)
PASS cron(0 */6 * * *): step syntax captured in full
PASS cron(0 * * * *): hourly cron captured in full
PASS daily(@19:00): non-cron schedule unchanged
PASS weekly(mon@09:00): weekly schedule unchanged
PASS persistent: simple keyword unchanged
PASS disabled routine: regex still extracts expression (caller must filter [x])
PASS no repeat: field → empty result

Results: 8 tests, 8 passed, 0 failed
```

Shellcheck: zero violations on both modified/new files.

Resolves #19465