### PR TITLE
t2215: fix(pre-commit): replace grep -c || echo "0" with || true

### DIFF
--- a/.agents/scripts/pre-commit-hook.sh
+++ b/.agents/scripts/pre-commit-hook.sh
@@ -90,9 +90,9 @@ validate_return_statements() {
 		if [[ -f "$file" ]]; then
 			# Check for functions without return statements
 			local functions
-			functions=$(grep -c "^[a-zA-Z_][a-zA-Z0-9_]*() {" "$file" || echo "0")
+			functions=$(grep -c "^[a-zA-Z_][a-zA-Z0-9_]*() {" "$file" || true)
 			local returns
-			returns=$(grep -c "return [01]" "$file" || echo "0")
+			returns=$(grep -c "return [01]" "$file" || true)
 
 			if [[ $functions -gt 0 && $returns -lt $functions ]]; then
 				print_error "Missing return statements in $file"
@@ -136,7 +136,7 @@ validate_string_literals() {
 		if [[ -f "$file" ]]; then
 			# Check for repeated string literals
 			local repeated
-			repeated=$(grep -o '"[^"]*"' "$file" | sort | uniq -c | awk '$1 >= 3' | wc -l || echo "0")
+			repeated=$(grep -o '"[^"]*"' "$file" | sort | uniq -c | awk '$1 >= 3' | wc -l || true)
 
 			if [[ $repeated -gt 0 ]]; then
 				print_warning "Repeated string literals in $file (consider using constants)"


### PR DESCRIPTION
## Summary

Replace `|| echo "0"` with `|| true` on 3 `grep -c` calls in `pre-commit-hook.sh` (lines 93, 95, 139).

## Root cause

When `grep -c` finds zero matches it outputs `"0"` to stdout AND exits 1. The `|| echo "0"` fallback then fires, appending a second `"0"` — so the captured variable becomes `"0\n0"` (two lines). Subsequent `[[ $var -gt 0 ]]` comparisons fail with "arithmetic syntax error" because bash cannot parse a two-line string as an integer.

This is the same anti-pattern fixed in PR #2745 for `pulse-wrapper.sh`. The pre-commit hook was introduced later (PR #19683 / t2191) with the same bug.

## Fix

`|| true` neutralises the non-zero exit code without appending extra output. `grep -c` already outputs `"0"` on zero matches, so the variable gets a clean single-line `"0"`.

## Testing

- Simulated zero-match scenario: old pattern produces 2-line `"0\n0"`, new pattern produces single-line `"0"`
- `[[ $new_val -gt 0 ]]` arithmetic comparison succeeds without error
- ShellCheck clean (exit 0)
- No remaining `|| echo "0"` instances in the file

Resolves #19714


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.71 plugin for [OpenCode](https://opencode.ai) v1.4.12 with claude-opus-4-6 spent 4m and 5,588 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved pre-commit validation script reliability by updating error handling to prevent false failures when validation checks don't detect issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->