### PR TITLE
GH#19660: t2187: document opencode run-mode Tool.execute OTEL span gap

### DIFF
--- a/.agents/plugins/opencode-aidevops/otel-enrichment.mjs
+++ b/.agents/plugins/opencode-aidevops/otel-enrichment.mjs
@@ -5,6 +5,15 @@
 // the AsyncLocalStorage context manager so nested code (our plugin hooks
 // included) observes the active span via @opentelemetry/api's `trace.getActiveSpan()`.
 //
+// KNOWN LIMITATION (t2187, 2026-04-18): in `run` mode (opencode v1.4.11),
+// the Tool.execute span is defined in the Effect-TS pipeline but does not
+// propagate to OTEL. The AI SDK's Promise-based tool execution boundary
+// breaks the AsyncLocalStorageContextManager context, so getActiveSpan()
+// returns undefined for every tool call in headless run mode. Outer
+// orchestration spans (Config.*, Session.*, etc.) are unaffected.
+// Plugin-side SQLite recording is independent and works in all modes.
+// See reference/observability.md "Known limitation: run mode" for details.
+//
 // This module offers a dynamic, fail-soft path to enrich that span with
 // aidevops-specific attributes (intent, task_id, session_origin, runtime)
 // WITHOUT adding @opentelemetry/api as a hard dependency. If the module

--- a/.agents/reference/observability.md
+++ b/.agents/reference/observability.md
@@ -113,17 +113,85 @@ Stuck-worker thresholds (informational):
 
 The helper exposes data for course-correction; it does not kill the session.
 
+## Known limitation: `run` mode does not emit per-tool OTEL spans (t2187)
+
+**Verified against:** opencode v1.4.11 (Bun-compiled), Jaeger all-in-one,
+2026-04-18. 471 spans / 108 unique operations observed; zero `Tool.execute`
+spans among them.
+
+**What works in `run` mode:** outer orchestration spans — `Config.*`,
+`FileSystem.*`, `Session.*`, `ToolRegistry.*`, `Auth.*`, `SessionPrompt.*`,
+`Git.*`, `Npm.*`, `Bus.*`. These confirm the `@effect/opentelemetry` bridge
+and `OTLPTraceExporter` are active.
+
+**What is missing:** per-tool-call `Tool.execute` spans. The span IS defined
+in the opencode source (`Effect.withSpan("Tool.execute", {attributes})`),
+but it does not appear in the OTEL export in `run` mode.
+
+**Root cause:** opencode uses Effect-TS internally. Tool execution is
+wrapped in `withSpan("Tool.execute")` inside the Effect pipeline, which
+the `@effect/opentelemetry` bridge should convert to OTEL spans. However,
+in `run` mode the AI SDK drives tool execution by calling an `execute()`
+function that returns a `Promise`. The tool's Effect code re-enters via
+`Effect.promise(Effect.gen(...))` — a Promise boundary that creates a
+new async context. The `AsyncLocalStorageContextManager` that
+`@effect/opentelemetry` relies on does not propagate the parent span
+across this Effect → Promise → Effect transition, so the `Tool.execute`
+span is either orphaned or never exported.
+
+The outer orchestration spans work because they run on the main Effect
+fiber where the OTEL tracer layer is provided. Tool execution runs inside
+the AI SDK's Promise-based callback chain, which exits and re-enters the
+Effect runtime without the tracer context.
+
+**Classification:** architectural consequence (outcome (a) from the
+t2187 brief). Not a config flag to toggle, not a simple bug — it is
+a structural gap in how `run` mode integrates with the AI SDK's
+tool interface.
+
+**Impact on aidevops plugin:** the plugin's `enrichActiveSpan()` in
+`otel-enrichment.mjs` calls `trace.getActiveSpan()` inside
+`tool.execute.before` / `tool.execute.after` hooks. When opencode
+does not create a `Tool.execute` span, `getActiveSpan()` returns
+`undefined` and the enrichment silently no-ops. The `aidevops.*`
+attributes (`intent`, `task_id`, `session_origin`, `runtime`) are
+therefore invisible in OTEL traces for headless `run` mode sessions.
+Plugin-side SQLite (`tool_calls` table) is unaffected — it records
+independently of OTEL.
+
+**Decision on plugin-owned fallback spans:** creating plugin-owned
+spans when opencode does not provide one would produce orphan traces
+under a separate service name (`opencode-aidevops`), disconnected
+from the Session/Config trace tree. The cost of implementation is low
+but the value is marginal — orphan spans without parent context are
+hard to correlate in Jaeger/Tempo and do not meaningfully improve the
+audit trail over what plugin SQLite already provides. **Status quo
+accepted**: rely on plugin SQLite for per-tool observability in `run`
+mode. Re-evaluate if opencode fixes the span gap upstream or if a
+future version exposes a tracer handle to plugins.
+
+**Upstream status:** the `opencode-ai/opencode` GitHub repo is archived
+(legacy Go codebase). The current v1.4.x is Bun-compiled TypeScript
+distributed via npm; no public issue tracker for the TypeScript version
+was identified as of 2026-04-18. The span gap may be resolved in a
+future release if the AI SDK integration switches to a span-preserving
+execution model. Monitor opencode release notes for OTEL changes.
+
 ## Verifying the OTEL integration
 
 After pointing opencode at a collector and restarting:
 
 1. Run any tool call in opencode (e.g. `ls`).
-2. Check the collector received an `opencode.tool.*` span.
-3. Expand the span's attributes — verify both opencode-native keys
-   (`session.id`, `message.id`) and aidevops-specific keys
-   (`aidevops.intent`, `aidevops.task_id`, …) are present.
+2. Check the collector received spans (look for `Config.*`,
+   `Session.*`, `ToolRegistry.*` — these confirm the bridge works).
+3. Expand a span's attributes — verify opencode-native keys
+   (`session.id`, `message.id`) are present.
+4. Check for `aidevops.*` attributes. **In TUI/server mode**, these
+   should appear on `Tool.execute` spans. **In `run` mode**, they
+   will be absent due to the known limitation above — verify via
+   plugin SQLite instead (`observability-helper.sh recent 10`).
 
-If aidevops attributes are missing:
+If aidevops attributes are missing in a mode where they should work:
 
 - Verify the plugin loaded: `AIDEVOPS_PLUGIN_DEBUG=1 opencode run ...`
   should emit `[aidevops]` startup lines.


### PR DESCRIPTION
## Summary

Root cause analysis of missing Tool.execute OTEL spans in opencode v1.4.11 run mode. The span exists in the Effect-TS pipeline but the AI SDK's Promise-based tool execution boundary breaks the AsyncLocalStorageContextManager context propagation. Documented finding in reference/observability.md with a 'Known limitation' section covering root cause, impact on aidevops plugin enrichment, and the decision to accept status quo (plugin SQLite covers per-tool observability). Updated otel-enrichment.mjs module comment to reference the limitation.

## Files Changed

.agents/plugins/opencode-aidevops/otel-enrichment.mjs,.agents/reference/observability.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified observability.md renders correctly. Confirmed upstream repo (opencode-ai/opencode) is archived (legacy Go codebase). Binary analysis confirmed Tool.execute span definition exists but does not propagate in run mode.

Resolves #19660


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.70 plugin for [OpenCode](https://opencode.ai) v1.4.11 with claude-opus-4-6 spent 6m and 14,577 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Documented a known limitation in run mode where individual tool execution spans are not emitted to OpenTelemetry, though outer orchestration spans remain unaffected.
- Updated observability verification procedures and troubleshooting guidance with alternative methods for per-tool monitoring when standard span attributes are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->