### PR TITLE
GH#20464: extend rebase age window for planning-only conflicts in dirty-pr-sweep

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -7486,9 +7486,9 @@
       "pr": 16415
     },
     "TODO.md": {
-      "at": "2026-04-22T04:32:56Z",
-      "hash": "398be6cb70a0c2dea7749158e5ff98816d7d9233",
-      "passes": 84,
+      "at": "2026-04-22T06:37:24Z",
+      "hash": "ed1b95b6625698037e926368e9f56295c3b59c0d",
+      "passes": 85,
       "pr": 15490
     },
     "aidevops.sh": {
@@ -7717,6 +7717,36 @@
       "hash": "8cd1496ba47e9d9aab51c70d25d0c091fbb35c4d",
       "at": "2026-04-22T02:40:59Z",
       "pr": 20413,
+      "passes": 1
+    },
+    ".agents/reference/parent-task-lifecycle.md": {
+      "hash": "f5095e0fd1caf6155532b727c3be332b113bd788",
+      "at": "2026-04-22T06:37:24Z",
+      "pr": 20443,
+      "passes": 1
+    },
+    ".agents/reference/auto-merge.md": {
+      "hash": "b4a0af6b7514271a14a4d9317321642a5aa19b59",
+      "at": "2026-04-22T06:37:24Z",
+      "pr": 20442,
+      "passes": 1
+    },
+    ".agents/reference/auto-dispatch.md": {
+      "hash": "d88b930d7311719ebbfebe2618f73a72eae0b095",
+      "at": "2026-04-22T06:37:24Z",
+      "pr": 20441,
+      "passes": 1
+    },
+    ".agents/reference/repos-json-fields.md": {
+      "hash": "02db77702d36f50ef908d4c7856e46e510cfa875",
+      "at": "2026-04-22T06:37:24Z",
+      "pr": 20440,
+      "passes": 1
+    },
+    ".agents/reference/progressive-disclosure.md": {
+      "hash": "99f542cafff9f7f04688752a0dd142b0542ed0ad",
+      "at": "2026-04-22T06:37:24Z",
+      "pr": 20439,
       "passes": 1
     }
   },

--- a/.agents/scripts/pulse-dirty-pr-sweep.sh
+++ b/.agents/scripts/pulse-dirty-pr-sweep.sh
@@ -71,9 +71,10 @@ DIRTY_PR_SWEEP_INTERVAL="${DIRTY_PR_SWEEP_INTERVAL:-1800}"       # 30 min
 DIRTY_PR_SWEEP_ACTION_COOLDOWN="${DIRTY_PR_SWEEP_ACTION_COOLDOWN:-1800}" # 30 min per-PR
 
 # Eligibility windows (seconds).
-DIRTY_PR_REBASE_MAX_AGE="${DIRTY_PR_REBASE_MAX_AGE:-172800}"     # 48h
-DIRTY_PR_CLOSE_MIN_AGE="${DIRTY_PR_CLOSE_MIN_AGE:-604800}"       # 7d
-DIRTY_PR_CLOSE_IDLE_HUMAN="${DIRTY_PR_CLOSE_IDLE_HUMAN:-259200}" # 3d since last human push
+DIRTY_PR_REBASE_MAX_AGE="${DIRTY_PR_REBASE_MAX_AGE:-172800}"                     # 48h — code conflicts
+DIRTY_PR_REBASE_PLANNING_MAX_AGE="${DIRTY_PR_REBASE_PLANNING_MAX_AGE:-604800}"   # 7d  — planning-only conflicts
+DIRTY_PR_CLOSE_MIN_AGE="${DIRTY_PR_CLOSE_MIN_AGE:-604800}"                       # 7d
+DIRTY_PR_CLOSE_IDLE_HUMAN="${DIRTY_PR_CLOSE_IDLE_HUMAN:-259200}"                 # 3d since last human push
 
 # Max PRs processed per sweep per repo (safety rail — a single run should
 # never thrash hundreds of PRs).
@@ -335,27 +336,44 @@ _dps_pr_body_has_issue_reference() {
 	return 1
 }
 
-# Decide whether a rebase path is structurally eligible (young + author-ok +
-# not parent-task). Output on stdout: "rebase|todo-only-conflict" if yes,
+# Decide whether a rebase path is structurally eligible (author-ok +
+# not parent-task + within age window for the conflict scope).
+# Output on stdout: "rebase|planning-only-conflict" if yes,
 # empty string if no. The caller uses a non-empty return to short-circuit.
+#
+# Two-tier age gate:
+#   planning-only conflicts (TODO.md, todo/**, README.md) → DIRTY_PR_REBASE_PLANNING_MAX_AGE (7d)
+#   non-planning conflicts                                 → DIRTY_PR_REBASE_MAX_AGE (48h) guard
 #
 # Args: $1=age $2=rebase_author_ok $3=has_parent_task $4=repo_path $5=head_ref
 _dps_consider_rebase() {
 	local age="$1" rebase_author_ok="$2" has_parent_task="$3"
 	local repo_path="$4" head_ref="$5"
 
-	[[ "$age" -lt "$DIRTY_PR_REBASE_MAX_AGE" ]] || return 0
+	# Author and label gates are age-independent — check them first.
 	[[ "$rebase_author_ok" -eq 1 ]] || return 0
 	[[ "$has_parent_task" -eq 0 ]] || return 0
 	[[ -n "$repo_path" && -d "$repo_path" ]] || return 0
 
-	local conflicts non_todo
+	local conflicts non_planning
 	conflicts=$(_dps_conflicting_files "$repo_path" "$head_ref" "origin/main" 2>/dev/null) || conflicts=""
 	[[ -n "$conflicts" ]] || return 0
-	non_todo=$(printf '%s\n' "$conflicts" | grep -vx 'TODO.md' | grep -v '^\s*$' || true)
-	if [[ -z "$non_todo" ]]; then
-		printf '%s|todo-only-conflict' "$_DIRTY_ACTION_REBASE"
+
+	# Strip planning-only files: TODO.md, todo/**, README.md.
+	non_planning=$(printf '%s\n' "$conflicts" \
+		| grep -vx 'TODO.md' \
+		| grep -v '^todo/' \
+		| grep -vx 'README.md' \
+		| grep -v '^\s*$' || true)
+
+	if [[ -z "$non_planning" ]]; then
+		# Planning-only conflict — use extended age window.
+		[[ "$age" -lt "$DIRTY_PR_REBASE_PLANNING_MAX_AGE" ]] || return 0
+		printf '%s|planning-only-conflict' "$_DIRTY_ACTION_REBASE"
 	fi
+	# Non-planning conflicts: currently no rebase path.
+	# Age guard kept here as a future extension point when mixed-conflict
+	# rebase is added: [[ "$age" -lt "$DIRTY_PR_REBASE_MAX_AGE" ]] || return 0
 	return 0
 }
 
@@ -877,12 +895,13 @@ Options:
 
 Environment:
   DRY_RUN=1                          Same as --dry-run.
-  DIRTY_PR_SWEEP_INTERVAL=1800       Outer cycle gate (seconds).
-  DIRTY_PR_SWEEP_ACTION_COOLDOWN=1800  Per-PR action cooldown (seconds).
-  DIRTY_PR_REBASE_MAX_AGE=172800     Rebase eligibility ceiling (seconds).
-  DIRTY_PR_CLOSE_MIN_AGE=604800      Close eligibility floor (seconds).
-  DIRTY_PR_CLOSE_IDLE_HUMAN=259200   Close idleness floor (seconds).
-  DIRTY_PR_SWEEP_BATCH_LIMIT=30      Max PRs per repo per run.
+  DIRTY_PR_SWEEP_INTERVAL=1800           Outer cycle gate (seconds).
+  DIRTY_PR_SWEEP_ACTION_COOLDOWN=1800    Per-PR action cooldown (seconds).
+  DIRTY_PR_REBASE_MAX_AGE=172800         Rebase ceiling for code conflicts (seconds, 48h).
+  DIRTY_PR_REBASE_PLANNING_MAX_AGE=604800  Rebase ceiling for planning-only conflicts (seconds, 7d).
+  DIRTY_PR_CLOSE_MIN_AGE=604800          Close eligibility floor (seconds).
+  DIRTY_PR_CLOSE_IDLE_HUMAN=259200       Close idleness floor (seconds).
+  DIRTY_PR_SWEEP_BATCH_LIMIT=30          Max PRs per repo per run.
 
 Examples:
   pulse-dirty-pr-sweep.sh --dry-run


### PR DESCRIPTION
## Summary

Extends the rebase age window in `_dps_consider_rebase` for planning-only conflicts from 48h to 7d (configurable via `DIRTY_PR_REBASE_PLANNING_MAX_AGE`). Code-conflict PRs retain the existing 48h ceiling.

## Changes

- **New env var**: `DIRTY_PR_REBASE_PLANNING_MAX_AGE` (default `604800` = 7 days) — applies only when all conflicting files are planning-only (TODO.md, `todo/**`, README.md)
- **Gate reorder**: author/label/repo gates now checked before conflict detection (age-independent first, cheaper checks first)
- **Widened allowlist**: `non_todo` renamed to `non_planning`; filter now strips `todo/**` and `README.md` in addition to `TODO.md` (incorporates sibling #20463 scope)
- **Reason string**: `todo-only-conflict` changed to `planning-only-conflict` (audit/log only, no logic impact)
- **Docs**: new env var added to the `Environment:` section of the help output

## Verification

- ShellCheck: zero violations
- A 3-day-old TODO-only DIRTY PR passes Gate 1 (age < 604800) instead of being rejected by the old 48h ceiling
- A 3-day-old code-conflict DIRTY PR still has no rebase path (non-planning branch emits nothing)

Resolves #20464


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.93 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 4m and 8,730 tokens on this as a headless worker.