### PR TITLE
GH#20487: suppress fatal: ambiguous argument origin/main via default-branch detection

### DIFF
--- a/.agents/scripts/pulse-canonical-maintenance.sh
+++ b/.agents/scripts/pulse-canonical-maintenance.sh
@@ -67,7 +67,29 @@ CANONICAL_MAINTENANCE_CADENCE="${CANONICAL_MAINTENANCE_CADENCE:-1800}"       # 3
 CANONICAL_MAINTENANCE_LAST_RUN="${CANONICAL_MAINTENANCE_LAST_RUN:-${HOME}/.aidevops/.agent-workspace/pulse-canonical-maintenance-last-run}"
 CANONICAL_MAINTENANCE_TIMEOUT="${CANONICAL_MAINTENANCE_TIMEOUT:-60}"         # 60s per-repo hard timeout
 CANONICAL_MAINTENANCE_CLAIM_STAMP_DIR="${CANONICAL_MAINTENANCE_CLAIM_STAMP_DIR:-${HOME}/.aidevops/.agent-workspace/interactive-claims}"
-CANONICAL_MAINTENANCE_DEFAULT_BRANCH="${CANONICAL_MAINTENANCE_DEFAULT_BRANCH:-main}"  # fallback when symbolic-ref fails
+
+# ---------------------------------------------------------------------------
+# _get_default_branch_for_repo
+#
+# Detect the default remote branch for a repo by reading the remote HEAD
+# symbolic ref. This avoids hardcoding "main" and prevents
+# `fatal: ambiguous argument 'origin/main'` errors on repos that use a
+# different default branch (master, develop, etc.) or that have not had
+# `git remote set-head origin --auto` run.
+#
+# Arguments: $1 - repo_path (absolute path to a git checkout)
+# Outputs: branch name (e.g. "main", "master") on stdout
+# Returns: 0 on success, 1 if the remote HEAD symbolic ref is not set
+#          (caller should skip and log instead of assuming a branch name)
+# ---------------------------------------------------------------------------
+_get_default_branch_for_repo() {
+	local repo_path="$1"
+	local default_ref
+	default_ref=$(git -C "$repo_path" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null) || return 1
+	[[ -n "$default_ref" ]] || return 1
+	printf '%s\n' "${default_ref#origin/}"
+	return 0
+}
 
 # ---------------------------------------------------------------------------
 # _canonical_maintenance_check_cadence
@@ -169,10 +191,16 @@ _canonical_ff_should_skip_repo() {
 		return 0
 	fi
 
-	# Skip if not on the default branch
+	# Skip if remote HEAD is not set — we cannot determine the default branch
+	# safely, so skip rather than assume "main" and risk a fatal: ambiguous
+	# argument error if origin/main does not exist in this repo.
 	local main_branch
-	main_branch=$(git -C "$repo_path" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||') || main_branch="$CANONICAL_MAINTENANCE_DEFAULT_BRANCH"
-	[[ -z "$main_branch" ]] && main_branch="$CANONICAL_MAINTENANCE_DEFAULT_BRANCH"
+	if ! main_branch=$(_get_default_branch_for_repo "$repo_path"); then
+		echo "[pulse-canonical-maintenance] Skipping ${repo_path} — no origin/HEAD set (run 'git remote set-head origin --auto')" >>"${LOGFILE:-/dev/null}"
+		return 0
+	fi
+
+	# Skip if not on the default branch
 	local current_branch
 	current_branch=$(git -C "$repo_path" branch --show-current 2>/dev/null) || current_branch=""
 	if [[ "$current_branch" != "$main_branch" ]]; then
@@ -195,10 +223,12 @@ _canonical_ff_single_repo() {
 	local repo_path="$1"
 	local dry_run="$2"
 
-	# Determine default branch
+	# Determine default branch — skip rather than assume if origin/HEAD is not set.
 	local main_branch
-	main_branch=$(git -C "$repo_path" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||') || main_branch="$CANONICAL_MAINTENANCE_DEFAULT_BRANCH"
-	[[ -z "$main_branch" ]] && main_branch="$CANONICAL_MAINTENANCE_DEFAULT_BRANCH"
+	if ! main_branch=$(_get_default_branch_for_repo "$repo_path"); then
+		echo "[pulse-canonical-maintenance] Skipping ${repo_path} — no origin/HEAD set" >>"${LOGFILE:-/dev/null}"
+		return 1
+	fi
 
 	# Fetch origin
 	if [[ "$dry_run" == "1" ]]; then
@@ -208,6 +238,13 @@ _canonical_ff_single_repo() {
 			echo "[pulse-canonical-maintenance] Fetch failed/timed out for ${repo_path}" >>"${LOGFILE:-/dev/null}"
 			return 1
 		}
+		# Verify the remote ref exists after fetch — guard against repos where
+		# origin/<branch> was never fetched or the remote branch was renamed.
+		# Without this, rev-list below emits `fatal: ambiguous argument` to stderr.
+		if ! git -C "$repo_path" rev-parse --verify "origin/${main_branch}" >/dev/null 2>&1; then
+			echo "[pulse-canonical-maintenance] Skipping ${repo_path} — origin/${main_branch} not found after fetch" >>"${LOGFILE:-/dev/null}"
+			return 1
+		fi
 	fi
 
 	# Check commits behind

--- a/.agents/scripts/pulse-dirty-pr-sweep.sh
+++ b/.agents/scripts/pulse-dirty-pr-sweep.sh
@@ -137,6 +137,29 @@ _dps_now_epoch() {
 	date +%s
 }
 
+# ---------------------------------------------------------------------------
+# _dps_get_default_branch
+#
+# Detect the default remote branch for a repo by reading the remote HEAD
+# symbolic ref. Avoids hardcoding "main" and prevents
+# `fatal: ambiguous argument 'origin/main'` errors on repos that use a
+# different default branch (master, develop, etc.) or that have not had
+# `git remote set-head origin --auto` run.
+#
+# Arguments: $1 - repo_path (absolute path to a git checkout)
+# Outputs: branch name (e.g. "main", "master") on stdout
+# Returns: 0 on success, 1 if the remote HEAD symbolic ref is not set
+#          (caller should skip rather than assume a branch name)
+# ---------------------------------------------------------------------------
+_dps_get_default_branch() {
+	local repo_path="$1"
+	local default_ref
+	default_ref=$(git -C "$repo_path" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null) || return 1
+	[[ -n "$default_ref" ]] || return 1
+	printf '%s\n' "${default_ref#origin/}"
+	return 0
+}
+
 # Convert ISO8601 timestamp → epoch seconds. Returns "0" on parse error.
 # Bash 3.2 compatible (macOS default).
 _dps_iso_to_epoch() {
@@ -360,8 +383,17 @@ _dps_consider_rebase() {
 	[[ "$has_parent_task" -eq 0 ]] || return 0
 	[[ -n "$repo_path" && -d "$repo_path" ]] || return 0
 
+	# Detect the default branch dynamically to avoid `fatal: ambiguous argument
+	# 'origin/main'` on repos that use master, develop, or have no fetched HEAD.
+	local default_branch base_ref
+	if ! default_branch=$(_dps_get_default_branch "$repo_path"); then
+		_dps_log "Consider-rebase: skipping ${repo_path} — no origin/HEAD set (run 'git remote set-head origin --auto')"
+		return 0
+	fi
+	base_ref="origin/${default_branch}"
+
 	local conflicts non_planning
-	conflicts=$(_dps_conflicting_files "$repo_path" "$head_ref" "origin/main" 2>/dev/null) || conflicts=""
+	conflicts=$(_dps_conflicting_files "$repo_path" "$head_ref" "$base_ref" 2>/dev/null) || conflicts=""
 	[[ -n "$conflicts" ]] || return 0
 
 	# Strip planning-only files: TODO.md, todo/**, README.md.
@@ -580,6 +612,14 @@ _dirty_pr_action_rebase() {
 		return 1
 	fi
 
+	# Detect the default branch — skip rather than assume "main" to avoid
+	# `fatal: ambiguous argument 'origin/main'` on non-main repos.
+	local default_branch
+	if ! default_branch=$(_dps_get_default_branch "$repo_path"); then
+		_dps_log "PR #$pr_number ($repo_slug): rebase skipped — no origin/HEAD set (run 'git remote set-head origin --auto')"
+		return 1
+	fi
+
 	# Ephemeral worktree for this rebase attempt. We use a throwaway directory
 	# under /tmp so we never interfere with real worktrees or the user's
 	# active branches. Cleanup is always attempted.
@@ -592,8 +632,8 @@ _dirty_pr_action_rebase() {
 	ephemeral_branch_ts=$(date +%s)
 	local ephemeral_branch="dirty-pr-sweep/pr-${pr_number}-${ephemeral_branch_ts}"
 
-	# Refresh origin/main and origin/<head_ref> before anything else.
-	git -C "$repo_path" fetch --quiet origin "main:refs/remotes/origin/main" 2>/dev/null || true
+	# Refresh origin/<default_branch> and origin/<head_ref> before anything else.
+	git -C "$repo_path" fetch --quiet origin "${default_branch}:refs/remotes/origin/${default_branch}" 2>/dev/null || true
 	git -C "$repo_path" fetch --quiet origin "${head_ref}:refs/remotes/origin/${head_ref}" 2>/dev/null || {
 		_dps_log "PR #$pr_number ($repo_slug): fetch of origin/${head_ref} failed — skipping rebase"
 		rm -rf "$ephemeral" 2>/dev/null || true
@@ -607,7 +647,7 @@ _dirty_pr_action_rebase() {
 	fi
 
 	local rebase_ok=1
-	if git -C "$ephemeral" rebase -X union origin/main >/dev/null 2>&1; then
+	if git -C "$ephemeral" rebase -X union "origin/${default_branch}" >/dev/null 2>&1; then
 		rebase_ok=0
 	else
 		git -C "$ephemeral" rebase --abort >/dev/null 2>&1 || true
@@ -634,7 +674,7 @@ _dirty_pr_action_rebase() {
 	fi
 
 	local comment_body
-	comment_body="**Auto-rebase**: this PR was DIRTY with only \`TODO.md\` conflicting, so the pulse rebased it onto \`origin/main\` with the \`union\` merge strategy and force-pushed.
+	comment_body="**Auto-rebase**: this PR was DIRTY with only \`TODO.md\` conflicting, so the pulse rebased it onto \`origin/${default_branch}\` with the \`union\` merge strategy and force-pushed.
 
 - If CI now passes, the merge pass will take it from here.
 - If this rebase was wrong, revert with \`git push --force-with-lease origin ${head_ref}\` from your local copy.
@@ -729,12 +769,12 @@ _dirty_pr_action_notify() {
 	fi
 
 	local comment_body
-	comment_body="**Maintainer review needed**: this PR is \`DIRTY\` (merge conflicts with \`main\`) and does not meet the auto-rebase or auto-close criteria.
+	comment_body="**Maintainer review needed**: this PR is \`DIRTY\` (merge conflicts with the default branch) and does not meet the auto-rebase or auto-close criteria.
 
 Reason: \`${reason}\`
 
 Options:
-- Rebase manually: \`git fetch origin && git rebase origin/main\` (or \`--strategy-option=union\` when TODO.md is the culprit).
+- Rebase manually: \`git fetch origin && git rebase origin/\$(git symbolic-ref --short refs/remotes/origin/HEAD | sed 's|origin/||')\` (or \`--strategy-option=union\` when TODO.md is the culprit).
 - Close as superseded: \`gh pr close ${pr_number} --delete-branch\`.
 - Opt out of future sweeps: add the \`do-not-close\` label.
 

--- a/.agents/scripts/tests/test-dirty-pr-sweep.sh
+++ b/.agents/scripts/tests/test-dirty-pr-sweep.sh
@@ -136,6 +136,8 @@ setup_repo_with_todo_conflict() {
 		printf '# base\nmain-side\n' >TODO.md
 		git add TODO.md && git commit -qm "main: add main-side"
 		git update-ref refs/remotes/origin/main main
+		# Set origin/HEAD so _dps_get_default_branch can resolve "main".
+		git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main
 		# Feature branch diverges from the base commit.
 		git checkout -qb feature/todo-conflict HEAD~1
 		printf '# base\nfeature-side\n' >TODO.md
@@ -194,6 +196,8 @@ setup_repo_with_nontodo_conflict() {
 		printf 'main-side-code\n' >src.sh
 		git add src.sh && git commit -qm "main: modify"
 		git update-ref refs/remotes/origin/main main
+		# Set origin/HEAD so _dps_get_default_branch can resolve "main".
+		git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main
 		git checkout -qb feature/code-conflict HEAD~1
 		printf 'feature-side-code\n' >src.sh
 		git add src.sh && git commit -qm "feature: modify"

--- a/.agents/scripts/tests/test-pulse-default-branch-detection.sh
+++ b/.agents/scripts/tests/test-pulse-default-branch-detection.sh
@@ -1,0 +1,359 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-pulse-default-branch-detection.sh — GH#20487 regression guard.
+#
+# Asserts that pulse-canonical-maintenance.sh and pulse-dirty-pr-sweep.sh
+# suppress `fatal: ambiguous argument 'origin/main'` errors and behave
+# correctly when operating on:
+#
+#   1. A repo with origin/HEAD pointing to "main" (standard case, unchanged).
+#   2. A repo with origin/HEAD pointing to "master" (non-main default branch).
+#   3. A repo without origin/HEAD set at all (no symbolic ref).
+#
+# Coverage:
+#   - _get_default_branch_for_repo detects "main" and "master" correctly.
+#   - _get_default_branch_for_repo returns 1 (failure) when no origin/HEAD set.
+#   - _canonical_ff_should_skip_repo skips repos with no origin/HEAD (logs reason).
+#   - _canonical_ff_single_repo skips repos with no origin/HEAD (logs reason).
+#   - _dps_get_default_branch detects branches correctly and fails gracefully.
+#   - _canonical_fast_forward produces no `fatal:` lines in stderr for
+#     repos without origin/HEAD.
+#   - _canonical_fast_forward successfully fast-forwards a "master"-branch repo.
+
+set -uo pipefail
+
+TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_RED=$'\033[0;31m'
+TEST_GREEN=$'\033[0;32m'
+TEST_RESET=$'\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1" rc="$2" extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf '%sPASS%s %s\n' "$TEST_GREEN" "$TEST_RESET" "$name"
+	else
+		printf '%sFAIL%s %s %s\n' "$TEST_RED" "$TEST_RESET" "$name" "$extra"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+# Sandbox
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+export HOME="${TEST_ROOT}/home"
+mkdir -p "${HOME}/.aidevops/logs" "${HOME}/.aidevops/.agent-workspace" \
+	"${HOME}/.config/aidevops"
+
+# Minimal LOGFILE for the module
+export LOGFILE="${TEST_ROOT}/test.log"
+touch "$LOGFILE"
+
+# SCRIPT_DIR expected by the module
+export SCRIPT_DIR="$TEST_SCRIPTS_DIR"
+
+# Disable commit signing for test repos (avoids SSH passphrase prompts)
+export GIT_CONFIG_NOSYSTEM=1
+export GIT_AUTHOR_NAME="Test"
+export GIT_AUTHOR_EMAIL="test@example.com"
+export GIT_COMMITTER_NAME="Test"
+export GIT_COMMITTER_EMAIL="test@example.com"
+git config --global commit.gpgsign false 2>/dev/null || true
+git config --global tag.gpgsign false 2>/dev/null || true
+
+# ---------------------------------------------------------------------------
+# Helper: create a bare origin + working clone on a given default branch name.
+# Args: $1 - default_branch_name (e.g. "main", "master")
+#       $2 - set_head ("1" to run git remote set-head, "0" to skip)
+# Output: clone directory path
+# ---------------------------------------------------------------------------
+_setup_repo_with_branch() {
+	local branch_name="$1"
+	local set_head="${2:-1}"
+	local bare_dir="${TEST_ROOT}/origin-${branch_name}.git"
+	local clone_dir="${TEST_ROOT}/repo-${branch_name}"
+
+	rm -rf "$bare_dir" "$clone_dir" 2>/dev/null || true
+
+	git init --bare "$bare_dir" >/dev/null 2>&1
+	git clone "$bare_dir" "$clone_dir" >/dev/null 2>&1
+	(
+		cd "$clone_dir" || exit 1
+		git checkout -b "$branch_name" >/dev/null 2>&1
+		echo "initial" >file.txt
+		git add file.txt
+		git commit -m "initial commit" >/dev/null 2>&1
+		git push -u origin "$branch_name" >/dev/null 2>&1
+		if [[ "$set_head" == "1" ]]; then
+			git remote set-head origin "$branch_name" >/dev/null 2>&1
+		fi
+	)
+
+	echo "$clone_dir"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Helper: push a new commit to the bare origin.
+# Args: $1 - branch_name, $2 - clone_dir
+# ---------------------------------------------------------------------------
+_push_new_commit() {
+	local branch_name="$1"
+	local clone_dir="$2"
+	local tmp_clone="${TEST_ROOT}/tmp-push-${branch_name}"
+
+	rm -rf "$tmp_clone" 2>/dev/null || true
+	local bare_dir="${TEST_ROOT}/origin-${branch_name}.git"
+	git clone "$bare_dir" "$tmp_clone" >/dev/null 2>&1
+	(
+		cd "$tmp_clone" || exit 1
+		git checkout "$branch_name" >/dev/null 2>&1
+		echo "new content $(date +%s)" >newfile.txt
+		git add newfile.txt
+		git commit -m "new commit from origin" >/dev/null 2>&1
+		git push origin "$branch_name" >/dev/null 2>&1
+	)
+	rm -rf "$tmp_clone" 2>/dev/null || true
+	return 0
+}
+
+# Source shared-constants.sh then the modules under test.
+# shellcheck source=/dev/null
+source "${TEST_SCRIPTS_DIR}/shared-constants.sh" 2>/dev/null || true
+set +e
+
+# shellcheck source=/dev/null
+source "${TEST_SCRIPTS_DIR}/pulse-canonical-maintenance.sh" 2>/dev/null || true
+
+# shellcheck source=/dev/null
+source "${TEST_SCRIPTS_DIR}/pulse-dirty-pr-sweep.sh" 2>/dev/null || true
+
+# =============================================================================
+# Test 1: _get_default_branch_for_repo detects "main"
+# =============================================================================
+test_detect_main_branch() {
+	local clone_dir
+	clone_dir=$(_setup_repo_with_branch "main" "1")
+
+	local detected
+	detected=$(_get_default_branch_for_repo "$clone_dir")
+	if [[ "$detected" == "main" ]]; then
+		print_result "get-default-branch-main" 0
+	else
+		print_result "get-default-branch-main" 1 "(expected 'main', got '${detected}')"
+	fi
+	return 0
+}
+
+# =============================================================================
+# Test 2: _get_default_branch_for_repo detects "master"
+# =============================================================================
+test_detect_master_branch() {
+	local clone_dir
+	clone_dir=$(_setup_repo_with_branch "master" "1")
+
+	local detected
+	detected=$(_get_default_branch_for_repo "$clone_dir")
+	if [[ "$detected" == "master" ]]; then
+		print_result "get-default-branch-master" 0
+	else
+		print_result "get-default-branch-master" 1 "(expected 'master', got '${detected}')"
+	fi
+	return 0
+}
+
+# =============================================================================
+# Test 3: _get_default_branch_for_repo returns 1 when no origin/HEAD set
+# =============================================================================
+test_no_origin_head_returns_failure() {
+	local clone_dir
+	clone_dir=$(_setup_repo_with_branch "main" "0")  # skip set-head
+
+	if _get_default_branch_for_repo "$clone_dir" 2>/dev/null; then
+		print_result "get-default-branch-no-head" 1 "(expected return 1, got 0)"
+	else
+		print_result "get-default-branch-no-head" 0
+	fi
+	return 0
+}
+
+# =============================================================================
+# Test 4: _canonical_ff_should_skip_repo skips when no origin/HEAD
+# =============================================================================
+test_canonical_skip_no_origin_head() {
+	local clone_dir
+	clone_dir=$(_setup_repo_with_branch "main" "0")  # skip set-head
+
+	true >"$LOGFILE"
+	_canonical_ff_should_skip_repo "$clone_dir"
+	local rc=$?
+
+	if [[ "$rc" -eq 0 ]] && grep -q "no origin/HEAD set" "$LOGFILE"; then
+		print_result "canonical-skip-no-origin-head" 0
+	else
+		print_result "canonical-skip-no-origin-head" 1 "(rc=${rc}, log: $(cat "$LOGFILE"))"
+	fi
+	return 0
+}
+
+# =============================================================================
+# Test 5: _canonical_ff_single_repo skips when no origin/HEAD
+# =============================================================================
+test_canonical_ff_single_skip_no_origin_head() {
+	local clone_dir
+	clone_dir=$(_setup_repo_with_branch "main" "0")  # skip set-head
+
+	true >"$LOGFILE"
+	_canonical_ff_single_repo "$clone_dir" "0"
+	local rc=$?
+
+	# Should return 1 (skip/failure) with a log message about no origin/HEAD
+	if [[ "$rc" -eq 1 ]] && grep -q "no origin/HEAD set" "$LOGFILE"; then
+		print_result "canonical-ff-single-skip-no-head" 0
+	else
+		print_result "canonical-ff-single-skip-no-head" 1 "(rc=${rc}, log: $(cat "$LOGFILE"))"
+	fi
+	return 0
+}
+
+# =============================================================================
+# Test 6: No `fatal:` lines in stderr when _canonical_fast_forward encounters
+#         a repo without origin/HEAD set (GH#20487 regression guard)
+# =============================================================================
+test_no_fatal_errors_without_origin_head() {
+	local clone_dir
+	clone_dir=$(_setup_repo_with_branch "main" "0")  # skip set-head
+
+	# Point repos.json at this repo
+	cat >"${HOME}/.config/aidevops/repos.json" <<EOF
+{"initialized_repos": [{"slug": "test/repo", "path": "${clone_dir}", "pulse": true}]}
+EOF
+	export REPOS_JSON="${HOME}/.config/aidevops/repos.json"
+
+	# Capture stderr separately to check for fatal errors
+	local stderr_file="${TEST_ROOT}/stderr.txt"
+	true >"$LOGFILE"
+	_canonical_fast_forward "0" 2>"$stderr_file"
+
+	if ! grep -q "^fatal:" "$stderr_file" 2>/dev/null; then
+		print_result "no-fatal-errors-without-origin-head" 0
+	else
+		print_result "no-fatal-errors-without-origin-head" 1 \
+			"(unexpected fatal errors: $(cat "$stderr_file"))"
+	fi
+	return 0
+}
+
+# =============================================================================
+# Test 7: _canonical_fast_forward succeeds for a "master"-branch repo
+# =============================================================================
+test_canonical_ff_master_branch() {
+	local clone_dir
+	clone_dir=$(_setup_repo_with_branch "master" "1")
+
+	# Push a new commit to origin
+	_push_new_commit "master" "$clone_dir"
+
+	# Point repos.json at this repo
+	cat >"${HOME}/.config/aidevops/repos.json" <<EOF
+{"initialized_repos": [{"slug": "test/repo", "path": "${clone_dir}", "pulse": true}]}
+EOF
+	export REPOS_JSON="${HOME}/.config/aidevops/repos.json"
+
+	# Reset cadence so it runs
+	export CANONICAL_MAINTENANCE_LAST_RUN="${TEST_ROOT}/last-run"
+	rm -f "$CANONICAL_MAINTENANCE_LAST_RUN"
+
+	true >"$LOGFILE"
+	_canonical_fast_forward "0"
+
+	if grep -q "Fast-forwarded" "$LOGFILE"; then
+		print_result "canonical-ff-master-branch" 0
+	else
+		print_result "canonical-ff-master-branch" 1 "(expected 'Fast-forwarded' in log, got: $(cat "$LOGFILE"))"
+	fi
+	return 0
+}
+
+# =============================================================================
+# Test 8: _dps_get_default_branch detects "main"
+# =============================================================================
+test_dps_detect_main() {
+	local clone_dir
+	clone_dir=$(_setup_repo_with_branch "main" "1")
+
+	local detected
+	detected=$(_dps_get_default_branch "$clone_dir")
+	if [[ "$detected" == "main" ]]; then
+		print_result "dps-get-default-branch-main" 0
+	else
+		print_result "dps-get-default-branch-main" 1 "(expected 'main', got '${detected}')"
+	fi
+	return 0
+}
+
+# =============================================================================
+# Test 9: _dps_get_default_branch detects "master"
+# =============================================================================
+test_dps_detect_master() {
+	local clone_dir
+	clone_dir=$(_setup_repo_with_branch "master" "1")
+
+	local detected
+	detected=$(_dps_get_default_branch "$clone_dir")
+	if [[ "$detected" == "master" ]]; then
+		print_result "dps-get-default-branch-master" 0
+	else
+		print_result "dps-get-default-branch-master" 1 "(expected 'master', got '${detected}')"
+	fi
+	return 0
+}
+
+# =============================================================================
+# Test 10: _dps_get_default_branch returns 1 when no origin/HEAD set
+# =============================================================================
+test_dps_no_origin_head_returns_failure() {
+	local clone_dir
+	clone_dir=$(_setup_repo_with_branch "main" "0")  # skip set-head
+
+	if _dps_get_default_branch "$clone_dir" 2>/dev/null; then
+		print_result "dps-get-default-branch-no-head" 1 "(expected return 1, got 0)"
+	else
+		print_result "dps-get-default-branch-no-head" 0
+	fi
+	return 0
+}
+
+# =============================================================================
+# Run all tests
+# =============================================================================
+test_detect_main_branch
+test_detect_master_branch
+test_no_origin_head_returns_failure
+test_canonical_skip_no_origin_head
+test_canonical_ff_single_skip_no_origin_head
+test_no_fatal_errors_without_origin_head
+test_canonical_ff_master_branch
+test_dps_detect_main
+test_dps_detect_master
+test_dps_no_origin_head_returns_failure
+
+# =============================================================================
+# Summary
+# =============================================================================
+echo ""
+echo "============================="
+echo "Tests run: ${TESTS_RUN}"
+echo "Tests failed: ${TESTS_FAILED}"
+echo "============================="
+
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

- Suppresses `fatal: ambiguous argument 'origin/main'` errors emitted by `pulse-canonical-maintenance.sh` and `pulse-dirty-pr-sweep.sh` when operating on repos without a fetched `origin/main` ref or using a non-`main` default branch (`master`, `develop`, etc.)
- Replaces hardcoded `origin/main` with dynamic detection via `git symbolic-ref --short refs/remotes/origin/HEAD`; when no HEAD is set, repos are skipped with a single-line debug log
- Adds a post-fetch `rev-parse` guard in `_canonical_ff_single_repo` to prevent `fatal:` errors even if the fetch succeeds but the ref is absent
- New test `test-pulse-default-branch-detection.sh` (10 tests) covers main/master detection, no-origin/HEAD skip, zero `fatal:` lines in stderr, and successful fast-forward of a `master`-branch repo

## Files changed

- `EDIT: .agents/scripts/pulse-canonical-maintenance.sh` — add `_get_default_branch_for_repo()`, update `_canonical_ff_should_skip_repo` and `_canonical_ff_single_repo`
- `EDIT: .agents/scripts/pulse-dirty-pr-sweep.sh` — add `_dps_get_default_branch()`, update `_dps_consider_rebase` and `_dirty_pr_action_rebase`; update `test-dirty-pr-sweep.sh` setup helpers to set `refs/remotes/origin/HEAD`
- `NEW: .agents/scripts/tests/test-pulse-default-branch-detection.sh` — 10 regression tests for default-branch detection behavior

## Verification

- `shellcheck` zero violations on all 4 modified files
- `test-pulse-default-branch-detection.sh`: 10/10 PASS
- `test-pulse-canonical-maintenance.sh`: 9/10 PASS (1 pre-existing failure: `skip-on-session-active`, unrelated to this PR)
- `test-dirty-pr-sweep.sh`: 18/18 PASS (fixed test setup to call `git symbolic-ref refs/remotes/origin/HEAD`)

Resolves #20487
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.94 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 10m and 35,372 tokens on this as a headless worker.
