### PR TITLE
GH#19559: fix(ci): bump BASH32_COMPAT_THRESHOLD 74→78 (GH#19554 post-merge CI break)

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -276,8 +276,10 @@ FILE_SIZE_THRESHOLD=59
 # against threshold 74 — same drift pattern as all prior attempts. Keeping at 78.
 # GH#19551 attempted ratchet to 74 (claimed actual: 72), but CI reported 76 violations
 # against threshold 74 — same drift pattern as all prior attempts. Keeping at 78.
-# Ratcheted down to 74 (GH#19554): actual violations 72 + 2 buffer
-BASH32_COMPAT_THRESHOLD=74
+# GH#19554 attempted ratchet to 74 (claimed actual: 72), but CI reported 76 violations
+# against threshold 74 — same drift pattern as all prior attempts. Keeping at 78.
+# GH#19559 (hotfix): reverted to 78 post-GH#19554 merge. CI: 76 violations vs threshold 74.
+BASH32_COMPAT_THRESHOLD=78
 
 # Qlty maintainability smell baseline (t2065, GH#18773). Seed value for
 # the `.github/workflows/qlty-regression.yml` gate. The gate itself uses


### PR DESCRIPTION
## Problem

PR #19555 (GH#19554) merged `BASH32_COMPAT_THRESHOLD=74`, but CI "Bash 3.2 Compatibility" reports **76 violations** against threshold 74, breaking main for all subsequent PRs.

## Root Cause

Same CI/local scanner discrepancy pattern documented in GH#19423/19448/19480/19506/19516/19519/19523/19528/19533/19547/19551: local scanner sees 72 violations, CI runner sees 76. Threshold must be 78 (76 actual + 2 buffer) until the 4 extra violations are resolved.

## Fix

Bumped `BASH32_COMPAT_THRESHOLD` back to 78 and updated the history comment to document:
- GH#19554 attempt failed (same CI/local drift)
- GH#19559 hotfix context

**File:** `.agents/configs/complexity-thresholds.conf`

## Verification

CI "Bash 3.2 Compatibility" check will pass with threshold 78 ≥ 76 actual violations.

Resolves #19559

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.65 plugin for [OpenCode](https://opencode.ai) v1.4.7 with claude-sonnet-4-6 spent 3m and 11,315 tokens on this as a headless worker.