### PR TITLE
GH#20626: fix: harden _handle_stale_llm_lock — portability, PID reuse guard, consistency

### DIFF
--- a/.agents/scripts/pulse-instance-lock.sh
+++ b/.agents/scripts/pulse-instance-lock.sh
@@ -158,44 +158,59 @@ _handle_stale_llm_lock() {
 		lock_pid=$(cat "${lockdir}/pid" 2>/dev/null || echo "")
 	fi
 
+	# Tier 1: No valid PID → corrupt/stale, clear immediately
 	if [[ -z "$lock_pid" ]] || [[ ! "$lock_pid" =~ ^[0-9]+$ ]]; then
-		echo "[pulse-wrapper] Stale LLM lockdir detected (no valid PID) — clearing (GH#20613)" >>"$LOGFILE"
+		echo "[pulse-wrapper] Stale LLM lockdir detected (no valid PID) — clearing (GH#20613)" >>"$WRAPPER_LOGFILE"
 		rm -rf "$lockdir" 2>/dev/null || true
 		if mkdir "$lockdir" 2>/dev/null; then return 0; fi
-		echo "[pulse-wrapper] Lost LLM lock race after stale-lock clear — skipping" >>"$LOGFILE"
+		echo "[pulse-wrapper] Lost LLM lock race after stale-lock clear — skipping" >>"$WRAPPER_LOGFILE"
 		return 1
 	fi
 
+	# Tier 2: Owner PID dead → stale from SIGKILL/OOM, clear
 	if ! ps -p "$lock_pid" >/dev/null 2>&1; then
-		echo "[pulse-wrapper] Stale LLM lockdir detected (owner PID ${lock_pid} is dead) — clearing (GH#20613)" >>"$LOGFILE"
+		echo "[pulse-wrapper] Stale LLM lockdir detected (owner PID ${lock_pid} is dead) — clearing (GH#20613)" >>"$WRAPPER_LOGFILE"
 		rm -rf "$lockdir" 2>/dev/null || true
 		if mkdir "$lockdir" 2>/dev/null; then return 0; fi
-		echo "[pulse-wrapper] Lost LLM lock race after stale-lock clear — skipping" >>"$LOGFILE"
+		echo "[pulse-wrapper] Lost LLM lock race after stale-lock clear — skipping" >>"$WRAPPER_LOGFILE"
 		return 1
 	fi
 
-	# Owner is alive — check age-based ceiling
-	local lock_age=0
-	local lock_mtime
-	lock_mtime=$(stat -c '%Y' "$lockdir" 2>/dev/null || echo "0")
-	if [[ "$lock_mtime" -gt 0 ]]; then
-		lock_age=$(( $(date +%s) - lock_mtime ))
+	# Tier 3: Owner alive — check PID reuse + age-based ceiling
+	# Use _get_process_age (portable ps-etime) instead of stat -c '%Y' (GNU-only)
+	local lock_age
+	lock_age=$(_get_process_age "$lock_pid")
+	local owner_cmd=""
+	owner_cmd=$(ps -p "$lock_pid" -o command= 2>/dev/null || echo "")
+
+	# PID reuse guard: if the process is NOT a pulse-wrapper, the original
+	# owner died and the PID was recycled by an unrelated process (GH#20025).
+	# Reclaim immediately without killing the unrelated process.
+	if [[ "$owner_cmd" != *"pulse-wrapper"* ]]; then
+		echo "[pulse-wrapper] FORCE-RECLAIMED stale LLM lockdir from PID ${lock_pid} (age ${lock_age}s, owner_cmd='${owner_cmd%%' '*}') — PID reused by non-pulse process (GH#20626)" >>"$WRAPPER_LOGFILE"
+		rm -rf "$lockdir" 2>/dev/null || true
+		if mkdir "$lockdir" 2>/dev/null; then return 0; fi
+		echo "[pulse-wrapper] Lost LLM lock race after PID-reuse reclaim — skipping" >>"$WRAPPER_LOGFILE"
+		return 1
 	fi
+
+	# Age-based force-reclaim: if a genuine pulse-wrapper has been holding
+	# the LLM lock for longer than PULSE_LOCK_MAX_AGE_S, it is hung.
 	local max_age="${PULSE_LOCK_MAX_AGE_S:-1800}"
 	if [[ "$lock_age" -gt "$max_age" ]]; then
-		echo "[pulse-wrapper] FORCE-RECLAIMED stale LLM lockdir (owner PID ${lock_pid}, age ${lock_age}s > ceiling ${max_age}s) — killing hung owner (GH#20613)" >>"$LOGFILE"
-		kill "$lock_pid" 2>/dev/null || true
+		echo "[pulse-wrapper] FORCE-RECLAIMED stale LLM lockdir (owner PID ${lock_pid}, age ${lock_age}s > ceiling ${max_age}s, owner_cmd='${owner_cmd%%' '*}') — killing hung owner (GH#20613)" >>"$WRAPPER_LOGFILE"
+		_kill_tree "$lock_pid" || true
 		sleep 2
 		if kill -0 "$lock_pid" 2>/dev/null; then
-			kill -9 "$lock_pid" 2>/dev/null || true
+			_force_kill_tree "$lock_pid" || true
 		fi
 		rm -rf "$lockdir" 2>/dev/null || true
 		if mkdir "$lockdir" 2>/dev/null; then return 0; fi
-		echo "[pulse-wrapper] Lost LLM lock race after force-reclaim — skipping" >>"$LOGFILE"
+		echo "[pulse-wrapper] Lost LLM lock race after force-reclaim — skipping" >>"$WRAPPER_LOGFILE"
 		return 1
 	fi
 
-	echo "[pulse-wrapper] LLM session already running (lock held by PID ${lock_pid}, age ${lock_age}s) — skipping" >>"$LOGFILE"
+	echo "[pulse-wrapper] LLM session already running (lock held by PID ${lock_pid}, age ${lock_age}s) — skipping" >>"$WRAPPER_LOGFILE"
 	return 1
 }
 

--- a/.agents/scripts/tests/test-pulse-lock-force-reclaim.sh
+++ b/.agents/scripts/tests/test-pulse-lock-force-reclaim.sh
@@ -378,13 +378,167 @@ test_self_release_removes_own_lock() {
 }
 
 #######################################
+# Test 8: LLM lock — no valid PID → reclaim (tier 1)
+#######################################
+test_llm_lock_no_valid_pid() {
+	reset_state
+
+	local llm_lockdir="${LOCKDIR}.llm"
+	mkdir -p "$llm_lockdir"
+	# Write garbage PID
+	echo "not-a-pid" >"${llm_lockdir}/pid"
+
+	local result=0
+	_handle_stale_llm_lock "$llm_lockdir" || result=$?
+
+	assert_equals "LLM no-valid-PID: returns 0 (reclaimed)" "0" "$result"
+
+	if grep -q "Stale LLM lockdir detected (no valid PID)" "$WRAPPER_LOGFILE" 2>/dev/null; then
+		print_result "LLM no-valid-PID: stale-lock logged" 0
+	else
+		print_result "LLM no-valid-PID: stale-lock logged" 1 "no stale-lock log line found"
+	fi
+	rm -rf "$llm_lockdir" 2>/dev/null || true
+	return 0
+}
+
+#######################################
+# Test 9: LLM lock — dead PID owner → reclaim (tier 2)
+#######################################
+test_llm_lock_dead_pid() {
+	reset_state
+
+	local llm_lockdir="${LOCKDIR}.llm"
+	mkdir -p "$llm_lockdir"
+	# Use a PID guaranteed to be dead
+	local dead_pid=999987
+	while ps -p "$dead_pid" >/dev/null 2>&1; do
+		dead_pid=$((dead_pid + 1))
+	done
+	echo "$dead_pid" >"${llm_lockdir}/pid"
+
+	local result=0
+	_handle_stale_llm_lock "$llm_lockdir" || result=$?
+
+	assert_equals "LLM dead-PID: returns 0 (reclaimed)" "0" "$result"
+
+	if grep -q "Stale LLM lockdir detected (owner PID ${dead_pid} is dead)" "$WRAPPER_LOGFILE" 2>/dev/null; then
+		print_result "LLM dead-PID: dead-owner logged" 0
+	else
+		print_result "LLM dead-PID: dead-owner logged" 1 "no dead-owner log line found"
+	fi
+	rm -rf "$llm_lockdir" 2>/dev/null || true
+	return 0
+}
+
+#######################################
+# Test 10: LLM lock — PID reuse by non-pulse process → reclaim without kill
+#######################################
+test_llm_lock_pid_reuse() {
+	reset_state
+
+	local llm_lockdir="${LOCKDIR}.llm"
+
+	# Launch a plain sleep (NOT pulse-wrapper)
+	sleep 60 &
+	local non_pulse_pid=$!
+	BG_PIDS="$BG_PIDS $non_pulse_pid"
+
+	mkdir -p "$llm_lockdir"
+	echo "$non_pulse_pid" >"${llm_lockdir}/pid"
+
+	STUB_PROCESS_AGE=100
+
+	local result=0
+	_handle_stale_llm_lock "$llm_lockdir" || result=$?
+
+	assert_equals "LLM PID-reuse: returns 0 (reclaimed)" "0" "$result"
+	assert_equals "LLM PID-reuse: _kill_tree NOT called" "0" "$KILL_TREE_CALLED"
+
+	if grep -q "FORCE-RECLAIMED stale LLM lockdir from PID.*PID reused by non-pulse" "$WRAPPER_LOGFILE" 2>/dev/null; then
+		print_result "LLM PID-reuse: force-reclaim logged" 0
+	else
+		print_result "LLM PID-reuse: force-reclaim logged" 1 "no PID-reuse FORCE-RECLAIMED line"
+	fi
+	rm -rf "$llm_lockdir" 2>/dev/null || true
+	return 0
+}
+
+#######################################
+# Test 11: LLM lock — alive pulse-wrapper within ceiling → blocked
+#######################################
+test_llm_lock_alive_within_ceiling() {
+	reset_state
+
+	local llm_lockdir="${LOCKDIR}.llm"
+
+	"${TEST_ROOT}/pulse-wrapper.sh" &
+	local fake_pid=$!
+	BG_PIDS="$BG_PIDS $fake_pid"
+
+	mkdir -p "$llm_lockdir"
+	echo "$fake_pid" >"${llm_lockdir}/pid"
+
+	STUB_PROCESS_AGE=120
+	PULSE_LOCK_MAX_AGE_S=1800
+
+	local result=0
+	_handle_stale_llm_lock "$llm_lockdir" || result=$?
+
+	assert_equals "LLM alive-within-ceiling: returns 1 (blocked)" "1" "$result"
+	assert_equals "LLM alive-within-ceiling: _kill_tree NOT called" "0" "$KILL_TREE_CALLED"
+
+	if grep -q "LLM session already running" "$WRAPPER_LOGFILE" 2>/dev/null; then
+		print_result "LLM alive-within-ceiling: blocking logged" 0
+	else
+		print_result "LLM alive-within-ceiling: blocking logged" 1 "no blocking log line found"
+	fi
+	rm -rf "$llm_lockdir" 2>/dev/null || true
+	return 0
+}
+
+#######################################
+# Test 12: LLM lock — alive pulse-wrapper above ceiling → kill + reclaim
+#######################################
+test_llm_lock_alive_above_ceiling() {
+	reset_state
+
+	local llm_lockdir="${LOCKDIR}.llm"
+
+	"${TEST_ROOT}/pulse-wrapper.sh" &
+	local fake_pid=$!
+	BG_PIDS="$BG_PIDS $fake_pid"
+
+	mkdir -p "$llm_lockdir"
+	echo "$fake_pid" >"${llm_lockdir}/pid"
+
+	STUB_PROCESS_AGE=2000
+	PULSE_LOCK_MAX_AGE_S=1800
+
+	local result=0
+	_handle_stale_llm_lock "$llm_lockdir" || result=$?
+
+	assert_equals "LLM alive-above-ceiling: returns 0 (reclaimed)" "0" "$result"
+	assert_equals "LLM alive-above-ceiling: _kill_tree called" "1" "$KILL_TREE_CALLED"
+	assert_equals "LLM alive-above-ceiling: _kill_tree target PID" "$fake_pid" "$KILL_TREE_PID"
+
+	if grep -q "FORCE-RECLAIMED stale LLM lockdir.*killing hung owner" "$WRAPPER_LOGFILE" 2>/dev/null; then
+		print_result "LLM alive-above-ceiling: force-reclaim logged" 0
+	else
+		print_result "LLM alive-above-ceiling: force-reclaim logged" 1 "no force-reclaim log line found"
+	fi
+	rm -rf "$llm_lockdir" 2>/dev/null || true
+	return 0
+}
+
+#######################################
 # Main
 #######################################
 main() {
 	setup_sandbox
 
 	echo ""
-	echo "=== Pulse Lock Force-Reclaim Tests (GH#20025 + GH#20260) ==="
+	echo "=== Pulse Lock Force-Reclaim Tests (GH#20025 + GH#20260 + GH#20626) ==="
 	echo ""
 
 	test_live_owner_within_ceiling
@@ -394,6 +548,16 @@ main() {
 	test_env_override_adjusts_ceiling
 	test_double_release_preserves_new_owner
 	test_self_release_removes_own_lock
+
+	echo ""
+	echo "=== LLM Lock Stale Detection Tests (GH#20626) ==="
+	echo ""
+
+	test_llm_lock_no_valid_pid
+	test_llm_lock_dead_pid
+	test_llm_lock_pid_reuse
+	test_llm_lock_alive_within_ceiling
+	test_llm_lock_alive_above_ceiling
 
 	teardown_sandbox
 


### PR DESCRIPTION
## Summary

Hardened _handle_stale_llm_lock in pulse-instance-lock.sh to mirror the robustness of _handle_existing_lock: replaced GNU-only stat -c with portable _get_process_age, added PID reuse guard to prevent killing unrelated processes, switched to _kill_tree/_force_kill_tree for consistent process management, and unified logging to WRAPPER_LOGFILE. Added 5 regression tests covering all three detection tiers plus PID reuse.

## Files Changed

.agents/scripts/pulse-instance-lock.sh,.agents/scripts/tests/test-pulse-lock-force-reclaim.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean on both files; 33/33 tests pass (19 existing + 14 new across 5 LLM lock test cases)

Resolves #20626


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.96 plugin for [OpenCode](https://opencode.ai) v1.14.22 with claude-opus-4-6 spent 6m and 13,538 tokens on this as a headless worker.