### PR TITLE
GH#20237: remove 2>/dev/null from gh api idempotency check in issue-sync-lib.sh

### DIFF
--- a/.agents/scripts/issue-sync-lib.sh
+++ b/.agents/scripts/issue-sync-lib.sh
@@ -756,7 +756,7 @@ _post_parent_task_no_markers_warning() {
 	# combine --slurp with --jq (gh api rejects). Stream per-page and count.
 	existing=$(gh api --paginate "repos/${slug}/issues/${issue_num}/comments" \
 		--jq ".[] | select(.body | contains(\"${marker}\")) | .id" \
-		2>/dev/null | wc -l | tr -d ' ') || existing=""
+		| wc -l | tr -d ' ') || existing=""
 	if [[ "$existing" =~ ^[1-9][0-9]*$ ]]; then
 		return 1
 	fi


### PR DESCRIPTION
## Summary

Removed 2>/dev/null stderr suppression from the idempotency check in _post_parent_task_no_markers_warning (issue-sync-lib.sh:757). The --paginate flag was already added by t2572 (PR #20249); this change makes gh api and jq errors visible in logs while the || existing='' fallback still provides best-effort degradation on API failure.

## Files Changed

.agents/scripts/issue-sync-lib.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck passes (pre-existing SC2016 info only, unrelated to this change); manual review of lines 756-762 confirms correct behavior

Resolves #20237


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.87 plugin for [OpenCode](https://opencode.ai) v1.14.19 with claude-sonnet-4-6 spent 2m and 7,066 tokens on this as a headless worker.