### PR TITLE
GH#19472: bump NESTING_DEPTH_THRESHOLD to 289

### DIFF
--- a/.agents/configs/complexity-thresholds-history.md
+++ b/.agents/configs/complexity-thresholds-history.md
@@ -76,6 +76,8 @@ Archives the full change history for `.agents/configs/complexity-thresholds.conf
 | 288 | GH#19419 | proximity guard firing at 281/283 (2 headroom); 281 violations + 7 headroom = 288; proximity guard (warn_at = 288-5 = 283) fires when violations exceed 283 (i.e., at 284), preventing saturation |
 | 283 | GH#19423 | ratcheted down — actual violations 281 + 2 buffer |
 | 288 | GH#19430 | proximity guard firing at 281/283 (2 headroom); 281 violations + 7 headroom = 288; proximity guard (warn_at = 288-5 = 283) fires when violations exceed 283 (i.e., at 284), preventing saturation |
+| 283 | GH#19448 | ratcheted down — actual violations 281 + 2 buffer |
+| 289 | GH#19472 | proximity guard firing at 282/283 (1 headroom); 282 violations + 7 headroom = 289; proximity guard (warn_at = 289-5 = 284) fires when violations exceed 284 (i.e., at 285), preventing saturation |
 
 ## FUNCTION_COMPLEXITY_THRESHOLD History
 

--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -161,7 +161,9 @@ FUNCTION_COMPLEXITY_THRESHOLD=31
 # Bumped to 288 (GH#19430): proximity guard firing at 281/283 (2 headroom); 281 violations + 7 headroom = 288.
 # Proximity guard (warn_at = 288-5 = 283) fires when violations exceed 283 (i.e., at 284), preventing saturation.
 # Ratcheted down to 283 (GH#19448): actual violations 281 + 2 buffer
-NESTING_DEPTH_THRESHOLD=283
+# Bumped to 289 (GH#19472): proximity guard firing at 282/283 (1 headroom); 282 violations + 7 headroom = 289.
+# Proximity guard (warn_at = 289-5 = 284) fires when violations exceed 284 (i.e., at 285), preventing saturation.
+NESTING_DEPTH_THRESHOLD=289
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Proximity guard fired at 282/283 (1 headroom remaining on main). This PR bumps the nesting depth threshold to restore adequate headroom.

**Verified actual violation count:** 282 (confirmed by running the CI awk logic locally against `lint_shell_files` output — same methodology as `.github/workflows/code-quality.yml`).

**Calculation:** 282 violations + 7 headroom = 289. Proximity guard (warn_at = 289-5 = 284) fires when violations exceed 284.

## Changes

- EDIT: `.agents/configs/complexity-thresholds.conf` — bump `NESTING_DEPTH_THRESHOLD` from 283 to 289, add history comment
- EDIT: `.agents/configs/complexity-thresholds-history.md` — add missing GH#19448 ratchet-down entry + new GH#19472 bump entry

## Verification

```bash
grep NESTING_DEPTH_THRESHOLD .agents/configs/complexity-thresholds.conf
# → NESTING_DEPTH_THRESHOLD=289
```

The CI `Shell nesting depth` job will pass with 282 violations < threshold 289.

Resolves #19472

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code complexity monitoring thresholds to reflect current project structure.

---

**Note:** These are internal infrastructure adjustments with no direct impact on user-facing functionality or application behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->