### PR TITLE
t2806: t2806: detect SYNC_PAT need under rulesets-based branch protection

### DIFF
--- a/.agents/reference/auto-dispatch.md
+++ b/.agents/reference/auto-dispatch.md
@@ -86,6 +86,8 @@ Without it, the workflow posts a remediation comment containing both the root-ca
 
 **Currently active for:** `marcusquinn/aidevops` (verified end-to-end 2026-04-19). Other registered repos still emit the t2166 warning until set per-repo — visible via `aidevops security check`.
 
+**Detector scope (t2806, GH#20745):** `aidevops security check` detects the need for SYNC_PAT under both classic branch-protection rules AND repository rulesets. Repos migrated to the modern rulesets API (Settings → Rules → Rulesets) return 404 on the legacy `/branches/{branch}/protection` endpoint but carry protection via `/repos/{slug}/rulesets`; the detector now falls back to the rulesets path when the classic endpoint reports "not protected". See `security-posture-helper.sh::_branch_is_rulesets_protected`.
+
 **Known false-positive (pending t2252):** the auto-completion path may mis-mark planning-only PRs (those using `Ref #NNN` / `For #NNN` without closing keywords) as `status:done` on merge — tracked as GH#19782.
 
 ## Reusable-Workflow Architecture (t2770)

--- a/.agents/scripts/security-posture-helper.sh
+++ b/.agents/scripts/security-posture-helper.sh
@@ -617,12 +617,15 @@ check_repo_security() {
 # Phase 7: SYNC_PAT detection helpers (t2374)
 
 # Emit a SYNC_PAT advisory file for a repo that needs it.
-# Usage: _emit_sync_pat_advisory <slug> <slug_sanitised> <advisory_file> <required_reviews>
+# Usage: _emit_sync_pat_advisory <slug> <slug_sanitised> <advisory_file> <protection_desc>
+# protection_desc is a human-readable description of the detected protection,
+# e.g. "requiring 1 approving review(s)" (classic) or "rulesets-based
+# protection" (t2806, rulesets path).
 _emit_sync_pat_advisory() {
 	local slug="$1"
 	local slug_sanitised="$2"
 	local advisory_file="$3"
-	local required_reviews="$4"
+	local protection_desc="$4"
 
 	local advisory_dir
 	advisory_dir="$(dirname "$advisory_file")"
@@ -631,9 +634,10 @@ _emit_sync_pat_advisory() {
 	cat >"$advisory_file" <<ADVISORY_EOF
 [ADVISORY] SYNC_PAT not set for ${slug}
 
-This repo uses issue-sync.yml + branch protection requiring ${required_reviews} approving review(s).
+This repo uses issue-sync.yml and has protection on the default branch
+(${protection_desc}).
 Without SYNC_PAT, TODO.md auto-completion silently fails on PR merge
-(github-actions[bot] cannot push to a branch-protected default branch).
+(github-actions[bot] cannot push to a protected default branch).
 
 To fix (run in a separate terminal, NOT in AI chat):
 
@@ -659,49 +663,139 @@ ADVISORY_EOF
 	return 0
 }
 
+# Check whether the default branch is protected via repository rulesets
+# (the modern replacement for classic branch-protection rules, see t2806).
+# Returns 0 if any active ruleset targets the default branch with a
+# meaningful protection rule; 1 otherwise (including API errors).
+# Usage: _branch_is_rulesets_protected <slug> <default_branch>
+#
+# Fail-open: empty/errored rulesets API returns 1 (not protected). A
+# false negative here loses the advisory; a false positive just results
+# in an advisory the user can dismiss. Per t2806, we prefer the former
+# because classic detection already covers the review-requiring cases.
+_branch_is_rulesets_protected() {
+	local slug="$1"
+	local default_branch="$2"
+
+	local rulesets_json
+	rulesets_json=$(gh api "repos/${slug}/rulesets" 2>/dev/null) || return 1
+	[[ -z "$rulesets_json" || "$rulesets_json" == "[]" ]] && return 1
+
+	# Extract active ruleset IDs (enforcement == "active")
+	local active_ids
+	active_ids=$(echo "$rulesets_json" | jq -r '.[] | select(.enforcement == "active") | .id' 2>/dev/null) || return 1
+	[[ -z "$active_ids" ]] && return 1
+
+	local id detail include_patterns rule_types
+	while IFS= read -r id; do
+		[[ -z "$id" ]] && continue
+		detail=$(gh api "repos/${slug}/rulesets/${id}" 2>/dev/null) || continue
+
+		# Include patterns can be specific refs ("refs/heads/main") or
+		# GitHub wildcards ("~DEFAULT_BRANCH", "~ALL").
+		include_patterns=$(echo "$detail" | jq -r '.conditions.ref_name.include // [] | .[]' 2>/dev/null) || continue
+
+		local matches_default="no"
+		while IFS= read -r pattern; do
+			[[ -z "$pattern" ]] && continue
+			case "$pattern" in
+			"refs/heads/${default_branch}" | "~DEFAULT_BRANCH" | "~ALL" | "refs/heads/*")
+				matches_default="yes"
+				break
+				;;
+			esac
+		done <<<"$include_patterns"
+
+		[[ "$matches_default" == "yes" ]] || continue
+
+		# Protection signals: pull_request review requirement OR
+		# required_status_checks. Either blocks direct bot pushes via
+		# the PR-required or checks-required gate, and is a strong
+		# signal that SYNC_PAT is needed downstream (t2449 author
+		# association chain, t2806).
+		rule_types=$(echo "$detail" | jq -r '.rules[].type' 2>/dev/null) || continue
+		if echo "$rule_types" | grep -qE '^(pull_request|required_status_checks)$'; then
+			return 0
+		fi
+	done <<<"$active_ids"
+
+	return 1
+}
+
 # Check whether a repo requires SYNC_PAT based on workflow + branch protection.
-# Returns via stdout: "needed" | "not_needed" | "skip"
+# Writes result to global SYNC_PAT_NEED_RESULT: "needed:<desc>" | "not_needed".
 # Side effect: prints findings and cleans stale advisories.
+#
+# NOTE (t2806): earlier versions returned the result via stdout capture
+# (`$()`), which was broken because `print_pass` / `add_finding` also
+# write to stdout — the captured result included ANSI-wrapped "[PASS]"
+# lines and the equality check against "not_needed" failed. Using a
+# dedicated global eliminates the capture conflict entirely.
+#
 # Usage: _check_sync_pat_need <repo_path> <slug> <advisory_file>
 _check_sync_pat_need() {
 	local repo_path="$1"
 	local slug="$2"
 	local advisory_file="$3"
 
+	SYNC_PAT_NEED_RESULT=""
+
 	# Step 1: Does the repo use issue-sync.yml?
 	if ! gh api "repos/${slug}/contents/.github/workflows/issue-sync.yml" &>/dev/null 2>&1; then
 		print_pass "No issue-sync.yml — SYNC_PAT not needed for $slug"
 		add_finding "$SEVERITY_PASS" "$CAT_SYNC_PAT" "No issue-sync.yml in $slug"
 		[[ -f "$advisory_file" ]] && rm -f "$advisory_file"
-		echo "not_needed"
+		SYNC_PAT_NEED_RESULT="not_needed"
 		return 0
 	fi
 
-	# Step 2: Does the repo have branch protection requiring PR reviews?
+	# Step 2: Does the repo have branch protection?
 	local default_branch
 	default_branch=$(git -C "$repo_path" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||') || true
 	default_branch="${default_branch:-main}"
 
+	# Step 2a: Classic branch-protection endpoint (legacy path).
 	local protection_json
 	protection_json=$(gh api "repos/${slug}/branches/${default_branch}/protection" 2>/dev/null) || true
 
-	if [[ -z "$protection_json" || "$protection_json" == *"Not Found"* || "$protection_json" == *"Branch not protected"* ]]; then
+	local protected_kind="none"
+	local protection_desc=""
+
+	if [[ -n "$protection_json" && "$protection_json" != *"Not Found"* && "$protection_json" != *"Branch not protected"* ]]; then
+		protected_kind="classic"
+	elif _branch_is_rulesets_protected "$slug" "$default_branch"; then
+		# Step 2b: Rulesets-based protection (t2806). Modern repos
+		# return 404 on the classic endpoint but carry rulesets via
+		# /repos/{slug}/rulesets — the legacy detector silently
+		# skipped these. See GH#20745.
+		protected_kind="rulesets"
+		protection_desc="rulesets-based protection"
+	fi
+
+	if [[ "$protected_kind" == "none" ]]; then
 		print_pass "No branch protection — SYNC_PAT not needed for $slug"
 		add_finding "$SEVERITY_PASS" "$CAT_SYNC_PAT" "No branch protection in $slug"
 		[[ -f "$advisory_file" ]] && rm -f "$advisory_file"
-		echo "not_needed"
+		SYNC_PAT_NEED_RESULT="not_needed"
 		return 0
 	fi
 
-	local required_reviews
-	required_reviews=$(echo "$protection_json" | jq -r '.required_pull_request_reviews.required_approving_review_count // 0' 2>/dev/null) || required_reviews="0"
+	# For classic protection, keep the required_reviews -eq 0 optimisation.
+	# For rulesets, we assume reviews are effectively required — the
+	# rulesets API shape doesn't expose a simple "0 approvals" state, and
+	# a false positive here only produces an advisory the user can dismiss.
+	if [[ "$protected_kind" == "classic" ]]; then
+		local required_reviews
+		required_reviews=$(echo "$protection_json" | jq -r '.required_pull_request_reviews.required_approving_review_count // 0' 2>/dev/null) || required_reviews="0"
 
-	if [[ "$required_reviews" -eq 0 ]]; then
-		print_pass "PR reviews not required — SYNC_PAT not needed for $slug"
-		add_finding "$SEVERITY_PASS" "$CAT_SYNC_PAT" "No review requirement in $slug"
-		[[ -f "$advisory_file" ]] && rm -f "$advisory_file"
-		echo "not_needed"
-		return 0
+		if [[ "$required_reviews" -eq 0 ]]; then
+			print_pass "PR reviews not required — SYNC_PAT not needed for $slug"
+			add_finding "$SEVERITY_PASS" "$CAT_SYNC_PAT" "No review requirement in $slug"
+			[[ -f "$advisory_file" ]] && rm -f "$advisory_file"
+			SYNC_PAT_NEED_RESULT="not_needed"
+			return 0
+		fi
+		protection_desc="requiring ${required_reviews} approving review(s)"
 	fi
 
 	# Step 3: Is SYNC_PAT set?
@@ -712,12 +806,12 @@ _check_sync_pat_need() {
 		print_pass "SYNC_PAT is set for $slug"
 		add_finding "$SEVERITY_PASS" "$CAT_SYNC_PAT" "SYNC_PAT set for $slug"
 		[[ -f "$advisory_file" ]] && rm -f "$advisory_file"
-		echo "not_needed"
+		SYNC_PAT_NEED_RESULT="not_needed"
 		return 0
 	fi
 
-	# Needs SYNC_PAT — return the required_reviews count for advisory
-	echo "needed:${required_reviews}"
+	# Needs SYNC_PAT — return the protection description for the advisory
+	SYNC_PAT_NEED_RESULT="needed:${protection_desc}"
 	return 0
 }
 
@@ -764,22 +858,25 @@ check_sync_pat() {
 		return 0
 	fi
 
-	# Check need via helper
-	local need_result
-	need_result=$(_check_sync_pat_need "$repo_path" "$slug" "$advisory_file")
+	# Check need via helper. Result is written to SYNC_PAT_NEED_RESULT — NOT
+	# returned via stdout, because `print_pass` / `add_finding` inside the
+	# helper also write to stdout and would pollute a `$()` capture (t2806).
+	_check_sync_pat_need "$repo_path" "$slug" "$advisory_file"
 
-	if [[ "$need_result" == "not_needed" ]]; then
+	if [[ "$SYNC_PAT_NEED_RESULT" == "not_needed" ]]; then
 		return 0
 	fi
 
-	# Extract required_reviews count from "needed:<N>" result
-	local required_reviews
-	required_reviews="${need_result#needed:}"
+	# Extract protection description from "needed:<description>" result.
+	# For classic protection this is e.g. "requiring 1 approving review(s)";
+	# for rulesets-based protection (t2806) it is "rulesets-based protection".
+	local protection_desc
+	protection_desc="${SYNC_PAT_NEED_RESULT#needed:}"
 
 	print_warn "SYNC_PAT not set for $slug — TODO.md auto-completion will silently fail on PR merge"
 	add_finding "$SEVERITY_WARNING" "$CAT_SYNC_PAT" "SYNC_PAT not set for $slug"
 
-	_emit_sync_pat_advisory "$slug" "$slug_sanitised" "$advisory_file" "$required_reviews"
+	_emit_sync_pat_advisory "$slug" "$slug_sanitised" "$advisory_file" "$protection_desc"
 
 	return 0
 }

--- a/.agents/scripts/tests/test-sync-pat-detection.sh
+++ b/.agents/scripts/tests/test-sync-pat-detection.sh
@@ -2,19 +2,24 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 #
-# test-sync-pat-detection.sh — t2374 regression guard.
+# test-sync-pat-detection.sh — t2374 / t2806 regression guard.
 #
 # Verifies check_sync_pat() in security-posture-helper.sh correctly detects
 # repos that need SYNC_PAT but don't have it set, and skips repos where
-# SYNC_PAT is not needed.
+# SYNC_PAT is not needed — across BOTH classic branch-protection and
+# repository-rulesets (t2806) protection mechanisms.
 #
-# Six test cases:
-#   1. Has issue-sync.yml + branch protection + NO SYNC_PAT → emits advisory
-#   2. Has issue-sync.yml + branch protection + HAS SYNC_PAT → no advisory (pass)
+# Test cases:
+#   1. issue-sync.yml + classic protection + NO SYNC_PAT → emits advisory
+#   2. issue-sync.yml + classic protection + HAS SYNC_PAT → no advisory
 #   3. No issue-sync.yml → no advisory (irrelevant)
-#   4. No branch protection requiring reviews → no advisory (not needed)
+#   4. No protection (classic or rulesets) → no advisory
 #   5. Dismissed advisory → skip silently
 #   6. Stale advisory cleaned up when SYNC_PAT set
+#   7. issue-sync.yml + rulesets-only (pull_request) + NO SYNC_PAT → emits advisory (t2806)
+#   8. issue-sync.yml + rulesets-only (required_status_checks) + NO SYNC_PAT → emits advisory (t2806)
+#   9. issue-sync.yml + rulesets-only (no relevant rules) → no advisory
+#  10. issue-sync.yml + both classic + rulesets + NO SYNC_PAT → classic wins, emits advisory
 #
 # Stub strategy: a single configurable gh() stub dispatches based on
 # STUB_* variables set per test. This avoids redefining gh() 6 times
@@ -75,6 +80,20 @@ readonly ISSUE_SYNC_RESPONSE='{"name":"issue-sync.yml"}'
 readonly PROTECTION_WITH_REVIEWS='{"required_pull_request_reviews":{"required_approving_review_count":1}}'
 readonly GH_API_SYNC_PATTERN="contents/.github/workflows/issue-sync.yml"
 readonly GH_API_PROT_PATTERN="/protection"
+readonly GH_API_RULESETS_LIST_PATTERN="/rulesets"
+
+# Rulesets fixtures (t2806)
+readonly RULESETS_LIST_WITH_ACTIVE='[{"id":1000,"enforcement":"active"}]'
+readonly RULESETS_LIST_EMPTY='[]'
+
+# Active ruleset on default branch with pull_request rule
+readonly RULESET_DETAIL_PULL_REQUEST='{"conditions":{"ref_name":{"include":["refs/heads/main"]}},"rules":[{"type":"pull_request"},{"type":"non_fast_forward"}]}'
+# Active ruleset on default branch with required_status_checks only
+readonly RULESET_DETAIL_STATUS_CHECKS='{"conditions":{"ref_name":{"include":["refs/heads/main"]}},"rules":[{"type":"required_status_checks"},{"type":"deletion"}]}'
+# Active ruleset on default branch with no relevant protection rules
+readonly RULESET_DETAIL_NO_RELEVANT='{"conditions":{"ref_name":{"include":["refs/heads/main"]}},"rules":[{"type":"non_fast_forward"},{"type":"deletion"}]}'
+# Active ruleset NOT matching default branch
+readonly RULESET_DETAIL_OTHER_BRANCH='{"conditions":{"ref_name":{"include":["refs/heads/feature"]}},"rules":[{"type":"pull_request"}]}'
 
 # =============================================================================
 # Configurable stub variables (set per test case)
@@ -82,6 +101,8 @@ readonly GH_API_PROT_PATTERN="/protection"
 STUB_HAS_ISSUE_SYNC="true"     # "true" = API returns 200, "false" = API returns 1
 STUB_PROTECTION_RESPONSE=""     # JSON response from /protection, empty = no protection
 STUB_SECRET_RESPONSE=""         # Output from gh secret list, empty = no SYNC_PAT
+STUB_RULESETS_LIST=""           # JSON response for /rulesets list endpoint
+STUB_RULESET_DETAIL=""          # JSON response for /rulesets/{id} detail endpoint
 
 # Single shared gh stub — dispatches based on STUB_* variables
 gh() {
@@ -105,6 +126,20 @@ gh() {
 			fi
 			echo "Branch not protected"
 			return 1
+		elif [[ "$url" == *"/rulesets/"* ]]; then
+			# Individual ruleset detail endpoint
+			if [[ -n "$STUB_RULESET_DETAIL" ]]; then
+				echo "$STUB_RULESET_DETAIL"
+				return 0
+			fi
+			return 1
+		elif [[ "$url" == *"$GH_API_RULESETS_LIST_PATTERN" ]]; then
+			# List rulesets endpoint (suffix match)
+			if [[ -n "$STUB_RULESETS_LIST" ]]; then
+				echo "$STUB_RULESETS_LIST"
+				return 0
+			fi
+			return 1
 		fi
 		return 1
 		;;
@@ -126,13 +161,10 @@ git() {
 	command git "$@"
 }
 
-# Stub jq for protection JSON parsing
+# Stub jq: delegate to real jq so rulesets detail parsing works end-to-end.
+# For protection JSON parsing (classic path), real jq also works correctly
+# against the fixture, so no special-casing is needed.
 jq() {
-	local args=("$@")
-	if [[ "${args[*]}" == *"required_approving_review_count"* ]]; then
-		echo "1"
-		return 0
-	fi
 	command jq "$@"
 }
 
@@ -203,8 +235,11 @@ resolve_slug() {
 	return 0
 }
 
-# Extract function bodies from the helper (check_sync_pat + its sub-functions)
+# Extract function bodies from the helper (check_sync_pat + its sub-functions).
+# Order matters: _branch_is_rulesets_protected is called by _check_sync_pat_need
+# (t2806), so it must be defined first.
 eval "$(sed -n '/^_emit_sync_pat_advisory()/,/^}/p' "${SCRIPTS_DIR}/security-posture-helper.sh")"
+eval "$(sed -n '/^_branch_is_rulesets_protected()/,/^}/p' "${SCRIPTS_DIR}/security-posture-helper.sh")"
 eval "$(sed -n '/^_check_sync_pat_need()/,/^}/p' "${SCRIPTS_DIR}/security-posture-helper.sh")"
 eval "$(sed -n '/^check_sync_pat()/,/^}/p' "${SCRIPTS_DIR}/security-posture-helper.sh")"
 
@@ -216,6 +251,10 @@ SEVERITY_WARNING="warning"
 SEVERITY_INFO="info"
 SEVERITY_PASS="pass"
 CAT_SYNC_PAT="sync_pat"
+
+# Global result variable (t2806). _check_sync_pat_need writes here instead
+# of using stdout capture, which was broken by print_pass stdout output.
+SYNC_PAT_NEED_RESULT=""
 
 # =============================================================================
 # Helper to reset state between tests
@@ -233,6 +272,10 @@ reset_state() {
 	STUB_HAS_ISSUE_SYNC="true"
 	STUB_PROTECTION_RESPONSE="$PROTECTION_WITH_REVIEWS"
 	STUB_SECRET_RESPONSE=""
+	# Rulesets defaults to "no rulesets" (t2806). Individual tests that
+	# exercise the rulesets path set STUB_RULESETS_LIST and STUB_RULESET_DETAIL.
+	STUB_RULESETS_LIST=""
+	STUB_RULESET_DETAIL=""
 	return 0
 }
 
@@ -365,6 +408,114 @@ if [[ ! -f "$ADVISORY_PATH" ]]; then
 	pass "Stale advisory cleaned up after SYNC_PAT set"
 else
 	fail "Stale advisory NOT cleaned up"
+fi
+
+# =============================================================================
+# Test 7 (t2806): Rulesets-only protection with pull_request rule — emits advisory
+# =============================================================================
+printf '\n%sTest 7 (t2806): Rulesets-only protection (pull_request) — should advise%s\n' "$TEST_BLUE" "$TEST_NC"
+reset_state
+STUB_PROTECTION_RESPONSE=""  # Classic API returns 404
+STUB_RULESETS_LIST="$RULESETS_LIST_WITH_ACTIVE"
+STUB_RULESET_DETAIL="$RULESET_DETAIL_PULL_REQUEST"
+STUB_SECRET_RESPONSE=""
+
+check_sync_pat "$FAKE_REPO"
+
+if [[ -f "$ADVISORY_PATH" ]]; then
+	pass "Advisory fired for rulesets-protected repo (pull_request rule)"
+else
+	fail "Advisory NOT fired for rulesets-protected repo" "Log: $(cat "$OUTPUT_LOG")"
+fi
+
+if [[ -f "$ADVISORY_PATH" ]] && grep -q "rulesets-based" "$ADVISORY_PATH" 2>/dev/null; then
+	pass "Advisory mentions rulesets-based protection"
+else
+	fail "Advisory missing rulesets-based description"
+fi
+
+# =============================================================================
+# Test 8 (t2806): Rulesets-only with required_status_checks — emits advisory
+# =============================================================================
+printf '\n%sTest 8 (t2806): Rulesets-only (required_status_checks) — should advise%s\n' "$TEST_BLUE" "$TEST_NC"
+reset_state
+STUB_PROTECTION_RESPONSE=""
+STUB_RULESETS_LIST="$RULESETS_LIST_WITH_ACTIVE"
+STUB_RULESET_DETAIL="$RULESET_DETAIL_STATUS_CHECKS"
+STUB_SECRET_RESPONSE=""
+
+check_sync_pat "$FAKE_REPO"
+
+if [[ -f "$ADVISORY_PATH" ]]; then
+	pass "Advisory fired for rulesets with required_status_checks (awardsapp/develop case)"
+else
+	fail "Advisory NOT fired for status-checks rulesets" "Log: $(cat "$OUTPUT_LOG")"
+fi
+
+# =============================================================================
+# Test 9 (t2806): Rulesets-only with no relevant rules — no advisory
+# =============================================================================
+printf '\n%sTest 9 (t2806): Rulesets with only deletion/non_fast_forward — no advisory%s\n' "$TEST_BLUE" "$TEST_NC"
+reset_state
+STUB_PROTECTION_RESPONSE=""
+STUB_RULESETS_LIST="$RULESETS_LIST_WITH_ACTIVE"
+STUB_RULESET_DETAIL="$RULESET_DETAIL_NO_RELEVANT"
+STUB_SECRET_RESPONSE=""
+
+check_sync_pat "$FAKE_REPO"
+
+if [[ ! -f "$ADVISORY_PATH" ]]; then
+	pass "No advisory when rulesets have no meaningful protection rules"
+else
+	fail "Advisory fired for rulesets with no review/check rules"
+fi
+
+if grep -q '\[PASS\].*No branch protection' "$OUTPUT_LOG" 2>/dev/null; then
+	pass "PASS message emitted when only deletion/non_fast_forward rules present"
+else
+	fail "Expected pass message for non-protective rulesets" "Log: $(cat "$OUTPUT_LOG")"
+fi
+
+# =============================================================================
+# Test 10 (t2806): Both classic and rulesets — classic path wins, emits advisory
+# =============================================================================
+printf '\n%sTest 10 (t2806): Both classic + rulesets protection — classic takes precedence%s\n' "$TEST_BLUE" "$TEST_NC"
+reset_state
+STUB_PROTECTION_RESPONSE="$PROTECTION_WITH_REVIEWS"
+STUB_RULESETS_LIST="$RULESETS_LIST_WITH_ACTIVE"
+STUB_RULESET_DETAIL="$RULESET_DETAIL_PULL_REQUEST"
+STUB_SECRET_RESPONSE=""
+
+check_sync_pat "$FAKE_REPO"
+
+if [[ -f "$ADVISORY_PATH" ]]; then
+	pass "Advisory fired when both classic and rulesets present"
+else
+	fail "Advisory NOT fired for dual-protection repo"
+fi
+
+if [[ -f "$ADVISORY_PATH" ]] && grep -q "requiring.*approving review" "$ADVISORY_PATH" 2>/dev/null; then
+	pass "Classic protection description wins when both exist"
+else
+	fail "Classic description missing — rulesets path may have taken precedence" "Advisory: $(cat "$ADVISORY_PATH" 2>/dev/null || echo "<missing>")"
+fi
+
+# =============================================================================
+# Test 11 (t2806): Rulesets targeting a non-default branch — no advisory
+# =============================================================================
+printf '\n%sTest 11 (t2806): Ruleset targeting feature/ branch, not default — no advisory%s\n' "$TEST_BLUE" "$TEST_NC"
+reset_state
+STUB_PROTECTION_RESPONSE=""
+STUB_RULESETS_LIST="$RULESETS_LIST_WITH_ACTIVE"
+STUB_RULESET_DETAIL="$RULESET_DETAIL_OTHER_BRANCH"
+STUB_SECRET_RESPONSE=""
+
+check_sync_pat "$FAKE_REPO"
+
+if [[ ! -f "$ADVISORY_PATH" ]]; then
+	pass "No advisory when rulesets target non-default branch"
+else
+	fail "Advisory fired despite rulesets not matching default branch"
 fi
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Extends security-posture-helper.sh Phase 7 SYNC_PAT detector to recognise repos protected via the modern GitHub rulesets API (Settings → Rules → Rulesets). The legacy /branches/{branch}/protection endpoint returns 404 on rulesets-migrated repos, causing the detector to silently skip them.

Also fixes a pre-existing stdout-capture bug: _check_sync_pat_need used $(...) capture for its result, but print_pass / add_finding wrote to the same stdout — so SYNC_PAT-set repos spuriously emitted advisories. Result is now passed via global SYNC_PAT_NEED_RESULT.

## Files Changed

.agents/reference/auto-dispatch.md,.agents/scripts/security-posture-helper.sh,.agents/scripts/tests/test-sync-pat-detection.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 20/20 unit tests pass (bash tests/test-sync-pat-detection.sh). shellcheck clean. Integration verified: marcusquinn/aidevops (classic + SYNC_PAT set) → PASS; <webapp>/<webapp> (rulesets, no SYNC_PAT) → WARN + advisory.

Resolves #20745


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.3 plugin for [OpenCode](https://opencode.ai) v1.14.24 with claude-opus-4-7 spent 10m and 40,002 tokens on this as a headless worker.