### PR TITLE
t2404: feat(issue-sync): parent-side detection for umbrella-style parent-task backfill

### DIFF
--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -1594,14 +1594,20 @@ Relationships (t1889):
                          that have ref:GH# plus blocked-by:/blocks: or subtask IDs.
                          Use --dry-run to preview. Idempotent (skips existing).
 
-Sub-issue backfill (t2114):
-  backfill-sub-issues [--issue N] — link decomposition children to their
-                         parents using GitHub state alone (title + body). No
-                         TODO.md or brief file required. Detects parents via:
+Sub-issue backfill (t2114, GH#19942):
+  backfill-sub-issues [--issue N] — link parent-child issue relationships
+                         using GitHub state alone (title + body + labels). No
+                         TODO.md or brief file required. Two detection paths:
+                         Child-side (existing): detects parents via
                          (1) dot-notation title `tNNN.M: ...`, (2) `Parent: ...`
                          line in body, (3) `Blocked by: tNNN` where the blocker
-                         carries the `parent-task` label. Idempotent; supports
-                         --dry-run.
+                         carries the `parent-task` label.
+                         Parent-side (GH#19942): when an issue carries the
+                         `parent-task` label, parses its body for a ## Children
+                         section (aliases: ## Child Issues, ## Sub-issues,
+                         ## Phases) and links every #NNN / GH#NNN reference in
+                         list items or table cells as a sub-issue.
+                         Idempotent; supports --dry-run.
 
 Note: Bulk push (no task ID) is CI-only by default to prevent duplicate issues.
       Use 'push <task_id>' for single tasks, or --force-push to override.

--- a/.agents/scripts/issue-sync-relationships.sh
+++ b/.agents/scripts/issue-sync-relationships.sh
@@ -614,20 +614,29 @@ _detect_parent_from_gh_state() {
 # Arguments:
 #   $1 - child issue number
 #   $2 - repo slug
+#   $3 - (optional) pre-fetched title — avoids redundant gh API call
+#   $4 - (optional) pre-fetched body — must be provided alongside $3
 # Returns: 0 on success/skip, 1 on unexpected failure
 # Echoes one of: "LINKED <child>:<parent>", "SKIPPED <child>", "DRY <child>:<parent>"
 _backfill_one_issue() {
-	local num="$1" repo="$2"
+	local num="$1" repo="$2" prefetched_title="${3:-}" prefetched_body="${4:-}"
 	[[ -z "$num" || -z "$repo" ]] && {
 		echo "SKIPPED $num"
 		return 0
 	}
 
-	local meta
-	meta=$(gh issue view "$num" --repo "$repo" --json title,body 2>/dev/null || echo "{}")
+	# Accept optional pre-fetched title/body to avoid redundant API calls
+	# when called from cmd_backfill_sub_issues outer loop (GH#19942).
 	local title body
-	title=$(printf '%s' "$meta" | jq -r '.title // ""' 2>/dev/null)
-	body=$(printf '%s' "$meta" | jq -r '.body // ""' 2>/dev/null)
+	if [[ -n "$prefetched_title" ]]; then
+		title="$prefetched_title"
+		body="$prefetched_body"
+	else
+		local meta
+		meta=$(gh issue view "$num" --repo "$repo" --json title,body 2>/dev/null || echo "{}")
+		title=$(printf '%s' "$meta" | jq -r '.title // ""' 2>/dev/null)
+		body=$(printf '%s' "$meta" | jq -r '.body // ""' 2>/dev/null)
+	fi
 	if [[ -z "$title" ]]; then
 		echo "SKIPPED $num"
 		return 0
@@ -661,6 +670,155 @@ _backfill_one_issue() {
 		return 0
 	fi
 	echo "SKIPPED $num"
+	return 0
+}
+
+# =============================================================================
+# Parent-Side Detection — Umbrella-Style Parent-Task Backfill (GH#19942)
+# =============================================================================
+# Extends backfill-sub-issues with parent-side detection: when an issue carries
+# the `parent-task` label, parse its body for a children section and link every
+# referenced child as a sub-issue. Complements the existing child-side path
+# that detects parents from child title/body.
+
+# Extract the children section from an issue body. Matches headings:
+#   ## Children, ## Child Issues, ## Sub-issues, ## Phases
+# (case-insensitive). Returns content from the heading to the next ## heading
+# or end of body.
+#
+# Arguments:
+#   $1 - issue body text
+# Echo: section content (may be empty if no matching heading found)
+_extract_children_section() {
+	local body="$1"
+	[[ -z "$body" ]] && return 0
+
+	printf '%s\n' "$body" | awk '
+		BEGIN { in_section = 0 }
+		{
+			lower = tolower($0)
+			if (lower ~ /^##[[:space:]]+(children|child issues|sub-issues|phases)/) {
+				in_section = 1
+				next
+			}
+			if (/^##[[:space:]]/) {
+				if (in_section) exit
+			}
+			if (in_section) print
+		}
+	'
+	return 0
+}
+
+# Extract child issue references from a children section. Only matches #NNN
+# and GH#NNN references on lines starting with list markers (-, +, *) or
+# table cell delimiters (|) to avoid false positives from prose mentions.
+#
+# Arguments:
+#   $1 - children section text (output of _extract_children_section)
+# Echo: one issue number per line (deduplicated, sorted numerically)
+_extract_child_references() {
+	local section="$1"
+	[[ -z "$section" ]] && return 0
+
+	printf '%s\n' "$section" |
+		grep -E '^[[:space:]]*[-+*|]' |
+		grep -oE '(GH)?#[0-9]+' |
+		sed -E 's/^(GH)?#//' |
+		sort -un
+	return 0
+}
+
+# Link children listed in a parent-task issue's body section. Parses the body
+# for a ## Children (or alias) heading and links every #NNN reference found
+# in list items or table cells within that section.
+#
+# Arguments:
+#   $1 - parent issue number
+#   $2 - repo slug
+#   $3 - issue body (pre-fetched to avoid redundant API calls)
+# Echo: "PARENT_LINKED <num>:<count>" or "PARENT_DRY <num>:<count>" or
+#       "PARENT_SKIPPED <num>:0"
+# Returns: 0 always (errors are logged, not propagated)
+_backfill_parent_children() {
+	local num="$1" repo="$2" body="$3"
+	local _skip_tag="PARENT_SKIPPED"
+
+	[[ -z "$num" || -z "$repo" ]] && {
+		echo "${_skip_tag} ${num:-0}:0"
+		return 0
+	}
+
+	local children_section
+	children_section=$(_extract_children_section "$body")
+	if [[ -z "$children_section" ]]; then
+		log_verbose "#$num: no children section found in body"
+		echo "${_skip_tag} $num:0"
+		return 0
+	fi
+
+	local child_nums_raw
+	child_nums_raw=$(_extract_child_references "$children_section")
+	if [[ -z "$child_nums_raw" ]]; then
+		log_verbose "#$num: children section present but no issue references found"
+		echo "${_skip_tag} $num:0"
+		return 0
+	fi
+
+	# Read into array (bash 3.2 compatible — no mapfile)
+	local child_nums=()
+	local _cn
+	while IFS= read -r _cn; do
+		[[ -n "$_cn" ]] && child_nums+=("$_cn")
+	done <<< "$child_nums_raw"
+
+	if [[ ${#child_nums[@]} -eq 0 ]]; then
+		echo "${_skip_tag} $num:0"
+		return 0
+	fi
+
+	local linked=0
+	local parent_node=""
+	local _link_desc="sub-issue of #$num (parent-side)"
+
+	for _cn in "${child_nums[@]}"; do
+		# Skip self-references
+		[[ "$_cn" == "$num" ]] && continue
+
+		if [[ "$DRY_RUN" == "true" ]]; then
+			print_info "[DRY-RUN] Would link #$_cn as ${_link_desc}"
+			linked=$((linked + 1))
+			continue
+		fi
+
+		# Lazy-resolve parent node ID (once, on first real link)
+		if [[ -z "$parent_node" ]]; then
+			parent_node=$(_cached_node_id "$num" "$repo")
+			if [[ -z "$parent_node" ]]; then
+				log_verbose "#$num: could not resolve parent node ID"
+				echo "${_skip_tag} $num:0"
+				return 0
+			fi
+		fi
+
+		local child_node
+		child_node=$(_cached_node_id "$_cn" "$repo")
+		if [[ -z "$child_node" ]]; then
+			log_verbose "#$_cn: could not resolve child node ID for parent #$num"
+			continue
+		fi
+
+		if _gh_add_sub_issue "$parent_node" "$child_node"; then
+			log_verbose "#$_cn linked as ${_link_desc}"
+			linked=$((linked + 1))
+		fi
+	done
+
+	if [[ "$DRY_RUN" == "true" ]]; then
+		echo "PARENT_DRY $num:$linked"
+	else
+		echo "PARENT_LINKED $num:$linked"
+	fi
 	return 0
 }
 
@@ -733,16 +891,35 @@ cmd_backfill_sub_issues() {
 	print_info "Backfilling sub-issue links for $total issue(s) in $repo"
 
 	local linked=0 skipped=0 processed=0
-	local _num result
+	local _num result meta _title _body _has_parent _pcount
 	for _num in "${issue_numbers[@]}"; do
 		processed=$((processed + 1))
 		if [[ $((processed % 25)) -eq 0 || $processed -eq $total ]]; then
 			printf "\r  Progress: %d/%d issues..." "$processed" "$total" >&2
 		fi
-		result=$(_backfill_one_issue "$_num" "$repo" | tail -1)
+
+		# Pre-fetch issue data (title, body, labels) for routing (GH#19942).
+		# A single API call per issue avoids double-fetch in both paths.
+		meta=$(gh issue view "$_num" --repo "$repo" --json title,body,labels 2>/dev/null || echo "{}")
+		_title=$(printf '%s' "$meta" | jq -r '.title // ""' 2>/dev/null)
+		_body=$(printf '%s' "$meta" | jq -r '.body // ""' 2>/dev/null)
+		_has_parent=$(printf '%s' "$meta" | jq -r '[.labels[].name] | any(. == "parent-task")' 2>/dev/null || echo "false")
+
+		if [[ "$_has_parent" == "true" ]]; then
+			# Parent-side: parse body for children section and link downward
+			result=$(_backfill_parent_children "$_num" "$repo" "$_body" | tail -1)
+		else
+			# Child-side: detect parent from title/body and link upward
+			result=$(_backfill_one_issue "$_num" "$repo" "$_title" "$_body" | tail -1)
+		fi
+
 		case "$result" in
 		LINKED*) linked=$((linked + 1)) ;;
 		DRY*) linked=$((linked + 1)) ;;
+		PARENT_LINKED*|PARENT_DRY*)
+			_pcount="${result##*:}"
+			linked=$((linked + _pcount))
+			;;
 		*) skipped=$((skipped + 1)) ;;
 		esac
 	done

--- a/.agents/scripts/tests/test-backfill-sub-issues.sh
+++ b/.agents/scripts/tests/test-backfill-sub-issues.sh
@@ -129,7 +129,13 @@ _emit() {
 if [[ "$cmd1" == "issue" && "$cmd2" == "view" ]]; then
 	num="${3:-}"
 	var="GH_ISSUE_${num}_JSON"
-	payload="${!var:-{\"title\":\"\",\"body\":\"\",\"labels\":[]}}"
+	# Avoid ${!var:-{...}} — bash indirect expansion has a brace-matching
+	# bug that appends an extra } when the variable IS set and the default
+	# contains { (GH#19942 test discovery).
+	payload="${!var}"
+	if [[ -z "$payload" ]]; then
+		payload='{"title":"","body":"","labels":[]}'
+	fi
 	_emit "$payload" "$@"
 	exit 0
 fi
@@ -212,6 +218,14 @@ _init_cmd() {
 	_CMD_TODO="${FAKE_PROJECT_ROOT}/TODO.md"
 	return 0
 }
+
+# Pre-initialize node ID cache to prevent EXIT trap chaining.
+# _init_node_id_cache's trap chains the parent's EXIT trap into subshells;
+# on bash 5.x, subshells inherit EXIT traps, so when $(cmd | tail -1) exits,
+# the chained trap fires and deletes $TMP prematurely. Pre-initializing the
+# cache file skips the trap setup entirely (the guard checks -z).
+_NODE_ID_CACHE_FILE="${TMP}/node_cache"
+: >"$_NODE_ID_CACHE_FILE"
 
 printf '%sRunning backfill-sub-issues tests (t2114)%s\n' "$TEST_BLUE" "$TEST_NC"
 
@@ -370,6 +384,166 @@ if grep -q 'Linked: 0' "${TMP}/out.11"; then
 else
 	fail "no parent detected → Linked: 0, no mutation" \
 		"missing 'Linked: 0' in output: $(tr '\n' '|' <"${TMP}/out.11" | head -c 200)"
+fi
+
+# =============================================================================
+# Class C: Parent-side detection — _extract_children_section,
+#           _extract_child_references, _backfill_parent_children (GH#19942)
+# =============================================================================
+
+printf '\n%sRunning parent-side detection tests (GH#19942)%s\n' "$TEST_BLUE" "$TEST_NC"
+
+# ---- Test 12: _extract_children_section extracts ## Children section ----
+_test_body_12="## Summary
+Some overview text
+
+## Children
+
+- #301 — first child
+- #302 — second child
+| LOW | t2350 | #303 | third child |
+
+## Related
+
+See #9999 in prose"
+
+section_12=$(_extract_children_section "$_test_body_12")
+if printf '%s' "$section_12" | grep -q '#301' && printf '%s' "$section_12" | grep -q '#303'; then
+	if ! printf '%s' "$section_12" | grep -q '#9999'; then
+		pass "_extract_children_section extracts ## Children, excludes ## Related"
+	else
+		fail "_extract_children_section extracts ## Children, excludes ## Related" \
+			"section leaked #9999 from ## Related"
+	fi
+else
+	fail "_extract_children_section extracts ## Children, excludes ## Related" \
+		"section missing expected references: $(printf '%s' "$section_12" | tr '\n' '|' | head -c 200)"
+fi
+
+# ---- Test 13: _extract_children_section matches aliases (case-insensitive) ----
+_test_body_13="## sub-issues
+
+- #401 — sub one
+- #402 — sub two"
+
+section_13=$(_extract_children_section "$_test_body_13")
+if printf '%s' "$section_13" | grep -q '#401'; then
+	pass "_extract_children_section matches ## sub-issues alias (case-insensitive)"
+else
+	fail "_extract_children_section matches ## sub-issues alias (case-insensitive)" \
+		"got: $(printf '%s' "$section_13" | tr '\n' '|' | head -c 200)"
+fi
+
+# ---- Test 14: _extract_child_references extracts list and table refs ----
+_test_section_14="
+- #301 — first child
+- t2350 / #302 — second child
+| LOW | t2350 | #303 | third child |
+| --- | --- | --- | --- |
+some prose with #9999 that is not in a list or table"
+
+refs_14=$(_extract_child_references "$_test_section_14")
+if printf '%s\n' "$refs_14" | grep -q '^301$' && \
+   printf '%s\n' "$refs_14" | grep -q '^302$' && \
+   printf '%s\n' "$refs_14" | grep -q '^303$'; then
+	if ! printf '%s\n' "$refs_14" | grep -q '^9999$'; then
+		pass "_extract_child_references extracts list/table refs, rejects prose"
+	else
+		fail "_extract_child_references extracts list/table refs, rejects prose" \
+			"extracted #9999 from prose line"
+	fi
+else
+	fail "_extract_child_references extracts list/table refs, rejects prose" \
+		"missing expected refs: $(printf '%s' "$refs_14" | tr '\n' ',' | head -c 200)"
+fi
+
+# ---- Test 15: _extract_child_references handles GH#NNN format ----
+_test_section_15="- GH#501 — issue with GH prefix
+- #502 — normal ref"
+
+refs_15=$(_extract_child_references "$_test_section_15")
+if printf '%s\n' "$refs_15" | grep -q '^501$' && \
+   printf '%s\n' "$refs_15" | grep -q '^502$'; then
+	pass "_extract_child_references handles GH#NNN format"
+else
+	fail "_extract_child_references handles GH#NNN format" \
+		"got: $(printf '%s' "$refs_15" | tr '\n' ',' | head -c 200)"
+fi
+
+# ---- Test 16: cmd_backfill_sub_issues with parent-task issue (dry-run) ----
+# Umbrella parent #300 with ## Children section listing 3 children
+export GH_ISSUE_300_JSON='{"title":"t2349: umbrella parent","body":"## Summary\nOverview\n\n## Children\n\n- #301 — first child\n- #302 — second child\n| LOW | t2350 | #303 | third child |\n\nSee #9999 in prose","labels":[{"name":"parent-task"},{"name":"enhancement"}]}'
+export GH_ISSUE_301_JSON='{"title":"t2349.1: first child","body":"","labels":[]}'
+export GH_ISSUE_302_JSON='{"title":"t2349.2: second child","body":"","labels":[]}'
+export GH_ISSUE_303_JSON='{"title":"t2350: third child","body":"","labels":[]}'
+
+: >"$GH_LOG"
+DRY_RUN="true" cmd_backfill_sub_issues --issue 300 >"${TMP}/out.16" 2>&1 || true
+DRY_RUN="false"
+
+# Should report 3 children would be linked
+count_16=$(grep -c 'Would link.*sub-issue of #300 (parent-side)' "${TMP}/out.16" 2>/dev/null) || count_16=0
+if [[ "$count_16" -eq 3 ]]; then
+	if ! grep -q 'addSubIssue' "$GH_LOG"; then
+		pass "parent-side dry-run reports 3 children, no mutation"
+	else
+		fail "parent-side dry-run reports 3 children, no mutation" \
+			"unexpected addSubIssue in gh.log"
+	fi
+else
+	fail "parent-side dry-run reports 3 children, no mutation" \
+		"expected 3 'Would link' lines, got $count_16; output: $(tr '\n' '|' <"${TMP}/out.16" | head -c 300)"
+fi
+
+# ---- Test 17: cmd_backfill_sub_issues with parent-task issue (live) ----
+: >"$GH_LOG"
+cmd_backfill_sub_issues --issue 300 >"${TMP}/out.17" 2>&1 || true
+
+add_count_17=$(grep -c 'addSubIssue' "$GH_LOG" 2>/dev/null) || add_count_17=0
+if [[ "$add_count_17" -eq 3 ]]; then
+	pass "parent-side live run calls addSubIssue 3 times"
+else
+	fail "parent-side live run calls addSubIssue 3 times" \
+		"expected 3 addSubIssue calls, got $add_count_17; log: $(tr '\n' '|' <"$GH_LOG" | head -c 300)"
+fi
+
+# ---- Test 18: prose #NNN outside ## Children does NOT produce false link ----
+# The body has "See #9999 in prose" outside the Children section
+if ! grep -q '9999' "$GH_LOG"; then
+	pass "prose #9999 outside Children section not linked"
+else
+	fail "prose #9999 outside Children section not linked" \
+		"found 9999 reference in gh.log (false positive)"
+fi
+
+# ---- Test 19: parent-task issue without ## Children section → Linked: 0 ----
+export GH_ISSUE_304_JSON='{"title":"t2351: parent no children","body":"Just a regular parent\n\nSee #305 in prose","labels":[{"name":"parent-task"}]}'
+
+: >"$GH_LOG"
+cmd_backfill_sub_issues --issue 304 >"${TMP}/out.19" 2>&1 || true
+
+if grep -q 'Linked: 0' "${TMP}/out.19"; then
+	if ! grep -q 'addSubIssue' "$GH_LOG"; then
+		pass "parent-task without Children section → Linked: 0, no mutation"
+	else
+		fail "parent-task without Children section → Linked: 0, no mutation" \
+			"unexpected addSubIssue in gh.log"
+	fi
+else
+	fail "parent-task without Children section → Linked: 0, no mutation" \
+		"missing 'Linked: 0' in output: $(tr '\n' '|' <"${TMP}/out.19" | head -c 200)"
+fi
+
+# ---- Test 20: existing child-side detection still works with pre-fetched data ----
+# Issue #200 is a t1873.2 child (set up in Class B fixtures above)
+: >"$GH_LOG"
+cmd_backfill_sub_issues --issue 200 >"${TMP}/out.20" 2>&1 || true
+
+if grep -q 'addSubIssue' "$GH_LOG"; then
+	pass "child-side detection still works through pre-fetch routing (regression)"
+else
+	fail "child-side detection still works through pre-fetch routing (regression)" \
+		"missing addSubIssue in gh.log: $(tr '\n' '|' <"$GH_LOG" | head -c 200)"
 fi
 
 # =============================================================================


### PR DESCRIPTION
## Summary

- Add parent-side detection to `backfill-sub-issues`: when an issue carries the `parent-task` label, parse its body for a `## Children` section (aliases: `## Child Issues`, `## Sub-issues`, `## Phases`) and link every `#NNN` / `GH#NNN` reference found in list items or table cells as a sub-issue via the GitHub sub_issues API.
- Complement the existing child-side detection path (dot-notation, `Parent:` line, `Blocked by:` with parent-task label) with parent-side detection for umbrella-style parents.
- Optimize API calls by pre-fetching title/body/labels once per issue in the outer loop, eliminating redundant `gh issue view` calls.

## Changes

### `.agents/scripts/issue-sync-relationships.sh`
- **New function `_extract_children_section`** — awk-based parser that extracts content between a children heading and the next `##` heading, case-insensitive matching of 4 heading aliases.
- **New function `_extract_child_references`** — extracts `#NNN` / `GH#NNN` from lines starting with list markers (`-`, `+`, `*`) or table cells (`|`), rejecting prose mentions. Deduplicated and sorted.
- **New function `_backfill_parent_children`** — links children found in parent body section. Handles dry-run, lazy node ID resolution, self-reference skipping, bash 3.2 compatibility.
- **Modified `_backfill_one_issue`** — accepts optional pre-fetched title/body via new `prefetched_title`/`prefetched_body` parameters to avoid double-fetch.
- **Modified `cmd_backfill_sub_issues`** — pre-fetches title/body/labels in one API call per issue, routes to parent-side or child-side path based on `parent-task` label.

### `.agents/scripts/issue-sync-helper.sh`
- Updated docstring to document both child-side and parent-side detection paths.

### `.agents/scripts/tests/test-backfill-sub-issues.sh`
- **9 new Class C tests** covering: section extraction, alias matching, list/table ref extraction, GH#NNN format, parent-side dry-run/live, prose false-positive rejection, parent without children section, child-side regression through pre-fetch routing.
- Fix bash 3.2 brace-matching bug in indirect expansion (`${!var:-{...}}` appends extra `}`).
- Pre-initialize node ID cache to prevent EXIT trap chaining in subshell pipelines.

## Verification

- ShellCheck: 0 new violations (2 pre-existing SC2016 info-level on GraphQL strings)
- All 21 tests pass: 12 existing (Class A + B) + 9 new (Class C)
- Pre-commit quality gate: passed (ratchet-clean)

Resolves #19942

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.78 plugin for [OpenCode](https://opencode.ai) v1.14.18 with claude-opus-4-6 spent 8m and 10,174 tokens on this as a headless worker.