### PR TITLE
t2225: feat(interactive-session-helper): post-merge subcommand for auto-heal

### DIFF
--- a/.agents/scripts/interactive-session-helper.sh
+++ b/.agents/scripts/interactive-session-helper.sh
@@ -33,6 +33,7 @@
 #   interactive-session-helper.sh release <issue> <slug> [--unassign]
 #   interactive-session-helper.sh status [<issue>]
 #   interactive-session-helper.sh scan-stale
+#   interactive-session-helper.sh post-merge <pr_number> [<slug>]
 #   interactive-session-helper.sh help
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
@@ -902,6 +903,224 @@ _isc_cmd_scan_stale() {
 }
 
 # -----------------------------------------------------------------------------
+# Subcommand: post-merge (t2225)
+# -----------------------------------------------------------------------------
+# Auto-heal two known drift patterns after a planning PR merges.
+# Called after `gh pr merge` succeeds, alongside `release <N>`.
+#
+# Heal pass 1 — t2219 workaround: removes false `status:done` on OPEN issues
+#   referenced by `For #N` / `Ref #N` keywords (planning-convention refs that
+#   issue-sync.yml title-fallback falsely closes).
+#
+# Heal pass 2 — t2218 workaround: unassigns the PR author from OPEN issues
+#   with `origin:interactive` + `auto-dispatch` + no active status label (these
+#   should be pulse-dispatched, not held by the interactive session that just
+#   finished planning).
+#
+# Both passes are idempotent, fail-open, and post short audit-trail comments
+# citing the relevant bug ID so history is traceable.
+#
+# Arguments:
+#   $1 = PR number
+#   $2 = repo slug (owner/repo) — defaults to current repo if omitted
+#
+# Exit: 0 always (fail-open contract).
+
+# _isc_post_merge_heal_status_done — t2219 workaround
+# Removes false status:done from OPEN For/Ref-referenced issues.
+# Args: $1=pr_number $2=slug $3=pr_body
+_isc_post_merge_heal_status_done() {
+	local pr_number="$1"
+	local slug="$2"
+	local body="$3"
+
+	# Extract For/Ref issue numbers (case-insensitive)
+	local for_refs
+	for_refs=$(printf '%s' "$body" \
+		| grep -oiE '(for|ref)[[:space:]]+#[0-9]+' \
+		| grep -oE '[0-9]+' | sort -u 2>/dev/null || true)
+
+	[[ -n "$for_refs" ]] || return 0
+
+	local healed=0
+	local issue_num
+	while IFS= read -r issue_num; do
+		[[ -n "$issue_num" ]] || continue
+		[[ "$issue_num" =~ ^[0-9]+$ ]] || continue
+
+		local issue_json issue_state has_done
+		issue_json=$(gh issue view "$issue_num" --repo "$slug" --json state,labels 2>/dev/null) || continue
+		issue_state=$(printf '%s' "$issue_json" | jq -r '.state // ""' 2>/dev/null) || continue
+		[[ "$issue_state" == "OPEN" ]] || continue
+
+		has_done=$(printf '%s' "$issue_json" | jq -r '[.labels[].name] | map(select(. == "status:done")) | length' 2>/dev/null) || continue
+		[[ "${has_done:-0}" -gt 0 ]] || continue
+
+		_isc_info "post-merge: healing false status:done on #$issue_num (t2219, For/Ref in PR #$pr_number)"
+		gh issue edit "$issue_num" --repo "$slug" \
+			--remove-label "status:done" \
+			--add-label "status:available" >/dev/null 2>&1 || continue
+
+		gh issue comment "$issue_num" --repo "$slug" --body \
+			"Reset \`status:done\` → \`status:available\` — PR #${pr_number} referenced this via \`For\`/\`Ref\` (planning convention), not \`Closes\`/\`Resolves\`. Workaround for [t2219](../issues/19719) (\`issue-sync.yml\` title-fallback false-positive)." \
+			>/dev/null 2>&1 || true
+
+		healed=$((healed + 1))
+	done <<<"$for_refs"
+
+	[[ $healed -gt 0 ]] && _isc_info "post-merge: healed status:done on $healed issue(s) (t2219)"
+	return 0
+}
+
+# _isc_post_merge_heal_stale_self_assign — t2218 workaround
+# Unassigns PR author from auto-dispatch issues with no active status.
+# Args: $1=pr_number $2=slug $3=pr_body $4=pr_author
+_isc_post_merge_heal_stale_self_assign() {
+	local pr_number="$1"
+	local slug="$2"
+	local body="$3"
+	local pr_author="$4"
+
+	[[ -n "$pr_author" ]] || return 0
+
+	# Extract ALL issue refs (closing keywords + For/Ref)
+	local all_refs
+	all_refs=$(printf '%s' "$body" \
+		| grep -oiE '(closes?|fixes?|resolves?|for|ref)[[:space:]]+#[0-9]+' \
+		| grep -oE '[0-9]+' | sort -u 2>/dev/null || true)
+
+	[[ -n "$all_refs" ]] || return 0
+
+	local healed=0
+	local issue_num
+	while IFS= read -r issue_num; do
+		[[ -n "$issue_num" ]] || continue
+		[[ "$issue_num" =~ ^[0-9]+$ ]] || continue
+
+		local issue_json issue_state labels_str has_author
+		issue_json=$(gh issue view "$issue_num" --repo "$slug" --json state,labels,assignees 2>/dev/null) || continue
+		issue_state=$(printf '%s' "$issue_json" | jq -r '.state // ""' 2>/dev/null) || continue
+		[[ "$issue_state" == "OPEN" ]] || continue
+
+		labels_str=$(printf '%s' "$issue_json" | jq -r '[.labels[].name] | join(",")' 2>/dev/null) || continue
+
+		# Require origin:interactive + auto-dispatch
+		[[ ",$labels_str," == *",origin:interactive,"* ]] || continue
+		[[ ",$labels_str," == *",auto-dispatch,"* ]] || continue
+		# Skip if actively worked
+		[[ ",$labels_str," != *",status:in-review,"* ]] || continue
+		[[ ",$labels_str," != *",status:in-progress,"* ]] || continue
+
+		has_author=$(printf '%s' "$issue_json" | jq -r --arg u "$pr_author" \
+			'[.assignees[].login] | map(select(. == $u)) | length' 2>/dev/null) || continue
+		[[ "${has_author:-0}" -gt 0 ]] || continue
+
+		_isc_info "post-merge: healing stale self-assignment on #$issue_num (t2218, author=$pr_author)"
+		gh issue edit "$issue_num" --repo "$slug" --remove-assignee "$pr_author" >/dev/null 2>&1 || continue
+
+		gh issue comment "$issue_num" --repo "$slug" --body \
+			"Unassigned @${pr_author} — this issue has \`auto-dispatch\` and should be pulse-dispatched to a worker. Workaround for [t2218](../issues/19718) (\`claim-task-id.sh\` missing t2157 carve-out in \`_auto_assign_issue\`)." \
+			>/dev/null 2>&1 || true
+
+		healed=$((healed + 1))
+	done <<<"$all_refs"
+
+	[[ $healed -gt 0 ]] && _isc_info "post-merge: healed stale self-assignment on $healed issue(s) (t2218)"
+	return 0
+}
+
+# _isc_cmd_post_merge — entry point for the post-merge subcommand
+_isc_cmd_post_merge() {
+	local pr_number="" slug=""
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		-h | --help)
+			_isc_cmd_help
+			return 0
+			;;
+		*)
+			if [[ -z "$pr_number" ]]; then
+				pr_number="$1"
+			elif [[ -z "$slug" ]]; then
+				slug="$1"
+			else
+				_isc_warn "post-merge: unexpected argument: $1 (ignored)"
+			fi
+			shift
+			;;
+		esac
+	done
+
+	if [[ -z "$pr_number" ]]; then
+		_isc_err "post-merge: <pr_number> is required"
+		_isc_err "usage: interactive-session-helper.sh post-merge <pr_number> [<slug>]"
+		return 2
+	fi
+
+	if [[ ! "$pr_number" =~ ^[0-9]+$ ]]; then
+		_isc_err "post-merge: <pr_number> must be numeric (got: $pr_number)"
+		return 2
+	fi
+
+	# Resolve slug from repos.json if not provided
+	if [[ -z "$slug" ]]; then
+		local repos_json="${HOME}/.config/aidevops/repos.json"
+		if [[ -f "$repos_json" ]]; then
+			local repo_dir
+			repo_dir=$(git rev-parse --show-toplevel 2>/dev/null || echo "")
+			if [[ -n "$repo_dir" ]]; then
+				slug=$(jq -r --arg p "$repo_dir" \
+					'.initialized_repos[] | select(.path == $p) | .slug // empty' \
+					"$repos_json" 2>/dev/null | head -1 || true)
+			fi
+		fi
+	fi
+
+	if [[ -z "$slug" ]]; then
+		# Last-resort: derive from git remote
+		local remote_url
+		remote_url=$(git remote get-url origin 2>/dev/null || echo "")
+		if [[ "$remote_url" =~ github\.com[:/]([^/]+/[^/]+?)(\.git)?$ ]]; then
+			slug="${BASH_REMATCH[1]}"
+		fi
+	fi
+
+	if [[ -z "$slug" ]]; then
+		_isc_err "post-merge: could not determine repo slug; pass it explicitly"
+		return 2
+	fi
+
+	if ! _isc_gh_reachable; then
+		_isc_warn "post-merge: gh offline — skipping post-merge heal for PR #$pr_number"
+		return 0
+	fi
+
+	# Fetch PR metadata
+	local pr_json merged_at state body author
+	pr_json=$(gh pr view "$pr_number" --repo "$slug" --json body,author,mergedAt,state 2>/dev/null) || {
+		_isc_warn "post-merge: gh unavailable or PR #$pr_number not accessible; skipping"
+		return 0
+	}
+
+	merged_at=$(printf '%s' "$pr_json" | jq -r '.mergedAt // ""' 2>/dev/null || echo "")
+	state=$(printf '%s' "$pr_json" | jq -r '.state // ""' 2>/dev/null || echo "")
+	body=$(printf '%s' "$pr_json" | jq -r '.body // ""' 2>/dev/null || echo "")
+	author=$(printf '%s' "$pr_json" | jq -r '.author.login // ""' 2>/dev/null || echo "")
+
+	if [[ -z "$merged_at" || "$state" != "MERGED" ]]; then
+		_isc_info "post-merge: PR #$pr_number not merged (state=$state); skipping"
+		return 0
+	fi
+
+	_isc_info "post-merge: auditing PR #$pr_number ($slug) for drift patterns"
+	_isc_post_merge_heal_status_done "$pr_number" "$slug" "$body"
+	_isc_post_merge_heal_stale_self_assign "$pr_number" "$slug" "$body" "$author"
+	_isc_info "post-merge: done"
+	return 0
+}
+
+# -----------------------------------------------------------------------------
 # Subcommand: help
 # -----------------------------------------------------------------------------
 _isc_cmd_help() {
@@ -933,6 +1152,16 @@ USAGE:
       Phase 2  — Scan all pulse-enabled repos for closed-not-merged PRs
                  (last 14 days) whose linked issue is still OPEN. Surfaces
                  these as recovery candidates. Does NOT auto-reopen.
+
+  interactive-session-helper.sh post-merge <pr_number> [<slug>]
+      Auto-heal two known drift patterns after a planning PR merges (t2225).
+      Call after `gh pr merge` succeeds, alongside `release <N>`.
+      Heal 1 (t2219): removes false status:done on OPEN For/Ref-referenced
+        issues — planning-convention refs that issue-sync.yml falsely closes.
+      Heal 2 (t2218): unassigns PR author from OPEN auto-dispatch issues with
+        origin:interactive + no active status label (should be pulse-dispatched).
+      Both passes are idempotent, fail-open, and post audit-trail comments.
+      Slug defaults to the current repo if not provided.
 
   interactive-session-helper.sh help
       Print this message.
@@ -977,6 +1206,9 @@ main() {
 		;;
 	scan-stale)
 		_isc_cmd_scan_stale "$@" || rc=$?
+		;;
+	post-merge)
+		_isc_cmd_post_merge "$@" || rc=$?
 		;;
 	help | -h | --help)
 		_isc_cmd_help || rc=$?

--- a/.agents/scripts/tests/test-interactive-session-post-merge.sh
+++ b/.agents/scripts/tests/test-interactive-session-post-merge.sh
@@ -1,0 +1,360 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-interactive-session-post-merge.sh — Regression tests for the post-merge subcommand (t2225)
+#
+# Covers:
+#   1. Positive t2219: For #X + OPEN + status:done → removes status:done, adds status:available
+#   2. Negative t2219: Closes #X + OPEN + status:done → NOT touched (legitimate close)
+#   3. Positive t2218: For #X + OPEN + origin:interactive + auto-dispatch + assignee=author → unassigns
+#   4. Negative t2218: For #X + OPEN + origin:interactive + auto-dispatch + status:in-review → NOT unassigned
+#   5. Idempotency: second run on already-healthy PR makes no edits
+#   6. Fail-open: unmerged PR → returns 0 without editing
+#   7. Both heals fire in same run when applicable
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+HELPER_SCRIPT="${SCRIPT_DIR}/../interactive-session-helper.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+GH_EDIT_LOG=""
+GH_COMMENT_LOG=""
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+	GH_EDIT_LOG="${TEST_ROOT}/gh_edit.log"
+	GH_COMMENT_LOG="${TEST_ROOT}/gh_comment.log"
+
+	mkdir -p "${TEST_ROOT}/bin"
+	export PATH="${TEST_ROOT}/bin:${PATH}"
+	# Point HOME to TEST_ROOT so no real gh auth is attempted
+	export HOME="${TEST_ROOT}"
+	mkdir -p "${TEST_ROOT}/.config/aidevops"
+
+	# Stub git for slug resolution fallback
+	cat >"${TEST_ROOT}/bin/git" <<'GITEOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "remote" && "${2:-}" == "get-url" ]]; then
+	printf 'https://github.com/testorg/testrepo.git\n'
+	exit 0
+fi
+if [[ "${1:-}" == "rev-parse" && "${2:-}" == "--show-toplevel" ]]; then
+	printf '/home/user/Git/testrepo\n'
+	exit 0
+fi
+exit 0
+GITEOF
+	chmod +x "${TEST_ROOT}/bin/git"
+
+	return 0
+}
+
+teardown_test_env() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+# Build a JSON array of single-key objects: [{key:v1},{key:v2},...]
+# Args: $1=key $2=csv-values
+# Prints the JSON array to stdout.
+_build_obj_json_array() {
+	local key="$1"
+	local csv="$2"
+	local result="[" first=1 item
+	IFS=',' read -ra _arr <<<"$csv"
+	for item in "${_arr[@]}"; do
+		item="${item#"${item%%[![:space:]]*}"}"
+		item="${item%"${item##*[![:space:]]}"}"
+		[[ -n "$item" ]] || continue
+		if [[ $first -eq 1 ]]; then
+			result+='{"'"$key"'":"'"$item"'"}'
+			first=0
+		else
+			result+=',{"'"$key"'":"'"$item"'"}'
+		fi
+	done
+	result+="]"
+	printf '%s' "$result"
+	return 0
+}
+
+# Create a gh stub that returns constructed PR and issue responses.
+#
+# Args:
+#   pr_body      — PR body text (string)
+#   pr_state     — MERGED or OPEN (default MERGED)
+#   pr_author    — PR author login (default testauthor)
+#   issue_num    — which issue number the stub responds to (default 42)
+#   issue_state  — OPEN or CLOSED (default OPEN)
+#   issue_labels — comma-separated label names (default "status:available")
+#   issue_assignees — comma-separated assignee logins (default "")
+create_gh_stub() {
+	local pr_body="${1:-}"
+	local pr_state="${2:-MERGED}"
+	local pr_author="${3:-testauthor}"
+	local issue_num="${4:-42}"
+	local issue_state="${5:-OPEN}"
+	local issue_labels_csv="${6:-status:available}"
+	local issue_assignees_csv="${7:-}"
+
+	local labels_json assignees_json
+	labels_json=$(_build_obj_json_array "name" "$issue_labels_csv")
+	assignees_json=$(_build_obj_json_array "login" "$issue_assignees_csv")
+
+	# Escape the PR body for embedding in the shell heredoc
+	local escaped_body
+	escaped_body=$(printf '%s' "$pr_body" | sed "s/'/'\\''/g")
+
+	local merged_at=""
+	if [[ "$pr_state" == "MERGED" ]]; then
+		merged_at="2026-04-18T12:00:00Z"
+	fi
+
+	local gh_edit_log_path="$GH_EDIT_LOG"
+	local gh_comment_log_path="$GH_COMMENT_LOG"
+
+	cat >"${TEST_ROOT}/bin/gh" <<GHEOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+GH_EDIT_LOG="${gh_edit_log_path}"
+GH_COMMENT_LOG="${gh_comment_log_path}"
+
+# auth status — succeed so _isc_gh_reachable passes
+if [[ "\${1:-}" == "auth" && "\${2:-}" == "status" ]]; then
+	exit 0
+fi
+
+# api user — return a user login
+if [[ "\${1:-}" == "api" && "\${2:-}" == "user" ]]; then
+	printf '{"login":"testauthor"}\n'
+	exit 0
+fi
+
+# pr view — return PR metadata
+if [[ "\${1:-}" == "pr" && "\${2:-}" == "view" ]]; then
+	printf '%s\n' '{"state":"${pr_state}","mergedAt":"${merged_at}","body":"${escaped_body}","author":{"login":"${pr_author}"}}'
+	exit 0
+fi
+
+# issue view — return issue metadata for any issue number
+if [[ "\${1:-}" == "issue" && "\${2:-}" == "view" ]]; then
+	printf '%s\n' '{"state":"${issue_state}","labels":${labels_json},"assignees":${assignees_json}}'
+	exit 0
+fi
+
+# issue edit — log the invocation, succeed
+if [[ "\${1:-}" == "issue" && "\${2:-}" == "edit" ]]; then
+	printf '%s\n' "\$*" >> "\$GH_EDIT_LOG"
+	exit 0
+fi
+
+# issue comment — log the invocation, succeed
+if [[ "\${1:-}" == "issue" && "\${2:-}" == "comment" ]]; then
+	printf '%s\n' "\$*" >> "\$GH_COMMENT_LOG"
+	exit 0
+fi
+
+printf 'unsupported gh invocation in stub: %s\n' "\$*" >&2
+exit 1
+GHEOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+	# Clear logs for each test
+	: >"$GH_EDIT_LOG"
+	: >"$GH_COMMENT_LOG"
+	return 0
+}
+
+# ─── Test 1: Positive t2219 — For #X + OPEN + status:done → healed ─────────
+test_t2219_for_ref_open_statusdone_healed() {
+	local pr_body="For #42"
+	create_gh_stub "$pr_body" "MERGED" "testauthor" "42" "OPEN" "status:done,auto-dispatch"
+
+	bash "$HELPER_SCRIPT" post-merge 100 testorg/testrepo >/dev/null 2>&1 || true
+
+	if grep -q "\-\-remove-label" "$GH_EDIT_LOG" && grep -q "status:done" "$GH_EDIT_LOG"; then
+		print_result "t2219: For #42 + OPEN + status:done → status:done removed" 0
+	else
+		print_result "t2219: For #42 + OPEN + status:done → status:done removed" 1 \
+			"Expected gh issue edit --remove-label status:done; got: $(cat "$GH_EDIT_LOG")"
+	fi
+	return 0
+}
+
+# ─── Test 2: Negative t2219 — Closes #X + OPEN + status:done → NOT touched ──
+test_t2219_closes_open_statusdone_not_touched() {
+	local pr_body="Closes #42"
+	create_gh_stub "$pr_body" "MERGED" "testauthor" "42" "OPEN" "status:done,auto-dispatch"
+
+	bash "$HELPER_SCRIPT" post-merge 100 testorg/testrepo >/dev/null 2>&1 || true
+
+	# t2219 heal only fires on For/Ref — Closes must NOT trigger it
+	if grep -q "status:done" "$GH_EDIT_LOG" 2>/dev/null; then
+		print_result "t2219: Closes #42 + status:done → NOT touched (legitimate close)" 1 \
+			"gh issue edit was called with status:done despite Closes keyword"
+	else
+		print_result "t2219: Closes #42 + status:done → NOT touched (legitimate close)" 0
+	fi
+	return 0
+}
+
+# ─── Test 3: Positive t2218 — For #42 + origin:interactive + auto-dispatch + assignee → unassigned ─
+test_t2218_for_ref_interactive_autodispatch_healed() {
+	local pr_body="For #42"
+	create_gh_stub "$pr_body" "MERGED" "testauthor" "42" "OPEN" \
+		"origin:interactive,auto-dispatch,status:queued" "testauthor"
+
+	bash "$HELPER_SCRIPT" post-merge 100 testorg/testrepo >/dev/null 2>&1 || true
+
+	if grep -q "\-\-remove-assignee" "$GH_EDIT_LOG"; then
+		print_result "t2218: auto-dispatch + self-assigned + no active status → unassigned" 0
+	else
+		print_result "t2218: auto-dispatch + self-assigned + no active status → unassigned" 1 \
+			"Expected gh issue edit --remove-assignee; got: $(cat "$GH_EDIT_LOG")"
+	fi
+	return 0
+}
+
+# ─── Test 4: Negative t2218 — status:in-review present → NOT unassigned ─────
+test_t2218_in_review_not_unassigned() {
+	local pr_body="For #42"
+	create_gh_stub "$pr_body" "MERGED" "testauthor" "42" "OPEN" \
+		"origin:interactive,auto-dispatch,status:in-review" "testauthor"
+
+	bash "$HELPER_SCRIPT" post-merge 100 testorg/testrepo >/dev/null 2>&1 || true
+
+	if grep -q "\-\-remove-assignee" "$GH_EDIT_LOG" 2>/dev/null; then
+		print_result "t2218: status:in-review present → NOT unassigned" 1 \
+			"gh issue edit --remove-assignee was called despite status:in-review"
+	else
+		print_result "t2218: status:in-review present → NOT unassigned" 0
+	fi
+	return 0
+}
+
+# ─── Test 5: Idempotency — no status:done, no stale assign → no edits ────────
+test_idempotency_no_edits_needed() {
+	local pr_body="For #42"
+	# Clean issue: no status:done, no stale self-assign (not assigned at all)
+	create_gh_stub "$pr_body" "MERGED" "testauthor" "42" "OPEN" \
+		"origin:interactive,auto-dispatch,status:available" ""
+
+	bash "$HELPER_SCRIPT" post-merge 100 testorg/testrepo >/dev/null 2>&1 || true
+
+	local edit_count comment_count
+	edit_count=$(wc -l <"$GH_EDIT_LOG" 2>/dev/null || echo "0")
+	comment_count=$(wc -l <"$GH_COMMENT_LOG" 2>/dev/null || echo "0")
+
+	# Trim whitespace from wc output
+	edit_count="${edit_count// /}"
+	comment_count="${comment_count// /}"
+
+	if [[ "${edit_count:-0}" -eq 0 && "${comment_count:-0}" -eq 0 ]]; then
+		print_result "idempotency: already-healthy PR makes no edits" 0
+	else
+		print_result "idempotency: already-healthy PR makes no edits" 1 \
+			"Expected 0 edits/comments; got edits=$edit_count comments=$comment_count"
+	fi
+	return 0
+}
+
+# ─── Test 6: Fail-open — unmerged PR → exit 0, no edits ─────────────────────
+test_failopen_unmerged_pr() {
+	local pr_body="For #42"
+	create_gh_stub "$pr_body" "OPEN" "testauthor" "42" "OPEN" "status:done"
+
+	local exit_code=0
+	bash "$HELPER_SCRIPT" post-merge 100 testorg/testrepo >/dev/null 2>&1 || exit_code=$?
+
+	local edit_count
+	edit_count=$(wc -l <"$GH_EDIT_LOG" 2>/dev/null || echo "0")
+	edit_count="${edit_count// /}"
+
+	if [[ "$exit_code" -eq 0 && "${edit_count:-0}" -eq 0 ]]; then
+		print_result "fail-open: unmerged PR → exit 0, no edits" 0
+	else
+		print_result "fail-open: unmerged PR → exit 0, no edits" 1 \
+			"exit_code=$exit_code edits=$edit_count (expected 0 and 0)"
+	fi
+	return 0
+}
+
+# ─── Test 7: Both heals fire in same run ─────────────────────────────────────
+test_both_heals_fire_together() {
+	# PR references same issue via For #42; issue has BOTH status:done AND is
+	# self-assigned with auto-dispatch + origin:interactive (no active status)
+	local pr_body="For #42"
+	create_gh_stub "$pr_body" "MERGED" "testauthor" "42" "OPEN" \
+		"status:done,origin:interactive,auto-dispatch" "testauthor"
+
+	bash "$HELPER_SCRIPT" post-merge 100 testorg/testrepo >/dev/null 2>&1 || true
+
+	local has_status_edit has_assignee_edit
+	has_status_edit=0
+	has_assignee_edit=0
+	grep -q "status:done" "$GH_EDIT_LOG" 2>/dev/null && has_status_edit=1
+	grep -q "\-\-remove-assignee" "$GH_EDIT_LOG" 2>/dev/null && has_assignee_edit=1
+
+	if [[ $has_status_edit -eq 1 && $has_assignee_edit -eq 1 ]]; then
+		print_result "both heals fire in same run (t2219 + t2218)" 0
+	else
+		print_result "both heals fire in same run (t2219 + t2218)" 1 \
+			"status_edit=$has_status_edit assignee_edit=$has_assignee_edit (expected both 1)"
+	fi
+	return 0
+}
+
+# ─── Main ────────────────────────────────────────────────────────────────────
+
+main() {
+	setup_test_env
+
+	printf 'Running post-merge regression tests (t2225)...\n\n'
+
+	test_t2219_for_ref_open_statusdone_healed
+	test_t2219_closes_open_statusdone_not_touched
+	test_t2218_for_ref_interactive_autodispatch_healed
+	test_t2218_in_review_not_unassigned
+	test_idempotency_no_edits_needed
+	test_failopen_unmerged_pr
+	test_both_heals_fire_together
+
+	printf '\n%d test(s) run, %d failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+
+	teardown_test_env
+
+	if [[ $TESTS_FAILED -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Add `post-merge <PR_NUMBER> [<slug>]` subcommand to `interactive-session-helper.sh` that auto-heals two known drift patterns after a planning PR merges (t2225).

- **Heal 1 (t2219 workaround):** removes false `status:done` on OPEN `For/Ref`-referenced issues — `issue-sync.yml` title-fallback falsely closes these planning-convention refs
- **Heal 2 (t2218 workaround):** unassigns PR author from OPEN issues with `origin:interactive` + `auto-dispatch` + no active status label
- Both passes are idempotent, fail-open, and post short audit-trail comments citing the relevant bug ID
- Regression test: 7 assertions (positive t2219, negative t2219, positive t2218, negative t2218, idempotency, fail-open, combined)

## Files Changed

- `EDIT: .agents/scripts/interactive-session-helper.sh` — added `post-merge` subcommand + `_isc_post_merge_heal_status_done()` + `_isc_post_merge_heal_stale_self_assign()` helpers + updated `--help` text + dispatcher
- `NEW: .agents/scripts/tests/test-interactive-session-post-merge.sh` — 7-case regression test with gh stubbing

## Verification

```
# ShellCheck clean
shellcheck .agents/scripts/interactive-session-helper.sh
shellcheck .agents/scripts/tests/test-interactive-session-post-merge.sh

# All 7 tests pass
bash .agents/scripts/tests/test-interactive-session-post-merge.sh
# → 7 test(s) run, 0 failed.

# Help text includes the new subcommand
bash .agents/scripts/interactive-session-helper.sh --help | grep post-merge
```

Resolves #19732