### PR TITLE
GH#20796: quote repo_slug in log_error and extract _extract_github_slug helper

### DIFF
--- a/.agents/scripts/claim-task-id.sh
+++ b/.agents/scripts/claim-task-id.sh
@@ -407,8 +407,7 @@ create_github_issue() {
 	# and the bare-fallback path for the parent-task warn call. Must run
 	# BEFORE delegation because the delegation branch returns early.
 	local _slug_for_warn=""
-	_slug_for_warn=$(git -C "$repo_path" remote get-url "${REMOTE_NAME:-origin}" 2>/dev/null \
-		| sed 's|.*github\.com[:/]||;s|\.git$||' || true)
+	_slug_for_warn=$(_extract_github_slug "$repo_path" "${REMOTE_NAME:-origin}")
 
 	# Try rich delegation first (t1324)
 	local issue_num
@@ -608,6 +607,17 @@ check_framework_routing() {
 #               no labels provided, platform != github, or gh not available.
 # ---------------------------------------------------------------------------
 
+# _extract_github_slug — extract owner/repo slug from a git remote URL.
+# Args: $1 repo_path, $2 remote_name (default: origin).
+# Prints the slug (owner/repo) on stdout; prints nothing on failure.
+_extract_github_slug() {
+	local repo_path="$1"
+	local remote_name="${2:-origin}"
+	git -C "$repo_path" remote get-url "$remote_name" 2>/dev/null \
+		| sed 's|.*github\.com[:/]||;s|\.git$||' || true
+	return 0
+}
+
 # _validate_labels_exist — check that every label in $2 exists in repo $1.
 # Args: $1 repo_slug (owner/repo), $2 comma-separated label names.
 # Returns: 0 = all valid (or fail-open), 1 = invalid labels found.
@@ -665,7 +675,7 @@ _validate_labels_exist() {
 
 	if [[ -n "$invalid_labels" ]]; then
 		log_error "Pre-flight label validation failed — invalid label(s): ${invalid_labels}"
-		log_error "  Run: gh label list --repo ${repo_slug} | grep -i '<name>'"
+		log_error "  Run: gh label list --repo \"${repo_slug}\" | grep -i '<name>'"
 		log_error "  Claim aborted — counter NOT advanced."
 		return 1
 	fi
@@ -1041,8 +1051,7 @@ main() {
 	# offline, dry-run, or when no title is supplied.
 	if [[ "$NO_ISSUE" == "false" && "$OFFLINE_MODE" == "false" && "$DRY_RUN" == "false" && -n "$TASK_TITLE" ]]; then
 		local _disc_slug=""
-		_disc_slug=$(git -C "$REPO_PATH" remote get-url "$REMOTE_NAME" 2>/dev/null \
-			| sed 's|.*github\.com[:/]||;s|\.git$||' || true)
+		_disc_slug=$(_extract_github_slug "$REPO_PATH" "$REMOTE_NAME")
 		if [[ -n "$_disc_slug" ]]; then
 			local _disc_rc=0
 			_pre_claim_discovery_pass "$TASK_TITLE" "$_disc_slug" || _disc_rc=$?
@@ -1068,8 +1077,7 @@ main() {
 		&& [[ "$platform" == "github" ]] \
 		&& [[ -n "$TASK_LABELS" ]]; then
 		local _val_slug=""
-		_val_slug=$(git -C "$REPO_PATH" remote get-url "$REMOTE_NAME" 2>/dev/null \
-			| sed 's|.*github\.com[:/]||;s|\.git$||' || true)
+		_val_slug=$(_extract_github_slug "$REPO_PATH" "$REMOTE_NAME")
 		if [[ -n "$_val_slug" ]]; then
 			if ! _validate_labels_exist "$_val_slug" "$TASK_LABELS"; then
 				return 3


### PR DESCRIPTION
## Summary

Addresses two Gemini review bot suggestions from PR #20744 that were left unresolved.

Both premises were verified against the current code before implementing.

### Fix 1 — Quote `${repo_slug}` in `log_error` (line 668)

The error message suggesting `gh label list --repo ${repo_slug}` was missing quotes around the slug. Without quotes, the copy-paste command is shell-unsafe if the slug contains spaces or special characters. Now emits `gh label list --repo "${repo_slug}"`.

### Fix 2 — Extract `_extract_github_slug` helper (line 1072)

The pattern:

```bash
git -C "$REPO_PATH" remote get-url "$REMOTE_NAME" 2>/dev/null \
    | sed 's|.*github\.com[:/]||;s|\.git$||' || true
```

was duplicated in three places:
- `create_github_issue()` — lines 410-411 (`_slug_for_warn`)
- `main()` — lines 1044-1045 (`_disc_slug`)
- `main()` — lines 1071-1072 (`_val_slug`)

Consolidated into `_extract_github_slug(repo_path, remote_name)` placed alongside `_validate_labels_exist` in the label-validation section. All three call sites updated.

## Verification

- `shellcheck .agents/scripts/claim-task-id.sh` — 0 violations
- Pre-commit hook passed (ratchet — no new violations)
- Pre-push quality gate passed

Resolves #20796
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.3 plugin for [OpenCode](https://opencode.ai) v1.14.24 with claude-sonnet-4-6 spent 4m and 7,318 tokens on this as a headless worker.