### PR TITLE
GH#20623: fix: broaden counter-stack regex, use process substitution, harden safe_grep_count

### DIFF
--- a/.agents/scripts/counter-stack-check.sh
+++ b/.agents/scripts/counter-stack-check.sh
@@ -48,8 +48,9 @@ SCRIPT_NAME=$(basename "$0")
 
 # The anti-pattern. Matches `grep -c ... || echo "N"` where N is 0-9.
 # Captures the shape: grep -c, optional args that don't include a pipe, ||,
-# optional whitespace, echo, optional whitespace, quoted integer.
-readonly ANTI_PATTERN='grep -c[^|]*\|\|[[:space:]]*echo[[:space:]]*"[0-9]+"'
+# optional whitespace, echo, optional whitespace, optionally quoted integer.
+# Handles double-quoted ("0"), single-quoted ('0'), and unquoted (0) forms.
+readonly ANTI_PATTERN="grep -c[^|]*\\|\\|[[:space:]]*echo[[:space:]]*[\"']?[0-9]+[\"']?"
 
 # ── helpers ──────────────────────────────────────────────────────────
 
@@ -100,16 +101,12 @@ scan_file() {
 	fi
 
 	# grep -nE prints line numbers; we post-format for the CI report.
-	# Use a temp file because pipes mask exit codes under `set -u`.
-	local _tmp
-	_tmp=$(mktemp)
-	if grep -nE "$ANTI_PATTERN" "$_file" >"$_tmp" 2>/dev/null; then
-		while IFS=: read -r _line_num _content; do
-			printf '%s:%s: counter-stacking: %s\n' "$_file" "$_line_num" "$(_trim "$_content")"
-			_violations=$((_violations + 1))
-		done <"$_tmp"
-	fi
-	rm -f "$_tmp"
+	# Process substitution avoids temp-file disk I/O while keeping the
+	# while-loop in the current shell (unlike a pipe, which would fork).
+	while IFS=: read -r _line_num _content; do
+		printf '%s:%s: counter-stacking: %s\n' "$_file" "$_line_num" "$(_trim "$_content")"
+		_violations=$((_violations + 1))
+	done < <(grep -nE "$ANTI_PATTERN" "$_file" 2>/dev/null)
 
 	if [[ "$_violations" -gt 0 ]]; then
 		return 1

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -524,6 +524,12 @@ print_info() {
 # code with `|| true`, and guards the result with a regex to guarantee a
 # single integer on a single line.
 #
+# NOTE: Designed for single-file or stdin use. With multiple file arguments,
+# grep -c outputs "filename:count" per file, which fails the integer regex
+# and returns 0. The -h flag is passed defensively to suppress filename
+# prefixes, but multi-line output (from multiple files) still falls through
+# to the 0 fallback. For multi-file counting, call once per file.
+#
 # Usage:
 #   count=$(safe_grep_count -E '^pat' file.txt)
 #   count=$(printf '%s\n' "$data" | safe_grep_count 'needle')
@@ -533,7 +539,7 @@ print_info() {
 # idiom in CI. See also `reference/shell-style-guide.md` § Counter Safety.
 safe_grep_count() {
 	local _result
-	_result=$(grep -c "$@" 2>/dev/null || true)
+	_result=$(grep -h -c "$@" 2>/dev/null || true)
 	if [[ "$_result" =~ ^[0-9]+$ ]]; then
 		printf '%s\n' "$_result"
 	else


### PR DESCRIPTION
## Summary

Applied three review bot suggestions from PR #20621: (1) broadened ANTI_PATTERN regex to catch single-quoted and unquoted echo fallbacks, (2) replaced temp file with process substitution in scan_file for efficiency, (3) added -h flag and multi-file documentation to safe_grep_count

## Files Changed

.agents/scripts/counter-stack-check.sh,.agents/scripts/shared-constants.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean on both files, all 13 safe_grep_count unit tests pass, broader regex now catches 5 previously-missed violations in test-stagehand-both-integration.sh

Resolves #20623


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.96 plugin for [OpenCode](https://opencode.ai) v1.14.22 with claude-opus-4-6 spent 9m and 10,606 tokens on this as a headless worker.