### PR TITLE
t2387: skip tier escalation on no_work crashes (infrastructure failures)

### DIFF
--- a/.agents/scripts/tests/test-worker-reliability-self-heal.sh
+++ b/.agents/scripts/tests/test-worker-reliability-self-heal.sh
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 #
-# Regression tests for t2119 worker reliability self-heal bundle:
+# Regression tests for t2119 + t2387 worker reliability self-heal bundle:
 #
 #   Part A — check_launchd_plist_drift:
 #     - No drift: stored hash matches current schedulers.sh hash → no-op.
@@ -10,9 +10,15 @@
 #     - Bootstrap: no stored hash → treated as drift (self-heals pre-t2119 installs).
 #     - Rate limit: stamp newer than interval → skipped without work.
 #
-#   Part B — escalate_issue_tier body-quality gate skip:
+#   Part B — escalate_issue_tier no_work skipping (t2119 + t2387):
 #     - When crash_type="no_work", _escalate_body_quality_gate must NOT be
 #       called regardless of body content (structural assertion on source).
+#     - When crash_type="no_work", the entire tier cascade must be skipped
+#       via an early return BEFORE any `gh issue edit` tier-mutation line
+#       (t2387). The early-return block must call
+#       _log_no_work_skip_escalation so operators get a diagnostic comment.
+#     - _log_no_work_skip_escalation must exist and emit the
+#       <!-- no-work-escalation-skip --> marker.
 #
 #   Part C — _preserve_no_activity_output:
 #     - Moves the output file to the diagnostics dir instead of deleting.
@@ -231,8 +237,23 @@ test_drift_stores_stamp_after_run() {
 
 # -----------------------------------------------------------------
 # Part B — escalation skip for no_work crash_type
-# Structural assertion: the guard comparing crash_type must appear
-# before the _escalate_body_quality_gate call in escalate_issue_tier.
+#
+# Two structural assertions covering two related guards:
+#
+# 1. test_escalate_skips_body_gate_on_no_work (t2119 + t2387)
+#    There must be a no_work-aware guard somewhere in escalate_issue_tier
+#    that fires before _escalate_body_quality_gate runs. Originally this
+#    was an inline `!=` guard at the body-gate call site (t2119). t2387
+#    replaced it with an earlier `==` short-circuit that returns before
+#    the gate is reached. Either form satisfies the invariant "no_work
+#    crashes never invoke the body-gate" — so the regex accepts both.
+#
+# 2. test_escalate_skips_tier_cascade_on_no_work (t2387)
+#    There must be an early-return for crash_type=="no_work" that fires
+#    BEFORE any tier label mutation (the `gh issue edit ... --add-label`
+#    line), so no_work crashes never cascade the tier. This is the
+#    actual behavioural guarantee t2387 adds — the body-gate assertion
+#    above is a weaker invariant that happens to follow from it.
 # -----------------------------------------------------------------
 
 test_escalate_skips_body_gate_on_no_work() {
@@ -248,10 +269,13 @@ test_escalate_skips_body_gate_on_no_work() {
 		return 0
 	fi
 
-	# Assertion 1: the function contains a no_work guard before the gate call
+	# Assertion 1: the function contains a no_work guard before the gate call.
+	# Accept either the old t2119 inline `!=` form or the t2387 early-return
+	# `==` form — both satisfy the invariant that no_work never invokes the
+	# body-gate.
 	local guard_pos gate_pos
 	# shellcheck disable=SC2016  # matching literal source text, not expanding
-	guard_pos=$(printf '%s\n' "$fn_src" | grep -n '"\$crash_type" != "no_work"' | head -1 | cut -d: -f1)
+	guard_pos=$(printf '%s\n' "$fn_src" | grep -nE '"\$crash_type" (!=|==) "no_work"' | head -1 | cut -d: -f1)
 	gate_pos=$(printf '%s\n' "$fn_src" | grep -n '_escalate_body_quality_gate' | head -1 | cut -d: -f1)
 
 	if [[ -z "$guard_pos" || -z "$gate_pos" ]]; then
@@ -268,6 +292,93 @@ test_escalate_skips_body_gate_on_no_work() {
 	fi
 
 	print_result "escalate: no_work guard present (structural)" 0
+	return 0
+}
+
+test_escalate_skips_tier_cascade_on_no_work() {
+	# Extract escalate_issue_tier function source
+	local fn_src
+	fn_src=$(awk '
+		/^escalate_issue_tier\(\) \{/,/^}$/ { print }
+	' "$LIFECYCLE_SCRIPT")
+
+	if [[ -z "$fn_src" ]]; then
+		print_result "escalate: no_work tier-cascade skip (t2387)" 1 \
+			"could not extract escalate_issue_tier"
+		return 0
+	fi
+
+	# Assertion 1: the function contains an `== "no_work"` early-return guard.
+	# This is the specific t2387 short-circuit — distinguished from the
+	# original t2119 inline `!= "no_work"` guard.
+	local early_return_pos
+	# shellcheck disable=SC2016  # matching literal source text, not expanding
+	early_return_pos=$(printf '%s\n' "$fn_src" | grep -n '"\$crash_type" == "no_work"' | head -1 | cut -d: -f1)
+
+	if [[ -z "$early_return_pos" ]]; then
+		print_result "escalate: no_work tier-cascade skip (t2387)" 1 \
+			"early-return guard 'crash_type == \"no_work\"' not found"
+		return 0
+	fi
+
+	# Assertion 2: the early return must precede the tier-mutation line.
+	# The canonical tier-mutation signal is the `gh issue edit ... --add-label`
+	# call that swaps tier labels.
+	local tier_mutation_pos
+	tier_mutation_pos=$(printf '%s\n' "$fn_src" | grep -n 'gh issue edit' | head -1 | cut -d: -f1)
+
+	if [[ -z "$tier_mutation_pos" ]]; then
+		print_result "escalate: no_work tier-cascade skip (t2387)" 1 \
+			"tier mutation line ('gh issue edit') not found — cannot verify ordering"
+		return 0
+	fi
+
+	if [[ "$early_return_pos" -ge "$tier_mutation_pos" ]]; then
+		print_result "escalate: no_work tier-cascade skip (t2387)" 1 \
+			"early-return at line ${early_return_pos} must precede tier mutation at line ${tier_mutation_pos}"
+		return 0
+	fi
+
+	# Assertion 3: the early-return block calls _log_no_work_skip_escalation
+	# (the diagnostic helper) before returning, so operators see the skip.
+	local helper_call_pos
+	helper_call_pos=$(printf '%s\n' "$fn_src" | grep -n '_log_no_work_skip_escalation' | head -1 | cut -d: -f1)
+	if [[ -z "$helper_call_pos" ]]; then
+		print_result "escalate: no_work tier-cascade skip (t2387)" 1 \
+			"early-return block does not call _log_no_work_skip_escalation"
+		return 0
+	fi
+
+	# The helper call must be between the early-return guard and the tier mutation
+	if [[ "$helper_call_pos" -le "$early_return_pos" ]] || [[ "$helper_call_pos" -ge "$tier_mutation_pos" ]]; then
+		print_result "escalate: no_work tier-cascade skip (t2387)" 1 \
+			"helper call at ${helper_call_pos} not between guard ${early_return_pos} and mutation ${tier_mutation_pos}"
+		return 0
+	fi
+
+	print_result "escalate: no_work tier-cascade skip (t2387)" 0
+	return 0
+}
+
+test_log_no_work_skip_escalation_helper_exists() {
+	# The helper _log_no_work_skip_escalation must exist as a function
+	# definition in worker-lifecycle-common.sh. This guards against the
+	# guard-only form being added without the accompanying helper.
+	if ! grep -qE '^_log_no_work_skip_escalation\(\) \{' "$LIFECYCLE_SCRIPT"; then
+		print_result "escalate: _log_no_work_skip_escalation helper defined" 1 \
+			"function definition not found in $LIFECYCLE_SCRIPT"
+		return 0
+	fi
+
+	# The helper must emit the <!-- no-work-escalation-skip --> marker so
+	# idempotency checks and operator searches can find it.
+	if ! grep -q 'no-work-escalation-skip' "$LIFECYCLE_SCRIPT"; then
+		print_result "escalate: _log_no_work_skip_escalation helper defined" 1 \
+			"marker 'no-work-escalation-skip' not found"
+		return 0
+	fi
+
+	print_result "escalate: _log_no_work_skip_escalation helper defined" 0
 	return 0
 }
 
@@ -416,8 +527,10 @@ main() {
 	test_drift_rate_limit_suppresses_check
 	test_drift_stores_stamp_after_run
 
-	# Part B: structural assertion
+	# Part B: structural assertions for no_work escalation skipping
 	test_escalate_skips_body_gate_on_no_work
+	test_escalate_skips_tier_cascade_on_no_work
+	test_log_no_work_skip_escalation_helper_exists
 
 	# Part C: preserve tests — clean out any pollution from Part A first
 	rm -rf "${HOME}/.aidevops/logs/worker-no-activity" 2>/dev/null || true

--- a/.agents/scripts/worker-lifecycle-common.sh
+++ b/.agents/scripts/worker-lifecycle-common.sh
@@ -793,6 +793,77 @@ _Automated by \`escalate_issue_tier()\` body quality gate (t1900) in worker-life
 }
 
 #######################################
+# Post an idempotent diagnostic comment when tier escalation is skipped
+# because the worker crashed with crash_type=no_work (infrastructure
+# failure — FD exhaustion, plugin init crash, branch naming race, auth
+# refresh race). Tier escalation is the wrong response to infra failures:
+# a more expensive model cannot fix an FD leak. We keep the issue at its
+# current tier, let the next retry attempt run cheaply after the infra
+# issue resolves, and rely on the existing circuit breakers to apply NMR
+# on cost/staleness thresholds if retries keep failing.
+#
+# Idempotent: checks for a prior comment with the marker
+# <!-- no-work-escalation-skip --> and skips if present, so a cascade of
+# consecutive no_work failures doesn't spam the issue with duplicates.
+#
+# Arguments:
+#   arg1 - issue number
+#   arg2 - repo slug (owner/repo)
+#   arg3 - failure count (for context)
+#   arg4 - kill/failure reason (sanitised)
+# Returns: 0 always (best-effort, never fatal)
+#######################################
+_log_no_work_skip_escalation() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local failure_count="$3"
+	local reason="${4:-worker_exited_before_reading_brief}"
+
+	[[ "$issue_number" =~ ^[0-9]+$ ]] || return 0
+	[[ -n "$repo_slug" ]] || return 0
+
+	local marker='<!-- no-work-escalation-skip -->'
+
+	# Idempotency check: skip if a prior comment already carries the marker.
+	# Best-effort — if gh api fails, fall through and post (better to repeat
+	# once than to lose the diagnostic entirely).
+	local existing=""
+	existing=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
+		--jq "[.[] | select(.body | contains(\"${marker}\"))] | length" \
+		2>/dev/null) || existing=""
+	if [[ "$existing" =~ ^[1-9][0-9]*$ ]]; then
+		# Already posted once — nothing more to do. Still emit a one-line
+		# log so operators can track the skip rate if they're tailing logs.
+		printf '[worker-lifecycle][t2387] no_work skip-escalation already recorded for #%s (%s, count=%s)\n' \
+			"$issue_number" "$repo_slug" "$failure_count" >&2 || true
+		return 0
+	fi
+
+	local safe_reason
+	safe_reason=$(_sanitize_markdown "$reason")
+
+	local comment_body="${marker}
+## Tier Escalation Skipped: Infrastructure Failure (no_work)
+
+**Trigger:** ${failure_count} worker failure(s) classified as \`no_work\` — the worker exited during setup without reading any target files.
+**Action:** Tier escalation **skipped**. The issue stays at its current tier so the next retry can succeed cheaply once the infrastructure issue resolves.
+**Reason:** ${safe_reason}
+
+**Why no cascade:** \`no_work\` means the worker never engaged with the brief — it crashed during runtime setup (FD exhaustion, plugin init failure, branch naming race, auth refresh race). A more expensive model cannot fix an infrastructure problem it never reached. Cascading to \`tier:thinking\` would burn opus tokens on a problem sonnet (or haiku) will handle once the infra clears.
+
+If \`no_work\` crashes continue, the existing circuit breakers (\`cost-circuit-breaker-helper.sh\`, \`dispatch-dedup-stale.sh\`, stale-recovery) will apply \`needs-maintainer-review\` on their own thresholds with markers that \`_nmr_application_is_circuit_breaker_trip\` (t2386) recognises, so auto-approval will correctly preserve the NMR.
+
+_Automated by \`escalate_issue_tier()\` no_work skip (t2387) in worker-lifecycle-common.sh_"
+
+	gh issue comment "$issue_number" --repo "$repo_slug" \
+		--body "$comment_body" 2>/dev/null || true
+
+	printf '[worker-lifecycle][t2387] no_work skip-escalation posted for #%s (%s, count=%s)\n' \
+		"$issue_number" "$repo_slug" "$failure_count" >&2 || true
+	return 0
+}
+
+#######################################
 # Escalate issue model tier after repeated worker failures.
 #
 # Cascade escalation: tier:simple → tier:standard → tier:thinking.
@@ -800,8 +871,12 @@ _Automated by \`escalate_issue_tier()\` body quality gate (t1900) in worker-life
 #   - "overwhelmed": model read files, attempted work, but couldn't complete
 #     → escalate immediately (threshold=1). Retrying at the same tier wastes
 #     tokens on the same complexity the model already failed on.
-#   - "no_work": infrastructure failure, setup crash, branch naming failure
-#     → use default threshold (2). Transient issues may resolve on retry.
+#   - "no_work": infrastructure failure (FD exhaustion, plugin init crash,
+#     auth refresh race). **Short-circuits BEFORE tier cascade** (t2387) —
+#     a more expensive model cannot fix infrastructure. Keeps the issue
+#     at its current tier and posts a diagnostic comment via
+#     _log_no_work_skip_escalation; existing circuit breakers apply NMR
+#     on cost/staleness thresholds if retries persist.
 #   - "partial" / other: default threshold (2). Model got partway, may
 #     succeed with a continuation or fresh attempt.
 #
@@ -846,6 +921,26 @@ escalate_issue_tier() {
 	fi
 	[[ "$threshold" =~ ^[0-9]+$ ]] || threshold=2
 	[[ "$threshold" -ge 1 ]] || threshold=2
+
+	# t2387: no_work crashes are infrastructure failures (FD exhaustion,
+	# plugin init crash, branch naming race, auth refresh race — see t2116
+	# session memory). Tier escalation is the wrong response: a more
+	# expensive model cannot fix an FD leak or an auth race. Skip the
+	# cascade entirely and keep the issue at its current tier so the
+	# next retry can succeed cheaply once the infra issue resolves. If
+	# retries keep failing, the existing circuit-breaker helpers
+	# (cost-circuit-breaker, dispatch-dedup-stale, stale-recovery) apply
+	# NMR on their own thresholds using markers that t2386
+	# _nmr_application_is_circuit_breaker_trip recognises, so auto-approval
+	# preserves the NMR correctly. This early return also subsumes the
+	# t2119 body-quality-gate skip — the later gate call becomes
+	# unreachable on no_work crashes, so the original inline != guard is
+	# no longer needed there.
+	if [[ "$crash_type" == "no_work" ]]; then
+		_log_no_work_skip_escalation "$issue_number" "$repo_slug" \
+			"$failure_count" "$reason"
+		return 0
+	fi
 
 	# Only escalate at the threshold boundary (not on every subsequent failure)
 	if [[ "$failure_count" -ne "$threshold" ]]; then
@@ -914,23 +1009,18 @@ escalate_issue_tier() {
 	# is a vague issue — not model capability. Escalating wastes a more
 	# expensive model on the same exploration problem.
 	#
-	# t2119 guard: skip the body-quality gate entirely when crash_type is
-	# "no_work". In that case the worker died during infrastructure setup
-	# (FD exhaustion, plugin init crash, auth refresh race — see t2116
-	# session memory) BEFORE ever reading the brief. Blaming the brief in
-	# that case is a false positive that wrongly froze good issues like
-	# #19037, #19038, #19099, #19110 while the real cause was #19079 FD
-	# exhaustion. The body-quality gate only makes sense when the model
-	# actually engaged with the brief — i.e. `overwhelmed` or `partial`
-	# crash types, or unclassified failures where we at least have
-	# evidence the worker started a real session.
+	# Note: t2119 originally added an inline `crash_type != "no_work"` guard
+	# here so no_work crashes would bypass the body-gate. That guard was
+	# removed by t2387 when the entire function gained an earlier
+	# `crash_type == "no_work"` short-circuit that returns before reaching
+	# this point — so only overwhelmed / partial / unclassified reach here,
+	# and every path through the function that gets here wants the gate
+	# evaluated.
 	local issue_body
 	issue_body=$(gh issue view "$issue_number" --repo "$repo_slug" \
 		--json body --jq '.body // ""' 2>/dev/null) || issue_body=""
-	if [[ "$crash_type" != "no_work" ]]; then
-		_escalate_body_quality_gate "$issue_number" "$repo_slug" \
-			"$failure_count" "$threshold" "$issue_body" || return 0
-	fi
+	_escalate_body_quality_gate "$issue_number" "$repo_slug" \
+		"$failure_count" "$threshold" "$issue_body" || return 0
 
 	# Create next tier label (creates label if needed)
 	local label_desc=""
@@ -980,13 +1070,14 @@ escalate_issue_tier() {
 	overwhelmed)
 		crash_type_label="**Crash type:** \`overwhelmed\` — model read target files and attempted implementation but could not produce commits. Immediate escalation triggered (threshold=1)."
 		;;
-	no_work)
-		crash_type_label="**Crash type:** \`no_work\` — worker exited during setup without reading target files. Likely infrastructure/transient failure."
-		;;
 	partial)
 		crash_type_label="**Crash type:** \`partial\` — worker produced commits but could not complete the PR lifecycle."
 		;;
 	esac
+	# Note: t2387 removed the `no_work` case here because that crash_type
+	# short-circuits at the top of escalate_issue_tier and never reaches
+	# the comment-posting path. Infrastructure failures get their own
+	# diagnostic comment via _log_no_work_skip_escalation instead.
 	local comment_body="## Cascade Tier Escalation: tier:${current_tier} → tier:${next_tier}
 
 **Trigger:** ${failure_count} consecutive worker failures at \`tier:${current_tier}\` (threshold: ${threshold})

--- a/todo/tasks/t2387-brief.md
+++ b/todo/tasks/t2387-brief.md
@@ -1,0 +1,136 @@
+# t2387 — Route no_work crashes to skip tier escalation
+
+**Session origin:** interactive (2026-04-19 diagnostic pass on 17 open issues)
+
+**Issue:** GH#19914
+
+## What
+
+When `worker-watchdog.sh` classifies a worker exit as `crash_type=no_work`
+(the worker died during infrastructure setup — FD exhaustion, plugin init
+crash, branch naming failure, auth refresh race — BEFORE ever reading the
+target files), `escalate_issue_tier` in `worker-lifecycle-common.sh` still
+runs the tier cascade at threshold=2 (`tier:simple` → `tier:standard` →
+`tier:thinking` → NMR). This wastes progressively more expensive models on
+the same underlying infrastructure failure.
+
+Fix: when `crash_type == "no_work"`, skip tier escalation entirely. Keep the
+issue at its current tier, post a diagnostic comment, and let the existing
+circuit breakers (`cost-circuit-breaker-helper.sh`, `dispatch-dedup-stale.sh`,
+stale-recovery) apply NMR after their own thresholds trip. Those breakers
+already use distinct markers that t2386 (`_nmr_application_is_circuit_breaker_trip`)
+recognises so `auto_approve_maintainer_issues` correctly preserves NMR.
+
+## Why
+
+**Failure mode observed in the 2026-04-19 diagnostic audit (issues #19733,
+#19738, #19749):** 5 dispatches / 0 kills per issue. Workers start, claim,
+exit cleanly without a PR. Watchdog logs them as `no_work`. Current
+`escalate_issue_tier` behaviour:
+
+1. First `no_work` crash → failure_count=1 → below threshold → no escalation
+2. Second `no_work` crash → failure_count=2 → **escalates tier:simple → tier:standard**
+3. Third `no_work` crash → failure_count=3 → no escalation (already past threshold)
+4. ...but wait, failure_count keeps incrementing on each dispatch. If the
+   issue gets stuck in a no_work loop it eventually hits `threshold*2` etc.
+   Actually re-reading line 851: `if [[ "$failure_count" -ne "$threshold" ]]; then return 0; fi` — the
+   function only escalates AT the threshold boundary, so it escalates exactly
+   once per tier. Cascade progression needs another 2 failures at the new
+   tier to trigger the next cascade step.
+
+Regardless of the exact cascade geometry, the core problem is: no_work
+failures are *infrastructure* problems. Throwing a more expensive model at
+them does not help — the worker never even got to the model. The t2119 fix
+already acknowledged this by skipping the body-quality gate on no_work.
+This task completes that reasoning: skip the tier escalation too.
+
+**Impact of the fix:** issues repeatedly failing with no_work stay at their
+original tier (usually `tier:simple` or `tier:standard`). If the
+infrastructure problem resolves (next pulse cycle the FD is free, the plugin
+loads cleanly, the auth refresh succeeds), the retry can succeed at the
+cheap tier. If the infrastructure problem persists, the existing
+circuit-breaker helpers fire on retry frequency/cost thresholds and apply
+NMR with markers t2386 preserves correctly.
+
+## How
+
+Edit `.agents/scripts/worker-lifecycle-common.sh` `escalate_issue_tier`
+(currently ~lines 825-1014):
+
+1. After the numeric/label validation (lines 832-848) and BEFORE the
+   threshold gate (line 850), add a short-circuit branch:
+
+   ```bash
+   # t2387: no_work crashes are infrastructure failures. Tier escalation
+   # is the wrong response — a more expensive model cannot fix an FD
+   # exhaustion, a plugin init crash, or an auth refresh race. Skip tier
+   # escalation entirely and let the circuit-breaker helpers (cost,
+   # stale-recovery, dispatch-dedup-stale) apply NMR on retry frequency
+   # thresholds. Their NMR markers are recognised by t2386
+   # _nmr_application_is_circuit_breaker_trip so auto-approval preserves
+   # the NMR correctly.
+   if [[ "$crash_type" == "no_work" ]]; then
+       _log_no_work_skip_escalation "$issue_number" "$repo_slug" \
+           "$failure_count" "$reason"
+       return 0
+   fi
+   ```
+
+2. Add a new helper function `_log_no_work_skip_escalation` that:
+   - Posts a one-time diagnostic comment (idempotent via marker
+     `<!-- no-work-escalation-skip -->`) explaining that the cascade was
+     skipped because infrastructure failures don't benefit from tier
+     escalation.
+   - Emits a structured log line so the pulse telemetry can track the
+     skip rate.
+
+3. Remove the now-dead `no_work` branch from the `crash_type_label` switch
+   (lines 983-985) since that path is unreachable after the early return.
+   Keep the `overwhelmed` and `partial` branches intact.
+
+## Verification
+
+1. **Unit test** at `.agents/scripts/tests/test-worker-reliability-self-heal.sh`
+   (extend existing `test_escalate_skips_body_gate_on_no_work` pattern at
+   line 233-270):
+
+   ```bash
+   test_escalate_skips_tier_cascade_on_no_work() {
+       # Mock: issue with tier:simple label, failure_count=2 (threshold)
+       # Call: escalate_issue_tier 42 fake/repo 2 "worker_exit_0" "no_work"
+       # Expect: no gh edit, no tier:standard label added, diagnostic comment posted
+   }
+   ```
+
+2. **Regression test:** confirm existing `overwhelmed` crash type still
+   escalates at threshold=1 (existing test `test_escalate_body_gate_no_work_bypasses_gate`
+   should remain green; add `test_escalate_skips_tier_cascade_on_no_work` as a
+   new assertion).
+
+3. **Local shellcheck:** `shellcheck .agents/scripts/worker-lifecycle-common.sh`.
+
+## Acceptance Criteria
+
+- [ ] `crash_type == "no_work"` short-circuits `escalate_issue_tier` before
+  any tier label mutation.
+- [ ] A diagnostic comment with marker `<!-- no-work-escalation-skip -->`
+  is posted once per issue (idempotent via marker lookup).
+- [ ] Existing `overwhelmed` threshold=1 behaviour unchanged.
+- [ ] Existing `partial` / unclassified default threshold=2 behaviour
+  unchanged.
+- [ ] New unit test asserts no tier label change on no_work crashes.
+- [ ] Shellcheck clean.
+
+## Context
+
+- **Companion fix:** t2386 (PR #19909) narrows NMR auto-approval to
+  creation-defaults so circuit-breaker NMR applications are preserved.
+  Together, t2386 and t2387 close the GH#19756-class auto-approval loop.
+- **Related:** t2119 (body-quality gate skip on no_work) at
+  worker-lifecycle-common.sh:930-933.
+- **Evidence:** issues #19733, #19738, #19749 — 5 dispatches / 0 kills,
+  cascaded to tier:thinking on infrastructure failures.
+
+## PR Conventions
+
+Leaf issue (not parent-task). Use `Resolves #19914` in PR body.


### PR DESCRIPTION
## Summary

- Short-circuits `escalate_issue_tier` for `crash_type=no_work`: keeps the issue at its current tier instead of cascading `tier:simple → tier:standard → tier:thinking → NMR`.
- Adds a new diagnostic helper `_log_no_work_skip_escalation` that posts an idempotent explainer comment (marker `<!-- no-work-escalation-skip -->`) so operators understand why no cascade fired.
- Removes the now-unreachable t2119 inline `!= "no_work"` guard and the dead `no_work` case in the cascade comment switch.
- Adds two new structural tests; all 12 tests in `test-worker-reliability-self-heal.sh` pass. Shellcheck clean.

## Why

`no_work` means the worker exited during infrastructure setup (FD exhaustion, plugin init crash, branch naming race, auth refresh race — see t2116 session memory) **before reading any target files**. A more expensive model cannot fix an FD leak. Under the prior behaviour, pairs of `no_work` crashes cascaded the tier, burning opus tokens at `tier:thinking` on infrastructure problems that didn't need (and wouldn't benefit from) the opus-tier model.

## Evidence

2026-04-19 diagnostic audit on `marcusquinn/aidevops` identified failure-mode C: issues **#19733, #19738, #19749** all show 5 dispatches / 0 kills — workers start, claim, exit cleanly without a PR. Under the old `escalate_issue_tier` these issues cascaded from `tier:simple` toward `tier:thinking` without the infra problem ever getting addressed.

## Companion fix

t2386 (PR #19909, under review) narrows NMR auto-approval to creation-defaults so circuit-breaker NMR applications are preserved. Together:
- **t2386** fixes: once NMR is applied by a circuit breaker, auto-approval preserves it (closes the GH#19756 infinite loop).
- **t2387** fixes: `no_work` crashes get a correct response (skip the cascade, wait for infra to clear, let circuit breakers apply NMR on cost/staleness thresholds if retries persist).

Both PRs target the same 17-open-issue diagnostic audit. They are independent edits to different files and can merge in either order.

## Testing

```bash
cd ~/Git/aidevops && bash .agents/scripts/tests/test-worker-reliability-self-heal.sh
# Ran 12 tests, 0 failed.

shellcheck .agents/scripts/worker-lifecycle-common.sh
# (clean)
```

New assertions:
- `test_escalate_skips_tier_cascade_on_no_work`: early-return guard exists, precedes tier mutation, calls `_log_no_work_skip_escalation`.
- `test_log_no_work_skip_escalation_helper_exists`: helper defined, marker present.

Existing assertion `test_escalate_skips_body_gate_on_no_work` regex updated to accept either `!= "no_work"` (old t2119) or `== "no_work"` (new t2387) — both satisfy the invariant "no_work never invokes body-gate".

Resolves #19914