### PR TITLE
GH#20550: two-phase bot support in _comment_is_settled (Option A')

### DIFF
--- a/.agents/scripts/review-bot-gate-helper.sh
+++ b/.agents/scripts/review-bot-gate-helper.sh
@@ -86,6 +86,13 @@ NON_REVIEW_PATTERNS=(
 # Backwards-compat alias for any callers/tests still referencing the old name.
 RATE_LIMIT_PATTERNS=("${NON_REVIEW_PATTERNS[@]}")
 
+# Bots that post a Phase 1 placeholder and later edit it with real review
+# content. For these, age-derived settlement is unreliable — require
+# edit-observed settlement (edit_delta > 0). All other bots preserve existing
+# OR semantics (edit_delta >= min_lag OR age >= min_lag).
+# GH#20550 / #20494 — two-phase bot list (Option A').
+readonly TWO_PHASE_BOTS=("coderabbitai")
+
 SKIP_LABEL="skip-review-gate"
 
 # GH#3827: Grace period for rate-limited bots. If bots posted rate-limit
@@ -185,6 +192,18 @@ _get_min_edit_lag() {
 	return 0
 }
 
+_is_two_phase_bot() {
+	# GH#20550: Return 0 if bot_login is in TWO_PHASE_BOTS; 1 otherwise.
+	# These bots post a Phase 1 placeholder and later edit with real review content.
+	# Age-derived settlement is unreliable for them — only edit_delta > 0 counts.
+	local bot_login="$1"
+	local b
+	for b in "${TWO_PHASE_BOTS[@]}"; do
+		[[ "$bot_login" == "$b" ]] && return 0
+	done
+	return 1
+}
+
 _to_epoch() {
 	# Cross-platform ISO-8601 → epoch (macOS BSD date vs GNU date). Returns 0
 	# on parse failure so callers can detect "unknown" and behave conservatively.
@@ -210,9 +229,16 @@ _comment_is_settled() {
 	# If timestamps are missing/unparseable (older API responses, network
 	# issues), be conservative: treat as settled — better to PASS the gate
 	# than block forever on missing data.
+	#
+	# GH#20550: For two-phase bots (e.g. coderabbitai), age-derived settlement
+	# is disabled. Only edit_delta > 0 counts — a Phase 1 placeholder that has
+	# aged past min_lag is still NOT a real review for two-phase bots.
+	# 4th param bot_login is optional (defaults to ""); omitting it preserves
+	# old non-two-phase OR semantics for all callers that don't supply it.
 	local created_at="$1"
 	local updated_at="$2"
 	local min_lag="$3"
+	local bot_login="${4:-}"
 
 	# Missing inputs → conservative pass.
 	[[ -z "$created_at" ]] && return 0
@@ -229,6 +255,14 @@ _comment_is_settled() {
 	local edit_delta=$((updated_epoch - created_epoch))
 	local age=$((now_epoch - created_epoch))
 
+	if _is_two_phase_bot "$bot_login"; then
+		# Phase 2 edit is authoritative; Phase 1 placeholder is not a real review
+		# regardless of age. Any positive edit_delta is the settlement signal.
+		[[ "$edit_delta" -gt 0 ]] && return 0
+		return 1
+	fi
+
+	# Non-two-phase bots: preserve existing OR semantics.
 	if [[ "$edit_delta" -ge "$min_lag" ]] || [[ "$age" -ge "$min_lag" ]]; then
 		return 0
 	fi
@@ -376,8 +410,9 @@ bot_has_real_review() {
 			fi
 			# Phase 2: must be settled. If not, this is likely a placeholder
 			# (e.g., CodeRabbit Phase 1) — wait for it to settle before
-			# classifying as a real review.
-			if ! _comment_is_settled "$created_at" "$updated_at" "$min_lag"; then
+			# classifying as a real review. Pass bot_login so two-phase bots
+			# require edit-observed settlement (GH#20550).
+			if ! _comment_is_settled "$created_at" "$updated_at" "$min_lag" "$bot_login"; then
 				continue
 			fi
 			return 0
@@ -623,7 +658,9 @@ _classify_bot_state() {
 				saw_non_review=1
 				continue
 			fi
-			if _comment_is_settled "$created_at" "$updated_at" "$min_lag"; then
+			# Pass bot_login so two-phase bots require edit-observed settlement
+			# (GH#20550 — age alone is not sufficient for coderabbitai etc.).
+			if _comment_is_settled "$created_at" "$updated_at" "$min_lag" "$bot_login"; then
 				echo "real-review"
 				return 0
 			fi

--- a/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
+++ b/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
@@ -319,6 +319,78 @@ test_get_min_edit_lag_unknown_repo_default() {
 	return 0
 }
 
+# ---------- Unit tests: two-phase bot behaviour (GH#20550) ----------
+
+test_two_phase_coderabbitai_aged_unedited_not_settled() {
+	# Two-phase bot: coderabbitai, created 120s ago but never edited (edit_delta=0).
+	# Age alone is NOT sufficient for coderabbitai — requires edit_delta > 0.
+	local now created
+	now=$(date +%s)
+	created=$(TZ=UTC date -u -r "$((now - 120))" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null ||
+		date -u -d "@$((now - 120))" +"%Y-%m-%dT%H:%M:%SZ")
+	if ! _comment_is_settled "$created" "$created" 30 "coderabbitai"; then
+		print_result "two-phase: coderabbitai aged-unedited NOT settled (age alone insufficient)" 0
+	else
+		print_result "two-phase: coderabbitai aged-unedited NOT settled (age alone insufficient)" 1 \
+			"created=${created} — expected NOT settled; age-derived branch must be skipped for coderabbitai"
+	fi
+	return 0
+}
+
+test_two_phase_coderabbitai_any_edit_settled() {
+	# Two-phase bot: coderabbitai, created 10s ago, edited 5s ago (edit_delta=5).
+	# Any positive edit_delta is authoritative for coderabbitai — settled immediately.
+	# Under non-two-phase OR semantics this same input is NOT settled
+	# (edit_delta=5 < min_lag=30 AND age=10 < min_lag=30).
+	local now created updated
+	now=$(date +%s)
+	created=$(TZ=UTC date -u -r "$((now - 10))" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null ||
+		date -u -d "@$((now - 10))" +"%Y-%m-%dT%H:%M:%SZ")
+	updated=$(TZ=UTC date -u -r "$((now - 5))" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null ||
+		date -u -d "@$((now - 5))" +"%Y-%m-%dT%H:%M:%SZ")
+	if _comment_is_settled "$created" "$updated" 30 "coderabbitai"; then
+		print_result "two-phase: coderabbitai edit_delta=5 settled (any positive edit is authoritative)" 0
+	else
+		print_result "two-phase: coderabbitai edit_delta=5 settled (any positive edit is authoritative)" 1 \
+			"created=${created} updated=${updated} — expected settled; edit_delta > 0 should pass for coderabbitai"
+	fi
+	return 0
+}
+
+test_two_phase_unknown_bot_or_semantics_preserved() {
+	# Non-two-phase bot with unknown login: aged 120s, never edited.
+	# Should settle by age — OR semantics preserved for non-two-phase bots.
+	local now created
+	now=$(date +%s)
+	created=$(TZ=UTC date -u -r "$((now - 120))" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null ||
+		date -u -d "@$((now - 120))" +"%Y-%m-%dT%H:%M:%SZ")
+	if _comment_is_settled "$created" "$created" 30 "gemini-code-assist"; then
+		print_result "non-two-phase: unknown bot aged-unedited settled by age (OR semantics preserved)" 0
+	else
+		print_result "non-two-phase: unknown bot aged-unedited settled by age (OR semantics preserved)" 1 \
+			"created=${created} — expected settled by age for gemini-code-assist (non-two-phase)"
+	fi
+	return 0
+}
+
+test_two_phase_env_override_respected_non_two_phase() {
+	# Non-two-phase bot: pass min_lag=60 (representing env override), age=40s.
+	# age=40 < min_lag=60 and no edit → NOT settled.
+	# Confirms env-derived min_lag is still applied for non-two-phase bots
+	# (the two-phase path does not interfere with OR semantics + larger lag).
+	local now created
+	now=$(date +%s)
+	created=$(TZ=UTC date -u -r "$((now - 40))" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null ||
+		date -u -d "@$((now - 40))" +"%Y-%m-%dT%H:%M:%SZ")
+	if ! _comment_is_settled "$created" "$created" 60 "gemini-code-assist"; then
+		print_result "non-two-phase: env min_lag=60, age=40 → NOT settled (override respected)" 0
+	else
+		print_result "non-two-phase: env min_lag=60, age=40 → NOT settled (override respected)" 1 \
+			"created=${created} — expected NOT settled; age=40 is below min_lag=60"
+	fi
+	return 0
+}
+
 # ---------- Run ----------
 
 main() {
@@ -352,6 +424,13 @@ main() {
 	test_get_min_edit_lag_per_repo
 	test_get_min_edit_lag_global_default
 	test_get_min_edit_lag_unknown_repo_default
+
+	echo ""
+	echo "=== Two-phase bot behaviour (GH#20550) ==="
+	test_two_phase_coderabbitai_aged_unedited_not_settled
+	test_two_phase_coderabbitai_any_edit_settled
+	test_two_phase_unknown_bot_or_semantics_preserved
+	test_two_phase_env_override_respected_non_two_phase
 
 	echo ""
 	echo "Tests run: ${TESTS_RUN}, failed: ${TESTS_FAILED}"


### PR DESCRIPTION
## Summary

Fixes the semantic defect in `_comment_is_settled` for CodeRabbit's two-phase posting pattern (Phase 1 placeholder → Phase 2 edit with real review). Implements Option A' from the evaluation in #20494.

## Changes

- **`TWO_PHASE_BOTS=("coderabbitai")`** constant added near `NON_REVIEW_PATTERNS`
- **`_is_two_phase_bot`** helper: iterates `TWO_PHASE_BOTS` array; modelled on `_get_rate_limit_behavior`/`_get_min_edit_lag` resolver pattern
- **`_comment_is_settled`** extended with optional `bot_login` 4th param (backward-compat, defaults to `""`). For two-phase bots: requires `edit_delta > 0`, age-derived branch skipped. Non-two-phase bots: existing OR semantics preserved.
- Call sites updated: `bot_has_real_review` and `_classify_bot_state` both pass `bot_login` as 4th arg
- Test suite extended: 4 new two-phase cases added; all 20 tests pass; shellcheck clean

## Verification

```
bash .agents/scripts/tests/test-review-bot-gate-completion-signal.sh
# Tests run: 20, failed: 0

shellcheck .agents/scripts/review-bot-gate-helper.sh
# (no output — clean)
```

## Layer-1 note

#20493 — The CI workflow has its own inline copy of `_comment_is_settled`. This PR covers the helper script only. Port-through to Layer 1 is required for full coverage — this PR does NOT claim the bug is fully resolved on merge alone.

Resolves #20550
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.95 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 5m and 13,424 tokens on this as a headless worker.
