### PR TITLE
t2749: Phase 2 fill-floor for same-cycle consolidation child dispatch

### DIFF
--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -821,6 +821,14 @@ _adaptive_launch_settle_wait() {
 # Dispatches deterministic fill floor, then waits adaptively based on
 # how many workers were launched so they can appear in process lists
 # before the next worker count.
+#
+# t2749: Two-phase fill floor. Phase 1 is the existing candidate loop.
+# Phase 2 fires when _dispatch_issue_consolidation created a new child
+# during Phase 1 (detected via a per-cycle sentinel file). The child is
+# not in Phase 1's candidate list (enumeration ran before the loop), so
+# Phase 2 re-enumerates and dispatches it in the same cycle. Without
+# Phase 2, the child waits a minimum of one additional pulse cycle
+# (3–7 min stable; 10–20 min when wrapper cycles are unstable).
 #######################################
 apply_deterministic_fill_floor() {
 	if [[ -f "$STOP_FLAG" ]]; then
@@ -833,6 +841,31 @@ apply_deterministic_fill_floor() {
 	[[ "$fill_dispatched" =~ ^[0-9]+$ ]] || fill_dispatched=0
 
 	_adaptive_launch_settle_wait "$fill_dispatched" "fill floor"
+
+	# t2749: Phase 2 — re-enumerate when consolidation created a child during
+	# Phase 1. The sentinel is written by _dispatch_issue_consolidation in
+	# pulse-triage.sh. Named with $$ (top-level PID) so it is cycle-scoped.
+	# Consume it before checking worker slots to prevent double Phase 2 when
+	# apply_deterministic_fill_floor is called again in the same cycle
+	# (early dispatch pass + main fill floor both invoke this function).
+	local _p2_sentinel="${HOME}/.aidevops/cache/pulse-cycle-$$-consolidation-fired"
+	if [[ -f "$_p2_sentinel" && ! -f "$STOP_FLAG" ]]; then
+		rm -f "$_p2_sentinel" 2>/dev/null || true
+		local _p2_active _p2_max
+		_p2_active=$(count_active_workers)
+		_p2_max=$(get_max_workers_target)
+		[[ "$_p2_active" =~ ^[0-9]+$ ]] || _p2_active=0
+		[[ "$_p2_max" =~ ^[0-9]+$ ]] || _p2_max=1
+		if [[ "$_p2_active" -lt "$_p2_max" ]]; then
+			echo "[pulse-wrapper] Deterministic fill floor Phase 2: consolidation child created during Phase 1 (active=${_p2_active}, max=${_p2_max}) — re-enumerating candidates (t2749)" >>"$LOGFILE"
+			local fill_dispatched_p2
+			fill_dispatched_p2=$(dispatch_deterministic_fill_floor) || fill_dispatched_p2=0
+			[[ "$fill_dispatched_p2" =~ ^[0-9]+$ ]] || fill_dispatched_p2=0
+			_adaptive_launch_settle_wait "$fill_dispatched_p2" "fill floor phase 2"
+		else
+			echo "[pulse-wrapper] Deterministic fill floor Phase 2: consolidation child created but slots full (active=${_p2_active}, max=${_p2_max}) — skipping (t2749)" >>"$LOGFILE"
+		fi
+	fi
 	return 0
 }
 

--- a/.agents/scripts/pulse-triage.sh
+++ b/.agents/scripts/pulse-triage.sh
@@ -1365,25 +1365,15 @@ _dispatch_issue_consolidation() {
 	# Ensure labels exist on this repo up front. Idempotent (--force).
 	_ensure_consolidation_labels "$repo_slug"
 
-	# t2161: Safety net — skip dispatch if an open PR with a closing keyword
-	# already resolves this parent. Mirrors the same guard in
-	# _issue_needs_consolidation; checked here too because the dispatch path
-	# is reachable from contributor runners on stale code where the gate
-	# may have been satisfied at flag time but a fix PR landed since.
-	# (Note: _backfill_stale_consolidation_labels has called the gate since
-	# t2144/A2. This defence-in-depth remains for cross-runner version drift.)
-	# Cheaper than _consolidation_child_exists (one PR search vs two issue
-	# searches + label read) so it runs first.
+	# t2161: skip if a resolving PR already exists — defence-in-depth vs
+	# cross-runner version drift; cheaper than child_exists, runs first.
 	if _consolidation_resolving_pr_exists "$issue_number" "$repo_slug"; then
 		echo "[pulse-wrapper] Consolidation: in-flight resolving PR exists for #${issue_number} in ${repo_slug}; skipping dispatch (t2161)" >>"$LOGFILE"
 		return 0
 	fi
 
-	# Dedup: if an open consolidation-task already references this parent,
-	# just ensure the parent is flagged and return. Do NOT create a duplicate.
-	# t2151: _consolidation_child_exists also returns 0 when the lock label
-	# is present, so a competing runner's in-flight creation blocks us here
-	# before we ever touch the acquire path.
+	# Dedup: child already exists (t2151: lock label also returns 0, blocking
+	# competing runners before they reach the acquire path).
 	if _consolidation_child_exists "$issue_number" "$repo_slug"; then
 		gh issue edit "$issue_number" --repo "$repo_slug" \
 			--add-label "needs-consolidation" 2>/dev/null || true
@@ -1391,10 +1381,8 @@ _dispatch_issue_consolidation() {
 		return 0
 	fi
 
-	# t2151: acquire the cross-runner advisory lock before any state changes
-	# that would be expensive or visible to cause a partial-state race.
-	# If we don't win the lock, another runner will create the child; we
-	# just need to flag the parent as needing consolidation and return.
+	# t2151: acquire advisory lock before any visible state changes;
+	# if we lose, flag the parent and yield.
 	if ! _consolidation_lock_acquire "$issue_number" "$repo_slug"; then
 		gh issue edit "$issue_number" --repo "$repo_slug" \
 			--add-label "needs-consolidation" 2>/dev/null || true

--- a/.agents/scripts/pulse-triage.sh
+++ b/.agents/scripts/pulse-triage.sh
@@ -1449,6 +1449,13 @@ _dispatch_issue_consolidation() {
 
 	# Flag parent and post the idempotent pointer comment.
 	_post_consolidation_dispatch_comment "$issue_number" "$repo_slug" "$child_num" "$authors_csv"
+	# t2749: Signal to apply_deterministic_fill_floor that a consolidation child
+	# was created this cycle. The sentinel triggers a Phase 2 re-enumeration so
+	# the child is dispatched in the same cycle without waiting for the next pulse
+	# cycle (3–7 min latency when wrapper cycles are stable; 10–20 min when unstable).
+	# Named with $$ (top-level PID) so each pulse run has a unique sentinel file.
+	mkdir -p "${HOME}/.aidevops/cache" 2>/dev/null || true
+	touch "${HOME}/.aidevops/cache/pulse-cycle-$$-consolidation-fired" 2>/dev/null || true
 	# t2151: release the lock — the child now exists on GitHub and
 	# `_consolidation_child_exists` will block subsequent dispatches on
 	# its own, making the lock unnecessary past this point.

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1564,6 +1564,16 @@ main() {
 	local _cycle_start_epoch
 	_cycle_start_epoch=$(date +%s)
 
+	# t2749: Defence-in-depth — clean up any stale Phase 2 consolidation
+	# sentinels from a previous cycle before preflight stages run. With
+	# PID-scoped naming (pulse-cycle-$$-consolidation-fired) a different
+	# PID produces a different filename, so stale files from a crash can
+	# only exist when the OS reuses the same PID. This glob sweep is the
+	# safety net for that rare case. Runs after lock acquisition so only
+	# one process sweeps at a time.
+	# shellcheck disable=SC2086,SC2015
+	rm -f "${HOME}/.aidevops/cache/pulse-cycle-"*"-consolidation-fired" 2>/dev/null || true
+
 	# Phase 0 (t1963): --dry-run short-circuits here. Bootstrap, sourcing,
 	# config validation, lock acquisition, session gate, dedup guard, and
 	# log rotation have all run cleanly by this point — that is the Phase 0

--- a/.agents/scripts/tests/test-pulse-consolidation-phase2.sh
+++ b/.agents/scripts/tests/test-pulse-consolidation-phase2.sh
@@ -462,27 +462,14 @@ test_sentinel_path_pattern_in_source() {
 }
 
 # ---------------------------------------------------------------------------
-# Test 8: _dispatch_issue_consolidation writes sentinel on success
-#
-# Sources pulse-triage.sh with a minimal gh stub and the lock override so
-# the full dispatch path runs and creates the sentinel file. Verifies that
-# the sentinel at pulse-cycle-$$-consolidation-fired exists after a
-# successful _dispatch_issue_consolidation call.
+# Shared helper: create the gh stub binary used by test_dispatch_writes_sentinel.
 # ---------------------------------------------------------------------------
 
-test_dispatch_writes_sentinel() {
-	local tmp; tmp=$(mktemp -d -t t2749-sentinel.XXXXXX)
-	local fake_home="${tmp}/home"
-	mkdir -p "${fake_home}/.aidevops/cache" "${fake_home}/.aidevops/logs"
-	local gh_log="${tmp}/gh.log"
-	: >"$gh_log"
-
-	# gh stub: handles all expected calls.
-	local stub_bin="${tmp}/bin"
+_create_sentinel_test_stub() {
+	local stub_bin="$1"
+	local gh_log="$2"
 	mkdir -p "$stub_bin"
-	# Export gh_log for use inside the stub.
-	local _GH_LOG_PATH="$gh_log"
-	export _GH_LOG_PATH
+	export _GH_LOG_PATH="$gh_log"
 	cat >"${stub_bin}/gh" <<'STUB'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >>"${_GH_LOG_PATH:-/dev/null}"
@@ -513,6 +500,27 @@ esac
 exit 0
 STUB
 	chmod +x "${stub_bin}/gh"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 8: _dispatch_issue_consolidation writes sentinel on success
+#
+# Sources pulse-triage.sh with a minimal gh stub and the lock override so
+# the full dispatch path runs and creates the sentinel file. Verifies that
+# the sentinel at pulse-cycle-$$-consolidation-fired exists after a
+# successful _dispatch_issue_consolidation call.
+# ---------------------------------------------------------------------------
+
+test_dispatch_writes_sentinel() {
+	local tmp; tmp=$(mktemp -d -t t2749-sentinel.XXXXXX)
+	local fake_home="${tmp}/home"
+	mkdir -p "${fake_home}/.aidevops/cache" "${fake_home}/.aidevops/logs"
+	local gh_log="${tmp}/gh.log"
+	: >"$gh_log"
+
+	local stub_bin="${tmp}/bin"
+	_create_sentinel_test_stub "$stub_bin" "$gh_log"
 
 	local prev_path="$PATH"
 	export PATH="${stub_bin}:${PATH}"
@@ -535,14 +543,12 @@ STUB
 	# Lock override: bypass gh api user call in _consolidation_lock_self_login.
 	export CONSOLIDATION_LOCK_SELF_LOGIN_OVERRIDE="testrunner"
 
-	# gh stub env vars for view/list/comments.
 	export GH_ISSUE_VIEW_TITLE="Test parent title"
 	export GH_ISSUE_VIEW_BODY="Parent body text for testing."
 	export GH_ISSUE_VIEW_LABELS="bug,tier:standard"
 	export GH_ISSUE_LIST_CHILD_JSON="[]"
 	export GH_ISSUE_LIST_CHILD_CLOSED_JSON="[]"
 	export GH_PR_LIST_RESOLVING_JSON="[]"
-	# Two long comments (>50 chars) to satisfy the threshold.
 	local long_body="Detailed review comment with enough characters to clear the minimum length threshold for consolidation."
 	export GH_API_COMMENTS_JSON
 	GH_API_COMMENTS_JSON=$(printf '[
@@ -550,9 +556,7 @@ STUB
   {"user": {"login": "bob",   "type": "User"}, "created_at": "2026-01-01T01:00:00Z", "body": "%s"}
 ]' "$long_body" "$long_body")
 
-	# Clear the triage module load guard before sourcing.
 	unset _PULSE_TRIAGE_LOADED
-
 	# shellcheck disable=SC1091
 	source "${REPO_ROOT}/.agents/scripts/pulse-triage.sh" || {
 		printf 'ERROR: failed to source pulse-triage.sh\n' >&2

--- a/.agents/scripts/tests/test-pulse-consolidation-phase2.sh
+++ b/.agents/scripts/tests/test-pulse-consolidation-phase2.sh
@@ -1,0 +1,637 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-pulse-consolidation-phase2.sh — regression tests for t2749
+#
+# Covers the Phase 2 fill-floor pass that dispatches consolidation-task
+# children in the same pulse cycle as their creation.
+#
+# The bug: newly-created consolidation children were invisible to the
+# fill-floor loop because candidate enumeration ran BEFORE the loop,
+# forcing children to wait a minimum of one additional pulse cycle
+# (3–7 min stable; 10–20 min with unstable wrapper cycles).
+#
+# Fix: after Phase 1 completes, check for the per-cycle sentinel file
+# (pulse-cycle-$$-consolidation-fired). If it exists, consume it and
+# re-run dispatch_deterministic_fill_floor (Phase 2) when slots are
+# available.
+#
+# Test strategy:
+#   1. Source pulse-dispatch-engine.sh with stub overrides for the
+#      external functions it calls.
+#   2. Track dispatch_deterministic_fill_floor call count via a counter
+#      file (required because the function runs inside $(...) subshells
+#      where variable mutations are lost in the parent).
+#   3. Verify sentinel file mechanics: created → Phase 2 fires → consumed.
+#   4. Verify Phase 2 is skipped when no sentinel or slots full.
+#   5. Source pulse-triage.sh with lock stubs to verify sentinel write.
+#   6. Verify cycle-start glob cleanup of stale sentinels.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+LOGFILE=""
+
+# ---------------------------------------------------------------------------
+# Test harness helpers
+# ---------------------------------------------------------------------------
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# File-based dispatch counter
+#
+# dispatch_deterministic_fill_floor runs inside $(...) command substitution
+# which creates a subshell. Variable mutations in a subshell are lost when
+# the subshell exits. Use a counter file so the parent shell can read the
+# updated count after the subshell returns.
+# ---------------------------------------------------------------------------
+_DISPATCH_COUNT_FILE=""
+
+_init_dispatch_counter() {
+	_DISPATCH_COUNT_FILE="${TEST_ROOT}/dispatch-count.txt"
+	echo "0" >"$_DISPATCH_COUNT_FILE"
+	return 0
+}
+
+_read_dispatch_count() {
+	cat "$_DISPATCH_COUNT_FILE" 2>/dev/null || echo "0"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Environment setup / teardown
+# ---------------------------------------------------------------------------
+
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d -t t2749-phase2.XXXXXX)
+	export HOME="${TEST_ROOT}/home"
+	mkdir -p "${HOME}/.aidevops/cache" "${HOME}/.aidevops/logs"
+
+	LOGFILE="${TEST_ROOT}/pulse.log"
+	export LOGFILE
+	: >"$LOGFILE"
+
+	# STOP_FLAG must NOT exist by default.
+	export STOP_FLAG="${TEST_ROOT}/stop.flag"
+	[[ -f "$STOP_FLAG" ]] && rm -f "$STOP_FLAG"
+
+	_init_dispatch_counter
+
+	# Stubs: defined BEFORE sourcing so the module load does not fail on
+	# missing external symbols. The module's own definitions overwrite
+	# these during source; we re-declare them AFTER source to win back.
+
+	dispatch_deterministic_fill_floor() {
+		local c; c=$(cat "$_DISPATCH_COUNT_FILE" 2>/dev/null || echo 0)
+		echo "$((c + 1))" >"$_DISPATCH_COUNT_FILE"
+		printf '0\n'
+		return 0
+	}
+	count_active_workers() { printf '%s\n' "${_STUB_ACTIVE_WORKERS:-0}"; return 0; }
+	get_max_workers_target() { printf '%s\n' "${_STUB_MAX_WORKERS:-3}"; return 0; }
+	_adaptive_launch_settle_wait() { return 0; }
+	pulse_dispatch_debug_log() { return 0; }
+
+	# Prevent loading the rate-limit circuit breaker (it has its own deps).
+	export _PULSE_RATE_LIMIT_CB_LOADED=1
+
+	# Clear the engine load guard so the module re-evaluates on source.
+	unset _PULSE_DISPATCH_ENGINE_LOADED
+
+	# shellcheck disable=SC1091
+	source "${REPO_ROOT}/.agents/scripts/pulse-dispatch-engine.sh" || {
+		printf 'ERROR: failed to source pulse-dispatch-engine.sh\n' >&2
+		return 1
+	}
+
+	# Re-declare stubs AFTER source to override the module's definitions.
+	dispatch_deterministic_fill_floor() {
+		local c; c=$(cat "$_DISPATCH_COUNT_FILE" 2>/dev/null || echo 0)
+		echo "$((c + 1))" >"$_DISPATCH_COUNT_FILE"
+		printf '0\n'
+		return 0
+	}
+	count_active_workers() { printf '%s\n' "${_STUB_ACTIVE_WORKERS:-0}"; return 0; }
+	get_max_workers_target() { printf '%s\n' "${_STUB_MAX_WORKERS:-3}"; return 0; }
+	_adaptive_launch_settle_wait() { return 0; }
+
+	_STUB_ACTIVE_WORKERS=0
+	_STUB_MAX_WORKERS=3
+
+	return 0
+}
+
+teardown_test_env() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	TEST_ROOT=""
+	LOGFILE=""
+	_DISPATCH_COUNT_FILE=""
+	unset _PULSE_DISPATCH_ENGINE_LOADED _PULSE_RATE_LIMIT_CB_LOADED
+	unset _STUB_ACTIVE_WORKERS _STUB_MAX_WORKERS
+	return 0
+}
+
+# Sentinel path: mirrors the formula in pulse-dispatch-engine.sh.
+_sentinel_path() {
+	printf '%s/.aidevops/cache/pulse-cycle-%s-consolidation-fired\n' \
+		"$HOME" "$$"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: sentinel exists + worker slots available → Phase 2 fires
+# ---------------------------------------------------------------------------
+
+test_phase2_fires_when_sentinel_and_slots_available() {
+	setup_test_env
+	_STUB_ACTIVE_WORKERS=0
+	_STUB_MAX_WORKERS=3
+
+	# Simulate consolidation fired: create the sentinel.
+	touch "$(_sentinel_path)"
+
+	_init_dispatch_counter
+	apply_deterministic_fill_floor
+	local count; count=$(_read_dispatch_count)
+
+	local sentinel_after; sentinel_after="$(_sentinel_path)"
+	local failures=0 failmsg=""
+
+	# Phase 1 + Phase 2 = dispatch called twice.
+	if [[ "$count" -ne 2 ]]; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | dispatch called ${count} times (expected 2)"
+	fi
+
+	# Sentinel must be consumed.
+	if [[ -f "$sentinel_after" ]]; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | sentinel not removed after Phase 2"
+	fi
+
+	# Phase 2 log line must appear.
+	if ! grep -q "fill floor Phase 2.*re-enumerating" "$LOGFILE" 2>/dev/null; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | Phase 2 log line not found"
+	fi
+
+	if [[ "$failures" -eq 0 ]]; then
+		print_result "t2749: Phase 2 fires when sentinel exists and slots available" 0
+	else
+		print_result "t2749: Phase 2 fires when sentinel exists and slots available" 1 "$failmsg"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: no sentinel → Phase 2 does NOT fire
+# ---------------------------------------------------------------------------
+
+test_phase2_skipped_when_no_sentinel() {
+	setup_test_env
+	_STUB_ACTIVE_WORKERS=0
+	_STUB_MAX_WORKERS=3
+	# No sentinel created.
+
+	_init_dispatch_counter
+	apply_deterministic_fill_floor
+	local count; count=$(_read_dispatch_count)
+
+	local failures=0 failmsg=""
+
+	# Only Phase 1 should dispatch.
+	if [[ "$count" -ne 1 ]]; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | dispatch called ${count} times (expected 1)"
+	fi
+
+	# No Phase 2 log line.
+	if grep -q "fill floor Phase 2" "$LOGFILE" 2>/dev/null; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | unexpected Phase 2 log line found"
+	fi
+
+	if [[ "$failures" -eq 0 ]]; then
+		print_result "t2749: Phase 2 skipped when no sentinel" 0
+	else
+		print_result "t2749: Phase 2 skipped when no sentinel" 1 "$failmsg"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: sentinel exists but all slots occupied → Phase 2 skipped
+# ---------------------------------------------------------------------------
+
+test_phase2_skipped_when_slots_full() {
+	setup_test_env
+	_STUB_ACTIVE_WORKERS=3
+	_STUB_MAX_WORKERS=3
+
+	touch "$(_sentinel_path)"
+
+	_init_dispatch_counter
+	apply_deterministic_fill_floor
+	local count; count=$(_read_dispatch_count)
+
+	local sentinel_after; sentinel_after="$(_sentinel_path)"
+	local failures=0 failmsg=""
+
+	# Sentinel consumed even when Phase 2 is skipped (prevents triggering
+	# Phase 2 a second time if apply_deterministic_fill_floor is called again
+	# in the same cycle: early-dispatch pass + main fill floor both call it).
+	if [[ -f "$sentinel_after" ]]; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | sentinel not consumed despite slot check"
+	fi
+
+	# Only Phase 1 dispatched.
+	if [[ "$count" -ne 1 ]]; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | dispatch called ${count} times (expected 1)"
+	fi
+
+	# Slots-full skip log line.
+	if ! grep -q "Phase 2.*slots full" "$LOGFILE" 2>/dev/null; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | 'Phase 2.*slots full' log line not found"
+	fi
+
+	if [[ "$failures" -eq 0 ]]; then
+		print_result "t2749: Phase 2 skipped (sentinel consumed) when slots full" 0
+	else
+		print_result "t2749: Phase 2 skipped (sentinel consumed) when slots full" 1 "$failmsg"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: sentinel consumed on first call — second call does NOT re-trigger
+# ---------------------------------------------------------------------------
+
+test_sentinel_consumed_prevents_double_phase2() {
+	setup_test_env
+	_STUB_ACTIVE_WORKERS=0
+	_STUB_MAX_WORKERS=3
+
+	touch "$(_sentinel_path)"
+
+	_init_dispatch_counter
+
+	# First call: Phase 1 + Phase 2 (sentinel consumed).
+	apply_deterministic_fill_floor
+	local count_after_first; count_after_first=$(_read_dispatch_count)
+
+	# Second call: sentinel gone → Phase 1 only.
+	apply_deterministic_fill_floor
+	local count_after_second; count_after_second=$(_read_dispatch_count)
+
+	local failures=0 failmsg=""
+	local delta=$((count_after_second - count_after_first))
+
+	if [[ "$count_after_first" -ne 2 ]]; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | first call: count=${count_after_first} (expected 2)"
+	fi
+
+	if [[ "$delta" -ne 1 ]]; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | second call: delta=${delta} (expected 1, no Phase 2)"
+	fi
+
+	if [[ "$failures" -eq 0 ]]; then
+		print_result "t2749: sentinel consumed — second call skips Phase 2" 0
+	else
+		print_result "t2749: sentinel consumed — second call skips Phase 2" 1 "$failmsg"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 5: stop flag prevents entire function (Phase 1 + Phase 2 skipped)
+# ---------------------------------------------------------------------------
+
+test_stop_flag_skips_entire_fill_floor() {
+	setup_test_env
+	_STUB_ACTIVE_WORKERS=0
+	_STUB_MAX_WORKERS=3
+
+	touch "$(_sentinel_path)"
+	touch "$STOP_FLAG"  # Set stop flag.
+
+	_init_dispatch_counter
+	apply_deterministic_fill_floor
+	local count; count=$(_read_dispatch_count)
+
+	local failures=0 failmsg=""
+
+	# Stop flag short-circuits before Phase 1 — dispatch count must be 0.
+	if [[ "$count" -ne 0 ]]; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | dispatch called ${count} times despite stop flag (expected 0)"
+	fi
+
+	rm -f "$STOP_FLAG"
+
+	if [[ "$failures" -eq 0 ]]; then
+		print_result "t2749: stop flag skips entire fill floor (Phase 1 + Phase 2)" 0
+	else
+		print_result "t2749: stop flag skips entire fill floor (Phase 1 + Phase 2)" 1 "$failmsg"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 6: stale sentinel glob cleanup (pulse-wrapper.sh cycle-start defence)
+#
+# The cycle-start cleanup in main() removes ALL
+# pulse-cycle-*-consolidation-fired files before preflight stages run.
+# This test verifies: the glob pattern matches the sentinel filename format,
+# and leaves unrelated cache files untouched.
+# ---------------------------------------------------------------------------
+
+test_stale_sentinel_glob_cleanup() {
+	local tmp; tmp=$(mktemp -d -t t2749-glob.XXXXXX)
+	local fake_home="${tmp}/home"
+	mkdir -p "${fake_home}/.aidevops/cache"
+
+	# Stale sentinel left by a hypothetical previous cycle.
+	local stale_sentinel="${fake_home}/.aidevops/cache/pulse-cycle-99999-consolidation-fired"
+	touch "$stale_sentinel"
+
+	# An unrelated cache file that must NOT be removed.
+	local unrelated="${fake_home}/.aidevops/cache/some-other-file"
+	touch "$unrelated"
+
+	# Exactly the cleanup command from pulse-wrapper.sh.
+	# shellcheck disable=SC2086,SC2015
+	rm -f "${fake_home}/.aidevops/cache/pulse-cycle-"*"-consolidation-fired" 2>/dev/null || true
+
+	local failures=0 failmsg=""
+
+	if [[ -f "$stale_sentinel" ]]; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | stale sentinel not removed by glob"
+	fi
+
+	if [[ ! -f "$unrelated" ]]; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | unrelated cache file removed by glob (too broad)"
+	fi
+
+	rm -rf "$tmp"
+
+	if [[ "$failures" -eq 0 ]]; then
+		print_result "t2749: stale sentinel glob cleanup is specific enough" 0
+	else
+		print_result "t2749: stale sentinel glob cleanup is specific enough" 1 "$failmsg"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 7: sentinel pattern present in all three modified files
+# ---------------------------------------------------------------------------
+
+test_sentinel_path_pattern_in_source() {
+	local triage_file="${REPO_ROOT}/.agents/scripts/pulse-triage.sh"
+	local engine_file="${REPO_ROOT}/.agents/scripts/pulse-dispatch-engine.sh"
+	local wrapper_file="${REPO_ROOT}/.agents/scripts/pulse-wrapper.sh"
+
+	local failures=0 failmsg=""
+
+	if ! grep -q 'pulse-cycle-\$\$-consolidation-fired' "$triage_file" 2>/dev/null; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | sentinel touch not found in pulse-triage.sh"
+	fi
+
+	if ! grep -q 'pulse-cycle-\$\$-consolidation-fired' "$engine_file" 2>/dev/null; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | sentinel reference not found in pulse-dispatch-engine.sh"
+	fi
+
+	if ! grep -q 'pulse-cycle.*consolidation-fired' "$wrapper_file" 2>/dev/null; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | stale sentinel cleanup not found in pulse-wrapper.sh"
+	fi
+
+	if [[ "$failures" -eq 0 ]]; then
+		print_result "t2749: sentinel pattern present in all three modified files" 0
+	else
+		print_result "t2749: sentinel pattern present in all three modified files" 1 "$failmsg"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 8: _dispatch_issue_consolidation writes sentinel on success
+#
+# Sources pulse-triage.sh with a minimal gh stub and the lock override so
+# the full dispatch path runs and creates the sentinel file. Verifies that
+# the sentinel at pulse-cycle-$$-consolidation-fired exists after a
+# successful _dispatch_issue_consolidation call.
+# ---------------------------------------------------------------------------
+
+test_dispatch_writes_sentinel() {
+	local tmp; tmp=$(mktemp -d -t t2749-sentinel.XXXXXX)
+	local fake_home="${tmp}/home"
+	mkdir -p "${fake_home}/.aidevops/cache" "${fake_home}/.aidevops/logs"
+	local gh_log="${tmp}/gh.log"
+	: >"$gh_log"
+
+	# gh stub: handles all expected calls.
+	local stub_bin="${tmp}/bin"
+	mkdir -p "$stub_bin"
+	# Export gh_log for use inside the stub.
+	local _GH_LOG_PATH="$gh_log"
+	export _GH_LOG_PATH
+	cat >"${stub_bin}/gh" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${_GH_LOG_PATH:-/dev/null}"
+case "${1:-}-${2:-}" in
+issue-view)
+	shift 2
+	local_json=""
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--json) local_json="$2"; shift 2 ;;
+		--jq) shift 2 ;;
+		*) shift ;;
+		esac
+	done
+	case "$local_json" in
+	title) printf 'Test parent title\n' ;;
+	body) printf 'Parent body text for testing.\n' ;;
+	labels) printf 'bug,tier:standard\n' ;;
+	*) printf '\n' ;;
+	esac ;;
+issue-list) printf '[]\n' ;;
+pr-list) printf '[]\n' ;;
+issue-create) printf 'https://github.com/owner/repo/issues/9999\n' ;;
+api-*) printf '[]\n' ;;
+issue-edit | issue-comment | label-create | issue-close) ;;
+*) ;;
+esac
+exit 0
+STUB
+	chmod +x "${stub_bin}/gh"
+
+	local prev_path="$PATH"
+	export PATH="${stub_bin}:${PATH}"
+	local prev_home="$HOME"
+	export HOME="$fake_home"
+
+	local prev_logfile="${LOGFILE:-}"
+	local log_file="${tmp}/pulse.log"
+	: >"$log_file"
+	export LOGFILE="$log_file"
+
+	# Globals required by pulse-triage.sh.
+	export TRIAGE_CACHE_DIR="${tmp}/triage-cache"
+	mkdir -p "$TRIAGE_CACHE_DIR"
+	export ISSUE_CONSOLIDATION_COMMENT_MIN_CHARS=50
+	export ISSUE_CONSOLIDATION_COMMENT_THRESHOLD=2
+	export REPOS_JSON="${tmp}/repos.json"
+	printf '{"initialized_repos": []}\n' >"$REPOS_JSON"
+
+	# Lock override: bypass gh api user call in _consolidation_lock_self_login.
+	export CONSOLIDATION_LOCK_SELF_LOGIN_OVERRIDE="testrunner"
+
+	# gh stub env vars for view/list/comments.
+	export GH_ISSUE_VIEW_TITLE="Test parent title"
+	export GH_ISSUE_VIEW_BODY="Parent body text for testing."
+	export GH_ISSUE_VIEW_LABELS="bug,tier:standard"
+	export GH_ISSUE_LIST_CHILD_JSON="[]"
+	export GH_ISSUE_LIST_CHILD_CLOSED_JSON="[]"
+	export GH_PR_LIST_RESOLVING_JSON="[]"
+	# Two long comments (>50 chars) to satisfy the threshold.
+	local long_body="Detailed review comment with enough characters to clear the minimum length threshold for consolidation."
+	export GH_API_COMMENTS_JSON
+	GH_API_COMMENTS_JSON=$(printf '[
+  {"user": {"login": "alice", "type": "User"}, "created_at": "2026-01-01T00:00:00Z", "body": "%s"},
+  {"user": {"login": "bob",   "type": "User"}, "created_at": "2026-01-01T01:00:00Z", "body": "%s"}
+]' "$long_body" "$long_body")
+
+	# Clear the triage module load guard before sourcing.
+	unset _PULSE_TRIAGE_LOADED
+
+	# shellcheck disable=SC1091
+	source "${REPO_ROOT}/.agents/scripts/pulse-triage.sh" || {
+		printf 'ERROR: failed to source pulse-triage.sh\n' >&2
+		PATH="$prev_path"
+		HOME="$prev_home"
+		LOGFILE="$prev_logfile"
+		rm -rf "$tmp"
+		return 1
+	}
+
+	# gh_create_issue wrapper (defined in shared-constants.sh, not sourced here).
+	gh_create_issue() { gh issue create "$@"; }
+	# gh_issue_comment wrapper: just call the stubbed gh.
+	gh_issue_comment() { gh issue comment "$@"; }
+
+	local sentinel="${fake_home}/.aidevops/cache/pulse-cycle-$$-consolidation-fired"
+	rm -f "$sentinel" 2>/dev/null || true
+
+	local rc=0
+	_dispatch_issue_consolidation 123 "owner/repo" "/tmp/fake-path" || rc=$?
+
+	local failures=0 failmsg=""
+
+	if [[ "$rc" -ne 0 ]]; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | _dispatch_issue_consolidation returned rc=${rc}"
+	fi
+
+	if [[ ! -f "$sentinel" ]]; then
+		failures=$((failures + 1))
+		failmsg="${failmsg} | sentinel file not created"
+		# Diagnostic: show log and gh invocations.
+		printf '  LOG: %s\n' "$(cat "$log_file" 2>/dev/null || echo '<empty>')"
+		printf '  GH:  %s\n' "$(cat "$gh_log" 2>/dev/null || echo '<empty>')"
+	fi
+
+	# Restore environment.
+	rm -f "$sentinel" 2>/dev/null || true
+	PATH="$prev_path"
+	HOME="$prev_home"
+	LOGFILE="$prev_logfile"
+	unset _PULSE_TRIAGE_LOADED CONSOLIDATION_LOCK_SELF_LOGIN_OVERRIDE _GH_LOG_PATH
+	unset GH_ISSUE_VIEW_TITLE GH_ISSUE_VIEW_BODY GH_ISSUE_VIEW_LABELS
+	unset GH_ISSUE_LIST_CHILD_JSON GH_ISSUE_LIST_CHILD_CLOSED_JSON
+	unset GH_PR_LIST_RESOLVING_JSON GH_API_COMMENTS_JSON
+	rm -rf "$tmp"
+
+	if [[ "$failures" -eq 0 ]]; then
+		print_result "t2749: _dispatch_issue_consolidation writes sentinel on success" 0
+	else
+		print_result "t2749: _dispatch_issue_consolidation writes sentinel on success" 1 "$failmsg"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+	test_sentinel_path_pattern_in_source
+	test_phase2_fires_when_sentinel_and_slots_available
+	test_phase2_skipped_when_no_sentinel
+	test_phase2_skipped_when_slots_full
+	test_sentinel_consumed_prevents_double_phase2
+	test_stop_flag_skips_entire_fill_floor
+	test_stale_sentinel_glob_cleanup
+	test_dispatch_writes_sentinel
+
+	echo
+	echo "============================================"
+	printf 'Tests run:    %d\n' "$TESTS_RUN"
+	printf 'Tests failed: %d\n' "$TESTS_FAILED"
+	echo "============================================"
+
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		exit 1
+	fi
+	exit 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Add a "Phase 2" re-enumeration pass to `apply_deterministic_fill_floor` that dispatches consolidation-task children in the **same pulse cycle** as their creation.
- Write a per-cycle sentinel file in `_dispatch_issue_consolidation` after successful child creation so the fill-floor can detect new children without scanning GitHub.
- Clean up stale sentinels at cycle start in `main()` (defence-in-depth for PID reuse after crash).
- Add 8-test regression suite `test-pulse-consolidation-phase2.sh`.

## Why

Observed 2026-04-23, pulse cycle 47496:
- `#20548` created at `00:18:39Z` by `_dispatch_issue_consolidation` during fill-floor iter=7
- Fill-floor continued with the **pre-loop candidate list** (child not in it)
- `#20548` not dispatched until `00:37:25Z` — a 19-minute delay

When wrapper cycles are unstable, each aborted cycle misses the window again, compounding to 10-20 min delays. The consolidation child is ready-to-run the moment it is created — the delay was pure architectural latency.

## How

Sentinel mechanism:
1. `_dispatch_issue_consolidation` touches `${HOME}/.aidevops/cache/pulse-cycle-$$-consolidation-fired` after success.
2. `apply_deterministic_fill_floor` checks for sentinel after Phase 1, consumes it, and runs `dispatch_deterministic_fill_floor` once more when slots are available (Phase 2).
3. `main()` globs stale `pulse-cycle-*-consolidation-fired` files and removes them at cycle start.

## Verification

```bash
shellcheck .agents/scripts/pulse-dispatch-engine.sh .agents/scripts/pulse-triage.sh .agents/scripts/pulse-wrapper.sh
bash .agents/scripts/tests/test-pulse-consolidation-phase2.sh  # 8/8 PASS
```

Resolves #20553

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.95 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 18m and 59,436 tokens on this as a headless worker.
