### PR TITLE
t2788: extend _parse_phases_section for bold-heading form (Phase 1 of #20559)

### DIFF
--- a/.agents/scripts/shared-phase-filing.sh
+++ b/.agents/scripts/shared-phase-filing.sh
@@ -53,6 +53,13 @@ _SHARED_PHASE_FILING_LOADED=1
 # Override: AIDEVOPS_SEQUENTIAL_PHASE_AUTOFILE=0 to disable.
 AIDEVOPS_SEQUENTIAL_PHASE_AUTOFILE="${AIDEVOPS_SEQUENTIAL_PHASE_AUTOFILE:-1}"
 
+# Phase marker constants — single source of truth for marker string values
+# used by _parse_phases_section, _phase_marker_for_line, and auto_file_next_phase.
+# Keeps the codebase DRY and satisfies the repeated-string-literal quality gate.
+_PHASE_MARKER_AUTO_FIRE="auto-fire"
+_PHASE_MARKER_REQUIRES_DECISION="requires-decision"
+_PHASE_MARKER_NONE="none"
+
 _phase_log() {
 	local _log="${LOGFILE:-/dev/null}"
 	echo "[phase-filing] $*" >>"$_log"
@@ -109,12 +116,123 @@ _find_parent_task_for_child() {
 }
 
 #######################################
+# Determine the marker for a phase line. Shared by list-form and bold-form
+# parsers. Explicit inline markers take precedence; otherwise the fallback
+# is used (caller supplies 'none' for list form, or the global-opt-in value
+# for bold form so <!-- phase-auto-fire:on --> can flip narrative phases).
+#
+# Args: $1=line, $2=fallback_marker
+# Output: marker on stdout (auto-fire|requires-decision|none|<fallback>)
+# Returns: 0 always
+#######################################
+_phase_marker_for_line() {
+	local line="$1" fallback="${2:-$_PHASE_MARKER_NONE}"
+	if printf '%s' "$line" | grep -qiF '[auto-fire:on-prior-merge]'; then
+		printf '%s' "$_PHASE_MARKER_AUTO_FIRE"
+	elif printf '%s' "$line" | grep -qiF '[requires-decision]'; then
+		printf '%s' "$_PHASE_MARKER_REQUIRES_DECISION"
+	else
+		printf '%s' "$fallback"
+	fi
+	return 0
+}
+
+#######################################
+# Parse a single list-form phase line:
+#   - Phase <N> - <description> [auto-fire:on-prior-merge] [#<child>]
+#   - Phase <N>: <description> [requires-decision]
+# Separator is `-` or `:`, flexible whitespace.
+#
+# Args: $1=line
+# Output: tab-separated <phase_num>\t<desc>\t<marker>\t<child_ref> on stdout
+#         (empty output if line doesn't match list form)
+# Returns: 0 always
+#######################################
+_parse_phase_line_list_form() {
+	local line="$1"
+	printf '%s' "$line" | grep -qE '^[[:space:]]*-[[:space:]]+[Pp]hase[[:space:]]+[0-9]+' || return 0
+
+	local phase_num description marker child_ref
+	phase_num=$(printf '%s' "$line" | grep -oE '[Pp]hase[[:space:]]+[0-9]+' | grep -oE '[0-9]+')
+
+	# Description: strip leading "- Phase N -/:", trailing child ref, then
+	# trailing marker brackets (order matters — see t2755 parser notes).
+	description=$(printf '%s' "$line" | sed -E \
+		-e 's/^[[:space:]]*-[[:space:]]+[Pp]hase[[:space:]]+[0-9]+[[:space:]]*[-:][[:space:]]*//' \
+		-e 's/[[:space:]]*#[0-9]+[[:space:]]*$//' \
+		-e 's/[[:space:]]*\[(auto-fire|requires-decision)[^]]*\][[:space:]]*$//')
+
+	marker=$(_phase_marker_for_line "$line" "$_PHASE_MARKER_NONE")
+
+	# Child ref: trailing bare #NNN at end of line only (anchored).
+	child_ref=$(printf '%s' "$line" | sed -nE 's/.*#([0-9]+)[[:space:]]*$/\1/p')
+
+	printf '%s\t%s\t%s\t%s\n' "$phase_num" "$description" "$marker" "$child_ref"
+	return 0
+}
+
+#######################################
+# Parse a single bold-heading phase line:
+#   **Phase <N> — <description>**
+#   **Phase <N> - <description> [auto-fire:on-prior-merge]**
+#   **Phase <N>: <description>** #<child>
+#   **Phase <N> — <description> #<child>**
+# Separators: em-dash, en-dash, hyphen, colon (any non-alnum leading char).
+# Child ref may appear inside or outside the bold span.
+#
+# Args: $1=line, $2=global_auto_fire (fallback marker when none explicit)
+# Output: tab-separated <phase_num>\t<desc>\t<marker>\t<child_ref> on stdout
+#         (empty output if line doesn't match bold form)
+# Returns: 0 always
+#######################################
+_parse_phase_line_bold_form() {
+	local line="$1" global_auto_fire="${2:-none}"
+	printf '%s' "$line" | grep -qE '^\*\*[Pp]hase[[:space:]]+[0-9]+' || return 0
+
+	local phase_num description marker child_ref
+	phase_num=$(printf '%s' "$line" | grep -oE '\*\*[Pp]hase[[:space:]]+[0-9]+' | grep -oE '[0-9]+')
+
+	# Description extraction for bold form:
+	#   1. Strip leading **Phase N (with trailing whitespace)
+	#   2. Strip leading non-alnum separator run (em-dash/en-dash/hyphen/colon/space)
+	#   3. Strip trailing child ref, closing `**`, marker brackets — in that order
+	#      so #NNN appearing INSIDE the bold span (**Phase N — desc #NNN**) is
+	#      matched before we lose the `**` terminator, and markers adjacent to
+	#      the closing `**` (**Phase N — desc [auto-fire:on-prior-merge]**) are
+	#      peeled cleanly.
+	description=$(printf '%s' "$line" \
+		| sed -E 's/^\*\*[Pp]hase[[:space:]]+[0-9]+[[:space:]]*//' \
+		| sed -E 's/^[^[:alnum:]]*//' \
+		| sed -E 's/[[:space:]]*#[0-9]+[[:space:]]*\*\*[[:space:]]*$//;s/[[:space:]]*#[0-9]+[[:space:]]*$//;s/\*\*[[:space:]]*$//;s/[[:space:]]*\[(auto-fire|requires-decision)[^]]*\][[:space:]]*$//')
+
+	marker=$(_phase_marker_for_line "$line" "$global_auto_fire")
+
+	# Child ref: match #NNN either outside (`** #NNN`) or inside (`#NNN**`).
+	# Strip closing `**` first so the anchored tail regex finds either form.
+	child_ref=$(printf '%s' "$line" \
+		| sed -E 's/\*\*[[:space:]]*$//' \
+		| sed -nE 's/.*#([0-9]+)[[:space:]]*$/\1/p')
+
+	printf '%s\t%s\t%s\t%s\n' "$phase_num" "$description" "$marker" "$child_ref"
+	return 0
+}
+
+#######################################
 # Parse the ## Phases section from a parent issue body.
 # Outputs one line per phase in tab-separated format:
 #   phase_num\tdescription\tmarker\tchild_issue
 #
+# Supported phase-line forms (mixable within a single body):
+#   List form:  - Phase <N> - <description> [marker] [#<child>]
+#   Bold form:  **Phase <N> — <description> [marker]** [#<child>]
+#
 # marker is one of: auto-fire, requires-decision, none
 # child_issue is the issue number (digits only) or empty
+#
+# Global opt-in: an HTML comment `<!-- phase-auto-fire:on -->` anywhere in
+# the parent body flips ALL bold-form phases without explicit markers to
+# `auto-fire`. List-form phases always require explicit markers (conservative
+# — the legacy convention is opt-in per line).
 #
 # Args: $1=parent_body
 # Output: phase lines on stdout
@@ -123,6 +241,12 @@ _find_parent_task_for_child() {
 _parse_phases_section() {
 	local body="$1"
 	[[ -n "$body" ]] || return 0
+
+	# Global opt-in marker: flips narrative bold-form phases to auto-fire.
+	local global_auto_fire="$_PHASE_MARKER_NONE"
+	if printf '%s' "$body" | grep -qF '<!-- phase-auto-fire:on -->'; then
+		global_auto_fire="$_PHASE_MARKER_AUTO_FIRE"
+	fi
 
 	# Extract the ## Phases section: everything between "## Phases" and the
 	# next ## heading (or end of string). Use awk for multi-line extraction.
@@ -134,49 +258,13 @@ _parse_phases_section() {
 	')
 	[[ -n "$phases_block" ]] || return 0
 
-	# Parse each phase line. Format:
-	#   - Phase <N> - <description> [auto-fire:on-prior-merge] [#<child>]
-	#   - Phase <N>: <description> [requires-decision]
-	# We are flexible with separators (-, :, whitespace).
+	# Dispatch each non-empty line to the appropriate per-form parser.
+	# Each helper emits a parsed row on match or nothing on no-match, so a
+	# simple serial call chain is sufficient — no duplicate emission risk.
 	printf '%s\n' "$phases_block" | while IFS= read -r line; do
-		# Match lines starting with "- Phase <N>"
-		if printf '%s' "$line" | grep -qE '^[[:space:]]*-[[:space:]]+[Pp]hase[[:space:]]+[0-9]+'; then
-			local phase_num description marker child_ref
-
-			# Extract phase number
-			phase_num=$(printf '%s' "$line" | grep -oE '[Pp]hase[[:space:]]+[0-9]+' | grep -oE '[0-9]+')
-
-			# Extract description: text after "Phase N" separator (- or :).
-			# Order matters: strip trailing child ref (#NNN) first, then strip
-			# trailing known marker brackets anchored to end-of-line. This avoids
-			# the marker's greedy .* consuming the child ref and exposing a
-			# description-internal #NNN that the trailing strip then incorrectly
-			# removes. Only strips [auto-fire:...] and [requires-decision] so
-			# descriptions containing other brackets (e.g. "Fix [bug] in X") are
-			# preserved.
-			description=$(printf '%s' "$line" | sed -E \
-				-e 's/^[[:space:]]*-[[:space:]]+[Pp]hase[[:space:]]+[0-9]+[[:space:]]*[-:][[:space:]]*//' \
-				-e 's/[[:space:]]*#[0-9]+[[:space:]]*$//' \
-				-e 's/[[:space:]]*\[(auto-fire|requires-decision)[^]]*\][[:space:]]*$//')
-
-			# Determine marker
-			if printf '%s' "$line" | grep -qiF '[auto-fire:on-prior-merge]'; then
-				marker="auto-fire"
-			elif printf '%s' "$line" | grep -qiF '[requires-decision]'; then
-				marker="requires-decision"
-			else
-				marker="none"
-			fi
-
-			# Extract child issue reference: a trailing bare #NNNN at end of line.
-			# Anchoring to line-end (rather than tail -1 on all matches) prevents
-			# false positives where the description contains a #NNN reference but
-			# no child ref is actually present. Child refs are stored as " #NNN"
-			# at end of line by _update_parent_phases_section.
-			child_ref=$(printf '%s' "$line" | sed -nE 's/.*#([0-9]+)[[:space:]]*$/\1/p')
-
-			printf '%s\t%s\t%s\t%s\n' "$phase_num" "$description" "$marker" "$child_ref"
-		fi
+		[[ -n "$line" ]] || continue
+		_parse_phase_line_list_form "$line"
+		_parse_phase_line_bold_form "$line" "$global_auto_fire"
 	done
 	return 0
 }
@@ -488,8 +576,8 @@ auto_file_next_phase() {
 	fi
 
 	# Guard: next phase must be opted in
-	if [[ "$next_marker" != "auto-fire" ]]; then
-		_phase_log "Parent #${parent_issue}: Phase ${next_phase_num} marker is '${next_marker}', not auto-fire — skip"
+	if [[ "$next_marker" != "$_PHASE_MARKER_AUTO_FIRE" ]]; then
+		_phase_log "Parent #${parent_issue}: Phase ${next_phase_num} marker is '${next_marker}', not ${_PHASE_MARKER_AUTO_FIRE} — skip"
 		return 0
 	fi
 

--- a/.agents/scripts/tests/test-shared-phase-filing.sh
+++ b/.agents/scripts/tests/test-shared-phase-filing.sh
@@ -267,6 +267,257 @@ else
 fi
 
 # =============================================================================
+# Test 8: _parse_phases_section — bold-heading form basic detection (t2788)
+# =============================================================================
+printf '%s--- Test 8: bold-heading form basic detection ---%s\n' "$TEST_BLUE" "$TEST_NC"
+
+PARENT_BODY_BOLD='## Phases
+
+**Phase 1 — Remove auto-dispatch label plumbing**
+**Phase 2 — Update dispatch dedup logic**
+**Phase 3 — Architecture review**
+
+## Acceptance
+
+- Some criteria'
+
+bold_output=$(_parse_phases_section "$PARENT_BODY_BOLD")
+bold_count=$(printf '%s\n' "$bold_output" | grep -c '^[0-9]')
+
+if [[ "$bold_count" -eq 3 ]]; then
+	pass "Parsed 3 bold-heading phases from body"
+else
+	fail "Expected 3 bold-heading phases, got ${bold_count}" "Output: ${bold_output}"
+fi
+
+b1_line=$(printf '%s\n' "$bold_output" | head -1)
+b1_num=$(printf '%s' "$b1_line" | cut -f1)
+b1_desc=$(printf '%s' "$b1_line" | cut -f2)
+b1_marker=$(printf '%s' "$b1_line" | cut -f3)
+b1_child=$(printf '%s' "$b1_line" | cut -f4)
+
+if [[ "$b1_num" == "1" && "$b1_desc" == "Remove auto-dispatch label plumbing" && "$b1_marker" == "none" && -z "$b1_child" ]]; then
+	pass "Bold Phase 1: num=1, desc correct, default marker=none, no child ref"
+else
+	fail "Bold Phase 1 field mismatch" "num='${b1_num}' desc='${b1_desc}' marker='${b1_marker}' child='${b1_child}'"
+fi
+
+# =============================================================================
+# Test 9: _parse_phases_section — explicit markers on bold form (t2788)
+# =============================================================================
+printf '%s--- Test 9: bold-heading explicit markers ---%s\n' "$TEST_BLUE" "$TEST_NC"
+
+PARENT_BODY_BOLD_EXPLICIT='## Phases
+
+**Phase 1 — Remove plumbing [auto-fire:on-prior-merge]**
+**Phase 2 — Update logic [requires-decision]**
+**Phase 3 — No marker**'
+
+explicit_output=$(_parse_phases_section "$PARENT_BODY_BOLD_EXPLICIT")
+e1_marker=$(printf '%s\n' "$explicit_output" | sed -n '1p' | cut -f3)
+e2_marker=$(printf '%s\n' "$explicit_output" | sed -n '2p' | cut -f3)
+e3_marker=$(printf '%s\n' "$explicit_output" | sed -n '3p' | cut -f3)
+e1_desc=$(printf '%s\n' "$explicit_output" | sed -n '1p' | cut -f2)
+
+if [[ "$e1_marker" == "auto-fire" && "$e2_marker" == "requires-decision" && "$e3_marker" == "none" ]]; then
+	pass "Bold explicit markers respected: auto-fire, requires-decision, none"
+else
+	fail "Bold explicit markers wrong: e1='${e1_marker}' e2='${e2_marker}' e3='${e3_marker}'"
+fi
+
+if [[ "$e1_desc" == "Remove plumbing" ]]; then
+	pass "Bold Phase 1 description stripped of marker bracket"
+else
+	fail "Bold Phase 1 description expected 'Remove plumbing', got '${e1_desc}'"
+fi
+
+# =============================================================================
+# Test 10: _parse_phases_section — <!-- phase-auto-fire:on --> opt-in (t2788)
+# =============================================================================
+printf '%s--- Test 10: global opt-in comment flips bold phases ---%s\n' "$TEST_BLUE" "$TEST_NC"
+
+PARENT_BODY_GLOBAL='<!-- phase-auto-fire:on -->
+
+## Phases
+
+**Phase 1 — First phase**
+**Phase 2 — Second phase [requires-decision]**
+**Phase 3 — Third phase**'
+
+global_output=$(_parse_phases_section "$PARENT_BODY_GLOBAL")
+g1_marker=$(printf '%s\n' "$global_output" | sed -n '1p' | cut -f3)
+g2_marker=$(printf '%s\n' "$global_output" | sed -n '2p' | cut -f3)
+g3_marker=$(printf '%s\n' "$global_output" | sed -n '3p' | cut -f3)
+
+if [[ "$g1_marker" == "auto-fire" && "$g3_marker" == "auto-fire" ]]; then
+	pass "Global opt-in flips unmarked bold phases to auto-fire"
+else
+	fail "Global opt-in failed: g1='${g1_marker}' g3='${g3_marker}' (expected auto-fire)"
+fi
+
+if [[ "$g2_marker" == "requires-decision" ]]; then
+	pass "Explicit [requires-decision] still overrides global opt-in"
+else
+	fail "Explicit marker should override global: got '${g2_marker}'"
+fi
+
+# List-form phases are NOT affected by the global opt-in (conservative).
+PARENT_BODY_GLOBAL_MIXED='<!-- phase-auto-fire:on -->
+
+## Phases
+
+- Phase 1 - List-form phase
+**Phase 2 — Bold-form phase**'
+
+mixed_global=$(_parse_phases_section "$PARENT_BODY_GLOBAL_MIXED")
+mg1_marker=$(printf '%s\n' "$mixed_global" | sed -n '1p' | cut -f3)
+mg2_marker=$(printf '%s\n' "$mixed_global" | sed -n '2p' | cut -f3)
+
+if [[ "$mg1_marker" == "none" && "$mg2_marker" == "auto-fire" ]]; then
+	pass "Global opt-in affects bold only, list form stays conservative"
+else
+	fail "Global opt-in scope wrong: list='${mg1_marker}' (want none), bold='${mg2_marker}' (want auto-fire)"
+fi
+
+# =============================================================================
+# Test 11: _parse_phases_section — mixed list and bold forms (t2788)
+# =============================================================================
+printf '%s--- Test 11: mixed list and bold forms ---%s\n' "$TEST_BLUE" "$TEST_NC"
+
+PARENT_BODY_MIXED='## Phases
+
+- Phase 1 - List form [auto-fire:on-prior-merge] #1001
+**Phase 2 — Bold form [auto-fire:on-prior-merge]**
+- Phase 3 - Second list phase [requires-decision]
+**Phase 4 — Final bold phase**'
+
+mixed_output=$(_parse_phases_section "$PARENT_BODY_MIXED")
+mixed_count=$(printf '%s\n' "$mixed_output" | grep -c '^[0-9]')
+
+if [[ "$mixed_count" -eq 4 ]]; then
+	pass "Parsed 4 phases (2 list + 2 bold) in mixed body"
+else
+	fail "Expected 4 phases, got ${mixed_count}" "Output: ${mixed_output}"
+fi
+
+m1_child=$(printf '%s\n' "$mixed_output" | sed -n '1p' | cut -f4)
+m2_marker=$(printf '%s\n' "$mixed_output" | sed -n '2p' | cut -f3)
+m3_marker=$(printf '%s\n' "$mixed_output" | sed -n '3p' | cut -f3)
+m4_marker=$(printf '%s\n' "$mixed_output" | sed -n '4p' | cut -f3)
+
+if [[ "$m1_child" == "1001" && "$m2_marker" == "auto-fire" && "$m3_marker" == "requires-decision" && "$m4_marker" == "none" ]]; then
+	pass "Mixed form: per-phase child refs, markers, and defaults all correct"
+else
+	fail "Mixed form mismatch: m1_child='${m1_child}' m2='${m2_marker}' m3='${m3_marker}' m4='${m4_marker}'"
+fi
+
+# =============================================================================
+# Test 12: _parse_phases_section — bold form child ref extraction (t2788)
+# =============================================================================
+printf '%s--- Test 12: bold form child ref placement ---%s\n' "$TEST_BLUE" "$TEST_NC"
+
+# Child ref outside closing ** — common when phase section is rewritten after
+# auto-fill appends the reference.
+PARENT_BODY_CHILD_OUTSIDE='## Phases
+
+**Phase 1 — First** #2001
+**Phase 2 — Second [auto-fire:on-prior-merge]** #2002'
+
+outside_output=$(_parse_phases_section "$PARENT_BODY_CHILD_OUTSIDE")
+o1_child=$(printf '%s\n' "$outside_output" | sed -n '1p' | cut -f4)
+o1_desc=$(printf '%s\n' "$outside_output" | sed -n '1p' | cut -f2)
+o2_child=$(printf '%s\n' "$outside_output" | sed -n '2p' | cut -f4)
+o2_desc=$(printf '%s\n' "$outside_output" | sed -n '2p' | cut -f2)
+
+if [[ "$o1_child" == "2001" && "$o2_child" == "2002" ]]; then
+	pass "Bold form child ref outside closing ** extracted"
+else
+	fail "Bold child ref outside ** wrong: '${o1_child}', '${o2_child}' (expected 2001, 2002)"
+fi
+
+if [[ "$o1_desc" == "First" && "$o2_desc" == "Second" ]]; then
+	pass "Bold form description clean when child ref is outside closing **"
+else
+	fail "Bold desc mismatch outside **: '${o1_desc}', '${o2_desc}' (expected 'First', 'Second')"
+fi
+
+# Child ref inside closing ** — alternate authoring style.
+PARENT_BODY_CHILD_INSIDE='## Phases
+
+**Phase 1 — First #3001**
+**Phase 2 — Second [auto-fire:on-prior-merge] #3002**'
+
+inside_output=$(_parse_phases_section "$PARENT_BODY_CHILD_INSIDE")
+i1_child=$(printf '%s\n' "$inside_output" | sed -n '1p' | cut -f4)
+i1_desc=$(printf '%s\n' "$inside_output" | sed -n '1p' | cut -f2)
+i2_child=$(printf '%s\n' "$inside_output" | sed -n '2p' | cut -f4)
+
+if [[ "$i1_child" == "3001" && "$i2_child" == "3002" ]]; then
+	pass "Bold form child ref inside closing ** extracted"
+else
+	fail "Bold child ref inside ** wrong: '${i1_child}', '${i2_child}' (expected 3001, 3002)"
+fi
+
+if [[ "$i1_desc" == "First" ]]; then
+	pass "Bold form description clean when child ref is inside closing **"
+else
+	fail "Bold desc mismatch inside **: '${i1_desc}' (expected 'First')"
+fi
+
+# =============================================================================
+# Test 13: _parse_phases_section — bold form separator variants (t2788)
+# =============================================================================
+printf '%s--- Test 13: bold form separator variants ---%s\n' "$TEST_BLUE" "$TEST_NC"
+
+# Em-dash, en-dash, hyphen, colon all supported as separators after Phase N.
+PARENT_BODY_SEPARATORS='## Phases
+
+**Phase 1 — Em-dash**
+**Phase 2 – En-dash**
+**Phase 3 - Hyphen**
+**Phase 4: Colon**'
+
+sep_output=$(_parse_phases_section "$PARENT_BODY_SEPARATORS")
+sep_count=$(printf '%s\n' "$sep_output" | grep -c '^[0-9]')
+
+if [[ "$sep_count" -eq 4 ]]; then
+	pass "All 4 separator variants parsed"
+else
+	fail "Expected 4 separator variants, got ${sep_count}" "Output: ${sep_output}"
+fi
+
+s1_desc=$(printf '%s\n' "$sep_output" | sed -n '1p' | cut -f2)
+s3_desc=$(printf '%s\n' "$sep_output" | sed -n '3p' | cut -f2)
+s4_desc=$(printf '%s\n' "$sep_output" | sed -n '4p' | cut -f2)
+
+if [[ "$s1_desc" == "Em-dash" && "$s3_desc" == "Hyphen" && "$s4_desc" == "Colon" ]]; then
+	pass "Bold separator variants strip cleanly"
+else
+	fail "Separator descriptions wrong: em-dash='${s1_desc}' hyphen='${s3_desc}' colon='${s4_desc}'"
+fi
+
+# =============================================================================
+# Test 14: _parse_phases_section — no double-emission (t2788)
+# =============================================================================
+printf '%s--- Test 14: no duplicate rows per line ---%s\n' "$TEST_BLUE" "$TEST_NC"
+
+# Each line must produce at most one output row. Both helpers are called but
+# each has an early return when the form doesn't match.
+PARENT_BODY_DEDUP='## Phases
+
+- Phase 1 - List form
+**Phase 2 — Bold form**'
+
+dedup_output=$(_parse_phases_section "$PARENT_BODY_DEDUP")
+dedup_count=$(printf '%s\n' "$dedup_output" | grep -c '^[0-9]')
+
+if [[ "$dedup_count" -eq 2 ]]; then
+	pass "No duplicate output rows — each line produces exactly one row"
+else
+	fail "Expected 2 rows for 2 lines, got ${dedup_count}" "Output: ${dedup_output}"
+fi
+
+# =============================================================================
 # Summary
 # =============================================================================
 printf '\n%s=== Results: %d/%d passed ===%s\n' \

--- a/TODO.md
+++ b/TODO.md
@@ -3005,8 +3005,6 @@ t019.3.4,Update AGENTS.md with Beads integration docs,,beads,1h,45m,2025-12-21T1
 
 - [x] t2787 Flip AIDEVOPS_SEQUENTIAL_PHASE_AUTOFILE default to 1 + docs sweep (Phase 3 of #20559) #auto-dispatch ref:GH#20704 pr:#20712 completed:2026-04-24
 
-- [ ] t2788 Extend _parse_phases_section to accept narrative bold-heading form (Phase 1 of #20559) #auto-dispatch ref:GH#20702
-
 - [x] t2789 claim-task-id.sh: apply status:available by default so new issues are dispatchable immediately #auto-dispatch #bug #framework ref:GH#20713 pr:#20720 completed:2026-04-24
 
 - [ ] t2791 t2789: test-status-default-with-desc #auto-dispatch ref:GH#20714


### PR DESCRIPTION
## Summary

Fixes the Complexity Analysis regression that closed prior PR #20705. Delivers Phase 1 of #20559 — extends `_parse_phases_section` to recognise bold-heading phase form (`**Phase N — description**`) alongside the existing list form.

## Why PR #20705 failed

The naive approach inlined a 67-line bold-form `elif` branch into `_parse_phases_section`, pushing the function from ~60 → ~120 lines. The 100-line function-complexity threshold fires, CI fails, PR is closed. 7+ subsequent worker attempts hit the same wall because the issue body said "add an elif branch" — workers copied the shape and got the same result.

## This PR: extract-helpers pattern (precedent: GH#20496)

`auto_file_next_phase` in the same file was already split into 4 helpers two weeks ago (PR #20503). This PR applies the identical pattern to `_parse_phases_section`:

| Function | Lines | Role |
|---|---:|---|
| `_phase_marker_for_line` | 11 | Shared marker lookup (explicit → fallback) |
| `_parse_phase_line_list_form` | 22 | List form parser (`- Phase N - desc`) |
| `_parse_phase_line_bold_form` | 31 | Bold form parser (`**Phase N — desc**`) |
| `_parse_phases_section` | 30 | Thin orchestrator |

All four well under the 100-line threshold.

## New capabilities

- **Bold-heading form**: `**Phase N — description [marker]** [#child]`
- **Global opt-in**: `<!-- phase-auto-fire:on -->` HTML comment in parent body flips unmarked bold phases to `auto-fire`. List form stays conservative (explicit markers required).
- **Child refs**: supported both inside (`**Phase N — desc #NNN**`) and outside (`**Phase N — desc** #NNN`) the closing bold span
- **Separators**: em-dash (`—`), en-dash (`–`), hyphen (`-`), colon (`:`) all strip cleanly

## Tests

7 new tests (Tests 8–14) in `test-shared-phase-filing.sh`:
- Basic bold-form detection, field extraction
- Explicit `[auto-fire:on-prior-merge]` / `[requires-decision]` markers
- `<!-- phase-auto-fire:on -->` global opt-in (bold only, not list form)
- Mixed list + bold in a single body
- Child ref placement variants (inside/outside `**`)
- Separator variants (em-dash, en-dash, hyphen, colon)
- No-duplicate-emission guarantee

`=== Results: 31/31 passed ===`

## Complexity verification (local)

| Metric | base | head | new |
|---|---:|---:|---:|
| function-complexity | 33 | 33 | 0 |
| nesting-depth | 1 | 1 | 0 |
| file-size | 59 | 59 | 0 |
| bash32-compat | 83 | 83 | 0 |
| shellcheck | clean | clean | — |

Measured with `.agents/scripts/complexity-regression-helper.sh check --base origin/main --head HEAD --metric <M>`.

## Incidental fix

Drops a duplicate `t2788` TODO.md entry (lines 3002 and 3008) that would have blocked the push via the `dup-todo` pre-push guard.

## Mentoring note for the next worker (if CI fails)

If a CI gate fires on this PR, the fix is almost certainly to extract a helper — NOT to inline more logic or add more `elif` branches. See `reference/self-improvement.md` and `reference/large-file-split.md`. The `complexity-bump-ok` label is **not** appropriate here — this PR has zero net new violations because it extracts properly.

Resolves #20702
For #20559

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.2 plugin for [OpenCode](https://opencode.ai) v1.14.24 with claude-opus-4-7 spent 10m and 33,520 tokens on this as a headless worker.
