### PR TITLE
t2383: fix(pulse-merge): harden 5 pre-existing reliability issues in merge conflict + feedback clusters

### DIFF
--- a/.agents/scripts/pulse-merge-conflict.sh
+++ b/.agents/scripts/pulse-merge-conflict.sh
@@ -161,6 +161,13 @@ _interactive_pr_is_stale() {
 	# Gate 4: age threshold (check before any other gh calls — cheapest filter)
 	local threshold_hours updated_at now_epoch updated_epoch pr_age_hours
 	threshold_hours="${AIDEVOPS_INTERACTIVE_PR_HANDOVER_HOURS:-24}"
+	# t2383 Fix 2: validate threshold is a positive integer before arithmetic.
+	# A non-numeric value (e.g. "24h", empty, negative) triggers bash
+	# "value too great for base" and silently breaks stale detection.
+	if [[ ! "$threshold_hours" =~ ^[0-9]+$ ]] || [[ "$threshold_hours" -eq 0 ]]; then
+		echo "[pulse-wrapper] _interactive_pr_is_stale: invalid AIDEVOPS_INTERACTIVE_PR_HANDOVER_HOURS='${threshold_hours}' — must be a positive integer, returning not-stale (t2383)" >>"$LOGFILE"
+		return 1
+	fi
 	updated_at=$(printf '%s' "$pr_meta" | jq -r '.updatedAt // empty')
 	[[ -z "$updated_at" ]] && return 1
 	now_epoch=$(date +%s)
@@ -225,10 +232,20 @@ _interactive_pr_trigger_handover() {
 	[[ "$pr_number" =~ ^[0-9]+$ && -n "$repo_slug" ]] || return 0
 
 	# Idempotence short-circuit: label already present → nothing to do
-	local has_label
-	has_label=$(gh pr view "$pr_number" --repo "$repo_slug" --json labels \
-		--jq '[.labels[].name] | index("origin:worker-takeover") // empty' 2>/dev/null)
-	if [[ -n "$has_label" && "$has_label" != "null" ]]; then
+	local pr_labels_json
+	pr_labels_json=$(gh pr view "$pr_number" --repo "$repo_slug" --json labels \
+		--jq '[.labels[].name]' 2>/dev/null) || pr_labels_json="[]"
+	[[ -n "$pr_labels_json" ]] || pr_labels_json="[]"
+
+	if printf '%s' "$pr_labels_json" | jq -e 'index("origin:worker-takeover")' >/dev/null 2>&1; then
+		return 0
+	fi
+
+	# t2383 Fix 1: honour no-takeover opt-out label before applying handover.
+	# The handover comment promises "Add the no-takeover label to this PR at
+	# any time. The routing gates will skip it." — enforce that promise here.
+	if printf '%s' "$pr_labels_json" | jq -e 'index("no-takeover")' >/dev/null 2>&1; then
+		echo "[pulse-wrapper] _interactive_pr_trigger_handover: PR #${pr_number} in ${repo_slug} has no-takeover label — skipping handover (t2383)" >>"$LOGFILE"
 		return 0
 	fi
 
@@ -452,10 +469,20 @@ _close_conflicting_pr() {
 	# sessions. The task-ID-on-main heuristic produces false positives when
 	# multiple PRs share a task ID (incremental work on the same issue).
 	# Maintainers decide what is redundant — the pulse must not auto-close their work.
-	local pr_labels
+	#
+	# t2383 Fix 3: fail CLOSED on label read failure — if we can't read labels,
+	# we might be about to close a protected origin:interactive PR. Also use
+	# grep -Fxq (exact line match) not grep -q (substring) so labels like
+	# "origin:interactive-fork" don't false-match "origin:interactive".
+	local pr_labels label_fetch_rc
+	label_fetch_rc=0
 	pr_labels=$(gh pr view "$pr_number" --repo "$repo_slug" \
-		--json labels --jq '.labels[].name' 2>/dev/null || true)
-	if printf '%s' "$pr_labels" | grep -q 'origin:interactive'; then
+		--json labels --jq '.labels[].name' 2>/dev/null) || label_fetch_rc=$?
+	if [[ $label_fetch_rc -ne 0 ]]; then
+		echo "[pulse-wrapper] _close_conflicting_pr: failed to fetch labels for PR #${pr_number} in ${repo_slug} (exit ${label_fetch_rc}) — skipping close to protect potential origin:interactive PR (t2383)" >>"$LOGFILE"
+		return 0
+	fi
+	if printf '%s\n' "$pr_labels" | grep -Fxq 'origin:interactive'; then
 		echo "[pulse-wrapper] Deterministic merge: skipping auto-close of origin:interactive PR #${pr_number} — maintainer session work is never auto-closed" >>"$LOGFILE"
 		# GH#18650 (Fix 4): post a one-time rebase nudge so the maintainer
 		# has a visible signal that their CONFLICTING PR needs manual
@@ -644,6 +671,23 @@ _carry_forward_pr_diff() {
 	fi
 
 	# --- Build the append section ---
+	# t2383 Fix 4: compute dynamic fence length. PR diffs can contain triple
+	# backticks (markdown/docs changes). A fixed ``` fence would break rendering
+	# and corrupt the worker handoff. Scan for the longest backtick run in the
+	# diff and use one more than that.
+	local fence_len=3
+	local longest_run
+	longest_run=$(printf '%s' "$diff_content" | grep -oE '\`{3,}' | awk '{ if (length > max) max = length } END { print max+0 }') || longest_run=0
+	[[ "$longest_run" =~ ^[0-9]+$ ]] || longest_run=0
+	if [[ "$longest_run" -ge "$fence_len" ]]; then
+		fence_len=$((longest_run + 1))
+	fi
+	local fence=""
+	local _i
+	for (( _i=0; _i<fence_len; _i++ )); do
+		fence="${fence}\`"
+	done
+
 	local new_section
 	new_section="${marker}
 ## Prior worker attempt (PR #${pr_number}, closed CONFLICTING)
@@ -654,9 +698,9 @@ rebase/apply it rather than re-deriving the solution from scratch.
 
 <details><summary>Diff from PR #${pr_number} (click to expand)</summary>
 
-\`\`\`diff
+${fence}diff
 ${diff_content}${truncation_note}
-\`\`\`
+${fence}
 
 </details>"
 

--- a/.agents/scripts/pulse-merge-feedback.sh
+++ b/.agents/scripts/pulse-merge-feedback.sh
@@ -172,9 +172,16 @@ ${failing_checks}
 _Routed by deterministic merge pass (pulse-merge.sh)._"
 
 	# Append to issue body (marker-guarded for idempotency)
-	local current_body
+	# t2383 Fix 5: fail-safe — skip body edit when issue fetch fails to prevent
+	# clobbering the issue body with only the routed-feedback section.
+	local current_body ci_fetch_rc
+	ci_fetch_rc=0
 	current_body=$(gh issue view "$linked_issue" --repo "$repo_slug" \
-		--json body --jq '.body // ""' 2>/dev/null) || current_body=""
+		--json body --jq '.body // ""' 2>/dev/null) || ci_fetch_rc=$?
+	if [[ $ci_fetch_rc -ne 0 ]]; then
+		echo "[pulse-wrapper] _dispatch_ci_fix_worker: failed to fetch issue #${linked_issue} body (exit ${ci_fetch_rc}) — skipping body edit to prevent data loss (t2383)" >>"$LOGFILE"
+		return 0
+	fi
 
 	local marker="<!-- ci-feedback:PR${pr_number} -->"
 	if printf '%s' "$current_body" | grep -qF "$marker"; then
@@ -278,9 +285,16 @@ ${pr_files}
 _Routed by deterministic merge pass (pulse-merge.sh)._"
 
 	# Append to issue body (marker-guarded)
-	local current_body
+	# t2383 Fix 5: fail-safe — skip body edit when issue fetch fails to prevent
+	# clobbering the issue body with only the routed-feedback section.
+	local current_body conflict_fetch_rc
+	conflict_fetch_rc=0
 	current_body=$(gh issue view "$linked_issue" --repo "$repo_slug" \
-		--json body --jq '.body // ""' 2>/dev/null) || current_body=""
+		--json body --jq '.body // ""' 2>/dev/null) || conflict_fetch_rc=$?
+	if [[ $conflict_fetch_rc -ne 0 ]]; then
+		echo "[pulse-wrapper] _dispatch_conflict_fix_worker: failed to fetch issue #${linked_issue} body (exit ${conflict_fetch_rc}) — skipping body edit to prevent data loss (t2383)" >>"$LOGFILE"
+		return 0
+	fi
 
 	local marker="<!-- conflict-feedback:PR${pr_number} -->"
 	if printf '%s' "$current_body" | grep -qF "$marker"; then
@@ -414,9 +428,16 @@ _dispatch_pr_fix_worker() {
 	fi
 
 	# --- Append to linked issue body (marker-guarded for idempotency) ---
-	local current_body
+	# t2383 Fix 5: fail-safe — skip body edit when issue fetch fails to prevent
+	# clobbering the issue body with only the routed-feedback section.
+	local current_body review_fetch_rc
+	review_fetch_rc=0
 	current_body=$(gh issue view "$linked_issue" --repo "$repo_slug" \
-		--json body --jq '.body // ""' 2>/dev/null) || current_body=""
+		--json body --jq '.body // ""' 2>/dev/null) || review_fetch_rc=$?
+	if [[ $review_fetch_rc -ne 0 ]]; then
+		echo "[pulse-wrapper] _dispatch_pr_fix_worker: failed to fetch issue #${linked_issue} body (exit ${review_fetch_rc}) — skipping body edit to prevent data loss (t2383)" >>"$LOGFILE"
+		return 0
+	fi
 
 	local marker="<!-- t2093:review-feedback:PR${pr_number} -->"
 	local body_updated="false"

--- a/.agents/scripts/tests/test-pulse-merge-carry-forward-diff.sh
+++ b/.agents/scripts/tests/test-pulse-merge-carry-forward-diff.sh
@@ -414,6 +414,80 @@ GHEOF
 	return 0
 }
 
+# ---------------------------------------------------------------
+# Test 7: t2383 Fix 4 — diff containing triple backticks uses dynamic fence
+# A diff that modifies markdown files can contain ``` runs.
+# The carry-forward function must use a fence longer than the longest
+# backtick run in the diff content so rendering is not corrupted.
+# ---------------------------------------------------------------
+test_dynamic_fence_with_triple_backticks() {
+	install_gh_stub
+	: >"$LOGFILE"
+
+	# Create a diff that contains triple backticks (common in markdown diffs)
+	local diff_with_backticks
+	diff_with_backticks='diff --git a/README.md b/README.md
+--- a/README.md
++++ b/README.md
+@@ -1,5 +1,8 @@
+ # My Project
+ 
++```bash
++echo "hello world"
++```
++
+ Some text here.'
+	printf '%s' "$diff_with_backticks" >"$GH_DIFF_FILE"
+	printf 'Existing issue body.' >"$GH_ISSUE_BODY_FILE"
+	: >"$GH_EDITED_BODY_FILE"
+
+	_carry_forward_pr_diff "50" "owner/repo" "30"
+
+	local edited
+	edited=$(cat "$GH_EDITED_BODY_FILE")
+
+	# The fence in the output must be longer than the 3-backtick runs in the diff.
+	# So we expect at least ```` (4 backticks) as the fence.
+	if printf '%s' "$edited" | grep -qE '^\`{4,}diff$'; then
+		print_result "dynamic fence: uses 4+ backtick fence for diff with triple backticks" 0
+	else
+		# Check if the old static fence is still there (regression)
+		if printf '%s' "$edited" | grep -qE '^\`{3}diff$'; then
+			print_result "dynamic fence: uses 4+ backtick fence" 1 \
+				"Still using 3-backtick fence — dynamic fence not applied"
+		else
+			print_result "dynamic fence: uses 4+ backtick fence" 1 \
+				"Could not find fence line in output. Body: ${edited:0:500}"
+		fi
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------
+# Test 8: t2383 Fix 4 — diff without backticks keeps standard 3-fence
+# ---------------------------------------------------------------
+test_standard_fence_without_backticks() {
+	install_gh_stub
+	: >"$LOGFILE"
+	printf 'diff --git a/foo.sh b/foo.sh\n+added line\n' >"$GH_DIFF_FILE"
+	printf 'Existing issue body.' >"$GH_ISSUE_BODY_FILE"
+	: >"$GH_EDITED_BODY_FILE"
+
+	_carry_forward_pr_diff "51" "owner/repo" "31"
+
+	local edited
+	edited=$(cat "$GH_EDITED_BODY_FILE")
+
+	# Standard diff without backticks should use exactly 3-backtick fence
+	if printf '%s' "$edited" | grep -qE '^\`{3}diff$'; then
+		print_result "standard fence: 3-backtick fence for plain diff" 0
+	else
+		print_result "standard fence: 3-backtick fence for plain diff" 1 \
+			"Expected 3-backtick fence. Body: ${edited:0:500}"
+	fi
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
@@ -429,6 +503,8 @@ main() {
 	test_origin_interactive_skip_static
 	test_empty_diff_skipped
 	test_issue_view_failure_skipped
+	test_dynamic_fence_with_triple_backticks
+	test_standard_fence_without_backticks
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-fix-worker-dispatch.sh
@@ -381,6 +381,86 @@ test_dispatch_clears_in_progress_labels_as_fallback() {
 	return 0
 }
 
+# ---------------------------------------------------------------
+# t2383 Fix 5: _dispatch_pr_fix_worker skips body edit on issue view failure
+# When `gh issue view` fails, the function must NOT proceed to
+# `gh issue edit` (which would clobber the body with only the feedback).
+# ---------------------------------------------------------------
+test_dispatch_skips_body_edit_on_issue_view_failure() {
+	reset_mock_state
+
+	# Override gh stub to fail on `issue view`
+	cat >"${TEST_ROOT}/bin/gh" <<'GHEOF'
+#!/usr/bin/env bash
+printf '%s\n' "gh $*" >>"${GH_LOG:-/dev/null}"
+
+_all_args=("$@")
+_subcmd="${1:-} ${2:-}"
+
+case "$_subcmd" in
+"label create") exit 0 ;;
+"pr view") exit 0 ;;
+"pr close" | "pr edit") exit 0 ;;
+"issue view") exit 1 ;;
+"issue edit")
+	# Should NOT be reached — if it is, the test fails
+	printf 'CLOBBERED' >"${TEST_ROOT}/clobber-marker.txt"
+	exit 0
+	;;
+esac
+
+if [[ "${1:-}" == "api" ]]; then
+	_jq_filter=""
+	for _i in "${!_all_args[@]}"; do
+		if [[ "${_all_args[$_i]}" == "--jq" ]]; then
+			_jq_filter="${_all_args[$((_i + 1))]:-}"
+			break
+		fi
+	done
+	if [[ "$*" == *"/pulls/"*"/reviews"* ]]; then
+		if [[ -n "$_jq_filter" ]]; then
+			jq "$_jq_filter" <"${TEST_ROOT}/reviews.json"
+		else
+			cat "${TEST_ROOT}/reviews.json"
+		fi
+		exit 0
+	fi
+	if [[ "$*" == *"/pulls/"*"/comments"* ]]; then
+		if [[ -n "$_jq_filter" ]]; then
+			jq "$_jq_filter" <"${TEST_ROOT}/comments.json"
+		else
+			cat "${TEST_ROOT}/comments.json"
+		fi
+		exit 0
+	fi
+fi
+exit 0
+GHEOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+
+	: >"$GH_LOG"
+	: >"$LOGFILE"
+	rm -f "${TEST_ROOT}/clobber-marker.txt"
+
+	_dispatch_pr_fix_worker "100" "owner/repo" "42"
+
+	# The clobber marker should NOT exist (issue edit should not have been called)
+	if [[ -f "${TEST_ROOT}/clobber-marker.txt" ]]; then
+		print_result "t2383: dispatch skips body edit on issue view failure" 1 \
+			"gh issue edit was called after gh issue view failure — data loss risk"
+		return 0
+	fi
+
+	if ! grep -q "failed to fetch issue.*body.*skipping body edit.*prevent data loss" "$LOGFILE"; then
+		print_result "t2383: dispatch logs skip reason on issue view failure" 1 \
+			"Expected data-loss prevention log. Got: $(cat "$LOGFILE")"
+		return 0
+	fi
+
+	print_result "t2383: dispatch skips body edit on issue view failure (data loss guard)" 0
+	return 0
+}
+
 main() {
 	trap teardown_test_env EXIT
 	setup_test_env
@@ -397,6 +477,7 @@ main() {
 	test_dispatch_noop_when_no_substantive_feedback
 	test_dispatch_noop_on_invalid_inputs
 	test_dispatch_clears_in_progress_labels_as_fallback
+	test_dispatch_skips_body_edit_on_issue_view_failure
 
 	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-pulse-merge-interactive-handover.sh
+++ b/.agents/scripts/tests/test-pulse-merge-interactive-handover.sh
@@ -319,6 +319,105 @@ test_J_enforce_is_idempotent_when_label_already_present() {
 }
 
 # =============================================================================
+# t2383 Fix 1: no-takeover label opt-out halts handover trigger
+# =============================================================================
+
+test_K_no_takeover_label_blocks_handover() {
+	reset_mock_state
+	# Add no-takeover to the PR labels
+	printf 'origin:interactive,no-takeover' >"${TEST_ROOT}/labels.txt"
+	: >"${TEST_ROOT}/idempotent-comments.log"
+	AIDEVOPS_INTERACTIVE_PR_HANDOVER_MODE=enforce _interactive_pr_trigger_handover "100" "owner/repo"
+	# Should NOT call issue edit to add the label
+	if grep -q "issue edit.*--add-label.*origin:worker-takeover" "$GH_LOG"; then
+		print_result "K: no-takeover label blocks handover label application" 1 \
+			"Unexpected label add call: $(cat "$GH_LOG")"
+		return 0
+	fi
+	# Should NOT post a comment
+	if [[ -s "${TEST_ROOT}/idempotent-comments.log" ]]; then
+		print_result "K: no-takeover label blocks handover comment" 1 "Unexpected comment call"
+		return 0
+	fi
+	# Should have a log entry about the skip
+	if ! grep -q "no-takeover label.*skipping handover" "$LOGFILE"; then
+		print_result "K: no-takeover label logs skip reason" 1 \
+			"Expected 'no-takeover label' skip message in LOGFILE. Got: $(cat "$LOGFILE")"
+		return 0
+	fi
+	print_result "K: no-takeover label halts handover trigger" 0
+	return 0
+}
+
+# =============================================================================
+# t2383 Fix 2: invalid HOURS value returns not-stale safely
+# =============================================================================
+
+test_L_invalid_hours_returns_not_stale() {
+	reset_mock_state
+	# "24h" is non-numeric — should not crash bash arithmetic
+	AIDEVOPS_INTERACTIVE_PR_HANDOVER_HOURS="24h" \
+	AIDEVOPS_INTERACTIVE_PR_HANDOVER_MODE=enforce \
+		_interactive_pr_is_stale "100" "owner/repo"
+	local rc=$?
+	if [[ "$rc" -ne 1 ]]; then
+		print_result "L: invalid HOURS ('24h') returns not-stale" 1 "Expected 1, got $rc"
+		return 0
+	fi
+	if ! grep -q "invalid AIDEVOPS_INTERACTIVE_PR_HANDOVER_HOURS" "$LOGFILE"; then
+		print_result "L: invalid HOURS logs validation error" 1 \
+			"Expected validation error in LOGFILE. Got: $(cat "$LOGFILE")"
+		return 0
+	fi
+	print_result "L: invalid HOURS returns not-stale with log message" 0
+	return 0
+}
+
+test_L2_zero_hours_returns_not_stale() {
+	reset_mock_state
+	AIDEVOPS_INTERACTIVE_PR_HANDOVER_HOURS="0" \
+	AIDEVOPS_INTERACTIVE_PR_HANDOVER_MODE=enforce \
+		_interactive_pr_is_stale "100" "owner/repo"
+	local rc=$?
+	if [[ "$rc" -ne 1 ]]; then
+		print_result "L2: zero HOURS returns not-stale" 1 "Expected 1, got $rc"
+		return 0
+	fi
+	print_result "L2: zero HOURS returns not-stale" 0
+	return 0
+}
+
+test_L3_empty_hours_uses_default_24() {
+	reset_mock_state
+	# Empty HOURS triggers bash's :- default substitution to "24", which is valid.
+	# The PR is 48h old (reset_mock_state default), so it should return stale (0).
+	AIDEVOPS_INTERACTIVE_PR_HANDOVER_HOURS="" \
+	AIDEVOPS_INTERACTIVE_PR_HANDOVER_MODE=enforce \
+		_interactive_pr_is_stale "100" "owner/repo"
+	local rc=$?
+	if [[ "$rc" -ne 0 ]]; then
+		print_result "L3: empty HOURS falls back to default 24 (stale)" 1 "Expected 0 (stale), got $rc"
+		return 0
+	fi
+	print_result "L3: empty HOURS falls back to default 24 (stale)" 0
+	return 0
+}
+
+test_L4_negative_hours_returns_not_stale() {
+	reset_mock_state
+	AIDEVOPS_INTERACTIVE_PR_HANDOVER_HOURS="-5" \
+	AIDEVOPS_INTERACTIVE_PR_HANDOVER_MODE=enforce \
+		_interactive_pr_is_stale "100" "owner/repo"
+	local rc=$?
+	if [[ "$rc" -ne 1 ]]; then
+		print_result "L4: negative HOURS returns not-stale" 1 "Expected 1, got $rc"
+		return 0
+	fi
+	print_result "L4: negative HOURS returns not-stale" 0
+	return 0
+}
+
+# =============================================================================
 # Main
 # =============================================================================
 
@@ -350,6 +449,11 @@ main() {
 	test_H_mode_detect_is_noop
 	test_I_mode_enforce_applies_label_and_posts_comment
 	test_J_enforce_is_idempotent_when_label_already_present
+	test_K_no_takeover_label_blocks_handover
+	test_L_invalid_hours_returns_not_stale
+	test_L2_zero_hours_returns_not_stale
+	test_L3_empty_hours_uses_default_24
+	test_L4_negative_hours_returns_not_stale
 
 	printf '\n=== %d test(s), %d failure(s) ===\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Resolves #19846

Five reliability fixes from CodeRabbit findings on PR #19842 (GH#19836: pulse-merge.sh split). All five existed on `main` before the split — pure lift-and-shift code that shipped with pre-existing error-handling gaps.

## Changes

### 1. `no-takeover` label guard (pulse-merge-conflict.sh)
`_interactive_pr_trigger_handover` now checks for the `no-takeover` label before applying `origin:worker-takeover`, honouring the opt-out promise in the handover comment. Previously, the function only checked for the existing `origin:worker-takeover` label (idempotence) but ignored `no-takeover`.

### 2. HOURS env var validation (pulse-merge-conflict.sh)
`_interactive_pr_is_stale` validates `AIDEVOPS_INTERACTIVE_PR_HANDOVER_HOURS` is a positive integer before arithmetic. Non-numeric values (e.g. `24h`, empty, negative) previously triggered bash "value too great for base" errors, silently breaking stale detection.

### 3. Fail-closed label fetch (pulse-merge-conflict.sh)
`_close_conflicting_pr` now fails closed when `gh pr view` returns an error (protecting potential `origin:interactive` PRs from auto-close on transient API failures) and uses `grep -Fxq` for exact label matching instead of `grep -q` (substring match).

### 4. Dynamic markdown fence (pulse-merge-conflict.sh)
`_carry_forward_pr_diff` computes fence length from the longest backtick run in the diff content. Previously used a fixed triple-backtick fence that would break rendering when the diff contained markdown files with their own triple backtick code blocks.

### 5. Body clobber prevention (pulse-merge-feedback.sh)
All three feedback routers (`_dispatch_ci_fix_worker`, `_dispatch_conflict_fix_worker`, `_dispatch_pr_fix_worker`) now skip body edits when `gh issue view` fails, preventing data loss. Previously, `|| current_body=""` meant a transient API failure followed by a successful PUT would replace the entire issue body with only the feedback section.

## Testing

All 73 tests across 9 pulse-merge test suites pass (0 failures). Added 7 new regression tests:

- **K**: no-takeover label blocks handover trigger
- **L/L2/L3/L4**: invalid/zero/empty/negative HOURS validation
- **Test 7/8**: dynamic fence for diffs with/without triple backticks
- **Fix 5 test**: body edit skipped on issue view failure


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.74 plugin for [OpenCode](https://opencode.ai) v1.14.17 with claude-opus-4-6 spent 12m and 22,143 tokens on this as a headless worker.