### PR TITLE
GH#19921: robustness(complexity-guard): explicit PID tracking, env var testability, direct hook tests

### DIFF
--- a/.agents/hooks/complexity-regression-pre-push.sh
+++ b/.agents/hooks/complexity-regression-pre-push.sh
@@ -22,8 +22,10 @@
 # Exit 0 = allow push. Exit 1 = block push.
 #
 # Environment:
-#   COMPLEXITY_GUARD_DISABLE=1  — bypass for this invocation (same as --no-verify)
-#   COMPLEXITY_GUARD_DEBUG=1    — verbose stderr trace
+#   COMPLEXITY_GUARD_DISABLE=1        — bypass for this invocation (same as --no-verify)
+#   COMPLEXITY_GUARD_DEBUG=1          — verbose stderr trace
+#   COMPLEXITY_HELPER=/path/to/bin    — override helper resolution (for testing)
+#   COMPLEXITY_GUARD_BASE_SHA=<sha>   — override merge-base SHA (for testing)
 #
 # Fail-open cases (exit 0 with warning):
 #   - complexity-regression-helper.sh not found
@@ -63,18 +65,22 @@ _resolve_self_dir() {
 }
 
 HOOK_DIR=$(_resolve_self_dir)
-HELPER_REPO="${HOOK_DIR}/../scripts/complexity-regression-helper.sh"
-HELPER_DEPLOYED="${HOME}/.aidevops/agents/scripts/complexity-regression-helper.sh"
 
-if [[ -f "$HELPER_REPO" ]]; then
-	COMPLEXITY_HELPER="$HELPER_REPO"
-elif [[ -f "$HELPER_DEPLOYED" ]]; then
-	COMPLEXITY_HELPER="$HELPER_DEPLOYED"
-else
-	_log WARN "complexity-regression-helper.sh not found — fail-open"
-	_log WARN "  checked: $HELPER_REPO"
-	_log WARN "  checked: $HELPER_DEPLOYED"
-	exit 0
+# Allow env override for testing (COMPLEXITY_HELPER=... bash hook.sh)
+if [[ -z "${COMPLEXITY_HELPER:-}" ]]; then
+	HELPER_REPO="${HOOK_DIR}/../scripts/complexity-regression-helper.sh"
+	HELPER_DEPLOYED="${HOME}/.aidevops/agents/scripts/complexity-regression-helper.sh"
+
+	if [[ -f "$HELPER_REPO" ]]; then
+		COMPLEXITY_HELPER="$HELPER_REPO"
+	elif [[ -f "$HELPER_DEPLOYED" ]]; then
+		COMPLEXITY_HELPER="$HELPER_DEPLOYED"
+	else
+		_log WARN "complexity-regression-helper.sh not found — fail-open"
+		_log WARN "  checked: $HELPER_REPO"
+		_log WARN "  checked: $HELPER_DEPLOYED"
+		exit 0
+	fi
 fi
 
 [[ "${COMPLEXITY_GUARD_DEBUG:-0}" == "1" ]] && _log INFO "helper: $COMPLEXITY_HELPER"
@@ -106,8 +112,8 @@ _resolve_base_sha() {
 	return 1
 }
 
-BASE_SHA=""
-if ! BASE_SHA=$(_resolve_base_sha); then
+BASE_SHA="${COMPLEXITY_GUARD_BASE_SHA:-}"
+if [[ -z "$BASE_SHA" ]] && ! BASE_SHA=$(_resolve_base_sha); then
 	_log WARN "cannot determine merge-base (offline or no upstream?) — fail-open"
 	exit 0
 fi
@@ -134,7 +140,8 @@ if [[ -z "$_parallel_tmpdir" || ! -d "$_parallel_tmpdir" ]]; then
 fi
 trap 'rm -rf "$_parallel_tmpdir"' EXIT
 
-# Launch all metric checks in parallel
+# Launch all metric checks in parallel, tracking PIDs for explicit synchronisation
+_pids=()
 for _i in "${!METRICS[@]}"; do
 	_metric="${METRICS[$_i]}"
 	[[ "${COMPLEXITY_GUARD_DEBUG:-0}" == "1" ]] && _log INFO "launching metric: $_metric (parallel)"
@@ -143,10 +150,11 @@ for _i in "${!METRICS[@]}"; do
 			> "${_parallel_tmpdir}/${_i}.out" 2>&1
 		printf '%d' "$?" > "${_parallel_tmpdir}/${_i}.rc"
 	) &
+	_pids+=($!)
 done
 
-# Wait for all parallel checks to complete
-wait
+# Wait only for the PIDs we launched (prevents waiting for unrelated background jobs)
+wait "${_pids[@]}"
 
 # Process results in original metric order (preserves output format)
 for _i in "${!METRICS[@]}"; do

--- a/.agents/scripts/tests/test-complexity-guard-parallel.sh
+++ b/.agents/scripts/tests/test-complexity-guard-parallel.sh
@@ -77,45 +77,9 @@ test_parallel_all_pass() {
 	printf '#!/usr/bin/env bash\nexit 0\n' > "$fake_helper"
 	chmod +x "$fake_helper"
 
-	# Run the hook with the fake helper, simulating a push
-	# We override COMPLEXITY_HELPER by patching the hook's resolution
-	local hook_copy="$TEST_ROOT/hook-copy.sh"
-	cp "$HOOK" "$hook_copy"
-	chmod +x "$hook_copy"
-
-	# Inject our fake helper path and skip the git merge-base (provide BASE_SHA)
-	local wrapper="$TEST_ROOT/run-hook.sh"
-	cat > "$wrapper" <<-'WRAPPER_EOF'
-	#!/usr/bin/env bash
-	set -u
-	GUARD_NAME="complexity-guard"
-	_log() { local _level="$1"; local _msg="$2"; printf '[%s][%s] %s\n' "$GUARD_NAME" "$_level" "$_msg" >&2; return 0; }
-	: "${COMPLEXITY_HELPER:?COMPLEXITY_HELPER env var required}"
-	BASE_SHA="abc1234"
-	METRICS=("function-complexity" "nesting-depth" "file-size")
-	exit_code=0
-	_parallel_tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/complexity-guard.XXXXXX")
-	if [[ -z "$_parallel_tmpdir" || ! -d "$_parallel_tmpdir" ]]; then
-	    exit 0
-	fi
-	trap 'rm -rf "$_parallel_tmpdir"' EXIT
-	for _i in "${!METRICS[@]}"; do
-	    _metric="${METRICS[$_i]}"
-	    ( "$COMPLEXITY_HELPER" check --base "$BASE_SHA" --metric "$_metric" > "${_parallel_tmpdir}/${_i}.out" 2>&1; printf '%d' "$?" > "${_parallel_tmpdir}/${_i}.rc" ) &
-	done
-	wait
-	for _i in "${!METRICS[@]}"; do
-	    helper_rc=$(cat "${_parallel_tmpdir}/${_i}.rc" 2>/dev/null || echo "0")
-	    case "$helper_rc" in
-	    0) ;; 1) exit_code=1 ;; *) ;;
-	    esac
-	done
-	exit "$exit_code"
-	WRAPPER_EOF
-	chmod +x "$wrapper"
-
-	local output rc=0
-	output=$(COMPLEXITY_HELPER="$fake_helper" "$wrapper" 2>&1) || rc=$?
+	local rc=0
+	COMPLEXITY_HELPER="$fake_helper" COMPLEXITY_GUARD_BASE_SHA="abc1234" \
+		bash "$HOOK" 2>&1 || rc=$?
 
 	print_result "parallel-all-pass" "$([[ $rc -eq 0 ]] && echo 0 || echo 1)" \
 		"expected exit 0, got $rc"
@@ -129,7 +93,7 @@ test_parallel_all_pass() {
 test_parallel_one_fail() {
 	setup
 
-	# Helper that fails for nesting-depth (metric index 1), passes for others
+	# Helper that fails for nesting-depth, passes for others
 	local fake_helper="$TEST_ROOT/fake-helper-fail.sh"
 	cat > "$fake_helper" <<-'EOF'
 	#!/usr/bin/env bash
@@ -143,46 +107,11 @@ test_parallel_one_fail() {
 	EOF
 	chmod +x "$fake_helper"
 
-	local wrapper="$TEST_ROOT/run-hook-fail.sh"
-	cat > "$wrapper" <<-'WRAPPER_EOF'
-	#!/usr/bin/env bash
-	set -u
-	GUARD_NAME="complexity-guard"
-	_log() { local _level="$1"; local _msg="$2"; printf '[%s][%s] %s\n' "$GUARD_NAME" "$_level" "$_msg" >&2; return 0; }
-	: "${COMPLEXITY_HELPER:?COMPLEXITY_HELPER env var required}"
-	BASE_SHA="abc1234"
-	METRICS=("function-complexity" "nesting-depth" "file-size")
-	exit_code=0
-	_parallel_tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/complexity-guard.XXXXXX")
-	if [[ -z "$_parallel_tmpdir" || ! -d "$_parallel_tmpdir" ]]; then
-	    exit 0
-	fi
-	trap 'rm -rf "$_parallel_tmpdir"' EXIT
-	for _i in "${!METRICS[@]}"; do
-	    _metric="${METRICS[$_i]}"
-	    ( "$COMPLEXITY_HELPER" check --base "$BASE_SHA" --metric "$_metric" > "${_parallel_tmpdir}/${_i}.out" 2>&1; printf '%d' "$?" > "${_parallel_tmpdir}/${_i}.rc" ) &
-	done
-	wait
-	for _i in "${!METRICS[@]}"; do
-	    helper_rc=$(cat "${_parallel_tmpdir}/${_i}.rc" 2>/dev/null || echo "0")
-	    helper_output=$(cat "${_parallel_tmpdir}/${_i}.out" 2>/dev/null || echo "")
-	    case "$helper_rc" in
-	    0) ;; 1) exit_code=1; printf '%s\n' "$helper_output" ;;  *) ;;
-	    esac
-	done
-	exit "$exit_code"
-	WRAPPER_EOF
-	chmod +x "$wrapper"
+	local rc=0
+	COMPLEXITY_HELPER="$fake_helper" COMPLEXITY_GUARD_BASE_SHA="abc1234" \
+		bash "$HOOK" 2>&1 || rc=$?
 
-	local output rc=0
-	output=$(COMPLEXITY_HELPER="$fake_helper" "$wrapper" 2>&1) || rc=$?
-
-	local fail=0
-	if [[ $rc -ne 1 ]]; then
-		fail=1
-	fi
-
-	print_result "parallel-one-fail" "$fail" \
+	print_result "parallel-one-fail" "$([[ $rc -eq 1 ]] && echo 0 || echo 1)" \
 		"expected exit 1, got $rc"
 	teardown
 	return 0
@@ -194,7 +123,7 @@ test_parallel_one_fail() {
 test_parallel_output_order() {
 	setup
 
-	# Helper that echoes the metric name — all exit 1 to produce output
+	# Helper that echoes the metric name — all exit 1 to produce ordered output
 	local fake_helper="$TEST_ROOT/fake-helper-order.sh"
 	cat > "$fake_helper" <<-'EOF'
 	#!/usr/bin/env bash
@@ -212,36 +141,9 @@ test_parallel_output_order() {
 	EOF
 	chmod +x "$fake_helper"
 
-	local wrapper="$TEST_ROOT/run-hook-order.sh"
-	cat > "$wrapper" <<-'WRAPPER_EOF'
-	#!/usr/bin/env bash
-	set -u
-	GUARD_NAME="complexity-guard"
-	_log() { local _level="$1"; local _msg="$2"; return 0; }
-	: "${COMPLEXITY_HELPER:?COMPLEXITY_HELPER env var required}"
-	BASE_SHA="abc1234"
-	METRICS=("function-complexity" "nesting-depth" "file-size")
-	exit_code=0
-	_parallel_tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/complexity-guard.XXXXXX")
-	trap 'rm -rf "$_parallel_tmpdir"' EXIT
-	for _i in "${!METRICS[@]}"; do
-	    _metric="${METRICS[$_i]}"
-	    ( "$COMPLEXITY_HELPER" check --base "$BASE_SHA" --metric "$_metric" > "${_parallel_tmpdir}/${_i}.out" 2>&1; printf '%d' "$?" > "${_parallel_tmpdir}/${_i}.rc" ) &
-	done
-	wait
-	for _i in "${!METRICS[@]}"; do
-	    helper_rc=$(cat "${_parallel_tmpdir}/${_i}.rc" 2>/dev/null || echo "0")
-	    helper_output=$(cat "${_parallel_tmpdir}/${_i}.out" 2>/dev/null || echo "")
-	    case "$helper_rc" in
-	    1) printf '%s\n' "$helper_output"; exit_code=1 ;; *) ;;
-	    esac
-	done
-	exit "$exit_code"
-	WRAPPER_EOF
-	chmod +x "$wrapper"
-
 	local output rc=0
-	output=$(COMPLEXITY_HELPER="$fake_helper" "$wrapper" 2>&1) || rc=$?
+	output=$(COMPLEXITY_HELPER="$fake_helper" COMPLEXITY_GUARD_BASE_SHA="abc1234" \
+		bash "$HOOK" 2>&1) || rc=$?
 
 	# Verify order: function-complexity before nesting-depth before file-size
 	local fc_pos nd_pos fs_pos
@@ -290,31 +192,9 @@ test_parallel_debug_output() {
 	printf '#!/usr/bin/env bash\nexit 0\n' > "$fake_helper"
 	chmod +x "$fake_helper"
 
-	local wrapper="$TEST_ROOT/run-hook-debug.sh"
-	cat > "$wrapper" <<-'WRAPPER_EOF'
-	#!/usr/bin/env bash
-	set -u
-	COMPLEXITY_GUARD_DEBUG=1
-	GUARD_NAME="complexity-guard"
-	_log() { local _level="$1"; local _msg="$2"; printf '[%s][%s] %s\n' "$GUARD_NAME" "$_level" "$_msg" >&2; return 0; }
-	: "${COMPLEXITY_HELPER:?COMPLEXITY_HELPER env var required}"
-	BASE_SHA="abc1234"
-	METRICS=("function-complexity" "nesting-depth" "file-size")
-	exit_code=0
-	_parallel_tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/complexity-guard.XXXXXX")
-	trap 'rm -rf "$_parallel_tmpdir"' EXIT
-	for _i in "${!METRICS[@]}"; do
-	    _metric="${METRICS[$_i]}"
-	    [[ "${COMPLEXITY_GUARD_DEBUG:-0}" == "1" ]] && _log INFO "launching metric: $_metric (parallel)"
-	    ( "$COMPLEXITY_HELPER" check --base "$BASE_SHA" --metric "$_metric" > "${_parallel_tmpdir}/${_i}.out" 2>&1; printf '%d' "$?" > "${_parallel_tmpdir}/${_i}.rc" ) &
-	done
-	wait
-	exit 0
-	WRAPPER_EOF
-	chmod +x "$wrapper"
-
 	local output rc=0
-	output=$(COMPLEXITY_HELPER="$fake_helper" "$wrapper" 2>&1) || rc=$?
+	output=$(COMPLEXITY_HELPER="$fake_helper" COMPLEXITY_GUARD_BASE_SHA="abc1234" \
+		COMPLEXITY_GUARD_DEBUG=1 bash "$HOOK" 2>&1) || rc=$?
 
 	local fail=0
 	if ! printf '%s' "$output" | grep -q "parallel"; then
@@ -380,36 +260,9 @@ test_parallel_helper_exit2() {
 	printf '#!/usr/bin/env bash\nexit 2\n' > "$fake_helper"
 	chmod +x "$fake_helper"
 
-	local wrapper="$TEST_ROOT/run-hook-exit2.sh"
-	cat > "$wrapper" <<-'WRAPPER_EOF'
-	#!/usr/bin/env bash
-	set -u
-	GUARD_NAME="complexity-guard"
-	_log() { local _level="$1"; local _msg="$2"; printf '[%s][%s] %s\n' "$GUARD_NAME" "$_level" "$_msg" >&2; return 0; }
-	: "${COMPLEXITY_HELPER:?COMPLEXITY_HELPER env var required}"
-	BASE_SHA="abc1234"
-	METRICS=("function-complexity" "nesting-depth" "file-size")
-	exit_code=0
-	_parallel_tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/complexity-guard.XXXXXX")
-	trap 'rm -rf "$_parallel_tmpdir"' EXIT
-	for _i in "${!METRICS[@]}"; do
-	    _metric="${METRICS[$_i]}"
-	    ( "$COMPLEXITY_HELPER" check --base "$BASE_SHA" --metric "$_metric" > "${_parallel_tmpdir}/${_i}.out" 2>&1; printf '%d' "$?" > "${_parallel_tmpdir}/${_i}.rc" ) &
-	done
-	wait
-	for _i in "${!METRICS[@]}"; do
-	    _metric="${METRICS[$_i]}"
-	    helper_rc=$(cat "${_parallel_tmpdir}/${_i}.rc" 2>/dev/null || echo "0")
-	    case "$helper_rc" in
-	    0) ;; 1) exit_code=1 ;; 2) _log WARN "[$_metric] helper invocation error (exit 2) — fail-open" ;; *) ;;
-	    esac
-	done
-	exit "$exit_code"
-	WRAPPER_EOF
-	chmod +x "$wrapper"
-
 	local output rc=0
-	output=$(COMPLEXITY_HELPER="$fake_helper" "$wrapper" 2>&1) || rc=$?
+	output=$(COMPLEXITY_HELPER="$fake_helper" COMPLEXITY_GUARD_BASE_SHA="abc1234" \
+		bash "$HOOK" 2>&1) || rc=$?
 
 	local fail=0
 	# exit 2 should be fail-open → exit 0


### PR DESCRIPTION
## Summary

Three review-bot suggestions from PR #19902 triage (issue #19921). Two implemented (Outcome B), one falsified (Outcome A).

### Outcome B — Implemented

**1. Explicit PID tracking** (gemini `complexity-regression-pre-push.sh:149`)

Replaced bare `wait` with tracked-PID `wait "${_pids[@]}"`. Prevents waiting for unrelated background processes if the script is ever sourced or called in a context where other jobs are running.

**2. Env var testability overrides + direct hook tests** (gemini `test-complexity-guard-parallel.sh:114`)

The test suite previously re-implemented the parallel dispatch logic in inline wrapper scripts, creating a maintenance burden and not exercising the actual hook code. Fix:
- Hook now checks `COMPLEXITY_HELPER` env var before running its resolver (skip resolution if already set)
- Hook now checks `COMPLEXITY_GUARD_BASE_SHA` env var to bypass `git merge-base` (for test injection)
- Variable name uses `COMPLEXITY_GUARD_` prefix (consistent with `COMPLEXITY_GUARD_DISABLE` / `COMPLEXITY_GUARD_DEBUG`) and avoids shadowing the hook's own `BASE_SHA` local
- Tests 1, 2, 3, 5, 7 refactored to invoke `$HOOK` directly using these overrides — removed ~150 lines of duplicated wrapper logic

### Outcome A — Premise falsified

**Suggestion 2: `_save_cleanup_scope` / `push_cleanup` pattern** (gemini `complexity-regression-pre-push.sh:135`)

> For resource cleanup, use the established project pattern: _save_cleanup_scope, trap '_run_cleanups' RETURN, and push_cleanup.

**Premise falsified.** These functions are defined in `shared-constants.sh` and used by scripts that source it. The `complexity-regression-pre-push.sh` hook is a standalone git hook that sources nothing — `_save_cleanup_scope`, `_run_cleanups`, and `push_cleanup` are undefined in its execution context. Applying the suggestion verbatim would add undefined-function calls that crash the hook. Additionally, `trap ... RETURN` at the script top-level (not inside a function) is a no-op — only `EXIT` fires on script exit. The current `trap 'rm -rf "$_parallel_tmpdir"' EXIT` is correct for a standalone script. Not acting on this suggestion.

## Files modified

- `EDIT: .agents/hooks/complexity-regression-pre-push.sh` — PID tracking, `COMPLEXITY_HELPER` + `COMPLEXITY_GUARD_BASE_SHA` env overrides, updated header docs
- `EDIT: .agents/scripts/tests/test-complexity-guard-parallel.sh` — tests 1-3, 5, 7 refactored to run `$HOOK` directly (removed wrapper scripts)

## Verification

```
bash .agents/scripts/tests/test-complexity-guard-parallel.sh
# 7/7 passed
shellcheck .agents/hooks/complexity-regression-pre-push.sh .agents/scripts/tests/test-complexity-guard-parallel.sh
# 0 violations
```

Resolves #19921
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.76 plugin for [OpenCode](https://opencode.ai) v1.14.18 with claude-sonnet-4-6 spent 15m and 26,388 tokens on this as a headless worker.