### PR TITLE
t2817: extend NOOP_RE to catch Gemini mid-sentence LGTM + zero-findings gate

### DIFF
--- a/.agents/scripts/post-merge-review-scanner.sh
+++ b/.agents/scripts/post-merge-review-scanner.sh
@@ -107,10 +107,18 @@ ACT_RE="should|consider|fix|change|update|refactor|missing|add"
 # containing "refactors" (matches ACT_RE "refactor"), then concludes with "I have
 # no feedback to provide." — the entire body is a description + LGTM, not an
 # actionable suggestion. NOOP_RE is applied as a deny-list in
-# fetch_review_summaries_md BEFORE the ACT_RE check. The phrases are specific
-# enough that false positives (a real review that also contains "no feedback to
-# provide" in a sub-clause) are rare in practice.
-NOOP_RE="(I have no feedback to provide|no feedback to provide|have no feedback|have no suggestions|no actionable feedback|no actionable suggestions|no further feedback|no issues to report|no suggestions to (add|provide|make))[[:space:][:punct:]]*$"
+# fetch_review_summaries_md BEFORE the ACT_RE check.
+#
+# Tradeoff (updated to cite #20792 incident, 2026-04-24): the end-anchor was
+# dropped deliberately. Gemini's exact phrasing on PR #20759 was "I have no
+# feedback to provide as there were no review comments." — the mid-sentence
+# continuation defeated the original end-anchored regex, causing a spurious
+# followup issue (#20792). We now prefer the occasional false negative (a real
+# review whose prose happens to include a noop substring mid-sentence loses its
+# issue creation) over the more frequent false positive (an empty LGTM fires a
+# dispatch cycle). Gemini's deterministic empty-review sentence makes the saving
+# repeatable; losing a genuine finding to an incidental phrase match is rare.
+NOOP_RE="(I have no feedback to provide|no feedback to provide|have no feedback|have no suggestions|no actionable feedback|no actionable suggestions|no further feedback|no issues to report|no suggestions to (add|provide|make)|no review comments)"
 
 log() { echo "[scanner] $*" >&2; }
 
@@ -543,7 +551,11 @@ build_pr_followup_body() {
 		return 2
 	fi
 
+	# Belt-and-braces zero-findings gate: even if NOOP_RE misses a new bot
+	# phrasing, an empty inline+review pair will never create an issue.
+	# Logging the skip makes the decision traceable in scanner output.
 	if [[ -z "$inline" && -z "$review" ]]; then
+		log "build_pr_followup_body: skip ${repo}#${pr} — zero findings (inline and review summaries both empty)"
 		return 1
 	fi
 

--- a/.agents/scripts/tests/test-post-merge-review-scanner.sh
+++ b/.agents/scripts/tests/test-post-merge-review-scanner.sh
@@ -577,6 +577,56 @@ assert_not_contains "do_scan does NOT flag for creation on fetch error" "Would c
 install_ok_gh
 
 # -----------------------------------------------------------------------------
+# NOOP_RE hardening tests (t2817 / GH#20818)
+#
+# Verify that Gemini's deterministic empty-review phrasing is filtered by the
+# updated NOOP_RE (end-anchor removed, "no review comments" added), and that
+# genuinely actionable prose containing noop substrings is NOT over-filtered.
+# -----------------------------------------------------------------------------
+
+echo ""
+echo "Test: NOOP_RE — Gemini exact phrasing from PR #20759 is filtered (mid-sentence no-review-comments)"
+write_graphql_fixture "$FIX_GRAPHQL"
+write_reviews_fixture "$FIX_REVIEWS" \
+	"gemini-code-assist" "This pull request updates the documentation in \`.agents/AGENTS.md\` to include a description of a new server-side safety net workflow. I have no feedback to provide as there were no review comments."
+out=$(fetch_review_summaries_md "stub/repo" "42")
+if [[ -z "$out" ]]; then
+	echo "  PASS: Gemini mid-sentence LGTM is filtered (empty output)"
+	PASS=$((PASS + 1))
+else
+	echo "  FAIL: Gemini mid-sentence LGTM was NOT filtered"
+	echo "    actual (first 200): ${out:0:200}"
+	FAIL=$((FAIL + 1))
+fi
+
+echo ""
+echo "Test: NOOP_RE — bare 'no review comments' phrase is filtered"
+write_graphql_fixture "$FIX_GRAPHQL"
+write_reviews_fixture "$FIX_REVIEWS" \
+	"gemini-code-assist" "LGTM. no review comments."
+out=$(fetch_review_summaries_md "stub/repo" "42")
+if [[ -z "$out" ]]; then
+	echo "  PASS: bare 'no review comments' is filtered (empty output)"
+	PASS=$((PASS + 1))
+else
+	echo "  FAIL: bare 'no review comments' was NOT filtered"
+	echo "    actual (first 200): ${out:0:200}"
+	FAIL=$((FAIL + 1))
+fi
+
+echo ""
+echo "Test: NOOP_RE positive control — actionable prose with 'feedback' keyword is preserved"
+# A real review that contains the word "feedback" in actionable prose should
+# NOT be suppressed by NOOP_RE. Only the exact deny-list phrases should match.
+write_graphql_fixture "$FIX_GRAPHQL"
+write_reviews_fixture "$FIX_REVIEWS" \
+	"gemini-code-assist" "## Code Review
+
+Some feedback: the function name should be more descriptive. POSITIVE_CONTROL_MARKER"
+out=$(fetch_review_summaries_md "stub/repo" "42")
+assert_contains "actionable prose with 'feedback' keyword is preserved" "POSITIVE_CONTROL_MARKER" "$out"
+
+# -----------------------------------------------------------------------------
 # Report
 # -----------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Extends `NOOP_RE` in `post-merge-review-scanner.sh` to catch Gemini's mid-sentence LGTM phrasing, and adds a belt-and-braces zero-findings gate with explicit logging.

## Changes

**Layer 1 — NOOP_RE hardening:**
- Dropped the `[[:space:][:punct:]]*$` end-anchor. Gemini's exact phrasing on PR #20759 was `"I have no feedback to provide as there were no review comments."` — the mid-sentence continuation defeated the anchored regex.
- Added `no review comments` to the alternation list.
- Updated the rationale comment to document the new tradeoff (prefer false negatives over false positives) and cite the triggering incident (#20792).

**Layer 2 — Zero-findings gate:**
- Added an explicit `log` message to the existing empty-findings early-return in `build_pr_followup_body`. Belt-and-braces defence against future bot phrasings not yet in NOOP_RE, with traceable log output.

**Tests:**
- New test: Gemini's exact phrasing from PR #20759 — asserts filtered (empty output).
- New test: Bare `no review comments` phrase — asserts filtered.
- New test: Positive control — actionable prose containing the word "feedback" — asserts preserved (not over-filtered).
- All 39 tests pass; shellcheck clean on both files.

## References

- Triggering incident: issue #20792 (closed Outcome A, 30K tokens, zero finding)
- Triggering PR: #20759
- Original filter: t2086 / PR #18947

Resolves #20818

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.3 plugin for [OpenCode](https://opencode.ai) v1.14.24 with claude-sonnet-4-6 spent 5m and 9,363 tokens on this as a headless worker.
