### PR TITLE
t2781: per-issue rate_limit backoff gate in dispatch engine

### DIFF
--- a/.agents/scripts/dispatch-backoff-helper.sh
+++ b/.agents/scripts/dispatch-backoff-helper.sh
@@ -1,0 +1,373 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# dispatch-backoff-helper.sh — Per-issue rate_limit backoff gate (t2781, GH#20680)
+#
+# Prevents repeated dispatch of issues that repeatedly produce rate_limit exits.
+# Reads headless-runtime-metrics.jsonl to count per-issue rate_limit exits within
+# a lookback window, then applies a graduated cooldown.
+#
+# Problem being solved:
+#   headless-runtime-metrics.jsonl shows 407 rate_limit events (~31.5h burn).
+#   The existing fast_fail rate_limit path immediately retries when another account
+#   is available — so a pool of N accounts means an issue can fail N times per
+#   cycle with zero cooldown. This compounds cost at scale.
+#
+# Backoff schedule (tuned against observed 407-event cluster):
+#   failures | cooldown
+#   ---------|----------
+#   1        | 5 min  (300s)   — single fluke; retry quickly
+#   2        | 30 min (1800s)  — pattern emerging; cool off
+#   3        | 2h     (7200s)  — systemic; wait for capacity recovery
+#   4+       | 24h    (86400s) — apply needs-maintainer-review too
+#
+# Subcommands:
+#   check <issue_num> [<slug>]  — exit 0 if clear, exit 1 if cooldown active,
+#                                 exit 2 on error (fail-open: dispatch proceeds)
+#   help                        — usage information
+#
+# Exit codes (check):
+#   0  — clear; dispatch may proceed
+#   1  — cooldown active; prints "BACKOFF_ACTIVE reason=rate_limit_cooldown next=<ts>"
+#        and next-eligible human timestamp to stderr
+#   2  — error (fail-open: dispatch proceeds with warning logged)
+#
+# Environment overrides:
+#   DISPATCH_BACKOFF_METRICS_FILE     — path to headless-runtime-metrics.jsonl
+#                                       (default: ~/.aidevops/logs/headless-runtime-metrics.jsonl)
+#   DISPATCH_BACKOFF_LOOKBACK_SECS    — how far back to count failures (default 604800 = 7 days)
+#   DISPATCH_BACKOFF_NMR_THRESHOLD    — failure count at which to request NMR (default 4)
+#   AIDEVOPS_SKIP_DISPATCH_BACKOFF=1  — emergency bypass (dispatch proceeds unconditionally)
+#
+# Integration:
+#   Sourced by pulse-dispatch-engine.sh. The check_dispatch_backoff() function
+#   is called in _dff_should_skip_candidate() after fast_fail_is_skipped().
+#   For NMR application (failure >= threshold), the caller reads the "NMR_REQUIRED"
+#   marker from stderr and applies the label via gh.
+#
+# Counter:
+#   dispatch_backoff_skipped in ~/.aidevops/logs/pulse-stats.json
+#   (via pulse-stats-helper.sh / pulse_stats_increment). Surfaced by `aidevops status`.
+#
+# Why read JSONL instead of a separate state file:
+#   The JSONL is the authoritative, tamper-evident record of per-worker outcomes.
+#   A separate state file would diverge on crash, restart, or manual recovery.
+#   awk processes the JSONL in O(n) with a 500K file in <10ms — cheap enough
+#   for every dispatch cycle candidate.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+
+# Source pulse-stats-helper.sh for counter support (optional — fail-open if missing).
+# shellcheck source=pulse-stats-helper.sh
+if [[ -f "${SCRIPT_DIR}/pulse-stats-helper.sh" ]]; then
+	# shellcheck disable=SC1091
+	source "${SCRIPT_DIR}/pulse-stats-helper.sh"
+fi
+
+# LOGFILE for sourced-mode usage (caller sets it; standalone mode defines a default).
+LOGFILE="${LOGFILE:-${HOME}/.aidevops/logs/pulse.log}"
+
+# Configuration (overridable via environment).
+DISPATCH_BACKOFF_METRICS_FILE="${DISPATCH_BACKOFF_METRICS_FILE:-${HOME}/.aidevops/logs/headless-runtime-metrics.jsonl}"
+DISPATCH_BACKOFF_LOOKBACK_SECS="${DISPATCH_BACKOFF_LOOKBACK_SECS:-604800}"  # 7 days
+DISPATCH_BACKOFF_NMR_THRESHOLD="${DISPATCH_BACKOFF_NMR_THRESHOLD:-4}"       # 4+ failures → NMR
+
+# Backoff intervals in seconds (indexed by failure count; index 0 unused).
+# Index >= NMR_THRESHOLD uses the last entry (86400 = 24h).
+readonly _BACKOFF_SCHEDULE=(0 300 1800 7200 86400)  # [0]=unused [1]=5m [2]=30m [3]=2h [4+]=24h
+
+# Log prefix for all messages from this module.
+_DB_LOG_PREFIX="[dispatch-backoff]"
+
+#######################################
+# Compute cooldown seconds for a given failure count.
+#
+# Args:
+#   $1 - failure_count (integer >= 1)
+# Stdout: cooldown in seconds
+#######################################
+_db_cooldown_for_count() {
+	local count="$1"
+	local max_idx=$(( ${#_BACKOFF_SCHEDULE[@]} - 1 ))
+	local idx="$count"
+	[[ "$idx" -gt "$max_idx" ]] && idx="$max_idx"
+	[[ "$idx" -lt 1 ]] && idx=1
+	printf '%s\n' "${_BACKOFF_SCHEDULE[$idx]}"
+	return 0
+}
+
+#######################################
+# Count rate_limit exits for an issue in the metrics JSONL within the lookback window.
+#
+# Uses jq for JSONL parsing — select() filters matching entries in a single
+# pass. BSD awk (macOS default) does not support capture groups in match(),
+# so awk-based parsing would fail silently. jq is a hard framework dependency.
+#
+# Returns two values on stdout: "<count> <last_ts>"
+#   count   — number of rate_limit entries in the lookback window
+#   last_ts — epoch of the most recent rate_limit entry (0 if count=0)
+#
+# Args:
+#   $1 - issue_number (integer)
+#   $2 - since_epoch  (only count entries with ts >= this)
+# Stdout: "count last_ts"
+#######################################
+_db_count_rate_limit_events() {
+	local issue_number="$1"
+	local since_epoch="$2"
+	local session_key="issue-${issue_number}"
+	local metrics_file="$DISPATCH_BACKOFF_METRICS_FILE"
+
+	if [[ ! -f "$metrics_file" ]]; then
+		printf '0 0\n'
+		return 0
+	fi
+
+	# jq JSONL parser: select matching entries (session_key, result, ts >= since),
+	# emit ts values, collect count and max. Single pass over the file.
+	# --slurp reads all lines into an array for aggregate operations.
+	# Fallback: if jq fails, return "0 0" (fail-open).
+	local result
+	result=$(jq -r --arg sk "$session_key" --argjson since "$since_epoch" \
+		'select(.session_key == $sk and .result == "rate_limit" and (.ts // 0) >= $since) | .ts' \
+		"$metrics_file" 2>/dev/null \
+		| awk 'BEGIN{count=0;last=0} {count++; if($1+0>last+0)last=$1+0} END{printf "%d %d\n",count,last}' \
+		2>/dev/null) || result="0 0"
+
+	[[ -n "$result" ]] || result="0 0"
+	printf '%s\n' "$result"
+	return 0
+}
+
+#######################################
+# Check whether dispatch backoff is active for an issue.
+#
+# Reads headless-runtime-metrics.jsonl for recent rate_limit events,
+# applies the graduated cooldown schedule, and returns exit 1 if
+# the cooldown window is still active.
+#
+# Called from _dff_should_skip_candidate() in pulse-dispatch-engine.sh
+# immediately after fast_fail_is_skipped().
+#
+# Exit codes:
+#   0 — clear; dispatch may proceed
+#   1 — cooldown active; prints BACKOFF_ACTIVE line to stderr
+#   2 — error; fail-open (caller should log warning and proceed)
+#
+# Args:
+#   $1 - issue_number
+#   $2 - repo_slug (informational only — JSONL does not include slug)
+#######################################
+check_dispatch_backoff() {
+	local issue_number="$1"
+	local repo_slug="${2:-unknown}"
+
+	# Emergency bypass.
+	if [[ "${AIDEVOPS_SKIP_DISPATCH_BACKOFF:-0}" == "1" ]]; then
+		echo "${_DB_LOG_PREFIX} AIDEVOPS_SKIP_DISPATCH_BACKOFF=1 — bypassing rate-limit backoff check" >>"$LOGFILE"
+		return 0
+	fi
+
+	# Validate input.
+	if [[ ! "$issue_number" =~ ^[0-9]+$ ]]; then
+		echo "${_DB_LOG_PREFIX} WARNING: invalid issue_number '${issue_number}' — proceeding (fail-open)" >>"$LOGFILE"
+		return 2
+	fi
+
+	local now
+	now=$(date +%s 2>/dev/null) || now=0
+	if [[ "$now" -eq 0 ]]; then
+		echo "${_DB_LOG_PREFIX} WARNING: could not get current epoch — proceeding (fail-open)" >>"$LOGFILE"
+		return 2
+	fi
+
+	local since=$(( now - DISPATCH_BACKOFF_LOOKBACK_SECS ))
+	[[ "$since" -lt 0 ]] && since=0
+
+	# Count recent rate_limit events.
+	local count_result
+	count_result=$(_db_count_rate_limit_events "$issue_number" "$since") || count_result="0 0"
+
+	local count last_ts
+	read -r count last_ts <<<"$count_result"
+	[[ "$count" =~ ^[0-9]+$ ]] || count=0
+	[[ "$last_ts" =~ ^[0-9]+$ ]] || last_ts=0
+
+	if [[ "$count" -eq 0 ]]; then
+		# No recent rate_limit events — clear for dispatch.
+		return 0
+	fi
+
+	# Compute cooldown window.
+	local cooldown_secs
+	cooldown_secs=$(_db_cooldown_for_count "$count")
+	local next_eligible=$(( last_ts + cooldown_secs ))
+
+	if [[ "$now" -lt "$next_eligible" ]]; then
+		# Cooldown still active.
+		local wait_remaining=$(( next_eligible - now ))
+		local next_human
+		next_human=$(date -r "$next_eligible" '+%Y-%m-%dT%H:%M:%S' 2>/dev/null || \
+			date -d "@${next_eligible}" '+%Y-%m-%dT%H:%M:%S' 2>/dev/null || \
+			printf 'epoch:%s' "$next_eligible")
+
+		local nmr_flag=""
+		if [[ "$count" -ge "$DISPATCH_BACKOFF_NMR_THRESHOLD" ]]; then
+			nmr_flag=" NMR_REQUIRED"
+		fi
+
+		printf 'BACKOFF_ACTIVE reason=rate_limit_cooldown count=%s cooldown=%ss wait=%ss next=%s%s\n' \
+			"$count" "$cooldown_secs" "$wait_remaining" "$next_human" "$nmr_flag" >&2
+
+		echo "${_DB_LOG_PREFIX} BACKOFF_ACTIVE #${issue_number} (${repo_slug}) count=${count} cooldown=${cooldown_secs}s wait=${wait_remaining}s next=${next_human}${nmr_flag}" >>"$LOGFILE"
+
+		# Increment stats counter.
+		if declare -F pulse_stats_increment >/dev/null 2>&1; then
+			pulse_stats_increment "dispatch_backoff_skipped" 2>/dev/null || true
+		fi
+
+		return 1
+	fi
+
+	# Cooldown has elapsed — clear for dispatch.
+	echo "${_DB_LOG_PREFIX} backoff elapsed for #${issue_number} (${repo_slug}) count=${count} last_rate_limit=$(date -r "$last_ts" '+%H:%M:%S' 2>/dev/null || printf '%s' "$last_ts") — dispatch may proceed" >>"$LOGFILE"
+	return 0
+}
+
+#######################################
+# Apply needs-maintainer-review to an issue when rate_limit failures
+# have exceeded the NMR threshold. Called by the dispatch engine when
+# check_dispatch_backoff returns 1 AND the stderr contains "NMR_REQUIRED".
+#
+# Idempotent: only applies NMR once per issue (uses a marker comment).
+# Best-effort: failures are logged but never fatal.
+#
+# Args:
+#   $1 - issue_number
+#   $2 - repo_slug
+#   $3 - failure_count
+#######################################
+_db_apply_nmr_if_needed() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local failure_count="$3"
+
+	local nmr_marker="<!-- dispatch-backoff:rate_limit_nmr -->"
+
+	# Idempotency check.
+	local existing_nmr=""
+	existing_nmr=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
+		--jq "[.[] | select(.body | contains(\"dispatch-backoff:rate_limit_nmr\"))] | length" \
+		2>/dev/null) || existing_nmr=""
+	if [[ "$existing_nmr" =~ ^[1-9][0-9]*$ ]]; then
+		echo "${_DB_LOG_PREFIX} NMR already applied for #${issue_number} (${repo_slug}) — skipping" >>"$LOGFILE"
+		return 0
+	fi
+
+	# Apply the label.
+	gh issue edit "$issue_number" --repo "$repo_slug" \
+		--add-label "needs-maintainer-review" 2>/dev/null || true
+
+	# Post diagnostic comment.
+	local body="${nmr_marker}
+## Rate-Limit Backoff Circuit Breaker (t2781)
+
+**Trigger:** ${failure_count} rate_limit failure(s) for this issue within the lookback window (threshold: ${DISPATCH_BACKOFF_NMR_THRESHOLD}).
+**Action:** Applied \`needs-maintainer-review\`. Further automated dispatch is suspended for 24h and until the label is removed.
+
+**Why this is different from other NMR trips:** Worker rate_limit failures are NOT a problem with the issue body or model tier — they indicate provider capacity exhaustion specific to this issue's account/provider pairing. Escalating to a higher tier would not help.
+
+**Possible causes:**
+- Provider rate limits for the account(s) dispatching this issue are exhausted
+- The issue's model/tier routing hits a heavily contended capacity tier
+- Multiple concurrent dispatches competing for the same limited capacity
+
+**Recommended actions:**
+1. Check \`aidevops status\` for current GraphQL budget and account pool state
+2. Rotate or add accounts via \`model-accounts-pool-helper.sh\`
+3. Wait for provider rate-limit reset (typically 1h for Anthropic, 24h for OpenAI tier limits)
+4. Remove \`needs-maintainer-review\` to re-enable dispatch once capacity recovers
+
+_Per-issue rate_limit backoff circuit breaker (t2781). The \`dispatch-backoff:rate_limit_nmr\` marker is recognised by \`_nmr_application_is_circuit_breaker_trip\` in \`pulse-nmr-approval.sh\` (t2386 split semantics: auto-approval preserves NMR)._"
+
+	if declare -F gh_issue_comment >/dev/null 2>&1; then
+		gh_issue_comment "$issue_number" --repo "$repo_slug" --body "$body" 2>/dev/null || true
+	else
+		gh issue comment "$issue_number" --repo "$repo_slug" --body "$body" 2>/dev/null || true
+	fi
+
+	echo "${_DB_LOG_PREFIX} NMR applied for #${issue_number} (${repo_slug}) count=${failure_count}" >>"$LOGFILE"
+	return 0
+}
+
+#######################################
+# Standalone CLI entry point.
+#######################################
+_main() {
+	local cmd="${1:-help}"
+	shift || true
+
+	case "$cmd" in
+		check)
+			local issue_number="${1:-}"
+			local slug="${2:-unknown}"
+
+			if [[ -z "$issue_number" ]]; then
+				printf 'Error: issue_number required\n' >&2
+				printf 'Usage: dispatch-backoff-helper.sh check <issue_number> [<slug>]\n' >&2
+				return 1
+			fi
+
+			local backoff_stderr_output=""
+			local backoff_rc=0
+			backoff_stderr_output=$(check_dispatch_backoff "$issue_number" "$slug" 2>&1 >/dev/null) || backoff_rc=$?
+
+			case "$backoff_rc" in
+				0)
+					printf 'CLEAR: no active rate_limit backoff for issue #%s\n' "$issue_number"
+					return 0
+					;;
+				1)
+					printf '%s\n' "$backoff_stderr_output"
+
+					# Apply NMR if needed (NMR_REQUIRED in output).
+					if printf '%s' "$backoff_stderr_output" | grep -q 'NMR_REQUIRED'; then
+						local count_field
+						count_field=$(printf '%s' "$backoff_stderr_output" | grep -oE 'count=[0-9]+' | head -1 | cut -d= -f2)
+						[[ "$count_field" =~ ^[0-9]+$ ]] || count_field="$DISPATCH_BACKOFF_NMR_THRESHOLD"
+						_db_apply_nmr_if_needed "$issue_number" "$slug" "$count_field"
+					fi
+					return 1
+					;;
+				*)
+					printf 'WARNING: backoff check error (fail-open)\n' >&2
+					return 2
+					;;
+			esac
+			;;
+		help | --help | -h)
+			printf 'dispatch-backoff-helper.sh — Per-issue rate_limit backoff gate (t2781)\n\n'
+			printf 'Usage:\n'
+			printf '  dispatch-backoff-helper.sh check <issue_num> [<slug>]  # exit 0=clear, 1=backoff active, 2=error\n'
+			printf '\n'
+			printf 'Environment:\n'
+			printf '  DISPATCH_BACKOFF_METRICS_FILE      path to headless-runtime-metrics.jsonl\n'
+			printf '  DISPATCH_BACKOFF_LOOKBACK_SECS     lookback window in seconds (default 604800 = 7 days)\n'
+			printf '  DISPATCH_BACKOFF_NMR_THRESHOLD     failure count triggering NMR (default 4)\n'
+			printf '  AIDEVOPS_SKIP_DISPATCH_BACKOFF=1   emergency bypass\n'
+			return 0
+			;;
+		*)
+			printf 'Unknown command: %s\n' "$cmd" >&2
+			printf 'Run: dispatch-backoff-helper.sh help\n' >&2
+			return 1
+			;;
+	esac
+}
+
+# Only run _main when executed directly (not sourced).
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+	_main "$@"
+fi

--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -44,6 +44,13 @@ if [[ -f "${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}/pulse-rat
 	source "${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}/pulse-rate-limit-circuit-breaker.sh"
 fi
 
+# t2781: Source per-issue rate_limit backoff helper (graduated cooldown by failure count).
+# shellcheck source=dispatch-backoff-helper.sh
+if [[ -f "${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}/dispatch-backoff-helper.sh" ]]; then
+	# shellcheck disable=SC1091
+	source "${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}/dispatch-backoff-helper.sh"
+fi
+
 # t1959: Module-level variable to communicate launch failure reason to callers.
 # Set by check_worker_launch before each return 1; read by dispatch loop for
 # per-round no_worker_process tracking and canary cache invalidation.
@@ -345,6 +352,32 @@ _dff_should_skip_candidate() {
 	if fast_fail_is_skipped "$issue_number" "$repo_slug"; then
 		echo "[pulse-wrapper] Deterministic fill floor: skipping #${issue_number} (${repo_slug}) — fast-fail threshold reached" >>"$LOGFILE"
 		return 0
+	fi
+
+	# t2781: Per-issue rate_limit backoff — graduated cooldown based on recent
+	# rate_limit exits in headless-runtime-metrics.jsonl. Prevents repeated dispatch
+	# of issues where every account in the pool rate-limits (the existing fast_fail
+	# rate_limit path does an immediate retry when other accounts are available,
+	# producing 0s cooldown. This gate adds a per-issue floor independent of pool state).
+	if declare -F check_dispatch_backoff >/dev/null 2>&1; then
+		local _backoff_output="" _backoff_rc=0
+		_backoff_output=$(check_dispatch_backoff "$issue_number" "$repo_slug" 2>&1 >/dev/null) || _backoff_rc=$?
+		if [[ "$_backoff_rc" -eq 1 ]]; then
+			echo "[pulse-wrapper] Deterministic fill floor: skipping #${issue_number} (${repo_slug}) — ${_backoff_output}" >>"$LOGFILE"
+			# Apply NMR when the backoff helper signals 4th+ failure threshold.
+			if printf '%s' "$_backoff_output" | grep -q 'NMR_REQUIRED'; then
+				local _backoff_count=""
+				_backoff_count=$(printf '%s' "$_backoff_output" | grep -oE 'count=[0-9]+' | head -1 | cut -d= -f2)
+				[[ "$_backoff_count" =~ ^[0-9]+$ ]] || _backoff_count="${DISPATCH_BACKOFF_NMR_THRESHOLD:-4}"
+				declare -F _db_apply_nmr_if_needed >/dev/null 2>&1 && \
+					_db_apply_nmr_if_needed "$issue_number" "$repo_slug" "$_backoff_count" || true
+			fi
+			return 0
+		fi
+		# rc=2 → error; fail-open (log warning, continue to dispatch)
+		if [[ "$_backoff_rc" -eq 2 ]]; then
+			echo "[pulse-wrapper] Deterministic fill floor: backoff check error for #${issue_number} — proceeding (fail-open)" >>"$LOGFILE"
+		fi
 	fi
 
 	# t1899/t1937: Skip issues with placeholder/empty bodies — dispatching a

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1122,6 +1122,7 @@ _pulse_execute_self_check() {
 		run_canonical_maintenance
 		dirty_pr_sweep_all_repos
 		_pulse_refresh_repo
+		check_dispatch_backoff
 	)
 	for _sc_fn in "${_sc_expected_fns[@]}"; do
 		if ! declare -F "$_sc_fn" >/dev/null 2>&1; then

--- a/.agents/scripts/tests/test-dispatch-backoff-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-backoff-helper.sh
@@ -1,0 +1,403 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-dispatch-backoff-helper.sh — t2781 / GH#20680 regression guard.
+#
+# Asserts the per-issue rate_limit backoff gate:
+#   1. Returns clear (exit 0) when no rate_limit events for the issue
+#   2. Returns clear (exit 0) after the cooldown window elapses
+#   3. 1st failure: 5min cooldown (300s) — blocks dispatch during window
+#   4. 2nd failure: 30min cooldown (1800s)
+#   5. 3rd failure: 2h cooldown (7200s)
+#   6. 4th+ failure: 24h cooldown + NMR_REQUIRED flag in stderr
+#   7. Fails open on JSONL read error (missing file)
+#   8. Emergency bypass via AIDEVOPS_SKIP_DISPATCH_BACKOFF=1
+#   9. Stats counter increments on backoff block
+#  10. AC3 from GH#20680: simulate 2 rate_limit exits, confirm 3rd dispatch blocked at 30min
+#
+# Stub strategy: write a fixture JSONL file with controlled timestamps.
+# No gh stubs needed for the check subcommand (NMR application tests use gh stubs).
+
+set -uo pipefail
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR_TEST}/.." && pwd)" || exit 1
+
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf '  %sPASS%s %s\n' "$TEST_GREEN" "$TEST_NC" "$1"
+	return 0
+}
+
+fail() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '  %sFAIL%s %s\n' "$TEST_RED" "$TEST_NC" "$1"
+	if [[ -n "${2:-}" ]]; then
+		printf '       %s\n' "$2"
+	fi
+	return 0
+}
+
+# =============================================================================
+# Sandbox
+# =============================================================================
+TMP=$(mktemp -d -t t2781.XXXXXX)
+trap 'rm -rf "$TMP"' EXIT
+
+export LOGFILE="${TMP}/test-pulse.log"
+export HOME="${TMP}/home"
+mkdir -p "${HOME}/.aidevops/logs"
+
+FIXTURE_METRICS="${TMP}/headless-runtime-metrics.jsonl"
+export DISPATCH_BACKOFF_METRICS_FILE="$FIXTURE_METRICS"
+
+# Stub pulse-stats-helper.sh — track counter increments.
+STATS_COUNTER_FILE="${TMP}/stats-counter.log"
+pulse_stats_increment() {
+	local counter_name="$1"
+	printf '%s\n' "$counter_name" >>"$STATS_COUNTER_FILE"
+	return 0
+}
+export -f pulse_stats_increment
+
+# Stub gh for NMR tests — captures calls without network.
+gh() {
+	printf '[gh-stub] %s\n' "$*" >>"${TMP}/gh-calls.log"
+	return 0
+}
+export -f gh
+
+# Source the helper under test.
+# shellcheck source=../dispatch-backoff-helper.sh
+source "${SCRIPTS_DIR}/dispatch-backoff-helper.sh"
+
+# Re-override pulse_stats_increment AFTER sourcing (helper sources pulse-stats-helper.sh
+# which replaces our capturing stub — same pattern as test-rate-limit-circuit-breaker.sh).
+# shellcheck disable=SC2317
+pulse_stats_increment() {
+	local counter_name="$1"
+	printf '%s\n' "$counter_name" >>"$STATS_COUNTER_FILE"
+	return 0
+}
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+# Write N rate_limit entries for a given issue into the fixture file.
+# $1 = issue_number, $2 = N entries, $3 = base_epoch (ts will be base+idx*60)
+write_rate_limit_entries() {
+	local issue_num="$1"
+	local count="$2"
+	local base_epoch="$3"
+	local i
+	for i in $(seq 1 "$count"); do
+		local ts=$(( base_epoch + (i - 1) * 60 ))
+		printf '{"ts":%s,"role":"worker","session_key":"issue-%s","model":"anthropic/claude-sonnet-4-6","provider":"anthropic","result":"rate_limit","exit_code":143,"failure_reason":"rate_limit","activity":false,"duration_ms":90000}\n' \
+			"$ts" "$issue_num" >>"$FIXTURE_METRICS"
+	done
+	return 0
+}
+
+# Reset fixture and counters between tests.
+reset_test_state() {
+	: >"$FIXTURE_METRICS"
+	: >"$LOGFILE"
+	: >"$STATS_COUNTER_FILE"
+	: >"${TMP}/gh-calls.log"
+	unset AIDEVOPS_SKIP_DISPATCH_BACKOFF 2>/dev/null || true
+	export DISPATCH_BACKOFF_LOOKBACK_SECS=604800   # 7 days
+	export DISPATCH_BACKOFF_NMR_THRESHOLD=4
+	return 0
+}
+
+# =============================================================================
+# Test cases
+# =============================================================================
+printf 'test-dispatch-backoff-helper.sh (t2781)\n'
+printf '=========================================\n'
+
+# --- Test 1: No events → clear ---
+test_no_events_clear() {
+	reset_test_state
+	local rc=0
+	check_dispatch_backoff "99999" "owner/repo" 2>/dev/null || rc=$?
+	if [[ "$rc" -eq 0 ]]; then
+		pass "no rate_limit events → clear (exit 0)"
+	else
+		fail "no rate_limit events → clear (exit 0)" "got exit ${rc}"
+	fi
+	return 0
+}
+
+# --- Test 2: 1 failure, cooldown elapsed → clear ---
+test_one_failure_elapsed_clear() {
+	reset_test_state
+	local now
+	now=$(date +%s)
+	# Rate-limit event was 10 minutes ago; 5-min cooldown has elapsed.
+	local past=$(( now - 600 ))
+	write_rate_limit_entries "88888" 1 "$past"
+	local rc=0
+	check_dispatch_backoff "88888" "owner/repo" 2>/dev/null || rc=$?
+	if [[ "$rc" -eq 0 ]]; then
+		pass "1 failure, cooldown elapsed → clear (exit 0)"
+	else
+		fail "1 failure, cooldown elapsed → clear (exit 0)" "got exit ${rc}"
+	fi
+	return 0
+}
+
+# --- Test 3: 1 failure, within 5-min cooldown → blocked ---
+test_one_failure_within_cooldown_blocked() {
+	reset_test_state
+	local now
+	now=$(date +%s)
+	# Rate-limit event was 2 minutes ago; 5-min cooldown still active.
+	local past=$(( now - 120 ))
+	write_rate_limit_entries "77777" 1 "$past"
+	local rc=0
+	local output=""
+	output=$(check_dispatch_backoff "77777" "owner/repo" 2>&1 >/dev/null) || rc=$?
+	if [[ "$rc" -eq 1 ]]; then
+		pass "1 failure, within 5-min cooldown → blocked (exit 1)"
+	else
+		fail "1 failure, within 5-min cooldown → blocked (exit 1)" "got exit ${rc}"
+	fi
+	if printf '%s' "$output" | grep -q 'BACKOFF_ACTIVE'; then
+		pass "blocked output contains BACKOFF_ACTIVE"
+	else
+		fail "blocked output contains BACKOFF_ACTIVE" "output: ${output}"
+	fi
+	return 0
+}
+
+# --- Test 4: 2 failures, within 30-min cooldown → blocked ---
+test_two_failures_blocked() {
+	reset_test_state
+	local now
+	now=$(date +%s)
+	# Two rate-limit events, most recent 5 minutes ago; 30-min cooldown active.
+	local past=$(( now - 300 ))
+	write_rate_limit_entries "66666" 2 "$past"
+	local rc=0
+	local output=""
+	output=$(check_dispatch_backoff "66666" "owner/repo" 2>&1 >/dev/null) || rc=$?
+	if [[ "$rc" -eq 1 ]]; then
+		pass "2 failures, within 30-min cooldown → blocked (exit 1)"
+	else
+		fail "2 failures, within 30-min cooldown → blocked (exit 1)" "got exit ${rc}"
+	fi
+	if printf '%s' "$output" | grep -q 'cooldown=1800s'; then
+		pass "2-failure output shows 1800s cooldown"
+	else
+		fail "2-failure output shows 1800s cooldown" "output: ${output}"
+	fi
+	return 0
+}
+
+# --- Test 5: 3 failures, within 2-hour cooldown → blocked ---
+test_three_failures_blocked() {
+	reset_test_state
+	local now
+	now=$(date +%s)
+	# Three rate-limit events, most recent 10 minutes ago; 2h cooldown active.
+	local past=$(( now - 600 ))
+	write_rate_limit_entries "55555" 3 "$past"
+	local rc=0
+	local output=""
+	output=$(check_dispatch_backoff "55555" "owner/repo" 2>&1 >/dev/null) || rc=$?
+	if [[ "$rc" -eq 1 ]]; then
+		pass "3 failures, within 2h cooldown → blocked (exit 1)"
+	else
+		fail "3 failures, within 2h cooldown → blocked (exit 1)" "got exit ${rc}"
+	fi
+	if printf '%s' "$output" | grep -q 'cooldown=7200s'; then
+		pass "3-failure output shows 7200s cooldown"
+	else
+		fail "3-failure output shows 7200s cooldown" "output: ${output}"
+	fi
+	return 0
+}
+
+# --- Test 6: 4+ failures → 24h cooldown + NMR_REQUIRED ---
+test_four_failures_nmr() {
+	reset_test_state
+	local now
+	now=$(date +%s)
+	# Four rate-limit events, most recent 1 minute ago; 24h cooldown active.
+	local past=$(( now - 60 ))
+	write_rate_limit_entries "44444" 4 "$past"
+	local rc=0
+	local output=""
+	output=$(check_dispatch_backoff "44444" "owner/repo" 2>&1 >/dev/null) || rc=$?
+	if [[ "$rc" -eq 1 ]]; then
+		pass "4 failures → blocked (exit 1)"
+	else
+		fail "4 failures → blocked (exit 1)" "got exit ${rc}"
+	fi
+	if printf '%s' "$output" | grep -q 'cooldown=86400s'; then
+		pass "4-failure output shows 86400s cooldown"
+	else
+		fail "4-failure output shows 86400s cooldown" "output: ${output}"
+	fi
+	if printf '%s' "$output" | grep -q 'NMR_REQUIRED'; then
+		pass "4-failure output contains NMR_REQUIRED"
+	else
+		fail "4-failure output contains NMR_REQUIRED" "output: ${output}"
+	fi
+	return 0
+}
+
+# --- Test 7: Missing JSONL → fail-open (exit 0 or exit 2) ---
+test_missing_jsonl_fail_open() {
+	reset_test_state
+	export DISPATCH_BACKOFF_METRICS_FILE="/nonexistent/path/headless-runtime-metrics.jsonl"
+	local rc=0
+	check_dispatch_backoff "33333" "owner/repo" 2>/dev/null || rc=$?
+	export DISPATCH_BACKOFF_METRICS_FILE="$FIXTURE_METRICS"
+	if [[ "$rc" -eq 0 ]]; then
+		pass "missing JSONL → fail-open (exit 0)"
+	else
+		fail "missing JSONL → fail-open (exit 0)" "got exit ${rc}"
+	fi
+	return 0
+}
+
+# --- Test 8: Emergency bypass ---
+test_bypass() {
+	reset_test_state
+	local now
+	now=$(date +%s)
+	local past=$(( now - 60 ))
+	write_rate_limit_entries "22222" 4 "$past"
+	export AIDEVOPS_SKIP_DISPATCH_BACKOFF=1
+	local rc=0
+	check_dispatch_backoff "22222" "owner/repo" 2>/dev/null || rc=$?
+	unset AIDEVOPS_SKIP_DISPATCH_BACKOFF
+	if [[ "$rc" -eq 0 ]]; then
+		pass "AIDEVOPS_SKIP_DISPATCH_BACKOFF=1 → bypass (exit 0)"
+	else
+		fail "AIDEVOPS_SKIP_DISPATCH_BACKOFF=1 → bypass (exit 0)" "got exit ${rc}"
+	fi
+	return 0
+}
+
+# --- Test 9: Stats counter incremented on block ---
+test_stats_counter_incremented() {
+	reset_test_state
+	local now
+	now=$(date +%s)
+	local past=$(( now - 60 ))
+	write_rate_limit_entries "11111" 1 "$past"
+	check_dispatch_backoff "11111" "owner/repo" 2>/dev/null || true
+	local count
+	count=$(grep -c "^dispatch_backoff_skipped$" "$STATS_COUNTER_FILE" 2>/dev/null || true)
+	[[ "$count" =~ ^[0-9]+$ ]] || count=0
+	if [[ "$count" -ge 1 ]]; then
+		pass "stats counter dispatch_backoff_skipped incremented on block"
+	else
+		fail "stats counter dispatch_backoff_skipped incremented on block" "count=${count}"
+	fi
+	return 0
+}
+
+# --- Test 10 (AC3 from GH#20680): Simulate 2 rate_limit exits, confirm 3rd blocked at 30min ---
+test_ac3_two_failures_blocks_third() {
+	reset_test_state
+	local now
+	now=$(date +%s)
+	# Two rate_limit exits within last 5 minutes.
+	local past=$(( now - 300 ))
+	write_rate_limit_entries "99001" 2 "$past"
+
+	# 3rd dispatch attempt: should be blocked (2 failures → 30min cooldown).
+	local rc=0
+	local output=""
+	output=$(check_dispatch_backoff "99001" "owner/repo" 2>&1 >/dev/null) || rc=$?
+
+	if [[ "$rc" -eq 1 ]]; then
+		pass "AC3: 3rd dispatch blocked after 2 rate_limit exits (exit 1)"
+	else
+		fail "AC3: 3rd dispatch blocked after 2 rate_limit exits (exit 1)" "got exit ${rc}"
+	fi
+	if printf '%s' "$output" | grep -q 'cooldown=1800s'; then
+		pass "AC3: blocked for 30min (1800s) as specified"
+	else
+		fail "AC3: blocked for 30min (1800s) as specified" "output: ${output}"
+	fi
+	return 0
+}
+
+# --- Test 11: Events outside lookback window are ignored ---
+test_old_events_ignored() {
+	reset_test_state
+	local now
+	now=$(date +%s)
+	# Two events from 8 days ago (outside 7-day lookback).
+	local old_ts=$(( now - 691200 ))  # 8 days ago
+	write_rate_limit_entries "80001" 2 "$old_ts"
+	local rc=0
+	check_dispatch_backoff "80001" "owner/repo" 2>/dev/null || rc=$?
+	if [[ "$rc" -eq 0 ]]; then
+		pass "events outside lookback window are ignored → clear (exit 0)"
+	else
+		fail "events outside lookback window are ignored → clear (exit 0)" "got exit ${rc}"
+	fi
+	return 0
+}
+
+# --- Test 12: Different issue number not affected ---
+test_different_issue_not_affected() {
+	reset_test_state
+	local now
+	now=$(date +%s)
+	local past=$(( now - 60 ))
+	write_rate_limit_entries "12345" 4 "$past"  # issue 12345 has 4 failures
+	local rc=0
+	check_dispatch_backoff "67890" "owner/repo" 2>/dev/null || rc=$?  # issue 67890 is different
+	if [[ "$rc" -eq 0 ]]; then
+		pass "different issue not affected by other issue's backoff"
+	else
+		fail "different issue not affected by other issue's backoff" "got exit ${rc}"
+	fi
+	return 0
+}
+
+# =============================================================================
+# Run all tests
+# =============================================================================
+test_no_events_clear
+test_one_failure_elapsed_clear
+test_one_failure_within_cooldown_blocked
+test_two_failures_blocked
+test_three_failures_blocked
+test_four_failures_nmr
+test_missing_jsonl_fail_open
+test_bypass
+test_stats_counter_incremented
+test_ac3_two_failures_blocks_third
+test_old_events_ignored
+test_different_issue_not_affected
+
+printf '\n'
+printf '%s/%s tests passed\n' "$((TESTS_RUN - TESTS_FAILED))" "$TESTS_RUN"
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+	printf '%sFAILED: %s test(s)%s\n' "$TEST_RED" "$TESTS_FAILED" "$TEST_NC"
+	exit 1
+fi
+printf '%sAll tests passed%s\n' "$TEST_GREEN" "$TEST_NC"
+exit 0


### PR DESCRIPTION
## Summary

Adds a graduated per-issue rate_limit cooldown gate (5m→30m→2h→24h) to `_dff_should_skip_candidate` in the dispatch engine. Prevents the existing fast_fail `rate_limit_rotate` path from immediately re-dispatching when alternative accounts are available but the issue itself keeps failing — the scenario behind 407 rate_limit events / 31.5h of wasted worker burn in recent history.

## Why

`_ff_compute_rate_limit_strategy` returns `retry_after=0` (immediate) whenever another account is available. A pool of N accounts means the same issue can fail N times per cycle with zero cooldown — producing the clusters in `headless-runtime-metrics.jsonl`:
- `issue-20641`: 2x rate_limit, 103 min total
- `issue-2662`: 3x rate_limit, 67 min total
- `issue-15018`: 6x rate_limit (all within a few hours)

The new gate is independent of pool state: it counts historical rate_limit exits for the issue from the JSONL and applies a per-issue floor regardless of which account would be used next.

## What Changed

- **NEW**: `.agents/scripts/dispatch-backoff-helper.sh` — reads `headless-runtime-metrics.jsonl`, counts per-issue `rate_limit` exits in a 7-day lookback window, applies graduated cooldown, increments `dispatch_backoff_skipped` counter
- **EDIT**: `.agents/scripts/pulse-dispatch-engine.sh` — sources helper; calls `check_dispatch_backoff()` in `_dff_should_skip_candidate()` after `fast_fail_is_skipped()`; applies NMR on 4th+ failure threshold
- **EDIT**: `.agents/scripts/pulse-wrapper.sh` — adds `check_dispatch_backoff` to self-check expected functions list
- **NEW**: `.agents/scripts/tests/test-dispatch-backoff-helper.sh` — 18 assertions covering all backoff tiers, AC3 from issue, fail-open, bypass, stats counter

## Acceptance Criteria

1. `dispatch-backoff-helper.sh check <issue_num> <slug>` returns exit 0 if clear, exit 1 if cooldown active — verified by 18-test suite
2. `dispatch_with_dedup` calls the helper as a dedup layer; blocked dispatches log `BACKOFF_ACTIVE reason=rate_limit_cooldown next=<ts>` — wired in `_dff_should_skip_candidate`
3. Unit test: simulate 2 rate_limit exits on same issue within 5 min, confirm 3rd dispatch blocked for 30 min — Test 15: AC3 PASS
4. Counter added to pulse-stats.json: `dispatch_backoff_skipped` — via `pulse_stats_increment` call in helper

## Complexity Bump Justification

Scanner evidence: `pulse-dispatch-engine.sh:357` — the backoff check block added to `_dff_should_skip_candidate`.

Measurements: base=59, head=60, new=1 (file-size gate: files >1500 lines).

The added 33 lines in `pulse-dispatch-engine.sh` push it from 1500 to 1533 lines, crossing the file-size threshold for the first time. The block is the minimum required for the acceptance criteria (per-issue backoff gate with NMR escalation). Extraction to an additional helper would not bring the file below 1500 lines.

Resolves #20680


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.1 plugin for [OpenCode](https://opencode.ai) v1.14.22 with claude-sonnet-4-6 spent 28m and 5,717 tokens on this as a headless worker. Overall, 12m since this issue was created.