### PR TITLE
t2391: fix(issue-sync): range-syntax PR title guard for TODO auto-complete

### DIFF
--- a/.agents/scripts/tests/test-pulse-auto-complete-keywords.sh
+++ b/.agents/scripts/tests/test-pulse-auto-complete-keywords.sh
@@ -1,0 +1,292 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Tests for the pulse TODO auto-complete keyword semantics (t2391 / GH#19825).
+#
+# Background: `.github/workflows/issue-sync.yml` `sync-on-pr-merge` job runs
+# on PR merge and marks `- [ ] tNNN` → `- [x] tNNN ... pr:#NNN completed:...`
+# in TODO.md. Prior to t2391 it extracted `TASK_ID` via `^t[0-9]+` from the PR
+# title with no range-syntax awareness. Planning PRs titled `t2259..t2264:
+# plan framework observations` would mark ONLY t2259 complete, which is always
+# wrong — none of the six tasks shipped code in the planning PR.
+#
+# The t2252 guard (line 705) already handles the `For/Ref`-only body case.
+# The t2391 guard (line 695) handles the range-syntax title case, firing
+# BEFORE the t2252 guard so Case D (range-syntax title + Closes body) is
+# caught by the belt-and-braces range-syntax check.
+#
+# Test strategy:
+#   - Static inspection: verify both guards exist with their expected regex
+#     patterns and fire in the correct order.
+#   - Behavioural classification: reimplement the extract-step regexes here
+#     and assert the 5 cases (A-E) from the issue body produce the expected
+#     classify decision (MARK_COMPLETE vs SKIP_RANGE vs SKIP_FOR_REF).
+#
+# Cases covered (from issue body):
+#   A. body `Resolves #19802`, title `fix(biome): batch-fix JS/MJS`
+#      → MARK_COMPLETE (baseline: single-task fix PR).
+#   B. body `For #19802`, title `plan: batch-fix JS/MJS`
+#      → SKIP_FOR_REF (t2252 guard).
+#   C. title `t2259..t2264: plan`, body `For #19802`
+#      → SKIP_RANGE (t2391 guard wins; range-syntax detection).
+#   D. body `Closes #19802`, title `t2259..t2264: plan`
+#      → SKIP_RANGE (t2391 guard wins over closing keyword; belt-and-braces).
+#   E. body `Resolves #19802`, title `t2259: fix(biome) implement proper fix`
+#      → MARK_COMPLETE (single-task ID title, not range-syntax).
+
+set -uo pipefail
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPT_DIR_TEST}/../../.." && pwd)" || exit 1
+WORKFLOW="${REPO_ROOT}/.github/workflows/issue-sync.yml"
+
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf '  %sPASS%s %s\n' "$TEST_GREEN" "$TEST_NC" "$1"
+	return 0
+}
+
+fail() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '  %sFAIL%s %s\n' "$TEST_RED" "$TEST_NC" "$1"
+	if [[ $# -ge 2 && -n "$2" ]]; then
+		printf '       %s\n' "$2"
+	fi
+	return 0
+}
+
+# Reimplementation of the extract-step regexes from issue-sync.yml.
+# Must be kept in sync with lines 374-401 of that file. The static inspection
+# tests below assert the workflow file still contains these patterns.
+classify_pr() {
+	local pr_title="$1"
+	local pr_body="$2"
+
+	local linked_issues=""
+	if [[ -n "$pr_body" ]]; then
+		linked_issues=$(echo "$pr_body" | grep -oiE '(closes?|fixes?|resolves?)[[:space:]]*#[0-9]+' | grep -oE '[0-9]+' | sort -u | tr '\n' ' ' || true)
+	fi
+
+	local for_ref_issues=""
+	if [[ -n "$pr_body" ]]; then
+		for_ref_issues=$(echo "$pr_body" | grep -oiE '(for|ref)[[:space:]]*#[0-9]+' | grep -oE '[0-9]+' | sort -u | tr '\n' ' ' || true)
+	fi
+
+	local range_syntax=""
+	if echo "$pr_title" | grep -qE '^t[0-9]+\.\.t[0-9]+'; then
+		range_syntax="true"
+	elif echo "$pr_title" | grep -qE '^t[0-9]+,[[:space:]]*t[0-9]+'; then
+		range_syntax="true"
+	fi
+
+	# Guard order mirrors the workflow run block:
+	#   1. range-syntax (t2391) — fires first, belt-and-braces
+	#   2. for/ref-only (t2252) — fires when no Closes/Fixes/Resolves
+	#   3. otherwise → mark complete
+	if [[ "$range_syntax" == "true" ]]; then
+		echo "SKIP_RANGE"
+		return 0
+	fi
+	if [[ -z "$linked_issues" ]] && [[ -n "$for_ref_issues" ]]; then
+		echo "SKIP_FOR_REF"
+		return 0
+	fi
+	echo "MARK_COMPLETE"
+	return 0
+}
+
+# ------------------------------------------------------------
+# Static inspection: t2391 range-syntax detection + guard exist
+# ------------------------------------------------------------
+test_range_syntax_detection_in_extract_step() {
+	if ! grep -qE "grep -qE '\^t\[0-9\]\+\\\\\\.\\\\\\.t\[0-9\]\+'" "$WORKFLOW"; then
+		fail "extract step contains tNNN..tNNN detection" \
+			"Expected '^t[0-9]+\\.\\.t[0-9]+' regex in workflow. The t2391 fix requires range-syntax detection in the extract step."
+		return 0
+	fi
+	if ! grep -qE "grep -qE '\^t\[0-9\]\+,\[\[:space:\]\]\*t\[0-9\]\+'" "$WORKFLOW"; then
+		fail "extract step contains tNNN, tNNN detection" \
+			"Expected '^t[0-9]+,[[:space:]]*t[0-9]+' regex in workflow."
+		return 0
+	fi
+	if ! grep -q 'echo "range_syntax=' "$WORKFLOW"; then
+		fail "extract step emits range_syntax output" \
+			"Expected 'range_syntax=' GITHUB_OUTPUT write."
+		return 0
+	fi
+	pass "extract step: range-syntax regex + GITHUB_OUTPUT present"
+	return 0
+}
+
+test_range_syntax_guard_in_update_step() {
+	# shellcheck disable=SC2016  # literal YAML expression intended
+	if ! grep -q 'RANGE_SYNTAX: ${{ steps.extract.outputs.range_syntax }}' "$WORKFLOW"; then
+		fail "update step: RANGE_SYNTAX env var wired from extract output" \
+			"Expected 'RANGE_SYNTAX: \${{ steps.extract.outputs.range_syntax }}' in the update step env block."
+		return 0
+	fi
+	if ! grep -qE '\[\[ "\$\{RANGE_SYNTAX:-\}" == "true" \]\]' "$WORKFLOW"; then
+		fail "update step: range-syntax guard condition" \
+			"Expected guard '[[ \"\${RANGE_SYNTAX:-}\" == \"true\" ]]' in the update step."
+		return 0
+	fi
+	pass "update step: RANGE_SYNTAX env + guard present"
+	return 0
+}
+
+# Guard order matters: t2391 must fire BEFORE t2252 so Case D (range-syntax
+# title + body `Closes #NNN`) doesn't fall through to the t2252 check (which
+# allows through because LINKED_ISSUES is populated) and reach the mark-
+# complete code path.
+test_range_guard_precedes_for_ref_guard() {
+	local range_line for_ref_line
+	range_line=$(grep -nE '"\$\{RANGE_SYNTAX:-\}" == "true"' "$WORKFLOW" | head -1 | cut -d: -f1)
+	for_ref_line=$(grep -nE '\[\[ -z "\$\{LINKED_ISSUES:-\}" \]\] && \[\[ -n "\$\{FOR_REF_ISSUES:-\}" \]\]' "$WORKFLOW" | head -1 | cut -d: -f1)
+	if [[ -z "$range_line" || -z "$for_ref_line" ]]; then
+		fail "range guard precedes for/ref guard" \
+			"Missing range_line=$range_line or for_ref_line=$for_ref_line"
+		return 0
+	fi
+	if [[ "$range_line" -lt "$for_ref_line" ]]; then
+		pass "guard order: range-syntax (line $range_line) precedes for/ref (line $for_ref_line)"
+		return 0
+	fi
+	fail "range guard precedes for/ref guard" \
+		"range_line=$range_line is NOT before for_ref_line=$for_ref_line. Case D would fall through to mark-complete."
+	return 0
+}
+
+# ------------------------------------------------------------
+# Behavioural: 5 cases from issue body
+# ------------------------------------------------------------
+assert_case() {
+	local name="$1"
+	local title="$2"
+	local body="$3"
+	local expected="$4"
+	local got
+	got=$(classify_pr "$title" "$body")
+	if [[ "$got" == "$expected" ]]; then
+		pass "Case $name: $expected"
+		return 0
+	fi
+	fail "Case $name: expected $expected got $got" \
+		"title=$title body=$body"
+	return 0
+}
+
+test_case_a_baseline_resolves() {
+	assert_case "A" \
+		"fix(biome): batch-fix JS/MJS" \
+		"Resolves #19802" \
+		"MARK_COMPLETE"
+	return 0
+}
+
+test_case_b_for_ref_only() {
+	assert_case "B" \
+		"plan: batch-fix JS/MJS" \
+		"For #19802" \
+		"SKIP_FOR_REF"
+	return 0
+}
+
+test_case_c_range_plus_for() {
+	assert_case "C" \
+		"t2259..t2264: plan framework observations" \
+		"For #19802" \
+		"SKIP_RANGE"
+	return 0
+}
+
+test_case_d_range_plus_closes_belt_and_braces() {
+	# This is the whole reason the range guard must precede the for/ref
+	# guard. Body has a closing keyword (Closes #19802) — absent the
+	# range guard, LINKED_ISSUES would be "19802", t2252 guard wouldn't
+	# fire, and the code would proceed to mark t2259 complete.
+	assert_case "D" \
+		"t2259..t2264: plan framework observations" \
+		"Closes #19802" \
+		"SKIP_RANGE"
+	return 0
+}
+
+test_case_e_single_task_id_not_range() {
+	assert_case "E" \
+		"t2259: fix(biome) implement proper fix" \
+		"Resolves #19802" \
+		"MARK_COMPLETE"
+	return 0
+}
+
+# Additional edge case: comma-separated range-syntax (tNNN, tNNN)
+test_case_f_comma_range_syntax() {
+	assert_case "F (comma range)" \
+		"t2259, t2260: plan two tasks" \
+		"For #19802" \
+		"SKIP_RANGE"
+	return 0
+}
+
+# PR #19814 real-world replay: this was the merge that motivated the fix.
+# Title: "t2259..t2264: plan framework observations from t2249 session"
+# Body: "## Summary ... ## For ... For #19802 ..."
+# Expected under new logic: SKIP_RANGE (would NOT have marked t2259 [x]).
+test_pr_19814_replay() {
+	local title="t2259..t2264: plan framework observations from t2249 session"
+	local body="## For
+
+- For #19802
+- For #19803
+- For #19804"
+	local got
+	got=$(classify_pr "$title" "$body")
+	if [[ "$got" == "SKIP_RANGE" ]]; then
+		pass "PR #19814 replay: new logic correctly skips (was mark-complete before t2391)"
+		return 0
+	fi
+	fail "PR #19814 replay: expected SKIP_RANGE got $got" ""
+	return 0
+}
+
+main_test() {
+	if [[ ! -f "$WORKFLOW" ]]; then
+		printf '%sFAIL%s workflow file not found at %s\n' "$TEST_RED" "$TEST_NC" "$WORKFLOW"
+		return 1
+	fi
+
+	printf 'Static inspection:\n'
+	test_range_syntax_detection_in_extract_step
+	test_range_syntax_guard_in_update_step
+	test_range_guard_precedes_for_ref_guard
+
+	printf '\nBehavioural cases (A-F + real-world replay):\n'
+	test_case_a_baseline_resolves
+	test_case_b_for_ref_only
+	test_case_c_range_plus_for
+	test_case_d_range_plus_closes_belt_and_braces
+	test_case_e_single_task_id_not_range
+	test_case_f_comma_range_syntax
+	test_pr_19814_replay
+
+	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main_test "$@"

--- a/.github/workflows/issue-sync.yml
+++ b/.github/workflows/issue-sync.yml
@@ -391,6 +391,21 @@ jobs:
           fi
           echo "for_ref_issues=$FOR_REF_ISSUES" >> "$GITHUB_OUTPUT"
 
+          # t2391 / GH#19825: Detect range-syntax PR titles (tNNN..tNNN or
+          # tNNN, tNNN). These signal multi-task planning PRs — the pulse's
+          # auto-complete would match only the first task ID and mark it [x]
+          # which is always wrong. Downstream steps consume this flag and
+          # skip auto-complete regardless of body keywords (belt-and-braces
+          # per issue Case D: body `Closes #NNN` + range-syntax title must
+          # still skip TODO update).
+          RANGE_SYNTAX=""
+          if echo "$PR_TITLE" | grep -qE '^t[0-9]+\.\.t[0-9]+'; then
+            RANGE_SYNTAX="true"
+          elif echo "$PR_TITLE" | grep -qE '^t[0-9]+,[[:space:]]*t[0-9]+'; then
+            RANGE_SYNTAX="true"
+          fi
+          echo "range_syntax=$RANGE_SYNTAX" >> "$GITHUB_OUTPUT"
+
           # Determine if we have anything to process
           if [[ -n "$TASK_ID" || -n "$LINKED_ISSUES" ]]; then
             echo "has_work=true" >> "$GITHUB_OUTPUT"
@@ -398,7 +413,7 @@ jobs:
             echo "has_work=false" >> "$GITHUB_OUTPUT"
           fi
 
-          echo "PR #$PR_NUMBER: task_id=$TASK_ID linked_issues=$LINKED_ISSUES for_ref_issues=$FOR_REF_ISSUES"
+          echo "PR #$PR_NUMBER: task_id=$TASK_ID linked_issues=$LINKED_ISSUES for_ref_issues=$FOR_REF_ISSUES range_syntax=$RANGE_SYNTAX"
 
       - name: Find issue by task ID (fallback)
         id: find-issue
@@ -671,6 +686,11 @@ jobs:
           # implementation work is not complete.
           LINKED_ISSUES: ${{ steps.extract.outputs.linked_issues }}
           FOR_REF_ISSUES: ${{ steps.extract.outputs.for_ref_issues }}
+          # t2391 / GH#19825: range-syntax PR titles (tNNN..tNNN or
+          # tNNN, tNNN) signal multi-task planning PRs and must skip the
+          # TODO auto-complete entirely, even if the body contains closing
+          # keywords. See the guard at the top of the run block.
+          RANGE_SYNTAX: ${{ steps.extract.outputs.range_syntax }}
           # t2034: gh CLI needs GH_TOKEN explicitly — without it, the t2029
           # `gh pr comment` fallback (posted when the TODO.md push is rejected
           # by branch protection) silently fails because gh has no auth.
@@ -691,6 +711,21 @@ jobs:
         run: |
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
+
+          # t2391 / GH#19825: Skip TODO.md proof-log for range-syntax titled PRs.
+          # Titles like `t2259..t2264: plan …` or `t2259, t2260: plan …` signal
+          # multi-task planning PRs. The auto-complete regex only captures the
+          # FIRST task ID, so marking it [x] is always wrong — the other tasks
+          # in the range never had implementation code shipped. This guard
+          # fires regardless of body keywords (belt-and-braces per issue Case D:
+          # even if the body contains `Closes #NNN`, the range-syntax title
+          # wins). The title-fallback path in `Find issue by task ID` (line 403)
+          # is separately gated by For/Ref (t2219) and parent-task (t2137);
+          # its status:done behaviour is out of scope for this guard.
+          if [[ "${RANGE_SYNTAX:-}" == "true" ]]; then
+            echo "::notice::PR title uses range-syntax (tNNN..tNNN or tNNN, tNNN) — skipping TODO.md proof-log (planning-only multi-task PR, GH#19825)"
+            exit 0
+          fi
 
           # GH#19782 / t2252: Skip TODO.md proof-log for planning-only PRs.
           # When the PR body uses only For/Ref references (t2046 planning

--- a/todo/tasks/t2391-brief.md
+++ b/todo/tasks/t2391-brief.md
@@ -1,0 +1,96 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# t2391: fix(issue-sync): range-syntax PR title guard for TODO auto-complete
+
+## Origin
+
+- **Created:** 2026-04-19
+- **Session:** Claude Code (interactive continuation, acting on open-issue triage)
+- **Observation:** While auditing the 36-issue backlog for concurrency/productivity blockers, revisited GH#19825 (t2369 in the issue title). The filing session's memory entry (`mem_20260419020126_e137cd2a`) confirmed that PR #19814 — titled `t2259..t2264: plan framework observations` — auto-marked t2259 `[x]` in TODO.md despite being a planning-only PR filing briefs for six tasks. The reverting PR #19818 restored the state, but the underlying guard was never added.
+
+## What
+
+Add a range-syntax PR title guard to the `.github/workflows/issue-sync.yml` `sync-on-pr-merge` job so that titles like `tNNN..tNNN: ...` or `tNNN, tNNN: ...` skip the TODO auto-complete step entirely, regardless of body keywords.
+
+## Why
+
+The canonical invariant — `[x] tNNN` in TODO.md means "the code for tNNN shipped" — is violated on every multi-task planning PR whose title starts with a task-ID range. PR #19814 is the existence proof. t2252 (PR #19819) added the `For/Ref`-only body guard, closing part of the gap; t2391 closes the remaining gap where a range-syntax title ships with a closing keyword in the body (Case D in the acceptance criteria).
+
+The direct consequence of leaving this open is trust erosion on the audit trail: operators who see a `[x]` mark in TODO.md can no longer rely on it meaning the task is done. This compounds across the multi-machine, multi-user pulse the user is trying to stabilise — every operator has to manually audit `[x]` marks against PR diffs.
+
+## How
+
+### Issue-filing session's premise was partly wrong on files
+
+The issue body names `.agents/scripts/pulse-merge.sh` and `.agents/scripts/task-complete-helper.sh` as edit sites. Neither is correct:
+
+- `pulse-merge.sh` has **0 hits** for auto-complete logic (verified via `rg 'completed:|mark.*complete|\[x\]' .agents/scripts/pulse-merge.sh`).
+- `task-complete-helper.sh` is a user-facing helper that takes an explicit `task_id` argument — it's invoked manually, not on PR merge.
+
+The actual fix site is `.github/workflows/issue-sync.yml`. This is a worker-triage Outcome B case: premise partly falsified on files, but the bug is real and the corrected fix site is obvious. Proceeded to implement.
+
+### Edits
+
+1. **Extract step** (lines 386-399): add `RANGE_SYNTAX` detection after `FOR_REF_ISSUES`. Two patterns: `^t[0-9]+\.\.t[0-9]+` (range) and `^t[0-9]+,[[:space:]]*t[0-9]+` (comma-separated). Emit to `GITHUB_OUTPUT`.
+2. **Update step** (lines 673-680): add `RANGE_SYNTAX` env from `steps.extract.outputs.range_syntax`.
+3. **Update step guard** (lines 695-710): add early exit when `RANGE_SYNTAX=true`, BEFORE the existing t2252 For/Ref-only guard. Order matters — Case D (range-syntax title + body `Closes #NNN`) has `LINKED_ISSUES` populated, which would fall through the t2252 guard and reach the mark-complete path.
+
+### Regression test
+
+`.agents/scripts/tests/test-pulse-auto-complete-keywords.sh` (10 tests):
+
+- **Static inspection (3)**: asserts the range-syntax regex exists in the extract step, the `RANGE_SYNTAX` env + guard exist in the update step, and the range guard precedes the for/ref guard in source order.
+- **Behavioural (7)**: reimplements the classification logic from the workflow as a pure bash function (`classify_pr`), then asserts the five cases from the issue body (A baseline, B for/ref, C range+for, D range+closes belt-and-braces, E single-task-ID) plus a comma-range edge case (F) and a real-world replay of PR #19814.
+
+The static-inspection tests keep the behavioural re-implementation honest: if someone changes the workflow regex without updating the test, the static checks fail.
+
+## Tier
+
+`tier:standard` — small logic change but blast radius is every merged PR on every repo using this workflow. Needs careful regression testing.
+
+## Acceptance
+
+- [x] Range-syntax PR titles (`tNNN..tNNN`, `tNNN, tNNN`) suppress TODO auto-complete regardless of body keywords.
+- [x] Existing t2252 For/Ref guard continues to fire (Case B still skips).
+- [x] Single-task-ID titles with `Resolves`/`Closes`/`Fixes` still mark complete (Cases A, E still proceed).
+- [x] Regression test `.agents/scripts/tests/test-pulse-auto-complete-keywords.sh` covers cases A-F plus PR #19814 replay and passes (10/10).
+- [x] Guard order asserted: range-syntax fires before for/ref.
+
+## Context
+
+- **Direct evidence:** PR #19814 merged 2026-04-19 00:47 UTC, auto-marked t2259 `[x]`. Reverted via PR #19818.
+- **Memory:** `mem_20260419020126_e137cd2a`.
+- **Related:**
+  - PR #19814 (batch planning that triggered the bug)
+  - PR #19818 (the revert)
+  - t2219 (sibling fix for the issue status:done path — PR #19820)
+  - t2252 (sibling fix for the TODO For/Ref-only path — PR #19819)
+- **Out of scope:** the `Find issue by task ID (fallback)` step (line 403) that applies `status:done` to issues via title-fallback. Its existing parent-task (t2137) and For/Ref (t2219) guards are sufficient for the cases specified in the issue. A range-syntax guard there could be added as a followup if needed, but none of the 5 issue cases exercise that path.
+
+## Relevant files
+
+- `.github/workflows/issue-sync.yml` — primary edit site (extract step + update step guard + env)
+- `.agents/scripts/tests/test-pulse-auto-complete-keywords.sh` — NEW regression test
+
+## Verification evidence
+
+Test run (in worktree, pre-commit):
+
+```
+Static inspection:
+  PASS extract step: range-syntax regex + GITHUB_OUTPUT present
+  PASS update step: RANGE_SYNTAX env + guard present
+  PASS guard order: range-syntax (line 725) precedes for/ref (line 740)
+
+Behavioural cases (A-F + real-world replay):
+  PASS Case A: MARK_COMPLETE
+  PASS Case B: SKIP_FOR_REF
+  PASS Case C: SKIP_RANGE
+  PASS Case D: SKIP_RANGE
+  PASS Case E: MARK_COMPLETE
+  PASS Case F (comma range): SKIP_RANGE
+  PASS PR #19814 replay: new logic correctly skips (was mark-complete before t2391)
+
+Ran 10 tests, 0 failed.
+```


### PR DESCRIPTION
## Summary

Closes the TODO auto-complete false-positive where a PR titled like `t2259..t2264: plan framework observations` auto-marks only t2259 `[x]` in `TODO.md`, even when the PR ships no implementation code. This is the existence-proof revert trail from PR #19814 → PR #19818.

`.github/workflows/issue-sync.yml` `sync-on-pr-merge` now:

1. **Extract step** (lines 394-403): emits `range_syntax=true` when the PR title matches `^t[0-9]+\.\.t[0-9]+` or `^t[0-9]+,[[:space:]]*t[0-9]+`.
2. **Update step** (lines 695-706): exits before the existing t2252 `For/Ref`-only guard when `RANGE_SYNTAX=true`. Order matters: Case D (range-syntax title + body `Closes #NNN`) has `LINKED_ISSUES` populated, which would fall through the t2252 guard and reach the mark-complete path.

## Triage note

The originating issue body named `.agents/scripts/pulse-merge.sh` and `.agents/scripts/task-complete-helper.sh` as edit sites. Neither was correct — `pulse-merge.sh` has zero auto-complete logic and `task-complete-helper.sh` is a user-facing helper that takes an explicit `task_id` argument. The actual fix site is `.github/workflows/issue-sync.yml sync-on-pr-merge`. Worker-triage Outcome B: premise partly falsified on files, bug real, corrected fix site obvious.

## Test coverage

`.agents/scripts/tests/test-pulse-auto-complete-keywords.sh` — 10 assertions, all passing locally:

```
Static inspection:
  PASS extract step: range-syntax regex + GITHUB_OUTPUT present
  PASS update step: RANGE_SYNTAX env + guard present
  PASS guard order: range-syntax (line 725) precedes for/ref (line 740)

Behavioural cases (A-F + real-world replay):
  PASS Case A: MARK_COMPLETE         (Resolves + non-range title → mark)
  PASS Case B: SKIP_FOR_REF          (For only + non-range title → skip via t2252)
  PASS Case C: SKIP_RANGE            (For + range title → skip via t2391)
  PASS Case D: SKIP_RANGE            (Closes + range title → skip via t2391 belt-and-braces)
  PASS Case E: MARK_COMPLETE         (Resolves + single-task-ID title → mark)
  PASS Case F (comma range): SKIP_RANGE
  PASS PR #19814 replay: new logic correctly skips (was mark-complete before t2391)

Ran 10 tests, 0 failed.
```

Static inspection keeps the behavioural re-implementation honest: if someone changes the workflow regex without updating the test, the static checks fail.

## Blast radius

Every merged PR on every repo using `issue-sync.yml`. Covered by:

- All 5 issue-body acceptance cases (A-E)
- PR #19814 real-world replay (the motivating failure)
- Comma-range syntax variant (F)

## Out of scope

The `Find issue by task ID (fallback)` step (line 403) that applies `status:done` via title-fallback. Its existing parent-task (t2137) and For/Ref (t2219) guards are sufficient for the cases specified in the issue. A range-syntax guard there can be added as a followup if needed — none of the 5 issue cases exercise that path.

Resolves #19825

$(~/.aidevops/agents/scripts/gh-signature-helper.sh footer --model claude-opus-4-7)