### PR TITLE
GH#20636: fix _state_json unbound variable in enrich single-task path

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -2544,9 +2544,9 @@
       "pr": 15916
     },
     ".agents/scripts/shared-constants.sh": {
-      "at": "2026-04-22T23:56:55Z",
-      "hash": "8a03b8f8e70a61bda90e2d4cc41999b14310ecd6",
-      "passes": 20,
+      "at": "2026-04-23T23:17:00Z",
+      "hash": "30b46728d9b1dd3d13e673860c43a4f9b8e68236",
+      "passes": 21,
       "pr": 18847
     },
     ".agents/scripts/stats-functions.sh": {
@@ -7486,9 +7486,9 @@
       "pr": 16415
     },
     "TODO.md": {
-      "at": "2026-04-23T21:03:24Z",
-      "hash": "5fa000f90be603deae873480ef3bbedb178c8a4c",
-      "passes": 92,
+      "at": "2026-04-23T23:19:53Z",
+      "hash": "57a63b74a85455e876fe331cd7dad4931dad56df",
+      "passes": 93,
       "pr": 15490
     },
     "aidevops.sh": {
@@ -7576,10 +7576,10 @@
       "passes": 1
     },
     ".agents/reference/shell-style-guide.md": {
-      "hash": "a611a5a02dbd5e29c9813543ef3546f1414608fe",
-      "at": "2026-04-16T21:58:05Z",
+      "hash": "0a2560bc09c5304973263f831563e4add4c13ab3",
+      "at": "2026-04-23T23:16:35Z",
       "pr": 19321,
-      "passes": 1
+      "passes": 2
     },
     ".agents/scripts/tests/test-consolidation-multi-runner.sh": {
       "hash": "a13a53c49a0bb67c640682bee85ec6eca8c9338a",

--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -1216,7 +1216,7 @@ _enrich_process_task() {
 	# sync-on-push 10-minute cap. Forwarding pre-fetched state collapses the
 	# per-task read cost to one call and lets each helper skip writes whose
 	# target value already matches.
-	local _state_json current_title="" current_body="" current_labels_csv=""
+	local _state_json="" current_title="" current_body="" current_labels_csv=""
 	# GH#20129: use batch-prefetched JSON when available to avoid per-task API
 	# calls. ENRICH_PREFETCH_FILE is set by cmd_enrich before the loop via
 	# _enrich_prefetch_issues_map. The prefetch includes all fields needed:


### PR DESCRIPTION
## Summary

Fixes `issue-sync-helper.sh enrich <task-id>` crashing with `unbound variable` on `_state_json` when invoked directly (without a preceding batch `cmd_enrich` that sets `ENRICH_PREFETCH_FILE`).

## Root Cause

`.agents/scripts/issue-sync-helper.sh:1219` declares `_state_json` without an empty-string initializer. The conditional prefetch block (lines 1224-1227) is skipped when `ENRICH_PREFETCH_FILE` is unset. Under `set -euo pipefail` (line 27), the subsequent `[[ -z "$_state_json" ]]` check at line 1231 then raises `unbound variable` before the `gh issue view` fallback can execute.

## Fix

One-character change matching the initialisation pattern of the three sibling variables on the same `local` declaration line (Option A from the issue):

Before: `local _state_json current_title="" current_body="" current_labels_csv=""`
After:  `local _state_json="" current_title="" current_body="" current_labels_csv=""`

## Verification

- `shellcheck .agents/scripts/issue-sync-helper.sh` passes with zero violations
- Line 1219 now reads `local _state_json="" ...` eliminating the unbound-variable condition
- The `gh issue view` fallback at line 1232 is now reachable on the single-task direct-invocation path

Resolves #20636


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.96 plugin for [OpenCode](https://opencode.ai) v1.14.22 with claude-sonnet-4-6 spent 2m and 3,169 tokens on this as a headless worker.
