### PR TITLE
t2704: auto-detect --head/--base in _gh_pr_create_rest when GraphQL exhausted

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -422,7 +422,8 @@ _gh_rest_compute_target_set() {
 _gh_pr_create_rest() {
 	local title=""
 	local head=""
-	local base="main"
+	local base=""
+	local has_base=0
 	local body=""
 	local body_file=""
 	local repo=""
@@ -440,8 +441,8 @@ _gh_pr_create_rest() {
 		--title=*) title="${_arg#--title=}"; shift ;;
 		--head) head="${2:-}"; shift 2 ;;
 		--head=*) head="${_arg#--head=}"; shift ;;
-		--base) base="${2:-}"; shift 2 ;;
-		--base=*) base="${_arg#--base=}"; shift ;;
+		--base) base="${2:-}"; has_base=1; shift 2 ;;
+		--base=*) base="${_arg#--base=}"; has_base=1; shift ;;
 		--body) body="${2:-}"; has_body=1; shift 2 ;;
 		--body=*) body="${_arg#--body=}"; has_body=1; shift ;;
 		--body-file) body_file="${2:-}"; has_body=1; shift 2 ;;
@@ -462,8 +463,33 @@ _gh_pr_create_rest() {
 		return 1
 	fi
 	if [[ -z "$head" ]]; then
-		printf '_gh_pr_create_rest: --head is required\n' >&2
-		return 1
+		# Auto-detect from current git branch (mirrors gh pr create behaviour).
+		head=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+		if [[ -n "$head" ]]; then
+			print_info "gh-wrapper: auto-detected --head=${head}"
+		else
+			printf '_gh_pr_create_rest: --head is required\n' >&2
+			return 1
+		fi
+	fi
+	if [[ $has_base -eq 0 || -z "$base" ]]; then
+		# Auto-detect repo default branch. Resolution order:
+		#   1. REST /repos/{owner}/{repo} .default_branch (no GraphQL cost)
+		#   2. git symbolic-ref refs/remotes/origin/HEAD
+		#   3. literal "main"
+		local _detected_base=""
+		if [[ -n "$repo" ]]; then
+			_detected_base=$(gh api "/repos/${repo}" --jq '.default_branch' 2>/dev/null || true)
+		fi
+		if [[ -z "$_detected_base" ]]; then
+			_detected_base=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null \
+				| sed 's@^refs/remotes/origin/@@' || true)
+		fi
+		if [[ -z "$_detected_base" ]]; then
+			_detected_base="main"
+		fi
+		base="$_detected_base"
+		print_info "gh-wrapper: auto-detected --base=${base}"
 	fi
 
 	local tmp_body="" tmp_body_owned=0

--- a/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
@@ -42,6 +42,8 @@
 #  15. gh_create_pr falls back to REST when primary fails AND exhausted
 #  16. gh_create_pr does NOT fall back when primary succeeds
 #  17. gh_create_pr does NOT fall back when primary fails but graphql healthy
+#  18. _gh_pr_create_rest without --head auto-detects head from current git branch
+#  19. _gh_pr_create_rest without --base auto-detects base from repo default_branch
 #
 # Stub strategy: define `gh` as a shell function. Shell functions take
 # precedence over PATH binaries, so the stub captures all `gh` invocations
@@ -128,6 +130,12 @@ gh() {
 	# gh api user - always returns testuser (for _gh_wrapper_auto_assignee)
 	if [[ "$1" == "api" && "$2" == "user" ]]; then
 		printf '"testuser"\n'
+		return 0
+	fi
+
+	# gh api /repos/owner/repo (repo metadata - for default_branch detection)
+	if [[ "$1" == "api" && "$2" =~ ^/repos/[^/]+/[^/]+$ ]]; then
+		printf '%s\n' "${STUB_DEFAULT_BRANCH:-main}"
 		return 0
 	fi
 
@@ -526,6 +534,58 @@ fi
 
 unset STUB_PRIMARY_FAIL
 export STUB_RATE_LIMIT_REMAINING=5000
+
+# =============================================================================
+# Test 18: _gh_pr_create_rest without --head auto-detects from current branch
+# The test suite runs inside a git repo, so git rev-parse --abbrev-ref HEAD
+# returns the active branch name. We capture it first for the assertion.
+# =============================================================================
+: >"$GH_CALLS"
+: >"$GH_INFO_OUTPUT"
+_EXPECTED_HEAD=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+
+_gh_pr_create_rest \
+	--repo "owner/repo" \
+	--title "t2704: auto-detect head test" \
+	--base "main" \
+	--body "head auto-detect" >/dev/null 2>&1 || true
+
+if [[ -n "$_EXPECTED_HEAD" ]] &&
+	grep -qF "head=${_EXPECTED_HEAD}" "$GH_CALLS" 2>/dev/null &&
+	grep -qE 'auto-detected --head=' "$GH_INFO_OUTPUT" 2>/dev/null; then
+	pass "_gh_pr_create_rest auto-detects --head from current branch (${_EXPECTED_HEAD})"
+else
+	fail "_gh_pr_create_rest auto-detects --head from current branch" \
+		"expected head=${_EXPECTED_HEAD:-<empty>} | GH_CALLS=$(cat "$GH_CALLS") | INFO=$(cat "$GH_INFO_OUTPUT")"
+fi
+
+unset _EXPECTED_HEAD
+
+# =============================================================================
+# Test 19: _gh_pr_create_rest without --base auto-detects from repo default_branch
+# Stub returns STUB_DEFAULT_BRANCH (set to "develop" to distinguish from "main"
+# literal fallback — verifies the REST path was taken, not just the hardcoded
+# default).
+# =============================================================================
+: >"$GH_CALLS"
+: >"$GH_INFO_OUTPUT"
+export STUB_DEFAULT_BRANCH="develop"
+
+_gh_pr_create_rest \
+	--repo "owner/repo" \
+	--title "t2704: auto-detect base test" \
+	--head "feature/t2704-base-detect" \
+	--body "base auto-detect" >/dev/null 2>&1 || true
+
+if grep -qE 'base=develop' "$GH_CALLS" 2>/dev/null &&
+	grep -qE 'auto-detected --base=develop' "$GH_INFO_OUTPUT" 2>/dev/null; then
+	pass "_gh_pr_create_rest auto-detects --base from repo default_branch (develop)"
+else
+	fail "_gh_pr_create_rest auto-detects --base from repo default_branch" \
+		"GH_CALLS=$(cat "$GH_CALLS") | INFO=$(cat "$GH_INFO_OUTPUT")"
+fi
+
+unset STUB_DEFAULT_BRANCH
 
 # =============================================================================
 # Summary


### PR DESCRIPTION
## What

Auto-detect `--head` and `--base` in `_gh_pr_create_rest` when callers omit them, matching the transparent-fallback intent of t2574.

## Why

When GraphQL is exhausted, `gh_create_pr` correctly falls back to `_gh_pr_create_rest`, but callers that relied on the primary path's implicit head-detection crashed with `--head is required`. Observed during t2701 (PR #20336) at graphql: 0/5000.

The REST fallback is supposed to be transparent per t2574's intent — callers that work under normal conditions should continue to work when GraphQL is exhausted.

## How

- **`_gh_pr_create_rest`** (`shared-gh-wrappers-rest-fallback.sh`): before emitting `--head is required`, try `git rev-parse --abbrev-ref HEAD`. For `--base`, when not explicitly set, detect via `gh api /repos/{owner}/{repo} .default_branch` → `git symbolic-ref refs/remotes/origin/HEAD` → literal `"main"`. Both emit `[INFO] gh-wrapper: auto-detected --head/--base=<value>` when the fallback fires.
- **Tests** (`test-gh-wrapper-rest-fallback.sh`): added assertions 18 (head auto-detect from current branch) and 19 (base auto-detect from mocked REST default_branch "develop" — uses non-"main" value to prove the REST path was taken, not the hardcoded fallback). All 22/22 tests pass.

## Verification

```bash
bash .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
# 22/22 tests passed
shellcheck .agents/scripts/shared-gh-wrappers-rest-fallback.sh
```

Resolves #20337

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.91 plugin for [OpenCode](https://opencode.ai) v1.14.19 with claude-sonnet-4-6 spent 9m and 21,963 tokens on this as a headless worker.
