### PR TITLE
GH#20228: clarify Files Scope requires repository-root-relative paths with traversal risk warning

### DIFF
--- a/.agents/templates/brief-template.md
+++ b/.agents/templates/brief-template.md
@@ -217,7 +217,20 @@ or "Single-file config edit with exact code block provided -> tier:simple"}
      and blocks pushes that include files outside the declared scope,
      preventing accidental scope-leak during rebase or implementation drift.
      Glob patterns are supported (e.g., `.agents/hooks/*.sh`).
-     One path or glob pattern per `- ` line. -->
+     One path or glob pattern per `- ` line.
+
+     CRITICAL RULES:
+     1. Paths MUST be relative to the repository root (e.g., `.agents/hooks/foo.sh`,
+        NOT `~/Git/aidevops/.agents/hooks/foo.sh` or `./hooks/foo.sh`).
+        Technical reason: scope-guard-pre-push.sh resolves all declared paths against
+        the repository root via `git rev-parse --show-toplevel`. Paths not anchored to
+        the root will silently fail to match — the guard will not fire and unintended
+        files can pass through without review.
+     2. Do NOT use overly-permissive globs (e.g., `**/*` or `*.sh` without a prefix).
+        Overly-broad scope declarations create a path traversal risk: files outside
+        the intended scope may be committed and pushed without triggering a block,
+        undermining the entire guard. Declare the narrowest scope that covers the
+        intended changes. -->
 
 - `{path/to/file-or-glob}`
 

--- a/todo/tasks/t2444-brief.md
+++ b/todo/tasks/t2444-brief.md
@@ -16,7 +16,7 @@ Prerequisite for the scope-guard pre-push hook (t2445). Workers declare intended
 
 ## How
 
-- EDIT: `.agents/templates/brief-template.md` — add `## Files Scope` section after `## Files to Modify` (format: markdown list of relative paths, one path or glob per list item); document the format requirement in a `## Critical Rules` callout within the section so the scope-guard parser has a stable, explicit contract
+- EDIT: `.agents/templates/brief-template.md` — add `## Files Scope` section after `## Files to Modify` (format: markdown list of paths **relative to the repository root**, one path or glob per list item); document the requirement in a `## Critical Rules` callout including: (1) the technical reasoning that the scope-guard parser (`scope-guard-pre-push.sh`) resolves all paths relative to the repository root — paths not anchored to the root will silently fail to match, allowing unintended files to pass the guard; (2) a warning that incorrect or overly-permissive paths create a path traversal risk where files outside the intended scope may be committed and pushed without review
 
 ## Acceptance
 


### PR DESCRIPTION
## Summary

Addresses review feedback from PR #20179 on `todo/tasks/t2444-brief.md:19`.

The gemini reviewer flagged that the Files Scope section documentation was incomplete:
it did not specify that paths must be relative to the repository root, did not explain
the technical reason (scope-guard parser resolution), and did not warn about path
traversal risks from overly-permissive declarations.

## Changes

- **`todo/tasks/t2444-brief.md:19`** — updated How section to specify:
  - Paths must be relative to the repository root
  - Technical reasoning: scope-guard-pre-push.sh resolves paths via `git rev-parse --show-toplevel`
  - Warning: incorrect or overly-permissive paths create path traversal risk

- **`.agents/templates/brief-template.md`** — enhanced `## Files Scope` comment with a `CRITICAL RULES` block:
  1. Paths MUST be relative to the repository root (with positive and negative examples)
  2. Do NOT use overly-permissive globs (path traversal risk explanation)

## Verification

- `markdownlint-cli2 .agents/templates/brief-template.md` — pre-existing errors only (unrelated to this change, count reduced from 12 to 11)
- `markdownlint-cli2 todo/tasks/t2444-brief.md` — clean
- Both files pass pre-commit hooks

Resolves #20228