### PR TITLE
t2172: OpenCode 1.4.8+ compat — fix session hang on startup

### DIFF
--- a/.agents/plugins/opencode-aidevops/agent-loader.mjs
+++ b/.agents/plugins/opencode-aidevops/agent-loader.mjs
@@ -168,18 +168,27 @@ export function loadAgentIndex(agentsDir, readIfExists) {
   const content = readIfExists(indexPath);
   if (!content) return loadAgentsFallback(agentsDir);
 
-  const subagentMatch = content.match(
-    /<!--TOON:subagents\[\d+\]\{[^}]+\}:\n([\s\S]*?)-->/,
-  );
-  if (!subagentMatch) return loadAgentsFallback(agentsDir);
-
-  const agents = parseToonSubagentBlock(subagentMatch[1]);
+  // Only register top-level agents (agent picker entries), not leaf
+  // subagents. OpenCode 1.4.8 evaluates permissions per-agent at startup;
+  // 900+ agents causes multi-minute hangs. Subagent routing is handled
+  // internally by the primary agent via the Task tool — no need to register
+  // every leaf file as a selectable agent.
+  const agents = [];
 
   const topLevelMatch = content.match(
     /<!--TOON:agents\[\d+\]\{[^}]+\}:\n([\s\S]*?)-->/,
   );
   if (topLevelMatch) {
     parseTopLevelAgents(topLevelMatch[1], agents);
+  }
+
+  // If no top-level block found, fall back to minimal subagent set
+  if (agents.length === 0) {
+    const subagentMatch = content.match(
+      /<!--TOON:subagents\[\d+\]\{[^}]+\}:\n([\s\S]*?)-->/,
+    );
+    if (!subagentMatch) return loadAgentsFallback(agentsDir);
+    return parseToonSubagentBlock(subagentMatch[1]);
   }
 
   return agents;

--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -95,6 +95,33 @@ function readIfExists(filepath) {
 }
 
 // ---------------------------------------------------------------------------
+// Plugin logging — informational messages gated behind AIDEVOPS_PLUGIN_DEBUG
+// to avoid stderr text overlapping OpenCode's TUI (GH#TBD).
+// Actual errors always use console.error directly.
+// ---------------------------------------------------------------------------
+
+/**
+ * Plugin stderr suppression — prevents [aidevops] informational messages
+ * from rendering over OpenCode's TUI input area. Only actual errors pass
+ * through. Set AIDEVOPS_PLUGIN_DEBUG=1 to see all messages.
+ *
+ * This wraps console.error at the process level so ALL plugin modules
+ * benefit without individual imports.
+ */
+const PLUGIN_DEBUG = !!process.env.AIDEVOPS_PLUGIN_DEBUG;
+if (!PLUGIN_DEBUG) {
+  const _origConsoleError = console.error;
+  console.error = (...args) => {
+    // Let actual errors through (stack traces, "failed", "error" in message)
+    const msg = typeof args[0] === "string" ? args[0] : "";
+    if (msg.startsWith("[aidevops]") && !(/fail|error|warn|disabled/i.test(msg))) {
+      return; // suppress informational [aidevops] messages
+    }
+    _origConsoleError.apply(console, args);
+  };
+}
+
+// ---------------------------------------------------------------------------
 // Main Plugin Export
 // ---------------------------------------------------------------------------
 
@@ -196,7 +223,10 @@ export async function AidevopsPlugin({ directory, client }) {
   return {
     // Config: agent index, MCP registration, OAuth pool injection
     config: async (config) => {
-      await initPoolAuth(client);
+      // HOTFIX: run initPoolAuth non-blocking — OpenCode 1.4.8 blocks
+      // on client.auth.set() inside the config hook. Fire-and-forget so
+      // the config hook can complete and the session becomes responsive.
+      initPoolAuth(client).catch(() => {});
       return configHook(config);
     },
 


### PR DESCRIPTION
## Summary

Hotfix for OpenCode 1.4.8 breaking changes that prevented new sessions from responding to user input.

### Root cause

OpenCode 1.4.8 changed its permission evaluation to be synchronous and O(agents × rules). Combined with three factors in our plugin:

1. `initPoolAuth()` blocks the config hook via `client.auth.set()` (new in 1.4.8's auth pipeline)
2. 962 leaf subagents registered from the TOON index (each evaluated against ~100 permission rules)
3. Plugin `console.error()` messages now render over the TUI input area (because fire-and-forget auth causes messages to arrive after TUI draws)

### Fixes

- **`initPoolAuth` fire-and-forget**: OAuth tokens injected in background, session responsive immediately
- **Suppress stderr TUI overlay**: Gate `[aidevops]` informational messages behind `AIDEVOPS_PLUGIN_DEBUG=1`
- **Agent count 962→9**: Only register top-level agents (Build+, Automate, etc.); subagent routing handled internally via Task tool
- **Bonus**: Fixed broken cloudflare-platform skill symlink

### Testing

- Verified `opencode run "Reply with exactly: HELLO"` completes in ~23s (was hanging indefinitely)
- Verified `opencode debug config` loads plugin in <500ms
- Verified no stderr output without `AIDEVOPS_PLUGIN_DEBUG`
- Verified user TUI session responds to "hi" with full agent greeting

Resolves #19611

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Plugin initialization is now non-blocking, improving startup performance.
  * Debug console output filtering enhanced for clearer error reporting.

* **Bug Fixes**
  * Agent loading logic refactored with improved fallback handling to ensure agents are discovered reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->