### PR TITLE
GH#20207: GH#20207: add transcript-side credential scrub (t2458 Layer 4)

### DIFF
--- a/.agents/hooks/credential-transcript-scrub.py
+++ b/.agents/hooks/credential-transcript-scrub.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""
+PostToolUse hook for Claude Code: transcript-side credential scrub (GH#20207).
+
+Fires after every tool call. Scrubs known credential token prefixes from the
+tool result before it reaches the model or is persisted to disk.
+
+This is Layer 4 of t2458 credential sanitization:
+  Layers 1-3 prevent framework helpers from emitting credentials.
+  Layer 4 (this hook) catches credentials that reach the tool-result channel
+  from other sources: user scripts, third-party CLIs, error backtraces.
+
+Token prefix families scrubbed (mirrors shared-constants.sh scrub_credentials):
+  sk-       OpenAI / Anthropic API keys
+  ghp_      GitHub personal access tokens
+  gho_      GitHub OAuth tokens
+  ghs_      GitHub server-to-server tokens
+  ghu_      GitHub user-to-server tokens
+  github_pat_  GitHub fine-grained PATs
+  glpat-    GitLab personal access tokens
+  xoxb-     Slack bot tokens
+  xoxp-     Slack user tokens
+
+Exit behavior:
+  - Exit 0 always — this hook MUST NOT block tool execution, only sanitize.
+  - Emits a JSON object to stdout with the scrubbed tool_response when a
+    credential is detected. Claude Code reads this to replace the tool result.
+  - Emits nothing (empty stdout) when no credential is found — allowing the
+    original result through unchanged.
+
+Input: JSON on stdin with Claude Code hook payload.
+Output: JSON on stdout with sanitized result (only when scrubbing occurs).
+
+Installed by: install-hooks-helper.sh
+Location: ~/.aidevops/hooks/credential-transcript-scrub.py
+Configured in: ~/.claude/settings.json (hooks.PostToolUse)
+
+Performance target: <5ms per 10KB tool result.
+"""
+import json
+import re
+import sys
+import time
+
+# Regex mirrors shared-constants.sh scrub_credentials sed pattern exactly.
+# Group 1: token prefix family (one of the 9 families).
+# Suffix: 10+ alphanumeric / dash / underscore chars (token body).
+CREDENTIAL_PATTERN = re.compile(
+    r"(sk-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}",
+    re.ASCII,
+)
+
+REDACTION_TOKEN = "[redacted-credential]"
+
+
+def scrub_credentials(text: str) -> tuple[str, int]:
+    """Replace credential tokens in text. Returns (scrubbed_text, match_count)."""
+    result, count = CREDENTIAL_PATTERN.subn(REDACTION_TOKEN, text)
+    return result, count
+
+
+def scrub_value(value):
+    """Recursively scrub credentials from any JSON-serialisable value."""
+    if isinstance(value, str):
+        return scrub_credentials(value)[0]
+    if isinstance(value, dict):
+        return {k: scrub_value(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [scrub_value(item) for item in value]
+    return value
+
+
+def main() -> None:
+    start_ns = time.monotonic_ns()
+
+    try:
+        raw = sys.stdin.read()
+        data = json.loads(raw)
+    except (json.JSONDecodeError, EOFError, ValueError):
+        # Malformed input — allow through, never block.
+        return
+
+    tool_response = data.get("tool_response", "")
+
+    # Fast path: no credential pattern anywhere in the raw payload.
+    if not CREDENTIAL_PATTERN.search(raw):
+        return
+
+    # Scrub the tool_response field (may be str or nested JSON object).
+    if isinstance(tool_response, str):
+        scrubbed, count = scrub_credentials(tool_response)
+        if count == 0:
+            return
+    elif isinstance(tool_response, (dict, list)):
+        scrubbed = scrub_value(tool_response)
+        # Re-serialise to detect if anything actually changed.
+        original_json = json.dumps(tool_response, ensure_ascii=False)
+        scrubbed_json = json.dumps(scrubbed, ensure_ascii=False)
+        if original_json == scrubbed_json:
+            return
+    else:
+        return
+
+    elapsed_ms = (time.monotonic_ns() - start_ns) / 1_000_000
+    # Emit replacement payload to Claude Code.
+    out = {
+        "tool_response": scrubbed,
+        "redacted_credential": True,
+        "scrub_elapsed_ms": round(elapsed_ms, 2),
+    }
+    print(json.dumps(out))
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/plugins/opencode-aidevops/quality-hooks.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks.mjs
@@ -17,6 +17,75 @@ import { enrichActiveSpan, detectTaskId, detectSessionOrigin } from "./otel-enri
 export { scanForSecrets } from "./quality-logging.mjs";
 
 // ---------------------------------------------------------------------------
+// Credential transcript scrub (GH#20207, Layer 4 of t2458)
+// Mirrors shared-constants.sh scrub_credentials regex.
+// Applied in handleToolAfter to redact tokens before they reach the model
+// or are persisted to the SQLite transcript store.
+// ---------------------------------------------------------------------------
+
+const CREDENTIAL_PATTERN =
+  /(sk-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}/g;
+
+const REDACTION_TOKEN = "[redacted-credential]";
+
+/**
+ * Scrub known credential token prefixes from a string value.
+ * @param {string} text
+ * @returns {{ scrubbed: string, count: number }}
+ */
+function scrubCredentials(text) {
+  let count = 0;
+  const scrubbed = text.replace(CREDENTIAL_PATTERN, () => {
+    count++;
+    return REDACTION_TOKEN;
+  });
+  return { scrubbed, count };
+}
+
+/**
+ * Recursively scrub credentials from any JSON-serialisable value.
+ * @param {unknown} value
+ * @returns {{ value: unknown, count: number }}
+ */
+function scrubValue(value) {
+  if (typeof value === "string") {
+    const { scrubbed, count } = scrubCredentials(value);
+    return { value: scrubbed, count };
+  }
+  if (Array.isArray(value)) {
+    let total = 0;
+    const result = value.map((item) => {
+      const { value: v, count } = scrubValue(item);
+      total += count;
+      return v;
+    });
+    return { value: result, count: total };
+  }
+  if (value !== null && typeof value === "object") {
+    let total = 0;
+    const result = {};
+    for (const [k, v] of Object.entries(value)) {
+      const { value: scrubbed, count } = scrubValue(v);
+      result[k] = scrubbed;
+      total += count;
+    }
+    return { value: result, count: total };
+  }
+  return { value, count: 0 };
+}
+
+/**
+ * Scrub credentials from tool output. Returns the sanitised output and a
+ * boolean indicating whether any redaction occurred.
+ * @param {unknown} output
+ * @returns {{ output: unknown, redacted: boolean }}
+ */
+function scrubToolOutput(output) {
+  const { value, count } = scrubValue(output);
+  return { output: value, redacted: count > 0 };
+}
+
+// ---------------------------------------------------------------------------
 // Tool classification helpers
 // ---------------------------------------------------------------------------
 
@@ -201,6 +270,19 @@ function handleToolBefore(ctx, log, input, output) {
  */
 function handleToolAfter(ctx, log, scriptsDir, input, output) {
   const toolName = input.tool || "";
+
+  // GH#20207 (t2458 Layer 4): scrub credentials from tool output before
+  // persisting to the SQLite transcript store or sending to the model.
+  // Applies to all tools — credentials can arrive via user scripts, third-party
+  // CLIs, or runtime error backtraces, not just framework helpers.
+  const rawOutput = output.output;
+  if (rawOutput !== undefined) {
+    const { output: scrubbedOutput, redacted } = scrubToolOutput(rawOutput);
+    if (redacted) {
+      output.output = scrubbedOutput;
+      log("WARN", `[credential-scrub] redacted credential token(s) from ${toolName} output`);
+    }
+  }
 
   if (isBashTool(toolName)) {
     trackBashOperation(ctx, output.title || "", output.output || "");

--- a/.agents/scripts/install-hooks-helper.sh
+++ b/.agents/scripts/install-hooks-helper.sh
@@ -27,9 +27,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 HOOKS_DIR="$HOME/.aidevops/hooks"
 HOOK_SCRIPT="$HOOKS_DIR/git_safety_guard.py"
 POST_HOOK_SCRIPT="$HOOKS_DIR/mcp_task_post_hook.py"
+CREDENTIAL_SCRUB_SCRIPT="$HOOKS_DIR/credential-transcript-scrub.py"
 CLAUDE_SETTINGS="$HOME/.claude/settings.json"
 HOOK_COMMAND="\$HOME/.aidevops/hooks/git_safety_guard.py"
 POST_HOOK_COMMAND="\$HOME/.aidevops/hooks/mcp_task_post_hook.py"
+CREDENTIAL_SCRUB_COMMAND="\$HOME/.aidevops/hooks/credential-transcript-scrub.py"
 
 # gh-wrapper-guard pre-push hook (t2113)
 GH_WRAPPER_GUARD_MARKER="# aidevops-gh-wrapper-guard"
@@ -471,6 +473,8 @@ install_hook() {
 	source_hook=$(find_source_hook) || return 1
 	local source_post_hook
 	source_post_hook=$(find_source_hook "mcp_task_post_hook.py") || return 1
+	local source_credential_scrub_hook
+	source_credential_scrub_hook=$(find_source_hook "credential-transcript-scrub.py") || return 1
 
 	# Pre-install validator dry-run (t2226): abort if validators fail HEAD state
 	_dry_run_validators "$source_hook" "$force_install" || return 1
@@ -485,6 +489,9 @@ install_hook() {
 	cp "$source_post_hook" "$POST_HOOK_SCRIPT"
 	chmod +x "$POST_HOOK_SCRIPT"
 	print_success "Installed $POST_HOOK_SCRIPT"
+	cp "$source_credential_scrub_hook" "$CREDENTIAL_SCRUB_SCRIPT"
+	chmod +x "$CREDENTIAL_SCRUB_SCRIPT"
+	print_success "Installed $CREDENTIAL_SCRUB_SCRIPT"
 
 	# Configure Claude Code settings.json
 	configure_claude_settings || return 1
@@ -544,6 +551,15 @@ settings = {
                         'command': '$POST_HOOK_COMMAND'
                     }
                 ]
+            },
+            {
+                'matcher': '.*',
+                'hooks': [
+                    {
+                        'type': 'command',
+                        'command': '$CREDENTIAL_SCRUB_COMMAND'
+                    }
+                ]
             }
         ]
     }
@@ -577,12 +593,15 @@ for h in hooks.get('PreToolUse', []):
             has_pre = True
 
 has_post = False
+has_scrub = False
 for h in hooks.get('PostToolUse', []):
     for sub in h.get('hooks', []):
         if 'mcp_task_post_hook' in sub.get('command', ''):
             has_post = True
+        if 'credential-transcript-scrub' in sub.get('command', ''):
+            has_scrub = True
 
-if has_pre and has_post:
+if has_pre and has_post and has_scrub:
     sys.exit(0)
 sys.exit(1)
 " 2>/dev/null; then
@@ -627,15 +646,28 @@ post_hook_entry = {
     ]
 }
 
+credential_scrub_entry = {
+    'matcher': '.*',
+    'hooks': [
+        {
+            'type': 'command',
+            'command': '$CREDENTIAL_SCRUB_COMMAND'
+        }
+    ]
+}
+
 if 'PreToolUse' not in settings['hooks']:
     settings['hooks']['PreToolUse'] = [hook_entry]
 elif not has_hook(settings['hooks']['PreToolUse'], 'git_safety_guard'):
     settings['hooks']['PreToolUse'].append(hook_entry)
 
 if 'PostToolUse' not in settings['hooks']:
-    settings['hooks']['PostToolUse'] = [post_hook_entry]
-elif not has_hook(settings['hooks']['PostToolUse'], 'mcp_task_post_hook'):
-    settings['hooks']['PostToolUse'].append(post_hook_entry)
+    settings['hooks']['PostToolUse'] = [post_hook_entry, credential_scrub_entry]
+else:
+    if not has_hook(settings['hooks']['PostToolUse'], 'mcp_task_post_hook'):
+        settings['hooks']['PostToolUse'].append(post_hook_entry)
+    if not has_hook(settings['hooks']['PostToolUse'], 'credential-transcript-scrub'):
+        settings['hooks']['PostToolUse'].append(credential_scrub_entry)
 
 path = '$CLAUDE_SETTINGS'
 fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path), suffix='.tmp')
@@ -669,6 +701,12 @@ uninstall_hook() {
 	else
 		print_info "Post hook script not found (already removed)"
 	fi
+	if [[ -f "$CREDENTIAL_SCRUB_SCRIPT" ]]; then
+		rm "$CREDENTIAL_SCRUB_SCRIPT"
+		print_success "Removed $CREDENTIAL_SCRUB_SCRIPT"
+	else
+		print_info "Credential scrub hook not found (already removed)"
+	fi
 
 	# Remove from Claude settings
 	if [[ -f "$CLAUDE_SETTINGS" ]]; then
@@ -696,7 +734,7 @@ post_hooks = settings.get('hooks', {}).get('PostToolUse', [])
 post_filtered = []
 for h in post_hooks:
     sub_hooks = h.get('hooks', [])
-    sub_filtered = [s for s in sub_hooks if 'mcp_task_post_hook' not in s.get('command', '')]
+    sub_filtered = [s for s in sub_hooks if 'mcp_task_post_hook' not in s.get('command', '') and 'credential-transcript-scrub' not in s.get('command', '')]
     if sub_filtered:
         h['hooks'] = sub_filtered
         post_filtered.append(h)
@@ -800,6 +838,34 @@ _check_status_gh_wrapper_guard() {
 	return 0
 }
 
+_check_status_credential_scrub_hook() {
+	if [[ -f "$CREDENTIAL_SCRUB_SCRIPT" ]] && [[ -x "$CREDENTIAL_SCRUB_SCRIPT" ]]; then
+		print_success "credential-transcript-scrub: $CREDENTIAL_SCRUB_SCRIPT"
+	elif [[ -f "$CREDENTIAL_SCRUB_SCRIPT" ]]; then
+		print_warning "credential-transcript-scrub: installed but not executable"
+		return 1
+	else
+		print_warning "credential-transcript-scrub: not installed (run: install-hooks-helper.sh install)"
+		return 1
+	fi
+	if [[ -f "$CLAUDE_SETTINGS" ]] && python3 -c "
+import json, sys
+with open('$CLAUDE_SETTINGS') as f:
+    d = json.load(f)
+for h in d.get('hooks', {}).get('PostToolUse', []):
+    for sub in h.get('hooks', []):
+        if 'credential-transcript-scrub' in sub.get('command', ''):
+            sys.exit(0)
+sys.exit(1)
+" 2>/dev/null; then
+		print_success "  PostToolUse registration: present"
+	else
+		print_warning "  PostToolUse registration: missing (run: install-hooks-helper.sh install)"
+		return 1
+	fi
+	return 0
+}
+
 _check_status_precommit_hook() {
 	local common_dir pc_hook_path
 	if ! common_dir=$(git rev-parse --git-common-dir 2>/dev/null); then
@@ -843,6 +909,11 @@ check_status() {
 	_check_status_hook_script || all_ok=false
 	_check_status_python || all_ok=false
 	_check_status_claude_settings || all_ok=false
+
+	echo ""
+	echo "Credential Transcript Scrub Hook (GH#20207)"
+	echo "--------------------------------------------"
+	_check_status_credential_scrub_hook || all_ok=false
 
 	echo ""
 	echo "GH Wrapper Guard (pre-push)"

--- a/.agents/scripts/tests/test-credential-transcript-scrub.sh
+++ b/.agents/scripts/tests/test-credential-transcript-scrub.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-credential-transcript-scrub.sh — GH#20207 regression guard.
+#
+# Verifies that credential-transcript-scrub.py correctly redacts all 9 known
+# token-prefix families from tool result payloads and meets the <5ms/10KB
+# performance budget.
+#
+# Tests:
+#   1.  gho_ token redacted in plain string tool_response
+#   2.  ghp_ token redacted in nested dict tool_response
+#   3.  sk-  token redacted (OpenAI / Anthropic API keys)
+#   4.  ghs_ token redacted (GitHub server-to-server)
+#   5.  ghu_ token redacted (GitHub user-to-server)
+#   6.  github_pat_ token redacted (fine-grained PAT)
+#   7.  glpat- token redacted (GitLab PAT)
+#   8.  xoxb- token redacted (Slack bot token)
+#   9.  xoxp- token redacted (Slack user token)
+#   10. Clean input produces no output (fast-path, no redaction)
+#   11. Token shorter than 10 chars NOT redacted (below minimum body length)
+#   12. Multiple tokens in one payload all redacted
+#   13. Nested JSON object tool_response scrubbed recursively
+#   14. Malformed JSON produces no output and exits 0 (fail-open)
+#   15. Performance: <5ms per 10KB tool result
+#
+# Usage: bash test-credential-transcript-scrub.sh
+
+set -uo pipefail
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+HOOKS_DIR="$(cd "${SCRIPT_DIR_TEST}/../../hooks" && pwd)" || exit 1
+HOOK_SCRIPT="$HOOKS_DIR/credential-transcript-scrub.py"
+
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_BLUE=$'\033[0;34m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_BLUE="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf '  %sPASS%s %s\n' "$TEST_GREEN" "$TEST_NC" "$1"
+	return 0
+}
+
+fail() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '  %sFAIL%s %s\n' "$TEST_RED" "$TEST_NC" "$1"
+	return 0
+}
+
+# Helpers
+run_hook() {
+	echo "$1" | python3 "$HOOK_SCRIPT"
+	return 0
+}
+
+assert_redacted() {
+	local label="$1"
+	local payload="$2"
+	local output
+	output=$(run_hook "$payload")
+	if echo "$output" | python3 -c "import json,sys; d=json.load(sys.stdin); assert d.get('redacted_credential') is True" 2>/dev/null; then
+		pass "$label — credential redacted"
+	else
+		fail "$label — expected redacted_credential:true, got: $output"
+	fi
+	if echo "$output" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+resp = d.get('tool_response', '')
+# Check that no raw token prefix family appears in the output
+import re
+pat = re.compile(r'(sk-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}')
+if isinstance(resp, str):
+    assert not pat.search(resp), f'token still present: {resp}'
+elif isinstance(resp, dict):
+    flat = json.dumps(resp)
+    assert not pat.search(flat), f'token still present in dict: {flat}'
+" 2>/dev/null; then
+		pass "$label — token absent from output"
+	else
+		fail "$label — raw credential token still present in output"
+	fi
+	return 0
+}
+
+assert_no_output() {
+	local label="$1"
+	local payload="$2"
+	local output
+	output=$(run_hook "$payload")
+	if [[ -z "$output" ]]; then
+		pass "$label — no output (fast-path)"
+	else
+		fail "$label — expected empty output, got: $output"
+	fi
+	return 0
+}
+
+assert_exit_zero() {
+	local label="$1"
+	local payload="$2"
+	if echo "$payload" | python3 "$HOOK_SCRIPT" >/dev/null 2>&1; then
+		pass "$label — exits 0"
+	else
+		fail "$label — expected exit 0, got non-zero"
+	fi
+	return 0
+}
+
+# ── Preflight ──────────────────────────────────────────────────────────────
+
+printf '%s\n' "${TEST_BLUE}Credential Transcript Scrub Hook — Test Suite${TEST_NC}"
+printf '%s\n' "=================================================="
+
+if [[ ! -f "$HOOK_SCRIPT" ]]; then
+	printf '%sFAIL%s Hook not found: %s\n' "$TEST_RED" "$TEST_NC" "$HOOK_SCRIPT"
+	exit 1
+fi
+if ! command -v python3 &>/dev/null; then
+	printf '%sFAIL%s python3 not found\n' "$TEST_RED" "$TEST_NC"
+	exit 1
+fi
+printf '  Hook: %s\n\n' "$HOOK_SCRIPT"
+
+# ── Token-family tests (1–9) ───────────────────────────────────────────────
+
+printf '%s\n' "${TEST_BLUE}Token family coverage${TEST_NC}"
+
+assert_redacted "1. gho_ token" \
+	'{"tool_response": "remote url: https://gho_ABCDEFGHIJ1234567890@github.com/owner/repo"}'
+
+assert_redacted "2. ghp_ token" \
+	'{"tool_response": {"url": "https://ghp_ABCDEFGHIJ1234567890@github.com/owner/repo"}}'
+
+assert_redacted "3. sk- token" \
+	'{"tool_response": "API call failed with key sk-abcdefghijklmnopqrstuvwx"}'
+
+assert_redacted "4. ghs_ token" \
+	'{"tool_response": "Authorization: Bearer ghs_ABCDEFGHIJ1234567890"}'
+
+assert_redacted "5. ghu_ token" \
+	'{"tool_response": "token ghu_ABCDEFGHIJ1234567890 expired"}'
+
+assert_redacted "6. github_pat_ token" \
+	'{"tool_response": "fine-grained PAT: github_pat_11ABCDEFGHIJ1234567890"}'
+
+assert_redacted "7. glpat- token" \
+	'{"tool_response": "GitLab token: glpat-ABCDEFGHIJ1234567890"}'
+
+assert_redacted "8. xoxb- token" \
+	'{"tool_response": "Slack bot: xoxb-ABCDEFGHIJKLM-1234567890-abcdefghij"}'
+
+assert_redacted "9. xoxp- token" \
+	'{"tool_response": "Slack user: xoxp-ABCDEFGHIJKLM-1234567890-abcdefghij"}'
+
+# ── Edge cases ─────────────────────────────────────────────────────────────
+
+printf '\n%s\n' "${TEST_BLUE}Edge cases${TEST_NC}"
+
+assert_no_output "10. Clean input produces no output" \
+	'{"tool_response": "git status: clean working tree"}'
+
+assert_no_output "11. Token body shorter than 10 chars not redacted" \
+	'{"tool_response": "gho_SHORT123"}'
+
+assert_redacted "12. Multiple tokens all redacted" \
+	'{"tool_response": "key1=ghp_ABCDEFGHIJ1234567890 key2=gho_ABCDEFGHIJ1234567890"}'
+
+# Test 13: nested JSON object
+NESTED_PAYLOAD='{"tool_response": {"stdout": "token: ghs_ABCDEFGHIJ1234567890", "stderr": "", "exit_code": 0}}'
+output13=$(run_hook "$NESTED_PAYLOAD")
+if echo "$output13" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+assert d.get('redacted_credential') is True, 'not redacted'
+resp = d.get('tool_response', {})
+assert isinstance(resp, dict), 'tool_response not dict'
+assert '[redacted-credential]' in resp.get('stdout', ''), 'token not scrubbed in stdout'
+" 2>/dev/null; then
+	pass "13. Nested dict tool_response scrubbed recursively"
+else
+	fail "13. Nested dict tool_response scrubbed recursively — got: $output13"
+fi
+
+# Test 14: malformed JSON exits 0
+assert_exit_zero "14. Malformed JSON exits 0 (fail-open)" \
+	"not-valid-json"
+
+# ── Performance budget ─────────────────────────────────────────────────────
+
+printf '\n%s\n' "${TEST_BLUE}Performance (<5ms per 10KB)${TEST_NC}"
+
+# Build a ~10KB payload with one embedded credential.
+# The 5ms budget is for the processing cost (regex + JSON parse/serialise),
+# not the Python process startup cost (~50ms fixed per-invocation).
+# We measure using scrub_elapsed_ms reported by the hook itself,
+# and by running the regex in-process for a microbenchmark.
+FILLER=$(python3 -c "print('x' * 9900)")
+PERF_PAYLOAD="{\"tool_response\": \"${FILLER} gho_ABCDEFGHIJ1234567890 end\"}"
+
+# Method A: use the scrub_elapsed_ms field reported by the hook
+ELAPSED_MS=$(echo "$PERF_PAYLOAD" | python3 "$HOOK_SCRIPT" 2>/dev/null | python3 -c "
+import json, sys
+try:
+    d = json.load(sys.stdin)
+    print(d.get('scrub_elapsed_ms', 'N/A'))
+except Exception:
+    print('N/A')
+")
+
+printf '  Hook-reported scrub_elapsed_ms: %sms (excludes Python startup)\n' "$ELAPSED_MS"
+
+# Method B: in-process microbenchmark (most accurate for the regex itself)
+BENCH_MS=$(python3 -c "
+import re, time, json
+
+CREDENTIAL_PATTERN = re.compile(
+    r'(sk-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}',
+    re.ASCII,
+)
+filler = 'x' * 9900
+payload_str = json.dumps({'tool_response': f'{filler} gho_ABCDEFGHIJ1234567890 end'})
+
+runs = 500
+start = time.monotonic_ns()
+for _ in range(runs):
+    CREDENTIAL_PATTERN.sub('[redacted-credential]', payload_str)
+end = time.monotonic_ns()
+avg_ms = (end - start) / runs / 1_000_000
+print(round(avg_ms, 4))
+")
+
+printf '  In-process regex per 10KB (%d runs): %sms\n' 500 "$BENCH_MS"
+
+if python3 -c "import sys; sys.exit(0 if float('$BENCH_MS') < 5 else 1)" 2>/dev/null; then
+	pass "15. Performance: ${BENCH_MS}ms per 10KB in-process (budget: <5ms)"
+else
+	fail "15. Performance: ${BENCH_MS}ms per 10KB in-process exceeds 5ms budget"
+fi
+printf '  Note: subprocess launch adds ~50ms Python startup; in-process cost shown above.\n'
+
+# ── Summary ────────────────────────────────────────────────────────────────
+
+printf '\n'
+if [[ "$TESTS_FAILED" -eq 0 ]]; then
+	printf '%sAll %d tests passed%s\n' "$TEST_GREEN" "$TESTS_RUN" "$TEST_NC"
+	exit 0
+else
+	printf '%s%d/%d tests failed%s\n' "$TEST_RED" "$TESTS_FAILED" "$TESTS_RUN" "$TEST_NC"
+	exit 1
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -57,7 +57,9 @@ authorized_keys
 !.agents/scripts/tests/test-secret-helper.sh
 !.agents/scripts/tests/test-credential-sanitizer.sh
 !.agents/scripts/tests/test-credential-emission-guard.sh
+!.agents/scripts/tests/test-credential-transcript-scrub.sh
 !.agents/hooks/credential-emission-pre-push.sh
+!.agents/hooks/credential-transcript-scrub.py
 
 # Exception for secret handling reference doc (guidance, not actual secrets)
 !.agents/reference/secret-handling.md


### PR DESCRIPTION
## Summary

Adds PostToolUse credential scrubber (Layer 4 of t2458) covering three new vectors: user scripts, third-party CLI output, and runtime error backtraces. Implemented as: (1) credential-transcript-scrub.py Python hook registered in ~/.claude/settings.json PostToolUse; (2) JS port in opencode-aidevops quality-hooks.mjs handleToolAfter; (3) 25-assertion test harness; (4) install-hooks-helper.sh updated to copy/register/uninstall/status-check the new hook.

## Files Changed

.agents/hooks/credential-transcript-scrub.py,.agents/plugins/opencode-aidevops/quality-hooks.mjs,.agents/scripts/install-hooks-helper.sh,.agents/scripts/tests/test-credential-transcript-scrub.sh,.gitignore

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-credential-transcript-scrub.sh — 25/25 pass; echo '{"tool_response": "fake gho_ABCDEFGHIJ1234567890"}' | python3 .agents/hooks/credential-transcript-scrub.py → emits redacted output; shellcheck on both shell files — zero violations

Resolves #20207


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.87 plugin for [OpenCode](https://opencode.ai) v1.14.19 with claude-sonnet-4-6 spent 7m and 25,484 tokens on this as a headless worker.