### PR TITLE
t2736: trim OpenCode first-response greeting to concise one-line

### DIFF
--- a/.agents/scripts/generate-runtime-config.sh
+++ b/.agents/scripts/generate-runtime-config.sh
@@ -128,24 +128,45 @@ _generate_agents_opencode() {
 
 	mkdir -p "$opencode_agent_dir"
 
-	# Deploy AGENTS.md with version check
+	# Deploy AGENTS.md with concise greeting template (t2736)
+	# The opencode-aidevops plugin already renders full framework status as a
+	# session-start toast; the model must NOT re-run aidevops-update-check.sh
+	# or dump toast content into the chat. Greeting is a one-liner sourced
+	# from the pre-populated cache file.
 	cat >"$opencode_config_dir/AGENTS.md" <<'AGENTSEOF'
 Add ~/.aidevops/agents/AGENTS.md to context for AI DevOps capabilities.
 
+**Runtime**: You are running in OpenCode. Global config: `~/.config/opencode/opencode.json`.
+
 ## aidevops Framework Status
 
-**On interactive conversation start** (skip this section entirely for headless/command sessions like `/pulse`, `/full-loop`, etc.):
-1. If you have Bash tool: Run `bash ~/.aidevops/agents/scripts/aidevops-update-check.sh --interactive`
-2. If no Bash tool: Read `~/.aidevops/cache/session-greeting.txt` (cached by agents with Bash) and greet with: "Hi!\n\n{content of file}.\n\nWhat would you like to work on?". If the file doesn't exist, read `~/.aidevops/agents/VERSION` to get the `{version}` and greet with: "Hi!\n\nWe're running https://aidevops.sh v{version}.\n\nWhat would you like to work on?"
-3. Then respond to the user's actual message
+The opencode-aidevops plugin renders session-start framework status (versions,
+security posture, advisories, update hints) as a TUI toast before your first
+turn. Raw output is cached at `~/.aidevops/cache/session-greeting.txt`. The
+user has already seen it — do NOT re-run `aidevops-update-check.sh` and do
+NOT repeat toast content in the chat.
 
-If you ran the update check script (step 1) and the output starts with `UPDATE_AVAILABLE|` (e.g., `UPDATE_AVAILABLE|2.41.1|2.41.2|OpenCode`), inform user: "Update available (current → latest). Run `aidevops update` in a terminal session to update, or type `!aidevops update` below and hit Enter." If the output also contains a line `AUTO_UPDATE_ENABLED`, replace the manual update instruction with: "Auto-update is enabled and will apply this within ~10 minutes." This check does not apply when falling back to reading the cache or VERSION file (step 2).
+**On interactive conversation start** (skip for headless sessions like `/pulse`, `/full-loop`):
+
+1. Read line 1 of `~/.aidevops/cache/session-greeting.txt`. Format: `aidevops v{X} running in OpenCode v{Y} | ...`. Extract `{X}` and `{Y}`.
+2. Greet with exactly this template — no extra prose, no status dump:
+
+       Hi!
+
+       We're running aidevops v{X} in OpenCode v{Y}.
+
+       What would you like to work on?
+
+3. If the cache file is missing, read `~/.aidevops/agents/VERSION` for `{X}` and greet: "Hi!\n\nWe're running aidevops v{X}.\n\nWhat would you like to work on?"
+4. Then respond to the user's actual message.
+
+If the user later asks about aidevops updates, direct them to run `aidevops update` in a terminal session (or type `!aidevops update` below). Do not announce updates unprompted — the toast already did.
 
 ## Pre-Edit Git Check
 
 Only for agents with Edit/Write/Bash tools. See ~/.aidevops/agents/AGENTS.md for workflow.
 AGENTSEOF
-	print_success "Updated AGENTS.md with version check"
+	print_success "Updated AGENTS.md with concise greeting template (t2736)"
 
 	# Remove legacy agent files
 	local legacy_files=(

--- a/TODO.md
+++ b/TODO.md
@@ -2926,4 +2926,4 @@ t019.3.4,Update AGENTS.md with Beads integration docs,,beads,1h,45m,2025-12-21T1
 
 - [x] t2734 SonarCloud residual hits — per-site NOSONAR pragmas and exemption inventory #auto-dispatch #quality-debt #sonarcloud ref:GH#20455 pr:#20461 completed:2026-04-22
 
-- [ ] t2736 trim OpenCode first-response greeting to concise one-line #bug #framework ref:GH#20469
+- [ ] t2736 trim OpenCode first-response greeting to concise one-line #bug #framework #interactive ref:GH#20469

--- a/todo/tasks/t2736-brief.md
+++ b/todo/tasks/t2736-brief.md
@@ -1,0 +1,102 @@
+# t2736: trim OpenCode first-response greeting to concise one-line
+
+## Session Origin
+
+Interactive follow-up to t2724/t2728/t2730/t2731. User asked: stop the model from running `aidevops-update-check.sh` and dumping the output into chat at session start. The plugin already renders the full framework status as a TUI toast — the chat greeting should be a one-liner.
+
+## What
+
+Rewrite the OpenCode-runtime `AGENTS.md` heredoc inside the canonical runtime-config generator so that OpenCode sessions produce the exact greeting:
+
+```text
+Hi!
+
+We're running aidevops v{X} in OpenCode v{Y}.
+
+What would you like to work on?
+```
+
+No bash tool call at session start. No toast-content duplication in chat.
+
+## Why
+
+Current live `~/.config/opencode/AGENTS.md:1-12` instructs the model to `Run bash ~/.aidevops/agents/scripts/aidevops-update-check.sh --interactive`, then implicitly dumps the 8+ line output (security advisories, contribution counts, update hints, etc.) into the chat. This is redundant with the toast the `opencode-aidevops` plugin renders at `session-start` and wastes user attention plus tokens on every session start.
+
+t2730 targeted the deprecated `generate-opencode-agents.sh` fallback, not the canonical generator — so the fix never landed in live output. This PR targets the correct file.
+
+## How
+
+### Files to modify
+
+- EDIT: `.agents/scripts/generate-runtime-config.sh:132-147` — replace the `AGENTSEOF` heredoc body inside `_generate_agents_opencode()`.
+
+### Reference pattern
+
+- The cache file `~/.aidevops/cache/session-greeting.txt` line 1 is always `aidevops v{X} running in OpenCode v{Y} | {repo}/{branch}` — populated by the opencode-aidevops plugin at session start. Line 1 is the cheapest source for both versions in a single `Read` call.
+- The plugin's `greeting.mjs` already renders the full framework status (versions, runtime, security posture, advisories, update hints) as a TUI toast — see t2731 / PR #20447 for the un-filtered variant.
+- Fallback: `~/.aidevops/agents/VERSION` holds just the aidevops version if the cache is missing.
+
+### Proposed heredoc replacement
+
+```markdown
+Add ~/.aidevops/agents/AGENTS.md to context for AI DevOps capabilities.
+
+**Runtime**: You are running in OpenCode. Global config: `~/.config/opencode/opencode.json`.
+
+## aidevops Framework Status
+
+The opencode-aidevops plugin renders session-start framework status (versions,
+security posture, advisories, update hints) as a TUI toast before your first
+turn. Raw output is cached at `~/.aidevops/cache/session-greeting.txt`. The
+user has already seen it — do NOT re-run `aidevops-update-check.sh` and do
+NOT repeat toast content in the chat.
+
+**On interactive conversation start** (skip for headless sessions like `/pulse`, `/full-loop`):
+
+1. Read line 1 of `~/.aidevops/cache/session-greeting.txt`. Format: `aidevops v{X} running in OpenCode v{Y} | ...`. Extract `{X}` and `{Y}`.
+2. Greet with exactly:
+
+       Hi!
+
+       We're running aidevops v{X} in OpenCode v{Y}.
+
+       What would you like to work on?
+
+3. If the cache file is missing, read `~/.aidevops/agents/VERSION` for `{X}` and greet: "Hi!\n\nWe're running aidevops v{X}.\n\nWhat would you like to work on?"
+4. Then respond to the user's actual message.
+
+If the user asks about aidevops updates, direct them to run `aidevops update` in a terminal session (or `!aidevops update` in chat). Do not announce updates unprompted — the toast already did.
+
+## Pre-Edit Git Check
+
+Only for agents with Edit/Write/Bash tools. See ~/.aidevops/agents/AGENTS.md for workflow.
+```
+
+### Verification
+
+1. Edit the heredoc in `generate-runtime-config.sh`.
+2. Run `~/.aidevops/agents/scripts/generate-runtime-config.sh agents --runtime opencode` to regenerate.
+3. `diff` the resulting `~/.config/opencode/AGENTS.md` against the proposed content.
+4. Manual user verification: start a new OpenCode session, confirm greeting is exactly the one-liner and no bash tool call fires.
+
+### Files Scope
+
+- `.agents/scripts/generate-runtime-config.sh`
+- `todo/tasks/t2736-brief.md`
+
+## Acceptance Criteria
+
+- [ ] `.agents/scripts/generate-runtime-config.sh` heredoc produces the concise greeting template
+- [ ] Regenerated `~/.config/opencode/AGENTS.md` contains: (a) runtime-identity line, (b) explicit "do NOT re-run aidevops-update-check.sh" directive, (c) concise greeting template with `{X}` and `{Y}` placeholders sourced from cache file line 1
+- [ ] Regenerated file does NOT contain the string `Run bash ~/.aidevops/agents/scripts/aidevops-update-check.sh`
+- [ ] Manual next-session check: the model greets with exactly the one-line format and makes no bash tool call at session start
+
+## Tier
+
+`tier:standard` — single-file heredoc replacement with narrative verification. Sonnet-class.
+
+## Context
+
+- Parent arc: t2724 → t2725 → t2727 → t2728 → t2730 (deprecated-script edit, ineffective) → t2731 (toast fix) → **t2736 (this)**.
+- Canonical generator identified: `.agents/scripts/generate-runtime-config.sh`. The deprecated `generate-opencode-agents.sh` (line 5: `# DEPRECATED: Use generate-runtime-config.sh instead (t1665.4)`) is the fallback-only path my earlier t2730 edit targeted.
+- Related memory: `mem_20260422051733_5ab9dcc8` — AGENTS.md is model-visible, toast is user-visible; don't confuse them.


### PR DESCRIPTION
## Summary

Trim the OpenCode first-response greeting to a concise one-liner. Stop the model from re-running `aidevops-update-check.sh` and dumping toast content into chat at session start.

The `opencode-aidevops` plugin already renders the full framework status (versions, security posture, advisories, update hints) as a TUI toast before the first turn. The chat greeting now just reads the two versions from the pre-populated cache file and emits:

```text
Hi!

We're running aidevops v{X} in OpenCode v{Y}.

What would you like to work on?
```

No bash tool call. No status duplication.

## Why t2730 didn't land

`PR #20438 (t2730)` edited `.agents/scripts/generate-opencode-agents.sh` — which is DEPRECATED per its own header (`# DEPRECATED: Use generate-runtime-config.sh instead (t1665.4)`). The canonical generator is `generate-runtime-config.sh`. This PR targets the correct file.

## Changes

- `.agents/scripts/generate-runtime-config.sh:131-148` — replace the `AGENTSEOF` heredoc body in `_generate_agents_opencode()`:
  - Add explicit Runtime identity line (OpenCode + config path)
  - State that the plugin already ran the update check; do NOT re-run
  - Direct the model to read cache file line 1 for `{X}`/`{Y}` versions
  - Provide exact greeting template (no bash tool call at session start)
  - Collapse update-notification rules to a passive pointer
- `TODO.md` — add t2736 entry with `ref:GH#20469`
- `todo/tasks/t2736-brief.md` — full implementation brief for provenance

## Verification

1. `shellcheck .agents/scripts/generate-runtime-config.sh` — passes (0 findings)
2. After merge + `setup.sh --non-interactive` redeploys, `~/.config/opencode/AGENTS.md` will contain the new template.
3. Manual: restart OpenCode, confirm first-turn greeting matches exactly and no bash tool call fires.

Resolves #20469

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.93 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-opus-4-7 spent 13h 37m and 385,234 tokens on this with the user in an interactive session.
