### PR TITLE
GH#19505: tighten agent doc Transcript SEO (.agents/seo/transcript-seo.md, 107→105 lines)

### DIFF
--- a/.agents/seo/transcript-seo.md
+++ b/.agents/seo/transcript-seo.md
@@ -14,7 +14,7 @@ tools:
 
 # Transcript SEO
 
-Transcripts are the primary LLM retrieval signal for spoken-word content. An LLM cannot watch a video or listen to audio — it reads the transcript. A poorly corrected auto-caption is the single highest-leverage fix in video/audio SEO.
+Transcripts are the primary LLM retrieval signal for spoken-word content. A poorly corrected auto-caption is the single highest-leverage fix in video/audio SEO.
 
 ## Why Transcripts Matter
 
@@ -72,11 +72,11 @@ Marks transcript sections as high-priority for TTS and LLM extraction.
 }
 ```
 
-Use `cssSelector` (not `xpath`) — Google's TTS pipeline primarily uses CSS selectors. Mark paragraphs that contain direct, full-sentence answers to the primary search query.
+Use `cssSelector` (not `xpath`) — Google's TTS pipeline primarily uses CSS selectors. Target paragraphs containing direct, full-sentence answers to the primary search query.
 
 ## LLM Retrieval Optimisation
 
-LLMs retrieve by semantic similarity. Transcript paragraphs that match query intent in full sentences rank higher than bullet fragments.
+Transcript paragraphs that match query intent in full sentences rank higher than bullet fragments.
 
 | Anti-pattern | LLM retrieval impact | Fix |
 |--------------|---------------------|-----|
@@ -86,8 +86,6 @@ LLMs retrieve by semantic similarity. Transcript paragraphs that match query int
 | Duplicate auto-caption noise | Dilutes relevance | Correct captions before indexing |
 
 ## Cross-Format Reuse
-
-Transcripts enable repurposing with no additional content production:
 
 - **Blog post**: transcript → `seo/seo-write.md` article workflow
 - **FAQ schema**: extract Q&A pairs from transcript → `seo/video-schema.md`


### PR DESCRIPTION
## Summary

Tighten `.agents/seo/transcript-seo.md` from 107 to 105 lines per issue classification guidance (instruction doc, not reference corpus).

## Changes

- Remove "An LLM cannot watch a video or listen to audio — it reads the transcript." from intro — implied by "primary LLM retrieval signal"
- Remove "LLMs retrieve by semantic similarity." opener in LLM Retrieval section — background knowledge for an LLM agent, not actionable
- Remove "Transcripts enable repurposing with no additional content production:" intro sentence from Cross-Format Reuse — self-evident from the section header and bullet list
- Minor: "Mark paragraphs" → "Target paragraphs" for active imperative tone

## Content Preservation Verification

- All code blocks intact: HTML embedding example + Speakable Schema JSON ✓
- All tables intact: consumer table, LLM anti-pattern table, integration points table ✓
- All 6 checklist items present ✓
- All 5 production workflow steps present ✓
- All 6 cross-format reuse bullets present ✓
- All `seo/*.md` internal references present ✓
- No task ID references (`tNNN`/`GH#NNN`) in original — N/A ✓

## Qlty

No smells flagged on this file (`qlty smells` returned 0 matches).

Resolves #19505