### PR TITLE
t2731: unfilter runtime-identity line from opencode toast (revert t2728 filter)

### DIFF
--- a/.agents/plugins/opencode-aidevops/greeting.mjs
+++ b/.agents/plugins/opencode-aidevops/greeting.mjs
@@ -34,10 +34,12 @@
 //   variant escalates (error overrides warning, warning overrides info) and
 //   all lines remain visible in the body.
 //
-// Toast-only filters (t2728): lines matching `You are running in <app>.`
-// are filtered in classifyLines() so they don't enter any toast bucket.
-// The runtime-identity line is useful as session prose for the model but
-// would clutter the toast — the cache file still captures it verbatim.
+// Toast filters: UPDATE_AVAILABLE|<...> and AUTO_UPDATE_ENABLED are the
+// only lines suppressed — those are machine-readable sentinels. The
+// runtime-identity line (`You are running in <app>. Global config: ...`)
+// WAS suppressed from the toast by t2728 but restored by t2731 after
+// user feedback that seeing the config path at session start is valuable.
+// See also t2730 for the parallel AGENTS.md prose (model-only surface).
 //
 // Diagnostics: set AIDEVOPS_PLUGIN_DEBUG=1 to trace every handler invocation
 // and each toast emission (including failures). Without DEBUG the handler
@@ -123,15 +125,6 @@ function classifyLines(output) {
     // Skip UPDATE_AVAILABLE| sentinel lines — those are machine-readable
     // markers consumed by the model greeting, not human banner text.
     if (line.startsWith("UPDATE_AVAILABLE|") || line === "AUTO_UPDATE_ENABLED") {
-      continue;
-    }
-
-    // Skip the runtime-identity line (t2728). "You are running in <app>.
-    // Global config: ..." is useful as session prose for the model but
-    // clutters the toast — the user already knows which app they launched.
-    // cacheGreeting(output) writes the raw output, so non-Bash agents still
-    // see the line via ~/.aidevops/cache/session-greeting.txt.
-    if (line.startsWith("You are running in ")) {
       continue;
     }
 


### PR DESCRIPTION
## Summary

Reverts the t2728 toast filter that stripped `You are running in <app>. Global config: ...` from the opencode session-start toast. The line re-enters the `info` severity bucket and will appear in the consolidated toast body alongside the version/env/security-active lines.

## Why

- **t2728** (PR #20434) filtered this line on the premise "user already knows which app they launched; clutters toast."
- **t2730** (PR #20438) restored it as static prose in `~/.config/opencode/AGENTS.md` — but AGENTS.md is model-context (silent). The model reads it; the user doesn't SEE it unless the model explicitly outputs the text, which it doesn't during a typical greeting.
- **User feedback after t2730**: "tried that, still not seeing it" with a screenshot showing the model's first response is generic ("Hi! What would you like to work on?") and the toast has only the short-form environment line (`aidevops v3.8.93 running in OpenCode v1.14.20 | aidevops/main`) — not the long-form runtime-identity with config path.
- The toast is the only user-visible surface at session start. Reverting the filter is the minimal fix.

t2728's design rationale was incorrect for users who value seeing the config path. One added line does not meaningfully clutter a toast that already carries 5-6 lines in typical sessions.

## Change

Two edits in `.agents/plugins/opencode-aidevops/greeting.mjs`:

1. **Top-of-file comment block** (lines 37-40 → 37-42): updated to record the t2728 → t2731 history without leaving a stale rationale.
2. **`classifyLines()` filter** (lines 129-136): deleted the 8-line `if (line.startsWith("You are running in "))` guard and its preceding comment. Line now routes into the `info` bucket via the existing catch-all.

```diff
-    // Skip the runtime-identity line (t2728). "You are running in <app>.
-    // Global config: ..." is useful as session prose for the model but
-    // clutters the toast — the user already knows which app they launched.
-    // cacheGreeting(output) writes the raw output, so non-Bash agents still
-    // see the line via ~/.aidevops/cache/session-greeting.txt.
-    if (line.startsWith("You are running in ")) {
-      continue;
-    }
-
     // Order matters: errors first (most specific), then warnings, then
     // success, then info (catch-all for version/env lines).
```

Net diff: `1 file changed, 6 insertions(+), 13 deletions(-)`.

## Verification

```bash
# Only narrative comment reference remains (no filter guard):
grep -n "You are running in" .agents/plugins/opencode-aidevops/greeting.mjs
# → 39:// runtime-identity line (`You are running in <app>. Global config: ...`)

# Pre-commit/pre-push quality gates passed locally.
```

After merge + redeploy + OpenCode restart: toast body will include `You are running in OpenCode. Global config: ~/.config/opencode/opencode.json` as one of the info-bucket lines.

## Post-merge action

1. Wait ~10 min for `aidevops update` to redeploy `greeting.mjs` to `~/.aidevops/agents/plugins/opencode-aidevops/` — OR run `aidevops update` explicitly.
2. Restart OpenCode (Cmd+Q → relaunch) so the plugin reloads.
3. The next session's toast will include the runtime-identity line.

## Relationship to t2730

t2730's AGENTS.md prose remains untouched. It serves a different purpose — the model's static context for answering "what runtime am I in?" without needing to read the cache. Two surfaces, two audiences:

- **Toast** (user): Visible at session start via plugin (t2731).
- **AGENTS.md** (model): Context-only, answers identity questions silently (t2730).

Both are valid and complementary.

Resolves #20446

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.93 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-opus-4-7 spent 3h 20m and 345,685 tokens on this with the user in an interactive session.
