### PR TITLE
t2771: pulse: deterministic phase-extractor for well-formed parent-task bodies

### DIFF
--- a/.agents/scripts/parent-task-phase-extractor.sh
+++ b/.agents/scripts/parent-task-phase-extractor.sh
@@ -1,0 +1,435 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# parent-task-phase-extractor.sh — Deterministic phase extractor for well-formed parent-task bodies
+#
+# Detects and files phases from parent-task issue bodies that follow the
+# well-formed phase template. Zero LLM, zero paraphrasing — pure regex +
+# verbatim text extraction.
+#
+# Complements auto-decomposer-scanner.sh (which handles the general case via
+# LLM). This scanner short-circuits for parent bodies that already contain a
+# fully-written phase plan, avoiding hallucination risk on already-written
+# content.
+#
+# Detection algorithm (all conditions must hold for EVERY phase):
+#   - ^### Phase \d+: heading line
+#   - At least one ^- EDIT: or ^- NEW: line in the phase section
+#   - **Reference pattern:** sub-section present
+#   - **Verification:** sub-section present
+#   - **Acceptance:** sub-section present with ≥1 criterion bullet (^- )
+#
+# Fail-safe: if ANY phase is missing ANY required sub-section, the scanner
+# NO-OPs entirely. All-or-nothing. Partial extraction is not performed.
+#
+# Dispatch guard: parents carrying no-auto-dispatch are skipped unconditionally.
+#
+# Usage:
+#   parent-task-phase-extractor.sh check  ISSUE_NUM SLUG   — exit 0 if eligible
+#   parent-task-phase-extractor.sh run    ISSUE_NUM SLUG   — detect + file + update
+#   parent-task-phase-extractor.sh help                    — usage message
+#
+# Exit codes for run:
+#   0 — fired: at least one child issue filed
+#   1 — no-op: body not eligible (missing sub-sections, <2 phases, no-auto-dispatch, or error)
+#
+# Env:
+#   PHASE_EXTRACTOR_DRY_RUN    (default 0) — 1 = log intent without side effects
+#   PHASE_EXTRACTOR_MIN_PHASES (default 2) — minimum phases required for eligibility
+#
+# t2771: https://github.com/marcusquinn/aidevops/issues/20641
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=shared-constants.sh
+[ -f "${SCRIPT_DIR}/shared-constants.sh" ] && source "${SCRIPT_DIR}/shared-constants.sh"
+
+PHASE_EXTRACTOR_DRY_RUN="${PHASE_EXTRACTOR_DRY_RUN:-0}"
+PHASE_EXTRACTOR_MIN_PHASES="${PHASE_EXTRACTOR_MIN_PHASES:-2}"
+
+# Generator marker for pre-dispatch-validator compatibility.
+readonly PHASE_EXTRACTOR_GENERATOR_MARKER="aidevops:generator=phase-extractor"
+
+log() { printf '[phase-extractor] %s\n' "$*" >&2; }
+
+#######################################
+# Enumerate phases from a parent issue body. For each ### Phase N: block,
+# checks all required sub-sections and emits a single-line record:
+#   PHASE_NUM<TAB>HEADING<TAB>STATUS
+# where STATUS is "complete" or "incomplete".
+#
+# All detection logic runs inside awk to avoid multi-line shell variable
+# handling issues. The caller reads only single-line records.
+#
+# Args: $1=body_content (may be multi-line)
+# Output: one tab-separated line per phase
+# Returns: 0 always
+#######################################
+_enumerate_phases_metadata() {
+	local body="$1"
+	[ -n "$body" ] || return 0
+
+	printf '%s\n' "$body" | awk '
+		BEGIN {
+			phase_num=""; heading=""
+			has_edit=0; has_ref=0; has_verify=0; has_accept=0; has_bullet=0
+			in_accept=0
+		}
+
+		/^### Phase [0-9]+:/ {
+			if (phase_num != "") _emit_phase()
+			phase_num = $0
+			sub(/^### Phase /, "", phase_num)
+			sub(/:.*/, "", phase_num)
+			heading = $0
+			sub(/^### Phase [0-9]+:[[:space:]]*/, "", heading)
+			has_edit=0; has_ref=0; has_verify=0; has_accept=0; has_bullet=0
+			in_accept=0
+			next
+		}
+
+		phase_num != "" {
+			if ($0 ~ /^- (EDIT|NEW):/) has_edit=1
+			if (index($0, "**Reference pattern:**") > 0) has_ref=1
+			if (index($0, "**Verification:**") > 0) has_verify=1
+			if (index($0, "**Acceptance:**") > 0) {
+				has_accept=1; in_accept=1
+			}
+			if (in_accept && $0 ~ /^- /) has_bullet=1
+			# A different bold heading ends the acceptance section
+			if (in_accept && $0 ~ /^\*\*[^*]+\*\*/ && \
+				index($0, "**Acceptance:**") == 0) in_accept=0
+		}
+
+		END { if (phase_num != "") _emit_phase() }
+
+		function _emit_phase(    status) {
+			status = (has_edit && has_ref && has_verify && has_accept && has_bullet) \
+				? "complete" : "incomplete"
+			printf "%s\t%s\t%s\n", phase_num, heading, status
+		}
+	'
+	return 0
+}
+
+#######################################
+# Extract the raw block content for a single phase (all lines from
+# ^### Phase N: up to the next ^### Phase or end of body).
+#
+# Args: $1=body_content, $2=phase_num
+# Output: block content on stdout (multi-line)
+# Returns: 0 always
+#######################################
+_extract_phase_block() {
+	local body="$1"
+	local target="$2"
+
+	printf '%s\n' "$body" | awk -v t="$target" '
+		$0 ~ ("^### Phase " t ":") { found=1; print; next }
+		found && /^### Phase [0-9]+:/ { exit }
+		found { print }
+	'
+	return 0
+}
+
+#######################################
+# Check whether a parent issue body is eligible for phase extraction.
+# Eligibility: ≥PHASE_EXTRACTOR_MIN_PHASES phase blocks AND all complete.
+#
+# Args: $1=body_content
+# Returns: 0 if eligible, 1 if not
+#######################################
+_body_is_eligible() {
+	local body="$1"
+	[ -n "$body" ] || return 1
+
+	local phase_count=0
+	local all_complete=1
+
+	# Read single-line metadata records from awk — no multi-line issues.
+	while IFS='	' read -r p_num _heading status; do
+		[ -n "$p_num" ] || continue
+		phase_count=$((phase_count + 1))
+		[ "$status" = "complete" ] || all_complete=0
+	done < <(_enumerate_phases_metadata "$body")
+
+	[ "$phase_count" -ge "$PHASE_EXTRACTOR_MIN_PHASES" ] || return 1
+	[ "$all_complete" -eq 1 ] || return 1
+	return 0
+}
+
+#######################################
+# Build the issue body for a child phase issue. Verbatim copy of the phase
+# section from the parent + auto-generated ## Context block linking back.
+#
+# Uses "For #NNN" (NOT Closes/Resolves) per the parent-task PR keyword rule.
+#
+# Args: $1=parent_num, $2=parent_title, $3=phase_num, $4=phase_heading,
+#       $5=phase_block, $6=repo_slug
+# Output: issue body on stdout
+# Returns: 0 always
+#######################################
+_build_child_body() {
+	local parent_num="$1"
+	local parent_title="$2"
+	local phase_num="$3"
+	local phase_heading="$4"
+	local phase_block="$5"
+	local repo_slug="$6"
+
+	cat <<MD
+<!-- ${PHASE_EXTRACTOR_GENERATOR_MARKER} parent=${parent_num} phase=${phase_num} -->
+
+## What
+
+${phase_block}
+
+## Context
+
+Auto-filed from parent-task [#${parent_num}](https://github.com/${repo_slug}/issues/${parent_num}) — _${parent_title}_ — via deterministic phase extraction (t2771).
+
+Phase content is verbatim from the parent body. No LLM paraphrasing was applied.
+
+For #${parent_num}
+
+## Session Origin
+
+Auto-filed by \`parent-task-phase-extractor.sh\` (t2771). Verbatim extraction from parent #${parent_num} Phase ${phase_num}.
+MD
+	return 0
+}
+
+#######################################
+# Append a ## Children section to the parent issue body, or add new child
+# lines to an existing ## Children section.
+#
+# Args: $1=current_body, $2=child_lines (newline-separated "- #NNN — ...")
+# Output: updated body on stdout
+# Returns: 0 always
+#######################################
+_append_children_section() {
+	local body="$1"
+	local child_lines="$2"
+	[ -n "$child_lines" ] || { printf '%s' "$body"; return 0; }
+
+	if printf '%s\n' "$body" | grep -qE '^## Children'; then
+		# Append to existing section
+		printf '%s\n' "$body" | awk -v lines="$child_lines" '
+			/^## Children/ { found=1 }
+			found && /^## / && !/^## Children/ {
+				print lines
+				found=0
+			}
+			{ print }
+			END { if (found) print lines }
+		'
+	else
+		# Append new ## Children section at the end
+		printf '%s\n' "$body"
+		printf '\n## Children\n\n%s\n' "$child_lines"
+	fi
+	return 0
+}
+
+#######################################
+# Run the phase extractor against a parent issue. Fetches the body from
+# GitHub, checks eligibility, files child issues, updates parent body.
+#
+# Args: $1=issue_num, $2=repo_slug
+# Returns: 0 if fired (children filed), 1 if no-op
+#######################################
+_run_extractor() {
+	local issue_num="$1"
+	local repo_slug="$2"
+
+	# Fetch parent issue body and title in a single API call
+	local parent_json
+	parent_json=$(gh api "repos/${repo_slug}/issues/${issue_num}" \
+		--jq '{body: (.body // ""), title: (.title // ""), labels: [.labels[].name]}' \
+		2>/dev/null) || parent_json=""
+	if [ -z "$parent_json" ]; then
+		log "#${issue_num}: failed to fetch issue, no-op"
+		return 1
+	fi
+
+	local parent_body parent_title parent_labels
+	parent_body=$(printf '%s' "$parent_json" | jq -r '.body // ""')
+	parent_title=$(printf '%s' "$parent_json" | jq -r '.title // ""')
+	parent_labels=$(printf '%s' "$parent_json" | jq -r '.labels | join(",")')
+
+	# Dispatch guard: skip parents with no-auto-dispatch (user opt-out)
+	case ",${parent_labels}," in
+	*",no-auto-dispatch,"*)
+		log "#${issue_num}: carries no-auto-dispatch, no-op"
+		return 1
+		;;
+	esac
+
+	# Eligibility check
+	if ! _body_is_eligible "$parent_body"; then
+		log "#${issue_num}: body not eligible (missing sub-sections or <${PHASE_EXTRACTOR_MIN_PHASES} phases)"
+		return 1
+	fi
+
+	log "#${issue_num}: eligible — filing phases"
+
+	local filed_count=0
+	local child_lines=""
+
+	# Determine tier label to inherit from parent (default tier:standard)
+	local child_tier="tier:standard"
+	case ",${parent_labels}," in
+	*",tier:thinking,"*) child_tier="tier:thinking" ;;
+	esac
+
+	while IFS='	' read -r phase_num phase_heading _status; do
+		[ -n "$phase_num" ] || continue
+
+		# Extract full verbatim block for this phase
+		local phase_block
+		phase_block=$(_extract_phase_block "$parent_body" "$phase_num")
+
+		local child_title="${parent_title}: Phase ${phase_num} — ${phase_heading}"
+
+		if [ "$PHASE_EXTRACTOR_DRY_RUN" = "1" ]; then
+			log "[DRY-RUN] Would file: ${child_title}"
+			filed_count=$((filed_count + 1))
+			child_lines="${child_lines}- #DRY_RUN — Phase ${phase_num}: ${phase_heading}
+"
+			continue
+		fi
+
+		local child_body
+		child_body=$(_build_child_body \
+			"$issue_num" "$parent_title" "$phase_num" "$phase_heading" \
+			"$phase_block" "$repo_slug")
+
+		# Append signature footer if helper is available
+		local sig=""
+		local sig_helper="${SCRIPT_DIR}/gh-signature-helper.sh"
+		[ -x "$sig_helper" ] && sig=$("$sig_helper" footer 2>/dev/null || true)
+
+		local new_issue_url
+		new_issue_url=$(gh_create_issue --repo "$repo_slug" \
+			--title "$child_title" \
+			--label "auto-dispatch,${child_tier},origin:worker" \
+			--body "${child_body}${sig}" 2>/dev/null) || new_issue_url=""
+
+		if [ -z "$new_issue_url" ]; then
+			log "#${issue_num}: failed to file Phase ${phase_num} child, aborting"
+			# Partial extraction is not permitted — return 1 so caller
+			# falls back to nudge path. Children already filed stay open.
+			return 1
+		fi
+
+		local new_issue_num
+		new_issue_num=$(printf '%s' "$new_issue_url" | grep -oE '[0-9]+$')
+		log "#${issue_num}: filed Phase ${phase_num} as #${new_issue_num}: ${phase_heading}"
+		filed_count=$((filed_count + 1))
+		child_lines="${child_lines}- #${new_issue_num} — Phase ${phase_num}: ${phase_heading}
+"
+	done < <(_enumerate_phases_metadata "$parent_body")
+
+	[ "$filed_count" -gt 0 ] || return 1
+
+	if [ "$PHASE_EXTRACTOR_DRY_RUN" = "1" ]; then
+		log "[DRY-RUN] Would update parent #${issue_num} ## Children section"
+		return 0
+	fi
+
+	# Update parent body with ## Children section
+	local updated_body
+	local child_lines_trimmed="${child_lines%$'\n'}"
+	updated_body=$(_append_children_section "$parent_body" "$child_lines_trimmed")
+
+	gh_issue_edit_safe "$issue_num" --repo "$repo_slug" \
+		--body "$updated_body" 2>/dev/null || true
+
+	log "#${issue_num}: updated ## Children section with ${filed_count} phase(s)"
+	return 0
+}
+
+#######################################
+# check subcommand — exit 0 if parent is eligible, 1 if not.
+# Does not file any issues.
+#######################################
+_cmd_check() {
+	local issue_num="$1"
+	local repo_slug="$2"
+
+	local parent_body
+	parent_body=$(gh api "repos/${repo_slug}/issues/${issue_num}" \
+		--jq '.body // ""' 2>/dev/null) || parent_body=""
+	if [ -z "$parent_body" ]; then
+		log "check: failed to fetch #${issue_num}"
+		return 1
+	fi
+
+	if _body_is_eligible "$parent_body"; then
+		printf 'eligible\n'
+		return 0
+	else
+		printf 'ineligible\n'
+		return 1
+	fi
+}
+
+main() {
+	local command="${1:-}"
+	case "$command" in
+	run)
+		local issue_num="${2:-}" repo_slug="${3:-}"
+		if [ -z "$issue_num" ] || [ -z "$repo_slug" ]; then
+			printf 'Usage: %s run ISSUE_NUM SLUG\n' "$(basename "$0")" >&2
+			return 2
+		fi
+		_run_extractor "$issue_num" "$repo_slug"
+		;;
+	check)
+		local issue_num="${2:-}" repo_slug="${3:-}"
+		if [ -z "$issue_num" ] || [ -z "$repo_slug" ]; then
+			printf 'Usage: %s check ISSUE_NUM SLUG\n' "$(basename "$0")" >&2
+			return 2
+		fi
+		_cmd_check "$issue_num" "$repo_slug"
+		;;
+	-h | --help | help)
+		cat <<EOF
+Usage: $(basename "$0") {run|check|help} ISSUE_NUM SLUG
+
+  run    ISSUE_NUM SLUG   Detect well-formed phases and file each as a child issue.
+                          Exits 0 if children were filed, 1 if body was not eligible.
+  check  ISSUE_NUM SLUG   Check eligibility without filing. Prints "eligible" or
+                          "ineligible" and exits accordingly.
+  help                    This message.
+
+Detection criteria (all required for every phase):
+  - ### Phase N: heading
+  - At least one "- EDIT:" or "- NEW:" line
+  - **Reference pattern:** sub-section
+  - **Verification:** sub-section
+  - **Acceptance:** sub-section with ≥1 bullet
+
+If ANY phase is missing ANY sub-section, the extractor NO-OPs entirely.
+Parents carrying no-auto-dispatch are always skipped.
+
+Env vars:
+  PHASE_EXTRACTOR_DRY_RUN    (default 0)  Set to 1 to log intent without side effects.
+  PHASE_EXTRACTOR_MIN_PHASES (default 2)  Minimum phase count for eligibility.
+
+t2771: https://github.com/marcusquinn/aidevops/issues/20641
+EOF
+		;;
+	*)
+		printf 'ERROR: Unknown command %q\n' "${command}" >&2
+		printf 'Usage: %s {run|check|help} ISSUE_NUM SLUG\n' "$(basename "$0")" >&2
+		return 2
+		;;
+	esac
+	return 0
+}
+
+# Source guard: only run main() when executed as a script, not when sourced
+# by the test harness.
+(return 0 2>/dev/null) || main "$@"

--- a/.agents/scripts/pulse-issue-reconcile.sh
+++ b/.agents/scripts/pulse-issue-reconcile.sh
@@ -1477,7 +1477,22 @@ reconcile_completed_parent_tasks() {
 			# idempotency marker means it returns 1 after the first cycle;
 			# we need the separate escalation path so the maintainer
 			# actually sees the issue in their review queue.
+			#
+			# t2771: before nudging/escalating, try the deterministic
+			# phase-extractor. When the parent body follows the well-formed
+			# phase template (### Phase N: headings with all required
+			# sub-sections), the extractor files children verbatim without
+			# an LLM pass. If the extractor fires (exit 0), skip
+			# nudge/escalation — children are now in flight.
 			if [[ -z "$child_nums" ]]; then
+				local _phase_extractor="${_PIR_SCRIPT_DIR}/parent-task-phase-extractor.sh"
+				if [[ -x "$_phase_extractor" ]]; then
+					if PHASE_EXTRACTOR_DRY_RUN="${PHASE_EXTRACTOR_DRY_RUN:-0}" \
+						"$_phase_extractor" run "$issue_num" "$slug" >>"${LOGFILE:-/dev/null}" 2>&1; then
+						echo "[pulse-wrapper] Reconcile parent-task: phase-extractor filed children for #${issue_num} in ${slug} (t2771)" >>"${LOGFILE:-/dev/null}"
+						continue
+					fi
+				fi
 				if [[ "$total_nudged" -lt "$max_nudges" ]]; then
 					if _post_parent_decomposition_nudge "$slug" "$issue_num" "$issue_title"; then
 						total_nudged=$((total_nudged + 1))

--- a/.agents/scripts/tests/test-parent-task-phase-extractor.sh
+++ b/.agents/scripts/tests/test-parent-task-phase-extractor.sh
@@ -1,0 +1,501 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# shellcheck disable=SC2016  # single-quoted regex patterns are literal by design
+#
+# test-parent-task-phase-extractor.sh — structural + unit tests for t2771
+#
+# Verifies:
+#   1.  parent-task-phase-extractor.sh is executable and shellcheck-clean
+#   2.  help subcommand works and documents all three subcommands
+#   3.  Unknown subcommand returns non-zero
+#   4.  Detection: well-formed body with 2+ phases → eligible
+#   5.  Detection: body with EDIT:/NEW: missing → ineligible
+#   6.  Detection: body with **Reference pattern:** missing → ineligible
+#   7.  Detection: body with **Verification:** missing → ineligible
+#   8.  Detection: body with **Acceptance:** missing → ineligible
+#   9.  Detection: body with **Acceptance:** present but no bullet → ineligible
+#   10. Detection: only 1 qualifying phase (below min threshold) → ineligible
+#   11. Detection: mixed body — one complete phase, one incomplete → ineligible (all-or-nothing)
+#   12. Detection: canonical #20622-shaped body with 4 phases → eligible
+#   13. Extractor carries generator marker compatible with pre-dispatch validators
+#   14. Extractor uses For #NNN (not Closes/Resolves) per parent-task PR keyword rule
+#   15. Extractor child label set includes auto-dispatch, tier:standard, origin:worker
+#   16. Extractor skips no-auto-dispatch parents (dispatch guard)
+#   17. Wiring: pulse-issue-reconcile.sh calls phase-extractor before nudge/escalation
+#   18. Wiring: call in reconcile uses _PIR_SCRIPT_DIR path for extractor
+#
+# This is a structural + unit test — no live GitHub API calls are made.
+# Detection logic is tested via function sourcing and synthetic bodies.
+
+set -u
+
+if [ -t 1 ]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_BLUE=$'\033[0;34m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_BLUE="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+assert_grep() {
+	local label="$1" pattern="$2" file="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if grep -qE "$pattern" "$file" 2>/dev/null; then
+		printf '%sPASS%s: %s\n' "$TEST_GREEN" "$TEST_NC" "$label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		printf '%sFAIL%s: %s\n' "$TEST_RED" "$TEST_NC" "$label"
+		printf '  expected pattern: %s\n' "$pattern"
+		printf '  in file:          %s\n' "$file"
+	fi
+	return 0
+}
+
+assert_grep_fixed() {
+	local label="$1" pattern="$2" file="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if grep -qF -- "$pattern" "$file" 2>/dev/null; then
+		printf '%sPASS%s: %s\n' "$TEST_GREEN" "$TEST_NC" "$label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		printf '%sFAIL%s: %s\n' "$TEST_RED" "$TEST_NC" "$label"
+		printf '  expected literal: %s\n' "$pattern"
+		printf '  in file:          %s\n' "$file"
+	fi
+	return 0
+}
+
+assert_rc() {
+	local label="$1" expected="$2" actual="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [ "$expected" = "$actual" ]; then
+		printf '%sPASS%s: %s\n' "$TEST_GREEN" "$TEST_NC" "$label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		printf '%sFAIL%s: %s\n' "$TEST_RED" "$TEST_NC" "$label"
+		printf '  expected rc=%s, got rc=%s\n' "$expected" "$actual"
+	fi
+	return 0
+}
+
+assert_true() {
+	local label="$1" condition="$2"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [ "$condition" = "0" ]; then
+		printf '%sPASS%s: %s\n' "$TEST_GREEN" "$TEST_NC" "$label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		printf '%sFAIL%s: %s (condition returned %s)\n' "$TEST_RED" "$TEST_NC" "$label" "$condition"
+	fi
+	return 0
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")/.." && pwd)"
+EXTRACTOR="$SCRIPT_DIR/parent-task-phase-extractor.sh"
+RECONCILE="$SCRIPT_DIR/pulse-issue-reconcile.sh"
+
+for required in "$EXTRACTOR" "$RECONCILE"; do
+	if [ ! -f "$required" ]; then
+		printf '%sFATAL%s: %s not found\n' "$TEST_RED" "$TEST_NC" "$required"
+		exit 1
+	fi
+done
+
+printf '%s=== t2771: parent-task phase extractor tests ===%s\n\n' "$TEST_BLUE" "$TEST_NC"
+
+# ─── 1. Executable ────────────────────────────────────────────────────────────
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if [ -x "$EXTRACTOR" ]; then
+	printf '%sPASS%s: 1: extractor is executable\n' "$TEST_GREEN" "$TEST_NC"
+else
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '%sFAIL%s: 1: extractor is NOT executable\n' "$TEST_RED" "$TEST_NC"
+fi
+
+# ─── 2. Help subcommand ───────────────────────────────────────────────────────
+
+help_output=$("$EXTRACTOR" help 2>&1)
+help_rc=$?
+assert_rc "2a: 'help' returns 0" "0" "$help_rc"
+
+TESTS_RUN=$((TESTS_RUN + 1))
+case "$help_output" in
+*"run"*"check"*"help"*)
+	printf '%sPASS%s: 2b: help output lists run / check / help subcommands\n' "$TEST_GREEN" "$TEST_NC"
+	;;
+*)
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '%sFAIL%s: 2b: help output is malformed\n' "$TEST_RED" "$TEST_NC"
+	;;
+esac
+
+TESTS_RUN=$((TESTS_RUN + 1))
+case "$help_output" in
+*"PHASE_EXTRACTOR_DRY_RUN"*"PHASE_EXTRACTOR_MIN_PHASES"*)
+	printf '%sPASS%s: 2c: help output documents env vars\n' "$TEST_GREEN" "$TEST_NC"
+	;;
+*)
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '%sFAIL%s: 2c: help output missing env var documentation\n' "$TEST_RED" "$TEST_NC"
+	;;
+esac
+
+# ─── 3. Unknown subcommand ────────────────────────────────────────────────────
+
+"$EXTRACTOR" bogus 2>/dev/null
+bogus_rc=$?
+TESTS_RUN=$((TESTS_RUN + 1))
+if [ "$bogus_rc" -ne 0 ]; then
+	printf '%sPASS%s: 3: unknown subcommand returns non-zero (rc=%s)\n' "$TEST_GREEN" "$TEST_NC" "$bogus_rc"
+else
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '%sFAIL%s: 3: unknown subcommand should return non-zero\n' "$TEST_RED" "$TEST_NC"
+fi
+
+# ─── Source extractor for unit tests ─────────────────────────────────────────
+# Source the extractor in a subshell context so its functions are available
+# without triggering main(). We use BASH_SOURCE source-guard.
+# shellcheck source=/dev/null
+source "$EXTRACTOR" 2>/dev/null || true
+
+# Build a canonical well-formed phase block (all 5 required sub-sections present)
+_canonical_phase() {
+	local n="$1" desc="${2:-Do the work}"
+	cat <<PHASE
+### Phase ${n}: ${desc}
+
+- EDIT: \`some-script.sh\` — replace old pattern with new pattern
+
+**Reference pattern:** See \`shared-constants.sh\` function \`safe_grep_count\`.
+
+**Verification:**
+\`\`\`bash
+shellcheck .agents/scripts/some-script.sh
+\`\`\`
+
+**Acceptance:**
+- some-script.sh passes shellcheck
+- old pattern no longer present
+PHASE
+	return 0
+}
+
+# Build a body with N canonical phases separated by blank lines
+_body_with_phases() {
+	local n="$1"
+	local i=1
+	while [ "$i" -le "$n" ]; do
+		_canonical_phase "$i" "Phase $i task"
+		printf '\n'
+		i=$((i + 1))
+	done
+	return 0
+}
+
+# ─── 4. Well-formed body with 2+ phases is eligible ──────────────────────────
+
+body_2_phases=$(_body_with_phases 2)
+if _body_is_eligible "$body_2_phases"; then
+	eligible_rc=0
+else
+	eligible_rc=1
+fi
+assert_rc "4: well-formed 2-phase body → eligible" "0" "$eligible_rc"
+
+# ─── 5. Missing EDIT:/NEW: lines → ineligible ────────────────────────────────
+# Using single-quoted multi-line string (no heredoc-in-subshell).
+
+body_no_edit='### Phase 1: Some work
+
+**Reference pattern:** See `shared-constants.sh`.
+
+**Verification:**
+```bash
+echo ok
+```
+
+**Acceptance:**
+- criteria met
+
+### Phase 2: More work
+
+**Reference pattern:** See `shared-constants.sh`.
+
+**Verification:**
+```bash
+echo ok
+```
+
+**Acceptance:**
+- criteria met'
+
+if _body_is_eligible "$body_no_edit"; then
+	no_edit_rc=0
+else
+	no_edit_rc=1
+fi
+assert_rc "5: body missing EDIT:/NEW: → ineligible" "1" "$no_edit_rc"
+
+# ─── 6. Missing **Reference pattern:** → ineligible ──────────────────────────
+
+body_no_ref='### Phase 1: Some work
+
+- EDIT: `some-script.sh` — fix it
+
+**Verification:**
+```bash
+echo ok
+```
+
+**Acceptance:**
+- criteria met
+
+### Phase 2: More work
+
+- EDIT: `other-script.sh` — fix it
+
+**Verification:**
+```bash
+echo ok
+```
+
+**Acceptance:**
+- criteria met'
+
+if _body_is_eligible "$body_no_ref"; then
+	no_ref_rc=0
+else
+	no_ref_rc=1
+fi
+assert_rc "6: body missing **Reference pattern:** → ineligible" "1" "$no_ref_rc"
+
+# ─── 7. Missing **Verification:** → ineligible ────────────────────────────────
+
+body_no_verify='### Phase 1: Some work
+
+- EDIT: `some-script.sh` — fix it
+
+**Reference pattern:** See `shared-constants.sh`.
+
+**Acceptance:**
+- criteria met
+
+### Phase 2: More work
+
+- EDIT: `other-script.sh` — fix it
+
+**Reference pattern:** See `shared-constants.sh`.
+
+**Acceptance:**
+- criteria met'
+
+if _body_is_eligible "$body_no_verify"; then
+	no_verify_rc=0
+else
+	no_verify_rc=1
+fi
+assert_rc "7: body missing **Verification:** → ineligible" "1" "$no_verify_rc"
+
+# ─── 8. Missing **Acceptance:** → ineligible ─────────────────────────────────
+
+body_no_accept='### Phase 1: Some work
+
+- EDIT: `some-script.sh` — fix it
+
+**Reference pattern:** See `shared-constants.sh`.
+
+**Verification:**
+```bash
+echo ok
+```
+
+### Phase 2: More work
+
+- EDIT: `other-script.sh` — fix it
+
+**Reference pattern:** See `shared-constants.sh`.
+
+**Verification:**
+```bash
+echo ok
+```'
+
+if _body_is_eligible "$body_no_accept"; then
+	no_accept_rc=0
+else
+	no_accept_rc=1
+fi
+assert_rc "8: body missing **Acceptance:** → ineligible" "1" "$no_accept_rc"
+
+# ─── 9. **Acceptance:** present but no bullet → ineligible ───────────────────
+
+body_accept_no_bullet='### Phase 1: Some work
+
+- EDIT: `some-script.sh` — fix it
+
+**Reference pattern:** See `shared-constants.sh`.
+
+**Verification:**
+```bash
+echo ok
+```
+
+**Acceptance:**
+(no bullets here, just prose)
+
+### Phase 2: More work
+
+- EDIT: `other-script.sh` — fix it
+
+**Reference pattern:** See `shared-constants.sh`.
+
+**Verification:**
+```bash
+echo ok
+```
+
+**Acceptance:**
+also no bullets'
+
+if _body_is_eligible "$body_accept_no_bullet"; then
+	accept_no_bullet_rc=0
+else
+	accept_no_bullet_rc=1
+fi
+assert_rc "9: **Acceptance:** without bullets → ineligible" "1" "$accept_no_bullet_rc"
+
+# ─── 10. Only 1 qualifying phase → ineligible (below min threshold) ───────────
+
+body_1_phase=$(_canonical_phase 1 "Only phase")
+if _body_is_eligible "$body_1_phase"; then
+	one_phase_rc=0
+else
+	one_phase_rc=1
+fi
+assert_rc "10: only 1 qualifying phase → ineligible" "1" "$one_phase_rc"
+
+# ─── 11. Mixed: one complete, one incomplete → ineligible (all-or-nothing) ────
+# Build with string concatenation instead of $(cat <<BODY) to avoid bash32 violation.
+
+_incomplete_phase2='### Phase 2: Incomplete phase (missing Verification)
+
+- EDIT: `some-script.sh` — fix it
+
+**Reference pattern:** See `shared-constants.sh`.
+
+**Acceptance:**
+- criteria met'
+
+body_mixed="$(_canonical_phase 1 "Complete phase")
+
+${_incomplete_phase2}"
+
+if _body_is_eligible "$body_mixed"; then
+	mixed_rc=0
+else
+	mixed_rc=1
+fi
+assert_rc "11: mixed body (one incomplete phase) → ineligible" "1" "$mixed_rc"
+
+# ─── 12. Canonical 4-phase body (#20622-shaped) → eligible ───────────────────
+
+body_4_phases=$(_body_with_phases 4)
+if _body_is_eligible "$body_4_phases"; then
+	four_phase_rc=0
+else
+	four_phase_rc=1
+fi
+assert_rc "12: canonical 4-phase body → eligible" "0" "$four_phase_rc"
+
+# ─── 13. Generator marker ─────────────────────────────────────────────────────
+
+assert_grep_fixed \
+	"13: extractor emits pre-dispatch-validator-friendly generator marker" \
+	'aidevops:generator=phase-extractor' \
+	"$EXTRACTOR"
+
+# ─── 14. Parent-task PR keyword rule: uses For #NNN not Closes/Resolves ───────
+
+assert_grep_fixed \
+	"14a: child body uses 'For #' (not Closes/Resolves per parent-task keyword rule)" \
+	'For #${parent_num}' \
+	"$EXTRACTOR"
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if ! grep -qF 'Closes #${parent_num}' "$EXTRACTOR" && \
+   ! grep -qF 'Resolves #${parent_num}' "$EXTRACTOR"; then
+	printf '%sPASS%s: 14b: child body does NOT use Closes/Resolves\n' "$TEST_GREEN" "$TEST_NC"
+else
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '%sFAIL%s: 14b: child body incorrectly uses Closes/Resolves\n' "$TEST_RED" "$TEST_NC"
+fi
+
+# ─── 15. Child label set ──────────────────────────────────────────────────────
+
+assert_grep_fixed "15a: child labels include auto-dispatch" 'auto-dispatch' "$EXTRACTOR"
+assert_grep_fixed "15b: child labels include tier:standard" 'tier:standard' "$EXTRACTOR"
+assert_grep_fixed "15c: child labels include origin:worker" 'origin:worker' "$EXTRACTOR"
+
+# ─── 16. no-auto-dispatch dispatch guard ─────────────────────────────────────
+
+assert_grep_fixed \
+	"16: extractor skips no-auto-dispatch parents (dispatch guard)" \
+	'no-auto-dispatch' \
+	"$EXTRACTOR"
+
+# ─── 17. Wiring: reconcile.sh calls phase-extractor before nudge/escalation ───
+
+assert_grep \
+	"17a: reconcile.sh calls phase-extractor (t2771)" \
+	'parent-task-phase-extractor\.sh' \
+	"$RECONCILE"
+
+assert_grep \
+	"17b: reconcile.sh skips nudge/escalation when extractor fires" \
+	'_phase_extractor.*run.*issue_num' \
+	"$RECONCILE"
+
+assert_grep_fixed \
+	"17c: reconcile.sh references t2771 in the phase-extractor integration comment" \
+	't2771' \
+	"$RECONCILE"
+
+# ─── 18. Wiring: reconcile uses _PIR_SCRIPT_DIR for extractor path ────────────
+
+assert_grep_fixed \
+	"18: reconcile.sh uses _PIR_SCRIPT_DIR to locate extractor (consistent with module sourcing)" \
+	'_PIR_SCRIPT_DIR' \
+	"$RECONCILE"
+
+# ─── Shellcheck ───────────────────────────────────────────────────────────────
+
+if command -v shellcheck >/dev/null 2>&1; then
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if shellcheck "$EXTRACTOR" >/dev/null 2>&1; then
+		printf '%sPASS%s: 19: extractor is shellcheck-clean\n' "$TEST_GREEN" "$TEST_NC"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		printf '%sFAIL%s: 19: extractor has shellcheck violations\n' "$TEST_RED" "$TEST_NC"
+		shellcheck "$EXTRACTOR" || true
+	fi
+else
+	printf '%sSKIP%s: 19: shellcheck not installed\n' "$TEST_BLUE" "$TEST_NC"
+fi
+
+# ─── Summary ─────────────────────────────────────────────────────────────────
+
+printf '\n%s=== Results: %s tests, %s failed ===%s\n' \
+	"$TEST_BLUE" "$TESTS_RUN" "$TESTS_FAILED" "$TEST_NC"
+
+if [ "$TESTS_FAILED" -gt 0 ]; then
+	exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## What

Adds a deterministic phase-extractor scanner that short-circuits the LLM-based auto-decomposer when a parent-task body already contains a fully-written phase plan. Zero LLM, zero paraphrasing — pure regex + verbatim text extraction.

## Why

Canonical case: #20622. The parent body already has 4 well-formed phases with file paths, reference patterns, verification commands, and acceptance criteria. Running an LLM over it adds hallucination surface for zero value. This scanner detects the template and files each phase verbatim.

## How

### Files modified

- **NEW:** `.agents/scripts/parent-task-phase-extractor.sh` — detection + filing. One-pass awk detects well-formed phases (all 5 sub-sections present per phase); a second awk pass extracts each phase block verbatim. All-or-nothing: if any phase is missing any sub-section, no-op entirely.

- **EDIT:** `.agents/scripts/pulse-issue-reconcile.sh` — `reconcile_completed_parent_tasks` now tries the extractor before nudge/escalation when a parent has zero children. If the extractor fires (exit 0), nudge/escalation is skipped — children are in flight (t2771).

- **NEW:** `.agents/scripts/tests/test-parent-task-phase-extractor.sh` — 26 tests: detection happy-path (2- and 4-phase bodies), all-or-nothing fail-safe (each sub-section missing individually, mixed body), pulse wiring, label/keyword compliance, shellcheck.

## Fix from PR #20656

The previous PR failed CI with 6 new bash32-compat violations (`heredoc-in-subshell` pattern). Root cause: test fixtures used `body=$(cat <<'BODY'...BODY)` which the complexity checker flags as `$(cat <<`. This PR replaces all 6 patterns with single-quoted multi-line string literals, eliminating the violations.

## Complexity Bump Justification

- **File:** `.agents/scripts/parent-task-phase-extractor.sh:242` — `_run_extractor` function
- **Measurement:** `base=32, head=33, new=1` function(s) >100 lines; `_run_extractor` = 109 lines (9 over threshold)

`_run_extractor` is the canonical orchestrator for a single-responsibility task: fetch parent issue, validate eligibility, loop over phases and file each as a child issue, update parent body with Children section. Splitting into sub-functions would require temp files or global variables for inter-function communication (filed_count, accumulated child_lines), which reduces both readability and correctness without meaningful benefit. The 9-line overage is the cost of complete inline context. This is a new file — no existing baseline was regressed.

## Verification

```bash
shellcheck .agents/scripts/parent-task-phase-extractor.sh .agents/scripts/pulse-issue-reconcile.sh
bash .agents/scripts/tests/test-parent-task-phase-extractor.sh
# Expected: Results: 26 tests, 0 failed
```

Local verification: all 26 tests pass. All three files shellcheck-clean. Zero bash32 violations in new files.

## New File Smell Justification

The two new shell files (`parent-task-phase-extractor.sh`, `test-parent-task-phase-extractor.sh`) follow established project patterns (sourced `shared-constants.sh`, source guard, explicit returns, shellcheck-clean). Qlty findings, if any, are expected to match the baseline for similar new scripts in this repo.

Resolves #20641


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.9.0 plugin for [OpenCode](https://opencode.ai) v1.14.22 with claude-sonnet-4-6 spent 36m and 38,564 tokens on this as a headless worker.
