### PR TITLE
GH#20369: GH#20369: URL-encode labels and assignee in _rest_issue_list query params

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -705,11 +705,20 @@ _rest_issue_list() {
 
 	local _query="state=${state}&per_page=${limit}"
 	if [[ ${#labels[@]} -gt 0 ]]; then
-		local _labels_csv
-		_labels_csv=$(IFS=','; printf '%s' "${labels[*]}")
-		_query="${_query}&labels=${_labels_csv}"
+		local _labels_encoded=""
+		local _label
+		for _label in "${labels[@]}"; do
+			local _enc
+			_enc=$(jq -rn --arg v "$_label" '$v | @uri')
+			_labels_encoded="${_labels_encoded:+${_labels_encoded}%2C}${_enc}"
+		done
+		_query="${_query}&labels=${_labels_encoded}"
 	fi
-	[[ -n "$assignee" ]] && _query="${_query}&assignee=${assignee}"
+	if [[ -n "$assignee" ]]; then
+		local _assignee_encoded
+		_assignee_encoded=$(jq -rn --arg v "$assignee" '$v | @uri')
+		_query="${_query}&assignee=${_assignee_encoded}"
+	fi
 
 	local _path="/repos/${repo}/issues?${_query}"
 	if [[ -n "$jq_expr" ]]; then


### PR DESCRIPTION
## Summary

URL-encode label names and assignee in _rest_issue_list before appending to the REST query string. GitHub labels can contain spaces (e.g., 'good first issue', 'help wanted'); without encoding these create malformed URLs. Each label is now encoded individually with jq @uri and joined with %2C. The assignee parameter is also encoded (a no-op for valid GitHub usernames but good practice). Uses jq (already a hard dependency) rather than python3 as suggested by gemini-code-assist.

## Files Changed

.agents/scripts/shared-gh-wrappers-rest-fallback.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/shared-gh-wrappers-rest-fallback.sh passes with zero violations

Resolves #20369


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.91 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 2m and 6,280 tokens on this as a headless worker.