### PR TITLE
GH#20230: GH#20230: fix _compute_baseline — separate local, add HEAD fallback, propagate exit code

### DIFF
--- a/.agents/hooks/scope-guard-pre-push.sh
+++ b/.agents/hooks/scope-guard-pre-push.sh
@@ -213,15 +213,19 @@ _file_in_scope() {
 # Mirrors the approach in complexity-regression-pre-push.sh (GH#20045).
 # ---------------------------------------------------------------------------
 _compute_baseline() {
-	local _remote="${1:-origin}"
+	local _remote
+	_remote="${1:-origin}"
 	local default_remote_head
 	local baseline
 	default_remote_head=$(git symbolic-ref "refs/remotes/$_remote/HEAD" 2>/dev/null \
 		| sed "s@^refs/remotes/$_remote/@@")
 	if [[ -z "$default_remote_head" ]]; then
-		for candidate in "$_remote/main" "$_remote/master"; do
-			git rev-parse --verify "$candidate" >/dev/null 2>&1 \
-				&& { default_remote_head="$candidate"; break; }
+		local candidate
+		for candidate in "$_remote/main" "$_remote/master" "HEAD"; do
+			if git rev-parse --verify "$candidate" >/dev/null 2>&1; then
+				default_remote_head="$candidate"
+				break
+			fi
 		done
 	fi
 	if [[ -z "$default_remote_head" ]]; then
@@ -237,7 +241,7 @@ _compute_baseline() {
 		baseline="$default_remote_head"
 	fi
 	printf '%s\n' "$baseline"
-	return 0
+	return $rc
 }
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixed three issues in _compute_baseline() per gemini review feedback on PR #20165: (1) separated local _remote declaration from assignment, (2) added 'HEAD' as a third fallback candidate after main/master with an explicit if statement replacing the && pattern, (3) added local candidate declaration, (4) changed hardcoded return 0 to return $rc to propagate the actual exit code.

## Files Changed

.agents/hooks/scope-guard-pre-push.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/hooks/scope-guard-pre-push.sh passes with zero violations. The HIGH-severity mapfile findings were already addressed in PR #20181 (the current code already uses while-read loops). The MEDIUM findings in _compute_baseline are now all addressed.

Resolves #20230


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.87 plugin for [OpenCode](https://opencode.ai) v1.14.19 with claude-sonnet-4-6 spent 2m and 9,297 tokens on this as a headless worker.