### PR TITLE
GH#20774: t2799: remove deprecated is_rate_limit_comment alias

### DIFF
--- a/.agents/scripts/review-bot-gate-helper.sh
+++ b/.agents/scripts/review-bot-gate-helper.sh
@@ -360,11 +360,6 @@ is_non_review_comment() {
 	return 1
 }
 
-# Backwards-compat alias for any callers/tests still using the old name.
-is_rate_limit_comment() {
-	is_non_review_comment "$@"
-}
-
 bot_has_real_review() {
 	# t2139 (GH#19251): Check if a bot has posted at least one comment that
 	# is BOTH (a) not a known non-review notice AND (b) "settled" — meaning

--- a/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
+++ b/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
@@ -170,16 +170,6 @@ Recommended changes: add a null check before line 42."
 	return 0
 }
 
-test_backwards_compat_alias() {
-	# is_rate_limit_comment must still work as alias.
-	if is_rate_limit_comment "rate limit exceeded"; then
-		print_result "is_rate_limit_comment alias still functions" 0
-	else
-		print_result "is_rate_limit_comment alias still functions" 1
-	fi
-	return 0
-}
-
 # ---------- Unit tests: settled-check ----------
 
 test_settled_recent_unedited_placeholder_rejected() {
@@ -407,7 +397,6 @@ main() {
 	test_is_non_review_comment_matches_review_skipped
 	test_is_non_review_comment_matches_closed_during_review
 	test_is_non_review_comment_rejects_real_review
-	test_backwards_compat_alias
 
 	echo ""
 	echo "=== Settled check ==="


### PR DESCRIPTION
## Summary

Removed the deprecated is_rate_limit_comment() function alias from review-bot-gate-helper.sh after one release cycle. Callers should use is_non_review_comment() or is_rate_limit_only_comment() instead. Verified no internal references remain and ShellCheck passes.

## Files Changed

.agents/scripts/review-bot-gate-helper.sh,.agents/scripts/tests/test-review-bot-gate-completion-signal.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Ran ShellCheck on both modified files; verified no references to is_rate_limit_comment remain except in historical comment.

Resolves #20774


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.3 plugin for [OpenCode](https://opencode.ai) v1.14.24 with claude-haiku-4-5 spent 1m and 1,931 tokens on this as a headless worker.