### PR TITLE
GH#20592: docs: resolve pulse-wrapper churn investigation with final verdict and stale comment fix

### DIFF
--- a/.agents/reference/pulse-wrapper-churn-investigation.md
+++ b/.agents/reference/pulse-wrapper-churn-investigation.md
@@ -141,3 +141,33 @@ common cases (rapid re-invocation and overlapping cycles).
   original plan is **not needed** — only one scheduler exists. The three remaining
   fix children (#20578, #20579, #20580) address the voluntary-release churn pattern,
   not a multi-scheduler problem.
+
+## Resolution (2026-04-23)
+
+Consolidated issue: [#20592](https://github.com/marcusquinn/aidevops/issues/20592)
+
+All four child issues have been resolved and their PRs merged:
+
+| Issue | PR | Merged | Summary |
+|-------|----|--------|---------|
+| [#20577](https://github.com/marcusquinn/aidevops/issues/20577) | [#20589](https://github.com/marcusquinn/aidevops/pull/20589) | 2026-04-23 | Investigation report (this file) |
+| [#20578](https://github.com/marcusquinn/aidevops/issues/20578) | [#20588](https://github.com/marcusquinn/aidevops/pull/20588) | 2026-04-23 | Entry-point rate-limit cooldown (`PULSE_MIN_INTERVAL_S`, default 90s) |
+| [#20579](https://github.com/marcusquinn/aidevops/issues/20579) | [#20584](https://github.com/marcusquinn/aidevops/pull/20584) | 2026-04-23 | Is-running short-circuit via `pgrep` before mkdir lock |
+| [#20580](https://github.com/marcusquinn/aidevops/issues/20580) | [#20586](https://github.com/marcusquinn/aidevops/pull/20586) | 2026-04-23 | Invocation-source logging and `pulse-stats.json` counters |
+
+### Verdict
+
+**Original hypothesis (multiple schedulers causing churn): rejected.**
+Only one direct scheduler exists (`com.aidevops.aidevops-supervisor-pulse`, launchd, 180s).
+
+**Root cause:** The 4-PID / 15-minute pattern is normal behaviour from the voluntary pre-LLM lock release at `pulse-wrapper.sh:1329`. Successive launchd firings acquire the lock after the previous invocation voluntarily releases it. The 11.9% lock rejection rate (477/4021 over 42 days) is within design parameters.
+
+**Fixes shipped:** Three defence-in-depth measures now reduce unnecessary lock contention:
+
+1. **Rate-limit** (#20578) — skips cycle if last run was <90s ago (single `stat` call)
+2. **Is-running check** (#20579) — skips if another pulse PID is alive (`pgrep`, before mkdir)
+3. **Source logging** (#20580) — per-source invocation counters for future monitoring
+
+**Scheduler consolidation (Child A) not needed** — confirmed only one scheduler.
+
+**Stale comment fix:** `pulse-wrapper.sh` header comment corrected from "120s" to "180s" to match the deployed plist `StartInterval=180`.

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -21,8 +21,9 @@
 #   9. Provider-aware pulse sessions via headless-runtime-helper.sh
 #  10. Per-issue fast-fail counter skips issues with repeated launch deaths (t1888)
 #
-# Lifecycle: launchd fires every 120s. If a pulse is still running, the
-# dedup check skips. run_pulse() has an internal watchdog that polls every
+# Lifecycle: launchd fires every 180s (StartInterval in the supervisor-pulse
+# plist). If a pulse is still running, the dedup check skips.
+# run_pulse() has an internal watchdog that polls every
 # 60s and checks three conditions:
 #   a) Wall-clock timeout: kills if elapsed > PULSE_STALE_THRESHOLD (60 min)
 #   b) Idle detection: kills if CPU usage stays below PULSE_IDLE_CPU_THRESHOLD
@@ -61,7 +62,7 @@
 #   blocklist. flock was removed entirely in GH#18668 (Path A) — see
 #   reference/bash-fd-locking.md for the full rationale and policy.
 #
-# Called by launchd every 120s via the supervisor-pulse plist.
+# Called by launchd every 180s via the supervisor-pulse plist.
 
 set -euo pipefail
 


### PR DESCRIPTION
## Summary

All 4 child issues (#20577-#20580) resolved and merged. Investigation concluded: single scheduler (launchd 180s), churn was normal voluntary pre-LLM lock release. Three defence-in-depth fixes shipped (rate-limit, is-running check, source logging). Stale 120s comment corrected to 180s in pulse-wrapper.sh header. Investigation report updated with resolution section documenting all merged PRs and final verdict.

## Files Changed

.agents/reference/pulse-wrapper-churn-investigation.md,.agents/scripts/pulse-wrapper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-wrapper.sh — zero violations. Verified all child PRs merged (#20584, #20586, #20588, #20589). Verified fix functions present in pulse-wrapper.sh (_detect_invocation_source, _record_invocation_source, PULSE_MIN_INTERVAL_S, _ir_pids).

Resolves #20592


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.95 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-opus-4-6 spent 6m and 10,825 tokens on this as a headless worker.