### PR TITLE
GH#20363: simplify AIDEVOPS_SESSION_ORIGIN inline assignment in health dashboard

### DIFF
--- a/.agents/scripts/stats-health-dashboard.sh
+++ b/.agents/scripts/stats-health-dashboard.sh
@@ -285,18 +285,11 @@ _create_health_issue() {
 	# caller has AIDEVOPS_HEADLESS set (defense-in-depth; stats-wrapper.sh
 	# already exports AIDEVOPS_HEADLESS=true, but this guards test contexts
 	# and any future invocation path that bypasses that wrapper).
-	local _saved_session_origin="${AIDEVOPS_SESSION_ORIGIN:-__unset__}"
-	export AIDEVOPS_SESSION_ORIGIN=worker
 	local health_issue_number
-	health_issue_number=$(gh_create_issue --repo "$repo_slug" \
+	health_issue_number=$(AIDEVOPS_SESSION_ORIGIN=worker gh_create_issue --repo "$repo_slug" \
 		--title "${runner_prefix} starting..." \
 		--body "$health_body" \
 		--label "$role_label" --label "$runner_user" --label "source:health-dashboard" --label "persistent" 2>/dev/null | grep -oE '[0-9]+$' || echo "")
-	if [[ "$_saved_session_origin" == "__unset__" ]]; then
-		unset AIDEVOPS_SESSION_ORIGIN
-	else
-		export AIDEVOPS_SESSION_ORIGIN="$_saved_session_origin"
-	fi
 
 	if [[ -z "$health_issue_number" ]]; then
 		echo "[stats] Health issue: could not create for ${repo_slug}" >>"$LOGFILE"


### PR DESCRIPTION
## Summary

Simplifies the `AIDEVOPS_SESSION_ORIGIN` handling in `_create_health_issue` in `stats-health-dashboard.sh`.

The previous implementation used a verbose save/restore pattern (save env var, export new value, call function, restore original). This is replaced with the idiomatic inline `VAR=value command` assignment inside the command substitution subshell, which achieves identical behaviour without modifying the parent environment.

**Before:**
```bash
local _saved_session_origin="${AIDEVOPS_SESSION_ORIGIN:-__unset__}"
export AIDEVOPS_SESSION_ORIGIN=worker
local health_issue_number
health_issue_number=$(gh_create_issue ...)
if [[ "$_saved_session_origin" == "__unset__" ]]; then
    unset AIDEVOPS_SESSION_ORIGIN
else
    export AIDEVOPS_SESSION_ORIGIN="$_saved_session_origin"
fi
```

**After:**
```bash
local health_issue_number
health_issue_number=$(AIDEVOPS_SESSION_ORIGIN=worker gh_create_issue ...)
```

The inline form sets `AIDEVOPS_SESSION_ORIGIN=worker` only in the command substitution subshell — `gh_create_issue` (a shell function) runs inside that subshell and sees the variable. The parent shell's environment is unchanged after the call, so the restore block is unnecessary.

Resolves #20363
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.91 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 1m and 4,298 tokens on this as a headless worker.
