### PR TITLE
GH#19474: skip consolidation when in-flight PR resolves parent

### DIFF
--- a/.agents/scripts/pulse-triage.sh
+++ b/.agents/scripts/pulse-triage.sh
@@ -299,6 +299,22 @@ _issue_needs_consolidation() {
 		was_already_labeled=true
 	fi
 
+	# t2161: Defence-in-depth — if an open PR already resolves this parent
+	# (closing keyword + #N), the work is in flight. Skip consolidation
+	# regardless of substantive-comment count. This catches the cascade
+	# vector where version drift on a contributor runner re-introduces a
+	# stale filter (root cause of GH#19448 → #19469 → #19471). Auto-clear
+	# any pre-existing needs-consolidation label so the issue can close
+	# cleanly when the PR merges.
+	if _consolidation_resolving_pr_exists "$issue_number" "$repo_slug"; then
+		if [[ "$was_already_labeled" == "true" ]]; then
+			gh issue edit "$issue_number" --repo "$repo_slug" \
+				--remove-label "needs-consolidation" >/dev/null 2>&1 || true
+			echo "[pulse-wrapper] Consolidation gate cleared for #${issue_number} (${repo_slug}) — in-flight resolving PR exists (t2161)" >>"$LOGFILE"
+		fi
+		return 1
+	fi
+
 	# Count substantive comments (>MIN_CHARS, not from bots or dispatch machinery).
 	# Only human-authored scope-changing comments should count. Operational
 	# comments (dispatch claims, kill notices, crash reports, stale recovery,
@@ -579,6 +595,76 @@ _consolidation_child_exists() {
 		--json number --jq 'length' --limit 5 2>/dev/null) || recent_closed_count=0
 	[[ "$recent_closed_count" =~ ^[0-9]+$ ]] || recent_closed_count=0
 	[[ "$recent_closed_count" -gt 0 ]]
+}
+
+#######################################
+# t2161: Check whether an open PR with a GitHub-native closing keyword
+# referencing this parent issue is currently in-flight. Used as a safety
+# net by `_issue_needs_consolidation` and `_dispatch_issue_consolidation`
+# to prevent the cascade observed in GH#19448 → GH#19469 → GH#19471, where
+# version drift on a contributor runner caused a stale filter to falsely
+# trigger consolidation while a fix PR was already mergeable.
+#
+# Why this is needed AT ALL given t2144's filter fix:
+#   The substantive-comment filter is the right primary defence (it solves
+#   the cause: noise comments). This helper is a defence-in-depth safety
+#   net that holds even when:
+#     (a) a contributor runner is running pre-t2144 code,
+#     (b) a future filter regression slips through,
+#     (c) a new operational comment shape ships and drifts past the regex.
+#   In all three cases, the existence of an in-flight PR resolving the
+#   parent is a strong, runtime-checkable "the work is in progress, do
+#   not file a planning task on top of it" signal.
+#
+# Why "in-flight PR" is a stronger signal than "open PR":
+#   GitHub only auto-closes the issue when the PR MERGES, so an open PR
+#   with a closing keyword has not yet resolved the issue — but the work
+#   is committed, reviewable, and a consolidation child filed now would
+#   become noise the moment the PR merges (the issue closes within
+#   seconds of merge). Asymmetric cost: skipping consolidation when there
+#   is an in-flight fix is cheap and reversible (the next pulse cycle
+#   fires if the PR closes without merging); filing a duplicate child
+#   issue burns a worker session and pollutes the issue thread.
+#
+# Closing-keyword regex sourced from `_extract_linked_issue` in
+# pulse-merge.sh:1173 — matches GitHub's full close keyword list:
+# close/closes/closed, fix/fixes/fixed, resolve/resolves/resolved
+# (case-insensitive). Bare `#NNN` references and `For #NNN` / `Ref #NNN`
+# references do NOT match — those are intentionally non-closing.
+#
+# Args: $1=parent_num $2=repo_slug
+# Returns: 0 if an open PR with a closing keyword referencing the parent
+#          exists, 1 otherwise (including network/parse errors — fail open
+#          so a misbehaving search never blocks legitimate consolidation).
+#######################################
+_consolidation_resolving_pr_exists() {
+	local parent_num="$1"
+	local repo_slug="$2"
+
+	[[ -n "$parent_num" && -n "$repo_slug" ]] || return 1
+
+	# Fast prefilter: GitHub search for open PRs that mention the parent
+	# anywhere in body. Cheap (one search hit, capped at 10 results) and
+	# scopes the regex match below to the small candidate set.
+	local prs_json
+	prs_json=$(gh pr list --repo "$repo_slug" --state open \
+		--search "in:body #${parent_num}" \
+		--json number,body --limit 10 2>/dev/null) || prs_json="[]"
+	[[ -n "$prs_json" ]] || prs_json="[]"
+
+	# Filter for GitHub-native closing keyword + #N (case-insensitive).
+	# Word boundary on the trailing # is enforced via the look-ahead
+	# `[^0-9]` (or end of string) so #${parent_num} does not match
+	# #${parent_num}1 / #${parent_num}99 etc.
+	local match_count
+	match_count=$(printf '%s' "$prs_json" | jq --arg n "$parent_num" '
+		[.[] | select(
+			(.body // "")
+			| test("(?i)\\b(close[ds]?|fix(es|ed)?|resolve[ds]?)[ \\t]+#" + $n + "\\b")
+		)] | length
+	' 2>/dev/null) || match_count=0
+	[[ "$match_count" =~ ^[0-9]+$ ]] || match_count=0
+	[[ "$match_count" -gt 0 ]]
 }
 
 #######################################
@@ -1130,6 +1216,19 @@ _dispatch_issue_consolidation() {
 
 	# Ensure labels exist on this repo up front. Idempotent (--force).
 	_ensure_consolidation_labels "$repo_slug"
+
+	# t2161: Safety net — skip dispatch if an open PR with a closing keyword
+	# already resolves this parent. Mirrors the same guard in
+	# _issue_needs_consolidation; checked here too because the dispatch path
+	# is reachable from _backfill_stale_consolidation_labels (which bypasses
+	# the gate) and from contributor runners on stale code where the gate
+	# may have been satisfied at flag time but a fix PR landed since.
+	# Cheaper than _consolidation_child_exists (one PR search vs two issue
+	# searches + label read) so it runs first.
+	if _consolidation_resolving_pr_exists "$issue_number" "$repo_slug"; then
+		echo "[pulse-wrapper] Consolidation: in-flight resolving PR exists for #${issue_number} in ${repo_slug}; skipping dispatch (t2161)" >>"$LOGFILE"
+		return 0
+	fi
 
 	# Dedup: if an open consolidation-task already references this parent,
 	# just ensure the parent is flagged and return. Do NOT create a duplicate.

--- a/.agents/scripts/pulse-triage.sh
+++ b/.agents/scripts/pulse-triage.sh
@@ -273,6 +273,21 @@ _gh_idempotent_comment() {
 	return 0
 }
 
+# t2161: Idempotently remove the `needs-consolidation` label from an issue
+# and log the reason. Used by `_issue_needs_consolidation`'s two auto-clear
+# branches (in-flight resolving PR + post-filter substantive_count drop).
+# Extracted to keep the parent function under the per-function complexity
+# threshold. Args: $1=issue_number $2=repo_slug $3=reason (free-text).
+_clear_needs_consolidation_label() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local reason="$3"
+	gh issue edit "$issue_number" --repo "$repo_slug" \
+		--remove-label "needs-consolidation" >/dev/null 2>&1 || true
+	echo "[pulse-wrapper] Consolidation gate cleared for #${issue_number} (${repo_slug}) — ${reason}" >>"$LOGFILE"
+	return 0
+}
+
 _issue_needs_consolidation() {
 	local issue_number="$1"
 	local repo_slug="$2"
@@ -307,11 +322,9 @@ _issue_needs_consolidation() {
 	# any pre-existing needs-consolidation label so the issue can close
 	# cleanly when the PR merges.
 	if _consolidation_resolving_pr_exists "$issue_number" "$repo_slug"; then
-		if [[ "$was_already_labeled" == "true" ]]; then
-			gh issue edit "$issue_number" --repo "$repo_slug" \
-				--remove-label "needs-consolidation" >/dev/null 2>&1 || true
-			echo "[pulse-wrapper] Consolidation gate cleared for #${issue_number} (${repo_slug}) — in-flight resolving PR exists (t2161)" >>"$LOGFILE"
-		fi
+		[[ "$was_already_labeled" == "true" ]] &&
+			_clear_needs_consolidation_label "$issue_number" "$repo_slug" \
+				"in-flight resolving PR exists (t2161)"
 		return 1
 	fi
 
@@ -369,11 +382,9 @@ _issue_needs_consolidation() {
 	# Auto-clear: if the issue was previously labeled but no longer triggers
 	# (e.g., filter improvement excluded operational comments that were false
 	# positives), remove the label so it becomes dispatchable immediately.
-	if [[ "$was_already_labeled" == "true" ]]; then
-		gh issue edit "$issue_number" --repo "$repo_slug" \
-			--remove-label "needs-consolidation" >/dev/null 2>&1 || true
-		echo "[pulse-wrapper] Consolidation gate cleared for #${issue_number} (${repo_slug}) — substantive_count=${substantive_count} below threshold=${ISSUE_CONSOLIDATION_COMMENT_THRESHOLD}" >>"$LOGFILE"
-	fi
+	[[ "$was_already_labeled" == "true" ]] &&
+		_clear_needs_consolidation_label "$issue_number" "$repo_slug" \
+			"substantive_count=${substantive_count} below threshold=${ISSUE_CONSOLIDATION_COMMENT_THRESHOLD}"
 	return 1
 }
 

--- a/.agents/scripts/pulse-triage.sh
+++ b/.agents/scripts/pulse-triage.sh
@@ -675,7 +675,10 @@ _consolidation_resolving_pr_exists() {
 		)] | length
 	' 2>/dev/null) || match_count=0
 	[[ "$match_count" =~ ^[0-9]+$ ]] || match_count=0
-	[[ "$match_count" -gt 0 ]]
+	if [[ "$match_count" -gt 0 ]]; then
+		return 0
+	fi
+	return 1
 }
 
 #######################################

--- a/.agents/scripts/tests/test-consolidation-dispatch.sh
+++ b/.agents/scripts/tests/test-consolidation-dispatch.sh
@@ -123,6 +123,28 @@ if [[ "$cmd1" == "issue" && "$cmd2" == "create" ]]; then
 	exit 0
 fi
 
+if [[ "$cmd1" == "pr" && "$cmd2" == "list" ]]; then
+	# t2161: stub `gh pr list` for _consolidation_resolving_pr_exists.
+	# Drives off GH_PR_LIST_RESOLVING_JSON. Honours --jq if the caller
+	# uses it (current production caller does NOT — it asks for raw JSON
+	# and pipes through jq itself — so the no-jq branch is the hot path).
+	pr_jq_filter=""
+	pr_prev_arg=""
+	for pr_arg in "$@"; do
+		if [[ "$pr_prev_arg" == "--jq" ]]; then
+			pr_jq_filter="$pr_arg"
+		fi
+		pr_prev_arg="$pr_arg"
+	done
+	pr_list_json="${GH_PR_LIST_RESOLVING_JSON:-[]}"
+	if [[ -n "$pr_jq_filter" ]]; then
+		printf '%s\n' "$pr_list_json" | jq -r "$pr_jq_filter"
+	else
+		printf '%s\n' "$pr_list_json"
+	fi
+	exit 0
+fi
+
 if [[ "$cmd1" == "issue" && "$cmd2" == "edit" ]]; then
 	exit 0
 fi
@@ -210,6 +232,7 @@ teardown_gh_stub() {
 	GH_LOG=""
 	unset GH_ISSUE_VIEW_TITLE GH_ISSUE_VIEW_BODY GH_ISSUE_VIEW_LABELS
 	unset GH_API_COMMENTS_JSON GH_ISSUE_LIST_CHILD_JSON GH_ISSUE_LIST_CHILD_CLOSED_JSON GH_ISSUE_CREATE_URL
+	unset GH_PR_LIST_RESOLVING_JSON
 	unset CONSOLIDATION_RECENT_CLOSE_GRACE_MIN
 	return 0
 }
@@ -554,6 +577,143 @@ JSON
 	return 0
 }
 
+# ----------------------------------------------------------------------
+# t2161 regression tests — in-flight PR skip safety net
+#
+# Reference evidence: GH#19448 → #19469 → #19471 cascade on 2026-04-17.
+# A contributor runner on pre-t2144 code falsely tripped consolidation
+# on #19448 (THRESHOLD=2 satisfied by two ~530-char WORKER_SUPERSEDED
+# bodies that bypassed the stale `^(\*\*)?Stale assignment recovered`
+# anchor) while PR #19466 was already mergeable. Result: #19469 created;
+# the consolidation worker then created #19471 — 5 seconds AFTER #19466
+# merged. t2144 fixed the filter; t2161 adds defence-in-depth so the
+# cascade is blocked even if version drift re-introduces the regression.
+# ----------------------------------------------------------------------
+
+# Helper: PR list payload with one open PR whose body resolves the parent.
+fixture_open_pr_resolving() {
+	local parent_num="$1"
+	jq -n --arg n "$parent_num" '
+		[
+			{
+				"number": 19466,
+				"body": "## Summary\n\nFix the thing.\n\nResolves #" + $n + "\n\n## Testing\n..."
+			}
+		]
+	'
+}
+
+# Helper: PR list payload with one open PR that REFERENCES the parent
+# but does NOT use a closing keyword (e.g. "For #N", "Ref #N", bare `#N`).
+fixture_open_pr_non_closing() {
+	local parent_num="$1"
+	jq -n --arg n "$parent_num" '
+		[
+			{
+				"number": 19467,
+				"body": "## Summary\n\nDocs-only follow-up that mentions #" + $n + " for context.\n\nFor #" + $n + "\n\n## Testing\n..."
+			}
+		]
+	'
+}
+
+# t2161 A1 regression: helper returns 0 when an open PR has Resolves #N.
+test_resolving_pr_helper_detects_closing_keyword() {
+	setup_gh_stub
+	GH_PR_LIST_RESOLVING_JSON=$(fixture_open_pr_resolving 19448)
+	export GH_PR_LIST_RESOLVING_JSON
+
+	if _consolidation_resolving_pr_exists 19448 "marcusquinn/aidevops"; then
+		print_result "t2161: helper detects open PR with Resolves keyword" 0
+	else
+		print_result "t2161: helper detects open PR with Resolves keyword" 1 \
+			"_consolidation_resolving_pr_exists returned 1 with closing keyword present"
+	fi
+
+	teardown_gh_stub
+	return 0
+}
+
+# t2161 A1 regression: helper returns 1 when only non-closing references exist.
+# `For #N`, `Ref #N`, and bare `#N` mentions must NOT be treated as resolving.
+test_resolving_pr_helper_ignores_non_closing_reference() {
+	setup_gh_stub
+	GH_PR_LIST_RESOLVING_JSON=$(fixture_open_pr_non_closing 19448)
+	export GH_PR_LIST_RESOLVING_JSON
+
+	if _consolidation_resolving_pr_exists 19448 "marcusquinn/aidevops"; then
+		print_result "t2161: helper ignores 'For #N' / bare '#N' references" 1 \
+			"_consolidation_resolving_pr_exists returned 0 for non-closing reference"
+	else
+		print_result "t2161: helper ignores 'For #N' / bare '#N' references" 0
+	fi
+
+	teardown_gh_stub
+	return 0
+}
+
+# t2161 A2 regression: _issue_needs_consolidation must skip dispatch when
+# an in-flight PR resolves the parent — even when the substantive-comment
+# count would otherwise meet the threshold. This is the GH#19448 cascade
+# scenario: pre-t2144 filter was satisfied (two WORKER_SUPERSEDED bodies
+# passed it), PR #19466 was open with `Resolves #19448` — t2161 must
+# block consolidation.
+test_needs_consolidation_skips_with_inflight_resolving_pr() {
+	setup_gh_stub
+	# Threshold-meeting fixture (would trip pre-t2144 filter), but t2161's
+	# in-flight PR check should fire first and override.
+	export ISSUE_CONSOLIDATION_COMMENT_MIN_CHARS=200
+	GH_ISSUE_VIEW_LABELS="bug,tier:standard"
+	GH_API_COMMENTS_JSON=$(fixture_two_worker_superseded_comments)
+	GH_ISSUE_LIST_CHILD_JSON="[]"
+	GH_ISSUE_LIST_CHILD_CLOSED_JSON="[]"
+	GH_PR_LIST_RESOLVING_JSON=$(fixture_open_pr_resolving 19448)
+	export GH_ISSUE_VIEW_LABELS GH_API_COMMENTS_JSON
+	export GH_ISSUE_LIST_CHILD_JSON GH_ISSUE_LIST_CHILD_CLOSED_JSON
+	export GH_PR_LIST_RESOLVING_JSON
+
+	if _issue_needs_consolidation 19448 "marcusquinn/aidevops"; then
+		print_result "t2161: needs_consolidation skips when in-flight PR resolves parent" 1 \
+			"_issue_needs_consolidation returned 0 despite open PR with Resolves keyword"
+	else
+		print_result "t2161: needs_consolidation skips when in-flight PR resolves parent" 0
+	fi
+
+	teardown_gh_stub
+	return 0
+}
+
+# t2161 A2 regression: _dispatch_issue_consolidation must short-circuit
+# when an in-flight PR resolves the parent — even when no consolidation
+# child exists yet. Covers the path where _backfill_stale_consolidation_labels
+# bypasses the gate and reaches dispatch directly.
+test_dispatch_skips_with_inflight_resolving_pr() {
+	setup_gh_stub
+	GH_ISSUE_VIEW_TITLE="test: parent with mergeable fix in flight"
+	GH_ISSUE_VIEW_BODY="Original parent body."
+	GH_ISSUE_VIEW_LABELS="bug,tier:standard,needs-consolidation"
+	GH_API_COMMENTS_JSON=$(fixture_two_substantive_comments)
+	GH_ISSUE_LIST_CHILD_JSON="[]"
+	GH_ISSUE_LIST_CHILD_CLOSED_JSON="[]"
+	GH_PR_LIST_RESOLVING_JSON=$(fixture_open_pr_resolving 19448)
+	GH_ISSUE_CREATE_URL="https://github.com/owner/repo/issues/SHOULD_NOT_BE_CALLED"
+	export GH_ISSUE_VIEW_TITLE GH_ISSUE_VIEW_BODY GH_ISSUE_VIEW_LABELS
+	export GH_API_COMMENTS_JSON GH_ISSUE_LIST_CHILD_JSON GH_ISSUE_LIST_CHILD_CLOSED_JSON
+	export GH_PR_LIST_RESOLVING_JSON GH_ISSUE_CREATE_URL
+
+	_dispatch_issue_consolidation 19448 "marcusquinn/aidevops" "/tmp/fake-path" || true
+
+	if grep -q 'issue create' "$GH_LOG" 2>/dev/null; then
+		print_result "t2161: dispatch skips child creation when in-flight PR resolves parent" 1 \
+			"gh issue create was invoked despite open PR with Resolves keyword"
+	else
+		print_result "t2161: dispatch skips child creation when in-flight PR resolves parent" 0
+	fi
+
+	teardown_gh_stub
+	return 0
+}
+
 main() {
 	test_dispatch_creates_child_issue
 	test_child_body_contains_parent_content_and_authors
@@ -567,6 +727,12 @@ main() {
 	test_recently_closed_child_blocks_redispatch_within_grace
 	test_grace_zero_restores_open_only_semantics
 	test_backfill_clears_stale_label_on_consolidated_parent
+
+	# t2161 regression suite
+	test_resolving_pr_helper_detects_closing_keyword
+	test_resolving_pr_helper_ignores_non_closing_reference
+	test_needs_consolidation_skips_with_inflight_resolving_pr
+	test_dispatch_skips_with_inflight_resolving_pr
 
 	echo
 	echo "============================================"

--- a/.agents/scripts/tests/test-consolidation-dispatch.sh
+++ b/.agents/scripts/tests/test-consolidation-dispatch.sh
@@ -74,11 +74,13 @@ _stub_parse_args() {
 		prev="$arg"
 	done
 	printf 'JQ=%s\nSTATE=%s\n' "$jq" "$state"
+	return 0
 }
 
 # _stub_emit: print $1 raw or piped through `jq -r $2` if filter non-empty.
 _stub_emit() {
 	if [[ -n "$2" ]]; then printf '%s\n' "$1" | jq -r "$2"; else printf '%s\n' "$1"; fi
+	return 0
 }
 
 case "${1:-}-${2:-}" in

--- a/.agents/scripts/tests/test-consolidation-dispatch.sh
+++ b/.agents/scripts/tests/test-consolidation-dispatch.sh
@@ -63,21 +63,32 @@ _write_gh_stub_binary() {
 # bash 3.2 compatible — no ;;& fall-through.
 printf '%s\n' "$*" >>"${GH_LOG:-/dev/null}"
 
-cmd1="${1:-}"
-cmd2="${2:-}"
+# _stub_parse_args: scan argv for `--jq <filter>` and `--state <state>`,
+# emit them on stdout as `JQ=<f>;STATE=<s>` so the caller can eval. Empty
+# values when absent. Used by the issue-list and pr-list branches.
+_stub_parse_args() {
+	local prev="" jq="" state="open" arg
+	for arg in "$@"; do
+		[[ "$prev" == "--jq" ]] && jq="$arg"
+		[[ "$prev" == "--state" ]] && state="$arg"
+		prev="$arg"
+	done
+	printf 'JQ=%s\nSTATE=%s\n' "$jq" "$state"
+}
 
-if [[ "$cmd1" == "issue" && "$cmd2" == "view" ]]; then
+# _stub_emit: print $1 raw or piped through `jq -r $2` if filter non-empty.
+_stub_emit() {
+	if [[ -n "$2" ]]; then printf '%s\n' "$1" | jq -r "$2"; else printf '%s\n' "$1"; fi
+}
+
+case "${1:-}-${2:-}" in
+issue-view)
 	shift 2
 	local_json=""
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
-		--json)
-			local_json="$2"
-			shift 2
-			;;
-		--jq)
-			shift 2
-			;;
+		--json) local_json="$2"; shift 2 ;;
+		--jq) shift 2 ;;
 		*) shift ;;
 		esac
 	done
@@ -87,83 +98,26 @@ if [[ "$cmd1" == "issue" && "$cmd2" == "view" ]]; then
 	labels) printf '%s\n' "${GH_ISSUE_VIEW_LABELS:-bug,tier:standard}" ;;
 	*) printf '\n' ;;
 	esac
-	exit 0
-fi
-
-if [[ "$cmd1" == "issue" && "$cmd2" == "list" ]]; then
-	# Parse --jq and --state so the stub emulates real gh behaviour.
-	# t2144: added --state dispatch so tests can fixture open and closed
-	# child lists independently (grace-window regression tests).
-	jq_filter=""
-	state_arg="open"
-	prev_arg=""
-	for arg in "$@"; do
-		if [[ "$prev_arg" == "--jq" ]]; then
-			jq_filter="$arg"
-		fi
-		if [[ "$prev_arg" == "--state" ]]; then
-			state_arg="$arg"
-		fi
-		prev_arg="$arg"
-	done
+	;;
+issue-list)
+	# t2144: --state dispatch so tests can fixture open and closed child
+	# lists independently (grace-window regression tests).
+	eval "$(_stub_parse_args "$@")"
 	list_json="${GH_ISSUE_LIST_CHILD_JSON:-[]}"
-	if [[ "$state_arg" == "closed" ]]; then
-		list_json="${GH_ISSUE_LIST_CHILD_CLOSED_JSON:-[]}"
-	fi
-	if [[ -n "$jq_filter" ]]; then
-		printf '%s\n' "$list_json" | jq -r "$jq_filter"
-	else
-		printf '%s\n' "$list_json"
-	fi
-	exit 0
-fi
-
-if [[ "$cmd1" == "issue" && "$cmd2" == "create" ]]; then
-	printf '%s\n' "${GH_ISSUE_CREATE_URL:-https://github.com/owner/repo/issues/999}"
-	exit 0
-fi
-
-if [[ "$cmd1" == "pr" && "$cmd2" == "list" ]]; then
-	# t2161: stub `gh pr list` for _consolidation_resolving_pr_exists.
-	# Drives off GH_PR_LIST_RESOLVING_JSON. Honours --jq if the caller
-	# uses it (current production caller does NOT — it asks for raw JSON
-	# and pipes through jq itself — so the no-jq branch is the hot path).
-	pr_jq_filter=""
-	pr_prev_arg=""
-	for pr_arg in "$@"; do
-		if [[ "$pr_prev_arg" == "--jq" ]]; then
-			pr_jq_filter="$pr_arg"
-		fi
-		pr_prev_arg="$pr_arg"
-	done
-	pr_list_json="${GH_PR_LIST_RESOLVING_JSON:-[]}"
-	if [[ -n "$pr_jq_filter" ]]; then
-		printf '%s\n' "$pr_list_json" | jq -r "$pr_jq_filter"
-	else
-		printf '%s\n' "$pr_list_json"
-	fi
-	exit 0
-fi
-
-if [[ "$cmd1" == "issue" && "$cmd2" == "edit" ]]; then
-	exit 0
-fi
-
-if [[ "$cmd1" == "issue" && "$cmd2" == "comment" ]]; then
-	exit 0
-fi
-
-if [[ "$cmd1" == "api" ]]; then
-	# gh api repos/owner/repo/issues/N/comments ...
-	printf '%s\n' "${GH_API_COMMENTS_JSON:-[]}"
-	exit 0
-fi
-
-if [[ "$cmd1" == "label" && "$cmd2" == "create" ]]; then
-	exit 0
-fi
-
-printf 'gh stub: unhandled: %s\n' "$*" >&2
+	[[ "$STATE" == "closed" ]] && list_json="${GH_ISSUE_LIST_CHILD_CLOSED_JSON:-[]}"
+	_stub_emit "$list_json" "$JQ"
+	;;
+pr-list)
+	# t2161: drives off GH_PR_LIST_RESOLVING_JSON. Honours --jq if used
+	# (current production caller does NOT — it pipes raw JSON through jq).
+	eval "$(_stub_parse_args "$@")"
+	_stub_emit "${GH_PR_LIST_RESOLVING_JSON:-[]}" "$JQ"
+	;;
+issue-create) printf '%s\n' "${GH_ISSUE_CREATE_URL:-https://github.com/owner/repo/issues/999}" ;;
+api-*) printf '%s\n' "${GH_API_COMMENTS_JSON:-[]}" ;;
+issue-edit | issue-comment | label-create) ;;
+*) printf 'gh stub: unhandled: %s\n' "$*" >&2 ;;
+esac
 exit 0
 STUB
 	chmod +x "${TEST_ROOT}/bin/gh"

--- a/.agents/scripts/tests/test-consolidation-dispatch.sh
+++ b/.agents/scripts/tests/test-consolidation-dispatch.sh
@@ -597,7 +597,7 @@ fixture_open_pr_resolving() {
 		[
 			{
 				"number": 19466,
-				"body": "## Summary\n\nFix the thing.\n\nResolves #" + $n + "\n\n## Testing\n..."
+				"body": ("## Summary\n\nFix the thing.\n\nResolves #" + $n + "\n\n## Testing\n...")
 			}
 		]
 	'
@@ -611,7 +611,7 @@ fixture_open_pr_non_closing() {
 		[
 			{
 				"number": 19467,
-				"body": "## Summary\n\nDocs-only follow-up that mentions #" + $n + " for context.\n\nFor #" + $n + "\n\n## Testing\n..."
+				"body": ("## Summary\n\nDocs-only follow-up that mentions #" + $n + " for context.\n\nFor #" + $n + "\n\n## Testing\n...")
 			}
 		]
 	'


### PR DESCRIPTION
## Summary

Adds an in-flight PR check to the consolidation gate. When an open PR carries a GitHub-native closing keyword (Resolves/Closes/Fixes #N) for an issue, the consolidation pipeline skips both the needs-consolidation flagging in `_issue_needs_consolidation` and the child-issue dispatch in `_dispatch_issue_consolidation`. Auto-clears any stale `needs-consolidation` label so the issue closes cleanly when the PR merges. New helper `_consolidation_resolving_pr_exists` in pulse-triage.sh; uses GitHub search prefilter (`gh pr list --state open --search 'in:body #N'`) then jq-filters bodies for the closing-keyword regex.

## Files Changed

.agents/scripts/pulse-triage.sh,.agents/scripts/tests/test-consolidation-dispatch.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Added 4 regression tests in test-consolidation-dispatch.sh covering: helper detects `Resolves #N`, helper ignores `For #N`/bare `#N`, `_issue_needs_consolidation` skips when in-flight PR resolves parent (even when substantive count would otherwise trip), `_dispatch_issue_consolidation` skips child creation when in-flight PR exists. All 16 tests pass (12 pre-existing + 4 new). test-consolidation-multi-runner.sh: 9/9 still pass. shellcheck: clean on both modified files.

Resolves #19474


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.63 plugin for [OpenCode](https://opencode.ai) v1.4.7 with claude-opus-4-7 spent 25m and 60,645 tokens on this with the user in an interactive session.