### PR TITLE
GH#20488: feat: add 'labeled' trigger to maintainer-gate.yml pull_request_target

### DIFF
--- a/.github/workflows/maintainer-gate.yml
+++ b/.github/workflows/maintainer-gate.yml
@@ -27,7 +27,7 @@ name: Maintainer Gate
 
 on:
   pull_request_target:
-    types: [opened, synchronize, reopened, edited, unlabeled]
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
   issues:
     types: [unlabeled, labeled, assigned, unassigned]
 


### PR DESCRIPTION
## Summary

Added 'labeled' to pull_request_target.types array in maintainer-gate.yml so that applying labels after PR creation re-triggers the gate evaluation. This fixes the failure mode where origin:interactive labels applied post-creation would not trigger re-evaluation without an --edit-body workaround.

## Files Changed

.github/workflows/maintainer-gate.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** actionlint validation passed; workflow syntax is valid

Resolves #20488


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.94 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-haiku-4-5 spent 41s and 1,300 tokens on this as a headless worker.