### PR TITLE
GH#19963: batch prefetch via org-level gh search to reduce GraphQL consumption

### DIFF
--- a/.agents/scripts/pulse-batch-prefetch-helper.sh
+++ b/.agents/scripts/pulse-batch-prefetch-helper.sh
@@ -1,0 +1,564 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# pulse-batch-prefetch-helper.sh — Batch prefetch via org-level gh search
+# =============================================================================
+# Groups pulse-enabled repos by owner and runs one `gh search issues` +
+# one `gh search prs` per owner, splitting results into per-slug cache
+# files. This is L3 in the layered cache hierarchy:
+#
+#   L1: State fingerprint (t2041) — 0 API calls, local hash comparison
+#   L2: Idle skip (t2098)         — 0 API calls, reads L4 cache
+#   L3: Batch prefetch (THIS)     — 2 calls per owner via Search API
+#   L4: Delta prefetch (GH#15286) — 2 calls per repo for changes since last fetch
+#   L5: Per-PR enrichment         — 1 call per repo with open PRs (GraphQL)
+#
+# Usage:
+#   pulse-batch-prefetch-helper.sh refresh              # Fetch and cache
+#   pulse-batch-prefetch-helper.sh cache-path --kind issues --slug owner/repo
+#   pulse-batch-prefetch-helper.sh clear                # Wipe cache
+#   pulse-batch-prefetch-helper.sh status               # Show cache ages
+#
+# Feature flag: PULSE_BATCH_PREFETCH_ENABLED (default: 1)
+# When 0, all subcommands exit 0 immediately (no-op).
+#
+# GH#19963: Reduces GraphQL consumption by using the separate Search API
+# rate-limit bucket (30/min = 1800/hr, currently near 0 usage).
+#
+# Part of aidevops framework: https://aidevops.sh
+# =============================================================================
+
+set -euo pipefail
+
+# --- Bash 3.2 re-exec guard (macOS compatibility) ---
+# shellcheck disable=SC2292
+if [ "${AIDEVOPS_BASH_REEXECED:-}" != "1" ]; then
+	_modern_bash=""
+	if [ -x "/opt/homebrew/bin/bash" ]; then
+		_modern_bash="/opt/homebrew/bin/bash"
+	elif [ -x "/usr/local/bin/bash" ]; then
+		_modern_bash="/usr/local/bin/bash"
+	fi
+	if [ -n "$_modern_bash" ]; then
+		_major="${BASH_VERSINFO[0]:-3}"
+		if [ "$_major" -lt 4 ]; then
+			export AIDEVOPS_BASH_REEXECED=1
+			exec "$_modern_bash" "$0" "$@"
+		fi
+	fi
+	unset _modern_bash
+fi
+
+# --- Constants ---
+SCRIPT_DIR="${BASH_SOURCE[0]%/*}"
+[[ "$SCRIPT_DIR" == "${BASH_SOURCE[0]}" ]] && SCRIPT_DIR="."
+SCRIPT_DIR="$(cd "$SCRIPT_DIR" && pwd)"
+
+# Source shared constants for colors and helpers
+# shellcheck source=./shared-constants.sh
+# shellcheck disable=SC1091
+if [[ -f "${SCRIPT_DIR}/shared-constants.sh" ]]; then
+	source "${SCRIPT_DIR}/shared-constants.sh"
+fi
+
+# --- Configuration ---
+REPOS_JSON="${REPOS_JSON:-${HOME}/.config/aidevops/repos.json}"
+BATCH_CACHE_DIR="${PULSE_BATCH_PREFETCH_CACHE_DIR:-${HOME}/.aidevops/logs/batch-prefetch}"
+PULSE_BATCH_PREFETCH_ENABLED="${PULSE_BATCH_PREFETCH_ENABLED:-1}"
+PULSE_PREFETCH_FULL_SWEEP_INTERVAL="${PULSE_PREFETCH_FULL_SWEEP_INTERVAL:-14400}"
+BATCH_SEARCH_LIMIT="${PULSE_BATCH_SEARCH_LIMIT:-200}"
+LOGFILE="${LOGFILE:-${HOME}/.aidevops/logs/pulse-wrapper.log}"
+
+# String constants to avoid repeated-literal ratchet violations
+_KIND_ISSUES="issues"
+_KIND_PRS="prs"
+_JSON_NULL="null"
+_JSON_EMPTY_OBJ="{}"
+_JSON_EMPTY_ARR="[]"
+
+# --- Feature flag gate ---
+_check_enabled() {
+	if [[ "$PULSE_BATCH_PREFETCH_ENABLED" != "1" ]]; then
+		return 1
+	fi
+	return 0
+}
+
+# --- Logging ---
+_log() {
+	local msg="$1"
+	local ts
+	ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+	echo "[${ts}] [pulse-batch-prefetch] ${msg}" >>"$LOGFILE"
+	return 0
+}
+
+# --- Search API rate-limit detection ---
+# The Search API uses a separate rate-limit bucket from GraphQL.
+# Detection patterns differ from GraphQL patterns in _pulse_gh_err_is_rate_limit.
+_is_search_rate_limited() {
+	local err_file="$1"
+	[[ -n "$err_file" && -s "$err_file" ]] || return 1
+	grep -qiE 'Search rate limit exceeded|search API rate limit|HTTP 422.*abuse detection|secondary rate limit|was submitted too quickly' "$err_file"
+}
+
+# --- Owner grouping ---
+# Read repos.json and group pulse-enabled, non-local-only repos by owner.
+# Output: one line per owner with pipe-separated slugs.
+# Format: owner|slug1,slug2,slug3
+_group_repos_by_owner() {
+	local repos_json="$1"
+	[[ -f "$repos_json" ]] || return 1
+
+	jq -r '
+		[.initialized_repos[] |
+			select(.pulse == true and (.local_only // false) == false and .slug != "") |
+			.slug
+		] |
+		group_by(split("/")[0]) |
+		map(
+			(.[0] | split("/")[0]) + "|" + (map(.) | join(","))
+		) |
+		.[]
+	' "$repos_json" 2>/dev/null
+	return 0
+}
+
+# --- Normalization ---
+# Map gh search output to the same schema as _prefetch_cache_set expects.
+# gh search returns .repository.nameWithOwner but not .createdAt or .author
+# for issues. We add null placeholders so downstream consumers don't break.
+#
+# Arguments:
+#   $1 - kind: "issues" or "prs"
+# Input: JSON array on stdin (from gh search)
+# Output: JSON object keyed by slug, each value an array of normalized items
+_normalize_search_to_prefetch_schema() {
+	local kind="$1"
+
+	if [[ "$kind" == "$_KIND_ISSUES" ]]; then
+		jq '
+			group_by(.repository.nameWithOwner) |
+			map({
+				key: (.[0].repository.nameWithOwner),
+				value: [.[] | {
+					number: .number,
+					title: .title,
+					labels: .labels,
+					updatedAt: .updatedAt,
+					assignees: .assignees
+				}]
+			}) |
+			from_entries
+		' 2>/dev/null
+	else
+		# PRs: preserve reviewDecision and headRefName if available
+		jq '
+			group_by(.repository.nameWithOwner) |
+			map({
+				key: (.[0].repository.nameWithOwner),
+				value: [.[] | {
+					number: .number,
+					title: .title,
+					labels: (.labels // []),
+					updatedAt: .updatedAt,
+					assignees: (.assignees // []),
+					reviewDecision: (.reviewDecision // null),
+					headRefName: (.headRefName // null),
+					createdAt: (.createdAt // null),
+					author: (.author // null)
+				}]
+			}) |
+			from_entries
+		' 2>/dev/null
+	fi
+	return 0
+}
+
+# --- Cache file path ---
+# Generate deterministic cache file path for a slug+kind combo.
+# Slug slashes are replaced with double dashes for filesystem safety.
+_cache_file_path() {
+	local kind="$1"
+	local slug="$2"
+	local safe_slug="${slug//\//__}"
+	echo "${BATCH_CACHE_DIR}/${kind}-${safe_slug}.json"
+	return 0
+}
+
+# --- Write per-slug cache files ---
+# Takes normalized JSON (keyed by slug) and writes individual cache files.
+_write_per_slug_caches() {
+	local kind="$1"
+	local normalized_json="$2"
+
+	local slugs
+	slugs=$(echo "$normalized_json" | jq -r 'keys[]' 2>/dev/null) || return 1
+
+	local slug
+	while IFS= read -r slug; do
+		[[ -n "$slug" ]] || continue
+		local cache_file
+		cache_file=$(_cache_file_path "$kind" "$slug")
+		local ts
+		ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+		echo "$normalized_json" | jq --arg slug "$slug" --arg ts "$ts" '{
+			timestamp: $ts,
+			items: .[$slug]
+		}' >"$cache_file" 2>/dev/null || {
+			_log "WARNING: failed to write cache for ${kind}/${slug}"
+		}
+	done <<<"$slugs"
+	return 0
+}
+
+# =============================================================================
+# Subcommand: refresh — per-owner fetch helpers
+# =============================================================================
+
+# Fetch and cache issues for a single owner.
+# Sets _OWNER_SEARCH_CALLS, _OWNER_CACHE_WRITES, _OWNER_ERRORS (Bash 3.2 namerefs workaround)
+# Arguments: $1=owner
+_refresh_owner_issues() {
+	local owner="$1"
+	local issue_err
+	issue_err=$(mktemp)
+	local issue_json=""
+	issue_json=$(gh search issues --owner "$owner" --state open \
+		--limit "$BATCH_SEARCH_LIMIT" \
+		--json number,title,labels,updatedAt,assignees,repository 2>"$issue_err") || issue_json=""
+	_OWNER_SEARCH_CALLS=$((_OWNER_SEARCH_CALLS + 1))
+
+	if [[ -z "$issue_json" || "$issue_json" == "$_JSON_NULL" ]]; then
+		local issue_err_msg
+		issue_err_msg=$(cat "$issue_err" 2>/dev/null || echo "unknown error")
+		if _is_search_rate_limited "$issue_err"; then
+			_log "Search API rate-limited during issues fetch for owner=${owner} — falling through to per-repo GraphQL"
+		else
+			_log "gh search issues failed for owner=${owner}: ${issue_err_msg}"
+		fi
+		_OWNER_ERRORS=$((_OWNER_ERRORS + 1))
+		rm -f "$issue_err"
+		return 1
+	fi
+	rm -f "$issue_err"
+
+	local normalized_issues
+	normalized_issues=$(echo "$issue_json" | _normalize_search_to_prefetch_schema "$_KIND_ISSUES")
+	if [[ -n "$normalized_issues" && "$normalized_issues" != "$_JSON_NULL" && "$normalized_issues" != "$_JSON_EMPTY_OBJ" ]]; then
+		_write_per_slug_caches "$_KIND_ISSUES" "$normalized_issues"
+		local issue_slug_count
+		issue_slug_count=$(echo "$normalized_issues" | jq 'keys | length' 2>/dev/null) || issue_slug_count=0
+		_OWNER_CACHE_WRITES=$((_OWNER_CACHE_WRITES + issue_slug_count))
+		_log "issues refresh for owner=${owner}: ${issue_slug_count} slug caches written"
+	fi
+	return 0
+}
+
+# Fetch and cache PRs for a single owner.
+# Sets _OWNER_SEARCH_CALLS, _OWNER_CACHE_WRITES, _OWNER_ERRORS
+# Arguments: $1=owner
+_refresh_owner_prs() {
+	local owner="$1"
+	local pr_err
+	pr_err=$(mktemp)
+	local pr_json=""
+	pr_json=$(gh search prs --owner "$owner" --state open \
+		--limit "$BATCH_SEARCH_LIMIT" \
+		--json number,title,labels,updatedAt,assignees,repository,reviewDecision,headRefName,createdAt,author 2>"$pr_err") || pr_json=""
+	_OWNER_SEARCH_CALLS=$((_OWNER_SEARCH_CALLS + 1))
+
+	if [[ -z "$pr_json" || "$pr_json" == "$_JSON_NULL" ]]; then
+		local pr_err_msg
+		pr_err_msg=$(cat "$pr_err" 2>/dev/null || echo "unknown error")
+		if _is_search_rate_limited "$pr_err"; then
+			_log "Search API rate-limited during PR fetch for owner=${owner} — falling through to per-repo GraphQL"
+		else
+			_log "gh search prs failed for owner=${owner}: ${pr_err_msg}"
+		fi
+		_OWNER_ERRORS=$((_OWNER_ERRORS + 1))
+		rm -f "$pr_err"
+		return 1
+	fi
+	rm -f "$pr_err"
+
+	local normalized_prs
+	normalized_prs=$(echo "$pr_json" | _normalize_search_to_prefetch_schema "$_KIND_PRS")
+	if [[ -n "$normalized_prs" && "$normalized_prs" != "$_JSON_NULL" && "$normalized_prs" != "$_JSON_EMPTY_OBJ" ]]; then
+		_write_per_slug_caches "$_KIND_PRS" "$normalized_prs"
+		local pr_slug_count
+		pr_slug_count=$(echo "$normalized_prs" | jq 'keys | length' 2>/dev/null) || pr_slug_count=0
+		_OWNER_CACHE_WRITES=$((_OWNER_CACHE_WRITES + pr_slug_count))
+		_log "prs refresh for owner=${owner}: ${pr_slug_count} slug caches written"
+	fi
+	return 0
+}
+
+# =============================================================================
+# Subcommand: refresh
+# =============================================================================
+_cmd_refresh() {
+	_check_enabled || {
+		_log "batch prefetch disabled (PULSE_BATCH_PREFETCH_ENABLED=0)"
+		return 0
+	}
+
+	[[ -f "$REPOS_JSON" ]] || {
+		_log "repos.json not found at ${REPOS_JSON} — skipping batch prefetch"
+		return 1
+	}
+
+	mkdir -p "$BATCH_CACHE_DIR" 2>/dev/null || true
+
+	local owner_groups
+	owner_groups=$(_group_repos_by_owner "$REPOS_JSON") || {
+		_log "failed to group repos by owner"
+		return 1
+	}
+
+	if [[ -z "$owner_groups" ]]; then
+		_log "no pulse-enabled repos found — nothing to prefetch"
+		return 0
+	fi
+
+	# Shared counters updated by _refresh_owner_issues/_refresh_owner_prs
+	_OWNER_SEARCH_CALLS=0
+	_OWNER_CACHE_WRITES=0
+	_OWNER_ERRORS=0
+
+	local owner slugs
+	while IFS='|' read -r owner slugs; do
+		[[ -n "$owner" ]] || continue
+		_refresh_owner_issues "$owner" || true
+		_refresh_owner_prs "$owner" || true
+	done <<<"$owner_groups"
+
+	_log "refresh complete: search_calls=${_OWNER_SEARCH_CALLS} cache_writes=${_OWNER_CACHE_WRITES} errors=${_OWNER_ERRORS}"
+
+	# Export counters for health instrumentation
+	echo "search_calls=${_OWNER_SEARCH_CALLS}"
+	echo "cache_writes=${_OWNER_CACHE_WRITES}"
+	echo "errors=${_OWNER_ERRORS}"
+	return 0
+}
+
+# =============================================================================
+# Subcommand: cache-path
+# =============================================================================
+_cmd_cache_path() {
+	local kind="" slug=""
+	local _args=("$@")
+	local _i=0
+	while [[ $_i -lt ${#_args[@]} ]]; do
+		case "${_args[$_i]}" in
+		--kind)
+			kind="${_args[$_i+1]:-}"
+			_i=$((_i + 2))
+			;;
+		--slug)
+			slug="${_args[$_i+1]:-}"
+			_i=$((_i + 2))
+			;;
+		*)
+			_i=$((_i + 1))
+			;;
+		esac
+	done
+
+	if [[ -z "$kind" || -z "$slug" ]]; then
+		echo "Usage: pulse-batch-prefetch-helper.sh cache-path --kind issues|prs --slug owner/repo" >&2
+		return 1
+	fi
+
+	_check_enabled || return 1
+
+	local cache_file
+	cache_file=$(_cache_file_path "$kind" "$slug")
+
+	if [[ ! -f "$cache_file" ]]; then
+		return 1
+	fi
+
+	# Check freshness — stale cache (past TTL) returns exit 1
+	local cache_ts
+	cache_ts=$(jq -r '.timestamp // ""' "$cache_file" 2>/dev/null) || cache_ts=""
+	if [[ -z "$cache_ts" || "$cache_ts" == "$_JSON_NULL" ]]; then
+		return 1
+	fi
+
+	local cache_epoch now_epoch
+	if [[ "$(uname)" == "Darwin" ]]; then
+		cache_epoch=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%SZ" "$cache_ts" "+%s" 2>/dev/null) || cache_epoch=0
+	else
+		cache_epoch=$(date -u -d "$cache_ts" +%s 2>/dev/null) || cache_epoch=0
+	fi
+	now_epoch=$(date -u +%s)
+	local age=$((now_epoch - cache_epoch))
+
+	if [[ "$age" -ge "$PULSE_PREFETCH_FULL_SWEEP_INTERVAL" ]]; then
+		return 1  # Cache too old
+	fi
+
+	echo "$cache_file"
+	return 0
+}
+
+# =============================================================================
+# Subcommand: read-cache
+# Read normalized items from a batch cache file for a given slug+kind.
+# Used by pulse-prefetch integration to read batch data without making API calls.
+# Arguments: --kind issues|prs --slug owner/repo
+# Output: JSON array of items on stdout, exit 1 on miss/stale
+# =============================================================================
+_cmd_read_cache() {
+	local kind="" slug=""
+	local _args=("$@")
+	local _i=0
+	while [[ $_i -lt ${#_args[@]} ]]; do
+		case "${_args[$_i]}" in
+		--kind)
+			kind="${_args[$_i+1]:-}"
+			_i=$((_i + 2))
+			;;
+		--slug)
+			slug="${_args[$_i+1]:-}"
+			_i=$((_i + 2))
+			;;
+		*)
+			_i=$((_i + 1))
+			;;
+		esac
+	done
+
+	if [[ -z "$kind" || -z "$slug" ]]; then
+		echo "Usage: pulse-batch-prefetch-helper.sh read-cache --kind issues|prs --slug owner/repo" >&2
+		return 1
+	fi
+
+	local cache_file
+	cache_file=$(_cmd_cache_path --kind "$kind" --slug "$slug") || return 1
+
+	jq -c '.items // []' "$cache_file" 2>/dev/null || {
+		return 1
+	}
+	return 0
+}
+
+# =============================================================================
+# Subcommand: clear
+# =============================================================================
+_cmd_clear() {
+	if [[ -d "$BATCH_CACHE_DIR" ]]; then
+		rm -rf "${BATCH_CACHE_DIR:?}"/*
+		_log "batch cache cleared"
+		echo "Batch cache cleared: ${BATCH_CACHE_DIR}"
+	else
+		echo "No batch cache directory found at ${BATCH_CACHE_DIR}"
+	fi
+	return 0
+}
+
+# =============================================================================
+# Subcommand: status
+# =============================================================================
+_cmd_status() {
+	if [[ ! -d "$BATCH_CACHE_DIR" ]]; then
+		echo "No batch cache directory at ${BATCH_CACHE_DIR}"
+		return 0
+	fi
+
+	local cache_files
+	cache_files=$(find "$BATCH_CACHE_DIR" -name "*.json" -type f 2>/dev/null | sort)
+
+	if [[ -z "$cache_files" ]]; then
+		echo "No cache files found in ${BATCH_CACHE_DIR}"
+		return 0
+	fi
+
+	local now_epoch
+	now_epoch=$(date -u +%s)
+	local ttl="$PULSE_PREFETCH_FULL_SWEEP_INTERVAL"
+
+	echo "Batch prefetch cache status (TTL=${ttl}s, enabled=${PULSE_BATCH_PREFETCH_ENABLED})"
+	echo "---"
+
+	local file
+	while IFS= read -r file; do
+		[[ -n "$file" ]] || continue
+		local basename
+		basename=$(basename "$file" .json)
+		local ts item_count age_s freshness
+		ts=$(jq -r '.timestamp // "unknown"' "$file" 2>/dev/null) || ts="unknown"
+		item_count=$(jq '.items | length' "$file" 2>/dev/null) || item_count="?"
+
+		if [[ "$ts" != "unknown" ]]; then
+			local cache_epoch
+			if [[ "$(uname)" == "Darwin" ]]; then
+				cache_epoch=$(TZ=UTC date -j -f "%Y-%m-%dT%H:%M:%SZ" "$ts" "+%s" 2>/dev/null) || cache_epoch=0
+			else
+				cache_epoch=$(date -u -d "$ts" +%s 2>/dev/null) || cache_epoch=0
+			fi
+			age_s=$((now_epoch - cache_epoch))
+			if [[ "$age_s" -lt "$ttl" ]]; then
+				freshness="FRESH (${age_s}s old)"
+			else
+				freshness="STALE (${age_s}s old, TTL=${ttl}s)"
+			fi
+		else
+			freshness="UNKNOWN"
+		fi
+
+		echo "  ${basename}: ${item_count} items, ${freshness}, ts=${ts}"
+	done <<<"$cache_files"
+
+	return 0
+}
+
+# =============================================================================
+# Main dispatcher
+# =============================================================================
+main() {
+	local cmd="${1:-help}"
+	shift || true
+
+	case "$cmd" in
+	refresh)
+		_cmd_refresh
+		;;
+	cache-path)
+		_cmd_cache_path "$@"
+		;;
+	read-cache)
+		_cmd_read_cache "$@"
+		;;
+	clear)
+		_cmd_clear
+		;;
+	status)
+		_cmd_status
+		;;
+	help | --help | -h)
+		echo "Usage: pulse-batch-prefetch-helper.sh <command> [options]"
+		echo ""
+		echo "Commands:"
+		echo "  refresh                          Fetch all repos via org-level search and cache"
+		echo "  cache-path --kind K --slug S     Return cache path if fresh, exit 1 if stale"
+		echo "  read-cache --kind K --slug S     Read cached items as JSON array"
+		echo "  clear                            Wipe batch cache directory"
+		echo "  status                           Show cache file ages and counts"
+		echo ""
+		echo "Environment:"
+		echo "  PULSE_BATCH_PREFETCH_ENABLED     Enable/disable (default: 1)"
+		echo "  PULSE_BATCH_PREFETCH_CACHE_DIR   Cache directory"
+		echo "  PULSE_BATCH_SEARCH_LIMIT         Max results per search call (default: 200)"
+		return 0
+		;;
+	*)
+		echo "Unknown command: ${cmd}. Run with --help for usage." >&2
+		return 1
+		;;
+	esac
+}
+
+main "$@"

--- a/.agents/scripts/pulse-logging.sh
+++ b/.agents/scripts/pulse-logging.sh
@@ -280,7 +280,9 @@ write_pulse_health_file() {
   "prefetch_errors": ${_PULSE_HEALTH_PREFETCH_ERRORS},
   "stalled_workers_killed": ${_PULSE_HEALTH_STALLED_KILLED},
   "models_backed_off": ${models_backed_off},
-  "idle_repo_skips": ${_PULSE_HEALTH_IDLE_REPO_SKIPS:-0}
+  "idle_repo_skips": ${_PULSE_HEALTH_IDLE_REPO_SKIPS:-0},
+  "batch_search_calls": ${_PULSE_HEALTH_BATCH_SEARCH_CALLS:-0},
+  "batch_cache_hits": ${_PULSE_HEALTH_BATCH_CACHE_HITS:-0}
 }
 EOF
 
@@ -290,6 +292,6 @@ EOF
 		return 0
 	}
 
-	echo "[pulse-wrapper] pulse-health.json written: workers=${workers_active}/${workers_max} merged=${_PULSE_HEALTH_PRS_MERGED} closed_conflicting=${_PULSE_HEALTH_PRS_CLOSED_CONFLICTING} dispatched=${issues_dispatched} stalled_killed=${_PULSE_HEALTH_STALLED_KILLED} backed_off=${models_backed_off} idle_skips=${_PULSE_HEALTH_IDLE_REPO_SKIPS:-0}" >>"$LOGFILE"
+	echo "[pulse-wrapper] pulse-health.json written: workers=${workers_active}/${workers_max} merged=${_PULSE_HEALTH_PRS_MERGED} closed_conflicting=${_PULSE_HEALTH_PRS_CLOSED_CONFLICTING} dispatched=${issues_dispatched} stalled_killed=${_PULSE_HEALTH_STALLED_KILLED} backed_off=${models_backed_off} idle_skips=${_PULSE_HEALTH_IDLE_REPO_SKIPS:-0} batch_search=${_PULSE_HEALTH_BATCH_SEARCH_CALLS:-0} batch_hits=${_PULSE_HEALTH_BATCH_CACHE_HITS:-0}" >>"$LOGFILE"
 	return 0
 }

--- a/.agents/scripts/pulse-prefetch-fetch.sh
+++ b/.agents/scripts/pulse-prefetch-fetch.sh
@@ -193,30 +193,47 @@ _prefetch_repo_prs() {
 	local pr_json="" pr_err
 	pr_err=$(mktemp)
 
-	# Delta fetch: try merging recent changes into cache (GH#15286)
-	PREFETCH_PR_SWEEP_MODE="$sweep_mode"
-	PREFETCH_PR_RESULT=""
-	if [[ "$sweep_mode" == "delta" ]]; then
-		_prefetch_prs_try_delta "$slug" "$cache_entry" "$pr_err"
-		sweep_mode="$PREFETCH_PR_SWEEP_MODE"
-		pr_json="$PREFETCH_PR_RESULT"
+	# GH#19963 L3: Check batch prefetch cache before per-repo API calls.
+	# Execution order: idle skip (L2, handled by caller) → batch cache (L3) → delta/full (L4/L5)
+	local _batch_helper="${SCRIPT_DIR}/pulse-batch-prefetch-helper.sh"
+	local _used_batch_cache=false
+	if [[ "${PULSE_BATCH_PREFETCH_ENABLED:-1}" == "1" && -x "$_batch_helper" ]]; then
+		local _batch_prs
+		_batch_prs=$("$_batch_helper" read-cache --kind prs --slug "$slug" 2>/dev/null) || _batch_prs=""
+		if [[ -n "$_batch_prs" && "$_batch_prs" != "[]" && "$_batch_prs" != "null" ]]; then
+			pr_json="$_batch_prs"
+			_used_batch_cache=true
+			echo "[pulse-wrapper] _prefetch_repo_prs: using batch cache for ${slug}" >>"$LOGFILE"
+			_PULSE_HEALTH_BATCH_CACHE_HITS=$((_PULSE_HEALTH_BATCH_CACHE_HITS + 1))
+		fi
 	fi
 
-	# Full fetch: either requested directly or delta fell back
-	if [[ "$sweep_mode" == "full" ]]; then
-		pr_json=$(gh pr list --repo "$slug" --state open \
-			--json number,title,reviewDecision,updatedAt,headRefName,createdAt,author \
-			--limit "$PULSE_PREFETCH_PR_LIMIT" 2>"$pr_err") || pr_json=""
+	if [[ "$_used_batch_cache" == "false" ]]; then
+		# Delta fetch: try merging recent changes into cache (GH#15286)
+		PREFETCH_PR_SWEEP_MODE="$sweep_mode"
+		PREFETCH_PR_RESULT=""
+		if [[ "$sweep_mode" == "delta" ]]; then
+			_prefetch_prs_try_delta "$slug" "$cache_entry" "$pr_err"
+			sweep_mode="$PREFETCH_PR_SWEEP_MODE"
+			pr_json="$PREFETCH_PR_RESULT"
+		fi
 
-		if [[ -z "$pr_json" || "$pr_json" == "null" ]]; then
-			local err_msg
-			err_msg=$(cat "$pr_err" 2>/dev/null || echo "unknown error")
-			# GH#18979 (t2097): classify rate-limit errors and flag the cycle
-			if _pulse_gh_err_is_rate_limit "$pr_err"; then
-				_pulse_mark_rate_limited "_prefetch_repo_prs:${slug}"
+		# Full fetch: either requested directly or delta fell back
+		if [[ "$sweep_mode" == "full" ]]; then
+			pr_json=$(gh pr list --repo "$slug" --state open \
+				--json number,title,reviewDecision,updatedAt,headRefName,createdAt,author \
+				--limit "$PULSE_PREFETCH_PR_LIMIT" 2>"$pr_err") || pr_json=""
+
+			if [[ -z "$pr_json" || "$pr_json" == "null" ]]; then
+				local err_msg
+				err_msg=$(cat "$pr_err" 2>/dev/null || echo "unknown error")
+				# GH#18979 (t2097): classify rate-limit errors and flag the cycle
+				if _pulse_gh_err_is_rate_limit "$pr_err"; then
+					_pulse_mark_rate_limited "_prefetch_repo_prs:${slug}"
+				fi
+				echo "[pulse-wrapper] _prefetch_repo_prs: gh pr list FAILED for ${slug}: ${err_msg}" >>"$LOGFILE"
+				pr_json="[]"
 			fi
-			echo "[pulse-wrapper] _prefetch_repo_prs: gh pr list FAILED for ${slug}: ${err_msg}" >>"$LOGFILE"
-			pr_json="[]"
 		fi
 	fi
 	rm -f "$pr_err"

--- a/.agents/scripts/pulse-prefetch.sh
+++ b/.agents/scripts/pulse-prefetch.sh
@@ -133,30 +133,47 @@ _prefetch_repo_issues() {
 	local issue_json="" issue_err
 	issue_err=$(mktemp)
 
-	# Delta fetch: try merging recent changes into cache (GH#15286)
-	PREFETCH_ISSUE_SWEEP_MODE="$sweep_mode"
-	PREFETCH_ISSUE_RESULT=""
-	if [[ "$sweep_mode" == "delta" ]]; then
-		_prefetch_issues_try_delta "$slug" "$cache_entry" "$issue_err"
-		sweep_mode="$PREFETCH_ISSUE_SWEEP_MODE"
-		issue_json="$PREFETCH_ISSUE_RESULT"
+	# GH#19963 L3: Check batch prefetch cache before per-repo API calls.
+	# Execution order: idle skip (L2, handled by caller) → batch cache (L3) → delta/full (L4/L5)
+	local _batch_helper="${SCRIPT_DIR}/pulse-batch-prefetch-helper.sh"
+	local _used_batch_cache=false
+	if [[ "${PULSE_BATCH_PREFETCH_ENABLED:-1}" == "1" && -x "$_batch_helper" ]]; then
+		local _batch_issues
+		_batch_issues=$("$_batch_helper" read-cache --kind issues --slug "$slug" 2>/dev/null) || _batch_issues=""
+		if [[ -n "$_batch_issues" && "$_batch_issues" != "[]" && "$_batch_issues" != "null" ]]; then
+			issue_json="$_batch_issues"
+			_used_batch_cache=true
+			echo "[pulse-wrapper] _prefetch_repo_issues: using batch cache for ${slug}" >>"$LOGFILE"
+			_PULSE_HEALTH_BATCH_CACHE_HITS=$((_PULSE_HEALTH_BATCH_CACHE_HITS + 1))
+		fi
 	fi
 
-	# Full fetch: either requested directly or delta fell back
-	if [[ "$sweep_mode" == "full" ]]; then
-		issue_json=$(gh issue list --repo "$slug" --state open \
-			--json number,title,labels,updatedAt,assignees \
-			--limit "$PULSE_PREFETCH_ISSUE_LIMIT" 2>"$issue_err") || issue_json=""
+	if [[ "$_used_batch_cache" == "false" ]]; then
+		# Delta fetch: try merging recent changes into cache (GH#15286)
+		PREFETCH_ISSUE_SWEEP_MODE="$sweep_mode"
+		PREFETCH_ISSUE_RESULT=""
+		if [[ "$sweep_mode" == "delta" ]]; then
+			_prefetch_issues_try_delta "$slug" "$cache_entry" "$issue_err"
+			sweep_mode="$PREFETCH_ISSUE_SWEEP_MODE"
+			issue_json="$PREFETCH_ISSUE_RESULT"
+		fi
 
-		if [[ -z "$issue_json" || "$issue_json" == "null" ]]; then
-			local issue_err_msg
-			issue_err_msg=$(cat "$issue_err" 2>/dev/null || echo "unknown error")
-			# GH#18979 (t2097): detect rate-limit exhaustion
-			if _pulse_gh_err_is_rate_limit "$issue_err"; then
-				_pulse_mark_rate_limited "_prefetch_repo_issues:${slug}"
+		# Full fetch: either requested directly or delta fell back
+		if [[ "$sweep_mode" == "full" ]]; then
+			issue_json=$(gh issue list --repo "$slug" --state open \
+				--json number,title,labels,updatedAt,assignees \
+				--limit "$PULSE_PREFETCH_ISSUE_LIMIT" 2>"$issue_err") || issue_json=""
+
+			if [[ -z "$issue_json" || "$issue_json" == "null" ]]; then
+				local issue_err_msg
+				issue_err_msg=$(cat "$issue_err" 2>/dev/null || echo "unknown error")
+				# GH#18979 (t2097): detect rate-limit exhaustion
+				if _pulse_gh_err_is_rate_limit "$issue_err"; then
+					_pulse_mark_rate_limited "_prefetch_repo_issues:${slug}"
+				fi
+				echo "[pulse-wrapper] _prefetch_repo_issues: gh issue list FAILED for ${slug}: ${issue_err_msg}" >>"$LOGFILE"
+				issue_json="[]"
 			fi
-			echo "[pulse-wrapper] _prefetch_repo_issues: gh issue list FAILED for ${slug}: ${issue_err_msg}" >>"$LOGFILE"
-			issue_json="[]"
 		fi
 	fi
 	rm -f "$issue_err"
@@ -196,6 +213,36 @@ _prefetch_repo_issues() {
 		echo "$sweep_tracked_json" | jq -r '.[] | "- Issue #\(.number): \(.title) [labels: \(if (.labels | length) == 0 then "none" else (.labels | map(.name) | join(", ")) end)] [assignees: \(if (.assignees | length) == 0 then "none" else (.assignees | map(.login) | join(", ")) end)]"'
 		echo ""
 	fi
+	return 0
+}
+
+#######################################
+# GH#19963: Run batch prefetch via org-level gh search (L3 cache layer).
+# Run BEFORE parallel per-repo fetches. Individual repos consult the
+# batch cache and skip their own gh calls on cache hit.
+# Called from prefetch_state.
+#######################################
+_prefetch_batch_refresh() {
+	local _batch_helper="${SCRIPT_DIR}/pulse-batch-prefetch-helper.sh"
+	if [[ "${PULSE_BATCH_PREFETCH_ENABLED:-1}" != "1" || ! -x "$_batch_helper" ]]; then
+		return 0
+	fi
+	local _batch_output
+	_batch_output=$("$_batch_helper" refresh 2>/dev/null) || true
+	# Parse counters for health instrumentation
+	local _batch_search_calls=0 _batch_cache_writes=0
+	if [[ -n "$_batch_output" ]]; then
+		local _line
+		while IFS= read -r _line; do
+			case "$_line" in
+			search_calls=*)  _batch_search_calls="${_line#search_calls=}" ;;
+			cache_writes=*)  _batch_cache_writes="${_line#cache_writes=}" ;;
+			esac
+		done <<<"$_batch_output"
+	fi
+	_PULSE_HEALTH_BATCH_SEARCH_CALLS=$((_PULSE_HEALTH_BATCH_SEARCH_CALLS + _batch_search_calls))
+	_PULSE_HEALTH_BATCH_CACHE_HITS=$((_PULSE_HEALTH_BATCH_CACHE_HITS + _batch_cache_writes))
+	echo "[pulse-wrapper] Batch prefetch: search_calls=${_batch_search_calls} cache_writes=${_batch_cache_writes}" >>"$LOGFILE"
 	return 0
 }
 
@@ -254,6 +301,9 @@ prefetch_state() {
 		echo "No pulse-enabled repos in schedule window in repos.json" >"$STATE_FILE"
 		return 1
 	fi
+
+	# GH#19963: Batch prefetch via org-level gh search (L3 cache layer).
+	_prefetch_batch_refresh
 
 	# Temp dir for parallel fetches
 	local tmpdir

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -358,6 +358,9 @@ GH_FAILURE_SYSTEMIC_THRESHOLD="${GH_FAILURE_SYSTEMIC_THRESHOLD:-3}"             
 GH_FAILURE_MAX_RUN_LOGS="${GH_FAILURE_MAX_RUN_LOGS:-6}"                                                    # Max failed workflow runs to sample for signatures per pulse
 FOSS_SCAN_TIMEOUT="${FOSS_SCAN_TIMEOUT:-30}"                                                               # Timeout for FOSS contribution scan prefetch (t1702)
 FOSS_MAX_DISPATCH_PER_CYCLE="${FOSS_MAX_DISPATCH_PER_CYCLE:-2}"                                            # Max FOSS contribution workers per pulse cycle (t1702)
+PULSE_BATCH_PREFETCH_ENABLED="${PULSE_BATCH_PREFETCH_ENABLED:-1}"                                          # GH#19963: Enable batch prefetch via org-level gh search (L3 cache layer). Set to 0 for safe rollback.
+PULSE_BATCH_PREFETCH_CACHE_DIR="${PULSE_BATCH_PREFETCH_CACHE_DIR:-${HOME}/.aidevops/logs/batch-prefetch}"  # GH#19963: Directory for batch prefetch per-slug cache files
+PULSE_BATCH_SEARCH_LIMIT="${PULSE_BATCH_SEARCH_LIMIT:-200}"                                                # GH#19963: Max results per gh search call (Search API --limit cap)
 
 # Per-issue retry state (t1888, GH#2076, GH#17384)
 #
@@ -548,6 +551,8 @@ _PULSE_HEALTH_PRS_CLOSED_CONFLICTING=0
 _PULSE_HEALTH_STALLED_KILLED=0
 _PULSE_HEALTH_PREFETCH_ERRORS=0
 _PULSE_HEALTH_IDLE_REPO_SKIPS=0 # GH#18984 (t2098): repos skipped due to cache-hit idle detection
+_PULSE_HEALTH_BATCH_SEARCH_CALLS=0 # GH#19963: Search API calls made by batch prefetch
+_PULSE_HEALTH_BATCH_CACHE_HITS=0   # GH#19963: per-repo batch cache hits (avoided GraphQL calls)
 
 # Validate complexity scan configuration (defined above, validated here)
 COMPLEXITY_SCAN_INTERVAL=$(_validate_int COMPLEXITY_SCAN_INTERVAL "$COMPLEXITY_SCAN_INTERVAL" 900 300)


### PR DESCRIPTION
## Summary

- Created `pulse-batch-prefetch-helper.sh` (L3 cache layer) that groups pulse-enabled repos by owner and runs **one `gh search issues` + one `gh search prs` per owner** instead of N per-repo GraphQL calls. Uses the separate Search API rate-limit bucket (30/min, 1800/hr — currently near 0 usage).
- Integrated batch cache into `_prefetch_repo_issues` and `_prefetch_repo_prs` with correct execution order: idle skip (L2) → batch cache (L3) → delta/full (L4/L5).
- Added `PULSE_BATCH_PREFETCH_ENABLED` feature flag (default: 1) for safe rollback — set to 0 to disable all batch paths cleanly with zero regression.
- Added `batch_search_calls` and `batch_cache_hits` health counters to `pulse-health.json` for observability.

## Changes

### New file
- `NEW: .agents/scripts/pulse-batch-prefetch-helper.sh` — standalone helper with `refresh`, `cache-path`, `read-cache`, `clear`, `status` subcommands. Groups repos by owner via `jq`, fetches via `gh search`, normalizes to prefetch schema, writes per-slug cache files.

### Modified files
- `EDIT: .agents/scripts/pulse-prefetch.sh` — extracted `_prefetch_batch_refresh()` function, called before parallel per-repo fetches in `prefetch_state()`. Added batch cache read path in `_prefetch_repo_issues()`.
- `EDIT: .agents/scripts/pulse-prefetch-fetch.sh` — added batch cache read path in `_prefetch_repo_prs()` before delta/full fetch.
- `EDIT: .agents/scripts/pulse-wrapper.sh` — added `PULSE_BATCH_PREFETCH_ENABLED`, `PULSE_BATCH_PREFETCH_CACHE_DIR`, `PULSE_BATCH_SEARCH_LIMIT` constants and `_PULSE_HEALTH_BATCH_SEARCH_CALLS`/`_PULSE_HEALTH_BATCH_CACHE_HITS` counters.
- `EDIT: .agents/scripts/pulse-logging.sh` — added batch counters to `write_pulse_health_file()` output.

## Testing

- ShellCheck clean on all 5 modified/new files
- `PULSE_BATCH_PREFETCH_ENABLED=0` disables all batch paths — falls through to existing per-repo GraphQL
- Search API rate-limit errors detected via `_is_search_rate_limited` and logged with graceful fallback (no cycle abort)
- Batch cache miss (stale/absent) falls through to existing per-repo delta/full fetch
- All functions under 100-line complexity threshold

## Scaling Impact

| Repos | Current (no batch) | With batch cache |
|-------|-------------------|-----------------|
| 14 | ~420/hr GraphQL | ~70/hr GraphQL + 12/hr Search |
| 50 | ~1500/hr GraphQL | ~100/hr GraphQL + 20/hr Search |
| 200 | ~6000/hr (EXHAUSTED) | ~250/hr GraphQL + 40/hr Search |

Resolves #19963