### PR TITLE
GH#19559: hotfix: revert BASH32_COMPAT_THRESHOLD 74→78 (GH#19554 post-merge)

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -274,8 +274,9 @@ FILE_SIZE_THRESHOLD=59
 # against threshold 74 — same drift pattern as all prior attempts. Keeping at 78.
 # GH#19551 attempted ratchet to 74 (claimed actual: 72), but CI reported 76 violations
 # against threshold 74 — same drift pattern as all prior attempts. Keeping at 78.
-# Ratcheted down to 74 (GH#19554): actual violations 72 + 2 buffer
-BASH32_COMPAT_THRESHOLD=74
+# GH#19554 attempted ratchet to 74 (claimed actual: 72), but CI reported 76 violations
+# against threshold 74 — same drift pattern as all prior attempts. Keeping at 78.
+BASH32_COMPAT_THRESHOLD=78
 
 # Qlty maintainability smell baseline (t2065, GH#18773). Seed value for
 # the `.github/workflows/qlty-regression.yml` gate. The gate itself uses


### PR DESCRIPTION
## Problem

PR #19555 (issue GH#19554) merged `BASH32_COMPAT_THRESHOLD=74`, but the CI "Bash 3.2 Compatibility" check reports **76 violations** against threshold 74 — this breaks main for all subsequent PRs.

CI job log confirms: `Bash 3.2 compatibility violations: 76` → `##[error]Bash 3.2 compatibility regression: 76 violations (threshold: 74)`.

## Fix

Bump `BASH32_COMPAT_THRESHOLD` back to 78 (76 actual + 2 buffer) and add a history comment documenting the GH#19554 attempt failure.

`NESTING_DEPTH_THRESHOLD=285` from #19555 is valid and unchanged.

## Pattern

This is the same CI/local scanner discrepancy documented in GH#19531 post-merge fix (and GH#19423/19448/19480/19506/19516/19519/19523/19528/19533/19547/19551): local scanner sees 72 violations, CI runner sees 76. Threshold must be set to 78 (76 + 2 buffer) until the 4 extra violations are fixed.

## Verification

CI "Bash 3.2 Compatibility" check will pass with threshold 78 ≥ 76 actual violations.

Resolves #19559