### PR TITLE
GH#20366: fix PATH security + array dispatch for run: fields with args

### DIFF
--- a/.agents/bin/aidevops-auto-update
+++ b/.agents/bin/aidevops-auto-update
@@ -19,7 +19,7 @@ set -euo pipefail
 # start children with a minimal PATH (typically /usr/bin:/bin). setup.sh
 # symlinks the CLI to either /usr/local/bin or ${HOME}/.local/bin (see
 # install_aidevops_cli in setup-modules/config.sh), so both are prepended.
-PATH="/usr/local/bin:${HOME}/.local/bin:${PATH}"
+PATH="/usr/local/bin:${HOME}/.local/bin${PATH:+:${PATH}}"
 
 if ! command -v aidevops >/dev/null 2>&1; then
 	echo "[aidevops-auto-update] aidevops CLI not found in PATH. Install via setup.sh or npm install -g aidevops." >&2

--- a/.agents/bin/aidevops-repo-sync
+++ b/.agents/bin/aidevops-repo-sync
@@ -19,7 +19,7 @@ set -euo pipefail
 # start children with a minimal PATH (typically /usr/bin:/bin). setup.sh
 # symlinks the CLI to either /usr/local/bin or ${HOME}/.local/bin (see
 # install_aidevops_cli in setup-modules/config.sh), so both are prepended.
-PATH="/usr/local/bin:${HOME}/.local/bin:${PATH}"
+PATH="/usr/local/bin:${HOME}/.local/bin${PATH:+:${PATH}}"
 
 if ! command -v aidevops >/dev/null 2>&1; then
 	echo "[aidevops-repo-sync] aidevops CLI not found in PATH. Install via setup.sh or npm install -g aidevops." >&2

--- a/.agents/bin/aidevops-skills-sync
+++ b/.agents/bin/aidevops-skills-sync
@@ -27,7 +27,7 @@ set -euo pipefail
 # start children with a minimal PATH (typically /usr/bin:/bin). setup.sh
 # symlinks the CLI to either /usr/local/bin or ${HOME}/.local/bin (see
 # install_aidevops_cli in setup-modules/config.sh), so both are prepended.
-PATH="/usr/local/bin:${HOME}/.local/bin:${PATH}"
+PATH="/usr/local/bin:${HOME}/.local/bin${PATH:+:${PATH}}"
 
 if ! command -v aidevops >/dev/null 2>&1; then
 	echo "[aidevops-skills-sync] aidevops CLI not found in PATH. Install via setup.sh or npm install -g aidevops." >&2

--- a/.agents/scripts/pulse-routines.sh
+++ b/.agents/scripts/pulse-routines.sh
@@ -105,16 +105,27 @@ _routine_execute() {
 	local status="success"
 
 	if [[ -n "$run_script" ]]; then
-		# Script-only dispatch — zero LLM tokens
-		local script_path="${agents_dir}/${run_script}"
+		# Script-only dispatch — zero LLM tokens.
+		# Split run_script into the executable path and optional space-separated
+		# arguments (e.g. "scripts/process-guard-helper.sh kill-runaways" becomes
+		# script_path=".../process-guard-helper.sh" script_args=("kill-runaways")).
+		# Using an array avoids word-splitting issues and safely passes args.
+		local run_parts=()
+		IFS=' ' read -r -a run_parts <<< "$run_script"
+		local script_path="${agents_dir}/${run_parts[0]}"
+		local script_args=("${run_parts[@]:1}")
 		if [[ ! -x "$script_path" ]]; then
 			echo "[pulse-wrapper] routine ${routine_id}: script not found or not executable: ${script_path}" >>"$LOGFILE"
 			_routine_update_state "$routine_id" "failure"
 			return 1
 		fi
-		echo "[pulse-wrapper] routine ${routine_id}: executing script ${script_path}" >>"$LOGFILE"
+		if [[ ${#script_args[@]} -gt 0 ]]; then
+			echo "[pulse-wrapper] routine ${routine_id}: executing script ${script_path} ${script_args[*]}" >>"$LOGFILE"
+		else
+			echo "[pulse-wrapper] routine ${routine_id}: executing script ${script_path}" >>"$LOGFILE"
+		fi
 		local exit_code=0
-		"$script_path" >>"$LOGFILE" 2>&1 || exit_code=$?
+		"$script_path" "${script_args[@]}" >>"$LOGFILE" 2>&1 || exit_code=$?
 		if [[ "$exit_code" -ne 0 ]]; then
 			status="failure"
 			echo "[pulse-wrapper] routine ${routine_id}: script exited with code ${exit_code}" >>"$LOGFILE"
@@ -231,10 +242,23 @@ evaluate_routines() {
 				continue
 			fi
 
-			# Extract optional run: field
+			# Extract optional run: field — captures script path and any trailing
+			# space-separated argument tokens. Field keywords (agent:, repeat:,
+			# started:, blocked-by:) always contain a colon, so we stop as soon as
+			# we encounter a token with a colon embedded.
 			local run_script=""
 			if [[ "$line" =~ run:([^[:space:]]+) ]]; then
 				run_script="${BASH_REMATCH[1]}"
+				# Append optional argument tokens that follow the script path.
+				# Stop when a token contains ':' (field keyword) or starts with '#'.
+				local _run_rest="${line#*run:"${run_script}"}"
+				local _arg_token
+				while [[ "$_run_rest" =~ ^[[:space:]]+([^[:space:]]+)(.*)$ ]]; do
+					_arg_token="${BASH_REMATCH[1]}"
+					[[ "$_arg_token" == *:* || "$_arg_token" == "#"* || "$_arg_token" == "~"* || "$_arg_token" == "@"* ]] && break
+					run_script="${run_script} ${_arg_token}"
+					_run_rest="${BASH_REMATCH[2]}"
+				done
 			fi
 
 			# Extract optional agent: field


### PR DESCRIPTION
## Summary

Review followup for PR #20334 — two bot-flagged findings, both verified correct (Outcome B).

### 1. PATH security: trailing-colon risk in bin wrappers

Gemini flagged `PATH="/usr/local/bin:${HOME}/.local/bin:${PATH}"` in all three wrappers. If `PATH` is unset or empty on entry (common in minimal cron/launchd environments), the trailing `:` is equivalent to including `.` in the search path — a textbook CWE-426 untrusted search path risk.

**Fix:** `PATH="/usr/local/bin:${HOME}/.local/bin${PATH:+:${PATH}}"` — the `:` is only inserted when `PATH` is non-empty.

Files: `.agents/bin/aidevops-auto-update:22`, `.agents/bin/aidevops-repo-sync:22`, `.agents/bin/aidevops-skills-sync:30`

### 2. Silently-dropped run: field arguments (r903/r904/r907/r908/r909)

Gemini noted that `core-routines.sh` entries r903/r904/r907/r908/r909 still contain spaces in their `run:` fields. Verified against `pulse-routines.sh`:

- The parser regex `run:([^[:space:]]+)` stops at the first space — dropping everything after it.
- The executor calls `"$script_path"` as a single unquoted arg — no array, no argument forwarding.
- Consequence: `process-guard-helper.sh` runs without `kill-runaways` (defaults to `help`), `worker-watchdog.sh` without `--check` (defaults to `check` — coincidentally OK), `contribution-watch-helper.sh` without `scan` (defaults to `help`), etc. Affected routines silently no-op every cycle.
- Same bug affects `r005` (`worktree-helper.sh clean --auto --force-merged`) and `r-gh-audit-scan` (`gh-audit-anomaly-helper.sh scan`) in the live TODO.md.

**Fix (dispatcher, not more wrappers):** per the bot's suggestion and `t2703` context:

1. Parser: after extracting the script path token, a while loop appends additional non-field tokens until a colon-bearing field keyword (`agent:`, `repeat:`, `started:`, `blocked-by:`) or a `#` / `~` / `@` terminator is hit.
2. Executor: split `run_script` into an array via `IFS=' ' read -r -a`, then execute `"${script_path}" "${script_args[@]}"` — safe array expansion.

9/9 parser unit tests pass (single arg, flag arg, multiple args, no arg, stops at `agent:`, stops at `#`, stops at `~`, stops at `@`, no run: field).

File: `.agents/scripts/pulse-routines.sh`

## Verification

- `shellcheck .agents/bin/aidevops-{auto-update,repo-sync,skills-sync}` — clean
- `shellcheck .agents/scripts/pulse-routines.sh` — clean
- Parser logic validated with 9 inline test cases (see commit message)

Resolves #20366
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.91 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 10m and 33,477 tokens on this as a headless worker.