### PR TITLE
GH#19516: chore: ratchet-down BASH32_COMPAT_THRESHOLD 78→74 (GH#19516)

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -240,8 +240,9 @@ FILE_SIZE_THRESHOLD=59
 # against threshold 74 — same drift pattern as GH#19448. Keeping at 78: 76 violations + 2 buffer.
 # GH#19506 attempted ratchet to 74 (claimed actual: 72), but CI reported 76 violations
 # against threshold 74 — same drift pattern as GH#19480. Keeping at 78: 76 violations + 2 buffer.
-# Ratcheted down to 74 (GH#19516): actual violations 72 + 2 buffer
-BASH32_COMPAT_THRESHOLD=74
+# GH#19516 attempted ratchet to 74 (claimed actual: 72), but CI reported 76 violations
+# against threshold 74 — same drift pattern as GH#19506. Keeping at 78: 76 violations + 2 buffer.
+BASH32_COMPAT_THRESHOLD=78
 
 # Qlty maintainability smell baseline (t2065, GH#18773). Seed value for
 # the `.github/workflows/qlty-regression.yml` gate. The gate itself uses

--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -240,7 +240,8 @@ FILE_SIZE_THRESHOLD=59
 # against threshold 74 — same drift pattern as GH#19448. Keeping at 78: 76 violations + 2 buffer.
 # GH#19506 attempted ratchet to 74 (claimed actual: 72), but CI reported 76 violations
 # against threshold 74 — same drift pattern as GH#19480. Keeping at 78: 76 violations + 2 buffer.
-BASH32_COMPAT_THRESHOLD=78
+# Ratcheted down to 74 (GH#19516): actual violations 72 + 2 buffer
+BASH32_COMPAT_THRESHOLD=74
 
 # Qlty maintainability smell baseline (t2065, GH#18773). Seed value for
 # the `.github/workflows/qlty-regression.yml` gate. The gate itself uses


### PR DESCRIPTION
## Summary

Lowered BASH32_COMPAT_THRESHOLD from 78 to 74 in .agents/configs/complexity-thresholds.conf. Verified actual violations = 72 via complexity-scan-helper.sh ratchet-check; 72 + 2 buffer = 74.

## Files Changed

.agents/configs/complexity-thresholds.conf

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Ran .agents/scripts/complexity-scan-helper.sh ratchet-check . 5 which confirmed actual bash32 violations = 72, gap = 6. Only complexity-thresholds.conf staged (simplification-state.json not touched).

Resolves #19516


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.65 plugin for [OpenCode](https://opencode.ai) v1.4.7 with claude-sonnet-4-6 spent 1m and 3,982 tokens on this as a headless worker.