### PR TITLE
GH#19536: GH#19536: chore(ci): bump NESTING_DEPTH_THRESHOLD 285→290 (283 violations + 7 headroom)

### DIFF
--- a/.agents/configs/complexity-thresholds-history.md
+++ b/.agents/configs/complexity-thresholds-history.md
@@ -86,6 +86,8 @@ Archives the full change history for `.agents/configs/complexity-thresholds.conf
 | 290 | GH#19526 | proximity guard firing at 283/284 (1 headroom); 283 violations + 7 headroom = 290; proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation |
 | 285 | GH#19528 | ratcheted down — actual violations 283 + 2 buffer |
 | 290 | GH#19530 | proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290; proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation |
+| 285 | GH#19533 | ratcheted down — actual violations 283 + 2 buffer |
+| 290 | GH#19536 | proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290; proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation |
 
 ## FUNCTION_COMPLEXITY_THRESHOLD History
 

--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -176,7 +176,9 @@ FUNCTION_COMPLEXITY_THRESHOLD=31
 # Bumped to 290 (GH#19530): proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290.
 # Proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation.
 # Ratcheted down to 285 (GH#19533): actual violations 283 + 2 buffer
-NESTING_DEPTH_THRESHOLD=285
+# Bumped to 290 (GH#19536): proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290.
+# Proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation.
+NESTING_DEPTH_THRESHOLD=290
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Bumped NESTING_DEPTH_THRESHOLD from 285 to 290 following proximity guard warning (283/285 violations, 2 headroom remaining). Added GH#19533 ratchet-down entry and GH#19536 bump entry to complexity-thresholds-history.md. Pattern: 283 violations + 7 headroom = 290.

## Files Changed

.agents/configs/complexity-thresholds-history.md,.agents/configs/complexity-thresholds.conf

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** CI code-quality check: NESTING_DEPTH_THRESHOLD=290 gives 7 headroom (283 violations), proximity guard fires at 285 violations (warn_at=285), preventing future saturation.

Resolves #19536


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.65 plugin for [OpenCode](https://opencode.ai) v1.4.7 with claude-sonnet-4-6 spent 1m and 5,586 tokens on this as a headless worker.