### PR TITLE
t2789: apply status:available by default in claim-task-id.sh

### DIFF
--- a/.agents/scripts/claim-task-id.sh
+++ b/.agents/scripts/claim-task-id.sh
@@ -443,6 +443,21 @@ create_github_issue() {
 	fi
 	gh_args+=(--body "$body")
 
+	# t2789: Ensure new issues are immediately dispatchable by applying
+	# status:available when the caller did not specify any status:* label.
+	# Without this default, new issues have no status label, and the pulse
+	# dispatcher's candidate filter (which requires status:available) skips
+	# them entirely until a human or downstream process labels them.
+	# Callers that pass an explicit status:* (e.g. status:queued, status:blocked,
+	# status:in-review) are respected verbatim — this only fills the gap.
+	if [[ ",${labels}," != *",status:"* ]]; then
+		if [[ -n "$labels" ]]; then
+			labels="${labels},status:available"
+		else
+			labels="status:available"
+		fi
+	fi
+
 	# Append session origin label (origin:worker or origin:interactive)
 	local origin_label
 	origin_label=$(session_origin_label)


### PR DESCRIPTION
Resolves #20713.

## Summary

Apply `status:available` by default when `claim-task-id.sh` creates a new GitHub issue and the caller did not specify an explicit `status:*` label. Closes the dispatcher-blind gap that left newly-filed issues invisible to the pulse until a human or downstream process labelled them.

## Root cause

`create_github_issue()` composed `gh issue create --label "${labels},${origin_label}"` verbatim from its `$labels` argument. Callers typically pass tier/topic labels (e.g. `bug,framework,auto-dispatch,tier:simple`) but not a status label — those are meant to be managed by state machinery later in the lifecycle. The pulse's deterministic fill-floor requires `status:available` to even enumerate a candidate (`pulse-wrapper.sh`'s candidate query filters on it), so issues without it sat in the backlog indefinitely.

Reproduced on five test issues (#20714-#20718) before shipping the fix: each was filed with no `status:*`, none entered the dispatch queue until manually labelled.

## Change

`.agents/scripts/claim-task-id.sh:446-458` — inject `status:available` into `$labels` before appending the origin label when the incoming string contains no `,status:` substring. Explicit `status:queued`, `status:blocked`, `status:in-review`, etc. from callers are respected verbatim.

## Verification

```bash
# Existing test coverage (label-adjacent paths still pass):
bash .agents/scripts/tests/test-status-label-state-machine.sh
bash .agents/scripts/tests/test-label-invariants.sh
bash .agents/scripts/tests/test-reassign-self-normalization.sh

# Shellcheck + syntax:
shellcheck .agents/scripts/claim-task-id.sh
bash -n .agents/scripts/claim-task-id.sh
```

Live verification will come on the first post-merge `claim-task-id.sh` invocation — new issues should ship with `status:available` immediately visible on the GitHub issue and enter the next pulse cycle's candidate set without manual label intervention.

## Non-scope

- Does NOT alter the status:* state machine downstream (`status_label_set_helper.sh` etc. — their invariants are unchanged).
- Does NOT change `_auto_assign_issue` or `_interactive_session_auto_claim_new_task` behaviour.
- Does NOT modify `issue-sync-helper.sh` — that path already handles status labels through `_push_process_task`; the gap was specifically in the `create_github_issue()` bare-fallback path.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.2 plugin for [OpenCode](https://opencode.ai) v1.14.23 with claude-opus-4-7 spent 10h 58m and 160,432 tokens on this with the user in an interactive session.
