### PR TITLE
t2404: feat(auto-update): loginctl enable-linger guidance for Linux systemd

### DIFF
--- a/.agents/reference/auto-update.md
+++ b/.agents/reference/auto-update.md
@@ -12,7 +12,21 @@ Polls GitHub every 10 min; runs `aidevops update` on new version. Safe during ac
 - **Linux (preferred)**: systemd user timer (`~/.config/systemd/user/aidevops-auto-update.timer` + `.service`). Selected by `_detect_linux_scheduler` when `systemctl --user` is available — this is the default on most modern Linux desktops and servers.
 - **Linux (fallback)**: cron (crontab entry with `# aidevops-auto-update` marker). Used when `systemctl --user` is unavailable (e.g., containers without systemd).
 
-Note: linger configuration (enabling systemd user services to run without an active login session) is a separate concern — see t2404 once it lands.
+## Linux systemd: logout persistence (linger)
+
+On Linux hosts using the systemd backend, the auto-update timer runs inside the **user** systemd manager. By default, the user manager stops when your last session ends — taking the timer with it.
+
+**When you need linger**: always on servers and headless hosts where you SSH in, run `aidevops auto-update enable`, then log out. Without linger, the timer fires only while you're logged in.
+
+**When you don't need it**: laptops or desktops where a graphical session is always running.
+
+**Enable once** (requires sudo):
+
+```bash
+sudo loginctl enable-linger $USER
+```
+
+Check current state: `aidevops auto-update status` shows a `Linger: yes|no` row on systemd hosts.
 
 **Disable**: `aidevops auto-update disable`, `"auto_update": false` in settings.json, or `AIDEVOPS_AUTO_UPDATE=false`. Priority: env > settings.json > default (`true`). **Logs**: `~/.aidevops/logs/auto-update.log`
 

--- a/.agents/scripts/auto-update-helper.sh
+++ b/.agents/scripts/auto-update-helper.sh
@@ -1689,20 +1689,7 @@ WantedBy=timers.target
 	echo "  Check now:    aidevops auto-update check"
 	echo ""
 	# Check linger state so the timer survives logout on headless/server Linux hosts.
-	# Skip for root (linger irrelevant) and when loginctl is absent (containers).
-	if [[ "${USER:-}" != "root" ]] && command -v loginctl &>/dev/null; then
-		local _linger_state _linger_cmd
-		_linger_state=$(loginctl show-user "$USER" -p Linger --value 2>/dev/null || true)
-		_linger_cmd="sudo loginctl enable-linger $USER"
-		if [[ "$_linger_state" == "yes" ]]; then
-			echo -e "  Linger:    ${GREEN}enabled${NC} (timer runs when logged out)"
-		elif [[ "$_linger_state" == "no" ]]; then
-			echo -e "  Linger:    ${YELLOW}disabled${NC} — timer stops when you log out" >&2
-			echo -e "  ${YELLOW}  Enable with: ${_linger_cmd}${NC}" >&2
-		else
-			echo -e "  Linger:    ${YELLOW}unknown${NC} — run: ${_linger_cmd}" >&2
-		fi
-	fi
+	_print_linger_status
 	return 0
 }
 
@@ -1900,6 +1887,29 @@ cmd_disable() {
 }
 
 #######################################
+# Print linger status row for systemd user timer.
+# Linger allows the user manager to keep running after logout.
+# Skips silently when loginctl is absent (containers) or when user is root.
+# Args: none. Reads $USER from environment.
+# Returns: 0
+#######################################
+_print_linger_status() {
+	[[ "${USER:-}" == "root" ]] && return 0
+	command -v loginctl &>/dev/null || return 0
+	local _linger_state _linger_cmd
+	_linger_state=$(loginctl show-user "$USER" -p Linger --value 2>/dev/null || true)
+	_linger_cmd="sudo loginctl enable-linger $USER"
+	if [[ "$_linger_state" == "yes" ]]; then
+		echo -e "  Linger:    ${GREEN}yes${NC}"
+	elif [[ "$_linger_state" == "no" ]]; then
+		echo -e "  Linger:    ${YELLOW}no${NC} — timer stops on logout; fix: ${_linger_cmd}"
+	else
+		echo -e "  Linger:    ${YELLOW}unknown${NC} — run: ${_linger_cmd}"
+	fi
+	return 0
+}
+
+#######################################
 # Print scheduler section of status output (launchd, systemd, or cron)
 # Args: $1 = backend ("launchd", "systemd", or "cron")
 #######################################
@@ -1963,19 +1973,7 @@ _cmd_status_scheduler() {
 			fi
 			echo "  Timer:     ${SYSTEMD_SERVICE_DIR}/${SYSTEMD_UNIT_NAME}.timer"
 			echo "  Service:   ${SYSTEMD_SERVICE_DIR}/${SYSTEMD_UNIT_NAME}.service"
-			# Linger row — required for timer to survive logout
-			if [[ "${USER:-}" != "root" ]] && command -v loginctl &>/dev/null; then
-				local _linger_state _linger_cmd
-				_linger_state=$(loginctl show-user "$USER" -p Linger --value 2>/dev/null || true)
-				_linger_cmd="sudo loginctl enable-linger $USER"
-				if [[ "$_linger_state" == "yes" ]]; then
-					echo -e "  Linger:    ${GREEN}yes${NC}"
-				elif [[ "$_linger_state" == "no" ]]; then
-					echo -e "  Linger:    ${YELLOW}no${NC} — timer stops on logout; fix: ${_linger_cmd}"
-				else
-					echo -e "  Linger:    ${YELLOW}unknown${NC} — run: ${_linger_cmd}"
-				fi
-			fi
+			_print_linger_status
 		fi
 		# Also check for any lingering cron entry
 		if crontab -l 2>/dev/null | grep -q "$CRON_MARKER"; then

--- a/.agents/scripts/auto-update-helper.sh
+++ b/.agents/scripts/auto-update-helper.sh
@@ -1687,6 +1687,22 @@ WantedBy=timers.target
 	echo ""
 	echo "  Disable with: aidevops auto-update disable"
 	echo "  Check now:    aidevops auto-update check"
+	echo ""
+	# Check linger state so the timer survives logout on headless/server Linux hosts.
+	# Skip for root (linger irrelevant) and when loginctl is absent (containers).
+	if [[ "${USER:-}" != "root" ]] && command -v loginctl &>/dev/null; then
+		local _linger_state _linger_cmd
+		_linger_state=$(loginctl show-user "$USER" -p Linger --value 2>/dev/null || true)
+		_linger_cmd="sudo loginctl enable-linger $USER"
+		if [[ "$_linger_state" == "yes" ]]; then
+			echo -e "  Linger:    ${GREEN}enabled${NC} (timer runs when logged out)"
+		elif [[ "$_linger_state" == "no" ]]; then
+			echo -e "  Linger:    ${YELLOW}disabled${NC} — timer stops when you log out" >&2
+			echo -e "  ${YELLOW}  Enable with: ${_linger_cmd}${NC}" >&2
+		else
+			echo -e "  Linger:    ${YELLOW}unknown${NC} — run: ${_linger_cmd}" >&2
+		fi
+	fi
 	return 0
 }
 
@@ -1947,6 +1963,19 @@ _cmd_status_scheduler() {
 			fi
 			echo "  Timer:     ${SYSTEMD_SERVICE_DIR}/${SYSTEMD_UNIT_NAME}.timer"
 			echo "  Service:   ${SYSTEMD_SERVICE_DIR}/${SYSTEMD_UNIT_NAME}.service"
+			# Linger row — required for timer to survive logout
+			if [[ "${USER:-}" != "root" ]] && command -v loginctl &>/dev/null; then
+				local _linger_state _linger_cmd
+				_linger_state=$(loginctl show-user "$USER" -p Linger --value 2>/dev/null || true)
+				_linger_cmd="sudo loginctl enable-linger $USER"
+				if [[ "$_linger_state" == "yes" ]]; then
+					echo -e "  Linger:    ${GREEN}yes${NC}"
+				elif [[ "$_linger_state" == "no" ]]; then
+					echo -e "  Linger:    ${YELLOW}no${NC} — timer stops on logout; fix: ${_linger_cmd}"
+				else
+					echo -e "  Linger:    ${YELLOW}unknown${NC} — run: ${_linger_cmd}"
+				fi
+			fi
 		fi
 		# Also check for any lingering cron entry
 		if crontab -l 2>/dev/null | grep -q "$CRON_MARKER"; then
@@ -2149,6 +2178,9 @@ SCHEDULER BACKENDS:
             - Auto-migrates existing cron entries on first 'enable'
     Linux:  systemd user timer preferred (~/.config/systemd/user/aidevops-auto-update.timer)
             - Falls back to cron when systemctl --user is unavailable
+            - Requires loginctl enable-linger $USER to run when logged out
+            - Without linger, the timer stops when your last session ends
+            - See 'aidevops auto-update status' for current linger state
     Linux:  cron fallback (crontab entry with # aidevops-auto-update marker)
 
 HOW IT WORKS:

--- a/setup-modules/post-setup.sh
+++ b/setup-modules/post-setup.sh
@@ -37,6 +37,16 @@ setup_auto_update() {
 			# Non-interactive: enable silently
 			bash "$auto_update_script" enable >/dev/null 2>&1 || true
 			print_info "Auto-update enabled (every 10 min). Disable: aidevops auto-update disable"
+			# On Linux systemd, advise about linger without running sudo automatically.
+			if [[ "$(uname -s)" == "Linux" ]] && [[ "${USER:-}" != "root" ]] \
+				&& command -v loginctl &>/dev/null; then
+				local _linger_state
+				_linger_state=$(loginctl show-user "$USER" -p Linger --value 2>/dev/null || true)
+				if [[ "$_linger_state" != "yes" ]]; then
+					echo "[INFO] Linux systemd: enable linger so auto-update runs when logged out:" >&2
+					echo "[INFO]   sudo loginctl enable-linger $USER" >&2
+				fi
+			fi
 		else
 			echo ""
 			echo "Auto-update keeps aidevops current by checking every 10 minutes."
@@ -45,6 +55,29 @@ setup_auto_update() {
 			setup_prompt enable_auto "Enable auto-update? [Y/n]: " "Y"
 			if [[ "$enable_auto" =~ ^[Yy]?$ ]]; then
 				bash "$auto_update_script" enable
+				# On Linux systemd hosts, offer to enable linger so the timer survives logout.
+				# Skip for root (irrelevant), WSL/container (loginctl may be absent or stub),
+				# and when the backend didn't resolve to systemd.
+				if [[ "$(uname -s)" == "Linux" ]] \
+					&& [[ "${USER:-}" != "root" ]] \
+					&& command -v loginctl &>/dev/null \
+					&& systemctl --user is-enabled aidevops-auto-update.timer &>/dev/null 2>&1; then
+					local _linger_state
+					_linger_state=$(loginctl show-user "$USER" -p Linger --value 2>/dev/null || true)
+					if [[ "$_linger_state" != "yes" ]]; then
+						echo ""
+						echo "Without linger, the auto-update timer stops when you log out."
+						echo "On servers and headless hosts, linger is almost always required."
+						local enable_linger=""
+					setup_prompt enable_linger "Enable linger so auto-update runs when logged out? Requires sudo. [Y/n]: " "Y"
+						if [[ "$enable_linger" =~ ^[Yy]?$ ]]; then
+							sudo loginctl enable-linger "$USER"
+							print_success "Linger enabled for $USER"
+						else
+							print_info "Skipped. Enable later: sudo loginctl enable-linger $USER"
+						fi
+					fi
+				fi
 			else
 				print_info "Skipped. Enable later: aidevops auto-update enable"
 			fi


### PR DESCRIPTION
## Summary

Closes the linger gap for Linux systemd auto-update — the most likely cause of a Linux user's auto-update silently not running after logout.

Builds on t2403 (merged in #19984) which added the systemd backend and status branch.

## Changes

### `.agents/scripts/auto-update-helper.sh`

- **`_print_linger_status`** (new helper): extracts linger check into a single function called by both `_cmd_enable_systemd` and `_cmd_status_scheduler`, reducing nesting depth and duplication. Queries `loginctl show-user $USER -p Linger --value`. Skips root and hosts without `loginctl` (containers, WSL stubs).
- **`_cmd_enable_systemd`**: calls `_print_linger_status` after timer enable. Prints GREEN when linger enabled, YELLOW when disabled with remediation command.
- **`_cmd_status_scheduler`**: the systemd branch (added by t2403) now includes a `Linger: yes|no` row via `_print_linger_status`.
- **`cmd_help` SCHEDULER BACKENDS**: adds 3 lines explaining the `loginctl enable-linger` requirement for the systemd backend.

### `setup-modules/post-setup.sh`

- **Interactive path**: after enabling the timer on Linux systemd, checks linger state and prompts "Enable linger so auto-update runs when logged out? Requires sudo. [Y/n]". Runs `sudo loginctl enable-linger $USER` on yes. Skips when already enabled, root user, or `loginctl` absent.
- **Non-interactive path**: prints advisory to stderr only — does NOT run sudo automatically.

### `.agents/reference/auto-update.md`

New "Linux systemd: logout persistence (linger)" subsection: when needed, when not, and the one-liner. Kept t2403's richer three-backend scheduler description.

## Edge cases handled

- Containers without `systemd-logind`: `loginctl` absent → function silently returns, no crash
- Root user: linger irrelevant → skipped entirely
- WSL2 with logind stub: blank/error → prints unknown advisory
- macOS: all linger code is Linux-only (uname/loginctl guards)

## Verification

- Pre-commit quality gate: passed (shellcheck ratchet, string literal ratchet)
- `shellcheck .agents/scripts/auto-update-helper.sh` — no new violations
- `shellcheck setup-modules/post-setup.sh` — no new violations
- Rebased on current main (includes t2403)

Resolves #19976