### PR TITLE
t2784: upstream-watch: fix cloudron-packaging-community URL (root→WanderingMonster)

### DIFF
--- a/.agents/configs/upstream-watch.json
+++ b/.agents/configs/upstream-watch.json
@@ -68,11 +68,11 @@
     },
     {
       "name": "cloudron-packaging-community",
-      "url": "https://forgejo.wanderingmonster.dev/root/cloudron-packaging",
+      "url": "https://forgejo.wanderingmonster.dev/WanderingMonster/cloudron-packaging",
       "source_type": "forgejo",
       "description": "Community Cloudron packaging assessment toolkit by LoudLemur/OrcVole",
       "relevance": "Source of the two-axis scoring rubric, verified base image inventory, and assessment patterns we adopted. New commits may add assessed apps, refine scoring, or update base image findings.",
-      "check_command": "curl -s 'https://forgejo.wanderingmonster.dev/api/v1/repos/root/cloudron-packaging/commits?limit=1' | jq -r '(.[0].sha // \"\")'",
+      "check_command": "curl -s 'https://forgejo.wanderingmonster.dev/api/v1/repos/WanderingMonster/cloudron-packaging/commits?limit=1' | jq -r '(.[0].sha // \"\")'",
       "affects": [".agents/tools/deployment/cloudron-app-packaging.md"],
       "last_seen_commit": "047e4b07ce362f484a0c5a9854b14a1a5ecf1b48",
       "added_at": "2026-03-19"


### PR DESCRIPTION
## Summary

Fix consistent `[WARN] check_command failed for cloudron-packaging-community` in `~/.aidevops/logs/upstream-watch.log`.

**Root cause:** The Forgejo instance at `forgejo.wanderingmonster.dev` renamed the `root` user to `WanderingMonster`. The old URL `/api/v1/repos/root/cloudron-packaging/commits?limit=1` now returns HTTP 301 to `/api/v1/repos/WanderingMonster/cloudron-packaging/commits?limit=1`. The `check_command` uses `curl -s` without `-L`, so curl receives the redirect response (HTML, not JSON), `jq` fails to parse it, and `upstream-watch-helper.sh` logs `check_command failed` — every ~13 min, 5+ hours straight.

**Fix:** Update both `url` and `check_command` in `.agents/configs/upstream-watch.json` to use `WanderingMonster` instead of `root`.

**Verified:** running the fixed check_command returns SHA `047e4b07ce362f484a0c5a9854b14a1a5ecf1b48` (non-empty, exit 0).

Resolves #20683

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.1 plugin for [OpenCode](https://opencode.ai) v1.14.22 with claude-sonnet-4-6 spent 3m and 6,048 tokens on this as a headless worker.
