### PR TITLE
GH#20236: GH#20236: fix _decompose_issue_exists to use --paginate and jq --arg

### DIFF
--- a/.agents/scripts/auto-decomposer-scanner.sh
+++ b/.agents/scripts/auto-decomposer-scanner.sh
@@ -184,20 +184,19 @@ _nudge_age_hours() {
 _decompose_issue_exists() {
 	local repo="$1"
 	local parent_num="$2"
-	local title_prefix="Decompose parent-task #${parent_num}"
-	# Filter by exact title prefix via jq rather than `in:title` substring
-	# search. `in:title` matches substrings — a title like "Decompose parent-
-	# task #12345 context" would false-positive-hit when looking for #1234.
-	# We list all issues carrying the dedup label (bounded — one per parent)
-	# and filter client-side for an exact prefix match. --paginate keeps the
-	# filter correct once the scanner has been running long enough that the
-	# dedup-labelled set exceeds one page.
+	# Titles are "Decompose parent-task #NNN: <title>" — include the colon
+	# so startswith("#1234:") cannot false-positive-match "#12345:". Filter
+	# client-side via jq --arg to avoid shell interpolation in the filter
+	# expression. --paginate retrieves all dedup-labelled issues regardless
+	# of count; stderr is not suppressed so jq errors surface in logs.
+	local title_prefix="Decompose parent-task #${parent_num}:"
 	local count
 	count=$(gh issue list --repo "$repo" --label "$SCANNER_LABEL" \
-		--state all --limit 1000 \
+		--state all --paginate \
 		--json title \
-		--jq "[.[] | select(.title | startswith(\"${title_prefix}\"))] | length" \
-		2>/dev/null || echo "0")
+		| jq --arg prefix "$title_prefix" \
+			'[.[] | select(.title | startswith($prefix))] | length' \
+		|| echo "0")
 	[[ "$count" =~ ^[1-9][0-9]*$ ]]
 }
 


### PR DESCRIPTION
## Summary

Replaced --limit 1000 with --paginate, added colon to title_prefix to prevent #1234 matching #12345, switched to jq --arg for proper variable passing, removed 2>/dev/null stderr suppression so jq errors surface in logs.

## Files Changed

.agents/scripts/auto-decomposer-scanner.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck passes with zero violations. The startswith(title_prefix) filter with colon suffix is verified correct against the issue title format 'Decompose parent-task #NNN: <title>' defined at line 303.

Resolves #20236


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.87 plugin for [OpenCode](https://opencode.ai) v1.14.19 with claude-sonnet-4-6 spent 3m and 9,126 tokens on this as a headless worker.