### PR TITLE
GH#20516: guard inner shift in _gh_auto_link_sub_issue arg parser against $#=0

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -7486,9 +7486,9 @@
       "pr": 16415
     },
     "TODO.md": {
-      "at": "2026-04-22T21:06:47Z",
-      "hash": "5b721866edb58a6c6a05d222d2ab5530f2e1a0e2",
-      "passes": 89,
+      "at": "2026-04-22T21:57:36Z",
+      "hash": "01786ba20f0cc715e74a3328f8c57ee9f2706f51",
+      "passes": 90,
       "pr": 15490
     },
     "aidevops.sh": {
@@ -7747,6 +7747,18 @@
       "hash": "99f542cafff9f7f04688752a0dd142b0542ed0ad",
       "at": "2026-04-22T06:37:24Z",
       "pr": 20439,
+      "passes": 1
+    },
+    ".agents/reference/pre-push-guards.md": {
+      "hash": "5bcd34e49fb925fe79a23b5e6b6167e10f5127a6",
+      "at": "2026-04-22T21:57:37Z",
+      "pr": 20507,
+      "passes": 1
+    },
+    ".agents/scripts/shared-phase-filing.sh": {
+      "hash": "c3a2382330b5003ceda337694f99df7b06b39daf",
+      "at": "2026-04-22T21:57:37Z",
+      "pr": 20496,
       "passes": 1
     }
   },

--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -646,24 +646,24 @@ _gh_auto_link_sub_issue() {
 		case "$_arg" in
 		--title)
 			title="$_next"
-			shift
+			[[ $# -gt 0 ]] && shift
 			;;
 		--title=*) title="${_arg#--title=}" ;;
 		--repo)
 			repo="$_next"
-			shift
+			[[ $# -gt 0 ]] && shift
 			;;
 		--repo=*) repo="${_arg#--repo=}" ;;
 		--body)
 			body="$_next"
-			shift
+			[[ $# -gt 0 ]] && shift
 			;;
 		--body=*) body="${_arg#--body=}" ;;
 		--body-file)
 			if [[ -n "$_next" && -r "$_next" ]]; then
 				body=$(<"$_next")
 			fi
-			shift
+			[[ $# -gt 0 ]] && shift
 			;;
 		--body-file=*)
 			_bf="${_arg#--body-file=}"


### PR DESCRIPTION
## Summary

Guard the inner `shift` calls in `_gh_auto_link_sub_issue`'s argument parser against `$# = 0`.

The argument parsing loop in `_gh_auto_link_sub_issue` uses a two-shift pattern: the outer `shift` consumes the flag (`_arg`), and an inner `shift` consumes the value (which was pre-captured in `_next`). If a flag like `--title` appeared as the last argument, the outer `shift` would leave `$# = 0` and the inner `shift` would return 1.

This is silent in current usage (no `set -e`), but is a latent failure mode if `set -e` is ever introduced in a calling context.

Fix: add `[[ $# -gt 0 ]] && shift` guards in all four value-consuming case arms (`--title`, `--repo`, `--body`, `--body-file`).

## Files changed

- EDIT: `.agents/scripts/shared-gh-wrappers.sh:647-667` — guarded inner shift calls

## Verification

- `shellcheck .agents/scripts/shared-gh-wrappers.sh` — no new violations (same 3 pre-existing SC2016 info-level findings for GraphQL strings)
- Existing tests for `_gh_auto_link_sub_issue` unchanged

Resolves #20516
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.94 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 2m and 7,460 tokens on this as a headless worker.
