### PR TITLE
t2752: add pulse-diagnose-helper.sh cycle-health subcommand for pulse stability observability

### DIFF
--- a/.agents/scripts/pulse-diagnose-helper.sh
+++ b/.agents/scripts/pulse-diagnose-helper.sh
@@ -630,6 +630,380 @@ cmd_rules() {
 	return 0
 }
 
+# =============================================================================
+# Subcommands — cycle_health (t2752)
+#
+# Provides a concise summary of pulse-cycle stability by parsing
+# pulse-stage-timings.log and pulse-wrapper.log.
+#
+# Log format (pulse-stage-timings.log):
+#   timestamp \t stage_name \t duration_secs \t exit_code \t pid
+#
+# "Fill-floor" proxy: the stage preflight_early_dispatch with exit_code=0
+# corresponds to a cycle that successfully reached worker dispatch.
+# =============================================================================
+
+_CMD_CH_WINDOW_SECS=3600
+_CMD_CH_JSON_OUTPUT=0
+_CMD_CH_VERBOSE=0
+_CH_DEGRADED="DEGRADED"
+
+# Convert a window string (1h, 24h, 7d, 30m, or raw integer) to seconds.
+_ch_parse_window_secs() {
+	local raw="$1"
+	case "$raw" in
+		*m) printf '%d' "$(( ${raw%m} * 60 ))" ;;
+		*h) printf '%d' "$(( ${raw%h} * 3600 ))" ;;
+		*d) printf '%d' "$(( ${raw%d} * 86400 ))" ;;
+		'') printf '%d' 3600 ;;
+		*)  printf '%d' "$raw" ;;
+	esac
+	return 0
+}
+
+# Compute ISO 8601 UTC cutoff timestamp (window_secs ago from now).
+# Tries macOS date -v syntax first; falls back to GNU date -d.
+_ch_cutoff_ts() {
+	local window_secs="$1"
+	local ts
+	if ts=$(date -u -v"-${window_secs}S" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null); then
+		printf '%s' "$ts"
+		return 0
+	fi
+	local now_epoch
+	now_epoch=$(date '+%s' 2>/dev/null) || now_epoch=0
+	if ts=$(date -u -d "@$(( now_epoch - window_secs ))" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null); then
+		printf '%s' "$ts"
+		return 0
+	fi
+	printf '1970-01-01T00:00:00Z'
+	return 0
+}
+
+# Convert an ISO 8601 UTC timestamp to a human "Xm ago" string.
+_ch_ts_ago() {
+	local ts="$1"
+	[[ -z "$ts" ]] && { printf 'never'; return 0; }
+	local ts_epoch now_epoch diff
+	ts_epoch=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$ts" '+%s' 2>/dev/null) ||
+		ts_epoch=$(date -u -d "$ts" '+%s' 2>/dev/null) || { printf '%s' "$ts"; return 0; }
+	now_epoch=$(date '+%s' 2>/dev/null) || { printf '%s' "$ts"; return 0; }
+	diff=$(( now_epoch - ts_epoch ))
+	if [[ "$diff" -lt 60 ]]; then
+		printf '%ds ago' "$diff"
+	elif [[ "$diff" -lt 3600 ]]; then
+		printf '%dm ago' "$(( diff / 60 ))"
+	elif [[ "$diff" -lt 86400 ]]; then
+		printf '%dh ago' "$(( diff / 3600 ))"
+	else
+		printf '%dd ago' "$(( diff / 86400 ))"
+	fi
+	return 0
+}
+
+_cmd_cycle_health_parse_args() {
+	_CMD_CH_WINDOW_SECS=3600
+	_CMD_CH_JSON_OUTPUT=0
+	_CMD_CH_VERBOSE=0
+
+	while [[ $# -gt 0 ]]; do
+		case "${1}" in
+			--window)
+				local raw="${2:-1h}"
+				shift 2
+				_CMD_CH_WINDOW_SECS=$(_ch_parse_window_secs "$raw")
+				;;
+			--json)
+				_CMD_CH_JSON_OUTPUT=1
+				shift
+				;;
+			--verbose)
+				_CMD_CH_VERBOSE=1
+				shift
+				;;
+			-*)
+				print_error "unknown option: ${1}"
+				return 1
+				;;
+			*)
+				shift
+				;;
+		esac
+	done
+	return 0
+}
+
+# Parse pulse-stage-timings.log within the window and emit per-stage stats.
+# Output TSV: stage runs timeouts p50_secs p95_secs last_ok_ts degraded
+_ch_stage_stats() {
+	local timings_file="$1"
+	local cutoff_ts="$2"
+
+	[[ -f "$timings_file" ]] || return 0
+
+	awk -v cutoff="$cutoff_ts" '
+	{
+		nf=split($0, f, "\t")
+		if (nf < 5 || f[1] < cutoff) next
+		ts=f[1]; stage=f[2]; dur=f[3]+0; rc=f[4]+0
+		cnt[stage]++
+		if (rc==124) to[stage]++
+		if (rc==0 && ts > last_ok[stage]) last_ok[stage]=ts
+		n=cnt[stage]; d[stage,n]=dur
+	}
+	END {
+		for (stage in cnt) {
+			n=cnt[stage]
+			for (i=2;i<=n;i++) {
+				key=d[stage,i]; j=i-1
+				while (j>=1 && d[stage,j]>key) {
+					d[stage,j+1]=d[stage,j]; j--
+				}
+				d[stage,j+1]=key
+			}
+			p50_i=int(n*0.50)+1; if(p50_i>n)p50_i=n
+			p95_i=int(n*0.95)+1; if(p95_i>n)p95_i=n
+			t=(to[stage]+0)
+			deg=(n>0 && (t/n)>0.50) ? "DEGRADED" : "ok"
+			printf "%s\t%d\t%d\t%d\t%d\t%s\t%s\n", \
+				stage, n, t, d[stage,p50_i], d[stage,p95_i], \
+				(last_ok[stage]?last_ok[stage]:""), deg
+		}
+	}' "$timings_file" 2>/dev/null | sort -t"	" -k1,1
+	return 0
+}
+
+# Compute cycle-level summary stats from pulse-stage-timings.log.
+# Output: key=value lines (cycles_started, fill_floor_cycles, cycles_since_ff, last_ff_ts)
+_ch_cycle_stats() {
+	local timings_file="$1"
+	local cutoff_ts="$2"
+
+	if [[ ! -f "$timings_file" ]]; then
+		printf 'cycles_started=0\nfill_floor_cycles=0\ncycles_since_ff=0\nlast_ff_ts=\n'
+		return 0
+	fi
+
+	awk -v cutoff="$cutoff_ts" '
+	{
+		nf=split($0, f, "\t")
+		if (nf < 5 || f[1] < cutoff) next
+		ts=f[1]; stage=f[2]; rc=f[4]+0; pid=f[5]
+		pids[pid]=1
+		if (!pid_first[pid] || ts < pid_first[pid]) pid_first[pid]=ts
+		if (stage=="preflight_early_dispatch" && rc==0) {
+			ff[pid]=1
+			if (ts > last_ff_ts) { last_ff_ts=ts; last_ff_pid=pid }
+		}
+	}
+	END {
+		total=0; ff_count=0; since_ff=0
+		for (pid in pids) total++
+		for (pid in ff) ff_count++
+		if (last_ff_ts) {
+			for (pid in pids) {
+				if (!(pid in ff) && pid_first[pid]>last_ff_ts) since_ff++
+			}
+		} else {
+			since_ff=total
+		}
+		printf "cycles_started=%d\nfill_floor_cycles=%d\ncycles_since_ff=%d\nlast_ff_ts=%s\n", \
+			total, ff_count, since_ff, last_ff_ts
+	}' "$timings_file" 2>/dev/null
+	return 0
+}
+
+# Parse pulse-wrapper.log for instance-lock churn (all-time).
+# Output: key=value lines (acquired, exited_early, churn_pct)
+_ch_wrapper_churn() {
+	local wrapper_log="$1"
+
+	if [[ ! -f "$wrapper_log" ]]; then
+		printf 'acquired=0\nexited_early=0\nchurn_pct=0\n'
+		return 0
+	fi
+
+	local acquired exited_early total churn_pct
+	acquired=$(grep -c 'Instance lock acquired via mkdir' "$wrapper_log" 2>/dev/null) || acquired=0
+	exited_early=$(grep -c 'Another pulse instance holds the mkdir lock' "$wrapper_log" 2>/dev/null) || exited_early=0
+	total=$(( acquired + exited_early ))
+	if [[ "$total" -gt 0 ]]; then
+		churn_pct=$(( exited_early * 100 / total ))
+	else
+		churn_pct=0
+	fi
+	printf 'acquired=%d\nexited_early=%d\nchurn_pct=%d\n' "$acquired" "$exited_early" "$churn_pct"
+	return 0
+}
+
+# Render the human-readable cycle health report.
+# Args: window_label cutoff_ts cycle_kv_str churn_kv_str stage_tsv stats_json_or_empty
+_ch_render_text() {
+	local window_label="$1"
+	local cutoff_ts="$2"
+	local cycle_kv="$3"
+	local churn_kv="$4"
+	local stage_tsv="$5"
+
+	# Parse cycle key-value pairs
+	local cycles_started=0 fill_floor_cycles=0 cycles_since_ff=0 last_ff_ts=""
+	while IFS='=' read -r key val; do
+		case "$key" in
+			cycles_started)     cycles_started="$val" ;;
+			fill_floor_cycles)  fill_floor_cycles="$val" ;;
+			cycles_since_ff)    cycles_since_ff="$val" ;;
+			last_ff_ts)         last_ff_ts="$val" ;;
+		esac
+	done <<< "$cycle_kv"
+
+	# Parse churn key-value pairs
+	local acquired=0 exited_early=0 churn_pct=0
+	while IFS='=' read -r key val; do
+		case "$key" in
+			acquired)     acquired="$val" ;;
+			exited_early) exited_early="$val" ;;
+			churn_pct)    churn_pct="$val" ;;
+		esac
+	done <<< "$churn_kv"
+
+	printf '\nPulse Cycle Health — last %s (cutoff: %s)\n\n' "$window_label" "$cutoff_ts"
+
+	# Stage table
+	if [[ -z "$stage_tsv" ]]; then
+		printf '  No stage timing data in window (log missing or empty).\n'
+	else
+		printf '%-38s %5s %8s %5s %5s  %s\n' "Stage" "Runs" "Timeouts" "p50s" "p95s" "Last OK"
+		printf '%s\n' "$(printf '%.0s-' {1..80})"
+		while IFS=$'\t' read -r stage runs timeouts p50 p95 last_ok degraded; do
+			[[ -z "$stage" ]] && continue
+			local ago marker=""
+			ago=$(_ch_ts_ago "$last_ok")
+			[[ "$degraded" == "$_CH_DEGRADED" ]] && marker=" [DEGRADED]"
+			printf '%-38s %5d %8d %5d %5d  %s%b%s%b\n' \
+				"${stage}" "$runs" "$timeouts" "$p50" "$p95" \
+				"$ago" "$YELLOW" "$marker" "$NC"
+		done <<< "$stage_tsv"
+		printf '\n'
+	fi
+
+	# Cycle summary
+	printf 'Cycle summary (last %s):\n' "$window_label"
+	printf '  Cycles started:              %d\n' "$cycles_started"
+	printf '  Cycles reached dispatch:     %d\n' "$fill_floor_cycles"
+	printf '  Cycles since last dispatch:  %d\n' "$cycles_since_ff"
+	if [[ -n "$last_ff_ts" ]]; then
+		local ff_ago
+		ff_ago=$(_ch_ts_ago "$last_ff_ts")
+		printf '  Last dispatch cycle:         %s (%s)\n' "$last_ff_ts" "$ff_ago"
+	else
+		printf '  Last dispatch cycle:         none in window\n'
+	fi
+
+	# Wrapper churn
+	local total_wrappers=$(( acquired + exited_early ))
+	printf '\nWrapper churn (all time):\n'
+	printf '  Acquired lock: %d   Exited early: %d   Churn: %d%% (%d/%d)\n' \
+		"$acquired" "$exited_early" "$churn_pct" "$exited_early" "$total_wrappers"
+	printf '\n'
+	return 0
+}
+
+# Render JSON cycle health output.
+_ch_render_json() {
+	local window_secs="$1"
+	local cutoff_ts="$2"
+	local cycle_kv="$3"
+	local churn_kv="$4"
+	local stage_tsv="$5"
+
+	local cycles_started=0 fill_floor_cycles=0 cycles_since_ff=0 last_ff_ts=""
+	while IFS='=' read -r key val; do
+		case "$key" in
+			cycles_started)     cycles_started="$val" ;;
+			fill_floor_cycles)  fill_floor_cycles="$val" ;;
+			cycles_since_ff)    cycles_since_ff="$val" ;;
+			last_ff_ts)         last_ff_ts="$val" ;;
+		esac
+	done <<< "$cycle_kv"
+
+	local acquired=0 exited_early=0 churn_pct=0
+	while IFS='=' read -r key val; do
+		case "$key" in
+			acquired)     acquired="$val" ;;
+			exited_early) exited_early="$val" ;;
+			churn_pct)    churn_pct="$val" ;;
+		esac
+	done <<< "$churn_kv"
+
+	printf '{\n'
+	_json_num_field "window_secs"            "$window_secs"
+	_json_str_field "cutoff_ts"              "$cutoff_ts"
+	_json_num_field "cycles_started"         "$cycles_started"
+	_json_num_field "fill_floor_cycles"      "$fill_floor_cycles"
+	_json_num_field "cycles_since_fill_floor" "$cycles_since_ff"
+	_json_str_field "last_fill_floor_ts"     "$last_ff_ts"
+	_json_num_field "wrapper_acquired"       "$acquired"
+	_json_num_field "wrapper_exited_early"   "$exited_early"
+	_json_num_field "wrapper_churn_pct"      "$churn_pct"
+	printf '  "stages": [\n'
+
+	local first=1
+	while IFS=$'\t' read -r stage runs timeouts p50 p95 last_ok degraded; do
+		[[ -z "$stage" ]] && continue
+		local deg_bool="false"
+		[[ "$degraded" == "$_CH_DEGRADED" ]] && deg_bool="true"
+		[[ "$first" -eq 0 ]] && printf ',\n'
+		first=0
+		printf '    {"stage": "%s", "runs": %s, "timeouts": %s, "p50_secs": %s, "p95_secs": %s, "last_ok_ts": "%s", "degraded": %s}' \
+			"$stage" "$runs" "$timeouts" "$p50" "$p95" "$last_ok" "$deg_bool"
+	done <<< "$stage_tsv"
+
+	printf '\n  ]\n'
+	printf '}\n'
+	return 0
+}
+
+cmd_cycle_health() {
+	_cmd_cycle_health_parse_args "$@" || return 1
+
+	local cutoff_ts
+	cutoff_ts=$(_ch_cutoff_ts "$_CMD_CH_WINDOW_SECS")
+
+	local logdir
+	logdir=$(_resolve_logdir)
+	local timings_file="${logdir}/pulse-stage-timings.log"
+	local wrapper_log="${logdir}/pulse-wrapper.log"
+
+	# Allow env overrides for tests
+	timings_file="${PULSE_DIAGNOSE_TIMINGS_FILE:-$timings_file}"
+	wrapper_log="${PULSE_DIAGNOSE_WRAPPER_LOG:-$wrapper_log}"
+
+	# Compute window label for display (convert secs back to human)
+	local window_label
+	if [[ "$_CMD_CH_WINDOW_SECS" -ge 86400 ]]; then
+		window_label="$(( _CMD_CH_WINDOW_SECS / 86400 ))d"
+	elif [[ "$_CMD_CH_WINDOW_SECS" -ge 3600 ]]; then
+		window_label="$(( _CMD_CH_WINDOW_SECS / 3600 ))h"
+	else
+		window_label="$(( _CMD_CH_WINDOW_SECS / 60 ))m"
+	fi
+
+	local stage_tsv cycle_kv churn_kv
+	stage_tsv=$(_ch_stage_stats "$timings_file" "$cutoff_ts")
+	cycle_kv=$(_ch_cycle_stats "$timings_file" "$cutoff_ts")
+	churn_kv=$(_ch_wrapper_churn "$wrapper_log")
+
+	if [[ "$_CMD_CH_JSON_OUTPUT" -eq 1 ]]; then
+		_ch_render_json "$_CMD_CH_WINDOW_SECS" "$cutoff_ts" \
+			"$cycle_kv" "$churn_kv" "$stage_tsv"
+		return 0
+	fi
+
+	_ch_render_text "$window_label" "$cutoff_ts" \
+		"$cycle_kv" "$churn_kv" "$stage_tsv"
+	return 0
+}
+
 cmd_help() {
 	cat <<'USAGE'
 pulse-diagnose-helper.sh — correlate pulse.log events with PR merge decisions
@@ -643,17 +1017,26 @@ COMMANDS:
 
   rules [--json]     List the full rule inventory
 
+  cycle-health [options]   Summarise pulse-cycle stability
+    --window <W>     Time window: 30m, 1h, 6h, 24h, 7d (default: 1h)
+    --json           Machine-readable JSON output
+    --verbose        (reserved for future use)
+
   help               Show this message
 
 ENVIRONMENT:
-  PULSE_DIAGNOSE_LOGFILE    Override pulse.log path
-  PULSE_DIAGNOSE_GH_OFFLINE Set to 1 to skip gh API calls (test mode)
-  PULSE_DIAGNOSE_LOGDIR     Override log directory for rotated logs
+  PULSE_DIAGNOSE_LOGFILE        Override pulse.log path
+  PULSE_DIAGNOSE_GH_OFFLINE     Set to 1 to skip gh API calls (test mode)
+  PULSE_DIAGNOSE_LOGDIR         Override log directory for rotated logs
+  PULSE_DIAGNOSE_TIMINGS_FILE   Override pulse-stage-timings.log path
+  PULSE_DIAGNOSE_WRAPPER_LOG    Override pulse-wrapper.log path
 
 EXAMPLES:
   pulse-diagnose-helper.sh pr 20329 --repo marcusquinn/aidevops
   pulse-diagnose-helper.sh pr 20336 --verbose
   pulse-diagnose-helper.sh rules --json
+  pulse-diagnose-helper.sh cycle-health
+  pulse-diagnose-helper.sh cycle-health --window 24h --json
 USAGE
 	return 0
 }
@@ -667,8 +1050,9 @@ main() {
 	shift 2>/dev/null || true
 
 	case "$cmd" in
-		pr)       cmd_pr "$@" ;;
-		rules)    cmd_rules "$@" ;;
+		pr)            cmd_pr "$@" ;;
+		rules)         cmd_rules "$@" ;;
+		cycle-health)  cmd_cycle_health "$@" ;;
 		help|-h|--help) cmd_help ;;
 		*)
 			print_error "unknown command: $cmd"

--- a/.agents/scripts/tests/test-pulse-diagnose-cycle-health.sh
+++ b/.agents/scripts/tests/test-pulse-diagnose-cycle-health.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Regression tests for pulse-diagnose-helper.sh cycle-health subcommand (t2752)
+#
+# Uses fixture log files — no live network or real pulse logs required.
+# Log format: timestamp \t stage_name \t duration_secs \t exit_code \t pid
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../pulse-diagnose-helper.sh"
+PASS=0
+FAIL=0
+TOTAL=0
+
+# =============================================================================
+# Test framework (mirrors test-pulse-diagnose-helper.sh)
+# =============================================================================
+
+assert_contains() {
+	local desc="$1" needle="$2" haystack="$3"
+	TOTAL=$((TOTAL + 1))
+	if printf '%s' "$haystack" | grep -qF "$needle" 2>/dev/null; then
+		PASS=$((PASS + 1))
+		printf '  ✓ %s\n' "$desc"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  ✗ %s\n    expected to contain: %s\n    actual: %s\n' \
+			"$desc" "$needle" "$haystack"
+	fi
+	return 0
+}
+
+assert_not_contains() {
+	local desc="$1" needle="$2" haystack="$3"
+	TOTAL=$((TOTAL + 1))
+	if ! printf '%s' "$haystack" | grep -qF "$needle" 2>/dev/null; then
+		PASS=$((PASS + 1))
+		printf '  ✓ %s\n' "$desc"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  ✗ %s\n    expected NOT to contain: %s\n' "$desc" "$needle"
+	fi
+	return 0
+}
+
+assert_exit_code() {
+	local desc="$1" expected="$2" actual="$3"
+	TOTAL=$((TOTAL + 1))
+	if [[ "$expected" -eq "$actual" ]]; then
+		PASS=$((PASS + 1))
+		printf '  ✓ %s\n' "$desc"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  ✗ %s (expected exit %d, got %d)\n' "$desc" "$expected" "$actual"
+	fi
+	return 0
+}
+
+# =============================================================================
+# Fixture setup
+# =============================================================================
+
+TMPDIR_TEST=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+FIXTURE_TIMINGS="${TMPDIR_TEST}/pulse-stage-timings.log"
+FIXTURE_WRAPPER="${TMPDIR_TEST}/pulse-wrapper.log"
+
+# Build a fixture with two complete and two incomplete cycles.
+#
+# Cycle 1 (PID 11111) — complete: reaches preflight_early_dispatch exit 0
+# Cycle 2 (PID 22222) — degraded: cleanup_worktrees exits 124 (timeout), stops early
+# Cycle 3 (PID 33333) — complete: reaches preflight_early_dispatch exit 0
+# Cycle 4 (PID 44444) — incomplete: cleanup_worktrees exits 124, stops (after last dispatch)
+#
+# All timestamps are recent enough that the default 1h window captures them.
+# We use a fixed reference point relative to "now" via env override + 24h window.
+
+cat > "$FIXTURE_TIMINGS" <<'TIMINGS'
+2026-04-23T00:00:01Z	cleanup_orphans	2	0	11111
+2026-04-23T00:00:03Z	cleanup_stale_opencode	2	0	11111
+2026-04-23T00:00:05Z	cleanup_stalled_workers	2	0	11111
+2026-04-23T00:01:10Z	cleanup_worktrees	5	0	11111
+2026-04-23T00:01:20Z	cleanup_stashes	3	0	11111
+2026-04-23T00:02:00Z	preflight_cleanup_and_ledger	60	0	11111
+2026-04-23T00:03:00Z	preflight_capacity_and_labels	60	0	11111
+2026-04-23T00:05:00Z	preflight_early_dispatch	120	0	11111
+2026-04-23T00:06:00Z	deterministic_merge_pass	30	0	11111
+2026-04-23T00:10:01Z	cleanup_orphans	2	0	22222
+2026-04-23T00:10:03Z	cleanup_stale_opencode	2	0	22222
+2026-04-23T00:10:05Z	cleanup_stalled_workers	2	0	22222
+2026-04-23T00:11:10Z	cleanup_worktrees	61	124	22222
+2026-04-23T00:11:20Z	cleanup_stashes	5	0	22222
+2026-04-23T00:20:01Z	cleanup_orphans	2	0	33333
+2026-04-23T00:20:03Z	cleanup_stale_opencode	2	0	33333
+2026-04-23T00:20:05Z	cleanup_stalled_workers	2	0	33333
+2026-04-23T00:21:10Z	cleanup_worktrees	61	124	33333
+2026-04-23T00:21:20Z	cleanup_stashes	3	0	33333
+2026-04-23T00:22:00Z	preflight_cleanup_and_ledger	55	0	33333
+2026-04-23T00:23:00Z	preflight_capacity_and_labels	58	0	33333
+2026-04-23T00:26:00Z	preflight_early_dispatch	180	0	33333
+2026-04-23T00:27:00Z	deterministic_merge_pass	35	0	33333
+2026-04-23T00:30:01Z	cleanup_orphans	2	0	44444
+2026-04-23T00:30:03Z	cleanup_stale_opencode	2	0	44444
+2026-04-23T00:30:05Z	cleanup_stalled_workers	2	0	44444
+2026-04-23T00:31:10Z	cleanup_worktrees	62	124	44444
+2026-04-23T00:31:20Z	cleanup_stashes	4	0	44444
+TIMINGS
+
+# Wrapper log: 3 acquired, 2 exited early = 40% churn
+cat > "$FIXTURE_WRAPPER" <<'WRAPPER'
+[pulse-wrapper] Instance lock acquired via mkdir (PID 11111)
+[pulse-wrapper] Instance lock acquired via mkdir (PID 22222)
+[pulse-wrapper] Another pulse instance holds the mkdir lock (PID 22222, age 30s, LOCKDIR=...) — exiting immediately (GH#4513)
+[pulse-wrapper] Instance lock acquired via mkdir (PID 33333)
+[pulse-wrapper] Another pulse instance holds the mkdir lock (PID 33333, age 25s, LOCKDIR=...) — exiting immediately (GH#4513)
+[pulse-wrapper] Instance lock acquired via mkdir (PID 44444)
+WRAPPER
+
+# =============================================================================
+# Tests
+# =============================================================================
+
+printf '\n=== pulse-diagnose-helper.sh cycle-health tests ===\n\n'
+
+# --- Test 1: cycle-health runs without errors on healthy data ---
+printf 'Test 1: cycle-health runs without error\n'
+rc=0
+output=$(PULSE_DIAGNOSE_TIMINGS_FILE="$FIXTURE_TIMINGS" \
+	PULSE_DIAGNOSE_WRAPPER_LOG="$FIXTURE_WRAPPER" \
+	PULSE_DIAGNOSE_LOGDIR="$TMPDIR_TEST" \
+	"$HELPER" cycle-health --window 24h 2>&1) || rc=$?
+assert_exit_code "exits 0 on valid data" 0 "$rc"
+assert_contains "output shows 'Cycle Health'" "Cycle Health" "$output"
+assert_contains "output shows cycle summary" "Cycle summary" "$output"
+assert_contains "output shows wrapper churn" "Wrapper churn" "$output"
+
+# --- Test 2: stage table shows correct counts ---
+printf '\nTest 2: stage stats computed correctly\n'
+output=$(PULSE_DIAGNOSE_TIMINGS_FILE="$FIXTURE_TIMINGS" \
+	PULSE_DIAGNOSE_WRAPPER_LOG="$FIXTURE_WRAPPER" \
+	PULSE_DIAGNOSE_LOGDIR="$TMPDIR_TEST" \
+	"$HELPER" cycle-health --window 24h 2>&1) || true
+assert_contains "shows cleanup_orphans stage" "cleanup_orphans" "$output"
+assert_contains "shows preflight_early_dispatch stage" "preflight_early_dispatch" "$output"
+assert_contains "shows deterministic_merge_pass stage" "deterministic_merge_pass" "$output"
+
+# --- Test 3: [DEGRADED] marker for cleanup_worktrees (3/4 = 75% timeout) ---
+printf '\nTest 3: DEGRADED marker when timeout rate > 50%%\n'
+output=$(PULSE_DIAGNOSE_TIMINGS_FILE="$FIXTURE_TIMINGS" \
+	PULSE_DIAGNOSE_WRAPPER_LOG="$FIXTURE_WRAPPER" \
+	PULSE_DIAGNOSE_LOGDIR="$TMPDIR_TEST" \
+	"$HELPER" cycle-health --window 24h 2>&1) || true
+assert_contains "flags cleanup_worktrees as DEGRADED" "[DEGRADED]" "$output"
+# cleanup_stashes has 0% timeout — should not be DEGRADED
+assert_not_contains "does not flag cleanup_stashes DEGRADED (0% timeout)" \
+	"cleanup_stashes" "$(printf '%s' "$output" | grep '\[DEGRADED\]')"
+
+# --- Test 4: cycle stats (4 started, 2 reached dispatch) ---
+printf '\nTest 4: cycle-level counters\n'
+output=$(PULSE_DIAGNOSE_TIMINGS_FILE="$FIXTURE_TIMINGS" \
+	PULSE_DIAGNOSE_WRAPPER_LOG="$FIXTURE_WRAPPER" \
+	PULSE_DIAGNOSE_LOGDIR="$TMPDIR_TEST" \
+	"$HELPER" cycle-health --window 24h 2>&1) || true
+assert_contains "cycles started = 4" "4" "$(printf '%s' "$output" | grep 'Cycles started')"
+assert_contains "fill-floor cycles = 2" "2" "$(printf '%s' "$output" | grep 'reached dispatch')"
+# cycles_since_ff: PID 44444 started after last fill-floor (PID 33333) → 1
+assert_contains "cycles since last dispatch present" "Cycles since last dispatch" "$output"
+
+# --- Test 5: wrapper churn stats ---
+printf '\nTest 5: wrapper churn (40%%)\n'
+output=$(PULSE_DIAGNOSE_TIMINGS_FILE="$FIXTURE_TIMINGS" \
+	PULSE_DIAGNOSE_WRAPPER_LOG="$FIXTURE_WRAPPER" \
+	PULSE_DIAGNOSE_LOGDIR="$TMPDIR_TEST" \
+	"$HELPER" cycle-health --window 24h 2>&1) || true
+assert_contains "shows acquired count 4" "Acquired lock: 4" "$output"
+assert_contains "shows exited early count 2" "Exited early: 2" "$output"
+assert_contains "shows churn pct 33" "33%" "$output"
+
+# --- Test 6: --json emits parseable JSON via jq ---
+printf '\nTest 6: --json output is valid JSON\n'
+output=$(PULSE_DIAGNOSE_TIMINGS_FILE="$FIXTURE_TIMINGS" \
+	PULSE_DIAGNOSE_WRAPPER_LOG="$FIXTURE_WRAPPER" \
+	PULSE_DIAGNOSE_LOGDIR="$TMPDIR_TEST" \
+	"$HELPER" cycle-health --window 24h --json 2>&1) || true
+if command -v jq >/dev/null 2>&1; then
+	rc=0
+	parsed=$(printf '%s' "$output" | jq '.' 2>/dev/null) || rc=$?
+	assert_exit_code "--json parses via jq" 0 "$rc"
+	cycles=$(printf '%s' "$output" | jq '.cycles_started' 2>/dev/null || echo "-1")
+	assert_contains "--json cycles_started = 4" "4" "$cycles"
+	ff=$(printf '%s' "$output" | jq '.fill_floor_cycles' 2>/dev/null || echo "-1")
+	assert_contains "--json fill_floor_cycles = 2" "2" "$ff"
+	stage_count=$(printf '%s' "$output" | jq '.stages | length' 2>/dev/null || echo "0")
+	TOTAL=$((TOTAL + 1))
+	if [[ "$stage_count" -ge 5 ]]; then
+		PASS=$((PASS + 1))
+		printf '  ✓ --json stages array has >=5 entries (got %s)\n' "$stage_count"
+	else
+		FAIL=$((FAIL + 1))
+		printf '  ✗ --json stages array has >=5 entries (got %s)\n' "$stage_count"
+	fi
+	# Verify degraded field present
+	has_degraded=$(printf '%s' "$output" | jq '.stages[0].degraded != null' 2>/dev/null || echo "false")
+	assert_contains "--json stages have degraded field" "true" "$has_degraded"
+else
+	printf '  (skipping jq validation — jq not installed)\n'
+fi
+
+# --- Test 7: --window flag is respected (narrow window excludes old entries) ---
+printf '\nTest 7: --window 1m excludes all fixture data (all entries are old)\n'
+output=$(PULSE_DIAGNOSE_TIMINGS_FILE="$FIXTURE_TIMINGS" \
+	PULSE_DIAGNOSE_WRAPPER_LOG="$FIXTURE_WRAPPER" \
+	PULSE_DIAGNOSE_LOGDIR="$TMPDIR_TEST" \
+	"$HELPER" cycle-health --window 1m 2>&1) || true
+assert_contains "no data in 1m window" "No stage timing data" "$output"
+
+# --- Test 8: missing pulse-stage-timings.log handled gracefully (exit 0) ---
+printf '\nTest 8: missing timings log is handled gracefully\n'
+rc=0
+output=$(PULSE_DIAGNOSE_TIMINGS_FILE="/nonexistent/pulse-stage-timings.log" \
+	PULSE_DIAGNOSE_WRAPPER_LOG="$FIXTURE_WRAPPER" \
+	PULSE_DIAGNOSE_LOGDIR="$TMPDIR_TEST" \
+	"$HELPER" cycle-health 2>&1) || rc=$?
+assert_exit_code "exits 0 when timings log missing" 0 "$rc"
+assert_contains "reports no stage data" "No stage timing data" "$output"
+assert_contains "still shows cycle summary" "Cycle summary" "$output"
+
+# --- Test 9: missing wrapper log handled gracefully ---
+printf '\nTest 9: missing wrapper log is handled gracefully\n'
+rc=0
+output=$(PULSE_DIAGNOSE_TIMINGS_FILE="$FIXTURE_TIMINGS" \
+	PULSE_DIAGNOSE_WRAPPER_LOG="/nonexistent/pulse-wrapper.log" \
+	PULSE_DIAGNOSE_LOGDIR="$TMPDIR_TEST" \
+	"$HELPER" cycle-health --window 24h 2>&1) || rc=$?
+assert_exit_code "exits 0 when wrapper log missing" 0 "$rc"
+assert_contains "shows 0 acquired" "Acquired lock: 0" "$output"
+
+# --- Test 10: --json emits degraded=true for cleanup_worktrees ---
+printf '\nTest 10: --json degraded flag correct for DEGRADED stage\n'
+if command -v jq >/dev/null 2>&1; then
+	output=$(PULSE_DIAGNOSE_TIMINGS_FILE="$FIXTURE_TIMINGS" \
+		PULSE_DIAGNOSE_WRAPPER_LOG="$FIXTURE_WRAPPER" \
+		PULSE_DIAGNOSE_LOGDIR="$TMPDIR_TEST" \
+		"$HELPER" cycle-health --window 24h --json 2>&1) || true
+	degraded_stages=$(printf '%s' "$output" | \
+		jq -r '[.stages[] | select(.degraded==true) | .stage] | join(",")' 2>/dev/null || echo "")
+	assert_contains "--json marks cleanup_worktrees as degraded" "cleanup_worktrees" "$degraded_stages"
+else
+	printf '  (skipping jq validation — jq not installed)\n'
+fi
+
+# --- Test 11: cycle-health shows in help text ---
+printf '\nTest 11: cycle-health appears in help output\n'
+output=$("$HELPER" help 2>&1) || true
+assert_contains "help shows cycle-health command" "cycle-health" "$output"
+assert_contains "help shows window option" "window <W>" "$output"
+
+# --- Test 12: unknown option returns error ---
+printf '\nTest 12: unknown option returns non-zero exit\n'
+rc=0
+"$HELPER" cycle-health --invalid-flag 2>/dev/null || rc=$?
+assert_exit_code "unknown option exits non-zero" 1 "$rc"
+
+# =============================================================================
+# Summary
+# =============================================================================
+
+printf '\n=== Results: %d passed, %d failed, %d total ===\n\n' "$PASS" "$FAIL" "$TOTAL"
+
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Adds the `cycle-health` subcommand to `pulse-diagnose-helper.sh` — the single command that answers "is the pulse healthy right now?" without manually tailing three log files.

## What

New subcommand `pulse-diagnose-helper.sh cycle-health [--window <W>] [--json] [--verbose]`:

- Parses `pulse-stage-timings.log` for the specified window (default 1h)
- Per-stage table: runs, timeouts, p50/p95 duration, last-success timestamp
- Flags stages with >50% timeout rate as `[DEGRADED]`
- Cycle summary: cycles started, cycles reaching `preflight_early_dispatch` (fill-floor proxy), cycles since last dispatch
- Wrapper churn ratio from `pulse-wrapper.log` (acquired lock vs exited-early)
- `--json` emits structured output with same data; parses via `jq .`
- `--window` accepts `30m`, `1h`, `6h`, `24h`, `7d` or raw seconds

## Why

During the #20548 investigation, it took ~15 minutes of manual log tailing to determine that four cycles had been timing out on `cleanup_worktrees` while only one cycle reached dispatch. This command surfaces that in seconds. (Fix 3 of 4 from that investigation.)

## Verification

30/30 tests pass (`test-pulse-diagnose-cycle-health.sh`). Zero shellcheck violations. All existing `test-pulse-diagnose-helper.sh` tests (31/31) still pass.

Live smoke-test against real logs:

```
pulse-diagnose-helper.sh cycle-health           # human-readable
pulse-diagnose-helper.sh cycle-health --json | jq .  # parseable JSON
pulse-diagnose-helper.sh cycle-health --window 24h   # wider window
```

## Files Changed

- EDIT: `.agents/scripts/pulse-diagnose-helper.sh` — added `_ch_*` function family + `cmd_cycle_health` + case branch + updated usage text
- NEW: `.agents/scripts/tests/test-pulse-diagnose-cycle-health.sh` — 12 tests covering healthy, degraded, empty, missing-log, JSON output, window filtering, churn stats

Resolves #20556

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.95 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 17m and 43,427 tokens on this as a headless worker.
