### PR TITLE
t2754: Phase 2 of #20402 — formalise dispatch-blocker vocabulary and needs-credentials label

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -100,7 +100,7 @@ Task IDs: `/new-task` or `claim-task-id.sh`. NEVER grep TODO.md for next ID.
 ### Auto-Dispatch and Completion
 
 **Auto-dispatch default**: Always add `#auto-dispatch` unless an exclusion applies. See `workflows/plans.md` "Auto-Dispatch Tagging".
-- **Exclusions**: Needs credentials, decomposition, or user preference.
+- **Exclusions**: Needs credentials, decomposition, or user preference. Canonical blocker label set: `reference/dispatch-blockers.md`.
 - **Quality gate**: 2+ acceptance criteria, file references in How section, clear deliverable in What section.
 - **Interactive workflow**: Add `assignee:` before pushing if working interactively.
 

--- a/.agents/reference/dispatch-blockers.md
+++ b/.agents/reference/dispatch-blockers.md
@@ -1,0 +1,101 @@
+# Dispatch-Blocker Vocabulary (t2754)
+
+This is the **single source of truth** for labels, states, and conditions that block automated worker dispatch or auto-merge. Maintained here to support Phase 4 of [#20402](https://github.com/marcusquinn/aidevops/issues/20402) (inverting the dispatch default from opt-in to opt-out).
+
+For the `#auto-dispatch` positive opt-in criteria, see `workflows/plans.md` "Auto-Dispatch Tagging". For enforcement architecture, see `reference/auto-dispatch.md`.
+
+---
+
+## Label-Level Blockers
+
+Applied to GitHub issues. The pulse checks these before spawning a worker.
+
+### Unconditional Dispatch Blocks (no assignee required)
+
+| Label | Enforced by | Rationale |
+|-------|-------------|-----------|
+| `parent-task` | `dispatch-dedup-helper.sh` `_is_assigned_check_parent_task` | Epics/trackers — children implement, not this issue. Cannot be overridden by NMR clearance (t2211). |
+| `meta` | Same as `parent-task` — treated as an alias | Alternative spelling of `parent-task`. |
+| `no-auto-dispatch` | `issue-sync-lib.sh`, `interactive-session-helper.sh` lockdown | Manual hold by session or user. Blocks enrich path too. Applied by `interactive-session-helper.sh lockdown`. |
+| `needs-maintainer-review` | `pulse-nmr-approval.sh` `auto_approve_maintainer_issues` | Requires maintainer cryptographic approval (`sudo aidevops approve issue <N>`) before dispatch. |
+| `needs-credentials` | `label-sync-helper.sh` SYSTEM_LABELS | Task requires credentials, API keys, or account access — cannot be completed by a headless worker autonomously. Add when the TODO entry has `#no-auto-dispatch` due to credential dependency. |
+| `persistent` | `pulse-issue-reconcile.sh` | Monitoring/tracking issue — must not be dispatched as a code task. |
+| `supervisor` | `pulse-issue-reconcile.sh` | Supervisor health dashboard — pulse-managed, not a dispatch target. |
+| `contributor` | `pulse-issue-reconcile.sh` | Contributor health dashboard — pulse-managed, not a dispatch target. |
+| `quality-review` | `pulse-issue-reconcile.sh` | Daily quality review tracker — pulse-managed. |
+| `routine-tracking` | `pulse-issue-reconcile.sh` | Routine execution tracking — pulse skips these unconditionally. |
+| `status:blocked` | `dispatch-dedup-helper.sh` `_has_active_claim` | Blocked on incomplete dependent tasks (`blocked-by:` edges). |
+
+### Conditional Dispatch Blocks (require active claim state)
+
+These labels DO NOT block dispatch on their own. They become blockers only when combined with an active claim signal — see "Claim-State Blockers" below.
+
+| Label | Block condition |
+|-------|----------------|
+| `origin:interactive` + any assignee | GH#18352: interactive session claimed this issue — blocks dispatch until `interactive-session-helper.sh release` |
+| `status:queued` / `status:in-progress` / `status:in-review` / `status:claimed` + non-passive assignee | Active lifecycle state with owner — safe to dispatch only when `_has_active_claim` returns false |
+
+### PR Auto-Merge Blockers (block merge, not dispatch)
+
+Applied to pull requests. The merge pass checks these before merging.
+
+| Label | Enforced by | Rationale |
+|-------|-------------|-----------|
+| `hold-for-review` | `pulse-merge.sh` `_check_interactive_pr_gates` (t2411), `_check_pr_merge_gates` (t2449) | Opt-out of auto-merge — holds PR for explicit maintainer review. |
+| Draft PR status | `pulse-merge.sh` | Draft PRs are never auto-merged. |
+| CHANGES_REQUESTED review | `review-bot-gate-helper.sh` | Unresolved review blocks merge. Exception: `coderabbit-nits-ok` label dismisses CodeRabbit-only CHANGES_REQUESTED (t2179). |
+
+---
+
+## Claim-State Blockers
+
+These are not labels — they are runtime state signals checked by `dispatch-dedup-helper.sh is-assigned`.
+
+| Signal | Exit code | Meaning |
+|--------|-----------|---------|
+| `PARENT_TASK_BLOCKED` | 0 (blocked) | `parent-task` / `meta` label — unconditional block |
+| `ASSIGNED: issue #N in repo` | 0 (blocked) | Active assignee with blocking claim state |
+| `GUARD_UNCERTAIN` | 0 (blocked, fail-closed) | API or jq failure — dispatch refused to avoid collision |
+| No assignees | 1 (allow dispatch) | Safe to dispatch |
+| Passive assignees only (owner/maintainer without active claim) | 1 (allow dispatch) | Owner bookkeeping — not a live claim |
+
+Stale assignment recovery: if the blocking assignee has no live worker process AND the last dispatch comment is >1h old AND no progress in the last hour, `_is_stale_assignment` clears the block and allows re-dispatch (GH#15060).
+
+---
+
+## Validator-State Blockers
+
+Checked by `pre-dispatch-validator-helper.sh` and the pre-dispatch eligibility gate (t2424) before spawning a worker.
+
+| Condition | Exit | Enforced by |
+|-----------|------|-------------|
+| Issue already CLOSED | 10 (close + skip) | `pre-dispatch-validator-helper.sh` |
+| `status:done` / `status:resolved` label | 10 (skip) | Pre-dispatch eligibility gate |
+| Linked PR merged in last 5 min | 10 (skip) | Pre-dispatch eligibility gate |
+| Cost circuit breaker fired (t2007) | 0 (blocked) | `dispatch-dedup-helper.sh` `_is_assigned_check_cost_budget` |
+| Hydration window active <30s (t2436) | 0 (blocked) | `dispatch-dedup-helper.sh` `_is_assigned_check_hydration_window` |
+| GraphQL budget < 30% (t2690) | pause all dispatch | Pulse circuit breaker in `pulse-wrapper.sh` |
+
+---
+
+## Adding a New Blocker
+
+To add a new label-level dispatch blocker:
+
+1. **Register in `label-sync-helper.sh`** — add to `SYSTEM_LABELS` array with a description starting "Opt-out:" or "Block:". The `cmd_sync` command will create it on all admin repos.
+2. **Protect in `issue-sync-helper.sh`** — add to `_is_protected_label()` exact-match list so the enrich path cannot strip it.
+3. **Enforce in `dispatch-dedup-helper.sh`** (if unconditional) — add label check to the pre-assignee block, before `_is_assigned_compute_blocking`. Or for conditional blockers, update `_has_active_claim`.
+4. **Document here** — add a row to the relevant table above with the enforcement point.
+
+---
+
+## Cross-References
+
+- `reference/auto-dispatch.md` — combined signal rule (`(active status label) AND (non-self assignee)`) and full dispatch lifecycle
+- `reference/auto-merge.md` — auto-merge timing rules (t2411, t2449) and NMR semantics
+- `reference/parent-task-lifecycle.md` — `parent-task` label lifecycle in detail (t2442)
+- `reference/worker-diagnostics.md` — pre-dispatch eligibility gate (t2424) and circuit breakers
+- `.agents/scripts/dispatch-dedup-helper.sh` — `is-assigned` command and all layer checks
+- `.agents/scripts/label-sync-helper.sh` — `SYSTEM_LABELS` canonical registry + `cmd_sync`
+- `.agents/scripts/issue-sync-helper.sh` — `_is_protected_label()` enrich-survivor set
+- `.agents/scripts/pulse-merge.sh` — `_check_interactive_pr_gates` and `_check_pr_merge_gates`

--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -272,10 +272,12 @@ _is_protected_label() {
 	# Exact-match protected labels
 	# GH#19856: added no-auto-dispatch and no-takeover — these are coordination
 	# signals set by explicit user/session action and must survive enrich.
+	# t2754: added hold-for-review and needs-credentials — canonical dispatch-blockers.
 	case "$lbl" in
 	persistent | needs-maintainer-review | not-planned | duplicate | wontfix | \
 		already-fixed | "good first issue" | "help wanted" | \
 		parent-task | meta | auto-dispatch | no-auto-dispatch | no-takeover | \
+		hold-for-review | needs-credentials | \
 		consolidation-in-progress | coderabbit-nits-ok | ratchet-bump | \
 		new-file-smell-ok)
 		return 0

--- a/.agents/scripts/label-sync-helper.sh
+++ b/.agents/scripts/label-sync-helper.sh
@@ -106,6 +106,9 @@ DISPATCH_LABELS=(
 # --- aidevops System Labels ---
 SYSTEM_LABELS=(
 	"auto-dispatch|0E8A16|Eligible for automated worker dispatch"
+	"no-auto-dispatch|EDEDED|Opt-out: block all auto-dispatch on this issue"
+	"hold-for-review|E99695|Opt-out: block auto-merge — hold PR for maintainer review"
+	"needs-credentials|FBCA04|Opt-out: block auto-dispatch — requires credentials or account access"
 	"ai-approved|0E8A16|Issue approved for AI agent processing"
 	"persistent|FBCA04|Persistent issue — do not close"
 	"supervisor|1D76DB|Supervisor health dashboard"

--- a/.agents/workflows/new-task.md
+++ b/.agents/workflows/new-task.md
@@ -105,7 +105,7 @@ Run `task-decompose-helper.sh classify "{title}"` if available. Skip with `--no-
 
 `#{origin}`: `#interactive` (user present) or `#worker` (headless). Detect via `detect_session_origin` from `shared-constants.sh`. Maps to `origin:interactive` / `origin:worker` GitHub labels on issue sync.
 
-**Auto-dispatch:** Only add `#auto-dispatch` if brief has: (1) 2+ acceptance criteria beyond "tests pass"/"lint clean", (2) non-empty "How" with file references, (3) clear deliverable in "What".
+**Auto-dispatch:** Only add `#auto-dispatch` if brief has: (1) 2+ acceptance criteria beyond "tests pass"/"lint clean", (2) non-empty "How" with file references, (3) clear deliverable in "What". Canonical dispatch-blocker labels: `reference/dispatch-blockers.md`.
 
 ### Step 5: Label, Commit, Push
 

--- a/.agents/workflows/plans.md
+++ b/.agents/workflows/plans.md
@@ -65,11 +65,13 @@ Add `#auto-dispatch` only when ALL inclusion criteria pass and NO exclusion crit
 
 | Include (ALL required) | Exclude (ANY blocks) |
 |------------------------|----------------------|
-| Clear fix/feature with specific files or patterns | Requires credentials, accounts, or purchases |
+| Clear fix/feature with specific files or patterns | Requires credentials, accounts, or purchases (`needs-credentials` label) |
 | Bounded scope (~1h or less) | Is a `#plan` needing decomposition first |
 | No design decisions requiring user preference | Requires hardware or external service setup |
 | Verification is automatable (tests, ShellCheck, syntax, browser) | Description says "investigate"/"evaluate" without clear deliverable |
 | | Has `blocked-by:` dependencies on incomplete tasks |
+
+Full canonical dispatch-blocker label set (labels + claim-states + validator-states): `reference/dispatch-blockers.md`.
 
 ## Saving Work
 

--- a/.agents/workflows/save-todo.md
+++ b/.agents/workflows/save-todo.md
@@ -28,7 +28,7 @@ Topic/context: $ARGUMENTS
 
 ## Step 1b: Dispatch Tags (MANDATORY)
 
-**`#auto-dispatch`** — Add when ALL true: clear description with specific files/patterns, ≤2h scope, no credentials/purchases needed, no user-preference design decisions, automatable verification. **Default to `#auto-dispatch`** — omit only when a specific exclusion applies. Full criteria: `workflows/plans.md` "Auto-Dispatch Tagging".
+**`#auto-dispatch`** — Add when ALL true: clear description with specific files/patterns, ≤2h scope, no credentials/purchases needed, no user-preference design decisions, automatable verification. **Default to `#auto-dispatch`** — omit only when a specific exclusion applies. Full criteria: `workflows/plans.md` "Auto-Dispatch Tagging". Canonical blocker labels: `reference/dispatch-blockers.md`.
 
 **`#plan`** — Add when decomposition needed before implementation (multi-phase, >2h, research/design).
 


### PR DESCRIPTION
## Summary

Phase 2 of #20402: formalise the canonical opt-out vocabulary for pulse dispatch.

### Changes

- **`label-sync-helper.sh` SYSTEM_LABELS**: Added three dispatch-blocker labels that were used in practice but absent from the canonical registry:
  - `needs-credentials` (NEW — first-class label for credential-dependent tasks)
  - `no-auto-dispatch` (was only in TAG_CAT_DEVOPS, not in SYSTEM_LABELS)
  - `hold-for-review` (was used in pulse-merge.sh but not registered)
- **`issue-sync-helper.sh` `_is_protected_label()`**: Added `hold-for-review` and `needs-credentials` to the protected set so the enrich path cannot strip them (t2754).
- **NEW `reference/dispatch-blockers.md`**: Single source of truth for the full dispatch-blocker vocabulary — label-level blockers, claim-state blockers, and validator-state blockers, each with enforcement points.
- **Cross-links** in `.agents/AGENTS.md`, `workflows/plans.md`, `workflows/new-task.md`, `workflows/save-todo.md`: replaced inline blocker enumerations with a pointer to the new reference.

### Acceptance Criteria Verification

1. `needs-credentials` label: in `SYSTEM_LABELS` (line 109 of label-sync-helper.sh) — created by `label-sync-helper.sh sync` on fresh repos.
2. `reference/dispatch-blockers.md`: exists with all 11+ canonical blockers enumerated.
3. Cross-links: verified via `grep dispatch-blockers` across all 4 target docs.
4. No behavior drift: only doc + label registry changes — no edits to dispatch logic.

### Testing

```bash
grep "needs-credentials" .agents/scripts/label-sync-helper.sh   # SYSTEM_LABELS entry
grep "needs-credentials" .agents/scripts/issue-sync-helper.sh   # protected set
ls .agents/reference/dispatch-blockers.md                       # new reference doc
grep "dispatch-blockers" .agents/AGENTS.md .agents/workflows/plans.md .agents/workflows/new-task.md .agents/workflows/save-todo.md  # cross-links
```

Resolves #20558. Ref #20402.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.95 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 8m and 20,812 tokens on this as a headless worker.
