### PR TITLE
t2260: fix(worktree-helper): replace greedy brief-body #NNN scanning with structured ref:GH# lookup

### DIFF
--- a/.agents/scripts/tests/test-worktree-helper-claim-scope.sh
+++ b/.agents/scripts/tests/test-worktree-helper-claim-scope.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-worktree-helper-claim-scope.sh — t2260 regression guard.
+#
+# Asserts that _interactive_session_auto_claim resolves the correct issue
+# number via structured sources ONLY:
+#
+#   1. Explicit --issue NNN arg (highest precedence)
+#   2. gh<NNN> from branch name (unambiguous)
+#   3. t<NNN> from branch → ref:GH#NNN in TODO.md (structured field only)
+#
+# The greedy brief-body scanning that grabbed historical #NNN references
+# from free-form text (root cause of the t2249 mis-claim on #15114) must
+# never fire. This test creates a brief body containing a decoy issue
+# reference and verifies it is NOT picked up.
+#
+# Assertions:
+#   1. t<NNN> branch with ref:GH# in TODO.md → resolves correct issue
+#   2. t<NNN> branch with decoy #99999 in brief body → does NOT claim 99999
+#   3. gh<NNN> branch pattern → resolves correct issue
+#   4. auto-*-gh<NNN> branch pattern → resolves correct issue
+#   5. Explicit --issue arg overrides branch-derived issue
+#   6. Branch with no matching pattern → no claim (silent skip)
+#   7. t<NNN> branch with NO ref:GH# in TODO.md → no claim
+
+set -uo pipefail
+
+TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_RED=$'\033[0;31m'
+TEST_GREEN=$'\033[0;32m'
+TEST_RESET=$'\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1" rc="$2" extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf '%sPASS%s %s\n' "$TEST_GREEN" "$TEST_RESET" "$name"
+	else
+		printf '%sFAIL%s %s %s\n' "$TEST_RED" "$TEST_RESET" "$name" "$extra"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+# =============================================================================
+# Sandbox setup
+# =============================================================================
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+export HOME="${TEST_ROOT}/home"
+mkdir -p "${HOME}/.aidevops/logs" "${HOME}/.aidevops/.agent-workspace/supervisor"
+
+# Create a mock interactive-session-helper.sh that records claim calls
+MOCK_HELPER="${HOME}/.aidevops/agents/scripts/interactive-session-helper.sh"
+mkdir -p "$(dirname "$MOCK_HELPER")"
+CLAIM_LOG="${TEST_ROOT}/claim-log.txt"
+cat > "$MOCK_HELPER" <<'MOCK'
+#!/usr/bin/env bash
+# Mock interactive-session-helper.sh — records claim calls
+if [[ "${1:-}" == "claim" ]]; then
+    echo "CLAIM:${2:-}:${3:-}" >> "${CLAIM_LOG_PATH}"
+fi
+exit 0
+MOCK
+chmod +x "$MOCK_HELPER"
+
+# Create a fake git repo to satisfy git rev-parse
+FAKE_REPO="${TEST_ROOT}/repo"
+mkdir -p "$FAKE_REPO"
+git -C "$FAKE_REPO" init -q
+git -C "$FAKE_REPO" remote add origin "https://github.com/testowner/testrepo.git"
+# Need at least one commit for git to work
+echo "init" > "$FAKE_REPO/README.md"
+git -C "$FAKE_REPO" add . && git -C "$FAKE_REPO" commit -q -m "init"
+
+# Create TODO.md with structured ref:GH#NNN entries
+cat > "$FAKE_REPO/TODO.md" <<'TODO'
+## Tasks
+
+- [ ] t5000 Fix the widget alignment bug #bugfix ~2h ref:GH#12345 logged:2026-04-18
+- [ ] t5001 Add new feature for dashboard #feature ~4h logged:2026-04-18
+TODO
+
+# Create a brief that contains a decoy issue reference
+mkdir -p "$FAKE_REPO/todo/tasks"
+cat > "$FAKE_REPO/todo/tasks/t5000-brief.md" <<'BRIEF'
+# t5000: Fix the widget alignment bug
+
+## Context
+
+This was discovered during the investigation of #99999 (a historical issue
+that has since been resolved). Also references GH#88888 from the original
+design doc and PR #77777 which introduced the regression.
+
+## What
+
+Fix the widget alignment.
+
+## How
+
+Edit src/widget.ts:42-60
+BRIEF
+
+# =============================================================================
+# Source the function under test
+# =============================================================================
+
+# Unset headless vars so the function thinks we're interactive
+unset FULL_LOOP_HEADLESS AIDEVOPS_HEADLESS OPENCODE_HEADLESS GITHUB_ACTIONS
+unset AIDEVOPS_SESSION_ORIGIN
+
+# Source shared constants (for colors) — guard against readonly collisions
+# by setting them before sourcing
+BLUE=$'\033[0;34m'
+NC=$'\033[0m'
+BOLD=$'\033[1m'
+RED=$'\033[0;31m'
+YELLOW=$'\033[0;33m'
+GREEN=$'\033[0;32m'
+
+# We need SCRIPT_DIR for the helper fallback path
+SCRIPT_DIR="${TEST_SCRIPTS_DIR}"
+
+# Extract only the _interactive_session_auto_claim function from worktree-helper.sh
+# to avoid sourcing the whole file (which has side effects)
+eval "$(sed -n '/^_interactive_session_auto_claim()/,/^}/p' "${TEST_SCRIPTS_DIR}/worktree-helper.sh")"
+
+# =============================================================================
+# Test helpers
+# =============================================================================
+reset_claim_log() {
+	true > "$CLAIM_LOG"
+	export CLAIM_LOG_PATH="$CLAIM_LOG"
+	return 0
+}
+
+get_claimed_issue() {
+	if [[ -f "$CLAIM_LOG" && -s "$CLAIM_LOG" ]]; then
+		head -1 "$CLAIM_LOG" | cut -d: -f2
+	else
+		echo ""
+	fi
+	return 0
+}
+
+# Run the function in the fake repo context
+run_auto_claim() {
+	local branch="$1"
+	local worktree_path="$2"
+	local explicit_issue="${3:-}"
+	reset_claim_log
+	# Run in the fake repo so git rev-parse works
+	(cd "$FAKE_REPO" && _interactive_session_auto_claim "$branch" "$worktree_path" "$explicit_issue")
+	return 0
+}
+
+# =============================================================================
+# Tests
+# =============================================================================
+
+# Test 1: t<NNN> branch with ref:GH#NNN in TODO.md → resolves 12345
+run_auto_claim "feature/t5000-fix-widget" "$FAKE_REPO" ""
+claimed=$(get_claimed_issue)
+rc=0
+[[ "$claimed" == "12345" ]] || rc=1
+print_result "t5000 branch resolves ref:GH#12345 from TODO.md" "$rc" "(got: '$claimed', expected: '12345')"
+
+# Test 2: Decoy #99999 in brief body is NOT picked up
+# (same call as Test 1 — if the old greedy grep were active, it would claim 99999)
+rc=0
+[[ "$claimed" != "99999" ]] || rc=1
+print_result "brief-body decoy #99999 is NOT claimed" "$rc" "(claimed: '$claimed')"
+
+# Test 3: gh<NNN> branch pattern → resolves 18700
+run_auto_claim "bugfix/gh18700-login-fix" "$FAKE_REPO" ""
+claimed=$(get_claimed_issue)
+rc=0
+[[ "$claimed" == "18700" ]] || rc=1
+print_result "gh<NNN> branch resolves issue 18700" "$rc" "(got: '$claimed', expected: '18700')"
+
+# Test 4: auto-*-gh<NNN> branch pattern → resolves 19803
+run_auto_claim "feature/auto-20260419-061301-gh19803" "$FAKE_REPO" ""
+claimed=$(get_claimed_issue)
+rc=0
+[[ "$claimed" == "19803" ]] || rc=1
+print_result "auto-*-gh<NNN> branch resolves issue 19803" "$rc" "(got: '$claimed', expected: '19803')"
+
+# Test 5: Explicit --issue arg overrides branch-derived issue
+run_auto_claim "bugfix/gh18700-login-fix" "$FAKE_REPO" "42"
+claimed=$(get_claimed_issue)
+rc=0
+[[ "$claimed" == "42" ]] || rc=1
+print_result "explicit --issue 42 overrides branch gh18700" "$rc" "(got: '$claimed', expected: '42')"
+
+# Test 6: Branch with no matching pattern → no claim
+run_auto_claim "feature/random-stuff" "$FAKE_REPO" ""
+claimed=$(get_claimed_issue)
+rc=0
+[[ -z "$claimed" ]] || rc=1
+print_result "unrecognised branch pattern → no claim" "$rc" "(got: '$claimed', expected: '')"
+
+# Test 7: t<NNN> branch with NO ref:GH# in TODO.md → no claim
+run_auto_claim "feature/t5001-dashboard-feature" "$FAKE_REPO" ""
+claimed=$(get_claimed_issue)
+rc=0
+[[ -z "$claimed" ]] || rc=1
+print_result "t5001 branch (no ref:GH# in TODO) → no claim" "$rc" "(got: '$claimed', expected: '')"
+
+# =============================================================================
+# Summary
+# =============================================================================
+echo ""
+echo "--- Results: ${TESTS_RUN} tests, ${TESTS_FAILED} failures ---"
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/.agents/scripts/worktree-helper.sh
+++ b/.agents/scripts/worktree-helper.sh
@@ -14,7 +14,7 @@
 #   worktree-helper.sh <command> [options]
 #
 # Commands:
-#   add <branch> [path]    Create worktree for branch (auto-names path)
+#   add <branch> [path] [--issue NNN]  Create worktree for branch (auto-names path)
 #   list                   List all worktrees with status
 #   remove <path|branch>   Remove a worktree
 #   status                 Show current worktree info
@@ -552,21 +552,26 @@ _remove_show_owner_error() {
 # issue while the interactive session owns it.
 #
 # Branch name patterns accepted:
-#   <prefix>/gh<NNN>-<rest>     e.g., bugfix/gh18700-foo
-#   <prefix>/t<NNN>-<rest>      e.g., feature/t2057-phase2-wire
-#   <prefix>/gh<NNN>_<rest>     (underscore separator)
+#   <prefix>/gh<NNN>-<rest>       e.g., bugfix/gh18700-foo
+#   <prefix>/t<NNN>-<rest>        e.g., feature/t2057-phase2-wire
+#   <prefix>/gh<NNN>_<rest>       (underscore separator)
 #   <prefix>/t<NNN>_<rest>
+#   <prefix>/auto-*-gh<NNN>       e.g., feature/auto-20260419-061301-gh19803
 #
-# Note: t<NNN> references a task ID and its linked GitHub issue may differ
-# from NNN. When the branch encodes only a t-ID, we resolve the linked issue
-# number via todo/tasks/<taskid>-brief.md ref:GH#NNN when possible; otherwise
-# the claim is skipped (the task-id path doesn't map to a GH issue reliably).
-# The gh<NNN> path is unambiguous.
+# Issue resolution priority (t2260):
+#   1. Explicit --issue NNN arg (highest precedence, unambiguous)
+#   2. gh<NNN> from branch name (unambiguous)
+#   3. t<NNN> from branch name → ref:GH#NNN in TODO.md entry (structured field)
+#
+# t2260: brief-body scanning REMOVED — greedy #NNN regex on free-form text
+# grabbed historical issue references (e.g. #15114 in a Context section)
+# instead of the task's intended issue. Only structured sources are used now.
 #
 # All failure modes are non-blocking — worktree creation proceeds regardless.
 _interactive_session_auto_claim() {
 	local branch="$1"
 	local worktree_path="$2"
+	local explicit_issue="${3:-}"  # t2260: --issue NNN takes highest precedence
 
 	# Only engage for interactive sessions — workers handle their own
 	# claim flow via dispatch-dedup-helper.sh at dispatch time.
@@ -578,23 +583,41 @@ _interactive_session_auto_claim() {
 		return 0
 	fi
 
-	# Parse issue number from branch. Accept gh<N> unambiguously; skip
-	# t<N>-only branches for now (ambiguous without the todo/tasks lookup).
 	local issue_num=""
-	if [[ "$branch" =~ /gh([0-9]+)[-_] ]]; then
-		issue_num="${BASH_REMATCH[1]}"
+
+	# t2260: Priority 1 — explicit --issue arg (unambiguous, highest precedence)
+	if [[ -n "$explicit_issue" ]]; then
+		issue_num="$explicit_issue"
 	fi
+
+	# Priority 2 — gh<NNN> from branch name (unambiguous)
 	if [[ -z "$issue_num" ]]; then
-		# t<N> branch — attempt to resolve the linked issue from the brief file
+		if [[ "$branch" =~ /gh([0-9]+)[-_] ]]; then
+			issue_num="${BASH_REMATCH[1]}"
+		# t2260: also match auto-dispatch branch pattern: auto-*-gh<NNN>
+		elif [[ "$branch" =~ -gh([0-9]+)$ ]]; then
+			issue_num="${BASH_REMATCH[1]}"
+		fi
+	fi
+
+	# Priority 3 — t<NNN> from branch → structured ref:GH#NNN in TODO.md
+	# t2260: ONLY reads the structured ref:GH#NNN field from the task's own
+	# TODO.md line. Does NOT scan brief bodies (too weak — free-form text
+	# contains historical issue references that produce false matches).
+	if [[ -z "$issue_num" ]]; then
 		local task_id=""
 		if [[ "$branch" =~ /(t[0-9]+)[-_] ]]; then
 			task_id="${BASH_REMATCH[1]}"
 		fi
 		if [[ -n "$task_id" ]]; then
-			local brief_file
-			brief_file=$(git rev-parse --show-toplevel 2>/dev/null)/todo/tasks/"${task_id}"-brief.md
-			if [[ -f "$brief_file" ]]; then
-				issue_num=$(grep -oE 'GH#[0-9]+|#[0-9]+' "$brief_file" | grep -oE '[0-9]+' | head -1 || true)
+			local repo_root=""
+			repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || repo_root=""
+			if [[ -n "$repo_root" && -f "$repo_root/TODO.md" ]]; then
+				# Match ONLY the structured ref:GH#NNN field on the task's TODO line
+				issue_num=$(grep -E "^- \[.\] ${task_id}\b" "$repo_root/TODO.md" \
+					| grep -oE 'ref:GH#[0-9]+' \
+					| grep -oE '[0-9]+' \
+					| head -1 || true)
 			fi
 		fi
 	fi
@@ -604,7 +627,7 @@ _interactive_session_auto_claim() {
 	fi
 
 	# Resolve the repo slug from the git remote
-	local slug
+	local slug=""
 	slug=$(git -C "$worktree_path" remote get-url origin 2>/dev/null |
 		sed 's|.*github\.com[:/]||;s|\.git$||' || echo "")
 	if [[ -z "$slug" ]]; then
@@ -676,15 +699,58 @@ _print_worktree_add_success() {
 	return 0
 }
 
-cmd_add() {
-	local branch="${1:-}"
-	local path="${2:-}"
-
-	if [[ -z "$branch" ]]; then
+# Parse cmd_add arguments: positional (branch, path) + optional --issue NNN.
+# Sets global _ADD_BRANCH, _ADD_PATH, _ADD_ISSUE. Returns 1 on parse error.
+# Extracted from cmd_add (t2260) to keep function bodies under 100 lines.
+_parse_cmd_add_args() {
+	_ADD_BRANCH=""
+	_ADD_PATH=""
+	_ADD_ISSUE=""
+	local _arg=""
+	while [[ $# -gt 0 ]]; do
+		_arg="$1"
+		case "$_arg" in
+			--issue)
+				local _next="${2:-}"
+				if [[ -z "$_next" ]]; then
+					echo -e "${RED}Error: --issue requires a number${NC}"
+					return 1
+				fi
+				_ADD_ISSUE="$_next"
+				shift 2
+				;;
+			--issue=*)
+				_ADD_ISSUE="${_arg#--issue=}"
+				shift
+				;;
+			-*)
+				echo -e "${RED}Error: Unknown option: $_arg${NC}"
+				echo "Usage: worktree-helper.sh add <branch> [path] [--issue NNN]"
+				return 1
+				;;
+			*)
+				if [[ -z "$_ADD_BRANCH" ]]; then
+					_ADD_BRANCH="$_arg"
+				elif [[ -z "$_ADD_PATH" ]]; then
+					_ADD_PATH="$_arg"
+				fi
+				shift
+				;;
+		esac
+	done
+	if [[ -z "$_ADD_BRANCH" ]]; then
 		echo -e "${RED}Error: Branch name required${NC}"
-		echo "Usage: worktree-helper.sh add <branch> [path]"
+		echo "Usage: worktree-helper.sh add <branch> [path] [--issue NNN]"
 		return 1
 	fi
+	return 0
+}
+
+cmd_add() {
+	_parse_cmd_add_args "$@" || return 1
+	local branch="$_ADD_BRANCH"
+	local path="$_ADD_PATH"
+	local explicit_issue="$_ADD_ISSUE"  # t2260: --issue NNN for unambiguous claim
 
 	# t2235: Detect self-invented task ID variants (e.g. t2213b, t2213-2, t2213.fix)
 	# Task IDs come ONLY from claim-task-id.sh. For follow-ups, claim a fresh ID.
@@ -756,7 +822,8 @@ cmd_add() {
 	# contract in prompts/build.txt covers the fallback path. Guard on
 	# helper presence so the worktree create works even before Phase 1
 	# has been deployed to the running environment.
-	_interactive_session_auto_claim "$branch" "$path" || true
+	# t2260: pass explicit --issue arg if provided for unambiguous claim.
+	_interactive_session_auto_claim "$branch" "$path" "$explicit_issue" || true
 
 	_print_worktree_add_success "$path" "$branch"
 
@@ -1595,8 +1662,10 @@ OVERVIEW
   - Quick context switching without stashing
 
 COMMANDS
-  add <branch> [path]    Create worktree for branch
+  add <branch> [path] [--issue NNN]
+                         Create worktree for branch
                          Path auto-generated as ~/Git/{repo}-{branch-slug}
+                         --issue NNN: explicit issue number for auto-claim (t2260)
 
   list                   List all worktrees with status
 


### PR DESCRIPTION
## Summary

- Replaced the greedy `grep -oE 'GH#[0-9]+|#[0-9]+'` that scanned entire brief bodies for issue references with three structured resolution sources: (1) explicit `--issue NNN` arg, (2) `gh<NNN>` from branch name, (3) `ref:GH#NNN` from TODO.md entry
- Added `auto-*-gh<NNN>` branch pattern support for dispatcher-created branches
- Extracted `_parse_cmd_add_args()` helper to keep `cmd_add` under 100-line complexity limit
- Created 7-assertion regression test at `.agents/scripts/tests/test-worktree-helper-claim-scope.sh`

Resolves #19803

## Testing

- shellcheck clean on both modified files
- 7/7 regression tests pass:
  1. t<NNN> branch resolves `ref:GH#NNN` from TODO.md (not brief body)
  2. Brief-body decoy `#99999` is NOT claimed
  3. `gh<NNN>` branch pattern resolves correctly
  4. `auto-*-gh<NNN>` branch pattern resolves correctly
  5. Explicit `--issue` arg overrides branch-derived issue
  6. Unrecognised branch pattern → no claim (silent skip)
  7. t<NNN> with no `ref:GH#` in TODO.md → no claim
- No complexity regression (base: 28, head: 28)

## Changed Files

- **EDIT:** `.agents/scripts/worktree-helper.sh` — `_interactive_session_auto_claim()` rewritten, `_parse_cmd_add_args()` extracted, `cmd_add()` refactored
- **NEW:** `.agents/scripts/tests/test-worktree-helper-claim-scope.sh` — 7-assertion regression test


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.74 plugin for [OpenCode](https://opencode.ai) v1.14.17 with claude-opus-4-6 spent 14m and 23,547 tokens on this as a headless worker.