### PR TITLE
t2733: t2733: add SonarCloud S1481/S1066/S100 config-level rule exclusions

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -7486,9 +7486,9 @@
       "pr": 16415
     },
     "TODO.md": {
-      "at": "2026-04-22T04:32:56Z",
-      "hash": "398be6cb70a0c2dea7749158e5ff98816d7d9233",
-      "passes": 84,
+      "at": "2026-04-22T06:37:24Z",
+      "hash": "ed1b95b6625698037e926368e9f56295c3b59c0d",
+      "passes": 85,
       "pr": 15490
     },
     "aidevops.sh": {
@@ -7717,6 +7717,36 @@
       "hash": "8cd1496ba47e9d9aab51c70d25d0c091fbb35c4d",
       "at": "2026-04-22T02:40:59Z",
       "pr": 20413,
+      "passes": 1
+    },
+    ".agents/reference/parent-task-lifecycle.md": {
+      "hash": "f5095e0fd1caf6155532b727c3be332b113bd788",
+      "at": "2026-04-22T06:37:24Z",
+      "pr": 20443,
+      "passes": 1
+    },
+    ".agents/reference/auto-merge.md": {
+      "hash": "b4a0af6b7514271a14a4d9317321642a5aa19b59",
+      "at": "2026-04-22T06:37:24Z",
+      "pr": 20442,
+      "passes": 1
+    },
+    ".agents/reference/auto-dispatch.md": {
+      "hash": "d88b930d7311719ebbfebe2618f73a72eae0b095",
+      "at": "2026-04-22T06:37:24Z",
+      "pr": 20441,
+      "passes": 1
+    },
+    ".agents/reference/repos-json-fields.md": {
+      "hash": "02db77702d36f50ef908d4c7856e46e510cfa875",
+      "at": "2026-04-22T06:37:24Z",
+      "pr": 20440,
+      "passes": 1
+    },
+    ".agents/reference/progressive-disclosure.md": {
+      "hash": "99f542cafff9f7f04688752a0dd142b0542ed0ad",
+      "at": "2026-04-22T06:37:24Z",
+      "pr": 20439,
       "passes": 1
     }
   },

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -41,7 +41,7 @@ sonar.cpd.exclusions=configs/**/*.txt,.agents/**/*.md,templates/**/*.md
 #
 # Individual file patterns were tried but 22 scripts don't match *-helper.sh/*-setup.sh/*-cli.sh
 # patterns. Maintaining per-file exclusions is unsustainable for a 70k+ line codebase.
-sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11,e12,e13,e14,e15,e16,e17
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6,e7,e8,e9,e10,e11,e12,e13,e14,e15,e16,e17,e18,e19,e20,e21,e22,e23
 
 # Ignore "npm install without --ignore-scripts" (shelldre:S6505) - all shell scripts
 # Required for CLI tool installation with native dependencies
@@ -95,8 +95,36 @@ sonar.issue.ignore.multicriteria.e6.resourceKey=**/*.sh
 sonar.issue.ignore.multicriteria.e7.ruleKey=shelldre:S1135
 sonar.issue.ignore.multicriteria.e7.resourceKey=**/*.sh
 
-# Note: S1481 (unused variables) and S1066 (collapsible ifs) are NOT excluded
-# These rules catch real issues and should be fixed in new code
+# S1481: Unused local variables - shell `set -e` safety pattern
+# `local var=$(cmd)` captures return code separately from value; variable IS used
+# via side effects or in subsequent conditional checks. SonarCloud's data-flow
+# analysis doesn't track shell variable usage across subshell boundaries.
+# Evidence: t2732 inventory classified 178/178 as false-positive.
+sonar.issue.ignore.multicriteria.e18.ruleKey=shelldre:S1481
+sonar.issue.ignore.multicriteria.e18.resourceKey=**/*.sh
+
+sonar.issue.ignore.multicriteria.e19.ruleKey=shell:S1481
+sonar.issue.ignore.multicriteria.e19.resourceKey=**/*.sh
+
+# S1066: Collapsible if statements - intentional guard/early-exit pattern
+# Nested ifs are kept for readability: outer block is a precondition guard,
+# inner block is the actual logic. Collapsing with && obscures the control flow.
+# Evidence: t2732 inventory classified 97/97 as false-positive or tactical-exemption.
+sonar.issue.ignore.multicriteria.e20.ruleKey=shelldre:S1066
+sonar.issue.ignore.multicriteria.e20.resourceKey=**/*.sh
+
+sonar.issue.ignore.multicriteria.e21.ruleKey=shell:S1066
+sonar.issue.ignore.multicriteria.e21.resourceKey=**/*.sh
+
+# S100: Function naming convention - framework uses snake_case by design
+# All shell functions follow snake_case and _leading_underscore convention.
+# camelCase would be inconsistent with 460+ existing scripts.
+# Evidence: t2732 inventory classified 18/18 as false-positive.
+sonar.issue.ignore.multicriteria.e22.ruleKey=shelldre:S100
+sonar.issue.ignore.multicriteria.e22.resourceKey=**/*.sh
+
+sonar.issue.ignore.multicriteria.e23.ruleKey=shell:S100
+sonar.issue.ignore.multicriteria.e23.resourceKey=**/*.sh
 
 # S131: Missing default case - Many case statements intentionally skip unknown options
 # The framework handles unknown commands at the main dispatch level


### PR DESCRIPTION
## Summary

Added config-level exclusions for three SonarCloud rules (S1481, S1066, S100) that generate ~293 false-positive findings on shell scripts. Both shelldre: and shell: prefixes covered (e18-e23). Each exclusion includes a rationale comment with evidence from the t2732 Phase 1 inventory.

## Files Changed

.agents/configs/simplification-state.json,sonar-project.properties

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** grep 'S1481\|S1066\|S100' sonar-project.properties confirms all 6 entries present. All three rules excluded with both shelldre: and shell: prefixes.

Resolves #20454


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.93 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 2m and 6,080 tokens on this as a headless worker.