### PR TITLE
t2427: split shared-constants.sh — extract feature toggles into shared-feature-toggles.sh

### DIFF
--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -1227,208 +1227,22 @@ get_provider_from_model() {
 }
 
 # =============================================================================
-# Configuration Loader (issue #2730 — JSONC config system)
+# Configuration Loader & Feature Toggles -- extracted module
 # =============================================================================
-# Loads user-configurable settings from JSONC config files:
-#   1. Defaults file (shipped with aidevops, overwritten on update)
-#      ~/.aidevops/agents/configs/aidevops.defaults.jsonc
-#   2. User overrides (~/.config/aidevops/config.jsonc)
-#   3. Environment variables (highest priority)
-#
-# Requires jq for JSONC parsing. Falls back to legacy .conf if jq unavailable.
-#
-# Scripts check config via:
-#   config_get <dotpath> [default]       — get any config value
-#   config_enabled <dotpath>             — check boolean config
-#   get_feature_toggle <key> [default]   — backward-compatible (flat key)
-#   is_feature_enabled <key>             — backward-compatible (flat key)
+# Functions: get_feature_toggle, is_feature_enabled, _load_config, _ft_env_map,
+#            _load_feature_toggles_legacy.
+# Variables: FEATURE_TOGGLES_DEFAULTS, FEATURE_TOGGLES_USER,
+#            _AIDEVOPS_CONFIG_MODE (populated on load).
+# Sources config-helper.sh and runtime-registry.sh transitively.
+# Extracted to shared-feature-toggles.sh (t2427, GH#20063) to keep this file
+# < 2000 lines. See shared-feature-toggles.sh for full documentation.
+# Sourcing this sub-library auto-invokes _load_config at its tail — no explicit
+# call needed here.
 
-# Source config-helper.sh (provides _jsonc_get, config_get, config_enabled, etc.)
-# IMPORTANT: source=/dev/null tells ShellCheck NOT to follow this source directive.
-# Without it, ShellCheck follows the cycle shared-constants.sh → config-helper.sh →
-# shared-constants.sh infinitely, consuming exponential memory (7-14 GB observed).
-# The include guard (_SHARED_CONSTANTS_LOADED at line 14) prevents infinite recursion
-# at execution time, but ShellCheck is a static analyzer and ignores runtime guards.
-# GH#3981: https://github.com/marcusquinn/aidevops/issues/3981
-# Use ${BASH_SOURCE[0]:-$0} for shell portability — BASH_SOURCE is undefined
-# in zsh (the MCP shell environment). Without this guard, sourcing from zsh
-# with set -u (nounset) fails with "BASH_SOURCE[0]: parameter not set". See GH#4904.
 _SC_SELF="${BASH_SOURCE[0]:-${0:-}}"
-_CONFIG_HELPER="${_SC_SELF%/*}/config-helper.sh"
-if [[ -r "$_CONFIG_HELPER" ]]; then
-	# shellcheck source=/dev/null
-	source "$_CONFIG_HELPER"
-fi
-
-# Source runtime registry (t1665.1) — central data source for all AI CLI runtimes
-_RUNTIME_REGISTRY="${_SC_SELF%/*}/runtime-registry.sh"
-if [[ -r "$_RUNTIME_REGISTRY" ]]; then
-	# shellcheck source=/dev/null
-	source "$_RUNTIME_REGISTRY"
-fi
-
-# Legacy paths (kept for backward compatibility and migration)
-FEATURE_TOGGLES_DEFAULTS="${HOME}/.aidevops/agents/configs/feature-toggles.conf.defaults"
-FEATURE_TOGGLES_USER="${HOME}/.config/aidevops/feature-toggles.conf"
-
-# Map from legacy toggle key to environment variable name.
-# Used by both the new JSONC system and the legacy fallback.
-_ft_env_map() {
-	local key="$1"
-	case "$key" in
-	auto_update) echo "AIDEVOPS_AUTO_UPDATE" ;;
-	update_interval) echo "AIDEVOPS_UPDATE_INTERVAL" ;;
-	skill_auto_update) echo "AIDEVOPS_SKILL_AUTO_UPDATE" ;;
-	skill_freshness_hours) echo "AIDEVOPS_SKILL_FRESHNESS_HOURS" ;;
-	tool_auto_update) echo "AIDEVOPS_TOOL_AUTO_UPDATE" ;;
-	tool_freshness_hours) echo "AIDEVOPS_TOOL_FRESHNESS_HOURS" ;;
-	tool_idle_hours) echo "AIDEVOPS_TOOL_IDLE_HOURS" ;;
-	supervisor_pulse) echo "AIDEVOPS_SUPERVISOR_PULSE" ;;
-	repo_sync) echo "AIDEVOPS_REPO_SYNC" ;;
-	repo_aidevops_health) echo "AIDEVOPS_REPO_HEALTH" ;;
-	openclaw_auto_update) echo "AIDEVOPS_OPENCLAW_AUTO_UPDATE" ;;
-	openclaw_freshness_hours) echo "AIDEVOPS_OPENCLAW_FRESHNESS_HOURS" ;;
-	upstream_watch) echo "AIDEVOPS_UPSTREAM_WATCH" ;;
-	upstream_watch_hours) echo "AIDEVOPS_UPSTREAM_WATCH_HOURS" ;;
-	max_interactive_sessions) echo "AIDEVOPS_MAX_SESSIONS" ;;
-	*) echo "" ;;
-	esac
-	return 0
-}
-
-# ---------------------------------------------------------------------------
-# Legacy fallback: load from .conf files when jq is not available
-# ---------------------------------------------------------------------------
-_load_feature_toggles_legacy() {
-	if [[ -r "$FEATURE_TOGGLES_DEFAULTS" ]]; then
-		local line key value
-		while IFS= read -r line || [[ -n "$line" ]]; do
-			[[ -z "$line" || "$line" == \#* ]] && continue
-			key="${line%%=*}"
-			value="${line#*=}"
-			[[ "$key" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]] || continue
-			printf -v "_FT_${key}" '%s' "$value"
-		done <"$FEATURE_TOGGLES_DEFAULTS"
-	fi
-
-	if [[ -r "$FEATURE_TOGGLES_USER" ]]; then
-		local line key value
-		while IFS= read -r line || [[ -n "$line" ]]; do
-			[[ -z "$line" || "$line" == \#* ]] && continue
-			key="${line%%=*}"
-			value="${line#*=}"
-			[[ "$key" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]] || continue
-			printf -v "_FT_${key}" '%s' "$value"
-		done <"$FEATURE_TOGGLES_USER"
-	fi
-
-	local toggle_keys="auto_update update_interval skill_auto_update skill_freshness_hours tool_auto_update tool_freshness_hours tool_idle_hours supervisor_pulse repo_sync repo_aidevops_health openclaw_auto_update openclaw_freshness_hours upstream_watch upstream_watch_hours max_interactive_sessions manage_opencode_config manage_claude_config session_greeting safety_hooks shell_aliases onboarding_prompt"
-	local tk env_var env_val
-	for tk in $toggle_keys; do
-		env_var=$(_ft_env_map "$tk")
-		if [[ -n "$env_var" ]]; then
-			env_val="${!env_var:-}"
-			if [[ -n "$env_val" ]]; then
-				printf -v "_FT_${tk}" '%s' "$env_val"
-			fi
-		fi
-	done
-
-	return 0
-}
-
-# ---------------------------------------------------------------------------
-# Detect which config system to use and load accordingly
-# ---------------------------------------------------------------------------
-_AIDEVOPS_CONFIG_MODE=""
-
-_load_config() {
-	# Prefer JSONC if jq is available, defaults file exists, AND config-helper.sh
-	# functions (config_get/config_enabled) are loaded. Without the functions,
-	# having jq + defaults is not enough — callers would fail at runtime.
-	local jsonc_defaults="${JSONC_DEFAULTS:-${HOME}/.aidevops/agents/configs/aidevops.defaults.jsonc}"
-	if command -v jq &>/dev/null && [[ -r "$jsonc_defaults" ]] &&
-		type config_get &>/dev/null && type config_enabled &>/dev/null; then
-		_AIDEVOPS_CONFIG_MODE="jsonc"
-		# config-helper.sh functions are already available via source above
-		# Auto-migrate legacy .conf if it exists and no JSONC user config yet
-		local jsonc_user="${JSONC_USER:-${HOME}/.config/aidevops/config.jsonc}"
-		if [[ -f "$FEATURE_TOGGLES_USER" && ! -f "$jsonc_user" ]]; then
-			if type _migrate_conf_to_jsonc &>/dev/null; then
-				if ! _migrate_conf_to_jsonc; then
-					echo "[WARN] Auto-migration from legacy config failed. Run 'aidevops config migrate' manually." >&2
-				fi
-			fi
-		fi
-	else
-		_AIDEVOPS_CONFIG_MODE="legacy"
-		_load_feature_toggles_legacy
-	fi
-
-	return 0
-}
-
-# ---------------------------------------------------------------------------
-# Backward-compatible API: get_feature_toggle / is_feature_enabled
-# These accept flat legacy keys (e.g. "auto_update") and route to the
-# appropriate backend (JSONC or legacy .conf).
-# ---------------------------------------------------------------------------
-
-# Get a feature toggle / config value.
-# Usage: get_feature_toggle <key> [default]
-# Accepts both legacy flat keys and new dotpath keys.
-get_feature_toggle() {
-	local key="$1"
-	local default="${2:-}"
-
-	if [[ "$_AIDEVOPS_CONFIG_MODE" == "jsonc" ]]; then
-		# Map legacy key to dotpath if needed
-		local dotpath
-		if type _legacy_key_to_dotpath &>/dev/null; then
-			dotpath=$(_legacy_key_to_dotpath "$key")
-		else
-			dotpath="$key"
-		fi
-		config_get "$dotpath" "$default"
-	else
-		# Legacy mode: read from _FT_* variables
-		local var_name="_FT_${key}"
-		local value="${!var_name:-}"
-		if [[ -n "$value" ]]; then
-			echo "$value"
-		else
-			echo "$default"
-		fi
-	fi
-	return 0
-}
-
-# Check if a feature toggle / config boolean is enabled (true).
-# Usage: if is_feature_enabled auto_update; then ...
-is_feature_enabled() {
-	local key="$1"
-
-	if [[ "$_AIDEVOPS_CONFIG_MODE" == "jsonc" ]]; then
-		local dotpath
-		if type _legacy_key_to_dotpath &>/dev/null; then
-			dotpath=$(_legacy_key_to_dotpath "$key")
-		else
-			dotpath="$key"
-		fi
-		config_enabled "$dotpath"
-		return $?
-	else
-		local value
-		value="$(get_feature_toggle "$key" "true")"
-		local lower
-		lower=$(echo "$value" | tr '[:upper:]' '[:lower:]')
-		[[ "$lower" == "true" ]]
-		return $?
-	fi
-}
-
-# Load config immediately when shared-constants.sh is sourced
-_load_config
+# shellcheck source=./shared-feature-toggles.sh
+# shellcheck disable=SC1091  # sub-library resolved at runtime via _SC_SELF
+source "${_SC_SELF%/*}/shared-feature-toggles.sh"
 
 # This ensures all constants are available when this file is sourced
 export CONTENT_TYPE_JSON CONTENT_TYPE_FORM USER_AGENT

--- a/.agents/scripts/shared-feature-toggles.sh
+++ b/.agents/scripts/shared-feature-toggles.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# Shared Feature Toggles & Configuration Loader (issue #2730 — JSONC config)
+# =============================================================================
+# Configuration-loading functions extracted from shared-constants.sh (t2427) to
+# keep that file under the 2000-line file-size-debt threshold.
+#
+# Loads user-configurable settings from JSONC config files:
+#   1. Defaults file (shipped with aidevops, overwritten on update)
+#      ~/.aidevops/agents/configs/aidevops.defaults.jsonc
+#   2. User overrides (~/.config/aidevops/config.jsonc)
+#   3. Environment variables (highest priority)
+#
+# Requires jq for JSONC parsing. Falls back to legacy .conf if jq unavailable.
+#
+# Public API (backward-compatible flat keys):
+#   - get_feature_toggle <key> [default]   — get any config value
+#   - is_feature_enabled <key>             — check boolean config
+#
+# Internal helpers:
+#   - _ft_env_map <key>                    — map legacy key to env var name
+#   - _load_config                         — auto-called on source
+#   - _load_feature_toggles_legacy         — .conf-file fallback loader
+#
+# Usage: source "${SCRIPT_DIR}/shared-feature-toggles.sh"
+#        # _load_config is invoked automatically at end of this file
+#
+# Dependencies:
+#   - config-helper.sh (sourced here — provides _jsonc_get, config_get, config_enabled)
+#   - runtime-registry.sh (sourced here — central data source for AI CLI runtimes)
+#   - bash 4+, jq (optional — falls back to legacy .conf without it)
+#
+# NOTE: This file is sourced BY shared-constants.sh, so all print_* and other
+# utility functions from shared-constants.sh are already in scope at load time.
+# If sourcing this file standalone (e.g. in tests), source shared-constants.sh first.
+#
+# Part of aidevops framework: https://aidevops.sh
+
+# Apply strict mode only when executed directly (not when sourced)
+[[ "${BASH_SOURCE[0]}" == "${0}" ]] && set -euo pipefail
+
+# Include guard
+[[ -n "${_SHARED_FEATURE_TOGGLES_LOADED:-}" ]] && return 0
+_SHARED_FEATURE_TOGGLES_LOADED=1
+
+# =============================================================================
+# Source dependencies (config-helper.sh, runtime-registry.sh)
+# =============================================================================
+
+# Source config-helper.sh (provides _jsonc_get, config_get, config_enabled, etc.)
+# IMPORTANT: source=/dev/null tells ShellCheck NOT to follow this source directive.
+# Without it, ShellCheck follows the cycle shared-constants.sh → config-helper.sh →
+# shared-constants.sh infinitely, consuming exponential memory (7-14 GB observed).
+# The include guard (_SHARED_CONSTANTS_LOADED) prevents infinite recursion at
+# execution time, but ShellCheck is a static analyzer and ignores runtime guards.
+# GH#3981: https://github.com/marcusquinn/aidevops/issues/3981
+# Use ${BASH_SOURCE[0]:-$0} for shell portability — BASH_SOURCE is undefined
+# in zsh (the MCP shell environment). Without this guard, sourcing from zsh
+# with set -u (nounset) fails with "BASH_SOURCE[0]: parameter not set". See GH#4904.
+_SC_SELF="${BASH_SOURCE[0]:-${0:-}}"
+_CONFIG_HELPER="${_SC_SELF%/*}/config-helper.sh"
+if [[ -r "$_CONFIG_HELPER" ]]; then
+	# shellcheck source=/dev/null
+	source "$_CONFIG_HELPER"
+fi
+
+# Source runtime registry (t1665.1) — central data source for all AI CLI runtimes
+_RUNTIME_REGISTRY="${_SC_SELF%/*}/runtime-registry.sh"
+if [[ -r "$_RUNTIME_REGISTRY" ]]; then
+	# shellcheck source=/dev/null
+	source "$_RUNTIME_REGISTRY"
+fi
+
+# =============================================================================
+# Legacy paths (kept for backward compatibility and migration)
+# =============================================================================
+
+FEATURE_TOGGLES_DEFAULTS="${HOME}/.aidevops/agents/configs/feature-toggles.conf.defaults"
+FEATURE_TOGGLES_USER="${HOME}/.config/aidevops/feature-toggles.conf"
+
+# Prefix for dynamic toggle variables exposed by legacy mode (e.g. _FT_auto_update).
+readonly _FT_VAR_PREFIX="_FT_"
+
+# Parse one key=value line from a legacy .conf file into a _FT_* variable.
+# Skips blank lines, comments, and lines with non-identifier keys.
+_ft_parse_conf_line() {
+	local line="$1"
+	[[ -z "$line" || "$line" == \#* ]] && return 0
+	local key="${line%%=*}"
+	local value="${line#*=}"
+	[[ "$key" =~ ^[a-zA-Z_][a-zA-Z0-9_]*$ ]] || return 0
+	printf -v "${_FT_VAR_PREFIX}${key}" '%s' "$value"
+	return 0
+}
+
+# Load one .conf file by iterating _ft_parse_conf_line over its lines.
+_ft_load_conf_file() {
+	local path="$1"
+	[[ -r "$path" ]] || return 0
+	local line
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		_ft_parse_conf_line "$line"
+	done <"$path"
+	return 0
+}
+
+# =============================================================================
+# Legacy key → environment variable name mapping
+# =============================================================================
+# Used by both the new JSONC system and the legacy fallback.
+_ft_env_map() {
+	local key="$1"
+	case "$key" in
+	auto_update) echo "AIDEVOPS_AUTO_UPDATE" ;;
+	update_interval) echo "AIDEVOPS_UPDATE_INTERVAL" ;;
+	skill_auto_update) echo "AIDEVOPS_SKILL_AUTO_UPDATE" ;;
+	skill_freshness_hours) echo "AIDEVOPS_SKILL_FRESHNESS_HOURS" ;;
+	tool_auto_update) echo "AIDEVOPS_TOOL_AUTO_UPDATE" ;;
+	tool_freshness_hours) echo "AIDEVOPS_TOOL_FRESHNESS_HOURS" ;;
+	tool_idle_hours) echo "AIDEVOPS_TOOL_IDLE_HOURS" ;;
+	supervisor_pulse) echo "AIDEVOPS_SUPERVISOR_PULSE" ;;
+	repo_sync) echo "AIDEVOPS_REPO_SYNC" ;;
+	repo_aidevops_health) echo "AIDEVOPS_REPO_HEALTH" ;;
+	openclaw_auto_update) echo "AIDEVOPS_OPENCLAW_AUTO_UPDATE" ;;
+	openclaw_freshness_hours) echo "AIDEVOPS_OPENCLAW_FRESHNESS_HOURS" ;;
+	upstream_watch) echo "AIDEVOPS_UPSTREAM_WATCH" ;;
+	upstream_watch_hours) echo "AIDEVOPS_UPSTREAM_WATCH_HOURS" ;;
+	max_interactive_sessions) echo "AIDEVOPS_MAX_SESSIONS" ;;
+	*) echo "" ;;
+	esac
+	return 0
+}
+
+# =============================================================================
+# Legacy fallback: load from .conf files when jq is not available
+# =============================================================================
+# Keys that should pick up environment-variable overrides in legacy mode.
+# Keep in sync with _ft_env_map plus a few extras that don't yet have env vars.
+readonly _FT_LEGACY_ENV_OVERRIDE_KEYS="auto_update update_interval skill_auto_update skill_freshness_hours tool_auto_update tool_freshness_hours tool_idle_hours supervisor_pulse repo_sync repo_aidevops_health openclaw_auto_update openclaw_freshness_hours upstream_watch upstream_watch_hours max_interactive_sessions manage_opencode_config manage_claude_config session_greeting safety_hooks shell_aliases onboarding_prompt"
+
+_load_feature_toggles_legacy() {
+	_ft_load_conf_file "$FEATURE_TOGGLES_DEFAULTS"
+	_ft_load_conf_file "$FEATURE_TOGGLES_USER"
+
+	local tk env_var env_val
+	for tk in $_FT_LEGACY_ENV_OVERRIDE_KEYS; do
+		env_var=$(_ft_env_map "$tk")
+		[[ -z "$env_var" ]] && continue
+		env_val="${!env_var:-}"
+		[[ -z "$env_val" ]] && continue
+		printf -v "${_FT_VAR_PREFIX}${tk}" '%s' "$env_val"
+	done
+
+	return 0
+}
+
+# =============================================================================
+# Detect which config system to use and load accordingly
+# =============================================================================
+# Config-mode sentinels (avoid repeated string literals across callers).
+readonly CONFIG_MODE_JSONC="jsonc"
+readonly CONFIG_MODE_LEGACY="legacy"
+
+_AIDEVOPS_CONFIG_MODE=""
+
+_load_config() {
+	# Prefer JSONC if jq is available, defaults file exists, AND config-helper.sh
+	# functions (config_get/config_enabled) are loaded. Without the functions,
+	# having jq + defaults is not enough — callers would fail at runtime.
+	local jsonc_defaults="${JSONC_DEFAULTS:-${HOME}/.aidevops/agents/configs/aidevops.defaults.jsonc}"
+	if command -v jq &>/dev/null && [[ -r "$jsonc_defaults" ]] &&
+		type config_get &>/dev/null && type config_enabled &>/dev/null; then
+		_AIDEVOPS_CONFIG_MODE="$CONFIG_MODE_JSONC"
+		# config-helper.sh functions are already available via source above
+		# Auto-migrate legacy .conf if it exists and no JSONC user config yet
+		local jsonc_user="${JSONC_USER:-${HOME}/.config/aidevops/config.jsonc}"
+		if [[ -f "$FEATURE_TOGGLES_USER" && ! -f "$jsonc_user" ]]; then
+			if type _migrate_conf_to_jsonc &>/dev/null; then
+				if ! _migrate_conf_to_jsonc; then
+					echo "[WARN] Auto-migration from legacy config failed. Run 'aidevops config migrate' manually." >&2
+				fi
+			fi
+		fi
+	else
+		_AIDEVOPS_CONFIG_MODE="$CONFIG_MODE_LEGACY"
+		_load_feature_toggles_legacy
+	fi
+
+	return 0
+}
+
+# =============================================================================
+# Backward-compatible API: get_feature_toggle / is_feature_enabled
+# =============================================================================
+# These accept flat legacy keys (e.g. "auto_update") and route to the
+# appropriate backend (JSONC or legacy .conf).
+
+# Resolve a legacy flat key to a dotpath via _legacy_key_to_dotpath if loaded,
+# else return the key verbatim. Shared by get_feature_toggle / is_feature_enabled.
+_ft_resolve_dotpath() {
+	local key="$1"
+	if type _legacy_key_to_dotpath &>/dev/null; then
+		_legacy_key_to_dotpath "$key"
+	else
+		echo "$key"
+	fi
+	return 0
+}
+
+# Get a feature toggle / config value.
+# Usage: get_feature_toggle <key> [default]
+# Accepts both legacy flat keys and new dotpath keys.
+get_feature_toggle() {
+	local key="$1"
+	local default="${2:-}"
+
+	if [[ "$_AIDEVOPS_CONFIG_MODE" == "$CONFIG_MODE_JSONC" ]]; then
+		local dotpath
+		dotpath=$(_ft_resolve_dotpath "$key")
+		config_get "$dotpath" "$default"
+	else
+		# Legacy mode: read from _FT_* variables
+		local var_name="${_FT_VAR_PREFIX}${key}"
+		local value="${!var_name:-}"
+		if [[ -n "$value" ]]; then
+			echo "$value"
+		else
+			echo "$default"
+		fi
+	fi
+	return 0
+}
+
+# Check if a feature toggle / config boolean is enabled (true).
+# Usage: if is_feature_enabled auto_update; then ...
+is_feature_enabled() {
+	local key="$1"
+
+	if [[ "$_AIDEVOPS_CONFIG_MODE" == "$CONFIG_MODE_JSONC" ]]; then
+		local dotpath
+		dotpath=$(_ft_resolve_dotpath "$key")
+		config_enabled "$dotpath"
+		return $?
+	else
+		local value
+		value="$(get_feature_toggle "$key" "true")"
+		local lower
+		lower=$(echo "$value" | tr '[:upper:]' '[:lower:]')
+		[[ "$lower" == "true" ]]
+		return $?
+	fi
+}
+
+# =============================================================================
+# Auto-load config on source
+# =============================================================================
+# Load config immediately when this file is sourced (directly or via
+# shared-constants.sh). Ensures _AIDEVOPS_CONFIG_MODE and _FT_* variables
+# are populated before any caller tries to read them.
+_load_config


### PR DESCRIPTION
## Summary

Continues the decomposition pattern established by PR #18879 and #20037. Extracts the Configuration Loader + Feature Toggles section (_ft_env_map, _load_feature_toggles_legacy, _load_config, get_feature_toggle, is_feature_enabled) — ~200 lines, 3 caller scripts, low blast-radius — into a new focused sub-library shared-feature-toggles.sh. shared-constants.sh shrinks from 1445 → 1259 lines (-13%).

## Files Changed

.agents/scripts/shared-constants.sh,.agents/scripts/shared-feature-toggles.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean on both files; shell-init-pattern-check clean; idempotent re-source verified; all 8 functions (5 public + 3 new private helpers) available after sourcing shared-constants.sh; all 15 known toggle keys map correctly; unknown keys return empty; config mode detected as jsonc; auto-update-helper.sh and contribution-watch-helper.sh parse cleanly; approval-wrappers and agent-discovery smoke tests pass

Resolves #20063


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.80 plugin for [OpenCode](https://opencode.ai) v1.14.18 with claude-opus-4-7 spent 14m and 37,859 tokens on this with the user in an interactive session.