### PR TITLE
t2228: Add task-counter monotonic guard to pre-commit hook

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1820,9 +1820,9 @@
       "pr": 16548
     },
     ".agents/scripts/approval-helper.sh": {
-      "at": "2026-04-14T08:25:15Z",
-      "hash": "5e11b9ad67f1c65ca3f599af558ef858cb1b4132",
-      "passes": 5,
+      "at": "2026-04-19T19:49:13Z",
+      "hash": "c17c9b5caf2a16de9579ab687636f1b20c7f8f03",
+      "passes": 6,
       "pr": 17454
     },
     ".agents/scripts/attribution-detection-helper.sh": {
@@ -2262,9 +2262,9 @@
       "pr": 12145
     },
     ".agents/scripts/full-loop-helper.sh": {
-      "at": "2026-04-19T05:30:53Z",
-      "hash": "0da699d76a8d8fb04cae2b8fc41b4d3a1f27ead4",
-      "passes": 11,
+      "at": "2026-04-19T19:49:16Z",
+      "hash": "0f8ab35f066deead150f2be89671dc13d68f3c10",
+      "passes": 12,
       "pr": 19046
     },
     ".agents/scripts/generate-claude-commands.sh": {
@@ -2310,9 +2310,9 @@
       "pr": 18707
     },
     ".agents/scripts/interactive-session-helper.sh": {
-      "at": "2026-04-19T15:35:43Z",
-      "hash": "7f1ff2dfe9f16e143dad1df55167e4599d192320",
-      "passes": 5,
+      "at": "2026-04-19T19:49:17Z",
+      "hash": "c211c40b61dd90a0462f217099e9d8dc1651f092",
+      "passes": 6,
       "pr": 18843
     },
     ".agents/scripts/issue-sync-helper.sh": {
@@ -2394,15 +2394,15 @@
       "pr": 17590
     },
     ".agents/scripts/pulse-ancillary-dispatch.sh": {
-      "at": "2026-04-15T07:31:55Z",
-      "hash": "ab72fd6b20e25c4e7f8002d79a94fa44e5a71193",
-      "passes": 5,
+      "at": "2026-04-19T19:49:18Z",
+      "hash": "addd94dd0e7fccf14ec501f96df233e13bb7635f",
+      "passes": 6,
       "pr": 18657
     },
     ".agents/scripts/pulse-cleanup.sh": {
-      "at": "2026-04-19T05:30:54Z",
-      "hash": "7ad09a7f4b01d77b7ef3717affa029687235a029",
-      "passes": 5,
+      "at": "2026-04-19T19:49:18Z",
+      "hash": "6e87466afbda81aa546fcfa807ec247e1a377575",
+      "passes": 6,
       "pr": 18704
     },
     ".agents/scripts/pulse-dep-graph.sh": {
@@ -2436,15 +2436,15 @@
       "pr": 18691
     },
     ".agents/scripts/pulse-issue-reconcile.sh": {
-      "at": "2026-04-19T16:33:53Z",
-      "hash": "1c38a184c6d2d2eb18be2c19c9b70a00e99b3ae6",
-      "passes": 12,
+      "at": "2026-04-19T19:49:19Z",
+      "hash": "333bf1d2301ec3f8fdaa92e661f319d0af9d66fd",
+      "passes": 13,
       "pr": 18690
     },
     ".agents/scripts/pulse-merge.sh": {
-      "at": "2026-04-19T05:30:55Z",
-      "hash": "f5d5e9a21c27d84d0ee85ec8ae0704af7c2f3c43",
-      "passes": 16,
+      "at": "2026-04-19T19:49:19Z",
+      "hash": "7c7b2da1a1f161faa84fc6de12329b8e34689adb",
+      "passes": 17,
       "pr": 18829
     },
     ".agents/scripts/pulse-prefetch.sh": {
@@ -2466,15 +2466,15 @@
       "pr": 18680
     },
     ".agents/scripts/pulse-simplification.sh": {
-      "at": "2026-04-19T19:19:44Z",
-      "hash": "5152aaa11f855afe1fa2cac2928e93c26c1f8ed2",
-      "passes": 12,
+      "at": "2026-04-19T19:49:19Z",
+      "hash": "c75571e3c08dc536515010addaee2ad74294f4ff",
+      "passes": 13,
       "pr": 18653
     },
     ".agents/scripts/pulse-triage.sh": {
-      "at": "2026-04-17T20:02:43Z",
-      "hash": "ccdec4f51fd698f9670d95bc44fc0c34c4481119",
-      "passes": 14,
+      "at": "2026-04-19T19:49:20Z",
+      "hash": "f124eb7f52c809170f73ab3c96ec08a388e2bbe3",
+      "passes": 15,
       "pr": 18655
     },
     ".agents/scripts/pulse-wrapper.sh": {
@@ -2496,15 +2496,15 @@
       "pr": 19000
     },
     ".agents/scripts/quality-feedback-issues-lib.sh": {
-      "at": "2026-04-14T22:16:57Z",
-      "hash": "659f27c08e7ad944343d00646a2ccc522fd90bcd",
-      "passes": 1,
+      "at": "2026-04-19T19:49:20Z",
+      "hash": "1896895d66108306b86290d2888e6b17346d5960",
+      "passes": 2,
       "pr": 19004
     },
     ".agents/scripts/routine-log-helper.sh": {
-      "at": "2026-04-19T15:35:45Z",
-      "hash": "38165378dc1fdd3945ea60afac7575fc2a370abd",
-      "passes": 5,
+      "at": "2026-04-19T19:49:20Z",
+      "hash": "42e7c977adf51385bb7a279747b2b31e70ef9772",
+      "passes": 6,
       "pr": 17786
     },
     ".agents/scripts/schema-validator-helper.sh": {
@@ -2544,9 +2544,9 @@
       "pr": 15916
     },
     ".agents/scripts/shared-constants.sh": {
-      "at": "2026-04-19T16:57:28Z",
-      "hash": "ddf89faf7483610db1c7092cf67ed61a95597713",
-      "passes": 12,
+      "at": "2026-04-19T19:49:21Z",
+      "hash": "0e5d4cdf24626e49e9c259934c029b6ffe3e1c56",
+      "passes": 13,
       "pr": 18847
     },
     ".agents/scripts/stats-functions.sh": {
@@ -2556,9 +2556,9 @@
       "pr": 18808
     },
     ".agents/scripts/stats-quality-sweep.sh": {
-      "at": "2026-04-19T19:19:45Z",
-      "hash": "82fa13bd747ca986255f0b39ecbd2274b78aa12a",
-      "passes": 5,
+      "at": "2026-04-19T19:49:21Z",
+      "hash": "91cf86de8603aa66652621ca81fe44ec18b04b27",
+      "passes": 6,
       "pr": 18810
     },
     ".agents/scripts/tabby-helper.sh": {
@@ -2615,15 +2615,15 @@
       "passes": 1
     },
     ".agents/scripts/worker-lifecycle-common.sh": {
-      "at": "2026-04-19T16:33:54Z",
-      "hash": "302d32f4bec7c6f123e4024359dcb9421e5030d0",
-      "passes": 9,
+      "at": "2026-04-19T19:49:22Z",
+      "hash": "8334e61684c800d3c352e35c246741408f28ea35",
+      "passes": 10,
       "pr": 17353
     },
     ".agents/scripts/worker-watchdog.sh": {
-      "at": "2026-04-19T05:30:58Z",
-      "hash": "02fd9b15d344af17fc4e89721aa2c8ff83c68315",
-      "passes": 6,
+      "at": "2026-04-19T19:49:22Z",
+      "hash": "450818e69470a55ecf028cb3619303b63cf54b73",
+      "passes": 7,
       "pr": 17393
     },
     ".agents/scripts/worktree-helper.sh": {
@@ -7492,9 +7492,9 @@
       "pr": 15490
     },
     "aidevops.sh": {
-      "at": "2026-04-19T18:37:10Z",
-      "hash": "9b5d67b5bddfcb9828eb2f57baa521950339c994",
-      "passes": 87,
+      "at": "2026-04-19T19:50:10Z",
+      "hash": "6e9cbe486ccf95dcb0de0817f50dc73de2b25e6a",
+      "passes": 88,
       "pr": 19029
     },
     "setup-modules/agent-deploy.sh": {
@@ -7504,9 +7504,9 @@
       "pr": 19203
     },
     "setup.sh": {
-      "at": "2026-04-19T18:37:10Z",
-      "hash": "df8bff4dde5cc40053f7fe800ebdb3fc19103f84",
-      "passes": 84,
+      "at": "2026-04-19T19:50:10Z",
+      "hash": "5a8b5cbbaebb5379cc22e590e9f57e2992be1f4f",
+      "passes": 85,
       "pr": 15470
     },
     "todo/tasks/GH#15363-brief.md": {

--- a/.agents/scripts/pre-commit-hook.sh
+++ b/.agents/scripts/pre-commit-hook.sh
@@ -124,6 +124,38 @@ validate_duplicate_task_ids() {
 	return 0
 }
 
+# Validate that a staged .task-counter is not regressing compared to HEAD.
+#
+# Scenarios:
+#   - .task-counter not staged        -> skip (pass)
+#   - Staged value == HEAD value      -> pass (no-op / merge)
+#   - Staged value >  HEAD value      -> pass (new claim)
+#   - Staged value <  HEAD value      -> FAIL (stale worktree regression)
+#   - Non-numeric in either           -> skip (first-commit or legacy)
+validate_task_counter_monotonic() {
+	if ! git diff --cached --name-only | grep -q '^\.task-counter$'; then
+		return 0
+	fi
+
+	local staged_value head_value
+	staged_value=$(git show :.task-counter 2>/dev/null | tr -d '[:space:]')
+	head_value=$(git show HEAD:.task-counter 2>/dev/null | tr -d '[:space:]')
+
+	[[ "$staged_value" =~ ^[0-9]+$ ]] || return 0
+	[[ "$head_value" =~ ^[0-9]+$ ]] || return 0
+
+	if (( staged_value < head_value )); then
+		print_error ".task-counter regression detected:"
+		print_error "  HEAD value:   $head_value"
+		print_error "  Staged value: $staged_value"
+		print_error ""
+		print_error "This is almost always a stale worktree overwriting main's counter."
+		print_error "Fix: git checkout origin/main -- .task-counter"
+		return 1
+	fi
+	return 0
+}
+
 validate_return_statements() {
 	local violations=0
 
@@ -783,6 +815,12 @@ main_pre_commit() {
 	# Always run TODO.md validation (even if no shell files changed)
 	validate_duplicate_task_ids || {
 		print_error "Commit rejected: duplicate task IDs"
+		exit 1
+	}
+	echo ""
+
+	validate_task_counter_monotonic || {
+		print_error "Commit rejected: .task-counter regression"
 		exit 1
 	}
 	echo ""

--- a/.agents/scripts/tests/test-pre-commit-hook-counter-monotonic.sh
+++ b/.agents/scripts/tests/test-pre-commit-hook-counter-monotonic.sh
@@ -1,0 +1,243 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-pre-commit-hook-counter-monotonic.sh — t2228 regression guard.
+#
+# Asserts the pre-commit hook's validate_task_counter_monotonic function
+# correctly blocks stale .task-counter regressions while permitting
+# legitimate advances and no-ops.
+#
+# Incident motivating this test: during PR #19730 preparation (2026-04-18)
+# a long-lived planning worktree staged .task-counter at 2204 while
+# origin/main was at 2224. Committing would have silently wiped 20 claimed
+# task IDs. The near-miss was caught only via manual diff inspection.
+
+# NOTE: not using `set -e` intentionally — assertions run the function
+# in subshells via run_case and capture non-zero exits. A fail-fast shell
+# would abort on the first expected non-zero.
+set -uo pipefail
+
+TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+HOOK_PATH="${TEST_SCRIPTS_DIR}/pre-commit-hook.sh"
+
+if [[ ! -f "$HOOK_PATH" ]]; then
+	printf 'FAIL: hook not found at %s\n' "$HOOK_PATH" >&2
+	exit 1
+fi
+
+# NOT readonly — shared-constants.sh (transitively sourced by the hook)
+# declares readonly RED/GREEN/RESET and the collision would fire under
+# set -e and silently kill the test shell.
+TEST_RED=$'\033[0;31m'
+TEST_GREEN=$'\033[0;32m'
+TEST_RESET=$'\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1" rc="$2" extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf '%sPASS%s %s\n' "$TEST_GREEN" "$TEST_RESET" "$name"
+	else
+		printf '%sFAIL%s %s %s\n' "$TEST_RED" "$TEST_RESET" "$name" "$extra"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+# Sandbox HOME so sourcing the hook is side-effect-free.
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+export HOME="${TEST_ROOT}/home"
+mkdir -p "${HOME}/.aidevops/logs" "${HOME}/.aidevops/.agent-workspace"
+
+# =============================================================================
+# Test harness
+# =============================================================================
+
+# Create a throwaway git repo, seed it with a HEAD .task-counter at
+# $head_value, stage .task-counter at $staged_value, and run
+# validate_task_counter_monotonic.
+#
+# Usage: run_case <head_value> <staged_value>
+# Pass empty string as head_value to simulate "no .task-counter in HEAD".
+run_case() {
+	local head_value="$1" staged_value="$2"
+	local repo="${TEST_ROOT}/repo-${TESTS_RUN}"
+
+	rm -rf "$repo"
+	mkdir -p "$repo"
+	(
+		cd "$repo" || exit 1
+		git init -q
+		git config user.email 'test@aidevops.local'
+		git config user.name 'Test Runner'
+		git config commit.gpgsign false
+
+		# Always create a HEAD so HEAD references work.
+		printf 'initial\n' >README.md
+		git add README.md
+		git commit -q -m 'initial'
+
+		if [[ -n "$head_value" ]]; then
+			printf '%s\n' "$head_value" >.task-counter
+			git add .task-counter
+			git commit -q -m 'seed counter'
+		fi
+
+		printf '%s\n' "$staged_value" >.task-counter
+		git add .task-counter
+
+		# Pre-source shared-constants.sh so print_error etc. are available.
+		# shellcheck source=/dev/null
+		source "${TEST_SCRIPTS_DIR}/shared-constants.sh" >/dev/null 2>&1
+
+		# Source hook with the trailing `main "$@"` invocation stripped so
+		# only function definitions load. Avoids executing the full hook
+		# (shellcheck, secret scan, etc.) and lets us call the validator
+		# in isolation.
+		# shellcheck source=/dev/null
+		source <(sed '/^main "\$@"$/d' "$HOOK_PATH") >/dev/null 2>&1
+
+		# The hook enables set -e; disable before invoking validate so a
+		# non-zero return doesn't kill this subshell before we capture $?.
+		set +e
+		validate_task_counter_monotonic 2>&1
+		local rc=$?
+		set -e
+		echo "rc=${rc}"
+	)
+	return 0
+}
+
+assert_pass() {
+	local name="$1" head_value="$2" staged_value="$3"
+	local output rc
+	output=$(run_case "$head_value" "$staged_value")
+	rc=$(printf '%s' "$output" | grep -oE 'rc=[0-9]+$' | tail -1 | cut -d= -f2)
+	if [[ "${rc:-1}" -eq 0 ]]; then
+		print_result "$name" 0
+	else
+		print_result "$name" 1 "expected pass, got rc=$rc; output: $output"
+	fi
+	return 0
+}
+
+assert_fail() {
+	local name="$1" head_value="$2" staged_value="$3" expect_msg="$4"
+	local output rc
+	output=$(run_case "$head_value" "$staged_value")
+	rc=$(printf '%s' "$output" | grep -oE 'rc=[0-9]+$' | tail -1 | cut -d= -f2)
+	if [[ "${rc:-0}" -ne 1 ]]; then
+		print_result "$name" 1 "expected fail (rc=1), got rc=$rc; output: $output"
+		return
+	fi
+	if ! printf '%s' "$output" | grep -qF "$expect_msg"; then
+		print_result "$name" 1 "expected '$expect_msg' in output; got: $output"
+		return
+	fi
+	print_result "$name" 0
+	return 0
+}
+
+# =============================================================================
+# Test cases
+# =============================================================================
+
+# Case 1: staged == HEAD → pass (no-op / merge commit pattern)
+assert_pass \
+	"staged == HEAD passes (no-op)" \
+	"2200" \
+	"2200"
+
+# Case 2: staged < HEAD → fail with regression message
+assert_fail \
+	"staged < HEAD fails with regression message" \
+	"2224" \
+	"2204" \
+	".task-counter regression detected"
+
+# Case 3: staged > HEAD → pass (normal new claim)
+assert_pass \
+	"staged > HEAD passes (new claim)" \
+	"2200" \
+	"2205"
+
+# Case 4: .task-counter not staged → pass (no-op, different files changed)
+# We achieve "not staged" by sourcing into a repo where the counter was not
+# added to the index. We repurpose run_case: pass a non-counter file instead.
+# Easier: directly call in a fresh repo with no .task-counter staged.
+_run_no_counter_staged() {
+	local repo="${TEST_ROOT}/repo-no-counter"
+	rm -rf "$repo"
+	mkdir -p "$repo"
+	(
+		cd "$repo" || exit 1
+		git init -q
+		git config user.email 'test@aidevops.local'
+		git config user.name 'Test Runner'
+		git config commit.gpgsign false
+
+		printf 'initial\n' >README.md
+		git add README.md
+		git commit -q -m 'initial'
+
+		# Stage something other than .task-counter
+		printf 'hello\n' >some-file.txt
+		git add some-file.txt
+
+		# shellcheck source=/dev/null
+		source "${TEST_SCRIPTS_DIR}/shared-constants.sh" >/dev/null 2>&1
+		# shellcheck source=/dev/null
+		source <(sed '/^main "\$@"$/d' "$HOOK_PATH") >/dev/null 2>&1
+
+		set +e
+		validate_task_counter_monotonic 2>&1
+		local rc=$?
+		set -e
+		echo "rc=${rc}"
+	)
+	return 0
+}
+
+output=$(_run_no_counter_staged)
+rc=$(printf '%s' "$output" | grep -oE 'rc=[0-9]+$' | tail -1 | cut -d= -f2)
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ "${rc:-1}" -eq 0 ]]; then
+	printf '%sPASS%s .task-counter not staged is a no-op (skipped)\n' "$TEST_GREEN" "$TEST_RESET"
+else
+	printf '%sFAIL%s .task-counter not staged is a no-op (skipped) expected pass got rc=%s; output: %s\n' "$TEST_RED" "$TEST_RESET" "$rc" "$output"
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+
+# Case 5: non-numeric in staged → skip gracefully (pass)
+assert_pass \
+	"non-numeric staged value skipped gracefully" \
+	"2200" \
+	"not-a-number"
+
+# Case 6: no .task-counter in HEAD (first commit introducing it) → pass
+# Non-numeric head_value (empty HEAD) falls through the numeric guard.
+assert_pass \
+	"first commit introducing .task-counter passes (no HEAD value)" \
+	"" \
+	"2200"
+
+# Case 7: HEAD has non-numeric value (legacy) → skip gracefully (pass)
+assert_pass \
+	"non-numeric HEAD value skipped gracefully" \
+	"legacy-value" \
+	"2200"
+
+# =============================================================================
+# Summary
+# =============================================================================
+
+printf '\n%d tests run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds `validate_task_counter_monotonic` to `.agents/scripts/pre-commit-hook.sh` to reject commits that stage a `.task-counter` value lower than HEAD's. Prevents the stale-worktree near-miss from PR #19730 (2026-04-18) where 20 claimed task IDs would have been silently wiped.

## Changes

- **EDIT: `.agents/scripts/pre-commit-hook.sh`** — added `validate_task_counter_monotonic()` function and wired into `main_pre_commit()` after `validate_duplicate_task_ids`
- **NEW: `.agents/scripts/tests/test-pre-commit-hook-counter-monotonic.sh`** — 7-scenario regression test (all pass)

## Validator Behaviour

| Scenario | Result |
|----------|--------|
| `.task-counter` not staged | pass (no-op) |
| staged == HEAD | pass |
| staged > HEAD | pass |
| staged < HEAD | **FAIL** with regression message + fix hint |
| non-numeric staged | pass (graceful skip) |
| non-numeric HEAD (legacy) | pass (graceful skip) |
| first commit (no HEAD counter) | pass |

## Verification

```
$ bash .agents/scripts/tests/test-pre-commit-hook-counter-monotonic.sh
PASS staged == HEAD passes (no-op)
PASS staged < HEAD fails with regression message
PASS staged > HEAD passes (new claim)
PASS .task-counter not staged is a no-op (skipped)
PASS non-numeric staged value skipped gracefully
PASS first commit introducing .task-counter passes (no HEAD value)
PASS non-numeric HEAD value skipped gracefully

7 tests run, 0 failed
```

ShellCheck: zero violations on both files.

Resolves #19749