### PR TITLE
GH#20358: fix: address review-followup items from PR #20354

### DIFF
--- a/.agents/scripts/issue-sync-lib.sh
+++ b/.agents/scripts/issue-sync-lib.sh
@@ -1558,7 +1558,7 @@ detect_parent_task_id() {
 #   Empty string if no mappable labels.
 _labels_json_to_tags() {
 	local labels_json="$1"
-	[[ -z "$labels_json" || "$labels_json" == "null" || "$labels_json" == "[]" ]] && return 0
+	[[ -z "$labels_json" || "$labels_json" == "[]" ]] && return 0
 
 	local names
 	names=$(printf '%s' "$labels_json" | jq -r '.[].name' 2>/dev/null || echo "")
@@ -1587,7 +1587,7 @@ _labels_json_to_tags() {
 
 	[[ -z "$tags" ]] && return 0
 	# Sort deterministically (stable) so test assertions are not order-sensitive
-	printf '%s' "$tags" | tr ' ' '\n' | sort -u | tr '\n' ' ' | sed 's/[[:space:]]*$//'
+	printf '%s' "$tags" | tr ' ' '\n' | sort -u | paste -sd ' ' -
 	return 0
 }
 

--- a/.agents/scripts/tests/test-issue-sync-pull-seeds-orphans.sh
+++ b/.agents/scripts/tests/test-issue-sync-pull-seeds-orphans.sh
@@ -151,7 +151,7 @@ malformed_line=$(grep -E '^\- \[ \] ' "$todo_d" | grep -v t0001 || echo "")
 check "$ok" "(d) malformed title — no spurious entry seeded" "got: '$malformed_line'"
 rm -f "$todo_d"
 
-# ─── (e) parent-task label → #parent tag, no #auto-dispatch ─────────────────
+# ─── (e) parent-task label maps to #parent tag ──────────────────────────────
 
 todo_e=$(make_todo)
 # Issue has both parent-task and auto-dispatch labels


### PR DESCRIPTION
## Summary

Implementation for issue #20358.

## Files Changed

.agents/scripts/issue-sync-lib.sh,.agents/scripts/tests/test-issue-sync-pull-seeds-orphans.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean, self-assessed

Resolves #20358


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.91 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 2m and 7,620 tokens on this as a headless worker.