### PR TITLE
GH#20226: GH#20226: fix ambiguous Muvera storage comparison language in vector-search.md

### DIFF
--- a/.agents/tools/database/vector-search.md
+++ b/.agents/tools/database/vector-search.md
@@ -282,9 +282,9 @@ Plain-text embeddings lose signature blocks, stamps, tables, and redaction boxes
 | Single-vector (default) | Baseline | Baseline | Text-dominant docs |
 | ColBERT late interaction | +15-30% on phrase/token-level lookups | ~10x (token-per-vector) | Legal discovery, precision-critical lookups |
 | ModernVBERT / visual transformer | Captures table cells, signatures, redaction boxes | ~10-15x | Forms, financial filings, stamped PDFs |
-| Muvera FDE compression | ColBERT recall, ~3x storage reduction | ~3x vs single-vector | ColBERT at production scale |
+| Muvera FDE compression | ColBERT recall, ~3x reduction vs ColBERT | ~3x vs single-vector | ColBERT at production scale |
 
-**Muvera** (Fixed-Dimensional Encoding) compresses multivectors into a single fixed-size vector while preserving late-interaction recall within ~1-2% at ~3x storage reduction vs single-vector. This makes ColBERT-scale retrieval feasible at production cost by eliminating most of the ~10x storage premium over single-vector models.
+**Muvera** (Fixed-Dimensional Encoding) compresses multivectors into a single fixed-size vector while preserving late-interaction recall within ~1-2% at ~3x storage cost vs single-vector. This makes ColBERT-scale retrieval feasible at production cost by eliminating most of the ~10x storage premium over single-vector models.
 
 **When to pay the cost**: Legal discovery, financial filings, and forms-heavy corpora where signatures, stamps, or table structure determine the correct answer. Text-dominant corpora (plain contracts, statutes, meeting notes) get negligible recall gain and should stay on single-vector.
 


### PR DESCRIPTION
## Summary

Fixed two logically inconsistent storage comparison phrases in the Muvera FDE section of vector-search.md: (1) table line 285 Recall gain column changed from 'ColBERT recall, ~3x storage reduction' to 'ColBERT recall, ~3x reduction vs ColBERT' to clarify the baseline; (2) paragraph line 287 changed from '~3x storage reduction vs single-vector' to '~3x storage cost vs single-vector' since Muvera costs 3x more than single-vector (the reduction is vs ColBERT's ~10x, not vs single-vector).

## Files Changed

.agents/tools/database/vector-search.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Read lines 280-290 of .agents/tools/database/vector-search.md post-edit to confirm both phrases are internally consistent with the table's Storage cost column.

Resolves #20226


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.87 plugin for [OpenCode](https://opencode.ai) v1.14.19 with claude-sonnet-4-6 spent 1m and 3,066 tokens on this as a headless worker.