### PR TITLE
GH#20105: rewrite nesting-depth scanner using shfmt AST walker

### DIFF
--- a/.agents/reference/large-file-split.md
+++ b/.agents/reference/large-file-split.md
@@ -110,7 +110,7 @@ depending on the metric.
 |--------|-------------|-------------|--------|
 | `function-complexity` | `(file, fname)` | Moving a >100-line function to a new file re-registers it as a **new** violation. | Functions over 100 lines **MUST stay in the original file**. Example: `_run_canary_test` stayed in `headless-runtime-lib.sh` (PR #19821). |
 | `file-size` | `(file)` | Splitting automatically resolves the original file's violation. New sub-files are typically under the threshold. | No special action needed. |
-| `nesting-depth` | `(file, 'NEST')` | Splitting into new files creates new `(newfile, 'NEST')` keys. Expect `+N new` regressions. | This is a **known false positive** -- see section 4. Override with `complexity-bump-ok` label. |
+| `nesting-depth` | `(file, 'NEST')` | Splitting into new files creates new `(newfile, 'NEST')` keys. Post GH#20105: reports real depth (shfmt AST), so regressions are genuine. | Usually no action needed. Override with `complexity-bump-ok` if the moved code is legitimately deep. |
 | `bash32-compat` | `(construct)` | Splitting is neutral -- the construct identity doesn't include the file. | No special action needed. |
 
 **Critical rule**: before splitting, run `complexity-regression-helper.sh check`
@@ -121,52 +121,28 @@ target file. Those functions stay put.
 
 ### 4.1 Nesting-depth scanner
 
-`scan_dir_nesting_depth` at `complexity-regression-helper.sh:225-256` is a
-global `elif`-counting AWK, not a real nesting metric:
+**Status (GH#20105, resolved):** The nesting-depth scanner was rewritten to
+use `shfmt --to-json` AST walking (`scanners/nesting-depth.sh`). The four
+documented false-positive classes (elif inflation, prose keywords, unterminated
+`done`, global counter) are eliminated by construction. Per-function reset is
+built in via `FuncDecl` AST node boundaries.
 
-```awk
-/[[:space:]]*(if|for|while|until|case)[[:space:]]/ { depth++; ... }
-/[[:space:]]*(fi|done|esac)[[:space:]]*$/ || /^[[:space:]]*(fi|done|esac)$/ { if(depth>0) depth-- }
-```
-
-The open-regex matches `elif` because `elif` contains the literal substring
-`if` preceded by optional whitespace. Each `elif` increments `depth` but
-has no corresponding close, so `if/elif/elif/fi` opens +3 but only closes -1.
-Every `elif` chain inflates the counter permanently.
-
-**Evidence**: the pre-split `headless-runtime-lib.sh` (2107 lines) scored
-`max_depth=83` -- physically impossible; bash has no code path that nests
-83 levels deep.
-
-**Override procedure**:
-
-1. Apply the `complexity-bump-ok` label to the PR.
-2. Add a `## Complexity Bump Justification` section to the PR body with:
-   - The scanner evidence (file:line ref showing the `elif` pattern)
-   - The measurement (`base=N, head=M, new=K`)
-   - Explanation that the new violations are identity-key artifacts, not real nesting increases.
-
-**Worker self-apply (t2370):** Workers dispatched against file-split or
-simplification issues may self-apply the `complexity-bump-ok` label. The
-`.github/workflows/complexity-bump-justification-check.yml` workflow triggers
-on the `labeled` event and validates that the PR body contains the required
-justification section with at least one `file:line` reference and a numeric measurement.
-If validation fails, the workflow removes the label and posts a remediation
-comment explaining what is missing. The label only sticks when the
-justification is complete -- no maintainer intervention required for
-legitimate splits. This mirrors the `new-file-smell-ok` + justification-section
-pattern from `qlty-new-file-gate.yml`.
+Post-fix, nesting-depth regressions from file splits should be rare and
+genuine. If you still see a nesting-depth regression on a split PR, it
+reflects real structural depth in the moved code, not scanner artifacts.
+The `complexity-bump-ok` override is still available for legitimate cases
+(see `AGENTS.md` "Complexity Bump Override").
 
 ### 4.2 Pre-push complexity guard
 
-The client-side `complexity-regression-pre-push.sh` hook rejects on the same
-false positive. Targeted bypass:
+The client-side `complexity-regression-pre-push.sh` hook uses the same
+scanner pipeline. Post-fix, false positives from `elif` chains, heredocs,
+and string-literal keywords no longer trigger the hook. Targeted bypass
+is still available:
 
 ```bash
 COMPLEXITY_GUARD_DISABLE=1 git push
 ```
-
-Document this alongside the CI label in your PR body.
 
 ## 5. Pre-Commit Hook Gotchas (and Compliant Rewrites)
 
@@ -254,31 +230,19 @@ cannot be statically followed without `-x`).
   - `file-size`: base=<N>, head=<N>, **new=0**
   - `function-complexity`: base=<N>, head=<N>, **new=0**
   - `bash32-compat`: base=<N>, head=<N>, **new=0**
-  - `nesting-depth`: base=<N>, head=<N>, new=<K> -- see justification below
+  - `nesting-depth`: base=<N>, head=<N>, new=<K>
 
 ## Complexity Bump Justification
 
+> **Note (GH#20105):** With the shfmt-based nesting-depth scanner, the
+> false-positive classes documented below are eliminated. You should rarely
+> need `complexity-bump-ok` for nesting-depth regressions on splits.
+> If you do, the regressions reflect real structural depth in the moved code.
+
 **`complexity-bump-ok` label applied.** The nesting-depth scanner reports <K>
-new violations solely because the `(file, 'NEST')` identity key changes when
-code moves to freshly-named files. The metric is not real nesting depth.
-
-**Evidence that the scanner is not measuring real nesting:**
-
-- `scan_dir_nesting_depth` in `complexity-regression-helper.sh:225-256` is a
-  single global AWK counter that increments on any line matching
-  `/[[:space:]]*(if|for|while|until|case)[[:space:]]/` and decrements on
-  `fi|done|esac`. It has no function scoping.
-- The open-regex also matches the literal string `if` in `elif`. Each `elif`
-  chain inflates the counter permanently.
-- `origin/main`'s current `<original-file>` scans as **max_depth=<N>** --
-  physically impossible; bash has no code path that nests <N> levels deep.
-- Per-function nesting is unchanged. The `function-complexity` metric confirms
-  `base=<N> head=<N> new=0`.
-
-**Pre-existing debt moved, not introduced:** all the `elif`-chain patterns
-that trip the scanner were already in the <N>-line file. The split relocates
-them, it does not create them. Apply `complexity-bump-ok` per the documented
-override procedure.
+new violations because the `(file, 'NEST')` identity key changes when code
+moves to freshly-named files. Per-function nesting is unchanged -- the
+`function-complexity` metric confirms `base=<N> head=<N> new=0`.
 
 ## Related
 

--- a/.agents/scripts/complexity-regression-helper.sh
+++ b/.agents/scripts/complexity-regression-helper.sh
@@ -217,11 +217,12 @@ scan_dir_function_complexity() {
 # ---------------------------------------------------------------------------
 # scan_dir_nesting_depth <dir> [<out-file>]
 #
-# Shell files with global max nesting depth >8. Output: <file>\tNEST\t<depth>.
-# Identity key: (file, 'NEST'). (t2171)
+# Shell files with per-function max nesting depth >8. Output: <file>\tNEST\t<depth>.
+# Identity key: (file, 'NEST'). (t2171, rewritten GH#20105)
 #
-# Uses the same global-counter AWK pattern as code-quality.yml:502-508 — it
-# does NOT reset depth at function boundaries, matching the existing CI gate.
+# Delegates to scanners/nesting-depth.sh which uses shfmt --to-json AST walk
+# (per-function reset, immune to the four documented AWK false-positive classes).
+# Falls back to AWK when shfmt/python3 unavailable (graceful degradation).
 # ---------------------------------------------------------------------------
 scan_dir_nesting_depth() {
 	local _dir="$1"
@@ -237,18 +238,28 @@ scan_dir_nesting_depth() {
 	local _result_file
 	_result_file=$(_open_result_file "$_out")
 
+	# Resolve scanner path relative to this script
+	local _scanner
+	_scanner="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/scanners/nesting-depth.sh"
+
 	local _file _rel_file _max_depth
 	while IFS= read -r _file; do
 		[ -n "$_file" ] || continue
 		[ -f "$_file" ] || continue
 		_rel_file="${_file#"${_dir}/"}"
-		_max_depth=$(awk '
-			BEGIN { depth=0; max_depth=0 }
-			/^[[:space:]]*#/ { next }
-			/[[:space:]]*(if|for|while|until|case)[[:space:]]/ { depth++; if(depth>max_depth) max_depth=depth }
-			/[[:space:]]*(fi|done|esac)[[:space:]]*$/ || /^[[:space:]]*(fi|done|esac)$/ { if(depth>0) depth-- }
-			END { print max_depth }
-		' "$_file" 2>/dev/null || echo 0)
+
+		if [ -x "$_scanner" ]; then
+			_max_depth=$("$_scanner" "$_file" 2>/dev/null) || _max_depth=0
+		else
+			# Inline AWK fallback if scanner script is missing
+			_max_depth=$(awk '
+				BEGIN { depth=0; max_depth=0 }
+				/^[[:space:]]*#/ { next }
+				/[[:space:]]*(if|for|while|until|case)[[:space:]]/ { depth++; if(depth>max_depth) max_depth=depth }
+				/[[:space:]]*(fi|done|esac)[[:space:]]*$/ || /^[[:space:]]*(fi|done|esac)$/ { if(depth>0) depth-- }
+				END { print max_depth }
+			' "$_file" 2>/dev/null || echo 0)
+		fi
 
 		if [ "${_max_depth:-0}" -gt 8 ] 2>/dev/null; then
 			printf '%s\tNEST\t%s\n' "$_rel_file" "$_max_depth" >>"$_result_file"

--- a/.agents/scripts/scanners/nesting-depth.sh
+++ b/.agents/scripts/scanners/nesting-depth.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# nesting-depth.sh — per-function nesting-depth scanner using shfmt AST (GH#20105)
+#
+# Computes max nesting depth per function via `shfmt --to-json` AST walk.
+# Falls back to AWK when shfmt is unavailable (graceful degradation).
+#
+# Usage:
+#   nesting-depth.sh <file>
+#     Prints the max nesting depth (integer) to stdout.
+#     Per-function reset: each function's depth is computed independently;
+#     global max across all functions (and top-level code) is reported.
+#
+# Exit codes:
+#   0 — success
+#   1 — file not readable or parse error (prints 0)
+#   2 — usage error
+#
+# Dependencies:
+#   - shfmt (preferred) — produces JSON AST; all four documented false-positive
+#     classes are eliminated by construction.
+#   - python3 — for walking the JSON AST (ships with macOS, available on Linux).
+#   - awk (fallback) — legacy regex-based scanner, used only when shfmt or
+#     python3 is unavailable.
+#
+# False-positive classes eliminated by shfmt AST (vs prior AWK regex):
+#   1. elif matches if — elif is Else subclause, not a separate IfClause
+#   2. Prose containing bare keywords — string literals are not control-flow nodes
+#   3. done <<<"$X" / done | cmd — WhileClause/ForClause close normally in AST
+#   4. Global counter never resets — FuncDecl gives natural function boundaries
+#
+set -uo pipefail
+
+_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_SCANNER_NAME="nesting-depth"
+
+# ---------------------------------------------------------------------------
+# _log / _die
+# ---------------------------------------------------------------------------
+_log() {
+	local _msg="$1"
+	printf '[%s] %s\n' "$_SCANNER_NAME" "$_msg" >&2
+	return 0
+}
+
+_die() {
+	local _msg="$1"
+	printf '[%s] ERROR: %s\n' "$_SCANNER_NAME" "$_msg" >&2
+	exit 2
+}
+
+# ---------------------------------------------------------------------------
+# _has_cmd <cmd>
+# ---------------------------------------------------------------------------
+_has_cmd() {
+	local _cmd="$1"
+	if command -v "$_cmd" >/dev/null 2>&1; then
+		return 0
+	fi
+	return 1
+}
+
+# ---------------------------------------------------------------------------
+# _scan_shfmt <file>
+#
+# Parse <file> with shfmt --to-json and walk the AST with python3 to compute
+# the max nesting depth. Per-function reset is built-in: FuncDecl nodes reset
+# depth to 0.
+# ---------------------------------------------------------------------------
+_scan_shfmt() {
+	local _file="$1"
+	local _ast _result
+
+	# shfmt --to-json reads from stdin only
+	_ast=$(shfmt --to-json < "$_file" 2>/dev/null) || {
+		_log "shfmt parse error on $_file, falling back to AWK"
+		_scan_awk "$_file"
+		return $?
+	}
+
+	# Walk the AST with python3
+	_result=$(printf '%s' "$_ast" | python3 -c '
+import json, sys
+
+NESTING_TYPES = {"IfClause", "ForClause", "WhileClause", "CaseClause"}
+
+def max_depth(node, depth=0):
+    """Walk the shfmt JSON AST and return the max nesting depth.
+
+    FuncDecl nodes reset depth to 0 (per-function measurement).
+    elif branches are Else subclauses without a Type field — they do NOT
+    increment depth, which is correct (elif is at the same nesting level).
+    """
+    best = depth
+    if isinstance(node, dict):
+        t = node.get("Type", "")
+        if t == "FuncDecl":
+            # Per-function reset: walk body at depth 0
+            body = node.get("Body")
+            if body:
+                child_max = max_depth(body, 0)
+                if child_max > best:
+                    best = child_max
+            return best
+        if t in NESTING_TYPES:
+            depth += 1
+            if depth > best:
+                best = depth
+        for key, val in node.items():
+            child_max = max_depth(val, depth)
+            if child_max > best:
+                best = child_max
+    elif isinstance(node, list):
+        for item in node:
+            child_max = max_depth(item, depth)
+            if child_max > best:
+                best = child_max
+    return best
+
+try:
+    ast = json.load(sys.stdin)
+    print(max_depth(ast))
+except Exception:
+    print(0)
+' 2>/dev/null) || _result=0
+
+	printf '%s' "${_result:-0}"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# _scan_awk <file>
+#
+# Legacy AWK-based scanner. Used as fallback when shfmt or python3 is
+# unavailable. Subject to the four documented false-positive classes.
+# ---------------------------------------------------------------------------
+_scan_awk() {
+	local _file="$1"
+	local _depth
+
+	_depth=$(awk '
+		BEGIN { depth=0; max_depth=0 }
+		/^[[:space:]]*#/ { next }
+		/[[:space:]]*(if|for|while|until|case)[[:space:]]/ { depth++; if(depth>max_depth) max_depth=depth }
+		/[[:space:]]*(fi|done|esac)[[:space:]]*$/ || /^[[:space:]]*(fi|done|esac)$/ { if(depth>0) depth-- }
+		END { print max_depth }
+	' "$_file" 2>/dev/null || echo 0)
+
+	printf '%s' "${_depth:-0}"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+	if [ $# -lt 1 ]; then
+		_die "usage: nesting-depth.sh <file>"
+	fi
+
+	local _file="$1"
+
+	if [ ! -r "$_file" ]; then
+		printf '0'
+		return 1
+	fi
+
+	# Prefer shfmt + python3; fall back to AWK
+	if _has_cmd shfmt && _has_cmd python3; then
+		_scan_shfmt "$_file"
+	else
+		if ! _has_cmd shfmt; then
+			_log "shfmt not found, using AWK fallback (false positives possible)"
+		elif ! _has_cmd python3; then
+			_log "python3 not found, using AWK fallback (false positives possible)"
+		fi
+		_scan_awk "$_file"
+	fi
+
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-nesting-depth-scanner.sh
+++ b/.agents/scripts/tests/test-nesting-depth-scanner.sh
@@ -1,0 +1,360 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-nesting-depth-scanner.sh — tests for scanners/nesting-depth.sh (GH#20105)
+#
+# Covers all four documented false-positive classes, per-function reset,
+# real positive nesting, and AWK fallback path.
+#
+# Note: fixture files are written via _write_fixture to avoid the pre-commit
+# return-statement ratchet counting heredoc function definitions as real
+# functions in this test file.
+#
+# shellcheck disable=SC2016  # Single-quoted fixture strings intentionally contain $var references
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)" || exit
+SCANNER="$REPO_ROOT/.agents/scripts/scanners/nesting-depth.sh"
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+TEST_DIR=""
+
+print_result() {
+	local test_name="$1"
+	local status="$2"
+	local message="${3:-}"
+
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$status" -eq 0 ]]; then
+		echo "PASS $test_name"
+		TESTS_PASSED=$((TESTS_PASSED + 1))
+	else
+		echo "FAIL $test_name"
+		if [[ -n "$message" ]]; then
+			echo "  $message"
+		fi
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+_write_fixture() {
+	local _path="$1"
+	local _content="$2"
+	printf '%s\n' "$_content" > "$_path"
+	return 0
+}
+
+setup() {
+	TEST_DIR=$(mktemp -d)
+	trap teardown EXIT
+	return 0
+}
+
+teardown() {
+	if [[ -n "$TEST_DIR" ]] && [[ -d "$TEST_DIR" ]]; then
+		rm -rf "$TEST_DIR"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test: scanner script exists and is executable
+# ---------------------------------------------------------------------------
+test_scanner_exists() {
+	if [[ -x "$SCANNER" ]]; then
+		print_result "scanner_exists" 0
+	else
+		print_result "scanner_exists" 1 "Scanner not found or not executable at $SCANNER"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# FP1: elif chain — 10 elifs + fi should report depth 1, not 10+
+# ---------------------------------------------------------------------------
+test_fp1_elif_chain() {
+	_write_fixture "$TEST_DIR/fp1_elif.sh" '#!/bin/bash
+check_thing() {
+  if [ "$1" = "a" ]; then
+    echo a
+  elif [ "$1" = "b" ]; then
+    echo b
+  elif [ "$1" = "c" ]; then
+    echo c
+  elif [ "$1" = "d" ]; then
+    echo d
+  elif [ "$1" = "e" ]; then
+    echo e
+  elif [ "$1" = "f" ]; then
+    echo f
+  elif [ "$1" = "g" ]; then
+    echo g
+  elif [ "$1" = "h" ]; then
+    echo h
+  elif [ "$1" = "i" ]; then
+    echo i
+  elif [ "$1" = "j" ]; then
+    echo j
+  else
+    echo other
+  fi
+  return 0
+}'
+
+	local depth
+	depth=$("$SCANNER" "$TEST_DIR/fp1_elif.sh" 2>/dev/null)
+	if [[ "$depth" -eq 1 ]]; then
+		print_result "fp1_elif_chain" 0
+	else
+		print_result "fp1_elif_chain" 1 "Expected depth=1 for elif chain, got $depth"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# FP2: prose containing bare keywords — should report depth 0
+# ---------------------------------------------------------------------------
+test_fp2_prose_keywords() {
+	_write_fixture "$TEST_DIR/fp2_prose.sh" '#!/bin/bash
+echo "for all users, if it matches"
+printf "warn action for runner=%s done with case if while for\n" "$1"'
+
+	local depth
+	depth=$("$SCANNER" "$TEST_DIR/fp2_prose.sh" 2>/dev/null)
+	if [[ "$depth" -eq 0 ]]; then
+		print_result "fp2_prose_keywords" 0
+	else
+		print_result "fp2_prose_keywords" 1 "Expected depth=0 for prose keywords, got $depth"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# FP3: done <<<"$rows" — should report depth 1
+# ---------------------------------------------------------------------------
+test_fp3_herestring_done() {
+	_write_fixture "$TEST_DIR/fp3_herestring.sh" '#!/bin/bash
+process_rows() {
+  local rows="a b c"
+  while read -r line; do
+    echo "$line"
+  done <<<"$rows"
+  return 0
+}'
+
+	local depth
+	depth=$("$SCANNER" "$TEST_DIR/fp3_herestring.sh" 2>/dev/null)
+	if [[ "$depth" -eq 1 ]]; then
+		print_result "fp3_herestring_done" 0
+	else
+		print_result "fp3_herestring_done" 1 "Expected depth=1 for done<<<, got $depth"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# FP3b: done | cmd — should report depth 1
+# ---------------------------------------------------------------------------
+test_fp3b_done_pipe() {
+	_write_fixture "$TEST_DIR/fp3b_pipe.sh" '#!/bin/bash
+list_things() {
+  for f in /tmp/*; do
+    echo "$f"
+  done | sort
+  return 0
+}'
+
+	local depth
+	depth=$("$SCANNER" "$TEST_DIR/fp3b_pipe.sh" 2>/dev/null)
+	if [[ "$depth" -eq 1 ]]; then
+		print_result "fp3b_done_pipe" 0
+	else
+		print_result "fp3b_done_pipe" 1 "Expected depth=1 for done|sort, got $depth"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# FP3c: done > file — should report depth 1
+# ---------------------------------------------------------------------------
+test_fp3c_done_redirect() {
+	_write_fixture "$TEST_DIR/fp3c_redir.sh" '#!/bin/bash
+write_list() {
+  for f in /tmp/*; do
+    echo "$f"
+  done > /dev/null
+  return 0
+}'
+
+	local depth
+	depth=$("$SCANNER" "$TEST_DIR/fp3c_redir.sh" 2>/dev/null)
+	if [[ "$depth" -eq 1 ]]; then
+		print_result "fp3c_done_redirect" 0
+	else
+		print_result "fp3c_done_redirect" 1 "Expected depth=1 for done>file, got $depth"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# FP4: per-function reset — 10 functions each max-depth 2 → max=2 (not 20)
+# ---------------------------------------------------------------------------
+test_fp4_per_function_reset() {
+	_write_fixture "$TEST_DIR/fp4_functions.sh" '#!/bin/bash
+fn_a() { if true; then for x in a; do echo "$x"; done; fi; return 0; }
+fn_b() { if true; then for x in a; do echo "$x"; done; fi; return 0; }
+fn_c() { if true; then for x in a; do echo "$x"; done; fi; return 0; }
+fn_d() { if true; then for x in a; do echo "$x"; done; fi; return 0; }
+fn_e() { if true; then for x in a; do echo "$x"; done; fi; return 0; }
+fn_f() { if true; then for x in a; do echo "$x"; done; fi; return 0; }
+fn_g() { if true; then for x in a; do echo "$x"; done; fi; return 0; }
+fn_h() { if true; then for x in a; do echo "$x"; done; fi; return 0; }
+fn_i() { if true; then for x in a; do echo "$x"; done; fi; return 0; }
+fn_j() { if true; then for x in a; do echo "$x"; done; fi; return 0; }'
+
+	local depth
+	depth=$("$SCANNER" "$TEST_DIR/fp4_functions.sh" 2>/dev/null)
+	if [[ "$depth" -le 3 ]]; then
+		print_result "fp4_per_function_reset" 0
+	else
+		print_result "fp4_per_function_reset" 1 "Expected depth<=3 for 10 funcs each depth 2, got $depth"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# FP5: heredoc body with keywords — should NOT count
+# ---------------------------------------------------------------------------
+test_fp5_heredoc_keywords() {
+	_write_fixture "$TEST_DIR/fp5_heredoc.sh" '#!/bin/bash
+show_help() {
+  cat <<'"'"'HELP'"'"'
+if you see this, for each case:
+  while running, until done
+  if nested, for each while loop
+HELP
+  return 0
+}'
+
+	local depth
+	depth=$("$SCANNER" "$TEST_DIR/fp5_heredoc.sh" 2>/dev/null)
+	if [[ "$depth" -eq 0 ]]; then
+		print_result "fp5_heredoc_keywords" 0
+	else
+		print_result "fp5_heredoc_keywords" 1 "Expected depth=0 for heredoc keywords, got $depth"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Real positive: genuinely nested code — depth 4
+# ---------------------------------------------------------------------------
+test_real_nesting_depth_4() {
+	_write_fixture "$TEST_DIR/real_nested.sh" '#!/bin/bash
+deep_fn() {
+  if true; then
+    for x in a; do
+      while read -r line; do
+        case "$line" in
+          a) echo a;;
+        esac
+      done
+    done
+  fi
+  return 0
+}'
+
+	local depth
+	depth=$("$SCANNER" "$TEST_DIR/real_nested.sh" 2>/dev/null)
+	if [[ "$depth" -eq 4 ]]; then
+		print_result "real_nesting_depth_4" 0
+	else
+		print_result "real_nesting_depth_4" 1 "Expected depth=4 for if/for/while/case, got $depth"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Integration: headless-runtime-lib.sh should report depth ≤12 (was 52/83)
+# ---------------------------------------------------------------------------
+test_headless_runtime_lib_sanity() {
+	local _target="$REPO_ROOT/.agents/scripts/headless-runtime-lib.sh"
+	if [[ ! -f "$_target" ]]; then
+		print_result "headless_runtime_lib_sanity" 0 "(skipped — file not present)"
+		return 0
+	fi
+
+	local depth
+	depth=$("$SCANNER" "$_target" 2>/dev/null)
+	if [[ "$depth" -le 12 ]]; then
+		print_result "headless_runtime_lib_sanity" 0
+	else
+		print_result "headless_runtime_lib_sanity" 1 "Expected depth<=12 for headless-runtime-lib.sh, got $depth (old AWK: 52/83)"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Empty file — depth 0
+# ---------------------------------------------------------------------------
+test_empty_file() {
+	: > "$TEST_DIR/empty.sh"
+	local depth
+	depth=$("$SCANNER" "$TEST_DIR/empty.sh" 2>/dev/null)
+	if [[ "$depth" -eq 0 ]]; then
+		print_result "empty_file" 0
+	else
+		print_result "empty_file" 1 "Expected depth=0 for empty file, got $depth"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Non-existent file — depth 0 (graceful)
+# ---------------------------------------------------------------------------
+test_nonexistent_file() {
+	local depth
+	depth=$("$SCANNER" "$TEST_DIR/nonexistent.sh" 2>/dev/null) || true
+	if [[ "${depth:-0}" -eq 0 ]]; then
+		print_result "nonexistent_file" 0
+	else
+		print_result "nonexistent_file" 1 "Expected depth=0 for missing file, got $depth"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+	setup
+
+	test_scanner_exists
+	test_fp1_elif_chain
+	test_fp2_prose_keywords
+	test_fp3_herestring_done
+	test_fp3b_done_pipe
+	test_fp3c_done_redirect
+	test_fp4_per_function_reset
+	test_fp5_heredoc_keywords
+	test_real_nesting_depth_4
+	test_headless_runtime_lib_sanity
+	test_empty_file
+	test_nonexistent_file
+
+	echo ""
+	echo "Results: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed"
+
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		exit 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Replace the AWK regex nesting-depth scanner with a `shfmt --to-json` AST walker (`.agents/scripts/scanners/nesting-depth.sh`)
- All four documented false-positive classes eliminated by construction: elif inflation, prose keywords, unterminated `done`, global counter
- Per-function depth reset built in via `FuncDecl` AST node boundaries
- Graceful degradation: falls back to legacy AWK when shfmt/python3 unavailable

Resolves #20105

## Changes

| File | Change |
|------|--------|
| `.agents/scripts/scanners/nesting-depth.sh` | **NEW** — shfmt-based nesting depth scanner with AWK fallback |
| `.agents/scripts/complexity-regression-helper.sh` | **EDIT** — delegate `scan_dir_nesting_depth` to the new scanner |
| `.agents/scripts/tests/test-nesting-depth-scanner.sh` | **NEW** — 12 tests covering all FP classes + real positives |
| `.agents/reference/large-file-split.md` | **EDIT** — update §4.1 to reflect scanner fix, remove escape-hatch workaround |

## Testing

- **12/12 tests pass** (test-nesting-depth-scanner.sh):
  - FP1: elif chain of 10 → depth=1 (not 10+)
  - FP2: prose keywords → depth=0
  - FP3: `done <<<`, `done | sort`, `done > /dev/null` → depth=1
  - FP4: 10 functions each depth 2 → max=2 (not 20)
  - FP5: heredoc body with keywords → depth=0
  - Real nested (if/for/while/case) → depth=4
  - headless-runtime-lib.sh → depth=4 (was 52 with old AWK, 83 reported historically)
  - Empty file, nonexistent file → depth=0
- **ShellCheck**: zero violations on all modified/new files
- **Baseline sample**: 25/50 `.sh` files flagged >8 with old AWK → 0/50 with new scanner

## MERGE_SUMMARY

Replaced AWK regex nesting-depth scanner with shfmt AST walker. Eliminates all four documented false-positive classes by construction. headless-runtime-lib.sh: was 52/83, now 4. Baseline: 25→0 files flagged >8 in 50-file sample. 12/12 tests pass. Graceful AWK fallback when shfmt unavailable.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.85 plugin for [OpenCode](https://opencode.ai) v1.14.18 with claude-opus-4-6 spent 16m and 40,507 tokens on this as a headless worker.