### PR TITLE
GH#19624: fix(routine-schedule): recognise 'persistent' as a valid schedule type

### DIFF
--- a/.agents/scripts/routine-schedule-helper.sh
+++ b/.agents/scripts/routine-schedule-helper.sh
@@ -3,7 +3,7 @@
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 # routine-schedule-helper.sh — Deterministic schedule parser for routine evaluation
 #
-# Supports: daily(@HH:MM), weekly(day@HH:MM), monthly(N@HH:MM), cron(5-field-expr)
+# Supports: daily(@HH:MM), weekly(day@HH:MM), monthly(N@HH:MM), cron(5-field-expr), persistent
 # Pure bash date arithmetic, no external deps beyond `date`.
 #
 # Commands:
@@ -170,6 +170,12 @@ _parse_expression() {
 		return 0
 	fi
 
+	# Persistent: lifecycle-managed externally (systemd/launchd), never due via pulse
+	if [[ "$expr" == "persistent" ]]; then
+		printf 'persistent'
+		return 0
+	fi
+
 	printf '%s\n' "ERROR: unrecognised schedule expression '$expr'" >&2
 	return 1
 }
@@ -262,10 +268,11 @@ _schedule_interval_seconds() {
 	local sched_type="$1"
 
 	case "$sched_type" in
-	daily) printf '%d' 86400 ;;     # 24 hours
-	weekly) printf '%d' 604800 ;;   # 7 days
-	monthly) printf '%d' 2592000 ;; # 30 days (approximate)
-	cron) printf '%d' 60 ;;         # 1 minute (cron granularity)
+	daily) printf '%d' 86400 ;;        # 24 hours
+	weekly) printf '%d' 604800 ;;      # 7 days
+	monthly) printf '%d' 2592000 ;;    # 30 days (approximate)
+	cron) printf '%d' 60 ;;            # 1 minute (cron granularity)
+	persistent) printf '%d' 2147483647 ;; # max int — never due via interval check
 	*)
 		printf '%d' 86400
 		;;
@@ -294,6 +301,11 @@ cmd_is_due() {
 
 	local sched_type
 	sched_type=$(printf '%s' "$parsed" | awk '{print $1}')
+
+	# Persistent services are lifecycle-managed externally — never due via pulse
+	if [[ "$sched_type" == "persistent" ]]; then
+		return 1
+	fi
 
 	local now_epoch
 	now_epoch=$(_now_epoch)
@@ -501,6 +513,9 @@ cmd_next_run() {
 		_epoch_to_iso "$next_epoch"
 		printf '\n'
 		;;
+	persistent)
+		printf 'never\n'
+		;;
 	*)
 		printf '%s\n' "ERROR: unknown schedule type '$sched_type'" >&2
 		return 2
@@ -551,6 +566,9 @@ cmd_parse() {
 		local cron_fields
 		cron_fields=$(printf '%s' "$parsed" | sed 's/^cron //')
 		printf 'type=cron fields=%s\n' "$cron_fields"
+		;;
+	persistent)
+		printf 'type=persistent lifecycle=external\n'
 		;;
 	*)
 		printf '%s\n' "ERROR: unknown type '$sched_type'" >&2
@@ -605,6 +623,7 @@ main() {
 		printf '%s\n' "  weekly(day@HH:MM)       Run weekly on day at time (UTC)" >&2
 		printf '%s\n' "  monthly(N@HH:MM)        Run monthly on day N at time (UTC)" >&2
 		printf '%s\n' "  cron(min hour dom mon dow)  Standard 5-field cron expression" >&2
+		printf '%s\n' "  persistent              Externally managed (systemd/launchd), never due via pulse" >&2
 		return 2
 		;;
 	esac


### PR DESCRIPTION
## Summary

- Add `persistent` as a first-class schedule grammar in `routine-schedule-helper.sh`, eliminating ~6000 ERROR log lines per 2-week pulse window
- Persistent services (like r912 Dashboard server) are lifecycle-managed externally by systemd/launchd, not by the pulse scheduler — they should never be marked "due"

## Changes

Single file: `.agents/scripts/routine-schedule-helper.sh` (24 insertions, 5 deletions)

1. **`_parse_expression`**: Recognises bare `persistent` string and emits `persistent` as the parsed type
2. **`cmd_is_due`**: Short-circuits `return 1` (not due) before any time/interval checks — persistent is never due, even on first run (epoch 0)
3. **`cmd_next_run`**: Emits `never` for persistent schedules
4. **`cmd_parse`**: Emits `type=persistent lifecycle=external` for debugging
5. **`_schedule_interval_seconds`**: Returns max-int for persistent (defense-in-depth; the is-due short-circuit is the primary gate)
6. **Help text**: Documents the new grammar alongside existing expressions

## Testing

- `is-due "persistent" 0` → exit 1 (not due, no stderr) ✓
- `is-due "persistent" 1000000` → exit 1 (not due, no stderr) ✓
- `next-run "persistent"` → prints `never` ✓
- `parse "persistent"` → prints `type=persistent lifecycle=external` ✓
- `"persistent extra"` → correctly rejected as unrecognised (exit 2) ✓
- Existing grammars (daily/weekly/monthly/cron) → all pass unchanged ✓
- Existing test suite (`test-pulse-routines-cron-extraction.sh`) → 8/8 pass ✓
- ShellCheck → clean ✓

## MERGE_SUMMARY

**What**: Added `persistent` schedule type to `routine-schedule-helper.sh`
**Why**: Grammar mismatch — `core-routines.sh` seeds r912 with `repeat:persistent` but the evaluator rejected it, producing ~600 ERROR lines/week in pulse logs
**Risk**: Low — additive change to the parser; no existing behaviour modified. All existing tests pass.

Resolves #19624


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.68 plugin for [OpenCode](https://opencode.ai) v1.4.10 with claude-opus-4-6 spent 3m and 7,252 tokens on this as a headless worker.