### PR TITLE
GH#19572: chore: bump NESTING_DEPTH_THRESHOLD to 290

### DIFF
--- a/.agents/configs/complexity-thresholds-history.md
+++ b/.agents/configs/complexity-thresholds-history.md
@@ -96,6 +96,8 @@ Archives the full change history for `.agents/configs/complexity-thresholds.conf
 | 290 | GH#19557 | proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290; proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation |
 | 285 | GH#19563 | ratcheted down — actual violations 283 + 2 buffer |
 | 290 | GH#19565 | proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290; proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation |
+| 285 | GH#19569 | ratcheted down — actual violations 283 + 2 buffer |
+| 290 | GH#19572 | proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290; proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation |
 
 ## FUNCTION_COMPLEXITY_THRESHOLD History
 

--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -191,7 +191,9 @@ FUNCTION_COMPLEXITY_THRESHOLD=31
 # Bumped to 290 (GH#19565): proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290.
 # Proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation.
 # Ratcheted down to 285 (GH#19569): actual violations 283 + 2 buffer
-NESTING_DEPTH_THRESHOLD=285
+# Bumped to 290 (GH#19572): proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290.
+# Proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation.
+NESTING_DEPTH_THRESHOLD=290
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Bump \`NESTING_DEPTH_THRESHOLD\` from 285 to 290 to restore headroom after the proximity guard fired.

- **Current violations**: 283
- **Previous threshold**: 285 (2 headroom — proximity guard fires at ≤5 headroom)
- **New threshold**: 290 (283 violations + 7 headroom)
- **Proximity guard** (warn_at = 290-5 = 285) fires when violations exceed 285 (at 286), preventing saturation

## Files Changed

- EDIT: `.agents/configs/complexity-thresholds.conf` — bump `NESTING_DEPTH_THRESHOLD` 285→290, add comment
- EDIT: `.agents/configs/complexity-thresholds-history.md` — add GH#19569 ratchet entry and GH#19572 bump entry

## Pattern

Standard bump-and-ratchet cadence established in GH#17808. Violations have been stable at 283 across multiple ratchet cycles; ratchet-down to 285 triggers the proximity guard within the same release cycle. This is a maintenance bump to unblock in-flight PRs that don't introduce new nesting violations.

Resolves #19572