### PR TITLE
GH#19543: chore(ci): bump NESTING_DEPTH_THRESHOLD 285→290

### DIFF
--- a/.agents/configs/complexity-thresholds-history.md
+++ b/.agents/configs/complexity-thresholds-history.md
@@ -88,6 +88,8 @@ Archives the full change history for `.agents/configs/complexity-thresholds.conf
 | 290 | GH#19530 | proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290; proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation |
 | 285 | GH#19533 | ratcheted down — actual violations 283 + 2 buffer |
 | 290 | GH#19536 | proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290; proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation |
+| 285 | GH#19541 | ratcheted down — actual violations 283 + 2 buffer |
+| 290 | GH#19543 | proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290; proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation |
 
 ## FUNCTION_COMPLEXITY_THRESHOLD History
 

--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -179,7 +179,9 @@ FUNCTION_COMPLEXITY_THRESHOLD=31
 # Bumped to 290 (GH#19536): proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290.
 # Proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation.
 # Ratcheted down to 285 (GH#19541): actual violations 283 + 2 buffer
-NESTING_DEPTH_THRESHOLD=285
+# Bumped to 290 (GH#19543): proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290.
+# Proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation.
+NESTING_DEPTH_THRESHOLD=290
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Bumps `NESTING_DEPTH_THRESHOLD` from 285 to 290 in response to the CI nesting proximity guard firing at 283/285 (2 headroom remaining).

**Pattern applied:** violations (283) + 7 headroom = 290. Proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation.

## Changes

- EDIT: `.agents/configs/complexity-thresholds.conf` — bump `NESTING_DEPTH_THRESHOLD` 285→290, add GH#19543 comment entry
- EDIT: `.agents/configs/complexity-thresholds-history.md` — add GH#19541 ratchet-down row and GH#19543 bump row to audit trail

## Verification

CI `Complexity Analysis` check will pass with 283 violations against threshold 290 (7 headroom).

Resolves #19543