### PR TITLE
t2408: fix(approval): source shared-constants.sh for comment wrappers

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1820,9 +1820,9 @@
       "pr": 16548
     },
     ".agents/scripts/approval-helper.sh": {
-      "at": "2026-04-14T08:25:15Z",
-      "hash": "5e11b9ad67f1c65ca3f599af558ef858cb1b4132",
-      "passes": 5,
+      "at": "2026-04-19T19:49:13Z",
+      "hash": "c17c9b5caf2a16de9579ab687636f1b20c7f8f03",
+      "passes": 6,
       "pr": 17454
     },
     ".agents/scripts/attribution-detection-helper.sh": {
@@ -2262,9 +2262,9 @@
       "pr": 12145
     },
     ".agents/scripts/full-loop-helper.sh": {
-      "at": "2026-04-19T05:30:53Z",
-      "hash": "0da699d76a8d8fb04cae2b8fc41b4d3a1f27ead4",
-      "passes": 11,
+      "at": "2026-04-19T19:49:16Z",
+      "hash": "0f8ab35f066deead150f2be89671dc13d68f3c10",
+      "passes": 12,
       "pr": 19046
     },
     ".agents/scripts/generate-claude-commands.sh": {
@@ -2310,9 +2310,9 @@
       "pr": 18707
     },
     ".agents/scripts/interactive-session-helper.sh": {
-      "at": "2026-04-19T15:35:43Z",
-      "hash": "7f1ff2dfe9f16e143dad1df55167e4599d192320",
-      "passes": 5,
+      "at": "2026-04-19T19:49:17Z",
+      "hash": "c211c40b61dd90a0462f217099e9d8dc1651f092",
+      "passes": 6,
       "pr": 18843
     },
     ".agents/scripts/issue-sync-helper.sh": {
@@ -2394,15 +2394,15 @@
       "pr": 17590
     },
     ".agents/scripts/pulse-ancillary-dispatch.sh": {
-      "at": "2026-04-15T07:31:55Z",
-      "hash": "ab72fd6b20e25c4e7f8002d79a94fa44e5a71193",
-      "passes": 5,
+      "at": "2026-04-19T19:49:18Z",
+      "hash": "addd94dd0e7fccf14ec501f96df233e13bb7635f",
+      "passes": 6,
       "pr": 18657
     },
     ".agents/scripts/pulse-cleanup.sh": {
-      "at": "2026-04-19T05:30:54Z",
-      "hash": "7ad09a7f4b01d77b7ef3717affa029687235a029",
-      "passes": 5,
+      "at": "2026-04-19T19:49:18Z",
+      "hash": "6e87466afbda81aa546fcfa807ec247e1a377575",
+      "passes": 6,
       "pr": 18704
     },
     ".agents/scripts/pulse-dep-graph.sh": {
@@ -2436,15 +2436,15 @@
       "pr": 18691
     },
     ".agents/scripts/pulse-issue-reconcile.sh": {
-      "at": "2026-04-19T16:33:53Z",
-      "hash": "1c38a184c6d2d2eb18be2c19c9b70a00e99b3ae6",
-      "passes": 12,
+      "at": "2026-04-19T19:49:19Z",
+      "hash": "333bf1d2301ec3f8fdaa92e661f319d0af9d66fd",
+      "passes": 13,
       "pr": 18690
     },
     ".agents/scripts/pulse-merge.sh": {
-      "at": "2026-04-19T05:30:55Z",
-      "hash": "f5d5e9a21c27d84d0ee85ec8ae0704af7c2f3c43",
-      "passes": 16,
+      "at": "2026-04-19T19:49:19Z",
+      "hash": "7c7b2da1a1f161faa84fc6de12329b8e34689adb",
+      "passes": 17,
       "pr": 18829
     },
     ".agents/scripts/pulse-prefetch.sh": {
@@ -2466,15 +2466,15 @@
       "pr": 18680
     },
     ".agents/scripts/pulse-simplification.sh": {
-      "at": "2026-04-19T19:19:44Z",
-      "hash": "5152aaa11f855afe1fa2cac2928e93c26c1f8ed2",
-      "passes": 12,
+      "at": "2026-04-19T19:49:19Z",
+      "hash": "c75571e3c08dc536515010addaee2ad74294f4ff",
+      "passes": 13,
       "pr": 18653
     },
     ".agents/scripts/pulse-triage.sh": {
-      "at": "2026-04-17T20:02:43Z",
-      "hash": "ccdec4f51fd698f9670d95bc44fc0c34c4481119",
-      "passes": 14,
+      "at": "2026-04-19T19:49:20Z",
+      "hash": "f124eb7f52c809170f73ab3c96ec08a388e2bbe3",
+      "passes": 15,
       "pr": 18655
     },
     ".agents/scripts/pulse-wrapper.sh": {
@@ -2496,15 +2496,15 @@
       "pr": 19000
     },
     ".agents/scripts/quality-feedback-issues-lib.sh": {
-      "at": "2026-04-14T22:16:57Z",
-      "hash": "659f27c08e7ad944343d00646a2ccc522fd90bcd",
-      "passes": 1,
+      "at": "2026-04-19T19:49:20Z",
+      "hash": "1896895d66108306b86290d2888e6b17346d5960",
+      "passes": 2,
       "pr": 19004
     },
     ".agents/scripts/routine-log-helper.sh": {
-      "at": "2026-04-19T15:35:45Z",
-      "hash": "38165378dc1fdd3945ea60afac7575fc2a370abd",
-      "passes": 5,
+      "at": "2026-04-19T19:49:20Z",
+      "hash": "42e7c977adf51385bb7a279747b2b31e70ef9772",
+      "passes": 6,
       "pr": 17786
     },
     ".agents/scripts/schema-validator-helper.sh": {
@@ -2544,9 +2544,9 @@
       "pr": 15916
     },
     ".agents/scripts/shared-constants.sh": {
-      "at": "2026-04-19T16:57:28Z",
-      "hash": "ddf89faf7483610db1c7092cf67ed61a95597713",
-      "passes": 12,
+      "at": "2026-04-19T19:49:21Z",
+      "hash": "0e5d4cdf24626e49e9c259934c029b6ffe3e1c56",
+      "passes": 13,
       "pr": 18847
     },
     ".agents/scripts/stats-functions.sh": {
@@ -2556,9 +2556,9 @@
       "pr": 18808
     },
     ".agents/scripts/stats-quality-sweep.sh": {
-      "at": "2026-04-19T19:19:45Z",
-      "hash": "82fa13bd747ca986255f0b39ecbd2274b78aa12a",
-      "passes": 5,
+      "at": "2026-04-19T19:49:21Z",
+      "hash": "91cf86de8603aa66652621ca81fe44ec18b04b27",
+      "passes": 6,
       "pr": 18810
     },
     ".agents/scripts/tabby-helper.sh": {
@@ -2615,15 +2615,15 @@
       "passes": 1
     },
     ".agents/scripts/worker-lifecycle-common.sh": {
-      "at": "2026-04-19T16:33:54Z",
-      "hash": "302d32f4bec7c6f123e4024359dcb9421e5030d0",
-      "passes": 9,
+      "at": "2026-04-19T19:49:22Z",
+      "hash": "8334e61684c800d3c352e35c246741408f28ea35",
+      "passes": 10,
       "pr": 17353
     },
     ".agents/scripts/worker-watchdog.sh": {
-      "at": "2026-04-19T05:30:58Z",
-      "hash": "02fd9b15d344af17fc4e89721aa2c8ff83c68315",
-      "passes": 6,
+      "at": "2026-04-19T19:49:22Z",
+      "hash": "450818e69470a55ecf028cb3619303b63cf54b73",
+      "passes": 7,
       "pr": 17393
     },
     ".agents/scripts/worktree-helper.sh": {
@@ -7492,9 +7492,9 @@
       "pr": 15490
     },
     "aidevops.sh": {
-      "at": "2026-04-19T18:37:10Z",
-      "hash": "9b5d67b5bddfcb9828eb2f57baa521950339c994",
-      "passes": 87,
+      "at": "2026-04-19T19:50:10Z",
+      "hash": "6e9cbe486ccf95dcb0de0817f50dc73de2b25e6a",
+      "passes": 88,
       "pr": 19029
     },
     "setup-modules/agent-deploy.sh": {
@@ -7504,9 +7504,9 @@
       "pr": 19203
     },
     "setup.sh": {
-      "at": "2026-04-19T18:37:10Z",
-      "hash": "df8bff4dde5cc40053f7fe800ebdb3fc19103f84",
-      "passes": 84,
+      "at": "2026-04-19T19:50:10Z",
+      "hash": "5a8b5cbbaebb5379cc22e590e9f57e2992be1f4f",
+      "passes": 85,
       "pr": 15470
     },
     "todo/tasks/GH#15363-brief.md": {

--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -23,6 +23,18 @@
 
 set -euo pipefail
 
+# Source shared-constants for gh_issue_comment / gh_pr_comment wrappers (t2393).
+# PR #19953 replaced raw `gh issue comment` / `gh pr comment` calls with these
+# wrappers to auto-append the t2393 signature footer, but this helper was
+# missed in the sourcing sweep (t2408 / GH#19997). Under `sudo aidevops
+# approve issue|pr`, the unbound wrappers produced `command not found` and
+# blocked every approval. Conditional `[[ -f ]] && source` mirrors the
+# circuit-breaker-helper.sh:29-32 pattern: fail-open if the shared file is
+# missing on a partial install rather than hard-crashing the approval flow.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=shared-constants.sh
+[[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
+
 # Resolve the real user's home directory, handling sudo env_reset on Linux.
 # Under sudo on Linux, HOME is reset to /root/ by env_reset; SUDO_USER holds
 # the original username. getent passwd is the canonical resolver on Linux.

--- a/.agents/scripts/tests/test-approval-wrappers-available.sh
+++ b/.agents/scripts/tests/test-approval-wrappers-available.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# Regression test for t2408 / GH#19997: approval-helper.sh must source
+# shared-constants.sh so the gh_issue_comment / gh_pr_comment wrappers are
+# defined at call time.
+# =============================================================================
+#
+# Background: PR #19953 (t2393) swapped the raw `gh issue comment` /
+# `gh pr comment` calls inside approval-helper.sh for the wrappers, but
+# approval-helper.sh did not source shared-constants.sh. Under
+# `sudo aidevops approve issue <N>` the wrappers were unbound, bash emitted
+# `gh_issue_comment: command not found`, and the approval flow failed
+# without posting the SSH-signed approval comment.
+#
+# This test sources approval-helper.sh in a subshell (bypassing the sudo
+# requirement via the exported ALLOW_APPROVAL_SOURCE guard check — the
+# helper only refuses sudo-sensitive *actions* at call time, not at
+# source time) and asserts both wrappers are present as bash functions.
+# If either is missing, the test fails with a diagnostic.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit
+PARENT_DIR="${SCRIPT_DIR}/.."
+
+PASS=0
+FAIL=0
+
+assert_defined() {
+	local test_name="$1"
+	local fn_name="$2"
+	local source_output="$3"
+	if printf '%s\n' "$source_output" | grep -qxF "FOUND $fn_name"; then
+		echo "  PASS: $test_name"
+		PASS=$((PASS + 1))
+		return 0
+	fi
+	echo "  FAIL: $test_name"
+	echo "    expected: $fn_name to be defined after sourcing approval-helper.sh"
+	echo "    actual source output:"
+	printf '%s\n' "$source_output" | sed 's/^/      /'
+	FAIL=$((FAIL + 1))
+	return 1
+}
+
+echo "Test: approval-helper.sh sources shared-constants.sh for wrappers"
+echo "=================================================================="
+echo ""
+
+# Source approval-helper.sh in a subshell. The helper is normally invoked
+# via `aidevops approve` dispatch, not sourced directly, so we override the
+# dispatch tail by sourcing only — no _main is called. We probe the
+# function table after source.
+source_output=$(
+	bash -c "
+		set -uo pipefail
+		# Prevent approval-helper's top-level argument handling from
+		# executing: it only dispatches when invoked as a script, not when
+		# sourced. Sourcing in this subshell is safe.
+		# shellcheck disable=SC1091
+		source '${PARENT_DIR}/approval-helper.sh' 2>&1 >/dev/null || true
+		for fn in gh_issue_comment gh_pr_comment; do
+			if declare -f \"\$fn\" >/dev/null 2>&1; then
+				echo \"FOUND \$fn\"
+			else
+				echo \"MISSING \$fn\"
+			fi
+		done
+	"
+)
+
+assert_defined "gh_issue_comment is defined after sourcing approval-helper.sh" \
+	"gh_issue_comment" "$source_output"
+assert_defined "gh_pr_comment is defined after sourcing approval-helper.sh" \
+	"gh_pr_comment" "$source_output"
+
+echo ""
+echo "=================================================================="
+echo "Results: ${PASS} passed, ${FAIL} failed"
+
+if [[ $FAIL -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/todo/tasks/t2408-brief.md
+++ b/todo/tasks/t2408-brief.md
@@ -1,0 +1,89 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# t2408: approval-helper.sh missing source of shared-constants.sh
+
+**Issue:** GH#19997
+**Origin:** interactive (user hit the bug running `sudo aidevops approve issue 19992`)
+**Tier:** simple
+**Estimate:** ~15m
+
+## What
+
+Add a conditional `source` of `shared-constants.sh` near the top of `approval-helper.sh` so the `gh_issue_comment` and `gh_pr_comment` wrappers are defined by the time `_approve_target` and `_post_issue_approval_updates` call them.
+
+## Why
+
+PR #19953 (t2393, merged 2026-04-19 19:16Z) replaced `gh issue comment` and `gh pr comment` with the `gh_issue_comment` / `gh_pr_comment` wrappers at:
+
+- `approval-helper.sh:396` (PR approval lock comment)
+- `approval-helper.sh:442` (issue approval comment)
+- `approval-helper.sh:447` (PR approval comment)
+
+The wrappers are defined in `shared-constants.sh:1167,1174` so they auto-append the t2393 signature footer. `approval-helper.sh` does NOT source `shared-constants.sh`, so under `sudo aidevops approve issue <N>` the wrappers are unbound and bash emits:
+
+```
+approval-helper.sh: line 442: gh_issue_comment: command not found
+[ERROR] Failed to post approval comment on issue #<N>
+```
+
+This blocks cryptographic approval entirely — the whole point of the `sudo aidevops approve` gate is to post the SSH-signed comment. Currently every approval attempt fails.
+
+PR #19953 also touched `circuit-breaker-helper.sh` and `loop-common.sh`, but both of those already source `shared-constants.sh` (circuit-breaker-helper.sh:29-32, loop-common.sh:33), so they weren't affected. `approval-helper.sh` is the only directly-invoked caller that was missed.
+
+## How
+
+### Files to modify
+
+- **EDIT:** `.agents/scripts/approval-helper.sh` — add a sourcing block mirroring `circuit-breaker-helper.sh:29-32` after the `set -euo pipefail` line (24) and before the `_resolve_real_home` helper (32). Must be conditional (`[[ -f ]] && source`) so the script doesn't hard-fail if `shared-constants.sh` goes missing on a partial install.
+
+- **NEW:** `.agents/scripts/tests/test-approval-wrappers-available.sh` — regression test that sources `approval-helper.sh` in a subshell and asserts both `gh_issue_comment` and `gh_pr_comment` are defined as functions. Must exit 0 when the wrappers are bound and exit 1 with a diagnostic when they aren't. This catches any future refactor that removes the source line.
+
+### Reference pattern
+
+`.agents/scripts/circuit-breaker-helper.sh:29-32`:
+
+```bash
+# Source shared-constants for gh_create_issue wrapper (t1756)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=shared-constants.sh
+[[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
+```
+
+Copy this block verbatim into `approval-helper.sh`, adjusting only the comment to mention the t2393 wrappers (`gh_issue_comment` / `gh_pr_comment`) rather than `gh_create_issue`.
+
+### Verification
+
+Inside the worktree:
+
+```bash
+# 1. Shellcheck clean
+shellcheck .agents/scripts/approval-helper.sh
+
+# 2. Wrappers resolvable after sourcing
+bash -c 'source .agents/scripts/approval-helper.sh 2>/dev/null || true; declare -f gh_issue_comment >/dev/null && echo "OK gh_issue_comment" || echo "MISS gh_issue_comment"; declare -f gh_pr_comment >/dev/null && echo "OK gh_pr_comment" || echo "MISS gh_pr_comment"'
+
+# 3. Regression test
+.agents/scripts/tests/test-approval-wrappers-available.sh
+
+# 4. End-to-end (separate terminal, requires sudo)
+sudo aidevops approve issue 19997
+```
+
+## Acceptance criteria
+
+- [ ] `approval-helper.sh` sources `shared-constants.sh` using the conditional pattern from `circuit-breaker-helper.sh:29-32`
+- [ ] `gh_issue_comment` and `gh_pr_comment` are defined after sourcing `approval-helper.sh`
+- [ ] `test-approval-wrappers-available.sh` exists and passes
+- [ ] Shellcheck clean on `approval-helper.sh`
+- [ ] `sudo aidevops approve issue <N>` posts a signed approval comment end-to-end
+
+## Tier rationale
+
+`tier:simple`: single file, <10 lines added, verbatim pattern copy from an existing caller, one small test. No judgment calls, no architectural decisions.
+
+## Context
+
+- Downstream impact: every `sudo aidevops approve issue <N>` / `sudo aidevops approve pr <N>` has failed since PR #19953 merged (~3 hours before this task was filed). Issue GH#19992 is currently blocked on manual approval.
+- No revert is needed — PR #19953's t2393 goal (signature footer on approval comments) is still desirable; we just need the wrappers to be reachable.
+- Related: memory recall returned no prior lesson for "gh_issue_comment approval-helper"; store one on completion.


### PR DESCRIPTION
## Summary

- `sudo aidevops approve issue|pr <N>` has been completely broken since PR #19953 (t2393, merged 2026-04-19 19:16Z) — the SSH-signed approval comment fails to post with `gh_issue_comment: command not found` and every approval gate is blocked.
- PR #19953 replaced the raw `gh issue comment` / `gh pr comment` calls at `approval-helper.sh:396,442,447` with the new `gh_issue_comment` / `gh_pr_comment` wrappers (which auto-append the t2393 signature footer), but `approval-helper.sh` does not source `shared-constants.sh` where those wrappers live. The other two files touched by PR #19953 already sourced it (`circuit-breaker-helper.sh:29-32`, `loop-common.sh:33`), so this was the lone miss.
- This PR adds the conditional source line near the top of `approval-helper.sh`, matching the `circuit-breaker-helper.sh:29-32` pattern verbatim (fail-open if `shared-constants.sh` is missing on a partial install rather than hard-crashing sudo flows).

## Reproduction

```
$ sudo aidevops approve issue 19992
Password:
...
Type APPROVE to confirm: APPROVE
/Users/.../approval-helper.sh: line 442: gh_issue_comment: command not found
[ERROR] Failed to post approval comment on issue #19992
```

Observed live by the user on issue #19992 just before this task was filed. Same failure mode applies to `sudo aidevops approve pr <N>`.

## Changes

- **EDIT** `.agents/scripts/approval-helper.sh` — add `SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"` plus `[[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"` right after `set -euo pipefail`. Net +12 lines (including the explanatory comment). Pattern copied from `circuit-breaker-helper.sh:29-32`.
- **NEW** `.agents/scripts/tests/test-approval-wrappers-available.sh` — regression test that sources `approval-helper.sh` in a subshell and asserts `gh_issue_comment` and `gh_pr_comment` are defined. Catches any future refactor that drops the source line.
- **NEW** `todo/tasks/t2408-brief.md` — task brief.

## Verification

Inside the worktree:

```
$ shellcheck .agents/scripts/approval-helper.sh
(no output — clean)

$ .agents/scripts/tests/test-approval-wrappers-available.sh
  PASS: gh_issue_comment is defined after sourcing approval-helper.sh
  PASS: gh_pr_comment is defined after sourcing approval-helper.sh
Results: 2 passed, 0 failed

$ .agents/scripts/tests/test-gh-wrapper-auto-sig.sh
=== Results: 30 passed, 0 failed ===
```

End-to-end smoke (requires sudo, run separately after merge):

```
sudo aidevops approve issue 19997
```

## Scope

Isolated to `approval-helper.sh`. Audit of the other 16 files that call `gh_issue_comment` / `gh_pr_comment` confirmed they either:

- Source `shared-constants.sh` directly (`interactive-session-helper.sh:52`, `stuck-detection-helper.sh:58`, `circuit-breaker-helper.sh:29-32`, `loop-common.sh:33`, `full-loop-helper.sh`, `worker-lifecycle-common.sh`, `dispatch-dedup-stale.sh`, `stats-quality-sweep.sh`, `tier-simple-body-shape-helper.sh`, `routine-log-helper.sh`, `draft-response-helper.sh`, `quality-feedback-issues-lib.sh`), or
- Get it transitively via a parent (`pulse-merge.sh`, `pulse-simplification.sh`, `pulse-cleanup.sh`, `pulse-triage.sh`, `pulse-ancillary-dispatch.sh` — all sourced by `pulse-wrapper.sh`).

No other call sites are affected.

## Risk

Minimal. `shared-constants.sh` has a load guard (`_SHARED_CONSTANTS_LOADED`) so repeated sourcing is safe. The runtime bash 4+ re-exec guard it carries is already proven under sudo (user runs a Homebrew bash 5.3.9 that sudo inherits via PATH). Trivial revert: delete the added block.

Resolves #19997


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.78 plugin for [OpenCode](https://opencode.ai) v1.14.18 with claude-opus-4-7 spent 14m and 25,612 tokens on this with the user in an interactive session.