### PR TITLE
t2395: fix(maintainer-gate): extend assignee-exemption to cover source:* automation-authored issues

### DIFF
--- a/.github/workflows/maintainer-gate.yml
+++ b/.github/workflows/maintainer-gate.yml
@@ -277,13 +277,17 @@ jobs:
             fi
 
             # Check 2: no assignee
-            # Exempt only when BOTH conditions hold (GH#6623, GH#18197):
-            #   a) Issue was created by github-actions[bot] — immutable, cannot be spoofed
-            #   b) PR author is OWNER or MEMBER (maintainer-tier only).
+            # Exempt when BOTH conditions hold (GH#6623, GH#18197, GH#19956):
+            #   1) PR author is OWNER or MEMBER (maintainer-tier only).
             #      COLLABORATOR is excluded — write-access contributors must have the
             #      issue explicitly assigned before their PR passes the gate.
             #      On personal repos there are no MEMBERs, so effectively OWNER-only.
-            # Either condition alone is insufficient.
+            #   2) AND one of:
+            #      a) Issue was created by github-actions[bot] — immutable, cannot be spoofed, OR
+            #      b) Issue carries a source:* automation label (non-spoofable — only the
+            #         pulse process running with the repo owner's token can apply these
+            #         labels at issue-creation time; contributors cannot self-label).
+            # Neither the PR author check nor the origin signal alone is sufficient.
             if [[ -z "$ASSIGNEES" ]]; then
               PR_AUTHOR_IS_MAINTAINER=false
               if [[ "$PR_AUTHOR_ASSOCIATION" == "OWNER" ]] || \
@@ -291,12 +295,24 @@ jobs:
                 PR_AUTHOR_IS_MAINTAINER=true
               fi
 
-              if [[ "$ISSUE_AUTHOR" == "github-actions[bot]" ]] && [[ "$PR_AUTHOR_IS_MAINTAINER" == "true" ]]; then
-                echo "EXEMPT: Issue #$ISSUE_NUM created by github-actions[bot] and PR author is maintainer (OWNER/MEMBER) — assignee check skipped"
+              HAS_AUTOMATION_LABEL=false
+              for automation_label in \
+                "source:review-scanner" "source:review-feedback" "source:ci-feedback" \
+                "source:ci-failure-miner" "source:conflict-feedback" "source:quality-debt" \
+                "source:post-merge-review-scanner"; do
+                if echo "$LABELS" | grep -qxF "$automation_label"; then
+                  HAS_AUTOMATION_LABEL=true
+                  break
+                fi
+              done
+
+              if [[ "$PR_AUTHOR_IS_MAINTAINER" == "true" ]] && \
+                 { [[ "$ISSUE_AUTHOR" == "github-actions[bot]" ]] || [[ "$HAS_AUTOMATION_LABEL" == "true" ]]; }; then
+                echo "EXEMPT: Issue #$ISSUE_NUM (issue_author=$ISSUE_AUTHOR, automation_label=$HAS_AUTOMATION_LABEL, pr_author=$PR_AUTHOR_ASSOCIATION) — assignee check skipped"
               else
                 BLOCKED=true
                 REASONS="${REASONS}Issue #${ISSUE_NUM} has no assignee — an issue must be assigned before work begins.\n"
-                echo "BLOCKED: Issue #$ISSUE_NUM has no assignee (issue_author=$ISSUE_AUTHOR, pr_author_association=$PR_AUTHOR_ASSOCIATION)"
+                echo "BLOCKED: Issue #$ISSUE_NUM has no assignee (issue_author=$ISSUE_AUTHOR, automation_label=$HAS_AUTOMATION_LABEL, pr_author_association=$PR_AUTHOR_ASSOCIATION)"
               fi
             fi
           done


### PR DESCRIPTION
## Summary

Extends Check 2 (no-assignee gate) in `maintainer-gate.yml` to exempt issues carrying `source:*` automation labels when the PR author is OWNER/MEMBER — closing a systemic class of worker PR failures.

Resolves #19956

## What changed

**EDIT**: `.github/workflows/maintainer-gate.yml` — Check 2 block (lines 279–317)

- Added `HAS_AUTOMATION_LABEL` detection loop that checks for any of 7 predefined `source:*` labels: `source:review-scanner`, `source:review-feedback`, `source:ci-feedback`, `source:ci-failure-miner`, `source:conflict-feedback`, `source:quality-debt`, `source:post-merge-review-scanner`
- Modified the exemption condition: `PR_AUTHOR_IS_MAINTAINER AND (bot-author OR automation-label)` — either origin signal qualifies, but the maintainer check is always required
- Updated comment block to document the extended exemption path and its security reasoning
- Enhanced log messages to include `automation_label` state for debugging

## Why

Pulse scanners run as the repo **owner** (`marcusquinn`), not `github-actions[bot]`. The existing exemption only checked `ISSUE_AUTHOR == "github-actions[bot]"`, so every scanner-filed issue (`source:review-scanner`, `source:ci-feedback`, etc.) failed Check 2 when the worker's self-assignment was cleared during cleanup. 9+ worker PRs were closed-unmerged in a single day (#19944, #19940, #19934, #19903, #19897, #19895, #19888, #19887, #19879).

## Security reasoning

`source:*` labels are non-spoofable: only the pulse process (running with the repo owner's token) can apply them at issue-creation time. Contributors cannot self-label. Even if they could, `PR_AUTHOR_IS_MAINTAINER` remains required — label alone is insufficient.

## Testing

- `actionlint .github/workflows/maintainer-gate.yml` passes clean
- `grep -qxF` ensures exact line match — no partial label collisions
- Backwards compat: existing `github-actions[bot]` exemption path is preserved unchanged
- Security: COLLABORATOR PRs still blocked even with `source:*` labels present

## MERGE_SUMMARY

**Change**: Extended maintainer-gate Check 2 assignee exemption to recognize `source:*` automation labels alongside `github-actions[bot]` authorship. Both paths require `PR_AUTHOR_IS_MAINTAINER`.

**Impact**: Worker PRs for scanner-filed issues (review-followup, ci-feedback, quality-debt) will now pass the assignee gate when the issue carries any `source:*` label, eliminating the #1 cause of closed-unmerged worker PRs.

**Risk**: Low — additive change, existing paths preserved, security gate (OWNER/MEMBER check) unchanged.