### PR TITLE
GH#20485: GH#20485: protect contributor PRs from auto-close on merge conflicts

### DIFF
--- a/.agents/scripts/pulse-merge-conflict.sh
+++ b/.agents/scripts/pulse-merge-conflict.sh
@@ -20,12 +20,17 @@
 #
 # Functions in this module (in source order):
 #   - _post_rebase_nudge_on_interactive_conflicting   (GH#18650 Fix 4)
+#   - _post_rebase_nudge_on_contributor_conflicting   (GH#20485)
 #   - _interactive_pr_is_stale                        (t2189)
 #   - _interactive_pr_trigger_handover                (t2189)
 #   - _is_planning_path_for_overlap                   (GH#18815)
 #   - _verify_pr_overlaps_commit                      (GH#18815)
 #   - _post_rebase_nudge_on_worker_conflicting        (GH#18815)
-#   - _close_conflicting_pr                           (GH#17574 + GH#18815)
+#   - _close_conflicting_pr_check_ownership_guard     (GH#20485, replaces _check_interactive_guard)
+#   - _close_conflicting_pr_classify_landed           (t2438)
+#   - _close_conflicting_pr_comment_landed            (t2438)
+#   - _close_conflicting_pr_comment_not_landed        (t2438)
+#   - _close_conflicting_pr                           (GH#17574 + GH#18815 + GH#20485)
 #   - _carry_forward_pr_diff                          (t2118)
 #
 # All functions fail-open: missing helpers, API errors, or malformed
@@ -102,6 +107,70 @@ Or use the GitHub web UI's *Update branch* button if the conflicts are trivial e
 Every pulse cycle the deterministic merge pass evaluates open PRs and auto-closes \`CONFLICTING\` ones that have no clear owner. \`origin:interactive\` PRs are explicitly protected from that path, which is correct for active maintainer work but left them to rot silently in the queue. This nudge is posted exactly once per PR so the stuck state surfaces in your inbox. If the PR still conflicts after you think you've rebased, the nudge will NOT repeat — re-check manually via \`gh pr view ${pr_number}\`.
 
 <sub>Posted automatically by \`pulse-merge-conflict.sh\` (GH#18650 / Fix 4 of the 2026-04-13 dispatch-unblocker pass).</sub>"
+
+	_gh_idempotent_comment "$pr_number" "$repo_slug" "$marker" "$nudge_body" "pr" || true
+	return 0
+}
+
+#######################################
+# GH#20485: Post a one-time rebase nudge on a conflicting contributor PR
+# that the deterministic merge pass has left open because the pulse does
+# not own the work.
+#
+# Rationale: the merge pass must never auto-close work it didn't create.
+# For contributor PRs (non-bot author, no origin:worker / origin:interactive
+# label), the correct action is: leave the PR open and post a visible signal
+# so the contributor knows their branch needs rebasing. Without this nudge
+# the stuck state would be invisible in the contributor's inbox.
+#
+# Idempotent via _gh_idempotent_comment marker — posted once per PR lifetime.
+# Fail-open: missing helpers or API errors never block the merge pass.
+#
+# Args:
+#   $1 - pr_number
+#   $2 - repo_slug (owner/repo)
+#######################################
+_post_rebase_nudge_on_contributor_conflicting() {
+	local pr_number="$1"
+	local repo_slug="$2"
+
+	[[ "$pr_number" =~ ^[0-9]+$ && -n "$repo_slug" ]] || return 0
+
+	if ! declare -F _gh_idempotent_comment >/dev/null 2>&1; then
+		echo "[pulse-wrapper] _post_rebase_nudge_on_contributor_conflicting: _gh_idempotent_comment not defined — skipping nudge for PR #${pr_number} in ${repo_slug}" >>"$LOGFILE"
+		return 0
+	fi
+
+	local head_branch
+	head_branch=$(gh pr view "$pr_number" --repo "$repo_slug" \
+		--json headRefName --jq '.headRefName' 2>/dev/null) || head_branch="<branch>"
+	[[ -n "$head_branch" ]] || head_branch="<branch>"
+
+	local marker="<!-- pulse-rebase-nudge-contributor -->"
+	local nudge_body
+	nudge_body="${marker}
+## Rebase needed — branch has diverged from \`main\`
+
+This PR has merge conflicts against \`main\`. The pulse merge pass does not auto-close contributor PRs (GH#20485) — this PR is kept open so your work is not lost.
+
+### To resolve
+
+From a terminal:
+
+\`\`\`bash
+git fetch origin
+git rebase origin/main
+# resolve any conflicts, then:
+git push --force-with-lease
+\`\`\`
+
+Or use the GitHub web UI's *Update branch* button if the conflicts are trivial enough for GitHub's web merger.
+
+### Why you're seeing this
+
+Every pulse cycle the deterministic merge pass evaluates open PRs with merge conflicts. Contributor PRs (without \`origin:worker\` or \`origin:interactive\` labels) are always left open — the pulse will not close work it did not create. This nudge is posted once per PR to surface the conflict state in your notifications. If the PR still conflicts after rebasing, re-check manually via \`gh pr view ${pr_number}\`.
+
+<sub>Posted automatically by \`pulse-merge-conflict.sh\` (GH#20485).</sub>"
 
 	_gh_idempotent_comment "$pr_number" "$repo_slug" "$marker" "$nudge_body" "pr" || true
 	return 0
@@ -541,55 +610,87 @@ _find_task_id_match_on_main() {
 }
 
 #######################################
-# Gate 1 of _close_conflicting_pr: origin:interactive protection.
+# Gate 1 of _close_conflicting_pr: ownership protection.
 #
-# Fetches the PR's labels with fail-CLOSED semantics. If the label
-# fetch fails, or if origin:interactive is present, the caller must
-# NOT close the PR.
+# Enforces the invariant "the pulse only auto-closes PRs it owns".
+# A PR is owned by the pulse when it carries origin:worker or
+# origin:worker-takeover. PRs that are interactive-session work
+# (origin:interactive) or external-contributor work (non-bot author,
+# no pulse origin label) must never be auto-closed.
 #
-# GH#18285 post-mortem: origin:interactive PRs are created during
-# maintainer sessions. The task-ID-on-main heuristic produces false
-# positives when multiple PRs share a task ID (incremental work on
-# the same issue). Maintainers decide what is redundant — the pulse
-# must not auto-close their work.
+# Fetches labels + author + authorAssociation with fail-CLOSED semantics.
+# If the metadata fetch fails, the caller must NOT close the PR.
 #
-# t2383 Fix 3: fail CLOSED on label read failure — if we can't read
-# labels, we might be about to close a protected origin:interactive
-# PR. Also use `grep -Fxq` (exact line match) not `grep -q`
-# (substring) so labels like "origin:interactive-fork" don't
+# GH#18285: origin:interactive PRs are maintainer session work — pulse
+# must not auto-close them.
+# GH#20485: external contributor PRs carry neither origin:worker nor
+# origin:interactive — the old guard fell through to close them, which
+# destroys contributor work. The fix extends the guard to the full
+# "only close PRs the pulse owns" invariant.
+#
+# t2383 Fix 3: fail CLOSED on metadata fetch failure. Use grep -Fxq
+# (exact line match) so labels like "origin:interactive-fork" don't
 # false-match "origin:interactive".
 #
 # Args: $1 = pr_number, $2 = repo_slug
 # Returns:
-#   0 — caller must return 0 without closing (fetch failed or
-#       origin:interactive)
-#   1 — safe to proceed with close logic
-# Side effects: posts rebase nudge via
-#   _post_rebase_nudge_on_interactive_conflicting on origin:interactive
+#   0 — caller must return 0 without closing (fetch failed, or PR is
+#       protected: origin:interactive or external contributor)
+#   1 — safe to proceed with close logic (pulse owns this PR)
+# Side effects:
+#   Posts _post_rebase_nudge_on_interactive_conflicting for interactive PRs.
+#   Posts _post_rebase_nudge_on_contributor_conflicting for contributor PRs.
 #######################################
-_close_conflicting_pr_check_interactive_guard() {
+_close_conflicting_pr_check_ownership_guard() {
 	local pr_number="$1"
 	local repo_slug="$2"
 
-	local pr_labels label_fetch_rc
-	label_fetch_rc=0
-	pr_labels=$(gh pr view "$pr_number" --repo "$repo_slug" \
-		--json labels --jq '.labels[].name' 2>/dev/null) || label_fetch_rc=$?
-	if [[ $label_fetch_rc -ne 0 ]]; then
-		echo "[pulse-wrapper] _close_conflicting_pr: failed to fetch labels for PR #${pr_number} in ${repo_slug} (exit ${label_fetch_rc}) — skipping close to protect potential origin:interactive PR (t2383)" >>"$LOGFILE"
+	# Fetch labels + author metadata in one call. Fail CLOSED if the
+	# fetch fails — if we can't determine ownership, do nothing.
+	local pr_meta meta_fetch_rc
+	meta_fetch_rc=0
+	pr_meta=$(gh pr view "$pr_number" --repo "$repo_slug" \
+		--json labels,author,authorAssociation 2>/dev/null) || meta_fetch_rc=$?
+	if [[ $meta_fetch_rc -ne 0 ]]; then
+		echo "[pulse-wrapper] _close_conflicting_pr: failed to fetch metadata for PR #${pr_number} in ${repo_slug} (exit ${meta_fetch_rc}) — skipping close to protect potential origin:interactive or contributor PR (t2383, GH#20485)" >>"$LOGFILE"
 		return 0
 	fi
+
+	local pr_labels
+	pr_labels=$(printf '%s' "$pr_meta" | jq -r '.labels[].name' 2>/dev/null) || pr_labels=""
+
+	# Guard 1: origin:interactive — never auto-close maintainer session work.
+	# GH#18285 + GH#18650 Fix 4: post a one-time rebase nudge so the
+	# maintainer has a visible signal that their CONFLICTING PR needs
+	# manual attention.
 	if printf '%s\n' "$pr_labels" | grep -Fxq 'origin:interactive'; then
 		echo "[pulse-wrapper] Deterministic merge: skipping auto-close of origin:interactive PR #${pr_number} — maintainer session work is never auto-closed" >>"$LOGFILE"
-		# GH#18650 (Fix 4): post a one-time rebase nudge so the
-		# maintainer has a visible signal that their CONFLICTING PR
-		# needs manual attention. Without this, interactive
-		# CONFLICTING PRs rot silently — the pulse log keeps skipping
-		# them every cycle but the maintainer never sees the signal.
 		_post_rebase_nudge_on_interactive_conflicting "$pr_number" "$repo_slug"
 		return 0
 	fi
-	return 1
+
+	# Guard 2: origin:worker or origin:worker-takeover — pulse owns these
+	# PRs; close is safe and correct.
+	if printf '%s\n' "$pr_labels" | grep -Fxq 'origin:worker' ||
+		printf '%s\n' "$pr_labels" | grep -Fxq 'origin:worker-takeover'; then
+		return 1
+	fi
+
+	# Guard 3: bot authors (login ends with "[bot]") — no human contributor
+	# is losing work. Close is safe.
+	local author_login
+	author_login=$(printf '%s' "$pr_meta" | jq -r '.author.login // ""' 2>/dev/null) || author_login=""
+	if [[ "$author_login" == *'[bot]' ]]; then
+		return 1
+	fi
+
+	# Guard 4: non-bot author with no pulse origin label — this is an
+	# external contributor PR. The pulse never auto-closes work it didn't
+	# create. Leave the PR open and post a rebase nudge so the contributor
+	# has a visible signal. (GH#20485)
+	echo "[pulse-wrapper] Deterministic merge: skipping auto-close of PR #${pr_number} in ${repo_slug} — non-bot author @${author_login} without pulse origin label; contributor work is never auto-closed (GH#20485)" >>"$LOGFILE"
+	_post_rebase_nudge_on_contributor_conflicting "$pr_number" "$repo_slug"
+	return 0
 }
 
 #######################################
@@ -751,6 +852,10 @@ _Closed by deterministic merge pass (pulse-wrapper.sh)._" 2>/dev/null || true
 # lookup failure, the PR is left open and a one-time rebase nudge
 # is posted.
 #
+# GH#20485: External contributor PRs (non-bot author, no pulse origin
+# label) are now protected by the ownership guard (Gate 1). The pulse
+# must not auto-close work it didn't create.
+#
 # t2438 / GH#20060: decomposed into helpers to keep this function
 # under the 100-line function-complexity threshold. The orchestrator
 # below is a thin driver — each gate is its own helper so the
@@ -763,10 +868,12 @@ _close_conflicting_pr() {
 	local repo_slug="$2"
 	local pr_title="$3"
 
-	# Gate 1: origin:interactive protection (with fail-CLOSED label
-	# fetch). Returns 0 (action taken / skipped) means the caller
-	# must NOT close this PR.
-	if _close_conflicting_pr_check_interactive_guard "$pr_number" "$repo_slug"; then
+	# Gate 1: ownership protection — only auto-close PRs the pulse owns.
+	# Protects: origin:interactive (maintainer session work),
+	#           non-bot PRs without origin:worker (external contributors).
+	# Returns 0 (action taken / skipped) means the caller must NOT close.
+	# GH#18285, GH#20485
+	if _close_conflicting_pr_check_ownership_guard "$pr_number" "$repo_slug"; then
 		return 0
 	fi
 

--- a/.agents/scripts/tests/test-close-conflicting-pr-wording.sh
+++ b/.agents/scripts/tests/test-close-conflicting-pr-wording.sh
@@ -104,7 +104,7 @@ if [[ "\$1" == "pr" && "\$2" == "close" ]]; then
 	exit 0
 fi
 
-if [[ "\$1" == "pr" && "\$2" == "view" ]]; then
+	if [[ "\$1" == "pr" && "\$2" == "view" ]]; then
 	# Find the --json field name to know which response to emit.
 	field=""
 	args=("\$@")
@@ -121,6 +121,19 @@ if [[ "\$1" == "pr" && "\$2" == "view" ]]; then
 		labels)
 			response="\${TEST_ROOT}/pr-labels.txt"
 			if [[ -f "\$response" ]]; then cat "\$response"; fi
+			exit 0
+			;;
+		"labels,author,authorAssociation")
+			# GH#20485: _close_conflicting_pr_check_ownership_guard fetches
+			# labels + author metadata in one call. Return pr-meta.json if
+			# present; fall back to a default that simulates a worker PR
+			# (origin:worker label, bot author) so existing tests are unaffected.
+			response="\${TEST_ROOT}/pr-meta.json"
+			if [[ -f "\$response" ]]; then
+				cat "\$response"
+			else
+				echo '{"labels":[{"name":"origin:worker"}],"author":{"login":"aidevops-worker[bot]"},"authorAssociation":"NONE"}'
+			fi
 			exit 0
 			;;
 		files)
@@ -183,12 +196,13 @@ load_functions_under_test() {
 
 	# Extract these functions in order:
 	#   _post_rebase_nudge_on_interactive_conflicting (label-fetch fail path)
+	#   _post_rebase_nudge_on_contributor_conflicting (GH#20485)
 	#   _is_planning_path_for_overlap
 	#   _verify_pr_overlaps_commit
 	#   _post_rebase_nudge_on_worker_conflicting
 	#   _parse_squash_merge_pr                         (t2438)
 	#   _find_task_id_match_on_main                    (t2438)
-	#   _close_conflicting_pr_check_interactive_guard  (t2438)
+	#   _close_conflicting_pr_check_ownership_guard    (GH#20485, replaces _check_interactive_guard)
 	#   _close_conflicting_pr_classify_landed          (t2438)
 	#   _close_conflicting_pr_comment_landed           (t2438)
 	#   _close_conflicting_pr_comment_not_landed       (t2438)
@@ -196,12 +210,13 @@ load_functions_under_test() {
 	# Each definition uses tab-indented bodies with a column-0 "}" closer.
 	awk '
 		/^_post_rebase_nudge_on_interactive_conflicting\(\) \{$/ { fn=1 }
-		/^_is_planning_path_for_overlap\(\) \{$/                 { fn=1 }
+		/^_post_rebase_nudge_on_contributor_conflicting\(\) \{$/  { fn=1 }
+		/^_is_planning_path_for_overlap\(\) \{$/                  { fn=1 }
 		/^_verify_pr_overlaps_commit\(\) \{$/                     { fn=1 }
 		/^_post_rebase_nudge_on_worker_conflicting\(\) \{$/       { fn=1 }
 		/^_parse_squash_merge_pr\(\) \{$/                         { fn=1 }
 		/^_find_task_id_match_on_main\(\) \{$/                    { fn=1 }
-		/^_close_conflicting_pr_check_interactive_guard\(\) \{$/  { fn=1 }
+		/^_close_conflicting_pr_check_ownership_guard\(\) \{$/    { fn=1 }
 		/^_close_conflicting_pr_classify_landed\(\) \{$/          { fn=1 }
 		/^_close_conflicting_pr_comment_landed\(\) \{$/           { fn=1 }
 		/^_close_conflicting_pr_comment_not_landed\(\) \{$/       { fn=1 }
@@ -225,16 +240,28 @@ STUB_EOF
 }
 
 # Helper to write per-test response files.
+# Optional 4th arg: pr-meta JSON for _close_conflicting_pr_check_ownership_guard.
+# Default simulates a worker-origin PR (origin:worker label, bot author) so
+# existing tests that expect closes are unaffected by GH#20485.
 set_responses() {
 	local commits_json="$1"
 	local commit_files="$2"
 	local pr_files="$3"
+	local pr_meta_json="${4:-}"
 	printf '%s' "$commits_json" >"${TEST_ROOT}/commits.json"
 	printf '%s' "$commit_files" >"${TEST_ROOT}/commit-files.txt"
 	printf '%s' "$pr_files" >"${TEST_ROOT}/pr-files.txt"
 	# Default empty labels (no origin:interactive)
 	: >"${TEST_ROOT}/pr-labels.txt"
 	echo "feature/test" >"${TEST_ROOT}/pr-branch.txt"
+	# GH#20485: ownership guard metadata. Default = worker-origin bot PR
+	# so existing close-path tests still proceed to the close logic.
+	if [[ -n "$pr_meta_json" ]]; then
+		printf '%s' "$pr_meta_json" >"${TEST_ROOT}/pr-meta.json"
+	else
+		printf '%s' '{"labels":[{"name":"origin:worker"}],"author":{"login":"aidevops-worker[bot]"},"authorAssociation":"NONE"}' \
+			>"${TEST_ROOT}/pr-meta.json"
+	fi
 	return 0
 }
 
@@ -475,6 +502,247 @@ test_no_close_when_pr_files_lookup_fails() {
 	return 0
 }
 
+# ── GH#20485: External contributor PR protection ──
+
+# GH#20485: Non-bot author with no origin label → skip close, post nudge.
+test_no_close_for_external_contributor_pr() {
+	setup_sandbox
+	# No task-ID match on main, so the flow reaches Gate 1. PR has no origin
+	# label and a human contributor author — must NOT be closed.
+	set_responses \
+		'[{"sha":"abc1234567890abcdef","subject":"chore: unrelated commit"},{"sha":"def4567890abcdef","subject":"feat: also unrelated"}]' \
+		'.agents/scripts/pulse-merge-conflict.sh' \
+		'.agents/scripts/pulse-merge-conflict.sh' \
+		'{"labels":[],"author":{"login":"superdav42"},"authorAssociation":"CONTRIBUTOR"}'
+
+	load_functions_under_test
+
+	# Stub _gh_idempotent_comment so we can detect the nudge post attempt
+	_gh_idempotent_comment() { return 0; }
+
+	_close_conflicting_pr "20485" "marcusquinn/aidevops" \
+		"superdav42: my feature"
+
+	local result=0
+	# Must NOT have called gh pr close (captured comment file is empty)
+	if [[ -s "$CAPTURED_COMMENT_FILE" ]]; then
+		result=1
+	fi
+	# Must have logged the contributor protection
+	if ! grep -q "GH#20485" "$LOGFILE"; then
+		result=1
+	fi
+	if ! grep -q "superdav42" "$LOGFILE"; then
+		result=1
+	fi
+
+	print_result "GH#20485: external contributor PR left open (no close)" \
+		"$result" \
+		"captured-comment=$(cat "$CAPTURED_COMMENT_FILE" | head -c 100); log=$(head -5 "$LOGFILE")"
+	teardown_sandbox
+	return 0
+}
+
+# GH#20485: origin:worker label present → proceed with close (pulse owns it).
+test_close_for_worker_origin_pr() {
+	setup_sandbox
+	# No commit match, worker PR → should close.
+	set_responses \
+		'[{"sha":"abc1234567890abcdef","subject":"chore: unrelated commit"}]' \
+		'.agents/scripts/pulse-merge-conflict.sh' \
+		'.agents/scripts/pulse-merge-conflict.sh' \
+		'{"labels":[{"name":"origin:worker"}],"author":{"login":"superdav42"},"authorAssociation":"CONTRIBUTOR"}'
+
+	load_functions_under_test
+
+	_close_conflicting_pr "20486" "marcusquinn/aidevops" \
+		"t9999: worker-created PR"
+
+	local result=0
+	# origin:worker → guard returns 1 → close proceeds
+	if [[ ! -s "$CAPTURED_COMMENT_FILE" ]]; then
+		result=1
+	fi
+	if ! grep -q "merge conflicts" "$(cat "$CAPTURED_COMMENT_FILE" 2>/dev/null || true)" 2>/dev/null; then
+		# check the comment has the expected text
+		local body
+		body=$(cat "$CAPTURED_COMMENT_FILE" 2>/dev/null || true)
+		if ! printf '%s' "$body" | grep -q "merge conflicts"; then
+			result=1
+		fi
+	fi
+
+	print_result "GH#20485: origin:worker PR is still closed on conflicts" \
+		"$result" \
+		"captured=$(cat "$CAPTURED_COMMENT_FILE" | head -c 150)"
+	teardown_sandbox
+	return 0
+}
+
+# GH#20485: origin:worker-takeover label → proceed with close (ownership transferred).
+test_close_for_worker_takeover_pr() {
+	setup_sandbox
+	set_responses \
+		'[{"sha":"abc1234567890abcdef","subject":"chore: unrelated commit"}]' \
+		'.agents/scripts/pulse-merge-conflict.sh' \
+		'.agents/scripts/pulse-merge-conflict.sh' \
+		'{"labels":[{"name":"origin:worker-takeover"},{"name":"origin:interactive"}],"author":{"login":"marcusquinn"},"authorAssociation":"OWNER"}'
+
+	load_functions_under_test
+
+	_close_conflicting_pr "20487" "marcusquinn/aidevops" \
+		"t9999: worker-takeover PR"
+
+	local result=0
+	# origin:worker-takeover → guard returns 1 → close proceeds
+	# (even though origin:interactive is also present; worker-takeover takes precedence
+	# over interactive in the guard because worker-takeover is checked first)
+	# Actually: interactive is checked FIRST and returns 0 (skip). Test expects no-close.
+	# Correction: origin:interactive guard fires first → no close.
+	# This tests that origin:worker-takeover WITHOUT origin:interactive → close.
+
+	teardown_sandbox
+
+	# Re-run without origin:interactive
+	setup_sandbox
+	set_responses \
+		'[{"sha":"abc1234567890abcdef","subject":"chore: unrelated commit"}]' \
+		'.agents/scripts/pulse-merge-conflict.sh' \
+		'.agents/scripts/pulse-merge-conflict.sh' \
+		'{"labels":[{"name":"origin:worker-takeover"}],"author":{"login":"superdav42"},"authorAssociation":"CONTRIBUTOR"}'
+
+	load_functions_under_test
+
+	_close_conflicting_pr "20488" "marcusquinn/aidevops" \
+		"t9999: worker-takeover PR"
+
+	if [[ ! -s "$CAPTURED_COMMENT_FILE" ]]; then
+		result=1
+	fi
+
+	print_result "GH#20485: origin:worker-takeover PR is closed on conflicts" \
+		"$result" \
+		"captured=$(cat "$CAPTURED_COMMENT_FILE" | head -c 150)"
+	teardown_sandbox
+	return 0
+}
+
+# GH#20485: bot author with no origin label → proceed with close (no human loses work).
+test_close_for_bot_author_no_label_pr() {
+	setup_sandbox
+	set_responses \
+		'[{"sha":"abc1234567890abcdef","subject":"chore: unrelated commit"}]' \
+		'.agents/scripts/pulse-merge-conflict.sh' \
+		'.agents/scripts/pulse-merge-conflict.sh' \
+		'{"labels":[],"author":{"login":"dependabot[bot]"},"authorAssociation":"NONE"}'
+
+	load_functions_under_test
+
+	_close_conflicting_pr "20489" "marcusquinn/aidevops" \
+		"chore: dependabot update"
+
+	local result=0
+	if [[ ! -s "$CAPTURED_COMMENT_FILE" ]]; then
+		result=1
+	fi
+
+	print_result "GH#20485: bot-author PR with no origin label is still closed" \
+		"$result" \
+		"captured=$(cat "$CAPTURED_COMMENT_FILE" | head -c 150)"
+	teardown_sandbox
+	return 0
+}
+
+# GH#20485: metadata fetch failure → fail CLOSED → no close.
+test_no_close_on_metadata_fetch_failure() {
+	# Simulate gh pr view returning non-zero for labels,author,authorAssociation
+	local tmp_sandbox
+	tmp_sandbox=$(mktemp -d)
+	local stub_dir="${tmp_sandbox}/stubs"
+	local captured="${tmp_sandbox}/captured.txt"
+	local log_file="${tmp_sandbox}/pulse.log"
+	mkdir -p "$stub_dir"
+	: >"$captured"
+	: >"$log_file"
+
+	# Write a stub that fails on the metadata fetch
+	cat >"${stub_dir}/gh" <<STUB_EOF
+#!/usr/bin/env bash
+if [[ "\$1" == "pr" && "\$2" == "view" ]]; then
+  field=""
+  args=("\$@")
+  i=2
+  while [[ \$i -lt \${#args[@]} ]]; do
+    if [[ "\${args[\$i]}" == "--json" ]]; then
+      j=\$((i + 1))
+      field="\${args[\$j]}"
+      break
+    fi
+    i=\$((i + 1))
+  done
+  if [[ "\$field" == "labels,author,authorAssociation" ]]; then
+    exit 1
+  fi
+fi
+exit 0
+STUB_EOF
+	chmod +x "${stub_dir}/gh"
+
+	local old_path="$PATH"
+	export PATH="${stub_dir}:${PATH}"
+	export LOGFILE="$log_file"
+
+	# Source functions from the real script
+	local repo_root
+	repo_root=$(cd "$(dirname "$0")/../../.." && pwd)
+	local src="${repo_root}/.agents/scripts/pulse-merge-conflict.sh"
+	local tmp_fn="${tmp_sandbox}/funcs.sh"
+	awk '
+		/^_post_rebase_nudge_on_interactive_conflicting\(\) \{$/ { fn=1 }
+		/^_post_rebase_nudge_on_contributor_conflicting\(\) \{$/  { fn=1 }
+		/^_is_planning_path_for_overlap\(\) \{$/                  { fn=1 }
+		/^_verify_pr_overlaps_commit\(\) \{$/                     { fn=1 }
+		/^_post_rebase_nudge_on_worker_conflicting\(\) \{$/       { fn=1 }
+		/^_parse_squash_merge_pr\(\) \{$/                         { fn=1 }
+		/^_find_task_id_match_on_main\(\) \{$/                    { fn=1 }
+		/^_close_conflicting_pr_check_ownership_guard\(\) \{$/    { fn=1 }
+		/^_close_conflicting_pr_classify_landed\(\) \{$/          { fn=1 }
+		/^_close_conflicting_pr_comment_landed\(\) \{$/           { fn=1 }
+		/^_close_conflicting_pr_comment_not_landed\(\) \{$/       { fn=1 }
+		/^_close_conflicting_pr\(\) \{$/                          { fn=1 }
+		fn { print }
+		fn && /^\}$/ { fn=0 }
+	' "$src" >"$tmp_fn"
+	cat >>"$tmp_fn" <<'STUB_EOF'
+_carry_forward_pr_diff() { return 0; }
+_extract_linked_issue() { return 0; }
+STUB_EOF
+	# shellcheck source=/dev/null
+	source "$tmp_fn"
+
+	_close_conflicting_pr "99999" "marcusquinn/aidevops" "t9999: metadata-fail test"
+
+	local result=0
+	if [[ -s "$captured" ]]; then
+		result=1
+	fi
+	if ! grep -q "failed to fetch metadata" "$log_file"; then
+		result=1
+	fi
+
+	export PATH="$old_path"
+	rm -rf "$tmp_sandbox"
+
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$result" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "GH#20485: metadata fetch failure leaves PR open (fail-CLOSED)"
+	else
+		printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "GH#20485: metadata fetch failure leaves PR open (fail-CLOSED)"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
 # ── Run all tests ──
 
 test_wording_with_squash_merge_pr_number
@@ -484,6 +752,11 @@ test_no_close_when_matching_commit_only_touches_planning_files
 test_close_when_matching_commit_overlaps_implementation_files
 test_no_close_when_commit_files_lookup_fails
 test_no_close_when_pr_files_lookup_fails
+test_no_close_for_external_contributor_pr
+test_close_for_worker_origin_pr
+test_close_for_worker_takeover_pr
+test_close_for_bot_author_no_label_pr
+test_no_close_on_metadata_fetch_failure
 
 printf '\n%d tests run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 if [[ "$TESTS_FAILED" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-pulse-merge-carry-forward-diff.sh
+++ b/.agents/scripts/tests/test-pulse-merge-carry-forward-diff.sh
@@ -266,9 +266,9 @@ test_size_cap_truncation() {
 # which is never reached by origin:interactive PRs).
 #
 # t2438 / GH#20060: _close_conflicting_pr was decomposed into an
-# orchestrator plus six helpers:
-#   - _close_conflicting_pr_check_interactive_guard  (origin:interactive
-#     check; called as Gate 1)
+# orchestrator plus helpers:
+#   - _close_conflicting_pr_check_ownership_guard    (origin:interactive
+#     + contributor check; called as Gate 1; renamed GH#20485)
 #   - _close_conflicting_pr_comment_not_landed       (contains the
 #     _carry_forward_pr_diff call; only called on the "not landed" branch)
 # The structural invariants are asserted on the orchestrator's call
@@ -280,7 +280,7 @@ test_origin_interactive_skip_static() {
 		/^_close_conflicting_pr\(\) \{/,/^}$/ { print }
 	' "$MERGE_SCRIPT")
 	guard_src=$(awk '
-		/^_close_conflicting_pr_check_interactive_guard\(\) \{/,/^}$/ { print }
+		/^_close_conflicting_pr_check_ownership_guard\(\) \{/,/^}$/ { print }
 	' "$MERGE_SCRIPT")
 	not_landed_src=$(awk '
 		/^_close_conflicting_pr_comment_not_landed\(\) \{/,/^}$/ { print }
@@ -293,7 +293,7 @@ test_origin_interactive_skip_static() {
 	fi
 	if [[ -z "$guard_src" ]]; then
 		print_result "origin:interactive skip: guard helper extractable" 1 \
-			"Could not extract _close_conflicting_pr_check_interactive_guard from $MERGE_SCRIPT"
+			"Could not extract _close_conflicting_pr_check_ownership_guard from $MERGE_SCRIPT"
 		return 0
 	fi
 	if [[ -z "$not_landed_src" ]]; then
@@ -305,7 +305,7 @@ test_origin_interactive_skip_static() {
 	# The guard helper must contain the origin:interactive check itself
 	if ! printf '%s' "$guard_src" | grep -q 'origin:interactive'; then
 		print_result "origin:interactive skip: guard contains label check" 1 \
-			"_close_conflicting_pr_check_interactive_guard missing origin:interactive check"
+			"_close_conflicting_pr_check_ownership_guard missing origin:interactive check"
 		return 0
 	fi
 
@@ -321,7 +321,7 @@ test_origin_interactive_skip_static() {
 	# carry-forward" invariant through the decomposition.
 	local guard_pos not_landed_pos
 	guard_pos=$(printf '%s\n' "$orch_src" |
-		grep -n '_close_conflicting_pr_check_interactive_guard' |
+		grep -n '_close_conflicting_pr_check_ownership_guard' |
 		head -1 | cut -d: -f1)
 	not_landed_pos=$(printf '%s\n' "$orch_src" |
 		grep -n '_close_conflicting_pr_comment_not_landed' |
@@ -329,7 +329,7 @@ test_origin_interactive_skip_static() {
 
 	if [[ -z "$guard_pos" ]]; then
 		print_result "origin:interactive skip: orchestrator calls guard" 1 \
-			"Orchestrator missing _close_conflicting_pr_check_interactive_guard call"
+			"Orchestrator missing _close_conflicting_pr_check_ownership_guard call"
 		return 0
 	fi
 	if [[ -z "$not_landed_pos" ]]; then


### PR DESCRIPTION
## Summary

Extended the deterministic merge pass ownership guard to protect external contributor PRs from auto-close. Added _post_rebase_nudge_on_contributor_conflicting for visible feedback and renamed the guard function to reflect the broadened invariant. All existing tests pass plus 5 new regression tests.

## Files Changed

.agents/scripts/pulse-merge-conflict.sh,.agents/scripts/tests/test-close-conflicting-pr-wording.sh,.agents/scripts/tests/test-pulse-merge-carry-forward-diff.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-close-conflicting-pr-wording.sh (12/12 pass) && bash .agents/scripts/tests/test-pulse-merge-carry-forward-diff.sh (8/8 pass) && shellcheck on all modified files (0 violations)

Resolves #20485


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.94 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 8m and 28,883 tokens on this as a headless worker.