### PR TITLE
GH#20463: widen _dps_consider_rebase conflict allowlist to match planning allowlist

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -7486,9 +7486,9 @@
       "pr": 16415
     },
     "TODO.md": {
-      "at": "2026-04-22T04:32:56Z",
-      "hash": "398be6cb70a0c2dea7749158e5ff98816d7d9233",
-      "passes": 84,
+      "at": "2026-04-22T06:37:24Z",
+      "hash": "ed1b95b6625698037e926368e9f56295c3b59c0d",
+      "passes": 85,
       "pr": 15490
     },
     "aidevops.sh": {
@@ -7717,6 +7717,36 @@
       "hash": "8cd1496ba47e9d9aab51c70d25d0c091fbb35c4d",
       "at": "2026-04-22T02:40:59Z",
       "pr": 20413,
+      "passes": 1
+    },
+    ".agents/reference/parent-task-lifecycle.md": {
+      "hash": "f5095e0fd1caf6155532b727c3be332b113bd788",
+      "at": "2026-04-22T06:37:24Z",
+      "pr": 20443,
+      "passes": 1
+    },
+    ".agents/reference/auto-merge.md": {
+      "hash": "b4a0af6b7514271a14a4d9317321642a5aa19b59",
+      "at": "2026-04-22T06:37:24Z",
+      "pr": 20442,
+      "passes": 1
+    },
+    ".agents/reference/auto-dispatch.md": {
+      "hash": "d88b930d7311719ebbfebe2618f73a72eae0b095",
+      "at": "2026-04-22T06:37:24Z",
+      "pr": 20441,
+      "passes": 1
+    },
+    ".agents/reference/repos-json-fields.md": {
+      "hash": "02db77702d36f50ef908d4c7856e46e510cfa875",
+      "at": "2026-04-22T06:37:24Z",
+      "pr": 20440,
+      "passes": 1
+    },
+    ".agents/reference/progressive-disclosure.md": {
+      "hash": "99f542cafff9f7f04688752a0dd142b0542ed0ad",
+      "at": "2026-04-22T06:37:24Z",
+      "pr": 20439,
       "passes": 1
     }
   },

--- a/.agents/scripts/pulse-dirty-pr-sweep.sh
+++ b/.agents/scripts/pulse-dirty-pr-sweep.sh
@@ -336,8 +336,10 @@ _dps_pr_body_has_issue_reference() {
 }
 
 # Decide whether a rebase path is structurally eligible (young + author-ok +
-# not parent-task). Output on stdout: "rebase|todo-only-conflict" if yes,
+# not parent-task). Output on stdout: "rebase|planning-only-conflict" if yes,
 # empty string if no. The caller uses a non-empty return to short-circuit.
+# Planning files (TODO.md, todo/**, README.md) match the headless planning
+# allowlist from pre-edit-check.sh:is_main_allowlisted_path.
 #
 # Args: $1=age $2=rebase_author_ok $3=has_parent_task $4=repo_path $5=head_ref
 _dps_consider_rebase() {
@@ -349,12 +351,12 @@ _dps_consider_rebase() {
 	[[ "$has_parent_task" -eq 0 ]] || return 0
 	[[ -n "$repo_path" && -d "$repo_path" ]] || return 0
 
-	local conflicts non_todo
+	local conflicts non_planning
 	conflicts=$(_dps_conflicting_files "$repo_path" "$head_ref" "origin/main" 2>/dev/null) || conflicts=""
 	[[ -n "$conflicts" ]] || return 0
-	non_todo=$(printf '%s\n' "$conflicts" | grep -vx 'TODO.md' | grep -v '^\s*$' || true)
-	if [[ -z "$non_todo" ]]; then
-		printf '%s|todo-only-conflict' "$_DIRTY_ACTION_REBASE"
+	non_planning=$(printf '%s\n' "$conflicts" | grep -vx 'TODO.md' | grep -v '^todo/' | grep -vx 'README.md' | grep -v '^\s*$' || true)
+	if [[ -z "$non_planning" ]]; then
+		printf '%s|planning-only-conflict' "$_DIRTY_ACTION_REBASE"
 	fi
 	return 0
 }


### PR DESCRIPTION
## Summary

Widen the conflict allowlist in `_dps_consider_rebase` to match the headless planning allowlist from `pre-edit-check.sh:is_main_allowlisted_path`.

Previously, only `TODO.md` was excluded from the conflict filter. PRs conflicting on `todo/**` or `README.md` fell through to the notify/close path instead of being auto-rebased.

## Changes

**File:** `.agents/scripts/pulse-dirty-pr-sweep.sh` (lines 338-362)

- Replace `grep -vx 'TODO.md'` filter with three-stage filter: `grep -vx 'TODO.md' | grep -v '^todo/' | grep -vx 'README.md'`
- Rename variable `non_todo` → `non_planning`
- Update reason tag `todo-only-conflict` → `planning-only-conflict`
- Update docstring to document the widened allowlist and reference `pre-edit-check.sh:is_main_allowlisted_path`

## Verification

ShellCheck clean (zero findings). All 4 acceptance criteria from issue satisfied:
1. `_dps_consider_rebase` now emits `rebase|planning-only-conflict` for PRs conflicting only on `TODO.md`, `todo/**`, or `README.md`
2. PRs with any non-planning conflict file are still rejected from the rebase path
3. ShellCheck clean
4. Variable name and reason tag updated for clarity

Resolves #20463
Ref #20361


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.93 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 1m and 3,738 tokens on this as a headless worker.