### PR TITLE
GH#20225: fix privacy-guard remote name hardcoding and HEAD fallback bypass

### DIFF
--- a/.agents/hooks/privacy-guard-pre-push.sh
+++ b/.agents/hooks/privacy-guard-pre-push.sh
@@ -110,17 +110,25 @@ while IFS=' ' read -r _lr _ls _rr _rs; do
 done
 
 # Determine default remote branch once for merge-base fallback (GH#20177).
-# Mirrors the pattern in complexity-regression-pre-push.sh:_compute_baseline.
-# Priority: origin/HEAD (repo-configured) → origin/main → origin/master → HEAD.
-_default_remote_head=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null \
-	| sed 's@^refs/remotes/origin/@origin/@')
-if [[ -z "$_default_remote_head" ]]; then
-	for _candidate in origin/main origin/master; do
-		git rev-parse --verify "$_candidate" >/dev/null 2>&1 \
-			&& { _default_remote_head="$_candidate"; break; }
-	done
+# Uses the actual remote name (not hardcoded 'origin') to support non-standard
+# remote names (e.g., 'upstream'). Leaves empty when unknown so line 139
+# triggers a full scan — safer than falling back to HEAD, which may produce an
+# empty diff and silently bypass the privacy guard (GH#20225).
+# Priority: remote/HEAD (repo-configured) → remote/main → remote/master.
+_default_remote_head=""
+if [[ -n "$remote_name" ]]; then
+	_default_remote_head=$(git symbolic-ref --short "refs/remotes/${remote_name}/HEAD" 2>/dev/null)
+	if [[ -z "$_default_remote_head" ]]; then
+		for _candidate in "${remote_name}/main" "${remote_name}/master"; do
+			git rev-parse --verify "$_candidate" >/dev/null 2>&1
+			_status=$?
+			if [[ $_status -eq 0 ]]; then
+				_default_remote_head="$_candidate"
+				break
+			fi
+		done
+	fi
 fi
-[[ -z "$_default_remote_head" ]] && _default_remote_head="HEAD"
 
 _watchlist_present=0
 for _ref_entry in "${_all_refs[@]}"; do


### PR DESCRIPTION
## Summary

Fixes the `privacy-guard-pre-push.sh` hook per Gemini review feedback on PR #20189.

**Three bugs fixed:**
1. **Hardcoded `origin`** — `git symbolic-ref refs/remotes/origin/HEAD` and `origin/main`/`origin/master` fail silently when the remote is named anything other than `origin` (e.g., `upstream`).
2. **Unsafe `HEAD` fallback** — falling back to `HEAD` when the remote base is unknown causes `git merge-base "$_ls" HEAD` to return `$_ls` itself (since you're already on that commit), producing an empty diff that silently bypasses the privacy scan.
3. **ShellCheck SC2181** — captured `git rev-parse` exit code in `$_status` variable per reviewer recommendation.

**Fix:** Use `${remote_name}` (from $1) throughout, `git symbolic-ref --short` (eliminates `sed` transform), and leave `_default_remote_head` empty on unknown remote — which correctly triggers the full-scan path at line 147.

## Files Changed

- EDIT: `.agents/hooks/privacy-guard-pre-push.sh:112-131` — replace the remote-base determination block

## Verification

```bash
shellcheck .agents/hooks/privacy-guard-pre-push.sh  # zero violations
```

Resolves #20225


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.87 plugin for [OpenCode](https://opencode.ai) v1.14.19 with claude-sonnet-4-6 spent 2m and 6,120 tokens on this as a headless worker.