### PR TITLE
GH#20170: improve Files Scope comment in brief template

### DIFF
--- a/.agents/templates/brief-template.md
+++ b/.agents/templates/brief-template.md
@@ -214,8 +214,9 @@ or "Single-file config edit with exact code block provided -> tier:simple"}
 
 <!-- Declares the file paths this task is allowed to modify.
      The scope-guard pre-push hook (scope-guard-pre-push.sh) reads this list
-     and blocks pushes that include files outside the declared scope.
-     Glob patterns are supported (e.g. `.agents/hooks/*.sh`).
+     and blocks pushes that include files outside the declared scope,
+     preventing accidental scope-leak during rebase or implementation drift.
+     Glob patterns are supported (e.g., `.agents/hooks/*.sh`).
      One path or glob pattern per `- ` line. -->
 
 - `{path/to/file-or-glob}`


### PR DESCRIPTION
## Summary

Addresses review bot feedback from PR #20162. Applies Comment 2 (valid improvement); falsifies Comments 1 and 3.

## Triage

**Comment 1** (`.agents/templates/brief-template.md:213`) — **Outcome A: Premise falsified.**
The bot suggested changing `## Files Scope` to `### Files Scope` to nest it inside `## How (Approach)`. However, `.agents/hooks/scope-guard-pre-push.sh:169` uses `grep -q "^## Files Scope"` to detect this section. Changing to `###` would cause the hook to always emit "brief has no '## Files Scope' section — fail-open" and skip scope enforcement. The `##` level is correct and intentional.

**Comment 2** (`.agents/templates/brief-template.md:219`) — **Outcome B: Applied.**
- Added comma after `e.g.` (grammar fix).
- Added technical reason: "preventing accidental scope-leak during rebase or implementation drift" — improving documentation clarity.

**Comment 3** (`.agents/AGENTS.md:84`) — **Outcome A: Premise falsified.**
The bot suggested `- **### Files Scope field:**` — placing `###` inside bold text, which is syntactically invalid Markdown. Additionally, this suggestion was predicated on Comment 1's `###` change, which is rejected. The existing AGENTS.md text is correct.

## Files Changed

- `EDIT: .agents/templates/brief-template.md:215-220` — improved comment inside `## Files Scope` section

## Verification

```bash
markdownlint-cli2 .agents/templates/brief-template.md  # no new violations
grep -q '^## Files Scope' .agents/templates/brief-template.md  # heading level preserved
grep -n 'preventing accidental scope-leak' .agents/templates/brief-template.md  # improvement present
```

Resolves #20170