### PR TITLE
GH#20365: fix _worktree_resolve_abs_path double-slash and pwd vs pwd -P inconsistency

### DIFF
--- a/.agents/scripts/worktree-helper.sh
+++ b/.agents/scripts/worktree-helper.sh
@@ -744,13 +744,13 @@ _worktree_resolve_abs_path() {
 		if [[ "$base" = "." ]]; then
 			printf '%s\n' "$abs_parent"
 		else
-			printf '%s/%s\n' "$abs_parent" "$base"
+			printf '%s/%s\n' "${abs_parent%/}" "$base"
 		fi
 	else
 		# Parent does not exist — naive join (best-effort absolute form)
 		case "$input" in
 			/*) printf '%s\n' "$input" ;;
-			*)  printf '%s/%s\n' "$(pwd)" "$input" ;;
+			*)  printf '%s/%s\n' "$(pwd -P)" "$input" ;;
 		esac
 	fi
 	return 0


### PR DESCRIPTION
GH#20365: fix _worktree_resolve_abs_path path canonicalization

Two precision fixes to `_worktree_resolve_abs_path` in `worktree-helper.sh` addressing valid gemini-code-assist review findings from PR #20336.

**Fix 1 — double-slash when parent is root (line 747):**
When `abs_parent` resolves to `/` (the filesystem root), the previous `printf '%s/%s\n' "$abs_parent" "$base"` produced `//base`. The `${abs_parent%/}` strip makes root → empty string → `/base`. For all other paths `pwd -P` never emits a trailing slash so this is a no-op outside the root case.

**Fix 2 — `pwd` vs `pwd -P` inconsistency (line 753):**
The success branch (parent exists) uses `cd "$parent" && pwd -P` to resolve symlinks. The fallback branch (parent does not exist) previously used bare `pwd`, which may return a symlink-unresolved path. Changed to `pwd -P` for consistency.

## Changes
- EDIT: `.agents/scripts/worktree-helper.sh:747` — `"$abs_parent"` → `"${abs_parent%/}"`
- EDIT: `.agents/scripts/worktree-helper.sh:753` — `"$(pwd)"` → `"$(pwd -P)"`

Resolves #20365
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.91 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 1m and 2,651 tokens on this as a headless worker.
