### PR TITLE
t2180: feat(claim-task-id): pre-claim discovery pass

### DIFF
--- a/.agents/scripts/claim-task-id.sh
+++ b/.agents/scripts/claim-task-id.sh
@@ -38,9 +38,10 @@
 #   CLI flags --remote and --counter-branch override .aidevops.json values.
 #
 # Exit codes:
-#   0 - Success (outputs: task_id=tNNN ref=GH#NNN or GL#NNN)
-#   1 - Error (network failure, git error, etc.)
-#   2 - Offline fallback used (outputs: task_id=tNNN ref=offline)
+#   0  - Success (outputs: task_id=tNNN ref=GH#NNN or GL#NNN)
+#   1  - Error (network failure, git error, etc.)
+#   2  - Offline fallback used (outputs: task_id=tNNN ref=offline)
+#   10 - User declined claim after duplicate warning (interactive TTY only, t2180)
 #
 # Algorithm (CAS loop — compare-and-swap via git push):
 #   1. git fetch <remote> <counter_branch>
@@ -1375,6 +1376,175 @@ _main_output_results() {
 	return 0
 }
 
+# Pre-claim discovery pass (t2180).
+# Runs before atomic ID allocation to surface similar in-flight or recently-merged PRs.
+# Prevents duplicate work (concrete evidence: PR #19494 duplicated merged PR #19495,
+# costing ~30 min of session time + 10 CI runs).
+#
+# Args:
+#   $1 — title   (the --title value passed to claim-task-id.sh)
+#   $2 — repo_slug (e.g. "marcusquinn/aidevops")
+#
+# Returns:
+#   0  — no relevant hits, or user confirmed (interactive), or non-interactive (warns + proceeds)
+#   10 — user declined claim after duplicate warning (interactive TTY only)
+#
+# Fail-open on: gh not installed, unauthenticated, jq not installed, network error.
+# Skip when:    NO_ISSUE=true, OFFLINE_MODE=true, DRY_RUN=true, or title empty.
+#
+# Configuration:
+#   AIDEVOPS_CLAIM_DEDUP_DAYS  (default 14) — recency window for merged PRs.
+#
+# Test hooks (unit tests only — not for production use):
+#   _AIDEVOPS_CLAIM_TEST_IS_TTY    "1" → force interactive path even in non-TTY test runner
+#   _AIDEVOPS_CLAIM_TEST_ANSWER    "y" or "n" → override the user's prompt answer
+_pre_claim_discovery_pass() {
+	local title="$1"
+	local repo_slug="$2"
+	local dedup_days="${AIDEVOPS_CLAIM_DEDUP_DAYS:-14}"
+
+	# Fail-open gates — any missing dependency aborts silently
+	[[ -z "$title" || -z "$repo_slug" ]] && return 0
+	command -v gh &>/dev/null || return 0
+	command -v jq &>/dev/null || return 0
+	gh auth status &>/dev/null 2>&1 || return 0
+
+	# --- Keyword extraction ---
+	# Lowercase and strip non-alphanumeric, filter short tokens and stop words,
+	# sort by length descending (longer = more discriminating), take top 4.
+	local stop=" feat fix chore add update remove delete get set the for to a an with from into via of at on in by and or is are was not use uses using new be do did does its it "
+	local sanitized
+	sanitized=$(printf '%s' "$title" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9' ' ')
+
+	local -a keywords=()
+	local -a raw_tokens=()
+	# Split sanitized string on whitespace into array (avoids SC2086 glob risk)
+	IFS=' ' read -ra raw_tokens <<< "$sanitized"
+	local token
+	for token in "${raw_tokens[@]}"; do
+		[[ -z "$token" ]] && continue
+		[[ ${#token} -lt 4 ]] && continue
+		[[ "$stop" == *" ${token} "* ]] && continue
+		keywords+=("$token")
+	done
+
+	[[ ${#keywords[@]} -eq 0 ]] && return 0
+
+	# Bubble-sort by length descending
+	local n="${#keywords[@]}"
+	local i j nxt tmp_kw
+	for ((i = 0; i < n - 1; i++)); do
+		for ((j = 0; j < n - i - 1; j++)); do
+			nxt=$((j + 1))
+			if [[ ${#keywords[$j]} -lt ${#keywords[$nxt]} ]]; then
+				tmp_kw="${keywords[$j]}"
+				keywords[$j]="${keywords[$nxt]}"
+				keywords[$nxt]="$tmp_kw"
+			fi
+		done
+	done
+
+	# Top 4 keywords joined with " OR " for GitHub's OR search semantics
+	local -a top_kw=()
+	local k
+	for ((k = 0; k < n && k < 4; k++)); do
+		top_kw+=("${keywords[$k]}")
+	done
+
+	local query
+	query=$(printf '%s OR ' "${top_kw[@]}")
+	query="${query% OR }"  # strip trailing " OR "
+
+	# --- GitHub PR search ---
+	local gh_output=""
+	gh_output=$(gh pr list --repo "$repo_slug" --state all \
+		--search "$query" --limit 5 \
+		--json number,title,state,mergedAt,createdAt 2>/dev/null) || return 0
+	[[ -z "$gh_output" || "$gh_output" == "[]" ]] && return 0
+
+	# --- Filter: relevance (>= 2 keyword overlap) + recency ---
+	local now_epoch cutoff_epoch
+	now_epoch=$(date +%s 2>/dev/null || echo "0")
+	cutoff_epoch=$((now_epoch - dedup_days * 86400))
+
+	local -a relevant_hits=()
+	local pr_num pr_title pr_state pr_merged_at
+
+	while IFS='|' read -r pr_num pr_title pr_state pr_merged_at; do
+		[[ -z "$pr_num" ]] && continue
+
+		# Skip CLOSED (not merged) PRs
+		[[ "$pr_state" == "CLOSED" ]] && continue
+
+		# Recency filter for MERGED PRs
+		if [[ "$pr_state" == "MERGED" && -n "$pr_merged_at" ]]; then
+			local merged_epoch=0
+			merged_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$pr_merged_at" +%s 2>/dev/null) \
+				|| merged_epoch=$(date --date="$pr_merged_at" +%s 2>/dev/null) \
+				|| true
+			if [[ "$merged_epoch" -gt 0 && "$merged_epoch" -lt "$cutoff_epoch" ]]; then
+				continue
+			fi
+		fi
+
+		# Relevance: >= 2 keywords from top_kw must appear in the hit title
+		local pr_lower overlap kw
+		pr_lower=$(printf '%s' "$pr_title" | tr '[:upper:]' '[:lower:]')
+		overlap=0
+		for kw in "${top_kw[@]}"; do
+			[[ "$pr_lower" == *"$kw"* ]] && overlap=$((overlap + 1))
+		done
+		[[ $overlap -lt 2 ]] && continue
+
+		local display_date="${pr_merged_at:-open}"
+		relevant_hits+=("#${pr_num} [${pr_state}] ${pr_title}  (${display_date})")
+	done < <(printf '%s' "$gh_output" | jq -r '.[] | "\(.number)|\(.title)|\(.state)|\(.mergedAt // "")"')
+
+	[[ ${#relevant_hits[@]} -eq 0 ]] && return 0
+
+	# --- TTY detection (test-overridable) ---
+	local is_tty=false
+	if [[ "${_AIDEVOPS_CLAIM_TEST_IS_TTY:-0}" == "1" ]]; then
+		is_tty=true
+	elif [[ -t 0 && -t 1 ]]; then
+		is_tty=true
+	fi
+
+	local hit_count="${#relevant_hits[@]}"
+	local max_show=3
+
+	if [[ "$is_tty" == "true" ]]; then
+		# Interactive: numbered list + Y/N prompt (default N = safe)
+		printf '\n[claim-task-id] WARNING: Found %d similar PR(s) — please check before claiming a new task ID:\n' "$hit_count" >&2
+		local h
+		for ((h = 0; h < hit_count && h < max_show; h++)); do
+			printf '  \xe2\x80\xa2 %s\n' "${relevant_hits[$h]}" >&2
+		done
+		printf '\nContinue claiming a new ID? [y/N]: ' >&2
+
+		# Test hook: supply answer without real TTY interaction
+		local answer="${_AIDEVOPS_CLAIM_TEST_ANSWER:-}"
+		if [[ -z "$answer" ]]; then
+			IFS= read -r answer </dev/tty 2>/dev/null || answer="n"
+		fi
+		local answer_lower
+		answer_lower=$(printf '%s' "$answer" | tr '[:upper:]' '[:lower:]')
+
+		if [[ "$answer_lower" != "y" && "$answer_lower" != "yes" ]]; then
+			printf '[claim-task-id] Claim aborted — verify the PRs above before proceeding.\n' >&2
+			return 10
+		fi
+	else
+		# Non-interactive: structured stderr warnings, proceed (workers can't answer prompts)
+		local h
+		for ((h = 0; h < hit_count && h < max_show; h++)); do
+			printf '[claim-task-id] WARN: similar PR found: %s\n' "${relevant_hits[$h]}" >&2
+		done
+	fi
+
+	return 0
+}
+
 # Main execution
 main() {
 	parse_args "$@"
@@ -1390,6 +1560,21 @@ main() {
 	# Framework routing guard: warn if title looks like a framework issue
 	# but we're not in the aidevops repo (GH#5149)
 	check_framework_routing "$TASK_TITLE" "$REPO_PATH"
+
+	# Pre-claim discovery pass: surface similar in-flight or recently-merged PRs (t2180).
+	# Skipped when --no-issue, --offline, --dry-run, or title is absent (batch mode).
+	if [[ "$NO_ISSUE" == "false" && "$OFFLINE_MODE" == "false" && "$DRY_RUN" == "false" && -n "$TASK_TITLE" ]]; then
+		local _disc_slug=""
+		_disc_slug=$(git -C "$REPO_PATH" remote get-url "$REMOTE_NAME" 2>/dev/null \
+			| sed 's|.*github\.com[:/]||;s|\.git$||' || true)
+		if [[ -n "$_disc_slug" ]]; then
+			local _disc_rc=0
+			_pre_claim_discovery_pass "$TASK_TITLE" "$_disc_slug" || _disc_rc=$?
+			if [[ $_disc_rc -eq 10 ]]; then
+				return 10
+			fi
+		fi
+	fi
 
 	log_info "Using remote: ${REMOTE_NAME}, counter branch: ${COUNTER_BRANCH}"
 

--- a/.agents/scripts/tests/test-claim-task-id-discovery.sh
+++ b/.agents/scripts/tests/test-claim-task-id-discovery.sh
@@ -1,0 +1,346 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-claim-task-id-discovery.sh — Unit tests for _pre_claim_discovery_pass (t2180)
+#
+# Validates the pre-claim discovery pass added to claim-task-id.sh that surfaces
+# similar in-flight or recently-merged PRs before allocating a new task ID.
+#
+# Cases covered:
+#   A: no PR hits → no warning, return 0 (normal claim)
+#   B: hits + interactive TTY + user answers "n" → return 10 (claim aborted)
+#   C: hits + interactive TTY + user answers "y" → return 0 (claim proceeds)
+#   D: hits + non-interactive (worker/CI) → structured stderr warnings, return 0
+#   E: gh unauthenticated/offline → fail-open, no warnings, return 0
+#
+# Mock strategy: a fake "gh" binary in a tmpdir is prepended to PATH.
+# The fake reads from a fixture file whose path is exported as GH_MOCK_FIXTURE.
+# _AIDEVOPS_CLAIM_TEST_IS_TTY and _AIDEVOPS_CLAIM_TEST_ANSWER override the
+# TTY detection and user-prompt branches without requiring a real terminal.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+CLAIM_SCRIPT="${SCRIPT_DIR}/../claim-task-id.sh"
+
+RED=$'\033[0;31m'
+GREEN=$'\033[0;32m'
+NC=$'\033[0m'
+
+PASS=0
+FAIL=0
+ERRORS=""
+
+# ---------------------------------------------------------------------------
+# Test framework helpers
+# ---------------------------------------------------------------------------
+
+pass() {
+	local name="${1:-}"
+	printf '%s[PASS]%s %s\n' "$GREEN" "$NC" "$name"
+	PASS=$((PASS + 1))
+	return 0
+}
+
+fail() {
+	local name="${1:-}"
+	local detail="${2:-}"
+	printf '%s[FAIL]%s %s\n' "$RED" "$NC" "$name"
+	[[ -n "$detail" ]] && printf '       %s\n' "$detail"
+	FAIL=$((FAIL + 1))
+	ERRORS="${ERRORS}\n  - ${name}: ${detail}"
+	return 0
+}
+
+# Source claim-task-id.sh to gain access to _pre_claim_discovery_pass.
+# The BASH_SOURCE guard prevents main() from running on source.
+_source_claim_script() {
+	# shellcheck disable=SC1090
+	if ! source "$CLAIM_SCRIPT" 2>/dev/null; then
+		printf '%s[FATAL]%s Failed to source %s\n' "$RED" "$NC" "$CLAIM_SCRIPT" >&2
+		exit 1
+	fi
+	return 0
+}
+
+# Create a mock "gh" binary in $1/gh that:
+#   - Returns 0 for "gh auth status"
+#   - Reads fixture JSON from $GH_MOCK_FIXTURE for "gh pr list"
+#   - Returns 0 for anything else
+_make_gh_mock() {
+	local bindir="$1"
+	local fixture_file="$2"
+	local gh_bin="${bindir}/gh"
+
+	cat >"$gh_bin" <<'MOCK_EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "auth" && "${2:-}" == "status" ]]; then
+	exit 0
+fi
+if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
+	cat "${GH_MOCK_FIXTURE}"
+	exit 0
+fi
+exit 0
+MOCK_EOF
+	chmod +x "$gh_bin"
+	export GH_MOCK_FIXTURE="$fixture_file"
+	return 0
+}
+
+# Create a mock "gh" that returns 1 for auth status (simulates offline/unauthed)
+_make_gh_mock_offline() {
+	local bindir="$1"
+	local gh_bin="${bindir}/gh"
+
+	cat >"$gh_bin" <<'MOCK_EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "auth" && "${2:-}" == "status" ]]; then
+	exit 1
+fi
+exit 0
+MOCK_EOF
+	chmod +x "$gh_bin"
+	return 0
+}
+
+# Fixture JSON: two PRs with enough keyword overlap to be "relevant"
+# to a title like "add video seo transcript schema agents"
+# Keywords extracted: transcript(10), schema(6), agents(6), video(5)
+# PR #19495: merged 2026-04-17 (within 14 days of test date 2026-04-18)
+# PR #19494: open
+_fixture_relevant_prs() {
+	cat <<'JSON'
+[
+  {
+    "number": 19495,
+    "title": "t2167: add video-seo, transcript-seo, video-schema agents",
+    "state": "MERGED",
+    "mergedAt": "2026-04-17T10:00:00Z",
+    "createdAt": "2026-04-16T08:00:00Z"
+  },
+  {
+    "number": 19494,
+    "title": "t2167: add video-schema, transcript agents (duplicate)",
+    "state": "OPEN",
+    "mergedAt": null,
+    "createdAt": "2026-04-17T09:00:00Z"
+  }
+]
+JSON
+}
+
+# ---------------------------------------------------------------------------
+# Source once for all tests
+# ---------------------------------------------------------------------------
+
+_source_claim_script
+
+# The title used in Cases A-D; chosen so keywords
+# (transcript, schema, agents, video) overlap with the fixture PR titles.
+_TEST_TITLE="add video seo transcript schema agents"
+_TEST_SLUG="marcusquinn/aidevops"
+
+# ---------------------------------------------------------------------------
+# Case A: no hits → no warning, return 0
+# ---------------------------------------------------------------------------
+
+test_case_a_no_hits() {
+	local name="A: no PR hits → no warning, return 0"
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir'" RETURN
+
+	local fixture="${tmpdir}/fixture.json"
+	printf '[]' >"$fixture"
+	_make_gh_mock "$tmpdir" "$fixture"
+
+	local saved_path="$PATH"
+	PATH="${tmpdir}:${PATH}"
+
+	# Clear test hooks
+	unset _AIDEVOPS_CLAIM_TEST_IS_TTY _AIDEVOPS_CLAIM_TEST_ANSWER 2>/dev/null || true
+
+	local stderr_output rc=0
+	stderr_output=$(_pre_claim_discovery_pass "$_TEST_TITLE" "$_TEST_SLUG" 2>&1) \
+		|| rc=$?
+
+	PATH="$saved_path"
+
+	if [[ $rc -eq 0 && -z "$stderr_output" ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected rc=0 empty stderr, got rc=${rc} stderr='${stderr_output}'"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Case B: hits + interactive + user answers "n" → return 10
+# ---------------------------------------------------------------------------
+
+test_case_b_interactive_decline() {
+	local name="B: hits + interactive + user 'n' → return 10 (claim aborted)"
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir'" RETURN
+
+	local fixture="${tmpdir}/fixture.json"
+	_fixture_relevant_prs >"$fixture"
+	_make_gh_mock "$tmpdir" "$fixture"
+
+	local saved_path="$PATH"
+	PATH="${tmpdir}:${PATH}"
+
+	export _AIDEVOPS_CLAIM_TEST_IS_TTY=1
+	export _AIDEVOPS_CLAIM_TEST_ANSWER="n"
+
+	local rc=0
+	_pre_claim_discovery_pass "$_TEST_TITLE" "$_TEST_SLUG" 2>/dev/null || rc=$?
+
+	unset _AIDEVOPS_CLAIM_TEST_IS_TTY _AIDEVOPS_CLAIM_TEST_ANSWER
+	PATH="$saved_path"
+
+	if [[ $rc -eq 10 ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected rc=10 (declined), got rc=${rc}"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Case C: hits + interactive + user answers "y" → return 0 (proceed)
+# ---------------------------------------------------------------------------
+
+test_case_c_interactive_confirm() {
+	local name="C: hits + interactive + user 'y' → return 0 (claim proceeds)"
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir'" RETURN
+
+	local fixture="${tmpdir}/fixture.json"
+	_fixture_relevant_prs >"$fixture"
+	_make_gh_mock "$tmpdir" "$fixture"
+
+	local saved_path="$PATH"
+	PATH="${tmpdir}:${PATH}"
+
+	export _AIDEVOPS_CLAIM_TEST_IS_TTY=1
+	export _AIDEVOPS_CLAIM_TEST_ANSWER="y"
+
+	local rc=0
+	_pre_claim_discovery_pass "$_TEST_TITLE" "$_TEST_SLUG" 2>/dev/null || rc=$?
+
+	unset _AIDEVOPS_CLAIM_TEST_IS_TTY _AIDEVOPS_CLAIM_TEST_ANSWER
+	PATH="$saved_path"
+
+	if [[ $rc -eq 0 ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected rc=0 (confirmed), got rc=${rc}"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Case D: hits + non-interactive → structured stderr warnings, return 0
+# ---------------------------------------------------------------------------
+
+test_case_d_noninteractive_warns() {
+	local name="D: hits + non-interactive → WARN lines to stderr, return 0"
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir'" RETURN
+
+	local fixture="${tmpdir}/fixture.json"
+	_fixture_relevant_prs >"$fixture"
+	_make_gh_mock "$tmpdir" "$fixture"
+
+	local saved_path="$PATH"
+	PATH="${tmpdir}:${PATH}"
+
+	# Ensure TTY hook is NOT set (simulates worker/CI environment)
+	unset _AIDEVOPS_CLAIM_TEST_IS_TTY _AIDEVOPS_CLAIM_TEST_ANSWER 2>/dev/null || true
+	export _AIDEVOPS_CLAIM_TEST_IS_TTY=0
+
+	local stderr_output rc=0
+	stderr_output=$(_pre_claim_discovery_pass "$_TEST_TITLE" "$_TEST_SLUG" 2>&1) \
+		|| rc=$?
+
+	unset _AIDEVOPS_CLAIM_TEST_IS_TTY
+	PATH="$saved_path"
+
+	local has_warn=false
+	if printf '%s' "$stderr_output" | grep -q '\[claim-task-id\] WARN: similar PR found:'; then
+		has_warn=true
+	fi
+
+	if [[ $rc -eq 0 && "$has_warn" == "true" ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected rc=0 with WARN lines, got rc=${rc} stderr='${stderr_output}'"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Case E: gh unauthenticated/offline → fail-open, no warnings, return 0
+# ---------------------------------------------------------------------------
+
+test_case_e_gh_offline() {
+	local name="E: gh auth fails (offline/unauthed) → fail-open, no warnings, return 0"
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir'" RETURN
+
+	_make_gh_mock_offline "$tmpdir"
+
+	local saved_path="$PATH"
+	PATH="${tmpdir}:${PATH}"
+
+	unset _AIDEVOPS_CLAIM_TEST_IS_TTY _AIDEVOPS_CLAIM_TEST_ANSWER 2>/dev/null || true
+
+	local stderr_output rc=0
+	stderr_output=$(_pre_claim_discovery_pass "$_TEST_TITLE" "$_TEST_SLUG" 2>&1) \
+		|| rc=$?
+
+	PATH="$saved_path"
+
+	if [[ $rc -eq 0 && -z "$stderr_output" ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected rc=0 empty stderr, got rc=${rc} stderr='${stderr_output}'"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Run all tests
+# ---------------------------------------------------------------------------
+
+main() {
+	printf 'Running claim-task-id pre-claim discovery pass tests (t2180)...\n\n'
+
+	test_case_a_no_hits
+	test_case_b_interactive_decline
+	test_case_c_interactive_confirm
+	test_case_d_noninteractive_warns
+	test_case_e_gh_offline
+
+	printf '\n'
+	printf 'Results: %s passed, %s failed\n' "$PASS" "$FAIL"
+	if [[ "$FAIL" -gt 0 ]]; then
+		printf '\nFailed tests:%b\n' "$ERRORS"
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Adds a `_pre_claim_discovery_pass` helper to `claim-task-id.sh` that runs a GitHub PR search before atomically allocating a new task ID. Surfaces similar in-flight or recently-merged PRs (within a configurable recency window, default 14 days) to prevent the duplicate-work pattern that cost ~30 min of session time in the t2167/PR#19494 incident.

**Behaviour:**
- **Interactive TTY**: prints up to 3 matching PRs, prompts Y/N (default N), exits 10 on decline
- **Non-interactive (workers/CI/pulse)**: prints structured `[claim-task-id] WARN:` lines to stderr, proceeds (workers can't answer prompts — the audit log is the deterrent)
- **Fail-open**: silently skips if `gh` unavailable, unauthenticated, `jq` missing, or network fails
- **Skipped**: when `--no-issue`, `--offline`, `--dry-run`, or title absent (batch mode)
- **Configurable**: `AIDEVOPS_CLAIM_DEDUP_DAYS` env var (default 14) controls the merged-PR recency window

**New exit code 10**: user declined claim after duplicate warning (interactive only).

## Changes

- **EDIT:** `.agents/scripts/claim-task-id.sh` — add `_pre_claim_discovery_pass` helper (~120 lines), wire into `main()` after `check_framework_routing`, update exit-code docs
- **NEW:** `.agents/scripts/tests/test-claim-task-id-discovery.sh` — 5 test cases (A: no hits, B: interactive+N, C: interactive+Y, D: non-interactive warns, E: offline fail-open); all pass

## Verification

```
bash .agents/scripts/tests/test-claim-task-id-discovery.sh  # 5/5 pass
bash .agents/scripts/tests/test-claim-task-id-todo-collision.sh  # 8/8 pass (regression)
shellcheck .agents/scripts/claim-task-id.sh  # SC1091 info only (pre-existing)
```

Resolves #19638


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.70 plugin for [OpenCode](https://opencode.ai) v1.4.11 with claude-sonnet-4-6 spent 7m and 24,724 tokens on this as a headless worker.