### PR TITLE
GH#20171: fix: apply gemini review suggestions to t2444 and t2445 briefs

### DIFF
--- a/todo/tasks/t2444-brief.md
+++ b/todo/tasks/t2444-brief.md
@@ -16,7 +16,7 @@ Prerequisite for the scope-guard pre-push hook (t2445). Workers declare intended
 
 ## How
 
-- EDIT: `.agents/templates/brief-template.md` — add `## Files Scope` section after `## Files to Modify`
+- EDIT: `.agents/templates/brief-template.md` — add `## Files Scope` section after `## Files to Modify` (format: markdown list of relative paths, one path or glob per list item); document the format requirement in a `## Critical Rules` callout within the section so the scope-guard parser has a stable, explicit contract
 
 ## Acceptance
 

--- a/todo/tasks/t2445-brief.md
+++ b/todo/tasks/t2445-brief.md
@@ -20,9 +20,9 @@ Prevents silent rebase-introduced scope creep (the root cause of #19808).
 
 ## Acceptance
 
-- Hook blocks out-of-scope files, passes in-scope files
+- Hook blocks out-of-scope files, passes in-scope files, and prevents path traversal (resolved real path must be within repo root)
 - `SCOPE_GUARD_DISABLE=1` bypass works
-- Missing brief = fail-open
+- Missing brief = fail-open; Missing `## Files Scope` section in existing brief = fail-closed
 - `shellcheck` passes
 
 ## Tier


### PR DESCRIPTION
## Summary

Updated t2444-brief.md and t2445-brief.md to address three gemini-code-assist inline review comments from PR #20159: (1) t2444 How section now specifies Files Scope format (markdown list, one path/glob per item) and notes the Critical Rules documentation requirement for the scope-guard parser; (2) t2445 acceptance criteria adds path traversal prevention with real-path confinement to repo root; (3) t2445 acceptance criteria clarifies fail-open for missing brief vs fail-closed for missing scope section in existing brief.

## Files Changed

todo/tasks/t2444-brief.md,todo/tasks/t2445-brief.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** markdownlint-cli2 passes on both files (0 errors)

Resolves #20171


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.85 plugin for [OpenCode](https://opencode.ai) v1.14.19 with claude-sonnet-4-6 spent 1m and 4,421 tokens on this as a headless worker.