### PR TITLE
t2431: fix(tests): unbreak silently-green tests after shared-gh-wrappers split + CI guard

### DIFF
--- a/.agents/reference/testing.md
+++ b/.agents/reference/testing.md
@@ -1,0 +1,137 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Testing Conventions
+
+This page documents repo-specific patterns for the shell test suite under
+`.agents/scripts/tests/`. It is intentionally short — most tests can be read
+top-to-bottom without any framework knowledge.
+
+## The `shared-constants.sh` copy pattern (t2431)
+
+A handful of tests copy `shared-constants.sh` into a temporary directory and
+source it from there. This is done so they can also install a stub
+`gh-signature-helper.sh` next to the copied file — the wrapper resolves the
+helper via `BASH_SOURCE` sibling lookup, so the stub must live in the same
+directory as the file being sourced.
+
+**The hard rule:** always copy `shared-constants.sh` via the helper, never
+bare.
+
+```bash
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+PARENT_DIR="${SCRIPT_DIR}/.."
+
+# shellcheck source=./lib/test-helpers.sh
+source "${SCRIPT_DIR}/lib/test-helpers.sh"
+
+TMPDIR_TEST=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+# Stubs go here...
+
+_test_copy_shared_deps "$PARENT_DIR" "$TMPDIR_TEST" || exit 1
+_test_source_shared_deps "$TMPDIR_TEST" || exit 1
+
+# Now gh_create_pr, gh_create_issue, _gh_wrapper_auto_sig, etc. are
+# defined and the test can assert their behaviour.
+```
+
+### Why a helper is mandatory
+
+`shared-constants.sh` is progressively split into sub-libraries — each split
+adds a new `source "${_SC_SELF%/*}/<sibling>.sh"` directive at file scope.
+Known splits so far:
+
+- PR #20037 (GH#20018) — extracted `gh_*` wrappers into `shared-gh-wrappers.sh`
+- PR #20066 (t2427) — extracted feature-toggle loading into `shared-feature-toggles.sh`
+
+Before t2431, tests that copied only `shared-constants.sh` to a tmpdir
+silently ran `set -euo pipefail` *after* sourcing, so the non-existent sibling
+source printed a warning and the rest of the test executed with the wrappers
+undefined — skipping every assertion and exiting 0. Two tests were affected:
+
+- `.agents/scripts/tests/test-gh-wrapper-auto-sig.sh` (30 assertions, 0 running)
+- `.agents/scripts/tests/test-comment-wrapper-marker-dedup.sh` (9 assertions, 0 running)
+
+Both tests were "green" in CI the entire time the regression was latent.
+
+The `_test_copy_shared_deps` helper parses `shared-constants.sh` for every
+`source "${_SC_SELF%/*}/<file>.sh"` directive and copies each sibling alongside
+the orchestrator. When a future split adds a new sibling, the helper picks
+it up automatically — no test-file edits required.
+
+### The CI guard
+
+`.github/workflows/test-harness-deps.yml` runs two checks on every relevant
+change:
+
+1. **Layer 3** — `.agents/scripts/shared-constants-deps-check.sh` greps for
+   any bare `cp ... shared-constants.sh` outside `tests/lib/test-helpers.sh`
+   and fails the build on hits. Comment lines that merely *describe* the
+   pattern (e.g., "use `_test_copy_shared_deps` rather than a bare
+   `cp shared-constants.sh`") are ignored — the check strips inline comments
+   before matching.
+2. **Layer 4** — the same script verifies that the helper's discovery regex
+   still matches the source-directive syntax in `shared-constants.sh`. If a
+   future rewrite uses a different syntax (e.g., `. ./sibling.sh` or
+   `source "$(dirname ...)/sibling.sh"`) the helper would silently return zero
+   deps; the check fails loudly with the candidate lines printed.
+
+The workflow also runs `test-test-helpers.sh` (the helper's own test) and
+the two previously-broken tests end-to-end, asserting that each emits at
+least one `PASS:` line. A test that runs to completion with zero assertions
+is the signature of the original regression class and fails the build.
+
+### Running the check locally
+
+```bash
+.agents/scripts/shared-constants-deps-check.sh
+bash .agents/scripts/tests/test-test-helpers.sh
+bash .agents/scripts/tests/test-gh-wrapper-auto-sig.sh
+bash .agents/scripts/tests/test-comment-wrapper-marker-dedup.sh
+```
+
+Clean output:
+
+```text
+OK: Layer 3: no bare `cp shared-constants.sh` outside helper
+OK: Layer 4: parser found N of N sibling source lines
+OK: all shared-constants deps checks passed
+```
+
+### Adding a new sub-library to shared-constants.sh
+
+1. Add the `source "${_SC_SELF%/*}/<new-sibling>.sh"` directive at file scope
+   in `shared-constants.sh`. No test-helper edits required — the parser
+   auto-discovers it.
+2. Run `.agents/scripts/shared-constants-deps-check.sh` locally — Layer 4
+   should show `parser found N+1 of N+1 sibling source lines`.
+3. Run `bash .agents/scripts/tests/test-test-helpers.sh` to confirm the
+   helper lands every dep (including the new one) in its synthetic tmpdir.
+
+If the new sub-library uses a *different* source syntax (e.g., conditional
+loading via `[[ -r ]]`, or a computed path), you must extend
+`_test_discover_shared_deps` in `tests/lib/test-helpers.sh` to match the
+new pattern — or accept that it won't be copied automatically (which is
+fine for conditional deps that tolerate absence).
+
+## Direct-source tests
+
+Most tests under `.agents/scripts/tests/` source `shared-constants.sh`
+directly from its real location (`${PARENT_DIR}/shared-constants.sh`). These
+tests work unchanged after a split because the siblings live alongside the
+orchestrator in the real tree. The copy-and-source pattern is only required
+when the test needs to co-locate stubs with the sourced file — typically
+for `BASH_SOURCE`-relative helper resolution.
+
+## General conventions
+
+- Each test sets `set -euo pipefail` at the top.
+- Each test prints `PASS: <name>` or `FAIL: <name>` per assertion and a final
+  `=== Results: X passed, Y failed ===` summary.
+- Exit 0 on all-pass, exit 1 on any failure. Exit 0 with zero `PASS:` lines is
+  caught by the t2431 CI guard.
+- Clean up tmpdirs via `trap 'rm -rf "$TMPDIR_TEST"' EXIT`.
+- Stub PATH commands (e.g., `gh`) by prepending a per-test `stub-bin`
+  directory to `PATH` in the test, not by globally shadowing them.

--- a/.agents/scripts/shared-constants-deps-check.sh
+++ b/.agents/scripts/shared-constants-deps-check.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# shared-constants-deps-check.sh (t2431)
+# =============================================================================
+# Layer 3 / Layer 4 guard for the test-harness `shared-constants.sh` split
+# regression class (issue #20069).
+#
+# Two responsibilities, both run as a single check:
+#   1. `layer3` — ban bare `cp .../shared-constants.sh ...` in test files
+#      outside of `.agents/scripts/tests/lib/test-helpers.sh`. Bare copies are
+#      the exact pattern that caused test-gh-wrapper-auto-sig.sh and
+#      test-comment-wrapper-marker-dedup.sh to silently exit 0 after PR #20037
+#      split out `shared-gh-wrappers.sh`. The only legitimate caller is the
+#      helper itself, which knows the current dep graph.
+#   2. `layer4` — verify that `_test_discover_shared_deps` (run against the
+#      on-disk `shared-constants.sh`) still succeeds and returns at least one
+#      sibling. This is a lightweight sanity check that the parser contract
+#      (match `source "${_SC_SELF%/*}/<file>.sh"` on a line by itself) still
+#      holds after any edit to shared-constants.sh. If shared-constants.sh is
+#      ever rewritten in a way that uses a different sibling-source syntax,
+#      this check will flag it immediately.
+#
+# Exit 0  = clean, all guards pass
+# Exit 1  = found bare `cp` outside the helper (Layer 3 failure)
+# Exit 2  = parser returned no siblings from shared-constants.sh — only an
+#           error when shared-constants.sh *does* have `source` directives
+#           for sub-libraries (otherwise legitimate state = exit 0). Best-effort
+#           heuristic: if a grep for `source "${_SC_SELF%/*}/` finds matches
+#           and the parser returns zero, something is wrong.
+# Exit 3  = invalid invocation / missing prerequisite file.
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit 3
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)" || exit 3
+
+TESTS_DIR="${SCRIPT_DIR}/tests"
+HELPER_REL_PATH="tests/lib/test-helpers.sh"
+SHARED_CONSTANTS="${SCRIPT_DIR}/shared-constants.sh"
+
+# Colors (only when stdout is a TTY so CI logs stay readable).
+if [[ -t 1 ]]; then
+	RED=$'\033[0;31m'
+	GREEN=$'\033[0;32m'
+	YELLOW=$'\033[0;33m'
+	RESET=$'\033[0m'
+else
+	RED=""
+	GREEN=""
+	YELLOW=""
+	RESET=""
+fi
+
+fail() {
+	local msg="$1"
+	printf '%sFAIL:%s %s\n' "$RED" "$RESET" "$msg" >&2
+	return 0
+}
+
+ok() {
+	local msg="$1"
+	printf '%sOK:%s %s\n' "$GREEN" "$RESET" "$msg"
+	return 0
+}
+
+warn() {
+	local msg="$1"
+	printf '%sWARN:%s %s\n' "$YELLOW" "$RESET" "$msg" >&2
+	return 0
+}
+
+# -----------------------------------------------------------------------------
+# Prerequisites
+# -----------------------------------------------------------------------------
+if [[ ! -d "$TESTS_DIR" ]]; then
+	fail "tests directory not found: $TESTS_DIR"
+	exit 3
+fi
+if [[ ! -f "$SHARED_CONSTANTS" ]]; then
+	fail "shared-constants.sh not found: $SHARED_CONSTANTS"
+	exit 3
+fi
+
+# -----------------------------------------------------------------------------
+# Layer 3: ban bare `cp shared-constants.sh` outside the helper
+# -----------------------------------------------------------------------------
+# Strategy: grep every file under .agents/scripts/tests/ for a `cp` call that
+# includes the string "shared-constants.sh". Exclude the helper file itself
+# (the one legitimate home for this pattern).
+#
+# False-positive guardrails:
+#  - We require `cp` to appear as a word (\bcp\b via -w), not inside another
+#    identifier.
+#  - We require the target filename to be the exact string "shared-constants.sh"
+#    (otherwise helper-internal comments that merely mention the name wouldn't
+#    trigger — but we DO grep code, so any comment-only hit is acceptable noise
+#    to flag).
+#
+# Output: a list of offending `file:line: <line>` entries.
+
+layer3_check() {
+	local bad=0
+	local offenders
+	# Strip inline comments before matching so test-file docstrings that
+	# describe the forbidden pattern (e.g. "use _test_copy_shared_deps
+	# rather than a bare `cp shared-constants.sh`") don't false-positive.
+	# Match `cp` only when it appears as a command (at line start or after
+	# a shell-command boundary: whitespace, `;`, `&&`, `||`, `|`, `(`).
+	# The helper file itself is the one legitimate home for this pattern.
+	local helper_abs="${SCRIPT_DIR}/${HELPER_REL_PATH}"
+	offenders=$(
+		find "$TESTS_DIR" -name '*.sh' -type f -not -path "$helper_abs" -print0 2>/dev/null |
+			while IFS= read -r -d '' file; do
+				awk -v f="$file" '
+					{
+						line = $0
+						# Strip from the first # onwards (naive but safe for our codebase).
+						sub(/#.*/, "", line)
+						if (line ~ /(^|[[:space:];&|(])cp([[:space:]]|$)/ && line ~ /shared-constants\.sh/) {
+							print f ":" NR ": " $0
+						}
+					}
+				' "$file"
+			done
+	)
+	if [[ -n "$offenders" ]]; then
+		fail "Layer 3: bare \`cp shared-constants.sh\` outside $HELPER_REL_PATH:"
+		printf '%s\n' "$offenders" | sed 's/^/  /' >&2
+		printf '\n' >&2
+		printf '%sFix:%s replace the bare cp with:\n' "$YELLOW" "$RESET" >&2
+		# shellcheck disable=SC2016  # literal snippet intended for user to copy
+		printf '  source "${SCRIPT_DIR}/lib/test-helpers.sh"\n' >&2
+		# shellcheck disable=SC2016
+		printf '  _test_copy_shared_deps "$PARENT_DIR" "$TMPDIR_TEST" || exit 1\n' >&2
+		# shellcheck disable=SC2016
+		printf '  _test_source_shared_deps "$TMPDIR_TEST" || exit 1\n' >&2
+		bad=1
+	else
+		ok "Layer 3: no bare \`cp shared-constants.sh\` outside helper"
+	fi
+	return "$bad"
+}
+
+# -----------------------------------------------------------------------------
+# Layer 4: verify parser contract still holds
+# -----------------------------------------------------------------------------
+# The helper's discovery regex is a single simple pattern:
+#   awk '/^source[[:space:]]/ && /_SC_SELF/ { ... }'
+#
+# If shared-constants.sh *has* sibling source directives (detectable via a
+# cheap grep), the helper MUST return a non-empty list. If the cheap grep
+# finds matches but the parser returns zero, either the parser broke OR
+# shared-constants.sh switched to a new syntax — both are actionable.
+
+layer4_check() {
+	local helper_path="${SCRIPT_DIR}/${HELPER_REL_PATH}"
+	if [[ ! -f "$helper_path" ]]; then
+		fail "Layer 4: helper missing — $helper_path"
+		return 1
+	fi
+
+	# Cheap grep: count candidate sibling-source lines.
+	local cheap_count
+	cheap_count=$(grep -cE '^source[[:space:]]+"\$\{_SC_SELF%/\*\}/' "$SHARED_CONSTANTS" || true)
+	cheap_count=${cheap_count:-0}
+
+	# Call the parser in a subshell so its errors / output don't leak.
+	local parsed_count=0
+	local parsed_out
+	parsed_out=$(
+		# shellcheck disable=SC1090
+		source "$helper_path"
+		_test_discover_shared_deps "$SCRIPT_DIR"
+	)
+	if [[ -n "$parsed_out" ]]; then
+		parsed_count=$(printf '%s\n' "$parsed_out" | wc -l | tr -d ' ')
+	fi
+
+	if [[ "$cheap_count" -eq 0 ]] && [[ "$parsed_count" -eq 0 ]]; then
+		ok "Layer 4: shared-constants.sh has no sub-library sources (nothing to parse)"
+		return 0
+	fi
+
+	if [[ "$cheap_count" -gt 0 ]] && [[ "$parsed_count" -eq 0 ]]; then
+		fail "Layer 4: shared-constants.sh has $cheap_count sibling source lines but parser found 0"
+		warn "The helper's discovery regex no longer matches the source syntax."
+		warn "Grep candidate lines:"
+		grep -nE '^source[[:space:]]+"\$\{_SC_SELF%/\*\}/' "$SHARED_CONSTANTS" | sed 's/^/  /' >&2
+		return 1
+	fi
+
+	ok "Layer 4: parser found $parsed_count of $cheap_count sibling source lines"
+	if [[ "$cheap_count" -ne "$parsed_count" ]]; then
+		warn "Parser and grep disagree on count ($parsed_count vs $cheap_count); sources may use variants."
+	fi
+	return 0
+}
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+main() {
+	local rc=0
+	layer3_check || rc=1
+	layer4_check || rc=${rc:-0}  # keep layer 3 exit code if that one failed too
+
+	if [[ "$rc" -eq 0 ]]; then
+		ok "all shared-constants deps checks passed"
+	fi
+	return "$rc"
+}
+
+main "$@"

--- a/.agents/scripts/tests/lib/test-helpers.sh
+++ b/.agents/scripts/tests/lib/test-helpers.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# Shared test-harness helpers (t2431)
+# =============================================================================
+# Centralises the "copy shared-constants.sh to a tmpdir and source it" pattern
+# so every test is picked up when shared-constants.sh grows new sub-library
+# dependencies.
+#
+# Background
+# ----------
+# `shared-constants.sh` is progressively split into sub-libraries to stay under
+# the 2000-line soft cap (examples: `shared-gh-wrappers.sh` via PR #20037 /
+# GH#20018, `shared-feature-toggles.sh` via PR #20066 / t2427). Each sub-library
+# is pulled in via a bare `source "${_SC_SELF%/*}/<filename>.sh"` directive at
+# file scope.
+#
+# Two tests in this repo (`test-gh-wrapper-auto-sig.sh` and
+# `test-comment-wrapper-marker-dedup.sh`) copy `shared-constants.sh` into a
+# temporary directory and source it from there so a stub `gh-signature-helper.sh`
+# can be resolved via `BASH_SOURCE` sibling-lookup. Before t2431 these tests
+# copied only `shared-constants.sh`, so sourcing the copy printed
+# "shared-gh-wrappers.sh: No such file or directory" and continued with
+# `set -euo pipefail` OFF (tests ran with the default shell options until that
+# point), leaving every subsequent assertion silently skipped. The tests
+# exited 0 with zero "PASS:" lines. This file removes that class of regression.
+#
+# Contract
+# --------
+# - `_test_discover_shared_deps <dir>` — echoes one filename per line for every
+#   bare `source "${_SC_SELF%/*}/<file>.sh"` directive in
+#   `<dir>/shared-constants.sh`. Conditional sources (guarded by `[[ -r ... ]]`
+#   or equivalent) are intentionally ignored — they are benign when the file
+#   is absent and do not break sourcing.
+# - `_test_copy_shared_deps <src_dir> <dest_dir>` — copies `shared-constants.sh`
+#   plus every sibling it discovers into `<dest_dir>`. Returns non-zero with a
+#   clear "FAIL:" message if any dep is missing in the source tree. Callers
+#   should `|| exit 1` after invoking it, or rely on `set -euo pipefail`.
+#
+# Invariants
+# ----------
+# - Any test that copies `shared-constants.sh` into a tmpdir MUST use this
+#   helper. Bare `cp ... shared-constants.sh` calls outside this helper are
+#   banned by `.agents/scripts/shared-constants-deps-check.sh` (t2431 Layer 3)
+#   and enforced by `.github/workflows/test-harness-deps.yml`.
+# - The discovery function is the single source of truth for the dependency
+#   graph; it never falls back to a hard-coded list. If parsing finds zero
+#   siblings it means shared-constants.sh has no sub-library sources (a real
+#   state), not that the parser is broken — the contract is stable because
+#   the source directive is always a simple one-line pattern at file scope.
+#
+# Usage example
+# -------------
+#
+#     # From a test at .agents/scripts/tests/test-foo.sh:
+#     SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+#     PARENT_DIR="${SCRIPT_DIR}/.."
+#     # shellcheck source=./lib/test-helpers.sh
+#     source "${SCRIPT_DIR}/lib/test-helpers.sh"
+#
+#     TMPDIR_TEST=$(mktemp -d)
+#     trap 'rm -rf "$TMPDIR_TEST"' EXIT
+#
+#     _test_copy_shared_deps "$PARENT_DIR" "$TMPDIR_TEST" || exit 1
+#     unset _SHARED_CONSTANTS_LOADED
+#     export AIDEVOPS_BASH_REEXECED=1
+#     # shellcheck source=/dev/null
+#     source "${TMPDIR_TEST}/shared-constants.sh"
+# =============================================================================
+
+# Include guard so the helper can be sourced multiple times without error.
+if [[ -n "${_TEST_HELPERS_LOADED:-}" ]]; then
+	return 0 2>/dev/null || exit 0
+fi
+_TEST_HELPERS_LOADED=1
+
+# -----------------------------------------------------------------------------
+# _test_discover_shared_deps <dir>
+# -----------------------------------------------------------------------------
+# Parses <dir>/shared-constants.sh and echoes every sibling file it sources
+# via the `source "${_SC_SELF%/*}/<filename>.sh"` pattern, one per line.
+#
+# Matches only UNCONDITIONAL, file-scope directives. Conditional sources
+# (e.g., `if [[ -r "$path" ]]; then source "$path"; fi` blocks inside
+# sub-libraries) are ignored: they tolerate missing siblings already.
+#
+# Arguments:
+#   $1 — absolute or relative path to a directory containing shared-constants.sh
+#
+# Outputs:
+#   One filename (basename only, e.g. `shared-gh-wrappers.sh`) per line.
+#   Empty output means `shared-constants.sh` has no sub-library sources.
+#
+# Returns:
+#   0 on success (including zero-match), 1 if the shared-constants.sh file
+#   is missing.
+# -----------------------------------------------------------------------------
+_test_discover_shared_deps() {
+	local src_dir="$1"
+	local shared_constants="${src_dir}/shared-constants.sh"
+
+	if [[ ! -f "$shared_constants" ]]; then
+		printf 'FAIL: shared-constants.sh not found at %s\n' "$shared_constants" >&2
+		return 1
+	fi
+
+	# Match lines that begin with `source "${_SC_SELF%/*}/<filename>.sh"`
+	# (no leading whitespace — file-scope only). Extract the basename.
+	awk '
+		/^source[[:space:]]/ && /_SC_SELF/ {
+			line = $0
+			# Strip everything up to and including the last slash
+			sub(/.*\//, "", line)
+			# Strip trailing quote and anything after it
+			sub(/".*/, "", line)
+			if (line != "") print line
+		}
+	' "$shared_constants"
+	return 0
+}
+
+# -----------------------------------------------------------------------------
+# _test_copy_shared_deps <src_dir> <dest_dir>
+# -----------------------------------------------------------------------------
+# Copies shared-constants.sh and every sibling it sources from <src_dir> into
+# <dest_dir>. The destination must already exist.
+#
+# Errors out (returns 1) if shared-constants.sh cites a sibling that does not
+# exist in <src_dir> — that state is a framework bug and should halt the test
+# rather than let it run with a silently broken orchestrator.
+#
+# Arguments:
+#   $1 — source directory (typically `.agents/scripts/`)
+#   $2 — destination directory (typically a `mktemp -d` tmpdir)
+#
+# Returns:
+#   0 on success, 1 on failure (with FAIL: message on stderr).
+# -----------------------------------------------------------------------------
+_test_copy_shared_deps() {
+	local src_dir="$1"
+	local dest_dir="$2"
+
+	if [[ ! -d "$src_dir" ]]; then
+		printf 'FAIL: source directory not found: %s\n' "$src_dir" >&2
+		return 1
+	fi
+	if [[ ! -d "$dest_dir" ]]; then
+		printf 'FAIL: destination directory not found: %s\n' "$dest_dir" >&2
+		return 1
+	fi
+
+	# Copy the orchestrator first.
+	if ! cp "${src_dir}/shared-constants.sh" "${dest_dir}/shared-constants.sh"; then
+		printf 'FAIL: could not copy shared-constants.sh from %s\n' "$src_dir" >&2
+		return 1
+	fi
+
+	# Discover siblings from the on-disk orchestrator and copy each one.
+	local sibling
+	local deps
+	deps=$(_test_discover_shared_deps "$src_dir") || return 1
+
+	# Iterate over discovered deps. Empty `deps` is fine — means no siblings.
+	while IFS= read -r sibling; do
+		[[ -z "$sibling" ]] && continue
+		if [[ ! -f "${src_dir}/${sibling}" ]]; then
+			printf 'FAIL: shared-constants.sh sources %s but file missing in %s\n' \
+				"$sibling" "$src_dir" >&2
+			return 1
+		fi
+		if ! cp "${src_dir}/${sibling}" "${dest_dir}/${sibling}"; then
+			printf 'FAIL: could not copy %s to %s\n' "$sibling" "$dest_dir" >&2
+			return 1
+		fi
+	done <<<"$deps"
+
+	return 0
+}
+
+# -----------------------------------------------------------------------------
+# _test_source_shared_deps <dest_dir>
+# -----------------------------------------------------------------------------
+# Convenience: source shared-constants.sh from <dest_dir> with error-checking.
+# Caller is responsible for having already called `_test_copy_shared_deps`.
+#
+# Clears the include guard so a re-source picks up a fresh state (tests often
+# source the helper once at the top and then source the orchestrator from a
+# tmpdir later). Exports AIDEVOPS_BASH_REEXECED=1 to skip the re-exec guard
+# when running under bash 3.2 on macOS.
+#
+# Arguments:
+#   $1 — destination directory (the same <dest_dir> used with _test_copy_shared_deps)
+#
+# Returns:
+#   0 on success, 1 on failure.
+# -----------------------------------------------------------------------------
+_test_source_shared_deps() {
+	local dest_dir="$1"
+	if [[ ! -f "${dest_dir}/shared-constants.sh" ]]; then
+		printf 'FAIL: %s/shared-constants.sh missing — did you call _test_copy_shared_deps?\n' \
+			"$dest_dir" >&2
+		return 1
+	fi
+
+	unset _SHARED_CONSTANTS_LOADED
+	export AIDEVOPS_BASH_REEXECED=1
+	# shellcheck source=/dev/null
+	if ! source "${dest_dir}/shared-constants.sh"; then
+		printf 'FAIL: sourcing %s/shared-constants.sh failed\n' "$dest_dir" >&2
+		return 1
+	fi
+	return 0
+}

--- a/.agents/scripts/tests/test-comment-wrapper-marker-dedup.sh
+++ b/.agents/scripts/tests/test-comment-wrapper-marker-dedup.sh
@@ -22,6 +22,11 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit
 PARENT_DIR="${SCRIPT_DIR}/.."
 
+# Pull in _test_copy_shared_deps / _test_source_shared_deps (t2431). See
+# lib/test-helpers.sh for the "copy shared-constants.sh + siblings" rationale.
+# shellcheck source=./lib/test-helpers.sh
+source "${SCRIPT_DIR}/lib/test-helpers.sh"
+
 PASS=0
 FAIL=0
 
@@ -83,7 +88,9 @@ exit 0
 STUB
 chmod +x "${TMPDIR_TEST}/gh-signature-helper.sh"
 
-cp "${PARENT_DIR}/shared-constants.sh" "${TMPDIR_TEST}/shared-constants.sh"
+# Copy shared-constants.sh AND every sibling it sources (shared-gh-wrappers.sh,
+# shared-feature-toggles.sh, ...) — see .agents/scripts/tests/lib/test-helpers.sh.
+_test_copy_shared_deps "$PARENT_DIR" "$TMPDIR_TEST" || exit 1
 
 STUB_DIR="${TMPDIR_TEST}/stub-bin"
 mkdir -p "$STUB_DIR"
@@ -119,10 +126,7 @@ chmod +x "${STUB_DIR}/gh"
 export PATH="${STUB_DIR}:$PATH"
 export GH_STUB_BODY_FILE="${TMPDIR_TEST}/gh-body.txt"
 
-unset _SHARED_CONSTANTS_LOADED
-export AIDEVOPS_BASH_REEXECED=1
-# shellcheck source=/dev/null
-source "${TMPDIR_TEST}/shared-constants.sh"
+_test_source_shared_deps "$TMPDIR_TEST" || exit 1
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Scenario 1: marker at the top of --body, wrapper appends sig, grep still finds

--- a/.agents/scripts/tests/test-gh-wrapper-auto-sig.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-auto-sig.sh
@@ -12,6 +12,13 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit
 PARENT_DIR="${SCRIPT_DIR}/.."
 
+# Pull in _test_copy_shared_deps / _test_source_shared_deps (t2431).
+# Without this, copying only shared-constants.sh into a tmpdir causes the
+# transitive `source "${_SC_SELF%/*}/shared-gh-wrappers.sh"` directive to
+# fail, leaving every assertion below silently skipped.
+# shellcheck source=./lib/test-helpers.sh
+source "${SCRIPT_DIR}/lib/test-helpers.sh"
+
 PASS=0
 FAIL=0
 
@@ -90,15 +97,12 @@ exit 0
 STUB
 chmod +x "${TMPDIR_TEST}/gh-signature-helper.sh"
 
-# Copy shared-constants.sh to the temp dir so BASH_SOURCE resolves the stub
-cp "${PARENT_DIR}/shared-constants.sh" "${TMPDIR_TEST}/shared-constants.sh"
-
-# Source with include guard reset to force reload
-unset _SHARED_CONSTANTS_LOADED
-# Prevent the re-exec guard from running by pretending we're already on bash 4+
-export AIDEVOPS_BASH_REEXECED=1
-# shellcheck source=/dev/null
-source "${TMPDIR_TEST}/shared-constants.sh"
+# Copy shared-constants.sh AND every sub-library it sources (shared-gh-wrappers.sh,
+# shared-feature-toggles.sh, ...) to the temp dir. BASH_SOURCE in the copy then
+# resolves the stub gh-signature-helper.sh AND every chained `source` directive.
+# Use _test_copy_shared_deps rather than a bare `cp shared-constants.sh` (t2431).
+_test_copy_shared_deps "$PARENT_DIR" "$TMPDIR_TEST" || exit 1
+_test_source_shared_deps "$TMPDIR_TEST" || exit 1
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Test 1: --body without signature gets footer appended

--- a/.agents/scripts/tests/test-test-helpers.sh
+++ b/.agents/scripts/tests/test-test-helpers.sh
@@ -1,0 +1,240 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# Meta-test for tests/lib/test-helpers.sh (t2431)
+# =============================================================================
+# Verifies:
+#  1. `_test_discover_shared_deps` finds every sibling file sourced by
+#     shared-constants.sh (auto-stays-in-sync when new siblings are added).
+#  2. `_test_copy_shared_deps` copies all discovered deps into a fresh tmpdir
+#     AND returns a non-zero exit + clear error when a dep is missing from
+#     the source tree (so future splits cannot introduce the "silent green"
+#     regression class).
+#  3. `_test_source_shared_deps` loads the copied orchestrator and the
+#     wrapper functions (`gh_create_pr`, `gh_create_issue`, `gh_issue_comment`,
+#     `gh_pr_comment`, `_gh_wrapper_auto_sig`) are callable after setup.
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit
+PARENT_DIR="${SCRIPT_DIR}/.."
+
+# shellcheck source=./lib/test-helpers.sh
+source "${SCRIPT_DIR}/lib/test-helpers.sh"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+	local test_name="$1"
+	local expected="$2"
+	local actual="$3"
+	if [[ "$expected" == "$actual" ]]; then
+		echo "  PASS: $test_name"
+		PASS=$((PASS + 1))
+	else
+		echo "  FAIL: $test_name"
+		echo "    expected: $expected"
+		echo "    actual:   $actual"
+		FAIL=$((FAIL + 1))
+	fi
+	return 0
+}
+
+assert_nonzero() {
+	local test_name="$1"
+	local actual="$2"
+	if [[ "$actual" -ne 0 ]]; then
+		echo "  PASS: $test_name"
+		PASS=$((PASS + 1))
+	else
+		echo "  FAIL: $test_name — expected non-zero exit"
+		FAIL=$((FAIL + 1))
+	fi
+	return 0
+}
+
+assert_func_defined() {
+	local test_name="$1"
+	local func="$2"
+	if declare -F "$func" >/dev/null 2>&1; then
+		echo "  PASS: $test_name"
+		PASS=$((PASS + 1))
+	else
+		echo "  FAIL: $test_name — function $func not defined after setup"
+		FAIL=$((FAIL + 1))
+	fi
+	return 0
+}
+
+echo "=== tests/lib/test-helpers.sh meta-test (t2431) ==="
+echo ""
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 1: discovery returns at least one sibling (parser is not silently empty)
+# ─────────────────────────────────────────────────────────────────────────────
+echo "Test 1: _test_discover_shared_deps returns sibling file list"
+deps_output=$(_test_discover_shared_deps "$PARENT_DIR")
+dep_count=0
+if [[ -n "$deps_output" ]]; then
+	dep_count=$(printf '%s\n' "$deps_output" | wc -l | tr -d ' ')
+fi
+if [[ "$dep_count" -ge 1 ]]; then
+	echo "  PASS: at least one sibling discovered ($dep_count found)"
+	PASS=$((PASS + 1))
+else
+	echo "  FAIL: _test_discover_shared_deps returned no siblings — parser broken?"
+	FAIL=$((FAIL + 1))
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 2: every discovered sibling exists on disk
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Test 2: every discovered sibling exists on disk"
+missing=0
+while IFS= read -r sibling; do
+	[[ -z "$sibling" ]] && continue
+	if [[ ! -f "${PARENT_DIR}/${sibling}" ]]; then
+		echo "  FAIL: sibling $sibling cited in shared-constants.sh but missing"
+		missing=$((missing + 1))
+	fi
+done <<<"$deps_output"
+assert_eq "all discovered siblings exist on disk" "0" "$missing"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 3: copy succeeds and all discovered files land in dest
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Test 3: _test_copy_shared_deps copies orchestrator + every sibling"
+tmpdir=$(mktemp -d 2>/dev/null || mktemp -d -t helpertest)
+# shellcheck disable=SC2064  # expand at trap-set time; we want $tmpdir captured now
+trap "rm -rf '$tmpdir'" EXIT
+
+if _test_copy_shared_deps "$PARENT_DIR" "$tmpdir"; then
+	echo "  PASS: _test_copy_shared_deps returned 0"
+	PASS=$((PASS + 1))
+else
+	echo "  FAIL: _test_copy_shared_deps returned non-zero"
+	FAIL=$((FAIL + 1))
+fi
+
+# Verify shared-constants.sh landed
+if [[ -f "${tmpdir}/shared-constants.sh" ]]; then
+	echo "  PASS: shared-constants.sh landed in tmpdir"
+	PASS=$((PASS + 1))
+else
+	echo "  FAIL: shared-constants.sh missing from tmpdir"
+	FAIL=$((FAIL + 1))
+fi
+
+# Verify each discovered sibling landed
+while IFS= read -r sibling; do
+	[[ -z "$sibling" ]] && continue
+	if [[ -f "${tmpdir}/${sibling}" ]]; then
+		echo "  PASS: $sibling landed in tmpdir"
+		PASS=$((PASS + 1))
+	else
+		echo "  FAIL: $sibling missing from tmpdir"
+		FAIL=$((FAIL + 1))
+	fi
+done <<<"$deps_output"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 4: sourcing the copy succeeds and wrappers are callable
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Test 4: _test_source_shared_deps loads orchestrator + wrappers are defined"
+if _test_source_shared_deps "$tmpdir"; then
+	echo "  PASS: _test_source_shared_deps returned 0"
+	PASS=$((PASS + 1))
+else
+	echo "  FAIL: _test_source_shared_deps returned non-zero"
+	FAIL=$((FAIL + 1))
+fi
+
+assert_func_defined "gh_create_pr defined after source" "gh_create_pr"
+assert_func_defined "gh_create_issue defined after source" "gh_create_issue"
+assert_func_defined "gh_issue_comment defined after source" "gh_issue_comment"
+assert_func_defined "gh_pr_comment defined after source" "gh_pr_comment"
+assert_func_defined "_gh_wrapper_auto_sig defined after source" "_gh_wrapper_auto_sig"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 5: copy fails loudly when a dep is missing (simulate future split with
+#         incomplete sync).
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Test 5: _test_copy_shared_deps fails when a dep is missing from src_dir"
+
+# Build a synthetic src_dir with shared-constants.sh that cites a phantom file.
+fake_src=$(mktemp -d 2>/dev/null || mktemp -d -t fakesrc)
+# shellcheck disable=SC2064
+trap "rm -rf '$tmpdir' '$fake_src'" EXIT
+
+cat >"${fake_src}/shared-constants.sh" <<'EOF'
+#!/usr/bin/env bash
+_SC_SELF="${BASH_SOURCE[0]:-${0:-}}"
+source "${_SC_SELF%/*}/phantom-sibling.sh"
+EOF
+
+fake_dest=$(mktemp -d 2>/dev/null || mktemp -d -t fakedest)
+# shellcheck disable=SC2064
+trap "rm -rf '$tmpdir' '$fake_src' '$fake_dest'" EXIT
+
+rc=0
+_test_copy_shared_deps "$fake_src" "$fake_dest" 2>/dev/null || rc=$?
+assert_nonzero "copy rejects phantom dep" "$rc"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 6: discover returns empty (not an error) when shared-constants.sh has
+#         no sibling sources — required so the contract is "presence of deps
+#         is data, not truth-of-existence".
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Test 6: discovery returns empty list for shared-constants.sh with no siblings"
+empty_src=$(mktemp -d 2>/dev/null || mktemp -d -t emptysrc)
+# shellcheck disable=SC2064
+trap "rm -rf '$tmpdir' '$fake_src' '$fake_dest' '$empty_src'" EXIT
+cat >"${empty_src}/shared-constants.sh" <<'EOF'
+#!/usr/bin/env bash
+# Hypothetical orchestrator with no sub-library sources.
+echo "hello"
+EOF
+
+out=$(_test_discover_shared_deps "$empty_src")
+assert_eq "no deps discovered for simple orchestrator" "" "$out"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 7: discover ignores conditional sources (guarded by [[ -r ... ]])
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Test 7: conditional sources are ignored (not reported as deps)"
+cond_src=$(mktemp -d 2>/dev/null || mktemp -d -t condsrc)
+# shellcheck disable=SC2064
+trap "rm -rf '$tmpdir' '$fake_src' '$fake_dest' '$empty_src' '$cond_src'" EXIT
+cat >"${cond_src}/shared-constants.sh" <<'EOF'
+#!/usr/bin/env bash
+_SC_SELF="${BASH_SOURCE[0]:-${0:-}}"
+# Unconditional source — SHOULD be discovered
+source "${_SC_SELF%/*}/real-sibling.sh"
+# Conditional source — should NOT be discovered
+_MAYBE="${_SC_SELF%/*}/optional-sibling.sh"
+if [[ -r "$_MAYBE" ]]; then
+	source "$_MAYBE"
+fi
+EOF
+out=$(_test_discover_shared_deps "$cond_src")
+assert_eq "only unconditional source discovered" "real-sibling.sh" "$out"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Summary
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "=== Results: $PASS passed, $FAIL failed ==="
+
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/.github/workflows/test-harness-deps.yml
+++ b/.github/workflows/test-harness-deps.yml
@@ -1,0 +1,97 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# t2431 — Test-harness dependency guard
+#
+# Ensures:
+#  Layer 3: No test file under .agents/scripts/tests/ uses a bare
+#           `cp shared-constants.sh` outside of the central helper
+#           .agents/scripts/tests/lib/test-helpers.sh. Bare copies are the
+#           exact pattern that left test-gh-wrapper-auto-sig.sh and
+#           test-comment-wrapper-marker-dedup.sh silently green after
+#           PR #20037 split out shared-gh-wrappers.sh.
+#
+#  Layer 4: The helper's sibling-discovery regex still matches the
+#           source-directive syntax used in shared-constants.sh. If a
+#           future rewrite of shared-constants.sh uses a different
+#           syntax (e.g., `. ./sibling.sh` instead of `source "${_SC_SELF%/*}/sibling.sh"`),
+#           the helper would silently return zero deps and every test
+#           using it would regress to the silent-green state. This check
+#           fails loudly when that happens.
+#
+# Also runs the two previously-broken tests end-to-end so a regression in
+# the helper itself is caught immediately (rather than waiting for those
+# tests to be flipped back to "bare cp" behaviour elsewhere).
+
+name: Test Harness Deps (t2431)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - ".agents/scripts/shared-constants.sh"
+      - ".agents/scripts/shared-gh-wrappers.sh"
+      - ".agents/scripts/shared-feature-toggles.sh"
+      - ".agents/scripts/shared-constants-deps-check.sh"
+      - ".agents/scripts/tests/lib/test-helpers.sh"
+      - ".agents/scripts/tests/test-gh-wrapper-auto-sig.sh"
+      - ".agents/scripts/tests/test-comment-wrapper-marker-dedup.sh"
+      - ".agents/scripts/tests/test-test-helpers.sh"
+      - ".github/workflows/test-harness-deps.yml"
+  pull_request:
+    paths:
+      - ".agents/scripts/shared-constants.sh"
+      - ".agents/scripts/shared-gh-wrappers.sh"
+      - ".agents/scripts/shared-feature-toggles.sh"
+      - ".agents/scripts/shared-constants-deps-check.sh"
+      - ".agents/scripts/tests/lib/test-helpers.sh"
+      - ".agents/scripts/tests/test-gh-wrapper-auto-sig.sh"
+      - ".agents/scripts/tests/test-comment-wrapper-marker-dedup.sh"
+      - ".agents/scripts/tests/test-test-helpers.sh"
+      - ".github/workflows/test-harness-deps.yml"
+      - ".agents/scripts/tests/**/*.sh"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  guard:
+    name: shared-constants deps guard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Layer 3 + Layer 4 deps check
+        run: |
+          bash .agents/scripts/shared-constants-deps-check.sh
+
+      - name: Run test-helpers meta-test
+        run: |
+          bash .agents/scripts/tests/test-test-helpers.sh
+
+      - name: Run test-gh-wrapper-auto-sig (must assert, not silently skip)
+        run: |
+          output=$(bash .agents/scripts/tests/test-gh-wrapper-auto-sig.sh)
+          echo "$output"
+          # Guard against the silent-green regression: the test MUST emit
+          # at least one "PASS:" line. If it exits 0 with zero assertions,
+          # fail this job — that is the exact failure mode t2431 addresses.
+          if ! printf '%s' "$output" | grep -q "PASS:"; then
+            echo "::error::test-gh-wrapper-auto-sig.sh ran to completion but emitted zero PASS lines." >&2
+            echo "::error::This is the silent-green regression class (t2431)." >&2
+            exit 1
+          fi
+
+      - name: Run test-comment-wrapper-marker-dedup (must assert, not silently skip)
+        run: |
+          output=$(bash .agents/scripts/tests/test-comment-wrapper-marker-dedup.sh)
+          echo "$output"
+          if ! printf '%s' "$output" | grep -q "PASS:"; then
+            echo "::error::test-comment-wrapper-marker-dedup.sh ran to completion but emitted zero PASS lines." >&2
+            echo "::error::This is the silent-green regression class (t2431)." >&2
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Fixes #20069 — the silent test-harness regression introduced when PR #20037 (and later PR #20066) extracted sibling sub-libraries from shared-constants.sh. Two tests (test-gh-wrapper-auto-sig.sh, test-comment-wrapper-marker-dedup.sh) copied only shared-constants.sh into a tmpdir; the transitive source of the new siblings failed, leaving every assertion silently skipped. Both tests went from 0 running assertions to 39 running assertions. Adds four layers of prevention: a central tests/lib/test-helpers.sh that auto-discovers siblings via awk parsing of shared-constants.sh; a meta-test (test-test-helpers.sh, 15 assertions) that verifies the helper itself; a shared-constants-deps-check.sh guard script with Layer 3 (ban bare `cp shared-constants.sh` outside the helper, with inline-comment stripping to avoid false positives) and Layer 4 (verify discovery regex still matches the source-directive syntax); a new .github/workflows/test-harness-deps.yml that runs the guard AND re-runs the previously-broken tests with a silent-green detector (any PASS-less run fails). Documentation added at .agents/reference/testing.md explaining the pattern and what to do when adding a new sub-library to shared-constants.sh.

## Files Changed

.agents/reference/testing.md,.agents/scripts/shared-constants-deps-check.sh,.agents/scripts/tests/lib/test-helpers.sh,.agents/scripts/tests/test-comment-wrapper-marker-dedup.sh,.agents/scripts/tests/test-gh-wrapper-auto-sig.sh,.agents/scripts/tests/test-test-helpers.sh,.github/workflows/test-harness-deps.yml,.task-counter

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean on all 5 affected files; test-test-helpers.sh: 15 PASS/0 FAIL; test-gh-wrapper-auto-sig.sh: 30 PASS/0 FAIL (was 0 assertions); test-comment-wrapper-marker-dedup.sh: 9 PASS/0 FAIL (was 0 assertions); shared-constants-deps-check.sh: passes on this tree and catches a synthetic `cp shared-constants.sh` violation; sanity regression verified — corrupting _gh_wrapper_auto_sig makes the test exit 1 with 6 FAILs (previously would have silently exited 0); adjacent tests unaffected.

Resolves #20069


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.85 plugin for [OpenCode](https://opencode.ai) v1.14.18 with claude-opus-4-7 spent 19m and 54,348 tokens on this as a headless worker.