### PR TITLE
GH#19608: chore: ratchet-down complexity thresholds

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -284,7 +284,10 @@ FILE_SIZE_THRESHOLD=59
 # against threshold 74 — same drift pattern as all prior attempts. Keeping at 78: 76 violations + 2 buffer.
 # GH#19593 attempted ratchet to 74 (claimed actual: 72), but CI reported 76 violations
 # against threshold 74 — same drift pattern as all prior attempts. Keeping at 78: 76 violations + 2 buffer.
-BASH32_COMPAT_THRESHOLD=78
+# Ratcheted down to 74 (GH#19608): actual violations 72 + 2 buffer. Safe to lower because
+# t2171 (GH#19592) changed the blocking gate to per-violation regression; total-count check
+# is now advisory only, so the local-vs-CI drift discrepancy no longer causes failures.
+BASH32_COMPAT_THRESHOLD=74
 
 # Qlty maintainability smell baseline (t2065, GH#18773). Seed value for
 # the `.github/workflows/qlty-regression.yml` gate. The gate itself uses


### PR DESCRIPTION
## Summary

Lowers `BASH32_COMPAT_THRESHOLD` from 78 to 74 as proposed by the automated ratchet-down scanner.

- Actual violations: 72, buffer: +2 → new threshold: 74
- Safe to lower post-t2171 (GH#19592): the blocking CI gate is now per-violation regression (only new violations introduced by a PR fail). The total-count check is now advisory/non-blocking, so the historical local-vs-CI drift discrepancy (local: 72, CI: 76) that caused 14+ failed attempts no longer matters.

## Changes

- `EDIT: .agents/configs/complexity-thresholds.conf` — lowered `BASH32_COMPAT_THRESHOLD` 78→74 with audit comment

## Verification

```
grep BASH32_COMPAT_THRESHOLD .agents/configs/complexity-thresholds.conf
# → BASH32_COMPAT_THRESHOLD=74
git diff --cached --name-only | grep -v simplification-state
# → (empty — state file not staged)
```

Resolves #19608

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.66 plugin for [OpenCode](https://opencode.ai) v1.4.7 with claude-sonnet-4-6 spent 2m and 5,946 tokens on this as a headless worker.