### PR TITLE
GH#20227: GH#20227: export TMP and INFO_LOG vars alongside stub functions in test-override-flags.sh

### DIFF
--- a/.agents/scripts/tests/test-override-flags.sh
+++ b/.agents/scripts/tests/test-override-flags.sh
@@ -178,7 +178,7 @@ print_error() { printf '[ERROR] %s\n' "$*" >>"$INFO_LOG"; return 0; }
 export -f print_info print_warning print_error
 find_project_root() { echo "$TMP"; }
 detect_repo_slug() { echo "test/test"; }
-export -f find_project_root detect_repo_slug
+export TMP INFO_LOG; export -f find_project_root detect_repo_slug
 
 # Test 1a: FORCE_ENRICH=true logs the bypass
 reset_log


### PR DESCRIPTION
## Summary

Added `export TMP INFO_LOG` at line 181 of test-override-flags.sh alongside the existing `export -f find_project_root detect_repo_slug`. These variables are referenced by the exported stub functions but were previously unexported, meaning external scripts called by helper functions would not have them in their environment. All 18/18 tests pass.

## Files Changed

.agents/scripts/tests/test-override-flags.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Ran `bash .agents/scripts/tests/test-override-flags.sh` — 18/18 tests passed. Ran `shellcheck .agents/scripts/tests/test-override-flags.sh` — zero violations.

Resolves #20227


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.87 plugin for [OpenCode](https://opencode.ai) v1.14.19 with claude-sonnet-4-6 spent 1m and 4,254 tokens on this as a headless worker.