### PR TITLE
t2739: extend REST fallback to sub-issue backfill node-ID resolution (Gap B)

### DIFF
--- a/.agents/scripts/issue-sync-relationships.sh
+++ b/.agents/scripts/issue-sync-relationships.sh
@@ -45,22 +45,42 @@ _ISSUE_SYNC_RELATIONSHIPS_LOADED=1
 # Format: one "number=node_id" per line. Populated by _cached_node_id().
 _NODE_ID_CACHE_FILE=""
 
+# Rate-limited flag file: written by _cached_node_id when GraphQL is exhausted
+# AND the REST fallback also fails. Uses a file (not a bash variable) so that
+# the signal survives bash subshell boundaries — callers invoke _cached_node_id
+# via $() which spawns a subshell, so bash variable writes inside would be lost.
+# Callers check via _node_id_was_rate_limited. Reset to empty at each call.
+_NODE_ID_RATE_LIMITED_FILE=""
+
 _init_node_id_cache() {
 	if [[ -z "$_NODE_ID_CACHE_FILE" ]]; then
 		_NODE_ID_CACHE_FILE=$(mktemp "${TMPDIR:-/tmp}/aidevops-node-cache.XXXXXX")
+		_NODE_ID_RATE_LIMITED_FILE=$(mktemp "${TMPDIR:-/tmp}/aidevops-ratelimited.XXXXXX")
 		# Chain onto any existing EXIT trap rather than replacing it.
 		local _prev_trap
 		_prev_trap=$(trap -p EXIT | sed -E "s/^trap -- '(.*)' EXIT$/\1/")
 		# shellcheck disable=SC2064
-		trap "rm -f '$_NODE_ID_CACHE_FILE'${_prev_trap:+; $_prev_trap}" EXIT
+		trap "rm -f '$_NODE_ID_CACHE_FILE' '$_NODE_ID_RATE_LIMITED_FILE'${_prev_trap:+; $_prev_trap}" EXIT
 	fi
 	return 0
+}
+
+# Return 0 (true) if the most recent _cached_node_id call was rate-limited.
+# Reads the flag file written by the subshell — bash variables set inside $()
+# are discarded when the subshell exits, but file writes persist.
+_node_id_was_rate_limited() {
+	[[ -n "${_NODE_ID_RATE_LIMITED_FILE:-}" ]] && \
+		[[ "$(cat "$_NODE_ID_RATE_LIMITED_FILE" 2>/dev/null)" == "1" ]]
+	return $?
 }
 
 _cached_node_id() {
 	local num="$1" repo="$2"
 	[[ -z "$num" ]] && return 0
 	_init_node_id_cache
+	# Reset the rate-limited flag for this resolution. Runs inside the subshell
+	# spawned by callers' $() — the file truncation IS visible to the parent.
+	[[ -n "$_NODE_ID_RATE_LIMITED_FILE" ]] && : >"$_NODE_ID_RATE_LIMITED_FILE"
 
 	# Check cache file
 	local cached
@@ -75,6 +95,22 @@ _cached_node_id() {
 	if [[ -n "$nid" ]]; then
 		echo "${num}=${nid}" >>"$_NODE_ID_CACHE_FILE"
 		echo "$nid"
+		return 0
+	fi
+
+	# GraphQL returned empty. If rate-limited, try REST path (t2739).
+	# REST: GET /repos/{owner}/{repo}/issues/{number} → .node_id
+	# Uses the same core-pool 5000/hr budget that the t2574 write-path fallbacks use.
+	if _gh_should_fallback_to_rest; then
+		local rest_nid
+		rest_nid=$(gh api "/repos/${repo}/issues/${num}" --jq '.node_id' 2>/dev/null || echo "")
+		if [[ -n "$rest_nid" ]]; then
+			echo "${num}=${rest_nid}" >>"$_NODE_ID_CACHE_FILE"
+			echo "$rest_nid"
+			return 0
+		fi
+		# Both GraphQL and REST failed — write flag so callers can emit RATE_LIMITED.
+		[[ -n "$_NODE_ID_RATE_LIMITED_FILE" ]] && echo "1" >"$_NODE_ID_RATE_LIMITED_FILE"
 	fi
 	return 0
 }
@@ -655,12 +691,18 @@ _backfill_one_issue() {
 		return 0
 	fi
 
-	local child_node parent_node
+	local child_node parent_node _rate_limited=0
 	child_node=$(_cached_node_id "$num" "$repo")
+	_node_id_was_rate_limited && _rate_limited=1
 	parent_node=$(_cached_node_id "$parent_num" "$repo")
+	_node_id_was_rate_limited && _rate_limited=1
 	if [[ -z "$child_node" || -z "$parent_node" ]]; then
 		log_verbose "#$num: could not resolve node IDs for $num / $parent_num"
-		echo "SKIPPED $num"
+		if [[ "$_rate_limited" == "1" ]]; then
+			echo "RATE_LIMITED $num"
+		else
+			echo "SKIPPED $num"
+		fi
 		return 0
 	fi
 
@@ -795,8 +837,13 @@ _backfill_parent_children() {
 		if [[ -z "$parent_node" ]]; then
 			parent_node=$(_cached_node_id "$num" "$repo")
 			if [[ -z "$parent_node" ]]; then
-				log_verbose "#$num: could not resolve parent node ID"
-				echo "${_skip_tag} $num:0"
+				if _node_id_was_rate_limited; then
+					log_verbose "#$num: parent node ID resolution hit rate limit"
+					echo "PARENT_RATE_LIMITED $num:0"
+				else
+					log_verbose "#$num: could not resolve parent node ID"
+					echo "${_skip_tag} $num:0"
+				fi
 				return 0
 			fi
 		fi
@@ -890,7 +937,7 @@ cmd_backfill_sub_issues() {
 
 	print_info "Backfilling sub-issue links for $total issue(s) in $repo"
 
-	local linked=0 skipped=0 processed=0
+	local linked=0 skipped=0 rate_limited=0 processed=0
 	local _num result meta _title _body _has_parent _pcount
 	for _num in "${issue_numbers[@]}"; do
 		processed=$((processed + 1))
@@ -920,12 +967,16 @@ cmd_backfill_sub_issues() {
 			_pcount="${result##*:}"
 			linked=$((linked + _pcount))
 			;;
+		# RATE_LIMITED / PARENT_RATE_LIMITED: node ID could not be resolved due to
+		# GraphQL exhaustion and REST also failing. Counted separately so callers
+		# (pulse t2112 reconciler) can re-enqueue rather than treating as permanent.
+		RATE_LIMITED*|PARENT_RATE_LIMITED*) rate_limited=$((rate_limited + 1)) ;;
 		*) skipped=$((skipped + 1)) ;;
 		esac
 	done
 	[[ $total -gt 25 ]] && printf "\n" >&2
 
-	printf "\n=== Backfill Sub-Issues ===\nLinked: %d | Skipped: %d | Issues processed: %d\n" \
-		"$linked" "$skipped" "$total"
+	printf "\n=== Backfill Sub-Issues ===\nLinked: %d | Skipped: %d | Rate-limited: %d | Issues processed: %d\n" \
+		"$linked" "$skipped" "$rate_limited" "$total"
 	return 0
 }

--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -87,6 +87,9 @@ _rest_fallback_append_sig() {
 # an unnecessary REST retry that may also fail.
 #######################################
 _gh_should_fallback_to_rest() {
+	# Test/CI override: set _GH_SHOULD_FALLBACK_OVERRIDE=1 to force true without
+	# requiring a real rate-limit state. Use in unit tests and manual smoke runs.
+	[[ "${_GH_SHOULD_FALLBACK_OVERRIDE:-0}" == "1" ]] && return 0
 	local remaining
 	remaining=$(gh api rate_limit --jq '.resources.graphql.remaining' 2>/dev/null)
 	[[ "$remaining" =~ ^[0-9]+$ ]] || return 1

--- a/.agents/scripts/tests/test-backfill-sub-issues.sh
+++ b/.agents/scripts/tests/test-backfill-sub-issues.sh
@@ -171,12 +171,37 @@ if [[ "$cmd1" == "api" && "$cmd2" == "graphql" ]]; then
 			exit 0
 		fi
 		if [[ "$arg" == *"issue(number"* ]]; then
-			# resolve_gh_node_id query
+			# resolve_gh_node_id query — fail when _GH_GRAPHQL_NODE_FAIL=1 is set
+			if [[ "${_GH_GRAPHQL_NODE_FAIL:-0}" == "1" ]]; then
+				printf '\n'
+				exit 0
+			fi
 			printf '%s\n' 'NODE_STUB_ID'
 			exit 0
 		fi
 	done
 	printf '%s\n' '{}'
+	exit 0
+fi
+
+# gh api rate_limit → used by _gh_should_fallback_to_rest
+if [[ "$cmd1" == "api" && "$cmd2" == "rate_limit" ]]; then
+	printf '%s\n' '{"resources":{"graphql":{"remaining":5000}}}'
+	exit 0
+fi
+
+# gh api /repos/.../issues/NNN → REST node_id fallback (t2739)
+# Returns {"node_id":"..."} when GH_REST_NODE_<num> env var is set.
+if [[ "$cmd1" == "api" && "$cmd2" =~ ^/repos/ ]]; then
+	num=$(basename "$cmd2")
+	var="GH_REST_NODE_${num}"
+	payload="${!var:-}"
+	if [[ -n "$payload" ]]; then
+		_emit "$payload" "$@"
+		exit 0
+	fi
+	# No fixture: return empty body (REST also failed)
+	printf '\n'
 	exit 0
 fi
 
@@ -219,13 +244,15 @@ _init_cmd() {
 	return 0
 }
 
-# Pre-initialize node ID cache to prevent EXIT trap chaining.
-# _init_node_id_cache's trap chains the parent's EXIT trap into subshells;
-# on bash 5.x, subshells inherit EXIT traps, so when $(cmd | tail -1) exits,
-# the chained trap fires and deletes $TMP prematurely. Pre-initializing the
-# cache file skips the trap setup entirely (the guard checks -z).
+# Pre-initialize node ID cache and rate-limited flag file to prevent EXIT trap
+# chaining. _init_node_id_cache's trap chains the parent's EXIT trap into
+# subshells; on bash 5.x, subshells inherit EXIT traps, so when $(cmd | tail -1)
+# exits, the chained trap fires and deletes $TMP prematurely. Pre-initializing
+# skips the trap setup entirely (both guards check -z before creating files).
 _NODE_ID_CACHE_FILE="${TMP}/node_cache"
 : >"$_NODE_ID_CACHE_FILE"
+_NODE_ID_RATE_LIMITED_FILE="${TMP}/rate_limited_flag"
+: >"$_NODE_ID_RATE_LIMITED_FILE"
 
 printf '%sRunning backfill-sub-issues tests (t2114)%s\n' "$TEST_BLUE" "$TEST_NC"
 
@@ -545,6 +572,83 @@ else
 	fail "child-side detection still works through pre-fetch routing (regression)" \
 		"missing addSubIssue in gh.log: $(tr '\n' '|' <"$GH_LOG" | head -c 200)"
 fi
+
+# =============================================================================
+# Class D: REST fallback for node-ID resolution (t2739)
+# =============================================================================
+# Tests 21–22 exercise the new REST path in _cached_node_id.
+# Strategy:
+#   - Override the resolve_gh_node_id bash function to return empty, simulating
+#     GraphQL budget exhaustion without needing stub-level plumbing.
+#   - Set _GH_SHOULD_FALLBACK_OVERRIDE=1 so _gh_should_fallback_to_rest
+#     returns true without needing a real rate-limit state.
+#   - For test 21: GH_REST_NODE_<num> fixtures supply node IDs via REST
+#     → link succeeds (addSubIssue mutation fires).
+#   - For test 22: no REST fixtures → both paths fail → RATE_LIMITED emitted
+#     and Rate-limited: 1 appears in the summary.
+
+printf '\n%sRunning REST fallback tests (t2739)%s\n' "$TEST_BLUE" "$TEST_NC"
+
+# Issue #400: child that maps to parent #100 via dot-notation (t1873.2 fixture)
+# Use the same parent/child fixture as test 9/10 (#200 → parent #100) so the
+# parent-detection logic is already proven; only node resolution changes.
+export GH_ISSUE_400_JSON='{"title":"t1873.2: child of 1873","body":"REST fallback child","labels":[]}'
+# Override resolve_gh_node_id to return empty (simulating GraphQL exhaustion).
+# The real function is in issue-sync-lib.sh; bash function override works here.
+resolve_gh_node_id() { echo ""; return 0; }
+export _GH_SHOULD_FALLBACK_OVERRIDE=1
+
+# ---- Test 21: REST fallback fires, link succeeds ----
+# Provide REST node_id for both child (#400) and parent (#100).
+export GH_REST_NODE_400='{"node_id":"REST_CHILD_NODE"}'
+export GH_REST_NODE_100='{"node_id":"REST_PARENT_NODE"}'
+# Clear node cache so it doesn't serve stale GraphQL-resolved entries.
+: >"$_NODE_ID_CACHE_FILE"
+
+: >"$GH_LOG"
+cmd_backfill_sub_issues --issue 400 >"${TMP}/out.21" 2>&1 || true
+
+if grep -q 'addSubIssue' "$GH_LOG"; then
+	pass "REST fallback: link succeeds when GraphQL exhausted but REST returns node_id"
+else
+	fail "REST fallback: link succeeds when GraphQL exhausted but REST returns node_id" \
+		"missing addSubIssue in gh.log: $(tr '\n' '|' <"$GH_LOG" | head -c 300)"
+fi
+
+# ---- Test 22: RATE_LIMITED emitted when both GraphQL and REST fail ----
+# Remove REST fixtures so the stub returns empty for /repos/.../issues/NNN.
+unset GH_REST_NODE_400 GH_REST_NODE_100
+: >"$_NODE_ID_CACHE_FILE"
+
+: >"$GH_LOG"
+cmd_backfill_sub_issues --issue 400 >"${TMP}/out.22" 2>&1 || true
+
+if grep -q 'Rate-limited: 1' "${TMP}/out.22"; then
+	if ! grep -q 'addSubIssue' "$GH_LOG"; then
+		pass "RATE_LIMITED emitted distinctly when both GraphQL and REST fail"
+	else
+		fail "RATE_LIMITED emitted distinctly when both GraphQL and REST fail" \
+			"unexpected addSubIssue in gh.log"
+	fi
+else
+	fail "RATE_LIMITED emitted distinctly when both GraphQL and REST fail" \
+		"missing 'Rate-limited: 1' in output: $(tr '\n' '|' <"${TMP}/out.22" | head -c 300)"
+fi
+
+# Restore normal behaviour for any future tests.
+unset _GH_SHOULD_FALLBACK_OVERRIDE
+unset _GH_GRAPHQL_NODE_FAIL
+resolve_gh_node_id() {
+	local issue_number="$1" repo="$2"
+	local owner="${repo%%/*}" name="${repo##*/}"
+	local node_id
+	node_id=$(gh api graphql \
+		-f query='query($owner:String!,$name:String!,$num:Int!){repository(owner:$owner,name:$name){issue(number:$num){id}}}' \
+		-f owner="$owner" -f name="$name" -F num="$issue_number" \
+		--jq '.data.repository.issue.id' 2>/dev/null || echo "")
+	echo "$node_id"
+	return 0
+}
 
 # =============================================================================
 # Summary


### PR DESCRIPTION
## Summary

Extends the t2574 REST-fallback pattern to `_cached_node_id` in `issue-sync-relationships.sh`, fixing the silent rate-limit skips that caused sub-issue graph population to be non-deterministic when GraphQL budget is exhausted.

## What changed

**`shared-gh-wrappers-rest-fallback.sh`**
- Added `_GH_SHOULD_FALLBACK_OVERRIDE=1` bypass to `_gh_should_fallback_to_rest` for testability and manual smoke runs without needing a real rate-limit state.

**`issue-sync-relationships.sh`**
- Replaced `_NODE_ID_CACHE_FILE` single-file init with co-initialization of a new `_NODE_ID_RATE_LIMITED_FILE` (temp file, same EXIT-trap cleanup pattern). File-based (not a bash variable) so the signal survives `$()` subshell boundaries.
- `_cached_node_id`: after `resolve_gh_node_id` returns empty, checks `_gh_should_fallback_to_rest`. If true, tries `GET /repos/{owner}/{repo}/issues/{number}` REST endpoint (returns `.node_id`). Caches success. On double failure writes `"1"` to the flag file.
- `_node_id_was_rate_limited`: thin helper that reads the flag file; callers use this after each `_cached_node_id` subshell invocation.
- `_backfill_one_issue`: accumulates rate-limited state across both `_cached_node_id` calls; emits `RATE_LIMITED $num` instead of `SKIPPED $num` when applicable.
- `_backfill_parent_children`: emits `PARENT_RATE_LIMITED $num:0` when parent node-ID resolution was rate-limited.
- `cmd_backfill_sub_issues`: adds `rate_limited` counter, handles `RATE_LIMITED*` / `PARENT_RATE_LIMITED*` result tokens, reports `Rate-limited: N` in summary so callers (pulse t2112 reconciler) can re-enqueue instead of treating as permanently skipped.

**`tests/test-backfill-sub-issues.sh`**
- Updated gh stub: handles `gh api rate_limit` (real rate_limit endpoint), `gh api /repos/.../issues/NNN` (REST node_id path), and `_GH_GRAPHQL_NODE_FAIL` env for stub-level graphql failures.
- Pre-initializes `_NODE_ID_RATE_LIMITED_FILE` alongside existing `_NODE_ID_CACHE_FILE` to prevent EXIT trap chaining on bash 5.x.
- Test 21 (Class D): REST fallback fires when GraphQL exhausted — link succeeds.
- Test 22 (Class D): RATE_LIMITED status emitted when both paths fail.
- All 21 existing tests still pass (23 total now).

## Acceptance

- [x] `shellcheck issue-sync-relationships.sh` clean (no new findings — 2 pre-existing SC2016 info on GraphQL strings)
- [x] 23/23 tests pass including new tests 21 & 22
- [x] Manual smoke: `AIDEVOPS_GH_REST_FALLBACK_THRESHOLD=9999` + `_GH_SHOULD_FALLBACK_OVERRIDE=1` reproduces REST path in integration

## Complexity Bump Justification

None needed — line count and nesting depth are within existing baseline for this file.

Resolves #20475

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.94 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 10m and 39,114 tokens on this as a headless worker.
