### PR TITLE
t2396: extend _normalize_reassign_self to cover status:available feedback-routed worker issues

### DIFF
--- a/.agents/scripts/pulse-issue-reconcile.sh
+++ b/.agents/scripts/pulse-issue-reconcile.sh
@@ -14,6 +14,7 @@
 # section.
 #
 # Functions in this module (in source order):
+#   - _normalize_get_feedback_routed_rows (t2396: find feedback-routed available issues)
 #   - _normalize_reassign_self           (Phase 12: orphaned active issue → self-assign)
 #   - normalize_active_issue_assignments (coordinator — calls stale-recovery helpers)
 #   - close_issues_with_merged_prs
@@ -47,12 +48,71 @@ source "${_PIR_SCRIPT_DIR}/pulse-issue-reconcile-stale.sh"
 # and self-assign this runner. Includes the t1996 dedup guard to prevent
 # the two-runner simultaneous-assign stuck state.
 #
+# Pass 2 (t2396): also covers status:available + origin:worker issues that
+# were routed back by pulse-merge-feedback.sh (delegated to
+# _normalize_get_feedback_routed_rows).
+#
 # Args:
 #   $1 runner_user        — GH login of the current runner
 #   $2 repos_json         — path to repos.json
 #   $3 dedup_helper       — path to dispatch-dedup-helper.sh (may be absent)
 # Returns: 0 always (best-effort; logs summary to $LOGFILE)
 #######################################
+# (t2396 helper) Find feedback-routed status:available worker issues.
+#
+# Scans the pre-fetched issue JSON for status:available + origin:worker
+# issues with no assignees that have either a feedback label
+# (source:ci-feedback, source:conflict-feedback, source:review-feedback)
+# or a feedback body marker (<!-- ci-feedback:PR..., etc.).
+#
+# Outputs issue numbers (one per line) to stdout.
+#
+# Args:
+#   $1 issue_rows_json — JSON from gh issue list (number,assignees,labels)
+#   $2 slug            — repo slug for body-marker lookups
+# Returns: 0 always
+#######################################
+_normalize_get_feedback_routed_rows() {
+	local issue_rows_json="$1"
+	local slug="$2"
+
+	# Single jq pass outputs "number|has_label" pairs. Issues with a
+	# feedback label qualify directly; those without need a body check.
+	local _avail_candidates=""
+	_avail_candidates=$(printf '%s' "$issue_rows_json" | jq -r '
+		.[] | select(
+			(.labels | map(.name) as $n |
+				($n | index("status:available")) and ($n | index("origin:worker"))
+			) and ((.assignees | length) == 0)
+		) | [
+			.number,
+			(if (.labels | map(.name) | (index("source:ci-feedback") or index("source:conflict-feedback") or index("source:review-feedback")))
+			 then "1" else "0" end)
+		] | join("|")
+	' 2>/dev/null) || _avail_candidates=""
+
+	[[ -n "$_avail_candidates" ]] || return 0
+
+	local _pair _cand_num _has_label _cand_body
+	while IFS= read -r _pair; do
+		_cand_num="${_pair%%|*}"
+		_has_label="${_pair##*|}"
+		[[ "$_cand_num" =~ ^[0-9]+$ ]] || continue
+
+		if [[ "$_has_label" == "1" ]]; then
+			echo "$_cand_num"
+		else
+			# No feedback label — check body for markers
+			_cand_body=$(gh issue view "$_cand_num" --repo "$slug" --json body --jq '.body' 2>/dev/null) || _cand_body=""
+			if printf '%s' "$_cand_body" | grep -qE '<!-- (ci-feedback|conflict-feedback|review-followup):PR'; then
+				echo "$_cand_num"
+			fi
+		fi
+	done <<<"$_avail_candidates"
+
+	return 0
+}
+
 _normalize_reassign_self() {
 	local runner_user="$1"
 	local repos_json="$2"
@@ -76,29 +136,28 @@ _normalize_reassign_self() {
 			continue
 		fi
 		rm -f "$issue_rows_err"
+
+		# Pass 1: status:queued or status:in-progress with no assignees (original)
 		local issue_rows
 		issue_rows=$(printf '%s' "$issue_rows_json" | jq -r '.[] | select(((.labels | map(.name) | index("status:queued")) or (.labels | map(.name) | index("status:in-progress"))) and ((.assignees | length) == 0)) | .number' 2>/dev/null) || issue_rows=""
-		[[ -n "$issue_rows" ]] || continue
+
+		# Pass 2 (t2396): status:available + origin:worker + feedback-routed
+		local feedback_rows=""
+		feedback_rows=$(_normalize_get_feedback_routed_rows "$issue_rows_json" "$slug")
+
+		# Merge Pass 1 + Pass 2 rows (dedup via sort -u)
+		local all_rows=""
+		all_rows=$(printf '%s\n%s' "$issue_rows" "$feedback_rows" | grep -E '^[0-9]+$' | sort -u -n) || all_rows=""
+		[[ -n "$all_rows" ]] || continue
 
 		while IFS= read -r issue_number; do
 			[[ "$issue_number" =~ ^[0-9]+$ ]] || continue
 			total_checked=$((total_checked + 1))
 
-			# t1996: Guard against the multi-runner assignment race. Two runners
-			# may both observe the same "status:queued, no assignee" issue in
-			# their batch queries and race to self-assign. Without this check,
-			# both succeed and the issue ends up with two assignees — each runner
-			# sees the other as blocking, so neither can dispatch, and the issue
-			# sits stuck until stale recovery clears it (up to 1h).
-			#
-			# Checking is_assigned() here re-reads the live issue state. If
-			# another runner has already claimed it (exit 0 = assigned to other),
-			# skip this issue and let that runner's pulse handle dispatch.
-			# If still unassigned (exit 1 = safe), proceed with self-assignment.
+			# t1996: Guard against the multi-runner assignment race.
 			if [[ -x "$dedup_helper" ]]; then
 				local _is_assigned_output=""
 				if _is_assigned_output=$("$dedup_helper" is-assigned "$issue_number" "$slug" "$runner_user" 2>/dev/null); then
-					# Another runner already claimed this issue — skip reconcile
 					echo "[pulse-wrapper] Assignment normalization: skipping #${issue_number} in ${slug} — already claimed by another runner (${_is_assigned_output})" >>"$LOGFILE"
 					total_skipped_claimed=$((total_skipped_claimed + 1))
 					continue
@@ -108,7 +167,7 @@ _normalize_reassign_self() {
 			if gh issue edit "$issue_number" --repo "$slug" --add-assignee "$runner_user" >/dev/null 2>&1; then
 				total_assigned=$((total_assigned + 1))
 			fi
-		done <<<"$issue_rows"
+		done <<<"$all_rows"
 	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug // ""' "$repos_json" || true)
 
 	if [[ "$total_checked" -gt 0 ]]; then

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -1413,6 +1413,25 @@ gh_pr_edit_safe() {
 # Canonical list of mutually-exclusive origin:* labels.
 ORIGIN_LABELS=("interactive" "worker" "worker-takeover")
 
+# (t2396) Labels applied by pulse-merge-feedback.sh when routing a failed/
+# conflicted/review-feedback PR back to its parent issue for re-dispatch.
+# Used by _normalize_reassign_self to detect feedback-routed status:available
+# issues that need runner self-assignment restored.
+FEEDBACK_ROUTED_LABELS=(
+	"source:ci-feedback"
+	"source:conflict-feedback"
+	"source:review-feedback"
+)
+
+# (t2396) HTML comment markers injected into issue bodies by
+# pulse-merge-feedback.sh when routing feedback. Presence of any marker
+# indicates the issue has been through at least one dispatch+feedback cycle.
+FEEDBACK_ROUTED_MARKERS=(
+	"<!-- ci-feedback:PR"
+	"<!-- conflict-feedback:PR"
+	"<!-- review-followup:PR"
+)
+
 #######################################
 # Transition an issue or PR to an origin:* label atomically (t2200).
 #

--- a/.agents/scripts/tests/test-reassign-self-normalization.sh
+++ b/.agents/scripts/tests/test-reassign-self-normalization.sh
@@ -1,0 +1,403 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-reassign-self-normalization.sh — Tests for _normalize_reassign_self (t2396)
+#
+# Verifies that _normalize_reassign_self correctly:
+#   1. Self-assigns status:queued / status:in-progress issues (regression)
+#   2. Self-assigns status:available + origin:worker + feedback label issues
+#   3. Self-assigns status:available + origin:worker + body marker issues
+#   4. Skips status:available without origin:worker
+#   5. Skips status:available with existing assignees
+#   6. Skips fresh scanner issues (no feedback markers/labels)
+#
+# Requires only: bash, a stub gh binary.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+SCRIPTS_DIR="${SCRIPT_DIR}/.."
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+ASSIGNED_ISSUES=""
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+	ASSIGNED_ISSUES=""
+
+	mkdir -p "${TEST_ROOT}/bin"
+
+	# repos.json with a single test repo
+	cat >"${TEST_ROOT}/repos.json" <<'EOF'
+{
+  "initialized_repos": [
+    {
+      "path": "/home/user/Git/testrepo",
+      "slug": "testorg/testrepo",
+      "pulse": true
+    }
+  ]
+}
+EOF
+
+	# LOGFILE for the function
+	export LOGFILE="${TEST_ROOT}/pulse.log"
+	touch "$LOGFILE"
+
+	# PULSE_QUEUED_SCAN_LIMIT used in the function
+	export PULSE_QUEUED_SCAN_LIMIT=100
+
+	# Stub dedup helper that always says "safe to assign" (exit 1)
+	cat >"${TEST_ROOT}/bin/dedup-stub.sh" <<'DEDUP_EOF'
+#!/usr/bin/env bash
+# Stub dispatch-dedup-helper.sh — always returns "not assigned" (exit 1 = safe)
+exit 1
+DEDUP_EOF
+	chmod +x "${TEST_ROOT}/bin/dedup-stub.sh"
+
+	return 0
+}
+
+cleanup_test_env() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+# Create a stub gh that returns canned JSON for "issue list" and tracks "issue edit" calls
+create_gh_stub() {
+	local issue_list_json="$1"
+	local issue_view_body="${2:-}"
+
+	cat >"${TEST_ROOT}/bin/gh" <<GHEOF
+#!/usr/bin/env bash
+if [[ "\$1" == "issue" && "\$2" == "list" ]]; then
+	cat <<'JSON_EOF'
+${issue_list_json}
+JSON_EOF
+	exit 0
+elif [[ "\$1" == "issue" && "\$2" == "view" ]]; then
+	# Return body for marker check
+	echo '{"body": "${issue_view_body}"}'
+	exit 0
+elif [[ "\$1" == "issue" && "\$2" == "edit" ]]; then
+	# Track which issues got assigned
+	echo "\$3" >> "${TEST_ROOT}/assigned.txt"
+	exit 0
+fi
+exit 1
+GHEOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+	return 0
+}
+
+# Source the function under test.
+# We pre-load the stale module (empty stub) and shared-constants.sh
+# constants that the function uses, then source the reconcile module.
+source_function_under_test() {
+	# Prevent re-sourcing on repeated calls within the same bash process
+	unset _PULSE_ISSUE_RECONCILE_LOADED 2>/dev/null || true
+	unset _PULSE_ISSUE_RECONCILE_STALE_LOADED 2>/dev/null || true
+
+	# Define the constants that _normalize_reassign_self needs
+	FEEDBACK_ROUTED_LABELS=(
+		"source:ci-feedback"
+		"source:conflict-feedback"
+		"source:review-feedback"
+	)
+	FEEDBACK_ROUTED_MARKERS=(
+		"<!-- ci-feedback:PR"
+		"<!-- conflict-feedback:PR"
+		"<!-- review-followup:PR"
+	)
+
+	# Stub the stale module so source won't fail on its functions
+	_PULSE_ISSUE_RECONCILE_STALE_LOADED=1
+	# Stub functions from the stale module that might be referenced
+	_normalize_clear_status_labels() { return 0; }
+	_normalize_stale_get_dispatch_info() { return 0; }
+	_normalize_stale_should_skip_reset() { return 0; }
+	_normalize_unassign_stale() { return 0; }
+
+	# Stub other dependencies from shared-constants.sh / worker-lifecycle-common.sh
+	# that the module-level code or other functions may reference
+	if ! type print_warning &>/dev/null; then
+		print_warning() { echo "[WARN] $*"; return 0; }
+	fi
+	if ! type print_info &>/dev/null; then
+		print_info() { echo "[INFO] $*"; return 0; }
+	fi
+	# Stub arrays that label-invariant functions need (we don't test those here)
+	ISSUE_STATUS_LABEL_PRECEDENCE=("done" "in-review" "in-progress" "queued" "claimed" "available" "blocked")
+	ISSUE_TIER_LABEL_RANK=("reasoning" "standard" "simple")
+
+	# Set SCRIPT_DIR for the source chain (used by pulse-issue-reconcile.sh
+	# to locate pulse-issue-reconcile-stale.sh)
+	export SCRIPT_DIR="$SCRIPTS_DIR"
+
+	local src_file="${SCRIPTS_DIR}/pulse-issue-reconcile.sh"
+	if [[ -f "$src_file" ]]; then
+		# shellcheck source=/dev/null
+		source "$src_file"
+		return 0
+	fi
+	echo "ERROR: cannot find pulse-issue-reconcile.sh at ${src_file}" >&2
+	return 1
+}
+
+get_assigned_issues() {
+	if [[ -f "${TEST_ROOT}/assigned.txt" ]]; then
+		cat "${TEST_ROOT}/assigned.txt"
+	fi
+	return 0
+}
+
+reset_assignments() {
+	rm -f "${TEST_ROOT}/assigned.txt"
+	return 0
+}
+
+# ─── Test 1: status:queued with no assignees → self-assigned (regression) ───
+test_queued_no_assignee_self_assigns() {
+	setup_test_env
+	local json='[
+		{"number": 100, "assignees": [], "labels": [{"name": "status:queued"}, {"name": "origin:worker"}]}
+	]'
+	create_gh_stub "$json"
+	export PATH="${TEST_ROOT}/bin:${PATH}"
+	source_function_under_test
+
+	_normalize_reassign_self "testrunner" "${TEST_ROOT}/repos.json" "${TEST_ROOT}/bin/dedup-stub.sh"
+
+	local assigned
+	assigned=$(get_assigned_issues)
+	if echo "$assigned" | grep -q "100"; then
+		print_result "status:queued + no assignee → self-assigned" 0
+	else
+		print_result "status:queued + no assignee → self-assigned" 1 \
+			"Expected issue 100 to be assigned, got: ${assigned:-<empty>}"
+	fi
+	cleanup_test_env
+	return 0
+}
+
+# ─── Test 2: status:in-progress with no assignees → self-assigned (regression) ───
+test_in_progress_no_assignee_self_assigns() {
+	setup_test_env
+	local json='[
+		{"number": 101, "assignees": [], "labels": [{"name": "status:in-progress"}, {"name": "origin:worker"}]}
+	]'
+	create_gh_stub "$json"
+	export PATH="${TEST_ROOT}/bin:${PATH}"
+	source_function_under_test
+
+	_normalize_reassign_self "testrunner" "${TEST_ROOT}/repos.json" "${TEST_ROOT}/bin/dedup-stub.sh"
+
+	local assigned
+	assigned=$(get_assigned_issues)
+	if echo "$assigned" | grep -q "101"; then
+		print_result "status:in-progress + no assignee → self-assigned" 0
+	else
+		print_result "status:in-progress + no assignee → self-assigned" 1 \
+			"Expected issue 101 to be assigned, got: ${assigned:-<empty>}"
+	fi
+	cleanup_test_env
+	return 0
+}
+
+# ─── Test 3: status:available + origin:worker + source:ci-feedback → self-assigned ───
+test_available_worker_ci_feedback_label_self_assigns() {
+	setup_test_env
+	local json='[
+		{"number": 200, "assignees": [], "labels": [{"name": "status:available"}, {"name": "origin:worker"}, {"name": "source:ci-feedback"}]}
+	]'
+	create_gh_stub "$json"
+	export PATH="${TEST_ROOT}/bin:${PATH}"
+	source_function_under_test
+
+	_normalize_reassign_self "testrunner" "${TEST_ROOT}/repos.json" "${TEST_ROOT}/bin/dedup-stub.sh"
+
+	local assigned
+	assigned=$(get_assigned_issues)
+	if echo "$assigned" | grep -q "200"; then
+		print_result "status:available + origin:worker + source:ci-feedback → self-assigned" 0
+	else
+		print_result "status:available + origin:worker + source:ci-feedback → self-assigned" 1 \
+			"Expected issue 200 to be assigned, got: ${assigned:-<empty>}"
+	fi
+	cleanup_test_env
+	return 0
+}
+
+# ─── Test 4: status:available + origin:worker + source:conflict-feedback → self-assigned ───
+test_available_worker_conflict_feedback_label_self_assigns() {
+	setup_test_env
+	local json='[
+		{"number": 201, "assignees": [], "labels": [{"name": "status:available"}, {"name": "origin:worker"}, {"name": "source:conflict-feedback"}]}
+	]'
+	create_gh_stub "$json"
+	export PATH="${TEST_ROOT}/bin:${PATH}"
+	source_function_under_test
+
+	_normalize_reassign_self "testrunner" "${TEST_ROOT}/repos.json" "${TEST_ROOT}/bin/dedup-stub.sh"
+
+	local assigned
+	assigned=$(get_assigned_issues)
+	if echo "$assigned" | grep -q "201"; then
+		print_result "status:available + origin:worker + source:conflict-feedback → self-assigned" 0
+	else
+		print_result "status:available + origin:worker + source:conflict-feedback → self-assigned" 1 \
+			"Expected issue 201 to be assigned, got: ${assigned:-<empty>}"
+	fi
+	cleanup_test_env
+	return 0
+}
+
+# ─── Test 5: status:available + origin:worker + body marker → self-assigned ───
+test_available_worker_body_marker_self_assigns() {
+	setup_test_env
+	local body_marker='<!-- ci-feedback:PR1234 -->'
+	local json='[
+		{"number": 300, "assignees": [], "labels": [{"name": "status:available"}, {"name": "origin:worker"}]}
+	]'
+	create_gh_stub "$json" "$body_marker"
+	export PATH="${TEST_ROOT}/bin:${PATH}"
+	source_function_under_test
+
+	_normalize_reassign_self "testrunner" "${TEST_ROOT}/repos.json" "${TEST_ROOT}/bin/dedup-stub.sh"
+
+	local assigned
+	assigned=$(get_assigned_issues)
+	if echo "$assigned" | grep -q "300"; then
+		print_result "status:available + origin:worker + body marker → self-assigned" 0
+	else
+		print_result "status:available + origin:worker + body marker → self-assigned" 1 \
+			"Expected issue 300 to be assigned, got: ${assigned:-<empty>}"
+	fi
+	cleanup_test_env
+	return 0
+}
+
+# ─── Test 6: status:available + NO origin:worker → NOT assigned ───
+test_available_no_worker_label_skips() {
+	setup_test_env
+	local json='[
+		{"number": 400, "assignees": [], "labels": [{"name": "status:available"}, {"name": "origin:interactive"}, {"name": "source:ci-feedback"}]}
+	]'
+	create_gh_stub "$json"
+	export PATH="${TEST_ROOT}/bin:${PATH}"
+	source_function_under_test
+
+	_normalize_reassign_self "testrunner" "${TEST_ROOT}/repos.json" "${TEST_ROOT}/bin/dedup-stub.sh"
+
+	local assigned
+	assigned=$(get_assigned_issues)
+	if [[ -z "$assigned" ]]; then
+		print_result "status:available + no origin:worker → skipped" 0
+	else
+		print_result "status:available + no origin:worker → skipped" 1 \
+			"Expected no assignment, but got: ${assigned}"
+	fi
+	cleanup_test_env
+	return 0
+}
+
+# ─── Test 7: status:available + existing assignees → NOT assigned ───
+test_available_with_assignee_skips() {
+	setup_test_env
+	local json='[
+		{"number": 500, "assignees": [{"login": "existing-user"}], "labels": [{"name": "status:available"}, {"name": "origin:worker"}, {"name": "source:ci-feedback"}]}
+	]'
+	create_gh_stub "$json"
+	export PATH="${TEST_ROOT}/bin:${PATH}"
+	source_function_under_test
+
+	_normalize_reassign_self "testrunner" "${TEST_ROOT}/repos.json" "${TEST_ROOT}/bin/dedup-stub.sh"
+
+	local assigned
+	assigned=$(get_assigned_issues)
+	if [[ -z "$assigned" ]]; then
+		print_result "status:available + existing assignee → skipped" 0
+	else
+		print_result "status:available + existing assignee → skipped" 1 \
+			"Expected no assignment, but got: ${assigned}"
+	fi
+	cleanup_test_env
+	return 0
+}
+
+# ─── Test 8: Fresh scanner issue (status:available, no feedback markers) → NOT assigned ───
+test_fresh_scanner_issue_skips() {
+	setup_test_env
+	local json='[
+		{"number": 600, "assignees": [], "labels": [{"name": "status:available"}, {"name": "origin:worker"}, {"name": "source:review-scanner"}]}
+	]'
+	# No body markers
+	create_gh_stub "$json" "This is a fresh scanner issue with no feedback markers"
+	export PATH="${TEST_ROOT}/bin:${PATH}"
+	source_function_under_test
+
+	_normalize_reassign_self "testrunner" "${TEST_ROOT}/repos.json" "${TEST_ROOT}/bin/dedup-stub.sh"
+
+	local assigned
+	assigned=$(get_assigned_issues)
+	if [[ -z "$assigned" ]]; then
+		print_result "fresh scanner issue (no feedback) → skipped" 0
+	else
+		print_result "fresh scanner issue (no feedback) → skipped" 1 \
+			"Expected no assignment, but got: ${assigned}"
+	fi
+	cleanup_test_env
+	return 0
+}
+
+# ─── Run all tests ───
+main() {
+	echo "=== _normalize_reassign_self tests (t2396) ==="
+	echo ""
+
+	test_queued_no_assignee_self_assigns
+	test_in_progress_no_assignee_self_assigns
+	test_available_worker_ci_feedback_label_self_assigns
+	test_available_worker_conflict_feedback_label_self_assigns
+	test_available_worker_body_marker_self_assigns
+	test_available_no_worker_label_skips
+	test_available_with_assignee_skips
+	test_fresh_scanner_issue_skips
+
+	echo ""
+	echo "=== Results: ${TESTS_RUN} tests, ${TESTS_FAILED} failures ==="
+
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		exit 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Extended `_normalize_reassign_self` in `pulse-issue-reconcile.sh` to self-assign feedback-routed `status:available` worker issues (previously only covered `status:queued` and `status:in-progress`)
- Added `FEEDBACK_ROUTED_LABELS` and `FEEDBACK_ROUTED_MARKERS` constants to `shared-constants.sh`
- Extracted `_normalize_get_feedback_routed_rows` helper to keep function complexity under the 100-line gate

## What changed

### `.agents/scripts/pulse-issue-reconcile.sh`
- New `_normalize_get_feedback_routed_rows()` helper: scans pre-fetched issue JSON for `status:available` + `origin:worker` + no-assignee issues that have either a feedback label (`source:ci-feedback`, `source:conflict-feedback`, `source:review-feedback`) or a feedback body marker (`<!-- ci-feedback:PR...`, etc.)
- `_normalize_reassign_self()` now merges Pass 1 (queued/in-progress) with Pass 2 (feedback-routed available) before the dedup guard + self-assign loop

### `.agents/scripts/shared-constants.sh`
- Added `FEEDBACK_ROUTED_LABELS` array (3 labels)
- Added `FEEDBACK_ROUTED_MARKERS` array (3 HTML comment prefixes)

### `.agents/scripts/tests/test-reassign-self-normalization.sh` (NEW)
8-test suite covering all acceptance criteria:
1. status:queued + no assignee → self-assigned (regression)
2. status:in-progress + no assignee → self-assigned (regression)
3. status:available + origin:worker + source:ci-feedback → self-assigned
4. status:available + origin:worker + source:conflict-feedback → self-assigned
5. status:available + origin:worker + body marker → self-assigned
6. status:available + no origin:worker → skipped
7. status:available + existing assignee → skipped
8. Fresh scanner issue (no feedback markers) → skipped

## Testing

- `shellcheck` passes on all 3 modified files (zero new violations)
- `test-reassign-self-normalization.sh`: 8/8 PASS
- Pre-commit quality gate passed (string literal ratchet, return statements, positional params, ShellCheck)
- Complexity gate passed (helper extraction keeps both functions under 100 lines)

Resolves #19957


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.78 plugin for [OpenCode](https://opencode.ai) v1.14.18 with claude-opus-4-6 spent 18m and 30,913 tokens on this as a headless worker.