### PR TITLE
GH#20579: add is-running short-circuit before mkdir lock in pulse-wrapper.sh

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1520,6 +1520,21 @@ main() {
 	_pulse_setup_dry_run_mode "$@"
 	_pulse_setup_canary_mode "$@"
 
+	# GH#20579: Is-running short-circuit — exit 0 immediately before attempting
+	# mkdir lock acquisition when a pulse process is already alive. Eliminates
+	# lock contention for the common launchd-fires-while-running case.
+	# Bypassed in --canary and --dry-run modes — they need the full code path.
+	if [[ "${PULSE_CANARY_MODE:-0}" != "1" && "${PULSE_DRY_RUN:-0}" != "1" ]]; then
+		local _ir_pids
+		_ir_pids=$(pgrep -f "(^|/)pulse-wrapper\\.sh( |\$)" 2>/dev/null | grep -v "^$$\$" || true)
+		if [[ -n "$_ir_pids" ]]; then
+			local _ir_first_pid
+			_ir_first_pid=$(printf '%s\n' "$_ir_pids" | awk 'NR==1')
+			echo "[pulse-wrapper] Pulse already running (PID: ${_ir_first_pid}), skipping" >>"$WRAPPER_LOGFILE"
+			return 0
+		fi
+	fi
+
 	# GH#4513: Acquire exclusive instance lock FIRST — before any other
 	# check. Uses mkdir atomicity as the ONLY primitive (POSIX-guaranteed,
 	# works identically on macOS APFS/HFS+ and Linux ext4/btrfs/xfs).


### PR DESCRIPTION
## Summary

Adds an is-running short-circuit to `main()` in `pulse-wrapper.sh` that exits 0 immediately — before attempting the mkdir instance lock — when a pulse process is already alive.

## What changed

**EDIT: `.agents/scripts/pulse-wrapper.sh:1523-1536`** — inserted 15 lines between `_pulse_setup_canary_mode` and the `# GH#4513` lock block:

- Uses `pgrep -f "(^|/)pulse-wrapper\.sh( |$)"` filtered via `grep -v "^$$\$"` to exclude the calling wrapper's own PID
- Logs `[pulse-wrapper] Pulse already running (PID: <pid>), skipping` to `$WRAPPER_LOGFILE`
- Returns 0 immediately without setting the EXIT trap or touching the mkdir lock directory
- Bypassed when `PULSE_CANARY_MODE=1` or `PULSE_DRY_RUN=1` — those modes need the full code path

## Why

The original flow was: launchd fires → source all modules → `_pulse_handle_self_check` → `acquire_instance_lock` (mkdir) → fail → exit 0. Each invocation did real work only to discover a pulse was already running. The pgrep-based check answers this question in microseconds before any locking overhead.

Resolves #20579
For #20557
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.95 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 4m and 7,379 tokens on this as a headless worker.
