### PR TITLE
GH#19588: chore: bump NESTING_DEPTH_THRESHOLD to 290

### DIFF
--- a/.agents/configs/complexity-thresholds-history.md
+++ b/.agents/configs/complexity-thresholds-history.md
@@ -102,6 +102,8 @@ Archives the full change history for `.agents/configs/complexity-thresholds.conf
 | 290 | GH#19577 | proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290; proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation |
 | 285 | GH#19579 | ratcheted down — actual violations 283 + 2 buffer |
 | 290 | GH#19581 | proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290; proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation |
+| 285 | GH#19586 | ratcheted down — actual violations 283 + 2 buffer |
+| 290 | GH#19588 | proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290; proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation |
 
 ## FUNCTION_COMPLEXITY_THRESHOLD History
 

--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -200,7 +200,9 @@ FUNCTION_COMPLEXITY_THRESHOLD=31
 # Bumped to 290 (GH#19581): proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290.
 # Proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation.
 # Ratcheted down to 285 (GH#19586): actual violations 283 + 2 buffer
-NESTING_DEPTH_THRESHOLD=285
+# Bumped to 290 (GH#19588): proximity guard firing at 283/285 (2 headroom); 283 violations + 7 headroom = 290.
+# Proximity guard (warn_at = 290-5 = 285) fires when violations exceed 285 (i.e., at 286), preventing saturation.
+NESTING_DEPTH_THRESHOLD=290
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)


### PR DESCRIPTION
## Summary

Bumps `NESTING_DEPTH_THRESHOLD` from 285 to 290 to resolve proximity guard warning.

- **Current violations**: 283
- **Previous threshold**: 285 (headroom: 2 — within 5, guard fires)
- **New threshold**: 290 (283 violations + 7 headroom)
- **Proximity guard**: `warn_at = 290 - 5 = 285`; fires when violations exceed 285 (i.e., at 286), preventing saturation

## Changes

- `EDIT: .agents/configs/complexity-thresholds.conf` — bump `NESTING_DEPTH_THRESHOLD` 285→290, add history comment
- `EDIT: .agents/configs/complexity-thresholds-history.md` — add GH#19586 ratchet-down and GH#19588 bump entries

## Verification

CI `Shell nesting depth` check will pass with the new threshold of 290 (283 violations < 290).

Resolves #19588