### PR TITLE
t2444: Add Files Scope section to brief template for PR scope enforcement

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -81,6 +81,8 @@ Task IDs: `/new-task` or `claim-task-id.sh`. NEVER grep TODO.md for next ID.
 
 - **Task briefs:** Every task must have `todo/tasks/{task_id}-brief.md` (via `/define` or `/new-task`). A task without a brief is undevelopable because it loses the implementation context needed for autonomous execution. See `workflows/plans.md` and `scripts/commands/new-task.md`.
 
+- **`## Files Scope` field:** The brief template includes a `## Files Scope` section where the author declares the file paths (glob patterns supported) that the task is allowed to modify. The scope-guard pre-push hook (`scope-guard-pre-push.sh`) reads this list and blocks pushes that touch files outside the declared scope, preventing accidental scope-leak during rebase or implementation drift. One path or glob per `- ` line.
+
 **Worker-ready issue body heuristic (t2417):** Before creating a full brief, `/define`, `/new-task`, and `task-brief-helper.sh` check whether the linked issue body is already worker-ready — i.e., it contains 4+ of the 7 known heading signals (`## Task`, `## Why`, `## How`, `## Acceptance`, `## What`, `## Session Origin`, `## Files to modify`). When the issue body is worker-ready, the brief file is either skipped (headless default) or replaced with a stub that links to the issue as the canonical brief. This prevents brief/issue body duplication and the collision surface it creates (see GH#20015). Helper: `scripts/brief-readiness-helper.sh`. Threshold override: `BRIEF_READINESS_THRESHOLD` env var.
 
 **Brief composition**: All GitHub-written content (issue bodies, PR descriptions, comments, escalation reports) follows `workflows/brief.md` — the centralised formatting workflow.

--- a/.agents/templates/brief-template.md
+++ b/.agents/templates/brief-template.md
@@ -210,6 +210,16 @@ or "Single-file config edit with exact code block provided -> tier:simple"}
 {Command(s) to confirm the implementation works — e.g., shellcheck, grep, test run}
 ```
 
+## Files Scope
+
+<!-- Declares the file paths this task is allowed to modify.
+     The scope-guard pre-push hook (scope-guard-pre-push.sh) reads this list
+     and blocks pushes that include files outside the declared scope.
+     Glob patterns are supported (e.g. `.agents/hooks/*.sh`).
+     One path or glob pattern per `- ` line. -->
+
+- `{path/to/file-or-glob}`
+
 ## Acceptance Criteria
 
 Each criterion may include an optional `verify:` block (YAML in a fenced code block)


### PR DESCRIPTION
## Summary

Adds a `## Files Scope` section to the task brief template, providing the declarative basis for the scope-guard pre-push hook. Also documents this field in `AGENTS.md`.

## Changes

- **EDIT: `.agents/templates/brief-template.md`** — Added `## Files Scope` section after the `### Verification` subsection (within `## How (Approach)`) and before `## Acceptance Criteria`. The section contains:
  - An HTML comment explaining that `scope-guard-pre-push.sh` reads this list
  - A machine-readable bullet-list format (one path/glob per `- ` line)
  - Glob patterns supported (e.g. `.agents/hooks/*.sh`)

- **EDIT: `.agents/AGENTS.md`** — Added `## Files Scope` field documentation in the "Briefs, Tiers, and Dispatchability" section, explaining the declarative scope enforcement role.

## Verification

```bash
# Section exists in brief template
grep -n "## Files Scope" .agents/templates/brief-template.md

# Machine-readable format present
grep -n "scope-guard-pre-push" .agents/templates/brief-template.md

# AGENTS.md mentions the field
grep -n "Files Scope" .agents/AGENTS.md
```

Resolves #20154