### PR TITLE
GH#19924: fix(pulse-merge): fail-closed label fetch in _interactive_pr_trigger_handover

### DIFF
--- a/.agents/scripts/pulse-merge-conflict.sh
+++ b/.agents/scripts/pulse-merge-conflict.sh
@@ -232,9 +232,17 @@ _interactive_pr_trigger_handover() {
 	[[ "$pr_number" =~ ^[0-9]+$ && -n "$repo_slug" ]] || return 0
 
 	# Idempotence short-circuit: label already present → nothing to do
-	local pr_labels_json
+	# GH#19924: fail CLOSED on label fetch failure — if we can't read labels,
+	# we might miss a no-takeover opt-out. Matches _close_conflicting_pr pattern
+	# (lines 477-484) where label-fetch failure aborts the operation.
+	local pr_labels_json label_fetch_rc
+	label_fetch_rc=0
 	pr_labels_json=$(gh pr view "$pr_number" --repo "$repo_slug" --json labels \
-		--jq '[.labels[].name]' 2>/dev/null) || pr_labels_json="[]"
+		--jq '[.labels[].name]' 2>/dev/null) || label_fetch_rc=$?
+	if [[ $label_fetch_rc -ne 0 ]]; then
+		echo "[pulse-wrapper] _interactive_pr_trigger_handover: failed to fetch labels for PR #${pr_number} in ${repo_slug} (exit ${label_fetch_rc}) — skipping handover to honor potential no-takeover label (GH#19924)" >>"$LOGFILE"
+		return 0
+	fi
 	[[ -n "$pr_labels_json" ]] || pr_labels_json="[]"
 
 	if printf '%s' "$pr_labels_json" | jq -e 'index("origin:worker-takeover")' >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

- Changes `_interactive_pr_trigger_handover` label fetch from fail-open to fail-closed: when `gh pr view` fails transiently, the function now aborts handover instead of defaulting to `[]` and silently ignoring a potential `no-takeover` opt-out label
- Aligns with the existing fail-closed pattern in `_close_conflicting_pr` (lines 477-484 of the same file)

## Changes

- **EDIT:** `.agents/scripts/pulse-merge-conflict.sh:234-246` — capture `label_fetch_rc` from `gh pr view`, return 0 with a log message on failure instead of defaulting to empty labels

## Testing

- `shellcheck .agents/scripts/pulse-merge-conflict.sh` — passes clean (zero violations)
- Pattern verified against `_close_conflicting_pr` fail-closed implementation at lines 477-484

Resolves #19924


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.76 plugin for [OpenCode](https://opencode.ai) v1.14.18 with claude-opus-4-6 spent 3m and 3,457 tokens on this as a headless worker.