### PR TITLE
t2728: toast UX polish — strip runtime-identity, add aidevops contributions subcommand, backtick commands

### DIFF
--- a/.agents/plugins/opencode-aidevops/greeting.mjs
+++ b/.agents/plugins/opencode-aidevops/greeting.mjs
@@ -34,6 +34,11 @@
 //   variant escalates (error overrides warning, warning overrides info) and
 //   all lines remain visible in the body.
 //
+// Toast-only filters (t2728): lines matching `You are running in <app>.`
+// are filtered in classifyLines() so they don't enter any toast bucket.
+// The runtime-identity line is useful as session prose for the model but
+// would clutter the toast — the cache file still captures it verbatim.
+//
 // Diagnostics: set AIDEVOPS_PLUGIN_DEBUG=1 to trace every handler invocation
 // and each toast emission (including failures). Without DEBUG the handler
 // is silent on success — only actual errors reach stderr.
@@ -118,6 +123,15 @@ function classifyLines(output) {
     // Skip UPDATE_AVAILABLE| sentinel lines — those are machine-readable
     // markers consumed by the model greeting, not human banner text.
     if (line.startsWith("UPDATE_AVAILABLE|") || line === "AUTO_UPDATE_ENABLED") {
+      continue;
+    }
+
+    // Skip the runtime-identity line (t2728). "You are running in <app>.
+    // Global config: ..." is useful as session prose for the model but
+    // clutters the toast — the user already knows which app they launched.
+    // cacheGreeting(output) writes the raw output, so non-Bash agents still
+    // see the line via ~/.aidevops/cache/session-greeting.txt.
+    if (line.startsWith("You are running in ")) {
       continue;
     }
 

--- a/.agents/scripts/aidevops-update-check.sh
+++ b/.agents/scripts/aidevops-update-check.sh
@@ -346,7 +346,7 @@ _check_advisories() {
 		first_line=$(head -1 "$advisory_file" | sed 's/^[[:space:]]*//')
 		if [[ -n "$first_line" ]]; then
 			local entry
-			entry=$(printf '%s Run in your terminal: aidevops security | Dismiss: aidevops security dismiss %s' "$first_line" "$adv_id")
+			entry=$(printf "%s Run in your terminal: \`aidevops security\` | Dismiss: \`aidevops security dismiss %s\`" "$first_line" "$adv_id")
 			if [[ -n "$advisories_output" ]]; then
 				advisories_output=$(printf '%s\n%s' "$advisories_output" "$entry")
 			else
@@ -388,7 +388,7 @@ _check_contribution_watch() {
 	' "$cw_state" 2>/dev/null) || cw_count=0
 
 	if [[ "${cw_count:-0}" -gt 0 ]]; then
-		contribution_watch="${cw_count} external contribution(s) need your reply (run contribution-watch-helper.sh status to see them)."
+		contribution_watch="${cw_count} external contribution(s) need your reply (run \`aidevops contributions\` to see them)."
 	fi
 
 	echo "$contribution_watch"

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -1382,6 +1382,7 @@ _help_commands() {
 	echo "  opencode-sandbox   Test OpenCode versions in isolation (install/run/check/clean)"
 	echo "  approve <cmd>      Cryptographic issue/PR approval (setup/issue/pr/verify/status)"
 	echo "  security [cmd]     Full security assessment (posture + hygiene + supply chain)"
+	echo "  contributions      External contributions inbox (bare: status | seed/scan/stop/restart/install/uninstall)"
 	echo "  ip-check <cmd>     IP reputation checks (check/batch/report/providers)"
 	echo "  secret <cmd>       Manage secrets (set/list/run/init/import/status)"
 	echo "  config <cmd>       Feature toggles (list/get/set/reset/path/help)"
@@ -1750,6 +1751,12 @@ main() {
 	secret | secrets) _dispatch_helper "secret-helper.sh" "secret-helper.sh" "$@" ;;
 	approve) _dispatch_helper "approval-helper.sh" "approval-helper.sh" "$@" ;;
 	signing) _dispatch_helper "signing-setup.sh" "signing-setup.sh" "$@" ;;
+	contributions | contrib)
+		# Bare `aidevops contributions` defaults to status (most common use).
+		# Other subcommands (seed, scan, stop, restart, install, uninstall) forward verbatim.
+		[[ $# -eq 0 ]] && set -- status
+		_dispatch_helper "contribution-watch-helper.sh" "contribution-watch-helper.sh" "$@"
+		;;
 	stats | observability) _dispatch_helper "observability-helper.sh" "observability-helper.sh" "$@" ;;
 	tabby) _dispatch_helper "tabby-helper.sh" "tabby-helper.sh" "$@" ;;
 	init-routines) _dispatch_helper "init-routines-helper.sh" "init-routines-helper.sh" "$@" ;;


### PR DESCRIPTION
## Summary

Three UX polish items on the opencode greeting toast, surfaced by end-user review of the t2727 consolidated toast (PR #20432).

## Changes

1. **Strip runtime-identity line from the toast.** `greeting.mjs::classifyLines()` now skips lines starting with `You are running in ` so they never enter any toast bucket. The line remains in `~/.aidevops/cache/session-greeting.txt` (via `cacheGreeting(output)` which writes the raw output pre-filter) so non-Bash agents can still see it as session prose. Rationale: the user already knows which app they launched — it's noise at toast altitude but useful context in permanent session prose.

2. **Add `aidevops contributions` (alias `contrib`) subcommand.** New case arm in `aidevops.sh` dispatcher that defaults to `status` when called bare, and forwards all other subcommands (`seed`, `scan`, `stop`, `restart`, `install`, `uninstall`) via `_dispatch_helper` to `contribution-watch-helper.sh`. Mirrors the pattern used for `aidevops pulse`, `aidevops doctor`, `aidevops security`, etc. Also added a one-line help entry.

3. **Wrap commands in backticks in toast strings.** The advisory emit (`aidevops-update-check.sh:349`) and contribution-watch emit (`aidevops-update-check.sh:391`) both embed commands mid-sentence. Backticks make it obvious what's copy-pastable:

   - `` `aidevops security` `` and `` `aidevops security dismiss <id>` `` (advisory)
   - `` `aidevops contributions` `` (contribution-watch, also renamed from the helper path)

## Verification

- `shellcheck .agents/scripts/aidevops-update-check.sh aidevops.sh` — clean (exit 0).
- `node --check .agents/plugins/opencode-aidevops/greeting.mjs` — clean.
- `bash aidevops.sh contributions` — runs `contribution-watch-helper.sh status` as expected.
- `bash aidevops.sh contrib` — alias works.
- `bash aidevops.sh contributions help` — pass-through to helper's own help.
- `classifyLines()` smoke test confirmed: input containing the runtime-identity line produces buckets with that line absent from all four categories; the cache file still captures it.
- End-to-end confirmation requires opencode TUI restart after deploy. Expected post-deploy: toast no longer shows "You are running in OpenCode. Global config: ~/.config/opencode/opencode.json"; advisory and contribution lines show their commands in backticks; `aidevops contributions` referenced instead of `contribution-watch-helper.sh status`.

## Scope

- `.agents/plugins/opencode-aidevops/greeting.mjs` — classifier filter + doc comment
- `.agents/scripts/aidevops-update-check.sh` — two `printf` / assignment strings
- `aidevops.sh` — one case arm + one help line

+23 / −2 across three files. No other files touched.

## Deferred

- **Startup latency (observation, not this PR)**: the user noticed a longer delay between hitting enter on the first message and the session starting, since the toast-greeting work landed. Root cause is the `execSync` call in `greeting.mjs::runUpdateCheck()` — the update-check script itself returns in 1-2s but its background child processes keep stdout open for 5-8s, and `execSync` waits for all inherited FDs. Currently the handler is async but blocks on the sync `execSync`. A fix would make the update-check read non-blocking (fire-and-forget, then emit the toast when stdout flushes), letting session.created return immediately. Will be filed as a separate follow-up once this PR ships.

Fixes #20433

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.92 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-opus-4-7 spent 2h 34m and 276,973 tokens on this with the user in an interactive session.
