### PR TITLE
GH#20790: simplify jq abs in co-temporality guard, remove 2>/dev/null

### DIFF
--- a/.agents/scripts/pulse-nmr-approval.sh
+++ b/.agents/scripts/pulse-nmr-approval.sh
@@ -345,9 +345,8 @@ _nmr_application_has_automation_signature() {
 			| jq -r '.created_at // ""' 2>/dev/null) || issue_created_at=""
 		if [[ -n "$issue_created_at" && -n "$label_at" ]]; then
 			local nmr_creation_gap
-			nmr_creation_gap=$(jq -n --arg c "$issue_created_at" --arg l "$label_at" \
-				'(($l | fromdateiso8601) - ($c | fromdateiso8601)) | if . < 0 then (0 - .) else . end | floor' \
-				2>/dev/null) || nmr_creation_gap=999999
+		nmr_creation_gap=$(jq -n --arg c "$issue_created_at" --arg l "$label_at" \
+			'(($l | fromdateiso8601) - ($c | fromdateiso8601)) | abs | floor') || nmr_creation_gap=999999
 			[[ "$nmr_creation_gap" =~ ^[0-9]+$ ]] || nmr_creation_gap=999999
 			if (( nmr_creation_gap <= 300 )); then
 				return 0


### PR DESCRIPTION
## What

Simplified the `jq` co-temporality gap calculation in `_nmr_applied_by_scanner_as_creation_default` (pulse-nmr-approval.sh:348-349):

- Replaced manual `if . < 0 then (0 - .) else . end` with `jq`'s built-in `abs` function (available since jq 1.5)
- Removed `2>/dev/null` from the `jq` call so syntax errors surface to stderr for debugging; the existing `|| nmr_creation_gap=999999` fallback still handles parse failures safely

## Why

Gemini Code Assist flagged both patterns on PR #20761. Both suggestions are correct:
- `abs` is cleaner and idiomatic jq
- Suppressing stderr on a calculation that recently landed (GH#20758) reduces debuggability without benefit

## Testing

- `jq` `abs` produces correct output for both positive and negative time differences (verified locally)
- `shellcheck` passes with zero violations
- The fallback `|| nmr_creation_gap=999999` with the `[[ "$nmr_creation_gap" =~ ^[0-9]+$ ]] || nmr_creation_gap=999999` guard below it still protects against jq errors

Resolves #20790

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.3 plugin for [OpenCode](https://opencode.ai) v1.14.24 with claude-sonnet-4-6 spent 3m and 6,664 tokens on this as a headless worker.