### PR TITLE
t2713: large-file gate exemption for surgical briefs with line ranges

### DIFF
--- a/.agents/scripts/pulse-dispatch-large-file-gate.sh
+++ b/.agents/scripts/pulse-dispatch-large-file-gate.sh
@@ -27,6 +27,11 @@ _PULSE_DISPATCH_LARGE_FILE_GATE_LOADED=1
 # data files (.json/.yaml/.yml/.toml/.xml/.csv) which are config, not code.
 _LFG_SKIP_PATTERN='(package-lock\.json|yarn\.lock|pnpm-lock\.yaml|composer\.lock|Cargo\.lock|Gemfile\.lock|poetry\.lock|simplification-state\.json|\.min\.(js|css)$|\.json$|\.yaml$|\.yml$|\.toml$|\.xml$|\.csv$)'
 
+# t2713: Module-level return variable for _large_file_gate_check_surgical_brief.
+# Holds a comma-separated list of exempted file basenames when the surgical-brief
+# exemption fires; reset to "" at the start of each call.
+_LFG_SURGICAL_EXEMPTED_FILES=""
+
 #######################################
 # Label-based early-exit precheck for the large-file gate.
 # Handles GH#18042 self-simplification auto-clear, force_recheck bypass,
@@ -641,6 +646,88 @@ _large_file_gate_clear_stale_label() {
 }
 
 #######################################
+# t2713: Surgical-brief exemption precheck for the large-file gate.
+# When the issue title encodes a task ID (^tNNN:) and the task's brief
+# cites an explicit line range for EVERY path returned by
+# _large_file_gate_extract_paths, the edits are surgical and do not
+# require whole-file context budget. Returns 0 (exemption applies) when
+# all paths are covered; returns 1 otherwise.
+#
+# Sets module-level global _LFG_SURGICAL_EXEMPTED_FILES to a comma-separated
+# list of exempted file basenames when returning 0.
+#
+# Three accepted line-range forms in the brief (any one form per file counts):
+#   a) basename:NNN-NNN            (direct citation, e.g. "auto-update-helper.sh:1320-1345")
+#   b) basename ... (line NNN-NNN) (narrative parenthetical)
+#   c) basename ... LNNN-LNNN      (GitHub URL / notebook-style)
+#
+# Conservative fail-open: missing task ID, missing brief, or unmatched
+# path all fall through to the normal per-target evaluation loop.
+#
+# Arguments:
+#   $1 - issue_title  (e.g. "t2706: fix deployed-sha drift")
+#   $2 - all_paths    (newline-separated, from _large_file_gate_extract_paths)
+#   $3 - repo_path    (absolute path to the repo checkout)
+# Exit codes:
+#   0 - exemption applies (all paths have ≥1 line-range ref in brief)
+#   1 - no exemption (no task ID, brief missing, empty paths, ≥1 uncovered)
+#######################################
+_large_file_gate_check_surgical_brief() {
+	local issue_title="$1"
+	local all_paths="$2"
+	local repo_path="$3"
+
+	_LFG_SURGICAL_EXEMPTED_FILES=""
+
+	# 1. Extract task ID from issue title (must begin with tNNN:).
+	local task_id=""
+	if [[ "$issue_title" =~ ^(t[0-9]+): ]]; then
+		task_id="${BASH_REMATCH[1]}"
+	fi
+	[[ -n "$task_id" ]] || return 1
+
+	# 2. Locate the task brief — fall through conservatively when missing.
+	local brief_path="${repo_path}/todo/tasks/${task_id}-brief.md"
+	[[ -f "$brief_path" ]] || return 1
+
+	# 3. For each extracted path, verify ≥1 line-range reference exists in the
+	#    brief. ALL paths must be covered for the exemption to fire.
+	local covered_all=true
+	local covered_files=""
+	local raw_target
+	while IFS= read -r raw_target; do
+		[[ -z "$raw_target" ]] && continue
+
+		# Strip any line qualifier already embedded in the extracted path
+		# (mirrors the stripping in _large_file_gate_evaluate_target).
+		local fpath="$raw_target"
+		if [[ "$raw_target" =~ ^(.+):([0-9]+(-[0-9]+)?)$ ]]; then
+			fpath="${BASH_REMATCH[1]}"
+		fi
+		local bname
+		bname=$(basename "$fpath")
+
+		# Pattern a: basename:NNN-NNN (most common — "Relevant Files" sections)
+		# Pattern b: basename ... (line NNN-NNN) (narrative parenthetical in prose)
+		# Pattern c: basename ... LNNN-LNNN (GitHub URL / notebook reference)
+		if grep -qE "${bname}:[0-9]+-[0-9]+" "$brief_path" 2>/dev/null ||
+			grep -qE "${bname}.*\(lines?[[:space:]]+[0-9]+-[0-9]+\)" "$brief_path" 2>/dev/null ||
+			grep -qE "${bname}.*L[0-9]+-L?[0-9]+" "$brief_path" 2>/dev/null; then
+			covered_files="${covered_files}${bname}, "
+		else
+			covered_all=false
+			break
+		fi
+	done <<<"$all_paths"
+
+	if [[ "$covered_all" == true && -n "$covered_files" ]]; then
+		_LFG_SURGICAL_EXEMPTED_FILES="${covered_files%, }"
+		return 0
+	fi
+	return 1
+}
+
+#######################################
 # Thin orchestrator for the large-file gate. Delegates label precheck,
 # path extraction, per-target evaluation, gate application, and stale-label
 # cleanup to the `_large_file_gate_*` helpers above. Byte-for-byte
@@ -698,6 +785,18 @@ _issue_targets_large_files() {
 		if [[ ",$issue_labels," == *",needs-simplification,"* ]]; then
 			_large_file_gate_clear_stale_label "$issue_number" "$repo_slug"
 		fi
+		return 1
+	fi
+
+	# t2713: Surgical-brief exemption — check before the per-target evaluation
+	# loop. If the issue title has a task ID and the linked brief cites line
+	# ranges for every extracted path, dispatch proceeds without a split.
+	local _surgical_title=""
+	_surgical_title=$(gh issue view "$issue_number" --repo "$repo_slug" \
+		--json title --jq '.title // ""' 2>/dev/null) || _surgical_title=""
+	if _large_file_gate_check_surgical_brief \
+		"$_surgical_title" "$all_paths" "$repo_path"; then
+		echo "[pulse-wrapper] Large-file gate EXEMPTED for #${issue_number} (${repo_slug}): surgical brief with line ranges for ${_LFG_SURGICAL_EXEMPTED_FILES}" >>"$LOGFILE"
 		return 1
 	fi
 

--- a/.agents/scripts/tests/test-large-file-gate-surgical-exemption.sh
+++ b/.agents/scripts/tests/test-large-file-gate-surgical-exemption.sh
@@ -1,0 +1,327 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-large-file-gate-surgical-exemption.sh — t2713 regression guard.
+#
+# Verifies that `_large_file_gate_check_surgical_brief()` in
+# pulse-dispatch-large-file-gate.sh correctly exempts the large-file gate
+# when every large file cited in an issue has an explicit line-range
+# reference in the linked task brief.
+#
+# Background: the gate blocks dispatch on any issue that references a file
+# exceeding 2000 lines, assuming workers will spend their context budget
+# reading the whole file. This assumption is wrong for surgical edits with
+# explicit line ranges. The brief already carries the signal (line ranges);
+# the gate now reads it via _large_file_gate_check_surgical_brief().
+#
+# Canonical trigger: GH#20341 (t2706) — a 25-line fix across two functions
+# in auto-update-helper.sh (2251 lines) was held behind a full file-split
+# PR cycle because the gate couldn't tell surgical from holistic.
+#
+# Tests:
+#   1. Full coverage: task ID + brief exists + all paths have line-range refs
+#      → EXEMPTED (returns 0), _LFG_SURGICAL_EXEMPTED_FILES populated
+#   2. Partial coverage: brief exists + one path has no line-range ref
+#      → gate applied (returns 1)
+#   3. No brief: task ID found + brief file missing
+#      → gate applied (returns 1)
+#   4. Brief exists but no line-range signals for any file
+#      → gate applied (returns 1)
+#   5. No task ID in title: title not in tNNN: format
+#      → gate applied (returns 1)
+#   6. Canonical t2706 brief: using the actual todo/tasks/t2706-brief.md
+#      → EXEMPTED for auto-update-helper.sh (pattern a: basename:NNN-NNN)
+#   7. Log format: source file contains the exact log string from the spec
+#      → structural check (no live pulse needed)
+#
+# Cross-references: GH#20371 / t2713, GH#20341 / t2706 (canonical trigger),
+# GH#20343 (child split issue this exemption makes unnecessary).
+
+set -uo pipefail
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+GATE_SCRIPT="${SCRIPT_DIR_TEST}/../pulse-dispatch-large-file-gate.sh"
+REPO_ROOT="$(cd "${SCRIPT_DIR_TEST}/../../.." && pwd)" || exit 1
+
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+# ---- shared assert helpers -----------------------------------------------
+
+assert_rc() {
+	local test_name="$1"
+	local expected_rc="$2"
+	local actual_rc="$3"
+
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$actual_rc" -eq "$expected_rc" ]]; then
+		printf '  %sPASS%s %s\n' "$TEST_GREEN" "$TEST_NC" "$test_name"
+		return 0
+	fi
+	printf '  %sFAIL%s %s\n' "$TEST_RED" "$TEST_NC" "$test_name"
+	printf '       expected rc=%s, got rc=%s\n' "$expected_rc" "$actual_rc"
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+assert_contains() {
+	local test_name="$1"
+	local haystack="$2"
+	local needle="$3"
+
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$haystack" == *"$needle"* ]]; then
+		printf '  %sPASS%s %s\n' "$TEST_GREEN" "$TEST_NC" "$test_name"
+		return 0
+	fi
+	printf '  %sFAIL%s %s\n' "$TEST_RED" "$TEST_NC" "$test_name"
+	printf '       missing: %s\n' "$needle"
+	printf '       in:      %s\n' "$haystack"
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+assert_empty() {
+	local test_name="$1"
+	local actual="$2"
+
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ -z "$actual" ]]; then
+		printf '  %sPASS%s %s\n' "$TEST_GREEN" "$TEST_NC" "$test_name"
+		return 0
+	fi
+	printf '  %sFAIL%s %s\n' "$TEST_RED" "$TEST_NC" "$test_name"
+	printf '       expected empty, got: %s\n' "$actual"
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+# ---- load the gate module ------------------------------------------------
+
+# LOGFILE, LARGE_FILE_LINE_THRESHOLD, and SCOPED_RANGE_THRESHOLD are used
+# by siblings of _large_file_gate_check_surgical_brief; set safe defaults
+# so the module sources cleanly.
+LOGFILE="/dev/null"
+export LOGFILE
+LARGE_FILE_LINE_THRESHOLD="${LARGE_FILE_LINE_THRESHOLD:-2000}"
+export LARGE_FILE_LINE_THRESHOLD
+SCOPED_RANGE_THRESHOLD="${SCOPED_RANGE_THRESHOLD:-200}"
+export SCOPED_RANGE_THRESHOLD
+
+# shellcheck source=/dev/null
+source "$GATE_SCRIPT"
+
+# ---- temp workspace ------------------------------------------------------
+
+TMPDIR_BASE="$(mktemp -d 2>/dev/null || mktemp -d -t 'lfg_test')"
+trap 'rm -rf "$TMPDIR_BASE"' EXIT
+
+# Helper: create a temp repo dir containing todo/tasks/<task_id>-brief.md
+setup_test_repo() {
+	local task_id="$1"
+	local brief_content="$2"
+	local repo_dir="${TMPDIR_BASE}/${task_id}-repo"
+	mkdir -p "${repo_dir}/todo/tasks"
+	printf '%s\n' "$brief_content" >"${repo_dir}/todo/tasks/${task_id}-brief.md"
+	printf '%s' "$repo_dir"
+}
+
+# =========================================================================
+printf '\n=== test-large-file-gate-surgical-exemption.sh (t2713) ===\n\n'
+
+# =========================================================================
+# Test 1: Full coverage — task ID + brief + all paths have line-range refs
+#         → EXEMPTED (function returns 0), _LFG_SURGICAL_EXEMPTED_FILES set
+# =========================================================================
+BRIEF_FULL=$(cat <<'EOF'
+# t9999: example brief
+
+## Relevant Files
+
+- `big-file.sh:500-600` — the main function we are editing
+- `another-file.sh:100-200` — helper used by the main function
+
+## How
+
+EDIT: .agents/scripts/big-file.sh
+EDIT: .agents/scripts/another-file.sh
+EOF
+)
+REPO1=$(setup_test_repo "t9999" "$BRIEF_FULL")
+
+PATHS_FULL=$'agents/scripts/big-file.sh\nagents/scripts/another-file.sh'
+EXEMPT_RC=99
+_large_file_gate_check_surgical_brief \
+	"t9999: example fix for the large file" \
+	"$PATHS_FULL" \
+	"$REPO1" && EXEMPT_RC=0 || EXEMPT_RC=$?
+
+assert_rc \
+	"full coverage → function returns 0 (exemption applies)" \
+	0 "$EXEMPT_RC"
+
+assert_contains \
+	"full coverage → _LFG_SURGICAL_EXEMPTED_FILES contains big-file.sh" \
+	"$_LFG_SURGICAL_EXEMPTED_FILES" \
+	"big-file.sh"
+
+assert_contains \
+	"full coverage → _LFG_SURGICAL_EXEMPTED_FILES contains another-file.sh" \
+	"$_LFG_SURGICAL_EXEMPTED_FILES" \
+	"another-file.sh"
+
+# =========================================================================
+# Test 2: Partial coverage — one path has no line-range ref → gate applied
+# =========================================================================
+BRIEF_PARTIAL=$(cat <<'EOF'
+# t8888: partial brief
+
+## Relevant Files
+
+- `big-file.sh:500-600` — has line range
+
+## How
+
+EDIT: .agents/scripts/big-file.sh
+EDIT: .agents/scripts/uncovered-file.sh
+EOF
+)
+REPO2=$(setup_test_repo "t8888" "$BRIEF_PARTIAL")
+
+PATHS_PARTIAL=$'agents/scripts/big-file.sh\nagents/scripts/uncovered-file.sh'
+PARTIAL_RC=99
+_large_file_gate_check_surgical_brief \
+	"t8888: partial brief example" \
+	"$PATHS_PARTIAL" \
+	"$REPO2" && PARTIAL_RC=0 || PARTIAL_RC=$?
+
+assert_rc \
+	"partial coverage → function returns 1 (gate applied)" \
+	1 "$PARTIAL_RC"
+
+assert_empty \
+	"partial coverage → _LFG_SURGICAL_EXEMPTED_FILES is empty" \
+	"$_LFG_SURGICAL_EXEMPTED_FILES"
+
+# =========================================================================
+# Test 3: No brief file — brief path does not exist → gate applied
+# =========================================================================
+REPO3="${TMPDIR_BASE}/no-brief-repo"
+mkdir -p "${REPO3}/todo/tasks"
+# Deliberately do NOT create a brief for t7777
+
+PATHS_SIMPLE='agents/scripts/big-file.sh'
+NOBRIRF_RC=99
+_large_file_gate_check_surgical_brief \
+	"t7777: task with no brief" \
+	"$PATHS_SIMPLE" \
+	"$REPO3" && NOBRIRF_RC=0 || NOBRIRF_RC=$?
+
+assert_rc \
+	"missing brief → function returns 1 (gate applied)" \
+	1 "$NOBRIRF_RC"
+
+# =========================================================================
+# Test 4: Brief exists but contains no line-range signals → gate applied
+# =========================================================================
+BRIEF_NO_RANGES=$(cat <<'EOF'
+# t6666: brief without ranges
+
+## How
+
+Edit big-file.sh to fix the bug. Look at the function near the top.
+The file is referenced but without any line numbers.
+
+EDIT: .agents/scripts/big-file.sh
+EOF
+)
+REPO4=$(setup_test_repo "t6666" "$BRIEF_NO_RANGES")
+
+PATHS_NORANGE='agents/scripts/big-file.sh'
+NORANGE_RC=99
+_large_file_gate_check_surgical_brief \
+	"t6666: task with no ranges in brief" \
+	"$PATHS_NORANGE" \
+	"$REPO4" && NORANGE_RC=0 || NORANGE_RC=$?
+
+assert_rc \
+	"brief with no line ranges → function returns 1 (gate applied)" \
+	1 "$NORANGE_RC"
+
+# =========================================================================
+# Test 5: No task ID in issue title → gate applied (first guard short-circuits)
+# =========================================================================
+REPO5=$(setup_test_repo "t5555" "$BRIEF_FULL")
+
+PATHS_NOTASKID='agents/scripts/big-file.sh'
+NOTASKID_RC=99
+_large_file_gate_check_surgical_brief \
+	"This title has no recognised task ID format" \
+	"$PATHS_NOTASKID" \
+	"$REPO5" && NOTASKID_RC=0 || NOTASKID_RC=$?
+
+assert_rc \
+	"no task ID in title → function returns 1 (gate applied)" \
+	1 "$NOTASKID_RC"
+
+# =========================================================================
+# Test 6: Canonical t2706 brief — auto-update-helper.sh:1320-1345 present
+#         Uses the actual brief from the repo to verify the canonical case.
+#         Simulates the GH#20341 triggering path that motivated this issue.
+# =========================================================================
+T2706_BRIEF="${REPO_ROOT}/todo/tasks/t2706-brief.md"
+if [[ -f "$T2706_BRIEF" ]]; then
+	# The brief contains `auto-update-helper.sh:1320-1345` (pattern a) and
+	# `aidevops.sh:540-580` (pattern a) — both should be covered.
+	# For the gate check, we test with just auto-update-helper.sh since
+	# that is the file that triggered needs-simplification on GH#20341.
+	PATHS_T2706='agents/scripts/auto-update-helper.sh'
+	T2706_RC=99
+	_large_file_gate_check_surgical_brief \
+		"t2706: redeploy on .deployed-sha drift, not just VERSION/sentinel" \
+		"$PATHS_T2706" \
+		"$REPO_ROOT" && T2706_RC=0 || T2706_RC=$?
+
+	assert_rc \
+		"canonical t2706 brief: auto-update-helper.sh → EXEMPTED (rc=0)" \
+		0 "$T2706_RC"
+
+	assert_contains \
+		"canonical t2706 brief: exempted files contains auto-update-helper.sh" \
+		"$_LFG_SURGICAL_EXEMPTED_FILES" \
+		"auto-update-helper.sh"
+else
+	printf '  SKIP  canonical t2706 brief test (todo/tasks/t2706-brief.md not found)\n'
+fi
+
+# =========================================================================
+# Test 7: Log format — structural check that the source file contains the
+#         exact log string specified in the issue (GH#20371).
+# =========================================================================
+LOG_NEEDLE='Large-file gate EXEMPTED for #'
+TESTS_RUN=$((TESTS_RUN + 1))
+if grep -qF "$LOG_NEEDLE" "$GATE_SCRIPT" 2>/dev/null; then
+	printf '  %sPASS%s log format: source contains expected log prefix\n' "$TEST_GREEN" "$TEST_NC"
+else
+	printf '  %sFAIL%s log format: source missing expected log prefix\n' "$TEST_RED" "$TEST_NC"
+	printf '       missing: %s\n' "$LOG_NEEDLE"
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+fi
+
+# ---- summary -------------------------------------------------------------
+
+printf '\n%d run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Extends `_issue_targets_large_files` in `pulse-dispatch-large-file-gate.sh` with a new surgical-brief exemption precheck. When an issue title encodes a task ID and the linked brief cites an explicit line range for every extracted file path, the large-file gate is skipped — surgical edits do not need the whole-file context budget the gate guards against.

## Why

The gate at `pulse-dispatch-large-file-gate.sh:660-735` blocks dispatch on any issue referencing a file exceeding 2000 lines. This is correct for holistic rewrites. It is wrong for surgical edits where the brief already tells the worker exactly which 25 lines to change.

**Canonical trigger:** GH#20341 (t2706) — a 25-line net change across two cited functions in `auto-update-helper.sh` (2251 lines) was held behind a full file-split PR cycle. The brief already contained `auto-update-helper.sh:1320-1345`. The gate never read it.

## Changes

**`pulse-dispatch-large-file-gate.sh`** (+87 lines):
- `_LFG_SURGICAL_EXEMPTED_FILES` — module-level global for the function's return value
- `_large_file_gate_check_surgical_brief()` — new function; extracts task ID from title, locates `todo/tasks/<task_id>-brief.md`, checks every extracted path for ≥1 line-range reference (3 accepted patterns: `basename:NNN-NNN`, parenthetical `(line NNN-NNN)`, GitHub `LNNN-LNNN`)
- `_issue_targets_large_files()` — exemption precheck inserted after empty-path check and before per-target evaluation loop; fetches issue title via `gh issue view --json title`; emits structured log line on exemption

**`tests/test-large-file-gate-surgical-exemption.sh`** (new, +339 lines):
- 7 test cases, 11 assertions
- Covers all 5 acceptance-criteria cases (full, partial, no-brief, no-ranges, no-task-ID)
- Canonical end-to-end: uses actual `todo/tasks/t2706-brief.md` to verify `auto-update-helper.sh` is EXEMPTED
- Structural: verifies expected log prefix is present in source

## Verification

```bash
# Regression test — 11/11 pass
bash .agents/scripts/tests/test-large-file-gate-surgical-exemption.sh

# Existing tests — no regression
bash .agents/scripts/tests/test-large-file-gate-extract-edit-only.sh
bash .agents/scripts/tests/test-large-file-gate-body.sh

# ShellCheck
shellcheck .agents/scripts/pulse-dispatch-large-file-gate.sh
```

## New File Smell Justification

The new test file `test-large-file-gate-surgical-exemption.sh` is a test fixture by design. Test fixtures legitimately repeat assertion strings and sample inputs to exercise the patterns they verify — this is documented in the qlty-new-file-gate workflow (exemption category: test fixtures). The `tests/` directory exclusion is also explicit in `qlty-new-file-gate-helper.sh`.

Resolves #20371
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.92 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 15m and 42,608 tokens on this as a headless worker.