### PR TITLE
GH#20059: decompose task-brief-helper.sh:generate_brief() below 100 lines

### DIFF
--- a/.agents/scripts/task-brief-helper.sh
+++ b/.agents/scripts/task-brief-helper.sh
@@ -601,6 +601,93 @@ _enrich_context() {
 	return 0
 }
 
+# Check if the task's linked issue body is already worker-ready (t2417) and
+# write a stub brief linking to the issue instead of duplicating its content.
+# Arguments: task_id project_root
+# Returns: 0 if stub was written (caller should return early); 1 otherwise.
+_try_worker_ready_stub_brief() {
+	local task_id="$1"
+	local project_root="$2"
+
+	local _readiness_helper="$SCRIPT_DIR/brief-readiness-helper.sh"
+	[[ -x "$_readiness_helper" ]] || return 1
+
+	# Extract issue number from TODO.md ref:GH#NNN for this task
+	local _issue_ref=""
+	_issue_ref=$(grep -E "^\s*- \[.\] ${task_id} " "$project_root/TODO.md" 2>/dev/null \
+		| grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/ref:GH#//' || true)
+	[[ -n "$_issue_ref" ]] || return 1
+
+	local _slug=""
+	_slug=$(git -C "$project_root" remote get-url origin 2>/dev/null \
+		| sed -E 's#.*github\.com[:/]##; s/\.git$//' || true)
+	[[ -n "$_slug" ]] || return 1
+
+	local _body=""
+	_body=$(gh issue view "$_issue_ref" --repo "$_slug" --json body --jq '.body' 2>/dev/null) || true
+	[[ -n "$_body" ]] || return 1
+
+	local _readiness_output=""
+	_readiness_output=$("$_readiness_helper" check --body "$_body" 2>/dev/null) || true
+	if printf '%s\n' "$_readiness_output" | grep -q 'WORKER_READY=true'; then
+		log_info "$task_id: linked issue #${_issue_ref} body is worker-ready — writing stub brief"
+		"$_readiness_helper" stub "$task_id" "$_issue_ref" "$_slug" "$project_root" 2>/dev/null || true
+		return 0
+	fi
+
+	return 1
+}
+
+# Combine attribution derivation (Step 6) with context-block extraction
+# (Step 7). Outputs results via module-level globals, since bash 3.2 has
+# no local -n namerefs for multi-value returns.
+# Arguments:
+#   session_id session_title parent_session supervisor_info commit_author
+#   task_id context
+# Globals set:
+#   _BRIEF_SESSION_ORIGIN, _BRIEF_CREATED_BY, _BRIEF_CONTEXT_BLOCK, _BRIEF_SUP_ID
+_resolve_final_attribution() {
+	local session_id="$1"
+	local session_title="$2"
+	local parent_session="$3"
+	local supervisor_info="$4"
+	local commit_author="$5"
+	local task_id="$6"
+	local context="$7"
+
+	# Step 6: derive session_origin, created_by, sup_id from attribution helper
+	local session_origin="" created_by="" sup_id=""
+	while IFS='=' read -r key value; do
+		case "$key" in
+		SESSION_ORIGIN) session_origin="$value" ;;
+		CREATED_BY) created_by="$value" ;;
+		SUP_ID) sup_id="$value" ;;
+		esac
+	done <<<"$(_derive_attribution "$session_id" "$session_title" "$parent_session" \
+		"$supervisor_info" "$commit_author" "$task_id")"
+
+	# Step 7: extract context block and enrich session_origin
+	local context_block="" _in_ctx=0
+	while IFS= read -r line; do
+		case "$line" in
+		SESSION_ORIGIN=*) session_origin="${line#SESSION_ORIGIN=}" ;;
+		CONTEXT_BLOCK_START) _in_ctx=1 ;;
+		CONTEXT_BLOCK_END) _in_ctx=0 ;;
+		*)
+			if [[ "$_in_ctx" -eq 1 ]]; then
+				context_block="${context_block:+${context_block}$'\n'}${line}"
+			fi
+			;;
+		esac
+	done <<<"$(_enrich_context "$context" "$session_origin")"
+
+	_BRIEF_SESSION_ORIGIN="$session_origin"
+	_BRIEF_CREATED_BY="$created_by"
+	_BRIEF_CONTEXT_BLOCK="$context_block"
+	_BRIEF_SUP_ID="$sup_id"
+	return 0
+}
+
 generate_brief() {
 	local task_id
 	local project_root
@@ -612,34 +699,10 @@ generate_brief() {
 	validate_task_id "$task_id" || return 1
 	mkdir -p "$project_root/todo/tasks"
 
-	# Step 0 (t2417): Check if a linked issue body is already worker-ready.
-	# If so, write a stub brief linking to the issue instead of duplicating
-	# its content. The readiness helper scores the body against known heading
-	# sets (4-of-7 threshold) — see brief-readiness-helper.sh for details.
-	local _readiness_helper="$SCRIPT_DIR/brief-readiness-helper.sh"
-	if [[ -x "$_readiness_helper" ]]; then
-		# Extract issue number from TODO.md ref:GH#NNN for this task
-		local _issue_ref=""
-		_issue_ref=$(grep -E "^\s*- \[.\] ${task_id} " "$project_root/TODO.md" 2>/dev/null \
-			| grep -oE 'ref:GH#[0-9]+' | head -1 | sed 's/ref:GH#//' || true)
-		if [[ -n "$_issue_ref" ]]; then
-			local _slug=""
-			_slug=$(git -C "$project_root" remote get-url origin 2>/dev/null \
-				| sed -E 's#.*github\.com[:/]##; s/\.git$//' || true)
-			if [[ -n "$_slug" ]]; then
-				local _body=""
-				_body=$(gh issue view "$_issue_ref" --repo "$_slug" --json body --jq '.body' 2>/dev/null) || true
-				if [[ -n "$_body" ]]; then
-					local _readiness_output=""
-					_readiness_output=$("$_readiness_helper" check --body "$_body" 2>/dev/null) || true
-					if printf '%s\n' "$_readiness_output" | grep -q 'WORKER_READY=true'; then
-						log_info "$task_id: linked issue #${_issue_ref} body is worker-ready — writing stub brief"
-						"$_readiness_helper" stub "$task_id" "$_issue_ref" "$_slug" "$project_root" 2>/dev/null || true
-						return 0
-					fi
-				fi
-			fi
-		fi
+	# Step 0 (t2417): If linked issue body is already worker-ready, write a
+	# stub brief and return. See _try_worker_ready_stub_brief / GH#20015.
+	if _try_worker_ready_stub_brief "$task_id" "$project_root"; then
+		return 0
 	fi
 
 	# Step 1: Resolve commit
@@ -690,31 +753,14 @@ generate_brief() {
 	local task_block=""
 	[[ -f "$task_block_file" ]] && task_block=$(cat "$task_block_file") && rm -f "$task_block_file"
 
-	# Step 6: Derive session_origin and created_by
-	local session_origin="" created_by="" sup_id=""
-	while IFS='=' read -r key value; do
-		case "$key" in
-		SESSION_ORIGIN) session_origin="$value" ;;
-		CREATED_BY) created_by="$value" ;;
-		SUP_ID) sup_id="$value" ;;
-		esac
-	done <<<"$(_derive_attribution "$session_id" "$session_title" "$parent_session" \
-		"$supervisor_info" "$commit_author" "$task_id")"
-
-	# Step 7: Extract context block and enrich session_origin
-	local context_block="" _in_ctx=0
-	while IFS= read -r line; do
-		case "$line" in
-		SESSION_ORIGIN=*) session_origin="${line#SESSION_ORIGIN=}" ;;
-		CONTEXT_BLOCK_START) _in_ctx=1 ;;
-		CONTEXT_BLOCK_END) _in_ctx=0 ;;
-		*)
-			if [[ "$_in_ctx" -eq 1 ]]; then
-				context_block="${context_block:+${context_block}$'\n'}${line}"
-			fi
-			;;
-		esac
-	done <<<"$(_enrich_context "$context" "$session_origin")"
+	# Steps 6+7: Derive attribution and extract context block.
+	# Results arrive via _BRIEF_* globals (bash 3.2: no local -n namerefs).
+	_resolve_final_attribution "$session_id" "$session_title" "$parent_session" \
+		"$supervisor_info" "$commit_author" "$task_id" "$context"
+	local session_origin="$_BRIEF_SESSION_ORIGIN"
+	local created_by="$_BRIEF_CREATED_BY"
+	local context_block="$_BRIEF_CONTEXT_BLOCK"
+	local sup_id="$_BRIEF_SUP_ID"
 
 	local parent_task=""
 	if echo "$task_id" | grep -qE '\.'; then


### PR DESCRIPTION
## Summary

Decompose `generate_brief()` in `.agents/scripts/task-brief-helper.sh` from **129 lines to 88 lines** to clear the 100-line `function-complexity` threshold (GH#20059).

## Changes

Two helpers extracted; no behavioural change — same call order, same state transitions, same output file contents.

| helper | lines | scope |
|---|---|---|
| `_try_worker_ready_stub_brief` | 31 | Step 0 t2417 worker-ready stub check, returning 0 when a stub was written. |
| `_resolve_final_attribution` | 40 | Combines Step 6 attribution derivation + Step 7 context-block extraction, returning via module-level globals (bash 3.2 has no local -n namerefs). |

Module-level globals used by `_resolve_final_attribution`: `_BRIEF_SESSION_ORIGIN`, `_BRIEF_CREATED_BY`, `_BRIEF_CONTEXT_BLOCK`, `_BRIEF_SUP_ID`. Prefix follows the `_BATCH_*`-style convention for multi-value shell returns (memory recall: cmd_batch / GH#18705).

## Testing

- `bash -n .agents/scripts/task-brief-helper.sh` — syntax OK
- `shellcheck .agents/scripts/task-brief-helper.sh` — clean
- `complexity-regression-helper.sh check --metric function-complexity`:
  - base=31, head=30, **new=0**
- End-to-end smoke test in a `/tmp` scratch repo: fresh git init + 1-entry TODO.md + sourced helper → brief file produced with correct origin/commit/session metadata and specification block.

### Function sizes after refactor (all < 100)

```
generate_brief: 88 lines  (was 129)
_resolve_final_attribution: 40 lines  (new)
_try_worker_ready_stub_brief: 31 lines  (new)
_python_extract_task_block: 80 lines  (unchanged — Python heredoc)
_write_brief_file: 72 lines  (unchanged — markdown heredoc)
_resolve_session_info: 47 lines  (unchanged)
_derive_attribution: 43 lines  (unchanged)
_extract_todo_block: 41 lines  (unchanged)
find_session_by_timestamp: 38 lines  (unchanged)
```

Resolves #20059

---

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.84 plugin for [OpenCode](https://opencode.ai) v1.14.18 with claude-opus-4-7 spent 13m and 25,628 tokens on this as a headless worker.