### PR TITLE
GH#19880: fix CAS retry exhaustion causing silent +100 offset drift in claim-task-id

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -288,9 +288,9 @@
       "pr": 11812
     },
     ".agents/commands/AGENTS.md": {
-      "at": "2026-04-19T02:07:12Z",
-      "hash": "6a1a9082053e7449bc53a12d16a948878e67a83d",
-      "passes": 25,
+      "at": "2026-04-19T05:30:32Z",
+      "hash": "bdab3c89527d15c7c8af8ae3cca1557e6a18af25",
+      "passes": 26,
       "pr": 18117
     },
     ".agents/commands/aidevops-automate.md": {
@@ -820,9 +820,9 @@
       "pr": 15249
     },
     ".agents/hooks/task-id-collision-guard.sh": {
-      "at": "2026-04-18T18:06:27Z",
-      "hash": "b64545528f1b24431c580ec4f5120f6070b4cc62",
-      "passes": 4,
+      "at": "2026-04-19T05:30:38Z",
+      "hash": "3dbec4a0bc598c9e43cd1b207de10a7cabeeef8a",
+      "passes": 5,
       "pr": 18718
     },
     ".agents/legal.md": {
@@ -1616,9 +1616,9 @@
       "pr": 12910
     },
     ".agents/prompts/worker-efficiency-protocol.md": {
-      "at": "2026-04-09T07:31:59Z",
-      "hash": "ad80bbd159a7ed21eeca89e99008a11bfe8a0649",
-      "passes": 4,
+      "at": "2026-04-19T05:30:46Z",
+      "hash": "1849115d37d8af048907168e6b53a01620b43cfa",
+      "passes": 5,
       "pr": 14943
     },
     ".agents/reference/agent-routing.md": {
@@ -2214,9 +2214,9 @@
       "pr": 17713
     },
     ".agents/scripts/config-helper.sh": {
-      "at": "2026-04-05T17:38:48Z",
-      "hash": "12dd983e382f5e3d45151fcb317d547ea4bec6f0",
-      "passes": 2,
+      "at": "2026-04-19T05:30:52Z",
+      "hash": "910364dbe5aa0873188c24d7a045ab7367088a0f",
+      "passes": 3,
       "pr": 16084
     },
     ".agents/scripts/cron-helper.sh": {
@@ -2262,9 +2262,9 @@
       "pr": 12145
     },
     ".agents/scripts/full-loop-helper.sh": {
-      "at": "2026-04-19T00:33:33Z",
-      "hash": "d52c49da54651ee9131dbf04c4559c6f6c7e015e",
-      "passes": 10,
+      "at": "2026-04-19T05:30:53Z",
+      "hash": "0da699d76a8d8fb04cae2b8fc41b4d3a1f27ead4",
+      "passes": 11,
       "pr": 19046
     },
     ".agents/scripts/generate-claude-commands.sh": {
@@ -2298,9 +2298,9 @@
       "pr": 13021
     },
     ".agents/scripts/headless-runtime-helper.sh": {
-      "at": "2026-04-19T00:33:34Z",
-      "hash": "62c1ad9820562de9e12d333ea1360b05869d6afc",
-      "passes": 21,
+      "at": "2026-04-19T05:30:53Z",
+      "hash": "f46465b88cb5140c2e91a5adb79efe9c2b0026f5",
+      "passes": 22,
       "pr": 15086
     },
     ".agents/scripts/headless-runtime-lib.sh": {
@@ -2316,9 +2316,9 @@
       "pr": 18843
     },
     ".agents/scripts/issue-sync-helper.sh": {
-      "at": "2026-04-18T05:04:08Z",
-      "hash": "4adb6934312de791dfa05152ce0441dd9c19fac8",
-      "passes": 13,
+      "at": "2026-04-19T05:30:53Z",
+      "hash": "5e82e93693e38056c20f328a8631d3cebda57a99",
+      "passes": 14,
       "pr": 18706
     },
     ".agents/scripts/issue-sync-lib.sh": {
@@ -2340,9 +2340,9 @@
       "pr": 15431
     },
     ".agents/scripts/memory-pressure-monitor.sh": {
-      "at": "2026-04-16T18:41:08Z",
-      "hash": "29ecc90b297c4af37a380937f1f949aac4effebf",
-      "passes": 3,
+      "at": "2026-04-19T05:30:54Z",
+      "hash": "5d6e622c72c89c082c993ec4667001cb26ac3671",
+      "passes": 4,
       "pr": 17843
     },
     ".agents/scripts/mission-email-helper.sh": {
@@ -2370,9 +2370,9 @@
       "pr": 17584
     },
     ".agents/scripts/opencode-github-setup-helper.sh": {
-      "at": "2026-04-03T03:15:28Z",
-      "hash": "0bc532636c20feb570ba6da3568d3b946c301288",
-      "passes": 1,
+      "at": "2026-04-19T05:30:54Z",
+      "hash": "2c64329a2f22dfc21e43b45c8b570f462f5a1041",
+      "passes": 2,
       "pr": 15918
     },
     ".agents/scripts/platform-detect.sh": {
@@ -2400,9 +2400,9 @@
       "pr": 18657
     },
     ".agents/scripts/pulse-cleanup.sh": {
-      "at": "2026-04-15T02:32:29Z",
-      "hash": "88c7d4f1beba3de5f86421e507fc899b9879a6e6",
-      "passes": 4,
+      "at": "2026-04-19T05:30:54Z",
+      "hash": "7ad09a7f4b01d77b7ef3717affa029687235a029",
+      "passes": 5,
       "pr": 18704
     },
     ".agents/scripts/pulse-dep-graph.sh": {
@@ -2412,9 +2412,9 @@
       "pr": 18796
     },
     ".agents/scripts/pulse-dispatch-core.sh": {
-      "at": "2026-04-16T16:56:58Z",
-      "hash": "92e246c27564e55db18971606fe98d3f951f2e4b",
-      "passes": 8,
+      "at": "2026-04-19T05:30:55Z",
+      "hash": "5b0f14f48045537e5aedc5ba0e141f898d50f6da",
+      "passes": 9,
       "pr": 18832
     },
     ".agents/scripts/pulse-dispatch-engine.sh": {
@@ -2436,15 +2436,15 @@
       "pr": 18691
     },
     ".agents/scripts/pulse-issue-reconcile.sh": {
-      "at": "2026-04-19T02:07:21Z",
-      "hash": "264e80b5bb7fa5ab3006a083e8a71e2f5c4f4a64",
-      "passes": 10,
+      "at": "2026-04-19T05:30:55Z",
+      "hash": "36c87b28b738972c2e82bed9eb5926a141460b26",
+      "passes": 11,
       "pr": 18690
     },
     ".agents/scripts/pulse-merge.sh": {
-      "at": "2026-04-18T19:23:58Z",
-      "hash": "41ab20abd167ef464938f8a599a95566149e94b6",
-      "passes": 15,
+      "at": "2026-04-19T05:30:55Z",
+      "hash": "f5d5e9a21c27d84d0ee85ec8ae0704af7c2f3c43",
+      "passes": 16,
       "pr": 18829
     },
     ".agents/scripts/pulse-prefetch.sh": {
@@ -2478,9 +2478,9 @@
       "pr": 18655
     },
     ".agents/scripts/pulse-wrapper.sh": {
-      "at": "2026-04-18T18:06:35Z",
-      "hash": "cdb7ed591c6db4c4ce2f312124b2483f86d31dbc",
-      "passes": 19,
+      "at": "2026-04-19T05:30:56Z",
+      "hash": "f2d0fa9b4700bb18b65a5bf0ecc649951f58bd32",
+      "passes": 20,
       "pr": 18689
     },
     ".agents/scripts/quality-feedback-findings-lib.sh": {
@@ -2544,9 +2544,9 @@
       "pr": 15916
     },
     ".agents/scripts/shared-constants.sh": {
-      "at": "2026-04-18T19:23:59Z",
-      "hash": "e6b133e8249fe451e1e67eb533d24aaf47004bbc",
-      "passes": 9,
+      "at": "2026-04-19T05:30:57Z",
+      "hash": "fac31bcc446d519b11bdc8c60c518834cf56d1d2",
+      "passes": 10,
       "pr": 18847
     },
     ".agents/scripts/stats-functions.sh": {
@@ -2615,21 +2615,21 @@
       "passes": 1
     },
     ".agents/scripts/worker-lifecycle-common.sh": {
-      "at": "2026-04-18T20:46:28Z",
-      "hash": "0bebff13d3e73369052211898362b0e6c647b97e",
-      "passes": 7,
+      "at": "2026-04-19T05:30:58Z",
+      "hash": "17cd5f52a0c322b8698908d0886b237326f43e7b",
+      "passes": 8,
       "pr": 17353
     },
     ".agents/scripts/worker-watchdog.sh": {
-      "at": "2026-04-18T18:06:36Z",
-      "hash": "7e111f2621d9d1b41f6991bd0e6afdba4782af43",
-      "passes": 5,
+      "at": "2026-04-19T05:30:58Z",
+      "hash": "02fd9b15d344af17fc4e89721aa2c8ff83c68315",
+      "passes": 6,
       "pr": 17393
     },
     ".agents/scripts/worktree-helper.sh": {
-      "at": "2026-04-15T21:02:40Z",
-      "hash": "4d554bea9e09f95a3d4929aa6aadc4c0a9539f29",
-      "passes": 2,
+      "at": "2026-04-19T05:30:58Z",
+      "hash": "3201c79ae20186c574ca49f1e569f13ee71724d9",
+      "passes": 3,
       "pr": 19087
     },
     ".agents/seo.md": {
@@ -7205,9 +7205,9 @@
       "pr": 19047
     },
     ".agents/workflows/git-workflow.md": {
-      "at": "2026-03-29T08:49:32Z",
-      "hash": "8b1c4557393fefcee67608abe5f50936b1a12431",
-      "passes": 1,
+      "at": "2026-04-19T05:31:47Z",
+      "hash": "f6a554a70b7ff221aedaa2e72670072bdd1aa8c8",
+      "passes": 2,
       "pr": 12777
     },
     ".agents/workflows/init-routines.md": {
@@ -7486,15 +7486,15 @@
       "pr": 16415
     },
     "TODO.md": {
-      "at": "2026-04-19T02:07:44Z",
-      "hash": "cf56297e6c74d096f680017bd22bb84e6e2578f0",
-      "passes": 52,
+      "at": "2026-04-19T05:31:49Z",
+      "hash": "0ecb6f4ae942040f1ff39cb10a31d0a84a860a90",
+      "passes": 53,
       "pr": 15490
     },
     "aidevops.sh": {
-      "at": "2026-04-19T00:34:22Z",
-      "hash": "55236ea920af6a41469c46f26053fec425439df5",
-      "passes": 82,
+      "at": "2026-04-19T05:31:49Z",
+      "hash": "a0639651eed9758ad38859c72330fa1b6f0b0d78",
+      "passes": 83,
       "pr": 19029
     },
     "setup-modules/agent-deploy.sh": {
@@ -7504,9 +7504,9 @@
       "pr": 19203
     },
     "setup.sh": {
-      "at": "2026-04-19T00:34:22Z",
-      "hash": "4e2f830062db6a82c4397c9fa71ad90f702ddcb0",
-      "passes": 80,
+      "at": "2026-04-19T05:31:49Z",
+      "hash": "8661cb8a2e0ff9af8449c9133b4b6e42386b0111",
+      "passes": 81,
       "pr": 15470
     },
     "todo/tasks/GH#15363-brief.md": {

--- a/.agents/scripts/claim-task-id.sh
+++ b/.agents/scripts/claim-task-id.sh
@@ -111,7 +111,13 @@ TASK_LABELS=""
 REPO_PATH="$PWD"
 ALLOC_COUNT=1
 OFFLINE_OFFSET=100
-CAS_MAX_RETRIES=10
+CAS_MAX_RETRIES=${CAS_MAX_RETRIES:-30}
+# When true (default), CAS retry exhaustion in online mode is fatal — does NOT
+# silently fall through to allocate_offline with +100 offset.  The offline path
+# exists for genuinely-offline scenarios (no network, explicit --offline flag),
+# not for contention failures on a reachable remote.  Set to 0 to restore the
+# legacy silent-fallback behaviour.
+CAS_EXHAUSTION_FATAL=${CAS_EXHAUSTION_FATAL:-1}
 COUNTER_FILE=".task-counter"
 # Remote and branch — defaults; overridden by .aidevops.json and/or CLI flags
 REMOTE_NAME="origin"
@@ -625,11 +631,13 @@ allocate_online() {
 
 		if [[ $attempt -gt 1 ]]; then
 			log_info "Retry attempt ${attempt}/${CAS_MAX_RETRIES}..."
-			# Brief backoff: 0.1s * attempt, capped at 1.0s, plus jitter to avoid thundering herd
-			local capped=$((attempt > 10 ? 10 : attempt))
+			# Exponential-ish backoff: 0.1s * attempt (uncapped) + jitter.
+			# At attempt 10 → ~1.0-1.3s; attempt 20 → ~2.0-2.3s; attempt 30 → ~3.0-3.3s.
+			# The old cap at 1.0s was too short to outlast sustained main-branch pushes
+			# from issue-sync.yml and simplification-state commits (GH#19880).
 			local jitter_ms=$((RANDOM % 300))
 			local backoff
-			backoff=$(awk "BEGIN {printf \"%.1f\", $capped * 0.1 + $jitter_ms / 1000}")
+			backoff=$(awk "BEGIN {printf \"%.1f\", $attempt * 0.1 + $jitter_ms / 1000}")
 			sleep "$backoff" 2>/dev/null || true
 		fi
 
@@ -1296,7 +1304,15 @@ _main_resolve_allocation() {
 		if first_id_out=$(_allocate_online_with_collision_check "$REPO_PATH" "$ALLOC_COUNT"); then
 			log_success "Allocated task ID: $(printf 't%03d' "$first_id_out")"
 		else
-			log_warn "Online allocation failed, falling back to offline mode"
+			if [[ "$CAS_EXHAUSTION_FATAL" == "1" ]]; then
+				log_error "CAS_EXHAUSTED: online allocation failed after ${CAS_MAX_RETRIES} attempts"
+				log_error "This is a contention failure, not an offline scenario."
+				log_error "The remote is reachable but concurrent pushes (issue-sync.yml, simplification-state,"
+				log_error "merge commits) outpaced the retry budget.  Recovery: wait a few seconds and retry,"
+				log_error "or set CAS_EXHAUSTION_FATAL=0 to restore the legacy +${OFFLINE_OFFSET} offset fallback."
+				return 1
+			fi
+			log_warn "Online allocation failed, falling back to offline mode (CAS_EXHAUSTION_FATAL=0)"
 			is_offline_out="true"
 		fi
 	else

--- a/.agents/scripts/tests/test-cas-retry-exhaustion.sh
+++ b/.agents/scripts/tests/test-cas-retry-exhaustion.sh
@@ -1,0 +1,430 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-cas-retry-exhaustion.sh — Regression tests for GH#19880
+#
+# Tests the CAS retry budget increase (10→30), uncapped backoff, and the
+# CAS_EXHAUSTION_FATAL guard that prevents silent +100 offset drift when
+# online allocation exhausts retries due to contention (not genuine offline).
+#
+# Branches covered:
+#   1. allocate_online: CAS succeeds on attempt 1 → returns 0 immediately
+#   2. allocate_online: CAS fails 20 times, succeeds on 21 → returns 0 (was fatal at 10)
+#   3. allocate_online: CAS fails 50 times → returns 1 (exhausted)
+#   4. _main_resolve_allocation: CAS_EXHAUSTION_FATAL=1 (default) blocks offline fallback
+#   5. _main_resolve_allocation: CAS_EXHAUSTION_FATAL=0 allows offline fallback (legacy)
+#   6. allocate_offline: explicit --offline flag still works as before
+#   7. CAS_MAX_RETRIES is configurable via env var
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+CLAIM_SCRIPT="${SCRIPT_DIR}/../claim-task-id.sh"
+
+RED=$'\033[0;31m'
+GREEN=$'\033[0;32m'
+NC=$'\033[0m'
+
+PASS=0
+FAIL=0
+ERRORS=""
+
+# Temp file for cross-subshell call counting.
+# allocate_counter_cas is invoked inside $(...) by allocate_online,
+# so global variable increments don't propagate to the parent shell.
+_STUB_COUNTER_FILE=""
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+pass() {
+	local name="${1:-}"
+	printf '%s[PASS]%s %s\n' "$GREEN" "$NC" "$name"
+	PASS=$((PASS + 1))
+	return 0
+}
+
+fail() {
+	local name="${1:-}"
+	local detail="${2:-}"
+	printf '%s[FAIL]%s %s\n' "$RED" "$NC" "$name"
+	[[ -n "$detail" ]] && printf '       %s\n' "$detail"
+	FAIL=$((FAIL + 1))
+	ERRORS="${ERRORS}\n  - ${name}: ${detail}"
+	return 0
+}
+
+# Source claim-task-id.sh to gain access to internal helper functions.
+# The script uses BASH_SOURCE guard so main() is NOT called on source.
+_source_claim_script() {
+	# shellcheck disable=SC1090
+	if ! source "$CLAIM_SCRIPT" 2>/dev/null; then
+		printf '%s[FATAL]%s Failed to source %s\n' "$RED" "$NC" "$CLAIM_SCRIPT" >&2
+		exit 1
+	fi
+	return 0
+}
+
+# Create a temporary directory for test repos
+_setup_tmpdir() {
+	local tmpdir
+	tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/cas-retry-test.XXXXXX") || exit 1
+	echo "$tmpdir"
+	return 0
+}
+
+_cleanup_tmpdir() {
+	local dir="$1"
+	[[ -d "$dir" ]] && rm -rf "$dir"
+	return 0
+}
+
+# Read the call count from the temp file counter
+_get_stub_call_count() {
+	if [[ -f "$_STUB_COUNTER_FILE" ]]; then
+		wc -l < "$_STUB_COUNTER_FILE" | tr -d ' '
+	else
+		echo "0"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Stub installation — MUST be called AFTER _source_claim_script()
+# because sourcing defines the real functions that we need to override.
+# ---------------------------------------------------------------------------
+
+_STUB_FAIL_COUNT=0
+_STUB_SUCCESS_ID=100
+
+_install_stubs() {
+	# Create temp file for call counting across subshells
+	_STUB_COUNTER_FILE=$(mktemp "${TMPDIR:-/tmp}/cas-stub-counter.XXXXXX") || exit 1
+	# Truncate
+	: > "$_STUB_COUNTER_FILE"
+
+	# Override allocate_counter_cas with a stub that uses a file-based counter.
+	# Returns exit 2 (retriable conflict) for the first $_STUB_FAIL_COUNT calls,
+	# then returns exit 0 (success) and echoes a task ID.
+	allocate_counter_cas() {
+		local _repo_path="$1"  # unused in stub
+		local _count="$2"      # unused in stub
+
+		# Append a line to the counter file (atomic enough for single-process tests)
+		echo "call" >> "$_STUB_COUNTER_FILE"
+		local call_count
+		call_count=$(wc -l < "$_STUB_COUNTER_FILE" | tr -d ' ')
+
+		if [[ "$call_count" -le "$_STUB_FAIL_COUNT" ]]; then
+			return 2  # retriable conflict
+		fi
+
+		echo "$_STUB_SUCCESS_ID"
+		return 0
+	}
+
+	# Suppress sleep during tests for speed
+	# shellcheck disable=SC2317
+	sleep() { :; return 0; }
+
+	return 0
+}
+
+_reset_stub() {
+	_STUB_FAIL_COUNT=0
+	_STUB_SUCCESS_ID=100
+	if [[ -n "$_STUB_COUNTER_FILE" && -f "$_STUB_COUNTER_FILE" ]]; then
+		: > "$_STUB_COUNTER_FILE"
+	fi
+	return 0
+}
+
+_cleanup_stubs() {
+	[[ -n "$_STUB_COUNTER_FILE" && -f "$_STUB_COUNTER_FILE" ]] && rm -f "$_STUB_COUNTER_FILE"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+# Test 1: CAS succeeds on attempt 1 → returns 0 immediately
+test_success_on_first_attempt() {
+	local name="allocate_online succeeds on first CAS attempt"
+	_reset_stub
+	_STUB_FAIL_COUNT=0  # no failures
+	_STUB_SUCCESS_ID=200
+
+	local result=""
+	local exit_code=0
+	result=$(allocate_online "/tmp/fake-repo" 1 2>/dev/null) || exit_code=$?
+
+	if [[ $exit_code -ne 0 ]]; then
+		fail "$name" "allocate_online returned $exit_code"
+		return 0
+	fi
+
+	if [[ "$result" == "200" ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected 200, got '$result'"
+	fi
+
+	local calls
+	calls=$(_get_stub_call_count)
+	if [[ "$calls" -eq 1 ]]; then
+		pass "${name} (call count)"
+	else
+		fail "${name} (call count)" "expected 1 CAS call, got $calls"
+	fi
+	return 0
+}
+
+# Test 2: CAS fails 20 times, succeeds on attempt 21 → returns 0.
+# This is the key regression: old CAS_MAX_RETRIES=10 would have exhausted.
+test_success_after_20_failures() {
+	local name="allocate_online succeeds after 20 CAS conflicts (was fatal at 10)"
+	_reset_stub
+	_STUB_FAIL_COUNT=20
+	_STUB_SUCCESS_ID=300
+
+	local result=""
+	local exit_code=0
+	result=$(allocate_online "/tmp/fake-repo" 1 2>/dev/null) || exit_code=$?
+
+	if [[ $exit_code -ne 0 ]]; then
+		fail "$name" "allocate_online returned $exit_code (should have succeeded on attempt 21)"
+		return 0
+	fi
+
+	if [[ "$result" == "300" ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected 300, got '$result'"
+	fi
+
+	local calls
+	calls=$(_get_stub_call_count)
+	if [[ "$calls" -eq 21 ]]; then
+		pass "${name} (attempt count)"
+	else
+		fail "${name} (attempt count)" "expected 21 CAS calls, got $calls"
+	fi
+	return 0
+}
+
+# Test 3: CAS fails 50 times → allocate_online returns 1 (exhausted at 30)
+test_exhaustion_at_50_failures() {
+	local name="allocate_online exhausts after ${CAS_MAX_RETRIES} attempts on 50 failures"
+	_reset_stub
+	_STUB_FAIL_COUNT=50
+
+	local result=""
+	local exit_code=0
+	result=$(allocate_online "/tmp/fake-repo" 1 2>/dev/null) || exit_code=$?
+
+	if [[ $exit_code -ne 0 ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected non-zero exit, got 0 with result '$result'"
+	fi
+
+	# Should have tried exactly CAS_MAX_RETRIES times
+	local calls
+	calls=$(_get_stub_call_count)
+	if [[ "$calls" -eq "$CAS_MAX_RETRIES" ]]; then
+		pass "${name} (tried ${CAS_MAX_RETRIES} times)"
+	else
+		fail "${name} (attempt count)" "expected ${CAS_MAX_RETRIES} CAS calls, got $calls"
+	fi
+	return 0
+}
+
+# Test 4: CAS_EXHAUSTION_FATAL=1 (default) blocks offline fallback after online exhaustion.
+# _main_resolve_allocation should return 1, NOT fall through to allocate_offline.
+test_cas_exhaustion_fatal_blocks_offline() {
+	local name="CAS_EXHAUSTION_FATAL=1 prevents silent offline fallback"
+	_reset_stub
+	_STUB_FAIL_COUNT=50  # exhaust all retries
+
+	# Override globals to simulate online mode
+	local orig_offline="$OFFLINE_MODE"
+	local orig_dry="$DRY_RUN"
+	OFFLINE_MODE="false"
+	DRY_RUN="false"
+	CAS_EXHAUSTION_FATAL=1
+
+	# We need a temp dir with a .task-counter so allocate_offline would succeed
+	local tmpdir
+	tmpdir=$(_setup_tmpdir)
+	echo "99" >"${tmpdir}/.task-counter"
+	REPO_PATH="$tmpdir"
+	ALLOC_COUNT=1
+
+	local output=""
+	local exit_code=0
+	output=$(_main_resolve_allocation 2>/dev/null) || exit_code=$?
+
+	OFFLINE_MODE="$orig_offline"
+	DRY_RUN="$orig_dry"
+	_cleanup_tmpdir "$tmpdir"
+
+	if [[ $exit_code -ne 0 ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected non-zero exit, got 0. Output: '$output'"
+	fi
+	return 0
+}
+
+# Test 5: CAS_EXHAUSTION_FATAL=0 allows legacy offline fallback after online exhaustion.
+test_cas_exhaustion_disabled_allows_offline() {
+	local name="CAS_EXHAUSTION_FATAL=0 allows offline fallback (legacy)"
+	_reset_stub
+	_STUB_FAIL_COUNT=50  # exhaust all retries
+
+	local orig_offline="$OFFLINE_MODE"
+	local orig_dry="$DRY_RUN"
+	OFFLINE_MODE="false"
+	DRY_RUN="false"
+	CAS_EXHAUSTION_FATAL=0
+
+	local tmpdir
+	tmpdir=$(_setup_tmpdir)
+	echo "99" >"${tmpdir}/.task-counter"
+	REPO_PATH="$tmpdir"
+	ALLOC_COUNT=1
+
+	local output=""
+	local exit_code=0
+	output=$(_main_resolve_allocation 2>/dev/null) || exit_code=$?
+
+	OFFLINE_MODE="$orig_offline"
+	DRY_RUN="$orig_dry"
+
+	if [[ $exit_code -eq 0 ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected exit 0 (offline fallback), got $exit_code"
+		_cleanup_tmpdir "$tmpdir"
+		return 0
+	fi
+
+	# Verify offline allocation happened (first_id = 99 + OFFLINE_OFFSET = 199)
+	if echo "$output" | grep -q "_alloc_is_offline=true"; then
+		pass "${name} (offline flag set)"
+	else
+		fail "${name} (offline flag)" "expected _alloc_is_offline=true in output: '$output'"
+	fi
+
+	_cleanup_tmpdir "$tmpdir"
+	return 0
+}
+
+# Test 6: Explicit --offline flag still works (allocate_offline called directly).
+test_explicit_offline_still_works() {
+	local name="Explicit --offline flag allocates with offset (unchanged)"
+
+	local tmpdir
+	tmpdir=$(_setup_tmpdir)
+	echo "99" >"${tmpdir}/.task-counter"
+
+	local result=""
+	local exit_code=0
+	result=$(allocate_offline "$tmpdir" 1 2>/dev/null) || exit_code=$?
+
+	if [[ $exit_code -eq 0 ]]; then
+		pass "$name"
+	else
+		fail "$name" "allocate_offline returned $exit_code"
+		_cleanup_tmpdir "$tmpdir"
+		return 0
+	fi
+
+	# Expected: 99 + OFFLINE_OFFSET(100) = 199
+	if [[ "$result" == "199" ]]; then
+		pass "${name} (ID = 199)"
+	else
+		fail "${name} (ID)" "expected 199, got '$result'"
+	fi
+
+	# Verify .task-counter was updated: 199 + 1 = 200
+	local counter_val
+	counter_val=$(cat "${tmpdir}/.task-counter" 2>/dev/null)
+	if [[ "$counter_val" == "200" ]]; then
+		pass "${name} (counter updated to 200)"
+	else
+		fail "${name} (counter)" "expected 200 in .task-counter, got '$counter_val'"
+	fi
+
+	_cleanup_tmpdir "$tmpdir"
+	return 0
+}
+
+# Test 7: Verify CAS_MAX_RETRIES is configurable via env var.
+test_cas_max_retries_env_override() {
+	local name="CAS_MAX_RETRIES respects env override"
+	_reset_stub
+	_STUB_FAIL_COUNT=50  # exhaust
+
+	# Override CAS_MAX_RETRIES to a smaller value
+	local orig_max="$CAS_MAX_RETRIES"
+	CAS_MAX_RETRIES=5
+
+	local result=""
+	local exit_code=0
+	result=$(allocate_online "/tmp/fake-repo" 1 2>/dev/null) || exit_code=$?
+
+	local calls
+	calls=$(_get_stub_call_count)
+
+	if [[ $exit_code -ne 0 ]] && [[ "$calls" -eq 5 ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected exhaustion after 5 attempts, got exit=$exit_code calls=$calls"
+	fi
+
+	CAS_MAX_RETRIES="$orig_max"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+	printf 'test-cas-retry-exhaustion.sh — GH#19880 regression tests\n'
+	printf '==========================================================\n\n'
+
+	# Step 1: Source the script (defines all real functions)
+	_source_claim_script
+
+	# Step 2: Install stubs AFTER sourcing (overrides real functions)
+	_install_stubs
+
+	# Override DRY_RUN and OFFLINE_MODE defaults from the sourced script
+	DRY_RUN="${DRY_RUN:-false}"
+	OFFLINE_MODE="${OFFLINE_MODE:-false}"
+
+	test_success_on_first_attempt
+	test_success_after_20_failures
+	test_exhaustion_at_50_failures
+	test_cas_exhaustion_fatal_blocks_offline
+	test_cas_exhaustion_disabled_allows_offline
+	test_explicit_offline_still_works
+	test_cas_max_retries_env_override
+
+	_cleanup_stubs
+
+	printf '\n'
+	printf 'Results: %s passed, %s failed\n' "$PASS" "$FAIL"
+	if [[ "$FAIL" -gt 0 ]]; then
+		printf '\nFailed tests:%b\n' "$ERRORS"
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Fixes silent +100 task-ID offset drift when `claim-task-id.sh` CAS retry loop exhausts during high-concurrency periods on `main` (GH#19880).

Three changes:

- **Raised `CAS_MAX_RETRIES` from 10 to 30** (env-var overridable) — the old 10-attempt budget spanned ~15s, insufficient to outlast sustained `main` pushes from `issue-sync.yml` and `simplification-state` commits that land every 1-3s during active bursts.
- **Removed backoff cap** — sleep now grows to 2-3s at attempts 20-30 instead of capping at 1.3s, dramatically improving odds of catching a gap in concurrent pushes.
- **Added `CAS_EXHAUSTION_FATAL` guard** (default on) — when online allocation exhausts retries, the script now fails loudly instead of silently falling through to `allocate_offline` with a +100 offset. The offline path is for genuinely-offline scenarios, not contention failures on a reachable remote. Explicit `--offline` flag path is unchanged. Set `CAS_EXHAUSTION_FATAL=0` to restore legacy behaviour.

## Testing

New regression test (`test-cas-retry-exhaustion.sh`) with 13 assertions covering:
1. CAS succeeds on first attempt → returns immediately
2. CAS fails 20 times, succeeds on 21 → returns OK (was fatal at old limit of 10)
3. CAS fails 50 times → exhausts at 30, returns error
4. `CAS_EXHAUSTION_FATAL=1` blocks silent offline fallback
5. `CAS_EXHAUSTION_FATAL=0` allows legacy offline fallback
6. Explicit `--offline` allocates with offset (unchanged)
7. `CAS_MAX_RETRIES` respects env-var override

Existing tests pass:
- `test-claim-task-id-todo-collision.sh` (8/8)
- `test-counter-monotonic.sh` (12/12)
- `shellcheck` clean on both modified files

Resolves #19880