### PR TITLE
GH#20250: t2576: update test-pulse-parent-nudge.sh tests 3 & 4 to match current gh api patterns

### DIFF
--- a/.agents/scripts/tests/test-pulse-parent-nudge.sh
+++ b/.agents/scripts/tests/test-pulse-parent-nudge.sh
@@ -107,15 +107,15 @@ assert_grep_fixed \
 # --- Idempotency check ---
 
 assert_grep \
-	"3: helper queries existing comments via gh api for idempotency" \
-	'gh api "repos/\$\{slug\}/issues/\$\{parent_num\}/comments"' \
+	"3: helper queries existing comments via gh api --paginate for idempotency" \
+	'gh api --paginate "repos/\$\{slug\}/issues/\$\{parent_num\}/comments"' \
 	"$TARGET"
 
 # --- Comment posting ---
 
 assert_grep \
-	"4: helper posts via gh issue comment" \
-	'gh issue comment "\$parent_num" --repo "\$slug"' \
+	"4: helper posts via gh_issue_comment wrapper" \
+	'gh_issue_comment "\$parent_num" --repo "\$slug"' \
 	"$TARGET"
 
 # --- Reconcile function counter ---


### PR DESCRIPTION
## Summary

Updated test assertions in test-pulse-parent-nudge.sh to match current implementation:
- Test 3: Changed pattern from 'gh api' to 'gh api --paginate' for idempotency check
- Test 4: Changed pattern from 'gh issue comment' to 'gh_issue_comment' wrapper
Both tests now pass, and t2572 regression tests still pass.

## Files Changed

.agents/scripts/tests/test-pulse-parent-nudge.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Ran test-pulse-parent-nudge.sh: all 11 tests pass. Ran test-parent-decomposition-nudge-dedup.sh: all 12 tests pass.

Resolves #20250


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.87 plugin for [OpenCode](https://opencode.ai) v1.14.19 with claude-haiku-4-5 spent 56s and 2,208 tokens on this as a headless worker.