### PR TITLE
t2775: pulse: per-repo pulse_interval throttle for contributor-role repos

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -166,7 +166,7 @@ Use `/routine` to design, dry-run, and schedule these definitions. Reference: `.
 
 **repos.json structure (CRITICAL):** The file is `{"initialized_repos": [...], "git_parent_dirs": [...]}`. New repo entries MUST be appended inside the `initialized_repos` array — NEVER as top-level keys. After ANY write, validate: `jq . ~/.config/aidevops/repos.json > /dev/null`. A malformed file silently breaks the pulse for ALL repos.
 
-Set fields based on the repo's purpose. Full field reference — `pulse`, `pulse_hours`, `pulse_expires`, `contributed`, `foss`, `foss_config`, `review_gate`, `platform`, `role`, `init_scope`, `priority`, `maintainer`, `local_only`: `reference/repos-json-fields.md`.
+Set fields based on the repo's purpose. Full field reference — `pulse`, `pulse_hours`, `pulse_interval`, `pulse_expires`, `contributed`, `foss`, `foss_config`, `review_gate`, `platform`, `role`, `init_scope`, `priority`, `maintainer`, `local_only`: `reference/repos-json-fields.md`.
 
 **Cross-repo task creation**: When creating a task in a *different* repo, follow the full workflow — not just the TODO edit:
 

--- a/.agents/reference/repos-json-fields.md
+++ b/.agents/reference/repos-json-fields.md
@@ -36,6 +36,7 @@ Auto-inferred when absent: `local_only`/no-remote → `minimal`; others → `sta
 | Field | Type | Example | Description |
 |-------|------|---------|-------------|
 | `pulse_hours` | object | `{"start": 17, "end": 5}` | Limits dispatch to window (24h local time). Overnight supported. Omit for 24/7. |
+| `pulse_interval` | integer | `600` | Minimum seconds between dispatch polls for this repo. Default: omit (poll every cycle). Min: 60. Useful for contributor-role repos with low activity — e.g. 600 polls every 5 cycles instead of every cycle, reducing GraphQL budget consumption ~5×. State: `~/.aidevops/logs/pulse-last-per-repo.json`. |
 | `pulse_expires` | string | `"2026-05-01"` | Past this date, pulse auto-sets `pulse: false`. Useful for temporary windows. |
 
 ## Contribution and FOSS Fields

--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -139,11 +139,17 @@ build_ranked_dispatch_candidates_json() {
 	tmp_candidates=$(mktemp 2>/dev/null || echo "/tmp/aidevops-pulse-candidates.$$")
 	: >"$tmp_candidates"
 
-	while IFS='|' read -r repo_slug repo_path repo_priority ph_start ph_end expires; do
+	while IFS='|' read -r repo_slug repo_path repo_priority ph_start ph_end expires repo_interval; do
 		[[ -n "$repo_slug" && -n "$repo_path" ]] || continue
 		if ! check_repo_pulse_schedule "$repo_slug" "$ph_start" "$ph_end" "$expires" "$REPOS_JSON"; then
 			continue
 		fi
+		# Per-repo interval throttle (GH#20660): skip if polled too recently
+		if ! check_repo_pulse_interval "$repo_slug" "$repo_interval"; then
+			continue
+		fi
+		# Record that we are polling this repo now (atomic write, non-fatal)
+		update_repo_pulse_timestamp "$repo_slug"
 		local repo_candidates_json
 		repo_candidates_json=$(list_dispatchable_issue_candidates_json "$repo_slug" "$per_repo_limit") || repo_candidates_json='[]'
 		if [[ -z "$repo_candidates_json" || "$repo_candidates_json" == "[]" ]]; then
@@ -168,7 +174,7 @@ build_ranked_dispatch_candidates_json() {
 				)
 			}
 		' >>"$tmp_candidates" 2>/dev/null || true
-	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "" and .path != "") | [(.slug), (.path), (.priority // "tooling"), (if .pulse_hours then (.pulse_hours.start | tostring) else "" end), (if .pulse_hours then (.pulse_hours.end | tostring) else "" end), (.pulse_expires // "")] | join("|")' "$REPOS_JSON" 2>/dev/null)
+	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "" and .path != "") | [(.slug), (.path), (.priority // "tooling"), (if .pulse_hours then (.pulse_hours.start | tostring) else "" end), (if .pulse_hours then (.pulse_hours.end | tostring) else "" end), (.pulse_expires // ""), (.pulse_interval // "")] | join("|")' "$REPOS_JSON" 2>/dev/null)
 
 	if [[ ! -s "$tmp_candidates" ]]; then
 		rm -f "$tmp_candidates"

--- a/.agents/scripts/pulse-prefetch-fetch.sh
+++ b/.agents/scripts/pulse-prefetch-fetch.sh
@@ -12,6 +12,7 @@
 #   4. Parallel pid wait
 #   5. State assembly and sub-helper runner
 #   6. Per-repo pulse schedule checking
+#   7. Per-repo pulse interval throttle (GH#20660)
 #
 # Usage: source "${SCRIPT_DIR}/pulse-prefetch-fetch.sh"
 #
@@ -746,6 +747,121 @@ _append_prefetch_sub_helpers() {
 #   0 - repo is in schedule window (include in this pulse)
 #   1 - repo is outside window or expired (skip this pulse)
 ########################################
+########################################
+# Per-repo pulse interval throttle (GH#20660)
+# State file path used by check_repo_pulse_interval and update_repo_pulse_timestamp.
+########################################
+PULSE_LAST_PER_REPO_FILE="${PULSE_LAST_PER_REPO_FILE:-${HOME}/.aidevops/logs/pulse-last-per-repo.json}"
+
+########################################
+# Check whether a per-repo pulse_interval has elapsed since the last poll.
+#
+# Mirrors the shape of check_repo_pulse_schedule: returns 0 to include the
+# repo this cycle, 1 to skip. Backwards compatible: when pulse_interval is
+# absent the repo is always included (no throttle).
+#
+# Arguments:
+#   $1 - repo_slug (owner/repo)
+#   $2 - pulse_interval (integer seconds from repos.json, or "" if not set)
+#   $3 - state_file (optional; defaults to PULSE_LAST_PER_REPO_FILE)
+#
+# Exit codes:
+#   0 - include this repo (interval elapsed or no interval set)
+#   1 - skip this repo (interval not yet elapsed)
+########################################
+check_repo_pulse_interval() {
+	local slug="$1"
+	local interval="$2"
+	local state_file="${3:-$PULSE_LAST_PER_REPO_FILE}"
+
+	# No interval set: always include (backwards compatible)
+	if [[ -z "$interval" ]]; then
+		return 0
+	fi
+
+	# Must be a positive integer
+	if [[ ! "$interval" =~ ^[0-9]+$ ]] || [[ "$interval" -eq 0 ]]; then
+		echo "[pulse-wrapper] WARNING: pulse_interval for ${slug} is not a valid positive integer (got: '${interval}') — falling back to no throttle" >>"$LOGFILE"
+		return 0
+	fi
+
+	# Enforce minimum 60s
+	if [[ "$interval" -lt 60 ]]; then
+		echo "[pulse-wrapper] WARNING: pulse_interval for ${slug} is below minimum 60s (got: ${interval}) — clamping to 60s" >>"$LOGFILE"
+		interval=60
+	fi
+
+	# Read last-polled timestamp from state file
+	local last_polled=0
+	if [[ -f "$state_file" ]] && command -v jq &>/dev/null; then
+		local val
+		val=$(jq -r --arg slug "$slug" '.last_pulsed[$slug] // 0' "$state_file" 2>/dev/null)
+		[[ "$val" =~ ^[0-9]+$ ]] && last_polled="$val"
+	fi
+
+	local now elapsed
+	now=$(date +%s)
+	elapsed=$((now - last_polled))
+
+	if [[ "$elapsed" -lt "$interval" ]]; then
+		echo "[pulse-wrapper] pulse_interval_skip repo=${slug} interval=${interval}s elapsed=${elapsed}s last_polled=${last_polled}" >>"$LOGFILE"
+		return 1
+	fi
+
+	return 0
+}
+
+########################################
+# Write the current epoch timestamp as the last-polled time for a repo.
+#
+# Uses atomic mktemp+mv so concurrent pulse runners cannot produce a torn
+# read. Last-writer-wins is acceptable since timestamps are monotone.
+#
+# Arguments:
+#   $1 - repo_slug (owner/repo)
+#   $2 - state_file (optional; defaults to PULSE_LAST_PER_REPO_FILE)
+#
+# Returns: 0 always (non-fatal; failures are logged and silently ignored)
+########################################
+update_repo_pulse_timestamp() {
+	local slug="$1"
+	local state_file="${2:-$PULSE_LAST_PER_REPO_FILE}"
+
+	command -v jq &>/dev/null || return 0
+
+	local now
+	now=$(date +%s)
+
+	# Read existing state or start with an empty object
+	local existing='{}'
+	if [[ -f "$state_file" ]]; then
+		existing=$(jq '.' "$state_file" 2>/dev/null) || existing='{}'
+		[[ -n "$existing" ]] || existing='{}'
+	fi
+
+	# Ensure the logs directory exists
+	local state_dir
+	state_dir="${state_file%/*}"
+	[[ -d "$state_dir" ]] || mkdir -p "$state_dir" 2>/dev/null || true
+
+	local tmp_state
+	tmp_state=$(mktemp "${state_dir}/.pulse-last-per-repo-XXXXXX.json") || {
+		echo "[pulse-wrapper] update_repo_pulse_timestamp: mktemp failed for ${slug} — skipping write" >>"$LOGFILE"
+		return 0
+	}
+
+	if printf '%s' "$existing" | jq --arg slug "$slug" --argjson ts "$now" '
+		if .last_pulsed then .last_pulsed[$slug] = $ts
+		else .last_pulsed = {($slug): $ts} end
+	' >"$tmp_state" 2>/dev/null && jq empty "$tmp_state" 2>/dev/null; then
+		mv "$tmp_state" "$state_file"
+	else
+		rm -f "$tmp_state"
+		echo "[pulse-wrapper] WARNING: update_repo_pulse_timestamp: jq produced invalid JSON for ${slug} — aborting write" >>"$LOGFILE"
+	fi
+	return 0
+}
+
 check_repo_pulse_schedule() {
 	local slug="$1"
 	local ph_start="$2"

--- a/.agents/scripts/tests/test-pulse-wrapper-interval.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-interval.sh
@@ -1,0 +1,293 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-pulse-wrapper-interval.sh — Tests for check_repo_pulse_interval() and
+#                                  update_repo_pulse_timestamp() (GH#20660)
+#
+# Tests:
+#   - No field set: always included (backwards compatible)
+#   - Field set, elapsed > interval: included
+#   - Field set, elapsed < interval: skipped with log message
+#   - Malformed field value: log warning, fall back to no throttle
+#   - Below-minimum interval: clamped to 60s
+#   - update_repo_pulse_timestamp: writes correct epoch to state file
+#   - update_repo_pulse_timestamp: creates state file if missing
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+WRAPPER_SCRIPT="${SCRIPT_DIR}/../pulse-wrapper.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+ORIGINAL_HOME="${HOME}"
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+	export HOME="${TEST_ROOT}/home"
+	mkdir -p "${HOME}/.aidevops/logs"
+	LOGFILE="${HOME}/.aidevops/logs/pulse.log"
+	export LOGFILE
+	# shellcheck source=/dev/null
+	source "$WRAPPER_SCRIPT"
+	return 0
+}
+
+teardown_test_env() {
+	export HOME="$ORIGINAL_HOME"
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+# ─── Tests ────────────────────────────────────────────────────────────────────
+
+test_no_interval_always_included() {
+	local state_file="${TEST_ROOT}/pulse-last-per-repo.json"
+
+	# No interval set: should always include regardless of state file
+	if check_repo_pulse_interval "owner/repo" "" "$state_file"; then
+		print_result "no interval set: always included" 0
+	else
+		print_result "no interval set: always included" 1 "Expected exit 0 (include), got 1 (skip)"
+	fi
+	return 0
+}
+
+test_interval_elapsed_included() {
+	local state_file="${TEST_ROOT}/pulse-last-per-repo-elapsed.json"
+
+	# Write a last-polled timestamp 700 seconds ago (interval is 600s)
+	local old_ts
+	old_ts=$(( $(date +%s) - 700 ))
+	printf '{"last_pulsed": {"owner/repo": %d}}\n' "$old_ts" >"$state_file"
+
+	if check_repo_pulse_interval "owner/repo" "600" "$state_file"; then
+		print_result "interval elapsed (700s > 600s): included" 0
+	else
+		print_result "interval elapsed (700s > 600s): included" 1 "Expected exit 0 (include), got 1 (skip)"
+	fi
+	return 0
+}
+
+test_interval_not_elapsed_skipped() {
+	local state_file="${TEST_ROOT}/pulse-last-per-repo-not-elapsed.json"
+
+	# Write a last-polled timestamp 100 seconds ago (interval is 600s)
+	local recent_ts
+	recent_ts=$(( $(date +%s) - 100 ))
+	printf '{"last_pulsed": {"owner/repo": %d}}\n' "$recent_ts" >"$state_file"
+
+	if check_repo_pulse_interval "owner/repo" "600" "$state_file"; then
+		print_result "interval not elapsed (100s < 600s): skipped" 1 "Expected exit 1 (skip), got 0 (include)"
+	else
+		print_result "interval not elapsed (100s < 600s): skipped" 0
+	fi
+	return 0
+}
+
+test_interval_not_elapsed_log_message() {
+	local state_file="${TEST_ROOT}/pulse-last-per-repo-log.json"
+	local logfile_tmp="${TEST_ROOT}/pulse-log-interval.log"
+	local orig_logfile="$LOGFILE"
+
+	# Redirect LOGFILE to capture the skip message
+	export LOGFILE="$logfile_tmp"
+
+	local recent_ts
+	recent_ts=$(( $(date +%s) - 50 ))
+	printf '{"last_pulsed": {"logtest/repo": %d}}\n' "$recent_ts" >"$state_file"
+
+	check_repo_pulse_interval "logtest/repo" "600" "$state_file" || true
+
+	export LOGFILE="$orig_logfile"
+
+	if grep -q "pulse_interval_skip" "$logfile_tmp" 2>/dev/null; then
+		print_result "interval skip: log line written" 0
+	else
+		print_result "interval skip: log line written" 1 "Expected 'pulse_interval_skip' in log output"
+	fi
+	return 0
+}
+
+test_malformed_interval_fallback() {
+	local state_file="${TEST_ROOT}/pulse-last-per-repo-malformed.json"
+	local logfile_tmp="${TEST_ROOT}/pulse-log-malformed.log"
+	local orig_logfile="$LOGFILE"
+	export LOGFILE="$logfile_tmp"
+
+	# Malformed interval ("abc") — should fall back to no throttle (include)
+	if check_repo_pulse_interval "owner/repo" "abc" "$state_file"; then
+		print_result "malformed interval: fall back to include" 0
+	else
+		print_result "malformed interval: fall back to include" 1 "Expected exit 0 (include/fallback), got 1 (skip)"
+	fi
+
+	export LOGFILE="$orig_logfile"
+
+	# Verify a warning was logged
+	if grep -q "WARNING.*pulse_interval.*not a valid" "$logfile_tmp" 2>/dev/null; then
+		print_result "malformed interval: WARNING logged" 0
+	else
+		print_result "malformed interval: WARNING logged" 1 "Expected WARNING about invalid pulse_interval in log"
+	fi
+	return 0
+}
+
+test_below_minimum_clamped() {
+	local state_file="${TEST_ROOT}/pulse-last-per-repo-belowmin.json"
+	local logfile_tmp="${TEST_ROOT}/pulse-log-belowmin.log"
+	local orig_logfile="$LOGFILE"
+	export LOGFILE="$logfile_tmp"
+
+	# interval=10 is below minimum 60s; repo was polled 30 seconds ago
+	# After clamping to 60s, 30 < 60 → should skip
+	local recent_ts
+	recent_ts=$(( $(date +%s) - 30 ))
+	printf '{"last_pulsed": {"owner/repo": %d}}\n' "$recent_ts" >"$state_file"
+
+	if check_repo_pulse_interval "owner/repo" "10" "$state_file"; then
+		print_result "below-minimum interval: clamped to 60s, polled 30s ago → skip" 1 "Expected exit 1 (skip after clamp), got 0 (include)"
+	else
+		print_result "below-minimum interval: clamped to 60s, polled 30s ago → skip" 0
+	fi
+
+	export LOGFILE="$orig_logfile"
+
+	# Verify warning logged
+	if grep -q "WARNING.*below minimum" "$logfile_tmp" 2>/dev/null; then
+		print_result "below-minimum interval: WARNING logged" 0
+	else
+		print_result "below-minimum interval: WARNING logged" 1 "Expected WARNING about below-minimum interval in log"
+	fi
+	return 0
+}
+
+test_update_writes_timestamp() {
+	local state_file="${TEST_ROOT}/pulse-ts-write-test.json"
+	local before
+	before=$(date +%s)
+
+	update_repo_pulse_timestamp "write/test" "$state_file"
+
+	local after
+	after=$(date +%s)
+
+	if command -v jq &>/dev/null && [[ -f "$state_file" ]]; then
+		local written_ts
+		written_ts=$(jq -r '.last_pulsed["write/test"] // 0' "$state_file" 2>/dev/null)
+		if [[ "$written_ts" -ge "$before" && "$written_ts" -le "$after" ]]; then
+			print_result "update_repo_pulse_timestamp: writes current epoch" 0
+		else
+			print_result "update_repo_pulse_timestamp: writes current epoch" 1 "Timestamp ${written_ts} not in range [${before}, ${after}]"
+		fi
+	else
+		print_result "update_repo_pulse_timestamp: writes current epoch" 0 "(jq not available or state file missing — skipped)"
+	fi
+	return 0
+}
+
+test_update_creates_state_file() {
+	local state_file="${TEST_ROOT}/pulse-ts-create-test.json"
+
+	# File must not exist before the call
+	rm -f "$state_file"
+
+	update_repo_pulse_timestamp "create/test" "$state_file"
+
+	if [[ -f "$state_file" ]]; then
+		print_result "update_repo_pulse_timestamp: creates state file if missing" 0
+	else
+		print_result "update_repo_pulse_timestamp: creates state file if missing" 1 "State file not created at ${state_file}"
+	fi
+	return 0
+}
+
+test_update_multiple_repos_independent() {
+	local state_file="${TEST_ROOT}/pulse-ts-multi.json"
+
+	# Write timestamps for two repos at different times (simulate separate calls)
+	local old_ts
+	old_ts=$(( $(date +%s) - 1000 ))
+	printf '{"last_pulsed": {"alpha/repo": %d}}\n' "$old_ts" >"$state_file"
+
+	update_repo_pulse_timestamp "beta/repo" "$state_file"
+
+	if command -v jq &>/dev/null; then
+		local alpha_ts beta_ts
+		alpha_ts=$(jq -r '.last_pulsed["alpha/repo"] // 0' "$state_file" 2>/dev/null)
+		beta_ts=$(jq -r '.last_pulsed["beta/repo"] // 0' "$state_file" 2>/dev/null)
+
+		if [[ "$alpha_ts" -eq "$old_ts" && "$beta_ts" -gt 0 ]]; then
+			print_result "update_repo_pulse_timestamp: updates are independent per repo" 0
+		else
+			print_result "update_repo_pulse_timestamp: updates are independent per repo" 1 "alpha=${alpha_ts} (expected ${old_ts}), beta=${beta_ts} (expected >0)"
+		fi
+	else
+		print_result "update_repo_pulse_timestamp: updates are independent per repo" 0 "(jq not available — skipped)"
+	fi
+	return 0
+}
+
+test_no_state_file_means_include() {
+	# State file does not exist: elapsed = (now - 0) which is always >= any reasonable interval
+	local state_file="${TEST_ROOT}/nonexistent-state.json"
+	rm -f "$state_file"
+
+	if check_repo_pulse_interval "owner/repo" "600" "$state_file"; then
+		print_result "no state file (first run): included" 0
+	else
+		print_result "no state file (first run): included" 1 "Expected exit 0 (include on first run)"
+	fi
+	return 0
+}
+
+# ─── Main ─────────────────────────────────────────────────────────────────────
+
+setup_test_env
+
+test_no_interval_always_included
+test_interval_elapsed_included
+test_interval_not_elapsed_skipped
+test_interval_not_elapsed_log_message
+test_malformed_interval_fallback
+test_below_minimum_clamped
+test_update_writes_timestamp
+test_update_creates_state_file
+test_update_multiple_repos_independent
+test_no_state_file_means_include
+
+teardown_test_env
+
+echo ""
+echo "Results: ${TESTS_RUN} tests, $((TESTS_RUN - TESTS_FAILED)) passed, ${TESTS_FAILED} failed"
+
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Implements per-repo `pulse_interval` field in `repos.json` that sets a minimum polling cadence (seconds) for individual repos. When the elapsed time since the last poll is less than `pulse_interval`, the dispatch engine skips that repo this cycle and logs a `pulse_interval_skip` line. Reduces GraphQL budget consumption for contributor-role repos with low activity.

For #20622

## Changes

- **`pulse-prefetch-fetch.sh`**: New `check_repo_pulse_interval()` function (mirrors `check_repo_pulse_schedule` shape: 0=include, 1=skip) and `update_repo_pulse_timestamp()` function (atomic mktemp+mv write to `~/.aidevops/logs/pulse-last-per-repo.json`).
- **`pulse-dispatch-engine.sh`**: The per-repo `build_ranked_dispatch_candidates_json` loop now extracts `pulse_interval` from the jq query, calls `check_repo_pulse_interval` after the schedule check, and calls `update_repo_pulse_timestamp` when the interval check passes.
- **`repos-json-fields.md`**: Documents `pulse_interval` (integer seconds, minimum 60, omit = poll every cycle) between `pulse_hours` and `pulse_expires`.
- **`AGENTS.md`**: Adds `pulse_interval` to the repos.json field list.
- **`test-pulse-wrapper-interval.sh`**: 12 unit tests — no-field, elapsed/not-elapsed, log message, malformed, below-minimum, timestamp write, creates-if-missing, multi-repo independence, first-run.

## Acceptance criteria

1. `pulse_interval` documented in `repos-json-fields.md` ✓
2. Pulse wrapper skips repo when `elapsed < interval` ✓
3. State file `pulse-last-per-repo.json` written atomically ✓
4. Backwards compatible (no field = poll every cycle) ✓
5. Unit tests cover no-field, skip, malformed-fallback ✓

## Complexity Bump Justification

No complexity bump — new functions added, existing per-repo loop minimally extended (+6 lines).

## Testing

All 12 unit tests pass:
```
bash .agents/scripts/tests/test-pulse-wrapper-interval.sh
Results: 12 tests, 12 passed, 0 failed
```

shellcheck: zero violations on all modified files.

Resolves #20660
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.1 plugin for [OpenCode](https://opencode.ai) v1.14.22 with claude-sonnet-4-6 spent 9m and 27,621 tokens on this as a headless worker.