### PR TITLE
t2170: fix(pulse-triage): clear stale needs-simplification labels when cited continuations are phantom

### DIFF
--- a/.agents/scripts/pulse-dispatch-large-file-gate.sh
+++ b/.agents/scripts/pulse-dispatch-large-file-gate.sh
@@ -675,7 +675,20 @@ _issue_targets_large_files() {
 
 	local all_paths
 	all_paths=$(_large_file_gate_extract_paths "$issue_body")
-	[[ -n "$all_paths" ]] || return 1
+	if [[ -z "$all_paths" ]]; then
+		# t2170 Fix E (primary): No paths in body — if already labeled, auto-clear
+		# (stale label from pre-Fix-A gate application that matched context-ref
+		# backtick paths). Closes the gap for issues where Fix A now correctly
+		# returns empty but the early-return prevented reaching the auto-clear
+		# at lines 682-684. Empirical evidence: GH#19415 received a CLEARED
+		# comment but the label persisted; 17 min of zero label events after
+		# pulse restart confirmed the extractor fix worked but the stale label
+		# required human intervention to clear.
+		if [[ ",$issue_labels," == *",needs-simplification,"* ]]; then
+			_large_file_gate_clear_stale_label "$issue_number" "$repo_slug"
+		fi
+		return 1
+	fi
 
 	local found_large=false
 	local large_files=""

--- a/.agents/scripts/pulse-triage.sh
+++ b/.agents/scripts/pulse-triage.sh
@@ -474,12 +474,124 @@ _Automated by \`_post_simplification_gate_cleared_comment()\` in pulse-triage.sh
 }
 
 #######################################
+# t2170 Fix E (secondary): Check if ALL continuation citations in the
+# large-file gate sticky comment are stale. Called when
+# _issue_targets_large_files returned 0 (file still targeted) to detect
+# deadlocked issues where phantom continuations prevent fresh gate
+# re-evaluation.
+#
+# A continuation citation is stale when:
+#   - The cited issue is CLOSED, AND one of:
+#     (a) it carries `simplification-incomplete` (Fix D, t2169) — file
+#         never simplified; short-circuits the wc -l check.
+#     (b) _large_file_gate_verify_prior_reduced_size confirms file is
+#         still over threshold.
+#   - If the cited issue is OPEN → valid (work in progress), preserve.
+#   - If the issue or its path is unresolvable → conservative: preserve.
+#
+# When ALL citations are stale the label is removed so the next dispatch
+# cycle re-fires the gate fresh (which, post-Fix-A/B, files a new debt
+# issue instead of re-citing the phantom).
+#
+# Arguments:
+#   $1 - issue_number
+#   $2 - repo_slug
+#   $3 - repo_path
+# Returns: 0 (cleared label), 1 (preserved label)
+#######################################
+_reevaluate_stale_continuations() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local repo_path="$3"
+
+	# Fetch gate sticky comment. map+.[0] preserves the full multi-line body
+	# (.[]+head-1 would truncate to the heading line, losing the issue refs).
+	local gate_comment
+	gate_comment=$(gh issue view "$issue_number" --repo "$repo_slug" \
+		--comments --json comments \
+		--jq '.comments | map(select(.body | contains("## Large File Simplification Gate"))) | .[0].body // empty' \
+		2>/dev/null) || gate_comment=""
+	[[ -n "$gate_comment" ]] || return 1
+
+	# Extract only the "recently-closed — continuation" issue numbers; open
+	# "existing"/"new" entries don't cause the deadlock this fix targets.
+	local continuation_nums
+	continuation_nums=$(printf '%s' "$gate_comment" |
+		grep -oE '#[0-9]+ \(recently-closed' |
+		grep -oE '[0-9]+') || continuation_nums=""
+	[[ -n "$continuation_nums" ]] || return 1
+
+	local all_stale="true"
+	local cont_num
+	while IFS= read -r cont_num; do
+		[[ "$cont_num" =~ ^[0-9]+$ ]] || continue
+
+		local cont_info cont_state cont_labels
+		cont_info=$(gh issue view "$cont_num" --repo "$repo_slug" \
+			--json state,labels,title 2>/dev/null) || cont_info=""
+		if [[ -z "$cont_info" ]]; then
+			all_stale="false"
+			break # Unresolvable → conservative
+		fi
+
+		cont_state=$(printf '%s' "$cont_info" | jq -r '.state // "OPEN"' 2>/dev/null)
+		if [[ "${cont_state^^}" != "CLOSED" ]]; then
+			all_stale="false"
+			break # Open → work in progress
+		fi
+
+		# Closed — short-circuit via simplification-incomplete (Fix D, t2169)
+		# or verify via file-size check.
+		cont_labels=$(printf '%s' "$cont_info" | jq -r '[.labels[].name] | join(",")' 2>/dev/null) || cont_labels=""
+		if [[ ",$cont_labels," == *",simplification-incomplete,"* ]]; then
+			continue # definite stale, no wc -l needed
+		fi
+
+		# Parse path from title: "simplification-debt: <path> exceeds N lines"
+		local cont_title cont_file_path
+		cont_title=$(printf '%s' "$cont_info" | jq -r '.title // ""' 2>/dev/null) || cont_title=""
+		cont_file_path=$(printf '%s' "$cont_title" |
+			sed 's/^simplification-debt: //;s/ exceeds [0-9]* lines$//' 2>/dev/null) || cont_file_path=""
+		if [[ -z "$cont_file_path" || "$cont_file_path" == "$cont_title" ]]; then
+			all_stale="false"
+			break # Path unresolvable → conservative
+		fi
+
+		# Guard: function is in pulse-dispatch-large-file-gate.sh (sourced first)
+		if ! declare -F _large_file_gate_verify_prior_reduced_size >/dev/null 2>&1; then
+			all_stale="false"
+			break # Function unavailable → conservative
+		fi
+
+		# Returns 0 = file under threshold (valid), 1 = still over (stale)
+		if _large_file_gate_verify_prior_reduced_size \
+			"$cont_num" "$cont_file_path" "$repo_path"; then
+			all_stale="false"
+			break # Prior work was effective → valid citation
+		fi
+	done < <(printf '%s\n' "$continuation_nums")
+
+	if [[ "$all_stale" == "true" ]]; then
+		gh issue edit "$issue_number" --repo "$repo_slug" \
+			--remove-label "needs-simplification" >/dev/null 2>&1 || true
+		echo "[pulse-triage] Cleared stale needs-simplification on #${issue_number} (all cited continuations phantom; next dispatch will re-evaluate the gate)" >>"$LOGFILE"
+		return 0
+	fi
+	return 1
+}
+
+#######################################
 # Re-evaluate needs-simplification labeled issues across pulse repos.
 # Same pattern as _reevaluate_consolidation_labels: issues filtered out
 # by the needs-* exclusion never reach dispatch_with_dedup, so the
 # auto-clear at the end of _issue_targets_large_files can't fire.
 # This pass re-evaluates them and clears the label when the file is
 # now excluded (lockfile, JSON config) or below threshold.
+#
+# t2170 Fix E (secondary): also runs _reevaluate_stale_continuations when
+# _issue_targets_large_files returns 0 (file still targeted). This covers
+# the deadlock where phantom continuation citations block the gate from
+# re-firing and creating a fresh (accurate) debt issue.
 #######################################
 _reevaluate_simplification_labels() {
 	local repos_json="$REPOS_JSON"
@@ -510,6 +622,15 @@ _reevaluate_simplification_labels() {
 				# t2042: post follow-up "CLEARED" comment so the original
 				# "Held from dispatch" comment doesn't mislead readers.
 				_post_simplification_gate_cleared_comment "$num" "$slug"
+			else
+				# t2170 Fix E (secondary): file still targets large files but
+				# check if ALL cited continuation issues are stale/phantom.
+				# Clears the label so the next dispatch cycle re-evaluates
+				# the gate fresh — breaking the deadlock where a phantom
+				# continuation blocks new accurate debt issue creation.
+				if _reevaluate_stale_continuations "$num" "$slug" "$rpath"; then
+					total_cleared=$((total_cleared + 1))
+				fi
 			fi
 		done < <(printf '%s' "$issues_json" | jq -r '.[]?.number // ""')
 	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "" and .path != "") | "\(.slug)|\(.path)"' "$repos_json" 2>/dev/null)

--- a/.agents/scripts/tests/test-reeval-stale-continuation.sh
+++ b/.agents/scripts/tests/test-reeval-stale-continuation.sh
@@ -1,0 +1,513 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-reeval-stale-continuation.sh — t2170 Fix E regression guard.
+#
+# Tests TWO fixes shipped in t2170:
+#
+# PRIMARY (pulse-dispatch-large-file-gate.sh line 654):
+#   When _large_file_gate_extract_paths returns empty AND the issue carries
+#   needs-simplification, the gate must auto-clear the label and return 1
+#   instead of early-returning without clearing. Empirical evidence: GH#19415
+#   received a CLEARED comment but the label persisted until manual removal.
+#
+# SECONDARY (_reevaluate_stale_continuations in pulse-triage.sh):
+#   When _issue_targets_large_files returns 0 (file still targeted), the
+#   re-evaluation pass checks whether ALL cited "recently-closed — continuation"
+#   issues are stale. If yes, clears the label to break the deadlock.
+#
+# Tests:
+#   PRIMARY (pulse-dispatch-large-file-gate.sh primary fix):
+#   1. Empty extraction + labeled issue → label cleared, return 1
+#   2. Empty extraction + unlabeled issue → no clear, return 1
+#   3. Non-empty extraction + large file → gate applies (return 0)
+#
+#   SECONDARY (_reevaluate_stale_continuations):
+#   4. No gate comment → label preserved (safe fallback)
+#   5. Open continuation → label preserved (work in progress)
+#   6. Closed + simplification-incomplete → label cleared (no wc-l needed)
+#   7. Closed + file over threshold → label cleared (stale citation)
+#   8. Closed + file under threshold → label preserved (prior work effective)
+#   9. Multiple continuations, all stale → label cleared
+#   10. Multiple continuations, one open → label preserved (short-circuit)
+#
+# Cross-references: GH#19415 (stuck label), GH#19499/t2170 (this fix),
+#   t2164 (Fix A/B), t2169 (Fix D — simplification-incomplete label)
+
+set -uo pipefail
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+GATE_SCRIPT="${SCRIPT_DIR_TEST}/../pulse-dispatch-large-file-gate.sh"
+TRIAGE_SCRIPT="${SCRIPT_DIR_TEST}/../pulse-triage.sh"
+
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+# =============================================================================
+# Sandbox
+# =============================================================================
+TMP=$(mktemp -d -t t2170.XXXXXX)
+trap 'rm -rf "$TMP"' EXIT
+
+LOGFILE="${TMP}/pulse.log"
+export LOGFILE
+export REPOS_JSON="${TMP}/repos.json"
+LARGE_FILE_LINE_THRESHOLD=2000
+export LARGE_FILE_LINE_THRESHOLD
+
+# Files for threshold tests — relative to TMP so resolve_path finds them
+OVER_BASENAME="large-over.sh"
+UNDER_BASENAME="large-under.sh"
+yes ":" 2>/dev/null | head -n 2050 >"${TMP}/${OVER_BASENAME}"
+yes ":" 2>/dev/null | head -n 100 >"${TMP}/${UNDER_BASENAME}"
+
+# =============================================================================
+# Stub state — writeable by stubs, read by assertions
+# =============================================================================
+GH_CALLS_LOG="${TMP}/gh_calls.log"
+: >"$GH_CALLS_LOG"
+
+# Per-test state reset via reset_state()
+GH_LABEL_REMOVED=""
+GH_VIEW_JSON=""     # JSON for plain gh issue view (no --comments)
+GH_COMMENTS_JSON="" # JSON for gh issue view --comments ({"comments":[...]})
+
+# =============================================================================
+# Source gate first (defines _large_file_gate_* and _issue_targets_large_files)
+# =============================================================================
+# shellcheck source=/dev/null
+source "$GATE_SCRIPT"
+# shellcheck source=/dev/null
+source "$TRIAGE_SCRIPT"
+
+# =============================================================================
+# Stubs — defined AFTER source so they shadow the sourced implementations.
+# The gh stub forwards --jq filters through actual jq so callers that use
+# the `gh ... --json fields --jq filter` pattern get processed output.
+# =============================================================================
+gh() {
+	printf '%s\n' "gh $*" >>"$GH_CALLS_LOG"
+
+	# gh issue edit --remove-label
+	if [[ "$1" == "issue" && "$2" == "edit" ]]; then
+		local arg
+		for arg in "$@"; do
+			[[ "$arg" == "--remove-label" ]] && GH_LABEL_REMOVED="true" && return 0
+			[[ "$arg" == "--add-label" ]] && return 0
+		done
+		return 0
+	fi
+
+	# gh issue view — detect --comments and --jq
+	if [[ "$1" == "issue" && "$2" == "view" ]]; then
+		local saw_comments="false"
+		local jq_filter=""
+		local next_is_jq="false"
+		local arg
+		for arg in "$@"; do
+			if [[ "$next_is_jq" == "true" ]]; then
+				jq_filter="$arg"
+				next_is_jq="false"
+			elif [[ "$arg" == "--comments" ]]; then
+				saw_comments="true"
+			elif [[ "$arg" == "--jq" ]]; then
+				next_is_jq="true"
+			fi
+		done
+
+		if [[ "$saw_comments" == "true" ]]; then
+			if [[ -n "$jq_filter" ]]; then
+				printf '%s\n' "$GH_COMMENTS_JSON" | jq -r "$jq_filter" 2>/dev/null
+			else
+				printf '%s\n' "$GH_COMMENTS_JSON"
+			fi
+			return 0
+		fi
+
+		if [[ -n "$jq_filter" ]]; then
+			printf '%s\n' "$GH_VIEW_JSON" | jq -r "$jq_filter" 2>/dev/null
+		else
+			printf '%s\n' "$GH_VIEW_JSON"
+		fi
+		return 0
+	fi
+
+	# gh issue list — return view JSON (labels check for precheck)
+	if [[ "$1" == "issue" && "$2" == "list" ]]; then
+		local jq_filter=""
+		local next_is_jq="false"
+		local arg
+		for arg in "$@"; do
+			if [[ "$next_is_jq" == "true" ]]; then
+				jq_filter="$arg"
+				next_is_jq="false"
+			elif [[ "$arg" == "--jq" ]]; then
+				next_is_jq="true"
+			fi
+		done
+		if [[ -n "$jq_filter" ]]; then
+			printf '%s\n' "$GH_VIEW_JSON" | jq -r "$jq_filter" 2>/dev/null
+		else
+			printf '%s\n' "$GH_VIEW_JSON"
+		fi
+		return 0
+	fi
+
+	# gh label create — silent no-op
+	[[ "$1" == "label" && "$2" == "create" ]] && return 0
+
+	# gh api — return empty array (idempotent comment check)
+	[[ "$1" == "api" ]] && printf '[]' && return 0
+
+	# gh issue comment — no-op
+	[[ "$1" == "issue" && "$2" == "comment" ]] && return 0
+
+	return 0
+}
+
+gh_create_issue() {
+	printf '%s\n' "gh_create_issue $*" >>"$GH_CALLS_LOG"
+	return 0
+}
+
+_gh_idempotent_comment() {
+	printf '%s\n' "_gh_idempotent_comment $*" >>"$GH_CALLS_LOG"
+	return 0
+}
+
+_post_simplification_gate_cleared_comment() {
+	printf '%s\n' "_post_simplification_gate_cleared_comment $*" >>"$GH_CALLS_LOG"
+	return 0
+}
+
+# =============================================================================
+# Assertions
+# =============================================================================
+assert_eq() {
+	local test_name="$1"
+	local expected="$2"
+	local actual="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$actual" == "$expected" ]]; then
+		printf '  %sPASS%s %s\n' "$TEST_GREEN" "$TEST_NC" "$test_name"
+		return 0
+	fi
+	printf '  %sFAIL%s %s\n' "$TEST_RED" "$TEST_NC" "$test_name"
+	printf '       expected: %q\n' "$expected"
+	printf '       actual:   %q\n' "$actual"
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+reset_state() {
+	GH_LABEL_REMOVED=""
+	GH_VIEW_JSON=""
+	GH_COMMENTS_JSON=""
+	: >"$GH_CALLS_LOG"
+	: >"$LOGFILE"
+}
+
+# =============================================================================
+# PRIMARY fix tests: _issue_targets_large_files empty-extraction auto-clear
+# =============================================================================
+printf '\n=== PRIMARY fix: _issue_targets_large_files empty-extraction auto-clear ===\n\n'
+
+# ---- Test 1: empty extraction + labeled → label cleared, return 1 ----
+reset_state
+# View returns labeled JSON; the code's --jq filter will extract label names
+GH_VIEW_JSON='{"labels":[{"name":"needs-simplification"}]}'
+# Body with NO intent markers (only backtick refs — pre-Fix-A matched these)
+empty_body="See \`pulse-triage.sh\` for context."
+rc=0
+_issue_targets_large_files "9999" "owner/repo" "$empty_body" "$TMP" "true" || rc=$?
+assert_eq \
+	"empty extraction + labeled → returns 1 (no large files)" \
+	"1" "$rc"
+assert_eq \
+	"empty extraction + labeled → label cleared" \
+	"true" "${GH_LABEL_REMOVED:-false}"
+
+# ---- Test 2: empty extraction + unlabeled → no clear, return 1 ----
+reset_state
+GH_VIEW_JSON='{"labels":[]}'
+rc=0
+_issue_targets_large_files "9998" "owner/repo" "$empty_body" "$TMP" "true" || rc=$?
+assert_eq \
+	"empty extraction + unlabeled → returns 1 (no large files)" \
+	"1" "$rc"
+assert_eq \
+	"empty extraction + unlabeled → label NOT cleared" \
+	"" "${GH_LABEL_REMOVED}"
+
+# ---- Test 3: non-empty extraction + large file → gate applies (return 0) ----
+reset_state
+GH_VIEW_JSON='{"labels":[]}'
+# Use a relative-path .sh file in a backtick EDIT: line so the extractor
+# picks it up and _large_file_gate_evaluate_target resolves it via ${TMP}/${path}
+large_body="EDIT: \`${OVER_BASENAME}\`"
+rc=0
+_issue_targets_large_files "9997" "owner/repo" "$large_body" "$TMP" "true" || rc=$?
+assert_eq \
+	"non-empty extraction + large file → returns 0 (gate applies)" \
+	"0" "$rc"
+
+# =============================================================================
+# SECONDARY fix tests: _reevaluate_stale_continuations
+# =============================================================================
+printf '\n=== SECONDARY fix: _reevaluate_stale_continuations ===\n\n'
+
+GATE_COMMENT_BODY="## Large File Simplification Gate
+
+This issue references file(s) exceeding 2000 lines.
+
+**Simplification issues:** PLACEHOLDER"
+
+make_gate_comments() {
+	local issues_line="$1"
+	local body="${GATE_COMMENT_BODY/PLACEHOLDER/${issues_line}}"
+	jq -cn --arg body "$body" '{"comments":[{"body":$body}]}'
+}
+
+# ---- Test 4: no gate comment → label preserved ----
+reset_state
+GH_COMMENTS_JSON='{"comments":[]}'
+GH_VIEW_JSON='{"state":"OPEN","labels":[],"title":"some issue"}'
+rc=0
+_reevaluate_stale_continuations "100" "owner/repo" "$TMP" || rc=$?
+assert_eq \
+	"no gate comment → return 1 (label preserved)" \
+	"1" "$rc"
+assert_eq \
+	"no gate comment → label NOT removed" \
+	"" "${GH_LABEL_REMOVED}"
+
+# ---- Test 5: open continuation → label preserved ----
+reset_state
+GH_COMMENTS_JSON=$(make_gate_comments "#42 (recently-closed — continuation)")
+# gh issue view #42 returns state=OPEN
+GH_VIEW_JSON='{"state":"OPEN","labels":[],"title":"simplification-debt: large-over.sh exceeds 2000 lines"}'
+rc=0
+_reevaluate_stale_continuations "100" "owner/repo" "$TMP" || rc=$?
+assert_eq \
+	"open continuation → return 1 (label preserved)" \
+	"1" "$rc"
+assert_eq \
+	"open continuation → label NOT removed" \
+	"" "${GH_LABEL_REMOVED}"
+
+# ---- Test 6: closed + simplification-incomplete → label cleared (no wc-l) ----
+reset_state
+GH_COMMENTS_JSON=$(make_gate_comments "#43 (recently-closed — continuation)")
+GH_VIEW_JSON='{"state":"CLOSED","labels":[{"name":"simplification-incomplete"}],"title":"simplification-debt: large-over.sh exceeds 2000 lines"}'
+rc=0
+_reevaluate_stale_continuations "100" "owner/repo" "$TMP" || rc=$?
+assert_eq \
+	"simplification-incomplete → return 0 (cleared, no wc-l needed)" \
+	"0" "$rc"
+assert_eq \
+	"simplification-incomplete → label removed" \
+	"true" "${GH_LABEL_REMOVED:-false}"
+
+# ---- Test 7: closed + file over threshold → label cleared (stale citation) ----
+reset_state
+GH_COMMENTS_JSON=$(make_gate_comments "#44 (recently-closed — continuation)")
+GH_VIEW_JSON=$(jq -cn \
+	--arg path "${OVER_BASENAME}" \
+	'{"state":"CLOSED","labels":[],"title": ("simplification-debt: " + $path + " exceeds 2000 lines")}')
+rc=0
+_reevaluate_stale_continuations "100" "owner/repo" "$TMP" || rc=$?
+assert_eq \
+	"closed + file over threshold → return 0 (label cleared, citation stale)" \
+	"0" "$rc"
+assert_eq \
+	"closed + file over threshold → label removed" \
+	"true" "${GH_LABEL_REMOVED:-false}"
+
+# ---- Test 8: closed + file under threshold → label preserved (work effective) ----
+reset_state
+GH_COMMENTS_JSON=$(make_gate_comments "#45 (recently-closed — continuation)")
+GH_VIEW_JSON=$(jq -cn \
+	--arg path "${UNDER_BASENAME}" \
+	'{"state":"CLOSED","labels":[],"title": ("simplification-debt: " + $path + " exceeds 2000 lines")}')
+rc=0
+_reevaluate_stale_continuations "100" "owner/repo" "$TMP" || rc=$?
+assert_eq \
+	"closed + file under threshold → return 1 (label preserved, work effective)" \
+	"1" "$rc"
+assert_eq \
+	"closed + file under threshold → label NOT removed" \
+	"" "${GH_LABEL_REMOVED}"
+
+# ---- Test 9: multiple continuations, all stale → label cleared ----
+reset_state
+OVER_BASENAME2="large-over2.sh"
+yes ":" 2>/dev/null | head -n 2050 >"${TMP}/${OVER_BASENAME2}"
+GH_COMMENTS_JSON=$(make_gate_comments "#46 (recently-closed — continuation), #47 (recently-closed — continuation)")
+
+# Both continuation issues closed + over-threshold; alternate per call
+_t9_call=0
+gh() {
+	printf '%s\n' "gh $*" >>"$GH_CALLS_LOG"
+	if [[ "$1" == "issue" && "$2" == "edit" ]]; then
+		local arg
+		for arg in "$@"; do
+			[[ "$arg" == "--remove-label" ]] && GH_LABEL_REMOVED="true" && return 0
+		done
+		return 0
+	fi
+	if [[ "$1" == "issue" && "$2" == "view" ]]; then
+		local saw_comments="false"
+		local jq_filter=""
+		local next_is_jq="false"
+		local arg
+		for arg in "$@"; do
+			if [[ "$next_is_jq" == "true" ]]; then
+				jq_filter="$arg"
+				next_is_jq="false"
+			elif [[ "$arg" == "--comments" ]]; then
+				saw_comments="true"
+			elif [[ "$arg" == "--jq" ]]; then
+				next_is_jq="true"
+			fi
+		done
+		if [[ "$saw_comments" == "true" ]]; then
+			if [[ -n "$jq_filter" ]]; then
+				printf '%s\n' "$GH_COMMENTS_JSON" | jq -r "$jq_filter" 2>/dev/null
+			else
+				printf '%s\n' "$GH_COMMENTS_JSON"
+			fi
+			return 0
+		fi
+		_t9_call=$((_t9_call + 1))
+		local resp
+		if ((_t9_call % 2 == 1)); then
+			resp=$(jq -cn --arg p "$OVER_BASENAME" \
+				'{"state":"CLOSED","labels":[],"title":("simplification-debt: "+$p+" exceeds 2000 lines")}')
+		else
+			resp=$(jq -cn --arg p "$OVER_BASENAME2" \
+				'{"state":"CLOSED","labels":[],"title":("simplification-debt: "+$p+" exceeds 2000 lines")}')
+		fi
+		if [[ -n "$jq_filter" ]]; then
+			printf '%s\n' "$resp" | jq -r "$jq_filter" 2>/dev/null
+		else
+			printf '%s\n' "$resp"
+		fi
+		return 0
+	fi
+	[[ "$1" == "label" && "$2" == "create" ]] && return 0
+	[[ "$1" == "api" ]] && printf '[]' && return 0
+	[[ "$1" == "issue" && "$2" == "comment" ]] && return 0
+	[[ "$1" == "issue" && "$2" == "list" ]] && printf '%s\n' "$GH_VIEW_JSON" && return 0
+	return 0
+}
+
+rc=0
+_reevaluate_stale_continuations "100" "owner/repo" "$TMP" || rc=$?
+assert_eq \
+	"all-stale multi-continuation → return 0 (label cleared)" \
+	"0" "$rc"
+assert_eq \
+	"all-stale multi-continuation → label removed" \
+	"true" "${GH_LABEL_REMOVED:-false}"
+
+# Restore standard stub
+gh() {
+	printf '%s\n' "gh $*" >>"$GH_CALLS_LOG"
+	if [[ "$1" == "issue" && "$2" == "edit" ]]; then
+		local arg
+		for arg in "$@"; do
+			[[ "$arg" == "--remove-label" ]] && GH_LABEL_REMOVED="true" && return 0
+		done
+		return 0
+	fi
+	if [[ "$1" == "issue" && "$2" == "view" ]]; then
+		local saw_comments="false"
+		local jq_filter=""
+		local next_is_jq="false"
+		local arg
+		for arg in "$@"; do
+			if [[ "$next_is_jq" == "true" ]]; then
+				jq_filter="$arg"
+				next_is_jq="false"
+			elif [[ "$arg" == "--comments" ]]; then
+				saw_comments="true"
+			elif [[ "$arg" == "--jq" ]]; then
+				next_is_jq="true"
+			fi
+		done
+		if [[ "$saw_comments" == "true" ]]; then
+			if [[ -n "$jq_filter" ]]; then
+				printf '%s\n' "$GH_COMMENTS_JSON" | jq -r "$jq_filter" 2>/dev/null
+			else
+				printf '%s\n' "$GH_COMMENTS_JSON"
+			fi
+			return 0
+		fi
+		if [[ -n "$jq_filter" ]]; then
+			printf '%s\n' "$GH_VIEW_JSON" | jq -r "$jq_filter" 2>/dev/null
+		else
+			printf '%s\n' "$GH_VIEW_JSON"
+		fi
+		return 0
+	fi
+	if [[ "$1" == "issue" && "$2" == "list" ]]; then
+		local jq_filter=""
+		local next_is_jq="false"
+		local arg
+		for arg in "$@"; do
+			if [[ "$next_is_jq" == "true" ]]; then
+				jq_filter="$arg"
+				next_is_jq="false"
+			elif [[ "$arg" == "--jq" ]]; then
+				next_is_jq="true"
+			fi
+		done
+		if [[ -n "$jq_filter" ]]; then
+			printf '%s\n' "$GH_VIEW_JSON" | jq -r "$jq_filter" 2>/dev/null
+		else
+			printf '%s\n' "$GH_VIEW_JSON"
+		fi
+		return 0
+	fi
+	[[ "$1" == "label" && "$2" == "create" ]] && return 0
+	[[ "$1" == "api" ]] && printf '[]' && return 0
+	[[ "$1" == "issue" && "$2" == "comment" ]] && return 0
+	return 0
+}
+
+# ---- Test 10: one open continuation → label preserved (short-circuit) ----
+reset_state
+GH_COMMENTS_JSON=$(make_gate_comments "#48 (recently-closed — continuation), #49 (recently-closed — continuation)")
+# Both view calls return OPEN → first citation valid → should short-circuit
+GH_VIEW_JSON='{"state":"OPEN","labels":[],"title":"simplification-debt: large-over.sh exceeds 2000 lines"}'
+rc=0
+_reevaluate_stale_continuations "100" "owner/repo" "$TMP" || rc=$?
+assert_eq \
+	"one open continuation → return 1 (label preserved, short-circuit on valid)" \
+	"1" "$rc"
+assert_eq \
+	"one open continuation → label NOT removed" \
+	"" "${GH_LABEL_REMOVED}"
+
+# =============================================================================
+# Summary
+# =============================================================================
+printf '\n%d run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+	printf '\n--- gh call log ---\n'
+	cat "$GH_CALLS_LOG"
+	printf '\n--- pulse log ---\n'
+	cat "$LOGFILE"
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Fix E of t2163: two-part fix that clears stale `needs-simplification` labels, breaking the deadlock where already-labeled issues can't self-unblock because dispatch is held by the label that gate re-run would clear.

### PRIMARY fix: `pulse-dispatch-large-file-gate.sh:654`

When `_large_file_gate_extract_paths` returns empty AND the issue already carries `needs-simplification`, the early-return at line 654 previously bypassed the auto-clear block at lines 682-684. Now auto-clears the label before returning 1.

**Empirical root cause (GH#19415):** After Fix A (t2164) the extractor correctly returns empty for bodies with no `EDIT:`/`NEW:`/`File:` intent markers. But the early-return prevented auto-clear, so the issue received a CLEARED comment but the label persisted until manually removed.

### SECONDARY fix: `pulse-triage.sh` — new `_reevaluate_stale_continuations` (80 lines)

New helper wired into `_reevaluate_simplification_labels`. When `_issue_targets_large_files` returns 0 (file still targeted), checks whether ALL cited `recently-closed — continuation` issues in the gate sticky comment are stale:

- OPEN citation → valid (work in progress), preserve label
- CLOSED + `simplification-incomplete` (Fix D, t2169) → stale, no `wc -l` needed
- CLOSED + file still over threshold → stale (phantom continuation)
- CLOSED + file under threshold → valid (prior work effective), preserve
- Unresolvable → conservative, preserve label

When ALL citations are stale, removes `needs-simplification` so the next dispatch cycle re-fires the gate fresh.

### Tests

`test-reeval-stale-continuation.sh`: 19 assertions (3 primary, 16 secondary), all passing.
Regression: `test-large-file-gate-continuation-verify.sh` still 7/7.

## Verification

```bash
bash .agents/scripts/tests/test-reeval-stale-continuation.sh
bash .agents/scripts/tests/test-large-file-gate-continuation-verify.sh
```

Resolves #19499
For #19482