### PR TITLE
t2222: extend pre-commit duplicate-ID check to declined tasks and routine IDs

### DIFF
--- a/.agents/scripts/pre-commit-hook.sh
+++ b/.agents/scripts/pre-commit-hook.sh
@@ -22,10 +22,12 @@ get_modified_shell_files() {
 #
 # Design (t2209):
 #   1. Task IDs are extracted only from real task-list entries — lines that
-#      start (after optional leading whitespace) with "- [ ] tNNN" or
-#      "- [x] tNNN". This excludes doc examples ("- `t001` - Top-level task")
-#      and prose mentions that embed "- [ ] tNNN" inside backticks or
-#      parentheses. Subtask IDs like t123.1.2 are captured by (\.[0-9]+)*.
+#      start (after optional leading whitespace) with "- [ ] tNNN",
+#      "- [x] tNNN", or "- [-] tNNN" (declined). Routine IDs (rNNN) under
+#      ## Routines are also matched. This excludes doc examples
+#      ("- `t001` - Top-level task") and prose mentions that embed
+#      "- [ ] tNNN" inside backticks or parentheses.
+#      Subtask IDs like t123.1.2 are captured by (\.[0-9]+)*.
 #   2. The check is DIFF-AWARE. TODO.md on main has historical duplicate
 #      IDs (e.g. t131 and t1056 were both claimed twice under old
 #      workflows). Those cannot be renamed without breaking issue and PR
@@ -55,10 +57,10 @@ validate_duplicate_task_ids() {
 
 	local staged_dupes head_dupes new_dupes
 	staged_dupes=$(printf '%s\n' "$staged_todo" \
-		| sed -nE 's/^[[:space:]]*- \[[ x]\][[:space:]]+(t[0-9]+(\.[0-9]+)*).*/\1/p' \
+		| sed -nE 's/^[[:space:]]*- \[[ x-]\][[:space:]]+([tr][0-9]+(\.[0-9]+)*).*/\1/p' \
 		| sort | uniq -d)
 	head_dupes=$(printf '%s\n' "$head_todo" \
-		| sed -nE 's/^[[:space:]]*- \[[ x]\][[:space:]]+(t[0-9]+(\.[0-9]+)*).*/\1/p' \
+		| sed -nE 's/^[[:space:]]*- \[[ x-]\][[:space:]]+([tr][0-9]+(\.[0-9]+)*).*/\1/p' \
 		| sort | uniq -d)
 
 	# IDs duplicated in staged that were NOT already duplicated in HEAD =

--- a/.agents/scripts/tests/test-pre-commit-hook-duplicate-ids.sh
+++ b/.agents/scripts/tests/test-pre-commit-hook-duplicate-ids.sh
@@ -50,6 +50,7 @@ print_result() {
 		printf '%sFAIL%s %s %s\n' "$TEST_RED" "$TEST_RESET" "$name" "$extra"
 		TESTS_FAILED=$((TESTS_FAILED + 1))
 	fi
+	return 0
 }
 
 # Sandbox HOME so sourcing the hook is side-effect-free. The hook sources
@@ -124,6 +125,7 @@ run_case() {
 		set -e
 		echo "rc=${rc}"
 	)
+	return 0
 }
 
 assert_pass() {
@@ -136,6 +138,7 @@ assert_pass() {
 	else
 		print_result "$name" 1 "expected pass, got rc=$rc; output: $output"
 	fi
+	return 0
 }
 
 assert_fail() {
@@ -152,6 +155,7 @@ assert_fail() {
 		return
 	fi
 	print_result "$name" 0
+	return 0
 }
 
 # =============================================================================
@@ -287,6 +291,32 @@ assert_fail \
 	"" \
 	"$FIXTURE_SUBTASK_DUPE" \
 	"t600.1"
+
+# Case 10 (t2222): declined task colliding with active task — must fail.
+# `- [-]` is the declined checkbox per TODO.md ## Format. A declined task
+# re-using an active task's ID is a real collision.
+FIXTURE_DECLINED_DUPE='## Ready
+- [-] t500 Declined version of this task
+- [ ] t500 Active version reusing same ID
+'
+assert_fail \
+	"declined task (- [-]) colliding with active task fails" \
+	"" \
+	"$FIXTURE_DECLINED_DUPE" \
+	"t500"
+
+# Case 11 (t2222): routine IDs (r-prefix) duplicated — must fail.
+# Routine entries under ## Routines use `r001`, `r002`, etc. Two
+# routines with the same r-ID is a collision.
+FIXTURE_ROUTINE_DUPE='## Routines
+- [ ] r099 First routine
+- [x] r099 Second routine reusing same ID
+'
+assert_fail \
+	"duplicate routine ID (r099) fails" \
+	"" \
+	"$FIXTURE_ROUTINE_DUPE" \
+	"r099"
 
 # =============================================================================
 # Summary


### PR DESCRIPTION
## Summary

- Extended `validate_duplicate_task_ids` in `pre-commit-hook.sh` to catch two previously-missed ID collision classes:
  - **Declined tasks** (`- [-] tNNN`) — the checkbox regex `[[ x]]` now includes `-`: `[[ x-]]`
  - **Routine IDs** (`rNNN`) — the ID prefix regex `t[0-9]+` now matches both prefixes: `[tr][0-9]+`
- Added 2 new regression test cases (10 and 11) to `test-pre-commit-hook-duplicate-ids.sh`, bringing the total to 11
- Added explicit `return 0` to test helper functions for pre-commit hook compliance

## Testing

- All 11 test scenarios pass: `bash .agents/scripts/tests/test-pre-commit-hook-duplicate-ids.sh`
- ShellCheck clean on both modified files

## Changes

| File | Change |
|------|--------|
| `.agents/scripts/pre-commit-hook.sh:57-63` | Widened regex character classes in both `sed` invocations |
| `.agents/scripts/tests/test-pre-commit-hook-duplicate-ids.sh` | Added cases 10-11 + explicit returns |

Resolves #19723


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.71 plugin for [OpenCode](https://opencode.ai) v1.4.14 with claude-opus-4-6 spent 7m and 9,577 tokens on this as a headless worker.