### PR TITLE
GH#19917: atomic cache writes + defensive jq in stub-title scanner

### DIFF
--- a/.agents/custom/scripts/r-stub-title-scan.sh
+++ b/.agents/custom/scripts/r-stub-title-scan.sh
@@ -130,7 +130,10 @@ _load_seen_cache() {
     pruned=$(jq --argjson cutoff "$cutoff" \
         'to_entries | map(select(.value >= $cutoff)) | from_entries' \
         "$SEEN_CACHE" 2>/dev/null) || pruned='{}'
-    echo "$pruned" > "$SEEN_CACHE"
+    echo "$pruned" > "${SEEN_CACHE}.tmp" && mv "${SEEN_CACHE}.tmp" "$SEEN_CACHE" || {
+        _log "ERROR" "Failed to write pruned cache to ${SEEN_CACHE}"
+        return 1
+    }
     return 0
 }
 
@@ -153,7 +156,10 @@ _mark_seen() {
         _log "WARN" "Failed to update seen cache for ${key}"
         return 1
     }
-    echo "$updated" > "$SEEN_CACHE"
+    echo "$updated" > "${SEEN_CACHE}.tmp" && mv "${SEEN_CACHE}.tmp" "$SEEN_CACHE" || {
+        _log "ERROR" "Failed to write updated cache to ${SEEN_CACHE}"
+        return 1
+    }
     return 0
 }
 
@@ -161,8 +167,8 @@ _mark_seen() {
 _get_pulse_repos() {
     [[ -n "${STUB_SCAN_REPOS:-}" ]] && { echo "$STUB_SCAN_REPOS" | tr ',' '\n'; return 0; }
     [[ -f "$REPOS_JSON" ]] || { _log "ERROR" "repos.json not found at ${REPOS_JSON}"; return 1; }
-    jq -r '.initialized_repos[] | select(.pulse == true) | select(.local_only != true) | .slug' \
-        "$REPOS_JSON" 2>/dev/null
+    jq -r '.initialized_repos[]? | select(.pulse == true) | select(.local_only != true) | .slug' \
+        "$REPOS_JSON" || true
     return 0
 }
 


### PR DESCRIPTION
## Summary

- Made cache file writes atomic in `_load_seen_cache()` and `_mark_seen()` using temp file + `mv` pattern to prevent data loss on script interruption
- Switched `_get_pulse_repos()` jq filter to use `[]?` (optional chaining) so missing/null `initialized_repos` key doesn't crash the script under `set -e`
- Removed `2>/dev/null` on the `_get_pulse_repos` jq call so real syntax errors in `repos.json` surface instead of being silently swallowed

## Testing

- `shellcheck .agents/custom/scripts/r-stub-title-scan.sh` — zero violations
- All three findings from gemini-code-assist on PR #19906 verified against actual code before applying

Resolves #19917


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.78 plugin for [OpenCode](https://opencode.ai) v1.14.18 with claude-opus-4-6 spent 14m and 13,024 tokens on this as a headless worker. Overall, 4h 6m since this issue was created.