### PR TITLE
t2243: strip markdown code spans before keyword scan in parent-task-keyword-guard

### DIFF
--- a/.agents/scripts/parent-task-keyword-guard.sh
+++ b/.agents/scripts/parent-task-keyword-guard.sh
@@ -57,13 +57,29 @@ _CLOSE_KEYWORD_PATTERN='[Cc][Ll][Oo][Ss][Ee][Ss]|[Rr][Ee][Ss][Oo][Ll][Vv][Ee][Ss
 # Helpers
 # =============================================================================
 
+# _strip_code_spans: read stdin, strip markdown code blocks and inline spans,
+# write stdout. Bash 3.2 compatible.
+# Fenced blocks (``` ... ```) are removed via an awk state machine.
+# Inline code spans (`...`) are removed via sed.
+# shellcheck disable=SC2016
+# SC2016: single quotes in the sed pattern are intentional — backticks are
+# literal sed regex characters, not shell variable/command-substitution syntax.
+_strip_code_spans() {
+	awk 'BEGIN{in_fence=0} /^[[:space:]]*```/{in_fence = !in_fence; next} !in_fence' |
+		sed 's/`[^`]*`//g'
+	return 0
+}
+
 # _extract_closing_refs: parse a PR body (stdin) and output one issue number
 # per line for each closing-keyword reference found.
 # Handles both `#NNN` and `OWNER/REPO#NNN` formats.
+# Code spans and fenced blocks are stripped first so that keywords inside
+# backticks (e.g. `Resolves #N`) do not produce false positives.
 _extract_closing_refs() {
 	# Use grep + sed for Bash 3.2 compat (no perl regex in bash natively).
 	# Pattern: keyword (space or nothing) (#NNN or owner/repo#NNN)
-	grep -oiE "(Closes|Resolves|Fixes)[[:space:]]+(([a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+)?#[0-9]+)" |
+	_strip_code_spans |
+		grep -oiE "(Closes|Resolves|Fixes)[[:space:]]+(([a-zA-Z0-9_.-]+/[a-zA-Z0-9_.-]+)?#[0-9]+)" |
 		grep -oE '#[0-9]+' |
 		tr -d '#' |
 		sort -un

--- a/.agents/scripts/tests/test-parent-task-keyword-guard.sh
+++ b/.agents/scripts/tests/test-parent-task-keyword-guard.sh
@@ -198,6 +198,55 @@ else
 		"(rc=$guard_rc output='$guard_output')"
 fi
 
+# =============================================================================
+# Case 6 — inline code span with Resolves → ignore (exit 0, no false positive)
+# =============================================================================
+# Covers t2243: retrospective prose like "helper refused `Resolves #123` per rule"
+# must NOT trigger the guard. The keyword is inside backticks — GitHub itself
+# would not auto-close on merge.
+write_stub_gh_parent "18458"
+# shellcheck disable=SC2016
+# SC2016: single quotes intentional — backticks are literal test fixture chars.
+run_check_body 'prose `Resolves #18458` more prose — this is retrospective text.' --strict
+
+if [[ "$guard_rc" -eq 0 ]]; then
+	print_result "Resolves in inline code span → exit 0 (no false positive)" 0
+else
+	print_result "Resolves in inline code span → exit 0 (no false positive)" 1 \
+		"(rc=$guard_rc output='$guard_output')"
+fi
+
+# =============================================================================
+# Case 7 — fenced code block with Resolves → ignore (exit 0, no false positive)
+# =============================================================================
+write_stub_gh_parent "18458"
+# shellcheck disable=SC2016
+# SC2016: single quotes inside printf intentional — backticks are literal fixture chars.
+run_check_body "$(printf 'Some prose.\n\n```\nResolves #18458\n```\n\nMore prose.')" --strict
+
+if [[ "$guard_rc" -eq 0 ]]; then
+	print_result "Resolves in fenced code block → exit 0 (no false positive)" 0
+else
+	print_result "Resolves in fenced code block → exit 0 (no false positive)" 1 \
+		"(rc=$guard_rc output='$guard_output')"
+fi
+
+# =============================================================================
+# Case 8 — plain-text Resolves on parent still detected (regression guard)
+# =============================================================================
+# Ensure that stripping code spans does not accidentally suppress a real keyword.
+write_stub_gh_parent "18458"
+run_check_body "Resolves #18458
+
+This is a plain-text closing keyword and MUST still be flagged." --strict
+
+if [[ "$guard_rc" -eq 2 ]]; then
+	print_result "Plain-text Resolves on parent still blocked after strip (regression)" 0
+else
+	print_result "Plain-text Resolves on parent still blocked after strip (regression)" 1 \
+		"(rc=$guard_rc output='$guard_output')"
+fi
+
 export PATH="$OLD_PATH"
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Fixes a false-positive in `parent-task-keyword-guard.sh` where closing keywords inside markdown inline code spans (`` `Resolves #N` ``) or fenced code blocks were incorrectly matched by `_extract_closing_refs`, causing legitimate retrospective PR prose to fail the guard.

## What Changed

- **EDIT `.agents/scripts/parent-task-keyword-guard.sh:54-71`**: Added `_strip_code_spans()` — an awk state machine that strips fenced code blocks, piped into `sed` that strips inline code spans. `_extract_closing_refs()` now pipes through this preprocessor before the keyword grep.
- **EDIT `.agents/scripts/tests/test-parent-task-keyword-guard.sh`**: Added three new test cases:
  - Case 6: `Resolves #N` inside inline backtick span → no match (was false positive)
  - Case 7: `Resolves #N` inside fenced code block → no match (was false positive)
  - Case 8: plain-text `Resolves #N` on parent → still blocked (regression guard)

## Verification

All 9 tests pass (5 existing + 3 new):

```
PASS Resolves on parent-task issue (--strict) → exit 2 (block)
PASS Resolves on parent-task issue (non-strict) → exit 1 (warn, not block)
PASS For on parent-task issue → exit 0 (allow)
PASS Resolves on leaf issue → exit 0 (allow, not a parent-task)
PASS No closing keyword (only For/Ref) → exit 0 (allow)
PASS Closes on parent + --allow-parent-close → exit 0 (final-phase exemption)
PASS Resolves in inline code span → exit 0 (no false positive)
PASS Resolves in fenced code block → exit 0 (no false positive)
PASS Plain-text Resolves on parent still blocked after strip (regression)

All 9 tests passed
```

ShellCheck clean on both modified files.

Resolves #19761

---
<!-- MERGE_SUMMARY -->
**Merge Summary**: Fixed false positives in `parent-task-keyword-guard.sh` by adding `_strip_code_spans()` preprocessor that removes markdown code spans/blocks before the closing-keyword regex. Added 3 test cases covering inline span, fenced block, and regression scenarios. All 9 tests pass. ShellCheck clean.