### PR TITLE
t2250: tabby-profile-sync: parse folded YAML, detect worktrees via git

### DIFF
--- a/.agents/scripts/tabby-profile-sync.py
+++ b/.agents/scripts/tabby-profile-sync.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import re
+import subprocess
 import uuid
 from pathlib import Path
 
@@ -30,6 +30,58 @@ from tabby_yaml_helpers import (
     extract_group_id,
     insert_profiles_block,
 )
+
+
+def is_linked_worktree(repo_path: str) -> bool:
+    """Return True iff ``repo_path`` is a linked git worktree (not the main one).
+
+    Deterministic replacement for the old string-heuristic that tried to guess
+    worktrees from the basename pattern ``repo.branch-name``. That heuristic
+    broke whenever the repo name itself contained a dot (domain-like names such
+    as ``wpallstars.com`` / ``example.io``) or when a worktree branch did not
+    start with one of the six hard-coded prefixes.
+
+    Detection rule: a linked worktree's ``git rev-parse --git-common-dir``
+    resolves to the *main* repo's ``.git`` directory, while the worktree's own
+    ``git rev-parse --git-dir`` resolves to ``<main>/.git/worktrees/<name>``.
+    For the main checkout (or any non-worktree clone) those two paths collapse
+    to the same ``.git`` directory. Comparing absolute paths gives a
+    heuristic-free answer that works for any repo name, branch name, or future
+    worktree convention.
+
+    Returns False on non-git paths or on any git invocation error — the caller
+    treats those as "not a worktree" so normal repos are never excluded.
+    """
+    git_dir = _run_git(repo_path, "rev-parse", "--git-dir")
+    common_dir = _run_git(repo_path, "rev-parse", "--git-common-dir")
+    if not git_dir or not common_dir:
+        return False
+
+    def _absolute(path: str) -> str:
+        # git may return a relative path (e.g. ``.git``) — resolve against
+        # ``repo_path`` so we always compare absolute paths.
+        if not os.path.isabs(path):
+            path = os.path.join(repo_path, path)
+        return os.path.realpath(path)
+
+    return _absolute(git_dir) != _absolute(common_dir)
+
+
+def _run_git(cwd: str, *args: str) -> str:
+    """Run ``git -C <cwd> <args...>`` and return stripped stdout, or ``""``."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", cwd, *args],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    if result.returncode != 0:
+        return ""
+    return result.stdout.strip()
 
 
 def profile_name_from_path(repo_path: str) -> str:
@@ -125,7 +177,19 @@ def ensure_groups_section(config_text: str, group_id: str) -> str:
 
 
 def get_repos(repos_json_path: str) -> list[dict]:
-    """Load repos from repos.json, filtering to those suitable for profiles."""
+    """Load repos from repos.json, filtering to those suitable for profiles.
+
+    Excludes:
+    - entries without a ``path`` field
+    - paths that don't exist on disk
+    - linked git worktrees (detected via :func:`is_linked_worktree`)
+
+    Worktrees are excluded because each worktree shares its parent repo's
+    purpose; creating a separate Tabby profile per branch would multiply
+    entries every time a branch is checked out. The canonical repo's profile
+    is sufficient — users ``cd`` into worktrees from the canonical terminal
+    when they need them.
+    """
     with open(repos_json_path) as f:
         data = json.load(f)
 
@@ -133,23 +197,13 @@ def get_repos(repos_json_path: str) -> list[dict]:
     result = []
     for repo in repos:
         path = repo.get("path", "")
-        # Skip repos without a path
         if not path:
             continue
-        # Expand ~ in path
         path = os.path.expanduser(path)
-        # Skip repos that don't exist on disk
         if not os.path.isdir(path):
             continue
-        # Skip worktree paths (contain dots suggesting branch names like repo.feature-name)
-        basename = os.path.basename(path)
-        if "." in basename and "-" in basename.split(".", 1)[1]:
-            # Heuristic: worktrees have patterns like "repo.feature-branch-name"
-            # But repos like "essentials.com" are valid — check if it looks like a branch
-            after_dot = basename.split(".", 1)[1]
-            if "/" in after_dot or after_dot.startswith(("feature-", "bugfix-", "hotfix-",
-                                                          "refactor-", "chore-", "experiment-")):
-                continue
+        if is_linked_worktree(path):
+            continue
         result.append({"path": path, "name": profile_name_from_path(path), "repo": repo})
     return result
 

--- a/.agents/scripts/tabby_yaml_helpers.py
+++ b/.agents/scripts/tabby_yaml_helpers.py
@@ -27,13 +27,94 @@ def save_yaml(path: str, content: str) -> None:
         f.write(content)
 
 
+_CWD_LINE_RE = re.compile(r"^(?P<indent>\s+)cwd:\s*(?P<value>.*)$")
+
+
+def _parse_block_scalar(
+    lines: list[str], start_idx: int, parent_indent: int, style: str
+) -> tuple[str, int]:
+    """Parse a YAML block scalar (folded ``>`` or literal ``|``).
+
+    Starts at the line AFTER the ``cwd: >-`` (or ``|-``, ``>``, ``|``) header.
+    Consumes indented continuation lines until a line dedents back to or below
+    ``parent_indent``.
+
+    Returns ``(joined_value, next_line_idx)``.
+
+    - Folded (``>``): continuation lines are joined with single spaces.
+    - Literal (``|``): continuation lines are joined with newlines.
+
+    Chomping indicators (``-`` strip, ``+`` keep) affect trailing newlines,
+    but since we only use the value as a path we strip whitespace regardless.
+    """
+    collected: list[str] = []
+    i = start_idx
+    while i < len(lines):
+        line = lines[i]
+        # Blank lines are part of the block; preserve only for literal style.
+        if not line.strip():
+            if style == "|" and collected:
+                collected.append("")
+            i += 1
+            continue
+        # Measure the leading whitespace of this line.
+        stripped = line.lstrip(" \t")
+        line_indent = len(line) - len(stripped)
+        if line_indent <= parent_indent:
+            break
+        collected.append(stripped.rstrip())
+        i += 1
+
+    if style == ">":
+        value = " ".join(collected)
+    else:
+        value = "\n".join(collected)
+    return value.strip(), i
+
+
 def extract_existing_cwds(config_text: str) -> set[str]:
-    """Extract all cwd paths from existing profiles."""
-    cwds = set()
-    # Match cwd: lines in profile blocks
-    for match in re.finditer(r"^\s+cwd:\s+(.+)$", config_text, re.MULTILINE):
-        cwd = match.group(1).strip().strip("'\"")
-        cwds.add(cwd)
+    """Extract all cwd paths from existing profiles.
+
+    Handles three YAML scalar forms that Tabby emits:
+
+    1. Inline plain or quoted: ``cwd: /path`` / ``cwd: '/path'``.
+    2. Folded block scalar: ``cwd: >-`` followed by an indented path on the
+       next line. Tabby rewrites long paths into this form whenever it
+       re-saves the config via its GUI.
+    3. Literal block scalar: ``cwd: |-`` followed by an indented path.
+
+    Missing any of (2) or (3) causes duplicate profile generation on every
+    sync because the dedup check fails to recognise the existing path.
+    """
+    cwds: set[str] = set()
+    lines = config_text.split("\n")
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        match = _CWD_LINE_RE.match(line)
+        if not match:
+            i += 1
+            continue
+
+        parent_indent = len(match.group("indent"))
+        value = match.group("value").strip()
+
+        # Block scalar header? ``>``, ``>-``, ``>+``, ``|``, ``|-``, ``|+``.
+        if value and value[0] in (">", "|"):
+            style = value[0]
+            folded_value, next_i = _parse_block_scalar(
+                lines, i + 1, parent_indent, style
+            )
+            if folded_value:
+                cwds.add(folded_value)
+            i = next_i
+            continue
+
+        # Inline form (plain or quoted). Empty value means malformed — skip.
+        if value:
+            cwds.add(value.strip("'\""))
+        i += 1
+
     return cwds
 
 

--- a/.agents/scripts/tests/test-resolve-canonical-repo-path.sh
+++ b/.agents/scripts/tests/test-resolve-canonical-repo-path.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-resolve-canonical-repo-path.sh — Regression tests for t2250.
+#
+# Background: auto-discovery via `find ~/Git -name .aidevops.json` picks up
+# .aidevops.json files that exist inside linked git worktrees because worktrees
+# inherit the working tree contents. Without a worktree guard, each worktree
+# gets registered as a separate repo in repos.json and downstream consumers
+# (tabby-profile-sync, pulse, etc.) treat it as a standalone project.
+#
+# resolve_canonical_repo_path() in aidevops.sh uses `git rev-parse --git-dir`
+# vs `git rev-parse --git-common-dir` to detect linked worktrees
+# deterministically, then resolves them to the main worktree path via
+# `git worktree list --porcelain`. This is heuristic-free and handles repos
+# with any naming convention, including TLD-style names (wpallstars.com).
+#
+# This test:
+#   1. Creates a temporary git repo and a linked worktree.
+#   2. Sources aidevops.sh in a stubbed environment (suppresses print_* calls).
+#   3. Asserts that resolve_canonical_repo_path returns the main-worktree path
+#      for the linked worktree, and returns the input unchanged for the main
+#      worktree and non-git paths.
+#   4. Covers the original-bug case: a repo name containing a dot.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit
+AIDEVOPS_SH="${REPO_ROOT}/aidevops.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_YELLOW='\033[1;33m'
+readonly TEST_NC='\033[0m'
+
+pass_count=0
+fail_count=0
+
+_pass() {
+	local msg="$1"
+	printf '%b  PASS:%b %s\n' "${TEST_GREEN}" "${TEST_NC}" "${msg}"
+	pass_count=$((pass_count + 1))
+	return 0
+}
+
+_fail() {
+	local msg="$1"
+	printf '%b  FAIL:%b %s\n' "${TEST_RED}" "${TEST_NC}" "${msg}" >&2
+	fail_count=$((fail_count + 1))
+	return 0
+}
+
+_info() {
+	local msg="$1"
+	printf '%b[INFO]%b %s\n' "${TEST_YELLOW}" "${TEST_NC}" "${msg}"
+	return 0
+}
+
+# Source resolve_canonical_repo_path by extracting and evaluating just the
+# function definition. Sourcing aidevops.sh whole would run side-effectful
+# init code; the function is self-contained and can be isolated.
+extract_and_source_function() {
+	local fn_name="$1"
+	local aidevops_sh="$2"
+	awk -v fn="$fn_name" '
+		$0 ~ ("^" fn "\\(\\) \\{") { in_fn = 1 }
+		in_fn { print }
+		in_fn && /^\}$/ { in_fn = 0 }
+	' "$aidevops_sh"
+	return 0
+}
+
+# Stub the framework print helpers — the production function calls them on
+# the worktree-resolution path and we don't want chatter in test output.
+print_info() { :; return 0; }
+print_warning() { :; return 0; }
+
+# shellcheck disable=SC1090
+eval "$(extract_and_source_function resolve_canonical_repo_path "${AIDEVOPS_SH}")"
+
+if ! declare -f resolve_canonical_repo_path >/dev/null; then
+	_fail "could not source resolve_canonical_repo_path from aidevops.sh"
+	exit 1
+fi
+
+# -----------------------------------------------------------------------------
+# Fixture: temporary repo + linked worktree (with a TLD-style name).
+# -----------------------------------------------------------------------------
+tmp_root="$(mktemp -d)"
+trap 'rm -rf "$tmp_root"' EXIT
+
+main_repo="${tmp_root}/example.com"
+worktree="${tmp_root}/example.com-chore-init"
+
+git init -q -b main "$main_repo"
+(cd "$main_repo" && git commit --allow-empty -q -m "init")
+(cd "$main_repo" && git worktree add -q "$worktree" -b "chore/init")
+
+# -----------------------------------------------------------------------------
+# Test cases
+# -----------------------------------------------------------------------------
+assert_resolves_to() {
+	local label="$1"
+	local input="$2"
+	local expected="$3"
+	local actual
+	# pwd -P to match the production function's path normalisation; the macOS
+	# /tmp symlink to /private/tmp otherwise causes spurious string mismatches.
+	expected="$(cd "$expected" 2>/dev/null && pwd -P || printf '%s' "$expected")"
+	actual="$(resolve_canonical_repo_path "$input")"
+	if [[ -d "$actual" ]]; then
+		actual="$(cd "$actual" 2>/dev/null && pwd -P || printf '%s' "$actual")"
+	fi
+	if [[ "$actual" == "$expected" ]]; then
+		_pass "${label} (${input} → ${actual})"
+	else
+		_fail "${label}: expected ${expected}, got ${actual}"
+	fi
+	return 0
+}
+
+_info "Test 1: linked worktree of dotted-name repo resolves to main"
+assert_resolves_to "worktree → main" "$worktree" "$main_repo"
+
+_info "Test 2: main worktree returns itself"
+assert_resolves_to "main → main" "$main_repo" "$main_repo"
+
+_info "Test 3: non-git path passes through unchanged"
+plain="${tmp_root}/not-a-repo"
+mkdir -p "$plain"
+assert_resolves_to "non-git → non-git" "$plain" "$plain"
+
+_info "Test 4: current canonical aidevops repo self-resolves"
+if [[ -d "$REPO_ROOT/.git" || -f "$REPO_ROOT/.git" ]]; then
+	# The aidevops checkout running this test may itself be a linked worktree
+	# (when executed from a development worktree), so don't assert on that case.
+	# Just assert the function returns a real, existing path.
+	actual="$(resolve_canonical_repo_path "$REPO_ROOT")"
+	if [[ -d "$actual" ]]; then
+		_pass "aidevops repo resolves to existing path ($actual)"
+	else
+		_fail "aidevops repo resolved to non-existent path: $actual"
+	fi
+fi
+
+# -----------------------------------------------------------------------------
+# Summary
+# -----------------------------------------------------------------------------
+echo ""
+if ((fail_count == 0)); then
+	printf '%bAll %d tests passed.%b\n' "${TEST_GREEN}" "${pass_count}" "${TEST_NC}"
+	exit 0
+else
+	printf '%b%d test(s) failed, %d passed.%b\n' \
+		"${TEST_RED}" "${fail_count}" "${pass_count}" "${TEST_NC}" >&2
+	exit 1
+fi

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -61,11 +61,31 @@ _timeout_cmd() {
 	fi
 }
 
-print_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
-print_success() { echo -e "${GREEN}[OK]${NC} $1"; }
-print_warning() { echo -e "${YELLOW}[WARN]${NC} $1"; }
-print_error() { echo -e "${RED}[ERROR]${NC} $1"; }
-print_header() { echo -e "${BOLD}${CYAN}$1${NC}"; }
+print_info() {
+	local msg="$1"
+	echo -e "${BLUE}[INFO]${NC} $msg"
+	return 0
+}
+print_success() {
+	local msg="$1"
+	echo -e "${GREEN}[OK]${NC} $msg"
+	return 0
+}
+print_warning() {
+	local msg="$1"
+	echo -e "${YELLOW}[WARN]${NC} $msg"
+	return 0
+}
+print_error() {
+	local msg="$1"
+	echo -e "${RED}[ERROR]${NC} $msg"
+	return 0
+}
+print_header() {
+	local msg="$1"
+	echo -e "${BOLD}${CYAN}$msg${NC}"
+	return 0
+}
 
 # Get current version
 get_version() {
@@ -106,17 +126,20 @@ get_public_release_tag() {
 
 # Check if a command exists
 check_cmd() {
-	command -v "$1" >/dev/null 2>&1
+	local cmd="$1"
+	command -v "$cmd" >/dev/null 2>&1
 }
 
 # Check if a directory exists
 check_dir() {
-	[[ -d "$1" ]]
+	local dir="$1"
+	[[ -d "$dir" ]]
 }
 
 # Check if a file exists
 check_file() {
-	[[ -f "$1" ]]
+	local file="$1"
+	[[ -f "$file" ]]
 }
 
 # Ensure file ends with a trailing newline (prevents malformed appends)
@@ -268,6 +291,61 @@ _compute_repo_registration_defaults() {
 	return 0
 }
 
+# Resolve a worktree path to its canonical main-worktree path, if applicable.
+# Usage: resolve_canonical_repo_path <path>
+# Prints the canonical path to stdout. If the input is already the main
+# worktree, a non-git path, or git is unavailable, prints the input unchanged.
+#
+# Why this exists: `find ~/Git -name .aidevops.json` in auto-discovery and
+# similar scans pick up .aidevops.json files that exist in linked worktrees
+# (because worktrees inherit the working tree contents), and without this
+# guard each worktree gets registered as a separate repo. That's what caused
+# tabby-profile-sync to emit a profile for a worktree directory.
+resolve_canonical_repo_path() {
+	local input_path="$1"
+	local common_dir
+	common_dir=$(git -C "$input_path" rev-parse --git-common-dir 2>/dev/null) || {
+		printf '%s\n' "$input_path"
+		return 0
+	}
+	local own_git_dir
+	own_git_dir=$(git -C "$input_path" rev-parse --git-dir 2>/dev/null) || {
+		printf '%s\n' "$input_path"
+		return 0
+	}
+
+	# Resolve both to absolute paths for a reliable comparison.
+	# git -C <path> returns paths relative to <path> when they are relative.
+	local common_abs own_abs
+	if [[ "$common_dir" = /* ]]; then
+		common_abs=$(cd "$common_dir" 2>/dev/null && pwd -P)
+	else
+		common_abs=$(cd "$input_path/$common_dir" 2>/dev/null && pwd -P)
+	fi
+	if [[ "$own_git_dir" = /* ]]; then
+		own_abs=$(cd "$own_git_dir" 2>/dev/null && pwd -P)
+	else
+		own_abs=$(cd "$input_path/$own_git_dir" 2>/dev/null && pwd -P)
+	fi
+
+	if [[ -z "$common_abs" || -z "$own_abs" || "$common_abs" == "$own_abs" ]]; then
+		# Main worktree or degraded resolution — pass through.
+		printf '%s\n' "$input_path"
+		return 0
+	fi
+
+	# Linked worktree — ask git for the main worktree's working tree path.
+	local main_path
+	main_path=$(git -C "$input_path" worktree list --porcelain 2>/dev/null | awk '/^worktree /{print $2; exit}')
+	if [[ -n "$main_path" && "$main_path" != "$input_path" && -d "$main_path" ]]; then
+		printf '%s\n' "$main_path"
+		return 0
+	fi
+
+	printf '%s\n' "$input_path"
+	return 0
+}
+
 # Register a repo in repos.json
 # Usage: register_repo <path> <version> <features>
 register_repo() {
@@ -281,6 +359,20 @@ register_repo() {
 	if ! repo_path=$(cd "$repo_path" 2>/dev/null && pwd -P); then
 		print_warning "Cannot access path: $repo_path"
 		return 1
+	fi
+
+	# Resolve linked worktrees to their canonical main-worktree path.
+	# Every registration path (cmd_init, auto-discovery, scan) runs through
+	# register_repo, so the guard here catches all of them — not just the
+	# cmd_init path that previously checked only when WORKTREE_PATH was set.
+	local canonical_path
+	canonical_path=$(resolve_canonical_repo_path "$repo_path")
+	if [[ -n "$canonical_path" && "$canonical_path" != "$repo_path" ]]; then
+		print_info "Resolved worktree to canonical repo: $repo_path → $canonical_path"
+		if ! repo_path=$(cd "$canonical_path" 2>/dev/null && pwd -P); then
+			print_warning "Cannot access canonical path: $canonical_path"
+			return 1
+		fi
 	fi
 
 	if ! command -v jq &>/dev/null; then

--- a/setup-modules/migrations.sh
+++ b/setup-modules/migrations.sh
@@ -308,6 +308,62 @@ cleanup_stale_bun_opencode() {
 # by the 4-layer role resolution in stats-functions.sh.
 #
 # Gated by a flag file so it runs exactly once per install.
+cleanup_worktree_entries_in_repos_json() {
+	# t2250: `find ~/Git -name .aidevops.json` during auto-discovery picks up
+	# files that exist inside linked worktrees (because worktrees inherit the
+	# working tree). Before the register_repo guard, each worktree ended up as
+	# a separate entry in repos.json — confusing tabby-profile-sync, pulse,
+	# cross-repo tooling, and anything that enumerates `initialized_repos`.
+	#
+	# One-shot migration: scan `initialized_repos[].path`, detect entries that
+	# are linked worktrees (git rev-parse --git-dir != --git-common-dir), and
+	# remove them. Safe to re-run; a flag file suppresses re-execution once
+	# the cleanup has been done on this machine.
+	local flag_file="${HOME}/.aidevops/logs/.migrated-worktree-repos-json-t2250"
+	[[ -f "$flag_file" ]] && return 0
+
+	local repos_json="${HOME}/.config/aidevops/repos.json"
+	[[ -f "$repos_json" ]] || return 0
+
+	command -v jq &>/dev/null || return 0
+	command -v git &>/dev/null || return 0
+
+	local stale_paths=()
+	local path git_dir common_dir
+
+	while IFS= read -r path; do
+		[[ -n "$path" && -d "$path" ]] || continue
+		git_dir=$(git -C "$path" rev-parse --git-dir 2>/dev/null) || continue
+		common_dir=$(git -C "$path" rev-parse --git-common-dir 2>/dev/null) || continue
+		# Normalise to absolute paths for comparison.
+		[[ "$git_dir" = /* ]] || git_dir="$path/$git_dir"
+		[[ "$common_dir" = /* ]] || common_dir="$path/$common_dir"
+		git_dir=$(cd "$git_dir" 2>/dev/null && pwd -P) || git_dir=""
+		common_dir=$(cd "$common_dir" 2>/dev/null && pwd -P) || common_dir=""
+		if [[ -n "$git_dir" && -n "$common_dir" && "$git_dir" != "$common_dir" ]]; then
+			stale_paths+=("$path")
+		fi
+	done < <(jq -r '.initialized_repos[].path // empty' "$repos_json" 2>/dev/null)
+
+	if [[ ${#stale_paths[@]} -gt 0 ]]; then
+		local temp_file="${repos_json}.tmp"
+		local paths_json
+		paths_json=$(printf '%s\n' "${stale_paths[@]}" | jq -R . | jq -s .)
+		jq --argjson stale "$paths_json" \
+			'.initialized_repos |= map(select(.path as $p | ($stale | index($p)) | not))' \
+			"$repos_json" >"$temp_file" && mv "$temp_file" "$repos_json"
+		print_info "Removed ${#stale_paths[@]} worktree entry/entries from repos.json (t2250):"
+		local p
+		for p in "${stale_paths[@]}"; do
+			print_info "  - $p"
+		done
+	fi
+
+	mkdir -p "$(dirname "$flag_file")"
+	date -u +"%Y-%m-%dT%H:%M:%SZ" >"$flag_file"
+	return 0
+}
+
 cleanup_stale_health_issue_caches() {
 	local flag_file="${HOME}/.aidevops/logs/.migrated-health-issue-caches-t1929"
 	[[ -f "$flag_file" ]] && return 0

--- a/setup.sh
+++ b/setup.sh
@@ -1031,9 +1031,8 @@ _setup_run_interactive() {
 	confirm_step "Backfill GitHub issue relationships (blocked-by, sub-issues)" && backfill_issue_relationships
 	confirm_step "Cleanup deprecated MCP entries (hetzner, serper, etc.)" && cleanup_deprecated_mcps
 	confirm_step "Cleanup stale bun opencode install" && cleanup_stale_bun_opencode
-	cleanup_stale_health_issue_caches
-	cleanup_worktree_entries_in_repos_json
-	_cleanup_legacy_model_config
+	# Silent one-shot migrations (idempotent, flag-guarded — no prompt needed).
+	cleanup_stale_health_issue_caches; cleanup_worktree_entries_in_repos_json; _cleanup_legacy_model_config
 	confirm_step "Validate and repair OpenCode config schema" && validate_opencode_config
 	confirm_step "Extract OpenCode prompts" && extract_opencode_prompts
 	confirm_step "Check OpenCode prompt drift" && check_opencode_prompt_drift

--- a/setup.sh
+++ b/setup.sh
@@ -915,6 +915,7 @@ _setup_run_non_interactive() {
 	cleanup_deprecated_mcps
 	cleanup_stale_bun_opencode
 	cleanup_stale_health_issue_caches
+	cleanup_worktree_entries_in_repos_json
 	_cleanup_legacy_model_config
 	validate_opencode_config
 	deploy_aidevops_agents
@@ -1031,6 +1032,7 @@ _setup_run_interactive() {
 	confirm_step "Cleanup deprecated MCP entries (hetzner, serper, etc.)" && cleanup_deprecated_mcps
 	confirm_step "Cleanup stale bun opencode install" && cleanup_stale_bun_opencode
 	cleanup_stale_health_issue_caches
+	cleanup_worktree_entries_in_repos_json
 	_cleanup_legacy_model_config
 	confirm_step "Validate and repair OpenCode config schema" && validate_opencode_config
 	confirm_step "Extract OpenCode prompts" && extract_opencode_prompts

--- a/tests/test-tabby-profile-sync.py
+++ b/tests/test-tabby-profile-sync.py
@@ -1,10 +1,19 @@
 #!/usr/bin/env python3
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
-"""Tests for tabby-profile-sync.py compatibility and helpers."""
+"""Tests for tabby-profile-sync.py compatibility and helpers.
+
+t2250: covers the two root causes behind duplicate Tabby profiles
+(``>-`` folded YAML scalars missed by the dedup regex) and worktree
+leakage (the string-heuristic failing on names with dots like
+``wpallstars.com-chore-aidevops-init``).
+"""
 
 import importlib.util
+import os
+import subprocess
 import sys
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -16,6 +25,9 @@ spec = importlib.util.spec_from_file_location(
 )
 tabby_profile_sync = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(tabby_profile_sync)
+
+# Re-import helpers directly so tests exercise the same module the script uses.
+from tabby_yaml_helpers import extract_existing_cwds  # noqa: E402
 
 
 class TestTabbyProfileSync(unittest.TestCase):
@@ -35,6 +47,217 @@ profiles:
 """
 
         self.assertEqual(tabby_profile_sync.extract_group_id(config_text), "abc-123")
+
+
+class TestExtractExistingCwds(unittest.TestCase):
+    """Regression tests for YAML scalar parsing (t2250 root cause A).
+
+    Before the fix the dedup regex matched only single-line ``cwd: value``
+    assignments. Tabby's GUI reformats long paths as folded block scalars
+    on every save, causing the dedup check to miss the path and generate a
+    duplicate profile on every sync.
+    """
+
+    def test_inline_plain_scalar(self):
+        cwds = extract_existing_cwds(
+            """profiles:
+  - name: foo
+    options:
+      cwd: /Users/alice/repo
+"""
+        )
+        self.assertIn("/Users/alice/repo", cwds)
+
+    def test_inline_single_quoted_scalar(self):
+        cwds = extract_existing_cwds(
+            """profiles:
+  - name: foo
+    options:
+      cwd: '/Users/alice/repo'
+"""
+        )
+        self.assertIn("/Users/alice/repo", cwds)
+
+    def test_inline_double_quoted_scalar(self):
+        cwds = extract_existing_cwds(
+            """profiles:
+  - name: foo
+    options:
+      cwd: "/Users/alice/repo"
+"""
+        )
+        self.assertIn("/Users/alice/repo", cwds)
+
+    def test_folded_block_scalar(self):
+        """Tabby's GUI-saved form — the exact shape that caused duplicates."""
+        cwds = extract_existing_cwds(
+            """profiles:
+  - name: foo
+    options:
+      cwd: >-
+        /Users/marcusquinn/Git/wordpress/wp-plugin-starter-template-for-ai-coding
+    color: '#DA5CD3'
+"""
+        )
+        self.assertIn(
+            "/Users/marcusquinn/Git/wordpress/wp-plugin-starter-template-for-ai-coding",
+            cwds,
+        )
+        self.assertNotIn(">-", cwds)
+
+    def test_literal_block_scalar(self):
+        cwds = extract_existing_cwds(
+            """profiles:
+  - name: foo
+    options:
+      cwd: |-
+        /Users/alice/nested/project
+"""
+        )
+        self.assertIn("/Users/alice/nested/project", cwds)
+        self.assertNotIn("|-", cwds)
+
+    def test_mixed_forms_in_one_config(self):
+        """All three forms in one file are extracted correctly."""
+        cwds = extract_existing_cwds(
+            """profiles:
+  - name: a
+    options:
+      cwd: /path/a
+  - name: b
+    options:
+      cwd: '/path/b'
+  - name: c
+    options:
+      cwd: >-
+        /path/c
+  - name: d
+    options:
+      cwd: |-
+        /path/d
+"""
+        )
+        self.assertEqual(
+            cwds, {"/path/a", "/path/b", "/path/c", "/path/d"}
+        )
+
+    def test_empty_config_returns_empty_set(self):
+        self.assertEqual(extract_existing_cwds(""), set())
+
+    def test_config_without_profiles_returns_empty_set(self):
+        self.assertEqual(extract_existing_cwds("version: 1\nhotkeys: {}\n"), set())
+
+
+class TestIsLinkedWorktree(unittest.TestCase):
+    """Deterministic worktree detection (t2250 root cause B).
+
+    Replaces the old string-heuristic that tried to guess worktrees from
+    basename patterns like ``repo.branch-name``. That heuristic broke for:
+
+    - repo names containing a dot (``wpallstars.com``, ``example.io``)
+    - worktrees whose branch prefix is not in the hard-coded list
+      (``feature-``, ``bugfix-``, ``hotfix-``, ``refactor-``,
+      ``chore-``, ``experiment-``)
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.tmp = Path(self._tmp.name).resolve()
+
+    def _git(self, *args, cwd=None):
+        subprocess.run(
+            ["git", *args],
+            cwd=cwd,
+            check=True,
+            capture_output=True,
+        )
+
+    def test_main_worktree_is_not_linked(self):
+        repo = self.tmp / "repo"
+        repo.mkdir()
+        self._git("init", "-q", cwd=repo)
+        self._git("commit", "--allow-empty", "-q", "-m", "init", cwd=repo)
+        self.assertFalse(tabby_profile_sync.is_linked_worktree(str(repo)))
+
+    def test_non_git_path_is_not_linked(self):
+        plain = self.tmp / "plain"
+        plain.mkdir()
+        self.assertFalse(tabby_profile_sync.is_linked_worktree(str(plain)))
+
+    def test_nonexistent_path_is_not_linked(self):
+        self.assertFalse(
+            tabby_profile_sync.is_linked_worktree(str(self.tmp / "missing"))
+        )
+
+    def test_linked_worktree_is_detected(self):
+        """The critical case: a linked worktree must return True."""
+        repo = self.tmp / "repo"
+        repo.mkdir()
+        self._git("init", "-q", "-b", "main", cwd=repo)
+        self._git("commit", "--allow-empty", "-q", "-m", "init", cwd=repo)
+        wt = self.tmp / "repo-feature"
+        self._git(
+            "worktree", "add", "-q", str(wt), "-b", "feature/x", cwd=repo
+        )
+        self.assertTrue(tabby_profile_sync.is_linked_worktree(str(wt)))
+        # Main remains not-linked.
+        self.assertFalse(tabby_profile_sync.is_linked_worktree(str(repo)))
+
+    def test_worktree_with_dot_in_repo_name_is_detected(self):
+        """The original bug: worktrees of repos with TLD-style names.
+
+        ``wpallstars.com`` worktree named ``wpallstars.com-chore-aidevops-init``
+        was not caught by the old heuristic because splitting on the first
+        dot yielded ``com-chore-aidevops-init``, which does not start with
+        any of the hard-coded branch prefixes.
+        """
+        repo = self.tmp / "wpallstars.com"
+        repo.mkdir()
+        self._git("init", "-q", "-b", "main", cwd=repo)
+        self._git("commit", "--allow-empty", "-q", "-m", "init", cwd=repo)
+        wt = self.tmp / "wpallstars.com-chore-aidevops-init"
+        self._git(
+            "worktree", "add", "-q",
+            str(wt), "-b", "chore/aidevops-init",
+            cwd=repo,
+        )
+        self.assertTrue(tabby_profile_sync.is_linked_worktree(str(wt)))
+
+
+class TestGetReposExcludesWorktrees(unittest.TestCase):
+    """End-to-end: repos.json entries for worktrees do not reach the sync."""
+
+    def test_worktree_entry_is_filtered(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        root = Path(tmp.name).resolve()
+
+        repo = root / "demo.com"
+        repo.mkdir()
+        subprocess.run(
+            ["git", "init", "-q", "-b", "main"], cwd=repo, check=True
+        )
+        subprocess.run(
+            ["git", "commit", "--allow-empty", "-q", "-m", "init"],
+            cwd=repo, check=True,
+        )
+        wt = root / "demo.com-chore-task"
+        subprocess.run(
+            ["git", "worktree", "add", "-q", str(wt), "-b", "chore/task"],
+            cwd=repo, check=True,
+        )
+
+        repos_json = root / "repos.json"
+        repos_json.write_text(
+            '{{"initialized_repos":[{{"path":"{main}"}},{{"path":"{wt}"}}]}}'.format(
+                main=str(repo), wt=str(wt)
+            )
+        )
+        result = tabby_profile_sync.get_repos(str(repos_json))
+        paths = [r["path"] for r in result]
+        self.assertIn(str(repo), paths)
+        self.assertNotIn(str(wt), paths)
 
 
 if __name__ == "__main__":

--- a/todo/tasks/t2250-brief.md
+++ b/todo/tasks/t2250-brief.md
@@ -1,0 +1,126 @@
+# t2250 — tabby-profile-sync: handle folded YAML scalars, detect worktrees deterministically
+
+## Session origin
+
+Interactive. User observed the routine that creates Tabby terminal profiles from `repos.json` had:
+
+1. Produced a duplicate profile for `wordpress/wp-plugin-starter-template-for-ai-coding`.
+2. Created a profile for `wpallstars.com-chore-aidevops-init` — a linked git worktree, not a canonical repo.
+
+## What
+
+Fix two independent bugs in the tabby profile sync pipeline, both of which trace
+to fragile string heuristics that can't handle real-world inputs:
+
+- **A (duplicate profiles):** `tabby_yaml_helpers.extract_existing_cwds()` uses a
+  single-line regex that misses YAML folded (`>-`) and literal (`|-`) block
+  scalars. Tabby's GUI rewrites long paths into folded form on every save, so
+  after the first sync + first Tabby session the dedup check silently fails for
+  every profile with a long cwd, and the next sync duplicates it.
+- **B (worktree leakage):** `tabby-profile-sync.get_repos()` tries to detect
+  worktrees by splitting the basename on `.` and checking if the remainder
+  starts with a known branch prefix (`feature-`, `bugfix-`, `chore-`, ...).
+  The heuristic fails for repos whose names contain a dot
+  (`wpallstars.com`, `example.io`, `essentials.com`) because `split(".", 1)[1]`
+  begins with the TLD (`com-...`), not the branch prefix.
+
+Also: the upstream cause of worktrees ending up in `repos.json` at all —
+`register_repo()` in `aidevops.sh` has no worktree detection on its general
+path (only `cmd_init` does, and only when `WORKTREE_PATH` is set). The
+auto-discovery scan (`find ~/Git -name .aidevops.json`) picks up
+`.aidevops.json` files from inside worktrees (because worktrees inherit working
+tree contents) and registers each worktree as a standalone repo.
+
+## Why
+
+Every tabby profile sync duplicates long-path entries and occasionally leaks
+worktree entries as standalone profiles. Compounds over time: each sync adds a
+new duplicate for every long-path repo. The root causes are framework-level
+(`register_repo` treating worktrees as repos) and propagate to any other
+consumer of `initialized_repos` (pulse, cross-repo tooling, tabby).
+
+## How
+
+Three-layer defense, paired with a one-shot migration:
+
+### Layer 1 — YAML scalar parser
+
+`.agents/scripts/tabby_yaml_helpers.py::extract_existing_cwds`:
+- Replace the single-line regex with a line-by-line parser that recognises
+  `cwd: value`, `cwd: 'value'`, `cwd: "value"`, `cwd: >-` + indented
+  continuation, and `cwd: |-` + indented continuation.
+- New helper `_parse_block_scalar` walks indented continuation lines until
+  dedent and joins folded lines with spaces / literal lines with newlines.
+
+### Layer 2 — Deterministic worktree detection
+
+`.agents/scripts/tabby-profile-sync.py`:
+- New `is_linked_worktree(repo_path)` uses `git rev-parse --git-dir` vs
+  `git rev-parse --git-common-dir`. If they differ (after absolutising), the
+  path is a linked worktree. Works for any repo name, any branch name, any
+  future worktree convention. No string heuristics.
+- `get_repos()` calls `is_linked_worktree()` in place of the old
+  basename-splitting code.
+- Helper `_run_git()` wraps `subprocess.run` with a 5s timeout and swallows
+  errors so non-git paths pass through as "not a worktree".
+
+### Layer 3 — Root cause fix
+
+`aidevops.sh`:
+- New `resolve_canonical_repo_path()` resolves a worktree path to the main
+  worktree via `git worktree list --porcelain`, falls through for non-git and
+  main-worktree inputs.
+- `register_repo()` now calls `resolve_canonical_repo_path()` after path
+  normalisation, so *every* registration path (cmd_init, auto-discovery, scan)
+  is protected — not just the `cmd_init` branch that checks `WORKTREE_PATH`.
+
+### One-shot migration
+
+`setup-modules/migrations.sh::cleanup_worktree_entries_in_repos_json`:
+- Scans `initialized_repos[].path`, detects linked worktrees, removes them.
+- Flag file `~/.aidevops/logs/.migrated-worktree-repos-json-t2250` suppresses
+  re-execution.
+- Wired into both `setup.sh` non-interactive and interactive flows alongside
+  the other cleanup_* calls.
+
+### Tests
+
+- `tests/test-tabby-profile-sync.py` grows from 2 tests to 16:
+  - `TestExtractExistingCwds` × 8: inline plain/quoted, folded, literal, mixed
+    forms, empty config, no-profiles config. The folded-scalar test uses the
+    exact wp-plugin-starter path that caused the original duplicate.
+  - `TestIsLinkedWorktree` × 5: main, non-git, nonexistent, linked worktree,
+    **worktree of dotted-name repo** (the canonical regression case).
+  - `TestGetReposExcludesWorktrees` × 1: end-to-end check that a worktree
+    entry in a synthetic `repos.json` does not reach the result list.
+- `.agents/scripts/tests/test-resolve-canonical-repo-path.sh` × 4: shell-level
+  tests for the aidevops.sh function. Uses temporary git fixtures.
+
+## Acceptance criteria
+
+- [x] `extract_existing_cwds` recognises the wp-plugin-starter folded-scalar
+      cwd as an existing path (verified against real user config).
+- [x] `is_linked_worktree()` returns True for linked worktrees including
+      TLD-named ones, False for main and non-git paths.
+- [x] `get_repos()` no longer emits the wpallstars.com worktree (verified
+      end-to-end via `tabby-profile-sync.py --status-only`).
+- [x] `register_repo()` resolves worktree input paths to the canonical main.
+- [x] Migration removes the stale worktree entry from the real user config;
+      flag file prevents re-execution.
+- [x] All 16 Python tests pass, all 4 shell tests pass, shellcheck clean.
+
+## Manual follow-up (user)
+
+The duplicate Tabby profile at line 1176 of
+`~/Library/Application Support/tabby/config.yaml` should be removed via
+Tabby's GUI (right-click → delete). The sync tool deliberately never
+overwrites existing profiles to preserve user customisations (colours,
+icons, env vars), so the one pre-existing duplicate won't be auto-cleaned.
+The fix prevents *new* duplicates from appearing.
+
+## Context
+
+- Canonical failure config: `~/Library/Application Support/tabby/config.yaml`
+  (lines 809 and 1176 had identical `cwd` for the wp-plugin-starter path).
+- Canonical worktree leak: `wpallstars.com-chore-aidevops-init`.
+- Related: PR #17555 (tabby-helper refactor), PR #18677 (issue-sync SYNC_PAT).


### PR DESCRIPTION
Resolves #19792

## Summary

Fixes two independent bugs in the tabby-profile-sync pipeline plus the upstream cause in `register_repo` that let both symptoms surface.

**A. Duplicate profiles** — `extract_existing_cwds` was a single-line regex that missed YAML folded (`>-`) and literal (`|-`) block scalars. Tabby's GUI reformats long paths into folded form on every save, so after the first Tabby session the dedup check silently failed and every sync regenerated a duplicate for every long-path repo.

**B. Worktree leakage** — `get_repos` used a basename-split heuristic to detect worktrees. It failed for repos whose names contain a dot (`wpallstars.com`, `example.io`) because `split('.', 1)[1]` began with the TLD rather than a branch prefix.

**C. Upstream cause** — `register_repo` only resolved worktrees when `WORKTREE_PATH` was set by `cmd_init`. The auto-discovery scan (`find ~/Git -name .aidevops.json`) caught `.aidevops.json` files inside linked worktrees and registered each as a standalone repo. Any consumer of `initialized_repos[]` (tabby, pulse, cross-repo tooling) then saw a bogus entry.

## Fix

Three-layer defense plus a one-shot migration:

| Layer | File | Change |
|---|---|---|
| YAML parser | `.agents/scripts/tabby_yaml_helpers.py` | `extract_existing_cwds` walks lines and recognises inline + folded + literal scalars via a stateful `_parse_block_scalar` helper |
| Worktree detection | `.agents/scripts/tabby-profile-sync.py` | New `is_linked_worktree()` uses `git rev-parse --git-dir` vs `--git-common-dir` — deterministic, heuristic-free |
| Root cause | `aidevops.sh` | New `resolve_canonical_repo_path()` runs inside `register_repo` so **every** registration path is protected |
| Migration | `setup-modules/migrations.sh` | `cleanup_worktree_entries_in_repos_json` scans `initialized_repos[]`, removes linked-worktree entries; flag-guarded, idempotent; wired into interactive + non-interactive `setup.sh` |

## Tests

- **Python**: 2 → 16 tests. `TestExtractExistingCwds` × 8 (all scalar forms, mixed, edge cases), `TestIsLinkedWorktree` × 5 (main, non-git, nonexistent, linked, **TLD-named regression**), `TestGetReposExcludesWorktrees` × 1 (end-to-end).
- **Shell**: new `.agents/scripts/tests/test-resolve-canonical-repo-path.sh` × 4 — uses a temporary repo + worktree fixture with a dotted name (`example.com`).
- All 16 Python and 4 shell tests pass.
- Verified end-to-end against real user config: the wp-plugin-starter duplicate path is now recognised as existing, the wpallstars.com worktree is no longer emitted.

## Drive-by cleanups in `aidevops.sh`

Pre-existing style violations the pre-commit hook flagged when any other line in the file was touched. Converted `print_info/success/warning/error/header` and `check_cmd/check_dir/check_file` from direct `$N` usage to `local var="$N"` + explicit `return 0`.

Two `case "$1" in` matches at lines 2586/3171 are legitimate bash idioms the hook's regex doesn't recognise — left in place; separate cleanup PR candidate.

## Manual follow-up for existing users

Pre-existing duplicate Tabby profiles must be deleted via Tabby's GUI (right-click → delete). The sync tool deliberately never overwrites existing profiles to preserve user customisations, so the one pre-existing duplicate won't auto-clean. The fix prevents *new* duplicates.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.71 plugin for [OpenCode](https://opencode.ai) v1.4.14 with claude-opus-4-7 spent 22m and 195 tokens on this as a headless worker. Overall, 41s since this issue was created.
