### PR TITLE
GH#20177: fix(pre-push-hooks): use ref local SHA and dynamic default branch; expose git push stderr

### DIFF
--- a/.agents/hooks/privacy-guard-pre-push.sh
+++ b/.agents/hooks/privacy-guard-pre-push.sh
@@ -109,17 +109,32 @@ while IFS=' ' read -r _lr _ls _rr _rs; do
 	_all_refs+=("$_lr $_ls $_rr $_rs")
 done
 
+# Determine default remote branch once for merge-base fallback (GH#20177).
+# Mirrors the pattern in complexity-regression-pre-push.sh:_compute_baseline.
+# Priority: origin/HEAD (repo-configured) → origin/main → origin/master → HEAD.
+_default_remote_head=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null \
+	| sed 's@^refs/remotes/origin/@origin/@')
+if [[ -z "$_default_remote_head" ]]; then
+	for _candidate in origin/main origin/master; do
+		git rev-parse --verify "$_candidate" >/dev/null 2>&1 \
+			&& { _default_remote_head="$_candidate"; break; }
+	done
+fi
+[[ -z "$_default_remote_head" ]] && _default_remote_head="HEAD"
+
 _watchlist_present=0
 for _ref_entry in "${_all_refs[@]}"; do
 	read -r _lr _ls _rr _rs <<<"$_ref_entry"
 	[[ -z "$_ls" ]] && continue
 	[[ "$_ls" =~ ^0+$ ]] && continue
-	# Determine base for diff: use remote sha when known, merge-base otherwise
+	# Determine base for diff: use remote sha when known, merge-base otherwise.
+	# Use the ref's own local SHA ($_ls) instead of HEAD so multi-ref pushes
+	# compute the correct base for each ref being pushed (GH#20177).
 	_base=""
 	if [[ -n "$_rs" ]] && ! [[ "$_rs" =~ ^0+$ ]]; then
 		_base="$_rs"
 	else
-		_base=$(git merge-base HEAD origin/main 2>/dev/null || echo "")
+		_base=$(git merge-base "$_ls" "$_default_remote_head" 2>/dev/null || echo "")
 	fi
 	[[ -z "$_base" ]] && _watchlist_present=1 && break
 	if git diff --name-only "$_base" "$_ls" 2>/dev/null \

--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -730,11 +730,12 @@ _rebase_and_push() {
 	local _push_args=(-u origin "$branch" --force-with-lease)
 	[[ "$skip_hooks" == "1" ]] && _push_args+=(--no-verify)
 
-	local push_rc=0
+	local push_rc
+	push_rc=0
 	if command -v timeout >/dev/null 2>&1; then
-		timeout "$push_timeout" git push "${_push_args[@]}" 2>/dev/null || push_rc=$?
+		timeout "$push_timeout" git push "${_push_args[@]}" || push_rc=$?
 	else
-		git push "${_push_args[@]}" 2>/dev/null || push_rc=$?
+		git push "${_push_args[@]}" || push_rc=$?
 	fi
 
 	if [[ "$push_rc" -eq 124 ]]; then


### PR DESCRIPTION
## Summary

Address gemini-code-assist review feedback from PR #20142 (GH#20138).

### Fix 1: `.agents/hooks/privacy-guard-pre-push.sh`

**Premise verified:** The merge-base fallback at line 122 used `HEAD` instead of the ref's own local SHA `$_ls`, which produces incorrect results for multi-ref pushes. Additionally, `origin/main` was hardcoded instead of dynamically resolved.

**Changes:**
- Pre-compute the default remote branch once before the watchlist loop using `git symbolic-ref refs/remotes/origin/HEAD`, with `origin/main` → `origin/master` → `HEAD` fallback (mirrors `complexity-regression-pre-push.sh:_compute_baseline` pattern).
- Use `$_ls` (the ref's own local SHA) instead of `HEAD` in the `git merge-base` call so each ref in a multi-ref push gets the correct base.

### Fix 2: `.agents/scripts/full-loop-helper.sh`

**Premise verified:** Both `git push` invocations had `2>/dev/null` suppressing stderr, hiding authentication errors, remote rejections, and pre-push hook diagnostic output from callers.

**Changes:**
- Remove `2>/dev/null` from both `timeout ... git push` and the fallback `git push` call.
- Separate `local push_rc` declaration from its `push_rc=0` assignment for ShellCheck exit-code safety (SC2155 class pattern).

## Verification

- `shellcheck .agents/hooks/privacy-guard-pre-push.sh` — passes ✓
- `shellcheck .agents/scripts/full-loop-helper.sh` — passes ✓

Resolves #20177