### PR TITLE
t2263: fix(complexity-guard): add file-existence guards to all scanner functions

### DIFF
--- a/.agents/scripts/complexity-regression-helper.sh
+++ b/.agents/scripts/complexity-regression-helper.sh
@@ -185,6 +185,7 @@ scan_dir_function_complexity() {
 	local _file _rel_file _awk_result
 	while IFS= read -r _file; do
 		[ -n "$_file" ] || continue
+		[ -f "$_file" ] || continue
 		_rel_file="${_file#"${_dir}/"}"
 		# Matches code-quality.yml:391-404 AWK.
 		# Detects top-level functions of the form:  name() {
@@ -239,6 +240,7 @@ scan_dir_nesting_depth() {
 	local _file _rel_file _max_depth
 	while IFS= read -r _file; do
 		[ -n "$_file" ] || continue
+		[ -f "$_file" ] || continue
 		_rel_file="${_file#"${_dir}/"}"
 		_max_depth=$(awk '
 			BEGIN { depth=0; max_depth=0 }
@@ -279,6 +281,7 @@ scan_dir_file_size() {
 	local _file _rel_file _lc
 	while IFS= read -r _file; do
 		[ -n "$_file" ] || continue
+		[ -f "$_file" ] || continue
 		_rel_file="${_file#"${_dir}/"}"
 		_lc=$(wc -l <"$_file" 2>/dev/null | tr -d ' ')
 		if [ "${_lc:-0}" -gt 1500 ] 2>/dev/null; then


### PR DESCRIPTION
## Summary

Added `[ -f "$_file" ] || continue` guards to `scan_dir_function_complexity`, `scan_dir_nesting_depth`, and `scan_dir_file_size` — making them consistent with the existing guard in `scan_dir_bash32_compat`. This prevents `wc -l` and `awk` errors when `_collect_files` returns paths for files not present on disk (e.g., new files in base worktree during regression checks).

## Changes

- **`.agents/scripts/complexity-regression-helper.sh`**: Added `[ -f "$_file" ] || continue` to three scanner loop bodies:
  - `scan_dir_function_complexity` (line 188)
  - `scan_dir_nesting_depth` (line 243)
  - `scan_dir_file_size` (line 284)

These match the existing pattern in `scan_dir_bash32_compat` (line 338).

## Testing

- ShellCheck: zero violations
- Dry-run scan for all three metrics (file-size, function-complexity, nesting-depth): all pass
- Full worktree-based regression check with `--allow-increase`: passes

Resolves #19806


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.74 plugin for [OpenCode](https://opencode.ai) v1.14.17 with claude-opus-4-6 spent 9m and 16,347 tokens on this as a headless worker.