### PR TITLE
GH#20134: apply Gemini review fixes to legal-research subagent

### DIFF
--- a/.agents/tools/legal/legal-research.md
+++ b/.agents/tools/legal/legal-research.md
@@ -44,7 +44,7 @@ Linear "embed-query → cosine-topK → return" collapses on legal questions bec
 What is the research task?
 ├── Deep Q&A over ONE long document (>50 pages, structured ToC)?
 │     → PageIndex (vectorless, reasoning-over-tree, 98.7% on FinanceBench)
-│     → ~/.aidevops/agents/tools/context/pageindex.md
+│     → ../context/pageindex.md
 │
 ├── Keyword-exhaustive review (term sheet search, named-entity scan)?
 │     → rg/grep over extracted text + SQLite FTS5 for ranked recall
@@ -102,7 +102,7 @@ Legal citations are load-bearing. Apply these rules in every ask-mode response:
 1. **Every assertion traces to a retrieved chunk**. No chunk → no claim. Say "not found" instead of speculating.
 2. **Page/line citations come from chunk metadata, never from the LLM**. The LLM formats, the metadata supplies. Verify post-generation: every `[p.N]` in output must appear in retrieved `page` fields.
 3. **Jurisdiction banners**. Opinions without a `jurisdiction` field are untagged; never rank them as authoritative. Warn the user.
-4. **Currency caveat**. Corpus retrieval returns what was ingested, not what is currently in force. Any "binding" / "precedent" claim requires a live shepardising / KeyCite / CanLII-Connects check — surface this as a follow-up step, not as implicit trust.
+4. **Currency caveat**. Corpus retrieval returns what was ingested, not what is currently in force. Any "binding" / "precedent" claim requires a live Shepardizing / KeyCite / CanLII-Connects check — surface this as a follow-up step, not as implicit trust.
 5. **Pincite discipline**. "See Smith v. Jones, 123 F.3d 456" without the pincite is a drafting smell. The retriever should return the paragraph-level citation; carry it through.
 
 ## When to Scale Beyond File-Based
@@ -123,12 +123,12 @@ See [`tools/database/vector-search.md`](../database/vector-search.md) for the fu
 
 Every operation is CLI/chat-driven; no GUI is required at any step.
 
-1. **Ingest**: `mineru` / `pandoc` for PDFs → chunked text (see `tools/conversion/`, `tools/document/`). OCR first for scanned filings (`tools/ocr/`).
-2. **Index**: `zvec.create_and_open(path=f"/data/matters/{matter_id}/{collection}")` per collection; attach metadata on every chunk.
+1. **Ingest**: [`mineru`](../conversion/mineru.md) / [`pandoc`](../conversion/pandoc.md) for PDFs → chunked text. OCR first for scanned filings ([`tools/ocr/overview.md`](../ocr/overview.md)).
+2. **Index**: `zvec.create_and_open(path=f"~/.aidevops/.agent-workspace/work/{matter_id}/{collection}")` per collection (framework-standard persistent path); attach metadata on every chunk.
 3. **Query**: agent receives natural-language question → decomposes into (collection route, filters, sub-queries) → executes parallel searches → reranks → cites.
 4. **Deliver**: inline answer in chat with `[doc_id, p.N]` citations; full retrieved chunks available on request; export to `todo/research/{matter_id}/{question-slug}.md` for persistent matter notes.
 
-For long-running matters, persist the index to `~/.aidevops/.agent-workspace/work/{matter_id}/` (framework-standard persistent path) and version-control the ingestion manifest in the matter's repo.
+Version-control the ingestion manifest (document list, chunk strategy, embedding model ID) in the matter's repo so re-indexing is reproducible.
 
 ## Gotchas
 


### PR DESCRIPTION
## Summary

Follow-up to #20130 / PR #20131. Applies 4 Gemini Code Assist review findings that landed AFTER the origin:interactive auto-merge (t2411) fired on check-passing. Gemini's review was COMMENTED (non-blocking), so the pulse did not wait for it before merging.

## What

Single-file edit to `.agents/tools/legal/legal-research.md` (+5/-5 lines):

1. **HIGH (line 127)**: `/data/matters/` → `~/.aidevops/.agent-workspace/work/{matter_id}/`. The framework-standard persistent path was already cited as the production location two lines later; the illustrative example now matches, removing the internal contradiction.
2. **MEDIUM (line 47)**: Flowchart reference now uses relative `../context/pageindex.md` instead of hardcoded `~/.aidevops/agents/tools/context/pageindex.md`, matching the convention used in the adjacent Related section.
3. **MEDIUM (line 105)**: `shepardising` → `Shepardizing`. This is a US trademark (Shepard's Citations); the canonical spelling uses 'z' regardless of locale. Matters for a subagent whose whole purpose is citation fidelity.
4. **MEDIUM (line 126)**: Plain-text refs (`mineru`, `pandoc`, `tools/ocr/`) in Chat-First Workflow converted to markdown links targeting actual files. Consistent with the Related section and enables in-editor navigation.

## Why

All 4 findings were valid. The HIGH-priority one fixes a real documentation smell (two different paths cited for the same purpose in adjacent paragraphs). The Shepardizing correction preserves legal-industry terminology precision.

## Testing

- `markdownlint-cli2 .agents/tools/legal/legal-research.md` — 0 errors
- All link targets verified to exist: `../conversion/mineru.md`, `../conversion/pandoc.md`, `../ocr/overview.md`, `../context/pageindex.md`

Resolves #20134


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.85 plugin for [OpenCode](https://opencode.ai) v1.14.19 with claude-opus-4-7 spent 1h 41m and 78,154 tokens on this with the user in an interactive session.