### PR TITLE
GH#19857: feat: add framework-wide safety invariant for gh issue/pr edit (GH#19857)

### DIFF
--- a/.agents/scripts/draft-response-helper.sh
+++ b/.agents/scripts/draft-response-helper.sh
@@ -317,7 +317,7 @@ _update_notification_draft() {
 		{ print }
 	')
 
-	gh issue edit "$issue_number" --repo "$slug" --body "$new_body" >/dev/null 2>&1 || {
+	gh_issue_edit_safe "$issue_number" --repo "$slug" --body "$new_body" >/dev/null 2>&1 || {
 		_log_warn "Failed to update notification issue #${issue_number} body"
 		return 1
 	}

--- a/.agents/scripts/gh-wrapper-guard.sh
+++ b/.agents/scripts/gh-wrapper-guard.sh
@@ -2,11 +2,13 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 #
-# gh-wrapper-guard.sh — static checker for raw gh issue/pr create calls
+# gh-wrapper-guard.sh — static checker for raw gh issue/pr create AND edit calls
 #
-# Enforces the origin-labelling rule from prompts/build.txt:
-#   "NEVER use raw gh pr create or gh issue create directly. Always use
-#    the wrappers: gh_create_pr and gh_create_issue."
+# Enforces two rules from prompts/build.txt:
+#   1. Origin labelling: "NEVER use raw gh pr create or gh issue create directly.
+#      Always use the wrappers: gh_create_pr and gh_create_issue."
+#   2. Edit safety (GH#19857): "NEVER use raw gh issue edit / gh pr edit with
+#      --title or --body. Always use gh_issue_edit_safe / gh_pr_edit_safe."
 #
 # Subcommands:
 #   check        --base <ref>   Scan added/modified lines in diff vs <ref>
@@ -80,6 +82,17 @@ _scan_line() {
 		return 0
 	fi
 
+	# GH#19857: Match raw "gh issue edit" or "gh pr edit" with --title or --body.
+	# Label-only edits (no --title/--body) are fine without the safe wrapper.
+	if echo "$line" | grep -qE '(^|[[:space:];|`]|\$\()gh[[:space:]]+issue[[:space:]]+edit' &&
+		echo "$line" | grep -qE '\-\-title\b|\-\-body\b|\-\-body-file\b'; then
+		return 0
+	fi
+	if echo "$line" | grep -qE '(^|[[:space:];|`]|\$\()gh[[:space:]]+pr[[:space:]]+edit' &&
+		echo "$line" | grep -qE '\-\-title\b|\-\-body\b|\-\-body-file\b'; then
+		return 0
+	fi
+
 	return 1
 }
 
@@ -127,8 +140,9 @@ _scan_diff_for_file() {
 
 _report_violations() {
 	if [[ "$_SCAN_VIOLATIONS" -gt 0 ]]; then
-		printf 'gh-wrapper-guard: %d violation(s) found — use gh_create_issue / gh_create_pr wrappers instead of raw gh commands.\n' "$_SCAN_VIOLATIONS"
-		printf 'Rule: prompts/build.txt → "Origin labelling (MANDATORY)"\n'
+		printf 'gh-wrapper-guard: %d violation(s) found — use safe wrappers instead of raw gh commands.\n' "$_SCAN_VIOLATIONS"
+		printf 'Create: gh_create_issue / gh_create_pr. Edit: gh_issue_edit_safe / gh_pr_edit_safe.\n'
+		printf 'Rule: prompts/build.txt → "Origin labelling" + GH#19857 (edit safety invariant)\n'
 		printf 'Suppress: append "# aidevops-allow: raw-gh-wrapper" to the line.\n\n'
 		printf '%s' "$_SCAN_OUTPUT"
 		return 1
@@ -205,11 +219,11 @@ cmd_check_full() {
 	file_count=$(git ls-files '*.sh' 2>/dev/null | grep -cvE '(shared-constants\.sh|agents/scripts/tests/)' || true)
 	[[ "$file_count" -eq 0 ]] && return 0
 
-	# Fast grep pass: find candidate files with raw gh issue/pr create
+	# Fast grep pass: find candidate files with raw gh issue/pr create or edit
 	local candidates
 	candidates=$(git ls-files '*.sh' 2>/dev/null |
 		grep -vE '(shared-constants\.sh|agents/scripts/tests/)' |
-		xargs grep -lE 'gh[[:space:]]+(issue|pr)[[:space:]]+create' 2>/dev/null ||
+		xargs grep -lE 'gh[[:space:]]+(issue|pr)[[:space:]]+(create|edit)' 2>/dev/null ||
 		true)
 
 	if [[ -z "$candidates" ]]; then
@@ -228,12 +242,13 @@ cmd_check_full() {
 				violation_output+=$'\n'
 				violations=$((violations + 1))
 			fi
-		done < <(grep -nE 'gh[[:space:]]+(issue|pr)[[:space:]]+create' "$file" 2>/dev/null || true)
+		done < <(grep -nE 'gh[[:space:]]+(issue|pr)[[:space:]]+(create|edit)' "$file" 2>/dev/null || true)
 	done <<<"$candidates"
 
 	if [[ "$violations" -gt 0 ]]; then
-		printf 'gh-wrapper-guard: %d violation(s) found — use gh_create_issue / gh_create_pr wrappers instead of raw gh commands.\n' "$violations"
-		printf 'Rule: prompts/build.txt → "Origin labelling (MANDATORY)"\n'
+		printf 'gh-wrapper-guard: %d violation(s) found — use safe wrappers instead of raw gh commands.\n' "$violations"
+		printf 'Create: gh_create_issue / gh_create_pr. Edit: gh_issue_edit_safe / gh_pr_edit_safe.\n'
+		printf 'Rule: prompts/build.txt → "Origin labelling" + GH#19857 (edit safety invariant)\n'
 		printf 'Suppress: append "# aidevops-allow: raw-gh-wrapper" to the line.\n\n'
 		printf '%s' "$violation_output"
 		return 1
@@ -244,7 +259,7 @@ cmd_check_full() {
 }
 
 show_help() {
-	printf 'gh-wrapper-guard.sh — enforce gh_create_issue / gh_create_pr wrapper usage\n\n'
+	printf 'gh-wrapper-guard.sh — enforce safe gh wrapper usage (create + edit)\n\n'
 	printf 'Usage:\n'
 	printf '  gh-wrapper-guard.sh check --base <ref>   Scan PR diff vs base ref\n'
 	printf '  gh-wrapper-guard.sh check-staged          Scan staged changes\n'

--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -1010,7 +1010,7 @@ _enrich_update_issue() {
 	fi
 
 	if [[ "$do_body_update" == "true" ]]; then
-		if gh issue edit "$num" --repo "$repo" --title "$title" --body "$body" 2>/dev/null; then
+		if gh_issue_edit_safe "$num" --repo "$repo" --title "$title" --body "$body" 2>/dev/null; then
 			return 0
 		fi
 		print_error "Failed to enrich body on #$num ($task_id)"
@@ -1025,7 +1025,7 @@ _enrich_update_issue() {
 		return 0
 	fi
 	# Still update title even when body is preserved/skipped (GH#18411).
-	if gh issue edit "$num" --repo "$repo" --title "$title" 2>/dev/null; then
+	if gh_issue_edit_safe "$num" --repo "$repo" --title "$title" 2>/dev/null; then
 		return 0
 	fi
 	print_error "Failed to enrich title on #$num ($task_id)"

--- a/.agents/scripts/routine-log-helper.sh
+++ b/.agents/scripts/routine-log-helper.sh
@@ -579,7 +579,7 @@ _update_tracking_issue() {
 		"$period_summary")
 
 	# Update issue description
-	if gh issue edit "$issue_number" --repo "$repo_slug" --body "$new_body" &>/dev/null; then
+	if gh_issue_edit_safe "$issue_number" --repo "$repo_slug" --body "$new_body" &>/dev/null; then
 		_log_success "Updated issue #${issue_number} for ${routine_id} (${status}, ${duration}s)"
 	else
 		_log_error "Failed to update issue #${issue_number} for ${routine_id}"
@@ -738,7 +738,7 @@ cmd_refresh_description() {
 		"$period_summary")
 
 	# Push updated body to GitHub
-	if gh issue edit "$issue_number" --repo "$repo_slug" --body "$new_body" &>/dev/null; then
+	if gh_issue_edit_safe "$issue_number" --repo "$repo_slug" --body "$new_body" &>/dev/null; then
 		_log_success "Refreshed description for issue #${issue_number} (${routine_id}) — no run entry recorded"
 	else
 		_log_error "Failed to refresh issue #${issue_number} for ${routine_id}"

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -1017,6 +1017,12 @@ _gh_wrapper_auto_sig() {
 }
 
 gh_create_issue() {
+	# GH#19857: validate title/body before creating (same invariant as edit wrappers)
+	if ! _gh_validate_edit_args "$@"; then
+		_gh_edit_audit_rejection "gh issue create" "$_GH_EDIT_REJECTION_REASON" "$@"
+		return 1
+	fi
+
 	local origin_label
 	origin_label=$(session_origin_label)
 	# Ensure labels exist on the target repo (once per repo per process)
@@ -1132,6 +1138,12 @@ _gh_auto_link_sub_issue() {
 }
 
 gh_create_pr() {
+	# GH#19857: validate title/body before creating (same invariant as edit wrappers)
+	if ! _gh_validate_edit_args "$@"; then
+		_gh_edit_audit_rejection "gh pr create" "$_GH_EDIT_REJECTION_REASON" "$@"
+		return 1
+	fi
+
 	local origin_label
 	origin_label=$(session_origin_label)
 	_ensure_origin_labels_for_args "$@"
@@ -1185,6 +1197,178 @@ ensure_origin_labels_exist() {
 		--description "Worker took over from interactive session" \
 		--color "D4C5F9" 2>/dev/null || true
 	return 0
+}
+
+# =============================================================================
+# Safe gh Edit Wrappers (GH#19857)
+# =============================================================================
+# Framework-wide safety invariant: no code path may invoke gh issue edit or
+# gh pr edit with an empty title or empty body — under any condition, including
+# FORCE_* override flags. The check lives here so ALL call sites go through it.
+#
+# This mirrors the gh_create_issue / gh_create_pr pattern (origin labelling +
+# signing) but for DESTRUCTIVE edits rather than creation.
+#
+# Validation rules:
+#   Title: MUST be non-empty after trimming whitespace. Bare task-ID stubs
+#          like "tNNN: " or "GH#NNN: " (nothing after the prefix) are rejected.
+#   Body:  MUST be non-empty after trimming when --body is present.
+#          --body-file /dev/null and --body "" are rejected.
+#   Override: NO env var bypasses this. This is the hard invariant.
+#
+# Usage (drop-in replacements for gh issue edit / gh pr edit):
+#   gh_issue_edit_safe 123 --repo owner/repo --title "t001: Fix bug" --body "..."
+#   gh_pr_edit_safe 456 --repo owner/repo --title "t001: Fix bug"
+
+# Internal: rejection reason for the most recent _gh_validate_edit_args call.
+_GH_EDIT_REJECTION_REASON=""
+
+#######################################
+# Internal: validate --title and --body/--body-file args.
+# Returns 0 if valid, 1 if rejected (with stderr message + _GH_EDIT_REJECTION_REASON).
+# Args: the full argument list that would be passed to gh issue/pr edit.
+#######################################
+_gh_validate_edit_args() {
+	_GH_EDIT_REJECTION_REASON=""
+	local i=0 title_val="" has_title=0 body_val="" has_body=0
+	local body_file_val="" has_body_file=0
+	local -a args=("$@")
+
+	while [[ $i -lt ${#args[@]} ]]; do
+		case "${args[i]}" in
+		--title)
+			has_title=1
+			title_val="${args[i + 1]:-}"
+			i=$((i + 1))
+			;;
+		--title=*)
+			has_title=1
+			title_val="${args[i]#--title=}"
+			;;
+		--body)
+			has_body=1
+			body_val="${args[i + 1]:-}"
+			i=$((i + 1))
+			;;
+		--body=*)
+			has_body=1
+			body_val="${args[i]#--body=}"
+			;;
+		--body-file)
+			has_body_file=1
+			body_file_val="${args[i + 1]:-}"
+			i=$((i + 1))
+			;;
+		--body-file=*)
+			has_body_file=1
+			body_file_val="${args[i]#--body-file=}"
+			;;
+		*) ;;
+		esac
+		i=$((i + 1))
+	done
+
+	# Validate title if present
+	if [[ "$has_title" -eq 1 ]]; then
+		local trimmed_title
+		trimmed_title=$(printf '%s' "$title_val" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+		if [[ -z "$trimmed_title" ]]; then
+			_GH_EDIT_REJECTION_REASON="empty title (after trimming whitespace)"
+			printf '[SAFETY] gh edit rejected: %s\n' "$_GH_EDIT_REJECTION_REASON" >&2
+			return 1
+		fi
+		# Reject bare task-ID stubs: "tNNN: " or "GH#NNN: " with nothing after
+		if [[ "$trimmed_title" =~ ^(t[0-9]+|GH#[0-9]+):[[:space:]]*$ ]]; then
+			_GH_EDIT_REJECTION_REASON="stub title '${trimmed_title}' (task-ID prefix with no description)"
+			printf '[SAFETY] gh edit rejected: %s\n' "$_GH_EDIT_REJECTION_REASON" >&2
+			return 1
+		fi
+	fi
+
+	# Validate body if present
+	if [[ "$has_body" -eq 1 ]]; then
+		local trimmed_body
+		trimmed_body=$(printf '%s' "$body_val" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+		if [[ -z "$trimmed_body" ]]; then
+			_GH_EDIT_REJECTION_REASON="empty body (after trimming whitespace)"
+			printf '[SAFETY] gh edit rejected: %s\n' "$_GH_EDIT_REJECTION_REASON" >&2
+			return 1
+		fi
+	fi
+
+	# Validate body-file if present
+	if [[ "$has_body_file" -eq 1 ]]; then
+		if [[ "$body_file_val" == "/dev/null" ]]; then
+			_GH_EDIT_REJECTION_REASON="body-file is /dev/null (would clear body)"
+			printf '[SAFETY] gh edit rejected: %s\n' "$_GH_EDIT_REJECTION_REASON" >&2
+			return 1
+		fi
+		if [[ -f "$body_file_val" ]]; then
+			local file_size
+			file_size=$(wc -c <"$body_file_val" 2>/dev/null || echo "0")
+			file_size=$(echo "$file_size" | tr -d '[:space:]')
+			if [[ "$file_size" -eq 0 ]]; then
+				_GH_EDIT_REJECTION_REASON="body-file '${body_file_val}' is empty"
+				printf '[SAFETY] gh edit rejected: %s\n' "$_GH_EDIT_REJECTION_REASON" >&2
+				return 1
+			fi
+		fi
+	fi
+
+	return 0
+}
+
+#######################################
+# Internal: audit-log a safety rejection.
+# Non-fatal — if audit-log-helper.sh is unavailable, the stderr message
+# from _gh_validate_edit_args is still emitted.
+# Args:
+#   $1 — operation name (e.g. "gh issue edit")
+#   $2 — rejection reason
+#   $3..N — original command args (truncated to 500 chars for the log)
+#######################################
+_gh_edit_audit_rejection() {
+	local operation="$1"
+	local reason="$2"
+	shift 2
+	local context
+	context=$(printf '%q ' "$@" | head -c 500)
+	local audit_helper
+	audit_helper="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/audit-log-helper.sh"
+	if [[ -x "$audit_helper" ]]; then
+		"$audit_helper" log operation.block \
+			"gh_edit_safety: ${operation} rejected — ${reason}. Context: ${context}" \
+			2>/dev/null || true
+	fi
+	return 0
+}
+
+#######################################
+# gh_issue_edit_safe — drop-in replacement for gh issue edit.
+# Validates --title/--body before delegating. Rejects empty/stub values.
+# All arguments are forwarded to gh issue edit on success.
+# Returns 1 with stderr message on validation failure.
+#######################################
+gh_issue_edit_safe() {
+	if ! _gh_validate_edit_args "$@"; then
+		_gh_edit_audit_rejection "gh issue edit" "$_GH_EDIT_REJECTION_REASON" "$@"
+		return 1
+	fi
+	gh issue edit "$@"
+}
+
+#######################################
+# gh_pr_edit_safe — drop-in replacement for gh pr edit.
+# Validates --title/--body before delegating. Rejects empty/stub values.
+# All arguments are forwarded to gh pr edit on success.
+# Returns 1 with stderr message on validation failure.
+#######################################
+gh_pr_edit_safe() {
+	if ! _gh_validate_edit_args "$@"; then
+		_gh_edit_audit_rejection "gh pr edit" "$_GH_EDIT_REJECTION_REASON" "$@"
+		return 1
+	fi
+	gh pr edit "$@"
 }
 
 # =============================================================================

--- a/.agents/scripts/stats-health-dashboard.sh
+++ b/.agents/scripts/stats-health-dashboard.sh
@@ -656,7 +656,7 @@ _update_health_issue_title() {
 	local new_stats="${health_title% at [0-9][0-9]:[0-9][0-9] UTC}"
 	if [[ "$current_stats" != "$new_stats" ]]; then
 		local title_edit_stderr
-		title_edit_stderr=$(gh issue edit "$health_issue_number" --repo "$repo_slug" --title "$health_title" 2>&1 >/dev/null)
+		title_edit_stderr=$(gh_issue_edit_safe "$health_issue_number" --repo "$repo_slug" --title "$health_title" 2>&1 >/dev/null)
 		local title_edit_exit_code=$?
 		if [[ $title_edit_exit_code -ne 0 ]]; then
 			echo "[stats] Health issue: failed to update title for #${health_issue_number}: ${title_edit_stderr}" >>"$LOGFILE"

--- a/.agents/scripts/stats-quality-sweep.sh
+++ b/.agents/scripts/stats-quality-sweep.sh
@@ -1903,7 +1903,7 @@ _update_quality_issue_title() {
 	local current_title
 	current_title=$(gh issue view "$issue_number" --repo "$repo_slug" --json title --jq '.title' 2>>"$LOGFILE" || echo "")
 	if [[ "$current_title" != "$quality_title" ]]; then
-		gh issue edit "$issue_number" --repo "$repo_slug" --title "$quality_title" 2>>"$LOGFILE" >/dev/null || true
+		gh_issue_edit_safe "$issue_number" --repo "$repo_slug" --title "$quality_title" 2>>"$LOGFILE" >/dev/null || true
 	fi
 	return 0
 }
@@ -1995,7 +1995,7 @@ _update_quality_issue_body() {
 
 	# Update issue body — redirect stderr to log for debugging on failure
 	local edit_stderr
-	edit_stderr=$(gh issue edit "$issue_number" --repo "$repo_slug" --body "$body" 2>&1 >/dev/null) || {
+	edit_stderr=$(gh_issue_edit_safe "$issue_number" --repo "$repo_slug" --body "$body" 2>&1 >/dev/null) || {
 		echo "[stats] Quality sweep: failed to update body on #${issue_number} in ${repo_slug}: ${edit_stderr}" >>"$LOGFILE"
 		return 0
 	}

--- a/.agents/scripts/tests/test-gh-edit-safety.sh
+++ b/.agents/scripts/tests/test-gh-edit-safety.sh
@@ -1,0 +1,328 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-gh-edit-safety.sh — regression tests for GH#19857
+#
+# Asserts the framework-wide safety invariant: gh_issue_edit_safe,
+# gh_pr_edit_safe, gh_create_issue, and gh_create_pr all reject
+# empty titles, empty bodies, stub titles, and /dev/null body-files.
+#
+# Strategy:
+#   - Source shared-constants.sh with stubbed external commands.
+#   - Call the validation function directly and the wrapper functions.
+#   - Assert rejection (return 1) for invalid args, acceptance (return 0)
+#     for valid args.
+
+# shellcheck disable=SC2181  # Deliberate $? pattern for testing specific exit codes
+set -u
+set +e
+
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_BLUE=$'\033[0;34m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_BLUE="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	local msg="$1"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf '  %sPASS%s %s\n' "$TEST_GREEN" "$TEST_NC" "$msg"
+	return 0
+}
+
+fail() {
+	local msg="$1"
+	local detail="${2:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '  %sFAIL%s %s\n' "$TEST_RED" "$TEST_NC" "$msg"
+	if [[ -n "$detail" ]]; then
+		printf '       %s\n' "$detail"
+	fi
+	return 0
+}
+
+section() {
+	local title="$1"
+	printf '\n%s%s%s\n' "$TEST_BLUE" "$title" "$TEST_NC"
+	return 0
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)" || exit 1
+
+# ── Stub externals so we can source shared-constants.sh in isolation ──
+
+# Stub gh so it never hits the network
+gh() {
+	# Record what was called for assertions
+	GH_CALLS+=("$*")
+	echo "https://github.com/test/repo/issues/999"
+	return 0
+}
+export -f gh
+
+# Stub audit-log-helper.sh — record calls but don't do anything
+AUDIT_LOG_CALLS=()
+
+# Stub jq for config loading
+if ! command -v jq &>/dev/null; then
+	jq() { echo "{}"; return 0; }
+	export -f jq
+fi
+
+# Prevent the config loader from failing
+export AIDEVOPS_CONFIG_FILE="${SCRIPT_DIR}/nonexistent-config.jsonc"
+
+# Source shared-constants.sh (need the validation functions)
+# shellcheck disable=SC1091
+source "${SCRIPTS_DIR}/shared-constants.sh" 2>/dev/null || {
+	printf 'FATAL: cannot source shared-constants.sh\n' >&2
+	exit 1
+}
+
+# ── Tests ──
+
+section "1. _gh_validate_edit_args — empty title rejection"
+
+_gh_validate_edit_args --title "" --repo "test/repo" 2>/dev/null
+if [[ $? -eq 1 ]]; then
+	pass "rejects empty string title"
+else
+	fail "should reject empty string title"
+fi
+
+_gh_validate_edit_args --title "   " --repo "test/repo" 2>/dev/null
+if [[ $? -eq 1 ]]; then
+	pass "rejects whitespace-only title"
+else
+	fail "should reject whitespace-only title"
+fi
+
+_gh_validate_edit_args --title="" --repo "test/repo" 2>/dev/null
+if [[ $? -eq 1 ]]; then
+	pass "rejects empty title (= form)"
+else
+	fail "should reject empty title (= form)"
+fi
+
+section "2. _gh_validate_edit_args — stub title rejection"
+
+_gh_validate_edit_args --title "t1234: " --repo "test/repo" 2>/dev/null
+if [[ $? -eq 1 ]]; then
+	pass "rejects stub title 't1234: '"
+else
+	fail "should reject stub title 't1234: '"
+fi
+
+_gh_validate_edit_args --title "t001:  " --repo "test/repo" 2>/dev/null
+if [[ $? -eq 1 ]]; then
+	pass "rejects stub title 't001:  ' (trailing spaces)"
+else
+	fail "should reject stub title 't001:  ' (trailing spaces)"
+fi
+
+_gh_validate_edit_args --title "GH#9999: " --repo "test/repo" 2>/dev/null
+if [[ $? -eq 1 ]]; then
+	pass "rejects stub title 'GH#9999: '"
+else
+	fail "should reject stub title 'GH#9999: '"
+fi
+
+_gh_validate_edit_args --title "GH#123:" --repo "test/repo" 2>/dev/null
+if [[ $? -eq 1 ]]; then
+	pass "rejects stub title 'GH#123:' (no space after colon)"
+else
+	fail "should reject stub title 'GH#123:' (no space after colon)"
+fi
+
+section "3. _gh_validate_edit_args — valid title acceptance"
+
+_gh_validate_edit_args --title "t1234: Fix the bug" --repo "test/repo" 2>/dev/null
+if [[ $? -eq 0 ]]; then
+	pass "accepts valid title 't1234: Fix the bug'"
+else
+	fail "should accept valid title 't1234: Fix the bug'"
+fi
+
+_gh_validate_edit_args --title "A normal title" --repo "test/repo" 2>/dev/null
+if [[ $? -eq 0 ]]; then
+	pass "accepts valid title 'A normal title'"
+else
+	fail "should accept valid title 'A normal title'"
+fi
+
+_gh_validate_edit_args --repo "test/repo" --add-label "bug" 2>/dev/null
+if [[ $? -eq 0 ]]; then
+	pass "accepts label-only edit (no title/body)"
+else
+	fail "should accept label-only edit (no title/body)"
+fi
+
+section "4. _gh_validate_edit_args — empty body rejection"
+
+_gh_validate_edit_args --body "" --repo "test/repo" 2>/dev/null
+if [[ $? -eq 1 ]]; then
+	pass "rejects empty string body"
+else
+	fail "should reject empty string body"
+fi
+
+_gh_validate_edit_args --body "   " --repo "test/repo" 2>/dev/null
+if [[ $? -eq 1 ]]; then
+	pass "rejects whitespace-only body"
+else
+	fail "should reject whitespace-only body"
+fi
+
+_gh_validate_edit_args --body="" --repo "test/repo" 2>/dev/null
+if [[ $? -eq 1 ]]; then
+	pass "rejects empty body (= form)"
+else
+	fail "should reject empty body (= form)"
+fi
+
+section "5. _gh_validate_edit_args — valid body acceptance"
+
+_gh_validate_edit_args --body "Some content here" --repo "test/repo" 2>/dev/null
+if [[ $? -eq 0 ]]; then
+	pass "accepts valid body"
+else
+	fail "should accept valid body"
+fi
+
+section "6. _gh_validate_edit_args — body-file validation"
+
+_gh_validate_edit_args --body-file "/dev/null" --repo "test/repo" 2>/dev/null
+if [[ $? -eq 1 ]]; then
+	pass "rejects --body-file /dev/null"
+else
+	fail "should reject --body-file /dev/null"
+fi
+
+# Create a temp empty file
+TMPFILE=$(mktemp)
+: >"$TMPFILE"
+_gh_validate_edit_args --body-file "$TMPFILE" --repo "test/repo" 2>/dev/null
+if [[ $? -eq 1 ]]; then
+	pass "rejects --body-file pointing to empty file"
+else
+	fail "should reject --body-file pointing to empty file"
+fi
+
+# Write content to the temp file
+printf 'Some body content' >"$TMPFILE"
+_gh_validate_edit_args --body-file "$TMPFILE" --repo "test/repo" 2>/dev/null
+if [[ $? -eq 0 ]]; then
+	pass "accepts --body-file with content"
+else
+	fail "should accept --body-file with content"
+fi
+rm -f "$TMPFILE"
+
+section "7. gh_issue_edit_safe — integration"
+
+GH_CALLS=()
+gh_issue_edit_safe 123 --repo "test/repo" --title "" 2>/dev/null
+if [[ $? -eq 1 ]]; then
+	pass "gh_issue_edit_safe rejects empty title"
+else
+	fail "gh_issue_edit_safe should reject empty title"
+fi
+
+# Verify gh was NOT called
+if [[ ${#GH_CALLS[@]} -eq 0 ]]; then
+	pass "gh was not invoked on rejection"
+else
+	fail "gh should not be invoked on rejection" "got: ${GH_CALLS[*]}"
+fi
+
+GH_CALLS=()
+gh_issue_edit_safe 123 --repo "test/repo" --title "t001: Real fix" 2>/dev/null
+if [[ $? -eq 0 ]]; then
+	pass "gh_issue_edit_safe accepts valid args and delegates to gh"
+else
+	fail "gh_issue_edit_safe should accept valid args"
+fi
+
+if [[ ${#GH_CALLS[@]} -gt 0 ]]; then
+	pass "gh was invoked on valid args"
+else
+	fail "gh should be invoked on valid args"
+fi
+
+section "8. gh_pr_edit_safe — integration"
+
+GH_CALLS=()
+gh_pr_edit_safe 456 --repo "test/repo" --body "" 2>/dev/null
+if [[ $? -eq 1 ]]; then
+	pass "gh_pr_edit_safe rejects empty body"
+else
+	fail "gh_pr_edit_safe should reject empty body"
+fi
+
+GH_CALLS=()
+gh_pr_edit_safe 456 --repo "test/repo" --title "t002: Update docs" 2>/dev/null
+if [[ $? -eq 0 ]]; then
+	pass "gh_pr_edit_safe accepts valid args"
+else
+	fail "gh_pr_edit_safe should accept valid args"
+fi
+
+section "9. _gh_validate_edit_args — combined title + body"
+
+_gh_validate_edit_args --title "t001: Fix" --body "Real content" 2>/dev/null
+if [[ $? -eq 0 ]]; then
+	pass "accepts valid title + body combo"
+else
+	fail "should accept valid title + body combo"
+fi
+
+_gh_validate_edit_args --title "t001: Fix" --body "" 2>/dev/null
+if [[ $? -eq 1 ]]; then
+	pass "rejects valid title with empty body"
+else
+	fail "should reject valid title with empty body"
+fi
+
+_gh_validate_edit_args --title "" --body "Real content" 2>/dev/null
+if [[ $? -eq 1 ]]; then
+	pass "rejects empty title with valid body"
+else
+	fail "should reject empty title with valid body"
+fi
+
+section "10. _GH_EDIT_REJECTION_REASON is set on failure"
+
+_gh_validate_edit_args --title "" 2>/dev/null
+if [[ -n "$_GH_EDIT_REJECTION_REASON" ]]; then
+	pass "rejection reason is set: '${_GH_EDIT_REJECTION_REASON}'"
+else
+	fail "rejection reason should be set on failure"
+fi
+
+_gh_validate_edit_args --title "Valid title" 2>/dev/null
+if [[ -z "$_GH_EDIT_REJECTION_REASON" ]]; then
+	pass "rejection reason is cleared on success"
+else
+	fail "rejection reason should be cleared on success" "got: '${_GH_EDIT_REJECTION_REASON}'"
+fi
+
+# ── Summary ──
+
+printf '\n%s/%s tests passed' "$((TESTS_RUN - TESTS_FAILED))" "$TESTS_RUN"
+if [[ $TESTS_FAILED -gt 0 ]]; then
+	printf ' (%s%d FAILED%s)' "$TEST_RED" "$TESTS_FAILED" "$TEST_NC"
+	printf '\n'
+	exit 1
+else
+	printf ' %s✓%s\n' "$TEST_GREEN" "$TEST_NC"
+	exit 0
+fi

--- a/.github/workflows/gh-wrapper-guard.yml
+++ b/.github/workflows/gh-wrapper-guard.yml
@@ -1,14 +1,16 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 #
-# GH Wrapper Guard (t2113)
+# GH Wrapper Guard (t2113 + GH#19857)
 #
-# Blocks PRs that introduce raw `gh issue create` or `gh pr create` calls
-# in .agents/scripts/ or .agents/hooks/ shell scripts. These must use the
-# gh_create_issue / gh_create_pr wrappers (defined in shared-constants.sh)
-# to ensure origin labelling.
+# Blocks PRs that introduce:
+#   1. Raw `gh issue create` or `gh pr create` calls — must use
+#      gh_create_issue / gh_create_pr wrappers (origin labelling).
+#   2. Raw `gh issue edit --title/--body` or `gh pr edit --title/--body`
+#      calls — must use gh_issue_edit_safe / gh_pr_edit_safe wrappers
+#      (empty title/body safety invariant, GH#19857).
 #
-# Rule: prompts/build.txt → "Origin labelling (MANDATORY)"
+# Rules: prompts/build.txt → "Origin labelling (MANDATORY)" + GH#19857
 
 name: GH Wrapper Guard
 
@@ -80,17 +82,19 @@ jobs:
           printf '%s\n' "$output"
 
           if [[ "$scan_rc" -ne 0 ]]; then
-            printf '\n::error::Raw gh issue/pr create calls found in changed files.\n'
-            printf '::error::Use gh_create_issue / gh_create_pr wrappers instead.\n'
-            printf '::error::Rule: prompts/build.txt → "Origin labelling (MANDATORY)"\n'
+            printf '\n::error::Raw gh issue/pr create or edit --title/--body calls found in changed files.\n'
+            printf '::error::Create: use gh_create_issue / gh_create_pr wrappers.\n'
+            printf '::error::Edit: use gh_issue_edit_safe / gh_pr_edit_safe wrappers.\n'
             printf '::error::Suppress: append "# aidevops-allow: raw-gh-wrapper" to the line.\n'
             # Save output for PR comment
             {
               printf 'comment<<GH_WRAPPER_GUARD_EOF\n'
               printf '### GH Wrapper Guard — violations found\n\n'
-              printf 'Raw `gh issue create` or `gh pr create` calls detected in added/modified lines.\n'
-              printf 'Use `gh_create_issue` / `gh_create_pr` wrappers instead (defined in `shared-constants.sh`).\n\n'
-              printf '**Rule:** `prompts/build.txt` → "Origin labelling (MANDATORY)"\n\n'
+              printf 'Raw `gh issue/pr create` or `gh issue/pr edit --title/--body` calls detected in added/modified lines.\n'
+              printf 'Use safe wrappers defined in `shared-constants.sh`:\n'
+              printf '- **Create:** `gh_create_issue` / `gh_create_pr`\n'
+              printf '- **Edit:** `gh_issue_edit_safe` / `gh_pr_edit_safe`\n\n'
+              printf '**Rules:** Origin labelling (t2113) + edit safety invariant (GH#19857)\n\n'
               printf '```\n%s\n```\n\n' "$output"
               printf 'To suppress a specific line, append `# aidevops-allow: raw-gh-wrapper`.\n'
               printf 'GH_WRAPPER_GUARD_EOF\n'


### PR DESCRIPTION
## Summary

Added gh_issue_edit_safe / gh_pr_edit_safe wrappers in shared-constants.sh that validate --title and --body args before delegating to gh. Rejects empty titles, whitespace-only titles, stub titles (tNNN:/GH#NNN: with no description), empty bodies, and /dev/null body-files. Added the same validation to existing gh_create_issue/gh_create_pr. Migrated all 8 production call sites across 6 files. Extended gh-wrapper-guard.sh and its CI workflow to also flag raw gh issue edit --title/--body usage. 28-assertion regression test passes.

## Files Changed

.agents/scripts/draft-response-helper.sh,.agents/scripts/gh-wrapper-guard.sh,.agents/scripts/issue-sync-helper.sh,.agents/scripts/routine-log-helper.sh,.agents/scripts/shared-constants.sh,.agents/scripts/stats-health-dashboard.sh,.agents/scripts/stats-quality-sweep.sh,.agents/scripts/tests/test-gh-edit-safety.sh,.github/workflows/gh-wrapper-guard.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-gh-edit-safety.sh — 28/28 tests pass. ShellCheck clean on all modified files. rg confirms no remaining raw gh issue edit --title/--body in migrated files.

Resolves #19857


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.74 plugin for [OpenCode](https://opencode.ai) v1.14.17 with claude-opus-4-6 spent 13m and 34,324 tokens on this as a headless worker.