### PR TITLE
t2219: fix(ci): skip title-fallback for For/Ref-referenced issues in issue-sync.yml

### DIFF
--- a/.agents/scripts/tests/test-issue-sync-for-ref-skip.sh
+++ b/.agents/scripts/tests/test-issue-sync-for-ref-skip.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression test for t2219: PR body with For/Ref references must not
+# trigger the issue-sync.yml title-fallback against the referenced issues.
+#
+# This test exercises the regex extraction and conditional skip logic
+# from .github/workflows/issue-sync.yml in isolation (fixture-based,
+# no act or Docker dependency).
+set -euo pipefail
+
+PASS=0
+FAIL=0
+RESULT_PREFIX_OK="PASS"
+RESULT_PREFIX_BAD="FAIL"
+
+# --- Helpers: simulate the extract step regexes ---
+extract_for_ref() {
+  local body="$1"
+  echo "$body" | grep -oiE '(for|ref)[[:space:]]*#[0-9]+' | grep -oE '[0-9]+' | sort -u | tr '\n' ' ' || true
+  return 0
+}
+
+extract_linked() {
+  local body="$1"
+  echo "$body" | grep -oiE '(closes?|fixes?|resolves?)[[:space:]]*#[0-9]+' | grep -oE '[0-9]+' | sort -u | tr '\n' ' ' || true
+  return 0
+}
+
+# --- Helper: simulate the title-fallback skip check ---
+# Returns 0 (skip) if FOUND is in FOR_REF_ISSUES, 1 (accept) otherwise.
+should_skip_for_ref() {
+  local found="$1"
+  local for_ref_set="$2"
+  if [[ " $for_ref_set " == *" $found "* ]]; then
+    return 0
+  fi
+  return 1
+}
+
+# --- Single assertion function (avoids repeated-literal warnings) ---
+check() {
+  local ok="$1" tc="$2" detail="$3"
+  if [[ "$ok" == "1" ]]; then
+    PASS=$((PASS + 1)); echo "${RESULT_PREFIX_OK}: $tc"
+  else
+    FAIL=$((FAIL + 1)); echo "${RESULT_PREFIX_BAD}: $tc — $detail"
+  fi
+  return 0
+}
+
+# ============================================================
+# Test 1: PR body with only For references
+# ============================================================
+PR_BODY_1='## Summary
+
+Plans three follow-up tasks.
+
+For #19692
+For #19693
+For #19694
+'
+
+linked_1=$(extract_linked "$PR_BODY_1")
+fr_1=$(extract_for_ref "$PR_BODY_1")
+
+[[ -z "${linked_1// /}" ]] && ok=1 || ok=0
+check "$ok" "Test 1a: LINKED_ISSUES is empty for For-only body" "got '$linked_1'"
+
+[[ "$fr_1" == "19692 19693 19694 " ]] && ok=1 || ok=0
+check "$ok" "Test 1b: FOR_REF_ISSUES extracted correctly" "got '$fr_1'"
+
+should_skip_for_ref "19692" "$fr_1" && ok=1 || ok=0
+check "$ok" "Test 1c: title-fallback skips #19692 (in For/Ref set)" "should skip"
+
+should_skip_for_ref "19693" "$fr_1" && ok=1 || ok=0
+check "$ok" "Test 1d: title-fallback skips #19693 (in For/Ref set)" "should skip"
+
+# ============================================================
+# Test 2: PR body with Closes + For (mixed)
+# ============================================================
+PR_BODY_2='Resolves #100
+
+For #200
+Ref #300
+'
+
+linked_2=$(extract_linked "$PR_BODY_2")
+fr_2=$(extract_for_ref "$PR_BODY_2")
+
+[[ "$linked_2" == "100 " ]] && ok=1 || ok=0
+check "$ok" "Test 2a: LINKED_ISSUES captures Resolves #100" "got '$linked_2'"
+
+[[ "$fr_2" == "200 300 " ]] && ok=1 || ok=0
+check "$ok" "Test 2b: FOR_REF_ISSUES captures For #200 and Ref #300" "got '$fr_2'"
+
+# Title-fallback wouldn't fire here (LINKED_ISSUES is non-empty), but the
+# skip check should still work correctly if called.
+should_skip_for_ref "200" "$fr_2" && ok=1 || ok=0
+check "$ok" "Test 2c: skip check works for #200 in mixed body" "should skip"
+
+! should_skip_for_ref "100" "$fr_2" && ok=1 || ok=0
+check "$ok" "Test 2d: skip check does NOT match #100 (Resolves, not For/Ref)" "should not skip"
+
+# ============================================================
+# Test 3: PR body with no For/Ref references
+# ============================================================
+PR_BODY_3='Closes #500
+
+Regular PR body with no planning references.
+'
+
+fr_3=$(extract_for_ref "$PR_BODY_3")
+
+[[ -z "${fr_3// /}" ]] && ok=1 || ok=0
+check "$ok" "Test 3a: FOR_REF_ISSUES is empty when no For/Ref in body" "got '$fr_3'"
+
+! should_skip_for_ref "500" "$fr_3" && ok=1 || ok=0
+check "$ok" "Test 3b: skip check does NOT fire with empty For/Ref set" "should not skip"
+
+# ============================================================
+# Test 4: Case-insensitive For/Ref matching
+# ============================================================
+PR_BODY_4='FOR #10
+for #20
+Ref #30
+REF #40
+'
+
+fr_4=$(extract_for_ref "$PR_BODY_4")
+[[ "$fr_4" == "10 20 30 40 " ]] && ok=1 || ok=0
+check "$ok" "Test 4a: case-insensitive For/Ref extraction" "got '$fr_4'"
+
+# ============================================================
+# Test 5: Issue NOT in For/Ref set should NOT be skipped
+# ============================================================
+! should_skip_for_ref "99999" "$fr_1" && ok=1 || ok=0
+check "$ok" "Test 5a: issue not in For/Ref set is not skipped" "should not skip"
+
+# ============================================================
+# Summary
+# ============================================================
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [[ "$FAIL" -gt 0 ]]; then
+  exit 1
+fi
+exit 0

--- a/.github/workflows/issue-sync.yml
+++ b/.github/workflows/issue-sync.yml
@@ -383,6 +383,14 @@ jobs:
           fi
           echo "linked_issues=$LINKED_ISSUES" >> "$GITHUB_OUTPUT"
 
+          # t2219: Collect 'For #NNN' and 'Ref #NNN' references (planning convention t2046)
+          # These are explicit signals that the PR is NOT closing the referenced issue.
+          FOR_REF_ISSUES=""
+          if [[ -n "$PR_BODY" ]]; then
+            FOR_REF_ISSUES=$(echo "$PR_BODY" | grep -oiE '(for|ref)[[:space:]]*#[0-9]+' | grep -oE '[0-9]+' | sort -u | tr '\n' ' ' || true)
+          fi
+          echo "for_ref_issues=$FOR_REF_ISSUES" >> "$GITHUB_OUTPUT"
+
           # Determine if we have anything to process
           if [[ -n "$TASK_ID" || -n "$LINKED_ISSUES" ]]; then
             echo "has_work=true" >> "$GITHUB_OUTPUT"
@@ -390,7 +398,7 @@ jobs:
             echo "has_work=false" >> "$GITHUB_OUTPUT"
           fi
 
-          echo "PR #$PR_NUMBER: task_id=$TASK_ID linked_issues=$LINKED_ISSUES"
+          echo "PR #$PR_NUMBER: task_id=$TASK_ID linked_issues=$LINKED_ISSUES for_ref_issues=$FOR_REF_ISSUES"
 
       - name: Find issue by task ID (fallback)
         id: find-issue
@@ -398,6 +406,7 @@ jobs:
         env:
           TASK_ID: ${{ steps.extract.outputs.task_id }}
           LINKED_ISSUES: ${{ steps.extract.outputs.linked_issues }}
+          FOR_REF_ISSUES: ${{ steps.extract.outputs.for_ref_issues }}
           REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -417,6 +426,13 @@ jobs:
               if echo "$FOUND_LABELS" | grep -qw "parent-task"; then
                 echo "found_issues=" >> "$GITHUB_OUTPUT"
                 echo "Found issue #$FOUND for task $TASK_ID is a parent-task — skipping title-fallback hygiene (use explicit Closes #NNN on the terminal-phase PR to close a parent)"
+              # t2219: skip title-fallback when the issue was explicitly referenced
+              # via 'For #NNN' or 'Ref #NNN' in the PR body. The t2046 planning
+              # convention says these references mean "this PR does NOT close that
+              # issue" — extend the same semantics to status:done auto-application.
+              elif [[ " $FOR_REF_ISSUES " == *" $FOUND "* ]]; then
+                echo "found_issues=" >> "$GITHUB_OUTPUT"
+                echo "Found issue #$FOUND for task $TASK_ID is referenced via For/Ref in PR body — skipping title-fallback hygiene (t2219)"
               else
                 echo "found_issues=$FOUND" >> "$GITHUB_OUTPUT"
                 echo "Found issue #$FOUND for task $TASK_ID"


### PR DESCRIPTION
## Summary

- Extended `.github/workflows/issue-sync.yml` `sync-on-pr-merge` job to extract `For #NNN` / `Ref #NNN` references from PR bodies during the `extract` step
- Added skip logic in the `find-issue` step's title-fallback to exclude issues referenced via For/Ref, preventing planning PRs from incorrectly applying `status:done` to future-work issues
- Added regression test (`.agents/scripts/tests/test-issue-sync-for-ref-skip.sh`) with 12 assertions covering extraction, skip logic, mixed bodies, case-insensitivity, and negative cases

## Testing

- ShellCheck: clean on new test script
- Regression test: 12/12 assertions pass
- Manual review: workflow YAML insertion points and env var wiring confirmed correct
- Existing t2137 parent-task carve-out preserved (no regression)

Resolves #19719


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.72 plugin for [OpenCode](https://opencode.ai) v1.4.17 with claude-opus-4-6 spent 10m and 25,122 tokens on this as a headless worker.