### PR TITLE
GH#20058: decompose setup_test_env into per-fixture helpers

### DIFF
--- a/.agents/scripts/tests/test-workflow-cascade-lint.sh
+++ b/.agents/scripts/tests/test-workflow-cascade-lint.sh
@@ -47,12 +47,7 @@ print_result() {
 	return 0
 }
 
-setup_test_env() {
-	TEST_ROOT=$(mktemp -d)
-	mkdir -p "${TEST_ROOT}/fixtures"
-	export TEST_ROOT
-
-	# ── Fixture: vulnerable (labeled + cancel-in-progress, no mitigation) ──
+_create_fixture_vulnerable() {
 	cat > "${TEST_ROOT}/fixtures/vulnerable.yml" << 'YAML'
 name: Vulnerable Workflow
 on:
@@ -71,8 +66,10 @@ jobs:
       - name: Do work
         run: echo "Working"
 YAML
+	return 0
+}
 
-	# ── Fixture: vulnerable PR (labeled in pull_request types) ──
+_create_fixture_vulnerable_pr() {
 	cat > "${TEST_ROOT}/fixtures/vulnerable-pr.yml" << 'YAML'
 name: Vulnerable PR Workflow
 on:
@@ -87,8 +84,10 @@ jobs:
     steps:
       - run: echo "Checking"
 YAML
+	return 0
+}
 
-	# ── Fixture: mitigated with paths-ignore ──
+_create_fixture_mitigated_paths_ignore() {
 	cat > "${TEST_ROOT}/fixtures/mitigated-paths-ignore.yml" << 'YAML'
 name: Mitigated With Paths Ignore
 on:
@@ -106,8 +105,10 @@ jobs:
     steps:
       - run: echo "Scanning"
 YAML
+	return 0
+}
 
-	# ── Fixture: mitigated with event-action guard (job-level if) ──
+_create_fixture_mitigated_action_guard() {
 	cat > "${TEST_ROOT}/fixtures/mitigated-action-guard.yml" << 'YAML'
 name: Mitigated With Action Guard
 on:
@@ -123,8 +124,10 @@ jobs:
     steps:
       - run: echo "Checking"
 YAML
+	return 0
+}
 
-	# ── Fixture: safe (no labeled trigger) ──
+_create_fixture_safe_no_labeled() {
 	cat > "${TEST_ROOT}/fixtures/safe-no-labeled.yml" << 'YAML'
 name: Safe No Labeled
 on:
@@ -139,8 +142,10 @@ jobs:
     steps:
       - run: echo "Checking"
 YAML
+	return 0
+}
 
-	# ── Fixture: safe (no cancel-in-progress) ──
+_create_fixture_safe_no_cancel() {
 	cat > "${TEST_ROOT}/fixtures/safe-no-cancel.yml" << 'YAML'
 name: Safe No Cancel
 on:
@@ -154,8 +159,10 @@ jobs:
     steps:
       - run: echo "Checking"
 YAML
+	return 0
+}
 
-	# ── Fixture: multi-line types form ──
+_create_fixture_vulnerable_multiline() {
 	cat > "${TEST_ROOT}/fixtures/vulnerable-multiline.yml" << 'YAML'
 name: Vulnerable Multiline Types
 on:
@@ -173,8 +180,10 @@ jobs:
     steps:
       - run: echo "Checking"
 YAML
+	return 0
+}
 
-	# ── Fixture: mitigated with step-level EVENT_ACTION guard ──
+_create_fixture_mitigated_step_guard() {
 	cat > "${TEST_ROOT}/fixtures/mitigated-step-guard.yml" << 'YAML'
 name: Mitigated Step Guard
 on:
@@ -198,6 +207,22 @@ jobs:
             exit 0
           fi
 YAML
+	return 0
+}
+
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+	mkdir -p "${TEST_ROOT}/fixtures"
+	export TEST_ROOT
+
+	_create_fixture_vulnerable
+	_create_fixture_vulnerable_pr
+	_create_fixture_mitigated_paths_ignore
+	_create_fixture_mitigated_action_guard
+	_create_fixture_safe_no_labeled
+	_create_fixture_safe_no_cancel
+	_create_fixture_vulnerable_multiline
+	_create_fixture_mitigated_step_guard
 
 	return 0
 }


### PR DESCRIPTION
Resolves #20058

## Summary

Decomposes the 153-line `setup_test_env()` function in `.agents/scripts/tests/test-workflow-cascade-lint.sh` into an orchestrator + 8 pure per-fixture helpers. No behavioural change; test suite passes byte-for-byte identically.

## Changes

- Extracted 8 `_create_fixture_*` helpers, one per YAML heredoc fixture:
  - `_create_fixture_vulnerable` — labeled + cancel-in-progress, no mitigation
  - `_create_fixture_vulnerable_pr` — labeled/unlabeled in PR types
  - `_create_fixture_mitigated_paths_ignore` — `paths-ignore` mitigation
  - `_create_fixture_mitigated_action_guard` — job-level `if` guard
  - `_create_fixture_safe_no_labeled` — no labeled trigger
  - `_create_fixture_safe_no_cancel` — no `cancel-in-progress`
  - `_create_fixture_vulnerable_multiline` — multi-line types form
  - `_create_fixture_mitigated_step_guard` — step-level `EVENT_ACTION` guard
- `setup_test_env()` is now a ~15-line orchestrator calling the helpers in order.
- Each helper ends with `return 0` per shell-style convention.

## Why this is the "pure helper" decomposition

These fixtures share no state beyond the `${TEST_ROOT}` global set by `setup_test_env()` before any helper runs. No bash-3.2 nameref workarounds needed — the memory lesson's easier case applies ("pure group helpers with no shared state").

## Verification

- `bash -n .agents/scripts/tests/test-workflow-cascade-lint.sh` — clean
- `shellcheck .agents/scripts/tests/test-workflow-cascade-lint.sh` — clean
- `complexity-scan-helper.sh metrics` — `Long functions (>100 lines): 0` (was 1)
- `bash .agents/scripts/tests/test-workflow-cascade-lint.sh` — 13/13 passed

## Session history

This issue had 4 prior worker dispatches (2× sonnet, 2× opus) — all died with `no_worker_process`/`process_exit` before producing a PR (GH#5317 class: prior-session infrastructure failure, not implementation failure). The last opus dispatch (`362c9974c`) actually completed the decomposition cleanly and pushed to this branch, but its session ended before step 4.2 (PR create). This PR continues from that commit after rebase onto current main, re-verification, and force-push.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.83 plugin for [OpenCode](https://opencode.ai) v1.14.18 with claude-opus-4-7 spent 7m and 19,662 tokens on this as a headless worker.