### PR TITLE
GH#20513: fix local variable style in shared-gh-wrappers-rest-fallback (separate decl from assignment, hoist _tok)

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -171,8 +171,11 @@ _gh_issue_create_rest() {
 	local repo=""
 	local milestone=""
 	local has_body=0
-	local -a labels=()
-	local -a assignees=()
+	local -a labels
+	local -a assignees
+	local _tok
+	labels=()
+	assignees=()
 
 	while [[ $# -gt 0 ]]; do
 		local _arg="$1"
@@ -185,10 +188,10 @@ _gh_issue_create_rest() {
 		--body=*) body="${_arg#--body=}"; has_body=1; shift ;;
 		--body-file) body_file="${2:-}"; has_body=1; shift 2 ;;
 		--body-file=*) body_file="${_arg#--body-file=}"; has_body=1; shift ;;
-		--label) local _tok; while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_gh_split_csv "${2:-}"); shift 2 ;;
-		--label=*) local _tok; while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_gh_split_csv "${_arg#--label=}"); shift ;;
-		--assignee) local _tok; while IFS= read -r _tok; do [[ -n "$_tok" ]] && assignees+=("$_tok"); done < <(_gh_split_csv "${2:-}"); shift 2 ;;
-		--assignee=*) local _tok; while IFS= read -r _tok; do [[ -n "$_tok" ]] && assignees+=("$_tok"); done < <(_gh_split_csv "${_arg#--assignee=}"); shift ;;
+		--label) while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_gh_split_csv "${2:-}"); shift 2 ;;
+		--label=*) while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_gh_split_csv "${_arg#--label=}"); shift ;;
+		--assignee) while IFS= read -r _tok; do [[ -n "$_tok" ]] && assignees+=("$_tok"); done < <(_gh_split_csv "${2:-}"); shift 2 ;;
+		--assignee=*) while IFS= read -r _tok; do [[ -n "$_tok" ]] && assignees+=("$_tok"); done < <(_gh_split_csv "${_arg#--assignee=}"); shift ;;
 		--milestone) milestone="${2:-}"; shift 2 ;;
 		--milestone=*) milestone="${_arg#--milestone=}"; shift ;;
 		*) shift ;;
@@ -332,7 +335,15 @@ _gh_issue_edit_rest() {
 	local milestone=""
 	local state=""
 	local has_title=0 has_body=0 has_milestone=0 has_state=0
-	local -a add_labels=() rm_labels=() add_assignees=() rm_assignees=()
+	local -a add_labels
+	local -a rm_labels
+	local -a add_assignees
+	local -a rm_assignees
+	local _tok
+	add_labels=()
+	rm_labels=()
+	add_assignees=()
+	rm_assignees=()
 
 	local _first="${1:-}"
 	if [[ $# -gt 0 && "$_first" != --* ]]; then
@@ -351,14 +362,14 @@ _gh_issue_edit_rest() {
 		--body=*) body="${_arg#--body=}"; has_body=1; shift ;;
 		--body-file) body_file="${2:-}"; has_body=1; shift 2 ;;
 		--body-file=*) body_file="${_arg#--body-file=}"; has_body=1; shift ;;
-		--add-label) local _tok; while IFS= read -r _tok; do [[ -n "$_tok" ]] && add_labels+=("$_tok"); done < <(_gh_split_csv "${2:-}"); shift 2 ;;
-		--add-label=*) local _tok; while IFS= read -r _tok; do [[ -n "$_tok" ]] && add_labels+=("$_tok"); done < <(_gh_split_csv "${_arg#--add-label=}"); shift ;;
-		--remove-label) local _tok; while IFS= read -r _tok; do [[ -n "$_tok" ]] && rm_labels+=("$_tok"); done < <(_gh_split_csv "${2:-}"); shift 2 ;;
-		--remove-label=*) local _tok; while IFS= read -r _tok; do [[ -n "$_tok" ]] && rm_labels+=("$_tok"); done < <(_gh_split_csv "${_arg#--remove-label=}"); shift ;;
-		--add-assignee) local _tok; while IFS= read -r _tok; do [[ -n "$_tok" ]] && add_assignees+=("$_tok"); done < <(_gh_split_csv "${2:-}"); shift 2 ;;
-		--add-assignee=*) local _tok; while IFS= read -r _tok; do [[ -n "$_tok" ]] && add_assignees+=("$_tok"); done < <(_gh_split_csv "${_arg#--add-assignee=}"); shift ;;
-		--remove-assignee) local _tok; while IFS= read -r _tok; do [[ -n "$_tok" ]] && rm_assignees+=("$_tok"); done < <(_gh_split_csv "${2:-}"); shift 2 ;;
-		--remove-assignee=*) local _tok; while IFS= read -r _tok; do [[ -n "$_tok" ]] && rm_assignees+=("$_tok"); done < <(_gh_split_csv "${_arg#--remove-assignee=}"); shift ;;
+		--add-label) while IFS= read -r _tok; do [[ -n "$_tok" ]] && add_labels+=("$_tok"); done < <(_gh_split_csv "${2:-}"); shift 2 ;;
+		--add-label=*) while IFS= read -r _tok; do [[ -n "$_tok" ]] && add_labels+=("$_tok"); done < <(_gh_split_csv "${_arg#--add-label=}"); shift ;;
+		--remove-label) while IFS= read -r _tok; do [[ -n "$_tok" ]] && rm_labels+=("$_tok"); done < <(_gh_split_csv "${2:-}"); shift 2 ;;
+		--remove-label=*) while IFS= read -r _tok; do [[ -n "$_tok" ]] && rm_labels+=("$_tok"); done < <(_gh_split_csv "${_arg#--remove-label=}"); shift ;;
+		--add-assignee) while IFS= read -r _tok; do [[ -n "$_tok" ]] && add_assignees+=("$_tok"); done < <(_gh_split_csv "${2:-}"); shift 2 ;;
+		--add-assignee=*) while IFS= read -r _tok; do [[ -n "$_tok" ]] && add_assignees+=("$_tok"); done < <(_gh_split_csv "${_arg#--add-assignee=}"); shift ;;
+		--remove-assignee) while IFS= read -r _tok; do [[ -n "$_tok" ]] && rm_assignees+=("$_tok"); done < <(_gh_split_csv "${2:-}"); shift 2 ;;
+		--remove-assignee=*) while IFS= read -r _tok; do [[ -n "$_tok" ]] && rm_assignees+=("$_tok"); done < <(_gh_split_csv "${_arg#--remove-assignee=}"); shift ;;
 		--milestone) milestone="${2:-}"; has_milestone=1; shift 2 ;;
 		--milestone=*) milestone="${_arg#--milestone=}"; has_milestone=1; shift ;;
 		--state) state="${2:-}"; has_state=1; shift 2 ;;
@@ -550,7 +561,9 @@ _gh_pr_create_rest() {
 	local repo=""
 	local draft=0
 	local has_body=0
-	local -a labels=()
+	local -a labels
+	local _tok
+	labels=()
 
 	while [[ $# -gt 0 ]]; do
 		local _arg="$1"
@@ -568,8 +581,8 @@ _gh_pr_create_rest() {
 		--body-file) body_file="${2:-}"; has_body=1; shift 2 ;;
 		--body-file=*) body_file="${_arg#--body-file=}"; has_body=1; shift ;;
 		--draft) draft=1; shift ;;
-		--label) local _tok; while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_gh_split_csv "${2:-}"); shift 2 ;;
-		--label=*) local _tok; while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_gh_split_csv "${_arg#--label=}"); shift ;;
+		--label) while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_gh_split_csv "${2:-}"); shift 2 ;;
+		--label=*) while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_gh_split_csv "${_arg#--label=}"); shift ;;
 		*) shift ;;
 		esac
 	done
@@ -721,7 +734,9 @@ _rest_issue_list() {
 	local limit=30
 	local jq_expr=""
 	local assignee=""
-	local -a labels=()
+	local -a labels
+	local _tok
+	labels=()
 
 	while [[ $# -gt 0 ]]; do
 		local _arg="$1"
@@ -730,8 +745,8 @@ _rest_issue_list() {
 		--repo=*) repo="${_arg#--repo=}"; shift ;;
 		--state) state="${2:-}"; shift 2 ;;
 		--state=*) state="${_arg#--state=}"; shift ;;
-		--label) local _tok; while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_gh_split_csv "${2:-}"); shift 2 ;;
-		--label=*) local _tok; while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_gh_split_csv "${_arg#--label=}"); shift ;;
+		--label) while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_gh_split_csv "${2:-}"); shift 2 ;;
+		--label=*) while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_gh_split_csv "${_arg#--label=}"); shift ;;
 		--assignee) assignee="${2:-}"; shift 2 ;;
 		--assignee=*) assignee="${_arg#--assignee=}"; shift ;;
 		--limit) limit="${2:-}"; shift 2 ;;


### PR DESCRIPTION
## Summary

Addresses review bot feedback from PR #20490: separate `local` variable declarations from assignments and hoist `_tok` to function scope in four REST fallback functions.

**Outcome: B** — bot premises verified correct, implementing the fix.

### Changes

In four functions in `.agents/scripts/shared-gh-wrappers-rest-fallback.sh`:

- `_gh_issue_create_rest` (line 167): split `local -a labels=()` and `local -a assignees=()` into separate `local -a X; X=()` forms; add `local _tok` at function level; remove 4× redundant `local _tok;` from case branches.
- `_gh_issue_edit_rest` (line 329): split `local -a add_labels=() rm_labels=() add_assignees=() rm_assignees=()` into 4 separate declarations + assignments; add `local _tok`; remove 8× redundant `local _tok;` from case branches.
- `_gh_pr_create_rest` (line 555): split `local -a labels=()`; add `local _tok`; remove 2× redundant `local _tok;` from case branches.
- `_rest_issue_list` (line 731): split `local -a labels=()`; add `local _tok`; remove 2× redundant `local _tok;` from case branches.

ShellCheck: passes clean (zero new violations).

## Complexity Bump Justification

Functions `_gh_issue_edit_rest` and `_gh_pr_create_rest` were both exactly 99 lines in `origin/main` (1 line below the 100-line threshold). Applying the required style fix — separating `local -a X=()` into `local -a X; X=()` and hoisting `local _tok` — mechanically adds lines.

- File: `.agents/scripts/shared-gh-wrappers-rest-fallback.sh:329` (`_gh_issue_edit_rest`)
- File: `.agents/scripts/shared-gh-wrappers-rest-fallback.sh:555` (`_gh_pr_create_rest`)
- `_gh_issue_edit_rest`: base=99, head=107, new=8
- `_gh_pr_create_rest`: base=99, head=101, new=2

Both functions were at the threshold boundary. The violations are artefacts of the mandatory style fix — not new functional complexity. Refactoring to reduce function length is a separate concern.

Resolves #20513


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.94 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 10m and 2,703 tokens on this as a headless worker. Overall, 1m since this issue was created.