### PR TITLE
GH#19923: fix(scanner-bodies): qualify shell-specific advice for multi-language scanners

### DIFF
--- a/.agents/scripts/pulse-dispatch-large-file-gate.sh
+++ b/.agents/scripts/pulse-dispatch-large-file-gate.sh
@@ -450,9 +450,9 @@ Issue #${parent_issue} is blocked by the large-file gate. Workers dispatched aga
 - Keep a thin orchestrator in the original file that sources the extracted modules
 - Verify: \`wc -l ${lf_path}\` should be below ${LARGE_FILE_LINE_THRESHOLD}
 
-**Reference pattern:** \`.agents/reference/large-file-split.md\` (playbook for shell-lib splits, covers identity-key preservation, CI false-positives, and PR body template).
+**Reference pattern:** \`.agents/reference/large-file-split.md\` (playbook for file splits — covers identity-key preservation, CI false-positives, and PR body template).
 
-**Precedent in this repo:** \`issue-sync-helper.sh\` + \`issue-sync-lib.sh\` (simple split) and \`headless-runtime-lib.sh\` + sub-libraries (complex split). Copy the include-guard and SCRIPT_DIR-fallback pattern from the simple precedent.
+**Precedent in this repo:** \`issue-sync-helper.sh\` + \`issue-sync-lib.sh\` (simple split) and \`headless-runtime-lib.sh\` + sub-libraries (complex split). For shell scripts, copy the include-guard and SCRIPT_DIR-fallback pattern from the simple precedent.
 
 **Expected CI gate overrides:** This PR will likely trigger a complexity regression from the file-split identity-key change. Apply the \`complexity-bump-ok\` label AND include a \`## Complexity Bump Justification\` section in the PR body citing scanner evidence. See the playbook section 4 (Known CI False-Positive Classes).
 

--- a/.agents/scripts/pulse-simplification-state.sh
+++ b/.agents/scripts/pulse-simplification-state.sh
@@ -405,11 +405,11 @@ Review issue #${prev_issue_num} for what the previous attempt accomplished and w
 2. Address the flagged complexity — reduce function length, extract helpers, simplify control flow
 3. Verify: \`~/.qlty/bin/qlty smells --all 2>&1 | grep '${file_path}' | grep -c . | grep -q '^0$'\` (report \`SKIP\` if Qlty unavailable)${escalation_note}
 
-**Reference pattern:** \`.agents/reference/large-file-split.md\` (playbook for shell-lib splits — covers orchestrator pattern, identity-key preservation, and PR body template).
+**Reference pattern:** \`.agents/reference/large-file-split.md\` (playbook for file splits — covers orchestrator pattern, identity-key preservation, and PR body template).
 
-**Precedent in this repo:** \`issue-sync-helper.sh\` + \`issue-sync-lib.sh\` (simple split) and \`headless-runtime-lib.sh\` + sub-libraries (complex split). Copy the include-guard and SCRIPT_DIR-fallback pattern from the simple precedent.
+**Precedent in this repo:** \`issue-sync-helper.sh\` + \`issue-sync-lib.sh\` (simple split) and \`headless-runtime-lib.sh\` + sub-libraries (complex split). For shell scripts, copy the include-guard and SCRIPT_DIR-fallback pattern from the simple precedent.
 
-**Expected CI gate overrides:** This PR may trigger a complexity regression from function extraction. Apply the \`complexity-bump-ok\` label AND include a \`## Complexity Bump Justification\` section in the PR body citing scanner evidence.
+**Expected CI gate overrides:** This PR may trigger a complexity regression from function extraction. Apply the \`complexity-bump-ok\` label AND include a \`## Complexity Bump Justification\` section in the PR body citing scanner evidence. See the playbook section 4 (Known CI False-Positive Classes).
 
 ### Verification
 

--- a/.agents/scripts/pulse-simplification.sh
+++ b/.agents/scripts/pulse-simplification.sh
@@ -809,7 +809,7 @@ Tighten and restructure this agent doc. Follow \`tools/build-agent/build-agent.m
 
 **Precedent in this repo:** \`issue-sync-helper.sh\` + \`issue-sync-lib.sh\` (simple split) and \`headless-runtime-lib.sh\` + sub-libraries (complex split). For agent docs, see existing chapter-file splits in \`.agents/reference/\`.
 
-**Expected CI gate overrides:** If this PR triggers a complexity regression from restructured files, apply the \`complexity-bump-ok\` label AND include a \`## Complexity Bump Justification\` section in the PR body citing scanner evidence.
+**Expected CI gate overrides:** If this PR triggers a complexity regression from restructured files, apply the \`complexity-bump-ok\` label AND include a \`## Complexity Bump Justification\` section in the PR body citing scanner evidence. See the playbook section 4 (Known CI False-Positive Classes).
 
 ### Verification
 

--- a/.agents/scripts/stats-quality-sweep.sh
+++ b/.agents/scripts/stats-quality-sweep.sh
@@ -1302,9 +1302,9 @@ This file was flagged by the daily quality sweep for high smell density. The sme
 3. Verify with \`qlty smells ${file_path}\` after each change
 4. No behavior changes — pure structural refactoring
 
-**Reference pattern:** \`.agents/reference/large-file-split.md\` (playbook for shell-lib splits — sections 2-3 cover the canonical split pattern and identity-key preservation; section 5 covers pre-commit hook gotchas).
+**Reference pattern:** \`.agents/reference/large-file-split.md\` (playbook for file splits — sections 2-3 cover the canonical split pattern and identity-key preservation; section 5 covers pre-commit hook gotchas).
 
-**Precedent in this repo:** \`issue-sync-helper.sh\` + \`issue-sync-lib.sh\` (simple split) and \`headless-runtime-lib.sh\` + sub-libraries (complex split). Copy the include-guard and SCRIPT_DIR-fallback pattern from the simple precedent.
+**Precedent in this repo:** \`issue-sync-helper.sh\` + \`issue-sync-lib.sh\` (simple split) and \`headless-runtime-lib.sh\` + sub-libraries (complex split). For shell scripts, copy the include-guard and SCRIPT_DIR-fallback pattern from the simple precedent.
 
 **Expected CI gate overrides:** If this refactoring splits functions into new files, the PR may trigger complexity or smell regression gates. Apply the \`ratchet-bump\` label AND include a \`## Complexity Bump Justification\` section in the PR body citing the Qlty smell reduction. See the playbook section 4 (Known CI False-Positive Classes).
 


### PR DESCRIPTION
## Summary

Qualified shell-specific advice (include-guard, SCRIPT_DIR patterns) with 'For shell scripts' prefix in 3 scanner templates that also target Python/JS/TS files. Added Section 4 (Known CI False-Positive Classes) playbook reference to CI gate override instructions in 2 templates for consistency. Changed 'playbook for shell-lib splits' to 'playbook for file splits' across 3 templates. Comment 2 (dynamic threshold) was triaged as invalid: _create_requeue_issue is specifically for function-complexity-debt (code files only), so COMPLEXITY_FUNC_LINE_THRESHOLD=100 is correct.

## Files Changed

.agents/scripts/linters-local.sh,.agents/scripts/pulse-dispatch-large-file-gate.sh,.agents/scripts/pulse-simplification-state.sh,.agents/scripts/pulse-simplification.sh,.agents/scripts/stats-quality-sweep.sh,.agents/scripts/tests/test-shellcheckrc-parity.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean on all 4 modified files. Changes are in heredoc string literal templates only — no code logic modified.

Resolves #19923


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.76 plugin for [OpenCode](https://opencode.ai) v1.14.18 with claude-opus-4-6 spent 6m and 10,838 tokens on this as a headless worker.