### PR TITLE
t2816: /setup-git slash command + per-repo setup debt aggregator (Phase 1)

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -141,7 +141,7 @@ Use for: decomposition epics, roadmap trackers, research summaries. **Do not use
 
 Completion: NEVER mark `[x]` without merged PR (`pr:#NNN`) or `verified:YYYY-MM-DD`. Use `task-complete-helper.sh`. Every completed task must link to its verification evidence — work without an audit trail is unverifiable and may be reverted.
 
-**Known limitation — issue-sync TODO auto-completion (t2029 → t2166):** `issue-sync.yml` cannot auto-push to `main` without `SYNC_PAT` (fine-grained PAT, Contents: Read and write). Set: `gh secret set SYNC_PAT --repo <owner>/<repo> --body "<PAT>"`. Without it, the workflow posts a remediation comment with `task-complete-helper.sh` workaround. `SYNC_PAT` is per-repo. Full setup and known false-positive (t2252): `reference/auto-dispatch.md`.
+**Known limitation — issue-sync TODO auto-completion (t2029 → t2166):** `issue-sync.yml` cannot auto-push to `main` without `SYNC_PAT` (fine-grained PAT, Contents: Read and write). **Guided fix:** run `/setup-git` in your AI assistant — it walks all affected repos with pre-filled token-creation URLs (see `reference/sync-pat-platforms.md`). Manual fix per repo: create the PAT, then `gh secret set SYNC_PAT --repo <owner>/<repo>` (interactive prompt, NOT `--body` which leaks to shell history). Without SYNC_PAT, the workflow posts a remediation comment with a `task-complete-helper.sh` workaround. `SYNC_PAT` is per-repo. Full setup and known false-positive (t2252): `reference/auto-dispatch.md`.
 
 Code changes need worktree + PR. Workers NEVER edit TODO.md.
 
@@ -165,7 +165,7 @@ Use `/routine` to design, dry-run, and schedule these definitions. Reference: `.
 
 **Cross-repo awareness**: The supervisor manages tasks across all repos in `~/.config/aidevops/repos.json` where `pulse: true`. Each repo entry has a `slug` field (`owner/repo`) — ALWAYS use this for `gh` commands, never guess org names. Use `gh issue list --repo <slug>` and `gh pr list --repo <slug>` for each pulse-enabled repo to get the full picture. Repos with `"local_only": true` have no GitHub remote — skip `gh` operations on them. Repo paths may be nested (e.g., `~/Git/cloudron/netbird-app`), not just `~/Git/<name>`.
 
-**Repo registration**: When you create or clone a new repo (via `gh repo create`, `git clone`, `git init`, etc.), add it to `~/.config/aidevops/repos.json` immediately. Every repo the user works with should be registered — unregistered repos are invisible to cross-repo tools (pulse, health dashboard, session time, contributor stats).
+**Repo registration**: When you create or clone a new repo (via `gh repo create`, `git clone`, `git init`, etc.), add it to `~/.config/aidevops/repos.json` immediately. Every repo the user works with should be registered — unregistered repos are invisible to cross-repo tools (pulse, health dashboard, session time, contributor stats). After registering, run `/setup-git` to apply per-repo platform secrets (currently `SYNC_PAT` for GitHub, with GitLab/Gitea/Bitbucket coming) — see `reference/sync-pat-platforms.md`.
 
 **repos.json structure (CRITICAL):** The file is `{"initialized_repos": [...], "git_parent_dirs": [...]}`. New repo entries MUST be appended inside the `initialized_repos` array — NEVER as top-level keys. After ANY write, validate: `jq . ~/.config/aidevops/repos.json > /dev/null`. A malformed file silently breaks the pulse for ALL repos.
 

--- a/.agents/aidevops/onboarding.md
+++ b/.agents/aidevops/onboarding.md
@@ -32,6 +32,22 @@ Hand-fix: `"tools": {}` (not `[]`), `"type": "local"|"remote"`, `"tool_name": tr
 3. **Capture work type** (web-dev, devops, seo, wordpress, other): `onboarding-helper.sh save-work-type devops`
 4. **Show status**: `onboarding-helper.sh status`
 5. **Guide service-by-service setup**: purpose → credential source → setup command → verification
+6. **Per-repo platform setup**: after `gh auth login` succeeds, mention `/setup-git` for per-repo secrets (SYNC_PAT for issue-sync, etc.) — see "Scope" note below.
+
+## Scope: Per-Account vs Per-Repo
+
+`/onboarding` (this wizard) handles **per-account** setup — credentials and tooling that apply globally to a user or workstation:
+
+- Auth tokens stored in `~/.config/aidevops/credentials.sh` or `gopass` (one set of values, used everywhere)
+- Platform CLI logins: `gh auth login`, `glab auth login`, `tea login` (one auth per platform per account)
+- AI assistant API keys, hosting tokens, SEO service credentials
+
+`/setup-git` handles **per-repo** platform configuration — secrets that must be set on each individual remote repo:
+
+- `SYNC_PAT` (GitHub Actions secret used by `issue-sync.yml` to push TODO.md auto-completion past branch protection)
+- Future: GitLab CI variables, Gitea Actions secrets, Bitbucket Pipelines variables — same model, different platform UIs
+
+The two workflows compose: `/onboarding` first (you need `gh` to be authenticated before any per-repo helper can run), `/setup-git` second (run when new repos are registered or when SYNC_PAT advisories appear in the session greeting toast).
 
 ## Service Catalog
 

--- a/.agents/reference/sync-pat-platforms.md
+++ b/.agents/reference/sync-pat-platforms.md
@@ -1,0 +1,225 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# SYNC_PAT — Platform Matrix
+
+Canonical reference for the `SYNC_PAT` secret used by the `issue-sync`
+workflow across supported git platforms. Consumed by `/setup-git` to
+generate platform-specific PAT-creation URLs and secret-set instructions.
+
+## What `SYNC_PAT` is
+
+A platform personal access token configured as a **per-repo** secret named
+`SYNC_PAT`. The `issue-sync` reusable workflow uses it to authenticate as the
+maintainer (instead of the platform's bot identity) when:
+
+- Creating issues from `TODO.md` entries that lack `ref:GH#NNN`
+- Pushing back the auto-injected `chore: sync ref:GH#NNN to TODO.md [skip ci]`
+  commit after the issue is created
+
+When unset, the workflow falls back to the platform's default token (`GITHUB_TOKEN`
+on GitHub Actions). Issues are then authored by the bot, which:
+
+1. Reports `author_association: NONE` (or platform equivalent), tripping the
+   t2449 worker-briefed auto-merge gate.
+2. Cannot push to a branch-protected default branch on most platforms,
+   leaving TODO.md sync commits silently failing.
+
+## Security posture (cross-platform)
+
+Three rules apply on every platform:
+
+1. **Per-repo PAT**, never an org-wide / account-wide token. Blast radius of a
+   leaked token is limited to one repo's contents+issues+PRs.
+2. **Fine-grained / scoped to specific repos**, never "all repos" or
+   "classic / personal scope". Most platforms now have a fine-grained option;
+   use it.
+3. **Save to password manager at creation time**. Most platforms only show
+   the token once. Rotation reminders (90 days default) belong in the
+   password manager entry, not in shell scripts.
+
+## Platform Matrix
+
+| Platform | Status | Native CLI | Secret Storage | Notes |
+|----------|--------|------------|----------------|-------|
+| GitHub | **Primary** (Phase 1) | `gh` | `gh secret set` | Fine-grained PAT, query-string scope encoding |
+| GitLab | Stub (Phase 2) | `glab` | `glab variable set` | Project-scoped PAT, manual scope selection |
+| Gitea | Stub (Phase 2) | `tea` | Manual repo secret UI | Token + repo-secret; no native query-string encoding |
+| Bitbucket | Stub (Phase 2) | (none) | Repository variables UI | App passwords; no native CLI; setup is fully manual |
+
+---
+
+## GitHub (Primary, Phase 1 implemented)
+
+### PAT creation URL
+
+The fine-grained PAT page accepts query-string parameters that pre-fill the
+form. Substitute placeholders as marked:
+
+```text
+https://github.com/settings/personal-access-tokens/new
+  ?name=aidevops-sync-<SLUG_SAFE>
+  &description=aidevops%20issue-sync%20PAT%20for%20<SLUG_URLENC>
+  &expiration=90
+  &target_name=<OWNER>
+  &permissions=contents:write,issues:write,pull_requests:write,metadata:read
+```
+
+Where:
+
+- `<SLUG_SAFE>` — the repo slug with `/` replaced by `-` (e.g., `awardsapp-awardsapp`)
+- `<SLUG_URLENC>` — URL-encoded slug (e.g., `awardsapp%2Fawardsapp`)
+- `<OWNER>` — the org/user that owns the repo
+
+The operator still has to:
+
+- Set "Repository access → Only select repositories → `<SLUG>`" (the URL
+  pre-selects `target_name` but doesn't auto-pick the repo from the dropdown)
+- Click Generate
+- Save the token to their password manager **before** closing the page
+
+### Required scopes
+
+Minimum scopes for the `issue-sync.yml` workflow:
+
+| Scope | Why |
+|-------|-----|
+| `contents: write` | Push the `chore: sync ref:GH#NNN` commit back to default branch |
+| `issues: write` | Create issues from TODO.md entries |
+| `pull_requests: write` | Update PR titles/bodies during issue-sync follow-ups |
+| `metadata: read` | Required by all fine-grained PATs (auto-applied) |
+
+Do NOT add `actions: read/write` (workflow can't trigger itself), `secrets`
+(only repo admins should manage secrets), or any account-wide scope.
+
+### Setting the secret
+
+```bash
+# Interactive prompt (recommended — token never lands in shell history):
+gh secret set SYNC_PAT --repo <SLUG>
+
+# DO NOT do this — leaks via process listing and shell history:
+# gh secret set SYNC_PAT --repo <SLUG> --body "$VALUE"
+```
+
+### Verification
+
+```bash
+gh secret list --repo <SLUG> | grep SYNC_PAT
+# Or via the helper:
+~/.aidevops/agents/scripts/setup-debt-helper.sh verify-secret <SLUG> SYNC_PAT
+```
+
+The helper never reads the secret value — it only confirms presence.
+
+### Detection of need
+
+`security-posture-helper.sh` Phase 7 (`_check_sync_pat_need`) determines
+whether a repo needs `SYNC_PAT` based on:
+
+1. Does `.github/workflows/issue-sync.yml` exist? (No → not needed.)
+2. Is the default branch protected (classic protection OR rulesets, t2806)?
+   (No → not needed.)
+3. Does protection require approving reviews? (No → not needed.)
+4. Is `SYNC_PAT` already set? (Yes → not needed.)
+
+If all four conditions resolve to "this repo needs `SYNC_PAT`", an advisory
+file is written at `~/.aidevops/advisories/sync-pat-<SLUG_SAFE>.advisory` and
+the `setup-debt-helper.sh` aggregator picks it up for the toast warning + the
+`/setup-git` walkthrough.
+
+---
+
+## GitLab (Stub — Phase 2)
+
+GitLab personal access tokens are configured at:
+
+```text
+https://gitlab.com/-/user_settings/personal_access_tokens
+```
+
+(Self-hosted: substitute the host.)
+
+GitLab's URL accepts a `name` and `scopes` query string but the form is more
+restrictive than GitHub's — pre-filling does not auto-select scope checkboxes
+in all UI versions. The Phase 2 implementation will:
+
+- Detect platform from `repos.json`
+- Emit the URL with `name=aidevops-sync-<SLUG_SAFE>` pre-filled
+- List required scopes textually for the operator to tick:
+  - `api`
+  - `read_repository`
+  - `write_repository`
+- Use `glab variable set --repo <SLUG> SYNC_PAT` for the secret-set step
+
+Until Phase 2 lands, treat GitLab as manual-setup. The `security-posture-helper.sh`
+detection layer is GitHub-only today; GitLab CI uses different auth primitives
+and the issue-sync workflow doesn't yet have a GitLab equivalent.
+
+---
+
+## Gitea (Stub — Phase 2)
+
+Gitea tokens are configured per-instance at:
+
+```text
+https://<GITEA_HOST>/user/settings/applications
+```
+
+Required scopes: `write:repository`, `write:issue`. There is no native
+query-string encoding — the operator picks scopes from a UI list.
+
+Setting a repo secret via the `tea` CLI:
+
+```bash
+tea token create --name aidevops-sync-<SLUG_SAFE>
+# Then add to repo via UI: Settings → Secrets → New
+```
+
+Until Phase 2 lands, treat Gitea as manual-setup.
+
+---
+
+## Bitbucket (Stub — Phase 2)
+
+Bitbucket uses **App passwords** rather than fine-grained PATs:
+
+```text
+https://bitbucket.org/account/settings/app-passwords/new
+```
+
+Required permissions: `Repositories: Write`, `Issues: Write`,
+`Pull requests: Write`. There is no native CLI for setting Pipelines
+secured variables — the operator does it via:
+
+```text
+Repository → Settings → Repository variables → Add variable
+```
+
+with the name `SYNC_PAT` and "Secured" enabled.
+
+Until Phase 2 lands, treat Bitbucket as manual-setup. Phase 2 will add a
+guided URL flow but cannot automate the variable-set step (no CLI exists).
+
+---
+
+## Phase 2+ TODO
+
+- Detect platform from `repos.json::platform` field and route in
+  `setup-debt-helper.sh` and `/setup-git`
+- Generate GitLab URL with `name=` query param + scope hint
+- Add Gitea + Bitbucket guided walkthroughs (URL + manual instructions)
+- Add `setup-debt-helper.sh verify-secret` GitLab/Gitea/Bitbucket backends
+- Surface PAT expiry advisory: warn 14 days before expiry (requires reading
+  expiry from secret-manifest.json — Phase 2 deliverable)
+
+## Cross-references
+
+- `scripts/commands/setup-git.md` — slash command spec (this matrix is its source of truth)
+- `security-posture-helper.sh::_check_sync_pat_need` — detection layer
+- `security-posture-helper.sh::_emit_sync_pat_advisory` — advisory writer
+- `aidevops-update-check.sh::_check_advisories` — advisory aggregation
+- `setup-debt-helper.sh` — count + slug aggregation for toast/CLI
+- `reference/auto-dispatch.md` — t2374 SYNC_PAT detection origin
+- `reference/auto-merge.md` — t2449 worker-briefed auto-merge gate
+- `aidevops/onboarding.md` — per-account auth (the sister command)

--- a/.agents/scripts/aidevops-update-check.sh
+++ b/.agents/scripts/aidevops-update-check.sh
@@ -333,6 +333,19 @@ _check_advisories() {
 		return 0
 	fi
 
+	# t2816: prepend a single aggregated [WARN] line for setup debt so the
+	# OpenCode plugin classifier (greeting.mjs) escalates the toast variant
+	# to warning when there is non-zero debt. The per-repo [ADVISORY] lines
+	# below remain as info-tier follow-up detail.
+	local setup_debt_helper="$SCRIPT_DIR/setup-debt-helper.sh"
+	if [[ -x "$setup_debt_helper" ]]; then
+		local debt_line
+		debt_line=$("$setup_debt_helper" summary --format=toast 2>/dev/null) || debt_line=""
+		if [[ -n "$debt_line" ]]; then
+			advisories_output="$debt_line"
+		fi
+	fi
+
 	local advisory_file
 	for advisory_file in "$advisories_dir"/*.advisory; do
 		[[ -f "$advisory_file" ]] || continue

--- a/.agents/scripts/commands/setup-git.md
+++ b/.agents/scripts/commands/setup-git.md
@@ -1,0 +1,205 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# /setup-git — Guided Per-Repo Platform Secret Setup
+
+<!-- AI-CONTEXT-START -->
+
+## Quick Reference
+
+- **Command**: `/setup-git`
+- **Aggregator**: `~/.aidevops/agents/scripts/setup-debt-helper.sh`
+- **Detector**: `~/.aidevops/agents/scripts/security-posture-helper.sh` (Phase 7)
+- **Platform matrix**: `reference/sync-pat-platforms.md`
+- **Sister command**: `/onboarding` — per-account auth (different scope)
+
+## Scope
+
+`/setup-git` is **per-repo platform secret setup** — most importantly `SYNC_PAT`, the
+fine-grained PAT that allows the `issue-sync` workflow to author issues as the
+maintainer instead of as `github-actions[bot]`. Without `SYNC_PAT`, every synced
+issue carries `author_association: NONE` and the t2449 worker-briefed auto-merge
+gate refuses to merge worker PRs.
+
+**Use `/setup-git` when**:
+
+- The toast shows `[WARN] N repos need SYNC_PAT setup`
+- A worker PR sits BLOCKED with all-green CI
+- You just registered a new repo via `aidevops init` or hand-edited `repos.json`
+- You're onboarding a new operator and want every active repo's secrets right
+
+**Use `/onboarding` instead when**:
+
+- You need per-account auth (`gh auth login`, `glab auth login`, `tea login`)
+- You need API keys for AI services (`OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, etc.) in `~/.config/aidevops/credentials.sh`
+- You're setting up a new machine and don't yet have any repos cloned
+
+## Security Posture (NON-NEGOTIABLE)
+
+This command **never** accepts secret values in conversation. The fix path is
+always `gh secret set NAME --repo SLUG` run **interactively in a separate
+terminal** so the value never lands in the AI session transcript or shell
+history (the `gh secret set` interactive prompt also avoids `--body "$VALUE"`,
+which would leave the token in process listings).
+
+The agent's job is: read the debt summary → tell the operator which URL to open →
+confirm with `setup-debt-helper.sh verify-secret` once they're done. **No tool call ever has
+a secret value as an argument.**
+
+If the operator pastes a token into the conversation, refuse it explicitly,
+discard the message context, and ask them to reset the conversation if any AI
+in the loop has training-data risk. (For Claude Code / OpenCode this risk is
+minimal but the discipline still applies.)
+
+<!-- AI-CONTEXT-END -->
+
+## Agent Workflow
+
+When invoked, walk the operator through these phases. Skip phases that are
+already clean (no debt → fast path to "all set").
+
+### Phase 1 — Inventory
+
+Run the aggregator and present the result:
+
+```bash
+~/.aidevops/agents/scripts/setup-debt-helper.sh summary --format=human
+```
+
+Then list the affected repos:
+
+```bash
+~/.aidevops/agents/scripts/setup-debt-helper.sh list-sync-pat-missing
+```
+
+For each slug, also fetch the platform from `~/.config/aidevops/repos.json`
+so you can route to the correct PAT URL template:
+
+```bash
+jq -r --arg slug "$SLUG" '.initialized_repos[] | select(.slug == $slug) | .platform // "github"' ~/.config/aidevops/repos.json
+```
+
+If `setup-debt-helper.sh summary` returns empty, congratulate the operator
+and exit — there is nothing to do.
+
+### Phase 2 — Per-Repo Walkthrough
+
+For each repo with missing `SYNC_PAT`, present this template (substitute slug
+and platform). Read the platform-specific section from
+`reference/sync-pat-platforms.md` and emit the URL with required scopes
+pre-encoded.
+
+#### GitHub example
+
+```text
+=== Repo: <SLUG> (platform: github) ===
+
+Why this matters: without SYNC_PAT on this repo, issues created by
+issue-sync.yml are authored by github-actions[bot] (author_association NONE),
+which causes the t2449 worker-briefed auto-merge gate to refuse to merge
+worker PRs. Setting SYNC_PAT once unblocks every future worker PR on this
+repo.
+
+Step 1 — Create a fine-grained PAT
+   Open this URL in your browser. Scopes are pre-filled:
+
+     https://github.com/settings/personal-access-tokens/new?name=aidevops-sync-<SLUG_SAFE>&description=aidevops%20issue-sync%20PAT%20for%20<SLUG_URLENC>&expiration=90&target_name=<OWNER>&permissions=contents:write,issues:write,pull_requests:write,metadata:read
+
+   Set repository access to "Only select repositories → <SLUG>".
+   Click Generate. Save the generated token.
+
+Step 2 — Save to your password manager NOW
+   GitHub will not show this token again. Add an entry like:
+
+     Title:    aidevops SYNC_PAT — <SLUG>
+     URL:      https://github.com/settings/personal-access-tokens
+     Expiry:   <90 days from today>
+     Notes:    Fine-grained PAT, scoped to <SLUG> only.
+               Used by .github/workflows/issue-sync.yml.
+
+Step 3 — Set the repo secret (SEPARATE TERMINAL)
+   In a new terminal window — NOT this AI session — run:
+
+     gh secret set SYNC_PAT --repo <SLUG>
+
+   The CLI will prompt for the value. Paste the token there. This keeps the
+   token out of this conversation transcript and out of shell history.
+
+Step 4 — Confirm setup landed
+   Type: verify <SLUG>
+
+   I will run setup-debt-helper.sh verify-secret which checks `gh secret list`
+   for SYNC_PAT presence — it never reads the value.
+```
+
+#### Other platforms
+
+GitLab, Gitea, Bitbucket: read the appropriate section of
+`reference/sync-pat-platforms.md`. If a platform is listed as "stub" in the
+matrix, emit a clear "manual setup required, see `<docs URL>`" message and move
+to the next repo.
+
+### Phase 3 — Verification
+
+When the operator types `verify <SLUG>` (or `verify all`):
+
+```bash
+# Per-repo
+~/.aidevops/agents/scripts/setup-debt-helper.sh verify-secret <SLUG> SYNC_PAT
+
+# All known
+~/.aidevops/agents/scripts/setup-debt-helper.sh list-sync-pat-missing | \
+    while IFS= read -r slug; do
+        ~/.aidevops/agents/scripts/setup-debt-helper.sh verify-secret "$slug" SYNC_PAT
+    done
+```
+
+Report each result. On confirmed-set repos, the next pulse cycle's
+`security-posture-helper.sh` run will detect SYNC_PAT and remove the advisory
+file automatically — no manual dismiss step needed.
+
+If the operator wants to dismiss without setting (e.g., they've decided this
+repo doesn't need worker auto-merge):
+
+```bash
+aidevops security dismiss sync-pat-<SLUG_SAFE>
+```
+
+### Phase 4 — Wrap
+
+After all advisories are addressed, summarise:
+
+- Number of repos walked
+- Number now set vs dismissed vs deferred
+- Reminder to verify expiry calendar entries are saved in their password manager
+- Pointer to the next pulse cycle re-running `aidevops security check` (no manual rerun needed)
+
+## Out of scope (Phase 1)
+
+These belong in follow-up tasks; do not attempt them in `/setup-git`:
+
+- Repo discovery / auto-registration of unregistered `~/Git/*` directories — Phase 2
+- Multi-platform full implementation (GitLab/Gitea/Bitbucket guided flow) — Phase 2
+- AI review keys (`OPENAI_API_KEY`, `CODERABBIT_API_KEY` per-repo) — Phase 3
+- `gh auth` scope checks, default-branch drift, workflow-file drift — separate `aidevops security check` covers these
+- Writing a manifest of confirmed-set secrets — Phase 2
+
+If the operator asks for any of the above, point them at the relevant
+follow-up issue (filed off this PR) and continue with the in-scope SYNC_PAT
+walkthrough.
+
+## Cross-references
+
+- `aidevops/onboarding.md` — per-account auth (the `/onboarding` command)
+- `reference/sync-pat-platforms.md` — PAT URL templates and scopes per platform
+- `prompts/build.txt` "Security Rules" — secret handling principles
+- `tools/credentials/gopass.md` — preferred secret store for AIDEVOPS env vars
+- t2449 (auto-merge.md) — why SYNC_PAT matters for worker auto-merge
+- t2374 (auto-dispatch.md) — original SYNC_PAT advisory infrastructure
+- t2806 / GH#20745 — rulesets-protected repo detection (sibling fix)
+
+## Related issues
+
+- GH#20812 — t2816 — this command's parent task
+- GH#20743 — t2805 — `pulse-merge.sh` rebase-before-fix-worker (sibling)
+- GH#20745 — t2806 — `security-posture-helper.sh` rulesets detection (dependency)

--- a/.agents/scripts/security-posture-helper.sh
+++ b/.agents/scripts/security-posture-helper.sh
@@ -639,12 +639,14 @@ This repo uses issue-sync.yml and has protection on the default branch
 Without SYNC_PAT, TODO.md auto-completion silently fails on PR merge
 (github-actions[bot] cannot push to a protected default branch).
 
-To fix (run in a separate terminal, NOT in AI chat):
+For a guided fix across all affected repos, run \`/setup-git\` in
+your AI assistant (OpenCode or Claude Code). It walks you through
+each repo with the correct pre-filled token-creation URL.
 
-1. Create a fine-grained PAT in GitHub UI:
-   Settings > Developer settings > Personal access tokens > Fine-grained
-   > Only selected repositories > ${slug}
-   > Contents: Read and write
+To fix this single repo manually (run in a separate terminal, NOT in AI chat):
+
+1. Create a fine-grained PAT (pre-filled URL):
+   https://github.com/settings/personal-access-tokens/new?name=aidevops-sync-pat&description=SYNC_PAT+for+aidevops+TODO+auto-completion&expires_in=none&target_name=${slug}&permissions=contents:write,metadata:read
 
 2. Set the secret:
    gh secret set SYNC_PAT --repo ${slug}

--- a/.agents/scripts/setup-debt-helper.sh
+++ b/.agents/scripts/setup-debt-helper.sh
@@ -1,0 +1,341 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# setup-debt-helper.sh — Aggregate per-repo platform-secret setup debt
+#
+# DESCRIPTION:
+#   Reads ~/.aidevops/advisories/sync-pat-*.advisory files (written by
+#   security-posture-helper.sh::_emit_sync_pat_advisory, t2374) and exposes
+#   the aggregated count + slug list to two consumers:
+#
+#     1. aidevops-update-check.sh — emits a single [WARN] toast line so the
+#        OpenCode plugin classifier (greeting.mjs) escalates the toast to
+#        warning tier when there is non-zero setup debt.
+#     2. /setup-git slash command — walks the operator through each gap
+#        with platform-specific PAT URLs and gh secret set instructions.
+#
+#   This helper is purely a read-side aggregator. It NEVER reads, accepts,
+#   or emits secret values. It NEVER calls gh secret set. The fix path is
+#   always the operator running gh secret set in a separate terminal.
+#
+# USAGE:
+#   setup-debt-helper.sh <command> [args]
+#
+# COMMANDS:
+#   summary [--format=human|toast|json]
+#       Aggregate count + summary line.
+#       human (default): 3 SYNC_PAT advisories (awardsapp/awardsapp, ...)
+#       toast:           [WARN] 3 repos need SYNC_PAT setup — run /setup-git ...
+#       json:            {"sync_pat_missing": [...], "count": 3}
+#       Empty stdout, exit 0 when count == 0 (suppresses toast lines).
+#
+#   list-sync-pat-missing
+#       One slug per line for repos with active (non-dismissed) SYNC_PAT
+#       advisories. Suitable for piping to xargs / for-loop in /setup-git.
+#       Empty stdout when none.
+#
+#   verify-secret <slug> <secret_name>
+#       Returns 0 if the named secret exists on the repo, 1 otherwise.
+#       Used by /setup-git after the operator runs gh secret set in a
+#       separate terminal — confirms the secret landed without ever
+#       reading its value.
+#
+#   help
+#       Show this help.
+#
+# EXAMPLES:
+#   setup-debt-helper.sh summary
+#   setup-debt-helper.sh summary --format=toast
+#   setup-debt-helper.sh list-sync-pat-missing | xargs -I{} echo "Setup: {}"
+#   setup-debt-helper.sh verify-secret awardsapp/awardsapp SYNC_PAT
+#
+# DEPENDENCIES:
+#   - jq (for --format=json)
+#   - gh (for verify-secret only)
+#
+# AUTHOR: AI DevOps Framework
+# VERSION: 1.0.0
+# LICENSE: MIT
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+# shellcheck source=shared-constants.sh
+source "${SCRIPT_DIR}/shared-constants.sh"
+
+set -euo pipefail
+
+# -----------------------------------------------------------------------------
+# Configuration
+# -----------------------------------------------------------------------------
+
+readonly ADVISORIES_DIR="${HOME}/.aidevops/advisories"
+readonly DISMISSED_FILE="${ADVISORIES_DIR}/dismissed.txt"
+readonly SYNC_PAT_PREFIX="sync-pat-"
+
+# -----------------------------------------------------------------------------
+# Internal helpers
+# -----------------------------------------------------------------------------
+
+# _is_dismissed: check whether an advisory ID appears in dismissed.txt.
+# Args: $1 = advisory id (e.g., sync-pat-awardsapp-awardsapp)
+# Returns: 0 if dismissed, 1 otherwise
+_is_dismissed() {
+	local adv_id="$1"
+	[[ -f "$DISMISSED_FILE" ]] || return 1
+	grep -qxF "$adv_id" "$DISMISSED_FILE" 2>/dev/null
+}
+
+# _slug_from_filename: reconstruct OWNER/REPO slug from advisory filename.
+# Files are named sync-pat-OWNER-REPO.advisory; the slash is replaced with
+# a hyphen at write time. We split on the LAST hyphen so OWNER may itself
+# contain hyphens (e.g., essentials-com/essentials.com → essentials-com-essentials.com → split → essentials-com/essentials.com).
+# Args: $1 = filename without prefix or extension (e.g., awardsapp-awardsapp)
+# Returns: slug on stdout, or empty string if the filename has no separator
+_slug_from_filename() {
+	local stem="$1"
+	# Find the LAST hyphen and split there
+	local owner repo
+	owner="${stem%-*}"
+	repo="${stem##*-}"
+	if [[ "$owner" == "$stem" ]]; then
+		# No hyphen — malformed advisory filename
+		echo ""
+		return 0
+	fi
+	echo "${owner}/${repo}"
+	return 0
+}
+
+# _collect_sync_pat_slugs: emit one slug per line for non-dismissed advisories.
+# Stable sort order so test-script assertions are deterministic.
+_collect_sync_pat_slugs() {
+	if [[ ! -d "$ADVISORIES_DIR" ]]; then
+		return 0
+	fi
+
+	local advisory_file
+	# shellcheck disable=SC2231
+	for advisory_file in "$ADVISORIES_DIR"/${SYNC_PAT_PREFIX}*.advisory; do
+		[[ -f "$advisory_file" ]] || continue
+
+		local basename adv_id stem slug
+		basename="$(basename "$advisory_file" .advisory)"
+		adv_id="$basename"
+		stem="${basename#"$SYNC_PAT_PREFIX"}"
+
+		if _is_dismissed "$adv_id"; then
+			continue
+		fi
+
+		slug="$(_slug_from_filename "$stem")"
+		[[ -n "$slug" ]] || continue
+
+		echo "$slug"
+	done | sort -u
+	return 0
+}
+
+# -----------------------------------------------------------------------------
+# Subcommand: summary
+# -----------------------------------------------------------------------------
+
+_cmd_summary() {
+	local format="human"
+	local -a args=("$@")
+	local arg
+	local i=0
+	local arg_count=${#args[@]}
+
+	while [[ $i -lt $arg_count ]]; do
+		arg="${args[i]}"
+		case "$arg" in
+		--format=*)
+			format="${arg#--format=}"
+			;;
+		--format)
+			i=$((i + 1))
+			format="${args[i]:-human}"
+			;;
+		--help | -h)
+			echo "Usage: setup-debt-helper.sh summary [--format=human|toast|json]"
+			return 0
+			;;
+		*)
+			print_error "Unknown option for summary: $arg"
+			return 1
+			;;
+		esac
+		i=$((i + 1))
+	done
+
+	local slugs
+	slugs="$(_collect_sync_pat_slugs)"
+
+	local count=0
+	if [[ -n "$slugs" ]]; then
+		count=$(printf '%s\n' "$slugs" | wc -l | tr -d ' ')
+	fi
+
+	case "$format" in
+	human)
+		if [[ "$count" -eq 0 ]]; then
+			# Suppress on zero-debt: empty stdout, exit 0
+			return 0
+		fi
+		# Comma-separated slug list, capped at 3 with " ..."
+		local slug_list
+		slug_list="$(printf '%s\n' "$slugs" | head -3 | tr '\n' ',' | sed 's/,$//;s/,/, /g')"
+		if [[ "$count" -gt 3 ]]; then
+			slug_list="${slug_list}, +$((count - 3)) more"
+		fi
+		printf '%d SYNC_PAT advisor%s (%s)\n' "$count" "$([[ "$count" -eq 1 ]] && echo "y" || echo "ies")" "$slug_list"
+		;;
+	toast)
+		if [[ "$count" -eq 0 ]]; then
+			# Suppress on zero-debt: empty stdout, exit 0. The plugin will
+			# omit the warning-tier line when nothing is emitted here.
+			return 0
+		fi
+		# Single line, [WARN] prefix so greeting.mjs::classifyLines buckets
+		# this into the warning tier (15s display, more prominent than the
+		# per-repo [ADVISORY] info-tier lines below).
+		# Singular: "1 repo needs"; plural: "N repos need"
+		if [[ "$count" -eq 1 ]]; then
+			printf '[WARN] 1 repo needs SYNC_PAT setup — run /setup-git in OpenCode or Claude Code\n'
+		else
+			printf '[WARN] %d repos need SYNC_PAT setup — run /setup-git in OpenCode or Claude Code\n' "$count"
+		fi
+		;;
+	json)
+		if ! command -v jq >/dev/null 2>&1; then
+			print_error "--format=json requires jq"
+			return 1
+		fi
+		local slugs_json
+		if [[ -n "$slugs" ]]; then
+			slugs_json="$(printf '%s\n' "$slugs" | jq -R . | jq -s .)"
+		else
+			slugs_json="[]"
+		fi
+		jq -n --argjson slugs "$slugs_json" --argjson count "$count" \
+			'{sync_pat_missing: $slugs, count: $count}'
+		;;
+	*)
+		print_error "Unknown format: $format (expected: human, toast, json)"
+		return 1
+		;;
+	esac
+
+	return 0
+}
+
+# -----------------------------------------------------------------------------
+# Subcommand: list-sync-pat-missing
+# -----------------------------------------------------------------------------
+
+_cmd_list_sync_pat_missing() {
+	_collect_sync_pat_slugs
+	return 0
+}
+
+# -----------------------------------------------------------------------------
+# Subcommand: verify-secret
+# -----------------------------------------------------------------------------
+
+_cmd_verify_secret() {
+	local slug="${1:-}"
+	local name="${2:-}"
+
+	if [[ -z "$slug" || -z "$name" ]]; then
+		print_error "Usage: setup-debt-helper.sh verify-secret <slug> <secret_name>"
+		return 2
+	fi
+
+	if ! command -v gh >/dev/null 2>&1; then
+		print_error "gh CLI not installed — cannot verify secret presence"
+		return 2
+	fi
+
+	if ! gh auth status >/dev/null 2>&1; then
+		print_error "gh not authenticated — run gh auth login"
+		return 2
+	fi
+
+	local found
+	found="$(gh secret list --repo "$slug" --json name -q ".[] | select(.name == \"${name}\") | .name" 2>/dev/null)" || found=""
+
+	if [[ -n "$found" ]]; then
+		print_success "$name is set for $slug"
+		return 0
+	fi
+
+	print_warn "$name is NOT set for $slug"
+	return 1
+}
+
+# -----------------------------------------------------------------------------
+# CLI dispatch
+# -----------------------------------------------------------------------------
+
+_usage() {
+	cat <<'EOF'
+setup-debt-helper.sh — Aggregate per-repo platform-secret setup debt
+
+Usage:
+  setup-debt-helper.sh <command> [args]
+
+Commands:
+  summary [--format=human|toast|json]   Aggregate count + summary line
+  list-sync-pat-missing                 One slug per line, non-dismissed only
+  verify-secret <slug> <secret_name>    Check if a secret exists on a repo
+  help                                  Show this help
+
+Examples:
+  setup-debt-helper.sh summary
+  setup-debt-helper.sh summary --format=toast
+  setup-debt-helper.sh list-sync-pat-missing
+  setup-debt-helper.sh verify-secret awardsapp/awardsapp SYNC_PAT
+
+Emits no output and returns 0 when there is no setup debt; this is the
+intended quiet-on-clean signal for toast suppression.
+
+See also:
+  /setup-git                       Slash command that consumes this helper
+  aidevops security check          Generates the SYNC_PAT advisories
+  scripts/commands/setup-git.md    Slash command spec
+  reference/sync-pat-platforms.md  PAT URL templates and scopes per platform
+EOF
+	return 0
+}
+
+main() {
+	local cmd="${1:-help}"
+	shift || true
+
+	case "$cmd" in
+	summary)
+		_cmd_summary "$@"
+		;;
+	list-sync-pat-missing)
+		_cmd_list_sync_pat_missing
+		;;
+	verify-secret)
+		_cmd_verify_secret "$@"
+		;;
+	help | --help | -h)
+		_usage
+		;;
+	*)
+		print_error "Unknown command: $cmd"
+		_usage >&2
+		return 1
+		;;
+	esac
+
+	return $?
+}
+
+# Only run main when executed directly (not sourced)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+	main "$@"
+fi

--- a/.agents/scripts/tests/test-setup-debt-helper.sh
+++ b/.agents/scripts/tests/test-setup-debt-helper.sh
@@ -1,0 +1,236 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-setup-debt-helper.sh — unit tests for setup-debt-helper.sh
+#
+# Each test mounts a temporary HOME directory containing a fake
+# ~/.aidevops/advisories/ tree, then asserts the helper's behaviour.
+# verify-secret is NOT covered here — that path requires live gh CLI
+# and is exercised manually during /setup-git operator testing.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+HELPER="${SCRIPT_DIR}/../setup-debt-helper.sh"
+
+if [[ ! -x "$HELPER" ]]; then
+	echo "FAIL: helper not executable at $HELPER" >&2
+	exit 1
+fi
+
+# Per-test sandbox — each test calls _setup_sandbox; teardown is done by
+# overwriting HOME on the next call and removing the trap directory at exit.
+TEST_TMPDIR=""
+
+_setup_sandbox() {
+	TEST_TMPDIR="$(mktemp -d -t setup-debt-test.XXXXXX)"
+	export HOME="$TEST_TMPDIR"
+	mkdir -p "$HOME/.aidevops/advisories"
+}
+
+_teardown_sandbox() {
+	if [[ -n "$TEST_TMPDIR" && -d "$TEST_TMPDIR" ]]; then
+		rm -rf "$TEST_TMPDIR"
+	fi
+	TEST_TMPDIR=""
+}
+
+trap _teardown_sandbox EXIT
+
+# Test runner
+PASS=0
+FAIL=0
+
+_run_test() {
+	local name="$1"
+	local fn="$2"
+	if "$fn"; then
+		echo "  PASS: $name"
+		PASS=$((PASS + 1))
+	else
+		echo "  FAIL: $name" >&2
+		FAIL=$((FAIL + 1))
+	fi
+	_teardown_sandbox
+}
+
+_assert_eq() {
+	local expected="$1"
+	local actual="$2"
+	local msg="${3:-assertion}"
+	if [[ "$expected" != "$actual" ]]; then
+		echo "    $msg: expected '$expected', got '$actual'" >&2
+		return 1
+	fi
+	return 0
+}
+
+_assert_empty() {
+	local actual="$1"
+	local msg="${2:-empty assertion}"
+	if [[ -n "$actual" ]]; then
+		echo "    $msg: expected empty, got '$actual'" >&2
+		return 1
+	fi
+	return 0
+}
+
+# -----------------------------------------------------------------------------
+# Test cases
+# -----------------------------------------------------------------------------
+
+test_zero_advisories_empty_summary() {
+	_setup_sandbox
+	local out
+	out="$("$HELPER" summary)"
+	_assert_empty "$out" "summary should be empty when no advisories"
+}
+
+test_zero_advisories_empty_toast() {
+	_setup_sandbox
+	local out
+	out="$("$HELPER" summary --format=toast)"
+	_assert_empty "$out" "toast format should be empty when no advisories"
+}
+
+test_zero_advisories_empty_list() {
+	_setup_sandbox
+	local out
+	out="$("$HELPER" list-sync-pat-missing)"
+	_assert_empty "$out" "list should be empty when no advisories"
+}
+
+test_single_advisory_human() {
+	_setup_sandbox
+	# Use a single-segment owner so the lastsplit reconstructs cleanly
+	echo "[ADVISORY] SYNC_PAT not set for awardsapp/awardsapp" > "$HOME/.aidevops/advisories/sync-pat-awardsapp-awardsapp.advisory"
+	local out
+	out="$("$HELPER" summary --format=human)"
+	# Expect: "1 SYNC_PAT advisory (awardsapp/awardsapp)"
+	if [[ "$out" != *"1 SYNC_PAT"* || "$out" != *"awardsapp/awardsapp"* ]]; then
+		echo "    expected count + slug, got: '$out'" >&2
+		return 1
+	fi
+	return 0
+}
+
+test_single_advisory_toast() {
+	_setup_sandbox
+	echo "[ADVISORY] SYNC_PAT not set for awardsapp/awardsapp" > "$HOME/.aidevops/advisories/sync-pat-awardsapp-awardsapp.advisory"
+	local out
+	out="$("$HELPER" summary --format=toast)"
+	# Expect: "[WARN] 1 repo needs SYNC_PAT setup — run /setup-git in OpenCode or Claude Code"
+	# Singular subject-verb agreement: "1 repo needs" (NOT "1 repo need" / "1 repos needs").
+	if [[ "$out" != "[WARN] 1 repo needs"* ]]; then
+		echo "    expected '[WARN] 1 repo needs ...', got: '$out'" >&2
+		return 1
+	fi
+	if [[ "$out" != *"/setup-git"* ]]; then
+		echo "    expected /setup-git mention, got: '$out'" >&2
+		return 1
+	fi
+	return 0
+}
+
+test_multi_advisory_count() {
+	_setup_sandbox
+	echo "[ADVISORY] X" > "$HOME/.aidevops/advisories/sync-pat-foo-bar.advisory"
+	echo "[ADVISORY] X" > "$HOME/.aidevops/advisories/sync-pat-baz-qux.advisory"
+	echo "[ADVISORY] X" > "$HOME/.aidevops/advisories/sync-pat-quux-quuz.advisory"
+	local out
+	out="$("$HELPER" summary --format=toast)"
+	if [[ "$out" != "[WARN] 3 repos need"* ]]; then
+		echo "    expected '3 repos need', got: '$out'" >&2
+		return 1
+	fi
+	return 0
+}
+
+test_dismissed_advisory_excluded() {
+	_setup_sandbox
+	echo "[ADVISORY] X" > "$HOME/.aidevops/advisories/sync-pat-foo-bar.advisory"
+	echo "[ADVISORY] X" > "$HOME/.aidevops/advisories/sync-pat-baz-qux.advisory"
+	# Dismiss one
+	echo "sync-pat-foo-bar" > "$HOME/.aidevops/advisories/dismissed.txt"
+	local out
+	out="$("$HELPER" summary --format=toast)"
+	# Should count only the non-dismissed one
+	if [[ "$out" != "[WARN] 1 repo need"* ]]; then
+		echo "    expected 1 repo (other dismissed), got: '$out'" >&2
+		return 1
+	fi
+}
+
+test_list_returns_slugs() {
+	_setup_sandbox
+	echo "[ADVISORY] X" > "$HOME/.aidevops/advisories/sync-pat-foo-bar.advisory"
+	echo "[ADVISORY] X" > "$HOME/.aidevops/advisories/sync-pat-baz-qux.advisory"
+	local out
+	out="$("$HELPER" list-sync-pat-missing | sort)"
+	local expected
+	expected="$(printf 'baz/qux\nfoo/bar\n')"
+	_assert_eq "$expected" "$out" "list output mismatch"
+}
+
+test_json_format_structure() {
+	_setup_sandbox
+	if ! command -v jq >/dev/null 2>&1; then
+		echo "    skipping json test (jq not installed)" >&2
+		return 0
+	fi
+	echo "[ADVISORY] X" > "$HOME/.aidevops/advisories/sync-pat-foo-bar.advisory"
+	local out count
+	out="$("$HELPER" summary --format=json)"
+	count="$(echo "$out" | jq -r '.count')"
+	_assert_eq "1" "$count" "json count mismatch"
+}
+
+test_help_command() {
+	_setup_sandbox
+	local out
+	out="$("$HELPER" help 2>&1 || true)"
+	if [[ "$out" != *"setup-debt-helper.sh"* ]]; then
+		echo "    expected help banner, got: '$out'" >&2
+		return 1
+	fi
+	return 0
+}
+
+test_unknown_command_returns_error() {
+	_setup_sandbox
+	local rc=0
+	"$HELPER" nonexistent >/dev/null 2>&1 || rc=$?
+	if [[ "$rc" -eq 0 ]]; then
+		echo "    expected nonzero exit, got 0" >&2
+		return 1
+	fi
+	return 0
+}
+
+# -----------------------------------------------------------------------------
+# Run
+# -----------------------------------------------------------------------------
+
+echo "=== test-setup-debt-helper.sh ==="
+
+_run_test "zero advisories: empty human summary" test_zero_advisories_empty_summary
+_run_test "zero advisories: empty toast line" test_zero_advisories_empty_toast
+_run_test "zero advisories: empty list" test_zero_advisories_empty_list
+_run_test "single advisory: human format" test_single_advisory_human
+_run_test "single advisory: toast format with [WARN] + /setup-git" test_single_advisory_toast
+_run_test "multiple advisories: pluralised count" test_multi_advisory_count
+_run_test "dismissed advisory excluded from count" test_dismissed_advisory_excluded
+_run_test "list returns reconstructed slugs" test_list_returns_slugs
+_run_test "json format has expected structure" test_json_format_structure
+_run_test "help command emits banner" test_help_command
+_run_test "unknown command returns error" test_unknown_command_returns_error
+
+echo ""
+echo "PASS: $PASS"
+echo "FAIL: $FAIL"
+
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Phase 1 of the `/setup-git` guided setup workflow for per-repo platform secrets:

- **Toast surfacing**: a single `[WARN]` aggregate line for all pending `SYNC_PAT` advisories is now prepended to session greeting output, escalating the existing info-tier `[ADVISORY]` detail lines to the warning tier that the OpenCode plugin classifier (`greeting.mjs::classifyLines`) already buckets as 15s display.
- **Slash command**: `/setup-git` walks the operator through per-repo setup with pre-filled fine-grained PAT creation URLs, covering GitHub today (SYNC_PAT) with GitLab/Gitea/Bitbucket stubs for Phase 2.
- **Advisory body**: the existing per-repo `SYNC_PAT` advisory emitted by `security-posture-helper.sh` now points at `/setup-git` as the guided-fix path and ships the pre-filled token URL for manual fallback (no `--body "<PAT>"` shell-history leak).
- **Scope split in docs**: `/onboarding` stays per-account; `/setup-git` is per-repo. New section in `onboarding.md` plus cross-references in `AGENTS.md` (Repo registration + the `issue-sync` known-limitation note).

Composes existing helpers — no new detection logic. The aggregator (`setup-debt-helper.sh`) reads the advisory files already written by `security-posture-helper.sh` Phase 7 (t2374 + t2806).

Phase 2 (repo discovery/registration, GitLab/Gitea/Bitbucket full implementations, `secret-manifest.json` catalog) and Phase 3 (gh auth scope elevation, AI service key adjacency checks) are tracked as future phases on this PR — to be filed as fresh framework issues when work starts, not pre-filed as backlog stubs.

## Files

- **NEW** `.agents/scripts/setup-debt-helper.sh` — aggregator with `summary [--format=human|toast|json]`, `list-sync-pat-missing`, `verify-secret`, `help`. Reads `~/.aidevops/advisories/sync-pat-*.advisory`, applies `dismissed.txt` filter, reconstructs slug via last-hyphen split.
- **NEW** `.agents/scripts/tests/test-setup-debt-helper.sh` — 11 tests (zero/single/multi advisories, dismissed filter, JSON structure, help/unknown-command, slug reconstruction, singular-form grammar).
- **NEW** `.agents/scripts/commands/setup-git.md` — slash command spec with security posture (NEVER accept secret values in chat), 4-phase agent workflow (Inventory → Per-Repo Walkthrough → Verification → Wrap).
- **NEW** `.agents/reference/sync-pat-platforms.md` — platform matrix (GitHub primary with query-string PAT URL; GitLab/Gitea/Bitbucket Phase 2 stubs).
- **EDIT** `.agents/scripts/aidevops-update-check.sh::_check_advisories` — prepend `[WARN]` aggregate line from `setup-debt-helper.sh summary --format=toast` before existing per-advisory loop.
- **EDIT** `.agents/scripts/security-posture-helper.sh::_emit_sync_pat_advisory` — advisory body mentions `/setup-git`, ships pre-filled PAT URL.
- **EDIT** `.agents/aidevops/onboarding.md` — "Scope: Per-Account vs Per-Repo" section + step-6 `/setup-git` nudge.
- **EDIT** `.agents/AGENTS.md` — Repo registration mentions `/setup-git`; `issue-sync` known-limitation note points at `/setup-git` as primary fix path.

## Verification

- [x] `shellcheck` clean across `aidevops-update-check.sh`, `security-posture-helper.sh`, `setup-debt-helper.sh`.
- [x] `markdownlint-cli2` clean on all new + touched markdown (one pre-existing `MD038` on `.agents/AGENTS.md:84` is not introduced by this PR).
- [x] 11/11 unit tests pass (`bash .agents/scripts/tests/test-setup-debt-helper.sh`).
- [x] Direct `_check_advisories()` call emits `[WARN] 1 repo needs SYNC_PAT setup — run /setup-git in OpenCode or Claude Code` first, followed by existing `[SECURITY ADVISORY]` + `[ADVISORY]` lines — classifier picks up warning-tier display.
- [x] Grammar test tightened to catch regression: singular "1 repo needs" asserted specifically.

## Related

- Sibling framework issues filed during the same session:
  - #20743 (t2805) — `pulse-merge.sh` rebase-before-fix-worker for CI-failing MERGEABLE PRs.
  - #20745 (t2806) — `security-posture-helper.sh` Phase 7 rulesets-based protection detection.

Resolves #20812

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.3 plugin for [OpenCode](https://opencode.ai) v1.14.24 with claude-opus-4-7 spent 7h 15m and 94,000 tokens on this with the user in an interactive session.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.3 plugin for [OpenCode](https://opencode.ai) v1.14.24 with claude-opus-4-7 spent 7h 16m on this with the user in an interactive session. Overall, 45s since this issue was created.
