### PR TITLE
GH#19739: GH#19739: refactor(pre-commit): ratchet-style validators (block on increase, pass pre-existing)

### DIFF
--- a/.agents/scripts/pre-commit-hook.sh
+++ b/.agents/scripts/pre-commit-hook.sh
@@ -12,6 +12,47 @@ set -euo pipefail
 
 # Color codes for output
 
+# --- Ratchet helpers (t2230) --------------------------------------------------
+# Quality validators compare the staged file's violation count against its HEAD
+# count and only block on INCREASE. This mirrors the pattern used by
+# qlty-regression-helper.sh (t2065) and qlty-new-file-gate-helper.sh (t2068):
+# blocks new debt without trapping authors on pre-existing legacy violations.
+#
+# SECURITY EXCEPTION: check_secrets remains absolute-count — a newly introduced
+# hardcoded credential is a CVE-class event regardless of pre-existing state.
+# Per AGENTS.md "Gate design — ratchet, not absolute (t2228 class)":
+# "security/credentials checks are absolute — a new violation is P1 regardless."
+
+# Return file content at HEAD for a given path. Prints empty output for new
+# files or when HEAD does not yet exist (first commit). Always exits 0 so the
+# callers can `head_content=$(_get_head_content "$file")` without tripping
+# `set -e`.
+_get_head_content() {
+	local _file="$1"
+	git show "HEAD:$_file" 2>/dev/null || true
+	return 0
+}
+
+# Materialize HEAD content of a file into a temp file with the same basename
+# (so shellcheck can pick up shebang + extension cues). Prints the temp path
+# on stdout; caller is responsible for removing the containing directory.
+# Returns 1 with empty stdout when there is no HEAD version (new file).
+_make_head_temp() {
+	local _file="$1"
+	local _head_content
+	_head_content=$(_get_head_content "$_file")
+	if [[ -z "$_head_content" ]]; then
+		return 1
+	fi
+	local _tmpdir _tmpfile _base
+	_tmpdir=$(mktemp -d) || return 1
+	_base=$(basename "$_file")
+	_tmpfile="$_tmpdir/$_base"
+	printf '%s\n' "$_head_content" >"$_tmpfile"
+	printf '%s\n' "$_tmpfile"
+	return 0
+}
+
 # Get list of modified shell files
 get_modified_shell_files() {
 	git diff --cached --name-only --diff-filter=ACM | grep '\.sh$' || true
@@ -86,19 +127,34 @@ validate_duplicate_task_ids() {
 validate_return_statements() {
 	local violations=0
 
-	print_info "Validating return statements..."
+	print_info "Validating return statements (ratchet)..."
 
 	for file in "$@"; do
 		if [[ -f "$file" ]]; then
-			# Check for functions without return statements
-			local functions
-			functions=$(grep -c "^[a-zA-Z_][a-zA-Z0-9_]*() {" "$file" || true)
-			local returns
-			returns=$(grep -c "return [01]" "$file" || true)
+			# Count missing-return functions in staged version.
+			local staged_funcs staged_returns staged_missing=0
+			staged_funcs=$(grep -c "^[a-zA-Z_][a-zA-Z0-9_]*() {" "$file" || true)
+			staged_returns=$(grep -c "return [01]" "$file" || true)
+			if ((staged_funcs > 0 && staged_returns < staged_funcs)); then
+				staged_missing=$((staged_funcs - staged_returns))
+			fi
 
-			if [[ $functions -gt 0 && $returns -lt $functions ]]; then
-				print_error "Missing return statements in $file"
+			# Count missing-return functions in HEAD version (if file exists).
+			local head_content head_funcs head_returns head_missing=0
+			head_content=$(_get_head_content "$file")
+			if [[ -n "$head_content" ]]; then
+				head_funcs=$(printf '%s\n' "$head_content" | grep -c "^[a-zA-Z_][a-zA-Z0-9_]*() {" || true)
+				head_returns=$(printf '%s\n' "$head_content" | grep -c "return [01]" || true)
+				if ((head_funcs > 0 && head_returns < head_funcs)); then
+					head_missing=$((head_funcs - head_returns))
+				fi
+			fi
+
+			if ((staged_missing > head_missing)); then
+				print_error "NEW missing return statements in $file (new: $((staged_missing - head_missing)), pre-existing: $head_missing)"
 				((++violations))
+			elif ((staged_missing > 0)); then
+				print_warning "Pre-existing missing returns in $file: $staged_missing (not blocking)"
 			fi
 		fi
 	done
@@ -109,44 +165,65 @@ validate_return_statements() {
 validate_positional_parameters() {
 	local violations=0
 
-	print_info "Validating positional parameters..."
+	print_info "Validating positional parameters (ratchet)..."
+
+	# Shared awk script — extracted so we can run it over both staged content
+	# (the on-disk file) and HEAD content (piped from git show).
+	# shellcheck disable=SC2016  # $1, $[1-9] etc. are awk regex literals, not shell expansions
+	local _awk_script='
+	{
+		line = $0
+		# Strip single-quoted segments — shell does not expand $ inside single quotes,
+		# so awk field refs like awk '"'"'$1 >= 3'"'"' are not positional params.
+		# \047 is octal for single-quote (avoids shell quoting issues).
+		gsub(/\047[^\047]*\047/, "", line)
+		# Skip pure comment lines (after stripping quoted content)
+		if (line ~ /^[[:space:]]*#/) next
+		# Strip inline comments
+		sub(/[[:space:]]+#.*/, "", line)
+		# Skip lines with local var assignments (proper usage pattern)
+		if (line ~ /local[[:space:]].*=.*\$[1-9]/) next
+		# Skip currency/pricing patterns: $N followed by digit, decimal, comma, slash
+		if (line ~ /\$[1-9][0-9.,\/]/) next
+		# Skip markdown table cells: $N followed by pipe
+		if (line ~ /\$[1-9][[:space:]]*\|/) next
+		# Skip pricing unit words
+		if (line ~ /\$[1-9][[:space:]]+(per|mo(nth)?|year|yr|day|week|hr|hour|flat|each|off|fee|plan|tier|user|seat|unit|addon|setup|trial|credit|annual|quarterly|monthly)/) next
+		# After stripping, if $[1-9] is still present, flag as violation
+		if (line ~ /\$[1-9]/) print NR ": " $0
+	}'
 
 	for file in "$@"; do
+		# Skip test files — fixtures deliberately inject bare positional
+		# parameter usage to exercise the validator. See validate_string_literals
+		# for the same rationale.
+		if [[ "$file" == *"/tests/"* ]] || [[ "$(basename "$file")" == test-*.sh ]]; then
+			continue
+		fi
+
 		if [[ -f "$file" ]]; then
-			local violations_output
-			# Use awk to strip single-quoted segments and comments before scanning.
-			# This prevents false positives on:
-			#   - awk field references: awk '$1 >= 3' (not shell positional params)
-			#   - doc comments: # Arguments: $1=name (comments aren't executed)
-			# Exclusion patterns (currency, local assignments, pipes, pricing words)
-			# are preserved from the original grep pipeline.
-			# shellcheck disable=SC2016  # $1, $[1-9] etc. are awk regex literals, not shell expansions
-			violations_output=$(awk '
-			{
-				line = $0
-				# Strip single-quoted segments — shell does not expand $ inside single quotes,
-				# so awk field refs like awk '"'"'$1 >= 3'"'"' are not positional params.
-				# \047 is octal for single-quote (avoids shell quoting issues).
-				gsub(/\047[^\047]*\047/, "", line)
-				# Skip pure comment lines (after stripping quoted content)
-				if (line ~ /^[[:space:]]*#/) next
-				# Strip inline comments
-				sub(/[[:space:]]+#.*/, "", line)
-				# Skip lines with local var assignments (proper usage pattern)
-				if (line ~ /local[[:space:]].*=.*\$[1-9]/) next
-				# Skip currency/pricing patterns: $N followed by digit, decimal, comma, slash
-				if (line ~ /\$[1-9][0-9.,\/]/) next
-				# Skip markdown table cells: $N followed by pipe
-				if (line ~ /\$[1-9][[:space:]]*\|/) next
-				# Skip pricing unit words
-				if (line ~ /\$[1-9][[:space:]]+(per|mo(nth)?|year|yr|day|week|hr|hour|flat|each|off|fee|plan|tier|user|seat|unit|addon|setup|trial|credit|annual|quarterly|monthly)/) next
-				# After stripping, if $[1-9] is still present, flag as violation
-				if (line ~ /\$[1-9]/) print NR ": " $0
-			}' "$file") || true
-			if [[ -n "$violations_output" ]]; then
-				print_error "Direct positional parameter usage in $file"
-				echo "$violations_output" | head -3
+			local staged_output head_output
+			local staged_count=0 head_count=0
+			staged_output=$(awk "$_awk_script" "$file" 2>/dev/null || true)
+			if [[ -n "$staged_output" ]]; then
+				staged_count=$(printf '%s\n' "$staged_output" | wc -l | tr -d ' ')
+			fi
+
+			local head_content
+			head_content=$(_get_head_content "$file")
+			if [[ -n "$head_content" ]]; then
+				head_output=$(printf '%s\n' "$head_content" | awk "$_awk_script" 2>/dev/null || true)
+				if [[ -n "$head_output" ]]; then
+					head_count=$(printf '%s\n' "$head_output" | wc -l | tr -d ' ')
+				fi
+			fi
+
+			if ((staged_count > head_count)); then
+				print_error "NEW direct positional parameter usage in $file (new: $((staged_count - head_count)), pre-existing: $head_count)"
+				echo "$staged_output" | head -3
 				((++violations))
+			elif ((staged_count > 0)); then
+				print_warning "Pre-existing positional parameter usage in $file: $staged_count (not blocking)"
 			fi
 		fi
 	done
@@ -154,27 +231,78 @@ validate_positional_parameters() {
 	return $violations
 }
 
+# Extract the distinct-repeated-literal detection pipeline into a single helper
+# so the patterns are defined once. Keeps validate_string_literals from
+# dogfooding itself (4× repeated literal regexes in-source).
+# Reads content on stdin, prints "<count>" of distinct literals repeated ≥3×.
+_count_repeated_literals() {
+	local _ext_literal='"[^"]{4,}"'
+	local _ext_numeric='^"[0-9]+\.?[0-9]*"$'
+	local _ext_varref='^"\$'
+	grep -v '^\s*#' |
+		grep -oE "$_ext_literal" |
+		grep -vE "$_ext_numeric" |
+		grep -vE "$_ext_varref" |
+		sort | uniq -c | awk '$1 >= 3' | wc -l | tr -d ' '
+	return 0
+}
+
+# Same pipeline but prints the top-3 "count: literal" display form.
+_show_repeated_literals() {
+	local _ext_literal='"[^"]{4,}"'
+	local _ext_numeric='^"[0-9]+\.?[0-9]*"$'
+	local _ext_varref='^"\$'
+	grep -v '^\s*#' |
+		grep -oE "$_ext_literal" |
+		grep -vE "$_ext_numeric" |
+		grep -vE "$_ext_varref" |
+		sort | uniq -c | awk '$1 >= 3 {print "  " $1 "x: " $2}' | head -3
+	return 0
+}
+
 validate_string_literals() {
 	local violations=0
 
-	print_info "Validating string literals..."
+	print_info "Validating string literals (ratchet)..."
 
 	for file in "$@"; do
+		# Skip test files — fixtures legitimately repeat assertion strings
+		# and sample inputs to exercise the patterns they verify. Blocking
+		# these produces false positives that force test authors to obscure
+		# their fixtures.
+		if [[ "$file" == *"/tests/"* ]] || [[ "$(basename "$file")" == test-*.sh ]]; then
+			continue
+		fi
+
 		if [[ -f "$file" ]]; then
-			# Check for repeated string literals in code lines only.
+			# Count DISTINCT literals repeated >= 3 times in code lines.
 			# Exclusions (false-positive classes):
 			#   - Comment-only lines (^\s*#) — documentation, not code
 			#   - Numeric strings ("123", "3.14") — version numbers, counts
-			#   - Shell variable references ("$var", "${var}") — proper quoting, not literals
-			local repeated
-			repeated=$(grep -v '^\s*#' "$file" | grep -oE '"[^"]{4,}"' | grep -vE '^"[0-9]+\.?[0-9]*"$' | grep -vE '^"\$' | sort | uniq -c | awk '$1 >= 3' | wc -l || true)
+			#   - Shell variable references ("$var", "${var}") — interpolations, not literals
+			#   - Strings shorter than 4 chars — covers "", "$1", "$@", "$?" etc.
+			local staged_repeated head_repeated=0
+			staged_repeated=$(<"$file" _count_repeated_literals)
+			[[ -z "$staged_repeated" ]] && staged_repeated=0
 
-			if [[ $repeated -gt 0 ]]; then
-				print_warning "Repeated string literals in $file (consider using constants)"
-				grep -v '^\s*#' "$file" | grep -oE '"[^"]{4,}"' | grep -vE '^"[0-9]+\.?[0-9]*"$' | grep -vE '^"\$' | sort | uniq -c | awk '$1 >= 3 {print "  " $1 "x: " $2}' | head -3
-				# print_warning is advisory — do NOT increment violations counter
-				# (AGENTS.md "Gate design — ratchet, not absolute (t2228 class)"):
-				# test files legitimately repeat assertion strings; this should inform, not block.
+			local head_content
+			head_content=$(_get_head_content "$file")
+			if [[ -n "$head_content" ]]; then
+				head_repeated=$(printf '%s\n' "$head_content" | _count_repeated_literals)
+				[[ -z "$head_repeated" ]] && head_repeated=0
+			fi
+
+			if ((staged_repeated > head_repeated)); then
+				# NEW repeated literals introduced by this commit — ratchet blocks.
+				print_error "NEW repeated string literals in $file (new: $((staged_repeated - head_repeated)), pre-existing: $head_repeated)"
+				<"$file" _show_repeated_literals
+				((++violations))
+			elif ((staged_repeated > 0)); then
+				# Pre-existing debt — advisory only, never blocks. Test fixtures
+				# legitimately repeat assertion strings; maintenance commits must
+				# not be trapped by legacy files they merely touch.
+				print_warning "Pre-existing repeated string literals in $file: $staged_repeated distinct literal(s) (not blocking)"
+				<"$file" _show_repeated_literals
 			fi
 		fi
 	done
@@ -185,12 +313,39 @@ validate_string_literals() {
 run_shellcheck() {
 	local violations=0
 
-	print_info "Running ShellCheck validation..."
+	print_info "Running ShellCheck validation (ratchet)..."
 
+	# ShellCheck regressions are quality debt, not CVE-class — ratchet applies.
+	# New files with ANY findings still block (head_count=0 → staged_count > 0
+	# is a strict increase). Files that already carried findings on main can be
+	# touched without paying down their legacy debt in the same commit.
 	for file in "$@"; do
-		if [[ -f "$file" ]] && ! shellcheck "$file"; then
-			print_error "ShellCheck violations in $file"
+		if [[ ! -f "$file" ]]; then
+			continue
+		fi
+
+		# Count staged-file findings (gcc format: one finding per line).
+		local staged_count head_count=0
+		staged_count=$(shellcheck -f gcc "$file" 2>/dev/null | grep -c ':[[:space:]]' || true)
+		[[ -z "$staged_count" ]] && staged_count=0
+
+		# Count HEAD findings by materializing the content into a temp file
+		# that preserves the basename (so shellcheck uses shebang/ext heuristics).
+		local head_tmp head_dir
+		if head_tmp=$(_make_head_temp "$file"); then
+			head_dir=$(dirname "$head_tmp")
+			head_count=$(shellcheck -f gcc "$head_tmp" 2>/dev/null | grep -c ':[[:space:]]' || true)
+			[[ -z "$head_count" ]] && head_count=0
+			rm -rf "$head_dir"
+		fi
+
+		if ((staged_count > head_count)); then
+			print_error "NEW ShellCheck violations in $file (new: $((staged_count - head_count)), pre-existing: $head_count)"
+			# Re-run for full-detail output so the author can fix the new findings.
+			shellcheck "$file" || true
 			((++violations))
+		elif ((staged_count > 0)); then
+			print_warning "Pre-existing ShellCheck violations in $file: $staged_count (not blocking)"
 		fi
 	done
 
@@ -198,11 +353,15 @@ run_shellcheck() {
 }
 
 check_secrets() {
+	# SECURITY EXCEPTION (t2230, AGENTS.md "Gate design — ratchet, not absolute"):
+	# Credential/secret detection is ABSOLUTE-COUNT by design. A newly exposed
+	# secret is a CVE-class event regardless of pre-existing state. Do NOT
+	# convert this validator to ratchet semantics.
 	local violations=0
 	local secrets_clean_msg="No secrets detected in staged files"
 	local secrets_found_msg="Potential secrets detected in staged files!"
 
-	print_info "Checking for exposed secrets (Secretlint)..."
+	print_info "Checking for exposed secrets (Secretlint, absolute-count security gate)..."
 
 	# Get staged files
 	local staged_files

--- a/.agents/scripts/tests/test-pre-commit-hook-warning-decoupling.sh
+++ b/.agents/scripts/tests/test-pre-commit-hook-warning-decoupling.sh
@@ -1,19 +1,24 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
-# test-pre-commit-hook-warning-decoupling.sh — Tests that validate_string_literals
-# emits a WARNING without blocking (exit 0) when repeated literals are found.
+# test-pre-commit-hook-warning-decoupling.sh — Tests that the advisory
+# (print_warning) branch of validate_string_literals does NOT increment the
+# violations counter. Only the error branch (new introductions under ratchet
+# semantics) may increment.
 #
-# Regression: GH#19839 (t2228 anti-pattern) — print_warning was incorrectly
-# incrementing the violations counter, turning an advisory into a commit blocker.
+# Regression history:
+#   - GH#19839 (t2228 anti-pattern) — print_warning was incorrectly
+#     incrementing the violations counter, turning an advisory into a blocker.
+#   - t2230 — validator upgraded to ratchet semantics (head-vs-staged diff).
+#     The advisory invariant is preserved: pre-existing debt emits a warning
+#     and never blocks; only NEW literals emit an error and block.
 #
-# Tests:
-#   1. validate_string_literals exits 0 on a file with repeated string literals
-#      (confirm: advisory warning does NOT block the commit)
-#   2. validate_string_literals emits "[WARNING]" text to stderr
-#   3. validate_string_literals exits 0 on a clean file (no repeated literals)
-#   4. Smoke: the full pre-commit-hook.sh exits 0 when only repeated literals
-#      are staged (the warning is informational only)
+# What this test guards:
+#   1. The warning branch (pre-existing literals) does NOT increment violations.
+#   2. The "[WARNING]" marker still appears in stderr for pre-existing debt.
+#   3. A clean file (no repeated literals) exits 0 silently.
+#   4. The real hook source preserves this structure — ((++violations)) only
+#      appears inside the print_error branch, never in the print_warning branch.
 
 set -euo pipefail
 
@@ -60,17 +65,26 @@ teardown() {
 }
 
 # ---------------------------------------------------------------------------
-# Helper: define validate_string_literals in isolation (no full-hook source).
-# We inline the function with minimal stubs so the test is self-contained and
-# does not break on shared-constants.sh color dependencies in CI.
-# The inlined function body MUST match the fixed version in pre-commit-hook.sh.
+# Helper: simulate the ratchet-aware validate_string_literals in isolation.
+# Pre-existing state is stubbed via _stub_head_content, so the test is
+# self-contained and doesn't require a real git HEAD.
+# The inlined function body MUST match the ratchet version in pre-commit-hook.sh.
 # ---------------------------------------------------------------------------
 WARNING_CAPTURED=""
+ERROR_CAPTURED=""
+STUB_HEAD_CONTENT=""
 
 stub_print_warning() {
 	local msg="$1"
 	WARNING_CAPTURED="$msg"
 	echo "[WARNING] $msg" >&2
+	return 0
+}
+
+stub_print_error() {
+	local msg="$1"
+	ERROR_CAPTURED="$msg"
+	echo "[ERROR] $msg" >&2
 	return 0
 }
 
@@ -80,24 +94,36 @@ stub_print_info() {
 	return 0
 }
 
-# Define the function under test using the fixed implementation.
-# This avoids sourcing the full hook (which requires git context, secretlint, etc.).
+_stub_get_head_content() {
+	printf '%s' "$STUB_HEAD_CONTENT"
+	return 0
+}
+
+# Ratchet-aware validator. Mirrors validate_string_literals in
+# pre-commit-hook.sh but with stubbed head-content and print_* helpers.
 validate_string_literals_under_test() {
 	local violations=0
 
-	stub_print_info "Validating string literals..."
+	stub_print_info "Validating string literals (ratchet)..."
 
 	for file in "$@"; do
 		if [[ -f "$file" ]]; then
-			local repeated
-			repeated=$(grep -oE '"[^"]{4,}"' "$file" | grep -vE '^"[0-9]+\.?[0-9]*"$' | sort | uniq -c | awk '$1 >= 3' | wc -l || true)
+			local staged_repeated head_repeated=0
+			staged_repeated=$(grep -v '^\s*#' "$file" | grep -oE '"[^"]{4,}"' | grep -vE '^"[0-9]+\.?[0-9]*"$' | grep -vE '^"\$' | sort | uniq -c | awk '$1 >= 3' | wc -l | tr -d ' ')
+			[[ -z "$staged_repeated" ]] && staged_repeated=0
 
-			if [[ $repeated -gt 0 ]]; then
-				stub_print_warning "Repeated string literals in $file (consider using constants)"
-				grep -oE '"[^"]{4,}"' "$file" | grep -vE '^"[0-9]+\.?[0-9]*"$' | sort | uniq -c | awk '$1 >= 3 {print "  " $1 "x: " $2}' | head -3
-				# print_warning is advisory — do NOT increment violations counter
-				# (AGENTS.md "Gate design — ratchet, not absolute (t2228 class)"):
-				# test files legitimately repeat assertion strings; this should inform, not block.
+			local head_content
+			head_content=$(_stub_get_head_content)
+			if [[ -n "$head_content" ]]; then
+				head_repeated=$(printf '%s\n' "$head_content" | grep -v '^\s*#' | grep -oE '"[^"]{4,}"' | grep -vE '^"[0-9]+\.?[0-9]*"$' | grep -vE '^"\$' | sort | uniq -c | awk '$1 >= 3' | wc -l | tr -d ' ')
+				[[ -z "$head_repeated" ]] && head_repeated=0
+			fi
+
+			if ((staged_repeated > head_repeated)); then
+				stub_print_error "NEW repeated string literals in $file (new: $((staged_repeated - head_repeated)), pre-existing: $head_repeated)"
+				((++violations))
+			elif ((staged_repeated > 0)); then
+				stub_print_warning "Pre-existing repeated string literals in $file: $staged_repeated distinct literal(s) (not blocking)"
 			fi
 		fi
 	done
@@ -106,11 +132,10 @@ validate_string_literals_under_test() {
 }
 
 # ---------------------------------------------------------------------------
-# Test 1: validate_string_literals exits 0 on file with repeated literals
+# Test 1: Pre-existing literals equal to staged → WARNING branch, no increment.
 # ---------------------------------------------------------------------------
-test_returns_zero_with_repeated_literals() {
-	local fixture="${TEST_ROOT}/repeated_literals.sh"
-	# Create a file with the same string appearing 4 times (threshold is 3)
+test_warning_branch_does_not_increment() {
+	local fixture="${TEST_ROOT}/preexisting_literals.sh"
 	cat >"$fixture" <<'EOF'
 #!/usr/bin/env bash
 msg1="assert this string"
@@ -119,24 +144,28 @@ msg3="assert this string"
 msg4="assert this string"
 EOF
 
+	# Head content is identical — pre-existing debt, no new introduction.
+	STUB_HEAD_CONTENT=$(cat "$fixture")
 	WARNING_CAPTURED=""
+	ERROR_CAPTURED=""
+
 	local ret=0
 	validate_string_literals_under_test "$fixture" 2>/dev/null || ret=$?
 
-	if [ "$ret" -eq 0 ]; then
-		print_result "validate_string_literals exits 0 with repeated literals" 0
+	if [ "$ret" -eq 0 ] && [ -n "$WARNING_CAPTURED" ] && [ -z "$ERROR_CAPTURED" ]; then
+		print_result "warning branch does not increment violations" 0
 	else
-		print_result "validate_string_literals exits 0 with repeated literals" 1 \
-			"expected exit 0 (advisory), got exit $ret — violation counter incorrectly incremented"
+		print_result "warning branch does not increment violations" 1 \
+			"expected exit 0 + warning + no error, got exit=$ret warn='$WARNING_CAPTURED' err='$ERROR_CAPTURED'"
 	fi
 	return 0
 }
 
 # ---------------------------------------------------------------------------
-# Test 2: validate_string_literals emits [WARNING] to stderr
+# Test 2: Warning branch still emits "[WARNING]" to stderr.
 # ---------------------------------------------------------------------------
 test_emits_warning_to_stderr() {
-	local fixture="${TEST_ROOT}/repeated_literals2.sh"
+	local fixture="${TEST_ROOT}/preexisting_literals2.sh"
 	cat >"$fixture" <<'EOF'
 #!/usr/bin/env bash
 msg1="assert this string"
@@ -145,21 +174,22 @@ msg3="assert this string"
 msg4="assert this string"
 EOF
 
-	WARNING_CAPTURED=""
+	STUB_HEAD_CONTENT=$(cat "$fixture")
+
 	local stderr_out
 	stderr_out=$(validate_string_literals_under_test "$fixture" 2>&1 >/dev/null || true)
 
 	if echo "$stderr_out" | grep -q "\[WARNING\]"; then
-		print_result "validate_string_literals emits [WARNING] to stderr" 0
+		print_result "warning branch emits [WARNING] to stderr" 0
 	else
-		print_result "validate_string_literals emits [WARNING] to stderr" 1 \
+		print_result "warning branch emits [WARNING] to stderr" 1 \
 			"expected '[WARNING]' in stderr, got: $stderr_out"
 	fi
 	return 0
 }
 
 # ---------------------------------------------------------------------------
-# Test 3: validate_string_literals exits 0 on a clean file (no repeated literals)
+# Test 3: Clean file (no repeated literals) exits 0 silently.
 # ---------------------------------------------------------------------------
 test_returns_zero_on_clean_file() {
 	local fixture="${TEST_ROOT}/clean_file.sh"
@@ -173,43 +203,63 @@ foo() {
 }
 EOF
 
+	STUB_HEAD_CONTENT=$(cat "$fixture")
+	WARNING_CAPTURED=""
+	ERROR_CAPTURED=""
+
 	local ret=0
 	validate_string_literals_under_test "$fixture" 2>/dev/null || ret=$?
 
-	if [ "$ret" -eq 0 ]; then
-		print_result "validate_string_literals exits 0 on clean file" 0
+	if [ "$ret" -eq 0 ] && [ -z "$WARNING_CAPTURED" ] && [ -z "$ERROR_CAPTURED" ]; then
+		print_result "clean file exits 0 silently" 0
 	else
-		print_result "validate_string_literals exits 0 on clean file" 1 \
-			"expected exit 0, got exit $ret"
+		print_result "clean file exits 0 silently" 1 \
+			"expected exit 0 + no output, got exit=$ret warn='$WARNING_CAPTURED' err='$ERROR_CAPTURED'"
 	fi
 	return 0
 }
 
 # ---------------------------------------------------------------------------
-# Test 4: Verify the fixed function body in pre-commit-hook.sh does NOT
-#          increment violations on repeated-literal warning (source validation).
-# Check: the line '((++violations))' does NOT appear directly after print_warning
-#         in validate_string_literals block.
+# Test 4: The real hook source places ((++violations)) ONLY inside the
+#         print_error branch of validate_string_literals. The print_warning
+#         branch must never increment.
 # ---------------------------------------------------------------------------
-test_hook_source_no_violations_after_warning() {
+test_hook_source_warning_branch_no_increment() {
 	if [ ! -f "$HOOK_SCRIPT" ]; then
-		print_result "hook source: no violation increment after string-literal warning" 1 \
+		print_result "hook source: warning branch does not increment" 1 \
 			"pre-commit-hook.sh not found at $HOOK_SCRIPT"
 		return 0
 	fi
 
-	# Extract the validate_string_literals function body and check the old
-	# anti-pattern (print_warning followed by ((++violations))) is absent.
+	# Extract the validate_string_literals function body.
 	local func_body
 	func_body=$(awk '/^validate_string_literals\(\)/{found=1} found{print} /^}$/{if(found){exit}}' "$HOOK_SCRIPT")
 
-	# The advisory pattern: print_warning line immediately followed by ((++violations))
-	# We check that no line with ((++violations)) appears in the function body.
-	if echo "$func_body" | grep -qF '((++violations))'; then
-		print_result "hook source: no violation increment after string-literal warning" 1 \
-			"((++violations)) still present in validate_string_literals — fix not applied"
+	if [ -z "$func_body" ]; then
+		print_result "hook source: warning branch does not increment" 1 \
+			"could not extract validate_string_literals body from $HOOK_SCRIPT"
+		return 0
+	fi
+
+	# Find the print_warning line number, then check no ((++violations))
+	# appears between it and the next structural boundary (elif/else/fi/done).
+	local warning_line_num
+	warning_line_num=$(echo "$func_body" | grep -n 'print_warning' | head -1 | cut -d: -f1)
+	if [ -z "$warning_line_num" ]; then
+		# Hook has no print_warning call — acceptable (no warning branch to gate).
+		print_result "hook source: warning branch does not increment" 0
+		return 0
+	fi
+
+	# Look at up to 10 lines following print_warning. Any ((++violations)) in
+	# that window would mean the warning branch blocks — the GH#19839 bug.
+	local following_block
+	following_block=$(echo "$func_body" | sed -n "${warning_line_num},$((warning_line_num + 10))p")
+	if echo "$following_block" | grep -qF '((++violations))'; then
+		print_result "hook source: warning branch does not increment" 1 \
+			"((++violations)) appears within 10 lines after print_warning — regression of GH#19839"
 	else
-		print_result "hook source: no violation increment after string-literal warning" 0
+		print_result "hook source: warning branch does not increment" 0
 	fi
 	return 0
 }
@@ -220,10 +270,10 @@ test_hook_source_no_violations_after_warning() {
 main() {
 	setup
 
-	test_returns_zero_with_repeated_literals
+	test_warning_branch_does_not_increment
 	test_emits_warning_to_stderr
 	test_returns_zero_on_clean_file
-	test_hook_source_no_violations_after_warning
+	test_hook_source_warning_branch_no_increment
 
 	teardown
 

--- a/.agents/scripts/tests/test-pre-commit-ratchet.sh
+++ b/.agents/scripts/tests/test-pre-commit-ratchet.sh
@@ -1,0 +1,475 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-pre-commit-ratchet.sh — Integration test for ratchet-style quality
+# validators in pre-commit-hook.sh (t2230).
+#
+# Validators under test:
+#   1. validate_string_literals       — repeated string literals
+#   2. validate_return_statements     — functions without explicit return
+#   3. validate_positional_parameters — bare $1/$2 usage
+#   4. run_shellcheck                 — ShellCheck findings
+#
+# Ratchet contract (AGENTS.md "Gate design — ratchet, not absolute"):
+#   - Pre-existing violations (staged_count <= head_count) MUST pass, with a
+#     warning. Authors cannot be trapped by legacy debt on files they touch.
+#   - NEW violations (staged_count > head_count) MUST fail. Regression is
+#     blocked at the exact point it is introduced.
+#   - NEW files carrying violations (head_count = 0, staged_count > 0) MUST
+#     fail — first arrival is caught by the strict inequality.
+#
+# Security exception: check_secrets remains absolute-count. Not covered here
+# (covered by its own secretlint test suite).
+#
+# Test strategy:
+#   Each test scenario initialises an ephemeral git repo, commits a "base"
+#   version of a file, stages a "modified" version, and invokes the real
+#   validator function sourced from pre-commit-hook.sh. Return value is the
+#   contract; stdout/stderr is scanned for classification markers
+#   ("NEW ..." = blocking, "Pre-existing ..." = advisory).
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+HOOK_SCRIPT="${SCRIPT_DIR}/../pre-commit-hook.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+ORIG_DIR=""
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [ "$passed" -eq 0 ]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [ -n "$message" ]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup() {
+	ORIG_DIR=$(pwd)
+	TEST_ROOT=$(mktemp -d)
+	return 0
+}
+
+teardown() {
+	if [ -n "$ORIG_DIR" ]; then
+		cd "$ORIG_DIR" || true
+	fi
+	if [ -n "$TEST_ROOT" ] && [ -d "$TEST_ROOT" ]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+# Initialise an ephemeral git repo under $TEST_ROOT/<slug> and cd into it.
+# Global: sets REPO_DIR to the new repo path.
+# shellcheck disable=SC2034
+init_repo() {
+	local slug="$1"
+	REPO_DIR="${TEST_ROOT}/${slug}"
+	mkdir -p "$REPO_DIR"
+	cd "$REPO_DIR" || return 1
+	git init -q -b main
+	git config user.email "test@example.invalid"
+	git config user.name "Ratchet Test"
+	git config commit.gpgsign false
+	return 0
+}
+
+# Commit $2 as the base version of file $1. Leaves the working tree clean.
+commit_base() {
+	local file="$1"
+	local content="$2"
+	printf '%s' "$content" >"$file"
+	git add "$file"
+	git commit -q -m "base: $file" --no-verify
+	return 0
+}
+
+# Overwrite $1 with $2 and stage it (no commit). This is the "staged" state
+# the validators inspect.
+stage_change() {
+	local file="$1"
+	local content="$2"
+	printf '%s' "$content" >"$file"
+	git add "$file"
+	return 0
+}
+
+# Source just the helpers + validator we want to exercise, under a stubbed
+# shared-constants so color codes and print_* work in a minimal environment.
+source_hook_helpers() {
+	# Provide stubs for print_* so output classification is captured.
+	print_error() {
+		local msg="$1"
+		echo "[ERROR] $msg" >&2
+		return 0
+	}
+	print_warning() {
+		local msg="$1"
+		echo "[WARNING] $msg" >&2
+		return 0
+	}
+	print_info() {
+		local msg="$1"
+		echo "[INFO] $msg" >&2
+		return 0
+	}
+	print_success() {
+		local msg="$1"
+		echo "[OK] $msg" >&2
+		return 0
+	}
+
+	# Source helpers and validators by evaluating only the function definitions
+	# from the hook script. The script's `main "$@"` call would run the full
+	# hook, which we don't want here — extract only the definitions.
+	local hook_funcs
+	hook_funcs=$(awk '
+		/^_get_head_content\(\)/              { c=1 }
+		/^_make_head_temp\(\)/                { c=1 }
+		/^_count_repeated_literals\(\)/       { c=1 }
+		/^_show_repeated_literals\(\)/        { c=1 }
+		/^validate_return_statements\(\)/     { c=1 }
+		/^validate_positional_parameters\(\)/ { c=1 }
+		/^validate_string_literals\(\)/       { c=1 }
+		/^run_shellcheck\(\)/                 { c=1 }
+		c { print }
+		c && /^}$/                            { c=0 }
+	' "$HOOK_SCRIPT")
+
+	# shellcheck disable=SC1090  # dynamic eval is the whole point here
+	eval "$hook_funcs"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Scenario: a file with N distinct literals repeated >= 3 times
+# ---------------------------------------------------------------------------
+
+STRING_LITERAL_BASE='#!/usr/bin/env bash
+a1="assertion one matches"
+a2="assertion one matches"
+a3="assertion one matches"
+b1="second repeated message"
+b2="second repeated message"
+b3="second repeated message"
+'
+
+STRING_LITERAL_MORE='#!/usr/bin/env bash
+a1="assertion one matches"
+a2="assertion one matches"
+a3="assertion one matches"
+b1="second repeated message"
+b2="second repeated message"
+b3="second repeated message"
+c1="brand new repeated string"
+c2="brand new repeated string"
+c3="brand new repeated string"
+'
+
+STRING_LITERAL_UNCHANGED_BUT_TOUCHED='#!/usr/bin/env bash
+a1="assertion one matches"
+a2="assertion one matches"
+a3="assertion one matches"
+b1="second repeated message"
+b2="second repeated message"
+b3="second repeated message"
+# Adding this comment is a no-op touch — no new literals.
+'
+
+# ---------------------------------------------------------------------------
+# Scenario: a file with N functions missing explicit returns
+# ---------------------------------------------------------------------------
+
+RETURN_BASE='#!/usr/bin/env bash
+foo() {
+	echo "foo"
+}
+
+bar() {
+	echo "bar"
+}
+'
+
+RETURN_MORE='#!/usr/bin/env bash
+foo() {
+	echo "foo"
+}
+
+bar() {
+	echo "bar"
+}
+
+baz() {
+	echo "baz"
+}
+'
+
+# ---------------------------------------------------------------------------
+# Scenario: a file with N bare positional parameter references
+# ---------------------------------------------------------------------------
+# shellcheck disable=SC2016  # $1/$2 are literal fixture bodies, not shell expansions
+POSPARAM_BASE='#!/usr/bin/env bash
+foo() {
+	echo "$1 got value"
+	echo "$2 was also here"
+}
+'
+
+# shellcheck disable=SC2016  # $1/$2/$3 are literal fixture bodies, not shell expansions
+POSPARAM_MORE='#!/usr/bin/env bash
+foo() {
+	echo "$1 got value"
+	echo "$2 was also here"
+	echo "$3 is a new offender"
+}
+'
+
+# ---------------------------------------------------------------------------
+# String literal validator — 3 cases
+# ---------------------------------------------------------------------------
+
+test_string_literals_preexisting_pass() {
+	init_repo "strlit_preexisting"
+	commit_base "offender.sh" "$STRING_LITERAL_BASE"
+	stage_change "offender.sh" "$STRING_LITERAL_UNCHANGED_BUT_TOUCHED"
+
+	source_hook_helpers
+	local stderr_out ret=0
+	stderr_out=$(validate_string_literals "offender.sh" 2>&1) || ret=$?
+
+	if [ "$ret" -eq 0 ] && echo "$stderr_out" | grep -q 'Pre-existing repeated string literals'; then
+		print_result "string_literals: pre-existing same-count PASSES (ratchet)" 0
+	else
+		print_result "string_literals: pre-existing same-count PASSES (ratchet)" 1 \
+			"expected exit 0 + 'Pre-existing' warning, got exit=$ret output=[$stderr_out]"
+	fi
+	return 0
+}
+
+test_string_literals_new_literal_blocks() {
+	init_repo "strlit_new"
+	commit_base "offender.sh" "$STRING_LITERAL_BASE"
+	stage_change "offender.sh" "$STRING_LITERAL_MORE"
+
+	source_hook_helpers
+	local stderr_out ret=0
+	stderr_out=$(validate_string_literals "offender.sh" 2>&1) || ret=$?
+
+	if [ "$ret" -gt 0 ] && echo "$stderr_out" | grep -q 'NEW repeated string literals'; then
+		print_result "string_literals: NEW literal BLOCKS (ratchet)" 0
+	else
+		print_result "string_literals: NEW literal BLOCKS (ratchet)" 1 \
+			"expected exit>0 + 'NEW' error, got exit=$ret output=[$stderr_out]"
+	fi
+	return 0
+}
+
+test_string_literals_new_file_with_debt_blocks() {
+	init_repo "strlit_newfile"
+	# Make git happy with an initial commit, then introduce the offender as new.
+	commit_base "README.md" "seed"
+	stage_change "offender.sh" "$STRING_LITERAL_BASE"
+
+	source_hook_helpers
+	local stderr_out ret=0
+	stderr_out=$(validate_string_literals "offender.sh" 2>&1) || ret=$?
+
+	if [ "$ret" -gt 0 ] && echo "$stderr_out" | grep -q 'NEW repeated string literals'; then
+		print_result "string_literals: NEW file with debt BLOCKS" 0
+	else
+		print_result "string_literals: NEW file with debt BLOCKS" 1 \
+			"expected exit>0 + 'NEW' error for new file, got exit=$ret output=[$stderr_out]"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Return statement validator — 2 cases
+# ---------------------------------------------------------------------------
+
+test_return_statements_preexisting_pass() {
+	init_repo "return_preexisting"
+	commit_base "returns.sh" "$RETURN_BASE"
+	# Identical content — "touched" but no new missing returns.
+	stage_change "returns.sh" "$RETURN_BASE
+# trivial comment touch
+"
+
+	source_hook_helpers
+	local stderr_out ret=0
+	stderr_out=$(validate_return_statements "returns.sh" 2>&1) || ret=$?
+
+	if [ "$ret" -eq 0 ] && echo "$stderr_out" | grep -q 'Pre-existing missing returns'; then
+		print_result "return_statements: pre-existing missing returns PASS (ratchet)" 0
+	else
+		print_result "return_statements: pre-existing missing returns PASS (ratchet)" 1 \
+			"expected exit 0 + 'Pre-existing' warning, got exit=$ret output=[$stderr_out]"
+	fi
+	return 0
+}
+
+test_return_statements_new_missing_blocks() {
+	init_repo "return_new"
+	commit_base "returns.sh" "$RETURN_BASE"
+	stage_change "returns.sh" "$RETURN_MORE"
+
+	source_hook_helpers
+	local stderr_out ret=0
+	stderr_out=$(validate_return_statements "returns.sh" 2>&1) || ret=$?
+
+	if [ "$ret" -gt 0 ] && echo "$stderr_out" | grep -q 'NEW missing return statements'; then
+		print_result "return_statements: NEW missing return BLOCKS (ratchet)" 0
+	else
+		print_result "return_statements: NEW missing return BLOCKS (ratchet)" 1 \
+			"expected exit>0 + 'NEW' error, got exit=$ret output=[$stderr_out]"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Positional parameter validator — 2 cases
+# ---------------------------------------------------------------------------
+
+test_positional_params_preexisting_pass() {
+	init_repo "posparam_preexisting"
+	commit_base "posparam.sh" "$POSPARAM_BASE"
+	stage_change "posparam.sh" "$POSPARAM_BASE
+# trivial touch
+"
+
+	source_hook_helpers
+	local stderr_out ret=0
+	stderr_out=$(validate_positional_parameters "posparam.sh" 2>&1) || ret=$?
+
+	if [ "$ret" -eq 0 ] && echo "$stderr_out" | grep -q 'Pre-existing positional parameter usage'; then
+		print_result "positional_params: pre-existing usage PASSES (ratchet)" 0
+	else
+		print_result "positional_params: pre-existing usage PASSES (ratchet)" 1 \
+			"expected exit 0 + 'Pre-existing' warning, got exit=$ret output=[$stderr_out]"
+	fi
+	return 0
+}
+
+test_positional_params_new_usage_blocks() {
+	init_repo "posparam_new"
+	commit_base "posparam.sh" "$POSPARAM_BASE"
+	stage_change "posparam.sh" "$POSPARAM_MORE"
+
+	source_hook_helpers
+	local stderr_out ret=0
+	stderr_out=$(validate_positional_parameters "posparam.sh" 2>&1) || ret=$?
+
+	if [ "$ret" -gt 0 ] && echo "$stderr_out" | grep -q 'NEW direct positional parameter usage'; then
+		print_result "positional_params: NEW usage BLOCKS (ratchet)" 0
+	else
+		print_result "positional_params: NEW usage BLOCKS (ratchet)" 1 \
+			"expected exit>0 + 'NEW' error, got exit=$ret output=[$stderr_out]"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Classification labels (output contract)
+# ---------------------------------------------------------------------------
+
+test_classification_labels_present() {
+	init_repo "labels"
+	commit_base "offender.sh" "$STRING_LITERAL_BASE"
+
+	# Case 1: unchanged → warning path
+	stage_change "offender.sh" "$STRING_LITERAL_UNCHANGED_BUT_TOUCHED"
+	source_hook_helpers
+	local out_pre
+	out_pre=$(validate_string_literals "offender.sh" 2>&1 || true)
+
+	# Case 2: new → error path
+	stage_change "offender.sh" "$STRING_LITERAL_MORE"
+	local out_new
+	out_new=$(validate_string_literals "offender.sh" 2>&1 || true)
+
+	local ok=0
+	if ! echo "$out_pre" | grep -q '(not blocking)'; then
+		ok=1
+	fi
+	if ! echo "$out_new" | grep -q 'new:'; then
+		ok=1
+	fi
+
+	if [ "$ok" -eq 0 ]; then
+		print_result "output classification: 'not blocking' + 'new:' labels present" 0
+	else
+		print_result "output classification: 'not blocking' + 'new:' labels present" 1 \
+			"pre-existing output: [$out_pre]; new output: [$out_new]"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Security exception: source check — check_secrets stays absolute
+# ---------------------------------------------------------------------------
+
+test_check_secrets_remains_absolute() {
+	if [ ! -f "$HOOK_SCRIPT" ]; then
+		print_result "check_secrets: security exception annotation present" 1 \
+			"pre-commit-hook.sh not found"
+		return 0
+	fi
+
+	# The function must be marked with the absolute-count annotation.
+	if grep -q 'SECURITY EXCEPTION' "$HOOK_SCRIPT" && \
+	   grep -q 'absolute-count security gate' "$HOOK_SCRIPT"; then
+		print_result "check_secrets: security exception annotation present" 0
+	else
+		print_result "check_secrets: security exception annotation present" 1 \
+			"expected SECURITY EXCEPTION + 'absolute-count security gate' annotation in hook source"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Run all tests
+# ---------------------------------------------------------------------------
+main() {
+	setup
+
+	test_string_literals_preexisting_pass
+	test_string_literals_new_literal_blocks
+	test_string_literals_new_file_with_debt_blocks
+	test_return_statements_preexisting_pass
+	test_return_statements_new_missing_blocks
+	test_positional_params_preexisting_pass
+	test_positional_params_new_usage_blocks
+	test_classification_labels_present
+	test_check_secrets_remains_absolute
+
+	teardown
+
+	echo ""
+	if [ "$TESTS_FAILED" -eq 0 ]; then
+		printf '%bAll %d tests passed%b\n' "$TEST_GREEN" "$TESTS_RUN" "$TEST_RESET"
+		return 0
+	else
+		printf '%b%d/%d tests failed%b\n' "$TEST_RED" "$TESTS_FAILED" "$TESTS_RUN" "$TEST_RESET"
+		return 1
+	fi
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Refactors pre-commit-hook.sh quality validators to ratchet semantics (mirror qlty-regression t2065 / qlty-new-file-gate t2068 patterns): block on INCREASE vs HEAD, emit '[WARNING] Pre-existing … (not blocking)' for legacy debt, so a minor touch to a file with accumulated debt no longer requires --no-verify.

Validators converted to ratchet:
- validate_return_statements — functions without explicit return
- validate_positional_parameters — bare $1/$2 usage
- validate_string_literals — repeated string literals
- run_shellcheck — shellcheck findings

SECURITY EXCEPTION (per AGENTS.md 'Gate design — ratchet, not absolute'):
- check_secrets remains absolute-count. A newly-exposed credential is
  CVE-class regardless of pre-existing state. Annotated in-source.

Test-file exemption added for validate_string_literals and
validate_positional_parameters (test fixtures deliberately exercise
the patterns under test).

New helpers:
- _get_head_content <file> — git show HEAD:$file, empty on new files
- _make_head_temp <file> — materialize HEAD content for shellcheck
- _count_repeated_literals / _show_repeated_literals — share the
  detection pipeline so the function no longer dogfoods itself with
  4× repeated regex literals in-source.

## Files Changed

.agents/scripts/pre-commit-hook.sh,.agents/scripts/tests/test-pre-commit-hook-warning-decoupling.sh,.agents/scripts/tests/test-pre-commit-ratchet.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Added 9-test suite .agents/scripts/tests/test-pre-commit-ratchet.sh (real git fixtures covering all 3 quality validators + new-file + classification labels + security-exception annotation — all pass). Existing test-pre-commit-hook-warning-decoupling.sh (GH#19839 regression guard) rewritten to match ratchet semantics — all 4 pass. Dogfood: HOOK_MODE=pre-commit on the committed diff exits 0. Manual verification: touching auto-update-helper.sh (18 pre-existing literals) with a trivial comment-only change emits 'Pre-existing … (not blocking)' + exit 0; adding 3 new copies of a brand new string emits 'NEW repeated string literals (new: 1, pre-existing: 18)' + exit 1.

Resolves #19739


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.74 plugin for [OpenCode](https://opencode.ai) v1.14.17 with claude-opus-4-7 spent 15m and 58,860 tokens on this as a headless worker.