### PR TITLE
GH#19531: fix(ci): bump BASH32_COMPAT_THRESHOLD 74→78 (CI drift post-merge)

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -260,7 +260,10 @@ FILE_SIZE_THRESHOLD=59
 # GH#19533 attempted ratchet to 74 (claimed actual: 72), but CI reported 76 violations
 # against threshold 74 — same drift pattern as GH#19528. Keeping at 78: 76 violations + 2 buffer.
 # Ratcheted down to 74 (GH#19531): actual violations 72 + 2 buffer
-BASH32_COMPAT_THRESHOLD=74
+# Bumped to 78 (GH#19531 post-merge fix): CI reported 76 violations vs threshold 74 —
+# same drift pattern as GH#19423/19448/19480/19506/19516/19519/19523/19528/19533.
+# Local scan saw 72 violations but CI runner sees 76. 76 + 2 buffer = 78.
+BASH32_COMPAT_THRESHOLD=78
 
 # Qlty maintainability smell baseline (t2065, GH#18773). Seed value for
 # the `.github/workflows/qlty-regression.yml` gate. The gate itself uses


### PR DESCRIPTION
## Summary

Post-merge fix for GH#19531. The ratchet-down to 74 merged, but CI shows 76 violations against the new threshold — same recurring drift (local scan sees 72, CI runner sees 76).

- **Root cause**: Local complexity scan sees 72 bash32 violations; CI runner sees 76.
- **Fix**: Bump threshold back to 78 (76 violations + 2 buffer).
- **Pattern**: 11th consecutive attempt at this ratchet that failed with 72→76 drift.

## Files

- EDIT: `.agents/configs/complexity-thresholds.conf` — bump BASH32_COMPAT_THRESHOLD 74→78

Resolves #19531