### PR TITLE
t2220: add paths-ignore to Qlty workflows for docs-only PRs

### DIFF
--- a/.github/workflows/qlty-new-file-gate.yml
+++ b/.github/workflows/qlty-new-file-gate.yml
@@ -16,6 +16,18 @@ name: Qlty New-File Gate
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
+    # t2220: suppress concurrency-cancellation cascade on docs-only PRs.
+    # `gh pr create --label "a,b,c,d"` fires one `labeled` event per label
+    # after the initial `opened`; each event triggers a new run that
+    # cancels the in-flight one via `cancel-in-progress: true`. Docs-only
+    # PRs observed 15+ cancelled runs per workflow, which `gh pr checks`
+    # then surfaces as `fail` (it displays `cancelled` conclusions as
+    # `fail` in its TSV output). Filtering docs-only at the trigger
+    # level prevents the cascade entirely. In-workflow `detect-new-files`
+    # still runs for mixed PRs as a belt-and-suspenders check.
+    paths-ignore:
+      - '**/*.md'
+      - 'todo/**'
 
 permissions:
   pull-requests: write

--- a/.github/workflows/qlty-regression.yml
+++ b/.github/workflows/qlty-regression.yml
@@ -13,6 +13,18 @@ name: Qlty Regression Gate
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
+    # t2220: suppress concurrency-cancellation cascade on docs-only PRs.
+    # `gh pr create --label "a,b,c,d"` fires one `labeled` event per label
+    # after the initial `opened`; each event triggers a new run that
+    # cancels the in-flight one via `cancel-in-progress: true`. Docs-only
+    # PRs observed 15+ cancelled runs per workflow, which `gh pr checks`
+    # then surfaces as `fail` (it displays `cancelled` conclusions as
+    # `fail` in its TSV output). Filtering docs-only at the trigger
+    # level prevents the cascade entirely. In-workflow `detect-scope`
+    # still runs for mixed PRs as a belt-and-suspenders check.
+    paths-ignore:
+      - '**/*.md'
+      - 'todo/**'
 
 permissions:
   pull-requests: write


### PR DESCRIPTION
## Summary

Fixes the "fail" status seen on docs-only PRs #19704 and #19705 for the Qlty Regression Gate and Qlty New-File Gate workflows.

## Root cause

`gh pr create --label "a,b,c,d"` fires one `labeled` event per label (GitHub doesn't batch). Both Qlty workflows:
- list `labeled` in `pull_request.types`
- set `concurrency.cancel-in-progress: true` keyed on `${{ github.workflow }}-${{ github.ref }}`

So for a PR with 4 labels: `opened` → run 1; `labeled` ×4 → runs 2, 3, 4, 5 — each cancelling its predecessor. `gh pr checks` renders `cancelled` as `fail` in its TSV output, making these surface as red CI. The in-workflow `detect-scope` docs-only filter runs **after** the workflow triggers, so it can't suppress the cascade.

For PR #19704 alone, `gh api repos/.../actions/runs -f branch=chore/t2211-...` returned 15 `cancelled` + 2 `success` runs of Qlty Regression Gate in ~2 seconds. Identical cascade for Qlty New-File Gate.

## Fix

Add `paths-ignore: ['**/*.md', 'todo/**']` to the `pull_request` trigger in both Qlty workflows. For docs-only PRs the workflows won't trigger at all, eliminating the cascade. Code-touching PRs remain unaffected.

Inline comments reference t2220 for traceability.

## Resolves

Resolves #19720

---

$(~/.aidevops/agents/scripts/gh-signature-helper.sh footer --model claude-opus-4-7 --issue marcusquinn/aidevops#19720)