### PR TITLE
GH#20629: fix: restore stderr suppression and clear node-ID cache per repo

### DIFF
--- a/.agents/scripts/issue-sync-relationships.sh
+++ b/.agents/scripts/issue-sync-relationships.sh
@@ -103,7 +103,7 @@ _cached_node_id() {
 	# Uses the same core-pool 5000/hr budget that the t2574 write-path fallbacks use.
 	if _gh_should_fallback_to_rest; then
 		local rest_nid
-		rest_nid=$(gh api "/repos/${repo}/issues/${num}" --jq '.node_id // ""' || echo "")
+		rest_nid=$(gh api "/repos/${repo}/issues/${num}" --jq '.node_id // ""' 2>/dev/null || echo "")
 		if [[ -n "$rest_nid" ]]; then
 			echo "${num}=${rest_nid}" >>"$_NODE_ID_CACHE_FILE"
 			echo "$rest_nid"
@@ -947,6 +947,11 @@ _backfill_process_loop() {
 	# Without this, each _cached_node_id() subshell creates its own temp file and
 	# cache hits between issues are lost.
 	_init_node_id_cache
+	# Clear cache to prevent cross-repo poisoning in long-lived processes.
+	# Cache key is just the issue number (e.g. "123=node_id") — without repo
+	# qualification, stale entries from a prior repo would be returned for
+	# same-numbered issues in a different repo.
+	: >"$_NODE_ID_CACHE_FILE"
 
 	local linked
 	local skipped


### PR DESCRIPTION
## Summary

Applied two review-followup fixes from PR #20536: (1) restored 2>/dev/null on gh api REST fallback in _cached_node_id to prevent stderr noise in loop contexts, (2) added cache-file clearing at the start of _backfill_process_loop to prevent cross-repo node-ID poisoning when the same process handles multiple repos

## Files Changed

.agents/scripts/issue-sync-relationships.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck -x passes with no new findings; both changes are minimal and defensively correct

Resolves #20629


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.96 plugin for [OpenCode](https://opencode.ai) v1.14.22 with claude-opus-4-6 spent 3m and 3,762 tokens on this as a headless worker.