### PR TITLE
t2226: add pre-install validator dry-run to install-hooks-helper.sh

### DIFF
--- a/.agents/scripts/install-hooks-helper.sh
+++ b/.agents/scripts/install-hooks-helper.sh
@@ -7,10 +7,11 @@
 # Installs Claude Code PreToolUse hooks to block destructive git/filesystem commands
 #
 # Usage:
-#   install-hooks-helper.sh install   # Install hooks (default)
-#   install-hooks-helper.sh uninstall # Remove hooks
-#   install-hooks-helper.sh status    # Check installation status
-#   install-hooks-helper.sh test      # Run hook self-test
+#   install-hooks-helper.sh install              # Install hooks (default)
+#   install-hooks-helper.sh install --force-install  # Install, bypass validator preflight
+#   install-hooks-helper.sh uninstall            # Remove hooks
+#   install-hooks-helper.sh status               # Check installation status
+#   install-hooks-helper.sh test                 # Run hook self-test
 #
 # Installs to:
 #   ~/.aidevops/hooks/git_safety_guard.py  (hook script)
@@ -349,7 +350,114 @@ HOOKEOF
 	return 0
 }
 
+# --- Pre-install validator dry-run (t2226) ---
+# Runs all validate_* functions from pre-commit-hook.sh against HEAD state.
+# If any validator fails a no-op commit, the hook is buggy and would strand
+# the repo — abort before installing.
+
+_dry_run_validators() {
+	local hook_source="$1"
+	local force_install="${2:-false}"
+
+	print_info "Running pre-install validator dry-run against HEAD..."
+
+	# Find the pre-commit-hook.sh source
+	local pch_source
+	pch_source=$(_find_pre_commit_hook) || {
+		print_warning "pre-commit-hook.sh not found — skipping validator preflight"
+		return 0
+	}
+
+	# Enumerate validator functions from the hook source
+	local validators=()
+	while IFS= read -r fn; do
+		[[ -n "$fn" ]] && validators+=("$fn")
+	done < <(grep -oE 'validate_[a-z_]+\(\)' "$pch_source" | sed 's/()//' | sort -u)
+
+	if [[ ${#validators[@]} -eq 0 ]]; then
+		print_warning "No validate_* functions found in $pch_source — skipping preflight"
+		return 0
+	fi
+
+	print_info "Found ${#validators[@]} validators: ${validators[*]}"
+
+	# Gather a representative sample of tracked .sh files for file-arg validators.
+	# Use git ls-files from the repo root for consistent paths.
+	local repo_root
+	repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || repo_root="."
+	local shell_files=()
+	while IFS= read -r f; do
+		[[ -n "$f" ]] && shell_files+=("$f")
+	done < <(git -C "$repo_root" ls-files '*.sh' 2>/dev/null | head -20)
+
+	# Validators that accept file arguments (iterate over "$@" internally).
+	# All others are no-arg (check staged state, which is empty for dry-run → pass).
+	local file_arg_validators="validate_return_statements validate_positional_parameters validate_string_literals"
+
+	local failed_validators=()
+
+	for validator in "${validators[@]}"; do
+		local exit_code=0
+		# Run each validator in a subshell that sources the hook but skips main()
+		if [[ " $file_arg_validators " == *" $validator "* ]]; then
+			# File-arg validator: pass tracked shell files
+			if [[ ${#shell_files[@]} -gt 0 ]]; then
+				(
+					# Source everything except the final main "$@" call
+					# shellcheck disable=SC1090
+					eval "$(sed '$ { /^main "\$@"$/d; }' "$pch_source")"
+					"$validator" "${shell_files[@]}"
+				) >/dev/null 2>&1 || exit_code=$?
+			fi
+		else
+			# No-arg validator: call directly (nothing staged → trivial pass)
+			(
+				# shellcheck disable=SC1090
+				eval "$(sed '$ { /^main "\$@"$/d; }' "$pch_source")"
+				"$validator"
+			) >/dev/null 2>&1 || exit_code=$?
+		fi
+
+		if [[ $exit_code -ne 0 ]]; then
+			failed_validators+=("$validator")
+			print_error "  FAIL: $validator (exit $exit_code)"
+		else
+			print_success "  PASS: $validator"
+		fi
+	done
+
+	if [[ ${#failed_validators[@]} -gt 0 ]]; then
+		echo ""
+		if [[ "$force_install" == "true" ]]; then
+			print_warning "Bypassing validator preflight (--force-install)."
+			print_warning "Failing validators: ${failed_validators[*]}"
+			print_warning "The installed hook may reject commits until these are fixed."
+			return 0
+		fi
+		print_error "Validator preflight failed — ${#failed_validators[@]} validator(s) fail against current HEAD:"
+		for v in "${failed_validators[@]}"; do
+			print_error "  - $v"
+		done
+		echo ""
+		print_error "Installing the hook would strand this repo (commits rejected until fixed)."
+		print_info "Fix the validator(s) first, or re-run with --force-install to bypass:"
+		print_info "  install-hooks-helper.sh install --force-install"
+		return 1
+	fi
+
+	print_success "All ${#validators[@]} validators pass against HEAD — safe to install"
+	return 0
+}
+
 install_hook() {
+	local force_install="false"
+	local arg
+	for arg in "$@"; do
+		case "$arg" in
+		--force-install) force_install="true" ;;
+		esac
+	done
+
 	print_info "Installing Claude Code safety hooks..."
 
 	# Check Python is available
@@ -363,6 +471,9 @@ install_hook() {
 	source_hook=$(find_source_hook) || return 1
 	local source_post_hook
 	source_post_hook=$(find_source_hook "mcp_task_post_hook.py") || return 1
+
+	# Pre-install validator dry-run (t2226): abort if validators fail HEAD state
+	_dry_run_validators "$source_hook" "$force_install" || return 1
 
 	# Create hooks directory
 	mkdir -p "$HOOKS_DIR"
@@ -834,11 +945,12 @@ show_help() {
 	echo "Usage: install-hooks-helper.sh [command]"
 	echo ""
 	echo "Commands:"
-	echo "  install     Install safety hooks (default)"
-	echo "  uninstall   Remove safety hooks"
-	echo "  status      Check installation status"
-	echo "  test        Run hook self-test"
-	echo "  help        Show this help"
+	echo "  install               Install safety hooks (default)"
+	echo "  install --force-install  Bypass validator preflight check"
+	echo "  uninstall             Remove safety hooks"
+	echo "  status                Check installation status"
+	echo "  test                  Run hook self-test"
+	echo "  help                  Show this help"
 	echo ""
 	echo "Installs to:"
 	echo "  ~/.aidevops/hooks/git_safety_guard.py"
@@ -850,8 +962,9 @@ show_help() {
 
 # Main
 cmd="${1:-install}"
+shift || true
 case "$cmd" in
-install) install_hook ;;
+install) install_hook "$@" ;;
 uninstall) uninstall_hook ;;
 status) check_status ;;
 test) test_hook ;;

--- a/.agents/scripts/tests/test-install-hooks-validator-preflight.sh
+++ b/.agents/scripts/tests/test-install-hooks-validator-preflight.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-install-hooks-validator-preflight.sh — t2226 regression test.
+#
+# Validates the pre-install validator dry-run gate in install-hooks-helper.sh:
+#   1. _dry_run_validators function exists.
+#   2. Happy path: validators pass → install proceeds (function returns 0).
+#   3. Failure path: a broken validator → install aborts (function returns 1).
+#   4. Force-install path: --force-install bypasses failure (returns 0 with warning).
+#   5. install_hook accepts --force-install flag.
+#   6. Validator enumeration finds validate_* functions from pre-commit-hook.sh.
+#
+# These tests validate the preflight logic without running actual install
+# (no .git/hooks writes, no settings.json modifications).
+
+set -uo pipefail
+
+TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_RED=$'\033[0;31m'
+TEST_GREEN=$'\033[0;32m'
+TEST_RESET=$'\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1" rc="$2" extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf '%sPASS%s %s\n' "$TEST_GREEN" "$TEST_RESET" "$name"
+	else
+		printf '%sFAIL%s %s %s\n' "$TEST_RED" "$TEST_RESET" "$name" "$extra"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+# --- Test 1: _dry_run_validators function exists ---
+test_function_exists() {
+	if grep -q '^_dry_run_validators()' "$TEST_SCRIPTS_DIR/install-hooks-helper.sh"; then
+		print_result "_dry_run_validators() function exists" 0
+	else
+		print_result "_dry_run_validators() function exists" 1 "not found in install-hooks-helper.sh"
+	fi
+	return 0
+}
+
+# --- Test 2: install_hook accepts --force-install ---
+test_force_install_flag() {
+	if grep -q '\-\-force-install' "$TEST_SCRIPTS_DIR/install-hooks-helper.sh"; then
+		print_result "install_hook accepts --force-install" 0
+	else
+		print_result "install_hook accepts --force-install" 1 "flag not found"
+	fi
+	return 0
+}
+
+# --- Test 3: Validator enumeration finds functions ---
+test_validator_enumeration() {
+	local pch="$TEST_SCRIPTS_DIR/pre-commit-hook.sh"
+	if [[ ! -f "$pch" ]]; then
+		print_result "validator enumeration" 1 "pre-commit-hook.sh not found"
+		return 0
+	fi
+	local count
+	count=$(grep -oE 'validate_[a-z_]+\(\)' "$pch" | sed 's/()//' | sort -u | wc -l | tr -d ' ')
+	if [[ "$count" -gt 0 ]]; then
+		print_result "validator enumeration finds $count validators" 0
+	else
+		print_result "validator enumeration finds validators" 1 "found 0"
+	fi
+	return 0
+}
+
+# --- Test 4: _dry_run_validators is called in install flow ---
+test_dry_run_called_in_install() {
+	if grep -q '_dry_run_validators.*force_install' "$TEST_SCRIPTS_DIR/install-hooks-helper.sh"; then
+		print_result "_dry_run_validators called in install flow" 0
+	else
+		print_result "_dry_run_validators called in install flow" 1 "call not found in install_hook"
+	fi
+	return 0
+}
+
+# --- Helper: run _dry_run_validators with a mock pre-commit-hook.sh ---
+# Creates a temp mock, sources install-hooks-helper.sh functions, overrides
+# _find_pre_commit_hook AFTER sourcing (so the override sticks), then calls
+# _dry_run_validators.
+_run_dry_run_test() {
+	local mock_content="$1"
+	local force_flag="$2"
+
+	local test_tmpdir
+	test_tmpdir=$(mktemp -d)
+
+	cat >"$test_tmpdir/pre-commit-hook.sh" <<MOCK_EOF
+$mock_content
+MOCK_EOF
+
+	# Write a test harness script that sources the helper and runs the function
+	cat >"$test_tmpdir/harness.sh" <<HARNESS_EOF
+#!/usr/bin/env bash
+set -uo pipefail
+SCRIPT_DIR="$TEST_SCRIPTS_DIR"
+# shellcheck source=../shared-constants.sh disable=SC1091
+[[ -f "\${SCRIPT_DIR}/shared-constants.sh" ]] && source "\${SCRIPT_DIR}/shared-constants.sh"
+
+# Source functions from install-hooks-helper.sh, skipping set -euo and main block
+eval "\$(sed '/^set -euo pipefail\$/d; /^# Main\$/,\$ d' "$TEST_SCRIPTS_DIR/install-hooks-helper.sh")"
+
+# Override _find_pre_commit_hook AFTER sourcing (so our mock wins)
+_find_pre_commit_hook() {
+	echo "$test_tmpdir/pre-commit-hook.sh"
+	return 0
+}
+
+_dry_run_validators "unused" "$force_flag"
+HARNESS_EOF
+
+	local rc=0
+	bash "$test_tmpdir/harness.sh" >/dev/null 2>&1 || rc=$?
+	rm -rf "$test_tmpdir"
+	return $rc
+}
+
+# --- Test 5: Dry-run passes with valid validators (happy path) ---
+test_dry_run_happy_path() {
+	local mock_body
+	mock_body='#!/usr/bin/env bash
+validate_test_pass() {
+	return 0
+}'
+
+	local rc=0
+	_run_dry_run_test "$mock_body" "false" || rc=$?
+
+	if [[ "$rc" -eq 0 ]]; then
+		print_result "dry-run happy path (passing validator)" 0
+	else
+		print_result "dry-run happy path (passing validator)" 1 "exit=$rc"
+	fi
+	return 0
+}
+
+# --- Test 6: Dry-run fails with broken validator ---
+test_dry_run_failure_path() {
+	local mock_body
+	mock_body='#!/usr/bin/env bash
+validate_test_fail() {
+	return 1
+}'
+
+	local rc=0
+	_run_dry_run_test "$mock_body" "false" || rc=$?
+
+	if [[ "$rc" -ne 0 ]]; then
+		print_result "dry-run failure path (broken validator aborts)" 0
+	else
+		print_result "dry-run failure path (broken validator aborts)" 1 "expected non-zero exit"
+	fi
+	return 0
+}
+
+# --- Test 7: --force-install bypasses failure ---
+test_force_install_bypass() {
+	local mock_body
+	mock_body='#!/usr/bin/env bash
+validate_test_fail() {
+	return 1
+}'
+
+	local rc=0
+	_run_dry_run_test "$mock_body" "true" || rc=$?
+
+	if [[ "$rc" -eq 0 ]]; then
+		print_result "force-install bypasses broken validator" 0
+	else
+		print_result "force-install bypasses broken validator" 1 "exit=$rc"
+	fi
+	return 0
+}
+
+# --- Test 8: help text includes --force-install ---
+test_help_text() {
+	local output
+	output=$(bash "$TEST_SCRIPTS_DIR/install-hooks-helper.sh" help 2>&1)
+	if echo "$output" | grep -q '\-\-force-install'; then
+		print_result "help text mentions --force-install" 0
+	else
+		print_result "help text mentions --force-install" 1 "not in help output"
+	fi
+	return 0
+}
+
+# --- Run all tests ---
+main() {
+	echo "=== install-hooks-helper.sh validator preflight tests (t2226) ==="
+	echo ""
+
+	test_function_exists
+	test_force_install_flag
+	test_validator_enumeration
+	test_dry_run_called_in_install
+	test_dry_run_happy_path
+	test_dry_run_failure_path
+	test_force_install_bypass
+	test_help_text
+
+	echo ""
+	echo "=== Results: $TESTS_RUN tests, $TESTS_FAILED failures ==="
+
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Adds `_dry_run_validators()` preflight check to `install-hooks-helper.sh` that runs all `validate_*` functions from `pre-commit-hook.sh` against HEAD state before installing hooks
- If any validator fails a no-op commit, the install aborts with a clear error identifying the failing validator — preventing the self-blocking toolchain scenario from PR #19683 (t2191)
- Adds `--force-install` bypass flag for bootstrap cases (when the install itself ships the fix) with visible warning listing bypassed validators

## Changes

- **EDIT:** `.agents/scripts/install-hooks-helper.sh` — added `_dry_run_validators()` function, integrated into `install_hook()` before dispatcher write, added `--force-install` flag parsing, updated usage comment and help text
- **NEW:** `.agents/scripts/tests/test-install-hooks-validator-preflight.sh` — 8-test regression suite covering: function existence, flag acceptance, validator enumeration, install flow integration, happy path (passing validator → install proceeds), failure path (broken validator → install aborts), force-install bypass, and help text

## Testing

```bash
# All 8 tests pass
bash .agents/scripts/tests/test-install-hooks-validator-preflight.sh

# ShellCheck clean on both files
shellcheck .agents/scripts/install-hooks-helper.sh
shellcheck .agents/scripts/tests/test-install-hooks-validator-preflight.sh
```

## Verification

```bash
# Happy path: clean repo, install succeeds
bash .agents/scripts/install-hooks-helper.sh install

# Force-install path: bypass works with warning
bash .agents/scripts/install-hooks-helper.sh install --force-install 2>&1 | grep -i "bypassing"
```

Resolves #19747


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.73 plugin for [OpenCode](https://opencode.ai) v1.14.17 with claude-opus-4-6 spent 7m and 18,903 tokens on this as a headless worker.