### PR TITLE
GH#19526: GH#19526: chore(ci): bump nesting depth threshold 284→290 (283 violations + 7 headroom)

### DIFF
--- a/.agents/configs/complexity-thresholds-history.md
+++ b/.agents/configs/complexity-thresholds-history.md
@@ -82,6 +82,8 @@ Archives the full change history for `.agents/configs/complexity-thresholds.conf
 | 289 | GH#19490 | proximity guard firing at 282/284 (2 headroom); 282 violations + 7 headroom = 289; proximity guard (warn_at = 289-5 = 284) fires when violations exceed 284 (i.e., at 285), preventing saturation |
 | 284 | GH#19506 | ratcheted down — actual violations 282 + 2 buffer |
 | 289 | GH#19512 | proximity guard firing at 282/284 (2 headroom); 282 violations + 7 headroom = 289; proximity guard (warn_at = 289-5 = 284) fires when violations exceed 284 (i.e., at 285), preventing saturation |
+| 284 | GH#19519 | ratcheted down — actual violations 282 + 2 buffer |
+| 290 | GH#19526 | proximity guard firing at 283/284 (1 headroom); 283 violations + 7 headroom = 290; proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation |
 
 ## FUNCTION_COMPLEXITY_THRESHOLD History
 

--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -170,7 +170,9 @@ FUNCTION_COMPLEXITY_THRESHOLD=31
 # Bumped to 289 (GH#19512): proximity guard firing at 282/284 (2 headroom); 282 violations + 7 headroom = 289.
 # Proximity guard (warn_at = 289-5 = 284) fires when violations exceed 284 (i.e., at 285), preventing saturation.
 # Ratcheted down to 284 (GH#19519): actual violations 282 + 2 buffer
-NESTING_DEPTH_THRESHOLD=284
+# Bumped to 290 (GH#19526): proximity guard firing at 283/284 (1 headroom); 283 violations + 7 headroom = 290.
+# Proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation.
+NESTING_DEPTH_THRESHOLD=290
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Bumped NESTING_DEPTH_THRESHOLD from 284 to 290 (283 violations + 7 headroom = 290). Added missing GH#19519 ratchet entry and new GH#19526 bump entry to complexity-thresholds-history.md.

## Files Changed

.agents/configs/complexity-thresholds-history.md,.agents/configs/complexity-thresholds.conf

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** CI code-quality check will pass with new threshold 290 > 283 current violations

Resolves #19526


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.65 plugin for [OpenCode](https://opencode.ai) v1.4.7 with claude-sonnet-4-6 spent 2m and 7,128 tokens on this as a headless worker.