### PR TITLE
t2569: add structured audit log for CAS claims

### DIFF
--- a/.agents/scripts/claim-task-id-counter.sh
+++ b/.agents/scripts/claim-task-id-counter.sh
@@ -53,6 +53,38 @@ _format_task_range() {
 	printf 't%03d..t%03d' "$first_num" "$last_num"
 }
 
+# ---------------------------------------------------------------------------
+# Append a structured audit log line for a successful CAS claim.
+# Format: ISO8601 \t pid \t session_id \t tNNN \t attempt \t elapsed_s
+# (tab-separated so later tooling can parse without quoting concerns.)
+# Log file: ~/.aidevops/logs/task-claim.log (created on first append).
+#
+# Phase 3 (t2569 / GH#20001): forensics for CAS-race or reuse incidents.
+# ---------------------------------------------------------------------------
+_append_claim_audit_log() {
+	local first_id="${1:-}"
+	local attempt="${2:-1}"
+	local elapsed="${3:-0}"
+
+	[[ -z "$first_id" ]] && return 0
+
+	local log_dir="${HOME}/.aidevops/logs"
+	local log_file="${log_dir}/task-claim.log"
+
+	mkdir -p "$log_dir" 2>/dev/null || return 0
+
+	local ts pid sid tid
+	ts=$(date -u +'%Y-%m-%dT%H:%M:%SZ' 2>/dev/null)
+	pid="${BASHPID:-$$}"
+	sid="${AIDEVOPS_SESSION_ID:-${Claude_SESSION_ID:-${OPENCODE_SESSION_ID:-unknown}}}"
+	tid=$(printf 't%03d' "$first_id")
+
+	# Tab-separated; single append is atomic on POSIX filesystems for short writes.
+	printf '%s\t%s\t%s\t%s\t%s\t%ss\n' \
+		"$ts" "$pid" "$sid" "$tid" "$attempt" "$elapsed" >> "$log_file" 2>/dev/null || true
+	return 0
+}
+
 # =============================================================================
 # Counter Reads
 # =============================================================================
@@ -455,6 +487,8 @@ allocate_online() {
 		0)
 			# go for it — CAS succeeded on this attempt
 			log_success "Claimed $(printf 't%03d' "$first_id") (attempt ${attempt}, ${elapsed}s)"
+			# Phase 3 (t2569 / GH#20001): structured audit log.
+			_append_claim_audit_log "$first_id" "$attempt" "$elapsed"
 			echo "$first_id"
 			return 0
 			;;


### PR DESCRIPTION
## Summary

Add `_append_claim_audit_log` helper and call site in `allocate_online()`. Appends one TSV line per successful CAS allocation to `~/.aidevops/logs/task-claim.log` with: ISO8601 timestamp, pid, session_id (fallback chain: `AIDEVOPS_SESSION_ID` → `Claude_SESSION_ID` → `OPENCODE_SESSION_ID` → `unknown`), tNNN, attempt count, and elapsed seconds.

## What changed

- **EDIT:** `.agents/scripts/claim-task-id-counter.sh`
  - Added `_append_claim_audit_log()` helper (lines 56-86) — plain POSIX shell, no jq, fail-open on I/O errors
  - Inserted call between `log_success` and `echo "$first_id"` in the CAS success branch of `allocate_online()`

## Note on file location

The issue body targets `.agents/scripts/claim-task-id.sh` — the correct file at time of authoring. Since then, GH#20224 split the CAS allocation functions into `claim-task-id-counter.sh`. The helper and call site were placed in the sub-library where `allocate_online()` now lives.

## Verification

```
shellcheck .agents/scripts/claim-task-id-counter.sh  # PASS — zero violations
```

Log line format (tab-separated):
```
2026-04-21T04:20:00Z	12345	unknown	t2570	1	0s
```

## Acceptance criteria

- [x] `_append_claim_audit_log` helper added and shellcheck-clean
- [x] `allocate_online()` success branch calls the helper between `log_success` and `echo "$first_id"`
- [x] Log directory `~/.aidevops/logs/` is created if missing; append fails open (no error on disk-full/perms)
- [x] Log line contains ISO8601 timestamp, pid, session_id (or `unknown`), tNNN, attempt, elapsed
- [x] `shellcheck .agents/scripts/claim-task-id-counter.sh` passes with zero violations

Resolves #20223
Closes #20001