### PR TITLE
t2798: t2798: add status:available default workflow for bypass-path issue creation

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -103,6 +103,7 @@ Task IDs: `/new-task` or `claim-task-id.sh`. NEVER grep TODO.md for next ID.
 - **Exclusions**: Needs credentials, decomposition, or user preference. Canonical blocker label set: `reference/dispatch-blockers.md`.
 - **Quality gate**: 2+ acceptance criteria, file references in How section, clear deliverable in What section.
 - **Interactive workflow**: Add `assignee:` before pushing if working interactively.
+- **Server-side safety net (t2798)**: `.github/workflows/apply-status-available-default.yml` applies `status:available` to issues that carry `auto-dispatch` but have no `status:*` label — catches bypass-path creations (bare `gh issue create`, web UI) that skip `claim-task-id.sh`.
 
 **Session origin labels**: Issues and PRs are automatically tagged with `origin:worker` (headless/pulse dispatch) or `origin:interactive` (user session). Applied by `claim-task-id.sh`, `issue-sync-helper.sh`, and `pulse-wrapper.sh`. In TODO.md, use `#worker` or `#interactive` tags to set origin explicitly; these map to the corresponding labels on push.
 

--- a/.github/workflows/apply-status-available-default.yml
+++ b/.github/workflows/apply-status-available-default.yml
@@ -1,0 +1,65 @@
+name: Apply status:available Default
+
+# Safety net for bypass-path issue creation (t2798).
+# When issues are created via bare `gh issue create` (bypassing claim-task-id.sh),
+# they ship without status:available — making them invisible to the pulse's
+# dispatch fill-floor. This workflow applies the default label server-side.
+#
+# Primary source of status:available: claim-task-id.sh (application-layer, t2789).
+# This workflow: platform-layer defence-in-depth for the bypass path.
+
+on:
+  issues:
+    types: [opened, labeled]
+
+permissions:
+  issues: write
+
+jobs:
+  apply-default:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    concurrency:
+      group: apply-status-default-${{ github.event.issue.number }}
+      cancel-in-progress: true
+    steps:
+      - name: Apply status:available if missing
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const labels = (issue.labels || []).map(l => l.name);
+
+            // Gate 1: must have auto-dispatch
+            if (!labels.includes('auto-dispatch')) {
+              console.log(`Issue #${issue.number} has no auto-dispatch label — skipping`);
+              return;
+            }
+
+            // Gate 2: already has a status:* label — do not override
+            if (labels.some(l => l.startsWith('status:'))) {
+              console.log(`Issue #${issue.number} already has a status label — skipping`);
+              return;
+            }
+
+            // Gate 3: excluded label classes — these issue types are never
+            // auto-dispatched even if they carry auto-dispatch
+            const excluded = [
+              'parent-task',
+              'persistent',
+              'consolidation-task',
+              'routine-tracking',
+              'no-auto-dispatch'
+            ];
+            if (labels.some(l => excluded.includes(l))) {
+              console.log(`Issue #${issue.number} has excluded label — skipping`);
+              return;
+            }
+
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issue.number,
+              labels: ['status:available']
+            });
+            console.log(`Applied status:available to #${issue.number}`);

--- a/.github/workflows/apply-status-available-default.yml
+++ b/.github/workflows/apply-status-available-default.yml
@@ -21,7 +21,7 @@ jobs:
     timeout-minutes: 2
     concurrency:
       group: apply-status-default-${{ github.event.issue.number }}
-      cancel-in-progress: true
+      cancel-in-progress: false
     steps:
       - name: Apply status:available if missing
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7


### PR DESCRIPTION
## Summary

Created .github/workflows/apply-status-available-default.yml — a server-side safety net that applies status:available to auto-dispatch issues missing any status:* label. Catches bypass-path creations (bare gh issue create, web UI) that skip claim-task-id.sh. Added one-line documentation to .agents/AGENTS.md under Auto-Dispatch and Completion.

## Files Changed

.agents/AGENTS.md,.github/workflows/apply-status-available-default.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Pre-commit actionlint validation passed. Workflow triggers on issues.opened and issues.labeled with three idempotent gates: auto-dispatch required, no existing status:* label, excluded labels (parent-task, persistent, consolidation-task, routine-tracking, no-auto-dispatch) skip.

Resolves #20730


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.3 plugin for [OpenCode](https://opencode.ai) v1.14.24 with claude-opus-4-6 spent 2m and 4,437 tokens on this as a headless worker.