### PR TITLE
GH#20367: fix(GH#20367): remove redundant stderr redirect and extract helper function

### DIFF
--- a/.agents/scripts/migrate-health-issue-duplicates-t2687.sh
+++ b/.agents/scripts/migrate-health-issue-duplicates-t2687.sh
@@ -237,7 +237,7 @@ _close_duplicate_groups() {
 			# Strip 'persistent' before closing so issue-sync.yml 'Reopen Persistent Issues'
 			# job does not reopen the duplicate (GH#20326). That job blocks USER-initiated
 			# closes, not programmatic dedup. Idempotent: no-op if label not present.
-			run_gh issue edit "$close_num" --repo "$repo" --remove-label persistent 2>/dev/null || true
+			run_gh issue edit "$close_num" --repo "$repo" --remove-label persistent || true
 			run_gh issue close "$close_num" --repo "$repo" --comment "$comment" \
 				|| log_warn "    close failed for #${close_num}"
 		done <<<"$close_list"

--- a/.agents/scripts/stats-health-dashboard.sh
+++ b/.agents/scripts/stats-health-dashboard.sh
@@ -136,6 +136,20 @@ _try_cached_health_issue_lookup() {
 }
 
 #######################################
+# Strip the 'persistent' label from a health issue before closing it,
+# preventing issue-sync.yml 'Reopen Persistent Issues' from reopening
+# programmatic dedup closes (GH#20326). Idempotent: no-op if not present.
+# Arguments:
+#   $1 - issue number
+#   $2 - repo slug
+_strip_persistent_label_before_close() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	gh issue edit "$issue_number" --repo "$repo_slug" --remove-label persistent 2>/dev/null || true
+	return 0
+}
+
+#######################################
 # Close all duplicate health issues (all but the first) from a jq array.
 # Arguments: label_results_json keep_number repo_slug runner_role
 _close_health_issue_duplicates() {
@@ -150,10 +164,7 @@ _close_health_issue_duplicates() {
 	while IFS= read -r dup_num; do
 		[[ -z "$dup_num" ]] && continue
 		[[ "$runner_role" == "supervisor" ]] && _unpin_health_issue "$dup_num" "$repo_slug"
-		# Strip 'persistent' before closing so issue-sync.yml 'Reopen Persistent Issues'
-		# job does not reopen the duplicate. That job is designed to block USER-initiated
-		# closes, not programmatic dedup. Idempotent: no-op if label not present.
-		gh issue edit "$dup_num" --repo "$repo_slug" --remove-label persistent 2>/dev/null || true
+		_strip_persistent_label_before_close "$dup_num" "$repo_slug"
 		gh issue close "$dup_num" --repo "$repo_slug" \
 			--comment "Closing duplicate ${runner_role} health issue — superseded by #${keep_number}." 2>/dev/null || true
 	done <<<"$dup_numbers"
@@ -463,10 +474,7 @@ _periodic_health_issue_dedup() {
 			# Duplicate supervisor issues CAN be pinned in pathological
 			# cases (stale pin from a pre-rate-limit canonical).
 			_unpin_health_issue "$dup_num" "$repo_slug"
-			# Strip 'persistent' before closing so issue-sync.yml 'Reopen Persistent Issues'
-			# job does not reopen the duplicate (GH#20326). That job blocks USER-initiated
-			# closes, not programmatic dedup. Idempotent: no-op if label not present.
-			gh issue edit "$dup_num" --repo "$repo_slug" --remove-label persistent 2>/dev/null || true
+			_strip_persistent_label_before_close "$dup_num" "$repo_slug"
 			gh issue close "$dup_num" --repo "$repo_slug" \
 				--comment "Closing duplicate ${runner_role} health issue — superseded by #${current_issue} (t2687 periodic dedup). Root cause likely a past GraphQL rate-limit window; see GH#20301." 2>/dev/null || true
 			echo "[stats] Health issue: periodic dedup closed #${dup_num} in ${repo_slug} (kept #${current_issue})" >>"${LOGFILE:-/dev/null}"


### PR DESCRIPTION
## Summary

Addressed both Gemini review bot suggestions from PR #20333:

1. **migrate-health-issue-duplicates-t2687.sh**: Removed redundant `2>/dev/null` from `run_gh` call — the `run_gh` wrapper already silences all output internally via `>/dev/null 2>&1` on the underlying `gh` invocation (verified at line 140).

2. **stats-health-dashboard.sh**: Extracted the duplicated persistent-label-stripping logic into a new `_strip_persistent_label_before_close` helper function and replaced both call sites (previously at lines 156 and 453), improving maintainability.

## Files Changed

.agents/scripts/migrate-health-issue-duplicates-t2687.sh,.agents/scripts/stats-health-dashboard.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck on both files: zero violations

Resolves #20367


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.91 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 2m and 6,218 tokens on this as a headless worker.