### PR TITLE
GH#19620: fix octal parse trap in claim-task-id + task-id-collision-guard for leading-zero IDs

### DIFF
--- a/.agents/hooks/task-id-collision-guard.sh
+++ b/.agents/hooks/task-id-collision-guard.sh
@@ -287,7 +287,10 @@ _check_message() {
 			_debug "Non-numeric suffix for $tid — skipping"
 			continue
 		fi
-		if [[ "$num" -le "$counter" ]]; then
+		# Force base-10 (10#) so leading-zero IDs like "008", "068" don't trip
+		# bash's octal parser. Same root cause as the _compute_counter_seed bug
+		# in claim-task-id.sh — both fixed in this PR (GH#19620).
+		if ((10#$num <= 10#$counter)); then
 			_debug "$tid ≤ counter ($counter) — allowed"
 			continue
 		fi

--- a/.agents/scripts/claim-task-id.sh
+++ b/.agents/scripts/claim-task-id.sh
@@ -343,8 +343,13 @@ _compute_counter_seed() {
 		if [[ -n "$todo_content" ]]; then
 			local highest
 			highest=$(get_highest_task_id "$todo_content")
-			if [[ "$highest" =~ ^[0-9]+$ ]] && [[ "$highest" -gt 0 ]]; then
-				seed=$((highest + 1))
+			# Force base-10 (10#) so leading-zero IDs like "068" don't trip
+			# bash's octal parser. Without this, repos that have any TODO entry
+			# with t008-t009 or t08x-t09x ranges fail counter bootstrap with
+			# "value too great for base (error token is "068")" on either the
+			# -gt test below or the arithmetic on the next line.
+			if [[ "$highest" =~ ^[0-9]+$ ]] && ((10#$highest > 0)); then
+				seed=$((10#$highest + 1))
 			fi
 		fi
 	fi

--- a/.agents/scripts/tests/test-compute-counter-seed-octal.sh
+++ b/.agents/scripts/tests/test-compute-counter-seed-octal.sh
@@ -1,0 +1,234 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-compute-counter-seed-octal.sh — Regression tests for the octal-leading-
+# zero parse bug in claim-task-id.sh::_compute_counter_seed.
+#
+# Bug: get_highest_task_id returns the literal task-number string (e.g. "068"),
+# and _compute_counter_seed used `[[ "$highest" -gt 0 ]]` and
+# `seed=$((highest + 1))` — both of which trigger bash's octal parser when
+# $highest has a leading zero AND a non-octal digit (8 or 9). Repos with any
+# TODO entry in the t008-t009 or t08x-t09x ranges fail counter bootstrap with:
+#   bash: [[: 068: value too great for base (error token is "068")
+# The fix forces base-10 with `10#$highest` on both the test and the arithmetic.
+#
+# Cases covered:
+#   1. Empty TODO.md → seed=1
+#   2. Non-padded IDs (t005, t042, t100) → seed=highest+1
+#   3. Zero-padded ID t068 (octal-trap trigger) → seed=69 (NOT crash)
+#   4. Zero-padded ID t009 (octal-trap edge) → seed=10
+#   5. Zero-padded ID t007 (valid octal — should still return 8 in base-10) → seed=8
+#   6. Mixed padded + non-padded entries → seed=max+1
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+CLAIM_SCRIPT="${SCRIPT_DIR}/../claim-task-id.sh"
+
+RED=$'\033[0;31m'
+GREEN=$'\033[0;32m'
+NC=$'\033[0m'
+
+PASS=0
+FAIL=0
+ERRORS=""
+
+pass() {
+	local name="${1:-}"
+	printf '%s[PASS]%s %s\n' "$GREEN" "$NC" "$name"
+	PASS=$((PASS + 1))
+	return 0
+}
+
+fail() {
+	local name="${1:-}"
+	local detail="${2:-}"
+	printf '%s[FAIL]%s %s\n' "$RED" "$NC" "$name"
+	[[ -n "$detail" ]] && printf '       %s\n' "$detail"
+	FAIL=$((FAIL + 1))
+	ERRORS="${ERRORS}\n  - ${name}: ${detail}"
+	return 0
+}
+
+# Source claim-task-id.sh to gain access to internal helper functions.
+# BASH_SOURCE guard prevents main() from running on source.
+_source_claim_script() {
+	# shellcheck disable=SC1090
+	if ! source "$CLAIM_SCRIPT" 2>/dev/null; then
+		printf '%s[FATAL]%s Failed to source %s\n' "$RED" "$NC" "$CLAIM_SCRIPT" >&2
+		exit 1
+	fi
+	return 0
+}
+
+# Create a minimal TODO.md in $1 with the given entries.
+_make_todo() {
+	local dir="$1"
+	shift
+	local todo_file="${dir}/TODO.md"
+	{
+		printf '# Tasks\n\n'
+		for entry in "$@"; do
+			printf '%s\n' "$entry"
+		done
+	} >"$todo_file"
+	return 0
+}
+
+_source_claim_script
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+test_empty_todo() {
+	local name="1: _compute_counter_seed — empty TODO.md returns seed=1"
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir'" RETURN
+
+	_make_todo "$tmpdir"
+
+	local seed
+	seed=$(_compute_counter_seed "$tmpdir" 2>&1)
+	if [[ "$seed" == "1" ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected seed=1, got '$seed'"
+	fi
+	return 0
+}
+
+test_unpadded_ids() {
+	local name="2: _compute_counter_seed — unpadded IDs (t005, t042, t100) returns 101"
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir'" RETURN
+
+	_make_todo "$tmpdir" \
+		"- [x] t005 first task" \
+		"- [ ] t042 middle task" \
+		"- [x] t100 highest task"
+
+	local seed
+	seed=$(_compute_counter_seed "$tmpdir" 2>&1)
+	if [[ "$seed" == "101" ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected seed=101, got '$seed'"
+	fi
+	return 0
+}
+
+test_octal_trap_t068() {
+	local name="3: _compute_counter_seed — t068 (octal trap) returns 69 not crash"
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir'" RETURN
+
+	_make_todo "$tmpdir" \
+		"- [x] t042 padded prior" \
+		"- [x] t068 octal-trap trigger"
+
+	local seed
+	seed=$(_compute_counter_seed "$tmpdir" 2>&1)
+	if [[ "$seed" == "69" ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected seed=69, got '$seed' (likely octal parse error)"
+	fi
+	return 0
+}
+
+test_octal_edge_t009() {
+	local name="4: _compute_counter_seed — t009 (octal edge) returns 10"
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir'" RETURN
+
+	_make_todo "$tmpdir" \
+		"- [x] t009 octal-edge trigger"
+
+	local seed
+	seed=$(_compute_counter_seed "$tmpdir" 2>&1)
+	if [[ "$seed" == "10" ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected seed=10, got '$seed' (likely octal parse error)"
+	fi
+	return 0
+}
+
+test_valid_octal_t007() {
+	local name="5: _compute_counter_seed — t007 (valid octal, base-10 forced) returns 8"
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir'" RETURN
+
+	_make_todo "$tmpdir" \
+		"- [x] t007 valid-octal trigger"
+
+	local seed
+	seed=$(_compute_counter_seed "$tmpdir" 2>&1)
+	if [[ "$seed" == "8" ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected seed=8 (10#007+1), got '$seed'"
+	fi
+	return 0
+}
+
+test_mixed_padded_unpadded() {
+	local name="6: _compute_counter_seed — mixed padded/unpadded picks max correctly"
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir'" RETURN
+
+	# Real-world MLW pattern: t042 (padded), t068 (padded, octal-trap),
+	# t101 (unpadded). Expected seed: 102.
+	_make_todo "$tmpdir" \
+		"- [ ] t042 first padded" \
+		"- [x] t068 padded octal-trap" \
+		"- [x] t101 unpadded highest"
+
+	local seed
+	seed=$(_compute_counter_seed "$tmpdir" 2>&1)
+	if [[ "$seed" == "102" ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected seed=102, got '$seed'"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Run all tests
+# ---------------------------------------------------------------------------
+
+main() {
+	printf 'Running _compute_counter_seed octal-trap regression tests...\n\n'
+
+	test_empty_todo
+	test_unpadded_ids
+	test_octal_trap_t068
+	test_octal_edge_t009
+	test_valid_octal_t007
+	test_mixed_padded_unpadded
+
+	printf '\n'
+	printf 'Results: %s passed, %s failed\n' "$PASS" "$FAIL"
+	if [[ "$FAIL" -gt 0 ]]; then
+		printf '\nFailed tests:%b\n' "$ERRORS"
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Fixes the octal-leading-zero crash in two places that handle TODO.md task-ID strings:

1. `.agents/scripts/claim-task-id.sh::_compute_counter_seed` (lines 346-347) — counter bootstrap from TODO.md.
2. `.agents/hooks/task-id-collision-guard.sh` (line 290) — commit-msg hook task-ID validation.

Both crash with `bash: [[: 068: value too great for base (error token is "068")` when bash's default integer parser hits a leading-zero string containing 8 or 9 (i.e. invalid octal).

Resolves #19620.

## Problem

`get_highest_task_id` (claim-task-id.sh:292) compares with `((10#$task_num > 10#$highest))` correctly but stores the literal string at line 301 (`highest="$task_num"`). The single consumer at lines 346-347 then drops the base-10 prefix and bash falls back to default integer parsing → octal for leading-zero values.

`task-id-collision-guard.sh:290` has the same shape: `num=$(printf '%s' "$tid" | tr -d 't')` then `[[ "$num" -le "$counter" ]]` — the moment a tid like `t068` is found in a commit message, the hook crashes instead of validating.

This was discovered during this very PR's commit attempt: the hook started erroring on `008/009/068/08/09` in the commit body's narrative repro examples. The bug fixes itself once merged.

## Fix

Two-line change at each callsite — force base-10 with `10#` on both the `-gt`/`-le` test and the arithmetic. Comments in both spots cross-reference each other so future readers see the pattern.

## Tests

New: `.agents/scripts/tests/test-compute-counter-seed-octal.sh` — 6 cases:

| # | Case | Expected seed |
|---|------|--------------|
| 1 | Empty TODO.md | 1 |
| 2 | Unpadded IDs (t005, t042, t100) | 101 |
| 3 | Octal trap (t068) | 69 |
| 4 | Octal edge (t009) | 10 |
| 5 | Valid octal (t007) — confirms base-10 normalization | 8 |
| 6 | Mixed padded + unpadded | max+1 |

Verification:

```
$ git stash  # revert fix
$ bash .agents/scripts/tests/test-compute-counter-seed-octal.sh
[PASS] 1, 2, 5, 6
[FAIL] 3: ...claim-task-id.sh: line 346: [[: 068: value too great for base
[FAIL] 4: ...claim-task-id.sh: line 346: [[: 009: value too great for base
Results: 4 passed, 2 failed

$ git stash pop  # restore fix
$ bash .agents/scripts/tests/test-compute-counter-seed-octal.sh
Results: 6 passed, 0 failed
```

The hook fix is validated by this very commit landing without `TASK_ID_GUARD_DISABLE=1` after merge — the broken hook required the bypass for the commit that fixes it. (No dedicated hook test added because the hook is invoked by git plumbing and tested via integration; happy to add one if the maintainer prefers.)

Shellcheck clean on all three modified files (only the standard SC1091 info on `shared-constants.sh`).

## Discovery context

Found in `johnwaldo/mylabelwater.com` during an interactive session. TODO.md there contains `t042` and `t068` from earlier framework convention. With no `.task-counter` and remote-counter bootstrap unavailable, `claim-task-id.sh` aborted on the octal trap. Session had to file an issue without a t-prefix and stamp the counter manually at `102` with a `needs-reconcile` note. The `needs-reconcile` workflow can stay — this PR just makes sure new repos in the same shape don't have to use it.

## Scope

Minimal — two-line change at each callsite plus the regression test. Kept `get_highest_task_id` unchanged (it currently returns the literal string for the comparison-display contract; consumers that need a number are responsible for normalising). Open to widening if you'd prefer producer-side normalisation in `get_highest_task_id` instead.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.68 plugin for [OpenCode](https://opencode.ai) v1.4.9 with claude-opus-4-7 spent 23m and 5,420 tokens on this with the user in an interactive session. Overall, 2m since this issue was created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed task ID collision detection and generation to correctly interpret IDs with leading zeros as decimal numbers instead of octal, ensuring proper validation of task references.

* **Tests**
  * Added comprehensive regression test to verify task ID seed computation handles octal-edge cases correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->