### PR TITLE
GH#20174: fix(claim-task-id) — use git -c flags for HTTP timeouts; harden offline commit

### DIFF
--- a/.agents/scripts/claim-task-id.sh
+++ b/.agents/scripts/claim-task-id.sh
@@ -564,14 +564,15 @@ _cas_fetch_and_pin() {
 
 	cd "$repo_path" || return 1
 
-	# GH#20137: set git-native network timeouts to prevent indefinite hangs.
-	# GIT_HTTP_LOW_SPEED_LIMIT=1000 + GIT_HTTP_LOW_SPEED_TIME=CAS_GIT_CMD_TIMEOUT_S
+	# GH#20137: set git-native HTTP timeouts to prevent indefinite hangs.
+	# http.lowSpeedLimit=1000 + http.lowSpeedTime=CAS_GIT_CMD_TIMEOUT_S
 	# tells git to abort if HTTP transfer drops below 1KB/s for N seconds.
 	# These only affect HTTP(S) transport; local/SSH transports don't hang on
 	# network I/O.  index.lock contention is caught by the wall-clock timeout
-	# in allocate_online().
-	if ! GIT_HTTP_LOW_SPEED_LIMIT=1000 GIT_HTTP_LOW_SPEED_TIME="$CAS_GIT_CMD_TIMEOUT_S" \
-		git fetch "$REMOTE_NAME" "$COUNTER_BRANCH" 2>/dev/null; then
+	# in allocate_online().  Pass via -c so git actually reads them (env vars
+	# GIT_HTTP_LOW_SPEED_LIMIT/TIME are not recognised by git).
+	if ! git -c http.lowSpeedLimit=1000 -c http.lowSpeedTime="$CAS_GIT_CMD_TIMEOUT_S" \
+		fetch -q "$REMOTE_NAME" "$COUNTER_BRANCH"; then
 		log_warn "Failed to fetch ${REMOTE_NAME}/${COUNTER_BRANCH}"
 	fi
 
@@ -588,8 +589,8 @@ _cas_fetch_and_pin() {
 		log_info "Counter missing/invalid — attempting auto-bootstrap (GH#6569)"
 		local bootstrap_result
 		bootstrap_result=$(bootstrap_remote_counter "$repo_path") || true
-		GIT_HTTP_LOW_SPEED_LIMIT=1000 GIT_HTTP_LOW_SPEED_TIME="$CAS_GIT_CMD_TIMEOUT_S" \
-			git fetch "$REMOTE_NAME" "$COUNTER_BRANCH" 2>/dev/null || true
+		git -c http.lowSpeedLimit=1000 -c http.lowSpeedTime="$CAS_GIT_CMD_TIMEOUT_S" \
+			fetch -q "$REMOTE_NAME" "$COUNTER_BRANCH" || true
 		pinned_sha=$(git rev-parse "${REMOTE_NAME}/${COUNTER_BRANCH}" 2>/dev/null) || {
 			log_error "BOOTSTRAP_COUNTER_FAILED: cannot resolve ref after bootstrap"
 			return 1
@@ -636,17 +637,18 @@ _cas_build_and_push() {
 
 	# GH#20137: set git-native HTTP timeouts to prevent indefinite hangs on slow
 	# networks.  index.lock contention is caught by the wall-clock timeout in
-	# allocate_online().
-	if ! GIT_HTTP_LOW_SPEED_LIMIT=1000 GIT_HTTP_LOW_SPEED_TIME="$CAS_GIT_CMD_TIMEOUT_S" \
-		git push "$REMOTE_NAME" "${commit_sha}:refs/heads/${COUNTER_BRANCH}" 2>/dev/null; then
+	# allocate_online().  Pass via -c so git actually reads them (env vars
+	# GIT_HTTP_LOW_SPEED_LIMIT/TIME are not recognised by git).
+	if ! git -c http.lowSpeedLimit=1000 -c http.lowSpeedTime="$CAS_GIT_CMD_TIMEOUT_S" \
+		push -q "$REMOTE_NAME" "${commit_sha}:refs/heads/${COUNTER_BRANCH}"; then
 		log_warn "Push failed (conflict — another session claimed an ID)"
-		GIT_HTTP_LOW_SPEED_LIMIT=1000 GIT_HTTP_LOW_SPEED_TIME="$CAS_GIT_CMD_TIMEOUT_S" \
-			git fetch "$REMOTE_NAME" "$COUNTER_BRANCH" 2>/dev/null || true
+		git -c http.lowSpeedLimit=1000 -c http.lowSpeedTime="$CAS_GIT_CMD_TIMEOUT_S" \
+			fetch -q "$REMOTE_NAME" "$COUNTER_BRANCH" || true
 		return 2
 	fi
 
-	GIT_HTTP_LOW_SPEED_LIMIT=1000 GIT_HTTP_LOW_SPEED_TIME="$CAS_GIT_CMD_TIMEOUT_S" \
-		git fetch "$REMOTE_NAME" "$COUNTER_BRANCH" 2>/dev/null || true
+	git -c http.lowSpeedLimit=1000 -c http.lowSpeedTime="$CAS_GIT_CMD_TIMEOUT_S" \
+		fetch -q "$REMOTE_NAME" "$COUNTER_BRANCH" || true
 	return 0
 }
 
@@ -842,9 +844,11 @@ allocate_offline() {
 	echo "$new_counter" >"${repo_path}/${COUNTER_FILE}"
 	(
 		cd "$repo_path" || exit 1
-		git add "$COUNTER_FILE" 2>/dev/null || true
-		git commit -m "chore: offline claim $(printf 't%03d' "$first_id")..$(printf 't%03d' "$last_id") [offline]" \
-			--no-verify 2>/dev/null || true
+		git add "$COUNTER_FILE" || true
+		GIT_AUTHOR_NAME="aidevops" GIT_AUTHOR_EMAIL="aidevops@local" \
+		GIT_COMMITTER_NAME="aidevops" GIT_COMMITTER_EMAIL="aidevops@local" \
+		git commit -q -m "chore: offline claim $(printf 't%03d' "$first_id")..$(printf 't%03d' "$last_id") [offline]" \
+			--no-verify --no-gpg-sign "$COUNTER_FILE" || true
 	)
 
 	log_warn "Allocated $(printf 't%03d' "$first_id") with offset (reconcile when back online)"

--- a/.agents/scripts/tests/test-claim-task-id-wall-timeout.sh
+++ b/.agents/scripts/tests/test-claim-task-id-wall-timeout.sh
@@ -98,7 +98,7 @@ test_timeout_constants_exist() {
 # Test 2: source check — git fetch/push in CAS path wrapped with timeout
 # ---------------------------------------------------------------------------
 test_git_commands_have_timeout() {
-	local name="source check: git fetch/push in CAS path have HTTP timeout env vars"
+	local name="source check: git fetch/push in CAS path have http.lowSpeedTime configuration"
 
 	local fetch_body
 	fetch_body=$(sed -n '/^_cas_fetch_and_pin()/,/^}/p' "$CLAIM_SCRIPT")
@@ -107,8 +107,8 @@ test_git_commands_have_timeout() {
 		return 0
 	fi
 
-	if ! echo "$fetch_body" | grep -q 'GIT_HTTP_LOW_SPEED_TIME'; then
-		fail "$name" "git fetch in _cas_fetch_and_pin missing GIT_HTTP_LOW_SPEED_TIME"
+	if ! echo "$fetch_body" | grep -q 'http.lowSpeedTime'; then
+		fail "$name" "git fetch in _cas_fetch_and_pin missing http.lowSpeedTime configuration"
 		return 0
 	fi
 
@@ -119,8 +119,8 @@ test_git_commands_have_timeout() {
 		return 0
 	fi
 
-	if ! echo "$push_body" | grep -q 'GIT_HTTP_LOW_SPEED_TIME'; then
-		fail "$name" "git push in _cas_build_and_push missing GIT_HTTP_LOW_SPEED_TIME"
+	if ! echo "$push_body" | grep -q 'http.lowSpeedTime'; then
+		fail "$name" "git push in _cas_build_and_push missing http.lowSpeedTime configuration"
 		return 0
 	fi
 


### PR DESCRIPTION
## Summary

GIT_HTTP_LOW_SPEED_LIMIT and GIT_HTTP_LOW_SPEED_TIME are not recognised
by git and are silently ignored. This PR fixes all 5 usages in
`_cas_fetch_and_pin` and `_cas_build_and_push` to use the correct
`git -c http.lowSpeedLimit=N -c http.lowSpeedTime=N` form that git
actually reads.

## Changes

### claim-task-id.sh

- **`_cas_fetch_and_pin`**: Replace env-var-prefixed `git fetch` calls
  with `git -c http.lowSpeedLimit=... -c http.lowSpeedTime=... fetch -q`.
  The `-q` flag suppresses stdout while keeping stderr visible for
  debugging; `2>/dev/null` was hiding errors.

- **`_cas_build_and_push`**: Same fix for the `git push` and the two
  `git fetch` calls (conflict-recovery path and success path).

- **`allocate_offline` offline commit hardening**: Provide a fallback git
  identity via `GIT_AUTHOR_*/GIT_COMMITTER_*` env vars so the commit
  doesn't fail in environments without a configured `user.name`/`user.email`.
  Add `--no-gpg-sign` to prevent GPG failures where no signing key is
  configured. Use `-q` for silence. Restrict the commit to `"$COUNTER_FILE"`
  only to avoid accidentally staging unrelated working-tree changes.

### test-claim-task-id-wall-timeout.sh

- Update `test_git_commands_have_timeout` to assert on `http.lowSpeedTime`
  (the correct git config key) rather than the ineffective env var name
  `GIT_HTTP_LOW_SPEED_TIME`. Test name updated to match.

## Verification

- `bash .agents/scripts/tests/test-claim-task-id-wall-timeout.sh` → 7/7 PASS
- `shellcheck .agents/scripts/claim-task-id.sh` → no violations
- `shellcheck .agents/scripts/tests/test-claim-task-id-wall-timeout.sh` → no violations

Resolves #20174