### PR TITLE
t2229: add CI workflow cascade-vulnerability linter

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -261,6 +261,8 @@ Pre-t2386 the two automation cases were conflated, producing the #19756 infinite
 
 **Complexity Bump Override (t2370):** The `complexity-bump-ok` label overrides the complexity regression gates in `code-quality.yml` (nesting-depth, file-size, function-complexity, bash32-compat). Workers and maintainers may self-apply this label when the PR body contains a validated `## Complexity Bump Justification` section with: (1) at least one `file:line` reference citing the scanner evidence, and (2) at least one numeric measurement (`base=N, head=M, new=K` or similar). Workflow: `.github/workflows/complexity-bump-justification-check.yml` — triggers on `labeled` event, validates the section, and removes the label with a remediation comment if justification is incomplete. This mirrors the `new-file-smell-ok` + justification-section pattern. Primary use case: file splits that trigger nesting-depth false positives from identity-key changes (see `reference/large-file-split.md` section 4.1).
 
+**Workflow Cascade Vulnerability Lint (t2229):** `.github/workflows/workflow-cascade-lint.yml` flags PRs that modify workflows containing the cascade-vulnerable combination: label-like event types (`labeled`, `unlabeled`, `assigned`, etc.) + `cancel-in-progress: true` + no mitigation (`paths-ignore` or event-action guard). See t2220 for the failure mode (15 cancelled runs in ~2s). Helper: `.agents/scripts/workflow-cascade-lint.sh` (supports `--dry-run` for local checks). Override: apply `workflow-cascade-ok` label AND add a `## Workflow Cascade Justification` section to the PR body.
+
 Full workflow: `workflows/git-workflow.md`, `reference/session.md`
 
 ---

--- a/.agents/scripts/tests/test-workflow-cascade-lint.sh
+++ b/.agents/scripts/tests/test-workflow-cascade-lint.sh
@@ -1,0 +1,439 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-workflow-cascade-lint.sh — test harness for workflow-cascade-lint.sh (t2229)
+#
+# Tests the cascade vulnerability linter against fixture YAML files covering:
+# - Vulnerable workflows (labeled + cancel-in-progress + no mitigation)
+# - Mitigated workflows (paths-ignore, event-action guard)
+# - Safe workflows (no labeled trigger, no cancel-in-progress)
+# - Dry-run mode
+#
+# Run: bash .agents/scripts/tests/test-workflow-cascade-lint.sh
+
+# See test-harness-template.sh PITFALL 1: set -e intentionally omitted.
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+SCRIPT_UNDER_TEST="${SCRIPT_DIR}/../workflow-cascade-lint.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+
+# ─── Test infrastructure ────────────────────────────────────────────────────
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+	mkdir -p "${TEST_ROOT}/fixtures"
+	export TEST_ROOT
+
+	# ── Fixture: vulnerable (labeled + cancel-in-progress, no mitigation) ──
+	cat > "${TEST_ROOT}/fixtures/vulnerable.yml" << 'YAML'
+name: Vulnerable Workflow
+on:
+  issues:
+    types: [labeled]
+permissions:
+  issues: write
+jobs:
+  post-comment:
+    if: github.event.label.name == 'needs-maintainer-review'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: nmr-hold-${{ github.event.issue.number }}
+      cancel-in-progress: true
+    steps:
+      - name: Do work
+        run: echo "Working"
+YAML
+
+	# ── Fixture: vulnerable PR (labeled in pull_request types) ──
+	cat > "${TEST_ROOT}/fixtures/vulnerable-pr.yml" << 'YAML'
+name: Vulnerable PR Workflow
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Checking"
+YAML
+
+	# ── Fixture: mitigated with paths-ignore ──
+	cat > "${TEST_ROOT}/fixtures/mitigated-paths-ignore.yml" << 'YAML'
+name: Mitigated With Paths Ignore
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+    paths-ignore:
+      - '**/*.md'
+      - 'todo/**'
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Scanning"
+YAML
+
+	# ── Fixture: mitigated with event-action guard (job-level if) ──
+	cat > "${TEST_ROOT}/fixtures/mitigated-action-guard.yml" << 'YAML'
+name: Mitigated With Action Guard
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  check:
+    if: github.event.action != 'labeled' || contains(github.event.pull_request.labels.*.name, 'target-label')
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Checking"
+YAML
+
+	# ── Fixture: safe (no labeled trigger) ──
+	cat > "${TEST_ROOT}/fixtures/safe-no-labeled.yml" << 'YAML'
+name: Safe No Labeled
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Checking"
+YAML
+
+	# ── Fixture: safe (no cancel-in-progress) ──
+	cat > "${TEST_ROOT}/fixtures/safe-no-cancel.yml" << 'YAML'
+name: Safe No Cancel
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Checking"
+YAML
+
+	# ── Fixture: multi-line types form ──
+	cat > "${TEST_ROOT}/fixtures/vulnerable-multiline.yml" << 'YAML'
+name: Vulnerable Multiline Types
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - labeled
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Checking"
+YAML
+
+	# ── Fixture: mitigated with step-level EVENT_ACTION guard ──
+	cat > "${TEST_ROOT}/fixtures/mitigated-step-guard.yml" << 'YAML'
+name: Mitigated Step Guard
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Guard
+        env:
+          EVENT_ACTION: ${{ github.event.action }}
+          LABEL_NAME: ${{ github.event.label.name }}
+        run: |
+          if { [ "${EVENT_ACTION}" = "labeled" ] || [ "${EVENT_ACTION}" = "unlabeled" ]; } && \
+             [ "${LABEL_NAME}" != "target-label" ]; then
+            echo "Skipping: unrelated label event."
+            exit 0
+          fi
+YAML
+
+	return 0
+}
+
+teardown_test_env() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "${TEST_ROOT}"
+	fi
+	return 0
+}
+
+# ─── Test cases ─────────────────────────────────────────────────────────────
+
+test_vulnerable_issue_workflow() {
+	local output rc
+	output=$(bash "$SCRIPT_UNDER_TEST" "${TEST_ROOT}/fixtures/vulnerable.yml" 2>&1)
+	rc=$?
+	local failed=0
+	if [[ $rc -ne 1 ]]; then
+		failed=1
+	fi
+	if ! echo "$output" | grep -q "VULN"; then
+		failed=1
+	fi
+	print_result "vulnerable issue workflow (labeled + cancel-in-progress)" "$failed" "exit=$rc output=$output"
+	return 0
+}
+
+test_vulnerable_pr_workflow() {
+	local output rc
+	output=$(bash "$SCRIPT_UNDER_TEST" "${TEST_ROOT}/fixtures/vulnerable-pr.yml" 2>&1)
+	rc=$?
+	local failed=0
+	if [[ $rc -ne 1 ]]; then
+		failed=1
+	fi
+	print_result "vulnerable PR workflow (labeled/unlabeled + cancel-in-progress)" "$failed" "exit=$rc"
+	return 0
+}
+
+test_vulnerable_multiline_types() {
+	local output rc
+	output=$(bash "$SCRIPT_UNDER_TEST" "${TEST_ROOT}/fixtures/vulnerable-multiline.yml" 2>&1)
+	rc=$?
+	local failed=0
+	if [[ $rc -ne 1 ]]; then
+		failed=1
+	fi
+	print_result "vulnerable multiline types form" "$failed" "exit=$rc"
+	return 0
+}
+
+test_mitigated_paths_ignore() {
+	local output rc
+	output=$(bash "$SCRIPT_UNDER_TEST" "${TEST_ROOT}/fixtures/mitigated-paths-ignore.yml" 2>&1)
+	rc=$?
+	local failed=0
+	if [[ $rc -ne 0 ]]; then
+		failed=1
+	fi
+	print_result "mitigated with paths-ignore" "$failed" "exit=$rc"
+	return 0
+}
+
+test_mitigated_action_guard() {
+	local output rc
+	output=$(bash "$SCRIPT_UNDER_TEST" "${TEST_ROOT}/fixtures/mitigated-action-guard.yml" 2>&1)
+	rc=$?
+	local failed=0
+	if [[ $rc -ne 0 ]]; then
+		failed=1
+	fi
+	print_result "mitigated with job-level event-action guard" "$failed" "exit=$rc"
+	return 0
+}
+
+test_mitigated_step_guard() {
+	local output rc
+	output=$(bash "$SCRIPT_UNDER_TEST" "${TEST_ROOT}/fixtures/mitigated-step-guard.yml" 2>&1)
+	rc=$?
+	local failed=0
+	if [[ $rc -ne 0 ]]; then
+		failed=1
+	fi
+	print_result "mitigated with step-level EVENT_ACTION guard" "$failed" "exit=$rc"
+	return 0
+}
+
+test_safe_no_labeled_trigger() {
+	local output rc
+	output=$(bash "$SCRIPT_UNDER_TEST" "${TEST_ROOT}/fixtures/safe-no-labeled.yml" 2>&1)
+	rc=$?
+	local failed=0
+	if [[ $rc -ne 0 ]]; then
+		failed=1
+	fi
+	print_result "safe: no labeled trigger type" "$failed" "exit=$rc"
+	return 0
+}
+
+test_safe_no_cancel_in_progress() {
+	local output rc
+	output=$(bash "$SCRIPT_UNDER_TEST" "${TEST_ROOT}/fixtures/safe-no-cancel.yml" 2>&1)
+	rc=$?
+	local failed=0
+	if [[ $rc -ne 0 ]]; then
+		failed=1
+	fi
+	print_result "safe: no cancel-in-progress" "$failed" "exit=$rc"
+	return 0
+}
+
+test_dry_run_exits_zero() {
+	local output rc
+	output=$(bash "$SCRIPT_UNDER_TEST" --dry-run "${TEST_ROOT}/fixtures/vulnerable.yml" 2>&1)
+	rc=$?
+	local failed=0
+	if [[ $rc -ne 0 ]]; then
+		failed=1
+	fi
+	if ! echo "$output" | grep -q "VULN"; then
+		failed=1
+	fi
+	print_result "dry-run mode: lists VULN but exits 0" "$failed" "exit=$rc output=$output"
+	return 0
+}
+
+test_output_md_report() {
+	local output rc report_file
+	report_file="${TEST_ROOT}/report.md"
+	output=$(bash "$SCRIPT_UNDER_TEST" --output-md "$report_file" "${TEST_ROOT}/fixtures/vulnerable.yml" 2>&1)
+	rc=$?
+	local failed=0
+	if [ ! -f "$report_file" ]; then
+		failed=1
+	elif ! grep -q "workflow-cascade-lint" "$report_file"; then
+		failed=1
+	elif ! grep -q "cascade-vulnerable" "$report_file"; then
+		failed=1
+	fi
+	print_result "markdown report generation" "$failed" "exit=$rc report_exists=$([ -f "$report_file" ] && echo yes || echo no)"
+	return 0
+}
+
+test_real_nmr_hold_workflow() {
+	local nmr_file=".github/workflows/nmr-hold-comment.yml"
+	if [ ! -f "$nmr_file" ]; then
+		print_result "real: nmr-hold-comment.yml flagged as VULN" 1 "file not found"
+		return 0
+	fi
+	local output rc
+	output=$(bash "$SCRIPT_UNDER_TEST" "$nmr_file" 2>&1)
+	rc=$?
+	local failed=0
+	if [[ $rc -ne 1 ]]; then
+		failed=1
+	fi
+	if ! echo "$output" | grep -q "VULN"; then
+		failed=1
+	fi
+	print_result "real: nmr-hold-comment.yml flagged as VULN" "$failed" "exit=$rc"
+	return 0
+}
+
+test_real_qlty_regression_mitigated() {
+	local qlty_file=".github/workflows/qlty-regression.yml"
+	if [ ! -f "$qlty_file" ]; then
+		print_result "real: qlty-regression.yml NOT flagged (paths-ignore mitigation)" 1 "file not found"
+		return 0
+	fi
+	local output rc
+	output=$(bash "$SCRIPT_UNDER_TEST" "$qlty_file" 2>&1)
+	rc=$?
+	local failed=0
+	if [[ $rc -ne 0 ]]; then
+		failed=1
+	fi
+	print_result "real: qlty-regression.yml NOT flagged (paths-ignore mitigation)" "$failed" "exit=$rc"
+	return 0
+}
+
+test_real_qlty_new_file_gate_mitigated() {
+	local gate_file=".github/workflows/qlty-new-file-gate.yml"
+	if [ ! -f "$gate_file" ]; then
+		print_result "real: qlty-new-file-gate.yml NOT flagged (paths-ignore + step guard)" 1 "file not found"
+		return 0
+	fi
+	local output rc
+	output=$(bash "$SCRIPT_UNDER_TEST" "$gate_file" 2>&1)
+	rc=$?
+	local failed=0
+	if [[ $rc -ne 0 ]]; then
+		failed=1
+	fi
+	print_result "real: qlty-new-file-gate.yml NOT flagged (paths-ignore + step guard)" "$failed" "exit=$rc"
+	return 0
+}
+
+# ─── Main ────────────────────────────────────────────────────────────────────
+
+main() {
+	printf '=== test-workflow-cascade-lint.sh ===\n\n'
+
+	if [ ! -f "$SCRIPT_UNDER_TEST" ]; then
+		printf '%bFAIL%b Script under test not found: %s\n' "$TEST_RED" "$TEST_RESET" "$SCRIPT_UNDER_TEST"
+		exit 1
+	fi
+
+	setup_test_env
+
+	# Fixture-based tests
+	test_vulnerable_issue_workflow
+	test_vulnerable_pr_workflow
+	test_vulnerable_multiline_types
+	test_mitigated_paths_ignore
+	test_mitigated_action_guard
+	test_mitigated_step_guard
+	test_safe_no_labeled_trigger
+	test_safe_no_cancel_in_progress
+	test_dry_run_exits_zero
+	test_output_md_report
+
+	# Real workflow tests (acceptance criteria)
+	test_real_nmr_hold_workflow
+	test_real_qlty_regression_mitigated
+	test_real_qlty_new_file_gate_mitigated
+
+	teardown_test_env
+
+	printf '\n--- Results: %d/%d passed ---\n' "$((TESTS_RUN - TESTS_FAILED))" "$TESTS_RUN"
+	if [[ $TESTS_FAILED -gt 0 ]]; then
+		printf '%b%d test(s) FAILED%b\n' "$TEST_RED" "$TESTS_FAILED" "$TEST_RESET"
+		exit 1
+	fi
+	printf '%bAll tests passed%b\n' "$TEST_GREEN" "$TEST_RESET"
+	exit 0
+}
+
+main "$@"

--- a/.agents/scripts/workflow-cascade-lint.sh
+++ b/.agents/scripts/workflow-cascade-lint.sh
@@ -1,0 +1,330 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# workflow-cascade-lint.sh — detect cascade-vulnerable CI workflows (t2229)
+#
+# Scans .github/workflows/*.yml for the dangerous combination:
+#   1. Label-like event types in triggers (labeled, unlabeled, assigned,
+#      unassigned, review_requested, review_request_removed) — these fire
+#      once per item, so `gh pr create --label "a,b,c"` fires 3 events.
+#   2. cancel-in-progress: true on any concurrency group.
+#   3. No effective mitigation (paths-ignore or job-level event-action guard).
+#
+# This combination causes rapid-fire event cascades where intermediate
+# workflow runs get cancelled before completing. See t2220 for the canonical
+# failure mode (15 cancelled + 2 success runs of Qlty Regression Gate in
+# ~2s on PR #19704).
+#
+# Usage:
+#   workflow-cascade-lint.sh [options] [file...]
+#   workflow-cascade-lint.sh --dry-run
+#   workflow-cascade-lint.sh --help
+#
+# Options:
+#   --dry-run       List vulnerable files without failing (exit 0)
+#   --scan-dir DIR  Directory to scan (default: .github/workflows)
+#   -h, --help      Show usage and exit 0
+#
+# Exit codes:
+#   0 — no vulnerable workflows found (or --dry-run)
+#   1 — one or more workflows are cascade-vulnerable
+#   2 — usage error
+#
+# When run without file arguments, scans all .github/workflows/*.yml.
+# Files are checked with grep-based heuristics — no yq dependency required.
+
+set -uo pipefail
+
+SCRIPT_NAME=$(basename "$0")
+
+# Label-like event types that fire once per item.
+# These are the triggers that cause rapid-fire cascades when multiple items
+# are applied in a single API call (e.g., gh pr create --label "a,b,c,d").
+CASCADE_EVENT_TYPES="labeled|unlabeled|assigned|unassigned|review_requested|review_request_removed"
+
+# ─── Logging ────────────────────────────────────────────────────────────────
+
+log() {
+	local _msg="$1"
+	printf '[%s] %s\n' "$SCRIPT_NAME" "$_msg" >&2
+	return 0
+}
+
+die() {
+	local _msg="$1"
+	printf '[%s] ERROR: %s\n' "$SCRIPT_NAME" "$_msg" >&2
+	exit 2
+}
+
+usage() {
+	sed -n '4,35p' "$0" | sed 's/^# \{0,1\}//'
+	return 0
+}
+
+# ─── Detection helpers ──────────────────────────────────────────────────────
+
+# has_cascade_triggers <file>
+# Returns 0 if the file contains label-like event types in a types: context.
+# Checks both inline (types: [labeled, ...]) and multi-line (- labeled) forms.
+has_cascade_triggers() {
+	local _file="$1"
+	# Inline form: types: [..., labeled, ...]
+	if grep -qE "types:\s*\[.*\b(${CASCADE_EVENT_TYPES})\b" "$_file"; then
+		return 0
+	fi
+	# Multi-line form: a YAML list item that is exactly a cascade event type
+	if grep -qE "^\s+-\s+(${CASCADE_EVENT_TYPES})\s*$" "$_file"; then
+		return 0
+	fi
+	return 1
+}
+
+# has_cancel_in_progress <file>
+# Returns 0 if cancel-in-progress: true is set anywhere (top-level or job-level).
+has_cancel_in_progress() {
+	local _file="$1"
+	grep -qE 'cancel-in-progress:\s*true' "$_file"
+	return $?
+}
+
+# has_paths_ignore <file>
+# Returns 0 if paths-ignore is present under a trigger section.
+# paths-ignore scopes the trigger to file-changing events, which prevents
+# the cascade for PRs matching the ignore pattern (e.g., docs-only PRs).
+has_paths_ignore() {
+	local _file="$1"
+	grep -qE '^\s+paths-ignore:' "$_file"
+	return $?
+}
+
+# has_event_action_guard <file>
+# Returns 0 if at least one job has an if: condition that gates on
+# github.event.action. This catches patterns like:
+#   if: github.event.action != 'labeled' || contains(...)
+# which prevent cascade by skipping unrelated label events early.
+# Note: checking github.event.label.name alone does NOT mitigate cascade
+# because the run still enters the concurrency group and can be cancelled.
+has_event_action_guard() {
+	local _file="$1"
+	# Job-level if: referencing event.action
+	if grep -qE '^\s+if:.*github\.event\.action' "$_file"; then
+		return 0
+	fi
+	# Step-level early exit on event action (run: block)
+	# Pattern: check EVENT_ACTION or github.event.action in a run block
+	# and exit 0 before doing work — prevents wasting the concurrency slot.
+	if grep -qE 'EVENT_ACTION|github\.event\.action' "$_file" &&
+		grep -qE '(exit 0|echo.*skip|echo.*Skipping)' "$_file"; then
+		return 0
+	fi
+	return 1
+}
+
+# check_file <file>
+# Returns 0 if the file is OK (not vulnerable), 1 if vulnerable.
+check_file() {
+	local _file="$1"
+
+	# Step 1: Does it have cascade-prone trigger types?
+	if ! has_cascade_triggers "$_file"; then
+		return 0
+	fi
+
+	# Step 2: Does it have cancel-in-progress: true?
+	if ! has_cancel_in_progress "$_file"; then
+		return 0
+	fi
+
+	# Step 3: Check mitigations (either is sufficient)
+	if has_paths_ignore "$_file"; then
+		log "MITIGATED (paths-ignore): $_file"
+		return 0
+	fi
+
+	if has_event_action_guard "$_file"; then
+		log "MITIGATED (event-action guard): $_file"
+		return 0
+	fi
+
+	# No mitigation found — vulnerable
+	return 1
+}
+
+# ─── Output formatting ──────────────────────────────────────────────────────
+
+# print_report <vuln_files_file> <vuln_count>
+# Prints a human-readable report of vulnerable workflows.
+print_report() {
+	local _vuln_file="$1"
+	local _count="$2"
+
+	printf '\nCascade-vulnerable workflows detected (%d):\n' "$_count"
+	while IFS= read -r _f; do
+		printf '  - %s\n' "$_f"
+	done < "$_vuln_file"
+	printf '\n'
+	printf 'Remediation:\n'
+	printf '  1. Add paths-ignore under the trigger to scope to file-changing events\n'
+	printf '  2. OR add a job-level if: guard on github.event.action\n'
+	printf '  3. OR remove cancel-in-progress: true from the concurrency group\n'
+	printf '\n'
+	printf 'See: t2220 (evidence), t2228 (parent remediation)\n'
+	printf 'Override: apply the workflow-cascade-ok label with a justification section\n'
+	return 0
+}
+
+# print_markdown_report <vuln_files_file> <vuln_count> <scanned_count>
+# Prints a markdown-formatted report suitable for PR comments.
+print_markdown_report() {
+	local _vuln_file="$1"
+	local _count="$2"
+	local _scanned="$3"
+
+	printf '<!-- workflow-cascade-lint -->\n'
+	printf '## Cascade Vulnerability Lint\n\n'
+	if [ "$_count" -eq 0 ]; then
+		printf 'No cascade-vulnerable workflows detected (%d scanned).\n' "$_scanned"
+		return 0
+	fi
+	printf '**%d workflow(s) have the cascade-vulnerable combination** ' "$_count"
+	# Backticks below are intentional markdown formatting, not command substitution.
+	# shellcheck disable=SC2016
+	printf '(label-like trigger + `cancel-in-progress: true` + no mitigation):\n\n'
+	while IFS= read -r _f; do
+		# shellcheck disable=SC2016
+		printf '- `%s`\n' "$_f"
+	done < "$_vuln_file"
+	printf '\n'
+	printf '### Remediation\n\n'
+	# shellcheck disable=SC2016
+	printf '1. Add `paths-ignore` under the trigger to scope to file-changing events\n'
+	# shellcheck disable=SC2016
+	printf '2. OR add a job-level `if:` guard on `github.event.action`\n'
+	# shellcheck disable=SC2016
+	printf '3. OR remove `cancel-in-progress: true` from the concurrency group\n\n'
+	printf 'See: [t2220](https://github.com/marcusquinn/aidevops/pull/19726) (evidence), '
+	printf '[t2228 parent](https://github.com/marcusquinn/aidevops/issues/19736) (remediation plan)\n\n'
+	# shellcheck disable=SC2016
+	printf '**Override:** apply the `workflow-cascade-ok` label AND add a '
+	# shellcheck disable=SC2016
+	printf '`## Workflow Cascade Justification` section to the PR description.\n'
+	return 0
+}
+
+# ─── Argument parsing ────────────────────────────────────────────────────────
+
+# Globals set by parse_args (used by main)
+_G_DRY_RUN=0
+_G_SCAN_DIR=".github/workflows"
+_G_OUTPUT_MD=""
+_G_FILES=""
+_G_FILE_COUNT=0
+
+parse_args() {
+	while [ $# -gt 0 ]; do
+		local _arg="$1"
+		case "$_arg" in
+		--dry-run)
+			_G_DRY_RUN=1
+			shift
+			;;
+		--scan-dir)
+			if [ $# -lt 2 ]; then die "--scan-dir requires a directory argument"; fi
+			local _val_dir="$2"
+			_G_SCAN_DIR="$_val_dir"
+			shift 2
+			;;
+		--output-md)
+			if [ $# -lt 2 ]; then die "--output-md requires a file path argument"; fi
+			local _val_md="$2"
+			_G_OUTPUT_MD="$_val_md"
+			shift 2
+			;;
+		-h | --help)
+			usage
+			exit 0
+			;;
+		-*)
+			die "Unknown option: $_arg"
+			;;
+		*)
+			_G_FILES="${_G_FILES}${_G_FILES:+$'\n'}$_arg"
+			_G_FILE_COUNT=$((_G_FILE_COUNT + 1))
+			shift
+			;;
+		esac
+	done
+	return 0
+}
+
+# collect_files — populate _G_FILES from _G_SCAN_DIR when no explicit files given
+collect_files() {
+	if [ "$_G_FILE_COUNT" -gt 0 ]; then
+		return 0
+	fi
+	if [ ! -d "$_G_SCAN_DIR" ]; then
+		log "No workflow directory found at $_G_SCAN_DIR — nothing to scan."
+		exit 0
+	fi
+	while IFS= read -r _f; do
+		_G_FILES="${_G_FILES}${_G_FILES:+$'\n'}$_f"
+		_G_FILE_COUNT=$((_G_FILE_COUNT + 1))
+	done < <(find "$_G_SCAN_DIR" -maxdepth 1 -name '*.yml' -type f | sort)
+	if [ "$_G_FILE_COUNT" -eq 0 ]; then
+		log "No .yml files found in $_G_SCAN_DIR."
+		exit 0
+	fi
+	return 0
+}
+
+# ─── Main ────────────────────────────────────────────────────────────────────
+
+main() {
+	parse_args "$@"
+	collect_files
+
+	local _vuln_count=0
+	local _scanned=0
+	local _vuln_tmp
+	_vuln_tmp=$(mktemp)
+
+	while IFS= read -r _f; do
+		[ -z "$_f" ] && continue
+		if [ ! -f "$_f" ]; then
+			log "SKIP (not a file): $_f"
+			continue
+		fi
+		_scanned=$((_scanned + 1))
+
+		if ! check_file "$_f"; then
+			_vuln_count=$((_vuln_count + 1))
+			printf '%s\n' "$_f" >> "$_vuln_tmp"
+			printf 'VULN %s\n' "$_f"
+		fi
+	done <<< "$_G_FILES"
+
+	log "Scanned $_scanned workflow(s): $_vuln_count vulnerable."
+
+	# Write markdown report if requested
+	if [ -n "$_G_OUTPUT_MD" ]; then
+		print_markdown_report "$_vuln_tmp" "$_vuln_count" "$_scanned" > "$_G_OUTPUT_MD"
+	fi
+
+	# Dry-run: always exit 0
+	if [ "$_G_DRY_RUN" -eq 1 ]; then
+		rm -f "$_vuln_tmp"
+		exit 0
+	fi
+
+	if [ "$_vuln_count" -gt 0 ]; then
+		print_report "$_vuln_tmp" "$_vuln_count"
+		rm -f "$_vuln_tmp"
+		exit 1
+	fi
+
+	rm -f "$_vuln_tmp"
+	exit 0
+}
+
+main "$@"

--- a/.github/workflows/workflow-cascade-lint.yml
+++ b/.github/workflows/workflow-cascade-lint.yml
@@ -1,0 +1,130 @@
+name: Workflow Cascade Lint
+
+# t2229: CI gate that detects cascade-vulnerable workflow configurations.
+#
+# Flags any .github/workflows/*.yml that combines label-like event types
+# (labeled, unlabeled, assigned, etc.) with cancel-in-progress: true and
+# no mitigation (paths-ignore or event-action guard).
+#
+# See t2220 for the failure mode this prevents.
+#
+# Override: apply the `workflow-cascade-ok` label AND add a
+# `## Workflow Cascade Justification` section to the PR body.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - '.github/workflows/**'
+
+permissions:
+  pull-requests: write
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Cascade Vulnerability Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Get changed workflow files
+        id: changed
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          changed=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- '.github/workflows/*.yml' || true)
+          if [ -z "$changed" ]; then
+            echo "No workflow files changed."
+            echo "has_files=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          printf 'Changed workflow files:\n%s\n' "$changed"
+          echo "has_files=true" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "$changed" > /tmp/changed-workflows.txt
+
+      - name: Run cascade vulnerability lint
+        if: steps.changed.outputs.has_files == 'true'
+        id: scan
+        run: |
+          set +e
+          files=$(cat /tmp/changed-workflows.txt | tr '\n' ' ')
+          # shellcheck disable=SC2086
+          output=$(bash .agents/scripts/workflow-cascade-lint.sh \
+            --output-md /tmp/cascade-lint-report.md \
+            $files 2>&1)
+          exit_code=$?
+          set -e
+          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "$output"
+
+      - name: Post PR comment
+        if: steps.changed.outputs.has_files == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          body_file=/tmp/cascade-lint-report.md
+          if [ ! -s "$body_file" ]; then
+            echo "No report to post."
+            exit 0
+          fi
+          marker="<!-- workflow-cascade-lint -->"
+          existing=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --jq "[.[] | select(.body | contains(\"$marker\")) | .id] | .[0] // empty" \
+            2>/dev/null || true)
+          if [ -n "$existing" ]; then
+            echo "Updating existing comment $existing"
+            gh api "repos/${REPO}/issues/comments/${existing}" \
+              --method PATCH -F body=@"$body_file" >/dev/null 2>&1 || true
+          else
+            echo "Creating new comment"
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file "$body_file" \
+              >/dev/null 2>&1 || true
+          fi
+
+      - name: Enforce gate
+        if: steps.changed.outputs.has_files == 'true'
+        env:
+          HAS_OVERRIDE: ${{ contains(github.event.pull_request.labels.*.name, 'workflow-cascade-ok') }}
+          AUTHOR_ASSOC: ${{ github.event.pull_request.author_association }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          EXIT_CODE: ${{ steps.scan.outputs.exit_code }}
+        run: |
+          set -euo pipefail
+          if [ "${EXIT_CODE:-0}" = "0" ]; then
+            echo "Workflow cascade lint: no vulnerable workflows in changed files."
+            exit 0
+          fi
+          if [ "$EXIT_CODE" != "1" ]; then
+            echo "::error::Linter exited with unexpected code: $EXIT_CODE"
+            exit 1
+          fi
+          # Check for override label + justification section
+          if [ "$HAS_OVERRIDE" != "true" ]; then
+            echo "::error::Cascade-vulnerable workflow(s) detected. Apply the 'workflow-cascade-ok' label AND add a '## Workflow Cascade Justification' section to the PR description to override."
+            exit 1
+          fi
+          # Override requires OWNER or MEMBER authorship
+          if [ "$AUTHOR_ASSOC" != "OWNER" ] && [ "$AUTHOR_ASSOC" != "MEMBER" ]; then
+            echo "::error::'workflow-cascade-ok' override requires OWNER or MEMBER authorship (got: ${AUTHOR_ASSOC})."
+            exit 1
+          fi
+          # Require justification section in PR body
+          if printf '%s' "$PR_BODY" | grep -qE '^##+[[:space:]]+Workflow Cascade Justification'; then
+            echo "::warning::Cascade-vulnerable workflow(s) detected but 'workflow-cascade-ok' label + justification present (maintainer override) — allowing with warning."
+            exit 0
+          fi
+          echo "::error::'workflow-cascade-ok' label is set but PR description is missing a '## Workflow Cascade Justification' section."
+          exit 1


### PR DESCRIPTION
## Summary

- Added `.agents/scripts/workflow-cascade-lint.sh` — grep-based linter that detects the cascade-vulnerable combination of label-like event types + `cancel-in-progress: true` + no mitigation
- Added `.github/workflows/workflow-cascade-lint.yml` — CI gate that runs on PRs touching `.github/workflows/**`, posts a PR comment with findings, supports `workflow-cascade-ok` label + justification section bypass
- Added 13-case test harness (`.agents/scripts/tests/test-workflow-cascade-lint.sh`) with fixture YAML files and real-workflow validation
- Documented in `.agents/AGENTS.md` under the existing gates section

## Testing

All 13 tests pass (`bash .agents/scripts/tests/test-workflow-cascade-lint.sh`):
- nmr-hold-comment.yml flagged as VULN (acceptance criteria)
- qlty-regression.yml NOT flagged (paths-ignore mitigation)
- qlty-new-file-gate.yml NOT flagged (paths-ignore + step guard)
- ShellCheck clean (SC2016 intentionally suppressed for markdown backticks)

## Complexity Bump Justification

Pre-existing baseline drift in `aidevops.sh:434` (`register_repo` function, 101 lines) — not introduced by this PR. This PR does not modify `aidevops.sh`. The function-complexity regression gate reports: `base=29, head=30, new=1`. The sole new violation is `aidevops.sh:register_repo` at 101 lines vs the 100-line threshold. The count difference is from baseline drift between the merge-base and HEAD, not from changes in this PR.

For #19736
Resolves #19738