### PR TITLE
GH#19922: fix(pulse): pass self_login to is-assigned, avoid redundant API fetch, use parameter expansion

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -769,9 +769,19 @@ is_assigned() {
 		return 1
 	fi
 
+	# GH#19922: accept pre-fetched JSON via ISSUE_META_JSON env var to avoid
+	# a redundant gh issue view call when the caller already has the metadata
+	# (e.g. the enrich path in issue-sync-helper.sh which fetches state in
+	# _enrich_process_task and forwards it through _enrich_check_active_claim).
+	# The pre-fetched JSON must contain at least assignees and labels fields.
 	local issue_meta_json gh_rc=0
-	issue_meta_json=$(gh issue view "$issue_number" --repo "$repo_slug" \
-		--json state,assignees,labels 2>/dev/null) || gh_rc=$?
+	if [[ -n "${ISSUE_META_JSON:-}" ]] \
+		&& printf '%s' "$ISSUE_META_JSON" | jq -e '.assignees and .labels' >/dev/null 2>&1; then
+		issue_meta_json="$ISSUE_META_JSON"
+	else
+		issue_meta_json=$(gh issue view "$issue_number" --repo "$repo_slug" \
+			--json state,assignees,labels 2>/dev/null) || gh_rc=$?
+	fi
 
 	# t2046: fail-closed on gh API failure. When we cannot fetch issue metadata
 	# (network error, auth failure, rate limit, issue not found), we cannot

--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -1040,12 +1040,21 @@ _enrich_update_issue() {
 #   $1 - issue number
 #   $2 - repo slug (owner/repo)
 #   $3 - task_id (for logging)
+#   $4 - (optional) pre-fetched issue JSON (forwarded via ISSUE_META_JSON to
+#        is_assigned to avoid a redundant gh issue view call; GH#19922)
 _enrich_check_active_claim() {
-	local num="$1" repo="$2" task_id="$3"
+	local num="$1" repo="$2" task_id="$3" pre_fetched_json="${4:-}"
 	local _dedup_helper="${SCRIPT_DIR}/dispatch-dedup-helper.sh"
 	if [[ -x "$_dedup_helper" ]]; then
+		# GH#19922: resolve runner login so is-assigned can apply the self-login
+		# exemption — without it the runner blocks its own enrichment when it is
+		# also an assignee (e.g. single-user setups).
+		local _user="${AIDEVOPS_SESSION_USER:-}"
+		[[ -z "$_user" ]] && _user=$(gh api user --jq '.login // ""' 2>/dev/null || echo "")
 		local _dedup_result=""
-		_dedup_result=$("$_dedup_helper" is-assigned "$num" "$repo" 2>/dev/null) || true
+		# GH#19922: pass pre-fetched JSON via ISSUE_META_JSON env var to avoid
+		# a redundant gh issue view call inside is_assigned().
+		_dedup_result=$(ISSUE_META_JSON="$pre_fetched_json" "$_dedup_helper" is-assigned "$num" "$repo" "$_user" 2>/dev/null) || true
 		if [[ -n "$_dedup_result" ]]; then
 			print_warning "Skipping enrich for #$num ($task_id) — active claim detected: $_dedup_result (GH#19856)"
 			return 0
@@ -1128,7 +1137,9 @@ _enrich_process_task() {
 	# per-task read cost to one call and lets each helper skip writes whose
 	# target value already matches.
 	local _state_json current_title="" current_body="" current_labels_csv=""
-	_state_json=$(gh issue view "$num" --repo "$repo" --json title,body,labels 2>/dev/null || echo "")
+	# GH#19922: include state,assignees so the pre-fetched JSON can be forwarded
+	# to _enrich_check_active_claim → is_assigned(), avoiding a redundant API call.
+	_state_json=$(gh issue view "$num" --repo "$repo" --json title,body,labels,state,assignees 2>/dev/null || echo "")
 	if [[ -n "$_state_json" ]]; then
 		current_title=$(echo "$_state_json" | jq -r '.title // ""' 2>/dev/null || echo "")
 		current_body=$(echo "$_state_json" | jq -r '.body // ""' 2>/dev/null || echo "")
@@ -1137,7 +1148,8 @@ _enrich_process_task() {
 
 	# GH#19856: cross-runner dedup guard — abort if another runner holds
 	# an active claim. See _enrich_check_active_claim for the full rationale.
-	if _enrich_check_active_claim "$num" "$repo" "$task_id"; then
+	# GH#19922: pass _state_json so is_assigned() skips a redundant gh issue view.
+	if _enrich_check_active_claim "$num" "$repo" "$task_id" "$_state_json"; then
 		return 0
 	fi
 

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -1064,10 +1064,13 @@ _ensure_issue_body_has_brief() {
 	# runs its dedup check upstream, this guard catches TOCTOU races where
 	# another runner claims between the dedup check and the enrich call.
 	local dedup_helper
-	dedup_helper="$(dirname "${BASH_SOURCE[0]}")/dispatch-dedup-helper.sh"
+	# GH#19922: use parameter expansion instead of external dirname command.
+	dedup_helper="${BASH_SOURCE[0]%/*}/dispatch-dedup-helper.sh"
 	if [[ -x "$dedup_helper" ]]; then
 		local _dedup_out=""
-		_dedup_out=$("$dedup_helper" is-assigned "$issue_number" "$repo_slug" 2>/dev/null) || true
+		# GH#19922: pass AIDEVOPS_SESSION_USER as self_login so the runner
+		# does not block its own enrichment via the self-login exemption.
+		_dedup_out=$("$dedup_helper" is-assigned "$issue_number" "$repo_slug" "${AIDEVOPS_SESSION_USER:-}" 2>/dev/null) || true
 		if [[ -n "$_dedup_out" ]]; then
 			echo "[dispatch_with_dedup] GH#19856: skipping force-enrich for #${issue_number} — active claim: ${_dedup_out}" >>"$LOGFILE"
 			return 0


### PR DESCRIPTION
## Summary

Address all 4 unaddressed review bot findings from PR #19901 (GH#19856 enrich-path dedup guard):

- **Pass self_login to is-assigned** (HIGH, 2 sites): Both `_enrich_check_active_claim` in `issue-sync-helper.sh` and the TOCTOU guard in `pulse-dispatch-core.sh` called `dispatch-dedup-helper.sh is-assigned` without the third argument (runner login). Without it, `_is_assigned_compute_blocking` cannot apply the self-login exemption, causing the runner to block its own enrichment when it is also an assignee (common in single-user setups).
- **Eliminate redundant API fetch** (MEDIUM): `_enrich_process_task` already fetches issue metadata into `_state_json` at line 1131. The subsequent `_enrich_check_active_claim` → `is_assigned()` call issued a second `gh issue view` for the same issue. Fix: expand the initial fetch to include `state,assignees`, forward the JSON via `ISSUE_META_JSON` env var, and add a validated override path in `is_assigned()`.
- **Replace dirname with parameter expansion** (MEDIUM): `$(dirname "${BASH_SOURCE[0]}")` → `${BASH_SOURCE[0]%/*}` avoids an unnecessary process fork.

## Files Changed

- `.agents/scripts/issue-sync-helper.sh` — `_enrich_check_active_claim`: accept optional pre-fetched JSON (4th arg), resolve self_login, pass both to is-assigned. `_enrich_process_task`: expand `--json` fields, pass `_state_json` to guard.
- `.agents/scripts/pulse-dispatch-core.sh` — TOCTOU guard: pass `AIDEVOPS_SESSION_USER` as self_login, use parameter expansion for dirname.
- `.agents/scripts/dispatch-dedup-helper.sh` — `is_assigned()`: accept pre-fetched JSON via `ISSUE_META_JSON` env var with field validation fallback.

## Testing

- `shellcheck` passes on all 3 modified files (zero violations)
- Backward-compatible: `ISSUE_META_JSON` is optional (empty/missing → existing API call path), 4th arg to `_enrich_check_active_claim` defaults to empty

Resolves #19922


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.77 plugin for [OpenCode](https://opencode.ai) v1.14.18 with claude-opus-4-6 spent 6m and 15,430 tokens on this as a headless worker.