### PR TITLE
GH#19692: t2206: ci: add markdownlint-cli2 and biome CI jobs to code-quality.yml

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -897,3 +897,48 @@ jobs:
         echo "   Codacy: https://app.codacy.com/gh/marcusquinn/aidevops"
         echo ""
         echo "Code Quality Pipeline: COMPLETE"
+
+  markdownlint:
+    name: Markdown Lint
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      with:
+        fetch-depth: 0
+
+    - name: Set up Node.js
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      with:
+        node-version: '20'
+
+    - name: Get changed markdown files
+      id: changed
+      run: |
+        base="${{ github.event.pull_request.base.sha }}"
+        head="${{ github.event.pull_request.head.sha }}"
+        files=$(git diff --name-only --diff-filter=ACM "$base" "$head" -- '*.md' | tr '\n' ' ')
+        echo "files=$files" >> "$GITHUB_OUTPUT"
+
+    - name: Run markdownlint-cli2
+      if: steps.changed.outputs.files != ''
+      run: npx --yes markdownlint-cli2@0.22.0 ${{ steps.changed.outputs.files }}
+
+  biome:
+    name: Biome CI
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+    - name: Set up Node.js
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      with:
+        node-version: '20'
+
+    - name: Run biome ci
+      run: npx --yes @biomejs/biome@2.4.12 ci .


### PR DESCRIPTION
## Summary

Adds two new CI jobs to .github/workflows/code-quality.yml: (1) Markdown Lint job using markdownlint-cli2@0.22.0 that runs on PRs touching *.md files, skips if no markdown changed; (2) Biome CI job using @biomejs/biome@2.4.12 (matching biome.json schema version) that runs biome ci . on every PR. Both jobs are gated on pull_request events and use SHA-pinned actions following existing workflow conventions. Fails on errors, passes on warnings (advisory on existing 156-finding backlog).

## Files Changed

.github/workflows/code-quality.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** PR CI checks will show 'Markdown Lint' and 'Biome CI' job names. Both jobs run only on pull_request events. markdownlint job skips gracefully when no *.md files are changed. Biome version matches biome.json schema pin (2.4.12). Actions use SHA pins consistent with existing workflow.

Resolves #19692


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.70 plugin for [OpenCode](https://opencode.ai) v1.4.12 with claude-sonnet-4-6 spent 3m and 9,350 tokens on this as a headless worker.