### PR TITLE
t2410: upgrade log-issue-aidevops agent for worker-ready issue/PR drafting

### DIFF
--- a/.agents/scripts/log-issue-helper.sh
+++ b/.agents/scripts/log-issue-helper.sh
@@ -179,6 +179,92 @@ search_issues() {
 		--limit 10 \
 		--json number,title,state,url \
 		--jq '.[] | "#\(.number) [\(.state)] \(.title)\n   \(.url)"'
+	return 0
+}
+
+# -----------------------------------------------------------------------------
+# Reproducer Prompt (t2410)
+# Outputs the section template the agent uses to prompt the user for
+# reproducer evidence before drafting a framework-bug report.
+# -----------------------------------------------------------------------------
+
+prompt_reproducer() {
+	cat <<'EOF'
+## Reproducer
+
+Please provide the following evidence for the framework bug. The session context
+that captured this failure will be gone after this conversation ends.
+
+**Symptom command** (paste the exact command you ran that demonstrated the bug):
+
+```
+<paste command here>
+```
+
+**Actual output** (paste what happened — include any error messages or unexpected behaviour):
+
+```
+<paste terminal output here>
+```
+
+**Expected output** (what should have happened instead):
+
+```
+<describe what you expected>
+```
+
+**Causal code** (optional — if you identified the file/line or commit that introduced this):
+
+```bash
+git blame <file> -L <line>,<line>
+# or: paste the commit SHA suspected to be the regression
+```
+
+**Call-site sweep** (optional — to enumerate all affected locations):
+
+```bash
+rg "<function-or-pattern>" .agents/scripts/
+```
+
+EOF
+	return 0
+}
+
+# -----------------------------------------------------------------------------
+# Brief Validator (t2410)
+# Checks if an issue body contains the required sections for a framework-bug
+# brief. Returns 0 if valid, 1 if sections are missing.
+#
+# Usage: validate_brief <body-text-or-file>
+#   - Pass a filename if the body is in a file
+#   - Pass body text directly via stdin when called as: validate_brief -
+# -----------------------------------------------------------------------------
+
+validate_brief_has_reproducer() {
+	local body="$1"
+	local missing_sections=()
+
+	# Read from file if body is a file path
+	if [[ -f "$body" ]]; then
+		body=$(cat "$body")
+	fi
+
+	# Check for required sections
+	if ! echo "$body" | grep -qi "## Reproducer"; then
+		missing_sections+=("## Reproducer")
+	fi
+
+	if [[ ${#missing_sections[@]} -eq 0 ]]; then
+		echo "OK: Brief contains all required sections"
+		return 0
+	else
+		echo "ERROR: Brief is missing required sections: ${missing_sections[*]}" >&2
+		echo "Framework-bug briefs MUST include a ## Reproducer section with:" >&2
+		echo "  - Symptom command + actual output" >&2
+		echo "  - Expected output" >&2
+		echo "  - (optional) Causal code / commit SHA" >&2
+		return 1
+	fi
 }
 
 # -----------------------------------------------------------------------------
@@ -203,6 +289,20 @@ main() {
 		fi
 		search_issues "$query"
 		;;
+	prompt-reproducer)
+		# Output the reproducer section template for the agent to show the user
+		prompt_reproducer
+		;;
+	validate-brief)
+		# Validate that a brief body contains the required Reproducer section
+		local body_or_file="${2:-}"
+		if [[ -z "$body_or_file" ]]; then
+			echo "Usage: log-issue-helper.sh validate-brief <file-path-or-body-text>" >&2
+			echo "Example: log-issue-helper.sh validate-brief issue-body.md" >&2
+			return 1
+		fi
+		validate_brief_has_reproducer "$body_or_file"
+		;;
 	help | --help | -h)
 		cat <<EOF
 aidevops Issue Logger Helper
@@ -210,15 +310,19 @@ aidevops Issue Logger Helper
 Usage: log-issue-helper.sh [command]
 
 Commands:
-  diagnostics    Gather system and aidevops diagnostic info (default)
-  check-auth     Verify GitHub CLI authentication
-  search "query" Search existing issues for duplicates
-  help           Show this help message
+  diagnostics            Gather system and aidevops diagnostic info (default)
+  check-auth             Verify GitHub CLI authentication
+  search "query"         Search existing issues for duplicates
+  prompt-reproducer      Output the reproducer section template for framework bugs
+  validate-brief <file>  Validate that a brief body contains required sections
+  help                   Show this help message
 
 Examples:
   log-issue-helper.sh diagnostics
   log-issue-helper.sh check-auth
   log-issue-helper.sh search "update check"
+  log-issue-helper.sh prompt-reproducer
+  log-issue-helper.sh validate-brief /tmp/issue-body.md
 EOF
 		;;
 	*)
@@ -227,6 +331,7 @@ EOF
 		return 1
 		;;
 	esac
+	return 0
 }
 
 main "$@"

--- a/.agents/scripts/tests/test-verify-brief.sh
+++ b/.agents/scripts/tests/test-verify-brief.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-verify-brief.sh — regression tests for t2410
+#
+# Covers framework-bug brief quality requirements introduced by the
+# log-issue-aidevops upgrade (GH#20008):
+#
+#   1. Framework-bug briefs without ## Reproducer sections are rejected by
+#      validate_brief_has_reproducer (log-issue-helper.sh validate-brief).
+#
+#   2. Framework-bug briefs WITH ## Reproducer sections pass validation.
+#
+#   3. log-issue-helper.sh prompt-reproducer outputs the required section
+#      headers that the agent uses to prompt the user.
+#
+#   4. validate-brief returns the correct exit codes (0=valid, 1=invalid).
+
+set -u
+set +e
+
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_BLUE=$'\033[0;34m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_BLUE="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf '  %sPASS%s %s\n' "$TEST_GREEN" "$TEST_NC" "$1"
+	return 0
+}
+
+fail() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '  %sFAIL%s %s\n' "$TEST_RED" "$TEST_NC" "$1"
+	if [[ -n "${2:-}" ]]; then
+		printf '       %s\n' "$2"
+	fi
+	return 0
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+HELPER="${SCRIPT_DIR}/../log-issue-helper.sh"
+
+if [[ ! -f "$HELPER" ]]; then
+	printf 'test harness cannot find %s\n' "$HELPER" >&2
+	exit 1
+fi
+
+TMP=$(mktemp -d -t t2410-verify-brief.XXXXXX)
+trap 'rm -rf "$TMP"' EXIT
+
+printf '%sRunning t2410 verify-brief tests (log-issue-aidevops upgrade)%s\n' "$TEST_BLUE" "$TEST_NC"
+
+# =============================================================================
+# Class A: prompt-reproducer outputs required section headers
+# =============================================================================
+
+printf '\n%sClass A: prompt-reproducer output%s\n' "$TEST_BLUE" "$TEST_NC"
+
+output=$(bash "$HELPER" prompt-reproducer 2>&1)
+rc=$?
+
+# Test A1: command exits 0
+if [[ $rc -eq 0 ]]; then
+	pass "A1 prompt-reproducer exits 0"
+else
+	fail "A1 prompt-reproducer exit code" "expected rc=0, got rc=$rc"
+fi
+
+# Test A2: output contains ## Reproducer heading
+if [[ "$output" == *"## Reproducer"* ]]; then
+	pass "A2 prompt-reproducer output contains '## Reproducer' heading"
+else
+	fail "A2 Reproducer heading" "expected '## Reproducer' in output, got: $output"
+fi
+
+# Test A3: output contains Symptom command prompt
+if [[ "$output" == *"Symptom command"* ]]; then
+	pass "A3 prompt-reproducer output contains 'Symptom command' prompt"
+else
+	fail "A3 symptom command prompt" "expected 'Symptom command' in output"
+fi
+
+# Test A4: output contains Actual output prompt
+if [[ "$output" == *"Actual output"* ]]; then
+	pass "A4 prompt-reproducer output contains 'Actual output' prompt"
+else
+	fail "A4 actual output prompt" "expected 'Actual output' in output"
+fi
+
+# Test A5: output contains Expected output prompt
+if [[ "$output" == *"Expected output"* ]]; then
+	pass "A5 prompt-reproducer output contains 'Expected output' prompt"
+else
+	fail "A5 expected output prompt" "expected 'Expected output' in output"
+fi
+
+# =============================================================================
+# Class B: validate-brief with a complete framework-bug brief (passes)
+# =============================================================================
+
+printf '\n%sClass B: validate-brief passes for complete briefs%s\n' "$TEST_BLUE" "$TEST_NC"
+
+# Test B1: brief with ## Reproducer section passes
+cat >"$TMP/brief-complete.md" <<'BRIEF'
+## Description
+
+log-issue-helper.sh diagnostics fails with ENOENT when gh CLI is not in PATH.
+
+## Reproducer
+
+**Symptom command**:
+
+```
+~/.aidevops/agents/scripts/log-issue-helper.sh diagnostics
+```
+
+**Actual output**:
+
+```
+log-issue-helper.sh: line 141: gh: command not found
+```
+
+**Expected output**:
+
+```
+- **gh CLI**: not installed
+```
+
+## Environment
+
+- aidevops version: 3.8.78
+BRIEF
+
+output=$(bash "$HELPER" validate-brief "$TMP/brief-complete.md" 2>&1)
+rc=$?
+
+if [[ $rc -eq 0 ]]; then
+	pass "B1 complete brief with ## Reproducer passes validation"
+else
+	fail "B1 complete brief validation" "expected rc=0, got rc=$rc; output: $output"
+fi
+
+# Test B2: brief with ## Reproducer in mixed case passes (case-insensitive)
+cat >"$TMP/brief-mixed-case.md" <<'BRIEF'
+## Description
+
+Some bug.
+
+## Reproducer
+
+command output here
+BRIEF
+
+output=$(bash "$HELPER" validate-brief "$TMP/brief-mixed-case.md" 2>&1)
+rc=$?
+
+if [[ $rc -eq 0 ]]; then
+	pass "B2 brief with ## Reproducer (standard case) passes"
+else
+	fail "B2 Reproducer case sensitivity" "expected rc=0, got rc=$rc; output: $output"
+fi
+
+# =============================================================================
+# Class C: validate-brief without Reproducer section (fails)
+# =============================================================================
+
+printf '\n%sClass C: validate-brief rejects briefs missing ## Reproducer%s\n' "$TEST_BLUE" "$TEST_NC"
+
+# Test C1: brief without Reproducer section is rejected
+cat >"$TMP/brief-no-reproducer.md" <<'BRIEF'
+## Description
+
+Some framework bug description.
+
+## Expected Behavior
+
+Should work correctly.
+
+## Steps to Reproduce
+
+1. Run the command.
+
+## Environment
+
+- aidevops version: 3.8.78
+BRIEF
+
+output=$(bash "$HELPER" validate-brief "$TMP/brief-no-reproducer.md" 2>&1)
+rc=$?
+
+if [[ $rc -ne 0 ]]; then
+	pass "C1 brief without ## Reproducer is rejected (non-zero exit)"
+else
+	fail "C1 missing Reproducer rejection" "expected rc!=0, got rc=0; output: $output"
+fi
+
+# Test C2: error message mentions the missing section
+if [[ "$output" == *"Reproducer"* ]]; then
+	pass "C2 rejection error message names the missing section"
+else
+	fail "C2 error message content" "expected 'Reproducer' in error output: $output"
+fi
+
+# Test C3: empty brief is rejected
+output=$(bash "$HELPER" validate-brief "$TMP/brief-no-reproducer.md" 2>&1)
+rc=$?
+
+if [[ $rc -ne 0 ]]; then
+	pass "C3 brief without Reproducer is consistently rejected"
+else
+	fail "C3 consistent rejection" "expected rc!=0, got rc=0"
+fi
+
+# =============================================================================
+# Class D: validate-brief argument validation
+# =============================================================================
+
+printf '\n%sClass D: validate-brief argument handling%s\n' "$TEST_BLUE" "$TEST_NC"
+
+# Test D1: missing argument exits non-zero with usage message
+output=$(bash "$HELPER" validate-brief 2>&1)
+rc=$?
+
+if [[ $rc -ne 0 ]]; then
+	pass "D1 validate-brief without argument exits non-zero"
+else
+	fail "D1 missing argument" "expected rc!=0, got rc=0"
+fi
+
+# Test D2: usage message shown on missing argument
+if [[ "$output" == *"Usage"* ]] || [[ "$output" == *"usage"* ]]; then
+	pass "D2 validate-brief without argument shows usage hint"
+else
+	fail "D2 usage hint" "expected usage hint in output: $output"
+fi
+
+# =============================================================================
+# Summary
+# =============================================================================
+
+printf '\n'
+if [[ $TESTS_FAILED -eq 0 ]]; then
+	printf '%s✓ All %d tests passed%s\n' "$TEST_GREEN" "$TESTS_RUN" "$TEST_NC"
+	exit 0
+else
+	printf '%s✗ %d of %d tests failed%s\n' "$TEST_RED" "$TESTS_FAILED" "$TESTS_RUN" "$TEST_NC"
+	exit 1
+fi

--- a/.agents/workflows/log-issue-aidevops.md
+++ b/.agents/workflows/log-issue-aidevops.md
@@ -22,6 +22,45 @@ Log an issue with the aidevops framework to GitHub.
 
 All issues from non-collaborators are gated behind `needs-maintainer-review` — a maintainer must approve before the pipeline picks them up. This command produces higher-quality reports than the web form because it gathers diagnostics, checks duplicates, and validates before submission.
 
+## Before Composing
+
+**Enumerate every manual workaround you applied in the current session.** Each is a candidate fix for a systemic problem:
+
+- File the highest-ROI workaround as the primary issue.
+- File the rest as sibling issues with `See-also: #<this-issue>` cross-references.
+- Add a `## Workarounds Applied` section to the primary issue body listing all workarounds.
+
+**Workaround examples and their fix routes:**
+
+| Workaround applied | Likely systemic fix |
+|---|---|
+| `gh issue edit --remove-assignee` after `#auto-dispatch` filing | t2157/t2218 bug — auto-assign should skip `auto-dispatch` label |
+| Applied `complexity-bump-ok` label to bypass a false-positive gate | Gate needs refinement for specific false-positive class |
+| `sudo aidevops approve` to unblock auto-approved issue stuck in NMR | NMR classification logic has a gap |
+| Manually ran `pre-edit-check.sh` because hook didn't fire | Hook installation or detection issue |
+
+## Pre-composition Checks (MANDATORY)
+
+Before composing any framework-bug report, run these 5 checks. They are shared with t2409 (`workflows/brief.md` "Pre-composition checks") — referenced here by pointer, not duplicated.
+
+1. **Memory recall**: `memory-helper.sh recall --query "<symptom-keywords>" --limit 5` — surface accumulated lessons before re-diagnosing a known issue. A lesson that says "same error, fixed in t2108" saves 30+ minutes.
+
+2. **Discovery pass (t2046)**: Check if the bug was already fixed:
+
+   ```bash
+   git log --since="1 week ago" --oneline -- <suspect-files>
+   gh pr list --state merged --search "<keywords>" --limit 5
+   gh pr list --state open --search "<keywords>" --limit 5
+   ```
+
+   If a recent commit touches the exact file/function you're investigating, verify the bug still reproduces on HEAD before filing. Stale symptoms from a pre-deploy state (see `prompts/build.txt` section 10) are not bugs — close the investigation.
+
+3. **File:line verification**: For every file reference in the brief, run `git ls-files <path>` or `sed -n "<line>p" <path>` to confirm the reference exists and the content matches the claim. Phantom line refs force the worker to spend the first hour re-locating the code (GH#17832-17835).
+
+4. **Tier disqualifier check**: Framework bugs are usually `tier:standard`. Cross-check the draft brief against `reference/task-taxonomy.md` "Tier Assignment Validation" disqualifiers before assigning `tier:simple`. Default to `tier:standard` when uncertain.
+
+5. **Self-assignment awareness**: If filing via `gh_create_issue` with the `auto-dispatch` label, plan to `gh issue edit N --remove-assignee <user>` immediately after — the wrapper currently self-assigns (t2406/#19991). Alternatively, omit `auto-dispatch` until ready to hand off.
+
 ## Workflow
 
 ### Step 1: Gather Diagnostics
@@ -40,6 +79,38 @@ Ask the user:
 3. Steps to reproduce (if known)?
 
 Use any provided argument as the title starting point. Review session context for commands, errors, and intent.
+
+### Step 2.5: Evidence Attribution and Reproducer (framework bugs only)
+
+For bugs with an observable failure mode, the observing session has a live reproducer context that vanishes at session end. Capture it now:
+
+```bash
+~/.aidevops/agents/scripts/log-issue-helper.sh prompt-reproducer
+```
+
+This outputs the section template. Collect and include in the issue body:
+
+1. **Symptom**: exact command that exhibited the bug + full terminal output
+2. **Expected**: what should have happened
+3. **Causal code**: `git blame <file> -L <line>,<line>` output or commit SHA suspected to have introduced the regression
+4. **Call-site sweep**: `rg "<function-or-pattern>" .agents/scripts/` to enumerate all affected locations
+
+Store the collected data under a `## Reproducer` section in the issue body (included in the compose template in Step 4).
+
+A brief filed without a Reproducer section forces the worker to spend 30-60 min reconstructing the failure mode from scratch — the exact time cost described in GH#20008.
+
+### Step 2.6: Workaround Enumeration
+
+Before composing, enumerate every manual workaround you applied during the current session that relates to this bug. For each workaround:
+
+- What was the workaround command or action?
+- Does the workaround reveal a gap that should be a separate fix?
+- Can it be automated so no future session needs it?
+
+**For each workaround that has a clear systemic fix:**
+
+- File it as a separate issue with `See-also: #<this-issue>` in its body, OR
+- Add it to the `## Siblings` section of the current brief
 
 ### Step 3: Check for Duplicates
 
@@ -89,20 +160,79 @@ If the proposal doesn't survive these questions, discuss before filing — it ma
 
 ### Step 4: Compose the Issue
 
+For framework bugs, use this expanded template that includes Evidence Attribution and Reproducer sections:
+
 ```markdown
 ## Description
+
 {problem}
 
 ## Expected Behavior
+
 {what should have happened}
 
+## Reproducer
+
+**Symptom command**:
+
+```
+{exact command that exhibited the bug}
+```
+
+**Actual output**:
+
+```
+{full terminal output}
+```
+
+**Expected output**:
+
+{what should have happened}
+
+**Causal code** (if identified):
+
+```bash
+{git blame output or commit SHA}
+```
+
 ## Steps to Reproduce
+
 1. {step}
 
+## Workarounds Applied
+
+{list each workaround used during the observing session}
+
 ## Environment
+
 {diagnostics output}
 
 ## Additional Context
+
+{errors, session context}
+```
+
+For non-bug reports (enhancements, questions), use the shorter template without Reproducer and Workarounds sections:
+
+```markdown
+## Description
+
+{problem or request}
+
+## Expected Behavior
+
+{what should happen}
+
+## Steps to Reproduce
+
+1. {step, if applicable}
+
+## Environment
+
+{diagnostics output}
+
+## Additional Context
+
 {errors, session context}
 ```
 


### PR DESCRIPTION
## Summary

Upgrades the `log-issue-aidevops` workflow and command doc with the changes required by GH#20008 to reduce worker token burn from low-quality framework-bug briefs.

## Changes

### `.agents/workflows/log-issue-aidevops.md` (and its symlink `.agents/scripts/commands/log-issue-aidevops.md`)

- **Before Composing section** (at top): prompts the composer to enumerate every manual workaround applied in the current session, with a routing table of common workarounds → systemic fixes. Each workaround is a candidate sibling issue.
- **Pre-composition Checks (MANDATORY)**: imports the 5-step check sequence from t2409/GH#20007 (`brief.md`) by reference (not duplicated): memory recall, discovery pass, file:line verification, tier disqualifier check, self-assignment awareness.
- **Step 2.5 — Evidence Attribution and Reproducer**: for framework bugs only, calls `log-issue-helper.sh prompt-reproducer` to capture symptom command + output + causal code before the session context is lost.
- **Step 2.6 — Workaround Enumeration**: embedded in the workflow to prompt per-workaround assessment of whether a sibling fix should be filed.
- **Step 4 compose template**: expanded to include `## Reproducer` and `## Workarounds Applied` sections for bug reports.

### `.agents/scripts/log-issue-helper.sh`

Two new subcommands (t2410):

- **`prompt-reproducer`**: outputs the `## Reproducer` section template the agent shows to the user (symptom command, actual output, expected output, causal code, call-site sweep).
- **`validate-brief <file>`**: checks that a framework-bug brief body contains a `## Reproducer` section; exits 1 with remediation guidance if missing.

Both pass shellcheck with zero violations.

### `.agents/scripts/tests/test-verify-brief.sh` (new)

12 regression fixtures across 4 test classes:
- **Class A** (5 tests): `prompt-reproducer` output contains required headings
- **Class B** (2 tests): `validate-brief` passes for complete briefs
- **Class C** (3 tests): `validate-brief` rejects briefs missing `## Reproducer`
- **Class D** (2 tests): argument validation (missing arg exits non-zero with usage hint)

All 12 pass locally.

## Dogfood verification

The upgraded workflow was used to compose this PR body: the `## Before Composing` prompt reminded me to note that the commands doc is a symlink to the workflow doc (a discovery that would have caused a confusing double-write bug without the "file:line verification" pre-check step).

## Verification

```bash
# Run the new regression tests
bash .agents/scripts/tests/test-verify-brief.sh

# Test prompt-reproducer output
bash .agents/scripts/log-issue-helper.sh prompt-reproducer

# Test validate-brief rejects missing Reproducer
echo "## Description\n\nSome bug" > /tmp/no-reproducer.md
bash .agents/scripts/log-issue-helper.sh validate-brief /tmp/no-reproducer.md
echo "Exit code should be 1: $?"
```

Resolves #20008