### PR TITLE
t2247: emit PR comment, audit log, and label on admin-merge fallback

### DIFF
--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -1045,6 +1045,63 @@ _merge_resolve_repo() {
 	return 0
 }
 
+# _signal_admin_merge_fallback — post PR comment, audit log, and label after --admin fallback merge.
+#
+# t2247: When `_merge_execute` falls back to `--admin` because branch protection
+# blocked a plain merge, this function records three signaling artifacts so the
+# fallback is visible at PR level (not just in session logs).
+#
+# Args: pr_number repo merge_method original_error_output
+# Returns: 0 always (signaling failures are non-fatal — the merge already succeeded)
+_signal_admin_merge_fallback() {
+	local pr_number="$1"
+	local repo="$2"
+	local merge_method="$3"
+	local original_error="$4"
+
+	# (a) PR comment with error context, ops markers, and remediation
+	local _sig_footer=""
+	_sig_footer=$(gh-signature-helper.sh footer --model "${AIDEVOPS_MODEL:-unknown}" 2>/dev/null) || _sig_footer=""
+
+	local _admin_comment="<!-- ops:start — workers: skip this comment, it is audit trail not implementation context -->
+## Admin Merge Fallback (t2247)
+
+Branch protection blocked the plain \`gh pr merge\` for PR #${pr_number}. The merge succeeded using \`--admin\` fallback (per GH#18538 — workers share the maintainer's \`gh auth\`).
+
+**Merge method:** \`${merge_method}\`
+
+<details>
+<summary>Original branch-protection error</summary>
+
+\`\`\`text
+${original_error}
+\`\`\`
+
+</details>
+
+**Remediation:** If this bypass was unintended, revert with \`gh pr revert ${pr_number} --repo ${repo}\` and investigate why review bots did not approve.
+<!-- ops:end -->
+${_sig_footer}"
+
+	if gh pr comment "$pr_number" --repo "$repo" --body "$_admin_comment" >/dev/null 2>&1; then
+		print_info "Admin-merge fallback comment posted on PR #${pr_number}"
+	else
+		print_warning "Failed to post admin-merge fallback comment on PR #${pr_number}"
+	fi
+
+	# (b) Audit log entry
+	if command -v audit-log-helper.sh >/dev/null 2>&1; then
+		audit-log-helper.sh log merge-admin-fallback \
+			"PR #${pr_number} in ${repo} — ${merge_method} — branch protection blocked plain merge" \
+			2>/dev/null || true
+	fi
+
+	# (c) admin-merge label for cross-PR filtering
+	gh pr edit "$pr_number" --repo "$repo" --add-label "admin-merge" 2>/dev/null || true
+
+	return 0
+}
+
 # _merge_execute — attempt `gh pr merge` with optional --admin fallback on branch-protection errors.
 #
 # GH#18538: branch protection that requires an approving review rejects plain
@@ -1094,6 +1151,11 @@ _merge_execute() {
 			print_info "Branch protection blocked plain merge; retrying with --admin (workers share the maintainer's gh auth per GH#18538)..."
 			if gh pr merge "$pr_number" --repo "$repo" "$merge_method" --admin 2>&1; then
 				print_success "PR #${pr_number} merged with --admin fallback"
+				# t2247: Signal that admin-merge fallback was used — three artifacts:
+				# (a) PR comment with error context + remediation
+				# (b) Audit log entry
+				# (c) admin-merge label for cross-PR filtering
+				_signal_admin_merge_fallback "$pr_number" "$repo" "$merge_method" "$_merge_out"
 				return 0
 			else
 				print_error "Merge failed for PR #${pr_number} (even with --admin — maintainer gate or admin rights missing)"

--- a/.agents/scripts/tests/test-full-loop-merge.sh
+++ b/.agents/scripts/tests/test-full-loop-merge.sh
@@ -1,0 +1,295 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-full-loop-merge.sh — Regression tests for _merge_execute admin fallback signaling (t2247)
+#
+# Verifies:
+#   1. Admin fallback fires all three signaling artifacts (PR comment, audit log, label)
+#   2. Explicit --admin caller does NOT trigger extra signaling (back-compat)
+#   3. Non-branch-protection errors do NOT trigger fallback
+#
+# Strategy: stub gh, audit-log-helper.sh, and gh-signature-helper.sh in a temp
+# directory prepended to PATH, then source the functions from full-loop-helper.sh.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+HELPER_SCRIPT="${SCRIPT_DIR}/../full-loop-helper.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+	mkdir -p "${TEST_ROOT}/bin"
+	mkdir -p "${TEST_ROOT}/logs"
+
+	# Stub gh-signature-helper.sh
+	cat >"${TEST_ROOT}/bin/gh-signature-helper.sh" <<'STUB'
+#!/usr/bin/env bash
+echo "---"
+echo "test-signature-footer"
+STUB
+	chmod +x "${TEST_ROOT}/bin/gh-signature-helper.sh"
+
+	# Stub audit-log-helper.sh — records invocations to a log file
+	cat >"${TEST_ROOT}/bin/audit-log-helper.sh" <<STUB
+#!/usr/bin/env bash
+echo "\$*" >> "${TEST_ROOT}/logs/audit-log-calls.txt"
+STUB
+	chmod +x "${TEST_ROOT}/bin/audit-log-helper.sh"
+
+	return 0
+}
+
+teardown_test_env() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+# Create a gh stub that simulates merge behavior.
+# Args:
+#   $1 = "fallback" — first merge fails with branch-protection error, --admin succeeds
+#   $2 = "explicit-admin" — merge with --admin succeeds immediately (no fallback)
+#   $3 = "other-error" — merge fails with non-branch-protection error
+create_gh_stub() {
+	local mode="$1"
+
+	cat >"${TEST_ROOT}/bin/gh" <<GHSTUB
+#!/usr/bin/env bash
+# Log all gh calls
+_gh_cmd="\$1"
+_gh_sub="\$2"
+echo "gh \$*" >> "${TEST_ROOT}/logs/gh-calls.txt"
+
+if [[ "\$_gh_cmd" == "pr" && "\$_gh_sub" == "merge" ]]; then
+	# Check if --admin flag is present
+	_gh_has_admin=0
+	for _gh_arg in "\$@"; do
+		if [[ "\$_gh_arg" == "--admin" ]]; then
+			_gh_has_admin=1
+		fi
+	done
+
+	if [[ "$mode" == "fallback" ]]; then
+		if [[ "\$_gh_has_admin" -eq 1 ]]; then
+			echo "Merged PR"
+			exit 0
+		else
+			echo "At least 1 approving review is required" >&2
+			exit 1
+		fi
+	elif [[ "$mode" == "explicit-admin" ]]; then
+		echo "Merged PR"
+		exit 0
+	elif [[ "$mode" == "other-error" ]]; then
+		echo "Something completely different went wrong" >&2
+		exit 1
+	fi
+fi
+
+if [[ "\$_gh_cmd" == "pr" && "\$_gh_sub" == "comment" ]]; then
+	echo "pr comment \$*" >> "${TEST_ROOT}/logs/pr-comments.txt"
+	exit 0
+fi
+
+if [[ "\$_gh_cmd" == "pr" && "\$_gh_sub" == "edit" ]]; then
+	echo "pr edit \$*" >> "${TEST_ROOT}/logs/pr-edits.txt"
+	exit 0
+fi
+
+# Default: succeed silently
+exit 0
+GHSTUB
+	chmod +x "${TEST_ROOT}/bin/gh"
+	return 0
+}
+
+# Run _merge_execute in an isolated subprocess.
+# Sources full-loop-helper.sh with init lines stripped (SCRIPT_DIR assignment,
+# shared-constants source, readonly SCRIPT_DIR, and main "$@" call) so we get
+# all function definitions without side effects.
+# Args: pr_number repo merge_method has_admin has_auto
+run_merge_execute() {
+	local pr_number="$1"
+	local repo="$2"
+	local merge_method="$3"
+	local has_admin="$4"
+	local has_auto="$5"
+
+	local scripts_dir="${SCRIPT_DIR}/.."
+
+	# Build a temporary script that sources the helper with init lines stripped.
+	# Using a temp file avoids heredoc/process-substitution escaping issues with $.
+	local tmp_runner=""
+	tmp_runner=$(mktemp)
+	cat >"$tmp_runner" <<RUNNER_EOF
+#!/usr/bin/env bash
+set -euo pipefail
+SCRIPT_DIR='${scripts_dir}'
+source '${scripts_dir}/shared-constants.sh'
+# Strip: line 10 (SCRIPT_DIR=), line 11 (source shared-constants), line 13 (readonly SCRIPT_DIR), last line (main "\$@")
+source <(sed -e '10d' -e '11d' -e '13d' -e '\$d' '${HELPER_SCRIPT}')
+_merge_execute '$pr_number' '$repo' '$merge_method' '$has_admin' '$has_auto'
+RUNNER_EOF
+	chmod +x "$tmp_runner"
+
+	# Run in a subprocess with our stubs on PATH
+	local rc=0
+	env PATH="${TEST_ROOT}/bin:${scripts_dir}:${PATH}" \
+		AIDEVOPS_MODEL="test-model" \
+		bash "$tmp_runner" 2>&1 || rc=$?
+	rm -f "$tmp_runner"
+	return $rc
+}
+
+# Test 1: Admin fallback fires and produces all three signaling artifacts
+test_admin_fallback_signals() {
+	# Clear logs
+	rm -f "${TEST_ROOT}/logs/"*.txt
+
+	create_gh_stub "fallback"
+
+	local output=""
+	output=$(run_merge_execute "42" "testorg/testrepo" "--squash" "0" "0") || true
+
+	# (a) Check PR comment was posted
+	local pr_comment_posted=0
+	if [[ -f "${TEST_ROOT}/logs/pr-comments.txt" ]]; then
+		if grep -q "pr comment" "${TEST_ROOT}/logs/pr-comments.txt"; then
+			pr_comment_posted=1
+		fi
+	fi
+	print_result "admin fallback: PR comment posted" "$((1 - pr_comment_posted))"
+
+	# (b) Check audit log was called
+	local audit_logged=0
+	if [[ -f "${TEST_ROOT}/logs/audit-log-calls.txt" ]]; then
+		if grep -q "merge-admin-fallback" "${TEST_ROOT}/logs/audit-log-calls.txt"; then
+			audit_logged=1
+		fi
+	fi
+	print_result "admin fallback: audit log entry written" "$((1 - audit_logged))"
+
+	# (c) Check admin-merge label was applied
+	local label_applied=0
+	if [[ -f "${TEST_ROOT}/logs/pr-edits.txt" ]]; then
+		if grep -q "admin-merge" "${TEST_ROOT}/logs/pr-edits.txt"; then
+			label_applied=1
+		fi
+	fi
+	print_result "admin fallback: admin-merge label applied" "$((1 - label_applied))"
+
+	return 0
+}
+
+# Test 2: Explicit --admin caller does NOT trigger extra signaling
+test_explicit_admin_no_signaling() {
+	# Clear logs
+	rm -f "${TEST_ROOT}/logs/"*.txt
+
+	create_gh_stub "explicit-admin"
+
+	local output=""
+	output=$(run_merge_execute "42" "testorg/testrepo" "--squash" "1" "0") || true
+
+	# PR comment should NOT have been posted (explicit --admin is not a fallback)
+	local pr_comment_posted=0
+	if [[ -f "${TEST_ROOT}/logs/pr-comments.txt" ]]; then
+		if grep -q "pr comment" "${TEST_ROOT}/logs/pr-comments.txt"; then
+			pr_comment_posted=1
+		fi
+	fi
+	print_result "explicit --admin: no extra PR comment" "$pr_comment_posted"
+
+	# Audit log should NOT have been called
+	local audit_logged=0
+	if [[ -f "${TEST_ROOT}/logs/audit-log-calls.txt" ]]; then
+		if grep -q "merge-admin-fallback" "${TEST_ROOT}/logs/audit-log-calls.txt"; then
+			audit_logged=1
+		fi
+	fi
+	print_result "explicit --admin: no extra audit log" "$audit_logged"
+
+	# Label should NOT have been applied
+	local label_applied=0
+	if [[ -f "${TEST_ROOT}/logs/pr-edits.txt" ]]; then
+		if grep -q "admin-merge" "${TEST_ROOT}/logs/pr-edits.txt"; then
+			label_applied=1
+		fi
+	fi
+	print_result "explicit --admin: no admin-merge label" "$label_applied"
+
+	return 0
+}
+
+# Test 3: Non-branch-protection errors do NOT trigger fallback at all
+test_other_error_no_fallback() {
+	# Clear logs
+	rm -f "${TEST_ROOT}/logs/"*.txt
+
+	create_gh_stub "other-error"
+
+	local exit_code=0
+	run_merge_execute "42" "testorg/testrepo" "--squash" "0" "0" >/dev/null 2>&1 || exit_code=$?
+
+	# Should have failed (exit code != 0)
+	print_result "other error: merge fails without fallback" "$((exit_code == 0 ? 1 : 0))"
+
+	# No signaling should have fired
+	local any_signaling=0
+	if [[ -f "${TEST_ROOT}/logs/pr-comments.txt" ]] ||
+		[[ -f "${TEST_ROOT}/logs/audit-log-calls.txt" ]] ||
+		[[ -f "${TEST_ROOT}/logs/pr-edits.txt" ]]; then
+		any_signaling=1
+	fi
+	print_result "other error: no signaling artifacts" "$any_signaling"
+
+	return 0
+}
+
+main() {
+	trap teardown_test_env EXIT
+	setup_test_env
+
+	echo "=== Admin merge fallback signaling tests (t2247) ==="
+	echo ""
+
+	test_admin_fallback_signals
+	test_explicit_admin_no_signaling
+	test_other_error_no_fallback
+
+	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Added `_signal_admin_merge_fallback` function to `full-loop-helper.sh` that fires after a successful `--admin` fallback merge, posting three signaling artifacts: (a) PR comment with `<!-- ops:start/end -->` markers, branch-protection error details, and remediation note, (b) `audit-log-helper.sh log merge-admin-fallback` entry, (c) `admin-merge` label for cross-PR filtering
- Explicit `--admin`/`--auto` callers are unaffected — signaling only fires on the error-retry fallback path (lines 1092–1097)
- Regression test with 8 assertions covering fallback signals, explicit-admin back-compat, and non-branch-protection error handling

Resolves #19771