### PR TITLE
GH#19824: docs(reference): add large-file split playbook for shell libs

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -246,6 +246,8 @@ Worktrees: `wt switch -c {type}/{name}`. Keep the canonical repo directory on `m
 
 **Task-ID collision guard (t2047):** t-IDs in commit subjects MUST be claimed via `claim-task-id.sh`. The commit-msg hook (`install-task-id-guard.sh install`) enforces this client-side; the CI check (`.github/workflows/task-id-collision-check.yml`) enforces it server-side for commits authored outside the hook.
 
+**Large-file splits (t2368):** When splitting a shell library into sub-libraries (responding to `file-size-debt`, `function-complexity`, or `nesting-depth` scanner issues), read `reference/large-file-split.md` first. It covers the canonical orchestrator + sub-library pattern, identity-key preservation rules, known CI false-positive classes, pre-commit hook gotchas, and a complete PR body template. A worker reading only this doc + the scanner-filed issue body can complete a split PR end-to-end without re-discovering any lesson.
+
 Full workflow: `workflows/git-workflow.md`, `reference/session.md`
 
 ---

--- a/.agents/reference/large-file-split.md
+++ b/.agents/reference/large-file-split.md
@@ -1,0 +1,336 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Large-File Split Playbook for Shell Libraries
+
+Consolidated from six prior worker attempts on GH#19699, each of which re-discovered
+the same framework lessons from scratch. This document exists so the next worker
+arrives already knowing the answer.
+
+## 1. When to Use This
+
+Use this playbook when:
+
+- You are responding to a `file-size-debt`, `function-complexity`, or `nesting-depth`
+  scanner-filed issue that recommends splitting a shell library.
+- You are voluntarily splitting a shell lib that has grown past maintainable size
+  (the `file-size` scanner threshold is 1500 lines for `.sh` files).
+
+**Do not use** for non-shell splits (Python, JS, etc.) or for refactors that change
+behaviour. This playbook covers mechanical, behaviour-preserving splits only.
+
+## 2. Canonical Pattern
+
+Two in-repo precedents demonstrate the pattern end-to-end:
+
+| Precedent | Orchestrator | Sub-libraries |
+|-----------|-------------|---------------|
+| Simple | `issue-sync-helper.sh` | `issue-sync-lib.sh` |
+| Complex | `headless-runtime-lib.sh` | `headless-runtime-provider.sh`, `headless-runtime-failure.sh`, `headless-runtime-model.sh` |
+
+### 2.1 Orchestrator file
+
+The orchestrator retains the original filename. It keeps:
+
+- The include guard (`[[ -n "${_XXX_LOADED:-}" ]] && return 0`)
+- The `shared-constants.sh` import
+- The `SCRIPT_DIR` fallback (see 2.3)
+- `source` calls to each sub-library
+- Any functions whose identity keys must be preserved (see section 3)
+
+### 2.2 Sub-library file
+
+Each sub-library follows this template:
+
+```bash
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# <Library Name> -- <One-Line Description>
+# =============================================================================
+# <Multi-line description of what this sub-library covers.>
+#
+# Usage: source "${SCRIPT_DIR}/<this-file>.sh"
+#
+# Dependencies:
+#   - shared-constants.sh (print_error, print_info, etc.)
+#   - <any other dependencies>
+#
+# Part of aidevops framework: https://aidevops.sh
+
+# Apply strict mode only when executed directly (not when sourced)
+[[ "${BASH_SOURCE[0]}" == "${0}" ]] && set -euo pipefail
+
+# Include guard
+[[ -n "${_<UNIQUE_NAME>_LIB_LOADED:-}" ]] && return 0
+_<UNIQUE_NAME>_LIB_LOADED=1
+
+# --- Functions ---
+
+# <function definitions here>
+```
+
+### 2.3 Sourcing sub-libraries from the orchestrator
+
+The orchestrator sources sub-libraries via `$SCRIPT_DIR`. ShellCheck cannot
+statically resolve runtime-computed paths, so each source call needs two
+directives. From `headless-runtime-lib.sh:102-104`:
+
+```bash
+# shellcheck source=./headless-runtime-provider.sh
+# shellcheck disable=SC1091  # sub-library resolved at runtime via $SCRIPT_DIR
+source "${SCRIPT_DIR}/headless-runtime-provider.sh"
+```
+
+### 2.4 Defensive `SCRIPT_DIR` fallback
+
+Both orchestrators and sub-libraries need `SCRIPT_DIR` to resolve sibling
+files. The caller (e.g., `headless-runtime-helper.sh`) usually sets it, but
+test harnesses and direct sourcing may not. Add this fallback at the top,
+after the include guard. Cite: `issue-sync-lib.sh:35-41`:
+
+```bash
+if [[ -z "${SCRIPT_DIR:-}" ]]; then
+    # Pure-bash dirname replacement -- avoids external binary dependency
+    _lib_path="${BASH_SOURCE[0]%/*}"
+    [[ "$_lib_path" == "${BASH_SOURCE[0]}" ]] && _lib_path="."
+    SCRIPT_DIR="$(cd "$_lib_path" && pwd)"
+    unset _lib_path
+fi
+```
+
+## 3. Identity-Key Preservation Rules
+
+The complexity scanners (`complexity-regression-helper.sh`) track violations by
+identity keys. Moving code between files can create or destroy violations
+depending on the metric.
+
+| Metric | Identity key | Split impact | Action |
+|--------|-------------|-------------|--------|
+| `function-complexity` | `(file, fname)` | Moving a >100-line function to a new file re-registers it as a **new** violation. | Functions over 100 lines **MUST stay in the original file**. Example: `_run_canary_test` stayed in `headless-runtime-lib.sh` (PR #19821). |
+| `file-size` | `(file)` | Splitting automatically resolves the original file's violation. New sub-files are typically under the threshold. | No special action needed. |
+| `nesting-depth` | `(file, 'NEST')` | Splitting into new files creates new `(newfile, 'NEST')` keys. Expect `+N new` regressions. | This is a **known false positive** -- see section 4. Override with `complexity-bump-ok` label. |
+| `bash32-compat` | `(construct)` | Splitting is neutral -- the construct identity doesn't include the file. | No special action needed. |
+
+**Critical rule**: before splitting, run `complexity-regression-helper.sh check`
+on the pre-split state. Identify every `function-complexity` violation in the
+target file. Those functions stay put.
+
+## 4. Known CI False-Positive Classes on Splits
+
+### 4.1 Nesting-depth scanner
+
+`scan_dir_nesting_depth` at `complexity-regression-helper.sh:225-256` is a
+global `elif`-counting AWK, not a real nesting metric:
+
+```awk
+/[[:space:]]*(if|for|while|until|case)[[:space:]]/ { depth++; ... }
+/[[:space:]]*(fi|done|esac)[[:space:]]*$/ || /^[[:space:]]*(fi|done|esac)$/ { if(depth>0) depth-- }
+```
+
+The open-regex matches `elif` because `elif` contains the literal substring
+`if` preceded by optional whitespace. Each `elif` increments `depth` but
+has no corresponding close, so `if/elif/elif/fi` opens +3 but only closes -1.
+Every `elif` chain inflates the counter permanently.
+
+**Evidence**: the pre-split `headless-runtime-lib.sh` (2107 lines) scored
+`max_depth=83` -- physically impossible; bash has no code path that nests
+83 levels deep.
+
+**Override procedure**:
+
+1. Apply the `complexity-bump-ok` label to the PR.
+2. Add a `## Complexity Bump Justification` section to the PR body with:
+   - The scanner evidence (file:line ref showing the `elif` pattern)
+   - The measurement (`base=N, head=M, new=K`)
+   - Explanation that the new violations are identity-key artifacts, not real nesting increases.
+
+### 4.2 Pre-push complexity guard
+
+The client-side `complexity-regression-pre-push.sh` hook rejects on the same
+false positive. Targeted bypass:
+
+```bash
+COMPLEXITY_GUARD_DISABLE=1 git push
+```
+
+Document this alongside the CI label in your PR body.
+
+## 5. Pre-Commit Hook Gotchas (and Compliant Rewrites)
+
+### 5.1 SC1091 from sourced sub-libraries
+
+The pre-commit ShellCheck hook flags `source "${SCRIPT_DIR}/sub-lib.sh"` as
+SC1091 ("Not following: ... was not specified as input"). Fix with an inline
+directive and a one-line reason:
+
+```bash
+# shellcheck source=./sub-lib.sh
+# shellcheck disable=SC1091  # sub-library resolved at runtime via $SCRIPT_DIR
+source "${SCRIPT_DIR}/sub-lib.sh"
+```
+
+### 5.2 Positional parameter validation
+
+`validate_positional_parameters` flags `"$1"` usage in rest-args emit loops.
+Compliant rewrite (identical behaviour, no `$1` reference):
+
+```bash
+# Before (flagged):
+while [[ $# -gt 0 ]]; do printf '%s\0' "$1"; shift; done
+
+# After (compliant):
+[[ $# -gt 0 ]] && printf '%s\0' "$@"
+```
+
+### 5.3 String-literal validation (t2230 bug)
+
+`validate_string_literals` flags `"$var"` interpolations as "repeated string
+literals". These are variable references, not literals -- this is a **known
+framework bug** tracked in t2230 (GH#19739).
+
+If you hit this on a split, do NOT rewrite variable references to deduplicate
+(that causes code harm). Options:
+
+1. If t2230 has landed, use whatever opt-out it ships.
+2. Otherwise: `COMPLEXITY_GUARD_DISABLE=1` + commit with `--no-verify` +
+   document the maintainer authorization in the commit message and PR body
+   self-assessment section.
+
+## 6. PR Body Template
+
+Copy this skeleton into `gh pr create --body`. Replace placeholders in
+`<angle brackets>`.
+
+````markdown
+## Summary
+
+Split `<original-file>` (<N> lines) into <M> focused files so every shell
+script is under the <threshold>-line file-size-debt threshold. Function groups
+move verbatim; no behavioural changes.
+
+| file | lines | scope |
+|---|---|---|
+| `<orchestrator>` | <N> | thin orchestrator: <scope summary> |
+| `<sub-lib-1>` | <N> | <scope summary> |
+| `<sub-lib-2>` | <N> | <scope summary> |
+
+Mirrors the `issue-sync-helper.sh` / `issue-sync-lib.sh` split precedent.
+Each sub-library has an include guard and a `# shellcheck source=./...`
+directive paired with an SC1091 disable (runtime-resolved via `$SCRIPT_DIR`,
+cannot be statically followed without `-x`).
+
+## Changes
+
+1. **<M> files** -- <N-1> new sub-libraries + rewritten orchestrator lib. No
+   caller-facing API changes; `<caller>` continues to source only
+   `<orchestrator>`.
+2. **Defensive `SCRIPT_DIR` fallback** in `<orchestrator>` (derived from
+   `BASH_SOURCE[0]`, matches the `issue-sync-lib.sh` pattern).
+3. **<Any compliant rewrites>** (e.g., rest-arg loops rewritten per
+   `reference/large-file-split.md` section 5.2).
+4. **`<large-function>` stays in `<orchestrator>`** -- deliberately, to keep
+   its `(file, fname)` identity key unchanged so the function-complexity
+   metric does not regress.
+
+## Testing
+
+- `shellcheck <all-files>` -- clean at warning+error severity
+- Smoke test via the real caller path (`SCRIPT_DIR=... source <orchestrator>`):
+  all expected functions resolve; behaviour is identical
+- `complexity-regression-helper.sh check` vs `origin/main`:
+  - `file-size`: base=<N>, head=<N>, **new=0**
+  - `function-complexity`: base=<N>, head=<N>, **new=0**
+  - `bash32-compat`: base=<N>, head=<N>, **new=0**
+  - `nesting-depth`: base=<N>, head=<N>, new=<K> -- see justification below
+
+## Complexity Bump Justification
+
+**`complexity-bump-ok` label applied.** The nesting-depth scanner reports <K>
+new violations solely because the `(file, 'NEST')` identity key changes when
+code moves to freshly-named files. The metric is not real nesting depth.
+
+**Evidence that the scanner is not measuring real nesting:**
+
+- `scan_dir_nesting_depth` in `complexity-regression-helper.sh:225-256` is a
+  single global AWK counter that increments on any line matching
+  `/[[:space:]]*(if|for|while|until|case)[[:space:]]/` and decrements on
+  `fi|done|esac`. It has no function scoping.
+- The open-regex also matches the literal string `if` in `elif`. Each `elif`
+  chain inflates the counter permanently.
+- `origin/main`'s current `<original-file>` scans as **max_depth=<N>** --
+  physically impossible; bash has no code path that nests <N> levels deep.
+- Per-function nesting is unchanged. The `function-complexity` metric confirms
+  `base=<N> head=<N> new=0`.
+
+**Pre-existing debt moved, not introduced:** all the `elif`-chain patterns
+that trip the scanner were already in the <N>-line file. The split relocates
+them, it does not create them. Apply `complexity-bump-ok` per the documented
+override procedure.
+
+## Related
+
+- Resolves #<issue-number>
+- Reference: `reference/large-file-split.md`
+
+## Self-Assessment
+
+**`--no-verify` disclosure:** <if used, document why and what maintainer
+authorized it. If not used, delete this section.>
+````
+
+## 7. Verification Checklist
+
+Run these checks before pushing:
+
+### 7.1 ShellCheck
+
+```bash
+shellcheck .agents/scripts/<orchestrator>.sh .agents/scripts/<sub-lib-1>.sh ...
+```
+
+Must be clean at warning+ severity. SC1091 must be suppressed inline (section 5.1),
+not globally.
+
+### 7.2 Smoke test
+
+Confirm all expected functions resolve and behaviour is identical:
+
+```bash
+SCRIPT_DIR=.agents/scripts source .agents/scripts/<orchestrator>.sh
+
+# Verify key functions are available:
+type <function_1> <function_2> <function_3>
+```
+
+### 7.3 Complexity regression check
+
+```bash
+.agents/scripts/complexity-regression-helper.sh check
+```
+
+Expected results for a well-executed split:
+
+- `file-size`: `new=0` (original >threshold file cleared)
+- `function-complexity`: `new=0` (large functions stayed in original file)
+- `bash32-compat`: `new=0` (splitting is neutral)
+- `nesting-depth`: `new>=0` (document any `new>0` in PR body per section 4.1)
+
+### 7.4 Pre-push dry run
+
+```bash
+COMPLEXITY_GUARD_DISABLE=1 git push --dry-run
+```
+
+If the dry run passes with the complexity guard disabled, the only remaining
+gate is the CI `complexity-bump-ok` label (section 4.1).
+
+---
+
+## Related
+
+- GH#19699, PR #19821 -- the session that surfaced the missing documentation
+- GH#19739 (t2230) -- string-literal hook bug; if fixed, section 5.3 simplifies
+- `reference/bash-compat.md` -- Bash 3.2 compatibility rules
+- `tools/code-review/code-simplifier.md` -- primary consumer for simplification issues

--- a/.agents/workflows/brief.md
+++ b/.agents/workflows/brief.md
@@ -86,6 +86,7 @@ for the classified tier. Load on demand — do not inline the format rules.
 - `templates/brief-template.md` — Full task brief template (for `/define`, `/new-task`)
 - `templates/escalation-report-template.md` — Failure report format for cascade dispatch
 - `reference/task-taxonomy.md` — Tier definitions, cascade model, escalation reasons
+- `reference/large-file-split.md` — Playbook for shell library splits (scanner-filed issues, PR body template)
 - `tools/build-agent/build-agent.md` — "Designing tier-aware output" section
 - `tools/code-review/code-simplifier.md` — Primary consumer for simplification issues
 - `prompts/build.txt` — Traceability rules, signature footer, PR title format


### PR DESCRIPTION
## Summary

New .agents/reference/large-file-split.md consolidating every framework lesson six prior worker attempts on #19699 re-discovered from scratch. Covers canonical orchestrator + sub-library pattern, identity-key preservation rules, known CI false-positive classes, pre-commit hook gotchas, and a complete PR body template. Cross-linked from AGENTS.md Git Workflow section and workflows/brief.md.

## Files Changed

.agents/AGENTS.md,.agents/reference/large-file-split.md,.agents/workflows/brief.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** markdownlint-cli2 clean (0 errors). Verified all 7 required sections present. Confirmed file:line citations match actual source (complexity-regression-helper.sh:225-256, issue-sync-lib.sh:35-41). Cross-links verified in AGENTS.md and brief.md.

Resolves #19824


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.74 plugin for [OpenCode](https://opencode.ai) v1.14.17 with claude-opus-4-6 spent 6m and 9,769 tokens on this as a headless worker.