### PR TITLE
t2769: per-issue no_work circuit breaker — NMR after N consecutive failures

### DIFF
--- a/.agents/scripts/pulse-nmr-approval.sh
+++ b/.agents/scripts/pulse-nmr-approval.sh
@@ -345,6 +345,7 @@ _nmr_application_has_automation_signature() {
 # Breaker-trip signatures detected:
 #   - <!-- stale-recovery-tick:escalated   — t2008 stale recovery (retry limit)
 #   - <!-- cost-circuit-breaker:fired      — t2007 cost circuit breaker (budget)
+#   - <!-- cost-circuit-breaker:no_work_loop — t2769 per-issue no_work breaker
 #   - <!-- circuit-breaker-escalated       — legacy fast-fail alias
 #
 # Args:
@@ -364,12 +365,13 @@ _nmr_application_is_circuit_breaker_trip() {
 	[[ -n "$issue_num" && -n "$slug" && -n "$label_at" ]] || return 1
 
 	# Same ±60s window as _nmr_application_has_automation_signature —
-	# breaker helpers (dispatch-dedup-stale.sh, dispatch-dedup-cost.sh)
-	# post the marker comment immediately after applying the NMR label,
+	# breaker helpers (dispatch-dedup-stale.sh, dispatch-dedup-cost.sh,
+	# and the t2769 no_work breaker in worker-lifecycle-common.sh) post
+	# the marker comment immediately after applying the NMR label,
 	# so the two events are always co-temporal.
 	local has_breaker_trip
 	has_breaker_trip=$(gh api "repos/${slug}/issues/${issue_num}/comments" --paginate \
-		--jq "[.[] | select((.created_at | fromdateiso8601) >= ((\"${label_at}\" | fromdateiso8601) - 5) and (.created_at | fromdateiso8601) <= ((\"${label_at}\" | fromdateiso8601) + 60)) | .body | select(test(\"stale-recovery-tick:escalated|cost-circuit-breaker:fired|circuit-breaker-escalated\"))] | length" \
+		--jq "[.[] | select((.created_at | fromdateiso8601) >= ((\"${label_at}\" | fromdateiso8601) - 5) and (.created_at | fromdateiso8601) <= ((\"${label_at}\" | fromdateiso8601) + 60)) | .body | select(test(\"stale-recovery-tick:escalated|cost-circuit-breaker:fired|cost-circuit-breaker:no_work_loop|circuit-breaker-escalated\"))] | length" \
 		2>/dev/null) || has_breaker_trip=0
 	[[ "$has_breaker_trip" =~ ^[0-9]+$ ]] || has_breaker_trip=0
 

--- a/.agents/scripts/tests/test-worker-reliability-self-heal.sh
+++ b/.agents/scripts/tests/test-worker-reliability-self-heal.sh
@@ -34,7 +34,9 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
-AUTO_UPDATE_SCRIPT="${REPO_ROOT}/.agents/scripts/auto-update-helper.sh"
+# check_launchd_plist_drift moved to auto-update-freshness-lib.sh when
+# auto-update-helper.sh was split in GH#20343.
+AUTO_UPDATE_SCRIPT="${REPO_ROOT}/.agents/scripts/auto-update-freshness-lib.sh"
 HEADLESS_SCRIPT="${REPO_ROOT}/.agents/scripts/headless-runtime-helper.sh"
 LIFECYCLE_SCRIPT="${REPO_ROOT}/.agents/scripts/worker-lifecycle-common.sh"
 SCHEDULERS_SCRIPT="${REPO_ROOT}/setup-modules/schedulers.sh"
@@ -383,6 +385,128 @@ test_log_no_work_skip_escalation_helper_exists() {
 }
 
 # -----------------------------------------------------------------
+# Part B2 — t2769 no_work circuit breaker structural tests
+# -----------------------------------------------------------------
+# These are code-analysis assertions (no live GH calls). They verify
+# that the t2769 circuit breaker wiring is correct by inspecting the
+# source text of the two files it touches.
+
+NMR_APPROVAL_SCRIPT="${NMR_APPROVAL_SCRIPT:-$(dirname "$LIFECYCLE_SCRIPT")/pulse-nmr-approval.sh}"
+
+test_no_work_circuit_breaker_threshold_guard() {
+	# _log_no_work_skip_escalation must reference NO_WORK_NMR_THRESHOLD
+	# and apply needs-maintainer-review when the threshold is reached.
+
+	# Assertion 1: NO_WORK_NMR_THRESHOLD is referenced in the function body.
+	local fn_src
+	fn_src=$(awk '/^_log_no_work_skip_escalation\(\) \{/,/^\}/' "$LIFECYCLE_SCRIPT" 2>/dev/null)
+	if [[ -z "$fn_src" ]]; then
+		print_result "t2769: no_work circuit breaker threshold guard" 1 \
+			"_log_no_work_skip_escalation not found in $LIFECYCLE_SCRIPT"
+		return 0
+	fi
+
+	if ! printf '%s\n' "$fn_src" | grep -q 'NO_WORK_NMR_THRESHOLD'; then
+		print_result "t2769: no_work circuit breaker threshold guard" 1 \
+			"NO_WORK_NMR_THRESHOLD not referenced in _log_no_work_skip_escalation"
+		return 0
+	fi
+
+	# Assertion 2: the function applies needs-maintainer-review.
+	if ! printf '%s\n' "$fn_src" | grep -q 'needs-maintainer-review'; then
+		print_result "t2769: no_work circuit breaker threshold guard" 1 \
+			"needs-maintainer-review label not applied in _log_no_work_skip_escalation"
+		return 0
+	fi
+
+	# Assertion 3: the NMR path appears BEFORE the below-threshold diagnostic path
+	# (threshold check is the first branch; diagnostic is the fallthrough).
+	local nmr_line diag_line
+	nmr_line=$(printf '%s\n' "$fn_src" | grep -n 'needs-maintainer-review' | head -1 | cut -d: -f1)
+	diag_line=$(printf '%s\n' "$fn_src" | grep -n 'no-work-escalation-skip' | head -1 | cut -d: -f1)
+	if [[ -z "$nmr_line" || -z "$diag_line" ]]; then
+		print_result "t2769: no_work circuit breaker threshold guard" 1 \
+			"could not locate both NMR line (${nmr_line}) and diagnostic line (${diag_line})"
+		return 0
+	fi
+	if [[ "$nmr_line" -ge "$diag_line" ]]; then
+		print_result "t2769: no_work circuit breaker threshold guard" 1 \
+			"NMR path (${nmr_line}) must appear before diagnostic path (${diag_line})"
+		return 0
+	fi
+
+	print_result "t2769: no_work circuit breaker threshold guard" 0
+	return 0
+}
+
+test_no_work_circuit_breaker_marker_posted() {
+	# The NMR path must post a comment containing the
+	# cost-circuit-breaker:no_work_loop marker so that
+	# _nmr_application_is_circuit_breaker_trip can detect it.
+
+	local fn_src
+	fn_src=$(awk '/^_log_no_work_skip_escalation\(\) \{/,/^\}/' "$LIFECYCLE_SCRIPT" 2>/dev/null)
+	if [[ -z "$fn_src" ]]; then
+		print_result "t2769: no_work circuit breaker marker posted" 1 \
+			"_log_no_work_skip_escalation not found"
+		return 0
+	fi
+
+	if ! printf '%s\n' "$fn_src" | grep -q 'cost-circuit-breaker:no_work_loop'; then
+		print_result "t2769: no_work circuit breaker marker posted" 1 \
+			"marker 'cost-circuit-breaker:no_work_loop' not found in function body"
+		return 0
+	fi
+
+	print_result "t2769: no_work circuit breaker marker posted" 0
+	return 0
+}
+
+test_nmr_approval_recognises_no_work_loop_marker() {
+	# _nmr_application_is_circuit_breaker_trip in pulse-nmr-approval.sh must
+	# include cost-circuit-breaker:no_work_loop in its regex so that
+	# auto-approval preserves NMR (t2386 split semantics).
+
+	if [[ ! -f "$NMR_APPROVAL_SCRIPT" ]]; then
+		print_result "t2769: nmr-approval recognises no_work_loop marker" 1 \
+			"pulse-nmr-approval.sh not found at $NMR_APPROVAL_SCRIPT"
+		return 0
+	fi
+
+	local fn_src
+	fn_src=$(awk '/^_nmr_application_is_circuit_breaker_trip\(\) \{/,/^\}/' "$NMR_APPROVAL_SCRIPT" 2>/dev/null)
+	if [[ -z "$fn_src" ]]; then
+		print_result "t2769: nmr-approval recognises no_work_loop marker" 1 \
+			"_nmr_application_is_circuit_breaker_trip not found in $NMR_APPROVAL_SCRIPT"
+		return 0
+	fi
+
+	if ! printf '%s\n' "$fn_src" | grep -q 'cost-circuit-breaker:no_work_loop'; then
+		print_result "t2769: nmr-approval recognises no_work_loop marker" 1 \
+			"marker 'cost-circuit-breaker:no_work_loop' not in recognition regex"
+		return 0
+	fi
+
+	print_result "t2769: nmr-approval recognises no_work_loop marker" 0
+	return 0
+}
+
+test_no_work_false_claim_comment_removed() {
+	# The aspirational comment that falsely claimed cost-circuit-breaker-helper.sh
+	# would apply NMR must no longer be present in worker-lifecycle-common.sh.
+	# Acceptance criterion 3 from GH#20639.
+
+	if grep -q 'cost-circuit-breaker-helper\.sh' "$LIFECYCLE_SCRIPT"; then
+		print_result "t2769: false claim comment removed (AC3)" 1 \
+			"'cost-circuit-breaker-helper.sh' still referenced in $LIFECYCLE_SCRIPT"
+		return 0
+	fi
+
+	print_result "t2769: false claim comment removed (AC3)" 0
+	return 0
+}
+
+# -----------------------------------------------------------------
 # Part C — _preserve_no_activity_output tests
 # -----------------------------------------------------------------
 
@@ -531,6 +655,12 @@ main() {
 	test_escalate_skips_body_gate_on_no_work
 	test_escalate_skips_tier_cascade_on_no_work
 	test_log_no_work_skip_escalation_helper_exists
+
+	# Part B2: t2769 no_work circuit breaker structural assertions
+	test_no_work_circuit_breaker_threshold_guard
+	test_no_work_circuit_breaker_marker_posted
+	test_nmr_approval_recognises_no_work_loop_marker
+	test_no_work_false_claim_comment_removed
 
 	# Part C: preserve tests — clean out any pollution from Part A first
 	rm -rf "${HOME}/.aidevops/logs/worker-no-activity" 2>/dev/null || true

--- a/.agents/scripts/worker-lifecycle-common.sh
+++ b/.agents/scripts/worker-lifecycle-common.sh
@@ -822,6 +822,56 @@ _log_no_work_skip_escalation() {
 	[[ "$issue_number" =~ ^[0-9]+$ ]] || return 0
 	[[ -n "$repo_slug" ]] || return 0
 
+	local nmr_threshold="${NO_WORK_NMR_THRESHOLD:-3}"
+
+	# Circuit-breaker path (t2769): when failure_count reaches the threshold,
+	# apply needs-maintainer-review with a marker that
+	# _nmr_application_is_circuit_breaker_trip recognises, so auto-approval
+	# preserves NMR (t2386 split semantics).
+	if [[ "$failure_count" -ge "$nmr_threshold" ]]; then
+		local nmr_marker='cost-circuit-breaker:no_work_loop'
+		local existing_nmr=""
+		existing_nmr=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
+			--jq "[.[] | select(.body | contains(\"${nmr_marker}\"))] | length" \
+			2>/dev/null) || existing_nmr=""
+		if [[ "$existing_nmr" =~ ^[1-9][0-9]*$ ]]; then
+			printf '[worker-lifecycle][t2769] no_work NMR circuit breaker already applied for #%s (%s, count=%s)\n' \
+				"$issue_number" "$repo_slug" "$failure_count" >&2 || true
+			return 0
+		fi
+
+		gh issue edit "$issue_number" --repo "$repo_slug" \
+			--add-label "needs-maintainer-review" 2>/dev/null || true
+
+		local safe_reason
+		safe_reason=$(_sanitize_markdown "$reason")
+
+		gh_issue_comment "$issue_number" --repo "$repo_slug" \
+			--body "<!-- ${nmr_marker} -->
+## no_work Circuit Breaker Fired (t2769)
+
+**Trigger:** ${failure_count} consecutive worker failure(s) classified as \`no_work\` (threshold: ${nmr_threshold}).
+**Action:** Applied \`needs-maintainer-review\`. Further automated dispatch is suspended.
+**Last failure reason:** ${safe_reason}
+
+**Why this class of failure does not cascade tiers:** \`no_work\` means the worker crashed during runtime setup before reading any target files (FD exhaustion, plugin init failure, auth refresh race). A more expensive model cannot fix an infrastructure problem it never reached.
+
+**Possible causes:**
+- Brief not yet merged or branch missing at dispatch time
+- Auth token stale or missing
+- Plugin init crash (FD exhaustion, env pollution)
+- Branch naming race at dispatch time
+
+Remove \`needs-maintainer-review\` after investigating the root cause to re-enable dispatch.
+
+_Per-issue no_work circuit breaker (t2769). The \`${nmr_marker}\` marker is recognised by \`_nmr_application_is_circuit_breaker_trip\` in \`pulse-nmr-approval.sh\` (t2386 split semantics: auto-approval preserves NMR)._" 2>/dev/null || true
+
+		printf '[worker-lifecycle][t2769] no_work NMR circuit breaker fired for #%s (%s, count=%s)\n' \
+			"$issue_number" "$repo_slug" "$failure_count" >&2 || true
+		return 0
+	fi
+
+	# Below threshold: idempotent diagnostic comment (existing t2387 behaviour).
 	local marker='<!-- no-work-escalation-skip -->'
 
 	# Idempotency check: skip if a prior comment already carries the marker.
@@ -851,7 +901,7 @@ _log_no_work_skip_escalation() {
 
 **Why no cascade:** \`no_work\` means the worker never engaged with the brief — it crashed during runtime setup (FD exhaustion, plugin init failure, branch naming race, auth refresh race). A more expensive model cannot fix an infrastructure problem it never reached. Cascading to \`tier:thinking\` would burn opus tokens on a problem sonnet (or haiku) will handle once the infra clears.
 
-If \`no_work\` crashes continue, the existing circuit breakers (\`cost-circuit-breaker-helper.sh\`, \`dispatch-dedup-stale.sh\`, stale-recovery) will apply \`needs-maintainer-review\` on their own thresholds with markers that \`_nmr_application_is_circuit_breaker_trip\` (t2386) recognises, so auto-approval will correctly preserve the NMR.
+After ${nmr_threshold} consecutive \`no_work\` failures the per-issue no_work circuit breaker (t2769) applies \`needs-maintainer-review\` with a \`cost-circuit-breaker:no_work_loop\` marker that \`_nmr_application_is_circuit_breaker_trip\` (t2386) recognises, so auto-approval correctly preserves NMR.
 
 _Automated by \`escalate_issue_tier()\` no_work skip (t2387) in worker-lifecycle-common.sh_"
 
@@ -896,6 +946,7 @@ _Automated by \`escalate_issue_tier()\` no_work skip (t2387) in worker-lifecycle
 #######################################
 ESCALATION_FAILURE_THRESHOLD="${ESCALATION_FAILURE_THRESHOLD:-2}"
 ESCALATION_OVERWHELMED_THRESHOLD="${ESCALATION_OVERWHELMED_THRESHOLD:-1}"
+NO_WORK_NMR_THRESHOLD="${NO_WORK_NMR_THRESHOLD:-3}"
 
 escalate_issue_tier() {
 	local issue_number="$1"


### PR DESCRIPTION
## Summary

Implements the per-issue `no_work` circuit breaker (GH#20639, Child 2 of #20560).

After N consecutive `no_work` failures on the same issue, applies `needs-maintainer-review` with a `cost-circuit-breaker:no_work_loop` marker. Auto-approval recognises the marker (t2386 split semantics) and preserves NMR until a human investigates.

## What changed

**`worker-lifecycle-common.sh`**
- New env var `NO_WORK_NMR_THRESHOLD` (default 3)
- `_log_no_work_skip_escalation`: when `failure_count >= threshold`, bypasses the idempotent below-threshold path and instead: applies `needs-maintainer-review` via `gh issue edit --add-label` + posts a comment with `<!-- cost-circuit-breaker:no_work_loop -->` marker
- Below threshold: existing idempotent t2387 diagnostic behaviour unchanged; comment updated to reference t2769 instead of the false `cost-circuit-breaker-helper.sh` claim (AC3)

**`pulse-nmr-approval.sh`**
- `_nmr_application_is_circuit_breaker_trip`: adds `cost-circuit-breaker:no_work_loop` to the jq regex — auto-approval preserves NMR for this new class

**`test-worker-reliability-self-heal.sh`**
- 4 new structural tests (AC4): threshold guard present, marker posted, nmr-approval recognises marker, false-claim comment absent
- Fixes pre-existing `AUTO_UPDATE_SCRIPT` path: `check_launchd_plist_drift` moved to `auto-update-freshness-lib.sh` in GH#20343, blocking the entire suite

## Verification

```
shellcheck .agents/scripts/worker-lifecycle-common.sh .agents/scripts/pulse-nmr-approval.sh .agents/scripts/tests/test-worker-reliability-self-heal.sh
bash .agents/scripts/tests/test-worker-reliability-self-heal.sh
# → Ran 16 tests, 0 failed.
```

## Acceptance criteria met

1. `_log_no_work_skip_escalation` at `failure_count >= NO_WORK_NMR_THRESHOLD` posts NMR + marker ✓
2. `_nmr_application_is_circuit_breaker_trip` recognises `cost-circuit-breaker:no_work_loop` → auto-approval preserves NMR ✓
3. Aspirational false claim about `cost-circuit-breaker-helper.sh` removed from comment body ✓
4. 4 new test cases pass ✓

Resolves #20639 For #20560
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.9.0 plugin for [OpenCode](https://opencode.ai) v1.14.22 with claude-sonnet-4-6 spent 10m and 21,679 tokens on this as a headless worker.