### PR TITLE
GH#20489: add actionlint pre-commit check for .github/workflows/*.yml

### DIFF
--- a/.agents/scripts/lint-workflows-helper.sh
+++ b/.agents/scripts/lint-workflows-helper.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# lint-workflows-helper.sh — validate .github/workflows/*.yml files.
+#
+# Issue: GH#20489
+# Background: A one-extra-leading-space regression in maintainer-gate.yml
+# (t2691 / PR #20311) caused silent YAML parse failures that broke the
+# Maintainer Review & Assignee Gate framework-wide for ~24 hours.
+#
+# Usage (standalone):
+#   lint-workflows-helper.sh [--staged] [FILE...]
+#
+#   --staged   lint only files staged for the current git commit
+#   FILE...    explicit files to lint (default: all .github/workflows/*.yml)
+#
+# Exit codes:
+#   0 — all checked files are valid
+#   1 — one or more files have errors
+#   2 — no workflow files found / nothing to check (treated as pass)
+#
+# Tool priority (first found wins):
+#   1. actionlint   — full semantic + YAML validation
+#   2. yamllint     — YAML-only structural validation
+#   3. python3 yaml — bare YAML parse (lowest fidelity, always available)
+#
+# Bypass: git commit --no-verify  (standard pre-commit convention)
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+# shellcheck disable=SC1091
+if [[ -f "${SCRIPT_DIR}/shared-constants.sh" ]]; then
+	source "${SCRIPT_DIR}/shared-constants.sh"
+else
+	# Colour fallbacks when sourced in isolation (e.g. direct CLI invocation
+	# before shared-constants.sh has been deployed alongside).
+	[[ -z "${RED+x}" ]]    && RED='\033[0;31m'
+	[[ -z "${GREEN+x}" ]]  && GREEN='\033[0;32m'
+	[[ -z "${YELLOW+x}" ]] && YELLOW='\033[1;33m'
+	[[ -z "${BLUE+x}" ]]   && BLUE='\033[0;34m'
+	[[ -z "${NC+x}" ]]     && NC='\033[0m'
+
+	print_error()   { printf '%b[workflow-lint-error]%b %s\n' "${RED}"    "${NC}" "$*" >&2; return 0; }
+	print_warning() { printf '%b[workflow-lint-warn]%b  %s\n' "${YELLOW}" "${NC}" "$*" >&2; return 0; }
+	print_info()    { printf '%b[workflow-lint]%b %s\n'        "${BLUE}"   "${NC}" "$*" >&2; return 0; }
+	print_success() { printf '%b[workflow-lint]%b %s\n'        "${GREEN}"  "${NC}" "$*" >&2; return 0; }
+fi
+
+# ---------------------------------------------------------------------------
+# Tool detection (cached in variables, evaluated once at startup)
+# ---------------------------------------------------------------------------
+_LINT_TOOL=""
+_LINT_TOOL_VERSION=""
+
+_detect_lint_tool() {
+	if command -v actionlint &>/dev/null; then
+		_LINT_TOOL="actionlint"
+		_LINT_TOOL_VERSION=$(actionlint --version 2>/dev/null || echo "unknown")
+	elif command -v yamllint &>/dev/null; then
+		_LINT_TOOL="yamllint"
+		_LINT_TOOL_VERSION=$(yamllint --version 2>/dev/null || echo "unknown")
+	elif python3 -c "import yaml" &>/dev/null; then
+		_LINT_TOOL="python3-yaml"
+		_LINT_TOOL_VERSION=$(python3 --version 2>/dev/null || echo "unknown")
+	else
+		_LINT_TOOL="none"
+		_LINT_TOOL_VERSION="n/a"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Per-file linters
+# ---------------------------------------------------------------------------
+
+# Run actionlint on a single file.
+# Output: actionlint findings on stderr, exit 1 on error.
+_lint_with_actionlint() {
+	local file="$1"
+	# actionlint -format wraps output cleanly; no -oneline needed for file:line.
+	# We run with shellcheck disabled to avoid false positives from inline shell
+	# expressions in workflow run: blocks — those are validated by shellcheck
+	# separately via pre-commit-hook.sh.
+	actionlint -shellcheck="" "$file" 2>&1
+	return $?
+}
+
+# Run yamllint on a single file.
+# Output: yamllint findings on stderr, exit 1 on error.
+_lint_with_yamllint() {
+	local file="$1"
+	# -d relaxed: GitHub Actions files intentionally use long lines, missing
+	# document-start markers, etc. We only want structural errors.
+	yamllint -d "{extends: relaxed, rules: {line-length: disable, document-start: disable}}" "$file" 2>&1
+	return $?
+}
+
+# Run python3 yaml.safe_load on a single file (bare parse-error detection).
+# Output: parse errors on stderr, exit 1 on error.
+_lint_with_python_yaml() {
+	local file="$1"
+	python3 -c "
+import sys, yaml
+try:
+    with open(sys.argv[1]) as f:
+        yaml.safe_load(f)
+except yaml.YAMLError as e:
+    print(f'{sys.argv[1]}: YAML parse error: {e}', file=sys.stderr)
+    sys.exit(1)
+" "$file" 2>&1
+	return $?
+}
+
+# ---------------------------------------------------------------------------
+# Core lint dispatcher
+# ---------------------------------------------------------------------------
+
+# Lint a single workflow file with the best available tool.
+# Returns: 0=valid, 1=errors found
+_lint_file() {
+	local file="$1"
+	local exit_code=0
+
+	case "$_LINT_TOOL" in
+	actionlint)
+		if ! _lint_with_actionlint "$file"; then
+			exit_code=1
+		fi
+		;;
+	yamllint)
+		if ! _lint_with_yamllint "$file"; then
+			exit_code=1
+		fi
+		;;
+	python3-yaml)
+		if ! _lint_with_python_yaml "$file"; then
+			exit_code=1
+		fi
+		;;
+	none)
+		# No tool available — warn and pass (degrade gracefully).
+		print_warning "No workflow linter available (actionlint/yamllint/python3-yaml)."
+		print_warning "Install actionlint for full validation: brew install actionlint"
+		return 0
+		;;
+	esac
+
+	return $exit_code
+}
+
+# ---------------------------------------------------------------------------
+# File collection helpers
+# ---------------------------------------------------------------------------
+
+# Collect staged .github/workflows/*.yml files from git index.
+_get_staged_workflow_files() {
+	git diff --cached --name-only --diff-filter=ACM 2>/dev/null \
+		| grep -E '^\.github/workflows/[^/]+\.ya?ml$' \
+		|| true
+	return 0
+}
+
+# Collect all .github/workflows/*.yml files in the repo.
+_get_all_workflow_files() {
+	git ls-files '.github/workflows/*.yml' '.github/workflows/*.yaml' 2>/dev/null \
+		|| find .github/workflows -maxdepth 1 -name '*.yml' -o -name '*.yaml' 2>/dev/null \
+		|| true
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+# lint_workflows [--staged] [FILE...]
+#
+# Main entry point. Returns 0 on success, 1 on lint failures.
+lint_workflows() {
+	local staged_only=0
+	local explicit_files=()
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--staged)
+			staged_only=1
+			shift
+			;;
+		--)
+			shift
+			explicit_files+=("$@")
+			break
+			;;
+		-*)
+			print_error "Unknown option: $1"
+			return 1
+			;;
+		*)
+			explicit_files+=("$1")
+			shift
+			;;
+		esac
+	done
+
+	_detect_lint_tool
+
+	# Determine file list
+	local files_to_lint=()
+	if [[ ${#explicit_files[@]} -gt 0 ]]; then
+		files_to_lint=("${explicit_files[@]}")
+	elif [[ "$staged_only" -eq 1 ]]; then
+		while IFS= read -r f; do
+			[[ -n "$f" ]] && files_to_lint+=("$f")
+		done < <(_get_staged_workflow_files)
+	else
+		while IFS= read -r f; do
+			[[ -n "$f" ]] && files_to_lint+=("$f")
+		done < <(_get_all_workflow_files)
+	fi
+
+	if [[ ${#files_to_lint[@]} -eq 0 ]]; then
+		# Nothing to check — not an error
+		return 0
+	fi
+
+	print_info "Linting ${#files_to_lint[@]} workflow file(s) with $_LINT_TOOL..."
+
+	local total_errors=0
+	local failed_files=()
+
+	for wf_file in "${files_to_lint[@]}"; do
+		if [[ ! -f "$wf_file" ]]; then
+			print_warning "Skipping missing file: $wf_file"
+			continue
+		fi
+
+		local lint_output exit_val
+		exit_val=0
+		lint_output=$(_lint_file "$wf_file" 2>&1) || exit_val=$?
+
+		if [[ $exit_val -ne 0 ]]; then
+			print_error "Workflow lint FAILED: $wf_file"
+			# Re-emit the linter output with context prefix
+			while IFS= read -r line; do
+				[[ -n "$line" ]] && printf '  %s\n' "$line" >&2
+			done <<< "$lint_output"
+			failed_files+=("$wf_file")
+			((++total_errors))
+		fi
+	done
+
+	if [[ $total_errors -eq 0 ]]; then
+		print_success "All ${#files_to_lint[@]} workflow file(s) are valid."
+		return 0
+	fi
+
+	print_error ""
+	print_error "$total_errors workflow file(s) failed linting:"
+	for f in "${failed_files[@]}"; do
+		print_error "  - $f"
+	done
+	print_error ""
+	print_error "Fix the YAML errors before committing."
+	print_error "Use 'git commit --no-verify' to bypass (not recommended)."
+	return 1
+}
+
+# ---------------------------------------------------------------------------
+# CLI entry point (when invoked directly, not sourced)
+# ---------------------------------------------------------------------------
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+	lint_workflows "$@"
+fi

--- a/.agents/scripts/pre-commit-hook.sh
+++ b/.agents/scripts/pre-commit-hook.sh
@@ -805,6 +805,50 @@ validate_repo_root_files() {
 	return 0
 }
 
+# --- Workflow YAML validation (GH#20489) ---
+# Run lint-workflows-helper.sh on staged .github/workflows/*.yml files.
+# Catches YAML parse errors and actionlint semantic errors before they ship
+# and silently break framework-wide CI gates (root cause: t2691 / PR #20311).
+#
+# Tool priority (handled inside the helper): actionlint > yamllint > python3 yaml.
+# Missing binary: helper warns and exits 0 (degrade gracefully, never block).
+
+check_workflow_files() {
+	# Detect staged workflow files without shelling into the helper first —
+	# avoids an extra process when no workflow files are staged.
+	local staged_workflows
+	staged_workflows=$(git diff --cached --name-only --diff-filter=ACM \
+		| grep -E '^\.github/workflows/[^/]+\.ya?ml$' || true)
+
+	if [[ -z "$staged_workflows" ]]; then
+		return 0
+	fi
+
+	print_info "Checking staged GitHub Actions workflow files..."
+
+	# Locate the helper: prefer repo source (worktree), fall back to deployed copy.
+	local helper_path="${SCRIPT_DIR}/lint-workflows-helper.sh"
+	if [[ ! -f "$helper_path" ]]; then
+		helper_path="$HOME/.aidevops/agents/scripts/lint-workflows-helper.sh"
+	fi
+
+	if [[ ! -f "$helper_path" ]]; then
+		print_warning "lint-workflows-helper.sh not found — skipping workflow YAML check"
+		return 0
+	fi
+
+	# Pass --staged so the helper reads exactly the same staged file list.
+	if bash "$helper_path" --staged; then
+		return 0
+	fi
+
+	# Helper returned non-zero: YAML errors found.
+	print_error "Commit blocked: workflow YAML error(s) detected."
+	print_info "Fix the issues above, then retry commit."
+	print_info "Bypass (not recommended): git commit --no-verify"
+	return 1
+}
+
 # --- Split hook entry points (t2207) ---
 # pre-commit: fast local checks only (target <5s)
 # pre-push:   slower network-dependent checks (secretlint, SonarCloud, CodeRabbit)
@@ -838,6 +882,11 @@ main_pre_commit() {
 
 	validate_repo_root_files || {
 		print_error "Commit rejected: new repo root files not in allowlist"
+		exit 1
+	}
+	echo "" >&2
+
+	check_workflow_files || {
 		exit 1
 	}
 	echo "" >&2

--- a/.agents/scripts/tests/test-lint-workflows-helper.sh
+++ b/.agents/scripts/tests/test-lint-workflows-helper.sh
@@ -1,0 +1,347 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-lint-workflows-helper.sh — Integration tests for lint-workflows-helper.sh
+#
+# Issue: GH#20489
+#
+# Scenarios covered:
+#   1. Broken YAML (extra leading space → indentation error) → lint FAILS
+#   2. Valid workflow YAML → lint PASSES
+#   3. No staged workflow files → lint skipped (pass)
+#   4. Non-workflow YAML file staged (e.g. .github/other.yml) → not checked
+#   5. check_workflow_files() in pre-commit-hook.sh blocks on invalid YAML
+#   6. check_workflow_files() passes on valid YAML
+#
+# Strategy: Each scenario creates an ephemeral git repo, commits a base state,
+# stages the scenario content, then invokes the linter directly (sourcing the
+# helper) to test return values and stderr output.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+HELPER="${SCRIPT_DIR}/../lint-workflows-helper.sh"
+HOOK="${SCRIPT_DIR}/../pre-commit-hook.sh"
+
+if [[ ! -f "$HELPER" ]]; then
+	echo "SKIP: lint-workflows-helper.sh not found at $HELPER" >&2
+	exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Test harness
+# ---------------------------------------------------------------------------
+
+readonly _T_GREEN='\033[0;32m'
+readonly _T_RED='\033[0;31m'
+readonly _T_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+ORIG_DIR="$(pwd)"
+
+_pass() {
+	local name="$1"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf '%bPASS%b %s\n' "$_T_GREEN" "$_T_RESET" "$name"
+	return 0
+}
+
+_fail() {
+	local name="$1"
+	local msg="${2:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '%bFAIL%b %s\n' "$_T_RED" "$_T_RESET" "$name"
+	[[ -n "$msg" ]] && printf '       %s\n' "$msg"
+	return 0
+}
+
+setup() {
+	TEST_ROOT=$(mktemp -d)
+	return 0
+}
+
+teardown() {
+	cd "$ORIG_DIR" || true
+	[[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]] && rm -rf "$TEST_ROOT"
+	return 0
+}
+
+# Create an ephemeral git repo under $TEST_ROOT/<name> and cd into it.
+# Sets REPO_DIR.
+# shellcheck disable=SC2034
+_init_repo() {
+	local name="$1"
+	REPO_DIR="${TEST_ROOT}/${name}"
+	mkdir -p "$REPO_DIR/.github/workflows"
+	cd "$REPO_DIR" || return 1
+	git init -q -b main
+	git config user.email "test@example.invalid"
+	git config user.name "Workflow Lint Test"
+	git config commit.gpgsign false
+	# Initial empty commit so HEAD exists
+	git commit -q --allow-empty -m "init" --no-verify
+	return 0
+}
+
+# Commit a workflow file with given content.
+_commit_workflow() {
+	local file="$1"
+	local content="$2"
+	mkdir -p "$(dirname "$file")"
+	printf '%s' "$content" >"$file"
+	git add "$file"
+	git commit -q -m "base: $file" --no-verify
+	return 0
+}
+
+# Stage a workflow file (no commit).
+_stage_workflow() {
+	local file="$1"
+	local content="$2"
+	mkdir -p "$(dirname "$file")"
+	printf '%s' "$content" >"$file"
+	git add "$file"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Workflow YAML fixtures
+# ---------------------------------------------------------------------------
+
+# A valid minimal GitHub Actions workflow.
+_VALID_WORKFLOW='name: CI
+on:
+  push:
+    branches: [main]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: echo "hello"
+'
+
+# An invalid workflow: extra leading space on the `name:` line causes
+# YAML to treat the entire document as a mapping-within-mapping, producing
+# a parse error. This is exactly the class of regression from t2691.
+_BROKEN_WORKFLOW='name: CI
+on:
+  push:
+    branches: [main]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+       - run: echo "broken indentation"
+'
+
+# A valid YAML file that lives outside .github/workflows — should not be checked.
+_OTHER_YAML='key: value
+nested:
+  field: data
+'
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+test_valid_workflow_passes() {
+	local name="test_valid_workflow_passes"
+	_init_repo "$name" || { _fail "$name" "repo init failed"; return 0; }
+
+	_stage_workflow ".github/workflows/ci.yml" "$_VALID_WORKFLOW"
+
+	local output exit_val
+	output=$(bash "$HELPER" --staged 2>&1)
+	exit_val=$?
+
+	if [[ $exit_val -eq 0 ]]; then
+		_pass "$name"
+	else
+		_fail "$name" "Expected exit 0 for valid workflow; got $exit_val. Output: $output"
+	fi
+
+	cd "$ORIG_DIR" || true
+	return 0
+}
+
+test_broken_yaml_fails() {
+	local name="test_broken_yaml_fails"
+	_init_repo "$name" || { _fail "$name" "repo init failed"; return 0; }
+
+	_stage_workflow ".github/workflows/ci.yml" "$_BROKEN_WORKFLOW"
+
+	local output exit_val
+	output=$(bash "$HELPER" --staged 2>&1)
+	exit_val=$?
+
+	if [[ $exit_val -ne 0 ]]; then
+		_pass "$name"
+	else
+		_fail "$name" "Expected non-zero exit for broken YAML; got $exit_val. Output: $output"
+	fi
+
+	cd "$ORIG_DIR" || true
+	return 0
+}
+
+test_no_staged_workflow_files_passes() {
+	local name="test_no_staged_workflow_files_passes"
+	_init_repo "$name" || { _fail "$name" "repo init failed"; return 0; }
+
+	# Stage a non-workflow file (e.g. a shell script)
+	printf '#!/usr/bin/env bash\necho hi\n' >"helper.sh"
+	git add helper.sh
+
+	local output exit_val
+	output=$(bash "$HELPER" --staged 2>&1)
+	exit_val=$?
+
+	if [[ $exit_val -eq 0 ]]; then
+		_pass "$name"
+	else
+		_fail "$name" "Expected exit 0 when no workflow files staged; got $exit_val. Output: $output"
+	fi
+
+	cd "$ORIG_DIR" || true
+	return 0
+}
+
+test_non_workflow_yaml_not_checked() {
+	local name="test_non_workflow_yaml_not_checked"
+	_init_repo "$name" || { _fail "$name" "repo init failed"; return 0; }
+
+	# Stage a YAML file that is NOT under .github/workflows
+	mkdir -p .github
+	printf '%s' "$_OTHER_YAML" >.github/other.yml
+	git add .github/other.yml
+
+	local output exit_val
+	output=$(bash "$HELPER" --staged 2>&1)
+	exit_val=$?
+
+	if [[ $exit_val -eq 0 ]]; then
+		_pass "$name"
+	else
+		_fail "$name" "Expected exit 0 for non-workflow YAML file; got $exit_val. Output: $output"
+	fi
+
+	cd "$ORIG_DIR" || true
+	return 0
+}
+
+test_previously_valid_broken_in_commit_fails() {
+	local name="test_previously_valid_broken_in_commit_fails"
+	_init_repo "$name" || { _fail "$name" "repo init failed"; return 0; }
+
+	# Start with a valid committed workflow
+	_commit_workflow ".github/workflows/ci.yml" "$_VALID_WORKFLOW"
+
+	# Now stage a broken version (regression introduced in this commit)
+	_stage_workflow ".github/workflows/ci.yml" "$_BROKEN_WORKFLOW"
+
+	local output exit_val
+	output=$(bash "$HELPER" --staged 2>&1)
+	exit_val=$?
+
+	if [[ $exit_val -ne 0 ]]; then
+		_pass "$name"
+	else
+		_fail "$name" "Expected non-zero exit for regression to broken YAML; got $exit_val. Output: $output"
+	fi
+
+	cd "$ORIG_DIR" || true
+	return 0
+}
+
+# Test that check_workflow_files() in pre-commit-hook.sh blocks on invalid YAML.
+# Strategy: set up a git repo with a broken workflow staged, then invoke the
+# helper directly with --staged (the same codepath check_workflow_files uses).
+# Full end-to-end hook sourcing is intentionally avoided — sourcing
+# pre-commit-hook.sh requires shared-constants.sh and a full git env.
+test_pre_commit_hook_blocks_on_broken_yaml() {
+	local name="test_pre_commit_hook_blocks_on_broken_yaml"
+	_init_repo "$name" || { _fail "$name" "repo init failed"; return 0; }
+
+	_stage_workflow ".github/workflows/ci.yml" "$_BROKEN_WORKFLOW"
+
+	# The helper is what check_workflow_files delegates to. Verifying it
+	# returns non-zero is equivalent to verifying the hook would block.
+	local output exit_val
+	output=$(bash "$HELPER" --staged 2>&1) || exit_val=$?
+	exit_val=${exit_val:-0}
+
+	if [[ $exit_val -ne 0 ]]; then
+		_pass "$name"
+	else
+		_fail "$name" "Expected non-zero exit (hook would block); got $exit_val. Output: $output"
+	fi
+
+	cd "$ORIG_DIR" || true
+	return 0
+}
+
+test_pre_commit_hook_passes_valid_workflow() {
+	local name="test_pre_commit_hook_passes_valid_workflow"
+
+	if [[ ! -f "$HOOK" ]]; then
+		_fail "$name" "pre-commit-hook.sh not found at $HOOK"
+		return 0
+	fi
+
+	_init_repo "$name" || { _fail "$name" "repo init failed"; return 0; }
+
+	local fake_script_dir="${REPO_DIR}/.agents/scripts"
+	mkdir -p "$fake_script_dir"
+	cp "$HELPER" "$fake_script_dir/lint-workflows-helper.sh"
+
+	_stage_workflow ".github/workflows/ci.yml" "$_VALID_WORKFLOW"
+
+	local output exit_val
+	output=$(bash "$HELPER" --staged 2>&1)
+	exit_val=$?
+
+	if [[ $exit_val -eq 0 ]]; then
+		_pass "$name"
+	else
+		_fail "$name" "Expected exit 0 for valid workflow; got $exit_val. Output: $output"
+	fi
+
+	cd "$ORIG_DIR" || true
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+	setup
+
+	echo "Running lint-workflows-helper tests..."
+	echo ""
+
+	test_valid_workflow_passes
+	test_broken_yaml_fails
+	test_no_staged_workflow_files_passes
+	test_non_workflow_yaml_not_checked
+	test_previously_valid_broken_in_commit_fails
+	test_pre_commit_hook_blocks_on_broken_yaml
+	test_pre_commit_hook_passes_valid_workflow
+
+	echo ""
+
+	if [[ $TESTS_FAILED -eq 0 ]]; then
+		printf '%bAll %d tests passed.%b\n' "$_T_GREEN" "$TESTS_RUN" "$_T_RESET"
+	else
+		printf '%b%d/%d tests FAILED.%b\n' "$_T_RED" "$TESTS_FAILED" "$TESTS_RUN" "$_T_RESET"
+	fi
+
+	teardown
+	return $TESTS_FAILED
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Adds `actionlint` (with `yamllint` / `python3 yaml.safe_load` fallbacks) to the pre-commit hook chain, so YAML parse errors and GitHub Actions semantic issues in `.github/workflows/*.yml` are caught locally before they ship and silently break framework-wide CI gates.

**Root cause context:** t2691 introduced a one-extra-leading-space indentation regression in `maintainer-gate.yml` that caused silent phantom failures, broke the framework-wide Maintainer Review & Assignee Gate, and required ~24h of manual diagnosis (PR #20311, PR #20483). This check would have caught it at commit time.

## Changes

### NEW: `.agents/scripts/lint-workflows-helper.sh`

Standalone linter wrapper:
- **Tool priority:** `actionlint` (semantic + YAML) → `yamllint` (YAML-only) → `python3 yaml.safe_load` (bare parse)
- Degrades gracefully when no tool is available (warn, exit 0)
- Supports `--staged` mode (for pre-commit path) and `FILE...` mode (standalone CLI)
- Reports `file:line` context from actionlint output

### EDIT: `.agents/scripts/pre-commit-hook.sh`

- Adds `check_workflow_files()` function that detects staged `.github/workflows/*.yml` files and delegates to the helper via `--staged`
- No-op when no workflow files are staged (zero overhead on unrelated commits)
- Wired into `main_pre_commit()` after `validate_repo_root_files`
- Bypass: `git commit --no-verify` (standard convention)

### NEW: `.agents/scripts/tests/test-lint-workflows-helper.sh`

7 test scenarios (all green):
1. Valid workflow YAML passes
2. Broken YAML (indentation error) fails with non-zero exit
3. No staged workflow files → skipped (pass)
4. Non-workflow YAML file (`.github/other.yml`) not checked
5. Previously-valid workflow broken in commit → fails
6. Hook integration: helper blocks on broken YAML
7. Hook integration: helper passes on valid YAML

## Verification

```bash
bash .agents/scripts/tests/test-lint-workflows-helper.sh
```

## Acceptance criteria status

- [x] Pre-commit hook runs actionlint on staged `.github/workflows/*.yml` changes
- [x] Hook blocks commits introducing YAML parse errors with file:line context
- [x] Hook degrades gracefully when actionlint binary absent (yamllint / python3 yaml.safe_load fallback)
- [x] `--no-verify` bypasses the check (standard pre-commit convention)
- [x] No-op when no workflow files changed
- [x] Test added under `.agents/scripts/tests/`

Resolves #20489

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.94 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 7m and 22,991 tokens on this as a headless worker.
