### PR TITLE
GH#20388: Decompose parent #20303 into audit + fix children

### DIFF
--- a/todo/tasks/gh20303-decomposition-brief.md
+++ b/todo/tasks/gh20303-decomposition-brief.md
@@ -1,0 +1,33 @@
+# Decomposition Brief: Parent #20303 — Audit local -n nameref usages
+
+## Parent Issue
+
+[#20303](https://github.com/marcusquinn/aidevops/issues/20303) — Audit remaining local -n nameref usages for zsh-source compatibility gaps.
+
+## Decomposition Rationale
+
+The parent identified 72 `local -n` usages across 6 files but explicitly scoped itself as a **research/audit task**, not a blanket rewrite. The natural decomposition splits the research phase from the targeted fix phase.
+
+## Reachability Analysis Summary
+
+| File | Count | Sourced? | Re-exec guard? | Verdict |
+|---|---:|---|---|---|
+| `compare-models-helper.sh` | 43 | No — standalone executable | N/A | **SAFE** |
+| `email-delivery-test-helper.sh` | 12 | No — standalone executable | N/A | **SAFE** |
+| `document-creation-helper.sh` | 11 | No — standalone executable | N/A | **SAFE** |
+| `setup/_tools.sh` | 2 | Yes — by `setup.sh:83` | No — `setup.sh` does not source `shared-constants.sh` | **AT RISK** |
+| `thumbnail-helper.sh` | 1 | No — standalone executable | N/A | **SAFE** |
+| `label-sync-helper.sh` | 1 | Yes — by `issue-sync-helper.sh:379` | Yes — `issue-sync-helper.sh:38` sources `shared-constants.sh` | **SAFE** |
+
+Key finding: only `setup/_tools.sh` is genuinely at risk. On macOS first-run (before Homebrew bash install), `setup.sh` runs under `/bin/bash` 3.2 via `#!/usr/bin/env bash`, and the `local -n` in `_tools.sh` lines 96 and 126 will fail.
+
+## Children
+
+| Child | Issue | Task ID | Scope |
+|---|---|---|---|
+| Reachability audit | #20392 | t2718 | Formal per-file analysis, document findings on parent |
+| Fix `setup/_tools.sh` | #20393 | t2719 | Apply module-globals pattern to 2 sites, add regression test |
+
+## Decomposition trigger
+
+Filed by auto-decomposer scanner (#20388) after parent's `parent-needs-decomposition` nudge aged ≥24h.


### PR DESCRIPTION
## Summary

Decompose parent-task #20303 (Audit remaining local -n nameref usages for zsh-source compatibility gaps) into 2 tracked children, unblocking the dispatch pipeline.

## What was done

1. **Reachability analysis** of all 6 files containing `local -n` declarations:
   - `compare-models-helper.sh` (43 sites): **SAFE** — standalone executable, never sourced
   - `email-delivery-test-helper.sh` (12 sites): **SAFE** — standalone executable
   - `document-creation-helper.sh` (11 sites): **SAFE** — standalone executable
   - `setup/_tools.sh` (2 sites): **AT RISK** — sourced by `setup.sh:83` which lacks `shared-constants.sh` re-exec guard
   - `thumbnail-helper.sh` (1 site): **SAFE** — standalone executable
   - `label-sync-helper.sh` (1 site): **SAFE** — sourced by `issue-sync-helper.sh` which has re-exec guard via `shared-constants.sh:38`

2. **Created 2 child issues**:
   - #20392 (t2718): Reachability audit — formal per-file analysis and documentation
   - #20393 (t2719): Fix `setup/_tools.sh` `local -n` usages at lines 96 and 126

3. **Updated parent #20303** body with `## Children` section linking both children.

4. **Added decomposition brief** at `todo/tasks/gh20303-decomposition-brief.md`.

## Testing

- Verified `## Children` section appears on parent #20303 with both child links
- Verified both child issues (#20392, #20393) exist with proper labels and bodies
- Verified TODO.md entries pushed to main with `ref:GH#` links

Resolves #20388
For #20303

<!-- allow-planning-close: this PR's deliverable IS the decomposition planning work -->