### PR TITLE
GH#20813: wire fingerprint dedup into framework-routing-helper, normalize body before hashing

### DIFF
--- a/.agents/scripts/framework-routing-helper.sh
+++ b/.agents/scripts/framework-routing-helper.sh
@@ -316,7 +316,34 @@ log_framework_issue() {
 		return 1
 	fi
 
-	# Dedup: search for existing issues with similar title
+	# Build body (before sig footer, so fingerprint is stable across paths)
+	if [[ -z "$body" ]]; then
+		body="$title"
+	fi
+
+	# Add source context if provided — BEFORE dedup so it's part of the identity
+	if [[ -n "$source_repo" ]]; then
+		body="${body}
+
+---
+*Detected by framework-routing-helper in \`${source_repo}\`.*"
+	fi
+
+	# Source canonical fingerprint dedup (shared state file, cross-path dedup)
+	# shellcheck source=./log-issue-helper.sh
+	source "${SCRIPT_DIR}/log-issue-helper.sh"
+
+	local dedup_result
+	dedup_result=$(check_recent_filing "$title" "$body" || true)
+	if [[ "$dedup_result" == DUPLICATE:* ]]; then
+		local dup_num="${dedup_result#DUPLICATE:}"
+		dup_num="${dup_num%%:*}"
+		log_info "Fingerprint duplicate within window: #${dup_num}"
+		echo "https://github.com/${slug}/issues/${dup_num}"
+		return 2
+	fi
+
+	# Secondary dedup: search-based (catches duplicates outside the dedup window)
 	local search_terms
 	search_terms=$(printf '%s' "$title" | sed 's/^[a-zA-Z0-9_-]*: *//')
 	if [[ -n "$search_terms" ]]; then
@@ -325,39 +352,32 @@ log_framework_issue() {
 			--state open --search "$search_terms" \
 			--json number,url --limit 1 -q '.[0].url' 2>/dev/null || echo "")
 		if [[ -n "$existing" && "$existing" != "null" ]]; then
-			log_info "Duplicate found: $existing"
+			log_info "Duplicate found (search): $existing"
 			echo "$existing"
 			return 2
 		fi
 	fi
 
-	# Build body
-	if [[ -z "$body" ]]; then
-		body="$title"
-	fi
-
-	# Add source context if provided
-	if [[ -n "$source_repo" ]]; then
-		body="${body}
-
----
-*Detected by framework-routing-helper in \`${source_repo}\`.*"
-	fi
-
-	# Append signature footer
+	# Append signature footer only for the API call body (not for fingerprinting)
+	local body_for_api="$body"
 	local sig_footer=""
 	sig_footer=$("${HOME}/.aidevops/agents/scripts/gh-signature-helper.sh" footer --body "$body" 2>/dev/null || true)
-	body="${body}${sig_footer}"
+	body_for_api="${body}${sig_footer}"
 
 	# Create the issue
 	local issue_url
 	if ! issue_url=$(gh_create_issue --repo "$slug" \
 		--title "$title" \
-		--body "$body" \
+		--body "$body_for_api" \
 		--label "$labels" 2>&1); then
 		log_error "Failed to create issue: $issue_url"
 		return 1
 	fi
+
+	# Record fingerprint for future cross-path dedup (body without sig footer)
+	local issue_number
+	issue_number=$(printf '%s' "$issue_url" | sed 's|.*/||')
+	record_filing "$title" "$body" "$issue_number"
 
 	log_success "Framework issue created: $issue_url"
 	echo "$issue_url"

--- a/.agents/scripts/log-issue-helper.sh
+++ b/.agents/scripts/log-issue-helper.sh
@@ -204,10 +204,32 @@ _log_issue_dedup_window() {
 	return 0
 }
 
+_normalize_body_for_fingerprint() {
+	local body="$1"
+	# Strip aidevops sig footer (everything from <!-- aidevops:sig --> to end)
+	body=$(printf '%s' "$body" | awk '/<!-- aidevops:sig -->/{exit} {print}')
+	# Strip "*Detected by ... in `...`.*" source-context trailer lines
+	# shellcheck disable=SC2016
+	body=$(printf '%s' "$body" | sed '/^\*Detected by .*\*[[:space:]]*$/d')
+	# Strip trailing blank lines and standalone "---" separator lines
+	body=$(printf '%s' "$body" | awk '
+		{lines[NR]=$0}
+		END {
+			n=NR
+			while (n>0 && (lines[n]=="" || lines[n]=="---")) n--
+			for (i=1; i<=n; i++) print lines[i]
+		}
+	')
+	printf '%s' "$body"
+	return 0
+}
+
 _compute_issue_fingerprint() {
 	local title="$1"
 	local body="$2"
-	local input="${title}|${body}"
+	local normalized_body
+	normalized_body=$(_normalize_body_for_fingerprint "$body")
+	local input="${title}|${normalized_body}"
 	local hash=""
 
 	if command -v shasum &>/dev/null; then
@@ -473,4 +495,6 @@ EOF
 	return 0
 }
 
-main "$@"
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+	main "$@"
+fi

--- a/.agents/tests/log-issue-helper.bats
+++ b/.agents/tests/log-issue-helper.bats
@@ -1,0 +1,191 @@
+#!/usr/bin/env bats
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# Tests for log-issue-helper.sh fingerprint dedup
+# =============================================================================
+# Run: bats .agents/tests/log-issue-helper.bats
+#
+# Covers GH#20813:
+#   - _normalize_body_for_fingerprint strips sig footer and source trailers
+#   - Cross-path dedup: same (title, body) filed via two paths hashes the same
+#   - check_recent_filing / record_filing round-trip dedup
+
+SCRIPT_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME:-$0}")/.." && pwd)/scripts"
+HELPER="${SCRIPT_DIR}/log-issue-helper.sh"
+
+# Use a temp state dir for each test run
+setup() {
+	export TEST_TMPDIR
+	TEST_TMPDIR=$(mktemp -d)
+	export HOME="$TEST_TMPDIR/home"
+	mkdir -p "${HOME}/.aidevops/state"
+	# Shorten dedup window to 60s for tests
+	export LOG_ISSUE_DEDUP_WINDOW_SECONDS=60
+}
+
+teardown() {
+	rm -rf "$TEST_TMPDIR"
+}
+
+# Source the helper once so functions are available across tests
+_source_helper() {
+	# shellcheck source=../scripts/log-issue-helper.sh
+	source "$HELPER"
+}
+
+# =============================================================================
+# _normalize_body_for_fingerprint
+# =============================================================================
+
+@test "_normalize_body_for_fingerprint: strips aidevops sig footer" {
+	_source_helper
+	local body
+	body="$(printf 'Main body content\n<!-- aidevops:sig -->\nsome sig block')"
+	local result
+	result=$(_normalize_body_for_fingerprint "$body")
+	[[ "$result" == "Main body content" ]]
+}
+
+@test "_normalize_body_for_fingerprint: strips Detected-by trailer and trailing ---" {
+	_source_helper
+	local body
+	body="$(printf 'Main body content\n\n---\n*Detected by framework-routing-helper in \`owner/repo\`.*')"
+	local result
+	result=$(_normalize_body_for_fingerprint "$body")
+	[[ "$result" == "Main body content" ]]
+}
+
+@test "_normalize_body_for_fingerprint: strips Detected-by but preserves mid-body ---" {
+	_source_helper
+	local body
+	body="$(printf 'Section A\n\n---\n\nSection B\n\n---\n*Detected by framework-routing-helper in \`owner/repo\`.*')"
+	local result
+	result=$(_normalize_body_for_fingerprint "$body")
+	# The mid-body --- should still be present; only trailing --- is stripped
+	[[ "$result" == *"Section A"* ]] && [[ "$result" == *"Section B"* ]]
+}
+
+@test "_normalize_body_for_fingerprint: idempotent on body without suffix" {
+	_source_helper
+	local body="Plain issue body with no suffix"
+	local result
+	result=$(_normalize_body_for_fingerprint "$body")
+	[[ "$result" == "$body" ]]
+}
+
+# =============================================================================
+# _compute_issue_fingerprint: cross-path normalization
+# =============================================================================
+
+@test "_compute_issue_fingerprint: body with trailer == body without trailer" {
+	_source_helper
+	local title="test: fingerprint normalization"
+	local body_plain="Some issue body text"
+	local body_with_trailer
+	body_with_trailer="$(printf '%s\n\n---\n*Detected by framework-routing-helper in \`owner/repo\`.*' "$body_plain")"
+
+	local fp_plain fp_with_trailer
+	fp_plain=$(_compute_issue_fingerprint "$title" "$body_plain")
+	fp_with_trailer=$(_compute_issue_fingerprint "$title" "$body_with_trailer")
+
+	[[ "$fp_plain" == "$fp_with_trailer" ]]
+}
+
+@test "_compute_issue_fingerprint: body with sig footer == body without sig footer" {
+	_source_helper
+	local title="test: sig footer normalization"
+	local body_plain="Some issue body text"
+	local body_with_sig
+	body_with_sig="$(printf '%s\n<!-- aidevops:sig -->\nsig content' "$body_plain")"
+
+	local fp_plain fp_with_sig
+	fp_plain=$(_compute_issue_fingerprint "$title" "$body_plain")
+	fp_with_sig=$(_compute_issue_fingerprint "$title" "$body_with_sig")
+
+	[[ "$fp_plain" == "$fp_with_sig" ]]
+}
+
+@test "_compute_issue_fingerprint: different bodies produce different fingerprints" {
+	_source_helper
+	local fp1 fp2
+	fp1=$(_compute_issue_fingerprint "title" "body A")
+	fp2=$(_compute_issue_fingerprint "title" "body B")
+	[[ "$fp1" != "$fp2" ]]
+}
+
+# =============================================================================
+# check_recent_filing / record_filing round-trip
+# =============================================================================
+
+@test "check_recent_filing returns OK when no state file" {
+	_source_helper
+	local result
+	result=$(check_recent_filing "my title" "my body")
+	[[ "$result" == "OK" ]]
+}
+
+@test "record_filing then check_recent_filing returns DUPLICATE" {
+	_source_helper
+	local title="dedup: integration test"
+	local body="Issue body content"
+
+	record_filing "$title" "$body" 99999
+
+	local result
+	result=$(check_recent_filing "$title" "$body" || true)
+	[[ "$result" == DUPLICATE:99999:* ]]
+}
+
+@test "cross-path dedup: body-with-trailer filed after body-plain returns DUPLICATE" {
+	_source_helper
+	local title="dedup: cross-path test"
+	local body_plain="Issue body content"
+	local body_with_trailer
+	body_with_trailer="$(printf '%s\n\n---\n*Detected by framework-routing-helper in \`owner/repo\`.*' "$body_plain")"
+
+	# Path A: file via /log-issue-aidevops (no trailer)
+	record_filing "$title" "$body_plain" 10001
+
+	# Path B: framework-routing-helper fires with trailer
+	local result
+	result=$(check_recent_filing "$title" "$body_with_trailer" || true)
+	[[ "$result" == DUPLICATE:10001:* ]]
+}
+
+@test "cross-path dedup: body-with-sig filed after body-with-trailer returns DUPLICATE" {
+	_source_helper
+	local title="dedup: sig+trailer cross-path test"
+	local body_plain="Issue body content"
+	local body_with_trailer
+	body_with_trailer="$(printf '%s\n\n---\n*Detected by framework-routing-helper in \`owner/repo\`.*' "$body_plain")"
+	local body_with_sig_and_trailer
+	body_with_sig_and_trailer="$(printf '%s\n<!-- aidevops:sig -->\nsig block' "$body_with_trailer")"
+
+	# Path A: framework-routing-helper filed (body + trailer)
+	record_filing "$title" "$body_with_trailer" 10002
+
+	# Path B: same but body has sig footer too
+	local result
+	result=$(check_recent_filing "$title" "$body_with_sig_and_trailer" || true)
+	[[ "$result" == DUPLICATE:10002:* ]]
+}
+
+@test "check_recent_filing returns OK after dedup window expires" {
+	_source_helper
+	local title="dedup: window expiry test"
+	local body="Issue body content"
+	local fp_file
+	fp_file=$(_log_issue_fingerprint_file)
+
+	# Inject an expired record (epoch 1 = far in the past)
+	local fingerprint
+	fingerprint=$(_compute_issue_fingerprint "$title" "$body")
+	printf '{"hash":"%s","issue":77777,"filed_at":"2020-01-01T00:00:00Z","filed_epoch":1}\n' \
+		"$fingerprint" >> "$fp_file"
+
+	# Should NOT deduplicate — record is outside the window
+	local result
+	result=$(check_recent_filing "$title" "$body")
+	[[ "$result" == "OK" ]]
+}

--- a/.agents/tests/log-issue-helper.bats
+++ b/.agents/tests/log-issue-helper.bats
@@ -10,6 +10,12 @@
 #   - _normalize_body_for_fingerprint strips sig footer and source trailers
 #   - Cross-path dedup: same (title, body) filed via two paths hashes the same
 #   - check_recent_filing / record_filing round-trip dedup
+#
+# shellcheck disable=SC2016
+# Single-quoted printf format strings contain literal backticks (escaped \`...\`)
+# and `$N` placeholders that are intentional test fixtures, not unexpanded
+# expressions. Bats fixtures routinely use this pattern; SC2016 is a false
+# positive in this file.
 
 SCRIPT_DIR="$(cd "$(dirname "${BATS_TEST_FILENAME:-$0}")/.." && pwd)/scripts"
 HELPER="${SCRIPT_DIR}/log-issue-helper.sh"


### PR DESCRIPTION
## Summary

Fixes the cross-path duplicate-issue gap exposed by GH#20807/GH#20808 (filed 36s apart about the same root cause — one via \`/log-issue-aidevops\`, one via \`framework-routing-helper.sh\`).

## Changes

### Fix 1 — \`framework-routing-helper.sh::log_framework_issue\` (GH#20813 How §1)

- Build body + source trailer **before** the dedup check (trailer is part of the issue identity)
- Source \`log-issue-helper.sh\` and call \`check_recent_filing\` before \`gh_create_issue\`
- Keep the existing \`gh issue list --search\` block as a **secondary** check (catches duplicates outside the window)
- Call \`record_filing\` after successful creation (body without sig footer, so the hash is stable)
- Use separate \`body_for_api\` variable to keep sig footer out of the fingerprint

### Fix 2 — \`log-issue-helper.sh::_compute_issue_fingerprint\` (GH#20813 How §2)

- New \`_normalize_body_for_fingerprint()\` strips before hashing:
  - aidevops sig footer (\`<!-- aidevops:sig -->\` to end)
  - \`*Detected by ... in \`...\`.*\` source-context trailer lines
  - Trailing blank lines and standalone \`---\` separators
- \`_compute_issue_fingerprint\` now normalizes body before hashing — same \`(title, body)\` + \`(title, body+trailer)\` produce the same fingerprint
- Add \`BASH_SOURCE\` guard so \`log-issue-helper.sh\` is safely sourceable as a library without running \`main\`

### Tests — \`.agents/tests/log-issue-helper.bats\` (new file)

Covers all acceptance criteria:
- \`_normalize_body_for_fingerprint\`: sig footer, Detected-by trailer, mid-body \`---\` preserved, idempotent
- \`_compute_issue_fingerprint\`: cross-path normalization, different bodies differ
- \`check_recent_filing\`/\`record_filing\` round-trip: dedup, cross-path dedup, window expiry

## Verification

```bash
grep -n 'check_recent_filing\|record_filing' .agents/scripts/framework-routing-helper.sh
# → 2 matches (lines 337 and 380)

grep -n '_normalize_body_for_fingerprint' .agents/scripts/log-issue-helper.sh
# → 3 matches (definition at 207, call at 231)

shellcheck .agents/scripts/framework-routing-helper.sh .agents/scripts/log-issue-helper.sh
# → no violations

bats .agents/tests/log-issue-helper.bats
# → all tests pass (verified via bash inline test runner)
```

Resolves #20813

## Complexity Bump Justification

This PR grows `log_framework_issue` from 93 lines to 113 lines (**base=93, head=113, +20, threshold=100**) — verified by `awk '/^log_framework_issue\(\)/,/^}/' .agents/scripts/framework-routing-helper.sh | wc -l` against `origin/main` and the PR head. The Complexity Analysis gate reports the gross body as 112 (excluding the function-name line), matching this measurement.

The growth is the fix itself — wiring the canonical fingerprint dedup into `log_framework_issue` requires:

- `.agents/scripts/framework-routing-helper.sh:319-345` — build body+trailer before dedup, source `log-issue-helper.sh`, call `check_recent_filing`, return DUPLICATE branch
- `.agents/scripts/framework-routing-helper.sh:354-380` — separate `body_for_api` (with sig footer) from fingerprint body (without), call `record_filing` after successful creation

Splitting this would scatter the "build identity → dedup → create → record" flow across helpers without improving readability — the function is one coherent transaction with two early-exit paths (dedup hit, gh-create failure). Per `reference/large-file-split.md` §0, function bodies that represent a single linear transaction should not be artificially fragmented to satisfy threshold gates.

Override label: `complexity-bump-ok`.
