### PR TITLE
t2213: sync cloudron skill files with upstream

### DIFF
--- a/.agents/tools/deployment/cloudron-app-packaging-skill.md
+++ b/.agents/tools/deployment/cloudron-app-packaging-skill.md
@@ -52,7 +52,7 @@ Cloudron apps are Docker images plus `CloudronManifest.json`, with a readonly ro
 Use `Dockerfile`, `Dockerfile.cloudron`, or `cloudron/Dockerfile`. See `cloudron-app-packaging.md` "Dockerfile Patterns" for stack-specific variants.
 
 ```dockerfile
-FROM cloudron/base:5.0.0@sha256:...
+FROM cloudron/base:5.0.0@sha256:04fd70dbd8ad6149c19de39e35718e024417c3e01dc9c6637eaf4a41ec4e596c
 RUN mkdir -p /app/code
 WORKDIR /app/code
 COPY . /app/code/
@@ -60,6 +60,8 @@ RUN ln -sf /run/app/config.json /app/code/config.json
 RUN chmod +x /app/code/start.sh
 CMD [ "/app/code/start.sh" ]
 ```
+
+**Base image requirement:** the final stage MUST use the SHA-pinned `cloudron/base:5.0.0` tag above. Platform tooling (file manager, web terminal, log viewer) depends on utilities provided by this base image. Multi-stage builds are fine for compilation, but the final stage always lands on pinned `cloudron/base`. Current SHA tracked at [hub.docker.com/r/cloudron/base/tags](https://hub.docker.com/r/cloudron/base/tags).
 
 ### `start.sh` Conventions
 
@@ -83,6 +85,19 @@ CMD [ "/app/code/start.sh" ]
   "manifestVersion": 2
 }
 ```
+
+Common fields beyond the minimum:
+
+| Field | Purpose |
+|-------|---------|
+| `memoryLimit` | Max memory in bytes (default 256 MB) |
+| `tcpPorts` / `udpPorts` | Non-HTTP port bindings exposed to the user |
+| `httpPorts` | Additional HTTP services on secondary domains |
+| `multiDomain` | Enable alias domains |
+| `optionalSso` | Allow install without user management |
+| `configurePath` | Admin panel path shown in dashboard |
+| `postInstallMessage` | Markdown shown after install (supports `<sso>`/`<nosso>` tags) |
+| `minBoxVersion` | Minimum platform version required |
 
 Full field reference: [manifest-ref.md](cloudron-app-packaging-skill/manifest-ref.md).
 

--- a/.agents/tools/deployment/cloudron-app-packaging.md
+++ b/.agents/tools/deployment/cloudron-app-packaging.md
@@ -87,7 +87,7 @@ Score both axes before writing code. Initial packaging is ~25% of effort; SSO, u
 
 ## Base Image
 
-**Always `FROM cloudron/base:5.0.0`.** Never start from upstream images — monolithic images bundle databases, reverse proxies, and init systems that conflict with Cloudron (e.g., docassemble: 25 symlinks, 15-20 min boot). Read upstream `docker-compose.yml` for dependencies, then install on `cloudron/base` via package manager.
+**Always `FROM cloudron/base:5.0.0@sha256:04fd70dbd8ad6149c19de39e35718e024417c3e01dc9c6637eaf4a41ec4e596c`.** The final stage MUST use the SHA-pinned `cloudron/base` — platform tooling (file manager, web terminal, log viewer) depends on utilities in this image. Never start from upstream images — monolithic images bundle databases, reverse proxies, and init systems that conflict with Cloudron (e.g., docassemble: 25 symlinks, 15-20 min boot). Read upstream `docker-compose.yml` for dependencies, then install on `cloudron/base` via package manager. Current SHA tracked at [hub.docker.com/r/cloudron/base/tags](https://hub.docker.com/r/cloudron/base/tags) and in `cloudron-app-packaging-skill.md`.
 
 **Multi-stage builds**: Only when build toolchain is exotic. Build in upstream image, `COPY --from` artifacts into final `cloudron/base` stage. **Alpine/musl warning**: musl-compiled binaries won't run on `cloudron/base` (Ubuntu/glibc) — always use glibc builder stage.
 
@@ -101,7 +101,7 @@ Run DB migrations on each start. `localstorage` is MANDATORY for persistent data
 
 **Memory limits** (`memoryLimit` in bytes: 256MB=268435456, 512MB=536870912, 1GB=1073741824): Static/PHP 128-256 MB, Node/Go/Rust 256-512 MB, PHP+workers/Python/Ruby 512-768 MB, Java/JVM 1024+ MB.
 
-**Dynamic worker count from memory limit**:
+**Dynamic worker count from memory limit** (matches upstream Cloudron skill: 1 worker per 150 MB, clamped 1-8):
 
 ```bash
 if [[ -f /sys/fs/cgroup/cgroup.controllers ]]; then
@@ -110,8 +110,9 @@ if [[ -f /sys/fs/cgroup/cgroup.controllers ]]; then
 else
     mem=$(cat /sys/fs/cgroup/memory/memory.limit_in_bytes)
 fi
-workers=$(( mem / 1024 / 1024 / 128 ))  # 1 worker per 128MB
-[[ $workers -lt 1 ]] && workers=1
+workers=$(( mem / 1024 / 1024 / 150 ))      # 1 worker per 150MB
+workers=$(( workers > 8 ? 8 : workers ))    # cap at 8
+workers=$(( workers < 1 ? 1 : workers ))    # floor at 1
 ```
 
 **TCP/UDP ports**: Declare in `tcpPorts` manifest field; exposed as env vars (e.g., `XMPP_C2S_PORT`). Apps handle their own TLS termination.

--- a/.agents/tools/deployment/cloudron-server-ops-skill.md
+++ b/.agents/tools/deployment/cloudron-server-ops-skill.md
@@ -81,12 +81,31 @@ cloudron debug --app <app> --disable   # exit debug mode
 
 ### File Transfer
 
+One-off file copy with `push`/`pull`:
+
 ```bash
 cloudron push --app <app> local.txt /tmp/remote.txt
 cloudron push --app <app> localdir /tmp/
 cloudron pull --app <app> /app/data/file.txt .
 cloudron pull --app <app> /app/data/ ./backup/
 ```
+
+Directory sync with `cloudron sync` (rsync-style, changed files only):
+
+```bash
+cloudron sync push --app <app> ./local/ /app/data       # contents of ./local -> /app/data (trailing slash)
+cloudron sync push --app <app> ./local /app/data        # ./local itself into /app/data/local (no slash)
+cloudron sync push --app <app> file.txt /app/data       # single file -> remote
+cloudron sync pull --app <app> /app/data/ ./local       # contents of /app/data -> ./local
+cloudron sync pull --app <app> /app/data ./local        # /app/data itself into ./local/data
+cloudron sync push --app <app> ./local/ /app/data --delete   # also delete remote-only files
+cloudron sync pull --app <app> /app/data/ ./local --delete   # also delete local-only files
+cloudron sync push --app <app> ./local/ /app/data --force    # remove files blocking directory creation
+```
+
+Trailing slash on the source syncs its contents; without it, the directory itself is placed inside the destination (rsync convention). `--delete` removes files present only on the destination side. `--force` removes files blocking directory creation.
+
+**Rule of thumb:** for directory transfers, prefer `cloudron sync`; keep `cloudron push`/`pull` for one-off file copy and stream-oriented use cases.
 
 ### Environment Variables and Configuration
 
@@ -118,4 +137,38 @@ cloudron backup encrypt <infile> <outfile> --password <pw>     # local offline
 ```bash
 cloudron open --app <app>       # open app in browser
 cloudron init                   # create CloudronManifest.json + Dockerfile
+cloudron completion             # shell completion (source the output)
+```
+
+## Common Workflows
+
+**Check and restart a misbehaving app:**
+
+```bash
+cloudron status --app <app>
+cloudron logs --app <app> -l 100
+cloudron restart --app <app>
+```
+
+**Debug a crashing app** (pauses the app, makes filesystem writable):
+
+```bash
+cloudron debug --app <app>
+cloudron exec --app <app>       # inspect filesystem, test manually
+cloudron debug --app <app> --disable
+```
+
+**Backup and restore:**
+
+```bash
+cloudron backup create --app <app>
+cloudron backup list --app <app>              # note the backup ID
+cloudron restore --app <app> --backup <id>
+```
+
+**Set env vars for an app** (auto-restarts):
+
+```bash
+cloudron env set --app <app> FEATURE_FLAG=true DEBUG=1
+cloudron logs --app <app> -f                  # watch the restart
 ```

--- a/todo/tasks/t2213-brief.md
+++ b/todo/tasks/t2213-brief.md
@@ -1,0 +1,82 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# t2213: sync cloudron skill files with upstream
+
+**Session origin:** interactive (maintainer, Marcus Quinn)
+**GitHub:** GH#19702
+**Tier:** tier:simple (three bounded edit blocks, docs-only, upstream canonical source)
+
+## What
+
+Three focused docs-only edits to align our imported Cloudron skill files with upstream `git.cloudron.io/docs/skills`, the canonical source our `cloudron-app-*-skill.md` files are imported from. Side-by-side review identified three concrete drifts.
+
+## Why
+
+- `cloudron-server-ops-skill.md` omits the entire `cloudron sync` command family. Users asking "how do I sync a directory to a Cloudron app" get the wrong shape (push/pull) when upstream explicitly says to prefer `sync` for directory transfers.
+- `cloudron-app-packaging-skill.md` has a placeholder `@sha256:...` on the base image line and doesn't carry upstream's rationale for why the final stage MUST be the pinned tag.
+- Internal drift: our native `cloudron-app-packaging.md` uses a different memory-per-worker divisor (128MB) than upstream (150MB), and doesn't pin the base image SHA — so a reader following either path gets a subtly different message.
+
+Deployed skills at `~/.claude/skills/cloudron-*/SKILL.md` are symlinks to our repo files, so fixing the source fixes the deployment automatically.
+
+## How
+
+### P1 — `.agents/tools/deployment/cloudron-server-ops-skill.md`
+
+Model on upstream `https://git.cloudron.io/docs/skills/-/raw/master/cloudron-server-ops/SKILL.md`. Add, in this order:
+
+- After the File Transfer section (currently lines 83-89), insert `cloudron sync push`/`sync pull` examples with `--delete` / `--force`, and the rule: "A trailing slash on the source syncs its contents; without it, the directory itself is placed inside the destination (rsync convention)." Plus the guidance: "For directory transfers, prefer `cloudron sync`; keep `cloudron push`/`pull` for one-off file copy and stream-oriented use cases."
+- Add `cloudron completion` under Utilities (currently lines 117-120).
+- Add a "Common workflows" section at the end with compact code blocks for: (a) check and restart a misbehaving app, (b) debug a crashing app, (c) backup and restore, (d) set env vars for an app.
+
+### P2 — `.agents/tools/deployment/cloudron-app-packaging-skill.md`
+
+Model on upstream `https://git.cloudron.io/docs/skills/-/raw/master/cloudron-app-packaging/SKILL.md`. Apply:
+
+- Replace line 55 `FROM cloudron/base:5.0.0@sha256:...` with the concrete pin `FROM cloudron/base:5.0.0@sha256:04fd70dbd8ad6149c19de39e35718e024417c3e01dc9c6637eaf4a41ec4e596c`.
+- Add a one-line rationale paragraph before or after the Dockerfile block: "The final stage must use the SHA-pinned `cloudron/base` — platform tooling (file manager, web terminal, log viewer) depends on utilities provided by this base image."
+- Extend the "Manifest Essentials" minimal JSON (no change) with a follow-up common-fields table covering: `configurePath`, `postInstallMessage` (note `<sso>`/`<nosso>` substitution), `tcpPorts`, `udpPorts`, `httpPorts`, `multiDomain`, `optionalSso`, `memoryLimit`, `minBoxVersion`. Keep the pointer to `manifest-ref.md` for full depth.
+
+### P3 — `.agents/tools/deployment/cloudron-app-packaging.md` (native guide)
+
+- Line 90: update `FROM cloudron/base:5.0.0` (in prose) to point to the pinned SHA via cross-reference ("See `cloudron-app-packaging-skill.md` for the current SHA pin") or quote the pin directly.
+- Lines 104-115 (worker-count snippet): change divisor from `128` to `150` to match upstream, and add a cap at 8 workers (upstream: `worker_count=$((worker_count > 8 ? 8 : worker_count))`). Both are defensible; matching upstream reduces maintenance burden.
+
+## Acceptance criteria
+
+- [ ] `cloudron-server-ops-skill.md` documents `cloudron sync push` and `cloudron sync pull` with flags and trailing-slash convention
+- [ ] `cloudron-server-ops-skill.md` documents `cloudron completion`
+- [ ] `cloudron-server-ops-skill.md` has a "Common workflows" block
+- [ ] `cloudron-app-packaging-skill.md` pins the concrete SHA on the base image line
+- [ ] `cloudron-app-packaging-skill.md` has the upstream base-image rationale line
+- [ ] `cloudron-app-packaging-skill.md` manifest table lists the six common fields plus `memoryLimit`/`minBoxVersion`
+- [ ] `cloudron-app-packaging.md` base image is consistent with skill (pin or cross-ref)
+- [ ] `cloudron-app-packaging.md` worker-count divisor matches upstream (`/150`, cap 1-8)
+- [ ] `markdownlint-cli2` clean on all three files
+- [ ] Deployed `~/.claude/skills/cloudron-*/SKILL.md` symlinks resolve to updated content (verify post-merge)
+
+## Verification
+
+```bash
+# Lint
+markdownlint-cli2 .agents/tools/deployment/cloudron-server-ops-skill.md \
+                  .agents/tools/deployment/cloudron-app-packaging-skill.md \
+                  .agents/tools/deployment/cloudron-app-packaging.md
+
+# Content checks
+grep -l "cloudron sync push" .agents/tools/deployment/cloudron-server-ops-skill.md
+grep -l "sha256:04fd70dbd8ad6149c19de39e35718e024417c3e01dc9c6637eaf4a41ec4e596c" .agents/tools/deployment/cloudron-app-packaging-skill.md
+grep "memory_limit / 1024 / 1024 / 150" .agents/tools/deployment/cloudron-app-packaging.md
+
+# Symlink integrity (post-merge)
+readlink ~/.claude/skills/cloudron-server-ops/SKILL.md
+readlink ~/.claude/skills/cloudron-app-packaging/SKILL.md
+```
+
+## Context
+
+- Upstream canonical: https://git.cloudron.io/docs/skills (master branch)
+- Imported files carry `imported_from: external` YAML frontmatter
+- Deployed via symlink: `~/.claude/skills/cloudron-{packaging,publishing,server-ops}/SKILL.md` → `~/.aidevops/agents/tools/deployment/cloudron-*-skill.md`
+- Upstream `cloudron-app-publishing` is already aligned — no changes needed
+- Our native `cloudron-app-packaging.md` and `services/hosting/cloudron.md` are intentionally ahead of upstream (pre-packaging scoring, 9.1+ features, diagnostic playbook) — no scope change


### PR DESCRIPTION
## Summary

Three docs-only fixes aligning imported cloudron-app-{packaging,publishing,server-ops}-skill.md with upstream git.cloudron.io/docs/skills, plus reconcile internal drift between the skill import and the native packaging guide.

P1 cloudron-server-ops-skill.md: documented the cloudron sync push/pull command family (rsync-style, --delete/--force, trailing-slash convention), the 'prefer sync for directory transfers' rule, cloudron completion, and a compact Common Workflows block (misbehaving app, debug crashing, backup/restore, set env vars).

P2 cloudron-app-packaging-skill.md: replaced placeholder base image SHA with upstream-pinned @sha256:04fd70dbd8ad6149c19de39e35718e024417c3e01dc9c6637eaf4a41ec4e596c and added the rationale (platform tooling depends on the base image); extended manifest-essentials with memoryLimit, tcpPorts/udpPorts/httpPorts, multiDomain, optionalSso, configurePath, postInstallMessage (<sso>/<nosso> tags), minBoxVersion.

P3 cloudron-app-packaging.md (native): pinned base image SHA to match the skill import, reconciled worker-count divisor with upstream (1 worker per 150MB, clamped 1-8, was /128 with no cap).

## Files Changed

.agents/tools/deployment/cloudron-app-packaging-skill.md,.agents/tools/deployment/cloudron-app-packaging.md,.agents/tools/deployment/cloudron-server-ops-skill.md,todo/tasks/t2213-brief.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** markdownlint-cli2 v0.22.0 clean on all three edited files plus the brief.
Content verifications: cloudron sync push x5, cloudron completion x1, Common Workflows x1, pinned sha256 x2 (skill + native), worker-count /150 x1.
Deployed skills at ~/.claude/skills/cloudron-{packaging,server-ops}/SKILL.md are symlinks to the edited files — changes take effect automatically post-merge.

Resolves #19702


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.70 plugin for [OpenCode](https://opencode.ai) v1.4.12 with claude-opus-4-7 spent 12m and 26,615 tokens on this with the user in an interactive session.