### PR TITLE
GH#20168: fix(brief): replace head-1-devnull with jq-any single-pass in t2449 NMR detection snippet

### DIFF
--- a/todo/tasks/t2449-brief.md
+++ b/todo/tasks/t2449-brief.md
@@ -97,12 +97,20 @@ We need the **cryptographic approval signal** specifically. Detection logic:
 
 ```bash
 # Has the linked issue's NMR ever been cleared, and if so, was it crypto?
-if gh api "repos/$REPO/issues/$ISSUE/comments" \
-    --jq '.[] | select(.body | test("aidevops:approval-signature:")) | .id' | head -1 >/dev/null; then
+# Single API call extracts both flags via jq any() to avoid the head -1 >/dev/null
+# pitfall (head exits 0 on empty input, making the if always-true).
+# strings filter guards against null .body values from the GitHub API.
+read -r has_crypto has_auto < <(gh api "repos/$REPO/issues/$ISSUE/comments" --jq '
+  [
+    (any(.[] | .body | strings; contains("aidevops:approval-signature:"))),
+    (any(.[] | .body | strings; contains("auto-approved-maintainer-issue")))
+  ] | @tsv
+')
+
+if [[ "$has_crypto" == "true" ]]; then
   # Crypto approval comment exists → legitimate clearance
   nmr_gate_pass=true
-elif gh api "repos/$REPO/issues/$ISSUE/comments" \
-    --jq '.[] | select(.body | test("auto-approved-maintainer-issue")) | .id' | head -1 >/dev/null; then
+elif [[ "$has_auto" == "true" ]]; then
   # Auto-approval fired → NOT a legitimate clearance for auto-merge purposes
   nmr_gate_pass=false
 else


### PR DESCRIPTION
## Summary

Fixed a logic bug in todo/tasks/t2449-brief.md:100-111 where the bash snippet used 'head -1 >/dev/null' to detect API output presence. Since head exits 0 even on empty input, both if/elif branches always evaluated to true, meaning nmr_gate_pass was always set to true regardless of whether any approval comment existed. Replaced with a single-pass jq approach using any() with a strings filter, reducing API calls from two to one and correctly detecting comment presence.

## Files Changed

todo/tasks/t2449-brief.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified head returns exit 0 on empty input (confirmed bug). Ran markdownlint-cli2 on the file: 0 errors. The new jq snippet uses any() which returns false for empty arrays, correctly distinguishing 'found match' from 'no match'.

Resolves #20168


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.85 plugin for [OpenCode](https://opencode.ai) v1.14.19 with claude-sonnet-4-6 spent 3m and 3,308 tokens on this as a headless worker.