### PR TITLE
GH#20797: restore blank line before markdown header in conflict feedback

### DIFF
--- a/.agents/scripts/pulse-merge-feedback.sh
+++ b/.agents/scripts/pulse-merge-feedback.sh
@@ -395,6 +395,7 @@ _build_conflict_feedback_section() {
 		The previous worker's PR #${pr_number} (\`${pr_title}\`) developed merge conflicts with
 		\`${default_branch}\` that could not be resolved by \`gh pr update-branch\` (server-side fast-forward).
 		The conflicts are semantic — the same files were modified on both branches${pr_file_count:+ (${pr_file_count} files touched)}.${scope_block}
+
 		### Files in the conflicting PR
 
 		\`\`\`


### PR DESCRIPTION
GH#20797: restore blank line before markdown header in conflict feedback

## What

Restore the blank line between the conflict-description sentence and the
`### Files in the conflicting PR` markdown header in
`.agents/scripts/pulse-merge-feedback.sh`.

## Why

When `scope_block` is empty (no scope-leak warning fires), the heredoc
produced no blank line before the header — broken Markdown rendering in
the GitHub comment. When `scope_block` is non-empty it already ends with
`$'\n'`, so the header was coincidentally preceded by a blank line. This
inconsistency was caught by gemini-code-assist on PR #20742.

## How

One-line insertion: blank line in the heredoc between line 397 and the
header line. shellcheck passes, pre-commit passes.

Resolves #20797


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.3 plugin for [OpenCode](https://opencode.ai) v1.14.24 with claude-sonnet-4-6 spent 3m and 3,528 tokens on this as a headless worker.