### PR TITLE
t2807: align design-md agent with google-labs DESIGN.md spec v0.1.0

### DIFF
--- a/.agents/configs/upstream-watch.json
+++ b/.agents/configs/upstream-watch.json
@@ -42,6 +42,13 @@
       "relevance": "Optional MCP server alternative to asc CLI. New MCP tools may extend our ios-simulator-mcp and xcodebuild-mcp coverage. Documented as optional in tools/mobile/app-store-connect.md.",
       "default_branch": "master",
       "added_at": "2026-03-21"
+    },
+    {
+      "slug": "google-labs-code/design.md",
+      "description": "A format specification for describing a visual identity to coding agents. DESIGN.md gives agents a persistent, structured understanding of a design system.",
+      "relevance": "DESIGN.md format spec at version alpha — aidevops design-md agent (.agents/tools/design/design-md.md) and template (.agents/templates/DESIGN.md.template) adopted v0.1.0 in t2807/PR #20749. New releases may change YAML schema, rename sections, add/remove linter rules, or alter component property set. CLI is @google/design.md on npm. Watch for v1 release (signals format stabilisation) and breaking schema changes.",
+      "default_branch": "main",
+      "added_at": "2026-04-24T17:24:54Z"
     }
   ],
   "non_github_upstreams": [
@@ -52,7 +59,10 @@
       "description": "Cloudron base Docker image (Ubuntu 24.04 + Node/Python/PHP/nginx/gosu)",
       "relevance": "Base image for all Cloudron app packages. Version bumps change the verified inventory table in cloudron-app-packaging.md (Node.js, PHP, Python versions, available tools). Current: 5.0.0 on Cloudron 9.1.3.",
       "check_command": "curl -s 'https://hub.docker.com/v2/repositories/cloudron/base/tags/?page_size=5&ordering=last_updated' | jq -r '(.results[0].name // \"\")'",
-      "affects": [".agents/tools/deployment/cloudron-app-packaging.md", ".agents/tools/deployment/cloudron-app-packaging-skill.md"],
+      "affects": [
+        ".agents/tools/deployment/cloudron-app-packaging.md",
+        ".agents/tools/deployment/cloudron-app-packaging-skill.md"
+      ],
       "added_at": "2026-03-19"
     },
     {
@@ -62,7 +72,11 @@
       "description": "Official Cloudron packaging/publishing/server-ops skills from git.cloudron.io",
       "relevance": "Source for our 3 imported Cloudron skills. New commits may add addons, manifest fields, CLI commands, or build methods. Last imported: commit b247b124 (2026-03-01).",
       "check_command": "curl -s 'https://git.cloudron.io/api/v4/projects/docs%2Fskills/repository/commits?per_page=1' | jq -r '(.[0].id // \"\")'",
-      "affects": [".agents/tools/deployment/cloudron-app-packaging-skill.md", ".agents/tools/deployment/cloudron-app-publishing-skill.md", ".agents/tools/deployment/cloudron-server-ops-skill.md"],
+      "affects": [
+        ".agents/tools/deployment/cloudron-app-packaging-skill.md",
+        ".agents/tools/deployment/cloudron-app-publishing-skill.md",
+        ".agents/tools/deployment/cloudron-server-ops-skill.md"
+      ],
       "last_seen_commit": "b247b124d168730051186aa63afad87c0c1f5a52",
       "added_at": "2026-03-19"
     },
@@ -73,7 +87,9 @@
       "description": "Community Cloudron packaging assessment toolkit by LoudLemur/OrcVole",
       "relevance": "Source of the two-axis scoring rubric, verified base image inventory, and assessment patterns we adopted. New commits may add assessed apps, refine scoring, or update base image findings.",
       "check_command": "curl -s 'https://forgejo.wanderingmonster.dev/api/v1/repos/WanderingMonster/cloudron-packaging/commits?limit=1' | jq -r '(.[0].sha // \"\")'",
-      "affects": [".agents/tools/deployment/cloudron-app-packaging.md"],
+      "affects": [
+        ".agents/tools/deployment/cloudron-app-packaging.md"
+      ],
       "last_seen_commit": "047e4b07ce362f484a0c5a9854b14a1a5ecf1b48",
       "added_at": "2026-03-19"
     }

--- a/.agents/templates/DESIGN.md.template
+++ b/.agents/templates/DESIGN.md.template
@@ -1,153 +1,286 @@
+---
+version: alpha
+name: {Project Name}
+description: {one-line description of the design system}
+colors:
+  # Canonical palette (required: primary; recommended: secondary, tertiary, neutral, surface, on-surface, error)
+  primary: "#{hex}"
+  secondary: "#{hex}"
+  tertiary: "#{hex}"
+  neutral: "#{hex}"
+  surface: "#{hex}"
+  on-surface: "#{hex}"
+  error: "#{hex}"
+typography:
+  # Recommended levels: headline-display, headline-lg, headline-md, body-lg, body-md, body-sm, label-lg, label-md, label-sm
+  headline-display:
+    fontFamily: {family}
+    fontSize: {size}
+    fontWeight: 700
+    lineHeight: 1.1
+    letterSpacing: -0.02em
+  headline-lg:
+    fontFamily: {family}
+    fontSize: 32px
+    fontWeight: 600
+    lineHeight: 1.2
+  body-md:
+    fontFamily: {family}
+    fontSize: 16px
+    fontWeight: 400
+    lineHeight: 1.5
+  label-md:
+    fontFamily: {family}
+    fontSize: 14px
+    fontWeight: 500
+    lineHeight: 1.4
+rounded:
+  none: 0
+  sm: 4px
+  md: 8px
+  lg: 16px
+  xl: 24px
+  full: 9999px
+spacing:
+  unit: 8px
+  xs: 4px
+  sm: 8px
+  md: 16px
+  lg: 32px
+  xl: 64px
+  gutter: 24px
+  margin: 32px
+components:
+  button-primary:
+    backgroundColor: "{colors.primary}"
+    textColor: "{colors.surface}"
+    typography: "{typography.label-md}"
+    rounded: "{rounded.md}"
+    padding: 12px 24px
+  button-primary-hover:
+    backgroundColor: "{colors.secondary}"
+  button-secondary:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.primary}"
+    typography: "{typography.label-md}"
+    rounded: "{rounded.md}"
+    padding: 12px 24px
+  input-default:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.on-surface}"
+    typography: "{typography.body-md}"
+    rounded: "{rounded.sm}"
+    padding: 12px 16px
+  card:
+    backgroundColor: "{colors.surface}"
+    textColor: "{colors.on-surface}"
+    rounded: "{rounded.lg}"
+    padding: 24px
+---
+
+<!--
+DESIGN.md — AI-readable design system document
+Format: google-labs-code/design.md v0.1.0 (format version: alpha)
+Spec: https://github.com/google-labs-code/design.md/blob/main/docs/spec.md
+Validate: npx @google/design.md lint DESIGN.md
+Template source: aidevops `templates/DESIGN.md.template`
+
+Sections 1-8 are the normative spec order.
+Sections 9-10 are aidevops-specific extensions (unknown sections are preserved per spec).
+-->
+
 # Design System: {Project Name}
 
-## 1. Visual Theme & Atmosphere
+## 1. Overview
 
-<!-- Describe the overall mood, aesthetic direction, and what makes this design distinctive. -->
-<!-- Include key characteristics as a bullet list with exact values. -->
-<!-- Reference: tools/design/library/ for brand examples and style archetypes. -->
+<!-- Also known as "Brand & Style" or "Visual Theme". -->
+<!-- Holistic description of the product's look and feel. Define brand personality, target audience, -->
+<!-- and the emotional response the UI should evoke. This is foundational context for high-level -->
+<!-- stylistic decisions when a specific rule or token isn't explicitly defined. -->
+
+**Mood**: {playful | professional | editorial | luxurious | technical | …}
+**Density**: {spacious | balanced | dense}
+**Atmosphere**: {one sentence capturing the feel}
 
 **Key Characteristics:**
-- {characteristic with value}
 
-## 2. Colour Palette & Roles
+- {characteristic with concrete reference}
+- {characteristic with concrete reference}
 
-<!-- Every colour needs: semantic name, hex value, and functional role. -->
-<!-- Use tools/design/colour-palette.md to generate and spin palettes. -->
+## 2. Colors
 
-### Primary Brand
-- **Primary** (`#{hex}`): {usage}
-- **Secondary** (`#{hex}`): {usage}
+<!-- Define the color palettes. The `primary` palette is required; others are conventionally named -->
+<!-- `secondary`, `tertiary`, `neutral`. Prose may use descriptive color names (e.g. "Boston Clay") -->
+<!-- that correspond to token names (e.g. `tertiary`). Tokens are normative; prose provides context. -->
 
-### Accent Colours
-- **Accent** (`#{hex}`): {usage}
+The palette is rooted in {describe: high-contrast neutrals, warm earth tones, cool modernist, etc.} with {one | two | …} accent colour(s) driving interaction.
 
-### Text Colours
-- **Text Primary** (`#{hex}`): {usage}
-- **Text Secondary** (`#{hex}`): {usage}
+- **Primary (`#{hex}`)**: {role and usage — e.g. headlines, core text, primary actions}
+- **Secondary (`#{hex}`)**: {role — e.g. borders, captions, metadata}
+- **Tertiary (`#{hex}`)**: {role — e.g. accent, CTAs, highlights}
+- **Neutral (`#{hex}`)**: {role — e.g. backgrounds, surfaces}
+- **Surface (`#{hex}`)**: {role — e.g. cards, panels}
+- **On-surface (`#{hex}`)**: {role — e.g. text on surface}
+- **Error (`#{hex}`)**: {role — e.g. destructive, error states}
 
-### Surface & Background
-- **Background** (`#{hex}`): {usage}
-- **Surface** (`#{hex}`): {usage}
+## 3. Typography
 
-### Semantic
-- **Success** (`#{hex}`): {usage}
-- **Warning** (`#{hex}`): {usage}
-- **Error** (`#{hex}`): {usage}
+<!-- Define typography levels. Most design systems have 9-15 levels. Common categories: -->
+<!-- headline, display, body, label, caption. Each may have small/medium/large variants. -->
 
-### Shadows
-- **Card Shadow** (`{value}`): {usage}
+The typography strategy uses **{font-family-primary}** for {body/headlines/both} and **{font-family-secondary}** for {purpose}.
 
-## 3. Typography Rules
-
-### Font Families
-- **Heading**: {font family}
-- **Body**: {font family}
-- **Monospace**: {font family}
+- **Headlines**: Set in {family weight} to establish {tone}.
+- **Body**: {family} at {size} ensures {quality — e.g. contemporary professionalism, long-form readability}.
+- **Labels**: {family} for {technical data / UI elements}. {key treatment — e.g. uppercase with generous letter spacing}.
 
 ### Hierarchy
 
-| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
-|------|------|------|--------|-------------|----------------|-------|
-| Display | | | | | | |
-| Heading 1 | | | | | | |
-| Heading 2 | | | | | | |
-| Heading 3 | | | | | | |
-| Body | | 16px | 400 | 1.50 | normal | |
-| Body Small | | 14px | 400 | 1.43 | normal | |
-| Caption | | 12px | 500 | 1.33 | normal | |
-| Button | | 14px | 600 | 1.14 | normal | |
-| Code | | 14px | 400 | 1.50 | normal | |
+| Role | Token | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|-------|------|------|--------|-------------|----------------|-------|
+| Display | `headline-display` | | | 700 | 1.1 | -0.02em | |
+| Heading 1 | `headline-lg` | | 32px | 600 | 1.2 | | |
+| Heading 2 | `headline-md` | | 24px | 500 | 1.3 | | |
+| Body Large | `body-lg` | | 18px | 400 | 1.6 | | |
+| Body | `body-md` | | 16px | 400 | 1.5 | | |
+| Body Small | `body-sm` | | 14px | 400 | 1.5 | | |
+| Label | `label-md` | | 14px | 500 | 1.4 | | |
+| Label Small | `label-sm` | | 12px | 600 | 1.33 | 0.05em | Caps |
 
-### Principles
-- {typography principle}
+## 4. Layout
 
-## 4. Component Stylings
+<!-- Also known as "Layout & Spacing". -->
+<!-- Describe the layout and spacing strategy. Grid-based, margin-based, or dynamic. -->
+
+The layout follows a **{Fluid Grid | Fixed-Max-Width Grid | Asymmetric | Liquid Glass}** model with a **{value}px** spacing scale ({mention half-step if used, e.g. "with a 4px half-step for micro-adjustments"}).
+
+### Spacing Scale
+
+| Token | Value | Use |
+|-------|-------|-----|
+| `xs` | 4px | Micro-adjustments |
+| `sm` | 8px | Tight spacing |
+| `md` | 16px | Default gap |
+| `lg` | 32px | Section spacing |
+| `xl` | 64px | Major divisions |
+| `gutter` | 24px | Column gutters |
+| `margin` | 32px | Page margins |
+
+### Grid & Container
+
+- **Max content width**: {value}
+- **Columns**: {value}
+- **Gutter**: `{spacing.gutter}`
+- **Container padding**: `{spacing.margin}`
+
+### Whitespace Philosophy
+
+{describe the spacing approach — e.g. "Components are grouped using containment principles, where related items are housed in cards with generous internal padding (24px) to emphasize the soft, approachable nature of the brand."}
+
+## 5. Elevation & Depth
+
+<!-- How visual hierarchy is conveyed. If elevation is used, define styling (spread, blur, color). -->
+<!-- For flat designs, explain alternative methods (borders, color contrast, tonal layers). -->
+
+Depth is achieved through **{shadows | tonal layers | borders | flat contrast}**.
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (0) | No elevation | Default surfaces |
+| Raised (1) | `{shadow value}` | Cards, dropdowns |
+| Elevated (2) | `{shadow value}` | Modals, popovers |
+| Overlay (3) | `{shadow value}` | Tooltips, notifications |
+
+## 6. Shapes
+
+<!-- Describe how visual elements are shaped. Corner radius strategy. -->
+
+The shape language is defined by **{Architectural Sharpness | Soft Modernism | Pill Interaction | …}**. {describe corner-radius approach}.
+
+### Rounded Scale
+
+| Token | Value | Use |
+|-------|-------|-----|
+| `none` | 0 | Sharp corners, data tables |
+| `sm` | 4px | Inputs, badges, tags |
+| `md` | 8px | Buttons, cards |
+| `lg` | 16px | Panels, modals, dialogs |
+| `xl` | 24px | Heroes, feature cards |
+| `full` | 9999px | Pills, avatars, circular buttons |
+
+## 7. Components
+
+<!-- Style guidance for component atoms. Use YAML `components:` in front matter for token references. -->
+<!-- Prose below documents interactive states, behaviour, and anti-patterns for each component. -->
 
 ### Buttons
 
-**Primary**
-- Background: `#{hex}`
-- Text: `#{hex}`
-- Border: {value}
-- Radius: {value}
-- Padding: {value}
-- Hover: {description}
-- Focus: {description}
+**Primary** (`{components.button-primary}`)
+
+- States: Default → Hover (`{components.button-primary-hover}`) → Active → Focus → Disabled
+- Focus ring: {description}
 - Disabled: {description}
 
-**Secondary**
-- {specs}
+**Secondary** (`{components.button-secondary}`)
 
-**Ghost/Outline**
-- {specs}
+- {specs beyond tokens}
+
+**Ghost / Outline**
+
+- Background: transparent
+- Border: {value}
+- Hover: {description}
 
 ### Inputs
 
-**Text Input**
-- Background: `#{hex}`
-- Border: {value}
-- Radius: {value}
-- Padding: {value}
+**Text Input** (`{components.input-default}`)
+
 - Focus: {description}
-- Error: {description}
+- Error: {description — reference `{colors.error}`}
+- Disabled: {description}
 
 ### Links
+
 - Default: {colour + decoration}
 - Hover: {colour + decoration}
 - Visited: {colour + decoration}
 
 ### Cards & Containers
-- Background: {value}
-- Radius: {value}
-- Shadow: {value}
-- Padding: {value}
+
+**Card** (`{components.card}`)
+
+- Shadow: {reference §5}
+- Content spacing: {value}
 
 ### Navigation
-- {nav style description}
 
-## 5. Layout Principles
+{nav style description — fixed/sticky, transparent/opaque, backdrop-filter usage if glass style}
 
-### Spacing Scale
-- Base unit: {value, e.g. 8px}
-- Scale: {values, e.g. 4, 8, 12, 16, 24, 32, 48, 64}
+## 8. Do's and Don'ts
 
-### Grid & Container
-- Max content width: {value}
-- Columns: {value}
-- Gutter: {value}
-- Container padding: {value}
-
-### Whitespace Philosophy
-- {description of spacing approach}
-
-### Border Radius Scale
-| Size | Value | Use |
-|------|-------|-----|
-| Small | | Inputs, badges |
-| Medium | | Buttons, cards |
-| Large | | Modals, panels |
-| Full | 9999px | Pills, avatars |
-
-## 6. Depth & Elevation
-
-| Level | Treatment | Use |
-|-------|-----------|-----|
-| Flat (0) | No shadow | Default surfaces |
-| Raised (1) | {shadow value} | Cards, dropdowns |
-| Elevated (2) | {shadow value} | Modals, popovers |
-| Overlay (3) | {shadow value} | Tooltips, notifications |
-
-## 7. Do's and Don'ts
+<!-- Practical guidelines and common pitfalls. These act as guardrails when creating designs. -->
 
 **Do:**
-- {guideline}
-- {guideline}
+
+- Use `{colors.primary}` only for the single most important action per screen
+- Maintain WCAG AA contrast ratios (4.5:1 for normal text, 3:1 for large text)
+- {project-specific guideline}
 
 **Don't:**
-- {anti-pattern}
-- {anti-pattern}
 
-## 8. Responsive Behaviour
+- Mix sharp (`{rounded.none}`) and rounded (`{rounded.lg}`) corners in the same view
+- Use more than two font weights on a single screen
+- {project-specific anti-pattern}
+
+---
+
+<!-- Sections 9-10 below are aidevops-specific extensions. The Google Labs DESIGN.md spec preserves -->
+<!-- unknown sections per its "Consumer Behavior for Unknown Content" rule. -->
+
+## 9. Responsive Behaviour
+
+<!-- aidevops extension: breakpoints, touch targets, collapsing strategy. -->
+<!-- Preserved per spec's unknown-section rule. -->
 
 ### Breakpoints
 
@@ -159,30 +292,39 @@
 | Wide | > 1440px | Max-width contained |
 
 ### Touch Targets
+
 - Minimum: 44x44px (iOS) / 48x48dp (Android)
 
 ### Mobile Rules
+
 - {mobile-specific behaviour}
 
-## 9. Agent Prompt Guide
+## 10. Agent Prompt Guide
 
-### Quick Colour Reference
+<!-- aidevops extension: quick reference and ready-to-use prompts for coding agents. -->
+<!-- Preserved per spec's unknown-section rule. -->
 
-| Token | Value | Use |
-|-------|-------|-----|
-| --bg-primary | #{hex} | Page background |
-| --bg-surface | #{hex} | Card/panel background |
-| --text-primary | #{hex} | Main text |
-| --text-secondary | #{hex} | Muted text |
-| --accent | #{hex} | CTAs, links, highlights |
-| --border | #{hex} | Borders, dividers |
+### Quick Token Reference
+
+Primary tokens a coding agent reaches for most often:
+
+| Use | Token | Value |
+|-----|-------|-------|
+| Page background | `{colors.neutral}` | `#{hex}` |
+| Card/panel background | `{colors.surface}` | `#{hex}` |
+| Main text | `{colors.primary}` | `#{hex}` |
+| Muted text | `{colors.secondary}` | `#{hex}` |
+| CTAs, highlights | `{colors.tertiary}` | `#{hex}` |
+| Default body | `{typography.body-md}` | — |
+| Primary action | `{components.button-primary}` | — |
 
 ### Ready-to-Use Prompts
+
 - "Build a hero section": {specific instructions referencing tokens above}
-- "Build a feature grid": {specific instructions}
+- "Build a feature grid": {specific instructions — e.g. "3 cards using `{components.card}`, `{typography.headline-md}` for titles, `{spacing.lg}` between cards"}
 - "Build a pricing table": {specific instructions}
 
 <!--
 Generated by AI DevOps (https://aidevops.sh)
-DESIGN.md format: https://stitch.withgoogle.com/docs/design-md/overview
+DESIGN.md spec: https://github.com/google-labs-code/design.md
 -->

--- a/.agents/tools/design/design-md.md
+++ b/.agents/tools/design/design-md.md
@@ -176,18 +176,18 @@ npx @google/design.md export --format dtcg DESIGN.md > tokens.json
 npx @google/design.md spec --rules
 ```
 
-**Linter rules (seven):**
+**Linter rules (eight, verified against `@google/design.md` v0.1.1):**
 
 | Rule | Severity | What it checks |
 |------|----------|---------------|
-| `broken-ref` | error | Token references that don't resolve |
-| `missing-primary` | warning | No `primary` color — agents will auto-generate one |
-| `contrast-ratio` | warning | Component bg/text pairs below WCAG AA (4.5:1) |
-| `orphaned-tokens` | warning | Color tokens defined but never referenced |
-| `missing-typography` | warning | Colors defined but no typography — agents use defaults |
+| `broken-ref` | error | Broken/circular token references and unknown component sub-tokens |
+| `missing-primary` | warning | No `primary` color when other colors are defined |
+| `contrast-ratio` | warning | Component `backgroundColor`/`textColor` pairs below WCAG AA (4.5:1) |
+| `orphaned-tokens` | warning | Tokens defined but never referenced by any component |
+| `missing-typography` | warning | Colors defined but no typography tokens exist |
 | `section-order` | warning | Sections out of canonical order |
-| `missing-sections` | info | Optional sections absent when other tokens exist |
-| `token-summary` | info | Count summary per section |
+| `missing-sections` | info | Optional sections (spacing, rounded) absent when others exist |
+| `token-summary` | info | Count summary per token group |
 
 **aidevops convention**: zero errors mandatory; warnings reviewed before committing. The aidevops library examples may carry orphaned-token and missing-section warnings while migration is in progress — see the library migration task.
 

--- a/.agents/tools/design/design-md.md
+++ b/.agents/tools/design/design-md.md
@@ -25,8 +25,10 @@ model: sonnet
 ## Quick Reference
 
 - **What**: Plain-text markdown capturing a complete visual design system for AI agents
-- **Origin**: Google Stitch (https://stitch.withgoogle.com/docs/design-md/overview)
+- **Normative spec**: [google-labs-code/design.md](https://github.com/google-labs-code/design.md) (Apache 2.0, v0.1.0, format version `alpha`). Full spec: [`docs/spec.md`](https://github.com/google-labs-code/design.md/blob/main/docs/spec.md)
+- **Format**: YAML front matter (machine-readable tokens) + Markdown body (human-readable rationale)
 - **Location**: `DESIGN.md` in project root (alongside `AGENTS.md`)
+- **Validator**: `npx @google/design.md lint DESIGN.md` (lint, diff, export to tailwind/dtcg, spec)
 - **Template**: `templates/DESIGN.md.template`
 - **Library**: `tools/design/library/` (55 brand examples + 12 style templates)
 - **Preview**: `tools/design/library/_template/preview.html.template`
@@ -51,39 +53,143 @@ model: sonnet
 
 1. **Check** — does `DESIGN.md` exist in project root? If yes, use it. If no, create one.
 2. **Create** — from scratch (interview), URL (extraction), or library example.
-3. **Preview** — generate `preview.html` to visually verify the design system.
-4. **Iterate** — spin palettes, adjust tokens, regenerate preview until satisfied.
-5. **Build** — hand DESIGN.md to coding agents for consistent, on-brand UI output.
+3. **Validate** — run `npx @google/design.md lint DESIGN.md`. Zero errors, warnings reviewed.
+4. **Preview** — generate `preview.html` to visually verify the design system.
+5. **Iterate** — spin palettes, adjust tokens, regenerate preview until satisfied.
+6. **Build** — hand DESIGN.md to coding agents for consistent, on-brand UI output.
 
 <!-- AI-CONTEXT-END -->
 
 ## The DESIGN.md Format
 
-DESIGN.md is to visual design what AGENTS.md is to code behaviour — plain-text that LLMs read natively. No Figma exports, no JSON schemas.
+DESIGN.md is to visual design what AGENTS.md is to code behaviour — plain-text that LLMs read natively. A DESIGN.md file has **two layers**:
 
-### The 9 Sections
+1. **YAML front matter** — Machine-readable design tokens (normative values), delimited by `---` fences at the top of the file.
+2. **Markdown body** — Human-readable design rationale organised into `##` sections.
 
-All sections required for a complete system; partial files work but produce less consistent output.
+Tokens give agents exact values. Prose tells them *why* those values exist and how to apply them. The Google Labs spec is inspired by the [W3C Design Token Format (DTCG)](https://tr.designtokens.org/format/), so tokens round-trip to Figma variables, Tailwind theme configs, and `tokens.json`.
 
-| # | Section | What it captures |
-|---|---------|-----------------|
-| 1 | Visual Theme & Atmosphere | Mood, density, design philosophy, key characteristics |
-| 2 | Colour Palette & Roles | Semantic name + hex + functional role for every colour |
-| 3 | Typography Rules | Font families, full hierarchy table (size, weight, line-height, spacing) |
-| 4 | Component Stylings | Buttons, cards, inputs, navigation with all states (hover, focus, active, disabled) |
-| 5 | Layout Principles | Spacing scale, grid system, container widths, whitespace philosophy |
-| 6 | Depth & Elevation | Shadow system, surface hierarchy, layering rules |
-| 7 | Do's and Don'ts | Design guardrails and anti-patterns |
-| 8 | Responsive Behaviour | Breakpoints, touch targets, collapsing strategy |
-| 9 | Agent Prompt Guide | Quick colour reference, ready-to-use prompts |
+### YAML Front Matter Schema
 
-**Key format rules per section:**
+```yaml
+---
+version: alpha              # optional, current format version
+name: <string>              # required
+description: <string>       # optional
+colors:
+  <token-name>: <Color>     # e.g. primary: "#1A1C1E"
+typography:
+  <token-name>: <Typography>
+rounded:
+  <scale-level>: <Dimension>
+spacing:
+  <scale-level>: <Dimension | number>
+components:
+  <component-name>:
+    <token-name>: <string | token reference>
+---
+```
 
-- **Section 2**: Group by function (Primary Brand, Accent, Text, Surface). Every colour: semantic name + hex + usage.
-- **Section 3**: Hierarchy table is the core — map every role to exact size/weight/line-height/letter-spacing.
-- **Section 4**: Each component variant needs background, text colour, border, radius, padding, shadow, and all interactive states.
-- **Section 6**: Table of elevation levels with shadow values and use cases (Sunken/Flat/Elevated).
-- **Section 9**: Quick-reference colour token table + ready-to-use prompts for common tasks.
+**Token types:**
+
+| Type | Format | Example |
+|------|--------|---------|
+| Color | `#` + hex, sRGB | `"#1A1C1E"` |
+| Dimension | number + unit (`px`, `em`, `rem`) | `48px`, `-0.02em` |
+| Token Reference | `{path.to.token}` | `{colors.primary}` |
+| Typography | object (see below) | *inline object* |
+
+**Typography object:** `fontFamily`, `fontSize`, `fontWeight`, `lineHeight`, `letterSpacing`, `fontFeature`, `fontVariation`. `lineHeight` accepts a Dimension or a unitless multiplier. `fontWeight` accepts a bare number or quoted string.
+
+**Token references** wrap a dotted path in curly braces: `{colors.primary-60}`, `{typography.body-md}`, `{rounded.sm}`. Components may reference composite tokens like `{typography.label-md}`; other groups must reference primitive values.
+
+### Canonical Section Order
+
+Sections use `##` headings. All are optional, but those present MUST appear in this order:
+
+| # | Section | Aliases | aidevops tokens |
+|---|---------|---------|-----------------|
+| 1 | Overview | Brand & Style, Visual Theme | — |
+| 2 | Colors | — | `colors:` |
+| 3 | Typography | — | `typography:` |
+| 4 | Layout | Layout & Spacing | `spacing:` |
+| 5 | Elevation & Depth | Elevation | — |
+| 6 | Shapes | — | `rounded:` |
+| 7 | Components | — | `components:` |
+| 8 | Do's and Don'ts | — | — |
+| 9 | Responsive Behaviour | *(aidevops extension)* | — |
+| 10 | Agent Prompt Guide | *(aidevops extension)* | — |
+
+Sections 1-8 are the Google Labs spec. Sections 9-10 are aidevops-specific extensions the spec's unknown-content rule explicitly permits (unknown `##` headings are preserved, not errored). Duplicate section headings are an error — the linter rejects the file.
+
+### Recommended Token Names (Non-Normative)
+
+Adopted from the spec for cross-tool consistency:
+
+- **Colors**: `primary`, `secondary`, `tertiary`, `neutral`, `surface`, `on-surface`, `error`
+- **Typography**: `headline-display`, `headline-lg`, `headline-md`, `body-lg`, `body-md`, `body-sm`, `label-lg`, `label-md`, `label-sm`
+- **Rounded**: `none`, `sm`, `md`, `lg`, `xl`, `full`
+
+### Component Property Tokens
+
+Components map a name to a group of sub-token properties:
+
+```yaml
+components:
+  button-primary:
+    backgroundColor: "{colors.tertiary}"
+    textColor: "{colors.on-tertiary}"
+    typography: "{typography.label-md}"
+    rounded: "{rounded.sm}"
+    padding: 12px
+  button-primary-hover:
+    backgroundColor: "{colors.tertiary-container}"
+```
+
+Valid component properties: `backgroundColor`, `textColor`, `typography`, `rounded`, `padding`, `size`, `height`, `width`. Variants (hover, active, pressed, disabled) are expressed as **separate component entries with a related key name** — NOT nested under the base component.
+
+### Unknown Content Behaviour
+
+| Scenario | Spec behaviour |
+|----------|---------------|
+| Unknown section heading (e.g. our §9, §10) | Preserve; do not error |
+| Unknown color/typography token name | Accept if value is valid |
+| Unknown component property | Accept with warning |
+| Duplicate section heading | **Error; reject the file** |
+
+## Validation
+
+The `@google/design.md` npm package ships four commands. Run the linter at least once before handing a DESIGN.md to a coding agent:
+
+```bash
+# Lint: seven rules, JSON output, exit 1 on errors
+npx @google/design.md lint DESIGN.md
+
+# Diff: detect token regressions between versions
+npx @google/design.md diff DESIGN.md DESIGN-v2.md
+
+# Export: tokens to Tailwind theme config or DTCG tokens.json
+npx @google/design.md export --format tailwind DESIGN.md > tailwind.theme.json
+npx @google/design.md export --format dtcg DESIGN.md > tokens.json
+
+# Spec: output the format spec (useful for injecting into agent prompts)
+npx @google/design.md spec --rules
+```
+
+**Linter rules (seven):**
+
+| Rule | Severity | What it checks |
+|------|----------|---------------|
+| `broken-ref` | error | Token references that don't resolve |
+| `missing-primary` | warning | No `primary` color — agents will auto-generate one |
+| `contrast-ratio` | warning | Component bg/text pairs below WCAG AA (4.5:1) |
+| `orphaned-tokens` | warning | Color tokens defined but never referenced |
+| `missing-typography` | warning | Colors defined but no typography — agents use defaults |
+| `section-order` | warning | Sections out of canonical order |
+| `missing-sections` | info | Optional sections absent when other tokens exist |
+| `token-summary` | info | Count summary per section |
+
+**aidevops convention**: zero errors mandatory; warnings reviewed before committing. The aidevops library examples may carry orphaned-token and missing-section warnings while migration is in progress — see the library migration task.
 
 ## Creating a DESIGN.md
 
@@ -96,23 +202,26 @@ Choose method based on what exists:
 | Known brand/style | Library copy | `tools/design/library/brands/` or `library/styles/` |
 | `brand-identity.toon` exists | Brand identity | Map dimensions to sections (see below) |
 
-**Method 1 (Interview):** Brand identity interview (`tools/design/brand-identity.md`) → select UI style from `ui-ux-catalogue.toon` → generate palette (`colour-palette.md`) → copy closest library example → synthesise into template → preview + iterate.
+**Method 1 (Interview):** Brand identity interview (`tools/design/brand-identity.md`) → select UI style from `ui-ux-catalogue.toon` → generate palette (`colour-palette.md`) → copy closest library example → synthesise into template → lint + preview + iterate.
 
-**Method 2 (URL):** URL study workflow extracts computed styles (colours, typography, spacing, components, shadows, CSS custom properties from `:root`). Map to 9-section format. Fill gaps (do's/don'ts, responsive rules) by inference. Generate preview, validate against source. Full browser automation process: `tools/design/ui-ux-inspiration.md`.
+**Method 2 (URL):** URL study workflow extracts computed styles (colours, typography, spacing, components, shadows, CSS custom properties from `:root`). Populate YAML token layer from extracted values, write prose rationale for each section, fill gaps (do's/don'ts, responsive rules) by inference. Validate with linter, generate preview, validate against source. Full browser automation process: `tools/design/ui-ux-inspiration.md`.
 
-**Method 3 (Library):** Copy closest `library/brands/` or `library/styles/` DESIGN.md into project root. Swap colours, adjust typography, update do's/don'ts. Preview + iterate.
+**Method 3 (Library):** Copy closest `library/brands/` or `library/styles/` DESIGN.md into project root. Swap token values in YAML front matter, rewrite prose to match, update do's/don'ts. Lint + preview + iterate.
 
-**Method 4 (Brand identity):** Map `context/brand-identity.toon` dimensions:
+**Method 4 (Brand identity):** Map `context/brand-identity.toon` dimensions to sections using the canonical order:
 
-- `visual_style` + `buttons_and_forms` → sections 1, 4, 5, 6
-- `voice_and_tone` + `copywriting_patterns` → section 7
-- `imagery` + `iconography` → section 7
-- `media_and_motion` → sections 4, 8
-- `brand_positioning` → sections 1, 9
+- `visual_style` → §1 Overview, §5 Elevation, §6 Shapes
+- `buttons_and_forms` → §7 Components (with YAML `components:` tokens)
+- `voice_and_tone` + `copywriting_patterns` → §8 Do's and Don'ts
+- `imagery` + `iconography` → §8 Do's and Don'ts
+- `media_and_motion` → §7 Components, §9 Responsive
+- `brand_positioning` → §1 Overview, §10 Agent Prompt Guide
 
 ## Using a DESIGN.md
 
-**For coding agents:** Drop `DESIGN.md` in project root. Tell the agent: `"Build a landing page following DESIGN.md"`. The agent uses exact hex values, font specs, spacing, and component styles — specific, reproducible output.
+**For coding agents:** Drop `DESIGN.md` in project root. Tell the agent: `"Build a landing page following DESIGN.md"`. The agent reads YAML tokens for exact values and prose for rationale — specific, reproducible output.
+
+**For Tailwind projects:** Export tokens with `npx @google/design.md export --format tailwind DESIGN.md > tailwind.theme.json` and import into `tailwind.config.js`. Design updates in DESIGN.md propagate automatically on next build.
 
 **For design review:** Generate `preview.html` from `tools/design/library/_template/preview.html.template`. Shows colour swatches, typography scale, button variants, card/input examples, spacing scale, light/dark modes.
 
@@ -120,7 +229,7 @@ Choose method based on what exists:
 
 ## Library Structure
 
-```
+```text
 tools/design/library/
 ├── README.md                  -- Index, disclaimer, usage guide
 ├── _template/
@@ -146,6 +255,17 @@ tools/design/library/
 - **Brands**: Extracted from real websites. Use for "I want something like Stripe" or "make it feel like Linear".
 - **Styles**: Original archetype templates. Use for "I need a corporate site" or "build me a developer tool dashboard".
 
+**Migration status**: Pre-spec library files use the prose-only 9-section format without YAML front matter. The spec tolerates this (prose sections are preserved, missing tokens produce info/warning findings only). YAML-token migration is tracked as a separate backlog task.
+
+## Format Version Policy
+
+The spec format is `alpha` — expect changes. aidevops mitigations:
+
+- **Pin the spec URL** in `## Related` so workers see the version they were built against.
+- **Validate before commit** — `npx @google/design.md lint` catches most compatibility breaks.
+- **YAML tokens are forward-safe** — they track the stable DTCG-inspired schema. Prose is free-form and survives format churn.
+- **Component property set is the churn surface** — treat `size`, `height`, `width`, etc. as likely to evolve. Prefer composition (`{typography.label-md}`) over inline values where feasible.
+
 ## Related
 
 - `tools/design/brand-identity.md` -- Strategic brand profile (upstream input)
@@ -159,3 +279,5 @@ tools/design/library/
 - `tools/ui/nothing-design-skill.md` -- Example: complete design system as agent
 - `templates/DESIGN.md.template` -- Skeleton for `aidevops init`
 - `workflows/ui-verification.md` -- Visual regression testing
+- **External**: [google-labs-code/design.md](https://github.com/google-labs-code/design.md) — normative spec, CLI, examples
+- **External**: [W3C Design Tokens Format Module](https://tr.designtokens.org/format/) — underlying token schema inspiration


### PR DESCRIPTION
## Summary

Aligns the aidevops `design-md` agent and `DESIGN.md` template with the formal Google Labs DESIGN.md spec (v0.1.0, format version `alpha`) released April 2026 at [google-labs-code/design.md](https://github.com/google-labs-code/design.md).

Previously the agent referenced the pre-formal *overview* URL (`stitch.withgoogle.com/docs/design-md/overview`) and used a prose-only 9-section format with no machine-readable token layer. The new normative spec defines a two-layer format (YAML front matter tokens + Markdown body rationale), a canonical 8-section order, a CLI validator (`npx @google/design.md`), and DTCG-inspired token interop (Tailwind, Figma variables, `tokens.json`).

## Changes

### `.agents/tools/design/design-md.md` (agent)

- Cite the formal spec repo and pin `docs/spec.md` as authoritative.
- Document the two-layer YAML + Markdown format, token types, and `{path.to.token}` reference syntax.
- Replace the 9-section prose list with the canonical spec order (1-8) plus aidevops extensions (9 Responsive, 10 Agent Prompt Guide) preserved per the spec's unknown-section rule.
- Add recommended token names for colors/typography/rounded (DTCG-aligned).
- Document the eight linter rules with severity/intent (verified against CLI v0.1.1 — upstream README says "seven" but the CLI ships eight).
- Add `Validation` section covering `lint`, `diff`, `export --format tailwind|dtcg`, `spec --rules`.
- Add `Format Version Policy` section documenting the `alpha` churn risk and mitigations.

### `.agents/templates/DESIGN.md.template`

- Prepend YAML front matter with canonical schema and recommended token names.
- Reorder prose sections to canonical spec order: Overview → Colors → Typography → Layout → Elevation → Shapes → Components → Do's and Don'ts.
- Insert new `## 6. Shapes` section (spec requirement, previously absent from aidevops format).
- Move Components from old §4 to canonical §7.
- Keep `## 9. Responsive Behaviour` and `## 10. Agent Prompt Guide` as non-normative extensions.
- Component examples use token references (`{colors.primary}`, `{rounded.md}`) to demonstrate composition.

## Verification

- **Spec lint (concrete sample resolved from template)**: `npx @google/design.md@0.1.1 lint` → **0 errors**, 3 expected warnings, 1 info.
- **Markdownlint**: 0 errors on both modified files.
- **CLI rules verified**: linter rule names/severities in the agent match `npx @google/design.md spec --rules-only --format json` output.

## Scope boundary

This PR updates ONLY the agent doc and the `aidevops init` template skeleton. The 55 brand + 12 style example files in `tools/design/library/` remain prose-only pending a separate migration task (filed as sibling auto-dispatch issue). The spec tolerates prose-only files.

## Trade-offs

- **`alpha`-marked spec** — format churn risk. Mitigated by spec URL pin, CLI validation gate, YAML schema tracks stable DTCG, prose is free-form.
- **External dep on `@google/design.md`** — acceptable (Apache 2.0, Google-backed, 7k stars, optional at runtime).
- **Legacy library files** — not broken; spec tolerates prose-only per unknown-content rule.

Resolves #20747

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.2 plugin for [OpenCode](https://opencode.ai) v1.14.24 with claude-opus-4-7 spent 29m and 31,392 tokens on this with the user in an interactive session.