### PR TITLE
t2660: route operational narration to stderr — fix ANSI pollution of command substitution callers

### DIFF
--- a/.agents/scripts/pre-commit-hook.sh
+++ b/.agents/scripts/pre-commit-hook.sh
@@ -809,36 +809,36 @@ validate_repo_root_files() {
 # Single script, mode selected by HOOK_MODE env var or $(basename "$0").
 
 main_pre_commit() {
-	echo -e "${BLUE}Pre-commit Quality Validation${NC}"
-	echo -e "${BLUE}================================${NC}"
+	echo -e "${BLUE}Pre-commit Quality Validation${NC}" >&2
+	echo -e "${BLUE}================================${NC}" >&2
 
 	# Always run TODO.md validation (even if no shell files changed)
 	validate_duplicate_task_ids || {
 		print_error "Commit rejected: duplicate task IDs"
 		exit 1
 	}
-	echo ""
+	echo "" >&2
 
 	validate_task_counter_monotonic || {
 		print_error "Commit rejected: .task-counter regression"
 		exit 1
 	}
-	echo ""
+	echo "" >&2
 
 	validate_todo_completions || true
-	echo ""
+	echo "" >&2
 
 	validate_parent_subtask_blocking || {
 		print_error "Commit rejected: parent tasks with open subtasks"
 		exit 1
 	}
-	echo ""
+	echo "" >&2
 
 	validate_repo_root_files || {
 		print_error "Commit rejected: new repo root files not in allowlist"
 		exit 1
 	}
-	echo ""
+	echo "" >&2
 
 	# Get modified shell files
 	local modified_files=()
@@ -853,23 +853,23 @@ main_pre_commit() {
 	fi
 
 	print_info "Checking ${#modified_files[@]} modified shell files:"
-	printf '  %s\n' "${modified_files[@]}"
-	echo ""
+	printf '  %s\n' "${modified_files[@]}" >&2
+	echo "" >&2
 
 	local total_violations=0
 
 	# Run local validation checks (fast — no network calls)
 	validate_return_statements "${modified_files[@]}" || ((total_violations += $?))
-	echo ""
+	echo "" >&2
 
 	validate_positional_parameters "${modified_files[@]}" || ((total_violations += $?))
-	echo ""
+	echo "" >&2
 
 	validate_string_literals "${modified_files[@]}" || ((total_violations += $?))
-	echo ""
+	echo "" >&2
 
 	run_shellcheck "${modified_files[@]}" || ((total_violations += $?))
-	echo ""
+	echo "" >&2
 
 	# Final decision
 	if [[ $total_violations -eq 0 ]]; then
@@ -877,13 +877,13 @@ main_pre_commit() {
 		return 0
 	else
 		print_error "Quality violations detected ($total_violations total)"
-		echo ""
+		echo "" >&2
 		print_info "To fix issues automatically, run:"
 		print_info "  ./.agents/scripts/quality-fix.sh"
-		echo ""
+		echo "" >&2
 		print_info "To check current status, run:"
 		print_info "  ./.agents/scripts/linters-local.sh"
-		echo ""
+		echo "" >&2
 		print_info "To bypass this check (not recommended), use:"
 		print_info "  git commit --no-verify"
 
@@ -892,16 +892,16 @@ main_pre_commit() {
 }
 
 main_pre_push() {
-	echo -e "${BLUE}Pre-push Quality Validation${NC}"
-	echo -e "${BLUE}================================${NC}"
+	echo -e "${BLUE}Pre-push Quality Validation${NC}" >&2
+	echo -e "${BLUE}================================${NC}" >&2
 
 	local total_violations=0
 
 	check_secrets || ((total_violations += $?))
-	echo ""
+	echo "" >&2
 
 	check_quality_standards
-	echo ""
+	echo "" >&2
 
 	# Optional CodeRabbit CLI review (if available)
 	if [[ -f ".agents/scripts/coderabbit-cli.sh" ]] && command -v coderabbit &>/dev/null; then
@@ -911,7 +911,7 @@ main_pre_push() {
 		else
 			print_info "CodeRabbit CLI review skipped (setup required)"
 		fi
-		echo ""
+		echo "" >&2
 	fi
 
 	# Final decision
@@ -920,7 +920,7 @@ main_pre_push() {
 		return 0
 	else
 		print_error "Quality violations detected ($total_violations total)"
-		echo ""
+		echo "" >&2
 		print_info "To bypass this check (not recommended), use:"
 		print_info "  git push --no-verify"
 

--- a/.agents/scripts/tests/test-stdout-narration-hygiene.sh
+++ b/.agents/scripts/tests/test-stdout-narration-hygiene.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-stdout-narration-hygiene.sh — GH#20212 regression tests
+#
+# Verifies that "data-returning" functions do not emit ANSI colour codes or
+# banner narration to stdout. Root cause: worktree-helper.sh cmd_clean and
+# pre-commit-hook.sh main_pre_push/main_pre_commit wrote coloured banners to
+# stdout, poisoning callers that used $(…) command substitution.
+#
+# Two concrete failures from GH#20212:
+#   1. pulse-canonical-maintenance.sh:334 — sweep_count=$((sweep_count + removed))
+#      where removed=$(_stale_worktree_sweep_single_repo …) → called
+#      worktree-helper.sh clean --auto → banner "[1mChecking for worktrees..."
+#      leaked into $removed → arithmetic crash.
+#   2. claim-task-id.sh:792 — first_id=$((first_id + i)) where first_id was
+#      captured via $(allocate_online …) → allocate_online ran git push → hook
+#      emitted "${BLUE}Pre-push Quality Validation" to stdout → arithmetic crash.
+#
+# Tests cover:
+#   1. worktree-helper.sh clean --auto: stdout empty
+#   2. worktree-helper.sh clean --auto: no ANSI on stdout
+#   3. worktree-helper.sh clean --auto: arithmetic-safe in $(( ))
+#   4. pre-commit-hook.sh main_pre_push: no ANSI on stdout
+#   5. pre-commit-hook.sh main_pre_commit: no ANSI on stdout
+
+set -u
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="${SCRIPT_DIR_TEST}/.."
+WORKTREE_HELPER="${SCRIPTS_DIR}/worktree-helper.sh"
+PRE_COMMIT_HOOK="${SCRIPTS_DIR}/pre-commit-hook.sh"
+
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_BLUE=$'\033[0;34m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_BLUE="" TEST_NC=""
+fi
+
+PASS=0
+FAIL=0
+ERRORS=""
+
+pass() {
+	local name="${1:-}"
+	printf '  %sPASS%s %s\n' "$TEST_GREEN" "$TEST_NC" "$name"
+	PASS=$((PASS + 1))
+	return 0
+}
+
+fail() {
+	local name="${1:-}"
+	local detail="${2:-}"
+	printf '  %sFAIL%s %s\n' "$TEST_RED" "$TEST_NC" "$name"
+	[[ -n "$detail" ]] && printf '       %s\n' "$detail"
+	FAIL=$((FAIL + 1))
+	ERRORS="${ERRORS}\n  - ${name}: ${detail}"
+	return 0
+}
+
+# Returns 0 (true) if $1 contains an ANSI ESC sequence (\033[).
+# Uses bash pattern matching — portable, no grep -P required.
+_contains_ansi() {
+	local str="$1"
+	[[ "$str" == *$'\033'* ]]
+	return $?
+}
+
+TMP=$(mktemp -d -t "narration-hygiene.XXXXXX") || exit 1
+trap 'rm -rf "$TMP"' EXIT
+
+# Create a minimal git repo in $1 with one empty commit.
+_setup_git_repo() {
+	local dir="$1"
+	git -C "$dir" init -q 2>/dev/null
+	git -C "$dir" config user.email "test@test.invalid" 2>/dev/null
+	git -C "$dir" config user.name "Test" 2>/dev/null
+	git -C "$dir" commit --allow-empty -m "init" -q 2>/dev/null
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: worktree-helper.sh clean --auto produces empty stdout
+# ---------------------------------------------------------------------------
+test_worktree_clean_auto_stdout_empty() {
+	local name="worktree-helper.sh clean --auto: stdout is empty (no narration leaked)"
+	local repo="${TMP}/repo-t1"
+	mkdir -p "$repo"
+	_setup_git_repo "$repo"
+
+	local captured_stdout
+	captured_stdout=$(cd "$repo" && bash "$WORKTREE_HELPER" clean --auto 2>/dev/null)
+
+	if [[ -n "$captured_stdout" ]]; then
+		fail "$name" "expected empty stdout, got: $(printf '%q' "$captured_stdout")"
+	else
+		pass "$name"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: worktree-helper.sh clean --auto stdout contains no ANSI codes
+# (Covers the case where a plain-text message might slip through even if
+# the empty-stdout check above relaxes in future.)
+# ---------------------------------------------------------------------------
+test_worktree_clean_auto_no_ansi_stdout() {
+	local name="worktree-helper.sh clean --auto: no ANSI escape codes on stdout"
+	local repo="${TMP}/repo-t2"
+	mkdir -p "$repo"
+	_setup_git_repo "$repo"
+
+	local captured_stdout
+	captured_stdout=$(cd "$repo" && bash "$WORKTREE_HELPER" clean --auto 2>/dev/null)
+
+	if _contains_ansi "$captured_stdout"; then
+		fail "$name" "stdout contains ANSI: $(printf '%q' "$captured_stdout")"
+	else
+		pass "$name"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: worktree-helper.sh clean --auto stdout is arithmetic-safe
+# Reproduces the exact pattern from pulse-canonical-maintenance.sh:
+#   removed=$(_stale_worktree_sweep_single_repo …)
+#   sweep_count=$((sweep_count + removed))
+# ---------------------------------------------------------------------------
+test_worktree_clean_auto_arithmetic_safe() {
+	local name="worktree-helper.sh clean --auto: captured stdout is arithmetic-safe in \$(( ))"
+	local repo="${TMP}/repo-t3"
+	mkdir -p "$repo"
+	_setup_git_repo "$repo"
+
+	local captured_stdout
+	captured_stdout=$(cd "$repo" && bash "$WORKTREE_HELPER" clean --auto 2>/dev/null)
+
+	# Simulate: sweep_count=$((0 + captured_stdout))
+	local arith_result=0
+	if ! arith_result=$(( 0 + ${captured_stdout:-0} )) 2>/dev/null; then
+		fail "$name" "arithmetic failed with captured stdout: $(printf '%q' "$captured_stdout")"
+	else
+		pass "$name"
+		# arith_result is intentionally unused — we only test that arithmetic doesn't crash
+		: "$arith_result"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: pre-commit-hook.sh main_pre_push stdout has no ANSI codes
+# Sources the hook in a subshell and stubs out the check_* functions so the
+# test is fast and doesn't require git state. Verifies the banner that was
+# previously at line 895-896 goes to stderr, not stdout.
+# ---------------------------------------------------------------------------
+test_pre_push_banner_no_ansi_stdout() {
+	local name="pre-commit-hook.sh main_pre_push: banner written to stderr, not stdout"
+
+	# Run in a subshell to isolate the hook's set -euo pipefail
+	local captured_stdout
+	captured_stdout=$(
+		# shellcheck disable=SC1090
+		source "$PRE_COMMIT_HOOK" 2>/dev/null || exit 1
+		# Stub expensive checks to no-ops for speed
+		check_secrets() { return 0; }
+		check_quality_standards() { return 0; }
+		main_pre_push 2>/dev/null
+	)
+
+	if _contains_ansi "$captured_stdout"; then
+		fail "$name" "stdout contains ANSI: $(printf '%q' "$captured_stdout")"
+	else
+		pass "$name"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 5: pre-commit-hook.sh main_pre_commit stdout has no ANSI codes
+# Tests the "no shell files modified" early-exit path (most common).
+# ---------------------------------------------------------------------------
+test_pre_commit_banner_no_ansi_stdout() {
+	local name="pre-commit-hook.sh main_pre_commit: banner written to stderr, not stdout"
+
+	local captured_stdout
+	captured_stdout=$(
+		# shellcheck disable=SC1090
+		source "$PRE_COMMIT_HOOK" 2>/dev/null || exit 1
+		# Stub all validators so the function exits early via the
+		# "no shell files modified" path.
+		validate_duplicate_task_ids() { return 0; }
+		validate_task_counter_monotonic() { return 0; }
+		validate_todo_completions() { return 0; }
+		validate_parent_subtask_blocking() { return 0; }
+		validate_repo_root_files() { return 0; }
+		# Return empty output → ${#modified_files[@]} == 0 → early return
+		get_modified_shell_files() { printf ''; return 0; }
+		main_pre_commit 2>/dev/null
+	)
+
+	if _contains_ansi "$captured_stdout"; then
+		fail "$name" "stdout contains ANSI: $(printf '%q' "$captured_stdout")"
+	else
+		pass "$name"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+	printf '%stest-stdout-narration-hygiene.sh — GH#20212 regression%s\n' \
+		"$TEST_BLUE" "$TEST_NC"
+	printf '==========================================================\n\n'
+
+	test_worktree_clean_auto_stdout_empty
+	test_worktree_clean_auto_no_ansi_stdout
+	test_worktree_clean_auto_arithmetic_safe
+	test_pre_push_banner_no_ansi_stdout
+	test_pre_commit_banner_no_ansi_stdout
+
+	printf '\n'
+	printf 'Results: %d passed, %d failed\n' "$PASS" "$FAIL"
+	if [[ "$FAIL" -gt 0 ]]; then
+		printf '\nFailed tests:%b\n' "$ERRORS"
+		return 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/worktree-helper.sh
+++ b/.agents/scripts/worktree-helper.sh
@@ -1442,9 +1442,9 @@ _clean_scan_merged() {
 				merge_type=$(_clean_classify_worktree "$worktree_path" "$worktree_branch" "$default_br" "$remote_unknown" "$merged_prs" "$open_prs" "$force_merged" "$closed_prs")
 				if [[ -n "$merge_type" ]]; then
 					found_any=true
-					echo -e "  ${YELLOW}$worktree_branch${NC} ($merge_type)"
-					echo "    $worktree_path"
-					echo ""
+					echo -e "  ${YELLOW}$worktree_branch${NC} ($merge_type)" >&2
+					echo "    $worktree_path" >&2
+					echo "" >&2
 				fi
 			fi
 			worktree_path=""
@@ -1489,8 +1489,8 @@ _clean_remove_merged() {
 					if worktree_has_changes "$worktree_path" && [[ "$force_merged" == "true" ]]; then
 						use_force=true
 					fi
-					echo -e "${BLUE}Removing $worktree_branch...${NC}"
-					# Clean up heavy reproducible directories first to speed up removal
+				echo -e "${BLUE}Removing $worktree_branch...${NC}" >&2
+				# Clean up heavy reproducible directories first to speed up removal
 					# (node_modules, .next, .turbo can have 100k+ files — rm -rf is faster than trash)
 					rm -rf "$worktree_path/node_modules" 2>/dev/null || true
 					rm -rf "$worktree_path/.next" 2>/dev/null || true
@@ -1511,9 +1511,9 @@ _clean_remove_merged() {
 							removed=true
 						fi
 					fi
-					if [[ "$removed" != "true" ]]; then
-						echo -e "${RED}Failed to remove $worktree_branch - may have uncommitted changes${NC}"
-					else
+				if [[ "$removed" != "true" ]]; then
+					echo -e "${RED}Failed to remove $worktree_branch - may have uncommitted changes${NC}" >&2
+				else
 						# Unregister ownership (t189)
 						unregister_worktree "$worktree_path"
 						# Localdev integration (t1224.8): auto-remove branch route
@@ -1611,8 +1611,8 @@ cmd_clean() {
 		return 1
 	fi
 
-	echo -e "${BOLD}Checking for worktrees with merged branches...${NC}"
-	echo ""
+	echo -e "${BOLD}Checking for worktrees with merged branches...${NC}" >&2
+	echo "" >&2
 
 	local default_branch
 	default_branch=$(get_default_branch)
@@ -1637,7 +1637,7 @@ cmd_clean() {
 
 	# First pass: scan and display merged worktrees
 	if ! _clean_scan_merged "$default_branch" "$main_worktree_path" "$remote_state_unknown" "$merged_pr_branches" "$open_pr_branches" "$force_merged" "$closed_pr_branches"; then
-		echo -e "${GREEN}No merged worktrees to clean up${NC}"
+		echo -e "${GREEN}No merged worktrees to clean up${NC}" >&2
 		return 0
 	fi
 
@@ -1645,17 +1645,17 @@ cmd_clean() {
 	if [[ "$auto_mode" == "true" ]]; then
 		response="y"
 	else
-		echo ""
-		echo -e "${YELLOW}Remove these worktrees? [y/N]${NC}"
+		echo "" >&2
+		echo -e "${YELLOW}Remove these worktrees? [y/N]${NC}" >&2
 		read -r response
 	fi
 
 	if [[ "$response" =~ ^[Yy]$ ]]; then
 		# Second pass: remove merged worktrees
 		_clean_remove_merged "$default_branch" "$main_worktree_path" "$remote_state_unknown" "$merged_pr_branches" "$open_pr_branches" "$force_merged" "$closed_pr_branches"
-		echo -e "${GREEN}Cleanup complete${NC}"
+		echo -e "${GREEN}Cleanup complete${NC}" >&2
 	else
-		echo "Cancelled"
+		echo "Cancelled" >&2
 	fi
 
 	return 0


### PR DESCRIPTION
## Summary

Fixes the systemic ANSI colour code pollution of command substitution callers caused by worktree-helper.sh and pre-commit-hook.sh writing operational banners to stdout instead of stderr.

## Root Cause (GH#20212)

Two concrete arithmetic crashes in one session:

1. pulse-canonical-maintenance.sh:334 — sweep_count=$((sweep_count + removed)) where removed captured worktree-helper.sh clean --auto output. The ANSI-coloured banner leaked into $removed, crashing arithmetic with 'operand expected'.

2. claim-task-id.sh:792 — first_id=$((first_id + i)) where first_id was captured via $(allocate_online ...). Inside allocate_online, git push triggered the pre-push hook, which emitted the Pre-push Quality Validation banner to stdout. All 30 CAS retry attempts failed with arithmetic errors — CAS_EXHAUSTED — offline +100 fallback — counter drift to t2660 (real counter ~t2460).

## Changes

**worktree-helper.sh**: cmd_clean banner/blank lines/status/prompts, _clean_scan_merged display lines, _clean_remove_merged progress/error messages — all redirected to stderr with >&2.

**pre-commit-hook.sh**: main_pre_push banner (lines 895-896) and blank echo calls, main_pre_commit banner (lines 812-813) and blank echo calls, printf file list — all redirected to stderr.

Convention: print_info/print_warning in shared-constants.sh already route to stderr. This PR applies the same convention to the remaining raw echo -e color calls. Data payload stays on stdout; narration goes to stderr. Interactive TTY users see identical output.

**New regression test**: .agents/scripts/tests/test-stdout-narration-hygiene.sh — 5 assertions:
- worktree-helper.sh clean --auto stdout is empty
- worktree-helper.sh clean --auto stdout has no ANSI codes
- clean --auto stdout is arithmetic-safe in $(( ))
- main_pre_push stdout has no ANSI codes
- main_pre_commit stdout has no ANSI codes

All 5 pass. Shellcheck clean on all 3 modified files.

## Related

- t2559 / PR #20209: per-caller bandaid in pulse-canonical-maintenance.sh — this PR fixes the root cause so no new callers hit the same bug.

Resolves #20212


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.86 plugin for [OpenCode](https://opencode.ai) v1.14.19 with claude-opus-4-7 spent 5m and 21,500 tokens on this as a headless worker.