### PR TITLE
GH#19544: chore: ratchet-down BASH32_COMPAT_THRESHOLD 78→74 (GH#19544)

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -266,7 +266,8 @@ FILE_SIZE_THRESHOLD=59
 # Bumped to 78 (GH#19531 post-merge fix): CI reported 76 violations vs threshold 74 —
 # same drift pattern as GH#19423/19448/19480/19506/19516/19519/19523/19528/19533.
 # Local scan saw 72 violations but CI runner sees 76. 76 + 2 buffer = 78.
-BASH32_COMPAT_THRESHOLD=78
+# Ratcheted down to 74 (GH#19544): actual violations 72 + 2 buffer
+BASH32_COMPAT_THRESHOLD=74
 
 # Qlty maintainability smell baseline (t2065, GH#18773). Seed value for
 # the `.github/workflows/qlty-regression.yml` gate. The gate itself uses


### PR DESCRIPTION
## Summary

Lowered BASH32_COMPAT_THRESHOLD from 78 to 74 in .agents/configs/complexity-thresholds.conf. Local scan confirms 72 actual violations; 72 + 2 buffer = 74.

## Files Changed

.agents/configs/complexity-thresholds.conf

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Ran .agents/scripts/complexity-scan-helper.sh ratchet-check . 5 — confirmed actual bash32 violations = 72 and ratchet available. Verified simplification-state.json not staged.

Resolves #19544


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.65 plugin for [OpenCode](https://opencode.ai) v1.4.7 with claude-sonnet-4-6 spent 1m and 4,188 tokens on this as a headless worker.