### PR TITLE
t2443: fix(pulse) unwrap preflight_daily_scans so each scanner gets independent timeout budget

### DIFF
--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -1134,44 +1134,10 @@ _preflight_early_dispatch() {
 	return 0
 }
 
-#######################################
-# Daily maintenance scans: complexity scan, CodeRabbit review, post-merge
-# scanner, dedup cleanup, fast-fail prune. All non-fatal — pulse proceeds
-# even if any individual scan fails.
-#######################################
-_preflight_daily_scans() {
-	# Daily complexity scan (GH#5628): creates function-complexity-debt issues
-	# for .sh files with complex functions and .md agent docs exceeding size
-	# threshold. Longest files first. Runs at most once per day.
-	run_stage_with_timeout "complexity_scan" "$PRE_RUN_STAGE_TIMEOUT" run_weekly_complexity_scan || true
-
-	# Daily full codebase review via CodeRabbit (GH#17640): posts a review
-	# trigger on issue #2632 once per 24h. Uses simple timestamp gate.
-	run_stage_with_timeout "coderabbit_review" "$PRE_RUN_STAGE_TIMEOUT" run_daily_codebase_review || true
-
-	# Daily post-merge review scanner (t1993): ingests inline AI bot review
-	# comments from recently merged PRs into review-followup issues.
-	# Time-gated to 24h; scans all pulse-enabled repos via scanner's own dedup.
-	run_stage_with_timeout "post_merge_scanner" "$PRE_RUN_STAGE_TIMEOUT" _run_post_merge_review_scanner || true
-
-	# Daily auto-decomposer scanner (t2442): files worker-ready tier:thinking
-	# issues for parent-task issues whose <!-- parent-needs-decomposition -->
-	# nudge has aged ≥24h without a human response. Closes the parent-task
-	# dispatch black hole — before t2442 the reconciler's nudge was advisory-
-	# only, so a parent-task with no children could sit forever.
-	# Time-gated to 24h; scans only maintainer-role repos; idempotent via
-	# auto-decomposer-scanner.sh's title + source:auto-decomposer dedup.
-	run_stage_with_timeout "auto_decomposer_scanner" "$PRE_RUN_STAGE_TIMEOUT" _run_auto_decomposer_scanner || true
-
-	# Daily dedup cleanup: close duplicate function-complexity-debt issues.
-	# Runs after complexity scan so any new duplicates from this cycle are caught.
-	run_stage_with_timeout "dedup_cleanup" "$PRE_RUN_STAGE_TIMEOUT" run_simplification_dedup_cleanup || true
-
-	# Prune expired fast-fail counter entries (t1888).
-	# Lightweight — just reads and rewrites a small JSON file.
-	fast_fail_prune_expired || true
-	return 0
-}
+# t2443: _preflight_daily_scans() was removed here. Its children (complexity_scan,
+# coderabbit_review, post_merge_scanner, auto_decomposer_scanner, dedup_cleanup,
+# fast_fail_prune_expired) are now promoted to top-level stages in
+# _run_preflight_stages() with independent timeouts. See the call site below.
 
 #######################################
 # Ownership normalization + issue reconciliation stages.
@@ -1271,13 +1237,13 @@ _run_preflight_stages() {
 	# t1425, t1482: Write SETUP sentinel during pre-flight stages.
 	echo "SETUP:$$" >"$PIDFILE"
 
-	# GH#20025 Phase B: Wrap each preflight group in run_stage_with_timeout
-	# so that individual groups that overrun are killed without blocking
-	# the entire pulse cycle. Each group gets its own budget; the total
-	# cannot exceed the cycle window. _preflight_cleanup_and_ledger and
-	# _preflight_daily_scans already wrap their internal stages with
-	# run_stage_with_timeout, but the group function itself can hang on
-	# code between those calls (API calls, JSON parsing, etc.).
+	# GH#20025 Phase B + t2443: Each preflight stage wrapped in
+	# run_stage_with_timeout so overruns are killed without blocking
+	# the entire pulse cycle. Daily scans (complexity, coderabbit,
+	# post-merge, auto-decomposer, dedup, fast-fail prune) were
+	# previously grouped in _preflight_daily_scans() with a shared
+	# budget — t2443 promoted them to independent top-level stages
+	# so one slow scanner cannot starve downstream scanners.
 	local _pflt_timeout="${PREFLIGHT_GROUP_TIMEOUT:-${PRE_RUN_STAGE_TIMEOUT:-600}}"
 
 	run_stage_with_timeout "preflight_cleanup_and_ledger" "$_pflt_timeout" \
@@ -1286,8 +1252,17 @@ _run_preflight_stages() {
 		_preflight_capacity_and_labels || true
 	run_stage_with_timeout "preflight_early_dispatch" "$_pflt_timeout" \
 		_preflight_early_dispatch || true
-	run_stage_with_timeout "preflight_daily_scans" "$_pflt_timeout" \
-		_preflight_daily_scans || true
+	# t2443: Daily scans promoted to independent top-level stages so each
+	# scanner gets its own timeout budget. Previously wrapped in a single
+	# _preflight_daily_scans() group with a shared 600s budget — a slow
+	# complexity_scan (200-340s) would starve downstream scanners
+	# (auto_decomposer, post_merge, dedup) from ever running.
+	run_stage_with_timeout "complexity_scan" "$_pflt_timeout" run_weekly_complexity_scan || true
+	run_stage_with_timeout "coderabbit_review" "$_pflt_timeout" run_daily_codebase_review || true
+	run_stage_with_timeout "post_merge_scanner" "$_pflt_timeout" _run_post_merge_review_scanner || true
+	run_stage_with_timeout "auto_decomposer_scanner" "$_pflt_timeout" _run_auto_decomposer_scanner || true
+	run_stage_with_timeout "dedup_cleanup" "$_pflt_timeout" run_simplification_dedup_cleanup || true
+	fast_fail_prune_expired || true
 	run_stage_with_timeout "preflight_ownership_reconcile" "$_pflt_timeout" \
 		_preflight_ownership_reconcile || true
 	# prefetch_and_scope is the only preflight stage whose failure aborts

--- a/.agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# shellcheck disable=SC2016  # single-quoted regex patterns are literal by design
+#
+# test-pulse-dispatch-engine-stage-wiring.sh — regression guard for t2443
+#
+# Verifies that daily scan stages are registered as independent top-level
+# stages in _run_preflight_stages() with their own run_stage_with_timeout
+# calls, not wrapped in a shared-budget group.
+#
+# Background: _preflight_daily_scans() wrapped 4+ children under a single
+# 600s timeout. A slow complexity_scan (200-340s) would exhaust the budget
+# before auto_decomposer_scanner could run. t2443 promoted each scanner to
+# an independent top-level stage so each gets its own timeout budget.
+
+set -u
+
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+assert_grep() {
+	local label="$1" pattern="$2" file="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if grep -qE "$pattern" "$file" 2>/dev/null; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  expected pattern: $pattern"
+		echo "  in file:          $file"
+	fi
+	return 0
+}
+
+assert_not_grep() {
+	local label="$1" pattern="$2" file="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if ! grep -qE "$pattern" "$file" 2>/dev/null; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  pattern should NOT match: $pattern"
+		echo "  in file:                  $file"
+	fi
+	return 0
+}
+
+# Resolve paths relative to this test file
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENGINE="$SCRIPT_DIR/pulse-dispatch-engine.sh"
+
+echo "=== t2443: pulse-dispatch-engine stage wiring regression tests ==="
+echo "Engine: $ENGINE"
+echo ""
+
+# --- Each daily scanner has its own independent run_stage_with_timeout ---
+
+assert_grep \
+	"1: complexity_scan has independent run_stage_with_timeout" \
+	'run_stage_with_timeout "complexity_scan".*run_weekly_complexity_scan' \
+	"$ENGINE"
+
+assert_grep \
+	"2: coderabbit_review has independent run_stage_with_timeout" \
+	'run_stage_with_timeout "coderabbit_review".*run_daily_codebase_review' \
+	"$ENGINE"
+
+assert_grep \
+	"3: post_merge_scanner has independent run_stage_with_timeout" \
+	'run_stage_with_timeout "post_merge_scanner".*_run_post_merge_review_scanner' \
+	"$ENGINE"
+
+assert_grep \
+	"4: auto_decomposer_scanner has independent run_stage_with_timeout" \
+	'run_stage_with_timeout "auto_decomposer_scanner".*_run_auto_decomposer_scanner' \
+	"$ENGINE"
+
+assert_grep \
+	"5: dedup_cleanup has independent run_stage_with_timeout" \
+	'run_stage_with_timeout "dedup_cleanup".*run_simplification_dedup_cleanup' \
+	"$ENGINE"
+
+assert_grep \
+	"6: fast_fail_prune_expired is called directly (lightweight, no stage timeout needed)" \
+	'fast_fail_prune_expired \|\| true' \
+	"$ENGINE"
+
+# --- The shared-budget wrapper must NOT exist ---
+
+assert_not_grep \
+	"7: _preflight_daily_scans() function wrapper removed (no shared budget)" \
+	'^_preflight_daily_scans\(\)' \
+	"$ENGINE"
+
+assert_not_grep \
+	"8: no run_stage_with_timeout wrapping preflight_daily_scans as a group" \
+	'run_stage_with_timeout "preflight_daily_scans"' \
+	"$ENGINE"
+
+# --- All daily stages use the same timeout variable as peer preflight groups ---
+
+assert_grep \
+	"9: complexity_scan uses _pflt_timeout (same as other preflight groups)" \
+	'run_stage_with_timeout "complexity_scan" "\$_pflt_timeout"' \
+	"$ENGINE"
+
+assert_grep \
+	"10: auto_decomposer_scanner uses _pflt_timeout" \
+	'run_stage_with_timeout "auto_decomposer_scanner" "\$_pflt_timeout"' \
+	"$ENGINE"
+
+# --- Summary ---
+
+echo ""
+echo "=== Results: $TESTS_RUN tests, $TESTS_FAILED failures ==="
+
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Promoted daily scan children from shared-budget `_preflight_daily_scans()` wrapper to independent top-level stages in `_run_preflight_stages()`.

Each scanner now gets its own 600s timeout — one slow scanner can no longer starve downstream scanners (the root cause of `auto_decomposer_scanner` never running under the pulse).

Resolves #20149

## Changes

- **EDIT**: `.agents/scripts/pulse-dispatch-engine.sh` — removed `_preflight_daily_scans()` function, promoted its 6 children (`complexity_scan`, `coderabbit_review`, `post_merge_scanner`, `auto_decomposer_scanner`, `dedup_cleanup`, `fast_fail_prune_expired`) to independent `run_stage_with_timeout` calls in `_run_preflight_stages()`
- **NEW**: `.agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh` — 10 assertions verifying independent stage registration and absence of shared wrapper

## Testing

- All 10 new regression tests pass
- All 27 existing auto-decomposer-scanner tests pass (assertion 12 validates engine wiring)
- ShellCheck clean on both modified files
- Net -25 lines (47 removed, 22 added) — simpler structure

## Verification (post-deploy)

After merge + pulse restart, `~/.aidevops/logs/pulse.log` should show:
- Each scanner appearing as its own `Stage start:` / `Stage complete:` entry
- `auto_decomposer_scanner` completing independently even when `complexity_scan` takes 300s+
- No more `Stage timeout: preflight_daily_scans` entries


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.85 plugin for [OpenCode](https://opencode.ai) v1.14.19 with claude-opus-4-6 spent 8m and 14,858 tokens on this as a headless worker.