### PR TITLE
t2760: classify worker exit reason in EXIT trap

### DIFF
--- a/.agents/scripts/headless-runtime-failure.sh
+++ b/.agents/scripts/headless-runtime-failure.sh
@@ -29,6 +29,12 @@
 [[ -n "${_HEADLESS_RUNTIME_FAILURE_LOADED:-}" ]] && return 0
 readonly _HEADLESS_RUNTIME_FAILURE_LOADED=1
 
+# Fallback exit reason — backward-compatible value used when classify_worker_exit
+# cannot determine the actual cause (missing sqlite3, corrupt DB, unexpected format).
+# Recognised by dispatch-dedup-helper.sh: any CLAIM_RELEASED is treated as
+# authoritative regardless of reason value.
+readonly _HRFF_FALLBACK_EXIT="process_exit"
+
 #######################################
 # Release a dispatch claim by posting a CLAIM_RELEASED comment.
 # The dedup guard recognises this and allows immediate re-dispatch
@@ -37,10 +43,14 @@ readonly _HEADLESS_RUNTIME_FAILURE_LOADED=1
 # Args:
 #   $1 = session_key (contains issue number and repo slug)
 #   $2 = reason (logged in the comment for debugging)
+#   $3 = exit_code (optional — included in comment when provided by exit trap)
+#   $4 = session_count (optional — session_count from worker DB for exit trap)
 #######################################
 _release_dispatch_claim() {
 	local session_key="$1"
 	local reason="${2:-worker_failed}"
+	local exit_code_arg="${3:-}"
+	local session_count_arg="${4:-}"
 
 	# Extract issue number and repo slug from session key
 	# Format: pulse-{login}-{repo}-{issue} or similar
@@ -57,6 +67,12 @@ _release_dispatch_claim() {
 
 	local comment_body
 	comment_body="CLAIM_RELEASED reason=${reason} runner=$(whoami) ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+	if [[ -n "$exit_code_arg" ]]; then
+		comment_body="${comment_body} exit=${exit_code_arg}"
+	fi
+	if [[ -n "$session_count_arg" ]]; then
+		comment_body="${comment_body} session_count=${session_count_arg}"
+	fi
 
 	gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
 		--method POST \
@@ -77,6 +93,144 @@ _release_dispatch_claim() {
 		clear_active_status_on_release "$issue_number" "$repo_slug" "$(whoami)" \
 			|| print_warning "Failed to clear active status on #${issue_number} (non-fatal)"
 	fi
+	return 0
+}
+
+#######################################
+# Classify worker termination reason for CLAIM_RELEASED audit lines.
+# Called from _exit_trap_handler before posting the claim release.
+#
+# Args:
+#   $1 = wait_status  (bash exit status; >128 means signal N = wait_status - 128)
+#   $2 = start_epoch_ms (milliseconds epoch when worker was prepared; 0 = unknown)
+#
+# Globals (optional, set by _invoke_opencode / _cmd_run_prepare):
+#   _WORKER_ISOLATED_DB_PATH  — path to isolated worker opencode.db (if active)
+#
+# Returns classification string via stdout:
+#   "clean"                   — exit status 0 (unexpected in EXIT trap context)
+#   "signal_killed:<signum>"  — received signal N (wait_status > 128)
+#   "crash_during_startup"    — non-zero exit, no OpenCode session found in DB
+#   "crash_during_execution"  — non-zero exit, session(s) present in worker DB
+#   "process_exit"            — fallback when classifier cannot determine reason
+#
+# Exit: always 0
+#######################################
+classify_worker_exit() {
+	local wait_status="$1"
+	local start_epoch_ms="${2:-0}"
+
+	# Signal detection: bash encodes signal N as exit status 128+N
+	if [[ "$wait_status" =~ ^[0-9]+$ ]] && (( wait_status > 128 )); then
+		printf '%s' "signal_killed:$((wait_status - 128))"
+		return 0
+	fi
+
+	# Clean exit (unusual in EXIT trap context — trap is normally cleared on success)
+	if [[ "$wait_status" == "0" ]]; then
+		printf '%s' "clean"
+		return 0
+	fi
+
+	# Session creation check: count sessions created since worker started.
+	# Primary: isolated worker DB (still present when EXIT fires during _invoke_opencode).
+	# Fallback: shared DB (~/.local/share/opencode/opencode.db) after merge completes.
+	local session_count=0
+	local shared_db_path="${HOME}/.local/share/opencode/opencode.db"
+	local isolated_db="${_WORKER_ISOLATED_DB_PATH:-}"
+	local active_db=""
+
+	if [[ -n "$isolated_db" && -f "$isolated_db" ]]; then
+		active_db="$isolated_db"
+	elif [[ -f "$shared_db_path" ]]; then
+		active_db="$shared_db_path"
+	fi
+
+	if ! command -v sqlite3 >/dev/null 2>&1 || [[ -z "$active_db" ]]; then
+		# sqlite3 unavailable or no DB found — cannot classify by session
+		print_warning "[exit-classifier] sqlite3 unavailable or DB missing (isolated=${isolated_db:-none} shared=${shared_db_path}) — using ${_HRFF_FALLBACK_EXIT} fallback"
+		printf '%s' "$_HRFF_FALLBACK_EXIT"
+		return 0
+	fi
+
+	local query=""
+	if [[ "$start_epoch_ms" =~ ^[0-9]+$ ]] && (( start_epoch_ms > 0 )); then
+		# Count sessions created at or after worker start time (ms epoch)
+		query="SELECT count(*) FROM session WHERE time_created >= ${start_epoch_ms}"
+	else
+		# No start time: count all sessions (crude fallback — may over-count)
+		query="SELECT count(*) FROM session"
+	fi
+
+	local raw_count=""
+	raw_count=$(sqlite3 "$active_db" "$query" 2>/dev/null) || raw_count=""
+
+	if [[ ! "$raw_count" =~ ^[0-9]+$ ]]; then
+		# sqlite3 returned non-numeric output (e.g. error or corrupt DB)
+		print_warning "[exit-classifier] sqlite3 query failed for ${active_db} — using ${_HRFF_FALLBACK_EXIT} fallback"
+		printf '%s' "$_HRFF_FALLBACK_EXIT"
+		return 0
+	fi
+	session_count="$raw_count"
+
+	if (( session_count == 0 )); then
+		printf '%s' "crash_during_startup"
+	else
+		printf '%s' "crash_during_execution"
+	fi
+	return 0
+}
+
+#######################################
+# EXIT trap handler — classify worker termination and post CLAIM_RELEASED.
+# Replaces the inline 'process_exit' reason in the EXIT trap with a
+# classified reason from classify_worker_exit. Falls back to process_exit
+# if classification fails, preserving backward compatibility.
+#
+# Args:
+#   $1 = session_key (baked in at trap-set time via SC2064-disabled trap)
+#
+# Globals consumed:
+#   _WORKER_START_EPOCH_MS   — ms epoch set by _cmd_run_prepare
+#   _WORKER_ISOLATED_DB_PATH — isolated DB path set by _invoke_opencode
+#######################################
+_exit_trap_handler() {
+	local session_key="$1"
+	# Capture exit status immediately — any subsequent command will overwrite $?
+	local exit_status=$?
+
+	local reason="$_HRFF_FALLBACK_EXIT"
+	local session_count=0
+
+	if declare -F classify_worker_exit >/dev/null 2>&1; then
+		local _start_ms="${_WORKER_START_EPOCH_MS:-0}"
+		local _classified=""
+		_classified=$(classify_worker_exit "$exit_status" "$_start_ms" 2>/dev/null) || true
+		if [[ -n "$_classified" ]]; then
+			reason="$_classified"
+		else
+			print_warning "[exit-trap] classify_worker_exit returned empty — using process_exit fallback"
+		fi
+
+		# Re-read session count for the enriched comment (best-effort)
+		local _db="${_WORKER_ISOLATED_DB_PATH:-}"
+		local _shared="${HOME}/.local/share/opencode/opencode.db"
+		[[ -z "$_db" || ! -f "$_db" ]] && _db="$_shared"
+		if command -v sqlite3 >/dev/null 2>&1 && [[ -f "$_db" && "$_start_ms" =~ ^[0-9]+$ ]] && (( _start_ms > 0 )); then
+			local _cnt=""
+			_cnt=$(sqlite3 "$_db" \
+				"SELECT count(*) FROM session WHERE time_created >= ${_start_ms}" \
+				2>/dev/null) || _cnt=""
+			[[ "$_cnt" =~ ^[0-9]+$ ]] && session_count="$_cnt"
+		fi
+	else
+		print_warning "[exit-trap] classify_worker_exit not available — using process_exit fallback"
+	fi
+
+	print_info "[exit-trap] session=$session_key exit=$exit_status reason=$reason session_count=$session_count"
+	_release_dispatch_claim "$session_key" "$reason" "$exit_status" "$session_count"
+	_release_session_lock "$session_key"
+	_update_dispatch_ledger "$session_key" "fail"
 	return 0
 }
 

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -424,6 +424,10 @@ _invoke_opencode() {
 		# silently kills streaming connections — workers stall at step_start
 		# with zero API errors. Session stats are sacrificed for reliability.
 		export XDG_DATA_HOME="$isolated_data_dir"
+		# GH#20564: Expose isolated DB path to exit trap classifier so
+		# classify_worker_exit can check for sessions even when the EXIT trap
+		# fires while _invoke_opencode is still waiting for the worker.
+		_WORKER_ISOLATED_DB_PATH="${isolated_data_dir}/opencode/opencode.db"
 		print_info "[lifecycle] db_isolated dir=$isolated_data_dir pid=$$"
 
 		# t2249: Pre-dispatch OAuth pool check. If the account copied into the
@@ -555,6 +559,9 @@ _invoke_opencode() {
 		fi
 		rm -rf "$isolated_data_dir" 2>/dev/null || true
 		unset XDG_DATA_HOME
+		# GH#20564: Clear isolated DB path after cleanup so exit trap
+		# classifier falls back to shared DB if EXIT fires post-cleanup.
+		_WORKER_ISOLATED_DB_PATH=""
 		print_info "[lifecycle] db_cleanup dir=$isolated_data_dir pid=$$"
 	fi
 
@@ -1143,8 +1150,18 @@ _cmd_run_prepare() {
 	if ! _acquire_session_lock "$session_key"; then
 		return 2
 	fi
+	# GH#20564: Use _exit_trap_handler to classify the exit reason
+	# (crash_during_startup / crash_during_execution / signal_killed:<N> / clean)
+	# instead of emitting a fixed 'process_exit' reason for all abnormal exits.
+	# SC2064: session_key is intentionally baked in at trap-set time.
 	# shellcheck disable=SC2064
-	trap "_release_dispatch_claim '$session_key' 'process_exit'; _release_session_lock '$session_key'; _update_dispatch_ledger '$session_key' 'fail'" EXIT
+	trap "_exit_trap_handler '$session_key'" EXIT
+
+	# GH#20564: Record worker start time in milliseconds for exit trap classifier.
+	# classify_worker_exit uses this to distinguish crash_during_startup (no
+	# session created since start) from crash_during_execution (session found).
+	# Uses the same python3 ms-epoch pattern as _execute_run_attempt metrics.
+	_WORKER_START_EPOCH_MS=$(python3 -c 'import time; print(int(time.time() * 1000))' 2>/dev/null || printf '%s' "0")
 
 	# GH#6696: Register this dispatch in the in-flight ledger so the pulse
 	# can detect workers that haven't created PRs yet. The ledger bridges

--- a/.agents/scripts/tests/test-worker-exit-classifier.sh
+++ b/.agents/scripts/tests/test-worker-exit-classifier.sh
@@ -1,0 +1,280 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# test-worker-exit-classifier.sh — Exercise classify_worker_exit (GH#20564)
+# =============================================================================
+# Covers all four classification paths:
+#   1. signal_killed:<signum>   — wait_status > 128
+#   2. crash_during_startup     — non-zero exit, no session in DB
+#   3. crash_during_execution   — non-zero exit, session exists in DB
+#   4. process_exit (fallback)  — classifier fails (corrupt/missing DB)
+# And: clean exit (wait_status == 0)
+#
+# Usage: bash tests/test-worker-exit-classifier.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AGENTS_SCRIPTS="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+TMPDIR_TEST=""
+
+print_result() {
+	local test_name="$1"
+	local status="$2"
+	local message="${3:-}"
+
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$status" -eq 0 ]]; then
+		printf 'PASS %s\n' "$test_name"
+		TESTS_PASSED=$((TESTS_PASSED + 1))
+	else
+		printf 'FAIL %s\n' "$test_name"
+		[[ -n "$message" ]] && printf '  %s\n' "$message"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+assert_eq() {
+	local test_name="$1"
+	local got="$2"
+	local want="$3"
+	if [[ "$got" == "$want" ]]; then
+		print_result "$test_name" 0
+	else
+		print_result "$test_name" 1 "got='${got}' want='${want}'"
+	fi
+	return 0
+}
+
+setup() {
+	TMPDIR_TEST=$(mktemp -d)
+	# Provide stub shared-constants.sh functions (print_warning/print_info)
+	# so headless-runtime-failure.sh can be sourced without shared-constants.sh
+	print_warning() { return 0; }
+	print_info()    { return 0; }
+	export -f print_warning print_info
+
+	# Source the target file
+	# shellcheck source=../headless-runtime-failure.sh
+	source "${AGENTS_SCRIPTS}/headless-runtime-failure.sh"
+	return 0
+}
+
+teardown() {
+	[[ -n "$TMPDIR_TEST" && -d "$TMPDIR_TEST" ]] && rm -rf "$TMPDIR_TEST" || true
+	return 0
+}
+
+_make_db() {
+	local db_path="$1"
+	sqlite3 "$db_path" \
+		"CREATE TABLE IF NOT EXISTS session (id TEXT, title TEXT, time_created INTEGER);" \
+		2>/dev/null
+	return 0
+}
+
+_insert_session() {
+	local db_path="$1"
+	local ts_ms="$2"
+	sqlite3 "$db_path" \
+		"INSERT INTO session VALUES ('test-id-$(date +%s%N)', 'test session', ${ts_ms});" \
+		2>/dev/null
+	return 0
+}
+
+_now_ms() {
+	python3 -c 'import time; print(int(time.time() * 1000))' 2>/dev/null || printf '%s' "0"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+test_signal_killed_sigterm() {
+	# SIGTERM = 15; bash exit status = 128 + 15 = 143
+	local result
+	result=$(classify_worker_exit 143 0)
+	assert_eq "signal_killed:SIGTERM (status=143)" "$result" "signal_killed:15"
+	return 0
+}
+
+test_signal_killed_sigkill() {
+	# SIGKILL = 9; bash exit status = 128 + 9 = 137
+	local result
+	result=$(classify_worker_exit 137 0)
+	assert_eq "signal_killed:SIGKILL (status=137)" "$result" "signal_killed:9"
+	return 0
+}
+
+test_signal_killed_sighup() {
+	# SIGHUP = 1; bash exit status = 128 + 1 = 129
+	local result
+	result=$(classify_worker_exit 129 0)
+	assert_eq "signal_killed:SIGHUP (status=129)" "$result" "signal_killed:1"
+	return 0
+}
+
+test_clean_exit() {
+	local result
+	result=$(classify_worker_exit 0 0)
+	assert_eq "clean exit (status=0)" "$result" "clean"
+	return 0
+}
+
+test_crash_during_startup_empty_db() {
+	# Non-zero exit, DB exists but has no sessions
+	local db_path="${TMPDIR_TEST}/empty.db"
+	_make_db "$db_path"
+	local start_ms
+	start_ms=$(_now_ms)
+
+	_WORKER_ISOLATED_DB_PATH="$db_path"
+	local result
+	result=$(classify_worker_exit 1 "$start_ms")
+	unset _WORKER_ISOLATED_DB_PATH
+
+	assert_eq "crash_during_startup (empty DB)" "$result" "crash_during_startup"
+	return 0
+}
+
+test_crash_during_startup_no_db() {
+	# Non-zero exit, no DB at all — sqlite3 cannot find any DB
+	local nonexistent_db="${TMPDIR_TEST}/nonexistent/opencode.db"
+	_WORKER_ISOLATED_DB_PATH="$nonexistent_db"
+	# Also shadow shared DB by using HOME pointing at non-existent dir
+	local result
+	result=$(HOME="${TMPDIR_TEST}/nohome" classify_worker_exit 1 0)
+	unset _WORKER_ISOLATED_DB_PATH
+
+	# When neither isolated nor shared DB exist, falls back to process_exit
+	assert_eq "crash_during_startup fallback (no DB → process_exit)" "$result" "process_exit"
+	return 0
+}
+
+test_crash_during_execution_session_in_db() {
+	# Non-zero exit, session created after worker start → crash_during_execution
+	local db_path="${TMPDIR_TEST}/execution.db"
+	_make_db "$db_path"
+
+	local start_ms
+	start_ms=$(_now_ms)
+	# Insert a session AFTER start time
+	_insert_session "$db_path" "$start_ms"
+
+	_WORKER_ISOLATED_DB_PATH="$db_path"
+	local result
+	result=$(classify_worker_exit 1 "$start_ms")
+	unset _WORKER_ISOLATED_DB_PATH
+
+	assert_eq "crash_during_execution (session after start)" "$result" "crash_during_execution"
+	return 0
+}
+
+test_crash_during_startup_session_before_start() {
+	# Non-zero exit, session EXISTS but was created BEFORE this worker started
+	# → should be crash_during_startup (session_count == 0 for this worker's window)
+	local db_path="${TMPDIR_TEST}/before-start.db"
+	_make_db "$db_path"
+
+	# Insert session with timestamp 10 seconds in the past
+	local old_ts=$(( $(_now_ms) - 10000 ))
+	_insert_session "$db_path" "$old_ts"
+
+	# Worker "start" is now (after the old session)
+	local start_ms
+	start_ms=$(_now_ms)
+
+	_WORKER_ISOLATED_DB_PATH="$db_path"
+	local result
+	result=$(classify_worker_exit 1 "$start_ms")
+	unset _WORKER_ISOLATED_DB_PATH
+
+	assert_eq "crash_during_startup (session before worker start)" "$result" "crash_during_startup"
+	return 0
+}
+
+test_classifier_failure_corrupt_db() {
+	# Corrupt DB → sqlite3 returns error → process_exit fallback
+	local bad_db="${TMPDIR_TEST}/corrupt.db"
+	printf 'not a database\n' >"$bad_db"
+
+	local start_ms
+	start_ms=$(_now_ms)
+
+	_WORKER_ISOLATED_DB_PATH="$bad_db"
+	local result
+	result=$(classify_worker_exit 1 "$start_ms")
+	unset _WORKER_ISOLATED_DB_PATH
+
+	assert_eq "classifier_failure (corrupt DB → process_exit)" "$result" "process_exit"
+	return 0
+}
+
+test_no_start_time_empty_db() {
+	# start_epoch_ms == 0 → uses count-all query (no time filter)
+	# DB is empty → crash_during_startup
+	local db_path="${TMPDIR_TEST}/no-start.db"
+	_make_db "$db_path"
+
+	_WORKER_ISOLATED_DB_PATH="$db_path"
+	local result
+	result=$(classify_worker_exit 1 0)
+	unset _WORKER_ISOLATED_DB_PATH
+
+	assert_eq "crash_during_startup (no start_ms, empty DB)" "$result" "crash_during_startup"
+	return 0
+}
+
+test_no_start_time_with_sessions() {
+	# start_epoch_ms == 0 → uses count-all query
+	# DB has a session → crash_during_execution
+	local db_path="${TMPDIR_TEST}/no-start-sessions.db"
+	_make_db "$db_path"
+	_insert_session "$db_path" "$(_now_ms)"
+
+	_WORKER_ISOLATED_DB_PATH="$db_path"
+	local result
+	result=$(classify_worker_exit 1 0)
+	unset _WORKER_ISOLATED_DB_PATH
+
+	assert_eq "crash_during_execution (no start_ms, session in DB)" "$result" "crash_during_execution"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+	setup
+	trap teardown EXIT
+
+	test_signal_killed_sigterm
+	test_signal_killed_sigkill
+	test_signal_killed_sighup
+	test_clean_exit
+	test_crash_during_startup_empty_db
+	test_crash_during_startup_no_db
+	test_crash_during_execution_session_in_db
+	test_crash_during_startup_session_before_start
+	test_classifier_failure_corrupt_db
+	test_no_start_time_empty_db
+	test_no_start_time_with_sessions
+
+	printf '\n%d tests: %d passed, %d failed\n' \
+		"$TESTS_RUN" "$TESTS_PASSED" "$TESTS_FAILED"
+
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Implements exit reason classification in the EXIT trap of `headless-runtime-helper.sh`, replacing the fixed `process_exit` bucket with four distinct reasons that enable smarter retry decisions.

## What was done

- **`headless-runtime-failure.sh`**: Added `classify_worker_exit()` (detects signal-killed, startup crash, execution crash, or clean) and `_exit_trap_handler()` (captures exit status, calls classifier, posts enriched CLAIM_RELEASED with `exit=<code> session_count=<N>` metadata). Extended `_release_dispatch_claim()` with optional `$3=exit_code` and `$4=session_count` params (backward-compatible).
- **`headless-runtime-helper.sh`**: Exports `_WORKER_START_EPOCH_MS` in `_cmd_run_prepare` (ms epoch for DB session query) and `_WORKER_ISOLATED_DB_PATH` in `_invoke_opencode` (cleared after cleanup). EXIT trap now calls `_exit_trap_handler` instead of the fixed inline string.
- **`tests/test-worker-exit-classifier.sh`**: 11 tests covering all four classification paths including the classifier-failure fallback.

## Classification logic

| wait_status | DB check | Result |
|-------------|----------|--------|
| >128 | — | `signal_killed:<signum>` |
| 0 | — | `clean` |
| non-zero | 0 sessions since start | `crash_during_startup` |
| non-zero | >=1 session since start | `crash_during_execution` |
| non-zero | sqlite3 unavailable / corrupt | `process_exit` (fallback) |

## Verification

```
shellcheck .agents/scripts/headless-runtime-failure.sh
bash .agents/scripts/tests/test-worker-exit-classifier.sh
# 11 tests: 11 passed, 0 failed

grep "CLAIM_RELEASED" ~/.aidevops/logs/pulse.log | tail -20
# Expect reason= values: signal_killed:15, crash_during_startup, crash_during_execution
```

Resolves #20564

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.95 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 15m and 39,790 tokens on this as a headless worker.
