### PR TITLE
GH#19667: force base-10 in _resolve_current_counter octal-trap comparisons

### DIFF
--- a/.agents/hooks/task-id-collision-guard.sh
+++ b/.agents/hooks/task-id-collision-guard.sh
@@ -97,7 +97,10 @@ _resolve_current_counter() {
 		if git rev-parse --verify "$ref" >/dev/null 2>&1; then
 			val=$(git show "${ref}:.task-counter" 2>/dev/null | tr -d '[:space:]')
 			if [[ "$val" =~ ^[0-9]+$ ]]; then
-				if [[ -z "$best" || "$val" -gt "$best" ]]; then
+				# Force base-10 (10#) so leading-zero values like "008" don't trip
+				# bash's octal parser — same root cause as the line 290 comparison
+				# fixed in GH#19620. The ^[0-9]+$ guard above makes 10# safe.
+				if [[ -z "$best" ]] || ((10#$val > 10#$best)); then
 					best="$val"
 				fi
 			fi
@@ -107,7 +110,8 @@ _resolve_current_counter() {
 	if [[ -f .task-counter ]]; then
 		val=$(tr -d '[:space:]' <.task-counter)
 		if [[ "$val" =~ ^[0-9]+$ ]]; then
-			if [[ -z "$best" || "$val" -gt "$best" ]]; then
+			# Force base-10 (10#) — same octal-trap fix as above.
+			if [[ -z "$best" ]] || ((10#$val > 10#$best)); then
 				best="$val"
 			fi
 		fi

--- a/.agents/hooks/task-id-collision-guard.sh
+++ b/.agents/hooks/task-id-collision-guard.sh
@@ -11,7 +11,7 @@
 #
 # Modes:
 #   Default (commit-msg hook):
-#     Called with $1 = path to the commit message file.
+#     Called with arg1 = path to the commit message file.
 #     Exits 0 (allow) or 1 (reject with actionable error).
 #
 #   check-pr <PR_NUMBER>:
@@ -45,17 +45,20 @@ fi
 # ---------------------------------------------------------------------------
 
 _debug() {
-	[[ "${TASK_ID_GUARD_DEBUG:-0}" == "1" ]] && printf '[task-id-guard][DEBUG] %s\n' "$1" >&2
+	local msg="$1"
+	[[ "${TASK_ID_GUARD_DEBUG:-0}" == "1" ]] && printf '[task-id-guard][DEBUG] %s\n' "$msg" >&2
 	return 0
 }
 
 _warn() {
-	printf '[task-id-guard][WARN] %s\n' "$1" >&2
+	local msg="$1"
+	printf '[task-id-guard][WARN] %s\n' "$msg" >&2
 	return 0
 }
 
 _info() {
-	printf '[task-id-guard][INFO] %s\n' "$1" >&2
+	local msg="$1"
+	printf '[task-id-guard][INFO] %s\n' "$msg" >&2
 	return 0
 }
 
@@ -167,8 +170,8 @@ _extract_closing_issues() {
 # ---------------------------------------------------------------------------
 # Cross-reference a single t-ID against closing issues via the gh API.
 # Args:
-#   $1 = tid (e.g. "t2047")
-#   $2 = newline-separated closing issue numbers
+#   arg1 = tid (e.g. "t2047")
+#   arg2 = newline-separated closing issue numbers
 # Returns:
 #   0 = confirmed (title of at least one linked issue contains the t-ID)
 #   1 = not confirmed (violation)
@@ -221,8 +224,8 @@ _verify_tid_via_issues() {
 # ---------------------------------------------------------------------------
 # Print the violation block to stderr.
 # Args:
-#   $1 = violations string (printf %b-formatted lines)
-#   $2 = commit subject (for display)
+#   arg1 = violations string (printf %b-formatted lines)
+#   arg2 = commit subject (for display)
 # ---------------------------------------------------------------------------
 _report_violations() {
 	local violations="${1:-}"
@@ -242,8 +245,8 @@ _report_violations() {
 # ---------------------------------------------------------------------------
 # Core check: given a commit message, check if any t\d+ reference is invented.
 # Args:
-#   $1 = full commit message text
-#   $2 = commit subject (for display in errors), optional
+#   arg1 = full commit message text
+#   arg2 = commit subject (for display in errors), optional
 # Returns 0 (clean), 1 (violation found), 2 (fail-open — skip).
 # ---------------------------------------------------------------------------
 _check_message() {
@@ -320,7 +323,7 @@ _check_message() {
 
 # ---------------------------------------------------------------------------
 # Commit-msg hook mode (default).
-# $1 = path to commit message file
+# arg1 = path to commit message file
 # ---------------------------------------------------------------------------
 _run_hook() {
 	local msg_file="${1:-}"
@@ -430,7 +433,7 @@ main() {
 		return 0
 		;;
 	*)
-		# Default: commit-msg hook mode. $1 is the message file path.
+		# Default: commit-msg hook mode. First arg is the message file path.
 		_run_hook "${1:-}"
 		return $?
 		;;

--- a/.agents/scripts/tests/test-resolve-counter-octal.sh
+++ b/.agents/scripts/tests/test-resolve-counter-octal.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-resolve-counter-octal.sh — Regression test for the octal-leading-zero
+# parse bug in task-id-collision-guard.sh::_resolve_current_counter.
+#
+# Bug: _resolve_current_counter used `"$val" -gt "$best"` inside [[ ]] which
+# triggers bash's octal parser when the .task-counter file contains a value
+# with a leading zero AND a non-octal digit (8 or 9). For example, "068"
+# would crash with:
+#   bash: [[: 068: value too great for base (error token is "068")
+# The fix forces base-10 with (( 10#$val > 10#$best )) on the comparison.
+#
+# GH#19667 (review-followup from GH#19620 / PR #19621).
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+GUARD_SCRIPT="${SCRIPT_DIR}/../../hooks/task-id-collision-guard.sh"
+
+RED=$'\033[0;31m'
+GREEN=$'\033[0;32m'
+NC=$'\033[0m'
+
+PASS=0
+FAIL=0
+ERRORS=""
+
+pass() {
+	local name="${1:-}"
+	printf '%s[PASS]%s %s\n' "$GREEN" "$NC" "$name"
+	PASS=$((PASS + 1))
+	return 0
+}
+
+fail() {
+	local name="${1:-}"
+	local detail="${2:-}"
+	printf '%s[FAIL]%s %s\n' "$RED" "$NC" "$name"
+	[[ -n "$detail" ]] && printf '       %s\n' "$detail"
+	FAIL=$((FAIL + 1))
+	ERRORS="${ERRORS}\n  - ${name}: ${detail}"
+	return 0
+}
+
+# Source the guard script to access _resolve_current_counter.
+_source_guard_script() {
+	# The guard script has a main() that only runs when invoked directly
+	# (not sourced), but we need to prevent any side effects.
+	# shellcheck disable=SC1090
+	if ! source "$GUARD_SCRIPT" 2>/dev/null; then
+		printf '%s[FATAL]%s Failed to source %s\n' "$RED" "$NC" "$GUARD_SCRIPT" >&2
+		exit 1
+	fi
+	return 0
+}
+
+# Create a temp git repo with a .task-counter containing $1.
+_make_repo_with_counter() {
+	local counter_value="$1"
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	(
+		cd "$tmpdir" || exit 1
+		git init -q
+		git config user.email "test@test.com"
+		git config user.name "Test"
+		printf '%s\n' "$counter_value" >.task-counter
+		git add .task-counter
+		git commit -q -m "init with counter=$counter_value"
+	) >/dev/null 2>&1
+	printf '%s' "$tmpdir"
+	return 0
+}
+
+_source_guard_script
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+# Test 1: .task-counter = "068" (octal trap) — should not crash, return "068"
+test_counter_068() {
+	local name="1: _resolve_current_counter — counter=068 (octal trap) does not crash"
+	local tmpdir
+	tmpdir=$(_make_repo_with_counter "068")
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir'" RETURN
+
+	local result
+	result=$(cd "$tmpdir" && _resolve_current_counter 2>&1)
+	local rc=$?
+
+	if [[ "$rc" -ne 0 ]]; then
+		fail "$name" "exit code=$rc (expected 0)"
+		return 0
+	fi
+	if [[ "$result" == "068" ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected '068', got '$result'"
+	fi
+	return 0
+}
+
+# Test 2: .task-counter = "009" (octal edge) — should return "009"
+test_counter_009() {
+	local name="2: _resolve_current_counter — counter=009 (octal edge) does not crash"
+	local tmpdir
+	tmpdir=$(_make_repo_with_counter "009")
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir'" RETURN
+
+	local result
+	result=$(cd "$tmpdir" && _resolve_current_counter 2>&1)
+	local rc=$?
+
+	if [[ "$rc" -ne 0 ]]; then
+		fail "$name" "exit code=$rc (expected 0)"
+		return 0
+	fi
+	if [[ "$result" == "009" ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected '009', got '$result'"
+	fi
+	return 0
+}
+
+# Test 3: .task-counter = "100" (no leading zero) — baseline sanity
+test_counter_100() {
+	local name="3: _resolve_current_counter — counter=100 (no leading zero) returns 100"
+	local tmpdir
+	tmpdir=$(_make_repo_with_counter "100")
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir'" RETURN
+
+	local result
+	result=$(cd "$tmpdir" && _resolve_current_counter 2>&1)
+
+	if [[ "$result" == "100" ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected '100', got '$result'"
+	fi
+	return 0
+}
+
+# Test 4: Two sources with leading-zero values — picks the max correctly.
+# Working-copy .task-counter = "078", HEAD commit has "042".
+# 78 > 42 so result should be "078".
+test_counter_max_with_leading_zeros() {
+	local name="4: _resolve_current_counter — max pick works with leading-zero values (078 vs 042)"
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir'" RETURN
+
+	(
+		cd "$tmpdir" || exit 1
+		git init -q
+		git config user.email "test@test.com"
+		git config user.name "Test"
+		printf '042\n' >.task-counter
+		git add .task-counter
+		git commit -q -m "init with counter=042"
+		# Now update working copy to 078 (not committed)
+		printf '078\n' >.task-counter
+	) >/dev/null 2>&1
+
+	local result
+	result=$(cd "$tmpdir" && _resolve_current_counter 2>&1)
+
+	if [[ "$result" == "078" ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected '078', got '$result'"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Run all tests
+# ---------------------------------------------------------------------------
+
+main() {
+	printf 'Running _resolve_current_counter octal-trap regression tests...\n\n'
+
+	test_counter_068
+	test_counter_009
+	test_counter_100
+	test_counter_max_with_leading_zeros
+
+	printf '\n'
+	printf 'Results: %s passed, %s failed\n' "$PASS" "$FAIL"
+	if [[ "$FAIL" -gt 0 ]]; then
+		printf '\nFailed tests:%b\n' "$ERRORS"
+		return 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-task-id-collision-guard.sh
+++ b/.agents/scripts/tests/test-task-id-collision-guard.sh
@@ -370,6 +370,28 @@ test_stale_worktree_scenario() {
 }
 
 # ---------------------------------------------------------------------------
+# Case 9: Allow — leading-zero .task-counter doesn't trigger octal crash
+# (GH#19667: _resolve_current_counter octal-trap symmetry fix)
+# ---------------------------------------------------------------------------
+test_octal_trap_leading_zero_counter() {
+	local name="case-9: allows t-ID ≤ leading-zero counter (octal-trap in _resolve_current_counter)"
+	# Counter written as "09" — was read by _resolve_current_counter via
+	# [[ "$val" -gt "$best" ]] which triggers bash's octal parser on the
+	# second comparison iteration (when $best is already "09").
+	# After the fix: ((10#$val > 10#$best)) forces decimal, so 9 ≤ 9 → allowed.
+	local msg="feat: implement GH#19667 t9"
+	local rc
+	_run_with_counter "$msg" "09"
+	rc=$?
+	if [[ "$rc" -eq 0 ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected exit 0 (t9 ≤ counter 09 in base-10), got $rc (likely octal crash)"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
 main() {
@@ -383,6 +405,7 @@ main() {
 	test_skips_merge_commits
 	test_check_pr_mode
 	test_stale_worktree_scenario
+	test_octal_trap_leading_zero_counter
 
 	printf '\n'
 	printf 'Results: %s passed, %s failed\n' "$PASS" "$FAIL"


### PR DESCRIPTION
## Summary

- Force base-10 (10#) in _resolve_current_counter comparisons in task-id-collision-guard.sh, fixing the same latent octal-trap bug fixed at line ~293 in PR #19621 (GH#19620)
- Fix pre-existing direct $1 usage in _debug/_warn/_info helpers to use local variables per project conventions
- Reword comment-only arg references to avoid false-positive pre-commit hook rejections
- Add regression test test-resolve-counter-octal.sh (4 cases: octal trap, octal edge, baseline, max-pick with leading zeros)

## Testing

- shellcheck clean
- test-resolve-counter-octal.sh: 4/4 pass
- test-compute-counter-seed-octal.sh: 6/6 pass (no regression)

Resolves #19667