### PR TITLE
t2435: AIDEVOPS_OPUS_47_CONTEXT env var for opus-4.7 context override

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -347,6 +347,8 @@ User references past work ("remember when...")? Search progressively: memory rec
 
 Preserve on compaction: (1) task IDs+states, (2) batch/concurrency, (3) worktree+branch, (4) PR numbers, (5) next 3 actions, (6) blockers, (7) key paths. Checkpoint: `~/.aidevops/.agent-workspace/tmp/session-checkpoint.md`.
 
+**Opus 4.7 context override (t2435):** the framework registers `claude-opus-4-7` with a 250K context cap by default — sized so OpenCode's 80% auto-compact triggers at the 200K MRCR reliability boundary. To opt into a larger window (up to the 1M API ceiling), set `AIDEVOPS_OPUS_47_CONTEXT=<integer>` before launching OpenCode/Claude Code. The plugin warns at init when the override is active so the MRCR-collapse tradeoff is visible in logs. See `tools/ai-assistants/models-opus.md` "User override" for the full validation matrix and tradeoffs.
+
 ## Slash Command Resolution
 
 When a user invokes a slash command (`/runners`, `/full-loop`, `/routine`, etc.) or provides input that clearly maps to one, resolve the command doc in this order:

--- a/.agents/plugins/opencode-aidevops/claude-proxy.mjs
+++ b/.agents/plugins/opencode-aidevops/claude-proxy.mjs
@@ -39,6 +39,7 @@ import {
 import { streamClaudeResponse } from "./claude-proxy-streaming.mjs";
 import { buildProviderModels } from "./proxy-provider-models.mjs";
 import { jsonResponse, textResponse } from "./response-helpers.mjs";
+import { CLAUDE_MODEL_LIMITS } from "./model-limits.mjs";
 
 const CLAUDE_PROXY_DEFAULT_PORT = parseInt(process.env.CLAUDE_PROXY_PORT || "32125", 10);
 const CLAUDE_PROVIDER_ID = "claudecli";
@@ -114,16 +115,18 @@ function getClaudeProxyModels() {
     },
     {
       // Opus 4.7 — opt-in only. Framework defaults stay on 4.6.
-      // Context capped at 250K (not 1M API ceiling) due to MRCR v2 regression
+      // Context default 250K (not 1M API ceiling) due to MRCR v2 regression
       // past 200K (256K 91.9% -> 59.2%, 1M 78.3% -> 32.2%). The 250K limit
       // is sized so OpenCode's 80% auto-compact threshold lands at the 200K
       // reliability boundary, giving the full functional window before
-      // compaction. See models-opus.md.
+      // compaction. Context value is sourced from model-limits.mjs so the
+      // AIDEVOPS_OPUS_47_CONTEXT env-var override (t2435) flows through here
+      // too. See models-opus.md.
       id: "claude-opus-4-7",
       name: "Claude Opus 4.7 (via Claude CLI)",
       reasoning: true,
-      contextWindow: 250000,
-      maxTokens: 64000,
+      contextWindow: CLAUDE_MODEL_LIMITS["claude-opus-4-7"].context,
+      maxTokens: CLAUDE_MODEL_LIMITS["claude-opus-4-7"].output,
     },
   ];
 }

--- a/.agents/plugins/opencode-aidevops/config-hook.mjs
+++ b/.agents/plugins/opencode-aidevops/config-hook.mjs
@@ -12,6 +12,7 @@ import { getCursorProxyPort, registerCursorProvider } from "./cursor-proxy.mjs";
 import { getGoogleProxyPort, registerGoogleProvider } from "./google-proxy.mjs";
 import { getClaudeProxyPort, registerClaudeProvider } from "./claude-proxy.mjs";
 import { checkOpenCodeVersionDrift } from "./version-tracking.mjs";
+import { CLAUDE_MODEL_LIMITS } from "./model-limits.mjs";
 
 /**
  * Shared model definition template for Claude models managed by aidevops.
@@ -31,30 +32,14 @@ function claudeModelDef(overrides) {
 }
 
 /**
- * Single source of truth for Claude model limits (GH#18621 Finding 5).
- * Both ANTHROPIC_MODELS and CLAUDECLI_MODELS derive their `limit` from here so
- * the transport metadata stays consistent no matter which provider
- * registration path runs first.
- */
-const CLAUDE_MODEL_LIMITS = {
-  "claude-haiku-4-5":  { context: 1000000, output: 32000 },
-  "claude-sonnet-4-5": { context:  200000, output: 64000 },
-  "claude-sonnet-4-6": { context: 1000000, output: 64000 },
-  "claude-opus-4-5":   { context:  200000, output: 64000 },
-  "claude-opus-4-6":   { context: 1000000, output: 64000 },
-  // Opus 4.7 context capped at 250K (not the 1M API ceiling). Anthropic's own
-  // MRCR v2 8-needle data shows long-context retrieval collapse past 200K
-  // (256K: 91.9% -> 59.2%, 1M: 78.3% -> 32.2%). Setting the limit to 250K lets
-  // OpenCode's 80% auto-compact threshold trigger right at the 200K reliability
-  // boundary -- users get the full functional window before compaction kicks in,
-  // instead of compacting at 160K (80% of a 200K cap). See models-opus.md.
-  "claude-opus-4-7":   { context:  250000, output: 64000 },
-};
-
-/**
  * Build a provider model map from CLAUDE_MODEL_LIMITS with provider-specific
  * display names. Preserves backward compatibility with the previous
  * ANTHROPIC_MODELS / CLAUDECLI_MODELS shapes.
+ *
+ * Note: CLAUDE_MODEL_LIMITS lives in `model-limits.mjs` so claude-proxy.mjs
+ * (the Claude CLI proxy provider drift-copy that previously hardcoded the
+ * same numbers) can share it. See model-limits.mjs for the env-var override
+ * (AIDEVOPS_OPUS_47_CONTEXT) and the MRCR rationale.
  * @param {Record<string,string>} names - model id → display name
  * @returns {Record<string,object>}
  */

--- a/.agents/plugins/opencode-aidevops/model-limits.mjs
+++ b/.agents/plugins/opencode-aidevops/model-limits.mjs
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+//
+// model-limits.mjs — single source of truth for Claude model context/output
+// limits, with optional user override for the opus-4-7 context window.
+//
+// Why this module exists (t2435):
+//   The opus-4-7 context window is intentionally capped at 250K (not the 1M
+//   API ceiling) so OpenCode's 80% auto-compact threshold triggers right at
+//   the 200K MRCR reliability boundary. That default protects most users
+//   from coherence collapse past 200K. Some users want to opt into the full
+//   1M window anyway — to experiment, or because their prompts don't hit
+//   the cold-retrieval failure mode. The AIDEVOPS_OPUS_47_CONTEXT env var
+//   is the opt-in.
+//
+//   Previously the limits table lived inline in config-hook.mjs and a
+//   drift-prone copy lived in claude-proxy.mjs (`getClaudeProxyModels`).
+//   Centralising here also fixes the drift surface flagged in t1960's PR.
+// ---------------------------------------------------------------------------
+
+/** Default opus-4-7 context window. See models-opus.md for the MRCR rationale. */
+export const OPUS_47_CONTEXT_DEFAULT = 250000;
+
+/** Hard upper bound — Anthropic's API ceiling for opus-4-7. */
+export const OPUS_47_CONTEXT_MAX = 1000000;
+
+/**
+ * Resolve the opus-4-7 context window from env, falling back to the default.
+ * Reads `process.env.AIDEVOPS_OPUS_47_CONTEXT` each call (so tests can mutate
+ * env between invocations without re-importing the module).
+ *
+ * Validation:
+ *   - Unset / empty → default (250000)
+ *   - Non-numeric  → default (250000), warn at module-load time
+ *   - <= 0         → default (250000), warn at module-load time
+ *   - > MAX        → clamped to MAX (1000000), warn at module-load time
+ *   - Otherwise    → the parsed integer
+ *
+ * @returns {number} resolved context window in tokens
+ */
+export function resolveOpus47Context() {
+  const raw = process.env.AIDEVOPS_OPUS_47_CONTEXT;
+  if (raw === undefined || raw === "") return OPUS_47_CONTEXT_DEFAULT;
+
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return OPUS_47_CONTEXT_DEFAULT;
+  if (parsed > OPUS_47_CONTEXT_MAX) return OPUS_47_CONTEXT_MAX;
+  return parsed;
+}
+
+/**
+ * Describe what the env var did at module load — used for the one-shot warn.
+ * Returns null when no override was attempted (silent default path).
+ *
+ * @returns {{kind: "applied"|"clamped"|"invalid", raw: string, resolved: number} | null}
+ */
+export function describeOpus47Override() {
+  const raw = process.env.AIDEVOPS_OPUS_47_CONTEXT;
+  if (raw === undefined || raw === "") return null;
+
+  const parsed = Number.parseInt(raw, 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return { kind: "invalid", raw, resolved: OPUS_47_CONTEXT_DEFAULT };
+  }
+  if (parsed > OPUS_47_CONTEXT_MAX) {
+    return { kind: "clamped", raw, resolved: OPUS_47_CONTEXT_MAX };
+  }
+  if (parsed === OPUS_47_CONTEXT_DEFAULT) {
+    // Set explicitly to the default — treat as a no-op, no warn.
+    return null;
+  }
+  return { kind: "applied", raw, resolved: parsed };
+}
+
+/**
+ * Single source of truth for Claude model limits.
+ * Both the anthropic provider models (config-hook.mjs) and the Claude CLI
+ * proxy models (claude-proxy.mjs) derive their context/output values from
+ * this table.
+ */
+export const CLAUDE_MODEL_LIMITS = {
+  "claude-haiku-4-5":  { context: 1000000, output: 32000 },
+  "claude-sonnet-4-5": { context:  200000, output: 64000 },
+  "claude-sonnet-4-6": { context: 1000000, output: 64000 },
+  "claude-opus-4-5":   { context:  200000, output: 64000 },
+  "claude-opus-4-6":   { context: 1000000, output: 64000 },
+  // Opus 4.7 context default 250K (not the 1M API ceiling). Anthropic's own
+  // MRCR v2 8-needle data shows long-context retrieval collapse past 200K
+  // (256K: 91.9% -> 59.2%, 1M: 78.3% -> 32.2%). Setting the limit to 250K lets
+  // OpenCode's 80% auto-compact threshold trigger right at the 200K reliability
+  // boundary -- users get the full functional window before compaction kicks in,
+  // instead of compacting at 160K (80% of a 200K cap). Override via env var
+  // AIDEVOPS_OPUS_47_CONTEXT=<integer> if you understand the MRCR tradeoff.
+  // See tools/ai-assistants/models-opus.md for the full rationale.
+  "claude-opus-4-7":   { context: resolveOpus47Context(), output: 64000 },
+};
+
+// One-shot warn at module load when the env override changed something.
+// Module load runs once per process (Node caches), so this won't spam.
+const _override = describeOpus47Override();
+if (_override) {
+  if (_override.kind === "applied") {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[aidevops] AIDEVOPS_OPUS_47_CONTEXT=${_override.raw} — opus-4-7 context overridden to ${_override.resolved} ` +
+      `(default ${OPUS_47_CONTEXT_DEFAULT}). Be aware: MRCR v2 8-needle retrieval drops ` +
+      `from 91.9% at 256K to 59.2%, and to 32.2% at 1M. See models-opus.md.`
+    );
+  } else if (_override.kind === "clamped") {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[aidevops] AIDEVOPS_OPUS_47_CONTEXT=${_override.raw} exceeds the 1M API ceiling. ` +
+      `Clamped to ${OPUS_47_CONTEXT_MAX}.`
+    );
+  } else {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[aidevops] AIDEVOPS_OPUS_47_CONTEXT=${_override.raw} is not a positive integer. ` +
+      `Ignored — using default ${OPUS_47_CONTEXT_DEFAULT}.`
+    );
+  }
+}

--- a/.agents/plugins/opencode-aidevops/tests/test-model-limits.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-model-limits.mjs
@@ -1,0 +1,207 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+//
+// Tests for model-limits.mjs (t2435 — AIDEVOPS_OPUS_47_CONTEXT env override).
+//
+//   node --test .agents/plugins/opencode-aidevops/tests/test-model-limits.mjs
+//
+// Scope:
+//   - resolveOpus47Context() honours env var across the full validity matrix
+//   - describeOpus47Override() returns the right kind for each input class
+//   - CLAUDE_MODEL_LIMITS table shape is intact (regression guard)
+// ---------------------------------------------------------------------------
+
+import { test, describe, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  resolveOpus47Context,
+  describeOpus47Override,
+  OPUS_47_CONTEXT_DEFAULT,
+  OPUS_47_CONTEXT_MAX,
+  CLAUDE_MODEL_LIMITS,
+} from "../model-limits.mjs";
+
+// ---------------------------------------------------------------------------
+// resolveOpus47Context — input → output matrix
+// ---------------------------------------------------------------------------
+
+describe("resolveOpus47Context", () => {
+  let originalEnv;
+
+  beforeEach(() => {
+    originalEnv = process.env.AIDEVOPS_OPUS_47_CONTEXT;
+    delete process.env.AIDEVOPS_OPUS_47_CONTEXT;
+  });
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.AIDEVOPS_OPUS_47_CONTEXT = originalEnv;
+    } else {
+      delete process.env.AIDEVOPS_OPUS_47_CONTEXT;
+    }
+  });
+
+  test("unset env → default 250000", () => {
+    assert.equal(resolveOpus47Context(), OPUS_47_CONTEXT_DEFAULT);
+    assert.equal(OPUS_47_CONTEXT_DEFAULT, 250000);
+  });
+
+  test("empty string → default 250000", () => {
+    process.env.AIDEVOPS_OPUS_47_CONTEXT = "";
+    assert.equal(resolveOpus47Context(), OPUS_47_CONTEXT_DEFAULT);
+  });
+
+  test("valid override 1000000 → 1000000", () => {
+    process.env.AIDEVOPS_OPUS_47_CONTEXT = "1000000";
+    assert.equal(resolveOpus47Context(), 1000000);
+  });
+
+  test("valid override 500000 → 500000", () => {
+    process.env.AIDEVOPS_OPUS_47_CONTEXT = "500000";
+    assert.equal(resolveOpus47Context(), 500000);
+  });
+
+  test("zero → default 250000 (treated as invalid)", () => {
+    process.env.AIDEVOPS_OPUS_47_CONTEXT = "0";
+    assert.equal(resolveOpus47Context(), OPUS_47_CONTEXT_DEFAULT);
+  });
+
+  test("negative → default 250000", () => {
+    process.env.AIDEVOPS_OPUS_47_CONTEXT = "-100";
+    assert.equal(resolveOpus47Context(), OPUS_47_CONTEXT_DEFAULT);
+  });
+
+  test("non-numeric → default 250000", () => {
+    process.env.AIDEVOPS_OPUS_47_CONTEXT = "foo";
+    assert.equal(resolveOpus47Context(), OPUS_47_CONTEXT_DEFAULT);
+  });
+
+  test("garbage with leading digits → parsed as the leading int", () => {
+    // parseInt("123abc", 10) === 123. We don't try to be stricter than
+    // parseInt — if a user writes garbage that parses to a positive int,
+    // they get that int. The MRCR-collapse warning will educate them.
+    process.env.AIDEVOPS_OPUS_47_CONTEXT = "300000abc";
+    assert.equal(resolveOpus47Context(), 300000);
+  });
+
+  test("above MAX → clamped to OPUS_47_CONTEXT_MAX", () => {
+    process.env.AIDEVOPS_OPUS_47_CONTEXT = "5000000";
+    assert.equal(resolveOpus47Context(), OPUS_47_CONTEXT_MAX);
+    assert.equal(OPUS_47_CONTEXT_MAX, 1000000);
+  });
+
+  test("at MAX exactly → MAX", () => {
+    process.env.AIDEVOPS_OPUS_47_CONTEXT = "1000000";
+    assert.equal(resolveOpus47Context(), OPUS_47_CONTEXT_MAX);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// describeOpus47Override — classification of env-var states
+// ---------------------------------------------------------------------------
+
+describe("describeOpus47Override", () => {
+  let originalEnv;
+
+  beforeEach(() => {
+    originalEnv = process.env.AIDEVOPS_OPUS_47_CONTEXT;
+    delete process.env.AIDEVOPS_OPUS_47_CONTEXT;
+  });
+
+  afterEach(() => {
+    if (originalEnv !== undefined) {
+      process.env.AIDEVOPS_OPUS_47_CONTEXT = originalEnv;
+    } else {
+      delete process.env.AIDEVOPS_OPUS_47_CONTEXT;
+    }
+  });
+
+  test("unset → null (silent default path, no warn)", () => {
+    assert.equal(describeOpus47Override(), null);
+  });
+
+  test("empty → null (silent default path, no warn)", () => {
+    process.env.AIDEVOPS_OPUS_47_CONTEXT = "";
+    assert.equal(describeOpus47Override(), null);
+  });
+
+  test("explicit default → null (no-op, no warn)", () => {
+    process.env.AIDEVOPS_OPUS_47_CONTEXT = "250000";
+    assert.equal(describeOpus47Override(), null);
+  });
+
+  test("valid override → kind=applied", () => {
+    process.env.AIDEVOPS_OPUS_47_CONTEXT = "1000000";
+    const desc = describeOpus47Override();
+    assert.deepEqual(desc, { kind: "applied", raw: "1000000", resolved: 1000000 });
+  });
+
+  test("above MAX → kind=clamped", () => {
+    process.env.AIDEVOPS_OPUS_47_CONTEXT = "5000000";
+    const desc = describeOpus47Override();
+    assert.deepEqual(desc, { kind: "clamped", raw: "5000000", resolved: OPUS_47_CONTEXT_MAX });
+  });
+
+  test("non-numeric → kind=invalid", () => {
+    process.env.AIDEVOPS_OPUS_47_CONTEXT = "foo";
+    const desc = describeOpus47Override();
+    assert.deepEqual(desc, { kind: "invalid", raw: "foo", resolved: OPUS_47_CONTEXT_DEFAULT });
+  });
+
+  test("zero → kind=invalid", () => {
+    process.env.AIDEVOPS_OPUS_47_CONTEXT = "0";
+    const desc = describeOpus47Override();
+    assert.deepEqual(desc, { kind: "invalid", raw: "0", resolved: OPUS_47_CONTEXT_DEFAULT });
+  });
+
+  test("negative → kind=invalid", () => {
+    process.env.AIDEVOPS_OPUS_47_CONTEXT = "-5";
+    const desc = describeOpus47Override();
+    assert.deepEqual(desc, { kind: "invalid", raw: "-5", resolved: OPUS_47_CONTEXT_DEFAULT });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// CLAUDE_MODEL_LIMITS — regression guard on table shape
+// ---------------------------------------------------------------------------
+
+describe("CLAUDE_MODEL_LIMITS table", () => {
+  test("contains all six expected Claude model ids", () => {
+    const expected = [
+      "claude-haiku-4-5",
+      "claude-sonnet-4-5",
+      "claude-sonnet-4-6",
+      "claude-opus-4-5",
+      "claude-opus-4-6",
+      "claude-opus-4-7",
+    ];
+    for (const id of expected) {
+      assert.ok(
+        CLAUDE_MODEL_LIMITS[id],
+        `missing limit entry for ${id}`,
+      );
+      assert.equal(typeof CLAUDE_MODEL_LIMITS[id].context, "number");
+      assert.equal(typeof CLAUDE_MODEL_LIMITS[id].output, "number");
+      assert.ok(CLAUDE_MODEL_LIMITS[id].context > 0);
+      assert.ok(CLAUDE_MODEL_LIMITS[id].output > 0);
+    }
+  });
+
+  test("opus-4-7 context matches resolveOpus47Context() at module-load time", () => {
+    // The table is computed once at module load. Confirm it didn't drift
+    // from the resolver function.
+    assert.equal(
+      CLAUDE_MODEL_LIMITS["claude-opus-4-7"].context,
+      resolveOpus47Context(),
+      "opus-4-7 context in table != resolveOpus47Context()",
+    );
+  });
+
+  test("non-opus-4-7 entries are not affected by env var", () => {
+    // Sanity: the env var is opus-4-7-specific. Other models keep their
+    // hard-coded limits regardless.
+    assert.equal(CLAUDE_MODEL_LIMITS["claude-opus-4-6"].context, 1000000);
+    assert.equal(CLAUDE_MODEL_LIMITS["claude-haiku-4-5"].context, 1000000);
+  });
+});

--- a/.agents/tools/ai-assistants/models-opus.md
+++ b/.agents/tools/ai-assistants/models-opus.md
@@ -85,6 +85,47 @@ Sessions get the full still-functional window before compaction kicks in,
 instead of compacting prematurely at 160K (what an unaligned 200K cap
 produces).
 
+#### User override: `AIDEVOPS_OPUS_47_CONTEXT` (t2435)
+
+The 250K cap is the right *default*, but it is not the right value for every
+user. If you want to opt into a larger context (up to the 1M API ceiling),
+set the env var before launching OpenCode/Claude Code:
+
+```bash
+# Use the full 1M API ceiling
+export AIDEVOPS_OPUS_47_CONTEXT=1000000
+
+# Or a custom value somewhere between
+export AIDEVOPS_OPUS_47_CONTEXT=500000
+```
+
+Both the built-in `anthropic` provider (via the OAuth pool) and the
+`claudecli` provider read this value via the shared `model-limits.mjs`
+helper, so OpenCode's 80% auto-compact threshold moves with it
+(e.g. 1000000 → ~800K compaction trigger).
+
+**Validation:**
+
+- Unset / empty / non-numeric / `<=0` → default 250000 (silent for unset/empty;
+  warned at plugin init for invalid values).
+- `> 1000000` → clamped to the 1M API ceiling, with a warning.
+- Otherwise → the integer is used verbatim, with an MRCR-collapse warning at
+  plugin init so the cost is visible in your logs.
+
+**Tradeoffs you accept by overriding:**
+
+- MRCR v2 8-needle retrieval drops from 91.9% (256K) → 59.2% (256K, 4.7) →
+  32.2% (1M, 4.7). Your worker may "lose the plot" mid-session as the cold
+  context grows beyond the reliability boundary.
+- 4.7's tokenizer adds 20-60% to English token counts at identical pricing.
+  A 1M-token session costs 1.2-1.6x what the same content would cost on 4.6.
+- Default behaviour is unchanged for all other Claude models — the override
+  is opus-4-7-only.
+
+If you set this and find sessions degrading, unset the env var (or reduce
+the value) and restart OpenCode. The cap exists for a reason; treat the
+override as a calibrated experiment, not a free upgrade.
+
 ### When to apply `model:opus-4-7`
 
 - **Short brief + high-reasoning task.** Architecture calls, security


### PR DESCRIPTION
## Summary

Adds AIDEVOPS_OPUS_47_CONTEXT env var so users can opt into a larger opus-4.7 context window (default 250K, configurable up to the 1M API ceiling). Default behaviour unchanged. Centralises the limits table in a new model-limits.mjs module, eliminating drift between config-hook.mjs and claude-proxy.mjs.

## Files Changed

.agents/AGENTS.md,.agents/plugins/opencode-aidevops/claude-proxy.mjs,.agents/plugins/opencode-aidevops/config-hook.mjs,.agents/plugins/opencode-aidevops/model-limits.mjs,.agents/plugins/opencode-aidevops/tests/test-model-limits.mjs,.agents/tools/ai-assistants/models-opus.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 21 new node:test cases pass. All 53 prior plugin tests still pass (no regression). End-to-end smoke test with AIDEVOPS_OPUS_47_CONTEXT=1000000 confirms warning fires and value flows through. node --check passes for all modified .mjs files. markdownlint clean. qlty smells clean on the new model-limits.mjs file.

Resolves #20078


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.81 plugin for [OpenCode](https://opencode.ai) v1.14.18 with claude-opus-4-7 spent 13m and 34,466 tokens on this with the user in an interactive session.