### PR TITLE
t2738: extend _gh_auto_link_sub_issue to detect Parent: line at create-time

### DIFF
--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -548,19 +548,57 @@ gh_create_issue() {
 	return $rc
 }
 
+# Resolve a tNNN task ID to its GitHub issue number via title prefix search.
+# Used by both detection methods in _gh_auto_link_sub_issue. Echoes the issue
+# number on stdout, empty string if not found. Non-blocking.
+_gh_resolve_task_id_to_issue() {
+	local tid="$1"
+	local repo="$2"
+	[[ -z "$tid" || -z "$repo" ]] && return 0
+	gh issue list --repo "$repo" --state all \
+		--search "${tid}: in:title" --json number,title --limit 5 2>/dev/null |
+		jq -r --arg prefix "${tid}: " \
+			'.[] | select(.title | startswith($prefix)) | .number // ""' 2>/dev/null |
+		head -1
+	return 0
+}
+
+# Parse a `Parent:` line from an issue body and resolve to an issue number.
+# Accepts plain, bold-markdown (`**Parent:**`), and backtick-quoted variants.
+# Supports `#NNN`, `GH#NNN`, `tNNN` ref forms. `tNNN` resolves via
+# `_gh_resolve_task_id_to_issue`. Echoes the issue number on stdout, empty
+# string if no parent ref found. Non-blocking.
+_gh_parse_parent_from_body() {
+	local body="$1"
+	local repo="$2"
+	[[ -z "$body" ]] && return 0
+	local parent_ref
+	# shellcheck disable=SC2016  # sed pattern contains literal `*` and backticks
+	parent_ref=$(printf '%s\n' "$body" |
+		sed -nE 's/^[[:space:]]*\**Parent:\**[[:space:]]*`?(t[0-9]+|GH#[0-9]+|#[0-9]+)`?.*/\1/p' |
+		head -1 || true)
+	[[ -z "$parent_ref" ]] && return 0
+	if [[ "$parent_ref" =~ ^#([0-9]+)$ ]]; then
+		echo "${BASH_REMATCH[1]}"
+	elif [[ "$parent_ref" =~ ^GH#([0-9]+)$ ]]; then
+		echo "${BASH_REMATCH[1]}"
+	elif [[ "$parent_ref" =~ ^(t[0-9]+)$ ]]; then
+		_gh_resolve_task_id_to_issue "${BASH_REMATCH[1]}" "$repo"
+	fi
+	return 0
+}
+
 # GH#18735 + GH#20473 (t2738): auto-link newly created issues as sub-issues of
 # their parent at create-time. Two detection methods, in order of preference:
 #
-#   1. Dot-notation in title — `tNNN.M:` / `tNNN.M.K:` → parent is `tNNN` (or
-#      the dotted prefix one level up). Original behaviour.
+#   1. Dot-notation in title — `tNNN.M:` / `tNNN.M.K:` → parent is the dotted
+#      prefix one level up. Original behaviour.
 #
-#   2. `Parent:` line in body — plain, bold-markdown, or backtick-quoted:
-#        Parent: #500            → linked directly to #500
-#        Parent: GH#501          → linked directly to #501
-#        Parent: tNNN            → resolved via `gh issue list --search`
-#        **Parent:** `tNNN`      → bold-markdown + backtick variant
-#      Mirrors method 2 of `_detect_parent_from_gh_state` so the detection
-#      shape stays consistent across create-time and backfill-time paths.
+#   2. `Parent:` line in body — plain, bold-markdown, or backtick-quoted.
+#      Supports `#NNN`, `GH#NNN`, `tNNN` refs. Delegates parsing to
+#      `_gh_parse_parent_from_body`. Mirrors method 2 of
+#      `_detect_parent_from_gh_state` so the detection shape stays consistent
+#      across create-time and backfill-time paths.
 #
 # Non-blocking — every detection / resolution step returns silently on failure
 # so issue creation is never affected.
@@ -575,9 +613,10 @@ _gh_auto_link_sub_issue() {
 
 	# Extract --title, --repo, and --body (or --body-file) from the original args.
 	# Consolidated positional access: read $1/$2 into locals once at top of loop,
-	# then reference locals in case arms. Keeps ratchet happy and matches shell
-	# style guide ("local var=\"$1\" — never use $1 directly in function bodies").
-	local title="" repo="" body=""
+	# then reference locals in case arms. Matches shell style guide.
+	local title=""
+	local repo=""
+	local body=""
 	local _arg _next _bf
 	while [[ $# -gt 0 ]]; do
 		_arg="$1"
@@ -628,41 +667,17 @@ _gh_auto_link_sub_issue() {
 	local owner="${repo%%/*}" name="${repo##*/}"
 	local parent_num=""
 
-	# --- Method 1: dot-notation in title ---
+	# Method 1: dot-notation in title
 	if [[ "$title" =~ ^(t[0-9]+\.[0-9]+[a-z]?) ]]; then
-		local child_task_id="${BASH_REMATCH[1]}"
-		local parent_task_id="${child_task_id%.*}"
-		if [[ -n "$parent_task_id" && "$parent_task_id" != "$child_task_id" ]]; then
-			parent_num=$(gh issue list --repo "$repo" --state all \
-				--search "${parent_task_id}: in:title" --json number,title --limit 5 2>/dev/null |
-				jq -r --arg prefix "${parent_task_id}: " \
-					'.[] | select(.title | startswith($prefix)) | .number // ""' 2>/dev/null |
-				head -1)
+		local _cid="${BASH_REMATCH[1]}"
+		local _pid="${_cid%.*}"
+		if [[ -n "$_pid" && "$_pid" != "$_cid" ]]; then
+			parent_num=$(_gh_resolve_task_id_to_issue "$_pid" "$repo")
 		fi
 	fi
 
-	# --- Method 2: `Parent:` line in body (only if method 1 did not resolve) ---
-	if [[ -z "$parent_num" && -n "$body" ]]; then
-		local parent_ref
-		# shellcheck disable=SC2016  # sed pattern contains literal `*` and backticks
-		parent_ref=$(printf '%s\n' "$body" |
-			sed -nE 's/^[[:space:]]*\**Parent:\**[[:space:]]*`?(t[0-9]+|GH#[0-9]+|#[0-9]+)`?.*/\1/p' |
-			head -1 || true)
-		if [[ -n "$parent_ref" ]]; then
-			if [[ "$parent_ref" =~ ^#([0-9]+)$ ]]; then
-				parent_num="${BASH_REMATCH[1]}"
-			elif [[ "$parent_ref" =~ ^GH#([0-9]+)$ ]]; then
-				parent_num="${BASH_REMATCH[1]}"
-			elif [[ "$parent_ref" =~ ^(t[0-9]+)$ ]]; then
-				local _ptid="${BASH_REMATCH[1]}"
-				parent_num=$(gh issue list --repo "$repo" --state all \
-					--search "${_ptid}: in:title" --json number,title --limit 5 2>/dev/null |
-					jq -r --arg prefix "${_ptid}: " \
-						'.[] | select(.title | startswith($prefix)) | .number // ""' 2>/dev/null |
-					head -1)
-			fi
-		fi
-	fi
+	# Method 2: `Parent:` line in body (only if method 1 did not resolve)
+	[[ -z "$parent_num" ]] && parent_num=$(_gh_parse_parent_from_body "$body" "$repo")
 
 	[[ -z "$parent_num" ]] && return 0
 

--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -548,49 +548,75 @@ gh_create_issue() {
 	return $rc
 }
 
-# GH#18735: auto-link newly created issues as sub-issues of their parent
-# when the title matches tNNN.M (dot-notation subtask pattern).
-# Non-blocking — errors are silently ignored so issue creation is never affected.
+# GH#18735 + GH#20473 (t2738): auto-link newly created issues as sub-issues of
+# their parent at create-time. Two detection methods, in order of preference:
+#
+#   1. Dot-notation in title — `tNNN.M:` / `tNNN.M.K:` → parent is `tNNN` (or
+#      the dotted prefix one level up). Original behaviour.
+#
+#   2. `Parent:` line in body — plain, bold-markdown, or backtick-quoted:
+#        Parent: #500            → linked directly to #500
+#        Parent: GH#501          → linked directly to #501
+#        Parent: tNNN            → resolved via `gh issue list --search`
+#        **Parent:** `tNNN`      → bold-markdown + backtick variant
+#      Mirrors method 2 of `_detect_parent_from_gh_state` so the detection
+#      shape stays consistent across create-time and backfill-time paths.
+#
+# Non-blocking — every detection / resolution step returns silently on failure
+# so issue creation is never affected.
+#
 # Arguments:
 #   $1 - issue URL output from gh issue create
-#   $2... - original args passed to gh issue create (to extract --title and --repo)
+#   $2... - original args passed to gh issue create (to extract
+#           --title, --repo, --body, --body-file and their `=` variants)
 _gh_auto_link_sub_issue() {
 	local issue_url="$1"
 	shift
 
-	# Extract --title from the original args
-	local title="" repo=""
+	# Extract --title, --repo, and --body (or --body-file) from the original args.
+	# Consolidated positional access: read $1/$2 into locals once at top of loop,
+	# then reference locals in case arms. Keeps ratchet happy and matches shell
+	# style guide ("local var=\"$1\" — never use $1 directly in function bodies").
+	local title="" repo="" body=""
+	local _arg _next _bf
 	while [[ $# -gt 0 ]]; do
-		case "$1" in
+		_arg="$1"
+		_next="${2:-}"
+		shift
+		case "$_arg" in
 		--title)
-			title="${2:-}"
+			title="$_next"
 			shift
 			;;
-		--title=*) title="${1#--title=}" ;;
+		--title=*) title="${_arg#--title=}" ;;
 		--repo)
-			repo="${2:-}"
+			repo="$_next"
 			shift
 			;;
-		--repo=*) repo="${1#--repo=}" ;;
+		--repo=*) repo="${_arg#--repo=}" ;;
+		--body)
+			body="$_next"
+			shift
+			;;
+		--body=*) body="${_arg#--body=}" ;;
+		--body-file)
+			if [[ -n "$_next" && -r "$_next" ]]; then
+				body=$(<"$_next")
+			fi
+			shift
+			;;
+		--body-file=*)
+			_bf="${_arg#--body-file=}"
+			if [[ -n "$_bf" && -r "$_bf" ]]; then
+				body=$(<"$_bf")
+			fi
+			;;
 		*) ;;
 		esac
-		shift
 	done
 	[[ -z "$title" ]] && return 0
 
-	# Check if title starts with a dot-notation task ID (tNNN.M)
-	local child_task_id=""
-	if [[ "$title" =~ ^(t[0-9]+\.[0-9]+[a-z]?) ]]; then
-		child_task_id="${BASH_REMATCH[1]}"
-	else
-		return 0
-	fi
-
-	# Derive the parent task ID (strip last .segment)
-	local parent_task_id="${child_task_id%.*}"
-	[[ -z "$parent_task_id" || "$parent_task_id" == "$child_task_id" ]] && return 0
-
-	# Extract the child issue number from the URL
+	# Extract the child issue number from the URL — both detection methods need it.
 	local child_num
 	child_num=$(echo "$issue_url" | grep -oE '[0-9]+$' || echo "")
 	[[ -z "$child_num" ]] && return 0
@@ -600,14 +626,44 @@ _gh_auto_link_sub_issue() {
 	[[ -z "$repo" ]] && return 0
 
 	local owner="${repo%%/*}" name="${repo##*/}"
+	local parent_num=""
 
-	# Find the parent issue by searching for the task ID prefix in the title
-	local parent_num
-	parent_num=$(gh issue list --repo "$repo" --state all \
-		--search "${parent_task_id}: in:title" --json number,title --limit 5 2>/dev/null |
-		jq -r --arg prefix "${parent_task_id}: " \
-			'.[] | select(.title | startswith($prefix)) | .number // ""' 2>/dev/null |
-		head -1)
+	# --- Method 1: dot-notation in title ---
+	if [[ "$title" =~ ^(t[0-9]+\.[0-9]+[a-z]?) ]]; then
+		local child_task_id="${BASH_REMATCH[1]}"
+		local parent_task_id="${child_task_id%.*}"
+		if [[ -n "$parent_task_id" && "$parent_task_id" != "$child_task_id" ]]; then
+			parent_num=$(gh issue list --repo "$repo" --state all \
+				--search "${parent_task_id}: in:title" --json number,title --limit 5 2>/dev/null |
+				jq -r --arg prefix "${parent_task_id}: " \
+					'.[] | select(.title | startswith($prefix)) | .number // ""' 2>/dev/null |
+				head -1)
+		fi
+	fi
+
+	# --- Method 2: `Parent:` line in body (only if method 1 did not resolve) ---
+	if [[ -z "$parent_num" && -n "$body" ]]; then
+		local parent_ref
+		# shellcheck disable=SC2016  # sed pattern contains literal `*` and backticks
+		parent_ref=$(printf '%s\n' "$body" |
+			sed -nE 's/^[[:space:]]*\**Parent:\**[[:space:]]*`?(t[0-9]+|GH#[0-9]+|#[0-9]+)`?.*/\1/p' |
+			head -1 || true)
+		if [[ -n "$parent_ref" ]]; then
+			if [[ "$parent_ref" =~ ^#([0-9]+)$ ]]; then
+				parent_num="${BASH_REMATCH[1]}"
+			elif [[ "$parent_ref" =~ ^GH#([0-9]+)$ ]]; then
+				parent_num="${BASH_REMATCH[1]}"
+			elif [[ "$parent_ref" =~ ^(t[0-9]+)$ ]]; then
+				local _ptid="${BASH_REMATCH[1]}"
+				parent_num=$(gh issue list --repo "$repo" --state all \
+					--search "${_ptid}: in:title" --json number,title --limit 5 2>/dev/null |
+					jq -r --arg prefix "${_ptid}: " \
+						'.[] | select(.title | startswith($prefix)) | .number // ""' 2>/dev/null |
+					head -1)
+			fi
+		fi
+	fi
+
 	[[ -z "$parent_num" ]] && return 0
 
 	# Resolve both to node IDs and link

--- a/.agents/scripts/tests/test-gh-auto-link-parent-line.sh
+++ b/.agents/scripts/tests/test-gh-auto-link-parent-line.sh
@@ -1,0 +1,356 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-gh-auto-link-parent-line.sh — tests for t2738 (GH#20473)
+#
+# `_gh_auto_link_sub_issue` in `shared-gh-wrappers.sh` fires immediately after
+# `gh_create_issue` returns a new issue URL. It attempts to establish a
+# GitHub sub-issue relationship between the newly-created child and its
+# parent, using two detection methods:
+#
+#   Method 1 — dot-notation in title: `tNNN.M: foo` → parent `tNNN`,
+#              resolved via `gh issue list --search "tNNN: in:title"`.
+#
+#   Method 2 — `Parent:` line in body: `Parent: #NNN` / `Parent: GH#NNN` /
+#              `Parent: tNNN`, plus bold-markdown (`**Parent:**`) and
+#              backtick-quoted variants.
+#
+# Test coverage:
+#   1. Dot-notation title fires method 1 (regression — existing behaviour).
+#   2. `Parent: #500` in body fires method 2 with raw number.
+#   3. `Parent: GH#501` in body fires method 2 with raw number.
+#   4. `Parent: t1873` in body fires method 2, resolves via gh issue list.
+#   5. `**Parent:** \`t1873\`` (bold + backtick) resolves.
+#   6. `--body-file <path>` with `Parent: #502` inside fires method 2.
+#   7. No dot-notation and no `Parent:` line → no addSubIssue mutation.
+#   8. Dot-notation in title AND `Parent:` in body → method 1 wins.
+#
+# Strategy mirrors test-backfill-sub-issues.sh: stub `gh` on PATH, record all
+# `gh api graphql` calls to a log file, inspect the log after each scenario
+# to assert whether `addSubIssue` fired and with which parent.
+
+set -u
+
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_BLUE=$'\033[0;34m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_BLUE="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf '  %sPASS%s %s\n' "$TEST_GREEN" "$TEST_NC" "$1"
+	return 0
+}
+
+fail() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '  %sFAIL%s %s\n' "$TEST_RED" "$TEST_NC" "$1"
+	if [[ -n "${2:-}" ]]; then
+		printf '       %s\n' "$2"
+	fi
+	return 0
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)" || exit 1
+HELPER="${SCRIPTS_DIR}/shared-gh-wrappers.sh"
+CONSTANTS="${SCRIPTS_DIR}/shared-constants.sh"
+
+if [[ ! -f "$HELPER" ]]; then
+	printf 'test harness cannot find helper at %s\n' "$HELPER" >&2
+	exit 1
+fi
+
+TMP=$(mktemp -d -t t2738-auto-link.XXXXXX)
+trap 'rm -rf "$TMP"' EXIT
+
+# -----------------------------------------------------------------------------
+# Stubbed gh binary
+# -----------------------------------------------------------------------------
+# The stub records every invocation to $GH_LOG and emits canned responses:
+#   gh issue list --search "<prefix>: in:title" ...
+#                           → uses GH_LIST_<prefix-safe>_JSON env
+#   gh api graphql ... addSubIssue ...
+#                           → logs the full arg list, returns success payload
+#   gh api graphql ... issue(number ...
+#                           → returns a fake node ID string
+#   gh repo view ...        → returns "owner/repo"
+#   (anything else)         → exits 0 silently
+#
+# Dots in task IDs cannot appear in bash identifiers, so callers expose
+# fixtures under underscore-translated names (e.g. GH_LIST_t1873_JSON).
+
+GH_LOG="${TMP}/gh.log"
+export GH_LOG
+: >"$GH_LOG"
+
+mkdir -p "${TMP}/bin"
+cat >"${TMP}/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${GH_LOG:-/dev/null}"
+
+cmd1="${1:-}"
+cmd2="${2:-}"
+
+# gh repo view --json nameWithOwner -q .nameWithOwner
+if [[ "$cmd1" == "repo" && "$cmd2" == "view" ]]; then
+	printf '%s\n' "owner/repo"
+	exit 0
+fi
+
+# gh issue list --repo ... --search "<prefix>: in:title" ...
+# Extract the search value; convert dots to underscores for env-var lookup.
+if [[ "$cmd1" == "issue" && "$cmd2" == "list" ]]; then
+	prev=""
+	search_q=""
+	for arg in "$@"; do
+		if [[ "$prev" == "--search" ]]; then
+			search_q="$arg"
+		fi
+		prev="$arg"
+	done
+	# Strip " in:title" suffix and trailing colon: "t1873: in:title" → "t1873"
+	prefix="${search_q%%:*}"
+	prefix_safe="${prefix//./_}"
+	var="GH_LIST_${prefix_safe}_JSON"
+	payload="${!var:-[]}"
+	printf '%s\n' "$payload"
+	exit 0
+fi
+
+# gh api graphql -f query=... (node ID lookup or addSubIssue mutation)
+if [[ "$cmd1" == "api" && "$cmd2" == "graphql" ]]; then
+	for arg in "$@"; do
+		if [[ "$arg" == *"addSubIssue"* ]]; then
+			# Record the addSubIssue call explicitly so tests can assert on it.
+			printf 'ADDSUBISSUE: %s\n' "$*" >>"${GH_LOG:-/dev/null}"
+			printf '%s\n' '{"data":{"addSubIssue":{"issue":{"number":1}}}}'
+			exit 0
+		fi
+		if [[ "$arg" == *"issue(number"* ]]; then
+			# Emit a fake node ID string — the --jq filter will extract it as-is.
+			printf '%s\n' 'NODE_STUB_ID'
+			exit 0
+		fi
+	done
+	printf '%s\n' '{}'
+	exit 0
+fi
+
+# gh auth status and anything else
+exit 0
+STUB
+chmod +x "${TMP}/bin/gh"
+
+# Put the stub first on PATH, then source the helper.
+export PATH="${TMP}/bin:${PATH}"
+
+# shared-gh-wrappers.sh expects shared-constants.sh's print_* helpers in scope
+# when sourced (see dependency note in the file header). Source it first if
+# available, then the wrapper itself.
+if [[ -f "$CONSTANTS" ]]; then
+	# shellcheck source=../shared-constants.sh
+	source "$CONSTANTS" >/dev/null 2>&1 || true
+fi
+# shellcheck source=../shared-gh-wrappers.sh
+source "$HELPER" >/dev/null 2>&1 || true
+# Re-prepend in case the sourced files reset PATH
+export PATH="${TMP}/bin:${PATH}"
+
+# Fixture: parent t1873 lives at issue #100.
+# The stub returns this payload for `gh issue list --search "t1873: in:title"`.
+export GH_LIST_t1873_JSON='[{"number":100,"title":"t1873: parent task"}]'
+# Parent t2721 lives at #20402 — used to sanity-check the numeric path.
+export GH_LIST_t2721_JSON='[{"number":20402,"title":"t2721: parent auto-dispatch"}]'
+
+# Helper: clear the gh log before each scenario so per-test assertions are clean.
+reset_log() {
+	: >"$GH_LOG"
+	return 0
+}
+
+# Helper: inspect the log for an addSubIssue call. Returns 0 if found.
+saw_addsubissue() {
+	if grep -q '^ADDSUBISSUE:' "$GH_LOG"; then
+		return 0
+	fi
+	return 1
+}
+
+# Helper: extract the most recent addSubIssue call from the log. Not used for
+# strict parent-number assertion (we stub node IDs as a constant), but
+# included for future extension.
+last_addsubissue_args() {
+	grep '^ADDSUBISSUE:' "$GH_LOG" | tail -1
+	return 0
+}
+
+printf '%sRunning gh auto-link Parent: line tests (t2738)%s\n' "$TEST_BLUE" "$TEST_NC"
+
+# =============================================================================
+# Test 1 — dot-notation title fires method 1 (regression)
+# =============================================================================
+reset_log
+_gh_auto_link_sub_issue "https://github.com/owner/repo/issues/200" \
+	--repo "owner/repo" \
+	--title "t1873.2: child task"
+if saw_addsubissue; then
+	pass "dot-notation title fires addSubIssue (method 1, regression)"
+else
+	fail "dot-notation title fires addSubIssue (method 1, regression)" \
+		"no ADDSUBISSUE entry in gh log"
+fi
+
+# =============================================================================
+# Test 2 — Parent: #NNN in body fires method 2
+# =============================================================================
+reset_log
+_gh_auto_link_sub_issue "https://github.com/owner/repo/issues/301" \
+	--repo "owner/repo" \
+	--title "some plain title without dot-notation" \
+	--body "## Session Origin
+
+Follow-up work on the auto-dispatch inventory.
+
+Parent: #500
+
+## What
+..."
+if saw_addsubissue; then
+	pass "Parent: #NNN in body fires addSubIssue (method 2)"
+else
+	fail "Parent: #NNN in body fires addSubIssue (method 2)" \
+		"no ADDSUBISSUE entry in gh log"
+fi
+
+# =============================================================================
+# Test 3 — Parent: GH#NNN in body fires method 2
+# =============================================================================
+reset_log
+_gh_auto_link_sub_issue "https://github.com/owner/repo/issues/302" \
+	--repo "owner/repo" \
+	--title "some plain title" \
+	--body "Parent: GH#501"
+if saw_addsubissue; then
+	pass "Parent: GH#NNN in body fires addSubIssue"
+else
+	fail "Parent: GH#NNN in body fires addSubIssue" \
+		"no ADDSUBISSUE entry in gh log"
+fi
+
+# =============================================================================
+# Test 4 — Parent: tNNN in body resolves via gh issue list
+# =============================================================================
+reset_log
+_gh_auto_link_sub_issue "https://github.com/owner/repo/issues/303" \
+	--repo "owner/repo" \
+	--title "some plain title" \
+	--body "Parent: t1873"
+if saw_addsubissue && grep -q 'issue list.*--search t1873' "$GH_LOG"; then
+	pass "Parent: tNNN in body resolves via gh issue list + fires addSubIssue"
+else
+	fail "Parent: tNNN in body resolves via gh issue list + fires addSubIssue" \
+		"log missing expected search or addSubIssue entry:
+$(cat "$GH_LOG")"
+fi
+
+# =============================================================================
+# Test 5 — **Parent:** `tNNN` (bold-markdown + backtick) resolves
+# =============================================================================
+reset_log
+_gh_auto_link_sub_issue "https://github.com/owner/repo/issues/304" \
+	--repo "owner/repo" \
+	--title "some plain title" \
+	--body "**Parent:** \`t1873\`"
+if saw_addsubissue; then
+	pass "bold-markdown **Parent:** \`tNNN\` variant fires addSubIssue"
+else
+	fail "bold-markdown **Parent:** \`tNNN\` variant fires addSubIssue" \
+		"no ADDSUBISSUE entry in gh log"
+fi
+
+# =============================================================================
+# Test 6 — --body-file with Parent: inside fires method 2
+# =============================================================================
+reset_log
+BODY_FILE="${TMP}/body6.md"
+cat >"$BODY_FILE" <<'BODY'
+## Session Origin
+
+Some preamble.
+
+Parent: #502
+
+## What
+...
+BODY
+_gh_auto_link_sub_issue "https://github.com/owner/repo/issues/305" \
+	--repo "owner/repo" \
+	--title "some plain title" \
+	--body-file "$BODY_FILE"
+if saw_addsubissue; then
+	pass "--body-file with Parent: #NNN inside fires addSubIssue"
+else
+	fail "--body-file with Parent: #NNN inside fires addSubIssue" \
+		"no ADDSUBISSUE entry in gh log"
+fi
+
+# =============================================================================
+# Test 7 — no dot-notation, no Parent: → no mutation (negative)
+# =============================================================================
+reset_log
+_gh_auto_link_sub_issue "https://github.com/owner/repo/issues/306" \
+	--repo "owner/repo" \
+	--title "plain descriptive title" \
+	--body "This body has no parent declaration. It mentions #999 casually but not as Parent."
+if saw_addsubissue; then
+	fail "no parent signal produces no addSubIssue (negative test)" \
+		"unexpected ADDSUBISSUE entry: $(last_addsubissue_args)"
+else
+	pass "no parent signal produces no addSubIssue (negative test)"
+fi
+
+# =============================================================================
+# Test 8 — dot-notation in title AND Parent: in body → method 1 wins
+# =============================================================================
+# Method 1's gh issue list search would use "t2721: in:title" if the parent
+# resolution path executed — we assert that it did, and that the body's
+# Parent: line was not consulted (no second gh issue list for t1873).
+reset_log
+_gh_auto_link_sub_issue "https://github.com/owner/repo/issues/307" \
+	--repo "owner/repo" \
+	--title "t2721.1: phase one" \
+	--body "Parent: t1873"
+if saw_addsubissue; then
+	# Method 1 should have searched t2721; it should not have also searched t1873.
+	if grep -q 'issue list.*--search t2721' "$GH_LOG" &&
+		! grep -q 'issue list.*--search t1873' "$GH_LOG"; then
+		pass "dot-notation title wins over body Parent: (method 1 short-circuits)"
+	else
+		fail "dot-notation title wins over body Parent:" \
+			"unexpected search pattern in gh log:
+$(cat "$GH_LOG")"
+	fi
+else
+	fail "dot-notation title wins over body Parent:" \
+		"method 1 did not fire addSubIssue"
+fi
+
+# =============================================================================
+# Summary
+# =============================================================================
+printf '\n'
+printf '%sTests run: %d, failed: %d%s\n' "$TEST_BLUE" "$TESTS_RUN" "$TESTS_FAILED" "$TEST_NC"
+if [[ $TESTS_FAILED -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/todo/tasks/t2738-brief.md
+++ b/todo/tasks/t2738-brief.md
@@ -1,0 +1,73 @@
+# t2738 brief
+
+## Session Origin
+
+Follow-up from the t2721/t2722 auto-dispatch inventory session (parent #20402, Phase 1 PR #20415). While filing the Phase 1 child issue (#20410, t2722), the framework's create-time parent-child auto-linkage did not fire — the sub-issue graph between #20402 (parent) and #20410 (child) remained empty. Root cause: `_gh_auto_link_sub_issue` only matches dot-notation titles (`tNNN.M:`); non-dot-notation phase children are invisible to it. Backfill path (`_detect_parent_from_gh_state`) is richer but only runs periodically and silently skipped on the GraphQL rate-limit window active in that session.
+
+Four framework gaps were identified (A/B/C/D). This task implements Gap A — the highest-leverage of the four because it closes the linkage gap for every future issue without relying on backfill recovery.
+
+## What
+
+Extend `_gh_auto_link_sub_issue` in `.agents/scripts/shared-gh-wrappers.sh` so it detects a `Parent: <ref>` line in the child issue body at create-time. Supports three ref forms (`#NNN`, `GH#NNN`, `tNNN`) and three markup variants (plain, bold-markdown `**Parent:**`, backtick-quoted). Mirrors method 2 of the existing backfill-time `_detect_parent_from_gh_state` so the detection shape stays consistent across create-time and backfill-time paths.
+
+## Why
+
+Parent-child auto-linkage has two entry points in the framework:
+
+1. **Create-time** — `_gh_auto_link_sub_issue` (shared-gh-wrappers.sh), called by `gh_create_issue` immediately after a new issue is returned. Runs once per creation. Previously detected only dot-notation titles.
+2. **Backfill-time** — `_detect_parent_from_gh_state` (issue-sync-relationships.sh), called by `backfill-sub-issues`. Runs periodically. Detects dot-notation + `Parent:` line + `Blocked by:` + parent-task label.
+
+The create-time path is structurally narrower. Phase-style children with titles like `t2722: Phase 1 inventory` never get linked at creation. The backfill path recovers them — *unless* GraphQL budget is exhausted, in which case node-ID resolution silently fails (Gap B, separate issue). Net effect: sub-issue graph populated non-deterministically.
+
+Adding `Parent:` line detection at create-time makes the behaviour deterministic: any brief that declares `Parent: #NNN` gets linked immediately, no backfill dependency, no rate-limit window hole.
+
+## How
+
+### Files Scope
+
+- .agents/scripts/shared-gh-wrappers.sh
+- .agents/scripts/tests/test-gh-auto-link-parent-line.sh
+- todo/tasks/t2738-brief.md
+
+### Design
+
+- Refactor `_gh_auto_link_sub_issue` arg-parse loop to also capture `--body` / `--body=VAL` / `--body-file PATH` / `--body-file=PATH`. When `--body-file` is supplied, read the file (if readable) into the same `body` variable.
+- Move `child_num` extraction and repo resolution above the detection branches — both methods need them.
+- Restructure the body of the function:
+  - Method 1 (unchanged semantics): title dot-notation (`^tNNN.M[a-z]?`) → resolve parent via `gh issue list --search`.
+  - Method 2 (new): body `Parent: <ref>` line. Use the same sed pattern as `_detect_parent_from_gh_state` method 2. Resolve the ref to a parent issue number — `#NNN` / `GH#NNN` are direct, `tNNN` needs a `gh issue list --search` round-trip.
+  - Both converge on a single `parent_num` variable, then the existing GraphQL node-resolve + `addSubIssue` mutation block.
+- Non-blocking throughout. Any failure in detection or resolution returns 0 silently — issue creation never affected.
+- Bash 3.2 compat preserved (no associative arrays, no process substitution in the new paths).
+
+### Test Coverage
+
+New `test-gh-auto-link-parent-line.sh` following the stub pattern from `test-backfill-sub-issues.sh`:
+
+1. Title dot-notation fires method 1 (regression: existing behaviour).
+2. Body `Parent: #500` fires method 2 with raw number.
+3. Body `Parent: GH#501` fires method 2 with raw number.
+4. Body `Parent: t1873` fires method 2, resolves via `gh issue list`.
+5. Body `**Parent:** \`t1873\`` (bold-markdown + backtick) resolves.
+6. `--body-file` with a file containing `Parent: #502` fires method 2.
+7. Neither title dot-notation nor body `Parent:` line → no mutation (negative).
+8. Both title dot-notation AND body `Parent:` → title wins (method 1 short-circuits method 2).
+
+## Acceptance
+
+- `shellcheck .agents/scripts/shared-gh-wrappers.sh` exits 0.
+- `bash .agents/scripts/tests/test-gh-auto-link-parent-line.sh` exits 0 with all 8 tests passing.
+- `bash .agents/scripts/tests/test-backfill-sub-issues.sh` still exits 0 (no regression to backfill path).
+- Manual smoke test: create an issue with `--body "Parent: #20402"` and confirm the child appears in `gh api repos/marcusquinn/aidevops/issues/20402/sub_issues`.
+
+## Not In Scope
+
+- Narrative-prose detection (`Phase N of ... #NNNN`, `(child of tNNN)`, `Ref #NNNN` requiring parent-task label verification). Follow-up task — requires additional API call per creation and a false-positive mitigation design.
+- REST fallback for rate-limit-exhausted node-ID resolution. Separate issue (Gap B).
+- Post-merge sequential-phase filing automation. Separate issue (Gap C).
+- `aidevops parent-status <N>` CLI helper for inspecting decomposition state. Separate issue (Gap D).
+- Convention change to require `Parent:` lines in all phase-child briefs. This PR is necessary-but-not-sufficient for that convention — the detection must work before the convention can be relied on.
+
+## Tier
+
+`tier:standard` — narrative brief, ~60 LOC of bash inside one function, regression test mirrors an existing stub pattern, no novel architecture.


### PR DESCRIPTION
## Summary

Extends `_gh_auto_link_sub_issue` in `shared-gh-wrappers.sh` with a second detection method — `Parent: <ref>` line in the child issue body — so non-dot-notation phase children get linked to their parent at creation time. Closes Gap A of the four-gap parent-child relationship audit from the t2721 session.

Resolves #20473

## Background

Sub-issue linkage has two entry points in the framework:

| Path | Function | Trigger | Coverage before | Coverage after |
|---|---|---|---|---|
| Create-time | `_gh_auto_link_sub_issue` (shared-gh-wrappers.sh) | every `gh_create_issue` | dot-notation titles only | dot-notation + `Parent:` body line |
| Backfill-time | `_detect_parent_from_gh_state` (issue-sync-relationships.sh) | periodic `backfill-sub-issues` | dot-notation + `Parent:` + `Blocked by:` + label | unchanged |

Create-time was structurally narrower than backfill-time. When the t2721 parent (#20402) filed the t2722 child (#20410) in the 2026-04-22 session, the title was `t2722: ...` (not dot-notation), so create-time skipped. Backfill would have caught it — but GraphQL budget was exhausted, so node-ID resolution silently failed (Gap B, separate issue).

Net effect: parent-child sub-issue graph was populated non-deterministically depending on rate-limit windows. This PR makes it deterministic: any brief declaring `Parent: #NNN` gets linked immediately.

## Change Shape

- Arg-parse loop refactored to consolidate positional-param access into `_arg`/`_next` locals, matches the shell style guide. Net positional-param count: 5 → 2.
- Added capture for `--body` / `--body=VAL` / `--body-file PATH` / `--body-file=PATH`.
- Method 1 (dot-notation) restructured to set `parent_num` instead of short-circuiting return.
- Method 2 (new) uses the same sed pattern as `_detect_parent_from_gh_state` method 2. Accepts plain, bold-markdown, and backtick-quoted variants. Handles `#NNN`, `GH#NNN`, `tNNN` refs (`tNNN` resolves via `gh issue list --search`).
- Non-blocking throughout — every failure path returns 0 silently.

## Tests

8-scenario regression suite in `test-gh-auto-link-parent-line.sh`, stub pattern mirrors `test-backfill-sub-issues.sh`:

1. Dot-notation title fires method 1 (regression)
2. `Parent: #500` fires method 2
3. `Parent: GH#501` fires method 2
4. `Parent: t1873` resolves via gh issue list
5. Bold-markdown `**Parent:**` backtick variant
6. `--body-file <path>` with `Parent:` inside
7. No signals → no mutation (negative)
8. Dot-notation + `Parent:` → method 1 wins (precedence)

Result: 8/8 pass. Existing `test-backfill-sub-issues.sh`: 21/21 still pass (no regression).

## Acceptance

- [x] shellcheck: no new findings (4 pre-existing SC2016 infos on GraphQL query strings unchanged)
- [x] new test: 8/8 pass
- [x] adjacent test: 21/21 pass
- [x] positional-param ratchet: 5 → 2 (reduction)
- [x] return-statement ratchet: clean

## Not In Scope (follow-ups)

- **Gap B** — GraphQL rate-limit REST fallback for node-ID resolution (silent backfill failure). Separate issue.
- **Gap C** — Post-merge sequential-phase filing automation. Separate issue.
- **Gap D** — `aidevops parent-status <N>` CLI helper for decomposition inspection. Separate issue.
- Narrative-prose detection (`Phase N of ... #NNNN`, `(child of tNNN)`, `Ref #NNNN` + parent-task label). Further extension of Method 2 — follow-up.

## Session Origin

Follow-up from t2721/t2722 auto-dispatch inventory session. PR #20415 surfaced this gap.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.94 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 15h 54m and 314 tokens on this as a headless worker.
