### PR TITLE
GH#20292: t2582: add Slack token allowlist to secretlintrc

### DIFF
--- a/.secretlintrc.json
+++ b/.secretlintrc.json
@@ -30,7 +30,13 @@
           "id": "@secretlint/secretlint-rule-basicauth"
         },
         {
-          "id": "@secretlint/secretlint-rule-slack"
+          "id": "@secretlint/secretlint-rule-slack",
+          "options": {
+            "allows": [
+              "xoxb-ABCDEFGHIJKLM-1234567890-abcdefghij",
+              "xoxp-ABCDEFGHIJKLM-1234567890-abcdefghij"
+            ]
+          }
         },
         {
           "id": "@secretlint/secretlint-rule-sendgrid"


### PR DESCRIPTION
## Summary

Added allowlist entries for fake Slack tokens (xoxb- and xoxp- patterns) in test fixture to prevent secretlint false positives during version-manager release preflight.

## Files Changed

.secretlintrc.json

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified: npx secretlint passes on test-credential-transcript-scrub.sh, version-manager.sh release patch --dry-run passes preflight

Resolves #20292


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.88 plugin for [OpenCode](https://opencode.ai) v1.14.19 with claude-haiku-4-5 spent 56s and 2,663 tokens on this as a headless worker.