### PR TITLE
GH#20550: two-phase bot support in _comment_is_settled

### DIFF
--- a/.agents/scripts/review-bot-gate-helper.sh
+++ b/.agents/scripts/review-bot-gate-helper.sh
@@ -86,6 +86,13 @@ NON_REVIEW_PATTERNS=(
 # Backwards-compat alias for any callers/tests still referencing the old name.
 RATE_LIMIT_PATTERNS=("${NON_REVIEW_PATTERNS[@]}")
 
+# Bots that post a Phase 1 placeholder and later edit it with real review content.
+# For these, age-derived settlement is unreliable — require edit-observed settlement.
+# GH#20550: Option A' — two-phase bot list avoids per-repo config duplication.
+# NOTE: no `readonly` — bash 3.2 scopes readonly arrays function-local when
+# declared via `source` inside a function (see load_helper_functions in tests).
+TWO_PHASE_BOTS=("coderabbitai")
+
 SKIP_LABEL="skip-review-gate"
 
 # GH#3827: Grace period for rate-limited bots. If bots posted rate-limit
@@ -185,6 +192,19 @@ _get_min_edit_lag() {
 	return 0
 }
 
+_is_two_phase_bot() {
+	# GH#20550: Return 0 if bot_login is in the TWO_PHASE_BOTS list.
+	# Two-phase bots post a Phase 1 placeholder and later edit it with real content.
+	# For these bots, age-derived settlement is unreliable — only edit-observed
+	# settlement (edit_delta > 0) is authoritative.
+	local bot_login="$1"
+	local b
+	for b in "${TWO_PHASE_BOTS[@]}"; do
+		[[ "$bot_login" == "$b" ]] && return 0
+	done
+	return 1
+}
+
 _to_epoch() {
 	# Cross-platform ISO-8601 → epoch (macOS BSD date vs GNU date). Returns 0
 	# on parse failure so callers can detect "unknown" and behave conservatively.
@@ -203,16 +223,29 @@ _to_epoch() {
 
 _comment_is_settled() {
 	# t2139: A comment is "settled" (final form, safe to classify as a real
-	# review) if EITHER:
+	# review) depending on bot type:
+	#
+	# Two-phase bots (e.g. coderabbitai — see TWO_PHASE_BOTS):
+	#   Require edit-observed settlement only (edit_delta > 0). Age-derived
+	#   fallback is disabled — Phase 1 placeholders aged past min_lag would
+	#   otherwise false-positive as settled real reviews. GH#20550.
+	#
+	# Non-two-phase bots (OR semantics — existing behaviour):
+	#   Settled if EITHER:
 	#   (a) it has been edited (updated_at >= created_at + min_lag), OR
 	#   (b) it is old enough that the bot would have edited by now
 	#       (now - created_at >= min_lag).
+	#
 	# If timestamps are missing/unparseable (older API responses, network
 	# issues), be conservative: treat as settled — better to PASS the gate
 	# than block forever on missing data.
+	#
+	# $4 (bot_login) is optional for backward-compatibility. Callers that omit
+	# it fall through to non-two-phase OR semantics (preserves old behaviour).
 	local created_at="$1"
 	local updated_at="$2"
 	local min_lag="$3"
+	local bot_login="${4:-}"
 
 	# Missing inputs → conservative pass.
 	[[ -z "$created_at" ]] && return 0
@@ -229,6 +262,14 @@ _comment_is_settled() {
 	local edit_delta=$((updated_epoch - created_epoch))
 	local age=$((now_epoch - created_epoch))
 
+	if _is_two_phase_bot "$bot_login"; then
+		# Phase 2 edit is authoritative; Phase 1 placeholder is not a real
+		# review regardless of age. Any positive edit_delta means Phase 2 landed.
+		[[ "$edit_delta" -gt 0 ]] && return 0
+		return 1
+	fi
+
+	# Non-two-phase bots: preserve existing OR semantics.
 	if [[ "$edit_delta" -ge "$min_lag" ]] || [[ "$age" -ge "$min_lag" ]]; then
 		return 0
 	fi
@@ -377,7 +418,7 @@ bot_has_real_review() {
 			# Phase 2: must be settled. If not, this is likely a placeholder
 			# (e.g., CodeRabbit Phase 1) — wait for it to settle before
 			# classifying as a real review.
-			if ! _comment_is_settled "$created_at" "$updated_at" "$min_lag"; then
+			if ! _comment_is_settled "$created_at" "$updated_at" "$min_lag" "$bot_login"; then
 				continue
 			fi
 			return 0
@@ -623,7 +664,7 @@ _classify_bot_state() {
 				saw_non_review=1
 				continue
 			fi
-			if _comment_is_settled "$created_at" "$updated_at" "$min_lag"; then
+			if _comment_is_settled "$created_at" "$updated_at" "$min_lag" "$bot_login"; then
 				echo "real-review"
 				return 0
 			fi

--- a/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
+++ b/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 # test-review-bot-gate-completion-signal.sh — Regression tests for t2139 (GH#19251)
+#   Extended with two-phase bot support tests — GH#20550
 #
 # Verifies that bot_has_real_review() requires a positive completion signal
 # and rejects:
@@ -15,6 +16,12 @@
 #   6. Comments edited > min_lag after creation (Phase 2 settled)
 #   7. Comments older than min_lag (no edit needed — bot had time to finish)
 #   8. Real review content with no non-review-pattern match
+#
+# Two-phase bot tests (GH#20550):
+#   9.  coderabbitai aged-in unedited (age=120s) → NOT settled (age branch suppressed)
+#  10.  coderabbitai with any edit (edit_delta=5s) → settled regardless of min_lag
+#  11.  Unknown bot login → falls through to OR semantics (non-two-phase)
+#  12.  env min_lag override still respected for non-two-phase bots
 #
 # Plus unit tests on _comment_is_settled, is_non_review_comment, and
 # _get_min_edit_lag direct invocations (no gh stubbing needed).
@@ -265,6 +272,74 @@ test_settled_unparseable_timestamps_conservative_pass() {
 	return 0
 }
 
+# ---------- Unit tests: two-phase bot settled check (GH#20550) ----------
+
+test_two_phase_bot_aged_unedited_not_settled() {
+	# coderabbitai aged 120s, never edited (edit_delta=0) → NOT settled.
+	# Age-derived OR branch must be suppressed for two-phase bots.
+	local now created
+	now=$(date +%s)
+	created=$(TZ=UTC date -u -r "$((now - 120))" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null ||
+		date -u -d "@$((now - 120))" +"%Y-%m-%dT%H:%M:%SZ")
+	if ! _comment_is_settled "$created" "$created" 30 "coderabbitai"; then
+		print_result "two-phase bot: aged unedited coderabbitai → not settled" 0
+	else
+		print_result "two-phase bot: aged unedited coderabbitai → not settled" 1 \
+			"expected NOT settled (Phase 1 placeholder aged past min_lag should not pass)"
+	fi
+	return 0
+}
+
+test_two_phase_bot_any_edit_settled() {
+	# coderabbitai with edit_delta=5s → settled regardless of age or min_lag.
+	# Any positive edit_delta is Phase 2 — authoritative.
+	local now created updated
+	now=$(date +%s)
+	created=$(TZ=UTC date -u -r "$((now - 10))" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null ||
+		date -u -d "@$((now - 10))" +"%Y-%m-%dT%H:%M:%SZ")
+	updated=$(TZ=UTC date -u -r "$((now - 5))" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null ||
+		date -u -d "@$((now - 5))" +"%Y-%m-%dT%H:%M:%SZ")
+	if _comment_is_settled "$created" "$updated" 30 "coderabbitai"; then
+		print_result "two-phase bot: any edit on coderabbitai → settled" 0
+	else
+		print_result "two-phase bot: any edit on coderabbitai → settled" 1 \
+			"expected settled (edit_delta=5s is Phase 2 — authoritative regardless of min_lag)"
+	fi
+	return 0
+}
+
+test_two_phase_bot_unknown_login_or_semantics() {
+	# An unknown bot login → falls through to non-two-phase OR semantics.
+	# Age=120s >= min_lag=30 → settled (same as test_settled_old_unedited_accepted).
+	local now created
+	now=$(date +%s)
+	created=$(TZ=UTC date -u -r "$((now - 120))" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null ||
+		date -u -d "@$((now - 120))" +"%Y-%m-%dT%H:%M:%SZ")
+	if _comment_is_settled "$created" "$created" 30 "gemini-code-assist"; then
+		print_result "two-phase bot: unknown bot login falls through to OR semantics" 0
+	else
+		print_result "two-phase bot: unknown bot login falls through to OR semantics" 1 \
+			"expected settled via age-derived branch for non-two-phase bot"
+	fi
+	return 0
+}
+
+test_two_phase_bot_env_override_non_two_phase() {
+	# REVIEW_BOT_MIN_EDIT_LAG_SECONDS env override is respected for non-two-phase bots.
+	# Set min_lag=120, age=60 → NOT settled for a non-two-phase bot.
+	local now created
+	now=$(date +%s)
+	created=$(TZ=UTC date -u -r "$((now - 60))" +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null ||
+		date -u -d "@$((now - 60))" +"%Y-%m-%dT%H:%M:%SZ")
+	if ! _comment_is_settled "$created" "$created" 120 "gemini-code-assist"; then
+		print_result "two-phase bot: env min_lag=120 respected for non-two-phase bot (age=60)" 0
+	else
+		print_result "two-phase bot: env min_lag=120 respected for non-two-phase bot (age=60)" 1 \
+			"expected NOT settled (age=60 < min_lag=120 for non-two-phase bot)"
+	fi
+	return 0
+}
+
 # ---------- Unit tests: per-tool / per-repo lag resolution ----------
 
 test_get_min_edit_lag_per_tool() {
@@ -345,6 +420,13 @@ main() {
 	test_settled_edit_delta_over_min_lag_accepted
 	test_settled_missing_timestamps_conservative_pass
 	test_settled_unparseable_timestamps_conservative_pass
+
+	echo ""
+	echo "=== Two-phase bot settled check (GH#20550) ==="
+	test_two_phase_bot_aged_unedited_not_settled
+	test_two_phase_bot_any_edit_settled
+	test_two_phase_bot_unknown_login_or_semantics
+	test_two_phase_bot_env_override_non_two_phase
 
 	echo ""
 	echo "=== Min-edit-lag resolver ==="


### PR DESCRIPTION
## Summary

Implements Option A' two-phase bot support for `_comment_is_settled` in `review-bot-gate-helper.sh`, as specified in #20550.

Resolves #20550

## Changes

**`.agents/scripts/review-bot-gate-helper.sh`**

- `TWO_PHASE_BOTS=("coderabbitai")` constant added near `NON_REVIEW_PATTERNS` (line ~93). No `readonly` — bash 3.2 scopes `readonly` arrays function-local when declared via `source` inside a function (which is how the test harness loads the helper via `load_helper_functions`).
- `_is_two_phase_bot` helper added before `_to_epoch`, modelled on the `_get_rate_limit_behavior`/`_get_min_edit_lag` resolver pattern.
- `_comment_is_settled` extended with `bot_login` as optional 4th param (backward-compat; omitting falls through to non-two-phase OR semantics). For two-phase bots, age-derived settlement is suppressed — only `edit_delta > 0` is authoritative.
- Both call sites updated: `bot_has_real_review` (~line 419) and `_classify_bot_state` (~line 665).

**`.agents/scripts/tests/test-review-bot-gate-completion-signal.sh`**

4 new test cases in a new `=== Two-phase bot settled check (GH#20550) ===` section:
1. `coderabbitai` aged 120s, never edited → NOT settled (age branch suppressed)
2. `coderabbitai` with edit_delta=5s → settled (any positive edit is authoritative)
3. Unknown bot login (`gemini-code-assist`) aged 120s → settled via OR semantics
4. `min_lag=120`, `age=60`, non-two-phase bot → NOT settled (env override respected)

All 20 tests pass (16 existing + 4 new). shellcheck exits clean.

## Layer-1 note

`#20493` — the CI workflow (`.github/workflows/`) has its own inline copy of this logic; this PR does NOT reach it. Coordinate port-through as a separate task.

## Verification

```bash
bash .agents/scripts/tests/test-review-bot-gate-completion-signal.sh
shellcheck .agents/scripts/review-bot-gate-helper.sh
```

Both exit 0. Test output: 20 run, 0 failed.

---

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.95 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 13m and 35,163 tokens on this as a headless worker.