### PR TITLE
t2743: fix shared-gh-wrappers REST fallback for zsh (drops labels+assignees silently)

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -80,6 +80,39 @@ _rest_fallback_append_sig() {
 }
 
 #######################################
+# _gh_split_csv: portable CSV tokeniser. Emits one token per line to stdout.
+#
+# Works in bash 3.2+, zsh 5+, and BusyBox ash — uses POSIX parameter
+# expansion only. Does NOT use:
+#   - `read -ra arr` (bash-only; zsh emits "bad option: -a")
+#   - `read -A arr` (zsh-only; bash emits "invalid option")
+#   - `mapfile`/`readarray` (bash 4.4+ only)
+#   - `${(f)var}` (zsh-only array expansion)
+#
+# Args: $1=csv_string $2=delimiter (default: comma)
+# Returns: 0 always
+#
+# Usage:
+#   while IFS= read -r _tok; do
+#       [[ -n "$_tok" ]] && arr+=("$_tok")
+#   done < <(_gh_split_csv "a,b,c")
+#######################################
+_gh_split_csv() {
+	local _str="$1"
+	local _delim="${2:-,}"
+	while [[ -n "$_str" ]]; do
+		if [[ "$_str" == *"$_delim"* ]]; then
+			printf '%s\n' "${_str%%"$_delim"*}"
+			_str="${_str#*"$_delim"}"
+		else
+			printf '%s\n' "$_str"
+			_str=""
+		fi
+	done
+	return 0
+}
+
+#######################################
 # Return 0 (true) when GraphQL rate limit remaining is <= threshold.
 # `gh api rate_limit` is a free endpoint (does not count against quotas).
 # Fail-safe: if the response is unparseable (network error, gh auth missing),
@@ -130,7 +163,6 @@ _gh_issue_create_rest() {
 	local has_body=0
 	local -a labels=()
 	local -a assignees=()
-	local -a _toks=()
 
 	while [[ $# -gt 0 ]]; do
 		local _arg="$1"
@@ -143,10 +175,10 @@ _gh_issue_create_rest() {
 		--body=*) body="${_arg#--body=}"; has_body=1; shift ;;
 		--body-file) body_file="${2:-}"; has_body=1; shift 2 ;;
 		--body-file=*) body_file="${_arg#--body-file=}"; has_body=1; shift ;;
-		--label) IFS=',' read -ra _toks <<<"${2:-}"; labels+=("${_toks[@]}"); shift 2 ;;
-		--label=*) IFS=',' read -ra _toks <<<"${_arg#--label=}"; labels+=("${_toks[@]}"); shift ;;
-		--assignee) IFS=',' read -ra _toks <<<"${2:-}"; assignees+=("${_toks[@]}"); shift 2 ;;
-		--assignee=*) IFS=',' read -ra _toks <<<"${_arg#--assignee=}"; assignees+=("${_toks[@]}"); shift ;;
+		--label) local _tok; while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_gh_split_csv "${2:-}"); shift 2 ;;
+		--label=*) local _tok; while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_gh_split_csv "${_arg#--label=}"); shift ;;
+		--assignee) local _tok; while IFS= read -r _tok; do [[ -n "$_tok" ]] && assignees+=("$_tok"); done < <(_gh_split_csv "${2:-}"); shift 2 ;;
+		--assignee=*) local _tok; while IFS= read -r _tok; do [[ -n "$_tok" ]] && assignees+=("$_tok"); done < <(_gh_split_csv "${_arg#--assignee=}"); shift ;;
 		--milestone) milestone="${2:-}"; shift 2 ;;
 		--milestone=*) milestone="${_arg#--milestone=}"; shift ;;
 		*) shift ;;
@@ -290,7 +322,7 @@ _gh_issue_edit_rest() {
 	local milestone=""
 	local state=""
 	local has_title=0 has_body=0 has_milestone=0 has_state=0
-	local -a add_labels=() rm_labels=() add_assignees=() rm_assignees=() _toks=()
+	local -a add_labels=() rm_labels=() add_assignees=() rm_assignees=()
 
 	local _first="${1:-}"
 	if [[ $# -gt 0 && "$_first" != --* ]]; then
@@ -309,14 +341,14 @@ _gh_issue_edit_rest() {
 		--body=*) body="${_arg#--body=}"; has_body=1; shift ;;
 		--body-file) body_file="${2:-}"; has_body=1; shift 2 ;;
 		--body-file=*) body_file="${_arg#--body-file=}"; has_body=1; shift ;;
-		--add-label) IFS=',' read -ra _toks <<<"${2:-}"; add_labels+=("${_toks[@]}"); shift 2 ;;
-		--add-label=*) IFS=',' read -ra _toks <<<"${_arg#--add-label=}"; add_labels+=("${_toks[@]}"); shift ;;
-		--remove-label) IFS=',' read -ra _toks <<<"${2:-}"; rm_labels+=("${_toks[@]}"); shift 2 ;;
-		--remove-label=*) IFS=',' read -ra _toks <<<"${_arg#--remove-label=}"; rm_labels+=("${_toks[@]}"); shift ;;
-		--add-assignee) IFS=',' read -ra _toks <<<"${2:-}"; add_assignees+=("${_toks[@]}"); shift 2 ;;
-		--add-assignee=*) IFS=',' read -ra _toks <<<"${_arg#--add-assignee=}"; add_assignees+=("${_toks[@]}"); shift ;;
-		--remove-assignee) IFS=',' read -ra _toks <<<"${2:-}"; rm_assignees+=("${_toks[@]}"); shift 2 ;;
-		--remove-assignee=*) IFS=',' read -ra _toks <<<"${_arg#--remove-assignee=}"; rm_assignees+=("${_toks[@]}"); shift ;;
+		--add-label) local _tok; while IFS= read -r _tok; do [[ -n "$_tok" ]] && add_labels+=("$_tok"); done < <(_gh_split_csv "${2:-}"); shift 2 ;;
+		--add-label=*) local _tok; while IFS= read -r _tok; do [[ -n "$_tok" ]] && add_labels+=("$_tok"); done < <(_gh_split_csv "${_arg#--add-label=}"); shift ;;
+		--remove-label) local _tok; while IFS= read -r _tok; do [[ -n "$_tok" ]] && rm_labels+=("$_tok"); done < <(_gh_split_csv "${2:-}"); shift 2 ;;
+		--remove-label=*) local _tok; while IFS= read -r _tok; do [[ -n "$_tok" ]] && rm_labels+=("$_tok"); done < <(_gh_split_csv "${_arg#--remove-label=}"); shift ;;
+		--add-assignee) local _tok; while IFS= read -r _tok; do [[ -n "$_tok" ]] && add_assignees+=("$_tok"); done < <(_gh_split_csv "${2:-}"); shift 2 ;;
+		--add-assignee=*) local _tok; while IFS= read -r _tok; do [[ -n "$_tok" ]] && add_assignees+=("$_tok"); done < <(_gh_split_csv "${_arg#--add-assignee=}"); shift ;;
+		--remove-assignee) local _tok; while IFS= read -r _tok; do [[ -n "$_tok" ]] && rm_assignees+=("$_tok"); done < <(_gh_split_csv "${2:-}"); shift 2 ;;
+		--remove-assignee=*) local _tok; while IFS= read -r _tok; do [[ -n "$_tok" ]] && rm_assignees+=("$_tok"); done < <(_gh_split_csv "${_arg#--remove-assignee=}"); shift ;;
 		--milestone) milestone="${2:-}"; has_milestone=1; shift 2 ;;
 		--milestone=*) milestone="${_arg#--milestone=}"; has_milestone=1; shift ;;
 		--state) state="${2:-}"; has_state=1; shift 2 ;;
@@ -509,7 +541,6 @@ _gh_pr_create_rest() {
 	local draft=0
 	local has_body=0
 	local -a labels=()
-	local -a _toks=()
 
 	while [[ $# -gt 0 ]]; do
 		local _arg="$1"
@@ -527,8 +558,8 @@ _gh_pr_create_rest() {
 		--body-file) body_file="${2:-}"; has_body=1; shift 2 ;;
 		--body-file=*) body_file="${_arg#--body-file=}"; has_body=1; shift ;;
 		--draft) draft=1; shift ;;
-		--label) IFS=',' read -ra _toks <<<"${2:-}"; labels+=("${_toks[@]}"); shift 2 ;;
-		--label=*) IFS=',' read -ra _toks <<<"${_arg#--label=}"; labels+=("${_toks[@]}"); shift ;;
+		--label) local _tok; while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_gh_split_csv "${2:-}"); shift 2 ;;
+		--label=*) local _tok; while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_gh_split_csv "${_arg#--label=}"); shift ;;
 		*) shift ;;
 		esac
 	done
@@ -681,7 +712,6 @@ _rest_issue_list() {
 	local jq_expr=""
 	local assignee=""
 	local -a labels=()
-	local -a _toks=()
 
 	while [[ $# -gt 0 ]]; do
 		local _arg="$1"
@@ -690,8 +720,8 @@ _rest_issue_list() {
 		--repo=*) repo="${_arg#--repo=}"; shift ;;
 		--state) state="${2:-}"; shift 2 ;;
 		--state=*) state="${_arg#--state=}"; shift ;;
-		--label) IFS=',' read -ra _toks <<<"${2:-}"; labels+=("${_toks[@]}"); shift 2 ;;
-		--label=*) IFS=',' read -ra _toks <<<"${_arg#--label=}"; labels+=("${_toks[@]}"); shift ;;
+		--label) local _tok; while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_gh_split_csv "${2:-}"); shift 2 ;;
+		--label=*) local _tok; while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_gh_split_csv "${_arg#--label=}"); shift ;;
 		--assignee) assignee="${2:-}"; shift 2 ;;
 		--assignee=*) assignee="${_arg#--assignee=}"; shift ;;
 		--limit) limit="${2:-}"; shift 2 ;;

--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -37,17 +37,38 @@
 [[ -n "${_SHARED_GH_WRAPPERS_LOADED:-}" ]] && return 0
 _SHARED_GH_WRAPPERS_LOADED=1
 
+# Minimal stub fallbacks for print_info / print_warning.
+# shared-constants.sh defines the real implementations; later sourcing
+# overrides these stubs transparently. Prevents 'command not found: print_info'
+# when shared-gh-wrappers.sh is sourced standalone from a zsh interactive
+# session that has not already sourced shared-constants.sh.
+# `command -v` works in bash 3.2+, zsh 5+, and BusyBox ash.
+if ! command -v print_info >/dev/null 2>&1; then
+	print_info() { printf '[INFO] %s\n' "$*" >&2; return 0; }
+fi
+if ! command -v print_warning >/dev/null 2>&1; then
+	print_warning() { printf '[WARN] %s\n' "$*" >&2; return 0; }
+fi
+
 # t2574: REST fallback for GraphQL-exhausted gh issue wrappers (GH#20243).
 # t2689: Extended to READ paths — _rest_issue_view, _rest_issue_list.
+# t2743: Fixed CSV tokenisation for zsh compat (replaced read -ra with _gh_split_csv).
 # Provides _gh_should_fallback_to_rest, _gh_issue_{create,comment,edit}_rest,
 # _gh_pr_create_rest, _rest_issue_view, _rest_issue_list.
+#
 # Resolve own directory cross-shell (bash + zsh).
-# Priority: (1) BASH_SOURCE[0] under bash; (2) _SC_SELF set by shared-constants.sh
-# before sourcing us — both bash and zsh populate it correctly via ${0:-}, and it
-# points to shared-constants.sh which lives in the same directory as the REST
-# fallback; (3) absent both, silently skip — the primary GraphQL path still works.
+# Priority: (1) BASH_SOURCE[0] under bash (or zsh with BASH_SOURCE emulation);
+#           (2) zsh: $0 is the sourced file path when `source /abs/path` is used
+#               (confirmed: $0 is set to the file path inside sourced files in zsh,
+#               unlike bash where $0 is the shell executable name);
+#           (3) _SC_SELF set by shared-constants.sh before sourcing us;
+#           (4) absent all three, silently skip — the primary GraphQL path still works.
 if [[ -n "${BASH_SOURCE[0]:-}" ]]; then
 	_SHARED_GH_WRAPPERS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)" || _SHARED_GH_WRAPPERS_DIR=""
+elif [[ -n "${ZSH_VERSION:-}" && -f "${0:-}" ]]; then
+	# zsh without BASH_SOURCE emulation: $0 is the sourced file path.
+	# Guard: -f ensures $0 is a real file (rules out '-zsh' interactive shell name).
+	_SHARED_GH_WRAPPERS_DIR="$(cd "$(dirname "$0")" 2>/dev/null && pwd)" || _SHARED_GH_WRAPPERS_DIR=""
 elif [[ -n "${_SC_SELF:-}" ]]; then
 	_SHARED_GH_WRAPPERS_DIR="${_SC_SELF%/*}"
 else

--- a/.agents/scripts/tests/test-gh-wrapper-shell-compat.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-shell-compat.sh
@@ -1,0 +1,302 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-gh-wrapper-shell-compat.sh — t2743 / GH#20480 regression guard.
+#
+# Asserts that shared-gh-wrappers-rest-fallback.sh correctly tokenises
+# CSV arguments (--label, --assignee, --add-label, etc.) under both
+# bash and zsh, and that shared-gh-wrappers.sh loads the REST fallback
+# helper without requiring _SHARED_GH_WRAPPERS_DIR or shared-constants.sh
+# to be pre-set.
+#
+# Root cause (t2743, 2026-04-22):
+#   `IFS=',' read -ra _toks <<<"$val"` is bash-only. In zsh, `read -a`
+#   is not recognised (zsh uses `read -A`) and the command fails with
+#   "bad option: -a", silently producing empty arrays. Issues created
+#   via _gh_issue_create_rest in zsh sessions received no labels and
+#   no assignees, breaking tier-routing, origin-detection, and
+#   auto-dispatch pipelines.
+#
+# Fix: replaced all 16 `read -ra` sites with a portable helper
+# `_gh_split_csv` that uses POSIX parameter expansion only.
+#
+# Test scenarios:
+#   1. _gh_split_csv: basic CSV split under bash
+#   2. _gh_split_csv: same split under zsh (skip if zsh unavailable)
+#   3. _gh_split_csv: single token (no delimiter) returns string unchanged
+#   4. _gh_split_csv: empty string returns nothing
+#   5. _gh_split_csv: trailing delimiter — raw output, caller skips empty
+#   6. Integration: _gh_issue_create_rest labels+assignees reach gh api
+#      payload under bash (via stubbed gh)
+#   7. Integration: same under zsh (skip if zsh unavailable)
+#   8. Load-order: sourcing shared-gh-wrappers.sh with no _SHARED_GH_WRAPPERS_DIR
+#      and no shared-constants.sh still defines _gh_should_fallback_to_rest
+#
+# macOS vs Linux:
+#   macOS: /bin/bash is 3.2; /bin/zsh is the default interactive shell.
+#   Linux: /bin/bash is 4+/5+; zsh may or may not be installed.
+#   Tests skip gracefully when zsh is absent — they are supplementary
+#   guards alongside the existing t2574 bash-only suite.
+#
+# CI matrix note:
+#   For zsh tests to run on Ubuntu CI, add `apt-get install -y zsh` to the
+#   test-setup step in ShellCheck (ubuntu-latest) workflow.
+
+set -uo pipefail
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR_TEST}/.." && pwd)" || exit 1
+
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_YELLOW=$'\033[1;33m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_YELLOW="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf '  %sPASS%s %s\n' "$TEST_GREEN" "$TEST_NC" "$1"
+	return 0
+}
+
+fail() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '  %sFAIL%s %s\n' "$TEST_RED" "$TEST_NC" "$1"
+	if [[ -n "${2:-}" ]]; then
+		printf '       %s\n' "$2"
+	fi
+	return 0
+}
+
+skip() {
+	printf '  %sSKIP%s %s (%s)\n' "$TEST_YELLOW" "$TEST_NC" "$1" "${2:-}"
+	return 0
+}
+
+FALLBACK_FILE="${SCRIPTS_DIR}/shared-gh-wrappers-rest-fallback.sh"
+WRAPPERS_FILE="${SCRIPTS_DIR}/shared-gh-wrappers.sh"
+
+if [[ ! -f "$FALLBACK_FILE" ]]; then
+	printf '%sFATAL%s shared-gh-wrappers-rest-fallback.sh not found at %s\n' \
+		"$TEST_RED" "$TEST_NC" "$FALLBACK_FILE"
+	exit 1
+fi
+
+# Source the fallback file under bash to load _gh_split_csv and helpers.
+# Stub out print_info / print_warning so sourcing is noise-free.
+print_info() { return 0; }
+print_warning() { return 0; }
+export -f print_info print_warning
+
+# shellcheck source=../shared-gh-wrappers-rest-fallback.sh
+source "$FALLBACK_FILE"
+
+printf '%sRunning gh-wrapper shell-compat tests (t2743 / GH#20480)%s\n' \
+	"$TEST_GREEN" "$TEST_NC"
+
+# =============================================================================
+# Test 1: _gh_split_csv basic CSV split under bash
+# =============================================================================
+out=$(_gh_split_csv "a,b,c" ",")
+expected=$(printf 'a\nb\nc')
+if [[ "$out" == "$expected" ]]; then
+	pass "1: _gh_split_csv splits 'a,b,c' into 3 tokens under bash"
+else
+	fail "1: _gh_split_csv splits 'a,b,c' into 3 tokens under bash" \
+		"expected: $(printf '%q' "$expected")  got: $(printf '%q' "$out")"
+fi
+
+# =============================================================================
+# Test 2: _gh_split_csv under zsh
+# =============================================================================
+if ! command -v zsh >/dev/null 2>&1; then
+	skip "2: _gh_split_csv splits correctly under zsh" "zsh not installed"
+else
+	zsh_out=$(zsh -c "
+source '${FALLBACK_FILE}'
+out=\$(_gh_split_csv 'a,b,c' ',')
+printf '%s' \"\$out\"
+" 2>&1)
+	zsh_expected=$(printf 'a\nb\nc')
+	if [[ "$zsh_out" == "$zsh_expected" ]]; then
+		pass "2: _gh_split_csv splits 'a,b,c' into 3 tokens under zsh"
+	else
+		fail "2: _gh_split_csv splits 'a,b,c' into 3 tokens under zsh" \
+			"expected: $(printf '%q' "$zsh_expected")  got: $(printf '%q' "$zsh_out")"
+	fi
+fi
+
+# =============================================================================
+# Test 3: _gh_split_csv single token (no delimiter) returns string unchanged
+# =============================================================================
+out=$(_gh_split_csv "solo" ",")
+if [[ "$out" == "solo" ]]; then
+	pass "3: _gh_split_csv returns single token unchanged when no delimiter present"
+else
+	fail "3: _gh_split_csv returns single token unchanged when no delimiter present" \
+		"expected 'solo' got: $(printf '%q' "$out")"
+fi
+
+# =============================================================================
+# Test 4: _gh_split_csv empty string returns nothing (no spurious empty line)
+# =============================================================================
+out=$(_gh_split_csv "" ",")
+if [[ -z "$out" ]]; then
+	pass "4: _gh_split_csv empty string returns empty output"
+else
+	fail "4: _gh_split_csv empty string returns empty output" \
+		"expected empty, got: $(printf '%q' "$out")"
+fi
+
+# =============================================================================
+# Test 5: _gh_split_csv trailing delimiter — function does NOT emit spurious
+# trailing empty token. The `while [[ -n "$_str" ]]` guard in _gh_split_csv
+# ensures the loop exits when _str becomes "" after the last delimited token,
+# so "a,b," produces exactly 2 lines ("a" and "b") — no empty trailing line.
+# The caller's `[[ -n "$_tok" ]]` guard remains a defensive safety measure
+# for callers that feed raw shell word-splitting output, not _gh_split_csv output.
+# =============================================================================
+out=$(_gh_split_csv "a,b," ",")
+line_count=$(printf '%s\n' "$out" | wc -l | tr -d ' ')
+if [[ "$line_count" == "2" ]]; then
+	pass "5: _gh_split_csv trailing delimiter produces 2 tokens (no spurious empty)"
+else
+	fail "5: _gh_split_csv trailing delimiter produces 2 tokens (no spurious empty)" \
+		"expected 2, got: $line_count  (raw output: $(printf '%q' "$out"))"
+fi
+
+# =============================================================================
+# Test 6: Integration — _gh_issue_create_rest labels+assignees reach gh api
+# under bash. Stub `gh` as a shell function; capture calls to a temp file.
+# =============================================================================
+TMP=$(mktemp -d -t t2743.XXXXXX)
+trap 'rm -rf "$TMP"' EXIT
+GH_CALLS="${TMP}/gh_calls.log"
+
+gh() {
+	printf '%s\n' "$*" >>"${GH_CALLS}"
+	if [[ "$1" == "api" && "$2" == "rate_limit" ]]; then
+		printf '5000\n'
+		return 0
+	fi
+	if [[ "$1" == "api" && "$2" == "-X" ]]; then
+		printf 'https://github.com/owner/repo/issues/9999\n'
+		return 0
+	fi
+	return 0
+}
+export -f gh
+
+: >"$GH_CALLS"
+_gh_issue_create_rest \
+	--repo "owner/repo" \
+	--title "t2743: shell compat test" \
+	--body "test body" \
+	--label "tier:standard,auto-dispatch,framework" \
+	--assignee "marcusquinn,otheruser" >/dev/null 2>&1 || true
+
+label_standard=$(grep -c 'labels\[\]=tier:standard' "$GH_CALLS" 2>/dev/null || printf '0')
+label_auto=$(grep -c 'labels\[\]=auto-dispatch' "$GH_CALLS" 2>/dev/null || printf '0')
+label_fw=$(grep -c 'labels\[\]=framework' "$GH_CALLS" 2>/dev/null || printf '0')
+assignee_main=$(grep -c 'assignees\[\]=marcusquinn' "$GH_CALLS" 2>/dev/null || printf '0')
+assignee_other=$(grep -c 'assignees\[\]=otheruser' "$GH_CALLS" 2>/dev/null || printf '0')
+
+if [[ "$label_standard" -ge 1 && "$label_auto" -ge 1 && "$label_fw" -ge 1 && \
+      "$assignee_main" -ge 1 && "$assignee_other" -ge 1 ]]; then
+	pass "6: _gh_issue_create_rest sends all labels and assignees to gh api under bash"
+else
+	fail "6: _gh_issue_create_rest sends all labels and assignees to gh api under bash" \
+		"GH_CALLS=$(cat "$GH_CALLS")"
+fi
+
+# =============================================================================
+# Test 7: Integration — same test under zsh
+# =============================================================================
+if ! command -v zsh >/dev/null 2>&1; then
+	skip "7: _gh_issue_create_rest labels+assignees under zsh" "zsh not installed"
+else
+	ZSH_CALLS="${TMP}/zsh_calls.log"
+	: >"$ZSH_CALLS"
+
+	zsh -c "
+print_info() { return 0; }
+print_warning() { return 0; }
+gh() {
+    printf '%s\n' \"\$*\" >>\"${ZSH_CALLS}\"
+    if [[ \"\$1\" == 'api' && \"\$2\" == '-X' ]]; then
+        printf 'https://github.com/owner/repo/issues/9999\n'
+        return 0
+    fi
+    return 0
+}
+source '${FALLBACK_FILE}'
+_gh_issue_create_rest \
+    --repo 'owner/repo' \
+    --title 't2743: zsh compat test' \
+    --body 'zsh body' \
+    --label 'tier:standard,auto-dispatch,framework' \
+    --assignee 'marcusquinn,otheruser' >/dev/null 2>&1 || true
+" 2>&1 || true
+
+	zsh_label_standard=$(grep -c 'labels\[\]=tier:standard' "$ZSH_CALLS" 2>/dev/null || printf '0')
+	zsh_label_auto=$(grep -c 'labels\[\]=auto-dispatch' "$ZSH_CALLS" 2>/dev/null || printf '0')
+	zsh_label_fw=$(grep -c 'labels\[\]=framework' "$ZSH_CALLS" 2>/dev/null || printf '0')
+	zsh_assignee_main=$(grep -c 'assignees\[\]=marcusquinn' "$ZSH_CALLS" 2>/dev/null || printf '0')
+	zsh_assignee_other=$(grep -c 'assignees\[\]=otheruser' "$ZSH_CALLS" 2>/dev/null || printf '0')
+
+	if [[ "$zsh_label_standard" -ge 1 && "$zsh_label_auto" -ge 1 && "$zsh_label_fw" -ge 1 && \
+	      "$zsh_assignee_main" -ge 1 && "$zsh_assignee_other" -ge 1 ]]; then
+		pass "7: _gh_issue_create_rest sends all labels and assignees under zsh"
+	else
+		fail "7: _gh_issue_create_rest sends all labels and assignees under zsh" \
+			"ZSH_CALLS=$(cat "$ZSH_CALLS")"
+	fi
+fi
+
+# =============================================================================
+# Test 8: Load-order — sourcing shared-gh-wrappers.sh with no
+# _SHARED_GH_WRAPPERS_DIR and no shared-constants.sh defines the REST helpers.
+# Verifies Bug 2a fix: _SHARED_GH_WRAPPERS_DIR is derived from BASH_SOURCE[0]
+# (or $0 in zsh) rather than requiring the caller to pre-set it.
+# =============================================================================
+bash_out=$(
+	/bin/bash -c "
+unset _SHARED_GH_WRAPPERS_DIR 2>/dev/null || true
+unset _SC_SELF 2>/dev/null || true
+# No shared-constants.sh sourced — test that stubs prevent command-not-found.
+source '${WRAPPERS_FILE}' 2>/dev/null
+if declare -F _gh_should_fallback_to_rest >/dev/null 2>&1 && \
+   declare -F _gh_issue_create_rest >/dev/null 2>&1 && \
+   declare -F _gh_pr_create_rest >/dev/null 2>&1; then
+    printf 'OK\n'
+else
+    printf 'MISSING\n'
+fi
+" 2>&1
+)
+if [[ "$bash_out" == *"OK"* ]]; then
+	pass "8: sourcing shared-gh-wrappers.sh alone (no _SHARED_GH_WRAPPERS_DIR) defines REST helpers under bash"
+else
+	fail "8: sourcing shared-gh-wrappers.sh alone (no _SHARED_GH_WRAPPERS_DIR) defines REST helpers under bash" \
+		"output: $(printf '%q' "$bash_out")"
+fi
+
+# =============================================================================
+# Summary
+# =============================================================================
+printf '\n'
+if [[ $TESTS_FAILED -eq 0 ]]; then
+	printf '%s%d/%d tests passed%s\n' "$TEST_GREEN" "$TESTS_RUN" "$TESTS_RUN" "$TEST_NC"
+	exit 0
+else
+	printf '%s%d/%d tests failed%s\n' "$TEST_RED" "$TESTS_FAILED" "$TESTS_RUN" "$TEST_NC"
+	exit 1
+fi


### PR DESCRIPTION
## Summary

Fixes a silent data loss bug in the REST fallback path of `shared-gh-wrappers-rest-fallback.sh` that caused `--label` and `--assignee` values to be silently dropped when the wrappers were invoked from a zsh interactive session under GraphQL exhaustion.

Root cause: `IFS=',' read -ra _toks <<<"$val"` is bash-only. In zsh, `read -a` is not recognised (zsh uses `read -A`) and fails with `bad option: -a`, producing empty arrays. The REST fallback was introduced in t2574 and tested only under bash.

## Changes

### `.agents/scripts/shared-gh-wrappers-rest-fallback.sh`
- Added `_gh_split_csv` — portable CSV tokeniser using POSIX parameter expansion only (bash 3.2+, zsh 5+, BusyBox ash compatible)
- Replaced all 16 `IFS=',' read -ra _toks <<<"$val"` occurrences with `while IFS= read -r _tok; do ... done < <(_gh_split_csv "$val")` pattern in `_gh_issue_create_rest`, `_gh_issue_edit_rest`, `_gh_pr_create_rest`, and `_rest_issue_list`
- Removed now-unused `local -a _toks=()` declarations

### `.agents/scripts/shared-gh-wrappers.sh`
- Added zsh `$0` fallback branch to `_SHARED_GH_WRAPPERS_DIR` resolution: when `BASH_SOURCE[0]` is empty (zsh without BASH_SOURCE emulation) and `_SC_SELF` is unset (no `shared-constants.sh` pre-sourced), derive the directory from `$0` which zsh sets to the sourced file path
- Added `print_info`/`print_warning` stub fallbacks (using `command -v` check, portable across bash/zsh) to prevent `command not found` errors when the wrapper is sourced standalone

### `.agents/scripts/tests/test-gh-wrapper-shell-compat.sh` (NEW)
- 8 regression scenarios covering: `_gh_split_csv` under bash, `_gh_split_csv` under zsh, single token, empty string, trailing delimiter, integration (labels+assignees reach gh api) under bash, integration under zsh, and load-order (no pre-set env required)
- All 8 scenarios pass; existing t2574 suite (22 tests) also passes unchanged

## Verification

```bash
# New tests
bash .agents/scripts/tests/test-gh-wrapper-shell-compat.sh
# 8/8 tests passed

# Existing regression suite
bash .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
# 22/22 tests passed

# Shellcheck
shellcheck .agents/scripts/shared-gh-wrappers-rest-fallback.sh
shellcheck .agents/scripts/shared-gh-wrappers.sh
shellcheck .agents/scripts/tests/test-gh-wrapper-shell-compat.sh
```

Resolves #20480

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.94 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 9m and 32,192 tokens on this as a headless worker.
