### PR TITLE
t2780: fix sync/check-workflows for non-main default branches

### DIFF
--- a/.agents/scripts/check-workflows-helper.sh
+++ b/.agents/scripts/check-workflows-helper.sh
@@ -119,9 +119,14 @@ _classify_workflow() {
 	if grep -qE "uses:\s*marcusquinn/aidevops/\.github/workflows/issue-sync-reusable\.yml@" "$_wf"; then
 		# It's a caller. Compare against canonical, normalising the @ref so that
 		# `@main` vs `@v3.9.0` doesn't count as drift (intentional pinning is OK).
+		# Also normalise the push-trigger branch filter so a repo with
+		# `branches: [develop]` installed by sync-workflows is not flagged as
+		# drift — the branch name reflects the downstream default, not the template.
 		local _wf_norm _canon_norm
-		_wf_norm=$(sed -E 's|(marcusquinn/aidevops/\.github/workflows/issue-sync-reusable\.yml)@[^[:space:]]+|\1@REF|g' "$_wf")
-		_canon_norm=$(sed -E 's|(marcusquinn/aidevops/\.github/workflows/issue-sync-reusable\.yml)@[^[:space:]]+|\1@REF|g' "$_canon")
+		_wf_norm=$(sed -E 's|(marcusquinn/aidevops/\.github/workflows/issue-sync-reusable\.yml)@[^[:space:]]+|\1@REF|g' "$_wf" \
+			| sed -E 's|^([[:space:]]+branches:) \[[^]]+\]$|\1 [BRANCH]|')
+		_canon_norm=$(sed -E 's|(marcusquinn/aidevops/\.github/workflows/issue-sync-reusable\.yml)@[^[:space:]]+|\1@REF|g' "$_canon" \
+			| sed -E 's|^([[:space:]]+branches:) \[[^]]+\]$|\1 [BRANCH]|')
 
 		if [[ "$_wf_norm" == "$_canon_norm" ]]; then
 			printf 'CURRENT/CALLER\n'

--- a/.agents/scripts/sync-workflows-helper.sh
+++ b/.agents/scripts/sync-workflows-helper.sh
@@ -73,6 +73,9 @@ readonly _STATUS_FAILED="FAILED"
 readonly _CLASS_DRIFTED='DRIFTED/CALLER'
 readonly _CLASS_NEEDS_MIGRATION='NEEDS-MIGRATION'
 
+# Canonical default branch name used in the template and as preflight fallback.
+readonly _BRANCH_DEFAULT_NAME="main"
+
 # ─── Helpers ────────────────────────────────────────────────────────────────
 
 _die() {
@@ -176,6 +179,23 @@ _render_template_with_ref() {
 	_ref_escaped=$(printf '%s' "$_ref" | sed 's/[&|]/\\&/g')
 	# Template ships with `@main` by default; rewrite to target ref.
 	sed -E 's|(uses:[[:space:]]*marcusquinn/aidevops/.github/workflows/[^@]+)@[^[:space:]]+|\1'"$_ref_escaped"'|' "$_template"
+	return 0
+}
+
+# Rewrite `branches: [main]` → `branches: [<default_branch>]` in caller YAML content.
+# No-op when default branch is `main`. Emits rewritten content on stdout.
+# Used after preflight resolves the downstream default branch.
+_rewrite_content_branch_filter() {
+	local _content="$1"
+	local _branch="$2"
+	if [[ "$_branch" == "$_BRANCH_DEFAULT_NAME" ]]; then
+		printf '%s\n' "$_content"
+		return 0
+	fi
+	local _branch_escaped
+	_branch_escaped=$(printf '%s' "$_branch" | sed 's/[&|/]/\\&/g')
+	printf '%s\n' "$_content" | \
+		sed -E "s|^([[:space:]]+branches:) \[${_BRANCH_DEFAULT_NAME}\]$|\1 [${_branch_escaped}]|"
 	return 0
 }
 
@@ -303,7 +323,7 @@ _sync_preflight() {
 	fi
 	local _default_branch
 	_default_branch=$(git -C "$_path" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's|^origin/||')
-	[[ -z "$_default_branch" ]] && _default_branch="main"
+	[[ -z "$_default_branch" ]] && _default_branch="$_BRANCH_DEFAULT_NAME"
 	if ! git -C "$_path" diff-index --quiet HEAD -- 2>/dev/null; then
 		printf '%s\t%s\t%s\tworking tree not clean; skipping\n' "$_slug" "$_status" "$_STATUS_SKIPPED"
 		return 2
@@ -427,6 +447,11 @@ _sync_one_repo() {
 		return 1
 	fi
 	local _default_branch="$_PREFLIGHT_DEFAULT_BRANCH"
+
+	# Rewrite branch filter to match downstream default branch (e.g. develop → develop).
+	if [[ "$_default_branch" != "$_BRANCH_DEFAULT_NAME" ]]; then
+		_target_content=$(_rewrite_content_branch_filter "$_target_content" "$_default_branch")
+	fi
 
 	if ! _sync_write_commit_push \
 		"$_slug" "$_path" "$_status" "$_branch_name" \

--- a/.agents/scripts/tests/test-check-workflows-helper.sh
+++ b/.agents/scripts/tests/test-check-workflows-helper.sh
@@ -312,6 +312,27 @@ else
 fi
 rm -rf "$TMPDIR_11"
 
+# Test 12: downstream caller with branches: [develop] → CURRENT/CALLER
+# Verifies the branch-filter normalisation: a repo whose default branch is `develop`
+# (installed by sync-workflows with branches: [develop]) is not flagged as DRIFTED.
+TMPDIR_12="$(mktemp -d)"
+_setup_fake_home "$TMPDIR_12"
+_make_repo_with_workflow "$TMPDIR_12/repos/downstream-develop"
+# Take canonical and replace `branches: [main]` with `branches: [develop]`.
+sed 's/branches: \[main\]/branches: [develop]/' \
+	"$CANONICAL_TEMPLATE" > "$TMPDIR_12/repos/downstream-develop/.github/workflows/issue-sync.yml"
+_write_repos_json "$TMPDIR_12" \
+	"$(jq -n --arg path "$TMPDIR_12/repos/downstream-develop" \
+		'{initialized_repos: [{slug: "x/develop-repo", path: $path, local_only: false}]}')"
+result=$(_run_and_classify "$TMPDIR_12")
+if [[ "$result" == "CURRENT/CALLER" ]]; then
+	_pass "canonical caller with branches: [develop] → CURRENT/CALLER (normalised branch filter)"
+else
+	_fail "canonical caller with branches: [develop] → CURRENT/CALLER (normalised branch filter)" \
+		"got: $result"
+fi
+rm -rf "$TMPDIR_12"
+
 # ─── Summary ────────────────────────────────────────────────────────────────
 
 echo

--- a/.agents/scripts/tests/test-sync-workflows-helper.sh
+++ b/.agents/scripts/tests/test-sync-workflows-helper.sh
@@ -216,6 +216,54 @@ EXIT_9=$?
 _assert_exit "unknown option → exit 2" 2 "$EXIT_9"
 _assert_contains "unknown option error message" "$OUT_9" "unknown option"
 
+# ─── Test 10: apply-mode rewrites branches: [main] → [develop] for develop-branch repos ───
+# Strategy: create a local git repo with develop as default branch + a local bare
+# remote so push succeeds. Run --apply; verify the committed workflow has
+# `branches: [develop]` even though the canonical template ships `branches: [main]`.
+# Note: _sync_open_pr will fail (gh_create_pr unavailable) but _sync_write_commit_push
+# will have already committed the file to the feature branch before that.
+TMPDIR_10="$(mktemp -d)"
+_setup_fake_home "$TMPDIR_10"
+# Local bare remote so `git push` succeeds.
+BARE_10="$TMPDIR_10/bare.git"
+git init --bare -q "$BARE_10" 2>/dev/null
+git -C "$BARE_10" symbolic-ref HEAD refs/heads/develop 2>/dev/null
+REPO_10="$TMPDIR_10/repo-develop"
+mkdir -p "$REPO_10/.github/workflows"
+git -C "$REPO_10" init -q 2>/dev/null
+git -C "$REPO_10" config user.email test@example.com
+git -C "$REPO_10" config user.name Test
+# Disable commit signing — test repos don't need signed commits and
+# the global gpg/ssh key may be passphrase-protected (causing commit failure).
+git -C "$REPO_10" config commit.gpgsign false
+git -C "$REPO_10" config tag.gpgsign false
+# Set initial branch to develop before the first commit (works on all git versions).
+git -C "$REPO_10" symbolic-ref HEAD refs/heads/develop 2>/dev/null
+# Legacy workflow to trigger NEEDS-MIGRATION classification.
+printf '%s\n' "$LEGACY_CONTENT" >"$REPO_10/.github/workflows/issue-sync.yml"
+git -C "$REPO_10" add -A >/dev/null
+git -C "$REPO_10" commit -q -m "initial"
+git -C "$REPO_10" remote add origin "$BARE_10" 2>/dev/null
+git -C "$REPO_10" push -q origin develop 2>/dev/null
+# Set refs/remotes/origin/HEAD so _sync_preflight resolves develop as default.
+git -C "$REPO_10" fetch -q origin 2>/dev/null
+git -C "$REPO_10" remote set-head origin develop 2>/dev/null
+_write_repos_json "$TMPDIR_10" "{\"initialized_repos\":[{\"path\":\"$REPO_10\",\"slug\":\"owner/repo-develop\"}]}"
+SYNC_BRANCH_10="chore/workflow-sync-$(date +%Y%m%d)"
+HOME="$TMPDIR_10" bash "$HELPER" --apply 2>/dev/null || true
+# Verify the committed file on the feature branch has branches: [develop].
+WF_BRANCHES_10=$(git -C "$REPO_10" show "${SYNC_BRANCH_10}:.github/workflows/issue-sync.yml" 2>/dev/null \
+	| grep -E "^\s+branches:" | head -1 || true)
+if [[ "$WF_BRANCHES_10" == *"[develop]"* ]]; then
+	printf '%sPASS%s apply-mode writes branches: [develop] for develop-branch repo\n' "$GREEN" "$NC"
+	((_PASS++))
+else
+	printf '%sFAIL%s apply-mode writes branches: [develop] for develop-branch repo\n' "$RED" "$NC"
+	printf '       got: %s\n' "$WF_BRANCHES_10"
+	((_FAIL++))
+fi
+rm -rf "$TMPDIR_10"
+
 # ─── Summary ────────────────────────────────────────────────────────────────
 printf '\n'
 if [[ "$_FAIL" -eq 0 ]]; then


### PR DESCRIPTION
## Summary

- **sync-workflows-helper**: Add `_rewrite_content_branch_filter` that rewrites `branches: [main]` → `branches: [<default>]` in the installed caller YAML after `_sync_preflight` resolves the downstream repo's default branch. Extract `_BRANCH_DEFAULT_NAME` constant.
- **check-workflows-helper**: Normalise the push-trigger branch filter (`branches: [X]` → `branches: [BRANCH]`) in both sides of the canonical comparison, so repos with `branches: [develop]` (installed by sync-workflows) are classified `CURRENT/CALLER` instead of `DRIFTED/CALLER`.
- **Tests**: Test 10 (sync apply-mode writes `branches: [develop]` for develop-branch repos) and Test 12 (canonical caller with `branches: [develop]` → `CURRENT/CALLER`). All 23 + 12 tests pass.

## Root cause

<webapp>'s default branch is `develop`. The v3.10.0 migration (PR #20673) installed the canonical template verbatim with `branches: [main]`, so `TODO.md` pushes on `develop` never triggered issue-sync. A manual follow-up (<webapp>/<webapp>#2700) patched it. This PR fixes both the install path and the drift detector so the situation cannot recur.

## Verification

- ShellCheck: zero violations on all four files.
- `bash .agents/scripts/tests/test-check-workflows-helper.sh` → All 12 passed.
- `bash .agents/scripts/tests/test-sync-workflows-helper.sh` → All 23 passed.
- Acceptance criteria from GH#20674: repo with `default branch = develop` returns `CURRENT/CALLER` after `aidevops sync-workflows --apply`.

Resolves #20674

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.1 plugin for [OpenCode](https://opencode.ai) v1.14.22 with claude-sonnet-4-6 spent 12m and 36,572 tokens on this as a headless worker.