### PR TITLE
t2412: retarget stacked PRs before base-branch merge to prevent auto-close

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -226,6 +226,16 @@ Worktrees: `wt switch -c {type}/{name}`. Keep the canonical repo directory on `m
 
 **Traceability and signature footer:** Hard rules in `prompts/build.txt` (sections "Traceability" and "#8 Signature footer"). Link both sides when closing (issue→PR, PR→issue). Do NOT pass `--issue` when creating new issues (the issue doesn't exist yet). See `scripts/commands/pulse.md` for dispatch/kill/merge comment templates.
 
+**Stacked PRs (t2412):** Stacked PRs (`--base feature/<other-branch>`) are retargeted to the default branch before the parent merges. This is automatic in `pulse-merge.sh` (`_retarget_stacked_children`) and `full-loop-helper.sh merge` (`_retarget_stacked_children_interactive`). For bare `gh pr merge` calls, run this retarget manually before merging:
+
+```bash
+# Retarget all open PRs stacked on <head-ref> before merging
+gh pr list --base <head-ref> --state open --json number -q '.[].number' \
+  | xargs -I{} gh pr edit {} --base main
+```
+
+Note: only direct children are retargeted by the helpers; grandchildren are handled when their own parent merges.
+
 **Parent-task PR keyword rule (t2046 — MANDATORY).** When a PR delivers ANY work for a `parent-task`-labeled issue — including the initial plan-filing PR — use `For #NNN` or `Ref #NNN` in the PR body, NEVER `Closes`/`Resolves`/`Fixes`. The parent issue must stay open until ALL phase children merge; only the final phase PR uses `Closes #NNN`. `full-loop-helper.sh commit-and-pr` enforces this automatically (see `.github/workflows/parent-task-keyword-check.yml`). For leaf (non-parent) issues, use `Resolves #NNN` as normal. See `templates/brief-template.md` "PR Conventions" for the full rule.
 
 **Self-improvement routing (t1541):** Framework-level tasks → `framework-routing-helper.sh log-framework-issue`. Project tasks → current repo. Framework tasks in project repos are invisible to maintainers.

--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -1202,6 +1202,44 @@ _merge_unlock_resources() {
 	return 0
 }
 
+# _retarget_stacked_children_interactive — retarget open PRs stacked on the
+# head branch of the PR that is about to be merged. GitHub auto-closes stacked
+# children when their base branch disappears after the delete-on-merge step.
+# This runs before every interactive merge (cmd_merge). The pulse equivalent
+# is _retarget_stacked_children in pulse-merge.sh. (t2412 / GH#20005)
+#
+# Limitation: only direct children are retargeted; grandchildren are handled
+# when their own parent merges and fires this function in turn.
+#
+# Args: pr_number repo
+_retarget_stacked_children_interactive() {
+	local pr_number="$1"
+	local repo="$2"
+	local parent_head_ref
+	parent_head_ref=$(gh pr view "$pr_number" --repo "$repo" --json headRefName -q '.headRefName' 2>/dev/null) || parent_head_ref=""
+	if [[ -z "$parent_head_ref" ]]; then
+		return 0
+	fi
+
+	local children
+	children=$(gh pr list --repo "$repo" --base "$parent_head_ref" --state open --json number -q '.[].number' 2>/dev/null) || children=""
+	if [[ -z "$children" ]]; then
+		return 0
+	fi
+
+	local default_branch
+	default_branch=$(gh repo view "$repo" --json defaultBranchRef -q '.defaultBranchRef.name' 2>/dev/null || true)
+	default_branch="${default_branch:-main}"
+
+	local child
+	while IFS= read -r child; do
+		[[ -z "$child" ]] && continue
+		print_info "Retargeting stacked PR #${child} from '${parent_head_ref}' to '${default_branch}' before merging PR #${pr_number} (t2412)"
+		gh pr edit "$child" --repo "$repo" --base "$default_branch" 2>&1 || true
+	done <<<"$children"
+	return 0
+}
+
 # Merge wrapper (GH#17541) — enforces review-bot-gate then merges.
 # Single command that replaces the multi-step protocol (wait + merge).
 # Workers call this instead of bare `gh pr merge`.
@@ -1273,6 +1311,12 @@ cmd_merge() {
 		print_error "Merge blocked by review bot gate. Address bot findings or wait for reviews."
 		return 1
 	}
+
+	# Retarget any open PRs stacked on this branch before the head branch is
+	# deleted post-merge. GitHub auto-closes stacked children when their base
+	# branch disappears; retargeting to the default branch prevents this.
+	# (t2412 / GH#20005)
+	_retarget_stacked_children_interactive "$pr_number" "$repo"
 
 	_merge_execute "$pr_number" "$repo" "$merge_method" "$has_admin" "$has_auto" || return 1
 

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -1112,6 +1112,48 @@ _Merged by deterministic merge pass (pulse-wrapper.sh). Neither MERGE_SUMMARY co
 }
 
 #######################################
+# Retarget any open PRs that are stacked on the head branch of a PR
+# that is about to be merged (and its branch deleted). GitHub auto-closes
+# stacked children when their base branch disappears; retargeting to main
+# before the delete prevents the auto-close.
+#
+# Limitation: only direct children are retargeted. Grandchildren are
+# naturally handled when their own parent PR merges and retargets them.
+#
+# Args:
+#   $1 - parent PR number (the PR being merged)
+#   $2 - repo slug
+# Returns: 0 always (errors are non-fatal)
+#######################################
+_retarget_stacked_children() {
+	local parent_pr_number="$1"
+	local repo_slug="$2"
+	local parent_head_ref
+	parent_head_ref=$(gh pr view "$parent_pr_number" --repo "$repo_slug" --json headRefName -q '.headRefName' 2>/dev/null) || parent_head_ref=""
+	if [[ -z "$parent_head_ref" ]]; then
+		return 0
+	fi
+
+	local children
+	children=$(gh pr list --repo "$repo_slug" --base "$parent_head_ref" --state open --json number -q '.[].number' 2>/dev/null) || children=""
+	if [[ -z "$children" ]]; then
+		return 0
+	fi
+
+	local default_branch
+	default_branch=$(gh repo view "$repo_slug" --json defaultBranchRef -q '.defaultBranchRef.name' 2>/dev/null || true)
+	default_branch="${default_branch:-main}"
+
+	local child
+	while IFS= read -r child; do
+		[[ -z "$child" ]] && continue
+		echo "[pulse-merge] retargeting stacked PR #${child} from '${parent_head_ref}' to '${default_branch}' before deleting parent PR #${parent_pr_number} branch (t2412)" >>"$LOGFILE"
+		gh pr edit "$child" --repo "$repo_slug" --base "$default_branch" 2>&1 | tee -a "$LOGFILE" || true
+	done <<<"$children"
+	return 0
+}
+
+#######################################
 # Process a single PR end-to-end: gate checks, merge attempt,
 # conflict detection, and closing comment posting.
 #
@@ -1249,6 +1291,12 @@ _process_single_ready_pr() {
 	# Extract merge summary: MERGE_SUMMARY comment → PR body → generic fallback
 	local merge_summary
 	merge_summary=$(_extract_merge_summary "$pr_number" "$repo_slug")
+
+	# Retarget any open PRs stacked on this branch before --delete-branch
+	# kills their base. GitHub auto-closes children without warning when their
+	# base branch disappears; retargeting to the default branch prevents this.
+	# (t2412 / GH#20005)
+	_retarget_stacked_children "$pr_number" "$repo_slug"
 
 	# Merge
 	local merge_output _merge_exit

--- a/.agents/scripts/tests/test-pulse-merge-retarget-stacked.sh
+++ b/.agents/scripts/tests/test-pulse-merge-retarget-stacked.sh
@@ -1,0 +1,341 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Tests for _retarget_stacked_children (t2412 / GH#20005):
+#
+# Regression for: merging a PR whose head branch is the base of open stacked
+# PRs caused GitHub to auto-close the children. `_retarget_stacked_children`
+# runs before every pulse-merge to retarget direct children to the default branch.
+#
+# Test cases:
+#   1. 0 children → no `gh pr edit` call (no-op)
+#   2. 1 child → retargeted to default branch
+#   3. 2 children → both retargeted
+#   4. Idempotent: child already targeting default branch → edit call still sent
+#      (GitHub accepts it silently; idempotency is on the server side)
+#   5. headRefName fetch failure → graceful no-op (non-fatal)
+#   6. Audit log line carries (t2412) tag for every retarget
+#
+# Mock pattern follows test-pulse-merge-update-branch.sh: extract the helper
+# from pulse-merge.sh via awk, eval it into the test shell, substitute `gh`
+# with a per-test stub on PATH.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+MERGE_SCRIPT="${SCRIPT_DIR}/../pulse-merge.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+LAST_GH_ARGS_FILE=""
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+	mkdir -p "${TEST_ROOT}/bin"
+	export PATH="${TEST_ROOT}/bin:${PATH}"
+	export LOGFILE="${TEST_ROOT}/pulse.log"
+	: >"$LOGFILE"
+	LAST_GH_ARGS_FILE="${TEST_ROOT}/gh-args.log"
+	export LAST_GH_ARGS_FILE
+	: >"$LAST_GH_ARGS_FILE"
+	return 0
+}
+
+teardown_test_env() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+# Install a configurable gh stub.
+#
+# Env vars consumed by the stub:
+#   GH_HEAD_REF   — what `gh pr view <N> --json headRefName` returns (default: "feature/parent")
+#   GH_CHILDREN   — newline-separated child PR numbers from `gh pr list --base ...`
+#                   (default: empty → no children)
+#   GH_DEFAULT_BR — what `gh repo view --json defaultBranchRef` returns (default: "main")
+#
+# The stub records every invocation to LAST_GH_ARGS_FILE (one line per call).
+install_gh_stub() {
+	local head_ref="${1:-feature/parent}"
+	local children="${2:-}"
+	local default_br="${3:-main}"
+
+	# Write env vars to a file so the stub can read them (avoids export escaping).
+	printf '%s' "$children" >"${TEST_ROOT}/gh-children.txt"
+	printf '%s' "$head_ref" >"${TEST_ROOT}/gh-head-ref.txt"
+	printf '%s' "$default_br" >"${TEST_ROOT}/gh-default-br.txt"
+
+	cat >"${TEST_ROOT}/bin/gh" <<'STUB_EOF'
+#!/usr/bin/env bash
+# Log every call.
+printf '%s\n' "$*" >>"${LAST_GH_ARGS_FILE}"
+
+test_root="$(dirname "$(dirname "${BASH_SOURCE[0]}")")"
+head_ref_file="${test_root}/gh-head-ref.txt"
+children_file="${test_root}/gh-children.txt"
+default_br_file="${test_root}/gh-default-br.txt"
+
+head_ref=""
+[[ -f "$head_ref_file" ]] && head_ref="$(cat "$head_ref_file")"
+default_br="main"
+[[ -f "$default_br_file" ]] && default_br="$(cat "$default_br_file")"
+
+# `gh pr view <N> --json headRefName -q ...`
+if [[ "${1:-}" == "pr" && "${2:-}" == "view" && "$*" == *"headRefName"* ]]; then
+	printf '%s\n' "$head_ref"
+	exit 0
+fi
+
+# `gh repo view --json defaultBranchRef -q ...`
+if [[ "${1:-}" == "repo" && "${2:-}" == "view" && "$*" == *"defaultBranchRef"* ]]; then
+	printf '%s\n' "$default_br"
+	exit 0
+fi
+
+# `gh pr list --base <ref> --state open --json number -q ...`
+if [[ "${1:-}" == "pr" && "${2:-}" == "list" && "$*" == *"--state open"* ]]; then
+	[[ -f "$children_file" ]] && cat "$children_file"
+	exit 0
+fi
+
+# `gh pr edit <N> --repo <slug> --base <branch>` → just succeed
+if [[ "${1:-}" == "pr" && "${2:-}" == "edit" ]]; then
+	exit 0
+fi
+
+exit 0
+STUB_EOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+	return 0
+}
+
+# Extract `_retarget_stacked_children` from pulse-merge.sh and eval it.
+define_helper_under_test() {
+	local helper_src
+	helper_src=$(awk '
+		/^_retarget_stacked_children\(\) \{/,/^}$/ { print }
+	' "$MERGE_SCRIPT")
+	if [[ -z "$helper_src" ]]; then
+		printf 'ERROR: could not extract _retarget_stacked_children from %s\n' "$MERGE_SCRIPT" >&2
+		return 1
+	fi
+	# shellcheck disable=SC1090
+	eval "$helper_src"
+	return 0
+}
+
+# ---------------------------------------------------------------
+# Test 1: 0 children → no gh pr edit calls
+# ---------------------------------------------------------------
+test_zero_children_noop() {
+	: >"$LOGFILE"
+	: >"$LAST_GH_ARGS_FILE"
+	install_gh_stub "feature/parent" "" "main"
+
+	_retarget_stacked_children "100" "marcusquinn/aidevops"
+
+	if grep -q "pr edit" "$LAST_GH_ARGS_FILE"; then
+		print_result "0 children → no-op (no gh pr edit)" 1 \
+			"gh pr edit was called when there are no children. Args: $(cat "$LAST_GH_ARGS_FILE")"
+		return 0
+	fi
+
+	print_result "0 children → no-op (no gh pr edit)" 0
+	return 0
+}
+
+# ---------------------------------------------------------------
+# Test 2: 1 child → retargeted
+# ---------------------------------------------------------------
+test_one_child_retargeted() {
+	: >"$LOGFILE"
+	: >"$LAST_GH_ARGS_FILE"
+	install_gh_stub "feature/parent" "201" "main"
+
+	_retarget_stacked_children "100" "marcusquinn/aidevops"
+
+	if ! grep -q "pr edit 201" "$LAST_GH_ARGS_FILE"; then
+		print_result "1 child → retargeted" 1 \
+			"Expected 'pr edit 201' in gh args. Got: $(cat "$LAST_GH_ARGS_FILE")"
+		return 0
+	fi
+
+	if ! grep -q -- "--base main" "$LAST_GH_ARGS_FILE"; then
+		print_result "1 child → retargeted" 1 \
+			"Expected '--base main' in gh args. Got: $(cat "$LAST_GH_ARGS_FILE")"
+		return 0
+	fi
+
+	print_result "1 child → retargeted" 0
+	return 0
+}
+
+# ---------------------------------------------------------------
+# Test 3: 2 children → both retargeted
+# ---------------------------------------------------------------
+test_two_children_both_retargeted() {
+	: >"$LOGFILE"
+	: >"$LAST_GH_ARGS_FILE"
+	install_gh_stub "feature/parent" "$(printf '301\n302')" "main"
+
+	_retarget_stacked_children "100" "marcusquinn/aidevops"
+
+	local edit_count
+	edit_count=$(grep -c "pr edit" "$LAST_GH_ARGS_FILE" 2>/dev/null || true)
+	if [[ "$edit_count" -lt 2 ]]; then
+		print_result "2 children → both retargeted" 1 \
+			"Expected 2 gh pr edit calls, got ${edit_count}. Args: $(cat "$LAST_GH_ARGS_FILE")"
+		return 0
+	fi
+
+	if ! grep -q "pr edit 301" "$LAST_GH_ARGS_FILE"; then
+		print_result "2 children → both retargeted" 1 \
+			"Expected 'pr edit 301' in gh args. Got: $(cat "$LAST_GH_ARGS_FILE")"
+		return 0
+	fi
+
+	if ! grep -q "pr edit 302" "$LAST_GH_ARGS_FILE"; then
+		print_result "2 children → both retargeted" 1 \
+			"Expected 'pr edit 302' in gh args. Got: $(cat "$LAST_GH_ARGS_FILE")"
+		return 0
+	fi
+
+	print_result "2 children → both retargeted" 0
+	return 0
+}
+
+# ---------------------------------------------------------------
+# Test 4: headRefName fetch failure → graceful no-op
+# ---------------------------------------------------------------
+test_head_ref_failure_noop() {
+	: >"$LOGFILE"
+	: >"$LAST_GH_ARGS_FILE"
+	# Empty head ref → simulates gh failure / empty response
+	install_gh_stub "" "" "main"
+
+	_retarget_stacked_children "100" "marcusquinn/aidevops"
+
+	if grep -q "pr edit" "$LAST_GH_ARGS_FILE"; then
+		print_result "headRefName failure → graceful no-op" 1 \
+			"gh pr edit was called despite empty headRefName. Args: $(cat "$LAST_GH_ARGS_FILE")"
+		return 0
+	fi
+
+	print_result "headRefName failure → graceful no-op" 0
+	return 0
+}
+
+# ---------------------------------------------------------------
+# Test 5: Audit log line carries (t2412) tag
+# ---------------------------------------------------------------
+test_audit_log_carries_t2412_tag() {
+	: >"$LOGFILE"
+	: >"$LAST_GH_ARGS_FILE"
+	install_gh_stub "feature/parent" "401" "main"
+
+	_retarget_stacked_children "100" "marcusquinn/aidevops"
+
+	if ! grep -q '(t2412)' "$LOGFILE"; then
+		print_result "audit log carries (t2412) tag" 1 \
+			"Expected '(t2412)' in LOGFILE. Contents: $(cat "$LOGFILE")"
+		return 0
+	fi
+
+	print_result "audit log carries (t2412) tag" 0
+	return 0
+}
+
+# ---------------------------------------------------------------
+# Test 6: Static check — _retarget_stacked_children called before
+#         gh pr merge in _process_single_ready_pr
+# ---------------------------------------------------------------
+test_retarget_called_before_merge() {
+	local func_body
+	func_body=$(awk '
+		/^_process_single_ready_pr\(\) \{/,/^}$/ { print }
+	' "$MERGE_SCRIPT")
+
+	if [[ -z "$func_body" ]]; then
+		print_result "retarget called before merge in _process_single_ready_pr" 1 \
+			"Could not extract _process_single_ready_pr from pulse-merge.sh"
+		return 0
+	fi
+
+	if [[ "$func_body" != *"_retarget_stacked_children"* ]]; then
+		print_result "retarget called before merge in _process_single_ready_pr" 1 \
+			"_retarget_stacked_children not found in _process_single_ready_pr"
+		return 0
+	fi
+
+	# Retarget must appear before the gh pr merge call.
+	local retarget_pos merge_pos
+	retarget_pos=$(printf '%s\n' "$func_body" | grep -n '_retarget_stacked_children' | head -1 | cut -d: -f1)
+	merge_pos=$(printf '%s\n' "$func_body" | grep -n 'gh pr merge' | head -1 | cut -d: -f1)
+
+	if [[ -z "$retarget_pos" || -z "$merge_pos" ]]; then
+		print_result "retarget called before merge in _process_single_ready_pr" 1 \
+			"retarget_pos=${retarget_pos}, merge_pos=${merge_pos}"
+		return 0
+	fi
+
+	if [[ "$retarget_pos" -ge "$merge_pos" ]]; then
+		print_result "retarget called before merge in _process_single_ready_pr" 1 \
+			"_retarget_stacked_children must appear before gh pr merge (pos: ${retarget_pos} vs ${merge_pos})"
+		return 0
+	fi
+
+	print_result "retarget called before merge in _process_single_ready_pr" 0
+	return 0
+}
+
+main() {
+	trap teardown_test_env EXIT
+	setup_test_env
+
+	if ! define_helper_under_test; then
+		printf 'FATAL: helper extraction failed\n' >&2
+		return 1
+	fi
+
+	test_zero_children_noop
+	test_one_child_retargeted
+	test_two_children_both_retargeted
+	test_head_ref_failure_noop
+	test_audit_log_carries_t2412_tag
+	test_retarget_called_before_merge
+
+	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## What

Adds `_retarget_stacked_children()` to `pulse-merge.sh` and `_retarget_stacked_children_interactive()` to `full-loop-helper.sh`. Both functions scan for open PRs whose base branch is the head branch of the PR being merged, then retarget them to the default branch before the merge deletes the parent branch.

Documents the behaviour and provides a manual recipe in `.agents/AGENTS.md`.

## Why

When a parent PR is merged (and its branch deleted), GitHub immediately auto-closes any open PRs whose `baseRefName` equals the deleted branch — with no warning and no way to reopen. The only recovery is force-push + fresh PR, breaking audit trail and costing ~30 min. Live incident: PR #19983 was auto-closed 1 second after PR #19965 merged (see GH#20005).

## Changes

- **EDIT**: `.agents/scripts/pulse-merge.sh` — `_retarget_stacked_children()` inserted before line 1295 (`gh pr merge`). Queries `gh pr list --base <head-ref> --state open`, retargets each child to the default branch via `gh pr edit --base <default>`, logs each operation with `(t2412)` tag.
- **EDIT**: `.agents/scripts/full-loop-helper.sh` — `_retarget_stacked_children_interactive()` added before `cmd_merge`; called in `cmd_merge` before `_merge_execute`.
- **EDIT**: `.agents/AGENTS.md` — **Stacked PRs (t2412)** block after "Traceability" section; includes the manual recipe for bare `gh pr merge` calls.
- **NEW**: `.agents/scripts/tests/test-pulse-merge-retarget-stacked.sh` — 6 assertions covering 0 children (no-op), 1 child, 2 children, headRefName failure (graceful no-op), audit log tag, and static ordering check (retarget before merge).

## Testing

```
bash .agents/scripts/tests/test-pulse-merge-retarget-stacked.sh
# Ran 6 tests, 0 failed.
```

ShellCheck clean on all modified files. Pre-commit quality hook passes (no new string literal violations).

## Complexity Justification

No complexity increase — new standalone helper functions with a simple loop.

Resolves #20005