### PR TITLE
t2199: Add PATH-discoverable gh_create_pr and gh_create_issue shims

### DIFF
--- a/.agents/bin/gh_create_issue
+++ b/.agents/bin/gh_create_issue
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Thin PATH shim for gh_create_issue (t2199).
+# Sources shared-constants.sh and calls the gh_create_issue wrapper function
+# so that `origin:interactive` / `origin:worker` labels are always applied.
+#
+# This makes the wrapper discoverable via `type gh_create_issue` in any shell
+# — including agent tool-invocation shells that don't source shared-constants.sh.
+
+set -euo pipefail
+
+# Resolve shared-constants.sh: prefer repo-local (worktree), then deployed.
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../scripts" 2>/dev/null && pwd)" || true
+_SHARED_CONSTANTS=""
+if [[ -n "${_SCRIPT_DIR:-}" && -f "${_SCRIPT_DIR}/shared-constants.sh" ]]; then
+	_SHARED_CONSTANTS="${_SCRIPT_DIR}/shared-constants.sh"
+elif [[ -f "${HOME}/.aidevops/agents/scripts/shared-constants.sh" ]]; then
+	_SHARED_CONSTANTS="${HOME}/.aidevops/agents/scripts/shared-constants.sh"
+fi
+
+if [[ -z "$_SHARED_CONSTANTS" ]]; then
+	echo "[ERROR] gh_create_issue: shared-constants.sh not found" >&2
+	exit 1
+fi
+
+# shellcheck disable=SC1090  # dynamic path resolved at runtime
+source "$_SHARED_CONSTANTS"
+
+gh_create_issue "$@"

--- a/.agents/bin/gh_create_pr
+++ b/.agents/bin/gh_create_pr
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Thin PATH shim for gh_create_pr (t2199).
+# Sources shared-constants.sh and calls the gh_create_pr wrapper function
+# so that `origin:interactive` / `origin:worker` labels are always applied.
+#
+# This makes the wrapper discoverable via `type gh_create_pr` in any shell
+# — including agent tool-invocation shells that don't source shared-constants.sh.
+
+set -euo pipefail
+
+# Resolve shared-constants.sh: prefer repo-local (worktree), then deployed.
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../scripts" 2>/dev/null && pwd)" || true
+_SHARED_CONSTANTS=""
+if [[ -n "${_SCRIPT_DIR:-}" && -f "${_SCRIPT_DIR}/shared-constants.sh" ]]; then
+	_SHARED_CONSTANTS="${_SCRIPT_DIR}/shared-constants.sh"
+elif [[ -f "${HOME}/.aidevops/agents/scripts/shared-constants.sh" ]]; then
+	_SHARED_CONSTANTS="${HOME}/.aidevops/agents/scripts/shared-constants.sh"
+fi
+
+if [[ -z "$_SHARED_CONSTANTS" ]]; then
+	echo "[ERROR] gh_create_pr: shared-constants.sh not found" >&2
+	exit 1
+fi
+
+# shellcheck disable=SC1090  # dynamic path resolved at runtime
+source "$_SHARED_CONSTANTS"
+
+gh_create_pr "$@"

--- a/.agents/scripts/setup/_deployment.sh
+++ b/.agents/scripts/setup/_deployment.sh
@@ -81,8 +81,22 @@ deploy_aidevops_agents() {
 		return 1
 	}
 
-	# Set permissions on scripts
+	# Set permissions on scripts and bin shims
 	chmod +x "${target_dir}/scripts/"*.sh 2>/dev/null || true
+	chmod +x "${target_dir}/bin/"* 2>/dev/null || true
+
+	# t2199: Symlink bin shims into ~/.aidevops/bin/ for PATH discoverability.
+	# ~/.aidevops/bin/ is already on PATH (managed by setup.sh shell-env).
+	if [[ -d "${target_dir}/bin" ]]; then
+		mkdir -p "${HOME}/.aidevops/bin"
+		local shim
+		for shim in "${target_dir}/bin/"*; do
+			[[ -f "$shim" ]] || continue
+			local shim_name
+			shim_name="$(basename "$shim")"
+			ln -sf "$shim" "${HOME}/.aidevops/bin/${shim_name}"
+		done
+	fi
 
 	echo "[deploy] Deployed agents to ${target_dir} ($(find "$target_dir" -type f | wc -l | tr -d ' ') files)"
 	return 0


### PR DESCRIPTION
## Summary

- Created thin shell shim scripts at `.agents/bin/gh_create_pr` and `.agents/bin/gh_create_issue` that source `shared-constants.sh` and delegate to the wrapper functions
- Updated `_deployment.sh` to `chmod +x` the `bin/` directory and symlink shims into `~/.aidevops/bin/` (already on PATH) during `deploy_aidevops_agents()`
- After `aidevops update`, `type gh_create_pr` resolves to a PATH hit from any shell — including agent tool-invocation shells that don't source `shared-constants.sh`

## Problem

The `gh_create_pr` and `gh_create_issue` wrappers existed only as bash functions in `shared-constants.sh`. Agent tool-invocation shells don't source that file, so `type gh_create_pr` returned "not found". The build.txt rule "NEVER use raw `gh pr create`" was unfollowable in interactive contexts without these wrappers on PATH.

## Implementation

**Shim pattern:** Each shim resolves `shared-constants.sh` (repo-local first, then deployed fallback), sources it, and calls the function with `"$@"`. Minimal — no logic duplication.

**Deployment integration:** `deploy_aidevops_agents()` in `_deployment.sh` now:
1. `chmod +x` all files in the deployed `bin/` directory
2. Symlinks each file into `~/.aidevops/bin/` (already on PATH)

**Files changed:**
- NEW: `.agents/bin/gh_create_pr` — thin PATH shim
- NEW: `.agents/bin/gh_create_issue` — thin PATH shim  
- EDIT: `.agents/scripts/setup/_deployment.sh` — chmod + symlink integration

## Testing

- ShellCheck passed on all 3 files (0 violations)
- Smoke-tested both shims with `--help` flag — they source `shared-constants.sh` and delegate correctly to `gh issue create` / `gh pr create`
- Verified `session_origin_label()` is called via the wrapper functions, auto-applying `origin:interactive` or `origin:worker`

Resolves #19686


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.72 plugin for [OpenCode](https://opencode.ai) v1.4.14 with claude-opus-4-6 spent 9m and 13,017 tokens on this as a headless worker.