### PR TITLE
t2246: .coderabbit.yaml — restore include-all label semantics

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -45,15 +45,21 @@ reviews:
       - "dependabot[bot]"
       - "renovate[bot]"
     # GH#17671 post-mortem: external-contributor PRs must always be reviewed,
-    # even when rate-limited. The "!no-review" exclusion filter skips PRs that
-    # are explicitly opted out. Positive labels (without "!") act as inclusion
-    # filters — they restrict reviews to only PRs with those labels, which would
-    # disable reviews for all internal PRs. Do NOT add "external-contributor"
-    # here; use path_filters or path_instructions to apply stricter review rules
-    # to external-contributor PRs instead. GH#17904: removed "external-contributor"
-    # positive label that was inadvertently disabling internal PR reviews.
+    # even when rate-limited. GH#17904: removed "external-contributor" positive
+    # label that was inadvertently disabling internal PR reviews (positive-only
+    # filters restrict to matching PRs only).
+    #
+    # GH#19770: CodeRabbit treats negative-only label filters as "include nothing"
+    # rather than "include all" (observed on PR #19764: skipped with "only excluded
+    # labels are configured"). Schema description says ['!wip'] reviews all PRs
+    # except wip, but runtime behaviour contradicts this. Fix: add explicit wildcard
+    # positive include "*" + negative exclude "!no-review" — Option A from the
+    # t2246 brief. This restores "review everything unless tagged no-review" intent
+    # without GH#17904 regression (wildcard includes external-contributor PRs too).
+    # Do NOT remove the "*" entry — reverting to negative-only breaks auto-review.
     labels:
-      - "!no-review"
+      - "*"           # include all PRs (positive include required — see GH#19770)
+      - "!no-review"  # except those explicitly opted out
 
   # Request changes for critical issues — this is the setting that controls
   # whether CodeRabbit submits formal APPROVED/CHANGES_REQUESTED reviews.


### PR DESCRIPTION
## Summary

Restores CodeRabbit auto-review include-all semantics by adding an explicit `"*"` wildcard positive include to the labels filter.

**Root cause (GH#19770):** CodeRabbit Pro treats negative-only label filters (`['!no-review']`) as "include nothing" rather than "include all". This contradicts both the schema description and the inline comment intent. Observed on PR #19764: review was skipped with _"only excluded labels are configured"_.

**Fix (Option A from t2246 brief):**
```yaml
labels:
  - "*"           # include all PRs (positive include required — see GH#19770)
  - "!no-review"  # except those explicitly opted out
```

This restores the original "review everything unless tagged `no-review`" intent without GH#17904 regression (wildcard `"*"` includes external-contributor PRs, unlike explicit origin-label enumeration under Option B).

## Files changed

- **EDIT:** `.coderabbit.yaml:55-56` — added `"*"` wildcard; updated comment at `:47-62` to document GH#19770 finding and the no-revert warning.

## Verification

- Internal PRs (origin:interactive, origin:worker) should trigger CodeRabbit auto-review on next push
- PRs with `no-review` label should still be skipped (opt-out preserved)
- External-contributor PRs (no origin:* label) should be reviewed under wildcard include

## Schema cross-check

CodeRabbit schema at `https://coderabbit.ai/integrations/schema.v2.json` confirms `labels` is a string array. Schema description reads: `['!wip'] reviews all PRs except those labeled 'wip'` — stating negative-only should work. However, runtime contradicts schema. `"*"` is a valid string item; CodeRabbit's documented example `['bug', '!wip']` follows the positive+negative pattern this fix adopts.

Resolves #19770