### PR TITLE
t2687: fix health-dashboard dedup under GraphQL rate-limit pressure

### DIFF
--- a/.agents/scripts/migrate-health-issue-duplicates-t2687.sh
+++ b/.agents/scripts/migrate-health-issue-duplicates-t2687.sh
@@ -169,6 +169,78 @@ has_label() {
 	return $?
 }
 
+_backfill_origin_worker_labels() {
+	# Backfill origin:worker on every health-dashboard issue missing it
+	# (independent from dedup — even the kept issue might be missing it).
+	local enriched="$1"
+	local repo="$2"
+	local line
+	while IFS= read -r line; do
+		[[ -z "$line" ]] && continue
+		local num labels
+		num=$(printf '%s' "$line" | jq -r '.number')
+		labels=$(printf '%s' "$line" | jq -c '.labels')
+		if ! has_label "$labels" "origin:worker"; then
+			local flags=(--add-label "origin:worker")
+			# Mutual exclusion (.agents/AGENTS.md "Origin label mutual exclusion").
+			if has_label "$labels" "origin:interactive"; then
+				flags+=(--remove-label "origin:interactive")
+			fi
+			if has_label "$labels" "origin:worker-takeover"; then
+				flags+=(--remove-label "origin:worker-takeover")
+			fi
+			log_info "  backfill origin:worker on #${num} (${repo})"
+			run_gh issue edit "$num" --repo "$repo" "${flags[@]}" \
+				|| log_warn "    origin:worker backfill failed for #${num}"
+		fi
+	done < <(printf '%s' "$enriched")
+	return 0
+}
+
+_unpin_duplicate_issue() {
+	local close_num="$1"
+	local repo="$2"
+	if ((DRY_RUN)); then
+		log_dry "gh api graphql unpinIssue issueId=<node_id_for_#${close_num}>"
+		return 0
+	fi
+	local node_id
+	node_id=$(gh issue view "$close_num" --repo "$repo" --json id --jq '.id' 2>/dev/null || echo "")
+	[[ -z "$node_id" ]] && return 0
+	gh api graphql -f query="
+		mutation {
+			unpinIssue(input: {issueId: \"${node_id}\"}) {
+				issue { number }
+			}
+		}" >/dev/null 2>&1 || true
+	return 0
+}
+
+_close_duplicate_groups() {
+	local groups_summary="$1"
+	local repo="$2"
+	local grp
+	while IFS= read -r grp; do
+		[[ -z "$grp" ]] && continue
+		local role user keep close_list
+		role=$(printf '%s' "$grp" | jq -r '.role')
+		user=$(printf '%s' "$grp" | jq -r '.user')
+		keep=$(printf '%s' "$grp" | jq -r '.issues[0].number')
+		close_list=$(printf '%s' "$grp" | jq -r '.issues[1:] | .[].number')
+		log_info "  dedup group role=${role} user=${user}: keep #${keep}, close $(echo "$close_list" | wc -w | tr -d ' ')"
+
+		local close_num
+		while IFS= read -r close_num; do
+			[[ -z "$close_num" ]] && continue
+			local comment="Closing duplicate ${role} health issue — superseded by #${keep}. Root cause: GraphQL rate-limit window on 2026-04-21 (t2574 REST fallback covered CREATE but not READ paths). See GH#20301 for the systemic fix."
+			_unpin_duplicate_issue "$close_num" "$repo"
+			run_gh issue close "$close_num" --repo "$repo" --comment "$comment" \
+				|| log_warn "    close failed for #${close_num}"
+		done <<<"$close_list"
+	done <<<"$groups_summary"
+	return 0
+}
+
 process_repo() {
 	local slug="$1"
 	log_info "Scanning ${slug}"
@@ -208,29 +280,7 @@ process_repo() {
 		)
 	}')
 
-	# Backfill origin:worker on every health-dashboard issue missing it
-	# (independent from dedup — even the kept issue might be missing it).
-	local line
-	while IFS= read -r line; do
-		[[ -z "$line" ]] && continue
-		local num labels
-		num=$(printf '%s' "$line" | jq -r '.number')
-		labels=$(printf '%s' "$line" | jq -c '.labels')
-		if ! has_label "$labels" "origin:worker"; then
-			local flags=(--add-label "origin:worker")
-			# Remove sibling origin labels (mutual exclusion per
-			# .agents/AGENTS.md "Origin label mutual exclusion").
-			if has_label "$labels" "origin:interactive"; then
-				flags+=(--remove-label "origin:interactive")
-			fi
-			if has_label "$labels" "origin:worker-takeover"; then
-				flags+=(--remove-label "origin:worker-takeover")
-			fi
-			log_info "  backfill origin:worker on #${num} (${slug})"
-			run_gh issue edit "$num" --repo "$slug" "${flags[@]}" \
-				|| log_warn "    origin:worker backfill failed for #${num}"
-		fi
-	done < <(printf '%s' "$enriched")
+	_backfill_origin_worker_labels "$enriched" "$slug"
 
 	# Group by (role, user). For each group with >1 members, keep the
 	# newest by createdAt and close the rest.
@@ -247,40 +297,7 @@ process_repo() {
 		return 0
 	fi
 
-	local grp
-	while IFS= read -r grp; do
-		[[ -z "$grp" ]] && continue
-		local role user keep close_list
-		role=$(printf '%s' "$grp" | jq -r '.role')
-		user=$(printf '%s' "$grp" | jq -r '.user')
-		keep=$(printf '%s' "$grp" | jq -r '.issues[0].number')
-		close_list=$(printf '%s' "$grp" | jq -r '.issues[1:] | .[].number')
-		log_info "  dedup group role=${role} user=${user}: keep #${keep}, close $(echo "$close_list" | wc -w | tr -d ' ')"
-
-		local close_num
-		while IFS= read -r close_num; do
-			[[ -z "$close_num" ]] && continue
-			local comment="Closing duplicate ${role} health issue — superseded by #${keep}. Root cause: GraphQL rate-limit window on 2026-04-21 (t2574 REST fallback covered CREATE but not READ paths). See GH#20301 for the systemic fix."
-			# Best-effort unpin (no-op for unpinned/contributor issues).
-			if ((DRY_RUN)); then
-				log_dry "gh api graphql unpinIssue issueId=<node_id_for_#${close_num}>"
-			else
-				local node_id
-				node_id=$(gh issue view "$close_num" --repo "$slug" --json id --jq '.id' 2>/dev/null || echo "")
-				if [[ -n "$node_id" ]]; then
-					gh api graphql -f query="
-						mutation {
-							unpinIssue(input: {issueId: \"${node_id}\"}) {
-								issue { number }
-							}
-						}" >/dev/null 2>&1 || true
-				fi
-			fi
-			run_gh issue close "$close_num" --repo "$slug" --comment "$comment" \
-				|| log_warn "    close failed for #${close_num}"
-		done <<<"$close_list"
-	done <<<"$groups_summary"
-
+	_close_duplicate_groups "$groups_summary" "$slug"
 	return 0
 }
 

--- a/.agents/scripts/migrate-health-issue-duplicates-t2687.sh
+++ b/.agents/scripts/migrate-health-issue-duplicates-t2687.sh
@@ -1,0 +1,321 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# migrate-health-issue-duplicates-t2687.sh
+#
+# One-shot migration that closes duplicate [Supervisor:*]/[Contributor:*]
+# health-dashboard issues created during the 2026-04-21 GraphQL rate-limit
+# window (GH#20301). Also backfills the `origin:worker` label on any
+# `source:health-dashboard` issue missing it (surfaced on #20298).
+#
+# Strategy:
+#   - Iterate ~/.config/aidevops/repos.json `initialized_repos[]` entries
+#     where `pulse: true` and not `local_only`.
+#   - For each repo, list open issues with label `source:health-dashboard`.
+#   - Group by (runner_user, role_label). Runner_user is extracted from
+#     the issue title via the `[Supervisor:user]` / `[Contributor:user]`
+#     prefix. Role is derived from the `supervisor` or `contributor` label.
+#   - Keep the newest issue per group (by createdAt).
+#   - Close the older ones with an explanatory comment linking to GH#20301.
+#   - Backfill `origin:worker` on every surviving health-dashboard issue
+#     that is missing it. Remove `origin:interactive` / `origin:worker-takeover`
+#     on the same call (origin labels are mutually exclusive).
+#   - Write marker file on success so repeated runs are no-ops.
+#
+# Usage:
+#   migrate-health-issue-duplicates-t2687.sh [--dry-run] [--force] \
+#     [--slug <owner/repo>]
+#
+# Exits 0 on success, 1 on any critical failure, 2 on invalid args.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+# shellcheck disable=SC2034  # referenced via setup log prefix below
+MARKER_FILE="${HOME}/.aidevops/logs/.migrated-health-issue-duplicates-t2687"
+REPOS_JSON="${HOME}/.config/aidevops/repos.json"
+LOG_PREFIX="[migrate-t2687]"
+
+# ------------------------------------------------------------------
+# CLI parsing
+# ------------------------------------------------------------------
+DRY_RUN=0
+FORCE=0
+TARGET_SLUG=""
+
+usage() {
+	cat <<EOF
+migrate-health-issue-duplicates-t2687.sh
+
+One-shot migration for health-dashboard duplicates (GH#20301).
+
+Usage:
+  $(basename "$0") [--dry-run] [--force] [--slug owner/repo]
+
+Flags:
+  --dry-run      Report actions without making changes.
+  --force        Run even if the marker file exists.
+  --slug SLUG    Only process the given owner/repo (default: all pulse repos).
+  -h, --help     Show this help.
+
+Reads:  ${REPOS_JSON}
+Marker: ${MARKER_FILE}
+EOF
+}
+
+parse_args() {
+	# Wrapped in a function so positional refs use `local var="$N"` pattern
+	# per aidevops Quality Rules ("never use $1 directly in function bodies").
+	while (($# > 0)); do
+		local arg="$1"
+		case "$arg" in
+			--dry-run) DRY_RUN=1; shift ;;
+			--force) FORCE=1; shift ;;
+			--slug)
+				local next_val="${2:-}"
+				if [[ $# -lt 2 || -z "$next_val" ]]; then
+					echo "${LOG_PREFIX} --slug requires an argument" >&2
+					exit 2
+				fi
+				TARGET_SLUG="$next_val"
+				shift 2
+				;;
+			-h|--help) usage; exit 0 ;;
+			*)
+				echo "${LOG_PREFIX} unknown arg: $arg" >&2
+				usage >&2
+				exit 2
+				;;
+		esac
+	done
+	return 0
+}
+parse_args "$@"
+
+# ------------------------------------------------------------------
+# Guards
+# ------------------------------------------------------------------
+if ! command -v gh >/dev/null 2>&1; then
+	echo "${LOG_PREFIX} gh CLI not found" >&2
+	exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+	echo "${LOG_PREFIX} jq not found" >&2
+	exit 1
+fi
+
+if [[ ! -f "$REPOS_JSON" ]]; then
+	echo "${LOG_PREFIX} repos.json not found at $REPOS_JSON" >&2
+	exit 1
+fi
+
+if [[ -f "$MARKER_FILE" && $FORCE -eq 0 ]]; then
+	echo "${LOG_PREFIX} marker file exists (${MARKER_FILE}) — use --force to re-run"
+	exit 0
+fi
+
+mkdir -p "$(dirname "$MARKER_FILE")" 2>/dev/null || true
+
+# ------------------------------------------------------------------
+# Logging helpers
+# ------------------------------------------------------------------
+log_info() { printf '%s INFO  %s\n' "$LOG_PREFIX" "$*"; return 0; }
+log_warn() { printf '%s WARN  %s\n' "$LOG_PREFIX" "$*" >&2; return 0; }
+log_do()   { printf '%s DO    %s\n' "$LOG_PREFIX" "$*"; return 0; }
+log_dry()  { printf '%s DRY   %s\n' "$LOG_PREFIX" "$*"; return 0; }
+
+run_gh() {
+	# Wrapper that logs & respects --dry-run. Silences gh's own output
+	# internally so call sites do NOT need `>/dev/null 2>&1` — which
+	# would also mask our audit log line. Returns gh's exit code on
+	# real-run, 0 on dry-run.
+	if ((DRY_RUN)); then
+		log_dry "gh $*"
+		return 0
+	fi
+	log_do "gh $*"
+	local rc=0
+	gh "$@" >/dev/null 2>&1 || rc=$?
+	return "$rc"
+}
+
+# ------------------------------------------------------------------
+# Build list of target repos
+# ------------------------------------------------------------------
+resolve_target_slugs() {
+	if [[ -n "$TARGET_SLUG" ]]; then
+		printf '%s\n' "$TARGET_SLUG"
+		return 0
+	fi
+	jq -r '.initialized_repos[]? | select(.pulse == true) | select(.local_only // false | not) | .slug // empty' \
+		"$REPOS_JSON" 2>/dev/null |
+		grep -E '^[^/]+/[^/]+$' || true
+	return 0
+}
+
+# ------------------------------------------------------------------
+# Process one repo
+# ------------------------------------------------------------------
+# Note: runner_user and role are extracted inline via the jq enrichment
+# step in process_repo() — no separate shell helpers needed. Keeping
+# the extraction logic in one place prevents drift between the grouping
+# key (jq) and any shell-side re-derivation.
+
+has_label() {
+	local labels_json="$1" name="$2"
+	printf '%s' "$labels_json" | jq -e --arg n "$name" '.[] | select(.name == $n)' >/dev/null 2>&1
+	return $?
+}
+
+process_repo() {
+	local slug="$1"
+	log_info "Scanning ${slug}"
+
+	local issues_json
+	if ! issues_json=$(gh issue list --repo "$slug" \
+		--label source:health-dashboard --state open \
+		--json number,title,labels,createdAt --limit 100 2>/dev/null); then
+		log_warn "Failed to list issues for ${slug} — skipping"
+		return 0
+	fi
+
+	local total
+	total=$(printf '%s' "$issues_json" | jq 'length')
+	if [[ "${total:-0}" -eq 0 ]]; then
+		log_info "  no health-dashboard issues in ${slug}"
+		return 0
+	fi
+	log_info "  found ${total} health-dashboard issue(s) in ${slug}"
+
+	# Enrich every issue with a grouping key "<role>:<runner_user>" so we
+	# can group via jq. Issues missing role or runner_user get "UNGROUPED"
+	# and are skipped (but still reported).
+	local enriched
+	enriched=$(printf '%s' "$issues_json" | jq -c '.[] | {
+		number: .number,
+		title: .title,
+		labels: .labels,
+		createdAt: .createdAt,
+		role: (
+			if (.labels | map(.name) | index("supervisor")) then "supervisor"
+			elif (.labels | map(.name) | index("contributor")) then "contributor"
+			else "" end
+		),
+		user: (
+			(.title | capture("^\\[(?<role>Supervisor|Contributor):(?<user>[^]]+)\\]").user) // ""
+		)
+	}')
+
+	# Backfill origin:worker on every health-dashboard issue missing it
+	# (independent from dedup — even the kept issue might be missing it).
+	local line
+	while IFS= read -r line; do
+		[[ -z "$line" ]] && continue
+		local num labels
+		num=$(printf '%s' "$line" | jq -r '.number')
+		labels=$(printf '%s' "$line" | jq -c '.labels')
+		if ! has_label "$labels" "origin:worker"; then
+			local flags=(--add-label "origin:worker")
+			# Remove sibling origin labels (mutual exclusion per
+			# .agents/AGENTS.md "Origin label mutual exclusion").
+			if has_label "$labels" "origin:interactive"; then
+				flags+=(--remove-label "origin:interactive")
+			fi
+			if has_label "$labels" "origin:worker-takeover"; then
+				flags+=(--remove-label "origin:worker-takeover")
+			fi
+			log_info "  backfill origin:worker on #${num} (${slug})"
+			run_gh issue edit "$num" --repo "$slug" "${flags[@]}" \
+				|| log_warn "    origin:worker backfill failed for #${num}"
+		fi
+	done < <(printf '%s' "$enriched")
+
+	# Group by (role, user). For each group with >1 members, keep the
+	# newest by createdAt and close the rest.
+	local groups_summary
+	groups_summary=$(printf '%s' "$enriched" |
+		jq -sc 'group_by(.role + "\u0001" + .user) | .[] | {
+			role: .[0].role,
+			user: .[0].user,
+			issues: (sort_by(.createdAt) | reverse)
+		} | select(.role != "" and .user != "") | select(.issues | length > 1)')
+
+	if [[ -z "$groups_summary" ]]; then
+		log_info "  no duplicates in ${slug}"
+		return 0
+	fi
+
+	local grp
+	while IFS= read -r grp; do
+		[[ -z "$grp" ]] && continue
+		local role user keep close_list
+		role=$(printf '%s' "$grp" | jq -r '.role')
+		user=$(printf '%s' "$grp" | jq -r '.user')
+		keep=$(printf '%s' "$grp" | jq -r '.issues[0].number')
+		close_list=$(printf '%s' "$grp" | jq -r '.issues[1:] | .[].number')
+		log_info "  dedup group role=${role} user=${user}: keep #${keep}, close $(echo "$close_list" | wc -w | tr -d ' ')"
+
+		local close_num
+		while IFS= read -r close_num; do
+			[[ -z "$close_num" ]] && continue
+			local comment="Closing duplicate ${role} health issue — superseded by #${keep}. Root cause: GraphQL rate-limit window on 2026-04-21 (t2574 REST fallback covered CREATE but not READ paths). See GH#20301 for the systemic fix."
+			# Best-effort unpin (no-op for unpinned/contributor issues).
+			if ((DRY_RUN)); then
+				log_dry "gh api graphql unpinIssue issueId=<node_id_for_#${close_num}>"
+			else
+				local node_id
+				node_id=$(gh issue view "$close_num" --repo "$slug" --json id --jq '.id' 2>/dev/null || echo "")
+				if [[ -n "$node_id" ]]; then
+					gh api graphql -f query="
+						mutation {
+							unpinIssue(input: {issueId: \"${node_id}\"}) {
+								issue { number }
+							}
+						}" >/dev/null 2>&1 || true
+				fi
+			fi
+			run_gh issue close "$close_num" --repo "$slug" --comment "$comment" \
+				|| log_warn "    close failed for #${close_num}"
+		done <<<"$close_list"
+	done <<<"$groups_summary"
+
+	return 0
+}
+
+# ------------------------------------------------------------------
+# Main
+# ------------------------------------------------------------------
+main() {
+	log_info "script=$(basename "$0") dry_run=${DRY_RUN} force=${FORCE} target=${TARGET_SLUG:-all}"
+
+	local -a target_slugs=()
+	while IFS= read -r s; do
+		[[ -z "$s" ]] && continue
+		target_slugs+=("$s")
+	done < <(resolve_target_slugs)
+
+	if [[ "${#target_slugs[@]}" -eq 0 ]]; then
+		log_warn "no pulse-enabled repos found in ${REPOS_JSON}"
+		exit 0
+	fi
+
+	log_info "target_repos=${#target_slugs[@]}"
+
+	local slug
+	for slug in "${target_slugs[@]}"; do
+		process_repo "$slug" || log_warn "process_repo failed for ${slug} (continuing)"
+	done
+
+	if ((DRY_RUN == 0)); then
+		touch "$MARKER_FILE"
+		log_info "migration complete — marker written: ${MARKER_FILE}"
+	else
+		log_info "dry-run complete — no changes made, no marker written"
+	fi
+
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/stats-health-dashboard.sh
+++ b/.agents/scripts/stats-health-dashboard.sh
@@ -90,6 +90,101 @@ _list_health_issues_by_role_label() {
 # Output: issue number to stdout, or empty string (confirmed-not-found),
 #         or "__QUERY_FAILED__" (caller must skip creation this cycle).
 #######################################
+# Validate a cached health-issue number: check it still exists and is OPEN.
+# Returns (via stdout):
+#   - the cached number if still valid
+#   - empty if the cache entry points to a CLOSED issue (caller should re-resolve)
+#   - $_HEALTH_QUERY_FAILED_SENTINEL if `gh issue view` failed (rate-limit/network)
+# Side effects: removes the cache file on CLOSED state, unpins on CLOSED supervisor.
+_try_cached_health_issue_lookup() {
+	local health_issue_file="$1"
+	local repo_slug="$2"
+	local runner_role="$3"
+
+	[[ ! -f "$health_issue_file" ]] && return 0  # empty stdout
+
+	local cached_number
+	cached_number=$(cat "$health_issue_file" 2>/dev/null || echo "")
+	[[ -z "$cached_number" ]] && return 0
+
+	local issue_state rc=0
+	issue_state=$(gh issue view "$cached_number" --repo "$repo_slug" --json state --jq '.state' 2>/dev/null) || rc=$?
+
+	if [[ $rc -ne 0 ]]; then
+		# Query failed (rate limit, network, API 5xx). Preserve cache and return
+		# it — caller still points to a valid-as-far-as-we-know issue.
+		echo "[stats] Health issue: cache validation failed for #${cached_number} in ${repo_slug} (rc=${rc}) — preserving cache" >>"${LOGFILE:-/dev/null}"
+		echo "$cached_number"
+		return 0
+	fi
+
+	if [[ "$issue_state" == "CLOSED" ]]; then
+		[[ "$runner_role" == "supervisor" ]] && _unpin_health_issue "$cached_number" "$repo_slug"
+		rm -f "$health_issue_file" 2>/dev/null || true
+		return 0  # empty → caller re-resolves
+	fi
+
+	if [[ "$issue_state" != "OPEN" ]]; then
+		# Unexpected state (empty, unknown enum). Preserve cache defensively.
+		echo "[stats] Health issue: unexpected state '${issue_state}' for #${cached_number} in ${repo_slug} — preserving cache" >>"${LOGFILE:-/dev/null}"
+		echo "$cached_number"
+		return 0
+	fi
+
+	echo "$cached_number"
+	return 0
+}
+
+#######################################
+# Close all duplicate health issues (all but the first) from a jq array.
+# Arguments: label_results_json keep_number repo_slug runner_role
+_close_health_issue_duplicates() {
+	local label_results="$1" keep_number="$2" repo_slug="$3" runner_role="$4"
+
+	local dup_count
+	dup_count=$(printf '%s' "$label_results" | jq 'length' 2>/dev/null || echo "0")
+	[[ "${dup_count:-0}" -le 1 ]] && return 0
+
+	local dup_numbers
+	dup_numbers=$(printf '%s' "$label_results" | jq -r '.[1:][].number' 2>/dev/null || echo "")
+	while IFS= read -r dup_num; do
+		[[ -z "$dup_num" ]] && continue
+		[[ "$runner_role" == "supervisor" ]] && _unpin_health_issue "$dup_num" "$repo_slug"
+		gh issue close "$dup_num" --repo "$repo_slug" \
+			--comment "Closing duplicate ${runner_role} health issue — superseded by #${keep_number}." 2>/dev/null || true
+	done <<<"$dup_numbers"
+	return 0
+}
+
+#######################################
+# Title-based fallback lookup with label backfill.
+# Returns issue number if found, empty if not, $_HEALTH_QUERY_FAILED_SENTINEL on failure.
+_try_title_health_issue_fallback() {
+	local runner_prefix="$1" repo_slug="$2" runner_user="$3" role_label="$4" role_display="$5"
+
+	local title_result rc=0
+	title_result=$(gh issue list --repo "$repo_slug" \
+		--search "in:title ${runner_prefix}" \
+		--state open --json number,title \
+		--jq "[.[] | select(.title | startswith(\"${runner_prefix}\"))][0].number" 2>/dev/null) || rc=$?
+
+	if [[ $rc -ne 0 ]]; then
+		echo "[stats] Health issue: title lookup failed for ${runner_prefix} in ${repo_slug} (rc=${rc}) — abstaining this cycle" >>"${LOGFILE:-/dev/null}"
+		echo "$_HEALTH_QUERY_FAILED_SENTINEL"
+		return 0
+	fi
+
+	local health_issue_number="${title_result:-}"
+	if [[ -n "$health_issue_number" ]]; then
+		gh label create "$runner_user" --repo "$repo_slug" --color "0E8A16" \
+			--description "${role_display} runner: ${runner_user}" --force 2>/dev/null || true
+		gh issue edit "$health_issue_number" --repo "$repo_slug" \
+			--add-label "$role_label" --add-label "$runner_user" 2>/dev/null || true
+	fi
+	echo "$health_issue_number"
+	return 0
+}
+
 _find_health_issue() {
 	local repo_slug="$1"
 	local runner_user="$2"
@@ -99,48 +194,20 @@ _find_health_issue() {
 	local role_display="$6"
 	local health_issue_file="$7"
 
-	local health_issue_number=""
-	local rc=0
+	local health_issue_number
+	health_issue_number=$(_try_cached_health_issue_lookup "$health_issue_file" "$repo_slug" "$runner_role")
 
-	# Try cached issue number first
-	if [[ -f "$health_issue_file" ]]; then
-		health_issue_number=$(cat "$health_issue_file" 2>/dev/null || echo "")
+	# Sentinel from cache lookup is defensive only; current behaviour preserves
+	# the cached number on error, but downstream checks still need it to pass
+	# through. Short-circuit on sentinel.
+	if [[ "$health_issue_number" == "$_HEALTH_QUERY_FAILED_SENTINEL" ]]; then
+		echo "$_HEALTH_QUERY_FAILED_SENTINEL"
+		return 0
 	fi
 
-	# Validate cached issue still exists and is open
-	if [[ -n "$health_issue_number" ]]; then
-		local issue_state
-		rc=0
-		issue_state=$(gh issue view "$health_issue_number" --repo "$repo_slug" --json state --jq '.state' 2>/dev/null) || rc=$?
-
-		if [[ $rc -ne 0 ]]; then
-			# Query failed (rate limit, network, API 5xx). Preserve cache
-			# and skip the label/title dedup scans to reduce API pressure
-			# while the upstream issue is being resolved.
-			echo "[stats] Health issue: cache validation failed for #${health_issue_number} in ${repo_slug} (rc=${rc}) — preserving cache" >>"${LOGFILE:-/dev/null}"
-			echo "$health_issue_number"
-			return 0
-		fi
-
-		if [[ "$issue_state" == "CLOSED" ]]; then
-			if [[ "$runner_role" == "supervisor" ]]; then
-				_unpin_health_issue "$health_issue_number" "$repo_slug"
-			fi
-			health_issue_number=""
-			rm -f "$health_issue_file" 2>/dev/null || true
-		elif [[ "$issue_state" != "OPEN" ]]; then
-			# Unexpected state (empty, unknown enum). Preserve cache defensively —
-			# GitHub only returns OPEN/CLOSED under normal conditions.
-			echo "[stats] Health issue: unexpected state '${issue_state}' for #${health_issue_number} in ${repo_slug} — preserving cache" >>"${LOGFILE:-/dev/null}"
-			echo "$health_issue_number"
-			return 0
-		fi
-	fi
-
-	# Search by labels (more reliable than title search)
+	# Search by labels (more reliable than title search) if cache gave nothing.
 	if [[ -z "$health_issue_number" ]]; then
-		local label_results
-		rc=0
+		local label_results rc=0
 		label_results=$(_list_health_issues_by_role_label \
 			"$repo_slug" "$role_label" "$runner_user" "$role_display" 2>/dev/null) || rc=$?
 
@@ -152,52 +219,15 @@ _find_health_issue() {
 			return 0
 		fi
 
-		# Normalize to empty array on empty/malformed output (defensive default
-		# only — rc=0 here means the command succeeded).
 		label_results="${label_results:-[]}"
-
 		health_issue_number=$(printf '%s' "$label_results" | jq -r '.[0].number // empty' 2>/dev/null || echo "")
-
-		# Dedup: close all but the newest
-		local dup_count
-		dup_count=$(printf '%s' "$label_results" | jq 'length' 2>/dev/null || echo "0")
-		if [[ "${dup_count:-0}" -gt 1 ]]; then
-			local dup_numbers
-			dup_numbers=$(printf '%s' "$label_results" | jq -r '.[1:][].number' 2>/dev/null || echo "")
-			while IFS= read -r dup_num; do
-				[[ -z "$dup_num" ]] && continue
-				if [[ "$runner_role" == "supervisor" ]]; then
-					_unpin_health_issue "$dup_num" "$repo_slug"
-				fi
-				gh issue close "$dup_num" --repo "$repo_slug" \
-					--comment "Closing duplicate ${runner_role} health issue — superseded by #${health_issue_number}." 2>/dev/null || true
-			done <<<"$dup_numbers"
-		fi
+		_close_health_issue_duplicates "$label_results" "$health_issue_number" "$repo_slug" "$runner_role"
 	fi
 
-	# Fallback: title-based search with label backfill
+	# Fallback: title-based search with label backfill.
 	if [[ -z "$health_issue_number" ]]; then
-		local title_result
-		rc=0
-		title_result=$(gh issue list --repo "$repo_slug" \
-			--search "in:title ${runner_prefix}" \
-			--state open --json number,title \
-			--jq "[.[] | select(.title | startswith(\"${runner_prefix}\"))][0].number" 2>/dev/null) || rc=$?
-
-		if [[ $rc -ne 0 ]]; then
-			echo "[stats] Health issue: title lookup failed for ${runner_prefix} in ${repo_slug} (rc=${rc}) — abstaining this cycle" >>"${LOGFILE:-/dev/null}"
-			echo "$_HEALTH_QUERY_FAILED_SENTINEL"
-			return 0
-		fi
-
-		health_issue_number="${title_result:-}"
-
-		if [[ -n "$health_issue_number" ]]; then
-			gh label create "$runner_user" --repo "$repo_slug" --color "0E8A16" \
-				--description "${role_display} runner: ${runner_user}" --force 2>/dev/null || true
-			gh issue edit "$health_issue_number" --repo "$repo_slug" \
-				--add-label "$role_label" --add-label "$runner_user" 2>/dev/null || true
-		fi
+		health_issue_number=$(_try_title_health_issue_fallback \
+			"$runner_prefix" "$repo_slug" "$runner_user" "$role_label" "$role_display")
 	fi
 
 	echo "$health_issue_number"
@@ -1264,6 +1294,37 @@ _extract_body_counts() {
 #   $5 - cross-repo person stats markdown (pre-computed by update_health_issues)
 # Returns: 0 always (best-effort, never breaks the pulse)
 #######################################
+# t2687: extracted activity guard — returns 0 to proceed, 1 to skip.
+# Only runs when the cached health-issue file is absent (would create a new one).
+_check_health_issue_activity_guard() {
+	local repo_slug="$1"
+	local repo_path="$2"
+	local runner_user="$3"
+	local health_issue_file="$4"
+
+	[[ -f "$health_issue_file" ]] && return 0
+
+	local guard_pr_count guard_assigned_count guard_worker_count
+	guard_pr_count=$(gh pr list --repo "$repo_slug" --state open \
+		--json number --jq 'length' 2>/dev/null || echo "0")
+	guard_assigned_count=$(gh issue list --repo "$repo_slug" \
+		--assignee "$runner_user" --state open \
+		--json number --jq 'length' 2>/dev/null || echo "0")
+
+	local _guard_fields=()
+	while IFS= read -r -d '' _gf; do
+		_guard_fields+=("$_gf")
+	done < <(_scan_active_workers "${repo_path:-}")
+	guard_worker_count="${_guard_fields[1]:-0}"
+
+	if [[ "${guard_pr_count:-0}" -eq 0 && "${guard_assigned_count:-0}" -eq 0 && "${guard_worker_count:-0}" -eq 0 ]]; then
+		echo "[stats] Health issue: skipping creation for ${repo_slug} — no active PRs, issues, or workers" \
+			>>"${LOGFILE:-/dev/null}"
+		return 1
+	fi
+	return 0
+}
+
 _update_health_issue_for_repo() {
 	local repo_slug="$1"
 	local repo_path="$2"
@@ -1289,29 +1350,8 @@ _update_health_issue_for_repo() {
 	local health_issue_file="${cache_dir}/health-issue-${runner_user}-${role_label}-${slug_safe}"
 	mkdir -p "$cache_dir"
 
-	# Guard: skip health issue creation for repos with no activity (GH#15959).
-	# Only applies when no cached issue exists (i.e. this would CREATE a new one).
-	# Existing health issues are still updated normally so the dashboard shows idle state.
-	if [[ ! -f "$health_issue_file" ]]; then
-		local guard_pr_count guard_assigned_count guard_worker_output guard_worker_count
-		guard_pr_count=$(gh pr list --repo "$repo_slug" --state open \
-			--json number --jq 'length' 2>/dev/null || echo "0")
-		guard_assigned_count=$(gh issue list --repo "$repo_slug" \
-			--assignee "$runner_user" --state open \
-			--json number --jq 'length' 2>/dev/null || echo "0")
-		# Parse NUL-delimited output: workers_md\0worker_count\0
-		local _guard_fields=()
-		while IFS= read -r -d '' _gf; do
-			_guard_fields+=("$_gf")
-		done < <(_scan_active_workers "${repo_path:-}")
-		local guard_worker_count="${_guard_fields[1]:-0}"
-
-		if [[ "${guard_pr_count:-0}" -eq 0 && "${guard_assigned_count:-0}" -eq 0 && "${guard_worker_count:-0}" -eq 0 ]]; then
-			echo "[stats] Health issue: skipping creation for ${repo_slug} — no active PRs, issues, or workers" \
-				>>"${LOGFILE:-/dev/null}"
-			return 0
-		fi
-	fi
+	_check_health_issue_activity_guard \
+		"$repo_slug" "$repo_path" "$runner_user" "$health_issue_file" || return 0
 
 	local health_issue_number
 	health_issue_number=$(_resolve_health_issue_number \

--- a/.agents/scripts/stats-health-dashboard.sh
+++ b/.agents/scripts/stats-health-dashboard.sh
@@ -26,8 +26,58 @@
 [[ -n "${_STATS_HEALTH_DASHBOARD_LOADED:-}" ]] && return 0
 _STATS_HEALTH_DASHBOARD_LOADED=1
 
+# t2687: sentinel returned by _find_health_issue when a gh query fails
+# (rate limit, network, API 5xx). Callers treat this as "abstain this
+# cycle" — never fall through to _create_health_issue, which would
+# create a duplicate while the dedup lookups are silently unable to
+# see existing ones.
+readonly _HEALTH_QUERY_FAILED_SENTINEL="__QUERY_FAILED__"
+
+#######################################
+# List open health issues matching a role + runner_user pair, filtered
+# by title-prefix. Helper centralises the jq filter so `_find_health_issue`
+# and `_periodic_health_issue_dedup` share one query definition.
+#
+# Arguments:
+#   $1 - repo slug
+#   $2 - role label (supervisor|contributor)
+#   $3 - runner user
+#   $4 - role display (Supervisor|Contributor)
+# Output: JSON array sorted newest-first (by number desc).
+# Returns: gh's exit code (non-zero on rate limit / network / API error).
+#######################################
+_list_health_issues_by_role_label() {
+	local repo_slug="$1"
+	local role_label="$2"
+	local runner_user="$3"
+	local role_display="$4"
+
+	gh issue list --repo "$repo_slug" \
+		--label "$role_label" --label "$runner_user" \
+		--state open --json number,title \
+		--jq "[.[] | select(.title | startswith(\"[${role_display}:\"))] | sort_by(.number) | reverse"
+}
+
 #######################################
 # Find an existing health issue by cache, labels, or title search.
+#
+# Error-classification policy (t2687, GH#20301):
+#
+#   Under GraphQL rate-limit pressure, the pre-t2687 logic silently
+#   treated `gh issue view|list` failures as "not found" and let
+#   _resolve_health_issue_number fall through to _create_health_issue.
+#   Combined with the asymmetric t2574 REST fallback (which made CREATE
+#   succeed during exhaustion while READ paths still failed), this
+#   produced 19 duplicate [Supervisor:*]/[Contributor:*] issues across
+#   the fleet on 2026-04-21.
+#
+#   The fix distinguishes success-with-empty-result from query-failure:
+#     - Cache validation query fails (rc != 0):   preserve cache, return cached number.
+#     - Cache validation returns CLOSED:          unpin, clear cache, fall through to lookup.
+#     - Cache validation returns unknown state:   preserve cache defensively (log warning).
+#     - Label/title lookup fails (rc != 0):       emit __QUERY_FAILED__ sentinel so the
+#                                                 caller abstains from creation this cycle.
+#     - Label/title lookup returns empty array:   confirmed-not-found, safe to create.
 #
 # Arguments:
 #   $1 - repo slug
@@ -37,7 +87,8 @@ _STATS_HEALTH_DASHBOARD_LOADED=1
 #   $5 - role label (supervisor|contributor)
 #   $6 - role display (Supervisor|Contributor)
 #   $7 - cache file path
-# Output: issue number to stdout (empty if not found)
+# Output: issue number to stdout, or empty string (confirmed-not-found),
+#         or "__QUERY_FAILED__" (caller must skip creation this cycle).
 #######################################
 _find_health_issue() {
 	local repo_slug="$1"
@@ -49,6 +100,7 @@ _find_health_issue() {
 	local health_issue_file="$7"
 
 	local health_issue_number=""
+	local rc=0
 
 	# Try cached issue number first
 	if [[ -f "$health_issue_file" ]]; then
@@ -58,23 +110,51 @@ _find_health_issue() {
 	# Validate cached issue still exists and is open
 	if [[ -n "$health_issue_number" ]]; then
 		local issue_state
-		issue_state=$(gh issue view "$health_issue_number" --repo "$repo_slug" --json state --jq '.state' 2>/dev/null || echo "")
-		if [[ "$issue_state" != "OPEN" ]]; then
+		rc=0
+		issue_state=$(gh issue view "$health_issue_number" --repo "$repo_slug" --json state --jq '.state' 2>/dev/null) || rc=$?
+
+		if [[ $rc -ne 0 ]]; then
+			# Query failed (rate limit, network, API 5xx). Preserve cache
+			# and skip the label/title dedup scans to reduce API pressure
+			# while the upstream issue is being resolved.
+			echo "[stats] Health issue: cache validation failed for #${health_issue_number} in ${repo_slug} (rc=${rc}) — preserving cache" >>"${LOGFILE:-/dev/null}"
+			echo "$health_issue_number"
+			return 0
+		fi
+
+		if [[ "$issue_state" == "CLOSED" ]]; then
 			if [[ "$runner_role" == "supervisor" ]]; then
 				_unpin_health_issue "$health_issue_number" "$repo_slug"
 			fi
 			health_issue_number=""
 			rm -f "$health_issue_file" 2>/dev/null || true
+		elif [[ "$issue_state" != "OPEN" ]]; then
+			# Unexpected state (empty, unknown enum). Preserve cache defensively —
+			# GitHub only returns OPEN/CLOSED under normal conditions.
+			echo "[stats] Health issue: unexpected state '${issue_state}' for #${health_issue_number} in ${repo_slug} — preserving cache" >>"${LOGFILE:-/dev/null}"
+			echo "$health_issue_number"
+			return 0
 		fi
 	fi
 
 	# Search by labels (more reliable than title search)
 	if [[ -z "$health_issue_number" ]]; then
 		local label_results
-		label_results=$(gh issue list --repo "$repo_slug" \
-			--label "$role_label" --label "$runner_user" \
-			--state open --json number,title \
-			--jq "[.[] | select(.title | startswith(\"[${role_display}:\"))] | sort_by(.number) | reverse" 2>/dev/null || echo "[]")
+		rc=0
+		label_results=$(_list_health_issues_by_role_label \
+			"$repo_slug" "$role_label" "$runner_user" "$role_display" 2>/dev/null) || rc=$?
+
+		if [[ $rc -ne 0 ]]; then
+			# Abstain this cycle. Emit sentinel so _resolve_health_issue_number
+			# refuses to create a duplicate.
+			echo "[stats] Health issue: label lookup failed for ${role_label}+${runner_user} in ${repo_slug} (rc=${rc}) — abstaining this cycle" >>"${LOGFILE:-/dev/null}"
+			echo "$_HEALTH_QUERY_FAILED_SENTINEL"
+			return 0
+		fi
+
+		# Normalize to empty array on empty/malformed output (defensive default
+		# only — rc=0 here means the command succeeded).
+		label_results="${label_results:-[]}"
 
 		health_issue_number=$(printf '%s' "$label_results" | jq -r '.[0].number // empty' 2>/dev/null || echo "")
 
@@ -97,10 +177,21 @@ _find_health_issue() {
 
 	# Fallback: title-based search with label backfill
 	if [[ -z "$health_issue_number" ]]; then
-		health_issue_number=$(gh issue list --repo "$repo_slug" \
+		local title_result
+		rc=0
+		title_result=$(gh issue list --repo "$repo_slug" \
 			--search "in:title ${runner_prefix}" \
 			--state open --json number,title \
-			--jq "[.[] | select(.title | startswith(\"${runner_prefix}\"))][0].number" 2>/dev/null || echo "")
+			--jq "[.[] | select(.title | startswith(\"${runner_prefix}\"))][0].number" 2>/dev/null) || rc=$?
+
+		if [[ $rc -ne 0 ]]; then
+			echo "[stats] Health issue: title lookup failed for ${runner_prefix} in ${repo_slug} (rc=${rc}) — abstaining this cycle" >>"${LOGFILE:-/dev/null}"
+			echo "$_HEALTH_QUERY_FAILED_SENTINEL"
+			return 0
+		fi
+
+		health_issue_number="${title_result:-}"
+
 		if [[ -n "$health_issue_number" ]]; then
 			gh label create "$runner_user" --repo "$repo_slug" --color "0E8A16" \
 				--description "${role_display} runner: ${runner_user}" --force 2>/dev/null || true
@@ -220,6 +311,16 @@ _resolve_health_issue_number() {
 		"$repo_slug" "$runner_user" "$runner_role" "$runner_prefix" \
 		"$role_label" "$role_display" "$health_issue_file")
 
+	# t2687: honour the query-failed sentinel from _find_health_issue.
+	# When the API was unreachable for the dedup lookups, abstain from
+	# creation this cycle — otherwise we create duplicates every time
+	# GraphQL is exhausted (the root cause of GH#20301).
+	if [[ "$health_issue_number" == "$_HEALTH_QUERY_FAILED_SENTINEL" ]]; then
+		echo "[stats] Health issue: abstaining from create/update cycle for ${repo_slug} (runner=${runner_user}, role=${runner_role}) — dedup lookups failed" >>"${LOGFILE:-/dev/null}"
+		echo ""
+		return 0
+	fi
+
 	if [[ -z "$health_issue_number" ]]; then
 		health_issue_number=$(_create_health_issue \
 			"$repo_slug" "$runner_user" "$runner_role" "$runner_prefix" \
@@ -227,6 +328,104 @@ _resolve_health_issue_number() {
 	fi
 
 	echo "$health_issue_number"
+	return 0
+}
+
+#######################################
+# Periodic label-based dedup scan (t2687, GH#20301).
+#
+# Even when the cached health issue is valid and returns quickly via
+# _find_health_issue, the label-based dedup block inside that function
+# is bypassed because the cache-hit path short-circuits before the
+# label scan runs. That means duplicates that slipped in during past
+# GraphQL rate-limit windows never get closed automatically — they
+# require either a cache invalidation or manual intervention.
+#
+# This helper runs the same label-based dedup at most once per hour
+# per repo-runner-role tuple, keyed by a timestamp state file. On
+# query failure (rc != 0), the state file is NOT updated so the next
+# pulse cycle retries — avoids starving the scan during an extended
+# rate-limit window.
+#
+# Arguments:
+#   $1 - repo slug
+#   $2 - runner user
+#   $3 - runner role (supervisor|contributor)
+#   $4 - role label (supervisor|contributor)
+#   $5 - role display (Supervisor|Contributor)
+#   $6 - current (kept) health issue number
+# Env:
+#   HEALTH_DEDUP_INTERVAL - seconds between scans per (repo, runner, role).
+#                           Default 3600 (1 hour).
+# Returns: 0 always (best-effort, never breaks the pulse).
+#######################################
+_periodic_health_issue_dedup() {
+	local repo_slug="$1"
+	local runner_user="$2"
+	local runner_role="$3"
+	local role_label="$4"
+	local role_display="$5"
+	local current_issue="$6"
+
+	[[ -z "$repo_slug" || -z "$runner_user" || -z "$role_label" || -z "$current_issue" ]] && return 0
+
+	local slug_safe="${repo_slug//\//-}"
+	local cache_dir="${HOME}/.aidevops/logs"
+	local state_file="${cache_dir}/health-dedup-last-scan-${runner_user}-${role_label}-${slug_safe}"
+	local interval="${HEALTH_DEDUP_INTERVAL:-3600}"
+
+	# Throttle: skip if last scan was recent
+	if [[ -f "$state_file" ]]; then
+		local last_scan_epoch now_epoch elapsed
+		last_scan_epoch=$(stat -f %m "$state_file" 2>/dev/null || stat -c %Y "$state_file" 2>/dev/null || echo 0)
+		now_epoch=$(date +%s)
+		elapsed=$((now_epoch - last_scan_epoch))
+		if [[ $elapsed -lt $interval ]]; then
+			return 0
+		fi
+	fi
+
+	mkdir -p "$cache_dir" 2>/dev/null || true
+
+	local label_results rc=0
+	label_results=$(_list_health_issues_by_role_label \
+		"$repo_slug" "$role_label" "$runner_user" "$role_display" 2>/dev/null) || rc=$?
+
+	if [[ $rc -ne 0 ]]; then
+		# Leave state_file alone — retry next pulse cycle.
+		echo "[stats] Health issue: periodic dedup scan failed for ${repo_slug} (rc=${rc}) — will retry next cycle" >>"${LOGFILE:-/dev/null}"
+		return 0
+	fi
+
+	label_results="${label_results:-[]}"
+
+	local total_count
+	total_count=$(printf '%s' "$label_results" | jq 'length' 2>/dev/null || echo "0")
+
+	if [[ "${total_count:-0}" -gt 1 ]]; then
+		local dup_numbers
+		# Close every issue in the label-match set except the one we're
+		# currently using. The cached/resolved issue is the canonical one
+		# because its body+title are up-to-date with this pulse.
+		dup_numbers=$(printf '%s' "$label_results" | jq -r --arg keep "$current_issue" \
+			'.[] | select((.number | tostring) != $keep) | .number' 2>/dev/null || echo "")
+		while IFS= read -r dup_num; do
+			[[ -z "$dup_num" ]] && continue
+			# _unpin_health_issue is already best-effort and a no-op for
+			# unpinned (contributor) issues, so call unconditionally.
+			# Duplicate supervisor issues CAN be pinned in pathological
+			# cases (stale pin from a pre-rate-limit canonical).
+			_unpin_health_issue "$dup_num" "$repo_slug"
+			gh issue close "$dup_num" --repo "$repo_slug" \
+				--comment "Closing duplicate ${runner_role} health issue — superseded by #${current_issue} (t2687 periodic dedup). Root cause likely a past GraphQL rate-limit window; see GH#20301." 2>/dev/null || true
+			echo "[stats] Health issue: periodic dedup closed #${dup_num} in ${repo_slug} (kept #${current_issue})" >>"${LOGFILE:-/dev/null}"
+		done <<<"$dup_numbers"
+	fi
+
+	# Update state file timestamp (even when no duplicates found) so we
+	# don't re-query every cycle.
+	touch "$state_file" 2>/dev/null || true
+
 	return 0
 }
 
@@ -1120,6 +1319,14 @@ _update_health_issue_for_repo() {
 		"$role_label" "$role_label_color" "$role_label_desc" \
 		"$role_display" "$health_issue_file")
 	[[ -z "$health_issue_number" ]] && return 0
+
+	# t2687: periodic dedup scan (at most once per HEALTH_DEDUP_INTERVAL
+	# seconds per repo+runner+role, default 1h). Closes duplicates that
+	# slipped in during past GraphQL rate-limit windows when the cache
+	# was valid so the label-scan inside _find_health_issue never ran.
+	_periodic_health_issue_dedup \
+		"$repo_slug" "$runner_user" "$runner_role" \
+		"$role_label" "$role_display" "$health_issue_number"
 
 	if [[ "$runner_role" == "supervisor" ]]; then
 		_ensure_health_issue_pinned "$health_issue_number" "$repo_slug" "$runner_user"

--- a/.agents/scripts/tests/test-find-health-issue-rate-limit.sh
+++ b/.agents/scripts/tests/test-find-health-issue-rate-limit.sh
@@ -1,0 +1,371 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-find-health-issue-rate-limit.sh — t2687 / GH#20301 regression guard.
+#
+# Asserts that _find_health_issue and _resolve_health_issue_number in
+# stats-health-dashboard.sh refuse to create duplicates when `gh` query
+# commands fail (rate limit, network, API 5xx).
+#
+# Production failure (2026-04-21 UTC on marcusquinn/aidevops and fleet):
+#   GraphQL rate-limit window left 19 orphaned duplicate [Supervisor:*]
+#   health issues across 7 repos. The t2574 REST fallback for CREATE
+#   paths made CREATE succeed under rate limit, but READ paths (gh issue
+#   view, gh issue list) had no fallback and silently returned empty —
+#   so the dedup lookups treated success-with-empty identically to
+#   confirmed-not-found and fell through to _create_health_issue.
+#
+# Fix (t2687): _find_health_issue classifies gh failure (rc != 0) as
+# query-failure and emits the __QUERY_FAILED__ sentinel on the lookup
+# paths; _resolve_health_issue_number treats the sentinel as abstain
+# (echoes empty, returns without calling _create_health_issue); and
+# _update_health_issue_for_repo runs a periodic label-based dedup scan
+# at most once per HEALTH_DEDUP_INTERVAL seconds (default 1h) to close
+# duplicates that slipped in during past rate-limit windows.
+#
+# Test scenarios:
+#   1. cache-hit + gh issue view fails (rc=4)     → cache preserved, cached number echoed
+#   2. cache-hit + gh issue view returns CLOSED   → cache cleared, fall through
+#   3. no cache + gh issue list label fails (rc=4) → sentinel emitted
+#   4. no cache + gh issue list title fails (rc=4) → sentinel emitted
+#   5. no cache + two issues via label search      → older closed, newer returned
+#   6. _resolve_health_issue_number sees sentinel  → echo empty, no _create_health_issue call
+#   7. _resolve_health_issue_number sees empty     → _create_health_issue invoked
+#   8. _periodic_health_issue_dedup within interval → no-op (skips gh calls)
+#   9. _periodic_health_issue_dedup past interval + failing list → state file NOT updated
+#  10. _periodic_health_issue_dedup past interval + two issues    → older closed
+#
+# Stub strategy: define `gh` as a shell function. Shell functions take
+# precedence over PATH binaries. Per-call responses are sequenced via
+# STUB_GH_* arrays that the test sets before invoking the function
+# under test.
+
+set -uo pipefail
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR_TEST}/.." && pwd)" || exit 1
+
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_BLUE=$'\033[0;34m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_BLUE="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf '  %sPASS%s %s\n' "$TEST_GREEN" "$TEST_NC" "$1"
+	return 0
+}
+
+fail() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '  %sFAIL%s %s\n' "$TEST_RED" "$TEST_NC" "$1"
+	if [[ -n "${2:-}" ]]; then
+		printf '       %s\n' "$2"
+	fi
+	return 0
+}
+
+section() {
+	printf '\n%s== %s ==%s\n' "$TEST_BLUE" "$1" "$TEST_NC"
+	return 0
+}
+
+# =============================================================================
+# Sandbox
+# =============================================================================
+TMP=$(mktemp -d -t t2687.XXXXXX)
+trap 'rm -rf "$TMP"' EXIT
+
+GH_CALLS="${TMP}/gh_calls.log"
+export HOME="${TMP}/home"
+mkdir -p "${HOME}/.aidevops/logs"
+
+export LOGFILE="${TMP}/logfile.log"
+: >"$LOGFILE"
+
+# =============================================================================
+# Stub controls
+# =============================================================================
+# Arrays pair patterns (matched as substrings of "$*") with payloads + rc.
+# First pattern that matches a call wins. Default (no match) = rc 0, empty.
+declare -a STUB_GH_PATTERNS=()
+declare -a STUB_GH_RESPONSES=()
+declare -a STUB_GH_RCS=()
+
+reset_stubs() {
+	STUB_GH_PATTERNS=()
+	STUB_GH_RESPONSES=()
+	STUB_GH_RCS=()
+	: >"$GH_CALLS"
+	return 0
+}
+
+stub_gh_for() {
+	# $1 substring pattern, $2 response payload, $3 rc (default 0)
+	STUB_GH_PATTERNS+=("$1")
+	STUB_GH_RESPONSES+=("$2")
+	STUB_GH_RCS+=("${3:-0}")
+	return 0
+}
+
+# shellcheck disable=SC2317  # invoked via command-name resolution in tested function
+gh() {
+	local call="$*"
+	printf '%s\n' "$call" >>"$GH_CALLS"
+	local i
+	for i in "${!STUB_GH_PATTERNS[@]}"; do
+		if [[ "$call" == *"${STUB_GH_PATTERNS[$i]}"* ]]; then
+			if [[ -n "${STUB_GH_RESPONSES[$i]}" ]]; then
+				printf '%s' "${STUB_GH_RESPONSES[$i]}"
+			fi
+			return "${STUB_GH_RCS[$i]}"
+		fi
+	done
+	# Default: success with no output
+	return 0
+}
+
+# Stub _unpin_health_issue and _create_health_issue so we can assert on
+# call counts without hitting the GitHub API. Placed before sourcing so
+# the sourced file sees them as pre-defined; the include guard prevents
+# the module from redefining them after source (no — the module DOES
+# redefine them). So we must override AFTER source.
+# Track invocations via counter files in $TMP.
+
+# =============================================================================
+# Source the unit under test
+# =============================================================================
+# The stats-health-dashboard.sh module has an include guard and is intended
+# to be sourced by stats-functions.sh. We source it directly — it doesn't
+# actually exercise the orchestrator's bootstrap constants at parse time.
+# shellcheck source=../stats-health-dashboard.sh
+source "${SCRIPTS_DIR}/stats-health-dashboard.sh"
+
+# Override _unpin_health_issue and _create_health_issue after source —
+# the module defines them, and we want to observe rather than execute.
+CREATE_CALLS="${TMP}/create_calls.log"
+UNPIN_CALLS="${TMP}/unpin_calls.log"
+: >"$CREATE_CALLS"
+: >"$UNPIN_CALLS"
+
+# shellcheck disable=SC2317
+_unpin_health_issue() {
+	printf '%s\n' "$*" >>"$UNPIN_CALLS"
+	return 0
+}
+
+# shellcheck disable=SC2317
+_create_health_issue() {
+	printf '%s\n' "$*" >>"$CREATE_CALLS"
+	echo "99999"
+	return 0
+}
+
+# =============================================================================
+# Helpers
+# =============================================================================
+create_count() { wc -l <"$CREATE_CALLS" | tr -d ' '; return 0; }
+gh_call_count() { wc -l <"$GH_CALLS" | tr -d ' '; return 0; }
+
+# Fixed fixture args
+REPO="owner/repo"
+RUNNER_USER="alice"
+RUNNER_ROLE="supervisor"
+RUNNER_PREFIX="[Supervisor:alice]"
+ROLE_LABEL="supervisor"
+ROLE_COLOR="0E8A16"
+ROLE_DESC="Supervisor runner"
+ROLE_DISPLAY="Supervisor"
+CACHE_FILE="${HOME}/.aidevops/logs/health-issue-alice-supervisor-owner-repo"
+
+setup_cache() { echo "$1" >"$CACHE_FILE"; return 0; }
+clear_cache() { rm -f "$CACHE_FILE"; return 0; }
+
+# =============================================================================
+# Scenarios
+# =============================================================================
+section "Scenario 1: cache-hit + gh view fails (rc=4) → cache preserved"
+reset_stubs
+setup_cache "42"
+stub_gh_for "issue view 42" "" 4
+result=$(_find_health_issue "$REPO" "$RUNNER_USER" "$RUNNER_ROLE" "$RUNNER_PREFIX" "$ROLE_LABEL" "$ROLE_DISPLAY" "$CACHE_FILE")
+if [[ "$result" == "42" ]]; then
+	pass "echoes cached number when view fails"
+else
+	fail "echoes cached number when view fails" "got '$result'"
+fi
+if [[ -f "$CACHE_FILE" ]] && [[ "$(cat "$CACHE_FILE")" == "42" ]]; then
+	pass "cache file preserved after view failure"
+else
+	fail "cache file preserved after view failure" "file missing or content changed"
+fi
+if ! grep -q "issue list" "$GH_CALLS"; then
+	pass "skips label/title dedup scans when cache-view fails (reduces API load)"
+else
+	fail "skips label/title dedup scans when cache-view fails" "saw list call: $(grep 'issue list' "$GH_CALLS")"
+fi
+
+section "Scenario 2: cache-hit + gh view returns CLOSED → cache cleared, falls through"
+reset_stubs
+setup_cache "42"
+stub_gh_for "issue view 42" "CLOSED" 0
+stub_gh_for "issue list --repo ${REPO} --label supervisor --label alice" "[]" 0
+stub_gh_for "issue list --repo ${REPO} --search" "" 0
+result=$(_find_health_issue "$REPO" "$RUNNER_USER" "$RUNNER_ROLE" "$RUNNER_PREFIX" "$ROLE_LABEL" "$ROLE_DISPLAY" "$CACHE_FILE")
+if [[ "$result" == "" ]]; then
+	pass "echoes empty after CLOSED cached issue clears"
+else
+	fail "echoes empty after CLOSED cached issue clears" "got '$result'"
+fi
+if [[ ! -f "$CACHE_FILE" ]]; then
+	pass "cache file removed when issue is CLOSED"
+else
+	fail "cache file removed when issue is CLOSED" "file still exists"
+fi
+
+section "Scenario 3: no cache + label list fails (rc=4) → __QUERY_FAILED__ sentinel"
+reset_stubs
+clear_cache
+stub_gh_for "issue list --repo ${REPO} --label supervisor --label alice" "" 4
+result=$(_find_health_issue "$REPO" "$RUNNER_USER" "$RUNNER_ROLE" "$RUNNER_PREFIX" "$ROLE_LABEL" "$ROLE_DISPLAY" "$CACHE_FILE")
+if [[ "$result" == "__QUERY_FAILED__" ]]; then
+	pass "emits __QUERY_FAILED__ sentinel when label lookup fails"
+else
+	fail "emits __QUERY_FAILED__ sentinel when label lookup fails" "got '$result'"
+fi
+if ! grep -q "issue list --repo ${REPO} --search" "$GH_CALLS"; then
+	pass "skips title search after label lookup fails (reduces API load)"
+else
+	fail "skips title search after label lookup fails" "saw title search"
+fi
+
+section "Scenario 4: no cache + label empty + title fails (rc=4) → sentinel"
+reset_stubs
+clear_cache
+stub_gh_for "issue list --repo ${REPO} --label supervisor --label alice" "[]" 0
+stub_gh_for "issue list --repo ${REPO} --search" "" 4
+result=$(_find_health_issue "$REPO" "$RUNNER_USER" "$RUNNER_ROLE" "$RUNNER_PREFIX" "$ROLE_LABEL" "$ROLE_DISPLAY" "$CACHE_FILE")
+if [[ "$result" == "__QUERY_FAILED__" ]]; then
+	pass "emits __QUERY_FAILED__ when title lookup fails"
+else
+	fail "emits __QUERY_FAILED__ when title lookup fails" "got '$result'"
+fi
+
+section "Scenario 5: no cache + label returns two issues → older closed, newer returned"
+reset_stubs
+clear_cache
+two_issues='[{"number":50,"title":"[Supervisor:alice] foo"},{"number":42,"title":"[Supervisor:alice] bar"}]'
+stub_gh_for "issue list --repo ${REPO} --label supervisor --label alice" "$two_issues" 0
+result=$(_find_health_issue "$REPO" "$RUNNER_USER" "$RUNNER_ROLE" "$RUNNER_PREFIX" "$ROLE_LABEL" "$ROLE_DISPLAY" "$CACHE_FILE")
+if [[ "$result" == "50" ]]; then
+	pass "returns newest (highest number) issue"
+else
+	fail "returns newest (highest number) issue" "got '$result'"
+fi
+if grep -q "issue close 42" "$GH_CALLS"; then
+	pass "closes older duplicate #42"
+else
+	fail "closes older duplicate #42" "no close call for 42 in: $(cat "$GH_CALLS")"
+fi
+
+section "Scenario 6: _resolve_health_issue_number sees __QUERY_FAILED__ → no create"
+reset_stubs
+clear_cache
+stub_gh_for "issue list --repo ${REPO} --label supervisor --label alice" "" 4
+result=$(_resolve_health_issue_number "$REPO" "$RUNNER_USER" "$RUNNER_ROLE" "$RUNNER_PREFIX" \
+	"$ROLE_LABEL" "$ROLE_COLOR" "$ROLE_DESC" "$ROLE_DISPLAY" "$CACHE_FILE")
+if [[ -z "$result" ]]; then
+	pass "returns empty on sentinel (caller skips update)"
+else
+	fail "returns empty on sentinel" "got '$result'"
+fi
+if [[ "$(create_count)" == "0" ]]; then
+	pass "does NOT call _create_health_issue under query failure"
+else
+	fail "does NOT call _create_health_issue under query failure" "_create_health_issue was called"
+fi
+
+section "Scenario 7: _resolve_health_issue_number empty-not-failed → create"
+reset_stubs
+clear_cache
+stub_gh_for "issue list --repo ${REPO} --label supervisor --label alice" "[]" 0
+stub_gh_for "issue list --repo ${REPO} --search" "" 0
+: >"$CREATE_CALLS"
+result=$(_resolve_health_issue_number "$REPO" "$RUNNER_USER" "$RUNNER_ROLE" "$RUNNER_PREFIX" \
+	"$ROLE_LABEL" "$ROLE_COLOR" "$ROLE_DESC" "$ROLE_DISPLAY" "$CACHE_FILE")
+if [[ "$result" == "99999" ]]; then
+	pass "returns new issue number from _create_health_issue stub"
+else
+	fail "returns new issue number from _create_health_issue stub" "got '$result'"
+fi
+if [[ "$(create_count)" == "1" ]]; then
+	pass "calls _create_health_issue exactly once when confirmed-not-found"
+else
+	fail "calls _create_health_issue exactly once" "call count=$(create_count)"
+fi
+
+section "Scenario 8: _periodic_health_issue_dedup within interval → no-op"
+reset_stubs
+state_file="${HOME}/.aidevops/logs/health-dedup-last-scan-alice-supervisor-owner-repo"
+touch "$state_file"  # just-scanned
+_periodic_health_issue_dedup "$REPO" "$RUNNER_USER" "$RUNNER_ROLE" "$ROLE_LABEL" "$ROLE_DISPLAY" "42"
+if [[ "$(gh_call_count)" == "0" ]]; then
+	pass "makes zero gh calls when within HEALTH_DEDUP_INTERVAL"
+else
+	fail "makes zero gh calls when within HEALTH_DEDUP_INTERVAL" "saw $(gh_call_count) calls"
+fi
+
+section "Scenario 9: periodic dedup past interval + list fails → state file NOT updated"
+reset_stubs
+state_file="${HOME}/.aidevops/logs/health-dedup-last-scan-alice-supervisor-owner-repo"
+touch -t 202001010000 "$state_file"  # stale
+stub_gh_for "issue list --repo ${REPO} --label supervisor --label alice" "" 4
+orig_mtime=$(stat -f %m "$state_file" 2>/dev/null || stat -c %Y "$state_file" 2>/dev/null)
+_periodic_health_issue_dedup "$REPO" "$RUNNER_USER" "$RUNNER_ROLE" "$ROLE_LABEL" "$ROLE_DISPLAY" "42"
+new_mtime=$(stat -f %m "$state_file" 2>/dev/null || stat -c %Y "$state_file" 2>/dev/null)
+if [[ "$orig_mtime" == "$new_mtime" ]]; then
+	pass "state file mtime unchanged after list failure (retry next cycle)"
+else
+	fail "state file mtime unchanged after list failure" "orig=$orig_mtime new=$new_mtime"
+fi
+
+section "Scenario 10: periodic dedup past interval + two issues → older closed, state updated"
+reset_stubs
+state_file="${HOME}/.aidevops/logs/health-dedup-last-scan-alice-supervisor-owner-repo"
+touch -t 202001010000 "$state_file"  # stale
+two_issues='[{"number":50,"title":"[Supervisor:alice] foo"},{"number":42,"title":"[Supervisor:alice] bar"}]'
+stub_gh_for "issue list --repo ${REPO} --label supervisor --label alice" "$two_issues" 0
+_periodic_health_issue_dedup "$REPO" "$RUNNER_USER" "$RUNNER_ROLE" "$ROLE_LABEL" "$ROLE_DISPLAY" "50"
+if grep -q "issue close 42" "$GH_CALLS"; then
+	pass "periodic dedup closes older duplicate (kept #50)"
+else
+	fail "periodic dedup closes older duplicate" "no close for 42 in: $(cat "$GH_CALLS")"
+fi
+# State file should be touched to "now" — verify it's newer than the stale mtime
+new_mtime=$(stat -f %m "$state_file" 2>/dev/null || stat -c %Y "$state_file" 2>/dev/null)
+now=$(date +%s)
+if ((now - new_mtime < 60)); then
+	pass "state file touched after successful dedup (within last 60s)"
+else
+	fail "state file touched after successful dedup" "new_mtime=$new_mtime now=$now"
+fi
+
+# =============================================================================
+# Summary
+# =============================================================================
+printf '\n%s== Summary ==%s\n' "$TEST_BLUE" "$TEST_NC"
+if ((TESTS_FAILED > 0)); then
+	printf '  %s%d failed%s of %d tests\n' "$TEST_RED" "$TESTS_FAILED" "$TEST_NC" "$TESTS_RUN"
+	exit 1
+fi
+printf '  %sAll %d tests passed%s\n' "$TEST_GREEN" "$TESTS_RUN" "$TEST_NC"
+exit 0

--- a/TODO.md
+++ b/TODO.md
@@ -764,6 +764,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [x] t2685 harden gh signature-footer enforcement: add `.agents/scripts/gh` PATH shim (auto-injects sig on `--body`/`--body-file` for gh issue/pr comment/create) + tighten `quality-hooks.mjs::checkSignatureFooterGate` with marker-based detection + transparent repair + mentoring throw on unparseable bodies. Prompted by awardsapp#2546 hallucinated footer incident 2026-04-21. See `todo/tasks/t2685-brief.md`. #bug #priority:high #framework #interactive ref:GH#20306 pr:#20307 completed:2026-04-21
 
+- [ ] t2687 fix health-dashboard dedup: preserve cache on gh query errors and add periodic dedup scan to prevent duplicate supervisor/contributor health issues under GraphQL rate-limit pressure — surgical fix for the 2026-04-21 incident where asymmetric t2574 REST fallback (CREATE-side only) caused 19 duplicate `[Supervisor:*]` issues across 7 repos. Layer 1 (rc-aware lookups + `__QUERY_FAILED__` sentinel) + Layer 2 (1h periodic dedup on cache hits) + migration script. Layers 3 (framework-wide REST fallback for read paths) and 4 (pulse-level rate-limit circuit breaker) deferred as follow-ups. #bug #framework #interactive ref:GH#20301
+
 ## In Progress
 
 - [x] t1543 feat: OAuth multi-account pool plugin for provider credential rotation — add pool module to opencode-aidevops plugin enabling multiple Anthropic OAuth accounts with automatic rotation on rate limits (429). Uses existing plugin auth hook + custom fetch wrapper. Includes /model-accounts-pool tool for account management. #feature #plugin #auth ~4h ref:GH#5243 started:2026-03-19 pr:#5244 completed:2026-03-19

--- a/TODO.md
+++ b/TODO.md
@@ -766,6 +766,12 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t2687 fix health-dashboard dedup: preserve cache on gh query errors and add periodic dedup scan to prevent duplicate supervisor/contributor health issues under GraphQL rate-limit pressure — surgical fix for the 2026-04-21 incident where asymmetric t2574 REST fallback (CREATE-side only) caused 19 duplicate `[Supervisor:*]` issues across 7 repos. Layer 1 (rc-aware lookups + `__QUERY_FAILED__` sentinel) + Layer 2 (1h periodic dedup on cache hits) + migration script. Layers 3 (framework-wide REST fallback for read paths) and 4 (pulse-level rate-limit circuit breaker) deferred as follow-ups. #bug #framework #interactive ref:GH#20301
 
+- [ ] t2689 Extend t2574 REST fallback to `gh issue view` / `gh issue list` reads — framework-wide Layer 3 of defence-in-depth after t2687 (Layer 1) and t2574 (CREATE/EDIT-only writes). Mirror the existing `gh_issue_edit_safe` pattern in `shared-gh-wrappers.sh` + `shared-gh-wrappers-rest-fallback.sh`. Opportunistically migrate other `gh issue view`/`list` callers. #auto-dispatch #bug #framework ~3h ref:GH#20309
+
+- [ ] t2690 Pulse-level GraphQL rate-limit circuit breaker — proactive complement to t2574/t2687/t2689 reactive fallbacks. Pause worker dispatch when `gh api rate_limit` GraphQL remaining ≤ `AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD` (default 5%). Counter in `pulse-stats.json`. Design questions in issue body. #auto-dispatch #feat #framework model:opus ~4h ref:GH#20310
+
+- [ ] t2691 Root-cause why `origin:worker` was missing on health-dashboard issue #20298 — triggering symptom that led to GH#20301. Suspected cause (H1): REST fallback in `shared-gh-wrappers-rest-fallback.sh` does not apply auto-detected origin label because REST path uses a separate `POST /issues/{N}/labels` step that may fail silently. Validate before fixing. #auto-dispatch #bug #framework ~1h ref:GH#20311
+
 ## In Progress
 
 - [x] t1543 feat: OAuth multi-account pool plugin for provider credential rotation — add pool module to opencode-aidevops plugin enabling multiple Anthropic OAuth accounts with automatic rotation on rate limits (429). Uses existing plugin auth hook + custom fetch wrapper. Includes /model-accounts-pool tool for account management. #feature #plugin #auth ~4h ref:GH#5243 started:2026-03-19 pr:#5244 completed:2026-03-19

--- a/todo/tasks/t2687-brief.md
+++ b/todo/tasks/t2687-brief.md
@@ -1,0 +1,179 @@
+---
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+# t2687: fix health-dashboard dedup under rate-limit pressure
+
+## Pre-flight
+
+- [x] Memory recall: `duplicate supervisor issue dedup` / `issue tag label inconsistent` → 0 hits — no prior lesson, first incident of this class
+- [x] Discovery pass: 0 commits / 0 merged PRs / 0 open PRs touch `stats-health-dashboard.sh` in last 48h. Recent relevant work: t2574/t2580 (REST fallback for CREATE/EDIT paths — this incident exposes the asymmetric READ-path gap)
+- [x] File refs verified: `.agents/scripts/stats-health-dashboard.sh` (1419 lines, deployed matches source), `.agents/scripts/shared-gh-wrappers-rest-fallback.sh` (present), `~/.aidevops/logs/stats.log` (84 rate-limit failures, 19 creation failures today)
+- [x] Tier: `tier:standard` — multi-file fix with bash logic changes and test harness, not a one-line config tweak; no novel architecture required (pattern already established by `_find_health_issue` dedup logic itself)
+
+## Origin
+
+- **Created:** 2026-04-21
+- **Session:** opencode:interactive
+- **Created by:** ai-interactive (marcusquinn directed investigation)
+- **Parent task:** none
+- **Conversation context:** User noticed duplicate `[Supervisor:*]` issues on `marcusquinn/aidevops` (and later `awardsapp/awardsapp`). Investigation traced the incident to a GraphQL rate-limit window on 2026-04-21 04:00-13:30 UTC during which `_find_health_issue` silently treated query failures as "not found" and created duplicates.
+
+## What
+
+Harden `_find_health_issue` in `stats-health-dashboard.sh` so that `gh` query errors (rate limit, network timeout, connection reset) never cascade into duplicate issue creation. Add a one-shot migration to close the 19 orphaned duplicates across the fleet. File follow-up issues for the broader systemic gaps (framework-wide read-path REST fallback, pulse-level rate-limit circuit breaker).
+
+After this change:
+
+- A pulse cycle that encounters GraphQL rate-limit errors during cache validation or label/title dedup lookup preserves the cache and skips creation for that cycle, instead of silently creating a duplicate.
+- Even on cache hits, the label-based dedup scan runs at least once per hour per repo, so duplicates that slipped in during past rate-limit windows get closed automatically.
+- Existing 19 duplicate supervisor issues are closed via one-shot migration script with explanatory comments.
+
+## Why
+
+- **Signal integrity:** Duplicate supervisor issues corrupt pin slots, confuse human monitoring, and create noise in per-runner dashboards. Multiple open `[Supervisor:marcusquinn]` and `[Supervisor:alex-solovyev]` issues actively mislead.
+- **Regression surface from t2574/t2580:** The REST fallback for CREATE/EDIT operations made this latent bug actively harmful. Pre-t2574, CREATE would also fail under rate limit → no duplicate. Post-t2574, CREATE succeeds via REST while the READ-side lookup silently returns empty → duplicate created. We must either mirror the fallback on READ (bigger change, follow-up) or teach `_find_health_issue` to refuse-on-error (this PR).
+- **Fleet impact:** 19 duplicates across 7 repos today. Will recur on every GraphQL exhaustion window until fixed.
+
+## Tier
+
+### Tier checklist
+
+- [x] 2 or fewer files to modify? **NO** — 3 files (helper script, test, migration)
+- [x] Every target file under 500 lines? **NO** — `stats-health-dashboard.sh` is 1419 lines
+- [x] Exact `oldString`/`newString` for every edit? **NO** — new function-level logic
+- [x] No judgment or design decisions? **NO** — error discrimination policy is a design choice
+- [x] No error handling or fallback logic to design? **NO** — that's literally the point
+- [x] No cross-package changes? yes — all in `.agents/scripts/`
+- [x] Estimate 1h or less? **NO** — ~2h including tests and migration
+- [x] 4 or fewer acceptance criteria? marginal
+
+Any unchecked → **`tier:standard`**.
+
+**Selected tier:** `tier:standard` — implementing interactively, self-dispatched.
+
+**Tier rationale:** Multi-file bash logic change with explicit error-handling semantics. Pattern already exists (the existing dedup logic at `:82-95`) so no novel architecture, but the error-classification policy is a design decision that requires judgment.
+
+## PR Conventions
+
+Leaf (non-parent) issue — PR body will use `Resolves #{NNN}` where NNN is the t2687 issue number.
+
+## How (Approach)
+
+### Files to Modify
+
+- `EDIT: .agents/scripts/stats-health-dashboard.sh:42-114` — rewrite `_find_health_issue` to classify `gh` command errors (success-empty vs. query-failure) and return a sentinel on failure that callers honour.
+- `EDIT: .agents/scripts/stats-health-dashboard.sh:207-231` — update `_resolve_health_issue_number` to treat the failure sentinel as "skip cycle", never fall through to `_create_health_issue`.
+- `EDIT: .agents/scripts/stats-health-dashboard.sh:1088-1128` — add periodic dedup scan in `_update_health_issue_for_repo` (run once per hour per repo even on cache hits).
+- `NEW: .agents/scripts/tests/test-find-health-issue-rate-limit.sh` — unit test using stubbed `gh` command that returns rate-limit errors; asserts cache preserved and no duplicate created.
+- `NEW: .agents/scripts/migrate-health-issue-duplicates-t2687.sh` — one-shot migration that closes duplicates per (repo, runner, role). Marker file: `~/.aidevops/logs/.migrated-health-issue-duplicates-t2687`.
+- `EDIT: TODO.md` — task entry updated with `ref:GH#NNN`.
+
+### Implementation Steps
+
+1. **Error classification helper.** Add a helper that runs a `gh` command and returns distinct outputs: the payload, the rc, and stderr. Use for both view and list calls. Pattern:
+
+```bash
+# _gh_query_with_rc: run gh command, capture payload + rc + stderr
+# Output (on stdout): <rc>\n<stderr_first_line>\n<payload>
+_gh_query_with_rc() {
+    local out rc=0
+    local stderr_file
+    stderr_file=$(mktemp)
+    out=$("$@" 2>"$stderr_file") || rc=$?
+    local stderr_first
+    stderr_first=$(head -1 "$stderr_file" 2>/dev/null || echo "")
+    rm -f "$stderr_file"
+    printf '%s\n%s\n%s' "$rc" "$stderr_first" "$out"
+}
+```
+
+2. **Cache validation fail-safe.** In `_find_health_issue`, replace the `|| echo ""` pattern on `gh issue view` with rc-aware logic:
+   - rc=0, state==OPEN → keep cache
+   - rc=0, state==CLOSED → remove cache (current behaviour)
+   - rc≠0 OR empty state → log query-failure warning, KEEP cache, return cached number. Do NOT `rm` the cache file.
+
+3. **Label/title search fail-safe.** Same treatment: if rc≠0 on the dedup lookups, return a sentinel `__QUERY_FAILED__` so `_resolve_health_issue_number` can refuse to create. Caller contract: empty string = confirmed-not-found (safe to create); `__QUERY_FAILED__` = abstain this cycle.
+
+4. **Periodic dedup on cache hits.** Track last-dedup-scan time per repo in `~/.aidevops/logs/health-dedup-last-scan-<slug_safe>`. On each `_update_health_issue_for_repo` call, if > 1 hour since last scan, run the label-based dedup scan even if cache is valid. Close duplicates per the existing `:82-95` logic.
+
+5. **Migration script.** Iterate all repos with `pulse: true`, group supervisor/contributor health issues by (runner_user, role_label), keep newest by created_at, close older ones with comment template `Closing duplicate ${role} health issue — superseded by #${newest}. Root cause: GraphQL rate-limit window 2026-04-21 (GH#{issue_num}).`. Write marker file to prevent re-runs.
+
+6. **Tag normalization.** Migration also backfills `origin:worker` on any `source:health-dashboard` issue missing it (#20298 specifically) via `gh issue edit --add-label origin:worker`.
+
+7. **Test harness.** Use the existing `tests/helpers/gh-stub.sh` pattern (or create a minimal inline stub). Test scenarios: (a) rate-limit on view → cache preserved; (b) rate-limit on list → no create; (c) rate-limit on title search → no create; (d) two existing issues + stale cache → both discovered, older closed.
+
+### Verification
+
+```bash
+# Lint
+shellcheck .agents/scripts/stats-health-dashboard.sh
+shellcheck .agents/scripts/tests/test-find-health-issue-rate-limit.sh
+shellcheck .agents/scripts/migrate-health-issue-duplicates-t2687.sh
+
+# Unit test
+bash .agents/scripts/tests/test-find-health-issue-rate-limit.sh
+
+# Migration dry-run
+bash .agents/scripts/migrate-health-issue-duplicates-t2687.sh --dry-run
+
+# Post-merge: verify no supervisor duplicates per (repo, runner)
+for slug in $(jq -r '.initialized_repos[] | select(.pulse == true) | .slug' ~/.config/aidevops/repos.json); do
+  gh issue list --repo "$slug" --state open --search "Supervisor in:title" --limit 30 --json title | \
+    jq -r 'group_by(.title[0:30]) | map(select(length>1)) | length' | \
+    xargs -I{} test {} -eq 0 || echo "DUPES STILL IN $slug"
+done
+```
+
+### Files Scope
+
+- `.agents/scripts/stats-health-dashboard.sh`
+- `.agents/scripts/tests/test-find-health-issue-rate-limit.sh`
+- `.agents/scripts/migrate-health-issue-duplicates-t2687.sh`
+- `TODO.md`
+- `todo/tasks/t2687-brief.md`
+
+## Acceptance Criteria
+
+- [ ] `_find_health_issue` preserves the cache file when `gh issue view` returns non-zero (simulated rate limit). No `rm -f "$health_issue_file"`.
+- [ ] `_find_health_issue` returns the `__QUERY_FAILED__` sentinel when both label and title lookups return non-zero, and `_resolve_health_issue_number` treats this as "skip cycle" (no create).
+- [ ] `_update_health_issue_for_repo` runs the label-based dedup scan at least once per hour per repo, even on cache hits. Scan closes all but the newest per (repo, runner, role) tuple.
+- [ ] Migration script closes the 19 currently-orphaned duplicate supervisor/contributor issues across the fleet with explanatory comments referencing GH#NNN.
+- [ ] Migration script backfills `origin:worker` on any `source:health-dashboard` issue missing it.
+- [ ] Test harness passes all 4 scenarios: rate-limit-on-view, rate-limit-on-list, rate-limit-on-title-search, stale-cache-with-two-existing.
+- [ ] `shellcheck` zero violations on all modified files.
+- [ ] Post-merge fleet scan shows zero duplicate supervisor issues per (repo, runner).
+
+## Context & Decisions
+
+- **Scope boundary (important):** this PR does NOT extend the t2574 REST fallback to READ operations (`gh issue view`, `gh issue list`). That is the correct framework-wide fix and will be filed as follow-up issue. This PR is the surgical fix that prevents the *duplicate creation* consequence.
+- **Why not fix in `_create_health_issue`?** We could check for existing duplicates inside `_create_health_issue` as a last-line defence, but that doubles the GraphQL load exactly when the API is struggling. Better to teach `_find_health_issue` to refuse-on-error.
+- **Circuit breaker at pulse-entry level?** Considered and rejected for this PR (Layer 4 in the analysis). A pulse-level rate-limit circuit breaker would stop ALL health-dashboard operations during exhaustion windows, including legitimate updates on already-found issues. This PR's finer-grained approach — preserve cache, abstain on create — keeps the dashboard working where it can.
+- **1-hour periodic dedup interval:** Short enough that duplicates from a rate-limit window close within one cycle after the window ends. Long enough that we don't waste a list call every pulse cycle (pulse runs every ~5min → 12 calls/hour currently; this reduces dedup scan to 1/hour which is 12× lower cost).
+- **`__QUERY_FAILED__` sentinel vs return code:** chose sentinel so the existing `echo $number / return 0` pattern stays; return codes would require refactoring all call sites.
+
+## Relevant Files
+
+- `.agents/scripts/stats-health-dashboard.sh:42-114` — `_find_health_issue` (core fix target)
+- `.agents/scripts/stats-health-dashboard.sh:130-188` — `_create_health_issue` (unchanged, but called less often after fix)
+- `.agents/scripts/stats-health-dashboard.sh:207-231` — `_resolve_health_issue_number` (needs sentinel handling)
+- `.agents/scripts/stats-health-dashboard.sh:1068-1164` — `_update_health_issue_for_repo` (periodic dedup added here)
+- `.agents/scripts/shared-gh-wrappers-rest-fallback.sh` — pattern reference for future Layer 3 follow-up
+- `~/.aidevops/logs/stats.log` — evidence trail
+
+## Dependencies
+
+- **Blocked by:** none
+- **Blocks:** follow-up issues for Layers 3 (read-path REST fallback) and 4 (pulse-level rate-limit circuit breaker) — I will file these after this PR merges so they carry a `blocked-by: t2687` reference
+- **External:** none
+
+## Estimate Breakdown
+
+| Phase | Time | Notes |
+|-------|------|-------|
+| Research/read | done | investigation already complete |
+| Implementation | 1.5h | Layer 1 + Layer 2 + migration |
+| Testing | 30m | stub-based test, migration dry-run |
+| **Total** | **~2h** | |


### PR DESCRIPTION
Resolves #20301

## Summary

Fixes the health-dashboard duplicate-creation bug that surfaced across 7 repos during the 2026-04-21 GraphQL rate-limit window. Adds rc-aware lookups + a periodic dedup safety net, plus a one-shot migration to clean up already-created duplicates.

## Root cause

`_find_health_issue` in `stats-health-dashboard.sh` treated `gh` query failures as "issue not found" via the `... || echo ""` pattern. When GraphQL rate-limits returned non-zero exit codes, the function returned empty, the cache was cleared, and a duplicate issue was created even though the original still existed.

t2574's REST fallback (PR #20255, same day) made it worse — it added REST fallback to CREATE/EDIT paths but **not** to READ paths. So under GraphQL pressure, reads still silently failed while writes succeeded via REST, guaranteeing the duplicate was actually created.

## Fix (layered)

**Layer 1 — rc-aware lookups + sentinel** (`stats-health-dashboard.sh`):

- New `_gh_query_with_rc` helper classifies rc 0 vs rc>0 for `gh issue view` / `gh issue list` calls.
- Rewrote `_find_health_issue` to distinguish success-empty (confirmed no issue) from query-failure (don't mutate cache, don't create).
- New `_HEALTH_QUERY_FAILED_SENTINEL` constant returned on query failure; `_resolve_health_issue_number` and `_update_health_issue_for_repo` honour it as "skip cycle".
- Extracted `_list_health_issues_by_role_label` to a helper (avoids the jq-literal-duplication that would trip the ratchet).

**Layer 2 — periodic dedup safety net** (`stats-health-dashboard.sh`):

- New `_periodic_health_issue_dedup` runs at most once per hour per repo, even on cache hits.
- Groups `source:health-dashboard` issues by `(role, runner_user)`, keeps the newest by createdAt, closes the rest with an explanatory comment.
- Interval controlled by `HEALTH_DEDUP_INTERVAL` env var (default 3600s).
- State file at `~/.aidevops/logs/health-dedup-<slug-safe>`.

**Migration — one-shot** (`migrate-health-issue-duplicates-t2687.sh`):

- Iterates pulse repos in `~/.config/aidevops/repos.json`, dedupes health-dashboard issues per `(role, runner_user)`, backfills `origin:worker` on any survivors missing it.
- Idempotent via marker file at `~/.aidevops/logs/.migrated-health-issue-duplicates-t2687`.
- `--dry-run` for preview; `--force` to override marker; `--slug owner/repo` to limit scope.

Dry-run across 14 pulse repos identifies: **5 closes + 3 label backfills**. Verified output in `--dry-run` mode before committing.

## Testing

New `test-find-health-issue-rate-limit.sh` with 10 scenarios / 18 assertions covering:

- Cache preservation on rate-limit
- Sentinel propagation through `_resolve_health_issue_number`
- Periodic dedup skip-within-interval
- Periodic dedup runs past-interval
- List-failure → state file NOT updated (retry next cycle)
- List-success + two duplicates → older closed + state touched

All 18 pass; shellcheck clean on all touched files.

## Complexity Bump Justification

`.agents/scripts/stats-health-dashboard.sh` grew from ~1440 to 1666 lines (file-size gate: base=57, head=58, new=1 — threshold 1500). The +226 net lines are the core bug fix: rc-aware `_gh_query_with_rc` helper + `_HEALTH_QUERY_FAILED_SENTINEL` handling threaded through `_find_health_issue`, `_resolve_health_issue_number`, and `_update_health_issue_for_repo`, plus the new `_periodic_health_issue_dedup` safety net. See `.agents/scripts/stats-health-dashboard.sh:100-140` (rc helper) and `:392-460` (periodic dedup).

Function-complexity and nesting-depth gates pass cleanly (base=31/1, head=31/1, new=0/0) after extracting 7 helpers (`_try_cached_health_issue_lookup`, `_close_health_issue_duplicates`, `_try_title_health_issue_fallback`, `_check_health_issue_activity_guard`, `_backfill_origin_worker_labels`, `_unpin_duplicate_issue`, `_close_duplicate_groups`).

Splitting the file into a sub-library is tracked by the pre-existing large-file backlog (`reference/large-file-split.md`) — not in scope for this bug fix. Doing it inline would conflate a critical bug fix with a refactor that needs its own PR, own review, and own identity-key audit.

## Out of scope (follow-ups)

Filed as separate issues after merge:

1. Framework-wide REST fallback for `gh issue view` / `gh issue list` reads (t2574 only covered writes).
2. Pulse-level rate-limit circuit breaker (pause dispatch when GraphQL budget <10%).
3. Root-cause why `origin:worker` was missing on newly-created #20298 (symptom that led to this discovery).

## Files changed

- `.agents/scripts/stats-health-dashboard.sh` — Layer 1 + 2 (+216 / -9)
- `.agents/scripts/tests/test-find-health-issue-rate-limit.sh` — new (+371)
- `.agents/scripts/migrate-health-issue-duplicates-t2687.sh` — new (+321)
- `todo/tasks/t2687-brief.md` — brief (+179)
- `TODO.md` — entry (+2)

---


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.88 plugin for [OpenCode](https://opencode.ai) v1.14.19 with claude-opus-4-7 spent 45m on this with the user in an interactive session. Overall, 16s since this issue was created.