### PR TITLE
t2380: harden gh API error handling in pulse-merge split modules

### DIFF
--- a/.agents/scripts/pulse-merge-conflict.sh
+++ b/.agents/scripts/pulse-merge-conflict.sh
@@ -158,9 +158,22 @@ _interactive_pr_is_stale() {
 		'.labels | map(.name) | index("origin:interactive")' \
 		>/dev/null 2>&1 || return 1
 
+	# Gate 1b (GH#19864): honor no-takeover label — opt-out for maintainers
+	if printf '%s' "$pr_meta" | jq -e \
+		'.labels | map(.name) | index("no-takeover")' \
+		>/dev/null 2>&1; then
+		echo "[pulse-merge-conflict] _interactive_pr_is_stale: PR #${pr_number} has no-takeover label — skipping handover (GH#19864)" >>"$LOGFILE"
+		return 1
+	fi
+
 	# Gate 4: age threshold (check before any other gh calls — cheapest filter)
 	local threshold_hours updated_at now_epoch updated_epoch pr_age_hours
 	threshold_hours="${AIDEVOPS_INTERACTIVE_PR_HANDOVER_HOURS:-24}"
+	# GH#19864: validate threshold is a non-negative integer; fallback to 24 on bad input
+	if ! [[ "$threshold_hours" =~ ^[0-9]+$ ]]; then
+		echo "[pulse-merge-conflict] _interactive_pr_is_stale: invalid AIDEVOPS_INTERACTIVE_PR_HANDOVER_HOURS='${threshold_hours}' — falling back to 24 (GH#19864)" >>"$LOGFILE"
+		threshold_hours=24
+	fi
 	updated_at=$(printf '%s' "$pr_meta" | jq -r '.updatedAt // empty')
 	[[ -z "$updated_at" ]] && return 1
 	now_epoch=$(date +%s)
@@ -452,10 +465,15 @@ _close_conflicting_pr() {
 	# sessions. The task-ID-on-main heuristic produces false positives when
 	# multiple PRs share a task ID (incremental work on the same issue).
 	# Maintainers decide what is redundant — the pulse must not auto-close their work.
-	local pr_labels
+	local pr_labels pr_view_rc=0
 	pr_labels=$(gh pr view "$pr_number" --repo "$repo_slug" \
-		--json labels --jq '.labels[].name' 2>/dev/null || true)
-	if printf '%s' "$pr_labels" | grep -q 'origin:interactive'; then
+		--json labels --jq '.labels[].name' 2>/dev/null) || pr_view_rc=$?
+	if [[ $pr_view_rc -ne 0 ]]; then
+		echo "[pulse-merge-conflict] _close_conflicting_pr: gh pr view failed for PR #${pr_number} (exit ${pr_view_rc}) — skipping auto-close to avoid acting on incomplete data (GH#19864)" >>"$LOGFILE"
+		return 0
+	fi
+	# GH#19864: use fixed-string line-anchored match to avoid substring false positives
+	if printf '%s\n' "$pr_labels" | grep -qxF 'origin:interactive'; then
 		echo "[pulse-wrapper] Deterministic merge: skipping auto-close of origin:interactive PR #${pr_number} — maintainer session work is never auto-closed" >>"$LOGFILE"
 		# GH#18650 (Fix 4): post a one-time rebase nudge so the maintainer
 		# has a visible signal that their CONFLICTING PR needs manual
@@ -644,6 +662,15 @@ _carry_forward_pr_diff() {
 	fi
 
 	# --- Build the append section ---
+	# GH#19864: compute a dynamic fence length so embedded backtick runs in
+	# diff_content cannot break the code block.
+	local fence='```'
+	local longest_run
+	longest_run=$(printf '%s' "$diff_content" | grep -oE '\`{3,}' | awk '{ if (length > m) m = length } END { print m+0 }')
+	if [[ "${longest_run:-0}" -ge 3 ]]; then
+		fence=$(printf '%*s' "$((longest_run + 1))" '' | tr ' ' '`')
+	fi
+
 	local new_section
 	new_section="${marker}
 ## Prior worker attempt (PR #${pr_number}, closed CONFLICTING)
@@ -654,9 +681,9 @@ rebase/apply it rather than re-deriving the solution from scratch.
 
 <details><summary>Diff from PR #${pr_number} (click to expand)</summary>
 
-\`\`\`diff
+${fence}diff
 ${diff_content}${truncation_note}
-\`\`\`
+${fence}
 
 </details>"
 

--- a/.agents/scripts/pulse-merge-feedback.sh
+++ b/.agents/scripts/pulse-merge-feedback.sh
@@ -172,9 +172,14 @@ ${failing_checks}
 _Routed by deterministic merge pass (pulse-merge.sh)._"
 
 	# Append to issue body (marker-guarded for idempotency)
-	local current_body
+	# GH#19864: capture exit status to avoid clobbering the issue body on fetch failure
+	local current_body fetch_rc=0
 	current_body=$(gh issue view "$linked_issue" --repo "$repo_slug" \
-		--json body --jq '.body // ""' 2>/dev/null) || current_body=""
+		--json body --jq '.body // ""' 2>/dev/null) || fetch_rc=$?
+	if [[ $fetch_rc -ne 0 ]]; then
+		echo "[pulse-wrapper] _dispatch_ci_fix_worker: failed to fetch issue #${linked_issue} body (exit ${fetch_rc}) — skipping edit to avoid data loss (GH#19864)" >>"$LOGFILE"
+		return 1
+	fi
 
 	local marker="<!-- ci-feedback:PR${pr_number} -->"
 	if printf '%s' "$current_body" | grep -qF "$marker"; then
@@ -278,9 +283,14 @@ ${pr_files}
 _Routed by deterministic merge pass (pulse-merge.sh)._"
 
 	# Append to issue body (marker-guarded)
-	local current_body
+	# GH#19864: capture exit status to avoid clobbering the issue body on fetch failure
+	local current_body fetch_rc=0
 	current_body=$(gh issue view "$linked_issue" --repo "$repo_slug" \
-		--json body --jq '.body // ""' 2>/dev/null) || current_body=""
+		--json body --jq '.body // ""' 2>/dev/null) || fetch_rc=$?
+	if [[ $fetch_rc -ne 0 ]]; then
+		echo "[pulse-wrapper] _dispatch_conflict_fix_worker: failed to fetch issue #${linked_issue} body (exit ${fetch_rc}) — skipping edit to avoid data loss (GH#19864)" >>"$LOGFILE"
+		return 1
+	fi
 
 	local marker="<!-- conflict-feedback:PR${pr_number} -->"
 	if printf '%s' "$current_body" | grep -qF "$marker"; then
@@ -414,9 +424,14 @@ _dispatch_pr_fix_worker() {
 	fi
 
 	# --- Append to linked issue body (marker-guarded for idempotency) ---
-	local current_body
+	# GH#19864: capture exit status to avoid clobbering the issue body on fetch failure
+	local current_body fetch_rc=0
 	current_body=$(gh issue view "$linked_issue" --repo "$repo_slug" \
-		--json body --jq '.body // ""' 2>/dev/null) || current_body=""
+		--json body --jq '.body // ""' 2>/dev/null) || fetch_rc=$?
+	if [[ $fetch_rc -ne 0 ]]; then
+		echo "[pulse-wrapper] _dispatch_pr_fix_worker: failed to fetch issue #${linked_issue} body (exit ${fetch_rc}) — skipping edit to avoid data loss (GH#19864)" >>"$LOGFILE"
+		return 1
+	fi
 
 	local marker="<!-- t2093:review-feedback:PR${pr_number} -->"
 	local body_updated="false"

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -16,15 +16,22 @@
 # clusters that are called after the gate checks fire. They are sourced
 # by pulse-wrapper.sh AFTER pulse-merge.sh so they can use shared merge
 # helpers such as _extract_linked_issue, while Bash lazy resolution keeps
-# the runtime cross-module calls safe. The dependency is one-way only
-# (downstream → core); merge-core/pr-gates do not require the downstream
-# modules at source time:
+# the runtime cross-module calls safe.
+#
+# Dependency direction (one-way only — GH#19864 clarification):
+#   pulse-merge-conflict.sh  ──depends on──▶  pulse-merge.sh (this file)
+#   pulse-merge-feedback.sh  ──depends on──▶  pulse-merge.sh (this file)
+#   pulse-merge.sh does NOT call any function defined in the downstream
+#   modules at source time. At runtime, _check_pr_merge_gates dispatches
+#   to downstream functions (e.g. _dispatch_pr_fix_worker in feedback,
+#   _close_conflicting_pr in conflict), but these are resolved lazily by
+#   Bash at call time — after all three modules have been sourced.
+#
+# Downstream modules:
 #   - pulse-merge-conflict.sh — conflict handling, interactive handover,
 #     carry-forward diff, rebase nudges
 #   - pulse-merge-feedback.sh — CI/conflict/review feedback routing to
 #     linked issues with PR close
-# Example cross-module call: _check_pr_merge_gates (merge-core) →
-# _dispatch_pr_fix_worker (feedback) is resolved at invocation time.
 #
 # This module is sourced by pulse-wrapper.sh. It MUST NOT be executed
 # directly — it relies on the orchestrator having sourced:

--- a/.agents/scripts/tests/test-pulse-merge-gh-error-handling.sh
+++ b/.agents/scripts/tests/test-pulse-merge-gh-error-handling.sh
@@ -1,0 +1,543 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression tests for GH#19864 — hardened gh API error handling in the
+# pulse-merge split modules (pulse-merge-conflict.sh, pulse-merge-feedback.sh).
+#
+# Tests verify that:
+#   1. _close_conflicting_pr skips auto-close when gh pr view fails (finding 2)
+#   2. _close_conflicting_pr uses exact-match for origin:interactive (finding 2)
+#   3. _interactive_pr_is_stale returns not-stale when no-takeover label present (finding 1)
+#   4. _interactive_pr_is_stale validates HANDOVER_HOURS (finding 4)
+#   5. _carry_forward_pr_diff uses dynamic backtick fence (finding 3)
+#   6. Feedback helpers abort on gh issue view failure (finding 5)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+CONFLICT_SCRIPT="${SCRIPT_DIR}/../pulse-merge-conflict.sh"
+FEEDBACK_SCRIPT="${SCRIPT_DIR}/../pulse-merge-feedback.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+GH_LOG=""
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+	mkdir -p "${TEST_ROOT}/bin"
+	export PATH="${TEST_ROOT}/bin:${PATH}"
+	export LOGFILE="${TEST_ROOT}/pulse.log"
+	: >"$LOGFILE"
+	GH_LOG="${TEST_ROOT}/gh-calls.log"
+	: >"$GH_LOG"
+	export TEST_ROOT GH_LOG
+	return 0
+}
+
+teardown_test_env() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+# =============================================================================
+# Test 1: _close_conflicting_pr skips when gh pr view fails
+# =============================================================================
+test_close_conflicting_pr_skips_on_gh_failure() {
+	# Mock gh that always fails for pr view
+	cat >"${TEST_ROOT}/bin/gh" <<'GHEOF'
+#!/usr/bin/env bash
+printf '%s\n' "gh $*" >>"${GH_LOG:-/dev/null}"
+if [[ "${1:-} ${2:-}" == "pr view" ]]; then
+	exit 1
+fi
+exit 0
+GHEOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+
+	# Extract _close_conflicting_pr
+	local fn_src
+	fn_src=$(awk '/^_close_conflicting_pr\(\) \{/,/^}$/ { print }' "$CONFLICT_SCRIPT")
+	# shellcheck disable=SC1090
+	eval "$fn_src"
+
+	# Stub helpers it calls
+	_post_rebase_nudge_on_interactive_conflicting() { return 0; }
+	_extract_linked_issue() { echo "42"; return 0; }
+	_verify_pr_overlaps_commit() { return 0; }
+	_post_rebase_nudge_on_worker_conflicting() { return 0; }
+	_carry_forward_pr_diff() { return 0; }
+	_gh_idempotent_comment() { return 0; }
+
+	: >"$LOGFILE"
+	_close_conflicting_pr "99" "owner/repo" "t123: some fix"
+	local rc=$?
+
+	# Should return 0 (fail-open) and log the API failure
+	local failed=0
+	if [[ $rc -ne 0 ]]; then
+		failed=1
+	fi
+	if ! grep -q "gh pr view failed" "$LOGFILE"; then
+		failed=1
+	fi
+	# Should NOT have called pr close (skipped)
+	if grep -q "pr close" "$GH_LOG"; then
+		failed=1
+	fi
+	print_result "close_conflicting_pr skips on gh pr view failure" "$failed" \
+		"Expected return 0, 'gh pr view failed' in log, no pr close call"
+	return 0
+}
+
+# =============================================================================
+# Test 2: _close_conflicting_pr uses exact-match for origin:interactive
+# =============================================================================
+test_close_conflicting_pr_exact_label_match() {
+	# Mock gh that returns a label that contains "origin:interactive" as substring
+	cat >"${TEST_ROOT}/bin/gh" <<'GHEOF'
+#!/usr/bin/env bash
+printf '%s\n' "gh $*" >>"${GH_LOG:-/dev/null}"
+_subcmd="${1:-} ${2:-}"
+case "$_subcmd" in
+"pr view")
+	if [[ "$*" == *"--json labels"* ]]; then
+		# Return a label that is NOT exactly "origin:interactive" but contains it
+		printf 'not-origin:interactive-extended\n'
+		exit 0
+	fi
+	;;
+"pr close" | "pr edit" | "label create")
+	exit 0
+	;;
+"issue view")
+	if [[ "$*" == *"--json body"* ]]; then
+		echo 'body text'
+		exit 0
+	fi
+	exit 0
+	;;
+"issue edit")
+	exit 0
+	;;
+esac
+if [[ "${1:-}" == "api" ]]; then
+	echo '[]'
+	exit 0
+fi
+exit 0
+GHEOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+
+	local fn_src
+	fn_src=$(awk '/^_close_conflicting_pr\(\) \{/,/^}$/ { print }' "$CONFLICT_SCRIPT")
+	# shellcheck disable=SC1090
+	eval "$fn_src"
+
+	_post_rebase_nudge_on_interactive_conflicting() { return 0; }
+	_extract_linked_issue() { echo "42"; return 0; }
+	_verify_pr_overlaps_commit() { return 0; }
+	_post_rebase_nudge_on_worker_conflicting() { return 0; }
+	_carry_forward_pr_diff() { return 0; }
+	_gh_idempotent_comment() { return 0; }
+
+	: >"$LOGFILE"
+	_close_conflicting_pr "99" "owner/repo" "t123: some fix"
+
+	# With exact-match, the label "not-origin:interactive-extended" should NOT match
+	# So the function should NOT skip with the "maintainer session" message
+	local failed=0
+	if grep -q "skipping auto-close of origin:interactive" "$LOGFILE"; then
+		failed=1
+	fi
+	print_result "close_conflicting_pr uses exact-match for origin:interactive" "$failed" \
+		"Substring label should not trigger origin:interactive skip"
+	return 0
+}
+
+# =============================================================================
+# Test 3: _interactive_pr_is_stale returns not-stale when no-takeover present
+# =============================================================================
+test_stale_check_honors_no_takeover() {
+	# Mock gh that returns labels including no-takeover
+	cat >"${TEST_ROOT}/bin/gh" <<'GHEOF'
+#!/usr/bin/env bash
+printf '%s\n' "gh $*" >>"${GH_LOG:-/dev/null}"
+if [[ "${1:-} ${2:-}" == "pr view" ]]; then
+	if [[ "$*" == *"--json labels"* ]]; then
+		printf '{"labels":[{"name":"origin:interactive"},{"name":"no-takeover"}],"updatedAt":"2026-01-01T00:00:00Z"}\n'
+		exit 0
+	fi
+fi
+if [[ "${1:-}" == "api" ]]; then
+	printf '{"state":"open","labels":[]}\n'
+	exit 0
+fi
+exit 0
+GHEOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+
+	local fn_src
+	fn_src=$(awk '/^_interactive_pr_is_stale\(\) \{/,/^}$/ { print }' "$CONFLICT_SCRIPT")
+	# shellcheck disable=SC1090
+	eval "$fn_src"
+
+	export AIDEVOPS_INTERACTIVE_PR_HANDOVER_MODE="enforce"
+	: >"$LOGFILE"
+	local rc=0
+	_interactive_pr_is_stale "99" "owner/repo" || rc=$?
+
+	local failed=0
+	if [[ $rc -eq 0 ]]; then
+		failed=1  # Should return 1 (not stale) because of no-takeover
+	fi
+	if ! grep -q "no-takeover label" "$LOGFILE"; then
+		failed=1
+	fi
+	print_result "stale check returns not-stale when no-takeover label present" "$failed" \
+		"Expected rc=1 (not stale) and 'no-takeover label' in log"
+
+	unset AIDEVOPS_INTERACTIVE_PR_HANDOVER_MODE
+	return 0
+}
+
+# =============================================================================
+# Test 4: _interactive_pr_is_stale validates HANDOVER_HOURS
+# =============================================================================
+test_stale_check_validates_hours() {
+	# Mock gh that returns a very old PR
+	cat >"${TEST_ROOT}/bin/gh" <<'GHEOF'
+#!/usr/bin/env bash
+printf '%s\n' "gh $*" >>"${GH_LOG:-/dev/null}"
+if [[ "${1:-} ${2:-}" == "pr view" ]]; then
+	if [[ "$*" == *"--json labels"* ]]; then
+		printf '{"labels":[{"name":"origin:interactive"}],"updatedAt":"2025-01-01T00:00:00Z"}\n'
+		exit 0
+	fi
+fi
+if [[ "${1:-}" == "api" ]]; then
+	printf '{"state":"open","labels":[]}\n'
+	exit 0
+fi
+exit 0
+GHEOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+
+	local fn_src
+	fn_src=$(awk '/^_interactive_pr_is_stale\(\) \{/,/^}$/ { print }' "$CONFLICT_SCRIPT")
+	# shellcheck disable=SC1090
+	eval "$fn_src"
+
+	# Stub for linked issue extraction
+	_extract_linked_issue() { echo "42"; return 0; }
+
+	export AIDEVOPS_INTERACTIVE_PR_HANDOVER_MODE="enforce"
+	export AIDEVOPS_INTERACTIVE_PR_HANDOVER_HOURS="not-a-number"
+	: >"$LOGFILE"
+	_interactive_pr_is_stale "99" "owner/repo" 2>/dev/null || true
+
+	local failed=0
+	if ! grep -q "invalid.*falling back to 24" "$LOGFILE"; then
+		failed=1
+	fi
+	print_result "stale check validates HANDOVER_HOURS and falls back to 24" "$failed" \
+		"Expected 'invalid.*falling back to 24' in log"
+
+	unset AIDEVOPS_INTERACTIVE_PR_HANDOVER_MODE
+	unset AIDEVOPS_INTERACTIVE_PR_HANDOVER_HOURS
+	return 0
+}
+
+# =============================================================================
+# Test 5: _carry_forward_pr_diff uses dynamic fence when diff contains backticks
+# =============================================================================
+test_carry_forward_uses_dynamic_fence() {
+	# _carry_forward_pr_diff takes (pr_number, repo_slug, linked_issue) and
+	# fetches the diff itself via `gh pr diff`. The mock returns diff content
+	# with embedded triple backticks to trigger the dynamic fence logic.
+	cat >"${TEST_ROOT}/bin/gh" <<'GHEOF'
+#!/usr/bin/env bash
+printf '%s\n' "gh $*" >>"${GH_LOG:-/dev/null}"
+_subcmd="${1:-} ${2:-}"
+case "$_subcmd" in
+"pr diff")
+	# Return diff content containing triple backticks
+	cat <<'DIFF'
+--- a/file.sh
++++ b/file.sh
+@@ -1,3 +1,5 @@
+ line1
++```bash
++echo "hello"
++```
+ line3
+DIFF
+	exit 0
+	;;
+"issue view")
+	if [[ "$*" == *"--json body"* ]]; then
+		echo ''
+		exit 0
+	fi
+	exit 0
+	;;
+"issue edit")
+	_args=("$@")
+	for _i in "${!_args[@]}"; do
+		if [[ "${_args[$_i]}" == "--body" ]]; then
+			printf '%s' "${_args[$((_i + 1))]}" >"${TEST_ROOT}/edit-body.txt"
+			break
+		fi
+	done
+	exit 0
+	;;
+esac
+exit 0
+GHEOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+
+	local fn_src
+	fn_src=$(awk '/^_carry_forward_pr_diff\(\) \{/,/^}$/ { print }' "$CONFLICT_SCRIPT")
+	# shellcheck disable=SC1090
+	eval "$fn_src"
+
+	: >"$LOGFILE"
+	_carry_forward_pr_diff "99" "owner/repo" "42"
+
+	local failed=0
+	if [[ -f "${TEST_ROOT}/edit-body.txt" ]]; then
+		# The fence should be at least 4 backticks (longer than the 3 in the diff)
+		if ! grep -E '^`{4,}diff' "${TEST_ROOT}/edit-body.txt" >/dev/null 2>&1; then
+			failed=1
+		fi
+	else
+		failed=1
+	fi
+	print_result "carry_forward uses dynamic fence when diff has backticks" "$failed" \
+		"Expected fence with 4+ backticks in issue body"
+	return 0
+}
+
+# =============================================================================
+# Test 6: _dispatch_ci_fix_worker aborts on gh issue view failure
+# =============================================================================
+test_ci_fix_worker_aborts_on_fetch_failure() {
+	# _dispatch_ci_fix_worker takes (pr_number, repo_slug, linked_issue).
+	# It calls `gh pr checks` first — mock must return failing checks so it
+	# doesn't return early. Then `gh issue view` must fail.
+	cat >"${TEST_ROOT}/bin/gh" <<'GHEOF'
+#!/usr/bin/env bash
+printf '%s\n' "gh $*" >>"${GH_LOG:-/dev/null}"
+_subcmd="${1:-} ${2:-}"
+case "$_subcmd" in
+"label create")
+	exit 0
+	;;
+"pr checks")
+	printf '%s\n' '- **lint**: fail — [https://example.com](https://example.com)'
+	exit 0
+	;;
+"issue view")
+	exit 1
+	;;
+"issue edit")
+	printf 'SHOULD_NOT_BE_CALLED\n' >>"${TEST_ROOT}/unexpected.log"
+	exit 0
+	;;
+esac
+exit 0
+GHEOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+
+	local fn_src
+	fn_src=$(awk '/^_dispatch_ci_fix_worker\(\) \{/,/^}$/ { print }' "$FEEDBACK_SCRIPT")
+	# shellcheck disable=SC1090
+	eval "$fn_src"
+
+	# Stub set_issue_status
+	set_issue_status() { return 0; }
+
+	: >"$LOGFILE"
+	rm -f "${TEST_ROOT}/unexpected.log"
+	local rc=0
+	_dispatch_ci_fix_worker "99" "owner/repo" "42" 2>/dev/null || rc=$?
+
+	local failed=0
+	# Should fail (return 1) and log the fetch failure
+	if [[ $rc -eq 0 ]]; then
+		failed=1
+	fi
+	if ! grep -q "failed to fetch issue.*skipping edit to avoid data loss" "$LOGFILE"; then
+		failed=1
+	fi
+	# issue edit should NOT have been called
+	if [[ -f "${TEST_ROOT}/unexpected.log" ]]; then
+		failed=1
+	fi
+	print_result "ci_fix_worker aborts on gh issue view failure" "$failed" \
+		"Expected return 1, fetch failure log, no issue edit"
+	return 0
+}
+
+# =============================================================================
+# Test 7: _dispatch_conflict_fix_worker aborts on gh issue view failure
+# =============================================================================
+test_conflict_fix_worker_aborts_on_fetch_failure() {
+	# Same mock — gh issue view fails
+	cat >"${TEST_ROOT}/bin/gh" <<'GHEOF'
+#!/usr/bin/env bash
+printf '%s\n' "gh $*" >>"${GH_LOG:-/dev/null}"
+if [[ "${1:-} ${2:-}" == "issue view" ]]; then
+	exit 1
+fi
+if [[ "${1:-} ${2:-}" == "issue edit" ]]; then
+	printf 'SHOULD_NOT_BE_CALLED\n' >>"${TEST_ROOT}/unexpected.log"
+	exit 0
+fi
+exit 0
+GHEOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+
+	local fn_src
+	fn_src=$(awk '/^_dispatch_conflict_fix_worker\(\) \{/,/^}$/ { print }' "$FEEDBACK_SCRIPT")
+	# shellcheck disable=SC1090
+	eval "$fn_src"
+
+	set_issue_status() { return 0; }
+
+	: >"$LOGFILE"
+	rm -f "${TEST_ROOT}/unexpected.log"
+	local rc=0
+	_dispatch_conflict_fix_worker "99" "owner/repo" "42" "## Conflict Feedback" 2>/dev/null || rc=$?
+
+	local failed=0
+	if [[ $rc -eq 0 ]]; then
+		failed=1
+	fi
+	if ! grep -q "failed to fetch issue.*skipping edit to avoid data loss" "$LOGFILE"; then
+		failed=1
+	fi
+	if [[ -f "${TEST_ROOT}/unexpected.log" ]]; then
+		failed=1
+	fi
+	print_result "conflict_fix_worker aborts on gh issue view failure" "$failed" \
+		"Expected return 1, fetch failure log, no issue edit"
+	return 0
+}
+
+# =============================================================================
+# Test 8: _dispatch_pr_fix_worker aborts on gh issue view failure
+# =============================================================================
+test_pr_fix_worker_aborts_on_fetch_failure() {
+	# _dispatch_pr_fix_worker takes (pr_number, repo_slug, linked_issue).
+	# It fetches reviews via `gh api repos/.../reviews` and inline comments
+	# via `gh api repos/.../comments` before calling _build_review_feedback_section.
+	# The mock must return substantive review data for those, then fail on issue view.
+	cat >"${TEST_ROOT}/bin/gh" <<'GHEOF'
+#!/usr/bin/env bash
+printf '%s\n' "gh $*" >>"${GH_LOG:-/dev/null}"
+_subcmd="${1:-} ${2:-}"
+case "$_subcmd" in
+"label create")
+	exit 0
+	;;
+"pr close" | "pr edit")
+	exit 0
+	;;
+"issue view")
+	exit 1
+	;;
+"issue edit")
+	printf 'SHOULD_NOT_BE_CALLED\n' >>"${TEST_ROOT}/unexpected.log"
+	exit 0
+	;;
+esac
+if [[ "${1:-}" == "api" ]]; then
+	if [[ "$*" == *"/reviews"* ]]; then
+		printf '[{"author":"coderabbitai[bot]","state":"CHANGES_REQUESTED","body":"Two issues found.","url":"https://example.com"}]\n'
+		exit 0
+	fi
+	if [[ "$*" == *"/comments"* ]]; then
+		printf '[{"author":"coderabbitai[bot]","path":"f.sh","line":1,"body":"off-by-one","url":"https://example.com"}]\n'
+		exit 0
+	fi
+fi
+exit 0
+GHEOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+
+	# Extract both _build_review_feedback_section and _dispatch_pr_fix_worker
+	local build_src dispatch_src
+	build_src=$(awk '/^_build_review_feedback_section\(\) \{/,/^}$/ { print }' "$FEEDBACK_SCRIPT")
+	dispatch_src=$(awk '/^_dispatch_pr_fix_worker\(\) \{/,/^}$/ { print }' "$FEEDBACK_SCRIPT")
+	# shellcheck disable=SC1090
+	eval "$build_src"
+	# shellcheck disable=SC1090
+	eval "$dispatch_src"
+
+	set_issue_status() { return 0; }
+
+	: >"$LOGFILE"
+	rm -f "${TEST_ROOT}/unexpected.log"
+	local rc=0
+	_dispatch_pr_fix_worker "99" "owner/repo" "42" 2>/dev/null || rc=$?
+
+	local failed=0
+	if [[ $rc -eq 0 ]]; then
+		failed=1
+	fi
+	if ! grep -q "failed to fetch issue.*skipping edit to avoid data loss" "$LOGFILE"; then
+		failed=1
+	fi
+	if [[ -f "${TEST_ROOT}/unexpected.log" ]]; then
+		failed=1
+	fi
+	print_result "pr_fix_worker aborts on gh issue view failure" "$failed" \
+		"Expected return 1, fetch failure log, no issue edit"
+	return 0
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+
+setup_test_env
+trap teardown_test_env EXIT
+
+test_close_conflicting_pr_skips_on_gh_failure
+test_close_conflicting_pr_exact_label_match
+test_stale_check_honors_no_takeover
+test_stale_check_validates_hours
+test_carry_forward_uses_dynamic_fence
+test_ci_fix_worker_aborts_on_fetch_failure
+test_conflict_fix_worker_aborts_on_fetch_failure
+test_pr_fix_worker_aborts_on_fetch_failure
+
+printf '\nRan %d tests, %d failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]] || exit 1


### PR DESCRIPTION
## Summary

Addresses all 7 CodeRabbit findings from PR #19842 on pre-existing code lifted into the pulse-merge split modules during the GH#19836 extraction.

Resolves #19864

## Changes

### pulse-merge-conflict.sh
- **Finding 1 (L156-159):** Added `no-takeover` label check to `_interactive_pr_is_stale` handover gate — maintainers can now opt a PR out of worker takeover
- **Finding 2 (L455-458):** `_close_conflicting_pr` now captures `gh pr view` exit status instead of swallowing with `|| true`; uses `grep -qxF` (line-anchored fixed-string) for `origin:interactive` label matching to prevent substring false positives
- **Finding 3 (L646-659):** `_carry_forward_pr_diff` now computes a dynamic backtick fence — scans `diff_content` for the longest backtick run and uses N+1 backticks as the fence, preventing code block corruption when diffs contain triple-backtick fenced blocks
- **Finding 4 (L162-172):** `_interactive_pr_is_stale` now validates `AIDEVOPS_INTERACTIVE_PR_HANDOVER_HOURS` is a non-negative integer; falls back to 24 on bad input with a log warning

### pulse-merge-feedback.sh
- **Finding 5 (L175-188, L281-294, L417-433):** All three `gh issue view` append sites (`_dispatch_ci_fix_worker`, `_dispatch_conflict_fix_worker`, `_dispatch_pr_fix_worker`) now capture the exit status and abort early on fetch failure instead of falling through with `current_body=""` which would clobber the issue body on the subsequent `gh issue edit`

### pulse-merge.sh
- **Finding 6 (L15-24):** Expanded the module-sourcing comment with an explicit dependency-direction diagram showing the one-way relationship (downstream modules depend on core, not vice versa)

### pulse-wrapper.sh
- **Finding 7 (L193-203):** Verified — `_PULSE_MERGE_CONFLICT_LOADED` and `_PULSE_MERGE_FEEDBACK_LOADED` guards are already defined in both modules and already listed in `_pulse_execute_self_check`'s expected guards array. No code change needed.

## Testing

- `shellcheck -s bash` clean on all 3 modified files (zero violations)
- All 9 existing `test-pulse-merge-*.sh` test files pass (27 total assertions)
- **New:** `test-pulse-merge-gh-error-handling.sh` — 8 assertions covering:
  1. `_close_conflicting_pr` skips on `gh pr view` failure
  2. `_close_conflicting_pr` uses exact-match for `origin:interactive`
  3. `_interactive_pr_is_stale` returns not-stale when `no-takeover` label present
  4. `_interactive_pr_is_stale` validates `HANDOVER_HOURS` and falls back to 24
  5. `_carry_forward_pr_diff` uses dynamic fence when diff has backticks
  6. `_dispatch_ci_fix_worker` aborts on `gh issue view` failure
  7. `_dispatch_conflict_fix_worker` aborts on `gh issue view` failure
  8. `_dispatch_pr_fix_worker` aborts on `gh issue view` failure