### PR TITLE
GH#19916: apply gemini review suggestions from PR #19907 followup

### DIFF
--- a/.agents/scripts/gh-wrapper-guard.sh
+++ b/.agents/scripts/gh-wrapper-guard.sh
@@ -75,21 +75,21 @@ _scan_line() {
 	# Match raw "gh issue create" or "gh pr create"
 	# Use word-boundary-like matching: the gh command should be preceded by
 	# start-of-line, whitespace, pipe, semicolon, $( or backtick.
-	if echo "$line" | grep -qE '(^|[[:space:];|`]|\$\()gh[[:space:]]+issue[[:space:]]+create'; then
+	if printf '%s\n' "$line" | grep -qE '(^|[[:space:];|`]|\$\()gh[[:space:]]+issue[[:space:]]+create'; then
 		return 0
 	fi
-	if echo "$line" | grep -qE '(^|[[:space:];|`]|\$\()gh[[:space:]]+pr[[:space:]]+create'; then
+	if printf '%s\n' "$line" | grep -qE '(^|[[:space:];|`]|\$\()gh[[:space:]]+pr[[:space:]]+create'; then
 		return 0
 	fi
 
 	# GH#19857: Match raw "gh issue edit" or "gh pr edit" with --title or --body.
 	# Label-only edits (no --title/--body) are fine without the safe wrapper.
-	if echo "$line" | grep -qE '(^|[[:space:];|`]|\$\()gh[[:space:]]+issue[[:space:]]+edit' &&
-		echo "$line" | grep -qE '\-\-title\b|\-\-body\b|\-\-body-file\b'; then
+	if printf '%s\n' "$line" | grep -qE '(^|[[:space:];|`]|\$\()gh[[:space:]]+issue[[:space:]]+edit' &&
+		printf '%s\n' "$line" | grep -qE '\-\-title\b|\-\-body\b|\-\-body-file\b'; then
 		return 0
 	fi
-	if echo "$line" | grep -qE '(^|[[:space:];|`]|\$\()gh[[:space:]]+pr[[:space:]]+edit' &&
-		echo "$line" | grep -qE '\-\-title\b|\-\-body\b|\-\-body-file\b'; then
+	if printf '%s\n' "$line" | grep -qE '(^|[[:space:];|`]|\$\()gh[[:space:]]+pr[[:space:]]+edit' &&
+		printf '%s\n' "$line" | grep -qE '\-\-title\b|\-\-body\b|\-\-body-file\b'; then
 		return 0
 	fi
 
@@ -221,9 +221,9 @@ cmd_check_full() {
 
 	# Fast grep pass: find candidate files with raw gh issue/pr create or edit
 	local candidates
-	candidates=$(git ls-files '*.sh' 2>/dev/null |
-		grep -vE '(shared-constants\.sh|agents/scripts/tests/)' |
-		xargs grep -lE 'gh[[:space:]]+(issue|pr)[[:space:]]+(create|edit)' 2>/dev/null ||
+	candidates=$(git ls-files -z '*.sh' 2>/dev/null |
+		grep -zvE '(shared-constants\.sh|agents/scripts/tests/)' |
+		xargs -0 grep -lE 'gh[[:space:]]+(issue|pr)[[:space:]]+(create|edit)' ||
 		true)
 
 	if [[ -z "$candidates" ]]; then

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -1271,7 +1271,8 @@ _gh_validate_edit_args() {
 	# Validate title if present
 	if [[ "$has_title" -eq 1 ]]; then
 		local trimmed_title
-		trimmed_title=$(printf '%s' "$title_val" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+		trimmed_title="${title_val#"${title_val%%[![:space:]]*}"}"
+		trimmed_title="${trimmed_title%"${trimmed_title##*[![:space:]]}"}"
 		if [[ -z "$trimmed_title" ]]; then
 			_GH_EDIT_REJECTION_REASON="empty title (after trimming whitespace)"
 			printf '[SAFETY] gh edit rejected: %s\n' "$_GH_EDIT_REJECTION_REASON" >&2
@@ -1288,7 +1289,8 @@ _gh_validate_edit_args() {
 	# Validate body if present
 	if [[ "$has_body" -eq 1 ]]; then
 		local trimmed_body
-		trimmed_body=$(printf '%s' "$body_val" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+		trimmed_body="${body_val#"${body_val%%[![:space:]]*}"}"
+		trimmed_body="${trimmed_body%"${trimmed_body##*[![:space:]]}"}"
 		if [[ -z "$trimmed_body" ]]; then
 			_GH_EDIT_REJECTION_REASON="empty body (after trimming whitespace)"
 			printf '[SAFETY] gh edit rejected: %s\n' "$_GH_EDIT_REJECTION_REASON" >&2


### PR DESCRIPTION
## Summary

Applies three robustness improvements flagged by gemini-code-assist on PR #19907:

1. **shared-constants.sh:1274,1291** — Replace `printf '%s' | sed` whitespace trimming with pure Bash parameter expansion in `_gh_validate_edit_args`. Avoids forking a subshell + sed process on every call. Works correctly in Bash 4+ (guaranteed by the script's re-exec guard).

2. **gh-wrapper-guard.sh:227** — Switch to NUL-delimited pipeline (`git ls-files -z` + `grep -z` + `xargs -0`) in `cmd_check_full`. Prevents breakage if any `.sh` file path contains spaces.

3. **gh-wrapper-guard.sh:78,81,87-94** — Replace `echo "$line"` with `printf '%s\n' "$line"` in `_scan_line`. `echo` mishandles lines starting with `-e` or similar flags; `printf '%s\n'` is unconditionally safe.

Fourth suggestion (stripping trailing comments before scanning) was not addressed: the existing pure-comment-line filter (lines 69-73) already covers the most likely false-positive case, and the residual scenario (a non-comment line with `gh issue edit` in code AND `--title` only in a trailing `# ...` comment) is contrived enough that the complexity of a parser-level fix isn't justified.

## Verification

- `shellcheck .agents/scripts/gh-wrapper-guard.sh` — zero violations
- `shellcheck .agents/scripts/shared-constants.sh` — only pre-existing SC2016 on GraphQL literals (unchanged)

Resolves #19916