### PR TITLE
t2709: shared-gh-wrappers.sh: make REST-fallback source path resolution cross-shell (bash + zsh)

### DIFF
--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -41,9 +41,24 @@ _SHARED_GH_WRAPPERS_LOADED=1
 # t2689: Extended to READ paths — _rest_issue_view, _rest_issue_list.
 # Provides _gh_should_fallback_to_rest, _gh_issue_{create,comment,edit}_rest,
 # _gh_pr_create_rest, _rest_issue_view, _rest_issue_list.
-_SHARED_GH_WRAPPERS_DIR="${BASH_SOURCE[0]%/*}"
-# shellcheck source=shared-gh-wrappers-rest-fallback.sh
-source "${_SHARED_GH_WRAPPERS_DIR}/shared-gh-wrappers-rest-fallback.sh"
+# Resolve own directory across bash (BASH_SOURCE) and zsh (%x prompt flag).
+# Prefer SCRIPT_DIR when already set (the common path — shared-constants.sh
+# sets it before sourcing us). Silently skip the REST fallback when the
+# sibling file is not locatable; the primary GraphQL path keeps working.
+_SHARED_GH_WRAPPERS_DIR="${SCRIPT_DIR:-}"
+if [[ -z "$_SHARED_GH_WRAPPERS_DIR" ]]; then
+	if [[ -n "${BASH_SOURCE[0]:-}" ]]; then
+		_SHARED_GH_WRAPPERS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)" || _SHARED_GH_WRAPPERS_DIR=""
+	elif [[ -n "${ZSH_VERSION:-}" ]]; then
+		# zsh: %x prompt flag expands to the current script path when sourced
+		# shellcheck disable=SC2296
+		_SHARED_GH_WRAPPERS_DIR="$(cd "$(dirname "${(%):-%x}")" 2>/dev/null && pwd)" || _SHARED_GH_WRAPPERS_DIR=""
+	fi
+fi
+if [[ -n "$_SHARED_GH_WRAPPERS_DIR" && -f "$_SHARED_GH_WRAPPERS_DIR/shared-gh-wrappers-rest-fallback.sh" ]]; then
+	# shellcheck source=shared-gh-wrappers-rest-fallback.sh
+	source "$_SHARED_GH_WRAPPERS_DIR/shared-gh-wrappers-rest-fallback.sh"
+fi
 
 # =============================================================================
 # GitHub Token Workflow Scope Check (t1540)

--- a/.agents/scripts/tests/test-shared-gh-wrappers-source.sh
+++ b/.agents/scripts/tests/test-shared-gh-wrappers-source.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-shared-gh-wrappers-source.sh — t2709 / GH#20357 regression guard.
+#
+# Asserts that sourcing shared-constants.sh (which in turn sources
+# shared-gh-wrappers.sh) emits no warning about shared-gh-wrappers-rest-fallback.sh
+# under both bash and zsh, and that the REST fallback helpers are defined.
+#
+# Root cause: shared-gh-wrappers.sh:44 used ${BASH_SOURCE[0]%/*} which
+# evaluates to empty string under zsh (BASH_SOURCE is not populated), causing
+# the source call to attempt /shared-gh-wrappers-rest-fallback.sh — a warning
+# on every invocation from a zsh session. Fix: cross-shell resolver with
+# SCRIPT_DIR priority, BASH_SOURCE fallback, and zsh ${(%):-%x} fallback.
+#
+# Tests:
+#   1. bash: source shared-constants.sh produces no warning about rest-fallback
+#   2. bash: REST fallback helper _gh_issue_create_rest is defined after sourcing
+#   3. zsh:  source shared-constants.sh produces no warning about rest-fallback (skip if no zsh)
+#   4. zsh:  REST fallback helper _gh_issue_create_rest is defined after sourcing (skip if no zsh)
+
+set -uo pipefail
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR_TEST}/.." && pwd)" || exit 1
+SHARED_CONSTANTS="${SCRIPTS_DIR}/shared-constants.sh"
+
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_YELLOW=$'\033[0;33m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN=''
+	TEST_RED=''
+	TEST_YELLOW=''
+	TEST_NC=''
+fi
+
+PASS_COUNT=0
+FAIL_COUNT=0
+SKIP_COUNT=0
+
+pass() {
+	local msg="$1"
+	echo "${TEST_GREEN}PASS${TEST_NC}: ${msg}"
+	PASS_COUNT=$((PASS_COUNT + 1))
+	return 0
+}
+
+fail() {
+	local msg="$1"
+	echo "${TEST_RED}FAIL${TEST_NC}: ${msg}"
+	FAIL_COUNT=$((FAIL_COUNT + 1))
+	return 0
+}
+
+skip() {
+	local msg="$1"
+	echo "${TEST_YELLOW}SKIP${TEST_NC}: ${msg}"
+	SKIP_COUNT=$((SKIP_COUNT + 1))
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: bash — no warning about rest-fallback on source
+# ---------------------------------------------------------------------------
+test_bash_no_warning() {
+	local output
+	output=$(bash -c "source '${SHARED_CONSTANTS}'" 2>&1) || true
+	if echo "${output}" | grep -q 'shared-gh-wrappers-rest-fallback.sh'; then
+		fail "bash source emitted warning about shared-gh-wrappers-rest-fallback.sh"
+		echo "  Output: ${output}"
+	else
+		pass "bash sources shared-constants.sh with no rest-fallback warning"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: bash — REST fallback helper is defined after sourcing
+# ---------------------------------------------------------------------------
+test_bash_rest_helper_defined() {
+	local type_output
+	type_output=$(bash -c "source '${SHARED_CONSTANTS}' && type _gh_issue_create_rest 2>/dev/null") || true
+	if echo "${type_output}" | grep -q 'function'; then
+		pass "bash: _gh_issue_create_rest is defined after sourcing shared-constants.sh"
+	else
+		fail "bash: _gh_issue_create_rest is NOT defined after sourcing shared-constants.sh"
+		echo "  type output: ${type_output}"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: zsh — no warning about rest-fallback on source (skip if no zsh)
+# ---------------------------------------------------------------------------
+test_zsh_no_warning() {
+	if ! command -v zsh >/dev/null 2>&1; then
+		skip "zsh not available — skipping zsh source-clean test"
+		return 0
+	fi
+	local output
+	output=$(zsh -c "source '${SHARED_CONSTANTS}'" 2>&1) || true
+	if echo "${output}" | grep -q 'shared-gh-wrappers-rest-fallback.sh'; then
+		fail "zsh source emitted warning about shared-gh-wrappers-rest-fallback.sh"
+		echo "  Output: ${output}"
+	else
+		pass "zsh sources shared-constants.sh with no rest-fallback warning"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: zsh — REST fallback helper is defined after sourcing (skip if no zsh)
+# ---------------------------------------------------------------------------
+test_zsh_rest_helper_defined() {
+	if ! command -v zsh >/dev/null 2>&1; then
+		skip "zsh not available — skipping zsh REST helper definition test"
+		return 0
+	fi
+	local type_output
+	type_output=$(zsh -c "source '${SHARED_CONSTANTS}' && type _gh_issue_create_rest 2>/dev/null") || true
+	if echo "${type_output}" | grep -q 'function'; then
+		pass "zsh: _gh_issue_create_rest is defined after sourcing shared-constants.sh"
+	else
+		fail "zsh: _gh_issue_create_rest is NOT defined after sourcing shared-constants.sh"
+		echo "  type output: ${type_output}"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Run all tests
+# ---------------------------------------------------------------------------
+echo "=== test-shared-gh-wrappers-source.sh — t2709 cross-shell sourcing ==="
+test_bash_no_warning
+test_bash_rest_helper_defined
+test_zsh_no_warning
+test_zsh_rest_helper_defined
+
+echo ""
+echo "Results: ${PASS_COUNT} passed, ${FAIL_COUNT} failed, ${SKIP_COUNT} skipped"
+
+if [[ "${FAIL_COUNT}" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Fixes the `no such file or directory: /shared-gh-wrappers-rest-fallback.sh` warning emitted on every `source shared-constants.sh` from a zsh session. Under zsh, `${BASH_SOURCE[0]%/*}` evaluates to empty string (BASH_SOURCE is not populated), so the source call tried to load the fallback from the filesystem root.

## Changes

**EDIT: `.agents/scripts/shared-gh-wrappers.sh` lines 44-46**

Replace BASH_SOURCE-only self-directory resolver with a cross-shell resolver:
1. Prefer `SCRIPT_DIR` when already set (the common path — `shared-constants.sh` sets this before sourcing us)
2. Fall back to `BASH_SOURCE[0]` under bash
3. Fall back to zsh `${(%):-%x}` prompt-expansion flag under zsh
4. Guard the `source` call with a file-exists test so a missing fallback degrades silently

**NEW: `.agents/scripts/tests/test-shared-gh-wrappers-source.sh`**

4 tests verifying bash and zsh both source cleanly with no warning and that `_gh_issue_create_rest` is defined after sourcing.

## Verification

All 4 tests pass:
```
PASS: bash sources shared-constants.sh with no rest-fallback warning
PASS: bash: _gh_issue_create_rest is defined after sourcing shared-constants.sh
PASS: zsh sources shared-constants.sh with no rest-fallback warning
PASS: zsh: _gh_issue_create_rest is defined after sourcing shared-constants.sh
```

Acceptance criteria confirmed:
- `bash -c 'source .agents/scripts/shared-constants.sh 2>&1'` → zero output about rest-fallback
- `zsh -c 'source .agents/scripts/shared-constants.sh 2>&1'` → zero output about rest-fallback
- `zsh -c 'source .agents/scripts/shared-constants.sh && type _gh_issue_create_rest'` → `_gh_issue_create_rest is a shell function`
- ShellCheck: zero new violations

## Complexity Bump Justification

**False positive from shfmt parse failure.**

The zsh-specific `${(%):-%x}` prompt-expansion syntax at `.agents/scripts/shared-gh-wrappers.sh:56` is valid zsh but cannot be parsed by shfmt in bash mode. When shfmt fails to parse the file, the scanner falls back to AWK, which reports an inflated nesting depth of 14 (AWK has no concept of per-function reset and counts block-nesting across the whole file).

Evidence:
- `.agents/scripts/shared-gh-wrappers.sh:56` — the `${(%):-%x}` expression (zsh-only, inside `[[ -n "${ZSH_VERSION:-}" ]]` guard)
- Measurements: `base=4` (shfmt parses successfully on main), `head=14` (AWK fallback after shfmt parse failure), `new=1 file violation`
- The actual nesting depth introduced by this PR is **2 levels** (one outer `if [[ -z ... ]]`, one inner `if/elif`). The `${(%):-%x}` is inside a zsh-only branch that bash never executes; the shfmt failure is a parse-time artifact, not a runtime nesting issue.
- This is the prescribed idiom per the issue body (t2709/GH#20357) and zshexpn(1) documentation. There is no bash-compatible alternative that works at global scope in a sourced zsh script.

Resolves #20357