### PR TITLE
t2708: narrow pulse-dirty-pr-sweep origin-interactive rule to true orphans

### DIFF
--- a/.agents/scripts/pulse-dirty-pr-sweep.sh
+++ b/.agents/scripts/pulse-dirty-pr-sweep.sh
@@ -19,7 +19,10 @@
 #   - Never rebases PRs with non-TODO.md conflicts (always escalate instead).
 #   - Never auto-closes PRs tagged `do-not-close` OR linked to an OPEN issue
 #     that has the `parent-task` label.
-#   - Never auto-closes PRs tagged `origin:interactive` (author was active).
+#   - Escalates `origin:interactive` PRs only when the body contains no
+#     recognised issue reference (`For #NNN`, `Ref #NNN`, or a closing
+#     keyword). Referenced PRs flow through the normal age/idle close
+#     heuristic like any other PR (t2708). True orphans still escalate.
 #   - Idempotency: per-PR actions logged to a state file with timestamp;
 #     re-running within 30 min (action cooldown) is a no-op for each PR.
 #   - Dry-run: DRY_RUN=1 env var (or `--dry-run` CLI flag) prints would-be
@@ -304,6 +307,34 @@ _dps_labels_has() {
 	printf '%s' "$labels" | grep -qx "$target"
 }
 
+# Check whether a PR body contains a recognised issue reference (t2708).
+#
+# Recognises three reference patterns, matching the conventions documented in
+# `prompts/build.txt` ("Parent-task PR keyword rule") and the closing-keyword
+# regex used by `_extract_linked_issue` in pulse-merge.sh:
+#
+#   - Closing keywords: `(close[ds]?|fix(es|ed)?|resolve[ds]?)\s+#NNN` (case-
+#     insensitive). These auto-close the linked issue when the PR merges.
+#   - `For #NNN` (case-insensitive) — canonical planning-PR non-closing marker.
+#   - `Ref #NNN` (case-insensitive) — alternate non-closing reference.
+#
+# Returns 0 if any pattern matches, 1 otherwise. Accepts the body as argument.
+# Empty body returns 1.
+_dps_pr_body_has_issue_reference() {
+	local body="$1"
+	[[ -n "$body" ]] || return 1
+	# Closing keywords — same regex pulse-merge.sh:_extract_linked_issue uses.
+	if printf '%s' "$body" | grep -ioE '(close[ds]?|fix(es|ed)?|resolve[ds]?)\s+#[0-9]+' >/dev/null 2>&1; then
+		return 0
+	fi
+	# Non-closing references: "For #NNN" or "Ref #NNN" (word boundary on the
+	# keyword so "before #NNN" and "reference #NNN" don't false-match).
+	if printf '%s' "$body" | grep -ioE '(^|[^[:alnum:]])(for|ref)[[:space:]]+#[0-9]+' >/dev/null 2>&1; then
+		return 0
+	fi
+	return 1
+}
+
 # Decide whether a rebase path is structurally eligible (young + author-ok +
 # not parent-task). Output on stdout: "rebase|todo-only-conflict" if yes,
 # empty string if no. The caller uses a non-empty return to short-circuit.
@@ -369,13 +400,14 @@ _dirty_pr_classify() {
 	local repo_path="$3"
 	local self_login="$4"
 
-	local pr_number mss created updated author head_ref
+	local pr_number mss created updated author head_ref body
 	pr_number=$(printf '%s' "$pr_json" | jq -r '.number // empty')
 	mss=$(printf '%s' "$pr_json" | jq -r '.mergeStateStatus // empty')
 	created=$(printf '%s' "$pr_json" | jq -r '.createdAt // empty')
 	updated=$(printf '%s' "$pr_json" | jq -r '.updatedAt // empty')
 	author=$(printf '%s' "$pr_json" | jq -r '.author.login // empty')
 	head_ref=$(printf '%s' "$pr_json" | jq -r '.headRefName // empty')
+	body=$(printf '%s' "$pr_json" | jq -r '.body // empty')
 
 	if [[ -z "$pr_number" ]]; then
 		printf '%s|invalid-pr-json' "$_DIRTY_ACTION_SKIP"
@@ -424,9 +456,16 @@ _dirty_pr_classify() {
 		printf '%s|parent-task-label' "$_DIRTY_ACTION_ESCALATE"
 		return 0
 	fi
+	# origin:interactive PRs: escalate only if the body has no recognised
+	# issue reference (true orphan). PRs with "For #NNN", "Ref #NNN", or any
+	# closing keyword reference a tracked issue and should flow through the
+	# normal age/idle close heuristic like any other PR (t2708).
 	if [[ "$has_interactive" -eq 1 ]]; then
-		printf '%s|origin-interactive-no-close' "$_DIRTY_ACTION_ESCALATE"
-		return 0
+		if ! _dps_pr_body_has_issue_reference "$body"; then
+			printf '%s|origin-interactive-orphan' "$_DIRTY_ACTION_ESCALATE"
+			return 0
+		fi
+		# Has a reference — fall through to age-based close check.
 	fi
 
 	# Age-based close.
@@ -713,7 +752,7 @@ _dirty_pr_sweep_for_repo() {
 	local list_json err_file
 	err_file=$(mktemp) || err_file=/dev/null
 	list_json=$(gh pr list --repo "$repo_slug" --state open \
-		--json number,mergeStateStatus,createdAt,updatedAt,author,labels,headRefName,baseRefName \
+		--json number,mergeStateStatus,createdAt,updatedAt,author,labels,headRefName,baseRefName,body \
 		--limit "$DIRTY_PR_SWEEP_BATCH_LIMIT" 2>"$err_file") || list_json="[]"
 	[[ -z "$list_json" || "$list_json" == "null" ]] && list_json="[]"
 	rm -f "$err_file" 2>/dev/null || true

--- a/.agents/scripts/tests/test-dirty-pr-sweep.sh
+++ b/.agents/scripts/tests/test-dirty-pr-sweep.sh
@@ -74,8 +74,10 @@ source "${TEST_SCRIPTS_DIR}/pulse-dirty-pr-sweep.sh" || {
 # _dirty_pr_classify reads from `gh pr list`.
 # Args: $1=number $2=mss $3=createdAt $4=updatedAt $5=author $6=headRef
 #       $7=labels_json (e.g. '["origin:worker"]' or '[]')
+#       $8=body (optional; defaults to empty string)
 mkpr() {
 	local n="$1" mss="$2" created="$3" updated="$4" author="$5" head="$6" labels_json="$7"
+	local body="${8:-}"
 	local tmpfile
 	tmpfile=$(mktemp)
 	local labels_array
@@ -88,8 +90,9 @@ mkpr() {
 		--arg author "$author" \
 		--arg head "$head" \
 		--argjson labels "$labels_array" \
+		--arg body "$body" \
 		'{number:$n, mergeStateStatus:$mss, createdAt:$created, updatedAt:$updated,
-			author:{login:$author}, labels:$labels, headRefName:$head, baseRefName:"main"}' \
+			author:{login:$author}, labels:$labels, headRefName:$head, baseRefName:"main", body:$body}' \
 		>"$tmpfile"
 	cat "$tmpfile"
 	rm -f "$tmpfile"
@@ -250,21 +253,105 @@ case "$decision" in
 esac
 
 # =============================================================================
-# Test 6: origin:interactive never auto-closes
+# Test 6: origin:interactive WITHOUT issue reference → escalate (orphan)
+#         After t2708 the label alone no longer forces escalate — the body must
+#         also lack any recognised issue reference.
 # =============================================================================
 
-PR_INTERACTIVE=$(mkpr 600 "DIRTY" \
+PR_INTERACTIVE_ORPHAN=$(mkpr 600 "DIRTY" \
 	"$(iso_n_seconds_ago $((10 * 86400)))" \
 	"$(iso_n_seconds_ago $((5 * 86400)))" \
 	"marcusquinn" \
 	"feature/baz" \
-	'["origin:interactive"]')
+	'["origin:interactive"]' \
+	"Some PR description with no issue reference at all.")
 
-decision=$(_dirty_pr_classify "$PR_INTERACTIVE" "test/repo" "" "marcusquinn")
+decision=$(_dirty_pr_classify "$PR_INTERACTIVE_ORPHAN" "test/repo" "" "marcusquinn")
 case "$decision" in
-	escalate\|*) print_result "opt-out: origin:interactive → escalate (never close)" 0 ;;
-	close\|*) print_result "opt-out: origin:interactive → escalate (never close)" 1 "got: $decision (must NOT close)" ;;
-	*) print_result "opt-out: origin:interactive → escalate (never close)" 1 "got: $decision" ;;
+	escalate\|origin-interactive-orphan) print_result "t2708: origin:interactive orphan → escalate with orphan reason" 0 ;;
+	close\|*) print_result "t2708: origin:interactive orphan → escalate with orphan reason" 1 "got: $decision (must NOT close when body has no ref)" ;;
+	*) print_result "t2708: origin:interactive orphan → escalate with orphan reason" 1 "got: $decision" ;;
+esac
+
+# =============================================================================
+# Test 6a: origin:interactive WITH `Resolves #NNN` → falls through to close
+#          (t2708) A stale+idle interactive PR that references an issue via a
+#          closing keyword should be closable like any other PR.
+# =============================================================================
+
+PR_INTERACTIVE_RESOLVES=$(mkpr 610 "DIRTY" \
+	"$(iso_n_seconds_ago $((10 * 86400)))" \
+	"$(iso_n_seconds_ago $((5 * 86400)))" \
+	"marcusquinn" \
+	"feature/baz-resolves" \
+	'["origin:interactive"]' \
+	"This PR implements the fix. Resolves #12345.")
+
+decision=$(_dirty_pr_classify "$PR_INTERACTIVE_RESOLVES" "test/repo" "" "marcusquinn")
+case "$decision" in
+	close\|stale-and-idle) print_result "t2708: origin:interactive + Resolves #NNN → falls through to close" 0 ;;
+	escalate\|*) print_result "t2708: origin:interactive + Resolves #NNN → falls through to close" 1 "got: $decision (must NOT escalate when body has reference)" ;;
+	*) print_result "t2708: origin:interactive + Resolves #NNN → falls through to close" 1 "got: $decision" ;;
+esac
+
+# =============================================================================
+# Test 6b: origin:interactive WITH `For #NNN` (non-closing reference)
+#          → falls through to close. This is the canonical planning-PR pattern
+#          documented in prompts/build.txt "Parent-task PR keyword rule".
+# =============================================================================
+
+PR_INTERACTIVE_FOR=$(mkpr 620 "DIRTY" \
+	"$(iso_n_seconds_ago $((10 * 86400)))" \
+	"$(iso_n_seconds_ago $((5 * 86400)))" \
+	"marcusquinn" \
+	"feature/baz-for" \
+	'["origin:interactive"]' \
+	"Phase 1 implementation. For #12345.")
+
+decision=$(_dirty_pr_classify "$PR_INTERACTIVE_FOR" "test/repo" "" "marcusquinn")
+case "$decision" in
+	close\|stale-and-idle) print_result "t2708: origin:interactive + For #NNN → falls through to close" 0 ;;
+	escalate\|*) print_result "t2708: origin:interactive + For #NNN → falls through to close" 1 "got: $decision (must NOT escalate when body has For #NNN)" ;;
+	*) print_result "t2708: origin:interactive + For #NNN → falls through to close" 1 "got: $decision" ;;
+esac
+
+# =============================================================================
+# Test 6c: origin:interactive WITH `Ref #NNN` → falls through to close
+# =============================================================================
+
+PR_INTERACTIVE_REF=$(mkpr 630 "DIRTY" \
+	"$(iso_n_seconds_ago $((10 * 86400)))" \
+	"$(iso_n_seconds_ago $((5 * 86400)))" \
+	"marcusquinn" \
+	"feature/baz-ref" \
+	'["origin:interactive"]' \
+	"Investigation notes. Ref #12345.")
+
+decision=$(_dirty_pr_classify "$PR_INTERACTIVE_REF" "test/repo" "" "marcusquinn")
+case "$decision" in
+	close\|stale-and-idle) print_result "t2708: origin:interactive + Ref #NNN → falls through to close" 0 ;;
+	escalate\|*) print_result "t2708: origin:interactive + Ref #NNN → falls through to close" 1 "got: $decision (must NOT escalate when body has Ref #NNN)" ;;
+	*) print_result "t2708: origin:interactive + Ref #NNN → falls through to close" 1 "got: $decision" ;;
+esac
+
+# =============================================================================
+# Test 6d: parent-task label still takes precedence over the narrowed rule.
+#          Even if an interactive PR has a valid reference, the parent-task
+#          label must still force escalate (line 423-425 precedence, t1986).
+# =============================================================================
+
+PR_INTERACTIVE_PARENT=$(mkpr 640 "DIRTY" \
+	"$(iso_n_seconds_ago $((10 * 86400)))" \
+	"$(iso_n_seconds_ago $((5 * 86400)))" \
+	"marcusquinn" \
+	"feature/baz-parent" \
+	'["origin:interactive", "parent-task"]' \
+	"Parent planning PR. Resolves #12345.")
+
+decision=$(_dirty_pr_classify "$PR_INTERACTIVE_PARENT" "test/repo" "" "marcusquinn")
+case "$decision" in
+	escalate\|parent-task-label) print_result "t2708: parent-task precedence preserved over narrowed rule" 0 ;;
+	*) print_result "t2708: parent-task precedence preserved over narrowed rule" 1 "got: $decision (must still escalate with parent-task-label reason)" ;;
 esac
 
 # =============================================================================


### PR DESCRIPTION
# Summary

Narrow the `origin-interactive-no-close` rule in `pulse-dirty-pr-sweep.sh:_dirty_pr_classify` so it only escalates DIRTY `origin:interactive` PRs whose body contains no recognised issue reference. Referenced PRs now fall through to the normal age/idle close heuristic like any other PR.

## Root Cause

Before this PR, the rule at lines 427-430 was:

```bash
if [[ "$has_interactive" -eq 1 ]]; then
    printf '%s|origin-interactive-no-close' "$_DIRTY_ACTION_ESCALATE"
    return 0
fi
```

Every DIRTY `origin:interactive` PR hit this branch unconditionally and was classified as `escalate` — which is a documentation comment (`_dirty_pr_action_escalate` at line 645), not a merge block. The escalate path prevented `_dps_consider_close` (age/idle heuristic) from ever firing, so DIRTY interactive PRs sat indefinitely even when they referenced a tracked issue and met the standard close criteria (>7d old, >3d idle).

The reason code was also misleading: `origin-interactive-no-close` implied the classifier was checking for missing closing keywords, but it only checked the label.

## Change

**New helper** `_dps_pr_body_has_issue_reference` (after `_dps_labels_has`, lines ~307-330). Recognises three documented reference patterns:

1. **Closing keywords**: `(close[ds]?|fix(es|ed)?|resolve[ds]?)\s+#NNN` — same regex used by `pulse-merge.sh:_extract_linked_issue`, keeping the two classifiers in lockstep on what counts as a "link to an issue".
2. **`For #NNN`** — canonical planning-PR non-closing marker, per the "Parent-task PR keyword rule (t2046)" in `prompts/build.txt`.
3. **`Ref #NNN`** — alternate non-closing reference, also documented for planning PRs.

**Narrowed rule** (replaces the unconditional escalate at lines 427-430):

```bash
if [[ "$has_interactive" -eq 1 ]]; then
    if ! _dps_pr_body_has_issue_reference "$body"; then
        printf '%s|origin-interactive-orphan' "$_DIRTY_ACTION_ESCALATE"
        return 0
    fi
    # Has a reference — fall through to age-based close check.
fi
```

**Reason code** changed from `origin-interactive-no-close` → `origin-interactive-orphan` to accurately describe the narrowed semantic.

**JSON extraction** (line 716) extended with `body` so `_dirty_pr_classify` can inspect it.

**Header docblock** updated to describe the new behaviour accurately.

## Precedence Preserved

The `parent-task` label check at lines 423-425 still runs BEFORE the interactive check, so a PR with both labels still escalates with `parent-task-label` — no change to the decomposition-block semantic documented in t1986/t2442.

## Tests

15/15 pass. Added four new cases to `.agents/scripts/tests/test-dirty-pr-sweep.sh`:

- `t2708: origin:interactive orphan → escalate with orphan reason` — body has no reference → `escalate|origin-interactive-orphan`.
- `t2708: origin:interactive + Resolves #NNN → falls through to close` — stale+idle PR with closing keyword → `close|stale-and-idle`.
- `t2708: origin:interactive + For #NNN → falls through to close` — the canonical planning pattern.
- `t2708: origin:interactive + Ref #NNN → falls through to close` — alternate non-closing ref.
- `t2708: parent-task precedence preserved over narrowed rule` — parent-task + interactive + reference still escalates.

The `mkpr` test helper now accepts an optional `body` argument (empty default preserves backward-compat for the existing rebase/close/escalate tests).

## Impact

PRs that match the observed pattern (`origin:interactive` + `For #NNN` planning keyword going DIRTY) — such as #20201, #20232, #20329 — will now be eligible for age-based auto-close once they cross the 7d+3d-idle threshold, instead of accumulating escalate comments forever.

Orphan interactive PRs (label present, no issue reference in body) still escalate — the safety net for "interactive session got interrupted before the author could link the work" remains intact.

## Out of Scope

This is one child of the t2705 investigation parent (#20338). Other t2705 findings (rebase path gates rejecting on non-TODO file-scope interpretations, auto-merge timing gaps) are tracked separately and not addressed here.

Resolves #20355
Ref #20338

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.91 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-opus-4-7 spent 8h 24m and 516,190 tokens on this with the user in an interactive session.
