### PR TITLE
GH#19949: add pulse canonical-repo fast-forward + stale worktree sweep stage

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1820,9 +1820,9 @@
       "pr": 16548
     },
     ".agents/scripts/approval-helper.sh": {
-      "at": "2026-04-14T08:25:15Z",
-      "hash": "5e11b9ad67f1c65ca3f599af558ef858cb1b4132",
-      "passes": 5,
+      "at": "2026-04-19T19:49:13Z",
+      "hash": "c17c9b5caf2a16de9579ab687636f1b20c7f8f03",
+      "passes": 6,
       "pr": 17454
     },
     ".agents/scripts/attribution-detection-helper.sh": {
@@ -2262,9 +2262,9 @@
       "pr": 12145
     },
     ".agents/scripts/full-loop-helper.sh": {
-      "at": "2026-04-19T05:30:53Z",
-      "hash": "0da699d76a8d8fb04cae2b8fc41b4d3a1f27ead4",
-      "passes": 11,
+      "at": "2026-04-19T19:49:16Z",
+      "hash": "0f8ab35f066deead150f2be89671dc13d68f3c10",
+      "passes": 12,
       "pr": 19046
     },
     ".agents/scripts/generate-claude-commands.sh": {
@@ -2310,9 +2310,9 @@
       "pr": 18707
     },
     ".agents/scripts/interactive-session-helper.sh": {
-      "at": "2026-04-19T15:35:43Z",
-      "hash": "7f1ff2dfe9f16e143dad1df55167e4599d192320",
-      "passes": 5,
+      "at": "2026-04-19T19:49:17Z",
+      "hash": "c211c40b61dd90a0462f217099e9d8dc1651f092",
+      "passes": 6,
       "pr": 18843
     },
     ".agents/scripts/issue-sync-helper.sh": {
@@ -2394,15 +2394,15 @@
       "pr": 17590
     },
     ".agents/scripts/pulse-ancillary-dispatch.sh": {
-      "at": "2026-04-15T07:31:55Z",
-      "hash": "ab72fd6b20e25c4e7f8002d79a94fa44e5a71193",
-      "passes": 5,
+      "at": "2026-04-19T19:49:18Z",
+      "hash": "addd94dd0e7fccf14ec501f96df233e13bb7635f",
+      "passes": 6,
       "pr": 18657
     },
     ".agents/scripts/pulse-cleanup.sh": {
-      "at": "2026-04-19T05:30:54Z",
-      "hash": "7ad09a7f4b01d77b7ef3717affa029687235a029",
-      "passes": 5,
+      "at": "2026-04-19T19:49:18Z",
+      "hash": "6e87466afbda81aa546fcfa807ec247e1a377575",
+      "passes": 6,
       "pr": 18704
     },
     ".agents/scripts/pulse-dep-graph.sh": {
@@ -2436,15 +2436,15 @@
       "pr": 18691
     },
     ".agents/scripts/pulse-issue-reconcile.sh": {
-      "at": "2026-04-19T16:33:53Z",
-      "hash": "1c38a184c6d2d2eb18be2c19c9b70a00e99b3ae6",
-      "passes": 12,
+      "at": "2026-04-19T19:49:19Z",
+      "hash": "333bf1d2301ec3f8fdaa92e661f319d0af9d66fd",
+      "passes": 13,
       "pr": 18690
     },
     ".agents/scripts/pulse-merge.sh": {
-      "at": "2026-04-19T05:30:55Z",
-      "hash": "f5d5e9a21c27d84d0ee85ec8ae0704af7c2f3c43",
-      "passes": 16,
+      "at": "2026-04-19T19:49:19Z",
+      "hash": "7c7b2da1a1f161faa84fc6de12329b8e34689adb",
+      "passes": 17,
       "pr": 18829
     },
     ".agents/scripts/pulse-prefetch.sh": {
@@ -2466,15 +2466,15 @@
       "pr": 18680
     },
     ".agents/scripts/pulse-simplification.sh": {
-      "at": "2026-04-19T19:19:44Z",
-      "hash": "5152aaa11f855afe1fa2cac2928e93c26c1f8ed2",
-      "passes": 12,
+      "at": "2026-04-19T19:49:19Z",
+      "hash": "c75571e3c08dc536515010addaee2ad74294f4ff",
+      "passes": 13,
       "pr": 18653
     },
     ".agents/scripts/pulse-triage.sh": {
-      "at": "2026-04-17T20:02:43Z",
-      "hash": "ccdec4f51fd698f9670d95bc44fc0c34c4481119",
-      "passes": 14,
+      "at": "2026-04-19T19:49:20Z",
+      "hash": "f124eb7f52c809170f73ab3c96ec08a388e2bbe3",
+      "passes": 15,
       "pr": 18655
     },
     ".agents/scripts/pulse-wrapper.sh": {
@@ -2496,15 +2496,15 @@
       "pr": 19000
     },
     ".agents/scripts/quality-feedback-issues-lib.sh": {
-      "at": "2026-04-14T22:16:57Z",
-      "hash": "659f27c08e7ad944343d00646a2ccc522fd90bcd",
-      "passes": 1,
+      "at": "2026-04-19T19:49:20Z",
+      "hash": "1896895d66108306b86290d2888e6b17346d5960",
+      "passes": 2,
       "pr": 19004
     },
     ".agents/scripts/routine-log-helper.sh": {
-      "at": "2026-04-19T15:35:45Z",
-      "hash": "38165378dc1fdd3945ea60afac7575fc2a370abd",
-      "passes": 5,
+      "at": "2026-04-19T19:49:20Z",
+      "hash": "42e7c977adf51385bb7a279747b2b31e70ef9772",
+      "passes": 6,
       "pr": 17786
     },
     ".agents/scripts/schema-validator-helper.sh": {
@@ -2544,9 +2544,9 @@
       "pr": 15916
     },
     ".agents/scripts/shared-constants.sh": {
-      "at": "2026-04-19T16:57:28Z",
-      "hash": "ddf89faf7483610db1c7092cf67ed61a95597713",
-      "passes": 12,
+      "at": "2026-04-19T19:49:21Z",
+      "hash": "0e5d4cdf24626e49e9c259934c029b6ffe3e1c56",
+      "passes": 13,
       "pr": 18847
     },
     ".agents/scripts/stats-functions.sh": {
@@ -2556,9 +2556,9 @@
       "pr": 18808
     },
     ".agents/scripts/stats-quality-sweep.sh": {
-      "at": "2026-04-19T19:19:45Z",
-      "hash": "82fa13bd747ca986255f0b39ecbd2274b78aa12a",
-      "passes": 5,
+      "at": "2026-04-19T19:49:21Z",
+      "hash": "91cf86de8603aa66652621ca81fe44ec18b04b27",
+      "passes": 6,
       "pr": 18810
     },
     ".agents/scripts/tabby-helper.sh": {
@@ -2615,15 +2615,15 @@
       "passes": 1
     },
     ".agents/scripts/worker-lifecycle-common.sh": {
-      "at": "2026-04-19T16:33:54Z",
-      "hash": "302d32f4bec7c6f123e4024359dcb9421e5030d0",
-      "passes": 9,
+      "at": "2026-04-19T19:49:22Z",
+      "hash": "8334e61684c800d3c352e35c246741408f28ea35",
+      "passes": 10,
       "pr": 17353
     },
     ".agents/scripts/worker-watchdog.sh": {
-      "at": "2026-04-19T05:30:58Z",
-      "hash": "02fd9b15d344af17fc4e89721aa2c8ff83c68315",
-      "passes": 6,
+      "at": "2026-04-19T19:49:22Z",
+      "hash": "450818e69470a55ecf028cb3619303b63cf54b73",
+      "passes": 7,
       "pr": 17393
     },
     ".agents/scripts/worktree-helper.sh": {
@@ -7492,9 +7492,9 @@
       "pr": 15490
     },
     "aidevops.sh": {
-      "at": "2026-04-19T18:37:10Z",
-      "hash": "9b5d67b5bddfcb9828eb2f57baa521950339c994",
-      "passes": 87,
+      "at": "2026-04-19T19:50:10Z",
+      "hash": "6e9cbe486ccf95dcb0de0817f50dc73de2b25e6a",
+      "passes": 88,
       "pr": 19029
     },
     "setup-modules/agent-deploy.sh": {
@@ -7504,9 +7504,9 @@
       "pr": 19203
     },
     "setup.sh": {
-      "at": "2026-04-19T18:37:10Z",
-      "hash": "df8bff4dde5cc40053f7fe800ebdb3fc19103f84",
-      "passes": 84,
+      "at": "2026-04-19T19:50:10Z",
+      "hash": "5a8b5cbbaebb5379cc22e590e9f57e2992be1f4f",
+      "passes": 85,
       "pr": 15470
     },
     "todo/tasks/GH#15363-brief.md": {

--- a/.agents/scripts/pulse-canonical-maintenance.sh
+++ b/.agents/scripts/pulse-canonical-maintenance.sh
@@ -1,0 +1,372 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# pulse-canonical-maintenance.sh — Periodic canonical-repo fast-forward and stale worktree sweep.
+#
+# GH#19949: consolidated pulse stage combining two housekeeping tasks:
+#   1. Fast-forward canonical repos to origin/main (avoids stale main)
+#   2. Sweep stale worktrees whose branches are merged or PRs are closed
+#
+# Cadence: ~30 min (1800s), not per-cycle. Both operations are deterministic
+# and safe — fail-open on dirty trees, skip on active sessions, per-repo timeout.
+#
+# This module is sourced by pulse-wrapper.sh. It MUST NOT be executed
+# directly — it relies on the orchestrator having sourced:
+#   shared-constants.sh
+#   worker-lifecycle-common.sh
+# and having defined all PULSE_* configuration constants in the bootstrap section.
+#
+# Functions in this module (in source order):
+#   - _canonical_maintenance_run_with_timeout
+#   - _canonical_maintenance_check_cadence
+#   - _canonical_maintenance_has_active_session
+#   - _canonical_maintenance_audit_log
+#   - _canonical_ff_should_skip_repo
+#   - _canonical_ff_single_repo
+#   - _canonical_fast_forward
+#   - _stale_worktree_sweep_single_repo
+#   - _stale_worktree_sweep
+#   - run_canonical_maintenance
+
+# Include guard — prevent double-sourcing.
+[[ -n "${_PULSE_CANONICAL_MAINTENANCE_LOADED:-}" ]] && return 0
+_PULSE_CANONICAL_MAINTENANCE_LOADED=1
+
+# ---------------------------------------------------------------------------
+# _canonical_maintenance_run_with_timeout
+#
+# Runs a command with a timeout, falling back to running directly if the
+# `timeout` utility is not available (common on stock macOS without coreutils).
+# Arguments: $1 - timeout_seconds, $2.. - command and args
+# ---------------------------------------------------------------------------
+_canonical_maintenance_run_with_timeout() {
+	local timeout_seconds="$1"
+	shift
+	if command -v timeout &>/dev/null; then
+		timeout "$timeout_seconds" "$@"
+	else
+		"$@"
+	fi
+	return $?
+}
+
+# ---------------------------------------------------------------------------
+# Configuration constants (overridable via env)
+# ---------------------------------------------------------------------------
+CANONICAL_MAINTENANCE_CADENCE="${CANONICAL_MAINTENANCE_CADENCE:-1800}"       # 30 min
+CANONICAL_MAINTENANCE_LAST_RUN="${CANONICAL_MAINTENANCE_LAST_RUN:-${HOME}/.aidevops/.agent-workspace/pulse-canonical-maintenance-last-run}"
+CANONICAL_MAINTENANCE_TIMEOUT="${CANONICAL_MAINTENANCE_TIMEOUT:-60}"         # 60s per-repo hard timeout
+CANONICAL_MAINTENANCE_CLAIM_STAMP_DIR="${CANONICAL_MAINTENANCE_CLAIM_STAMP_DIR:-${HOME}/.aidevops/.agent-workspace/interactive-claims}"
+CANONICAL_MAINTENANCE_DEFAULT_BRANCH="${CANONICAL_MAINTENANCE_DEFAULT_BRANCH:-main}"  # fallback when symbolic-ref fails
+
+# ---------------------------------------------------------------------------
+# _canonical_maintenance_check_cadence
+#
+# Returns 0 if enough time has elapsed since the last run, 1 otherwise.
+# Arguments: $1 - now_epoch (current epoch seconds)
+# ---------------------------------------------------------------------------
+_canonical_maintenance_check_cadence() {
+	local now_epoch="$1"
+	if [[ ! -f "$CANONICAL_MAINTENANCE_LAST_RUN" ]]; then
+		return 0
+	fi
+	local last_run
+	last_run=$(cat "$CANONICAL_MAINTENANCE_LAST_RUN" 2>/dev/null || echo "0")
+	[[ "$last_run" =~ ^[0-9]+$ ]] || last_run=0
+	local elapsed=$((now_epoch - last_run))
+	if [[ "$elapsed" -lt "$CANONICAL_MAINTENANCE_CADENCE" ]]; then
+		local remaining_min=$(((CANONICAL_MAINTENANCE_CADENCE - elapsed) / 60))
+		echo "[pulse-canonical-maintenance] Not due yet (${remaining_min}m remaining)" >>"${LOGFILE:-/dev/null}"
+		return 1
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# _canonical_maintenance_has_active_session
+#
+# Check whether a repo has an active interactive session claim stamp.
+# Arguments: $1 - repo_path
+# Returns: 0 if an active session is detected (skip this repo), 1 if safe.
+# ---------------------------------------------------------------------------
+_canonical_maintenance_has_active_session() {
+	local repo_path="$1"
+	local stamp_dir="$CANONICAL_MAINTENANCE_CLAIM_STAMP_DIR"
+	[[ -d "$stamp_dir" ]] || return 1
+
+	local stamp
+	for stamp in "$stamp_dir"/*.json; do
+		[[ -f "$stamp" ]] || continue
+		local stamp_worktree=""
+		stamp_worktree=$(jq -r '.worktree // ""' "$stamp" 2>/dev/null) || continue
+		if [[ -n "$stamp_worktree" ]] && [[ "$stamp_worktree" == "$repo_path"* ]]; then
+			local stamp_pid=""
+			stamp_pid=$(jq -r '.pid // ""' "$stamp" 2>/dev/null) || continue
+			if [[ -n "$stamp_pid" ]] && [[ "$stamp_pid" =~ ^[0-9]+$ ]] && kill -0 "$stamp_pid" 2>/dev/null; then
+				return 0
+			fi
+		fi
+	done
+	return 1
+}
+
+# ---------------------------------------------------------------------------
+# _canonical_maintenance_audit_log
+#
+# Emit an audit log entry if the helper is available.
+# Arguments: $1 - message
+# ---------------------------------------------------------------------------
+_canonical_maintenance_audit_log() {
+	local message="$1"
+	local _audit_helper="${SCRIPT_DIR:-$(dirname "${BASH_SOURCE[0]}")}/audit-log-helper.sh"
+	[[ -x "$_audit_helper" ]] && "$_audit_helper" log config.change "$message" 2>/dev/null || true
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# _canonical_ff_should_skip_repo
+#
+# Pre-flight checks for a single repo. Returns 0 if the repo should be
+# skipped, 1 if it's safe to fast-forward. Prints skip reason to LOGFILE.
+# Arguments: $1 - repo_path
+# ---------------------------------------------------------------------------
+_canonical_ff_should_skip_repo() {
+	local repo_path="$1"
+
+	# Skip if dirty tree
+	local porcelain_output=""
+	porcelain_output=$(git -C "$repo_path" status --porcelain 2>/dev/null) || return 0
+	if [[ -n "$porcelain_output" ]]; then
+		echo "[pulse-canonical-maintenance] Skipping ${repo_path} — dirty tree" >>"${LOGFILE:-/dev/null}"
+		return 0
+	fi
+
+	# Skip if non-empty stash
+	local stash_output=""
+	stash_output=$(git -C "$repo_path" stash list 2>/dev/null) || stash_output=""
+	if [[ -n "$stash_output" ]]; then
+		echo "[pulse-canonical-maintenance] Skipping ${repo_path} — non-empty stash" >>"${LOGFILE:-/dev/null}"
+		return 0
+	fi
+
+	# Skip if active session
+	if _canonical_maintenance_has_active_session "$repo_path"; then
+		echo "[pulse-canonical-maintenance] Skipping ${repo_path} — active session detected" >>"${LOGFILE:-/dev/null}"
+		return 0
+	fi
+
+	# Skip if not on the default branch
+	local main_branch
+	main_branch=$(git -C "$repo_path" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||') || main_branch="$CANONICAL_MAINTENANCE_DEFAULT_BRANCH"
+	[[ -z "$main_branch" ]] && main_branch="$CANONICAL_MAINTENANCE_DEFAULT_BRANCH"
+	local current_branch
+	current_branch=$(git -C "$repo_path" branch --show-current 2>/dev/null) || current_branch=""
+	if [[ "$current_branch" != "$main_branch" ]]; then
+		echo "[pulse-canonical-maintenance] Skipping ${repo_path} — not on ${main_branch} (on ${current_branch})" >>"${LOGFILE:-/dev/null}"
+		return 0
+	fi
+
+	# All checks passed — do not skip
+	return 1
+}
+
+# ---------------------------------------------------------------------------
+# _canonical_ff_single_repo
+#
+# Fast-forward a single repo. Called from the per-repo loop in
+# _canonical_fast_forward. Returns 0=fast-forwarded, 1=skipped/failed.
+# Arguments: $1 - repo_path, $2 - dry_run ("1" or "0")
+# ---------------------------------------------------------------------------
+_canonical_ff_single_repo() {
+	local repo_path="$1"
+	local dry_run="$2"
+
+	# Determine default branch
+	local main_branch
+	main_branch=$(git -C "$repo_path" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||') || main_branch="$CANONICAL_MAINTENANCE_DEFAULT_BRANCH"
+	[[ -z "$main_branch" ]] && main_branch="$CANONICAL_MAINTENANCE_DEFAULT_BRANCH"
+
+	# Fetch origin
+	if [[ "$dry_run" == "1" ]]; then
+		echo "[DRY_RUN] Would fetch origin for ${repo_path}"
+	else
+		_canonical_maintenance_run_with_timeout "$CANONICAL_MAINTENANCE_TIMEOUT" git -C "$repo_path" fetch origin --prune --quiet 2>/dev/null || {
+			echo "[pulse-canonical-maintenance] Fetch failed/timed out for ${repo_path}" >>"${LOGFILE:-/dev/null}"
+			return 1
+		}
+	fi
+
+	# Check commits behind
+	local behind_count=0
+	behind_count=$(git -C "$repo_path" rev-list --count "HEAD..origin/${main_branch}" 2>/dev/null) || behind_count=0
+	[[ "$behind_count" =~ ^[0-9]+$ ]] || behind_count=0
+	if [[ "$behind_count" -eq 0 ]]; then
+		echo "[pulse-canonical-maintenance] ${repo_path} — already up to date" >>"${LOGFILE:-/dev/null}"
+		return 1
+	fi
+
+	# Fast-forward
+	if [[ "$dry_run" == "1" ]]; then
+		echo "[DRY_RUN] Would fast-forward ${repo_path} (${behind_count} commits behind)"
+		return 0
+	fi
+
+	if _canonical_maintenance_run_with_timeout "$CANONICAL_MAINTENANCE_TIMEOUT" git -C "$repo_path" pull --ff-only "origin" "$main_branch" 2>/dev/null; then
+		echo "[pulse-canonical-maintenance] Fast-forwarded ${repo_path} by ${behind_count} commits" >>"${LOGFILE:-/dev/null}"
+		_canonical_maintenance_audit_log "canonical-maintenance: fast-forwarded ${repo_path} by ${behind_count} commits"
+		return 0
+	fi
+
+	echo "[pulse-canonical-maintenance] Fast-forward failed for ${repo_path} (non-ff divergence?)" >>"${LOGFILE:-/dev/null}"
+	return 1
+}
+
+# ---------------------------------------------------------------------------
+# _canonical_fast_forward
+#
+# For each pulse-enabled, non-local_only repo in repos.json, run pre-flight
+# checks and fast-forward if behind origin.
+# Arguments: $1 - dry_run ("1" for dry run, "0" for real)
+# Returns: 0 always (fail-open per repo)
+# ---------------------------------------------------------------------------
+_canonical_fast_forward() {
+	local dry_run="${1:-0}"
+	local repos_json="${REPOS_JSON:-${HOME}/.config/aidevops/repos.json}"
+	[[ -f "$repos_json" ]] && command -v jq &>/dev/null || return 0
+
+	local -a _repo_list=()
+	mapfile -t _repo_list < <(jq -r '.initialized_repos[] | select((.pulse // false) == true) | select((.local_only // false) == false) | .path // ""' "$repos_json" 2>/dev/null)
+
+	local repo_path ff_count=0 skip_count=0
+	for repo_path in "${_repo_list[@]}"; do
+		[[ -z "$repo_path" ]] && continue
+		[[ ! -d "$repo_path/.git" ]] && continue
+
+		if _canonical_ff_should_skip_repo "$repo_path"; then
+			skip_count=$((skip_count + 1))
+			continue
+		fi
+
+		if _canonical_ff_single_repo "$repo_path" "$dry_run"; then
+			ff_count=$((ff_count + 1))
+		fi
+	done
+
+	echo "[pulse-canonical-maintenance] Fast-forward pass: ${ff_count} repos updated, ${skip_count} skipped" >>"${LOGFILE:-/dev/null}"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# _stale_worktree_sweep_single_repo
+#
+# Sweep stale worktrees for a single repo.
+# Arguments: $1 - repo_path, $2 - dry_run, $3 - worktree_helper path
+# Outputs: number of removed worktrees to stdout
+# Returns: 0 always
+# ---------------------------------------------------------------------------
+_stale_worktree_sweep_single_repo() {
+	local repo_path="$1"
+	local dry_run="$2"
+	local worktree_helper="$3"
+	local _wt_prefix="^worktree "
+
+	if [[ "$dry_run" == "1" ]]; then
+		local wt_count=0
+		wt_count=$(git -C "$repo_path" worktree list --porcelain 2>/dev/null | grep -c "$_wt_prefix" || echo "0")
+		[[ "$wt_count" -gt 0 ]] && wt_count=$((wt_count - 1))
+		echo "[DRY_RUN] Would sweep worktrees for ${repo_path} (${wt_count} linked worktrees)"
+		printf '0'
+		return 0
+	fi
+
+	local before_count=0
+	before_count=$(git -C "$repo_path" worktree list --porcelain 2>/dev/null | grep -c "$_wt_prefix" || echo "0")
+
+	if ! _canonical_maintenance_run_with_timeout "$CANONICAL_MAINTENANCE_TIMEOUT" "$worktree_helper" clean --auto --force-merged 2>/dev/null; then
+		echo "[pulse-canonical-maintenance] Worktree sweep timed out for ${repo_path}" >>"${LOGFILE:-/dev/null}"
+		printf '0'
+		return 0
+	fi
+
+	local after_count=0
+	after_count=$(git -C "$repo_path" worktree list --porcelain 2>/dev/null | grep -c "$_wt_prefix" || echo "0")
+	local removed=$((before_count - after_count))
+	if [[ "$removed" -gt 0 ]]; then
+		echo "[pulse-canonical-maintenance] Swept ${removed} worktrees for ${repo_path}" >>"${LOGFILE:-/dev/null}"
+		_canonical_maintenance_audit_log "canonical-maintenance: swept ${removed} worktrees for ${repo_path}"
+	fi
+	printf '%d' "$removed"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# _stale_worktree_sweep
+#
+# For each pulse-enabled, non-local_only repo: invoke worktree-helper.sh
+# clean --auto --force-merged with a per-repo hard timeout.
+# Arguments: $1 - dry_run ("1" for dry run, "0" for real)
+# Returns: 0 always (fail-open per repo)
+# ---------------------------------------------------------------------------
+_stale_worktree_sweep() {
+	local dry_run="${1:-0}"
+	local repos_json="${REPOS_JSON:-${HOME}/.config/aidevops/repos.json}"
+	[[ -f "$repos_json" ]] && command -v jq &>/dev/null || return 0
+
+	local worktree_helper="${SCRIPT_DIR:-$(dirname "${BASH_SOURCE[0]}")}/worktree-helper.sh"
+	if [[ ! -x "$worktree_helper" ]]; then
+		echo "[pulse-canonical-maintenance] worktree-helper.sh not found or not executable" >>"${LOGFILE:-/dev/null}"
+		return 0
+	fi
+
+	local -a _repo_list=()
+	mapfile -t _repo_list < <(jq -r '.initialized_repos[] | select((.pulse // false) == true) | select((.local_only // false) == false) | .path // ""' "$repos_json" 2>/dev/null)
+
+	local repo_path sweep_count=0
+	for repo_path in "${_repo_list[@]}"; do
+		[[ -z "$repo_path" ]] && continue
+		[[ ! -d "$repo_path/.git" ]] && continue
+		local removed=0
+		removed=$(_stale_worktree_sweep_single_repo "$repo_path" "$dry_run" "$worktree_helper")
+		sweep_count=$((sweep_count + removed))
+	done
+
+	echo "[pulse-canonical-maintenance] Worktree sweep: ${sweep_count} total removed" >>"${LOGFILE:-/dev/null}"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# run_canonical_maintenance
+#
+# Top-level entry point called from the deterministic pipeline.
+# Checks cadence, runs both passes, writes cadence state file.
+# Arguments: none (reads --dry-run from $1 if called directly)
+# Returns: 0 always
+# ---------------------------------------------------------------------------
+run_canonical_maintenance() {
+	local dry_run=0
+	if [[ "${1:-}" == "--dry-run" ]]; then
+		dry_run=1
+	fi
+
+	local now_epoch
+	now_epoch=$(date +%s)
+
+	# Cadence gate (skip in dry-run mode to always show output)
+	if [[ "$dry_run" -eq 0 ]] && ! _canonical_maintenance_check_cadence "$now_epoch"; then
+		return 0
+	fi
+
+	echo "[pulse-canonical-maintenance] Starting canonical maintenance pass" >>"${LOGFILE:-/dev/null}"
+
+	_canonical_fast_forward "$dry_run"
+	_stale_worktree_sweep "$dry_run"
+
+	# Update cadence state file
+	if [[ "$dry_run" -eq 0 ]]; then
+		mkdir -p "$(dirname "$CANONICAL_MAINTENANCE_LAST_RUN")" 2>/dev/null || true
+		echo "$now_epoch" >"$CANONICAL_MAINTENANCE_LAST_RUN"
+	fi
+
+	echo "[pulse-canonical-maintenance] Canonical maintenance pass complete" >>"${LOGFILE:-/dev/null}"
+	return 0
+}

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -233,6 +233,9 @@ source "${SCRIPT_DIR}/pulse-dispatch-engine.sh"
 source "${SCRIPT_DIR}/pulse-quality-debt.sh"
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}/pulse-ancillary-dispatch.sh"
+# GH#19949: canonical-repo fast-forward + stale worktree sweep (30min cadence).
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/pulse-canonical-maintenance.sh"
 
 #######################################
 # SSH agent integration for commit signing (t1882)
@@ -1024,6 +1027,7 @@ _pulse_execute_self_check() {
 		_interactive_pr_trigger_handover
 		_dispatch_ci_fix_worker
 		_dispatch_conflict_fix_worker
+		run_canonical_maintenance
 	)
 	for _sc_fn in "${_sc_expected_fns[@]}"; do
 		if ! declare -F "$_sc_fn" >/dev/null 2>&1; then
@@ -1069,6 +1073,7 @@ _pulse_execute_self_check() {
 		_PULSE_DISPATCH_ENGINE_LOADED
 		_PULSE_QUALITY_DEBT_LOADED
 		_PULSE_ANCILLARY_DISPATCH_LOADED
+		_PULSE_CANONICAL_MAINTENANCE_LOADED
 	)
 	local _sc_guard _sc_val
 	# The `${array[@]+"${array[@]}"}` pattern is safe under `set -u`
@@ -1177,6 +1182,17 @@ _pulse_run_deterministic_pipeline() {
 	else
 		run_stage_with_timeout "evaluate_routines" "$PRE_RUN_STAGE_TIMEOUT" \
 			evaluate_routines || true
+	fi
+
+	# GH#19949: Canonical-repo fast-forward + stale worktree sweep.
+	# Cadence-gated (~30 min) — the function's internal cadence check skips
+	# if too soon. Runs after routine evaluation and before health snapshot
+	# so the snapshot reflects the maintenance outcome.
+	if [[ -f "$STOP_FLAG" ]]; then
+		echo "[pulse-wrapper] Stop flag appeared — skipping canonical maintenance" >>"$LOGFILE"
+	else
+		run_stage_with_timeout "canonical_maintenance" "$PRE_RUN_STAGE_TIMEOUT" \
+			run_canonical_maintenance || true
 	fi
 
 	# Write structured health snapshot for instant diagnosis (GH#15107)

--- a/.agents/scripts/tests/test-pulse-canonical-maintenance.sh
+++ b/.agents/scripts/tests/test-pulse-canonical-maintenance.sh
@@ -1,0 +1,359 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-pulse-canonical-maintenance.sh — GH#19949 regression guard.
+#
+# Asserts the canonical-repo fast-forward and stale worktree sweep
+# pulse stage works end-to-end:
+#
+#   1. Cadence gate: skips when last run is recent, proceeds when stale.
+#   2. Skip-on-dirty: repos with uncommitted changes are skipped.
+#   3. Skip-on-session-active: repos with an active claim stamp are skipped.
+#   4. Fast-forward: repos behind origin are fast-forwarded.
+#   5. Dry-run mode: lists actions without mutating state.
+#
+# Uses a sandboxed git repo pair (bare origin + working clone) to test
+# fast-forward behaviour without touching real repos.
+
+set -uo pipefail
+
+TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_RED=$'\033[0;31m'
+TEST_GREEN=$'\033[0;32m'
+TEST_RESET=$'\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1" rc="$2" extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf '%sPASS%s %s\n' "$TEST_GREEN" "$TEST_RESET" "$name"
+	else
+		printf '%sFAIL%s %s %s\n' "$TEST_RED" "$TEST_RESET" "$name" "$extra"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+# Sandbox
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+export HOME="${TEST_ROOT}/home"
+mkdir -p "${HOME}/.aidevops/logs" "${HOME}/.aidevops/.agent-workspace" "${HOME}/.config/aidevops"
+
+# Minimal LOGFILE for the module
+export LOGFILE="${TEST_ROOT}/test.log"
+touch "$LOGFILE"
+
+# SCRIPT_DIR expected by the module
+export SCRIPT_DIR="$TEST_SCRIPTS_DIR"
+
+# Disable commit signing for test repos (avoids SSH passphrase prompts)
+export GIT_CONFIG_NOSYSTEM=1
+export GIT_AUTHOR_NAME="Test"
+export GIT_AUTHOR_EMAIL="test@example.com"
+export GIT_COMMITTER_NAME="Test"
+export GIT_COMMITTER_EMAIL="test@example.com"
+git config --global commit.gpgsign false 2>/dev/null || true
+git config --global tag.gpgsign false 2>/dev/null || true
+git config --global init.defaultBranch main 2>/dev/null || true
+
+# Create a bare "origin" repo and a working clone for testing
+_setup_test_repos() {
+	local bare_dir="${TEST_ROOT}/origin.git"
+	local clone_dir="${TEST_ROOT}/testrepo"
+
+	# Clean up from previous tests to avoid stale state
+	rm -rf "$bare_dir" "$clone_dir" "${TEST_ROOT}/tmp_clone" 2>/dev/null
+
+	git init --bare "$bare_dir" >/dev/null 2>&1
+	git clone "$bare_dir" "$clone_dir" >/dev/null 2>&1
+
+	# Make an initial commit so main exists
+	(
+		cd "$clone_dir" || exit 1
+		git checkout -b main >/dev/null 2>&1
+		echo "initial" >file.txt
+		git add file.txt
+		git commit -m "initial commit" >/dev/null 2>&1
+		git push -u origin main >/dev/null 2>&1
+		# Set HEAD for symbolic-ref resolution
+		git remote set-head origin main >/dev/null 2>&1
+	)
+
+	# Write repos.json pointing at the clone
+	cat >"${HOME}/.config/aidevops/repos.json" <<EOF
+{"initialized_repos": [{"slug": "test/repo", "path": "${clone_dir}", "pulse": true}]}
+EOF
+	export REPOS_JSON="${HOME}/.config/aidevops/repos.json"
+
+	echo "$clone_dir"
+	return 0
+}
+
+# Add a commit to origin (to make clone fall behind)
+_push_new_commit_to_origin() {
+	local bare_dir="${TEST_ROOT}/origin.git"
+	local tmp_clone="${TEST_ROOT}/tmp_clone"
+
+	git clone "$bare_dir" "$tmp_clone" >/dev/null 2>&1
+	(
+		cd "$tmp_clone" || exit 1
+		echo "new content $(date +%s)" >newfile.txt
+		git add newfile.txt
+		git commit -m "new commit from origin" >/dev/null 2>&1
+		git push origin main >/dev/null 2>&1
+	)
+	rm -rf "$tmp_clone"
+	return 0
+}
+
+# Source shared-constants.sh to get basic utilities, then source the module
+# Some functions from shared-constants.sh may not be available in test,
+# so source with error suppression
+# shellcheck source=/dev/null
+source "${TEST_SCRIPTS_DIR}/shared-constants.sh" 2>/dev/null || true
+set +e
+
+# Source the module under test
+# shellcheck source=/dev/null
+source "${TEST_SCRIPTS_DIR}/pulse-canonical-maintenance.sh" 2>/dev/null || true
+
+# =============================================================================
+# Test 1: Cadence gate — skip when last run is recent
+# =============================================================================
+test_cadence_skip_recent() {
+	local now_epoch
+	now_epoch=$(date +%s)
+	# Set last run to 5 minutes ago (300s, well under 1800s cadence)
+	local recent=$((now_epoch - 300))
+	echo "$recent" >"$CANONICAL_MAINTENANCE_LAST_RUN"
+
+	if _canonical_maintenance_check_cadence "$now_epoch"; then
+		print_result "cadence-skip-recent" 1 "(expected skip, got proceed)"
+	else
+		print_result "cadence-skip-recent" 0
+	fi
+	return 0
+}
+
+# =============================================================================
+# Test 2: Cadence gate — proceed when last run is old
+# =============================================================================
+test_cadence_proceed_old() {
+	local now_epoch
+	now_epoch=$(date +%s)
+	# Set last run to 2 hours ago (7200s, well over 1800s cadence)
+	local old=$((now_epoch - 7200))
+	echo "$old" >"$CANONICAL_MAINTENANCE_LAST_RUN"
+
+	if _canonical_maintenance_check_cadence "$now_epoch"; then
+		print_result "cadence-proceed-old" 0
+	else
+		print_result "cadence-proceed-old" 1 "(expected proceed, got skip)"
+	fi
+	return 0
+}
+
+# =============================================================================
+# Test 3: Cadence gate — proceed when state file missing
+# =============================================================================
+test_cadence_proceed_missing() {
+	rm -f "$CANONICAL_MAINTENANCE_LAST_RUN"
+	local now_epoch
+	now_epoch=$(date +%s)
+
+	if _canonical_maintenance_check_cadence "$now_epoch"; then
+		print_result "cadence-proceed-missing" 0
+	else
+		print_result "cadence-proceed-missing" 1 "(expected proceed, got skip)"
+	fi
+	return 0
+}
+
+# =============================================================================
+# Test 4: Skip-on-dirty — repos with uncommitted changes are skipped
+# =============================================================================
+test_skip_on_dirty() {
+	local clone_dir
+	clone_dir=$(_setup_test_repos)
+
+	# Make the tree dirty
+	echo "dirty" >"${clone_dir}/untracked_dirty.txt"
+	(cd "$clone_dir" && git add untracked_dirty.txt) >/dev/null 2>&1
+
+	# Reset cadence so it runs
+	rm -f "$CANONICAL_MAINTENANCE_LAST_RUN"
+
+	# Capture log output
+	true > "$LOGFILE"
+	_canonical_fast_forward "0"
+
+	if grep -q "dirty tree" "$LOGFILE"; then
+		print_result "skip-on-dirty" 0
+	else
+		print_result "skip-on-dirty" 1 "(expected 'dirty tree' in log)"
+	fi
+	return 0
+}
+
+# =============================================================================
+# Test 5: Skip-on-session-active — repos with an active claim stamp are skipped
+# =============================================================================
+test_skip_on_session_active() {
+	local clone_dir
+	clone_dir=$(_setup_test_repos)
+
+	# Create a fake claim stamp pointing at this repo with our PID
+	local stamp_dir="${CANONICAL_MAINTENANCE_CLAIM_STAMP_DIR}"
+	mkdir -p "$stamp_dir"
+	cat >"${stamp_dir}/test-repo-123.json" <<EOF
+{"worktree": "${clone_dir}", "pid": $$, "issue": 123}
+EOF
+
+	# Reset cadence
+	rm -f "$CANONICAL_MAINTENANCE_LAST_RUN"
+
+	true > "$LOGFILE"
+	_canonical_fast_forward "0"
+
+	if grep -q "active session" "$LOGFILE"; then
+		print_result "skip-on-session-active" 0
+	else
+		print_result "skip-on-session-active" 1 "(expected 'active session' in log)"
+	fi
+
+	# Cleanup stamp
+	rm -f "${stamp_dir}/test-repo-123.json"
+	return 0
+}
+
+# =============================================================================
+# Test 6: Successful fast-forward
+# =============================================================================
+test_fast_forward_success() {
+	local clone_dir
+	clone_dir=$(_setup_test_repos)
+
+	# Push a new commit to origin so clone is behind
+	_push_new_commit_to_origin
+
+	# Reset cadence
+	rm -f "$CANONICAL_MAINTENANCE_LAST_RUN"
+
+	true > "$LOGFILE"
+	_canonical_fast_forward "0"
+
+	if grep -q "Fast-forwarded" "$LOGFILE"; then
+		print_result "fast-forward-success" 0
+	else
+		print_result "fast-forward-success" 1 "(expected 'Fast-forwarded' in log, got: $(cat "$LOGFILE"))"
+	fi
+	return 0
+}
+
+# =============================================================================
+# Test 7: Already up to date — no fast-forward needed
+# =============================================================================
+test_already_up_to_date() {
+	local clone_dir
+	clone_dir=$(_setup_test_repos)
+
+	# No new commits, repo is already up to date
+	# Fetch so origin ref is current
+	(cd "$clone_dir" && git fetch origin --quiet) >/dev/null 2>&1
+
+	rm -f "$CANONICAL_MAINTENANCE_LAST_RUN"
+	true > "$LOGFILE"
+	_canonical_fast_forward "0"
+
+	if grep -q "already up to date" "$LOGFILE"; then
+		print_result "already-up-to-date" 0
+	else
+		print_result "already-up-to-date" 1 "(expected 'already up to date' in log)"
+	fi
+	return 0
+}
+
+# =============================================================================
+# Test 8: Dry-run mode — no mutations
+# =============================================================================
+test_dry_run() {
+	local clone_dir
+	clone_dir=$(_setup_test_repos)
+
+	_push_new_commit_to_origin
+
+	rm -f "$CANONICAL_MAINTENANCE_LAST_RUN"
+
+	local output
+	output=$(run_canonical_maintenance --dry-run 2>&1)
+
+	if echo "$output" | grep -q "DRY_RUN"; then
+		print_result "dry-run-output" 0
+	else
+		print_result "dry-run-output" 1 "(expected DRY_RUN in output)"
+	fi
+
+	# Verify clone was NOT actually fast-forwarded
+	local behind
+	behind=$(cd "$clone_dir" && git fetch origin --quiet 2>/dev/null && git rev-list --count "HEAD..origin/main" 2>/dev/null) || behind=0
+	if [[ "$behind" -gt 0 ]]; then
+		print_result "dry-run-no-mutation" 0
+	else
+		print_result "dry-run-no-mutation" 1 "(repo was mutated during dry-run)"
+	fi
+	return 0
+}
+
+# =============================================================================
+# Test 9: Skip when not on default branch
+# =============================================================================
+test_skip_not_on_main() {
+	local clone_dir
+	clone_dir=$(_setup_test_repos)
+
+	# Switch to a feature branch
+	(cd "$clone_dir" && git checkout -b feature/test) >/dev/null 2>&1
+
+	rm -f "$CANONICAL_MAINTENANCE_LAST_RUN"
+	true > "$LOGFILE"
+	_canonical_fast_forward "0"
+
+	if grep -q "not on main" "$LOGFILE"; then
+		print_result "skip-not-on-main" 0
+	else
+		print_result "skip-not-on-main" 1 "(expected 'not on main' in log)"
+	fi
+	return 0
+}
+
+# =============================================================================
+# Run all tests
+# =============================================================================
+test_cadence_skip_recent
+test_cadence_proceed_old
+test_cadence_proceed_missing
+test_skip_on_dirty
+test_skip_on_session_active
+test_fast_forward_success
+test_already_up_to_date
+test_dry_run
+test_skip_not_on_main
+
+# =============================================================================
+# Summary
+# =============================================================================
+echo ""
+echo "============================="
+echo "Tests run: ${TESTS_RUN}"
+echo "Tests failed: ${TESTS_FAILED}"
+echo "============================="
+
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds a new `pulse-canonical-maintenance.sh` module as a cadence-gated (~30 min) deterministic pulse stage that:

1. **Fast-forwards canonical repos** to `origin/main` — keeps `~/Git/<repo>/` current so interactive sessions don't start on stale main
2. **Sweeps stale worktrees** via `worktree-helper.sh clean --auto --force-merged` — reclaims disk and declutters `git worktree list`

Both operations are fail-open: dirty trees, non-empty stashes, active session stamps, and non-default branches all cause a per-repo skip with no mutation.

Resolves #19949

## Changes

- **NEW:** `.agents/scripts/pulse-canonical-maintenance.sh` — 10 functions: cadence gate, active-session detection, per-repo fast-forward, per-repo worktree sweep, audit logging, timeout fallback, top-level entry point
- **EDIT:** `.agents/scripts/pulse-wrapper.sh` — source the new module, register `run_canonical_maintenance` in `_pulse_run_deterministic_pipeline` (after routine evaluation, before health snapshot), add function + include guard to self-check
- **NEW:** `.agents/scripts/tests/test-pulse-canonical-maintenance.sh` — 10 assertions: cadence skip/proceed/missing, skip-on-dirty, skip-on-session-active, fast-forward success, already-up-to-date, dry-run output + no-mutation, skip-not-on-main

## Testing

- `shellcheck` — zero violations on both new files
- `bash .agents/scripts/tests/test-pulse-canonical-maintenance.sh` — 10/10 PASS
- Pre-commit quality gate — all ratchet checks pass (returns, positional params, string literals, ShellCheck)
- Nesting depth ≤ 8 (refactored into extracted helpers + mapfile to avoid scanner false positives)


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.78 plugin for [OpenCode](https://opencode.ai) v1.14.18 with claude-opus-4-6 spent 26m and 58,581 tokens on this as a headless worker. Overall, 3h 9m since this issue was created.