### PR TITLE
t2572: fix gh api --slurp --jq anti-pattern causing duplicate parent-decomposition nudge comments

### DIFF
--- a/.agents/scripts/issue-sync-lib.sh
+++ b/.agents/scripts/issue-sync-lib.sh
@@ -752,13 +752,11 @@ _post_parent_task_no_markers_warning() {
 	# failure: fall through to post a potentially-duplicate comment
 	# rather than silently dropping the warning.
 	local existing=""
-	# --paginate + --slurp: comments API caps at 30/page; without this the
-	# marker dedup check would return zero for parents with >30 comments,
-	# causing duplicate warnings. --slurp makes jq receive the pages as an
-	# array-of-arrays which the double-iteration [.[] | .[] | ...] flattens.
-	existing=$(gh api --paginate "repos/${slug}/issues/${issue_num}/comments" --slurp \
-		--jq "[.[] | .[] | select(.body | contains(\"${marker}\"))] | length" \
-		2>/dev/null) || existing=""
+	# t2572: comments API caps at 30/page; --paginate concatenates. Cannot
+	# combine --slurp with --jq (gh api rejects). Stream per-page and count.
+	existing=$(gh api --paginate "repos/${slug}/issues/${issue_num}/comments" \
+		--jq ".[] | select(.body | contains(\"${marker}\")) | .id" \
+		2>/dev/null | wc -l | tr -d ' ') || existing=""
 	if [[ "$existing" =~ ^[1-9][0-9]*$ ]]; then
 		return 1
 	fi

--- a/.agents/scripts/pulse-issue-reconcile.sh
+++ b/.agents/scripts/pulse-issue-reconcile.sh
@@ -1124,22 +1124,25 @@ _post_parent_decomposition_nudge() {
 	local max_nudge_count="${MAX_PARENT_NUDGE_COUNT:-3}"
 
 	# Idempotency check: skip if marker already present in any comment.
-	# --paginate + --slurp ensures we read the FULL comment history; without
-	# it the default page size is 30 and the marker may be missed on long-
-	# running parents, causing duplicate comments. --slurp makes jq receive
-	# the page array stream as a single array-of-arrays which we flatten.
 	#
-	# GH#20219: changed from fail-open to fail-CLOSED. The original design
-	# fell through to posting on API failure ("better than missing the nudge").
-	# In practice, transient API errors caused EVERY pulse cycle from EVERY
-	# runner to post a new nudge — 19+ comments in 6h on #20161. The nudge
-	# is advisory (not safety-critical), so missing one cycle is harmless;
-	# posting 19 duplicates is not.
+	# t2572 + GH#20219: the original --slurp+--jq query was rejected by `gh
+	# api` ("the --slurp option is not supported with --jq or --template"),
+	# silently returning empty and defeating the dedup check — every pulse
+	# cycle posted a fresh nudge (23 on #20001, 19+ on #20161, 4 on
+	# awardsapp#2546 from two runners in minutes).
+	#
+	# Fix (t2572): streaming --paginate + --jq (no --slurp). Per-page jq
+	# emits matching .id values; wc -l counts across all pages.
+	#
+	# Defence-in-depth (GH#20219): fail-CLOSED on API error (skip the cycle
+	# rather than post) + MAX_PARENT_NUDGE_COUNT cap bounds total nudges
+	# even if the dedup query somehow returns 0 on a populated thread. The
+	# nudge is advisory, not safety-critical; missing a cycle is harmless,
+	# duplicating is not.
 	local existing=""
 	existing=$(gh api --paginate "repos/${slug}/issues/${parent_num}/comments" \
-		--slurp \
-		--jq "[.[] | .[] | select(.body | contains(\"${marker}\"))] | length" \
-		2>/dev/null) || existing=""
+		--jq ".[] | select(.body | contains(\"${marker}\")) | .id" \
+		2>/dev/null | wc -l | tr -d ' ') || existing=""
 
 	# Fail-closed: if we cannot determine the count, skip this cycle.
 	if [[ ! "$existing" =~ ^[0-9]+$ ]]; then
@@ -1219,15 +1222,14 @@ _compute_parent_nudge_age_hours() {
 
 	[[ -n "$slug" && "$parent_num" =~ ^[0-9]+$ ]] || return 0
 
-	# --paginate + --slurp: same rationale as the idempotency checks above.
-	# The nudge marker may live on page 2+ for long-running parents; without
-	# pagination the age check would always return empty for them and the
-	# 7-day escalation gate would never fire.
+	# t2572: streaming pattern — --paginate + --jq (no --slurp, which `gh api`
+	# rejects). Per-page jq emits matching .created_at values; `head -n1`
+	# yields the first match across all pages (chronological order = oldest,
+	# which is what the 7-day escalation gate wants).
 	local nudge_created_at
 	nudge_created_at=$(gh api --paginate "repos/${slug}/issues/${parent_num}/comments" \
-		--slurp \
-		--jq '[.[] | .[] | select(.body | contains("<!-- parent-needs-decomposition -->")) | .created_at] | first // ""' \
-		2>/dev/null) || nudge_created_at=""
+		--jq '.[] | select(.body | contains("<!-- parent-needs-decomposition -->")) | .created_at' \
+		2>/dev/null | head -n1) || nudge_created_at=""
 	[[ -n "$nudge_created_at" ]] || return 0
 
 	# Convert ISO-8601 to epoch. macOS `date` needs -j -f; GNU `date` uses -d.
@@ -1287,12 +1289,14 @@ _post_parent_decomposition_escalation() {
 	# Escalation is rarer than nudging but the same TOCTOU race applies in
 	# multi-runner fleets. Fail-closed: if we cannot determine the count,
 	# skip this cycle (escalation is advisory, not safety-critical).
+	#
+	# t2572: streaming --paginate + --jq (no --slurp — gh api rejects the
+	# combination). See _post_parent_decomposition_nudge for the full story.
 	local max_escalation_count="${MAX_PARENT_ESCALATION_COUNT:-2}"
 	local existing=""
 	existing=$(gh api --paginate "repos/${slug}/issues/${parent_num}/comments" \
-		--slurp \
-		--jq "[.[] | .[] | select(.body | contains(\"${marker}\"))] | length" \
-		2>/dev/null) || existing=""
+		--jq ".[] | select(.body | contains(\"${marker}\")) | .id" \
+		2>/dev/null | wc -l | tr -d ' ') || existing=""
 	if [[ ! "$existing" =~ ^[0-9]+$ ]]; then
 		echo "[pulse-wrapper] Escalation dedup: API/jq failure for #${parent_num} in ${slug} — skipping (fail-closed, GH#20219)" >>"$LOGFILE"
 		return 1

--- a/.agents/scripts/tests/test-parent-decomposition-nudge-dedup.sh
+++ b/.agents/scripts/tests/test-parent-decomposition-nudge-dedup.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# shellcheck disable=SC2016  # single-quoted regex patterns are literal by design
+#
+# test-parent-decomposition-nudge-dedup.sh — regression test for t2572 (GH#20240)
+#
+# The parent-decomposition nudge dedup check was silently broken since
+# introduction: `gh api --paginate ... --slurp --jq "..."` is REJECTED by
+# `gh api` with "the --slurp option is not supported with --jq or --template".
+# The error was swallowed by `2>/dev/null`, `existing=""` never matched the
+# `^[1-9]` regex, and the "post only once" guarantee was voided — every pulse
+# cycle re-posted a fresh nudge comment.
+#
+# Observed impact: 22 identical nudge comments on a single parent-task issue
+# across ~30h from two pulse runners (aidevops#20001). 4 identical comments
+# on awardsapp#2546 from two runners within minutes.
+#
+# Fix: replace `--slurp --jq` with streaming `--paginate | --jq | wc -l`
+# pattern. --paginate alone concatenates per-page responses; --jq applies
+# per page. Emit one .id per matching comment across all pages and count.
+#
+# Test coverage:
+#   1. No `--slurp` combined with `--jq`/`--template` remains in .agents/
+#      (acceptance criterion from the issue body)
+#   2. _post_parent_decomposition_nudge uses streaming + wc -l pattern
+#   3. _post_parent_decomposition_nudge has no --slurp flag
+#   4. _compute_parent_nudge_age_hours uses streaming + head -n1 pattern
+#   5. _compute_parent_nudge_age_hours has no --slurp flag
+#   6. _post_parent_decomposition_escalation uses streaming + wc -l pattern
+#   7. _post_parent_decomposition_escalation has no --slurp flag
+#   8. _post_parent_task_no_markers_warning (issue-sync-lib.sh) uses streaming
+#   9. _post_parent_task_no_markers_warning has no --slurp flag
+#  10. Idempotency regex unchanged (`^[1-9][0-9]*$`) — 0 and empty fall through
+#  11. t2572 provenance comment present in at least one fixed site
+#
+# Structural grep-based tests; functional end-to-end with a stubbed gh api
+# requires sourcing all pulse-wrapper dependencies which is out of scope for
+# a regression test. The broken-state detection (no --slurp+--jq remains)
+# is the canonical regression signal — if the anti-pattern reappears, this
+# test catches it.
+
+set -u
+
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_BLUE=$'\033[0;34m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_BLUE="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+assert_grep() {
+	local label="$1" pattern="$2" file="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if grep -qE "$pattern" "$file" 2>/dev/null; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  expected pattern: $pattern"
+		echo "  in file:          $file"
+	fi
+	return 0
+}
+
+assert_no_grep() {
+	local label="$1" pattern="$2" file="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if ! grep -qE "$pattern" "$file" 2>/dev/null; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  unexpected pattern found: $pattern"
+		echo "  in file:                  $file"
+		grep -nE "$pattern" "$file" 2>/dev/null | head -5 | sed 's/^/    /'
+	fi
+	return 0
+}
+
+assert_grep_fixed() {
+	local label="$1" pattern="$2" file="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if grep -qF -- "$pattern" "$file" 2>/dev/null; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  expected literal: $pattern"
+		echo "  in file:          $file"
+	fi
+	return 0
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+AGENTS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+RECONCILE="$SCRIPT_DIR/pulse-issue-reconcile.sh"
+SYNC_LIB="$SCRIPT_DIR/issue-sync-lib.sh"
+
+for f in "$RECONCILE" "$SYNC_LIB"; do
+	if [[ ! -f "$f" ]]; then
+		echo "${TEST_RED}FATAL${TEST_NC}: $f not found"
+		exit 1
+	fi
+done
+
+echo "${TEST_BLUE}=== t2572: gh api --slurp+--jq anti-pattern regression tests ===${TEST_NC}"
+echo ""
+
+# --- Acceptance criterion 1: no --slurp+--jq/--template anywhere in .agents/ ---
+# This catches reintroduction of the anti-pattern in any new or modified file.
+# We filter:
+#   - comment lines (prose reference to the bug is fine)
+#   - jq's own --slurpfile flag (unrelated)
+#   - this test file itself (it cites the anti-pattern in prose + regex)
+# and check that no line containing `--slurp` as a bash flag remains.
+TESTS_RUN=$((TESTS_RUN + 1))
+anti_pattern_hits=$(grep -rn -- '--slurp' "$AGENTS_DIR" 2>/dev/null \
+	| grep -vE -- '--slurpfile' \
+	| grep -vE -- '/tests/test-parent-decomposition-nudge-dedup\.sh:' \
+	| grep -vE ':\s*#' \
+	|| true)
+if [[ -z "$anti_pattern_hits" ]]; then
+	echo "${TEST_GREEN}PASS${TEST_NC}: 1: no non-comment gh api --slurp usage in .agents/"
+else
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	echo "${TEST_RED}FAIL${TEST_NC}: 1: found non-comment --slurp usage:"
+	echo "$anti_pattern_hits" | sed 's/^/    /'
+fi
+
+# --- _post_parent_decomposition_nudge (pulse-issue-reconcile.sh:~1127) ---
+
+assert_grep_fixed \
+	"2: nudge helper uses streaming --jq + .id select" \
+	'--jq ".[] | select(.body | contains(\"${marker}\")) | .id"' \
+	"$RECONCILE"
+
+assert_grep_fixed \
+	"3: nudge helper pipes to wc -l | tr -d" \
+	'2>/dev/null | wc -l | tr -d' \
+	"$RECONCILE"
+
+# --- _compute_parent_nudge_age_hours (~1204) ---
+
+assert_grep_fixed \
+	"4: nudge-age helper uses streaming + head -n1" \
+	'| head -n1) || nudge_created_at=""' \
+	"$RECONCILE"
+
+assert_grep_fixed \
+	"5: nudge-age helper selects .created_at without slurp" \
+	"--jq '.[] | select(.body | contains(\"<!-- parent-needs-decomposition -->\")) | .created_at'" \
+	"$RECONCILE"
+
+# --- _post_parent_decomposition_escalation (~1271) ---
+# Counts occurrences of the streaming pattern — expect 2 (nudge + escalation)
+# in pulse-issue-reconcile.sh.
+TESTS_RUN=$((TESTS_RUN + 1))
+streaming_count=$(grep -cF -- '2>/dev/null | wc -l | tr -d' "$RECONCILE" 2>/dev/null || echo 0)
+if [[ "$streaming_count" -ge 2 ]]; then
+	echo "${TEST_GREEN}PASS${TEST_NC}: 6: pulse-issue-reconcile.sh has 2+ streaming-pattern sites (got: $streaming_count)"
+else
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	echo "${TEST_RED}FAIL${TEST_NC}: 6: expected 2+ streaming-pattern sites, got: $streaming_count"
+fi
+
+# --- _post_parent_task_no_markers_warning (issue-sync-lib.sh:~759) ---
+
+assert_grep_fixed \
+	"7: no-markers warning uses streaming --jq + .id select" \
+	'--jq ".[] | select(.body | contains(\"${marker}\")) | .id"' \
+	"$SYNC_LIB"
+
+# Test 8: verify no non-comment --slurp in sync lib.
+TESTS_RUN=$((TESTS_RUN + 1))
+sync_slurp=$(grep -n -- '--slurp' "$SYNC_LIB" 2>/dev/null \
+	| grep -vE ':\s*#' \
+	| grep -vE -- '--slurpfile' \
+	|| true)
+if [[ -z "$sync_slurp" ]]; then
+	echo "${TEST_GREEN}PASS${TEST_NC}: 8: no-markers warning has no non-comment --slurp flag"
+else
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	echo "${TEST_RED}FAIL${TEST_NC}: 8: found non-comment --slurp in issue-sync-lib.sh:"
+	echo "$sync_slurp" | sed 's/^/    /'
+fi
+
+# --- Idempotency regex semantics ---
+# Nudge + escalation sites use fail-closed `^[0-9]+$` (GH#20219): on API
+# failure, skip the cycle rather than post. The no-markers-warning in
+# issue-sync-lib.sh still uses the original `^[1-9][0-9]*$` (fail-open on
+# empty — a one-shot warning is low-cost to duplicate).
+
+assert_grep_fixed \
+	"9: nudge site uses fail-closed regex (GH#20219)" \
+	'[[ ! "$existing" =~ ^[0-9]+$ ]]' \
+	"$RECONCILE"
+
+assert_grep_fixed \
+	"10: no-markers-warning retains original ^[1-9] regex (fail-open)" \
+	'[[ "$existing" =~ ^[1-9][0-9]*$ ]]' \
+	"$SYNC_LIB"
+
+# --- Provenance ---
+
+assert_grep_fixed \
+	"11: t2572 provenance comment present in pulse-issue-reconcile.sh" \
+	't2572:' \
+	"$RECONCILE"
+
+assert_grep_fixed \
+	"12: t2572 provenance comment present in issue-sync-lib.sh" \
+	't2572:' \
+	"$SYNC_LIB"
+
+# --- Summary ---
+
+echo ""
+echo "${TEST_BLUE}=== Results: ${TESTS_RUN} tests, ${TESTS_FAILED} failed ===${TEST_NC}"
+
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## What

Replace the broken `gh api --paginate ... --slurp --jq "..."` pattern with a streaming `gh api --paginate ... --jq "..." | wc -l` (or `| head -n1`) pattern across **4 sites**.

## Why

`gh api` explicitly rejects combining `--slurp` with `--jq` or `--template`:

    the --slurp option is not supported with --jq or --template

The error was swallowed by `2>/dev/null`, so `existing=""` on every invocation. The idempotency regex `^[1-9][0-9]*$` never matched empty, and the dedup check fell through to post a fresh nudge/escalation/warning on every pulse cycle — from every runner.

**Live evidence:**
- **aidevops#20001**: 23 identical `<!-- parent-needs-decomposition -->` comments posted over ~30h from two pulse runners
- **<webapp>#2546**: 4 identical nudges from two runners within minutes
- **#20161**: 19+ comments in 6h (root cause of GH#20219 → PR #20246)

## How

**Query pattern replacement** — per-page streaming, no `--slurp`:

    # Count matches across all pages:
    existing=$(gh api --paginate "repos/.../comments" \
        --jq '.[] | select(.body | contains("MARKER")) | .id' \
        2>/dev/null | wc -l | tr -d ' ') || existing=""

    # First match (oldest) across all pages:
    nudge_created_at=$(gh api --paginate "repos/.../comments" \
        --jq '.[] | select(.body | contains("MARKER")) | .created_at' \
        2>/dev/null | head -n1) || nudge_created_at=""

`--paginate` concatenates per-page responses; `--jq` applies per page. No slurping needed — `wc -l` counts across all pages, `head -n1` takes the first match.

**Sites fixed (4 total):**

1. `pulse-issue-reconcile.sh` → `_post_parent_decomposition_nudge` (t2388 idempotency)
2. `pulse-issue-reconcile.sh` → `_compute_parent_nudge_age_hours` (t2442 escalation age gate)
3. `pulse-issue-reconcile.sh` → `_post_parent_decomposition_escalation` (t2442 idempotency)
4. `issue-sync-lib.sh` → `_post_parent_task_no_markers_warning` (t2442 Fix #2 idempotency)

## Merged with PR #20246

PR #20246 (GH#20219) landed during this work and added:
- Fail-closed semantics on API error (skip the cycle rather than post)
- `MAX_PARENT_NUDGE_COUNT` / `MAX_PARENT_ESCALATION_COUNT` caps as defence-in-depth

#20246 was a **band-aid that worked by accident**: the broken `--slurp+--jq` always returned empty, always failed the new `^[0-9]+$` fail-closed check, so **no nudges ever posted at all**. This PR fixes the underlying query so the dedup actually works, and #20246's caps become the real safety net for corner cases (API drift, pagination edge cases).

The merge resolution keeps #20246's fail-closed + cap logic in the nudge and escalation sites, paired with t2572's working query.

## Testing

**Smoke test against real API** (post-fix, pre-merge):

    $ gh api --paginate "repos/marcusquinn/aidevops/issues/20001/comments" \
        --jq '.[] | select(.body | contains("<!-- parent-needs-decomposition -->")) | .id' \
        2>/dev/null | wc -l | tr -d ' '
    23  # Before fix: always 0 (gh api errored on --slurp+--jq)

**New regression test:** `.agents/scripts/tests/test-parent-decomposition-nudge-dedup.sh` — 12 structural assertions including a cross-repo sweep for any reintroduction of `gh api --slurp` (excluding comments and `jq --slurpfile`).

**Existing tests** (ran post-rebase, all pass):
- `test-parent-decomposition-escalation.sh`: 20/20
- `test-parent-task-application-warn.sh`: 19/19
- `test-pulse-parent-nudge.sh`: 9/11 (tests 3 & 4 are **pre-existing** failures unrelated to this PR — stale patterns expecting `gh api "repos/...` instead of `gh api --paginate "repos/...` and `gh issue comment` instead of the `gh_issue_comment` wrapper; out of scope for t2572)

**Shellcheck**: clean on modified files (pre-existing SC2016 at `issue-sync-lib.sh:1426` is a GraphQL query string, unrelated).

## Acceptance criteria (from issue body)

- [x] `rg -nS -- '--slurp' .agents/ | rg -- '--jq|--template'` returns zero matches (non-comment)
- [x] Regression test present and passing
- [x] Test passes locally
- [ ] No new `<!-- parent-needs-decomposition -->` duplicates on open parents after landing (live verification post-merge + deploy)

## Files Scope

- `.agents/scripts/pulse-issue-reconcile.sh`
- `.agents/scripts/issue-sync-lib.sh`
- `.agents/scripts/tests/test-parent-decomposition-nudge-dedup.sh`

Resolves #20240


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.87 plugin for [OpenCode](https://opencode.ai) v1.14.19 with claude-opus-4-7 spent 16m and 58,708 tokens on this with the user in an interactive session.