### PR TITLE
fix: bump BASH32_COMPAT_THRESHOLD to 78 (CI reports 76 violations vs threshold 74)

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -290,7 +290,9 @@ FILE_SIZE_THRESHOLD=59
 # GH#19569 attempted ratchet to 74 (claimed actual: 72), but CI reported 76 violations
 # against threshold 74 — same drift pattern as all prior attempts. Keeping at 78: 76 violations + 2 buffer.
 # Ratcheted down to 74 (GH#19574): actual violations 72 + 2 buffer
-BASH32_COMPAT_THRESHOLD=74
+# Bumped to 78 (GH#19574 post-merge fix): CI reported 76 violations vs threshold 74 —
+# same drift pattern as GH#19569/19563/19554/19547/19533/19531. 76 violations + 2 buffer = 78.
+BASH32_COMPAT_THRESHOLD=78
 
 # Qlty maintainability smell baseline (t2065, GH#18773). Seed value for
 # the `.github/workflows/qlty-regression.yml` gate. The gate itself uses


### PR DESCRIPTION
## Summary

Post-merge hotfix for PR #19575 (GH#19574).

PR #19575 merged `BASH32_COMPAT_THRESHOLD=74` but CI immediately reported 76 violations vs threshold 74 — the same drift pattern observed in GH#19569/19563/19554/19547/19533/19531/19528/19523/19519. Local scan sees 72 violations, CI runner sees 76.

**Changes:**
- `BASH32_COMPAT_THRESHOLD`: 74 → 78 (76 violations + 2 buffer)
- `NESTING_DEPTH_THRESHOLD` stays at 285 — that ratchet passed CI ✅

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.65 plugin for [OpenCode](https://opencode.ai) v1.4.7 with claude-sonnet-4-6 as a headless worker.

For #19574