### PR TITLE
GH#19557: GH#19557: chore(ci): bump NESTING_DEPTH_THRESHOLD 285→290 (283 violations + 7 headroom)

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -185,7 +185,9 @@ FUNCTION_COMPLEXITY_THRESHOLD=31
 # Bumped to 290 (GH#19550): proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290.
 # Proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation.
 # Ratcheted down to 285 (GH#19554): actual violations 283 + 2 buffer
-NESTING_DEPTH_THRESHOLD=285
+# Bumped to 290 (GH#19557): proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290.
+# Proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation.
+NESTING_DEPTH_THRESHOLD=290
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Bumped NESTING_DEPTH_THRESHOLD from 285 to 290. Actual violations: 283. New headroom: 7. Proximity guard will fire at 286+ violations (warn_at=285). Follows the established bump-and-ratchet pattern.

## Files Changed

.agents/configs/complexity-thresholds.conf

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified with complexity-scan-helper.sh ratchet-check: func=27/31, nest=283/290, size=57/59, bash32=72/74 — all within thresholds.

Resolves #19557


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.65 plugin for [OpenCode](https://opencode.ai) v1.4.7 with claude-sonnet-4-6 spent 2m and 4,896 tokens on this as a headless worker.