### PR TITLE
GH#19864: fix: honor no-takeover label in interactive PR staleness check (GH#19864)

### DIFF
--- a/.agents/scripts/pulse-merge-conflict.sh
+++ b/.agents/scripts/pulse-merge-conflict.sh
@@ -158,6 +158,15 @@ _interactive_pr_is_stale() {
 		'.labels | map(.name) | index("origin:interactive")' \
 		>/dev/null 2>&1 || return 1
 
+	# Gate 1b (GH#19864): honor no-takeover label — opt-out for maintainers
+	# who want to keep an idle PR out of the worker pipeline.
+	if printf '%s' "$pr_meta" | jq -e \
+		'.labels | map(.name) | index("no-takeover")' \
+		>/dev/null 2>&1; then
+		echo "[pulse-merge-conflict] _interactive_pr_is_stale: PR #${pr_number} has no-takeover label — skipping handover (GH#19864)" >>"$LOGFILE"
+		return 1
+	fi
+
 	# Gate 4: age threshold (check before any other gh calls — cheapest filter)
 	local threshold_hours updated_at now_epoch updated_epoch pr_age_hours
 	threshold_hours="${AIDEVOPS_INTERACTIVE_PR_HANDOVER_HOURS:-24}"

--- a/.agents/scripts/tests/test-pulse-merge-interactive-handover.sh
+++ b/.agents/scripts/tests/test-pulse-merge-interactive-handover.sh
@@ -256,6 +256,26 @@ test_G_mode_detect_logs_and_returns_stale() {
 	return 0
 }
 
+test_G2_no_takeover_label_returns_not_stale() {
+	reset_mock_state
+	# Add no-takeover to the PR labels — staleness check should short-circuit
+	printf 'origin:interactive,no-takeover' >"${TEST_ROOT}/labels.txt"
+	AIDEVOPS_INTERACTIVE_PR_HANDOVER_MODE=enforce _interactive_pr_is_stale "100" "owner/repo"
+	local rc=$?
+	if [[ "$rc" -eq 1 ]]; then
+		print_result "G2: no-takeover label returns not-stale from _interactive_pr_is_stale (GH#19864)" 0
+	else
+		print_result "G2: no-takeover label returns not-stale from _interactive_pr_is_stale (GH#19864)" 1 "Expected 1, got $rc"
+	fi
+	# Verify log message
+	if ! grep -q "no-takeover label.*skipping handover" "$LOGFILE"; then
+		print_result "G2: no-takeover label logs skip reason" 1 \
+			"Expected 'no-takeover label' skip message in LOGFILE. Got: $(cat "$LOGFILE")"
+		return 0
+	fi
+	return 0
+}
+
 # =============================================================================
 # Tests — _interactive_pr_trigger_handover
 # =============================================================================
@@ -446,6 +466,7 @@ main() {
 	test_E_missing_origin_interactive_returns_not_stale
 	test_F_mode_off_returns_not_stale_unconditionally
 	test_G_mode_detect_logs_and_returns_stale
+	test_G2_no_takeover_label_returns_not_stale
 	test_H_mode_detect_is_noop
 	test_I_mode_enforce_applies_label_and_posts_comment
 	test_J_enforce_is_idempotent_when_label_already_present


### PR DESCRIPTION
## Summary

Of the 7 CodeRabbit nits filed in GH#19864, 6 were already addressed by t2383/t2438. The remaining finding — Gate 1b in _interactive_pr_is_stale to honor the no-takeover label — is now implemented. When a PR carries no-takeover, the staleness check short-circuits early (returns not-stale) so the PR is never considered for worker handover. A new regression test (test_G2) validates this gate.

## Files Changed

.agents/scripts/pulse-merge-conflict.sh,.agents/scripts/tests/test-pulse-merge-interactive-handover.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean on both modified files; all 16 interactive handover tests pass (including new test_G2_no_takeover_label_returns_not_stale); all other pulse-merge test suites pass unchanged

Resolves #19864


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.85 plugin for [OpenCode](https://opencode.ai) v1.14.18 with claude-opus-4-6 spent 6m and 14,143 tokens on this as a headless worker.