### PR TITLE
GH#19530: GH#19530: chore(ci): bump NESTING_DEPTH_THRESHOLD 285→290 (283 violations + 7 headroom)

### DIFF
--- a/.agents/configs/complexity-thresholds-history.md
+++ b/.agents/configs/complexity-thresholds-history.md
@@ -84,6 +84,8 @@ Archives the full change history for `.agents/configs/complexity-thresholds.conf
 | 289 | GH#19512 | proximity guard firing at 282/284 (2 headroom); 282 violations + 7 headroom = 289; proximity guard (warn_at = 289-5 = 284) fires when violations exceed 284 (i.e., at 285), preventing saturation |
 | 284 | GH#19519 | ratcheted down — actual violations 282 + 2 buffer |
 | 290 | GH#19526 | proximity guard firing at 283/284 (1 headroom); 283 violations + 7 headroom = 290; proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation |
+| 285 | GH#19528 | ratcheted down — actual violations 283 + 2 buffer |
+| 290 | GH#19530 | proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290; proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation |
 
 ## FUNCTION_COMPLEXITY_THRESHOLD History
 

--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -173,7 +173,9 @@ FUNCTION_COMPLEXITY_THRESHOLD=31
 # Bumped to 290 (GH#19526): proximity guard firing at 283/284 (1 headroom); 283 violations + 7 headroom = 290.
 # Proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation.
 # Ratcheted down to 285 (GH#19528): actual violations 283 + 2 buffer
-NESTING_DEPTH_THRESHOLD=285
+# Bumped to 290 (GH#19530): proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290.
+# Proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation.
+NESTING_DEPTH_THRESHOLD=290
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Bumped NESTING_DEPTH_THRESHOLD from 285 to 290 (283 violations + 7 headroom) following the established bump-and-ratchet cadence. The proximity guard was firing at 283/285 (2 headroom). With the new threshold of 290, the proximity guard will fire at violations > 285 (i.e., at 286), giving adequate headroom before CI saturation.

## Files Changed

.agents/configs/complexity-thresholds-history.md,.agents/configs/complexity-thresholds.conf

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** CI nesting depth check passes: 283 violations < 290 threshold. Verified locally: source .agents/scripts/lint-file-discovery.sh && lint_shell_files && count = 283 violations.

Resolves #19530


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.65 plugin for [OpenCode](https://opencode.ai) v1.4.7 with claude-sonnet-4-6 spent 3m and 7,099 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code quality configuration thresholds and corresponding documentation records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->