### PR TITLE
GH#19917: fix atomic cache writes and optional jq chaining in r-stub-title-scan.sh

### DIFF
--- a/.agents/custom/scripts/r-stub-title-scan.sh
+++ b/.agents/custom/scripts/r-stub-title-scan.sh
@@ -130,7 +130,10 @@ _load_seen_cache() {
     pruned=$(jq --argjson cutoff "$cutoff" \
         'to_entries | map(select(.value >= $cutoff)) | from_entries' \
         "$SEEN_CACHE" 2>/dev/null) || pruned='{}'
-    echo "$pruned" > "$SEEN_CACHE"
+    echo "$pruned" > "${SEEN_CACHE}.tmp" && mv "${SEEN_CACHE}.tmp" "$SEEN_CACHE" || {
+        echo "Error: Failed to write to ${SEEN_CACHE}" >&2
+        return 1
+    }
     return 0
 }
 
@@ -153,7 +156,10 @@ _mark_seen() {
         _log "WARN" "Failed to update seen cache for ${key}"
         return 1
     }
-    echo "$updated" > "$SEEN_CACHE"
+    echo "$updated" > "${SEEN_CACHE}.tmp" && mv "${SEEN_CACHE}.tmp" "$SEEN_CACHE" || {
+        echo "Error: Failed to update ${SEEN_CACHE}" >&2
+        return 1
+    }
     return 0
 }
 
@@ -161,7 +167,7 @@ _mark_seen() {
 _get_pulse_repos() {
     [[ -n "${STUB_SCAN_REPOS:-}" ]] && { echo "$STUB_SCAN_REPOS" | tr ',' '\n'; return 0; }
     [[ -f "$REPOS_JSON" ]] || { _log "ERROR" "repos.json not found at ${REPOS_JSON}"; return 1; }
-    jq -r '.initialized_repos[] | select(.pulse == true) | select(.local_only != true) | .slug' \
+    jq -r '.initialized_repos[]? | select(.pulse == true) | select(.local_only != true) | .slug' \
         "$REPOS_JSON" 2>/dev/null
     return 0
 }


### PR DESCRIPTION
## Summary

Addresses three gemini-code-assist inline review suggestions from PR #19906 (unaddressed at merge time — filed as GH#19917).

### Changes

- **`_load_seen_cache` (line 133):** Replace non-atomic direct write `echo "$pruned" > "$SEEN_CACHE"` with temp-file-and-move pattern to prevent data loss if the script is interrupted mid-write.
- **`_mark_seen` (line 156):** Same atomic write fix for the cache update path.
- **`_get_pulse_repos` (line 164):** Use `.initialized_repos[]?` optional chaining so jq returns an empty iterator (exit 0) instead of erroring when `initialized_repos` is missing or null in `repos.json`.

### Verification

- `shellcheck .agents/custom/scripts/r-stub-title-scan.sh` — passes clean (zero violations)
- All three premises verified against file before implementing
- Error messages include the file path for diagnostics (consistent with bot's guidance)

Resolves #19917