### PR TITLE
t2704: auto-detect --head/--base in _gh_pr_create_rest REST fallback

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -411,6 +411,47 @@ _gh_rest_compute_target_set() {
 }
 
 #######################################
+# _gh_pr_autodetect_head
+# Returns the current git branch name for use as --head when omitted.
+# Returns empty string when in detached HEAD state or outside a git repo.
+# Emits an [INFO] log line when auto-detect fires.
+#######################################
+_gh_pr_autodetect_head() {
+	local _branch
+	_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
+	if [[ -n "$_branch" && "$_branch" != "HEAD" ]]; then
+		print_info "gh-wrapper: auto-detected --head=${_branch}"
+		printf '%s\n' "$_branch"
+	fi
+	return 0
+}
+
+#######################################
+# _gh_pr_autodetect_base <repo>
+# Returns the repository's default branch for use as --base when omitted.
+# Resolution order:
+#   1. gh api /repos/{repo} --jq .default_branch (REST, no GraphQL cost)
+#   2. git symbolic-ref refs/remotes/origin/HEAD
+#   3. "main" (final fallback)
+# Emits an [INFO] log line when auto-detect fires.
+#######################################
+_gh_pr_autodetect_base() {
+	local _repo="${1:-}"
+	local _base=""
+	if [[ -n "$_repo" ]]; then
+		_base=$(gh api "/repos/${_repo}" --jq '.default_branch' 2>/dev/null)
+	fi
+	if [[ -z "$_base" ]]; then
+		_base=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null \
+			| sed 's@^refs/remotes/origin/@@')
+	fi
+	[[ -z "$_base" ]] && _base="main"
+	print_info "gh-wrapper: auto-detected --base=${_base}"
+	printf '%s\n' "$_base"
+	return 0
+}
+
+#######################################
 # _gh_pr_create_rest: POST /repos/{owner}/{repo}/pulls.
 # Parses gh-style args (--head, --base, --title, --body, --body-file, --draft,
 # --label) into a REST payload. Labels are applied via a separate
@@ -418,11 +459,13 @@ _gh_rest_compute_target_set() {
 # GitHub pulls endpoint does not accept a labels field at creation time.
 # Emits the PR html_url on stdout, mirroring `gh pr create`. Returns underlying
 # gh api exit code.
+# When --head or --base are omitted, auto-detects from git HEAD / repo
+# default branch respectively (see _gh_pr_autodetect_head/base above).
 #######################################
 _gh_pr_create_rest() {
 	local title=""
 	local head=""
-	local base="main"
+	local base=""
 	local body=""
 	local body_file=""
 	local repo=""
@@ -462,8 +505,14 @@ _gh_pr_create_rest() {
 		return 1
 	fi
 	if [[ -z "$head" ]]; then
-		printf '_gh_pr_create_rest: --head is required\n' >&2
-		return 1
+		head=$(_gh_pr_autodetect_head)
+		if [[ -z "$head" ]]; then
+			printf '_gh_pr_create_rest: --head is required\n' >&2
+			return 1
+		fi
+	fi
+	if [[ -z "$base" ]]; then
+		base=$(_gh_pr_autodetect_base "$repo")
 	fi
 
 	local tmp_body="" tmp_body_owned=0

--- a/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
@@ -42,6 +42,8 @@
 #  15. gh_create_pr falls back to REST when primary fails AND exhausted
 #  16. gh_create_pr does NOT fall back when primary succeeds
 #  17. gh_create_pr does NOT fall back when primary fails but graphql healthy
+#  18. _gh_pr_create_rest auto-detects --head from git HEAD when omitted
+#  19. _gh_pr_create_rest auto-detects --base from repo default_branch via REST
 #
 # Stub strategy: define `gh` as a shell function. Shell functions take
 # precedence over PATH binaries, so the stub captures all `gh` invocations
@@ -135,6 +137,13 @@ gh() {
 	if [[ "$1" == "api" && "$2" =~ ^/repos/.+/issues/[0-9]+$ ]]; then
 		# Return pre-canned labels/assignees from env for label delta tests
 		printf '%s\n' "${STUB_CURRENT_LABELS:-bug}"
+		return 0
+	fi
+
+	# gh api /repos/{owner}/{repo} (GET, no -X, no /issues suffix) — default branch lookup
+	# STUB_REPO_DEFAULT_BRANCH controls the returned value (default: main).
+	if [[ "$1" == "api" && "$2" =~ ^/repos/[^/]+/[^/]+$ ]]; then
+		printf '%s\n' "${STUB_REPO_DEFAULT_BRANCH:-main}"
 		return 0
 	fi
 
@@ -526,6 +535,45 @@ fi
 
 unset STUB_PRIMARY_FAIL
 export STUB_RATE_LIMIT_REMAINING=5000
+
+# =============================================================================
+# Test 18: _gh_pr_create_rest auto-detects --head from git HEAD when omitted
+# Verifies that omitting --head causes the current branch to be used as head.
+# =============================================================================
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+: >"$GH_CALLS"
+_gh_pr_create_rest \
+	--repo "owner/repo" \
+	--title "t9999: auto-head test" \
+	--base "main" \
+	--body "auto-detect head body" >/dev/null 2>&1 || true
+
+if [[ -n "$CURRENT_BRANCH" ]] && grep -qE "head=${CURRENT_BRANCH}" "$GH_CALLS" 2>/dev/null; then
+	pass "_gh_pr_create_rest auto-detects --head from git HEAD when omitted"
+else
+	fail "_gh_pr_create_rest auto-detects --head from git HEAD when omitted" \
+		"expected head=${CURRENT_BRANCH} in calls; GH_CALLS=$(cat "$GH_CALLS")"
+fi
+
+# =============================================================================
+# Test 19: _gh_pr_create_rest auto-detects --base from repo default_branch
+# Uses STUB_REPO_DEFAULT_BRANCH=develop to verify REST resolution path.
+# =============================================================================
+: >"$GH_CALLS"
+export STUB_REPO_DEFAULT_BRANCH="develop"
+_gh_pr_create_rest \
+	--repo "owner/repo" \
+	--title "t9999: auto-base test" \
+	--head "feature/t9999-auto-base" \
+	--body "auto-detect base body" >/dev/null 2>&1 || true
+
+if grep -qE "base=develop" "$GH_CALLS" 2>/dev/null; then
+	pass "_gh_pr_create_rest auto-detects --base from repo default_branch via REST"
+else
+	fail "_gh_pr_create_rest auto-detects --base from repo default_branch via REST" \
+		"expected base=develop in calls; GH_CALLS=$(cat "$GH_CALLS")"
+fi
+unset STUB_REPO_DEFAULT_BRANCH
 
 # =============================================================================
 # Summary


### PR DESCRIPTION
## Summary

When `gh_create_pr` falls back to REST due to GraphQL exhaustion, `_gh_pr_create_rest` previously required explicit `--head` and `--base` flags — unlike the primary `gh pr create` path which auto-detects both from the current git context. This caused workers to crash at PR creation with `_gh_pr_create_rest: --head is required` exactly during GraphQL exhaustion windows.

## Changes

- **EDIT** `.agents/scripts/shared-gh-wrappers-rest-fallback.sh`: adds two new helpers:
  - `_gh_pr_autodetect_head`: calls `git rev-parse --abbrev-ref HEAD` to get the current branch
  - `_gh_pr_autodetect_base`: tries `gh api /repos/{owner}/{repo}` (REST, no GraphQL cost) for `default_branch`, falls back to `git symbolic-ref refs/remotes/origin/HEAD`, then literal `main`
  - `_gh_pr_create_rest` now calls these helpers when `--head`/`--base` are omitted; both log `[INFO] gh-wrapper: auto-detected --head/base=<value>` for visibility
  - Function body held at 98 lines (threshold >100 = violation)

- **EDIT** `.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh`: adds Tests 18 and 19 verifying head/base auto-detection; extends `gh` stub with `STUB_REPO_DEFAULT_BRANCH` env var support for the `/repos/{owner}/{repo}` REST endpoint

## Verification

```bash
bash .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
# 22/22 tests passed (including 2 new assertions)
shellcheck .agents/scripts/shared-gh-wrappers-rest-fallback.sh
# zero violations
```

## CI fix note

Previous PR #20348 failed `Complexity Analysis` with function body = 99 lines (threshold >100 = fail). This PR avoids the same issue by extracting auto-detect logic into two small helper functions, keeping `_gh_pr_create_rest` at 98 lines.

Resolves #20337


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.91 plugin for [OpenCode](https://opencode.ai) v1.14.19 with claude-sonnet-4-6 spent 7m and 21,853 tokens on this as a headless worker.