### PR TITLE
GH#19569: fix: bump BASH32_COMPAT_THRESHOLD back to 78 (76 violations vs threshold 74)

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -284,8 +284,9 @@ FILE_SIZE_THRESHOLD=59
 # against threshold 74 — same drift pattern as all prior attempts. Keeping at 78.
 # GH#19563 attempted ratchet to 74 (claimed actual: 72), but CI reported 76 violations
 # against threshold 74 — same drift pattern as all prior attempts. Keeping at 78: 76 violations + 2 buffer.
-# Ratcheted down to 74 (GH#19569): actual violations 72 + 2 buffer
-BASH32_COMPAT_THRESHOLD=74
+# GH#19569 attempted ratchet to 74 (claimed actual: 72), but CI reported 76 violations
+# against threshold 74 — same drift pattern as all prior attempts. Keeping at 78: 76 violations + 2 buffer.
+BASH32_COMPAT_THRESHOLD=78
 
 # Qlty maintainability smell baseline (t2065, GH#18773). Seed value for
 # the `.github/workflows/qlty-regression.yml` gate. The gate itself uses


### PR DESCRIPTION
## Summary

PR #19570 merged with `BASH32_COMPAT_THRESHOLD=74`, but CI confirmed **76 violations** against threshold 74 — same drift pattern as all prior ratchet attempts (GH#19395, GH#19396, GH#19423, GH#19448, GH#19480, GH#19506, GH#19516, GH#19519, GH#19523, GH#19528, GH#19533, GH#19547, GH#19551, GH#19554, GH#19563). With 74 on main, every subsequent PR fails the Bash 3.2 Compatibility check.

This PR bumps `BASH32_COMPAT_THRESHOLD` from 74 → 78 (76 violations + 2 buffer) to restore CI green.

The `NESTING_DEPTH_THRESHOLD` ratchet (290 → 285) from PR #19570 is preserved — that change was valid.

## Changes

- `EDIT: .agents/configs/complexity-thresholds.conf` — bump BASH32_COMPAT_THRESHOLD 74 → 78; add audit comment for failed GH#19569 ratchet attempt

For #19569

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code complexity threshold configuration for testing and validation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->