### PR TITLE
t2548: fix(claim-task-id): append TODO entry after verified issue creation to prevent orphans

### DIFF
--- a/.agents/scripts/backfill-orphan-todos.sh
+++ b/.agents/scripts/backfill-orphan-todos.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# backfill-orphan-todos.sh — one-shot repair tool for the t2548 orphan bug.
+#
+# Scans a repo's GitHub issues for "orphans" — issues whose title starts
+# with `tNNN: ` but whose `tNNN` ID has NO matching entry in TODO.md.
+# These are pre-fix leakage from `claim-task-id.sh` creating issues
+# without writing TODO.md (fixed in t2548 / GH#20180).
+#
+# Behaviour:
+#   list     (default) — print each orphan as `tNNN<TAB>GH#<num><TAB>title`
+#   annotate — append a `- [ ] tNNN <title> ref:GH#<num>` entry to the
+#              `## Backlog` section of TODO.md for every open orphan.
+#              Idempotent: skips IDs already in TODO.md.
+#              WRITES TODO.md in place; run inside a worktree, commit, PR.
+#
+# Scope:
+#   - Open issues only by default. Use `--include-closed` to also
+#     annotate orphans from closed issues (audit-trail completeness).
+#   - Only issues whose title matches `^t[0-9]+: ` are considered orphans.
+#
+# Usage:
+#   backfill-orphan-todos.sh list [--repo-path <path>] [--include-closed]
+#   backfill-orphan-todos.sh annotate [--repo-path <path>] [--include-closed] [--dry-run]
+#
+# Exit codes:
+#   0 — success (or no orphans found)
+#   1 — error (missing gh, no TODO.md, etc.)
+#
+# Cross-references:
+#   - t2548: root-cause fix (claim-task-id.sh::_ensure_todo_entry_written)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+
+# shellcheck source=shared-constants.sh
+if [[ -f "${SCRIPT_DIR}/shared-constants.sh" ]]; then
+	source "${SCRIPT_DIR}/shared-constants.sh"
+fi
+
+# Fallback helpers when shared-constants.sh is unavailable.
+if ! declare -F print_info >/dev/null 2>&1; then
+	print_info() { printf '[INFO] %s\n' "$*" >&2; return 0; }
+fi
+if ! declare -F print_warning >/dev/null 2>&1; then
+	print_warning() { printf '[WARN] %s\n' "$*" >&2; return 0; }
+fi
+if ! declare -F print_error >/dev/null 2>&1; then
+	print_error() { printf '[ERROR] %s\n' "$*" >&2; return 0; }
+fi
+
+usage() {
+	sed -n '7,30p' "$0" | sed 's/^# \{0,1\}//'
+	return 0
+}
+
+COMMAND="list"
+REPO_PATH=""
+INCLUDE_CLOSED=false
+DRY_RUN=false
+
+_parse_args() {
+	local cmd="${1:-list}"
+	COMMAND="$cmd"
+	shift || true
+	while [[ $# -gt 0 ]]; do
+		local flag="$1"; shift
+		case "$flag" in
+		--repo-path)
+			local _rp_val="$1"; shift
+			REPO_PATH="$_rp_val" ;;
+		--include-closed)
+			INCLUDE_CLOSED=true ;;
+		--dry-run)
+			DRY_RUN=true ;;
+		-h|--help)
+			usage; exit 0 ;;
+		*)
+			print_error "unknown flag: $flag"; usage; exit 1 ;;
+		esac
+	done
+	return 0
+}
+_parse_args "$@"
+
+[[ -z "$REPO_PATH" ]] && REPO_PATH="$(pwd)"
+
+if ! command -v gh >/dev/null 2>&1; then
+	print_error "gh CLI not found"; exit 1
+fi
+
+TODO_FILE="${REPO_PATH}/TODO.md"
+if [[ ! -f "$TODO_FILE" ]]; then
+	print_error "no TODO.md at ${REPO_PATH}"; exit 1
+fi
+
+SLUG=$(git -C "$REPO_PATH" remote get-url origin 2>/dev/null \
+	| sed 's|.*github\.com[:/]||;s|\.git$||' || true)
+if [[ -z "$SLUG" ]]; then
+	print_error "could not resolve GitHub slug from origin remote in ${REPO_PATH}"
+	exit 1
+fi
+
+STATE_FILTER="open"
+[[ "$INCLUDE_CLOSED" == "true" ]] && STATE_FILTER="all"
+
+print_info "scanning ${SLUG} (${STATE_FILTER}) for tNNN: orphans..."
+
+ISSUES_JSON=$(gh issue list --repo "$SLUG" --state "$STATE_FILTER" \
+	--search "t in:title" --limit 1000 \
+	--json number,title 2>/dev/null || echo "[]")
+
+CANDIDATES=$(printf '%s' "$ISSUES_JSON" | jq -r '
+	.[]
+	| select(.title | test("^t[0-9]+:"))
+	| [
+		(.title | capture("^(?<id>t[0-9]+):") | .id),
+		(.number | tostring),
+		.title
+	]
+	| @tsv
+' 2>/dev/null || echo "")
+
+if [[ -z "$CANDIDATES" ]]; then
+	print_info "no tNNN-prefixed issues found"; exit 0
+fi
+
+declare -a ORPHANS=()
+
+_find_orphans() {
+	local task_id issue_num title
+	while IFS=$'\t' read -r task_id issue_num title; do
+		[[ -z "$task_id" || -z "$issue_num" ]] && continue
+		if grep -qE "^[[:space:]]*- \[.\] ${task_id}( |$)" "$TODO_FILE"; then
+			continue
+		fi
+		ORPHANS+=("${task_id}"$'\t'"${issue_num}"$'\t'"${title}")
+	done <<<"$CANDIDATES"
+	return 0
+}
+_find_orphans
+
+ORPHAN_COUNT=${#ORPHANS[@]}
+
+if [[ "$ORPHAN_COUNT" -eq 0 ]]; then
+	print_info "no orphans found in ${SLUG}"; exit 0
+fi
+
+_annotate_orphans() {
+	print_info "${ORPHAN_COUNT} orphan(s) to annotate in ${TODO_FILE}"
+	if [[ "$DRY_RUN" == "true" ]]; then
+		print_info "[DRY-RUN] would append:"
+		local row task_id issue_num title desc
+		for row in "${ORPHANS[@]}"; do
+			IFS=$'\t' read -r task_id issue_num title <<<"$row"
+			desc="${title#"${task_id}": }"
+			printf '  - [ ] %s %s ref:GH#%s\n' "$task_id" "$desc" "$issue_num"
+		done
+		return 0
+	fi
+
+	local backlog_start
+	backlog_start=$(grep -nE '^## Backlog[[:space:]]*$' "$TODO_FILE" 2>/dev/null \
+		| head -1 | cut -d: -f1 || true)
+
+	local tmp
+	tmp=$(mktemp)
+	trap 'rm -f "$tmp"' RETURN
+
+	local row task_id issue_num title desc
+	for row in "${ORPHANS[@]}"; do
+		IFS=$'\t' read -r task_id issue_num title <<<"$row"
+		desc="${title#"${task_id}": }"
+		local todo_line="- [ ] ${task_id} ${desc} ref:GH#${issue_num}"
+
+		if [[ -n "$backlog_start" ]]; then
+			local next_heading
+			next_heading=$(awk -v s="$backlog_start" \
+				'NR > s && /^## / {print NR; exit}' "$TODO_FILE" 2>/dev/null || true)
+			if [[ -z "$next_heading" ]]; then
+				cat "$TODO_FILE" >"$tmp"
+				[[ -n "$(tail -c 1 "$tmp")" ]] && printf '\n' >>"$tmp"
+				printf '%s\n' "$todo_line" >>"$tmp"
+			else
+				awk -v nh="$next_heading" -v line="$todo_line" '
+					NR == nh { print line; print "" }
+					{ print }
+				' "$TODO_FILE" >"$tmp"
+			fi
+		else
+			cat "$TODO_FILE" >"$tmp"
+			printf '\n## Backlog (t2548 backfill)\n\n%s\n' "$todo_line" >>"$tmp"
+		fi
+
+		[[ -s "$tmp" ]] && mv "$tmp" "$TODO_FILE"
+		# Recompute backlog_start for the next iteration (file grew).
+		backlog_start=$(grep -nE '^## Backlog' "$TODO_FILE" 2>/dev/null \
+			| head -1 | cut -d: -f1 || true)
+	done
+
+	print_info "annotated ${ORPHAN_COUNT} orphan(s) — review 'git diff' and commit"
+	return 0
+}
+
+case "$COMMAND" in
+list)
+	print_info "${ORPHAN_COUNT} orphan(s) in ${SLUG}:"
+	printf '%s\n' "${ORPHANS[@]}"
+	exit 0
+	;;
+annotate)
+	_annotate_orphans
+	exit 0
+	;;
+*)
+	print_error "unknown command: ${COMMAND}"; usage; exit 1 ;;
+esac

--- a/.agents/scripts/claim-task-id.sh
+++ b/.agents/scripts/claim-task-id.sh
@@ -1207,10 +1207,131 @@ _compose_issue_body() {
 	return 0
 }
 
+# _insert_todo_line FILE LINE
+# Write LINE into FILE at the end of the ## Backlog section (or at EOF).
+# Extracted from _ensure_todo_entry_written to keep function bodies <=100 lines.
+_insert_todo_line() {
+	local todo_file="$1"
+	local todo_line="$2"
+
+	local backlog_start
+	backlog_start=$(grep -nE '^## Backlog[[:space:]]*$' "$todo_file" 2>/dev/null \
+		| head -1 | cut -d: -f1 || true)
+
+	local tmp
+	tmp=$(mktemp)
+	if [[ -n "$backlog_start" ]]; then
+		local next_heading
+		next_heading=$(awk -v s="$backlog_start" \
+			'NR > s && /^## / {print NR; exit}' "$todo_file" 2>/dev/null || true)
+		if [[ -z "$next_heading" ]]; then
+			# Backlog is the last section — insert before trailing blank lines.
+			awk -v line="$todo_line" '
+				{ lines[NR] = $0 }
+				END {
+					last = NR
+					while (last > 0 && lines[last] == "") last--
+					for (i = 1; i <= last; i++) print lines[i]
+					print line
+					for (i = last + 1; i <= NR; i++) print lines[i]
+				}
+			' "$todo_file" >"$tmp"
+		else
+			# Insert just before the next heading.
+			awk -v nh="$next_heading" -v line="$todo_line" '
+				NR == nh { print line; print "" }
+				{ print }
+			' "$todo_file" >"$tmp"
+		fi
+	else
+		# No Backlog section — append at EOF.
+		cat "$todo_file" >"$tmp"
+		printf '\n%s\n' "$todo_line" >>"$tmp"
+	fi
+
+	if [[ -s "$tmp" ]]; then
+		mv "$tmp" "$todo_file"
+	else
+		rm -f "$tmp"
+	fi
+	return 0
+}
+
+# _ensure_todo_entry_written TASK_ID ISSUE_NUM DESCRIPTION LABELS REPO_PATH
+# t2548: Idempotently appends a TODO.md entry after verified GitHub issue
+# creation. Closes the orphan gap where both create_github_issue() paths
+# created issues without writing a corresponding TODO.md line.
+#
+# - If TODO.md already has a matching entry, delegates to add_gh_ref_to_todo
+#   to stamp the ref:GH#NNN if missing (idempotent).
+# - Otherwise appends `- [ ] <task_id> <description> <tags> ref:GH#<num>`
+#   to the `## Backlog` section (falls back to EOF if absent).
+# - Labels with status:, tier:, origin:, dispatched:, implemented: prefixes
+#   are skipped — they are not TODO-file-format tags.
+# Returns 0 always (non-fatal; the issue is already created).
+_ensure_todo_entry_written() {
+	local task_id="$1"
+	local issue_num="$2"
+	local description="$3"
+	local labels="$4"
+	local repo_path="$5"
+
+	local todo_file="${repo_path}/TODO.md"
+	[[ -f "$todo_file" ]] || return 0
+	[[ -n "$task_id" && -n "$issue_num" ]] || return 0
+
+	# Fast path: entry already exists — stamp the ref if missing.
+	if grep -qE "^[[:space:]]*- \[.\] ${task_id}( |$)" "$todo_file"; then
+		if declare -F add_gh_ref_to_todo >/dev/null 2>&1; then
+			add_gh_ref_to_todo "$task_id" "$issue_num" "$todo_file" 2>/dev/null || true
+		fi
+		return 0
+	fi
+
+	# Build tag suffix from labels (skip reserved-prefix labels applied
+	# server-side by issue-sync / pulse, not authored in TODO).
+	local tags_str=""
+	if [[ -n "$labels" ]]; then
+		local _saved_ifs="$IFS"
+		IFS=','
+		local label
+		for label in $labels; do
+			label="${label#"${label%%[![:space:]]*}"}"
+			label="${label%"${label##*[![:space:]]}"}"
+			[[ -z "$label" ]] && continue
+			case "$label" in
+			status:* | tier:* | origin:* | dispatched:* | implemented:* | aidevops:*)
+				continue ;;
+			bug)         tags_str="${tags_str:+${tags_str} }#bug" ;;
+			enhancement) tags_str="${tags_str:+${tags_str} }#feat" ;;
+			*)           tags_str="${tags_str:+${tags_str} }#${label}" ;;
+			esac
+		done
+		IFS="$_saved_ifs"
+	fi
+
+	# Build the TODO line.
+	local safe_desc
+	safe_desc=$(printf '%s' "$description" \
+		| tr '\n\t' '  ' | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')
+	[[ -z "$safe_desc" ]] && safe_desc="(no description)"
+	local todo_line="- [ ] ${task_id} ${safe_desc}"
+	[[ -n "$tags_str" ]] && todo_line="${todo_line} ${tags_str}"
+	todo_line="${todo_line} ref:GH#${issue_num}"
+
+	_insert_todo_line "$todo_file" "$todo_line"
+
+	if declare -F log_info >/dev/null 2>&1; then
+		log_info "t2548: appended TODO entry for ${task_id} (ref:GH#${issue_num})"
+	fi
+	return 0
+}
+
 # Create GitHub issue (post-allocation, non-blocking)
 # t1324: Delegates to issue-sync-helper.sh push when available for rich
 # issue bodies, proper labels (including auto-dispatch), and duplicate
 # detection. Falls back to bare gh issue create if helper not found.
+# t2548: Guarantees TODO.md entry after verified issue creation on both paths.
 create_github_issue() {
 	local title="$1"
 	local description="$2"
@@ -1218,6 +1339,11 @@ create_github_issue() {
 	local repo_path="$4"
 
 	cd "$repo_path" || return 1
+
+	# t2548: extract task_id once — used on both creation paths to write
+	# the TODO.md entry after verified issue creation.
+	local _task_id_for_todo=""
+	[[ "$title" =~ ^(t[0-9]+(\.[0-9]+)*) ]] && _task_id_for_todo="${BASH_REMATCH[1]}"
 
 	# t2442: resolve repo slug once — used both by the delegation path
 	# and the bare-fallback path for the parent-task warn call. Must run
@@ -1232,6 +1358,12 @@ create_github_issue() {
 		_auto_assign_issue "$issue_num" "$repo_path"
 		_interactive_session_auto_claim_new_task "$issue_num" "$repo_path"
 		_lock_maintainer_issue_at_creation "$issue_num" "$repo_path"
+		# t2548: ensure TODO.md has the entry. On the delegation path
+		# issue-sync-helper.sh _push_process_task silently returns SKIPPED
+		# when the task line is absent from TODO.md — issue is created but
+		# TODO never written. This call closes that gap idempotently.
+		_ensure_todo_entry_written \
+			"$_task_id_for_todo" "$issue_num" "$description" "$labels" "$repo_path"
 		# t2442: warn if parent-task label applied but body has no markers.
 		# The delegation path creates the issue via issue-sync-helper.sh
 		# cmd_push which ALREADY fires this warn — so we skip here to
@@ -1318,6 +1450,13 @@ create_github_issue() {
 			fi
 		fi
 	fi
+
+	# t2548: ensure TODO.md has an entry for this task. The bare-fallback
+	# path creates the issue via `gh issue create` directly and never goes
+	# through issue-sync-helper.sh, so _push_process_task never runs and
+	# the TODO entry is never written. This call closes that gap idempotently.
+	_ensure_todo_entry_written \
+		"$_task_id_for_todo" "$issue_num" "$description" "$labels" "$repo_path"
 
 	echo "$issue_num"
 	return 0

--- a/.agents/scripts/tests/test-claim-task-id-no-orphan.sh
+++ b/.agents/scripts/tests/test-claim-task-id-no-orphan.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-claim-task-id-no-orphan.sh — t2548 regression guard.
+#
+# Asserts that `_ensure_todo_entry_written()` in claim-task-id.sh appends a
+# TODO.md entry with ref:GH#NNN after a verified issue creation when the
+# task ID is not yet present in TODO.md.
+#
+# Production failure (t2548):
+#   `claim-task-id.sh --title X --description Y` created a GitHub issue
+#   (via _try_issue_sync_delegation OR the bare `gh issue create` fallback)
+#   but NEVER wrote a TODO.md entry when the task ID wasn't already
+#   registered in TODO.md. `_push_process_task` in issue-sync-helper.sh
+#   silently returns 0 when `target_task` is missing from TODO.md;
+#   `add_gh_ref_to_todo` is a modify-existing-line helper and no-ops.
+#   Evidence: 4/4 orphans from one ILDS session 2026-04-20 (t135-t138).
+#
+# Fix (Option A, t2548): idempotent `_ensure_todo_entry_written` helper
+# called from `create_github_issue` on both the delegation success path
+# and the bare-fallback path.
+#
+# Tests:
+#   1. Missing entry + no Backlog → appended at EOF with ref
+#   2. Missing entry + Backlog section present → appended inside Backlog
+#   3. Entry already present → ref stamped, no duplicate added
+#   4. Empty labels → no tag suffix, still valid line
+#   5. Reserved-prefix labels (status:, tier:, origin:) are skipped
+#   6. `bug` / `enhancement` labels map to `#bug` / `#feat` tags
+#   7. No TODO.md file → silent no-op (non-fatal)
+#   8. Empty task_id or issue_num → silent no-op (non-fatal)
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+CLAIM_SCRIPT="${SCRIPT_DIR}/../claim-task-id.sh"
+
+RED=$'\033[0;31m'
+GREEN=$'\033[0;32m'
+BLUE=$'\033[0;34m'
+NC=$'\033[0m'
+
+PASS=0
+FAIL=0
+ERRORS=""
+
+pass() {
+	local name="$1"
+	printf '%s[PASS]%s %s\n' "$GREEN" "$NC" "$name"
+	PASS=$((PASS + 1))
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local detail="${2:-}"
+	printf '%s[FAIL]%s %s\n' "$RED" "$NC" "$name"
+	[[ -n "$detail" ]] && printf '       %s\n' "$detail"
+	FAIL=$((FAIL + 1))
+	ERRORS="${ERRORS}\n  - ${name}: ${detail}"
+	return 0
+}
+
+# Source claim-task-id.sh to gain access to internal helper functions.
+# The BASH_SOURCE guard in the script prevents main() from running.
+# shellcheck disable=SC1090
+if ! source "$CLAIM_SCRIPT" 2>/dev/null; then
+	printf '%s[FATAL]%s Failed to source %s\n' "$RED" "$NC" "$CLAIM_SCRIPT" >&2
+	exit 1
+fi
+
+if ! declare -F _ensure_todo_entry_written >/dev/null 2>&1; then
+	printf '%s[FATAL]%s _ensure_todo_entry_written not defined after sourcing\n' \
+		"$RED" "$NC" >&2
+	exit 1
+fi
+
+printf '%sRunning _ensure_todo_entry_written tests (t2548)%s\n' "$BLUE" "$NC"
+
+# ---------------------------------------------------------------------------
+# Test 1 — Missing entry + no Backlog section → appended at EOF
+# ---------------------------------------------------------------------------
+test_missing_no_backlog() {
+	local name="1: missing entry + no Backlog → appended at EOF with ref"
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir'" RETURN
+
+	cat >"${tmpdir}/TODO.md" <<'EOF'
+# Project TODO
+
+## Ready
+
+- [ ] t001 pre-existing ref:GH#1
+
+## Done
+
+- [x] t000 historical ref:GH#0
+EOF
+
+	_ensure_todo_entry_written "t2548" "20180" "fix orphan bug" "" "$tmpdir"
+
+	if grep -qE "^- \[ \] t2548 fix orphan bug ref:GH#20180$" "${tmpdir}/TODO.md"; then
+		pass "$name"
+	else
+		fail "$name" "line not found: $(grep 't2548' "${tmpdir}/TODO.md" || echo '(none)')"
+	fi
+	return 0
+}
+test_missing_no_backlog
+
+# ---------------------------------------------------------------------------
+# Test 2 — Missing entry + Backlog section → appended inside Backlog
+# ---------------------------------------------------------------------------
+test_missing_with_backlog() {
+	local name="2: missing entry + Backlog present → appended inside Backlog"
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir'" RETURN
+
+	cat >"${tmpdir}/TODO.md" <<'EOF'
+# Project TODO
+
+## Tasks
+
+- [ ] t001 existing task ref:GH#1
+
+## Backlog
+
+- [ ] t002 backlog item ref:GH#2
+
+## Done
+
+- [x] t000 done ref:GH#0
+EOF
+
+	_ensure_todo_entry_written "t2548" "20180" "fix orphan bug" "" "$tmpdir"
+
+	# Line must exist AND appear between ## Backlog and ## Done
+	local backlog_line done_line new_line
+	backlog_line=$(grep -n '^## Backlog' "${tmpdir}/TODO.md" | cut -d: -f1)
+	done_line=$(grep -n '^## Done' "${tmpdir}/TODO.md" | cut -d: -f1)
+	new_line=$(grep -n 't2548' "${tmpdir}/TODO.md" | cut -d: -f1)
+
+	if [[ -n "$new_line" && -n "$backlog_line" && -n "$done_line" ]] \
+		&& [[ "$new_line" -gt "$backlog_line" ]] \
+		&& [[ "$new_line" -lt "$done_line" ]]; then
+		pass "$name"
+	else
+		fail "$name" "backlog=${backlog_line} done=${done_line} new=${new_line:-absent}"
+	fi
+	return 0
+}
+test_missing_with_backlog
+
+# ---------------------------------------------------------------------------
+# Test 3 — Entry already present → no duplicate line added
+# ---------------------------------------------------------------------------
+test_entry_already_present() {
+	local name="3: entry already present → no duplicate line added"
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir'" RETURN
+
+	cat >"${tmpdir}/TODO.md" <<'EOF'
+# Tasks
+
+- [ ] t2548 fix orphan bug ref:GH#20180
+EOF
+
+	_ensure_todo_entry_written "t2548" "20180" "fix orphan bug" "" "$tmpdir"
+
+	local count
+	count=$(grep -c 't2548' "${tmpdir}/TODO.md" 2>/dev/null || echo 0)
+	if [[ "$count" -eq 1 ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected 1 occurrence, got ${count}"
+	fi
+	return 0
+}
+test_entry_already_present
+
+# ---------------------------------------------------------------------------
+# Test 4 — Empty labels → no tag suffix, valid line
+# ---------------------------------------------------------------------------
+test_empty_labels() {
+	local name="4: empty labels → no tag suffix in appended line"
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir'" RETURN
+
+	printf '# Tasks\n\n' >"${tmpdir}/TODO.md"
+
+	_ensure_todo_entry_written "t2548" "20180" "fix orphan bug" "" "$tmpdir"
+
+	if grep -qE "^- \[ \] t2548 fix orphan bug ref:GH#20180$" "${tmpdir}/TODO.md"; then
+		pass "$name"
+	else
+		fail "$name" "$(grep 't2548' "${tmpdir}/TODO.md" || echo '(none)')"
+	fi
+	return 0
+}
+test_empty_labels
+
+# ---------------------------------------------------------------------------
+# Test 5 — Reserved-prefix labels skipped; plain labels become tags
+# ---------------------------------------------------------------------------
+test_reserved_label_filtering() {
+	local name="5: reserved-prefix labels filtered; plain labels become tags"
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir'" RETURN
+
+	printf '# Tasks\n\n' >"${tmpdir}/TODO.md"
+
+	_ensure_todo_entry_written "t2548" "20180" "fix orphan bug" \
+		"status:queued,tier:standard,origin:worker,auto-dispatch" "$tmpdir"
+
+	if grep -qE "^- \[ \] t2548 fix orphan bug #auto-dispatch ref:GH#20180$" \
+		"${tmpdir}/TODO.md"; then
+		pass "$name"
+	else
+		fail "$name" "$(grep 't2548' "${tmpdir}/TODO.md" || echo '(none)')"
+	fi
+	return 0
+}
+test_reserved_label_filtering
+
+# ---------------------------------------------------------------------------
+# Test 6 — `bug` / `enhancement` labels map to `#bug` / `#feat`
+# ---------------------------------------------------------------------------
+test_label_mapping() {
+	local name="6: bug/enhancement labels map to #bug/#feat"
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir'" RETURN
+
+	printf '# Tasks\n\n' >"${tmpdir}/TODO.md"
+
+	_ensure_todo_entry_written "t2548" "20180" "fix orphan bug" \
+		"bug,enhancement" "$tmpdir"
+
+	if grep -qE "^- \[ \] t2548 fix orphan bug #bug #feat ref:GH#20180$" \
+		"${tmpdir}/TODO.md"; then
+		pass "$name"
+	else
+		fail "$name" "$(grep 't2548' "${tmpdir}/TODO.md" || echo '(none)')"
+	fi
+	return 0
+}
+test_label_mapping
+
+# ---------------------------------------------------------------------------
+# Test 7 — No TODO.md file → silent no-op
+# ---------------------------------------------------------------------------
+test_no_todo_file() {
+	local name="7: no TODO.md → silent no-op (non-fatal)"
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir'" RETURN
+
+	local rc=0
+	_ensure_todo_entry_written "t2548" "20180" "fix orphan bug" "" "$tmpdir" || rc=$?
+	if [[ $rc -eq 0 ]]; then
+		pass "$name"
+	else
+		fail "$name" "returned non-zero: $rc"
+	fi
+	return 0
+}
+test_no_todo_file
+
+# ---------------------------------------------------------------------------
+# Test 8 — Empty task_id or issue_num → silent no-op
+# ---------------------------------------------------------------------------
+test_empty_task_id() {
+	local name="8: empty task_id → silent no-op"
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir'" RETURN
+
+	printf '# Tasks\n\n' >"${tmpdir}/TODO.md"
+
+	local rc=0
+	_ensure_todo_entry_written "" "20180" "fix orphan bug" "" "$tmpdir" || rc=$?
+	local lc
+	lc=$(wc -l <"${tmpdir}/TODO.md")
+	if [[ $rc -eq 0 && "$lc" -le 3 ]]; then
+		pass "$name"
+	else
+		fail "$name" "rc=${rc} lines=${lc}"
+	fi
+	return 0
+}
+test_empty_task_id
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\n'
+printf '%sResults: %d passed, %d failed%s\n' "$BLUE" "$PASS" "$FAIL" "$NC"
+if [[ $FAIL -gt 0 ]]; then
+	printf '%sFailed tests:%s%s\n' "$RED" "$NC" "$ERRORS"
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## What

Fixes the orphan-task-id bug: `claim-task-id.sh` was creating GitHub issues on both paths (delegation via `issue-sync-helper.sh` and the bare `gh issue create` fallback) without ever writing a corresponding TODO.md entry when the task ID was not already present. This left issues on GitHub with no TODO tracking.

## Root Cause

- `issue-sync-helper.sh` `_push_process_task` silently returns 0 with `[WARN] Task <tid> not found in TODO.md` when `target_task` is absent — issue is created but TODO entry never written.
- `add_gh_ref_to_todo` is a modify-existing-line helper only — it cannot create new entries.
- `claim-task-id.sh` had zero TODO.md append logic anywhere in the allocation path.

## Changes

### `.agents/scripts/claim-task-id.sh`

- **`_insert_todo_line`** — idempotent helper that writes a new TODO line at the end of the `## Backlog` section (EOF fallback if absent).
- **`_ensure_todo_entry_written`** — called after verified issue creation on both paths:
  - Fast path (entry already present): delegates to `add_gh_ref_to_todo` to stamp `ref:GH#NNN`.
  - Slow path (entry absent): builds `- [ ] <task_id> <description> <tags> ref:GH#<num>` and calls `_insert_todo_line`. Reserved-prefix labels (`status:`, `tier:`, `origin:`, etc.) are filtered; `bug`/`enhancement` map to `#bug`/`#feat`.
- Extracted `_task_id_for_todo` at top of `create_github_issue` — shared by both branch paths.
- Both the **delegation success branch** and the **bare-fallback branch** now call `_ensure_todo_entry_written`.

### `.agents/scripts/tests/test-claim-task-id-no-orphan.sh` (NEW)

8-assertion regression test covering:
1. Missing entry + no Backlog → appended at EOF
2. Missing entry + Backlog present → appended inside Backlog
3. Entry already present → no duplicate added
4. Empty labels → no tag suffix
5. Reserved-prefix labels filtered; plain labels become tags
6. `bug`/`enhancement` → `#bug`/`#feat`
7. No TODO.md file → silent no-op
8. Empty task_id → silent no-op

All 8 pass. ShellCheck: zero violations.

### `.agents/scripts/backfill-orphan-todos.sh` (NEW)

One-shot repair tool for pre-fix orphans:
- `list` — prints tNNN-prefixed GitHub issues with no TODO entry
- `annotate` — appends entries to TODO.md `## Backlog` (idempotent, supports `--dry-run`)

## Verification

```bash
bash .agents/scripts/tests/test-claim-task-id-no-orphan.sh
# Results: 8 passed, 0 failed

shellcheck .agents/scripts/claim-task-id.sh .agents/scripts/backfill-orphan-todos.sh .agents/scripts/tests/test-claim-task-id-no-orphan.sh
# (no output — zero violations)
```

## New File Smell Justification

The two new files (`backfill-orphan-todos.sh` and `test-claim-task-id-no-orphan.sh`) are purpose-built scripts with clear structure. Any qlty smells are pre-existing patterns from the surrounding framework (e.g. `claim-task-id.sh` sourcing), not new complexity.

Resolves #20180