### PR TITLE
GH#20026: feat(dispatch-claim): clear active status labels on CLAIM_RELEASED (t2420)

### DIFF
--- a/.agents/scripts/headless-runtime-failure.sh
+++ b/.agents/scripts/headless-runtime-failure.sh
@@ -65,6 +65,18 @@ _release_dispatch_claim() {
 		print_warning "Failed to post CLAIM_RELEASED on #${issue_number} (non-fatal)"
 	}
 	print_info "Released claim on #${issue_number} (reason: ${reason})"
+
+	# t2420: clear active-lifecycle status labels + worker assignment so the
+	# pulse's combined-signal dedup guard (t1996) doesn't treat the issue
+	# as active after release. Without this, orphan labels pin the issue
+	# as "active" for the full 30-min TTL even though no worker holds the
+	# claim, blocking re-dispatch. Preserves terminal states (done, blocked)
+	# set by authoritative paths. Defensive skip if origin:interactive.
+	# Non-fatal: failure does not block the release comment path.
+	if declare -F clear_active_status_on_release >/dev/null 2>&1; then
+		clear_active_status_on_release "$issue_number" "$repo_slug" "$(whoami)" \
+			|| print_warning "Failed to clear active status on #${issue_number} (non-fatal)"
+	fi
 	return 0
 }
 

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -1729,6 +1729,80 @@ set_issue_status() {
 	gh issue edit "$issue_num" --repo "$repo_slug" "${_flags[@]}" 2>/dev/null
 }
 
+#######################################
+# Clear active-lifecycle status labels on dispatch claim release (t2420).
+#
+# Removes only the four ACTIVE status labels (queued, claimed, in-progress,
+# in-review) and optionally the worker's assignment. PRESERVES terminal
+# states (done, blocked) and the eligible state (available) — those are set
+# by authoritative paths (PR merge, blocker triage, explicit re-queue) and
+# must survive a worker's claim release.
+#
+# Why not set_issue_status "" ? Because it would strip status:done set by
+# the PR merge path if the CLAIM_RELEASED comment races ahead — a worker
+# that succeeds, creates a PR, the PR merges (setting status:done), and
+# then the worker's EXIT trap fires CLAIM_RELEASED would regress the state.
+# This helper is the targeted, race-safe alternative.
+#
+# Why not just skip label cleanup entirely? Because without it, orphan
+# labels pin an issue as "active" even though no worker holds the claim,
+# blocking pulse re-dispatch via the t1996 combined-signal guard
+# (active-status + assignee = block). Observed in production: #19864 and
+# #19738 were both pinned status:queued/claimed for 40+ minutes after
+# worker completion, with dead PIDs (one case was PID 11742 reused by
+# Brave Browser — see t2421).
+#
+# Defensive: skips entirely if origin:interactive is present. Workers
+# should never hold the claim on interactive issues (dispatch-dedup
+# blocks that), but if we find one, we never touch interactive-session
+# ownership state (t2056).
+#
+# Args:
+#   $1 — issue number
+#   $2 — repo slug (owner/repo)
+#   $3 — worker login to remove as assignee (optional; empty = no assignee change)
+#
+# Returns:
+#   0 on success, including idempotent no-ops and defensive skips
+#   1 on gh failure (logged by gh to stderr; suppressed here)
+#
+# Example:
+#   clear_active_status_on_release 20026 marcusquinn/aidevops "$(whoami)"
+#######################################
+clear_active_status_on_release() {
+	local issue_num="$1"
+	local repo_slug="$2"
+	local worker_login="${3:-}"
+
+	if [[ -z "$issue_num" || -z "$repo_slug" ]]; then
+		return 0
+	fi
+
+	# Defensive: don't touch interactive-session-owned issues.
+	# A single fetch is cheap — only fires on claim release, not hot path.
+	local labels_json=""
+	labels_json=$(gh issue view "$issue_num" --repo "$repo_slug" \
+		--json labels --jq '[.labels[].name] | join(",")' 2>/dev/null) || labels_json=""
+	case ",${labels_json}," in
+	*,origin:interactive,*)
+		return 0
+		;;
+	esac
+
+	local -a _flags=()
+	_flags+=(--remove-label "status:queued")
+	_flags+=(--remove-label "status:claimed")
+	_flags+=(--remove-label "status:in-progress")
+	_flags+=(--remove-label "status:in-review")
+
+	if [[ -n "$worker_login" ]]; then
+		_flags+=(--remove-assignee "$worker_login")
+	fi
+
+	gh issue edit "$issue_num" --repo "$repo_slug" "${_flags[@]}" 2>/dev/null || return 1
+	return 0
+}
+
 # =============================================================================
 # TODO.md Serialized Commit+Push
 # =============================================================================

--- a/.agents/scripts/tests/test-claim-release-label-mutation.sh
+++ b/.agents/scripts/tests/test-claim-release-label-mutation.sh
@@ -1,0 +1,209 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-claim-release-label-mutation.sh — t2420 regression guard.
+#
+# Asserts the `clear_active_status_on_release` helper in shared-constants.sh:
+#
+#   1. Removes the 4 active-lifecycle status labels (queued, claimed,
+#      in-progress, in-review) in a single gh issue edit call
+#   2. Preserves terminal states — NEVER emits --remove-label for
+#      status:done, status:blocked, or status:available
+#   3. Removes the worker_login as assignee when provided
+#   4. Skips assignee mutation when worker_login is empty
+#   5. Defensively skips entirely when origin:interactive is present,
+#      preserving interactive-session ownership (t2056)
+#   6. Returns 0 on empty issue_num or repo_slug (idempotent no-op)
+#
+# Failure history motivating this test: production observation 2026-04-20
+# of #19864 and #19738 pinned as status:queued/claimed for 40+ minutes
+# after worker completion because _release_dispatch_claim only posted
+# a CLAIM_RELEASED comment without clearing the labels that block the
+# t1996 combined-signal dedup guard.
+#
+# NOTE: not using `set -e` — assertions rely on capturing non-zero exits.
+
+set -uo pipefail
+
+TEST_RED=$'\033[0;31m'
+TEST_GREEN=$'\033[0;32m'
+TEST_RESET=$'\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1" rc="$2" extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf '%sPASS%s %s\n' "$TEST_GREEN" "$TEST_RESET" "$name"
+	else
+		printf '%sFAIL%s %s %s\n' "$TEST_RED" "$TEST_RESET" "$name" "$extra"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+# Sandbox HOME so sourcing shared-constants.sh is side-effect-free
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+export HOME="${TEST_ROOT}/home"
+mkdir -p "${HOME}/.aidevops/logs"
+
+STUB_DIR="${TEST_ROOT}/bin"
+mkdir -p "$STUB_DIR"
+export GH_CALLS_FILE="${TEST_ROOT}/gh_calls.log"
+export GH_VIEW_LABELS="${TEST_ROOT}/gh_view_labels.txt"
+
+#######################################
+# Write a gh stub that:
+#   - For `gh issue view ... --json labels ...` → prints the contents of
+#     GH_VIEW_LABELS (empty string = no labels, simulating a fresh issue)
+#   - For any other gh invocation (e.g. `gh issue edit ...`) → records the
+#     argv to GH_CALLS_FILE and exits 0
+#######################################
+write_stub_gh() {
+	: >"$GH_CALLS_FILE"
+	: >"$GH_VIEW_LABELS"
+	cat >"${STUB_DIR}/gh" <<'STUBEOF'
+#!/usr/bin/env bash
+# Stub gh — serves `gh issue view --json labels` from GH_VIEW_LABELS,
+# and records all other calls to GH_CALLS_FILE.
+if [[ "$1" == "issue" && "$2" == "view" ]]; then
+	# Emit whatever the test put in GH_VIEW_LABELS (jq output string form)
+	cat "${GH_VIEW_LABELS}" 2>/dev/null || true
+	exit 0
+fi
+printf '%s\n' "$*" >>"${GH_CALLS_FILE}"
+exit 0
+STUBEOF
+	chmod +x "${STUB_DIR}/gh"
+	return 0
+}
+
+export PATH="${STUB_DIR}:${PATH}"
+write_stub_gh
+
+# Locate the script tree the same way the sibling tests do.
+TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# shellcheck source=/dev/null
+source "${TEST_SCRIPTS_DIR}/shared-constants.sh"
+
+#######################################
+# Reset the gh stub state between cases.
+#######################################
+reset_stub() {
+	: >"$GH_CALLS_FILE"
+	: >"$GH_VIEW_LABELS"
+	return 0
+}
+
+#######################################
+# Assert a pattern is present in the recorded gh invocation argv.
+#######################################
+assert_grep() {
+	local pattern="$1" label="$2"
+	if grep -q -- "$pattern" "$GH_CALLS_FILE" 2>/dev/null; then
+		print_result "$label" 0
+	else
+		print_result "$label" 1 "pattern '${pattern}' not found in gh calls"
+	fi
+	return 0
+}
+
+#######################################
+# Assert a pattern is ABSENT from the recorded gh invocation argv.
+#######################################
+assert_not_grep() {
+	local pattern="$1" label="$2"
+	if grep -q -- "$pattern" "$GH_CALLS_FILE" 2>/dev/null; then
+		print_result "$label" 1 "pattern '${pattern}' unexpectedly present"
+	else
+		print_result "$label" 0
+	fi
+	return 0
+}
+
+# -------------------------------------------------------------------
+# Case 1: removes all 4 active labels, preserves terminal labels
+# -------------------------------------------------------------------
+reset_stub
+clear_active_status_on_release 20026 owner/repo worker1
+assert_grep "remove-label status:queued" "removes status:queued"
+assert_grep "remove-label status:claimed" "removes status:claimed"
+assert_grep "remove-label status:in-progress" "removes status:in-progress"
+assert_grep "remove-label status:in-review" "removes status:in-review"
+assert_not_grep "remove-label status:done" "preserves status:done"
+assert_not_grep "remove-label status:blocked" "preserves status:blocked"
+assert_not_grep "remove-label status:available" "preserves status:available"
+
+# -------------------------------------------------------------------
+# Case 2: removes the worker_login assignee when provided
+# -------------------------------------------------------------------
+reset_stub
+clear_active_status_on_release 20026 owner/repo alice
+assert_grep "remove-assignee alice" "removes worker_login assignee"
+
+# -------------------------------------------------------------------
+# Case 3: skips assignee mutation when worker_login is empty
+# -------------------------------------------------------------------
+reset_stub
+clear_active_status_on_release 20026 owner/repo ""
+assert_not_grep "remove-assignee" "no assignee mutation when empty"
+# Labels should still be cleared
+assert_grep "remove-label status:queued" "labels still cleared when worker_login empty"
+
+# -------------------------------------------------------------------
+# Case 4: defensively skips entirely when origin:interactive present
+# -------------------------------------------------------------------
+reset_stub
+printf 'bug,origin:interactive,tier:standard' >"$GH_VIEW_LABELS"
+clear_active_status_on_release 20026 owner/repo alice
+# No `gh issue edit` call should have been recorded (view is skipped by stub)
+if ! grep -q "issue edit" "$GH_CALLS_FILE" 2>/dev/null; then
+	print_result "skips edit on origin:interactive" 0
+else
+	print_result "skips edit on origin:interactive" 1 "gh issue edit was called"
+fi
+
+# -------------------------------------------------------------------
+# Case 5: empty issue_num returns 0 without gh call
+# -------------------------------------------------------------------
+reset_stub
+clear_active_status_on_release "" owner/repo alice
+rc=$?
+if [[ "$rc" -eq 0 ]] && ! grep -q "issue edit" "$GH_CALLS_FILE" 2>/dev/null; then
+	print_result "empty issue_num is idempotent no-op" 0
+else
+	print_result "empty issue_num is idempotent no-op" 1 "rc=$rc or edit called"
+fi
+
+# -------------------------------------------------------------------
+# Case 6: empty repo_slug returns 0 without gh call
+# -------------------------------------------------------------------
+reset_stub
+clear_active_status_on_release 20026 "" alice
+rc=$?
+if [[ "$rc" -eq 0 ]] && ! grep -q "issue edit" "$GH_CALLS_FILE" 2>/dev/null; then
+	print_result "empty repo_slug is idempotent no-op" 0
+else
+	print_result "empty repo_slug is idempotent no-op" 1 "rc=$rc or edit called"
+fi
+
+# -------------------------------------------------------------------
+# Case 7: labels not matching interactive substring don't trigger defensive skip
+# (e.g., a label named "interactive-candidate" or "origin:worker-takeover")
+# -------------------------------------------------------------------
+reset_stub
+printf 'bug,origin:worker-takeover,tier:standard' >"$GH_VIEW_LABELS"
+clear_active_status_on_release 20026 owner/repo alice
+assert_grep "remove-label status:queued" "clears labels on origin:worker-takeover (not interactive)"
+
+# -------------------------------------------------------------------
+# Summary
+# -------------------------------------------------------------------
+printf '\n%d tests run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]] || exit 1
+exit 0


### PR DESCRIPTION
## Summary

Implementation for issue #20026.

## Files Changed

.agents/scripts/headless-runtime-failure.sh,.agents/scripts/shared-constants.sh,.agents/scripts/tests/test-claim-release-label-mutation.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean, self-assessed

Resolves #20026


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.78 plugin for [OpenCode](https://opencode.ai) v1.14.18 with claude-opus-4-7 spent 4h 50m and 528,285 tokens on this with the user in an interactive session.