### PR TITLE
GH#19565: bump NESTING_DEPTH_THRESHOLD to 290

### DIFF
--- a/.agents/configs/complexity-thresholds-history.md
+++ b/.agents/configs/complexity-thresholds-history.md
@@ -92,6 +92,10 @@ Archives the full change history for `.agents/configs/complexity-thresholds.conf
 | 290 | GH#19543 | proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290; proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation |
 | 285 | GH#19547 | ratcheted down — actual violations 283 + 2 buffer |
 | 290 | GH#19550 | proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290; proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation |
+| 285 | GH#19554 | ratcheted down — actual violations 283 + 2 buffer |
+| 290 | GH#19557 | proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290; proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation |
+| 285 | GH#19563 | ratcheted down — actual violations 283 + 2 buffer |
+| 290 | GH#19565 | proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290; proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation |
 
 ## FUNCTION_COMPLEXITY_THRESHOLD History
 

--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -188,7 +188,9 @@ FUNCTION_COMPLEXITY_THRESHOLD=31
 # Bumped to 290 (GH#19557): proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290.
 # Proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation.
 # Ratcheted down to 285 (GH#19563): actual violations 283 + 2 buffer
-NESTING_DEPTH_THRESHOLD=285
+# Bumped to 290 (GH#19565): proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290.
+# Proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation.
+NESTING_DEPTH_THRESHOLD=290
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Bumps `NESTING_DEPTH_THRESHOLD` from 285 to 290 to restore adequate headroom after the proximity guard fired at 283/285 (2 headroom remaining).

**Verified violation count**: 283 (CI-identical awk methodology via `lint_shell_files()`).
**New threshold**: 283 + 7 headroom = 290.
**Proximity guard**: `warn_at = 290-5 = 285` — fires when violations exceed 285 (i.e., at 286), preventing saturation before the CI gate.

## Changes

- EDIT: `.agents/configs/complexity-thresholds.conf` — bump `NESTING_DEPTH_THRESHOLD` 285→290, add GH#19565 history comment
- EDIT: `.agents/configs/complexity-thresholds-history.md` — add missing GH#19554/GH#19557/GH#19563 entries that were in conf but not history table, plus new GH#19565 entry

## Pattern

This follows the established bump-and-ratchet cadence documented throughout the conf file. The next ratchet-down PR should target 285 once violations drop to 283 again.

Resolves #19565