### PR TITLE
GH#20259: t2577: remove unsupported reviewDecision field from gh search prs calls

### DIFF
--- a/.agents/scripts/pulse-batch-prefetch-helper.sh
+++ b/.agents/scripts/pulse-batch-prefetch-helper.sh
@@ -153,7 +153,7 @@ _normalize_search_to_prefetch_schema() {
 			from_entries
 		' 2>/dev/null
 	else
-		# PRs: preserve reviewDecision and headRefName if available
+		# PRs: preserve headRefName if available
 		jq '
 			group_by(.repository.nameWithOwner) |
 			map({
@@ -164,7 +164,6 @@ _normalize_search_to_prefetch_schema() {
 					labels: (.labels // []),
 					updatedAt: .updatedAt,
 					assignees: (.assignees // []),
-					reviewDecision: (.reviewDecision // null),
 					headRefName: (.headRefName // null),
 					createdAt: (.createdAt // null),
 					author: (.author // null)
@@ -266,7 +265,7 @@ _refresh_owner_prs() {
 	local pr_json=""
 	pr_json=$(gh search prs --owner "$owner" --state open \
 		--limit "$BATCH_SEARCH_LIMIT" \
-		--json number,title,labels,updatedAt,assignees,repository,reviewDecision,headRefName,createdAt,author 2>"$pr_err") || pr_json=""
+		--json number,title,labels,updatedAt,assignees,repository,headRefName,createdAt,author 2>"$pr_err") || pr_json=""
 	_OWNER_SEARCH_CALLS=$((_OWNER_SEARCH_CALLS + 1))
 
 	if [[ -z "$pr_json" || "$pr_json" == "$_JSON_NULL" ]]; then


### PR DESCRIPTION
## Summary

Removed reviewDecision from gh search prs --json field list and jq filter, as this field is not supported by the REST-based search endpoint. The field was causing 'Unknown JSON field' errors on every pulse cycle.

## Files Changed

.agents/scripts/pulse-batch-prefetch-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified with: bash pulse-batch-prefetch-helper.sh refresh --dry-run — no JSON field errors, errors=0 for field-name issues

Resolves #20259


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.87 plugin for [OpenCode](https://opencode.ai) v1.14.19 with claude-haiku-4-5 spent 1m and 2,004 tokens on this as a headless worker.