### PR TITLE
GH#19665: GH#19665: fix Effect.runPromise terminology and session-introspect-helper.sh naming in observability.md

### DIFF
--- a/.agents/reference/observability.md
+++ b/.agents/reference/observability.md
@@ -133,7 +133,7 @@ wrapped in `withSpan("Tool.execute")` inside the Effect pipeline, which
 the `@effect/opentelemetry` bridge should convert to OTEL spans. However,
 in `run` mode the AI SDK drives tool execution by calling an `execute()`
 function that returns a `Promise`. The tool's Effect code re-enters via
-`Effect.promise(Effect.gen(...))` — a Promise boundary that creates a
+`Effect.runPromise(Effect.gen(...))` — a Promise boundary that creates a
 new async context. The `AsyncLocalStorageContextManager` that
 `@effect/opentelemetry` relies on does not propagate the parent span
 across this Effect → Promise → Effect transition, so the `Tool.execute`
@@ -189,7 +189,7 @@ After pointing opencode at a collector and restarting:
 4. Check for `aidevops.*` attributes. **In TUI/server mode**, these
    should appear on `Tool.execute` spans. **In `run` mode**, they
    will be absent due to the known limitation above — verify via
-   plugin SQLite instead (`observability-helper.sh recent 10`).
+   plugin SQLite instead (`session-introspect-helper.sh recent 10`).
 
 If aidevops attributes are missing in a mode where they should work:
 


### PR DESCRIPTION
## Summary

Fixed two inaccuracies in .agents/reference/observability.md flagged by Gemini review bot on PR #19662: (1) corrected Effect.runPromise (was Effect.promise) — Effect.promise wraps a Promise into an Effect, while Effect.runPromise runs an Effect returning a Promise, which is what the async boundary description requires; (2) corrected session-introspect-helper.sh recent 10 (was observability-helper.sh recent 10) — the recent subcommand belongs to session-introspect-helper.sh as documented at line 89, while observability-helper.sh handles cache-health and rate-limits.

## Files Changed

.agents/reference/observability.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified both file references against the documented script interfaces in observability.md lines 89-99 (session-introspect-helper.sh subcommands) and Effect-TS documentation (Effect.runPromise = run Effect → Promise).

Resolves #19665


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.70 plugin for [OpenCode](https://opencode.ai) v1.4.11 with claude-sonnet-4-6 spent 1m and 3,401 tokens on this as a headless worker.