### PR TITLE
GH#20628: align Linux/cron interval label with launchd modulo-60 logic

### DIFF
--- a/.agents/configs/simplification-state.json
+++ b/.agents/configs/simplification-state.json
@@ -2544,9 +2544,9 @@
       "pr": 15916
     },
     ".agents/scripts/shared-constants.sh": {
-      "at": "2026-04-22T23:56:55Z",
-      "hash": "8a03b8f8e70a61bda90e2d4cc41999b14310ecd6",
-      "passes": 20,
+      "at": "2026-04-23T23:17:00Z",
+      "hash": "30b46728d9b1dd3d13e673860c43a4f9b8e68236",
+      "passes": 21,
       "pr": 18847
     },
     ".agents/scripts/stats-functions.sh": {
@@ -7486,9 +7486,9 @@
       "pr": 16415
     },
     "TODO.md": {
-      "at": "2026-04-23T21:03:24Z",
-      "hash": "5fa000f90be603deae873480ef3bbedb178c8a4c",
-      "passes": 92,
+      "at": "2026-04-23T23:19:53Z",
+      "hash": "57a63b74a85455e876fe331cd7dad4931dad56df",
+      "passes": 93,
       "pr": 15490
     },
     "aidevops.sh": {
@@ -7576,10 +7576,10 @@
       "passes": 1
     },
     ".agents/reference/shell-style-guide.md": {
-      "hash": "a611a5a02dbd5e29c9813543ef3546f1414608fe",
-      "at": "2026-04-16T21:58:05Z",
+      "hash": "0a2560bc09c5304973263f831563e4add4c13ab3",
+      "at": "2026-04-23T23:16:35Z",
       "pr": 19321,
-      "passes": 1
+      "passes": 2
     },
     ".agents/scripts/tests/test-consolidation-multi-runner.sh": {
       "hash": "a13a53c49a0bb67c640682bee85ec6eca8c9338a",

--- a/setup-modules/schedulers.sh
+++ b/setup-modules/schedulers.sh
@@ -344,12 +344,12 @@ _install_supervisor_pulse() {
 	_pulse_interval_sec=$(_read_pulse_interval_seconds)
 	local _pulse_cron_schedule
 	_pulse_cron_schedule=$(_seconds_to_cron_schedule "$_pulse_interval_sec")
-	# Build a human-readable interval label: show seconds when < 60s, minutes otherwise
+	# Build a human-readable interval label: show minutes for exact multiples of 60, seconds otherwise
 	local _pulse_interval_label
-	if [[ "$_pulse_interval_sec" -lt 60 ]]; then
-		_pulse_interval_label="${_pulse_interval_sec}s"
+	if (( _pulse_interval_sec % 60 == 0 )); then
+		_pulse_interval_label="$((_pulse_interval_sec / 60)) min"
 	else
-		_pulse_interval_label="$((_pulse_interval_sec / 60))min"
+		_pulse_interval_label="${_pulse_interval_sec}s"
 	fi
 
 	local _pulse_timeout_sec=$((PULSE_STALE_THRESHOLD_SECONDS + 60))


### PR DESCRIPTION
## Summary

Aligns the Linux/cron interval label logic in `_install_supervisor_pulse` with the launchd path fixed in PR #20537.

- Applied the `% 60 == 0` modulo check (replacing the old `< 60` integer comparison) so non-multiples of 60 display as seconds instead of truncated minutes (e.g. `90s` not `1min`)
- Standardized spacing to `"X min"` (with space) across both platform paths

**Files changed:** `setup-modules/schedulers.sh:347-353`

Resolves #20628

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.96 plugin for [OpenCode](https://opencode.ai) v1.14.22 with claude-opus-4-6 spent 3m and 3,255 tokens on this as a headless worker. Overall, 1h 59m since this issue was created.