### PR TITLE
t2178: exclude archived briefs + design/skill docs from Codacy; hide Codacy badge until LOC indexing resolves

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -53,3 +53,22 @@ exclude_paths:
   - ".agents/scripts/higgsfield/higgsfield-image.mjs"
   - ".agents/scripts/higgsfield/higgsfield-video.mjs"
   - ".agents/scripts/higgsfield/higgsfield-commands.mjs"
+  # Archived task briefs (t2178, GH#19636): point-in-time audit records of what
+  # was thought at the time a task was planned. We don't rewrite old briefs —
+  # they're immutable history. Codacy's markdownlint routinely suggests edits
+  # that would actively corrupt their content: joining function identifiers
+  # across whitespace (e.g. `extract _has_active_claim` → `extract_has_active_claim`),
+  # breaking GitHub issue refs (e.g. `#19222` → `# 19222`), eating spaces in
+  # math expressions (`0.95 * (1 - ...)` → `0.95 *(1 - ...)`), mixing emphasis
+  # markers, dedenting code-block content out of its fence, and more. Keeping
+  # these files out of Codacy stops the noise at source. ~428 files, ~55K LOC.
+  - "todo/tasks/**"
+  # Brand design reference library (t2178, GH#19636): heavily-prose markdown
+  # documenting third-party brand guidelines (ClickHouse, NVIDIA, etc.). Not
+  # executable code; style rules like "no trailing space after heading" produce
+  # noise without value on reference material. ~269 files, ~15.8K LOC.
+  - ".agents/tools/design/library/brands/**"
+  # Cloudflare platform skill docs (t2178, GH#19636): 188 prose-heavy markdown
+  # files describing Cloudflare product behaviour. Same category as the brand
+  # library — skill reference material, not source code. ~12.6K LOC.
+  - ".agents/services/hosting/cloudflare-platform-skill/**"

--- a/README.md
+++ b/README.md
@@ -52,7 +52,13 @@ The result: an AI operations platform that manages projects across every busines
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=marcusquinn_aidevops&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=marcusquinn_aidevops)
 [![CodeFactor](https://www.codefactor.io/repository/github/marcusquinn/aidevops/badge)](https://www.codefactor.io/repository/github/marcusquinn/aidevops)
 [![Maintainability](https://qlty.sh/gh/marcusquinn/projects/aidevops/maintainability.svg)](https://qlty.sh/gh/marcusquinn/projects/aidevops)
-[![Codacy Badge](https://app.codacy.com/project/badge/Grade/2b1adbd66c454dae92234341e801b984)](https://app.codacy.com/gh/marcusquinn/aidevops/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
+<!-- Codacy badge temporarily hidden (t2178, GH#19636): Codacy's analyzer dropped
+     ~370K LOC from its index between 2026-04-16 and 2026-04-17 (532K → 162K)
+     while issue count stayed flat, collapsing the displayed grade from A to E
+     despite zero matching repo change. Same signature as prior self-healing
+     glitches on 2026-03-26 and 2026-03-31. SonarCloud, CodeFactor, and qlty.sh
+     still show A. Restore this line once Codacy re-indexes:
+     [![Codacy Badge](https://app.codacy.com/project/badge/Grade/2b1adbd66c454dae92234341e801b984)](https://app.codacy.com/gh/marcusquinn/aidevops/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade) -->
 [![CodeRabbit](https://img.shields.io/badge/CodeRabbit-AI%20Reviews-FF570A?logo=coderabbit&logoColor=white)](https://coderabbit.ai)
 
 <!-- License & Legal -->


### PR DESCRIPTION
## Summary

Codacy dropped ~370K LOC from its index between 2026-04-16 and 2026-04-17 (532K → 162K) while issue count stayed flat, collapsing the displayed grade from **A → E** without any matching repo change. Same signature as the self-healing glitches on 2026-03-26 and 2026-03-31 — this one has been stuck on day 2. SonarCloud, CodeFactor, and qlty.sh still show A.

This PR does the two things we can do from our side without waiting on Codacy support.

## Changes

### 1. Exclude heavy-prose markdown from Codacy (`.codacy.yml`)

| Path | Files | LOC | Why |
|------|------:|----:|-----|
| `todo/tasks/**` | 428 | ~55K | Archived point-in-time briefs. Markdownlint was suggesting edits that would **actively corrupt** content — joining function identifiers (`extract _has_active_claim` → `extract_has_active_claim`), breaking GitHub refs (`#19222` → `# 19222`), eating spaces in math (`0.95 * (1 - ...)` → `0.95 *(1 - ...)`), dedenting code-block content out of its fence, mixing emphasis markers. |
| `.agents/tools/design/library/brands/**` | 269 | ~15.8K | Third-party brand reference material. |
| `.agents/services/hosting/cloudflare-platform-skill/**` | 188 | ~12.6K | Prose skill docs, not executable code. |

Net: ~83K LOC of reference prose stops being policed by a rule set designed for executable source.

### 2. Hide the Codacy badge (`README.md`)

Commented out (not deleted) with an explanatory HTML comment pointing to this PR. **SonarCloud, CodeFactor, Maintainability (qlty.sh), and CodeRabbit badges all remain visible** — all green.

## Why commented rather than deleted

Codacy analysis still runs (we get the PR-level issue gate), just without a badge parading the glitched grade on the README. When Codacy re-indexes and LOC returns to ~530K, restoring the badge is a one-line uncomment.

## Verification

```bash
python3 -c "import yaml; yaml.safe_load(open('.codacy.yml'))"  # valid YAML
rg -c '^\[\!\[' README.md  # quality-badge block count unchanged visually (5 in code block, 1 now hidden)
```

## Not in scope

- **Codacy support ticket** (option b from the diagnostic conversation) — deferred per maintainer direction; will revisit if the glitch persists or recurs.
- **Fixing the actual Codacy LOC index** — that's a Codacy-side problem. They self-healed in 1 day the last two times; this one is day 2.
- **README line 1129** ("Codacy: Multi-tool analysis (0 findings)" in the features list) — the badge was the user-facing surface; the feature-list text is internal prose and will read correctly again once Codacy re-indexes.

Resolves #19636


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.68 plugin for [OpenCode](https://opencode.ai) v1.4.11 with claude-opus-4-7 spent 24m and 7,720 tokens on this with the user in an interactive session. Overall, 3m since this issue was created.