### PR TITLE
GH#20624: fix: use explicit empty-string guards for PGID pipeline fallbacks

### DIFF
--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -403,8 +403,10 @@ _dlw_exec_detached() {
 		worker_pid="$!"
 		# Log the detached PGID for diagnostics (should differ from pulse PGID)
 		local worker_pgid pulse_pgid
-		worker_pgid=$(ps -o pgid= -p "$worker_pid" 2>/dev/null | tr -d ' ') || worker_pgid="unknown"
-		pulse_pgid=$(ps -o pgid= -p "$$" 2>/dev/null | tr -d ' ') || pulse_pgid="unknown"
+		worker_pgid=$(ps -o pgid= -p "$worker_pid" 2>/dev/null | tr -d ' ')
+		[[ -n "$worker_pgid" ]] || worker_pgid="unknown"
+		pulse_pgid=$(ps -o pgid= -p "$$" 2>/dev/null | tr -d ' ')
+		[[ -n "$pulse_pgid" ]] || pulse_pgid="unknown"
 		echo "[dispatch_worker_launch] Issue #${issue_number}: worker PID=$worker_pid PGID=$worker_pgid (setsid detached from pulse PGID=$pulse_pgid)" >>"$LOGFILE"
 	else
 		echo "[dispatch_worker_launch] Warning: setsid not found — worker will share pulse's PGID; install util-linux (Linux) or upgrade macOS 12+ for signal isolation" >>"$LOGFILE"


### PR DESCRIPTION
## Summary

Replace pipeline exit-code fallbacks with explicit empty-string guards for worker/pulse PGID variables in _dlw_exec_detached. The ps|tr pipeline masks ps failures because tr always exits 0, so the || fallback never triggers. Now uses [[ -n ]] checks instead.

## Files Changed

.agents/scripts/pulse-dispatch-worker-launch.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck passes clean, pre-commit hooks pass

Resolves #20624


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.8.96 plugin for [OpenCode](https://opencode.ai) v1.14.22 with claude-opus-4-6 spent 1m and 2,000 tokens on this as a headless worker.