### PR TITLE
GH#20756: add log_warning alias to shared-constants.sh

### DIFF
--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -593,6 +593,12 @@ log_warn() {
 	return 0
 }
 
+# Alias for log_warn — callers using the more explicit name are supported
+log_warning() {
+	log_warn "$@"
+	return 0
+}
+
 # Validate required parameter
 validate_required_param() {
 	local param_name="$1"


### PR DESCRIPTION
## Summary

Add `log_warning()` as an alias for `log_warn()` in `shared-constants.sh`.

**Root cause:** `log_warning` was called at 60+ callsites across framework helpers but only `log_warn()` was defined in `shared-constants.sh`. Every invocation of those branches failed with `log_warning: command not found`.

**Affected helpers (now fixed):**
- `.agents/scripts/planning-commit-helper.sh` — 6 callsites (lines 164, 205, 211, 304, 525, 561)
- `.agents/scripts/virustotal-helper.sh` — 3 callsites
- `.agents/scripts/plugin-loader-helper.sh` — 7+ callsites
- `.agents/scripts/tech-stack-helper.sh` — 4 callsites

**Fix:** Option 2 from the issue — add `log_warning() { log_warn "$@"; }` alias in `shared-constants.sh`. Scripts that already have local `log_warning()` definitions (`generate-skills.sh`, `skill-update-helper.sh`) continue to use their local version since they redefine after sourcing.

## Testing

- ShellCheck passes on `shared-constants.sh` with zero new violations.
- Existing callers of `log_warn` are unaffected (alias delegates to it).
- Scripts with local `log_warning()` definitions continue to use their own implementation (no override because they source shared-constants.sh first, then redefine).

Resolves #20756


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.3 plugin for [OpenCode](https://opencode.ai) v1.14.24 with claude-sonnet-4-6 spent 2m and 4,389 tokens on this as a headless worker.