### PR TITLE
GH#19727: GH#19727: wire up Hostinger SSH key auth in wp-helper, hostinger-helper, docs, and template

### DIFF
--- a/.agents/scripts/hostinger-helper.sh
+++ b/.agents/scripts/hostinger-helper.sh
@@ -65,29 +65,38 @@ connect_site() {
     local port
     local username
     local password_file
+    local ssh_identity_file
     local domain_path
     server=$(jq -r ".sites.$site.server" "$CONFIG_FILE")
     port=$(jq -r ".sites.$site.port" "$CONFIG_FILE")
     username=$(jq -r ".sites.$site.username" "$CONFIG_FILE")
-    password_file=$(jq -r ".sites.$site.password_file" "$CONFIG_FILE")
+    password_file=$(jq -r ".sites.$site.password_file // empty" "$CONFIG_FILE")
+    ssh_identity_file=$(jq -r ".sites.$site.ssh_identity_file // empty" "$CONFIG_FILE")
     domain_path=$(jq -r ".sites.$site.domain_path" "$CONFIG_FILE")
-    
+
     if [[ "$server" == "null" ]]; then
         print_error "Site not found: $site"
         list_sites
         exit 1
     fi
-    
+
     print_info "Connecting to $site..."
-    
-    # Check if password file exists
+
+    # Prefer SSH key auth if configured (Hostinger recommends it)
+    if [[ -n "$ssh_identity_file" ]]; then
+        local expanded_identity="${ssh_identity_file/#\~/$HOME}"
+        ssh -i "$expanded_identity" -p "$port" "$username@$server" -t "cd $domain_path && bash" || exit
+        return 0
+    fi
+
+    # Fallback: sshpass with password file (backward compatible)
     password_file="${password_file/\~/$HOME}"
     if [[ ! -f "$password_file" ]]; then
         print_error "Password file not found: $password_file"
         print_info "Create password file: echo 'your-password' > $password_file && chmod 600 $password_file"
         exit 1
     fi
-    
+
     # Connect with sshpass
     sshpass -f "$password_file" ssh -p "$port" "$username@$server" -t "cd $domain_path && bash" || exit
     return 0
@@ -109,21 +118,31 @@ exec_on_site() {
     local port
     local username
     local password_file
+    local ssh_identity_file
     local domain_path
     server=$(jq -r ".sites.$site.server" "$CONFIG_FILE")
     port=$(jq -r ".sites.$site.port" "$CONFIG_FILE")
     username=$(jq -r ".sites.$site.username" "$CONFIG_FILE")
-    password_file=$(jq -r ".sites.$site.password_file" "$CONFIG_FILE")
+    password_file=$(jq -r ".sites.$site.password_file // empty" "$CONFIG_FILE")
+    ssh_identity_file=$(jq -r ".sites.$site.ssh_identity_file // empty" "$CONFIG_FILE")
     domain_path=$(jq -r ".sites.$site.domain_path" "$CONFIG_FILE")
-    
+
     if [[ "$server" == "null" ]]; then
         print_error "Site not found: $site"
         exit 1
     fi
-    
-    password_file="${password_file/\~/$HOME}"
+
     print_info "Executing '$command' on $site..."
-    
+
+    # Prefer SSH key auth if configured (Hostinger recommends it)
+    if [[ -n "$ssh_identity_file" ]]; then
+        local expanded_identity="${ssh_identity_file/#\~/$HOME}"
+        ssh -i "$expanded_identity" -p "$port" "$username@$server" "cd $domain_path && $command" || exit
+        return 0
+    fi
+
+    # Fallback: sshpass with password file (backward compatible)
+    password_file="${password_file/\~/$HOME}"
     sshpass -f "$password_file" ssh -p "$port" "$username@$server" "cd $domain_path && $command" || exit
     return 0
 }

--- a/.agents/scripts/wp-helper.sh
+++ b/.agents/scripts/wp-helper.sh
@@ -320,7 +320,12 @@ execute_wp_via_ssh() {
 		return $?
 		;;
 	hostinger | closte)
-		# Hostinger/Closte - sshpass with password file
+		# Prefer SSH key auth if configured (Hostinger supports and recommends it)
+		if [[ -n "$ssh_identity_file" ]]; then
+			ssh -n "${ssh_identity_flag[@]}" -p "$ssh_port" "${ssh_user}@${ssh_host}" "$remote_cmd"
+			return $?
+		fi
+		# Fallback: sshpass with password file (backward compatible for password-auth users)
 		check_sshpass
 		local expanded_password_file
 		if [[ -n "$password_file" ]]; then
@@ -347,7 +352,7 @@ execute_wp_via_ssh() {
 			print_info "Fix with: chmod 600 $expanded_password_file"
 		fi
 
-		sshpass -f "$expanded_password_file" ssh -n "${ssh_identity_flag[@]}" -p "$ssh_port" "${ssh_user}@${ssh_host}" "$remote_cmd"
+		sshpass -f "$expanded_password_file" ssh -n -p "$ssh_port" "${ssh_user}@${ssh_host}" "$remote_cmd"
 		return $?
 		;;
 	hetzner | cloudways | cloudron)

--- a/.agents/services/hosting/hostinger.md
+++ b/.agents/services/hosting/hostinger.md
@@ -22,9 +22,9 @@ tools:
 - **Type**: Shared/VPS/Cloud hosting, budget-friendly
 - **API**: REST at `https://developers.hostinger.com`
 - **Auth**: Bearer token in `~/.config/aidevops/credentials.sh` as `HOSTINGER_API_TOKEN`
-- **SSH**: Port 65002, password auth (no SSH keys on shared)
+- **SSH**: Port 65002, key auth (recommended) or password auth; framework prefers key when `ssh_identity_file` is configured
 - **Panel**: Custom hPanel
-- **No MCP required** — uses curl for API, sshpass for SSH
+- **No MCP required** — uses curl for API, ssh for key auth or sshpass for password auth
 
 <!-- AI-CONTEXT-END -->
 
@@ -45,21 +45,26 @@ Config structure:
       "server": "server-hostname-or-ip",
       "port": 65002,
       "username": "u123456789",
-      "password_file": "~/.ssh/hostinger_password",
+      "ssh_identity_file": "~/.ssh/hostinger_ed25519",
       "domain_path": "/domains/example.com/public_html",
       "description": "Main website"
     }
   },
   "default_settings": {
     "port": 65002,
-    "username_pattern": "u[0-9]+",
-    "password_authentication": true,
-    "ssh_keys_supported": false
+    "username_pattern": "u[0-9]+"
   }
 }
 ```
 
-Password file setup:
+SSH key setup (recommended):
+
+```bash
+ssh-keygen -t ed25519 -f ~/.ssh/hostinger_ed25519
+# Upload ~/.ssh/hostinger_ed25519.pub via hPanel → SSH Keys
+```
+
+Password file setup (fallback):
 
 ```bash
 echo 'your-hostinger-password' > ~/.ssh/hostinger_password
@@ -86,8 +91,8 @@ sudo apt-get install sshpass  # Linux
 
 ## Security
 
+- SSH key auth is recommended; set `ssh_identity_file` in site config (e.g. `~/.ssh/hostinger_ed25519`)
 - Store passwords in files with 600 permissions; never commit them
-- SSH keys not supported on shared hosting — password auth only
 - Port 65002 (non-standard); be aware of concurrent connection limits
 
 Set web file permissions:

--- a/configs/hostinger-config.json.txt
+++ b/configs/hostinger-config.json.txt
@@ -4,15 +4,15 @@
       "server": "server-hostname-or-ip",
       "port": 65002,
       "username": "u123456789",
-      "password_file": "~/.ssh/hostinger_password",
+      "ssh_identity_file": "~/.ssh/hostinger_ed25519",
       "domain_path": "/domains/example.com/public_html",
-      "description": "Main website"
+      "description": "Main website (SSH key auth — recommended)"
     },
     "blog.example.com": {
       "server": "server-hostname-or-ip",
       "port": 65002,
       "username": "u123456789",
-      "password_file": "~/.ssh/hostinger_password",
+      "ssh_identity_file": "~/.ssh/hostinger_ed25519",
       "domain_path": "/domains/blog.example.com/public_html",
       "description": "Company blog"
     },
@@ -22,13 +22,13 @@
       "username": "u123456789",
       "password_file": "~/.ssh/hostinger_password",
       "domain_path": "/domains/shop.example.com/public_html",
-      "description": "Online store"
+      "description": "Online store (password auth fallback example)"
     },
     "api.example.com": {
       "server": "server-hostname-or-ip",
       "port": 65002,
       "username": "u123456789",
-      "password_file": "~/.ssh/hostinger_password",
+      "ssh_identity_file": "~/.ssh/hostinger_ed25519",
       "domain_path": "/domains/api.example.com/public_html",
       "description": "API backend"
     },
@@ -36,7 +36,7 @@
       "server": "server-hostname-or-ip",
       "port": 65002,
       "username": "u123456789",
-      "password_file": "~/.ssh/hostinger_password",
+      "ssh_identity_file": "~/.ssh/hostinger_ed25519",
       "domain_path": "/domains/docs.example.com/public_html",
       "description": "Documentation site"
     }
@@ -49,6 +49,7 @@
     "server": "server-hostname-or-ip",
     "port": 65002,
     "username": "u123456789",
+    "ssh_identity_file": "~/.ssh/hostinger_ed25519",
     "password_file": "~/.ssh/hostinger_password"
   }
 }


### PR DESCRIPTION
## Summary

Wired SSH key auth into the Hostinger hosting path across four files. The wp-helper.sh hostinger|closte branch and hostinger-helper.sh connect_site/exec_on_site now prefer ssh_identity_file key auth when configured, falling back to sshpass only when no key is set. Updated hostinger.md to correct the stale 'no SSH keys on shared' claim and recommend keys. Updated configs/hostinger-config.json.txt to show ssh_identity_file as the primary auth option.

## Files Changed

.agents/scripts/hostinger-helper.sh,.agents/scripts/wp-helper.sh,.agents/services/hosting/hostinger.md,configs/hostinger-config.json.txt

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified shellcheck produces no new violations. Code inspection confirms: (1) wp-helper.sh hostinger|closte arm uses SSH key when ssh_identity_file is set, sshpass only when absent; (2) hostinger-helper.sh connect_site and exec_on_site follow the same pattern; (3) hostinger.md no longer claims password-only; (4) config template shows ssh_identity_file.

Resolves #19727


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.71 plugin for [OpenCode](https://opencode.ai) v1.4.12 with claude-sonnet-4-6 spent 14m and 13,314 tokens on this as a headless worker.