### PR TITLE
GH#20360: GH#20360: use AIDEVOPS_FRAMEWORK_REPO env var and defensive arithmetic in staleness check

### DIFF
--- a/.agents/scripts/security-posture-helper.sh
+++ b/.agents/scripts/security-posture-helper.sh
@@ -1000,7 +1000,7 @@ check_prompt_guard_patterns() {
 
 	# Level 2: upstream git commit date (only if stamp was not found)
 	if [[ "$ref_epoch" -eq 0 ]]; then
-		local framework_repo="${HOME}/Git/aidevops"
+		local framework_repo="${AIDEVOPS_FRAMEWORK_REPO:-${HOME}/Git/aidevops}"
 		if [[ -d "${framework_repo}/.git" ]]; then
 			local git_epoch
 			git_epoch=$(git -C "$framework_repo" log -1 --format=%ct -- \
@@ -1020,7 +1020,7 @@ check_prompt_guard_patterns() {
 
 	local file_age_days=0
 	if [[ "$ref_epoch" -gt 0 ]]; then
-		file_age_days=$(((now - ref_epoch) / 86400))
+		file_age_days=$(( (now - ${ref_epoch:-0}) / 86400 ))
 	fi
 
 	if [[ "$file_age_days" -gt 30 ]]; then


### PR DESCRIPTION
## Summary

Fixed two review bot suggestions from PR #20351: (1) replaced hardcoded ~/Git/aidevops path with ${AIDEVOPS_FRAMEWORK_REPO:-${HOME}/Git/aidevops} at security-posture-helper.sh:1003, aligning with the canonical pattern used in aidevops-update-check.sh; (2) added ${ref_epoch:-0} defensive parameter expansion in the arithmetic at line 1024 for robustness.

## Files Changed

.agents/scripts/security-posture-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck passes with zero violations; both edits verified at the exact lines the bot flagged

Resolves #20360


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.91 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 2m and 7,357 tokens on this as a headless worker.