### PR TITLE
GH#19554: chore: ratchet-down complexity thresholds (GH#19554)

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -184,7 +184,8 @@ FUNCTION_COMPLEXITY_THRESHOLD=31
 # Ratcheted down to 285 (GH#19547): actual violations 283 + 2 buffer
 # Bumped to 290 (GH#19550): proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290.
 # Proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation.
-NESTING_DEPTH_THRESHOLD=290
+# Ratcheted down to 285 (GH#19554): actual violations 283 + 2 buffer
+NESTING_DEPTH_THRESHOLD=285
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)
@@ -273,7 +274,8 @@ FILE_SIZE_THRESHOLD=59
 # against threshold 74 — same drift pattern as all prior attempts. Keeping at 78.
 # GH#19551 attempted ratchet to 74 (claimed actual: 72), but CI reported 76 violations
 # against threshold 74 — same drift pattern as all prior attempts. Keeping at 78.
-BASH32_COMPAT_THRESHOLD=78
+# Ratcheted down to 74 (GH#19554): actual violations 72 + 2 buffer
+BASH32_COMPAT_THRESHOLD=74
 
 # Qlty maintainability smell baseline (t2065, GH#18773). Seed value for
 # the `.github/workflows/qlty-regression.yml` gate. The gate itself uses


### PR DESCRIPTION
## Summary

Lowered NESTING_DEPTH_THRESHOLD from 290 to 285 (actual 283) and BASH32_COMPAT_THRESHOLD from 78 to 74 (actual 72) in .agents/configs/complexity-thresholds.conf, each with a ratchet-down audit comment.

## Files Changed

.agents/configs/complexity-thresholds.conf

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** complexity-scan-helper.sh ratchet-check reports actual violations (nest:283, bash32:72) are within new thresholds (nest:285, bash32:74) with no further ratchet-down available (all gaps ≤5).

Resolves #19554


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.65 plugin for [OpenCode](https://opencode.ai) v1.4.7 with claude-sonnet-4-6 spent 1m and 3,800 tokens on this as a headless worker.