### PR TITLE
t2423: add Phase C metachar guard and Phase D end-to-end test for routine-schedule parser

### DIFF
--- a/.agents/scripts/routine-schedule-helper.sh
+++ b/.agents/scripts/routine-schedule-helper.sh
@@ -129,6 +129,30 @@ _current_dom() {
 _parse_expression() {
 	local expr="$1"
 
+	# Phase C defensive guard (t2423): detect regex metacharacters that indicate
+	# a caller has passed a pattern string instead of a schedule expression.
+	# Observed: pulse-routines.sh grep selector matched t-prefix task descriptions
+	# containing `repeat:([^[:space:]]+)` and the capture group was passed here.
+	#
+	# Valid schedule expressions only contain: letters, digits, ( ) @ : * / - , space.
+	# Regex-specific characters NOT used in any valid schedule: [ ] ^ $ \ { } + | ? .
+	# Note: ( and ) are intentionally excluded from the guard — they appear in all
+	# schedule types: daily(@...), cron(...), weekly(...), monthly(...).
+	#
+	# Bash 3.2 compat: use a variable to hold the pattern to avoid inline-regex
+	# parsing issues with character class brackets in [[ =~ ]].
+	local _metachar_re='[][^$\{}+|?.]'
+	if [[ "$expr" =~ $_metachar_re ]]; then
+		printf '%s\n' "ERROR: schedule expression '$expr' contains regex metacharacters — caller likely passed a pattern instead of a match (t2423 guard)" >&2
+		# Print caller stack for actionable diagnosis. FUNCNAME/BASH_SOURCE/BASH_LINENO
+		# are standard bash arrays available in bash 3.2+.
+		local _i
+		for ((_i = 1; _i < ${#FUNCNAME[@]}; _i++)); do
+			printf '  at %s (%s:%s)\n' "${FUNCNAME[$_i]:-?}" "${BASH_SOURCE[$_i]:-?}" "${BASH_LINENO[$((_i - 1))]:-?}" >&2
+		done
+		return 2
+	fi
+
 	if [[ "$expr" =~ ^daily\(@([0-9]{1,2}):([0-9]{2})\)$ ]]; then
 		local hour="${BASH_REMATCH[1]}"
 		local minute="${BASH_REMATCH[2]}"
@@ -166,6 +190,16 @@ _parse_expression() {
 			printf '%s\n' "ERROR: cron expression must have 5 fields, got $field_count" >&2
 			return 1
 		fi
+		# Warn about escaped asterisks (\*) that won't match as wildcards.
+		# In TODO.md, authors sometimes write cron(\* \* \*) for Markdown rendering,
+		# but the backslash is literal in bash and _cron_field_matches sees "\*" not "*".
+		local _field
+		for _field in "${_cron_fields[@]}"; do
+			if [[ "$_field" == '\*' ]]; then
+				printf '%s\n' "WARNING: cron field '\\*' (escaped asterisk) does not match as wildcard — use '*' in repeat: expressions (t2423)" >&2
+				break
+			fi
+		done
 		printf 'cron %s' "$cron_expr"
 		return 0
 	fi

--- a/.agents/scripts/tests/test-pulse-routines-selector.sh
+++ b/.agents/scripts/tests/test-pulse-routines-selector.sh
@@ -2,10 +2,15 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 #
-# test-pulse-routines-selector.sh — Regression tests for the two false-match
-# bugs fixed in pulse-routines.sh by t2175:
+# test-pulse-routines-selector.sh — Regression tests for routine selector bugs
+# fixed in pulse-routines.sh and routine-schedule-helper.sh:
 #
-# Bug 1 — t-prefix false match: the grep selector
+# History:
+#   t2160 — cron schedule extraction truncated at first space (fixed Apr 17)
+#   t2175 — two false-match bugs (fixed Apr 18):
+#   t2423 — Phase C metachar guard + Phase D end-to-end test (this PR)
+#
+# Bug 1 (t2175) — t-prefix false match: the grep selector
 #   '^\s*-\s*\[x\].*repeat:' matched any completed task whose description text
 #   contains the literal "repeat:" (e.g. t2160 quotes `repeat:([^[:space:]]+)`).
 #   Combined with the unanchored routine-ID regex (r[0-9]+), this caused r-IDs
@@ -13,9 +18,9 @@
 #   routine IDs and their neighbour text passed to the schedule parser.
 #   Observed error: ERROR: unrecognised schedule expression '([^[:space:]]+)`'
 #
-# Bug 2 — persistent unsupported: r912 in aidevops-routines/TODO.md carries
-#   repeat:persistent (launchd-supervised daemon). The schedule parser and the
-#   pulse evaluator both rejected this keyword.
+# Bug 2 (t2175) — persistent unsupported: r912 in aidevops-routines/TODO.md
+#   carries repeat:persistent (launchd-supervised daemon). The schedule parser
+#   and the pulse evaluator both rejected this keyword.
 #   Observed error: ERROR: unrecognised schedule expression 'persistent'
 #
 # Fixes verified here:
@@ -23,6 +28,7 @@
 #   2. Anchored routine-ID regex: ^[[:space:]]*-[[:space:]]\[x\][[:space:]]+(r[0-9]+)
 #   3. persistent short-circuit in pulse-routines.sh evaluator loop
 #   4. persistent handling in routine-schedule-helper.sh (cmd_is_due returns 1)
+#   5. (t2423) Phase C metachar guard in routine-schedule-helper.sh _parse_expression
 #
 # Cases:
 #   1. t-prefix with repeat: in description → selector finds 0 matches
@@ -31,6 +37,10 @@
 #   3. r-prefix with repeat:cron(*/2 * * * *) → selector finds 1 match; no parse error
 #   4. Mixed: t-prefix false-match line + two r-prefix routines → selector finds
 #      exactly 2 matches (only the r-prefixed entries)
+#   5. (t2423 Phase C) regex metachars directly passed to schedule helper → exit 2
+#      with distinct error message, no "unrecognised schedule expression"
+#   6. (t2423 Phase D) Full discovery simulation: mixed TODO with t-prefix false-match
+#      lines produces zero "unrecognised schedule expression" errors on stderr
 
 set -u
 
@@ -143,6 +153,68 @@ main() {
 		pass "Case 4: mixed TODO — 2 r-prefix routines matched, t-prefix excluded"
 	else
 		fail "Case 4: mixed TODO — 2 r-prefix routines matched" "expected 2 matches, got $count"
+	fi
+
+	# === Case 5 (t2423 Phase C): regex metachars passed directly to schedule helper ===
+	# Verifies that the Phase C guard in _parse_expression catches patterns like
+	# '([^[:space:]]+)`' before they hit the "unrecognised" fallback.
+	# The guard must:
+	#   a) exit 2 (distinct from normal parse error exit 1)
+	#   b) emit "regex metacharacters" in the error message
+	#   c) NOT emit "unrecognised schedule expression" (that would be false noise)
+	local meta_exit meta_stderr
+	meta_stderr=$("$SCHEDULE_HELPER" is-due '([^[:space:]]+)`' '0' 2>&1 >/dev/null)
+	meta_exit=$?
+	if [[ "$meta_exit" -eq 2 ]] && [[ "$meta_stderr" == *"regex metacharacters"* ]] && [[ "$meta_stderr" != *"unrecognised schedule expression"* ]]; then
+		pass "Case 5 (t2423 Phase C): metachar guard fires for regex pattern input"
+	else
+		fail "Case 5 (t2423 Phase C): metachar guard fires for regex pattern input" \
+			"exit=$meta_exit stderr='$meta_stderr'"
+	fi
+
+	# === Case 6 (t2423 Phase D): end-to-end discovery produces zero schedule errors ===
+	# Simulates the full pulse-routines discovery path using a TODO.md that contains:
+	#   - A t-prefix task quoting a repeat: regex (the original t2175 false-match trigger)
+	#   - A t2423 task that mentions the regex guard
+	#   - Two valid r-prefix routines (cron + persistent)
+	# The simulation pipes each matched line through the same extraction regex used
+	# by pulse-routines.sh and calls routine-schedule-helper.sh is-due for each.
+	# The test passes if zero "unrecognised schedule expression" errors appear on stderr.
+	_make_todo "$tmpdir" \
+		"- [x] t2160 fix: \`repeat:([^[:space:]]+)\` (r901, r902) ref:GH#19465" \
+		"- [x] t2423 guard: routine-schedule-helper.sh regex metachar guard" \
+		"- [x] r901 Supervisor pulse repeat:cron(*/2 * * * *) ~0s agent:Build+" \
+		"- [x] r912 Dashboard server repeat:persistent ~0s run:server/index.ts"
+
+	# This is the regex used in pulse-routines.sh to extract the repeat: value.
+	# Store in a variable (not inline) so bash doesn't misparse the literal ')'.
+	local re_repeat='repeat:(cron\([^)]*\)|[^[:space:]]+)'
+	local e2e_errors=0
+	local e2e_stderr=""
+	while IFS= read -r line; do
+		local repeat_expr=""
+		if [[ "$line" =~ $re_repeat ]]; then
+			repeat_expr="${BASH_REMATCH[1]}"
+		else
+			continue
+		fi
+		# Skip persistent — pulse-routines.sh skips before calling is-due.
+		if [[ "$repeat_expr" == "persistent" ]]; then
+			continue
+		fi
+		local _ise_out
+		_ise_out=$("$SCHEDULE_HELPER" is-due "$repeat_expr" "0" 2>&1 >/dev/null)
+		if [[ "$_ise_out" == *"unrecognised schedule expression"* ]]; then
+			e2e_errors=$((e2e_errors + 1))
+			e2e_stderr="${e2e_stderr}|${repeat_expr}: ${_ise_out}"
+		fi
+	done < <(grep -E "$SELECTOR" "${tmpdir}/TODO.md" 2>/dev/null || true)
+
+	if [[ "$e2e_errors" -eq 0 ]]; then
+		pass "Case 6 (t2423 Phase D): full discovery path — zero unrecognised schedule errors"
+	else
+		fail "Case 6 (t2423 Phase D): full discovery path — zero unrecognised schedule errors" \
+			"got $e2e_errors error(s): $e2e_stderr"
 	fi
 
 	# === Summary ===

--- a/.agents/scripts/tests/test-pulse-routines-selector.sh
+++ b/.agents/scripts/tests/test-pulse-routines-selector.sh
@@ -89,20 +89,16 @@ _make_todo() {
 # Must match the grep -E pattern used in the production script.
 SELECTOR='^\s*-\s*\[x\][[:space:]]+r[0-9]+[[:space:]].*repeat:'
 
-main() {
-	local tmpdir
-	tmpdir=$(mktemp -d) || { printf 'FATAL: mktemp failed\n' >&2; exit 1; }
-	# shellcheck disable=SC2064
-	trap "rm -rf '$tmpdir'" EXIT
+# _test_selector_cases: cases 1-4 — grep selector correctness (t2175)
+_test_selector_cases() {
+	local tmpdir="$1"
+	local count
 
-	# === Case 1: t-prefix task with repeat: in description → 0 selector matches ===
-	# Mirrors the t2160 TODO.md entry that triggered bug 1.  The description quotes
-	# the repeat: regex and lists r901/r902 as example routine IDs.  With the OLD
-	# selector, this line matched; with the NEW selector it must not.
+	# Case 1: t-prefix task with repeat: in description → 0 selector matches.
+	# Mirrors t2160 TODO entry. OLD selector matched; NEW must not.
 	_make_todo "$tmpdir" \
 		"- [x] t2160 fix: \`repeat:([^[:space:]]+)\` (r901, r902) ref:GH#19465"
-	local count
-	# grep -c always prints the count even when 0; no || fallback needed.
+	# grep -c prints 0 even on no match; no || fallback needed.
 	count=$(grep -cE "$SELECTOR" "${tmpdir}/TODO.md" 2>/dev/null; true)
 	if [[ "$count" -eq 0 ]]; then
 		pass "Case 1: t-prefix false-match prevented by tightened selector"
@@ -110,10 +106,8 @@ main() {
 		fail "Case 1: t-prefix false-match prevented" "expected 0 matches, got $count"
 	fi
 
-	# === Case 2: r-prefix with repeat:persistent — selector matches, is-due skips ===
-	# Mirrors r912 in aidevops-routines/TODO.md (launchd-supervised dashboard).
-	# Verifies both that the selector captures the line AND that is-due treats it
-	# as "not due" with no ERROR output (bug t2175 fix #2).
+	# Case 2: r-prefix with repeat:persistent — selector matches, is-due skips.
+	# Mirrors r912 in aidevops-routines/TODO.md (launchd-supervised daemon).
 	_make_todo "$tmpdir" \
 		"- [x] r912 Dashboard server repeat:persistent ~0s run:server/index.ts"
 	count=$(grep -cE "$SELECTOR" "${tmpdir}/TODO.md" 2>/dev/null; true)
@@ -127,8 +121,7 @@ main() {
 			"count=$count is_due_exit=$is_due_exit output='$is_due_output'"
 	fi
 
-	# === Case 3: r-prefix with cron schedule — selector matches, no parse error ===
-	# Verifies that a standard cron routine still works after the selector tightening.
+	# Case 3: r-prefix with cron schedule — selector matches, no parse error.
 	_make_todo "$tmpdir" \
 		"- [x] r901 Supervisor pulse repeat:cron(*/2 * * * *) ~0s agent:Build+"
 	count=$(grep -cE "$SELECTOR" "${tmpdir}/TODO.md" 2>/dev/null; true)
@@ -141,9 +134,7 @@ main() {
 			"count=$count cron_stderr='$cron_output'"
 	fi
 
-	# === Case 4: Mixed TODO — t-prefix false-match + 2 r-prefix routines ===
-	# The selector must find exactly 2 matches (the r-prefix entries) and exclude
-	# the t-prefix task even though its description contains repeat: and r-IDs.
+	# Case 4: Mixed TODO — selector finds exactly 2 r-prefix entries, excludes t-prefix.
 	_make_todo "$tmpdir" \
 		"- [x] t2160 fix: \`repeat:([^[:space:]]+)\` (r901, r902) ref:GH#19465" \
 		"- [x] r901 Supervisor pulse repeat:cron(*/2 * * * *) ~0s agent:Build+" \
@@ -154,55 +145,58 @@ main() {
 	else
 		fail "Case 4: mixed TODO — 2 r-prefix routines matched" "expected 2 matches, got $count"
 	fi
+	return 0
+}
 
-	# === Case 5 (t2423 Phase C): regex metachars passed directly to schedule helper ===
-	# Verifies that the Phase C guard in _parse_expression catches patterns like
-	# '([^[:space:]]+)`' before they hit the "unrecognised" fallback.
-	# The guard must:
+# _test_metachar_guard: case 5 — Phase C metachar guard (t2423)
+_test_metachar_guard() {
+	# Verifies that _parse_expression catches regex patterns before the generic
+	# "unrecognised schedule expression" fallback. Guard must:
 	#   a) exit 2 (distinct from normal parse error exit 1)
 	#   b) emit "regex metacharacters" in the error message
-	#   c) NOT emit "unrecognised schedule expression" (that would be false noise)
+	#   c) NOT emit "unrecognised schedule expression"
 	local meta_exit meta_stderr
 	meta_stderr=$("$SCHEDULE_HELPER" is-due '([^[:space:]]+)`' '0' 2>&1 >/dev/null)
 	meta_exit=$?
-	if [[ "$meta_exit" -eq 2 ]] && [[ "$meta_stderr" == *"regex metacharacters"* ]] && [[ "$meta_stderr" != *"unrecognised schedule expression"* ]]; then
+	if [[ "$meta_exit" -eq 2 ]] && [[ "$meta_stderr" == *"regex metacharacters"* ]] && \
+		[[ "$meta_stderr" != *"unrecognised schedule expression"* ]]; then
 		pass "Case 5 (t2423 Phase C): metachar guard fires for regex pattern input"
 	else
 		fail "Case 5 (t2423 Phase C): metachar guard fires for regex pattern input" \
 			"exit=$meta_exit stderr='$meta_stderr'"
 	fi
+	return 0
+}
 
-	# === Case 6 (t2423 Phase D): end-to-end discovery produces zero schedule errors ===
-	# Simulates the full pulse-routines discovery path using a TODO.md that contains:
-	#   - A t-prefix task quoting a repeat: regex (the original t2175 false-match trigger)
-	#   - A t2423 task that mentions the regex guard
+# _test_e2e_discovery: case 6 — Phase D end-to-end simulation (t2423)
+_test_e2e_discovery() {
+	local tmpdir="$1"
+	# Simulates the full pulse-routines discovery path. TODO.md contains:
+	#   - t-prefix tasks with repeat: in descriptions (t2175 false-match triggers)
 	#   - Two valid r-prefix routines (cron + persistent)
-	# The simulation pipes each matched line through the same extraction regex used
-	# by pulse-routines.sh and calls routine-schedule-helper.sh is-due for each.
-	# The test passes if zero "unrecognised schedule expression" errors appear on stderr.
+	# All matched lines are piped through the extraction regex from pulse-routines.sh
+	# and sent to routine-schedule-helper.sh is-due. Zero "unrecognised schedule
+	# expression" errors must appear on stderr.
 	_make_todo "$tmpdir" \
 		"- [x] t2160 fix: \`repeat:([^[:space:]]+)\` (r901, r902) ref:GH#19465" \
 		"- [x] t2423 guard: routine-schedule-helper.sh regex metachar guard" \
 		"- [x] r901 Supervisor pulse repeat:cron(*/2 * * * *) ~0s agent:Build+" \
 		"- [x] r912 Dashboard server repeat:persistent ~0s run:server/index.ts"
 
-	# This is the regex used in pulse-routines.sh to extract the repeat: value.
-	# Store in a variable (not inline) so bash doesn't misparse the literal ')'.
+	# Store regex in variable — avoids bash misparsing the literal ')' inline.
 	local re_repeat='repeat:(cron\([^)]*\)|[^[:space:]]+)'
 	local e2e_errors=0
 	local e2e_stderr=""
+	local line repeat_expr _ise_out
 	while IFS= read -r line; do
-		local repeat_expr=""
+		repeat_expr=""
 		if [[ "$line" =~ $re_repeat ]]; then
 			repeat_expr="${BASH_REMATCH[1]}"
 		else
 			continue
 		fi
-		# Skip persistent — pulse-routines.sh skips before calling is-due.
-		if [[ "$repeat_expr" == "persistent" ]]; then
-			continue
-		fi
-		local _ise_out
+		# Skip persistent — pulse-routines.sh short-circuits before calling is-due.
+		if [[ "$repeat_expr" == "persistent" ]]; then continue; fi
 		_ise_out=$("$SCHEDULE_HELPER" is-due "$repeat_expr" "0" 2>&1 >/dev/null)
 		if [[ "$_ise_out" == *"unrecognised schedule expression"* ]]; then
 			e2e_errors=$((e2e_errors + 1))
@@ -216,6 +210,18 @@ main() {
 		fail "Case 6 (t2423 Phase D): full discovery path — zero unrecognised schedule errors" \
 			"got $e2e_errors error(s): $e2e_stderr"
 	fi
+	return 0
+}
+
+main() {
+	local tmpdir
+	tmpdir=$(mktemp -d) || { printf 'FATAL: mktemp failed\n' >&2; exit 1; }
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir'" EXIT
+
+	_test_selector_cases "$tmpdir"
+	_test_metachar_guard
+	_test_e2e_discovery "$tmpdir"
 
 	# === Summary ===
 	printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"

--- a/TODO.md
+++ b/TODO.md
@@ -28,7 +28,7 @@ Compatible with [todo-md](https://github.com/todo-md/todo-md), [todomd](https://
 - [x] r001 Weekly SEO rankings export repeat:weekly(mon@09:00) ~30m run:custom/scripts/seo-export.sh
 - [x] r002 Daily health check repeat:daily(@06:00) ~2m run:custom/scripts/health-check.sh
 - [ ] r003 Monthly content calendar review repeat:monthly(1@09:00) ~15m agent:Content
-- [x] r004 Nightly repo triage repeat:cron(15 2 \* \* \*) ~20m agent:Build+
+- [x] r004 Nightly repo triage repeat:cron(15 2 * * *) ~20m agent:Build+
 - [x] r005 Daily worktree cleanup repeat:daily(@03:00) ~5m run:scripts/worktree-helper.sh clean --auto --force-merged
 - [x] r006 Hourly stub-title issue scanner repeat:cron(15 * * * *) ~2m run:custom/scripts/r-stub-title-scan.sh
 ```


### PR DESCRIPTION
## Summary

Diagnoses and hardens the routine-schedule parser against the `([^[:space:]]+)\`` regex-pattern-as-input regression, and fixes a secondary silent bug in r004.

**Root cause confirmed:** The regex-pattern-as-input errors in `pulse-wrapper.log` were caused by the t2175 false-match bug (t-prefix task descriptions containing `repeat:` text were matched as routines by the old unanchored grep selector). t2175 fixed both the selector and the `persistent` keyword on Apr 18. The historical errors in the log are now absent from all pulse cycles after the fix was deployed.

**What this PR adds:**

### Phase C — defensive input-validation guard (`routine-schedule-helper.sh`)

Added metacharacter detection at the top of `_parse_expression`:
- Detects characters that CANNOT appear in valid schedule expressions: `[`, `]`, `^`, `$`, `\`, `{`, `}`, `+`, `|`, `?`, `.`
- `(` and `)` are intentionally excluded — they appear legitimately in all schedule types (`daily(...)`, `cron(...)`, etc.)
- Emits a distinct error message referencing "regex metacharacters" (not "unrecognised schedule expression") so log scans can distinguish caller bugs from unknown schedule types
- Prints full caller stack trace via `FUNCNAME[]`/`BASH_SOURCE[]`/`BASH_LINENO[]` for immediate diagnosis
- Returns exit 2 (distinct from exit 1 for unknown-but-valid-format expressions)

Also adds a warning when cron fields contain `\*` (backslash-escaped asterisk from Markdown) that won't match as wildcards.

### Phase D — end-to-end discovery test (`test-pulse-routines-selector.sh`)

Extends the existing test file with two new cases:
- **Case 5 (Phase C):** directly passes `([^[:space:]]+)\`` to the schedule helper and asserts exit 2 + "regex metacharacters" error message + no "unrecognised schedule expression"
- **Case 6 (Phase D):** simulates the full `pulse-routines.sh` discovery path with a mixed TODO.md (t-prefix false-match lines + two valid r-prefix routines), asserts zero "unrecognised schedule expression" errors on stderr

### r004 cron expression fix (`TODO.md`)

Fixed r004's cron expression from `cron(15 2 \* \* \*)` to `cron(15 2 * * *)`. The `\*` (Markdown-escaped asterisk) is NOT treated as a wildcard by the cron field matcher — it would cause the routine to never fire (silent failure).

## Testing

```
bash .agents/scripts/tests/test-pulse-routines-selector.sh
→ 6 passed, 0 failed

shellcheck .agents/scripts/routine-schedule-helper.sh \
           .agents/scripts/tests/test-pulse-routines-selector.sh
→ 0 violations
```

## Acceptance verification

- [x] Root cause identified: t2175 false-match (already fixed Apr 18), no new regression
- [x] Phase C metachar guard with caller stack trace in `routine-schedule-helper.sh`
- [x] Phase D end-to-end test covers full discovery path (Cases 5+6)
- [x] Test cross-references t2423 + prior t2160/t2175 fix history
- [x] r004 cron expression corrected (`\*` → `*`)
- [x] `shellcheck` clean on all modified files

Resolves #20029