### PR TITLE
GH#19668: fix trap chaining, fixed-string dedup, and --issue validation in issue-sync-relationships.sh

### DIFF
--- a/.agents/scripts/issue-sync-relationships.sh
+++ b/.agents/scripts/issue-sync-relationships.sh
@@ -47,9 +47,12 @@ _NODE_ID_CACHE_FILE=""
 
 _init_node_id_cache() {
 	if [[ -z "$_NODE_ID_CACHE_FILE" ]]; then
-		_NODE_ID_CACHE_FILE=$(mktemp /tmp/aidevops-node-cache.XXXXXX)
+		_NODE_ID_CACHE_FILE=$(mktemp "${TMPDIR:-/tmp}/aidevops-node-cache.XXXXXX")
+		# Chain onto any existing EXIT trap rather than replacing it.
+		local _prev_trap
+		_prev_trap=$(trap -p EXIT | sed -E "s/^trap -- '(.*)' EXIT$/\1/")
 		# shellcheck disable=SC2064
-		trap "rm -f '$_NODE_ID_CACHE_FILE'" EXIT
+		trap "rm -f '$_NODE_ID_CACHE_FILE'${_prev_trap:+; $_prev_trap}" EXIT
 	fi
 	return 0
 }
@@ -405,7 +408,7 @@ cmd_relationships() {
 	local unique_tasks=()
 	local t
 	for t in "${tasks[@]}"; do
-		if ! echo "$seen_list" | grep -qx "$t"; then
+		if ! printf '%s' "$seen_list" | grep -Fxq -- "$t"; then
 			unique_tasks+=("$t")
 			seen_list="${seen_list}${t}"$'\n'
 		fi
@@ -675,7 +678,11 @@ cmd_backfill_sub_issues() {
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--issue)
-			target_issue="${2:-}"
+			if [[ -z "${2:-}" ]]; then
+				print_error "backfill-sub-issues: --issue requires an issue number"
+				return 1
+			fi
+			target_issue="$2"
 			shift 2
 			;;
 		*)


### PR DESCRIPTION
## Summary

Three CodeRabbit findings from PR #19613 review, all verified correct:

1. **Trap chaining** (`_init_node_id_cache`): changed `/tmp` → `\${TMPDIR:-/tmp}` and chains onto existing EXIT trap via `trap -p` + sed instead of silently replacing it, preventing cleanup handlers from being lost when this module is sourced by callers that install their own EXIT trap.

2. **Fixed-string dedup** (task collection loop): replaced `echo "$seen_list" | grep -qx "$t"` with `printf '%s' "$seen_list" | grep -Fxq -- "$t"` — without `-F`, dot-notation task IDs like `t2114.1` had their dots treated as BRE wildcards, allowing false dedup matches against e.g. `t211411`.

3. **`--issue` argument validation** (`cmd_backfill_sub_issues`): added guard for empty/missing value; now `print_error` + `return 1` when `--issue` is the last argument, preventing silent empty assignment followed by a `shift 2` crash under `set -e` and the unintended bulk-500-issue enumeration path.

## Verification

- `shellcheck` passes with zero new violations (SC2016 info notices are pre-existing GraphQL query strings, unrelated to these changes)
- All three fixes are minimal and localised; no logic flow changes beyond the added guard

Resolves #19668