### PR TITLE
t2786: add declared-vs-filed guard to _try_close_parent_tracker

### DIFF
--- a/.agents/scripts/pulse-issue-reconcile.sh
+++ b/.agents/scripts/pulse-issue-reconcile.sh
@@ -1325,12 +1325,107 @@ _Automated by \`_post_parent_decomposition_escalation\` in \`pulse-issue-reconci
 }
 
 #######################################
+# t2786: extract the ## Phases section from a parent issue body.
+# Returns only the text between the "## Phases" heading and the next
+# ## heading (or EOF). Returns empty if no ## Phases heading is found.
+# Pure string processing — no side effects, no gh calls.
+# Arguments:
+#   arg1 - parent issue body text
+# Returns: always 0
+#######################################
+_parse_phases_section() {
+	local body="$1"
+	printf '%s' "$body" | awk '
+		BEGIN { in_section = 0 }
+		/^##[[:space:]]+Phases[[:space:]]*$/ {
+			in_section = 1; next
+		}
+		in_section && /^##[[:space:]]/ { exit }
+		in_section { print }
+	'
+	return 0
+}
+
+#######################################
+# t2786: post an idempotent "declared phases not yet filed" nudge comment.
+# Called by _try_close_parent_tracker when the parent body's ## Phases
+# section declares more phases than have been filed as child issues.
+# Prevents premature parent close when unfiled phases exist.
+#
+# Idempotent via the <!-- parent-declared-phases-unfiled --> marker:
+# re-runs skip any parent already nudged. Fail-closed on API errors.
+#
+# Arguments:
+#   arg1 - repo slug (owner/repo)
+#   arg2 - parent issue number
+#   arg3 - declared phase count (from ## Phases section)
+#   arg4 - filed child count (child_count already verified via gh api)
+#   arg5 - unfiled phase text (lines without #NNN, for nudge body listing)
+# Returns: 0 if nudge posted, 1 if skipped (marker present, API error,
+#          or comment call failed).
+#######################################
+_post_parent_phases_unfiled_nudge() {
+	local slug="$1"
+	local parent_num="$2"
+	local declared_count="${3:-0}"
+	local filed_count="${4:-0}"
+	local unfiled_phases="${5:-}"
+
+	[[ -n "$slug" ]] || return 1
+	[[ "$parent_num" =~ ^[0-9]+$ ]] || return 1
+
+	local marker='<!-- parent-declared-phases-unfiled -->'
+
+	# Idempotency check: skip if marker already present in any comment.
+	# Pattern mirrors _post_parent_decomposition_nudge (t2572 fix: streaming
+	# --paginate + --jq, no --slurp). Fail-closed on API error.
+	# Use printf to build the jq filter to avoid a 3rd raw copy of the
+	# .[] | select(.body | contains()) fragment (string-literal ratchet).
+	local _jq_filter
+	_jq_filter=$(printf '.[] | select(.body | contains("%s")) | .id' "$marker")
+	local existing=""
+	existing=$(gh api --paginate "repos/${slug}/issues/${parent_num}/comments" \
+		--jq "$_jq_filter" \
+		2>/dev/null | wc -l | tr -d ' ') || existing=""
+
+	if [[ ! "$existing" =~ ^[0-9]+$ ]]; then
+		echo "[pulse-wrapper] Phases nudge dedup: API/jq failure for #${parent_num} in ${slug} — skipping (fail-closed, t2786)" >>"${LOGFILE:-/dev/null}"
+		return 1
+	fi
+	[[ "$existing" -ge 1 ]] && return 1
+
+	local unfiled_list=""
+	if [[ -n "$unfiled_phases" ]]; then
+		unfiled_list="
+
+**Unfiled phases detected:**
+
+$(printf '%s' "$unfiled_phases" | sed 's/^[[:space:]]*//' | sed 's/^/- /')"
+	fi
+
+	local comment_body="${marker}
+## Parent Tracker: Declared Phases Not Yet Filed
+
+This parent declares **${declared_count} phase(s)** in its \`## Phases\` section but only **${filed_count}** have been filed as child issues. Closing the parent now would be premature — the unfiled phases would be silently dropped.${unfiled_list}
+
+**To proceed:** file the remaining phases as child issues and link them in a \`## Children\` section in the parent body. The parent will close automatically once all children are resolved.
+
+_Detected by \`_try_close_parent_tracker\` (pulse-issue-reconcile.sh, t2786). Posted once per issue via the \`<!-- parent-declared-phases-unfiled -->\` marker; re-runs are no-ops._"
+
+	gh_issue_comment "$parent_num" --repo "$slug" \
+		--body "$comment_body" >/dev/null 2>&1 || return 1
+
+	echo "[pulse-wrapper] Reconcile parent-task: phases-unfiled nudge posted for #${parent_num} in ${slug} (declared=${declared_count}, filed=${filed_count}, t2786)" >>"${LOGFILE:-/dev/null}"
+	return 0
+}
+
+#######################################
 # t2138: extract per-parent close logic. Keeps reconcile_completed_parent_tasks
 # under the 100-line shell-complexity threshold and makes the close decision
 # independently testable. Returns 0 if the parent was closed, 1 if skipped
 # (fewer than 2 known children, any child still open, or close call failed).
 _try_close_parent_tracker() {
-	local slug="$1" parent_num="$2" child_nums="$3" child_source="$4"
+	local slug="$1" parent_num="$2" child_nums="$3" child_source="$4" parent_body="${5:-}"
 	local all_closed="true" child_summary="" child_count=0
 	local child_num child_state child_title_line
 
@@ -1358,6 +1453,29 @@ _try_close_parent_tracker() {
 	# Need at least 2 children (1 = probably just a reference, not a parent).
 	[[ "$child_count" -ge 2 ]] || return 1
 	[[ "$all_closed" == "true" ]] || return 1
+
+	# t2786: declared-vs-filed guard. If the parent body declares more phases
+	# in a ## Phases section than have been filed as child issues, skip close
+	# and post a one-time nudge. Prevents premature parent close when some
+	# declared phases were never filed as children.
+	if [[ -n "$parent_body" ]]; then
+		local _phases_section
+		_phases_section=$(_parse_phases_section "$parent_body")
+		if [[ -n "$_phases_section" ]]; then
+			local _declared_count
+			_declared_count=$(printf '%s' "$_phases_section" | safe_grep_count -E '(^|[[:space:]])Phase[[:space:]]+[0-9]+')
+			if [[ "$_declared_count" -gt "$child_count" ]]; then
+				local _unfiled_phases
+				_unfiled_phases=$(printf '%s' "$_phases_section" | \
+					grep -E '(^|[[:space:]])Phase[[:space:]]+[0-9]+' | \
+					grep -vE '#[0-9]+' || true)
+				_post_parent_phases_unfiled_nudge \
+					"$slug" "$parent_num" "$_declared_count" "$child_count" "$_unfiled_phases"
+				echo "[pulse-wrapper] Reconcile parent-task: skip close #${parent_num} in ${slug} — declared ${_declared_count} phases but only ${child_count} filed (t2786)" >>"${LOGFILE:-/dev/null}"
+				return 1
+			fi
+		fi
+	fi
 
 	gh issue close "$parent_num" --repo "$slug" \
 		--comment "## All child tasks completed — closing parent tracker
@@ -1881,7 +1999,7 @@ _action_cpt_single() {
 	fi
 
 	if [[ "$can_close" == "1" ]]; then
-		if _try_close_parent_tracker "$slug" "$issue_num" "$child_nums" "$child_source"; then
+		if _try_close_parent_tracker "$slug" "$issue_num" "$child_nums" "$child_source" "$issue_body"; then
 			_SP_CPT_CLOSED=1
 		fi
 	fi

--- a/.agents/scripts/tests/test-parent-task-lifecycle.sh
+++ b/.agents/scripts/tests/test-parent-task-lifecycle.sh
@@ -1,0 +1,333 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# shellcheck disable=SC2016  # single-quoted regex/grep patterns are literal by design
+#
+# test-parent-task-lifecycle.sh — tests for t2786 (GH#20703)
+#
+# Regression tests for the declared-vs-filed guard added to
+# _try_close_parent_tracker in pulse-issue-reconcile.sh (Phase 2 of #20559).
+#
+# The guard prevents premature parent close when a parent body declares more
+# phases in a ## Phases section than have been filed as child issues.
+#
+# Test strategy:
+#   Part A — unit tests for _parse_phases_section (pure string processing).
+#             Inline the function definition; no gh stubs required.
+#   Part B — structural tests (grep) verifying the guard wiring in
+#             _try_close_parent_tracker and _post_parent_phases_unfiled_nudge.
+#             These check code structure rather than executing the function
+#             (which would require full gh API stubs).
+#
+# Test coverage:
+#   A1. Body with ## Phases + 3 declared phases → section extracted, count=3
+#   A2. Body with no ## Phases heading → empty result (backward compat)
+#   A3. Body with ## Phases where all phases have #NNN refs (all filed)
+#   A4. Body with ## Phases where some phases have #NNN refs (mixed)
+#   A5. ## Phases at end of file (no trailing ## heading) → still extracted
+#   A6. Empty body → empty result
+#   B1. _parse_phases_section function defined in source file
+#   B2. _post_parent_phases_unfiled_nudge function defined in source file
+#   B3. Guard uses the canonical marker <!-- parent-declared-phases-unfiled -->
+#   B4. Guard queries existing comments for idempotency
+#   B5. Guard posts via gh_issue_comment wrapper
+#   B6. _try_close_parent_tracker accepts parent_body as 5th parameter
+#   B7. Guard skips close when declared_count > child_count
+#   B8. _action_cpt_single passes issue_body to _try_close_parent_tracker
+
+set -u
+
+# Use TEST_-prefixed color vars to avoid colliding with readonly vars
+# from shared-constants.sh when the helper is sourced later.
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_BLUE=$'\033[0;34m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_BLUE="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+assert_eq() {
+	local label="$1" expected="$2" actual="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$expected" == "$actual" ]]; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  expected: $(printf '%q' "$expected")"
+		echo "  actual:   $(printf '%q' "$actual")"
+	fi
+	return 0
+}
+
+assert_empty() {
+	local label="$1" actual="$2"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ -z "$actual" ]]; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  expected: (empty)"
+		echo "  actual:   $(printf '%q' "$actual")"
+	fi
+	return 0
+}
+
+assert_contains() {
+	local label="$1" needle="$2" haystack="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$haystack" == *"$needle"* ]]; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  expected to contain: $needle"
+		echo "  actual: $(printf '%q' "$haystack")"
+	fi
+	return 0
+}
+
+assert_not_contains() {
+	local label="$1" needle="$2" haystack="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$haystack" != *"$needle"* ]]; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  expected NOT to contain: $needle"
+		echo "  actual: $(printf '%q' "$haystack")"
+	fi
+	return 0
+}
+
+assert_grep() {
+	local label="$1" pattern="$2" file="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if grep -qE "$pattern" "$file" 2>/dev/null; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  expected pattern: $pattern"
+		echo "  in file:          $file"
+	fi
+	return 0
+}
+
+assert_grep_fixed() {
+	local label="$1" pattern="$2" file="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if grep -qF "$pattern" "$file" 2>/dev/null; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  expected literal: $pattern"
+		echo "  in file:          $file"
+	fi
+	return 0
+}
+
+# --- Inline function under test (pure string processing — no gh required) ---
+# Mirrors the definition in pulse-issue-reconcile.sh.
+_parse_phases_section() {
+	local body="$1"
+	printf '%s' "$body" | awk '
+		BEGIN { in_section = 0 }
+		/^##[[:space:]]+Phases[[:space:]]*$/ {
+			in_section = 1; next
+		}
+		in_section && /^##[[:space:]]/ { exit }
+		in_section { print }
+	'
+	return 0
+}
+
+# --- Locate source file for structural tests ---
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET="$SCRIPT_DIR/pulse-issue-reconcile.sh"
+
+if [[ ! -f "$TARGET" ]]; then
+	echo "${TEST_RED}FATAL${TEST_NC}: $TARGET not found"
+	exit 1
+fi
+
+# ============================================================
+echo "${TEST_BLUE}=== Part A: _parse_phases_section unit tests ===${TEST_NC}"
+echo ""
+
+# --- A1: Body with ## Phases + 3 declared phases ---
+BODY_A1="## What
+
+This parent tracks the decomposition of #20559.
+
+## Phases
+
+Phase 1: audit (this issue)
+Phase 2: implement guard — filed as #20685
+Phase 3: add tests — filed as #20703
+
+## Acceptance
+
+All phases merged."
+
+result=$(_parse_phases_section "$BODY_A1")
+count=$(printf '%s' "$result" | grep -cE '(^|[[:space:]])Phase[[:space:]]+[0-9]+' 2>/dev/null || true)
+[[ "$count" =~ ^[0-9]+$ ]] || count=0
+assert_eq "A1a: 3 declared phases detected" "3" "$count"
+assert_contains "A1b: Phase 1 line present in section" "Phase 1" "$result"
+assert_contains "A1c: Phase 3 line present in section" "Phase 3" "$result"
+assert_not_contains "A1d: ## What heading NOT in section" "## What" "$result"
+
+# --- A2: Body with no ## Phases heading ---
+BODY_A2="## What
+
+This parent has children but no Phases heading.
+
+## Children
+
+- #100 — child one
+- #101 — child two
+
+## Acceptance
+
+Done."
+
+result=$(_parse_phases_section "$BODY_A2")
+assert_empty "A2: no ## Phases heading → empty result (backward compat)" "$result"
+
+# --- A3: Body with ## Phases where ALL phases have #NNN refs (all filed) ---
+BODY_A3="## Phases
+
+- Phase 1: Description — filed as #19996
+- Phase 2: Description — filed as #20001
+- Phase 3: Description — filed as #20685
+
+## Children
+
+- #19996 — phase 1 issue
+- #20001 — phase 2 issue
+- #20685 — phase 3 issue"
+
+result=$(_parse_phases_section "$BODY_A3")
+# All 3 phases have #NNN refs
+filed=$(printf '%s' "$result" | grep -E '(^|[[:space:]])Phase[[:space:]]+[0-9]+' | grep -cE '#[0-9]+' 2>/dev/null || true)
+[[ "$filed" =~ ^[0-9]+$ ]] || filed=0
+assert_eq "A3a: all 3 phases have #NNN refs (filed)" "3" "$filed"
+# None unfiled
+unfiled=$(printf '%s' "$result" | grep -E '(^|[[:space:]])Phase[[:space:]]+[0-9]+' | grep -cvE '#[0-9]+' 2>/dev/null || true)
+[[ "$unfiled" =~ ^[0-9]+$ ]] || unfiled=0
+assert_eq "A3b: zero unfiled phases" "0" "$unfiled"
+
+# --- A4: Body with ## Phases where some phases have #NNN (mixed) ---
+BODY_A4="## Phases
+
+Phase 1: split out as #19996
+Phase 2: filed as #20001
+Phase 3: not yet started
+Phase 4: planning in progress
+
+## Notes
+
+See parent #20559 for background."
+
+result=$(_parse_phases_section "$BODY_A4")
+total=$(printf '%s' "$result" | grep -cE '(^|[[:space:]])Phase[[:space:]]+[0-9]+' 2>/dev/null || true)
+[[ "$total" =~ ^[0-9]+$ ]] || total=0
+assert_eq "A4a: 4 declared phases total" "4" "$total"
+filed=$(printf '%s' "$result" | grep -E '(^|[[:space:]])Phase[[:space:]]+[0-9]+' | grep -cE '#[0-9]+' 2>/dev/null || true)
+[[ "$filed" =~ ^[0-9]+$ ]] || filed=0
+assert_eq "A4b: 2 filed phases (with #NNN refs)" "2" "$filed"
+unfiled_text=$(printf '%s' "$result" | grep -E '(^|[[:space:]])Phase[[:space:]]+[0-9]+' | grep -vE '#[0-9]+' || true)
+assert_contains "A4c: unfiled list includes Phase 3" "Phase 3" "$unfiled_text"
+assert_contains "A4d: unfiled list includes Phase 4" "Phase 4" "$unfiled_text"
+assert_not_contains "A4e: ## Notes NOT in phases section" "## Notes" "$result"
+
+# --- A5: ## Phases at end of file (no trailing ## heading) ---
+BODY_A5="## What
+
+Some description.
+
+## Phases
+
+Phase 1: alpha — #10001
+Phase 2: beta"
+
+result=$(_parse_phases_section "$BODY_A5")
+count=$(printf '%s' "$result" | grep -cE '(^|[[:space:]])Phase[[:space:]]+[0-9]+' 2>/dev/null || true)
+[[ "$count" =~ ^[0-9]+$ ]] || count=0
+assert_eq "A5: ## Phases at EOF extracts both phases" "2" "$count"
+
+# --- A6: Empty body ---
+result=$(_parse_phases_section "")
+assert_empty "A6: empty body → empty result" "$result"
+
+# ============================================================
+echo ""
+echo "${TEST_BLUE}=== Part B: structural wiring tests ===${TEST_NC}"
+echo ""
+
+# B1: _parse_phases_section defined
+assert_grep \
+	"B1: _parse_phases_section function defined in source" \
+	'^_parse_phases_section\(\) \{' \
+	"$TARGET"
+
+# B2: _post_parent_phases_unfiled_nudge defined
+assert_grep \
+	"B2: _post_parent_phases_unfiled_nudge function defined in source" \
+	'^_post_parent_phases_unfiled_nudge\(\) \{' \
+	"$TARGET"
+
+# B3: canonical marker present
+assert_grep_fixed \
+	"B3: canonical marker <!-- parent-declared-phases-unfiled --> present" \
+	'<!-- parent-declared-phases-unfiled -->' \
+	"$TARGET"
+
+# B4: idempotency check via gh api --paginate
+assert_grep \
+	"B4: nudge function queries comments via gh api --paginate for idempotency" \
+	'gh api --paginate "repos/\$\{slug\}/issues/\$\{parent_num\}/comments"' \
+	"$TARGET"
+
+# B5: nudge posts via gh_issue_comment wrapper
+assert_grep \
+	"B5: nudge posts via gh_issue_comment wrapper" \
+	'gh_issue_comment "\$parent_num" --repo "\$slug"' \
+	"$TARGET"
+
+# B6: _try_close_parent_tracker accepts 5th param parent_body
+assert_grep_fixed \
+	"B6: _try_close_parent_tracker signature includes parent_body 5th param" \
+	'local slug="$1" parent_num="$2" child_nums="$3" child_source="$4" parent_body="${5:-}"' \
+	"$TARGET"
+
+# B7: guard fires when declared_count > child_count
+assert_grep_fixed \
+	'B7: guard skips close when declared_count > child_count' \
+	'if [[ "$_declared_count" -gt "$child_count" ]]; then' \
+	"$TARGET"
+
+# B8: call site passes issue_body as 5th arg
+assert_grep_fixed \
+	"B8: _action_cpt_single passes issue_body to _try_close_parent_tracker" \
+	'_try_close_parent_tracker "$slug" "$issue_num" "$child_nums" "$child_source" "$issue_body"' \
+	"$TARGET"
+
+# ============================================================
+echo ""
+echo "${TEST_BLUE}=== Results: ${TESTS_RUN} tests, ${TESTS_FAILED} failed ===${TEST_NC}"
+
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Implements Phase 2 of the parent-task phase-lifecycle automation fix (Ref #20559).

Adds a declared-vs-filed guard to `_try_close_parent_tracker` that prevents premature parent close when the parent body's `## Phases` section declares more phases than have been filed as child issues.

## Changes

- **`_parse_phases_section`**: pure awk function that extracts the `## Phases` section (heading to next `##` or EOF) from a parent body; returns empty when no Phases section exists (backward compat)
- **`_post_parent_phases_unfiled_nudge`**: idempotent `<!-- parent-declared-phases-unfiled -->` nudge (fail-closed API check; single post per issue; lists unfiled phases); uses `printf`-constructed jq filter to stay within string-literal ratchet
- **`_try_close_parent_tracker`**: accepts `parent_body` as 5th param; after the `all_closed` check passes, counts declared phases via `safe_grep_count`; when declared > filed: posts nudge, logs skip reason, returns 1
- **`_action_cpt_single`**: passes `$issue_body` as 5th arg to `_try_close_parent_tracker`
- **`test-parent-task-lifecycle.sh`**: 22 tests — Part A unit-tests `_parse_phases_section` with fixture bodies; Part B structural-grepping verifies guard wiring

## Acceptance

1. Parents with no `## Phases` section close normally (backward compat) ✅
2. Parents where all declared phases are filed and closed → close normally ✅
3. Parents with declared-but-unfiled phases → skip close + idempotent nudge ✅
4. All 22 new and existing related tests pass ✅

## Testing

```bash
bash .agents/scripts/tests/test-parent-task-lifecycle.sh
# === Results: 22 tests, 0 failed ===
```

Also verified:
- `shellcheck .agents/scripts/pulse-issue-reconcile.sh` — clean
- `shellcheck .agents/scripts/tests/test-parent-task-lifecycle.sh` — clean
- String-literal ratchet: 10 distinct literals (unchanged from baseline)

Resolves #20703
For #20559


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.2 plugin for [OpenCode](https://opencode.ai) v1.14.24 with claude-sonnet-4-6 spent 15m and 38,296 tokens on this as a headless worker.