### PR TITLE
GH#19920: fix pre-commit-hook.sh Gemini review feedback — here-string idiom + shellcheck guard

### DIFF
--- a/.agents/scripts/pre-commit-hook.sh
+++ b/.agents/scripts/pre-commit-hook.sh
@@ -143,8 +143,8 @@ validate_return_statements() {
 			local head_content head_funcs head_returns head_missing=0
 			head_content=$(_get_head_content "$file")
 			if [[ -n "$head_content" ]]; then
-				head_funcs=$(printf '%s\n' "$head_content" | grep -c "^[a-zA-Z_][a-zA-Z0-9_]*() {" || true)
-				head_returns=$(printf '%s\n' "$head_content" | grep -c "return [01]" || true)
+				head_funcs=$(grep -c "^[a-zA-Z_][a-zA-Z0-9_]*() {" <<< "$head_content" || true)
+				head_returns=$(grep -c "return [01]" <<< "$head_content" || true)
 				if ((head_funcs > 0 && head_returns < head_funcs)); then
 					head_missing=$((head_funcs - head_returns))
 				fi
@@ -312,6 +312,11 @@ validate_string_literals() {
 
 run_shellcheck() {
 	local violations=0
+
+	if ! command -v shellcheck &>/dev/null; then
+		print_warning "shellcheck not found — skipping ShellCheck validation"
+		return 0
+	fi
 
 	print_info "Running ShellCheck validation (ratchet)..."
 


### PR DESCRIPTION
## Summary

Addresses two medium-priority review bot findings from PR #19904 that were unresolved at merge time.

### Changes

**`.agents/scripts/pre-commit-hook.sh`**

1. **Here-string idiom (line 147)** — replaced `printf '%s\n' "$head_content" | grep -c` with idiomatic `grep -c ... <<< "$head_content"` in `validate_return_statements`. Avoids an unnecessary subshell fork; `<<<` is supported in Bash 3.2+.

2. **shellcheck availability guard (line 313)** — added `command -v shellcheck` check at the start of `run_shellcheck()`. Previously, a missing `shellcheck` binary caused `2>/dev/null` to suppress the "command not found" error, counting 0 findings for both staged and HEAD, and silently passing the gate. Now emits a warning and returns 0 (skip) explicitly rather than failing invisibly.

### Verification

- `shellcheck .agents/scripts/pre-commit-hook.sh` — zero violations
- Pre-commit hook ran cleanly on the modified file during commit

Resolves #19920