### PR TITLE
t2191: install pre-commit hook, biome.json, document Codacy auto-fix anti-pattern

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -494,6 +494,21 @@ Short, concise, GitHub-flavored markdown. Numbered options for prompts.
 # AI Suggestion Verification
 Never apply AI tool suggestions without independent verification. AI reviewers hallucinate.
 
+# Codacy auto-fix diffs — NEVER apply verbatim (t2191)
+# Observed in t2178: Codacy's one-click "Apply fix" / "AutoFix" diffs
+# corrupt markdown and code in ways a human reviewer catches immediately
+# but a bulk-apply session won't. Treat Codacy suggestions as hints
+# pointing at a location, NOT as patches to land.
+- Concrete failure modes observed when applying Codacy diffs verbatim:
+  - Joins function identifiers and keywords across whitespace (`foo bar` → `foobar`).
+  - Breaks GitHub issue/PR references (`#19222` → `# 19222`, losing the autolink).
+  - Mangles UTF-8 em-dashes and other multi-byte chars (`—` → `â`).
+  - Misinterprets inline math expressions, eating spaces around operators.
+  - Dedents content inside fenced code blocks, breaking indentation-sensitive languages.
+  - Flips emphasis markers inconsistently (`*foo*` ↔ `_foo_`) mid-document.
+- Required flow: read the Codacy finding, navigate to `file:line` yourself, apply the fix by hand with Edit/Write. Run `shellcheck` / `markdownlint-cli2` / `biome check` locally to confirm the issue is actually resolved.
+- Tool-native configs (`.bandit`, `biome.json`, `.markdownlint.json`, `.shellcheckrc`) ARE respected by Codacy — disable a noisy rule at the source instead of hand-fixing every occurrence of a false positive.
+
 # Model-Specific Reinforcements
 - Follow project conventions — check imports, configs, neighbouring files.
 - Verify libraries exist in package.json/Cargo.toml before using.

--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -507,6 +507,7 @@ Never apply AI tool suggestions without independent verification. AI reviewers h
   - Dedents content inside fenced code blocks, breaking indentation-sensitive languages.
   - Flips emphasis markers inconsistently (`*foo*` ↔ `_foo_`) mid-document.
 - Required flow: read the Codacy finding, navigate to `file:line` yourself, apply the fix by hand with Edit/Write. Run `shellcheck` / `markdownlint-cli2` / `biome check` locally to confirm the issue is actually resolved.
+- Worked example — Codacy reports MD040 (fenced code block missing language) on `docs/guide.md:42`: open `docs/guide.md`, read the surrounding context, add the correct language tag (`bash`, `json`, `text` — NOT whatever Codacy guessed), then run `npx --yes markdownlint-cli2 docs/guide.md` and confirm MD040 is gone without introducing new findings.
 - Tool-native configs (`.bandit`, `biome.json`, `.markdownlint.json`, `.shellcheckrc`) ARE respected by Codacy — disable a noisy rule at the source instead of hand-fixing every occurrence of a false positive.
 
 # Model-Specific Reinforcements

--- a/.agents/scripts/install-hooks-helper.sh
+++ b/.agents/scripts/install-hooks-helper.sh
@@ -34,6 +34,10 @@ POST_HOOK_COMMAND="\$HOME/.aidevops/hooks/mcp_task_post_hook.py"
 GH_WRAPPER_GUARD_MARKER="# aidevops-gh-wrapper-guard"
 GH_WRAPPER_GUARD_DEPLOYED="$HOME/.aidevops/agents/hooks/gh-wrapper-guard-pre-push.sh"
 
+# pre-commit quality-validation hook (t2191)
+PRE_COMMIT_MARKER="# aidevops-pre-commit-hook"
+PRE_COMMIT_DEPLOYED="$HOME/.aidevops/agents/scripts/pre-commit-hook.sh"
+
 print_info() { printf "${BLUE}[INFO]${NC} %s\n" "$1"; }
 print_success() { printf "${GREEN}[OK]${NC} %s\n" "$1"; }
 print_warning() { printf "${YELLOW}[WARN]${NC} %s\n" "$1"; }
@@ -156,6 +160,102 @@ HOOKEOF
 	return 0
 }
 
+# --- pre-commit quality-validation hook (t2191) ---
+
+_find_pre_commit_hook() {
+	local script_dir
+	script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+	local repo_hook="$script_dir/pre-commit-hook.sh"
+	if [[ -f "$repo_hook" ]]; then
+		echo "$repo_hook"
+		return 0
+	fi
+	if [[ -f "$PRE_COMMIT_DEPLOYED" ]]; then
+		echo "$PRE_COMMIT_DEPLOYED"
+		return 0
+	fi
+	return 1
+}
+
+install_pre_commit_hook() {
+	# Only install if we're in a git repo
+	local common_dir
+	common_dir=$(git rev-parse --git-common-dir 2>/dev/null) || {
+		print_warning "Not in a git repo — skipping pre-commit quality hook"
+		return 0
+	}
+
+	local hook_path="${common_dir}/hooks/pre-commit"
+	mkdir -p "$(dirname "$hook_path")"
+
+	local source_hook
+	if ! source_hook=$(_find_pre_commit_hook); then
+		print_warning "pre-commit-hook.sh not found — skipping"
+		return 0
+	fi
+
+	if [[ -f "$hook_path" ]]; then
+		if grep -q "$PRE_COMMIT_MARKER" "$hook_path" 2>/dev/null; then
+			print_info "pre-commit hook already installed — refreshing dispatcher"
+		elif grep -q "aidevops" "$hook_path" 2>/dev/null; then
+			# Existing aidevops-managed pre-commit hook — chain ours in
+			if ! grep -q "pre-commit-hook.sh" "$hook_path" 2>/dev/null; then
+				# shellcheck disable=SC2016 # single quotes intentional — template content
+				{
+					printf '\n%s\n' "$PRE_COMMIT_MARKER"
+					printf '# pre-commit-hook: shellcheck, TODO.md validation, secretlint\n'
+					printf '_pch_hook=""\n'
+					printf 'if git_dir=$(git rev-parse --show-toplevel 2>/dev/null); then\n'
+					printf '  _pch_hook="${git_dir}/.agents/scripts/pre-commit-hook.sh"\n'
+					printf 'fi\n'
+					printf 'if [[ -n "$_pch_hook" && -f "$_pch_hook" ]]; then\n'
+					printf '  "$_pch_hook" "$@" || exit $?\n'
+					printf 'elif [[ -f "%s" ]]; then\n' "$PRE_COMMIT_DEPLOYED"
+					printf '  "%s" "$@" || exit $?\n' "$PRE_COMMIT_DEPLOYED"
+					printf 'fi\n'
+				} >>"$hook_path"
+				print_success "chained pre-commit-hook into existing pre-commit hook"
+			fi
+			return 0
+		else
+			print_warning "existing non-aidevops pre-commit hook — cannot auto-install"
+			print_warning "  manually add: $source_hook \"\$@\" || exit \$?"
+			return 0
+		fi
+	fi
+
+	# Write a dispatcher that prefers the in-repo copy (so script updates
+	# propagate without re-running this installer) and falls back to the
+	# deployed copy when no repo checkout is available.
+	cat >"$hook_path" <<HOOKEOF
+#!/usr/bin/env bash
+$PRE_COMMIT_MARKER
+# Managed by install-hooks-helper.sh — do not edit.
+# Dispatcher for pre-commit quality validation (shellcheck, TODO.md,
+# secretlint, root-file allowlist, task-completion proof-log).
+# Bypass: git commit --no-verify
+
+set -u
+
+_pch_hook=""
+if git_dir=\$(git rev-parse --show-toplevel 2>/dev/null); then
+	_pch_hook="\${git_dir}/.agents/scripts/pre-commit-hook.sh"
+fi
+_pch_deployed="$PRE_COMMIT_DEPLOYED"
+
+if [[ -n "\$_pch_hook" && -f "\$_pch_hook" ]]; then
+	"\$_pch_hook" "\$@" || exit \$?
+elif [[ -f "\$_pch_deployed" ]]; then
+	"\$_pch_deployed" "\$@" || exit \$?
+else
+	printf '[pre-commit-hook][WARN] hook not found — allowing commit\n' >&2
+fi
+HOOKEOF
+	chmod +x "$hook_path"
+	print_success "installed pre-commit quality hook at $hook_path"
+	return 0
+}
+
 install_hook() {
 	print_info "Installing Claude Code safety hooks..."
 
@@ -201,6 +301,9 @@ install_hook() {
 
 	# Also install the gh-wrapper-guard pre-push hook (t2113)
 	install_gh_wrapper_guard_hook
+
+	# Also install the pre-commit quality-validation hook (t2191)
+	install_pre_commit_hook
 
 	return 0
 }
@@ -490,6 +593,23 @@ sys.exit(1)
 		print_info "gh-wrapper-guard: not in a git repo — skipped"
 	fi
 
+	# Check pre-commit quality hook (t2191)
+	echo ""
+	echo "Pre-commit Quality Hook"
+	echo "------------------------"
+	if common_dir=$(git rev-parse --git-common-dir 2>/dev/null); then
+		local pc_hook_path="${common_dir}/hooks/pre-commit"
+		if [[ -f "$pc_hook_path" ]] && grep -q "$PRE_COMMIT_MARKER" "$pc_hook_path" 2>/dev/null; then
+			print_success "pre-commit-hook: installed"
+		elif [[ -f "$pc_hook_path" ]] && grep -q "pre-commit-hook.sh" "$pc_hook_path" 2>/dev/null; then
+			print_success "pre-commit-hook: chained in pre-commit hook"
+		else
+			print_warning "pre-commit-hook: not installed (run: install-hooks-helper.sh install)"
+		fi
+	else
+		print_info "pre-commit-hook: not in a git repo — skipped"
+	fi
+
 	echo ""
 	if [[ "$all_ok" == "true" ]]; then
 		print_success "All checks passed - safety hooks are active"
@@ -586,6 +706,7 @@ show_help() {
 	echo "  ~/.aidevops/hooks/git_safety_guard.py"
 	echo "  ~/.claude/settings.json (PreToolUse hook config)"
 	echo "  .git/hooks/pre-push (gh-wrapper-guard, t2113)"
+	echo "  .git/hooks/pre-commit (quality-validation, t2191)"
 	return 0
 }
 

--- a/.agents/scripts/install-hooks-helper.sh
+++ b/.agents/scripts/install-hooks-helper.sh
@@ -197,8 +197,11 @@ install_pre_commit_hook() {
 	if [[ -f "$hook_path" ]]; then
 		if grep -q "$PRE_COMMIT_MARKER" "$hook_path" 2>/dev/null; then
 			print_info "pre-commit hook already installed — refreshing dispatcher"
-		elif grep -q "aidevops" "$hook_path" 2>/dev/null; then
-			# Existing aidevops-managed pre-commit hook — chain ours in
+		elif grep -qE "^#[[:space:]]*aidevops-[a-z-]+" "$hook_path" 2>/dev/null; then
+			# Existing aidevops-managed pre-commit hook — chain ours in.
+			# Detection: a sibling aidevops marker line (e.g. the gh-wrapper-guard
+			# marker if we ever share pre-commit) rather than bare mentions of
+			# "aidevops" in comments/paths, which could false-match.
 			if ! grep -q "pre-commit-hook.sh" "$hook_path" 2>/dev/null; then
 				# shellcheck disable=SC2016 # single quotes intentional — template content
 				{

--- a/.agents/scripts/pre-commit-hook.sh
+++ b/.agents/scripts/pre-commit-hook.sh
@@ -450,10 +450,12 @@ _init_root_file_allowlist() {
 		"CHANGELOG.md" "LICENSE" "CODE_OF_CONDUCT.md" "CONTRIBUTING.md"
 		"SECURITY.md" "TERMS.md" "MODELS.md" "VERSION"
 		# Config files (dotfiles)
-		".gitignore" ".codacy.yml" ".codefactor.yml" ".coderabbit.yaml"
+		".bandit" ".gitignore" ".codacy.yml" ".codefactor.yml" ".coderabbit.yaml"
 		".markdownlint-cli2.jsonc" ".markdownlint.json" ".markdownlintignore"
 		".qlty/qlty.toml" ".qlty.toml" ".qltyignore" ".repomixignore"
 		".secretlintignore" ".secretlintrc.json"
+		# Tool configs (non-dotfile)
+		"biome.json"
 		# Build/package files
 		"package.json" "bun.lock" "requirements.txt" "requirements-lock.txt"
 		# Scripts

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,40 @@
+{
+	"$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
+	"files": {
+		"ignoreUnknown": true,
+		"includes": [
+			"**",
+			"!**/node_modules/**",
+			"!**/.git/**",
+			"!**/dist/**",
+			"!**/build/**",
+			"!**/coverage/**",
+			"!todo/tasks/**",
+			"!.agents/plugins/opencode-aidevops/**",
+			"!.agents/tools/design/library/brands/**",
+			"!.agents/services/hosting/cloudflare-platform-skill/**"
+		]
+	},
+	"linter": {
+		"enabled": true,
+		"rules": {
+			"recommended": true,
+			"correctness": {
+				"useQwikValidLexicalScope": "off"
+			}
+		}
+	},
+	"formatter": {
+		"enabled": false
+	},
+	"javascript": {
+		"formatter": {
+			"enabled": false
+		}
+	},
+	"json": {
+		"formatter": {
+			"enabled": false
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Close write-time quality gaps so future PRs don't re-accumulate the Codacy noise trimmed in t2178 and t2182.

**1. `biome.json`** — minimal config disabling `useQwikValidLexicalScope` (18 false positives — repo is not Qwik). Anchors the recommended ruleset and excludes the same paths as `.codacy.yml` for consistency when biome runs locally. Verified: config parses, Qwik rule suppressed (0 diagnostics).

**2. `install-hooks-helper.sh`** — adds `install_pre_commit_hook()` modelled on `install_gh_wrapper_guard_hook()`. `setup.sh --non-interactive` now installs `.git/hooks/pre-commit` on every initialized repo. The hook is a dispatcher that prefers the in-repo `.agents/scripts/pre-commit-hook.sh` and falls back to the deployed copy, so script updates propagate without re-running the installer. Also wired into `check_status` and help text.

**3. `pre-commit-hook.sh`** — extends the root-file allowlist to include `.bandit` and `biome.json` (both legitimate root-level tool configs picked up automatically by their respective analysers).

**4. `prompts/build.txt`** — documents the concrete failure modes observed when applying Codacy auto-fix diffs verbatim (joined identifiers, broken GitHub issue refs, mangled em-dashes, eaten math operator spaces, dedented code blocks, flipped emphasis markers). Required flow: navigate to `file:line` yourself and fix by hand. Notes that tool-native configs ARE respected by Codacy — disable noisy rules at the source rather than hand-fixing every occurrence.

## Verification

- `npx @biomejs/biome check` — config parses, 165 files scanned, Qwik rule produces 0 diagnostics.
- Installer smoke test in a fresh temp repo:
  - `install` creates `.git/hooks/pre-commit` with the dispatcher marker.
  - `status` reports `pre-commit-hook: installed`.
  - Committing a shell file containing `echo $UNQUOTED` is rejected with SC2086.
- `shellcheck .agents/scripts/install-hooks-helper.sh` clean (only pre-existing SC1091 info on the `shared-constants.sh` source line).
- Installer run against the canonical aidevops repo — `.git/hooks/pre-commit` now installed, `.git/hooks/pre-push` had `gh-wrapper-guard` chained into the existing privacy-guard hook (chain logic exercised).

## Follow-ups (not in this PR)

- The full pre-commit-hook `main()` runs secretlint + a SonarCloud API call + optional CodeRabbit CLI, which can exceed interactive commit time on large repos. A future task should split fast (shellcheck, TODO.md validation, root-file allowlist) from slow (network-dependent) checks — move the slow ones to pre-push.
- Add `markdownlint-cli2` and `biome ci` jobs to `.github/workflows/code-quality.yml` so findings gate at PR time too (complements but doesn't replace the local hook).
- Un-hide Codacy badge in `README.md` once grade reaches A (pointer left in the HTML comment from t2178).

Resolves #19681

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.70 plugin for [OpenCode](https://opencode.ai) v1.4.11 with claude-opus-4-7 spent 12h 50m and 32,083 tokens on this with the user in an interactive session. Overall, 12m since this issue was created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Git pre-commit quality validation hook for automated checks before committing code.
  * Configured Biome linting with recommended rules to enforce code quality standards.

* **Documentation**
  * Enhanced guidance on handling and applying code quality suggestions safely.

* **Configuration**
  * Updated development tool configurations to support additional file types and validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->