### PR TITLE
GH#20291: fix: allow t-ID prose references when claimed in repo history

### DIFF
--- a/.agents/hooks/task-id-collision-guard.sh
+++ b/.agents/hooks/task-id-collision-guard.sh
@@ -192,6 +192,42 @@ _branch_has_claim() {
 }
 
 # ---------------------------------------------------------------------------
+# Check whether a given t-ID has a matching claim commit anywhere in the
+# repo history (git log --all). This catches t-IDs that were claimed in
+# prior merged PRs and are now being referenced in prose (e.g., "the t2574
+# REST fallback covers..."). The claim commit subject must match
+# `chore: claim tNNN[..tMMM] [nonce]` (single or range form).
+#
+# Returns 0 if a claim commit is found, 1 otherwise.
+# ---------------------------------------------------------------------------
+_repo_has_claim() {
+	local tid="${1:-}"
+	local num
+	num=$(printf '%s' "$tid" | tr -d 't')
+	if ! [[ "$num" =~ ^[0-9]+$ ]]; then
+		return 1
+	fi
+	# Look for an exact single-ID claim first.
+	if git log --all --format='%s' 2>/dev/null |
+		grep -qE "^chore: claim t0*${num}( |\$|\\[)"; then
+		return 0
+	fi
+	# Look for a range claim that covers num: chore: claim tA..tB
+	local line low high
+	while IFS= read -r line; do
+		# Extract tA and tB from "chore: claim t00A..t00B [nonce]"
+		if [[ "$line" =~ ^chore:\ claim\ t0*([0-9]+)\.\.t0*([0-9]+) ]]; then
+			low="${BASH_REMATCH[1]}"
+			high="${BASH_REMATCH[2]}"
+			if ((10#$num >= 10#$low && 10#$num <= 10#$high)); then
+				return 0
+			fi
+		fi
+	done < <(git log --all --format='%s' 2>/dev/null)
+	return 1
+}
+
+# ---------------------------------------------------------------------------
 # Extract all tNNN references from text.
 # Outputs one per line.
 # ---------------------------------------------------------------------------
@@ -350,15 +386,22 @@ _check_message() {
 			# Phase 1 (t2567 / GH#20001): reuse-without-claim detection.
 			# A t-ID ≤ counter exists globally, but must be claimed on THIS
 			# branch. If no matching `chore: claim tNNN` commit is found on
-			# merge-base..HEAD, fall through to the linked-issue check so the
-			# worker can still authorise via `Resolves/Closes/Fixes/Ref/For
-			# #NNN` (matching issue title). If neither claim commit nor
-			# linked issue confirms, this becomes a violation (reuse).
+			# merge-base..HEAD, check if it was claimed anywhere in repo history
+			# (git log --all) — this handles cross-references to prior merged PRs.
+			# If repo-wide claim exists, allow it. Otherwise, fall through to the
+			# linked-issue check so the worker can still authorise via
+			# `Resolves/Closes/Fixes/Ref/For #NNN` (matching issue title).
+			# If neither claim commit nor linked issue confirms, this becomes a
+			# violation (reuse).
 			if _branch_has_claim "$tid"; then
 				_debug "$tid claimed on this branch — allowed"
 				continue
 			fi
-			_debug "$tid ≤ counter but no branch claim — verifying via linked issues"
+			if _repo_has_claim "$tid"; then
+				_debug "$tid claimed in repo history — allowed (cross-reference)"
+				continue
+			fi
+			_debug "$tid ≤ counter but no branch/repo claim — verifying via linked issues"
 			local verify_rc
 			_verify_tid_via_issues "$tid" "$closing_issues"
 			verify_rc=$?
@@ -366,7 +409,7 @@ _check_message() {
 				return 2
 			fi
 			if [[ "$verify_rc" -eq 1 ]]; then
-				violations="${violations}  ${tid} — ≤ counter ${counter}, but no 'chore: claim ${tid}' commit on this branch and no linked issue title contains ${tid}\n"
+				violations="${violations}  ${tid} — ≤ counter ${counter}, but no 'chore: claim ${tid}' commit on this branch, in repo history, or linked issue title\n"
 			fi
 			continue
 		fi

--- a/.agents/scripts/tests/test-task-id-collision-guard.sh
+++ b/.agents/scripts/tests/test-task-id-collision-guard.sh
@@ -718,10 +718,81 @@ test_check_pr_allows_pr_title_tid_confirmed_via_body() {
 }
 
 # ---------------------------------------------------------------------------
+# Test case 15: Allow t-ID ≤ counter when claimed in repo history (GH#20291)
+# Scenario: PR body contains prose reference to a t-ID that was claimed in
+# a prior merged PR. The guard should allow it via repo-wide claim lookup.
+# ---------------------------------------------------------------------------
+test_repo_wide_claim_in_prose() {
+	local name="case-15: allow t-ID ≤ counter when claimed in repo history (prose reference)"
+	# Counter = 100; t50 ≤ counter but claimed in prior merged commit.
+	# PR body contains prose "the t50 REST fallback covers..." — should allow.
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir'" RETURN
+
+	# Create a temporary git repo with a prior merged claim commit
+	local base_repo="${tmpdir}/base"
+	mkdir -p "$base_repo"
+	git -C "$base_repo" init -q
+	git -C "$base_repo" config user.email "test@test.local"
+	git -C "$base_repo" config user.name "Test"
+	git -C "$base_repo" config commit.gpgsign false
+	git -C "$base_repo" config tag.gpgsign false
+	printf '100' >"${base_repo}/.task-counter"
+	git -C "$base_repo" add .task-counter
+	git -C "$base_repo" commit -q -m "init"
+
+	# Create a work repo with a prior merged claim commit on main
+	local work_repo="${tmpdir}/work"
+	git -C "$base_repo" clone -q . "$work_repo"
+	git -C "$work_repo" config user.email "test@test.local"
+	git -C "$work_repo" config user.name "Test"
+	git -C "$work_repo" config commit.gpgsign false
+	git -C "$work_repo" config tag.gpgsign false
+
+	# Add a prior claim commit on main (simulating a merged PR)
+	touch "${work_repo}/t50-marker.txt"
+	git -C "$work_repo" add "t50-marker.txt"
+	git -C "$work_repo" commit -q -m "chore: claim t50 [prior-merge]"
+	git -C "$work_repo" push -q origin main
+
+	# Create a feature branch for the new PR
+	git -C "$work_repo" checkout -q -b feature/t51-new-feature
+	touch "${work_repo}/feature.txt"
+	git -C "$work_repo" add "feature.txt"
+	git -C "$work_repo" commit -q -m "feat: add new feature"
+
+	# Create a commit message with prose reference to t50 (claimed in prior merge)
+	local msg_file="${tmpdir}/msg.txt"
+	cat >"$msg_file" <<'EOF'
+feat: implement feature
+
+The t50 REST fallback covers GraphQL exhaustion scenarios.
+This feature builds on that foundation.
+EOF
+
+	# Run the guard in the feature branch context
+	local rc
+	(
+		cd "$work_repo" || exit 1
+		TASK_ID_GUARD_DEBUG=0 bash "$GUARD" "$msg_file"
+	)
+	rc=$?
+
+	if [[ "$rc" -eq 0 ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected exit 0 (t50 claimed in repo history), got $rc"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
 main() {
-	printf 'Running task-id-collision-guard tests...\n\n'
+	printf 'Running ta[redacted-credential] tests...\n\n'
 
 	test_rejects_invented_tid
 	test_allows_claimed_tid
@@ -737,6 +808,7 @@ main() {
 	test_ref_keyword_without_matching_title
 	test_check_pr_rejects_invented_tid_in_title
 	test_check_pr_allows_pr_title_tid_confirmed_via_body
+	test_repo_wide_claim_in_prose
 
 	printf '\n'
 	printf 'Results: %s passed, %s failed\n' "$PASS" "$FAIL"


### PR DESCRIPTION
## Summary

Added _repo_has_claim() function to check git log --all for prior claim commits. This fixes false-positives when PR body prose references t-IDs that were claimed in prior merged PRs. The guard now checks: (1) branch claim, (2) repo-wide claim (NEW), (3) linked issue title.

## Files Changed

.agents/hooks/task-id-collision-guard.sh,.agents/scripts/tests/test-task-id-collision-guard.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** All 15 test cases pass, including new case-15 for repo-wide claim in prose

Resolves #20291


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.88 plugin for [OpenCode](https://opencode.ai) v1.14.19 with claude-haiku-4-5 spent 2m and 3,098 tokens on this as a headless worker.