### PR TITLE
GH#20254: reduce cmd_install complexity in install-pre-push-guards.sh

### DIFF
--- a/.agents/scripts/install-pre-push-guards.sh
+++ b/.agents/scripts/install-pre-push-guards.sh
@@ -258,37 +258,57 @@ HOOK_HEADER
 }
 
 #######################################
-# cmd_install — install or refresh guard(s)
+# _install_parse_guard_filter — parse --guard CLI argument.
+# Prints the guard filter name on stdout; returns 1 on error.
 #######################################
-cmd_install() {
-	local _guard_filter="all"
+_install_parse_guard_filter() {
+	local _filter="all"
 	while [[ $# -gt 0 ]]; do
 		local _opt="$1"
 		case "$_opt" in
 		--guard)
 			[[ $# -ge 2 ]] || { print_error "missing value for --guard"; return 1; }
 			local _val="$2"
-			_guard_filter="$_val"
+			_filter="$_val"
 			shift 2
 			;;
 		*) print_error "install: unknown argument: $_opt"; return 1 ;;
 		esac
 	done
+	printf '%s' "$_filter"
+	return 0
+}
+
+#######################################
+# _install_reject_unmanaged_hook — abort if hook exists but isn't managed by us.
+# Args: _hook_path
+# Returns 1 (and prints guidance) if hook exists and is not aidevops-managed.
+#######################################
+_install_reject_unmanaged_hook() {
+	local _hook_path="$1"
+	[[ ! -f "$_hook_path" ]] && return 0
+	_hook_is_managed "$_hook_path" && return 0
+	print_error "existing pre-push hook at $_hook_path is NOT managed by aidevops"
+	print_error "Refusing to overwrite. To chain manually, add each guard to your hook:"
+	local _gh
+	for _gh in "privacy-guard-pre-push.sh" "complexity-regression-pre-push.sh" "scope-guard-pre-push.sh" "credential-emission-pre-push.sh"; do
+		# shellcheck disable=SC2016
+		print_error '  ${REPO}/.agents/hooks/'"$_gh"' "$@" < /dev/stdin'
+	done
+	return 1
+}
+
+#######################################
+# cmd_install — install or refresh guard(s)
+#######################################
+cmd_install() {
+	local _guard_filter
+	_guard_filter=$(_install_parse_guard_filter "$@") || return 1
 
 	local _hook_path
 	_hook_path=$(_hook_path) || return 1
 
-	# Refuse to overwrite unmanaged hooks
-	if [[ -f "$_hook_path" ]] && ! _hook_is_managed "$_hook_path"; then
-		print_error "existing pre-push hook at $_hook_path is NOT managed by aidevops"
-		print_error "Refusing to overwrite. To chain manually, add each guard to your hook:"
-		local _gh
-		for _gh in "privacy-guard-pre-push.sh" "complexity-regression-pre-push.sh" "scope-guard-pre-push.sh" "credential-emission-pre-push.sh"; do
-			# shellcheck disable=SC2016
-			print_error '  ${REPO}/.agents/hooks/'"$_gh"' "$@" < /dev/stdin'
-		done
-		return 1
-	fi
+	_install_reject_unmanaged_hook "$_hook_path" || return 1
 
 	# Determine which guards are currently in the hook
 	local _cur_privacy=0 _cur_complexity=0 _cur_scope=0 _cur_credential=0


### PR DESCRIPTION
## Summary

`cmd_install()` in `.agents/scripts/install-pre-push-guards.sh` exceeded the 100-line function complexity threshold at 106 lines (scanner: GH#20254).

## Changes

Extract two focused helper functions from `cmd_install()`:

- **`_install_parse_guard_filter()`** (~20 lines): handles `--guard` CLI argument parsing. Prints the filter name on stdout, returns 1 on error. Allows `cmd_install` to use a clean one-liner: `_guard_filter=$(_install_parse_guard_filter "$@") || return 1`.

- **`_install_reject_unmanaged_hook()`** (~13 lines): encapsulates the unmanaged hook refusal block. Short-circuits immediately when hook doesn't exist or is already managed; prints error guidance and returns 1 otherwise.

`cmd_install()` is now **86 lines** (was 106) — an orchestrator that delegates to helpers.

## Verification

- `bash -n .agents/scripts/install-pre-push-guards.sh` → syntax OK
- `shellcheck .agents/scripts/install-pre-push-guards.sh` → zero violations
- `cmd_install` line count: 86 (under 100 threshold)
- No functional change — identical runtime behaviour

## Complexity Bump Justification

Not applicable. This PR reduces function complexity (106 → 86 lines). No new complexity violations are introduced.

Resolves #20254