### PR TITLE
t2388: nudge parent-task issues with zero filed children

### DIFF
--- a/.agents/scripts/pulse-issue-reconcile.sh
+++ b/.agents/scripts/pulse-issue-reconcile.sh
@@ -946,6 +946,86 @@ _extract_children_section() {
 }
 
 #######################################
+# t2388: post an idempotent decomposition-nudge comment on a parent-task
+# issue that has zero filed children. Without this, undecomposed parents
+# sit silently forever — the parent-task label blocks dispatch, no
+# children exist to do the work, and no signal surfaces to the maintainer.
+#
+# Idempotent via the <!-- parent-needs-decomposition --> marker: re-runs
+# skip any parent already nudged. The marker is checked via the issue
+# comments API before posting; if already present, returns 1 (no-op).
+#
+# Arguments:
+#   arg1 - repo slug (owner/repo)
+#   arg2 - parent issue number
+#   arg3 - parent title (for the comment body)
+# Returns: 0 if the nudge was posted, 1 if skipped (marker present or
+# comment failed).
+#######################################
+_post_parent_decomposition_nudge() {
+	local slug="$1"
+	local parent_num="$2"
+	local parent_title="${3:-}"
+
+	[[ -n "$slug" ]] || return 1
+	[[ "$parent_num" =~ ^[0-9]+$ ]] || return 1
+
+	local marker='<!-- parent-needs-decomposition -->'
+
+	# Idempotency check: skip if marker already present in any comment.
+	# Best-effort — if the API fails we fall through to posting, which
+	# is better than missing the nudge entirely. A one-time duplicate
+	# on a transient API error is harmless.
+	local existing=""
+	existing=$(gh api "repos/${slug}/issues/${parent_num}/comments" \
+		--jq "[.[] | select(.body | contains(\"${marker}\"))] | length" \
+		2>/dev/null) || existing=""
+	if [[ "$existing" =~ ^[1-9][0-9]*$ ]]; then
+		return 1
+	fi
+
+	# Sanitise title for safe markdown embed.
+	local safe_title="$parent_title"
+	safe_title="${safe_title//\`/}"
+
+	local comment_body="${marker}
+## Parent Task Needs Decomposition
+
+This issue carries the \`parent-task\` label, which unconditionally blocks pulse dispatch (see \`dispatch-dedup-helper.sh\` → \`PARENT_TASK_BLOCKED\`). It also has **zero filed children** — no \`## Children\`, \`## Sub-tasks\`, or \`## Child issues\` section with \`#NNNN\` references, and no GraphQL sub-issue graph.
+
+Under these two conditions the issue cannot make progress on its own. Workers won't pick it up (dispatch blocked), no completion sweep can fire (no children to check), and nothing else nudges it forward. Without decomposition it will sit here silently forever.
+
+**Two paths forward — pick one:**
+
+1. **Decompose into children.** File the specific implementation tasks as separate issues, then edit this parent body to include a section like:
+
+   \`\`\`
+   ## Children
+
+   - t2XXX / #NNNN — first specific task
+   - t2YYY / #MMMM — second specific task
+   \`\`\`
+
+   The next pulse cycle will detect the children via \`reconcile_completed_parent_tasks\` and auto-close this parent once all listed children are closed.
+
+2. **Drop the parent-task label.** If this issue is actually a single unit of work (not a roadmap tracker), remove the \`parent-task\` label so the pulse can dispatch it directly:
+
+   \`\`\`
+   gh issue edit ${parent_num} --repo ${slug} --remove-label parent-task
+   \`\`\`
+
+See \`.agents/AGENTS.md\` → \"Parent / meta tasks\" (t1986 / t2211) for the full rule. Parent-task is for epics and roadmap trackers that will never be implemented as a single unit — only their children will.
+
+_Automated by \`_post_parent_decomposition_nudge\` in \`pulse-issue-reconcile.sh\` (t2388). Posted once per issue via the \`<!-- parent-needs-decomposition -->\` marker; re-runs are no-ops._"
+
+	gh issue comment "$parent_num" --repo "$slug" \
+		--body "$comment_body" >/dev/null 2>&1 || return 1
+
+	echo "[pulse-wrapper] Reconcile parent-task: nudge posted for #${parent_num} in ${slug} (no children filed)" >>"$LOGFILE"
+	return 0
+}
+
+#######################################
 # t2138: extract per-parent close logic. Keeps reconcile_completed_parent_tasks
 # under the 100-line shell-complexity threshold and makes the close decision
 # independently testable. Returns 0 if the parent was closed, 1 if skipped
@@ -1000,10 +1080,12 @@ reconcile_completed_parent_tasks() {
 
 	local total_closed=0
 	local max_closes=5
+	local total_nudged=0
+	local max_nudges=5
 
 	while IFS= read -r slug; do
 		[[ -n "$slug" ]] || continue
-		[[ "$total_closed" -lt "$max_closes" ]] || break
+		[[ "$total_closed" -lt "$max_closes" || "$total_nudged" -lt "$max_nudges" ]] || break
 
 		local issues_json
 		issues_json=$(gh issue list --repo "$slug" --state open \
@@ -1016,10 +1098,11 @@ reconcile_completed_parent_tasks() {
 		[[ "$issue_count" -gt 0 ]] || continue
 
 		local i=0
-		while [[ "$i" -lt "$issue_count" ]] && [[ "$total_closed" -lt "$max_closes" ]]; do
-			local issue_num issue_body
+		while [[ "$i" -lt "$issue_count" ]] && [[ "$total_closed" -lt "$max_closes" || "$total_nudged" -lt "$max_nudges" ]]; do
+			local issue_num issue_body issue_title
 			issue_num=$(printf '%s' "$issues_json" | jq -r --argjson i "$i" '.[$i].number // ""') || true
 			issue_body=$(printf '%s' "$issues_json" | jq -r --argjson i "$i" '.[$i].body // ""') || true
+			issue_title=$(printf '%s' "$issues_json" | jq -r --argjson i "$i" '.[$i].title // ""') || true
 			i=$((i + 1))
 			[[ "$issue_num" =~ ^[0-9]+$ ]] || continue
 
@@ -1037,16 +1120,31 @@ reconcile_completed_parent_tasks() {
 					child_source="body"
 				fi
 			fi
-			[[ -n "$child_nums" ]] || continue
 
-			if _try_close_parent_tracker "$slug" "$issue_num" "$child_nums" "$child_source"; then
+			# t2388: parent-task with zero filed children is a decomposition
+			# silent-stuck state. Dispatch is blocked by parent-task label,
+			# completion sweep has nothing to sweep, nothing nudges it
+			# forward. Post a one-time decomposition nudge (idempotent via
+			# the <!-- parent-needs-decomposition --> marker) so the
+			# maintainer can either decompose into children or drop the
+			# parent-task label.
+			if [[ -z "$child_nums" ]]; then
+				if [[ "$total_nudged" -lt "$max_nudges" ]]; then
+					if _post_parent_decomposition_nudge "$slug" "$issue_num" "$issue_title"; then
+						total_nudged=$((total_nudged + 1))
+					fi
+				fi
+				continue
+			fi
+
+			if [[ "$total_closed" -lt "$max_closes" ]] && _try_close_parent_tracker "$slug" "$issue_num" "$child_nums" "$child_source"; then
 				total_closed=$((total_closed + 1))
 			fi
 		done
 	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug // ""' "$repos_json" || true)
 
-	if [[ "$total_closed" -gt 0 ]]; then
-		echo "[pulse-wrapper] Reconcile completed parent tasks: closed=${total_closed}" >>"$LOGFILE"
+	if [[ "$total_closed" -gt 0 || "$total_nudged" -gt 0 ]]; then
+		echo "[pulse-wrapper] Reconcile completed parent tasks: closed=${total_closed} nudged=${total_nudged}" >>"$LOGFILE"
 	fi
 
 	return 0

--- a/.agents/scripts/tests/test-pulse-parent-nudge.sh
+++ b/.agents/scripts/tests/test-pulse-parent-nudge.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# shellcheck disable=SC2016  # single-quoted regex/grep patterns are literal by design
+#
+# test-pulse-parent-nudge.sh — structural tests for t2388 (GH#19927)
+#
+# Verifies the parent-task decomposition nudge wiring in
+# pulse-issue-reconcile.sh. The nudge fires when a parent-task-labelled
+# issue has ZERO filed children (neither GraphQL sub-issue graph nor
+# ## Children body section), which is a silent-stuck state: dispatch is
+# blocked by the parent-task label, the completion sweep has nothing to
+# sweep, and nothing else nudges it forward.
+#
+# Test strategy: this is a structural test — we grep the source file to
+# verify the wiring is present, rather than executing the function (which
+# would require gh API stubs for comments + sub-issue graph + label list).
+# Functional verification of the idempotency marker and comment posting
+# path happens live when the pulse runs against the first eligible parent.
+#
+# Test coverage:
+#   1. Helper function _post_parent_decomposition_nudge exists
+#   2. Helper uses the canonical marker <!-- parent-needs-decomposition -->
+#   3. Helper performs idempotency check via gh api comments lookup
+#   4. Helper posts comment via gh issue comment
+#   5. Reconcile function declares total_nudged counter
+#   6. Reconcile function declares max_nudges cap
+#   7. Reconcile function fetches issue_title from jq
+#   8. Reconcile function calls _post_parent_decomposition_nudge when
+#      child_nums is empty
+#   9. Reconcile function increments total_nudged on successful nudge
+#  10. Final log line includes nudged= counter
+#  11. Helper file is shellcheck-clean (delegated to CI)
+
+set -u
+
+# Use TEST_-prefixed color vars to avoid colliding with readonly vars
+# from shared-constants.sh when the helper is sourced later.
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_BLUE=$'\033[0;34m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_BLUE="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+assert_grep() {
+	local label="$1" pattern="$2" file="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if grep -qE "$pattern" "$file" 2>/dev/null; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  expected pattern: $pattern"
+		echo "  in file:          $file"
+	fi
+	return 0
+}
+
+assert_grep_fixed() {
+	local label="$1" pattern="$2" file="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if grep -qF "$pattern" "$file" 2>/dev/null; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  expected literal: $pattern"
+		echo "  in file:          $file"
+	fi
+	return 0
+}
+
+# --- Locate source file ---
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET="$SCRIPT_DIR/pulse-issue-reconcile.sh"
+
+if [[ ! -f "$TARGET" ]]; then
+	echo "${TEST_RED}FATAL${TEST_NC}: $TARGET not found"
+	exit 1
+fi
+
+echo "${TEST_BLUE}=== t2388: parent-task decomposition nudge structural tests ===${TEST_NC}"
+echo ""
+
+# --- Helper function presence ---
+
+assert_grep \
+	"1: _post_parent_decomposition_nudge function defined" \
+	'^_post_parent_decomposition_nudge\(\) \{' \
+	"$TARGET"
+
+# --- Marker wiring ---
+
+assert_grep_fixed \
+	"2: helper uses canonical marker <!-- parent-needs-decomposition -->" \
+	'<!-- parent-needs-decomposition -->' \
+	"$TARGET"
+
+# --- Idempotency check ---
+
+assert_grep \
+	"3: helper queries existing comments via gh api for idempotency" \
+	'gh api "repos/\$\{slug\}/issues/\$\{parent_num\}/comments"' \
+	"$TARGET"
+
+# --- Comment posting ---
+
+assert_grep \
+	"4: helper posts via gh issue comment" \
+	'gh issue comment "\$parent_num" --repo "\$slug"' \
+	"$TARGET"
+
+# --- Reconcile function counter ---
+
+assert_grep \
+	"5: reconcile declares total_nudged=0 counter" \
+	'local total_nudged=0' \
+	"$TARGET"
+
+assert_grep \
+	"6: reconcile declares max_nudges=5 cap" \
+	'local max_nudges=5' \
+	"$TARGET"
+
+# --- Title extraction ---
+
+assert_grep \
+	"7: reconcile extracts issue_title from jq" \
+	'issue_title=\$\(printf .* jq -r --argjson i "\$i" .*.title' \
+	"$TARGET"
+
+# --- Nudge call wiring ---
+
+assert_grep \
+	"8: reconcile calls _post_parent_decomposition_nudge with slug+num+title" \
+	'_post_parent_decomposition_nudge "\$slug" "\$issue_num" "\$issue_title"' \
+	"$TARGET"
+
+# --- Counter increment ---
+
+assert_grep \
+	"9: reconcile increments total_nudged on success" \
+	'total_nudged=\$\(\(total_nudged \+ 1\)\)' \
+	"$TARGET"
+
+# --- Final log line ---
+
+assert_grep \
+	"10: final log line includes nudged= counter" \
+	'closed=\$\{total_closed\} nudged=\$\{total_nudged\}' \
+	"$TARGET"
+
+# --- Entry conditions ---
+
+# The nudge MUST fire only when child_nums is empty AND both sub-issue
+# graph and body-section lookups have been tried. This is enforced by
+# placing the nudge AFTER the existing graph/body resolution block and
+# BEFORE the silent-continue that previously existed.
+assert_grep_fixed \
+	"11: nudge fires only when \$child_nums is empty (guards graph+body lookups first)" \
+	'if [[ -z "$child_nums" ]]; then
+				if [[ "$total_nudged" -lt "$max_nudges" ]]; then' \
+	"$TARGET"
+
+# --- Summary ---
+
+echo ""
+echo "${TEST_BLUE}=== Results: ${TESTS_RUN} tests, ${TESTS_FAILED} failed ===${TEST_NC}"
+
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/todo/tasks/t2388-brief.md
+++ b/todo/tasks/t2388-brief.md
@@ -1,0 +1,114 @@
+# t2388 — Nudge parent-task issues with no filed children
+
+**Session origin:** interactive (2026-04-19 diagnostic audit on 17 open issues)
+
+**Issue:** GH#19927
+
+## What
+
+Extend `reconcile_completed_parent_tasks` in
+`.agents/scripts/pulse-issue-reconcile.sh` (function starts at line 997)
+to post a one-time idempotent decomposition-nudge comment on `parent-task`
+issues that have zero filed children. The parent currently has two signals
+fighting each other: (1) the `parent-task` label unconditionally blocks
+dispatch (correct — see `dispatch-dedup-helper.sh` `PARENT_TASK_BLOCKED`),
+and (2) no children exist to do the work. The existing scanner silently
+`continue`s on empty `$child_nums` at line 1040, so the maintainer never
+gets a prompt to decompose.
+
+Fix: when the scanner detects a parent with zero children, post one nudge
+comment with marker `<!-- parent-needs-decomposition -->` explaining the
+stall and listing the two options (file children under a `## Children`
+heading, OR remove the `parent-task` label). Idempotent: re-runs skip any
+parent already nudged.
+
+## Why
+
+Observed 4 stranded issues on 2026-04-19: #19808 (t2264 PR scope-leak
+decomposition designed but not filed), #19858 (override-flags audit —
+designed as parent but no children filed), #19859 (gh-audit-log — same
+pattern), #19874 (claim-task-id race investigation — probably should not
+be a parent at all). All four:
+
+- Have the `parent-task` label — dispatch blocked.
+- Have ZERO filed children — no progress possible.
+- Have ZERO signal to the maintainer that they need attention.
+
+This is a silent failure mode: the issues simply sit there forever.
+Adding a nudge closes the observability gap. Workers and the maintainer
+reading the pulse will see the "NEEDS DECOMPOSITION" comments and act.
+
+## How
+
+Edit `.agents/scripts/pulse-issue-reconcile.sh`:
+
+1. Add a new helper `_post_parent_decomposition_nudge` near
+   `_try_close_parent_tracker` (around line 953) that:
+
+   - Takes `slug`, `parent_num`, `parent_title`, `parent_body` as arguments.
+   - Does an idempotency check for the marker
+     `<!-- parent-needs-decomposition -->` via
+     `gh api repos/SLUG/issues/N/comments --jq '[.[] | select(.body | contains(MARKER))] | length'`.
+   - Returns 1 (no-op) if the marker is already present.
+   - Posts a templated comment explaining:
+     - This parent has the `parent-task` label, which unconditionally
+       blocks dispatch.
+     - No children are filed (no `## Children` / `## Sub-tasks` /
+       `## Child issues` section, or empty section, or empty sub-issue
+       graph).
+     - The maintainer has two options: (a) file children under one of
+       the recognised headings with `#NNNN` references, or (b) remove
+       the `parent-task` label so the pulse can dispatch this issue
+       directly.
+     - Links to the relevant docs (`.agents/AGENTS.md` Parent /
+       meta tasks section).
+   - Returns 0 after posting.
+
+2. In `reconcile_completed_parent_tasks` (the main scanner), after the
+   existing child-detection path and BEFORE the silent continue on empty
+   `$child_nums`, call the nudge helper. Only call if body-section
+   extraction also yielded empty (i.e., both graph AND body produced
+   zero children). Rate-limit nudges per cycle to 5 (match the `max_closes`
+   cap pattern already in the function).
+
+3. Track nudge count in a new local `total_nudged` counter, log it at
+   function end alongside `total_closed`.
+
+## Verification
+
+1. **Structural test** in a new file
+   `.agents/scripts/tests/test-pulse-parent-nudge.sh`:
+   - Extract `_post_parent_decomposition_nudge` via awk, verify:
+     - It checks for the `<!-- parent-needs-decomposition -->` marker.
+     - It calls `gh issue comment` with the marker in the body.
+     - The function exits 1 (no-op) before the `gh issue comment` call
+       when the marker lookup returns a positive count.
+   - Extract `reconcile_completed_parent_tasks` and verify:
+     - The nudge helper is called when `child_nums` is empty.
+     - The rate-limit cap (5 or similar) gates the nudge path.
+
+2. **Shellcheck:** `shellcheck .agents/scripts/pulse-issue-reconcile.sh`.
+
+## Acceptance Criteria
+
+- [ ] `_post_parent_decomposition_nudge` helper added to
+  `pulse-issue-reconcile.sh` with idempotency via the
+  `<!-- parent-needs-decomposition -->` marker.
+- [ ] `reconcile_completed_parent_tasks` calls the helper when
+  both sub-issue graph AND body-section yield zero children.
+- [ ] Per-cycle rate-limit (max 5 nudges per pulse) prevents noise.
+- [ ] Structural tests pass.
+- [ ] Shellcheck clean.
+
+## Context
+
+- **Companion fixes:** t2386 (PR #19909, NMR preservation), t2387
+  (PR #19918, no_work skip). Together these form the 2026-04-19
+  diagnostic audit framework bundle.
+- **Related:** GH#19736 (t2228 — parent with already-filed children, 2
+  still open due to no_work failures that t2387 addresses).
+- **Blocks on:** nothing — independent edit to `pulse-issue-reconcile.sh`.
+
+## PR Conventions
+
+Leaf issue (not parent-task). Use `Resolves #19927` in PR body.


### PR DESCRIPTION
## Summary

Parent-task-labelled issues with **zero filed children** are silently stuck in the pipeline. The `parent-task` label unconditionally blocks pulse dispatch (`PARENT_TASK_BLOCKED` in `dispatch-dedup-helper.sh`), the reconcile sweep has nothing to sweep (no child refs found), and nothing surfaces the decomposition need to the maintainer — so these issues accumulate indefinitely.

**Observed impact (2026-04-19 scan of marcusquinn/aidevops):**
- #19808 (t2264) — parent-task, no `## Children` section, open since filing
- #19858 — parent-task, no `## Children` section, open since filing
- #19859 — parent-task, no `## Children` section, open since filing
- #19874 — parent-task, no `## Children` section, open since filing

All four have zero dispatch attempts, zero reconcile activity, zero surfaced signal. This is the "silent-stuck" failure mode Fix #3 targets in the broader pipeline-autonomy investigation.

## Fix

In `reconcile_completed_parent_tasks` (`.agents/scripts/pulse-issue-reconcile.sh`), when both the sub-issue graph AND the `## Children` body section return empty, post a **one-time decomposition nudge comment** via a new `_post_parent_decomposition_nudge` helper.

- **Idempotent** via the `<!-- parent-needs-decomposition -->` marker checked against the issue comments API before posting (fail-open on transient API errors — a one-time duplicate on a flaky API is better than missing the nudge entirely).
- **Capped at 5 nudges per reconcile cycle** to match the existing `max_closes=5` cap, preventing a maintainer from waking up to 50 near-identical comments.
- **Comment body** explains the two paths forward (decompose into children with a `## Children` section, or drop the `parent-task` label for single-unit work) with copy-pasteable snippets — matching the mentorship pattern used by the framework's other self-nudging loops.
- **Logs** `closed=N nudged=M` at end of cycle so the signal is visible in pulse logs.

## Test coverage

New `test-pulse-parent-nudge.sh` with 11 structural assertions covering:
1. Helper function exists
2. Canonical marker present
3. Idempotency check via `gh api comments`
4. Comment posting via `gh issue comment`
5-6. Counter + cap declared
7. Title extracted from jq
8. Helper called with slug+num+title
9. Counter incremented on success
10. Final log line includes `nudged=`
11. Nudge gated on empty `child_nums` (runs AFTER graph+body lookups)

Structural over functional because functional verification would require stubbing both the `gh api comments` endpoint and the GraphQL sub-issue graph — cheaper to grep for wiring and verify live on first-eligible parent.

**Regression check:** existing `test-reconcile-parent-body-parse.sh` (22 assertions) passes unchanged. The 5 pre-existing failures in `test-pulse-reconcile-parent-task-subissue-graph.sh` are unchanged by this PR (confirmed via stash-and-run) — they pre-date t2388 and relate to t2244 fixture drift, not this change.

## Context

This is **Fix #3** of a session investigating 17 open issues on marcusquinn/aidevops as diagnostic evidence of pipeline failure modes. Companion PRs:
- #19909 (t2386) — NMR circuit-breaker loop fix
- #19918 (t2387) — no_work crash tier-escalation skip

Resolves #19927

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.75 plugin for [OpenCode](https://opencode.ai) v1.14.18 with claude-opus-4-7 spent 11h 48m and 107,840 tokens on this with the user in an interactive session.