### PR TITLE
t2430: rewrite nesting-depth scanner using shfmt AST walker

### DIFF
--- a/.agents/reference/large-file-split.md
+++ b/.agents/reference/large-file-split.md
@@ -110,7 +110,7 @@ depending on the metric.
 |--------|-------------|-------------|--------|
 | `function-complexity` | `(file, fname)` | Moving a >100-line function to a new file re-registers it as a **new** violation. | Functions over 100 lines **MUST stay in the original file**. Example: `_run_canary_test` stayed in `headless-runtime-lib.sh` (PR #19821). |
 | `file-size` | `(file)` | Splitting automatically resolves the original file's violation. New sub-files are typically under the threshold. | No special action needed. |
-| `nesting-depth` | `(file, 'NEST')` | Splitting into new files creates new `(newfile, 'NEST')` keys. Expect `+N new` regressions. | This is a **known false positive** -- see section 4. Override with `complexity-bump-ok` label. |
+| `nesting-depth` | `(file, 'NEST')` | Splitting into new files creates new `(newfile, 'NEST')` keys. With the shfmt-based scanner (t2430), reported depths are accurate per-function measurements, so `+N new` regressions reflect real nesting. | Review each new violation. If real nesting >8 exists, refactor the function. The `complexity-bump-ok` label is available as a last resort. |
 | `bash32-compat` | `(construct)` | Splitting is neutral -- the construct identity doesn't include the file. | No special action needed. |
 
 **Critical rule**: before splitting, run `complexity-regression-helper.sh check`
@@ -119,43 +119,32 @@ target file. Those functions stay put.
 
 ## 4. Known CI False-Positive Classes on Splits
 
-### 4.1 Nesting-depth scanner
+### 4.1 Nesting-depth scanner (t2430 — rewritten)
 
-`scan_dir_nesting_depth` at `complexity-regression-helper.sh:225-256` is a
-global `elif`-counting AWK, not a real nesting metric:
+As of t2430, `scan_dir_nesting_depth` uses a `shfmt --to-json` AST walker
+(`scanners/nesting-depth.sh`) that computes accurate per-function nesting
+depth. The four false-positive classes from the old AWK scanner are
+eliminated by construction:
 
-```awk
-/[[:space:]]*(if|for|while|until|case)[[:space:]]/ { depth++; ... }
-/[[:space:]]*(fi|done|esac)[[:space:]]*$/ || /^[[:space:]]*(fi|done|esac)$/ { if(depth>0) depth-- }
-```
+1. **elif** — AST represents elif as nested IfClause in `.Else`; walker
+   treats as same depth (not double-counted).
+2. **Prose keywords** — string content is not tokenized as control flow.
+3. **`done <<<"$x"`** — WhileClause closes normally regardless of redirect.
+4. **Global counter** — FuncDecl nodes provide natural per-function reset.
 
-The open-regex matches `elif` because `elif` contains the literal substring
-`if` preceded by optional whitespace. Each `elif` increments `depth` but
-has no corresponding close, so `if/elif/elif/fi` opens +3 but only closes -1.
-Every `elif` chain inflates the counter permanently.
+**Verification**: `headless-runtime-lib.sh` now scores `max_depth=4` (real
+max per-function depth), down from the old AWK's `max_depth=83`.
 
-**Evidence**: the pre-split `headless-runtime-lib.sh` (2107 lines) scored
-`max_depth=83` -- physically impossible; bash has no code path that nests
-83 levels deep.
+**Implication for file splits**: nesting-depth regressions on file splits
+now reflect real nesting. If a split creates `+N new` nesting violations,
+the functions genuinely nest >8 levels deep and should be refactored. The
+`complexity-bump-ok` override is still available as a last resort but
+should rarely be needed for nesting-depth specifically.
 
-**Override procedure**:
-
-1. Apply the `complexity-bump-ok` label to the PR.
-2. Add a `## Complexity Bump Justification` section to the PR body with:
-   - The scanner evidence (file:line ref showing the `elif` pattern)
-   - The measurement (`base=N, head=M, new=K`)
-   - Explanation that the new violations are identity-key artifacts, not real nesting increases.
-
-**Worker self-apply (t2370):** Workers dispatched against file-split or
-simplification issues may self-apply the `complexity-bump-ok` label. The
-`.github/workflows/complexity-bump-justification-check.yml` workflow triggers
-on the `labeled` event and validates that the PR body contains the required
-justification section with at least one `file:line` reference and a numeric measurement.
-If validation fails, the workflow removes the label and posts a remediation
-comment explaining what is missing. The label only sticks when the
-justification is complete -- no maintainer intervention required for
-legitimate splits. This mirrors the `new-file-smell-ok` + justification-section
-pattern from `qlty-new-file-gate.yml`.
+**Graceful degradation**: when `shfmt` is unavailable, the scanner falls
+back to the legacy AWK with a warning on stderr. The AWK fallback retains
+all four false-positive classes — environments without `shfmt` should use
+`COMPLEXITY_GUARD_DISABLE=1` for known false positives.
 
 ### 4.2 Pre-push complexity guard
 
@@ -254,31 +243,23 @@ cannot be statically followed without `-x`).
   - `file-size`: base=<N>, head=<N>, **new=0**
   - `function-complexity`: base=<N>, head=<N>, **new=0**
   - `bash32-compat`: base=<N>, head=<N>, **new=0**
-  - `nesting-depth`: base=<N>, head=<N>, new=<K> -- see justification below
+  - `nesting-depth`: base=<N>, head=<N>, new=<K> -- <if K>0, document the functions and their real depth>
 
 ## Complexity Bump Justification
 
-**`complexity-bump-ok` label applied.** The nesting-depth scanner reports <K>
-new violations solely because the `(file, 'NEST')` identity key changes when
-code moves to freshly-named files. The metric is not real nesting depth.
+> **Note (t2430):** As of t2430, the nesting-depth scanner uses a shfmt AST
+> walker that measures real per-function depth. Nesting-depth regressions on
+> file splits now reflect genuine nesting. If new=0, delete this section. If
+> new>0, document the specific functions and their real depth below.
 
-**Evidence that the scanner is not measuring real nesting:**
+**`complexity-bump-ok` label applied.** The following functions have nesting
+depth >8 and are candidates for refactoring in a follow-up task:
 
-- `scan_dir_nesting_depth` in `complexity-regression-helper.sh:225-256` is a
-  single global AWK counter that increments on any line matching
-  `/[[:space:]]*(if|for|while|until|case)[[:space:]]/` and decrements on
-  `fi|done|esac`. It has no function scoping.
-- The open-regex also matches the literal string `if` in `elif`. Each `elif`
-  chain inflates the counter permanently.
-- `origin/main`'s current `<original-file>` scans as **max_depth=<N>** --
-  physically impossible; bash has no code path that nests <N> levels deep.
-- Per-function nesting is unchanged. The `function-complexity` metric confirms
-  `base=<N> head=<N> new=0`.
+- `<function_name>` in `<file>`: depth=<N> (reason: <brief explanation>)
 
-**Pre-existing debt moved, not introduced:** all the `elif`-chain patterns
-that trip the scanner were already in the <N>-line file. The split relocates
-them, it does not create them. Apply `complexity-bump-ok` per the documented
-override procedure.
+**Pre-existing depth moved, not introduced:** these functions had the same
+nesting depth in the original file. The split relocates them without
+changing their structure.
 
 ## Related
 
@@ -326,7 +307,7 @@ Expected results for a well-executed split:
 - `file-size`: `new=0` (original >threshold file cleared)
 - `function-complexity`: `new=0` (large functions stayed in original file)
 - `bash32-compat`: `new=0` (splitting is neutral)
-- `nesting-depth`: `new>=0` (document any `new>0` in PR body per section 4.1)
+- `nesting-depth`: `new>=0` (with the shfmt scanner (t2430), any `new>0` reflects real per-function depth >8; refactor or document per section 4.1)
 
 ### 7.4 Pre-push dry run
 

--- a/.agents/scripts/complexity-regression-helper.sh
+++ b/.agents/scripts/complexity-regression-helper.sh
@@ -217,11 +217,16 @@ scan_dir_function_complexity() {
 # ---------------------------------------------------------------------------
 # scan_dir_nesting_depth <dir> [<out-file>]
 #
-# Shell files with global max nesting depth >8. Output: <file>\tNEST\t<depth>.
-# Identity key: (file, 'NEST'). (t2171)
+# Shell files with per-function max nesting depth >8. Output: <file>\tNEST\t<depth>.
+# Identity key: (file, 'NEST'). (t2171, rewritten t2430)
 #
-# Uses the same global-counter AWK pattern as code-quality.yml:502-508 — it
-# does NOT reset depth at function boundaries, matching the existing CI gate.
+# Uses shfmt --to-json AST walker (scanners/nesting-depth.sh) for accurate
+# per-function depth measurement. Falls back to legacy AWK when shfmt is
+# unavailable. Eliminates four false-positive classes from the old AWK scanner:
+#   1. elif matches if (inflated counter)
+#   2. Prose containing bare keywords (printf "for all users")
+#   3. done <<<"$x" not recognized as close
+#   4. Global counter never resets between functions
 # ---------------------------------------------------------------------------
 scan_dir_nesting_depth() {
 	local _dir="$1"
@@ -237,18 +242,34 @@ scan_dir_nesting_depth() {
 	local _result_file
 	_result_file=$(_open_result_file "$_out")
 
+	# Resolve scanner path: co-located in the same repo tree, or deployed.
+	local _scanner=""
+	local _script_dir
+	_script_dir="$(cd "$(dirname "$0")" && pwd)"
+	if [ -f "${_script_dir}/scanners/nesting-depth.sh" ]; then
+		_scanner="${_script_dir}/scanners/nesting-depth.sh"
+	elif [ -f "${HOME}/.aidevops/agents/scripts/scanners/nesting-depth.sh" ]; then
+		_scanner="${HOME}/.aidevops/agents/scripts/scanners/nesting-depth.sh"
+	fi
+
 	local _file _rel_file _max_depth
 	while IFS= read -r _file; do
 		[ -n "$_file" ] || continue
 		[ -f "$_file" ] || continue
 		_rel_file="${_file#"${_dir}/"}"
-		_max_depth=$(awk '
-			BEGIN { depth=0; max_depth=0 }
-			/^[[:space:]]*#/ { next }
-			/[[:space:]]*(if|for|while|until|case)[[:space:]]/ { depth++; if(depth>max_depth) max_depth=depth }
-			/[[:space:]]*(fi|done|esac)[[:space:]]*$/ || /^[[:space:]]*(fi|done|esac)$/ { if(depth>0) depth-- }
-			END { print max_depth }
-		' "$_file" 2>/dev/null || echo 0)
+
+		if [ -n "$_scanner" ]; then
+			_max_depth=$(bash "$_scanner" "$_file" 2>/dev/null) || _max_depth=0
+		else
+			# Inline AWK fallback when scanner script is missing
+			_max_depth=$(awk '
+				BEGIN { depth=0; max_depth=0 }
+				/^[[:space:]]*#/ { next }
+				/[[:space:]]*(if|for|while|until|case)[[:space:]]/ { depth++; if(depth>max_depth) max_depth=depth }
+				/[[:space:]]*(fi|done|esac)[[:space:]]*$/ || /^[[:space:]]*(fi|done|esac)$/ { if(depth>0) depth-- }
+				END { print max_depth }
+			' "$_file" 2>/dev/null || echo 0)
+		fi
 
 		if [ "${_max_depth:-0}" -gt 8 ] 2>/dev/null; then
 			printf '%s\tNEST\t%s\n' "$_rel_file" "$_max_depth" >>"$_result_file"

--- a/.agents/scripts/scanners/nesting-depth.sh
+++ b/.agents/scripts/scanners/nesting-depth.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# nesting-depth.sh — compute per-function max nesting depth using shfmt AST
+#
+# Usage:
+#   nesting-depth.sh <file>
+#     Prints the per-function max nesting depth for <file>.
+#     Output: one integer (the file-level max depth across all functions
+#     and top-level code).
+#
+#   nesting-depth.sh --per-function <file>
+#     Prints per-function breakdown: <function>\t<depth> per line.
+#
+# Approach B (t2430): walks the shfmt --to-json AST depth-first, counting
+# IfClause, ForClause, WhileClause, CaseClause as nesting levels. FuncDecl
+# nodes give natural per-function boundaries. elif chains are correctly
+# handled as same-depth (not double-counted). All four documented false-
+# positive classes from the old AWK scanner are eliminated by construction:
+#
+#   1. elif matches if           — AST: elif is nested IfClause in .Else,
+#                                  walker treats as same depth.
+#   2. Prose containing keywords — AST: string content not tokenized as
+#                                  control flow.
+#   3. done <<<"$x" not close    — AST: WhileClause closes normally
+#                                  regardless of redirect syntax.
+#   4. Global counter no reset   — AST: FuncDecl nodes provide natural
+#                                  per-function boundaries.
+#
+# Graceful degradation: when shfmt is unavailable, falls back to the legacy
+# AWK scanner with a warning on stderr.
+#
+# Dependencies: shfmt (--to-json), jq. Both are framework dev deps
+# provisioned by setup.sh.
+
+set -uo pipefail
+
+# ---------------------------------------------------------------------------
+# JQ filter: walk the shfmt AST and compute per-function max nesting depth.
+#
+# Nesting types: IfClause, ForClause, WhileClause, CaseClause.
+# FuncDecl gives per-function reset boundaries.
+# elif handling: IfClause.Else with a Cond field = elif (same depth, not +1).
+# ---------------------------------------------------------------------------
+# The JQ filter below is intentionally single-quoted to prevent shell expansion
+# of jq variable references ($t, $nd, $funcs, etc.). SC2016 is a false positive.
+# shellcheck disable=SC2016
+_FUNC_TYPE="FuncDecl"
+# Build the jq filter with the function type injected, avoiding repeated literals.
+JQ_NESTING_WALKER="
+def func_type: \"${_FUNC_TYPE}\";
+def nw(d):
+  if type == \"object\" then
+    (.Type // \"\") as \$t |
+    if \$t == \"IfClause\" or \$t == \"ForClause\" or \$t == \"WhileClause\" or \$t == \"CaseClause\" then
+      (d + 1),
+      if \$t == \"IfClause\" then
+        ((.Then // [])[] | nw(d + 1)),
+        ((.Cond // [])[] | nw(d + 1)),
+        (if .Else then
+          if (.Else | has(\"Cond\")) then .Else | nw(d)
+          else ((.Else.Then // [])[] | nw(d + 1))
+          end
+        else empty end)
+      elif \$t == \"CaseClause\" then
+        ((.Items // [])[] | (.Stmts // [])[] | nw(d + 1))
+      else
+        ((.Do // [])[] | nw(d + 1)),
+        ((.Cond // [])[] | nw(d + 1))
+      end
+    elif \$t == func_type then
+      empty
+    else
+      to_entries[] | .value | nw(d)
+    end
+  elif type == \"array\" then
+    .[] | nw(d)
+  else empty end;
+
+[.. | select(.Type? == func_type)] as \$funcs |
+
+([.Stmts // [] | .[] | select(.Cmd.Type != func_type) | nw(0)] |
+  if length > 0 then max else 0 end) as \$top |
+
+[\$funcs[] |
+  {function: .Name.Value, depth: ([.Body | nw(0)] | if length > 0 then max else 0 end)}
+] as \$fdepths |
+
+([\$top, (\$fdepths | .[].depth)] | max) as \$fmax |
+
+{
+  per_function: \$fdepths,
+  toplevel: \$top,
+  file_max: \$fmax
+}
+"
+
+# ---------------------------------------------------------------------------
+# Legacy AWK fallback — identical to the old complexity-regression-helper.sh
+# scanner for backward compatibility when shfmt is unavailable.
+# ---------------------------------------------------------------------------
+_awk_nesting_depth() {
+	local _file="$1"
+	awk '
+		BEGIN { depth=0; max_depth=0 }
+		/^[[:space:]]*#/ { next }
+		/[[:space:]]*(if|for|while|until|case)[[:space:]]/ { depth++; if(depth>max_depth) max_depth=depth }
+		/[[:space:]]*(fi|done|esac)[[:space:]]*$/ || /^[[:space:]]*(fi|done|esac)$/ { if(depth>0) depth-- }
+		END { print max_depth }
+	' "$_file" 2>/dev/null || echo 0
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+	local _per_function=false
+	local _file=""
+
+	while [ $# -gt 0 ]; do
+		local _arg="$1"
+		case "$_arg" in
+			--per-function) _per_function=true; shift ;;
+			-h|--help)
+				sed -n '5,36p' "$0" | sed 's/^# \{0,1\}//'
+				return 0
+				;;
+			-*)
+				printf 'ERROR: unknown flag: %s\n' "$_arg" >&2
+				return 2
+				;;
+			*)
+				_file="$_arg"; shift ;;
+		esac
+	done
+
+	if [ -z "$_file" ]; then
+		printf 'ERROR: no file specified\n' >&2
+		return 2
+	fi
+
+	if [ ! -f "$_file" ]; then
+		printf 'ERROR: file not found: %s\n' "$_file" >&2
+		return 2
+	fi
+
+	# --- shfmt path (preferred) ---
+	if command -v shfmt >/dev/null 2>&1 && command -v jq >/dev/null 2>&1; then
+		local _json
+		_json=$(shfmt --to-json < "$_file" 2>/dev/null) || {
+			# shfmt parse error (e.g., POSIX-mode file, syntax error) — fall back
+			printf '[nesting-depth] WARN: shfmt parse failed on %s, falling back to AWK\n' "$_file" >&2
+			_awk_nesting_depth "$_file"
+			return 0
+		}
+
+		if [ "$_per_function" = true ]; then
+			printf '%s\n' "$_json" | jq -r "$JQ_NESTING_WALKER"' | .per_function[] | "\(.function)\t\(.depth)"'
+		else
+			printf '%s\n' "$_json" | jq -r "$JQ_NESTING_WALKER"' | .file_max'
+		fi
+		return 0
+	fi
+
+	# --- AWK fallback ---
+	printf '[nesting-depth] WARN: shfmt not available, falling back to legacy AWK scanner (may produce false positives)\n' >&2
+	if [ "$_per_function" = true ]; then
+		printf '(global)\t%s\n' "$(_awk_nesting_depth "$_file")"
+	else
+		_awk_nesting_depth "$_file"
+	fi
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-nesting-depth-scanner.sh
+++ b/.agents/scripts/tests/test-nesting-depth-scanner.sh
@@ -1,0 +1,296 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2016  # fixture strings deliberately contain unexpanded $vars
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-nesting-depth-scanner.sh — tests for scanners/nesting-depth.sh (t2430)
+#
+# Covers all four false-positive classes from the old AWK scanner, plus:
+#   - Per-function reset (depth does not compound across functions)
+#   - Real deep nesting (positive case)
+#   - elif chain correctness
+#   - Heredoc body isolation
+#   - done with redirect/pipe/herestring
+#
+# Usage: bash test-nesting-depth-scanner.sh
+#   Exits 0 on all pass, 1 on any failure.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SCANNER="${SCRIPT_DIR}/../scanners/nesting-depth.sh"
+PASS=0
+FAIL=0
+TMPDIR_TEST=""
+
+cleanup() {
+	if [ -n "$TMPDIR_TEST" ] && [ -d "$TMPDIR_TEST" ]; then
+		rm -rf "$TMPDIR_TEST"
+	fi
+	return 0
+}
+trap cleanup EXIT
+
+TMPDIR_TEST=$(mktemp -d)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+assert_depth() {
+	local _label="$1"
+	local _fixture_file="$2"
+	local _expected="$3"
+	local _actual
+
+	_actual=$(bash "$SCANNER" "$_fixture_file" 2>/dev/null)
+	if [ "$_actual" = "$_expected" ]; then
+		printf '  PASS: %s (expected=%s, got=%s)\n' "$_label" "$_expected" "$_actual"
+		PASS=$((PASS + 1))
+	else
+		printf '  FAIL: %s (expected=%s, got=%s)\n' "$_label" "$_expected" "$_actual" >&2
+		FAIL=$((FAIL + 1))
+	fi
+	return 0
+}
+
+assert_func_depth() {
+	local _label="$1"
+	local _fixture_file="$2"
+	local _func_name="$3"
+	local _expected="$4"
+	local _actual
+
+	_actual=$(bash "$SCANNER" --per-function "$_fixture_file" 2>/dev/null |
+		awk -F'\t' -v fn="$_func_name" '$1 == fn { print $2 }')
+	if [ "$_actual" = "$_expected" ]; then
+		printf '  PASS: %s (func=%s, expected=%s, got=%s)\n' "$_label" "$_func_name" "$_expected" "$_actual"
+		PASS=$((PASS + 1))
+	else
+		printf '  FAIL: %s (func=%s, expected=%s, got=%s)\n' "$_label" "$_func_name" "$_expected" "$_actual" >&2
+		FAIL=$((FAIL + 1))
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# _write_fixture <filename> <content>
+# Writes a fixture file to the test tmpdir. Using a helper avoids putting
+# fixture function declarations at column 1 in the host file, which would
+# trip the pre-commit return-statement ratchet.
+# ---------------------------------------------------------------------------
+_write_fixture() {
+	local _name="$1"
+	local _content="$2"
+	printf '%s\n' "$_content" > "${TMPDIR_TEST}/${_name}"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Fixture 1: elif chain (FP class 1)
+# 10 elifs + fi = net depth 1 (not 10+)
+# ---------------------------------------------------------------------------
+_write_fixture "elif-chain.sh" '#!/bin/bash
+func_elif() {
+  if [ "$1" = "a" ]; then
+    echo a
+  elif [ "$1" = "b" ]; then
+    echo b
+  elif [ "$1" = "c" ]; then
+    echo c
+  elif [ "$1" = "d" ]; then
+    echo d
+  elif [ "$1" = "e" ]; then
+    echo e
+  elif [ "$1" = "f" ]; then
+    echo f
+  elif [ "$1" = "g" ]; then
+    echo g
+  elif [ "$1" = "h" ]; then
+    echo h
+  elif [ "$1" = "i" ]; then
+    echo i
+  elif [ "$1" = "j" ]; then
+    echo j
+  else
+    echo other
+  fi
+  return 0
+}'
+
+# ---------------------------------------------------------------------------
+# Fixture 2: Prose containing bare keywords (FP class 2)
+# No real control flow, just strings with if/for/while/case words
+# ---------------------------------------------------------------------------
+_write_fixture "prose-keywords.sh" '#!/bin/bash
+func_prose() {
+  echo "warn action for runner=%s"
+  printf "for all users, if it matches\n"
+  echo "while processing, until done with case"
+  echo "if you need help, for each item, while waiting"
+  return 0
+}'
+
+# ---------------------------------------------------------------------------
+# Fixture 3: done <<<"$rows" (FP class 3)
+# while/done with herestring, pipe, redirect — all should close properly
+# ---------------------------------------------------------------------------
+_write_fixture "done-variants.sh" '#!/bin/bash
+func_herestring() {
+  while IFS= read -r row; do
+    echo "$row"
+  done <<<"$rows"
+  return 0
+}
+
+func_pipe() {
+  while IFS= read -r line; do
+    echo "$line"
+  done | sort
+  return 0
+}
+
+func_redirect() {
+  while IFS= read -r line; do
+    echo "$line"
+  done > /tmp/out.txt
+  return 0
+}'
+
+# ---------------------------------------------------------------------------
+# Fixture 4: Heredoc body containing keywords (FP class 4 overlap)
+# Keywords inside heredoc should contribute 0 to nesting
+# ---------------------------------------------------------------------------
+_write_fixture "heredoc-keywords.sh" '#!/bin/bash
+func_heredoc() {
+  cat <<HEREDOC
+if this is a test
+for all intents
+while we wait
+case in point
+done with this
+fi
+esac
+until further notice
+HEREDOC
+  return 0
+}'
+
+# ---------------------------------------------------------------------------
+# Fixture 5: Per-function reset
+# 10 functions each with max depth 3 → file max should be 3, not 30
+# ---------------------------------------------------------------------------
+_write_fixture "per-function-reset.sh" '#!/bin/bash
+f1() { if true; then for i in 1; do while true; do break; done; done; fi; return 0; }
+f2() { if true; then for i in 1; do while true; do break; done; done; fi; return 0; }
+f3() { if true; then for i in 1; do while true; do break; done; done; fi; return 0; }
+f4() { if true; then for i in 1; do while true; do break; done; done; fi; return 0; }
+f5() { if true; then for i in 1; do while true; do break; done; done; fi; return 0; }
+f6() { if true; then for i in 1; do while true; do break; done; done; fi; return 0; }
+f7() { if true; then for i in 1; do while true; do break; done; done; fi; return 0; }
+f8() { if true; then for i in 1; do while true; do break; done; done; fi; return 0; }
+f9() { if true; then for i in 1; do while true; do break; done; done; fi; return 0; }
+f10() { if true; then for i in 1; do while true; do break; done; done; fi; return 0; }'
+
+# ---------------------------------------------------------------------------
+# Fixture 6: Real deep nesting (positive case — should report actual depth)
+# if > for > while > case > if = depth 5
+# ---------------------------------------------------------------------------
+_write_fixture "deep-nesting.sh" '#!/bin/bash
+func_deep() {
+  if [ -n "$1" ]; then
+    for i in 1 2 3; do
+      while read -r line; do
+        case "$line" in
+          a)
+            if [ "$i" -eq 1 ]; then
+              echo "depth 5"
+            fi
+            ;;
+        esac
+      done
+    done
+  fi
+  return 0
+}'
+
+# ---------------------------------------------------------------------------
+# Fixture 7: Only echo/printf — depth 0
+# ---------------------------------------------------------------------------
+_write_fixture "no-nesting.sh" '#!/bin/bash
+func_flat() {
+  echo "hello"
+  printf "world\n"
+  local var="value"
+  return 0
+}'
+
+# ---------------------------------------------------------------------------
+# Fixture 8: Subshell containing control flow
+# ---------------------------------------------------------------------------
+_write_fixture "subshell.sh" '#!/bin/bash
+func_subshell() {
+  result=$(
+    if [ -n "$1" ]; then
+      for item in "$@"; do
+        echo "$item"
+      done
+    fi
+  )
+  echo "$result"
+  return 0
+}'
+
+# ---------------------------------------------------------------------------
+# Run tests
+# ---------------------------------------------------------------------------
+printf '=== nesting-depth scanner tests (t2430) ===\n\n'
+
+# Check scanner exists
+if [ ! -f "$SCANNER" ]; then
+	printf 'FATAL: scanner not found at %s\n' "$SCANNER" >&2
+	exit 2
+fi
+
+# Check shfmt available
+if ! command -v shfmt >/dev/null 2>&1; then
+	printf 'SKIP: shfmt not available, cannot run AST-based tests\n' >&2
+	exit 0
+fi
+
+printf 'Test group: FP class 1 — elif chain\n'
+assert_depth "elif chain of 10: file max = 1" "$TMPDIR_TEST/elif-chain.sh" "1"
+assert_func_depth "elif chain: func_elif depth = 1" "$TMPDIR_TEST/elif-chain.sh" "func_elif" "1"
+
+printf '\nTest group: FP class 2 — prose keywords\n'
+assert_depth "prose keywords: file max = 0" "$TMPDIR_TEST/prose-keywords.sh" "0"
+assert_func_depth "prose keywords: func_prose depth = 0" "$TMPDIR_TEST/prose-keywords.sh" "func_prose" "0"
+
+printf '\nTest group: FP class 3 — done variants\n'
+assert_depth "done variants: file max = 1" "$TMPDIR_TEST/done-variants.sh" "1"
+assert_func_depth "herestring: func_herestring depth = 1" "$TMPDIR_TEST/done-variants.sh" "func_herestring" "1"
+assert_func_depth "pipe: func_pipe depth = 1" "$TMPDIR_TEST/done-variants.sh" "func_pipe" "1"
+assert_func_depth "redirect: func_redirect depth = 1" "$TMPDIR_TEST/done-variants.sh" "func_redirect" "1"
+
+printf '\nTest group: FP class 4 — heredoc keywords\n'
+assert_depth "heredoc keywords: file max = 0" "$TMPDIR_TEST/heredoc-keywords.sh" "0"
+assert_func_depth "heredoc: func_heredoc depth = 0" "$TMPDIR_TEST/heredoc-keywords.sh" "func_heredoc" "0"
+
+printf '\nTest group: per-function reset\n'
+assert_depth "10 funcs each depth 3: file max = 3" "$TMPDIR_TEST/per-function-reset.sh" "3"
+
+printf '\nTest group: real deep nesting (positive case)\n'
+assert_depth "deep nesting: file max = 5" "$TMPDIR_TEST/deep-nesting.sh" "5"
+assert_func_depth "deep: func_deep depth = 5" "$TMPDIR_TEST/deep-nesting.sh" "func_deep" "5"
+
+printf '\nTest group: no nesting\n'
+assert_depth "flat code: file max = 0" "$TMPDIR_TEST/no-nesting.sh" "0"
+
+printf '\nTest group: subshell nesting\n'
+assert_depth "subshell: file max = 2" "$TMPDIR_TEST/subshell.sh" "2"
+
+printf '\n=== Results: %d passed, %d failed ===\n' "$PASS" "$FAIL"
+
+if [ "$FAIL" -gt 0 ]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Replace the naive AWK regex nesting-depth scanner in `complexity-regression-helper.sh` with a `shfmt --to-json` AST walker that computes accurate per-function nesting depth. Eliminates four documented false-positive classes that inflated nesting-depth reports and blocked legitimate refactors.

## Changes

- **NEW**: `.agents/scripts/scanners/nesting-depth.sh` — shfmt AST walker with AWK fallback for graceful degradation
- **NEW**: `.agents/scripts/tests/test-nesting-depth-scanner.sh` — 15-assertion test suite covering all 4 FP classes + per-function reset + real deep nesting positive case
- **EDIT**: `.agents/scripts/complexity-regression-helper.sh` — `scan_dir_nesting_depth` now calls the external scanner (retains inline AWK fallback if scanner script is missing)
- **EDIT**: `.agents/reference/large-file-split.md` — section 4.1 rewritten to reflect accurate measurements; nesting-depth override procedure updated

## False-Positive Classes Eliminated

1. **elif matches if** — old AWK regex matched `if` substring in `elif`, inflating depth per elif branch. AST: elif is a nested IfClause in `.Else`, walker treats as same depth.
2. **Prose containing bare keywords** — `printf "for all users, if it matches"` triggered depth increment. AST: string content not tokenized as control flow.
3. **`done <<<"$x"` not recognized as close** — close regex required `done` at EOL. AST: WhileClause closes normally regardless of redirect syntax.
4. **Global counter never resets** — all false positives compounded across entire file. AST: FuncDecl nodes provide natural per-function boundaries.

## Verification

- `headless-runtime-lib.sh`: old AWK depth=52, new shfmt depth=**4** (real per-function max). Acceptance: depth <= 12.
- 15/15 tests pass: elif chain (depth=1 not 10+), prose keywords (depth=0), herestring/pipe/redirect (depth=1 each), heredoc keywords (depth=0), per-function reset (10 funcs * depth 3 = max 3 not 30), real deep nesting (depth=5), subshell (depth=2).
- ShellCheck clean on both new files.
- Pre-commit hook passes (return statements, positional params, string literals, ShellCheck ratchets).

## Testing

```bash
bash .agents/scripts/tests/test-nesting-depth-scanner.sh
bash .agents/scripts/scanners/nesting-depth.sh .agents/scripts/headless-runtime-lib.sh  # expect: 4
bash .agents/scripts/scanners/nesting-depth.sh --per-function .agents/scripts/headless-runtime-lib.sh
```

Resolves #20105


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.85 plugin for [OpenCode](https://opencode.ai) v1.14.18 with claude-opus-4-6 spent 26m and 45,675 tokens on this as a headless worker.

## Complexity Bump Justification

**`complexity-bump-ok` label applied.** The nesting-depth regression gate reports 2 new violations on the new files added in this PR:

- `.agents/scripts/scanners/nesting-depth.sh`: AWK fallback reports depth=12, shfmt reports depth=**2** (real)
- `.agents/scripts/tests/test-nesting-depth-scanner.sh`: AWK fallback reports depth=34, shfmt reports depth=**1** (real)

**Root cause:** The CI runner does not have `shfmt` installed, so `scan_dir_nesting_depth` falls back to the legacy AWK scanner — the same scanner this PR replaces. The AWK scanner trips on the fixture content (single-quoted strings containing `if`, `for`, `while` keywords, elif chains, etc.) which ARE the false-positive test cases.

**Evidence:**
- `complexity-regression-helper.sh:231-290` — `scan_dir_nesting_depth` delegates to `scanners/nesting-depth.sh` when available, falls back to AWK when not
- `.agents/scripts/scanners/nesting-depth.sh:113-121` — AWK fallback, base=0 (new file), head=12/34 (AWK false positives)
- Local shfmt measurement: `bash .agents/scripts/scanners/nesting-depth.sh .agents/scripts/scanners/nesting-depth.sh` → **2**; `bash .agents/scripts/scanners/nesting-depth.sh .agents/scripts/tests/test-nesting-depth-scanner.sh` → **1**

**Follow-up:** Add `shfmt` installation to `.github/workflows/code-quality.yml` so the CI uses the shfmt scanner instead of the AWK fallback.