### PR TITLE
GH#20309: t2689: extend REST fallback to gh issue view/list read paths

### DIFF
--- a/.agents/scripts/brief-readiness-helper.sh
+++ b/.agents/scripts/brief-readiness-helper.sh
@@ -133,7 +133,7 @@ _fetch_issue_body() {
 	local slug="${_fib_args[1]}"
 
 	local body
-	body=$(gh issue view "$issue_number" --repo "$slug" --json body --jq '.body' 2>/dev/null) || {
+	body=$(gh_issue_view "$issue_number" --repo "$slug" --json body --jq '.body' 2>/dev/null) || {
 		log_error "Failed to fetch issue #${issue_number} from ${slug}"
 		return 1
 	}
@@ -240,7 +240,7 @@ cmd_stub() {
 
 	# Fetch issue title for the heading
 	local issue_title=""
-	issue_title=$(gh issue view "$issue_number" --repo "$slug" --json title --jq '.title' 2>/dev/null) || true
+	issue_title=$(gh_issue_view "$issue_number" --repo "$slug" --json title --jq '.title' 2>/dev/null) || true
 	issue_title="${issue_title:-${task_id}}"
 
 	cat >"$brief_path" <<EOF

--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -844,7 +844,7 @@ is_assigned() {
 		# t2436: include createdAt for the hydration window check (Approach B safety net).
 		# Existing callers that pass ISSUE_META_JSON without createdAt will skip that
 		# check (fail-open), which is correct — the primary fix is label sync at creation.
-		issue_meta_json=$(gh issue view "$issue_number" --repo "$repo_slug" \
+		issue_meta_json=$(gh_issue_view "$issue_number" --repo "$repo_slug" \
 			--json state,assignees,labels,createdAt 2>/dev/null) || gh_rc=$?
 	fi
 

--- a/.agents/scripts/dispatch-dedup-stale.sh
+++ b/.agents/scripts/dispatch-dedup-stale.sh
@@ -324,7 +324,7 @@ _resolve_stale_threshold() {
 	local issue_number="$1"
 	local repo_slug="$2"
 	local _issue_meta_json _meta_rc=0
-	_issue_meta_json=$(gh issue view "$issue_number" --repo "$repo_slug" \
+	_issue_meta_json=$(gh_issue_view "$issue_number" --repo "$repo_slug" \
 		--json labels,createdAt 2>/dev/null) || _meta_rc=$?
 
 	local is_interactive='false'

--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -2,15 +2,24 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 # =============================================================================
-# Shared GitHub CLI Wrappers -- REST Fallback (t2574, GH#20243)
+# Shared GitHub CLI Wrappers -- REST Fallback (t2574, GH#20243; t2689)
 # =============================================================================
-# When gh's native `gh issue create|comment|edit` commands fail and GraphQL
-# quota is exhausted (remaining <= threshold), these translators retry the
-# operation via `gh api` REST endpoints, which run against GitHub's separate
-# 5000/hour core REST budget.
+# When gh's native `gh issue create|comment|edit|view|list` commands fail and
+# GraphQL quota is exhausted (remaining <= threshold), these translators retry
+# via `gh api` REST endpoints, which run against GitHub's separate 5000/hour
+# core REST budget.
 #
 # Detection: _gh_should_fallback_to_rest -- consults gh api rate_limit.
-# Translators: _gh_issue_create_rest, _gh_issue_comment_rest, _gh_issue_edit_rest.
+# Write translators (t2574): _gh_issue_create_rest, _gh_issue_comment_rest,
+#   _gh_issue_edit_rest, _gh_pr_create_rest.
+# Read translators (t2689): _rest_issue_view, _rest_issue_list.
+#
+# Note on field mapping (_rest_issue_view): `gh issue view --json id` returns
+# the GraphQL node_id (e.g. I_kgDO...). The REST endpoint stores this in the
+# `node_id` field, not `id`. Callers that need the node_id for GraphQL mutations
+# should note that those mutations will also fail during GraphQL exhaustion, so
+# the discrepancy is benign in practice. All other fields (state, title, body,
+# labels, assignees, createdAt) map directly between gh and REST responses.
 #
 # Loaded by shared-gh-wrappers.sh. Do not source directly.
 #
@@ -502,4 +511,132 @@ _gh_pr_create_rest() {
 		fi
 	fi
 	return 0
+}
+
+#######################################
+# _rest_issue_view: GET /repos/{owner}/{repo}/issues/{N}.  (t2689)
+# Parses gh-style args (positional number or URL, --repo, --json, --jq)
+# and returns the issue JSON or a jq-filtered value. Mirrors `gh issue view`.
+#
+# The --json FIELDS flag is accepted for interface parity but ignored — the
+# REST endpoint always returns the full issue object. Use --jq to extract
+# specific fields. Field names align with `gh issue view --json` for all
+# common fields (state, title, body, labels, assignees, createdAt).
+# Exception: `id` maps to the numeric issue id in REST, not the GraphQL
+# node_id — see the file header for the benign impact of this discrepancy.
+#
+# Returns the underlying gh api exit code.
+#######################################
+_rest_issue_view() {
+	local num_or_url=""
+	local repo=""
+	local jq_expr=""
+
+	local _first="${1:-}"
+	if [[ $# -gt 0 && "$_first" != --* ]]; then
+		num_or_url="$_first"
+		shift
+	fi
+
+	while [[ $# -gt 0 ]]; do
+		local _arg="$1"
+		case "$_arg" in
+		--repo) repo="${2:-}"; shift 2 ;;
+		--repo=*) repo="${_arg#--repo=}"; shift ;;
+		--json) shift 2 ;;
+		--json=*) shift ;;
+		--jq) jq_expr="${2:-}"; shift 2 ;;
+		--jq=*) jq_expr="${_arg#--jq=}"; shift ;;
+		*) shift ;;
+		esac
+	done
+
+	local num=""
+	{ read -r repo; read -r num; } < <(_gh_rest_normalize_issue_ref "$num_or_url" "$repo")
+
+	if [[ -z "$repo" || -z "$num" ]]; then
+		printf '_rest_issue_view: issue number and --repo are required\n' >&2
+		return 1
+	fi
+	if [[ ! "$num" =~ ^[0-9]+$ ]]; then
+		printf '_rest_issue_view: invalid issue number: %s\n' "$num" >&2
+		return 1
+	fi
+
+	local _path="/repos/${repo}/issues/${num}"
+	if [[ -n "$jq_expr" ]]; then
+		gh api "$_path" --jq "$jq_expr"
+	else
+		gh api "$_path"
+	fi
+	return $?
+}
+
+#######################################
+# _rest_issue_list: GET /repos/{owner}/{repo}/issues.  (t2689)
+# Parses gh-style args (--repo, --state, --label, --assignee, --limit,
+# --json, --jq) and returns a JSON array or jq-filtered output.
+# Mirrors `gh issue list` for state/label/assignee filtering.
+#
+# Multiple --label flags are collected and joined into a comma-separated
+# `?labels=` query parameter (GitHub REST AND semantics — same as gh CLI).
+# The --search flag is not supported by this REST translator and is silently
+# skipped; callers that require full-text search semantics must use the
+# GraphQL / Search API path. --json FIELDS is accepted for parity but
+# ignored (the REST endpoint returns the full object; use --jq to select).
+#
+# Returns the underlying gh api exit code.
+#######################################
+_rest_issue_list() {
+	local repo=""
+	local state="open"
+	local limit=30
+	local jq_expr=""
+	local assignee=""
+	local -a labels=()
+	local -a _toks=()
+
+	while [[ $# -gt 0 ]]; do
+		local _arg="$1"
+		case "$_arg" in
+		--repo) repo="${2:-}"; shift 2 ;;
+		--repo=*) repo="${_arg#--repo=}"; shift ;;
+		--state) state="${2:-}"; shift 2 ;;
+		--state=*) state="${_arg#--state=}"; shift ;;
+		--label) IFS=',' read -ra _toks <<<"${2:-}"; labels+=("${_toks[@]}"); shift 2 ;;
+		--label=*) IFS=',' read -ra _toks <<<"${_arg#--label=}"; labels+=("${_toks[@]}"); shift ;;
+		--assignee) assignee="${2:-}"; shift 2 ;;
+		--assignee=*) assignee="${_arg#--assignee=}"; shift ;;
+		--limit) limit="${2:-}"; shift 2 ;;
+		--limit=*) limit="${_arg#--limit=}"; shift ;;
+		--json) shift 2 ;;
+		--json=*) shift ;;
+		--jq) jq_expr="${2:-}"; shift 2 ;;
+		--jq=*) jq_expr="${_arg#--jq=}"; shift ;;
+		--search) shift 2 ;;
+		--search=*) shift ;;
+		*) shift ;;
+		esac
+	done
+
+	if [[ -z "$repo" ]]; then
+		printf '_rest_issue_list: --repo is required\n' >&2
+		return 1
+	fi
+
+	local _query="state=${state}&per_page=${limit}"
+	if [[ ${#labels[@]} -gt 0 ]]; then
+		local _labels_csv
+		_labels_csv=$(IFS=','; printf '%s' "${labels[*]}")
+		_query="${_query}&labels=${_labels_csv}"
+	fi
+	[[ -n "$assignee" ]] && _query="${_query}&assignee=${assignee}"
+
+	local _path="/repos/${repo}/issues?${_query}"
+	if [[ -n "$jq_expr" ]]; then
+		gh api "$_path" --jq "$jq_expr"
+	else
+		gh api "$_path"
+	fi
+	return $?
 }

--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -14,6 +14,7 @@
 #   - Origin-label-aware gh create wrappers (gh_create_issue, gh_create_pr)
 #   - Comment wrappers (gh_issue_comment, gh_pr_comment)
 #   - Safe edit wrappers (gh_issue_edit_safe, gh_pr_edit_safe)
+#   - Read wrappers with REST fallback (gh_issue_view, gh_issue_list) [t2689]
 #   - Origin label mutual exclusion (set_origin_label, ensure_origin_labels_exist)
 #   - Issue status label state machine (set_issue_status, ensure_status_labels_exist)
 #
@@ -37,7 +38,9 @@
 _SHARED_GH_WRAPPERS_LOADED=1
 
 # t2574: REST fallback for GraphQL-exhausted gh issue wrappers (GH#20243).
-# Provides _gh_should_fallback_to_rest and _gh_issue_{create,comment,edit}_rest.
+# t2689: Extended to READ paths — _rest_issue_view, _rest_issue_list.
+# Provides _gh_should_fallback_to_rest, _gh_issue_{create,comment,edit}_rest,
+# _gh_pr_create_rest, _rest_issue_view, _rest_issue_list.
 _SHARED_GH_WRAPPERS_DIR="${BASH_SOURCE[0]%/*}"
 # shellcheck source=shared-gh-wrappers-rest-fallback.sh
 source "${_SHARED_GH_WRAPPERS_DIR}/shared-gh-wrappers-rest-fallback.sh"
@@ -1478,4 +1481,53 @@ set_issue_status() {
 		_rc=$?
 	fi
 	return $_rc
+}
+
+#######################################
+# gh_issue_view — drop-in replacement for gh issue view.  (t2689)
+# Falls back to REST (`gh api GET /repos/{owner}/{repo}/issues/{N}`) when the
+# primary call fails AND GraphQL is exhausted, so callers keep working during
+# rate-limit windows. All arguments are forwarded unchanged to gh issue view.
+#
+#   gh_issue_view 42 --repo owner/repo --json state --jq '.state'
+#   gh_issue_view 42 --repo owner/repo --json title,body,labels,assignees
+#
+# Returns the exit code of whichever path succeeded (or the REST path's code
+# when both paths ran).
+#######################################
+gh_issue_view() {
+	local _first_num="${1:-}"
+	gh issue view "$@"
+	local rc=$?
+	if [[ $rc -ne 0 ]] && _gh_should_fallback_to_rest; then
+		print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to REST for issue view #${_first_num}"
+		_rest_issue_view "$@"
+		rc=$?
+	fi
+	return $rc
+}
+
+#######################################
+# gh_issue_list — drop-in replacement for gh issue list.  (t2689)
+# Falls back to REST (`gh api GET /repos/{owner}/{repo}/issues`) when the
+# primary call fails AND GraphQL is exhausted. Supports --state, --label
+# (multiple), --assignee, --limit, --json, --jq. The --search flag is
+# accepted but silently skipped in the REST path (not supported by the
+# /repos/.../issues endpoint).
+#
+#   gh_issue_list --repo owner/repo --state open --label bug --json number,title
+#   gh_issue_list --repo owner/repo --state open --limit 500 --json number --jq length
+#
+# Returns the exit code of whichever path succeeded (or the REST path's code
+# when both paths ran).
+#######################################
+gh_issue_list() {
+	gh issue list "$@"
+	local rc=$?
+	if [[ $rc -ne 0 ]] && _gh_should_fallback_to_rest; then
+		print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to REST for issue list"
+		_rest_issue_list "$@"
+		rc=$?
+	fi
+	return $rc
 }

--- a/.agents/scripts/stats-health-dashboard.sh
+++ b/.agents/scripts/stats-health-dashboard.sh
@@ -52,7 +52,7 @@ _list_health_issues_by_role_label() {
 	local runner_user="$3"
 	local role_display="$4"
 
-	gh issue list --repo "$repo_slug" \
+	gh_issue_list --repo "$repo_slug" \
 		--label "$role_label" --label "$runner_user" \
 		--state open --json number,title \
 		--jq "[.[] | select(.title | startswith(\"[${role_display}:\"))] | sort_by(.number) | reverse"
@@ -108,7 +108,7 @@ _try_cached_health_issue_lookup() {
 	[[ -z "$cached_number" ]] && return 0
 
 	local issue_state rc=0
-	issue_state=$(gh issue view "$cached_number" --repo "$repo_slug" --json state --jq '.state' 2>/dev/null) || rc=$?
+	issue_state=$(gh_issue_view "$cached_number" --repo "$repo_slug" --json state --jq '.state' 2>/dev/null) || rc=$?
 
 	if [[ $rc -ne 0 ]]; then
 		# Query failed (rate limit, network, API 5xx). Preserve cache and return
@@ -163,7 +163,7 @@ _try_title_health_issue_fallback() {
 	local runner_prefix="$1" repo_slug="$2" runner_user="$3" role_label="$4" role_display="$5"
 
 	local title_result rc=0
-	title_result=$(gh issue list --repo "$repo_slug" \
+	title_result=$(gh_issue_list --repo "$repo_slug" \
 		--search "in:title ${runner_prefix}" \
 		--state open --json number,title \
 		--jq "[.[] | select(.title | startswith(\"${runner_prefix}\"))][0].number" 2>/dev/null) || rc=$?
@@ -292,7 +292,7 @@ _create_health_issue() {
 	# reserved for maintainer dashboards and the quality review issue.
 	if [[ "$runner_role" == "supervisor" ]]; then
 		local node_id
-		node_id=$(gh issue view "$health_issue_number" --repo "$repo_slug" --json id --jq '.id' 2>/dev/null || echo "")
+		node_id=$(gh_issue_view "$health_issue_number" --repo "$repo_slug" --json id --jq '.id' 2>/dev/null || echo "")
 		if [[ -n "$node_id" ]]; then
 			gh api graphql -f query="
 				mutation {
@@ -628,11 +628,11 @@ _gather_health_stats() {
 	# Open issues — assigned to this runner (actionable) vs total.
 	# --limit 500: gh defaults to 30, which undercounts for active repos.
 	local assigned_issue_count
-	assigned_issue_count=$(gh issue list --repo "$repo_slug" --state open \
+	assigned_issue_count=$(gh_issue_list --repo "$repo_slug" --state open \
 		--assignee "$runner_user" --limit 500 \
 		--json number --jq 'length' 2>/dev/null || echo "0")
 	local total_issue_count
-	total_issue_count=$(gh issue list --repo "$repo_slug" --state open \
+	total_issue_count=$(gh_issue_list --repo "$repo_slug" --state open \
 		--limit 500 \
 		--json number,labels --jq '[.[] | select(.labels | map(.name) | (index("supervisor") or index("contributor") or index("persistent") or index("quality-review")) | not)] | length' 2>/dev/null || echo "0")
 
@@ -1000,7 +1000,7 @@ _update_health_issue_title() {
 
 	local current_title=""
 	local view_output
-	view_output=$(gh issue view "$health_issue_number" --repo "$repo_slug" --json title --jq '.title' 2>&1)
+	view_output=$(gh_issue_view "$health_issue_number" --repo "$repo_slug" --json title --jq '.title' 2>&1)
 	local view_exit_code=$?
 	if [[ $view_exit_code -eq 0 ]]; then
 		current_title="$view_output"
@@ -1226,7 +1226,7 @@ _ensure_health_issue_pinned() {
 	_cleanup_stale_pinned_issues "$repo_slug" "$runner_user"
 
 	local active_node_id
-	active_node_id=$(gh issue view "$health_issue_number" --repo "$repo_slug" \
+	active_node_id=$(gh_issue_view "$health_issue_number" --repo "$repo_slug" \
 		--json id --jq '.id' 2>/dev/null || echo "")
 	if [[ -n "$active_node_id" ]]; then
 		gh api graphql -f query="
@@ -1307,7 +1307,7 @@ _check_health_issue_activity_guard() {
 	local guard_pr_count guard_assigned_count guard_worker_count
 	guard_pr_count=$(gh pr list --repo "$repo_slug" --state open \
 		--json number --jq 'length' 2>/dev/null || echo "0")
-	guard_assigned_count=$(gh issue list --repo "$repo_slug" \
+	guard_assigned_count=$(gh_issue_list --repo "$repo_slug" \
 		--assignee "$runner_user" --state open \
 		--json number --jq 'length' 2>/dev/null || echo "0")
 
@@ -1482,7 +1482,7 @@ _unpin_health_issue() {
 	[[ -z "$issue_number" || -z "$repo_slug" ]] && return 0
 
 	local issue_node_id
-	issue_node_id=$(gh issue view "$issue_number" --repo "$repo_slug" --json id --jq '.id' 2>/dev/null || echo "")
+	issue_node_id=$(gh_issue_view "$issue_number" --repo "$repo_slug" --json id --jq '.id' 2>/dev/null || echo "")
 	[[ -z "$issue_node_id" ]] && return 0
 
 	gh api graphql -f query="

--- a/.agents/scripts/tests/test-gh-issue-read-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-issue-read-rest-fallback.sh
@@ -1,0 +1,512 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-gh-issue-read-rest-fallback.sh — t2689 / GH#20309 regression guard.
+#
+# Asserts that `gh issue view` and `gh issue list` wrappers in shared-gh-wrappers.sh
+# fall back to REST API (`gh api GET /repos/...`) when:
+#   1. the primary `gh issue view` / `gh issue list` call fails, AND
+#   2. `gh api rate_limit --jq .resources.graphql.remaining` returns <= 10.
+#
+# Context (GH#20301, 2026-04-21):
+#   GraphQL quota saturated to 0/5000 for ~45 min. t2574 added REST fallback
+#   for CREATE/EDIT/COMMENT paths but NOT for READ paths. During exhaustion,
+#   `gh issue view` and `gh issue list` still returned non-zero exit codes.
+#   Callers that treated failure as "not found" created duplicate issues.
+#   t2687 (PR #20308) patched ONE call site (stats-health-dashboard.sh). This
+#   task (t2689) adds framework-wide fallback so every caller benefits.
+#
+# Tests:
+#   1. _rest_issue_view → GET /repos/.../issues/N (correct REST path)
+#   2. _rest_issue_view → applies --jq expression to REST response
+#   3. _rest_issue_view → accepts --json flag without error (compat, ignored)
+#   4. _rest_issue_view → returns error when issue number or repo missing
+#   5. _rest_issue_list → GET /repos/.../issues?state=open&per_page=N
+#   6. _rest_issue_list → includes label filter in query string
+#   7. _rest_issue_list → handles multiple --label flags (comma-joined)
+#   8. _rest_issue_list → applies --jq expression
+#   9. _rest_issue_list → includes --assignee in query string
+#  10. _rest_issue_list → returns error when --repo is missing
+#  11. gh_issue_view falls back to REST when primary fails AND GraphQL exhausted
+#  12. gh_issue_view does NOT fall back when primary succeeds
+#  13. gh_issue_view does NOT fall back when primary fails but GraphQL healthy
+#  14. gh_issue_list falls back to REST when primary fails AND GraphQL exhausted
+#  15. gh_issue_list does NOT fall back when primary succeeds
+#  16. gh_issue_list does NOT fall back when primary fails but GraphQL healthy
+#  17. _rest_issue_list handles --search flag without error (silently skipped)
+#
+# Stub strategy: define `gh` as a shell function. Shell functions take
+# precedence over PATH binaries, so the stub captures all `gh` invocations
+# without PATH mutation.
+
+set -uo pipefail
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR_TEST}/.." && pwd)" || exit 1
+
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_BLUE=$'\033[0;34m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_BLUE="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf '  %sPASS%s %s\n' "$TEST_GREEN" "$TEST_NC" "$1"
+	return 0
+}
+
+fail() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '  %sFAIL%s %s\n' "$TEST_RED" "$TEST_NC" "$1"
+	if [[ -n "${2:-}" ]]; then
+		printf '       %s\n' "$2"
+	fi
+	return 0
+}
+
+# =============================================================================
+# Sandbox
+# =============================================================================
+TMP=$(mktemp -d -t t2689.XXXXXX)
+trap 'rm -rf "$TMP"' EXIT
+
+GH_CALLS="${TMP}/gh_calls.log"
+GH_INFO_OUTPUT="${TMP}/info_output.log"
+
+# Configurable stub behaviour per test via env vars:
+#   STUB_RATE_LIMIT_REMAINING  — what gh api rate_limit returns (default: 5000)
+#   STUB_PRIMARY_FAIL          — 1 to make gh issue view/list fail
+#   STUB_REST_FAIL             — 1 to make gh api GET calls fail
+#   STUB_VIEW_RESULT           — JSON string returned by primary gh issue view
+#   STUB_LIST_RESULT           — JSON string returned by primary gh issue list
+#   STUB_REST_VIEW_RESULT      — JSON string returned by REST gh api /issues/N
+#   STUB_REST_LIST_RESULT      — JSON string returned by REST gh api /issues?...
+# =============================================================================
+print_info() { printf '[INFO] %s\n' "$*" >>"${GH_INFO_OUTPUT}"; return 0; }
+print_warning() { return 0; }
+print_error() { return 0; }
+print_success() { return 0; }
+log_verbose() { return 0; }
+export -f print_info print_warning print_error print_success log_verbose
+
+export AIDEVOPS_SESSION_ORIGIN=interactive
+export AIDEVOPS_SESSION_USER=testuser
+
+# shellcheck source=../shared-constants.sh
+source "${SCRIPTS_DIR}/shared-constants.sh" >/dev/null 2>&1 || true
+
+# Re-override print_* AFTER sourcing — shared-constants.sh defines its own.
+# shellcheck disable=SC2317
+print_info() { printf '[INFO] %s\n' "$*" >>"${GH_INFO_OUTPUT}"; return 0; }
+export -f print_info
+
+# Post-source stubs. Shell functions beat PATH binaries.
+gh() {
+	printf '%s\n' "$*" >>"${GH_CALLS}"
+
+	# gh api rate_limit — returns configurable value
+	if [[ "$1" == "api" && "$2" == "rate_limit" ]]; then
+		local remaining="${STUB_RATE_LIMIT_REMAINING:-5000}"
+		printf '%s\n' "$remaining"
+		return 0
+	fi
+
+	# gh api user — returns testuser
+	if [[ "$1" == "api" && "$2" == "user" ]]; then
+		printf '"testuser"\n'
+		return 0
+	fi
+
+	# gh api /repos/.../issues/N — REST issue view
+	if [[ "$1" == "api" && "$2" =~ ^/repos/.+/issues/[0-9]+ && "${STUB_REST_FAIL:-0}" != "1" ]]; then
+		# Apply --jq if present in args
+		local _jq_expr=""
+		local _i=3
+		while [[ $_i -le $# ]]; do
+			local _v="${!_i}"
+			if [[ "$_v" == "--jq" ]]; then
+				_i=$((_i + 1))
+				_jq_expr="${!_i}"
+				break
+			fi
+			_i=$((_i + 1))
+		done
+		local _result="${STUB_REST_VIEW_RESULT:-{\"state\":\"OPEN\",\"number\":42,\"title\":\"Test issue\",\"body\":\"body text\",\"labels\":[{\"name\":\"bug\"}],\"assignees\":[]}}"
+		if [[ -n "$_jq_expr" ]]; then
+			printf '%s\n' "$_result" | jq -r "$_jq_expr" 2>/dev/null
+		else
+			printf '%s\n' "$_result"
+		fi
+		return 0
+	fi
+
+	# gh api /repos/.../issues?... — REST issue list
+	if [[ "$1" == "api" && "$2" =~ ^/repos/.+/issues\? && "${STUB_REST_FAIL:-0}" != "1" ]]; then
+		local _jq_expr=""
+		local _i=3
+		while [[ $_i -le $# ]]; do
+			local _v="${!_i}"
+			if [[ "$_v" == "--jq" ]]; then
+				_i=$((_i + 1))
+				_jq_expr="${!_i}"
+				break
+			fi
+			_i=$((_i + 1))
+		done
+		local _result="${STUB_REST_LIST_RESULT:-[{\"number\":1,\"title\":\"Issue one\",\"labels\":[]},{\"number\":2,\"title\":\"Issue two\",\"labels\":[]}]}"
+		if [[ -n "$_jq_expr" ]]; then
+			printf '%s\n' "$_result" | jq -r "$_jq_expr" 2>/dev/null
+		else
+			printf '%s\n' "$_result"
+		fi
+		return 0
+	fi
+
+	# gh api -X POST|PATCH ... (write REST) — for other wrappers
+	if [[ "$1" == "api" && ("$2" == "-X" || "$2" =~ ^-X) ]]; then
+		if [[ "${STUB_REST_FAIL:-0}" == "1" ]]; then
+			printf 'REST stub forced failure\n' >&2
+			return 1
+		fi
+		printf 'https://github.com/owner/repo/issues/9999\n'
+		return 0
+	fi
+
+	# gh issue view — primary path
+	if [[ "$1" == "issue" && "$2" == "view" ]]; then
+		if [[ "${STUB_PRIMARY_FAIL:-0}" == "1" ]]; then
+			printf 'primary stub forced failure (rate limit)\n' >&2
+			return 1
+		fi
+		local _result="${STUB_VIEW_RESULT:-{\"state\":\"OPEN\",\"number\":42,\"title\":\"Test issue\"}}"
+		printf '%s\n' "$_result"
+		return 0
+	fi
+
+	# gh issue list — primary path
+	if [[ "$1" == "issue" && "$2" == "list" ]]; then
+		if [[ "${STUB_PRIMARY_FAIL:-0}" == "1" ]]; then
+			printf 'primary stub forced failure (rate limit)\n' >&2
+			return 1
+		fi
+		local _result="${STUB_LIST_RESULT:-[{\"number\":1,\"title\":\"Issue one\"},{\"number\":2,\"title\":\"Issue two\"}]}"
+		printf '%s\n' "$_result"
+		return 0
+	fi
+
+	# gh issue create/comment/edit and other calls — silent success
+	return 0
+}
+export -f gh
+
+printf '%sRunning gh-wrapper READ REST fallback tests (t2689 / GH#20309)%s\n' \
+	"$TEST_BLUE" "$TEST_NC"
+
+# =============================================================================
+# Test 1: _rest_issue_view calls GET /repos/.../issues/N
+# =============================================================================
+: >"$GH_CALLS"
+
+_rest_issue_view 42 --repo "owner/repo" >/dev/null 2>&1 || true
+
+if grep -qE '^api /repos/owner/repo/issues/42' "$GH_CALLS" 2>/dev/null; then
+	pass "_rest_issue_view calls GET /repos/owner/repo/issues/42"
+else
+	fail "_rest_issue_view calls GET /repos/owner/repo/issues/42" \
+		"GH_CALLS=$(cat "$GH_CALLS")"
+fi
+
+# =============================================================================
+# Test 2: _rest_issue_view applies --jq expression
+# =============================================================================
+: >"$GH_CALLS"
+export STUB_REST_VIEW_RESULT='{"state":"OPEN","number":42,"title":"Hello world"}'
+
+result=$(_rest_issue_view 42 --repo "owner/repo" --jq '.title' 2>/dev/null)
+
+if [[ "$result" == "Hello world" ]]; then
+	pass "_rest_issue_view applies --jq '.title' correctly"
+else
+	fail "_rest_issue_view applies --jq '.title' correctly" \
+		"expected 'Hello world', got '${result}'"
+fi
+unset STUB_REST_VIEW_RESULT
+
+# =============================================================================
+# Test 3: _rest_issue_view accepts --json flag without error (compat, ignored)
+# =============================================================================
+: >"$GH_CALLS"
+
+_result=$(_rest_issue_view 42 --repo "owner/repo" --json state 2>&1)
+_rc=$?
+
+if [[ $_rc -eq 0 ]]; then
+	pass "_rest_issue_view accepts --json flag without error"
+else
+	fail "_rest_issue_view accepts --json flag without error" \
+		"rc=${_rc} output=${_result}"
+fi
+
+# =============================================================================
+# Test 4: _rest_issue_view returns error when issue number or repo missing
+# =============================================================================
+_err_output=$(_rest_issue_view 42 2>&1)
+_rc=$?
+if [[ $_rc -ne 0 ]]; then
+	pass "_rest_issue_view returns error when --repo is missing"
+else
+	fail "_rest_issue_view returns error when --repo is missing" \
+		"expected non-zero rc but got 0"
+fi
+
+_err_output=$(_rest_issue_view --repo "owner/repo" 2>&1)
+_rc=$?
+if [[ $_rc -ne 0 ]]; then
+	pass "_rest_issue_view returns error when issue number is missing"
+else
+	fail "_rest_issue_view returns error when issue number is missing" \
+		"expected non-zero rc but got 0"
+fi
+
+# =============================================================================
+# Test 5: _rest_issue_list builds correct query (state + per_page)
+# =============================================================================
+: >"$GH_CALLS"
+
+_rest_issue_list --repo "owner/repo" --state open --limit 50 >/dev/null 2>&1 || true
+
+if grep -qE '^api /repos/owner/repo/issues\?state=open&per_page=50' "$GH_CALLS" 2>/dev/null; then
+	pass "_rest_issue_list builds correct query with state=open&per_page=50"
+else
+	fail "_rest_issue_list builds correct query with state=open&per_page=50" \
+		"GH_CALLS=$(cat "$GH_CALLS")"
+fi
+
+# =============================================================================
+# Test 6: _rest_issue_list includes label filter in query string
+# =============================================================================
+: >"$GH_CALLS"
+
+_rest_issue_list --repo "owner/repo" --state open --label "bug" >/dev/null 2>&1 || true
+
+if grep -qE 'labels=bug' "$GH_CALLS" 2>/dev/null; then
+	pass "_rest_issue_list includes label=bug in query string"
+else
+	fail "_rest_issue_list includes label=bug in query string" \
+		"GH_CALLS=$(cat "$GH_CALLS")"
+fi
+
+# =============================================================================
+# Test 7: _rest_issue_list handles multiple --label flags (comma-joined)
+# =============================================================================
+: >"$GH_CALLS"
+
+_rest_issue_list --repo "owner/repo" --label "supervisor" --label "alice" >/dev/null 2>&1 || true
+
+if grep -qE 'labels=supervisor,alice' "$GH_CALLS" 2>/dev/null; then
+	pass "_rest_issue_list joins multiple --label flags as comma-separated"
+else
+	fail "_rest_issue_list joins multiple --label flags as comma-separated" \
+		"GH_CALLS=$(cat "$GH_CALLS")"
+fi
+
+# =============================================================================
+# Test 8: _rest_issue_list applies --jq expression
+# =============================================================================
+: >"$GH_CALLS"
+export STUB_REST_LIST_RESULT='[{"number":7,"title":"Alpha"},{"number":8,"title":"Beta"}]'
+
+result=$(_rest_issue_list --repo "owner/repo" --state open --jq '.[0].title' 2>/dev/null)
+
+if [[ "$result" == "Alpha" ]]; then
+	pass "_rest_issue_list applies --jq '.[0].title' correctly"
+else
+	fail "_rest_issue_list applies --jq '.[0].title' correctly" \
+		"expected 'Alpha', got '${result}'"
+fi
+unset STUB_REST_LIST_RESULT
+
+# =============================================================================
+# Test 9: _rest_issue_list includes --assignee in query string
+# =============================================================================
+: >"$GH_CALLS"
+
+_rest_issue_list --repo "owner/repo" --state open --assignee "alice" >/dev/null 2>&1 || true
+
+if grep -qE 'assignee=alice' "$GH_CALLS" 2>/dev/null; then
+	pass "_rest_issue_list includes assignee=alice in query string"
+else
+	fail "_rest_issue_list includes assignee=alice in query string" \
+		"GH_CALLS=$(cat "$GH_CALLS")"
+fi
+
+# =============================================================================
+# Test 10: _rest_issue_list returns error when --repo is missing
+# =============================================================================
+_err_output=$(_rest_issue_list --state open 2>&1)
+_rc=$?
+if [[ $_rc -ne 0 ]]; then
+	pass "_rest_issue_list returns error when --repo is missing"
+else
+	fail "_rest_issue_list returns error when --repo is missing" \
+		"expected non-zero rc but got 0"
+fi
+
+# =============================================================================
+# Test 11: gh_issue_view falls back to REST when primary fails AND GraphQL exhausted
+# =============================================================================
+: >"$GH_CALLS"
+: >"$GH_INFO_OUTPUT"
+export STUB_PRIMARY_FAIL=1
+export STUB_RATE_LIMIT_REMAINING=0
+
+gh_issue_view 42 --repo "owner/repo" --json state --jq '.state' >/dev/null 2>&1 || true
+
+if grep -qE '^issue view' "$GH_CALLS" 2>/dev/null &&
+	grep -qE '^api rate_limit' "$GH_CALLS" 2>/dev/null &&
+	grep -qE '^api /repos/owner/repo/issues/42' "$GH_CALLS" 2>/dev/null &&
+	grep -q 'GraphQL exhausted.*issue view' "$GH_INFO_OUTPUT" 2>/dev/null; then
+	pass "gh_issue_view falls back to REST when primary fails AND exhausted"
+else
+	fail "gh_issue_view falls back to REST when primary fails AND exhausted" \
+		"GH_CALLS=$(cat "$GH_CALLS") | INFO=$(cat "$GH_INFO_OUTPUT")"
+fi
+
+unset STUB_PRIMARY_FAIL
+export STUB_RATE_LIMIT_REMAINING=5000
+
+# =============================================================================
+# Test 12: gh_issue_view does NOT fall back when primary succeeds
+# =============================================================================
+: >"$GH_CALLS"
+: >"$GH_INFO_OUTPUT"
+
+gh_issue_view 42 --repo "owner/repo" --json state >/dev/null 2>&1 || true
+
+if grep -qE '^issue view' "$GH_CALLS" 2>/dev/null &&
+	! grep -qE '^api /repos/owner/repo/issues/42' "$GH_CALLS" 2>/dev/null; then
+	pass "gh_issue_view does NOT fall back when primary succeeds"
+else
+	fail "gh_issue_view does NOT fall back when primary succeeds" \
+		"GH_CALLS=$(cat "$GH_CALLS") | INFO=$(cat "$GH_INFO_OUTPUT")"
+fi
+
+# =============================================================================
+# Test 13: gh_issue_view does NOT fall back when primary fails but GraphQL healthy
+# =============================================================================
+: >"$GH_CALLS"
+: >"$GH_INFO_OUTPUT"
+export STUB_PRIMARY_FAIL=1
+export STUB_RATE_LIMIT_REMAINING=5000
+
+gh_issue_view 42 --repo "owner/repo" --json state >/dev/null 2>&1 || true
+
+if grep -qE '^issue view' "$GH_CALLS" 2>/dev/null &&
+	grep -qE '^api rate_limit' "$GH_CALLS" 2>/dev/null &&
+	! grep -qE '^api /repos/owner/repo/issues/42' "$GH_CALLS" 2>/dev/null; then
+	pass "gh_issue_view does NOT fall back when primary fails but GraphQL healthy"
+else
+	fail "gh_issue_view does NOT fall back when primary fails but GraphQL healthy" \
+		"GH_CALLS=$(cat "$GH_CALLS")"
+fi
+
+unset STUB_PRIMARY_FAIL
+export STUB_RATE_LIMIT_REMAINING=5000
+
+# =============================================================================
+# Test 14: gh_issue_list falls back to REST when primary fails AND GraphQL exhausted
+# =============================================================================
+: >"$GH_CALLS"
+: >"$GH_INFO_OUTPUT"
+export STUB_PRIMARY_FAIL=1
+export STUB_RATE_LIMIT_REMAINING=0
+
+gh_issue_list --repo "owner/repo" --state open --json number >/dev/null 2>&1 || true
+
+if grep -qE '^issue list' "$GH_CALLS" 2>/dev/null &&
+	grep -qE '^api rate_limit' "$GH_CALLS" 2>/dev/null &&
+	grep -qE '^api /repos/owner/repo/issues\?' "$GH_CALLS" 2>/dev/null &&
+	grep -q 'GraphQL exhausted.*issue list' "$GH_INFO_OUTPUT" 2>/dev/null; then
+	pass "gh_issue_list falls back to REST when primary fails AND exhausted"
+else
+	fail "gh_issue_list falls back to REST when primary fails AND exhausted" \
+		"GH_CALLS=$(cat "$GH_CALLS") | INFO=$(cat "$GH_INFO_OUTPUT")"
+fi
+
+unset STUB_PRIMARY_FAIL
+export STUB_RATE_LIMIT_REMAINING=5000
+
+# =============================================================================
+# Test 15: gh_issue_list does NOT fall back when primary succeeds
+# =============================================================================
+: >"$GH_CALLS"
+: >"$GH_INFO_OUTPUT"
+
+gh_issue_list --repo "owner/repo" --state open >/dev/null 2>&1 || true
+
+if grep -qE '^issue list' "$GH_CALLS" 2>/dev/null &&
+	! grep -qE '^api /repos/owner/repo/issues\?' "$GH_CALLS" 2>/dev/null; then
+	pass "gh_issue_list does NOT fall back when primary succeeds"
+else
+	fail "gh_issue_list does NOT fall back when primary succeeds" \
+		"GH_CALLS=$(cat "$GH_CALLS") | INFO=$(cat "$GH_INFO_OUTPUT")"
+fi
+
+# =============================================================================
+# Test 16: gh_issue_list does NOT fall back when primary fails but GraphQL healthy
+# =============================================================================
+: >"$GH_CALLS"
+: >"$GH_INFO_OUTPUT"
+export STUB_PRIMARY_FAIL=1
+export STUB_RATE_LIMIT_REMAINING=5000
+
+gh_issue_list --repo "owner/repo" --state open >/dev/null 2>&1 || true
+
+if grep -qE '^issue list' "$GH_CALLS" 2>/dev/null &&
+	grep -qE '^api rate_limit' "$GH_CALLS" 2>/dev/null &&
+	! grep -qE '^api /repos/owner/repo/issues\?' "$GH_CALLS" 2>/dev/null; then
+	pass "gh_issue_list does NOT fall back when primary fails but GraphQL healthy"
+else
+	fail "gh_issue_list does NOT fall back when primary fails but GraphQL healthy" \
+		"GH_CALLS=$(cat "$GH_CALLS")"
+fi
+
+unset STUB_PRIMARY_FAIL
+export STUB_RATE_LIMIT_REMAINING=5000
+
+# =============================================================================
+# Test 17: _rest_issue_list handles --search flag without error (silently skipped)
+# =============================================================================
+: >"$GH_CALLS"
+
+_result=$(_rest_issue_list --repo "owner/repo" --state open \
+	--search "in:title [Supervisor:" 2>&1)
+_rc=$?
+
+if [[ $_rc -eq 0 ]]; then
+	pass "_rest_issue_list handles --search flag without error (silently skipped)"
+else
+	fail "_rest_issue_list handles --search flag without error (silently skipped)" \
+		"rc=${_rc} output=${_result}"
+fi
+
+# =============================================================================
+# Summary
+# =============================================================================
+printf '\n'
+if [[ $TESTS_FAILED -eq 0 ]]; then
+	printf '%s%d/%d tests passed%s\n' "$TEST_GREEN" "$TESTS_RUN" "$TESTS_RUN" "$TEST_NC"
+	exit 0
+else
+	printf '%s%d/%d tests failed%s\n' "$TEST_RED" "$TESTS_FAILED" "$TESTS_RUN" "$TEST_NC"
+	exit 1
+fi


### PR DESCRIPTION
## Summary

Added gh_issue_view and gh_issue_list wrapper functions with REST fallback to cover read paths during GraphQL exhaustion. Mirrors t2574 write-path pattern. Added _rest_issue_view and _rest_issue_list translators. Migrated 9 call sites in stats-health-dashboard.sh + 4 in 3 other files.

## Files Changed

.agents/scripts/brief-readiness-helper.sh,.agents/scripts/dispatch-dedup-helper.sh,.agents/scripts/dispatch-dedup-stale.sh,.agents/scripts/shared-gh-wrappers-rest-fallback.sh,.agents/scripts/shared-gh-wrappers.sh,.agents/scripts/stats-health-dashboard.sh,.agents/scripts/tests/test-gh-issue-read-rest-fallback.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-gh-issue-read-rest-fallback.sh (18/18 pass) and bash .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh (20/20 pass, no regression). shellcheck zero new violations on all modified files.

Resolves #20309


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.91 plugin for [OpenCode](https://opencode.ai) v1.14.19 with claude-sonnet-4-6 spent 12m and 37,131 tokens on this as a headless worker.