### PR TITLE
GH#19577: bump NESTING_DEPTH_THRESHOLD to 290

### DIFF
--- a/.agents/configs/complexity-thresholds-history.md
+++ b/.agents/configs/complexity-thresholds-history.md
@@ -98,6 +98,8 @@ Archives the full change history for `.agents/configs/complexity-thresholds.conf
 | 290 | GH#19565 | proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290; proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation |
 | 285 | GH#19569 | ratcheted down — actual violations 283 + 2 buffer |
 | 290 | GH#19572 | proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290; proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation |
+| 285 | GH#19574 | ratcheted down — actual violations 283 + 2 buffer |
+| 290 | GH#19577 | proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290; proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation |
 
 ## FUNCTION_COMPLEXITY_THRESHOLD History
 

--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -194,7 +194,9 @@ FUNCTION_COMPLEXITY_THRESHOLD=31
 # Bumped to 290 (GH#19572): proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290.
 # Proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation.
 # Ratcheted down to 285 (GH#19574): actual violations 283 + 2 buffer
-NESTING_DEPTH_THRESHOLD=285
+# Bumped to 290 (GH#19577): proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290.
+# Proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation.
+NESTING_DEPTH_THRESHOLD=290
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Bumps `NESTING_DEPTH_THRESHOLD` from 285 to 290 to restore headroom after the proximity guard fired at 283/285 (2 headroom remaining — below the 5-unit warning threshold).

- **Current violations**: 283 (verified locally)
- **Previous threshold**: 285
- **New threshold**: 290 (283 violations + 7 headroom)
- **New proximity guard warn_at**: 285 (fires when violations exceed 285, i.e., at 286)

Also adds the missing GH#19574 ratchet entry and this GH#19577 bump entry to `complexity-thresholds-history.md`.

Resolves #19577