### PR TITLE
GH#20632: fix phase parsing — description strip order and child_ref line-end anchor

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -2544,9 +2544,9 @@
       "pr": 15916
     },
     ".agents/scripts/shared-constants.sh": {
-      "at": "2026-04-22T23:56:55Z",
-      "hash": "8a03b8f8e70a61bda90e2d4cc41999b14310ecd6",
-      "passes": 20,
+      "at": "2026-04-23T23:17:00Z",
+      "hash": "30b46728d9b1dd3d13e673860c43a4f9b8e68236",
+      "passes": 21,
       "pr": 18847
     },
     ".agents/scripts/stats-functions.sh": {
@@ -7486,9 +7486,9 @@
       "pr": 16415
     },
     "TODO.md": {
-      "at": "2026-04-23T21:03:24Z",
-      "hash": "5fa000f90be603deae873480ef3bbedb178c8a4c",
-      "passes": 92,
+      "at": "2026-04-23T23:19:53Z",
+      "hash": "57a63b74a85455e876fe331cd7dad4931dad56df",
+      "passes": 93,
       "pr": 15490
     },
     "aidevops.sh": {
@@ -7576,10 +7576,10 @@
       "passes": 1
     },
     ".agents/reference/shell-style-guide.md": {
-      "hash": "a611a5a02dbd5e29c9813543ef3546f1414608fe",
-      "at": "2026-04-16T21:58:05Z",
+      "hash": "0a2560bc09c5304973263f831563e4add4c13ab3",
+      "at": "2026-04-23T23:16:35Z",
       "pr": 19321,
-      "passes": 1
+      "passes": 2
     },
     ".agents/scripts/tests/test-consolidation-multi-runner.sh": {
       "hash": "a13a53c49a0bb67c640682bee85ec6eca8c9338a",

--- a/.agents/scripts/shared-phase-filing.sh
+++ b/.agents/scripts/shared-phase-filing.sh
@@ -145,10 +145,18 @@ _parse_phases_section() {
 			# Extract phase number
 			phase_num=$(printf '%s' "$line" | grep -oE '[Pp]hase[[:space:]]+[0-9]+' | grep -oE '[0-9]+')
 
-			# Extract description: text after "Phase N" separator (- or :) up to
-			# known marker brackets. Only strip [auto-fire:...] and [requires-decision]
-			# so descriptions containing brackets (e.g. "Fix [bug] in X") are preserved.
-			description=$(printf '%s' "$line" | sed -E 's/^[[:space:]]*-[[:space:]]+[Pp]hase[[:space:]]+[0-9]+[[:space:]]*[-:][[:space:]]*//' | sed -E 's/[[:space:]]*\[(auto-fire|requires-decision)[^]]*\].*//' | sed -E 's/[[:space:]]*#[0-9]+[[:space:]]*$//')
+			# Extract description: text after "Phase N" separator (- or :).
+			# Order matters: strip trailing child ref (#NNN) first, then strip
+			# trailing known marker brackets anchored to end-of-line. This avoids
+			# the marker's greedy .* consuming the child ref and exposing a
+			# description-internal #NNN that the trailing strip then incorrectly
+			# removes. Only strips [auto-fire:...] and [requires-decision] so
+			# descriptions containing other brackets (e.g. "Fix [bug] in X") are
+			# preserved.
+			description=$(printf '%s' "$line" | sed -E \
+				-e 's/^[[:space:]]*-[[:space:]]+[Pp]hase[[:space:]]+[0-9]+[[:space:]]*[-:][[:space:]]*//' \
+				-e 's/[[:space:]]*#[0-9]+[[:space:]]*$//' \
+				-e 's/[[:space:]]*\[(auto-fire|requires-decision)[^]]*\][[:space:]]*$//')
 
 			# Determine marker
 			if printf '%s' "$line" | grep -qiF '[auto-fire:on-prior-merge]'; then
@@ -159,10 +167,12 @@ _parse_phases_section() {
 				marker="none"
 			fi
 
-			# Extract child issue reference: the last #NNNN on the line.
-			# Child refs appear after marker brackets so tail -1 selects correctly
-			# even when the description also contains issue references.
-			child_ref=$(printf '%s' "$line" | grep -oE '#[0-9]+' | tail -1 | grep -oE '[0-9]+')
+			# Extract child issue reference: a trailing bare #NNNN at end of line.
+			# Anchoring to line-end (rather than tail -1 on all matches) prevents
+			# false positives where the description contains a #NNN reference but
+			# no child ref is actually present. Child refs are stored as " #NNN"
+			# at end of line by _update_parent_phases_section.
+			child_ref=$(printf '%s' "$line" | sed -nE 's/.*#([0-9]+)[[:space:]]*$/\1/p')
 
 			printf '%s\t%s\t%s\t%s\n' "$phase_num" "$description" "$marker" "$child_ref"
 		fi


### PR DESCRIPTION
## Summary

Addresses two review bot findings from PR #20531 on `shared-phase-filing.sh::_parse_phases_section()`.

### Fix 1: description extraction ordering (line 151)

The previous pipeline stripped the marker bracket with `.*` (greedy), which consumed everything after the marker including the trailing child ref. The subsequent `#NNN$` strip then incorrectly removed description-internal issue references that were exposed after the marker was eaten.

Fix: swap order — strip trailing bare `#NNN` first (before any marker is removed), then strip the trailing marker bracket anchored to `$`. Collapsed into a single `sed -e` chain for clarity.

### Fix 2: child_ref anchored to line-end (line 165)

The previous `grep -oE '#[0-9]+' | tail -1 | grep -oE '[0-9]+'` returned the last `#NNN` found *anywhere* on the line. If the description contained a `#NNN` reference but no child ref was appended at end of line, that description reference became a false-positive `child_ref`, causing `auto_file_next_phase` to skip filing the phase (incorrectly treating it as already-filed).

Fix: `sed -nE 's/.*#([0-9]+)[[:space:]]*$/\1/p'` — anchors the match to end of line. Returns empty when no trailing bare `#NNN` is present, which is the correct signal for "not yet filed".

Child refs are stored as bare ` #NNN` at end of line by `_update_parent_phases_section` (line 254), so `$` anchoring is correct for the actual storage format.

Resolves #20632

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.96 plugin for [OpenCode](https://opencode.ai) v1.14.22 with claude-sonnet-4-6 spent 7m and 17,846 tokens on this as a headless worker.
