### PR TITLE
t2202: Fix CAS race in claim-task-id.sh producing duplicate task IDs under concurrent invocation

### DIFF
--- a/.agents/scripts/claim-task-id.sh
+++ b/.agents/scripts/claim-task-id.sh
@@ -475,6 +475,90 @@ read_local_counter() {
 	return 0
 }
 
+# Fetch remote counter branch and pin the commit SHA for atomic reads.
+# CRITICAL (GH#19689): all subsequent reads in the CAS function MUST use
+# the pinned SHA, never the ref name. When concurrent processes share a
+# repo, a competing push+fetch can update the local ref between our
+# counter-read and our tree/parent-read, breaking the CAS invariant.
+#
+# Echoes "pinned_sha counter_value" on success. Returns 1 on failure.
+_cas_fetch_and_pin() {
+	local repo_path="$1"
+
+	cd "$repo_path" || return 1
+
+	if ! git fetch "$REMOTE_NAME" "$COUNTER_BRANCH" 2>/dev/null; then
+		log_warn "Failed to fetch ${REMOTE_NAME}/${COUNTER_BRANCH}"
+	fi
+
+	local pinned_sha
+	pinned_sha=$(git rev-parse "${REMOTE_NAME}/${COUNTER_BRANCH}" 2>/dev/null) || {
+		log_warn "Failed to resolve ${REMOTE_NAME}/${COUNTER_BRANCH}"
+		return 1
+	}
+
+	local current_value
+	current_value=$(git show "${pinned_sha}:${COUNTER_FILE}" 2>/dev/null | tr -d '[:space:]')
+
+	if [[ -z "$current_value" ]] || ! [[ "$current_value" =~ ^[0-9]+$ ]]; then
+		log_info "Counter missing/invalid — attempting auto-bootstrap (GH#6569)"
+		local bootstrap_result
+		bootstrap_result=$(bootstrap_remote_counter "$repo_path") || true
+		git fetch "$REMOTE_NAME" "$COUNTER_BRANCH" 2>/dev/null || true
+		pinned_sha=$(git rev-parse "${REMOTE_NAME}/${COUNTER_BRANCH}" 2>/dev/null) || {
+			log_error "BOOTSTRAP_COUNTER_FAILED: cannot resolve ref after bootstrap"
+			return 1
+		}
+		current_value=$(git show "${pinned_sha}:${COUNTER_FILE}" 2>/dev/null | tr -d '[:space:]')
+		if [[ -z "$current_value" ]] || ! [[ "$current_value" =~ ^[0-9]+$ ]]; then
+			log_error "BOOTSTRAP_COUNTER_FAILED: counter unavailable after bootstrap attempt"
+			return 1
+		fi
+	fi
+
+	echo "${pinned_sha} ${current_value}"
+	return 0
+}
+
+# Build a counter-increment commit on top of pinned_sha and push it.
+# Uses git plumbing (hash-object, ls-tree, mktree, commit-tree) — safe
+# from any branch, never touches HEAD or the working tree index.
+# All reads use pinned_sha to prevent the ref-race (GH#19689).
+#
+# Returns 0 on success, 1 on hard error, 2 on retriable conflict.
+_cas_build_and_push() {
+	local pinned_sha="$1"
+	local new_counter="$2"
+	local commit_msg="$3"
+
+	local blob_sha
+	blob_sha=$(echo "$new_counter" | git hash-object -w --stdin 2>/dev/null) || {
+		log_warn "Failed to create blob"
+		return 1
+	}
+
+	local tree_sha
+	tree_sha=$(git ls-tree "${pinned_sha}" | sed "s|[0-9a-f]\{40,64\}	${COUNTER_FILE}$|${blob_sha}	${COUNTER_FILE}|" | git mktree 2>/dev/null) || {
+		log_warn "Failed to create tree"
+		return 1
+	}
+
+	local commit_sha
+	commit_sha=$(git commit-tree "$tree_sha" -p "$pinned_sha" -m "$commit_msg" 2>/dev/null) || {
+		log_warn "Failed to create commit"
+		return 1
+	}
+
+	if ! git push "$REMOTE_NAME" "${commit_sha}:refs/heads/${COUNTER_BRANCH}" 2>/dev/null; then
+		log_warn "Push failed (conflict — another session claimed an ID)"
+		git fetch "$REMOTE_NAME" "$COUNTER_BRANCH" 2>/dev/null || true
+		return 2
+	fi
+
+	git fetch "$REMOTE_NAME" "$COUNTER_BRANCH" 2>/dev/null || true
+	return 0
+}
+
 # Atomic CAS allocation: fetch → read → increment → commit → push
 # Returns 0 on success, 1 on hard error, 2 on retriable conflict
 allocate_counter_cas() {
@@ -483,20 +567,12 @@ allocate_counter_cas() {
 
 	cd "$repo_path" || return 1
 
-	# Step 1: Read current counter from <remote>/<counter_branch>.
-	# If missing/invalid, auto-bootstrap from TODO.md (GH#6569).
-	local current_value
-	if ! current_value=$(read_remote_counter "$repo_path"); then
-		log_info "Counter missing — attempting auto-bootstrap (GH#6569)"
-		local bootstrap_result
-		bootstrap_result=$(bootstrap_remote_counter "$repo_path") || true
-		# After bootstrap attempt, retry reading the counter.
-		# If another session bootstrapped concurrently, we still get a valid value.
-		if ! current_value=$(read_remote_counter "$repo_path"); then
-			log_error "BOOTSTRAP_COUNTER_FAILED: counter unavailable after bootstrap attempt"
-			return 1
-		fi
-	fi
+	# Step 1: Fetch + pin (atomic snapshot of counter + parent SHA)
+	local pin_result
+	pin_result=$(_cas_fetch_and_pin "$repo_path") || return 1
+	local pinned_sha current_value
+	pinned_sha="${pin_result%% *}"
+	current_value="${pin_result##* }"
 
 	local first_id="$current_value"
 	local last_id=$((current_value + count - 1))
@@ -504,56 +580,23 @@ allocate_counter_cas() {
 
 	log_info "Counter at ${current_value}, claiming $(printf 't%03d' "$first_id")..$(printf 't%03d' "$last_id"), new counter: ${new_counter}"
 
-	# Step 2: Build a commit directly on <remote>/<counter_branch> using plumbing commands.
-	# This is safe from any branch — we never touch HEAD or the working tree index.
-	cd "$repo_path" || return 1
+	# Per-process nonce prevents commit-identity collision (GH#19689 root cause #2).
+	# git commit-tree is content-addressed: identical inputs (tree, parent, message,
+	# timestamp) produce identical SHA. Concurrent processes in the same second all
+	# produce the same SHA, and git push returns 0 ("Everything up-to-date") for
+	# duplicates — the CAS gate silently passes. The nonce (PID + random) makes
+	# each process's commit unique.
+	local nonce="${BASHPID:-$$}_${RANDOM}"
 
 	local commit_msg="chore: claim task ID"
 	if [[ "$count" -eq 1 ]]; then
-		commit_msg="chore: claim $(printf 't%03d' "$first_id")"
+		commit_msg="chore: claim $(printf 't%03d' "$first_id") [${nonce}]"
 	else
-		commit_msg="chore: claim $(printf 't%03d' "$first_id")..$(printf 't%03d' "$last_id")"
+		commit_msg="chore: claim $(printf 't%03d' "$first_id")..$(printf 't%03d' "$last_id") [${nonce}]"
 	fi
 
-	# Create a blob with the new counter value
-	local blob_sha
-	blob_sha=$(echo "$new_counter" | git hash-object -w --stdin 2>/dev/null) || {
-		log_warn "Failed to create blob"
-		return 1
-	}
-
-	# Read <remote>/<counter_branch>'s tree, replace .task-counter with our new blob
-	local tree_sha
-	tree_sha=$(git ls-tree "${REMOTE_NAME}/${COUNTER_BRANCH}" | sed "s|[0-9a-f]\{40,64\}	${COUNTER_FILE}$|${blob_sha}	${COUNTER_FILE}|" | git mktree 2>/dev/null) || {
-		log_warn "Failed to create tree"
-		return 1
-	}
-
-	# Create a commit on top of <remote>/<counter_branch>
-	local parent_sha
-	parent_sha=$(git rev-parse "${REMOTE_NAME}/${COUNTER_BRANCH}" 2>/dev/null) || {
-		log_warn "Failed to resolve ${REMOTE_NAME}/${COUNTER_BRANCH}"
-		return 1
-	}
-
-	local commit_sha
-	commit_sha=$(git commit-tree "$tree_sha" -p "$parent_sha" -m "$commit_msg" 2>/dev/null) || {
-		log_warn "Failed to create commit"
-		return 1
-	}
-
-	# Step 3: Push the exact commit to <counter_branch> — this is the atomic gate.
-	# If another session pushed between our fetch and now, this fails (non-fast-forward).
-	# Safe from any branch: we push a specific SHA, not HEAD.
-	if ! git push "$REMOTE_NAME" "${commit_sha}:refs/heads/${COUNTER_BRANCH}" 2>/dev/null; then
-		log_warn "Push failed (conflict — another session claimed an ID)"
-		# Fetch latest for next retry attempt
-		git fetch "$REMOTE_NAME" "$COUNTER_BRANCH" 2>/dev/null || true
-		return 2
-	fi
-
-	# Update local ref so subsequent fetches see our commit
-	git fetch "$REMOTE_NAME" "$COUNTER_BRANCH" 2>/dev/null || true
+	# Step 2+3: Build commit on pinned_sha and push (atomic gate)
+	_cas_build_and_push "$pinned_sha" "$new_counter" "$commit_msg" || return $?
 
 	# Success — output the claimed IDs
 	echo "$first_id"

--- a/.agents/scripts/tests/test-claim-task-id-concurrent-cas.sh
+++ b/.agents/scripts/tests/test-claim-task-id-concurrent-cas.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-claim-task-id-concurrent-cas.sh — Regression test for GH#19689
+#
+# Verifies that N concurrent claim-task-id.sh invocations produce N
+# distinct task IDs with the counter advancing by exactly N.
+#
+# Approach: creates a local bare repo as a "remote", seeds .task-counter,
+# then launches N concurrent claim processes. Asserts:
+#   1. All N IDs are distinct
+#   2. Counter advances by exactly N
+#   3. No two commit messages share the same task ID
+#
+# Requires: bash 4+, git
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+CLAIM_SCRIPT="${SCRIPT_DIR}/../claim-task-id.sh"
+
+RED=$'\033[0;31m'
+GREEN=$'\033[0;32m'
+NC=$'\033[0m'
+
+PASS=0
+FAIL=0
+ERRORS=""
+
+pass() {
+	local name="${1:-}"
+	printf '%s[PASS]%s %s\n' "$GREEN" "$NC" "$name"
+	PASS=$((PASS + 1))
+	return 0
+}
+
+fail() {
+	local name="${1:-}"
+	local detail="${2:-}"
+	printf '%s[FAIL]%s %s\n' "$RED" "$NC" "$name"
+	[[ -n "$detail" ]] && printf '       %s\n' "$detail"
+	FAIL=$((FAIL + 1))
+	ERRORS="${ERRORS}\n  - ${name}: ${detail}"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Setup: create a local bare repo as the "remote" and a working clone
+# ---------------------------------------------------------------------------
+setup_test_repos() {
+	local base_dir="$1"
+
+	# Create bare repo (acts as "origin")
+	local bare_dir="${base_dir}/remote.git"
+	git init --bare --initial-branch=main "$bare_dir" >/dev/null 2>&1 || {
+		# Fallback for older git without --initial-branch
+		git init --bare "$bare_dir" >/dev/null 2>&1 || return 1
+	}
+
+	# Create working clone
+	local work_dir="${base_dir}/work"
+	git clone "$bare_dir" "$work_dir" >/dev/null 2>&1 || return 1
+
+	# Disable commit signing in the test repo (avoids SSH passphrase prompts)
+	git -C "$work_dir" config commit.gpgsign false >/dev/null 2>&1 || true
+	git -C "$work_dir" config tag.gpgsign false >/dev/null 2>&1 || true
+	# Set required identity for commits
+	git -C "$work_dir" config user.email "test@test.local" >/dev/null 2>&1 || true
+	git -C "$work_dir" config user.name "Test" >/dev/null 2>&1 || true
+
+	# Seed .task-counter with a known value
+	local seed_value=1000
+	printf '%s\n' "$seed_value" >"${work_dir}/.task-counter"
+
+	# Create a minimal TODO.md (required by collision check)
+	printf '# Tasks\n\n- [x] t999 seed task\n' >"${work_dir}/TODO.md"
+
+	# Initial commit + push
+	git -C "$work_dir" checkout -b main >/dev/null 2>&1 || true
+	git -C "$work_dir" add .task-counter TODO.md >/dev/null 2>&1
+	git -C "$work_dir" commit -m "chore: seed counter at ${seed_value}" >/dev/null 2>&1 || return 1
+	git -C "$work_dir" push origin main >/dev/null 2>&1 || return 1
+
+	echo "$work_dir"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test: N concurrent claims produce N distinct IDs
+# ---------------------------------------------------------------------------
+# Launch N concurrent claim-task-id processes, collect results into results_dir.
+# Returns: claimed IDs in result-{1..N}.txt files under results_dir.
+_launch_concurrent_claims() {
+	local num_concurrent="$1"
+	local work_dir="$2"
+	local results_dir="$3"
+
+	mkdir -p "$results_dir"
+	local pids=()
+	local i
+	for ((i = 1; i <= num_concurrent; i++)); do
+		(
+			local output
+			output=$("$CLAIM_SCRIPT" \
+				--title "concurrent test $i" \
+				--no-issue \
+				--repo-path "$work_dir" \
+				--counter-branch main 2>/dev/null) || true
+			local task_id
+			task_id=$(printf '%s' "$output" | grep '^task_id=' | head -1 | sed 's/^task_id=//')
+			printf '%s\n' "$task_id" >"${results_dir}/result-${i}.txt"
+		) &
+		pids+=($!)
+	done
+	for pid in "${pids[@]}"; do
+		wait "$pid" 2>/dev/null || true
+	done
+	return 0
+}
+
+# Verify concurrent claim results: all IDs distinct, counter correct, no dup commits.
+_verify_claim_results() {
+	local name="$1"
+	local num_concurrent="$2"
+	local work_dir="$3"
+	local results_dir="$4"
+	local initial_counter="$5"
+
+	# Collect results
+	local -a claimed_ids=()
+	local result_count=0 i
+	for ((i = 1; i <= num_concurrent; i++)); do
+		local result_file="${results_dir}/result-${i}.txt"
+		if [[ -f "$result_file" ]]; then
+			local tid
+			tid=$(tr -d '[:space:]' < "$result_file")
+			[[ -n "$tid" ]] && { claimed_ids+=("$tid"); result_count=$((result_count + 1)); }
+		fi
+	done
+	if [[ $result_count -ne $num_concurrent ]]; then
+		fail "$name" "expected ${num_concurrent} results, got ${result_count}"; return 0
+	fi
+
+	# All IDs distinct
+	local unique_count
+	unique_count=$(printf '%s\n' "${claimed_ids[@]}" | sort -u | wc -l | tr -d '[:space:]')
+	if [[ "$unique_count" -ne "$num_concurrent" ]]; then
+		local dups
+		dups=$(printf '%s\n' "${claimed_ids[@]}" | sort | uniq -d | tr '\n' ' ')
+		fail "$name" "expected ${num_concurrent} distinct IDs, got ${unique_count} (duplicates: ${dups})"; return 0
+	fi
+
+	# Counter advanced by exactly N
+	git -C "$work_dir" fetch origin main >/dev/null 2>&1 || true
+	local final_counter expected_counter
+	final_counter=$(git -C "$work_dir" show "origin/main:.task-counter" 2>/dev/null | tr -d '[:space:]')
+	expected_counter=$((initial_counter + num_concurrent))
+	if [[ "$final_counter" -ne "$expected_counter" ]]; then
+		fail "$name" "expected counter=${expected_counter}, got ${final_counter}"; return 0
+	fi
+
+	# No duplicate task IDs in commit messages
+	local claim_commits
+	claim_commits=$(git -C "$work_dir" log origin/main --oneline --grep="chore: claim" | grep -oE 't[0-9]+' | sort)
+	local uniq_commits total_commits
+	uniq_commits=$(printf '%s\n' "$claim_commits" | sort -u | wc -l | tr -d '[:space:]')
+	total_commits=$(printf '%s\n' "$claim_commits" | wc -l | tr -d '[:space:]')
+	if [[ "$uniq_commits" -ne "$total_commits" ]]; then
+		local dup_commits
+		dup_commits=$(printf '%s\n' "$claim_commits" | sort | uniq -d | tr '\n' ' ')
+		fail "$name" "duplicate task IDs in commit messages: ${dup_commits}"; return 0
+	fi
+
+	pass "$name"
+	return 0
+}
+
+test_concurrent_claims() {
+	local num_concurrent="${1:-10}"
+	local name="concurrent CAS: ${num_concurrent} parallel claims produce ${num_concurrent} distinct IDs"
+
+	local tmpdir
+	tmpdir=$(mktemp -d) || { fail "$name" "mktemp failed"; return 0; }
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir'" RETURN
+
+	local work_dir
+	work_dir=$(setup_test_repos "$tmpdir") || { fail "$name" "repo setup failed"; return 0; }
+
+	local initial_counter
+	initial_counter=$(git -C "$work_dir" show "origin/main:.task-counter" 2>/dev/null | tr -d '[:space:]')
+	if [[ -z "$initial_counter" ]]; then
+		fail "$name" "could not read initial counter"; return 0
+	fi
+
+	_launch_concurrent_claims "$num_concurrent" "$work_dir" "${tmpdir}/results"
+	_verify_claim_results "$name" "$num_concurrent" "$work_dir" "${tmpdir}/results" "$initial_counter"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test: verify pinned SHA prevents stale-parent race
+#
+# This is a unit-style test that sources the script and verifies that
+# allocate_counter_cas uses the pinned SHA for tree reads, not the ref.
+# We do this by checking that git ls-tree is called with a SHA pattern
+# (40+ hex chars) rather than "origin/main" in the fixed code.
+# ---------------------------------------------------------------------------
+test_pinned_sha_in_source() {
+	local name="source check: CAS helpers use pinned_sha for ls-tree and commit-tree"
+
+	# After refactoring (GH#19689), the git plumbing lives in _cas_build_and_push.
+	# Verify it uses the pinned_sha parameter, not the ref name.
+	local build_body
+	build_body=$(sed -n '/^_cas_build_and_push()/,/^}/p' "$CLAIM_SCRIPT")
+
+	# Check that git ls-tree uses the first parameter (pinned_sha)
+	if echo "$build_body" | grep -q 'git ls-tree.*pinned_sha'; then
+		: # good
+	else
+		fail "$name" "git ls-tree in _cas_build_and_push does not use pinned_sha"
+		return 0
+	fi
+
+	# Check that git commit-tree uses pinned_sha as parent
+	if echo "$build_body" | grep -q '\-p.*pinned_sha'; then
+		: # good
+	else
+		fail "$name" "git commit-tree does not use pinned_sha as parent"
+		return 0
+	fi
+
+	# Verify _cas_fetch_and_pin exists and does the pinning
+	local fetch_body
+	fetch_body=$(sed -n '/^_cas_fetch_and_pin()/,/^}/p' "$CLAIM_SCRIPT")
+	if [[ -z "$fetch_body" ]]; then
+		fail "$name" "_cas_fetch_and_pin function not found"
+		return 0
+	fi
+
+	# Verify allocate_counter_cas does NOT contain git ls-tree or rev-parse
+	# (all plumbing delegated to helpers)
+	local cas_body
+	cas_body=$(sed -n '/^allocate_counter_cas()/,/^}/p' "$CLAIM_SCRIPT")
+	if echo "$cas_body" | grep -q 'git ls-tree'; then
+		fail "$name" "allocate_counter_cas still contains git ls-tree — should be in helper"
+		return 0
+	fi
+
+	pass "$name"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Run all tests
+# ---------------------------------------------------------------------------
+main() {
+	printf 'Running claim-task-id concurrent CAS tests (GH#19689)...\n\n'
+
+	test_pinned_sha_in_source
+	test_concurrent_claims 10
+
+	printf '\n'
+	printf 'Results: %s passed, %s failed\n' "$PASS" "$FAIL"
+	if [[ "$FAIL" -gt 0 ]]; then
+		printf '\nFailed tests:%b\n' "$ERRORS"
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Fixed two race conditions in `claim-task-id.sh` `allocate_counter_cas()` that caused duplicate task IDs under concurrent invocation (GH#19689).

**Root causes identified and fixed:**

1. **Ref-race (SHA pinning):** After fetching, the commit SHA is now pinned immediately and used for ALL subsequent reads (counter value, tree, parent). Previously, re-reading the `origin/main` ref could return a different commit if a concurrent process pushed and fetched between our reads — the second process would create a valid fast-forward commit with a stale counter value.

2. **Commit identity collision (nonce):** `git commit-tree` is content-addressed: identical inputs (tree, parent, message, timestamp) produce identical SHA. Concurrent processes within the same second all produced the same commit SHA, and `git push` returned exit 0 ("Everything up-to-date") for duplicates — the CAS gate silently passed. Added a per-process nonce (`PID_RANDOM`) to the commit message to ensure unique commit SHAs.

**Refactoring:** Extracted `_cas_fetch_and_pin()` and `_cas_build_and_push()` from `allocate_counter_cas()` for clarity and to stay under the 100-line complexity threshold.

**Regression test:** `test-claim-task-id-concurrent-cas.sh` launches 10 concurrent claim processes against a local bare repo and asserts: all IDs distinct, counter advances by exactly 10, no duplicate task IDs in commit messages, and source structure uses pinned SHA.

## Testing

- shellcheck clean (only pre-existing SC1091 info on source directive)
- Existing tests (`test-claim-task-id-todo-collision.sh`): 8/8 pass
- New concurrent CAS test: 2/2 pass
- Manual verification: confirmed `git commit-tree` identity collision root cause

## Files Changed

- **EDIT:** `.agents/scripts/claim-task-id.sh` — refactored `allocate_counter_cas()`, added `_cas_fetch_and_pin()` and `_cas_build_and_push()`
- **NEW:** `.agents/scripts/tests/test-claim-task-id-concurrent-cas.sh` — regression test

Resolves #19689