### PR TITLE
t2787: flip AIDEVOPS_SEQUENTIAL_PHASE_AUTOFILE default to 1 + docs sweep

### DIFF
--- a/.agents/reference/parent-task-lifecycle.md
+++ b/.agents/reference/parent-task-lifecycle.md
@@ -55,6 +55,49 @@ Env override: `PARENT_DECOMPOSITION_ESCALATION_HOURS` (default 168). Capped at `
 
 `.agents/scripts/tests/test-parent-prose-child-detection.sh`, `test-parent-task-application-warn.sh`, `test-parent-decomposition-escalation.sh`, `test-auto-decomposer-scanner.sh`, `test-auto-decomposer-per-parent-gate.sh` (84+ structural assertions total).
 
+## Sequential Phase Auto-File (t2740, enabled by default since t2787)
+
+The sequential phase auto-file mechanism reads phase declarations from the parent-task issue body and files the **next unfiled phase** as a child issue automatically once the prior phase's PR merges.
+
+**Feature flag:** `AIDEVOPS_SEQUENTIAL_PHASE_AUTOFILE` — defaults to `1` (ON) since t2787. Set to `0` to disable.
+
+### Canonical Phase Formats
+
+Two formats are supported. Both are parsed by `_extract_sequential_phases` in `shared-phase-filing.sh`.
+
+**List format (preferred — auto-fire enabled by default):**
+
+```
+- Phase 1 - description [auto-fire:on-prior-merge]
+- Phase 2 - description [auto-fire:on-prior-merge]
+- Phase 3 - description
+```
+
+**Narrative bold-heading format (for prose-style decomposition plans):**
+
+```
+**Phase 1 — description [auto-fire:on-prior-merge]**
+Detailed implementation notes for Phase 1...
+
+**Phase 2 — description**
+Detailed implementation notes for Phase 2...
+```
+
+### Auto-Fire Markers
+
+| Marker | Behaviour |
+|--------|-----------|
+| `[auto-fire:on-prior-merge]` | File this phase when the prior phase PR merges (recommended) |
+| `[auto-fire:on]` | File immediately — no wait for prior merge |
+| *(no marker — list format)* | Filed in sequence (same as `on-prior-merge`) |
+| *(no marker — narrative format)* | NOT auto-filed unless `<!-- phase-auto-fire:on -->` appears in the issue body |
+
+The `<!-- phase-auto-fire:on -->` HTML comment is the opt-in for narrative phases without per-phase markers. It applies the `on-prior-merge` behaviour to every unmarked narrative phase in the issue.
+
+### Close Guard
+
+The close guard (t2755 Phase 2) prevents premature parent-task closure while any declared phase is still unfiled or open. If a PR uses a closing keyword (`Closes #NNN`) on a parent-task issue that still has pending phases, the merge is accepted but the issue is re-opened with an explanatory comment.
+
 ## Use Cases
 
 **Use `#parent` for:** decomposition epics with child implementation tasks, roadmap trackers, research summaries that spawn separate work items, any investigation or "think-before-acting" issue.

--- a/.agents/scripts/shared-phase-filing.sh
+++ b/.agents/scripts/shared-phase-filing.sh
@@ -49,8 +49,9 @@
 [[ -n "${_SHARED_PHASE_FILING_LOADED:-}" ]] && return 0
 _SHARED_PHASE_FILING_LOADED=1
 
-# Feature flag: default OFF for initial rollout.
-AIDEVOPS_SEQUENTIAL_PHASE_AUTOFILE="${AIDEVOPS_SEQUENTIAL_PHASE_AUTOFILE:-0}"
+# Feature flag: default ON since Phase 1 (parser) and Phase 2 (close guard) landed (t2787).
+# Override: AIDEVOPS_SEQUENTIAL_PHASE_AUTOFILE=0 to disable.
+AIDEVOPS_SEQUENTIAL_PHASE_AUTOFILE="${AIDEVOPS_SEQUENTIAL_PHASE_AUTOFILE:-1}"
 
 _phase_log() {
 	local _log="${LOGFILE:-/dev/null}"

--- a/.agents/templates/brief-template.md
+++ b/.agents/templates/brief-template.md
@@ -114,6 +114,40 @@ or "Single-file config edit with exact code block provided -> tier:simple"}
 {If this task is for a `parent-task`-labeled issue, confirm: PR body will use `For #NNN`, not `Resolves`.}
 {If leaf task: use `Resolves #NNN` as normal — delete this section or leave it blank.}
 
+## Phases
+
+<!-- For `parent-task`-labeled issues only. Delete this section for leaf tasks.
+
+     The sequential phase auto-file mechanism (t2740) is ON by default since t2787.
+     It reads phase declarations from the parent-task issue body and auto-files the
+     next phase as a child issue once the prior phase's PR merges.
+
+     Override to disable: AIDEVOPS_SEQUENTIAL_PHASE_AUTOFILE=0
+
+     **List format (preferred — auto-fire works out of the box):**
+
+       - Phase 1 - description [auto-fire:on-prior-merge]
+       - Phase 2 - description [auto-fire:on-prior-merge]
+       - Phase 3 - description
+
+     **Narrative bold-heading format (for prose-style decomposition plans):**
+
+       **Phase 1 — description [auto-fire:on-prior-merge]**
+       Detailed implementation notes...
+
+       **Phase 2 — description**
+       Detailed implementation notes...
+
+     Available markers:
+     - `[auto-fire:on-prior-merge]` — file this phase when the prior phase PR merges (recommended)
+     - `[auto-fire:on]` — file immediately (no wait for prior merge)
+     - No marker — not auto-filed unless `<!-- phase-auto-fire:on -->` appears in the issue body
+
+     The close guard (t2755 Phase 2) prevents premature parent closure while any declared
+     phase is still unfiled or open. -->
+
+{Delete this section for leaf tasks. For parent tasks, list phases here.}
+
 <!-- HEADING LOCK (t2063): the `## How` heading below must remain exactly
      "## How" (optionally with " (Approach)" suffix). The subsection headings
      MUST be exactly "### Files to Modify", "### Implementation Steps", and

--- a/.agents/workflows/new-task.md
+++ b/.agents/workflows/new-task.md
@@ -97,6 +97,27 @@ Run `task-decompose-helper.sh classify "{title}"` if available. Skip with `--no-
 - **Atomic (default):** Proceed to Step 4.
 - **Composite:** Present decomposition tree. If approved: allocate `{task_id}.N` IDs via `claim-task-id.sh`, create brief per subtask, add `blocked-by:` edges, mark parent `status:blocked`. Each subtask brief must (1) reference parent, (2) inherit parent context, (3) include supervisor session ID, (4) set `blocked-by:` from `depends_on`. `batch_strategy` (depth-first/breadth-first) informs pulse dispatch ordering.
 
+### Step 3.6: Declare Phases for Parent Tasks
+
+If the task is tagged `#parent`, add a `## Phases` section to the issue body (and the brief). The sequential phase auto-file mechanism (t2740) is **on by default** — it files the next phase automatically when the prior phase PR merges.
+
+**Canonical list format (preferred):**
+
+```
+- Phase 1 - description [auto-fire:on-prior-merge]
+- Phase 2 - description [auto-fire:on-prior-merge]
+- Phase 3 - description
+```
+
+**Narrative bold-heading format:**
+
+```
+**Phase 1 — description [auto-fire:on-prior-merge]**
+Implementation notes...
+```
+
+Narrative phases without a per-phase marker are NOT auto-filed unless `<!-- phase-auto-fire:on -->` appears in the issue body. Full format reference and marker options: `reference/parent-task-lifecycle.md` § Sequential Phase Auto-File.
+
 ### Step 4: Add to TODO.md
 
 ```markdown


### PR DESCRIPTION
## Summary

Phase 3 of the parent-task phase-lifecycle automation fix (#20559). With Phase 1 (parser extension) and Phase 2 (close guard) both landed, the sequential phase auto-file mechanism is safe to enable by default.

## Changes

- **`shared-phase-filing.sh:53`** — flip `AIDEVOPS_SEQUENTIAL_PHASE_AUTOFILE` default from `0` to `1`. Updated comment to reflect t2787 rationale. Override to disable: `AIDEVOPS_SEQUENTIAL_PHASE_AUTOFILE=0`.
- **`brief-template.md`** — add `## Phases` section documenting list format, narrative bold-heading format, auto-fire markers (`on-prior-merge`, `on`, none), and the `<!-- phase-auto-fire:on -->` HTML comment opt-in.
- **`parent-task-lifecycle.md`** — add "Sequential Phase Auto-File" section with canonical format reference, marker table, close guard note, and flag default.
- **`new-task.md`** — add Step 3.6 directing users to declare phases for parent tasks and pointing to the full reference.

## Verification

```bash
# Flag default
grep 'AIDEVOPS_SEQUENTIAL_PHASE_AUTOFILE.*:-1' .agents/scripts/shared-phase-filing.sh
# Docs contain auto-fire references
grep -l 'Phase.*auto-fire' .agents/templates/brief-template.md .agents/reference/parent-task-lifecycle.md
```

Resolves #20704


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.1 plugin for [OpenCode](https://opencode.ai) v1.14.22 with claude-sonnet-4-6 spent 3m and 8,462 tokens on this as a headless worker.