### PR TITLE
t2434: fix(upgrade-planning): preserve tasks across all 6 sections

### DIFF
--- a/.agents/scripts/tests/test-upgrade-planning-sections.sh
+++ b/.agents/scripts/tests/test-upgrade-planning-sections.sh
@@ -1,0 +1,404 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-upgrade-planning-sections.sh — Regression test for t2434 (GH#20077)
+#
+# Verifies that _upgrade_todo preserves tasks from ALL 6 template sections
+# (Ready, Backlog, In Progress, In Review, Done, Declined), not just Backlog.
+#
+# Bug being regression-tested: prior to t2434, _upgrade_todo extracted tasks
+# only from "## Backlog" and silently dropped the other 5 sections into
+# TODO.md.bak. On awardsapp (2026-04-20) this ate 141 completed "[x]" rows —
+# audit-trail data NOT reconstructable from GitHub.
+#
+# Pattern modelled on tests/test-init-scope.sh:
+#   - Extract the target functions from aidevops.sh via sed
+#   - eval them into the test shell
+#   - Stub print_info / print_success / sed_inplace
+#   - Build synthetic fixtures in a temp dir
+#   - Drive the upgrade and assert survivors
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+AIDEVOPS_SH="$SCRIPT_DIR/../../../aidevops.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+
+print_result() {
+	local test_name="$1" passed="$2" message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	[[ -n "$message" ]] && printf '       %s\n' "$message"
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+cleanup() {
+	[[ -n "${TEST_ROOT:-}" && -d "${TEST_ROOT}" ]] && rm -rf "$TEST_ROOT"
+	return 0
+}
+trap cleanup EXIT
+
+if [[ ! -f "$AIDEVOPS_SH" ]]; then
+	echo "ERROR: Cannot find aidevops.sh at $AIDEVOPS_SH" >&2
+	exit 1
+fi
+
+# Stub the aidevops.sh globals the target functions depend on. The test runs
+# purely against the extracted function bodies — no CLI side effects.
+print_info() { return 0; }
+print_success() { return 0; }
+print_warning() { return 0; }
+print_error() { return 0; }
+sed_inplace() { if [[ "$(uname)" == "Darwin" ]]; then sed -i '' "$@"; else sed -i "$@"; fi; }
+
+# Extract target function bodies from aidevops.sh and eval them into this shell.
+_extract_function() {
+	local name="$1"
+	sed -n "/^${name}() {/,/^}/p" "$AIDEVOPS_SH"
+	return 0
+}
+
+for fn in _extract_todo_section _filter_todo_placeholders _insert_after_toon_marker \
+	_upgrade_todo_preserve_sections _upgrade_todo_reinsert_sections _upgrade_todo; do
+	body=$(_extract_function "$fn")
+	if [[ -z "$body" ]]; then
+		echo "ERROR: could not extract $fn from aidevops.sh" >&2
+		exit 1
+	fi
+	eval "$body"
+done
+
+# ---- Fixtures ----
+
+# Old-format TODO.md with tasks in ALL 6 sections. Includes Format-block
+# placeholders (tXXX/tYYY/tZZZ) that must be filtered out.
+write_old_todo() {
+	local path="$1"
+	cat >"$path" <<'EOF'
+# TODO
+
+Header text.
+
+## Format
+
+<!-- Placeholders that must be filtered out during upgrade -->
+- [ ] tXXX Placeholder task @user #tag ~30m logged:2026-01-01
+- [ ] tYYY Another placeholder ~15m
+- [x] tZZZ Fake completed placeholder
+
+```
+- [ ] tAAA Code-block content also filtered
+```
+
+<!--TOON:meta{version,format,updated}:
+1.0,todo-md+toon,2026-01-01
+-->
+
+## Ready
+
+- [ ] t100 Ready task one @alice #ready ~1h logged:2026-04-01
+- [ ] t101 Ready task two @bob #ready ~30m logged:2026-04-02
+
+## Backlog
+
+- [ ] t200 Backlog task one @alice #feat ~2h logged:2026-04-03
+- [ ] t201 Backlog task two @bob #bug ~45m logged:2026-04-04
+- [ ] t202 Backlog task three @alice ~1h logged:2026-04-05
+
+## In Progress
+
+- [ ] t300 Work in progress @alice ~4h started:2026-04-10T09:00:00Z
+
+## In Review
+
+- [ ] t400 PR open @bob ~3h pr:#9001 started:2026-04-11
+
+## Done
+
+- [x] t500 Done task one @alice ~2h actual:1h45m completed:2026-04-12
+- [x] t501 Done task two @bob ~30m actual:25m completed:2026-04-13
+- [x] t502 Done task three @alice ~1h completed:2026-04-14
+
+## Declined
+
+- [-] t600 Declined as scope creep @alice reason:scope
+
+EOF
+	return 0
+}
+
+# Minimal new-format template with all 6 TOON section markers plus the front
+# matter separators aidevops.sh expects (two --- lines).
+write_new_template() {
+	local path="$1"
+	cat >"$path" <<'EOF'
+---
+mode: subagent
+---
+
+# TODO
+
+Template intro.
+
+## Format
+
+<!-- Format-block placeholders. Upgrade must NOT promote these into real sections. -->
+- [ ] tXXX Template placeholder ~30m
+- [ ] tYYY Another placeholder
+
+<!--TOON:meta{version,format,updated}:
+1.1,todo-md+toon,{{DATE}}
+-->
+
+## Ready
+
+<!--TOON:ready[0]{id,desc,owner,tags,est,risk,logged,status}:
+-->
+
+## Backlog
+
+<!--TOON:backlog[0]{id,desc,owner,tags,est,risk,logged,status}:
+-->
+
+## In Progress
+
+<!--TOON:in_progress[0]{id,desc,owner,tags,est,risk,logged,started,status}:
+-->
+
+## In Review
+
+<!--TOON:in_review[0]{id,desc,owner,tags,est,pr_url,started,pr_created,status}:
+-->
+
+## Done
+
+<!--TOON:done[0]{id,desc,owner,tags,est,actual,logged,started,completed,status}:
+-->
+
+## Declined
+
+<!--TOON:declined[0]{id,desc,reason,logged,status}:
+-->
+EOF
+	return 0
+}
+
+# ---- Assertion helpers ----
+
+count_tasks() {
+	local file="$1"
+	[[ -f "$file" ]] || { echo 0; return 0; }
+	local n
+	# grep -c prints "0" on no-matches AND exits 1; swallow the exit with || true
+	# so we don't end up with both grep's "0" and a fallback "0" on stdout.
+	n=$(grep -cE '^- \[[ x-]\] t[0-9]' "$file" 2>/dev/null || true)
+	echo "${n:-0}"
+}
+
+# Confirm the task line with the given ID appears inside the given section.
+# "Inside" means: after the `## <section>` header and before the next `## `.
+task_in_section() {
+	local file="$1" section="$2" task_id="$3"
+	if awk -v target="## $section" -v tid="$task_id" '
+		$0 == target { found=1; next }
+		found && /^## / { found=0 }
+		found && $0 ~ ("^- \\[[ x-]\\] " tid "( |$)") { print "HIT"; exit }
+	' "$file" | grep -q HIT; then
+		return 0
+	fi
+	return 1
+}
+
+# ---- Tests ----
+
+test_extract_todo_section() {
+	echo ""
+	echo "=== Testing _extract_todo_section ==="
+	local src="$TEST_ROOT/fixture.md"
+	write_old_todo "$src"
+
+	local out
+	out=$(_extract_todo_section "$src" "Backlog")
+	echo "$out" | grep -q "t200 Backlog task one" \
+		&& print_result "Backlog extraction includes t200" 0 \
+		|| print_result "Backlog extraction includes t200" 1 "$(printf '%s' "$out" | head -3)"
+
+	# Must not leak tasks from adjacent sections
+	if echo "$out" | grep -q "t300 "; then
+		print_result "Backlog extraction stops before In Progress" 1 "t300 leaked in"
+	else
+		print_result "Backlog extraction stops before In Progress" 0
+	fi
+
+	# Format block must be skipped entirely
+	out=$(_extract_todo_section "$src" "Ready")
+	if echo "$out" | grep -qE "^- \[[ x-]\] tXXX"; then
+		print_result "Format placeholders filtered at extraction" 1 "tXXX leaked"
+	else
+		print_result "Format placeholders filtered at extraction" 0
+	fi
+	return 0
+}
+
+test_filter_placeholders() {
+	echo ""
+	echo "=== Testing _filter_todo_placeholders ==="
+	local out
+	out=$(printf '%s\n' \
+		"- [ ] tXXX placeholder" \
+		"- [ ] tYYY placeholder" \
+		"- [ ] t123 real task" \
+		"- [x] t456.1 subtask done" \
+		"not a task line" \
+		| _filter_todo_placeholders)
+	echo "$out" | grep -q "t123" && print_result "Real t123 kept" 0 || print_result "Real t123 kept" 1
+	echo "$out" | grep -q "t456.1" && print_result "Subtask t456.1 kept" 0 || print_result "Subtask t456.1 kept" 1
+	echo "$out" | grep -q "tXXX" && print_result "tXXX filtered" 1 "tXXX leaked" || print_result "tXXX filtered" 0
+	echo "$out" | grep -q "tYYY" && print_result "tYYY filtered" 1 "tYYY leaked" || print_result "tYYY filtered" 0
+	echo "$out" | grep -q "not a task line" && print_result "Non-task line kept" 0 || print_result "Non-task line kept" 1
+	return 0
+}
+
+test_upgrade_preserves_all_sections() {
+	echo ""
+	echo "=== Testing _upgrade_todo preserves all 6 sections ==="
+	local todo="$TEST_ROOT/TODO.md" template="$TEST_ROOT/template.md"
+	write_old_todo "$todo"
+	write_new_template "$template"
+
+	local before_count after_count
+	before_count=$(count_tasks "$todo")
+
+	_upgrade_todo "$todo" "$template" "true"
+
+	after_count=$(count_tasks "$todo")
+
+	# Before had 4 Format-block placeholders + 11 real tasks = 15 task-like lines.
+	# The 4 Format placeholders MUST NOT appear in the upgraded file.
+	# Real tasks = 2 Ready + 3 Backlog + 1 In Progress + 1 In Review + 3 Done + 1 Declined = 11.
+	if [[ "$after_count" -eq 11 ]]; then
+		print_result "All 11 real tasks survived upgrade (${before_count} -> ${after_count})" 0
+	else
+		print_result "Task count preserved" 1 "expected 11, got ${after_count}"
+	fi
+
+	# Every real task must land in its original section
+	task_in_section "$todo" "Ready" "t100" \
+		&& print_result "t100 in Ready" 0 || print_result "t100 in Ready" 1
+	task_in_section "$todo" "Ready" "t101" \
+		&& print_result "t101 in Ready" 0 || print_result "t101 in Ready" 1
+	task_in_section "$todo" "Backlog" "t200" \
+		&& print_result "t200 in Backlog" 0 || print_result "t200 in Backlog" 1
+	task_in_section "$todo" "Backlog" "t201" \
+		&& print_result "t201 in Backlog" 0 || print_result "t201 in Backlog" 1
+	task_in_section "$todo" "Backlog" "t202" \
+		&& print_result "t202 in Backlog" 0 || print_result "t202 in Backlog" 1
+	task_in_section "$todo" "In Progress" "t300" \
+		&& print_result "t300 in In Progress" 0 || print_result "t300 in In Progress" 1
+	task_in_section "$todo" "In Review" "t400" \
+		&& print_result "t400 in In Review" 0 || print_result "t400 in In Review" 1
+	task_in_section "$todo" "Done" "t500" \
+		&& print_result "t500 in Done" 0 || print_result "t500 in Done" 1
+	task_in_section "$todo" "Done" "t501" \
+		&& print_result "t501 in Done" 0 || print_result "t501 in Done" 1
+	task_in_section "$todo" "Done" "t502" \
+		&& print_result "t502 in Done" 0 || print_result "t502 in Done" 1
+	task_in_section "$todo" "Declined" "t600" \
+		&& print_result "t600 in Declined" 0 || print_result "t600 in Declined" 1
+
+	# Regression assertion: 141-row Done drop must not recur
+	local done_count
+	done_count=$(awk '
+		$0 == "## Done" { found=1; next }
+		found && /^## / { exit }
+		found && /^- \[[ x-]\] t[0-9]/ { n++ }
+		END { print n+0 }
+	' "$todo")
+	if [[ "$done_count" -eq 3 ]]; then
+		print_result "Done section retains all 3 completed tasks (t2434 regression)" 0
+	else
+		print_result "Done section retains all 3 completed tasks (t2434 regression)" 1 \
+			"expected 3, got $done_count"
+	fi
+
+	# Placeholders must not promote into real sections. Note: the NEW template's
+	# own ## Format block legitimately contains tXXX/tYYY examples — so a naive
+	# grep of the whole file would false-positive. Scope the check to sections
+	# after ## Format.
+	local leaked
+	leaked=$(awk '
+		/^## Format/ { in_format=1; next }
+		in_format && /^## / { in_format=0 }
+		!in_format && /^- \[[ x-]\] t(XXX|YYY|ZZZ)( |$)/ { print }
+	' "$todo")
+	if [[ -z "$leaked" ]]; then
+		print_result "Format placeholders not promoted to sections" 0
+	else
+		print_result "Format placeholders not promoted to sections" 1 "leaked: ${leaked}"
+	fi
+
+	# Backup created
+	[[ -f "${todo}.bak" ]] \
+		&& print_result "Backup TODO.md.bak created" 0 \
+		|| print_result "Backup TODO.md.bak created" 1
+	return 0
+}
+
+test_upgrade_empty_todo() {
+	echo ""
+	echo "=== Testing _upgrade_todo on empty TODO.md ==="
+	local todo="$TEST_ROOT/empty.md" template="$TEST_ROOT/template.md"
+	write_new_template "$template"
+	cat >"$todo" <<'EOF'
+# TODO
+
+## Backlog
+
+## Done
+
+EOF
+	_upgrade_todo "$todo" "$template" "false"
+	local n
+	n=$(count_tasks "$todo")
+	if [[ "$n" -eq 0 ]]; then
+		print_result "Empty TODO upgrades to empty TODO" 0
+	else
+		print_result "Empty TODO upgrades to empty TODO" 1 "unexpected $n tasks after upgrade"
+	fi
+	# Must still have TOON markers
+	grep -q "<!--TOON:backlog" "$todo" \
+		&& print_result "New template markers present on empty upgrade" 0 \
+		|| print_result "New template markers present on empty upgrade" 1
+	return 0
+}
+
+# ---- Run all tests ----
+
+echo "test-upgrade-planning-sections.sh — _upgrade_todo multi-section preservation (t2434)"
+echo "===================================================================================="
+
+TEST_ROOT=$(mktemp -d)
+
+test_extract_todo_section
+test_filter_placeholders
+test_upgrade_preserves_all_sections
+test_upgrade_empty_todo
+
+echo ""
+echo "===================================================================================="
+echo "Results: $TESTS_RUN tests, $TESTS_FAILED failures"
+
+[[ $TESTS_FAILED -gt 0 ]] && exit 1
+exit 0

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -2592,44 +2592,118 @@ _upgrade_check_version() {
 	fi
 }
 
+# t2434: Extract lines under "## <section>" until the next "## " header.
+# Skips ## Format block entirely (its content is documentation, not tasks).
+# Skips fenced code blocks.
+# Exact-match on the section header — no regex escaping concerns.
+_extract_todo_section() {
+	local file="$1" section="$2"
+	awk -v target="## $section" '
+		/^## Format/ { in_format=1; next }
+		in_format && /^## / { in_format=0 }
+		in_format { next }
+		/^```/ { in_codeblock = !in_codeblock; next }
+		in_codeblock { next }
+		$0 == target { found=1; next }
+		found && /^## / { exit }
+		found
+	' "$file" 2>/dev/null || echo ""
+}
+
+# t2434: Filter stdin, removing only the literal Format-block placeholder IDs
+# (tXXX, tYYY, tZZZ). Real-world repos have historic IDs that don't follow the
+# strict t<digits> shape (e.g. "t059b", "t043-merge" from awardsapp) — we must
+# preserve those. A blocklist is safer than an allowlist here: extraction
+# already skips the Format section, so the filter is a secondary guard rather
+# than primary validation.
+_filter_todo_placeholders() {
+	awk '
+		!/^- \[[ x-]\] t/ { print; next }
+		{
+			id = $0
+			sub(/^- \[[ x-]\] /, "", id)
+			sub(/ .*/, "", id)
+			if (id == "tXXX" || id == "tYYY" || id == "tZZZ") next
+			print
+		}
+	'
+}
+
+# t2434: Insert content_file into target_file immediately after the closing
+# "-->" of the named TOON marker block (<!--TOON:<tag>...-->).
+# Idempotent only in the sense that each call inserts once per marker; repeated
+# calls would stack insertions. Intended to be called once per tag per upgrade.
+_insert_after_toon_marker() {
+	local target_file="$1" toon_tag="$2" content_file="$3"
+	local temp_file="${target_file}.insert"
+	local marker_open="<!--TOON:${toon_tag}"
+	local in_marker=false
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		[[ "$line" == *"$marker_open"* ]] && in_marker=true
+		if [[ "$in_marker" == true && "$line" == "-->" ]]; then
+			echo "$line"
+			echo ""
+			cat "$content_file"
+			in_marker=false
+			continue
+		fi
+		echo "$line"
+	done <"$target_file" >"$temp_file"
+	mv "$temp_file" "$target_file"
+}
+
+# t2434: Preserve each of the 6 task sections into $workdir/<tag>.txt for
+# later re-insertion after the template is applied. Placeholder filter runs
+# per section so Format-block tXXX-style examples never reach the new file.
+_upgrade_todo_preserve_sections() {
+	local todo_file="$1" workdir="$2"
+	local sections=("Ready" "Backlog" "In Progress" "In Review" "Done" "Declined")
+	local tags=("ready" "backlog" "in_progress" "in_review" "done" "declined")
+	local i=0
+	while [[ $i -lt ${#sections[@]} ]]; do
+		local section="${sections[$i]}" tag="${tags[$i]}"
+		local content
+		content=$(_extract_todo_section "$todo_file" "$section")
+		if [[ -n "$content" ]]; then
+			content=$(printf '%s\n' "$content" | _filter_todo_placeholders)
+			[[ -n "$content" ]] && printf '%s\n' "$content" >"$workdir/${tag}.txt"
+		fi
+		i=$((i + 1))
+	done
+	return 0
+}
+
+# t2434: Re-insert preserved section content after its matching TOON marker
+# in the freshly-applied new template. Caller is responsible for counting
+# merged tasks from the final file — keeping count out of the hot loop avoids
+# subshell/arithmetic edge cases under `set -u` when content contains `GH#`-
+# style IDs that don't match a naive `t[0-9]` count pattern.
+_upgrade_todo_reinsert_sections() {
+	local todo_file="$1" workdir="$2"
+	local tags=("ready" "backlog" "in_progress" "in_review" "done" "declined")
+	local tag content_file
+	for tag in "${tags[@]}"; do
+		content_file="$workdir/${tag}.txt"
+		[[ -f "$content_file" && -s "$content_file" ]] || continue
+		grep -q "<!--TOON:${tag}" "$todo_file" || continue
+		_insert_after_toon_marker "$todo_file" "$tag" "$content_file"
+	done
+	return 0
+}
+
+# t2434: Upgrade TODO.md to the latest TOON-enhanced template, preserving
+# tasks from all 6 sections (Ready, Backlog, In Progress, In Review, Done,
+# Declined). Prior behaviour (GH#20077) only preserved Backlog and silently
+# dropped the other 5 sections into TODO.md.bak, losing audit-trail data.
 _upgrade_todo() {
 	local todo_file="$1" todo_template="$2" backup="$3"
 	print_info "Upgrading TODO.md..."
-	local existing_tasks=""
+	local workdir=""
+	workdir=$(mktemp -d)
+	# shellcheck disable=SC2064  # intentional $workdir expansion at trap-set time
+	trap "rm -rf \"${workdir}\"" RETURN
 	if [[ -f "$todo_file" ]]; then
-		# Extract everything under ## Backlog (tasks AND ### subsection headers)
-		# until the next ## header or EOF — preserves semantic grouping.
-		# GH#17804: Skip ## Format section and filter out template placeholder IDs
-		# (tXXX, tYYY, tZZZ) that are documentation examples, not real tasks.
-		existing_tasks=$(awk '
-			# Section-aware: track when inside ## Format to skip its content
-			/^## Format/ { in_format=1; next }
-			in_format && /^## / { in_format=0 }
-			in_format { next }
-			# Also skip content inside markdown code blocks (``` fenced blocks)
-			/^```/ { in_codeblock = !in_codeblock; next }
-			in_codeblock { next }
-			# Extract from ## Backlog to next ## header
-			/^## Backlog/ { found=1; next }
-			found && /^## / { exit }
-			found
-		' "$todo_file" 2>/dev/null || echo "")
-		# GH#17804: Filter out lines with non-numeric task IDs (template placeholders
-		# like tXXX, tYYY, tZZZ). Real task IDs match t<digits> or t<digits>.<digits>.
-		if [[ -n "$existing_tasks" ]]; then
-			existing_tasks=$(printf '%s\n' "$existing_tasks" | awk '
-				# Keep non-task lines (subsection headers, comments, blank lines)
-				!/^- \[[ x-]\] t/ { print; next }
-				# For task lines: extract the ID and validate it is numeric
-				{
-					id = $0
-					sub(/^- \[[ x-]\] /, "", id)
-					sub(/ .*/, "", id)
-					# Valid IDs: t followed by digits, optionally .digits (subtasks)
-					if (id ~ /^t[0-9]+(\.[0-9]+)*$/) print
-				}
-			')
-		fi
+		_upgrade_todo_preserve_sections "$todo_file" "$workdir"
 		[[ "$backup" == "true" ]] && {
 			cp "$todo_file" "${todo_file}.bak"
 			print_success "Backup created: TODO.md.bak"
@@ -2643,27 +2717,11 @@ _upgrade_todo() {
 		cp "$todo_template" "$todo_file"
 	fi
 	sed_inplace "s/{{DATE}}/$(date +%Y-%m-%d)/" "$todo_file" 2>/dev/null || true
-	if [[ -n "$existing_tasks" ]] && grep -q "<!--TOON:backlog" "$todo_file"; then
-		local temp_file="${todo_file}.merge" tasks_file
-		tasks_file=$(mktemp)
-		trap 'rm -f "${tasks_file:-}"' RETURN
-		printf '%s\n' "$existing_tasks" >"$tasks_file"
-		local in_backlog=false
-		while IFS= read -r line || [[ -n "$line" ]]; do
-			[[ "$line" == *"<!--TOON:backlog"* ]] && in_backlog=true
-			if [[ "$in_backlog" == true && "$line" == "-->" ]]; then
-				echo "$line"
-				echo ""
-				cat "$tasks_file"
-				in_backlog=false
-				continue
-			fi
-			echo "$line"
-		done <"$todo_file" >"$temp_file"
-		rm -f "$tasks_file"
-		mv "$temp_file" "$todo_file"
-		print_success "Merged existing tasks into Backlog"
-	fi
+	_upgrade_todo_reinsert_sections "$todo_file" "$workdir"
+	local merged=0
+	merged=$(grep -cE '^- \[[ x-]\] (t[0-9]|GH#[0-9])' "$todo_file" 2>/dev/null || true)
+	merged="${merged:-0}"
+	[[ "$merged" -gt 0 ]] && print_success "Merged $merged existing task(s) across sections"
 	print_success "TODO.md upgraded to TOON-enhanced template"
 	return 0
 }

--- a/todo/tasks/t2434-brief.md
+++ b/todo/tasks/t2434-brief.md
@@ -1,0 +1,88 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+# t2434: fix(upgrade-planning): preserve tasks across all 6 sections
+
+## Pre-flight
+
+- [x] Memory recall: "_upgrade_todo extraction TODO.md section" → 1 hit — just-stored lesson confirms 141-row Done drop; no broader prior fix.
+- [x] Discovery pass: 0 open PRs, 0 commits touching `aidevops.sh:2595-2669` in last 48h. Prior merged fixes GH#17804 (Format leakage) and GH#17806 (### inside Backlog) both in same function but narrower scope.
+- [x] File refs verified: `aidevops.sh:2595-2669` matches the function at HEAD; line ranges confirmed via Read.
+- [x] Tier: `tier:standard` — multi-section extraction refactor plus test, single file touch plus a new test, not mechanical enough for simple.
+
+## Origin
+
+- **Created:** 2026-04-20
+- **Session:** opencode interactive
+- **Created by:** ai-interactive (during user request to upgrade planning templates on awardsapp + propertyservicesdirectory.com)
+- **Conversation context:** User asked to upgrade 2 projects flagged by `aidevops update` (outdated planning templates). First run on awardsapp silently dropped 141 `[x]` completed tasks from `## Done` (extraction only covers `## Backlog`). Restored from `.bak` before proceeding. Fixing the bug before re-running the upgrades.
+
+## What
+
+`_upgrade_todo` (`aidevops.sh:2595-2669`) must extract and preserve tasks from all 6 template sections — `Ready`, `Backlog`, `In Progress`, `In Review`, `Done`, `Declined` — and re-insert each into its matching `<!--TOON:<tag>` marker in the new template. Today it only handles `Backlog`.
+
+## Why
+
+Reproduced 2026-04-20: `aidevops upgrade-planning --force` on awardsapp silently dropped 141 completed tasks from `## Done` (57 Backlog + 141 Done = 198 total → 57 only after upgrade). Completed-task rows carry `actual:` session time and `est:` breakdowns that only live in TODO.md — GitHub issues don't store these fields, so the audit trail is NOT reconstructable. Data was recovered from `.bak` before the working tree was committed, but the silent loss is the critical defect: any user following the recommended upgrade flow loses every task outside Backlog.
+
+Adjacent prior fixes in the same function: GH#17804 (Format placeholder leakage), GH#17806 (### subsection preservation inside Backlog). Neither addressed cross-section extraction.
+
+## Tier
+
+**Selected tier:** `tier:standard`
+
+**Rationale:** One function refactor in a ~1500-line shell script, plus a new regression test harness. Not a mechanical `oldString`/`newString` swap — requires understanding the existing section-skip logic and re-weaving it into a per-section loop. Standard Sonnet work.
+
+## PR Conventions
+
+Leaf issue — use `Resolves #20077` in PR body.
+
+## How (Approach)
+
+### Files to Modify
+
+- EDIT: `aidevops.sh` — function `_upgrade_todo` (lines 2595-2669).
+- NEW:  `.agents/scripts/tests/test-upgrade-planning-sections.sh` — regression test. Model on `.agents/scripts/tests/test-init-scope.sh` (same directory, similar scope: single-function test with synthetic fixtures).
+
+### Implementation Steps
+
+1. Replace single-section `awk` extraction (current lines 2604-2616, targeting `## Backlog`) with a per-section extraction helper invoked for each of the 6 sections. The helper takes `(file, section_name)` and returns the section body, preserving the existing skips:
+   - Skip content inside `## Format` entirely.
+   - Skip content inside triple-backtick code blocks.
+   - Stop at the next `##` header.
+2. Keep the post-extraction placeholder filter (lines 2619-2632) and apply it per-section.
+3. Replace single-section re-insertion (current lines 2646-2666, targeting `<!--TOON:backlog`) with a loop over `(section → tag)` pairs:
+   - `Ready → ready`
+   - `Backlog → backlog`
+   - `In Progress → in_progress`
+   - `In Review → in_review`
+   - `Done → done`
+   - `Declined → declined`
+   For each, insert the preserved content after the matching TOON marker's closing `-->`.
+4. Emit a summary log line with the total task count merged (e.g. `Merged 198 tasks across 2 sections`).
+5. Keep bash 3.2 compatible — no associative arrays, no `${var,,}`. Use parallel arrays or `case` dispatch.
+6. Run `shellcheck aidevops.sh` — must stay clean.
+
+### Verification
+
+1. `shellcheck aidevops.sh` — clean.
+2. New test: `bash .agents/scripts/tests/test-upgrade-planning-sections.sh` — passes.
+   - Creates a synthetic TODO.md with tasks in all 6 sections (plus Format placeholders that must still be filtered).
+   - Sources `aidevops.sh` to get access to `_upgrade_todo`.
+   - Invokes the upgrade against a temp file.
+   - Asserts every real task survives in its matching new-template section.
+   - Asserts Format placeholders (tXXX/tYYY/tZZZ) are NOT promoted to real sections.
+3. End-to-end: run `aidevops upgrade-planning --force` in `/Users/marcusquinn/Git/awardsapp` (local only, don't commit). Task count must match pre-upgrade (198). Revert the test run afterwards.
+
+## Acceptance
+
+- [ ] `_upgrade_todo` extracts tasks from all 6 sections.
+- [ ] Tasks land in the matching `<!--TOON:<tag>` marker in the new template (not all dumped into Backlog).
+- [ ] `## Format` placeholders and `tXXX`-style template IDs are still filtered out.
+- [ ] New regression test covers all 6 sections plus Format-filter preservation.
+- [ ] `shellcheck aidevops.sh` clean.
+- [ ] Local end-to-end on awardsapp: `grep -cE '^- \[[ x-]\] t[0-9]' TODO.md` before == after (198).
+
+## Out of Scope
+
+- `_upgrade_plans` (extracts from first `###` header only — known limitation for free-form `##` plan content, separate issue if needed).
+- Template version bump (v1.1 already published; this is a consumer-side fix).


### PR DESCRIPTION
## Summary

Fix `_upgrade_todo` silently dropping tasks from 5 of 6 TODO sections during `aidevops upgrade-planning`. Previously only `## Backlog` content was preserved; tasks under `## Ready`, `## In Progress`, `## In Review`, `## Done`, and `## Declined` were written to `TODO.md.bak` and lost.

Observed on <webapp> 2026-04-20: a real upgrade dropped 141 `[x]` completed rows from Done (198 → 57). The lost rows are audit-trail data — they are NOT reconstructable from GitHub (commit history shows a merge, not the cross-section summary we'd curated locally).

## Root Cause

`_upgrade_todo` extracted tasks via a single awk pass scoped to `## Backlog` and re-inserted after `<!--TOON:backlog-->`. Prior PRs GH#17804 (Format placeholder leakage) and GH#17806 (`###` subsection preservation in Backlog) narrowed adjacent issues but didn't cross the section boundary.

Secondary bug surfaced during remediation: the old placeholder filter used an allowlist regex `^t[0-9]+(\.[0-9]+)*$` that rejected real historic IDs like `t059b` and `t043-merge` from <webapp>'s Done section — those would have been silently dropped even after the primary fix.

## Changes

**`aidevops.sh`** — refactor `_upgrade_todo` into 5 focused helpers:

- `_extract_todo_section(file, section)` — awk-extract one section, skipping `## Format` and fenced code blocks.
- `_filter_todo_placeholders` — blocklist literal `tXXX`/`tYYY`/`tZZZ` only (was allowlist that rejected real historic IDs).
- `_insert_after_toon_marker(file, tag, content)` — drop preserved content after the matching `<!--TOON:<tag>...-->` marker.
- `_upgrade_todo_preserve_sections` — extract all 6 sections into `tempdir/<tag>.txt` before the new template is applied.
- `_upgrade_todo_reinsert_sections` — loop over all 6 tags, insert each. Intentionally no inline task counting (the previous inline `grep -c || echo 0` pattern produced `"0\n0"` stdout under `set -u` when content contained `GH#`-style IDs, breaking arithmetic).

**`.agents/scripts/tests/test-upgrade-planning-sections.sh`** — new regression test with 25 assertions across 4 test functions:

1. `_extract_todo_section` scope correctness (stops at next `##`, skips `## Format`).
2. `_filter_todo_placeholders` blocklist semantics (drops tXXX, keeps t123/t456.1).
3. Full-pipeline preservation across all 6 sections + `t2434 regression` assertion on Done count.
4. Empty-TODO edge case.

**`todo/tasks/t2434-brief.md`** — task brief per framework convention.

## Verification

- `shellcheck aidevops.sh` + `shellcheck .agents/scripts/tests/test-upgrade-planning-sections.sh`: clean.
- Unit tests: `bash .agents/scripts/tests/test-upgrade-planning-sections.sh` — 25/25 pass.
- End-to-end on real <webapp> TODO.md (224 tasks pre-upgrade — 65 Backlog + 155 Done + 4 Format placeholders):
  - After upgrade: 224 tasks. Exact preservation of all 220 real user tasks including historic `t059b` and `t043-merge`. Format placeholders replaced as expected (old tXXX/tYYY/tZZZ → new t001/t002/t003).
  - Idempotent: re-running upgrade on the upgraded file produces the same 224.
- Empty TODO on propertyservicesdirectory.com: 0 → 4 (template placeholders), no data loss.

## Impact

Any project that ran `aidevops upgrade-planning` with a TODO.md containing tasks outside Backlog would have silently lost them into `.bak`. <webapp> was the detection case (141 Done rows dropped); unknown how many other repos may have been affected pre-fix. This PR prevents recurrence.

The failed <webapp> upgrade in this session was restored manually from `.bak` before work began — no data loss in flight.

Resolves #20077