### PR TITLE
t2759: preserve user env overrides in generated plists across framework updates

### DIFF
--- a/.agents/configs/plist-env-overrides.json.txt
+++ b/.agents/configs/plist-env-overrides.json.txt
@@ -1,0 +1,11 @@
+{
+  "_doc": "Copy this file to plist-env-overrides.json (gitignored) to activate. Keys are launchd plist labels. Values are objects mapping env var names to string values. Keys prefixed with _ are ignored by the loader.",
+  "com.aidevops.aidevops-supervisor-pulse": {
+    "_doc": "Examples — rename (remove leading _) to activate. All values must be strings.",
+    "_SCANNER_NUDGE_AGE_HOURS": "0",
+    "_AUTO_DECOMPOSER_INTERVAL": "86400",
+    "_AIDEVOPS_WORKER_BRIEFED_AUTO_MERGE": "0",
+    "_AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD": "0.30",
+    "_AIDEVOPS_SKIP_TIER_VALIDATOR": "1"
+  }
+}

--- a/.agents/reference/plist-env-overrides.md
+++ b/.agents/reference/plist-env-overrides.md
@@ -1,0 +1,112 @@
+# Plist Environment Variable Overrides
+
+Inject persistent environment variables into generated launchd plists without
+losing them on every `aidevops update` or `setup.sh` run.
+
+## Problem This Solves
+
+`setup.sh` regenerates launchd plists on every run (~every 10 min via
+`aidevops update`). Any manual edits to
+`~/Library/LaunchAgents/com.aidevops.aidevops-supervisor-pulse.plist`
+are silently wiped.
+
+The override file survives framework updates because it lives outside the
+deployed agent scripts tree and is gitignored.
+
+## Setup
+
+```bash
+# 1. Copy the committed template to the working file
+cp ~/.aidevops/agents/configs/plist-env-overrides.json.txt \
+   ~/.aidevops/agents/configs/plist-env-overrides.json
+
+# 2. Edit the working file — add the env vars you want
+#    Keys prefixed with _ are ignored (template examples)
+nano ~/.aidevops/agents/configs/plist-env-overrides.json
+
+# 3. Run setup.sh to regenerate the plist with your overrides
+~/.aidevops/agents/../setup.sh --non-interactive
+# or: aidevops update
+```
+
+## File Format
+
+The override file is a JSON object keyed by **launchd plist label**. Each
+value is an object of `{ "ENV_VAR_NAME": "value" }` pairs. All values must be
+strings.
+
+Keys prefixed with `_` are skipped — they serve as in-file comments.
+
+```json
+{
+  "com.aidevops.aidevops-supervisor-pulse": {
+    "SCANNER_NUDGE_AGE_HOURS": "0",
+    "AUTO_DECOMPOSER_INTERVAL": "86400"
+  }
+}
+```
+
+## Supported Labels
+
+Currently only the supervisor pulse label is handled:
+
+| Label | Plist |
+|-------|-------|
+| `com.aidevops.aidevops-supervisor-pulse` | `~/Library/LaunchAgents/com.aidevops.aidevops-supervisor-pulse.plist` |
+
+Additional labels can be supported by extending
+`_build_plist_env_overrides_xml` in `setup-modules/schedulers.sh`.
+
+## Worked Example: Tune Per-Runner Thresholds
+
+Runner A (aggressive nudging, wants decomposer every 24h):
+```json
+{
+  "com.aidevops.aidevops-supervisor-pulse": {
+    "SCANNER_NUDGE_AGE_HOURS": "0",
+    "AUTO_DECOMPOSER_INTERVAL": "86400"
+  }
+}
+```
+
+Runner B (conservative, disable worker-briefed auto-merge for soak):
+```json
+{
+  "com.aidevops.aidevops-supervisor-pulse": {
+    "AIDEVOPS_WORKER_BRIEFED_AUTO_MERGE": "0"
+  }
+}
+```
+
+After `aidevops update`, verify the plist was updated:
+
+```bash
+grep -A1 "SCANNER_NUDGE_AGE_HOURS\|AUTO_DECOMPOSER_INTERVAL" \
+  ~/Library/LaunchAgents/com.aidevops.aidevops-supervisor-pulse.plist
+```
+
+## Precedence and Conflict
+
+Injected vars are appended to the plist `EnvironmentVariables` dict. If you
+inject a key that already exists in the dict (e.g. `PATH`, `HOME`), the
+**later definition wins** under launchd's dict parsing rules. Overriding
+`PATH`, `HOME`, `OPENCODE_BIN`, or `PULSE_DIR` is not recommended — use the
+override file for aidevops-specific tuning variables only.
+
+## Error Handling
+
+| Condition | Behaviour |
+|-----------|-----------|
+| File absent | Silent no-op. Default plist generated. |
+| File present, valid JSON, label not found | No-op for that plist. |
+| File present, malformed JSON | `WARN` logged; plist generated without overrides. |
+| `jq` not installed | `WARN` logged; plist generated without overrides. |
+
+## Template Location
+
+The committed template (with example keys, all `_`-prefixed) lives at:
+`.agents/configs/plist-env-overrides.json.txt`
+
+The working file (gitignored) lives at:
+`.agents/configs/plist-env-overrides.json`
+(deployed to `~/.aidevops/agents/configs/plist-env-overrides.json`)

--- a/.agents/scripts/tests/test-plist-env-overrides.sh
+++ b/.agents/scripts/tests/test-plist-env-overrides.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Regression tests for plist env override injection (GH#20563 / t2759).
+# Tests: missing file, valid file with label match, valid file without label match, malformed JSON.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)" || exit 1
+SCHEDULERS_SH="$REPO_ROOT/setup-modules/schedulers.sh"
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+TEST_DIR=""
+
+# ---------------------------------------------------------------------------
+# Test harness
+# ---------------------------------------------------------------------------
+
+print_result() {
+	local test_name="$1"
+	local status="$2"
+	local message="${3:-}"
+
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$status" -eq 0 ]]; then
+		echo "PASS $test_name"
+		TESTS_PASSED=$((TESTS_PASSED + 1))
+	else
+		echo "FAIL $test_name"
+		if [[ -n "$message" ]]; then
+			echo "  $message"
+		fi
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+teardown() {
+	if [[ -n "$TEST_DIR" ]] && [[ -d "$TEST_DIR" ]]; then
+		rm -rf "$TEST_DIR"
+	fi
+	return 0
+}
+
+setup() {
+	TEST_DIR=$(mktemp -d)
+	trap teardown EXIT
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Load only the functions we need from schedulers.sh.
+# schedulers.sh uses print_info / print_warning from shared-constants.sh;
+# stub them so the sourced code doesn't blow up without the full setup context.
+# ---------------------------------------------------------------------------
+
+_load_schedulers_functions() {
+	# Stubs for helpers that schedulers.sh calls at source-time or in helpers we use
+	print_info()    { : ; }
+	print_warning() { echo "[WARN] $*" >&2; }
+	print_error()   { echo "[ERROR] $*" >&2; }
+	_xml_escape()   { printf '%s' "$1"; }   # passthrough — not testing XML escaping here
+
+	# shellcheck source=/dev/null
+	source "$SCHEDULERS_SH" 2>/dev/null || {
+		echo "SKIP: could not source $SCHEDULERS_SH (missing dependencies?)"
+		exit 0
+	}
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+test_missing_file() {
+	local missing_file="$TEST_DIR/nonexistent-plist-env-overrides.json"
+	local output
+	output=$(_build_plist_env_overrides_xml "com.aidevops.aidevops-supervisor-pulse" "$missing_file")
+	if [[ -z "$output" ]]; then
+		print_result "missing_file: emits empty output" 0
+	else
+		print_result "missing_file: emits empty output" 1 "got: $output"
+	fi
+	return 0
+}
+
+test_label_match_injects_vars() {
+	local override_file="$TEST_DIR/plist-env-overrides.json"
+	cat >"$override_file" <<'EOF'
+{
+  "com.aidevops.aidevops-supervisor-pulse": {
+    "SCANNER_NUDGE_AGE_HOURS": "0",
+    "AUTO_DECOMPOSER_INTERVAL": "86400"
+  }
+}
+EOF
+	local output
+	output=$(_build_plist_env_overrides_xml "com.aidevops.aidevops-supervisor-pulse" "$override_file")
+
+	local ok=0
+	echo "$output" | grep -q "SCANNER_NUDGE_AGE_HOURS" || ok=1
+	echo "$output" | grep -q "<string>0</string>" || ok=1
+	echo "$output" | grep -q "AUTO_DECOMPOSER_INTERVAL" || ok=1
+	echo "$output" | grep -q "<string>86400</string>" || ok=1
+
+	print_result "label_match: injects SCANNER_NUDGE_AGE_HOURS and AUTO_DECOMPOSER_INTERVAL" "$ok" \
+		"output was: $output"
+	return 0
+}
+
+test_underscore_keys_skipped() {
+	local override_file="$TEST_DIR/plist-env-overrides.json"
+	cat >"$override_file" <<'EOF'
+{
+  "com.aidevops.aidevops-supervisor-pulse": {
+    "_doc": "example comment",
+    "_SKIP_ME": "should not appear",
+    "KEEP_ME": "keep"
+  }
+}
+EOF
+	local output
+	output=$(_build_plist_env_overrides_xml "com.aidevops.aidevops-supervisor-pulse" "$override_file")
+
+	local ok=0
+	echo "$output" | grep -q "_doc" && ok=1
+	echo "$output" | grep -q "_SKIP_ME" && ok=1
+	echo "$output" | grep -q "KEEP_ME" || ok=1
+
+	print_result "underscore_keys: _-prefixed keys are skipped, non-_ keys are kept" "$ok" \
+		"output was: $output"
+	return 0
+}
+
+test_no_label_match_emits_nothing() {
+	local override_file="$TEST_DIR/plist-env-overrides.json"
+	cat >"$override_file" <<'EOF'
+{
+  "com.aidevops.some-other-label": {
+    "FOO": "bar"
+  }
+}
+EOF
+	local output
+	output=$(_build_plist_env_overrides_xml "com.aidevops.aidevops-supervisor-pulse" "$override_file")
+
+	if [[ -z "$output" ]]; then
+		print_result "no_label_match: emits empty output" 0
+	else
+		print_result "no_label_match: emits empty output" 1 "got: $output"
+	fi
+	return 0
+}
+
+test_malformed_json_logs_warn_and_emits_nothing() {
+	local override_file="$TEST_DIR/plist-env-overrides.json"
+	printf '{invalid json' >"$override_file"
+
+	local output stderr_output
+	stderr_output=$(_build_plist_env_overrides_xml "com.aidevops.aidevops-supervisor-pulse" "$override_file" 2>&1 >/dev/null) || true
+	output=$(_build_plist_env_overrides_xml "com.aidevops.aidevops-supervisor-pulse" "$override_file" 2>/dev/null) || true
+
+	local ok=0
+	[[ -z "$output" ]] || ok=1
+	echo "$stderr_output" | grep -qi "WARN\|malformed" || ok=1
+
+	print_result "malformed_json: emits WARN and no output" "$ok" \
+		"stderr: $stderr_output | stdout: $output"
+	return 0
+}
+
+test_xml_structure_valid() {
+	# Check that the output is parseable XML when embedded in a minimal plist.
+	# Only runs if xmllint is available.
+	if ! command -v xmllint >/dev/null 2>&1; then
+		echo "SKIP xml_structure_valid: xmllint not available"
+		return 0
+	fi
+
+	local override_file="$TEST_DIR/plist-env-overrides.json"
+	cat >"$override_file" <<'EOF'
+{
+  "com.aidevops.aidevops-supervisor-pulse": {
+    "MY_VAR": "my_value"
+  }
+}
+EOF
+	local xml_fragment
+	xml_fragment=$(_build_plist_env_overrides_xml "com.aidevops.aidevops-supervisor-pulse" "$override_file")
+
+	local test_plist
+	test_plist="<?xml version=\"1.0\" encoding=\"UTF-8\"?>
+<!DOCTYPE plist PUBLIC \"-//Apple//DTD PLIST 1.0//EN\" \"http://www.apple.com/DTDs/PropertyList-1.0.dtd\">
+<plist version=\"1.0\"><dict>
+${xml_fragment}
+</dict></plist>"
+
+	local ok=0
+	if echo "$test_plist" | xmllint --noout - 2>/dev/null; then
+		ok=0
+	else
+		ok=1
+	fi
+	print_result "xml_structure_valid: injected XML parses as valid plist" "$ok" \
+		"fragment: $xml_fragment"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+	setup
+
+	if ! command -v jq >/dev/null 2>&1; then
+		echo "SKIP all tests: jq not available"
+		exit 0
+	fi
+
+	_load_schedulers_functions
+
+	test_missing_file
+	test_label_match_injects_vars
+	test_underscore_keys_skipped
+	test_no_label_match_emits_nothing
+	test_malformed_json_logs_warn_and_emits_nothing
+	test_xml_structure_valid
+
+	echo ""
+	echo "Results: ${TESTS_PASSED}/${TESTS_RUN} passed, ${TESTS_FAILED} failed"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ configs/*.json
 # Allow agent directory to be committed
 !.agents/
 
+# User-owned plist env override working file (gitignored; template: .agents/configs/plist-env-overrides.json.txt)
+.agents/configs/plist-env-overrides.json
+
 # Password files and credentials
 *.password
 *_password

--- a/setup-modules/schedulers.sh
+++ b/setup-modules/schedulers.sh
@@ -499,6 +499,90 @@ _build_pulse_headless_env_xml() {
 	return 0
 }
 
+# Read user-owned plist env override file and emit XML key/string pairs
+# for the matching label's env vars. Keys prefixed with _ are skipped
+# (used as comments in the JSON template).
+#
+# Args: $1=plist_label (e.g. "com.aidevops.aidevops-supervisor-pulse")
+#       $2=override_file (absolute path; default ~/.agents/configs/plist-env-overrides.json)
+#       $3=indent (string to prepend each line; default "\t\t")
+#
+# Returns 0 on success (including empty result when label not found).
+# Prints WARN to stderr and returns 0 when file is present but malformed.
+# Emits nothing when file is absent.
+_build_plist_env_overrides_xml() {
+	local _label="$1"
+	local _override_file="${2:-$HOME/.aidevops/agents/configs/plist-env-overrides.json}"
+	local _indent="${3:-		}"
+
+	# Missing file is the normal case (user has not created the override file yet)
+	[[ -f "$_override_file" ]] || return 0
+
+	# Require jq — without it we cannot parse JSON safely
+	if ! command -v jq >/dev/null 2>&1; then
+		echo "[schedulers] WARN: jq not found; skipping plist-env-overrides.json injection" >&2
+		return 0
+	fi
+
+	# Validate JSON
+	if ! jq empty "$_override_file" 2>/dev/null; then
+		echo "[schedulers] WARN: plist-env-overrides.json is malformed; skipping injection (file: $_override_file)" >&2
+		return 0
+	fi
+
+	# Extract key=value pairs for the matching label; skip _ prefixed keys
+	local _pairs
+	_pairs=$(jq -r --arg label "$_label" '
+		.[$label] // {} |
+		to_entries[] |
+		select(.key | startswith("_") | not) |
+		"\(.key)=\(.value)"
+	' "$_override_file" 2>/dev/null) || return 0
+
+	[[ -z "$_pairs" ]] && return 0
+
+	local _line _key _val _xml_key _xml_val
+	while IFS= read -r _line; do
+		[[ -z "$_line" ]] && continue
+		_key="${_line%%=*}"
+		_val="${_line#*=}"
+		_xml_key=$(_xml_escape "$_key")
+		_xml_val=$(_xml_escape "$_val")
+		printf '%s<key>%s</key>\n%s<string>%s</string>\n' \
+			"$_indent" "$_xml_key" "$_indent" "$_xml_val"
+	done <<<"$_pairs"
+
+	return 0
+}
+
+# Log which env var overrides were injected from plist-env-overrides.json for a label.
+# Prints to stdout (setup.sh output). No-op when file absent or label not found.
+# Args: $1=plist_label, $2=override_file (optional)
+_log_plist_env_overrides() {
+	local _label="$1"
+	local _override_file="${2:-$HOME/.aidevops/agents/configs/plist-env-overrides.json}"
+
+	[[ -f "$_override_file" ]] || return 0
+	command -v jq >/dev/null 2>&1 || return 0
+	jq empty "$_override_file" 2>/dev/null || return 0
+
+	local _keys
+	_keys=$(jq -r --arg label "$_label" '
+		.[$label] // {} |
+		keys[] |
+		select(startswith("_") | not)
+	' "$_override_file" 2>/dev/null) || return 0
+
+	[[ -z "$_keys" ]] && return 0
+
+	local _count
+	_count=$(echo "$_keys" | wc -l | tr -d ' ')
+	local _keys_inline
+	_keys_inline=$(echo "$_keys" | tr '\n' ' ' | sed 's/ $//')
+	print_info "  plist-env-overrides: injected ${_count} var(s) into ${_label}: ${_keys_inline}"
+	return 0
+}
+
 # Generate the full pulse launchd plist XML content.
 # Args: $1=pulse_label, $2=wrapper_script, $3=opencode_bin
 # Prints the complete plist XML to stdout.
@@ -538,6 +622,12 @@ _generate_pulse_plist_content() {
 	local _pulse_interval_sec
 	_pulse_interval_sec=$(_read_pulse_interval_seconds)
 
+	# Inject user-owned plist env overrides (GH#20563 / t2759).
+	# Reads ~/.aidevops/agents/configs/plist-env-overrides.json when present.
+	# Missing file or label not found → emits nothing (no-op, safe default).
+	local _env_overrides_xml
+	_env_overrides_xml=$(_build_plist_env_overrides_xml "$pulse_label")
+
 	cat <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -569,7 +659,7 @@ _generate_pulse_plist_content() {
 		<key>PULSE_STALE_THRESHOLD</key>
 		<string>${PULSE_STALE_THRESHOLD_SECONDS}</string>
 		${_headless_xml_env}
-	</dict>
+${_env_overrides_xml}	</dict>
 	<key>SoftResourceLimits</key>
 	<dict>
 		<key>NumberOfFiles</key>
@@ -614,6 +704,8 @@ _install_pulse_launchd() {
 		else
 			print_info "Supervisor pulse enabled (launchd, every ${_interval_label})"
 		fi
+		# Log any user-provided env var overrides that were injected (GH#20563 / t2759)
+		_log_plist_env_overrides "$pulse_label"
 	else
 		print_warning "Failed to load supervisor pulse LaunchAgent"
 	fi


### PR DESCRIPTION
## Summary

Adds a durable plist environment variable override mechanism that survives `aidevops update` / `setup.sh` regeneration cycles (every ~10 min). Previously, any manual edits to `~/Library/LaunchAgents/com.aidevops.aidevops-supervisor-pulse.plist` were silently wiped on the next update.

## Changes

- **`setup-modules/schedulers.sh`**: Adds `_build_plist_env_overrides_xml()` and `_log_plist_env_overrides()` helpers. Injects user override XML into `_generate_pulse_plist_content()`'s `EnvironmentVariables` dict. Logs applied vars after `launchctl load` succeeds.
- **`.agents/configs/plist-env-overrides.json.txt`**: Committed template with `_`-prefixed example keys (skipped by the loader) and schema documentation.
- **`.agents/reference/plist-env-overrides.md`**: Usage docs with setup steps, format spec, worked examples, and error-handling table.
- **`.agents/scripts/tests/test-plist-env-overrides.sh`**: 6 regression tests covering all acceptance criteria.
- **`.gitignore`**: Gitignores `.agents/configs/plist-env-overrides.json` (the user working file).

## Verification

```bash
shellcheck setup-modules/schedulers.sh
bash .agents/scripts/tests/test-plist-env-overrides.sh
# Results: 6/6 passed, 0 failed

# Operational: inject a test override, run setup.sh, verify plist
cp .agents/configs/plist-env-overrides.json.txt .agents/configs/plist-env-overrides.json
# Edit to remove _ prefixes from example keys
./setup.sh --non-interactive
grep -A1 "SCANNER_NUDGE_AGE_HOURS" ~/Library/LaunchAgents/com.aidevops.aidevops-supervisor-pulse.plist
```

## Acceptance Criteria Coverage

1. User creates `plist-env-overrides.json` → next `setup.sh` injects vars ✓
2. Injected values survive `aidevops update` / regeneration ✓ (file is user-owned and gitignored)
3. Missing or malformed file → setup.sh proceeds with defaults and logs WARN ✓
4. Documentation with template→working-copy convention and worked example ✓
5. Regression tests: missing file, label match, no-label match, malformed JSON, underscore skip, XML validity ✓

Resolves #20563
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.95 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 6m and 22,764 tokens on this as a headless worker.
