### PR TITLE
t2767: commit-and-pr partial-success recovery for transient GraphQL errors

### DIFF
--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -943,13 +943,16 @@ _derive_pr_title_prefix() {
 # Arguments: repo, pr_title, pr_body, origin_label; extra_labels passed as remaining args.
 # Returns 1 on failure.
 # t2115: Uses gh_create_pr wrapper (shared-constants.sh) for origin label + signature auto-append.
+# t2767: Implements partial-success recovery — when gh_create_pr exits non-zero but a PR
+# already exists for the current branch (GitHub created it but a follow-up update failed),
+# we recover and continue instead of bailing out.
 _create_pr() {
 	local repo="$1" pr_title="$2" pr_body="$3" origin_label="$4"
 	shift 4
 	local -a extra_labels=("$@")
 
 	print_info "Creating PR..."
-	local pr_url=""
+	local pr_url="" rc=0
 	# t2115: gh_create_pr auto-appends origin label and signature footer.
 	# The explicit --label "$origin_label" is kept for backward compat (GitHub deduplicates).
 	local -a pr_cmd=(gh_create_pr --repo "$repo" --title "$pr_title" --body "$pr_body" --label "$origin_label")
@@ -957,10 +960,26 @@ _create_pr() {
 		pr_cmd+=(--label "$lbl")
 	done
 
-	pr_url=$("${pr_cmd[@]}" 2>&1) || {
-		print_error "PR creation failed: ${pr_url}"
-		return 1
-	}
+	pr_url=$("${pr_cmd[@]}" 2>&1) || rc=$?
+
+	if [[ $rc -ne 0 ]]; then
+		# t2767: Partial-success recovery.
+		# gh pr create (via gh_create_pr) can return non-zero even when GitHub already
+		# created the PR — this happens when a follow-up GraphQL mutation (body update,
+		# label application) succeeds on GitHub's backend but the subsequent API response
+		# fails with a transient error (e.g. "Something went wrong while executing your query").
+		# Before treating this as a hard failure, check whether the PR now exists.
+		local current_branch="" recovered_url=""
+		current_branch=$(git branch --show-current 2>/dev/null || echo "")
+		recovered_url=$(_gh_recover_pr_if_exists "$current_branch" "$repo" 2>/dev/null || echo "")
+		if [[ -n "$recovered_url" ]]; then
+			print_info "PR creation command returned non-zero but PR exists — recovering (t2767): ${recovered_url}"
+			pr_url="$recovered_url"
+		else
+			print_error "PR creation failed: ${pr_url}"
+			return 1
+		fi
+	fi
 
 	local pr_number=""
 	pr_number=$(printf '%s' "$pr_url" | grep -oE '[0-9]+$' || echo "")
@@ -977,9 +996,25 @@ _create_pr() {
 # Post the MERGE_SUMMARY comment on the PR (full-loop step 4.2.1).
 # Arguments: pr_number, repo, issue_number, summary_what, files_changed,
 #            summary_testing, summary_decisions
+# t2767: Idempotent — skips posting if MERGE_SUMMARY comment already exists.
+# This handles the partial-success recovery case where commit-and-pr was
+# interrupted after posting the comment but before returning the PR number.
 _post_merge_summary() {
 	local pr_number="$1" repo="$2" issue_number="$3" summary_what="$4"
 	local files_changed="$5" summary_testing="$6" summary_decisions="$7"
+
+	# t2767: Check if MERGE_SUMMARY comment already exists before posting.
+	# Uses PR timeline comments endpoint (issues endpoint covers PR comments).
+	# Counter safety: validate result is a number before comparing (t2763).
+	local _existing_count=0
+	local _tmp_count=""
+	_tmp_count=$(gh api "repos/${repo}/issues/${pr_number}/comments" \
+		--jq '[.[] | select(.body | test("MERGE_SUMMARY"))] | length' 2>/dev/null || true)
+	[[ "$_tmp_count" =~ ^[0-9]+$ ]] && _existing_count="$_tmp_count"
+	if [[ "$_existing_count" -gt 0 ]]; then
+		print_info "Merge summary comment already exists on PR #${pr_number} — skipping duplicate (t2767)"
+		return 0
+	fi
 
 	local merge_summary="<!-- MERGE_SUMMARY -->
 ## Completion Summary

--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -777,6 +777,27 @@ gh_create_pr() {
 	return $rc
 }
 
+# t2767: Partial-success recovery for gh pr create.
+# When gh pr create returns non-zero, GitHub may have successfully created the
+# PR but a follow-up update call (label application, body normalisation, etc.)
+# failed with a transient GraphQL error. This helper checks whether a PR already
+# exists for the given branch in the repo, returning its URL if found.
+#
+# Usage: recovered_url=$(_gh_recover_pr_if_exists "$branch" "$repo")
+# Returns: PR URL (HTTPS) or empty string. Always exits 0 (fail-open).
+#
+# Callers must treat a non-empty return value as the PR URL to continue with
+# and log a recovery warning so operators know a transient error occurred.
+_gh_recover_pr_if_exists() {
+	local branch="$1" repo="${2:-}"
+	[[ -z "$branch" ]] && return 0
+	local url_candidate=""
+	url_candidate=$(gh pr list --head "$branch" ${repo:+--repo "$repo"} --state open \
+		--json number,url --jq '.[0].url // empty' 2>/dev/null || true)
+	printf '%s\n' "${url_candidate:-}"
+	return 0
+}
+
 # t2393: auto-append signature footer on all `gh issue comment` posts.
 # Thin wrapper mirroring gh_create_issue/gh_create_pr — invokes
 # _gh_wrapper_auto_sig on --body/--body-file before delegating to the

--- a/.agents/scripts/tests/test-commit-and-pr-partial-success.sh
+++ b/.agents/scripts/tests/test-commit-and-pr-partial-success.sh
@@ -1,0 +1,341 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-commit-and-pr-partial-success.sh — t2767 regression guard.
+#
+# Verifies that _create_pr() and _post_merge_summary() in full-loop-helper.sh
+# handle partial-success failures correctly:
+#
+#   1. PR creation partial-success recovery:
+#      When gh_create_pr returns non-zero but a PR already exists for the
+#      current branch (e.g. GitHub created the PR but a follow-up GraphQL
+#      mutation failed), _create_pr() must recover and return 0 with the
+#      correct PR number — not bail with exit 1.
+#
+#   2. PR creation hard failure:
+#      When gh_create_pr returns non-zero AND no PR exists for the branch,
+#      _create_pr() must return 1 with an error message.
+#
+#   3. Merge-summary idempotency:
+#      When _post_merge_summary() is called a second time and a MERGE_SUMMARY
+#      comment already exists on the PR, it must skip posting and return 0
+#      (no duplicate comment).
+#
+#   4. Merge-summary first post:
+#      When no MERGE_SUMMARY comment exists, _post_merge_summary() must
+#      post the comment and return 0.
+#
+# Stub strategy: define gh, gh_create_pr, _gh_recover_pr_if_exists,
+# gh_pr_comment, and git as shell functions AFTER extracting the tested
+# functions. Shell functions take precedence over PATH binaries. The
+# _SOURCING_FOR_TEST guard prevents full-loop-helper.sh's main entrypoint
+# from running during extraction.
+#
+# Cross-reference: GH#20634 / t2767 (fix), PR #20616 (original failure).
+
+# NOT using set -e — negative assertions rely on non-zero exits
+set -uo pipefail
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR_TEST}/.." && pwd)" || exit 1
+
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_BLUE=$'\033[0;34m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_BLUE="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf '  %sPASS%s %s\n' "$TEST_GREEN" "$TEST_NC" "$1"
+	return 0
+}
+
+fail() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '  %sFAIL%s %s\n' "$TEST_RED" "$TEST_NC" "$1"
+	if [[ -n "${2:-}" ]]; then
+		printf '       %s\n' "$2"
+	fi
+	return 0
+}
+
+# =============================================================================
+# Sandbox setup
+# =============================================================================
+TMP=$(mktemp -d -t t2767.XXXXXX)
+trap 'rm -rf "$TMP"' EXIT
+
+STUB_LOG="${TMP}/stub_calls.log"
+GH_API_RESPONSE="${TMP}/gh_api_response.txt"
+: >"$STUB_LOG"
+printf '0\n' >"$GH_API_RESPONSE"  # default: 0 existing MERGE_SUMMARY comments
+
+# =============================================================================
+# Minimal stubs for shared-constants.sh symbols required by full-loop-helper.sh
+# =============================================================================
+if [[ -z "${NC+x}" ]]; then
+	NC=$'\033[0m'
+	RED=$'\033[0;31m'
+	GREEN=$'\033[0;32m'
+	YELLOW=$'\033[0;33m'
+	BLUE=$'\033[0;34m'
+	PURPLE=$'\033[0;35m'
+	CYAN=$'\033[0;36m'
+	WHITE=$'\033[0;37m'
+	BOLD=$'\033[1m'
+fi
+
+# Quiet print stubs — capture to log for assertions
+print_info()    { printf '[INFO] %s\n' "$*" >>"$STUB_LOG"; return 0; }
+print_error()   { printf '[ERROR] %s\n' "$*" >>"$STUB_LOG"; return 0; }
+print_warning() { printf '[WARN] %s\n' "$*" >>"$STUB_LOG"; return 0; }
+print_success() { printf '[OK] %s\n' "$*" >>"$STUB_LOG"; return 0; }
+
+# =============================================================================
+# Extract the functions under test directly from the helper.
+# Extraction uses sed to pull from function declaration to closing brace.
+# The _SOURCING_FOR_TEST sentinel prevents main entrypoint execution.
+# =============================================================================
+_SOURCING_FOR_TEST=1
+
+# Extract _create_pr
+# shellcheck disable=SC2312
+eval "$(sed -n '/^_create_pr() {/,/^}/p' "${SCRIPTS_DIR}/full-loop-helper.sh")"
+
+# Extract _post_merge_summary
+# shellcheck disable=SC2312
+eval "$(sed -n '/^_post_merge_summary() {/,/^}/p' "${SCRIPTS_DIR}/full-loop-helper.sh")"
+
+# =============================================================================
+# Post-extraction stubs (override PATH binaries and define missing deps).
+# Defined after eval so they take precedence over any stubs extracted from helper.
+# =============================================================================
+
+# Stub: git branch --show-current → always returns "feature/t2767-test"
+git() {
+	if [[ "${1:-}" == "branch" && "${2:-}" == "--show-current" ]]; then
+		printf 'feature/t2767-test\n'
+		return 0
+	fi
+	command git "$@"
+	return $?
+}
+export -f git
+
+# Control variable: set to 1 to simulate gh_create_pr partial success
+GH_CREATE_PR_FAIL=0
+# Control variable: the URL to return from gh_create_pr on success
+GH_CREATE_PR_URL="https://github.com/owner/repo/pull/999"
+
+# Stub: gh_create_pr — honours GH_CREATE_PR_FAIL
+# On failure, outputs an error message (like real gh does) and returns 1.
+gh_create_pr() {
+	printf 'gh_create_pr %s\n' "$*" >>"$STUB_LOG"
+	if [[ "$GH_CREATE_PR_FAIL" -eq 1 ]]; then
+		printf 'pull request update failed: GraphQL: Something went wrong\n' >&2
+		return 1
+	fi
+	printf '%s\n' "$GH_CREATE_PR_URL"
+	return 0
+}
+export -f gh_create_pr
+
+# Control variable: PR URL to return from _gh_recover_pr_if_exists
+GH_RECOVER_PR_URL=""
+
+# Stub: _gh_recover_pr_if_exists — honours GH_RECOVER_PR_URL
+# Returns the URL if set (simulating PR exists), empty string otherwise.
+_gh_recover_pr_if_exists() {
+	printf '_gh_recover_pr_if_exists branch=%s repo=%s\n' "${1:-}" "${2:-}" >>"$STUB_LOG"
+	printf '%s\n' "${GH_RECOVER_PR_URL:-}"
+	return 0
+}
+export -f _gh_recover_pr_if_exists
+
+# Control variable: set to non-empty to simulate MERGE_SUMMARY already existing
+GH_EXISTING_MERGE_SUMMARY_COUNT=0
+
+# Stub: gh — handles the gh api call for MERGE_SUMMARY check, plus pr comment
+gh() {
+	printf 'gh %s\n' "$*" >>"$STUB_LOG"
+	# Handle: gh api repos/.../issues/.../comments --jq '...'
+	if [[ "${1:-}" == "api" ]]; then
+		printf '%s\n' "$GH_EXISTING_MERGE_SUMMARY_COUNT"
+		return 0
+	fi
+	# Handle: gh pr comment ... (simulated via gh_pr_comment stub below)
+	return 0
+}
+export -f gh
+
+# Stub: gh_pr_comment — records call, returns 0
+gh_pr_comment() {
+	printf 'gh_pr_comment pr=%s\n' "${1:-}" >>"$STUB_LOG"
+	return 0
+}
+export -f gh_pr_comment
+
+# =============================================================================
+# Test 1: _create_pr partial-success recovery
+# gh_create_pr returns non-zero, but _gh_recover_pr_if_exists finds the PR.
+# Expected: _create_pr returns 0 and outputs the correct PR number (999).
+# =============================================================================
+: >"$STUB_LOG"
+GH_CREATE_PR_FAIL=1
+GH_RECOVER_PR_URL="https://github.com/owner/repo/pull/999"
+
+actual_pr_number=""
+actual_rc=0
+actual_pr_number=$(_create_pr "owner/repo" "t2767: test" "body text" "origin:worker") || actual_rc=$?
+
+if [[ "$actual_rc" -eq 0 ]]; then
+	pass "partial-success recovery: _create_pr returns 0 when PR exists after create failure"
+else
+	fail "partial-success recovery: _create_pr returns 0 when PR exists after create failure" \
+		"got exit $actual_rc; stub log: $(cat "$STUB_LOG" 2>/dev/null)"
+fi
+
+if [[ "$actual_pr_number" == "999" ]]; then
+	pass "partial-success recovery: _create_pr outputs correct PR number (999)"
+else
+	fail "partial-success recovery: _create_pr outputs correct PR number (999)" \
+		"got '${actual_pr_number}'; stub log: $(cat "$STUB_LOG" 2>/dev/null)"
+fi
+
+if grep -q "recovering (t2767)" "$STUB_LOG" 2>/dev/null; then
+	pass "partial-success recovery: recovery log message emitted"
+else
+	fail "partial-success recovery: recovery log message emitted" \
+		"expected '[INFO] ... recovering (t2767)' in log; got: $(cat "$STUB_LOG" 2>/dev/null)"
+fi
+
+# =============================================================================
+# Test 2: _create_pr hard failure
+# gh_create_pr returns non-zero AND _gh_recover_pr_if_exists finds nothing.
+# Expected: _create_pr returns non-zero with an error.
+# =============================================================================
+: >"$STUB_LOG"
+GH_CREATE_PR_FAIL=1
+GH_RECOVER_PR_URL=""
+
+hard_fail_rc=0
+_create_pr "owner/repo" "t2767: test" "body text" "origin:worker" >/dev/null 2>&1 || hard_fail_rc=$?
+
+if [[ "$hard_fail_rc" -ne 0 ]]; then
+	pass "hard failure: _create_pr returns non-zero when no PR exists after failure"
+else
+	fail "hard failure: _create_pr returns non-zero when no PR exists after failure" \
+		"expected non-zero exit, got 0; stub log: $(cat "$STUB_LOG" 2>/dev/null)"
+fi
+
+if grep -q "\[ERROR\] PR creation failed" "$STUB_LOG" 2>/dev/null; then
+	pass "hard failure: error message emitted"
+else
+	fail "hard failure: error message emitted" \
+		"expected '[ERROR] PR creation failed' in log; got: $(cat "$STUB_LOG" 2>/dev/null)"
+fi
+
+# =============================================================================
+# Test 3: _create_pr success (no recovery needed)
+# gh_create_pr succeeds. Expected: _create_pr returns 0, outputs PR number.
+# =============================================================================
+: >"$STUB_LOG"
+GH_CREATE_PR_FAIL=0
+GH_RECOVER_PR_URL=""
+GH_CREATE_PR_URL="https://github.com/owner/repo/pull/888"
+
+success_pr_number=""
+success_rc=0
+success_pr_number=$(_create_pr "owner/repo" "t2767: test" "body text" "origin:worker") || success_rc=$?
+
+if [[ "$success_rc" -eq 0 ]]; then
+	pass "normal success: _create_pr returns 0 on clean create"
+else
+	fail "normal success: _create_pr returns 0 on clean create" \
+		"got exit $success_rc"
+fi
+
+if [[ "$success_pr_number" == "888" ]]; then
+	pass "normal success: _create_pr outputs correct PR number (888)"
+else
+	fail "normal success: _create_pr outputs correct PR number (888)" \
+		"got '${success_pr_number}'"
+fi
+
+# =============================================================================
+# Test 4: _post_merge_summary idempotency — skip when comment already exists
+# GH_EXISTING_MERGE_SUMMARY_COUNT=1 simulates an existing MERGE_SUMMARY comment.
+# Expected: gh_pr_comment NOT called, returns 0.
+# =============================================================================
+: >"$STUB_LOG"
+GH_EXISTING_MERGE_SUMMARY_COUNT=1
+
+idem_rc=0
+_post_merge_summary "999" "owner/repo" "42" "impl" "file.sh" "shellcheck" "none" || idem_rc=$?
+
+if [[ "$idem_rc" -eq 0 ]]; then
+	pass "idempotency: _post_merge_summary returns 0 when comment already exists"
+else
+	fail "idempotency: _post_merge_summary returns 0 when comment already exists" \
+		"got exit $idem_rc"
+fi
+
+if ! grep -q "gh_pr_comment" "$STUB_LOG" 2>/dev/null; then
+	pass "idempotency: gh_pr_comment NOT called when MERGE_SUMMARY already exists"
+else
+	fail "idempotency: gh_pr_comment NOT called when MERGE_SUMMARY already exists" \
+		"gh_pr_comment was called; stub log: $(cat "$STUB_LOG" 2>/dev/null)"
+fi
+
+if grep -q "skipping duplicate (t2767)" "$STUB_LOG" 2>/dev/null; then
+	pass "idempotency: skip message logged"
+else
+	fail "idempotency: skip message logged" \
+		"expected 'skipping duplicate (t2767)' in log; got: $(cat "$STUB_LOG" 2>/dev/null)"
+fi
+
+# =============================================================================
+# Test 5: _post_merge_summary first post — no existing comment
+# GH_EXISTING_MERGE_SUMMARY_COUNT=0 simulates no existing MERGE_SUMMARY comment.
+# Expected: gh_pr_comment IS called, returns 0.
+# =============================================================================
+: >"$STUB_LOG"
+GH_EXISTING_MERGE_SUMMARY_COUNT=0
+
+first_post_rc=0
+_post_merge_summary "999" "owner/repo" "42" "impl" "file.sh" "shellcheck" "none" || first_post_rc=$?
+
+if [[ "$first_post_rc" -eq 0 ]]; then
+	pass "first post: _post_merge_summary returns 0 on fresh PR"
+else
+	fail "first post: _post_merge_summary returns 0 on fresh PR" \
+		"got exit $first_post_rc"
+fi
+
+if grep -q "gh_pr_comment" "$STUB_LOG" 2>/dev/null; then
+	pass "first post: gh_pr_comment IS called when no MERGE_SUMMARY exists"
+else
+	fail "first post: gh_pr_comment IS called when no MERGE_SUMMARY exists" \
+		"gh_pr_comment was NOT called; stub log: $(cat "$STUB_LOG" 2>/dev/null)"
+fi
+
+# =============================================================================
+# Summary
+# =============================================================================
+echo
+if [[ "$TESTS_FAILED" -eq 0 ]]; then
+	printf '%sAll %d tests passed%s\n' "$TEST_GREEN" "$TESTS_RUN" "$TEST_NC"
+	exit 0
+else
+	printf '%s%d / %d tests failed%s\n' "$TEST_RED" "$TESTS_FAILED" "$TESTS_RUN" "$TEST_NC"
+	exit 1
+fi

--- a/.agents/workflows/full-loop.md
+++ b/.agents/workflows/full-loop.md
@@ -117,6 +117,8 @@ PR_NUMBER=$(full-loop-helper.sh commit-and-pr \
 
 Handles: `git add -A`, commit, `git rebase origin/main`, `git push -u`, `gh pr create` with `Resolves #NNN` + signature footer, merge summary comment, and `status:in-review` label. On rebase conflict: aborts and returns 1 — resolve and retry.
 
+**Partial-success recovery (t2767):** If `gh pr create` exits non-zero but GitHub actually created the PR (common with transient GraphQL errors like `"Something went wrong while executing your query"`), `commit-and-pr` automatically detects the existing PR via `gh pr list --head <branch>` and continues with all post-create steps (labels, merge-summary comment, issue status). Exit code 0. If the PR does not exist after the failure, the command exits 1 as before. The merge-summary post is idempotent: if a `<!-- MERGE_SUMMARY -->` comment already exists on the PR (from a previous partial run), the second call skips posting and returns 0.
+
 **Manual alternative:** rebase onto `origin/main`, push, create PR. Body MUST include `Resolves #NNN`. Add `origin:worker` or `origin:interactive` label.
 
 **Signature footer (GH#12805 — MANDATORY):** `commit-and-pr` appends this automatically. For manual PRs: append `gh-signature-helper.sh footer` output. Verify: `gh pr view --json body | jq -e '.body | (contains("aidevops.sh") and (contains("spent") or contains("Overall,")))'`.


### PR DESCRIPTION
## Summary

Resolves #20634

When `gh pr create` returns non-zero due to a transient GraphQL error on a follow-up update call (label application, body normalisation), the PR may have been successfully created on GitHub's backend. Previously the helper treated any non-zero exit as total failure and bailed out — leaving the PR orphaned without a merge-summary comment. Headless workers emitted `BLOCKED` and the task required manual recovery.

## Changes

### `.agents/scripts/full-loop-helper.sh` — partial-success recovery in `_create_pr`

- Capture `rc` from `gh_create_pr` separately (was an inline `|| { return 1 }`)
- On non-zero: call `_gh_recover_pr_if_exists` to check if the PR exists for the current branch
- If found: log the recovery with `(t2767)` tag and continue with the recovered URL
- If not found: fail hard as before with the original error message

### `.agents/scripts/full-loop-helper.sh` — idempotent `_post_merge_summary`

- Before posting: query `gh api repos/{repo}/issues/{pr}/comments` with jq `length` filter
- If `<!-- MERGE_SUMMARY -->` comment already exists: skip posting, log skip, return 0
- Counter safety per t2763: validate jq output is numeric before using it
- First post (0 existing): unchanged behaviour

### `.agents/scripts/shared-gh-wrappers.sh` — new `_gh_recover_pr_if_exists`

- Queries `gh pr list --head $branch --repo $repo --state open` with `jq '.[0].url // empty'`
- Always exits 0 (fail-open): network failures are surfaced as empty string, not hard error
- Available to all callers of `gh_create_pr`, not just `_create_pr`

### `.agents/scripts/tests/test-commit-and-pr-partial-success.sh` — regression test

12 test cases covering:
1. Partial-success recovery: `_create_pr` returns 0 + correct PR number when PR exists after failure
2. Hard failure: `_create_pr` returns non-zero when no PR exists after failure
3. Normal success: `_create_pr` returns 0 on clean create
4. Idempotency: `_post_merge_summary` skips posting when MERGE_SUMMARY exists
5. First post: `_post_merge_summary` posts when no MERGE_SUMMARY exists

### `.agents/workflows/full-loop.md` — documentation

Describes the partial-success recovery path and merge-summary idempotency guarantee.

## Testing

```bash
shellcheck .agents/scripts/full-loop-helper.sh    # zero violations
shellcheck .agents/scripts/shared-gh-wrappers.sh  # 3 pre-existing SC2016 info, no new
shellcheck .agents/scripts/tests/test-commit-and-pr-partial-success.sh  # zero violations
bash .agents/scripts/tests/test-commit-and-pr-partial-success.sh
# All 12 tests passed
```

## Acceptance criteria status

1. ✅ Non-zero `gh pr create` with existing PR → continues post-create steps, exits 0
2. ✅ Non-zero `gh pr create` with no PR → exits 1 with error message
3. ✅ Merge-summary idempotent (existing comment → no duplicate post)
4. ✅ Label application already idempotent via `set_issue_status` (unchanged)
5. ✅ Regression test exercises canonical failure mode
6. ✅ Documentation in `full-loop.md`
7. ✅ ShellCheck clean


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.96 plugin for [OpenCode](https://opencode.ai) v1.14.22 with claude-sonnet-4-6 spent 14m and 30,306 tokens on this as a headless worker.