### PR TITLE
GH#20675: fix Gemini review feedback on pulse-issue-reconcile.sh

### DIFF
--- a/.agents/scripts/pulse-issue-reconcile.sh
+++ b/.agents/scripts/pulse-issue-reconcile.sh
@@ -73,7 +73,7 @@ _read_cache_issues_for_slug() {
 	# Read issues array for this slug
 	local issues
 	issues=$(jq -e --arg slug "$slug" '.[$slug].issues // empty' "$cache_file" 2>/dev/null) || return 1
-	[[ -n "$issues" && "$issues" != "null" ]] || return 1
+	[[ -n "$issues" ]] || return 1
 
 	printf '%s' "$issues"
 	return 0
@@ -958,6 +958,13 @@ reconcile_open_issues_with_merged_prs() {
 		issue_count=$(printf '%s' "$issues_json" | jq 'length' 2>/dev/null) || issue_count=0
 		[[ "$issue_count" -gt 0 ]] || continue
 
+		# Pre-extract parent-task issue numbers in one jq pass to avoid spawning
+		# jq once per loop iteration (GH#20675: Gemini review feedback on PR #20667).
+		local parent_task_nums
+		parent_task_nums=$(printf '%s' "$issues_json" | \
+			jq -r '.[] | select((.labels // []) | map(.name) | index("parent-task") != null) | .number' \
+			2>/dev/null) || parent_task_nums=""
+
 		local i=0
 		while [[ "$i" -lt "$issue_count" ]] && [[ "$total_closed" -lt "$max_closes" ]]; do
 			local issue_num
@@ -991,13 +998,8 @@ reconcile_open_issues_with_merged_prs() {
 			fi
 
 			# Skip parent-task issues (closing a parent from a child PR is wrong).
-			# t2773: read labels from issues_json (already fetched from cache or
-			# gh_issue_list with --json labels) — eliminates a per-issue gh api call.
-			local issue_labels
-			issue_labels=$(printf '%s' "$issues_json" | \
-				jq -r --argjson idx "$((i - 1))" '.[$idx].labels // [] | map(.name) | join(",")' \
-				2>/dev/null) || issue_labels=""
-			if [[ "$issue_labels" == *"parent-task"* ]]; then
+			# Labels pre-extracted above in a single jq pass (GH#20675).
+			if [[ -n "$parent_task_nums" ]] && printf '%s\n' "$parent_task_nums" | grep -qx "$issue_num"; then
 				continue
 			fi
 


### PR DESCRIPTION
## Summary

Addresses two medium-severity findings from the Gemini review of PR #20667.

### Fix 1 — redundant null check (line 76)

`jq -e` exits non-zero when its output is `null` or `false`, so the `|| return 1` on the assignment line already handles null. The subsequent ```[[ ... && "$issues" != "null" ]]``` check is unreachable by construction. Simplified to `[[ -n "$issues" ]] || return 1`.

### Fix 2 — jq spawning inside loop (around line 999)

`reconcile_open_issues_with_merged_prs` was calling `jq` once per issue iteration to extract the labels for parent-task detection. For N issues this spawns N processes. Replaced with a single `jq` pass before the loop that builds `parent_task_nums` (a newline-separated list of issue numbers carrying the `parent-task` label), then uses `grep -qx` inside the loop for O(1) string matching.

## Files Modified

- EDIT: `.agents/scripts/pulse-issue-reconcile.sh`

## Verification

`shellcheck .agents/scripts/pulse-issue-reconcile.sh` — zero violations.

Resolves #20675

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.1 plugin for [OpenCode](https://opencode.ai) v1.14.22 with claude-sonnet-4-6 spent 5m and 12,806 tokens on this as a headless worker.