### PR TITLE
GH#20566: docs: add pulse-wrapper churn decomposition reference

### DIFF
--- a/.agents/reference/pulse-wrapper-churn-investigation.md
+++ b/.agents/reference/pulse-wrapper-churn-investigation.md
@@ -1,0 +1,75 @@
+# Pulse-Wrapper Invocation Churn Investigation
+
+Parent issue: [#20557](https://github.com/marcusquinn/aidevops/issues/20557)
+Decomposition issue: [#20566](https://github.com/marcusquinn/aidevops/issues/20566)
+
+## Problem Statement
+
+Observed on 2026-04-23: 3541 instance-lock acquisitions and 4 distinct
+`pulse-wrapper.sh` PIDs in a 15-minute window. The mkdir instance lock
+prevents concurrent execution correctly, but the volume of contending
+invocations indicates redundant scheduling.
+
+Hypothesis: multiple schedulers (launchd + cron + plugin hooks + shell
+login hooks) independently trigger `pulse-wrapper.sh`.
+
+## Decomposition
+
+| Child | Issue | Description | Tier |
+|-------|-------|-------------|------|
+| Investigation | [#20577](https://github.com/marcusquinn/aidevops/issues/20577) | Enumerate invocation sources and measure cadence | `tier:standard` |
+| Rate-limit | [#20578](https://github.com/marcusquinn/aidevops/issues/20578) | Timestamp-based cooldown at wrapper entry | `tier:standard` |
+| Is-running check | [#20579](https://github.com/marcusquinn/aidevops/issues/20579) | pgrep short-circuit before mkdir lock | `tier:standard` |
+| Source logging | [#20580](https://github.com/marcusquinn/aidevops/issues/20580) | Per-source invocation counters in pulse-stats.json | `tier:standard` |
+
+## Architecture Notes
+
+### Current invocation flow (pulse-wrapper.sh main())
+
+```text
+launchd fires (every 120s)
+  -> main()
+    -> _pulse_handle_self_check()     # Phase 0: validate all symbols loaded
+    -> _pulse_setup_dry_run_mode()
+    -> _pulse_setup_canary_mode()
+    -> trap 'release_instance_lock' EXIT
+    -> acquire_instance_lock()         # mkdir atomicity (POSIX-guaranteed)
+    -> check_session_gate()            # pulse-hours window
+    -> check_dedup()                   # PID file sentinel
+    -> [pulse cycle runs]
+    -> release_instance_lock()
+```
+
+### Proposed flow (after #20578 + #20579)
+
+```text
+launchd fires (every 120s)
+  -> main()
+    -> _pulse_handle_self_check()
+    -> _pulse_setup_dry_run_mode()
+    -> _pulse_setup_canary_mode()
+    -> [NEW] rate-limit check          # Exit 0 if last run < 90s ago
+    -> [NEW] is-running check          # Exit 0 if pulse PID alive (pgrep)
+    -> trap 'release_instance_lock' EXIT
+    -> acquire_instance_lock()
+    -> check_session_gate()
+    -> check_dedup()
+    -> [pulse cycle runs]
+    -> release_instance_lock()
+```
+
+The two new checks are ordered intentionally:
+1. **Rate-limit first** — cheapest check (single `stat` call on a timestamp file).
+2. **Is-running second** — slightly more expensive (`pgrep` syscall) but catches
+   the case where a previous cycle is still running past the rate-limit window.
+
+Both checks exit before the mkdir lock, eliminating contention entirely for the
+common cases (rapid re-invocation and overlapping cycles).
+
+## Dependency Order
+
+- #20577 (investigation) runs in parallel with #20578-#20580 (fixes).
+- The fixes are independently implementable.
+- #20577 may surface an additional child: "Consolidate schedulers" (Child A from
+  the parent's original plan). This child is deferred until the investigation
+  identifies which schedulers are redundant.


### PR DESCRIPTION
## Summary

Decomposed parent-task #20557 (pulse-wrapper invocation churn investigation) into 4 child issues:
- #20577: Enumerate invocation sources and measure cadence (investigation)
- #20578: Add entry-point rate-limit cooldown (defence-in-depth)
- #20579: Add is-running short-circuit before mkdir lock (eliminate contention)
- #20580: Add invocation-source logging and counters (observability)

Updated parent #20557 body with a ## Children section linking all 4 children.
Created .agents/reference/pulse-wrapper-churn-investigation.md documenting the decomposition rationale, current vs proposed invocation flow, and dependency order.

## Files Changed

.agents/reference/pulse-wrapper-churn-investigation.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified parent #20557 body contains ## Children section with all 4 issue links. Verified all 4 child issues exist and have auto-dispatch + tier:standard labels. Reference doc committed and passes pre-commit checks.

Resolves #20566


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.95 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-opus-4-6 spent 6m and 14,379 tokens on this as a headless worker.