### PR TITLE
GH#20339: t2702: disable r912 dashboard routine

### DIFF
--- a/.agents/scripts/routines/core-routines.sh
+++ b/.agents/scripts/routines/core-routines.sh
@@ -27,7 +27,7 @@ r908|x|Profile README update|repeat:cron(0 * * * *)|~30s|scripts/profile-readme-
 r909|x|Screen time snapshot|repeat:cron(0 */6 * * *)|~10s|scripts/screen-time-helper.sh snapshot|script
 r910|x|Skills sync — refresh agent skills|repeat:cron(*/5 * * * *)|~15s|bin/aidevops-skills-sync|script
 r911|x|OAuth token refresh|repeat:cron(*/30 * * * *)|~10s|scripts/oauth-pool-helper.sh refresh|script
-r912|x|Dashboard server|repeat:persistent|~0s|server/index.ts|service
+r912| |Dashboard server|repeat:persistent|~0s|server/index.ts|service
 r913|x|Weekly opencode DB maintenance|repeat:weekly(sun@04:00)|~2m|scripts/opencode-db-maintenance-helper.sh auto|script
 r914|x|Repo aidevops health — bump stale .aidevops.json, detect drift|repeat:daily(@03:30)|~2m|scripts/repo-aidevops-health-helper.sh run|script
 ENTRIES


### PR DESCRIPTION
## Summary

Disabled r912 (dashboard server) routine by changing enabled flag from 'x' to ' ' (space) in core-routines.sh:30. The routine pointed to server/index.ts which has never shipped and does not exist in the repo.

## Files Changed

.agents/scripts/routines/core-routines.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified: r912 entry shows '| |' instead of '|x|', no regression in shellcheck

Resolves #20339


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.91 plugin for [OpenCode](https://opencode.ai) v1.14.19 with claude-haiku-4-5 spent 44s and 1,186 tokens on this as a headless worker.