### PR TITLE
GH#20678: add --paginate to gh api comments call in no_work circuit breaker

### DIFF
--- a/.agents/scripts/worker-lifecycle-common.sh
+++ b/.agents/scripts/worker-lifecycle-common.sh
@@ -831,7 +831,7 @@ _log_no_work_skip_escalation() {
 	if [[ "$failure_count" -ge "$nmr_threshold" ]]; then
 		local nmr_marker='cost-circuit-breaker:no_work_loop'
 		local existing_nmr=""
-		existing_nmr=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
+		existing_nmr=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" --paginate \
 			--jq "[.[] | select(.body | contains(\"${nmr_marker}\"))] | length" \
 			2>/dev/null) || existing_nmr=""
 		if [[ "$existing_nmr" =~ ^[1-9][0-9]*$ ]]; then


### PR DESCRIPTION
## Summary

Add `--paginate` flag to the `gh api` call that checks for existing NMR circuit breaker comments in `_maybe_apply_no_work_nmr`.

## Problem

Without `--paginate`, GitHub API returns only the first 30 comments (oldest first by default). For issues with >30 comments, the idempotency check (`existing_nmr`) would fail to find a circuit breaker marker that exists in a later page, causing:
- Redundant `needs-maintainer-review` label applications
- Duplicate `<!-- cost-circuit-breaker:no_work_loop -->` comments on every subsequent `no_work` failure

## Fix

`.agents/scripts/worker-lifecycle-common.sh:834` — added `--paginate` so all comment pages are fetched before evaluating the marker count.

## Verification

- ShellCheck passes (zero violations)
- Pre-commit and pre-push hooks pass

Resolves #20678

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.1 plugin for [OpenCode](https://opencode.ai) v1.14.22 with claude-sonnet-4-6 spent 1m and 2,769 tokens on this as a headless worker.