### PR TITLE
GH#20508: handle default_branch fetch failure in _dirty_pr_action_rebase

### DIFF
--- a/.agents/scripts/pulse-dirty-pr-sweep.sh
+++ b/.agents/scripts/pulse-dirty-pr-sweep.sh
@@ -633,7 +633,11 @@ _dirty_pr_action_rebase() {
 	local ephemeral_branch="dirty-pr-sweep/pr-${pr_number}-${ephemeral_branch_ts}"
 
 	# Refresh origin/<default_branch> and origin/<head_ref> before anything else.
-	git -C "$repo_path" fetch --quiet origin "${default_branch}:refs/remotes/origin/${default_branch}" 2>/dev/null || true
+	git -C "$repo_path" fetch --quiet origin "${default_branch}:refs/remotes/origin/${default_branch}" 2>/dev/null || {
+		_dps_log "PR #$pr_number ($repo_slug): fetch of origin/${default_branch} failed — skipping rebase"
+		rm -rf "$ephemeral" 2>/dev/null || true
+		return 1
+	}
 	git -C "$repo_path" fetch --quiet origin "${head_ref}:refs/remotes/origin/${head_ref}" 2>/dev/null || {
 		_dps_log "PR #$pr_number ($repo_slug): fetch of origin/${head_ref} failed — skipping rebase"
 		rm -rf "$ephemeral" 2>/dev/null || true

--- a/.agents/scripts/pulse-dirty-pr-sweep.sh
+++ b/.agents/scripts/pulse-dirty-pr-sweep.sh
@@ -7,7 +7,7 @@
 # actions based on age, content, and conflict scope:
 #
 #   Auto-rebase : PR < 48h old AND maintainer/worker-owned AND only TODO.md
-#                 is conflicting → rebase onto origin/main with union merge
+#                 is conflicting → rebase onto origin/<default_branch> with union merge
 #                 strategy, force-push, post documentation comment.
 #   Auto-close  : PR > 7d old AND no human commits in 3d AND no
 #                 `do-not-close` label → close with a "superseded" comment.


### PR DESCRIPTION
## Summary

Handle `git fetch` failure for `origin/${default_branch}` in `_dirty_pr_action_rebase` with the same error-logging pattern already used for the `head_ref` fetch.

**Before:** `|| true` silently ignored fetch failures, allowing the subsequent rebase to run against a stale or missing remote reference.

**After:** fetch failure logs a message via `_dps_log`, cleans up the ephemeral directory, and returns 1 — identical to the `head_ref` fetch pattern on the next lines.

## Change

- EDIT: `.agents/scripts/pulse-dirty-pr-sweep.sh:636` — replace `2>/dev/null || true` with a `|| { log + cleanup + return 1 }` block

## Verification

- `shellcheck .agents/scripts/pulse-dirty-pr-sweep.sh` → 0 violations
- Pre-commit hook passed

## Complexity Bump Justification

`complexity-bump-ok` label applied. The function-complexity scanner reports 1 new violation from `pulse-dirty-pr-sweep.sh:_dirty_pr_action_rebase`. Measurements: base=33, head=34, new=1. The function grew from ~99 to 103 lines due to adding 4 net lines of required error handling (matching the existing `head_ref` fetch pattern in the same function). No reduction is possible without discarding the correctness fix — this is a minimum-viable change.

Resolves #20508

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.94 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 10m and 8,727 tokens on this as a headless worker.
