### PR TITLE
t2724: route session-start framework status to TUI toasts

### DIFF
--- a/.agents/plugins/opencode-aidevops/greeting.mjs
+++ b/.agents/plugins/opencode-aidevops/greeting.mjs
@@ -1,0 +1,274 @@
+// ---------------------------------------------------------------------------
+// greeting.mjs — session-start framework status as TUI toasts (t2724)
+//
+// Routes the output of `aidevops-update-check.sh --interactive` through
+// OpenCode's `client.tui.showToast()` so the session banner renders as
+// ephemeral toasts instead of (or alongside) a message-context block.
+//
+// Phase 1: additive — the model still renders the greeting as the first
+// message. Phase 2 (separate commit) trims the redundant text from
+// generate-opencode-agents.sh once we've visually confirmed the toast.
+//
+// Trigger semantics (fail-open):
+//   - Primary: fires once per plugin init on the first session.created event.
+//   - Fallback: if session.created is missed (plugin loaded mid-session),
+//     fires on the first session.updated event within 30s of plugin init.
+//
+// Caching: raw update-check output is written to
+//   ~/.aidevops/cache/session-greeting.txt
+// so non-Bash agents can read it without re-running the script (t2724 phase 2
+// template change points agents at this file).
+//
+// Toast grouping (single-pass, cheap):
+//   - info    : version + env lines                         (8s)
+//   - success : "Security: all protections active"          (5s)
+//   - warning : pulse-stalled / external contribution lines (15s)
+//   - error   : [SECURITY ADVISORY] lines                   (30s)
+//
+// If a category has no matching lines, no toast for it is emitted. A
+// user with a clean environment sees one info toast and one success toast.
+//
+// Diagnostics: set AIDEVOPS_PLUGIN_DEBUG=1 to trace every handler invocation
+// and each toast emission (including failures). Without DEBUG the handler
+// is silent on success — only actual errors reach stderr.
+// ---------------------------------------------------------------------------
+
+import { execSync } from "child_process";
+import { mkdirSync, writeFileSync } from "fs";
+import { join, dirname } from "path";
+import { homedir } from "os";
+
+const CACHE_DIR = join(homedir(), ".aidevops", "cache");
+const CACHE_FILE = join(CACHE_DIR, "session-greeting.txt");
+
+// Fallback window: accept the first session.updated as a trigger if no
+// session.created arrived within this many ms of plugin init. Keeps the
+// handler from firing on every subsequent session.updated event.
+const FALLBACK_WINDOW_MS = 30000;
+
+/**
+ * Run the update-check script and return its stdout (trimmed), or "" on failure.
+ * Uses a short timeout — we never want a hung greeting to block plugin init.
+ *
+ * @param {string} scriptsDir
+ * @returns {string}
+ */
+function runUpdateCheck(scriptsDir) {
+  const script = join(scriptsDir, "aidevops-update-check.sh");
+  try {
+    return execSync(`bash ${JSON.stringify(script)} --interactive`, {
+      encoding: "utf-8",
+      timeout: 5000,
+      stdio: ["pipe", "pipe", "pipe"],
+    }).trim();
+  } catch (err) {
+    if (process.env.AIDEVOPS_PLUGIN_DEBUG) {
+      console.error(`[aidevops] greeting: update-check failed: ${err.message}`);
+    }
+    return "";
+  }
+}
+
+/**
+ * Write raw update-check output to ~/.aidevops/cache/session-greeting.txt
+ * so non-Bash agents can consult it without re-running the script.
+ * Failures are non-fatal — the toast path continues regardless.
+ *
+ * @param {string} output
+ */
+function cacheGreeting(output) {
+  try {
+    mkdirSync(dirname(CACHE_FILE), { recursive: true });
+    writeFileSync(CACHE_FILE, output + "\n", "utf-8");
+  } catch (err) {
+    if (process.env.AIDEVOPS_PLUGIN_DEBUG) {
+      console.error(`[aidevops] greeting: cache write failed: ${err.message}`);
+    }
+  }
+}
+
+/**
+ * Classify each line of update-check output into toast variants.
+ *
+ * @param {string} output
+ * @returns {{ info: string[], success: string[], warning: string[], error: string[] }}
+ */
+function classifyLines(output) {
+  const info = [];
+  const success = [];
+  const warning = [];
+  const error = [];
+
+  for (const rawLine of output.split("\n")) {
+    const line = rawLine.trim();
+    if (!line) continue;
+
+    // Skip UPDATE_AVAILABLE| sentinel lines — those are machine-readable
+    // markers consumed by the model greeting, not human banner text.
+    if (line.startsWith("UPDATE_AVAILABLE|") || line === "AUTO_UPDATE_ENABLED") {
+      continue;
+    }
+
+    // Order matters: errors first (most specific), then warnings, then
+    // success, then info (catch-all for version/env lines).
+    if (line.startsWith("[SECURITY ADVISORY]") || line.startsWith("[ERROR]")) {
+      error.push(line);
+    } else if (
+      line.startsWith("Pulse stalled") ||
+      /contribution\(s\) need/i.test(line) ||
+      line.startsWith("[WARNING]") ||
+      line.startsWith("[WARN]")
+    ) {
+      warning.push(line);
+    } else if (line.startsWith("Security: all protections active")) {
+      success.push(line);
+    } else {
+      info.push(line);
+    }
+  }
+
+  return { info, success, warning, error };
+}
+
+/**
+ * Build toast bodies from classified lines, skipping empty categories.
+ *
+ * @param {{ info: string[], success: string[], warning: string[], error: string[] }} buckets
+ * @returns {Array<{ title: string, message: string, variant: "info"|"success"|"warning"|"error", duration: number }>}
+ */
+function buildToasts(buckets) {
+  const toasts = [];
+
+  if (buckets.error.length > 0) {
+    toasts.push({
+      title: "aidevops — attention required",
+      message: buckets.error.join("\n"),
+      variant: "error",
+      duration: 30000,
+    });
+  }
+
+  if (buckets.warning.length > 0) {
+    toasts.push({
+      title: "aidevops",
+      message: buckets.warning.join("\n"),
+      variant: "warning",
+      duration: 15000,
+    });
+  }
+
+  if (buckets.info.length > 0) {
+    toasts.push({
+      title: "aidevops",
+      message: buckets.info.join("\n"),
+      variant: "info",
+      duration: 8000,
+    });
+  }
+
+  if (buckets.success.length > 0) {
+    toasts.push({
+      title: "aidevops",
+      message: buckets.success.join("\n"),
+      variant: "success",
+      duration: 5000,
+    });
+  }
+
+  return toasts;
+}
+
+/**
+ * Emit one toast via client.tui.showToast(). Logs failures when DEBUG is on.
+ *
+ * @param {any} client
+ * @param {{ title: string, message: string, variant: string, duration: number }} body
+ */
+async function emitToast(client, body) {
+  try {
+    await client.tui.showToast({ body });
+    if (process.env.AIDEVOPS_PLUGIN_DEBUG) {
+      console.error(`[aidevops] greeting: toast emitted (variant=${body.variant}, ${body.message.length} chars)`);
+    }
+  } catch (err) {
+    // Log on DEBUG; otherwise swallow (failures here are non-fatal —
+    // the user still has the message-context greeting in Phase 1).
+    if (process.env.AIDEVOPS_PLUGIN_DEBUG) {
+      console.error(`[aidevops] greeting: toast failed: ${err.message}`);
+    }
+  }
+}
+
+/**
+ * Run the full greeting flow: update-check → cache → classify → toasts.
+ *
+ * @param {string} scriptsDir
+ * @param {any} client
+ */
+async function runGreeting(scriptsDir, client) {
+  const output = runUpdateCheck(scriptsDir);
+  if (!output) {
+    if (process.env.AIDEVOPS_PLUGIN_DEBUG) {
+      console.error("[aidevops] greeting: update-check returned empty, skipping toasts");
+    }
+    return;
+  }
+
+  cacheGreeting(output);
+
+  const buckets = classifyLines(output);
+  const toasts = buildToasts(buckets);
+
+  if (process.env.AIDEVOPS_PLUGIN_DEBUG) {
+    console.error(`[aidevops] greeting: built ${toasts.length} toasts (info=${buckets.info.length}, success=${buckets.success.length}, warning=${buckets.warning.length}, error=${buckets.error.length})`);
+  }
+
+  // Emit sequentially so the ordering (error → warning → info → success)
+  // is preserved in the TUI toast stack. Per-toast errors are swallowed
+  // so one bad emit doesn't prevent later ones.
+  for (const body of toasts) {
+    await emitToast(client, body);
+  }
+}
+
+/**
+ * Create a handler that fires the greeting once per plugin init. The
+ * returned function matches the plugin `event` hook contract so it can be
+ * composed alongside other event consumers.
+ *
+ * Trigger rules:
+ *   1. Fires on the first `session.created` event received.
+ *   2. Falls back to the first `session.updated` event if >0ms but <30s
+ *      since plugin init has elapsed without a session.created arriving
+ *      (handles the case where the plugin loads after a session is already
+ *      active — e.g., hot-deploy during an existing session).
+ *   3. Ignores all other event types.
+ *
+ * @param {{ scriptsDir: string, client: any }} opts
+ * @returns {(input: { event: { type: string } }) => Promise<void>}
+ */
+export function createGreetingHandler({ scriptsDir, client }) {
+  let fired = false;
+  const initTime = Date.now();
+
+  return async ({ event }) => {
+    if (fired) return;
+    if (!event || !event.type) return;
+
+    const isPrimary = event.type === "session.created";
+    const isFallback =
+      event.type === "session.updated" &&
+      Date.now() - initTime < FALLBACK_WINDOW_MS;
+
+    if (!isPrimary && !isFallback) return;
+
+    fired = true;
+
+    if (process.env.AIDEVOPS_PLUGIN_DEBUG) {
+      const mode = isPrimary ? "primary" : "fallback";
+      console.error(`[aidevops] greeting: triggered (mode=${mode}, type=${event.type})`);
+    }
+
+    await runGreeting(scriptsDir, client);
+  };
+}

--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -34,6 +34,7 @@ import { createQualityHooks } from "./quality-hooks.mjs";
 import { createShellEnvHook } from "./shell-env.mjs";
 import { compactingHook } from "./compaction.mjs";
 import { INTENT_FIELD } from "./intent-tracing.mjs";
+import { createGreetingHandler } from "./greeting.mjs";
 
 // Existing modules
 import { createTools } from "./tools.mjs";
@@ -220,6 +221,15 @@ export async function AidevopsPlugin({ directory, client }) {
     intentField: INTENT_FIELD,
   });
 
+  // Greeting handler (t2724) — emits session-start framework status as
+  // TUI toasts via client.tui.showToast(). Fires once per plugin init on
+  // the first session.created event. See greeting.mjs for classification
+  // and variant rules.
+  const greetingHandler = createGreetingHandler({
+    scriptsDir: SCRIPTS_DIR,
+    client,
+  });
+
   return {
     // Config: agent index, MCP registration, OAuth pool injection
     config: async (config) => {
@@ -245,8 +255,19 @@ export async function AidevopsPlugin({ directory, client }) {
     "experimental.chat.messages.transform": messagesTransformHook,
     "experimental.text.complete": textCompleteHook,
 
-    // LLM observability
-    event: async (input) => handleEvent(input),
+    // LLM observability + session-start toast greeting (t2724).
+    // Both run on every event; greeting self-gates to session.created.
+    event: async (input) => {
+      // Fire both in parallel — neither depends on the other's result.
+      await Promise.all([
+        handleEvent(input),
+        greetingHandler(input).catch((err) => {
+          if (process.env.AIDEVOPS_PLUGIN_DEBUG) {
+            console.error(`[aidevops] greeting handler error: ${err.message}`);
+          }
+        }),
+      ]);
+    },
 
     // OAuth multi-account pool + provider auth
     auth: (() => {

--- a/.agents/scripts/generate-opencode-agents.sh
+++ b/.agents/scripts/generate-opencode-agents.sh
@@ -44,12 +44,13 @@ Add ~/.aidevops/agents/AGENTS.md to context for AI DevOps capabilities.
 
 ## aidevops Framework Status
 
-**On interactive conversation start** (skip this section entirely for headless/command sessions like `/pulse`, `/full-loop`, etc.):
-1. If you have Bash tool: Run `bash ~/.aidevops/agents/scripts/aidevops-update-check.sh --interactive`
-2. If no Bash tool: Read `~/.aidevops/cache/session-greeting.txt` (cached by agents with Bash) and greet with: "Hi!\n\n{content of file}.\n\nWhat would you like to work on?". If the file doesn't exist, read `~/.aidevops/agents/VERSION` to get the `{version}` and greet with: "Hi!\n\nWe're running https://aidevops.sh v{version}.\n\nWhat would you like to work on?"
-3. Then respond to the user's actual message
+The opencode-aidevops plugin renders session-start framework status (version, environment, security advisories, pulse health, contribution count) as TUI toasts at session creation via `client.tui.showToast()`. Raw output is cached at `~/.aidevops/cache/session-greeting.txt`.
 
-If you ran the update check script (step 1) and the output starts with `UPDATE_AVAILABLE|` (e.g., `UPDATE_AVAILABLE|2.41.1|2.41.2|OpenCode`), inform user: "Update available (current → latest). Run `aidevops update` in a terminal session to update, or type `!aidevops update` below and hit Enter." If the output also contains a line `AUTO_UPDATE_ENABLED`, replace the manual update instruction with: "Auto-update is enabled and will apply this within ~10 minutes." This check does not apply when falling back to reading the cache or VERSION file (step 2).
+Do not re-run `aidevops-update-check.sh` or repeat toast content as a greeting — the user has already seen it. Respond directly to the user's message.
+
+**Fallback for agents without a Bash tool** (the plugin only fires toasts when the host runtime exposes the TUI — subagents may not see them): read `~/.aidevops/cache/session-greeting.txt` if it exists; otherwise read `~/.aidevops/agents/VERSION` for `{version}` and greet with `"Hi!\n\nWe're running https://aidevops.sh v{version}.\n\nWhat would you like to work on?"`.
+
+**Update available prompt**: the raw cached output may begin with `UPDATE_AVAILABLE|<current>|<latest>|<runtime>`. When present, inform the user: "Update available (current → latest). Run `aidevops update` in a terminal session, or type `!aidevops update` below and hit Enter." If the cached output also contains `AUTO_UPDATE_ENABLED`, replace the manual instruction with: "Auto-update is enabled and will apply this within ~10 minutes."
 
 ## Pre-Edit Git Check
 


### PR DESCRIPTION
## Summary

- New plugin module `greeting.mjs` renders the session-start framework status banner as OpenCode TUI toasts via `client.tui.showToast()`, replacing the model-rendered message-context greeting.
- Classifies update-check output into four variants (error/warning/info/success) with appropriate durations, fires once per plugin init with a session-updated fallback for hot-deploy cases, and caches raw output at `~/.aidevops/cache/session-greeting.txt`.
- Phase 2 trims the `generate-opencode-agents.sh` AGENTS.md template so the model no longer re-runs the script or re-emits the greeting content — saves ~100-200 tokens per interactive session.

## Why

The session greeting (version, security advisories, pulse status, contribution count) was rendered as the first message in every interactive OpenCode session, consuming 100-200 tokens that the human needs to see but the model rarely acts on. OpenCode 1.14 exposes `client.tui.showToast()` — routing the banner through toasts frees that context entirely.

## What changed

**New module** (`.agents/plugins/opencode-aidevops/greeting.mjs`):
- `createGreetingHandler({ scriptsDir, client })` returns an event-hook-compatible function.
- Triggers: first `session.created` event OR first `session.updated` within 30s of init (fallback for plugins loaded mid-session).
- Fire-once semantics via a closure flag.
- Runs `aidevops-update-check.sh --interactive`, classifies lines, emits up to 4 toasts in order (error → warning → info → success).
- Writes cache file for non-Bash subagents.
- Diagnostic logging gated by `AIDEVOPS_PLUGIN_DEBUG=1`.

**Wired into event hook** (`.agents/plugins/opencode-aidevops/index.mjs`):
- Imports `createGreetingHandler`, instantiates with `SCRIPTS_DIR` + `client`.
- Composed into the existing `event:` hook via `Promise.all([handleEvent, greetingHandler(…).catch(…)])` — failures isolated from observability.

**Template trim** (`.agents/scripts/generate-opencode-agents.sh`):
- Replaced the "On interactive conversation start" block (which told the model to run the script and render output as `"Hi!\n\n…"`) with a short note that the plugin handles this via TUI toasts.
- Retained: no-Bash agent fallback (reads cache file or VERSION), UPDATE_AVAILABLE prompting (model still needs to surface the `!aidevops update` action).

## Verification

Phase 1 could not be end-to-end verified from inside this authoring session — the plugin was hot-deployed during an active OpenCode session, so the running plugin is the pre-change version. Verification requires a fresh OpenCode launch after the AGENTS.md template regenerates:

1. Merge or manually run `setup.sh --non-interactive` to deploy the new `~/.config/opencode/AGENTS.md`.
2. Fully quit and relaunch OpenCode.
3. At session start, expect ≥1 TUI toast (info variant with version/env) within ~2s.
4. If advisories are active, expect an error-variant toast with the advisory text.
5. Model should NOT greet with version/advisory content (Phase 2 effect).
6. Verify `~/.aidevops/cache/session-greeting.txt` exists and contains raw update-check output.
7. On diagnostic failures, set `AIDEVOPS_PLUGIN_DEBUG=1` before launching to surface `[aidevops] greeting: …` traces in the OpenCode log.

## Passes

- `node --check` on both `.mjs` files.
- `shellcheck .agents/scripts/generate-opencode-agents.sh`.
- Pre-commit quality validation (ratchet gates, ShellCheck).
- Pre-push quality validation (secretlint, baseline).

Resolves #20412

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.92 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-opus-4-7 spent 50m and 67,230 tokens on this with the user in an interactive session.
