### PR TITLE
t2730: restore runtime-identity line in generated opencode AGENTS.md

### DIFF
--- a/.agents/scripts/generate-opencode-agents.sh
+++ b/.agents/scripts/generate-opencode-agents.sh
@@ -42,6 +42,8 @@ mkdir -p "$OPENCODE_AGENT_DIR"
 cat >"$OPENCODE_CONFIG_DIR/AGENTS.md" <<'EOF'
 Add ~/.aidevops/agents/AGENTS.md to context for AI DevOps capabilities.
 
+**Runtime**: You are running in OpenCode. Global config: `~/.config/opencode/opencode.json`.
+
 ## aidevops Framework Status
 
 The opencode-aidevops plugin renders session-start framework status (version, environment, security advisories, pulse health, contribution count) as TUI toasts at session creation via `client.tui.showToast()`. Raw output is cached at `~/.aidevops/cache/session-greeting.txt`.


### PR DESCRIPTION
## Summary

Restores the `**Runtime**: You are running in OpenCode. Global config: \`~/.config/opencode/opencode.json\`.` paragraph to the heredoc in `.agents/scripts/generate-opencode-agents.sh`, so the line lives in `~/.config/opencode/AGENTS.md` as permanent model-context prose.

## Why

- **t2724 Phase 2** (PR #20420) trimmed this line from the template on the assumption the toast would carry it.
- **t2728** (PR #20434) then removed it from the toast — correctly, since it's static runtime info, not session-state updates.
- **Result**: the line now lives only in `~/.aidevops/cache/session-greeting.txt`, which the model reads only when explicitly fetched. User confirmed directly: "i'm just not seeing this message, which we need back in the session context first response."

## Change

Two-line insertion at `generate-opencode-agents.sh:44` (inside the `<<'EOF' ... EOF` heredoc):

```diff
 cat >"$OPENCODE_CONFIG_DIR/AGENTS.md" <<'EOF'
 Add ~/.aidevops/agents/AGENTS.md to context for AI DevOps capabilities.

+**Runtime**: You are running in OpenCode. Global config: `~/.config/opencode/opencode.json`.
+
 ## aidevops Framework Status
```

## Verification

- `shellcheck .agents/scripts/generate-opencode-agents.sh` → zero violations.
- Heredoc extraction confirms expected output:

  ```
  Add ~/.aidevops/agents/AGENTS.md to context for AI DevOps capabilities.

  **Runtime**: You are running in OpenCode. Global config: `~/.config/opencode/opencode.json`.

  ## aidevops Framework Status
  ...
  ```

- Pre-commit ratchet + ShellCheck gates passed locally.

## Post-merge action

The deployed copy at `~/.aidevops/agents/scripts/generate-opencode-agents.sh` is re-applied by `aidevops update` (~10 min cycle). To see the line immediately in a fresh OpenCode session:

1. After merge, run `aidevops update` (or wait for auto-update).
2. `bash ~/.aidevops/agents/scripts/generate-opencode-agents.sh` to regenerate `~/.config/opencode/AGENTS.md`.
3. Restart OpenCode (Cmd+Q → relaunch) so the model re-reads AGENTS.md.

## Scope

One file, two lines inserted. No logic change, no behaviour shift beyond the templated AGENTS.md content.

Resolves #20437

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.93 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-opus-4-7 spent 2h 59m and 313,511 tokens on this with the user in an interactive session.
