### PR TITLE
t2259: fix(ci): batch-fix pre-existing Biome violations in .agents/scripts/

### DIFF
--- a/.agents/scripts/accessibility/playwright-contrast.mjs
+++ b/.agents/scripts/accessibility/playwright-contrast.mjs
@@ -219,7 +219,7 @@ function formatMarkdown(results, level) {
     lines.push(`### Failing Elements`, '', `| Element | Ratio | Required | FG | BG | Size | WCAG |`, `|---------|-------|----------|----|----|------|------|`);
     for (const f of failures) {
       const { threshold, criterion } = getLevel(f, level);
-      const sel = f.selector.length > 40 ? f.selector.substring(0, 37) + '...' : f.selector;
+      const sel = f.selector.length > 40 ? `${f.selector.substring(0, 37)}...` : f.selector;
       lines.push(`| \`${sel}\` | ${f.ratio}:1 | ${threshold}:1 | ${f.foreground} | ${f.background} | ${f.fontSize} ${f.fontWeight}${f.isLargeText ? ' (L)' : ''} | SC ${criterion} |`);
     }
     lines.push('');

--- a/.agents/scripts/ahrefs-mcp-wrapper.js
+++ b/.agents/scripts/ahrefs-mcp-wrapper.js
@@ -22,17 +22,17 @@
  * but the bash wrapper pattern is simpler and handles the env var issue.
  */
 
-const { spawn } = require('child_process');
+const { spawn } = require('node:child_process');
 
 // Find npx command - try common locations
 const findNpx = () => {
-  const fs = require('fs');
+  const fs = require('node:fs');
   const paths = [
     '/opt/homebrew/bin/npx',
     '/usr/local/bin/npx',
     '/usr/bin/npx',
-    process.env.HOME + '/.nvm/versions/node/v20/bin/npx',
-    process.env.HOME + '/.nvm/versions/node/v18/bin/npx',
+    `${process.env.HOME}/.nvm/versions/node/v20/bin/npx`,
+    `${process.env.HOME}/.nvm/versions/node/v18/bin/npx`,
   ];
   for (const p of paths) {
     if (fs.existsSync(p)) return p;
@@ -71,6 +71,7 @@ const fixSchemaForOpenAI = (obj, path = '', fixCount = { items: 0, additionalPro
   
   // Handle arrays (JSON arrays, not schema arrays)
   if (Array.isArray(obj)) {
+    // biome-ignore lint/suspicious/useIterableCallbackReturn: forEach callback, return value unused
     obj.forEach((item, idx) => fixSchemaForOpenAI(item, `${path}[${idx}]`, fixCount));
     return;
   }
@@ -112,6 +113,7 @@ server.stdout.on('data', (data) => {
   buffer += data.toString();
   
   let newlineIndex;
+  // biome-ignore lint/suspicious/noAssignInExpressions: idiomatic buffered-line parsing loop
   while ((newlineIndex = buffer.indexOf('\n')) !== -1) {
     const line = buffer.slice(0, newlineIndex);
     buffer = buffer.slice(newlineIndex + 1);
@@ -123,7 +125,7 @@ server.stdout.on('data', (data) => {
       
       // Intercept tool list response to patch schema - handle various response formats
       let tools = null;
-      if (msg.result && msg.result.tools) {
+      if (msg.result?.tools) {
         tools = msg.result.tools;
       } else if (msg.result && Array.isArray(msg.result)) {
         // Some MCP servers return tools directly as array

--- a/.agents/scripts/browser-qa/browser-qa.mjs
+++ b/.agents/scripts/browser-qa/browser-qa.mjs
@@ -20,9 +20,9 @@
 //   --format <type>        Output format: json, summary (default: summary)
 //   --help                 Show help
 
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { chromium } from 'playwright';
-import { writeFileSync, mkdirSync, existsSync } from 'fs';
-import { join } from 'path';
 
 // ============================================================================
 // CLI Argument Parsing
@@ -50,8 +50,8 @@ const ARG_HANDLERS = new Map([
   ['--flows', (o, a, i) => { o.flows = a[++i]; return i; }],
   ['--timeout', (o, a, i) => { o.timeout = parseInt(a[++i], 10); return i; }],
   ['--viewport', (o, a, i) => { const p = a[++i].split('x'); o.viewportWidth = parseInt(p[0], 10); o.viewportHeight = parseInt(p[1], 10); return i; }],
-  ['--check-links', (o, a, i) => { o.checkLinks = true; return i; }],
-  ['--no-check-links', (o, a, i) => { o.checkLinks = false; return i; }],
+  ['--check-links', (o, _a, i) => { o.checkLinks = true; return i; }],
+  ['--no-check-links', (o, _a, i) => { o.checkLinks = false; return i; }],
   ['--max-links', (o, a, i) => { o.maxLinks = parseInt(a[++i], 10); return i; }],
   ['--format', (o, a, i) => { o.format = a[++i]; return i; }],
   ['--help', () => { printUsage(); process.exit(0); }],
@@ -134,7 +134,7 @@ function attachErrorListeners(page) {
   const errors = { consoleErrors: [], networkErrors: [] };
   page.on('console', (msg) => { if (msg.type() === 'error') errors.consoleErrors.push(msg.text()); });
   page.on('pageerror', (err) => errors.consoleErrors.push(`Uncaught: ${err.message}`));
-  page.on('requestfailed', (req) => errors.networkErrors.push(`${req.method()} ${req.url()} — ${(req.failure() || {}).errorText || 'unknown'}`));
+  page.on('requestfailed', (req) => errors.networkErrors.push(`${req.method()} ${req.url()} — ${req.failure()?.errorText || 'unknown'}`));
   return errors;
 }
 
@@ -152,7 +152,7 @@ async function navigatePage(page, url, timeout) {
 
 /** Take a screenshot. Returns the path, or null on failure. */
 async function captureScreenshot(page, url, outputDir, suffix) {
-  const path = join(outputDir, sanitizeFilename(url) + (suffix || '') + '.png');
+  const path = join(outputDir, `${sanitizeFilename(url) + (suffix || '')}.png`);
   try { await page.screenshot({ path, fullPage: true }); return path; } catch { return null; }
 }
 
@@ -164,7 +164,7 @@ async function extractPageData(page, result) {
   result.title = await page.title();
   const bodyText = await page.evaluate(() => document.body ? document.body.innerText.trim() : '');
   if (bodyText.length < 10) { result.isEmpty = true; result.passed = false; result.failures.push(`Page appears empty (body text: ${bodyText.length} chars)`); }
-  const errorIndicators = await page.evaluate(DETECT_ERRORS_SCRIPT + '()');
+  const errorIndicators = await page.evaluate(`${DETECT_ERRORS_SCRIPT}()`);
   if (errorIndicators.length > 0) { result.hasErrorState = true; result.passed = false; result.failures.push(`Error state detected: ${errorIndicators.join(', ')}`); }
   try { result.ariaSnapshot = await page.locator('body').ariaSnapshot({ timeout: 5000 }); } catch { result.ariaSnapshot = null; }
 }
@@ -217,7 +217,7 @@ async function headCheckLink(page, link) {
  * Uses HEAD requests to avoid downloading full pages.
  */
 async function checkPageLinks(page, maxLinks) {
-  const links = await page.evaluate(COLLECT_LINKS_SCRIPT + `(${maxLinks})`);
+  const links = await page.evaluate(`${COLLECT_LINKS_SCRIPT}(${maxLinks})`);
   return Promise.all(links.map((link) => headCheckLink(page, link)));
 }
 
@@ -226,7 +226,7 @@ function sanitizeFilename(url) {
   try {
     const parsed = new URL(url);
     const path = parsed.pathname.replace(/\//g, '_').replace(/^_/, '');
-    return (parsed.hostname + '_' + (path || 'index')).replace(/[^a-zA-Z0-9_.-]/g, '_');
+    return (`${parsed.hostname}_${path || 'index'}`).replace(/[^a-zA-Z0-9_.-]/g, '_');
   } catch {
     return url.replace(/[^a-zA-Z0-9_.-]/g, '_').substring(0, 100);
   }

--- a/.agents/scripts/chromium-debug-use-lib/commands.mjs
+++ b/.agents/scripts/chromium-debug-use-lib/commands.mjs
@@ -3,6 +3,7 @@
 import { writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { CACHE_DIR, MIN_TARGET_PREFIX_LEN, NAVIGATION_TIMEOUT_MS, sleep } from './constants.mjs';
+
 export { snapshotStr } from './accessibility.mjs';
 
 export async function getPages(cdp) {

--- a/.agents/scripts/chromium-debug-use-lib/daemon.mjs
+++ b/.agents/scripts/chromium-debug-use-lib/daemon.mjs
@@ -1,21 +1,9 @@
 // Daemon lifecycle — per-tab CDP daemon process management.
 
-import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
 import { spawn } from 'node:child_process';
+import { existsSync, readFileSync, unlinkSync, } from 'node:fs';
 import net from 'node:net';
-import {
-  DAEMON_CONNECT_DELAY_MS,
-  DAEMON_CONNECT_RETRIES,
-  IDLE_TIMEOUT_MS,
-  IS_WINDOWS,
-  PAGES_CACHE,
-  cleanupStaleSocket,
-  resolvePrefix,
-  sleep,
-  socketPath,
-} from './constants.mjs';
 import { CDPClient } from './cdp-client.mjs';
-import { getWsUrl } from './connection.mjs';
 import {
   browserVersionStr,
   clickStr,
@@ -31,6 +19,18 @@ import {
   snapshotStr,
   typeStr,
 } from './commands.mjs';
+import { getWsUrl } from './connection.mjs';
+import {
+  cleanupStaleSocket,
+  DAEMON_CONNECT_DELAY_MS,
+  DAEMON_CONNECT_RETRIES,
+  IDLE_TIMEOUT_MS,
+  IS_WINDOWS,
+  PAGES_CACHE,
+  resolvePrefix,
+  sleep,
+  socketPath,
+} from './constants.mjs';
 
 // --- Daemon command registry ---
 

--- a/.agents/scripts/chromium-debug-use.mjs
+++ b/.agents/scripts/chromium-debug-use.mjs
@@ -6,10 +6,10 @@
 // Uses raw CDP over WebSocket with Node 22+ built-in WebSocket support.
 
 import { existsSync, readFileSync, writeFileSync } from 'node:fs';
-import { PAGES_CACHE, resolvePrefix } from './chromium-debug-use-lib/constants.mjs';
 import { CDPClient } from './chromium-debug-use-lib/cdp-client.mjs';
-import { getWsUrl } from './chromium-debug-use-lib/connection.mjs';
 import { browserVersionStr, formatPageList, getPages } from './chromium-debug-use-lib/commands.mjs';
+import { getWsUrl } from './chromium-debug-use-lib/connection.mjs';
+import { PAGES_CACHE, resolvePrefix } from './chromium-debug-use-lib/constants.mjs';
 import { getOrStartTabDaemon, runDaemon, sendCommand, stopDaemons } from './chromium-debug-use-lib/daemon.mjs';
 
 const USAGE = `chromium-debug-use - lightweight Chromium DevTools Protocol CLI

--- a/.agents/scripts/higgsfield/higgsfield-api-client.mjs
+++ b/.agents/scripts/higgsfield/higgsfield-api-client.mjs
@@ -2,11 +2,11 @@
 // Holds: credential loading, fetch + retry, file upload/download, status polling.
 // High-level commands live in higgsfield-api.mjs.
 
-import { readFileSync, existsSync, createWriteStream, statSync } from 'fs';
-import { join, extname, basename } from 'path';
-import { homedir } from 'os';
-import { Readable } from 'stream';
-import { pipeline } from 'stream/promises';
+import { createWriteStream, existsSync, readFileSync, statSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { basename, extname, join } from 'node:path';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -81,7 +81,7 @@ function buildApiHeaders(apiKey, apiSecret) {
 }
 
 function backoffDelayMs(attempt) {
-  return 200 * Math.pow(2, attempt);
+  return 200 * 2 ** attempt;
 }
 
 async function sleep(ms) {

--- a/.agents/scripts/higgsfield/higgsfield-api.mjs
+++ b/.agents/scripts/higgsfield/higgsfield-api.mjs
@@ -3,6 +3,16 @@
 // Auth: HF_API_KEY + HF_API_SECRET from credentials.sh
 // Imported by playwright-automator.mjs.
 
+
+import {
+  API_BASE_URL,
+  apiDownloadFile,
+  apiPollStatus,
+  apiRequest,
+  apiUploadFile,
+  loadApiCredentials,
+  requireApiCredentials,
+} from './higgsfield-api-client.mjs';
 import {
   getDefaultOutputDir,
   resolveOutputDir,
@@ -11,32 +21,22 @@ import {
   writeJsonSidecar,
 } from './higgsfield-common.mjs';
 
-import {
-  API_BASE_URL,
-  loadApiCredentials,
-  requireApiCredentials,
-  apiRequest,
-  apiUploadFile,
-  apiDownloadFile,
-  apiPollStatus,
+export {
+  API_POLL_INTERVAL_MS,
+  API_POLL_MAX_WAIT_MS,
+  apiExecuteFetch,
+  parseApiErrorDetail,
 } from './higgsfield-api-client.mjs';
-
 // Re-export low-level surface so existing callers (and tests) keep working.
 export {
   API_BASE_URL,
-  loadApiCredentials,
-  requireApiCredentials,
-  apiRequest,
-  apiUploadFile,
   apiDownloadFile,
   apiPollStatus,
+  apiRequest,
+  apiUploadFile,
+  loadApiCredentials,
+  requireApiCredentials,
 };
-export {
-  apiExecuteFetch,
-  parseApiErrorDetail,
-  API_POLL_INTERVAL_MS,
-  API_POLL_MAX_WAIT_MS,
-} from './higgsfield-api-client.mjs';
 
 // ---------------------------------------------------------------------------
 // Model mapping

--- a/.agents/scripts/higgsfield/higgsfield-asset-chain.mjs
+++ b/.agents/scripts/higgsfield/higgsfield-asset-chain.mjs
@@ -2,30 +2,27 @@
 // Chain actions (animate, inpaint, upscale, relight, etc.) on existing assets.
 // Extracted from higgsfield-commands.mjs (t2127 file-complexity decomposition).
 
-import { basename } from 'path';
+import { basename } from 'node:path';
 
 import {
-  launchBrowser,
-  navigateTo,
-  dismissAllModals,
   debugScreenshot,
+  dismissAllModals,
   forceCloseDialogs,
   getDefaultOutputDir,
+  launchBrowser,
+  navigateTo,
 } from './higgsfield-browser.mjs';
-
-import {
-  resolveOutputDir,
-  downloadLatestResult,
-} from './higgsfield-output.mjs';
-
 import {
   BASE_URL,
-  STATE_FILE,
+  curlDownload,
   GENERATED_IMAGE_SELECTOR,
   safeJoin,
   sanitizePathSegment,
-  curlDownload,
 } from './higgsfield-common.mjs';
+import {
+  downloadLatestResult,
+  resolveOutputDir,
+} from './higgsfield-output.mjs';
 
 import { downloadVideoFromHistory } from './higgsfield-video.mjs';
 

--- a/.agents/scripts/higgsfield/higgsfield-batch-infra.mjs
+++ b/.agents/scripts/higgsfield/higgsfield-batch-infra.mjs
@@ -2,24 +2,22 @@
 // waiter for the Higgsfield automation suite.
 // Extracted from higgsfield-common.mjs (t2127 file-complexity decomposition).
 
-import { readFileSync, writeFileSync, existsSync } from 'fs';
-
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
 import {
-  GENERATED_IMAGE_SELECTOR,
+  debugScreenshot,
+  dismissAllModals,
+  getDefaultOutputDir,
+} from './higgsfield-browser.mjs';
+import {
   ensureDir,
+  GENERATED_IMAGE_SELECTOR,
   safeJoin,
   withRetry,
 } from './higgsfield-common.mjs';
 
 import {
-  getDefaultOutputDir,
-  dismissAllModals,
-  debugScreenshot,
-} from './higgsfield-browser.mjs';
-
-import {
-  resolveOutputDir,
   downloadLatestResult,
+  resolveOutputDir,
 } from './higgsfield-output.mjs';
 
 // ---------------------------------------------------------------------------
@@ -79,7 +77,7 @@ export async function runWithConcurrency(tasks, concurrency) {
   return results;
 }
 
-function loadResumeState(options, outputDir, type) {
+function loadResumeState(options, outputDir, _type) {
   let completedIndices = new Set();
   if (options.resume) {
     const prevState = loadBatchState(outputDir);
@@ -148,6 +146,7 @@ export function finalizeBatch({ type, batchState, results, startTime, outputDir,
 
   if (failed > 0) {
     console.log(`\nFailed jobs:`);
+    // biome-ignore lint/suspicious/useIterableCallbackReturn: forEach for logging
     batchState.failed.forEach(f => console.log(`  [${f.index + 1}] ${f.error}`));
     console.log(`\nTo retry failed jobs: add --resume flag`);
   }
@@ -172,7 +171,7 @@ export async function waitForGenerationResult(page, options, opts = {}) {
     label = 'generation',
     outputSubdir = 'output',
     defaultTimeout = 180000,
-    isVideo = false,
+    isVideo: _isVideo = false,
     useHistoryPoll = false,
   } = opts;
   const timeout = options.timeout || defaultTimeout;

--- a/.agents/scripts/higgsfield/higgsfield-batch-video.mjs
+++ b/.agents/scripts/higgsfield/higgsfield-batch-video.mjs
@@ -2,49 +2,46 @@
 // and download operations for the Higgsfield automation suite.
 // Extracted from higgsfield-video.mjs (t2127 file-complexity decomposition).
 
+
+import {
+  clickHistoryTab,
+  dismissAllModals,
+  getDefaultOutputDir,
+  launchBrowser,
+  navigateTo,
+  withBrowser,
+} from './higgsfield-browser.mjs';
 import {
   BASE_URL,
-  STATE_FILE,
-  ensureDir,
-  safeJoin,
-  sanitizePathSegment,
   curlDownload,
+  ensureDir,
+  finalizeBatch,
+  initBatch,
   runBatchJob,
   runWithConcurrency,
-  initBatch,
-  finalizeBatch,
+  STATE_FILE,
+  safeJoin,
+  sanitizePathSegment,
   saveBatchState,
 } from './higgsfield-common.mjs';
-
+import { generateLipsync } from './higgsfield-lipsync.mjs';
 import {
-  launchBrowser,
-  withBrowser,
-  dismissAllModals,
-  clickHistoryTab,
-  navigateTo,
-  getDefaultOutputDir,
-} from './higgsfield-browser.mjs';
-
-import {
-  resolveOutputDir,
   buildDescriptiveFilename,
   downloadLatestResult,
+  resolveOutputDir,
 } from './higgsfield-output.mjs';
-
 // NOTE: VIDEO_MODEL_NAME_MAP, removeExistingStartFrame, tryUploadViaButton,
 // tryUploadViaStartFrameArea, and findModelButtonInDropdown are currently
 // internal to higgsfield-video.mjs and need to be exported from there for
 // this import to work.
 import {
-  VIDEO_MODEL_NAME_MAP,
+  downloadVideoFromHistory,
+  findModelButtonInDropdown,
   removeExistingStartFrame,
   tryUploadViaButton,
   tryUploadViaStartFrameArea,
-  findModelButtonInDropdown,
-  downloadVideoFromHistory,
+  VIDEO_MODEL_NAME_MAP,
 } from './higgsfield-video.mjs';
-
-import { generateLipsync } from './higgsfield-lipsync.mjs';
 
 // ---------------------------------------------------------------------------
 // Batch video submission helpers
@@ -158,7 +155,7 @@ function countJobStatuses(submittedJobs, historyItems, results) {
       job.promptPrefix.substring(0, 40).includes(h.promptText.substring(0, 40))
     );
     if (match && !match.isProcessing) completedThisPoll++;
-    else if (match && match.isProcessing) processingCount++;
+    else if (match?.isProcessing) processingCount++;
   }
 
   return { completedThisPoll, processingCount };
@@ -322,7 +319,7 @@ export async function pollAndDownloadVideos(page, submittedJobs, outputDir, time
   const pollInterval = 15000;
 
   console.log(`Polling for ${submittedJobs.length} video(s) (timeout: ${timeout / 1000}s)...`);
-  const historyTab = await clickHistoryTab(page);
+  const _historyTab = await clickHistoryTab(page);
 
   while (Date.now() - startTime < timeout && results.size < submittedJobs.length) {
     await page.waitForTimeout(pollInterval);

--- a/.agents/scripts/higgsfield/higgsfield-browser.mjs
+++ b/.agents/scripts/higgsfield/higgsfield-browser.mjs
@@ -2,19 +2,18 @@
 // page interaction helpers for the Higgsfield automation suite.
 // Extracted from higgsfield-common.mjs (t2127 file-complexity decomposition).
 
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { chromium } from 'playwright';
-import { existsSync, readFileSync, writeFileSync } from 'fs';
-import { join } from 'path';
-import { homedir } from 'os';
 
 import {
   BASE_URL,
-  STATE_FILE,
   STATE_DIR,
-  WORKSPACE_OUTPUT_DIR,
-  USER_DOWNLOADS_DIR,
-  sanitizePathSegment,
+  STATE_FILE,
   safeJoin,
+  sanitizePathSegment,
+  USER_DOWNLOADS_DIR,
+  WORKSPACE_OUTPUT_DIR,
 } from './higgsfield-common.mjs';
 
 // ---------------------------------------------------------------------------
@@ -30,7 +29,8 @@ export function getDefaultOutputDir(options = {}) {
 
 export async function launchBrowser(options = {}) {
   const headless = options.headless !== undefined ? options.headless :
-                   options.headed ? false : true;
+                   !
+                   options.headed;
 
   const launchOptions = {
     headless,

--- a/.agents/scripts/higgsfield/higgsfield-commands.mjs
+++ b/.agents/scripts/higgsfield/higgsfield-commands.mjs
@@ -8,40 +8,35 @@
 // Tests → higgsfield-tests.mjs
 // (t2127 file-complexity decomposition)
 
-import {
-  BASE_URL,
-  STATE_DIR,
-  GENERATED_IMAGE_SELECTOR,
-  getUnlimitedModelForCommand,
-  ensureDir,
-  safeJoin,
-} from './higgsfield-common.mjs';
 
 import {
+  debugScreenshot,
+  dismissAllModals,
   getDefaultOutputDir,
   launchBrowser,
-  withBrowser,
   navigateTo,
-  dismissAllModals,
-  debugScreenshot,
+  withBrowser,
 } from './higgsfield-browser.mjs';
-
 import {
-  resolveOutputDir,
+  BASE_URL,
+  ensureDir,
+  GENERATED_IMAGE_SELECTOR,
+  getUnlimitedModelForCommand,
+  STATE_DIR,
+  safeJoin,
+  saveCreditCache,
+} from './higgsfield-common.mjs';
+import { generateImage } from './higgsfield-image.mjs';
+import {
   downloadLatestResult,
+  resolveOutputDir,
 } from './higgsfield-output.mjs';
 
 import {
-  saveCreditCache,
-} from './higgsfield-common.mjs';
-
-import { generateImage } from './higgsfield-image.mjs';
-
-import {
-  uploadFileToPage,
   fillPromptField,
   navigateAndDismiss,
   saveStateAndClose,
+  uploadFileToPage,
 } from './higgsfield-studio-commands.mjs';
 
 // ─── Misc Commands ────────────────────────────────────────────────────────────
@@ -271,7 +266,7 @@ export async function seedBracket(options = {}) {
   console.log(`\nReview the images in ${outputDir} and note the best seeds.`);
   console.log(`Then use --seed <number> with your chosen seed for consistent results.`);
 
-  const { writeFileSync } = await import('fs');
+  const { writeFileSync } = await import('node:fs');
   const manifest = {
     prompt, model,
     seeds: results.map(r => ({ seed: r.seed, success: r.success })),

--- a/.agents/scripts/higgsfield/higgsfield-common.mjs
+++ b/.agents/scripts/higgsfield/higgsfield-common.mjs
@@ -7,10 +7,10 @@
 // Discovery/login → higgsfield-discovery.mjs
 // (t2127 file-complexity decomposition)
 
-import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync, statSync } from 'fs';
-import { join, basename, extname } from 'path';
-import { homedir } from 'os';
-import { execFileSync } from 'child_process';
+import { execFileSync } from 'node:child_process';
+import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { basename, extname, join } from 'node:path';
 
 // ---------------------------------------------------------------------------
 // Paths & Constants
@@ -101,7 +101,7 @@ if (!existsSync(STATE_DIR)) {
 
 export function getUnlimitedModelForCommand(commandType) {
   const cache = getCachedCredits();
-  if (!cache || !cache.unlimitedModels || cache.unlimitedModels.length === 0) return null;
+  if (!cache?.unlimitedModels || cache.unlimitedModels.length === 0) return null;
 
   const activeNames = new Set(cache.unlimitedModels.map(m => m.model));
   const candidates = Object.entries(UNLIMITED_MODELS)
@@ -118,7 +118,7 @@ export function isUnlimitedModel(slug, commandType) {
   if (!UNLIMITED_SLUGS.has(key)) return false;
 
   const cache = getCachedCredits();
-  if (!cache || !cache.unlimitedModels) return false;
+  if (!cache?.unlimitedModels) return false;
 
   const activeNames = new Set(cache.unlimitedModels.map(m => m.model));
   return UNLIMITED_SLUGS.get(key).some(name => activeNames.has(name));
@@ -150,7 +150,7 @@ export async function withRetry(fn, { maxRetries = 2, baseDelay = 3000, label = 
       const msg = error.message || String(error);
       if (isNonRetryableError(msg)) throw error;
       if (attempt < maxRetries) {
-        const delay = baseDelay * Math.pow(2, attempt);
+        const delay = baseDelay * 2 ** attempt;
         console.log(`[retry] ${label} failed (attempt ${attempt + 1}/${maxRetries + 1}): ${msg}`);
         console.log(`[retry] Waiting ${delay / 1000}s before retry...`);
         await new Promise(resolve => setTimeout(resolve, delay));
@@ -382,7 +382,7 @@ export function checkCreditGuard(command, options = {}) {
   }
 
   const remaining = parseInt(cached.remaining, 10);
-  if (isNaN(remaining)) return;
+  if (Number.isNaN(remaining)) return;
 
   if (remaining < estimated) {
     throw new Error(
@@ -400,61 +400,60 @@ export function checkCreditGuard(command, options = {}) {
 // Re-exports from decomposed modules (backward compatibility)
 // ---------------------------------------------------------------------------
 
+
 export {
-  getDefaultOutputDir,
-  launchBrowser,
-  withBrowser,
-  navigateTo,
-  debugScreenshot,
-  clickHistoryTab,
+  finalizeBatch,
+  initBatch,
+  loadBatchManifest,
+  loadBatchState,
+  runBatchJob,
+  runWithConcurrency,
+  saveBatchState,
+  waitForGenerationResult,
+} from './higgsfield-batch-infra.mjs';
+export {
   clickGenerate,
+  clickHistoryTab,
+  debugScreenshot,
   dismissAllModals,
-  forceCloseDialogs,
   dismissInterruptions,
   dismissModalsAndBanners,
   dismissOverlaysAndAgreements,
+  forceCloseDialogs,
+  getDefaultOutputDir,
+  launchBrowser,
   loadKnownInterruptions,
   logNewInterruption,
+  navigateTo,
+  withBrowser,
 } from './higgsfield-browser.mjs';
 
 export {
-  resolveOutputDir,
-  inferOutputType,
-  writeJsonSidecar,
-  computeFileHash,
-  checkDuplicate,
-  finalizeDownload,
+  ACCOUNT_PREFIXES,
+  categoriseRoutes,
+  diffRoutesAgainstCache,
+  discoveryNeeded,
+  ensureDiscovery,
+  FEATURE_PREFIXES,
+  isNonAuthUrl,
+  loadCredentials,
+  login,
+  ROUTE_PREFIXES,
+  runDiscovery,
+  tryClickSubmit,
+  tryFillField,
+} from './higgsfield-discovery.mjs';
+export {
   buildDescriptiveFilename,
-  downloadImageViaDialog,
+  checkDuplicate,
+  computeFileHash,
   downloadImagesByCDN,
+  downloadImageViaDialog,
   downloadLatestResult,
   downloadSpecificImages,
   extractDialogMetadata,
+  finalizeDownload,
+  inferOutputType,
+  resolveOutputDir,
+  writeJsonSidecar,
 } from './higgsfield-output.mjs';
-
-export {
-  loadCredentials,
-  login,
-  runDiscovery,
-  ensureDiscovery,
-  discoveryNeeded,
-  categoriseRoutes,
-  diffRoutesAgainstCache,
-  ROUTE_PREFIXES,
-  ACCOUNT_PREFIXES,
-  FEATURE_PREFIXES,
-  tryFillField,
-  tryClickSubmit,
-  isNonAuthUrl,
-} from './higgsfield-discovery.mjs';
-
-export {
-  loadBatchManifest,
-  saveBatchState,
-  loadBatchState,
-  runWithConcurrency,
-  initBatch,
-  runBatchJob,
-  finalizeBatch,
-  waitForGenerationResult,
-} from './higgsfield-batch-infra.mjs';

--- a/.agents/scripts/higgsfield/higgsfield-discovery.mjs
+++ b/.agents/scripts/higgsfield/higgsfield-discovery.mjs
@@ -2,24 +2,21 @@
 // the Higgsfield automation suite.
 // Extracted from higgsfield-common.mjs (t2127 file-complexity decomposition).
 
-import { readFileSync, writeFileSync, existsSync } from 'fs';
-import { join } from 'path';
-import { homedir } from 'os';
-
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import {
+  debugScreenshot,
+  dismissAllModals,
+  launchBrowser,
+} from './higgsfield-browser.mjs';
 import {
   BASE_URL,
-  STATE_FILE,
-  STATE_DIR,
-  ROUTES_CACHE,
-  DISCOVERY_TIMESTAMP,
   DISCOVERY_MAX_AGE_HOURS,
+  DISCOVERY_TIMESTAMP,
+  ROUTES_CACHE,
+  STATE_FILE,
 } from './higgsfield-common.mjs';
-
-import {
-  launchBrowser,
-  dismissAllModals,
-  debugScreenshot,
-} from './higgsfield-browser.mjs';
 
 // ---------------------------------------------------------------------------
 // Credentials (only used by login)
@@ -144,11 +141,11 @@ async function scrapeDiscoveryLinks(page) {
     const map = {};
     allLinks.forEach(a => {
       const href = a.getAttribute('href');
-      let text = a.textContent?.trim()
+      const text = a.textContent?.trim()
         .replace(/Your browser does not support the video\.\s*/g, '')
         .replace(/\s+/g, ' ')
         .substring(0, 80) || '';
-      if (href && href.startsWith('/') && !href.startsWith('//') && text) {
+      if (href?.startsWith('/') && !href.startsWith('//') && text) {
         if (!map[href]) map[href] = text;
       }
     });
@@ -177,6 +174,7 @@ function logDiscoverySummary(links, routes, changes) {
   console.log(`  Features: ${Object.keys(routes.features).length} features`);
   if (changes.length > 0) {
     console.log(`\n  CHANGES since last discovery:`);
+    // biome-ignore lint/suspicious/useIterableCallbackReturn: forEach for logging
     changes.forEach(c => console.log(`    ${c}`));
   } else if (existsSync(ROUTES_CACHE)) {
     console.log('  No changes since last discovery');

--- a/.agents/scripts/higgsfield/higgsfield-image-helpers.mjs
+++ b/.agents/scripts/higgsfield/higgsfield-image-helpers.mjs
@@ -2,14 +2,13 @@
 // helpers for the Higgsfield automation suite.
 // Extracted from higgsfield-image.mjs (t2127 file-complexity decomposition).
 
-import {
-  GENERATED_IMAGE_SELECTOR,
-} from './higgsfield-common.mjs';
 
 import {
   dismissAllModals,
-  debugScreenshot,
 } from './higgsfield-browser.mjs';
+import {
+  GENERATED_IMAGE_SELECTOR,
+} from './higgsfield-common.mjs';
 
 // ---------------------------------------------------------------------------
 // Generation detection helpers
@@ -39,7 +38,7 @@ export async function clickAndVerifyGenerate(page, queueBefore, existingImageCou
   }
 
   await page.waitForTimeout(3000);
-  const postClickState = await page.evaluate(({ prevQueue, prevImages, imgSelector }) => {
+  const postClickState = await page.evaluate(({ prevQueue: _prevQueue, prevImages: _prevImages, imgSelector }) => {
     const queueNow = (document.body.innerText.match(/In queue/g) || []).length;
     const imagesNow = document.querySelectorAll(imgSelector).length;
     const hasGeneratingIndicator = document.body.innerText.includes('Generating') ||

--- a/.agents/scripts/higgsfield/higgsfield-image.mjs
+++ b/.agents/scripts/higgsfield/higgsfield-image.mjs
@@ -4,29 +4,29 @@
 
 import {
   BASE_URL,
-  STATE_FILE,
-  STATE_DIR,
+  debugScreenshot,
+  dismissAllModals,
+  downloadSpecificImages,
+  finalizeBatch,
   GENERATED_IMAGE_SELECTOR,
   getDefaultOutputDir,
   getUnlimitedModelForCommand,
+  initBatch,
   isUnlimitedModel,
   launchBrowser,
-  dismissAllModals,
-  debugScreenshot,
   resolveOutputDir,
-  safeJoin,
-  downloadSpecificImages,
-  withRetry,
   runBatchJob,
   runWithConcurrency,
-  initBatch,
-  finalizeBatch,
+  STATE_DIR,
+  STATE_FILE,
+  safeJoin,
 } from './higgsfield-common.mjs';
 
 import {
   clickAndVerifyGenerate,
   waitForImageGeneration,
 } from './higgsfield-image-helpers.mjs';
+
 export { clickAndVerifyGenerate, waitForImageGeneration };
 
 // ---------------------------------------------------------------------------

--- a/.agents/scripts/higgsfield/higgsfield-lipsync.mjs
+++ b/.agents/scripts/higgsfield/higgsfield-lipsync.mjs
@@ -1,20 +1,20 @@
 // higgsfield-lipsync.mjs — Lipsync generation via the Higgsfield web UI.
 // Extracted from higgsfield-video.mjs (t2127 file-complexity decomposition).
 
-import {
-  BASE_URL,
-  STATE_FILE,
-  STATE_DIR,
-  safeJoin,
-} from './higgsfield-common.mjs';
 
 import {
-  launchBrowser,
-  dismissAllModals,
-  debugScreenshot,
   clickGenerate,
+  debugScreenshot,
+  dismissAllModals,
   getDefaultOutputDir,
+  launchBrowser,
 } from './higgsfield-browser.mjs';
+import {
+  BASE_URL,
+  STATE_DIR,
+  STATE_FILE,
+  safeJoin,
+} from './higgsfield-common.mjs';
 
 import {
   resolveOutputDir,

--- a/.agents/scripts/higgsfield/higgsfield-output.mjs
+++ b/.agents/scripts/higgsfield/higgsfield-output.mjs
@@ -2,23 +2,20 @@
 // filename building, and image download helpers for the Higgsfield automation suite.
 // Extracted from higgsfield-common.mjs (t2127 file-complexity decomposition).
 
-import { readFileSync, writeFileSync, existsSync, unlinkSync, statSync } from 'fs';
-import { basename, extname } from 'path';
-import { execFileSync } from 'child_process';
-import { createHash } from 'crypto';
-
-import {
-  GENERATED_IMAGE_SELECTOR,
-  ensureDir,
-  safeJoin,
-  sanitizePathSegment,
-} from './higgsfield-common.mjs';
-
+import { execFileSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync, statSync, unlinkSync, writeFileSync } from 'node:fs';
+import { basename, extname } from 'node:path';
 import {
   dismissAllModals,
   forceCloseDialogs,
-  getDefaultOutputDir,
 } from './higgsfield-browser.mjs';
+import {
+  ensureDir,
+  GENERATED_IMAGE_SELECTOR,
+  safeJoin,
+  sanitizePathSegment,
+} from './higgsfield-common.mjs';
 
 // ---------------------------------------------------------------------------
 // Output organisation (project dirs, JSON sidecars, dedup)

--- a/.agents/scripts/higgsfield/higgsfield-pipeline.mjs
+++ b/.agents/scripts/higgsfield/higgsfield-pipeline.mjs
@@ -2,32 +2,29 @@
 // Orchestrates image generation → video animation → lipsync → assembly.
 // Extracted from higgsfield-commands.mjs (t2127 file-complexity decomposition).
 
-import { readFileSync, writeFileSync, existsSync, copyFileSync, unlinkSync } from 'fs';
-import { dirname } from 'path';
-import { fileURLToPath } from 'url';
-import { execFileSync } from 'child_process';
-
+import { execFileSync } from 'node:child_process';
+import { copyFileSync, existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import {
-  STATE_FILE,
+  getDefaultOutputDir,
+  launchBrowser,
+} from './higgsfield-browser.mjs';
+import {
   ensureDir,
   findNewestFile,
   findNewestFileMatching,
+  getUnlimitedModelForCommand,
+  STATE_FILE,
   safeJoin,
   sanitizePathSegment,
-  getUnlimitedModelForCommand,
 } from './higgsfield-common.mjs';
-
-import {
-  launchBrowser,
-  getDefaultOutputDir,
-} from './higgsfield-browser.mjs';
 
 import { generateImage } from './higgsfield-image.mjs';
 import {
   generateLipsync,
-  downloadVideoFromHistory,
-  submitVideoJobOnPage,
   pollAndDownloadVideos,
+  submitVideoJobOnPage,
 } from './higgsfield-video.mjs';
 
 // ─── Pipeline ─────────────────────────────────────────────────────────────────

--- a/.agents/scripts/higgsfield/higgsfield-studio-commands.mjs
+++ b/.agents/scripts/higgsfield/higgsfield-studio-commands.mjs
@@ -2,32 +2,23 @@
 // upscale, storyboard, vibe, influencer, character, feature, presets) for Higgsfield.
 // Extracted from higgsfield-commands.mjs (t2127 file-complexity decomposition).
 
-import { readFileSync, existsSync } from 'fs';
-import { join, basename, dirname } from 'path';
-import { fileURLToPath } from 'url';
-
+import { existsSync, readFileSync } from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  clickGenerate,
+  debugScreenshot,
+  dismissAllModals,
+  launchBrowser,
+} from './higgsfield-browser.mjs';
 import {
   BASE_URL,
-  STATE_FILE,
-  ROUTES_CACHE,
   GENERATED_IMAGE_SELECTOR,
+  ROUTES_CACHE,
+  STATE_FILE,
   waitForGenerationResult,
 } from './higgsfield-common.mjs';
 
-import {
-  launchBrowser,
-  withBrowser,
-  navigateTo,
-  dismissAllModals,
-  debugScreenshot,
-  clickGenerate,
-  getDefaultOutputDir,
-} from './higgsfield-browser.mjs';
-
-import {
-  resolveOutputDir,
-  downloadLatestResult,
-} from './higgsfield-output.mjs';
 
 // ─── Shared command helpers ────────────────────────────────────────────────────
 
@@ -124,6 +115,7 @@ function listMotionPresets() {
   const motions = cache.motions || {};
   const names = Object.keys(motions);
   console.log(`Available motion presets (${names.length}):`);
+  // biome-ignore lint/suspicious/useIterableCallbackReturn: forEach for logging
   names.slice(0, 50).forEach(n => console.log(`  ${n} → ${motions[n]}`));
   if (names.length > 50) console.log(`  ... and ${names.length - 50} more`);
 }

--- a/.agents/scripts/higgsfield/higgsfield-tests.mjs
+++ b/.agents/scripts/higgsfield/higgsfield-tests.mjs
@@ -2,29 +2,24 @@
 // for the Higgsfield automation suite.
 // Extracted from higgsfield-commands.mjs (t2127 file-complexity decomposition).
 
-import { readFileSync, writeFileSync, existsSync, statSync } from 'fs';
-
-import {
-  BASE_URL,
-  STATE_FILE,
-  ROUTES_CACHE,
-  CREDITS_CACHE_FILE,
-  UNLIMITED_MODELS,
-  UNLIMITED_SLUGS,
-  getUnlimitedModelForCommand,
-  isUnlimitedModel,
-  estimateCreditCost,
-  checkCreditGuard,
-  getCachedCredits,
-  saveCreditCache,
-  parseArgs,
-} from './higgsfield-common.mjs';
-
+import { existsSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import {
   launchBrowser,
-  dismissAllModals,
-  debugScreenshot,
 } from './higgsfield-browser.mjs';
+import {
+  BASE_URL,
+  CREDITS_CACHE_FILE,
+  checkCreditGuard,
+  estimateCreditCost,
+  getUnlimitedModelForCommand,
+  isUnlimitedModel,
+  parseArgs,
+  ROUTES_CACHE,
+  STATE_FILE,
+  saveCreditCache,
+  UNLIMITED_MODELS,
+  UNLIMITED_SLUGS,
+} from './higgsfield-common.mjs';
 
 // ─── Auth Health Check & Smoke Test ──────────────────────────────────────────
 

--- a/.agents/scripts/higgsfield/higgsfield-video-download.mjs
+++ b/.agents/scripts/higgsfield/higgsfield-video-download.mjs
@@ -2,18 +2,18 @@
 // project API polling) for the Higgsfield automation suite.
 // Extracted from higgsfield-video.mjs (t2127 file-complexity decomposition).
 
-import {
-  safeJoin,
-  sanitizePathSegment,
-  curlDownload,
-  ensureDir,
-} from './higgsfield-common.mjs';
 
 import {
-  dismissAllModals,
-  debugScreenshot,
   clickHistoryTab,
+  debugScreenshot,
+  dismissAllModals,
 } from './higgsfield-browser.mjs';
+import {
+  curlDownload,
+  ensureDir,
+  safeJoin,
+  sanitizePathSegment,
+} from './higgsfield-common.mjs';
 
 import {
   buildDescriptiveFilename,

--- a/.agents/scripts/higgsfield/higgsfield-video.mjs
+++ b/.agents/scripts/higgsfield/higgsfield-video.mjs
@@ -5,38 +5,35 @@
 // Batch video/lipsync → higgsfield-batch-video.mjs
 // (t2127 file-complexity decomposition)
 
+
+import {
+  debugScreenshot,
+  dismissAllModals,
+  getDefaultOutputDir,
+  launchBrowser,
+} from './higgsfield-browser.mjs';
 import {
   BASE_URL,
-  STATE_FILE,
-  STATE_DIR,
   getUnlimitedModelForCommand,
   isUnlimitedModel,
+  STATE_DIR,
+  STATE_FILE,
   safeJoin,
 } from './higgsfield-common.mjs';
 
 import {
-  launchBrowser,
-  navigateTo,
-  dismissAllModals,
-  debugScreenshot,
-  clickHistoryTab,
-  getDefaultOutputDir,
-} from './higgsfield-browser.mjs';
-
-import {
   resolveOutputDir,
-  downloadLatestResult,
 } from './higgsfield-output.mjs';
 
 import { downloadVideoFromHistory } from './higgsfield-video-download.mjs';
-export { downloadVideoFromHistory };
 
 export {
-  extractVideoMetadata,
   downloadVideoFromApiData,
   evaluateNewestJobStatus,
+  extractVideoMetadata,
   fetchProjectApiWithPolling,
 } from './higgsfield-video-download.mjs';
+export { downloadVideoFromHistory };
 
 // ---------------------------------------------------------------------------
 // Video model mapping

--- a/.agents/scripts/higgsfield/playwright-automator.mjs
+++ b/.agents/scripts/higgsfield/playwright-automator.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+
 // Higgsfield UI Automator - CLI entry point
 // Uses the Higgsfield web UI to generate images/videos using subscription credits
 // Part of AI DevOps Framework
@@ -18,50 +19,48 @@
 //   higgsfield-batch-video.mjs   — batch video/lipsync, download from history
 //   higgsfield-tests.mjs         — auth health check, smoke test, self-tests
 
+import { apiGenerateImage, apiGenerateVideo, apiStatus } from './higgsfield-api.mjs';
+import { assetChain } from './higgsfield-asset-chain.mjs';
 import {
-  parseArgs,
+  batchLipsync,
+  batchVideo,
+  downloadFromHistory,
+} from './higgsfield-batch-video.mjs';
+import {
+  aiInfluencer,
+  checkCredits,
+  cinemaStudio,
+  createCharacter,
+  editImage,
+  editVideo,
+  featurePage,
+  listAssets,
+  manageAssets,
+  mixedMediaPreset,
+  motionControl,
+  motionPreset,
+  screenshot,
+  seedBracket,
+  storyboard,
+  upscale,
+  useApp,
+  vibeMotion,
+} from './higgsfield-commands.mjs';
+import {
   checkCreditGuard,
+  parseArgs,
   withRetry,
 } from './higgsfield-common.mjs';
-
 import {
   ensureDiscovery,
   login,
   runDiscovery,
 } from './higgsfield-discovery.mjs';
-
-import { generateImage, batchImage } from './higgsfield-image.mjs';
-import { generateVideo } from './higgsfield-video.mjs';
+import { batchImage, generateImage } from './higgsfield-image.mjs';
 import { generateLipsync } from './higgsfield-lipsync.mjs';
-import {
-  batchVideo,
-  batchLipsync,
-  downloadFromHistory,
-} from './higgsfield-batch-video.mjs';
-import { apiGenerateImage, apiGenerateVideo, apiStatus } from './higgsfield-api.mjs';
 import { pipeline } from './higgsfield-pipeline.mjs';
-import { assetChain } from './higgsfield-asset-chain.mjs';
-import { authHealthCheck, smokeTest, runSelfTests } from './higgsfield-tests.mjs';
-import {
-  seedBracket,
-  useApp,
-  screenshot,
-  checkCredits,
-  listAssets,
-  manageAssets,
-  mixedMediaPreset,
-  motionPreset,
-  cinemaStudio,
-  motionControl,
-  editImage,
-  upscale,
-  editVideo,
-  storyboard,
-  vibeMotion,
-  aiInfluencer,
-  createCharacter,
-  featurePage,
-} from './higgsfield-commands.mjs';
+import { authHealthCheck, runSelfTests, smokeTest } from './higgsfield-tests.mjs';
+import { generateVideo } from './higgsfield-video.mjs';
 
 // Run a command with API-first fallback to Playwright browser automation.
 async function runWithApiFallback(apiFn, browserFn, options, retryOpts) {

--- a/.agents/scripts/higgsfield/remotion/render.mjs
+++ b/.agents/scripts/higgsfield/remotion/render.mjs
@@ -5,8 +5,8 @@
 //   node render.mjs --still --text "Title" --aspect 9:16 --output title.png
 
 import { execFileSync } from "node:child_process";
-import { readFileSync, existsSync, copyFileSync, mkdirSync, realpathSync } from "node:fs";
-import { resolve, dirname, join, basename } from "node:path";
+import { copyFileSync, existsSync, mkdirSync, readFileSync, realpathSync } from "node:fs";
+import { basename, dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -43,7 +43,7 @@ function copyMusicToPublic(brief, briefPath, publicDir) {
   // Resolve symlinks to prevent symlink-based directory escapes
   const musicRealPath = realpathSync(musicAbsPath);
   const projectDir = resolve(__dirname, "..", "..");
-  if (!musicRealPath.startsWith(briefDir + "/") && !musicRealPath.startsWith(projectDir + "/")) {
+  if (!musicRealPath.startsWith(`${briefDir}/`) && !musicRealPath.startsWith(`${projectDir}/`)) {
     console.warn(
       `Warning: music path "${musicRealPath}" resolves outside the brief directory ` +
       `("${briefDir}") and project directory ("${projectDir}"), skipping for security`

--- a/.agents/scripts/higgsfield/remotion/src/CaptionOverlay.tsx
+++ b/.agents/scripts/higgsfield/remotion/src/CaptionOverlay.tsx
@@ -1,12 +1,12 @@
 import {
-  useCurrentFrame,
-  useVideoConfig,
+  AbsoluteFill,
   interpolate,
   spring,
-  AbsoluteFill,
+  useCurrentFrame,
+  useVideoConfig,
 } from "remotion";
-import type { CaptionOverlayProps } from "./types";
 import { CAPTION_STYLES, getPositionStyle } from "./styles";
+import type { CaptionOverlayProps } from "./types";
 
 // Typewriter: reveal characters one by one
 function TypewriterText({ text, style }: { text: string; style: typeof CAPTION_STYLES["typewriter"] }) {
@@ -51,6 +51,7 @@ function HighlightText({ text, style }: { text: string; style: typeof CAPTION_ST
         const isActive = i <= activeWordIndex;
         return (
           <span
+            // biome-ignore lint/suspicious/noArrayIndexKey: word segments are static text, no stable ID
             key={i}
             style={{
               fontFamily: style.fontFamily,

--- a/.agents/scripts/higgsfield/remotion/src/FullVideo.tsx
+++ b/.agents/scripts/higgsfield/remotion/src/FullVideo.tsx
@@ -1,8 +1,8 @@
-import React from "react";
-import { AbsoluteFill, Sequence, useVideoConfig, OffthreadVideo, staticFile } from "remotion";
-import { TransitionSeries, linearTiming } from "@remotion/transitions";
-import { fade } from "@remotion/transitions/fade";
 import { Audio } from "@remotion/media";
+import { linearTiming, TransitionSeries } from "@remotion/transitions";
+import { fade } from "@remotion/transitions/fade";
+import type React from "react";
+import { AbsoluteFill, OffthreadVideo, Sequence, staticFile, useVideoConfig } from "remotion";
 import { CaptionOverlay } from "./CaptionOverlay";
 import type { BriefProps, CaptionEntry } from "./types";
 
@@ -17,9 +17,9 @@ function toVideoSrc(path: string): string {
 }
 
 export const FullVideo: React.FC<BriefProps> = ({
-  title,
+  title: _title,
   scenes,
-  aspect,
+  aspect: _aspect,
   captions,
   sceneVideos,
   transitionStyle = "fade",
@@ -51,6 +51,7 @@ export const FullVideo: React.FC<BriefProps> = ({
 
             const elements: React.ReactNode[] = [
               <TransitionSeries.Sequence
+                // biome-ignore lint/suspicious/noArrayIndexKey: scenes lack stable IDs
                 key={`scene-${i}`}
                 durationInFrames={sceneDurationFrames}
               >
@@ -75,6 +76,7 @@ export const FullVideo: React.FC<BriefProps> = ({
             if (i < sceneVideos.length - 1) {
               elements.push(
                 <TransitionSeries.Transition
+                  // biome-ignore lint/suspicious/noArrayIndexKey: scenes lack stable IDs
                   key={`transition-${i}`}
                   presentation={fade()}
                   timing={linearTiming({ durationInFrames: transitionDuration })}
@@ -110,6 +112,7 @@ export const FullVideo: React.FC<BriefProps> = ({
 
         return (
           <Sequence
+            // biome-ignore lint/suspicious/noArrayIndexKey: scenes lack stable IDs
             key={`scene-${i}`}
             from={from}
             durationInFrames={sceneDurationFrames}

--- a/.agents/scripts/higgsfield/remotion/src/Root.tsx
+++ b/.agents/scripts/higgsfield/remotion/src/Root.tsx
@@ -1,14 +1,14 @@
-import React from "react";
-import { Composition, Still } from "remotion";
 import { loadFont as loadBangers } from "@remotion/google-fonts/Bangers";
-import { loadFont as loadInter } from "@remotion/google-fonts/Inter";
-import { loadFont as loadOswald } from "@remotion/google-fonts/Oswald";
-import { loadFont as loadMontserrat } from "@remotion/google-fonts/Montserrat";
 import { loadFont as loadIBMPlexMono } from "@remotion/google-fonts/IBMPlexMono";
+import { loadFont as loadInter } from "@remotion/google-fonts/Inter";
+import { loadFont as loadMontserrat } from "@remotion/google-fonts/Montserrat";
+import { loadFont as loadOswald } from "@remotion/google-fonts/Oswald";
+import type React from "react";
+import { Composition, Still } from "remotion";
 import { FullVideo } from "./FullVideo";
 import { SceneGraphic } from "./SceneGraphic";
-import { ASPECT_DIMENSIONS } from "./types";
 import type { BriefProps, SceneGraphicProps } from "./types";
+import { ASPECT_DIMENSIONS } from "./types";
 
 // Load only needed font weights/subsets to minimize network requests
 loadBangers("normal", { weights: ["400"], subsets: ["latin"] });
@@ -44,8 +44,10 @@ const defaultGraphicProps: SceneGraphicProps = {
   fontFamily: "Inter",
 };
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Remotion v4 Composition requires Zod schema as first type arg; we use runtime props instead
+// Remotion v4 Composition requires Zod schema as first type arg; we use runtime props instead
+// biome-ignore lint/suspicious/noExplicitAny: Remotion v4 typing workaround
 const AnyFullVideo = FullVideo as any;
+// biome-ignore lint/suspicious/noExplicitAny: Remotion v4 typing workaround
 const AnySceneGraphic = SceneGraphic as any;
 
 // Calculate duration and dimensions from actual props (handles --props override)
@@ -85,6 +87,7 @@ export const RemotionRoot: React.FC = () => {
       <Composition
         id="FullVideo"
         component={AnyFullVideo}
+        // biome-ignore lint/suspicious/noExplicitAny: Remotion v4 typing workaround
         calculateMetadata={calculateVideoMetadata as any}
         durationInFrames={defaultFrames}
         fps={FPS}
@@ -104,6 +107,7 @@ export const RemotionRoot: React.FC = () => {
       <Composition
         id="FullVideo-16x9"
         component={AnyFullVideo}
+        // biome-ignore lint/suspicious/noExplicitAny: Remotion v4 typing workaround
         calculateMetadata={calculateVideoMetadata as any}
         durationInFrames={defaultFrames}
         fps={FPS}
@@ -114,6 +118,7 @@ export const RemotionRoot: React.FC = () => {
       <Composition
         id="FullVideo-1x1"
         component={AnyFullVideo}
+        // biome-ignore lint/suspicious/noExplicitAny: Remotion v4 typing workaround
         calculateMetadata={calculateVideoMetadata as any}
         durationInFrames={defaultFrames}
         fps={FPS}

--- a/.agents/scripts/higgsfield/remotion/src/SceneGraphic.tsx
+++ b/.agents/scripts/higgsfield/remotion/src/SceneGraphic.tsx
@@ -1,4 +1,4 @@
-import { AbsoluteFill, useCurrentFrame, useVideoConfig, interpolate, spring } from "remotion";
+import { AbsoluteFill, interpolate, spring, useCurrentFrame, useVideoConfig } from "remotion";
 import type { SceneGraphicProps } from "./types";
 
 // Renders a static title card / graphic that can be:

--- a/.agents/scripts/higgsfield/remotion/src/SceneVideo.tsx
+++ b/.agents/scripts/higgsfield/remotion/src/SceneVideo.tsx
@@ -1,8 +1,8 @@
-import { AbsoluteFill } from "remotion";
 import { Video } from "@remotion/media";
+import { AbsoluteFill } from "remotion";
 import type { SceneVideoProps } from "./types";
 
-export const SceneVideo: React.FC<SceneVideoProps> = ({ src, durationInSeconds }) => {
+export const SceneVideo: React.FC<SceneVideoProps> = ({ src, durationInSeconds: _durationInSeconds }) => {
   return (
     <AbsoluteFill style={{ backgroundColor: "black" }}>
       <Video

--- a/.agents/scripts/higgsfield/remotion/src/styles.ts
+++ b/.agents/scripts/higgsfield/remotion/src/styles.ts
@@ -2,7 +2,7 @@
 // Each style defines font, colors, animation, and background treatment
 
 import type { CSSProperties } from "react";
-import type { CaptionStyle, CaptionPosition } from "./types";
+import type { CaptionPosition, CaptionStyle } from "./types";
 
 export interface CaptionStyleConfig {
   fontFamily: string;
@@ -104,7 +104,6 @@ export function getPositionStyle(
         justifyContent: "center",
         alignItems: "center",
       };
-    case "bottom":
     default:
       return {
         bottom: margin,

--- a/.agents/scripts/simplex-bot/src/approval.test.ts
+++ b/.agents/scripts/simplex-bot/src/approval.test.ts
@@ -5,9 +5,8 @@
  * Run: bun test
  */
 
-import { describe, expect, test, beforeEach, mock } from "bun:test";
+import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { ApprovalManager } from "./approval";
-import type { ExecApprovalConfig } from "./types";
 import { DEFAULT_EXEC_APPROVAL_CONFIG } from "./types";
 
 describe("ApprovalManager", () => {
@@ -94,7 +93,7 @@ describe("ApprovalManager", () => {
       const req = manager.createRequest("docker ps", 1, "alice", noopReply);
       const approved = manager.approve(req.id, 1);
       expect(approved).not.toBeNull();
-      expect(approved!.state).toBe("approved");
+      expect(approved?.state).toBe("approved");
     });
 
     test("rejects approval from a different contact", () => {
@@ -120,7 +119,7 @@ describe("ApprovalManager", () => {
       const req = manager.createRequest("docker ps", 1, "alice", noopReply);
       const rejected = manager.reject(req.id);
       expect(rejected).not.toBeNull();
-      expect(rejected!.state).toBe("rejected");
+      expect(rejected?.state).toBe("rejected");
     });
 
     test("returns null for non-existent request", () => {

--- a/.agents/scripts/simplex-bot/src/approval.ts
+++ b/.agents/scripts/simplex-bot/src/approval.ts
@@ -11,7 +11,6 @@
  */
 
 import type {
-  ApprovalState,
   ExecApprovalConfig,
   ExecClassification,
   PendingApproval,
@@ -299,5 +298,5 @@ function truncateOutput(text: string, maxLength: number = 2000): string {
   if (trimmed.length <= maxLength) {
     return trimmed;
   }
-  return trimmed.substring(0, maxLength) + "\n... (truncated)";
+  return `${trimmed.substring(0, maxLength)}\n... (truncated)`;
 }

--- a/.agents/scripts/simplex-bot/src/commands.ts
+++ b/.agents/scripts/simplex-bot/src/commands.ts
@@ -9,13 +9,14 @@
  */
 
 import { resolve } from "node:path";
-import type { CommandContext, CommandDefinition } from "./types";
 import pkg from "../package.json";
+import type { CommandContext, CommandDefinition } from "./types";
 
 // Re-export exec approval manager from extracted module
-export { setApprovalManager, getApprovalManager } from "./exec-commands";
-import {
-  runCommand, approveCommand, rejectCommand, pendingCommand,
+export { getApprovalManager, setApprovalManager } from "./exec-commands";
+
+import {approveCommand, pendingCommand,rejectCommand, 
+  runCommand, 
 } from "./exec-commands";
 
 // =============================================================================
@@ -55,7 +56,7 @@ const statusCommand: CommandDefinition = {
       const exitCode = await proc.exited;
       if (exitCode !== 0) {
         const detail = stderrText.trim();
-        return "Failed to get aidevops status." + (detail ? ` Error: ${detail}` : " Is aidevops installed?");
+        return `Failed to get aidevops status.${detail ? ` Error: ${detail}` : " Is aidevops installed?"}`;
       }
       return output.trim() || "aidevops is running (no output)";
     } catch {
@@ -108,17 +109,17 @@ const tasksCommand: CommandDefinition = {
 
       if (exitCode === 0) {
         const count = output.trim();
-        return "Open tasks: " + count + "\n\nUse /task <description> to create a new task.";
+        return `Open tasks: ${count}\n\nUse /task <description> to create a new task.`;
       } else if (exitCode === 1) {
         // grep returns 1 when no lines match — not an error
         return "Open tasks: 0\n\nUse /task <description> to create a new task.";
       } else {
         // grep returns >1 for actual errors (file not found, permission denied)
-        console.error("[tasksCommand] grep failed (exit " + exitCode + "): " + stderrOutput);
+        console.error(`[tasksCommand] grep failed (exit ${exitCode}): ${stderrOutput}`);
         return "Could not read TODO.md";
       }
     } catch (err) {
-      return "Could not read TODO.md: " + String(err);
+      return `Could not read TODO.md: ${String(err)}`;
     }
   },
 };
@@ -161,7 +162,7 @@ const versionCommand: CommandDefinition = {
   groupEnabled: true,
   dmEnabled: true,
   handler: async (_ctx: CommandContext): Promise<string> => {
-    return "aidevops SimpleX Bot v" + pkg.version;
+    return `aidevops SimpleX Bot v${pkg.version}`;
   },
 };
 
@@ -202,7 +203,7 @@ const roleCommand: CommandDefinition = {
     }
     const validRoles = ["observer", "author", "member", "moderator", "admin"];
     if (!validRoles.includes(role.toLowerCase())) {
-      return "Valid roles: " + validRoles.join(", ");
+      return `Valid roles: ${validRoles.join(", ")}`;
     }
     return (
       "Role change: " + user + " → " + role + "\n\n" +

--- a/.agents/scripts/simplex-bot/src/config.ts
+++ b/.agents/scripts/simplex-bot/src/config.ts
@@ -10,11 +10,11 @@
  */
 
 import { existsSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
 import { homedir } from "node:os";
+import { resolve } from "node:path";
+import { VALID_LOG_LEVELS, validateParsedConfig, warnUnknownKeys } from "./config-validation";
 import type { BotConfig } from "./types";
 import { DEFAULT_BOT_CONFIG } from "./types";
-import { VALID_LOG_LEVELS, warnUnknownKeys, validateParsedConfig } from "./config-validation";
 
 /** Path to the config file */
 const CONFIG_PATH = resolve(
@@ -26,11 +26,11 @@ const CONFIG_PATH = resolve(
 export {
   isValidPositiveNumber,
   removeInvalid,
-  validatePort,
   validateLogLevel,
   validateNumericFields,
-  warnUnknownKeys,
   validateParsedConfig,
+  validatePort,
+  warnUnknownKeys,
 } from "./config-validation";
 
 /**

--- a/.agents/scripts/simplex-bot/src/exec-commands.ts
+++ b/.agents/scripts/simplex-bot/src/exec-commands.ts
@@ -3,8 +3,8 @@
  * Extracted from commands.ts to reduce file-level complexity.
  */
 
-import type { CommandContext, CommandDefinition } from "./types";
 import { ApprovalManager, executeShellCommand } from "./approval";
+import type { CommandContext, CommandDefinition } from "./types";
 
 let approvalManager = new ApprovalManager();
 
@@ -37,14 +37,14 @@ export const runCommand: CommandDefinition = {
 
     switch (classification) {
       case "blocked":
-        return "BLOCKED: This command matches a blocked pattern and cannot be executed.\\nCommand: " + command;
+        return `BLOCKED: This command matches a blocked pattern and cannot be executed.\\nCommand: ${command}`;
 
       case "allowed": {
         const result = await executeShellCommand(command);
         const lines = ["Executed (allowlisted):", ""];
         if (result.stdout) lines.push(result.stdout);
-        if (result.stderr) lines.push("stderr: " + result.stderr);
-        lines.push("", "Exit code: " + result.exitCode);
+        if (result.stderr) lines.push(`stderr: ${result.stderr}`);
+        lines.push("", `Exit code: ${result.exitCode}`);
         return lines.join("\\n");
       }
 
@@ -52,11 +52,11 @@ export const runCommand: CommandDefinition = {
         const request = approvalManager.createRequest(command, contactId, contactName, ctx.reply);
         return [
           "Approval required for command execution.",
-          "", "Command: " + command,
-          "Request ID: " + request.id,
-          "Timeout: " + approvalManager.formatTimeout(),
-          "", "To approve:  /approve " + request.id,
-          "To reject:   /reject " + request.id,
+          "", `Command: ${command}`,
+          `Request ID: ${request.id}`,
+          `Timeout: ${approvalManager.formatTimeout()}`,
+          "", `To approve:  /approve ${request.id}`,
+          `To reject:   /reject ${request.id}`,
           "To list all: /pending",
         ].join("\\n");
       }
@@ -79,16 +79,16 @@ export const approveCommand: CommandDefinition = {
     const request = approvalManager.approve(requestId, contactId);
     if (!request) {
       const existing = approvalManager.getRequest(requestId);
-      if (existing) return "Request [" + requestId + "] is no longer pending (state: " + existing.state + ").";
-      return "No pending request found with ID: " + requestId;
+      if (existing) return `Request [${requestId}] is no longer pending (state: ${existing.state}).`;
+      return `No pending request found with ID: ${requestId}`;
     }
 
-    await ctx.reply("Approved. Executing: " + request.command);
+    await ctx.reply(`Approved. Executing: ${request.command}`);
     const result = await executeShellCommand(request.command);
-    const lines = ["Result for [" + requestId + "]:", ""];
+    const lines = [`Result for [${requestId}]:`, ""];
     if (result.stdout) lines.push(result.stdout);
-    if (result.stderr) lines.push("stderr: " + result.stderr);
-    lines.push("", "Exit code: " + result.exitCode);
+    if (result.stderr) lines.push(`stderr: ${result.stderr}`);
+    lines.push("", `Exit code: ${result.exitCode}`);
     return lines.join("\\n");
   },
 };
@@ -102,8 +102,8 @@ export const rejectCommand: CommandDefinition = {
     const requestId = ctx.args[0];
     if (!requestId) return "Usage: /reject [request-id]";
     const request = approvalManager.reject(requestId);
-    if (!request) return "No pending request found with ID: " + requestId;
-    return "Rejected command [" + requestId + "]: " + request.command;
+    if (!request) return `No pending request found with ID: ${requestId}`;
+    return `Rejected command [${requestId}]: ${request.command}`;
   },
 };
 
@@ -120,7 +120,7 @@ export const pendingCommand: CommandDefinition = {
     const lines = ["Pending approval requests:", ""];
     for (const req of requests) {
       const ageSeconds = Math.round((Date.now() - req.createdAt) / 1000);
-      lines.push("[" + req.id + "] " + req.command + " (" + ageSeconds + "s ago)");
+      lines.push(`[${req.id}] ${req.command} (${ageSeconds}s ago)`);
     }
     lines.push("", "Use /approve <id> or /reject <id> to respond.");
     return lines.join("\\n");

--- a/.agents/scripts/simplex-bot/src/handlers/contact.ts
+++ b/.agents/scripts/simplex-bot/src/handlers/contact.ts
@@ -9,14 +9,14 @@
  * Reference: t1327.1 research, section 4.1 (Essential Events for Bots)
  */
 
+import type { SessionStore } from "../session";
 import type {
   BotConfig,
+  BusinessRequestEvent,
   ContactConnectedEvent,
   ContactRequestEvent,
-  BusinessRequestEvent,
   SimplexEvent,
 } from "../types";
-import type { SessionStore } from "../session";
 
 /** Logger interface (matches the Logger class in index.ts) */
 interface Logger {

--- a/.agents/scripts/simplex-bot/src/handlers/file.ts
+++ b/.agents/scripts/simplex-bot/src/handlers/file.ts
@@ -9,12 +9,12 @@
  * Reference: t1327.1 research, section 4.1 (Essential Events for Bots)
  */
 
+import type { SessionStore } from "../session";
 import type {
   ChatItem,
-  SimplexEvent,
   FileEvent,
+  SimplexEvent,
 } from "../types";
-import type { SessionStore } from "../session";
 
 /** Logger interface */
 interface Logger {
@@ -200,6 +200,6 @@ function formatFileSize(bytes: number): string {
     Math.floor(Math.log(bytes) / Math.log(1024)),
     units.length - 1,
   );
-  const size = bytes / Math.pow(1024, i);
+  const size = bytes / 1024 ** i;
   return `${size.toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
 }

--- a/.agents/scripts/simplex-bot/src/handlers/group.ts
+++ b/.agents/scripts/simplex-bot/src/handlers/group.ts
@@ -10,12 +10,12 @@
  * Reference: t1327.1 research, section 4.1 (Essential Events for Bots)
  */
 
+import type { SessionStore } from "../session";
 import type {
-  SimplexEvent,
   GroupInvitationEvent,
   GroupMemberEvent,
+  SimplexEvent,
 } from "../types";
-import type { SessionStore } from "../session";
 
 /** Logger interface */
 interface Logger {

--- a/.agents/scripts/simplex-bot/src/handlers/index.ts
+++ b/.agents/scripts/simplex-bot/src/handlers/index.ts
@@ -4,27 +4,24 @@
  * Re-exports all event handlers for clean imports.
  */
 
+export type { ContactHandlerDeps } from "./contact";
 export {
+  handleBusinessRequest,
   handleContactConnected,
   handleContactRequest,
-  handleBusinessRequest,
 } from "./contact";
-export type { ContactHandlerDeps } from "./contact";
-
-export { handleNewChatItems } from "./message";
-export type { MessageHandlerDeps } from "./message";
-
+export type { FileHandlerDeps } from "./file";
 export {
-  handleGroupInvitation,
-  handleMemberJoined,
-  handleBotRemovedFromGroup,
-  handleMemberConnected,
-} from "./group";
-export type { GroupHandlerDeps } from "./group";
-
-export {
-  handleFileReady,
   handleFileComplete,
+  handleFileReady,
   handleNonTextMessage,
 } from "./file";
-export type { FileHandlerDeps } from "./file";
+export type { GroupHandlerDeps } from "./group";
+export {
+  handleBotRemovedFromGroup,
+  handleGroupInvitation,
+  handleMemberConnected,
+  handleMemberJoined,
+} from "./group";
+export type { MessageHandlerDeps } from "./message";
+export { handleNewChatItems } from "./message";

--- a/.agents/scripts/simplex-bot/src/handlers/message.ts
+++ b/.agents/scripts/simplex-bot/src/handlers/message.ts
@@ -7,6 +7,7 @@
  * Reference: t1327.1 research, section 4.2 (Message Event Structure)
  */
 
+import type { SessionStore } from "../session";
 import type {
   ChatItem,
   CommandDefinition,
@@ -14,8 +15,7 @@ import type {
   GroupInfo,
   NewChatItemsEvent,
 } from "../types";
-import type { SessionStore } from "../session";
-import { checkCommandPermission, buildCommandContext, executeCommand } from "./command-executor";
+import { buildCommandContext, checkCommandPermission, executeCommand } from "./command-executor";
 
 /** Logger interface */
 interface Logger {
@@ -51,7 +51,7 @@ export interface MessageHandlerDeps {
 }
 
 // Re-export command execution utilities for external consumers
-export { checkCommandPermission, buildCommandContext, executeCommand } from "./command-executor";
+export { buildCommandContext, checkCommandPermission, executeCommand } from "./command-executor";
 
 /**
  * Handle newChatItems event.

--- a/.agents/scripts/simplex-bot/src/index.ts
+++ b/.agents/scripts/simplex-bot/src/index.ts
@@ -20,6 +20,25 @@
  * Reference: t1327.4 bot framework specification
  */
 
+import { ApprovalManager } from "./approval";
+import { BUILTIN_COMMANDS, getApprovalManager, setApprovalManager } from "./commands";
+import {
+  handleBotRemovedFromGroup,
+  handleBusinessRequest,
+  handleContactConnected,
+  handleContactRequest,
+  handleFileComplete,
+  handleFileReady,
+  handleGroupInvitation,
+  handleMemberConnected,
+  handleMemberJoined,
+  handleNewChatItems,
+  handleNonTextMessage,
+} from "./handlers";
+import { formatLeakWarning, redactLeaks, scanForLeaks } from "./leak-detector";
+import { Logger } from "./logger";
+import { CommandRouter } from "./router";
+import { SessionStore } from "./session";
 import type {
   BotConfig,
   ChatItem,
@@ -27,32 +46,10 @@ import type {
   ContactInfo,
   ExecApprovalConfig,
   GroupInfo,
-  NewChatItemsEvent,
   SimplexCommand,
   SimplexEvent,
   SimplexResponse,
 } from "./types";
-import { DEFAULT_BOT_CONFIG, DEFAULT_EXEC_APPROVAL_CONFIG } from "./types";
-import { BUILTIN_COMMANDS, getApprovalManager, setApprovalManager } from "./commands";
-import { ApprovalManager } from "./approval";
-import { scanForLeaks, redactLeaks, formatLeakWarning } from "./leak-detector";
-import { loadConfig } from "./config";
-import { SessionStore } from "./session";
-import { Logger } from "./logger";
-import { CommandRouter } from "./router";
-import {
-  handleContactConnected,
-  handleContactRequest,
-  handleBusinessRequest,
-  handleNewChatItems,
-  handleGroupInvitation,
-  handleMemberJoined,
-  handleBotRemovedFromGroup,
-  handleMemberConnected,
-  handleFileReady,
-  handleFileComplete,
-  handleNonTextMessage,
-} from "./handlers";
 
 // Re-export for consumers that import from this module
 export { Logger } from "./logger";
@@ -287,6 +284,7 @@ export class SimplexAdapter {
     };
 
     // Handler map: event type → [handler function, deps object]
+    // biome-ignore lint/complexity/noBannedTypes: handler map uses generic callable type
     const handlers: Record<string, [Function, unknown]> = {
       newChatItems: [handleNewChatItems, messageDeps],
       contactConnected: [handleContactConnected, contactDeps],

--- a/.agents/scripts/simplex-bot/src/leak-detector.test.ts
+++ b/.agents/scripts/simplex-bot/src/leak-detector.test.ts
@@ -9,11 +9,10 @@
 
 import { describe, expect, test } from "bun:test";
 import {
-  shannonEntropy,
-  scanForLeaks,
-  redactLeaks,
   formatLeakWarning,
-  LEAK_PATTERNS,
+  redactLeaks,
+  scanForLeaks,
+  shannonEntropy,
 } from "./leak-detector";
 import type { LeakDetectionConfig } from "./types";
 

--- a/.agents/scripts/simplex-bot/src/leak-detector.ts
+++ b/.agents/scripts/simplex-bot/src/leak-detector.ts
@@ -95,7 +95,7 @@ export const LEAK_PATTERNS: ReadonlyArray<{
   // --- Chat/messaging tokens ---
   {
     name: "slack_token",
-    pattern: /\b(xox[bpors]-[0-9A-Za-z\-]{10,})\b/g,
+    pattern: /\b(xox[bpors]-[0-9A-Za-z-]{10,})\b/g,
     description: "Slack bot/user/app token",
   },
   {
@@ -178,6 +178,7 @@ function detectPatternLeaks(
     pattern.lastIndex = 0;
 
     let match: RegExpExecArray | null;
+    // biome-ignore lint/suspicious/noAssignInExpressions: idiomatic regex exec loop
     while ((match = pattern.exec(text)) !== null) {
       const value = match[1] ?? match[0];
 
@@ -210,6 +211,7 @@ function detectHighEntropyTokens(
   const matches: LeakMatch[] = [];
   const tokenRegex = new RegExp(`[A-Za-z0-9_\\-/.+=]{${minTokenLength},}`, "g");
   let tokenMatch: RegExpExecArray | null;
+  // biome-ignore lint/suspicious/noAssignInExpressions: idiomatic regex exec loop
   while ((tokenMatch = tokenRegex.exec(text)) !== null) {
     const token = tokenMatch[0];
     const index = tokenMatch.index;

--- a/.agents/scripts/simplex-bot/src/session.ts
+++ b/.agents/scripts/simplex-bot/src/session.ts
@@ -10,8 +10,8 @@
 
 import { Database } from "bun:sqlite";
 import { existsSync, mkdirSync } from "node:fs";
-import { dirname, resolve } from "node:path";
 import { homedir } from "node:os";
+import { resolve } from "node:path";
 
 /** Default data directory for bot state */
 const DEFAULT_DATA_DIR = resolve(
@@ -136,6 +136,7 @@ export class SessionStore {
       )
       .run(id, chatType, chatId, displayName);
 
+    // biome-ignore lint/style/noNonNullAssertion: row guaranteed to exist after INSERT
     return this.db
       .query<Session, [string]>("SELECT * FROM sessions WHERE id = ?")
       .get(id)!;

--- a/.agents/scripts/simplex-bot/src/start.ts
+++ b/.agents/scripts/simplex-bot/src/start.ts
@@ -3,8 +3,8 @@
  * Extracted from index.ts to reduce file-level complexity.
  */
 
-import { SimplexAdapter } from "./index";
 import { loadConfig } from "./config";
+import { SimplexAdapter } from "./index";
 
 async function main(): Promise<void> {
   const config = loadConfig();

--- a/.agents/scripts/simplex-bot/src/types.ts
+++ b/.agents/scripts/simplex-bot/src/types.ts
@@ -167,7 +167,7 @@ export interface GroupInfo {
 /** Bot command handler function */
 export type CommandHandler = (
   ctx: CommandContext,
-) => Promise<string | void>;
+) => Promise<string | undefined>;
 
 /** Context passed to command handlers */
 export interface CommandContext {

--- a/.agents/scripts/tests/fixtures/t2121/driver.mjs
+++ b/.agents/scripts/tests/fixtures/t2121/driver.mjs
@@ -48,11 +48,11 @@ async function run() {
   output += decoder.decode();
 
   if (output.includes("mcp__aidevops__")) {
-    console.log("FAIL_PREFIX_PRESENT " + JSON.stringify(output));
+    console.log(`FAIL_PREFIX_PRESENT ${JSON.stringify(output)}`);
     process.exit(1);
   }
   if (!output.includes('"name":"grep"')) {
-    console.log("FAIL_NAME_MISSING " + JSON.stringify(output));
+    console.log(`FAIL_NAME_MISSING ${JSON.stringify(output)}`);
     process.exit(2);
   }
   console.log("OK");
@@ -60,6 +60,6 @@ async function run() {
 }
 
 run().catch((e) => {
-  console.log("ERROR " + e.message);
+  console.log(`ERROR ${e.message}`);
   process.exit(3);
 });

--- a/.agents/scripts/tests/test-session-rename-ts.mjs
+++ b/.agents/scripts/tests/test-session-rename-ts.mjs
@@ -12,9 +12,9 @@
 // =============================================================================
 
 import { Database } from "bun:sqlite";
-import { mkdtempSync, rmSync } from "fs";
-import { tmpdir } from "os";
-import { join } from "path";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 // Import from the extracted guards module — it has no runtime-injected
 // dependencies so it loads cleanly under `bun run` without the OpenCode

--- a/.agents/scripts/wappalyzer-detect.mjs
+++ b/.agents/scripts/wappalyzer-detect.mjs
@@ -54,7 +54,7 @@ const url = args[0];
 // Validate URL
 try {
   new URL(url);
-} catch (error) {
+} catch (_error) {
   console.error(`Invalid URL: ${url}`);
   process.exit(1);
 }


### PR DESCRIPTION
## Summary

Resolves #19802

Batch-fixes all 185 pre-existing Biome lint violations across 51 `.agents/scripts/` JS/MJS/TS files that caused the Biome CI check to fail on every PR.

### Changes

**Auto-fixed (161 violations):**
- `useTemplate` (36): string concatenation → template literals
- `useNodejsImportProtocol` (37): bare imports → `node:` protocol (`'fs'` → `'node:fs'`)
- `noUnusedImports` (21): removed dead imports
- `useOptionalChain` (6): `a && a.b` → `a?.b`
- `useExponentiationOperator` (3): `Math.pow()` → `**`
- `useImportType` (2): value imports → type imports
- Plus: `useConst`, `noUselessTernary`, `noUselessSwitchCase`, `noUselessEscapeInRegex`, `noGlobalIsNan`, `noConfusingVoidType` (1 each)

**Manually fixed (8 violations):**
- Prefixed unused destructured params with `_` (5 locations)
- Renamed unused destructured variable: `isVideo` → `_isVideo`

**Suppressed with `biome-ignore` (16 violations — intentional patterns):**
- `noAssignInExpressions` (3): idiomatic `while ((match = regex.exec()) !== null)` loops
- `useIterableCallbackReturn` (4): `forEach` callbacks used for logging
- `noArrayIndexKey` (4): React components with static lists lacking stable IDs
- `noExplicitAny` (5): Remotion v4 type workarounds (already documented with eslint-disable)
- `noBannedTypes` (1): generic `Function` type in handler map
- `noNonNullAssertion` (1): guaranteed non-null after INSERT+SELECT

### Verification

```
npx --yes @biomejs/biome@2.4.12 check --no-errors-on-unmatched .agents/scripts/
Checked 71 files in 192ms. No fixes applied.
```

Zero errors, zero warnings. All changes are stylistic — no behavioral modifications.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.74 plugin for [OpenCode](https://opencode.ai) v1.14.17 with claude-opus-4-6 spent 9m and 18,299 tokens on this as a headless worker.