### PR TITLE
t2232: add ratchet gate rule and gh pr checks cancelled-vs-fail note

### DIFF
--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -478,6 +478,23 @@ Git is the audit trail. Procedures: AGENTS.md "Git Workflow" section.
 - After editing code: run relevant linter before next edit. Shell: `shellcheck`. MD: `markdownlint-cli2`.
 - Fix immediately, don't batch for commit time.
 
+# Gate design — ratchet, not absolute (t2228 class)
+# Any new pre-commit validator or CI gate MUST be ratchet-based: baseline
+# the violation count at activation, block only on regressions. Absolute-
+# count gating traps pre-existing debt every time a legacy file is
+# touched, wasting worker context tokens on unrelated cleanup.
+#
+# Exception: security/credentials checks (secrets, hardcoded tokens,
+# dangerous commands) are absolute — a new violation is a P1 regardless
+# of baseline. Classify explicitly in the validator.
+#
+# `print_warning` output MUST NOT increment the violation counter. If a
+# finding is "warning", it means "inform, do not block" — returning a
+# non-zero count from a warning path is a lie to the caller.
+#
+# Patterns to copy: `.agents/scripts/qlty-regression-helper.sh` (t2065),
+# `.agents/scripts/qlty-new-file-gate-helper.sh` (t2068).
+
 # Self-modifying tooling test discipline (GH#18538 / t2062)
 # When you edit a script that's part of the test/verification loop you'll
 # subsequently invoke (e.g., `full-loop-helper.sh`, `pre-edit-check.sh`,

--- a/.agents/reference/worker-diagnostics.md
+++ b/.agents/reference/worker-diagnostics.md
@@ -120,6 +120,24 @@ When multiple pulse runners are operating across machines, single-worker diagnos
 remain valid. For cross-runner race conditions, stale-recovery loops, and new runner setup,
 see `reference/cross-runner-coordination.md`.
 
+## `gh pr checks` cancelled-vs-fail
+
+`gh pr checks` renders the GitHub Actions `cancelled` conclusion as
+`fail` in its TSV/default output. Only `success` becomes `pass`; all
+of `cancelled`, `timed_out`, `action_required`, `failure` collapse to
+`fail`.
+
+Before assuming a PR is broken, run:
+
+```bash
+gh api repos/OWNER/REPO/actions/runs -f branch=BRANCH \
+  -q '.workflow_runs[] | [.conclusion, .name] | @tsv'
+```
+
+If all "fail"s are `cancelled`, the CI is not actually broken — a
+concurrency cascade (or manual cancel) produced them. See parent
+#19736 for the cascade class.
+
 ## Recovery Checklist
 
 When workers are failing systemically:

--- a/.agents/reference/worker-diagnostics.md
+++ b/.agents/reference/worker-diagnostics.md
@@ -13,7 +13,7 @@ Reference for diagnosing headless worker failures. Workers are OpenCode instance
 
 ## Worker Lifecycle
 
-```
+```text
 Pulse cycle (every 2 min)
   → Version guard (enforce OPENCODE_PINNED_VERSION)
   → Canary smoke test (cached 30 min)
@@ -37,6 +37,7 @@ Pulse cycle (every 2 min)
 **Fix**: Each worker gets its own DB via `XDG_DATA_HOME=/tmp/aidevops-worker-auth.XXXXXX`. After completion, `_merge_worker_db()` copies session/message rows back to the shared DB using `ATTACH DATABASE` + `INSERT OR IGNORE` with a 5s timeout.
 
 **Diagnostic**: If workers stall at `step_start` with no API errors, check:
+
 ```bash
 # Are isolated dirs being created?
 ls -d /tmp/aidevops-worker-auth.* 2>/dev/null || ls -d "$TMPDIR"/aidevops-worker-auth.* 2>/dev/null
@@ -51,6 +52,7 @@ grep 'OPENCODE_DB' ~/.aidevops/agents/scripts/headless-runtime-helper.sh
 **Fix**: Watchdog launched as a standalone process that outlives the worker subshell.
 
 **Diagnostic**: If workers stall past the 300s timeout:
+
 ```bash
 # Are watchdog processes alive?
 ps aux | grep 'worker-activity-watchdog\|activity_watchdog' | grep -v grep
@@ -69,6 +71,7 @@ gh api repos/<slug>/issues/<num>/comments --jq '.[] | select(.body | test("CLAIM
 4. Version guard runs on every dispatch (not cached)
 
 **Diagnostic**: If no workers dispatch at all:
+
 ```bash
 # Check canary cache
 cat ~/.aidevops/.agent-workspace/headless-runtime/canary-last-pass
@@ -135,8 +138,8 @@ gh api repos/OWNER/REPO/actions/runs -f branch=BRANCH \
 ```
 
 If all "fail"s are `cancelled`, the CI is not actually broken — a
-concurrency cascade (or manual cancel) produced them. See parent
-#19736 for the cascade class.
+concurrency cascade (or manual cancel) produced them. See parent issue
+GH#19736 for the cascade class.
 
 ## Recovery Checklist
 


### PR DESCRIPTION
## Summary

Two documentation additions that codify the lessons from parent #19736:

1. **`.agents/prompts/build.txt`** — added 'Gate design — ratchet, not absolute (t2228 class)' rule after the Write-Time Quality Enforcement section. Requires new validators/CI gates to baseline at activation and block only on regressions, with a security exception for credentials/token checks, and mandates that `print_warning` output does not increment violation counters.

2. **`.agents/reference/worker-diagnostics.md`** — added '`gh pr checks` cancelled-vs-fail' subsection before the Recovery Checklist, explaining that the `cancelled` conclusion renders as `fail` in TSV output and providing the verification command to distinguish real CI failures from concurrency cascades.

## Testing

Pure-docs PR — no code changes. Both additions verified via grep for key terms (`Gate design`, `ratchet`, `cancelled-vs-fail`, `concurrency cascade`).

## Acceptance Criteria

- [x] build.txt rule added with cross-refs to qlty helpers (t2065, t2068)
- [x] worker-diagnostics.md note added with verification command
- [x] No conflict with existing rules (grepped before adding)
- [x] PR is pure-docs (no code changes)

For #19736
Resolves #19742

---


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.71 plugin for [OpenCode](https://opencode.ai) v1.4.12 with claude-sonnet-4-6 spent 7m and 9,122 tokens on this as a headless worker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added CI validation documentation covering violation counting methodology, security check exception handling, and warning-mode behavior specifications.
  * Introduced troubleshooting guide for GitHub Actions workflow outcomes, including verification steps and interpretation guidelines for workflow run conclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->