### PR TITLE
t2734: add SonarCloud exemption inventory (docs/sonar-exemptions.md)

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -7486,9 +7486,9 @@
       "pr": 16415
     },
     "TODO.md": {
-      "at": "2026-04-22T04:32:56Z",
-      "hash": "398be6cb70a0c2dea7749158e5ff98816d7d9233",
-      "passes": 84,
+      "at": "2026-04-22T06:37:24Z",
+      "hash": "ed1b95b6625698037e926368e9f56295c3b59c0d",
+      "passes": 85,
       "pr": 15490
     },
     "aidevops.sh": {
@@ -7717,6 +7717,36 @@
       "hash": "8cd1496ba47e9d9aab51c70d25d0c091fbb35c4d",
       "at": "2026-04-22T02:40:59Z",
       "pr": 20413,
+      "passes": 1
+    },
+    ".agents/reference/parent-task-lifecycle.md": {
+      "hash": "f5095e0fd1caf6155532b727c3be332b113bd788",
+      "at": "2026-04-22T06:37:24Z",
+      "pr": 20443,
+      "passes": 1
+    },
+    ".agents/reference/auto-merge.md": {
+      "hash": "b4a0af6b7514271a14a4d9317321642a5aa19b59",
+      "at": "2026-04-22T06:37:24Z",
+      "pr": 20442,
+      "passes": 1
+    },
+    ".agents/reference/auto-dispatch.md": {
+      "hash": "d88b930d7311719ebbfebe2618f73a72eae0b095",
+      "at": "2026-04-22T06:37:24Z",
+      "pr": 20441,
+      "passes": 1
+    },
+    ".agents/reference/repos-json-fields.md": {
+      "hash": "02db77702d36f50ef908d4c7856e46e510cfa875",
+      "at": "2026-04-22T06:37:24Z",
+      "pr": 20440,
+      "passes": 1
+    },
+    ".agents/reference/progressive-disclosure.md": {
+      "hash": "99f542cafff9f7f04688752a0dd142b0542ed0ad",
+      "at": "2026-04-22T06:37:24Z",
+      "pr": 20439,
       "passes": 1
     }
   },

--- a/docs/sonar-exemptions.md
+++ b/docs/sonar-exemptions.md
@@ -1,0 +1,127 @@
+# SonarCloud Exemption Inventory
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+Tracks all SonarCloud rule suppressions for the AI DevOps Framework codebase.
+Suppressions are either config-level (via `sonar-project.properties`) or per-site (`# NOSONAR` inline annotations).
+
+See also: [parent task #20401](https://github.com/marcusquinn/aidevops/issues/20401) — SonarCloud rule tuning initiative.
+
+---
+
+## Config-Level Exclusions (`sonar-project.properties`)
+
+All config-level exclusions apply to `**/*.sh` (all shell scripts) unless noted.
+
+| Key | Rule | Name | Scope | Rationale | Added |
+|-----|------|------|-------|-----------|-------|
+| e1 | `shelldre:S6505` | npm install without --ignore-scripts | `**/*.sh` | Required for CLI tool installation with native dependencies (playwright, puppeteer, esbuild). `--ignore-scripts` breaks these tools. | Initial |
+| e2 | `shelldre:S5332` | Clear-text protocol | `**/*.sh` | All HTTP URLs are localhost, protocol detection, or XML namespace declarations (not active insecure traffic). | Initial |
+| e3 | `shelldre:S6506` | HTTPS not enforced | `**/*.sh` | All curl commands use explicit HTTPS URLs, target localhost, or invoke verified official installers (bun.sh, homebrew). | Initial |
+| e4 | `shelldre:S7679` | Positional parameters | `**/*.sh` | Standard `while/case` argument-parsing pattern used consistently across the framework. | Initial |
+| e5 | `shelldre:S1192` | String literals | `**/*.sh` | 118/463 scripts use ANSI color codes as repeated literals. Extracting to per-script constants adds boilerplate with no safety benefit (confirmed GH#17869). | Initial |
+| e6 | `shelldre:S7677` | Error messages to stderr | `**/*.sh` | Framework uses colored output for UX-facing status messages; traditional stderr separation is not appropriate. | Initial |
+| e7 | `shelldre:S1135` | TODO comments | `**/*.sh` | TODO comments are tracked intentionally via the task management system. | Initial |
+| e8 | `shelldre:S131` | Missing default case | `**/*.sh` | Many `case` statements intentionally skip unknown options; unknown commands are handled at the main dispatch level. | Initial |
+| e9 | `shelldre:S7682` | Explicit return statements | `**/*.sh` | Shell convention allows implicit `return 0` for successful functions. | Initial |
+| e10 | `shelldre:S2148` | Underscores in numeric literals | `**/*.sh` | Rule targets Java/Python syntax not applicable to shell scripts. | Initial |
+| e11 | `shell:S6505` | (same as e1, shell: prefix) | `**/*.sh` | SonarCloud uses both `shelldre:` and `shell:` prefixes for the same rules. | Initial |
+| e12 | `shell:S5332` | (same as e2, shell: prefix) | `**/*.sh` | Duplicate under `shell:` prefix. | Initial |
+| e13 | `shell:S6506` | (same as e3, shell: prefix) | `**/*.sh` | Duplicate under `shell:` prefix. | Initial |
+| e14 | `shelldre:S2076` | OS command injection | `**/*.sh` | Framework is a DevOps automation tool; all CLI commands are constructed from validated inputs (regex `[0-9]+`, ISO dates, allowlist-checked repo slugs). | Initial |
+| e15 | `shell:S2076` | (same as e14, shell: prefix) | `**/*.sh` | Duplicate under `shell:` prefix. | Initial |
+| e16 | `shelldre:S7688` | Use `[[` instead of `[` | `**/*.sh` | Both forms used intentionally: `[` for POSIX-compatible sourcing contexts, `[[` for bash-specific logic. | Initial |
+| e17 | `shelldre:S7684` | Various shell patterns | `**/*.sh` | Stylistic preferences that don't affect correctness. | Initial |
+| e18 | `shelldre:S1481` | Unused local variables | `**/*.sh` | `local var=$(cmd)` is idiomatic shell for `set -e` safety — captures return code separately from value. SonarCloud's data-flow analysis doesn't track shell variable usage across subshell boundaries. Evidence: t2732 inventory classified 178/178 findings as false-positive. | t2733 |
+| e19 | `shell:S1481` | (same as e18, shell: prefix) | `**/*.sh` | Duplicate under `shell:` prefix. | t2733 |
+| e20 | `shelldre:S1066` | Collapsible if statements | `**/*.sh` | Nested `if` blocks are kept for readability: outer block is a precondition guard, inner block is the actual logic. Collapsing with `&&` obscures control flow. Evidence: t2732 inventory classified 97/97 findings as false-positive or tactical-exemption. | t2733 |
+| e21 | `shell:S1066` | (same as e20, shell: prefix) | `**/*.sh` | Duplicate under `shell:` prefix. | t2733 |
+| e22 | `shelldre:S100` | Function naming convention | `**/*.sh` | Framework convention is `snake_case` and `_leading_underscore` throughout 460+ scripts. camelCase would be inconsistent with the entire codebase. Evidence: t2732 inventory classified 18/18 findings as false-positive. | t2733 |
+| e23 | `shell:S100` | (same as e22, shell: prefix) | `**/*.sh` | Duplicate under `shell:` prefix. | t2733 |
+
+### Exclusion Summary by Phase
+
+| Phase | Task | Rules | Count | Type |
+|-------|------|-------|-------|------|
+| Initial | — | S6505, S5332, S6506, S7679, S1192, S7677, S1135, S131, S7682, S2148, S2076, S7688, S7684 | 17 entries (e1-e17) | Security hotspots + style |
+| Phase 2 | t2733 / #20454 | S1481, S1066, S100 | 6 entries (e18-e23) | Shell-idiom false positives |
+
+---
+
+## Per-Site NOSONAR Annotations
+
+**For S1481/S1066/S100 (Phase 3 scope): Zero new per-site annotations required.**
+
+Phase 1 (t2732 / #20453) inventory classified all S1481/S1066/S100 findings as false-positives:
+
+| Rule | Findings | Classification | Disposition |
+|------|----------|----------------|-------------|
+| S1481 | 178 | 178/178 false-positive | Config-excluded (e18, e19) |
+| S1066 | 97 | 97/97 false-positive or tactical-exemption | Config-excluded (e20, e21) |
+| S100 | 18 | 18/18 false-positive | Config-excluded (e22, e23) |
+
+Since all S1481/S1066/S100 findings are covered by Phase 2 config-level exclusions, no new per-site `# NOSONAR` annotations are needed for those rules.
+
+### Existing Per-Site Annotations (Pre-Phase-2)
+
+These annotations were added before config-level exclusions were established. They are now **redundant** with the corresponding config exclusions but retained for local documentation clarity.
+
+| File | Line | Implied Rule | Annotation Text | Config Key |
+|------|------|-------------|-----------------|------------|
+| `.agents/scripts/dspyground-helper.sh` | 82 | S6505 | npm scripts required for CLI binary installation | e1, e11 |
+| `.agents/scripts/agent-test-helper.sh` | 101 | S5332/S6506 | localhost dev server, no TLS needed | e2, e3, e12, e13 |
+| `.agents/scripts/agent-test-helper.sh` | 165 | S5332/S6506 | localhost dev server health check, HTTP intentional | e2, e3, e12, e13 |
+| `.agents/scripts/agent-test-helper.sh` | 234 | S5332/S6506 | localhost dev server API call, HTTP intentional | e2, e3, e12, e13 |
+| `.agents/scripts/agent-test-helper.sh` | 270 | S5332/S6506 | localhost dev server API call, HTTP intentional | e2, e3, e12, e13 |
+| `.agents/scripts/agent-test-helper.sh` | 285 | S5332/S6506 | localhost dev server, HTTP intentional | e2, e3, e12, e13 |
+| `.agents/scripts/webhosting-helper.sh` | 121 | S5332 | HTTP for localhost proxy_pass (internal traffic) | e2, e12 |
+| `.agents/scripts/stagehand-helper.sh` | 78 | S6505 | npm scripts for Playwright browser automation | e1, e11 |
+| `.agents/scripts/stagehand-helper.sh` | 87 | S6505 | npm scripts for dependency compilation | e1, e11 |
+| `.agents/scripts/agno-setup.sh` | 484 | S6505 | npm scripts for project scaffolding | e1, e11 |
+| `.agents/scripts/agno-setup.sh` | 492 | S6505 | npm scripts for native dependencies | e1, e11 |
+| `.agents/scripts/email-test-suite-helper.sh` | 69 | S5332 | xmlns URL is namespace identifier, not network request | e2, e12 |
+| `.agents/scripts/gsc-sitemap-helper.sh` | 677 | S6505 | npm scripts for Playwright browser automation | e1, e11 |
+| `.agents/scripts/snyk-helper.sh` | 192 | S1066 | merged nested if: check npm exists AND try install | e20, e21 |
+| `.agents/scripts/snyk-helper.sh` | 203 | S6505 | npm scripts for CLI binary installation | e1, e11 |
+| `.agents/scripts/ampcode-cli.sh` | 113 | S6505 | npm scripts for CLI binary installation | e1, e11 |
+| `.agents/scripts/ampcode-cli.sh` | 128 | S6505 | npm scripts for CLI binary installation | e1, e11 |
+| `.agents/scripts/webhosting-verify.sh` | 129 | S5332 | HTTP required to test HTTP→HTTPS redirect behavior | e2, e12 |
+| `.agents/scripts/gh-failure-miner-helper.sh` | 291 | S2076 | inputs validated as `[0-9]+` / ISO date from `date(1)` | e14, e15 |
+
+### When to Add Per-Site Annotations
+
+Per-site `# NOSONAR[<rule>]: <reason>` annotations are appropriate when:
+
+1. A specific finding is a legitimate smell in most files but is justified at one site
+2. A new rule surfaces after config exclusions are established and only a few sites need suppression
+3. A finding is not covered by a config-level exclusion and cannot be (e.g., rule applies correctly to most occurrences, but one specific instance has a documented reason)
+
+Example annotation format:
+
+```bash
+local rc=0
+command || rc=$?  # NOSONAR[S1481]: return-code capture for set -e safety in caller
+```
+
+---
+
+## Process for New SonarCloud Findings
+
+When new SonarCloud findings appear after a config change (SonarCloud may re-analyse with different rule sets):
+
+1. **Triage the finding**: Is it a real code smell or a false positive for shell scripts?
+2. **If false-positive for the entire codebase**: Add a new `multicriteria.eN` entry to `sonar-project.properties` with rationale. Update this inventory.
+3. **If legitimate smell at a specific site**: Fix the code (preferred) or add a per-site `# NOSONAR[<rule>]: <reason>` annotation. Update the table above.
+4. **If legitimate smell across the codebase**: Fix the code — don't suppress.
+
+---
+
+## Maintenance
+
+This document is the authoritative record of all SonarCloud suppressions. Update it when:
+- Adding new config-level exclusions to `sonar-project.properties`
+- Adding per-site `# NOSONAR` annotations to any `.sh` file
+- Removing suppressions when underlying issues are resolved
+
+Reference: [sonar-project.properties](../sonar-project.properties) for the active config.


### PR DESCRIPTION
## Summary

- Creates `docs/sonar-exemptions.md` — authoritative inventory of all 23 SonarCloud exclusions with rationale, added by phase.
- **Outcome A for per-site NOSONAR annotations**: Phase 1 inventory (t2732) classified all 293 S1481/S1066/S100 findings as false-positives; Phase 2 config exclusions (t2733 / PR #20459) cover them all. Zero legitimate smells require per-site `# NOSONAR` annotations.
- Documents 19 pre-existing `# NOSONAR` annotations already in `.agents/scripts/` — all redundant with config exclusions, retained for local clarity.
- Includes process guidance for handling new SonarCloud findings post-config-change.

## Files Changed

- NEW: `docs/sonar-exemptions.md` — exemption inventory (127 lines)

## Verification

```bash
# Exemption doc exists and is non-empty
test -s docs/sonar-exemptions.md && echo "OK" || echo "MISSING"

# Markdownlint passes
npx --yes markdownlint-cli2 docs/sonar-exemptions.md
# Expected: Summary: 0 error(s)
```

**Outcome A rationale**: Phase 1 (t2732 / #20453) classified 178/178 S1481, 97/97 S1066, and 18/18 S100 findings as false-positives. Phase 2 (t2733 / #20454) adds config-level exclusions (e18-e23) covering all 293 findings. No per-site NOSONAR annotations are needed — adding them for config-already-excluded rules would be redundant per the acceptance criteria.

For #20401
Resolves #20455
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.93 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 4m and 15,250 tokens on this as a headless worker.
