### PR TITLE
t2437: harden version-manager.sh release against rebase-dropped bump commit

### DIFF
--- a/.agents/scripts/tests/test-version-manager-bump-verify.sh
+++ b/.agents/scripts/tests/test-version-manager-bump-verify.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-version-manager-bump-verify.sh — t2437/GH#20073 regression guard.
+#
+# Asserts that version-manager.sh refuses to create a release tag on a
+# non-bump commit. The failure history that motivated this test:
+#
+#   - PR #20066 (t2427) merged 2026-04-20T02:22:21Z.
+#   - `version-manager.sh release patch` ran moments later; pulse claim
+#     commits were pushed in between, triggering a rebase-and-retag
+#     inside push_changes.
+#   - The rebase silently dropped the bump commit (HEAD became
+#     origin/main = a pulse claim commit), and the retag placed the
+#     v3.8.82 tag on that claim commit.
+#   - VERSION and CHANGELOG never received the 3.8.82 bump entry on
+#     main; tag and GitHub release pointed at the wrong commit.
+#
+# The fix adds `_verify_bump_commit_at_ref` and wires it in at three
+# gates: after commit_version_changes, after the rebase inside
+# push_changes, and as a final guard inside create_git_tag. This test
+# exercises the helper directly (no git network ops, no fixture
+# release) so it runs fast and deterministically in CI.
+
+set -uo pipefail
+
+TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+# NOT readonly — version-manager.sh defines its own RED/GREEN constants
+# under `readonly`, and a collision under set -e silently kills the
+# test shell. Use plain vars (same pattern as test-parent-task-guard.sh).
+TEST_RED=$'\033[0;31m'
+TEST_GREEN=$'\033[0;32m'
+TEST_RESET=$'\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1" rc="$2" extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf '%sPASS%s %s\n' "$TEST_GREEN" "$TEST_RESET" "$name"
+	else
+		printf '%sFAIL%s %s %s\n' "$TEST_RED" "$TEST_RESET" "$name" "$extra"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+# Sandbox HOME and working dir
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+export HOME="${TEST_ROOT}/home"
+mkdir -p "${HOME}/.aidevops/logs"
+
+# Build a tiny git repo with two commits: a legitimate bump commit for
+# 9.9.1 and a sibling non-bump commit (simulating the pulse claim
+# commit that the rebase would have dropped our bump commit onto).
+REPO_DIR="${TEST_ROOT}/repo"
+mkdir -p "$REPO_DIR"
+cd "$REPO_DIR" || exit 1
+
+git init -q -b main
+git config user.email 'test@example.com'
+git config user.name 'Test Runner'
+git config commit.gpgsign false
+
+echo 'initial' >README.md
+git add README.md
+git commit -q -m 'initial commit'
+
+# Bump commit (legitimate)
+echo '9.9.1' >VERSION
+git add VERSION
+git commit -q -m 'chore(release): bump version to 9.9.1'
+BUMP_SHA=$(git rev-parse HEAD)
+
+# Non-bump commit on top (simulates the pulse claim commit scenario)
+echo 'unrelated' >other.txt
+git add other.txt
+git commit -q -m 'chore: claim t9999 [test-fixture]'
+CLAIM_SHA=$(git rev-parse HEAD)
+
+# Source version-manager.sh in library mode. The file ends with a
+# `if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then main "$@"; fi` guard, so
+# sourcing it directly as a file (NOT via <(...) process substitution)
+# skips the main-dispatch path.
+#
+# Why direct `source <path>` instead of `source <(cat <path>)`:
+# version-manager.sh line 14 computes `SCRIPT_DIR` from `BASH_SOURCE[0]`
+# and then sources shared-constants.sh relative to it. Under process
+# substitution BASH_SOURCE[0] resolves to `/dev/fd/N`, which breaks the
+# dirname+cd chain and takes down the test with it. Plain file sourcing
+# gives BASH_SOURCE[0] the real path and everything initialises normally
+# (t2437: documented here because future maintainers WILL try to "clean
+# up" by switching to process substitution).
+#
+# version-manager.sh has `set -euo pipefail` at the top, which propagates
+# to the outer shell on source. We turn -e back off immediately so the
+# `|| rc=$?` rc-capture pattern below works as expected.
+# shellcheck source=/dev/null
+source "${TEST_SCRIPTS_DIR}/version-manager.sh"
+set +e
+
+# =============================================================================
+# Test 1: _bump_commit_subject produces the canonical subject
+# =============================================================================
+expected_subj='chore(release): bump version to 9.9.1'
+actual_subj=$(_bump_commit_subject '9.9.1')
+if [[ "$actual_subj" == "$expected_subj" ]]; then
+	print_result '_bump_commit_subject: canonical format for 9.9.1' 0
+else
+	print_result '_bump_commit_subject: canonical format for 9.9.1' 1 \
+		"expected [$expected_subj], got [$actual_subj]"
+fi
+
+# =============================================================================
+# Test 2: verification PASSES on the legitimate bump commit
+# =============================================================================
+rc=0
+_verify_bump_commit_at_ref "$BUMP_SHA" '9.9.1' >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -eq 0 ]]; then
+	print_result '_verify_bump_commit_at_ref: passes for legitimate bump commit' 0
+else
+	print_result '_verify_bump_commit_at_ref: passes for legitimate bump commit' 1 \
+		"expected rc=0, got rc=$rc"
+fi
+
+# =============================================================================
+# Test 3: verification FAILS on a non-bump commit (GH#20073 symptom)
+# =============================================================================
+# This is the core regression: the rebase scenario that broke v3.8.82
+# left HEAD at a claim commit and retagged it. Under the fix, the
+# verifier must reject this.
+rc=0
+_verify_bump_commit_at_ref "$CLAIM_SHA" '9.9.1' >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -ne 0 ]]; then
+	print_result '_verify_bump_commit_at_ref: rejects non-bump commit (GH#20073 case)' 0
+else
+	print_result '_verify_bump_commit_at_ref: rejects non-bump commit (GH#20073 case)' 1 \
+		"expected non-zero rc, got rc=0"
+fi
+
+# =============================================================================
+# Test 4: verification FAILS on version mismatch (right shape, wrong version)
+# =============================================================================
+# A bump commit exists but for a different version — the subject is
+# structurally valid but does not match $version. Must still reject.
+rc=0
+_verify_bump_commit_at_ref "$BUMP_SHA" '9.9.2' >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -ne 0 ]]; then
+	print_result '_verify_bump_commit_at_ref: rejects version mismatch' 0
+else
+	print_result '_verify_bump_commit_at_ref: rejects version mismatch' 1 \
+		"expected non-zero rc, got rc=0"
+fi
+
+# =============================================================================
+# Test 5: verification FAILS on an invalid ref
+# =============================================================================
+rc=0
+_verify_bump_commit_at_ref 'does-not-exist' '9.9.1' >/dev/null 2>&1 || rc=$?
+if [[ "$rc" -ne 0 ]]; then
+	print_result '_verify_bump_commit_at_ref: rejects non-existent ref' 0
+else
+	print_result '_verify_bump_commit_at_ref: rejects non-existent ref' 1 \
+		"expected non-zero rc, got rc=0"
+fi
+
+# =============================================================================
+# Test 6: VERSION_MANAGER_NO_CHANGES_EXIT is distinct from success
+# =============================================================================
+# The t2437 fix widens commit_version_changes' contract: 0 = commit
+# made, 1 = commit failed, 2 = nothing staged. Callers must treat 2
+# as fatal for a release run (see _release_execute).
+if [[ "${VERSION_MANAGER_NO_CHANGES_EXIT:-0}" == "2" ]]; then
+	print_result 'VERSION_MANAGER_NO_CHANGES_EXIT: defined as 2 (distinct from success)' 0
+else
+	print_result 'VERSION_MANAGER_NO_CHANGES_EXIT: defined as 2 (distinct from success)' 1 \
+		"expected 2, got [${VERSION_MANAGER_NO_CHANGES_EXIT:-<unset>}]"
+fi
+
+# =============================================================================
+# Summary
+# =============================================================================
+printf '\n'
+printf 'Tests run:    %d\n' "$TESTS_RUN"
+printf 'Tests failed: %d\n' "$TESTS_FAILED"
+
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -1336,6 +1336,52 @@ _verify_bump_commit_at_ref() {
 # must treat exit 2 as fatal — see _release_execute (t2437/GH#20073).
 readonly VERSION_MANAGER_NO_CHANGES_EXIT=2
 
+# Run commit_version_changes with strict return-code semantics and verify
+# that HEAD ended up as the expected bump commit afterward.
+#
+# Usage: _release_commit_and_verify_bump <version> <bump_type>
+# Returns: 0 on success; 1 on any failure (error already printed).
+#
+# Extracted from _release_execute to keep that function under 100 body lines
+# while preserving the t2437/GH#20073 guard semantics. This is the canonical
+# release-path commit-and-verify sequence; do not inline it elsewhere.
+_release_commit_and_verify_bump() {
+	local version="$1"
+	local bump_type="$2"
+	local commit_rc=0
+
+	commit_version_changes "$version" || commit_rc=$?
+	case "$commit_rc" in
+	0) ;;
+	"$VERSION_MANAGER_NO_CHANGES_EXIT")
+		print_error "Aborting release: no version changes were staged (commit skipped)"
+		print_info "This usually means update_version_in_files wrote no changes — diagnose with:"
+		print_info "  git status && git diff VERSION CHANGELOG.md"
+		print_info "Fix the upstream update and re-run: $0 release $bump_type"
+		return 1
+		;;
+	*)
+		print_error "Aborting release: commit_version_changes failed (rc=$commit_rc)"
+		return 1
+		;;
+	esac
+
+	# Defence-in-depth: even if the commit appeared to succeed, confirm
+	# HEAD is actually the bump commit before the caller tags it. This
+	# catches any edge case where the commit landed on a different branch
+	# or a pre-commit hook amended it to a different subject.
+	if ! _verify_bump_commit_at_ref HEAD "$version"; then
+		print_error "Aborting release: HEAD is not the bump commit for v$version"
+		print_info "Something between update_version_in_files and commit_version_changes"
+		print_info "corrupted the intended commit. Recovery:"
+		print_info "  git log --oneline -5   # inspect recent history"
+		print_info "  git reset --hard origin/main && $0 release $bump_type"
+		return 1
+	fi
+
+	return 0
+}
+
 # Function to commit version changes.
 # Returns: 0 on successful commit, 1 on commit failure,
 # VERSION_MANAGER_NO_CHANGES_EXIT (2) when there was nothing to stage.
@@ -1845,37 +1891,8 @@ _release_execute() {
 	if validate_version_consistency "$new_version"; then
 		print_success "Version validation passed"
 
-		# t2437/GH#20073: distinguish "commit made" (0), "commit failed" (1),
-		# and "nothing staged" (VERSION_MANAGER_NO_CHANGES_EXIT=2). The
-		# pre-fix code treated 0 and 2 as identical, so a silently-skipped
-		# commit led to tagging HEAD (which was not a bump commit).
-		local commit_rc=0
-		commit_version_changes "$new_version" || commit_rc=$?
-		case "$commit_rc" in
-		0) ;;
-		"$VERSION_MANAGER_NO_CHANGES_EXIT")
-			print_error "Aborting release: no version changes were staged (commit skipped)"
-			print_info "This usually means update_version_in_files wrote no changes — diagnose with:"
-			print_info "  git status && git diff VERSION CHANGELOG.md"
-			print_info "Fix the upstream update and re-run: $0 release $bump_type"
-			exit 1
-			;;
-		*)
-			print_error "Aborting release: commit_version_changes failed (rc=$commit_rc)"
-			exit 1
-			;;
-		esac
-
-		# Defence-in-depth: even if the commit appeared to succeed, confirm
-		# HEAD is actually the bump commit before we tag it. This catches
-		# any edge case where the commit landed on a different branch or a
-		# pre-commit hook amended it to a different subject.
-		if ! _verify_bump_commit_at_ref HEAD "$new_version"; then
-			print_error "Aborting release: HEAD is not the bump commit for v$new_version"
-			print_info "Something between update_version_in_files and commit_version_changes"
-			print_info "corrupted the intended commit. Recovery:"
-			print_info "  git log --oneline -5   # inspect recent history"
-			print_info "  git reset --hard origin/main && $0 release $bump_type"
+		# t2437/GH#20073: commit the bump, verify HEAD is the bump commit.
+		if ! _release_commit_and_verify_bump "$new_version" "$bump_type"; then
 			exit 1
 		fi
 

--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -1289,7 +1289,59 @@ auto_mark_tasks_complete() {
 	return 0
 }
 
-# Function to commit version changes
+# Expected commit subject for a release bump commit at "$version".
+# Single source of truth — used by commit creation and by every downstream
+# verification gate (post-commit, post-rebase, pre-tag, pre-push).
+_bump_commit_subject() {
+	local version="$1"
+	printf 'chore(release): bump version to %s\n' "$version"
+}
+
+# Verify that a specific git ref (SHA, tag, HEAD) resolves to a commit whose
+# subject line matches the expected bump-commit subject for the given version.
+#
+# Usage: _verify_bump_commit_at_ref <ref> <version>
+# Returns: 0 on match, 1 on mismatch (with diagnostic output).
+#
+# This is the canonical guard that prevents the t2437/GH#20073 foot-gun: a
+# rebase (or any history-rewriting operation) silently drops the bump commit,
+# HEAD ends up at origin/main, and a subsequent retag-of-HEAD places the
+# release tag on the wrong commit. Every code path that creates a tag or
+# assumes HEAD is the bump commit MUST call this first.
+_verify_bump_commit_at_ref() {
+	local ref="$1"
+	local version="$2"
+	local expected actual resolved_sha
+
+	expected=$(_bump_commit_subject "$version")
+
+	resolved_sha=$(git rev-parse --verify "${ref}^{commit}" 2>/dev/null)
+	if [[ -z "$resolved_sha" ]]; then
+		print_error "Bump-commit verification failed: ref '$ref' does not resolve to a commit"
+		return 1
+	fi
+
+	actual=$(git log -1 --format='%s' "$resolved_sha" 2>/dev/null)
+	if [[ "$actual" != "$expected" ]]; then
+		print_error "Bump-commit verification failed for ref '$ref' ($resolved_sha)"
+		print_error "  Expected subject: $expected"
+		print_error "  Actual subject:   ${actual:-<empty>}"
+		return 1
+	fi
+	return 0
+}
+
+# Exit code 2 used by commit_version_changes to distinguish "nothing staged"
+# from "commit succeeded" (0). Callers that expect a new bump commit on HEAD
+# must treat exit 2 as fatal — see _release_execute (t2437/GH#20073).
+readonly VERSION_MANAGER_NO_CHANGES_EXIT=2
+
+# Function to commit version changes.
+# Returns: 0 on successful commit, 1 on commit failure,
+# VERSION_MANAGER_NO_CHANGES_EXIT (2) when there was nothing to stage.
+# The 0-vs-2 split is load-bearing: _release_execute treats 2 as a fatal
+# pre-tag condition because it means the VERSION bump never reached the
+# index and retagging HEAD would place the tag on a non-bump commit.
 commit_version_changes() {
 	local version="$1"
 
@@ -1303,14 +1355,16 @@ commit_version_changes() {
 	# Check if there are changes to commit
 	if git diff --cached --quiet; then
 		print_info "No version changes to commit"
-		return 0
+		return "$VERSION_MANAGER_NO_CHANGES_EXIT"
 	fi
 
 	# Version-bump commits contain only version-string updates — content is
 	# internally controlled by this script. Pre-commit quality gates run in
 	# CI on every other path. Skip the local hook here to avoid false positives
 	# on pre-existing code that the release commit didn't touch (t2237).
-	if git commit --no-verify -m "chore(release): bump version to $version"; then
+	local commit_subject
+	commit_subject=$(_bump_commit_subject "$version")
+	if git commit --no-verify -m "$commit_subject"; then
 		print_success "Committed version changes"
 		return 0
 	else
@@ -1349,7 +1403,29 @@ push_changes() {
 			return 1
 		fi
 
-		# Tag must be recreated on the new HEAD after rebase
+		# CRITICAL (t2437/GH#20073): Verify the rebase did NOT silently drop our
+		# bump commit before retagging HEAD. A rebase can lose the bump commit
+		# without a conflict if (a) Git treats it as already applied (duplicate
+		# patch upstream), (b) an interactive rebase drops it, or (c) the remote
+		# fast-forwards past it in a way that makes our commit empty. In every
+		# such case, HEAD becomes origin/main and retagging HEAD would place
+		# the release tag on the wrong commit — exactly the symptom observed
+		# in the broken v3.8.82 release (GH#20073).
+		if ! _verify_bump_commit_at_ref HEAD "$version"; then
+			print_error "Rebase silently dropped the bump commit for v$version"
+			print_info "HEAD is now $(git rev-parse HEAD), not a bump-version commit"
+			print_info "Recovery:"
+			print_info "  1. Inspect: git log --oneline origin/main..HEAD"
+			print_info "  2. Reset local branch: git reset --hard origin/main"
+			print_info "  3. Delete local tag: git tag -d $tag_name"
+			print_info "  4. Re-run: $0 release <bump-type>"
+			# Clean up the stale local tag to avoid divergence on next attempt.
+			git tag -d "$tag_name" 2>/dev/null || true
+			return 1
+		fi
+
+		# Tag must be recreated on the new HEAD after rebase (HEAD has been
+		# verified above to be the bump commit for $version).
 		if git show-ref --tags "$tag_name" &>/dev/null; then
 			print_info "Recreating tag $tag_name on rebased HEAD..."
 			git tag -d "$tag_name"
@@ -1401,6 +1477,26 @@ create_git_tag() {
 		print_info "  git fetch --tags && git show $tag_name"
 		print_info "  gh release view $tag_name"
 		return 1
+	fi
+
+	# t2437/GH#20073: Final guard before `git tag` — HEAD must be the bump
+	# commit for $version. This catches any residual case where an upstream
+	# caller skipped its own post-commit/post-rebase verification, or called
+	# create_git_tag directly (e.g., standalone `version-manager.sh tag`).
+	# Opt-out via AIDEVOPS_VM_SKIP_BUMP_VERIFY=1 for maintainer recovery flows
+	# that intentionally tag non-bump commits (e.g., annotated release sync
+	# tags). Default is strict.
+	if [[ "${AIDEVOPS_VM_SKIP_BUMP_VERIFY:-0}" != "1" ]]; then
+		if ! _verify_bump_commit_at_ref HEAD "$version"; then
+			print_error "Aborting tag creation: HEAD is not the bump commit for v$version"
+			print_info "The tag would land on the wrong commit (this is exactly the"
+			print_info "GH#20073 foot-gun). Inspect and recover:"
+			print_info "  git log -1 --format='%H %s'   # current HEAD"
+			print_info "  git log --oneline -5          # recent history"
+			print_info "Override only if you truly need to tag a non-bump commit:"
+			print_info "  AIDEVOPS_VM_SKIP_BUMP_VERIFY=1 $0 tag"
+			return 1
+		fi
 	fi
 
 	if git tag -a "$tag_name" -m "Release $tag_name - AI DevOps Framework"; then
@@ -1748,7 +1844,41 @@ _release_execute() {
 	print_info "Validating version consistency..."
 	if validate_version_consistency "$new_version"; then
 		print_success "Version validation passed"
-		commit_version_changes "$new_version"
+
+		# t2437/GH#20073: distinguish "commit made" (0), "commit failed" (1),
+		# and "nothing staged" (VERSION_MANAGER_NO_CHANGES_EXIT=2). The
+		# pre-fix code treated 0 and 2 as identical, so a silently-skipped
+		# commit led to tagging HEAD (which was not a bump commit).
+		local commit_rc=0
+		commit_version_changes "$new_version" || commit_rc=$?
+		case "$commit_rc" in
+		0) ;;
+		"$VERSION_MANAGER_NO_CHANGES_EXIT")
+			print_error "Aborting release: no version changes were staged (commit skipped)"
+			print_info "This usually means update_version_in_files wrote no changes — diagnose with:"
+			print_info "  git status && git diff VERSION CHANGELOG.md"
+			print_info "Fix the upstream update and re-run: $0 release $bump_type"
+			exit 1
+			;;
+		*)
+			print_error "Aborting release: commit_version_changes failed (rc=$commit_rc)"
+			exit 1
+			;;
+		esac
+
+		# Defence-in-depth: even if the commit appeared to succeed, confirm
+		# HEAD is actually the bump commit before we tag it. This catches
+		# any edge case where the commit landed on a different branch or a
+		# pre-commit hook amended it to a different subject.
+		if ! _verify_bump_commit_at_ref HEAD "$new_version"; then
+			print_error "Aborting release: HEAD is not the bump commit for v$new_version"
+			print_info "Something between update_version_in_files and commit_version_changes"
+			print_info "corrupted the intended commit. Recovery:"
+			print_info "  git log --oneline -5   # inspect recent history"
+			print_info "  git reset --hard origin/main && $0 release $bump_type"
+			exit 1
+		fi
+
 		if ! create_git_tag "$new_version"; then
 			print_error "Aborting release: tag creation failed (see above for diagnosis)"
 			exit 1


### PR DESCRIPTION
## Summary

`version-manager.sh release <bump>` could produce a broken release — a git tag pointing at a non-bump commit — when the final `git push --atomic` had to rebase over concurrent `main` activity and the bump commit was silently dropped by the rebase. Observed symptom: v3.8.82 tag pointed at a pulse claim commit; VERSION and CHANGELOG never received the 3.8.82 bump on `main`. Manually recovered via commit 4d98aed78, but the foot-gun remained live.

This PR closes the foot-gun with three verification gates (defence-in-depth), a return-code sentinel, and a regression test. Read the commit messages for the full mentor-grade walkthrough.

## Root cause

`push_changes` unconditionally retagged HEAD after `git rebase origin/main` without verifying that HEAD was still the bump commit. A silent rebase collapse (duplicate patch upstream, empty commit on fast-forward, interactive rebase drop, etc.) left HEAD at `origin/main` and the retag landed on the wrong commit. Orthogonally, `commit_version_changes` returned `0` on both "commit made" and "nothing staged" — callers couldn't tell the difference, so a silently-skipped commit also fed the bad retag.

## Fix

Five pieces, all in `version-manager.sh`:

1. **`_bump_commit_subject(version)`** — single source of truth for the canonical subject string.
2. **`_verify_bump_commit_at_ref(ref, version)`** — canonical verification helper; rejects any ref whose subject doesn't match.
3. **`VERSION_MANAGER_NO_CHANGES_EXIT=2`** — sentinel for the new "nothing staged" return code from `commit_version_changes`; `_release_execute` treats 2 as fatal.
4. **Three gates calling the verifier:**
   - After `commit_version_changes` in `_release_execute` (defence-in-depth on local commit).
   - After `git rebase origin/main` in `push_changes` — cleans up the local tag and surfaces recovery steps if the bump commit was dropped.
   - Before `git tag` in `create_git_tag` — final guard with `AIDEVOPS_VM_SKIP_BUMP_VERIFY=1` opt-out for maintainer recovery flows.
5. **`_release_commit_and_verify_bump` helper** — extracted from `_release_execute` to stay under the 100-line function-complexity ratchet; no behaviour change.

## Verification

New regression test: `.agents/scripts/tests/test-version-manager-bump-verify.sh` — 6 assertions.

```
PASS _bump_commit_subject: canonical format for 9.9.1
PASS _verify_bump_commit_at_ref: passes for legitimate bump commit
PASS _verify_bump_commit_at_ref: rejects non-bump commit (GH#20073 case)
PASS _verify_bump_commit_at_ref: rejects version mismatch
PASS _verify_bump_commit_at_ref: rejects non-existent ref
PASS VERSION_MANAGER_NO_CHANGES_EXIT: defined as 2 (distinct from success)

Tests run:    6
Tests failed: 0
```

- `shellcheck` clean on both files.
- Pre-commit quality gate passes (return statements, repeated strings, shellcheck).
- Complexity regression gate passes after the helper extraction (`_release_execute` = 94 body lines, new helper = 36; base had 31 functions >100 lines, head also 31).

## Scope & recovery note

- **Scope:** regression guard only. The broken v3.8.82 tag was already recovered externally (commit `4d98aed78`), so this PR carries no recovery tooling — just the permanent fix and its regression test.
- **Opt-out:** `AIDEVOPS_VM_SKIP_BUMP_VERIFY=1` on `create_git_tag` is documented for deliberate sync-tag flows (e.g., what happened in `4d98aed78`).

Resolves #20073


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.83 plugin for [OpenCode](https://opencode.ai) v1.14.18 with claude-opus-4-7 spent 1h 22m and 96,733 tokens on this with the user in an interactive session.
