### PR TITLE
t2751: fix phase-nudge counter stacking and recognise narrative phase format

### DIFF
--- a/.github/workflows/issue-sync.yml
+++ b/.github/workflows/issue-sync.yml
@@ -638,17 +638,31 @@ jobs:
               continue
             fi
 
-            # Count remaining unchecked items in the issue body
+            # Count items in the issue body. t2751 fix: the previous pattern
+            #   count=$(echo "$body" | grep -cE '...' || echo "0")
+            # was a classic bash command-substitution bug — grep -c prints "0"
+            # AND exits 1 on no-match, so `|| echo "0"` stacks a second "0" into
+            # the captured stdout. Result: count="0\n0" rendered as two lines
+            # (see the "Progress: **0\n0 done, 0\n0 remaining**" nudge on
+            # #20402). Pattern also noted in progressive-load-check.sh:87.
+            # Fix: `|| true` satisfies set -e without stacking output, and the
+            # numeric-guard catches any non-integer leakage.
             PARENT_BODY=$(gh api "repos/${REPO}/issues/${PARENT_NUM}" --jq '.body // ""' 2>/dev/null || echo "")
-            UNCHECKED_COUNT=$(echo "$PARENT_BODY" | grep -cE '^\s*- \[ \]' || echo "0")
-            CHECKED_COUNT=$(echo "$PARENT_BODY" | grep -cE '^\s*- \[x\]' || echo "0")
+            UNCHECKED_COUNT=$(printf '%s\n' "$PARENT_BODY" | grep -cE '^[[:space:]]*- \[ \]' || true)
+            CHECKED_COUNT=$(printf '%s\n' "$PARENT_BODY" | grep -cE '^[[:space:]]*- \[x\]' || true)
+            [[ "$UNCHECKED_COUNT" =~ ^[0-9]+$ ]] || UNCHECKED_COUNT=0
+            [[ "$CHECKED_COUNT" =~ ^[0-9]+$ ]] || CHECKED_COUNT=0
 
-            if [[ "$UNCHECKED_COUNT" -eq 0 ]]; then
-              echo "All phases checked in #$PARENT_NUM — no nudge needed (may be ready to close)"
-              continue
-            fi
+            # t2751 — also recognise narrative `**Phase N —**` bold-heading
+            # format. Parents filed before the t2740 auto-file contract (e.g.
+            # #20402) use this form and produce zero checkbox counts. Without
+            # this branch the nudge either stayed silent or emitted the
+            # misleading "0\n0 done, 0\n0 remaining" line.
+            NARRATIVE_PHASE_COUNT=$(printf '%s\n' "$PARENT_BODY" | grep -cE '^\*\*[Pp]hase[[:space:]]+[0-9]+' || true)
+            [[ "$NARRATIVE_PHASE_COUNT" =~ ^[0-9]+$ ]] || NARRATIVE_PHASE_COUNT=0
 
-            # Check if we already posted a nudge for this PR
+            # Check if we already posted a nudge for this PR (shared dedup for
+            # both checkbox and narrative-format nudges — same marker)
             EXISTING_NUDGE=$(gh api "repos/${REPO}/issues/${PARENT_NUM}/comments" \
               --jq "[.[] | select(.body | test(\"phase-nudge-pr-${PR_NUMBER}\"))] | length" 2>/dev/null || echo "0")
 
@@ -657,10 +671,48 @@ jobs:
               continue
             fi
 
-            # Extract the unchecked items for context
-            REMAINING_ITEMS=$(echo "$PARENT_BODY" | grep -E '^\s*- \[ \]' | sed 's/^[[:space:]]*/  /' | head -10 || true)
+            # Narrative-format path: no checkboxes at all, but bold-heading
+            # phases present → parent body is in pre-contract form.
+            if [[ "$UNCHECKED_COUNT" -eq 0 && "$CHECKED_COUNT" -eq 0 ]]; then
+              if [[ "$NARRATIVE_PHASE_COUNT" -gt 0 ]]; then
+                NARRATIVE_HINT_BODY="<!-- phase-nudge-pr-${PR_NUMBER} -->
+          ### Phase merged — parent uses narrative phase format
 
-            # Post the nudge
+          PR #${PR_NUMBER} (\`${PR_TITLE}\`) merged and references this parent, but the \`## Phases\` section uses narrative \`**Phase N — ...**\` bold-heading format rather than the canonical list form that phase-auto-filing (t2740, \`shared-phase-filing.sh\`) scans.
+
+          **Detected:** ${NARRATIVE_PHASE_COUNT} narrative phase heading(s).
+
+          **To enable auto-progression,** rewrite the \`## Phases\` section in list form, e.g.:
+
+          \`\`\`markdown
+          ## Phases
+
+          - Phase 1 - Inventory [auto-fire:on-prior-merge] #20410
+          - Phase 2 - Formalise opt-out vocabulary [auto-fire:on-prior-merge]
+          - Phase 3 - ...
+          \`\`\`
+
+          Until converted, phase children must be filed manually. This one-shot nudge is emitted per merged PR so the stuck state stays visible."
+                if gh issue comment "$PARENT_NUM" --repo "$REPO" --body "$NARRATIVE_HINT_BODY" 2>/dev/null; then
+                  echo "Posted narrative-format hint nudge on #$PARENT_NUM (${NARRATIVE_PHASE_COUNT} narrative phases detected)"
+                else
+                  echo "Warning: could not post narrative-format hint nudge on #$PARENT_NUM"
+                fi
+                continue
+              fi
+              echo "No checkbox or narrative phases found in #$PARENT_NUM — no nudge needed"
+              continue
+            fi
+
+            if [[ "$UNCHECKED_COUNT" -eq 0 ]]; then
+              echo "All phases checked in #$PARENT_NUM — no nudge needed (may be ready to close)"
+              continue
+            fi
+
+            # Extract the unchecked items for context
+            REMAINING_ITEMS=$(printf '%s\n' "$PARENT_BODY" | grep -E '^[[:space:]]*- \[ \]' | sed 's/^[[:space:]]*/  /' | head -10 || true)
+
+            # Post the checkbox-form nudge
             NUDGE_BODY="<!-- phase-nudge-pr-${PR_NUMBER} -->
           ### Phase merged — ${UNCHECKED_COUNT} remaining
 


### PR DESCRIPTION
## Summary

Fix the phase-nudge "0\n0" counter stacking bug visible on [#20402](https://github.com/marcusquinn/aidevops/issues/20402) and teach the nudge to recognise narrative `**Phase N —**` bold-heading parents so the pre-t2740 legacy form no longer produces misleading nudges.

## Root cause (one-liner)

`grep -cE '...' || echo "0"` is a classic bash command-substitution bug: `grep -c` prints `0` *and* exits 1 on no-match, so `|| echo "0"` stacks a second `0` into the captured stdout. Result: `UNCHECKED_COUNT="0\n0"` — literally the "Progress: **0\n0 done, 0\n0 remaining**" line on #20402's nudge comment.

The same anti-pattern is documented and worked around in [`progressive-load-check.sh:87`](https://github.com/marcusquinn/aidevops/blob/main/.agents/scripts/progressive-load-check.sh#L87), but the knowledge was never propagated to `issue-sync.yml`.

## Changes

- `.github/workflows/issue-sync.yml:641-720` (phase-nudge job):
  - Replace `|| echo "0"` with `|| true` + numeric regex guard so `UNCHECKED_COUNT` and `CHECKED_COUNT` cannot stack output.
  - Add narrative `**Phase N —**` bold-heading detection (`NARRATIVE_PHASE_COUNT`).
  - New branch: when both checkbox counts are 0 but narrative phases exist, emit a **format-hint nudge** pointing at the canonical list form that `shared-phase-filing.sh` parses (t2740). Same `<!-- phase-nudge-pr-${PR_NUMBER} -->` dedup marker.
  - Explanatory comment referencing t2751 and the progressive-load-check.sh precedent so future readers don't re-discover the footgun.

## Verification

Unit-tested the counter logic locally against three representative parent bodies — narrative-only (20402 shape), checkbox-only, and empty-body:

| Body shape | unchecked | checked | narrative | Branch taken |
|-----------|-----------|---------|-----------|--------------|
| Narrative (bold headings, no checkboxes) | 0 | 0 | 3 | Format-hint nudge ✓ |
| Canonical (`- [x]` + `- [ ]`) | 2 | 1 | 0 | Original checkbox nudge ("1 done, 2 remaining") ✓ |
| No phases | 0 | 0 | 0 | "No nudge needed" skip ✓ |

No `0\n0` stacking. No misclassification. Static checks:

- `python3 -c "import yaml; yaml.safe_load(open(...))"` → OK
- `actionlint .github/workflows/issue-sync.yml` → clean
- Pre-commit workflow-file validator → clean

## Scope

Only the `issue-sync.yml` phase-nudge job. The same `grep -c || echo` pattern is used ~20 other places in the codebase (see `rg -n 'grep -c.*\|\| echo'`). Those are latent but not visible — a systemic sweep belongs in a separate focused PR so that review stays on the observable bug being fixed here. I'll file that as a follow-up.

Fixes B/C/D from the #20402 root-cause analysis (parser extension, premature-close guard, feature-flag flip) are tracked as phase children of [#20559](https://github.com/marcusquinn/aidevops/issues/20559) — this PR is the pure "counter-stacking + narrative detection" fix.

## Why this unblocks #20402

#20402's nudge comment today shows the broken output literally. After this ships:

1. The next merge that references #20402 will emit a **format-hint nudge** with the canonical list-form example, rather than the misleading `0\n0 done, 0\n0 remaining`.
2. Phase 2 of #20402 has already been filed as [#20558](https://github.com/marcusquinn/aidevops/issues/20558) (unrelated to this PR, out-of-band unblock) so the parent's sub-issue graph now reads 1/2 not 1/1.

Resolves #20555
Ref #20402

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.95 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-opus-4-7 spent 1h 19m and 56,779 tokens on this with the user in an interactive session.
