### PR TITLE
GH#20627: fix: parameterize fallback global_config_path in generate-runtime-config

### DIFF
--- a/.agents/scripts/generate-runtime-config.sh
+++ b/.agents/scripts/generate-runtime-config.sh
@@ -156,7 +156,7 @@ _generate_greeting_agents_md() {
 		cache_path="~/.aidevops/cache/session-greeting-${runtime_id}.txt"
 		plugin_name="${runtime_id}-aidevops plugin"
 		# shellcheck disable=SC2088
-		global_config_path="~/.config/Claude/Claude.json"
+		global_config_path="~/.config/${runtime_id}/${runtime_id}.json"
 		;;
 	esac
 


### PR DESCRIPTION
## Summary

Parameterized the fallback (*) case in _generate_greeting_agents_md to use ${runtime_id} instead of hardcoding Claude's config path. Finding 1 (change claude-code global_config_path to ~/.claude/settings.json) was premise-falsified — these are two different files serving different purposes.

## Files Changed

.agents/scripts/generate-runtime-config.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck passes, verified edit in context

Resolves #20627


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.96 plugin for [OpenCode](https://opencode.ai) v1.14.22 with claude-opus-4-6 spent 3m and 6,372 tokens on this as a headless worker.