### PR TITLE
GH#20795: fix YAML description pipe-injection and non-portable mktemp in prompt-guard sub-libraries

### DIFF
--- a/.agents/scripts/prompt-guard-patterns.sh
+++ b/.agents/scripts/prompt-guard-patterns.sh
@@ -105,7 +105,7 @@ _pg_load_yaml_patterns() {
 		if [[ "$line" =~ ^[[:space:]]*-[[:space:]]*severity:[[:space:]]*\"?([A-Z]+)\"?$ ]]; then
 			# Emit previous pattern if complete
 			if [[ -n "$severity" && -n "$pattern" && -n "$current_category" ]]; then
-				patterns+="${severity}|${current_category}|${description}|${pattern}"$'\n'
+				patterns+="${severity}|${current_category}|$(_pg_sanitize_delimited "$description")|${pattern}"$'\n'
 			fi
 			severity="${BASH_REMATCH[1]}"
 			description=""
@@ -134,7 +134,7 @@ _pg_load_yaml_patterns() {
 
 	# Emit last pattern
 	if [[ -n "$severity" && -n "$pattern" && -n "$current_category" ]]; then
-		patterns+="${severity}|${current_category}|${description}|${pattern}"$'\n'
+		patterns+="${severity}|${current_category}|$(_pg_sanitize_delimited "$description")|${pattern}"$'\n'
 	fi
 
 	if [[ -z "$patterns" ]]; then

--- a/.agents/scripts/prompt-guard-tests.sh
+++ b/.agents/scripts/prompt-guard-tests.sh
@@ -396,7 +396,7 @@ _cmd_test_yaml_loading() {
 	# Test YAML loading with a temporary YAML file (pure-bash parser — no yq/python3 needed)
 	# Format: category-keyed blocks with severity as list item start trigger
 	local tmp_yaml
-	tmp_yaml=$(mktemp /tmp/pg-test-XXXXXX.yaml)
+	tmp_yaml=$(mktemp "${TMPDIR:-/tmp}/pg-test-XXXXXX")
 	cat >"$tmp_yaml" <<'YAML_EOF'
 yaml_test:
   - severity: "HIGH"


### PR DESCRIPTION
## Summary

Three correctness fixes from Gemini review on PR #20746, all verified against actual code before applying.

### Fix 1 — Pipe-injection in YAML description field (prompt-guard-patterns.sh:108 and :137)

The `_pg_load_yaml_patterns` function builds a pipe-delimited pattern string `severity|category|description|pattern`. The `description` value was inserted unsanitized. A YAML description containing a literal `|` character would produce a malformed record, misparse the category/pattern on readback in `_pg_scan_patterns_from_stream`, and corrupt regex matching.

**Fix:** wrap both emit sites (line 108 mid-loop, line 137 last-pattern) with `_pg_sanitize_delimited` — the same function already used at `prompt-guard-helper.sh:265` for `matched_text`.

### Fix 2 — Non-portable mktemp template (prompt-guard-tests.sh:399)

`mktemp /tmp/pg-test-XXXXXX.yaml` silently fails to randomize on macOS (BSD mktemp) because the X-placeholder must be at the END of the template. In practice the file is created literally as `/tmp/pg-test-XXXXXX.yaml` with no substitution — confirmed locally: a second `mktemp` call for the same template exits 1 with "File exists". This causes flaky test failures under concurrent test runs.

**Fix:** `mktemp "${TMPDIR:-/tmp}/pg-test-XXXXXX"` — matches the pattern used in `prompt-guard-helper.sh:1104`.

## Verification

- `shellcheck` on both modified files: zero violations
- Pre-commit hook: passed

Resolves #20795

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.3 plugin for [OpenCode](https://opencode.ai) v1.14.24 with claude-sonnet-4-6 spent 3m and 6,200 tokens on this as a headless worker.