### PR TITLE
GH#19664: trim INTENT_PARAM_SCHEMA description to reduce per-request token cost

### DIFF
--- a/.agents/plugins/opencode-aidevops/provider-auth-request.mjs
+++ b/.agents/plugins/opencode-aidevops/provider-auth-request.mjs
@@ -126,9 +126,7 @@ const INTENT_PARAM_NAME = "agent__intent";
 const INTENT_PARAM_SCHEMA = Object.freeze({
   type: "string",
   description:
-    "Intent tracing (observability). One sentence in present participle form describing " +
-    "your intent for this tool call (e.g., \"Reading the file to understand the existing schema\"). " +
-    "No trailing period. Stripped before tool execution — used only for debugging and audit trails.",
+    "Intent tracing: one sentence in present participle form describing your intent for this tool call (no trailing period).",
 });
 
 /**


### PR DESCRIPTION
## Summary

Shortens the `INTENT_PARAM_SCHEMA.description` in `provider-auth-request.mjs` from ~50 tokens to ~20 tokens.

The verbose form (example, "Stripped before tool execution" note) ships with every tool definition on every request. The system prompt already teaches the full intent-tracing concept, so the in-schema description only needs to communicate the key guidance to the LLM: present-participle form, no trailing period.

**Before:**
```js
"Intent tracing (observability). One sentence in present participle form describing " +
"your intent for this tool call (e.g., \"Reading the file to understand the existing schema\"). " +
"No trailing period. Stripped before tool execution — used only for debugging and audit trails."
```

**After:**
```js
"Intent tracing: one sentence in present participle form describing your intent for this tool call (no trailing period)."
```

## Testing

All 12 tests in `test-intent-schema-injection.mjs` pass — the tests assert `description.length > 0`, not the specific text.

Resolves #19664