### PR TITLE
GH#20511: fix shared-phase-filing: description brackets, child_ref tail-1, dedup regex anchor, _parent_json guard

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -7486,9 +7486,9 @@
       "pr": 16415
     },
     "TODO.md": {
-      "at": "2026-04-22T21:06:47Z",
-      "hash": "5b721866edb58a6c6a05d222d2ab5530f2e1a0e2",
-      "passes": 89,
+      "at": "2026-04-22T21:57:36Z",
+      "hash": "01786ba20f0cc715e74a3328f8c57ee9f2706f51",
+      "passes": 90,
       "pr": 15490
     },
     "aidevops.sh": {
@@ -7747,6 +7747,18 @@
       "hash": "99f542cafff9f7f04688752a0dd142b0542ed0ad",
       "at": "2026-04-22T06:37:24Z",
       "pr": 20439,
+      "passes": 1
+    },
+    ".agents/reference/pre-push-guards.md": {
+      "hash": "5bcd34e49fb925fe79a23b5e6b6167e10f5127a6",
+      "at": "2026-04-22T21:57:37Z",
+      "pr": 20507,
+      "passes": 1
+    },
+    ".agents/scripts/shared-phase-filing.sh": {
+      "hash": "c3a2382330b5003ceda337694f99df7b06b39daf",
+      "at": "2026-04-22T21:57:37Z",
+      "pr": 20496,
       "passes": 1
     }
   },

--- a/.agents/scripts/shared-phase-filing.sh
+++ b/.agents/scripts/shared-phase-filing.sh
@@ -145,8 +145,10 @@ _parse_phases_section() {
 			# Extract phase number
 			phase_num=$(printf '%s' "$line" | grep -oE '[Pp]hase[[:space:]]+[0-9]+' | grep -oE '[0-9]+')
 
-			# Extract description: text after "Phase N" separator (- or :) up to first [
-			description=$(printf '%s' "$line" | sed -E 's/^[[:space:]]*-[[:space:]]+[Pp]hase[[:space:]]+[0-9]+[[:space:]]*[-:][[:space:]]*//' | sed -E 's/[[:space:]]*\[.*//')
+			# Extract description: text after "Phase N" separator (- or :) up to
+			# known marker brackets. Only strip [auto-fire:...] and [requires-decision]
+			# so descriptions containing brackets (e.g. "Fix [bug] in X") are preserved.
+			description=$(printf '%s' "$line" | sed -E 's/^[[:space:]]*-[[:space:]]+[Pp]hase[[:space:]]+[0-9]+[[:space:]]*[-:][[:space:]]*//' | sed -E 's/[[:space:]]*\[(auto-fire|requires-decision)[^]]*\].*//' | sed -E 's/[[:space:]]*#[0-9]+[[:space:]]*$//')
 
 			# Determine marker
 			if printf '%s' "$line" | grep -qiF '[auto-fire:on-prior-merge]'; then
@@ -157,16 +159,10 @@ _parse_phases_section() {
 				marker="none"
 			fi
 
-			# Extract child issue reference (#NNNN not inside a marker bracket)
-			# Look for standalone #NNNN outside of [...]
-			child_ref=$(printf '%s' "$line" | grep -oE '#[0-9]+' | grep -oE '[0-9]+' | head -1)
-			# But skip if the #NNNN is inside a marker (unlikely but guard)
-			# Simple approach: if #NNNN appears after a ], it's a child ref
-			# If it only appears inside [...], it's not. For now, accept any #NNNN
-			# that is NOT the phase number itself.
-			if [[ "$child_ref" == "$phase_num" ]]; then
-				child_ref=""
-			fi
+			# Extract child issue reference: the last #NNNN on the line.
+			# Child refs appear after marker brackets so tail -1 selects correctly
+			# even when the description also contains issue references.
+			child_ref=$(printf '%s' "$line" | grep -oE '#[0-9]+' | tail -1 | grep -oE '[0-9]+')
 
 			printf '%s\t%s\t%s\t%s\n' "$phase_num" "$description" "$marker" "$child_ref"
 		fi
@@ -255,7 +251,7 @@ _update_parent_phases_section() {
 	# and appends the child ref only if it's not already present.
 	local updated_body
 	updated_body=$(printf '%s' "$parent_body" | sed -E "/^[[:space:]]*-[[:space:]]+[Pp]hase[[:space:]]+${phase_num}([^0-9]|$)/ {
-		/#${child_issue_num}/!s/[[:space:]]*$/ #${child_issue_num}/
+		/#${child_issue_num}([^0-9]|$)/!s/[[:space:]]*$/ #${child_issue_num}/
 	}")
 
 	# Only update if the body actually changed
@@ -442,6 +438,7 @@ auto_file_next_phase() {
 	local parent_body parent_title _parent_json
 	_parent_json=$(gh api "$parent_api" \
 		--jq '{body: (.body // ""), title: (.title // "")}' 2>/dev/null) || _parent_json=""
+	[[ -n "$_parent_json" ]] || return 0
 	parent_body=$(printf '%s' "$_parent_json" | jq -r '.body // ""')
 	parent_title=$(printf '%s' "$_parent_json" | jq -r '.title // ""')
 


### PR DESCRIPTION
## Summary

Addresses unresolved review-bot findings from PR #20492 (t2740: sequential phase auto-filing).

**Finding 1 — Premise falsified:** The broken jq dedup block with `or true` (cited at line 400) does not exist in the merged file. The current code deduplicates by checking `next_child` from the parsed phases section. No action taken.

**Finding 2 — Description truncation + child_ref extraction (line 169):** Fixed.
- Description sed now strips only `[auto-fire:...]` and `[requires-decision]` markers, not everything from `[` to end-of-line. Descriptions containing brackets (e.g., "Fix [bug] in logic") were previously corrupted.
- `child_ref` extraction changed from `head -1` to `tail -1`: child refs appear after marker brackets so the last `#NNN` on the line is the correct one.
- Removed incorrect guard that cleared `child_ref` when it equalled `phase_num` (logic error; not a real protection).

**Finding 3 — Sed dedup partial-number match (line 258):** Fixed.
- Pattern `/#${child_issue_num}/` could match `#123` when looking for `#12`, preventing the correct child ref from being appended.
- Fixed to `/#${child_issue_num}([^0-9]|$)/` to require a non-digit or end-of-line after the number.

**Finding 4 — No guard on empty `_parent_json` (line 321):** Fixed.
- Added `[[ -n "$_parent_json" ]] || return 0` so API failures are handled before jq parsing is attempted.
- The `@tsv` consolidation suggested by the bot is unsafe for multi-line issue bodies (newlines would be escaped, breaking downstream parsing); kept separate jq calls.

Resolves #20511


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.94 plugin for [OpenCode](https://opencode.ai) v1.14.20