### PR TITLE
GH#20599: add rt_version to runtime-registry + greeting-cache-helper.sh

### DIFF
--- a/.agents/scripts/greeting-cache-helper.sh
+++ b/.agents/scripts/greeting-cache-helper.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+# =============================================================================
+# greeting-cache-helper.sh — Write per-runtime greeting cache files
+# =============================================================================
+# Part of the multi-runtime greeting architecture (t2737, Phase A / GH#20599).
+# Writes ~/.aidevops/cache/session-greeting-{runtime}.txt with a normalised
+# line 1 in the format:
+#   aidevops vX running in {display_name} vY | {repo_slug}
+#
+# Also writes to the shared ~/.aidevops/cache/session-greeting.txt for
+# backward compatibility (the OpenCode plugin reads this path).
+#
+# Usage:
+#   greeting-cache-helper.sh write <runtime-id>
+#   greeting-cache-helper.sh help
+#
+# Commands:
+#   write <runtime-id>   — write greeting cache for the given runtime ID
+#   help                 — show this help
+#
+# Examples:
+#   greeting-cache-helper.sh write opencode
+#   greeting-cache-helper.sh write claude-code
+#
+# Environment:
+#   AIDEVOPS_GREETING_REPO_SLUG — override repo slug (default: from git remote)
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+# shellcheck source=shared-constants.sh
+source "${SCRIPT_DIR}/shared-constants.sh"
+# shellcheck source=runtime-registry.sh
+source "${SCRIPT_DIR}/runtime-registry.sh"
+set -euo pipefail
+init_log_file
+
+readonly CACHE_DIR="${HOME}/.aidevops/cache"
+readonly VERSION_FILE="${SCRIPT_DIR%/scripts}/VERSION"
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+_read_aidevops_version() {
+	if [[ -f "$VERSION_FILE" ]]; then
+		head -1 "$VERSION_FILE"
+		return 0
+	fi
+	# Fallback: try one level up (if sourced from a non-standard location)
+	local alt_version="${SCRIPT_DIR}/../../VERSION"
+	if [[ -f "$alt_version" ]]; then
+		head -1 "$alt_version"
+		return 0
+	fi
+	echo "unknown"
+	return 0
+}
+
+_detect_repo_slug() {
+	if [[ -n "${AIDEVOPS_GREETING_REPO_SLUG:-}" ]]; then
+		echo "${AIDEVOPS_GREETING_REPO_SLUG}"
+		return 0
+	fi
+	local slug
+	slug=$(git remote get-url origin 2>/dev/null | sed 's|.*github.com[:/]\(.*\)\.git|\1|;s|.*github.com[:/]\(.*\)|\1|' 2>/dev/null) || slug=""
+	echo "${slug:-local}"
+	return 0
+}
+
+# =============================================================================
+# Main function
+# =============================================================================
+
+# write_greeting_cache: write cache files for the given runtime ID.
+# Args: $1 = runtime-id
+# Returns: 0 on success, 1 on error
+write_greeting_cache() {
+	local runtime_id="$1"
+
+	# Validate runtime ID
+	if ! rt_binary "$runtime_id" >/dev/null 2>&1; then
+		print_error "Unknown runtime ID: $runtime_id"
+		print_info "Run: greeting-cache-helper.sh help  (for usage)"
+		return 1
+	fi
+
+	local display_name
+	display_name=$(rt_display_name "$runtime_id")
+
+	local runtime_version
+	runtime_version=$(rt_version "$runtime_id")
+
+	local aidevops_version
+	aidevops_version=$(_read_aidevops_version)
+
+	local repo_slug
+	repo_slug=$(_detect_repo_slug)
+
+	# Normalised line 1 format (as specified in issue #20599 / t2737 Phase A)
+	local greeting_line_1="aidevops v${aidevops_version} running in ${display_name} v${runtime_version} | ${repo_slug}"
+
+	mkdir -p "$CACHE_DIR"
+
+	# Write per-runtime cache file
+	local runtime_cache="${CACHE_DIR}/session-greeting-${runtime_id}.txt"
+	printf '%s\n' "$greeting_line_1" >"$runtime_cache"
+	print_info "Written: $runtime_cache"
+
+	# Write shared backward-compat cache file
+	local shared_cache="${CACHE_DIR}/session-greeting.txt"
+	printf '%s\n' "$greeting_line_1" >"$shared_cache"
+	print_info "Written: $shared_cache"
+
+	return 0
+}
+
+# =============================================================================
+# CLI dispatch
+# =============================================================================
+
+_usage() {
+	cat <<'EOF'
+greeting-cache-helper.sh — Write per-runtime greeting cache files
+
+Usage:
+  greeting-cache-helper.sh write <runtime-id>
+  greeting-cache-helper.sh help
+
+Commands:
+  write <runtime-id>   Write greeting cache for the given runtime ID.
+                       Creates ~/.aidevops/cache/session-greeting-<id>.txt
+                       and updates ~/.aidevops/cache/session-greeting.txt.
+  help                 Show this help message.
+
+Runtime IDs (from runtime-registry.sh):
+  opencode, claude-code, codex, cursor, droid, gemini-cli,
+  windsurf, continue, kilo, kiro, aider, amp, kimi, qwen
+
+Examples:
+  greeting-cache-helper.sh write opencode
+  greeting-cache-helper.sh write claude-code
+
+Environment:
+  AIDEVOPS_GREETING_REPO_SLUG  Override detected repo slug in line 1.
+EOF
+	return 0
+}
+
+main() {
+	local cmd="${1:-help}"
+	shift || true
+
+	case "$cmd" in
+	write)
+		if [[ $# -lt 1 ]]; then
+			print_error "write requires a runtime-id argument"
+			_usage
+			return 1
+		fi
+		local runtime_arg="$1"
+		write_greeting_cache "$runtime_arg"
+		return 0
+		;;
+	help | --help | -h)
+		_usage
+		return 0
+		;;
+	*)
+		print_error "Unknown command: $cmd"
+		_usage
+		return 1
+		;;
+	esac
+}
+
+# Only run main when executed directly (not sourced)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+	main "$@"
+fi

--- a/.agents/scripts/runtime-registry.sh
+++ b/.agents/scripts/runtime-registry.sh
@@ -88,6 +88,27 @@ _RT_BINARY=(
 	"qwen"     # qwen
 )
 
+# --- Version commands (CLI command to extract version string) ---
+# Each entry is a shell command fragment (eval'd at lookup time).
+# Use "" for runtimes with no known CLI version command (GUI-only apps,
+# editor extensions, or runtimes whose version is only accessible via their UI).
+_RT_VERSION_CMD=(
+	"opencode --version 2>/dev/null | head -1" # opencode
+	"claude --version 2>/dev/null | head -1"   # claude-code
+	"codex --version 2>/dev/null | head -1"    # codex
+	""                                         # cursor (GUI app, no CLI version)
+	"droid --version 2>/dev/null | head -1"    # droid
+	"gemini --version 2>/dev/null | head -1"   # gemini-cli
+	""                                         # windsurf (GUI app, no CLI version)
+	""                                         # continue (editor extension, no CLI)
+	"kilo --version 2>/dev/null | head -1"     # kilo
+	""                                         # kiro (GUI app, no CLI version)
+	"aider --version 2>/dev/null | head -1"    # aider
+	"amp --version 2>/dev/null | head -1"      # amp
+	"kimi --version 2>/dev/null | head -1"     # kimi
+	"qwen --version 2>/dev/null | head -1"     # qwen
+)
+
 # --- Display names (human-readable) ---
 _RT_DISPLAY_NAME=(
 	"OpenCode"    # opencode
@@ -518,6 +539,21 @@ rt_display_name() {
 	return 0
 }
 
+rt_version() {
+	local id="$1"
+	local idx
+	idx=$(_rt_index "$id") || return 1
+	local cmd="${_RT_VERSION_CMD[$idx]}"
+	if [[ -z "$cmd" ]]; then
+		echo "unknown"
+		return 0
+	fi
+	local ver
+	ver=$(eval "$cmd" 2>/dev/null) || ver="unknown"
+	echo "${ver:-unknown}"
+	return 0
+}
+
 rt_config_path() {
 	local id="$1"
 	local idx
@@ -907,6 +943,7 @@ rt_validate_registry() {
 	local errors=0
 	local arrays=(
 		"_RT_BINARY"
+		"_RT_VERSION_CMD"
 		"_RT_DISPLAY_NAME"
 		"_RT_CONFIG_PATH"
 		"_RT_CONFIG_FORMAT"

--- a/tests/test-runtime-registry.sh
+++ b/tests/test-runtime-registry.sh
@@ -206,6 +206,40 @@ else
 fi
 
 # =============================================================================
+section "rt_version — Known Runtimes"
+# =============================================================================
+# rt_version returns a string (version or "unknown") for all known runtimes.
+# Runtimes not installed return "unknown" (not an error).
+# Runtimes with no version command defined (GUI-only) return "unknown" directly.
+
+for rt_id in opencode claude-code codex cursor droid gemini-cli windsurf continue kilo kiro aider amp kimi qwen; do
+	ver=$(rt_version "$rt_id")
+	if [[ -n "$ver" ]]; then
+		pass "rt_version $rt_id returns non-empty string ('$ver')"
+	else
+		fail "rt_version $rt_id" "expected non-empty string (at least 'unknown'), got empty"
+	fi
+done
+
+# GUI-only runtimes without a version command must return "unknown" (not error)
+for gui_rt in cursor windsurf continue kiro; do
+	ver=$(rt_version "$gui_rt")
+	if [[ "$ver" == "unknown" ]]; then
+		pass "rt_version $gui_rt = 'unknown' (no version command)"
+	else
+		# May return actual version if runtime is installed with CLI — acceptable
+		pass "rt_version $gui_rt = '$ver' (installed version or unknown)"
+	fi
+done
+
+# Unknown runtime ID must return exit 1
+if ! rt_version "nonexistent-runtime" 2>/dev/null; then
+	pass "rt_version returns 1 for unknown runtime ID"
+else
+	fail "rt_version should return 1 for unknown runtime ID"
+fi
+
+# =============================================================================
 section "Unknown Runtime Handling"
 # =============================================================================
 


### PR DESCRIPTION
## Summary

Phase A of the multi-runtime greeting architecture (t2737, parent #20471):

- Add `_RT_VERSION_CMD` parallel array (14 entries) to `runtime-registry.sh`, with CLI version commands for runtimes that expose a `--version` flag and `""` for GUI-only runtimes
- Add `rt_version()` public API function following the `rt_binary()` pattern — returns version string or `"unknown"` for runtimes without a version command; exit 1 for unknown IDs
- Add `_RT_VERSION_CMD` to `rt_validate_registry()` so alignment is enforced by the test suite
- Create `greeting-cache-helper.sh`: writes `~/.aidevops/cache/session-greeting-{runtime}.txt` with line 1 `aidevops vX running in {display_name} vY | {slug}`, plus shared `session-greeting.txt` for backward compat
- Extend `tests/test-runtime-registry.sh` with 19 new assertions covering `rt_version` for all 14 runtime IDs and the unknown-ID error path

## Verification

- `tests/test-runtime-registry.sh`: 52/52 pass (was 33/33)
- `shellcheck` zero violations on all three modified files
- `greeting-cache-helper.sh write opencode` creates correct format: `aidevops v3.8.95 running in OpenCode v1.14.20 | marcusquinn/aidevops`

Resolves #20599
For #20471
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.95 plugin for [OpenCode](https://opencode.ai) v1.14.20 with claude-sonnet-4-6 spent 4m and 13,471 tokens on this as a headless worker.
