### PR TITLE
GH#20364: fix log-issue fingerprint dedup — collision, efficiency, validation

### DIFF
--- a/.agents/scripts/log-issue-helper.sh
+++ b/.agents/scripts/log-issue-helper.sh
@@ -207,7 +207,7 @@ _log_issue_dedup_window() {
 _compute_issue_fingerprint() {
 	local title="$1"
 	local body="$2"
-	local input="${title}${body}"
+	local input="${title}|${body}"
 	local hash=""
 
 	if command -v shasum &>/dev/null; then
@@ -249,23 +249,17 @@ check_recent_filing() {
 	local cutoff
 	cutoff=$(( now - dedup_window ))
 
-	local line hash issue_num filed_epoch age
-	while IFS= read -r line; do
-		[[ -z "$line" ]] && continue
-		hash=$(printf '%s' "$line" | grep -oE '"hash":"[a-f0-9]+"' | cut -d'"' -f4 || true)
-		issue_num=$(printf '%s' "$line" | grep -oE '"issue":[0-9]+' | grep -oE '[0-9]+' || true)
-		filed_epoch=$(printf '%s' "$line" | grep -oE '"filed_epoch":[0-9]+' | grep -oE '[0-9]+' || true)
+	local match filed_epoch issue_num age
+	match=$(grep -F "\"hash\":\"$fingerprint\"" "$fp_file" | tail -n 1 || true)
 
-		[[ -z "$hash" ]] && continue
-		[[ -z "$issue_num" ]] && continue
-		[[ -z "$filed_epoch" ]] && continue
-
-		if [[ "$hash" == "$fingerprint" ]] && [[ "$filed_epoch" -gt "$cutoff" ]]; then
+	if [[ -n "$match" ]]; then
+		read -r filed_epoch issue_num < <(sed -E 's/.*"issue":([0-9]+).*"filed_epoch":([0-9]+).*/\2 \1/' <<< "$match" || true)
+		if [[ "$filed_epoch" =~ ^[0-9]+$ ]] && [[ "$filed_epoch" -gt "$cutoff" ]]; then
 			age=$(( now - filed_epoch ))
 			echo "DUPLICATE:${issue_num}:${age}"
 			return 1
 		fi
-	done < "$fp_file"
+	fi
 
 	echo "OK"
 	return 0
@@ -291,6 +285,8 @@ record_filing() {
 	now=$(date +%s)
 	local iso_ts
 	iso_ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null || echo "unknown")
+
+	[[ "$issue_number" =~ ^[0-9]+$ ]] || issue_number=0
 
 	printf '{"hash":"%s","issue":%s,"filed_at":"%s","filed_epoch":%s}\n' \
 		"$fingerprint" "$issue_number" "$iso_ts" "$now" >> "$fp_file"


### PR DESCRIPTION
## Summary

Addresses three gemini-code-assist review findings from PR #20345 (fingerprint dedup for /log-issue-aidevops):

### Fix 1 — Fingerprint collision (line 210, medium)
`_compute_issue_fingerprint` concatenated title and body without a delimiter, so `title="A", body="BC"` and `title="AB", body="C"` produced identical hashes. Added `|` separator.

### Fix 2 — Loop efficiency + numeric validation (line 268, high)
`check_recent_filing` iterated every line of the fingerprint file and forked 3-6 processes per line. Replaced with `grep -F` to locate the matching hash in one pass, then `sed` to extract fields from the matching line only. Added `[[ $filed_epoch =~ ^[0-9]+$ ]]` guard before arithmetic comparison.

### Fix 3 — issue_number validation before JSON write (line 296, security-medium)
`record_filing` wrote `$issue_number` directly into the JSON without validation. Non-numeric values would produce invalid JSON. Added `[[ $issue_number =~ ^[0-9]+$ ]] || issue_number=0` guard.

## Verification

- `shellcheck .agents/scripts/log-issue-helper.sh` — zero violations
- Pre-commit hook passed
- Pre-push hook passed

Resolves #20364


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.91 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 2m and 5,251 tokens on this as a headless worker.