### PR TITLE
GH#20791: robustify release_interactive_claim_on_merge keyword regex and add pre-guard

### DIFF
--- a/.agents/scripts/shared-claim-lifecycle.sh
+++ b/.agents/scripts/shared-claim-lifecycle.sh
@@ -79,6 +79,14 @@ release_interactive_claim_on_merge() {
 	local pr_labels="${4:-}"
 	local _log="${LOGFILE:-/dev/null}"
 
+	# Pre-Guard: if the caller already provided labels and the PR is NOT
+	# origin:interactive, skip the expensive gh pr view body fetch — Guard 3
+	# would return 0 at that point anyway. Only skip when labels are non-empty
+	# so callers that omit the arg still fall through to the full path. (GH#20791)
+	if [[ -n "$pr_labels" ]] && [[ ",${pr_labels}," != *",origin:interactive,"* ]]; then
+		return 0
+	fi
+
 	# Guard 1: no linked issue from strict caller extraction → try permissive
 	# fallback for planning-only PRs that use "Ref #NNN" / "For #NNN".
 	# Strict _extract_linked_issue (callers) only matches closing keywords and
@@ -91,7 +99,7 @@ release_interactive_claim_on_merge() {
 		_pr_body=$(gh pr view "$pr_number" --repo "$repo_slug" \
 			--json body --jq '.body // empty' 2>/dev/null) || _pr_body=""
 		linked_issue=$(printf '%s' "$_pr_body" \
-			| grep -ioE '(close[ds]?|fix(es|ed)?|resolve[ds]?|ref(s|erences?)?|for)\s+#[0-9]+' \
+			| grep -ioE '\b(close[ds]?|fix(es|ed)?|resolve[ds]?|ref(s|erences?)?|for)\b[[:space:]]+#[0-9]+' \
 			| head -1 | grep -oE '[0-9]+')
 	fi
 	[[ -z "$linked_issue" ]] && return 0

--- a/.agents/scripts/tests/test-full-loop-merge-auto-release.sh
+++ b/.agents/scripts/tests/test-full-loop-merge-auto-release.sh
@@ -384,6 +384,75 @@ else
 fi
 
 # =============================================================================
+# Test 10 — Early-return pre-guard (GH#20791): pr_labels provided without
+#            origin:interactive → return 0 immediately, no gh API calls at all.
+#            Verifies the optimization that skips the expensive body fetch when
+#            the caller already knows the PR is not origin:interactive.
+# =============================================================================
+: >"$GH_CALLS"
+: >"$RELEASE_CALLS"
+: >"$LOGFILE"
+STAMP="${CLAIM_STAMP_DIR}/marcusquinn-aidevops-8810.json"
+printf '{"pid":1234}\n' >"$STAMP"
+# Set body so that if the body IS fetched, linked_issue would be extracted
+GH_BODY_RESPONSE="For #8810 — planning-only PR."
+GH_LABELS_RESPONSE="origin:worker,tier:standard"
+
+# Pass pr_labels as 4th argument — caller already knows it's not interactive
+release_interactive_claim_on_merge "63" "marcusquinn/aidevops" "" "origin:worker,tier:standard"
+
+if [[ -f "$STAMP" ]]; then
+	pass "pre-guard: pr_labels provided without origin:interactive → stamp untouched"
+else
+	fail "pre-guard: pr_labels provided without origin:interactive → stamp untouched" \
+		"stamp was removed when caller-provided pr_labels lacked origin:interactive"
+fi
+
+if [[ ! -s "$GH_CALLS" ]]; then
+	pass "pre-guard: pr_labels provided without origin:interactive → no gh API calls made"
+else
+	fail "pre-guard: pr_labels provided without origin:interactive → no gh API calls made" \
+		"gh was called even though pr_labels already indicated non-interactive: $(cat "$GH_CALLS")"
+fi
+
+if ! grep -q "release" "$RELEASE_CALLS" 2>/dev/null; then
+	pass "pre-guard: release NOT called when pr_labels lacks origin:interactive"
+else
+	fail "pre-guard: release NOT called when pr_labels lacks origin:interactive" \
+		"release was called when pr_labels lacked origin:interactive"
+fi
+
+# =============================================================================
+# Test 11 — Word-boundary false-positive prevention (GH#20791):
+#            "prefix #NNN" body text should NOT extract NNN via the "fix"
+#            keyword. Without \b, "fix" at the tail of "prefix" followed by
+#            whitespace+#number would produce a false match.
+# =============================================================================
+: >"$GH_CALLS"
+: >"$RELEASE_CALLS"
+: >"$LOGFILE"
+STAMP="${CLAIM_STAMP_DIR}/marcusquinn-aidevops-8811.json"
+printf '{"pid":1234}\n' >"$STAMP"
+GH_BODY_RESPONSE="Update the prefix #8811 to include the new format."
+GH_LABELS_RESPONSE="origin:interactive,tier:standard"
+
+release_interactive_claim_on_merge "65" "marcusquinn/aidevops" ""
+
+if [[ -f "$STAMP" ]]; then
+	pass "word-boundary: 'fix' inside 'prefix' → stamp untouched (no false match)"
+else
+	fail "word-boundary: 'fix' inside 'prefix' → stamp untouched (no false match)" \
+		"stamp was removed due to false 'fix' match inside 'prefix #8811'"
+fi
+
+if ! grep -q "release" "$RELEASE_CALLS" 2>/dev/null; then
+	pass "word-boundary: release NOT called due to false 'fix' in 'prefix'"
+else
+	fail "word-boundary: release NOT called due to false 'fix' in 'prefix'" \
+		"release was called from false 'fix' match inside 'prefix'"
+fi
+
+# =============================================================================
 # Summary
 # =============================================================================
 echo


### PR DESCRIPTION
## Summary

Two robustness fixes to `release_interactive_claim_on_merge` in `shared-claim-lifecycle.sh`, addressing gemini-code-assist review feedback on PR #20760.

### Fix 1 — Regex portability and word boundaries (HIGH, GH#20791)

The keyword extraction grep used non-POSIX `\s` and had no word boundaries, allowing false positives like `fix` inside "prefix #NNN" matching as a closing keyword.

- `\s` to `[[:space:]]` (POSIX ERE portability)
- Added `\b` word boundaries around all keywords to prevent substring matches
- Consistent with existing codebase use of `\b` in `dispatch-dedup-helper.sh`

### Fix 2 — Early-return pre-guard (MEDIUM, GH#20791)

When the caller already provides `pr_labels` that don't include `origin:interactive`, the function previously fetched the PR body unnecessarily before Guard 3 would return 0 anyway. The new pre-guard short-circuits immediately, saving one `gh pr view` API call per non-interactive PR merge.

### Tests

Added regression tests 10 and 11 to `test-full-loop-merge-auto-release.sh`:
- Test 10: verifies pre-guard fires and no gh API calls occur when `pr_labels` is provided without `origin:interactive`
- Test 11: verifies word-boundary fix prevents false match of `fix` inside "prefix #NNN"

All 22 tests pass (`bash .agents/scripts/tests/test-full-loop-merge-auto-release.sh`).

Resolves #20791

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.3 plugin for [OpenCode](https://opencode.ai) v1.14.24 with claude-sonnet-4-6 spent 8m and 24,619 tokens on this as a headless worker.