### PR TITLE
GH#19473: GH#19473: chore: ratchet-down BASH32_COMPAT_THRESHOLD 78→74

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -230,7 +230,8 @@ FILE_SIZE_THRESHOLD=59
 # run. Bumped back to 78 (GH#19425 post-merge fix): 76 violations + 2 buffer.
 # GH#19448 ratcheted to 74 (claimed actual: 72), but CI reported 76 violations
 # against threshold 74 — same drift pattern. Keeping at 78: 76 violations + 2 buffer.
-BASH32_COMPAT_THRESHOLD=78
+# Ratcheted down to 74 (GH#19473): actual violations 72 + 2 buffer
+BASH32_COMPAT_THRESHOLD=74
 
 # Qlty maintainability smell baseline (t2065, GH#18773). Seed value for
 # the `.github/workflows/qlty-regression.yml` gate. The gate itself uses


### PR DESCRIPTION
## Summary

Lowered BASH32_COMPAT_THRESHOLD from 78 to 74. Actual violations: 72, new threshold: 74 (72 + 2 buffer). Verified with complexity-scan-helper.sh ratchet-check showing actual=72 against updated threshold=74.

## Files Changed

.agents/configs/complexity-thresholds.conf

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** complexity-scan-helper.sh ratchet-check . 5 confirms actual violations=72, threshold=74, no further ratchet available.

Resolves #19473


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.63 plugin for [OpenCode](https://opencode.ai) v1.4.7 with claude-sonnet-4-6 spent 1m and 3,919 tokens on this as a headless worker.