### PR TITLE
t2409: upgrade briefing agent for META-quality interactive briefs

### DIFF
--- a/.agents/scripts/tests/test-verify-brief.sh
+++ b/.agents/scripts/tests/test-verify-brief.sh
@@ -1,0 +1,306 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-verify-brief.sh — t2409 regression tests for Pre-flight validation.
+#
+# Asserts:
+#   1. A brief missing the Pre-flight block is rejected by verify-brief.sh
+#   2. A brief with placeholder Pre-flight text is rejected
+#   3. A brief with populated Pre-flight passes
+#   4. A brief claiming tier:simple with >2 files is rejected
+#   5. verify-brief-helper.sh check-preflight rejects missing section
+#   6. verify-brief-helper.sh check-preflight rejects placeholders
+#   7. verify-brief-helper.sh check-preflight passes populated brief
+
+set -uo pipefail
+
+TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_RED=$'\033[0;31m'
+TEST_GREEN=$'\033[0;32m'
+TEST_RESET=$'\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1" rc="$2" extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf '%sPASS%s %s\n' "$TEST_GREEN" "$TEST_RESET" "$name"
+	else
+		printf '%sFAIL%s %s %s\n' "$TEST_RED" "$TEST_RESET" "$name" "$extra"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+# Create temp directory for fixtures
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+# Initialize a minimal git repo so verify-brief.sh can resolve repo path
+mkdir -p "${TEST_ROOT}/repo"
+(cd "${TEST_ROOT}/repo" && git init -q 2>/dev/null) || true
+
+# ============================================================================
+# Fixture: brief with NO Pre-flight section
+# ============================================================================
+cat > "${TEST_ROOT}/brief-no-preflight.md" << 'BRIEF_EOF'
+---
+mode: subagent
+---
+
+# t9999: Test Task
+
+## Origin
+
+- **Created:** 2026-04-20
+
+## What
+
+Test deliverable.
+
+## Acceptance Criteria
+
+- [ ] Something works
+BRIEF_EOF
+
+# ============================================================================
+# Fixture: brief with PLACEHOLDER Pre-flight section
+# ============================================================================
+cat > "${TEST_ROOT}/brief-placeholder.md" << 'BRIEF_EOF'
+---
+mode: subagent
+---
+
+# t9999: Test Task
+
+## Pre-flight (auto-populated by briefing workflow)
+
+- [ ] Memory recall: `<query>` -> `<N>` hits | no results
+- [ ] Discovery pass: `<N>` commits / `<N>` merged PRs / `<N>` open PRs touch target files since `<date>`
+- [ ] File refs verified: `<N>` refs checked, all present | `<N>` missing (list)
+- [ ] Tier: `<tier>` -- disqualifier check clean | disqualified from `<tier>` because `<reason>`
+
+## Origin
+
+- **Created:** 2026-04-20
+
+## What
+
+Test deliverable.
+
+## Acceptance Criteria
+
+- [ ] Something works
+BRIEF_EOF
+
+# ============================================================================
+# Fixture: brief with POPULATED Pre-flight section
+# ============================================================================
+cat > "${TEST_ROOT}/brief-populated.md" << 'BRIEF_EOF'
+---
+mode: subagent
+---
+
+# t9999: Test Task
+
+## Pre-flight (auto-populated by briefing workflow)
+
+- [x] Memory recall: `brief workflow` -> 2 hits, reviewed relevant lessons
+- [x] Discovery pass: 0 commits / 0 merged PRs / 0 open PRs touch target files since 2026-04-18
+- [x] File refs verified: 3 refs checked, all present
+- [x] Tier: `tier:standard` -- disqualifier check clean
+
+## Origin
+
+- **Created:** 2026-04-20
+
+## What
+
+Test deliverable.
+
+## Acceptance Criteria
+
+- [ ] Something works
+BRIEF_EOF
+
+# ============================================================================
+# Fixture: brief with tier:simple but >2 files
+# ============================================================================
+cat > "${TEST_ROOT}/brief-tier-mismatch.md" << 'BRIEF_EOF'
+---
+mode: subagent
+---
+
+# t9999: Test Task
+
+## Pre-flight (auto-populated by briefing workflow)
+
+- [x] Memory recall: `tier test` -> no results
+- [x] Discovery pass: 0 commits / 0 merged PRs / 0 open PRs touch target files since 2026-04-18
+- [x] File refs verified: 3 refs checked, all present
+- [x] Tier: `tier:simple` -- disqualifier check clean
+
+## Origin
+
+- **Created:** 2026-04-20
+
+## Tier
+
+**Selected tier:** `tier:simple`
+
+## How (Approach)
+
+### Files to Modify
+
+- `EDIT: src/foo.ts:10-20` -- change A
+- `EDIT: src/bar.ts:30-40` -- change B
+- `NEW: src/baz.ts` -- new file
+
+### Implementation Steps
+
+1. Do something.
+
+### Verification
+
+```bash
+echo "ok"
+```
+
+## Acceptance Criteria
+
+- [ ] Something works
+BRIEF_EOF
+
+# ============================================================================
+# Test 1: verify-brief.sh rejects brief missing Pre-flight
+# ============================================================================
+test_verify_brief_rejects_missing_preflight() {
+	local rc=0
+	bash "${TEST_SCRIPTS_DIR}/verify-brief.sh" "${TEST_ROOT}/brief-no-preflight.md" \
+		--repo-path "${TEST_ROOT}/repo" >/dev/null 2>&1 || rc=$?
+	# Should fail (exit 1) because Pre-flight is missing
+	if [[ $rc -ne 0 ]]; then
+		print_result "verify-brief.sh rejects missing Pre-flight" 0
+	else
+		print_result "verify-brief.sh rejects missing Pre-flight" 1 "(expected non-zero exit, got 0)"
+	fi
+	return 0
+}
+
+# ============================================================================
+# Test 2: verify-brief.sh rejects brief with placeholder Pre-flight
+# ============================================================================
+test_verify_brief_rejects_placeholder_preflight() {
+	local rc=0
+	bash "${TEST_SCRIPTS_DIR}/verify-brief.sh" "${TEST_ROOT}/brief-placeholder.md" \
+		--repo-path "${TEST_ROOT}/repo" >/dev/null 2>&1 || rc=$?
+	if [[ $rc -ne 0 ]]; then
+		print_result "verify-brief.sh rejects placeholder Pre-flight" 0
+	else
+		print_result "verify-brief.sh rejects placeholder Pre-flight" 1 "(expected non-zero exit, got 0)"
+	fi
+	return 0
+}
+
+# ============================================================================
+# Test 3: verify-brief.sh passes brief with populated Pre-flight
+# ============================================================================
+test_verify_brief_passes_populated_preflight() {
+	local rc=0
+	bash "${TEST_SCRIPTS_DIR}/verify-brief.sh" "${TEST_ROOT}/brief-populated.md" \
+		--repo-path "${TEST_ROOT}/repo" >/dev/null 2>&1 || rc=$?
+	if [[ $rc -eq 0 ]]; then
+		print_result "verify-brief.sh passes populated Pre-flight" 0
+	else
+		print_result "verify-brief.sh passes populated Pre-flight" 1 "(expected exit 0, got $rc)"
+	fi
+	return 0
+}
+
+# ============================================================================
+# Test 4: verify-brief.sh rejects tier:simple with >2 files
+# ============================================================================
+test_verify_brief_rejects_tier_mismatch() {
+	local rc=0
+	bash "${TEST_SCRIPTS_DIR}/verify-brief.sh" "${TEST_ROOT}/brief-tier-mismatch.md" \
+		--repo-path "${TEST_ROOT}/repo" >/dev/null 2>&1 || rc=$?
+	if [[ $rc -ne 0 ]]; then
+		print_result "verify-brief.sh rejects tier:simple with >2 files" 0
+	else
+		print_result "verify-brief.sh rejects tier:simple with >2 files" 1 "(expected non-zero exit, got 0)"
+	fi
+	return 0
+}
+
+# ============================================================================
+# Test 5: verify-brief-helper.sh check-preflight rejects missing section
+# ============================================================================
+test_helper_rejects_missing_preflight() {
+	local rc=0
+	bash "${TEST_SCRIPTS_DIR}/verify-brief-helper.sh" check-preflight \
+		"${TEST_ROOT}/brief-no-preflight.md" >/dev/null 2>&1 || rc=$?
+	if [[ $rc -ne 0 ]]; then
+		print_result "helper check-preflight rejects missing section" 0
+	else
+		print_result "helper check-preflight rejects missing section" 1 "(expected non-zero exit, got 0)"
+	fi
+	return 0
+}
+
+# ============================================================================
+# Test 6: verify-brief-helper.sh check-preflight rejects placeholders
+# ============================================================================
+test_helper_rejects_placeholder_preflight() {
+	local rc=0
+	bash "${TEST_SCRIPTS_DIR}/verify-brief-helper.sh" check-preflight \
+		"${TEST_ROOT}/brief-placeholder.md" >/dev/null 2>&1 || rc=$?
+	if [[ $rc -ne 0 ]]; then
+		print_result "helper check-preflight rejects placeholders" 0
+	else
+		print_result "helper check-preflight rejects placeholders" 1 "(expected non-zero exit, got 0)"
+	fi
+	return 0
+}
+
+# ============================================================================
+# Test 7: verify-brief-helper.sh check-preflight passes populated brief
+# ============================================================================
+test_helper_passes_populated_preflight() {
+	local rc=0
+	bash "${TEST_SCRIPTS_DIR}/verify-brief-helper.sh" check-preflight \
+		"${TEST_ROOT}/brief-populated.md" >/dev/null 2>&1 || rc=$?
+	if [[ $rc -eq 0 ]]; then
+		print_result "helper check-preflight passes populated brief" 0
+	else
+		print_result "helper check-preflight passes populated brief" 1 "(expected exit 0, got $rc)"
+	fi
+	return 0
+}
+
+# ============================================================================
+# Run all tests
+# ============================================================================
+main() {
+	printf '=== test-verify-brief.sh (t2409) ===\n\n'
+
+	test_verify_brief_rejects_missing_preflight
+	test_verify_brief_rejects_placeholder_preflight
+	test_verify_brief_passes_populated_preflight
+	test_verify_brief_rejects_tier_mismatch
+	test_helper_rejects_missing_preflight
+	test_helper_rejects_placeholder_preflight
+	test_helper_passes_populated_preflight
+
+	printf '\n--- Summary ---\n'
+	printf 'Tests: %d  Failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
+
+	if [[ $TESTS_FAILED -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/verify-brief-helper.sh
+++ b/.agents/scripts/verify-brief-helper.sh
@@ -25,9 +25,10 @@ _usage() {
 Usage: verify-brief-helper.sh <command> [brief-path]
 
 Commands:
-  verify <path>   Run all method:bash verify blocks from the brief
-  list   <path>   List verify blocks without executing
-  help             Show this help
+  verify          <path>   Run all method:bash verify blocks from the brief
+  list            <path>   List verify blocks without executing
+  check-preflight <path>   Validate Pre-flight block presence and completeness
+  help                     Show this help
 EOF
 	return 0
 }
@@ -39,6 +40,8 @@ _log() {
 	printf '[%s] %s\n' "$level" "$msg" >&2
 	return 0
 }
+
+_ERR_BRIEF_NOT_FOUND="Brief not found:"
 
 # ---------------------------------------------------------------------------
 # Parse verify blocks from a brief markdown file
@@ -149,7 +152,7 @@ _cmd_list() {
 	local brief_path="$1"
 
 	if [[ ! -f "$brief_path" ]]; then
-		_log "ERROR" "Brief not found: $brief_path"
+		_log "ERROR" "$_ERR_BRIEF_NOT_FOUND $brief_path"
 		return 2
 	fi
 
@@ -175,7 +178,7 @@ _cmd_verify() {
 	local brief_path="$1"
 
 	if [[ ! -f "$brief_path" ]]; then
-		_log "ERROR" "Brief not found: $brief_path"
+		_log "ERROR" "$_ERR_BRIEF_NOT_FOUND $brief_path"
 		return 2
 	fi
 
@@ -245,6 +248,108 @@ _cmd_verify() {
 }
 
 # ---------------------------------------------------------------------------
+# Pre-flight validation
+# ---------------------------------------------------------------------------
+
+_cmd_check_preflight() {
+	local brief_path="$1"
+
+	if [[ ! -f "$brief_path" ]]; then
+		_log "ERROR" "$_ERR_BRIEF_NOT_FOUND $brief_path"
+		return 2
+	fi
+
+	local in_preflight=0
+	local found_section=0
+	local total_boxes=0
+	local populated_count=0
+	local placeholder_count=0
+	local has_memory=0
+	local has_discovery=0
+	local has_filerefs=0
+	local has_tier=0
+
+	while IFS= read -r line; do
+		# Detect Pre-flight section
+		if echo "$line" | grep -qE '^##[[:space:]]+Pre-flight'; then
+			in_preflight=1
+			found_section=1
+			continue
+		fi
+
+		# Detect next section
+		if [[ $in_preflight -eq 1 ]] && echo "$line" | grep -qE '^##[[:space:]]' && ! echo "$line" | grep -qE 'Pre-flight'; then
+			break
+		fi
+
+		[[ $in_preflight -eq 0 ]] && continue
+
+		# Skip HTML comments
+		echo "$line" | grep -qE '^\s*<!--' && continue
+
+		# Detect checkbox lines
+		if echo "$line" | grep -qE '^\s*-\s+\[[[:space:]x]\]'; then
+			total_boxes=$((total_boxes + 1))
+
+			if echo "$line" | grep -qiE 'Memory[[:space:]]+recall'; then
+				has_memory=1
+				if echo "$line" | grep -qE '<query>|<N>[[:space:]]hits'; then
+					placeholder_count=$((placeholder_count + 1))
+				else
+					populated_count=$((populated_count + 1))
+				fi
+			elif echo "$line" | grep -qiE 'Discovery[[:space:]]+pass'; then
+				has_discovery=1
+				if echo "$line" | grep -qE '<N>[[:space:]]commits|<date>'; then
+					placeholder_count=$((placeholder_count + 1))
+				else
+					populated_count=$((populated_count + 1))
+				fi
+			elif echo "$line" | grep -qiE 'File[[:space:]]+refs'; then
+				has_filerefs=1
+				if echo "$line" | grep -qE '<N>[[:space:]]refs[[:space:]]checked'; then
+					placeholder_count=$((placeholder_count + 1))
+				else
+					populated_count=$((populated_count + 1))
+				fi
+			elif echo "$line" | grep -qiE '^[[:space:]]*-[[:space:]]+\[[[:space:]x]\][[:space:]]+Tier:'; then
+				has_tier=1
+				if echo "$line" | grep -qE '<tier>'; then
+					placeholder_count=$((placeholder_count + 1))
+				else
+					populated_count=$((populated_count + 1))
+				fi
+			fi
+		fi
+	done <"$brief_path"
+
+	if [[ $found_section -eq 0 ]]; then
+		printf 'FAIL  Pre-flight section missing from brief\n'
+		return 1
+	fi
+
+	local missing=""
+	[[ $has_memory -eq 0 ]] && missing="${missing}memory recall, "
+	[[ $has_discovery -eq 0 ]] && missing="${missing}discovery pass, "
+	[[ $has_filerefs -eq 0 ]] && missing="${missing}file refs, "
+	[[ $has_tier -eq 0 ]] && missing="${missing}tier check, "
+
+	if [[ -n "$missing" ]]; then
+		missing="${missing%, }"
+		printf 'FAIL  Pre-flight missing required items: %s\n' "$missing"
+		return 1
+	fi
+
+	if [[ $placeholder_count -gt 0 ]]; then
+		printf 'FAIL  Pre-flight: %d of %d items still contain placeholder text\n' "$placeholder_count" "$total_boxes"
+		return 1
+	fi
+
+	printf 'PASS  Pre-flight: %d/%d items populated\n' "$populated_count" "$total_boxes"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 
@@ -252,20 +357,29 @@ main() {
 	local cmd="${1:-help}"
 	shift || true
 
+	local brief_path="${1:-}"
+
 	case "$cmd" in
 	verify)
-		if [[ $# -lt 1 ]]; then
+		if [[ -z "$brief_path" ]]; then
 			_log "ERROR" "Missing brief path. Usage: verify-brief-helper.sh verify <path>"
 			return 2
 		fi
-		_cmd_verify "$1"
+		_cmd_verify "$brief_path"
 		;;
 	list)
-		if [[ $# -lt 1 ]]; then
+		if [[ -z "$brief_path" ]]; then
 			_log "ERROR" "Missing brief path. Usage: verify-brief-helper.sh list <path>"
 			return 2
 		fi
-		_cmd_list "$1"
+		_cmd_list "$brief_path"
+		;;
+	check-preflight)
+		if [[ -z "$brief_path" ]]; then
+			_log "ERROR" "Missing brief path. Usage: verify-brief-helper.sh check-preflight <path>"
+			return 2
+		fi
+		_cmd_check_preflight "$brief_path"
 		;;
 	help | --help | -h)
 		_usage

--- a/.agents/scripts/verify-brief.sh
+++ b/.agents/scripts/verify-brief.sh
@@ -59,6 +59,11 @@ SKIP_COUNT=0
 UNVERIFIED_COUNT=0
 TOTAL_CRITERIA=0
 
+# Status constants (avoid repeated string literals)
+STATUS_PASS="pass"
+STATUS_FAIL="fail"
+STATUS_SKIP="skip"
+
 # Results array (for JSON output)
 declare -a RESULTS=()
 
@@ -73,6 +78,166 @@ log_debug() { [[ "$VERBOSE" == "true" ]] && echo -e "${CYAN}[DEBUG]${NC} $*" >&2
 # Show help
 show_help() {
 	grep '^#' "$0" | grep -v '#!/usr/bin/env' | sed 's/^# //' | sed 's/^#//'
+	return 0
+}
+
+# Validate Pre-flight block presence and completeness.
+# Checks that the brief contains a "## Pre-flight" section with all 4
+# required checkboxes populated (not placeholder text).
+# Returns 0 if valid, 1 if missing/incomplete, 2 if section absent.
+validate_preflight() {
+	local brief_file="$1"
+	local in_preflight=false
+	local found_section=false
+	local checked_count=0
+	local unchecked_count=0
+	local total_boxes=0
+	local has_memory=false
+	local has_discovery=false
+	local has_filerefs=false
+	local has_tier=false
+
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		# Detect Pre-flight section
+		if [[ "$line" =~ ^##[[:space:]]+Pre-flight ]]; then
+			in_preflight=true
+			found_section=true
+			continue
+		fi
+
+		# Detect next section (exit preflight parsing)
+		if [[ "$in_preflight" == "true" && "$line" =~ ^##[[:space:]] && ! "$line" =~ Pre-flight ]]; then
+			break
+		fi
+
+		if [[ "$in_preflight" != "true" ]]; then
+			continue
+		fi
+
+		# Skip HTML comments
+		[[ "$line" =~ ^[[:space:]]*\<!-- ]] && continue
+
+		# Detect checkbox lines
+		if [[ "$line" =~ ^[[:space:]]*-[[:space:]]\[([[:space:]x])\][[:space:]](.+)$ ]]; then
+			local check_state="${BASH_REMATCH[1]}"
+			local check_text="${BASH_REMATCH[2]}"
+			total_boxes=$((total_boxes + 1))
+
+			if [[ "$check_state" == "x" ]]; then
+				checked_count=$((checked_count + 1))
+			else
+				unchecked_count=$((unchecked_count + 1))
+			fi
+
+			# Identify which check this is and verify it's populated (not template placeholder)
+			if [[ "$check_text" =~ ^Memory[[:space:]]recall ]]; then
+				has_memory=true
+				# Reject if still contains placeholder markers
+				if [[ "$check_text" =~ \<query\> || "$check_text" =~ \<N\>[[:space:]]hits ]]; then
+					log_fail "Pre-flight: Memory recall still contains placeholder text"
+					unchecked_count=$((unchecked_count + 1))
+					checked_count=$((checked_count > 0 ? checked_count - 1 : 0))
+				fi
+			elif [[ "$check_text" =~ ^Discovery[[:space:]]pass ]]; then
+				has_discovery=true
+				if [[ "$check_text" =~ \<N\>[[:space:]]commits || "$check_text" =~ \<date\> ]]; then
+					log_fail "Pre-flight: Discovery pass still contains placeholder text"
+					unchecked_count=$((unchecked_count + 1))
+					checked_count=$((checked_count > 0 ? checked_count - 1 : 0))
+				fi
+			elif [[ "$check_text" =~ ^File[[:space:]]refs ]]; then
+				has_filerefs=true
+				if [[ "$check_text" =~ \<N\>[[:space:]]refs[[:space:]]checked ]]; then
+					log_fail "Pre-flight: File refs still contains placeholder text"
+					unchecked_count=$((unchecked_count + 1))
+					checked_count=$((checked_count > 0 ? checked_count - 1 : 0))
+				fi
+			elif [[ "$check_text" =~ ^Tier: ]]; then
+				has_tier=true
+				if [[ "$check_text" =~ \<tier\> ]]; then
+					log_fail "Pre-flight: Tier still contains placeholder text"
+					unchecked_count=$((unchecked_count + 1))
+					checked_count=$((checked_count > 0 ? checked_count - 1 : 0))
+				fi
+			fi
+		fi
+	done <"$brief_file"
+
+	if [[ "$found_section" != "true" ]]; then
+		log_fail "Pre-flight section missing from brief"
+		return 2
+	fi
+
+	# Check all 4 required items are present
+	local missing=""
+	[[ "$has_memory" != "true" ]] && missing="${missing}memory recall, "
+	[[ "$has_discovery" != "true" ]] && missing="${missing}discovery pass, "
+	[[ "$has_filerefs" != "true" ]] && missing="${missing}file refs, "
+	[[ "$has_tier" != "true" ]] && missing="${missing}tier check, "
+
+	if [[ -n "$missing" ]]; then
+		missing="${missing%, }"
+		log_fail "Pre-flight missing required items: $missing"
+		return 1
+	fi
+
+	if [[ $unchecked_count -gt 0 ]]; then
+		log_warn "Pre-flight: $unchecked_count of $total_boxes items unchecked or contain placeholders"
+		return 1
+	fi
+
+	log_pass "Pre-flight: all $total_boxes items populated"
+	return 0
+}
+
+# Validate tier assignment against file count in Worker Guidance / Files to Modify.
+# If the brief claims tier:simple but lists >2 files, flag as invalid.
+# Returns 0 if valid or no tier claim, 1 if mis-tiered.
+validate_tier_file_count() {
+	local brief_file="$1"
+	local claimed_tier=""
+	local file_count=0
+	local in_files_section=false
+
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		# Extract tier from Pre-flight or Tier section
+		if [[ "$line" =~ Tier:[[:space:]]*\`?tier:([a-z]+) ]]; then
+			claimed_tier="${BASH_REMATCH[1]}"
+		fi
+		# Also check Selected tier line
+		if [[ "$line" =~ Selected[[:space:]]tier.*tier:([a-z]+) ]]; then
+			claimed_tier="${BASH_REMATCH[1]}"
+		fi
+
+		# Detect Files to Modify section
+		if [[ "$line" =~ ^###[[:space:]]+Files[[:space:]]to[[:space:]]Modify ]]; then
+			in_files_section=true
+			continue
+		fi
+
+		# Detect next section
+		if [[ "$in_files_section" == "true" && "$line" =~ ^### ]]; then
+			in_files_section=false
+			continue
+		fi
+
+		# Count file entries (lines starting with - ` or - NEW: or - EDIT:)
+		if [[ "$in_files_section" == "true" ]]; then
+			if [[ "$line" =~ ^[[:space:]]*-[[:space:]]+(NEW:|EDIT:|\`) ]]; then
+				file_count=$((file_count + 1))
+			fi
+		fi
+	done <"$brief_file"
+
+	if [[ "$claimed_tier" == "simple" && $file_count -gt 2 ]]; then
+		log_fail "Tier mismatch: brief claims tier:simple but lists $file_count files (max 2 for tier:simple)"
+		return 1
+	fi
+
+	if [[ -n "$claimed_tier" && $file_count -gt 0 ]]; then
+		log_debug "Tier validation: tier:$claimed_tier with $file_count file(s) — OK"
+	fi
+
 	return 0
 }
 
@@ -793,7 +958,7 @@ process_criterion() {
 	if ! parse_verify_yaml "$yaml"; then
 		FAIL_COUNT=$((FAIL_COUNT + 1))
 		log_fail "$criterion (invalid verify block)"
-		add_result "$criterion" "fail" "unknown" "Invalid verify block"
+		add_result "$criterion" "$STATUS_FAIL" "unknown" "Invalid verify block"
 		return 0
 	fi
 
@@ -835,17 +1000,17 @@ process_criterion() {
 	0)
 		PASS_COUNT=$((PASS_COUNT + 1))
 		log_pass "$criterion"
-		add_result "$criterion" "pass" "$V_METHOD" ""
+		add_result "$criterion" "$STATUS_PASS" "$V_METHOD" ""
 		;;
 	3)
 		# Skip (subagent/manual)
 		SKIP_COUNT=$((SKIP_COUNT + 1))
-		add_result "$criterion" "skip" "$V_METHOD" "Requires human/AI review"
+		add_result "$criterion" "$STATUS_SKIP" "$V_METHOD" "Requires human/AI review"
 		;;
 	*)
 		FAIL_COUNT=$((FAIL_COUNT + 1))
 		log_fail "$criterion"
-		add_result "$criterion" "fail" "$V_METHOD" "Exit code: $rc"
+		add_result "$criterion" "$STATUS_FAIL" "$V_METHOD" "Exit code: $rc"
 		;;
 	esac
 
@@ -867,20 +1032,54 @@ main() {
 		log_info "DRY RUN — parsing only, no execution"
 	fi
 
+	# --- Pre-flight block validation ---
+	local preflight_rc=0
+	log_info "--- Pre-flight Block ---"
+	if [[ "$DRY_RUN" == "true" ]]; then
+		log_info "  [preflight] Checking Pre-flight section presence and completeness"
+	else
+		validate_preflight "$BRIEF_FILE" || preflight_rc=$?
+		if [[ $preflight_rc -ne 0 ]]; then
+			FAIL_COUNT=$((FAIL_COUNT + 1))
+			TOTAL_CRITERIA=$((TOTAL_CRITERIA + 1))
+			add_result "Pre-flight block completeness" "$STATUS_FAIL" "preflight" "Exit code: $preflight_rc"
+		else
+			PASS_COUNT=$((PASS_COUNT + 1))
+			TOTAL_CRITERIA=$((TOTAL_CRITERIA + 1))
+			add_result "Pre-flight block completeness" "$STATUS_PASS" "preflight" ""
+		fi
+	fi
+
+	# --- Tier-file-count cross-validation ---
+	local tier_rc=0
+	if [[ "$DRY_RUN" == "true" ]]; then
+		log_info "  [tier] Checking tier vs file count consistency"
+	else
+		validate_tier_file_count "$BRIEF_FILE" || tier_rc=$?
+		if [[ $tier_rc -ne 0 ]]; then
+			FAIL_COUNT=$((FAIL_COUNT + 1))
+			TOTAL_CRITERIA=$((TOTAL_CRITERIA + 1))
+			add_result "Tier-file-count consistency" "$STATUS_FAIL" "tier" "tier:simple with >2 files"
+		else
+			PASS_COUNT=$((PASS_COUNT + 1))
+			TOTAL_CRITERIA=$((TOTAL_CRITERIA + 1))
+			add_result "Tier-file-count consistency" "$STATUS_PASS" "tier" ""
+		fi
+	fi
+
 	# Parse the brief file into parallel arrays
 	parse_brief "$BRIEF_FILE"
 
 	local count=${#CRITERIA_TEXT[@]}
 	if [[ $count -eq 0 ]]; then
 		log_info "No acceptance criteria found"
-		return 0
+	else
+		# Process each criterion
+		local i
+		for ((i = 0; i < count; i++)); do
+			process_criterion "${CRITERIA_TEXT[$i]}" "${CRITERIA_YAML[$i]}"
+		done
 	fi
-
-	# Process each criterion
-	local i
-	for ((i = 0; i < count; i++)); do
-		process_criterion "${CRITERIA_TEXT[$i]}" "${CRITERIA_YAML[$i]}"
-	done
 
 	# Summary
 	echo "" >&2

--- a/.agents/templates/brief-template.md
+++ b/.agents/templates/brief-template.md
@@ -6,6 +6,17 @@ mode: subagent
 <!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
 # {task_id}: {Title}
 
+## Pre-flight (auto-populated by briefing workflow)
+
+<!-- MANDATORY — workflows/brief.md "Pre-composition checks" populates these.
+     verify-brief.sh rejects briefs with unchecked Pre-flight boxes.
+     Each checkbox documents that the check was performed and what it found. -->
+
+- [ ] Memory recall: `<query>` -> `<N>` hits | no results
+- [ ] Discovery pass: `<N>` commits / `<N>` merged PRs / `<N>` open PRs touch target files since `<date>`
+- [ ] File refs verified: `<N>` refs checked, all present | `<N>` missing (list)
+- [ ] Tier: `<tier>` -- disqualifier check clean | disqualified from `<tier>` because `<reason>`
+
 ## Origin
 
 - **Created:** {YYYY-MM-DD}

--- a/.agents/workflows/brief.md
+++ b/.agents/workflows/brief.md
@@ -27,6 +27,69 @@ tools:
 
 <!-- AI-CONTEXT-END -->
 
+## Pre-Composition Checks (MANDATORY)
+
+Before composing any brief that will result in code changes, perform these checks in order. Skipping them causes duplicate work, phantom references, and mis-tiered dispatches (see GH#17832-17835, t2046, t2050 for prior evidence).
+
+### 1. Memory recall (t2050)
+
+```bash
+memory-helper.sh recall --query "<1-3 keyword phrase from task>" --limit 5
+```
+
+Surface accumulated lessons from prior sessions. Read any results before proceeding — they may reveal that the approach was tried before, that a specific pattern failed, or that a related fix already landed.
+
+### 2. Discovery pass (t2046)
+
+For any brief that targets code changes, run all three queries:
+
+```bash
+# Recent commits on target files
+git log --since="<issue-age + 2h>" --oneline -- <target-files>
+
+# Recently merged PRs in the same problem space
+gh pr list --state merged --search "<keywords>" --limit 5
+
+# Open PRs that may collide
+gh pr list --state open --search "<keywords>" --limit 5
+```
+
+**If any query surfaces a hit on the exact target files:**
+
+- STOP and verify whether the task is still valid.
+- If a merged PR already addresses the problem, route to a close-with-pointer comment (see `brief/routing.md` "Already-shipped detection") instead of filing a new task.
+- If an open PR is in-flight on the same files, route to a comment on that PR instead of creating a parallel effort.
+
+### 3. File:line verification
+
+For every file reference in the draft brief, confirm the reference exists and the content matches the claim:
+
+```bash
+# Verify file exists
+git ls-files <path>
+
+# Verify line content matches
+sed -n '<line>p' <path>
+```
+
+Briefs with phantom line refs waste worker cycles. A worker dispatched against a nonexistent `file:line` burns tokens navigating before discovering the reference is wrong (see GH#17832-17835).
+
+### 4. Tier disqualifier check
+
+Cross-check the draft brief against `reference/task-taxonomy.md` "Tier Assignment Validation" disqualifiers BEFORE choosing a tier. The server-side `tier-simple-body-shape-helper.sh` (t2389) auto-downgrades mis-tiered `tier:simple` issues, but catching mis-classification at composition time is cheaper than a failed dispatch + cascade escalation.
+
+### 5. Self-assignment awareness
+
+If filing via `gh_create_issue` with `auto-dispatch` label, plan to unassign immediately after:
+
+```bash
+gh issue edit <N> --repo <slug> --remove-assignee <user>
+```
+
+The wrapper currently self-assigns in violation of t2157 (tracked as t2406 / GH#19991). Until the fix merges, manual unassign is required to prevent dispatch-blocking.
+
+---
+
 ## Core Rule
 
 **The brief IS the product.** A vague brief dispatched to Opus wastes more money than a prescriptive brief dispatched to Haiku. Invest the effort in the brief, not the worker.

--- a/.agents/workflows/brief/routing.md
+++ b/.agents/workflows/brief/routing.md
@@ -27,6 +27,28 @@ When to use this agent for structured GitHub content.
 | Workers (on completion) | PR description | Summary + linked issue + verification evidence |
 | Workers (on failure) | Escalation comment | What was tried, where it stuck, brief gaps |
 
+## Already-Shipped Detection
+
+When the pre-composition discovery pass (see `workflows/brief.md` "Pre-composition checks") surfaces a **merged PR** that touched the exact target files:
+
+| Signal | Action |
+|--------|--------|
+| Merged PR fixes the same bug/gap | Close the issue with a pointer: `Duplicate of #NNN (merged <date>). Verified against HEAD — symptom no longer reproduces.` |
+| Merged PR partially addresses | File a narrower follow-up task scoped only to the remaining gap. Reference the merged PR in the brief. |
+| Merged PR is unrelated (coincidental file overlap) | Proceed with brief composition. Note the overlap in the brief's Context section to save the worker re-checking. |
+
+## In-Flight Collision Detection
+
+When the discovery pass surfaces an **open PR** on the same target files:
+
+| Signal | Action |
+|--------|--------|
+| Open PR covers the same scope | Post a comment on the open PR with the new requirement. Do NOT file a duplicate task. |
+| Open PR partially overlaps | Coordinate: file the new task with a `blocked-by:` reference to the open PR, or scope the new task to non-overlapping files. |
+| Open PR is unrelated (coincidental file overlap) | Proceed. Note the in-flight PR in the brief's Context section. |
+
+Both detection paths are mandatory when the discovery pass returns hits. Skipping them is how duplicate PRs get filed (see t2046 "Pre-implementation discovery" for the root cause and evidence).
+
 ## PR descriptions
 
 | Creator | Content type | What this agent provides |


### PR DESCRIPTION
## Summary

- Add mandatory **Pre-composition checks** section to `workflows/brief.md` with 5 checks: memory recall (t2050), discovery pass (t2046), file:line verification (GH#17832-17835), tier disqualifier check, and self-assignment awareness
- Add **Already-Shipped Detection** and **In-Flight Collision Detection** routing rules to `brief/routing.md` so briefs that hit existing work are routed to close/comment instead of duplicate tasks
- Add **Pre-flight** checklist block to `brief-template.md` that serves as audit trail that composition checks were performed
- Extend `verify-brief.sh` with `validate_preflight()` and `validate_tier_file_count()` — rejects briefs with missing/placeholder Pre-flight blocks and tier:simple claims with >2 files
- Extend `verify-brief-helper.sh` with `check-preflight` command for standalone Pre-flight validation
- Add `test-verify-brief.sh` with 7 regression assertions (all passing)

## Testing

- ShellCheck clean on all 3 modified shell scripts
- markdownlint clean on brief.md and routing.md
- All 7 regression tests pass:
  1. verify-brief.sh rejects missing Pre-flight
  2. verify-brief.sh rejects placeholder Pre-flight
  3. verify-brief.sh passes populated Pre-flight
  4. verify-brief.sh rejects tier:simple with >2 files
  5. helper check-preflight rejects missing section
  6. helper check-preflight rejects placeholders
  7. helper check-preflight passes populated brief
- Pre-commit quality ratchet clean (no new violations)

Resolves #20007


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.78 plugin for [OpenCode](https://opencode.ai) v1.14.18 with claude-opus-4-6 spent 20m and 25,183 tokens on this as a headless worker.