### PR TITLE
t2693: fix re-export-only breaking local binding in plugin modules

### DIFF
--- a/.agents/plugins/opencode-aidevops/google-proxy.mjs
+++ b/.agents/plugins/opencode-aidevops/google-proxy.mjs
@@ -28,7 +28,24 @@
 import { join } from "path";
 import { getAccounts, ensureValidToken, patchAccount } from "./oauth-pool.mjs";
 import { jsonResponse, textResponse } from "./response-helpers.mjs";
-export { buildGoogleProviderModels, registerGoogleProvider, persistGoogleProvider, discoverGoogleModels } from "./google-proxy-config.mjs";
+// Import + export: `export { … } from "./module"` is re-export only and
+// does NOT create a local binding. discoverGoogleModels and
+// persistGoogleProvider are both called locally below (see lines ~300 and
+// ~338), so they must be imported into this module's scope. Same class of
+// bug as the quality-hooks.mjs hotfix.
+import {
+  buildGoogleProviderModels,
+  registerGoogleProvider,
+  persistGoogleProvider,
+  discoverGoogleModels,
+} from "./google-proxy-config.mjs";
+
+export {
+  buildGoogleProviderModels,
+  registerGoogleProvider,
+  persistGoogleProvider,
+  discoverGoogleModels,
+};
 
 // ---------------------------------------------------------------------------
 // Constants

--- a/.agents/plugins/opencode-aidevops/quality-hooks.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks.mjs
@@ -111,8 +111,21 @@ function isBashTool(tool) {
 // Signature footer gate (GH#12805, t1755, t2685)
 // ---------------------------------------------------------------------------
 // Implementation extracted to quality-hooks-signature.mjs (t2685) to keep
-// this module below the qlty file-complexity ratchet. Re-exports preserve
-// the existing public API so callers and tests don't have to change imports.
+// this module below the qlty file-complexity ratchet. We import + export
+// rather than using `export { … } from "./module"` because the latter is a
+// re-export only and does NOT create a local binding — `checkSignatureFooterGate`
+// is called locally at handleToolAfter below, so it must be imported into
+// this module's scope. See GH hotfix: re-export-only form broke all Bash
+// tool calls with `ReferenceError: checkSignatureFooterGate is not defined`.
+
+import {
+  SIG_MARKER,
+  isGhWriteCommand,
+  isMachineProtocolCommand,
+  hasTrustedSignatureSignal,
+  tryRepairSignature,
+  checkSignatureFooterGate,
+} from "./quality-hooks-signature.mjs";
 
 export {
   SIG_MARKER,
@@ -121,7 +134,7 @@ export {
   hasTrustedSignatureSignal,
   tryRepairSignature,
   checkSignatureFooterGate,
-} from "./quality-hooks-signature.mjs";
+};
 
 // ---------------------------------------------------------------------------
 // Pattern tracking

--- a/.agents/plugins/opencode-aidevops/tests/test-reexport-local-binding.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-reexport-local-binding.mjs
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+//
+// Regression test for the "re-export only, used locally" class of bug.
+// ---------------------------------------------------------------------------
+// ES `export { X } from "./Y"` is a RE-EXPORT ONLY — it does NOT create a
+// local binding for X inside the exporting module. If the module also
+// *calls* X internally, it throws `ReferenceError: X is not defined` at
+// call time (not at module load).
+//
+// This test statically scans plugin source files for re-exported
+// identifiers that are also used in non-import/non-export positions and
+// lack a corresponding local `import`. It would have caught both:
+//   - quality-hooks.mjs: checkSignatureFooterGate (broke ALL Bash tool calls)
+//   - google-proxy.mjs: discoverGoogleModels, persistGoogleProvider (latent)
+//
+//   node --test .agents/plugins/opencode-aidevops/tests/test-reexport-local-binding.mjs
+// ---------------------------------------------------------------------------
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pluginDir = resolve(__dirname, "..");
+
+/**
+ * Parse names out of a destructured list, stripping `as` aliases.
+ * @param {string} block - Contents between `{` and `}`
+ * @returns {string[]}
+ */
+function parseNames(block) {
+  return block
+    .split(",")
+    .map((s) => s.trim().split(/\s+as\s+/)[0].trim())
+    .filter(Boolean);
+}
+
+/**
+ * Return identifiers that are re-exported via `export { … } from "./mod"`
+ * but are also used in non-import/non-export positions in the same file
+ * without a corresponding `import { … }` declaration.
+ *
+ * Implementation note: matches against byte-offset ranges rather than line
+ * scope so that multi-line `export { A, B, C } from "./mod"` blocks — whose
+ * identifier continuation lines contain only destructured names — don't
+ * look like "local uses" of A, B, or C.
+ *
+ * @param {string} filePath
+ * @returns {string[]}
+ */
+function findReExportLocalUseViolations(filePath) {
+  const src = readFileSync(filePath, "utf8");
+
+  const reExportRe = /^export\s*\{([^}]+)\}\s*from\s*["'][^"']+["'];?\s*$/gm;
+  const importRe = /^import\s*\{([^}]+)\}\s*from\s*["'][^"']+["'];?\s*$/gm;
+
+  // Collect re-exports + occupied byte ranges in one pass.
+  const reExported = new Set();
+  const blockRanges = [];
+  for (const m of src.matchAll(reExportRe)) {
+    parseNames(m[1]).forEach((id) => reExported.add(id));
+    blockRanges.push([m.index, m.index + m[0].length]);
+  }
+  if (reExported.size === 0) return [];
+
+  const imported = new Set();
+  for (const m of src.matchAll(importRe)) {
+    parseNames(m[1]).forEach((id) => imported.add(id));
+    blockRanges.push([m.index, m.index + m[0].length]);
+  }
+
+  const isInsideImportExportBlock = (pos) =>
+    blockRanges.some(([start, end]) => pos >= start && pos < end);
+
+  const violations = [];
+  for (const id of reExported) {
+    if (imported.has(id)) continue;
+    const idRe = new RegExp(`\\b${id}\\b`, "g");
+    let usedLocally = false;
+    for (const m of src.matchAll(idRe)) {
+      if (isInsideImportExportBlock(m.index)) continue;
+      // Skip comment lines: the most common false positive is a // or *
+      // that references the identifier in prose. Cheap line-scoped check.
+      const lineStart = src.lastIndexOf("\n", m.index) + 1;
+      const lineEnd = src.indexOf("\n", m.index);
+      const line = src.slice(lineStart, lineEnd === -1 ? src.length : lineEnd);
+      if (/^\s*(\/\/|\*)/.test(line)) continue;
+      usedLocally = true;
+      break;
+    }
+    if (usedLocally) violations.push(id);
+  }
+  return violations;
+}
+
+// Files known to use the re-export pattern — extend when new ones land.
+const CANDIDATES = [
+  "quality-hooks.mjs",
+  "google-proxy.mjs",
+  "oauth-pool.mjs",
+  "agent-loader.mjs",
+];
+
+for (const name of CANDIDATES) {
+  test(`${name}: re-exported identifiers used locally are also imported`, () => {
+    const violations = findReExportLocalUseViolations(resolve(pluginDir, name));
+    assert.deepEqual(
+      violations,
+      [],
+      `Identifier(s) are re-exported via \`export { … } from "./Y"\` and used locally in ${name} without a matching \`import\`. This causes ReferenceError at call time. Add them to an \`import { … } from "./Y"\` statement.`,
+    );
+  });
+}

--- a/.agents/plugins/opencode-aidevops/tests/test-reexport-local-binding.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-reexport-local-binding.mjs
@@ -39,6 +39,60 @@ function parseNames(block) {
 }
 
 /**
+ * Match all `^import/export { … } from "…"` blocks of a given kind and
+ * accumulate the destructured identifiers plus the byte ranges they occupy.
+ * @param {string} src
+ * @param {RegExp} re
+ * @param {Set<string>} identifiersOut
+ * @param {Array<[number, number]>} rangesOut
+ */
+function collectDestructuredFromBlocks(src, re, identifiersOut, rangesOut) {
+  for (const m of src.matchAll(re)) {
+    parseNames(m[1]).forEach((id) => identifiersOut.add(id));
+    rangesOut.push([m.index, m.index + m[0].length]);
+  }
+}
+
+/**
+ * True if `pos` falls inside any of the recorded import/export block ranges.
+ * @param {number} pos
+ * @param {Array<[number, number]>} ranges
+ */
+function positionIsInsideBlock(pos, ranges) {
+  return ranges.some(([start, end]) => pos >= start && pos < end);
+}
+
+/**
+ * True if the line containing byte offset `pos` begins with a comment marker
+ * (`//` or `*`). Cheap line-scoped check to skip prose mentions.
+ * @param {string} src
+ * @param {number} pos
+ */
+function positionIsOnCommentLine(src, pos) {
+  const lineStart = src.lastIndexOf("\n", pos) + 1;
+  const lineEnd = src.indexOf("\n", pos);
+  const line = src.slice(lineStart, lineEnd === -1 ? src.length : lineEnd);
+  return /^\s*(\/\/|\*)/.test(line);
+}
+
+/**
+ * True if `id` appears in `src` outside any of the given import/export block
+ * ranges and outside any comment line.
+ * @param {string} src
+ * @param {string} id
+ * @param {Array<[number, number]>} blockRanges
+ */
+function identifierHasLocalUse(src, id, blockRanges) {
+  const idRe = new RegExp(`\\b${id}\\b`, "g");
+  for (const m of src.matchAll(idRe)) {
+    if (positionIsInsideBlock(m.index, blockRanges)) continue;
+    if (positionIsOnCommentLine(src, m.index)) continue;
+    return true;
+  }
+  return false;
+}
+
+/**
  * Return identifiers that are re-exported via `export { … } from "./mod"`
  * but are also used in non-import/non-export positions in the same file
  * without a corresponding `import { … }` declaration.
@@ -57,43 +111,17 @@ function findReExportLocalUseViolations(filePath) {
   const reExportRe = /^export\s*\{([^}]+)\}\s*from\s*["'][^"']+["'];?\s*$/gm;
   const importRe = /^import\s*\{([^}]+)\}\s*from\s*["'][^"']+["'];?\s*$/gm;
 
-  // Collect re-exports + occupied byte ranges in one pass.
   const reExported = new Set();
-  const blockRanges = [];
-  for (const m of src.matchAll(reExportRe)) {
-    parseNames(m[1]).forEach((id) => reExported.add(id));
-    blockRanges.push([m.index, m.index + m[0].length]);
-  }
-  if (reExported.size === 0) return [];
-
   const imported = new Set();
-  for (const m of src.matchAll(importRe)) {
-    parseNames(m[1]).forEach((id) => imported.add(id));
-    blockRanges.push([m.index, m.index + m[0].length]);
-  }
+  const blockRanges = [];
 
-  const isInsideImportExportBlock = (pos) =>
-    blockRanges.some(([start, end]) => pos >= start && pos < end);
+  collectDestructuredFromBlocks(src, reExportRe, reExported, blockRanges);
+  if (reExported.size === 0) return [];
+  collectDestructuredFromBlocks(src, importRe, imported, blockRanges);
 
-  const violations = [];
-  for (const id of reExported) {
-    if (imported.has(id)) continue;
-    const idRe = new RegExp(`\\b${id}\\b`, "g");
-    let usedLocally = false;
-    for (const m of src.matchAll(idRe)) {
-      if (isInsideImportExportBlock(m.index)) continue;
-      // Skip comment lines: the most common false positive is a // or *
-      // that references the identifier in prose. Cheap line-scoped check.
-      const lineStart = src.lastIndexOf("\n", m.index) + 1;
-      const lineEnd = src.indexOf("\n", m.index);
-      const line = src.slice(lineStart, lineEnd === -1 ? src.length : lineEnd);
-      if (/^\s*(\/\/|\*)/.test(line)) continue;
-      usedLocally = true;
-      break;
-    }
-    if (usedLocally) violations.push(id);
-  }
-  return violations;
+  return [...reExported].filter(
+    (id) => !imported.has(id) && identifierHasLocalUse(src, id, blockRanges),
+  );
 }
 
 // Files known to use the re-export pattern — extend when new ones land.

--- a/.github/workflows/plugin-import-check.yml
+++ b/.github/workflows/plugin-import-check.yml
@@ -54,3 +54,17 @@ jobs:
             exit 1
           fi
           echo "All plugin imports resolve successfully."
+
+      - name: Run plugin tests
+        # Load-time import resolution (above) cannot catch ReferenceErrors at
+        # call time — e.g. `export { X } from "./Y"` is re-export only and
+        # doesn't create a local binding, so a module that also *calls* X
+        # internally loads fine but throws at runtime. The tests/ directory
+        # exercises these paths; keep them green to prevent regressions.
+        run: |
+          set -euo pipefail
+          for plugin_dir in .agents/plugins/*/; do
+            [ -d "${plugin_dir}tests" ] || continue
+            echo "Running tests under: ${plugin_dir}tests"
+            node --test "${plugin_dir}tests/"
+          done

--- a/.github/workflows/plugin-import-check.yml
+++ b/.github/workflows/plugin-import-check.yml
@@ -61,10 +61,25 @@ jobs:
         # doesn't create a local binding, so a module that also *calls* X
         # internally loads fine but throws at runtime. The tests/ directory
         # exercises these paths; keep them green to prevent regressions.
+        #
+        # We enumerate files via `find` rather than passing the directory
+        # to `node --test` — the directory form was unreliable in Node 22
+        # (tried to resolve the path as a module name: "Cannot find module
+        # '.../tests'") whereas explicit file paths work consistently.
         run: |
           set -euo pipefail
+          FAILED=0
           for plugin_dir in .agents/plugins/*/; do
             [ -d "${plugin_dir}tests" ] || continue
+            TEST_FILES=$(find "${plugin_dir}tests" -name 'test-*.mjs' -type f | sort)
+            [ -n "$TEST_FILES" ] || continue
             echo "Running tests under: ${plugin_dir}tests"
-            node --test "${plugin_dir}tests/"
+            # shellcheck disable=SC2086
+            if ! node --test $TEST_FILES; then
+              FAILED=$((FAILED + 1))
+            fi
           done
+          if [ "$FAILED" -gt 0 ]; then
+            echo "::error::$FAILED plugin(s) have failing tests"
+            exit 1
+          fi


### PR DESCRIPTION
## Summary

Emergency hotfix: PR #20307 (t2685, merged today) introduced a `ReferenceError: checkSignatureFooterGate is not defined` that fires on **every Bash tool call** in OpenCode and Claude Code sessions, blocking all gh/git/shell operations. Root cause: ES `export { X } from "./Y"` is a re-export only — it does NOT create a local binding, even though the module calls `X` internally.

## What's broken and what fixed

- **quality-hooks.mjs** (active blocker): `handleToolAfter` calls `checkSignatureFooterGate(...)` at line 238, but line 117-124 only re-exported it. Fix: add matching `import { … } from "./quality-hooks-signature.mjs"` alongside the re-export.
- **google-proxy.mjs** (latent): `discoverGoogleModels` (called at line 300) and `persistGoogleProvider` (called at line 338) had the same re-export-only shape at line 31. Google proxy would have crashed on activation. Fix: same import + export pattern.

## New regression protection

- **`tests/test-reexport-local-binding.mjs`** — static scan that collects every `export { X } from "./Y"` identifier and, for each one not also imported locally, flags non-comment / non-import-block uses. Caught `checkSignatureFooterGate` in the pre-fix shape; passes against the fix.
- **`plugin-import-check.yml`** — extended to run `node --test` on each plugin's `tests/` directory. The existing import-resolution step loads the entry point but cannot detect ReferenceErrors that only fire at call time (that's exactly how this bug landed).

## Verification

```bash
node --test .agents/plugins/opencode-aidevops/tests/test-reexport-local-binding.mjs
# quality-hooks.mjs / google-proxy.mjs / oauth-pool.mjs / agent-loader.mjs — 4/4 pass

node -e 'import("./.agents/plugins/opencode-aidevops/quality-hooks.mjs").then(m => console.log(typeof m.checkSignatureFooterGate))'
# function  (was: FAIL: checkSignatureFooterGate is not defined)
```

## Deployment

This is a framework-level blocker. After merge:
1. `aidevops update` / `setup.sh --non-interactive` deploys fixed plugin
2. Running OpenCode/Claude Code sessions with the broken plugin still cached in memory need restart to pick up the fix — the disk fix alone doesn't flush Node's module cache

## Who is NOT affected

- Headless pulse workers / CI workers: bash scripts only, don't load the .mjs plugin

Resolves #20319

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.89 plugin for [OpenCode](https://opencode.ai) v1.14.19 with claude-opus-4-7 spent 25m and 10,322 tokens on this as a headless worker.
