### PR TITLE
t2367: feat(pre-dispatch-validator): re-measure scanner-cited files before worker dispatch

### DIFF
--- a/.agents/scripts/pre-dispatch-validator-helper.sh
+++ b/.agents/scripts/pre-dispatch-validator-helper.sh
@@ -56,6 +56,8 @@ declare -A _VALIDATOR_REGISTRY=()
 
 _register_validators() {
 	_VALIDATOR_REGISTRY["ratchet-down"]="_validator_ratchet_down"
+	_VALIDATOR_REGISTRY["large-file-simplification-gate"]="_validator_large_file_simplification_gate"
+	_VALIDATOR_REGISTRY["function-complexity-gate"]="_validator_function_complexity_gate"
 	return 0
 }
 
@@ -110,6 +112,107 @@ _validator_ratchet_down() {
 }
 
 # ---------------------------------------------------------------------------
+# Large-file simplification gate validator (t2367)
+#
+# Re-measures the cited file against current HEAD. If the file is now below
+# the threshold, the premise is falsified — the debt was resolved before the
+# worker could be dispatched.
+#
+# Expects CITED_FILE and CITED_THRESHOLD to be set by cmd_validate() after
+# parsing the marker attributes.
+# ---------------------------------------------------------------------------
+_validator_large_file_simplification_gate() {
+	local slug="$1"
+
+	if [[ -z "${CITED_FILE:-}" || -z "${CITED_THRESHOLD:-}" ]]; then
+		_log "WARN" "large-file-simplification-gate validator: missing cited_file or threshold in marker"
+		return 20
+	fi
+
+	_log "INFO" "large-file-simplification-gate validator: re-measuring ${CITED_FILE} (threshold=${CITED_THRESHOLD})"
+
+	# Clone repo into scratch dir for a fresh read against HEAD
+	local clone_url
+	clone_url="https://github.com/${slug}.git"
+
+	if ! git clone --depth 1 --quiet "$clone_url" "${SCRATCH_DIR}/repo" 2>/dev/null; then
+		_log "WARN" "large-file-simplification-gate validator: git clone failed for ${slug}"
+		return 20
+	fi
+
+	local target_file="${SCRATCH_DIR}/repo/${CITED_FILE}"
+	if [[ ! -f "$target_file" ]]; then
+		_log "INFO" "large-file-simplification-gate validator: file ${CITED_FILE} no longer exists — premise falsified"
+		VALIDATOR_RATIONALE="File \`${CITED_FILE}\` no longer exists on HEAD. Premise falsified. Not dispatching."
+		return 10
+	fi
+
+	local line_count
+	line_count=$(wc -l < "$target_file" 2>/dev/null | tr -d ' ') || line_count=0
+
+	if [[ "$line_count" -lt "$CITED_THRESHOLD" ]]; then
+		_log "INFO" "large-file-simplification-gate validator: ${CITED_FILE} is now ${line_count} lines (threshold ${CITED_THRESHOLD}) — premise falsified"
+		VALIDATOR_RATIONALE="File \`${CITED_FILE}\` is now ${line_count} lines, below the ${CITED_THRESHOLD}-line threshold. Premise falsified. Not dispatching."
+		return 10
+	fi
+
+	_log "INFO" "large-file-simplification-gate validator: ${CITED_FILE} is still ${line_count} lines (threshold ${CITED_THRESHOLD}) — premise holds"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Function-complexity gate validator (t2367)
+#
+# Re-measures function complexity in the cited file. If no functions exceed
+# the threshold, the premise is falsified.
+#
+# Expects CITED_FILE and CITED_THRESHOLD to be set by cmd_validate().
+# ---------------------------------------------------------------------------
+_validator_function_complexity_gate() {
+	local slug="$1"
+
+	if [[ -z "${CITED_FILE:-}" || -z "${CITED_THRESHOLD:-}" ]]; then
+		_log "WARN" "function-complexity-gate validator: missing cited_file or threshold in marker"
+		return 20
+	fi
+
+	_log "INFO" "function-complexity-gate validator: re-measuring ${CITED_FILE} (threshold=${CITED_THRESHOLD})"
+
+	# Clone repo into scratch dir for a fresh read against HEAD
+	local clone_url
+	clone_url="https://github.com/${slug}.git"
+
+	if ! git clone --depth 1 --quiet "$clone_url" "${SCRATCH_DIR}/repo" 2>/dev/null; then
+		_log "WARN" "function-complexity-gate validator: git clone failed for ${slug}"
+		return 20
+	fi
+
+	local target_file="${SCRATCH_DIR}/repo/${CITED_FILE}"
+	if [[ ! -f "$target_file" ]]; then
+		_log "INFO" "function-complexity-gate validator: file ${CITED_FILE} no longer exists — premise falsified"
+		VALIDATOR_RATIONALE="File \`${CITED_FILE}\` no longer exists on HEAD. Premise falsified. Not dispatching."
+		return 10
+	fi
+
+	# Count functions exceeding the threshold (same awk as complexity-scan-helper.sh)
+	local violation_count
+	violation_count=$(awk -v threshold="$CITED_THRESHOLD" '
+		/^[a-zA-Z_][a-zA-Z0-9_]*\(\)[[:space:]]*\{/ { fname=$1; sub(/\(\)/, "", fname); start=NR; next }
+		fname && /^\}$/ { lines=NR-start; if(lines+0>threshold+0) count++; fname="" }
+		END { print count+0 }
+	' "$target_file" 2>/dev/null) || violation_count=0
+
+	if [[ "$violation_count" -eq 0 ]]; then
+		_log "INFO" "function-complexity-gate validator: no functions exceed ${CITED_THRESHOLD} lines in ${CITED_FILE} — premise falsified"
+		VALIDATOR_RATIONALE="File \`${CITED_FILE}\` has 0 functions exceeding ${CITED_THRESHOLD} lines on HEAD. Premise falsified. Not dispatching."
+		return 10
+	fi
+
+	_log "INFO" "function-complexity-gate validator: ${violation_count} function(s) still exceed ${CITED_THRESHOLD} lines in ${CITED_FILE} — premise holds"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
 # Compose and post the falsified-premise closure comment, then close the issue.
 # ---------------------------------------------------------------------------
 _close_with_rationale() {
@@ -122,12 +225,15 @@ _close_with_rationale() {
 		sig_footer=$("${SCRIPT_DIR}/gh-signature-helper.sh" footer --issue "${slug}#${issue_number}" 2>/dev/null || true)
 	fi
 
+	# Use specific validator rationale if available, otherwise generic message
+	local rationale_detail="${VALIDATOR_RATIONALE:-The \`${generator}\` check reports no actionable work is available.}"
+
 	local comment_body
 	comment_body=$(
 		cat <<EOF
-> Premise falsified. Pre-dispatch validator for generator \`${generator}\` determined the issue premise is no longer true. The \`${generator}\` check reports no actionable work is available. Not dispatching a worker.
+> Premise falsified. Pre-dispatch validator for generator \`${generator}\` determined the issue premise is no longer true. ${rationale_detail} Not dispatching a worker.
 
-The issue was closed automatically by the pre-dispatch validator (GH#19118). If conditions change and ratchet-down proposals become available again, a new issue will be created by the next pulse cycle.
+The issue was closed automatically by the pre-dispatch validator (GH#19118, t2367). If conditions change, a new issue will be created by the next pulse cycle.
 
 ${sig_footer}
 EOF
@@ -179,17 +285,25 @@ cmd_validate() {
 		return 20
 	}
 
-	# Extract generator marker
+	# Extract generator marker (supports both simple and attributed forms):
+	#   <!-- aidevops:generator=<name> -->
+	#   <!-- aidevops:generator=<name> cited_file=<path> threshold=<N> -->
+	local generator_line
+	generator_line=$(printf '%s' "$issue_body" | grep -oE '<!-- aidevops:generator=[a-z0-9_-]+[^>]*-->' | head -1) || generator_line=""
+
 	local generator
-	generator=$(printf '%s' "$issue_body" | grep -oE '<!-- aidevops:generator=[a-z-]+ -->' | head -1 |
-		sed 's/<!-- aidevops:generator=//;s/ -->//' 2>/dev/null) || generator=""
+	generator=$(printf '%s' "$generator_line" | sed 's/<!-- aidevops:generator=//;s/ .*//' 2>/dev/null) || generator=""
 
 	if [[ -z "$generator" ]]; then
 		_log "INFO" "#${issue_number}: no generator marker found — unregistered generator, dispatch proceeds"
 		return 0
 	fi
 
-	_log "INFO" "#${issue_number}: generator=${generator}"
+	# Extract optional attributes: cited_file and threshold
+	CITED_FILE=$(printf '%s' "$generator_line" | grep -oE 'cited_file=[^ >]+' | sed 's/cited_file=//' 2>/dev/null) || CITED_FILE=""
+	CITED_THRESHOLD=$(printf '%s' "$generator_line" | grep -oE 'threshold=[0-9]+' | sed 's/threshold=//' 2>/dev/null) || CITED_THRESHOLD=""
+
+	_log "INFO" "#${issue_number}: generator=${generator} cited_file=${CITED_FILE:-<none>} threshold=${CITED_THRESHOLD:-<none>}"
 
 	# Look up validator
 	_register_validators
@@ -207,7 +321,9 @@ cmd_validate() {
 	# shellcheck disable=SC2064
 	trap "rm -rf '${SCRATCH_DIR}'" EXIT
 
-	# Run validator
+	# Run validator (VALIDATOR_RATIONALE may be set by the validator for
+	# specific evidence in the closure comment)
+	VALIDATOR_RATIONALE=""
 	local validator_rc=0
 	"$validator_fn" "$slug" || validator_rc=$?
 

--- a/.agents/scripts/pulse-dispatch-large-file-gate.sh
+++ b/.agents/scripts/pulse-dispatch-large-file-gate.sh
@@ -436,7 +436,9 @@ _large_file_gate_file_new_debt_issue() {
 		--force 2>/dev/null || true
 
 	local _new_num _create_body _create_combined
-	_create_body="## What
+	_create_body="<!-- aidevops:generator=large-file-simplification-gate cited_file=${lf_path} threshold=${LARGE_FILE_LINE_THRESHOLD} -->
+
+## What
 Simplify \`${lf_path}\` — currently over ${LARGE_FILE_LINE_THRESHOLD} lines. Break into smaller, focused modules.
 
 ## Why

--- a/.agents/scripts/pulse-simplification.sh
+++ b/.agents/scripts/pulse-simplification.sh
@@ -1065,7 +1065,9 @@ _complexity_scan_sh_build_issue_body_with_sig() {
 	local details="$3"
 
 	local issue_body
-	issue_body="## Complexity scan finding (automated, GH#5628)
+	issue_body="<!-- aidevops:generator=function-complexity-gate cited_file=${file_path} threshold=${COMPLEXITY_FUNC_LINE_THRESHOLD} -->
+
+## Complexity scan finding (automated, GH#5628)
 
 **File:** \`${file_path}\`
 **Violations:** ${violation_count} functions exceed ${COMPLEXITY_FUNC_LINE_THRESHOLD} lines

--- a/.agents/scripts/tests/test-pre-dispatch-validator-large-file.sh
+++ b/.agents/scripts/tests/test-pre-dispatch-validator-large-file.sh
@@ -1,0 +1,355 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-pre-dispatch-validator-large-file.sh — Test harness for large-file and
+# function-complexity pre-dispatch validators (t2367, GH#19823)
+#
+# Tests:
+#   test_large_file_premise_falsified       — file under threshold → exit 10
+#   test_large_file_premise_holds           — file over threshold → exit 0
+#   test_large_file_deleted                 — file no longer exists → exit 10
+#   test_function_complexity_falsified      — no violations remain → exit 10
+#   test_function_complexity_holds          — violations still present → exit 0
+#   test_missing_attributes                 — marker without attributes → exit 20
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+HELPER_SCRIPT="${SCRIPT_DIR}/../pre-dispatch-validator-helper.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+
+# ---------------------------------------------------------------------------
+# Test framework helpers
+# ---------------------------------------------------------------------------
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+	mkdir -p "${TEST_ROOT}/bin"
+	export PATH="${TEST_ROOT}/bin:${PATH}"
+	return 0
+}
+
+teardown_test_env() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Stub factories
+# ---------------------------------------------------------------------------
+
+# Create a `gh` stub that returns a body from a file (supports --jq).
+create_gh_stub_with_body_file() {
+	local body_file="$1"
+
+	cat >"${TEST_ROOT}/bin/gh" <<GHEOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+# gh api repos/<slug>/issues/<num> with --jq '.body // ""'
+if [[ "\${1:-}" == "api" ]] && printf '%s' "\${2:-}" | grep -qE '/issues/[0-9]+\$'; then
+	body_file="${body_file}"
+	python3 -c "
+import sys
+body = open('${body_file}').read()
+sys.stdout.write(body)
+" 2>/dev/null
+	exit 0
+fi
+
+# gh issue comment / gh issue close / gh label create — succeed silently
+if [[ "\${1:-}" == "issue" || "\${1:-}" == "label" ]]; then
+	exit 0
+fi
+
+printf 'unsupported gh invocation: %s\n' "\$*" >&2
+exit 1
+GHEOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+	return 0
+}
+
+# Create a `git` stub that clones a fake repo with a specific file.
+# Arguments:
+#   $1 - mode: "success" or "fail"
+#   $2 - optional file path to create in cloned dir
+#   $3 - optional file content
+create_git_stub_with_file() {
+	local mode="${1:-success}"
+	local file_path="${2:-}"
+	local file_content="${3:-}"
+
+	# Write file content to a temp file the stub can read
+	local content_file="${TEST_ROOT}/stub_file_content.txt"
+	printf '%s' "$file_content" >"$content_file"
+
+	cat >"${TEST_ROOT}/bin/git" <<GITEOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "\${1:-}" == "clone" ]]; then
+	_target=""
+	for _arg in "\$@"; do
+		[[ "\$_arg" == --* ]] && continue
+		_target="\$_arg"
+	done
+	if [[ "${mode}" == "success" ]]; then
+		mkdir -p "\$_target"
+		_file_path="${file_path}"
+		if [[ -n "\$_file_path" ]]; then
+			mkdir -p "\$(dirname "\${_target}/\${_file_path}")"
+			cat "${content_file}" > "\${_target}/\${_file_path}"
+		fi
+		exit 0
+	else
+		printf 'fatal: repository not found\n' >&2
+		exit 128
+	fi
+fi
+
+# Pass-through for other git commands
+/usr/bin/git "\$@"
+GITEOF
+	chmod +x "${TEST_ROOT}/bin/git"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+# test_large_file_premise_falsified — file is now UNDER threshold
+# Expected: validator exits 10 (premise falsified)
+test_large_file_premise_falsified() {
+	setup_test_env
+
+	# Issue body with marker: file threshold=100
+	local body_file="${TEST_ROOT}/issue_body.txt"
+	printf '<!-- aidevops:generator=large-file-simplification-gate cited_file=.agents/scripts/big-file.sh threshold=100 -->\n## What\nSimplify big-file.sh\n' >"$body_file"
+	create_gh_stub_with_body_file "$body_file"
+
+	# Create git stub that produces a file with 50 lines (under threshold of 100)
+	local file_content=""
+	local i
+	for i in $(seq 1 50); do
+		file_content="${file_content}echo line${i}\n"
+	done
+	create_git_stub_with_file "success" ".agents/scripts/big-file.sh" "$(printf '%b' "$file_content")"
+
+	local rc=0
+	"$HELPER_SCRIPT" validate "100" "marcusquinn/aidevops" >/dev/null 2>&1 || rc=$?
+
+	if [[ "$rc" -eq 10 ]]; then
+		print_result "large_file_premise_falsified exits 10" 0
+	else
+		print_result "large_file_premise_falsified exits 10" 1 "Expected exit 10, got ${rc}"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
+# test_large_file_premise_holds — file is still OVER threshold
+# Expected: validator exits 0 (dispatch proceeds)
+test_large_file_premise_holds() {
+	setup_test_env
+
+	local body_file="${TEST_ROOT}/issue_body.txt"
+	printf '<!-- aidevops:generator=large-file-simplification-gate cited_file=.agents/scripts/big-file.sh threshold=100 -->\n## What\nSimplify big-file.sh\n' >"$body_file"
+	create_gh_stub_with_body_file "$body_file"
+
+	# Create git stub that produces a file with 150 lines (over threshold of 100)
+	local file_content=""
+	local i
+	for i in $(seq 1 150); do
+		file_content="${file_content}echo line${i}\n"
+	done
+	create_git_stub_with_file "success" ".agents/scripts/big-file.sh" "$(printf '%b' "$file_content")"
+
+	local rc=0
+	"$HELPER_SCRIPT" validate "101" "marcusquinn/aidevops" >/dev/null 2>&1 || rc=$?
+
+	if [[ "$rc" -eq 0 ]]; then
+		print_result "large_file_premise_holds exits 0" 0
+	else
+		print_result "large_file_premise_holds exits 0" 1 "Expected exit 0, got ${rc}"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
+# test_large_file_deleted — file no longer exists on HEAD
+# Expected: validator exits 10 (premise falsified — file gone)
+test_large_file_deleted() {
+	setup_test_env
+
+	local body_file="${TEST_ROOT}/issue_body.txt"
+	printf '<!-- aidevops:generator=large-file-simplification-gate cited_file=.agents/scripts/deleted-file.sh threshold=100 -->\n## What\nSimplify deleted-file.sh\n' >"$body_file"
+	create_gh_stub_with_body_file "$body_file"
+
+	# Git stub creates repo but without the cited file
+	create_git_stub_with_file "success" "" ""
+
+	local rc=0
+	"$HELPER_SCRIPT" validate "102" "marcusquinn/aidevops" >/dev/null 2>&1 || rc=$?
+
+	if [[ "$rc" -eq 10 ]]; then
+		print_result "large_file_deleted exits 10" 0
+	else
+		print_result "large_file_deleted exits 10" 1 "Expected exit 10, got ${rc}"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
+# test_function_complexity_falsified — no functions exceed threshold
+# Expected: validator exits 10 (premise falsified)
+test_function_complexity_falsified() {
+	setup_test_env
+
+	local body_file="${TEST_ROOT}/issue_body.txt"
+	printf '<!-- aidevops:generator=function-complexity-gate cited_file=.agents/scripts/simple.sh threshold=50 -->\n## Complexity finding\n' >"$body_file"
+	create_gh_stub_with_body_file "$body_file"
+
+	# Create a file with only short functions (under 50 lines each)
+	local file_content='#!/usr/bin/env bash
+short_func() {
+	echo "line1"
+	echo "line2"
+	echo "line3"
+}
+
+another_short() {
+	echo "hello"
+}
+'
+	create_git_stub_with_file "success" ".agents/scripts/simple.sh" "$file_content"
+
+	local rc=0
+	"$HELPER_SCRIPT" validate "103" "marcusquinn/aidevops" >/dev/null 2>&1 || rc=$?
+
+	if [[ "$rc" -eq 10 ]]; then
+		print_result "function_complexity_falsified exits 10" 0
+	else
+		print_result "function_complexity_falsified exits 10" 1 "Expected exit 10, got ${rc}"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
+# test_function_complexity_holds — functions still exceed threshold
+# Expected: validator exits 0 (dispatch proceeds)
+test_function_complexity_holds() {
+	setup_test_env
+
+	local body_file="${TEST_ROOT}/issue_body.txt"
+	printf '<!-- aidevops:generator=function-complexity-gate cited_file=.agents/scripts/complex.sh threshold=5 -->\n## Complexity finding\n' >"$body_file"
+	create_gh_stub_with_body_file "$body_file"
+
+	# Create a file with a function exceeding 5 lines
+	local file_content='#!/usr/bin/env bash
+big_func() {
+	echo "line1"
+	echo "line2"
+	echo "line3"
+	echo "line4"
+	echo "line5"
+	echo "line6"
+	echo "line7"
+}
+'
+	create_git_stub_with_file "success" ".agents/scripts/complex.sh" "$file_content"
+
+	local rc=0
+	"$HELPER_SCRIPT" validate "104" "marcusquinn/aidevops" >/dev/null 2>&1 || rc=$?
+
+	if [[ "$rc" -eq 0 ]]; then
+		print_result "function_complexity_holds exits 0" 0
+	else
+		print_result "function_complexity_holds exits 0" 1 "Expected exit 0, got ${rc}"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
+# test_missing_attributes — marker present but without cited_file/threshold
+# Expected: validator exits 20 (validator error — missing attributes)
+test_missing_attributes() {
+	setup_test_env
+
+	local body_file="${TEST_ROOT}/issue_body.txt"
+	printf '<!-- aidevops:generator=large-file-simplification-gate -->\n## What\nSimplify something\n' >"$body_file"
+	create_gh_stub_with_body_file "$body_file"
+
+	local rc=0
+	"$HELPER_SCRIPT" validate "105" "marcusquinn/aidevops" >/dev/null 2>&1 || rc=$?
+
+	if [[ "$rc" -eq 20 ]]; then
+		print_result "missing_attributes exits 20" 0
+	else
+		print_result "missing_attributes exits 20" 1 "Expected exit 20, got ${rc}"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+	printf 'Running pre-dispatch-validator large-file/complexity tests (t2367, GH#19823)...\n\n'
+
+	if [[ ! -x "$HELPER_SCRIPT" ]]; then
+		printf '%bERROR%b: Helper script not found or not executable: %s\n' \
+			"$TEST_RED" "$TEST_RESET" "$HELPER_SCRIPT" >&2
+		exit 1
+	fi
+
+	test_large_file_premise_falsified
+	test_large_file_premise_holds
+	test_large_file_deleted
+	test_function_complexity_falsified
+	test_function_complexity_holds
+	test_missing_attributes
+
+	printf '\n%d test(s) run, %d failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		exit 1
+	fi
+	exit 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Scanner gates (`pulse-dispatch-large-file-gate.sh`, `pulse-simplification.sh`) now emit `<!-- aidevops:generator=<name> cited_file=<path> threshold=<N> -->` markers in the issue body when creating file-size-debt and function-complexity-debt issues
- Two new validators registered in `pre-dispatch-validator-helper.sh` re-measure the cited file against HEAD before dispatching a worker
- Auto-closes issues whose premise has been falsified: file under threshold, file deleted, or no function violations remain
- Closure comment includes specific measurement evidence (e.g. "File X is now Y lines, below the Z-line threshold")
- Updated marker regex to parse attributed form (`cited_file=`, `threshold=`) alongside the existing simple form

## Files Changed

- **EDIT:** `.agents/scripts/pulse-dispatch-large-file-gate.sh` — added generator marker to file-size-debt issue body
- **EDIT:** `.agents/scripts/pulse-simplification.sh` — added generator marker to function-complexity-debt issue body
- **EDIT:** `.agents/scripts/pre-dispatch-validator-helper.sh` — updated regex, added two validators, registered them, enhanced closure rationale
- **NEW:** `.agents/scripts/tests/test-pre-dispatch-validator-large-file.sh` — 6 regression tests

## Testing

- 6 new tests pass: premise-falsified (under threshold), premise-holds (over threshold), file-deleted, function-complexity-falsified, function-complexity-holds, missing-attributes
- 5 existing pre-dispatch-validator tests pass (no regression)
- ShellCheck clean on all 4 files

Resolves #19823