### PR TITLE
t2799: t2799: split RATE_LIMIT_PATTERNS from NON_REVIEW_PATTERNS in review-bot-gate-helper

### DIFF
--- a/.agents/scripts/review-bot-gate-helper.sh
+++ b/.agents/scripts/review-bot-gate-helper.sh
@@ -64,27 +64,37 @@ KNOWN_BOTS=(
 	"copilot"
 )
 
-# Patterns that indicate a comment is NOT a real review. Includes rate-limit
-# / quota notices AND non-quota bot status messages ("Review failed", "Review
-# skipped", placeholder edits after the PR was closed). Case-insensitive grep
-# patterns — one per line.
-# t2139 (GH#19251): expanded from rate-limit-only to all known non-review
-# notices, after CodeRabbit "Review failed/skipped/closed-during-review"
-# messages were observed false-positive-classifying as real reviews.
-NON_REVIEW_PATTERNS=(
+# Rate-limit / quota notice patterns — entries that indicate the bot tried to
+# review but was capacity-constrained. Used by grace-period logic
+# (RATE_LIMIT_GRACE_SECONDS, _should_pass_rate_limited) where the semantic
+# distinction matters: a rate-limited bot may recover and review later, while
+# a "Review skipped" bot will not.
+# t2799: restored to original rate-limit-only semantics after t2139 expansion.
+RATE_LIMIT_PATTERNS=(
 	"rate limit exceeded"
 	"rate limited by coderabbit"
 	"daily quota limit"
 	"reached your daily quota"
 	"Please wait up to 24 hours"
 	"has exceeded the limit for the number of"
+)
+
+# Broader set: all patterns that indicate a comment is NOT a real review.
+# Includes rate-limit notices (above) AND non-quota bot status messages
+# ("Review failed", "Review skipped", placeholder edits after the PR was
+# closed). Case-insensitive grep patterns — one per line.
+# t2139 (GH#19251): expanded from rate-limit-only to include non-review
+# notices, after CodeRabbit "Review failed/skipped/closed-during-review"
+# messages were observed false-positive-classifying as real reviews.
+# t2799: split from RATE_LIMIT_PATTERNS; built as union so the two stay
+# consistent.
+NON_REVIEW_PATTERNS=(
+	"${RATE_LIMIT_PATTERNS[@]}"
 	"Review failed"
 	"Review skipped"
 	"closed or merged during review"
 	"Auto reviews are limited"
 )
-# Backwards-compat alias for any callers/tests still referencing the old name.
-RATE_LIMIT_PATTERNS=("${NON_REVIEW_PATTERNS[@]}")
 
 # Bots that post a Phase 1 placeholder and later edit it with real review
 # content. For these, age-derived settlement is unreliable — require
@@ -360,6 +370,20 @@ is_non_review_comment() {
 	return 1
 }
 
+# t2799: Check if a comment body matches a rate-limit-specific pattern only
+# (not the broader non-review set). Use when the caller cares specifically
+# about capacity-constrained bots that may retry later.
+is_rate_limit_only_comment() {
+	local body="$1"
+
+	for pattern in "${RATE_LIMIT_PATTERNS[@]}"; do
+		if echo "$body" | grep -qi "$pattern"; then
+			return 0
+		fi
+	done
+	return 1
+}
+
 bot_has_real_review() {
 	# t2139 (GH#19251): Check if a bot has posted at least one comment that
 	# is BOTH (a) not a known non-review notice AND (b) "settled" — meaning
@@ -526,12 +550,17 @@ do_check() {
 	local rate_limited_bots=""
 	for bot in "${KNOWN_BOTS[@]}"; do
 		if echo "$all_commenters" | grep -qi "$bot"; then
-			# Bot commented — but is it a real review or a rate-limit notice?
+			# Bot commented — but is it a real review or a non-review notice?
+			# t2799: "rate_limited_bots" is a legacy variable name — it covers
+			# all bots without a real review (rate-limited, "Review failed",
+			# "Review skipped", etc.). The grace-period / pass behaviour is the
+			# same for all non-review states; the semantic split lives in the
+			# pattern arrays (RATE_LIMIT_PATTERNS vs NON_REVIEW_PATTERNS).
 			if bot_has_real_review "$pr_number" "$repo" "$bot"; then
 				found_bots="${found_bots}${bot} "
 			else
 				rate_limited_bots="${rate_limited_bots}${bot} "
-				echo "rate-limited (not a real review): ${bot}" >&2
+				echo "non-review notice (not a real review): ${bot}" >&2
 			fi
 		fi
 	done
@@ -756,8 +785,11 @@ has_retry_comment() {
 }
 
 find_rate_limited_bots() {
-	# Return space-separated list of bots that posted only rate-limit notices.
-	# Empty string if no rate-limited bots found.
+	# Return space-separated list of bots that posted only non-review notices
+	# (rate-limit, "Review failed", "Review skipped", etc.).
+	# t2799: name is a legacy holdover — covers all non-review states, not
+	# just rate-limited. Kept for backwards compat with callers and the
+	# request-retry flow.
 	local pr_number="$1"
 	local repo="$2"
 

--- a/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
+++ b/.agents/scripts/tests/test-review-bot-gate-completion-signal.sh
@@ -170,6 +170,54 @@ Recommended changes: add a null check before line 42."
 	return 0
 }
 
+# t2799: is_rate_limit_only_comment matches the narrow 6-entry rate-limit set
+# only — NOT the broader non-review patterns ("Review failed", "Review
+# skipped", etc.). Used by grace-period logic where the semantic distinction
+# matters: a rate-limited bot may recover, a "Review skipped" bot will not.
+test_is_rate_limit_only_matches_rate_limit() {
+	if is_rate_limit_only_comment "Review skipped due to rate limit exceeded for this hour"; then
+		print_result "is_rate_limit_only_comment matches 'rate limit exceeded'" 0
+	else
+		print_result "is_rate_limit_only_comment matches 'rate limit exceeded'" 1
+	fi
+	return 0
+}
+
+test_is_rate_limit_only_rejects_review_failed() {
+	# "Review failed" is in NON_REVIEW_PATTERNS but NOT RATE_LIMIT_PATTERNS —
+	# this is the whole point of the t2799 split.
+	if ! is_rate_limit_only_comment "Review failed — Pull request was closed or merged during review."; then
+		print_result "is_rate_limit_only_comment rejects 'Review failed'" 0
+	else
+		print_result "is_rate_limit_only_comment rejects 'Review failed'" 1
+	fi
+	return 0
+}
+
+test_is_rate_limit_only_rejects_review_skipped() {
+	# Same: "Review skipped" / "Auto reviews are limited" are non-review but
+	# not rate-limit. Misclassifying these as rate-limited would trigger the
+	# grace-period retry path inappropriately.
+	if ! is_rate_limit_only_comment "Review skipped — Auto reviews are limited based on label configuration."; then
+		print_result "is_rate_limit_only_comment rejects 'Review skipped'" 0
+	else
+		print_result "is_rate_limit_only_comment rejects 'Review skipped'" 1
+	fi
+	return 0
+}
+
+test_is_rate_limit_only_rejects_real_review() {
+	local body="## Walkthrough
+
+This PR refactors the foo() function to handle the bar edge case."
+	if ! is_rate_limit_only_comment "$body"; then
+		print_result "is_rate_limit_only_comment rejects real review body" 0
+	else
+		print_result "is_rate_limit_only_comment rejects real review body" 1
+	fi
+	return 0
+}
+
 # ---------- Unit tests: settled-check ----------
 
 test_settled_recent_unedited_placeholder_rejected() {
@@ -397,6 +445,10 @@ main() {
 	test_is_non_review_comment_matches_review_skipped
 	test_is_non_review_comment_matches_closed_during_review
 	test_is_non_review_comment_rejects_real_review
+	test_is_rate_limit_only_matches_rate_limit
+	test_is_rate_limit_only_rejects_review_failed
+	test_is_rate_limit_only_rejects_review_skipped
+	test_is_rate_limit_only_rejects_real_review
 
 	echo ""
 	echo "=== Settled check ==="


### PR DESCRIPTION
## Summary

Restored RATE_LIMIT_PATTERNS to rate-limit-only semantics (6 entries) and rebuilt NON_REVIEW_PATTERNS as the 10-entry union, with is_rate_limit_only_comment() added for callers needing rate-limit-specific matching. Cherry-picked from closed PR #20775 (commit 40b04e902) onto current origin/main, with one conflict resolved: the deprecated is_rate_limit_comment() alias was dropped because PR #20776 already removed it from main.

## Files Changed

.agents/scripts/review-bot-gate-helper.sh,.agents/scripts/tests/test-review-bot-gate-completion-signal.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Re-ran .agents/scripts/tests/test-review-bot-gate-completion-signal.sh — 23/23 pass (added 4 new tests for is_rate_limit_only_comment covering positive rate-limit match, negative match against 'Review failed' / 'Review skipped' / real-review bodies). shellcheck clean on both modified files.

Resolves #20732


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.3 plugin for [OpenCode](https://opencode.ai) v1.14.24 with claude-opus-4-7 spent 5m and 10,351 tokens on this as a headless worker.