### PR TITLE
GH#20172: fix(pulse) wrap fast_fail_prune_expired in run_stage_with_timeout

### DIFF
--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -1262,7 +1262,7 @@ _run_preflight_stages() {
 	run_stage_with_timeout "post_merge_scanner" "$_pflt_timeout" _run_post_merge_review_scanner || true
 	run_stage_with_timeout "auto_decomposer_scanner" "$_pflt_timeout" _run_auto_decomposer_scanner || true
 	run_stage_with_timeout "dedup_cleanup" "$_pflt_timeout" run_simplification_dedup_cleanup || true
-	fast_fail_prune_expired || true
+	run_stage_with_timeout "fast_fail_prune_expired" "$_pflt_timeout" fast_fail_prune_expired || true
 	run_stage_with_timeout "preflight_ownership_reconcile" "$_pflt_timeout" \
 		_preflight_ownership_reconcile || true
 	# prefetch_and_scope is the only preflight stage whose failure aborts

--- a/.agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh
@@ -92,8 +92,8 @@ assert_grep \
 	"$ENGINE"
 
 assert_grep \
-	"6: fast_fail_prune_expired is called directly (lightweight, no stage timeout needed)" \
-	'fast_fail_prune_expired \|\| true' \
+	"6: fast_fail_prune_expired has independent run_stage_with_timeout" \
+	'run_stage_with_timeout "fast_fail_prune_expired".*fast_fail_prune_expired' \
 	"$ENGINE"
 
 # --- The shared-budget wrapper must NOT exist ---


### PR DESCRIPTION
## Summary

Wraps `fast_fail_prune_expired` in `run_stage_with_timeout` for consistency and hang protection, and updates the corresponding test assertion.

## What

- `.agents/scripts/pulse-dispatch-engine.sh`: `fast_fail_prune_expired || true` → `run_stage_with_timeout "fast_fail_prune_expired" "$_pflt_timeout" fast_fail_prune_expired || true`
- `.agents/scripts/tests/test-pulse-dispatch-engine-stage-wiring.sh`: Assertion 6 updated to verify the stage is wrapped in `run_stage_with_timeout` instead of asserting direct call

## Why

After t2443 promoted preflight daily scans to independent top-level stages (PR #20158), `fast_fail_prune_expired` was the only scanner not wrapped in `run_stage_with_timeout`. The omission:
- Leaves it without hang protection (all peer stages have timeout budgets)
- Makes it invisible as a distinct stage in logs
- Contradicts the PR description which stated all daily scans were promoted

The fix was flagged by gemini-code-assist in the review of PR #20158.

## Verification

All 10 assertions in `test-pulse-dispatch-engine-stage-wiring.sh` pass (was 1 failure before).

Resolves #20172