### PR TITLE
GH#20595: decompose parent-task #20471 into Phase A and Phase B children

### DIFF
--- a/todo/tasks/GH#20599-brief.md
+++ b/todo/tasks/GH#20599-brief.md
@@ -1,0 +1,11 @@
+# GH#20599 — Phase A: rt_version + greeting-cache-helper foundation
+
+Worker-ready issue body at https://github.com/marcusquinn/aidevops/issues/20599
+
+Child of #20471 (Phase A). See issue body for full implementation context.
+
+## Files Scope
+
+- `.agents/scripts/runtime-registry.sh`
+- `.agents/scripts/greeting-cache-helper.sh`
+- `tests/test-runtime-registry.sh`

--- a/todo/tasks/GH#20600-brief.md
+++ b/todo/tasks/GH#20600-brief.md
@@ -1,0 +1,11 @@
+# GH#20600 — Phase B: wire greeting-cache-helper into Claude Code runtime
+
+Worker-ready issue body at https://github.com/marcusquinn/aidevops/issues/20600
+
+Child of #20471 (Phase B). Depends on #20599 (Phase A). See issue body for full implementation context.
+
+## Files Scope
+
+- `.agents/scripts/generate-runtime-config.sh`
+- `.agents/scripts/install-hooks-helper.sh`
+- `.agents/scripts/greeting-cache-helper.sh`


### PR DESCRIPTION
## Summary

Decompose parent-task #20471 (t2737: multi-runtime version freshness for framework status greeting) into two implementation children.

Resolves #20595

## What was done

1. **Created child issue #20599** -- Phase A: `rt_version` + `greeting-cache-helper.sh` foundation. Worker-ready body with file paths, code patterns, and acceptance criteria.
2. **Created child issue #20600** -- Phase B: wire `greeting-cache-helper` into Claude Code runtime. Includes dependency on #20599 and explicit blocked-by marker.
3. **Updated parent #20471 body** with a `## Children` section listing both children and the deferred Phase C.
4. **Added brief stub files** for both children at `todo/tasks/GH#20599-brief.md` and `todo/tasks/GH#20600-brief.md`.

Phase C (remaining runtimes) is deferred per the parent's explicit instruction: "file follow-up child issues only as user demand surfaces."

## Verification

- Parent #20471 now has a `## Children` section with 2 linked children
- Both children have `auto-dispatch` + `tier:standard` labels
- #20600 declares `blocked-by: #20599` in its body
- Brief stubs link to the worker-ready issue bodies

## Testing

No code changes -- decomposition-only PR. Brief stubs are markdown files that passed pre-commit validation.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.95 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-opus-4-6 spent 14m and 18,479 tokens on this as a headless worker.
