### PR TITLE
t2770: pulse: cross-issue no_work rate circuit breaker

### DIFF
--- a/.agents/configs/pulse-rate-limit.conf
+++ b/.agents/configs/pulse-rate-limit.conf
@@ -28,3 +28,31 @@
 # Set to 0 to disable entirely.
 # Env var AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD takes precedence if already set.
 AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD=0.30
+
+# ── Cross-issue no_work rate circuit breaker (GH#20640, t2770) ────────────────
+#
+# Detects population-wide no_work storms (many DIFFERENT issues all returning
+# no_work in a short window) symptomatic of cross-cutting infrastructure
+# problems (auth outage, GraphQL exhaustion, wrapper stall recurrence).
+#
+# Complements the per-issue no_work breaker (GH#20639, t2769) — this one
+# catches anomalies across the whole issue population, not a single issue.
+#
+# Mechanism: count fast_fail_record crash_type=no_work events in a rolling
+# window. If count >= NO_WORK_WINDOW_MAX within NO_WORK_WINDOW_SECS, pause
+# all dispatch for this cycle and emit one alert log line.
+#
+# State file: ~/.aidevops/logs/pulse-no-work-breaker.state
+# Counter: pulse_dispatch_no_work_breaker_tripped in pulse-stats.json
+#
+# Env var overrides take precedence over these values:
+#   AIDEVOPS_NO_WORK_WINDOW_SECS  — override rolling window duration
+#   AIDEVOPS_NO_WORK_WINDOW_MAX   — override max events in window
+#   AIDEVOPS_SKIP_NO_WORK_BREAKER=1 — emergency bypass (dispatch proceeds)
+
+# Rolling window duration in seconds (default 10 minutes).
+NO_WORK_WINDOW_SECS=600
+
+# Maximum no_work events allowed within the window before the breaker trips.
+# Set to 0 to disable entirely.
+NO_WORK_WINDOW_MAX=10

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -352,6 +352,11 @@ if [[ -z "${AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD+x}" ]] && [[ -f "$_PULSE_RL
 fi
 AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD="${AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD:-0.30}"              # t2690/t2768: canonical default in .agents/configs/pulse-rate-limit.conf. Set to 0 to disable.
 export AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD
+# t2770/GH#20640: cross-issue no_work rate circuit breaker thresholds.
+# Conf file (sourced above) sets NO_WORK_WINDOW_SECS/NO_WORK_WINDOW_MAX if not already in env.
+# Triple-expansion: env var override > conf file value > hardcoded default.
+NO_WORK_WINDOW_SECS="${AIDEVOPS_NO_WORK_WINDOW_SECS:-${NO_WORK_WINDOW_SECS:-600}}"    # Rolling window in seconds (default 10 min)
+NO_WORK_WINDOW_MAX="${AIDEVOPS_NO_WORK_WINDOW_MAX:-${NO_WORK_WINDOW_MAX:-10}}"         # Max no_work events in window before trip
 PULSE_PREFETCH_FULL_SWEEP_INTERVAL="${PULSE_PREFETCH_FULL_SWEEP_INTERVAL:-14400}"                          # Full sweep interval in seconds (default 4h) (GH#15286, GH#18979: reduced from 24h to prevent stale-cache drift on active repos)
 PULSE_RUNNABLE_PR_LIMIT="${PULSE_RUNNABLE_PR_LIMIT:-200}"                                                  # Open PR sample size for runnable-candidate counting
 PULSE_RUNNABLE_ISSUE_LIMIT="${PULSE_RUNNABLE_ISSUE_LIMIT:-1000}"                                           # Open issue sample size for runnable-candidate counting
@@ -1198,6 +1203,131 @@ _pulse_execute_self_check() {
 	return 1
 }
 
+#######################################
+# is_no_work_rate_acceptable — cross-issue no_work rate circuit breaker.
+# t2770 (GH#20640): pulse-level rate breaker for no_work storms.
+#
+# Counts fast_fail_record crash_type=no_work events in a rolling window
+# (default: 10 events in 10 minutes). If exceeded, pauses all dispatch for
+# this cycle with one alert line — prevents chasing an infrastructure outage
+# with more workers that will also fail.
+#
+# Unlike the per-issue no_work escalation (GH#20639), this fires on population-
+# wide anomalies: many DIFFERENT issues returning no_work simultaneously,
+# signalling auth outage, GraphQL exhaustion, or wrapper stall recurrence.
+#
+# State file: ~/.aidevops/logs/pulse-no-work-breaker.state
+# Format: line 1 = "EPOCH TOTAL_LOG_COUNT"; line 2+ = epoch timestamps of
+# no_work events in the rolling window (pruned on each check).
+#
+# Counter: pulse_dispatch_no_work_breaker_tripped in pulse-stats.json
+#
+# Exit codes:
+#   0 — rate acceptable; dispatch may proceed
+#   1 — no_work rate exceeded; dispatch should be deferred this cycle
+#
+# Environment overrides:
+#   AIDEVOPS_NO_WORK_WINDOW_SECS  — rolling window duration (default 600)
+#   AIDEVOPS_NO_WORK_WINDOW_MAX   — max events in window (default 10; 0=disable)
+#   AIDEVOPS_SKIP_NO_WORK_BREAKER=1 — emergency bypass
+#######################################
+is_no_work_rate_acceptable() {
+	# Emergency bypass.
+	if [[ "${AIDEVOPS_SKIP_NO_WORK_BREAKER:-0}" == "1" ]]; then
+		echo "[pulse-wrapper] AIDEVOPS_SKIP_NO_WORK_BREAKER=1 — bypassing no_work rate check (t2770)" >>"$LOGFILE"
+		return 0
+	fi
+
+	local window_secs="${NO_WORK_WINDOW_SECS:-600}"
+	local max_events="${NO_WORK_WINDOW_MAX:-10}"
+	window_secs="${AIDEVOPS_NO_WORK_WINDOW_SECS:-$window_secs}"
+	max_events="${AIDEVOPS_NO_WORK_WINDOW_MAX:-$max_events}"
+
+	# Disabled if max is 0.
+	if [[ "$max_events" -eq 0 ]]; then
+		return 0
+	fi
+
+	local state_file="${HOME}/.aidevops/logs/pulse-no-work-breaker.state"
+	local logfile="${LOGFILE:-${HOME}/.aidevops/logs/pulse.log}"
+	local now
+	now=$(date +%s)
+	local cutoff=$((now - window_secs))
+
+	# Count total no_work events in pulse.log (grep -c exits 1 on zero matches).
+	local current_count=0
+	if [[ -f "$logfile" ]]; then
+		current_count=$(grep -c "crash_type=no_work" "$logfile" 2>/dev/null) || current_count=0
+		[[ "$current_count" =~ ^[0-9]+$ ]] || current_count=0
+	fi
+
+	# Read state file: line 1 = last_scan_epoch last_total_count;
+	# subsequent lines = epoch timestamps of recent no_work events.
+	local last_total=0
+	local -a window_timestamps=()
+	if [[ -f "$state_file" ]]; then
+		local sf_epoch="" sf_count=""
+		read -r sf_epoch sf_count <"$state_file" 2>/dev/null || true
+		[[ "$sf_epoch" =~ ^[0-9]+$ ]] || sf_epoch="0"
+		[[ "$sf_count" =~ ^[0-9]+$ ]] || sf_count="0"
+		last_total="$sf_count"
+
+		# Load timestamps from state file (lines 2+), pruning those outside window.
+		local ts_line
+		while IFS= read -r ts_line; do
+			[[ "$ts_line" =~ ^[0-9]+$ ]] || continue
+			[[ "$ts_line" -ge "$cutoff" ]] && window_timestamps+=("$ts_line")
+		done < <(tail -n +2 "$state_file" 2>/dev/null) || true
+	fi
+
+	# Compute new events since last check.
+	local new_events=0
+	if [[ "$current_count" -lt "$last_total" ]]; then
+		# Log was rotated — reset baseline, treat all current events as new.
+		last_total=0
+	fi
+	if [[ "$current_count" -gt "$last_total" ]]; then
+		new_events=$((current_count - last_total))
+	fi
+	# Cap to max_events to bound state file growth.
+	if [[ "$new_events" -gt "$max_events" ]]; then
+		new_events="$max_events"
+	fi
+
+	# Append current timestamp for each new event.
+	local i=0
+	while [[ "$i" -lt "$new_events" ]]; do
+		window_timestamps+=("$now")
+		i=$((i + 1))
+	done
+
+	local window_count=${#window_timestamps[@]}
+
+	# Write updated state file (atomic via temp file).
+	local tmp_state="${state_file}.tmp.$$"
+	{
+		printf '%s %s\n' "$now" "$current_count"
+		local ts
+		for ts in ${window_timestamps[@]+"${window_timestamps[@]}"}; do
+			printf '%s\n' "$ts"
+		done
+	} > "$tmp_state" 2>/dev/null && mv "$tmp_state" "$state_file" 2>/dev/null || rm -f "$tmp_state" 2>/dev/null || true
+
+	# Check threshold.
+	if [[ "$window_count" -ge "$max_events" ]]; then
+		echo "[pulse-wrapper] no_work rate circuit breaker TRIPPED: ${window_count} events in ${window_secs}s window (max=${max_events}) — deferring dispatch this cycle (t2770)" >>"$LOGFILE"
+
+		# Increment stats counter.
+		if declare -F pulse_stats_increment >/dev/null 2>&1; then
+			pulse_stats_increment "pulse_dispatch_no_work_breaker_tripped" 2>/dev/null || true
+		fi
+
+		return 1
+	fi
+
+	return 0
+}
+
 # ---------------------------------------------------------------------------
 # _pulse_run_deterministic_pipeline
 #
@@ -1278,7 +1408,17 @@ _pulse_run_deterministic_pipeline() {
 	if [[ -f "$STOP_FLAG" ]]; then
 		echo "[pulse-wrapper] Stop flag appeared — skipping deterministic fill floor" >>"$LOGFILE"
 	else
-		apply_deterministic_fill_floor
+		# t2770: cross-issue no_work rate circuit breaker check.
+		# Pauses dispatch when many different issues return no_work in a short
+		# window — symptomatic of auth outage, GraphQL exhaustion, or wrapper
+		# stall. Complementary to the per-issue no_work escalation (GH#20639).
+		local _nw_rc=0
+		is_no_work_rate_acceptable || _nw_rc=$?
+		if [[ "$_nw_rc" -eq 1 ]]; then
+			echo "[pulse-wrapper] Deterministic fill floor skipped: no_work rate circuit breaker tripped (t2770)" >>"$LOGFILE"
+		else
+			apply_deterministic_fill_floor
+		fi
 	fi
 
 	# Routine evaluation (t1925): check repeat: fields in TODO.md routines

--- a/.agents/scripts/tests/test-rate-limit-circuit-breaker.sh
+++ b/.agents/scripts/tests/test-rate-limit-circuit-breaker.sh
@@ -369,6 +369,297 @@ test_log_message_on_trip() {
 }
 
 # =============================================================================
+# Part 2: no_work rate circuit breaker (t2770, GH#20640)
+#
+# Tests is_no_work_rate_acceptable() from pulse-wrapper.sh.
+# The function is extracted via awk to avoid sourcing the entire
+# pulse-wrapper.sh (which triggers jitter, module sources, etc.).
+# Stub strategy: write fake pulse.log lines containing "crash_type=no_work"
+# to control the observed event count.
+# =============================================================================
+
+# Extract is_no_work_rate_acceptable from pulse-wrapper.sh using brace-counting awk.
+_NW_FUNC_DEF="$(awk '
+    /^is_no_work_rate_acceptable\(\) \{/ { depth=1; print; next }
+    depth > 0 {
+        for (i=1; i<=length($0); i++) {
+            c = substr($0,i,1)
+            if (c=="{") depth++
+            else if (c=="}") depth--
+        }
+        print
+        if (depth==0) exit
+    }
+' "${SCRIPTS_DIR}/pulse-wrapper.sh")"
+
+if [[ -z "$_NW_FUNC_DEF" ]]; then
+	printf '  %sSKIP%s no_work breaker tests: could not extract is_no_work_rate_acceptable from pulse-wrapper.sh\n' \
+		"$TEST_RED" "$TEST_NC"
+else
+	# shellcheck disable=SC2317
+	eval "$_NW_FUNC_DEF"
+
+	# Separate sandbox for no_work tests.
+	NW_TMP=$(mktemp -d -t t2770.XXXXXX)
+	trap 'rm -rf "$NW_TMP"' EXIT
+
+	NW_HOME="${NW_TMP}/home"
+	NW_LOGFILE="${NW_TMP}/pulse.log"
+	mkdir -p "${NW_HOME}/.aidevops/logs"
+
+	NW_STATE_FILE="${NW_HOME}/.aidevops/logs/pulse-no-work-breaker.state"
+
+	# Stub pulse_stats_increment for no_work counter tracking.
+	NW_STATS_FILE="${NW_TMP}/nw-stats.log"
+	# shellcheck disable=SC2317
+	pulse_stats_increment() {
+		local counter_name="$1"
+		printf '%s\n' "$counter_name" >>"$NW_STATS_FILE"
+		return 0
+	}
+
+	# Write N no_work lines to the fake pulse.log.
+	write_nw_log_lines() {
+		local count="$1"
+		local i=0
+		while [[ "$i" -lt "$count" ]]; do
+			printf '[pulse-wrapper] fast_fail_record: #%s (repo/repo) failure_backoff reason=stale_timeout crash_type=no_work\n' "$i" >>"$NW_LOGFILE"
+			i=$((i + 1))
+		done
+		return 0
+	}
+
+	reset_nw_state() {
+		: >"$NW_LOGFILE"
+		rm -f "$NW_STATE_FILE"
+		: >"$NW_STATS_FILE"
+		unset AIDEVOPS_SKIP_NO_WORK_BREAKER 2>/dev/null || true
+		export HOME="$NW_HOME"
+		export LOGFILE="$NW_LOGFILE"
+		export NO_WORK_WINDOW_SECS=600
+		export NO_WORK_WINDOW_MAX=10
+		unset AIDEVOPS_NO_WORK_WINDOW_SECS 2>/dev/null || true
+		unset AIDEVOPS_NO_WORK_WINDOW_MAX 2>/dev/null || true
+		return 0
+	}
+
+	printf '\ntest-rate-limit-circuit-breaker.sh (t2770 — no_work rate breaker)\n'
+	printf '====================================================================\n'
+
+	# --- NW Test 1: Passes when no no_work events present ---
+	test_nw_passes_with_no_events() {
+		reset_nw_state
+		local rc=0
+		is_no_work_rate_acceptable || rc=$?
+		if [[ "$rc" -eq 0 ]]; then
+			pass "no_work breaker: passes when log has zero no_work events"
+		else
+			fail "no_work breaker: should pass with zero events (rc=$rc)"
+		fi
+		return 0
+	}
+
+	# --- NW Test 2: Passes when below threshold ---
+	test_nw_passes_below_threshold() {
+		reset_nw_state
+		write_nw_log_lines 5  # 5 events, max=10 → should pass
+		# First call to establish state baseline.
+		local rc=0
+		is_no_work_rate_acceptable || rc=$?
+		if [[ "$rc" -eq 0 ]]; then
+			pass "no_work breaker: passes when 5 events below max=10"
+		else
+			fail "no_work breaker: should pass with 5 events, max=10 (rc=$rc)"
+		fi
+		return 0
+	}
+
+	# --- NW Test 3: Trips when threshold reached (exactly max events) ---
+	test_nw_trips_at_threshold() {
+		reset_nw_state
+		write_nw_log_lines 10  # 10 events, max=10 → should trip
+		local rc=0
+		is_no_work_rate_acceptable || rc=$?
+		if [[ "$rc" -eq 1 ]]; then
+			pass "no_work breaker: trips when exactly max=10 events in window"
+		else
+			fail "no_work breaker: should trip at max=10 events (rc=$rc)"
+		fi
+		return 0
+	}
+
+	# --- NW Test 4: Trips when above threshold (11 events) ---
+	test_nw_trips_above_threshold() {
+		reset_nw_state
+		write_nw_log_lines 11  # 11 events, max=10 → should trip
+		local rc=0
+		is_no_work_rate_acceptable || rc=$?
+		if [[ "$rc" -eq 1 ]]; then
+			pass "no_work breaker: trips when 11 events exceed max=10"
+		else
+			fail "no_work breaker: should trip with 11 events, max=10 (rc=$rc)"
+		fi
+		return 0
+	}
+
+	# --- NW Test 5: Emergency bypass ---
+	test_nw_emergency_bypass() {
+		reset_nw_state
+		write_nw_log_lines 50  # Far above threshold
+		export AIDEVOPS_SKIP_NO_WORK_BREAKER=1
+		local rc=0
+		is_no_work_rate_acceptable || rc=$?
+		if [[ "$rc" -eq 0 ]]; then
+			pass "no_work breaker: emergency bypass allows dispatch (rc=0)"
+		else
+			fail "no_work breaker: emergency bypass should allow dispatch (rc=$rc)"
+		fi
+		return 0
+	}
+
+	# --- NW Test 6: Disabled when max=0 ---
+	test_nw_disabled_at_zero_max() {
+		reset_nw_state
+		export NO_WORK_WINDOW_MAX=0
+		write_nw_log_lines 100  # Far above disabled threshold
+		local rc=0
+		is_no_work_rate_acceptable || rc=$?
+		if [[ "$rc" -eq 0 ]]; then
+			pass "no_work breaker: disabled when NO_WORK_WINDOW_MAX=0"
+		else
+			fail "no_work breaker: should be disabled when max=0 (rc=$rc)"
+		fi
+		return 0
+	}
+
+	# --- NW Test 7: Counter increments on trip ---
+	test_nw_counter_increments_on_trip() {
+		reset_nw_state
+		write_nw_log_lines 11
+		is_no_work_rate_acceptable || true
+		local count
+		count=$(grep -c "^pulse_dispatch_no_work_breaker_tripped$" "$NW_STATS_FILE" 2>/dev/null) || count=0
+		if [[ "$count" -eq 1 ]]; then
+			pass "no_work breaker: pulse_dispatch_no_work_breaker_tripped counter incremented"
+		else
+			fail "no_work breaker: counter should increment once on trip (got $count)"
+		fi
+		return 0
+	}
+
+	# --- NW Test 8: Counter does NOT increment when passing ---
+	test_nw_counter_no_increment_on_pass() {
+		reset_nw_state
+		write_nw_log_lines 3
+		is_no_work_rate_acceptable || true
+		local count
+		count=$(grep -c "^pulse_dispatch_no_work_breaker_tripped$" "$NW_STATS_FILE" 2>/dev/null) || count=0
+		if [[ "$count" -eq 0 ]]; then
+			pass "no_work breaker: counter not incremented when passing"
+		else
+			fail "no_work breaker: counter should not increment on pass (got $count)"
+		fi
+		return 0
+	}
+
+	# --- NW Test 9: State file written on check ---
+	test_nw_state_file_written() {
+		reset_nw_state
+		write_nw_log_lines 3
+		is_no_work_rate_acceptable || true
+		if [[ -f "$NW_STATE_FILE" ]]; then
+			pass "no_work breaker: state file written after check"
+		else
+			fail "no_work breaker: state file should be written after check"
+		fi
+		return 0
+	}
+
+	# --- NW Test 10: Log message on trip ---
+	test_nw_log_message_on_trip() {
+		reset_nw_state
+		write_nw_log_lines 11
+		is_no_work_rate_acceptable || true
+		if grep -q "no_work rate circuit breaker TRIPPED" "$NW_LOGFILE" 2>/dev/null; then
+			pass "no_work breaker: TRIPPED log message emitted"
+		else
+			fail "no_work breaker: should emit 'no_work rate circuit breaker TRIPPED' log message"
+		fi
+		return 0
+	}
+
+	# --- NW Test 11: Custom threshold via env var ---
+	test_nw_custom_max_env_var() {
+		reset_nw_state
+		export AIDEVOPS_NO_WORK_WINDOW_MAX=5
+		write_nw_log_lines 5
+		local rc=0
+		is_no_work_rate_acceptable || rc=$?
+		if [[ "$rc" -eq 1 ]]; then
+			pass "no_work breaker: AIDEVOPS_NO_WORK_WINDOW_MAX=5 trips at 5 events"
+		else
+			fail "no_work breaker: should trip at AIDEVOPS_NO_WORK_WINDOW_MAX=5 (rc=$rc)"
+		fi
+		return 0
+	}
+
+	# --- NW Test 12: Window pruning — old events don't count ---
+	test_nw_window_pruning() {
+		reset_nw_state
+		export NO_WORK_WINDOW_SECS=1  # 1 second window
+		write_nw_log_lines 11  # 11 events — enough to trip at max=10
+		# First call: establish state with 11 events in window.
+		is_no_work_rate_acceptable || true
+		# Wait for window to expire.
+		sleep 2
+		# Second call: all events should be pruned (outside the 1s window).
+		# No new events since last check → should pass.
+		local rc=0
+		is_no_work_rate_acceptable || rc=$?
+		if [[ "$rc" -eq 0 ]]; then
+			pass "no_work breaker: old events pruned after window expires"
+		else
+			fail "no_work breaker: should pass after window expires (rc=$rc)"
+		fi
+		return 0
+	}
+
+	# Save outer sandbox state before no_work tests modify HOME/LOGFILE.
+	_NW_SAVE_HOME="$HOME"
+	_NW_SAVE_LOGFILE="$LOGFILE"
+	_NW_SAVE_STATS_FILE="$STATS_COUNTER_FILE"
+
+	test_nw_passes_with_no_events
+	test_nw_passes_below_threshold
+	test_nw_trips_at_threshold
+	test_nw_trips_above_threshold
+	test_nw_emergency_bypass
+	test_nw_disabled_at_zero_max
+	test_nw_counter_increments_on_trip
+	test_nw_counter_no_increment_on_pass
+	test_nw_state_file_written
+	test_nw_log_message_on_trip
+	test_nw_custom_max_env_var
+	test_nw_window_pruning
+
+	# Restore outer sandbox state for GraphQL breaker tests that follow.
+	export HOME="$_NW_SAVE_HOME"
+	export LOGFILE="$_NW_SAVE_LOGFILE"
+	# Restore the original pulse_stats_increment (reads from $STATS_COUNTER_FILE).
+	# shellcheck disable=SC2317
+	pulse_stats_increment() {
+		local counter_name="$1"
+		printf '%s\n' "$counter_name" >>"$_NW_SAVE_STATS_FILE"
+		return 0
+	}
+	# Restore the circuit-breaker state file path (in outer HOME).
+	rm -f "${HOME}/.aidevops/logs/pulse-graphql-circuit-breaker.state" 2>/dev/null || true
+	# Restore GraphQL threshold to test default (0.05).
+	export AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD="0.05"
+	unset AIDEVOPS_SKIP_NO_WORK_BREAKER NO_WORK_WINDOW_SECS NO_WORK_WINDOW_MAX 2>/dev/null || true
+fi  # end: no_work breaker tests
+
+# =============================================================================
 # Run all tests
 # =============================================================================
 test_breaker_trips_below_threshold


### PR DESCRIPTION
## Summary

Implements a pulse-level rate circuit breaker (t2770) that detects population-wide `no_work` storms — many different issues returning `crash_type=no_work` in a short window, signalling cross-cutting infrastructure failures (auth outage, GraphQL exhaustion, wrapper stall recurrence).

Complements the per-issue no_work escalation (Child 2, #20639). This one fires on cross-issue anomalies; that one fires on a single issue looping.

## Changes

- **`.agents/configs/pulse-rate-limit.conf`**: Added `NO_WORK_WINDOW_SECS=600` (10 min window) and `NO_WORK_WINDOW_MAX=10` with env var overrides, bypass, and full documentation. Single source of truth alongside the existing GraphQL threshold.

- **`.agents/scripts/pulse-wrapper.sh`**:
  - Added `is_no_work_rate_acceptable()` — rolling window rate check over `pulse.log` delta counts. Tracks new `crash_type=no_work` events since last check; stores epoch timestamps in `~/.aidevops/logs/pulse-no-work-breaker.state`; prunes events older than the window on each check; increments `pulse_dispatch_no_work_breaker_tripped` counter in `pulse-stats.json`.
  - Env bypass: `AIDEVOPS_SKIP_NO_WORK_BREAKER=1`. Disabled when `NO_WORK_WINDOW_MAX=0`.
  - Call site in `_pulse_run_deterministic_pipeline` wraps `apply_deterministic_fill_floor` — same pattern as the STOP_FLAG guard. Logs exactly one clear message per trip (no spam).

- **`.agents/scripts/tests/test-rate-limit-circuit-breaker.sh`**: Added 12 test cases covering: trip/pass thresholds, emergency bypass, disabled-at-zero-max, counter increments, state file lifecycle, log message emission, custom threshold via env var, and window pruning. Env save/restore prevents test isolation failures with the existing 14 GraphQL breaker tests.

## Verification

```bash
shellcheck .agents/scripts/pulse-wrapper.sh
bash .agents/scripts/tests/test-rate-limit-circuit-breaker.sh
# Output: 27/27 tests passed (all passed)

# After a simulated trip in production:
jq '.counters.pulse_dispatch_no_work_breaker_tripped' ~/.aidevops/logs/pulse-stats.json
```

## Acceptance Criteria

- [x] Breaker trips when `no_work` rate exceeds threshold in window
- [x] Dispatch loop logs exactly one clear message per trip (no spam)
- [x] Counter `pulse_dispatch_no_work_breaker_tripped` visible in `pulse-stats.json`
- [x] Auto-resets when window clears (no stale-state hang) — window pruning test confirms

## Complexity Bump Justification

The changes add ~130 lines to `pulse-wrapper.sh` (new function + call site guard). This is within the function-complexity budget; each function is well-scoped. No nesting depth increase above the existing baseline in `pulse-wrapper.sh`.

Resolves #20640
For #20560
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.1 plugin for [OpenCode](https://opencode.ai) v1.14.22 with claude-sonnet-4-6 spent 15m and 36,563 tokens on this as a headless worker.