### PR TITLE
t2182: Trim Codacy noise (disable Prospector/PMD, skip Bandit B404, exclude opencode plugin)

### DIFF
--- a/.bandit
+++ b/.bandit
@@ -1,0 +1,20 @@
+# Bandit configuration (t2182, GH#19645)
+#
+# Codacy respects tool-native config files when present in the repo root.
+# This file skips Bandit B404 globally:
+#
+# B404 ("Consider possible security implications associated with the
+# subprocess module") fires on every `import subprocess` regardless of
+# how the module is used. It is a module-existence warning, not a usage
+# warning. Framework scripts legitimately need subprocess to shell out
+# to git, gh, jq, etc. The real risks Bandit catches are:
+#   - B602 subprocess-popen-with-shell-equals-true (kept — real risk)
+#   - B603 subprocess-without-shell-equals-true (kept — false-positive prone
+#     but some real uses; severity Warning means non-fatal)
+#   - B605 start-process-with-a-shell (kept — real risk)
+#   - B606 start-process-with-no-shell (kept — real risk)
+#   - B607 start-process-with-partial-path (kept — real risk)
+# So we only skip B404 specifically, not all subprocess-related rules.
+
+skips:
+  - B404

--- a/.codacy.yml
+++ b/.codacy.yml
@@ -21,6 +21,26 @@
 #   rationale so the setting is not silently reverted to 0 in the dashboard.
 #   API endpoint: PUT /api/v3/organizations/gh/marcusquinn/repositories/aidevops/settings/quality/pull-requests
 #   Current value: {"issueThreshold":{"threshold":10,"minimumSeverity":"Warning"}}
+#
+# Noise-trim rationale (t2182, GH#19645):
+# - prospector disabled: aggregates Pylint + Bandit with extra pydocstyle noise.
+#   pydocstyle alone contributed 305 findings, most from mutually-exclusive rules
+#   (D213 vs D212, D203 vs D211) and numpy-style `----` section underlines we do
+#   not use. Pylint (36 findings) and Bandit (56 findings) run as first-class
+#   tools, so the real signal is preserved.
+# - pmd disabled: PMD's ECMAScript ruleset duplicates ESLint; UnnecessaryBlock
+#   (26 findings) is stylistic preference, not a defect.
+# - Bandit_B404 (`import subprocess` module-existence warning) is suppressed via
+#   .bandit in repo root (Codacy respects tool-native configs).
+#
+# UI-only gap (not fixable via config file):
+# - Semgrep_bash.lang.security.ifs-tampering.ifs-tampering fires 62 times on
+#   legitimate `local IFS=':'` / `IFS=$' \t\n'` / `IFS="$saved_ifs"` idioms.
+#   Per-repo pattern disable is not exposed in the Codacy API (only GET), and
+#   tool-native Semgrep config is not respected by Codacy's Opengrep engine.
+#   To clear these, disable the pattern manually in the Codacy UI at
+#   https://app.codacy.com/gh/marcusquinn/organizations/coding-standards
+#   → Default coding standard → Opengrep → search "ifs-tampering" → uncheck.
 
 ---
 engines:
@@ -34,6 +54,11 @@ engines:
     enabled: true
   eslint:
     enabled: true
+  # Disabled engines (t2182, GH#19645) — see rationale in header comment.
+  prospector:
+    enabled: false
+  pmd:
+    enabled: false
 
 exclude_paths:
   # Archived code is versioned for reference but not actively maintained.
@@ -72,3 +97,11 @@ exclude_paths:
   # files describing Cloudflare product behaviour. Same category as the brand
   # library — skill reference material, not source code. ~12.6K LOC.
   - ".agents/services/hosting/cloudflare-platform-skill/**"
+  # OpenCode plugin sandbox (t2182, GH#19645): .mjs files running inside
+  # OpenCode's plugin host. Semgrep's JS path-traversal and child-process
+  # rules fire on framework-controlled paths (~75 findings: detect-non-literal
+  # -fs-filename, path-join-resolve-traversal, detect-child-process, unsafe-
+  # dynamic-method). The paths are not attacker-controlled — they are sourced
+  # from our own config, task IDs, and session metadata. Excluding the dir
+  # stops the noise; genuine review of plugin changes happens in PR review.
+  - ".agents/plugins/opencode-aidevops/**"


### PR DESCRIPTION
## Summary

Reduce Codacy issue count from ~1044 to ~500 by disabling duplicate/noisy engines and skipping one tautology Bandit pattern. Complements t2178 (PR #19637) which excluded prose-heavy paths.

## Changes

**`.codacy.yml`**
- Disable Prospector engine — aggregates Pylint + Bandit with pydocstyle (305 findings, most from mutually-exclusive D213/D212 and D203/D211 and numpy-style underlines we do not use). Pylint (36) and Bandit (56) continue to run as first-class tools.
- Disable PMD engine — ECMAScript ruleset duplicates ESLint; UnnecessaryBlock (26) is stylistic preference.
- Exclude `.agents/plugins/opencode-aidevops/**` — OpenCode plugin sandbox; ~75 JS Semgrep findings (path-traversal, child-process, unsafe-dynamic-method) fire on framework-controlled paths, not user input.
- Inline comment documents rationale and the one remaining noise source (`Semgrep_bash.lang.security.ifs-tampering`) which must be disabled in the Codacy UI coding standard.

**`.bandit`** (new)
- `skips: ['B404']` — B404 warns on every `import subprocess` existing. Framework scripts legitimately need subprocess. Kept: B602/B603/B605/B606/B607 (actual subprocess risks). Codacy respects tool-native configs.

## Signal kept

Bandit (56 including B603/B607/B310), Pylint, ShellCheck, Lizard complexity, Trivy, Hadolint, markdownlint, Opengrep Security rules (except IFS-tampering, pending UI action).

## Projected impact

| Source | Before | After |
|---|---:|---:|
| Prospector_pydocstyle | 305 | 0 |
| Prospector_bandit (duplicate) | 59 | 0 (Bandit standalone keeps them) |
| Prospector other | 23 | 0 |
| PMD UnnecessaryBlock | 26 | 0 |
| PMD other | 0 | 0 |
| Opengrep on opencode plugin | ~75 | 0 |
| Bandit_B404 | 12 | 0 |
| **Total removed** | **~500** | |
| Issue count | 1044 | **~540** |

Combined with the still-stuck IFS-tampering (62 more if user disables in UI): **~480 remaining** → likely Grade A.

## Verification

- [x] `.codacy.yml` YAML parses (`python3 -c 'import yaml; yaml.safe_load(open(".codacy.yml"))'`)
- [x] `.bandit` YAML parses
- [ ] Codacy re-indexes after merge (usually minutes)
- [ ] Issue count drops to ~500-600 range
- [ ] Grade reaches A or B

## Follow-up

If grade reaches A after this merges, un-hide the Codacy badge in README.md (currently commented out from t2178).

Resolves #19645

---


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.69 plugin for [OpenCode](https://opencode.ai) v1.4.11 with claude-opus-4-7 spent 54m and 103,864 tokens on this with the user in an interactive session.