### PR TITLE
t2374: feat(security): add SYNC_PAT detection to aidevops security check

### DIFF
--- a/.agents/scripts/security-posture-helper.sh
+++ b/.agents/scripts/security-posture-helper.sh
@@ -65,6 +65,7 @@ readonly CAT_REVIEW_BOT_GATE="review_bot_gate"
 readonly CAT_DEPENDENCIES="dependencies"
 readonly CAT_COLLABORATORS="collaborators"
 readonly CAT_REPO_SECURITY="repo_security"
+readonly CAT_SYNC_PAT="sync_pat"
 
 # Counters
 FINDINGS_CRITICAL=0
@@ -75,24 +76,28 @@ FINDINGS_PASS=0
 # Collected findings for JSON output
 FINDINGS_JSON="[]"
 
-print_info() { echo -e "${BLUE}[INFO]${NC} $1"; }
+print_info() { local msg="$1"; echo -e "${BLUE}[INFO]${NC} $msg"; }
 print_pass() {
-	echo -e "${GREEN}[PASS]${NC} $1"
+	local msg="$1"
+	echo -e "${GREEN}[PASS]${NC} $msg"
 	((++FINDINGS_PASS))
 }
 print_warn() {
-	echo -e "${YELLOW}[WARN]${NC} $1"
+	local msg="$1"
+	echo -e "${YELLOW}[WARN]${NC} $msg"
 	((++FINDINGS_WARNING))
 }
 print_crit() {
-	echo -e "${RED}[CRIT]${NC} $1"
+	local msg="$1"
+	echo -e "${RED}[CRIT]${NC} $msg"
 	((++FINDINGS_CRITICAL))
 }
 print_skip() {
-	echo -e "${CYAN}[SKIP]${NC} $1"
+	local msg="$1"
+	echo -e "${CYAN}[SKIP]${NC} $msg"
 	((++FINDINGS_INFO))
 }
-print_header() { echo -e "\n${BOLD}${CYAN}$1${NC}"; }
+print_header() { local msg="$1"; echo -e "\n${BOLD}${CYAN}$msg${NC}"; }
 
 # Add a finding to the JSON array
 # Usage: add_finding <severity> <category> <message>
@@ -609,6 +614,176 @@ check_repo_security() {
 	return 0
 }
 
+# Phase 7: SYNC_PAT detection helpers (t2374)
+
+# Emit a SYNC_PAT advisory file for a repo that needs it.
+# Usage: _emit_sync_pat_advisory <slug> <slug_sanitised> <advisory_file> <required_reviews>
+_emit_sync_pat_advisory() {
+	local slug="$1"
+	local slug_sanitised="$2"
+	local advisory_file="$3"
+	local required_reviews="$4"
+
+	local advisory_dir
+	advisory_dir="$(dirname "$advisory_file")"
+	mkdir -p "$advisory_dir"
+
+	cat >"$advisory_file" <<ADVISORY_EOF
+[ADVISORY] SYNC_PAT not set for ${slug}
+
+This repo uses issue-sync.yml + branch protection requiring ${required_reviews} approving review(s).
+Without SYNC_PAT, TODO.md auto-completion silently fails on PR merge
+(github-actions[bot] cannot push to a branch-protected default branch).
+
+To fix (run in a separate terminal, NOT in AI chat):
+
+1. Create a fine-grained PAT in GitHub UI:
+   Settings > Developer settings > Personal access tokens > Fine-grained
+   > Only selected repositories > ${slug}
+   > Contents: Read and write
+
+2. Set the secret:
+   gh secret set SYNC_PAT --repo ${slug}
+   (interactive prompt — safer than --body which lands in shell history)
+
+Verify:
+   gh secret list --repo ${slug} | grep SYNC_PAT
+
+Dismiss once fixed:
+   aidevops security dismiss sync-pat-${slug_sanitised}
+
+See AGENTS.md "Known limitation — issue-sync TODO auto-completion" for background.
+ADVISORY_EOF
+
+	print_info "  Advisory written to: $advisory_file"
+	return 0
+}
+
+# Check whether a repo requires SYNC_PAT based on workflow + branch protection.
+# Returns via stdout: "needed" | "not_needed" | "skip"
+# Side effect: prints findings and cleans stale advisories.
+# Usage: _check_sync_pat_need <repo_path> <slug> <advisory_file>
+_check_sync_pat_need() {
+	local repo_path="$1"
+	local slug="$2"
+	local advisory_file="$3"
+
+	# Step 1: Does the repo use issue-sync.yml?
+	if ! gh api "repos/${slug}/contents/.github/workflows/issue-sync.yml" &>/dev/null 2>&1; then
+		print_pass "No issue-sync.yml — SYNC_PAT not needed for $slug"
+		add_finding "$SEVERITY_PASS" "$CAT_SYNC_PAT" "No issue-sync.yml in $slug"
+		[[ -f "$advisory_file" ]] && rm -f "$advisory_file"
+		echo "not_needed"
+		return 0
+	fi
+
+	# Step 2: Does the repo have branch protection requiring PR reviews?
+	local default_branch
+	default_branch=$(git -C "$repo_path" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||') || true
+	default_branch="${default_branch:-main}"
+
+	local protection_json
+	protection_json=$(gh api "repos/${slug}/branches/${default_branch}/protection" 2>/dev/null) || true
+
+	if [[ -z "$protection_json" || "$protection_json" == *"Not Found"* || "$protection_json" == *"Branch not protected"* ]]; then
+		print_pass "No branch protection — SYNC_PAT not needed for $slug"
+		add_finding "$SEVERITY_PASS" "$CAT_SYNC_PAT" "No branch protection in $slug"
+		[[ -f "$advisory_file" ]] && rm -f "$advisory_file"
+		echo "not_needed"
+		return 0
+	fi
+
+	local required_reviews
+	required_reviews=$(echo "$protection_json" | jq -r '.required_pull_request_reviews.required_approving_review_count // 0' 2>/dev/null) || required_reviews="0"
+
+	if [[ "$required_reviews" -eq 0 ]]; then
+		print_pass "PR reviews not required — SYNC_PAT not needed for $slug"
+		add_finding "$SEVERITY_PASS" "$CAT_SYNC_PAT" "No review requirement in $slug"
+		[[ -f "$advisory_file" ]] && rm -f "$advisory_file"
+		echo "not_needed"
+		return 0
+	fi
+
+	# Step 3: Is SYNC_PAT set?
+	local secret_check
+	secret_check=$(gh secret list --repo "$slug" --json name -q '.[] | select(.name == "SYNC_PAT") | .name' 2>/dev/null) || true
+
+	if [[ -n "$secret_check" ]]; then
+		print_pass "SYNC_PAT is set for $slug"
+		add_finding "$SEVERITY_PASS" "$CAT_SYNC_PAT" "SYNC_PAT set for $slug"
+		[[ -f "$advisory_file" ]] && rm -f "$advisory_file"
+		echo "not_needed"
+		return 0
+	fi
+
+	# Needs SYNC_PAT — return the required_reviews count for advisory
+	echo "needed:${required_reviews}"
+	return 0
+}
+
+# Phase 7: Check SYNC_PAT secret for repos using issue-sync.yml (t2374)
+# Detects repos that need SYNC_PAT but don't have it set, and emits
+# per-repo advisories via ~/.aidevops/advisories/sync-pat-<slug>.advisory.
+check_sync_pat() {
+	local repo_path="$1"
+
+	print_header "Phase 7: SYNC_PAT Detection (issue-sync)"
+
+	# Need gh CLI
+	if ! command -v gh &>/dev/null; then
+		print_skip "GitHub CLI (gh) not installed — cannot check SYNC_PAT"
+		add_finding "$SEVERITY_INFO" "$CAT_SYNC_PAT" "gh CLI not available"
+		return 0
+	fi
+
+	# Need authenticated gh — fail open on auth failure
+	if ! gh auth status &>/dev/null 2>&1; then
+		print_skip "gh not authenticated — SYNC_PAT check skipped"
+		add_finding "$SEVERITY_INFO" "$CAT_SYNC_PAT" "gh not authenticated"
+		return 0
+	fi
+
+	local slug
+	if ! slug=$(resolve_slug "$repo_path"); then
+		print_skip "No GitHub remote — SYNC_PAT check skipped"
+		add_finding "$SEVERITY_INFO" "$CAT_SYNC_PAT" "No GitHub remote"
+		return 0
+	fi
+
+	local slug_sanitised
+	slug_sanitised="${slug//\//-}"
+
+	local advisory_dir="$HOME/.aidevops/advisories"
+	local advisory_file="$advisory_dir/sync-pat-${slug_sanitised}.advisory"
+	local dismissed_file="$advisory_dir/.dismissed-sync-pat-${slug_sanitised}"
+
+	# If already dismissed, skip silently
+	if [[ -f "$dismissed_file" ]]; then
+		print_pass "SYNC_PAT advisory dismissed for $slug"
+		add_finding "$SEVERITY_PASS" "$CAT_SYNC_PAT" "Advisory dismissed for $slug"
+		return 0
+	fi
+
+	# Check need via helper
+	local need_result
+	need_result=$(_check_sync_pat_need "$repo_path" "$slug" "$advisory_file")
+
+	if [[ "$need_result" == "not_needed" ]]; then
+		return 0
+	fi
+
+	# Extract required_reviews count from "needed:<N>" result
+	local required_reviews
+	required_reviews="${need_result#needed:}"
+
+	print_warn "SYNC_PAT not set for $slug — TODO.md auto-completion will silently fail on PR merge"
+	add_finding "$SEVERITY_WARNING" "$CAT_SYNC_PAT" "SYNC_PAT not set for $slug"
+
+	_emit_sync_pat_advisory "$slug" "$slug_sanitised" "$advisory_file" "$required_reviews"
+
+	return 0
+}
+
 # Store security posture in .aidevops.json
 store_posture() {
 	local repo_path="$1"
@@ -755,6 +930,7 @@ run_all_checks() {
 	check_dependencies "$repo_path"
 	check_collaborators "$repo_path"
 	check_repo_security "$repo_path"
+	check_sync_pat "$repo_path"
 	print_report
 
 	return 0
@@ -1334,6 +1510,7 @@ Per-repo checks (check/audit/store):
   4. Dependency vulnerabilities (npm/pip/cargo audit)
   5. Collaborator access levels (per-repo, never cached)
   6. Repository security basics (SECURITY.md, .gitignore, secrets)
+  7. SYNC_PAT detection for repos using issue-sync.yml (t2374)
 
 User-level checks (startup-check/setup/status):
   1. Prompt injection patterns (YAML file present and <30d old)

--- a/.agents/scripts/tests/test-sync-pat-detection.sh
+++ b/.agents/scripts/tests/test-sync-pat-detection.sh
@@ -1,0 +1,382 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-sync-pat-detection.sh — t2374 regression guard.
+#
+# Verifies check_sync_pat() in security-posture-helper.sh correctly detects
+# repos that need SYNC_PAT but don't have it set, and skips repos where
+# SYNC_PAT is not needed.
+#
+# Six test cases:
+#   1. Has issue-sync.yml + branch protection + NO SYNC_PAT → emits advisory
+#   2. Has issue-sync.yml + branch protection + HAS SYNC_PAT → no advisory (pass)
+#   3. No issue-sync.yml → no advisory (irrelevant)
+#   4. No branch protection requiring reviews → no advisory (not needed)
+#   5. Dismissed advisory → skip silently
+#   6. Stale advisory cleaned up when SYNC_PAT set
+#
+# Stub strategy: a single configurable gh() stub dispatches based on
+# STUB_* variables set per test. This avoids redefining gh() 6 times
+# and eliminates direct positional parameter usage across stub functions.
+
+set -uo pipefail
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR_TEST}/.." && pwd)" || exit 1
+
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_BLUE=$'\033[0;34m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_BLUE="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	local msg="$1"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf '  %sPASS%s %s\n' "$TEST_GREEN" "$TEST_NC" "$msg"
+	return 0
+}
+
+fail() {
+	local msg="$1"
+	local detail="${2:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '  %sFAIL%s %s\n' "$TEST_RED" "$TEST_NC" "$msg"
+	if [[ -n "$detail" ]]; then
+		printf '       %s\n' "$detail"
+	fi
+	return 0
+}
+
+# =============================================================================
+# Sandbox setup
+# =============================================================================
+TMP=$(mktemp -d -t t2374.XXXXXX)
+trap 'rm -rf "$TMP"' EXIT
+
+# Override HOME so advisory files go into sandbox
+export HOME="$TMP"
+mkdir -p "$TMP/.aidevops/advisories"
+
+# Create a fake repo dir
+FAKE_REPO="$TMP/fake-repo"
+mkdir -p "$FAKE_REPO/.git"
+
+# Constants for stub responses
+readonly ISSUE_SYNC_RESPONSE='{"name":"issue-sync.yml"}'
+readonly PROTECTION_WITH_REVIEWS='{"required_pull_request_reviews":{"required_approving_review_count":1}}'
+readonly GH_API_SYNC_PATTERN="contents/.github/workflows/issue-sync.yml"
+readonly GH_API_PROT_PATTERN="/protection"
+
+# =============================================================================
+# Configurable stub variables (set per test case)
+# =============================================================================
+STUB_HAS_ISSUE_SYNC="true"     # "true" = API returns 200, "false" = API returns 1
+STUB_PROTECTION_RESPONSE=""     # JSON response from /protection, empty = no protection
+STUB_SECRET_RESPONSE=""         # Output from gh secret list, empty = no SYNC_PAT
+
+# Single shared gh stub — dispatches based on STUB_* variables
+gh() {
+	local cmd="$1"
+	case "$cmd" in
+	auth)
+		return 0
+		;;
+	api)
+		local url="${2:-}"
+		if [[ "$url" == *"$GH_API_SYNC_PATTERN"* ]]; then
+			if [[ "$STUB_HAS_ISSUE_SYNC" == "true" ]]; then
+				echo "$ISSUE_SYNC_RESPONSE"
+				return 0
+			fi
+			return 1
+		elif [[ "$url" == *"$GH_API_PROT_PATTERN"* ]]; then
+			if [[ -n "$STUB_PROTECTION_RESPONSE" ]]; then
+				echo "$STUB_PROTECTION_RESPONSE"
+				return 0
+			fi
+			echo "Branch not protected"
+			return 1
+		fi
+		return 1
+		;;
+	secret)
+		echo "$STUB_SECRET_RESPONSE"
+		return 0
+		;;
+	esac
+	return 0
+}
+
+# Stub git for default branch detection
+git() {
+	local subcmd="${2:-}"
+	if [[ "$subcmd" == "symbolic-ref" ]]; then
+		echo "refs/remotes/origin/main"
+		return 0
+	fi
+	command git "$@"
+}
+
+# Stub jq for protection JSON parsing
+jq() {
+	local args=("$@")
+	if [[ "${args[*]}" == *"required_approving_review_count"* ]]; then
+		echo "1"
+		return 0
+	fi
+	command jq "$@"
+}
+
+export -f gh git jq
+
+# =============================================================================
+# Source the helper to get check_sync_pat
+# =============================================================================
+
+# Prevent shared-constants.sh from doing anything destructive
+export AIDEVOPS_AGENTS_DIR="$TMP/.aidevops/agents"
+mkdir -p "$AIDEVOPS_AGENTS_DIR"
+
+# Source shared-constants.sh fallbacks
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# Counters (same as in the helper)
+FINDINGS_CRITICAL=0
+FINDINGS_WARNING=0
+FINDINGS_INFO=0
+FINDINGS_PASS=0
+FINDINGS_JSON="[]"
+
+# Stubs for print functions — capture output for assertions
+OUTPUT_LOG="$TMP/output.log"
+
+print_header() { local msg="$1"; echo "[HEADER] $msg" >>"$OUTPUT_LOG"; return 0; }
+print_info() { local msg="$1"; echo "[INFO] $msg" >>"$OUTPUT_LOG"; return 0; }
+print_pass() {
+	local msg="$1"
+	echo "[PASS] $msg" >>"$OUTPUT_LOG"
+	((++FINDINGS_PASS))
+	return 0
+}
+print_warn() {
+	local msg="$1"
+	echo "[WARN] $msg" >>"$OUTPUT_LOG"
+	((++FINDINGS_WARNING))
+	return 0
+}
+print_crit() {
+	local msg="$1"
+	echo "[CRIT] $msg" >>"$OUTPUT_LOG"
+	((++FINDINGS_CRITICAL))
+	return 0
+}
+print_skip() {
+	local msg="$1"
+	echo "[SKIP] $msg" >>"$OUTPUT_LOG"
+	((++FINDINGS_INFO))
+	return 0
+}
+
+add_finding() {
+	# No-op for tests — we check output log and advisory files instead
+	return 0
+}
+
+# resolve_slug stub
+resolve_slug() {
+	echo "testowner/testrepo"
+	return 0
+}
+
+# Extract function bodies from the helper (check_sync_pat + its sub-functions)
+eval "$(sed -n '/^_emit_sync_pat_advisory()/,/^}/p' "${SCRIPTS_DIR}/security-posture-helper.sh")"
+eval "$(sed -n '/^_check_sync_pat_need()/,/^}/p' "${SCRIPTS_DIR}/security-posture-helper.sh")"
+eval "$(sed -n '/^check_sync_pat()/,/^}/p' "${SCRIPTS_DIR}/security-posture-helper.sh")"
+
+# =============================================================================
+# Severity constants needed by the function
+# =============================================================================
+SEVERITY_CRITICAL="critical"
+SEVERITY_WARNING="warning"
+SEVERITY_INFO="info"
+SEVERITY_PASS="pass"
+CAT_SYNC_PAT="sync_pat"
+
+# =============================================================================
+# Helper to reset state between tests
+# =============================================================================
+reset_state() {
+	FINDINGS_CRITICAL=0
+	FINDINGS_WARNING=0
+	FINDINGS_INFO=0
+	FINDINGS_PASS=0
+	FINDINGS_JSON="[]"
+	true >"$OUTPUT_LOG"
+	rm -f "$TMP/.aidevops/advisories/sync-pat-"*
+	rm -f "$TMP/.aidevops/advisories/.dismissed-sync-pat-"*
+	# Reset stub defaults
+	STUB_HAS_ISSUE_SYNC="true"
+	STUB_PROTECTION_RESPONSE="$PROTECTION_WITH_REVIEWS"
+	STUB_SECRET_RESPONSE=""
+	return 0
+}
+
+ADVISORY_PATH="$TMP/.aidevops/advisories/sync-pat-testowner-testrepo.advisory"
+
+# =============================================================================
+# Test 1: Needs SYNC_PAT — emits advisory
+# =============================================================================
+printf '\n%sTest 1: Repo needs SYNC_PAT (issue-sync + protection + no secret)%s\n' "$TEST_BLUE" "$TEST_NC"
+reset_state
+STUB_HAS_ISSUE_SYNC="true"
+STUB_PROTECTION_RESPONSE="$PROTECTION_WITH_REVIEWS"
+STUB_SECRET_RESPONSE=""
+
+check_sync_pat "$FAKE_REPO"
+
+if [[ -f "$ADVISORY_PATH" ]]; then
+	pass "Advisory file created for repo needing SYNC_PAT"
+else
+	fail "Advisory file NOT created" "Expected: $ADVISORY_PATH"
+fi
+
+if [[ -f "$ADVISORY_PATH" ]] && grep -q "gh secret set SYNC_PAT" "$ADVISORY_PATH" 2>/dev/null; then
+	pass "Advisory contains remediation command"
+else
+	fail "Advisory missing remediation command"
+fi
+
+if grep -q '\[WARN\].*SYNC_PAT not set' "$OUTPUT_LOG" 2>/dev/null; then
+	pass "Warning emitted for missing SYNC_PAT"
+else
+	fail "No warning emitted" "Log: $(cat "$OUTPUT_LOG")"
+fi
+
+# =============================================================================
+# Test 2: SYNC_PAT already set — no advisory
+# =============================================================================
+printf '\n%sTest 2: SYNC_PAT already set — should pass cleanly%s\n' "$TEST_BLUE" "$TEST_NC"
+reset_state
+STUB_SECRET_RESPONSE="SYNC_PAT"
+
+check_sync_pat "$FAKE_REPO"
+
+if [[ ! -f "$ADVISORY_PATH" ]]; then
+	pass "No advisory when SYNC_PAT is set"
+else
+	fail "Advisory created despite SYNC_PAT being set"
+fi
+
+if grep -q '\[PASS\].*SYNC_PAT is set' "$OUTPUT_LOG" 2>/dev/null; then
+	pass "Pass message emitted for set SYNC_PAT"
+else
+	fail "No pass message" "Log: $(cat "$OUTPUT_LOG")"
+fi
+
+# =============================================================================
+# Test 3: No issue-sync.yml — no advisory
+# =============================================================================
+printf '\n%sTest 3: No issue-sync.yml — should skip%s\n' "$TEST_BLUE" "$TEST_NC"
+reset_state
+STUB_HAS_ISSUE_SYNC="false"
+
+check_sync_pat "$FAKE_REPO"
+
+if [[ ! -f "$ADVISORY_PATH" ]]; then
+	pass "No advisory when issue-sync.yml absent"
+else
+	fail "Advisory created for repo without issue-sync.yml"
+fi
+
+if grep -q '\[PASS\].*No issue-sync.yml' "$OUTPUT_LOG" 2>/dev/null; then
+	pass "Pass message emitted for no issue-sync.yml"
+else
+	fail "No pass message for absent workflow" "Log: $(cat "$OUTPUT_LOG")"
+fi
+
+# =============================================================================
+# Test 4: No branch protection requiring reviews — no advisory
+# =============================================================================
+printf '\n%sTest 4: No branch protection requiring reviews — should skip%s\n' "$TEST_BLUE" "$TEST_NC"
+reset_state
+STUB_PROTECTION_RESPONSE=""
+
+check_sync_pat "$FAKE_REPO"
+
+if [[ ! -f "$ADVISORY_PATH" ]]; then
+	pass "No advisory when no branch protection"
+else
+	fail "Advisory created for repo without branch protection"
+fi
+
+if grep -q '\[PASS\].*No branch protection' "$OUTPUT_LOG" 2>/dev/null; then
+	pass "Pass message emitted for no branch protection"
+else
+	fail "No pass message for unprotected branch" "Log: $(cat "$OUTPUT_LOG")"
+fi
+
+# =============================================================================
+# Test 5: Dismissed advisory — should skip silently
+# =============================================================================
+printf '\n%sTest 5: Dismissed advisory — should skip%s\n' "$TEST_BLUE" "$TEST_NC"
+reset_state
+touch "$TMP/.aidevops/advisories/.dismissed-sync-pat-testowner-testrepo"
+
+check_sync_pat "$FAKE_REPO"
+
+if [[ ! -f "$ADVISORY_PATH" ]]; then
+	pass "No advisory when dismissed"
+else
+	fail "Advisory created despite being dismissed"
+fi
+
+if grep -q '\[PASS\].*dismissed' "$OUTPUT_LOG" 2>/dev/null; then
+	pass "Pass message emitted for dismissed advisory"
+else
+	fail "No pass message for dismissed advisory" "Log: $(cat "$OUTPUT_LOG")"
+fi
+
+# =============================================================================
+# Test 6: Stale advisory cleaned up when SYNC_PAT is set
+# =============================================================================
+printf '\n%sTest 6: Stale advisory cleaned up when SYNC_PAT set%s\n' "$TEST_BLUE" "$TEST_NC"
+reset_state
+echo "stale" >"$ADVISORY_PATH"
+STUB_SECRET_RESPONSE="SYNC_PAT"
+
+check_sync_pat "$FAKE_REPO"
+
+if [[ ! -f "$ADVISORY_PATH" ]]; then
+	pass "Stale advisory cleaned up after SYNC_PAT set"
+else
+	fail "Stale advisory NOT cleaned up"
+fi
+
+# =============================================================================
+# Summary
+# =============================================================================
+echo ""
+echo "======================================="
+if [[ "$TESTS_FAILED" -eq 0 ]]; then
+	printf '%sAll %d tests passed%s\n' "$TEST_GREEN" "$TESTS_RUN" "$TEST_NC"
+else
+	printf '%s%d of %d tests failed%s\n' "$TEST_RED" "$TESTS_FAILED" "$TESTS_RUN" "$TEST_NC"
+fi
+echo "======================================="
+
+exit "$TESTS_FAILED"


### PR DESCRIPTION
## Summary

- Added Phase 7 (`check_sync_pat`) to `security-posture-helper.sh` that detects repos needing `SYNC_PAT` but not having it set
- Emits per-repo advisory files via `~/.aidevops/advisories/sync-pat-<slug>.advisory` with actionable remediation steps
- Handles all four detection cases (needs PAT, has PAT, no workflow, no branch protection), plus dismissed-state tracking and stale advisory auto-cleanup
- Includes comprehensive test suite (`test-sync-pat-detection.sh`) with 12 assertions covering all cases

Resolves #19835

## Testing

- All 12 unit tests pass (`test-sync-pat-detection.sh`)
- ShellCheck clean on both modified and new files
- Tests cover: advisory creation when PAT missing, no-advisory when PAT set, no-advisory when no issue-sync.yml workflow, no-advisory when no branch protection, dismissed advisory handling, and stale advisory cleanup

## MERGE_SUMMARY

**What changed:** Added SYNC_PAT detection (Phase 7) to `aidevops security check`. When a repo uses `issue-sync.yml` + branch protection requiring reviews but lacks `SYNC_PAT`, emits a dismissible advisory file with step-by-step fix instructions. Refactored existing print functions for code quality compliance.

**Files modified:**
- `EDIT: .agents/scripts/security-posture-helper.sh` — added `_emit_sync_pat_advisory()`, `_check_sync_pat_need()`, `check_sync_pat()` functions; fixed positional param usage in print helpers; wired Phase 7 into `run_all_checks()`; updated help text
- `NEW: .agents/scripts/tests/test-sync-pat-detection.sh` — 12-assertion test suite with configurable gh/git/jq stubs


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.74 plugin for [OpenCode](https://opencode.ai) v1.14.17 with claude-opus-4-6 spent 21m and 37,336 tokens on this as a headless worker.