### PR TITLE
GH#20509: fix dup-todo guard regex for indented/hierarchical IDs + rename bypass var

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -7486,9 +7486,9 @@
       "pr": 16415
     },
     "TODO.md": {
-      "at": "2026-04-22T21:06:47Z",
-      "hash": "5b721866edb58a6c6a05d222d2ab5530f2e1a0e2",
-      "passes": 89,
+      "at": "2026-04-22T21:57:36Z",
+      "hash": "01786ba20f0cc715e74a3328f8c57ee9f2706f51",
+      "passes": 90,
       "pr": 15490
     },
     "aidevops.sh": {
@@ -7747,6 +7747,18 @@
       "hash": "99f542cafff9f7f04688752a0dd142b0542ed0ad",
       "at": "2026-04-22T06:37:24Z",
       "pr": 20439,
+      "passes": 1
+    },
+    ".agents/reference/pre-push-guards.md": {
+      "hash": "5bcd34e49fb925fe79a23b5e6b6167e10f5127a6",
+      "at": "2026-04-22T21:57:37Z",
+      "pr": 20507,
+      "passes": 1
+    },
+    ".agents/scripts/shared-phase-filing.sh": {
+      "hash": "c3a2382330b5003ceda337694f99df7b06b39daf",
+      "at": "2026-04-22T21:57:37Z",
+      "pr": 20496,
       "passes": 1
     }
   },

--- a/.agents/hooks/pre-push-dup-todo-guard.sh
+++ b/.agents/hooks/pre-push-dup-todo-guard.sh
@@ -24,8 +24,8 @@
 # Exit 0 = allow push. Exit 1 = block push.
 #
 # Environment:
-#   AIDEVOPS_SKIP_DUP_TODO_GUARD=1  — bypass for this invocation (logs warning to stderr)
-#   AIDEVOPS_DUP_TODO_GUARD_DEBUG=1 — verbose stderr trace
+#   DUP_TODO_GUARD_DISABLE=1  — bypass for this invocation (logs warning to stderr)
+#   DUP_TODO_GUARD_DEBUG=1    — verbose stderr trace
 #
 # Fail-open cases (exit 0 with warning):
 #   - TODO.md does not exist in the pushed commit
@@ -49,13 +49,13 @@ _log() {
 
 _dbg() {
 	local _msg="$1"
-	[[ "${AIDEVOPS_DUP_TODO_GUARD_DEBUG:-0}" == "1" ]] || return 0
+	[[ "${DUP_TODO_GUARD_DEBUG:-0}" == "1" ]] || return 0
 	_log DEBUG "$_msg"
 	return 0
 }
 
-if [[ "${AIDEVOPS_SKIP_DUP_TODO_GUARD:-0}" == "1" ]]; then
-	_log WARN "AIDEVOPS_SKIP_DUP_TODO_GUARD=1 — bypassing duplicate TODO check (audit trail: override active)"
+if [[ "${DUP_TODO_GUARD_DISABLE:-0}" == "1" ]]; then
+	_log WARN "DUP_TODO_GUARD_DISABLE=1 — bypassing duplicate TODO check (audit trail: override active)"
 	exit 0
 fi
 
@@ -90,12 +90,13 @@ while IFS=' ' read -r _local_ref _local_sha _remote_ref _remote_sha; do
 	}
 
 	# Extract task IDs from checkbox lines only.
-	# Pattern: ^- [x] tNNN<space> — anchored to avoid matching prose that
-	# mentions a task ID in a description or comment.
+	# Pattern: ^[whitespace]*- [x] tNNN[.N]*<space|EOL> — supports indented
+	# subtasks and hierarchical IDs (e.g., t1271.1). Anchored to checkbox-and-
+	# task-ID prefix to avoid matching prose that mentions a task ID.
 	# BSD sed and GNU sed both support \1 backreference in basic RE.
 	_task_ids=$(printf '%s\n' "$_todo_content" \
-		| grep -E '^- \[.\] t[0-9]+[[:space:]]' \
-		| sed 's/^- \[.\] \(t[0-9]*\)[[:space:]].*/\1/')
+		| grep -E '^[[:space:]]*- \[.\] t[0-9]+(\.[0-9]+)*([[:space:]]|$)' \
+		| sed 's/^[[:space:]]*- \[.\] \(t[0-9][0-9.]*\).*/\1/')
 
 	if [[ -z "$_task_ids" ]]; then
 		_dbg "no task IDs extracted from TODO.md in ${_local_sha}"
@@ -118,8 +119,10 @@ while IFS=' ' read -r _local_ref _local_sha _remote_ref _remote_sha; do
 		[[ -z "$_dup_id" ]] && continue
 		# Find line numbers of the duplicate entries (1-indexed, matching the
 		# checkbox-and-ID anchor so description-only mentions are excluded).
+		# Dots in the task ID must be escaped for ERE to prevent false positives.
+		_dup_id_esc=$(printf '%s' "$_dup_id" | sed 's/\./\\./g')
 		_line_nums=$(printf '%s\n' "$_todo_content" \
-			| grep -n "^- \[.\] ${_dup_id}[[:space:]]" \
+			| grep -nE '^[[:space:]]*- \[.\] '"${_dup_id_esc}"'([[:space:]]|$)' \
 			| cut -d: -f1 \
 			| tr '\n' ',' \
 			| sed 's/,$//')
@@ -130,7 +133,7 @@ while IFS=' ' read -r _local_ref _local_sha _remote_ref _remote_sha; do
 	printf '  Fix: remove the duplicate entry from TODO.md, amend the commit,\n' >&2
 	printf '       and push again.\n' >&2
 	printf '  Check: grep -n "^- \\[.\\] tNNN " TODO.md\n' >&2
-	printf '  Bypass (warning logged): AIDEVOPS_SKIP_DUP_TODO_GUARD=1 git push\n' >&2
+	printf '  Bypass (warning logged): DUP_TODO_GUARD_DISABLE=1 git push\n' >&2
 	printf '  Bypass all hooks:        git push --no-verify\n\n' >&2
 done
 

--- a/.agents/reference/pre-push-guards.md
+++ b/.agents/reference/pre-push-guards.md
@@ -52,11 +52,11 @@ Reads the brief file for the current branch's task ID and enforces the declared 
 
 Blocks pushes when the pushed commit's `TODO.md` contains two or more checkbox lines with the same task ID (t2745). Root cause: `_seed_orphan_todo_line` in `issue-sync-lib.sh` appends a minimal entry for an issue that already has a rich planning-PR entry. After `git rebase main`, both entries coexist with no merge conflict (different line numbers). This hook catches the duplicate at push time, before it reaches the remote.
 
-Detection pattern: `^- \[.\] tNNN ` — anchored to checkbox-and-task-ID prefix. Description-only mentions of a task ID (e.g., `See t2743 for context`) are not flagged.
+Detection pattern: `^[whitespace]*- \[.\] tNNN[.N]* ` — supports top-level and indented subtasks, and hierarchical IDs (e.g., `t1271.1`). Anchored to checkbox-and-task-ID prefix; description-only mentions of a task ID (e.g., `See t2743 for context`) are not flagged.
 
-Fix: `grep -n "^- \[.\] tNNN " TODO.md` to find both entries, remove the minimal (orphan-seeded) one, amend, and push again.
+Fix: `grep -nE '^[[:space:]]*- \[.\] tNNN([[:space:]]|$)' TODO.md` to find both entries, remove the minimal (orphan-seeded) one, amend, and push again.
 
-- Bypass (warning logged to stderr): `AIDEVOPS_SKIP_DUP_TODO_GUARD=1 git push ...`
+- Bypass (warning logged to stderr): `DUP_TODO_GUARD_DISABLE=1 git push ...`
 - Bypass all hooks: `git push --no-verify` (no warning)
 - **Fail-open** when: `TODO.md` is absent from the pushed commit, or `git show` fails
 - Test harness: `.agents/scripts/tests/test-pre-push-dup-todo-guard.sh`

--- a/.agents/scripts/install-pre-push-guards.sh
+++ b/.agents/scripts/install-pre-push-guards.sh
@@ -33,7 +33,7 @@
 #   COMPLEXITY_GUARD_DISABLE=1       skip complexity check for this push
 #   SCOPE_GUARD_DISABLE=1            skip scope check for this push
 #   CREDENTIAL_GUARD_DISABLE=1       skip credential check for this push
-#   AIDEVOPS_SKIP_DUP_TODO_GUARD=1   skip duplicate TODO check for this push
+#   DUP_TODO_GUARD_DISABLE=1          skip duplicate TODO check for this push
 #   git push --no-verify             skip all hooks
 
 set -euo pipefail
@@ -238,7 +238,7 @@ _write_dispatcher() {
 # Bypass all:  git push --no-verify
 # Bypass each: PRIVACY_GUARD_DISABLE=1, COMPLEXITY_GUARD_DISABLE=1,
 #              SCOPE_GUARD_DISABLE=1, CREDENTIAL_GUARD_DISABLE=1,
-#              or AIDEVOPS_SKIP_DUP_TODO_GUARD=1
+#              or DUP_TODO_GUARD_DISABLE=1
 
 set -u
 
@@ -407,7 +407,7 @@ cmd_install() {
 	print_success "installed pre-push guards: ${_installed_list% }"
 	print_info "hook: $_hook_path"
 	print_info "bypass all: git push --no-verify"
-	print_info "bypass individual: PRIVACY_GUARD_DISABLE=1, COMPLEXITY_GUARD_DISABLE=1, SCOPE_GUARD_DISABLE=1, CREDENTIAL_GUARD_DISABLE=1, or AIDEVOPS_SKIP_DUP_TODO_GUARD=1"
+	print_info "bypass individual: PRIVACY_GUARD_DISABLE=1, COMPLEXITY_GUARD_DISABLE=1, SCOPE_GUARD_DISABLE=1, CREDENTIAL_GUARD_DISABLE=1, or DUP_TODO_GUARD_DISABLE=1"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-pre-push-dup-todo-guard.sh
+++ b/.agents/scripts/tests/test-pre-push-dup-todo-guard.sh
@@ -4,14 +4,16 @@
 #
 # test-pre-push-dup-todo-guard.sh — Unit tests for pre-push-dup-todo-guard.sh (t2745).
 #
-# Tests 7 fixtures:
+# Tests 9 fixtures:
 #   1. Clean TODO.md (no duplicates)               → exit 0
 #   2. Single duplicate (t2743 twice)              → exit 1, cites lines
 #   3. Multiple duplicates (t2743 AND t2742)       → exit 1, cites both IDs
 #   4. Completed + open pair (- [x] + - [ ] same) → exit 1
 #   5. Pseudo-duplicate (task ID in description)   → exit 0
-#   6. AIDEVOPS_SKIP_DUP_TODO_GUARD=1              → exit 0, warning to stderr
+#   6. DUP_TODO_GUARD_DISABLE=1                    → exit 0, warning to stderr
 #   7. --no-verify bypass documentation            → informational (git-level bypass)
+#   8. Hierarchical ID duplicate (t1271.1 twice)   → exit 1, cites lines
+#   9. Indented subtask duplicate                  → exit 1, cites lines
 #
 # Usage: bash .agents/scripts/tests/test-pre-push-dup-todo-guard.sh
 # Exit 0 = all tests passed. Exit 1 = one or more tests failed.
@@ -276,7 +278,7 @@ test_pseudo_duplicate_in_description() {
 }
 
 # ---------------------------------------------------------------------------
-# Test 6: AIDEVOPS_SKIP_DUP_TODO_GUARD=1 → exit 0 even with duplicates; warning to stderr
+# Test 6: DUP_TODO_GUARD_DISABLE=1 → exit 0 even with duplicates; warning to stderr
 # ---------------------------------------------------------------------------
 test_bypass_env_var() {
 	local _name="test_6_bypass_env_var"
@@ -294,7 +296,7 @@ test_bypass_env_var() {
 
 	# Capture both stdout and stderr; run with bypass env var
 	local _stderr
-	_stderr=$(AIDEVOPS_SKIP_DUP_TODO_GUARD=1 bash "$HOOK" origin "https://github.com/test/repo" \
+	_stderr=$(DUP_TODO_GUARD_DISABLE=1 bash "$HOOK" origin "https://github.com/test/repo" \
 		<<<"refs/heads/test ${_sha} refs/heads/main 0000000000000000000000000000000000000000" \
 		2>&1 1>/dev/null)
 	local _rc=$?
@@ -339,6 +341,85 @@ test_no_verify_documentation() {
 }
 
 # ---------------------------------------------------------------------------
+# Test 8: hierarchical task ID duplicate (t1271.1 twice) → exit 1, cites lines
+# ---------------------------------------------------------------------------
+test_hierarchical_id_duplicate() {
+	local _name="test_8_hierarchical_id_duplicate"
+	_setup_git_repo || { _fail "$_name" "git repo setup failed"; return 0; }
+
+	local _content
+	_content="## Tasks
+- [ ] t1271 Parent task ref:GH#2001
+  - [x] t1271.1 First sub-entry ref:GH#2005
+
+## Backlog
+  - [ ] t1271.1 Second sub-entry ref:GH#2005"
+
+	local _sha
+	_sha=$(_commit_todo "$_content")
+
+	local _stdout _stderr
+	_stdout=$(bash "$HOOK" origin "https://github.com/test/repo" \
+		<<<"refs/heads/test ${_sha} refs/heads/main 0000000000000000000000000000000000000000" \
+		2>/dev/null)
+	_stderr=$(bash "$HOOK" origin "https://github.com/test/repo" \
+		<<<"refs/heads/test ${_sha} refs/heads/main 0000000000000000000000000000000000000000" \
+		2>&1 1>/dev/null)
+	local _rc=$?
+
+	_teardown_git_repo
+
+	if [[ "$_rc" -ne 1 ]]; then
+		_fail "$_name" "expected exit 1 (hierarchical duplicate t1271.1), got exit $_rc"
+		return 0
+	fi
+	if ! printf '%s\n' "$_stderr" | grep -q "t1271.1"; then
+		_fail "$_name" "expected t1271.1 cited in stderr; stderr: $_stderr"
+		return 0
+	fi
+	_pass "$_name"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 9: indented subtask duplicate → exit 1, cites lines
+# ---------------------------------------------------------------------------
+test_indented_subtask_duplicate() {
+	local _name="test_9_indented_subtask_duplicate"
+	_setup_git_repo || { _fail "$_name" "git repo setup failed"; return 0; }
+
+	local _content
+	_content="## Tasks
+- [ ] t1678 Parent task ref:GH#6821
+  - [ ] t1678.1 First occurrence ref:GH#6821
+
+## Backlog
+  - [ ] t1678.1 Second occurrence ref:GH#6821"
+
+	local _sha
+	_sha=$(_commit_todo "$_content")
+
+	local _stderr
+	_stderr=$(bash "$HOOK" origin "https://github.com/test/repo" \
+		<<<"refs/heads/test ${_sha} refs/heads/main 0000000000000000000000000000000000000000" \
+		2>&1 1>/dev/null)
+	local _rc=$?
+
+	_teardown_git_repo
+
+	if [[ "$_rc" -ne 1 ]]; then
+		_fail "$_name" "expected exit 1 (indented duplicate t1678.1), got exit $_rc"
+		return 0
+	fi
+	if ! printf '%s\n' "$_stderr" | grep -q "t1678.1"; then
+		_fail "$_name" "expected t1678.1 cited in stderr; stderr: $_stderr"
+		return 0
+	fi
+	_pass "$_name"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
 main() {
@@ -351,6 +432,8 @@ main() {
 	test_pseudo_duplicate_in_description
 	test_bypass_env_var
 	test_no_verify_documentation
+	test_hierarchical_id_duplicate
+	test_indented_subtask_duplicate
 
 	printf '\n'
 	printf 'Results: %d passed, %d failed\n' "$_TESTS_PASSED" "$_TESTS_FAILED"


### PR DESCRIPTION
## Summary

Review followup for PR #20499 (t2745 dup-todo pre-push guard). Addresses all inline bot suggestions from Gemini.

**High priority (premise verified correct):**
- TODO.md uses indented subtasks (`  - [x] t1271.1 ...`) and hierarchical IDs (`t1678.1`, `t1679.3`, etc.) — the original regex missed them
- Updated extraction regex: `^[[:space:]]*- \[.\] t[0-9]+(\.[0-9]+)*([[:space:]]|$)` — matches top-level, indented, and dotted IDs
- Updated line-number lookup: escapes dots in task IDs before building the ERE (without escaping, a literal dot in the ID would match any character, causing false positives)

**Medium priority (premise verified correct):**
- All other pre-push guards use `*_GUARD_DISABLE` naming; the new guard used `AIDEVOPS_SKIP_DUP_TODO_GUARD` — inconsistent
- Renamed to `DUP_TODO_GUARD_DISABLE` and `DUP_TODO_GUARD_DEBUG` across all 4 files

## Files changed

- EDIT: `.agents/hooks/pre-push-dup-todo-guard.sh` — regex + env var renames
- EDIT: `.agents/scripts/install-pre-push-guards.sh` — 3 comment/message updates
- EDIT: `.agents/reference/pre-push-guards.md` — detection pattern doc + bypass var
- EDIT: `.agents/scripts/tests/test-pre-push-dup-todo-guard.sh` — var rename + 2 new tests

## Verification

- `shellcheck` passes on all 3 modified shell files
- Test suite: 9/9 pass (2 new: `test_8_hierarchical_id_duplicate`, `test_9_indented_subtask_duplicate`)

Resolves #20509

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.94 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 9m and 22,587 tokens on this as a headless worker.
