### PR TITLE
GH#20321: t2694: bump pulse-wrapper canary test timeout from 30s to 60s

### DIFF
--- a/.agents/scripts/tests/test-pulse-wrapper-canary.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-canary.sh
@@ -76,7 +76,7 @@ test_canary_exits_zero() {
 	output=$(
 		HOME="${sandbox}/home" \
 			FULL_LOOP_HEADLESS=1 \
-			timeout 30 bash "$WRAPPER_SCRIPT" --canary 2>&1
+			timeout 60 bash "$WRAPPER_SCRIPT" --canary 2>&1
 	)
 	rc=$?
 	rm -rf "$sandbox"
@@ -104,7 +104,7 @@ test_canary_prints_checkpoint() {
 	output=$(
 		HOME="${sandbox}/home" \
 			FULL_LOOP_HEADLESS=1 \
-			timeout 30 bash "$WRAPPER_SCRIPT" --canary 2>&1
+			timeout 60 bash "$WRAPPER_SCRIPT" --canary 2>&1
 	)
 	rc=$?
 	rm -rf "$sandbox"


### PR DESCRIPTION
## Summary

Changed timeout values in test_canary_exits_zero and test_canary_prints_checkpoint from 30s to 60s to eliminate CI runner slowness flakes while maintaining regression detection.

## Files Changed

.agents/scripts/tests/test-pulse-wrapper-canary.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** All 4 tests pass locally (exit 0, <30s wall clock). Syntax check passes. Both timeout values verified at lines 79 and 107.

Resolves #20321


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.91 plugin for [OpenCode](https://opencode.ai) v1.14.19 with claude-haiku-4-5 spent 1m and 2,328 tokens on this as a headless worker.