### PR TITLE
GH#20234: reformat daily scan stages to multi-line style in _run_preflight_stages

### DIFF
--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -1257,12 +1257,18 @@ _run_preflight_stages() {
 	# _preflight_daily_scans() group with a shared 600s budget — a slow
 	# complexity_scan (200-340s) would starve downstream scanners
 	# (auto_decomposer, post_merge, dedup) from ever running.
-	run_stage_with_timeout "complexity_scan" "$_pflt_timeout" run_weekly_complexity_scan || true
-	run_stage_with_timeout "coderabbit_review" "$_pflt_timeout" run_daily_codebase_review || true
-	run_stage_with_timeout "post_merge_scanner" "$_pflt_timeout" _run_post_merge_review_scanner || true
-	run_stage_with_timeout "auto_decomposer_scanner" "$_pflt_timeout" _run_auto_decomposer_scanner || true
-	run_stage_with_timeout "dedup_cleanup" "$_pflt_timeout" run_simplification_dedup_cleanup || true
-	run_stage_with_timeout "fast_fail_prune_expired" "$_pflt_timeout" fast_fail_prune_expired || true
+	run_stage_with_timeout "complexity_scan" "$_pflt_timeout" \
+		run_weekly_complexity_scan || true
+	run_stage_with_timeout "coderabbit_review" "$_pflt_timeout" \
+		run_daily_codebase_review || true
+	run_stage_with_timeout "post_merge_scanner" "$_pflt_timeout" \
+		_run_post_merge_review_scanner || true
+	run_stage_with_timeout "auto_decomposer_scanner" "$_pflt_timeout" \
+		_run_auto_decomposer_scanner || true
+	run_stage_with_timeout "dedup_cleanup" "$_pflt_timeout" \
+		run_simplification_dedup_cleanup || true
+	run_stage_with_timeout "fast_fail_prune_expired" "$_pflt_timeout" \
+		fast_fail_prune_expired || true
 	run_stage_with_timeout "preflight_ownership_reconcile" "$_pflt_timeout" \
 		_preflight_ownership_reconcile || true
 	# prefetch_and_scope is the only preflight stage whose failure aborts


### PR DESCRIPTION
## Summary

Addresses Gemini code review feedback from PR #20158: reformats the 6 daily scan `run_stage_with_timeout` calls in `_run_preflight_stages()` to use the consistent multi-line style matching the surrounding preflight stage calls.

**Premise check:** The Gemini reviewer's first claim — that `fast_fail_prune_expired` was "not wrapped" in `run_stage_with_timeout` — was already incorrect in the merged PR. All 6 daily scan calls were correctly wrapped. The valid finding from the review was the style inconsistency: those 6 calls used single-line format while all other `run_stage_with_timeout` calls in the function used multi-line continuation format.

## Changes

- **EDIT**: `.agents/scripts/pulse-dispatch-engine.sh:1260-1271` — reformatted the 6 daily scan stage calls (`complexity_scan`, `coderabbit_review`, `post_merge_scanner`, `auto_decomposer_scanner`, `dedup_cleanup`, `fast_fail_prune_expired`) from single-line to multi-line format, matching the style of `preflight_cleanup_and_ledger`, `preflight_capacity_and_labels`, and `preflight_early_dispatch` calls at lines 1249-1254.

## Testing

- ShellCheck clean (zero violations)
- Semantically equivalent — `\` line continuation produces identical behaviour
- No logic changes; pure formatting

Resolves #20234


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.87 plugin for [OpenCode](https://opencode.ai) v1.14.19 with claude-sonnet-4-6 spent 2m and 8,266 tokens on this as a headless worker.