### PR TITLE
GH#19861: document claim scope limitation, add lockdown/unlock subcommands

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -210,6 +210,8 @@ Worktrees: `wt switch -c {type}/{name}`. Keep the canonical repo directory on `m
 
 **Interactive issue ownership (MANDATORY — AI-driven, t2056):** When an interactive session engages with a GitHub issue — opening a worktree for it, claiming a new task, or identifying an existing issue to work on — the agent MUST immediately call `interactive-session-helper.sh claim <N> <slug>`. This applies `status:in-review` + self-assignment, which the pulse's dispatch-dedup guard (`_has_active_claim`) already honours as a block. Unlike `origin:interactive` (which only marks creation-time origin), this is the session-ownership signal for picking up *any* issue mid-lifecycle.
 
+  **Scope limitation (GH#19861):** `claim` blocks the pulse's **dispatch** path only. It does NOT block the enrich path (which may overwrite issue title/body/labels), the completion-sweep path (which may strip status labels), or any other non-dispatch pulse operation. For full insulation from all pulse modifications (e.g., investigating a pulse bug), use `interactive-session-helper.sh lockdown <N> <slug>` instead — it applies `no-auto-dispatch` + `status:in-review` + self-assignment + conversation lock + audit comment.
+
 - **Release is the agent's responsibility**, not the user's. Call `interactive-session-helper.sh release <N> <slug>` when the user signals completion ("done", "ship it", "moving on", "let a worker take over"), when they switch to a different issue, or when a PR they opened merges. The user should never need to type a release command.
 - **Session start:** run `interactive-session-helper.sh scan-stale` and act on any findings:
   - Phase 1 (dead claims): if stamps with dead PID and missing worktree surface, prompt user to release them.

--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -288,9 +288,9 @@
       "pr": 11812
     },
     ".agents/commands/AGENTS.md": {
-      "at": "2026-04-19T02:07:12Z",
-      "hash": "6a1a9082053e7449bc53a12d16a948878e67a83d",
-      "passes": 25,
+      "at": "2026-04-19T05:30:32Z",
+      "hash": "bdab3c89527d15c7c8af8ae3cca1557e6a18af25",
+      "passes": 26,
       "pr": 18117
     },
     ".agents/commands/aidevops-automate.md": {
@@ -820,9 +820,9 @@
       "pr": 15249
     },
     ".agents/hooks/task-id-collision-guard.sh": {
-      "at": "2026-04-18T18:06:27Z",
-      "hash": "b64545528f1b24431c580ec4f5120f6070b4cc62",
-      "passes": 4,
+      "at": "2026-04-19T05:30:38Z",
+      "hash": "3dbec4a0bc598c9e43cd1b207de10a7cabeeef8a",
+      "passes": 5,
       "pr": 18718
     },
     ".agents/legal.md": {
@@ -1616,9 +1616,9 @@
       "pr": 12910
     },
     ".agents/prompts/worker-efficiency-protocol.md": {
-      "at": "2026-04-09T07:31:59Z",
-      "hash": "ad80bbd159a7ed21eeca89e99008a11bfe8a0649",
-      "passes": 4,
+      "at": "2026-04-19T05:30:46Z",
+      "hash": "1849115d37d8af048907168e6b53a01620b43cfa",
+      "passes": 5,
       "pr": 14943
     },
     ".agents/reference/agent-routing.md": {
@@ -2214,9 +2214,9 @@
       "pr": 17713
     },
     ".agents/scripts/config-helper.sh": {
-      "at": "2026-04-05T17:38:48Z",
-      "hash": "12dd983e382f5e3d45151fcb317d547ea4bec6f0",
-      "passes": 2,
+      "at": "2026-04-19T05:30:52Z",
+      "hash": "910364dbe5aa0873188c24d7a045ab7367088a0f",
+      "passes": 3,
       "pr": 16084
     },
     ".agents/scripts/cron-helper.sh": {
@@ -2262,9 +2262,9 @@
       "pr": 12145
     },
     ".agents/scripts/full-loop-helper.sh": {
-      "at": "2026-04-19T00:33:33Z",
-      "hash": "d52c49da54651ee9131dbf04c4559c6f6c7e015e",
-      "passes": 10,
+      "at": "2026-04-19T05:30:53Z",
+      "hash": "0da699d76a8d8fb04cae2b8fc41b4d3a1f27ead4",
+      "passes": 11,
       "pr": 19046
     },
     ".agents/scripts/generate-claude-commands.sh": {
@@ -2298,9 +2298,9 @@
       "pr": 13021
     },
     ".agents/scripts/headless-runtime-helper.sh": {
-      "at": "2026-04-19T00:33:34Z",
-      "hash": "62c1ad9820562de9e12d333ea1360b05869d6afc",
-      "passes": 21,
+      "at": "2026-04-19T05:30:53Z",
+      "hash": "f46465b88cb5140c2e91a5adb79efe9c2b0026f5",
+      "passes": 22,
       "pr": 15086
     },
     ".agents/scripts/headless-runtime-lib.sh": {
@@ -2316,9 +2316,9 @@
       "pr": 18843
     },
     ".agents/scripts/issue-sync-helper.sh": {
-      "at": "2026-04-18T05:04:08Z",
-      "hash": "4adb6934312de791dfa05152ce0441dd9c19fac8",
-      "passes": 13,
+      "at": "2026-04-19T05:30:53Z",
+      "hash": "5e82e93693e38056c20f328a8631d3cebda57a99",
+      "passes": 14,
       "pr": 18706
     },
     ".agents/scripts/issue-sync-lib.sh": {
@@ -2340,9 +2340,9 @@
       "pr": 15431
     },
     ".agents/scripts/memory-pressure-monitor.sh": {
-      "at": "2026-04-16T18:41:08Z",
-      "hash": "29ecc90b297c4af37a380937f1f949aac4effebf",
-      "passes": 3,
+      "at": "2026-04-19T05:30:54Z",
+      "hash": "5d6e622c72c89c082c993ec4667001cb26ac3671",
+      "passes": 4,
       "pr": 17843
     },
     ".agents/scripts/mission-email-helper.sh": {
@@ -2370,9 +2370,9 @@
       "pr": 17584
     },
     ".agents/scripts/opencode-github-setup-helper.sh": {
-      "at": "2026-04-03T03:15:28Z",
-      "hash": "0bc532636c20feb570ba6da3568d3b946c301288",
-      "passes": 1,
+      "at": "2026-04-19T05:30:54Z",
+      "hash": "2c64329a2f22dfc21e43b45c8b570f462f5a1041",
+      "passes": 2,
       "pr": 15918
     },
     ".agents/scripts/platform-detect.sh": {
@@ -2400,9 +2400,9 @@
       "pr": 18657
     },
     ".agents/scripts/pulse-cleanup.sh": {
-      "at": "2026-04-15T02:32:29Z",
-      "hash": "88c7d4f1beba3de5f86421e507fc899b9879a6e6",
-      "passes": 4,
+      "at": "2026-04-19T05:30:54Z",
+      "hash": "7ad09a7f4b01d77b7ef3717affa029687235a029",
+      "passes": 5,
       "pr": 18704
     },
     ".agents/scripts/pulse-dep-graph.sh": {
@@ -2412,9 +2412,9 @@
       "pr": 18796
     },
     ".agents/scripts/pulse-dispatch-core.sh": {
-      "at": "2026-04-16T16:56:58Z",
-      "hash": "92e246c27564e55db18971606fe98d3f951f2e4b",
-      "passes": 8,
+      "at": "2026-04-19T05:30:55Z",
+      "hash": "5b0f14f48045537e5aedc5ba0e141f898d50f6da",
+      "passes": 9,
       "pr": 18832
     },
     ".agents/scripts/pulse-dispatch-engine.sh": {
@@ -2436,15 +2436,15 @@
       "pr": 18691
     },
     ".agents/scripts/pulse-issue-reconcile.sh": {
-      "at": "2026-04-19T02:07:21Z",
-      "hash": "264e80b5bb7fa5ab3006a083e8a71e2f5c4f4a64",
-      "passes": 10,
+      "at": "2026-04-19T05:30:55Z",
+      "hash": "36c87b28b738972c2e82bed9eb5926a141460b26",
+      "passes": 11,
       "pr": 18690
     },
     ".agents/scripts/pulse-merge.sh": {
-      "at": "2026-04-18T19:23:58Z",
-      "hash": "41ab20abd167ef464938f8a599a95566149e94b6",
-      "passes": 15,
+      "at": "2026-04-19T05:30:55Z",
+      "hash": "f5d5e9a21c27d84d0ee85ec8ae0704af7c2f3c43",
+      "passes": 16,
       "pr": 18829
     },
     ".agents/scripts/pulse-prefetch.sh": {
@@ -2478,9 +2478,9 @@
       "pr": 18655
     },
     ".agents/scripts/pulse-wrapper.sh": {
-      "at": "2026-04-18T18:06:35Z",
-      "hash": "cdb7ed591c6db4c4ce2f312124b2483f86d31dbc",
-      "passes": 19,
+      "at": "2026-04-19T05:30:56Z",
+      "hash": "f2d0fa9b4700bb18b65a5bf0ecc649951f58bd32",
+      "passes": 20,
       "pr": 18689
     },
     ".agents/scripts/quality-feedback-findings-lib.sh": {
@@ -2544,9 +2544,9 @@
       "pr": 15916
     },
     ".agents/scripts/shared-constants.sh": {
-      "at": "2026-04-18T19:23:59Z",
-      "hash": "e6b133e8249fe451e1e67eb533d24aaf47004bbc",
-      "passes": 9,
+      "at": "2026-04-19T05:30:57Z",
+      "hash": "fac31bcc446d519b11bdc8c60c518834cf56d1d2",
+      "passes": 10,
       "pr": 18847
     },
     ".agents/scripts/stats-functions.sh": {
@@ -2615,21 +2615,21 @@
       "passes": 1
     },
     ".agents/scripts/worker-lifecycle-common.sh": {
-      "at": "2026-04-18T20:46:28Z",
-      "hash": "0bebff13d3e73369052211898362b0e6c647b97e",
-      "passes": 7,
+      "at": "2026-04-19T05:30:58Z",
+      "hash": "17cd5f52a0c322b8698908d0886b237326f43e7b",
+      "passes": 8,
       "pr": 17353
     },
     ".agents/scripts/worker-watchdog.sh": {
-      "at": "2026-04-18T18:06:36Z",
-      "hash": "7e111f2621d9d1b41f6991bd0e6afdba4782af43",
-      "passes": 5,
+      "at": "2026-04-19T05:30:58Z",
+      "hash": "02fd9b15d344af17fc4e89721aa2c8ff83c68315",
+      "passes": 6,
       "pr": 17393
     },
     ".agents/scripts/worktree-helper.sh": {
-      "at": "2026-04-15T21:02:40Z",
-      "hash": "4d554bea9e09f95a3d4929aa6aadc4c0a9539f29",
-      "passes": 2,
+      "at": "2026-04-19T05:30:58Z",
+      "hash": "3201c79ae20186c574ca49f1e569f13ee71724d9",
+      "passes": 3,
       "pr": 19087
     },
     ".agents/seo.md": {
@@ -7205,9 +7205,9 @@
       "pr": 19047
     },
     ".agents/workflows/git-workflow.md": {
-      "at": "2026-03-29T08:49:32Z",
-      "hash": "8b1c4557393fefcee67608abe5f50936b1a12431",
-      "passes": 1,
+      "at": "2026-04-19T05:31:47Z",
+      "hash": "f6a554a70b7ff221aedaa2e72670072bdd1aa8c8",
+      "passes": 2,
       "pr": 12777
     },
     ".agents/workflows/init-routines.md": {
@@ -7486,15 +7486,15 @@
       "pr": 16415
     },
     "TODO.md": {
-      "at": "2026-04-19T02:07:44Z",
-      "hash": "cf56297e6c74d096f680017bd22bb84e6e2578f0",
-      "passes": 52,
+      "at": "2026-04-19T05:31:49Z",
+      "hash": "0ecb6f4ae942040f1ff39cb10a31d0a84a860a90",
+      "passes": 53,
       "pr": 15490
     },
     "aidevops.sh": {
-      "at": "2026-04-19T00:34:22Z",
-      "hash": "55236ea920af6a41469c46f26053fec425439df5",
-      "passes": 82,
+      "at": "2026-04-19T05:31:49Z",
+      "hash": "a0639651eed9758ad38859c72330fa1b6f0b0d78",
+      "passes": 83,
       "pr": 19029
     },
     "setup-modules/agent-deploy.sh": {
@@ -7504,9 +7504,9 @@
       "pr": 19203
     },
     "setup.sh": {
-      "at": "2026-04-19T00:34:22Z",
-      "hash": "4e2f830062db6a82c4397c9fa71ad90f702ddcb0",
-      "passes": 80,
+      "at": "2026-04-19T05:31:49Z",
+      "hash": "8661cb8a2e0ff9af8449c9133b4b6e42386b0111",
+      "passes": 81,
       "pr": 15470
     },
     "todo/tasks/GH#15363-brief.md": {

--- a/.agents/prompts/build.txt
+++ b/.agents/prompts/build.txt
@@ -287,6 +287,15 @@ Git is the audit trail. Procedures: AGENTS.md "Git Workflow" section.
 # for blocking parallel pulse dispatch on an issue you are working on
 # interactively. Do not skip it; do not assume `origin:interactive` alone is
 # enough (it only marks creation-time origin, not active session ownership).
+#
+# SCOPE LIMITATION (GH#19861): `claim` blocks the pulse's DISPATCH path
+# only. It does NOT block the enrich path (which may overwrite issue
+# title/body/labels), the completion-sweep path (which may strip status
+# labels), or any other non-dispatch pulse operation. If you are
+# investigating a pulse bug or need maximum insulation from all pulse
+# modifications, use `interactive-session-helper.sh lockdown <N> <slug>`
+# instead — it applies `no-auto-dispatch` + `status:in-review` +
+# self-assignment + conversation lock + audit comment.
 - Release is YOUR responsibility, not the user's. When the user signals
   completion ("ship it", "I'm done", "moving on", "let a worker take over"),
   when they switch to a different issue, or when a PR they opened merges,

--- a/.agents/scripts/interactive-session-helper.sh
+++ b/.agents/scripts/interactive-session-helper.sh
@@ -9,6 +9,15 @@
 # so the pulse's dispatch-dedup guard (`dispatch-dedup-helper.sh is-assigned`)
 # will not dispatch a parallel worker.
 #
+# SCOPE LIMITATION (GH#19861):
+#   `claim` blocks the pulse's DISPATCH path only. It does NOT block:
+#   - The enrich path (pulse-enrich.sh) — may overwrite issue title/body/labels
+#   - The completion-sweep path — may strip status labels
+#   - Any other non-dispatch pulse operation that modifies label/title/body state
+#   If you need protection against ALL pulse modifications (e.g., investigating
+#   a pulse bug), use `lockdown` instead — it applies `no-auto-dispatch` +
+#   `status:in-review` + self-assignment + conversation lock + audit comment.
+#
 # Why reuse status:in-review rather than a new label:
 #   - `_has_active_claim` in dispatch-dedup-helper.sh already treats it as an
 #     active claim that blocks dispatch.
@@ -31,6 +40,8 @@
 # Usage:
 #   interactive-session-helper.sh claim <issue> <slug> [--worktree PATH]
 #   interactive-session-helper.sh release <issue> <slug> [--unassign]
+#   interactive-session-helper.sh lockdown <issue> <slug> [--worktree PATH]
+#   interactive-session-helper.sh unlock <issue> <slug> [--unassign]
 #   interactive-session-helper.sh status [<issue>]
 #   interactive-session-helper.sh scan-stale
 #   interactive-session-helper.sh post-merge <pr_number> [<slug>]
@@ -309,6 +320,10 @@ EOF
 # -----------------------------------------------------------------------------
 # Apply status:in-review, self-assign, and write a stamp.
 #
+# SCOPE: blocks pulse DISPATCH only. Does NOT block enrich, completion-sweep,
+# or other non-dispatch pulse operations that modify issue state. For full
+# insulation from all pulse paths, use `lockdown` instead. (GH#19861)
+#
 # Arguments:
 #   $1 = issue number
 #   $2 = repo slug (owner/repo)
@@ -328,13 +343,14 @@ _isc_cmd_claim() {
 
 	# Parse positional + flags
 	while [[ $# -gt 0 ]]; do
-		case "$1" in
+		local arg="$1"
+		case "$arg" in
 		--worktree)
 			worktree_path="${2:-}"
 			shift 2
 			;;
 		--worktree=*)
-			worktree_path="${1#--worktree=}"
+			worktree_path="${arg#--worktree=}"
 			shift
 			;;
 		-h | --help)
@@ -343,11 +359,11 @@ _isc_cmd_claim() {
 			;;
 		*)
 			if [[ -z "$issue" ]]; then
-				issue="$1"
+				issue="$arg"
 			elif [[ -z "$slug" ]]; then
-				slug="$1"
+				slug="$arg"
 			else
-				_isc_warn "unexpected argument: $1 (ignored)"
+				_isc_warn "unexpected argument: $arg (ignored)"
 			fi
 			shift
 			;;
@@ -411,6 +427,219 @@ _isc_cmd_claim() {
 }
 
 # -----------------------------------------------------------------------------
+# Subcommand: lockdown (GH#19861)
+# -----------------------------------------------------------------------------
+# Stricter protection than `claim`. Applies ALL of:
+#   1. `no-auto-dispatch` label — blocks the pulse enrich path from modifying
+#      issue state and prevents any auto-dispatch.
+#   2. `status:in-review` + self-assignment — blocks pulse dispatch (same as claim).
+#   3. GitHub conversation lock — prevents non-collaborator edits.
+#   4. Audit-trail comment — visible marker explaining the lockdown.
+#   5. Crash-recovery stamp — same as claim.
+#
+# Use this when investigating a pulse bug or when you need maximum insulation
+# from ALL pulse operations, not just dispatch.
+#
+# Arguments:
+#   $1 = issue number
+#   $2 = repo slug (owner/repo)
+#   [--worktree PATH] = optional worktree path to record in the stamp
+#
+# Exit: 0 always (warn-and-continue contract).
+_isc_cmd_lockdown() {
+	local issue="" slug="" worktree_path=""
+
+	# Parse positional + flags
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+		--worktree)
+			worktree_path="${2:-}"
+			shift 2
+			;;
+		--worktree=*)
+			worktree_path="${arg#--worktree=}"
+			shift
+			;;
+		-h | --help)
+			_isc_cmd_help
+			return 0
+			;;
+		*)
+			if [[ -z "$issue" ]]; then
+				issue="$arg"
+			elif [[ -z "$slug" ]]; then
+				slug="$arg"
+			else
+				_isc_warn "unexpected argument: $arg (ignored)"
+			fi
+			shift
+			;;
+		esac
+	done
+
+	if [[ -z "$issue" || -z "$slug" ]]; then
+		_isc_err "lockdown: <issue> and <slug> are required"
+		_isc_err "usage: interactive-session-helper.sh lockdown <issue> <slug> [--worktree PATH]"
+		return 2
+	fi
+
+	if [[ ! "$issue" =~ ^[0-9]+$ ]]; then
+		_isc_err "lockdown: <issue> must be numeric (got: $issue)"
+		return 2
+	fi
+
+	# Offline gate
+	if ! _isc_gh_reachable; then
+		_isc_warn "gh offline or not authenticated — skipping lockdown on #$issue ($slug)"
+		return 0
+	fi
+
+	local user
+	user=$(_isc_current_user)
+	if [[ -z "$user" ]]; then
+		_isc_warn "could not resolve gh user login — skipping lockdown on #$issue"
+		return 0
+	fi
+
+	# Step 1: Apply status:in-review + self-assign (same as claim)
+	if set_issue_status "$issue" "$slug" "in-review" --add-assignee "$user" >/dev/null 2>&1; then
+		_isc_info "lockdown: #$issue → status:in-review + assigned $user"
+	else
+		_isc_warn "lockdown: status transition failed on #$issue — continuing"
+	fi
+
+	# Step 2: Apply no-auto-dispatch label (blocks enrich + dispatch paths)
+	if gh issue edit "$issue" --repo "$slug" --add-label "no-auto-dispatch" >/dev/null 2>&1; then
+		_isc_info "lockdown: #$issue → no-auto-dispatch label applied"
+	else
+		_isc_warn "lockdown: could not apply no-auto-dispatch label on #$issue"
+	fi
+
+	# Step 3: Lock the conversation
+	if gh issue lock "$issue" --repo "$slug" --reason "resolved" >/dev/null 2>&1; then
+		_isc_info "lockdown: #$issue → conversation locked"
+	else
+		_isc_warn "lockdown: could not lock conversation on #$issue — continuing"
+	fi
+
+	# Step 4: Write crash-recovery stamp
+	_isc_write_stamp "$issue" "$slug" "$worktree_path" "$user"
+
+	# Step 5: Post audit-trail comment
+	local body
+	# shellcheck disable=SC2016 # backticks are intentional markdown formatting
+	body="$(printf '<!-- lockdown-marker -->\n**Lockdown applied** by `%s` (interactive session).\n\nThis issue is under active human investigation. All pulse operations (dispatch, enrich, completion-sweep) are blocked via `no-auto-dispatch` + `status:in-review` + conversation lock.\n\nTo release: `interactive-session-helper.sh unlock %s %s`' "$user" "$issue" "$slug")"
+	gh issue comment "$issue" --repo "$slug" --body "$body" >/dev/null 2>&1 || {
+		_isc_warn "lockdown: audit comment failed on #$issue — continuing"
+	}
+
+	_isc_info "lockdown: #$issue in $slug fully locked down"
+	return 0
+}
+
+# -----------------------------------------------------------------------------
+# Subcommand: unlock (GH#19861)
+# -----------------------------------------------------------------------------
+# Reverse a lockdown: remove no-auto-dispatch, transition to available,
+# unlock conversation, delete stamp.
+#
+# Arguments:
+#   $1 = issue number
+#   $2 = repo slug (owner/repo)
+#   [--unassign] = also remove self from assignees
+#
+# Exit: 0 always.
+_isc_cmd_unlock() {
+	local issue="" slug="" unassign=0
+
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+		--unassign)
+			unassign=1
+			shift
+			;;
+		-h | --help)
+			_isc_cmd_help
+			return 0
+			;;
+		*)
+			if [[ -z "$issue" ]]; then
+				issue="$arg"
+			elif [[ -z "$slug" ]]; then
+				slug="$arg"
+			else
+				_isc_warn "unexpected argument: $arg (ignored)"
+			fi
+			shift
+			;;
+		esac
+	done
+
+	if [[ -z "$issue" || -z "$slug" ]]; then
+		_isc_err "unlock: <issue> and <slug> are required"
+		return 2
+	fi
+
+	if [[ ! "$issue" =~ ^[0-9]+$ ]]; then
+		_isc_err "unlock: <issue> must be numeric (got: $issue)"
+		return 2
+	fi
+
+	# Delete local stamp regardless of gh state
+	_isc_delete_stamp "$issue" "$slug"
+
+	if ! _isc_gh_reachable; then
+		_isc_warn "gh offline — stamp deleted locally, lockdown unchanged on #$issue"
+		return 0
+	fi
+
+	# Step 1: Unlock conversation
+	if gh issue unlock "$issue" --repo "$slug" >/dev/null 2>&1; then
+		_isc_info "unlock: #$issue → conversation unlocked"
+	else
+		_isc_warn "unlock: could not unlock conversation on #$issue — continuing"
+	fi
+
+	# Step 2: Remove no-auto-dispatch label
+	if gh issue edit "$issue" --repo "$slug" --remove-label "no-auto-dispatch" >/dev/null 2>&1; then
+		_isc_info "unlock: #$issue → no-auto-dispatch label removed"
+	else
+		_isc_warn "unlock: could not remove no-auto-dispatch label on #$issue"
+	fi
+
+	# Step 3: Transition status:in-review -> status:available
+	local -a extra_flags=()
+	if [[ $unassign -eq 1 ]]; then
+		local user
+		user=$(_isc_current_user)
+		if [[ -n "$user" ]]; then
+			extra_flags+=(--remove-assignee "$user")
+		fi
+	fi
+
+	if set_issue_status "$issue" "$slug" "available" ${extra_flags[@]+"${extra_flags[@]}"} >/dev/null 2>&1; then
+		_isc_info "unlock: #$issue → status:available"
+	else
+		_isc_warn "unlock: status transition failed on #$issue"
+	fi
+
+	# Step 4: Post audit comment
+	local user
+	user=$(_isc_current_user) || true
+	local body
+	# shellcheck disable=SC2016 # backticks are intentional markdown formatting
+	body="$(printf '<!-- unlock-marker -->\n**Lockdown released** by `%s`. Issue returned to normal pulse operation.' "${user:-unknown}")"
+	gh issue comment "$issue" --repo "$slug" --body "$body" >/dev/null 2>&1 || {
+		_isc_warn "unlock: audit comment failed on #$issue — continuing"
+	}
+
+	_isc_info "unlock: #$issue in $slug fully unlocked"
+	return 0
+}
+
+# -----------------------------------------------------------------------------
 # Subcommand: release
 # -----------------------------------------------------------------------------
 # Transition status:in-review -> status:available and delete the stamp.
@@ -430,7 +659,8 @@ _isc_cmd_release() {
 	local issue="" slug="" unassign=0
 
 	while [[ $# -gt 0 ]]; do
-		case "$1" in
+		local arg="$1"
+		case "$arg" in
 		--unassign)
 			unassign=1
 			shift
@@ -441,11 +671,11 @@ _isc_cmd_release() {
 			;;
 		*)
 			if [[ -z "$issue" ]]; then
-				issue="$1"
+				issue="$arg"
 			elif [[ -z "$slug" ]]; then
-				slug="$1"
+				slug="$arg"
 			else
-				_isc_warn "unexpected argument: $1 (ignored)"
+				_isc_warn "unexpected argument: $arg (ignored)"
 			fi
 			shift
 			;;
@@ -1034,18 +1264,19 @@ _isc_cmd_post_merge() {
 	local pr_number="" slug=""
 
 	while [[ $# -gt 0 ]]; do
-		case "$1" in
+		local arg="$1"
+		case "$arg" in
 		-h | --help)
 			_isc_cmd_help
 			return 0
 			;;
 		*)
 			if [[ -z "$pr_number" ]]; then
-				pr_number="$1"
+				pr_number="$arg"
 			elif [[ -z "$slug" ]]; then
-				slug="$1"
+				slug="$arg"
 			else
-				_isc_warn "post-merge: unexpected argument: $1 (ignored)"
+				_isc_warn "post-merge: unexpected argument: $arg (ignored)"
 			fi
 			shift
 			;;
@@ -1136,6 +1367,18 @@ USAGE:
       Transition status:in-review → status:available, delete stamp.
       Idempotent. --unassign also removes self from assignees.
 
+  interactive-session-helper.sh lockdown <issue> <slug> [--worktree PATH]
+      Stricter than claim: blocks ALL pulse paths, not just dispatch.
+      Applies: no-auto-dispatch + status:in-review + self-assign +
+      conversation lock + audit comment + crash-recovery stamp.
+      Use when investigating pulse bugs or need maximum insulation.
+      Reverse with: unlock <issue> <slug>
+
+  interactive-session-helper.sh unlock <issue> <slug> [--unassign]
+      Reverse a lockdown: remove no-auto-dispatch, transition to
+      status:available, unlock conversation, delete stamp, post audit.
+      --unassign also removes self from assignees.
+
   interactive-session-helper.sh status [<issue>]
       List active claims from the stamp directory, or check one issue.
 
@@ -1172,6 +1415,10 @@ CONTRACT:
   ownership"). Users should never need to invoke it directly — the agent
   claims on engage and releases on signal.
 
+  SCOPE: `claim` blocks pulse DISPATCH only (GH#19861). It does NOT block
+  enrich, completion-sweep, or other non-dispatch pulse operations. For full
+  insulation from all pulse paths, use `lockdown` instead.
+
   Slug format: owner/repo (e.g., marcusquinn/aidevops).
 
 STAMP DIRECTORY:
@@ -1197,6 +1444,12 @@ main() {
 	case "$cmd" in
 	claim)
 		_isc_cmd_claim "$@" || rc=$?
+		;;
+	lockdown)
+		_isc_cmd_lockdown "$@" || rc=$?
+		;;
+	unlock)
+		_isc_cmd_unlock "$@" || rc=$?
 		;;
 	release)
 		_isc_cmd_release "$@" || rc=$?


### PR DESCRIPTION
## Summary

- Document that `interactive-session-helper.sh claim` blocks pulse **dispatch** only, not enrich/completion-sweep/other pulse operations (GH#19861)
- Add `lockdown` subcommand for full pulse insulation: `no-auto-dispatch` + `status:in-review` + self-assignment + conversation lock + audit comment
- Add `unlock` subcommand to reverse lockdown
- Update `prompts/build.txt` and `.agents/AGENTS.md` "Interactive issue ownership" sections with scope caveat
- Fix direct `$1` positional parameter usage in all arg parsers (pre-existing debt)

## Testing

- `shellcheck --severity=warning .agents/scripts/interactive-session-helper.sh` — clean
- Pre-commit hook passes (all quality checks green)
- Help text verified: `bash .agents/scripts/interactive-session-helper.sh help` shows lockdown/unlock entries

Resolves #19861


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.74 plugin for [OpenCode](https://opencode.ai) v1.14.17 with claude-opus-4-6 spent 13m and 23,660 tokens on this as a headless worker.