### PR TITLE
GH#20768: fix stale feature-flag comment in shared-phase-filing.sh

### DIFF
--- a/.agents/scripts/shared-phase-filing.sh
+++ b/.agents/scripts/shared-phase-filing.sh
@@ -15,8 +15,8 @@
 #       Best-effort; failures are logged but never propagate.
 #
 # Feature flag:
-#   AIDEVOPS_SEQUENTIAL_PHASE_AUTOFILE=0|1 (default 0)
-#   When 0, auto_file_next_phase is a no-op. Set to 1 to enable.
+#   AIDEVOPS_SEQUENTIAL_PHASE_AUTOFILE=0|1 (default 1, ON since t2787)
+#   When 0, auto_file_next_phase is a no-op. Defaults to 1 (enabled).
 #
 # Phase line format in parent issue body's ## Phases section:
 #   - Phase <N> - <description> [auto-fire:on-prior-merge] [#<child_issue>]


### PR DESCRIPTION
## Summary

The header comment in `.agents/scripts/shared-phase-filing.sh` (lines 18-19) described `AIDEVOPS_SEQUENTIAL_PHASE_AUTOFILE` as having a default of `0`. The actual default was flipped to `1` in PR #20712 (t2787) but the file header comment was not updated.

## What

- EDIT: `.agents/scripts/shared-phase-filing.sh:18-19` — update comment from `(default 0)` / `Set to 1 to enable` to `(default 1, ON since t2787)` / `Defaults to 1 (enabled)`.

## Context

Issue #20768 was auto-filed as "Phase 3: Flip AIDEVOPS_SEQUENTIAL_PHASE_AUTOFILE default to 1 + docs sweep". The core work was already completed in PR #20712 (t2787), which resolved the original Phase 3 child issue #20704. This PR addresses the one residual: the stale comment in the file header that still described the old `default 0` behaviour.

All other documentation targets (`brief-template.md`, `parent-task-lifecycle.md`, `new-task.md`) already reflect the new default-on behaviour from PR #20712.

## Verification

```
grep -n "SEQUENTIAL_PHASE_AUTOFILE" .agents/scripts/shared-phase-filing.sh
```

Expected: line 18 shows `(default 1, ON since t2787)`, line 54 shows `:-1`.

Resolves #20768
For #20559

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.3 plugin for [OpenCode](https://opencode.ai) v1.14.24 with claude-sonnet-4-6 spent 3m and 9,154 tokens on this as a headless worker.
