### PR TITLE
t2237: skip pre-commit hook on release commits to avoid false positives

### DIFF
--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -1306,7 +1306,11 @@ commit_version_changes() {
 		return 0
 	fi
 
-	if git commit -m "chore(release): bump version to $version"; then
+	# Version-bump commits contain only version-string updates — content is
+	# internally controlled by this script. Pre-commit quality gates run in
+	# CI on every other path. Skip the local hook here to avoid false positives
+	# on pre-existing code that the release commit didn't touch (t2237).
+	if git commit --no-verify -m "chore(release): bump version to $version"; then
 		print_success "Committed version changes"
 		return 0
 	else


### PR DESCRIPTION
## Summary

- Add `--no-verify` to the `git commit` call in `commit_version_changes()` in `version-manager.sh` to prevent pre-commit hook false positives on release commits
- Add inline rationale comment explaining why skipping the hook is safe for this specific code path (version-string-only changes, CI gates still run)

## Implementation

Option A from the issue brief: targeted `--no-verify` in `version-manager.sh` only. The pre-commit hook remains active for all other commit paths. CI quality gates still run on every push.

The root cause was `validate_positional_parameters` flagging pre-existing `$1` usage in `aidevops.sh` one-liner print helpers (lines 64-66) every time the file was touched by a version bump — even though the release commit didn't modify those lines.

## Testing

- `shellcheck .agents/scripts/version-manager.sh` — zero violations
- Pre-commit hook unchanged for all other commit paths
- Next `version-manager.sh release patch` will commit without false-positive friction

## Merge Summary

<!-- MERGE_SUMMARY -->
**What:** Added `--no-verify` flag to `commit_version_changes()` in `.agents/scripts/version-manager.sh:1313` with a 4-line rationale comment explaining why it's safe.

**Why:** Pre-commit hook was flagging pre-existing idiomatic `$1` usage in `aidevops.sh` print helpers on every release commit, forcing `--no-verify` workarounds at the CLI level. This makes the workaround explicit and documented in the script.

**Verification:** `shellcheck` clean. Single-file, 5-line change. Hook unchanged for all other commits.
<!-- /MERGE_SUMMARY -->

Resolves #19752