### PR TITLE
GH#20798: fix heredoc tag regex and gh write boundary anchors in quality-hooks-signature

### DIFF
--- a/.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs
@@ -65,7 +65,9 @@ function _stripHeredocBodies(cmd) {
       continue;
     }
     // Detect a heredoc opener: <<[-] with optional quotes around the tag
-    const m = line.match(/<<-?\s*['"]?(\w+)['"]?/);
+    // Use [\w-]+ (not \w+) because bash allows hyphens in heredoc tags
+    // e.g. <<EOF-TAG, which \w+ would not match.
+    const m = line.match(/<<-?\s*['"]?([\w-]+)['"]?/);
     if (m) {
       terminator = m[1];
     }
@@ -103,7 +105,9 @@ function _stripQuotedStrings(line) {
  *      unrelated tools like `rg "gh issue create"` (Failures 2 & 3).
  *   3. Command-boundary anchor — requires `gh` to be at a shell command
  *      start: beginning of the trimmed line, or immediately after one of
- *      ; & | ( ` $( — preventing matches mid-argument after plain whitespace.
+ *      ; & | ( ` $( ! — preventing matches mid-argument after plain whitespace.
+ *      Also allows optional prefixes (sudo, time, env VAR=val) between the
+ *      boundary and `gh` to avoid false negatives on prefixed invocations.
  *
  * @param {string} cmd - Raw bash command string (may be multi-line)
  * @returns {boolean}
@@ -112,8 +116,12 @@ export function isGhWriteCommand(cmd) {
   // Layer 3 pattern: gh must start a command segment.
   // Boundaries: start-of-trimmed-line (^), semicolon, ampersand (covers &&),
   // pipe (covers ||), open-paren (subshell / command-sub), backtick, literal $(.
+  // Also: ! (bash negation operator — gh still executes, needs sig).
+  // After a boundary, allow optional common command prefixes (sudo, time,
+  // env with optional VAR=val assignments) before gh to avoid false negatives
+  // for patterns like `sudo gh issue create` or `env GH_TOKEN=xxx gh pr create`.
   const ghWritePattern =
-    /(^|[;&|(`]|\$\()\s*gh\s+(pr\s+(create|comment)|issue\s+(create|comment))\b/;
+    /(^|[;&|(`!]|\$\()\s*(?:(?:sudo|time|env(?:\s+\w+=\S+)*)\s+)*gh\s+(pr\s+(create|comment)|issue\s+(create|comment))\b/;
 
   // Layer 1: strip heredoc bodies from the full command string first
   const noHeredoc = _stripHeredocBodies(cmd);


### PR DESCRIPTION
## Summary

Two correctness fixes in `.agents/plugins/opencode-aidevops/quality-hooks-signature.mjs` addressing unaddressed Gemini review feedback from PR #20739.

## Changes

### Fix 1 — `_stripHeredocBodies` heredoc terminator regex (line 68)

**Premise:** Bash allows hyphens in heredoc tags (`<<EOF-TAG` is valid Bash). The prior regex `(\w+)` only matches `[a-zA-Z0-9_]`, so tags like `EOF-TAG` are silently skipped — the heredoc body is not stripped, leaving those lines visible to the gh-write pattern and creating false positives.

**Fix:** Changed capture group from `(\w+)` to `([\w-]+)`.

### Fix 2 — `isGhWriteCommand` command boundary anchors (line 116)

**Premise:** The prior boundary set `(^|[;&|(\`]|\$\()` misses:
- `! gh issue create` — `!` is a Bash negation operator; `gh` still executes and still needs a signature
- `env GH_TOKEN=xxx gh issue create` — common CI/scripting pattern; `gh` runs with modified env
- `sudo gh ...`, `time gh ...` — less common but valid prefix patterns

**Fix:** Added `!` to the boundary character class and added an optional prefix group `(?:(?:sudo|time|env(?:\s+\w+=\S+)*)\s+)*` between the boundary and `gh`.

## Verification

- Pre-commit and pre-push hooks passed
- No shell files modified (JS only), shellcheck not applicable
- Both fixes are in `isGhWriteCommand` / `_stripHeredocBodies` — unit-testable with existing test infrastructure

Resolves #20798
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.3 plugin for [OpenCode](https://opencode.ai) v1.14.24 with claude-sonnet-4-6 spent 5m and 10,317 tokens on this as a headless worker.