### PR TITLE
fix: accurate interval label for non-multiples of 60 in launchd setup

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -7486,9 +7486,9 @@
       "pr": 16415
     },
     "TODO.md": {
-      "at": "2026-04-22T21:06:47Z",
-      "hash": "5b721866edb58a6c6a05d222d2ab5530f2e1a0e2",
-      "passes": 89,
+      "at": "2026-04-22T21:57:36Z",
+      "hash": "01786ba20f0cc715e74a3328f8c57ee9f2706f51",
+      "passes": 90,
       "pr": 15490
     },
     "aidevops.sh": {
@@ -7747,6 +7747,18 @@
       "hash": "99f542cafff9f7f04688752a0dd142b0542ed0ad",
       "at": "2026-04-22T06:37:24Z",
       "pr": 20439,
+      "passes": 1
+    },
+    ".agents/reference/pre-push-guards.md": {
+      "hash": "5bcd34e49fb925fe79a23b5e6b6167e10f5127a6",
+      "at": "2026-04-22T21:57:37Z",
+      "pr": 20507,
+      "passes": 1
+    },
+    ".agents/scripts/shared-phase-filing.sh": {
+      "hash": "c3a2382330b5003ceda337694f99df7b06b39daf",
+      "at": "2026-04-22T21:57:37Z",
+      "pr": 20496,
       "passes": 1
     }
   },

--- a/setup-modules/schedulers.sh
+++ b/setup-modules/schedulers.sh
@@ -601,10 +601,10 @@ _install_pulse_launchd() {
 	# Resolve interval for the user-facing message (matches what the plist contains).
 	local _interval_sec _interval_label
 	_interval_sec=$(_read_pulse_interval_seconds)
-	if [[ "$_interval_sec" -lt 60 ]]; then
-		_interval_label="${_interval_sec}s"
-	else
+	if (( _interval_sec % 60 == 0 )); then
 		_interval_label="$((_interval_sec / 60)) min"
+	else
+		_interval_label="${_interval_sec}s"
 	fi
 
 	# shell-portability: ignore next — _install_pulse_launchd is macOS-only (launchd)


### PR DESCRIPTION
## Summary

Fixes inaccurate pulse interval label in the macOS launchd setup message.

**Before:** Values ≥ 60s but not exact multiples (e.g. 90s) displayed as truncated minutes ("1 min").
**After:** Only exact multiples show as minutes; all others show as seconds ("90s").

## Change

`setup-modules/schedulers.sh:604-608` — swap the condition logic:

```diff
-	if [[ "$_interval_sec" -lt 60 ]]; then
-		_interval_label="${_interval_sec}s"
-	else
-		_interval_label="$((_interval_sec / 60)) min"
+	if (( _interval_sec % 60 == 0 )); then
+		_interval_label="$((_interval_sec / 60)) min"
+	else
+		_interval_label="${_interval_sec}s"
 	fi
```

## Verification

- `shellcheck setup-modules/schedulers.sh` — no new violations (pre-existing SC2016 info at line 28 is unrelated)
- Logic: 60s → "1 min", 120s → "2 min", 90s → "90s", 180s → "3 min", 150s → "150s" ✓

## Triage

**Outcome B** — premise correct, fix obvious. The bot finding was valid: PR #20483 introduced a configurable interval clamped to a range that can include non-multiples of 60, making the display inaccuracy reachable.

Resolves #20514

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.94 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 1m and 2,914 tokens on this as a headless worker.