### PR TITLE
t2709: fix REST-fallback source path resolution for zsh (use _SC_SELF)

### DIFF
--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -41,9 +41,22 @@ _SHARED_GH_WRAPPERS_LOADED=1
 # t2689: Extended to READ paths — _rest_issue_view, _rest_issue_list.
 # Provides _gh_should_fallback_to_rest, _gh_issue_{create,comment,edit}_rest,
 # _gh_pr_create_rest, _rest_issue_view, _rest_issue_list.
-_SHARED_GH_WRAPPERS_DIR="${BASH_SOURCE[0]%/*}"
-# shellcheck source=shared-gh-wrappers-rest-fallback.sh
-source "${_SHARED_GH_WRAPPERS_DIR}/shared-gh-wrappers-rest-fallback.sh"
+# Resolve own directory cross-shell (bash + zsh).
+# Priority: (1) BASH_SOURCE[0] under bash; (2) _SC_SELF set by shared-constants.sh
+# before sourcing us — both bash and zsh populate it correctly via ${0:-}, and it
+# points to shared-constants.sh which lives in the same directory as the REST
+# fallback; (3) absent both, silently skip — the primary GraphQL path still works.
+if [[ -n "${BASH_SOURCE[0]:-}" ]]; then
+	_SHARED_GH_WRAPPERS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)" || _SHARED_GH_WRAPPERS_DIR=""
+elif [[ -n "${_SC_SELF:-}" ]]; then
+	_SHARED_GH_WRAPPERS_DIR="${_SC_SELF%/*}"
+else
+	_SHARED_GH_WRAPPERS_DIR=""
+fi
+if [[ -n "$_SHARED_GH_WRAPPERS_DIR" && -f "$_SHARED_GH_WRAPPERS_DIR/shared-gh-wrappers-rest-fallback.sh" ]]; then
+	# shellcheck source=shared-gh-wrappers-rest-fallback.sh
+	source "$_SHARED_GH_WRAPPERS_DIR/shared-gh-wrappers-rest-fallback.sh"
+fi
 
 # =============================================================================
 # GitHub Token Workflow Scope Check (t1540)

--- a/.agents/scripts/tests/test-shared-gh-wrappers-source.sh
+++ b/.agents/scripts/tests/test-shared-gh-wrappers-source.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-shared-gh-wrappers-source.sh — t2709 / GH#20357 regression guard.
+#
+# Asserts that sourcing shared-constants.sh (which sources shared-gh-wrappers.sh)
+# emits zero output about shared-gh-wrappers-rest-fallback.sh under both bash
+# and zsh, and that the REST fallback helpers are loaded correctly in both.
+#
+# Root cause: shared-gh-wrappers.sh:44-46 used ${BASH_SOURCE[0]%/*} to resolve
+# its own directory. Under zsh, BASH_SOURCE is not populated, so the expansion
+# returned empty, and the subsequent source call tried to load
+# /shared-gh-wrappers-rest-fallback.sh (leading-slash absolute path), emitting:
+#   shared-gh-wrappers.sh:source:46: no such file or directory: /shared-gh-wrappers-rest-fallback.sh
+# Additionally the previous attempt used ${(%):-%x} (zsh-only syntax) which
+# caused shfmt to fail parsing the file, triggering the AWK fallback that
+# reported a false nesting depth of 14 and failed the CI regression gate.
+#
+# Fix: use _SC_SELF (set by shared-constants.sh before sourcing us) as the zsh
+# fallback — pure bash syntax, shfmt-parseable, same directory.
+#
+# Tests:
+#   1. bash: source shared-constants.sh emits zero REST-fallback warnings
+#   2. bash: _gh_issue_create_rest is defined after sourcing
+#   3. zsh:  source shared-constants.sh emits zero REST-fallback warnings (t2709)
+#   4. zsh:  _gh_issue_create_rest is defined after sourcing (t2709)
+
+set -uo pipefail
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR_TEST}/.." && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPTS_DIR}/../.." && pwd)" || exit 1
+
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_BLUE=$'\033[0;34m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_BLUE="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf '  %sPASS%s %s\n' "$TEST_GREEN" "$TEST_NC" "$1"
+	return 0
+}
+
+fail() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '  %sFAIL%s %s\n' "$TEST_RED" "$TEST_NC" "$1"
+	if [[ -n "${2:-}" ]]; then
+		printf '       %s\n' "$2"
+	fi
+	return 0
+}
+
+skip() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf '  %sSKIP%s %s\n' "$TEST_BLUE" "$TEST_NC" "$1"
+	return 0
+}
+
+# =============================================================================
+# Test 1 + 2: bash — source emits no REST-fallback warning, helper defined
+# =============================================================================
+printf '\n=== bash source tests ===\n'
+
+bash_output=$(bash -c "source '${SCRIPTS_DIR}/shared-constants.sh' 2>&1" || true)
+if printf '%s\n' "$bash_output" | grep -q 'shared-gh-wrappers-rest-fallback.sh'; then
+	fail "bash source emits REST-fallback warning" "$bash_output"
+else
+	pass "bash source emits no REST-fallback warning"
+fi
+
+bash_fn=$(bash -c "source '${SCRIPTS_DIR}/shared-constants.sh' 2>/dev/null && type _gh_issue_create_rest 2>/dev/null" || true)
+if printf '%s\n' "$bash_fn" | grep -q 'function\|_gh_issue_create_rest'; then
+	pass "bash: _gh_issue_create_rest defined after source"
+else
+	fail "bash: _gh_issue_create_rest NOT defined after source" "$bash_fn"
+fi
+
+# =============================================================================
+# Test 3 + 4: zsh — source emits no REST-fallback warning, helper defined
+# =============================================================================
+printf '\n=== zsh source tests ===\n'
+
+if ! command -v zsh >/dev/null 2>&1; then
+	skip "zsh not available — skipping zsh tests (not a failure)"
+	skip "zsh: _gh_issue_create_rest defined after source (zsh unavailable)"
+else
+	zsh_output=$(zsh -c "source '${SCRIPTS_DIR}/shared-constants.sh' 2>&1" || true)
+	if printf '%s\n' "$zsh_output" | grep -q 'shared-gh-wrappers-rest-fallback.sh'; then
+		fail "zsh source emits REST-fallback warning (t2709)" "$zsh_output"
+	else
+		pass "zsh source emits no REST-fallback warning (t2709)"
+	fi
+
+	zsh_fn=$(zsh -c "source '${SCRIPTS_DIR}/shared-constants.sh' 2>/dev/null && type _gh_issue_create_rest 2>/dev/null" || true)
+	if printf '%s\n' "$zsh_fn" | grep -q 'function\|_gh_issue_create_rest\|shell function'; then
+		pass "zsh: _gh_issue_create_rest defined after source (REST fallback loaded)"
+	else
+		fail "zsh: _gh_issue_create_rest NOT defined after source" "$zsh_fn"
+	fi
+fi
+
+# =============================================================================
+# Summary
+# =============================================================================
+printf '\n=== Results: %d/%d passed ===\n' "$((TESTS_RUN - TESTS_FAILED))" "$TESTS_RUN"
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Fix the `no such file or directory: /shared-gh-wrappers-rest-fallback.sh` warning emitted on every `source shared-constants.sh` from a zsh session.

**Root cause:** `shared-gh-wrappers.sh:44` used `${BASH_SOURCE[0]%/*}` to resolve its own directory. Under zsh, `BASH_SOURCE` is not populated, so the expansion returned empty, and the subsequent `source` call tried to load `/shared-gh-wrappers-rest-fallback.sh` (leading-slash absolute path).

**Previous fix failure (PR #20375):** The prior attempt used `${(%):-%x}` (zsh-only syntax) which caused `shfmt` to fail parsing the file. The AWK fallback then reported a false nesting depth of 14, triggering the CI regression gate (base: 1 violation, head: 2 violations).

**This fix:** Use `_SC_SELF` (already set by `shared-constants.sh` via `${BASH_SOURCE[0]:-${0:-}}` before sourcing us) as the zsh fallback. Under zsh, `${0:-}` resolves to the sourced file's path, so `_SC_SELF%/*` gives the correct directory. Pure bash syntax — `shfmt` parses cleanly.

## Changes

**EDIT: `.agents/scripts/shared-gh-wrappers.sh` lines 44-46**

Replace 3 lines with a cross-shell resolver:
1. If `BASH_SOURCE[0]` is populated (bash): `cd $(dirname ...)` for absolute path
2. Else if `_SC_SELF` is set (common path via `shared-constants.sh` in zsh): use `${_SC_SELF%/*}`
3. Else: skip REST fallback silently (primary GraphQL path continues working)

Guards the `source` call behind a file-exists test — no warning on missing fallback.

**NEW: `.agents/scripts/tests/test-shared-gh-wrappers-source.sh`**

4 assertions: bash emits no warning + defines helper; zsh emits no warning + defines helper (skipped if zsh unavailable).

## Verification

All tests pass locally:

```
bash .agents/scripts/tests/test-shared-gh-wrappers-source.sh
# PASS bash source emits no REST-fallback warning
# PASS bash: _gh_issue_create_rest defined after source
# PASS zsh source emits no REST-fallback warning (t2709)
# PASS zsh: _gh_issue_create_rest defined after source (REST fallback loaded)
```

Nesting depth unchanged: `.agents/scripts/shared-gh-wrappers.sh` = 4 (was 4). No regression gate violation.

ShellCheck: zero new violations.

## Complexity Bump Justification

N/A — nesting depth held at 4 (well below the 8 threshold). No complexity bump needed.

Resolves #20357