### PR TITLE
t2349+t2350+t2351: briefs for self-healing pulse framework improvements

### DIFF
--- a/todo/tasks/t2349-brief.md
+++ b/todo/tasks/t2349-brief.md
@@ -41,7 +41,7 @@ The child-side detection at `issue-sync-relationships.sh:619` shows the exact sh
 
 ### Extraction regex candidate
 
-```
+```bash
 rg -oE '^[[:space:]]*-[^-]*#([0-9]+)' | sed -E 's/.*#([0-9]+).*/\1/'
 ```
 
@@ -75,4 +75,3 @@ Run parent-side backfill from the existing pulse reconcile phase `pulse-issue-re
 - GH#19762 / t2244 (parent) — the `_try_close_parent_tracker` bug that misfires when the sub-issue graph is empty; this task addresses the upstream "graph is empty" root cause by populating it.
 - GH#19093 / t2114 — original backfill-sub-issues feature (child-side detection); this task is the Phase 2 extension.
 - Canonical parents needing this fix: #19734 (v3.8.71 retrospective, 7 children), #19736 (harness self-inflicted CI failure class, 4 children). Already wired manually during the filing session — test by running backfill and confirming idempotence.
-

--- a/todo/tasks/t2349-brief.md
+++ b/todo/tasks/t2349-brief.md
@@ -1,0 +1,78 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# t2349 Brief — backfill-sub-issues: add umbrella-parent → children detection
+
+**Issue:** GH#TBD (filed alongside this brief).
+
+## Session origin
+
+Discovered 2026-04-18 during board-clearing session after observing parent-tasks #19734 and #19736 had zero GitHub sub-issue links despite both bodies containing explicit `## Children` sections listing 7 and 4 children respectively. Manual `POST /repos/:owner/:repo/issues/:num/sub_issues` with child `id` (integer) linked all children cleanly. Root cause: the existing `backfill-sub-issues` path in `issue-sync-relationships.sh` runs CHILD-side only — `_backfill_one_issue` calls `_detect_parent_from_gh_state` on each candidate child and links upward when it finds one of three patterns (`tNNN.M` dot-notation title, `Parent:` line in body, `Blocked by:` referencing a parent-task-labeled issue). None of those patterns match the umbrella style where the PARENT carries the children list and the children never reference the parent. Result: a whole class of parent-tasks (decomposition umbrellas, retrospective trackers, roadmap epics) ship with a visible children table but no programmatic sub-issue graph, which then breaks `pulse-issue-reconcile.sh::_try_close_parent_tracker` (it falls back to a too-permissive body regex and mis-closes umbrellas on unrelated `#NNN` prose mentions — canonical: t2244/#19762 premature-close of #19734).
+
+## What
+
+Add parent-side detection to `backfill-sub-issues`: when iterating all issues, also check if the issue is a `parent-task` (by label) and, if so, parse its body for a `## Children` section and link every `#NNN` (or `GH#NNN`) reference in that section as a sub-issue.
+
+## Why
+
+- Umbrella-style parents never get their children linked programmatically — the only audit trail is prose in the body.
+- `pulse-issue-reconcile.sh::_try_close_parent_tracker` (t2244/#19762 target) needs the authoritative sub-issue graph to avoid false closures. Without umbrella-side detection, it will keep falling back to body regex.
+- GitHub UI shows sub-issue progress in the sidebar; unlinked children look like orphans.
+- Framework principle: the harness should wire relationships at creation/sync time, not require an agent to remember to POST manually.
+
+## How
+
+### Files to modify
+
+- **EDIT**: `.agents/scripts/issue-sync-relationships.sh:619-665` — extend `_backfill_one_issue` OR add a sibling `_backfill_parent_children($parent_num, $repo)` that runs when the issue carries the `parent-task` label.
+- **EDIT**: `.agents/scripts/issue-sync-relationships.sh:676-730` — in `cmd_backfill_sub_issues`, fetch labels alongside title/body and dispatch to child-side or parent-side logic.
+- **EXTEND** test: `.agents/scripts/tests/test-backfill-sub-issues.sh` — add cases for umbrella-style parent with `## Children` section listing 4 children. Mirror the existing Class B test harness.
+- **EDIT**: `.agents/scripts/issue-sync-helper.sh:1497-1503` — update docstring to document the new parent-side detection pattern.
+
+### Reference pattern
+
+The child-side detection at `issue-sync-relationships.sh:619` shows the exact shape to mirror — fetch title+body, detect pattern, resolve node IDs via `_cached_node_id`, call `_gh_add_sub_issue`. The new function should:
+1. Accept parent issue number + repo.
+2. Fetch parent body (already fetched in the outer loop — pass it in to avoid double-fetch).
+3. Parse the body for a `## Children` heading (case-insensitive, allow `## Child Issues`, `## Sub-issues`, `## Phases` as aliases).
+4. In that section, extract every `#NNN` / `GH#NNN` reference (anchored to line start with `-` list marker to avoid prose matches).
+5. For each extracted number, resolve its node ID and call `_gh_add_sub_issue($parent_node, $child_node)`.
+6. Return count of links made (for summary output).
+
+### Extraction regex candidate
+
+```
+rg -oE '^[[:space:]]*-[^-]*#([0-9]+)' | sed -E 's/.*#([0-9]+).*/\1/'
+```
+
+Validate against both umbrella styles observed today:
+
+- `#19734` body: `| HIGH | t2229 | #19735 | ...` (markdown table)
+- `#19736` body: `- t2229 / #19738 — CI workflow cascade-vulnerability linter` (markdown list)
+
+Table-cell regex needs to tolerate both.
+
+### Self-healing hook
+
+Run parent-side backfill from the existing pulse reconcile phase `pulse-issue-reconcile.sh:1236` (already wired to call `backfill-sub-issues`). No new scheduling needed — the addition just widens what the periodic pass detects.
+
+## Acceptance criteria
+
+1. `issue-sync-helper.sh backfill-sub-issues --issue 19734 --dry-run` reports 7 children that would be linked (all of #19735, #19737, #19743, #19744, #19751, #19752, #19753).
+2. Without `--dry-run`, the same command produces `sub_issues_summary.total = 7` on #19734.
+3. Idempotent — running twice doesn't error or duplicate.
+4. Existing child-side detection still works for the three legacy patterns (dot-notation, `Parent:` line, `Blocked by:` with parent-task label). No regression on `test-backfill-sub-issues.sh` Class A + Class B cases.
+5. New test case: fixture umbrella issue body with `## Children` section + 3 children issues; assert all 3 get linked.
+6. Prose body text like "see #19678" or "resolved by PR #19680" OUTSIDE the `## Children` section does NOT produce a false link.
+7. Verification command: `gh api "repos/marcusquinn/aidevops/issues/19734/sub_issues" --jq '[.[] | .number] | sort'` returns the child list.
+
+## Tier
+
+**tier:standard** — single-file change in existing helper, extends well-tested pattern, has clear acceptance criteria and verification command. Not tier:simple because the section-parsing and regex choice are judgment calls that benefit from Sonnet review.
+
+## Related
+
+- GH#19762 / t2244 (parent) — the `_try_close_parent_tracker` bug that misfires when the sub-issue graph is empty; this task addresses the upstream "graph is empty" root cause by populating it.
+- GH#19093 / t2114 — original backfill-sub-issues feature (child-side detection); this task is the Phase 2 extension.
+- Canonical parents needing this fix: #19734 (v3.8.71 retrospective, 7 children), #19736 (harness self-inflicted CI failure class, 4 children). Already wired manually during the filing session — test by running backfill and confirming idempotence.
+

--- a/todo/tasks/t2350-brief.md
+++ b/todo/tasks/t2350-brief.md
@@ -1,0 +1,93 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# t2350 Brief — pulse: auto-rebase or auto-close DIRTY PRs
+
+**Issue:** GH#TBD (filed alongside this brief).
+
+## Session origin
+
+Discovered 2026-04-18 during board-clearing session. Three `origin:interactive` PRs (#19754, #19703, #19696) had accumulated merge conflicts with main (`mergeStateStatus: DIRTY`) and sat unmerged for 1-2 days. Each required interactive rebase + triage decision (#19754 and #19703 closed as superseded; #19696 rebased and merged). The pulse has no periodic sweep for DIRTY PRs, so stuck PRs accumulate until an interactive session clears them.
+
+## What
+
+Add a pulse-stage scanner that detects DIRTY PRs and takes one of two actions based on age and content:
+
+- **Auto-rebase**: if PR is <48h old AND has real code changes AND only TODO.md is conflicting → rebase onto `origin/main`, resolve TODO.md by accepting HEAD + re-inserting the PR's task entry at correct chronological position, force-push.
+- **Auto-close**: if PR is >7d old AND hasn't had a human push in 3d → close with a comment explaining "superseded by subsequent merges" and link to any issue that remains open for worker re-dispatch.
+
+## Why
+
+- Interactive users file planning PRs (TODO.md + brief file) that go DIRTY within hours of any other TODO.md push.
+- Workers that complete work but get delayed through review bot gate age into DIRTY.
+- Nobody schedules manual DIRTY-PR triage, so stuck PRs pile up until a session notices them.
+- Both actions (rebase if possible, close if stale) are deterministic and idempotent — no human judgment needed in the common case.
+
+## How
+
+**NEW: `.agents/scripts/pulse-dirty-pr-sweep.sh`** — new pulse stage.
+
+**EDIT: `.agents/scripts/pulse-wrapper.sh`** — register the new stage after the merge pass.
+
+**Reference pattern**: model on `.agents/scripts/pulse-merge.sh` (pulse stage lifecycle: state file, dedup lock, gh query loop, comment on action).
+
+### Detection
+
+```
+gh pr list --state open --json number,mergeStateStatus,updatedAt,author,labels,files \
+  --jq '.[] | select(.mergeStateStatus == "DIRTY")'
+```
+
+### Auto-rebase path
+
+Eligibility: all true:
+- `mergeStateStatus == "DIRTY"`
+- PR age < 48h
+- `author.login == OWNER || labels contains "origin:worker"`
+- Conflicting files list (from `git merge-tree --write-tree`) includes ONLY TODO.md
+- Branch still exists on origin
+
+Action:
+1. Create ephemeral worktree for the PR branch.
+2. Attempt `git rebase origin/main`. If ONLY TODO.md conflicts, resolve via `git checkout --ours TODO.md` + re-insert the PR's task entry (extracted via `git show $commit -- TODO.md`) at correct chronological position.
+3. `git push --force-with-lease origin <branch>`.
+4. Remove ephemeral worktree.
+5. Post PR comment documenting the rebase.
+
+### Auto-close path
+
+Eligibility: all true:
+- `mergeStateStatus == "DIRTY"`
+- PR age > 7d
+- No human commits in last 3d (check `commits[-1].author.login` against repo maintainer list)
+- No `do-not-close` label
+
+Action:
+1. Post PR comment explaining closure (template with issue back-link if applicable).
+2. `gh pr close --delete-branch`.
+
+### Safety gates
+
+- Dry-run mode (`DRY_RUN=1` env var) prints would-be actions without executing.
+- Never rebases a PR with non-TODO.md conflicts — escalate to a maintainer-review comment instead.
+- Never auto-closes a PR with `do-not-close` label OR linked to an OPEN issue with `parent-task` label.
+- Audit log: every action written to `audit-log-helper.sh log dirty-pr-sweep`.
+
+## Acceptance criteria
+
+1. `pulse-dirty-pr-sweep.sh --dry-run` against current repo lists 0 or more DIRTY PRs with the proposed action (rebase / close / escalate).
+2. Test harness `tests/test-dirty-pr-sweep.sh` with fixtures for all three paths.
+3. Registered in `pulse-wrapper.sh` to run every Nth pulse cycle (every 30min is fine — not per-cycle).
+4. Idempotent — re-running within 30min doesn't re-action the same PR.
+5. Never rebases `parent-task` PRs (those have their own rules).
+6. Verification: open a fixture DIRTY PR, run the sweep, confirm rebase succeeds OR close fires per eligibility.
+
+## Tier
+
+`tier:thinking` — architectural decisions (which pulse stage, what eligibility windows, rebase conflict resolution heuristics) benefit from deeper reasoning. NOT `tier:simple` — many judgment calls.
+
+## Related
+
+- PR #19696 (rebased manually during this session) — canonical eligible-for-auto-rebase case.
+- PRs #19754, #19703 (closed manually during this session) — canonical eligible-for-auto-close case.
+

--- a/todo/tasks/t2350-brief.md
+++ b/todo/tasks/t2350-brief.md
@@ -33,7 +33,7 @@ Add a pulse-stage scanner that detects DIRTY PRs and takes one of two actions ba
 
 ### Detection
 
-```
+```bash
 gh pr list --state open --json number,mergeStateStatus,updatedAt,author,labels,files \
   --jq '.[] | select(.mergeStateStatus == "DIRTY")'
 ```
@@ -90,4 +90,3 @@ Action:
 
 - PR #19696 (rebased manually during this session) — canonical eligible-for-auto-rebase case.
 - PRs #19754, #19703 (closed manually during this session) — canonical eligible-for-auto-close case.
-

--- a/todo/tasks/t2351-brief.md
+++ b/todo/tasks/t2351-brief.md
@@ -1,0 +1,82 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# t2351 Brief — pulse: periodic canonical-repo fast-forward + stale worktree cleanup
+
+**Issue:** GH#TBD (filed alongside this brief).
+
+## Session origin
+
+Discovered 2026-04-18 during board-clearing session: (a) canonical `~/Git/aidevops` was 2 commits behind `origin/main` at session start — no harness keeps it current; (b) `git worktree list` reported 169 total worktrees, with ~30 dating from 2026-04-15 (3 days stale) whose branches were already merged. The existing `worktree-helper.sh clean --auto --force-merged` handles the cleanup but isn't scheduled, and nothing keeps canonical main fresh for interactive sessions that land on it by default.
+
+## What
+
+Add two scheduled maintenance tasks to the pulse:
+
+1. **Canonical-repo fast-forward**: for every repo in `~/.config/aidevops/repos.json`, run `git fetch origin && git checkout main && git pull --ff-only origin main` if the working tree is clean and no active session is mid-edit.
+2. **Stale worktree sweep**: for every repo, invoke `worktree-helper.sh clean --auto --force-merged` to drop worktrees whose branch is merged or PR is closed.
+
+Both run on a cadence (every ~30min is sufficient — not per-cycle).
+
+## Why
+
+- Interactive sessions start on canonical main by default. Stale main causes false `pre-edit-check.sh` decisions and requires manual `git pull`.
+- Stale worktrees consume disk, clutter `git worktree list`, and confuse the cross-session ownership check (`pre-edit-check.sh` "ownership conflict" logic).
+- Both operations are deterministic and safe with the right gates (fail-open on uncommitted changes, respect active-session stamps).
+- Agent doesn't need to remember to run these — the harness should.
+
+## How
+
+**NEW**: `.agents/scripts/pulse-canonical-maintenance.sh` — new pulse stage combining both operations.
+
+**EDIT**: `.agents/scripts/pulse-wrapper.sh` — register after existing merge/dispatch passes (runs once every ~30min via cadence counter).
+
+**Reference pattern**: follow `.agents/scripts/pulse-simplification.sh` lifecycle (state file, cadence gate, per-repo loop, audit log).
+
+### Fast-forward logic
+
+For each repo in `repos.json` where `pulse: true`:
+
+1. Skip if repo is `local_only: true`.
+2. `git -C $repo status --porcelain` — skip if any output (dirty tree).
+3. `git -C $repo stash list` — skip if stash non-empty (session in-flight).
+4. Check `.agents/active-session-stamps/` or equivalent — skip if active session owns canonical.
+5. `git -C $repo fetch origin --prune --quiet`.
+6. Check `git -C $repo rev-list --count HEAD..origin/main`. If 0, done. Otherwise:
+7. `git -C $repo checkout main && git -C $repo pull --ff-only origin main`.
+8. Log result via `audit-log-helper.sh log canonical-maintenance`.
+
+### Worktree cleanup logic
+
+For each repo in `repos.json`:
+
+1. Skip if `local_only: true`.
+2. `worktree-helper.sh clean --auto --force-merged` — the existing helper handles eligibility (merged branches, closed PRs via `gh pr list`, squash-merge detection).
+3. Log summary via audit log.
+
+### Timeout + safety
+
+- Hard timeout per repo (60s each) — the worktree cleanup was observed to spawn 13 runaway processes during manual run (2026-04-18); add `timeout 60 worktree-helper.sh ...` or equivalent and track why it was slow (likely per-worktree `gh pr list` network round-trips).
+- Before scheduling, investigate why `worktree-helper.sh clean --auto --force-merged` ran >3min on a 166-worktree checkout — may be a linear scan without batching. File as follow-up if so.
+
+## Acceptance criteria
+
+1. `pulse-canonical-maintenance.sh --dry-run` lists repos needing fast-forward and stale worktrees without mutating state.
+2. Real run fast-forwards canonical main for every clean repo and removes every merged worktree.
+3. Dirty tree → skip (no stash, no reset).
+4. Active session stamp → skip (no clobber).
+5. Audit log entries for every action.
+6. Test harness `tests/test-pulse-canonical-maintenance.sh` covers skip-on-dirty, skip-on-session-active, successful fast-forward, worktree cleanup integration.
+7. Registered in `pulse-wrapper.sh` on a 30min cadence — not per-cycle.
+8. Per-repo hard timeout prevents runaway (60s per repo is a generous default).
+
+## Tier
+
+`tier:standard` — well-defined mechanics, one new pulse stage, clear safety gates.
+
+## Related
+
+- Existing `worktree-helper.sh clean --auto --force-merged` handles the cleanup mechanics — this task only schedules and gates it.
+- `pulse-simplification.sh` is the cadence-gated template to copy.
+- Canonical repo was 2 commits behind origin at 2026-04-18 21:30 UTC — caught manually during board-clearing session.
+

--- a/todo/tasks/t2351-brief.md
+++ b/todo/tasks/t2351-brief.md
@@ -79,4 +79,3 @@ For each repo in `repos.json`:
 - Existing `worktree-helper.sh clean --auto --force-merged` handles the cleanup mechanics — this task only schedules and gates it.
 - `pulse-simplification.sh` is the cadence-gated template to copy.
 - Canonical repo was 2 commits behind origin at 2026-04-18 21:30 UTC — caught manually during board-clearing session.
-


### PR DESCRIPTION
## Summary

Planning-only PR adding three briefs (`todo/tasks/t2349-brief.md`, `t2350-brief.md`, `t2351-brief.md`) for self-healing pulse framework improvements identified during a pulse-productivity debugging session.

All three issues already exist — this PR just lands the implementation context so the fix PRs can be dispatched cleanly.

## Briefs

- **t2349** (#19778): parent-side sub-issue graph detection for umbrella issues (`backfill-sub-issues` to wire children from `## Children` sections in parent bodies).
- **t2350** (#19779): pulse auto-rebase / auto-close for DIRTY PRs (so mergeable PRs don't silently rot on merge conflicts).
- **t2351** (#19780): pulse canonical-repo fast-forward and stale worktree cleanup (so every cycle starts from a clean `main`; 166 worktrees found this session).

## Session context

Immediate remediations this session (done, not in this PR):

1. Unassigned `marcusquinn` from 11 zombie `(origin:interactive + assigned + active status)` issues → pulse re-dispatched within minutes, 10 PRs merged in the following hour.
2. Wired sub-issue relationships on #19734 (7 children) and #19736 (4 children) via GitHub Sub-issues API.
3. Rebased + admin-merged #19696 (t2204 closing-keyword docs).
4. Fast-forwarded canonical `~/Git/aidevops` to include merged PRs.

## PR conventions

Uses `Ref #NNN` instead of `Resolves #NNN` — these issues track implementation work that will land in separate fix PRs, so they should stay open.

## Follow-up

The `task-id-collision-guard.sh` hook only accepts `Resolves|Closes|Fixes` footers for cross-task linkage. Planning commits that legitimately use `Ref`/`For` and reference existing issues with matching t-IDs in their titles have no way to pass the hook without the documented `TASK_ID_GUARD_DISABLE=1` bypass. Worth a small enhancement (accept `Ref`/`For` linkage when the linked issue title contains the t-ID) — separate follow-up.

Ref #19778
Ref #19779
Ref #19780