### PR TITLE
GH#20510: harden standalone-source tests — LC_ALL=C, safer path arg, declare -f

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -7486,9 +7486,9 @@
       "pr": 16415
     },
     "TODO.md": {
-      "at": "2026-04-22T21:06:47Z",
-      "hash": "5b721866edb58a6c6a05d222d2ab5530f2e1a0e2",
-      "passes": 89,
+      "at": "2026-04-22T21:57:36Z",
+      "hash": "01786ba20f0cc715e74a3328f8c57ee9f2706f51",
+      "passes": 90,
       "pr": 15490
     },
     "aidevops.sh": {
@@ -7747,6 +7747,18 @@
       "hash": "99f542cafff9f7f04688752a0dd142b0542ed0ad",
       "at": "2026-04-22T06:37:24Z",
       "pr": 20439,
+      "passes": 1
+    },
+    ".agents/reference/pre-push-guards.md": {
+      "hash": "5bcd34e49fb925fe79a23b5e6b6167e10f5127a6",
+      "at": "2026-04-22T21:57:37Z",
+      "pr": 20507,
+      "passes": 1
+    },
+    ".agents/scripts/shared-phase-filing.sh": {
+      "hash": "c3a2382330b5003ceda337694f99df7b06b39daf",
+      "at": "2026-04-22T21:57:37Z",
+      "pr": 20496,
       "passes": 1
     }
   },

--- a/.agents/scripts/tests/test-shared-gh-wrappers-standalone.sh
+++ b/.agents/scripts/tests/test-shared-gh-wrappers-standalone.sh
@@ -87,9 +87,12 @@ printf '%sRunning shared-gh-wrappers standalone-source tests (GH#20486)%s\n' \
 # =============================================================================
 printf '\n=== bash standalone source tests ===\n'
 
-bash_stderr=$(bash -c "source '${WRAPPERS_FILE}'" 2>&1 >/dev/null || true)
-
-if printf '%s\n' "$bash_stderr" | grep -q 'command not found'; then
+bash_stderr=$(LC_ALL=C bash -c 'source "$1"' -- "${WRAPPERS_FILE}" 2>&1 >/dev/null)
+bash_exit=$?
+if [[ $bash_exit -ne 0 ]] && [[ -n "$bash_stderr" ]] && ! printf '%s\n' "$bash_stderr" | grep -q 'command not found'; then
+	fail "1: bash standalone source emits no 'command not found'" \
+		"execution failed: $bash_stderr"
+elif printf '%s\n' "$bash_stderr" | grep -q 'command not found'; then
 	fail "1: bash standalone source emits no 'command not found'" \
 		"stderr: $bash_stderr"
 else
@@ -166,15 +169,15 @@ fi
 if [[ -f "$CONSTANTS_FILE" ]]; then
 	bash_canonical=$(bash -c "
 source '${CONSTANTS_FILE}' 2>/dev/null
-# Capture type before sourcing wrappers
-before_type=\$(type print_info 2>/dev/null | head -1)
+# Capture full function definition before sourcing wrappers
+before_def=\$(declare -f print_info)
 source '${WRAPPERS_FILE}' 2>/dev/null
-after_type=\$(type print_info 2>/dev/null | head -1)
-# Both should refer to a function; the name should be the same
-if [[ \"\$before_type\" == \"\$after_type\" ]]; then
+after_def=\$(declare -f print_info)
+# Both should be identical if the stub did not override the canonical
+if [[ \"\$before_def\" == \"\$after_def\" ]]; then
     printf 'CONSISTENT\n'
 else
-    printf 'CHANGED: before=%s after=%s\n' \"\$before_type\" \"\$after_type\"
+    printf 'CHANGED: definition was modified\n'
 fi
 " 2>&1)
 	if [[ "$bash_canonical" == *"CONSISTENT"* ]]; then
@@ -198,8 +201,12 @@ if ! command -v zsh >/dev/null 2>&1; then
 	skip "8: zsh: all major wrapper functions defined after standalone sourcing" "zsh not installed"
 else
 	# Test 6: zsh — standalone source emits no 'command not found' stderr
-	zsh_stderr=$(zsh -c "source '${WRAPPERS_FILE}'" 2>&1 >/dev/null || true)
-	if printf '%s\n' "$zsh_stderr" | grep -q 'command not found'; then
+	zsh_stderr=$(LC_ALL=C zsh -c 'source "$1"' -- "${WRAPPERS_FILE}" 2>&1 >/dev/null)
+	zsh_exit=$?
+	if [[ $zsh_exit -ne 0 ]] && [[ -n "$zsh_stderr" ]] && ! printf '%s\n' "$zsh_stderr" | grep -q 'command not found'; then
+		fail "6: zsh standalone source emits no 'command not found'" \
+			"execution failed: $zsh_stderr"
+	elif printf '%s\n' "$zsh_stderr" | grep -q 'command not found'; then
 		fail "6: zsh standalone source emits no 'command not found'" \
 			"stderr: $zsh_stderr"
 	else


### PR DESCRIPTION
## Summary

Addresses the three unresolved Gemini review comments from PR #20498, hardening the GH#20486 regression test suite.

### Changes

**Tests 1 and 6 (bash/zsh standalone source — "command not found" check):**
- Add `LC_ALL=C` so the "command not found" grep is locale-independent
- Pass the file path via `'source "$1"' -- "${WRAPPERS_FILE}"` to avoid shell-expansion issues with special characters in paths
- Remove `|| true`; capture exit code explicitly in `bash_exit`/`zsh_exit` and add a separate failure branch for non-"command not found" execution failures (e.g. syntax error in the sourced file)
- `local` suggestion from bot: not applied — these variables are at top-level script scope, not inside a function; `local` would produce a bash warning

**Test 5 (bash: stubs must not override canonical print_info):**
- Replace `type print_info | head -1` with `declare -f print_info` — `type | head -1` returns the same string ("print_info is a function") for both the stub and canonical implementations, meaning it could never detect an override. `declare -f` captures the full function body, so the comparison is meaningful
- Update the CHANGED diagnostic message accordingly
- `local` / `2>/dev/null` removal suggestions: `local` not applicable (same reason as above); kept `2>/dev/null` to avoid stderr from sourcing helper files polluting test output

### Verification

- `shellcheck` zero violations
- All 8/8 tests pass locally with the updated code

Resolves #20510
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.94 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 4m and 13,503 tokens on this as a headless worker.
