### PR TITLE
GH#20625: harden awk if-pattern in extract_block test helper

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -2544,9 +2544,9 @@
       "pr": 15916
     },
     ".agents/scripts/shared-constants.sh": {
-      "at": "2026-04-22T23:56:55Z",
-      "hash": "8a03b8f8e70a61bda90e2d4cc41999b14310ecd6",
-      "passes": 20,
+      "at": "2026-04-23T23:17:00Z",
+      "hash": "30b46728d9b1dd3d13e673860c43a4f9b8e68236",
+      "passes": 21,
       "pr": 18847
     },
     ".agents/scripts/stats-functions.sh": {
@@ -7486,9 +7486,9 @@
       "pr": 16415
     },
     "TODO.md": {
-      "at": "2026-04-23T21:03:24Z",
-      "hash": "5fa000f90be603deae873480ef3bbedb178c8a4c",
-      "passes": 92,
+      "at": "2026-04-23T23:19:53Z",
+      "hash": "57a63b74a85455e876fe331cd7dad4931dad56df",
+      "passes": 93,
       "pr": 15490
     },
     "aidevops.sh": {
@@ -7576,10 +7576,10 @@
       "passes": 1
     },
     ".agents/reference/shell-style-guide.md": {
-      "hash": "a611a5a02dbd5e29c9813543ef3546f1414608fe",
-      "at": "2026-04-16T21:58:05Z",
+      "hash": "0a2560bc09c5304973263f831563e4add4c13ab3",
+      "at": "2026-04-23T23:16:35Z",
       "pr": 19321,
-      "passes": 1
+      "passes": 2
     },
     ".agents/scripts/tests/test-consolidation-multi-runner.sh": {
       "hash": "a13a53c49a0bb67c640682bee85ec6eca8c9338a",

--- a/.agents/scripts/tests/test-pulse-wrapper-isrunning-shortcircuit.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-isrunning-shortcircuit.sh
@@ -82,7 +82,7 @@ extract_block() {
 		in_block {
 			print
 			# Count "if [[" openings (one per line in the block)
-			n_if = gsub(/[[:space:]]if[[:space:]]\[\[/, "&")
+			n_if = gsub(/(^|[[:space:]])if[[:space:]]\[\[/, "&")
 			depth += n_if
 			# Count standalone "fi" lines (start of line, optional tabs/spaces)
 			if ($0 ~ /^[[:space:]]*fi[[:space:]]*$/) {


### PR DESCRIPTION
## Summary

Addresses review-followup issue #20625 (unaddressed review bot suggestions from PR #20616).

**Two inline comments triaged:**

### Comment 1 — `pulse-wrapper.sh:1635` (cat → bash built-in) — Outcome A: Premise falsified

The bot suggested replacing `_ir_pid=$(cat "${LOCKDIR}/pid" 2>/dev/null || true)` with `_ir_pid=$(< "${LOCKDIR}/pid" || true)`.

**This suggestion is functionally broken.** `$(< file)` is a special bash expansion that reads a file without spawning a subprocess. However, `$(< file || true)` is parsed as a regular command substitution: `< file` redirects stdin to the null command (discarding content), then `|| true` runs on failure. The expansion produces **empty string always**, silently breaking PID detection.

Additionally, removing `2>/dev/null` (the bot's secondary suggestion) would cause spurious stderr noise from the TOCTOU race between the `[[ -f "${LOCKDIR}/pid" ]]` check (line 1633) and the `cat` read (line 1635) — the file can be deleted between the two operations.

**Not acting on this suggestion.**

### Comment 2 — `test-pulse-wrapper-isrunning-shortcircuit.sh:85` (awk pattern) — Outcome B: Implemented

The awk pattern `/[[:space:]]if[[:space:]]\[\[/` requires leading whitespace before `if`, missing `if [[` at column 0. Verified empirically:
- Old pattern: returns 0 for `if [[ true ]]; then` (no leading whitespace)
- New pattern `/(^|[[:space:]])if[[:space:]]\[\[/`: returns 1 for both cases

Fix applied. All 8 existing tests pass.

## Testing

- `shellcheck` — zero violations
- `bash .agents/scripts/tests/test-pulse-wrapper-isrunning-shortcircuit.sh` — 8/8 pass
- Empirical awk pattern verification (both indented and unindented cases)

Resolves #20625

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.96 plugin for [OpenCode](https://opencode.ai) v1.14.22 with claude-opus-4-6 spent 3m and 6,347 tokens on this as a headless worker.
