### PR TITLE
GH#19503: restructure video-schema.md into slim index + chapter files

### DIFF
--- a/.agents/seo/video-schema.md
+++ b/.agents/seo/video-schema.md
@@ -16,153 +16,17 @@ tools:
 
 Structured data for video content. Powers Google Key Moments, video carousels, rich snippets, and LLM citation. Reusable across: video pages, blog posts with embedded video, podcast episodes, programmatic content templates.
 
-## VideoObject (Required for All Video Pages)
+## Chapters
 
-```json
-{
-  "@context": "https://schema.org",
-  "@type": "VideoObject",
-  "name": "How to Make Cold Brew Coffee",
-  "description": "Step-by-step cold brew guide with ratio science and steeping times.",
-  "thumbnailUrl": "https://example.com/cold-brew-thumb.jpg",
-  "uploadDate": "2026-01-15T08:00:00+00:00",
-  "duration": "PT8M30S",
-  "contentUrl": "https://example.com/videos/cold-brew.mp4",
-  "embedUrl": "https://www.youtube.com/embed/VIDEO_ID",
-  "interactionStatistic": {
-    "@type": "InteractionCounter",
-    "interactionType": "https://schema.org/WatchAction",
-    "userInteractionCount": 12400
-  }
-}
-```
-
-**Required fields**: `name`, `description`, `thumbnailUrl`, `uploadDate`.
-**For Key Moments eligibility**: add `hasPart` with `Clip` segments.
-
-## Clip (Google Key Moments)
-
-Add `hasPart` array to `VideoObject`. Each `Clip` maps to one chapter.
-
-```json
-"hasPart": [
-  {
-    "@type": "Clip",
-    "name": "Cold Brew Ratio",
-    "startOffset": 90,
-    "endOffset": 240,
-    "url": "https://youtu.be/VIDEO_ID?t=90"
-  },
-  {
-    "@type": "Clip",
-    "name": "Steeping Time",
-    "startOffset": 240,
-    "endOffset": 390,
-    "url": "https://youtu.be/VIDEO_ID?t=240"
-  }
-]
-```
-
-`startOffset` and `endOffset` are in seconds. `name` must match a search query for Key Moments eligibility — use the same phrasing as YouTube chapter titles.
-
-## Speakable
-
-Marks page sections for TTS extraction and LLM retrieval prioritisation. Apply to the 1–3 paragraphs that directly answer the primary query.
-
-```json
-{
-  "@context": "https://schema.org",
-  "@type": "WebPage",
-  "speakable": {
-    "@type": "SpeakableSpecification",
-    "cssSelector": ["#transcript p:first-of-type", "h2 + p"]
-  },
-  "url": "https://example.com/cold-brew-guide"
-}
-```
-
-## FAQPage with VideoObject
-
-Combine FAQ structured data with video for pages that answer multiple questions.
-
-```json
-[
-  {
-    "@context": "https://schema.org",
-    "@type": "VideoObject",
-    "name": "Cold Brew FAQ",
-    "description": "Answers to the 5 most common cold brew questions.",
-    "thumbnailUrl": "https://example.com/thumb.jpg",
-    "uploadDate": "2026-01-15"
-  },
-  {
-    "@context": "https://schema.org",
-    "@type": "FAQPage",
-    "mainEntity": [
-      {
-        "@type": "Question",
-        "name": "What is the cold brew coffee ratio?",
-        "acceptedAnswer": {
-          "@type": "Answer",
-          "text": "The standard ratio is 1:8 coffee to water by weight for a concentrate."
-        }
-      }
-    ]
-  }
-]
-```
-
-## HowTo with Video Steps
-
-```json
-{
-  "@context": "https://schema.org",
-  "@type": "HowTo",
-  "name": "How to Make Cold Brew Coffee",
-  "video": {
-    "@type": "VideoObject",
-    "name": "Cold Brew Tutorial",
-    "thumbnailUrl": "https://example.com/thumb.jpg",
-    "uploadDate": "2026-01-15",
-    "embedUrl": "https://www.youtube.com/embed/VIDEO_ID"
-  },
-  "step": [
-    {
-      "@type": "HowToStep",
-      "name": "Measure coffee",
-      "text": "Weigh 100g of coarsely ground coffee.",
-      "url": "https://youtu.be/VIDEO_ID?t=90"
-    }
-  ]
-}
-```
-
-## Property Reference
-
-| Property | Type | Notes |
-|----------|------|-------|
-| `name` | Text | Required; match page H1 |
-| `description` | Text | Required; 150–300 chars |
-| `thumbnailUrl` | URL | Required; min 1280×720 |
-| `uploadDate` | ISO 8601 | Required |
-| `duration` | ISO 8601 duration | `PT8M30S` = 8 min 30 sec |
-| `contentUrl` | URL | Direct video file URL |
-| `embedUrl` | URL | YouTube/Vimeo embed URL |
-| `hasPart` | Clip[] | Key Moments segments |
-
-## Validation
-
-```bash
-# Google Rich Results Test (CLI)
-curl -s "https://searchconsole.googleapis.com/v1/urlInspection/index:inspect" \
-  -H "Authorization: Bearer $GSC_TOKEN" \
-  -d '{"inspectionUrl":"https://example.com/cold-brew-guide","siteUrl":"https://example.com/"}'
-
-# Schema.org local validator
-npx schema-dts-gen --validate schema.json
-```
-
-Or use `seo/schema-validator.md` for local and bulk validation.
+| Chapter | Description |
+|---------|-------------|
+| [VideoObject](video-schema/videoobject.md) | Required schema for all video pages; required fields and Key Moments eligibility |
+| [Clip / Key Moments](video-schema/clip-key-moments.md) | `hasPart` Clip segments for Google Key Moments; chapter timestamps |
+| [Speakable](video-schema/speakable.md) | CSS selector markup for TTS extraction and LLM retrieval prioritisation |
+| [FAQPage + VideoObject](video-schema/faqpage-video.md) | Combined FAQ and video structured data for multi-question pages |
+| [HowTo + VideoObject](video-schema/howto-video.md) | HowTo schema with embedded video steps |
+| [Property Reference](video-schema/property-reference.md) | All VideoObject properties — types, requirements, and notes |
+| [Validation](video-schema/validation.md) | CLI commands and tools for validating video schema markup |
 
 ## Integration Points
 

--- a/.agents/seo/video-schema/clip-key-moments.md
+++ b/.agents/seo/video-schema/clip-key-moments.md
@@ -1,0 +1,27 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Clip (Google Key Moments)
+
+Add `hasPart` array to `VideoObject`. Each `Clip` maps to one chapter.
+
+```json
+"hasPart": [
+  {
+    "@type": "Clip",
+    "name": "Cold Brew Ratio",
+    "startOffset": 90,
+    "endOffset": 240,
+    "url": "https://youtu.be/VIDEO_ID?t=90"
+  },
+  {
+    "@type": "Clip",
+    "name": "Steeping Time",
+    "startOffset": 240,
+    "endOffset": 390,
+    "url": "https://youtu.be/VIDEO_ID?t=240"
+  }
+]
+```
+
+`startOffset` and `endOffset` are in seconds. `name` must match a search query for Key Moments eligibility — use the same phrasing as YouTube chapter titles.

--- a/.agents/seo/video-schema/faqpage-video.md
+++ b/.agents/seo/video-schema/faqpage-video.md
@@ -1,0 +1,33 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# FAQPage with VideoObject
+
+Combine FAQ structured data with video for pages that answer multiple questions.
+
+```json
+[
+  {
+    "@context": "https://schema.org",
+    "@type": "VideoObject",
+    "name": "Cold Brew FAQ",
+    "description": "Answers to the 5 most common cold brew questions.",
+    "thumbnailUrl": "https://example.com/thumb.jpg",
+    "uploadDate": "2026-01-15"
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "FAQPage",
+    "mainEntity": [
+      {
+        "@type": "Question",
+        "name": "What is the cold brew coffee ratio?",
+        "acceptedAnswer": {
+          "@type": "Answer",
+          "text": "The standard ratio is 1:8 coffee to water by weight for a concentrate."
+        }
+      }
+    ]
+  }
+]
+```

--- a/.agents/seo/video-schema/howto-video.md
+++ b/.agents/seo/video-schema/howto-video.md
@@ -1,0 +1,27 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# HowTo with Video Steps
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "How to Make Cold Brew Coffee",
+  "video": {
+    "@type": "VideoObject",
+    "name": "Cold Brew Tutorial",
+    "thumbnailUrl": "https://example.com/thumb.jpg",
+    "uploadDate": "2026-01-15",
+    "embedUrl": "https://www.youtube.com/embed/VIDEO_ID"
+  },
+  "step": [
+    {
+      "@type": "HowToStep",
+      "name": "Measure coffee",
+      "text": "Weigh 100g of coarsely ground coffee.",
+      "url": "https://youtu.be/VIDEO_ID?t=90"
+    }
+  ]
+}
+```

--- a/.agents/seo/video-schema/property-reference.md
+++ b/.agents/seo/video-schema/property-reference.md
@@ -1,0 +1,15 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Property Reference
+
+| Property | Type | Notes |
+|----------|------|-------|
+| `name` | Text | Required; match page H1 |
+| `description` | Text | Required; 150–300 chars |
+| `thumbnailUrl` | URL | Required; min 1280×720 |
+| `uploadDate` | ISO 8601 | Required |
+| `duration` | ISO 8601 duration | `PT8M30S` = 8 min 30 sec |
+| `contentUrl` | URL | Direct video file URL |
+| `embedUrl` | URL | YouTube/Vimeo embed URL |
+| `hasPart` | Clip[] | Key Moments segments |

--- a/.agents/seo/video-schema/speakable.md
+++ b/.agents/seo/video-schema/speakable.md
@@ -1,0 +1,18 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Speakable
+
+Marks page sections for TTS extraction and LLM retrieval prioritisation. Apply to the 1–3 paragraphs that directly answer the primary query.
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "WebPage",
+  "speakable": {
+    "@type": "SpeakableSpecification",
+    "cssSelector": ["#transcript p:first-of-type", "h2 + p"]
+  },
+  "url": "https://example.com/cold-brew-guide"
+}
+```

--- a/.agents/seo/video-schema/validation.md
+++ b/.agents/seo/video-schema/validation.md
@@ -1,0 +1,16 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Validation
+
+```bash
+# Google Rich Results Test (CLI)
+curl -s "https://searchconsole.googleapis.com/v1/urlInspection/index:inspect" \
+  -H "Authorization: Bearer $GSC_TOKEN" \
+  -d '{"inspectionUrl":"https://example.com/cold-brew-guide","siteUrl":"https://example.com/"}'
+
+# Schema.org local validator
+npx schema-dts-gen --validate schema.json
+```
+
+Or use `seo/schema-validator.md` for local and bulk validation.

--- a/.agents/seo/video-schema/videoobject.md
+++ b/.agents/seo/video-schema/videoobject.md
@@ -1,0 +1,26 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# VideoObject (Required for All Video Pages)
+
+```json
+{
+  "@context": "https://schema.org",
+  "@type": "VideoObject",
+  "name": "How to Make Cold Brew Coffee",
+  "description": "Step-by-step cold brew guide with ratio science and steeping times.",
+  "thumbnailUrl": "https://example.com/cold-brew-thumb.jpg",
+  "uploadDate": "2026-01-15T08:00:00+00:00",
+  "duration": "PT8M30S",
+  "contentUrl": "https://example.com/videos/cold-brew.mp4",
+  "embedUrl": "https://www.youtube.com/embed/VIDEO_ID",
+  "interactionStatistic": {
+    "@type": "InteractionCounter",
+    "interactionType": "https://schema.org/WatchAction",
+    "userInteractionCount": 12400
+  }
+}
+```
+
+**Required fields**: `name`, `description`, `thumbnailUrl`, `uploadDate`.
+**For Key Moments eligibility**: add `hasPart` with `Clip` segments.


### PR DESCRIPTION
## Summary

Restructured `.agents/seo/video-schema.md` from a 176-line monolith into a slim 40-line index with 7 chapter files under `video-schema/`.

**Classification:** Reference corpus — JSON schema examples with self-contained sections. Per the issue guidance, this warrants restructuring into chapters (not content compression).

## Changes

- **EDIT:** `.agents/seo/video-schema.md` — replaced full content with slim index (chapters table + integration points)
- **NEW:** `.agents/seo/video-schema/videoobject.md` — VideoObject required schema
- **NEW:** `.agents/seo/video-schema/clip-key-moments.md` — Clip/hasPart for Google Key Moments
- **NEW:** `.agents/seo/video-schema/speakable.md` — Speakable CSS selector markup
- **NEW:** `.agents/seo/video-schema/faqpage-video.md` — FAQPage combined with VideoObject
- **NEW:** `.agents/seo/video-schema/howto-video.md` — HowTo with embedded video steps
- **NEW:** `.agents/seo/video-schema/property-reference.md` — full property reference table
- **NEW:** `.agents/seo/video-schema/validation.md` — CLI validation commands

## Verification

- Content preservation: all code blocks, URLs, command examples moved verbatim to chapter files
- Line count: chapter total (162 lines) >= original (176) - index overhead (40) = 136
- No broken internal links — integration points table retained in slim index
- Qlty smells: SKIP (unavailable in environment)

Resolves #19503