### PR TITLE
GH#20676: fix sed escaping, checkout -B idempotency, and commit guard in sync-workflows-helper

### DIFF
--- a/.agents/scripts/sync-workflows-helper.sh
+++ b/.agents/scripts/sync-workflows-helper.sh
@@ -171,8 +171,11 @@ _extract_ref_pin() {
 _render_template_with_ref() {
 	local _template="$1"
 	local _ref="$2"
+	# Escape sed replacement special chars (&, |) before interpolation.
+	local _ref_escaped
+	_ref_escaped=$(printf '%s' "$_ref" | sed 's/[&|]/\\&/g')
 	# Template ships with `@main` by default; rewrite to target ref.
-	sed -E 's|(uses:[[:space:]]*marcusquinn/aidevops/.github/workflows/[^@]+)@[^[:space:]]+|\1'"$_ref"'|' "$_template"
+	sed -E 's|(uses:[[:space:]]*marcusquinn/aidevops/.github/workflows/[^@]+)@[^[:space:]]+|\1'"$_ref_escaped"'|' "$_template"
 	return 0
 }
 
@@ -330,11 +333,9 @@ _sync_write_commit_push() {
 	if ! git -C "$_path" pull --ff-only origin "$_default_branch" >/dev/null 2>&1; then
 		_warn "$_slug: pull --ff-only failed, attempting without"
 	fi
-	if ! git -C "$_path" checkout -b "$_branch_name" >/dev/null 2>&1; then
-		if ! git -C "$_path" checkout "$_branch_name" >/dev/null 2>&1; then
-			printf '%s\t%s\t%s\tbranch create/checkout failed\n' "$_slug" "$_status" "$_STATUS_FAILED"
-			return 1
-		fi
+	if ! git -C "$_path" checkout -q -B "$_branch_name" "$_default_branch"; then
+		printf '%s\t%s\t%s\tbranch create/reset failed\n' "$_slug" "$_status" "$_STATUS_FAILED"
+		return 1
 	fi
 	mkdir -p "$_path/.github/workflows"
 	printf '%s\n' "$_target_content" >"$_workflow"
@@ -342,10 +343,13 @@ _sync_write_commit_push() {
 	local _commit_subject="chore: resync framework workflow ($_status → CURRENT/CALLER)"
 	local _commit_body
 	_commit_body=$(_format_commit_body "$_status" "$_effective_ref")
-	if ! git -C "$_path" commit -m "$_commit_subject" -m "$_commit_body" >/dev/null 2>&1; then
-		printf '%s\t%s\t%s\tgit commit failed\n' "$_slug" "$_status" "$_STATUS_FAILED"
-		git -C "$_path" checkout "$_default_branch" >/dev/null 2>&1 || true
-		return 1
+	if ! git -C "$_path" diff --cached --quiet; then
+		if ! git -C "$_path" commit -q -m "$_commit_subject" -m "$_commit_body"; then
+			printf '%s\t%s\t%s\tgit commit failed\n' "$_slug" "$_status" "$_STATUS_FAILED"
+			# Return to default branch on failure so subsequent runs are clean.
+			git -C "$_path" checkout -q "$_default_branch" || true
+			return 1
+		fi
 	fi
 	if ! git -C "$_path" push -u origin "$_branch_name" >/dev/null 2>&1; then
 		printf '%s\t%s\t%s\tgit push failed\n' "$_slug" "$_status" "$_STATUS_FAILED"


### PR DESCRIPTION
## Summary

Addresses three medium-severity review findings from PR #20673 on `.agents/scripts/sync-workflows-helper.sh`.

### Fixes

1. **sed escaping** (`_render_template_with_ref`, line 175): Escape `&` and `|` in `$_ref` before sed interpolation. Without this, a ref containing `&` would be replaced by the entire matched string in the output, and `|` would break the sed delimiter.

2. **git checkout idempotency** (`_sync_write_commit_push`, lines 333–338): Replace the two-step `checkout -b` + fallback `checkout` with a single `checkout -B "$_branch_name" "$_default_branch"`. This atomically creates or resets the branch to the default branch start-point, ensuring a clean state on re-runs. Use `-q` instead of `>/dev/null 2>&1` so stderr remains visible for debugging.

3. **git commit guard** (`_sync_write_commit_push`, lines 345–350): Check `git diff --cached --quiet` before committing. If no staged changes exist (idempotent re-run), skip the commit rather than failing with exit 1. Use `-q` flag on commit and fallback checkout to preserve stderr visibility.

## Testing

- `shellcheck .agents/scripts/sync-workflows-helper.sh` — zero violations
- Pre-commit and pre-push hooks passed

Resolves #20676
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.1 plugin for [OpenCode](https://opencode.ai) v1.14.22 with claude-sonnet-4-6 spent 3m and 5,004 tokens on this as a headless worker.
