### PR TITLE
GH#19550: chore(ci): bump NESTING_DEPTH_THRESHOLD 285→290

### DIFF
--- a/.agents/configs/complexity-thresholds-history.md
+++ b/.agents/configs/complexity-thresholds-history.md
@@ -90,6 +90,8 @@ Archives the full change history for `.agents/configs/complexity-thresholds.conf
 | 290 | GH#19536 | proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290; proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation |
 | 285 | GH#19541 | ratcheted down — actual violations 283 + 2 buffer |
 | 290 | GH#19543 | proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290; proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation |
+| 285 | GH#19547 | ratcheted down — actual violations 283 + 2 buffer |
+| 290 | GH#19550 | proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290; proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation |
 
 ## FUNCTION_COMPLEXITY_THRESHOLD History
 

--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -182,7 +182,9 @@ FUNCTION_COMPLEXITY_THRESHOLD=31
 # Bumped to 290 (GH#19543): proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290.
 # Proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation.
 # Ratcheted down to 285 (GH#19547): actual violations 283 + 2 buffer
-NESTING_DEPTH_THRESHOLD=285
+# Bumped to 290 (GH#19550): proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290.
+# Proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation.
+NESTING_DEPTH_THRESHOLD=290
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Bumps `NESTING_DEPTH_THRESHOLD` from 285 to 290 to restore headroom after the proximity guard fired at 283/285 (2 headroom remaining).

- **Violations**: 283 (unchanged — no new violations introduced)
- **Old threshold**: 285
- **New threshold**: 290 (283 violations + 7 headroom)
- **Proximity guard** (warn_at = 290-5 = 285): fires when violations exceed 285 (i.e., at 286), preventing saturation

This follows the established bump-and-ratchet pattern documented in `complexity-thresholds-history.md`. A ratchet-down PR will follow after the next batch of simplification-debt work reduces the violation count.

## Files Changed

- EDIT: `.agents/configs/complexity-thresholds.conf` — bump `NESTING_DEPTH_THRESHOLD` 285→290, add history comment
- EDIT: `.agents/configs/complexity-thresholds-history.md` — add GH#19547 ratchet-down entry and GH#19550 bump entry

Resolves #19550

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code complexity validation threshold to allow slightly deeper nesting levels in shell scripts while maintaining quality guardrails.
  * Updated documentation to reflect the new threshold configuration and its proximity-guard behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->