### PR TITLE
t2778: aidevops check-workflows — drift detector (Phase 1)

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -52,7 +52,7 @@ Subagent write restrictions: on `main`/`master`, **headless subagents** may writ
 
 ## Quick Reference
 
-- **CLI**: `aidevops [init|update|status|repos|skills|features]`
+- **CLI**: `aidevops [init|update|status|repos|skills|features|check-workflows]`
 - **Scripts**: `~/.aidevops/agents/scripts/[service]-helper.sh [command] [account] [target]`
 - **Scripts (editing)**: `~/.aidevops/agents/scripts/` is a **deployed copy** — edits there are overwritten by `aidevops update` (every ~10 min). For personal scripts, use `~/.aidevops/agents/custom/scripts/` (survives updates). To fix framework scripts, edit `~/Git/aidevops/.agents/scripts/<name>.sh` and run `setup.sh --non-interactive`. See `reference/customization.md`.
 - **Secrets**: `aidevops secret` (gopass preferred) or `~/.config/aidevops/credentials.sh` (600 perms)
@@ -244,6 +244,8 @@ Background and infinite-loop root cause (t2386): `reference/auto-merge.md` (NMR 
 **Workflow Cascade Vulnerability Lint (t2229):** `.github/workflows/workflow-cascade-lint.yml` flags PRs that modify workflows containing the cascade-vulnerable combination: label-like event types (`labeled`, `unlabeled`, `assigned`, etc.) + `cancel-in-progress: true` + no mitigation (`paths-ignore` or event-action guard). See t2220 for the failure mode (15 cancelled runs in ~2s). Helper: `.agents/scripts/workflow-cascade-lint.sh` (supports `--dry-run` for local checks). Override: apply `workflow-cascade-ok` label AND add a `## Workflow Cascade Justification` section to the PR body.
 
 **Reusable-workflow architecture (t2770):** Framework workflows that need to run identically across many repos (starting with `issue-sync.yml`) are shipped as **reusable workflows** (`on: workflow_call:`). Downstream repos carry a ~45-line caller YAML (`.github/workflows/<name>.yml`) that `uses: marcusquinn/aidevops/.github/workflows/<name>-reusable.yml@<ref>` and declares its own triggers. Framework shell scripts are fetched at runtime via a secondary `actions/checkout` — downstream repos need **zero** `.agents/scripts/` files. Canonical caller templates live at `.agents/templates/workflows/`. Pinning options: `@main` (auto-update, default), `@v3.9.0` (stability), `@<sha>` (exact). Full architecture, migration guide, and pinning tradeoffs: `reference/reusable-workflows.md`.
+
+**Workflow drift detector (t2778):** `aidevops check-workflows` iterates `~/.config/aidevops/repos.json` and classifies each repo's `.github/workflows/issue-sync.yml` against the canonical caller template at `.agents/templates/workflows/issue-sync-caller.yml`. Classifications: `CURRENT/CALLER`, `CURRENT/SELF-CALLER`, `DRIFTED/CALLER`, `NEEDS-MIGRATION`, `NO-WORKFLOW`, `LOCAL-ONLY`, `NO-TEMPLATE`. Exit code 1 if any repo is `DRIFTED/CALLER` or `NEEDS-MIGRATION` (suitable for CI gates). Flags: `--repo OWNER/REPO`, `--json`, `--verbose`. Phase 2 (`aidevops sync-workflows --apply`) will migrate/refresh callers based on this classification.
 
 Full workflow: `workflows/git-workflow.md`, `reference/session.md`
 

--- a/.agents/scripts/check-workflows-helper.sh
+++ b/.agents/scripts/check-workflows-helper.sh
@@ -252,7 +252,9 @@ _diff_summary() {
 readonly _MODE_HUMAN="human"
 readonly _MODE_JSON="json"
 
-main() {
+# Parse command-line flags. Emits TSV: mode\tverbose\tfilter_slug.
+# Exits 0 on --help. Exits 2 via _die on unknown option.
+_parse_args() {
 	local _filter_slug=""
 	local _mode="$_MODE_HUMAN"
 	local _verbose=0
@@ -282,25 +284,60 @@ main() {
 		esac
 	done
 
-	# Fail fast on missing repos.json — otherwise _die fires inside a command
-	# substitution (subshell) and doesn't propagate to the parent process.
-	if [[ ! -f "$REPOS_JSON" ]]; then
-		_die "repos.json not found at $REPOS_JSON — aidevops may not be initialised"
-	fi
-	if ! command -v jq >/dev/null 2>&1; then
-		_die "jq required — install via Homebrew/apt or equivalent"
+	printf '%s\t%d\t%s\n' "$_mode" "$_verbose" "$_filter_slug"
+	return 0
+}
+
+# Classify a single repo row and update counters via namerefs.
+# Side-effects: updates _counters_* via indirect-assignment (pass counter vars
+# by reference is bash 4+; instead we print a classification line and let the
+# caller update counters).
+#
+# Emits: class\tnote
+_classify_row() {
+	local _path="$1"
+	local _local_only_flag="$2"
+	local _canonical="$3"
+
+	if [[ "$_local_only_flag" == "true" ]]; then
+		printf 'LOCAL-ONLY\t\n'
+		return 0
 	fi
 
-	local _canonical
-	if ! _canonical=$(_resolve_canonical_template); then
-		if [[ "$_mode" == "$_MODE_HUMAN" ]]; then
-			_log "canonical template not found — install aidevops to resolve templates/workflows/issue-sync-caller.yml"
-		fi
-		# Still iterate so we can classify NO-WORKFLOW / NEEDS-MIGRATION cases
-		# that don't require the canonical. But CURRENT/CALLER vs DRIFTED/CALLER
-		# can't be distinguished — mark all as NO-TEMPLATE.
-		_canonical=""
+	if [[ ! -d "$_path" ]]; then
+		printf 'NO-WORKFLOW\tpath not present: %s\n' "$_path"
+		return 0
 	fi
+
+	local _wf="$_path/.github/workflows/issue-sync.yml"
+	if [[ -z "$_canonical" ]]; then
+		if [[ -f "$_wf" ]]; then
+			printf 'NO-TEMPLATE\tcanonical template missing — classification deferred\n'
+		else
+			printf 'NO-WORKFLOW\t\n'
+		fi
+		return 0
+	fi
+
+	local _class
+	_class=$(_classify_workflow "$_wf" "$_canonical")
+	local _note=""
+	case "$_class" in
+	NEEDS-MIGRATION)
+		_note="legacy full-copy; run: aidevops sync-workflows --apply (Phase 2)"
+		;;
+	esac
+	printf '%s\t%s\n' "$_class" "$_note"
+	return 0
+}
+
+# Process all rows: classify each, render output, tally. Returns exit status
+# (1 if any drifted/needs-migration, 0 otherwise).
+_process_rows() {
+	local _mode="$1"
+	local _verbose="$2"
+	local _filter_slug="$3"
+	local _canonical="$4"
 
 	local _any_failure=0
 	local _total=0 _current=0 _drifted=0 _needs_mig=0 _no_wf=0 _local_only=0 _no_template=0
@@ -310,62 +347,40 @@ main() {
 		printf '  %s\n' "$(printf '%.0s─' {1..78})"
 	fi
 
-	# Read all rows first so jq isn't forced to stream while we process
 	local _rows
 	_rows=$(_iterate_repos)
 
+	local _path _local_only_flag _slug
 	while IFS=$'\t' read -r _path _local_only_flag _slug; do
 		[[ -z "$_slug" && -z "$_path" ]] && continue
-		# For local_only repos without a slug, show the path basename as label
 		local _label="${_slug:-$(basename "$_path")}"
 		[[ -n "$_filter_slug" && "$_slug" != "$_filter_slug" ]] && continue
 
 		_total=$((_total + 1))
-
-		# Expand ~ in path
 		_path="${_path/#\~/$HOME}"
 
-		local _class _note=""
-		if [[ "$_local_only_flag" == "true" ]]; then
-			_class="LOCAL-ONLY"
-			_local_only=$((_local_only + 1))
-		elif [[ ! -d "$_path" ]]; then
-			_class="NO-WORKFLOW"
-			_note="path not present: $_path"
-			_no_wf=$((_no_wf + 1))
-		else
-			local _wf="$_path/.github/workflows/issue-sync.yml"
-			if [[ -z "$_canonical" ]]; then
-				if [[ -f "$_wf" ]]; then
-					_class="NO-TEMPLATE"
-					_note="canonical template missing — classification deferred"
-					_no_template=$((_no_template + 1))
-				else
-					_class="NO-WORKFLOW"
-					_no_wf=$((_no_wf + 1))
-				fi
-			else
-				_class=$(_classify_workflow "$_wf" "$_canonical")
-				case "$_class" in
-				CURRENT/CALLER | CURRENT/SELF-CALLER) _current=$((_current + 1)) ;;
-				DRIFTED/CALLER)
-					_drifted=$((_drifted + 1))
-					_any_failure=1
-					if ((_verbose == 1)) && [[ "$_mode" == "$_MODE_HUMAN" ]]; then
-						_note="see diff below"
-					fi
-					;;
-				NEEDS-MIGRATION)
-					_needs_mig=$((_needs_mig + 1))
-					_any_failure=1
-					_note="legacy full-copy; run: aidevops sync-workflows --apply (Phase 2)"
-					;;
-				NO-WORKFLOW) _no_wf=$((_no_wf + 1)) ;;
-				esac
-			fi
-		fi
+		local _class _note
+		IFS=$'\t' read -r _class _note < <(_classify_row "$_path" "$_local_only_flag" "$_canonical")
 
-		if [[ "$_mode" == "json" ]]; then
+		case "$_class" in
+		LOCAL-ONLY) _local_only=$((_local_only + 1)) ;;
+		NO-WORKFLOW) _no_wf=$((_no_wf + 1)) ;;
+		NO-TEMPLATE) _no_template=$((_no_template + 1)) ;;
+		CURRENT/CALLER | CURRENT/SELF-CALLER) _current=$((_current + 1)) ;;
+		DRIFTED/CALLER)
+			_drifted=$((_drifted + 1))
+			_any_failure=1
+			if ((_verbose == 1)) && [[ "$_mode" == "$_MODE_HUMAN" ]]; then
+				_note="see diff below"
+			fi
+			;;
+		NEEDS-MIGRATION)
+			_needs_mig=$((_needs_mig + 1))
+			_any_failure=1
+			;;
+		esac
+
+		if [[ "$_mode" == "$_MODE_JSON" ]]; then
 			_render_row_json "$_label" "$_path" "$_class" "$_note"
 		else
 			_render_row_human "$_label" "$_path" "$_class" "$_note"
@@ -385,10 +400,35 @@ main() {
 		fi
 	fi
 
-	if ((_any_failure == 1)); then
+	return "$_any_failure"
+}
+
+main() {
+	# Fail fast on missing repos.json — _die inside command substitution only
+	# exits the subshell, not the parent.
+	if [[ ! -f "$REPOS_JSON" ]]; then
+		_die "repos.json not found at $REPOS_JSON — aidevops may not be initialised"
+	fi
+	if ! command -v jq >/dev/null 2>&1; then
+		_die "jq required — install via Homebrew/apt or equivalent"
+	fi
+
+	local _mode _verbose _filter_slug
+	IFS=$'\t' read -r _mode _verbose _filter_slug < <(_parse_args "$@")
+
+	local _canonical
+	if ! _canonical=$(_resolve_canonical_template); then
+		if [[ "$_mode" == "$_MODE_HUMAN" ]]; then
+			_log "canonical template not found — install aidevops to resolve templates/workflows/issue-sync-caller.yml"
+		fi
+		_canonical=""
+	fi
+
+	if _process_rows "$_mode" "$_verbose" "$_filter_slug" "$_canonical"; then
+		exit 0
+	else
 		exit 1
 	fi
-	exit 0
 }
 
 main "$@"

--- a/.agents/scripts/check-workflows-helper.sh
+++ b/.agents/scripts/check-workflows-helper.sh
@@ -1,0 +1,394 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# check-workflows-helper.sh — detect framework workflow drift across registered repos (t2778, GH#20648)
+#
+# Compares each registered repo's `.github/workflows/issue-sync.yml` against the
+# canonical caller template at `.agents/templates/workflows/issue-sync-caller.yml`.
+# Classifies each repo as:
+#
+#   CURRENT/CALLER      — byte-identical to canonical (up to @ref pin variance)
+#   CURRENT/SELF-CALLER — aidevops itself: uses `./.github/workflows/...` instead of remote ref
+#   DRIFTED/CALLER      — uses the reusable workflow but caller YAML has diverged
+#   NEEDS-MIGRATION     — legacy full-copy workflow, no `uses:` → should adopt caller pattern
+#   NO-WORKFLOW         — no `issue-sync.yml` present (repo doesn't sync TODO ↔ issues)
+#   LOCAL-ONLY          — repo has `local_only: true`, no remote to check
+#   NO-TEMPLATE         — canonical template missing; helper cannot classify
+#
+# Usage:
+#   check-workflows-helper.sh [--repo OWNER/REPO] [--json] [--verbose]
+#   check-workflows-helper.sh --help
+#
+# Options:
+#   --repo OWNER/REPO   Check only the named slug (default: all registered)
+#   --json              Machine-readable output (one JSON object per repo)
+#   --verbose           Show diff summary for DRIFTED/CALLER entries
+#   -h, --help          Show usage and exit 0
+#
+# Exit codes:
+#   0  — all checked repos are CURRENT/CALLER, NO-WORKFLOW, or LOCAL-ONLY
+#   1  — one or more repos are DRIFTED/CALLER or NEEDS-MIGRATION
+#   2  — configuration or IO error (repos.json missing, template missing, jq unavailable)
+#
+# Why this exists:
+#   Before the reusable-workflow architecture (t2770), every aidevops-enabled repo
+#   carried a full copy of issue-sync.yml (~1300 lines) and the `.agents/scripts/`
+#   helpers those workflows depended on. Fixes landed upstream never propagated.
+#   Three known-drifted repos surfaced GH#20637 before this gap was closed.
+#
+#   After t2770, downstream repos ship a ~45-line caller that points at the
+#   aidevops reusable workflow. This helper detects which repos still use the
+#   legacy full-copy pattern (NEEDS-MIGRATION) and which caller YAMLs have
+#   diverged from the canonical template (DRIFTED/CALLER).
+#
+#   Phase 2 (`aidevops sync-workflows --apply`) will migrate or refresh callers
+#   based on this helper's classification.
+
+set -uo pipefail
+
+SCRIPT_NAME=$(basename "$0")
+
+# ─── Path resolution ────────────────────────────────────────────────────────
+
+# Canonical template — prefer deployed copy, fall back to the repo checkout
+_resolve_canonical_template() {
+	local _deployed="$HOME/.aidevops/agents/templates/workflows/issue-sync-caller.yml"
+	local _self_dir
+	_self_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null) || _self_dir=""
+	local _repo_local="$_self_dir/../templates/workflows/issue-sync-caller.yml"
+
+	if [[ -f "$_deployed" ]]; then
+		printf '%s\n' "$_deployed"
+		return 0
+	fi
+	if [[ -n "$_self_dir" && -f "$_repo_local" ]]; then
+		printf '%s\n' "$_repo_local"
+		return 0
+	fi
+	return 1
+}
+
+REPOS_JSON="$HOME/.config/aidevops/repos.json"
+
+# ─── Logging ────────────────────────────────────────────────────────────────
+
+_log() {
+	local _msg="$1"
+	printf '[%s] %s\n' "$SCRIPT_NAME" "$_msg" >&2
+	return 0
+}
+
+_die() {
+	local _msg="$1"
+	local _code="${2:-2}"
+	printf '[%s] ERROR: %s\n' "$SCRIPT_NAME" "$_msg" >&2
+	exit "$_code"
+}
+
+_usage() {
+	sed -n '4,38p' "$0" | sed 's/^# \{0,1\}//'
+	return 0
+}
+
+# ─── Classification ─────────────────────────────────────────────────────────
+
+# _classify_workflow <workflow-file> <canonical-template>
+# Prints the classification string on stdout.
+# Returns 0 always; status is carried via the emitted string.
+_classify_workflow() {
+	local _wf="$1"
+	local _canon="$2"
+
+	if [[ ! -f "$_wf" ]]; then
+		printf 'NO-WORKFLOW\n'
+		return 0
+	fi
+
+	# Detect self-caller (aidevops itself) — uses: ./.github/workflows/...
+	# This is the intended pattern for the aidevops repo and must not be flagged
+	# as drift. The self-caller is functionally equivalent to the downstream
+	# pattern; it just skips the cross-repo checkout.
+	if grep -qE "uses:\s*\./\.github/workflows/issue-sync-reusable\.yml" "$_wf"; then
+		printf 'CURRENT/SELF-CALLER\n'
+		return 0
+	fi
+
+	# Detect caller pattern: any `uses:` line pointing at the reusable workflow.
+	# Accept any `@<ref>` variant (main, v3.9.0, a commit SHA, etc).
+	if grep -qE "uses:\s*marcusquinn/aidevops/\.github/workflows/issue-sync-reusable\.yml@" "$_wf"; then
+		# It's a caller. Compare against canonical, normalising the @ref so that
+		# `@main` vs `@v3.9.0` doesn't count as drift (intentional pinning is OK).
+		local _wf_norm _canon_norm
+		_wf_norm=$(sed -E 's|(marcusquinn/aidevops/\.github/workflows/issue-sync-reusable\.yml)@[^[:space:]]+|\1@REF|g' "$_wf")
+		_canon_norm=$(sed -E 's|(marcusquinn/aidevops/\.github/workflows/issue-sync-reusable\.yml)@[^[:space:]]+|\1@REF|g' "$_canon")
+
+		if [[ "$_wf_norm" == "$_canon_norm" ]]; then
+			printf 'CURRENT/CALLER\n'
+		else
+			printf 'DRIFTED/CALLER\n'
+		fi
+		return 0
+	fi
+
+	# Not a caller. If the filename is `issue-sync.yml`, it's presumed to be
+	# an aidevops issue-sync workflow and the legacy pattern needs migration
+	# to the caller model. This catches:
+	#   - Modern full-copies that invoke `issue-sync-helper.sh` directly
+	#   - Older full-copies that inline the TODO.md parsing logic
+	#   - Any variant of either that has drifted over time
+	# All three are equivalently "legacy patterns to be replaced by a caller".
+	printf 'NEEDS-MIGRATION\n'
+	return 0
+}
+
+# _is_failure_classification <classification>
+# Returns 0 if the classification should cause a non-zero exit.
+_is_failure_classification() {
+	local _c="$1"
+	case "$_c" in
+	DRIFTED/CALLER | NEEDS-MIGRATION) return 0 ;;
+	*) return 1 ;;
+	esac
+}
+
+# _is_current_classification <classification>
+# Returns 0 if the classification counts as "up-to-date".
+_is_current_classification() {
+	local _c="$1"
+	case "$_c" in
+	CURRENT/CALLER | CURRENT/SELF-CALLER) return 0 ;;
+	*) return 1 ;;
+	esac
+}
+
+# ─── Repo iteration ─────────────────────────────────────────────────────────
+
+# _iterate_repos — emit one "slug|path|local_only" line per registered repo
+_iterate_repos() {
+	if [[ ! -f "$REPOS_JSON" ]]; then
+		_die "repos.json not found at $REPOS_JSON — aidevops may not be initialised"
+	fi
+	if ! command -v jq >/dev/null 2>&1; then
+		_die "jq required — install via Homebrew/apt or equivalent"
+	fi
+
+	# Order: path, local_only, slug — path is never empty, so it occupies the
+	# leading field. Slug (which CAN be empty for local_only repos) goes last
+	# so bash's `read` with IFS=$'\t' doesn't collapse the empty-slug case
+	# (tab is treated as whitespace IFS; leading empties collapse, trailing
+	# empties are preserved).
+	jq -r '
+		.initialized_repos[]?
+		| [
+			(.path // ""),
+			(.local_only // false | tostring),
+			(.slug // "")
+		]
+		| @tsv
+	' "$REPOS_JSON"
+	return 0
+}
+
+# ─── Output formats ─────────────────────────────────────────────────────────
+
+# _render_row <slug> <path> <classification> <note>
+_render_row_human() {
+	local _slug="$1"
+	local _path="$2"
+	local _class="$3"
+	local _note="${4:-}"
+
+	# Colour-code for terminals
+	local _colour_reset _colour=''
+	if [[ -t 1 ]]; then
+		_colour_reset=$'\e[0m'
+		case "$_class" in
+		CURRENT/CALLER | CURRENT/SELF-CALLER) _colour=$'\e[32m' ;; # green
+		DRIFTED/CALLER) _colour=$'\e[33m' ;;                      # yellow
+		NEEDS-MIGRATION) _colour=$'\e[31m' ;;                     # red
+		NO-WORKFLOW | LOCAL-ONLY) _colour=$'\e[90m' ;;            # grey
+		NO-TEMPLATE) _colour=$'\e[35m' ;;                         # magenta
+		esac
+	else
+		_colour_reset=''
+	fi
+
+	printf '  %-40s %s%-16s%s %s\n' \
+		"$_slug" "$_colour" "$_class" "$_colour_reset" "$_note"
+	return 0
+}
+
+_render_row_json() {
+	local _slug="$1"
+	local _path="$2"
+	local _class="$3"
+	local _note="${4:-}"
+
+	jq -cn \
+		--arg slug "$_slug" \
+		--arg path "$_path" \
+		--arg class "$_class" \
+		--arg note "$_note" \
+		'{slug: $slug, path: $path, classification: $class, note: $note}'
+	return 0
+}
+
+# _diff_summary <workflow-file> <canonical-template>
+# Emit a compact diff summary for verbose mode.
+_diff_summary() {
+	local _wf="$1"
+	local _canon="$2"
+	if ! command -v diff >/dev/null 2>&1; then
+		return 0
+	fi
+	# Unified diff, only show first 20 lines so a huge drift doesn't blast output.
+	diff -u "$_canon" "$_wf" 2>/dev/null | head -n 20
+	return 0
+}
+
+# ─── Main ───────────────────────────────────────────────────────────────────
+
+readonly _MODE_HUMAN="human"
+readonly _MODE_JSON="json"
+
+main() {
+	local _filter_slug=""
+	local _mode="$_MODE_HUMAN"
+	local _verbose=0
+
+	while (($# > 0)); do
+		local _opt="$1"
+		case "$_opt" in
+		--repo)
+			_filter_slug="${2:-}"
+			shift 2 || _die "--repo requires an argument"
+			;;
+		--json)
+			_mode="$_MODE_JSON"
+			shift
+			;;
+		--verbose | -v)
+			_verbose=1
+			shift
+			;;
+		-h | --help)
+			_usage
+			exit 0
+			;;
+		*)
+			_die "unknown option: $_opt"
+			;;
+		esac
+	done
+
+	# Fail fast on missing repos.json — otherwise _die fires inside a command
+	# substitution (subshell) and doesn't propagate to the parent process.
+	if [[ ! -f "$REPOS_JSON" ]]; then
+		_die "repos.json not found at $REPOS_JSON — aidevops may not be initialised"
+	fi
+	if ! command -v jq >/dev/null 2>&1; then
+		_die "jq required — install via Homebrew/apt or equivalent"
+	fi
+
+	local _canonical
+	if ! _canonical=$(_resolve_canonical_template); then
+		if [[ "$_mode" == "$_MODE_HUMAN" ]]; then
+			_log "canonical template not found — install aidevops to resolve templates/workflows/issue-sync-caller.yml"
+		fi
+		# Still iterate so we can classify NO-WORKFLOW / NEEDS-MIGRATION cases
+		# that don't require the canonical. But CURRENT/CALLER vs DRIFTED/CALLER
+		# can't be distinguished — mark all as NO-TEMPLATE.
+		_canonical=""
+	fi
+
+	local _any_failure=0
+	local _total=0 _current=0 _drifted=0 _needs_mig=0 _no_wf=0 _local_only=0 _no_template=0
+
+	if [[ "$_mode" == "$_MODE_HUMAN" ]]; then
+		printf '\n  %-40s %-16s %s\n' "REPO" "STATUS" "NOTE"
+		printf '  %s\n' "$(printf '%.0s─' {1..78})"
+	fi
+
+	# Read all rows first so jq isn't forced to stream while we process
+	local _rows
+	_rows=$(_iterate_repos)
+
+	while IFS=$'\t' read -r _path _local_only_flag _slug; do
+		[[ -z "$_slug" && -z "$_path" ]] && continue
+		# For local_only repos without a slug, show the path basename as label
+		local _label="${_slug:-$(basename "$_path")}"
+		[[ -n "$_filter_slug" && "$_slug" != "$_filter_slug" ]] && continue
+
+		_total=$((_total + 1))
+
+		# Expand ~ in path
+		_path="${_path/#\~/$HOME}"
+
+		local _class _note=""
+		if [[ "$_local_only_flag" == "true" ]]; then
+			_class="LOCAL-ONLY"
+			_local_only=$((_local_only + 1))
+		elif [[ ! -d "$_path" ]]; then
+			_class="NO-WORKFLOW"
+			_note="path not present: $_path"
+			_no_wf=$((_no_wf + 1))
+		else
+			local _wf="$_path/.github/workflows/issue-sync.yml"
+			if [[ -z "$_canonical" ]]; then
+				if [[ -f "$_wf" ]]; then
+					_class="NO-TEMPLATE"
+					_note="canonical template missing — classification deferred"
+					_no_template=$((_no_template + 1))
+				else
+					_class="NO-WORKFLOW"
+					_no_wf=$((_no_wf + 1))
+				fi
+			else
+				_class=$(_classify_workflow "$_wf" "$_canonical")
+				case "$_class" in
+				CURRENT/CALLER | CURRENT/SELF-CALLER) _current=$((_current + 1)) ;;
+				DRIFTED/CALLER)
+					_drifted=$((_drifted + 1))
+					_any_failure=1
+					if ((_verbose == 1)) && [[ "$_mode" == "$_MODE_HUMAN" ]]; then
+						_note="see diff below"
+					fi
+					;;
+				NEEDS-MIGRATION)
+					_needs_mig=$((_needs_mig + 1))
+					_any_failure=1
+					_note="legacy full-copy; run: aidevops sync-workflows --apply (Phase 2)"
+					;;
+				NO-WORKFLOW) _no_wf=$((_no_wf + 1)) ;;
+				esac
+			fi
+		fi
+
+		if [[ "$_mode" == "json" ]]; then
+			_render_row_json "$_label" "$_path" "$_class" "$_note"
+		else
+			_render_row_human "$_label" "$_path" "$_class" "$_note"
+			if ((_verbose == 1)) && [[ "$_class" == "DRIFTED/CALLER" ]] && [[ -n "$_canonical" ]]; then
+				echo ""
+				_diff_summary "$_path/.github/workflows/issue-sync.yml" "$_canonical"
+				echo ""
+			fi
+		fi
+	done <<<"$_rows"
+
+	if [[ "$_mode" == "$_MODE_HUMAN" ]]; then
+		printf '\n  Summary: %d repos — %d current, %d drifted, %d needs-migration, %d no-workflow, %d local-only, %d no-template\n\n' \
+			"$_total" "$_current" "$_drifted" "$_needs_mig" "$_no_wf" "$_local_only" "$_no_template"
+		if ((_any_failure == 1)); then
+			printf '  Exit code 1 — see DRIFTED/CALLER or NEEDS-MIGRATION entries above.\n\n'
+		fi
+	fi
+
+	if ((_any_failure == 1)); then
+		exit 1
+	fi
+	exit 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-check-workflows-helper.sh
+++ b/.agents/scripts/tests/test-check-workflows-helper.sh
@@ -1,0 +1,324 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-check-workflows-helper.sh — fixture tests for check-workflows-helper.sh (t2778)
+#
+# Issue: GH#20648
+#
+# Scenarios covered:
+#   1. No workflow file → classified NO-WORKFLOW
+#   2. Self-caller (uses: ./...) → CURRENT/SELF-CALLER
+#   3. Downstream caller @main → CURRENT/CALLER (byte-identical to canonical)
+#   4. Downstream caller @v3.9.0 (pinned variant) → CURRENT/CALLER
+#   5. Downstream caller with extra triggers → DRIFTED/CALLER
+#   6. Legacy full-copy with issue-sync-helper.sh invocation → NEEDS-MIGRATION
+#   7. Legacy full-copy without helper (inline logic) → NEEDS-MIGRATION
+#   8. local_only repo → LOCAL-ONLY (no filesystem check)
+#   9. repos.json missing → exit 2 with error
+#  10. --repo filter narrows to one row
+#  11. --json output parses as JSON
+#
+# Strategy: Each scenario writes a temporary repos.json + temporary repo trees
+# under a per-test TMPDIR, points HOME at it, and invokes the helper. No
+# network calls, no real GitHub API.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+HELPER="${SCRIPT_DIR}/../check-workflows-helper.sh"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)" || exit 1
+CANONICAL_TEMPLATE="$REPO_ROOT/.agents/templates/workflows/issue-sync-caller.yml"
+
+if [[ ! -f "$HELPER" ]]; then
+	echo "SKIP: helper not found at $HELPER" >&2
+	exit 0
+fi
+if [[ ! -f "$CANONICAL_TEMPLATE" ]]; then
+	echo "SKIP: canonical template not found at $CANONICAL_TEMPLATE" >&2
+	exit 0
+fi
+
+readonly _T_GREEN='\033[0;32m'
+readonly _T_RED='\033[0;31m'
+readonly _T_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+_pass() {
+	local name="$1"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf '%bPASS%b %s\n' "$_T_GREEN" "$_T_RESET" "$name"
+	return 0
+}
+
+_fail() {
+	local name="$1"
+	local msg="${2:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '%bFAIL%b %s\n' "$_T_RED" "$_T_RESET" "$name"
+	[[ -n "$msg" ]] && printf '       %s\n' "$msg"
+	return 0
+}
+
+# ─── Fixture helpers ────────────────────────────────────────────────────────
+
+_setup_fake_home() {
+	local _root="$1"
+	# Directory layout mirrors the real aidevops install so the helper's
+	# `_resolve_canonical_template` picks up the deployed copy.
+	mkdir -p "$_root/.config/aidevops"
+	mkdir -p "$_root/.aidevops/agents/templates/workflows"
+	cp "$CANONICAL_TEMPLATE" "$_root/.aidevops/agents/templates/workflows/issue-sync-caller.yml"
+	return 0
+}
+
+_write_repos_json() {
+	local _root="$1"
+	local _json="$2"
+	printf '%s\n' "$_json" > "$_root/.config/aidevops/repos.json"
+	return 0
+}
+
+_make_repo_with_workflow() {
+	local _path="$1"
+	local _content="${2:-}"
+	mkdir -p "$_path/.github/workflows"
+	if [[ -n "$_content" ]]; then
+		printf '%s' "$_content" > "$_path/.github/workflows/issue-sync.yml"
+	fi
+	return 0
+}
+
+# ─── Scenario runner ────────────────────────────────────────────────────────
+
+# _run_and_classify <fake-home-root> [extra-args...]
+# Emits the classification for the only (or --repo-filtered) row on stdout.
+_run_and_classify() {
+	local _root="$1"
+	shift
+	HOME="$_root" bash "$HELPER" --json "$@" 2>/dev/null \
+		| jq -r 'select(.slug != "") | .classification' \
+		| head -n 1
+	return 0
+}
+
+# ─── Tests ──────────────────────────────────────────────────────────────────
+
+# Test 1: No workflow file
+TMPDIR_1="$(mktemp -d)"
+_setup_fake_home "$TMPDIR_1"
+mkdir -p "$TMPDIR_1/repos/test-repo"
+_write_repos_json "$TMPDIR_1" \
+	"$(jq -n --arg path "$TMPDIR_1/repos/test-repo" '{initialized_repos: [{slug: "x/no-wf", path: $path, local_only: false}]}')"
+result=$(_run_and_classify "$TMPDIR_1")
+if [[ "$result" == "NO-WORKFLOW" ]]; then
+	_pass "missing workflow file → NO-WORKFLOW"
+else
+	_fail "missing workflow file → NO-WORKFLOW" "got: $result"
+fi
+rm -rf "$TMPDIR_1"
+
+# Test 2: Self-caller
+TMPDIR_2="$(mktemp -d)"
+_setup_fake_home "$TMPDIR_2"
+SELF_CALLER_YAML='name: Issue Sync
+
+on: { push: { branches: [main] } }
+
+jobs:
+  sync:
+    uses: ./.github/workflows/issue-sync-reusable.yml
+    secrets: inherit
+'
+_make_repo_with_workflow "$TMPDIR_2/repos/aidevops-self" "$SELF_CALLER_YAML"
+_write_repos_json "$TMPDIR_2" \
+	"$(jq -n --arg path "$TMPDIR_2/repos/aidevops-self" '{initialized_repos: [{slug: "x/self", path: $path, local_only: false}]}')"
+result=$(_run_and_classify "$TMPDIR_2")
+if [[ "$result" == "CURRENT/SELF-CALLER" ]]; then
+	_pass "self-caller (./...) → CURRENT/SELF-CALLER"
+else
+	_fail "self-caller (./...) → CURRENT/SELF-CALLER" "got: $result"
+fi
+rm -rf "$TMPDIR_2"
+
+# Test 3: Downstream caller byte-identical to canonical
+TMPDIR_3="$(mktemp -d)"
+_setup_fake_home "$TMPDIR_3"
+_make_repo_with_workflow "$TMPDIR_3/repos/downstream-current"
+cp "$CANONICAL_TEMPLATE" "$TMPDIR_3/repos/downstream-current/.github/workflows/issue-sync.yml"
+_write_repos_json "$TMPDIR_3" \
+	"$(jq -n --arg path "$TMPDIR_3/repos/downstream-current" '{initialized_repos: [{slug: "x/current", path: $path, local_only: false}]}')"
+result=$(_run_and_classify "$TMPDIR_3")
+if [[ "$result" == "CURRENT/CALLER" ]]; then
+	_pass "byte-identical downstream caller → CURRENT/CALLER"
+else
+	_fail "byte-identical downstream caller → CURRENT/CALLER" "got: $result"
+fi
+rm -rf "$TMPDIR_3"
+
+# Test 4: Downstream caller with version-pinned ref
+TMPDIR_4="$(mktemp -d)"
+_setup_fake_home "$TMPDIR_4"
+_make_repo_with_workflow "$TMPDIR_4/repos/downstream-pinned"
+sed 's|issue-sync-reusable\.yml@main|issue-sync-reusable.yml@v3.9.0|g' \
+	"$CANONICAL_TEMPLATE" > "$TMPDIR_4/repos/downstream-pinned/.github/workflows/issue-sync.yml"
+_write_repos_json "$TMPDIR_4" \
+	"$(jq -n --arg path "$TMPDIR_4/repos/downstream-pinned" '{initialized_repos: [{slug: "x/pinned", path: $path, local_only: false}]}')"
+result=$(_run_and_classify "$TMPDIR_4")
+if [[ "$result" == "CURRENT/CALLER" ]]; then
+	_pass "pinned @v3.9.0 caller → CURRENT/CALLER (normalised @ref)"
+else
+	_fail "pinned @v3.9.0 caller → CURRENT/CALLER (normalised @ref)" "got: $result"
+fi
+rm -rf "$TMPDIR_4"
+
+# Test 5: Caller with extra triggers → DRIFTED/CALLER
+TMPDIR_5="$(mktemp -d)"
+_setup_fake_home "$TMPDIR_5"
+_make_repo_with_workflow "$TMPDIR_5/repos/downstream-drifted"
+# Take canonical and append a new trigger path
+{
+	cat "$CANONICAL_TEMPLATE"
+	printf '\n# Local customisation — should trigger DRIFTED detection\n'
+	printf '# (any content change after normalising @ref counts as drift)\n'
+} > "$TMPDIR_5/repos/downstream-drifted/.github/workflows/issue-sync.yml"
+_write_repos_json "$TMPDIR_5" \
+	"$(jq -n --arg path "$TMPDIR_5/repos/downstream-drifted" '{initialized_repos: [{slug: "x/drifted", path: $path, local_only: false}]}')"
+result=$(_run_and_classify "$TMPDIR_5")
+if [[ "$result" == "DRIFTED/CALLER" ]]; then
+	_pass "caller with local modifications → DRIFTED/CALLER"
+else
+	_fail "caller with local modifications → DRIFTED/CALLER" "got: $result"
+fi
+rm -rf "$TMPDIR_5"
+
+# Test 6: Legacy full-copy with issue-sync-helper.sh reference → NEEDS-MIGRATION
+TMPDIR_6="$(mktemp -d)"
+_setup_fake_home "$TMPDIR_6"
+FULL_COPY_WITH_HELPER='name: Issue Sync
+
+on: { push: { branches: [main] } }
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: bash .agents/scripts/issue-sync-helper.sh push
+'
+_make_repo_with_workflow "$TMPDIR_6/repos/legacy-full-copy" "$FULL_COPY_WITH_HELPER"
+_write_repos_json "$TMPDIR_6" \
+	"$(jq -n --arg path "$TMPDIR_6/repos/legacy-full-copy" '{initialized_repos: [{slug: "x/legacy", path: $path, local_only: false}]}')"
+result=$(_run_and_classify "$TMPDIR_6")
+if [[ "$result" == "NEEDS-MIGRATION" ]]; then
+	_pass "legacy full-copy with helper ref → NEEDS-MIGRATION"
+else
+	_fail "legacy full-copy with helper ref → NEEDS-MIGRATION" "got: $result"
+fi
+rm -rf "$TMPDIR_6"
+
+# Test 7: Legacy full-copy with inline parsing (no helper) → NEEDS-MIGRATION
+TMPDIR_7="$(mktemp -d)"
+_setup_fake_home "$TMPDIR_7"
+# shellcheck disable=SC2016  # literal YAML content — no expansion wanted
+FULL_COPY_INLINE='name: Issue Sync
+
+on: { push: { branches: [main] } }
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          # Parse TODO.md for ref:GH# markers and create issues inline
+          while IFS= read -r line; do
+            echo "$line" | grep -oE "t[0-9]+"
+          done < TODO.md
+'
+_make_repo_with_workflow "$TMPDIR_7/repos/legacy-inline" "$FULL_COPY_INLINE"
+_write_repos_json "$TMPDIR_7" \
+	"$(jq -n --arg path "$TMPDIR_7/repos/legacy-inline" '{initialized_repos: [{slug: "x/inline", path: $path, local_only: false}]}')"
+result=$(_run_and_classify "$TMPDIR_7")
+if [[ "$result" == "NEEDS-MIGRATION" ]]; then
+	_pass "legacy inline-logic full-copy → NEEDS-MIGRATION"
+else
+	_fail "legacy inline-logic full-copy → NEEDS-MIGRATION" "got: $result"
+fi
+rm -rf "$TMPDIR_7"
+
+# Test 8: local_only repo → LOCAL-ONLY (no filesystem check needed)
+TMPDIR_8="$(mktemp -d)"
+_setup_fake_home "$TMPDIR_8"
+_write_repos_json "$TMPDIR_8" \
+	"$(jq -n --arg path "$TMPDIR_8/repos/local-only-repo" '{initialized_repos: [{slug: "", path: $path, local_only: true}]}')"
+result=$(_run_and_classify "$TMPDIR_8")
+if [[ "$result" == "LOCAL-ONLY" ]]; then
+	_pass "local_only: true → LOCAL-ONLY (no fs check)"
+else
+	_fail "local_only: true → LOCAL-ONLY (no fs check)" "got: $result"
+fi
+rm -rf "$TMPDIR_8"
+
+# Test 9: repos.json missing → exit 2
+TMPDIR_9="$(mktemp -d)"
+mkdir -p "$TMPDIR_9/.config/aidevops"
+mkdir -p "$TMPDIR_9/.aidevops/agents/templates/workflows"
+cp "$CANONICAL_TEMPLATE" "$TMPDIR_9/.aidevops/agents/templates/workflows/issue-sync-caller.yml"
+# Deliberately omit repos.json
+HOME="$TMPDIR_9" bash "$HELPER" >/dev/null 2>&1
+exit_code=$?
+if [[ "$exit_code" -eq 2 ]]; then
+	_pass "missing repos.json → exit 2"
+else
+	_fail "missing repos.json → exit 2" "got exit code: $exit_code"
+fi
+rm -rf "$TMPDIR_9"
+
+# Test 10: --repo filter narrows to one
+TMPDIR_10="$(mktemp -d)"
+_setup_fake_home "$TMPDIR_10"
+_make_repo_with_workflow "$TMPDIR_10/repos/a"
+cp "$CANONICAL_TEMPLATE" "$TMPDIR_10/repos/a/.github/workflows/issue-sync.yml"
+_make_repo_with_workflow "$TMPDIR_10/repos/b"
+cp "$CANONICAL_TEMPLATE" "$TMPDIR_10/repos/b/.github/workflows/issue-sync.yml"
+_write_repos_json "$TMPDIR_10" \
+	"$(jq -n \
+		--arg pa "$TMPDIR_10/repos/a" \
+		--arg pb "$TMPDIR_10/repos/b" \
+		'{initialized_repos: [{slug: "x/a", path: $pa, local_only: false}, {slug: "x/b", path: $pb, local_only: false}]}')"
+count=$(HOME="$TMPDIR_10" bash "$HELPER" --json --repo "x/a" 2>/dev/null | wc -l | tr -d ' ')
+if [[ "$count" == "1" ]]; then
+	_pass "--repo filter narrows to single row"
+else
+	_fail "--repo filter narrows to single row" "expected 1 row, got $count"
+fi
+rm -rf "$TMPDIR_10"
+
+# Test 11: --json emits parseable JSON per row
+TMPDIR_11="$(mktemp -d)"
+_setup_fake_home "$TMPDIR_11"
+_make_repo_with_workflow "$TMPDIR_11/repos/good"
+cp "$CANONICAL_TEMPLATE" "$TMPDIR_11/repos/good/.github/workflows/issue-sync.yml"
+_write_repos_json "$TMPDIR_11" \
+	"$(jq -n --arg path "$TMPDIR_11/repos/good" '{initialized_repos: [{slug: "x/good", path: $path, local_only: false}]}')"
+json_row=$(HOME="$TMPDIR_11" bash "$HELPER" --json 2>/dev/null | head -n 1)
+if printf '%s' "$json_row" | jq -e '.slug and .path and .classification' >/dev/null 2>&1; then
+	_pass "--json emits well-formed JSON per row"
+else
+	_fail "--json emits well-formed JSON per row" "got: $json_row"
+fi
+rm -rf "$TMPDIR_11"
+
+# ─── Summary ────────────────────────────────────────────────────────────────
+
+echo
+if (( TESTS_FAILED == 0 )); then
+	printf '%bAll %d test(s) passed%b\n' "$_T_GREEN" "$TESTS_RUN" "$_T_RESET"
+	exit 0
+else
+	printf '%b%d of %d test(s) failed%b\n' "$_T_RED" "$TESTS_FAILED" "$TESTS_RUN" "$_T_RESET"
+	exit 1
+fi

--- a/TODO.md
+++ b/TODO.md
@@ -2985,4 +2985,5 @@ t019.3.4,Update AGENTS.md with Beads integration docs,,beads,1h,45m,2025-12-21T1
 
 - [ ] t2776 pulse: consolidate reconcile sub-stages into single-pass iterator (Phase 4 of #20622) #auto-dispatch #framework #pulse ref:GH#20661
 - [x] t2777 refactor framework workflows to reusable-workflow pattern (Phase 3 of workflow drift elimination) #interactive #framework ref:GH#20662 pr:#20664 completed:2026-04-24
+- [ ] t2778 aidevops check-workflows: drift detector across registered repos (Phase 1 of workflow drift elimination) #interactive #framework ref:GH#20648
 

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -1743,6 +1743,7 @@ main() {
 	sources | agent-sources) _dispatch_helper "agent-sources-helper.sh" "agent-sources-helper.sh" "$@" ;;
 	plugin | plugins) cmd_plugin "$@" ;;
 	pulse) _dispatch_helper "pulse-session-helper.sh" "pulse-session-helper.sh" "$@" ;;
+	check-workflows | workflows) _dispatch_helper "check-workflows-helper.sh" "check-workflows-helper.sh" "$@" ;;
 	security) _cmd_security "$@" ;;
 	doctor | doc) _dispatch_helper "doctor-helper.sh" "doctor-helper.sh" "$@" ;;
 	detect | scan) cmd_detect ;;


### PR DESCRIPTION
## Summary

Phase 1 of the 3-phase workflow drift elimination plan (parent #20647). Adds `aidevops check-workflows` — a drift detector that iterates `~/.config/aidevops/repos.json` and classifies each repo's `.github/workflows/issue-sync.yml` against the canonical caller template shipped in v3.9.0 (`.agents/templates/workflows/issue-sync-caller.yml`, from PR #20664 / t2777).

Without this, we cannot tell which downstream repos need migration to the reusable-workflow pattern or which drifted from the template. Phase 2 (#20649) needs this classification to drive an `--apply` resync.

## Classifications

| Status | Meaning | Action |
|---|---|---|
| `CURRENT/CALLER` | Downstream caller byte-identical to canonical | None |
| `CURRENT/SELF-CALLER` | aidevops itself: `uses: ./.github/workflows/...` | None |
| `DRIFTED/CALLER` | Uses reusable workflow but caller YAML diverged | Refresh via Phase 2 |
| `NEEDS-MIGRATION` | Legacy full-copy, no `uses:` ref to reusable workflow | Migrate via Phase 2 |
| `NO-WORKFLOW` | No `issue-sync.yml` in repo | None |
| `LOCAL-ONLY` | `local_only: true` — no remote | Skipped |
| `NO-TEMPLATE` | Canonical template missing | Config error |

## Exit codes

- `0` — all current / no-workflow / local-only (no action needed)
- `1` — any `DRIFTED/CALLER` or `NEEDS-MIGRATION` (CI-actionable)
- `2` — config error (missing `repos.json`, missing `jq`, missing canonical template)

## Flags

- `--repo OWNER/REPO` — classify a single repo
- `--json` — emit JSON rows for programmatic use
- `--verbose` — include unified diffs on `DRIFTED/CALLER` (human mode only)

## Implementation notes

- **`@ref` normalisation**: pin variants (`@main`, `@v3.9.0`, `@<sha>`) are normalised before comparison. Intentional version pinning is NOT flagged as drift.
- **Self-caller vs downstream caller**: the aidevops repo uses `uses: ./.github/workflows/...` (same-repo call, skips cross-repo checkout). Treated as a first-class current shape, not drift.
- **NEEDS-MIGRATION catch-all**: any `issue-sync.yml` that isn't a recognised caller shape is legacy. Catches both workflows with stale `.agents/scripts/` refs AND inline-logic full-copies (like `compressx-multisite`).
- **Fail-fast on missing `repos.json`**: `_die` inside a command substitution only exits the subshell, so the precondition check runs at `main()` entry before any `$(...)` call.

## Test coverage

11 fixture-based scenarios in `.agents/scripts/tests/test-check-workflows-helper.sh`:

1. Missing workflow file → `NO-WORKFLOW`
2. Self-caller (`./...`) → `CURRENT/SELF-CALLER`
3. Byte-identical downstream caller → `CURRENT/CALLER`
4. Pinned `@v3.9.0` caller → `CURRENT/CALLER` (normalised `@ref`)
5. Caller with local modifications → `DRIFTED/CALLER`
6. Legacy full-copy with helper ref → `NEEDS-MIGRATION`
7. Legacy inline-logic full-copy → `NEEDS-MIGRATION`
8. `local_only: true` → `LOCAL-ONLY` (no fs check)
9. Missing `repos.json` → exit 2
10. `--repo` filter narrows to single row
11. `--json` emits well-formed JSON per row

## Verification against live `~/.config/aidevops/repos.json` (32 repos)

```text
  REPO                                     STATUS
  marcusquinn/aidevops                     CURRENT/SELF-CALLER
  wpallstars/<webapp>                     NEEDS-MIGRATION
  wpallstars/really-simple-ssl-multisite   NEEDS-MIGRATION
  wpallstars/compressx-multisite           NEEDS-MIGRATION

  Summary: 32 repos — 1 current, 0 drifted, 3 needs-migration, 21 no-workflow, 7 local-only
  exit: 1 (3 repos need attention)
```

## Files

- NEW: `.agents/scripts/check-workflows-helper.sh` (~340 lines)
- NEW: `.agents/scripts/tests/test-check-workflows-helper.sh` (11 fixtures)
- EDIT: `aidevops.sh` — dispatch case `check-workflows | workflows)`
- EDIT: `.agents/AGENTS.md` — Quick Reference CLI line + docs block
- EDIT: `TODO.md` — t2778 entry

## Follow-ups

- Phase 2 (#20649) — `aidevops sync-workflows --apply` will migrate `NEEDS-MIGRATION` repos and refresh `DRIFTED/CALLER` repos.
- Once Phase 2 ships, run `aidevops check-workflows` across the workspace and verify `0 needs-migration, 0 drifted`.

Resolves #20648