### PR TITLE
GH#19581: bump NESTING_DEPTH_THRESHOLD 285→290 (proximity guard)

### DIFF
--- a/.agents/configs/complexity-thresholds-history.md
+++ b/.agents/configs/complexity-thresholds-history.md
@@ -100,6 +100,8 @@ Archives the full change history for `.agents/configs/complexity-thresholds.conf
 | 290 | GH#19572 | proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290; proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation |
 | 285 | GH#19574 | ratcheted down — actual violations 283 + 2 buffer |
 | 290 | GH#19577 | proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290; proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation |
+| 285 | GH#19579 | ratcheted down — actual violations 283 + 2 buffer |
+| 290 | GH#19581 | proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290; proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation |
 
 ## FUNCTION_COMPLEXITY_THRESHOLD History
 

--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -197,7 +197,9 @@ FUNCTION_COMPLEXITY_THRESHOLD=31
 # Bumped to 290 (GH#19577): proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290.
 # Proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation.
 # Ratcheted down to 285 (GH#19579): actual violations 283 + 2 buffer
-NESTING_DEPTH_THRESHOLD=285
+# Bumped to 290 (GH#19581): proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290.
+# Proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation.
+NESTING_DEPTH_THRESHOLD=290
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Bump `NESTING_DEPTH_THRESHOLD` from 285 to 290 to restore adequate headroom after the proximity guard fired at 283/285 (2 headroom remaining).

- Current violations: 283
- Previous threshold: 285
- New threshold: 290 (283 violations + 7 headroom)
- Proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing future saturation

Also adds the missing GH#19579 ratchet entry to `complexity-thresholds-history.md` (the entry was documented in the conf file comments but missing from the history table).

## Files Changed

- EDIT: `.agents/configs/complexity-thresholds.conf` — bumped `NESTING_DEPTH_THRESHOLD` from 285 to 290, added comment entries
- EDIT: `.agents/configs/complexity-thresholds-history.md` — added missing GH#19579 ratchet row + new GH#19581 bump row

## Verification

The `Complexity Analysis` CI check reads `NESTING_DEPTH_THRESHOLD` from this config. With 283 current violations and the threshold at 290, the check will pass with 7 units of headroom.

Resolves #19581