### PR TITLE
t2377: implement 5-layer defence against enrich-path data-loss bug

### DIFF
--- a/.agents/scripts/.shellcheckrc
+++ b/.agents/scripts/.shellcheckrc
@@ -21,6 +21,15 @@ external-sources=false
 # Inherit the same disable rules as root .shellcheckrc
 # (ShellCheck only reads ONE .shellcheckrc — the first found — so we must
 # duplicate the disables here rather than inheriting from root)
+#
+# SC1091 ("Not following: … was not specified as input") is disabled here for
+# parity with the root .shellcheckrc — without this line, every script in this
+# directory that uses `source "${SCRIPT_DIR}/foo.sh"` gets flagged on every
+# pre-commit run, even though the root rcfile intentionally disables it.
+# Drift between this file and the root rcfile caused t2377's PR to be blocked
+# by pre-existing debt in unrelated files; adding the disable here restores
+# the intended parity documented by the file header above.
+disable=SC1091
 disable=SC2329
 disable=SC2317
 disable=SC2034

--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -51,7 +51,8 @@ FORCE_ENRICH="${FORCE_ENRICH:-false}"
 REPO_SLUG=""
 
 log_verbose() {
-	[[ "$VERBOSE" == "true" ]] && print_info "$1"
+	local msg="$1"
+	[[ "$VERBOSE" == "true" ]] && print_info "$msg"
 	return 0
 }
 
@@ -92,11 +93,20 @@ _init_cmd() {
 
 _build_title() {
 	local task_id="$1" description="$2"
+	# Layer 3 (t2377): refuse stub titles. When description is empty, the
+	# pre-fix behaviour emitted "tNNN: " (task ID + colon + trailing space)
+	# which _enrich_update_issue then wrote to the issue, destroying the
+	# real title (#19778/#19779/#19780). Fail loudly so the caller sees it.
+	if [[ -z "$description" ]]; then
+		print_error "_build_title: refusing to emit stub title for ${task_id} — description is empty (t2377)"
+		return 1
+	fi
 	if [[ "$description" == *" — "* ]]; then
 		echo "${task_id}: ${description%% — *}"
 	elif [[ ${#description} -gt 80 ]]; then
 		echo "${task_id}: ${description:0:77}..."
 	else echo "${task_id}: ${description}"; fi
+	return 0
 }
 
 # =============================================================================
@@ -676,6 +686,23 @@ _push_create_issue() {
 # _push_process_task: process a single task_id — skip if existing/completed,
 # parse metadata, dry-run or create issue. Updates created/skipped counters
 # via stdout tokens "CREATED" or "SKIPPED" for the caller to count.
+# GH#18041 (t1957): Collision detection — warn if a merged PR already uses
+# this task ID. This catches task ID reuse (counter reset, fabricated IDs)
+# before the issue is created, preventing permanent dispatch blocks.
+# Extracted from _push_process_task to keep that function under the 100-line
+# complexity gate (t2377 refactor).
+_push_warn_if_task_id_collides() {
+	local repo="$1" task_id="$2"
+	local collision_pr
+	collision_pr=$(gh_find_merged_pr "$repo" "$task_id")
+	if [[ -n "$collision_pr" ]]; then
+		local collision_num="${collision_pr%%|*}"
+		local collision_url="${collision_pr#*|}"
+		print_warning "TASK ID COLLISION: ${task_id} already used by merged PR #${collision_num} (${collision_url}). This issue will be blocked by the dedup guard. Re-ID the task with claim-task-id.sh."
+	fi
+	return 0
+}
+
 _push_process_task() {
 	local task_id="$1" repo="$2" todo_file="$3" project_root="$4"
 	log_verbose "Processing $task_id..."
@@ -719,7 +746,11 @@ _push_process_task() {
 	local assignee
 	assignee=$(echo "$parsed" | grep '^assignee=' | cut -d= -f2-)
 	local title
-	title=$(_build_title "$task_id" "$description")
+	if ! title=$(_build_title "$task_id" "$description"); then
+		print_error "Skipping push for $task_id — empty description; fix TODO entry before retrying (t2377)"
+		echo "SKIPPED"
+		return 0
+	fi
 	local labels
 	labels=$(map_tags_to_labels "$tags")
 
@@ -736,17 +767,7 @@ _push_process_task() {
 	local body
 	body=$(compose_issue_body "$task_id" "$project_root")
 
-	# GH#18041 (t1957): Collision detection — warn if a merged PR already uses
-	# this task ID. This catches task ID reuse (counter reset, fabricated IDs)
-	# before the issue is created, preventing permanent dispatch blocks.
-	local collision_pr
-	collision_pr=$(gh_find_merged_pr "$repo" "$task_id")
-	if [[ -n "$collision_pr" ]]; then
-		local collision_num collision_url
-		collision_num="${collision_pr%%|*}"
-		collision_url="${collision_pr#*|}"
-		print_warning "TASK ID COLLISION: ${task_id} already used by merged PR #${collision_num} (${collision_url}). This issue will be blocked by the dedup guard. Re-ID the task with claim-task-id.sh."
-	fi
+	_push_warn_if_task_id_collides "$repo" "$task_id"
 
 	if [[ "$DRY_RUN" == "true" ]]; then
 		print_info "[DRY-RUN] Would create: $title"
@@ -930,6 +951,26 @@ _enrich_update_issue() {
 	local current_title="${6:-}" current_body="${7:-}"
 	local do_body_update=true
 
+	# Layer 2 (t2377): never-delete invariant. Regardless of FORCE_ENRICH or any
+	# other env override, refuse to write an empty title or empty body. These
+	# are never a legitimate target state — `gh issue edit --title "" --body ""`
+	# is pure data loss (observed on #19778/#19779/#19780). This guard runs
+	# BEFORE any FORCE_ENRICH bypass and cannot be disabled.
+	if [[ -z "$title" ]]; then
+		print_error "_enrich_update_issue refused empty title for #$num ($task_id) — data loss guard (t2377)"
+		return 1
+	fi
+	if [[ -z "$body" ]]; then
+		print_error "_enrich_update_issue refused empty body for #$num ($task_id) — data loss guard (t2377)"
+		return 1
+	fi
+	# Layer 2 (t2377): stub title ("tNNN: " or "tNNN:  " with trailing whitespace)
+	# is the symptom seen on #19778/#19779/#19780. Refuse even when non-empty.
+	if [[ "$title" =~ ^t[0-9]+:[[:space:]]*$ ]]; then
+		print_error "_enrich_update_issue refused stub title '$title' for #$num ($task_id) — data loss guard (t2377)"
+		return 1
+	fi
+
 	if [[ "$FORCE_ENRICH" != "true" ]]; then
 		if [[ -z "$current_body" ]]; then
 			current_body=$(gh issue view "$num" --repo "$repo" --json body -q '.body // ""' 2>/dev/null || echo "")
@@ -1025,9 +1066,25 @@ _enrich_process_task() {
 	fi
 
 	local title
-	title=$(_build_title "$task_id" "$desc")
+	if ! title=$(_build_title "$task_id" "$desc"); then
+		# Layer 3 follow-up (t2377): _build_title refused stub "tNNN: "
+		# emission because description is empty. This is the t2377 data-loss
+		# symptom — skip the enrich rather than forward an invalid title.
+		print_error "Skipping enrich for $task_id — empty description; fix TODO entry before retrying (t2377)"
+		return 0
+	fi
 	local body
-	body=$(compose_issue_body "$task_id" "$project_root")
+	local _compose_rc=0
+	body=$(compose_issue_body "$task_id" "$project_root") || _compose_rc=$?
+	# Layer 1 (t2377): composition failure = no authoritative body available.
+	# Skip the enrich entirely rather than emit an empty body. Previous
+	# behaviour allowed empty body to reach _enrich_update_issue which, under
+	# FORCE_ENRICH=true, executed `gh issue edit --body ""` and DESTROYED
+	# the issue's original content (data loss: #19778/#19779/#19780).
+	if [[ $_compose_rc -ne 0 || -z "$body" ]]; then
+		print_error "Skipping enrich for $task_id — compose_issue_body failed (rc=$_compose_rc). Task ID is not in TODO.md; fix the TODO entry or remove the brief file (t2377)."
+		return 0
+	fi
 
 	if [[ "$DRY_RUN" == "true" ]]; then
 		local _dry_tier_msg=""
@@ -1510,9 +1567,10 @@ EOF
 main() {
 	local command="" positional_args=()
 	while [[ $# -gt 0 ]]; do
-		case "$1" in
+		local arg="$1" val="${2:-}"
+		case "$arg" in
 		--repo)
-			REPO_SLUG="$2"
+			REPO_SLUG="$val"
 			shift 2
 			;;
 		--dry-run)
@@ -1537,7 +1595,7 @@ main() {
 			return 0
 			;;
 		*)
-			positional_args+=("$1")
+			positional_args+=("$arg")
 			shift
 			;;
 		esac

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -992,11 +992,41 @@ _ensure_issue_body_has_brief() {
 	local brief_file="${repo_path}/todo/tasks/${task_id}-brief.md"
 	[[ ! -f "$brief_file" ]] && return 0
 
-	# Check if body already contains the inline markers
+	# Check if body already has substantial content (framework-synced markers OR
+	# an externally-composed brief-style body).
+	# Layer 4 (t2377): the narrow marker check mis-classified externally-
+	# composed bodies as stubs. #19778/#19779/#19780 had "## What" / "## Why" /
+	# "## How" bodies ~5KB each; the old check treated them as stubs and
+	# force-enriched them into emptiness.
 	local current_body
 	current_body=$(gh issue view "$issue_number" --repo "$repo_slug" --json body -q .body 2>/dev/null || echo "")
 	if [[ "$current_body" == *"## Task Brief"* ]] || [[ "$current_body" == *"## Worker Guidance"* ]]; then
 		return 0
+	fi
+	# Brief-template-style headings count as substantial content too (layer 4).
+	if [[ "$current_body" == *"## What"* ]] && [[ "$current_body" == *"## How"* ]]; then
+		return 0
+	fi
+	# Fallback length heuristic: 500+ chars is unlikely to be a stub (layer 4).
+	# Real stubs from claim-task-id.sh are <200 chars.
+	if [[ ${#current_body} -ge 500 ]]; then
+		return 0
+	fi
+
+	# Layer 5 (t2377): refuse to force-enrich when the task has a brief on disk
+	# but no TODO.md entry. This combination makes compose_issue_body fail, and
+	# the resulting empty body previously destroyed the issue content. The
+	# correct behaviour in this case is: leave the existing (externally-
+	# composed) body alone; the worker will read the brief from disk directly.
+	local todo_file="${repo_path}/TODO.md"
+	if [[ -f "$todo_file" ]]; then
+		local task_id_ere
+		# shellcheck disable=SC2016  # $ inside single quotes is a literal regex metachar, not a shell expansion
+		task_id_ere=$(printf '%s' "$task_id" | sed 's/[].[\*^$()+?{|]/\\&/g')
+		if ! grep -qE "^[[:space:]]*- \[.\] ${task_id_ere}( |$)" "$todo_file" 2>/dev/null; then
+			echo "[dispatch_with_dedup] t2377: issue #${issue_number} has brief but no TODO.md entry; skipping force-enrich (safe: worker will read brief from disk)" >>"$LOGFILE"
+			return 0
+		fi
 	fi
 
 	# Brief exists but body is a stub — force-enrich before worker sees it.

--- a/.agents/scripts/tests/test-enrich-no-data-loss.sh
+++ b/.agents/scripts/tests/test-enrich-no-data-loss.sh
@@ -1,0 +1,325 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-enrich-no-data-loss.sh — regression tests for t2377
+#
+# Asserts that the 5-layer defence-in-depth against the enrich-path data-loss
+# bug (GH#19847) holds. The incident: #19778/#19779/#19780 had their titles
+# reduced to "tNNN: " stubs and bodies emptied by issue-sync-helper.sh enrich
+# when a brief existed on disk but no TODO.md entry referenced it.
+#
+# Layer coverage:
+#
+#   1. _enrich_process_task checks compose_issue_body exit code and skips
+#      rather than forwarding an empty body.
+#
+#   2. _enrich_update_issue refuses to run `gh issue edit` with an empty title,
+#      empty body, or stub "tNNN: " title regardless of FORCE_ENRICH.
+#
+#   3. _build_title returns non-zero on empty description (prevents the stub
+#      emission that feeds layer 2's rejection path).
+#
+#   4. _ensure_issue_body_has_brief recognises `## What` + `## How` style
+#      bodies AND the 500-char length heuristic as already-enriched.
+#
+#   5. _ensure_issue_body_has_brief skips force-enrich when TODO.md has no
+#      entry for the task — brief-without-TODO is legitimate, not a stub.
+#
+# Strategy:
+#   - Source issue-sync-helper.sh with stubbed logging.
+#   - Stub `gh` to FAIL the test loudly if any destructive edit is attempted.
+#   - For each layer, construct the minimal fixture and assert on either the
+#     return code or the absence of a gh call.
+
+set -u
+set +e
+
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_BLUE=$'\033[0;34m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_BLUE="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	local msg="$1"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf '  %sPASS%s %s\n' "$TEST_GREEN" "$TEST_NC" "$msg"
+	return 0
+}
+
+fail() {
+	local msg="$1"
+	local detail="${2:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '  %sFAIL%s %s\n' "$TEST_RED" "$TEST_NC" "$msg"
+	if [[ -n "$detail" ]]; then
+		printf '       %s\n' "$detail"
+	fi
+	return 0
+}
+
+section() {
+	local title="$1"
+	printf '\n%s%s%s\n' "$TEST_BLUE" "$title" "$TEST_NC"
+	return 0
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)" || exit 1
+HELPER="${SCRIPTS_DIR}/issue-sync-helper.sh"
+DISPATCH_CORE="${SCRIPTS_DIR}/pulse-dispatch-core.sh"
+
+for f in "$HELPER" "$DISPATCH_CORE"; do
+	if [[ ! -f "$f" ]]; then
+		printf 'test harness cannot find %s\n' "$f" >&2
+		exit 1
+	fi
+done
+
+TMP=$(mktemp -d -t t2377-enrich-no-data-loss.XXXXXX)
+trap 'rm -rf "$TMP"' EXIT
+
+# Track whether any destructive gh call fired during the test run.
+export T2377_DESTRUCTIVE_CALL_LOG="${TMP}/destructive-calls.log"
+: >"$T2377_DESTRUCTIVE_CALL_LOG"
+
+# Install a stub `gh` that records destructive invocations. A destructive
+# invocation is `gh issue edit --title "" ...` or `gh issue edit --body ""`
+# or `gh issue edit --title "tNNN: " ...`. Any such call is a regression.
+GH_STUB_BIN="${TMP}/bin/gh"
+mkdir -p "${TMP}/bin"
+cat >"$GH_STUB_BIN" <<'STUB'
+#!/usr/bin/env bash
+# t2377 test stub — records destructive gh issue edit calls.
+LOG="${T2377_DESTRUCTIVE_CALL_LOG:-/dev/null}"
+
+# For `gh issue view` — return a JSON body consistent with the fixture env.
+if [[ "${1:-}" == "issue" && "${2:-}" == "view" ]]; then
+	# Use the fixture-provided body if set, else empty.
+	echo "${T2377_FIXTURE_BODY:-}"
+	exit 0
+fi
+
+if [[ "${1:-}" == "issue" && "${2:-}" == "edit" ]]; then
+	ALL_ARGS="$*"
+	# Destructive patterns:
+	#   --body "" (empty body)
+	#   --body-file /dev/null
+	#   --title "" (empty title)
+	#   --title "tNNN: " (stub title)
+	# We scan positional args because bash doesn't give us the quoted form.
+	destructive=0
+	reason=""
+	prev=""
+	for arg in "$@"; do
+		if [[ "$prev" == "--body" && -z "$arg" ]]; then
+			destructive=1
+			reason="empty --body"
+		fi
+		if [[ "$prev" == "--title" && -z "$arg" ]]; then
+			destructive=1
+			reason="empty --title"
+		fi
+		if [[ "$prev" == "--title" && "$arg" =~ ^t[0-9]+:[[:space:]]*$ ]]; then
+			destructive=1
+			reason="stub --title '$arg'"
+		fi
+		if [[ "$prev" == "--body-file" && "$arg" == "/dev/null" ]]; then
+			destructive=1
+			reason="--body-file /dev/null"
+		fi
+		prev="$arg"
+	done
+	if [[ $destructive -eq 1 ]]; then
+		printf 'DESTRUCTIVE: %s (args: %s)\n' "$reason" "$ALL_ARGS" >>"$LOG"
+	fi
+	# Always succeed so test continues.
+	exit 0
+fi
+
+# Default: no-op success.
+exit 0
+STUB
+chmod +x "$GH_STUB_BIN"
+export PATH="${TMP}/bin:$PATH"
+
+# Stub logging helpers so sourcing the lib does not clobber stderr with colour
+# codes during tests.
+print_info() { :; return 0; }
+print_warning() { :; return 0; }
+print_error() { printf 'print_error: %s\n' "$*" >>"${TMP}/errors.log"; return 0; }
+print_success() { :; return 0; }
+export -f print_info print_warning print_error print_success
+
+# Source the helper so we can invoke its private functions directly.
+# shellcheck disable=SC1090
+source "$HELPER" 2>/dev/null || {
+	printf 'failed to source %s\n' "$HELPER" >&2
+	exit 1
+}
+# The sourced helper re-enables set -euo pipefail. Disable again so the test
+# can invoke functions expected to return non-zero without aborting the run.
+set +e
+set +u
+set +o pipefail
+
+# Re-stub print_error after sourcing — the helper re-defined it. We need our
+# stub that writes to the errors.log so Layer 2 tests can check for guard
+# evidence without polluting stdout.
+print_error() { printf 'print_error: %s\n' "$*" >>"${TMP}/errors.log"; return 0; }
+export -f print_error
+
+destructive_count() { wc -l <"$T2377_DESTRUCTIVE_CALL_LOG" | tr -d ' '; return 0; }
+
+reset_destructive_log() { : >"$T2377_DESTRUCTIVE_CALL_LOG"; return 0; }
+
+# ----------------------------------------------------------------------------
+# Layer 3: _build_title refuses empty description
+# ----------------------------------------------------------------------------
+section "Layer 3: _build_title refuses empty description"
+
+reset_destructive_log
+if _build_title "t9999" "" >/dev/null 2>&1; then
+	fail "_build_title with empty desc should return non-zero"
+else
+	pass "_build_title with empty desc returns non-zero"
+fi
+
+if title=$(_build_title "t9999" "real description" 2>/dev/null); then
+	if [[ "$title" == "t9999: real description" ]]; then
+		pass "_build_title with valid desc returns expected title"
+	else
+		fail "_build_title valid desc" "got: '$title', expected: 't9999: real description'"
+	fi
+else
+	fail "_build_title with valid desc should succeed"
+fi
+
+# Stub title (tNNN:) must NOT be emitted as output even through helpers.
+output=$(_build_title "t9999" "" 2>&1 || true)
+if [[ "$output" == *"t9999: "* && "$output" != *"refusing to emit stub title"* ]]; then
+	fail "_build_title emitted stub title '$output'"
+else
+	pass "_build_title did not emit stub title on empty desc"
+fi
+
+# ----------------------------------------------------------------------------
+# Layer 2: _enrich_update_issue refuses empty title/body/stub title
+# ----------------------------------------------------------------------------
+section "Layer 2: _enrich_update_issue never-delete invariant"
+
+# Case: empty title
+reset_destructive_log
+FORCE_ENRICH=true _enrich_update_issue "test/test" 9999 "t9999" "" "body with content" >/dev/null 2>&1
+rc=$?
+if [[ $rc -ne 0 ]]; then
+	pass "_enrich_update_issue refused empty title (rc=$rc)"
+else
+	fail "_enrich_update_issue should refuse empty title under FORCE_ENRICH"
+fi
+if [[ $(destructive_count) -eq 0 ]]; then
+	pass "no destructive gh edit called for empty title"
+else
+	fail "destructive gh edit fired for empty title"
+fi
+
+# Case: empty body
+reset_destructive_log
+FORCE_ENRICH=true _enrich_update_issue "test/test" 9999 "t9999" "t9999: title" "" >/dev/null 2>&1
+rc=$?
+if [[ $rc -ne 0 ]]; then
+	pass "_enrich_update_issue refused empty body (rc=$rc)"
+else
+	fail "_enrich_update_issue should refuse empty body under FORCE_ENRICH"
+fi
+if [[ $(destructive_count) -eq 0 ]]; then
+	pass "no destructive gh edit called for empty body"
+else
+	fail "destructive gh edit fired for empty body"
+fi
+
+# Case: stub "tNNN: " title (even if non-empty)
+reset_destructive_log
+FORCE_ENRICH=true _enrich_update_issue "test/test" 9999 "t9999" "t9999: " "body with content" >/dev/null 2>&1
+rc=$?
+if [[ $rc -ne 0 ]]; then
+	pass "_enrich_update_issue refused stub title 't9999: ' (rc=$rc)"
+else
+	fail "_enrich_update_issue should refuse stub title"
+fi
+if [[ $(destructive_count) -eq 0 ]]; then
+	pass "no destructive gh edit called for stub title"
+else
+	fail "destructive gh edit fired for stub title"
+fi
+
+# Case: valid title + body → passes the guard (even though downstream path
+# may fail in other ways under the test stub; we only care the guard accepted).
+# We look for the error-log evidence that our guards did NOT block the call.
+: >"${TMP}/errors.log"
+FORCE_ENRICH=true _enrich_update_issue "test/test" 9999 "t9999" "t9999: real title" "real body content" >/dev/null 2>&1 || true
+if ! grep -q "data loss guard (t2377)" "${TMP}/errors.log"; then
+	pass "_enrich_update_issue guard did not fire on valid title+body"
+else
+	fail "_enrich_update_issue guard fired on valid title+body (should not)" "$(cat "${TMP}/errors.log")"
+fi
+
+# ----------------------------------------------------------------------------
+# Layer 4: _ensure_issue_body_has_brief broader marker check
+# ----------------------------------------------------------------------------
+section "Layer 4: _ensure_issue_body_has_brief broader marker check"
+
+# Source pulse-dispatch-core.sh is complex (many cross-sources). Instead test
+# the layer 4 patterns by direct string assertion on the file content — this
+# is an effective regression check against the narrow-marker revert.
+
+if grep -q "## What" "$DISPATCH_CORE" && grep -q "## How" "$DISPATCH_CORE" && grep -qE "current_body.*500" "$DISPATCH_CORE"; then
+	pass "_ensure_issue_body_has_brief recognises ## What + ## How + length heuristic"
+else
+	fail "_ensure_issue_body_has_brief missing broader marker check"
+fi
+
+# ----------------------------------------------------------------------------
+# Layer 5: _ensure_issue_body_has_brief requires TODO entry before force-enrich
+# ----------------------------------------------------------------------------
+section "Layer 5: _ensure_issue_body_has_brief requires TODO entry"
+
+if grep -q "no TODO.md entry.*skipping force-enrich" "$DISPATCH_CORE"; then
+	pass "_ensure_issue_body_has_brief skips force-enrich when TODO entry missing"
+else
+	fail "_ensure_issue_body_has_brief missing TODO-entry precheck"
+fi
+
+# ----------------------------------------------------------------------------
+# Layer 1: _enrich_process_task exit-code check on compose_issue_body
+# ----------------------------------------------------------------------------
+section "Layer 1: _enrich_process_task compose_issue_body exit code"
+
+# Structural check — the exit-code handling pattern should be present.
+if grep -qE "compose_issue_body .*\\|\\| _compose_rc" "$HELPER" && grep -q "Skipping enrich.*compose_issue_body failed" "$HELPER"; then
+	pass "_enrich_process_task checks compose_issue_body exit code"
+else
+	fail "_enrich_process_task missing compose_issue_body exit-code check"
+fi
+
+# ----------------------------------------------------------------------------
+# Summary
+# ----------------------------------------------------------------------------
+section "Summary"
+
+printf '\nRan %d tests, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+
+if [[ $TESTS_FAILED -gt 0 ]]; then
+	printf '%sFAILED%s\n' "$TEST_RED" "$TEST_NC"
+	exit 1
+fi
+printf '%sOK%s\n' "$TEST_GREEN" "$TEST_NC"
+exit 0


### PR DESCRIPTION
## Summary

Implements 5 layers of defence-in-depth against the `issue-sync-helper.sh` enrich code path that destructively wiped GitHub issue titles and bodies when a brief-on-disk existed but the TODO.md entry did not. Three consecutive destructive incidents were observed on marcusquinn/aidevops#19778, #19779, #19780 during the investigation session. The destructive actor in each case was a legitimate concurrent runner (a known cross-runner coordination partner — see companion #19856 for the cross-runner strip-labels sub-bug).

## Why (root cause chain)

1. `compose_issue_body` fails silently when no TODO.md entry exists for the given task ID, returning an empty string.
2. `_enrich_process_task` didn't check the exit code — it forwarded the empty body to `_enrich_update_issue` which called `gh issue edit --body ""`.
3. `_build_title` returned `"tNNN: "` (stub) when description was empty, which paired with the empty body yielded a fully-destroyed issue.
4. The pulse's `_ensure_issue_body_has_brief` force-enrich trigger fired whenever a brief file existed on disk — even when there was no TODO entry to compose FROM. This is the force-path into the data-loss trap.
5. The enrich code also stripped `status:in-review` + `origin:interactive` within ~3 seconds of each destructive edit, defeating the dispatch-dedup guard that `interactive-session-helper.sh claim` relies on — the guard protects against dispatch, not against upstream destructive writes (see companion #19856).

## Layers

1. **`_enrich_process_task` — compose exit-code check** (`issue-sync-helper.sh`, ~line 1070). Skips with a `[t2377]` log line when `compose_issue_body` fails rather than forwarding empty output.
2. **`_enrich_update_issue` — never-delete invariant** (`issue-sync-helper.sh`, ~line 946). Refuses to run `gh issue edit` with empty title, empty body, or stub `"tNNN: "` title, regardless of `FORCE_ENRICH`. This is the last-line defence that would have prevented all three destructive incidents on its own.
3. **`_build_title` + both call sites** (`issue-sync-helper.sh`, ~line 95 + `_push_process_task:722` + `_enrich_process_task:1028`). Returns non-zero on empty description; callers abort the task with a `[t2377]` log line instead of emitting a stub title.
4. **`_ensure_issue_body_has_brief` — broader marker check** (`pulse-dispatch-core.sh`, ~line 997). Recognises `## What` + `## How` style bodies AND the 500-char length heuristic as already-enriched, so the force-enrich trigger no longer fires on legitimate bodies that lack the exact `<!-- aidevops:brief -->` marker.
5. **`_ensure_issue_body_has_brief` — TODO-entry precondition** (`pulse-dispatch-core.sh`, ~line 1016). Refuses to force-enrich when the task has a brief on disk but no TODO.md entry. The worker reads the brief from disk directly in that case; there is no legitimate reason to mutate the issue body.

## Verification

- **Regression harness**: `.agents/scripts/tests/test-enrich-no-data-loss.sh` — 13 assertions covering all 5 layers, `Ran 13 tests, 0 failed`. Mix of direct function calls (Layers 2, 3) + structural grep checks (Layers 1, 4, 5).
- **ShellCheck**: clean on both modified scripts. The `.agents/scripts/.shellcheckrc` was patched to disable SC1091 for parity with the root rcfile (drift bug exposed by this PR — the scripts-dir rcfile was missing the `disable=SC1091` line that the root rcfile has had since the GH#2915 fix).
- **Complexity guard**: `_push_process_task` extracted `_push_warn_if_task_id_collides` to stay under the 100-line function gate after the Layer 3 call-site fix added 4 lines. Diff: 28 → 28 functions over 100 lines, 0 new violations.
- **Smoke**: `issue-sync-helper.sh --help` and `_build_title` called with valid descriptions still behave identically.

## Cross-references

This PR is the central fix for the investigation. Companion self-improvement issues capture the broader systemic lessons:

- `Resolves #19847` — t2377 tracking issue (this fix)
- `Ref #19778`, `Ref #19779`, `Ref #19780` — the three destroyed issues (closed as `not planned` with `no-auto-dispatch`; content preserved in close comments and briefs on disk)
- `Ref #19856` — Cross-runner enrich strips claim labels (partially mitigated here — Layer 2 prevents the wipe that cascades into label-strip; the underlying enrich label behaviour is the remaining sub-bug)
- `Ref #19857` — Framework-wide safety invariant: never emit empty title/body in ANY `gh issue edit` call site
- `Ref #19858` — Audit `FORCE_*` / `SKIP_*` / `OVERRIDE_*` bypass flags for similar traps
- `Ref #19859` — Framework-level audit log for destructive GH operations
- `Ref #19860` — Stub-title scanner routine to catch `"tNNN: "` stubs on open issues
- `Ref #19861` — Document that `interactive-session-helper.sh claim` is dispatch-only protection, not upstream-edit protection

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.73 plugin for [OpenCode](https://opencode.ai) v1.14.17 with claude-opus-4-7 spent 2h 1m and 218,110 tokens on this with the user in an interactive session.
