### PR TITLE
t2417: detect worker-ready issue bodies and skip redundant brief creation

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -81,6 +81,8 @@ Task IDs: `/new-task` or `claim-task-id.sh`. NEVER grep TODO.md for next ID.
 
 - **Task briefs:** Every task must have `todo/tasks/{task_id}-brief.md` (via `/define` or `/new-task`). A task without a brief is undevelopable because it loses the implementation context needed for autonomous execution. See `workflows/plans.md` and `scripts/commands/new-task.md`.
 
+**Worker-ready issue body heuristic (t2417):** Before creating a full brief, `/define`, `/new-task`, and `task-brief-helper.sh` check whether the linked issue body is already worker-ready — i.e., it contains 4+ of the 7 known heading signals (`## Task`, `## Why`, `## How`, `## Acceptance`, `## What`, `## Session Origin`, `## Files to modify`). When the issue body is worker-ready, the brief file is either skipped (headless default) or replaced with a stub that links to the issue as the canonical brief. This prevents brief/issue body duplication and the collision surface it creates (see GH#20015). Helper: `scripts/brief-readiness-helper.sh`. Threshold override: `BRIEF_READINESS_THRESHOLD` env var.
+
 **Brief composition**: All GitHub-written content (issue bodies, PR descriptions, comments, escalation reports) follows `workflows/brief.md` — the centralised formatting workflow.
 
 **Model tiers**: Use GitHub labels to set the model tier. The pulse reads these labels for tier routing, not `model:` in `TODO.md`. See `reference/task-taxonomy.md`. **Brief quality determines which model tier can execute** — never assign a tier without verifying the brief meets that tier's prerequisites:

--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -1820,9 +1820,9 @@
       "pr": 16548
     },
     ".agents/scripts/approval-helper.sh": {
-      "at": "2026-04-14T08:25:15Z",
-      "hash": "5e11b9ad67f1c65ca3f599af558ef858cb1b4132",
-      "passes": 5,
+      "at": "2026-04-19T19:49:13Z",
+      "hash": "c17c9b5caf2a16de9579ab687636f1b20c7f8f03",
+      "passes": 6,
       "pr": 17454
     },
     ".agents/scripts/attribution-detection-helper.sh": {
@@ -2262,9 +2262,9 @@
       "pr": 12145
     },
     ".agents/scripts/full-loop-helper.sh": {
-      "at": "2026-04-19T05:30:53Z",
-      "hash": "0da699d76a8d8fb04cae2b8fc41b4d3a1f27ead4",
-      "passes": 11,
+      "at": "2026-04-19T19:49:16Z",
+      "hash": "0f8ab35f066deead150f2be89671dc13d68f3c10",
+      "passes": 12,
       "pr": 19046
     },
     ".agents/scripts/generate-claude-commands.sh": {
@@ -2310,9 +2310,9 @@
       "pr": 18707
     },
     ".agents/scripts/interactive-session-helper.sh": {
-      "at": "2026-04-19T15:35:43Z",
-      "hash": "7f1ff2dfe9f16e143dad1df55167e4599d192320",
-      "passes": 5,
+      "at": "2026-04-19T19:49:17Z",
+      "hash": "c211c40b61dd90a0462f217099e9d8dc1651f092",
+      "passes": 6,
       "pr": 18843
     },
     ".agents/scripts/issue-sync-helper.sh": {
@@ -2394,15 +2394,15 @@
       "pr": 17590
     },
     ".agents/scripts/pulse-ancillary-dispatch.sh": {
-      "at": "2026-04-15T07:31:55Z",
-      "hash": "ab72fd6b20e25c4e7f8002d79a94fa44e5a71193",
-      "passes": 5,
+      "at": "2026-04-19T19:49:18Z",
+      "hash": "addd94dd0e7fccf14ec501f96df233e13bb7635f",
+      "passes": 6,
       "pr": 18657
     },
     ".agents/scripts/pulse-cleanup.sh": {
-      "at": "2026-04-19T05:30:54Z",
-      "hash": "7ad09a7f4b01d77b7ef3717affa029687235a029",
-      "passes": 5,
+      "at": "2026-04-19T19:49:18Z",
+      "hash": "6e87466afbda81aa546fcfa807ec247e1a377575",
+      "passes": 6,
       "pr": 18704
     },
     ".agents/scripts/pulse-dep-graph.sh": {
@@ -2436,15 +2436,15 @@
       "pr": 18691
     },
     ".agents/scripts/pulse-issue-reconcile.sh": {
-      "at": "2026-04-19T16:33:53Z",
-      "hash": "1c38a184c6d2d2eb18be2c19c9b70a00e99b3ae6",
-      "passes": 12,
+      "at": "2026-04-19T19:49:19Z",
+      "hash": "333bf1d2301ec3f8fdaa92e661f319d0af9d66fd",
+      "passes": 13,
       "pr": 18690
     },
     ".agents/scripts/pulse-merge.sh": {
-      "at": "2026-04-19T05:30:55Z",
-      "hash": "f5d5e9a21c27d84d0ee85ec8ae0704af7c2f3c43",
-      "passes": 16,
+      "at": "2026-04-19T19:49:19Z",
+      "hash": "7c7b2da1a1f161faa84fc6de12329b8e34689adb",
+      "passes": 17,
       "pr": 18829
     },
     ".agents/scripts/pulse-prefetch.sh": {
@@ -2466,15 +2466,15 @@
       "pr": 18680
     },
     ".agents/scripts/pulse-simplification.sh": {
-      "at": "2026-04-19T19:19:44Z",
-      "hash": "5152aaa11f855afe1fa2cac2928e93c26c1f8ed2",
-      "passes": 12,
+      "at": "2026-04-19T19:49:19Z",
+      "hash": "c75571e3c08dc536515010addaee2ad74294f4ff",
+      "passes": 13,
       "pr": 18653
     },
     ".agents/scripts/pulse-triage.sh": {
-      "at": "2026-04-17T20:02:43Z",
-      "hash": "ccdec4f51fd698f9670d95bc44fc0c34c4481119",
-      "passes": 14,
+      "at": "2026-04-19T19:49:20Z",
+      "hash": "f124eb7f52c809170f73ab3c96ec08a388e2bbe3",
+      "passes": 15,
       "pr": 18655
     },
     ".agents/scripts/pulse-wrapper.sh": {
@@ -2496,15 +2496,15 @@
       "pr": 19000
     },
     ".agents/scripts/quality-feedback-issues-lib.sh": {
-      "at": "2026-04-14T22:16:57Z",
-      "hash": "659f27c08e7ad944343d00646a2ccc522fd90bcd",
-      "passes": 1,
+      "at": "2026-04-19T19:49:20Z",
+      "hash": "1896895d66108306b86290d2888e6b17346d5960",
+      "passes": 2,
       "pr": 19004
     },
     ".agents/scripts/routine-log-helper.sh": {
-      "at": "2026-04-19T15:35:45Z",
-      "hash": "38165378dc1fdd3945ea60afac7575fc2a370abd",
-      "passes": 5,
+      "at": "2026-04-19T19:49:20Z",
+      "hash": "42e7c977adf51385bb7a279747b2b31e70ef9772",
+      "passes": 6,
       "pr": 17786
     },
     ".agents/scripts/schema-validator-helper.sh": {
@@ -2544,9 +2544,9 @@
       "pr": 15916
     },
     ".agents/scripts/shared-constants.sh": {
-      "at": "2026-04-19T16:57:28Z",
-      "hash": "ddf89faf7483610db1c7092cf67ed61a95597713",
-      "passes": 12,
+      "at": "2026-04-19T19:49:21Z",
+      "hash": "0e5d4cdf24626e49e9c259934c029b6ffe3e1c56",
+      "passes": 13,
       "pr": 18847
     },
     ".agents/scripts/stats-functions.sh": {
@@ -2556,9 +2556,9 @@
       "pr": 18808
     },
     ".agents/scripts/stats-quality-sweep.sh": {
-      "at": "2026-04-19T19:19:45Z",
-      "hash": "82fa13bd747ca986255f0b39ecbd2274b78aa12a",
-      "passes": 5,
+      "at": "2026-04-19T19:49:21Z",
+      "hash": "91cf86de8603aa66652621ca81fe44ec18b04b27",
+      "passes": 6,
       "pr": 18810
     },
     ".agents/scripts/tabby-helper.sh": {
@@ -2615,15 +2615,15 @@
       "passes": 1
     },
     ".agents/scripts/worker-lifecycle-common.sh": {
-      "at": "2026-04-19T16:33:54Z",
-      "hash": "302d32f4bec7c6f123e4024359dcb9421e5030d0",
-      "passes": 9,
+      "at": "2026-04-19T19:49:22Z",
+      "hash": "8334e61684c800d3c352e35c246741408f28ea35",
+      "passes": 10,
       "pr": 17353
     },
     ".agents/scripts/worker-watchdog.sh": {
-      "at": "2026-04-19T05:30:58Z",
-      "hash": "02fd9b15d344af17fc4e89721aa2c8ff83c68315",
-      "passes": 6,
+      "at": "2026-04-19T19:49:22Z",
+      "hash": "450818e69470a55ecf028cb3619303b63cf54b73",
+      "passes": 7,
       "pr": 17393
     },
     ".agents/scripts/worktree-helper.sh": {
@@ -7492,9 +7492,9 @@
       "pr": 15490
     },
     "aidevops.sh": {
-      "at": "2026-04-19T18:37:10Z",
-      "hash": "9b5d67b5bddfcb9828eb2f57baa521950339c994",
-      "passes": 87,
+      "at": "2026-04-19T19:50:10Z",
+      "hash": "6e9cbe486ccf95dcb0de0817f50dc73de2b25e6a",
+      "passes": 88,
       "pr": 19029
     },
     "setup-modules/agent-deploy.sh": {
@@ -7504,9 +7504,9 @@
       "pr": 19203
     },
     "setup.sh": {
-      "at": "2026-04-19T18:37:10Z",
-      "hash": "df8bff4dde5cc40053f7fe800ebdb3fc19103f84",
-      "passes": 84,
+      "at": "2026-04-19T19:50:10Z",
+      "hash": "5a8b5cbbaebb5379cc22e590e9f57e2992be1f4f",
+      "passes": 85,
       "pr": 15470
     },
     "todo/tasks/GH#15363-brief.md": {

--- a/.agents/scripts/brief-readiness-helper.sh
+++ b/.agents/scripts/brief-readiness-helper.sh
@@ -1,0 +1,393 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# brief-readiness-helper.sh — Detect worker-ready issue bodies and generate
+# stub briefs linking to the canonical issue (t2417, GH#20015).
+#
+# An issue body is "worker-ready" when it already contains the structured
+# headings a worker needs to implement autonomously (Task/What, Why, How,
+# Acceptance, Files to modify). In that case, creating a separate brief
+# file at todo/tasks/{id}-brief.md is redundant — the issue IS the brief.
+#
+# This helper provides:
+#   1. A readiness detector (`check`) that scores an issue body against
+#      known heading sets and returns a pass/fail verdict.
+#   2. A stub-brief writer (`stub`) that creates a minimal brief linking
+#      to the canonical issue instead of duplicating its content.
+#   3. A similarity check (`similarity`) that compares an existing brief
+#      file against an issue body and reports overlap percentage.
+#
+# Usage:
+#   brief-readiness-helper.sh check   <issue-number> <slug>
+#   brief-readiness-helper.sh check   --body <body-text>
+#   brief-readiness-helper.sh stub    <task-id> <issue-number> <slug> [repo-path]
+#   brief-readiness-helper.sh similarity <brief-path> --body <body-text>
+#   brief-readiness-helper.sh help
+#
+# Exit codes:
+#   0 — issue body IS worker-ready (check), or operation succeeded
+#   1 — issue body is NOT worker-ready (check), or error
+#   2 — usage error
+#
+# Environment:
+#   BRIEF_READINESS_THRESHOLD — override the 4-of-7 heading threshold (default: 4)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit 1
+
+# shellcheck source=/dev/null
+if [[ -f "$SCRIPT_DIR/shared-constants.sh" ]]; then
+	source "$SCRIPT_DIR/shared-constants.sh"
+fi
+
+# ---------------------------------------------------------------------------
+# Logging (inline fallbacks if shared-constants not sourced)
+# ---------------------------------------------------------------------------
+if ! command -v log_info >/dev/null 2>&1; then
+	log_info()  { printf '[INFO]  %s\n' "$*" >&2; return 0; }
+	log_warn()  { printf '[WARN]  %s\n' "$*" >&2; return 0; }
+	log_error() { printf '[ERROR] %s\n' "$*" >&2; return 0; }
+fi
+
+# ---------------------------------------------------------------------------
+# Constants — the heading sets that signal worker-readiness.
+#
+# Two heading families exist in the wild:
+#   Primary:   ## Task, ## Why, ## How, ## Acceptance
+#   Alternate: ## What, ## Session Origin, ## Files to modify, ## Worker Guidance
+#
+# A body scoring >= THRESHOLD across both sets is worker-ready.
+# ---------------------------------------------------------------------------
+readonly DEFAULT_THRESHOLD=4
+
+# Primary headings (the brief-template canonical set)
+readonly -a PRIMARY_HEADINGS=(
+	"## Task"
+	"## Why"
+	"## How"
+	"## Acceptance"
+)
+
+# Alternate headings (common in enriched issue bodies)
+readonly -a ALTERNATE_HEADINGS=(
+	"## What"
+	"## Session Origin"
+	"## Files to modify"
+)
+
+# ---------------------------------------------------------------------------
+# _score_body: count how many of the known headings appear in the body.
+#
+# Args: body_text
+# Stdout: integer score (0-7)
+# Returns: 0 always
+# ---------------------------------------------------------------------------
+_score_body() {
+	local -a _sb_args=("$@")
+	local body="${_sb_args[0]}"
+	local score=0
+
+	local heading
+	for heading in "${PRIMARY_HEADINGS[@]}" "${ALTERNATE_HEADINGS[@]}"; do
+		if printf '%s\n' "$body" | grep -qiF "$heading"; then
+			score=$((score + 1))
+		fi
+	done
+
+	printf '%d\n' "$score"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# _is_worker_ready: check whether a body meets the readiness threshold.
+#
+# Args: body_text [threshold]
+# Returns: 0 if worker-ready, 1 if not
+# ---------------------------------------------------------------------------
+_is_worker_ready() {
+	local -a _iwr_args=("$@")
+	local body="${_iwr_args[0]}"
+	local threshold="${_iwr_args[1]:-${BRIEF_READINESS_THRESHOLD:-$DEFAULT_THRESHOLD}}"
+
+	local score
+	score=$(_score_body "$body")
+
+	if [[ "$score" -ge "$threshold" ]]; then
+		return 0
+	fi
+	return 1
+}
+
+# ---------------------------------------------------------------------------
+# _fetch_issue_body: retrieve the body text of a GitHub issue.
+#
+# Args: issue_number slug
+# Stdout: body text
+# Returns: 0 on success, 1 on failure
+# ---------------------------------------------------------------------------
+_fetch_issue_body() {
+	local -a _fib_args=("$@")
+	local issue_number="${_fib_args[0]}"
+	local slug="${_fib_args[1]}"
+
+	local body
+	body=$(gh issue view "$issue_number" --repo "$slug" --json body --jq '.body' 2>/dev/null) || {
+		log_error "Failed to fetch issue #${issue_number} from ${slug}"
+		return 1
+	}
+
+	printf '%s\n' "$body"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# cmd_check: score an issue body and report worker-readiness.
+#
+# Args: <issue-number> <slug>  OR  --body <body-text>
+# Stdout: WORKER_READY=true/false, SCORE=N, THRESHOLD=N
+# Exit: 0 if worker-ready, 1 if not
+# ---------------------------------------------------------------------------
+cmd_check() {
+	local body=""
+	local issue_number=""
+	local slug=""
+	local threshold="${BRIEF_READINESS_THRESHOLD:-$DEFAULT_THRESHOLD}"
+
+	# Capture all args into a local array to avoid direct $1/$2 references
+	local -a _args=("$@")
+	local _i=0 _len="${#_args[@]}" _cur=""
+
+	while [[ $_i -lt $_len ]]; do
+		_cur="${_args[$_i]}"
+		case "$_cur" in
+		--body)
+			_i=$((_i + 1)); body="${_args[$_i]}" ;;
+		--threshold)
+			_i=$((_i + 1)); threshold="${_args[$_i]}" ;;
+		*)
+			if [[ -z "$issue_number" ]]; then
+				issue_number="$_cur"
+			elif [[ -z "$slug" ]]; then
+				slug="$_cur"
+			else
+				log_error "Unexpected argument: $_cur"
+				return 2
+			fi
+			;;
+		esac
+		_i=$((_i + 1))
+	done
+
+	# Fetch body from GitHub if not provided inline
+	if [[ -z "$body" ]]; then
+		if [[ -z "$issue_number" || -z "$slug" ]]; then
+			log_error "Usage: brief-readiness-helper.sh check <issue-number> <slug>"
+			log_error "       brief-readiness-helper.sh check --body <body-text>"
+			return 2
+		fi
+		body=$(_fetch_issue_body "$issue_number" "$slug") || return 1
+	fi
+
+	local score
+	score=$(_score_body "$body")
+	local ready="false"
+	local exit_code=1
+
+	if [[ "$score" -ge "$threshold" ]]; then
+		ready="true"
+		exit_code=0
+	fi
+
+	printf 'WORKER_READY=%s\n' "$ready"
+	printf 'SCORE=%d\n' "$score"
+	printf 'THRESHOLD=%d\n' "$threshold"
+
+	return "$exit_code"
+}
+
+# ---------------------------------------------------------------------------
+# cmd_stub: write a minimal stub brief that links to the canonical issue.
+#
+# Args: <task-id> <issue-number> <slug> [repo-path]
+# Creates: todo/tasks/{task_id}-brief.md (stub form)
+# Exit: 0 on success
+# ---------------------------------------------------------------------------
+cmd_stub() {
+	local -a _stub_args=("$@")
+	local task_id="${_stub_args[0]:-}"
+	local issue_number="${_stub_args[1]:-}"
+	local slug="${_stub_args[2]:-}"
+	local repo_path="${_stub_args[3]:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+
+	if [[ -z "$task_id" || -z "$issue_number" || -z "$slug" ]]; then
+		log_error "Usage: brief-readiness-helper.sh stub <task-id> <issue-number> <slug> [repo-path]"
+		return 2
+	fi
+
+	local brief_dir="$repo_path/todo/tasks"
+	local brief_path="$brief_dir/${task_id}-brief.md"
+	local today
+	today=$(date +%Y-%m-%d)
+
+	mkdir -p "$brief_dir"
+
+	if [[ -f "$brief_path" ]]; then
+		log_warn "Brief already exists: $brief_path — skipping stub creation"
+		return 0
+	fi
+
+	# Fetch issue title for the heading
+	local issue_title=""
+	issue_title=$(gh issue view "$issue_number" --repo "$slug" --json title --jq '.title' 2>/dev/null) || true
+	issue_title="${issue_title:-${task_id}}"
+
+	cat >"$brief_path" <<EOF
+# ${task_id}: ${issue_title}
+
+## Origin
+
+- **Created:** ${today}
+- **Session:** auto-detected worker-ready issue body
+- **Created by:** brief-readiness-helper (stub — canonical brief lives in issue)
+
+## Canonical Brief
+
+**The authoritative brief for this task is the GitHub issue body:**
+
+https://github.com/${slug}/issues/${issue_number}
+
+The issue body contains all required sections (Task/What, Why, How,
+Acceptance, Files to modify) and is the single source of truth.
+This stub exists only to satisfy the brief-file-exists gate.
+
+## Session-Specific Context
+
+<!-- Add any session-specific context not captured in the issue body. -->
+<!-- If empty, this section can be removed. -->
+EOF
+
+	log_info "Stub brief written to $brief_path (canonical: issue #${issue_number})"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# cmd_similarity: compare a brief file against an issue body.
+#
+# Uses a line-level overlap heuristic: count lines in the brief that also
+# appear (after whitespace normalisation) in the issue body. Report the
+# percentage of brief lines that overlap.
+#
+# Args: <brief-path> --body <body-text>
+# Stdout: SIMILARITY=NN (0-100)
+# Exit: 0 always
+# ---------------------------------------------------------------------------
+cmd_similarity() {
+	# Capture all args into a local array to avoid direct positional refs
+	local -a _args=("$@")
+	local brief_path="${_args[0]:-}"
+	local body=""
+	local _i=1 _len="${#_args[@]}" _cur=""
+
+	while [[ $_i -lt $_len ]]; do
+		_cur="${_args[$_i]}"
+		case "$_cur" in
+		--body)
+			_i=$((_i + 1)); body="${_args[$_i]}" ;;
+		*)
+			log_error "Unknown option: $_cur"
+			return 2
+			;;
+		esac
+		_i=$((_i + 1))
+	done
+
+	if [[ -z "$brief_path" || -z "$body" ]]; then
+		log_error "Usage: brief-readiness-helper.sh similarity <brief-path> --body <body-text>"
+		return 2
+	fi
+
+	if [[ ! -f "$brief_path" ]]; then
+		log_error "Brief file not found: $brief_path"
+		return 1
+	fi
+
+	# Normalise both texts: collapse whitespace, lowercase, strip markdown
+	# formatting markers (##, **, ```, - [ ]), then compare line-by-line.
+	local norm_body norm_brief
+	norm_body=$(printf '%s\n' "$body" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//; s/[[:space:]]+/ /g' | tr '[:upper:]' '[:lower:]' | grep -v '^$' || true)
+	norm_brief=$(sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//; s/[[:space:]]+/ /g' "$brief_path" | tr '[:upper:]' '[:lower:]' | grep -v '^$' || true)
+
+	local total_lines=0
+	local matching_lines=0
+
+	while IFS= read -r line; do
+		# Skip very short lines (headers, blank, markers) — they match too easily
+		if [[ ${#line} -lt 10 ]]; then
+			continue
+		fi
+		total_lines=$((total_lines + 1))
+		if printf '%s\n' "$norm_body" | grep -qF "$line"; then
+			matching_lines=$((matching_lines + 1))
+		fi
+	done <<<"$norm_brief"
+
+	local similarity=0
+	if [[ "$total_lines" -gt 0 ]]; then
+		similarity=$(( (matching_lines * 100) / total_lines ))
+	fi
+
+	printf 'SIMILARITY=%d\n' "$similarity"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# cmd_help
+# ---------------------------------------------------------------------------
+cmd_help() {
+	cat <<'USAGE'
+brief-readiness-helper.sh — Detect worker-ready issue bodies (t2417)
+
+Usage:
+  check <issue-number> <slug>           Score an issue body for worker-readiness
+  check --body <body-text>              Score inline body text
+  stub  <task-id> <issue> <slug> [path] Write a stub brief linking to the issue
+  similarity <brief-path> --body <text> Compare brief vs issue body overlap (%)
+  help                                  Show this help
+
+Exit codes:
+  0 — worker-ready (check), or operation succeeded
+  1 — not worker-ready (check), or error
+  2 — usage error
+
+Environment:
+  BRIEF_READINESS_THRESHOLD  Override the 4-of-7 heading threshold (default: 4)
+USAGE
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Main dispatch
+# ---------------------------------------------------------------------------
+main() {
+	local -a _main_args=("$@")
+	local cmd="${_main_args[0]:-help}"
+
+	# Remove first element to pass remaining args
+	local -a _rest=("${_main_args[@]:1}")
+
+	case "$cmd" in
+	check)      cmd_check "${_rest[@]}" ;;
+	stub)       cmd_stub "${_rest[@]}" ;;
+	similarity) cmd_similarity "${_rest[@]}" ;;
+	help|--help|-h) cmd_help ;;
+	*)
+		log_error "Unknown command: $cmd"
+		cmd_help
+		return 2
+		;;
+	esac
+}
+
+main "$@"

--- a/.agents/scripts/new-task-helper.sh
+++ b/.agents/scripts/new-task-helper.sh
@@ -468,8 +468,35 @@ _process_one_batch_title() {
 	local task_id="${alloc_out%%|*}"
 	local task_ref="${alloc_out#*|}"
 
-	_create_stub_brief "$task_id" "$title" "$task_ref" "$repo_path" ||
-		log_warn "Brief creation failed for $task_id — continuing"
+	# (t2417) If the linked issue body is worker-ready, write a minimal stub
+	# linking to the issue instead of the full template brief. In headless/
+	# batch mode, default to skip (stub). The readiness helper scores the
+	# body against known heading sets (4-of-7 threshold).
+	local _brief_written=false
+	local _readiness_helper="$SCRIPT_DIR/brief-readiness-helper.sh"
+	if [[ -x "$_readiness_helper" && -n "$task_ref" && "$task_ref" != "offline" ]]; then
+		local _issue_num="${task_ref#GH#}"
+		local _slug=""
+		_slug=$(git -C "$repo_path" remote get-url origin 2>/dev/null \
+			| sed -E 's#.*github\.com[:/]##; s/\.git$//' || true)
+		if [[ -n "$_slug" && -n "$_issue_num" ]]; then
+			local _body=""
+			_body=$(gh issue view "$_issue_num" --repo "$_slug" --json body --jq '.body' 2>/dev/null) || true
+			if [[ -n "$_body" ]]; then
+				local _rout=""
+				_rout=$("$_readiness_helper" check --body "$_body" 2>/dev/null) || true
+				if printf '%s\n' "$_rout" | grep -q 'WORKER_READY=true'; then
+					log_info "$task_id: issue #${_issue_num} body is worker-ready — writing stub brief"
+					"$_readiness_helper" stub "$task_id" "$_issue_num" "$_slug" "$repo_path" 2>/dev/null || true
+					_brief_written=true
+				fi
+			fi
+		fi
+	fi
+	if [[ "$_brief_written" != "true" ]]; then
+		_create_stub_brief "$task_id" "$title" "$task_ref" "$repo_path" ||
+			log_warn "Brief creation failed for $task_id — continuing"
+	fi
 
 	_append_todo_entry "$task_id" "$title" "$task_ref" "$todo_file" ||
 		log_warn "TODO entry failed for $task_id — continuing"

--- a/.agents/scripts/task-brief-helper.sh
+++ b/.agents/scripts/task-brief-helper.sh
@@ -612,6 +612,36 @@ generate_brief() {
 	validate_task_id "$task_id" || return 1
 	mkdir -p "$project_root/todo/tasks"
 
+	# Step 0 (t2417): Check if a linked issue body is already worker-ready.
+	# If so, write a stub brief linking to the issue instead of duplicating
+	# its content. The readiness helper scores the body against known heading
+	# sets (4-of-7 threshold) — see brief-readiness-helper.sh for details.
+	local _readiness_helper="$SCRIPT_DIR/brief-readiness-helper.sh"
+	if [[ -x "$_readiness_helper" ]]; then
+		# Extract issue number from TODO.md ref:GH#NNN for this task
+		local _issue_ref=""
+		_issue_ref=$(grep -E "^\s*- \[.\] ${task_id} " "$project_root/TODO.md" 2>/dev/null \
+			| grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/ref:GH#//' || true)
+		if [[ -n "$_issue_ref" ]]; then
+			local _slug=""
+			_slug=$(git -C "$project_root" remote get-url origin 2>/dev/null \
+				| sed -E 's#.*github\.com[:/]##; s/\.git$//' || true)
+			if [[ -n "$_slug" ]]; then
+				local _body=""
+				_body=$(gh issue view "$_issue_ref" --repo "$_slug" --json body --jq '.body' 2>/dev/null) || true
+				if [[ -n "$_body" ]]; then
+					local _readiness_output=""
+					_readiness_output=$("$_readiness_helper" check --body "$_body" 2>/dev/null) || true
+					if printf '%s\n' "$_readiness_output" | grep -q 'WORKER_READY=true'; then
+						log_info "$task_id: linked issue #${_issue_ref} body is worker-ready — writing stub brief"
+						"$_readiness_helper" stub "$task_id" "$_issue_ref" "$_slug" "$project_root" 2>/dev/null || true
+						return 0
+					fi
+				fi
+			fi
+		fi
+	fi
+
 	# Step 1: Resolve commit
 	local commit="" commit_date="" commit_author="" commit_msg="" commit_epoch=""
 	while IFS='=' read -r key value; do

--- a/.agents/scripts/tests/test-brief-readiness.sh
+++ b/.agents/scripts/tests/test-brief-readiness.sh
@@ -1,0 +1,406 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-brief-readiness.sh — regression tests for brief-readiness-helper.sh (t2417)
+#
+# Covers:
+#   1. Worker-ready body detection (score >= threshold → exit 0)
+#   2. Minimal body detection (score < threshold → exit 1)
+#   3. Edge case: score-3 body (just under threshold → exit 1)
+#   4. Stub brief creation (writes valid markdown)
+#   5. Similarity scoring (high overlap → high %, low overlap → low %)
+#   6. Threshold override via BRIEF_READINESS_THRESHOLD env var
+
+set -u
+set +e
+
+# ---------------------------------------------------------------------------
+# Test harness
+# ---------------------------------------------------------------------------
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf '  %sPASS%s %s\n' "$TEST_GREEN" "$TEST_NC" "$1"
+	return 0
+}
+
+fail() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '  %sFAIL%s %s\n' "$TEST_RED" "$TEST_NC" "$1"
+	if [[ -n "${2:-}" ]]; then
+		printf '        %s\n' "$2"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Locate the helper
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="$SCRIPT_DIR/../brief-readiness-helper.sh"
+
+if [[ ! -x "$HELPER" ]]; then
+	echo "FATAL: brief-readiness-helper.sh not found or not executable at $HELPER" >&2
+	exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Test fixtures — body texts with varying heading counts
+# ---------------------------------------------------------------------------
+
+# 5 headings → worker-ready (above default threshold of 4)
+BODY_WORKER_READY="# t1234: Example task
+
+## Session Origin
+
+Created in interactive session.
+
+## What
+
+Implement the foo feature.
+
+## Why
+
+Because the bar needs it.
+
+## How
+
+### Files to modify
+
+- EDIT: src/foo.sh:10-20
+
+### Implementation Steps
+
+1. Do the thing.
+
+## Acceptance
+
+- [ ] Tests pass
+- [ ] Lint clean
+- [ ] Feature works
+"
+
+# 2 headings → NOT worker-ready
+BODY_MINIMAL="# Bug report
+
+## Description
+
+Something is broken.
+
+Steps to reproduce:
+1. Open app
+2. Click button
+3. See error
+"
+
+# 3 headings → just under threshold (NOT worker-ready at default 4)
+BODY_SCORE_3="# t5678: Another task
+
+## What
+
+Fix the broken widget.
+
+## Why
+
+Users are complaining.
+
+## Acceptance
+
+- [ ] Widget works
+- [ ] No regressions
+"
+
+# 4 headings → exactly at threshold (worker-ready)
+BODY_SCORE_4="# t9999: Threshold test
+
+## Task
+
+Do the thing.
+
+## Why
+
+Reasons.
+
+## How
+
+Steps here.
+
+## Acceptance
+
+- [ ] Done
+"
+
+# 7 headings → all of them (worker-ready)
+BODY_ALL_HEADINGS="# t0001: Full body
+
+## Task
+
+Full specification.
+
+## Why
+
+All the reasons.
+
+## How
+
+Detailed steps.
+
+## Acceptance
+
+All criteria met.
+
+## What
+
+Also this heading.
+
+## Session Origin
+
+Created somewhere.
+
+## Files to modify
+
+- EDIT: file.sh
+"
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+echo "=== test-brief-readiness.sh ==="
+echo ""
+
+# --- Test 1: Worker-ready body (5 headings, threshold 4) → exit 0 ---
+output=$("$HELPER" check --body "$BODY_WORKER_READY" 2>/dev/null)
+rc=$?
+if [[ $rc -eq 0 ]]; then
+	pass "T1: worker-ready body → exit 0"
+else
+	fail "T1: worker-ready body → exit 0" "got exit $rc, output: $output"
+fi
+
+# Verify output contains WORKER_READY=true
+if printf '%s\n' "$output" | grep -q 'WORKER_READY=true'; then
+	pass "T1b: output contains WORKER_READY=true"
+else
+	fail "T1b: output contains WORKER_READY=true" "output: $output"
+fi
+
+# --- Test 2: Minimal body (2 headings) → exit 1 ---
+output=$("$HELPER" check --body "$BODY_MINIMAL" 2>/dev/null)
+rc=$?
+if [[ $rc -eq 1 ]]; then
+	pass "T2: minimal body → exit 1"
+else
+	fail "T2: minimal body → exit 1" "got exit $rc, output: $output"
+fi
+
+if printf '%s\n' "$output" | grep -q 'WORKER_READY=false'; then
+	pass "T2b: output contains WORKER_READY=false"
+else
+	fail "T2b: output contains WORKER_READY=false" "output: $output"
+fi
+
+# --- Test 3: Score-3 body (just under threshold) → exit 1 ---
+output=$("$HELPER" check --body "$BODY_SCORE_3" 2>/dev/null)
+rc=$?
+if [[ $rc -eq 1 ]]; then
+	pass "T3: score-3 body → exit 1 (under threshold)"
+else
+	fail "T3: score-3 body → exit 1 (under threshold)" "got exit $rc, output: $output"
+fi
+
+# Verify score is 3
+score=$(printf '%s\n' "$output" | grep '^SCORE=' | sed 's/SCORE=//')
+if [[ "$score" -eq 3 ]]; then
+	pass "T3b: score is 3"
+else
+	fail "T3b: score is 3" "got score=$score"
+fi
+
+# --- Test 4: Score-4 body (exactly at threshold) → exit 0 ---
+output=$("$HELPER" check --body "$BODY_SCORE_4" 2>/dev/null)
+rc=$?
+if [[ $rc -eq 0 ]]; then
+	pass "T4: score-4 body → exit 0 (at threshold)"
+else
+	fail "T4: score-4 body → exit 0 (at threshold)" "got exit $rc, output: $output"
+fi
+
+# --- Test 5: All headings (score 7) → exit 0 ---
+output=$("$HELPER" check --body "$BODY_ALL_HEADINGS" 2>/dev/null)
+rc=$?
+score=$(printf '%s\n' "$output" | grep '^SCORE=' | sed 's/SCORE=//')
+if [[ $rc -eq 0 && "$score" -eq 7 ]]; then
+	pass "T5: all-headings body → exit 0 with score 7"
+else
+	fail "T5: all-headings body → exit 0 with score 7" "got exit=$rc score=$score"
+fi
+
+# --- Test 6: Threshold override via env var ---
+# BODY_WORKER_READY scores 6 (5 explicit ## headings + ### Files to modify
+# which contains "## Files to modify" as a substring). threshold=7 → fail.
+output=$(BRIEF_READINESS_THRESHOLD=7 "$HELPER" check --body "$BODY_WORKER_READY" 2>/dev/null)
+rc=$?
+if [[ $rc -eq 1 ]]; then
+	pass "T6: threshold=7, score-6 body → exit 1"
+else
+	fail "T6: threshold=7, score-6 body → exit 1" "got exit $rc"
+fi
+
+# BODY_SCORE_3 scores 3 (## What, ## Why, ## Acceptance). threshold=3 → pass.
+output=$(BRIEF_READINESS_THRESHOLD=3 "$HELPER" check --body "$BODY_SCORE_3" 2>/dev/null)
+rc=$?
+if [[ $rc -eq 0 ]]; then
+	pass "T6b: threshold=3, score-3 body → exit 0"
+else
+	fail "T6b: threshold=3, score-3 body → exit 0" "got exit $rc"
+fi
+
+# --- Test 7: Stub brief creation ---
+TMP_REPO=$(mktemp -d)
+mkdir -p "$TMP_REPO/todo/tasks"
+
+# Stub gh command for offline testing
+GH_STUB_DIR=$(mktemp -d)
+cat > "$GH_STUB_DIR/gh" <<'GHSTUB'
+#!/usr/bin/env bash
+# Stub gh for test-brief-readiness.sh
+if [[ "${1:-}" == "issue" && "${2:-}" == "view" ]]; then
+	if [[ "${*}" == *"--jq '.title'"* ]] || [[ "${*}" == *"--jq .title"* ]]; then
+		echo "Test Issue Title"
+	elif [[ "${*}" == *"--jq '.body'"* ]] || [[ "${*}" == *"--jq .body"* ]]; then
+		echo "Test body"
+	fi
+fi
+exit 0
+GHSTUB
+chmod +x "$GH_STUB_DIR/gh"
+
+# Run stub creation with stubbed gh
+PATH="$GH_STUB_DIR:$PATH" "$HELPER" stub "t9999" "12345" "owner/repo" "$TMP_REPO" 2>/dev/null
+stub_rc=$?
+brief_file="$TMP_REPO/todo/tasks/t9999-brief.md"
+
+if [[ $stub_rc -eq 0 && -f "$brief_file" ]]; then
+	pass "T7: stub brief created successfully"
+else
+	fail "T7: stub brief created successfully" "exit=$stub_rc, exists=$(test -f "$brief_file" && echo yes || echo no)"
+fi
+
+# Check stub content contains canonical link
+if grep -q "canonical brief" "$brief_file" 2>/dev/null; then
+	pass "T7b: stub contains canonical brief reference"
+else
+	fail "T7b: stub contains canonical brief reference" "content: $(cat "$brief_file" 2>/dev/null || echo 'empty')"
+fi
+
+# Check stub does not duplicate full template (should be ≤20 lines)
+line_count=$(wc -l < "$brief_file" 2>/dev/null || echo 999)
+if [[ $line_count -le 25 ]]; then
+	pass "T7c: stub brief is ≤25 lines ($line_count)"
+else
+	fail "T7c: stub brief is ≤25 lines" "got $line_count lines"
+fi
+
+# --- Test 8: Stub skips if brief already exists ---
+echo "# Existing brief" > "$brief_file"
+PATH="$GH_STUB_DIR:$PATH" "$HELPER" stub "t9999" "12345" "owner/repo" "$TMP_REPO" 2>/dev/null
+existing_content=$(cat "$brief_file")
+if [[ "$existing_content" == "# Existing brief" ]]; then
+	pass "T8: stub skips when brief already exists"
+else
+	fail "T8: stub skips when brief already exists" "content was overwritten"
+fi
+
+# --- Test 9: Similarity scoring ---
+# Create a brief that mostly duplicates the worker-ready body
+sim_brief_file=$(mktemp)
+printf '%s\n' "$BODY_WORKER_READY" > "$sim_brief_file"
+
+output=$("$HELPER" similarity "$sim_brief_file" --body "$BODY_WORKER_READY" 2>/dev/null)
+sim_rc=$?
+similarity=$(printf '%s\n' "$output" | grep '^SIMILARITY=' | sed 's/SIMILARITY=//')
+
+# Note: similarity is computed on lines >= 10 chars after normalisation,
+# so short heading lines are excluded — identical content may not reach 100%.
+if [[ $sim_rc -eq 0 && "$similarity" -ge 50 ]]; then
+	pass "T9: identical content → similarity ≥50% ($similarity%)"
+else
+	fail "T9: identical content → similarity ≥50%" "got sim=$similarity%, exit=$sim_rc"
+fi
+
+# Low similarity: brief with different content
+echo "Completely different content that shares nothing with the issue body whatsoever" > "$sim_brief_file"
+output=$("$HELPER" similarity "$sim_brief_file" --body "$BODY_WORKER_READY" 2>/dev/null)
+similarity=$(printf '%s\n' "$output" | grep '^SIMILARITY=' | sed 's/SIMILARITY=//')
+
+if [[ "$similarity" -le 20 ]]; then
+	pass "T9b: different content → similarity ≤20% ($similarity%)"
+else
+	fail "T9b: different content → similarity ≤20%" "got $similarity%"
+fi
+
+# --- Test 10: Usage error (no args to check) ---
+"$HELPER" check 2>/dev/null
+rc=$?
+if [[ $rc -eq 2 ]]; then
+	pass "T10: check with no args → exit 2 (usage error)"
+else
+	fail "T10: check with no args → exit 2 (usage error)" "got exit $rc"
+fi
+
+# --- Test 11: Case-insensitive heading matching ---
+BODY_LOWERCASE="# task
+
+## task
+
+Info here.
+
+## why
+
+Reasons.
+
+## how
+
+Steps.
+
+## acceptance
+
+Criteria.
+"
+output=$("$HELPER" check --body "$BODY_LOWERCASE" 2>/dev/null)
+rc=$?
+if [[ $rc -eq 0 ]]; then
+	pass "T11: case-insensitive heading matching → exit 0"
+else
+	fail "T11: case-insensitive heading matching → exit 0" "got exit $rc, output: $output"
+fi
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+rm -rf "$TMP_REPO" "$GH_STUB_DIR" "$sim_brief_file" 2>/dev/null || true
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "Results: $TESTS_RUN tests, $TESTS_FAILED failed"
+echo ""
+
+if [[ $TESTS_FAILED -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/.agents/workflows/define.md
+++ b/.agents/workflows/define.md
@@ -72,6 +72,14 @@ Before generating: "Do I know enough to predict what a code review would reject?
 
 ### Step 5: Generate Brief
 
+**Worker-ready issue body detection (t2417):** If the task has a linked issue (from `$ARGUMENTS` or a prior `/new-task` allocation), check `brief-readiness-helper.sh check <issue-number> <slug>` before generating. If the issue body is already worker-ready (4+ known headings), offer:
+
+1. Skip brief — point to issue as canonical brief (recommended)
+2. Stub brief — minimal file linking to issue + session-specific context
+3. Full brief anyway
+
+In headless mode, default to option 1 (skip). See `scripts/brief-readiness-helper.sh` for the scoring logic.
+
 Read `templates/brief-template.md` and format using `workflows/brief.md` for the classified tier. Populate from interview answers:
 
 | Interview Data | Brief Section |
@@ -107,10 +115,11 @@ When `--headless` or `$ARGUMENTS` contains ` -- ` (supervisor dispatch), skip in
 
 1. Auto-classify task type from description
 2. Apply default assumptions for that type
-3. Generate brief with `Created by: ai-supervisor` in Origin
-4. Write to `todo/tasks/{task_id}-brief.md`
-5. Add `#worker` tag to TODO.md entry
-6. No confirmation — save immediately
+3. **(t2417) Check worker-readiness** — if linked issue body scores 4+ on the heading heuristic, write a stub brief linking to the issue instead of generating a full brief. Default: skip.
+4. Generate brief with `Created by: ai-supervisor` in Origin (only if step 3 did not skip)
+5. Write to `todo/tasks/{task_id}-brief.md`
+6. Add `#worker` tag to TODO.md entry
+7. No confirmation — save immediately
 
 ## Related
 

--- a/.agents/workflows/new-task.md
+++ b/.agents/workflows/new-task.md
@@ -68,6 +68,13 @@ fi
 
 ### Step 3: Create Task Brief (MANDATORY)
 
+**Worker-ready issue body detection (t2417):** Before writing a full brief, check if the linked issue already has a worker-ready body (contains 4+ of: `## Task`, `## Why`, `## How`, `## Acceptance`, `## What`, `## Session Origin`, `## Files to modify`). Use `brief-readiness-helper.sh check <issue-number> <slug>` to detect. If the body is worker-ready:
+
+- **Headless mode:** skip the full brief and write a stub linking to the issue (`brief-readiness-helper.sh stub <task-id> <issue> <slug>`). Default behaviour.
+- **Interactive mode:** offer the user a choice: (1) skip brief, point to issue (recommended), (2) stub brief linking to issue, (3) full brief anyway.
+
+This prevents redundant brief files when the issue body already carries all the context a worker needs.
+
 Every task MUST have a brief at `todo/tasks/{task_id}-brief.md`. Use `templates/brief-template.md`, formatted per `workflows/brief.md`. Required sections:
 
 | Section | Content |

--- a/.github/workflows/planning-pr-redundancy-check.yml
+++ b/.github/workflows/planning-pr-redundancy-check.yml
@@ -1,0 +1,155 @@
+name: Planning PR Redundancy Check
+
+# t2417: Advisory check that detects when a PR contains a brief file
+# (todo/tasks/*-brief.md) whose content is >=80% similar to the linked
+# issue body. Posts an advisory comment — NOT a blocker.
+#
+# Purpose: catch planning PRs where the brief duplicates the issue body,
+# suggesting the brief should be a stub instead (or skipped entirely).
+#
+# Trigger: pull_request on opened/synchronize, only when brief files change.
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths:
+      - 'todo/tasks/*-brief.md'
+
+jobs:
+  check-redundancy:
+    name: Brief Redundancy Advisory
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      pull-requests: write
+      contents: read
+      issues: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+
+      - name: Detect redundant briefs
+        id: detect
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Find brief files added or modified in this PR
+          BRIEF_FILES=$(git diff --name-only HEAD~1..HEAD -- 'todo/tasks/*-brief.md' 2>/dev/null || true)
+          if [[ -z "$BRIEF_FILES" ]]; then
+            echo "No brief files changed in this PR"
+            echo "redundant=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          REDUNDANT_BRIEFS=""
+
+          while IFS= read -r brief_path; do
+            [[ -z "$brief_path" ]] && continue
+            [[ ! -f "$brief_path" ]] && continue
+
+            # Extract task ID from filename (e.g., t1234-brief.md -> t1234)
+            task_id=$(basename "$brief_path" | sed 's/-brief\.md$//')
+
+            # Find linked issue number from the brief or PR body
+            issue_num=""
+
+            # Try extracting from the brief file itself (stub briefs have issue URLs)
+            issue_num=$(grep -oE 'issues/([0-9]+)' "$brief_path" | head -1 | sed 's|issues/||' || true)
+
+            # Try from PR body (Resolves #NNN, For #NNN, Ref #NNN)
+            if [[ -z "$issue_num" ]]; then
+              issue_num=$(printf '%s' "$PR_BODY" | grep -oiE '(close[ds]?|fix(es|ed)?|resolve[ds]?|for|ref)\s+#([0-9]+)' | head -1 | grep -oE '[0-9]+' || true)
+            fi
+
+            if [[ -z "$issue_num" ]]; then
+              echo "No linked issue found for $brief_path — skipping"
+              continue
+            fi
+
+            # Fetch issue body
+            issue_body=$(gh issue view "$issue_num" --repo "$REPO" --json body --jq '.body' 2>/dev/null || true)
+            if [[ -z "$issue_body" ]]; then
+              echo "Could not fetch issue #$issue_num body — skipping"
+              continue
+            fi
+
+            # Normalise both texts and compute line-level similarity
+            brief_content=$(cat "$brief_path")
+            norm_issue=$(printf '%s\n' "$issue_body" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//; s/[[:space:]]+/ /g' | tr '[:upper:]' '[:lower:]' | grep -v '^$' || true)
+            norm_brief=$(printf '%s\n' "$brief_content" | sed -E 's/^[[:space:]]+//; s/[[:space:]]+$//; s/[[:space:]]+/ /g' | tr '[:upper:]' '[:lower:]' | grep -v '^$' || true)
+
+            total_lines=0
+            matching_lines=0
+            while IFS= read -r line; do
+              # Skip very short lines
+              [[ ${#line} -lt 10 ]] && continue
+              total_lines=$((total_lines + 1))
+              if printf '%s\n' "$norm_issue" | grep -qF "$line"; then
+                matching_lines=$((matching_lines + 1))
+              fi
+            done <<< "$norm_brief"
+
+            similarity=0
+            if [[ $total_lines -gt 0 ]]; then
+              similarity=$(( (matching_lines * 100) / total_lines ))
+            fi
+
+            echo "$brief_path: ${similarity}% similar to issue #${issue_num} (${matching_lines}/${total_lines} lines)"
+
+            if [[ $similarity -ge 80 ]]; then
+              REDUNDANT_BRIEFS="${REDUNDANT_BRIEFS}\n- \`${brief_path}\` is **${similarity}%** similar to issue #${issue_num}"
+            fi
+          done <<< "$BRIEF_FILES"
+
+          if [[ -n "$REDUNDANT_BRIEFS" ]]; then
+            echo "redundant=true" >> "$GITHUB_OUTPUT"
+            # Write to file for the comment step (avoids env var escaping)
+            printf '%b' "$REDUNDANT_BRIEFS" > /tmp/redundant-briefs.txt
+          else
+            echo "redundant=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Post advisory comment
+        if: steps.detect.outputs.redundant == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          # Check for existing advisory comment to avoid duplicates
+          EXISTING=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --jq '[.[] | select(.body | test("planning-pr-redundancy-check"))] | length' 2>/dev/null || echo "0")
+
+          if [[ "$EXISTING" != "0" ]]; then
+            echo "Advisory comment already exists — skipping"
+            exit 0
+          fi
+
+          REDUNDANT_BRIEFS=$(cat /tmp/redundant-briefs.txt)
+
+          COMMENT_BODY="<!-- planning-pr-redundancy-check -->
+          ## Brief Redundancy Advisory (t2417)
+
+          The following brief file(s) in this PR have **≥80% content overlap** with their linked issue body:
+
+          ${REDUNDANT_BRIEFS}
+
+          When the issue body already contains all required sections (Task/What, Why, How, Acceptance, Files to modify), a separate brief file duplicates content and creates collision surface.
+
+          **Consider:**
+          1. Replace with a stub brief linking to the issue (\`brief-readiness-helper.sh stub <task-id> <issue> <slug>\`)
+          2. Keep the brief only if it contains session-specific context not in the issue body
+
+          *This is an advisory — not a blocker.*"
+
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$COMMENT_BODY"


### PR DESCRIPTION
## Summary

- Adds `brief-readiness-helper.sh` — a new helper that scores issue bodies against 7 known heading signals (## Task, ## Why, ## How, ## Acceptance, ## What, ## Session Origin, ## Files to modify) with a 4-of-7 threshold to detect worker-readiness
- Integrates the detector into `task-brief-helper.sh` (generate_brief) and `new-task-helper.sh` (batch flow) to automatically skip redundant brief file creation when the linked issue body is already worker-ready
- Adds a stub brief template that links to the canonical issue instead of duplicating its content
- Creates `planning-pr-redundancy-check.yml` workflow — posts an advisory PR comment when a brief file has ≥80% content overlap with its linked issue body
- Updates `/define` and `/new-task` command docs with the heuristic
- Adds heuristic note to AGENTS.md "Briefs, Tiers, and Dispatchability" section
- 18 regression tests covering: worker-ready body detection, minimal body rejection, threshold boundary, env var override, stub creation, similarity scoring, case-insensitive matching

## Testing

```bash
bash .agents/scripts/tests/test-brief-readiness.sh  # 18/18 pass
shellcheck .agents/scripts/brief-readiness-helper.sh  # clean
shellcheck .agents/scripts/tests/test-brief-readiness.sh  # clean
npx markdownlint-cli2 .agents/AGENTS.md .agents/scripts/commands/define.md .agents/scripts/commands/new-task.md  # 0 errors
```

## MERGE_SUMMARY

### Changes
- NEW: `.agents/scripts/brief-readiness-helper.sh` — worker-readiness detector + stub brief writer + similarity scorer
- EDIT: `.agents/scripts/task-brief-helper.sh` — added Step 0 readiness check in `generate_brief()`
- EDIT: `.agents/scripts/new-task-helper.sh` — added readiness check in `_process_one_batch_title()`
- EDIT: `.agents/workflows/define.md` — documented heuristic in Step 5 and Headless Mode
- EDIT: `.agents/workflows/new-task.md` — documented heuristic in Step 3
- NEW: `.github/workflows/planning-pr-redundancy-check.yml` — advisory workflow for redundant briefs
- NEW: `.agents/scripts/tests/test-brief-readiness.sh` — 18 regression tests
- EDIT: `.agents/AGENTS.md` — added heuristic note in Briefs section

### Motivation
Prevents redundant brief files when issue bodies already carry all worker-ready context. Eliminates collision surface between planning PRs and implementation PRs (root cause documented in GH#20015 session origin).

Resolves #20015