### PR TITLE
t2725: fix toast greeting update-check timeout (5s -> 15s)

### DIFF
--- a/.agents/plugins/opencode-aidevops/greeting.mjs
+++ b/.agents/plugins/opencode-aidevops/greeting.mjs
@@ -48,7 +48,13 @@ const FALLBACK_WINDOW_MS = 30000;
 
 /**
  * Run the update-check script and return its stdout (trimmed), or "" on failure.
- * Uses a short timeout — we never want a hung greeting to block plugin init.
+ *
+ * Timeout 15s (t2725): the script itself produces output in ~1-2s, but forks
+ * background children (provenance notify, deploy drift check) that inherit
+ * stdout. Node's execSync waits for all inherited FDs to close, so total
+ * observed wallclock is 5-8s on a typical macOS system. 15s gives headroom
+ * for slower hardware; a timeout just means no toasts this session — the
+ * handler is async, so nothing else blocks.
  *
  * @param {string} scriptsDir
  * @returns {string}
@@ -58,7 +64,7 @@ function runUpdateCheck(scriptsDir) {
   try {
     return execSync(`bash ${JSON.stringify(script)} --interactive`, {
       encoding: "utf-8",
-      timeout: 5000,
+      timeout: 15000,
       stdio: ["pipe", "pipe", "pipe"],
     }).trim();
   } catch (err) {


### PR DESCRIPTION
## Summary

Fixes the toast greeting timeout bug shipped in PR #20420 (t2724, Phase 1). Raises `execSync` timeout for the update-check script from 5000ms to 15000ms.

## Root cause

`aidevops-update-check.sh` completes its own work in 1-2 seconds but forks background children that inherit stdout:

- `aidevops-update-check.sh:759` — provenance notify
- `aidevops-update-check.sh:895` — deploy drift check

Node's `execSync` waits for all inherited file descriptors to close, not just the main script exit. Observed wallclock on macOS is consistently 5-8 seconds, so the 5-second cap fires before the script's stdout is returned. Toasts are silently dropped because `runUpdateCheck()` returns "" on timeout.

Standalone `bash aidevops-update-check.sh --interactive` completes in 1-2 seconds because a terminal doesn't wait on FDs the same way `execSync` does.

## Fix

```diff
-      timeout: 5000,
+      timeout: 15000,
```

Plus an expanded doc comment explaining the FD-inheritance behaviour so the next contributor doesn't re-discover it.

15 seconds gives headroom for slower hardware. The handler is async and the fallback path (`session.updated` within 30s of plugin init) is idempotent, so a timeout just means no toasts this session — nothing else blocks.

## Verification

End-to-end traced in the deployed plugin with file-based tracing at `~/.aidevops/logs/greeting-trace.log`:

```
handler-triggered mode=fallback type=session.updated elapsed_ms=1280
runGreeting-start
runUpdateCheck-output length=432
cacheGreeting-done
buildToasts-result count=4 info=2 success=1 warning=1 error=1
emitToast-start/ok x4  (all returned {data:true})
runGreeting-end
handler-completed
```

All four toasts emit and the SDK acknowledges each with `{data: true}`.

## Scope

- `.agents/plugins/opencode-aidevops/greeting.mjs` — one-line timeout change + doc comment

No other files touched. Diagnostic tracing in the deployed plugin will be cleaned up separately once the user visually confirms toasts render in a fresh TUI (or overwritten by the next `aidevops update` sync from main after this PR merges).

Fixes #20423

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.92 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-opus-4-7 spent 1h 24m and 164,875 tokens on this with the user in an interactive session.
