### PR TITLE
GH#20615: fix: invert stat probe order to GNU-first for Linux compat

### DIFF
--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -662,6 +662,20 @@ ${text}
 }
 
 # =============================================================================
+# Portable file mtime (macOS vs GNU/Linux)
+# GNU stat uses -c %Y; BSD stat uses -f %m. On Linux, `stat -f %m` does NOT
+# fail — it prints filesystem info (exit 0), capturing garbage into variables.
+# GNU-first order is mandatory.  See GH#20615.
+# Usage: epoch=$(_file_mtime_epoch "/path/to/file")
+# Returns: modification time as epoch seconds, or 0 if file missing / error.
+# =============================================================================
+
+_file_mtime_epoch() {
+	local file_path="$1"
+	stat -c %Y "$file_path" 2>/dev/null || stat -f %m "$file_path" 2>/dev/null || echo 0
+}
+
+# =============================================================================
 # Stderr Logging Utilities
 # =============================================================================
 # Replace blanket 2>/dev/null with targeted stderr handling.

--- a/.agents/scripts/stats-health-dashboard.sh
+++ b/.agents/scripts/stats-health-dashboard.sh
@@ -428,7 +428,7 @@ _periodic_health_issue_dedup() {
 	# Throttle: skip if last scan was recent
 	if [[ -f "$state_file" ]]; then
 		local last_scan_epoch now_epoch elapsed
-		last_scan_epoch=$(stat -f %m "$state_file" 2>/dev/null || stat -c %Y "$state_file" 2>/dev/null || echo 0)
+		last_scan_epoch=$(_file_mtime_epoch "$state_file")
 		now_epoch=$(date +%s)
 		elapsed=$((now_epoch - last_scan_epoch))
 		if [[ $elapsed -lt $interval ]]; then

--- a/.agents/scripts/tests/test-find-health-issue-rate-limit.sh
+++ b/.agents/scripts/tests/test-find-health-issue-rate-limit.sh
@@ -329,9 +329,9 @@ reset_stubs
 state_file="${HOME}/.aidevops/logs/health-dedup-last-scan-alice-supervisor-owner-repo"
 touch -t 202001010000 "$state_file"  # stale
 stub_gh_for "issue list --repo ${REPO} --label supervisor --label alice" "" 4
-orig_mtime=$(stat -f %m "$state_file" 2>/dev/null || stat -c %Y "$state_file" 2>/dev/null)
+orig_mtime=$(stat -c %Y "$state_file" 2>/dev/null || stat -f %m "$state_file" 2>/dev/null)
 _periodic_health_issue_dedup "$REPO" "$RUNNER_USER" "$RUNNER_ROLE" "$ROLE_LABEL" "$ROLE_DISPLAY" "42"
-new_mtime=$(stat -f %m "$state_file" 2>/dev/null || stat -c %Y "$state_file" 2>/dev/null)
+new_mtime=$(stat -c %Y "$state_file" 2>/dev/null || stat -f %m "$state_file" 2>/dev/null)
 if [[ "$orig_mtime" == "$new_mtime" ]]; then
 	pass "state file mtime unchanged after list failure (retry next cycle)"
 else
@@ -351,7 +351,7 @@ else
 	fail "periodic dedup closes older duplicate" "no close for 42 in: $(cat "$GH_CALLS")"
 fi
 # State file should be touched to "now" — verify it's newer than the stale mtime
-new_mtime=$(stat -f %m "$state_file" 2>/dev/null || stat -c %Y "$state_file" 2>/dev/null)
+new_mtime=$(stat -c %Y "$state_file" 2>/dev/null || stat -f %m "$state_file" 2>/dev/null)
 now=$(date +%s)
 if ((now - new_mtime < 60)); then
 	pass "state file touched after successful dedup (within last 60s)"

--- a/.agents/scripts/tests/test-oauth-interactive-unaffected.sh
+++ b/.agents/scripts/tests/test-oauth-interactive-unaffected.sh
@@ -139,7 +139,7 @@ chmod +x "$TMP/bin/oauth-pool-helper.sh"
 
 # Hash the shared file before rotation.
 sha_before=$(shasum -a 256 "$TMP/shared/opencode/auth.json" | awk '{print $1}')
-mtime_before=$(stat -f %m "$TMP/shared/opencode/auth.json" 2>/dev/null || stat -c %Y "$TMP/shared/opencode/auth.json" 2>/dev/null || echo 0)
+mtime_before=$(stat -c %Y "$TMP/shared/opencode/auth.json" 2>/dev/null || stat -f %m "$TMP/shared/opencode/auth.json" 2>/dev/null || echo 0)
 
 # --- Execute rotation with XDG pointing at isolated -------------------------
 
@@ -163,7 +163,7 @@ fi
 # --- Test 2: shared file mtime unchanged -----------------------------------
 
 sleep 1 # ensure any errant mtime bump would be visible
-mtime_after=$(stat -f %m "$TMP/shared/opencode/auth.json" 2>/dev/null || stat -c %Y "$TMP/shared/opencode/auth.json" 2>/dev/null || echo 0)
+mtime_after=$(stat -c %Y "$TMP/shared/opencode/auth.json" 2>/dev/null || stat -f %m "$TMP/shared/opencode/auth.json" 2>/dev/null || echo 0)
 if [[ "$mtime_before" == "$mtime_after" ]]; then
 	pass "shared auth.json mtime unchanged (mtime=$mtime_before)"
 else

--- a/.agents/scripts/wappalyzer-helper.sh
+++ b/.agents/scripts/wappalyzer-helper.sh
@@ -159,7 +159,7 @@ cache_get() {
 	if [[ -f "$cache_file" ]]; then
 		# Check if cache is less than 7 days old
 		local cache_age
-		cache_age=$(($(date +%s) - $(stat -f %m "$cache_file" 2>/dev/null || stat -c %Y "$cache_file" 2>/dev/null || echo 0)))
+		cache_age=$(($(date +%s) - $(_file_mtime_epoch "$cache_file")))
 
 		if [[ $cache_age -lt 604800 ]]; then
 			cat "$cache_file"


### PR DESCRIPTION
## Summary

Fixed 7 sites with inverted BSD/GNU stat probe order that caused 'File: unbound variable' on Linux. Added _file_mtime_epoch() helper to shared-constants.sh for safe cross-platform file mtime retrieval.

## Files Changed

.agents/scripts/shared-constants.sh,.agents/scripts/stats-health-dashboard.sh,.agents/scripts/tests/test-find-health-issue-rate-limit.sh,.agents/scripts/tests/test-oauth-interactive-unaffected.sh,.agents/scripts/wappalyzer-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck passed on all 5 modified files. _file_mtime_epoch helper verified locally to return correct epoch integer.

Resolves #20615


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.96 plugin for [OpenCode](https://opencode.ai) v1.14.22 with claude-opus-4-6 spent 5m and 9,786 tokens on this as a headless worker.