### PR TITLE
t2801: signature-footer hook: fix heredoc/quoted-arg false positives

### DIFF
--- a/.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs
@@ -40,17 +40,92 @@ import { join } from "path";
 export const SIG_MARKER = "<!-- aidevops:sig -->";
 
 /**
+ * Strip heredoc body lines from a multi-line command string.
+ * Lines inside <<MARKER ... MARKER blocks are removed so that prose
+ * inside a heredoc body cannot trigger false-positive gh-write detection
+ * (GH#20735 Failure 1).
+ *
+ * Handles: <<TAG  <<-TAG  <<'TAG'  <<"TAG"
+ * Single-heredoc only; nested / multiple heredocs on one line are rare
+ * and handled conservatively (opener line is kept, body stripped).
+ * @param {string} cmd
+ * @returns {string} cmd with heredoc body lines removed
+ */
+function _stripHeredocBodies(cmd) {
+  const lines = cmd.split("\n");
+  const result = [];
+  let terminator = null;
+  for (const line of lines) {
+    if (terminator !== null) {
+      // Inside a heredoc — check for the terminator (possibly indented for <<-)
+      if (line.trim() === terminator) {
+        terminator = null;
+      }
+      // Skip this line regardless (heredoc body or terminator itself)
+      continue;
+    }
+    // Detect a heredoc opener: <<[-] with optional quotes around the tag
+    const m = line.match(/<<-?\s*['"]?(\w+)['"]?/);
+    if (m) {
+      terminator = m[1];
+    }
+    result.push(line);
+  }
+  return result.join("\n");
+}
+
+/**
+ * Strip balanced single and double quoted strings from a shell line.
+ * Replaces quoted content with empty quotes so that `gh …` tokens embedded
+ * inside quoted arguments of other tools (rg, grep, memory-helper.sh …)
+ * are invisible to the command-boundary check (GH#20735 Failures 2 & 3).
+ *
+ * Double quotes are stripped first (with basic escape handling), then
+ * single quotes (no escapes inside single quotes in POSIX shell).
+ * @param {string} line
+ * @returns {string}
+ */
+function _stripQuotedStrings(line) {
+  // Remove double-quoted strings (handles \" inside)
+  const withoutDouble = line.replace(/"(?:[^"\\]|\\.)*"/g, '""');
+  // Remove single-quoted strings (no escapes possible inside)
+  return withoutDouble.replace(/'[^']*'/g, "''");
+}
+
+/**
  * Decide whether a given bash command is a gh write that needs sig enforcement.
+ *
+ * Three-layer false-positive prevention (GH#20735):
+ *   1. Heredoc stripping — removes lines inside <<TAG…TAG so prose in a
+ *      heredoc body cannot match (Failure 1).
+ *   2. Quoted-string stripping — replaces content inside balanced quotes
+ *      with empty quotes, hiding `gh …` tokens inside string arguments of
+ *      unrelated tools like `rg "gh issue create"` (Failures 2 & 3).
+ *   3. Command-boundary anchor — requires `gh` to be at a shell command
+ *      start: beginning of the trimmed line, or immediately after one of
+ *      ; & | ( ` $( — preventing matches mid-argument after plain whitespace.
+ *
  * @param {string} cmd - Raw bash command string (may be multi-line)
  * @returns {boolean}
  */
 export function isGhWriteCommand(cmd) {
-  const ghWritePattern = /\bgh\s+(pr\s+(create|comment)|issue\s+(create|comment))\b/;
-  return cmd.split("\n").some((line) => {
+  // Layer 3 pattern: gh must start a command segment.
+  // Boundaries: start-of-trimmed-line (^), semicolon, ampersand (covers &&),
+  // pipe (covers ||), open-paren (subshell / command-sub), backtick, literal $(.
+  const ghWritePattern =
+    /(^|[;&|(`]|\$\()\s*gh\s+(pr\s+(create|comment)|issue\s+(create|comment))\b/;
+
+  // Layer 1: strip heredoc bodies from the full command string first
+  const noHeredoc = _stripHeredocBodies(cmd);
+
+  return noHeredoc.split("\n").some((line) => {
     const trimmed = line.trim();
     if (trimmed.startsWith("#")) return false;
     if (/\bgit\s+commit\b/.test(trimmed)) return false;
-    return ghWritePattern.test(trimmed);
+    // Layer 2: strip quoted strings so embedded gh tokens are invisible
+    const unquoted = _stripQuotedStrings(trimmed);
+    // Layer 3: require a command-boundary anchor before gh
+    return ghWritePattern.test(unquoted);
   });
 }
 

--- a/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
@@ -97,6 +97,70 @@ gh issue comment 1 --body "x"
 echo done`;
     assert.equal(isGhWriteCommand(cmd), true);
   });
+
+  // GH#20735 — false-positive regression tests
+  // These cases must NOT be treated as gh write commands.
+
+  test("FP1: heredoc body containing gh issue create prose → ALLOW", () => {
+    const cmd = `cat > /tmp/body.md <<'BODY'\nsome prose about gh issue create invocations\nBODY`;
+    assert.equal(isGhWriteCommand(cmd), false);
+  });
+
+  test("FP1: multi-line heredoc body with gh issue create line → ALLOW", () => {
+    const cmd = [
+      "cat > /tmp/body.md <<'EOF'",
+      "gh issue create --title X --body Y",
+      "EOF",
+    ].join("\n");
+    assert.equal(isGhWriteCommand(cmd), false);
+  });
+
+  test("FP2: memory-helper.sh --content quoting gh issue create → ALLOW", () => {
+    const cmd =
+      'memory-helper.sh store --content "the gh create step fails on label validation"';
+    assert.equal(isGhWriteCommand(cmd), false);
+  });
+
+  test("FP2: any non-gh tool with quoted gh issue create arg → ALLOW", () => {
+    assert.equal(
+      isGhWriteCommand('echo "to file a comment, run gh issue comment N"'),
+      false,
+    );
+  });
+
+  test("FP3: rg pattern containing gh issue create → ALLOW", () => {
+    assert.equal(isGhWriteCommand('rg "gh issue create" src/'), false);
+  });
+
+  test("FP3: grep pattern containing gh pr create → ALLOW", () => {
+    assert.equal(
+      isGhWriteCommand('grep -n "gh pr create" --include="*.md"'),
+      false,
+    );
+  });
+
+  // Legitimate chained gh invocations must still be detected.
+
+  test("chained: foo && gh issue create → BLOCK", () => {
+    assert.equal(
+      isGhWriteCommand('foo && gh issue create --title X --body Y'),
+      true,
+    );
+  });
+
+  test("command substitution: $(gh issue comment N) → BLOCK", () => {
+    assert.equal(
+      isGhWriteCommand('result=$(gh issue comment 123 --body "x")'),
+      true,
+    );
+  });
+
+  test("semicolon chain: setup; gh pr create → BLOCK", () => {
+    assert.equal(
+      isGhWriteCommand('git add .; gh pr create --title t --body b'),
+      true,
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Three-layer false-positive fix for `isGhWriteCommand` in the signature-footer gate (`quality-hooks-signature.mjs`). Prior implementation used `\bgh\b` which matched anywhere on a line, including inside heredoc bodies and quoted string arguments of unrelated tools.

## What changed

**`quality-hooks-signature.mjs`** — `isGhWriteCommand` now applies three complementary layers before testing each line:

1. **Heredoc stripping** (`_stripHeredocBodies`): removes lines inside `<<TAG … TAG` blocks before line-by-line analysis. Prevents matches on prose in heredoc bodies (Failure 1).
2. **Quoted-string stripping** (`_stripQuotedStrings`): replaces balanced single/double quoted content with empty quotes. Hides `gh …` tokens embedded in string arguments of other tools (Failures 2 & 3).
3. **Command-boundary anchor** (regex update): requires `gh` to be preceded by `^`, `;`, `&`, `|`, `(`, `` ` ``, or `$(` — not plain whitespace mid-argument.

The `gh` shim (`.agents/scripts/gh`) is unaffected: it operates on actual parsed shell arguments, not raw command strings, so it never had the false-positive problem.

**`tests/test-signature-footer-gate.mjs`** — 9 new test cases covering:
- Heredoc body with `gh issue create` line → ALLOW
- `memory-helper.sh --content "... gh issue create ..."` → ALLOW
- `rg "gh issue create" src/` → ALLOW
- `echo "run gh issue comment N"` → ALLOW
- `grep -n "gh pr create" ...` → ALLOW
- `foo && gh issue create ...` → BLOCK (chained, still detected)
- `$(gh issue comment N ...)` → BLOCK (command substitution, still detected)
- `git add .; gh pr create ...` → BLOCK (semicolon chain, still detected)

## Verification

```
node --test .agents/plugins/opencode-aidevops/tests/test-signature-footer-gate.mjs
# tests 41 | pass 41 | fail 0
```

All 41 tests pass (32 pre-existing + 9 new).

Resolves #20735
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.2 plugin for [OpenCode](https://opencode.ai) v1.14.24 with claude-sonnet-4-6 spent 3m and 13,117 tokens on this as a headless worker.
