### PR TITLE
GH#20512: fix node-ID null guard, parent-process cache init, and rest-fallback optional arg

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -7486,9 +7486,9 @@
       "pr": 16415
     },
     "TODO.md": {
-      "at": "2026-04-22T21:06:47Z",
-      "hash": "5b721866edb58a6c6a05d222d2ab5530f2e1a0e2",
-      "passes": 89,
+      "at": "2026-04-22T21:57:36Z",
+      "hash": "01786ba20f0cc715e74a3328f8c57ee9f2706f51",
+      "passes": 90,
       "pr": 15490
     },
     "aidevops.sh": {
@@ -7747,6 +7747,18 @@
       "hash": "99f542cafff9f7f04688752a0dd142b0542ed0ad",
       "at": "2026-04-22T06:37:24Z",
       "pr": 20439,
+      "passes": 1
+    },
+    ".agents/reference/pre-push-guards.md": {
+      "hash": "5bcd34e49fb925fe79a23b5e6b6167e10f5127a6",
+      "at": "2026-04-22T21:57:37Z",
+      "pr": 20507,
+      "passes": 1
+    },
+    ".agents/scripts/shared-phase-filing.sh": {
+      "hash": "c3a2382330b5003ceda337694f99df7b06b39daf",
+      "at": "2026-04-22T21:57:37Z",
+      "pr": 20496,
       "passes": 1
     }
   },

--- a/.agents/scripts/issue-sync-relationships.sh
+++ b/.agents/scripts/issue-sync-relationships.sh
@@ -103,7 +103,7 @@ _cached_node_id() {
 	# Uses the same core-pool 5000/hr budget that the t2574 write-path fallbacks use.
 	if _gh_should_fallback_to_rest; then
 		local rest_nid
-		rest_nid=$(gh api "/repos/${repo}/issues/${num}" --jq '.node_id' 2>/dev/null || echo "")
+		rest_nid=$(gh api "/repos/${repo}/issues/${num}" --jq '.node_id // ""' || echo "")
 		if [[ -n "$rest_nid" ]]; then
 			echo "${num}=${rest_nid}" >>"$_NODE_ID_CACHE_FILE"
 			echo "$rest_nid"
@@ -937,7 +937,20 @@ cmd_backfill_sub_issues() {
 
 	print_info "Backfilling sub-issue links for $total issue(s) in $repo"
 
-	local linked=0 skipped=0 rate_limited=0 processed=0
+	# Initialise the node-ID cache in the parent process so all subshells inherit
+	# the same _NODE_ID_CACHE_FILE and _NODE_ID_RATE_LIMITED_FILE paths.
+	# Without this, each _cached_node_id() subshell creates its own temp file and
+	# cache hits between issues are lost.
+	_init_node_id_cache
+
+	local linked
+	local skipped
+	local rate_limited
+	local processed
+	linked=0
+	skipped=0
+	rate_limited=0
+	processed=0
 	local _num result meta _title _body _has_parent _pcount
 	for _num in "${issue_numbers[@]}"; do
 		processed=$((processed + 1))

--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -118,13 +118,20 @@ _gh_split_csv() {
 # Fail-safe: if the response is unparseable (network error, gh auth missing),
 # return 1 (false) so the caller sees the original error rather than triggering
 # an unnecessary REST retry that may also fail.
+#
+# Optional arg: $1=pre-computed remaining count (integer string).
+# When provided, skips the `gh api rate_limit` call — callers that already
+# know the current rate-limit state (e.g. after fetching it once for a loop)
+# can pass it to avoid redundant I/O.
 #######################################
 _gh_should_fallback_to_rest() {
 	# Test/CI override: set _GH_SHOULD_FALLBACK_OVERRIDE=1 to force true without
 	# requiring a real rate-limit state. Use in unit tests and manual smoke runs.
 	[[ "${_GH_SHOULD_FALLBACK_OVERRIDE:-0}" == "1" ]] && return 0
-	local remaining
-	remaining=$(gh api rate_limit --jq '.resources.graphql.remaining' 2>/dev/null)
+	local remaining="${1:-}"
+	if [[ -z "$remaining" ]]; then
+		remaining=$(gh api rate_limit --jq '.resources.graphql.remaining' 2>/dev/null)
+	fi
 	[[ "$remaining" =~ ^[0-9]+$ ]] || return 1
 	[[ "$remaining" -le "$_GH_REST_FALLBACK_THRESHOLD" ]]
 }


### PR DESCRIPTION
## Summary

Three shell robustness fixes from Gemini review of PR #20491 (t2739: REST fallback for node-ID resolution).

### Fix 1 — `issue-sync-relationships.sh:106`: null guard + surface errors

`'.node_id'` returns the literal string `"null"` when the API field is null; `'.node_id // ""'` returns an empty string, which the existing `[[ -n "$rest_nid" ]]` guard handles correctly. Removed `2>/dev/null` so `gh api` errors surface in logs rather than being silently discarded (the `|| echo ""` fallback still handles non-zero exits).

### Fix 2 — `issue-sync-relationships.sh:940`: parent-process cache init

`_init_node_id_cache` creates the temp files and sets `_NODE_ID_CACHE_FILE` / `_NODE_ID_RATE_LIMITED_FILE` in the calling scope. Previously these were only initialised inside `_cached_node_id()` subshells — so every `$(…)` call started with an empty variable and created its own throwaway temp file. Cache hits between issues in `cmd_backfill_sub_issues` were silently lost. Calling `_init_node_id_cache` once in the parent ensures all subshells inherit the shared paths.

Also separates the combined `local linked=0 …` declaration into distinct `local` + assignment lines for exit-code safety style consistency.

### Fix 3 — `shared-gh-wrappers-rest-fallback.sh:122`: optional pre-computed arg

`_gh_should_fallback_to_rest` called `gh api rate_limit` on every invocation. Callers inside tight loops (e.g. `_cached_node_id` during a 500-issue backfill) can now pass a pre-computed `remaining` value as `$1` to skip the redundant HTTP call. Existing callers without the arg are unchanged.

## Verification

- `shellcheck` — no new violations
- `test-backfill-sub-issues.sh` — 23/23 pass
- `test-gh-wrapper-rest-fallback.sh` — 22/22 pass

Resolves #20512

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.94 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 6m and 15,021 tokens on this as a headless worker.
