### PR TITLE
t2695: remove unsupported headRefName JSON field from gh search prs calls

### DIFF
--- a/.agents/scripts/pulse-batch-prefetch-helper.sh
+++ b/.agents/scripts/pulse-batch-prefetch-helper.sh
@@ -153,7 +153,10 @@ _normalize_search_to_prefetch_schema() {
 			from_entries
 		' 2>/dev/null
 	else
-		# PRs: preserve headRefName if available
+		# PRs: normalize to prefetch schema.
+		# Note: headRefName is NOT available from gh search prs (Search API
+		# returns issue-shaped results). Consumers needing branch names must
+		# fetch lazily via `gh pr view <N> --json headRefName`.
 		jq '
 			group_by(.repository.nameWithOwner) |
 			map({
@@ -164,7 +167,6 @@ _normalize_search_to_prefetch_schema() {
 					labels: (.labels // []),
 					updatedAt: .updatedAt,
 					assignees: (.assignees // []),
-					headRefName: (.headRefName // null),
 					createdAt: (.createdAt // null),
 					author: (.author // null)
 				}]
@@ -265,7 +267,7 @@ _refresh_owner_prs() {
 	local pr_json=""
 	pr_json=$(gh search prs --owner "$owner" --state open \
 		--limit "$BATCH_SEARCH_LIMIT" \
-		--json number,title,labels,updatedAt,assignees,repository,headRefName,createdAt,author 2>"$pr_err") || pr_json=""
+		--json number,title,labels,updatedAt,assignees,repository,createdAt,author 2>"$pr_err") || pr_json=""
 	_OWNER_SEARCH_CALLS=$((_OWNER_SEARCH_CALLS + 1))
 
 	if [[ -z "$pr_json" || "$pr_json" == "$_JSON_NULL" ]]; then

--- a/todo/tasks/t2695-brief.md
+++ b/todo/tasks/t2695-brief.md
@@ -1,0 +1,26 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# t2695 — Remove unsupported `headRefName` JSON field from `gh search prs` calls
+
+**Canonical brief:** [GH#20314](https://github.com/marcusquinn/aidevops/issues/20314)
+
+The issue body on GH#20314 is worker-ready (per t2417 heuristic): it contains
+Task/Why/How/Acceptance/Reproducer/Suggested Fix sections with exact `file:line`
+references, a confirming live `gh` call, and an explicit measurement
+(`errors=1` per pulse cycle → `errors=0` after fix).
+
+This stub exists only to satisfy the brief-file structural requirement.
+
+## Session Origin
+
+Interactive session (marcusquinn), macOS, 2026-04-21. User directed attention to
+[GH#20314](https://github.com/marcusquinn/aidevops/issues/20314) filed by Linux
+contributor robstiles, asking whether it affected macOS. Platform-agnostic —
+the rejection is server-side at the GitHub Search API, not `gh` client.
+
+## How
+
+### Files Scope
+
+- `.agents/scripts/pulse-batch-prefetch-helper.sh`


### PR DESCRIPTION
## Summary

Drops `headRefName` from the `gh search prs --json` field list in `pulse-batch-prefetch-helper.sh` and from the jq normalization pipeline. Sibling of t2577 (#20261) which missed this field.

## Files Changed

.agents/scripts/pulse-batch-prefetch-helper.sh,todo/tasks/t2695-brief.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean; existing `test-enrich-batch-prefetch.sh` passes (16/16); runtime refresh now reports `errors=0` instead of `errors=1`; confirmed Search API rejects `headRefName` with `Unknown JSON field` and succeeds without it.

Resolves #20314


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.91 plugin for [OpenCode](https://opencode.ai) v1.14.19 with claude-opus-4-7 spent 52m and 10,322 tokens on this as a headless worker.