### PR TITLE
GH#20428: fix misleading coverage matrix comment in test-issue-sync-pull-seeds-orphans.sh

### DIFF
--- a/.agents/scripts/tests/test-issue-sync-pull-seeds-orphans.sh
+++ b/.agents/scripts/tests/test-issue-sync-pull-seeds-orphans.sh
@@ -14,7 +14,7 @@
 #   (b) closed orphan is NOT seeded (handled by caller; lib skips none)
 #   (c) duplicate-run is a no-op (idempotency)
 #   (d) malformed title (no tNNN: prefix) — no task_id → caller skips
-#   (e) parent-task label → #parent tag, no #auto-dispatch
+#   (e) parent-task label → #parent tag (auto-dispatch maps independently)
 #   (f) dry-run emits "would seed" to stderr, TODO.md unchanged
 #   (g) missing task ID → seeding skipped with log
 set -euo pipefail


### PR DESCRIPTION
## Summary

Fixes a misleading comment in the coverage matrix at the top of the test file.

Line 17 previously read:
```
#   (e) parent-task label → #parent tag, no #auto-dispatch
```

This is incorrect. Test case (e) uses both `parent-task` AND `auto-dispatch` labels together and explicitly verifies that `#auto-dispatch` IS present alongside `#parent` (line 168-169). The `no #auto-dispatch` claim was the misleading part surfaced in the Gemini review of PR #20354.

Updated to accurately describe the behaviour:
```
#   (e) parent-task label → #parent tag (auto-dispatch maps independently)
```

## Verification

All 20 tests pass:
```
Results: 20 passed, 0 failed
```

Resolves #20428


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.93 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 2m and 4,530 tokens on this as a headless worker.