### PR TITLE
GH#20128: install shfmt in CI, re-baseline nesting threshold to 10, add batch mode

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -176,7 +176,11 @@ FUNCTION_COMPLEXITY_THRESHOLD=31
 # after every ratchet-down to 285, triggering an immediate bump back to 290.
 # Fixed (GH#19599): buffer increased to 7 units (283+7=290); proximity guard (warn_at=290-5=285)
 # fires at 286+, safely above current 283 violations. Ratchet-down now stays at 290.
-NESTING_DEPTH_THRESHOLD=290
+# GH#20128: post PR #20124 (GH#20105), scanner rewritten from naive AWK regex to shfmt --to-json
+# AST walker (scanners/nesting-depth.sh). The real whole-codebase count drops from ~283 false
+# positives to 1 REAL violation (verify-brief-helper.sh at depth 10 — genuine debt, refactor
+# tracked separately). Ratcheted down to 10: 1 actual + 9 buffer.
+NESTING_DEPTH_THRESHOLD=10
 
 # File size: files with >1500 lines
 # Current baseline: 53 (as of 2026-03-25, pre-existing on main)

--- a/.agents/scripts/complexity-regression-helper.sh
+++ b/.agents/scripts/complexity-regression-helper.sh
@@ -249,29 +249,51 @@ scan_dir_nesting_depth() {
 		_scanner="nesting-depth.sh"
 	fi
 
-	local _file _rel_file _max_depth
-	while IFS= read -r _file; do
-		[ -n "$_file" ] || continue
-		[ -f "$_file" ] || continue
-		_rel_file="${_file#"${_dir}/"}"
+	# Probe batch-stdin support: empty stdin returns exit 0 on a capable scanner
+	local _has_batch=0
+	if [ -n "$_scanner" ] && "$_scanner" --batch-stdin </dev/null >/dev/null 2>&1; then
+		_has_batch=1
+	fi
 
-		if [ -n "$_scanner" ]; then
-			_max_depth=$("$_scanner" "$_file" 2>/dev/null) || _max_depth=0
-		else
-			# Inline AWK fallback when scanner script is missing
-			_max_depth=$(awk '
-				BEGIN { depth=0; max_depth=0 }
-				/^[[:space:]]*#/ { next }
-				/[[:space:]]*(if|for|while|until|case)[[:space:]]/ { depth++; if(depth>max_depth) max_depth=depth }
-				/[[:space:]]*(fi|done|esac)[[:space:]]*$/ || /^[[:space:]]*(fi|done|esac)$/ { if(depth>0) depth-- }
-				END { print max_depth }
-			' "$_file" 2>/dev/null || echo 0)
-		fi
+	if [ "$_has_batch" = "1" ]; then
+		# Batch mode (GH#20128): pipe all paths at once; scanner uses parallel
+		# background jobs internally, reducing whole-repo scan time ~75s → ~15s.
+		# Output format: <abs-path>\t<depth>
+		local _file _depth _rel_file
+		while IFS=$'\t' read -r _file _depth; do
+			[ -n "$_file" ] || continue
+			[ -f "$_file" ] || continue
+			_rel_file="${_file#"${_dir}/"}"
+			if [ "${_depth:-0}" -gt 8 ] 2>/dev/null; then
+				printf '%s\tNEST\t%s\n' "$_rel_file" "$_depth" >>"$_result_file"
+			fi
+		done < <(printf '%s\n' "$_sh_files" | "$_scanner" --batch-stdin 2>/dev/null)
+	else
+		# Serial fallback: per-file invocation (used when scanner is old or missing)
+		local _file _rel_file _max_depth
+		while IFS= read -r _file; do
+			[ -n "$_file" ] || continue
+			[ -f "$_file" ] || continue
+			_rel_file="${_file#"${_dir}/"}"
 
-		if [ "${_max_depth:-0}" -gt 8 ] 2>/dev/null; then
-			printf '%s\tNEST\t%s\n' "$_rel_file" "$_max_depth" >>"$_result_file"
-		fi
-	done <<<"$_sh_files"
+			if [ -n "$_scanner" ]; then
+				_max_depth=$("$_scanner" "$_file" 2>/dev/null) || _max_depth=0
+			else
+				# Inline AWK fallback when scanner script is missing
+				_max_depth=$(awk '
+					BEGIN { depth=0; max_depth=0 }
+					/^[[:space:]]*#/ { next }
+					/[[:space:]]*(if|for|while|until|case)[[:space:]]/ { depth++; if(depth>max_depth) max_depth=depth }
+					/[[:space:]]*(fi|done|esac)[[:space:]]*$/ || /^[[:space:]]*(fi|done|esac)$/ { if(depth>0) depth-- }
+					END { print max_depth }
+				' "$_file" 2>/dev/null || echo 0)
+			fi
+
+			if [ "${_max_depth:-0}" -gt 8 ] 2>/dev/null; then
+				printf '%s\tNEST\t%s\n' "$_rel_file" "$_max_depth" >>"$_result_file"
+			fi
+		done <<<"$_sh_files"
+	fi
 
 	return 0
 }

--- a/.agents/scripts/scanners/nesting-depth.sh
+++ b/.agents/scripts/scanners/nesting-depth.sh
@@ -16,9 +16,16 @@
 # with a warning on stderr.
 #
 # Usage:
-#   nesting-depth.sh <file>          Print max nesting depth (integer)
-#   nesting-depth.sh --check <file>  Exit 1 if depth > threshold (default 8)
-#   nesting-depth.sh --version       Print version
+#   nesting-depth.sh <file>               Print max nesting depth (integer)
+#   nesting-depth.sh --check <file>       Exit 1 if depth > threshold (default 8)
+#   nesting-depth.sh --batch-stdin        Read newline-separated paths from stdin;
+#                                         output <path>\t<depth> lines in input order
+#   nesting-depth.sh --batch <file>...    Scan listed files; output <path>\t<depth>
+#                                         lines in argument order
+#   nesting-depth.sh --version            Print version
+#
+# Batch modes use parallel background jobs (capped at 8 workers) and preserve
+# input order via per-position tempfiles. Useful for whole-repo scans.
 #
 # Environment:
 #   NESTING_DEPTH_THRESHOLD  Override the --check threshold (default: 8)
@@ -197,6 +204,95 @@ _nd_scan_awk() {
 }
 
 # ---------------------------------------------------------------------------
+# _nd_scan_batch_paths <mode> [<paths...>]
+#
+# Scan multiple files in parallel and emit <path>\t<depth> lines preserving
+# input order. mode=stdin reads newline-separated paths from stdin; mode=args
+# uses the remaining positional arguments.
+#
+# Parallelism: background jobs capped at _ncpu (sysctl hw.ncpu / nproc, max 8).
+# Order preservation: each path is assigned an index; results written to
+# per-index tempfiles and emitted in ascending index order after all jobs finish.
+# ---------------------------------------------------------------------------
+_nd_scan_batch_paths() {
+	local _mode="$1"
+	shift  # remaining args are file paths when mode=args
+
+	# Determine worker count (cap at 8)
+	local _ncpu
+	_ncpu=$(sysctl -n hw.ncpu 2>/dev/null || nproc 2>/dev/null || echo 4)
+	if [ "$_ncpu" -gt 8 ]; then _ncpu=8; fi
+
+	# Temp directory for indexed path/result files
+	local _tmpdir
+	_tmpdir=$(mktemp -d) || { _nd_die "mktemp failed for batch mode"; }
+
+	# Collect paths into numbered temp files (avoids array append for bash 3.2)
+	local _idx=0
+	if [ "$_mode" = "stdin" ]; then
+		while IFS= read -r _p; do
+			[ -n "$_p" ] || continue
+			printf '%s' "$_p" >"$_tmpdir/p.$_idx"
+			_idx=$((_idx + 1))
+		done
+	else
+		for _a in "$@"; do
+			[ -n "$_a" ] || continue
+			printf '%s' "$_a" >"$_tmpdir/p.$_idx"
+			_idx=$((_idx + 1))
+		done
+	fi
+
+	local _total="$_idx"
+
+	if [ "$_total" -eq 0 ]; then
+		rm -rf "$_tmpdir"
+		return 0
+	fi
+
+	# Scan files in parallel: launch background jobs, throttle to _ncpu at a time
+	local _running=0
+	_idx=0
+	while [ "$_idx" -lt "$_total" ]; do
+		local _pfile
+		_pfile=$(cat "$_tmpdir/p.$_idx")
+		local _rfile="$_tmpdir/r.$_idx"
+		(
+			local _d=0
+			if _nd_shfmt_available && _nd_jq_available; then
+				_d=$(_nd_scan_shfmt "$_pfile" 2>/dev/null) || _d=0
+			else
+				_d=$(_nd_scan_awk "$_pfile" 2>/dev/null) || _d=0
+			fi
+			printf '%s' "${_d:-0}" >"$_rfile"
+		) &
+		_running=$((_running + 1))
+		if [ "$_running" -ge "$_ncpu" ]; then
+			wait
+			_running=0
+		fi
+		_idx=$((_idx + 1))
+	done
+	wait  # wait for any remaining background jobs
+
+	# Emit results in input order: <path>\t<depth>
+	_idx=0
+	while [ "$_idx" -lt "$_total" ]; do
+		local _pfile
+		_pfile=$(cat "$_tmpdir/p.$_idx")
+		local _depth=0
+		if [ -f "$_tmpdir/r.$_idx" ]; then
+			_depth=$(cat "$_tmpdir/r.$_idx")
+		fi
+		printf '%s\t%s\n' "$_pfile" "${_depth:-0}"
+		_idx=$((_idx + 1))
+	done
+
+	rm -rf "$_tmpdir"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
 # Main entry point
 # ---------------------------------------------------------------------------
 _nd_main() {
@@ -213,6 +309,15 @@ _nd_main() {
 				_mode="check"
 				_i=$((_i + 1))
 				;;
+			--batch-stdin)
+				_mode="batch-stdin"
+				_i=$((_i + 1))
+				;;
+			--batch)
+				_mode="batch"
+				_i=$((_i + 1))
+				break  # remaining args are file paths
+				;;
 			--version)
 				printf '%s\n' "$_ND_VERSION"
 				return 0
@@ -223,7 +328,7 @@ _nd_main() {
 				_i=$((_i + 1))
 				;;
 			-h | --help)
-				sed -n '5,24p' "$0" | sed 's/^# \{0,1\}//'
+				sed -n '5,32p' "$0" | sed 's/^# \{0,1\}//'
 				return 0
 				;;
 			-*)
@@ -236,6 +341,24 @@ _nd_main() {
 		esac
 	done
 
+	# Batch modes: read paths from stdin or remaining args
+	if [ "$_mode" = "batch-stdin" ]; then
+		_nd_scan_batch_paths stdin
+		return $?
+	fi
+
+	if [ "$_mode" = "batch" ]; then
+		# _i is already past the --batch flag; remaining args are files
+		local _batch_files=()
+		while [ "$_i" -lt "${#_all_args[@]}" ]; do
+			_batch_files+=("${_all_args[$_i]}")
+			_i=$((_i + 1))
+		done
+		_nd_scan_batch_paths args "${_batch_files[@]}"
+		return $?
+	fi
+
+	# Single-file scan (scan or check mode)
 	if [ -z "$_file" ]; then
 		_nd_die "usage: nesting-depth.sh [--check] <file>"
 	fi

--- a/.agents/scripts/tests/test-nesting-depth-scanner.sh
+++ b/.agents/scripts/tests/test-nesting-depth-scanner.sh
@@ -294,6 +294,103 @@ EOF
 	return 0
 }
 
+test_batch_stdin_order_preservation() {
+	printf 'Test: --batch-stdin preserves input order (9,0,1 scrambled)\n'
+
+	# Fixture: depth=0 (empty function body)
+	cat <<'EOF' >"$TMP_DIR/batch_zero.sh"
+#!/bin/bash
+noop() {
+  return 0
+}
+EOF
+
+	# Fixture: depth=1 (single if)
+	cat <<'EOF' >"$TMP_DIR/batch_one.sh"
+#!/bin/bash
+check() {
+  if [ -n "$1" ]; then
+    echo "yes"
+  fi
+  return 0
+}
+EOF
+
+	# Fixture: depth=9 (nine nested ifs — unambiguous for both shfmt and AWK)
+	{
+		printf '#!/bin/bash\n'
+		printf 'd9() {\n'
+		printf '  if true; then\n'
+		printf '    if true; then\n'
+		printf '      if true; then\n'
+		printf '        if true; then\n'
+		printf '          if true; then\n'
+		printf '            if true; then\n'
+		printf '              if true; then\n'
+		printf '                if true; then\n'
+		printf '                  if true; then\n'
+		printf '                    echo "depth9"\n'
+		printf '                  fi\n'
+		printf '                fi\n'
+		printf '              fi\n'
+		printf '            fi\n'
+		printf '          fi\n'
+		printf '        fi\n'
+		printf '      fi\n'
+		printf '    fi\n'
+		printf '  fi\n'
+		printf '  return 0\n'
+		printf '}\n'
+	} >"$TMP_DIR/batch_nine.sh"
+
+	# Input in scrambled order: nine(9), zero(0), one(1)
+	local _output
+	_output=$(printf '%s\n%s\n%s\n' \
+		"$TMP_DIR/batch_nine.sh" \
+		"$TMP_DIR/batch_zero.sh" \
+		"$TMP_DIR/batch_one.sh" \
+		| "$SCANNER" --batch-stdin 2>/dev/null)
+
+	# Extract depths from tab-separated output lines
+	local _d1 _d2 _d3 _p1 _p2 _p3
+	_d1=$(printf '%s\n' "$_output" | awk 'NR==1{print $2}' FS=$'\t')
+	_d2=$(printf '%s\n' "$_output" | awk 'NR==2{print $2}' FS=$'\t')
+	_d3=$(printf '%s\n' "$_output" | awk 'NR==3{print $2}' FS=$'\t')
+	_p1=$(printf '%s\n' "$_output" | awk 'NR==1{print $1}' FS=$'\t')
+	_p2=$(printf '%s\n' "$_output" | awk 'NR==2{print $1}' FS=$'\t')
+	_p3=$(printf '%s\n' "$_output" | awk 'NR==3{print $1}' FS=$'\t')
+
+	# Assert depths in order: 9, 0, 1
+	if [ "${_d1:-}" = "9" ] && [ "${_d2:-}" = "0" ] && [ "${_d3:-}" = "1" ]; then
+		PASS=$((PASS + 1))
+		if [ "$VERBOSE" = "--verbose" ]; then
+			printf '  PASS: batch depths in order (9,0,1)\n'
+		fi
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL: batch depths out of order (expected 9,0,1; got %s,%s,%s)\n' \
+			"${_d1:-?}" "${_d2:-?}" "${_d3:-?}"
+	fi
+
+	# Assert paths in input order: nine, zero, one
+	if [ "${_p1:-}" = "$TMP_DIR/batch_nine.sh" ] && \
+	   [ "${_p2:-}" = "$TMP_DIR/batch_zero.sh" ] && \
+	   [ "${_p3:-}" = "$TMP_DIR/batch_one.sh" ]; then
+		PASS=$((PASS + 1))
+		if [ "$VERBOSE" = "--verbose" ]; then
+			printf '  PASS: batch paths in input order\n'
+		fi
+	else
+		FAIL=$((FAIL + 1))
+		printf '  FAIL: batch paths not in input order\n'
+		printf '    expected: %s / %s / %s\n' \
+			"$TMP_DIR/batch_nine.sh" "$TMP_DIR/batch_zero.sh" "$TMP_DIR/batch_one.sh"
+		printf '    got:      %s / %s / %s\n' \
+			"${_p1:-?}" "${_p2:-?}" "${_p3:-?}"
+	fi
+	return 0
+}
+
 test_headless_runtime_lib() {
 	printf 'Test: headless-runtime-lib.sh — depth <=12 (sanity)\n'
 	local _hrlib
@@ -345,6 +442,7 @@ main() {
 	test_empty_file
 	test_top_level_code
 	test_awk_fallback
+	test_batch_stdin_order_preservation
 	test_headless_runtime_lib
 
 	printf '\n--- Results: %d passed, %d failed ---\n' "$PASS" "$FAIL"

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -410,6 +410,17 @@ jobs:
       run: |
         pip install lizard pyflakes
 
+    - name: Install shfmt (for nesting-depth AST scanner, GH#20105)
+      # scanners/nesting-depth.sh uses `shfmt --to-json` + jq to walk the bash
+      # AST. Without shfmt it falls back to the legacy AWK scanner (which has
+      # the four false-positive classes the GH#20105 rewrite fixed). Ubuntu
+      # 22.04+ ships shfmt in the default apt repos; --to-json is stable since
+      # v3.0.0 so the packaged version is fine.
+      run: |
+        sudo apt-get update -qq
+        sudo apt-get install -y shfmt
+        shfmt --version
+
     - name: Shell function complexity
       # t2159: per-function regression model replaces total-count-vs-threshold.
       # PRs fail only when they introduce NEW violations (set difference B-A),


### PR DESCRIPTION
## Summary

Closes three follow-up gaps in the nesting-depth scanner from PR #20124 (GH#20105).

## Changes

### 1. Install shfmt in CI Complexity Analysis job

Added an `Install shfmt (for nesting-depth AST scanner, GH#20105)` step in `.github/workflows/code-quality.yml` immediately before `Shell function complexity`. This ensures `scanners/nesting-depth.sh` uses the shfmt AST walker rather than falling back to the legacy AWK regex scanner in CI.

### 2. Re-baseline NESTING_DEPTH_THRESHOLD to 10

`.agents/configs/complexity-thresholds.conf` updated: `NESTING_DEPTH_THRESHOLD=290` → `NESTING_DEPTH_THRESHOLD=10` with full history comment. The AST walker drops the whole-codebase violation count from ~283 (AWK false positives) to 1 real violation (verify-brief-helper.sh at depth 10). Threshold is now 1 actual + 9 buffer = 10.

### 3. Parallel batch mode for nesting-depth.sh

`scanners/nesting-depth.sh` gains `--batch-stdin` (paths from stdin) and `--batch <file>...` (paths as args) modes. Both use background-job parallelism (up to 8 workers) with per-position tempfiles to preserve input order. Output format: `<path>\t<depth>` per line.

`complexity-regression-helper.sh:scan_dir_nesting_depth` updated to probe for `--batch-stdin` support and use it when available, falling back to the serial per-file loop for older deployed scanners.

## Files Modified

- EDIT: `.github/workflows/code-quality.yml` — added `Install shfmt` step
- EDIT: `.agents/configs/complexity-thresholds.conf` — `NESTING_DEPTH_THRESHOLD=10` with audit comment
- EDIT: `.agents/scripts/scanners/nesting-depth.sh` — added `_nd_scan_batch_paths()`, `--batch-stdin`, `--batch` modes
- EDIT: `.agents/scripts/complexity-regression-helper.sh` — `scan_dir_nesting_depth` uses batch-stdin when available
- EDIT: `.agents/scripts/tests/test-nesting-depth-scanner.sh` — added `test_batch_stdin_order_preservation` (depths 9,0,1 scrambled; asserts both depth order and path order)

## Verification

All 16 test-nesting-depth-scanner.sh assertions pass locally (including new batch test). ShellCheck zero violations on all modified scripts.

```
Running nesting-depth scanner tests...
...
Test: --batch-stdin preserves input order (9,0,1 scrambled)
  PASS: batch depths in order (9,0,1)
  PASS: batch paths in input order
...
--- Results: 16 passed, 0 failed ---
```

## Complexity Bump Justification

The nesting-depth.sh additions increase file size from 274 to ~400 lines and introduce the `_nd_scan_batch_paths` function. This is intentional complexity for the performance improvement described in GH#20128.

- base=274 lines, head=406 lines, new=132 lines added (all new `_nd_scan_batch_paths` + `_nd_main` batch dispatch)
- New function depth stays within limit (no nesting >8 inside the batch function)
- The size increase is unavoidable for the feature; a further split would over-engineer a <500 line scanner

Resolves #20128