### PR TITLE
t2727: consolidate greeting toasts into single emit (opencode TUI shows only one)

### DIFF
--- a/.agents/plugins/opencode-aidevops/greeting.mjs
+++ b/.agents/plugins/opencode-aidevops/greeting.mjs
@@ -19,14 +19,20 @@
 // so non-Bash agents can read it without re-running the script (t2724 phase 2
 // template change points agents at this file).
 //
-// Toast grouping (single-pass, cheap):
-//   - info    : version + env lines                         (8s)
-//   - success : "Security: all protections active"          (5s)
-//   - warning : pulse-stalled / external contribution lines (15s)
-//   - error   : [SECURITY ADVISORY] lines                   (30s)
-//
-// If a category has no matching lines, no toast for it is emitted. A
-// user with a clean environment sees one info toast and one success toast.
+// Toast model (t2727 consolidation):
+//   OpenCode's TUI renders one toast at a time — each client.tui.showToast()
+//   call replaces the previous before the user can read it. So we classify
+//   lines into severity buckets (error, warning, info, success) but emit a
+//   SINGLE consolidated toast whose variant follows the highest severity
+//   present and whose message preserves severity ordering:
+//     error   (30s) : [SECURITY ADVISORY] / [ERROR] lines
+//     warning (15s) : pulse-stalled / external contribution / [WARN] lines
+//     info     (8s) : version + env lines
+//     success  (5s) : "Security: all protections active"
+//   A user with a clean environment sees one info/success-tinted toast with
+//   the version+env+security-active lines. With any advisory or warning, the
+//   variant escalates (error overrides warning, warning overrides info) and
+//   all lines remain visible in the body.
 //
 // Diagnostics: set AIDEVOPS_PLUGIN_DEBUG=1 to trace every handler invocation
 // and each toast emission (including failures). Without DEBUG the handler
@@ -137,51 +143,53 @@ function classifyLines(output) {
 }
 
 /**
- * Build toast bodies from classified lines, skipping empty categories.
+ * Consolidate classified lines into a single toast body.
+ *
+ * OpenCode's TUI renders one toast at a time — each new client.tui.showToast()
+ * call replaces the previous one before the user can read it (t2727, observed
+ * after PR #20424 deployed: end user saw only the final "success" toast of the
+ * original four-emit sequence). So we collapse the four-category Phase 1
+ * design into a single emit that preserves severity ordering in the message
+ * body.
+ *
+ * Variant follows the highest severity present (error > warning > info >
+ * success); duration follows the variant's existing mapping (30s/15s/8s/5s).
+ * Returns null when all buckets are empty so the caller can skip the emit.
  *
  * @param {{ info: string[], success: string[], warning: string[], error: string[] }} buckets
- * @returns {Array<{ title: string, message: string, variant: "info"|"success"|"warning"|"error", duration: number }>}
+ * @returns {{ title: string, message: string, variant: "info"|"success"|"warning"|"error", duration: number } | null}
  */
-function buildToasts(buckets) {
-  const toasts = [];
+function buildToast(buckets) {
+  const lines = [
+    ...buckets.error,
+    ...buckets.warning,
+    ...buckets.info,
+    ...buckets.success,
+  ];
 
+  if (lines.length === 0) return null;
+
+  let variant, duration;
   if (buckets.error.length > 0) {
-    toasts.push({
-      title: "aidevops — attention required",
-      message: buckets.error.join("\n"),
-      variant: "error",
-      duration: 30000,
-    });
+    variant = "error";
+    duration = 30000;
+  } else if (buckets.warning.length > 0) {
+    variant = "warning";
+    duration = 15000;
+  } else if (buckets.info.length > 0) {
+    variant = "info";
+    duration = 8000;
+  } else {
+    variant = "success";
+    duration = 5000;
   }
 
-  if (buckets.warning.length > 0) {
-    toasts.push({
-      title: "aidevops",
-      message: buckets.warning.join("\n"),
-      variant: "warning",
-      duration: 15000,
-    });
-  }
-
-  if (buckets.info.length > 0) {
-    toasts.push({
-      title: "aidevops",
-      message: buckets.info.join("\n"),
-      variant: "info",
-      duration: 8000,
-    });
-  }
-
-  if (buckets.success.length > 0) {
-    toasts.push({
-      title: "aidevops",
-      message: buckets.success.join("\n"),
-      variant: "success",
-      duration: 5000,
-    });
-  }
-
-  return toasts;
+  return {
+    title: "aidevops",
+    message: lines.join("\n"),
+    variant,
+    duration,
+  };
 }
 
 /**
@@ -223,17 +231,21 @@ async function runGreeting(scriptsDir, client) {
   cacheGreeting(output);
 
   const buckets = classifyLines(output);
-  const toasts = buildToasts(buckets);
+  const toast = buildToast(buckets);
 
   if (process.env.AIDEVOPS_PLUGIN_DEBUG) {
-    console.error(`[aidevops] greeting: built ${toasts.length} toasts (info=${buckets.info.length}, success=${buckets.success.length}, warning=${buckets.warning.length}, error=${buckets.error.length})`);
+    const bucketCounts = `info=${buckets.info.length}, success=${buckets.success.length}, warning=${buckets.warning.length}, error=${buckets.error.length}`;
+    if (toast) {
+      console.error(`[aidevops] greeting: built 1 toast (variant=${toast.variant}, ${bucketCounts})`);
+    } else {
+      console.error(`[aidevops] greeting: no lines to show (${bucketCounts})`);
+    }
   }
 
-  // Emit sequentially so the ordering (error → warning → info → success)
-  // is preserved in the TUI toast stack. Per-toast errors are swallowed
-  // so one bad emit doesn't prevent later ones.
-  for (const body of toasts) {
-    await emitToast(client, body);
+  // t2727: single emit. OpenCode's TUI replaces any existing toast on each
+  // showToast() call, so multiple emits race and only the last one is seen.
+  if (toast) {
+    await emitToast(client, toast);
   }
 }
 


### PR DESCRIPTION
## Summary

Consolidates the opencode greeting plugin's four-category toast sequence (error/warning/info/success) into a single `client.tui.showToast()` call. Follow-up to PR #20420 (t2724, Phase 1) and PR #20424 (t2725, timeout fix).

## Root cause

OpenCode's TUI renders one toast at a time. Each `client.tui.showToast()` call replaces the previous toast before the user can read it — the SDK's `TuiShowToastData` schema has no `id` field (`~/.config/opencode/node_modules/@opencode-ai/sdk/dist/gen/types.gen.d.ts:3261`), confirming per-call replacement.

End-user testing after PR #20424 deployed confirmed the failure mode: sending "hi" in a freshly-restarted opencode session surfaced exactly one toast (the terminal green `success` "Security: all protections active"). The three preceding toasts — `error` (SECURITY ADVISORY), `warning` (pulse stalled, external contribution count), `info` (version and environment) — emitted successfully at the SDK level (`{data: true}` acknowledged for all four in `~/.aidevops/logs/greeting-trace.log`) but were silently overwritten before being visible.

## Fix

Collapse `buildToasts()` (plural) into `buildToast()` (singular) that returns a single toast object — or `null` when all buckets are empty.

- **Classification unchanged**: `classifyLines()` still buckets into `error` / `warning` / `info` / `success`.
- **Variant**: highest severity present, priority `error > warning > info > success`.
- **Duration**: follows the variant's existing mapping (30s / 15s / 8s / 5s).
- **Message**: buckets concatenated in severity order so nothing the old four-toast design carried is dropped.
- **Title**: plain `"aidevops"` (severity is now conveyed by the toast color/variant alone — the per-variant "aidevops — attention required" string becomes redundant).
- **Call site**: `runGreeting()` emits at most once (or zero times if the result is `null`).

`+65 / -53` lines, one file touched.

## Verification

- `node --check .agents/plugins/opencode-aidevops/greeting.mjs` passes.
- End-to-end verification requires an opencode TUI restart after deploy — plugins load once per process, so in-flight TUIs continue running the pre-merge code until relaunch. Post-merge workflow: re-copy `greeting.mjs` from the tree to `~/.aidevops/agents/plugins/opencode-aidevops/`, update `~/.aidevops/.deployed-sha`, Cmd+Q and relaunch opencode.
- Expected: one toast whose variant color matches the highest severity present, containing all status lines the four-toast sequence would have shown.
- With `AIDEVOPS_PLUGIN_DEBUG=1`, `~/.aidevops/logs/greeting-trace.log` should log `emitToast-start/ok` once per session instead of four times.

## Scope

- `.agents/plugins/opencode-aidevops/greeting.mjs` — `buildToasts` → `buildToast` rename, single-toast assembly, doc comment updated to describe the single-slot TUI behaviour.

No other files touched. `index.mjs` continues to call `runGreeting()` as before (no wiring change needed).

## Deferred

- Per-session firing: `let fired = false` at `greeting.mjs:257` is module-level. OpenCode loads plugins once per process, so in long-lived TUIs new sessions never re-trigger the greeting. Known design gap; out of scope for this PR — will be filed as a follow-up once this consolidation is confirmed working.

Fixes #20431

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.92 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-opus-4-7 spent 2h and 233,903 tokens on this with the user in an interactive session.
