### PR TITLE
t2179: feat(pulse-merge): coderabbit-nits-ok label to auto-dismiss CR-only CHANGES_REQUESTED reviews

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -220,7 +220,7 @@ Worktrees: `wt switch -c {type}/{name}`. Keep the canonical repo directory on `m
 
 **Git-readiness:** Non-git project with ongoing development? Flag: "No git tracking. Consider `git init` + `aidevops init`."
 
-**Review Bot Gate (t1382):** Before merging: `review-bot-gate-helper.sh check <PR_NUMBER>`. Read bot reviews before merging. Full workflow: `reference/review-bot-gate.md`.
+**Review Bot Gate (t1382):** Before merging: `review-bot-gate-helper.sh check <PR_NUMBER>`. Read bot reviews before merging. Full workflow: `reference/review-bot-gate.md`. **Override:** apply `coderabbit-nits-ok` label to a PR to auto-dismiss CodeRabbit-only CHANGES_REQUESTED reviews on the next merge pass. Label is ignored if a human reviewer also requested changes (t2179).
 
 **Qlty Regression Gate (t2065, GH#18773):** `.github/workflows/qlty-regression.yml` runs `qlty smells --all --sarif` on the PR base and head, compares total smell counts, and fails the check if the PR introduces a net increase. The PR comment includes per-rule and per-file breakdowns of the new smells; SARIF artifacts are uploaded for inspection. Docs-only PRs (touching only `*.md`, `todo/**`, `.github/*.md`) skip the scan automatically. To override with justification (e.g., intentional code introduction that trades a smell for correctness/clarity), add the `ratchet-bump` label to the PR — the gate will pass with a warning. Baseline smell count is seeded in `.agents/configs/complexity-thresholds.conf` as `QLTY_SMELL_THRESHOLD` to anchor future ratchet-down work (t2067). Helper: `.agents/scripts/qlty-regression-helper.sh` (supports `--dry-run` for local spot-checks).
 

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -41,6 +41,7 @@
 #   - _carry_forward_pr_diff                    (t2118)
 #   - _build_review_feedback_section           (t2093)
 #   - _dispatch_pr_fix_worker                   (t2093)
+#   - _pulse_merge_dismiss_coderabbit_nits      (t2179)
 #
 # This was originally a pure move from pulse-wrapper.sh. Later additions
 # (rebase nudges GH#18650/GH#18815, review-feedback routing t2093) live
@@ -682,6 +683,58 @@ _resolve_pr_mergeable_status() {
 }
 
 #######################################
+# Auto-dismiss CodeRabbit-only CHANGES_REQUESTED reviews when the
+# coderabbit-nits-ok PR label has been applied by a maintainer (t2179).
+#
+# Enumerates all CHANGES_REQUESTED reviews on the PR. If any reviewer is
+# NOT coderabbitai[bot], returns 1 immediately — human reviewers are never
+# auto-dismissed. Otherwise dismisses each CodeRabbit review via the GitHub
+# reviews/dismissals API and returns 0.
+#
+# Returns: 0 if all CR reviews dismissed (or none existed)
+#          1 if a non-CR human review is blocking dismissal
+#
+# Arguments: $1=pr_number, $2=repo_slug
+#######################################
+_pulse_merge_dismiss_coderabbit_nits() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local reviews_json review_count has_human ids review_id
+
+	# Fetch all CHANGES_REQUESTED reviews as id+login pairs.
+	reviews_json=$(gh api "repos/${repo_slug}/pulls/${pr_number}/reviews" \
+		--jq '[.[] | select(.state=="CHANGES_REQUESTED") | {id: .id, login: .user.login}]' \
+		2>/dev/null) || reviews_json="[]"
+
+	# No CHANGES_REQUESTED reviews — nothing to dismiss, safe to proceed.
+	review_count=$(printf '%s' "$reviews_json" | jq 'length' 2>/dev/null) || review_count=0
+	if [[ "$review_count" -eq 0 ]]; then
+		return 0
+	fi
+
+	# If any CHANGES_REQUESTED reviewer is not coderabbitai[bot], bail immediately.
+	# Human reviewers are never auto-dismissed regardless of the label.
+	has_human=$(printf '%s' "$reviews_json" | \
+		jq -r '[.[] | select(.login != "coderabbitai[bot]")] | length' 2>/dev/null) || has_human=0
+	if [[ "$has_human" -gt 0 ]]; then
+		return 1
+	fi
+
+	# All CHANGES_REQUESTED reviews are from coderabbitai[bot] — dismiss each.
+	ids=$(printf '%s' "$reviews_json" | jq -r '.[].id' 2>/dev/null) || ids=""
+	while IFS= read -r review_id; do
+		[[ -z "$review_id" ]] && continue
+		gh api -X PUT \
+			"repos/${repo_slug}/pulls/${pr_number}/reviews/${review_id}/dismissals" \
+			-f message="Auto-dismissed: coderabbit-nits-ok label applied by maintainer (PR #${pr_number})" \
+			>/dev/null 2>&1 || true
+		echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — dismissed CodeRabbit review ${review_id} (t2179)" >>"$LOGFILE"
+	done <<<"$ids"
+
+	return 0
+}
+
+#######################################
 # Verify no branch-protection-required check on a PR is in a failed state.
 # Skips PRs with failing CI even when the merge would use --admin
 # (which bypasses branch protection).
@@ -757,21 +810,42 @@ _check_pr_merge_gates() {
 	# cycle picks the issue up with fresh context. Interactive PRs are
 	# always left alone (their humans own the feedback loop); external
 	# contributors go through their own crypto-approval flow.
+	#
+	# t2179: coderabbit-nits-ok override — if the maintainer applied the
+	# label and EVERY CHANGES_REQUESTED reviewer is coderabbitai[bot],
+	# auto-dismiss those reviews and fall through to the next gate. If any
+	# human reviewer is also blocking, the label is ignored.
 	if [[ "$pr_review" == "CHANGES_REQUESTED" ]]; then
-		if [[ -n "$linked_issue" ]]; then
-			local _cr_pr_labels
-			_cr_pr_labels=$(gh pr view "$pr_number" --repo "$repo_slug" \
-				--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || _cr_pr_labels=""
-			# Route if origin:worker present (origin:interactive may co-exist
-			# from issue inheritance — not a skip signal for worker PRs).
-			if [[ ",${_cr_pr_labels}," == *",origin:worker,"* &&
-				",${_cr_pr_labels}," != *",external-contributor,"* &&
-				",${_cr_pr_labels}," != *",review-routed-to-issue,"* ]]; then
-				_dispatch_pr_fix_worker "$pr_number" "$repo_slug" "$linked_issue" || true
+		# Fetch labels once — reused by both the nits-ok check and the
+		# worker-routing block below.
+		local _cr_pr_labels
+		_cr_pr_labels=$(gh pr view "$pr_number" --repo "$repo_slug" \
+			--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || _cr_pr_labels=""
+
+		# t2179: coderabbit-nits-ok path.
+		if [[ ",${_cr_pr_labels}," == *",coderabbit-nits-ok,"* ]]; then
+			if _pulse_merge_dismiss_coderabbit_nits "$pr_number" "$repo_slug"; then
+				echo "[pulse-wrapper] Merge pass: PR #${pr_number} in ${repo_slug} — auto-dismissed CodeRabbit-only CHANGES_REQUESTED reviews (coderabbit-nits-ok label) (t2179)" >>"$LOGFILE"
+				# Fall through to the next gate — do NOT return 1.
+			else
+				echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — coderabbit-nits-ok label present but human reviewer also blocking (t2179)" >>"$LOGFILE"
+				return 1
 			fi
+		else
+			# No coderabbit-nits-ok label — route worker-authored PRs for fix
+			# dispatch and skip the merge.
+			if [[ -n "$linked_issue" ]]; then
+				# Route if origin:worker present (origin:interactive may co-exist
+				# from issue inheritance — not a skip signal for worker PRs).
+				if [[ ",${_cr_pr_labels}," == *",origin:worker,"* &&
+					",${_cr_pr_labels}," != *",external-contributor,"* &&
+					",${_cr_pr_labels}," != *",review-routed-to-issue,"* ]]; then
+					_dispatch_pr_fix_worker "$pr_number" "$repo_slug" "$linked_issue" || true
+				fi
+			fi
+			echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — reviewDecision=CHANGES_REQUESTED" >>"$LOGFILE"
+			return 1
 		fi
-		echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — reviewDecision=CHANGES_REQUESTED" >>"$LOGFILE"
-		return 1
 	fi
 
 	# Skip external contributor PRs (non-collaborator)

--- a/.agents/scripts/tests/test-pulse-merge-coderabbit-nits-ok.sh
+++ b/.agents/scripts/tests/test-pulse-merge-coderabbit-nits-ok.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Tests for _pulse_merge_dismiss_coderabbit_nits() (t2179).
+#
+# When a maintainer applies the coderabbit-nits-ok label to a PR whose only
+# CHANGES_REQUESTED reviewers are coderabbitai[bot], the pulse merge gate
+# should auto-dismiss those reviews and fall through instead of skipping. If
+# any human reviewer is also blocking, the label is ignored and the normal
+# skip behaviour applies.
+#
+# These tests exercise the helper in isolation with a mock `gh` stub. No
+# real repository is touched.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+MERGE_SCRIPT="${SCRIPT_DIR}/../pulse-merge.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+GH_LOG=""
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+# Reset review fixture to the default (two CR-only CHANGES_REQUESTED reviews).
+reset_mock_state() {
+	: >"$GH_LOG"
+	cat >"${TEST_ROOT}/reviews.json" <<'EOF'
+[
+  {"id": 1001, "user": {"login": "coderabbitai[bot]"}, "state": "CHANGES_REQUESTED"},
+  {"id": 1002, "user": {"login": "coderabbitai[bot]"}, "state": "CHANGES_REQUESTED"}
+]
+EOF
+	return 0
+}
+
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+	mkdir -p "${TEST_ROOT}/bin"
+	export PATH="${TEST_ROOT}/bin:${PATH}"
+	export LOGFILE="${TEST_ROOT}/pulse.log"
+	: >"$LOGFILE"
+	GH_LOG="${TEST_ROOT}/gh-calls.log"
+	: >"$GH_LOG"
+	export TEST_ROOT GH_LOG
+
+	# Mock gh: logs every call and returns canned data from TEST_ROOT fixtures.
+	cat >"${TEST_ROOT}/bin/gh" <<'GHEOF'
+#!/usr/bin/env bash
+printf '%s\n' "gh $*" >>"${GH_LOG:-/dev/null}"
+
+_all_args=("$@")
+
+if [[ "${1:-}" == "api" ]]; then
+	# Extract --jq filter if present.
+	_jq_filter=""
+	for _i in "${!_all_args[@]}"; do
+		if [[ "${_all_args[$_i]}" == "--jq" ]]; then
+			_jq_filter="${_all_args[$((_i + 1))]:-}"
+			break
+		fi
+	done
+
+	# GET /reviews
+	if [[ "$*" == *"/pulls/"*"/reviews"* && "$*" != *"dismissals"* && "$*" != *"-X PUT"* ]]; then
+		if [[ -n "$_jq_filter" ]]; then
+			jq "$_jq_filter" <"${TEST_ROOT}/reviews.json"
+		else
+			cat "${TEST_ROOT}/reviews.json"
+		fi
+		exit 0
+	fi
+
+	# PUT /reviews/.../dismissals
+	if [[ "$*" == *"dismissals"* || "$*" == *"-X PUT"* ]]; then
+		exit 0
+	fi
+fi
+
+exit 0
+GHEOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+	return 0
+}
+
+teardown_test_env() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+# Extract _pulse_merge_dismiss_coderabbit_nits from pulse-merge.sh.
+define_helper_under_test() {
+	local src
+	src=$(awk '
+		/^_pulse_merge_dismiss_coderabbit_nits\(\) \{/,/^}$/ { print }
+	' "$MERGE_SCRIPT")
+	if [[ -z "$src" ]]; then
+		printf 'ERROR: could not extract _pulse_merge_dismiss_coderabbit_nits from %s\n' "$MERGE_SCRIPT" >&2
+		return 1
+	fi
+	# shellcheck disable=SC1090
+	eval "$src"
+	return 0
+}
+
+# =============================================================================
+# Case A: no coderabbit-nits-ok label — caller-level; function always has
+# CR-only reviews but the calling gate checks the label first. Test the
+# helper directly: it should dismiss CR-only reviews when called.
+# (The label check lives in _check_pr_merge_gates, not in the helper itself.)
+# =============================================================================
+
+test_case_a_cr_only_reviews_dismissed_returns_0() {
+	reset_mock_state
+	# Default fixture: two CR-only CHANGES_REQUESTED reviews.
+	local result
+	_pulse_merge_dismiss_coderabbit_nits "100" "owner/repo"
+	result=$?
+
+	if [[ "$result" -ne 0 ]]; then
+		print_result "Case A: CR-only reviews — helper returns 0" 1 \
+			"Expected exit 0, got ${result}"
+		return 0
+	fi
+	# Verify dismissal API calls were made for both review IDs.
+	if ! grep -q "dismissals" "$GH_LOG"; then
+		print_result "Case A: CR-only reviews — dismiss API called" 1 \
+			"Expected dismissals API call in log. Log: $(cat "$GH_LOG")"
+		return 0
+	fi
+	# Verify log messages were written.
+	if ! grep -qF "dismissed CodeRabbit review" "$LOGFILE"; then
+		print_result "Case A: CR-only reviews — dismissal logged" 1 \
+			"Expected dismissal log entry. Log: $(cat "$LOGFILE")"
+		return 0
+	fi
+	print_result "Case A: CR-only reviews — dismissed and returns 0" 0
+	return 0
+}
+
+# =============================================================================
+# Case B: mixed reviewers (CR + human) — helper must return 1, no dismissals.
+# =============================================================================
+
+test_case_b_mixed_reviewers_returns_1_no_dismissals() {
+	reset_mock_state
+	# Override fixture: one CR review + one human review.
+	cat >"${TEST_ROOT}/reviews.json" <<'EOF'
+[
+  {"id": 2001, "user": {"login": "coderabbitai[bot]"}, "state": "CHANGES_REQUESTED"},
+  {"id": 2002, "user": {"login": "human-reviewer"}, "state": "CHANGES_REQUESTED"}
+]
+EOF
+	: >"$GH_LOG"
+
+	local result
+	_pulse_merge_dismiss_coderabbit_nits "200" "owner/repo" || result=$?
+	result=${result:-0}
+
+	if [[ "$result" -eq 0 ]]; then
+		print_result "Case B: mixed reviewers — helper returns 1" 1 \
+			"Expected exit 1 (human reviewer blocking), got exit 0"
+		return 0
+	fi
+	# Verify no dismissal API calls were made.
+	if grep -q "dismissals" "$GH_LOG"; then
+		print_result "Case B: mixed reviewers — no dismissals called" 1 \
+			"Expected zero dismissals calls. Log: $(cat "$GH_LOG")"
+		return 0
+	fi
+	print_result "Case B: mixed reviewers — returns 1, no dismissals" 0
+	return 0
+}
+
+# =============================================================================
+# Case C: zero CHANGES_REQUESTED reviews — degenerate safe case, returns 0.
+# =============================================================================
+
+test_case_c_no_changes_requested_reviews_returns_0() {
+	reset_mock_state
+	# Override fixture: no CHANGES_REQUESTED reviews (e.g. already dismissed).
+	cat >"${TEST_ROOT}/reviews.json" <<'EOF'
+[
+  {"id": 3001, "user": {"login": "coderabbitai[bot]"}, "state": "APPROVED"}
+]
+EOF
+	: >"$GH_LOG"
+
+	local result
+	_pulse_merge_dismiss_coderabbit_nits "300" "owner/repo"
+	result=$?
+
+	if [[ "$result" -ne 0 ]]; then
+		print_result "Case C: no CHANGES_REQUESTED reviews — returns 0" 1 \
+			"Expected exit 0 (nothing to dismiss), got ${result}"
+		return 0
+	fi
+	# No dismissal calls needed.
+	if grep -q "dismissals" "$GH_LOG"; then
+		print_result "Case C: no CHANGES_REQUESTED reviews — no API calls" 1 \
+			"Expected zero dismissals calls. Log: $(cat "$GH_LOG")"
+		return 0
+	fi
+	print_result "Case C: no CHANGES_REQUESTED reviews — returns 0, no API calls" 0
+	return 0
+}
+
+# =============================================================================
+# Case D: empty reviews array — returns 0, no API calls.
+# =============================================================================
+
+test_case_d_empty_reviews_array_returns_0() {
+	reset_mock_state
+	echo '[]' >"${TEST_ROOT}/reviews.json"
+	: >"$GH_LOG"
+
+	local result
+	_pulse_merge_dismiss_coderabbit_nits "400" "owner/repo"
+	result=$?
+
+	if [[ "$result" -ne 0 ]]; then
+		print_result "Case D: empty reviews array — returns 0" 1 \
+			"Expected exit 0, got ${result}"
+		return 0
+	fi
+	if grep -q "dismissals" "$GH_LOG"; then
+		print_result "Case D: empty reviews array — no API calls" 1 \
+			"Expected zero API calls. Log: $(cat "$GH_LOG")"
+		return 0
+	fi
+	print_result "Case D: empty reviews array — returns 0, no API calls" 0
+	return 0
+}
+
+main() {
+	trap teardown_test_env EXIT
+	setup_test_env
+
+	if ! define_helper_under_test; then
+		printf 'FATAL: helper extraction failed\n' >&2
+		return 1
+	fi
+
+	test_case_a_cr_only_reviews_dismissed_returns_0
+	test_case_b_mixed_reviewers_returns_1_no_dismissals
+	test_case_c_no_changes_requested_reviews_returns_0
+	test_case_d_empty_reviews_array_returns_0
+
+	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Adds the `coderabbit-nits-ok` PR label that allows a maintainer to signal "I've read CodeRabbit's nits, ship it." When applied, the pulse merge gate auto-dismisses any CHANGES_REQUESTED reviews from `coderabbitai[bot]` and falls through to the next gate instead of skipping the merge.

## What changed

- **`pulse-merge.sh`**: Added `_pulse_merge_dismiss_coderabbit_nits()` helper that enumerates CHANGES_REQUESTED reviews, validates all are from `coderabbitai[bot]`, and dismisses each with an audit message. Extended `_check_pr_merge_gates` CHANGES_REQUESTED branch to check the label before existing routing — label-absent and mixed-reviewer paths preserve prior behaviour exactly.
- **`tests/test-pulse-merge-coderabbit-nits-ok.sh`**: New test file covering all 4 cases: CR-only (dismiss+proceed), mixed reviewers (no dismiss+return 1), no CHANGES_REQUESTED (safe return 0), empty array (safe return 0).
- **`.agents/AGENTS.md`**: One-line addition under "Review Bot Gate (t1382)" documenting the override label.

## Verification

- `bash .agents/scripts/tests/test-pulse-merge-coderabbit-nits-ok.sh` → 4/4 pass
- `shellcheck .agents/scripts/pulse-merge.sh` → zero violations
- `shellcheck .agents/scripts/tests/test-pulse-merge-coderabbit-nits-ok.sh` → zero violations

## New File Smell Justification

The new test file follows the identical structure of `test-pulse-merge-fix-worker-dispatch.sh` — it is a fixture-driven shell test, not a source module. Test files in `.agents/scripts/tests/` are deliberately excluded from the qlty smell gate.

Resolves #19639