### PR TITLE
GH#19925: fix: harden shellcheckrc parity grep against set -e exit and prefix false positives

### DIFF
--- a/.agents/scripts/linters-local.sh
+++ b/.agents/scripts/linters-local.sh
@@ -597,14 +597,14 @@ check_shellcheckrc_parity() {
 	fi
 
 	local root_disables scripts_disables
-	root_disables=$(grep -E '^disable=SC[0-9]+' "$root_rc" | sort)
-	scripts_disables=$(grep -E '^disable=SC[0-9]+' "$scripts_rc" | sort)
+	root_disables=$(grep -E '^disable=SC[0-9]+' "$root_rc" | sort || true)
+	scripts_disables=$(grep -E '^disable=SC[0-9]+' "$scripts_rc" | sort || true)
 
 	local missing=""
 	local code
 	while IFS= read -r code; do
 		[[ -z "$code" ]] && continue
-		if ! grep -qF "$code" <<<"$scripts_disables"; then
+		if ! grep -qxF "$code" <<<"$scripts_disables"; then
 			missing="${missing}  ${code}\n"
 		fi
 	done <<<"$root_disables"

--- a/.agents/scripts/tests/test-shellcheckrc-parity.sh
+++ b/.agents/scripts/tests/test-shellcheckrc-parity.sh
@@ -93,7 +93,7 @@ check_parity() {
 	local code
 	while IFS= read -r code; do
 		[[ -z "$code" ]] && continue
-		if ! grep -qF "$code" <<<"$scripts_disables"; then
+		if ! grep -qxF "$code" <<<"$scripts_disables"; then
 			missing="${missing}${code}
 "
 		fi


### PR DESCRIPTION
## Summary

Applied three review-bot suggestions from PR #19898: (1) added || true to grep assignments in linters-local.sh to prevent set -e script exit when no disable= directives exist, (2) changed grep -qF to grep -qxF in linters-local.sh for exact line matching to prevent SC code prefix collisions, (3) same grep -qxF fix in test-shellcheckrc-parity.sh.

## Files Changed

.agents/scripts/linters-local.sh,.agents/scripts/tests/test-shellcheckrc-parity.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean on modified files, test-shellcheckrc-parity.sh 4/4 PASS

Resolves #19925


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.76 plugin for [OpenCode](https://opencode.ai) v1.14.18 with claude-opus-4-6 spent 3m and 4,947 tokens on this as a headless worker.