### PR TITLE
t2578: fix release_instance_lock double-release removing new owner's lock

### DIFF
--- a/.agents/scripts/pulse-instance-lock.sh
+++ b/.agents/scripts/pulse-instance-lock.sh
@@ -114,7 +114,7 @@ _handle_existing_lock() {
 		fi
 
 		# Lock owner is genuinely alive and within time limits
-		echo "[pulse-wrapper] Another pulse instance holds the mkdir lock (PID ${lock_pid}, age ${lock_age}s) — exiting immediately (GH#4513)" >>"$WRAPPER_LOGFILE"
+		echo "[pulse-wrapper] Another pulse instance holds the mkdir lock (PID ${lock_pid}, age ${lock_age}s, LOCKDIR=${LOCKDIR}) — exiting immediately (GH#4513)" >>"$WRAPPER_LOGFILE"
 		return 1
 	fi
 
@@ -174,6 +174,14 @@ acquire_instance_lock() {
 # stale-lock detection in acquire_instance_lock() handles that case.
 #
 # Safe to call multiple times (idempotent).
+#
+# GH#20260: two-layer safety prevents removing another instance's lock
+# after a voluntary pre-LLM release:
+#   1. _LOCK_OWNED=false is set BEFORE the rm so the EXIT trap is a
+#      guaranteed no-op when called after the voluntary release.
+#   2. PID ownership is verified against LOCKDIR/pid — if another
+#      instance acquired the lock between the voluntary release and the
+#      EXIT trap, its PID will differ from $$ and we skip the removal.
 #######################################
 release_instance_lock() {
 	# GH#18264: only release the lock when this process actually acquired it.
@@ -181,9 +189,29 @@ release_instance_lock() {
 	# This prevents the EXIT trap from removing LOCKDIR when the lock was
 	# never acquired (e.g., another instance was already running).
 	[[ "$_LOCK_OWNED" == "true" ]] || return 0
+
+	# GH#20260: Reset _LOCK_OWNED BEFORE the rm so the EXIT trap is a
+	# guaranteed no-op after a voluntary pre-LLM release (run_cycle line
+	# ~1327). Without this reset, a second call from the EXIT trap would
+	# see _LOCK_OWNED=true and remove a LOCKDIR now owned by a new instance.
+	_LOCK_OWNED=false
+
+	# GH#20260: Verify PID ownership before removing — between a voluntary
+	# release and process exit, another instance may have acquired LOCKDIR.
+	# Only remove if LOCKDIR/pid still contains our own PID ($$).
+	local _lock_pid_file="${LOCKDIR}/pid"
+	if [[ -f "$_lock_pid_file" ]]; then
+		local _current_lock_pid
+		_current_lock_pid=$(cat "$_lock_pid_file" 2>/dev/null || echo "")
+		if [[ -n "$_current_lock_pid" ]] && [[ "$_current_lock_pid" != "$$" ]]; then
+			echo "[pulse-wrapper] release_instance_lock: LOCKDIR reacquired by PID ${_current_lock_pid} — skipping removal (PID $$ already released) (GH#20260)" >>"$WRAPPER_LOGFILE"
+			return 0
+		fi
+	fi
+
 	rm -rf "$LOCKDIR" 2>/dev/null || true
 	return 0
-} # nice — idempotent cleanup
+}
 
 #######################################
 # Handle SETUP sentinel in PID file (GH#5627, extracted from check_dedup)

--- a/.agents/scripts/tests/test-pulse-lock-force-reclaim.sh
+++ b/.agents/scripts/tests/test-pulse-lock-force-reclaim.sh
@@ -298,13 +298,93 @@ test_env_override_adjusts_ceiling() {
 }
 
 #######################################
+# Test 6: Double-release — voluntary pre-LLM release followed by EXIT trap
+# must NOT remove a LOCKDIR reacquired by a new instance (GH#20260).
+#
+# Scenario that the original code got wrong:
+#   1. Pulse A acquires lock (_LOCK_OWNED=true, LOCKDIR/pid=$A_PID)
+#   2. Pulse A voluntarily releases before LLM: release_instance_lock()
+#      → LOCKDIR removed, but OLD CODE left _LOCK_OWNED=true
+#   3. Pulse B acquires lock (LOCKDIR/pid=$B_PID)
+#   4. Pulse A's EXIT trap fires: release_instance_lock()
+#      → OLD CODE: _LOCK_OWNED=true → rm -rf LOCKDIR (B's lock removed!)
+#      → NEW CODE: _LOCK_OWNED=false (reset in step 2) → early return
+#
+# This test simulates step 4 by directly setting _LOCK_OWNED=true and
+# planting a LOCKDIR owned by a different PID, then calling
+# release_instance_lock() and asserting the LOCKDIR is preserved.
+#######################################
+test_double_release_preserves_new_owner() {
+	reset_state
+
+	# Plant a LOCKDIR owned by a "foreign" PID (not $$)
+	# Use a PID known to be dead to avoid any ps side-effects
+	local foreign_pid=999988
+	while ps -p "$foreign_pid" >/dev/null 2>&1; do
+		foreign_pid=$((foreign_pid + 1))
+	done
+	mkdir -p "$LOCKDIR"
+	echo "$foreign_pid" >"${LOCKDIR}/pid"
+
+	# Force _LOCK_OWNED=true to simulate the bug state (voluntary release
+	# did not reset it — as the OLD code would leave it)
+	_LOCK_OWNED=true
+
+	# Call release_instance_lock as the EXIT trap would
+	release_instance_lock
+
+	# With the GH#20260 fix the LOCKDIR must still exist — we did NOT own it
+	if [[ -d "$LOCKDIR" ]]; then
+		print_result "double-release: LOCKDIR owned by foreign PID preserved" 0
+	else
+		print_result "double-release: LOCKDIR owned by foreign PID preserved" 1 \
+			"EXIT trap incorrectly removed another instance's lock"
+	fi
+
+	# _LOCK_OWNED must be false regardless
+	assert_equals "double-release: _LOCK_OWNED reset to false" "false" "$_LOCK_OWNED"
+
+	if grep -q "reacquired by PID" "$WRAPPER_LOGFILE" 2>/dev/null; then
+		print_result "double-release: skip-removal logged" 0
+	else
+		print_result "double-release: skip-removal logged" 1 "no skip-removal log line found"
+	fi
+	return 0
+}
+
+#######################################
+# Test 7: Legitimate self-release — when LOCKDIR/pid matches $$,
+# release_instance_lock DOES remove it (normal exit path).
+#######################################
+test_self_release_removes_own_lock() {
+	reset_state
+
+	acquire_instance_lock >/dev/null
+
+	local pid_before
+	pid_before=$(cat "${LOCKDIR}/pid" 2>/dev/null || echo "")
+	assert_equals "self-release setup: PID file contains \$\$" "$$" "$pid_before"
+
+	release_instance_lock
+
+	if [[ ! -d "$LOCKDIR" ]]; then
+		print_result "self-release: LOCKDIR removed" 0
+	else
+		print_result "self-release: LOCKDIR removed" 1 "LOCKDIR still exists after self-release"
+	fi
+
+	assert_equals "self-release: _LOCK_OWNED reset to false" "false" "$_LOCK_OWNED"
+	return 0
+}
+
+#######################################
 # Main
 #######################################
 main() {
 	setup_sandbox
 
 	echo ""
-	echo "=== Pulse Lock Force-Reclaim Tests (GH#20025) ==="
+	echo "=== Pulse Lock Force-Reclaim Tests (GH#20025 + GH#20260) ==="
 	echo ""
 
 	test_live_owner_within_ceiling
@@ -312,6 +392,8 @@ main() {
 	test_alive_but_stale_owner
 	test_pid_reused_by_unrelated
 	test_env_override_adjusts_ceiling
+	test_double_release_preserves_new_owner
+	test_self_release_removes_own_lock
 
 	teardown_sandbox
 


### PR DESCRIPTION
## Summary

Fixes GH#20260: the voluntary pre-LLM lock release in `run_cycle()` left `_LOCK_OWNED=true`. When the pulse process later exited naturally, the EXIT trap fired a second `release_instance_lock()` call and `rm -rf`'d the LOCKDIR — which may have been reacquired by a new pulse instance in the interim. This caused the observed "three concurrent PIDs / stale lock / Another pulse instance holds the mkdir lock" symptom.

## Root cause

```bash
# BEFORE (broken):
release_instance_lock() {
    [[ "$_LOCK_OWNED" == "true" ]] || return 0
    rm -rf "$LOCKDIR" 2>/dev/null || true  # _LOCK_OWNED never reset!
    return 0
}
```

Timeline of the bug:
1. Pulse A acquires lock (`_LOCK_OWNED=true`, LOCKDIR/pid=A)
2. `run_cycle()` calls `release_instance_lock()` before LLM — LOCKDIR removed, but `_LOCK_OWNED` stays `true`
3. Pulse B starts, acquires lock (LOCKDIR/pid=B)
4. Pulse A exits: EXIT trap calls `release_instance_lock()` → `_LOCK_OWNED==true` → removes **B's** lock
5. Pulse C starts, acquires lock — B and C both think they hold the lock

## Fix

Two-layer defence in `release_instance_lock()`:

1. `_LOCK_OWNED=false` reset — set before `rm -rf` so the EXIT trap is a guaranteed no-op after voluntary release (idempotent by flag).
2. PID ownership check — verify `LOCKDIR/pid == $$` before removing; if another instance reacquired the lock, skip removal and log a diagnostic.

Log improvement: "Another pulse instance holds the mkdir lock" message now includes `LOCKDIR=<path>` so users can locate the lock.

## Files changed

- EDIT: `.agents/scripts/pulse-instance-lock.sh` — fix `release_instance_lock()`, improve log
- EDIT: `.agents/scripts/tests/test-pulse-lock-force-reclaim.sh` — Tests 6+7 for double-release and self-release

## Testing

All 19/19 force-reclaim tests pass. All 20/20 mkdir-only characterization tests pass.

Resolves #20260