### PR TITLE
GH#20113: feat: add recent-commit sweep (gate 4) to pre-dispatch eligibility gate

### DIFF
--- a/.agents/scripts/pre-dispatch-eligibility-helper.sh
+++ b/.agents/scripts/pre-dispatch-eligibility-helper.sh
@@ -16,13 +16,16 @@
 #   1. CLOSED state — issue.state == CLOSED → abort (exit 2)
 #   2. Status labels — status:done or status:resolved → abort (exit 3)
 #   3. Recent PR merge — linked PR merged in last 5 min → abort (exit 4)
-#   Note: recent-commit check is deferred to a follow-up task.
+#   4. Recent closing commit — commit on default branch within last ~10 min
+#      with a GitHub closing keyword (close/fix/resolve) referencing this
+#      issue → abort (exit 5). Ref/For commits are NOT closing references.
 #
 # Exit codes (returned by the `check` subcommand):
 #   0  — eligible; dispatch proceeds
 #   2  — issue is CLOSED
 #   3  — issue has status:done or status:resolved label
 #   4  — linked PR merged in recent window (5 min by default)
+#   5  — recent closing commit on default branch (10 min by default)
 #   20 — API error; caller should fail-open (dispatch proceeds with warning)
 #
 # Usage (standalone):
@@ -35,11 +38,15 @@
 #   ISSUE_META_JSON — pre-fetched JSON (state,labels,closedAt) from caller; avoids extra gh call
 #   AIDEVOPS_SKIP_PREDISPATCH_ELIGIBILITY=1 — bypass entirely (emergency escape hatch)
 #   AIDEVOPS_PREDISPATCH_RECENT_MERGE_WINDOW=<seconds> — recent-merge detection window (default 300)
+#   AIDEVOPS_PREDISPATCH_RECENT_COMMIT_WINDOW=<seconds> — recent-commit detection window (default 600)
 #
 # Counter output:
 #   Pre-dispatch aborts are tracked in ~/.aidevops/logs/pulse-stats.json
 #   via pulse-stats-helper.sh (sourced below). The 24h count is surfaced
 #   by `aidevops status` to make churn visible to operators.
+#   Counters:
+#     pre_dispatch_aborts           — total aborts across all gates
+#     pre_dispatch_aborts_recent_commit — aborts caused specifically by gate 4
 
 set -euo pipefail
 
@@ -82,7 +89,88 @@ _eligibility_record_abort() {
 }
 
 #######################################
-# Core eligibility check. Runs 3 gates in order (cheap to expensive).
+# Check whether any commit on the default branch within the recent-commit
+# window contains a GitHub closing keyword referencing the candidate issue.
+#
+# Uses the same closing-keyword regex as pulse-merge.sh::_extract_linked_issue:
+#   close/closes/closed, fix/fixes/fixed, resolve/resolves/resolved + #NNN
+# Does NOT match: Ref #NNN, For #NNN, GH#NNN, or other non-closing references.
+#
+# Fail-open: returns 0 (allow dispatch) on any gh API or date error so that
+# network failures or auth expiry do not block legitimate dispatch.
+#
+# Args:
+#   $1 - issue_number
+#   $2 - repo_slug (owner/repo)
+#
+# Returns:
+#   0 — no recent closing commit found (allow dispatch)
+#   1 — recent closing commit found (caller should abort dispatch with exit 5)
+#######################################
+_check_recent_commit_closes_issue() {
+	local issue_number="$1"
+	local repo_slug="$2"
+
+	local commit_window="${AIDEVOPS_PREDISPATCH_RECENT_COMMIT_WINDOW:-600}"
+	local now_epoch
+	now_epoch=$(date +%s 2>/dev/null) || now_epoch=0
+
+	if [[ "$now_epoch" -eq 0 ]]; then
+		return 0
+	fi
+
+	# Compute ISO 8601 window start (cross-platform: macOS uses -r, Linux uses -d).
+	local since_epoch=$(( now_epoch - commit_window ))
+	local since_iso
+	since_iso=$(date -r "$since_epoch" -u "+%Y-%m-%dT%H:%M:%SZ" 2>/dev/null \
+		|| date -d "@${since_epoch}" -u "+%Y-%m-%dT%H:%M:%SZ" 2>/dev/null) || since_iso=""
+
+	if [[ -z "$since_iso" ]]; then
+		echo "[dispatch-precheck] WARNING: could not compute since_iso for recent-commit check on #${issue_number} — skipping (fail-open)" >>"$LOGFILE"
+		return 0
+	fi
+
+	# Resolve the default branch for the repo (fail-open to "main").
+	local repo_json default_branch
+	repo_json=$(gh api "repos/${repo_slug}" 2>/dev/null) || repo_json=""
+	default_branch=$(jq -r '.default_branch // "main"' <<<"$repo_json" 2>/dev/null) || default_branch=""
+	[[ -z "$default_branch" ]] && default_branch="main"
+
+	# Fetch commits on the default branch within the window.
+	local commits_data
+	commits_data=$(gh api "repos/${repo_slug}/commits?sha=${default_branch}&since=${since_iso}" 2>/dev/null) \
+		|| commits_data=""
+
+	if [[ -z "$commits_data" ]]; then
+		# gh API error — fail-open: allow dispatch to proceed.
+		echo "[dispatch-precheck] WARNING: gh API error fetching recent commits for ${repo_slug} — proceeding (fail-open)" >>"$LOGFILE"
+		return 0
+	fi
+
+	# Extract issue numbers referenced by closing keywords in commit messages.
+	# Regex: close/closes/closed, fix/fixes/fixed, resolve/resolves/resolved + #NNN
+	# This is the same regex as pulse-merge.sh::_extract_linked_issue (t2204).
+	# Ref #NNN and For #NNN do NOT match — they are planning references, not closes.
+	local referenced_issues
+	referenced_issues=$(printf '%s' "$commits_data" \
+		| jq -r '.[].commit.message' 2>/dev/null \
+		| grep -ioE '(close[ds]?|fix(es|ed)?|resolve[ds]?)\s+#[0-9]+' \
+		| grep -oE '[0-9]+$') || referenced_issues=""
+
+	if [[ -z "$referenced_issues" ]]; then
+		return 0
+	fi
+
+	# Check whether any extracted issue number matches the candidate issue.
+	if printf '%s\n' "$referenced_issues" | grep -qx "$issue_number"; then
+		return 1
+	fi
+
+	return 0
+}
+
+#######################################
+# Core eligibility check. Runs 4 gates in order (cheap to expensive).
 # Accepts pre-fetched JSON via ISSUE_META_JSON env var to avoid duplicate
 # gh calls when the caller already has the metadata.
 #
@@ -95,6 +183,7 @@ _eligibility_record_abort() {
 #   2  — CLOSED state
 #   3  — status:done or status:resolved label
 #   4  — recent linked PR merge
+#   5  — recent closing commit on default branch
 #   20 — API error (fail-open: caller should proceed with dispatch + warning)
 #######################################
 is_issue_eligible_for_dispatch() {
@@ -160,6 +249,18 @@ is_issue_eligible_for_dispatch() {
 		fi
 	fi
 
+	# --- Gate 4: Recent closing commit on default branch (one extra gh call) ---
+	local commit_window="${AIDEVOPS_PREDISPATCH_RECENT_COMMIT_WINDOW:-600}"
+	local recent_commit_rc=0
+	_check_recent_commit_closes_issue "$issue_number" "$repo_slug" || recent_commit_rc=$?
+	if [[ "$recent_commit_rc" -eq 1 ]]; then
+		_eligibility_record_abort "$issue_number" "$repo_slug" "recent-commit closes issue within ${commit_window}s window" "5"
+		if declare -F pulse_stats_increment >/dev/null 2>&1; then
+			pulse_stats_increment "pre_dispatch_aborts_recent_commit" 2>/dev/null || true
+		fi
+		return 5
+	fi
+
 	# All gates passed — eligible for dispatch.
 	echo "[dispatch-precheck] #${issue_number} in ${repo_slug} eligible for dispatch" >>"$LOGFILE"
 	return 0
@@ -217,12 +318,14 @@ _main() {
 			echo "  2  — CLOSED state"
 			echo "  3  — status:done or status:resolved label"
 			echo "  4  — recent linked PR merge"
+			echo "  5  — recent closing commit on default branch"
 			echo "  20 — API error (fail-open)"
 			echo ""
 			echo "Environment:"
-			echo "  AIDEVOPS_SKIP_PREDISPATCH_ELIGIBILITY=1   bypass (emergency)"
-			echo "  AIDEVOPS_PREDISPATCH_RECENT_MERGE_WINDOW  merge window seconds (default 300)"
-			echo "  ISSUE_META_JSON                           pre-fetched JSON to reuse"
+			echo "  AIDEVOPS_SKIP_PREDISPATCH_ELIGIBILITY=1    bypass (emergency)"
+			echo "  AIDEVOPS_PREDISPATCH_RECENT_MERGE_WINDOW   merge window seconds (default 300)"
+			echo "  AIDEVOPS_PREDISPATCH_RECENT_COMMIT_WINDOW  commit window seconds (default 600)"
+			echo "  ISSUE_META_JSON                            pre-fetched JSON to reuse"
 			return 0
 			;;
 		*)

--- a/.agents/scripts/pulse-stats-helper.sh
+++ b/.agents/scripts/pulse-stats-helper.sh
@@ -8,7 +8,8 @@
 # windows can be computed without a separate cron sweep.
 #
 # Supported counters (initial set):
-#   pre_dispatch_aborts — pre-dispatch eligibility gate aborted dispatch
+#   pre_dispatch_aborts                — pre-dispatch eligibility gate aborted dispatch (all gates)
+#   pre_dispatch_aborts_recent_commit  — aborts caused by gate 4 (recent closing commit on default branch)
 #
 # The `aidevops status` command reads this file via `pulse_stats_get_24h`
 # to show operator-visible churn metrics.

--- a/.agents/scripts/tests/test-pre-dispatch-eligibility.sh
+++ b/.agents/scripts/tests/test-pre-dispatch-eligibility.sh
@@ -4,15 +4,18 @@
 # test-pre-dispatch-eligibility.sh — Regression tests for pre-dispatch-eligibility-helper.sh (t2424, GH#20030)
 #
 # Tests:
-#   test_closed_issue_blocked          — CLOSED state → exit 2
-#   test_status_done_blocked           — status:done label → exit 3
-#   test_status_resolved_blocked       — status:resolved label → exit 3
-#   test_recent_merge_blocked          — linked PR merged <5 min ago → exit 4
-#   test_eligible_open_no_labels       — OPEN, no blocking labels → exit 0 (happy path)
-#   test_eligible_open_with_queued     — OPEN, status:queued (not blocking) → exit 0
-#   test_api_error_fail_open           — gh API failure → exit 20 (fail-open)
-#   test_bypass_env_var                — AIDEVOPS_SKIP_PREDISPATCH_ELIGIBILITY=1 → exit 0
-#   test_prefetched_json_reused        — ISSUE_META_JSON avoids extra gh call for gates 1+2
+#   test_closed_issue_blocked                      — CLOSED state → exit 2
+#   test_status_done_blocked                       — status:done label → exit 3
+#   test_status_resolved_blocked                   — status:resolved label → exit 3
+#   test_recent_merge_blocked                      — linked PR merged <5 min ago → exit 4
+#   test_eligible_open_no_labels                   — OPEN, no blocking labels → exit 0 (happy path)
+#   test_eligible_open_with_queued                 — OPEN, status:queued (not blocking) → exit 0
+#   test_api_error_fail_open                       — gh API failure → exit 20 (fail-open)
+#   test_bypass_env_var                            — AIDEVOPS_SKIP_PREDISPATCH_ELIGIBILITY=1 → exit 0
+#   test_prefetched_json_reused                    — ISSUE_META_JSON avoids extra gh call for gates 1+2
+#   test_recent_commit_closes_issue_blocked        — recent commit closes this issue → exit 5
+#   test_recent_commit_ref_not_blocked             — Ref #NNN commit (not closing keyword) → exit 0
+#   test_recent_commit_different_issue_not_blocked — recent commit closes a different issue → exit 0
 
 set -euo pipefail
 
@@ -126,6 +129,80 @@ create_gh_stub_failing() {
 	cat >"${TEST_ROOT}/bin/gh" <<'GHEOF'
 #!/usr/bin/env bash
 printf 'gh: API error\n' >&2
+exit 1
+GHEOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+	return 0
+}
+
+#######################################
+# Create a gh stub that supports Gate 4 (recent commit) testing.
+# Routes API calls by path pattern so each gate gets the right data.
+#
+# Args:
+#   $1 - state ("OPEN" or "CLOSED")
+#   $2 - label_name (bare label string or "")
+#   $3 - commit_message (the message of a single recent commit, or "")
+#
+# Routes:
+#   gh issue view           → issue JSON (state + labels)
+#   gh api *timeline*       → [] (no recent merges — ensures gate 3 passes)
+#   gh api *commits*        → single-commit array with the given message (or [])
+#   gh api repos/<slug>     → {"default_branch":"main"}
+#######################################
+create_gh_stub_with_commits() {
+	local state="$1"
+	local label_name="${2:-}"
+	local commit_message="${3:-}"
+
+	# Write issue JSON data.
+	local issue_data_file="${TEST_ROOT}/issue_data.json"
+	local labels_json="[]"
+	if [[ -n "$label_name" ]]; then
+		labels_json="[{\"name\":\"${label_name}\"}]"
+	fi
+	printf '{"state":"%s","labels":%s,"closedAt":""}\n' \
+		"$state" "$labels_json" >"$issue_data_file"
+
+	# Write commits JSON data (one commit with the given message, or empty).
+	local commits_data_file="${TEST_ROOT}/commits_data.json"
+	if [[ -n "$commit_message" ]]; then
+		# Escape any double-quotes in the message for embedding in JSON.
+		local escaped_msg="${commit_message//\"/\\\"}"
+		printf '[{"commit":{"message":"%s"}}]\n' "$escaped_msg" >"$commits_data_file"
+	else
+		printf '[]\n' >"$commits_data_file"
+	fi
+
+	cat >"${TEST_ROOT}/bin/gh" <<GHEOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+# gh issue view <num> --repo <slug> --json state,labels,closedAt
+if [[ "\${1:-}" == "issue" && "\${2:-}" == "view" ]]; then
+	cat "${issue_data_file}"
+	exit 0
+fi
+
+if [[ "\${1:-}" == "api" ]]; then
+	case "\${2:-}" in
+		*"commits"*)
+			# Gate 4: recent commits endpoint
+			cat "${commits_data_file}"
+			;;
+		*"timeline"*)
+			# Gate 3: timeline endpoint — return empty (no recent merges)
+			printf '[]\n'
+			;;
+		*)
+			# Repo info endpoint (default branch lookup)
+			printf '{"default_branch":"main"}\n'
+			;;
+	esac
+	exit 0
+fi
+
+printf 'unsupported gh invocation: %s\n' "\$*" >&2
 exit 1
 GHEOF
 	chmod +x "${TEST_ROOT}/bin/gh"
@@ -306,6 +383,60 @@ test_prefetched_json_reused() {
 	return 0
 }
 
+# Test 10: Recent commit closes this issue → exit 5 (happy path for gate 4)
+test_recent_commit_closes_issue_blocked() {
+	setup_test_env
+
+	# Commit message uses a closing keyword ("closes") referencing issue 12345.
+	create_gh_stub_with_commits "OPEN" "status:queued" "closes #12345"
+
+	local rc=0
+	"$HELPER_SCRIPT" check 12345 "owner/repo" >/dev/null 2>&1 || rc=$?
+
+	local fail=0
+	[[ "$rc" -eq 5 ]] || fail=1
+	print_result "test_recent_commit_closes_issue_blocked" "$fail" "expected exit 5, got ${rc}"
+
+	teardown_test_env
+	return 0
+}
+
+# Test 11: Recent commit uses "Ref #NNN" (planning reference, not closing keyword) → exit 0
+test_recent_commit_ref_not_blocked() {
+	setup_test_env
+
+	# "Ref #12345" is a planning reference — must NOT trigger gate 4.
+	create_gh_stub_with_commits "OPEN" "" "Ref #12345 update planning notes"
+
+	local rc=0
+	"$HELPER_SCRIPT" check 12345 "owner/repo" >/dev/null 2>&1 || rc=$?
+
+	local fail=0
+	[[ "$rc" -eq 0 ]] || fail=1
+	print_result "test_recent_commit_ref_not_blocked" "$fail" "expected exit 0 for Ref commit, got ${rc}"
+
+	teardown_test_env
+	return 0
+}
+
+# Test 12: Recent commit closes a DIFFERENT issue → exit 0
+test_recent_commit_different_issue_not_blocked() {
+	setup_test_env
+
+	# Commit closes issue 99999, NOT the candidate issue 12345.
+	create_gh_stub_with_commits "OPEN" "" "fixes #99999"
+
+	local rc=0
+	"$HELPER_SCRIPT" check 12345 "owner/repo" >/dev/null 2>&1 || rc=$?
+
+	local fail=0
+	[[ "$rc" -eq 0 ]] || fail=1
+	print_result "test_recent_commit_different_issue_not_blocked" "$fail" "expected exit 0 for different issue, got ${rc}"
+
+	teardown_test_env
+	return 0
+}
+
 # ---------------------------------------------------------------------------
 # Runner
 # ---------------------------------------------------------------------------
@@ -327,6 +458,9 @@ main() {
 	test_api_error_fail_open
 	test_bypass_env_var
 	test_prefetched_json_reused
+	test_recent_commit_closes_issue_blocked
+	test_recent_commit_ref_not_blocked
+	test_recent_commit_different_issue_not_blocked
 
 	echo ""
 	echo "---"


### PR DESCRIPTION
## Summary

Implements t2432: adds a fourth eligibility check (_check_recent_commit_closes_issue) that scans commits on the default branch within the last 10 min and aborts dispatch (exit 5) if any commit message contains a GitHub closing keyword (close/fix/resolve + #NNN) referencing the candidate issue. Includes AIDEVOPS_PREDISPATCH_RECENT_COMMIT_WINDOW env override, pre_dispatch_aborts_recent_commit stats counter, and 3 new test cases.

## Files Changed

.agents/scripts/pre-dispatch-eligibility-helper.sh,.agents/scripts/pulse-stats-helper.sh,.agents/scripts/tests/test-pre-dispatch-eligibility.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean on all 3 edited files; bash .agents/scripts/tests/test-pre-dispatch-eligibility.sh passes 12/12 tests (9 existing + 3 new)

Resolves #20113


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.85 plugin for [OpenCode](https://opencode.ai) v1.14.18 with claude-sonnet-4-6 spent 8m and 27,091 tokens on this as a headless worker.