### PR TITLE
GH#20677: fix: use Bash parameter expansion and proper error handling in phase extractor

### DIFF
--- a/.agents/scripts/parent-task-phase-extractor.sh
+++ b/.agents/scripts/parent-task-phase-extractor.sh
@@ -338,7 +338,7 @@ _run_extractor() {
 			log "#${issue_num}: failed to file Phase ${phase_num} child, aborting"
 			return 1
 		}
-		new_issue_num=$(printf '%s' "$new_issue_url" | grep -oE '[0-9]+$')
+		new_issue_num="${new_issue_url##*/}"
 		log "#${issue_num}: filed Phase ${phase_num} as #${new_issue_num}: ${phase_heading}"
 		filed_count=$((filed_count + 1))
 		child_lines="${child_lines}- #${new_issue_num} — Phase ${phase_num}: ${phase_heading}
@@ -355,9 +355,12 @@ _run_extractor() {
 	local updated_body
 	local child_lines_trimmed="${child_lines%$'\n'}"
 	updated_body=$(_append_children_section "$parent_body" "$child_lines_trimmed")
-	gh_issue_edit_safe "$issue_num" --repo "$repo_slug" \
-		--body "$updated_body" 2>/dev/null || true
-	log "#${issue_num}: updated ## Children section with ${filed_count} phase(s)"
+	if gh_issue_edit_safe "$issue_num" --repo "$repo_slug" \
+		--body "$updated_body"; then
+		log "#${issue_num}: updated ## Children section with ${filed_count} phase(s)"
+	else
+		log "#${issue_num}: failed to update ## Children section"
+	fi
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Applied two review-feedback fixes to parent-task-phase-extractor.sh: (1) replaced fragile grep-based URL number extraction with Bash parameter expansion, (2) replaced blanket 2>/dev/null error suppression with proper exit code check and error logging.

## Files Changed

.agents/scripts/parent-task-phase-extractor.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean, all 26 test-parent-task-phase-extractor.sh tests pass

Resolves #20677


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.2 plugin for [OpenCode](https://opencode.ai) v1.14.23 with claude-opus-4-6 spent 3m and 5,140 tokens on this as a headless worker.