### PR TITLE
GH#20362: fix jq stderr suppression and // "" fallback in pulse-rate-limit-circuit-breaker

### DIFF
--- a/.agents/scripts/pulse-rate-limit-circuit-breaker.sh
+++ b/.agents/scripts/pulse-rate-limit-circuit-breaker.sh
@@ -101,8 +101,8 @@ is_graphql_budget_sufficient() {
 	fi
 
 	local remaining limit
-	remaining=$(printf '%s' "$rate_json" | jq -r '.resources.graphql.remaining // empty' 2>/dev/null) || remaining=""
-	limit=$(printf '%s' "$rate_json" | jq -r '.resources.graphql.limit // empty' 2>/dev/null) || limit=""
+	remaining=$(printf '%s' "$rate_json" | jq -r '.resources.graphql.remaining // ""') || remaining=""
+	limit=$(printf '%s' "$rate_json" | jq -r '.resources.graphql.limit // ""') || limit=""
 
 	if [[ ! "$remaining" =~ ^[0-9]+$ ]] || [[ ! "$limit" =~ ^[0-9]+$ ]]; then
 		echo "${_CB_RL_LOG_PREFIX} WARNING: could not parse GraphQL rate-limit response (remaining='${remaining}', limit='${limit}') — proceeding (fail-open)" >>"$LOGFILE"
@@ -203,9 +203,9 @@ _circuit_breaker_status() {
 	fi
 
 	local remaining limit reset_epoch
-	remaining=$(printf '%s' "$rate_json" | jq -r ".resources.graphql.remaining // \"${_CB_RL_UNKNOWN}\"" 2>/dev/null) || remaining="$_CB_RL_UNKNOWN"
-	limit=$(printf '%s' "$rate_json" | jq -r ".resources.graphql.limit // \"${_CB_RL_UNKNOWN}\"" 2>/dev/null) || limit="$_CB_RL_UNKNOWN"
-	reset_epoch=$(printf '%s' "$rate_json" | jq -r ".resources.graphql.reset // \"${_CB_RL_UNKNOWN}\"" 2>/dev/null) || reset_epoch="$_CB_RL_UNKNOWN"
+	remaining=$(printf '%s' "$rate_json" | jq -r ".resources.graphql.remaining // \"${_CB_RL_UNKNOWN}\"") || remaining="$_CB_RL_UNKNOWN"
+	limit=$(printf '%s' "$rate_json" | jq -r ".resources.graphql.limit // \"${_CB_RL_UNKNOWN}\"") || limit="$_CB_RL_UNKNOWN"
+	reset_epoch=$(printf '%s' "$rate_json" | jq -r ".resources.graphql.reset // \"${_CB_RL_UNKNOWN}\"") || reset_epoch="$_CB_RL_UNKNOWN"
 
 	local reset_human="$_CB_RL_UNKNOWN"
 	if [[ "$reset_epoch" =~ ^[0-9]+$ ]]; then


### PR DESCRIPTION
## Summary

Addresses gemini-code-assist inline review comments on PR #20349 (GraphQL rate-limit circuit breaker). Two changes grouped into one logical commit:

1. **`// empty` → `// ""`** (`is_graphql_budget_sufficient`, lines 104-105): uses the project-consistent fallback pattern for `jq -r`. Both produce an empty variable via command substitution, but `// ""` is the project standard.

2. **Remove `2>/dev/null` from all `jq` calls** (both functions): jq parsing errors on an already-validated non-empty JSON string are rare but would previously be silently swallowed. Removing suppression surfaces genuine errors to stderr while the `|| var=fallback` shell fallback still handles `jq` exit failures cleanly.

The `gh api rate_limit 2>/dev/null` stderr suppression on the outer `gh` call is intentionally retained — that suppresses auth/network errors from the `gh` binary itself, which are expected in offline/no-auth environments. Only the `jq` inner pipes are changed.

## Verification

- `shellcheck .agents/scripts/pulse-rate-limit-circuit-breaker.sh` — passes (0 violations)
- `bash .agents/scripts/tests/test-rate-limit-circuit-breaker.sh` — 15/15 tests pass

Resolves #20362

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.91 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 2m and 5,782 tokens on this as a headless worker.