### PR TITLE
GH#19486: fix(pulse-triage): bash 3.2 compat — replace ${var^^} with tr

### DIFF
--- a/.agents/scripts/pulse-triage.sh
+++ b/.agents/scripts/pulse-triage.sh
@@ -535,7 +535,8 @@ _reevaluate_stale_continuations() {
 		fi
 
 		cont_state=$(printf '%s' "$cont_info" | jq -r '.state // "OPEN"' 2>/dev/null)
-		if [[ "${cont_state^^}" != "CLOSED" ]]; then
+		cont_state_upper=$(printf '%s' "$cont_state" | tr '[:lower:]' '[:upper:]')
+		if [[ "$cont_state_upper" != "CLOSED" ]]; then
 			all_stale="false"
 			break # Open → work in progress
 		fi


### PR DESCRIPTION
## Summary

- Replace `${cont_state^^}` (Bash 4+ only) with `tr '[:lower:]' '[:upper:]'` at `pulse-triage.sh:538`
- This single line was crashing every pulse cycle under macOS `/bin/bash` 3.2 (used by all launchd plists), blocking all worker dispatch

## Root cause

All launchd plists invoke scripts with `/bin/bash` (macOS 3.2). The `shared-constants.sh` re-exec guard documented in AGENTS.md does not actually exist yet. The `${cont_state^^}` uppercase substitution at line 538 is Bash 4+ syntax that fails with `bad substitution` under 3.2.

## Evidence

```
pulse-triage.sh: line 538: ${cont_state^^}: bad substitution
```

Repeated every pulse cycle in `~/.aidevops/logs/pulse-wrapper.log`, with watchdog kills after each failure.

## Verification

- `shellcheck pulse-triage.sh` — clean
- No other `${var^^}` or `${var,,}` occurrences in pulse scripts
- `tr '[:lower:]' '[:upper:]'` is POSIX-compatible

Resolves #19486