### PR TITLE
t2221: correct opencode upstream slug to anomalyco/opencode

### DIFF
--- a/.agents/reference/observability.md
+++ b/.agents/reference/observability.md
@@ -130,7 +130,7 @@ every tool is wrapped via
 `.pipe(Effect.orDie, Effect.withSpan("Tool.execute", { attributes: attrs }))`.
 It simply does not appear in the OTEL export in `run` mode.
 
-**What is NOT the cause** (falsified against `sst/opencode` source on
+**What is NOT the cause** (falsified against `anomalyco/opencode` source on
 2026-04-18 as part of t2212):
 
 - NOT an `AsyncLocalStorageContextManager` gap. `packages/opencode/src/effect/observability.ts`
@@ -192,16 +192,16 @@ accepted**: rely on plugin SQLite for per-tool observability in `run`
 mode. Re-evaluate if opencode fixes the span gap upstream or if a
 future version exposes a tracer handle to plugins.
 
-**Upstream status:** the active opencode upstream is `sst/opencode`
+**Upstream status:** the active opencode upstream is `anomalyco/opencode`
 (not archived, default branch `dev`, Bun-compiled TypeScript, public
 issue tracker active, verified 2026-04-18 via `gh api`). A separate,
 legacy Go codebase exists at `opencode-ai/opencode` (archived, last
 push 2025-09-18) — that is NOT the same project as the v1.4.x
 Bun-compiled TypeScript binary users actually run. The span gap may
-be resolved in a future `sst/opencode` release if a contributor lands
+be resolved in a future `anomalyco/opencode` release if a contributor lands
 an explicit span-export in the tool execution path or the AI SDK
 switches to a span-preserving execution model. File OTEL-related
-issues at `https://github.com/sst/opencode/issues`; monitor release
+issues at `https://github.com/anomalyco/opencode/issues`; monitor release
 notes there for changes.
 
 ## Verifying the OTEL integration

--- a/.agents/tools/git/opencode-github.md
+++ b/.agents/tools/git/opencode-github.md
@@ -82,7 +82,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run OpenCode
-        uses: sst/opencode/github@latest
+        uses: anomalyco/opencode/github@latest
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:
@@ -95,7 +95,7 @@ jobs:
 ## Configuration
 
 ```yaml
-- uses: sst/opencode/github@latest
+- uses: anomalyco/opencode/github@latest
   with:
     model: anthropic/claude-sonnet-4-6  # Required
     agent: build                                # Optional: agent to use

--- a/.github/workflows/opencode-agent.yml
+++ b/.github/workflows/opencode-agent.yml
@@ -272,7 +272,7 @@ jobs:
             }
       
       - name: Run OpenCode Agent
-        uses: sst/opencode/github@a52d640c8c56a5d9fb4623a1c601046c3d9a37b7 # v1.2.21
+        uses: anomalyco/opencode/github@a52d640c8c56a5d9fb4623a1c601046c3d9a37b7 # v1.2.21
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
         with:

--- a/configs/mcp-templates/opencode-github-workflow.yml
+++ b/configs/mcp-templates/opencode-github-workflow.yml
@@ -53,7 +53,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run OpenCode
-        uses: sst/opencode/github@0cf0294787322664c6d668fa5ab0a9ce26796f78 # latest
+        uses: anomalyco/opencode/github@0cf0294787322664c6d668fa5ab0a9ce26796f78 # latest
         env:
           # Use your preferred AI provider
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary

The `opencode` GitHub App and Actions integration point to the canonical `anomalyco/opencode` repository. `sst/opencode` is a legacy redirect from a prior GitHub org rename — both slugs resolve to the same repo id (`975734319`), so Actions pinning like `sst/opencode/github@<SHA>` continues to work, but docs should name the canonical owner to avoid "did I hit the right repo" confusion.

Verified via `gh api repos/anomalyco/opencode` and `gh api repos/sst/opencode`: identical `id`, `node_id`, and `full_name: anomalyco/opencode`.

## Scope

Docs + workflow templates only (4 files, 1-4 slug refs each):

- `.agents/reference/observability.md` — 4 refs
- `.agents/tools/git/opencode-github.md` — 2 refs
- `configs/mcp-templates/opencode-github-workflow.yml` — 1 ref
- `.github/workflows/opencode-agent.yml` — 1 ref

`CHANGELOG.md` historical reference at line 4083 left unchanged.

## Deferred

`.agents/scripts/opencode-github-setup-helper.sh` (2 slug refs) is deferred to a follow-up. Touching that file triggers the pre-commit `validate_string_literals` counter on pre-existing debt (24× `""`, 6× `"\$remote_type"`, 3× `"\$1"`) that is out of scope for a slug-correction PR. A follow-up issue will track the helper's slug + hygiene fix together.

## Resolves

Resolves #19722

---

$(~/.aidevops/agents/scripts/gh-signature-helper.sh footer --model claude-opus-4-7 --issue marcusquinn/aidevops#19722)