### PR TITLE
GH#19541: chore: ratchet-down complexity thresholds

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -178,7 +178,8 @@ FUNCTION_COMPLEXITY_THRESHOLD=31
 # Ratcheted down to 285 (GH#19533): actual violations 283 + 2 buffer
 # Bumped to 290 (GH#19536): proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290.
 # Proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation.
-NESTING_DEPTH_THRESHOLD=290
+# Ratcheted down to 285 (GH#19541): actual violations 283 + 2 buffer
+NESTING_DEPTH_THRESHOLD=285
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Ratchets down `NESTING_DEPTH_THRESHOLD` from 290 to 285 following accumulated simplification wins.

- Actual violations: 283
- New threshold: 285 (283 + 2 buffer)
- Gap from threshold: 7 (283 actual vs 290 threshold)

Resolves #19541

## Changes

- `EDIT: .agents/configs/complexity-thresholds.conf` — lowered `NESTING_DEPTH_THRESHOLD` from 290 to 285, added ratchet-down comment with GH issue ref

## Verification

```
grep NESTING_DEPTH_THRESHOLD .agents/configs/complexity-thresholds.conf
# → NESTING_DEPTH_THRESHOLD=285
```

The `simplification-state.json` file was NOT modified or staged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI configuration thresholds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->