### PR TITLE
t2422: structured cross-runner dispatch coordination

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -199,7 +199,7 @@ Set fields based on the repo's purpose:
 
 Full rules: `reference/planning-detail.md`
 
-For multi-runner coordination (concurrent pulse runners across machines), see `reference/cross-runner-coordination.md`.
+For multi-runner coordination (concurrent pulse runners across machines), see `reference/cross-runner-coordination.md`. Key features (t2422): structured per-runner versioned overrides (`dispatch-override-resolve.sh`), deterministic tiebreaker for simultaneous claims, `CLAIM_DEFERRED` audit trail. Config: `~/.config/aidevops/dispatch-override.conf`.
 
 ## Git Workflow
 

--- a/.agents/configs/dispatch-override.conf.txt
+++ b/.agents/configs/dispatch-override.conf.txt
@@ -2,44 +2,58 @@
 #
 # Copy to ~/.config/aidevops/dispatch-override.conf and edit.
 #
-# This file is sourced by dispatch-claim-helper.sh to filter DISPATCH_CLAIM
-# comments from peer runners when the peer is known to be degraded — e.g.,
-# running stale code, fast-failing every dispatch, or version-skewed after a
-# hotfix — and their stale claim comments are poisoning cross-runner dispatch
-# for the full 1800s TTL.
+# This file is sourced by dispatch-claim-helper.sh and dispatch-override-resolve.sh
+# to filter DISPATCH_CLAIM comments from peer runners when the peer is known to
+# be degraded — e.g., running stale code, fast-failing every dispatch, or
+# version-skewed after a hotfix — and their stale claim comments are poisoning
+# cross-runner dispatch for the full 1800s TTL.
 #
-# Two composable filters:
+# ═══════════════════════════════════════════════════════════════════════════════
+# STRUCTURED PER-RUNNER OVERRIDES (t2422 — RECOMMENDED)
+# ═══════════════════════════════════════════════════════════════════════════════
 #
-#   1. Login-gated (t2400): DISPATCH_CLAIM_IGNORE_RUNNERS — strip claims from
-#      named GitHub logins. Requires manual removal when the peer recovers.
+# Format: DISPATCH_OVERRIDE_<LOGIN_UPPER>=<action>[:<version>]
 #
-#   2. Version-gated (t2401): DISPATCH_CLAIM_MIN_VERSION — strip claims whose
-#      framework version is below the configured semver floor. Self-sunsetting:
-#      once the peer upgrades to >= floor, their claims pass the filter
-#      automatically (no operator action needed). Pre-t2401 claims (with no
-#      version field) are treated as "unknown" and always below any floor.
+# LOGIN_UPPER is the runner's GitHub login uppercased with hyphens replaced by
+# underscores (e.g., alex-solovyev → ALEX_SOLOVYEV).
 #
-# For automated management based on worker success-rate comparison, see t2402
-# (supervisor-dashboard-driven auto-override).
+# Actions:
+#   honour              — always respect claims from this runner (default)
+#   ignore              — always ignore claims from this runner
+#   honour-only-above:V — ignore claims if runner version < V; once the peer
+#                         upgrades to >= V, coordination resumes automatically
+#   warn                — respect claims but emit a warning in the log
 #
-# Safety: filters are UNIDIRECTIONAL. If only your runner filters the peer,
-# your dispatch wins the claim race and the peer backs off normally (no
-# double-dispatch). If BOTH runners filter each other, double-dispatch is
-# possible — intended for temporary, unilateral use during peer-degraded
-# incidents, not mutual escalation.
+# Examples:
+# DISPATCH_OVERRIDE_ALEX_SOLOVYEV="honour-only-above:3.8.78"
+# DISPATCH_OVERRIDE_STALE_PEER="ignore"
+# DISPATCH_OVERRIDE_DEFAULT="honour"  # fallback for unlisted runners
 
-# Space-separated list of runner GitHub logins whose DISPATCH_CLAIM comments
-# should be ignored. Comma separators are also accepted.
+# Default action for runners without a specific override entry.
+DISPATCH_OVERRIDE_DEFAULT="honour"
+
+# ═══════════════════════════════════════════════════════════════════════════════
+# LEGACY FLAT FORMAT (t2400/t2401 — DEPRECATED, one-release grace period)
+# ═══════════════════════════════════════════════════════════════════════════════
+#
+# These settings still work but emit a deprecation warning. Migrate to the
+# structured format above. Run `dispatch-override-resolve.sh check-deprecated`
+# to see migration hints.
+
+# DEPRECATED: Space/comma-separated list of runner logins to ignore.
+# Migrate to: DISPATCH_OVERRIDE_<LOGIN_UPPER>="ignore"
 # Example: DISPATCH_CLAIM_IGNORE_RUNNERS="stale-peer1 stale-peer2"
 DISPATCH_CLAIM_IGNORE_RUNNERS=""
 
-# Semver floor for the version-gated filter (t2401). Claims with a version
-# strictly below this floor are stripped. Pre-t2401 claims have no version
-# field and are treated as "unknown" — always below any floor. Leave empty
-# to disable the version filter.
+# DEPRECATED: Semver floor. Claims below this version are stripped.
+# Migrate to: DISPATCH_OVERRIDE_<LOGIN_UPPER>="honour-only-above:<version>"
 # Example: DISPATCH_CLAIM_MIN_VERSION="3.9.0"
 DISPATCH_CLAIM_MIN_VERSION=""
 
-# Master switch for the overrides. Set to false to keep the config file in
-# place but temporarily respect all claims (useful during testing).
+# ═══════════════════════════════════════════════════════════════════════════════
+# COMMON SETTINGS
+# ═══════════════════════════════════════════════════════════════════════════════
+
+# Master switch. Set to false to temporarily respect all claims (useful during
+# testing). Applies to both structured and legacy formats.
 DISPATCH_OVERRIDE_ENABLED=true

--- a/.agents/reference/cross-runner-coordination.md
+++ b/.agents/reference/cross-runner-coordination.md
@@ -465,7 +465,109 @@ SCRIPT=~/.aidevops/agents/scripts/dispatch-dedup-helper.sh
 
 ---
 
-## 7. See Also
+## 7. Structured Dispatch Overrides (t2422)
+
+Prior to t2422, cross-runner claim filtering used two flat mechanisms:
+`DISPATCH_CLAIM_IGNORE_RUNNERS` (login list) and `DISPATCH_CLAIM_MIN_VERSION`
+(global version floor). These are now **deprecated** in favour of structured
+per-runner overrides that are version-aware and self-sunsetting.
+
+### 7.1 Config Format
+
+In `~/.config/aidevops/dispatch-override.conf`:
+
+```bash
+# Structured per-runner override (t2422):
+DISPATCH_OVERRIDE_ALEX_SOLOVYEV="honour-only-above:3.8.78"
+DISPATCH_OVERRIDE_STALE_PEER="ignore"
+DISPATCH_OVERRIDE_FLAKY_RUNNER="warn"
+DISPATCH_OVERRIDE_DEFAULT="honour"  # fallback for unlisted runners
+```
+
+**Actions:**
+
+| Action | Meaning |
+|---|---|
+| `honour` | Always respect claims from this runner (default) |
+| `ignore` | Always discard claims from this runner |
+| `honour-only-above:V` | Ignore claims with version < V; auto-sunsets when peer upgrades |
+| `warn` | Respect claims but emit a warning in the pulse log |
+
+The login is uppercased with hyphens→underscores for the env var name
+(e.g., `alex-solovyev` → `DISPATCH_OVERRIDE_ALEX_SOLOVYEV`).
+
+### 7.2 Resolution Order
+
+`dispatch-override-resolve.sh resolve <runner> <version>` resolves in order:
+
+1. Master switch (`DISPATCH_OVERRIDE_ENABLED=false` → `honour` for all)
+2. Structured per-runner (`DISPATCH_OVERRIDE_<LOGIN>`)
+3. Legacy flat list (`DISPATCH_CLAIM_IGNORE_RUNNERS`) — deprecated, emits warning
+4. Legacy version floor (`DISPATCH_CLAIM_MIN_VERSION`) — deprecated, emits warning
+5. Default action (`DISPATCH_OVERRIDE_DEFAULT`, defaults to `honour`)
+
+### 7.3 Migration from Flat Format
+
+Run `dispatch-override-resolve.sh check-deprecated` to see migration hints:
+
+```bash
+$ dispatch-override-resolve.sh check-deprecated
+[DEPRECATED] DISPATCH_CLAIM_IGNORE_RUNNERS="alex-solovyev"
+  Migrate to: DISPATCH_OVERRIDE_ALEX_SOLOVYEV="ignore"
+[DEPRECATED] DISPATCH_CLAIM_MIN_VERSION="3.8.78"
+  Migrate to per-runner entries: DISPATCH_OVERRIDE_<RUNNER>="honour-only-above:3.8.78"
+```
+
+The flat format continues to work during the one-release grace period but emits
+deprecation warnings on every resolution. After the grace period, the flat
+variables will be ignored entirely.
+
+---
+
+## 8. Simultaneous Claim Tiebreaker (t2422)
+
+When two runners post DISPATCH_CLAIM comments within
+`DISPATCH_CLAIM_TIEBREAKER_WINDOW` seconds (default 5s) of each other, the
+standard "oldest wins" rule can be ambiguous due to clock skew or same-second
+timestamps. The tiebreaker resolves this deterministically:
+
+1. **Compare `ts` (ISO 8601 string comparison)** — the claim with the
+   strictly earlier timestamp wins. Because the format is fixed-width
+   (`YYYY-MM-DDTHH:MM:SSZ`), lexicographic comparison is correct.
+
+2. **Tie on `ts` → compare `nonce` lexicographically** — the claim with
+   the lower nonce wins. Since nonces are random hex strings, this is
+   effectively a coin flip, but it's deterministic: both runners
+   independently compute the same result.
+
+3. **Loser posts `CLAIM_DEFERRED`** — an audit comment recording the
+   deferral decision:
+
+   ```
+   CLAIM_DEFERRED runner=alice nonce=abc123 ts=2026-04-20T00:00:05Z
+     deferring_to=bob winner_nonce=def456 winner_ts=2026-04-20T00:00:03Z
+   ```
+
+   This is visible in the issue timeline and survives for diagnosis.
+
+### Env Controls
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `DISPATCH_CLAIM_TIEBREAKER_WINDOW` | `5` | Max seconds between claims to trigger tiebreaker |
+| `DISPATCH_CLAIM_WINDOW` | `8` | Consensus window (sleep after posting, before checking) |
+
+### Diagnosis
+
+```bash
+# Find CLAIM_DEFERRED comments on an issue
+gh api repos/<slug>/issues/<num>/comments \
+  --jq '.[] | select(.body | test("CLAIM_DEFERRED")) | "\(.created_at): \(.body[0:120])"'
+```
+
+---
+
+## 9. See Also
 
 - `reference/worker-diagnostics.md` — single-runner worker lifecycle, DB
   isolation, watchdog, canary, recovery checklist
@@ -473,8 +575,12 @@ SCRIPT=~/.aidevops/agents/scripts/dispatch-dedup-helper.sh
 - `AGENTS.md` "Session origin labels" — `origin:interactive` implications
 - `AGENTS.md` "General dedup rule — combined signal (t1996)"
 - `AGENTS.md` "Parent / meta tasks (#parent tag, t1986)"
+- `scripts/dispatch-claim-helper.sh` — claim protocol with tiebreaker (t2422)
+- `scripts/dispatch-override-resolve.sh` — structured override resolver (t2422)
 - `scripts/dispatch-dedup-helper.sh` — implementation of Layers 3–7
 - `scripts/pulse-dispatch-core.sh` — `check_dispatch_dedup()` orchestration
+- `scripts/tests/test-cross-runner-coordination.sh` — t2422 regression suite
+- `scripts/tests/test-dispatch-override.sh` — t2399/t2400/t2401 override tests
 - `scripts/tests/test-parent-task-guard.sh` — regression coverage for t1986
 - `scripts/tests/test-dispatch-dedup-multi-operator.sh` — multi-operator dedup
   assertions
@@ -495,3 +601,4 @@ SCRIPT=~/.aidevops/agents/scripts/dispatch-dedup-helper.sh
 | GH#18371 (PR#18374, t1970) | Interactive-claim race via push path missing auto-assign |
 | GH#18399 (PR#18419, t1986) | Parent-task 4-hole fix + test harness |
 | GH#18458 | Fail-open dedup bug — jq null-handling allowed dispatch to parent-task issues |
+| GH#20028 (t2422) | Structured overrides + simultaneous claim tiebreaker |

--- a/.agents/scripts/dispatch-claim-helper.sh
+++ b/.agents/scripts/dispatch-claim-helper.sh
@@ -35,9 +35,18 @@
 
 set -euo pipefail
 
+# Resolve co-located override resolver (t2422)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+OVERRIDE_RESOLVER="${SCRIPT_DIR}/dispatch-override-resolve.sh"
+
 # Consensus window — how long to wait after posting a claim before checking
 # who won. Must be long enough for GitHub API propagation across runners.
 DISPATCH_CLAIM_WINDOW="${DISPATCH_CLAIM_WINDOW:-8}"
+
+# t2422: Tiebreaker window (seconds). When two claims land within this window,
+# a deterministic tiebreaker (ts strict-less → nonce lexicographic) is applied
+# instead of relying on GitHub's comment ordering alone.
+DISPATCH_CLAIM_TIEBREAKER_WINDOW="${DISPATCH_CLAIM_TIEBREAKER_WINDOW:-5}"
 
 # Maximum age (seconds) of a claim comment to consider it active.
 # Claims older than this are stale and ignored by the lock check.
@@ -87,6 +96,18 @@ fi
 
 # t2401: Framework VERSION file location. Override for tests.
 AIDEVOPS_VERSION_FILE="${AIDEVOPS_VERSION_FILE:-${HOME}/.aidevops/agents/VERSION}"
+
+#######################################
+# Build the GitHub API endpoint for issue comments.
+# Args: $1 = repo slug, $2 = issue number
+# Returns: endpoint path on stdout
+#######################################
+_comments_endpoint() {
+	local slug="$1"
+	local num="$2"
+	printf 'repos/%s/issues/%s/comments' "$slug" "$num"
+	return 0
+}
 
 #######################################
 # Generate a unique nonce for this claim attempt.
@@ -195,7 +216,7 @@ _post_claim() {
 	body="${CLAIM_MARKER} nonce=${nonce} runner=${runner} ts=${ts} max_age_s=${DISPATCH_CLAIM_MAX_AGE} version=${version}"
 
 	local comment_id
-	comment_id=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
+	comment_id=$(gh api "$(_comments_endpoint "$repo_slug" "$issue_number")" \
 		--method POST \
 		--field body="$body" \
 		--jq '.id' 2>/dev/null) || {
@@ -251,7 +272,7 @@ _fetch_claims() {
 	# A CLAIM_RELEASED comment posted after the most recent DISPATCH_CLAIM
 	# invalidates all prior claims (the worker died or completed).
 	local comments_json
-	comments_json=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
+	comments_json=$(gh api "$(_comments_endpoint "$repo_slug" "$issue_number")" \
 		--jq '[.[] | select(.body | test("'"${CLAIM_MARKER}"' nonce=|CLAIM_RELEASED")) | {id: .id, body: .body, created_at: .created_at}]' \
 		2>/dev/null) || {
 		echo "Error: failed to fetch comments for #${issue_number} in ${repo_slug}" >&2
@@ -400,15 +421,16 @@ _filter_below_version() {
 }
 
 #######################################
-# t2400/t2401: Apply runtime override filters to parsed claims.
+# t2400/t2401/t2422: Apply runtime override filters to parsed claims.
 #
-# Two composable filters:
+# t2422 upgrade: uses dispatch-override-resolve.sh for structured per-runner
+# resolution (honour | ignore | warn). Falls back to inline legacy logic when
+# the resolver is not available.
+#
+# Legacy composable filters (deprecated, still functional with warning):
 #   - Login filter (t2400): DISPATCH_CLAIM_IGNORE_RUNNERS strips named logins.
 #   - Version filter (t2401): DISPATCH_CLAIM_MIN_VERSION strips claims whose
 #     version field is below the semver floor (including legacy "unknown").
-#
-# Filters are no-op when override is disabled or both lists/floors are empty.
-# Emits a stderr log line when any claims are stripped, for operator audit.
 #
 # Args:
 #   $1 = parsed claims JSON array (from _fetch_claims parse step)
@@ -428,45 +450,158 @@ _apply_ignore_filter() {
 		return 0
 	fi
 
-	# Both filters empty → no-op fast path
-	if [[ -z "$DISPATCH_CLAIM_IGNORE_RUNNERS" && -z "$DISPATCH_CLAIM_MIN_VERSION" ]]; then
-		printf '%s' "$parsed"
-		return 0
-	fi
-
 	local pre_count
 	pre_count=$(printf '%s' "$parsed" | jq 'length' 2>/dev/null || echo 0)
 
-	# Login filter (t2400)
-	if [[ -n "$DISPATCH_CLAIM_IGNORE_RUNNERS" ]]; then
-		local ignored_json
-		# Normalise the ignore list (accept space OR comma separators) → JSON array
-		ignored_json=$(printf '%s' "$DISPATCH_CLAIM_IGNORE_RUNNERS" | tr ',' ' ' | tr -s ' ' '\n' | jq -Rsc 'split("\n") | map(select(length > 0))' 2>/dev/null) || ignored_json="[]"
-		if [[ "$ignored_json" != "[]" ]]; then
-			local filtered_login
-			filtered_login=$(printf '%s' "$parsed" | jq -c --argjson ignored "$ignored_json" '
-				map(select(.runner as $r | $ignored | index($r) | not))
-			' 2>/dev/null)
-			if [[ -n "$filtered_login" ]]; then
-				parsed="$filtered_login"
+	# t2422: Use structured resolver if available
+	if [[ -x "$OVERRIDE_RESOLVER" ]]; then
+		local claim_rows result_arr="["
+		claim_rows=$(printf '%s' "$parsed" | jq -r '.[] | [(.id | tostring), .runner, (.version // "unknown")] | @tsv' 2>/dev/null) || {
+			printf '%s' "$parsed"
+			return 0
+		}
+
+		local first=1
+		local claim_id runner version action
+		while IFS=$'\t' read -r claim_id runner version; do
+			[[ -z "$claim_id" ]] && continue
+			action=$("$OVERRIDE_RESOLVER" resolve "$runner" "$version" 2>/dev/null) || action="honour"
+
+			if [[ "$action" == "ignore" ]]; then
+				printf '[dispatch-claim-helper] Structured override: ignoring claim id=%s runner=%s version=%s on #%s in %s\n' \
+					"$claim_id" "$runner" "$version" "$issue_number" "$repo_slug" >&2
+				continue
+			fi
+
+			if [[ "$action" == "warn" ]]; then
+				printf '[dispatch-claim-helper] Structured override: warning for claim runner=%s version=%s on #%s in %s (honouring with warning)\n' \
+					"$runner" "$version" "$issue_number" "$repo_slug" >&2
+			fi
+
+			# honour or warn: keep the claim
+			local claim_json
+			claim_json=$(printf '%s' "$parsed" | jq -c --argjson cid "$claim_id" '.[] | select(.id == $cid)' 2>/dev/null) || continue
+			if [[ "$first" -eq 1 ]]; then
+				first=0
+			else
+				result_arr+=","
+			fi
+			result_arr+="$claim_json"
+		done <<<"$claim_rows"
+		result_arr+="]"
+		parsed="$result_arr"
+	else
+		# Fallback: legacy inline filter logic (t2400/t2401)
+		# Both filters empty → no-op fast path
+		if [[ -z "$DISPATCH_CLAIM_IGNORE_RUNNERS" && -z "$DISPATCH_CLAIM_MIN_VERSION" ]]; then
+			printf '%s' "$parsed"
+			return 0
+		fi
+
+		# Login filter (t2400, deprecated)
+		if [[ -n "$DISPATCH_CLAIM_IGNORE_RUNNERS" ]]; then
+			local ignored_json
+			ignored_json=$(printf '%s' "$DISPATCH_CLAIM_IGNORE_RUNNERS" | tr ',' ' ' | tr -s ' ' '\n' | jq -Rsc 'split("\n") | map(select(length > 0))' 2>/dev/null) || ignored_json="[]"
+			if [[ "$ignored_json" != "[]" ]]; then
+				local filtered_login
+				filtered_login=$(printf '%s' "$parsed" | jq -c --argjson ignored "$ignored_json" '
+					map(select(.runner as $r | $ignored | index($r) | not))
+				' 2>/dev/null)
+				if [[ -n "$filtered_login" ]]; then
+					parsed="$filtered_login"
+				fi
 			fi
 		fi
-	fi
 
-	# Version filter (t2401)
-	if [[ -n "$DISPATCH_CLAIM_MIN_VERSION" ]]; then
-		parsed=$(_filter_below_version "$parsed" "$DISPATCH_CLAIM_MIN_VERSION")
+		# Version filter (t2401, deprecated)
+		if [[ -n "$DISPATCH_CLAIM_MIN_VERSION" ]]; then
+			parsed=$(_filter_below_version "$parsed" "$DISPATCH_CLAIM_MIN_VERSION")
+		fi
 	fi
 
 	local post_count
 	post_count=$(printf '%s' "$parsed" | jq 'length' 2>/dev/null || echo 0)
 	if [[ "$pre_count" -gt "$post_count" ]]; then
-		printf '[dispatch-claim-helper] Filtered %d claim(s) on #%s in %s (ignore_runners=%s min_version=%s)\n' \
-			"$((pre_count - post_count))" "$issue_number" "$repo_slug" \
-			"${DISPATCH_CLAIM_IGNORE_RUNNERS:-none}" "${DISPATCH_CLAIM_MIN_VERSION:-none}" >&2
+		printf '[dispatch-claim-helper] Filtered %d claim(s) on #%s in %s\n' \
+			"$((pre_count - post_count))" "$issue_number" "$repo_slug" >&2
 	fi
 
 	printf '%s' "$parsed"
+	return 0
+}
+
+#######################################
+# t2422: Post a CLAIM_DEFERRED audit comment when the tiebreaker
+# determines this runner should back off.
+#
+# Args:
+#   $1 = issue number
+#   $2 = repo slug
+#   $3 = our runner login
+#   $4 = our nonce
+#   $5 = winner runner login
+#   $6 = winner nonce
+#   $7 = winner ts
+# Returns: exit 0 (best-effort, non-fatal)
+#######################################
+_post_claim_deferred() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local our_runner="$3"
+	local our_nonce="$4"
+	local winner_runner="$5"
+	local winner_nonce="$6"
+	local winner_ts="$7"
+
+	local body
+	body="CLAIM_DEFERRED runner=${our_runner} nonce=${our_nonce} ts=$(_now_utc) deferring_to=${winner_runner} winner_nonce=${winner_nonce} winner_ts=${winner_ts}"
+
+	gh api "$(_comments_endpoint "$repo_slug" "$issue_number")" \
+		--method POST \
+		--field body="$body" \
+		--jq '.id' 2>/dev/null || true
+	return 0
+}
+
+#######################################
+# t2422: Deterministic tiebreaker for simultaneous claims.
+# When two claims land within DISPATCH_CLAIM_TIEBREAKER_WINDOW seconds,
+# the winner is determined by:
+#   1. Strict-less ts (ISO 8601 string comparison — works because format is fixed)
+#   2. Tie on ts → lexicographic nonce comparison (lower wins)
+#
+# Args:
+#   $1 = our ts (ISO 8601)
+#   $2 = our nonce
+#   $3 = their ts (ISO 8601)
+#   $4 = their nonce
+# Returns:
+#   exit 0 = we win
+#   exit 1 = we lose
+#######################################
+_tiebreaker() {
+	local our_ts="$1"
+	local our_nonce="$2"
+	local their_ts="$3"
+	local their_nonce="$4"
+
+	# Compare ts — strict-less wins
+	if [[ "$our_ts" < "$their_ts" ]]; then
+		return 0
+	fi
+	if [[ "$our_ts" > "$their_ts" ]]; then
+		return 1
+	fi
+
+	# Tie on ts — compare nonce lexicographically (lower wins)
+	if [[ "$our_nonce" < "$their_nonce" ]]; then
+		return 0
+	fi
+	if [[ "$our_nonce" > "$their_nonce" ]]; then
+		return 1
+	fi
+
+	# Identical nonce (shouldn't happen) — we win by default
 	return 0
 }
 
@@ -478,7 +613,10 @@ _apply_ignore_filter() {
 #   2. Sleep consensus window
 #   3. Fetch all claim comments
 #   4. If this runner's claim is the oldest active claim → won
-#   5. If another runner's claim is older → lost, delete own claim
+#   4a. t2422: If claims are simultaneous (within tiebreaker window),
+#       apply deterministic tiebreaker (ts → nonce). Loser posts
+#       CLAIM_DEFERRED comment.
+#   5. If another runner's claim is older → lost
 #
 # Args:
 #   $1 = issue number
@@ -540,9 +678,10 @@ cmd_claim() {
 	fi
 
 	# Step 4: Check if our claim is the oldest
-	local oldest_nonce oldest_runner oldest_age_seconds
+	local oldest_nonce oldest_runner oldest_ts oldest_age_seconds
 	oldest_nonce=$(printf '%s' "$claims" | jq -r '.[0].nonce // ""' 2>/dev/null) || oldest_nonce=""
 	oldest_runner=$(printf '%s' "$claims" | jq -r '.[0].runner // "unknown"' 2>/dev/null) || oldest_runner="unknown"
+	oldest_ts=$(printf '%s' "$claims" | jq -r '.[0].ts // ""' 2>/dev/null) || oldest_ts=""
 	oldest_age_seconds=$(printf '%s' "$claims" | jq -r '.[0].age_seconds // 0' 2>/dev/null) || oldest_age_seconds=0
 
 	if [[ "$oldest_nonce" == "$nonce" ]]; then
@@ -565,7 +704,43 @@ cmd_claim() {
 		return 1
 	fi
 
-	# Step 5: We lost — another runner's claim is older
+	# t2422 Step 4a: Simultaneous claim tiebreaker.
+	# If our claim and the oldest are within DISPATCH_CLAIM_TIEBREAKER_WINDOW
+	# seconds, apply deterministic tiebreaker instead of pure oldest-wins.
+	# This handles clock skew and sub-second race conditions.
+	local our_entry_ts our_entry_epoch oldest_entry_epoch time_diff
+	our_entry_ts=$(printf '%s' "$claims" | jq -r --arg n "$nonce" '.[] | select(.nonce == $n) | .ts // ""' 2>/dev/null) || our_entry_ts="$ts"
+	our_entry_epoch=$(_iso_to_epoch "${our_entry_ts:-$ts}")
+	oldest_entry_epoch=$(_iso_to_epoch "${oldest_ts:-}")
+	time_diff=$(( our_entry_epoch - oldest_entry_epoch ))
+	# Absolute value
+	if [[ "$time_diff" -lt 0 ]]; then
+		time_diff=$(( -time_diff ))
+	fi
+
+	if [[ "$time_diff" -le "$DISPATCH_CLAIM_TIEBREAKER_WINDOW" ]] && [[ "$claim_count" -gt 1 ]]; then
+		# Simultaneous claims detected — apply tiebreaker
+		printf '[coordination] Simultaneous claims detected (diff=%ds, window=%ds) on #%s — applying tiebreaker\n' \
+			"$time_diff" "$DISPATCH_CLAIM_TIEBREAKER_WINDOW" "$issue_number" >&2
+
+		if _tiebreaker "$ts" "$nonce" "$oldest_ts" "$oldest_nonce"; then
+			# We won the tiebreaker
+			printf 'CLAIM_WON_TIEBREAKER: runner=%s nonce=%s issue=#%s (beat %s via tiebreaker)\n' \
+				"$runner" "$nonce" "$issue_number" "$oldest_runner"
+			return 0
+		fi
+
+		# We lost the tiebreaker — post CLAIM_DEFERRED for audit trail
+		printf '[coordination] deferring to runner=%s nonce=%s ts=%s on issue #%s\n' \
+			"$oldest_runner" "$oldest_nonce" "$oldest_ts" "$issue_number" >&2
+		_post_claim_deferred "$issue_number" "$repo_slug" "$runner" "$nonce" \
+			"$oldest_runner" "$oldest_nonce" "$oldest_ts"
+		printf 'CLAIM_DEFERRED: runner=%s lost tiebreaker to %s on issue #%s — CLAIM_DEFERRED comment posted\n' \
+			"$runner" "$oldest_runner" "$issue_number"
+		return 1
+	fi
+
+	# Step 5: We lost — another runner's claim is clearly older (outside tiebreaker window)
 	printf 'CLAIM_LOST: runner=%s lost to %s on issue #%s — backing off (both claims retained for audit)\n' \
 		"$runner" "$oldest_runner" "$issue_number"
 

--- a/.agents/scripts/dispatch-override-resolve.sh
+++ b/.agents/scripts/dispatch-override-resolve.sh
@@ -1,0 +1,340 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# dispatch-override-resolve.sh — structured per-runner dispatch override resolver (t2422)
+#
+# Replaces the flat DISPATCH_CLAIM_IGNORE_RUNNERS mechanism with structured,
+# per-runner, version-aware overrides. The flat format is deprecated with a
+# one-release grace period — it still works but emits a warning.
+#
+# Config file: ~/.config/aidevops/dispatch-override.conf
+#
+# NEW structured format (t2422):
+#   DISPATCH_OVERRIDE_<LOGIN_UPPER>=<action>[:<version>]
+#   DISPATCH_OVERRIDE_DEFAULT=<action>
+#
+#   Actions:
+#     honour              — always respect claims from this runner (default)
+#     ignore              — always ignore claims (same as flat list)
+#     honour-only-above:<version> — ignore claims with version < <version>;
+#                           once the peer upgrades, coordination resumes
+#     warn                — respect claims but emit a warning
+#
+#   LOGIN_UPPER is the runner's GitHub login uppercased with hyphens replaced
+#   by underscores (e.g., alex-solovyev → ALEX_SOLOVYEV).
+#
+# LEGACY flat format (t2400, deprecated):
+#   DISPATCH_CLAIM_IGNORE_RUNNERS="login1 login2"
+#   When any login matches, resolves to "ignore" + emits deprecation warning.
+#
+# Usage:
+#   dispatch-override-resolve.sh resolve <runner-login> <claim-version>
+#     Returns: honour | ignore | warn
+#     Exit 0 always (fail-safe to "honour" on parse errors).
+#
+#   dispatch-override-resolve.sh check-deprecated
+#     Exit 0 + prints warning if flat DISPATCH_CLAIM_IGNORE_RUNNERS is set.
+#     Exit 1 if no deprecation present.
+#
+#   dispatch-override-resolve.sh help
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+
+# Config file path — same as dispatch-claim-helper.sh uses
+DISPATCH_OVERRIDE_CONF="${DISPATCH_OVERRIDE_CONF:-${HOME}/.config/aidevops/dispatch-override.conf}"
+
+# Defaults — set before sourcing to allow config to override
+DISPATCH_CLAIM_IGNORE_RUNNERS="${DISPATCH_CLAIM_IGNORE_RUNNERS:-}"
+DISPATCH_CLAIM_MIN_VERSION="${DISPATCH_CLAIM_MIN_VERSION:-}"
+DISPATCH_OVERRIDE_ENABLED="${DISPATCH_OVERRIDE_ENABLED:-true}"
+DISPATCH_OVERRIDE_DEFAULT="${DISPATCH_OVERRIDE_DEFAULT:-honour}"
+
+# Source the config if it exists
+if [[ -r "$DISPATCH_OVERRIDE_CONF" ]]; then
+	# shellcheck disable=SC1090
+	source "$DISPATCH_OVERRIDE_CONF" 2>/dev/null || true
+fi
+
+#######################################
+# Normalise a GitHub login to an env var suffix.
+# Uppercases and replaces hyphens/dots with underscores.
+# Args: $1 = runner login (e.g., "alex-solovyev")
+# Returns: normalised suffix on stdout (e.g., "ALEX_SOLOVYEV")
+#######################################
+_login_to_var_suffix() {
+	local login="$1"
+	# Two separate tr calls to avoid BSD tr '-.' range interpretation bug
+	printf '%s' "$login" | tr '[:lower:]' '[:upper:]' | tr '-' '_' | tr '.' '_'
+	return 0
+}
+
+#######################################
+# Semver comparison — is $1 strictly less than $2?
+# Args: $1 = version, $2 = floor
+# Returns: exit 0 = below, exit 1 = at or above
+# "unknown" or empty is always below floor.
+#######################################
+_version_below() {
+	local version="${1:-}"
+	local floor="${2:-}"
+
+	if [[ -z "$version" || "$version" == "unknown" ]]; then
+		return 0
+	fi
+	if [[ "$version" == "$floor" ]]; then
+		return 1
+	fi
+
+	local first
+	first=$(printf '%s\n%s\n' "$version" "$floor" | sort -V | head -n1)
+	if [[ "$first" == "$version" ]]; then
+		return 0
+	fi
+	return 1
+}
+
+#######################################
+# Look up the structured override for a runner.
+# Args: $1 = runner login
+# Returns: the raw action string on stdout (e.g., "honour-only-above:3.8.78")
+#          or empty string if no override set.
+#######################################
+_lookup_structured_override() {
+	local login="$1"
+	local var_suffix
+	var_suffix=$(_login_to_var_suffix "$login")
+	local var_name="DISPATCH_OVERRIDE_${var_suffix}"
+
+	# Use indirect expansion to read the variable
+	local value="${!var_name:-}"
+	printf '%s' "$value"
+	return 0
+}
+
+#######################################
+# Check if a login is in the flat DISPATCH_CLAIM_IGNORE_RUNNERS list.
+# Args: $1 = runner login
+# Returns: exit 0 = in list, exit 1 = not in list
+#######################################
+_is_in_flat_ignore_list() {
+	local login="$1"
+	if [[ -z "$DISPATCH_CLAIM_IGNORE_RUNNERS" ]]; then
+		return 1
+	fi
+
+	# Normalise: accept comma or space separators
+	local normalised
+	normalised=$(printf '%s' "$DISPATCH_CLAIM_IGNORE_RUNNERS" | tr ',' ' ')
+	local entry
+	for entry in $normalised; do
+		if [[ "$entry" == "$login" ]]; then
+			return 0
+		fi
+	done
+	return 1
+}
+
+#######################################
+# Resolve the action for a given runner+version claim.
+#
+# Resolution order:
+#   1. If DISPATCH_OVERRIDE_ENABLED != true → "honour" (overrides disabled)
+#   2. Structured per-runner override (DISPATCH_OVERRIDE_<LOGIN>)
+#   3. Legacy flat list (DISPATCH_CLAIM_IGNORE_RUNNERS) with deprecation warning
+#   4. Legacy version floor (DISPATCH_CLAIM_MIN_VERSION) with deprecation warning
+#   5. DISPATCH_OVERRIDE_DEFAULT (defaults to "honour")
+#
+# Args:
+#   $1 = runner login
+#   $2 = claim version (semver or "unknown")
+# Returns: "honour" | "ignore" | "warn" on stdout. Exit 0 always.
+#######################################
+cmd_resolve() {
+	local runner_login="${1:-}"
+	local claim_version="${2:-unknown}"
+
+	if [[ -z "$runner_login" ]]; then
+		printf 'honour'
+		return 0
+	fi
+
+	# Master switch
+	if [[ "$DISPATCH_OVERRIDE_ENABLED" != "true" ]]; then
+		printf 'honour'
+		return 0
+	fi
+
+	# 1. Check structured per-runner override
+	local override_value
+	override_value=$(_lookup_structured_override "$runner_login")
+
+	if [[ -n "$override_value" ]]; then
+		# Parse action:param
+		local action param
+		action="${override_value%%:*}"
+		param="${override_value#*:}"
+		# If no colon, param == action (no parameter)
+		if [[ "$action" == "$override_value" ]]; then
+			param=""
+		fi
+
+		case "$action" in
+		honour | honor)
+			printf 'honour'
+			return 0
+			;;
+		ignore)
+			printf 'ignore'
+			return 0
+			;;
+		honour-only-above | honor-only-above)
+			if [[ -z "$param" ]]; then
+				# No version threshold — treat as honour
+				printf 'honour'
+				return 0
+			fi
+			if _version_below "$claim_version" "$param"; then
+				printf 'ignore'
+			else
+				printf 'honour'
+			fi
+			return 0
+			;;
+		warn)
+			printf 'warn'
+			return 0
+			;;
+		*)
+			# Unknown action — fail safe to honour
+			printf '[dispatch-override-resolve] Unknown action "%s" for runner %s — defaulting to honour\n' \
+				"$action" "$runner_login" >&2
+			printf 'honour'
+			return 0
+			;;
+		esac
+	fi
+
+	# 2. Legacy flat list (deprecated)
+	if _is_in_flat_ignore_list "$runner_login"; then
+		printf '[dispatch-override-resolve] DEPRECATED: runner %s matched via flat DISPATCH_CLAIM_IGNORE_RUNNERS. Migrate to structured format: DISPATCH_OVERRIDE_%s="ignore" (or "honour-only-above:<version>")\n' \
+			"$runner_login" "$(_login_to_var_suffix "$runner_login")" >&2
+		printf 'ignore'
+		return 0
+	fi
+
+	# 3. Legacy version floor (deprecated)
+	if [[ -n "$DISPATCH_CLAIM_MIN_VERSION" ]]; then
+		if _version_below "$claim_version" "$DISPATCH_CLAIM_MIN_VERSION"; then
+			printf '[dispatch-override-resolve] DEPRECATED: runner %s (version=%s) filtered by flat DISPATCH_CLAIM_MIN_VERSION=%s. Migrate to structured format: DISPATCH_OVERRIDE_%s="honour-only-above:%s"\n' \
+				"$runner_login" "$claim_version" "$DISPATCH_CLAIM_MIN_VERSION" \
+				"$(_login_to_var_suffix "$runner_login")" "$DISPATCH_CLAIM_MIN_VERSION" >&2
+			printf 'ignore'
+			return 0
+		fi
+	fi
+
+	# 4. Default action
+	printf '%s' "${DISPATCH_OVERRIDE_DEFAULT:-honour}"
+	return 0
+}
+
+#######################################
+# Check if deprecated flat-list format is in use. Emits a migration hint.
+# Exit 0 = deprecation present, exit 1 = clean.
+#######################################
+cmd_check_deprecated() {
+	local found=0
+
+	if [[ -n "$DISPATCH_CLAIM_IGNORE_RUNNERS" ]]; then
+		printf '[DEPRECATED] DISPATCH_CLAIM_IGNORE_RUNNERS="%s"\n' "$DISPATCH_CLAIM_IGNORE_RUNNERS"
+		printf '  Migrate to: '
+		local normalised
+		normalised=$(printf '%s' "$DISPATCH_CLAIM_IGNORE_RUNNERS" | tr ',' ' ')
+		local entry
+		for entry in $normalised; do
+			[[ -z "$entry" ]] && continue
+			printf 'DISPATCH_OVERRIDE_%s="ignore"  ' "$(_login_to_var_suffix "$entry")"
+		done
+		printf '\n'
+		found=1
+	fi
+
+	if [[ -n "$DISPATCH_CLAIM_MIN_VERSION" ]]; then
+		printf '[DEPRECATED] DISPATCH_CLAIM_MIN_VERSION="%s"\n' "$DISPATCH_CLAIM_MIN_VERSION"
+		printf '  Migrate to per-runner entries: DISPATCH_OVERRIDE_<RUNNER>="honour-only-above:%s"\n' \
+			"$DISPATCH_CLAIM_MIN_VERSION"
+		found=1
+	fi
+
+	if [[ "$found" -eq 1 ]]; then
+		return 0
+	fi
+	return 1
+}
+
+#######################################
+# Show help
+#######################################
+show_help() {
+	cat <<'HELP'
+dispatch-override-resolve.sh — structured per-runner dispatch override resolver (t2422)
+
+Resolves the action (honour|ignore|warn) for a given runner+version claim,
+using the structured per-runner config format.
+
+Usage:
+  dispatch-override-resolve.sh resolve <runner-login> <claim-version>
+    Returns: honour | ignore | warn
+
+  dispatch-override-resolve.sh check-deprecated
+    Checks for deprecated flat-list config entries and prints migration hints.
+    Exit 0 = deprecated entries found, exit 1 = clean.
+
+  dispatch-override-resolve.sh help
+
+Config format (in ~/.config/aidevops/dispatch-override.conf):
+  # Structured per-runner (t2422):
+  DISPATCH_OVERRIDE_ALEX_SOLOVYEV="honour-only-above:3.8.78"
+  DISPATCH_OVERRIDE_DEFAULT="honour"
+
+  # Legacy flat (deprecated, still works with warning):
+  DISPATCH_CLAIM_IGNORE_RUNNERS="alice bob"
+  DISPATCH_CLAIM_MIN_VERSION="3.8.78"
+
+Actions:
+  honour              — respect claims from this runner
+  ignore              — discard claims from this runner
+  honour-only-above:V — ignore claims with version < V
+  warn                — respect claims but emit a warning
+HELP
+	return 0
+}
+
+#######################################
+# Main
+#######################################
+main() {
+	local command="${1:-help}"
+	shift || true
+
+	case "$command" in
+	resolve)
+		cmd_resolve "$@"
+		;;
+	check-deprecated)
+		cmd_check_deprecated
+		;;
+	help | --help | -h)
+		show_help
+		;;
+	*)
+		echo "Error: Unknown command: $command" >&2
+		show_help
+		return 1
+		;;
+	esac
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-cross-runner-coordination.sh
+++ b/.agents/scripts/tests/test-cross-runner-coordination.sh
@@ -1,0 +1,351 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-cross-runner-coordination.sh — regression tests for t2422 cross-runner coordination
+#
+# Validates:
+#   1. Structured per-runner override: honour-only-above ignores old version
+#   2. Structured per-runner override: honour-only-above passes new version
+#   3. Structured per-runner override: plain ignore
+#   4. Structured per-runner override: warn action
+#   5. Structured fallback to DISPATCH_OVERRIDE_DEFAULT
+#   6. Legacy flat list still works with deprecation warning
+#   7. Override master switch disables all filtering
+#   8. Tiebreaker: earlier ts wins
+#   9. Tiebreaker: same ts, lower nonce wins
+#  10. Tiebreaker: identical inputs → self wins (defensive)
+#  11. dispatch-override-resolve.sh check-deprecated detects flat list
+#  12. _apply_ignore_filter uses structured resolver when available
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RESOLVER="${SCRIPT_DIR}/../dispatch-override-resolve.sh"
+CLAIM_HELPER="${SCRIPT_DIR}/../dispatch-claim-helper.sh"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+	local expected="$1"
+	local actual="$2"
+	local msg="$3"
+	if [[ "$expected" == "$actual" ]]; then
+		printf '  PASS: %s\n' "$msg"
+		PASS=$((PASS + 1))
+	else
+		printf '  FAIL: %s (expected: %q, got: %q)\n' "$msg" "$expected" "$actual"
+		FAIL=$((FAIL + 1))
+	fi
+	return 0
+}
+
+# Source claim helper's internal functions (strip main invocation)
+_source_claim_helper() {
+	local tmp
+	tmp=$(mktemp)
+	sed '/^main "$@"$/d' "$CLAIM_HELPER" >"$tmp"
+	# shellcheck disable=SC1090
+	source "$tmp"
+	rm -f "$tmp"
+	# Fix paths — sourcing from temp sets SCRIPT_DIR to /tmp/ which breaks
+	# OVERRIDE_RESOLVER resolution. Use the known script directory directly.
+	SCRIPT_DIR="${SCRIPT_DIR%/tests}"  # noop if already parent
+	OVERRIDE_RESOLVER="${SCRIPT_DIR}/../dispatch-override-resolve.sh"
+	# If that doesn't exist, use the scripts-dir-based path
+	if [[ ! -x "$OVERRIDE_RESOLVER" ]]; then
+		OVERRIDE_RESOLVER="$(cd "$(dirname "$CLAIM_HELPER")" && pwd)/dispatch-override-resolve.sh"
+	fi
+	return 0
+}
+
+# ──────────────────────────────────────────────────────────────────────
+# Phase B: Structured per-runner overrides via dispatch-override-resolve.sh
+# ──────────────────────────────────────────────────────────────────────
+
+test_structured_honour_only_above_old_version() {
+	printf '\nTest 1: structured override honour-only-above ignores old version\n'
+	local tmp_conf
+	tmp_conf=$(mktemp)
+	cat >"$tmp_conf" <<'EOF'
+DISPATCH_OVERRIDE_ENABLED=true
+DISPATCH_OVERRIDE_ALEX_SOLOVYEV="honour-only-above:3.8.78"
+DISPATCH_OVERRIDE_DEFAULT="honour"
+EOF
+	local result
+	result=$(DISPATCH_OVERRIDE_CONF="$tmp_conf" "$RESOLVER" resolve "alex-solovyev" "3.8.50" 2>/dev/null)
+	assert_eq "ignore" "$result" "alex-solovyev 3.8.50 < floor 3.8.78 → ignore"
+	rm -f "$tmp_conf"
+	return 0
+}
+
+test_structured_honour_only_above_new_version() {
+	printf '\nTest 2: structured override honour-only-above passes new version\n'
+	local tmp_conf
+	tmp_conf=$(mktemp)
+	cat >"$tmp_conf" <<'EOF'
+DISPATCH_OVERRIDE_ENABLED=true
+DISPATCH_OVERRIDE_ALEX_SOLOVYEV="honour-only-above:3.8.78"
+DISPATCH_OVERRIDE_DEFAULT="honour"
+EOF
+	local result
+	result=$(DISPATCH_OVERRIDE_CONF="$tmp_conf" "$RESOLVER" resolve "alex-solovyev" "3.9.0" 2>/dev/null)
+	assert_eq "honour" "$result" "alex-solovyev 3.9.0 >= floor 3.8.78 → honour"
+	rm -f "$tmp_conf"
+	return 0
+}
+
+test_structured_ignore() {
+	printf '\nTest 3: structured override plain ignore\n'
+	local tmp_conf
+	tmp_conf=$(mktemp)
+	cat >"$tmp_conf" <<'EOF'
+DISPATCH_OVERRIDE_ENABLED=true
+DISPATCH_OVERRIDE_STALE_PEER="ignore"
+DISPATCH_OVERRIDE_DEFAULT="honour"
+EOF
+	local result
+	result=$(DISPATCH_OVERRIDE_CONF="$tmp_conf" "$RESOLVER" resolve "stale-peer" "3.9.0" 2>/dev/null)
+	assert_eq "ignore" "$result" "stale-peer always ignored regardless of version"
+	rm -f "$tmp_conf"
+	return 0
+}
+
+test_structured_warn() {
+	printf '\nTest 4: structured override warn action\n'
+	local tmp_conf
+	tmp_conf=$(mktemp)
+	cat >"$tmp_conf" <<'EOF'
+DISPATCH_OVERRIDE_ENABLED=true
+DISPATCH_OVERRIDE_FLAKY_RUNNER="warn"
+DISPATCH_OVERRIDE_DEFAULT="honour"
+EOF
+	local result
+	result=$(DISPATCH_OVERRIDE_CONF="$tmp_conf" "$RESOLVER" resolve "flaky-runner" "3.9.0" 2>/dev/null)
+	assert_eq "warn" "$result" "flaky-runner gets warn action"
+	rm -f "$tmp_conf"
+	return 0
+}
+
+test_structured_default_fallback() {
+	printf '\nTest 5: structured fallback to DISPATCH_OVERRIDE_DEFAULT\n'
+	local tmp_conf
+	tmp_conf=$(mktemp)
+	cat >"$tmp_conf" <<'EOF'
+DISPATCH_OVERRIDE_ENABLED=true
+DISPATCH_OVERRIDE_DEFAULT="honour"
+DISPATCH_CLAIM_IGNORE_RUNNERS=""
+DISPATCH_CLAIM_MIN_VERSION=""
+EOF
+	local result
+	result=$(DISPATCH_OVERRIDE_CONF="$tmp_conf" "$RESOLVER" resolve "unknown-runner" "3.9.0" 2>/dev/null)
+	assert_eq "honour" "$result" "unknown runner falls through to default honour"
+	rm -f "$tmp_conf"
+	return 0
+}
+
+test_legacy_flat_list_with_deprecation() {
+	printf '\nTest 6: legacy flat list still works with deprecation warning\n'
+	local tmp_conf
+	tmp_conf=$(mktemp)
+	cat >"$tmp_conf" <<'EOF'
+DISPATCH_OVERRIDE_ENABLED=true
+DISPATCH_CLAIM_IGNORE_RUNNERS="legacy-peer"
+DISPATCH_CLAIM_MIN_VERSION=""
+EOF
+	local result stderr_out
+	stderr_out=$(mktemp)
+	result=$(DISPATCH_OVERRIDE_CONF="$tmp_conf" "$RESOLVER" resolve "legacy-peer" "3.9.0" 2>"$stderr_out")
+	assert_eq "ignore" "$result" "legacy flat list: legacy-peer → ignore"
+
+	# Check deprecation warning was emitted
+	if grep -q "DEPRECATED" "$stderr_out"; then
+		printf '  PASS: deprecation warning emitted\n'
+		PASS=$((PASS + 1))
+	else
+		printf '  FAIL: no deprecation warning emitted\n'
+		FAIL=$((FAIL + 1))
+	fi
+	rm -f "$tmp_conf" "$stderr_out"
+	return 0
+}
+
+test_master_switch_disabled() {
+	printf '\nTest 7: override master switch disables all filtering\n'
+	local tmp_conf
+	tmp_conf=$(mktemp)
+	cat >"$tmp_conf" <<'EOF'
+DISPATCH_OVERRIDE_ENABLED=false
+DISPATCH_OVERRIDE_ALEX_SOLOVYEV="ignore"
+DISPATCH_CLAIM_IGNORE_RUNNERS="other-peer"
+EOF
+	local result
+	result=$(DISPATCH_OVERRIDE_CONF="$tmp_conf" "$RESOLVER" resolve "alex-solovyev" "3.8.50" 2>/dev/null)
+	assert_eq "honour" "$result" "master switch false: alex → honour despite ignore override"
+
+	result=$(DISPATCH_OVERRIDE_CONF="$tmp_conf" "$RESOLVER" resolve "other-peer" "3.9.0" 2>/dev/null)
+	assert_eq "honour" "$result" "master switch false: legacy peer → honour despite flat list"
+	rm -f "$tmp_conf"
+	return 0
+}
+
+# ──────────────────────────────────────────────────────────────────────
+# Phase C: Tiebreaker for simultaneous claims
+# ──────────────────────────────────────────────────────────────────────
+
+test_tiebreaker_earlier_ts_wins() {
+	printf '\nTest 8: tiebreaker — earlier ts wins\n'
+	_source_claim_helper
+
+	if _tiebreaker "2026-04-20T00:00:01Z" "abc" "2026-04-20T00:00:03Z" "xyz"; then
+		printf '  PASS: earlier ts (01Z) beats later ts (03Z)\n'
+		PASS=$((PASS + 1))
+	else
+		printf '  FAIL: earlier ts should win\n'
+		FAIL=$((FAIL + 1))
+	fi
+
+	# Reverse: later ts loses
+	if _tiebreaker "2026-04-20T00:00:05Z" "abc" "2026-04-20T00:00:03Z" "xyz"; then
+		printf '  FAIL: later ts (05Z) should not beat earlier ts (03Z)\n'
+		FAIL=$((FAIL + 1))
+	else
+		printf '  PASS: later ts (05Z) loses to earlier ts (03Z)\n'
+		PASS=$((PASS + 1))
+	fi
+	return 0
+}
+
+test_tiebreaker_same_ts_nonce_wins() {
+	printf '\nTest 9: tiebreaker — same ts, lower nonce wins\n'
+	_source_claim_helper
+
+	if _tiebreaker "2026-04-20T00:00:01Z" "aaa111" "2026-04-20T00:00:01Z" "zzz999"; then
+		printf '  PASS: lower nonce (aaa111) beats higher nonce (zzz999)\n'
+		PASS=$((PASS + 1))
+	else
+		printf '  FAIL: lower nonce should win on same ts\n'
+		FAIL=$((FAIL + 1))
+	fi
+
+	# Reverse: higher nonce loses
+	if _tiebreaker "2026-04-20T00:00:01Z" "zzz999" "2026-04-20T00:00:01Z" "aaa111"; then
+		printf '  FAIL: higher nonce (zzz999) should not beat lower nonce (aaa111)\n'
+		FAIL=$((FAIL + 1))
+	else
+		printf '  PASS: higher nonce (zzz999) loses to lower nonce (aaa111)\n'
+		PASS=$((PASS + 1))
+	fi
+	return 0
+}
+
+test_tiebreaker_identical() {
+	printf '\nTest 10: tiebreaker — identical inputs (defensive, self wins)\n'
+	_source_claim_helper
+
+	if _tiebreaker "2026-04-20T00:00:01Z" "same" "2026-04-20T00:00:01Z" "same"; then
+		printf '  PASS: identical inputs → self wins (defensive)\n'
+		PASS=$((PASS + 1))
+	else
+		printf '  FAIL: identical inputs should return win (exit 0)\n'
+		FAIL=$((FAIL + 1))
+	fi
+	return 0
+}
+
+test_check_deprecated() {
+	printf '\nTest 11: check-deprecated detects flat list\n'
+	local tmp_conf
+	tmp_conf=$(mktemp)
+	cat >"$tmp_conf" <<'EOF'
+DISPATCH_OVERRIDE_ENABLED=true
+DISPATCH_CLAIM_IGNORE_RUNNERS="old-peer"
+DISPATCH_CLAIM_MIN_VERSION="3.8.0"
+EOF
+	local output
+	output=$(DISPATCH_OVERRIDE_CONF="$tmp_conf" "$RESOLVER" check-deprecated 2>&1)
+	local rc=$?
+	assert_eq "0" "$rc" "check-deprecated exits 0 when deprecated entries present"
+
+	if echo "$output" | grep -q "DEPRECATED.*DISPATCH_CLAIM_IGNORE_RUNNERS"; then
+		printf '  PASS: flat list deprecation detected\n'
+		PASS=$((PASS + 1))
+	else
+		printf '  FAIL: flat list deprecation not detected\n'
+		FAIL=$((FAIL + 1))
+	fi
+
+	if echo "$output" | grep -q "DEPRECATED.*DISPATCH_CLAIM_MIN_VERSION"; then
+		printf '  PASS: version floor deprecation detected\n'
+		PASS=$((PASS + 1))
+	else
+		printf '  FAIL: version floor deprecation not detected\n'
+		FAIL=$((FAIL + 1))
+	fi
+	rm -f "$tmp_conf"
+	return 0
+}
+
+test_apply_filter_uses_resolver() {
+	printf '\nTest 12: _apply_ignore_filter uses structured resolver when available\n'
+	_source_claim_helper
+
+	local tmp_conf
+	tmp_conf=$(mktemp)
+	cat >"$tmp_conf" <<'EOF'
+DISPATCH_OVERRIDE_ENABLED=true
+DISPATCH_OVERRIDE_ALICE="ignore"
+DISPATCH_OVERRIDE_DEFAULT="honour"
+DISPATCH_CLAIM_IGNORE_RUNNERS=""
+DISPATCH_CLAIM_MIN_VERSION=""
+EOF
+
+	local parsed='[{"id":1,"runner":"alice","version":"3.9.0","nonce":"n1","ts":"2026-04-20T00:00:01Z","created_at":"2026-04-20T00:00:01Z","created_epoch":1745107201,"age_seconds":10},{"id":2,"runner":"bob","version":"3.9.0","nonce":"n2","ts":"2026-04-20T00:00:02Z","created_at":"2026-04-20T00:00:02Z","created_epoch":1745107202,"age_seconds":9}]'
+
+	# Export DISPATCH_OVERRIDE_CONF so subprocesses (resolver) can read it.
+	# Also set DISPATCH_OVERRIDE_ENABLED in this shell (sourced helper reads it).
+	local saved_conf="${DISPATCH_OVERRIDE_CONF:-}"
+	local saved_enabled="${DISPATCH_OVERRIDE_ENABLED:-}"
+	export DISPATCH_OVERRIDE_CONF="$tmp_conf"
+	DISPATCH_OVERRIDE_ENABLED=true
+	DISPATCH_CLAIM_IGNORE_RUNNERS=""
+	DISPATCH_CLAIM_MIN_VERSION=""
+
+	local result
+	result=$(_apply_ignore_filter "$parsed" "42" "owner/repo" 2>/dev/null)
+
+	local runners
+	runners=$(printf '%s' "$result" | jq -r '.[].runner' 2>/dev/null | sort | tr '\n' ',')
+	assert_eq "bob," "$runners" "structured filter: alice (ignore) removed, bob kept"
+
+	# Restore
+	DISPATCH_OVERRIDE_CONF="$saved_conf"
+	DISPATCH_OVERRIDE_ENABLED="$saved_enabled"
+	rm -f "$tmp_conf"
+	return 0
+}
+
+# ──────────────────────────────────────────────────────────────────────
+# Run all tests
+# ──────────────────────────────────────────────────────────────────────
+
+test_structured_honour_only_above_old_version
+test_structured_honour_only_above_new_version
+test_structured_ignore
+test_structured_warn
+test_structured_default_fallback
+test_legacy_flat_list_with_deprecation
+test_master_switch_disabled
+test_tiebreaker_earlier_ts_wins
+test_tiebreaker_same_ts_nonce_wins
+test_tiebreaker_identical
+test_check_deprecated
+test_apply_filter_uses_resolver
+
+printf '\n========================\n'
+printf 'Passed: %d, Failed: %d\n' "$PASS" "$FAIL"
+
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- Structured per-runner versioned overrides replace the flat `DISPATCH_CLAIM_IGNORE_RUNNERS` mechanism with `DISPATCH_OVERRIDE_<LOGIN>=action[:version]` entries that are version-aware and self-sunsetting
- Deterministic simultaneous claim tiebreaker (ts strict-less, nonce lexicographic) resolves races within a 5s window, with `CLAIM_DEFERRED` audit comments for traceability
- 18-assertion regression test suite covering all override actions and tiebreaker edge cases

## What changed

### Phase B: Structured overrides
- **NEW** `.agents/scripts/dispatch-override-resolve.sh` — resolver that reads structured per-runner config (`honour`, `ignore`, `honour-only-above:V`, `warn`)
- **EDIT** `.agents/scripts/dispatch-claim-helper.sh` — `_apply_ignore_filter()` now delegates to resolver; legacy inline logic kept as fallback
- **EDIT** `.agents/configs/dispatch-override.conf.txt` — new structured format with migration docs
- Legacy flat list deprecated with one-release grace period + migration hints via `dispatch-override-resolve.sh check-deprecated`

### Phase C: Simultaneous claim tiebreaker
- **EDIT** `.agents/scripts/dispatch-claim-helper.sh` — `_tiebreaker()` function, `_post_claim_deferred()` audit comment, `DISPATCH_CLAIM_TIEBREAKER_WINDOW` (default 5s)
- When claims from different runners land within the tiebreaker window, deterministic resolution prevents ambiguity from clock skew or same-second timestamps

### Tests
- **NEW** `.agents/scripts/tests/test-cross-runner-coordination.sh` — 18 assertions: structured honour-only-above (old/new version), ignore, warn, default fallback, legacy compat with deprecation warning, master switch, tiebreaker (ts ordering, nonce fallback, identical inputs), `_apply_ignore_filter` integration

### Docs
- **EDIT** `.agents/reference/cross-runner-coordination.md` — sections 7 (Structured Overrides) and 8 (Simultaneous Claim Tiebreaker)
- **EDIT** `.agents/AGENTS.md` — cross-runner coordination pointer updated

## Testing

```bash
bash .agents/scripts/tests/test-cross-runner-coordination.sh  # 18 pass
bash .agents/scripts/tests/test-dispatch-override.sh           # 23 pass (backward compat)
shellcheck .agents/scripts/dispatch-override-resolve.sh .agents/scripts/dispatch-claim-helper.sh  # clean
```

## Verification

Post-deploy: scan pulse log for 1 week for double-dispatch events:
```bash
grep "Dispatching worker.*Issue #" ~/.aidevops/logs/pulse-wrapper.log | \
    awk '{print $NF}' | sort | uniq -c | awk '$1 > 1'
# Expect: empty
```

Resolves #20028


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.80 plugin for [OpenCode](https://opencode.ai) v1.14.18 with claude-opus-4-6 spent 19m and 43,715 tokens on this as a headless worker.