### PR TITLE
t2815: prevent cascade tier escalation on infra failures

### DIFF
--- a/.agents/reference/worker-diagnostics.md
+++ b/.agents/reference/worker-diagnostics.md
@@ -103,13 +103,14 @@ CLAIM_RELEASED reason=launch_recovery:no_worker_process runner=<login> ts=<ISO>
 
 **Observed pattern (2026-04-20 to 2026-04-24 data, t2812)**:
 - Occurs in **time-correlated clusters**, not random transients. A single runner experiences 30+ failures across many issues within a 2–4 hour window, then recovers.
-- **Self-heals**: cascade tier escalation (tier:standard → tier:thinking after 2 consecutive failures) resolves the issue at the next dispatch cycle. 63/65 affected issues in the observed window resolved within the same day.
+- **Self-heals**: the underlying infrastructure issue (canary auth expiry, session lock collision) typically clears within minutes. The issue retries at the same tier — cascade tier escalation is NOT used for `no_worker_process` failures (t2815). 63/65 affected issues in the observed window resolved within the same day.
 - **Runner-specific**: 82% of events attributed to one runner (`alex-solovyev`), 17% to the other (`marcusquinn`). Likely reflects resource constraints on the failing runner at time of cluster.
 - **Cross-repo**: affects all pulse-enabled repos simultaneously (observed in `marcusquinn/aidevops` ~112 events, `awardsapp/awardsapp` ~130 events in 5-day window).
 
 **Mitigation already in place**:
 - After 3 consecutive `no_worker_process` failures in a round, the canary cache is invalidated — next dispatch re-runs the canary to detect broken runtimes.
-- After 2 consecutive failures per issue, cascade escalation to `tier:thinking` triggers automatically.
+- `no_worker_process` failures are classified as `crash_type=no_work` (t2815) — cascade tier escalation is **skipped** (t2387). The issue retries at the same tier so the next attempt runs cheaply once the infrastructure issue clears.
+- After `NO_WORK_NMR_THRESHOLD` (default 3) consecutive infra failures per issue, the per-issue no_work circuit breaker (t2769) applies `needs-maintainer-review` with a `cost-circuit-breaker:no_work_loop` marker.
 - `fast_fail_record` increments the per-issue failure counter for backoff.
 
 **Diagnostic**:
@@ -236,14 +237,15 @@ model connectivity only — it does not test the full worker exec chain (sandbox
 plugin loading). A canary pass does not guarantee the worker's OpenCode will succeed.
 However, the more impactful failure mode is the canary FAILING (Path 1), not passing-then-failing.
 
-**(d) Cascade escalation fires on missing worker as if coding failure — CONFIRMED**
+**(d) Cascade escalation on missing worker — FIXED by t2815**
 
-`recover_failed_launch_state` (pulse-cleanup.sh:806) calls `fast_fail_record` with the
-`no_worker_process` failure reason. This increments the per-issue failure counter that
-drives cascade tier escalation. The cascade does not distinguish "worker never spawned"
-from "worker spawned and failed during execution". This is a correct observation but
-**not a root cause** — it's a symptom-recovery mechanism that happens to work by
-introducing delay and model rotation.
+`recover_failed_launch_state` (pulse-cleanup.sh) now maps `no_worker_process` to
+`crash_type=no_work` before calling `fast_fail_record`. This routes through the t2387
+infra-failure guard in `escalate_issue_tier`, which skips tier escalation and keeps
+the issue at its current tier. Same-tier retry applies; after `NO_WORK_NMR_THRESHOLD`
+(default 3) consecutive failures the t2769 no_work circuit breaker applies
+`needs-maintainer-review`. The cascade no longer fires on infrastructure failures where
+the worker never spawned.
 
 #### Diagnostic gap (the core infrastructure finding)
 
@@ -287,6 +289,26 @@ The pulse has no visibility into WHY a worker exited early. The gaps:
    60 seconds on canary runs that will all fail for the same reason. The batch throttle
    (pulse-dispatch-engine.sh:559) partially addresses this but only after 80% failure ratio.
 
+#### Phase 4 fix applied — t2815
+
+**Prevent cascade tier escalation on `no_worker_process` failures** (this issue, shipped):
+
+In `recover_failed_launch_state` (pulse-cleanup.sh), when `failure_reason == "no_worker_process"`
+and no explicit `crash_type` was provided, the effective crash type is now forced to `"no_work"`.
+This routes through the t2387 infra-failure guard in `escalate_issue_tier`, which skips tier
+escalation entirely. Observable change:
+- Before: 2 consecutive `no_worker_process` → tier:standard upgraded to tier:thinking → opus dispatch → same infra failure.
+- After: 2 consecutive `no_worker_process` → same-tier retry (no tier change). After `NO_WORK_NMR_THRESHOLD` (default 3) failures, the t2769 no_work circuit breaker applies `needs-maintainer-review`.
+
+**Crash type classification for `recover_failed_launch_state`**:
+
+| `failure_reason` | Effective `crash_type` | Cascade escalation? | Notes |
+|-----------------|------------------------|---------------------|-------|
+| `no_worker_process` | `no_work` (t2815) | No | Worker never spawned — infra failure |
+| `cli_usage_output` | caller-supplied (empty→unclassified) | Yes (at threshold) | CLI invoked incorrectly |
+| `premature_exit` | caller-supplied (explicit crash type from watchdog) | Depends on crash_type | Worker exited during execution |
+| `stale_timeout` | caller-supplied (from stale-recovery) | Depends on crash_type | Worker was stalled |
+
 ## Diagnostic Quick Reference
 
 | Symptom | Check | Likely cause |
@@ -298,7 +320,7 @@ The pulse has no visibility into WHY a worker exited early. The gaps:
 | PRs created but not merged | `review-bot-gate-helper.sh check <PR>` | Review bot rate-limited (passes immediately since v3.6.136) |
 | Claim/release loop | Comment history on issue | Stale claims, guard rejections — recreate issue with clean context |
 | Watchdog doesn't fire | `ps aux \| grep watchdog` | Watchdog process died with subshell |
-| `CLAIM_RELEASED reason=launch_recovery:no_worker_process` on multiple issues | `grep "no active worker process" ~/.aidevops/logs/pulse-wrapper.log` | Cluster failure on one runner — self-heals via cascade escalation; check system load |
+| `CLAIM_RELEASED reason=launch_recovery:no_worker_process` on multiple issues | `grep "no active worker process" ~/.aidevops/logs/pulse-wrapper.log` | Cluster failure on one runner — retries at same tier (no cascade escalation, t2815); check system load |
 
 ## Proving Workers Are Doing Real Work
 

--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -800,23 +800,14 @@ recover_failed_launch_state() {
 	# t1934: Unlock issue and linked PRs (locked at dispatch time)
 	unlock_issue_after_worker "$issue_number" "$repo_slug"
 
-	# Record the launch failure in the fast-fail counter (t1888)
-	# Pass crash_type through to fast_fail_record → escalate_issue_tier
-	# for crash-type-aware escalation (overwhelmed = immediate, no_work = default).
-	#
-	# t2815: no_worker_process is an infrastructure failure — the worker process
-	# never spawned (canary failure, auth race, session lock collision, FD exhaustion).
-	# Map to crash_type=no_work so escalate_issue_tier short-circuits at the t2387
-	# infra-failure guard and skips tier escalation. A more expensive model cannot
-	# fix a problem the worker never reached. Same-tier retry applies; after
-	# NO_WORK_NMR_THRESHOLD consecutive failures the per-issue circuit breaker
-	# (t2769) applies needs-maintainer-review.
+	# Record the launch failure in the fast-fail counter (t1888).
+	# t2815: no_worker_process = infra failure; map to no_work so escalate_issue_tier
+	# short-circuits at the t2387 guard and skips tier escalation.
 	local effective_crash_type="$crash_type"
 	if [[ "$failure_reason" == "no_worker_process" && -z "$effective_crash_type" ]]; then
 		effective_crash_type="no_work"
 	fi
 	fast_fail_record "$issue_number" "$repo_slug" "$failure_reason" "anthropic" "$effective_crash_type" || true
-
 	# t1959: Wire global circuit breaker for launch-class failures only.
 	# Stale timeouts and in-execution failures have their own per-issue backoff
 	# and should not trip a global halt. Only true launch failures signal

--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -802,8 +802,20 @@ recover_failed_launch_state() {
 
 	# Record the launch failure in the fast-fail counter (t1888)
 	# Pass crash_type through to fast_fail_record → escalate_issue_tier
-	# for crash-type-aware escalation (overwhelmed = immediate, no_work = default)
-	fast_fail_record "$issue_number" "$repo_slug" "$failure_reason" "anthropic" "$crash_type" || true
+	# for crash-type-aware escalation (overwhelmed = immediate, no_work = default).
+	#
+	# t2815: no_worker_process is an infrastructure failure — the worker process
+	# never spawned (canary failure, auth race, session lock collision, FD exhaustion).
+	# Map to crash_type=no_work so escalate_issue_tier short-circuits at the t2387
+	# infra-failure guard and skips tier escalation. A more expensive model cannot
+	# fix a problem the worker never reached. Same-tier retry applies; after
+	# NO_WORK_NMR_THRESHOLD consecutive failures the per-issue circuit breaker
+	# (t2769) applies needs-maintainer-review.
+	local effective_crash_type="$crash_type"
+	if [[ "$failure_reason" == "no_worker_process" && -z "$effective_crash_type" ]]; then
+		effective_crash_type="no_work"
+	fi
+	fast_fail_record "$issue_number" "$repo_slug" "$failure_reason" "anthropic" "$effective_crash_type" || true
 
 	# t1959: Wire global circuit breaker for launch-class failures only.
 	# Stale timeouts and in-execution failures have their own per-issue backoff
@@ -819,7 +831,7 @@ recover_failed_launch_state() {
 		;;
 	esac
 
-	echo "[pulse-wrapper] Launch recovery reset #${issue_number} (${repo_slug}) after ${failure_reason} crash_type=${crash_type:-unclassified}: removed self assignee + status:queued" >>"$LOGFILE"
+	echo "[pulse-wrapper] Launch recovery reset #${issue_number} (${repo_slug}) after ${failure_reason} crash_type=${effective_crash_type:-unclassified}: removed self assignee + status:queued" >>"$LOGFILE"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Prevent `launch_recovery:no_worker_process` from triggering cascade tier escalation. Infrastructure failures (worker never spawned) must be classified distinctly from coding failures (worker spawned but failed to implement) and handled with same-tier retry — not tier upgrade.

## Changes

### `pulse-cleanup.sh` — `recover_failed_launch_state`

In the call path `no_worker_process → recover_failed_launch_state → fast_fail_record → escalate_issue_tier`, the `crash_type` argument was empty for `no_worker_process` failures. The t2387 infra-failure guard in `escalate_issue_tier` only fires on `crash_type == "no_work"`, so the cascade escalation fired anyway.

Fix: before calling `fast_fail_record`, map `no_worker_process` → `effective_crash_type="no_work"` when no explicit crash type was provided. This routes through the t2387 guard and skips tier escalation. After `NO_WORK_NMR_THRESHOLD` (default 3) consecutive infra failures, the t2769 circuit breaker applies `needs-maintainer-review`.

**Before**: 2× `no_worker_process` → `tier:standard` upgraded to `tier:thinking` → opus dispatch → same infra failure.
**After**: `no_worker_process` → same-tier retry, no tier change.

### `worker-diagnostics.md` — Phase 4 documentation

- Updated "Mitigation already in place" section to reflect t2815 behavior.
- Updated "Self-heals" description to remove incorrect "cascade escalation" language.
- Updated finding (d) from "CONFIRMED" problem to "FIXED by t2815".
- Added Phase 4 classification table for `recover_failed_launch_state` crash types.
- Updated diagnostic quick-reference table row.

## Verification

```bash
shellcheck .agents/scripts/pulse-cleanup.sh
grep -n "no_worker_process\|effective_crash_type\|t2815" .agents/scripts/pulse-cleanup.sh
```

## Complexity Impact

No new functions added. Single 4-line guard added inline in existing `recover_failed_launch_state` function. No complexity regression expected.

Resolves #20766
Ref #20740
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.3 plugin for [OpenCode](https://opencode.ai) v1.14.24 with claude-sonnet-4-6 spent 11m and 13,930 tokens on this as a headless worker.
