### PR TITLE
t2712: rename 'escalate' action to 'notify' in pulse-dirty-pr-sweep.sh

### DIFF
--- a/.agents/scripts/pulse-dirty-pr-sweep.sh
+++ b/.agents/scripts/pulse-dirty-pr-sweep.sh
@@ -11,18 +11,18 @@
 #                 strategy, force-push, post documentation comment.
 #   Auto-close  : PR > 7d old AND no human commits in 3d AND no
 #                 `do-not-close` label → close with a "superseded" comment.
-#   Escalate    : PR has non-TODO.md conflicts and doesn't meet auto-close
-#                 criteria → post a one-time maintainer-review nudge comment
-#                 (no destructive action).
+#   Notify      : PR has non-TODO.md conflicts and doesn't meet auto-close
+#                 criteria → post a one-time informational comment
+#                 (no label applied, no dispatch, no merge block).
 #
 # Safety gates:
-#   - Never rebases PRs with non-TODO.md conflicts (always escalate instead).
+#   - Never rebases PRs with non-TODO.md conflicts (always notify instead).
 #   - Never auto-closes PRs tagged `do-not-close` OR linked to an OPEN issue
 #     that has the `parent-task` label.
-#   - Escalates `origin:interactive` PRs only when the body contains no
+#   - Notifies for `origin:interactive` PRs only when the body contains no
 #     recognised issue reference (`For #NNN`, `Ref #NNN`, or a closing
 #     keyword). Referenced PRs flow through the normal age/idle close
-#     heuristic like any other PR (t2708). True orphans still escalate.
+#     heuristic like any other PR (t2708). True orphans still notify.
 #   - Idempotency: per-PR actions logged to a state file with timestamp;
 #     re-running within 30 min (action cooldown) is a no-op for each PR.
 #   - Dry-run: DRY_RUN=1 env var (or `--dry-run` CLI flag) prints would-be
@@ -86,7 +86,7 @@ DIRTY_PR_SWEEP_STATE_FILE="${DIRTY_PR_SWEEP_STATE_FILE:-${HOME}/.aidevops/.agent
 
 # The audit-log-helper's event-type allowlist is closed. `operation.verify`
 # is the closest fit for "pulse took a verified deterministic action".
-# Detail keys disambiguate the op (rebase|close|escalate|skip).
+# Detail keys disambiguate the op (rebase|close|notify|skip).
 readonly _DIRTY_PR_AUDIT_EVENT="operation.verify"
 
 # Canonical action names — used as case labels, state-file keys, and audit
@@ -94,11 +94,11 @@ readonly _DIRTY_PR_AUDIT_EVENT="operation.verify"
 # (pre-commit "repeated string literals" ratchet).
 readonly _DIRTY_ACTION_REBASE="rebase"
 readonly _DIRTY_ACTION_CLOSE="close"
-readonly _DIRTY_ACTION_ESCALATE="escalate"
+readonly _DIRTY_ACTION_NOTIFY="notify"
 readonly _DIRTY_ACTION_SKIP="skip"
 
 # Comment markers for idempotency when scanning PR comment history.
-readonly _DIRTY_PR_ESCALATE_MARKER="<!-- pulse-dirty-pr-escalate -->"
+readonly _DIRTY_PR_NOTIFY_MARKER="<!-- pulse-dirty-pr-escalate -->"  # string preserved for comment-history dedup continuity
 readonly _DIRTY_PR_REBASE_MARKER="<!-- pulse-dirty-pr-rebase -->"
 readonly _DIRTY_PR_CLOSE_MARKER="<!-- pulse-dirty-pr-close -->"
 
@@ -380,7 +380,7 @@ _dps_consider_close() {
 # -----------------------------------------------------------------------------
 #
 # Given a PR JSON object (from `gh pr list`), classify the action:
-#   rebase | close | escalate | skip
+#   rebase | close | notify | skip
 #
 # The JSON must include: number, mergeStateStatus, createdAt, updatedAt,
 # author.login, labels[].name, headRefName, baseRefName.
@@ -392,7 +392,7 @@ _dps_consider_close() {
 #   $4 - self_login (the runner's GitHub login — maintainers)
 #
 # Output (stdout): one line of the form "ACTION|REASON"
-#   ACTION in {rebase, close, escalate, skip}
+#   ACTION in {rebase, close, notify, skip}
 #   REASON is a short human-readable phrase.
 _dirty_pr_classify() {
 	local pr_json="$1"
@@ -447,22 +447,22 @@ _dirty_pr_classify() {
 		return 0
 	fi
 
-	# Label-based escalation takes precedence over close.
+	# Label-based notify takes precedence over close.
 	if [[ "$has_do_not_close" -eq 1 ]]; then
-		printf '%s|do-not-close-label' "$_DIRTY_ACTION_ESCALATE"
+		printf '%s|do-not-close-label' "$_DIRTY_ACTION_NOTIFY"
 		return 0
 	fi
 	if [[ "$has_parent_task" -eq 1 ]]; then
-		printf '%s|parent-task-label' "$_DIRTY_ACTION_ESCALATE"
+		printf '%s|parent-task-label' "$_DIRTY_ACTION_NOTIFY"
 		return 0
 	fi
-	# origin:interactive PRs: escalate only if the body has no recognised
+	# origin:interactive PRs: notify only if the body has no recognised
 	# issue reference (true orphan). PRs with "For #NNN", "Ref #NNN", or any
 	# closing keyword reference a tracked issue and should flow through the
 	# normal age/idle close heuristic like any other PR (t2708).
 	if [[ "$has_interactive" -eq 1 ]]; then
 		if ! _dps_pr_body_has_issue_reference "$body"; then
-			printf '%s|origin-interactive-orphan' "$_DIRTY_ACTION_ESCALATE"
+			printf '%s|origin-interactive-orphan' "$_DIRTY_ACTION_NOTIFY"
 			return 0
 		fi
 		# Has a reference — fall through to age-based close check.
@@ -476,7 +476,7 @@ _dirty_pr_classify() {
 		return 0
 	fi
 
-	printf '%s|dirty-not-auto-resolvable' "$_DIRTY_ACTION_ESCALATE"
+	printf '%s|dirty-not-auto-resolvable' "$_DIRTY_ACTION_NOTIFY"
 	return 0
 }
 
@@ -521,7 +521,8 @@ ${body}"
 }
 
 # Rebase action: attempt `git rebase origin/main -X union` in an ephemeral
-# worktree and force-push. If anything fails, abort cleanly and escalate.
+# worktree and force-push. If anything fails, abort cleanly and return 1
+# (the PR remains DIRTY for re-classification on the next cycle).
 _dirty_pr_action_rebase() {
 	local pr_number="$1"
 	local repo_slug="$2"
@@ -639,8 +640,8 @@ _dirty_pr_action_close() {
 		linked_state=$(gh issue view "$linked" --repo "$repo_slug" --json state --jq '.state // empty' 2>/dev/null) || linked_state=""
 		linked_labels=$(gh issue view "$linked" --repo "$repo_slug" --json labels --jq '[.labels[].name] | .[]' 2>/dev/null | tr '[:upper:]' '[:lower:]') || linked_labels=""
 		if [[ "$linked_state" == "OPEN" ]] && printf '%s' "$linked_labels" | grep -qx 'parent-task'; then
-			_dps_log "PR #$pr_number ($repo_slug): close skipped — linked issue #$linked is open parent-task"
-			_dirty_pr_action_escalate "$pr_number" "$repo_slug" "parent-task-linked"
+		_dps_log "PR #$pr_number ($repo_slug): close skipped — linked issue #$linked is open parent-task"
+		_dirty_pr_action_notify "$pr_number" "$repo_slug" "parent-task-linked"
 			return 0
 		fi
 	fi
@@ -679,16 +680,18 @@ _Triggered by \`pulse-dirty-pr-sweep.sh\` (t2350 / GH#19948)._"
 	return 1
 }
 
-# Escalate action: post a nudge comment once (idempotent via marker) so a
-# human can review. No destructive action.
-_dirty_pr_action_escalate() {
+# Notify action: post an informational comment once (idempotent via marker).
+# This does NOT block merge, does NOT apply a label, does NOT dispatch a worker.
+# It only posts an idempotent comment. For a real escalation (maintainer review
+# required), use `needs-maintainer-review` labelling via `set_issue_status` instead.
+_dirty_pr_action_notify() {
 	local pr_number="$1"
 	local repo_slug="$2"
 	local reason="${3:-dirty-not-auto-resolvable}"
 
 	local key="${repo_slug}#${pr_number}"
 	if _dps_recently_actioned "$key"; then
-		_dps_log "PR #$pr_number ($repo_slug): escalate skipped — cooldown active"
+		_dps_log "PR #$pr_number ($repo_slug): notify skipped — cooldown active"
 		return 0
 	fi
 
@@ -707,15 +710,15 @@ This comment is posted once per cooldown window (${DIRTY_PR_SWEEP_ACTION_COOLDOW
 _Triggered by \`pulse-dirty-pr-sweep.sh\` (t2350 / GH#19948)._"
 
 	if _dps_is_dry_run; then
-		_dps_log "DRY-RUN: would escalate PR #$pr_number ($repo_slug) reason=$reason"
-		_dps_record_audit "$_DIRTY_ACTION_ESCALATE" "$repo_slug" "$pr_number" "dry-run:$reason"
+		_dps_log "DRY-RUN: would notify PR #$pr_number ($repo_slug) reason=$reason"
+		_dps_record_audit "$_DIRTY_ACTION_NOTIFY" "$repo_slug" "$pr_number" "dry-run:$reason"
 		return 0
 	fi
 
-	_dps_post_comment_if_new "$pr_number" "$repo_slug" "$_DIRTY_PR_ESCALATE_MARKER" "$comment_body" || true
-	_dps_state_record_action "$key" "$_DIRTY_ACTION_ESCALATE"
-	_dps_record_audit "$_DIRTY_ACTION_ESCALATE" "$repo_slug" "$pr_number" "ok:$reason"
-	_dps_log "PR #$pr_number ($repo_slug): escalated ($reason)"
+	_dps_post_comment_if_new "$pr_number" "$repo_slug" "$_DIRTY_PR_NOTIFY_MARKER" "$comment_body" || true
+	_dps_state_record_action "$key" "$_DIRTY_ACTION_NOTIFY"
+	_dps_record_audit "$_DIRTY_ACTION_NOTIFY" "$repo_slug" "$pr_number" "ok:$reason"
+	_dps_log "PR #$pr_number ($repo_slug): notified ($reason)"
 	return 0
 }
 
@@ -793,9 +796,9 @@ _dirty_pr_sweep_for_repo() {
 			"$_DIRTY_ACTION_CLOSE")
 				_dirty_pr_action_close "$pr_number" "$repo_slug" || true
 				;;
-			"$_DIRTY_ACTION_ESCALATE")
-				_dirty_pr_action_escalate "$pr_number" "$repo_slug" "$reason" || true
-				;;
+		"$_DIRTY_ACTION_NOTIFY")
+			_dirty_pr_action_notify "$pr_number" "$repo_slug" "$reason" || true
+			;;
 			"$_DIRTY_ACTION_SKIP")
 				:
 				;;
@@ -833,7 +836,7 @@ dirty_pr_sweep_all_repos() {
 	local self_login=""
 	self_login=$(gh api user --jq '.login // empty' 2>/dev/null) || self_login=""
 
-	local total_rebased=0 total_closed=0 total_escalated=0
+	local total_rebased=0 total_closed=0 total_notified=0
 
 	while IFS='|' read -r repo_slug repo_path; do
 		[[ -n "$repo_slug" ]] || continue
@@ -852,7 +855,7 @@ dirty_pr_sweep_all_repos() {
 	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | [.slug, .path] | join("|")' "$repos_json" 2>/dev/null)
 
 	_dirty_pr_sweep_mark_run
-	_dps_log "sweep complete: rebased=${total_rebased} closed=${total_closed} escalated=${total_escalated}"
+	_dps_log "sweep complete: rebased=${total_rebased} closed=${total_closed} notified=${total_notified}"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-dirty-pr-sweep.sh
+++ b/.agents/scripts/tests/test-dirty-pr-sweep.sh
@@ -11,11 +11,11 @@
 #                      conflicts → classify returns "rebase|todo-only-conflict".
 #   2. Close path    — old PR (> 7d), idle (> 3d), no opt-out label
 #                      → classify returns "close|stale-and-idle".
-#   3. Escalate path — young PR with non-TODO conflicts → classify returns
-#                      "escalate|..." (never rebase or close).
-#   4. Opt-out       — `do-not-close` label forces escalate, never close.
-#   5. Opt-out       — `parent-task` label forces escalate, never close.
-#   6. Opt-out       — `origin:interactive` label forces escalate, never close.
+#   3. Notify path   — young PR with non-TODO conflicts → classify returns
+#                      "notify|..." (never rebase or close).
+#   4. Opt-out       — `do-not-close` label forces notify, never close.
+#   5. Opt-out       — `parent-task` label forces notify, never close.
+#   6. Opt-out       — `origin:interactive` label forces notify, never close.
 #   7. Idempotency   — a recorded action within the cooldown window is
 #                      honoured (classify still returns a decision, but the
 #                      action helper short-circuits on _dps_recently_actioned).
@@ -176,7 +176,7 @@ case "$decision" in
 esac
 
 # =============================================================================
-# Test 3: escalate path — non-TODO conflicts
+# Test 3: notify path — non-TODO conflicts
 # =============================================================================
 
 # Build a repo where a non-TODO file conflicts
@@ -211,8 +211,8 @@ PR_CODE_CONFLICT=$(mkpr 300 "DIRTY" \
 
 decision=$(_dirty_pr_classify "$PR_CODE_CONFLICT" "test/repo" "$REPO_ROOT" "marcusquinn")
 case "$decision" in
-	escalate\|*) print_result "escalate path: non-TODO conflicts → escalate (no rebase)" 0 ;;
-	*) print_result "escalate path: non-TODO conflicts → escalate (no rebase)" 1 "got: $decision" ;;
+	notify\|*) print_result "notify path: non-TODO conflicts → notify (no rebase)" 0 ;;
+	*) print_result "notify path: non-TODO conflicts → notify (no rebase)" 1 "got: $decision" ;;
 esac
 
 # =============================================================================
@@ -228,9 +228,9 @@ PR_OPTOUT=$(mkpr 400 "DIRTY" \
 
 decision=$(_dirty_pr_classify "$PR_OPTOUT" "test/repo" "" "marcusquinn")
 case "$decision" in
-	escalate\|do-not-close-label) print_result "opt-out: do-not-close label → escalate" 0 ;;
-	close\|*) print_result "opt-out: do-not-close label → escalate" 1 "got: $decision (should NOT be close)" ;;
-	*) print_result "opt-out: do-not-close label → escalate" 1 "got: $decision" ;;
+	notify\|do-not-close-label) print_result "opt-out: do-not-close label → notify" 0 ;;
+	close\|*) print_result "opt-out: do-not-close label → notify" 1 "got: $decision (should NOT be close)" ;;
+	*) print_result "opt-out: do-not-close label → notify" 1 "got: $decision" ;;
 esac
 
 # =============================================================================
@@ -246,15 +246,15 @@ PR_PARENT=$(mkpr 500 "DIRTY" \
 
 decision=$(_dirty_pr_classify "$PR_PARENT" "test/repo" "" "marcusquinn")
 case "$decision" in
-	escalate\|parent-task-label) print_result "opt-out: parent-task label → escalate (no rebase)" 0 ;;
-	rebase\|*) print_result "opt-out: parent-task label → escalate (no rebase)" 1 "got: $decision (must NOT rebase)" ;;
-	close\|*) print_result "opt-out: parent-task label → escalate (no rebase)" 1 "got: $decision (must NOT close)" ;;
-	*) print_result "opt-out: parent-task label → escalate (no rebase)" 1 "got: $decision" ;;
+	notify\|parent-task-label) print_result "opt-out: parent-task label → notify (no rebase)" 0 ;;
+	rebase\|*) print_result "opt-out: parent-task label → notify (no rebase)" 1 "got: $decision (must NOT rebase)" ;;
+	close\|*) print_result "opt-out: parent-task label → notify (no rebase)" 1 "got: $decision (must NOT close)" ;;
+	*) print_result "opt-out: parent-task label → notify (no rebase)" 1 "got: $decision" ;;
 esac
 
 # =============================================================================
-# Test 6: origin:interactive WITHOUT issue reference → escalate (orphan)
-#         After t2708 the label alone no longer forces escalate — the body must
+# Test 6: origin:interactive WITHOUT issue reference → notify (orphan)
+#         After t2708 the label alone no longer forces notify — the body must
 #         also lack any recognised issue reference.
 # =============================================================================
 
@@ -268,9 +268,9 @@ PR_INTERACTIVE_ORPHAN=$(mkpr 600 "DIRTY" \
 
 decision=$(_dirty_pr_classify "$PR_INTERACTIVE_ORPHAN" "test/repo" "" "marcusquinn")
 case "$decision" in
-	escalate\|origin-interactive-orphan) print_result "t2708: origin:interactive orphan → escalate with orphan reason" 0 ;;
-	close\|*) print_result "t2708: origin:interactive orphan → escalate with orphan reason" 1 "got: $decision (must NOT close when body has no ref)" ;;
-	*) print_result "t2708: origin:interactive orphan → escalate with orphan reason" 1 "got: $decision" ;;
+	notify\|origin-interactive-orphan) print_result "t2708: origin:interactive orphan → notify with orphan reason" 0 ;;
+	close\|*) print_result "t2708: origin:interactive orphan → notify with orphan reason" 1 "got: $decision (must NOT close when body has no ref)" ;;
+	*) print_result "t2708: origin:interactive orphan → notify with orphan reason" 1 "got: $decision" ;;
 esac
 
 # =============================================================================
@@ -290,7 +290,7 @@ PR_INTERACTIVE_RESOLVES=$(mkpr 610 "DIRTY" \
 decision=$(_dirty_pr_classify "$PR_INTERACTIVE_RESOLVES" "test/repo" "" "marcusquinn")
 case "$decision" in
 	close\|stale-and-idle) print_result "t2708: origin:interactive + Resolves #NNN → falls through to close" 0 ;;
-	escalate\|*) print_result "t2708: origin:interactive + Resolves #NNN → falls through to close" 1 "got: $decision (must NOT escalate when body has reference)" ;;
+	notify\|*) print_result "t2708: origin:interactive + Resolves #NNN → falls through to close" 1 "got: $decision (must NOT notify when body has reference)" ;;
 	*) print_result "t2708: origin:interactive + Resolves #NNN → falls through to close" 1 "got: $decision" ;;
 esac
 
@@ -311,7 +311,7 @@ PR_INTERACTIVE_FOR=$(mkpr 620 "DIRTY" \
 decision=$(_dirty_pr_classify "$PR_INTERACTIVE_FOR" "test/repo" "" "marcusquinn")
 case "$decision" in
 	close\|stale-and-idle) print_result "t2708: origin:interactive + For #NNN → falls through to close" 0 ;;
-	escalate\|*) print_result "t2708: origin:interactive + For #NNN → falls through to close" 1 "got: $decision (must NOT escalate when body has For #NNN)" ;;
+	notify\|*) print_result "t2708: origin:interactive + For #NNN → falls through to close" 1 "got: $decision (must NOT notify when body has For #NNN)" ;;
 	*) print_result "t2708: origin:interactive + For #NNN → falls through to close" 1 "got: $decision" ;;
 esac
 
@@ -330,14 +330,14 @@ PR_INTERACTIVE_REF=$(mkpr 630 "DIRTY" \
 decision=$(_dirty_pr_classify "$PR_INTERACTIVE_REF" "test/repo" "" "marcusquinn")
 case "$decision" in
 	close\|stale-and-idle) print_result "t2708: origin:interactive + Ref #NNN → falls through to close" 0 ;;
-	escalate\|*) print_result "t2708: origin:interactive + Ref #NNN → falls through to close" 1 "got: $decision (must NOT escalate when body has Ref #NNN)" ;;
+	notify\|*) print_result "t2708: origin:interactive + Ref #NNN → falls through to close" 1 "got: $decision (must NOT notify when body has Ref #NNN)" ;;
 	*) print_result "t2708: origin:interactive + Ref #NNN → falls through to close" 1 "got: $decision" ;;
 esac
 
 # =============================================================================
 # Test 6d: parent-task label still takes precedence over the narrowed rule.
 #          Even if an interactive PR has a valid reference, the parent-task
-#          label must still force escalate (line 423-425 precedence, t1986).
+#          label must still force notify (line 423-425 precedence, t1986).
 # =============================================================================
 
 PR_INTERACTIVE_PARENT=$(mkpr 640 "DIRTY" \
@@ -350,8 +350,8 @@ PR_INTERACTIVE_PARENT=$(mkpr 640 "DIRTY" \
 
 decision=$(_dirty_pr_classify "$PR_INTERACTIVE_PARENT" "test/repo" "" "marcusquinn")
 case "$decision" in
-	escalate\|parent-task-label) print_result "t2708: parent-task precedence preserved over narrowed rule" 0 ;;
-	*) print_result "t2708: parent-task precedence preserved over narrowed rule" 1 "got: $decision (must still escalate with parent-task-label reason)" ;;
+	notify\|parent-task-label) print_result "t2708: parent-task precedence preserved over narrowed rule" 0 ;;
+	*) print_result "t2708: parent-task precedence preserved over narrowed rule" 1 "got: $decision (must still notify with parent-task-label reason)" ;;
 esac
 
 # =============================================================================


### PR DESCRIPTION
Resolves #20370

## Summary

Implements Option A: full rename of the `escalate` action to `notify` in `pulse-dirty-pr-sweep.sh`.

The word `escalate` misleadingly implied maintainer-review-required / merge-blocked semantics. The implementation is in fact just an idempotent comment — no label, no merge block, no dispatch. Renamed to `notify` to accurately reflect the semantic.

## Changes

- `readonly _DIRTY_ACTION_ESCALATE="escalate"` → `readonly _DIRTY_ACTION_NOTIFY="notify"`
- `readonly _DIRTY_PR_ESCALATE_MARKER` → `readonly _DIRTY_PR_NOTIFY_MARKER` (string value `<!-- pulse-dirty-pr-escalate -->` preserved for comment-history dedup continuity)
- `_dirty_pr_action_escalate()` → `_dirty_pr_action_notify()`
- Docstring updated to explicitly state: does NOT block merge, does NOT apply a label, does NOT dispatch a worker
- All callsites updated: classify printf calls, dispatcher case, counter (`total_escalated` → `total_notified`), sweep complete log line, header docblock
- `test-dirty-pr-sweep.sh`: all 6 `escalate|...` patterns updated to `notify|...`

## Option A decision rationale

~15 usage sites, but all localised to exactly 2 files. Issue guidance says "go with Option B if >10 sites", but also "Option A (preferred): if the rename is localised (internal constant)". Localisation wins — all changes are purely mechanical string replacements within the same two files. Option B would leave the misleading name in place permanently.

## Verification

- ShellCheck: clean on both modified files
- Tests: 15/15 pass (`test-dirty-pr-sweep.sh`)
- Orphan check: `rg "_DIRTY_ACTION_ESCALATE|_dirty_pr_action_escalate" .agents/scripts/` → no results

<!-- MERGE_SUMMARY
Option A chosen: all ~15 usage sites are localised to 2 files (pulse-dirty-pr-sweep.sh and its test), making the full rename appropriate.

Changes:
- _DIRTY_ACTION_ESCALATE → _DIRTY_ACTION_NOTIFY (value 'escalate' → 'notify')
- _DIRTY_PR_ESCALATE_MARKER → _DIRTY_PR_NOTIFY_MARKER (string value preserved for comment-history dedup)
- _dirty_pr_action_escalate() → _dirty_pr_action_notify()
- Updated docstring explicitly stating: no merge block, no label, no dispatch
- Updated all callsites, counters (total_escalated→total_notified), log lines, and header docblock
- Test file: all 6 escalate|... patterns → notify|...; 15/15 pass

Verification: shellcheck clean, 15/15 tests pass, no orphan escalate refs in .agents/scripts/.
-->

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.91 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 6m and 17,554 tokens on this as a headless worker.