### PR TITLE
GH#20326: fix(t2699): strip persistent label before dedup close to prevent issue-sync reopen

### DIFF
--- a/.agents/scripts/migrate-health-issue-duplicates-t2687.sh
+++ b/.agents/scripts/migrate-health-issue-duplicates-t2687.sh
@@ -234,6 +234,10 @@ _close_duplicate_groups() {
 			[[ -z "$close_num" ]] && continue
 			local comment="Closing duplicate ${role} health issue — superseded by #${keep}. Root cause: GraphQL rate-limit window on 2026-04-21 (t2574 REST fallback covered CREATE but not READ paths). See GH#20301 for the systemic fix."
 			_unpin_duplicate_issue "$close_num" "$repo"
+			# Strip 'persistent' before closing so issue-sync.yml 'Reopen Persistent Issues'
+			# job does not reopen the duplicate (GH#20326). That job blocks USER-initiated
+			# closes, not programmatic dedup. Idempotent: no-op if label not present.
+			run_gh issue edit "$close_num" --repo "$repo" --remove-label persistent 2>/dev/null || true
 			run_gh issue close "$close_num" --repo "$repo" --comment "$comment" \
 				|| log_warn "    close failed for #${close_num}"
 		done <<<"$close_list"

--- a/.agents/scripts/stats-health-dashboard.sh
+++ b/.agents/scripts/stats-health-dashboard.sh
@@ -150,6 +150,10 @@ _close_health_issue_duplicates() {
 	while IFS= read -r dup_num; do
 		[[ -z "$dup_num" ]] && continue
 		[[ "$runner_role" == "supervisor" ]] && _unpin_health_issue "$dup_num" "$repo_slug"
+		# Strip 'persistent' before closing so issue-sync.yml 'Reopen Persistent Issues'
+		# job does not reopen the duplicate. That job is designed to block USER-initiated
+		# closes, not programmatic dedup. Idempotent: no-op if label not present.
+		gh issue edit "$dup_num" --repo "$repo_slug" --remove-label persistent 2>/dev/null || true
 		gh issue close "$dup_num" --repo "$repo_slug" \
 			--comment "Closing duplicate ${runner_role} health issue — superseded by #${keep_number}." 2>/dev/null || true
 	done <<<"$dup_numbers"
@@ -446,6 +450,10 @@ _periodic_health_issue_dedup() {
 			# Duplicate supervisor issues CAN be pinned in pathological
 			# cases (stale pin from a pre-rate-limit canonical).
 			_unpin_health_issue "$dup_num" "$repo_slug"
+			# Strip 'persistent' before closing so issue-sync.yml 'Reopen Persistent Issues'
+			# job does not reopen the duplicate (GH#20326). That job blocks USER-initiated
+			# closes, not programmatic dedup. Idempotent: no-op if label not present.
+			gh issue edit "$dup_num" --repo "$repo_slug" --remove-label persistent 2>/dev/null || true
 			gh issue close "$dup_num" --repo "$repo_slug" \
 				--comment "Closing duplicate ${runner_role} health issue — superseded by #${current_issue} (t2687 periodic dedup). Root cause likely a past GraphQL rate-limit window; see GH#20301." 2>/dev/null || true
 			echo "[stats] Health issue: periodic dedup closed #${dup_num} in ${repo_slug} (kept #${current_issue})" >>"${LOGFILE:-/dev/null}"


### PR DESCRIPTION
## Summary

Added strip of 'persistent' label before closing duplicate health issues in both _close_health_issue_duplicates and _periodic_health_issue_dedup (stats-health-dashboard.sh) and _close_duplicate_groups (migrate-health-issue-duplicates-t2687.sh). Prevents issue-sync.yml 'Reopen Persistent Issues' job from reopening programmatically-closed duplicates.

## Files Changed

.agents/scripts/migrate-health-issue-duplicates-t2687.sh,.agents/scripts/stats-health-dashboard.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck passes on both modified files. Changes are idempotent (gh issue edit --remove-label is a no-op when label absent). Pattern matches the root cause: #20267 closed then reopened 6s later.

Resolves #20326


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.91 plugin for [OpenCode](https://opencode.ai) v1.14.19 with claude-sonnet-4-6 spent 3m and 7,277 tokens on this as a headless worker.