### PR TITLE
t2401: feat(dispatch-claim): version-gated override filter (self-sunsetting companion to t2400)

### DIFF
--- a/.agents/configs/dispatch-override.conf.txt
+++ b/.agents/configs/dispatch-override.conf.txt
@@ -3,16 +3,26 @@
 # Copy to ~/.config/aidevops/dispatch-override.conf and edit.
 #
 # This file is sourced by dispatch-claim-helper.sh to filter DISPATCH_CLAIM
-# comments from specific peer runners. Useful when a peer is known to be
-# degraded — e.g., running stale code, fast-failing every dispatch, or
-# version-skewed after a hotfix — and their stale claim comments are
-# poisoning cross-runner dispatch for the full 1800s TTL.
+# comments from peer runners when the peer is known to be degraded — e.g.,
+# running stale code, fast-failing every dispatch, or version-skewed after a
+# hotfix — and their stale claim comments are poisoning cross-runner dispatch
+# for the full 1800s TTL.
 #
-# Self-correcting: once the peer recovers, remove them from the list. For
-# automated management based on worker success-rate comparison, see t2401
+# Two composable filters:
+#
+#   1. Login-gated (t2400): DISPATCH_CLAIM_IGNORE_RUNNERS — strip claims from
+#      named GitHub logins. Requires manual removal when the peer recovers.
+#
+#   2. Version-gated (t2401): DISPATCH_CLAIM_MIN_VERSION — strip claims whose
+#      framework version is below the configured semver floor. Self-sunsetting:
+#      once the peer upgrades to >= floor, their claims pass the filter
+#      automatically (no operator action needed). Pre-t2401 claims (with no
+#      version field) are treated as "unknown" and always below any floor.
+#
+# For automated management based on worker success-rate comparison, see t2402
 # (supervisor-dashboard-driven auto-override).
 #
-# Safety: the filter is UNIDIRECTIONAL. If only your runner filters the peer,
+# Safety: filters are UNIDIRECTIONAL. If only your runner filters the peer,
 # your dispatch wins the claim race and the peer backs off normally (no
 # double-dispatch). If BOTH runners filter each other, double-dispatch is
 # possible — intended for temporary, unilateral use during peer-degraded
@@ -23,6 +33,13 @@
 # Example: DISPATCH_CLAIM_IGNORE_RUNNERS="stale-peer1 stale-peer2"
 DISPATCH_CLAIM_IGNORE_RUNNERS=""
 
-# Master switch for the override. Set to false to keep the config file in
+# Semver floor for the version-gated filter (t2401). Claims with a version
+# strictly below this floor are stripped. Pre-t2401 claims have no version
+# field and are treated as "unknown" — always below any floor. Leave empty
+# to disable the version filter.
+# Example: DISPATCH_CLAIM_MIN_VERSION="3.9.0"
+DISPATCH_CLAIM_MIN_VERSION=""
+
+# Master switch for the overrides. Set to false to keep the config file in
 # place but temporarily respect all claims (useful during testing).
 DISPATCH_OVERRIDE_ENABLED=true

--- a/.agents/scripts/dispatch-claim-helper.sh
+++ b/.agents/scripts/dispatch-claim-helper.sh
@@ -54,29 +54,39 @@ DISPATCH_CLAIM_SELF_RECLAIM_AGE="${DISPATCH_CLAIM_SELF_RECLAIM_AGE:-30}"
 # Plain text format: visible in rendered GitHub issue view.
 CLAIM_MARKER="DISPATCH_CLAIM"
 
-# t2399: Runtime override for cross-runner dispatch coordination.
+# t2399/t2401: Runtime override for cross-runner dispatch coordination.
 #
 # Allows a local runner to ignore DISPATCH_CLAIMs from specific peer runners
-# when the peer is known to be degraded (running stale code, fast-failing,
-# version-skewed). Self-correcting: once the peer recovers, remove from the
-# list (or let the long-term stats-based auto-override in t2401 manage it).
+# or from runners running framework versions older than a configured floor.
+# Both filters are self-correcting: once the peer recovers or upgrades, the
+# filter auto-sunsets (version filter) or the operator removes the login
+# (t2399 login-gated filter).
 #
 # Config file (optional, user-level): ~/.config/aidevops/dispatch-override.conf
 #   DISPATCH_CLAIM_IGNORE_RUNNERS="login1 login2"  # space or comma separated
+#   DISPATCH_CLAIM_MIN_VERSION="3.8.78"            # semver floor; older claims ignored
 #   DISPATCH_OVERRIDE_ENABLED=true                 # default true when config exists
 #
-# Safety: filter is UNIDIRECTIONAL — if only one runner filters the other, the
-# filtered runner's claim-race still honours the filterer's claim (normal
+# Version field (t2401): claim bodies include version=X.Y.Z sourced from
+# ~/.aidevops/agents/VERSION. Legacy claims (pre-t2401) have no version field
+# and are treated as "unknown" — below any configured floor.
+#
+# Safety: filters are UNIDIRECTIONAL — if only one runner filters the other,
+# the filtered runner's claim-race still honours the filterer's claim (normal
 # dedup behaviour). If BOTH runners filter each other, double-dispatch is
 # possible. Intended for temporary, unilateral use during peer-degraded
 # incidents.
 DISPATCH_OVERRIDE_CONF="${DISPATCH_OVERRIDE_CONF:-${HOME}/.config/aidevops/dispatch-override.conf}"
 DISPATCH_CLAIM_IGNORE_RUNNERS="${DISPATCH_CLAIM_IGNORE_RUNNERS:-}"
+DISPATCH_CLAIM_MIN_VERSION="${DISPATCH_CLAIM_MIN_VERSION:-}"
 DISPATCH_OVERRIDE_ENABLED="${DISPATCH_OVERRIDE_ENABLED:-true}"
 if [[ -r "$DISPATCH_OVERRIDE_CONF" ]]; then
 	# shellcheck disable=SC1090
 	source "$DISPATCH_OVERRIDE_CONF" 2>/dev/null || true
 fi
+
+# t2401: Framework VERSION file location. Override for tests.
+AIDEVOPS_VERSION_FILE="${AIDEVOPS_VERSION_FILE:-${HOME}/.aidevops/agents/VERSION}"
 
 #######################################
 # Generate a unique nonce for this claim attempt.
@@ -139,6 +149,24 @@ _resolve_runner() {
 }
 
 #######################################
+# t2401: Resolve the framework version from AIDEVOPS_VERSION_FILE.
+# Returns: semver string on stdout, "unknown" when file is missing/empty.
+# Always exit 0 — claim emission must never fail on a missing VERSION file.
+#######################################
+_resolve_version() {
+	if [[ -r "$AIDEVOPS_VERSION_FILE" ]]; then
+		local ver
+		ver=$(head -n1 "$AIDEVOPS_VERSION_FILE" 2>/dev/null | tr -d '[:space:]')
+		if [[ -n "$ver" ]]; then
+			printf '%s' "$ver"
+			return 0
+		fi
+	fi
+	printf '%s' "unknown"
+	return 0
+}
+
+#######################################
 # Post a claim comment on a GitHub issue.
 # The comment is plain text — visible in rendered view.
 #
@@ -159,8 +187,12 @@ _post_claim() {
 	local nonce="$4"
 	local ts="$5"
 
+	# t2401: include framework version so peers can filter claims from older runners.
+	local version
+	version=$(_resolve_version)
+
 	local body
-	body="${CLAIM_MARKER} nonce=${nonce} runner=${runner} ts=${ts} max_age_s=${DISPATCH_CLAIM_MAX_AGE}"
+	body="${CLAIM_MARKER} nonce=${nonce} runner=${runner} ts=${ts} max_age_s=${DISPATCH_CLAIM_MAX_AGE} version=${version}"
 
 	local comment_id
 	comment_id=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
@@ -255,16 +287,19 @@ _fetch_claims() {
 		return 0
 	fi
 
-	# Parse claim fields from comment bodies and filter by max age
+	# Parse claim fields from comment bodies and filter by max age.
+	# t2401: version is an optional trailing field; legacy pre-t2401 claims
+	# lack it and parse as "unknown".
 	local parsed
 	parsed=$(printf '%s' "$claims_only" | jq -c --argjson now "$now_epoch" --argjson max_age "$DISPATCH_CLAIM_MAX_AGE" '
 		[.[] |
-			(.body | capture("nonce=(?<nonce>[^ ]+) runner=(?<runner>[^ ]+) ts=(?<ts>[^ ]+)")) as $fields |
+			(.body | capture("nonce=(?<nonce>[^ ]+) runner=(?<runner>[^ ]+) ts=(?<ts>[^ ]+)(?: max_age_s=[^ ]+)?(?: version=(?<version>[^ ]+))?")) as $fields |
 			{
 				id: .id,
 				nonce: $fields.nonce,
 				runner: $fields.runner,
 				ts: $fields.ts,
+				version: ($fields.version // "unknown"),
 				created_at: .created_at,
 				created_epoch: (.created_at | fromdateiso8601? // 0)
 			}
@@ -287,10 +322,93 @@ _fetch_claims() {
 }
 
 #######################################
-# t2400: Filter out DISPATCH_CLAIM entries authored by runners listed in
-# DISPATCH_CLAIM_IGNORE_RUNNERS. No-op when override is disabled or list is empty.
-# Emits a stderr log line when filter actually strips claims so operators
-# can audit active overrides.
+# t2401: Semver comparison — is $1 strictly less than $2?
+# Args: $1 = version (e.g., "3.8.78"), $2 = floor (e.g., "3.9.0")
+# Returns: exit 0 = version < floor (below), exit 1 = version >= floor
+# "unknown" or empty version is always below floor.
+#######################################
+_version_below() {
+	local version="${1:-}"
+	local floor="${2:-}"
+
+	# Treat missing/unknown as below any configured floor
+	if [[ -z "$version" || "$version" == "unknown" ]]; then
+		return 0
+	fi
+
+	# Equal versions are not strictly below
+	if [[ "$version" == "$floor" ]]; then
+		return 1
+	fi
+
+	# sort -V puts smaller semver first. If $version is first, it's below $floor.
+	local first
+	first=$(printf '%s\n%s\n' "$version" "$floor" | sort -V | head -n1)
+	if [[ "$first" == "$version" ]]; then
+		return 0
+	fi
+	return 1
+}
+
+#######################################
+# t2401: Filter out claim entries whose version is below DISPATCH_CLAIM_MIN_VERSION.
+# Legacy claims parsed as "unknown" are always filtered out when a floor is set.
+#
+# Args:
+#   $1 = parsed claims JSON array
+#   $2 = min version floor (semver)
+# Returns:
+#   Filtered JSON on stdout. Fails safe — returns input unchanged on jq error.
+#######################################
+_filter_below_version() {
+	local parsed="$1"
+	local floor="$2"
+
+	# Collect IDs of claims strictly below the floor.
+	local below_ids=""
+	local claim_rows
+	claim_rows=$(printf '%s' "$parsed" | jq -r '.[] | [.id, (.version // "unknown")] | @tsv' 2>/dev/null) || return 0
+
+	local id version
+	while IFS=$'\t' read -r id version; do
+		[[ -z "$id" ]] && continue
+		if _version_below "$version" "$floor"; then
+			below_ids+="${id}"$'\n'
+		fi
+	done <<<"$claim_rows"
+
+	if [[ -z "$below_ids" ]]; then
+		printf '%s' "$parsed"
+		return 0
+	fi
+
+	local below_json
+	below_json=$(printf '%s' "$below_ids" | jq -Rsc 'split("\n") | map(select(length > 0)) | map(tonumber)' 2>/dev/null) || {
+		printf '%s' "$parsed"
+		return 0
+	}
+
+	local filtered
+	filtered=$(printf '%s' "$parsed" | jq -c --argjson below "$below_json" '
+		map(select((.id as $i | $below | index($i)) | not))
+	' 2>/dev/null) || {
+		printf '%s' "$parsed"
+		return 0
+	}
+	printf '%s' "$filtered"
+	return 0
+}
+
+#######################################
+# t2400/t2401: Apply runtime override filters to parsed claims.
+#
+# Two composable filters:
+#   - Login filter (t2400): DISPATCH_CLAIM_IGNORE_RUNNERS strips named logins.
+#   - Version filter (t2401): DISPATCH_CLAIM_MIN_VERSION strips claims whose
+#     version field is below the semver floor (including legacy "unknown").
+#
+# Filters are no-op when override is disabled or both lists/floors are empty.
+# Emits a stderr log line when any claims are stripped, for operator audit.
 #
 # Args:
 #   $1 = parsed claims JSON array (from _fetch_claims parse step)
@@ -305,31 +423,47 @@ _apply_ignore_filter() {
 	local issue_number="$2"
 	local repo_slug="$3"
 
-	if [[ "$DISPATCH_OVERRIDE_ENABLED" != "true" ]] || [[ -z "$DISPATCH_CLAIM_IGNORE_RUNNERS" ]]; then
+	if [[ "$DISPATCH_OVERRIDE_ENABLED" != "true" ]]; then
 		printf '%s' "$parsed"
 		return 0
 	fi
 
-	local ignored_json
-	# Normalise the ignore list (accept space OR comma separators) → JSON array
-	ignored_json=$(printf '%s' "$DISPATCH_CLAIM_IGNORE_RUNNERS" | tr ',' ' ' | tr -s ' ' '\n' | jq -Rsc 'split("\n") | map(select(length > 0))' 2>/dev/null) || ignored_json="[]"
-	if [[ "$ignored_json" == "[]" ]]; then
+	# Both filters empty → no-op fast path
+	if [[ -z "$DISPATCH_CLAIM_IGNORE_RUNNERS" && -z "$DISPATCH_CLAIM_MIN_VERSION" ]]; then
 		printf '%s' "$parsed"
 		return 0
 	fi
 
-	local pre_count post_count filtered_parsed
+	local pre_count
 	pre_count=$(printf '%s' "$parsed" | jq 'length' 2>/dev/null || echo 0)
-	filtered_parsed=$(printf '%s' "$parsed" | jq -c --argjson ignored "$ignored_json" '
-		map(select(.runner as $r | $ignored | index($r) | not))
-	' 2>/dev/null)
-	if [[ -n "$filtered_parsed" ]]; then
-		parsed="$filtered_parsed"
+
+	# Login filter (t2400)
+	if [[ -n "$DISPATCH_CLAIM_IGNORE_RUNNERS" ]]; then
+		local ignored_json
+		# Normalise the ignore list (accept space OR comma separators) → JSON array
+		ignored_json=$(printf '%s' "$DISPATCH_CLAIM_IGNORE_RUNNERS" | tr ',' ' ' | tr -s ' ' '\n' | jq -Rsc 'split("\n") | map(select(length > 0))' 2>/dev/null) || ignored_json="[]"
+		if [[ "$ignored_json" != "[]" ]]; then
+			local filtered_login
+			filtered_login=$(printf '%s' "$parsed" | jq -c --argjson ignored "$ignored_json" '
+				map(select(.runner as $r | $ignored | index($r) | not))
+			' 2>/dev/null)
+			if [[ -n "$filtered_login" ]]; then
+				parsed="$filtered_login"
+			fi
+		fi
 	fi
+
+	# Version filter (t2401)
+	if [[ -n "$DISPATCH_CLAIM_MIN_VERSION" ]]; then
+		parsed=$(_filter_below_version "$parsed" "$DISPATCH_CLAIM_MIN_VERSION")
+	fi
+
+	local post_count
 	post_count=$(printf '%s' "$parsed" | jq 'length' 2>/dev/null || echo 0)
 	if [[ "$pre_count" -gt "$post_count" ]]; then
-		printf '[dispatch-claim-helper] Filtered %d claim(s) from ignored runners (%s) on #%s in %s\n' \
-			"$((pre_count - post_count))" "$DISPATCH_CLAIM_IGNORE_RUNNERS" "$issue_number" "$repo_slug" >&2
+		printf '[dispatch-claim-helper] Filtered %d claim(s) on #%s in %s (ignore_runners=%s min_version=%s)\n' \
+			"$((pre_count - post_count))" "$issue_number" "$repo_slug" \
+			"${DISPATCH_CLAIM_IGNORE_RUNNERS:-none}" "${DISPATCH_CLAIM_MIN_VERSION:-none}" >&2
 	fi
 
 	printf '%s' "$parsed"

--- a/.agents/scripts/tests/test-dispatch-override.sh
+++ b/.agents/scripts/tests/test-dispatch-override.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
-# test-dispatch-override.sh — tests for DISPATCH_CLAIM_IGNORE_RUNNERS override (t2399)
+# test-dispatch-override.sh — tests for dispatch override filters (t2399, t2400, t2401)
 #
 # Validates:
 #   1. Config file loader respects DISPATCH_CLAIM_IGNORE_RUNNERS
@@ -9,7 +9,11 @@
 #   3. Comma-separated ignore list works
 #   4. Empty ignore list is a no-op
 #   5. DISPATCH_OVERRIDE_ENABLED=false disables filtering
-#   6. Filter log line is emitted when filtering fires
+#   6. Helper script sources config cleanly
+#   7. [t2401] Claim body includes version=X.Y.Z field
+#   8. [t2401] jq capture parses version field + legacy "unknown" fallback
+#   9. [t2401] _version_below semver comparison
+#  10. [t2401] _filter_below_version strips claims below floor
 
 set -euo pipefail
 
@@ -18,6 +22,17 @@ HELPER="${SCRIPT_DIR}/../dispatch-claim-helper.sh"
 
 PASS=0
 FAIL=0
+
+# Source the helper's internal functions (strip main invocation)
+_source_helper() {
+	local tmp
+	tmp=$(mktemp)
+	sed '/^main "$@"$/d' "$HELPER" >"$tmp"
+	# shellcheck disable=SC1090
+	source "$tmp"
+	rm -f "$tmp"
+	return 0
+}
 
 assert_eq() {
 	local expected="$1"
@@ -136,6 +151,155 @@ EOF
 	return 0
 }
 
+# Test 7 (t2401): _resolve_version reads VERSION file, falls back to "unknown"
+test_resolve_version() {
+	printf '\nTest 7: _resolve_version reads VERSION file and falls back to "unknown"\n'
+	_source_helper
+
+	local tmp_ver
+	tmp_ver=$(mktemp)
+	printf '3.8.78\n' >"$tmp_ver"
+	local ver
+	AIDEVOPS_VERSION_FILE="$tmp_ver" ver=$(_resolve_version)
+	assert_eq "3.8.78" "$ver" "VERSION file → 3.8.78"
+
+	# Tolerate trailing whitespace
+	printf '  3.9.1  \n' >"$tmp_ver"
+	AIDEVOPS_VERSION_FILE="$tmp_ver" ver=$(_resolve_version)
+	assert_eq "3.9.1" "$ver" "whitespace stripped"
+
+	AIDEVOPS_VERSION_FILE="/nonexistent/path/VERSION" ver=$(_resolve_version)
+	assert_eq "unknown" "$ver" "missing file → unknown"
+
+	# Empty file
+	: >"$tmp_ver"
+	AIDEVOPS_VERSION_FILE="$tmp_ver" ver=$(_resolve_version)
+	assert_eq "unknown" "$ver" "empty file → unknown"
+
+	rm -f "$tmp_ver"
+	return 0
+}
+
+# Test 8 (t2401): claim body format includes version=X.Y.Z; jq capture handles
+# both new and legacy (missing version) bodies.
+test_claim_body_version() {
+	printf '\nTest 8: claim body format + jq capture parse version field\n'
+
+	# New format (t2401+): version field present
+	local body_new='DISPATCH_CLAIM nonce=abc123 runner=alice ts=2026-04-19T00:00:00Z max_age_s=1800 version=3.9.0'
+	local parsed_new
+	parsed_new=$(printf '%s' "$body_new" | jq -Rnc '[inputs | capture("nonce=(?<nonce>[^ ]+) runner=(?<runner>[^ ]+) ts=(?<ts>[^ ]+)(?: max_age_s=[^ ]+)?(?: version=(?<version>[^ ]+))?") | {runner: .runner, version: (.version // "unknown")}]')
+	assert_eq '[{"runner":"alice","version":"3.9.0"}]' "$parsed_new" "new body → version=3.9.0"
+
+	# Legacy format (pre-t2401): no version field
+	local body_legacy='DISPATCH_CLAIM nonce=abc123 runner=alice ts=2026-04-19T00:00:00Z max_age_s=1800'
+	local parsed_legacy
+	parsed_legacy=$(printf '%s' "$body_legacy" | jq -Rnc '[inputs | capture("nonce=(?<nonce>[^ ]+) runner=(?<runner>[^ ]+) ts=(?<ts>[^ ]+)(?: max_age_s=[^ ]+)?(?: version=(?<version>[^ ]+))?") | {runner: .runner, version: (.version // "unknown")}]')
+	assert_eq '[{"runner":"alice","version":"unknown"}]' "$parsed_legacy" "legacy body → version=unknown"
+	return 0
+}
+
+# Test 9 (t2401): _version_below semver comparison. Critical assertion:
+# numeric semver (3.8.100 > 3.8.78), not lexicographic.
+test_version_below() {
+	printf '\nTest 9: _version_below semver comparison (incl. numeric ordering)\n'
+	_source_helper
+
+	if _version_below "3.8.78" "3.9.0"; then
+		printf '  PASS: 3.8.78 < 3.9.0\n'
+		PASS=$((PASS + 1))
+	else
+		printf '  FAIL: 3.8.78 should be below 3.9.0\n'
+		FAIL=$((FAIL + 1))
+	fi
+
+	if _version_below "3.9.1" "3.9.0"; then
+		printf '  FAIL: 3.9.1 should NOT be below 3.9.0\n'
+		FAIL=$((FAIL + 1))
+	else
+		printf '  PASS: 3.9.1 >= 3.9.0\n'
+		PASS=$((PASS + 1))
+	fi
+
+	# Critical: numeric semver, not lexicographic — "100" > "78" numerically
+	if _version_below "3.8.100" "3.8.78"; then
+		printf '  FAIL: 3.8.100 < 3.8.78 — lexicographic bug (should be numeric)\n'
+		FAIL=$((FAIL + 1))
+	else
+		printf '  PASS: 3.8.100 > 3.8.78 (numeric semver, not lexicographic)\n'
+		PASS=$((PASS + 1))
+	fi
+
+	if _version_below "unknown" "3.9.0"; then
+		printf '  PASS: "unknown" below any floor\n'
+		PASS=$((PASS + 1))
+	else
+		printf '  FAIL: "unknown" should be below 3.9.0\n'
+		FAIL=$((FAIL + 1))
+	fi
+
+	if _version_below "3.9.0" "3.9.0"; then
+		printf '  FAIL: equal versions should NOT be strictly below\n'
+		FAIL=$((FAIL + 1))
+	else
+		printf '  PASS: equal versions not below\n'
+		PASS=$((PASS + 1))
+	fi
+
+	if _version_below "" "3.9.0"; then
+		printf '  PASS: empty version below any floor\n'
+		PASS=$((PASS + 1))
+	else
+		printf '  FAIL: empty version should be below 3.9.0\n'
+		FAIL=$((FAIL + 1))
+	fi
+	return 0
+}
+
+# Test 10 (t2401): _filter_below_version + _apply_ignore_filter with MIN_VERSION
+test_version_filter_integration() {
+	printf '\nTest 10: _apply_ignore_filter strips old versions (DISPATCH_CLAIM_MIN_VERSION)\n'
+	_source_helper
+
+	local parsed='[{"id":1,"runner":"alice","version":"3.8.78"},{"id":2,"runner":"bob","version":"3.9.1"},{"id":3,"runner":"charlie","version":"unknown"}]'
+
+	# Version-only filter (floor=3.9.0): only bob (3.9.1) survives
+	local result
+	DISPATCH_OVERRIDE_ENABLED=true \
+		DISPATCH_CLAIM_IGNORE_RUNNERS="" \
+		DISPATCH_CLAIM_MIN_VERSION="3.9.0" \
+		result=$(_apply_ignore_filter "$parsed" "42" "owner/repo" 2>/dev/null)
+	local runners
+	runners=$(printf '%s' "$result" | jq -r '.[].runner' 2>/dev/null | sort | tr '\n' ',')
+	assert_eq "bob," "$runners" "version filter: only bob (3.9.1) kept"
+
+	# Combined login + version: alice filtered by login, bob filtered by version
+	local parsed2='[{"id":1,"runner":"alice","version":"3.9.1"},{"id":2,"runner":"bob","version":"3.8.78"},{"id":3,"runner":"charlie","version":"3.9.1"}]'
+	DISPATCH_OVERRIDE_ENABLED=true \
+		DISPATCH_CLAIM_IGNORE_RUNNERS="alice" \
+		DISPATCH_CLAIM_MIN_VERSION="3.9.0" \
+		result=$(_apply_ignore_filter "$parsed2" "42" "owner/repo" 2>/dev/null)
+	runners=$(printf '%s' "$result" | jq -r '.[].runner' 2>/dev/null | sort | tr '\n' ',')
+	assert_eq "charlie," "$runners" "combined filter: alice (login) + bob (version) removed"
+
+	# Disabled override: no-op even with filters set
+	DISPATCH_OVERRIDE_ENABLED=false \
+		DISPATCH_CLAIM_IGNORE_RUNNERS="alice" \
+		DISPATCH_CLAIM_MIN_VERSION="3.9.0" \
+		result=$(_apply_ignore_filter "$parsed2" "42" "owner/repo" 2>/dev/null)
+	assert_eq "$parsed2" "$result" "disabled override → input unchanged"
+
+	# Empty filters: no-op
+	DISPATCH_OVERRIDE_ENABLED=true \
+		DISPATCH_CLAIM_IGNORE_RUNNERS="" \
+		DISPATCH_CLAIM_MIN_VERSION="" \
+		result=$(_apply_ignore_filter "$parsed2" "42" "owner/repo" 2>/dev/null)
+	assert_eq "$parsed2" "$result" "empty filters → input unchanged"
+
+	unset DISPATCH_OVERRIDE_ENABLED DISPATCH_CLAIM_IGNORE_RUNNERS DISPATCH_CLAIM_MIN_VERSION
+	return 0
+}
+
 # Run all tests
 test_space_separated_list
 test_comma_separated_list
@@ -143,6 +307,10 @@ test_empty_list
 test_jq_filter_behaviour
 test_enabled_flag
 test_helper_sources
+test_resolve_version
+test_claim_body_version
+test_version_below
+test_version_filter_integration
 
 printf '\n========================\n'
 printf 'Passed: %d, Failed: %d\n' "$PASS" "$FAIL"


### PR DESCRIPTION
## Summary

Extends t2400's login-gated override (PR #19965, merged) with a self-sunsetting **version-gated filter**. Claims now include `version=X.Y.Z` sourced from `~/.aidevops/agents/VERSION`; peer runners can set `DISPATCH_CLAIM_MIN_VERSION` to strip claims from runners below a configured semver floor.

**Why this is more robust than login-only filtering** (per t2401 brief):

1. **Self-correcting**: once a peer upgrades past the floor, their claims pass automatically. No operator action. The login filter requires manual removal and operators forget.
2. **Expresses intent**: "ignore runners older than N" is a clearer primitive than "ignore this specific peer". Degraded runners are degraded because of code they run, not who runs them.

## Changes

**`dispatch-claim-helper.sh`**
- `_resolve_version` — reads `AIDEVOPS_VERSION_FILE` (default `~/.aidevops/agents/VERSION`), falls back to `unknown` when missing/empty. Always exit 0 — claim emission must never fail on a missing VERSION file.
- `_post_claim` — appends `version=${version}` to the DISPATCH_CLAIM body.
- `_fetch_claims` parse step — extends the jq `capture()` regex with optional `version` group; legacy pre-t2401 claims parse as `unknown`.
- `_version_below` — semver comparison via `sort -V`. Handles numeric ordering correctly (`3.8.100 > 3.8.78`, not lexicographic). `unknown`/empty always below any floor; equal versions are not below.
- `_filter_below_version` — strips claims < floor using the `_version_below` helper.
- `_apply_ignore_filter` — composes login AND version filters. Refactored to eliminate `has_login_filter`/`has_version_filter` flag vars (they introduced 3× `"true"` repeated literals). Uses direct `-n` / `-z` checks now. Audit log line now reports both configurations: `ignore_runners=… min_version=…`.

**`dispatch-override.conf.txt`** — documents `DISPATCH_CLAIM_MIN_VERSION` alongside existing fields. Clarifies the two composable filters and their self-sunsetting (version) vs manual-removal (login) semantics.

**`tests/test-dispatch-override.sh`** — adds 4 new test suites (17 new assertions):
- `test_resolve_version` — reads, strips whitespace, missing-file fallback, empty-file fallback
- `test_claim_body_version` — jq capture on new and legacy body formats
- `test_version_below` — numeric semver (the critical `3.8.100 > 3.8.78` assertion), equal-not-below, `unknown`/empty sentinels
- `test_version_filter_integration` — version-only, combined login+version, disabled override, empty filters

All 23 assertions (6 pre-existing + 17 new) green locally.

## Verification

- Shellcheck clean on both files
- Test harness: 23/23 passed
- Complexity gate: base=291 head=291 new=0 (no function exceeds 100 body lines; direct helper run against `origin/main` after rebase)
- Repeated-literal ratchet: 1 distinct pre-existing literal (`"unknown"`), 0 new.
- Backward compatible: legacy pre-t2401 claims parse as `version=unknown` and keep flowing through dedup when `DISPATCH_CLAIM_MIN_VERSION` is unset.

## History

- Originally opened as #19983 stacked on `feature/pulse-backlog-stall-fixes`. That base branch was deleted when PR #19965 merged with `--delete-branch`, which auto-closed #19983. This PR is the same commit, rebased onto `main` and reopened against `main`.
- The only commit change from #19983's tip: rebase dropped `d0f49bd1f` (t2394) and `569dca493` (t2400) — both now upstream on main.

## Context

- Brief: `todo/tasks/t2401-brief.md`
- Sibling: #19969 (t2402, stats-dashboard auto-override — longer-term replacement; t2401 is the smaller step useful even if t2402 never lands)
- Related: #19965 (t2400 login-gated override, merged), #19967 (t2400 audit trail)

Resolves #19968

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.78 plugin for [OpenCode](https://opencode.ai) v1.14.18 with claude-opus-4-7 spent 2h 48m and 345,551 tokens on this with the user in an interactive session.
