### PR TITLE
GH#19670: fix combined-flag detection in assoc-array and nameref patterns

### DIFF
--- a/.agents/scripts/complexity-regression-helper.sh
+++ b/.agents/scripts/complexity-regression-helper.sh
@@ -348,7 +348,7 @@ scan_dir_bash32_compat() {
 		done <<<"$_matches"
 
 		# Pattern 2: Associative arrays (bash 4.0+)
-		_matches=$(grep -nE '^[[:space:]]*(declare|local|typeset)[[:space:]]+-A[[:space:]]' "$_file" 2>/dev/null |
+		_matches=$(grep -nE '^[[:space:]]*(declare|local|typeset)[[:space:]]+-[a-zA-Z]*A[a-zA-Z]*[[:space:]]' "$_file" 2>/dev/null |
 			grep -vE '^[0-9]+:[[:space:]]*#' || true)
 		while IFS= read -r _match; do
 			[ -n "$_match" ] || continue
@@ -357,7 +357,7 @@ scan_dir_bash32_compat() {
 		done <<<"$_matches"
 
 		# Pattern 3: Namerefs (bash 4.3+)
-		_matches=$(grep -nE '^[[:space:]]*(declare|local)[[:space:]]+-n[[:space:]]' "$_file" 2>/dev/null |
+		_matches=$(grep -nE '^[[:space:]]*(declare|local)[[:space:]]+-[a-zA-Z]*n[a-zA-Z]*[[:space:]]' "$_file" 2>/dev/null |
 			grep -vE '^[0-9]+:[[:space:]]*#' || true)
 		while IFS= read -r _match; do
 			[ -n "$_match" ] || continue


### PR DESCRIPTION
## Summary

Extends the bash 4.0+ associative array and bash 4.3+ nameref regex patterns in `complexity-regression-helper.sh` to detect combined flag forms (e.g. `declare -Ar`, `local -nr`) in addition to the single-flag forms already handled.

**Changes:**
- `.agents/scripts/complexity-regression-helper.sh:351`: `-A[[:space:]]` → `-[a-zA-Z]*A[a-zA-Z]*[[:space:]]`
- `.agents/scripts/complexity-regression-helper.sh:360`: `-n[[:space:]]` → `-[a-zA-Z]*n[a-zA-Z]*[[:space:]]`

**Verification:** `shellcheck .agents/scripts/complexity-regression-helper.sh` passes with zero violations.

Resolves #19670


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.70 plugin for [OpenCode](https://opencode.ai) v1.4.11 with claude-sonnet-4-6 spent 1m and 2,641 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal pattern detection logic for improved accuracy and broader coverage of syntax variations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->