### PR TITLE
GH#19512: GH#19512: bump nesting threshold 284→289 (282 violations + 7 headroom)

### DIFF
--- a/.agents/configs/complexity-thresholds-history.md
+++ b/.agents/configs/complexity-thresholds-history.md
@@ -80,6 +80,8 @@ Archives the full change history for `.agents/configs/complexity-thresholds.conf
 | 289 | GH#19472 | proximity guard firing at 282/283 (1 headroom); 282 violations + 7 headroom = 289; proximity guard (warn_at = 289-5 = 284) fires when violations exceed 284 (i.e., at 285), preventing saturation |
 | 284 | GH#19480 | ratcheted down — actual violations 282 + 2 buffer |
 | 289 | GH#19490 | proximity guard firing at 282/284 (2 headroom); 282 violations + 7 headroom = 289; proximity guard (warn_at = 289-5 = 284) fires when violations exceed 284 (i.e., at 285), preventing saturation |
+| 284 | GH#19506 | ratcheted down — actual violations 282 + 2 buffer |
+| 289 | GH#19512 | proximity guard firing at 282/284 (2 headroom); 282 violations + 7 headroom = 289; proximity guard (warn_at = 289-5 = 284) fires when violations exceed 284 (i.e., at 285), preventing saturation |
 
 ## FUNCTION_COMPLEXITY_THRESHOLD History
 

--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -167,7 +167,9 @@ FUNCTION_COMPLEXITY_THRESHOLD=31
 # Bumped to 289 (GH#19490): proximity guard firing at 282/284 (2 headroom); 282 violations + 7 headroom = 289.
 # Proximity guard (warn_at = 289-5 = 284) fires when violations exceed 284 (i.e., at 285), preventing saturation.
 # Ratcheted down to 284 (GH#19506): actual violations 282 + 2 buffer
-NESTING_DEPTH_THRESHOLD=284
+# Bumped to 289 (GH#19512): proximity guard firing at 282/284 (2 headroom); 282 violations + 7 headroom = 289.
+# Proximity guard (warn_at = 289-5 = 284) fires when violations exceed 284 (i.e., at 285), preventing saturation.
+NESTING_DEPTH_THRESHOLD=289
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Bumped NESTING_DEPTH_THRESHOLD from 284 to 289 (282 actual violations + 7 headroom) following the established bump-and-ratchet cadence. Proximity guard fires when violations exceed 284 (i.e., at 285), preventing saturation. Also added the missing GH#19506 ratchet-down entry to complexity-thresholds-history.md.

## Files Changed

.agents/configs/complexity-thresholds-history.md,.agents/configs/complexity-thresholds.conf

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified: 282 actual violations (via CI methodology: lint_shell_files() + awk depth counter). 282 < 289 threshold passes the code-quality CI check. History file updated with both GH#19506 ratchet and GH#19512 bump entries.

Resolves #19512


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.65 plugin for [OpenCode](https://opencode.ai) v1.4.7 with claude-sonnet-4-6 spent 3m and 7,065 tokens on this as a headless worker.