### PR TITLE
GH#19504: GH#19504: tighten video-seo.md agent doc (109→97 lines)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -5835,7 +5835,7 @@
       "pr": 17019
     },
     ".agents/tools/design/library/styles/corporate-traditional/02-colours.md": {
-      "action": "consolidated 6 group tables + CSS block into single unified table with CSS variable column (94→28 lines)",
+      "action": "consolidated 6 group tables + CSS block into single unified table with CSS variable column (94\u219228 lines)",
       "at": "2026-04-04T14:53:40Z",
       "hash": "476c989fca56149f90f1eefc2b02cafdc5a6e0d5",
       "issue": "GH#17250",
@@ -7592,5 +7592,12 @@
     "hash": "c95a514b4e3a08d298efad5476f8ed723a42590bc0f32b251de4a626e7c61ac6",
     "note": "Extracted _atomic_stage_and_deploy_agents() from deploy_aidevops_agents() (GH#19203)",
     "status": "simplified"
+  },
+  ".agents/seo/video-seo.md": {
+    "action": "tightened",
+    "hash": "b6d25537d82c9c0b0285525efb19d3c587c3ea328cee085181a15c2aa43fc050",
+    "issue": "GH#19504",
+    "lines_after": 97,
+    "lines_before": 109
   }
 }

--- a/.agents/seo/video-seo.md
+++ b/.agents/seo/video-seo.md
@@ -15,7 +15,7 @@ tools:
 
 # Video SEO
 
-Video is a content atom that must rank across three surfaces simultaneously. Each surface has distinct ranking signals; a video optimised for only one surface leaves 66% of potential reach untapped.
+Video must rank across three surfaces simultaneously; optimising for only one leaves the other two untapped.
 
 ## Three-Surface Model
 
@@ -29,14 +29,9 @@ Video is a content atom that must rank across three surfaces simultaneously. Eac
 
 **Title**: Primary keyword in first 60 chars. "How to [do X] in [year]" outperforms generic labels.
 
-**Description** (first 150 chars shown in SERP):
+**Description** (first 150 chars shown in SERP): Primary keyword — value proposition. Include chapter timestamps inline: `0:00 Intro | 1:30 Topic 1 | 4:00 Topic 2`.
 
-```text
-[Primary keyword] — [value proposition in one sentence].
-Chapters: 0:00 Intro | 1:30 [Topic 1] | 4:00 [Topic 2]
-```
-
-**Chapters**: Add timestamps aligned to sub-queries (one chapter per audience question). Each chapter title is a standalone ranking signal for Key Moments.
+**Chapters**: Align timestamps to sub-queries (one chapter per audience question). Each chapter title is a standalone ranking signal for Key Moments.
 
 **Tags**: 5–10 only. Primary keyword first, then variants, then broad category. Stuffing reduces relevance weighting.
 
@@ -46,28 +41,21 @@ Chapters: 0:00 Intro | 1:30 [Topic 1] | 4:00 [Topic 2]
 
 Eligible when: video hosted on YouTube or with `VideoObject` + `Clip` schema. Google extracts chapters from description timestamps automatically; explicit `Clip` schema takes precedence.
 
+Key Moments schema — add `hasPart` to your `VideoObject`:
+
 ```json
-{
-  "@context": "https://schema.org",
-  "@type": "VideoObject",
-  "name": "How to Make Cold Brew Coffee",
-  "description": "Step-by-step guide with ratio science",
-  "thumbnailUrl": "https://example.com/cold-brew-thumb.jpg",
-  "uploadDate": "2026-01-15",
-  "duration": "PT8M30S",
-  "hasPart": [
-    {
-      "@type": "Clip",
-      "name": "Cold Brew Ratio",
-      "startOffset": 90,
-      "endOffset": 240,
-      "url": "https://youtu.be/VIDEO_ID?t=90"
-    }
-  ]
-}
+"hasPart": [
+  {
+    "@type": "Clip",
+    "name": "Cold Brew Ratio",
+    "startOffset": 90,
+    "endOffset": 240,
+    "url": "https://youtu.be/VIDEO_ID?t=90"
+  }
+]
 ```
 
-See `seo/video-schema.md` for complete schema reference.
+See `seo/video-schema.md` for complete VideoObject + Clip schema reference.
 
 ## LLM Answer Engine Optimisation
 


### PR DESCRIPTION
## Summary

Tightened .agents/seo/video-seo.md from 109 to 97 lines: compressed verbose opening paragraph, reduced Google Key Moments JSON to Clip-only structure (full VideoObject already in video-schema.md), and inlined the YouTube description template. All institutional knowledge preserved.

## Files Changed

.agents/configs/simplification-state.json,.agents/seo/video-seo.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** wc -l .agents/seo/video-seo.md shows 97 lines; all code blocks, URLs, task refs, and integration pointers verified present; simplification-state.json updated with GH#19504 entry.

Resolves #19504


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.65 plugin for [OpenCode](https://opencode.ai) v1.4.7 with claude-sonnet-4-6 spent 2m and 6,279 tokens on this as a headless worker.