### PR TITLE
GH#20727: migrate review-bot-gate.yml to reusable-workflow pattern

### DIFF
--- a/.agents/reference/reusable-workflows.md
+++ b/.agents/reference/reusable-workflows.md
@@ -21,26 +21,39 @@ The reusable pattern solves all three at once:
 - Framework scripts fetched at runtime via `actions/checkout` — downstream repos need **zero** `.agents/scripts/` files
 - Caller YAMLs are ~45 lines each, mostly event-trigger declarations — the surface area for drift is minimal and declarative
 
+## Migrated workflows
+
+| Workflow file | Reusable | Downstream template | Migrated |
+|---|---|---|---|
+| `issue-sync.yml` | `issue-sync-reusable.yml` | `issue-sync-caller.yml` | t2770 (PR #20662) |
+| `review-bot-gate.yml` | `review-bot-gate-reusable.yml` | `review-bot-gate-caller.yml` | GH#20727 |
+
 ## Architecture
 
 ```
 aidevops repo (source of truth):
-  .github/workflows/issue-sync-reusable.yml  ← on: workflow_call:
-                                                All jobs. All logic. 1300+ lines.
-  .github/workflows/issue-sync.yml           ← thin caller for aidevops's own CI
-                                                (uses: ./.github/workflows/issue-sync-reusable.yml)
+  .github/workflows/issue-sync-reusable.yml       ← on: workflow_call:
+                                                     All jobs. All logic. 1300+ lines.
+  .github/workflows/issue-sync.yml                ← thin caller for aidevops's own CI
+                                                     (uses: ./.github/workflows/issue-sync-reusable.yml)
+  .github/workflows/review-bot-gate-reusable.yml  ← on: workflow_call: (GH#20727)
+                                                     All gate logic. Helper runtime-fetched.
+  .github/workflows/review-bot-gate.yml           ← thin caller for aidevops's own CI
+                                                     (uses: ./.github/workflows/review-bot-gate-reusable.yml)
   .agents/templates/workflows/
-    issue-sync-caller.yml                    ← canonical downstream template
-  .agents/scripts/issue-sync-helper.sh       ← framework shell (source of truth)
+    issue-sync-caller.yml                         ← canonical downstream template (issue-sync)
+    review-bot-gate-caller.yml                    ← canonical downstream template (review-bot-gate)
+  .agents/scripts/issue-sync-helper.sh            ← framework shell (source of truth)
+  .agents/scripts/review-bot-gate-helper.sh       ← gate helper (source of truth, GH#20727)
   .agents/scripts/shared-constants.sh
   .agents/scripts/issue-sync-lib.sh
 
-downstream repo (thin caller):
-  .github/workflows/issue-sync.yml           ← ~45 lines, declares triggers,
-                                                calls the reusable workflow
-                                                via:
-                                                uses: marcusquinn/aidevops/.github/workflows/issue-sync-reusable.yml@<ref>
-  (no .agents/scripts/ needed)
+downstream repo (thin callers):
+  .github/workflows/issue-sync.yml                ← ~45 lines, declares triggers,
+                                                     uses: marcusquinn/aidevops/.github/workflows/issue-sync-reusable.yml@<ref>
+  .github/workflows/review-bot-gate.yml           ← ~50 lines, declares triggers + concurrency,
+                                                     uses: marcusquinn/aidevops/.github/workflows/review-bot-gate-reusable.yml@<ref>
+  (no .agents/scripts/ needed — fetched at runtime via __aidevops/)
 ```
 
 ### How a run flows
@@ -132,8 +145,9 @@ To make a new aidevops workflow reusable by downstream repos:
 
 ## References
 
-- PR [#20662](https://github.com/marcusquinn/aidevops/pull/20662) — Phase 3 implementation (this)
+- PR [#20662](https://github.com/marcusquinn/aidevops/pull/20662) — Phase 3 implementation (issue-sync migration)
 - Issue [#20637](https://github.com/marcusquinn/aidevops/issues/20637) — the symptom report that surfaced the drift class
 - Issue [#20648](https://github.com/marcusquinn/aidevops/issues/20648) — Phase 1 drift detector
 - Issue [#20649](https://github.com/marcusquinn/aidevops/issues/20649) — Phase 2 opt-in resync
+- Issue [#20727](https://github.com/marcusquinn/aidevops/issues/20727) — review-bot-gate migration (SHA-pin stale drift)
 - GitHub docs: [Reusing workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows)

--- a/.agents/scripts/check-workflows-helper.sh
+++ b/.agents/scripts/check-workflows-helper.sh
@@ -397,6 +397,23 @@ _classify_row() {
 	return 0
 }
 
+# _resolve_wf_canonical <template_file> <reusable_file>
+# Emits tab-separated: canonical_path\tcanon_norm (canon_norm may be empty)
+_resolve_wf_canonical() {
+	local _template_file="$1"
+	local _reusable_file="$2"
+	local _canonical=""
+	_canonical=$(_resolve_canonical_template "$_template_file") || _canonical=""
+	local _canon_norm=""
+	if [[ -n "$_canonical" ]]; then
+		local _reusable_escaped
+		_reusable_escaped=$(printf '%s' "$_reusable_file" | sed 's/\./\\./g')
+		_canon_norm=$(_normalize_wf_for_compare "$_canonical" "$_reusable_escaped")
+	fi
+	printf '%s\t%s\n' "$_canonical" "$_canon_norm"
+	return 0
+}
+
 # Process all rows: for each known workflow, classify each repo, render output,
 # tally. Returns exit status (1 if any drifted/needs-migration, 0 otherwise).
 # _process_rows <mode> <verbose> <filter_slug> <filter_workflow>
@@ -417,35 +434,21 @@ _process_rows() {
 	local _rows
 	_rows=$(_iterate_repos) || exit $?
 
-	# Outer loop: known workflows. Inner loop: repos.
-	# This produces one classification row per (repo × workflow).
 	local _wf_tuple
 	for _wf_tuple in "${_KNOWN_WORKFLOWS[@]}"; do
-		# Parse the colon-separated tuple: workflow_file:reusable_file:template_file
 		local _workflow_file _reusable_file _template_file
 		_workflow_file="${_wf_tuple%%:*}"
-		_reusable_file="${_wf_tuple#*:}"
-		_reusable_file="${_reusable_file%%:*}"
+		_reusable_file="${_wf_tuple#*:}"; _reusable_file="${_reusable_file%%:*}"
 		_template_file="${_wf_tuple##*:}"
 
-		# Apply --workflow filter if set (match against workflow_file without .yml)
 		local _workflow_name="${_workflow_file%.yml}"
 		if [[ -n "$_filter_workflow" ]]; then
 			local _fw_norm="${_filter_workflow%.yml}"
 			[[ "$_workflow_name" != "$_fw_norm" ]] && continue
 		fi
 
-		# Resolve canonical template for this workflow.
-		local _canonical=""
-		_canonical=$(_resolve_canonical_template "$_template_file") || _canonical=""
-
-		# Pre-compute the loop-invariant normalisation of the canonical template.
-		local _canon_norm=""
-		if [[ -n "$_canonical" ]]; then
-			local _reusable_escaped
-			_reusable_escaped=$(printf '%s' "$_reusable_file" | sed 's/\./\\./g')
-			_canon_norm=$(_normalize_wf_for_compare "$_canonical" "$_reusable_escaped")
-		fi
+		local _canonical _canon_norm
+		IFS=$'\t' read -r _canonical _canon_norm < <(_resolve_wf_canonical "$_template_file" "$_reusable_file")
 
 		local _path _local_only_flag _slug
 		while IFS=$'\t' read -r _path _local_only_flag _slug; do
@@ -467,16 +470,11 @@ _process_rows() {
 			NO-TEMPLATE) _no_template=$((_no_template + 1)) ;;
 			CURRENT/CALLER | CURRENT/SELF-CALLER) _current=$((_current + 1)) ;;
 			DRIFTED/CALLER)
-				_drifted=$((_drifted + 1))
-				_any_failure=1
-				if ((_verbose == 1)) && [[ "$_mode" == "$_MODE_HUMAN" ]]; then
-					_note="see diff below"
-				fi
+				_drifted=$((_drifted + 1)); _any_failure=1
+				((_verbose == 1)) && [[ "$_mode" == "$_MODE_HUMAN" ]] && _note="see diff below"
 				;;
 			NEEDS-MIGRATION)
-				_needs_mig=$((_needs_mig + 1))
-				_any_failure=1
-				;;
+				_needs_mig=$((_needs_mig + 1)); _any_failure=1 ;;
 			esac
 
 			if [[ "$_mode" == "$_MODE_JSON" ]]; then
@@ -484,9 +482,7 @@ _process_rows() {
 			else
 				_render_row_human "$_label" "$_path" "$_class" "$_note" "$_workflow_name"
 				if ((_verbose == 1)) && [[ "$_class" == "DRIFTED/CALLER" ]] && [[ -n "$_canonical" ]]; then
-					echo ""
-					_diff_summary "$_path/.github/workflows/${_workflow_file}" "$_canonical"
-					echo ""
+					echo ""; _diff_summary "$_path/.github/workflows/${_workflow_file}" "$_canonical"; echo ""
 				fi
 			fi
 		done <<<"$_rows"
@@ -495,9 +491,7 @@ _process_rows() {
 	if [[ "$_mode" == "$_MODE_HUMAN" ]]; then
 		printf '\n  Summary: %d entries — %d current, %d drifted, %d needs-migration, %d no-workflow, %d local-only, %d no-template\n\n' \
 			"$_total" "$_current" "$_drifted" "$_needs_mig" "$_no_wf" "$_local_only" "$_no_template"
-		if ((_any_failure == 1)); then
-			printf '  Exit code 1 — see DRIFTED/CALLER or NEEDS-MIGRATION entries above.\n\n'
-		fi
+		((_any_failure == 1)) && printf '  Exit code 1 — see DRIFTED/CALLER or NEEDS-MIGRATION entries above.\n\n'
 	fi
 
 	return "$_any_failure"

--- a/.agents/scripts/check-workflows-helper.sh
+++ b/.agents/scripts/check-workflows-helper.sh
@@ -4,25 +4,30 @@
 #
 # check-workflows-helper.sh — detect framework workflow drift across registered repos (t2778, GH#20648)
 #
-# Compares each registered repo's `.github/workflows/issue-sync.yml` against the
-# canonical caller template at `.agents/templates/workflows/issue-sync-caller.yml`.
-# Classifies each repo as:
+# Compares each registered repo's managed framework workflows against the
+# canonical caller templates in `.agents/templates/workflows/`. Currently
+# managed workflows:
+#   - issue-sync.yml         (template: issue-sync-caller.yml)
+#   - review-bot-gate.yml    (template: review-bot-gate-caller.yml, GH#20727)
+#
+# Classifies each (repo × workflow) as:
 #
 #   CURRENT/CALLER      — byte-identical to canonical (up to @ref pin variance)
 #   CURRENT/SELF-CALLER — aidevops itself: uses `./.github/workflows/...` instead of remote ref
 #   DRIFTED/CALLER      — uses the reusable workflow but caller YAML has diverged
 #   NEEDS-MIGRATION     — legacy full-copy workflow, no `uses:` → should adopt caller pattern
-#   NO-WORKFLOW         — no `issue-sync.yml` present (repo doesn't sync TODO ↔ issues)
+#   NO-WORKFLOW         — workflow file not present (repo hasn't adopted this workflow)
 #   LOCAL-ONLY          — repo has `local_only: true`, no remote to check
 #   NO-TEMPLATE         — canonical template missing; helper cannot classify
 #
 # Usage:
-#   check-workflows-helper.sh [--repo OWNER/REPO] [--json] [--verbose]
+#   check-workflows-helper.sh [--repo OWNER/REPO] [--workflow NAME] [--json] [--verbose]
 #   check-workflows-helper.sh --help
 #
 # Options:
 #   --repo OWNER/REPO   Check only the named slug (default: all registered)
-#   --json              Machine-readable output (one JSON object per repo)
+#   --workflow NAME     Check only the named workflow (issue-sync or review-bot-gate)
+#   --json              Machine-readable output (one JSON object per repo × workflow)
 #   --verbose           Show diff summary for DRIFTED/CALLER entries
 #   -h, --help          Show usage and exit 0
 #
@@ -42,6 +47,11 @@
 #   legacy full-copy pattern (NEEDS-MIGRATION) and which caller YAMLs have
 #   diverged from the canonical template (DRIFTED/CALLER).
 #
+#   GH#20727 extended the known-workflow set to include review-bot-gate.yml,
+#   which had a SHA-pinned helper checkout that silently drifted after helper
+#   changes (the Option A' settlement fix in PR #20572 never reached downstream
+#   repos pinned to 73b664a).
+#
 #   Phase 2 (`aidevops sync-workflows --apply`) will migrate or refresh callers
 #   based on this helper's classification.
 
@@ -49,14 +59,35 @@ set -uo pipefail
 
 SCRIPT_NAME=$(basename "$0")
 
+# ─── Known managed workflows ────────────────────────────────────────────────
+#
+# Each entry is a colon-separated tuple:
+#   workflow_file:reusable_file:template_file
+#
+# workflow_file   — the filename under .github/workflows/ in each repo
+# reusable_file  — the reusable workflow filename in marcusquinn/aidevops
+# template_file  — the canonical caller template filename under .agents/templates/workflows/
+#
+# Add new reusable-workflow migrations here. The helper loops over this list
+# for every repo and classifies each (repo × workflow) independently.
+#
+# GH#20727: review-bot-gate added.
+readonly _KNOWN_WORKFLOWS=(
+	"issue-sync.yml:issue-sync-reusable.yml:issue-sync-caller.yml"
+	"review-bot-gate.yml:review-bot-gate-reusable.yml:review-bot-gate-caller.yml"
+)
+
 # ─── Path resolution ────────────────────────────────────────────────────────
 
-# Canonical template — prefer deployed copy, fall back to the repo checkout
+# Canonical template — prefer deployed copy, fall back to the repo checkout.
+# _resolve_canonical_template <template_filename>
+# e.g. _resolve_canonical_template "issue-sync-caller.yml"
 _resolve_canonical_template() {
-	local _deployed="$HOME/.aidevops/agents/templates/workflows/issue-sync-caller.yml"
+	local _template_filename="$1"
+	local _deployed="$HOME/.aidevops/agents/templates/workflows/${_template_filename}"
 	local _self_dir
 	_self_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd 2>/dev/null) || _self_dir=""
-	local _repo_local="$_self_dir/../templates/workflows/issue-sync-caller.yml"
+	local _repo_local="$_self_dir/../templates/workflows/${_template_filename}"
 
 	if [[ -f "$_deployed" ]]; then
 		printf '%s\n' "$_deployed"
@@ -87,55 +118,79 @@ _die() {
 }
 
 _usage() {
-	sed -n '4,38p' "$0" | sed 's/^# \{0,1\}//'
+	sed -n '4,55p' "$0" | sed 's/^# \{0,1\}//'
 	return 0
 }
 
 # ─── Classification ─────────────────────────────────────────────────────────
 
-# _classify_workflow <workflow-file> <canonical-template> [<canon-norm>]
+# _normalize_wf_for_compare <file> <reusable_escaped>
+# Normalise a workflow file for byte-comparison:
+#   - Replaces the @<ref> suffix on reusable `uses:` lines with @REF so that
+#     `@main` vs `@v3.9.0` doesn't count as drift.
+#   - Replaces `branches: [<name>]` with `branches: [BRANCH]` so repos that
+#     default to `develop` aren't flagged as drifted from a main-defaulting template.
+# Emits normalised content on stdout.
+_normalize_wf_for_compare() {
+	local _file="$1"
+	local _reusable_escaped="$2"
+	sed -E "s|(marcusquinn/aidevops/\.github/workflows/${_reusable_escaped})@[^[:space:]]+|\1@REF|g" "$_file" \
+		| sed -E 's|^([[:space:]]+branches:) \[[^]]+\]$|\1 [BRANCH]|'
+	return 0
+}
+
+# _classify_workflow <workflow-file> <canonical-template> <reusable-name> [<canon-norm>]
 # Prints the classification string on stdout.
 # Returns 0 always; status is carried via the emitted string.
-# The optional third argument is a pre-computed normalised form of the
-# canonical template (loop-invariant); when provided, the inner sed call is
-# skipped, avoiding redundant work for each repo in the iteration loop.
+#
+# Parameters:
+#   _wf            — path to the workflow file to classify
+#   _canon         — path to the canonical caller template
+#   _reusable_name — filename of the reusable workflow (e.g. "issue-sync-reusable.yml")
+#   _canon_norm_pre — optional pre-computed normalised form of the canonical template
+#                    (loop-invariant optimisation; skip the inner sed call when provided)
 _classify_workflow() {
 	local _wf="$1"
 	local _canon="$2"
-	local _canon_norm_pre="${3:-}"
+	local _reusable_name="$3"
+	local _canon_norm_pre="${4:-}"
 
 	if [[ ! -f "$_wf" ]]; then
 		printf 'NO-WORKFLOW\n'
 		return 0
 	fi
 
-	# Detect self-caller (aidevops itself) — uses: ./.github/workflows/...
+	# Detect self-caller (aidevops itself) — uses: ./.github/workflows/<reusable-name>
 	# This is the intended pattern for the aidevops repo and must not be flagged
 	# as drift. The self-caller is functionally equivalent to the downstream
 	# pattern; it just skips the cross-repo checkout.
-	if grep -qE "uses:\s*\./\.github/workflows/issue-sync-reusable\.yml" "$_wf"; then
+	local _self_caller_pattern
+	_self_caller_pattern="uses:[[:space:]]*\./\.github/workflows/${_reusable_name}"
+	if grep -qE "$_self_caller_pattern" "$_wf"; then
 		printf 'CURRENT/SELF-CALLER\n'
 		return 0
 	fi
 
 	# Detect caller pattern: any `uses:` line pointing at the reusable workflow.
 	# Accept any `@<ref>` variant (main, v3.9.0, a commit SHA, etc).
-	if grep -qE "uses:\s*marcusquinn/aidevops/\.github/workflows/issue-sync-reusable\.yml@" "$_wf"; then
+	local _downstream_pattern
+	_downstream_pattern="uses:[[:space:]]*marcusquinn/aidevops/\.github/workflows/${_reusable_name}@"
+	if grep -qE "$_downstream_pattern" "$_wf"; then
 		# It's a caller. Compare against canonical, normalising the @ref so that
 		# `@main` vs `@v3.9.0` doesn't count as drift (intentional pinning is OK).
 		# Also normalise the push-trigger branch filter so a repo with
 		# `branches: [develop]` installed by sync-workflows is not flagged as
 		# drift — the branch name reflects the downstream default, not the template.
-		local _wf_norm _canon_norm
-		_wf_norm=$(sed -E 's|(marcusquinn/aidevops/\.github/workflows/issue-sync-reusable\.yml)@[^[:space:]]+|\1@REF|g' "$_wf" \
-			| sed -E 's|^([[:space:]]+branches:) \[[^]]+\]$|\1 [BRANCH]|')
+		local _reusable_escaped _wf_norm _canon_norm
+		# Escape dots for use in sed BRE/ERE pattern
+		_reusable_escaped=$(printf '%s' "$_reusable_name" | sed 's/\./\\./g')
+		_wf_norm=$(_normalize_wf_for_compare "$_wf" "$_reusable_escaped")
 		# Use pre-computed canon_norm when available (caller hoist); fall back to
 		# computing it here so the function remains usable in isolation.
 		if [[ -n "$_canon_norm_pre" ]]; then
 			_canon_norm="$_canon_norm_pre"
 		else
-			_canon_norm=$(sed -E 's|(marcusquinn/aidevops/\.github/workflows/issue-sync-reusable\.yml)@[^[:space:]]+|\1@REF|g' "$_canon" \
-				| sed -E 's|^([[:space:]]+branches:) \[[^]]+\]$|\1 [BRANCH]|')
+			_canon_norm=$(_normalize_wf_for_compare "$_canon" "$_reusable_escaped")
 		fi
 
 		if [[ "$_wf_norm" == "$_canon_norm" ]]; then
@@ -146,13 +201,13 @@ _classify_workflow() {
 		return 0
 	fi
 
-	# Not a caller. If the filename is `issue-sync.yml`, it's presumed to be
-	# an aidevops issue-sync workflow and the legacy pattern needs migration
-	# to the caller model. This catches:
-	#   - Modern full-copies that invoke `issue-sync-helper.sh` directly
-	#   - Older full-copies that inline the TODO.md parsing logic
-	#   - Any variant of either that has drifted over time
-	# All three are equivalently "legacy patterns to be replaced by a caller".
+	# Not a caller. The workflow exists but does not delegate to the reusable
+	# pattern — it's a legacy full-copy that needs migration to the caller model.
+	# This catches:
+	#   - Modern full-copies that invoke the helper script directly
+	#   - Older full-copies that inline the gate logic
+	#   - SHA-pinned helper checkouts (the GH#20727 pattern)
+	# All variants are equivalently "legacy patterns to be replaced by a caller".
 	printf 'NEEDS-MIGRATION\n'
 	return 0
 }
@@ -187,12 +242,13 @@ _iterate_repos() {
 
 # ─── Output formats ─────────────────────────────────────────────────────────
 
-# _render_row <slug> <path> <classification> <note>
+# _render_row_human <slug> <path> <classification> <note> [<workflow>]
 _render_row_human() {
 	local _slug="$1"
 	local _path="$2"
 	local _class="$3"
 	local _note="${4:-}"
+	local _workflow="${5:-}"
 
 	# Colour-code for terminals
 	local _colour_reset _colour=''
@@ -209,8 +265,14 @@ _render_row_human() {
 		_colour_reset=''
 	fi
 
-	printf '  %-40s %s%-16s%s %s\n' \
-		"$_slug" "$_colour" "$_class" "$_colour_reset" "$_note"
+	# When multiple workflows are checked, prefix slug with [workflow] for context.
+	local _label="$_slug"
+	if [[ -n "$_workflow" ]]; then
+		_label="[${_workflow}] ${_slug}"
+	fi
+
+	printf '  %-50s %s%-16s%s %s\n' \
+		"$_label" "$_colour" "$_class" "$_colour_reset" "$_note"
 	return 0
 }
 
@@ -219,13 +281,15 @@ _render_row_json() {
 	local _path="$2"
 	local _class="$3"
 	local _note="${4:-}"
+	local _workflow="${5:-}"
 
 	jq -cn \
 		--arg slug "$_slug" \
 		--arg path "$_path" \
 		--arg class "$_class" \
 		--arg note "$_note" \
-		'{slug: $slug, path: $path, classification: $class, note: $note}'
+		--arg workflow "$_workflow" \
+		'{slug: $slug, path: $path, workflow: $workflow, classification: $class, note: $note}'
 	return 0
 }
 
@@ -247,10 +311,11 @@ _diff_summary() {
 readonly _MODE_HUMAN="human"
 readonly _MODE_JSON="json"
 
-# Parse command-line flags. Emits TSV: mode\tverbose\tfilter_slug.
+# Parse command-line flags. Emits TSV: mode\tverbose\tfilter_slug\tfilter_workflow.
 # Exits 0 on --help. Exits 2 via _die on unknown option.
 _parse_args() {
 	local _filter_slug=""
+	local _filter_workflow=""
 	local _mode="$_MODE_HUMAN"
 	local _verbose=0
 
@@ -260,6 +325,10 @@ _parse_args() {
 		--repo)
 			_filter_slug="${2:-}"
 			shift 2 || _die "--repo requires an argument"
+			;;
+		--workflow)
+			_filter_workflow="${2:-}"
+			shift 2 || _die "--workflow requires an argument"
 			;;
 		--json)
 			_mode="$_MODE_JSON"
@@ -279,21 +348,22 @@ _parse_args() {
 		esac
 	done
 
-	printf '%s\t%d\t%s\n' "$_mode" "$_verbose" "$_filter_slug"
+	printf '%s\t%d\t%s\t%s\n' "$_mode" "$_verbose" "$_filter_slug" "$_filter_workflow"
 	return 0
 }
 
-# Classify a single repo row and update counters via namerefs.
-# Side-effects: updates _counters_* via indirect-assignment (pass counter vars
-# by reference is bash 4+; instead we print a classification line and let the
-# caller update counters).
+# Classify a single (repo × workflow) combination.
+# Side-effects: prints a classification line; caller updates counters.
 #
 # Emits: class\tnote
+# _classify_row <path> <local_only_flag> <canonical> <reusable_name> <workflow_file> [<canon_norm>]
 _classify_row() {
 	local _path="$1"
 	local _local_only_flag="$2"
 	local _canonical="$3"
-	local _canon_norm="${4:-}"
+	local _reusable_name="$4"
+	local _workflow_file="$5"
+	local _canon_norm="${6:-}"
 
 	if [[ "$_local_only_flag" == "true" ]]; then
 		printf 'LOCAL-ONLY\t\n'
@@ -305,7 +375,7 @@ _classify_row() {
 		return 0
 	fi
 
-	local _wf="$_path/.github/workflows/issue-sync.yml"
+	local _wf="$_path/.github/workflows/${_workflow_file}"
 	if [[ -z "$_canonical" ]]; then
 		if [[ -f "$_wf" ]]; then
 			printf 'NO-TEMPLATE\tcanonical template missing — classification deferred\n'
@@ -316,88 +386,114 @@ _classify_row() {
 	fi
 
 	local _class
-	_class=$(_classify_workflow "$_wf" "$_canonical" "$_canon_norm")
+	_class=$(_classify_workflow "$_wf" "$_canonical" "$_reusable_name" "$_canon_norm")
 	local _note=""
 	case "$_class" in
 	NEEDS-MIGRATION)
-		_note="legacy full-copy; run: aidevops sync-workflows --apply (Phase 2)"
+		_note="legacy full-copy; run: aidevops sync-workflows --apply"
 		;;
 	esac
 	printf '%s\t%s\n' "$_class" "$_note"
 	return 0
 }
 
-# Process all rows: classify each, render output, tally. Returns exit status
-# (1 if any drifted/needs-migration, 0 otherwise).
+# Process all rows: for each known workflow, classify each repo, render output,
+# tally. Returns exit status (1 if any drifted/needs-migration, 0 otherwise).
+# _process_rows <mode> <verbose> <filter_slug> <filter_workflow>
 _process_rows() {
 	local _mode="$1"
 	local _verbose="$2"
 	local _filter_slug="$3"
-	local _canonical="$4"
+	local _filter_workflow="${4:-}"
 
 	local _any_failure=0
 	local _total=0 _current=0 _drifted=0 _needs_mig=0 _no_wf=0 _local_only=0 _no_template=0
 
-	# Pre-compute the loop-invariant normalisation of the canonical template
-	# once here rather than inside _classify_workflow on every repo iteration.
-	local _canon_norm=""
-	if [[ -n "$_canonical" ]]; then
-		_canon_norm=$(sed -E 's|(marcusquinn/aidevops/\.github/workflows/issue-sync-reusable\.yml)@[^[:space:]]+|\1@REF|g' "$_canonical" \
-			| sed -E 's|^([[:space:]]+branches:) \[[^]]+\]$|\1 [BRANCH]|')
-	fi
-
 	if [[ "$_mode" == "$_MODE_HUMAN" ]]; then
-		printf '\n  %-40s %-16s %s\n' "REPO" "STATUS" "NOTE"
-		printf '  %s\n' "$(printf '%.0s─' {1..78})"
+		printf '\n  %-50s %-16s %s\n' "REPO [WORKFLOW]" "STATUS" "NOTE"
+		printf '  %s\n' "$(printf '%.0s─' {1..88})"
 	fi
 
 	local _rows
 	_rows=$(_iterate_repos) || exit $?
 
-	local _path _local_only_flag _slug
-	while IFS=$'\t' read -r _path _local_only_flag _slug; do
-		[[ -z "$_slug" && -z "$_path" ]] && continue
-		local _label="${_slug:-$(basename "$_path")}"
-		[[ -n "$_filter_slug" && "$_slug" != "$_filter_slug" ]] && continue
+	# Outer loop: known workflows. Inner loop: repos.
+	# This produces one classification row per (repo × workflow).
+	local _wf_tuple
+	for _wf_tuple in "${_KNOWN_WORKFLOWS[@]}"; do
+		# Parse the colon-separated tuple: workflow_file:reusable_file:template_file
+		local _workflow_file _reusable_file _template_file
+		_workflow_file="${_wf_tuple%%:*}"
+		_reusable_file="${_wf_tuple#*:}"
+		_reusable_file="${_reusable_file%%:*}"
+		_template_file="${_wf_tuple##*:}"
 
-		_total=$((_total + 1))
-		_path="${_path/#\~/$HOME}"
-
-		local _class _note
-		IFS=$'\t' read -r _class _note < <(_classify_row "$_path" "$_local_only_flag" "$_canonical" "$_canon_norm")
-
-		case "$_class" in
-		LOCAL-ONLY) _local_only=$((_local_only + 1)) ;;
-		NO-WORKFLOW) _no_wf=$((_no_wf + 1)) ;;
-		NO-TEMPLATE) _no_template=$((_no_template + 1)) ;;
-		CURRENT/CALLER | CURRENT/SELF-CALLER) _current=$((_current + 1)) ;;
-		DRIFTED/CALLER)
-			_drifted=$((_drifted + 1))
-			_any_failure=1
-			if ((_verbose == 1)) && [[ "$_mode" == "$_MODE_HUMAN" ]]; then
-				_note="see diff below"
-			fi
-			;;
-		NEEDS-MIGRATION)
-			_needs_mig=$((_needs_mig + 1))
-			_any_failure=1
-			;;
-		esac
-
-		if [[ "$_mode" == "$_MODE_JSON" ]]; then
-			_render_row_json "$_label" "$_path" "$_class" "$_note"
-		else
-			_render_row_human "$_label" "$_path" "$_class" "$_note"
-			if ((_verbose == 1)) && [[ "$_class" == "DRIFTED/CALLER" ]] && [[ -n "$_canonical" ]]; then
-				echo ""
-				_diff_summary "$_path/.github/workflows/issue-sync.yml" "$_canonical"
-				echo ""
-			fi
+		# Apply --workflow filter if set (match against workflow_file without .yml)
+		local _workflow_name="${_workflow_file%.yml}"
+		if [[ -n "$_filter_workflow" ]]; then
+			local _fw_norm="${_filter_workflow%.yml}"
+			[[ "$_workflow_name" != "$_fw_norm" ]] && continue
 		fi
-	done <<<"$_rows"
+
+		# Resolve canonical template for this workflow.
+		local _canonical=""
+		_canonical=$(_resolve_canonical_template "$_template_file") || _canonical=""
+
+		# Pre-compute the loop-invariant normalisation of the canonical template.
+		local _canon_norm=""
+		if [[ -n "$_canonical" ]]; then
+			local _reusable_escaped
+			_reusable_escaped=$(printf '%s' "$_reusable_file" | sed 's/\./\\./g')
+			_canon_norm=$(_normalize_wf_for_compare "$_canonical" "$_reusable_escaped")
+		fi
+
+		local _path _local_only_flag _slug
+		while IFS=$'\t' read -r _path _local_only_flag _slug; do
+			[[ -z "$_slug" && -z "$_path" ]] && continue
+			local _label="${_slug:-$(basename "$_path")}"
+			[[ -n "$_filter_slug" && "$_slug" != "$_filter_slug" ]] && continue
+
+			_total=$((_total + 1))
+			_path="${_path/#\~/$HOME}"
+
+			local _class _note
+			IFS=$'\t' read -r _class _note < <(_classify_row \
+				"$_path" "$_local_only_flag" "$_canonical" \
+				"$_reusable_file" "$_workflow_file" "$_canon_norm")
+
+			case "$_class" in
+			LOCAL-ONLY) _local_only=$((_local_only + 1)) ;;
+			NO-WORKFLOW) _no_wf=$((_no_wf + 1)) ;;
+			NO-TEMPLATE) _no_template=$((_no_template + 1)) ;;
+			CURRENT/CALLER | CURRENT/SELF-CALLER) _current=$((_current + 1)) ;;
+			DRIFTED/CALLER)
+				_drifted=$((_drifted + 1))
+				_any_failure=1
+				if ((_verbose == 1)) && [[ "$_mode" == "$_MODE_HUMAN" ]]; then
+					_note="see diff below"
+				fi
+				;;
+			NEEDS-MIGRATION)
+				_needs_mig=$((_needs_mig + 1))
+				_any_failure=1
+				;;
+			esac
+
+			if [[ "$_mode" == "$_MODE_JSON" ]]; then
+				_render_row_json "$_label" "$_path" "$_class" "$_note" "$_workflow_name"
+			else
+				_render_row_human "$_label" "$_path" "$_class" "$_note" "$_workflow_name"
+				if ((_verbose == 1)) && [[ "$_class" == "DRIFTED/CALLER" ]] && [[ -n "$_canonical" ]]; then
+					echo ""
+					_diff_summary "$_path/.github/workflows/${_workflow_file}" "$_canonical"
+					echo ""
+				fi
+			fi
+		done <<<"$_rows"
+	done
 
 	if [[ "$_mode" == "$_MODE_HUMAN" ]]; then
-		printf '\n  Summary: %d repos — %d current, %d drifted, %d needs-migration, %d no-workflow, %d local-only, %d no-template\n\n' \
+		printf '\n  Summary: %d entries — %d current, %d drifted, %d needs-migration, %d no-workflow, %d local-only, %d no-template\n\n' \
 			"$_total" "$_current" "$_drifted" "$_needs_mig" "$_no_wf" "$_local_only" "$_no_template"
 		if ((_any_failure == 1)); then
 			printf '  Exit code 1 — see DRIFTED/CALLER or NEEDS-MIGRATION entries above.\n\n'
@@ -417,18 +513,10 @@ main() {
 		_die "jq required — install via Homebrew/apt or equivalent"
 	fi
 
-	local _mode _verbose _filter_slug
-	IFS=$'\t' read -r _mode _verbose _filter_slug < <(_parse_args "$@")
+	local _mode _verbose _filter_slug _filter_workflow
+	IFS=$'\t' read -r _mode _verbose _filter_slug _filter_workflow < <(_parse_args "$@")
 
-	local _canonical
-	if ! _canonical=$(_resolve_canonical_template); then
-		if [[ "$_mode" == "$_MODE_HUMAN" ]]; then
-			_log "canonical template not found — install aidevops to resolve templates/workflows/issue-sync-caller.yml"
-		fi
-		_canonical=""
-	fi
-
-	if _process_rows "$_mode" "$_verbose" "$_filter_slug" "$_canonical"; then
+	if _process_rows "$_mode" "$_verbose" "$_filter_slug" "$_filter_workflow"; then
 		exit 0
 	else
 		exit 1

--- a/.agents/scripts/sync-workflows-helper.sh
+++ b/.agents/scripts/sync-workflows-helper.sh
@@ -7,7 +7,11 @@
 # Phase 2 of workflow drift elimination (t2779, GH#20649).
 # Partner to check-workflows-helper.sh (Phase 1, t2778). Reads classifications
 # from the detector and, per repo, either installs or refreshes the canonical
-# caller template at `.github/workflows/issue-sync.yml`.
+# caller template at `.github/workflows/<name>.yml`.
+#
+# Currently managed workflows (synced by default):
+#   - issue-sync.yml         (template: issue-sync-caller.yml)
+#   - review-bot-gate.yml    (template: review-bot-gate-caller.yml, GH#20727)
 #
 # Default mode is --dry-run. Pass --apply to actually write, commit, push, and
 # open a PR in each target repo.
@@ -61,7 +65,14 @@ _C_NC=$'\033[0m'
 
 readonly REPOS_JSON="$HOME/.config/aidevops/repos.json"
 readonly CHECK_HELPER="$SELF_DIR/check-workflows-helper.sh"
-readonly WORKFLOW_PATH=".github/workflows/issue-sync.yml"
+
+# Known managed workflows — each entry is workflow_file:template_file.
+# Mirrors _KNOWN_WORKFLOWS in check-workflows-helper.sh.
+# GH#20727: review-bot-gate added.
+readonly _SYNC_KNOWN_WORKFLOWS=(
+	"issue-sync.yml:issue-sync-caller.yml"
+	"review-bot-gate.yml:review-bot-gate-caller.yml"
+)
 
 # Output mode constants.
 readonly _STATUS_SKIPPED="SKIPPED"
@@ -102,27 +113,28 @@ _usage() {
 
 sync-workflows-helper.sh — resync drifted framework workflows (t2779, GH#20649)
 
-Reads classifications from check-workflows-helper.sh and, per repo, installs
-(NEEDS-MIGRATION) or refreshes (DRIFTED/CALLER) the canonical caller template
-at `.github/workflows/issue-sync.yml`.
+Reads classifications from check-workflows-helper.sh and, per repo × workflow,
+installs (NEEDS-MIGRATION) or refreshes (DRIFTED/CALLER) the canonical caller
+template. Managed workflows: issue-sync.yml, review-bot-gate.yml (GH#20727).
 
 Default is --dry-run. Pass --apply to write, commit, push, and open PRs.
 
 Usage:
-  sync-workflows-helper.sh [--apply] [--repo OWNER/REPO] [--force-ref]
-                           [--ref REF] [--branch NAME] [--json]
+  sync-workflows-helper.sh [--apply] [--repo OWNER/REPO] [--workflow NAME]
+                           [--force-ref] [--ref REF] [--branch NAME] [--json]
   sync-workflows-helper.sh --help
 
 Options:
-  --apply         Actually perform the migration. Without this, only prints
-                  what would happen (dry-run is the default for safety).
-  --repo SLUG     Limit to a single repo. Example: --repo owner/repo.
-  --force-ref     Overwrite existing @ref pinning with the template's default.
-                  Without this, existing pins (@v3.9.0, @<sha>) are preserved.
-  --ref REF       Explicit @ref for new installs (default: @main).
-  --branch NAME   Branch name prefix (default: chore/workflow-sync-YYYYMMDD).
-  --json          Emit one JSON object per repo describing the outcome.
-  -h, --help      Show this help.
+  --apply           Actually perform the migration. Without this, only prints
+                    what would happen (dry-run is the default for safety).
+  --repo SLUG       Limit to a single repo. Example: --repo owner/repo.
+  --workflow NAME   Limit to a single workflow (issue-sync or review-bot-gate).
+  --force-ref       Overwrite existing @ref pinning with the template's default.
+                    Without this, existing pins (@v3.9.0, @<sha>) are preserved.
+  --ref REF         Explicit @ref for new installs (default: @main).
+  --branch NAME     Branch name prefix (default: chore/workflow-sync-YYYYMMDD).
+  --json            Emit one JSON object per repo × workflow describing outcome.
+  -h, --help        Show this help.
 
 Exit codes:
   0  no work needed OR all targets succeeded
@@ -130,11 +142,11 @@ Exit codes:
   2  config error
 
 Examples:
-  # See what would happen across all repos:
+  # See what would happen across all repos (all workflows):
   sync-workflows-helper.sh
 
-  # Migrate one specific repo:
-  sync-workflows-helper.sh --apply --repo wpallstars/awardsapp
+  # Migrate review-bot-gate only for one repo:
+  sync-workflows-helper.sh --apply --repo wpallstars/awardsapp --workflow review-bot-gate
 
   # Migrate all drifted/needs-migration repos, pin to v3.9.0:
   sync-workflows-helper.sh --apply --ref @v3.9.0
@@ -145,10 +157,13 @@ EOF
 
 # ─── Template Resolution ────────────────────────────────────────────────────
 
+# _resolve_canonical_template <template_filename>
+# e.g. _resolve_canonical_template "review-bot-gate-caller.yml"
 _resolve_canonical_template() {
+	local _template_filename="$1"
 	local _candidates=(
-		"$HOME/.aidevops/agents/templates/workflows/issue-sync-caller.yml"
-		"$SELF_DIR/../templates/workflows/issue-sync-caller.yml"
+		"$HOME/.aidevops/agents/templates/workflows/${_template_filename}"
+		"$SELF_DIR/../templates/workflows/${_template_filename}"
 	)
 	local _path
 	for _path in "${_candidates[@]}"; do
@@ -202,11 +217,14 @@ _rewrite_content_branch_filter() {
 # ─── Classification Ingestion ───────────────────────────────────────────────
 
 # Invoke check-workflows-helper.sh --json and filter to actionable rows.
-# Emits TSV: slug\tpath\tstatus\tref_pin
+# Emits TSV: slug\tpath\tstatus\tworkflow
+# _list_actionable_repos <filter_slug> [filter_workflow]
 _list_actionable_repos() {
 	local _filter_slug="$1"
+	local _filter_workflow="${2:-}"
 	local _check_args=(--json)
 	[[ -n "$_filter_slug" ]] && _check_args+=(--repo "$_filter_slug")
+	[[ -n "$_filter_workflow" ]] && _check_args+=(--workflow "$_filter_workflow")
 
 	# check-workflows-helper.sh exits 1 when actionable rows exist — that is
 	# precisely when we have work to do. Capture output regardless of exit.
@@ -216,58 +234,61 @@ _list_actionable_repos() {
 		return 1
 	fi
 
-	# Filter to DRIFTED/CALLER and NEEDS-MIGRATION; carry slug, path, classification.
+	# Filter to DRIFTED/CALLER and NEEDS-MIGRATION; carry slug, path,
+	# classification, and workflow name so _process_rows can pick the right
+	# template for each (repo × workflow) combination.
 	# --arg makes the bash constants visible to jq without interpolation hacks.
 	printf '%s\n' "$_json" | jq -r \
 		--arg drifted "$_CLASS_DRIFTED" \
 		--arg needs "$_CLASS_NEEDS_MIGRATION" \
 		'select((.classification == $drifted) or (.classification == $needs))
-			| [.slug, .path, .classification, ""] | @tsv' 2>/dev/null
+			| [.slug, .path, .classification, (.workflow // "")] | @tsv' 2>/dev/null
 	return 0
 }
 
 # ─── Message Formatters ─────────────────────────────────────────────────────
 # Bash 3.2-safe multi-line body builders (no heredoc inside $()).
 
-# _format_commit_body <status> <ref>
+# _format_commit_body <status> <ref> <workflow_path>
 # shellcheck disable=SC2016  # backticks are intentional markdown literals
 _format_commit_body() {
 	local _status="$1"
 	local _ref="$2"
-	printf 'Resync `%s` to the canonical aidevops caller template.\n\n' "$WORKFLOW_PATH"
+	local _workflow_path="$3"
+	printf 'Resync `%s` to the canonical aidevops caller template.\n\n' "$_workflow_path"
 	printf 'Classification before: %s\n' "$_status"
 	printf 'Ref: %s\n\n' "$_ref"
-	printf 'This migrates/refreshes the workflow to the reusable-workflow pattern\n'
-	printf 'introduced in aidevops v3.9.0. The caller now delegates all logic to\n'
-	printf '`marcusquinn/aidevops/.github/workflows/issue-sync-reusable.yml`,\n'
+	printf 'This migrates/refreshes the workflow to the reusable-workflow pattern.\n'
+	printf 'The caller now delegates all logic to the aidevops reusable workflow,\n'
 	printf 'eliminating drift between this repo and the framework canonical version.\n\n'
 	printf 'Generated by: aidevops sync-workflows --apply (t2779, GH#20649)\n'
 	return 0
 }
 
-# _format_pr_body <status> <ref>
+# _format_pr_body <status> <ref> <workflow_path>
 # shellcheck disable=SC2016  # backticks are intentional markdown literals
 _format_pr_body() {
 	local _status="$1"
 	local _ref="$2"
+	local _workflow_path="$3"
 	printf '## Summary\n\n'
-	printf 'Resync `%s` to the canonical aidevops caller template\n' "$WORKFLOW_PATH"
-	printf '(v3.9.0+, reusable-workflow pattern).\n\n'
+	printf 'Resync `%s` to the canonical aidevops caller template\n' "$_workflow_path"
+	printf '(reusable-workflow pattern, GH#20649 + GH#20727).\n\n'
 	printf '**Classification before**: `%s`\n' "$_status"
 	printf '**Ref**: `%s`\n\n' "$_ref"
 	printf '## Why\n\n'
-	printf 'The aidevops framework migrated `issue-sync.yml` from a full-copy workflow\n'
-	printf 'to a reusable-workflow pattern in v3.9.0. Downstream repos now carry a ~45-line\n'
-	printf 'caller that delegates to `marcusquinn/aidevops/.github/workflows/issue-sync-reusable.yml`.\n\n'
+	printf 'The aidevops framework ships managed GitHub Actions workflows as reusable\n'
+	printf 'workflows. Downstream repos carry ~45-line callers that delegate all logic\n'
+	printf 'to `marcusquinn/aidevops/.github/workflows/*-reusable.yml`.\n\n'
 	printf 'This PR brings this repo in line with the canonical template, eliminating\n'
 	printf 'drift and unblocking automatic updates when the framework evolves.\n\n'
 	printf '## How to verify\n\n'
-	printf 'After merge, the next `TODO.md` push should trigger issue-sync using the\n'
-	printf 'reusable workflow. Framework shell scripts are fetched at runtime via a\n'
-	printf 'secondary checkout — no `.agents/scripts/` files are needed in this repo.\n\n'
+	printf 'After merge, trigger an event matching the workflow triggers. Framework\n'
+	printf 'scripts are fetched at runtime via a secondary checkout — no\n'
+	printf '`.agents/scripts/` files are needed in this repo.\n\n'
 	printf '## Rollback\n\n'
-	printf 'If issue-sync breaks, revert this PR. The previous workflow is preserved in\n'
-	printf 'git history at the parent commit.\n\n'
+	printf 'If the workflow breaks, revert this PR. The previous workflow is preserved\n'
+	printf 'in git history at the parent commit.\n\n'
 	printf 'Generated by: `aidevops sync-workflows --apply` (t2779, GH#20649).\n'
 	return 0
 }
@@ -293,15 +314,16 @@ _resolve_effective_ref() {
 	return 0
 }
 
-# _sync_dryrun_emit <slug> <status> <effective_ref>
+# _sync_dryrun_emit <slug> <status> <effective_ref> [workflow_relpath]
 _sync_dryrun_emit() {
 	local _slug="$1"
 	local _status="$2"
 	local _effective_ref="$3"
+	local _workflow_relpath="${4:-.github/workflows/issue-sync.yml}"
 	local _action="install"
 	[[ "$_status" == "$_CLASS_DRIFTED" ]] && _action="refresh"
 	printf '%s\t%s\t%s\t%s → %s at ref %s\n' \
-		"$_slug" "$_status" "$_STATUS_PLANNED" "$_action" "$WORKFLOW_PATH" "$_effective_ref"
+		"$_slug" "$_status" "$_STATUS_PLANNED" "$_action" "$_workflow_relpath" "$_effective_ref"
 	return 0
 }
 
@@ -339,7 +361,7 @@ _sync_preflight() {
 	return 0
 }
 
-# _sync_write_commit_push <slug> <path> <status> <branch> <default_branch> <effective_ref> <content>
+# _sync_write_commit_push <slug> <path> <status> <branch> <default_branch> <effective_ref> <content> [workflow_relpath]
 _sync_write_commit_push() {
 	local _slug="$1"
 	local _path="$2"
@@ -348,7 +370,8 @@ _sync_write_commit_push() {
 	local _default_branch="$5"
 	local _effective_ref="$6"
 	local _target_content="$7"
-	local _workflow="$_path/$WORKFLOW_PATH"
+	local _workflow_relpath="${8:-.github/workflows/issue-sync.yml}"
+	local _workflow="$_path/$_workflow_relpath"
 
 	if ! git -C "$_path" pull --ff-only origin "$_default_branch" >/dev/null 2>&1; then
 		_warn "$_slug: pull --ff-only failed, attempting without"
@@ -359,10 +382,10 @@ _sync_write_commit_push() {
 	fi
 	mkdir -p "$_path/.github/workflows"
 	printf '%s\n' "$_target_content" >"$_workflow"
-	git -C "$_path" add "$WORKFLOW_PATH" >/dev/null 2>&1
+	git -C "$_path" add "$_workflow_relpath" >/dev/null 2>&1
 	local _commit_subject="chore: resync framework workflow ($_status → CURRENT/CALLER)"
 	local _commit_body
-	_commit_body=$(_format_commit_body "$_status" "$_effective_ref")
+	_commit_body=$(_format_commit_body "$_status" "$_effective_ref" "$_workflow_relpath")
 	if ! git -C "$_path" diff --cached --quiet; then
 		if ! git -C "$_path" commit -q -m "$_commit_subject" -m "$_commit_body"; then
 			printf '%s\t%s\t%s\tgit commit failed\n' "$_slug" "$_status" "$_STATUS_FAILED"
@@ -378,7 +401,7 @@ _sync_write_commit_push() {
 	return 0
 }
 
-# _sync_open_pr <slug> <path> <status> <branch> <default_branch> <effective_ref>
+# _sync_open_pr <slug> <path> <status> <branch> <default_branch> <effective_ref> [workflow_relpath]
 _sync_open_pr() {
 	local _slug="$1"
 	local _path="$2"
@@ -386,6 +409,7 @@ _sync_open_pr() {
 	local _branch_name="$4"
 	local _default_branch="$5"
 	local _effective_ref="$6"
+	local _workflow_relpath="${7:-.github/workflows/issue-sync.yml}"
 
 	if ! command -v gh_create_pr >/dev/null 2>&1; then
 		printf '%s\t%s\t%s\tgh_create_pr unavailable — source shared-gh-wrappers.sh\n' \
@@ -394,7 +418,7 @@ _sync_open_pr() {
 	fi
 	local _pr_title="chore: resync framework workflow to aidevops canonical caller"
 	local _pr_body
-	_pr_body=$(_format_pr_body "$_status" "$_effective_ref")
+	_pr_body=$(_format_pr_body "$_status" "$_effective_ref" "$_workflow_relpath")
 	local _pr_url
 	if ! _pr_url=$(gh_create_pr \
 		--repo "$_slug" \
@@ -410,8 +434,9 @@ _sync_open_pr() {
 	return 0
 }
 
-# _sync_one_repo <slug> <path> <status> <template_path> <target_ref> <force_ref> <branch_name> <apply>
+# _sync_one_repo <slug> <path> <status> <template_path> <target_ref> <force_ref> <branch_name> <apply> <workflow_relpath>
 # Emits a single-line summary; returns 0 on success, 1 on failure.
+# workflow_relpath — path relative to repo root e.g. .github/workflows/review-bot-gate.yml
 _sync_one_repo() {
 	local _slug="$1"
 	local _path="$2"
@@ -421,8 +446,9 @@ _sync_one_repo() {
 	local _force_ref="$6"
 	local _branch_name="$7"
 	local _apply="$8"
+	local _workflow_relpath="${9:-.github/workflows/issue-sync.yml}"
 
-	local _workflow="$_path/$WORKFLOW_PATH"
+	local _workflow="$_path/$_workflow_relpath"
 	local _effective_ref
 	_effective_ref=$(_resolve_effective_ref "$_status" "$_workflow" "$_target_ref" "$_force_ref")
 
@@ -455,13 +481,13 @@ _sync_one_repo() {
 
 	if ! _sync_write_commit_push \
 		"$_slug" "$_path" "$_status" "$_branch_name" \
-		"$_default_branch" "$_effective_ref" "$_target_content"; then
+		"$_default_branch" "$_effective_ref" "$_target_content" "$_workflow_relpath"; then
 		return 1
 	fi
 
 	_sync_open_pr \
 		"$_slug" "$_path" "$_status" "$_branch_name" \
-		"$_default_branch" "$_effective_ref"
+		"$_default_branch" "$_effective_ref" "$_workflow_relpath"
 	return $?
 }
 
@@ -473,6 +499,7 @@ _sync_one_repo() {
 _parse_args() {
 	_OPT_APPLY=0
 	_OPT_FILTER_SLUG=""
+	_OPT_FILTER_WORKFLOW=""
 	_OPT_FORCE_REF=0
 	_OPT_TARGET_REF="@main"
 	_OPT_BRANCH_NAME=""
@@ -482,6 +509,7 @@ _parse_args() {
 		case "$_opt" in
 		--apply) _OPT_APPLY=1; shift ;;
 		--repo) _OPT_FILTER_SLUG="${2:-}"; shift 2 || _die "--repo requires an argument" ;;
+		--workflow) _OPT_FILTER_WORKFLOW="${2:-}"; shift 2 || _die "--workflow requires an argument" ;;
 		--force-ref) _OPT_FORCE_REF=1; shift ;;
 		--ref)
 			_OPT_TARGET_REF="${2:-}"
@@ -523,23 +551,36 @@ _print_result_row() {
 	return 0
 }
 
-# _process_rows <tsv> <template> → iterates, calls _sync_one_repo, emits rows.
+# _process_rows <tsv> → iterates, resolves per-workflow template, calls _sync_one_repo.
+# TSV columns: slug\tpath\tstatus\tworkflow_name
 # Returns the number of failures (0 if all ok).
 _process_rows() {
 	local _tsv="$1"
-	local _template="$2"
 	local _any_failed=0
-	local _slug _path _status _ref_pin
-	while IFS=$'\t' read -r _slug _path _status _ref_pin; do
+	local _slug _path _status _workflow_name
+	while IFS=$'\t' read -r _slug _path _status _workflow_name; do
 		[[ -z "$_slug" ]] && continue
 		# Never touch aidevops itself (defence in depth; Phase 1 also emits
 		# CURRENT/SELF-CALLER).
 		[[ "$_slug" == "marcusquinn/aidevops" ]] && continue
 
+		# Resolve the template for this workflow.
+		# _workflow_name is the short name (e.g. "issue-sync" or "review-bot-gate").
+		# Map it to the template filename.
+		local _workflow_file="${_workflow_name}.yml"
+		local _template_file="${_workflow_name}-caller.yml"
+		local _workflow_relpath=".github/workflows/${_workflow_file}"
+		local _template=""
+		if ! _template=$(_resolve_canonical_template "$_template_file"); then
+			_warn "$_slug: cannot resolve template for workflow '${_workflow_name}' — skipping"
+			continue
+		fi
+
 		local _result
 		if _result=$(_sync_one_repo \
 			"$_slug" "$_path" "$_status" "$_template" \
-			"$_OPT_TARGET_REF" "$_OPT_FORCE_REF" "$_OPT_BRANCH_NAME" "$_OPT_APPLY"); then
+			"$_OPT_TARGET_REF" "$_OPT_FORCE_REF" "$_OPT_BRANCH_NAME" "$_OPT_APPLY" \
+			"$_workflow_relpath"); then
 			:
 		else
 			_any_failed=1
@@ -586,20 +627,16 @@ main() {
 	command -v jq >/dev/null 2>&1 || _die "jq required — install via Homebrew/apt"
 	[[ -x "$CHECK_HELPER" ]] || _die "check-workflows-helper.sh not found or not executable at $CHECK_HELPER"
 
-	local _template
-	if ! _template=$(_resolve_canonical_template); then
-		_die "canonical template issue-sync-caller.yml not found — check aidevops installation"
-	fi
 	if [[ -z "$_OPT_BRANCH_NAME" ]]; then
 		_OPT_BRANCH_NAME="chore/workflow-sync-$(date +%Y%m%d)"
 	fi
 
 	local _tsv
-	if ! _tsv=$(_list_actionable_repos "$_OPT_FILTER_SLUG"); then
+	if ! _tsv=$(_list_actionable_repos "$_OPT_FILTER_SLUG" "$_OPT_FILTER_WORKFLOW"); then
 		_die "check-workflows-helper.sh failed — cannot classify repos"
 	fi
 	if [[ -z "$_tsv" ]]; then
-		_info "no actionable repos (all CURRENT or NO-WORKFLOW)."
+		_info "no actionable repos/workflows (all CURRENT or NO-WORKFLOW)."
 		return 0
 	fi
 
@@ -609,7 +646,7 @@ main() {
 
 	_print_header_footer "header" "$_OPT_APPLY"
 	local _any_failed=0
-	_process_rows "$_tsv" "$_template" || _any_failed=1
+	_process_rows "$_tsv" || _any_failed=1
 	_print_header_footer "footer" "$_OPT_APPLY"
 
 	return "$_any_failed"

--- a/.agents/scripts/tests/test-reusable-workflow-caller.sh
+++ b/.agents/scripts/tests/test-reusable-workflow-caller.sh
@@ -3,9 +3,9 @@
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 # test-reusable-workflow-caller.sh — Structural tests for the reusable workflow pattern (t2770)
 #
-# Issue: GH#20662
+# Issues: GH#20662 (issue-sync), GH#20727 (review-bot-gate)
 #
-# Scenarios covered:
+# Scenarios covered (issue-sync — tests 1-8):
 #   1. .github/workflows/issue-sync-reusable.yml exists and is valid YAML
 #   2. Reusable workflow declares `on: workflow_call:` with expected inputs/secrets
 #   3. .github/workflows/issue-sync.yml is a thin caller (uses: ./.github/workflows/...)
@@ -15,6 +15,14 @@
 #   7. Every checkout of the caller repo is paired with a checkout of marcusquinn/aidevops
 #      into __aidevops/ (so helpers resolve via __aidevops/.agents/scripts/*)
 #   8. No residual bare .agents/scripts/ helper invocations in the reusable workflow
+#
+# Scenarios covered (review-bot-gate — tests 9-14, GH#20727):
+#   9.  .github/workflows/review-bot-gate-reusable.yml exists
+#  10.  Reusable workflow declares `on: workflow_call:` with aidevops_ref input
+#  11.  .github/workflows/review-bot-gate.yml is a thin self-caller
+#  12.  .agents/templates/workflows/review-bot-gate-caller.yml exists
+#  13.  Downstream caller template references marcusquinn/aidevops reusable path
+#  14.  Reusable workflow uses __aidevops/ path (runtime-fetched, no SHA pin)
 #
 # Strategy: Parse YAML + grep for structural invariants. No network calls, no GitHub API.
 # Skips gracefully if python3 / yaml module missing.
@@ -268,6 +276,138 @@ PYEOF
 	fi
 else
 	_skip "framework-checkout pairing" "yaml unavailable"
+fi
+
+# ---------------------------------------------------------------------------
+# review-bot-gate tests (GH#20727)
+# ---------------------------------------------------------------------------
+
+RBG_REUSABLE_WF="$REPO_ROOT/.github/workflows/review-bot-gate-reusable.yml"
+RBG_SELF_CALLER_WF="$REPO_ROOT/.github/workflows/review-bot-gate.yml"
+RBG_DOWNSTREAM_TEMPLATE="$REPO_ROOT/.agents/templates/workflows/review-bot-gate-caller.yml"
+
+# ---------------------------------------------------------------------------
+# Test 9: Reusable review-bot-gate workflow file exists
+# ---------------------------------------------------------------------------
+
+if [[ -f "$RBG_REUSABLE_WF" ]]; then
+	_pass "review-bot-gate reusable workflow file exists"
+else
+	_fail "review-bot-gate reusable workflow file exists" "missing: $RBG_REUSABLE_WF"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 10: Reusable review-bot-gate workflow declares workflow_call with aidevops_ref input
+# ---------------------------------------------------------------------------
+
+if ! command -v python3 >/dev/null 2>&1; then
+	_skip "review-bot-gate reusable workflow YAML parse" "python3 unavailable"
+elif ! python3 -c "import yaml" 2>/dev/null; then
+	_skip "review-bot-gate reusable workflow YAML parse" "pyyaml unavailable"
+else
+	if [[ ! -f "$RBG_REUSABLE_WF" ]]; then
+		_skip "review-bot-gate reusable workflow YAML parse" "file missing"
+	else
+		parse_result="$(python3 - "$RBG_REUSABLE_WF" <<'PYEOF' 2>&1
+import sys, yaml
+with open(sys.argv[1]) as f:
+    doc = yaml.safe_load(f)
+on = doc.get('on') or doc.get(True)
+if not isinstance(on, dict):
+    print("FAIL: `on:` is not a mapping"); sys.exit(1)
+if 'workflow_call' not in on:
+    print(f"FAIL: `on:` missing `workflow_call`. Keys: {list(on.keys())}"); sys.exit(1)
+wc = on['workflow_call'] or {}
+inputs = wc.get('inputs', {}) or {}
+if 'aidevops_ref' not in inputs:
+    print(f"FAIL: workflow_call.inputs missing `aidevops_ref`. Keys: {list(inputs.keys())}"); sys.exit(1)
+print("OK")
+PYEOF
+)"
+		if [[ "$parse_result" == "OK" ]]; then
+			_pass "review-bot-gate reusable workflow declares workflow_call with aidevops_ref input"
+		else
+			_fail "review-bot-gate reusable workflow declares workflow_call with aidevops_ref input" "$parse_result"
+		fi
+	fi
+fi
+
+# ---------------------------------------------------------------------------
+# Test 11: Self-caller (aidevops's own review-bot-gate.yml) uses local reusable
+# ---------------------------------------------------------------------------
+
+if [[ -f "$RBG_SELF_CALLER_WF" ]]; then
+	if grep -Eq "uses:\s*\./\.github/workflows/review-bot-gate-reusable\.yml" "$RBG_SELF_CALLER_WF"; then
+		_pass "review-bot-gate self-caller uses local reusable workflow"
+	else
+		_fail "review-bot-gate self-caller uses local reusable workflow" \
+			"expected 'uses: ./.github/workflows/review-bot-gate-reusable.yml' in $RBG_SELF_CALLER_WF"
+	fi
+else
+	_fail "review-bot-gate self-caller uses local reusable workflow" "missing: $RBG_SELF_CALLER_WF"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 12: Downstream caller template exists
+# ---------------------------------------------------------------------------
+
+if [[ -f "$RBG_DOWNSTREAM_TEMPLATE" ]]; then
+	_pass "review-bot-gate downstream caller template exists"
+else
+	_fail "review-bot-gate downstream caller template exists" "missing: $RBG_DOWNSTREAM_TEMPLATE"
+fi
+
+# ---------------------------------------------------------------------------
+# Test 13: Downstream caller references marcusquinn/aidevops reusable path and uses secrets: inherit
+# ---------------------------------------------------------------------------
+
+if [[ -f "$RBG_DOWNSTREAM_TEMPLATE" ]]; then
+	if grep -Eq "uses:\s*marcusquinn/aidevops/\.github/workflows/review-bot-gate-reusable\.yml@" \
+		"$RBG_DOWNSTREAM_TEMPLATE"; then
+		_pass "review-bot-gate downstream template references marcusquinn/aidevops reusable path"
+	else
+		_fail "review-bot-gate downstream template references marcusquinn/aidevops reusable path" \
+			"expected 'uses: marcusquinn/aidevops/.github/workflows/review-bot-gate-reusable.yml@<ref>' in $RBG_DOWNSTREAM_TEMPLATE"
+	fi
+
+	if grep -Eq "secrets:\s*inherit" "$RBG_DOWNSTREAM_TEMPLATE"; then
+		_pass "review-bot-gate downstream template uses 'secrets: inherit'"
+	else
+		_fail "review-bot-gate downstream template uses 'secrets: inherit'" \
+			"missing 'secrets: inherit' in $RBG_DOWNSTREAM_TEMPLATE"
+	fi
+fi
+
+# ---------------------------------------------------------------------------
+# Test 14: Reusable review-bot-gate workflow uses __aidevops/ (no SHA pin)
+# ---------------------------------------------------------------------------
+
+if [[ -f "$RBG_REUSABLE_WF" ]]; then
+	# The old pattern hard-pinned a SHA and used path: .aidevops-helper
+	# GH#20727 fix: runtime-fetched into __aidevops/ using inputs.aidevops_ref
+	if grep -qE "path:\s*__aidevops" "$RBG_REUSABLE_WF"; then
+		_pass "review-bot-gate reusable workflow fetches helper into __aidevops/"
+	else
+		_fail "review-bot-gate reusable workflow fetches helper into __aidevops/" \
+			"expected 'path: __aidevops' in the checkout step — GH#20727 pattern not applied"
+	fi
+
+	# Confirm no SHA pin on the aidevops checkout (ref uses inputs.aidevops_ref)
+	if grep -qE "ref:\s*\\\$\{\{[[:space:]]*inputs\.aidevops_ref" "$RBG_REUSABLE_WF"; then
+		_pass "review-bot-gate reusable workflow uses inputs.aidevops_ref (not a hard-coded SHA)"
+	else
+		_fail "review-bot-gate reusable workflow uses inputs.aidevops_ref" \
+			"expected 'ref: \${{ inputs.aidevops_ref ... }}' — SHA pin not eliminated"
+	fi
+
+	# Helper path must not reference .aidevops-helper/ in functional (non-comment) lines.
+	# Comments mentioning the old path for historical context are allowed.
+	if grep -v "^\s*#" "$RBG_REUSABLE_WF" | grep -q ".aidevops-helper"; then
+		_fail "review-bot-gate reusable workflow has no functional .aidevops-helper/ reference" \
+			"found stale .aidevops-helper/ path in non-comment line — GH#20727 migration incomplete"
+	else
+		_pass "review-bot-gate reusable workflow has no functional .aidevops-helper/ reference"
+	fi
 fi
 
 # ---------------------------------------------------------------------------

--- a/.agents/templates/workflows/review-bot-gate-caller.yml
+++ b/.agents/templates/workflows/review-bot-gate-caller.yml
@@ -1,0 +1,52 @@
+name: Review Bot Gate
+
+# Managed by aidevops framework.
+# Upstream logic lives in: marcusquinn/aidevops/.github/workflows/review-bot-gate-reusable.yml
+# This caller is tiny on purpose — all the logic is centralised upstream.
+# Update this caller only to change the trigger filters below. For logic fixes,
+# run `aidevops update` to get the latest framework version; your caller will
+# pick up the change automatically (if pinned to @main) or on the next version
+# bump + resync (if pinned to @v3.9.0 style).
+#
+# To manage this file:
+#   aidevops check-workflows       # detect drift vs canonical template
+#   aidevops sync-workflows        # preview resync plan
+#   aidevops sync-workflows --apply
+#
+# To enforce: add "review-bot-gate" as a required status check in
+# GitHub branch protection settings for each repo.
+#
+# Rate-limit behaviour: controlled by `review_gate.rate_limit_behavior` in
+# ~/.config/aidevops/repos.json. Default: "pass" (merge proceeds when bots
+# are rate-limited). Set "wait" to block merge until bots come off rate-limit.
+# See: .agents/reference/repos-json-fields.md "review_gate" field.
+#
+# Pinning options:
+#   @main           ← auto-update; what this template uses by default
+#   @v3.9.0         ← pin to a specific aidevops version for stability
+#                     (bump via aidevops sync-workflows after upgrades)
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  pull_request_review:
+    types: [submitted]
+  issue_comment:
+    # edited re-triggers when CodeRabbit finalises its Phase 1 placeholder (t2139).
+    # Without this trigger, the settlement check only fires on new comments, not
+    # on the Phase 2 edit that makes the placeholder a real review.
+    types: [created, edited]
+
+# Do NOT cancel in-progress runs. When cancel-in-progress was true, the initial
+# pull_request:opened run was cancelled by the issue_comment:created event (fired
+# when a bot posted). The cancelled run left a permanent stale CANCELLED check on
+# the PR, making mergeStateStatus UNSTABLE even though the re-triggered run passed.
+# With cancel-in-progress: false, both runs complete. GH#2973.
+concurrency:
+  group: review-bot-gate-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  gate:
+    uses: marcusquinn/aidevops/.github/workflows/review-bot-gate-reusable.yml@main
+    secrets: inherit

--- a/.github/workflows/review-bot-gate-reusable.yml
+++ b/.github/workflows/review-bot-gate-reusable.yml
@@ -1,0 +1,217 @@
+name: Review Bot Gate (reusable)
+
+# Reusable workflow — call via a thin caller YAML in each repo.
+# See: .agents/templates/workflows/review-bot-gate-caller.yml
+# See: .agents/reference/reusable-workflows.md
+#
+# The caller declares the triggers (pull_request / pull_request_review / issue_comment)
+# and the concurrency group. All gate logic lives here; the framework helper
+# is fetched at runtime from marcusquinn/aidevops via inputs.aidevops_ref.
+#
+# GH#20727: migrated from vendored full-copy (SHA-pinned checkout) to
+# reusable-workflow pattern. Helper is now fetched from marcusquinn/aidevops
+# at run-time, eliminating the stale-pin drift class — the root cause of the
+# downstream regression observed on 2026-04-24 (Option A' settlement fix from
+# PR #20572 never reached downstream repos pinned to SHA 73b664a).
+#
+# To enforce: add "review-bot-gate" as a required status check in
+# GitHub branch protection settings for each repo.
+#
+# Rate-limit behaviour: controlled by `review_gate.rate_limit_behavior` in
+# ~/.config/aidevops/repos.json. Default: "pass". See:
+# .agents/reference/repos-json-fields.md "review_gate" field.
+#
+# t1382: https://github.com/marcusquinn/aidevops/issues/2735
+# GH#20493: Migrate from inline gate logic to helper (t2139 settlement fix)
+# GH#20727: Migrate from SHA-pinned checkout to reusable-workflow pattern
+
+on:
+  workflow_call:
+    inputs:
+      aidevops_ref:
+        description: 'aidevops ref to fetch framework scripts from (main, or a version tag like v3.9.0)'
+        required: false
+        type: string
+        default: 'main'
+
+jobs:
+  review-bot-gate:
+    runs-on: ubuntu-latest
+    # Only run on PRs (issue_comment fires for PR comments too).
+    # GH#4002: Skip pull_request_review events from known review bots.
+    # GitHub requires manual approval for workflow runs triggered by bot
+    # accounts on pull_request_review and pull_request_review_comment events,
+    # causing permanent action_required status on PRs. The issue_comment
+    # event from bots does NOT require approval, so we allow it — this is
+    # the primary re-trigger path when a bot posts its review as a comment.
+    if: >
+      (
+        github.event_name == 'pull_request' ||
+        github.event_name == 'pull_request_review' ||
+        (github.event_name == 'issue_comment' && github.event.issue.pull_request)
+      ) && !(
+        github.event_name == 'pull_request_review' && (
+          github.actor == 'coderabbitai' ||
+          github.actor == 'gemini-code-assist[bot]' ||
+          github.actor == 'augment-code[bot]' ||
+          github.actor == 'augmentcode[bot]' ||
+          github.actor == 'copilot[bot]' ||
+          github.actor == 'github-actions[bot]' ||
+          github.actor == 'dependabot[bot]'
+        )
+      )
+
+    permissions:
+      pull-requests: read
+      contents: read
+      statuses: read
+
+    steps:
+      - name: Checkout aidevops framework scripts
+        # Fetch review-bot-gate-helper.sh from marcusquinn/aidevops at runtime.
+        # GH#20727: replaces the SHA-pinned checkout (path: .aidevops-helper) that
+        # silently drifted after helper changes (e.g. the Option A' settlement fix
+        # in PR #20572 never propagated to downstream repos pinned to 73b664a).
+        # The ref is controlled by the caller via inputs.aidevops_ref (default: main).
+        # Pin to @v3.x.y for stability; see .agents/reference/reusable-workflows.md.
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: marcusquinn/aidevops
+          ref: ${{ inputs.aidevops_ref || 'main' }}
+          path: __aidevops
+          fetch-depth: 1
+
+      - name: Check for AI review bot activity
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          echo "Checking PR #${PR_NUMBER} for AI review bot activity..."
+
+          # Check if this is an external contributor PR.
+          # GH#17671: external-contributor PRs require real bot reviews;
+          # rate-limit grace is disabled — they cannot merge on rate-limit-only.
+          IS_EXTERNAL_PR=false
+          PR_LABELS=$(gh pr view "${PR_NUMBER}" --repo "${REPO}" \
+            --json labels --jq '.labels[].name' 2>/dev/null || true)
+          if echo "${PR_LABELS}" | grep -q 'external-contributor'; then
+            IS_EXTERNAL_PR=true
+            echo "External contributor PR detected — rate-limit grace DISABLED"
+            # Override to 'wait': prevents the default PASS_RATE_LIMITED shortcut.
+            export REVIEW_GATE_RATE_LIMIT_BEHAVIOR=wait
+          fi
+          echo "is_external_pr=${IS_EXTERNAL_PR}" >> "${GITHUB_OUTPUT}"
+
+          # Invoke the framework helper (runtime-fetched via __aidevops/).
+          # All gate logic lives in the helper:
+          #   - t2139 settlement check (defeats CodeRabbit two-phase placeholder)
+          #   - KNOWN_BOTS and NON_REVIEW_PATTERNS (including "Review failed/skipped")
+          #   - any_bot_has_success_status (status check fallback, GH#3005)
+          #   - rate-limit behaviour (configurable via repos.json or env var)
+          # Output values: PASS / PASS_RATE_LIMITED / WAITING / SKIP
+          # Exit codes:    0 = PASS/PASS_RATE_LIMITED/SKIP  1 = WAITING  2 = error
+          HELPER="${GITHUB_WORKSPACE}/__aidevops/.agents/scripts/review-bot-gate-helper.sh"
+          RESULT=""
+          HELPER_EXIT=0
+          RESULT=$(bash "${HELPER}" check "${PR_NUMBER}" "${REPO}") || HELPER_EXIT=$?
+
+          echo ""
+          echo "Helper result: ${RESULT:-<empty>} (exit: ${HELPER_EXIT})"
+
+          # GH#17671 post-mortem: external-contributor PRs cannot use the
+          # skip-review-gate label. The helper honours SKIP without knowing
+          # about external-contributor — override here at the workflow layer.
+          if [[ "${RESULT}" == "SKIP" && "${IS_EXTERNAL_PR}" == "true" ]]; then
+            echo "SKIP overridden: external-contributor PRs cannot use skip-review-gate."
+            RESULT="WAITING"
+            HELPER_EXIT=1
+          fi
+
+          if [[ "${HELPER_EXIT}" -eq 0 ]]; then
+            echo "gate_passed=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "gate_passed=false" >> "${GITHUB_OUTPUT}"
+          fi
+          echo "result=${RESULT}" >> "${GITHUB_OUTPUT}"
+
+      - name: Check for skip label
+        id: skip
+        if: steps.check.outputs.gate_passed != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          REPO: ${{ github.repository }}
+          IS_EXTERNAL_PR: ${{ steps.check.outputs.is_external_pr }}
+        run: |
+          LABELS=$(gh pr view "${PR_NUMBER}" --repo "${REPO}" \
+            --json labels -q '.labels[].name' 2>/dev/null || echo "")
+
+          # GH#17671 post-mortem: external-contributor PRs cannot skip the
+          # review gate. The skip label is only for internal PRs where bots
+          # are genuinely not configured.
+          if [[ "${IS_EXTERNAL_PR}" == "true" ]]; then
+            echo "skip=false" >> "${GITHUB_OUTPUT}"
+            echo "DENY: external-contributor PR cannot use skip-review-gate label."
+          elif echo "${LABELS}" | grep -q "skip-review-gate"; then
+            echo "skip=true" >> "${GITHUB_OUTPUT}"
+            echo "SKIP: 'skip-review-gate' label found — bypassing review bot gate."
+          else
+            echo "skip=false" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Gate result
+        if: steps.check.outputs.gate_passed != 'true' && steps.skip.outputs.skip != 'true'
+        env:
+          RESULT: ${{ steps.check.outputs.result }}
+        run: |
+          if [[ "${RESULT}" == "WAITING" || -z "${RESULT}" ]]; then
+            echo "::error::No AI review bots have posted a real, settled review on this PR yet."
+          else
+            echo "::error::Review bot gate blocked (helper result: ${RESULT})."
+          fi
+          echo ""
+          echo "This PR cannot be merged until at least one AI code review bot"
+          echo "(CodeRabbit, Gemini Code Assist, etc.) has posted a real review."
+          echo ""
+          echo "What to do:"
+          echo "  1. Wait a few minutes for bots to complete their analysis"
+          echo "  2. This check re-runs automatically when a bot posts or edits a comment"
+          echo "  3. If no bots are configured, add 'skip-review-gate' label"
+          exit 1
+
+      - name: Summary
+        if: always()
+        env:
+          GATE_PASSED: ${{ steps.check.outputs.gate_passed }}
+          RESULT: ${{ steps.check.outputs.result }}
+          SKIP_GATE: ${{ steps.skip.outputs.skip }}
+        run: |
+          {
+            echo "## Review Bot Gate"
+            echo ""
+            if [[ "${GATE_PASSED}" == "true" && "${RESULT}" == "PASS_RATE_LIMITED" ]]; then
+              echo "**Status**: PASSED (rate-limit grace)"
+              echo ""
+              echo "Bots are rate-limited (tried but capacity-constrained). Passing"
+              echo "gate — configured to pass on rate limit (rate_limit_behavior=pass)."
+              echo ""
+              echo "Bot reviews will be addressed post-merge if needed."
+            elif [[ "${GATE_PASSED}" == "true" && "${RESULT}" == "SKIP" ]]; then
+              echo "**Status**: SKIPPED (skip-review-gate label)"
+            elif [[ "${GATE_PASSED}" == "true" ]]; then
+              echo "**Status**: PASSED"
+              echo ""
+              echo "At least one AI review bot has posted a real, settled review."
+            elif [[ "${SKIP_GATE}" == "true" ]]; then
+              echo "**Status**: SKIPPED (skip-review-gate label)"
+            else
+              echo "**Status**: WAITING"
+              echo ""
+              echo "No real AI review bot feedback yet. This check will re-run"
+              echo "automatically when a bot posts or edits a review or comment."
+              echo ""
+              echo "If no bots are configured, add 'skip-review-gate' label to bypass."
+            fi
+          } >> "${GITHUB_STEP_SUMMARY}"

--- a/.github/workflows/review-bot-gate.yml
+++ b/.github/workflows/review-bot-gate.yml
@@ -1,23 +1,22 @@
 name: Review Bot Gate
 
-# Blocks merge until AI code review bots have posted a real, settled review.
-# All gate logic delegates to the vendored review-bot-gate-helper.sh, which
-# includes the t2139 settlement check that defeats CodeRabbit's two-phase
-# placeholder-then-edit posting pattern.
+# Self-caller for the aidevops repo.
+# Upstream logic: .github/workflows/review-bot-gate-reusable.yml
+# Downstream template: .agents/templates/workflows/review-bot-gate-caller.yml
+# See: .agents/reference/reusable-workflows.md
+#
+# GH#20727: migrated to reusable-workflow pattern. The helper script is now
+# fetched at runtime from marcusquinn/aidevops@main rather than being pinned
+# to a hard-coded SHA that silently drifts after helper changes.
 #
 # To enforce: add "review-bot-gate" as a required status check in
 # GitHub branch protection settings for each repo.
 #
-# Rate-limit behaviour is controlled by `review_gate.rate_limit_behavior` in
-# ~/.config/aidevops/repos.json. Default: "pass" (merge proceeds when bots
-# are rate-limited — rely on daily code audit for coverage). Users who want
-# to block merge until bots come off rate-limit can set:
-#   "review_gate": { "rate_limit_behavior": "wait" }
-# Per-tool overrides are also supported. See:
+# Rate-limit behaviour: controlled by `review_gate.rate_limit_behavior` in
+# ~/.config/aidevops/repos.json. Default: "pass". See:
 # .agents/reference/repos-json-fields.md "review_gate" field.
 #
 # t1382: https://github.com/marcusquinn/aidevops/issues/2735
-# GH#20493: Migrate from inline gate logic to helper (t2139 settlement fix)
 
 on:
   pull_request:
@@ -41,178 +40,6 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  review-bot-gate:
-    runs-on: ubuntu-latest
-    # Only run on PRs (issue_comment fires for PR comments too).
-    # GH#4002: Skip pull_request_review events from known review bots.
-    # GitHub requires manual approval for workflow runs triggered by bot
-    # accounts on pull_request_review and pull_request_review_comment events,
-    # causing permanent action_required status on PRs. The issue_comment
-    # event from bots does NOT require approval, so we allow it — this is
-    # the primary re-trigger path when a bot posts its review as a comment.
-    if: >
-      (
-        github.event_name == 'pull_request' ||
-        github.event_name == 'pull_request_review' ||
-        (github.event_name == 'issue_comment' && github.event.issue.pull_request)
-      ) && !(
-        github.event_name == 'pull_request_review' && (
-          github.actor == 'coderabbitai' ||
-          github.actor == 'gemini-code-assist[bot]' ||
-          github.actor == 'augment-code[bot]' ||
-          github.actor == 'augmentcode[bot]' ||
-          github.actor == 'copilot[bot]' ||
-          github.actor == 'github-actions[bot]' ||
-          github.actor == 'dependabot[bot]'
-        )
-      )
-
-    permissions:
-      pull-requests: read
-      contents: read
-      statuses: read
-
-    steps:
-      - name: Checkout aidevops helper
-        # Vendor the helper from the framework repo so GitHub-hosted runners
-        # (which don't have ~/.aidevops/) can call review-bot-gate-helper.sh.
-        # Pinned to a SHA that includes the t2139 settlement fix (PR #19309).
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          repository: marcusquinn/aidevops
-          ref: 73b664a8d7417e0da4a076eb80ef72609188399e
-          path: .aidevops-helper
-
-      - name: Check for AI review bot activity
-        id: check
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
-          REPO: ${{ github.repository }}
-        run: |
-          echo "Checking PR #${PR_NUMBER} for AI review bot activity..."
-
-          # Check if this is an external contributor PR.
-          # GH#17671: external-contributor PRs require real bot reviews;
-          # rate-limit grace is disabled — they cannot merge on rate-limit-only.
-          IS_EXTERNAL_PR=false
-          PR_LABELS=$(gh pr view "${PR_NUMBER}" --repo "${REPO}" \
-            --json labels --jq '.labels[].name' 2>/dev/null || true)
-          if echo "${PR_LABELS}" | grep -q 'external-contributor'; then
-            IS_EXTERNAL_PR=true
-            echo "External contributor PR detected — rate-limit grace DISABLED"
-            # Override to 'wait': prevents the default PASS_RATE_LIMITED shortcut.
-            export REVIEW_GATE_RATE_LIMIT_BEHAVIOR=wait
-          fi
-          echo "is_external_pr=${IS_EXTERNAL_PR}" >> "${GITHUB_OUTPUT}"
-
-          # Invoke the vendored helper. All gate logic lives in the helper:
-          #   - t2139 settlement check (defeats CodeRabbit two-phase placeholder)
-          #   - KNOWN_BOTS and NON_REVIEW_PATTERNS (including "Review failed/skipped")
-          #   - any_bot_has_success_status (status check fallback, GH#3005)
-          #   - rate-limit behaviour (configurable via repos.json or env var)
-          # Output values: PASS / PASS_RATE_LIMITED / WAITING / SKIP
-          # Exit codes:    0 = PASS/PASS_RATE_LIMITED/SKIP  1 = WAITING  2 = error
-          HELPER="${GITHUB_WORKSPACE}/.aidevops-helper/.agents/scripts/review-bot-gate-helper.sh"
-          RESULT=""
-          HELPER_EXIT=0
-          RESULT=$(bash "${HELPER}" check "${PR_NUMBER}" "${REPO}") || HELPER_EXIT=$?
-
-          echo ""
-          echo "Helper result: ${RESULT:-<empty>} (exit: ${HELPER_EXIT})"
-
-          # GH#17671 post-mortem: external-contributor PRs cannot use the
-          # skip-review-gate label. The helper honours SKIP without knowing
-          # about external-contributor — override here at the workflow layer.
-          if [[ "${RESULT}" == "SKIP" && "${IS_EXTERNAL_PR}" == "true" ]]; then
-            echo "SKIP overridden: external-contributor PRs cannot use skip-review-gate."
-            RESULT="WAITING"
-            HELPER_EXIT=1
-          fi
-
-          if [[ "${HELPER_EXIT}" -eq 0 ]]; then
-            echo "gate_passed=true" >> "${GITHUB_OUTPUT}"
-          else
-            echo "gate_passed=false" >> "${GITHUB_OUTPUT}"
-          fi
-          echo "result=${RESULT}" >> "${GITHUB_OUTPUT}"
-
-      - name: Check for skip label
-        id: skip
-        if: steps.check.outputs.gate_passed != 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
-          REPO: ${{ github.repository }}
-          IS_EXTERNAL_PR: ${{ steps.check.outputs.is_external_pr }}
-        run: |
-          LABELS=$(gh pr view "${PR_NUMBER}" --repo "${REPO}" \
-            --json labels -q '.labels[].name' 2>/dev/null || echo "")
-
-          # GH#17671 post-mortem: external-contributor PRs cannot skip the
-          # review gate. The skip label is only for internal PRs where bots
-          # are genuinely not configured.
-          if [[ "${IS_EXTERNAL_PR}" == "true" ]]; then
-            echo "skip=false" >> "${GITHUB_OUTPUT}"
-            echo "DENY: external-contributor PR cannot use skip-review-gate label."
-          elif echo "${LABELS}" | grep -q "skip-review-gate"; then
-            echo "skip=true" >> "${GITHUB_OUTPUT}"
-            echo "SKIP: 'skip-review-gate' label found — bypassing review bot gate."
-          else
-            echo "skip=false" >> "${GITHUB_OUTPUT}"
-          fi
-
-      - name: Gate result
-        if: steps.check.outputs.gate_passed != 'true' && steps.skip.outputs.skip != 'true'
-        env:
-          RESULT: ${{ steps.check.outputs.result }}
-        run: |
-          if [[ "${RESULT}" == "WAITING" || -z "${RESULT}" ]]; then
-            echo "::error::No AI review bots have posted a real, settled review on this PR yet."
-          else
-            echo "::error::Review bot gate blocked (helper result: ${RESULT})."
-          fi
-          echo ""
-          echo "This PR cannot be merged until at least one AI code review bot"
-          echo "(CodeRabbit, Gemini Code Assist, etc.) has posted a real review."
-          echo ""
-          echo "What to do:"
-          echo "  1. Wait a few minutes for bots to complete their analysis"
-          echo "  2. This check re-runs automatically when a bot posts or edits a comment"
-          echo "  3. If no bots are configured, add 'skip-review-gate' label"
-          exit 1
-
-      - name: Summary
-        if: always()
-        env:
-          GATE_PASSED: ${{ steps.check.outputs.gate_passed }}
-          RESULT: ${{ steps.check.outputs.result }}
-          SKIP_GATE: ${{ steps.skip.outputs.skip }}
-        run: |
-          {
-            echo "## Review Bot Gate"
-            echo ""
-            if [[ "${GATE_PASSED}" == "true" && "${RESULT}" == "PASS_RATE_LIMITED" ]]; then
-              echo "**Status**: PASSED (rate-limit grace)"
-              echo ""
-              echo "Bots are rate-limited (tried but capacity-constrained). Passing"
-              echo "gate — configured to pass on rate limit (rate_limit_behavior=pass)."
-              echo ""
-              echo "Bot reviews will be addressed post-merge if needed."
-            elif [[ "${GATE_PASSED}" == "true" && "${RESULT}" == "SKIP" ]]; then
-              echo "**Status**: SKIPPED (skip-review-gate label)"
-            elif [[ "${GATE_PASSED}" == "true" ]]; then
-              echo "**Status**: PASSED"
-              echo ""
-              echo "At least one AI review bot has posted a real, settled review."
-            elif [[ "${SKIP_GATE}" == "true" ]]; then
-              echo "**Status**: SKIPPED (skip-review-gate label)"
-            else
-              echo "**Status**: WAITING"
-              echo ""
-              echo "No real AI review bot feedback yet. This check will re-run"
-              echo "automatically when a bot posts or edits a review or comment."
-              echo ""
-              echo "If no bots are configured, add 'skip-review-gate' label to bypass."
-            fi
-          } >> "${GITHUB_STEP_SUMMARY}"
+  gate:
+    uses: ./.github/workflows/review-bot-gate-reusable.yml
+    secrets: inherit


### PR DESCRIPTION
## Summary

Migrates `review-bot-gate.yml` from a vendored SHA-pinned workflow to the reusable-workflow pattern (t2770), eliminating the drift class that caused downstream regressions.

- **Root cause**: `review-bot-gate.yml` vendored a hard-coded SHA (`73b664a`) that never auto-updated. The Option A' settlement fix (PR #20572) was invisible to every downstream repo pinned to that SHA.
- **Observed impact**: 4 of 10 `qs-agency` PRs on 2026-04-24 had stale CodeRabbit "Review failed — closed during review" markers because the pre-fix helper still classified Phase 1 placeholders as rate-limited passes.
- **Fix**: migrated to the same reusable-workflow pattern as `issue-sync.yml`. Helper now fetched from `marcusquinn/aidevops@main` at runtime.

## Changes

| File | Change |
|---|---|
| `.github/workflows/review-bot-gate-reusable.yml` | **NEW** — `on: workflow_call:` with `aidevops_ref` input; fetches helper via `__aidevops/` at runtime |
| `.github/workflows/review-bot-gate.yml` | **REWRITTEN** — thin self-caller (`uses: ./.github/workflows/review-bot-gate-reusable.yml`); preserves `concurrency.cancel-in-progress: false` (GH#2973) |
| `.agents/templates/workflows/review-bot-gate-caller.yml` | **NEW** — canonical downstream template with `@main` ref |
| `.agents/scripts/check-workflows-helper.sh` | Extended: `KNOWN_WORKFLOWS` array; classifies both `issue-sync` and `review-bot-gate` per repo. New `--workflow` flag. Extracted `_normalize_wf_for_compare` helper. |
| `.agents/scripts/sync-workflows-helper.sh` | Extended: per-workflow template resolution from TSV `workflow` column. New `--workflow` flag. |
| `.agents/scripts/tests/test-reusable-workflow-caller.sh` | 6 new structural tests (9-14) for review-bot-gate. All 19 tests pass. |
| `.agents/reference/reusable-workflows.md` | Migrated-workflows table + architecture diagram updated. |

## Verification

```
bash .agents/scripts/tests/test-reusable-workflow-caller.sh
# All 19 test(s) passed
```

actionlint validated both new/modified workflows. All shellcheck, string-literal ratchet, and return-statement checks pass.

## Migration path for downstream repos

After merge, run:

```bash
aidevops check-workflows   # detects NEEDS-MIGRATION for review-bot-gate.yml
aidevops sync-workflows --apply  # installs canonical caller template
```

The reporter's manual fix (qs-agency PR #1872 bumping the SHA to f145379) will be superseded automatically — the `@main` caller picks up any future helper changes without manual intervention.

Resolves #20727

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.2 plugin for [OpenCode](https://opencode.ai) v1.14.24 with claude-sonnet-4-6 spent 17m and 59,278 tokens on this as a headless worker.
