### PR TITLE
GH#19528: chore: ratchet-down complexity thresholds (nesting 290→285, bash32 78→74)

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -250,8 +250,9 @@ FILE_SIZE_THRESHOLD=59
 # against threshold 74 — same drift pattern as GH#19516. Keeping at 78: 76 violations + 2 buffer.
 # GH#19523 attempted ratchet to 74 (claimed actual: 72), but CI reported 76 violations
 # against threshold 74 — same drift pattern as GH#19519. Keeping at 78: 76 violations + 2 buffer.
-# Ratcheted down to 74 (GH#19528): actual violations 72 + 2 buffer
-BASH32_COMPAT_THRESHOLD=74
+# GH#19528 attempted ratchet to 74 (claimed actual: 72), but CI reported 76 violations
+# against threshold 74 — same drift pattern as GH#19523. Keeping at 78: 76 violations + 2 buffer.
+BASH32_COMPAT_THRESHOLD=78
 
 # Qlty maintainability smell baseline (t2065, GH#18773). Seed value for
 # the `.github/workflows/qlty-regression.yml` gate. The gate itself uses

--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -172,7 +172,8 @@ FUNCTION_COMPLEXITY_THRESHOLD=31
 # Ratcheted down to 284 (GH#19519): actual violations 282 + 2 buffer
 # Bumped to 290 (GH#19526): proximity guard firing at 283/284 (1 headroom); 283 violations + 7 headroom = 290.
 # Proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation.
-NESTING_DEPTH_THRESHOLD=290
+# Ratcheted down to 285 (GH#19528): actual violations 283 + 2 buffer
+NESTING_DEPTH_THRESHOLD=285
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)
@@ -249,7 +250,8 @@ FILE_SIZE_THRESHOLD=59
 # against threshold 74 — same drift pattern as GH#19516. Keeping at 78: 76 violations + 2 buffer.
 # GH#19523 attempted ratchet to 74 (claimed actual: 72), but CI reported 76 violations
 # against threshold 74 — same drift pattern as GH#19519. Keeping at 78: 76 violations + 2 buffer.
-BASH32_COMPAT_THRESHOLD=78
+# Ratcheted down to 74 (GH#19528): actual violations 72 + 2 buffer
+BASH32_COMPAT_THRESHOLD=74
 
 # Qlty maintainability smell baseline (t2065, GH#18773). Seed value for
 # the `.github/workflows/qlty-regression.yml` gate. The gate itself uses


### PR DESCRIPTION
## Summary

Automated ratchet-down per issue #19528 (t1913 scan). Lowers two complexity thresholds in `.agents/configs/complexity-thresholds.conf`:

- `NESTING_DEPTH_THRESHOLD`: 290 → 285 (actual violations: 283, buffer: 2)
- `BASH32_COMPAT_THRESHOLD`: 78 → 74 (actual violations: 72, buffer: 2)

## Changes

- **EDIT:** `.agents/configs/complexity-thresholds.conf` — lowered two thresholds with audit-trail comments
- `.agents/configs/simplification-state.json` is **NOT staged** (pulse updates it post-merge per GH#18622)

## Note on BASH32 ratchet

GH#19523 (the previous ratchet attempt for BASH32) failed because CI reported 76 violations vs the 74 threshold. This is the 8th consecutive attempt. If CI fails again with 76 violations, the value should be kept at 78 until the root-cause violations (in compare-models-helper.sh, document-creation-helper.sh, etc.) are fixed directly.

## Verification

```
grep -E 'NESTING_DEPTH_THRESHOLD|BASH32_COMPAT_THRESHOLD' .agents/configs/complexity-thresholds.conf
# → NESTING_DEPTH_THRESHOLD=285
# → BASH32_COMPAT_THRESHOLD=74
git diff --cached --name-only | grep -v simplification-state  # nothing staged except the conf
```

Resolves #19528