### PR TITLE
t2230: add GitHub release workflow for automatic release on tag push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,40 @@
+name: Create GitHub Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Extract CHANGELOG section
+        id: changelog
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          BODY=$(awk "/^## \[$VERSION\]/,/^## \[/" CHANGELOG.md | sed '$d')
+          PREV_TAG=$(git describe --tags --abbrev=0 "v$VERSION^" 2>/dev/null || echo '')
+          if [ -n "$PREV_TAG" ]; then
+            EXTRA=$(git log --oneline "$PREV_TAG..v$VERSION" -- | grep -v 'chore: claim t' | head -10)
+            BODY="$BODY"$'\n\n### Commits since CHANGELOG generation\n'"$EXTRA"
+          fi
+          {
+            echo "body<<DELIM"
+            echo "$BODY"
+            echo "DELIM"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" \
+            --title "$GITHUB_REF_NAME" \
+            --notes "${{ steps.changelog.outputs.body }}"


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/release.yml` triggered on `v*` tag push
- Extracts matching version section from CHANGELOG.md and appends post-CHANGELOG commits (filtering `chore: claim t` noise)
- Creates a GitHub Release with tag name as title and extracted notes as body
- Uses pinned `actions/checkout` SHA consistent with other repo workflows

## Testing

- Workflow YAML validated structurally
- Matches CHANGELOG.md heading format (`## [3.8.71] - 2026-04-18`)
- Verification: push a test tag `v0.0.0-test-release`, confirm release appears, then clean up

Resolves #19743


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.71 plugin for [OpenCode](https://opencode.ai) v1.4.14 with claude-opus-4-6 spent 5m and 3,131 tokens on this as a headless worker.