### PR TITLE
t2421: harden PID liveness checks against PID reuse (kill -0 false positives)

### DIFF
--- a/.agents/scripts/auto-update-helper.sh
+++ b/.agents/scripts/auto-update-helper.sh
@@ -273,8 +273,9 @@ acquire_lock() {
 		if [[ -f "$LOCK_FILE/pid" ]]; then
 			local lock_pid
 			lock_pid=$(cat "$LOCK_FILE/pid" 2>/dev/null || echo "")
-			if [[ -n "$lock_pid" ]] && ! kill -0 "$lock_pid" 2>/dev/null; then
-				log_warn "Removing stale lock (PID $lock_pid dead)"
+			# t2421: command-aware liveness — bare kill -0 lies on macOS PID reuse
+			if [[ -n "$lock_pid" ]] && ! _is_process_alive_and_matches "$lock_pid" "${FRAMEWORK_PROCESS_PATTERN:-}"; then
+				log_warn "Removing stale lock (PID $lock_pid dead or reused, t2421)"
 				rm -rf "$LOCK_FILE"
 				continue
 			fi

--- a/.agents/scripts/contribution-watch-helper.sh
+++ b/.agents/scripts/contribution-watch-helper.sh
@@ -165,7 +165,9 @@ _is_scan_running() {
 
 	local old_pid
 	old_pid=$(cat "$PID_FILE" 2>/dev/null || echo "")
-	if [[ -n "$old_pid" ]] && [[ "$old_pid" =~ ^[0-9]+$ ]] && kill -0 "$old_pid" 2>/dev/null; then
+	# t2421: command-aware liveness — bare kill -0 lies on macOS PID reuse
+	if [[ -n "$old_pid" ]] && [[ "$old_pid" =~ ^[0-9]+$ ]] && \
+	   _is_process_alive_and_matches "$old_pid" "contribution-watch-helper"; then
 		return 0
 	fi
 

--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -332,19 +332,20 @@ _check_db_entry() {
 	[[ -f "$pid_file" ]] && stored_pid=$(cat "$pid_file" 2>/dev/null || true)
 
 	if [[ -n "$stored_pid" ]] && [[ "$stored_pid" =~ ^[0-9]+$ ]]; then
-		if ! kill -0 "$stored_pid" 2>/dev/null; then
-			# Process is dead — stale DB entry; reset and allow dispatch
+		# t2421: command-aware liveness check — bare kill -0 lies on macOS PID reuse
+		if ! _is_process_alive_and_matches "$stored_pid" "${WORKER_PROCESS_PATTERN:-}"; then
+			# Process is dead or PID was reused by an unrelated process — stale DB entry
 			sqlite3 "$supervisor_db" "
 				UPDATE tasks SET status = 'failed',
-				  error = 'stale: PID ${stored_pid} not running (GH#5662)',
+				  error = 'stale: PID ${stored_pid} not running or reused (GH#5662/t2421)',
 				  updated_at = strftime('%Y-%m-%dT%H:%M:%SZ','now')
 				WHERE id = '$(printf '%s' "$db_match" | sed "s/'/''/g")';
 			" 2>/dev/null || true
-			printf 'STALE: key=%s task %s PID %s is dead — entry reset, safe to dispatch\n' \
+			printf 'STALE: key=%s task %s PID %s is dead or reused — entry reset, safe to dispatch\n' \
 				"$candidate_key" "$db_match" "$stored_pid"
 			return 1
 		fi
-		# PID is alive — genuine duplicate
+		# PID is alive AND command matches expected worker pattern — genuine duplicate
 		printf 'DUPLICATE: key=%s already active in supervisor DB (task %s PID %s)\n' \
 			"$candidate_key" "$db_match" "$stored_pid"
 		return 0

--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -740,21 +740,29 @@ _acquire_session_lock() {
 	local lock_file="${LOCK_DIR}/${safe_key}.pid"
 
 	if [[ -f "$lock_file" ]]; then
-		local existing_pid
-		existing_pid=$(cat "$lock_file" 2>/dev/null) || existing_pid=""
+		# t2421: format is "pid|argv_hash" — parse both fields (backward-compat with bare pid)
+		local existing_raw existing_pid existing_hash
+		existing_raw=$(cat "$lock_file" 2>/dev/null) || existing_raw=""
+		existing_pid="${existing_raw%%|*}"
+		existing_hash="${existing_raw#*|}"
+		[[ "$existing_hash" == "$existing_pid" ]] && existing_hash=""  # no | separator = legacy format
 		if [[ -n "$existing_pid" ]] && [[ "$existing_pid" =~ ^[0-9]+$ ]]; then
-			if kill -0 "$existing_pid" 2>/dev/null; then
-				# Live process exists -- duplicate dispatch
-				print_warning "Duplicate dispatch blocked: session-key '${lock_session_key}' already has active worker PID ${existing_pid} (GH#6538)"
+			# t2421: command-aware liveness — bare kill -0 lies on macOS PID reuse
+			if _is_process_alive_and_matches "$existing_pid" "${WORKER_PROCESS_PATTERN:-}" "$existing_hash"; then
+				# Live worker process exists -- duplicate dispatch
+				print_warning "Duplicate dispatch blocked: session-key '${lock_session_key}' already has active worker PID ${existing_pid} (GH#6538/t2421)"
 				return 1
 			fi
-			# PID is dead -- stale lock, clean up and proceed
+			# PID is dead or reused by unrelated process -- stale lock, clean up and proceed
 		fi
 		rm -f "$lock_file"
 	fi
 
 	# nice -- lock acquired, this session key is ours
-	printf '%s' "$$" >"$lock_file"
+	# t2421: store pid|argv_hash for PID-reuse-resistant liveness checks
+	local _hrl_argv_hash=""
+	_hrl_argv_hash=$(_compute_argv_hash "$$" 2>/dev/null || echo "")
+	printf '%s|%s' "$$" "$_hrl_argv_hash" >"$lock_file"
 	return 0
 }
 

--- a/.agents/scripts/interactive-session-helper.sh
+++ b/.agents/scripts/interactive-session-helper.sh
@@ -176,6 +176,11 @@ _isc_write_stamp() {
 	timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 	hostname=$(hostname 2>/dev/null || echo "unknown")
 
+	# t2421: compute argv hash for PID-reuse-resistant liveness checks.
+	# Stored in the stamp so scan-stale can verify PID identity later.
+	local argv_hash=""
+	argv_hash=$(_compute_argv_hash "$$" 2>/dev/null || echo "")
+
 	# Escape user-supplied fields via jq's string literals to avoid JSON injection
 	jq -n \
 		--arg issue "$issue" \
@@ -185,6 +190,7 @@ _isc_write_stamp() {
 		--arg pid "$$" \
 		--arg hostname "$hostname" \
 		--arg user "$user" \
+		--arg argv_hash "$argv_hash" \
 		'{
 			issue: ($issue | tonumber),
 			slug: $slug,
@@ -192,7 +198,8 @@ _isc_write_stamp() {
 			claimed_at: $claimed_at,
 			pid: ($pid | tonumber),
 			hostname: $hostname,
-			user: $user
+			user: $user,
+			owner_argv_hash: $argv_hash
 		}' >"$stamp_file" 2>/dev/null || {
 		_isc_warn "failed to write stamp: $stamp_file"
 		return 0
@@ -1120,7 +1127,13 @@ _isc_scan_dead_stamps_phase() {
 			[[ "$hostname" == "$local_host" ]] || continue
 
 			local pid_alive=0
-			[[ -n "$pid" ]] && kill -0 "$pid" 2>/dev/null && pid_alive=1
+			# t2421: command-aware liveness — bare kill -0 lies on macOS PID reuse.
+			# Read stored argv hash from stamp for higher precision.
+			local stored_hash
+			stored_hash=$(jq -r '.owner_argv_hash // empty' "$stamp" 2>/dev/null || echo "")
+			if [[ -n "$pid" ]] && _is_process_alive_and_matches "$pid" "${WORKER_PROCESS_PATTERN:-}" "$stored_hash"; then
+				pid_alive=1
+			fi
 
 			local worktree_exists=0
 			[[ -n "$worktree" && -d "$worktree" ]] && worktree_exists=1

--- a/.agents/scripts/pulse-canonical-maintenance.sh
+++ b/.agents/scripts/pulse-canonical-maintenance.sh
@@ -102,7 +102,11 @@ _canonical_maintenance_has_active_session() {
 		if [[ -n "$stamp_worktree" ]] && [[ "$stamp_worktree" == "$repo_path"* ]]; then
 			local stamp_pid=""
 			stamp_pid=$(jq -r '.pid // ""' "$stamp" 2>/dev/null) || continue
-			if [[ -n "$stamp_pid" ]] && [[ "$stamp_pid" =~ ^[0-9]+$ ]] && kill -0 "$stamp_pid" 2>/dev/null; then
+			# t2421: command-aware liveness — bare kill -0 lies on macOS PID reuse.
+			local stamp_hash=""
+			stamp_hash=$(jq -r '.owner_argv_hash // empty' "$stamp" 2>/dev/null || echo "")
+			if [[ -n "$stamp_pid" ]] && [[ "$stamp_pid" =~ ^[0-9]+$ ]] && \
+			   _is_process_alive_and_matches "$stamp_pid" "${WORKER_PROCESS_PATTERN:-}" "$stamp_hash"; then
 				return 0
 			fi
 		fi

--- a/.agents/scripts/pulse-fast-fail.sh
+++ b/.agents/scripts/pulse-fast-fail.sh
@@ -151,18 +151,25 @@ _ff_with_lock() {
 		fi
 		# Stale lock detection: read the owner PID stored in the lock directory.
 		# If that process is no longer running, the lock is orphaned — clear it.
-		local _ff_owner_pid
-		_ff_owner_pid=$(cat "${lock_dir}/owner.pid" 2>/dev/null || true)
-		if [[ -n "$_ff_owner_pid" ]] && ! kill -0 "$_ff_owner_pid" 2>/dev/null; then
-			echo "[pulse-wrapper] _ff_with_lock: clearing stale lock (owner PID ${_ff_owner_pid} gone)" >>"$LOGFILE"
+		# t2421: format is "pid|argv_hash" — parse both fields.
+		local _ff_owner_raw _ff_owner_pid _ff_owner_hash
+		_ff_owner_raw=$(cat "${lock_dir}/owner.pid" 2>/dev/null || true)
+		_ff_owner_pid="${_ff_owner_raw%%|*}"
+		_ff_owner_hash="${_ff_owner_raw#*|}"
+		[[ "$_ff_owner_hash" == "$_ff_owner_pid" ]] && _ff_owner_hash=""  # no | separator = legacy format
+		# t2421: command-aware liveness — bare kill -0 lies on macOS PID reuse
+		if [[ -n "$_ff_owner_pid" ]] && ! _is_process_alive_and_matches "$_ff_owner_pid" "${PULSE_PROCESS_PATTERN:-}" "$_ff_owner_hash"; then
+			echo "[pulse-wrapper] _ff_with_lock: clearing stale lock (owner PID ${_ff_owner_pid} gone or reused, t2421)" >>"$LOGFILE"
 			rm -f "${lock_dir}/owner.pid" 2>/dev/null || true
 			rmdir "$lock_dir" 2>/dev/null || true
 			continue
 		fi
 		sleep 0.1
 	done
-	# Record owner PID inside lock directory so retrying callers can detect staleness.
-	printf '%s\n' "$$" >"${lock_dir}/owner.pid" 2>/dev/null || true
+	# Record owner PID (and argv hash for t2421 PID-reuse detection) inside lock directory.
+	local _ff_argv_hash=""
+	_ff_argv_hash=$(_compute_argv_hash "$$" 2>/dev/null || echo "")
+	printf '%s|%s\n' "$$" "$_ff_argv_hash" >"${lock_dir}/owner.pid" 2>/dev/null || true
 	local rc=0
 	"$@" || rc=$?
 	rm -f "${lock_dir}/owner.pid" 2>/dev/null || true

--- a/.agents/scripts/repo-aidevops-health-helper.sh
+++ b/.agents/scripts/repo-aidevops-health-helper.sh
@@ -213,8 +213,9 @@ acquire_lock() {
 		if [[ -f "$LOCK_FILE/pid" ]]; then
 			local lock_pid
 			lock_pid=$(cat "$LOCK_FILE/pid" 2>/dev/null || echo "")
-			if [[ -n "$lock_pid" ]] && ! kill -0 "$lock_pid" 2>/dev/null; then
-				log_warn "Removing stale lock (PID $lock_pid dead)"
+			# t2421: command-aware liveness — bare kill -0 lies on macOS PID reuse
+			if [[ -n "$lock_pid" ]] && ! _is_process_alive_and_matches "$lock_pid" "${FRAMEWORK_PROCESS_PATTERN:-}"; then
+				log_warn "Removing stale lock (PID $lock_pid dead or reused, t2421)"
 				rm -rf "$LOCK_FILE"
 				continue
 			fi

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -878,6 +878,96 @@ _SC_SELF="${BASH_SOURCE[0]:-${0:-}}"
 # =============================================================================
 
 # =============================================================================
+# PID Liveness — command-aware process checks (t2421, GH#20027)
+# =============================================================================
+# Bare `kill -0 <PID>` lies when macOS recycles PIDs (wraps at 99999).
+# These helpers verify the PID is alive AND its command matches what we expect.
+#
+# Constants: WORKER_PROCESS_PATTERN, PULSE_PROCESS_PATTERN, FRAMEWORK_PROCESS_PATTERN
+# Functions: _compute_argv_hash, _is_process_alive_and_matches
+# =============================================================================
+
+# Expected command patterns for PID-owner verification.
+# Used by _is_process_alive_and_matches to distinguish real workers from
+# PID-reuse impostors (e.g., "Brave Browser Helper (Renderer)").
+[[ -z "${WORKER_PROCESS_PATTERN+x}" ]] && WORKER_PROCESS_PATTERN='opencode|claude|Claude'
+[[ -z "${PULSE_PROCESS_PATTERN+x}" ]] && PULSE_PROCESS_PATTERN='pulse-wrapper'
+[[ -z "${FRAMEWORK_PROCESS_PATTERN+x}" ]] && FRAMEWORK_PROCESS_PATTERN='opencode|claude|Claude|pulse|aidevops|headless-runtime'
+
+#######################################
+# Compute a short hash of a process's command line.
+# Portable across macOS (shasum) and Linux (sha256sum).
+# Args: $1 = PID (defaults to $$)
+# Outputs: 12-char hex hash on stdout, or empty string on failure.
+# Returns: 0 on success, 1 on failure.
+#######################################
+_compute_argv_hash() {
+	local pid="${1:-$$}"
+	local cmd
+	cmd=$(ps -p "$pid" -o command= 2>/dev/null) || return 1
+	[[ -z "$cmd" ]] && return 1
+	local hash
+	if command -v shasum >/dev/null 2>&1; then
+		hash=$(printf '%s' "$cmd" | shasum -a 256 2>/dev/null | cut -c1-12)
+	elif command -v sha256sum >/dev/null 2>&1; then
+		hash=$(printf '%s' "$cmd" | sha256sum 2>/dev/null | cut -c1-12)
+	else
+		# Fallback: no hash tool available, return empty (callers skip hash check)
+		return 1
+	fi
+	[[ -n "$hash" ]] && printf '%s' "$hash" && return 0
+	return 1
+}
+
+#######################################
+# Check that a PID is alive AND its command matches expected pattern.
+# Replaces bare `kill -0` checks that are vulnerable to PID reuse on macOS.
+#
+# Args:
+#   $1 = PID to check
+#   $2 = regex pattern (e.g., "opencode|claude"). If empty, falls back to
+#        bare kill -0 (backward-compatible for callers that don't know
+#        the expected command).
+#   $3 = (optional) stored argv hash. If provided and non-empty, the
+#        current process command hash must match. This catches PID reuse
+#        even when the new process name happens to match the pattern
+#        (e.g., two different claude sessions).
+#
+# Returns: 0 if alive and matches, 1 otherwise.
+#######################################
+_is_process_alive_and_matches() {
+	local pid="$1"
+	local pattern="${2:-}"
+	local stored_hash="${3:-}"
+
+	# Basic validation
+	[[ -z "$pid" ]] && return 1
+	[[ "$pid" == "0" ]] && return 1
+	[[ "$pid" =~ ^[0-9]+$ ]] || return 1
+
+	# Step 1: is the PID alive at all?
+	kill -0 "$pid" 2>/dev/null || return 1
+
+	# Step 2: does the command match the expected pattern?
+	if [[ -n "$pattern" ]]; then
+		local cmd
+		cmd=$(ps -p "$pid" -o command= 2>/dev/null) || return 1
+		[[ -z "$cmd" ]] && return 1
+		printf '%s' "$cmd" | grep -qE "$pattern" || return 1
+	fi
+
+	# Step 3: if a stored hash was provided, verify it matches
+	if [[ -n "$stored_hash" ]]; then
+		local current_hash
+		current_hash=$(_compute_argv_hash "$pid") || return 0  # no hash tool = skip check
+		[[ -z "$current_hash" ]] && return 0  # can't compute = optimistic pass
+		[[ "$stored_hash" == "$current_hash" ]] || return 1
+	fi
+
+	return 0
+}
+
+# =============================================================================
 # Model Tier Resolution & Pricing -- extracted module
 # =============================================================================
 # Functions: resolve_model_tier, detect_ai_backends, get_model_pricing,

--- a/.agents/scripts/shared-todo-commit.sh
+++ b/.agents/scripts/shared-todo-commit.sh
@@ -108,8 +108,9 @@ _todo_acquire_lock() {
 		if [[ -f "$TODO_LOCK_PATH/pid" ]]; then
 			local lock_pid
 			lock_pid=$(cat "$TODO_LOCK_PATH/pid" 2>/dev/null || echo "")
-			if [[ -n "$lock_pid" ]] && ! kill -0 "$lock_pid" 2>/dev/null; then
-				echo "[todo_lock] Removing stale lock (PID $lock_pid dead)" >>"$log_target"
+			# t2421: command-aware liveness — bare kill -0 lies on macOS PID reuse
+			if [[ -n "$lock_pid" ]] && ! _is_process_alive_and_matches "$lock_pid" "${FRAMEWORK_PROCESS_PATTERN:-}"; then
+				echo "[todo_lock] Removing stale lock (PID $lock_pid dead or reused, t2421)" >>"$log_target"
 				rm -rf "$TODO_LOCK_PATH"
 				continue
 			fi

--- a/.agents/scripts/tests/test-pid-liveness-reuse.sh
+++ b/.agents/scripts/tests/test-pid-liveness-reuse.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-pid-liveness-reuse.sh — t2421 PID liveness reuse regression test.
+#
+# Verifies that _is_process_alive_and_matches() correctly distinguishes between:
+#   1. Alive PID with matching command → passes (exit 0).
+#   2. Alive PID with NON-matching command (simulate Brave Browser case) → fails (exit 1).
+#   3. Dead PID → fails (exit 1).
+#   4. PID with stored argv_hash mismatching current → fails (exit 1).
+#   5. Empty/zero/non-numeric PID → fails (exit 1).
+#   6. _compute_argv_hash produces a stable 12-char hex hash.
+#
+# Run: bash .agents/scripts/tests/test-pid-liveness-reuse.sh
+# Expected: all tests PASS.
+
+# NOTE: not using `set -e` intentionally — negative assertions rely on
+# capturing non-zero exits. Each assertion explicitly captures exit codes.
+set -uo pipefail
+
+TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_RED=$'\033[0;31m'
+TEST_GREEN=$'\033[0;32m'
+TEST_RESET=$'\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1" rc="$2" extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf '%sPASS%s %s\n' "$TEST_GREEN" "$TEST_RESET" "$name"
+	else
+		printf '%sFAIL%s %s %s\n' "$TEST_RED" "$TEST_RESET" "$name" "$extra"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+# Sandbox HOME so sourcing is side-effect-free
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+export HOME="${TEST_ROOT}/home"
+mkdir -p "${HOME}/.aidevops/logs" "${HOME}/.aidevops/.agent-workspace/supervisor"
+
+# Source shared-constants.sh to get _is_process_alive_and_matches and _compute_argv_hash
+# shellcheck source=/dev/null
+source "${TEST_SCRIPTS_DIR}/shared-constants.sh" 2>/dev/null || {
+	echo "FATAL: Could not source shared-constants.sh"
+	exit 1
+}
+
+echo "=== t2421: PID liveness reuse regression tests ==="
+echo ""
+
+# -------------------------------------------------------------------------
+# Test 1: Alive PID with matching command → passes
+# Use our own PID ($$) which is running bash
+# -------------------------------------------------------------------------
+_is_process_alive_and_matches "$$" "bash"
+rc=$?
+print_result "1. Alive PID with matching command (our own bash process)" "$([[ $rc -eq 0 ]] && echo 0 || echo 1)"
+
+# -------------------------------------------------------------------------
+# Test 2: Alive PID with NON-matching command → fails
+# Use our own PID but expect a completely different pattern
+# -------------------------------------------------------------------------
+_is_process_alive_and_matches "$$" "Brave Browser Helper" 2>/dev/null
+rc=$?
+print_result "2. Alive PID with non-matching command (Brave Browser pattern)" "$([[ $rc -ne 0 ]] && echo 0 || echo 1)"
+
+# -------------------------------------------------------------------------
+# Test 3: Dead PID → fails
+# Use PID 99998 which is very unlikely to be alive, or find a guaranteed dead PID
+# -------------------------------------------------------------------------
+dead_pid=99998
+# Make sure it's actually dead
+while kill -0 "$dead_pid" 2>/dev/null; do
+	dead_pid=$((dead_pid - 1))
+done
+_is_process_alive_and_matches "$dead_pid" "bash" 2>/dev/null
+rc=$?
+print_result "3. Dead PID ($dead_pid) → fails" "$([[ $rc -ne 0 ]] && echo 0 || echo 1)"
+
+# -------------------------------------------------------------------------
+# Test 4: PID with stored argv_hash mismatching current → fails
+# Use our own PID but provide a fake stored hash
+# -------------------------------------------------------------------------
+_is_process_alive_and_matches "$$" "bash" "000000000000" 2>/dev/null
+rc=$?
+print_result "4. Alive PID + matching command + WRONG argv hash → fails" "$([[ $rc -ne 0 ]] && echo 0 || echo 1)"
+
+# -------------------------------------------------------------------------
+# Test 5: PID with matching stored argv_hash → passes
+# Compute our own hash and verify it matches
+# -------------------------------------------------------------------------
+our_hash=$(_compute_argv_hash "$$" 2>/dev/null || echo "")
+if [[ -n "$our_hash" ]]; then
+	_is_process_alive_and_matches "$$" "bash" "$our_hash"
+	rc=$?
+	print_result "5. Alive PID + matching command + CORRECT argv hash → passes" "$([[ $rc -eq 0 ]] && echo 0 || echo 1)"
+else
+	print_result "5. Alive PID + matching command + CORRECT argv hash → passes" 1 "(SKIP: no hash tool available)"
+fi
+
+# -------------------------------------------------------------------------
+# Test 6: Empty PID → fails
+# -------------------------------------------------------------------------
+_is_process_alive_and_matches "" "bash" 2>/dev/null
+rc=$?
+print_result "6. Empty PID → fails" "$([[ $rc -ne 0 ]] && echo 0 || echo 1)"
+
+# -------------------------------------------------------------------------
+# Test 7: PID 0 → fails
+# -------------------------------------------------------------------------
+_is_process_alive_and_matches "0" "bash" 2>/dev/null
+rc=$?
+print_result "7. PID 0 → fails" "$([[ $rc -ne 0 ]] && echo 0 || echo 1)"
+
+# -------------------------------------------------------------------------
+# Test 8: Non-numeric PID → fails
+# -------------------------------------------------------------------------
+_is_process_alive_and_matches "abc" "bash" 2>/dev/null
+rc=$?
+print_result "8. Non-numeric PID → fails" "$([[ $rc -ne 0 ]] && echo 0 || echo 1)"
+
+# -------------------------------------------------------------------------
+# Test 9: Empty pattern → falls back to bare kill -0 (alive PID passes)
+# -------------------------------------------------------------------------
+_is_process_alive_and_matches "$$" ""
+rc=$?
+print_result "9. Alive PID + empty pattern → passes (bare kill -0 fallback)" "$([[ $rc -eq 0 ]] && echo 0 || echo 1)"
+
+# -------------------------------------------------------------------------
+# Test 10: _compute_argv_hash produces stable 12-char hex output
+# -------------------------------------------------------------------------
+hash1=$(_compute_argv_hash "$$" 2>/dev/null || echo "")
+hash2=$(_compute_argv_hash "$$" 2>/dev/null || echo "")
+if [[ -n "$hash1" ]]; then
+	hash_ok=1
+	# Check length = 12
+	[[ ${#hash1} -eq 12 ]] || hash_ok=0
+	# Check hex chars only
+	[[ "$hash1" =~ ^[0-9a-f]+$ ]] || hash_ok=0
+	# Check stable (same PID, same hash)
+	[[ "$hash1" == "$hash2" ]] || hash_ok=0
+	print_result "10. _compute_argv_hash: stable 12-char hex (${hash1})" "$([[ $hash_ok -eq 1 ]] && echo 0 || echo 1)"
+else
+	print_result "10. _compute_argv_hash: stable 12-char hex" 1 "(SKIP: no hash tool available)"
+fi
+
+# -------------------------------------------------------------------------
+# Test 11: _compute_argv_hash for dead PID → fails (exit 1)
+# -------------------------------------------------------------------------
+_compute_argv_hash "$dead_pid" >/dev/null 2>&1
+rc=$?
+print_result "11. _compute_argv_hash for dead PID → fails" "$([[ $rc -ne 0 ]] && echo 0 || echo 1)"
+
+# -------------------------------------------------------------------------
+# Summary
+# -------------------------------------------------------------------------
+echo ""
+echo "=== Results: ${TESTS_RUN} run, ${TESTS_FAILED} failed ==="
+if [[ $TESTS_FAILED -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/.agents/scripts/worker-watchdog.sh
+++ b/.agents/scripts/worker-watchdog.sh
@@ -1429,7 +1429,8 @@ _cleanup_stale_tracking_files() {
 		[[ -f "$tracking_file" ]] || continue
 		local tracked_pid
 		tracked_pid=$(basename "$tracking_file" | sed 's/^idle-//;s/^stall-//;s/^grace-//')
-		if [[ "$tracked_pid" =~ ^[0-9]+$ ]] && ! kill -0 "$tracked_pid" 2>/dev/null; then
+		# t2421: command-aware liveness — bare kill -0 lies on macOS PID reuse
+		if [[ "$tracked_pid" =~ ^[0-9]+$ ]] && ! _is_process_alive_and_matches "$tracked_pid" "${WORKER_PROCESS_PATTERN:-}"; then
 			rm -f "$tracking_file" 2>/dev/null || true
 		fi
 	done


### PR DESCRIPTION
## Summary

Replace bare `kill -0 <PID>` checks across the framework with command-aware liveness checks that verify the PID is alive AND its command matches the expected pattern. This eliminates false positives from macOS PID reuse (PIDs wrap at 99999 and are reassigned to unrelated processes like Brave Browser Helper).

## What Changed

### New helper functions in `shared-constants.sh`
- **`_is_process_alive_and_matches(pid, pattern, stored_hash)`** — checks PID liveness + command regex match + optional argv hash verification. Drop-in replacement for bare `kill -0`.
- **`_compute_argv_hash(pid)`** — produces a 12-char hex hash of a process's command line. Portable across macOS (`shasum`) and Linux (`sha256sum`).
- **Pattern constants**: `WORKER_PROCESS_PATTERN`, `PULSE_PROCESS_PATTERN`, `FRAMEWORK_PROCESS_PATTERN` for site-specific command matching.

### 10 critical `kill -0` call sites migrated
| File | What it checks | Pattern used |
|------|---------------|-------------|
| `dispatch-dedup-helper.sh` | Supervisor DB worker PIDs | `WORKER_PROCESS_PATTERN` |
| `interactive-session-helper.sh` | Scan-stale stamp PIDs | `WORKER_PROCESS_PATTERN` + argv hash |
| `pulse-canonical-maintenance.sh` | Stamp PIDs | `WORKER_PROCESS_PATTERN` + argv hash |
| `headless-runtime-lib.sh` | Lock PIDs (duplicate dispatch block) | `WORKER_PROCESS_PATTERN` + argv hash |
| `contribution-watch-helper.sh` | Pidfile PIDs | `contribution-watch-helper` |
| `pulse-fast-fail.sh` | Lock owner PIDs | `PULSE_PROCESS_PATTERN` + argv hash |
| `shared-todo-commit.sh` | Lock PIDs | `FRAMEWORK_PROCESS_PATTERN` |
| `auto-update-helper.sh` | Lock PIDs | `FRAMEWORK_PROCESS_PATTERN` |
| `repo-aidevops-health-helper.sh` | Lock PIDs | `FRAMEWORK_PROCESS_PATTERN` |
| `worker-watchdog.sh` | Tracking file PIDs | `WORKER_PROCESS_PATTERN` |

### Stamp/lock format extensions (backward-compatible)
- Interactive claim stamp JSON: new `owner_argv_hash` field
- `headless-runtime-lib.sh` lock file: `pid|argv_hash` format
- `pulse-fast-fail.sh` lock file: `pid|argv_hash` format
- Missing hash field = skip hash check, rely on command pattern match only

### Non-migrated sites (safe — NOT vulnerable to PID reuse)
Post-kill checks (worker-watchdog.sh:832, pulse-watchdog.sh:114/484) and own-child wait loops (headless-runtime-lib.sh:557, pulse-watchdog.sh:153/205) are NOT vulnerable because they check PIDs within milliseconds of signaling or have parent-child relationships.

## Testing

```bash
bash .agents/scripts/tests/test-pid-liveness-reuse.sh
```

11/11 tests pass:
1. Alive PID + matching command → passes
2. Alive PID + non-matching command (Brave Browser case) → fails
3. Dead PID → fails
4. Alive PID + matching command + wrong argv hash → fails
5. Alive PID + matching command + correct argv hash → passes
6. Empty PID → fails
7. PID 0 → fails
8. Non-numeric PID → fails
9. Empty pattern → falls back to bare kill -0
10. `_compute_argv_hash` produces stable 12-char hex
11. `_compute_argv_hash` for dead PID → fails

All modified files pass `shellcheck` with zero violations (pre-existing warnings in auto-update-helper.sh are unrelated).

Resolves #20027


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.85 plugin for [OpenCode](https://opencode.ai) v1.14.18 with claude-opus-4-6 spent 10m and 24,595 tokens on this as a headless worker.