### PR TITLE
t2746: preserve worker assignee on merged linked PRs for audit trail

### DIFF
--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -860,33 +860,47 @@ clear_active_status_on_release() {
 		;;
 	esac
 
-	# Defensive: if an open linked PR exists for this issue, preserve the
-	# worker's assignee and status:in-review. The PR pipeline owns final
-	# cleanup on merge (see pulse-merge.sh::_release_interactive_claim_on_merge
-	# for the interactive mirror). Stripping them here strands the PR in
+	# Defensive: if a linked PR exists for this issue (OPEN or MERGED),
+	# preserve the worker's assignee and status:in-review.
+	#
+	# OPEN linked PR: the PR pipeline owns final cleanup on merge (see
+	# pulse-merge.sh::_release_interactive_claim_on_merge for the
+	# interactive mirror). Stripping here strands the PR in
 	# maintainer-gate Job 1 Check 2 because the assignee check fires
-	# after CLAIM_RELEASED but before PR merge. We still remove queued,
-	# claimed, and in-progress — those never outlive the worker process.
-	# GH#20195/t2451: closes the trust-gate loop where worker PRs on
-	# owner-authored origin:worker issues stall indefinitely.
+	# after CLAIM_RELEASED but before PR merge. GH#20195/t2451 closed
+	# that trust-gate loop.
+	#
+	# MERGED linked PR: preserves the closing-time audit trail on the
+	# issues list — the assignee identifies which runner's worker
+	# completed the work once the issue auto-closes. Without this, a
+	# fast merge (CI green before the worker exit trap fires — observed
+	# as little as 16s) races the unassign and erases the audit trail.
+	# t2746/GH#20520.
+	#
+	# We still remove queued, claimed, and in-progress — those never
+	# outlive the worker process regardless of PR state.
+	#
+	# CLOSED-not-merged PRs do NOT trigger preserve: the work didn't
+	# complete, and leaving the assignee on the issue would block
+	# future dispatch via the combined-signal dedup rule (t1996).
 	#
 	# Closing-keyword regex matches pulse-merge.sh::_extract_linked_issue
 	# character-for-character (case-insensitive) so behaviour is consistent
 	# across the merge path and the release path. Do NOT widen this to
 	# `Ref` or `For` — those are planning references that MUST NOT block
 	# assignee cleanup (see t2046).
-	local has_open_linked_pr=false
+	local has_linked_pr=false
 	local linked_prs_json=""
-	linked_prs_json=$(gh pr list --repo "$repo_slug" --state open \
+	linked_prs_json=$(gh pr list --repo "$repo_slug" --state all \
 		--search "#${issue_num} in:body" \
-		--json number,body --limit 20 2>/dev/null || true)
+		--json number,state,body --limit 20 2>/dev/null || true)
 	if [[ -z "$linked_prs_json" ]]; then
 		linked_prs_json="[]"
 	fi
 	if printf '%s' "$linked_prs_json" | jq -e --arg num "$issue_num" \
-		'[.[] | select((.body // "") | test("(close[ds]?|fix(es|ed)?|resolve[ds]?)[[:space:]]*#" + $num + "\\b"; "i"))] | length > 0' \
+		'[.[] | select((.state == "OPEN" or .state == "MERGED") and ((.body // "") | test("(close[ds]?|fix(es|ed)?|resolve[ds]?)[[:space:]]*#" + $num + "\\b"; "i")))] | length > 0' \
 		>/dev/null 2>&1; then
-		has_open_linked_pr=true
+		has_linked_pr=true
 	fi
 
 	local -a _flags=()
@@ -894,7 +908,7 @@ clear_active_status_on_release() {
 	_flags+=(--remove-label "status:claimed")
 	_flags+=(--remove-label "status:in-progress")
 
-	if [[ "$has_open_linked_pr" != "true" ]]; then
+	if [[ "$has_linked_pr" != "true" ]]; then
 		_flags+=(--remove-label "status:in-review")
 		if [[ -n "$worker_login" ]]; then
 			_flags+=(--remove-assignee "$worker_login")

--- a/.agents/scripts/tests/test-clear-active-status-on-release-preserves-merged-pr.sh
+++ b/.agents/scripts/tests/test-clear-active-status-on-release-preserves-merged-pr.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-clear-active-status-on-release-preserves-merged-pr.sh — t2746/GH#20520
+# regression guard.
+#
+# Asserts: when `clear_active_status_on_release` is called on an issue whose
+# linked PR has already MERGED (so the issue is also already closed), the
+# helper preserves the worker's assignee — preserving the closing-time
+# audit trail on the issues list.
+#
+#   1. MERGED linked PR (Resolves/Fixes/Closes) → preserve assignee + in-review
+#   2. CLOSED-not-merged linked PR → full cleanup (work didn't complete)
+#   3. Planning keywords (Ref/For) still do NOT trigger preserve
+#   4. MERGED PR for a different issue → full cleanup
+#   5. Mixed OPEN + MERGED PR list → preserve (either state qualifies)
+#
+# Motivation: workers run on user machines, so the assignee identifies WHICH
+# runner's worker completed the work. A closed issue with a preserved
+# assignee is the canonical "worker PR merged" audit row on the issues list.
+# Without this, a fast merge (CI green before the worker exit trap fires —
+# observed as 16s in GH#20484) races the unassign and erases the audit
+# trail.
+#
+# Siblings:
+#   test-clear-active-status-on-release-preserves-pr.sh     (OPEN PR case, t2451)
+#   test-clear-active-status-on-release-no-pr.sh            (no PR case, pre-t2451)
+#
+# NOTE: not using `set -e` — assertions capture non-zero exits.
+
+set -uo pipefail
+
+TEST_RED=$'\033[0;31m'
+TEST_GREEN=$'\033[0;32m'
+TEST_RESET=$'\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1" rc="$2" extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf '%sPASS%s %s\n' "$TEST_GREEN" "$TEST_RESET" "$name"
+	else
+		printf '%sFAIL%s %s %s\n' "$TEST_RED" "$TEST_RESET" "$name" "$extra"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+# Sandbox HOME
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+export HOME="${TEST_ROOT}/home"
+mkdir -p "${HOME}/.aidevops/logs"
+
+STUB_DIR="${TEST_ROOT}/bin"
+mkdir -p "$STUB_DIR"
+export GH_CALLS_FILE="${TEST_ROOT}/gh_calls.log"
+export GH_VIEW_LABELS="${TEST_ROOT}/gh_view_labels.txt"
+export GH_PR_LIST_JSON="${TEST_ROOT}/gh_pr_list.json"
+
+#######################################
+# Write a gh stub that:
+#   - For `gh issue view --json labels ...` → emits GH_VIEW_LABELS contents
+#   - For `gh pr list ...` → emits GH_PR_LIST_JSON contents
+#   - For any other gh invocation → records argv and exits 0
+#######################################
+write_stub_gh() {
+	: >"$GH_CALLS_FILE"
+	: >"$GH_VIEW_LABELS"
+	: >"$GH_PR_LIST_JSON"
+	cat >"${STUB_DIR}/gh" <<'STUBEOF'
+#!/usr/bin/env bash
+if [[ "$1" == "issue" && "$2" == "view" ]]; then
+	cat "${GH_VIEW_LABELS}" 2>/dev/null || true
+	exit 0
+fi
+if [[ "$1" == "pr" && "$2" == "list" ]]; then
+	cat "${GH_PR_LIST_JSON}" 2>/dev/null || true
+	exit 0
+fi
+printf '%s\n' "$*" >>"${GH_CALLS_FILE}"
+exit 0
+STUBEOF
+	chmod +x "${STUB_DIR}/gh"
+	return 0
+}
+
+export PATH="${STUB_DIR}:${PATH}"
+write_stub_gh
+
+TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+
+# shellcheck source=/dev/null
+source "${TEST_SCRIPTS_DIR}/shared-constants.sh"
+
+reset_stub() {
+	: >"$GH_CALLS_FILE"
+	: >"$GH_VIEW_LABELS"
+	: >"$GH_PR_LIST_JSON"
+	return 0
+}
+
+assert_grep() {
+	local pattern="$1" label="$2"
+	if grep -q -- "$pattern" "$GH_CALLS_FILE" 2>/dev/null; then
+		print_result "$label" 0
+	else
+		print_result "$label" 1 "pattern '${pattern}' not found in gh calls"
+	fi
+	return 0
+}
+
+assert_not_grep() {
+	local pattern="$1" label="$2"
+	if grep -q -- "$pattern" "$GH_CALLS_FILE" 2>/dev/null; then
+		print_result "$label" 1 "pattern '${pattern}' unexpectedly present"
+	else
+		print_result "$label" 0
+	fi
+	return 0
+}
+
+# -------------------------------------------------------------------
+# Case 1: MERGED PR with Resolves #N → preserve assignee + in-review
+# -------------------------------------------------------------------
+reset_stub
+printf '[{"number":20484,"state":"MERGED","body":"Summary.\\n\\nResolves #20520"}]' >"$GH_PR_LIST_JSON"
+clear_active_status_on_release 20520 owner/repo alice
+assert_grep "remove-label status:queued" "removes queued when PR merged"
+assert_grep "remove-label status:claimed" "removes claimed when PR merged"
+assert_grep "remove-label status:in-progress" "removes in-progress when PR merged"
+assert_not_grep "remove-label status:in-review" "preserves in-review when PR merged (Resolves)"
+assert_not_grep "remove-assignee" "preserves assignee when PR merged (Resolves)"
+
+# -------------------------------------------------------------------
+# Case 2: MERGED PR with Fixes #N → preserve
+# -------------------------------------------------------------------
+reset_stub
+printf '[{"number":99,"state":"MERGED","body":"Fixes #20520 end-to-end."}]' >"$GH_PR_LIST_JSON"
+clear_active_status_on_release 20520 owner/repo alice
+assert_not_grep "remove-label status:in-review" "preserves in-review when PR merged (Fixes)"
+assert_not_grep "remove-assignee" "preserves assignee when PR merged (Fixes)"
+
+# -------------------------------------------------------------------
+# Case 3: MERGED PR with closes (lowercase) → preserve
+# -------------------------------------------------------------------
+reset_stub
+printf '[{"number":42,"state":"MERGED","body":"closes #20520"}]' >"$GH_PR_LIST_JSON"
+clear_active_status_on_release 20520 owner/repo alice
+assert_not_grep "remove-assignee" "preserves assignee when PR merged (closes, lowercase)"
+
+# -------------------------------------------------------------------
+# Case 4: MERGED PR with CASE-INSENSITIVE RESOLVES → preserve
+# -------------------------------------------------------------------
+reset_stub
+printf '[{"number":7,"state":"MERGED","body":"RESOLVES #20520"}]' >"$GH_PR_LIST_JSON"
+clear_active_status_on_release 20520 owner/repo alice
+assert_not_grep "remove-assignee" "case-insensitive RESOLVES preserves assignee when merged"
+
+# -------------------------------------------------------------------
+# Case 5: CLOSED-not-merged PR with Resolves → DO NOT preserve
+#         (work didn't complete; assignee must be cleared so future
+#          dispatch isn't blocked by the combined-signal dedup rule)
+# -------------------------------------------------------------------
+reset_stub
+printf '[{"number":123,"state":"CLOSED","body":"Resolves #20520"}]' >"$GH_PR_LIST_JSON"
+clear_active_status_on_release 20520 owner/repo alice
+assert_grep "remove-assignee alice" "CLOSED-not-merged PR does NOT preserve assignee"
+assert_grep "remove-label status:in-review" "CLOSED-not-merged PR does NOT preserve in-review"
+
+# -------------------------------------------------------------------
+# Case 6: MERGED PR with planning keyword (Ref/For) → DO NOT preserve
+#         (planning references are tracked as audit links, not as
+#          closing keywords — see t2046 PR keyword rule)
+# -------------------------------------------------------------------
+reset_stub
+printf '[{"number":7,"state":"MERGED","body":"For #20520 — phase 1 of tracker"}]' >"$GH_PR_LIST_JSON"
+clear_active_status_on_release 20520 owner/repo alice
+assert_grep "remove-assignee alice" "For #N does NOT preserve even when merged"
+
+reset_stub
+printf '[{"number":7,"state":"MERGED","body":"Ref #20520"}]' >"$GH_PR_LIST_JSON"
+clear_active_status_on_release 20520 owner/repo alice
+assert_grep "remove-assignee alice" "Ref #N does NOT preserve even when merged"
+
+# -------------------------------------------------------------------
+# Case 7: MERGED PR referencing a DIFFERENT issue → DO NOT preserve
+# -------------------------------------------------------------------
+reset_stub
+printf '[{"number":7,"state":"MERGED","body":"Resolves #99999"}]' >"$GH_PR_LIST_JSON"
+clear_active_status_on_release 20520 owner/repo alice
+assert_grep "remove-assignee alice" "MERGED PR for different issue does NOT preserve"
+
+# -------------------------------------------------------------------
+# Case 8: Mixed list with CLOSED-not-merged + MERGED → preserve
+#         (any qualifying state is sufficient)
+# -------------------------------------------------------------------
+reset_stub
+printf '[{"number":1,"state":"CLOSED","body":"Resolves #20520"},{"number":2,"state":"MERGED","body":"Resolves #20520"}]' >"$GH_PR_LIST_JSON"
+clear_active_status_on_release 20520 owner/repo alice
+assert_not_grep "remove-assignee" "mixed list with MERGED preserves assignee"
+
+# -------------------------------------------------------------------
+# Case 9: MERGED PR but worker_login empty → no assignee call,
+#         still preserves in-review
+# -------------------------------------------------------------------
+reset_stub
+printf '[{"number":7,"state":"MERGED","body":"Resolves #20520"}]' >"$GH_PR_LIST_JSON"
+clear_active_status_on_release 20520 owner/repo ""
+assert_not_grep "remove-assignee" "no assignee call when worker_login empty (merged PR)"
+assert_not_grep "remove-label status:in-review" "preserves in-review with empty worker_login (merged PR)"
+assert_grep "remove-label status:queued" "still removes queued with empty worker_login (merged PR)"
+
+# -------------------------------------------------------------------
+# Summary
+# -------------------------------------------------------------------
+printf '\n%d tests run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]] || exit 1
+exit 0

--- a/.agents/scripts/tests/test-clear-active-status-on-release-preserves-pr.sh
+++ b/.agents/scripts/tests/test-clear-active-status-on-release-preserves-pr.sh
@@ -16,9 +16,9 @@
 # worker PR the moment its exit trap fires — the PR opens, the trap clears
 # the assignee, and the gate fires on the next PR push or issue-update event.
 #
-# Sibling: test-clear-active-status-on-release-no-pr.sh covers the complement
-# (no open linked PR → assignee + all four active labels removed, preserving
-# the pre-t2451 behaviour byte-for-byte).
+# Siblings:
+#   test-clear-active-status-on-release-preserves-merged-pr.sh (MERGED PR, t2746)
+#   test-clear-active-status-on-release-no-pr.sh               (no PR — pre-t2451)
 #
 # NOTE: not using `set -e` — assertions capture non-zero exits.
 
@@ -121,7 +121,7 @@ assert_not_grep() {
 # Case 1: Resolves #N in body → preserve assignee + in-review
 # -------------------------------------------------------------------
 reset_stub
-printf '[{"number":20188,"body":"Some description.\\n\\nResolves #20156"}]' >"$GH_PR_LIST_JSON"
+printf '[{"number":20188,"state":"OPEN","body":"Some description.\\n\\nResolves #20156"}]' >"$GH_PR_LIST_JSON"
 clear_active_status_on_release 20156 owner/repo alice
 assert_grep "remove-label status:queued" "removes queued when PR open"
 assert_grep "remove-label status:claimed" "removes claimed when PR open"
@@ -133,7 +133,7 @@ assert_not_grep "remove-assignee" "preserves assignee when PR open (Resolves)"
 # Case 2: Fixes #N in body → preserve assignee + in-review
 # -------------------------------------------------------------------
 reset_stub
-printf '[{"number":99,"body":"Fixes #20156 and adds coverage."}]' >"$GH_PR_LIST_JSON"
+printf '[{"number":99,"state":"OPEN","body":"Fixes #20156 and adds coverage."}]' >"$GH_PR_LIST_JSON"
 clear_active_status_on_release 20156 owner/repo alice
 assert_not_grep "remove-label status:in-review" "preserves in-review when PR open (Fixes)"
 assert_not_grep "remove-assignee" "preserves assignee when PR open (Fixes)"
@@ -142,7 +142,7 @@ assert_not_grep "remove-assignee" "preserves assignee when PR open (Fixes)"
 # Case 3: Closes #N in body → preserve assignee + in-review
 # -------------------------------------------------------------------
 reset_stub
-printf '[{"number":42,"body":"closes #20156"}]' >"$GH_PR_LIST_JSON"
+printf '[{"number":42,"state":"OPEN","body":"closes #20156"}]' >"$GH_PR_LIST_JSON"
 clear_active_status_on_release 20156 owner/repo alice
 assert_not_grep "remove-label status:in-review" "preserves in-review when PR open (closes, lowercase)"
 assert_not_grep "remove-assignee" "preserves assignee when PR open (closes, lowercase)"
@@ -151,7 +151,7 @@ assert_not_grep "remove-assignee" "preserves assignee when PR open (closes, lowe
 # Case 4: Case-insensitive keyword matching (RESOLVES, FIXES, CLOSES)
 # -------------------------------------------------------------------
 reset_stub
-printf '[{"number":7,"body":"RESOLVES #20156"}]' >"$GH_PR_LIST_JSON"
+printf '[{"number":7,"state":"OPEN","body":"RESOLVES #20156"}]' >"$GH_PR_LIST_JSON"
 clear_active_status_on_release 20156 owner/repo alice
 assert_not_grep "remove-assignee" "case-insensitive RESOLVES preserves assignee"
 
@@ -160,7 +160,7 @@ assert_not_grep "remove-assignee" "case-insensitive RESOLVES preserves assignee"
 #         still preserves in-review
 # -------------------------------------------------------------------
 reset_stub
-printf '[{"number":7,"body":"Resolves #20156"}]' >"$GH_PR_LIST_JSON"
+printf '[{"number":7,"state":"OPEN","body":"Resolves #20156"}]' >"$GH_PR_LIST_JSON"
 clear_active_status_on_release 20156 owner/repo ""
 assert_not_grep "remove-assignee" "no assignee call when worker_login empty"
 assert_not_grep "remove-label status:in-review" "preserves in-review with empty worker_login"
@@ -171,13 +171,13 @@ assert_grep "remove-label status:queued" "still removes queued with empty worker
 #         it's a planning link, not a closing keyword
 # -------------------------------------------------------------------
 reset_stub
-printf '[{"number":7,"body":"For #20156 tracking"}]' >"$GH_PR_LIST_JSON"
+printf '[{"number":7,"state":"OPEN","body":"For #20156 tracking"}]' >"$GH_PR_LIST_JSON"
 clear_active_status_on_release 20156 owner/repo alice
 assert_grep "remove-assignee alice" "For #N does NOT trigger preserve (planning keyword)"
 assert_grep "remove-label status:in-review" "For #N does NOT preserve in-review (planning keyword)"
 
 reset_stub
-printf '[{"number":7,"body":"Ref #20156"}]' >"$GH_PR_LIST_JSON"
+printf '[{"number":7,"state":"OPEN","body":"Ref #20156"}]' >"$GH_PR_LIST_JSON"
 clear_active_status_on_release 20156 owner/repo alice
 assert_grep "remove-assignee alice" "Ref #N does NOT trigger preserve (planning keyword)"
 
@@ -185,7 +185,7 @@ assert_grep "remove-assignee alice" "Ref #N does NOT trigger preserve (planning 
 # Case 7: Different issue number in body → does NOT match target
 # -------------------------------------------------------------------
 reset_stub
-printf '[{"number":7,"body":"Resolves #99999"}]' >"$GH_PR_LIST_JSON"
+printf '[{"number":7,"state":"OPEN","body":"Resolves #99999"}]' >"$GH_PR_LIST_JSON"
 clear_active_status_on_release 20156 owner/repo alice
 assert_grep "remove-assignee alice" "unrelated issue number does not preserve"
 


### PR DESCRIPTION
## Summary

3-state assignee visibility on the issues list: OPEN+assigned = active claim on that runner; OPEN+unassigned = no claim; CLOSED+assigned = worker PR merged (audit trail, NEW); CLOSED+unassigned = manual close/wontfix.

## Files Changed

.agents/scripts/shared-constants.sh,.agents/scripts/tests/test-clear-active-status-on-release-preserves-merged-pr.sh,.agents/scripts/tests/test-clear-active-status-on-release-preserves-pr.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** All four tests green: preserves-pr 17/17, preserves-merged-pr 18/18 (new), no-pr 14/14, claim-release-label-mutation 14/14. Shellcheck clean on all affected files.

Resolves #20520


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.94 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-opus-4-7 spent 1h 34m and 64,489 tokens on this with the user in an interactive session.