### PR TITLE
GH#20577: enumerate pulse-wrapper invocation sources and measure cadence

### DIFF
--- a/.agents/reference/pulse-wrapper-churn-investigation.md
+++ b/.agents/reference/pulse-wrapper-churn-investigation.md
@@ -22,12 +22,78 @@ login hooks) independently trigger `pulse-wrapper.sh`.
 | Is-running check | [#20579](https://github.com/marcusquinn/aidevops/issues/20579) | pgrep short-circuit before mkdir lock | `tier:standard` |
 | Source logging | [#20580](https://github.com/marcusquinn/aidevops/issues/20580) | Per-source invocation counters in pulse-stats.json | `tier:standard` |
 
+---
+
+## Investigation Findings (#20577)
+
+**Date:** 2026-04-23  
+**Result:** Hypothesis **partially rejected** — only one direct scheduler found.
+
+### Enumerated Invocation Sources
+
+| Source | Cadence | Direct invocation of pulse-wrapper.sh? |
+|--------|---------|----------------------------------------|
+| `com.aidevops.aidevops-supervisor-pulse` (launchd) | **180s** | YES — sole direct source |
+| `com.aidevops.aidevops-auto-update` → `setup.sh` → `restart-if-running` | 600s plist, but setup.sh only on updates | Indirect restart (~32× in 42 days, ~0.5% of auto-update runs) |
+| Cron | n/a | NO — no pulse entries in `crontab -l` |
+| Plugins (`opencode-aidevops`) | n/a | NO — plugin references are doc strings only |
+| Shell login hooks (`.zshrc`, `.bashrc`, `.bash_profile`) | n/a | NO — no pulse references |
+| `worker-watchdog` (launchd, 120s) | 120s | NO — monitors workers, does not invoke wrapper |
+| `process-guard-helper.sh` (launchd, 30s) | 30s | NO — kills runaway children inside existing sessions |
+
+**Conclusion: exactly one direct scheduler exists.**
+
+**Note:** `pulse-wrapper.sh` header line 64 says "launchd fires every 120s" — this is a stale
+comment. The deployed plist uses `StartInterval=180`.
+
+### The 4-PID / 15-Minute Pattern Explained
+
+Log evidence:
+```
+[pulse-wrapper] Instance lock acquired via mkdir (PID 93516)
+[pulse-wrapper] Instance lock acquired via mkdir (PID 10463)
+[pulse-wrapper] Another pulse instance holds the mkdir lock (PID 10463, age 203s…) — exiting
+[pulse-wrapper] Instance lock acquired via mkdir (PID 82162)
+[pulse-wrapper] Instance lock acquired via mkdir (PID 93078)
+```
+
+4 distinct PIDs in 15 minutes is expected at a 180s launchd interval (15×60/180 = 5 possible
+firings). The **voluntary pre-LLM lock release** (`pulse-wrapper.sh:1329`) releases the instance
+lock before launching the LLM session, allowing the next launchd invocation to run deterministic
+ops concurrently. This produces multiple sequential lock acquisitions while an earlier invocation's
+LLM session is still running. This is documented design behaviour, not anomalous churn.
+
+### Measured Cadence (42-day log window: 2026-03-11 to 2026-04-23)
+
+| Metric | Value |
+|--------|-------|
+| Total wrapper invocations (acquired + rejected) | 4,021 |
+| Successful lock acquisitions | 3,544 |
+| Lock rejections ("Another pulse instance holds…") | 477 (11.9%) |
+| LLM supervisor sessions started | 2,181 |
+| Actual invocation rate | 4.0/hr (avg 910s interval) |
+| Expected at 180s if always-on (42 days) | 20,323 |
+| Machine uptime fraction | ~20% (sleeping ~80% of the time) |
+
+The invocation rate is consistent with normal launchd operation on a laptop that
+sleeps frequently. The 11.9% lock rejection rate is within design parameters.
+
+### Additional Finding: Persistent trigger=stall
+
+All recent LLM sessions show `trigger=stall`, meaning the backlog stall detector
+(`_should_run_llm_supervisor` in `pulse-dispatch-engine.sh:686`) fires on every cycle
+because open issue+PR counts are not decreasing. April 2026 median LLM interval: **76 minutes**.
+This is a throughput/capacity signal — separate from the scheduler question — but means the LLM
+supervisor is running as often as the stall threshold allows, amplifying the observed invocation count.
+
+---
+
 ## Architecture Notes
 
 ### Current invocation flow (pulse-wrapper.sh main())
 
 ```text
-launchd fires (every 120s)
+launchd fires (every 180s — note: code comment on line 64 says 120s, stale)
   -> main()
     -> _pulse_handle_self_check()     # Phase 0: validate all symbols loaded
     -> _pulse_setup_dry_run_mode()
@@ -37,13 +103,14 @@ launchd fires (every 120s)
     -> check_session_gate()            # pulse-hours window
     -> check_dedup()                   # PID file sentinel
     -> [pulse cycle runs]
-    -> release_instance_lock()
+    -> release_instance_lock()         # voluntary pre-LLM release (line 1329)
+    -> [LLM session runs with lockdir.llm lock]
 ```
 
 ### Proposed flow (after #20578 + #20579)
 
 ```text
-launchd fires (every 120s)
+launchd fires (every 180s)
   -> main()
     -> _pulse_handle_self_check()
     -> _pulse_setup_dry_run_mode()
@@ -70,6 +137,7 @@ common cases (rapid re-invocation and overlapping cycles).
 
 - #20577 (investigation) runs in parallel with #20578-#20580 (fixes).
 - The fixes are independently implementable.
-- #20577 may surface an additional child: "Consolidate schedulers" (Child A from
-  the parent's original plan). This child is deferred until the investigation
-  identifies which schedulers are redundant.
+- Investigation confirms **Child A (Consolidate schedulers)** from the parent's
+  original plan is **not needed** — only one scheduler exists. The three remaining
+  fix children (#20578, #20579, #20580) address the voluntary-release churn pattern,
+  not a multi-scheduler problem.


### PR DESCRIPTION
## Summary

Investigation deliverable for #20577 — enumerates pulse-wrapper.sh invocation sources and measures cadence as requested by parent #20557.

## What

Adds `.agents/reference/pulse-wrapper-churn-investigation.md` documenting:
- All active scheduler sources on this runner machine
- Configured cadence per source
- Measured invocation rates vs expected rates
- Analysis of the 4-PID / 15-minute anomaly
- Hypothesis verdict and child issue decomposition

## Key findings

- **Hypothesis rejected:** Only one direct scheduler (`com.aidevops.aidevops-supervisor-pulse`, launchd, 180s). No cron, plugin, or login hook sources.
- **4-PID pattern explained:** Normal consequence of voluntary pre-LLM lock release at `pulse-wrapper.sh:1329` — successive launchd firings acquire the lock after the previous invocation voluntarily releases it before its LLM session. Not churn.
- **11.9% lock rejection rate:** Within design parameters.
- **Stale comment:** `pulse-wrapper.sh:64` says 120s; plist uses 180s.

## Verification

Report file exists and is readable:
```
cat .agents/reference/pulse-wrapper-churn-investigation.md
```

Comment posted on parent: https://github.com/marcusquinn/aidevops/issues/20557#issuecomment-4301308128

Resolves #20577
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.95 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 10m and 21,363 tokens on this as a headless worker.