### PR TITLE
t2748: fix(scanner): emit auto-dispatch + tier:standard on review-followup issues

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -7486,9 +7486,9 @@
       "pr": 16415
     },
     "TODO.md": {
-      "at": "2026-04-22T21:06:47Z",
-      "hash": "5b721866edb58a6c6a05d222d2ab5530f2e1a0e2",
-      "passes": 89,
+      "at": "2026-04-22T21:57:36Z",
+      "hash": "01786ba20f0cc715e74a3328f8c57ee9f2706f51",
+      "passes": 90,
       "pr": 15490
     },
     "aidevops.sh": {
@@ -7747,6 +7747,18 @@
       "hash": "99f542cafff9f7f04688752a0dd142b0542ed0ad",
       "at": "2026-04-22T06:37:24Z",
       "pr": 20439,
+      "passes": 1
+    },
+    ".agents/reference/pre-push-guards.md": {
+      "hash": "5bcd34e49fb925fe79a23b5e6b6167e10f5127a6",
+      "at": "2026-04-22T21:57:37Z",
+      "pr": 20507,
+      "passes": 1
+    },
+    ".agents/scripts/shared-phase-filing.sh": {
+      "hash": "c3a2382330b5003ceda337694f99df7b06b39daf",
+      "at": "2026-04-22T21:57:37Z",
+      "pr": 20496,
       "passes": 1
     }
   },

--- a/.agents/scripts/post-merge-review-scanner.sh
+++ b/.agents/scripts/post-merge-review-scanner.sh
@@ -617,6 +617,14 @@ create_issue() {
 			--description "Requires human triage before worker dispatch" \
 			--color "B60205" || true
 		label_list="${label_list},needs-maintainer-review"
+	else
+		# GH#20530 (t2748): scanner-emitted issues are dispatchable by default.
+		# Without auto-dispatch + tier:standard, pulse cannot pick them up and
+		# they sit unworked indefinitely (observed: 9 issues stalled when
+		# this branch was missing — backfilled manually as one-shot remediation).
+		# NMR'd issues skip this branch — NMR auto-approval (pulse-nmr-approval.sh)
+		# adds auto-dispatch on clear, so we don't double-apply here.
+		label_list="${label_list},auto-dispatch,tier:standard"
 	fi
 
 	local body_with_sig


### PR DESCRIPTION
## Summary

`post-merge-review-scanner.sh` was creating `review-followup` issues without `auto-dispatch` and `tier:*` labels. Pulse dispatch requires both. Result: scanner-emitted issues stalled.

Observed 9 issues (#20508, #20510-#20517) sat unworked until manual label backfill. This PR fixes the source.

## Change

Single-line addition (`.agents/scripts/post-merge-review-scanner.sh:614+`): in the non-NMR branch of label assembly, append `auto-dispatch,tier:standard`. NMR'd issues skip this branch — NMR auto-approval already adds `auto-dispatch` on clear, so no double-application risk.

## Testing

- shellcheck clean
- pre-commit ratchet checks passed
- diff is +8 lines, surgical
- semantic test: NMR'd issues still gated (label set unchanged on the `if true` branch); non-NMR'd issues now dispatchable

## Files Scope

- .agents/scripts/post-merge-review-scanner.sh

Resolves #20530

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.94 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-opus-4-7 spent 10m and 25,150 tokens on this with the user in an interactive session.
