### PR TITLE
GH#19490: bump NESTING_DEPTH_THRESHOLD 284 to 289

### DIFF
--- a/.agents/configs/complexity-thresholds-history.md
+++ b/.agents/configs/complexity-thresholds-history.md
@@ -78,6 +78,8 @@ Archives the full change history for `.agents/configs/complexity-thresholds.conf
 | 288 | GH#19430 | proximity guard firing at 281/283 (2 headroom); 281 violations + 7 headroom = 288; proximity guard (warn_at = 288-5 = 283) fires when violations exceed 283 (i.e., at 284), preventing saturation |
 | 283 | GH#19448 | ratcheted down — actual violations 281 + 2 buffer |
 | 289 | GH#19472 | proximity guard firing at 282/283 (1 headroom); 282 violations + 7 headroom = 289; proximity guard (warn_at = 289-5 = 284) fires when violations exceed 284 (i.e., at 285), preventing saturation |
+| 284 | GH#19480 | ratcheted down — actual violations 282 + 2 buffer |
+| 289 | GH#19490 | proximity guard firing at 282/284 (2 headroom); 282 violations + 7 headroom = 289; proximity guard (warn_at = 289-5 = 284) fires when violations exceed 284 (i.e., at 285), preventing saturation |
 
 ## FUNCTION_COMPLEXITY_THRESHOLD History
 

--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -164,7 +164,9 @@ FUNCTION_COMPLEXITY_THRESHOLD=31
 # Bumped to 289 (GH#19472): proximity guard firing at 282/283 (1 headroom); 282 violations + 7 headroom = 289.
 # Proximity guard (warn_at = 289-5 = 284) fires when violations exceed 284 (i.e., at 285), preventing saturation.
 # Ratcheted down to 284 (GH#19480): actual violations 282 + 2 buffer
-NESTING_DEPTH_THRESHOLD=284
+# Bumped to 289 (GH#19490): proximity guard firing at 282/284 (2 headroom); 282 violations + 7 headroom = 289.
+# Proximity guard (warn_at = 289-5 = 284) fires when violations exceed 284 (i.e., at 285), preventing saturation.
+NESTING_DEPTH_THRESHOLD=289
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Proximity guard fired at 282/284 (2 headroom remaining). Bump threshold from 284 to 289.

**Verified actual violation count**: 282 (using CI method via lint_shell_files + awk depth checker).

- 282 violations + 7 headroom = 289
- New proximity guard (warn_at = 289-5 = 284) fires when violations exceed 284 (i.e., at 285), preventing saturation
- Also adds the missing GH#19480 ratchet-down entry to complexity-thresholds-history.md

## Files changed

- EDIT: `.agents/configs/complexity-thresholds.conf` — bump NESTING_DEPTH_THRESHOLD 284 to 289 with documented rationale
- EDIT: `.agents/configs/complexity-thresholds-history.md` — add GH#19480 ratchet entry + GH#19490 bump entry

## Verification

Actual violations confirmed at 282 using the same method CI uses:

```bash
source .agents/scripts/lint-file-discovery.sh && lint_shell_files
violations=0
while IFS= read -r file; do
  [ -n "$file" ] || continue
  max_depth=$(awk 'BEGIN { depth=0; max_depth=0 }
    /^[[:space:]]*#/ { next }
    /[[:space:]]*(if|for|while|until|case)[[:space:]]/ { depth++; if(depth>max_depth) max_depth=depth }
    /[[:space:]]*(fi|done|esac)[[:space:]]*$/ || /^[[:space:]]*(fi|done|esac)$/ { if(depth>0) depth-- }
    END { print max_depth }
  ' "$file")
  if [ "$max_depth" -gt 8 ]; then violations=$((violations + 1)); fi
done <<< "$LINT_SH_FILES"
echo "TOTAL: $violations"  # outputs: 282
```

CI will pass: 282 violations < threshold 289 (7 headroom).

Resolves #19490