### PR TITLE
t2745: t2745: add pre-push guard to catch duplicate TODO entries from issue-sync orphan seed

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -354,7 +354,7 @@ Advisories delivered via `aidevops update`; shown in session greeting until dism
 
 **Cross-repo privacy:** NEVER include private repo names in TODO.md task descriptions, issue titles, or comments on public repos. Use generic references like "a managed private repo" or "cross-repo project". The issue-sync-helper.sh has automated sanitization, but prevention at the source is the primary defense.
 
-**Client-side pre-push guards (t1965, t2198):** Three opt-in `pre-push` hooks: **privacy** (blocks private repo slugs in public commits), **complexity** (blocks new violations of function/nesting/file size limits), **scope** (blocks out-of-scope file changes per brief `Files Scope`). Install: `install-pre-push-guards.sh install`. Bypass all: `git push --no-verify`. Full detail and individual bypass flags: `reference/pre-push-guards.md`.
+**Client-side pre-push guards (t1965, t2198, t2745):** Four opt-in `pre-push` hooks: **privacy** (blocks private repo slugs in public commits), **complexity** (blocks new violations of function/nesting/file size limits), **scope** (blocks out-of-scope file changes per brief `Files Scope`), **dup-todo** (blocks pushes where `TODO.md` has duplicate task-ID checkbox lines). Install: `install-pre-push-guards.sh install`. Bypass all: `git push --no-verify`. Full detail and individual bypass flags: `reference/pre-push-guards.md`.
 
 ## Working Directories
 

--- a/.agents/hooks/pre-push-dup-todo-guard.sh
+++ b/.agents/hooks/pre-push-dup-todo-guard.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# pre-push-dup-todo-guard.sh — git pre-push hook (t2745).
+#
+# Blocks a push when TODO.md on the pushed commit contains two or more
+# checkbox lines with the same task ID.
+# Example duplicate: two lines starting with "- [ ] t2743 " or "- [x] t2743 ".
+#
+# Root cause this catches: _seed_orphan_todo_line (issue-sync) appends a
+# minimal entry for an issue that already has a rich planning-PR entry. On
+# git rebase the two entries co-exist with no merge conflict (different line
+# numbers). This hook catches the duplicate before it reaches the remote.
+#
+# Install: see .agents/scripts/install-pre-push-guards.sh
+#
+# Git pre-push protocol:
+#   $1 = remote name
+#   $2 = remote URL
+#   stdin: one line per ref being pushed:
+#     <local_ref> <local_sha> <remote_ref> <remote_sha>
+#
+# Exit 0 = allow push. Exit 1 = block push.
+#
+# Environment:
+#   AIDEVOPS_SKIP_DUP_TODO_GUARD=1  — bypass for this invocation (logs warning to stderr)
+#   AIDEVOPS_DUP_TODO_GUARD_DEBUG=1 — verbose stderr trace
+#
+# Fail-open cases (exit 0 with warning):
+#   - TODO.md does not exist in the pushed commit
+#   - git show fails for the pushed SHA
+#
+# Cross-platform requirements met:
+#   - POSIX ERE only ([[:space:]] not \s, no \b, no \w)
+#   - Bash 3.2 compatible (no read -a, no mapfile, =~ uses variable pattern)
+#   - Works with BSD grep (macOS) and GNU grep
+
+set -u
+
+GUARD_NAME="dup-todo-guard"
+
+_log() {
+	local _level="$1"
+	local _msg="$2"
+	printf '[%s][%s] %s\n' "$GUARD_NAME" "$_level" "$_msg" >&2
+	return 0
+}
+
+_dbg() {
+	local _msg="$1"
+	[[ "${AIDEVOPS_DUP_TODO_GUARD_DEBUG:-0}" == "1" ]] || return 0
+	_log DEBUG "$_msg"
+	return 0
+}
+
+if [[ "${AIDEVOPS_SKIP_DUP_TODO_GUARD:-0}" == "1" ]]; then
+	_log WARN "AIDEVOPS_SKIP_DUP_TODO_GUARD=1 — bypassing duplicate TODO check (audit trail: override active)"
+	exit 0
+fi
+
+_exit_code=0
+
+# Pattern for zero-SHA (branch deletion). Use a variable so [[ =~ ]] works
+# consistently across Bash 3.2 (macOS default) and later versions.
+_zero_sha_pattern='^[0]+$'
+
+while IFS=' ' read -r _local_ref _local_sha _remote_ref _remote_sha; do
+	[[ -z "${_local_sha:-}" ]] && continue
+
+	# Branch deletion (all-zero SHA) — nothing to check.
+	if [[ "$_local_sha" =~ $_zero_sha_pattern ]]; then
+		_dbg "branch deletion detected for ${_local_ref} — skipping"
+		continue
+	fi
+
+	_dbg "checking ${_local_ref} at ${_local_sha}"
+
+	# Fast-path: is TODO.md present in this commit at all?
+	if ! git cat-file -e "${_local_sha}:TODO.md" 2>/dev/null; then
+		_dbg "TODO.md not in commit ${_local_sha} — skipping"
+		continue
+	fi
+
+	# Read TODO.md from the pushed commit (not the working tree).
+	_todo_content=""
+	_todo_content=$(git show "${_local_sha}:TODO.md" 2>/dev/null) || {
+		_log WARN "git show ${_local_sha}:TODO.md failed — fail-open for this ref"
+		continue
+	}
+
+	# Extract task IDs from checkbox lines only.
+	# Pattern: ^- [x] tNNN<space> — anchored to avoid matching prose that
+	# mentions a task ID in a description or comment.
+	# BSD sed and GNU sed both support \1 backreference in basic RE.
+	_task_ids=$(printf '%s\n' "$_todo_content" \
+		| grep -E '^- \[.\] t[0-9]+[[:space:]]' \
+		| sed 's/^- \[.\] \(t[0-9]*\)[[:space:]].*/\1/')
+
+	if [[ -z "$_task_ids" ]]; then
+		_dbg "no task IDs extracted from TODO.md in ${_local_sha}"
+		continue
+	fi
+
+	# Find IDs that appear more than once.
+	_duplicates=$(printf '%s\n' "$_task_ids" | sort | uniq -d)
+
+	if [[ -z "$_duplicates" ]]; then
+		_dbg "no duplicate task IDs in TODO.md at ${_local_sha}"
+		continue
+	fi
+
+	# Found duplicates — block and report line numbers for each.
+	_exit_code=1
+	printf '\n[%s][BLOCK] Push blocked: duplicate task IDs in TODO.md\n\n' "$GUARD_NAME" >&2
+
+	printf '%s\n' "$_duplicates" | while IFS= read -r _dup_id; do
+		[[ -z "$_dup_id" ]] && continue
+		# Find line numbers of the duplicate entries (1-indexed, matching the
+		# checkbox-and-ID anchor so description-only mentions are excluded).
+		_line_nums=$(printf '%s\n' "$_todo_content" \
+			| grep -n "^- \[.\] ${_dup_id}[[:space:]]" \
+			| cut -d: -f1 \
+			| tr '\n' ',' \
+			| sed 's/,$//')
+		printf '  Duplicate task ID: %s  (TODO.md lines: %s)\n' "$_dup_id" "$_line_nums" >&2
+	done
+
+	printf '\n' >&2
+	printf '  Fix: remove the duplicate entry from TODO.md, amend the commit,\n' >&2
+	printf '       and push again.\n' >&2
+	printf '  Check: grep -n "^- \\[.\\] tNNN " TODO.md\n' >&2
+	printf '  Bypass (warning logged): AIDEVOPS_SKIP_DUP_TODO_GUARD=1 git push\n' >&2
+	printf '  Bypass all hooks:        git push --no-verify\n\n' >&2
+done
+
+exit "$_exit_code"

--- a/.agents/reference/pre-push-guards.md
+++ b/.agents/reference/pre-push-guards.md
@@ -1,9 +1,9 @@
-# Pre-Push Guards Reference (t1965, t2198)
+# Pre-Push Guards Reference (t1965, t2198, t2745)
 
-Three opt-in `pre-push` hooks block common mistakes before they hit CI.
+Four opt-in `pre-push` hooks block common mistakes before they hit CI.
 
 Install all: `install-pre-push-guards.sh install`
-Install individual: `install-pre-push-guards.sh --guard privacy|complexity|scope`
+Install individual: `install-pre-push-guards.sh --guard privacy|complexity|scope|credential|dup-todo`
 Status: `install-pre-push-guards.sh status`
 Bypass all: `git push --no-verify`
 
@@ -45,3 +45,18 @@ Reads the brief file for the current branch's task ID and enforces the declared 
 - Bypass: `SCOPE_GUARD_DISABLE=1 git push ...`
 - **Fail-open** when: branch name has no task ID, or no brief file exists
 - **Fail-closed** when: brief exists but has no `Files Scope` section or the section is empty — this is a configuration error that must be fixed before pushing
+
+## Duplicate TODO Guard
+
+**File:** `.agents/hooks/pre-push-dup-todo-guard.sh`
+
+Blocks pushes when the pushed commit's `TODO.md` contains two or more checkbox lines with the same task ID (t2745). Root cause: `_seed_orphan_todo_line` in `issue-sync-lib.sh` appends a minimal entry for an issue that already has a rich planning-PR entry. After `git rebase main`, both entries coexist with no merge conflict (different line numbers). This hook catches the duplicate at push time, before it reaches the remote.
+
+Detection pattern: `^- \[.\] tNNN ` — anchored to checkbox-and-task-ID prefix. Description-only mentions of a task ID (e.g., `See t2743 for context`) are not flagged.
+
+Fix: `grep -n "^- \[.\] tNNN " TODO.md` to find both entries, remove the minimal (orphan-seeded) one, amend, and push again.
+
+- Bypass (warning logged to stderr): `AIDEVOPS_SKIP_DUP_TODO_GUARD=1 git push ...`
+- Bypass all hooks: `git push --no-verify` (no warning)
+- **Fail-open** when: `TODO.md` is absent from the pushed commit, or `git show` fails
+- Test harness: `.agents/scripts/tests/test-pre-push-dup-todo-guard.sh`

--- a/.agents/scripts/install-pre-push-guards.sh
+++ b/.agents/scripts/install-pre-push-guards.sh
@@ -2,22 +2,23 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 #
-# install-pre-push-guards.sh — Install aidevops git pre-push hooks (t2198, t2446, t2458).
+# install-pre-push-guards.sh — Install aidevops git pre-push hooks (t2198, t2446, t2458, t2745).
 #
-# Manages four pre-push guards in the current repository:
+# Manages five pre-push guards in the current repository:
 #   - privacy-guard      blocks pushes leaking private repo slugs
 #   - complexity-guard   blocks pushes introducing complexity regressions
 #   - scope-guard        blocks pushes touching files outside the brief's Files Scope
 #   - credential-guard   blocks pushes emitting unsanitised remote URLs (t2458)
+#   - dup-todo-guard     blocks pushes where TODO.md has duplicate task-ID checkbox lines (t2745)
 #
 # Usage:
 #   install-pre-push-guards.sh install [--guard <name>]
 #         Install (or refresh) guard(s).
-#         --guard: privacy|complexity|scope|credential|all (default: all)
+#         --guard: privacy|complexity|scope|credential|dup-todo|all (default: all)
 #
 #   install-pre-push-guards.sh uninstall [--guard <name>]
 #         Remove guard entry/entries.
-#         --guard: privacy|complexity|scope|credential|all (default: all)
+#         --guard: privacy|complexity|scope|credential|dup-todo|all (default: all)
 #
 #   install-pre-push-guards.sh status
 #         Report which guards are present and their hook source locations.
@@ -28,11 +29,12 @@
 # Existing hooks NOT managed by aidevops are refused and left untouched.
 #
 # Runtime bypass per-guard:
-#   PRIVACY_GUARD_DISABLE=1       skip privacy check for this push
-#   COMPLEXITY_GUARD_DISABLE=1    skip complexity check for this push
-#   SCOPE_GUARD_DISABLE=1         skip scope check for this push
-#   CREDENTIAL_GUARD_DISABLE=1    skip credential check for this push
-#   git push --no-verify          skip all hooks
+#   PRIVACY_GUARD_DISABLE=1          skip privacy check for this push
+#   COMPLEXITY_GUARD_DISABLE=1       skip complexity check for this push
+#   SCOPE_GUARD_DISABLE=1            skip scope check for this push
+#   CREDENTIAL_GUARD_DISABLE=1       skip credential check for this push
+#   AIDEVOPS_SKIP_DUP_TODO_GUARD=1   skip duplicate TODO check for this push
+#   git push --no-verify             skip all hooks
 
 set -euo pipefail
 
@@ -70,11 +72,13 @@ HOOK_MARKER_PRIVACY="# guard:privacy"
 HOOK_MARKER_COMPLEXITY="# guard:complexity"
 HOOK_MARKER_SCOPE="# guard:scope"
 HOOK_MARKER_CREDENTIAL="# guard:credential"
+HOOK_MARKER_DUP_TODO="# guard:dup-todo"
 
 DEPLOYED_PRIVACY_HOOK="$HOME/.aidevops/agents/hooks/privacy-guard-pre-push.sh"
 DEPLOYED_COMPLEXITY_HOOK="$HOME/.aidevops/agents/hooks/complexity-regression-pre-push.sh"
 DEPLOYED_SCOPE_HOOK="$HOME/.aidevops/agents/hooks/scope-guard-pre-push.sh"
 DEPLOYED_CREDENTIAL_HOOK="$HOME/.aidevops/agents/hooks/credential-emission-pre-push.sh"
+DEPLOYED_DUP_TODO_HOOK="$HOME/.aidevops/agents/hooks/pre-push-dup-todo-guard.sh"
 
 #######################################
 # Resolve the script's own directory (symlink-safe).
@@ -116,6 +120,10 @@ _find_hook_src() {
 	credential)
 		_repo_hook="${_sd}/../hooks/credential-emission-pre-push.sh"
 		_deployed_hook="$DEPLOYED_CREDENTIAL_HOOK"
+		;;
+	dup-todo)
+		_repo_hook="${_sd}/../hooks/pre-push-dup-todo-guard.sh"
+		_deployed_hook="$DEPLOYED_DUP_TODO_HOOK"
 		;;
 	*)
 		print_error "_find_hook_src: unknown guard: $_guard"
@@ -205,7 +213,7 @@ GUARD_BLOCK
 
 #######################################
 # Write (or rewrite) the dispatcher hook.
-# Args: _hook_path _inc_privacy _inc_complexity _inc_scope _inc_credential (0|1 each)
+# Args: _hook_path _inc_privacy _inc_complexity _inc_scope _inc_credential _inc_dup_todo (0|1 each)
 #
 # The generated script reads all stdin once, then pipes it to each
 # installed guard hook. Each guard receives (remote_name, remote_url)
@@ -217,6 +225,7 @@ _write_dispatcher() {
 	local _inc_complexity="$3"
 	local _inc_scope="${4:-0}"
 	local _inc_credential="${5:-0}"
+	local _inc_dup_todo="${6:-0}"
 
 	mkdir -p "$(dirname "$_hook_path")"
 
@@ -228,7 +237,8 @@ _write_dispatcher() {
 # Chains installed aidevops pre-push guards in order.
 # Bypass all:  git push --no-verify
 # Bypass each: PRIVACY_GUARD_DISABLE=1, COMPLEXITY_GUARD_DISABLE=1,
-#              SCOPE_GUARD_DISABLE=1, or CREDENTIAL_GUARD_DISABLE=1
+#              SCOPE_GUARD_DISABLE=1, CREDENTIAL_GUARD_DISABLE=1,
+#              or AIDEVOPS_SKIP_DUP_TODO_GUARD=1
 
 set -u
 
@@ -249,6 +259,8 @@ HOOK_HEADER
 		"scope" ".agents/hooks/scope-guard-pre-push.sh" "$DEPLOYED_SCOPE_HOOK"
 	[[ "$_inc_credential" -eq 1 ]] && _append_guard_block "$_hook_path" \
 		"credential" ".agents/hooks/credential-emission-pre-push.sh" "$DEPLOYED_CREDENTIAL_HOOK"
+	[[ "$_inc_dup_todo" -eq 1 ]] && _append_guard_block "$_hook_path" \
+		"dup-todo" ".agents/hooks/pre-push-dup-todo-guard.sh" "$DEPLOYED_DUP_TODO_HOOK"
 
 	# Single-quoted to write literal $-vars into the generated script (not expand here)
 	# shellcheck disable=SC2016
@@ -291,7 +303,7 @@ _install_reject_unmanaged_hook() {
 	print_error "existing pre-push hook at $_hook_path is NOT managed by aidevops"
 	print_error "Refusing to overwrite. To chain manually, add each guard to your hook:"
 	local _gh
-	for _gh in "privacy-guard-pre-push.sh" "complexity-regression-pre-push.sh" "scope-guard-pre-push.sh" "credential-emission-pre-push.sh"; do
+	for _gh in "privacy-guard-pre-push.sh" "complexity-regression-pre-push.sh" "scope-guard-pre-push.sh" "credential-emission-pre-push.sh" "pre-push-dup-todo-guard.sh"; do
 		# shellcheck disable=SC2016
 		print_error '  ${REPO}/.agents/hooks/'"$_gh"' "$@" < /dev/stdin'
 	done
@@ -311,34 +323,37 @@ cmd_install() {
 	_install_reject_unmanaged_hook "$_hook_path" || return 1
 
 	# Determine which guards are currently in the hook
-	local _cur_privacy=0 _cur_complexity=0 _cur_scope=0 _cur_credential=0
+	local _cur_privacy=0 _cur_complexity=0 _cur_scope=0 _cur_credential=0 _cur_dup_todo=0
 	if [[ -f "$_hook_path" ]]; then
 		grep -q "$HOOK_MARKER_PRIVACY" "$_hook_path" 2>/dev/null && _cur_privacy=1
 		grep -q "$HOOK_MARKER_COMPLEXITY" "$_hook_path" 2>/dev/null && _cur_complexity=1
 		grep -q "$HOOK_MARKER_SCOPE" "$_hook_path" 2>/dev/null && _cur_scope=1
 		grep -q "$HOOK_MARKER_CREDENTIAL" "$_hook_path" 2>/dev/null && _cur_credential=1
+		grep -q "$HOOK_MARKER_DUP_TODO" "$_hook_path" 2>/dev/null && _cur_dup_todo=1
 	fi
 
 	# Determine which guards to add based on filter
-	local _want_privacy=0 _want_complexity=0 _want_scope=0 _want_credential=0
+	local _want_privacy=0 _want_complexity=0 _want_scope=0 _want_credential=0 _want_dup_todo=0
 	case "$_guard_filter" in
-	all)        _want_privacy=1; _want_complexity=1; _want_scope=1; _want_credential=1 ;;
+	all)        _want_privacy=1; _want_complexity=1; _want_scope=1; _want_credential=1; _want_dup_todo=1 ;;
 	privacy)    _want_privacy=1 ;;
 	complexity) _want_complexity=1 ;;
 	scope)      _want_scope=1 ;;
 	credential) _want_credential=1 ;;
+	dup-todo)   _want_dup_todo=1 ;;
 	*)
-		print_error "unknown guard: $_guard_filter (valid: all, privacy, complexity, scope, credential)"
+		print_error "unknown guard: $_guard_filter (valid: all, privacy, complexity, scope, credential, dup-todo)"
 		return 1
 		;;
 	esac
 
 	# Merge: keep existing + add requested
-	local _inc_privacy=0 _inc_complexity=0 _inc_scope=0 _inc_credential=0
+	local _inc_privacy=0 _inc_complexity=0 _inc_scope=0 _inc_credential=0 _inc_dup_todo=0
 	[[ "$_cur_privacy" -eq 1 || "$_want_privacy" -eq 1 ]] && _inc_privacy=1
 	[[ "$_cur_complexity" -eq 1 || "$_want_complexity" -eq 1 ]] && _inc_complexity=1
 	[[ "$_cur_scope" -eq 1 || "$_want_scope" -eq 1 ]] && _inc_scope=1
 	[[ "$_cur_credential" -eq 1 || "$_want_credential" -eq 1 ]] && _inc_credential=1
+	[[ "$_cur_dup_todo" -eq 1 || "$_want_dup_todo" -eq 1 ]] && _inc_dup_todo=1
 
 	# Verify sources exist; warn and omit guards whose source is missing
 	local _installed_list=""
@@ -374,17 +389,25 @@ cmd_install() {
 			_inc_credential=0
 		fi
 	fi
+	if [[ "$_inc_dup_todo" -eq 1 ]]; then
+		if _find_hook_src dup-todo >/dev/null 2>&1; then
+			_installed_list="${_installed_list}dup-todo "
+		else
+			print_warning "dup-todo hook source not found — omitting dup-todo guard"
+			_inc_dup_todo=0
+		fi
+	fi
 
-	if [[ "$_inc_privacy" -eq 0 && "$_inc_complexity" -eq 0 && "$_inc_scope" -eq 0 && "$_inc_credential" -eq 0 ]]; then
+	if [[ "$_inc_privacy" -eq 0 && "$_inc_complexity" -eq 0 && "$_inc_scope" -eq 0 && "$_inc_credential" -eq 0 && "$_inc_dup_todo" -eq 0 ]]; then
 		print_warning "no guards to install (sources not found)"
 		return 0
 	fi
 
-	_write_dispatcher "$_hook_path" "$_inc_privacy" "$_inc_complexity" "$_inc_scope" "$_inc_credential"
+	_write_dispatcher "$_hook_path" "$_inc_privacy" "$_inc_complexity" "$_inc_scope" "$_inc_credential" "$_inc_dup_todo"
 	print_success "installed pre-push guards: ${_installed_list% }"
 	print_info "hook: $_hook_path"
 	print_info "bypass all: git push --no-verify"
-	print_info "bypass individual: PRIVACY_GUARD_DISABLE=1, COMPLEXITY_GUARD_DISABLE=1, SCOPE_GUARD_DISABLE=1, or CREDENTIAL_GUARD_DISABLE=1"
+	print_info "bypass individual: PRIVACY_GUARD_DISABLE=1, COMPLEXITY_GUARD_DISABLE=1, SCOPE_GUARD_DISABLE=1, CREDENTIAL_GUARD_DISABLE=1, or AIDEVOPS_SKIP_DUP_TODO_GUARD=1"
 	return 0
 }
 
@@ -426,28 +449,30 @@ cmd_uninstall() {
 	fi
 
 	# Remove one guard: read current state, rebuild without the removed guard
-	local _cur_privacy=0 _cur_complexity=0 _cur_scope=0 _cur_credential=0
+	local _cur_privacy=0 _cur_complexity=0 _cur_scope=0 _cur_credential=0 _cur_dup_todo=0
 	grep -q "$HOOK_MARKER_PRIVACY" "$_hook_path" 2>/dev/null && _cur_privacy=1
 	grep -q "$HOOK_MARKER_COMPLEXITY" "$_hook_path" 2>/dev/null && _cur_complexity=1
 	grep -q "$HOOK_MARKER_SCOPE" "$_hook_path" 2>/dev/null && _cur_scope=1
 	grep -q "$HOOK_MARKER_CREDENTIAL" "$_hook_path" 2>/dev/null && _cur_credential=1
+	grep -q "$HOOK_MARKER_DUP_TODO" "$_hook_path" 2>/dev/null && _cur_dup_todo=1
 
 	case "$_guard_filter" in
 	privacy)    _cur_privacy=0 ;;
 	complexity) _cur_complexity=0 ;;
 	scope)      _cur_scope=0 ;;
 	credential) _cur_credential=0 ;;
+	dup-todo)   _cur_dup_todo=0 ;;
 	*)
 		print_error "unknown guard: $_guard_filter"
 		return 1
 		;;
 	esac
 
-	if [[ "$_cur_privacy" -eq 0 && "$_cur_complexity" -eq 0 && "$_cur_scope" -eq 0 && "$_cur_credential" -eq 0 ]]; then
+	if [[ "$_cur_privacy" -eq 0 && "$_cur_complexity" -eq 0 && "$_cur_scope" -eq 0 && "$_cur_credential" -eq 0 && "$_cur_dup_todo" -eq 0 ]]; then
 		rm -f "$_hook_path"
 		print_success "removed last guard — hook deleted"
 	else
-		_write_dispatcher "$_hook_path" "$_cur_privacy" "$_cur_complexity" "$_cur_scope" "$_cur_credential"
+		_write_dispatcher "$_hook_path" "$_cur_privacy" "$_cur_complexity" "$_cur_scope" "$_cur_credential" "$_cur_dup_todo"
 		print_success "removed $_guard_filter guard from hook"
 	fi
 	return 0
@@ -474,16 +499,18 @@ cmd_status() {
 	printf 'pre-push hook: installed (aidevops managed)\n'
 	printf '  path: %s\n' "$_hook_path"
 
-	local _has_privacy=0 _has_complexity=0 _has_scope=0 _has_credential=0
+	local _has_privacy=0 _has_complexity=0 _has_scope=0 _has_credential=0 _has_dup_todo=0
 	grep -q "$HOOK_MARKER_PRIVACY" "$_hook_path" 2>/dev/null && _has_privacy=1
 	grep -q "$HOOK_MARKER_COMPLEXITY" "$_hook_path" 2>/dev/null && _has_complexity=1
 	grep -q "$HOOK_MARKER_SCOPE" "$_hook_path" 2>/dev/null && _has_scope=1
 	grep -q "$HOOK_MARKER_CREDENTIAL" "$_hook_path" 2>/dev/null && _has_credential=1
+	grep -q "$HOOK_MARKER_DUP_TODO" "$_hook_path" 2>/dev/null && _has_dup_todo=1
 
 	_status_report_guard "privacy"    "$_has_privacy"
 	_status_report_guard "complexity" "$_has_complexity"
 	_status_report_guard "scope"      "$_has_scope"
 	_status_report_guard "credential" "$_has_credential"
+	_status_report_guard "dup-todo"   "$_has_dup_todo"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-pre-push-dup-todo-guard.sh
+++ b/.agents/scripts/tests/test-pre-push-dup-todo-guard.sh
@@ -1,0 +1,364 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-pre-push-dup-todo-guard.sh — Unit tests for pre-push-dup-todo-guard.sh (t2745).
+#
+# Tests 7 fixtures:
+#   1. Clean TODO.md (no duplicates)               → exit 0
+#   2. Single duplicate (t2743 twice)              → exit 1, cites lines
+#   3. Multiple duplicates (t2743 AND t2742)       → exit 1, cites both IDs
+#   4. Completed + open pair (- [x] + - [ ] same) → exit 1
+#   5. Pseudo-duplicate (task ID in description)   → exit 0
+#   6. AIDEVOPS_SKIP_DUP_TODO_GUARD=1              → exit 0, warning to stderr
+#   7. --no-verify bypass documentation            → informational (git-level bypass)
+#
+# Usage: bash .agents/scripts/tests/test-pre-push-dup-todo-guard.sh
+# Exit 0 = all tests passed. Exit 1 = one or more tests failed.
+
+set -u
+
+# ---------------------------------------------------------------------------
+# Locate the hook under test (resolve relative to this script's directory).
+# ---------------------------------------------------------------------------
+_script_dir() {
+	local _src="${BASH_SOURCE[0]}"
+	while [[ -L "$_src" ]]; do
+		local _dir
+		_dir=$(cd -P "$(dirname "$_src")" && pwd)
+		_src=$(readlink "$_src")
+		[[ "$_src" != /* ]] && _src="${_dir}/${_src}"
+	done
+	cd -P "$(dirname "$_src")" && pwd
+	return 0
+}
+
+TESTS_DIR=$(_script_dir)
+REPO_ROOT=$(cd "${TESTS_DIR}/../../.." && pwd)
+HOOK="${REPO_ROOT}/.agents/hooks/pre-push-dup-todo-guard.sh"
+
+if [[ ! -f "$HOOK" ]]; then
+	printf '[FATAL] Hook not found: %s\n' "$HOOK" >&2
+	exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Test infrastructure
+# ---------------------------------------------------------------------------
+_TESTS_PASSED=0
+_TESTS_FAILED=0
+_TEST_TMPDIR=""
+
+_setup_git_repo() {
+	_TEST_TMPDIR=$(mktemp -d)
+	cd "$_TEST_TMPDIR" || return 1
+	git init -q
+	git config user.email "test@test.local"
+	git config user.name "Test"
+	# Disable commit signing for the test repo — global config may have
+	# commit.gpgsign=true which requires a key passphrase that won't be
+	# available in headless test runs.
+	git config commit.gpgsign false
+	git config tag.gpgsign false
+	# Initial commit required before git show works
+	touch TODO.md
+	git add TODO.md
+	git commit -q -m "init"
+	return 0
+}
+
+_teardown_git_repo() {
+	cd / 2>/dev/null || true
+	[[ -n "${_TEST_TMPDIR:-}" && -d "$_TEST_TMPDIR" ]] && rm -rf "$_TEST_TMPDIR"
+	_TEST_TMPDIR=""
+	return 0
+}
+
+# Commit TODO.md with given content; prints the resulting SHA on stdout.
+_commit_todo() {
+	local _content="$1"
+	printf '%s\n' "$_content" >"$_TEST_TMPDIR/TODO.md"
+	git add TODO.md
+	git commit -q -m "test commit"
+	git rev-parse HEAD
+	return 0
+}
+
+# Run the hook with a given SHA as the pushed commit.
+# Synthesises git pre-push stdin: local_ref local_sha remote_ref remote_sha
+# Returns the hook's exit code.
+_run_hook() {
+	local _sha="$1"
+	local _extra_env="${2:-}"
+	local _stdin
+	_stdin="refs/heads/test ${_sha} refs/heads/main 0000000000000000000000000000000000000000"
+	if [[ -n "$_extra_env" ]]; then
+		env "$_extra_env" bash "$HOOK" origin "https://github.com/test/repo" <<<"$_stdin"
+	else
+		bash "$HOOK" origin "https://github.com/test/repo" <<<"$_stdin"
+	fi
+	return $?
+}
+
+_pass() {
+	local _name="$1"
+	printf '[PASS] %s\n' "$_name"
+	_TESTS_PASSED=$((_TESTS_PASSED + 1))
+	return 0
+}
+
+_fail() {
+	local _name="$1"
+	local _reason="$2"
+	printf '[FAIL] %s: %s\n' "$_name" "$_reason" >&2
+	_TESTS_FAILED=$((_TESTS_FAILED + 1))
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: Clean TODO.md (no duplicates) → exit 0
+# ---------------------------------------------------------------------------
+test_clean_no_duplicates() {
+	local _name="test_1_clean_no_duplicates"
+	_setup_git_repo || { _fail "$_name" "git repo setup failed"; return 0; }
+
+	local _content
+	_content="## Ready
+- [ ] t2740 Some task #auto-dispatch ref:GH#20470
+- [ ] t2741 Another task #auto-dispatch ref:GH#20471
+- [ ] t2742 Third task #auto-dispatch ref:GH#20472"
+
+	local _sha
+	_sha=$(_commit_todo "$_content")
+	_run_hook "$_sha" 2>/dev/null
+	local _rc=$?
+
+	_teardown_git_repo
+
+	if [[ "$_rc" -eq 0 ]]; then
+		_pass "$_name"
+	else
+		_fail "$_name" "expected exit 0, got exit $_rc"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: Single duplicate (t2743 appears twice) → exit 1, error cites lines
+# ---------------------------------------------------------------------------
+test_single_duplicate() {
+	local _name="test_2_single_duplicate"
+	_setup_git_repo || { _fail "$_name" "git repo setup failed"; return 0; }
+
+	local _content
+	_content="## Ready
+- [ ] t2743 Fix REST fallback in zsh context #auto-dispatch ref:GH#20480
+- [ ] t2744 Unrelated task ref:GH#20481
+
+## Backlog
+- [ ] t2743 Fix shared-gh-wrappers REST fallback to work in zsh #auto-dispatch #framework ref:GH#20480"
+
+	local _sha
+	_sha=$(_commit_todo "$_content")
+	local _stderr
+	_stderr=$(_run_hook "$_sha" 2>&1 1>/dev/null)
+	local _rc=$?
+
+	_teardown_git_repo
+
+	if [[ "$_rc" -ne 1 ]]; then
+		_fail "$_name" "expected exit 1 (duplicate found), got exit $_rc"
+		return 0
+	fi
+	if printf '%s\n' "$_stderr" | grep -q "t2743"; then
+		_pass "$_name"
+	else
+		_fail "$_name" "error message did not mention 't2743'; stderr: $_stderr"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: Multiple duplicates (t2743 AND t2742 both duplicated) → exit 1, cites both
+# ---------------------------------------------------------------------------
+test_multiple_duplicates() {
+	local _name="test_3_multiple_duplicates"
+	_setup_git_repo || { _fail "$_name" "git repo setup failed"; return 0; }
+
+	local _content
+	_content="## Ready
+- [ ] t2742 First task ref:GH#20478
+- [ ] t2743 Second task ref:GH#20480
+
+## Backlog
+- [ ] t2742 First task seeded by issue-sync ref:GH#20478
+- [ ] t2743 Second task seeded by issue-sync ref:GH#20480"
+
+	local _sha
+	_sha=$(_commit_todo "$_content")
+	local _stderr
+	_stderr=$(_run_hook "$_sha" 2>&1 1>/dev/null)
+	local _rc=$?
+
+	_teardown_git_repo
+
+	if [[ "$_rc" -ne 1 ]]; then
+		_fail "$_name" "expected exit 1 (duplicates found), got exit $_rc"
+		return 0
+	fi
+	local _mentions_t2742 _mentions_t2743
+	_mentions_t2742=$(printf '%s\n' "$_stderr" | grep -c "t2742" || true)
+	_mentions_t2743=$(printf '%s\n' "$_stderr" | grep -c "t2743" || true)
+	if [[ "$_mentions_t2742" -ge 1 && "$_mentions_t2743" -ge 1 ]]; then
+		_pass "$_name"
+	else
+		_fail "$_name" "error message missing t2742 or t2743; stderr: $_stderr"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: Completed + open pair (- [x] t2743 + - [ ] t2743) → exit 1
+# Must not silently allow mixed completed/open duplicates.
+# ---------------------------------------------------------------------------
+test_completed_and_open_pair() {
+	local _name="test_4_completed_and_open_pair"
+	_setup_git_repo || { _fail "$_name" "git repo setup failed"; return 0; }
+
+	local _content
+	_content="## Done
+- [x] t2743 Fix REST fallback pr:#20482 ref:GH#20480
+
+## Backlog
+- [ ] t2743 Fix shared-gh-wrappers REST fallback #auto-dispatch ref:GH#20480"
+
+	local _sha
+	_sha=$(_commit_todo "$_content")
+	_run_hook "$_sha" 2>/dev/null
+	local _rc=$?
+
+	_teardown_git_repo
+
+	if [[ "$_rc" -eq 1 ]]; then
+		_pass "$_name"
+	else
+		_fail "$_name" "expected exit 1 (completed+open pair is still a duplicate), got exit $_rc"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 5: Pseudo-duplicate (t2743 in description, not checkbox anchor) → exit 0
+# Line: "- [ ] t2744 Tests for t2743 ref:GH#..." should NOT be flagged.
+# ---------------------------------------------------------------------------
+test_pseudo_duplicate_in_description() {
+	local _name="test_5_pseudo_duplicate_in_description"
+	_setup_git_repo || { _fail "$_name" "git repo setup failed"; return 0; }
+
+	local _content
+	_content="## Ready
+- [ ] t2743 Fix REST fallback ref:GH#20480
+- [ ] t2744 Tests for t2743 coverage ref:GH#20481"
+
+	local _sha
+	_sha=$(_commit_todo "$_content")
+	_run_hook "$_sha" 2>/dev/null
+	local _rc=$?
+
+	_teardown_git_repo
+
+	if [[ "$_rc" -eq 0 ]]; then
+		_pass "$_name"
+	else
+		_fail "$_name" "expected exit 0 (t2743 in description only), got exit $_rc"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 6: AIDEVOPS_SKIP_DUP_TODO_GUARD=1 → exit 0 even with duplicates; warning to stderr
+# ---------------------------------------------------------------------------
+test_bypass_env_var() {
+	local _name="test_6_bypass_env_var"
+	_setup_git_repo || { _fail "$_name" "git repo setup failed"; return 0; }
+
+	local _content
+	_content="## Ready
+- [ ] t2743 First entry ref:GH#20480
+
+## Backlog
+- [ ] t2743 Second entry ref:GH#20480"
+
+	local _sha
+	_sha=$(_commit_todo "$_content")
+
+	# Capture both stdout and stderr; run with bypass env var
+	local _stderr
+	_stderr=$(AIDEVOPS_SKIP_DUP_TODO_GUARD=1 bash "$HOOK" origin "https://github.com/test/repo" \
+		<<<"refs/heads/test ${_sha} refs/heads/main 0000000000000000000000000000000000000000" \
+		2>&1 1>/dev/null)
+	local _rc=$?
+
+	_teardown_git_repo
+
+	if [[ "$_rc" -ne 0 ]]; then
+		_fail "$_name" "expected exit 0 with bypass env var, got exit $_rc"
+		return 0
+	fi
+	# Warning should appear in stderr
+	if printf '%s\n' "$_stderr" | grep -qi "bypass\|skip\|override"; then
+		_pass "$_name"
+	else
+		_fail "$_name" "expected bypass warning in stderr; stderr: $_stderr"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 7: --no-verify bypass (documentation / informational)
+# git push --no-verify does not invoke the hook at all — this is git's own
+# bypass mechanism and not testable at the hook script level. This test
+# documents the expected behaviour and verifies the hook has no special
+# handling that would interfere with --no-verify.
+# ---------------------------------------------------------------------------
+test_no_verify_documentation() {
+	local _name="test_7_no_verify_bypass_documented"
+	# The hook does not need to do anything special for --no-verify;
+	# git itself skips all pre-push hooks. Verify that the hook exits 0
+	# with empty stdin (simulating a no-op invocation), which is the
+	# closest unit-testable analogue.
+	local _rc
+	bash "$HOOK" origin "https://github.com/test/repo" </dev/null 2>/dev/null
+	_rc=$?
+	if [[ "$_rc" -eq 0 ]]; then
+		_pass "$_name"
+	else
+		_fail "$_name" "expected exit 0 with empty stdin (no refs to check), got exit $_rc"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Run all tests
+# ---------------------------------------------------------------------------
+main() {
+	printf 'Running pre-push-dup-todo-guard tests...\n\n'
+
+	test_clean_no_duplicates
+	test_single_duplicate
+	test_multiple_duplicates
+	test_completed_and_open_pair
+	test_pseudo_duplicate_in_description
+	test_bypass_env_var
+	test_no_verify_documentation
+
+	printf '\n'
+	printf 'Results: %d passed, %d failed\n' "$_TESTS_PASSED" "$_TESTS_FAILED"
+
+	if [[ "$_TESTS_FAILED" -gt 0 ]]; then
+		exit 1
+	fi
+	exit 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Added pre-push-dup-todo-guard.sh hook, registered it in install-pre-push-guards.sh as the 5th guard (dup-todo), documented in pre-push-guards.md, and added 7-fixture test suite. All tests pass, shellcheck clean.

## Files Changed

.agents/AGENTS.md,.agents/hooks/pre-push-dup-todo-guard.sh,.agents/reference/pre-push-guards.md,.agents/scripts/install-pre-push-guards.sh,.agents/scripts/tests/test-pre-push-dup-todo-guard.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/hooks/pre-push-dup-todo-guard.sh && bash .agents/scripts/tests/test-pre-push-dup-todo-guard.sh — all 7 fixtures pass

Resolves #20484


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.94 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 9m and 33,126 tokens on this as a headless worker.