### PR TITLE
t2235: forbid self-invented task ID suffixes in Traceability rules

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -202,7 +202,7 @@ For multi-runner coordination (concurrent pulse runners across machines), see `r
 
 Worktree naming prefixes: `feature/`, `bugfix/`, `hotfix/`, `refactor/`, `chore/`, `experiment/`, `release/`
 
-PR title: `{task-id}: {description}`. Task ID is `tNNN` (from TODO.md) or `GH#NNN` (GitHub issue number, for debt/issue-only work). Examples: `t1702: integrate FOSS scanning`, `GH#12455: tighten hashline-edit-format.md`. NEVER use `qd-`, bare numbers, or invented prefixes. Create TODO entry first for unplanned work.
+PR title: `{task-id}: {description}`. Task ID is `tNNN` (from TODO.md) or `GH#NNN` (GitHub issue number, for debt/issue-only work). Examples: `t1702: integrate FOSS scanning`, `GH#12455: tighten hashline-edit-format.md`. NEVER use `qd-`, bare numbers, or invented prefixes. NEVER invent suffixes or variants either — `t2213b`, `t2213-2`, `t2213.fix`, `t2213-followup` are all forbidden. Task IDs come EXCLUSIVELY from `claim-task-id.sh` output; for follow-up work, claim a FRESH ID. Create TODO entry first for unplanned work.
 
 Worktrees: `wt switch -c {type}/{name}`. Keep the canonical repo directory on `main`, and treat the Git ref as an internal detail inside the linked worktree. User-facing guidance should talk about the worktree path, not "using a branch". Re-read files at worktree path before editing. NEVER remove others' worktrees.
 

--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -303,6 +303,7 @@ Git is the audit trail. Procedures: AGENTS.md "Git Workflow" section.
 
 **Traceability (MANDATORY):**
 - PR title MUST have task ID (`{task-id}: {description}`). No exceptions.
+- NEVER invent task ID suffixes or variants — `t2213b`, `t2213-2`, `t2213.fix`, `t2213-followup` are all forbidden. Task IDs come EXCLUSIVELY from `claim-task-id.sh` output. For follow-up work on a merged task, claim a FRESH task ID via `claim-task-id.sh` — don't extend the old one. NEVER prefix `--title` with a `tNNN:` when calling `claim-task-id.sh` — always let the helper inject the claimed ID. Titles must describe the work, not assert an ID.
 - **PR bodies MUST use `Resolves #NNN`** to link the PR to its issue. GitHub only
   creates the sidebar "Development" link (PR↔issue) when the PR body contains a closing
   keyword (`Closes`, `Fixes`, `Resolves`). Without it, the audit trail is broken — you

--- a/.agents/prompts/worker-efficiency-protocol.md
+++ b/.agents/prompts/worker-efficiency-protocol.md
@@ -46,7 +46,7 @@ fi
 - **PR titles must include the task ID (t318.2).** Use `<task-id>: <description>`.
   - `tNNN` for TODO tasks, e.g. `t318.2: Verify supervisor worker PRs include task ID`
   - `GH#NNN` for GitHub issues, e.g. `GH#12455: tighten hashline-edit-format.md`
-  - Never use `qd-`, bare numbers, or `t` + a GitHub issue number. CI and the supervisor validate this.
+  - Never use `qd-`, bare numbers, or `t` + a GitHub issue number. Never invent suffixes/variants (`t2213b`, `t2213-2`, `t2213.fix`). Task IDs come ONLY from `claim-task-id.sh`; for follow-ups, claim a fresh ID. CI and the supervisor validate this.
 
 ## 2. Spend tokens where they change outcomes
 

--- a/.agents/scripts/worktree-helper.sh
+++ b/.agents/scripts/worktree-helper.sh
@@ -686,6 +686,18 @@ cmd_add() {
 		return 1
 	fi
 
+	# t2235: Detect self-invented task ID variants (e.g. t2213b, t2213-2, t2213.fix)
+	# Task IDs come ONLY from claim-task-id.sh. For follow-ups, claim a fresh ID.
+	if [[ "$branch" =~ t[0-9]+[a-z]($|[-_/]) ]] || [[ "$branch" =~ t[0-9]+[-._][0-9]+($|[-_/]) ]]; then
+		print_warning "Branch name contains a non-claimed task ID variant ($branch)."
+		print_warning "Task IDs come ONLY from claim-task-id.sh. For follow-ups, claim a fresh ID."
+		if [[ -t 0 ]]; then # interactive
+			read -rp "Continue with this branch name anyway? [y/N] " confirm
+			[[ "$confirm" =~ ^[Yy]$ ]] || return 1
+		fi
+		# headless: warn only, don't block (could be legitimate in rare cases)
+	fi
+
 	# Check if we're in a git repo
 	if [[ -z "$(get_repo_root)" ]]; then
 		echo -e "${RED}Error: Not in a git repository${NC}"

--- a/.agents/workflows/git-workflow.md
+++ b/.agents/workflows/git-workflow.md
@@ -120,7 +120,7 @@ Management: `install-hooks-helper.sh [status|install|test|uninstall]`. Files: `~
 
 After file changes: run preflight automatically. Pass → auto-commit with suggested message (confirm or override). Fail → show issues, offer fixes. After commit → auto-push, offer: create PR, continue working, or done.
 
-**PR Title (MANDATORY)**: `{task-id}: {description}`. Task ID is `tNNN` (from TODO.md) or `GH#NNN` (GitHub issue number, for quality-debt/simplification-debt/issue-only work). Examples: `t318: Update PR workflow documentation`, `GH#12455: tighten hashline-edit-format.md`. NEVER use `qd-`, bare numbers, or invented prefixes. For unplanned work: create TODO entry first.
+**PR Title (MANDATORY)**: `{task-id}: {description}`. Task ID is `tNNN` (from TODO.md) or `GH#NNN` (GitHub issue number, for quality-debt/simplification-debt/issue-only work). Examples: `t318: Update PR workflow documentation`, `GH#12455: tighten hashline-edit-format.md`. NEVER use `qd-`, bare numbers, or invented prefixes. NEVER invent suffixes or variants either — `t2213b`, `t2213-2`, `t2213.fix`, `t2213-followup` are all forbidden. Task IDs come EXCLUSIVELY from `claim-task-id.sh` output; for follow-up work, claim a FRESH ID. For unplanned work: create TODO entry first.
 
 **If changes include `.agents/` files**: Offer to run `./setup.sh` to deploy to `~/.aidevops/agents/`.
 


### PR DESCRIPTION
## Summary

- Added explicit prohibition on self-invented task ID suffixes/variants (`t2213b`, `t2213-2`, `t2213.fix`, `t2213-followup`) to `build.txt` Traceability section, `AGENTS.md`, `git-workflow.md`, and `worker-efficiency-protocol.md`
- Added regex warning in `worktree-helper.sh cmd_add` that detects branch names containing non-claimed task ID variants and warns (interactive) or logs (headless)
- Documents that `claim-task-id.sh` is the EXCLUSIVE source of task IDs, and callers should never prefix `--title` with a `tNNN:`

Resolves #19744

## Testing

- `shellcheck .agents/scripts/worktree-helper.sh` — zero new violations (all flagged items pre-existing)
- Regex patterns tested: `feature/t9999b-test` triggers warning; `feature/t9999-test` and `chore/t2228-lifecycle-retrospective` pass cleanly


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.73 plugin for [OpenCode](https://opencode.ai) v1.14.17 with claude-opus-4-6 spent 9m and 13,710 tokens on this as a headless worker.