### PR TITLE
GH#20807: fix(issue-sync): closing-keyword-only status:done — word-boundary regex + For/Ref veto guard

### DIFF
--- a/.agents/scripts/tests/test-reusable-workflow-caller.sh
+++ b/.agents/scripts/tests/test-reusable-workflow-caller.sh
@@ -411,6 +411,43 @@ if [[ -f "$RBG_REUSABLE_WF" ]]; then
 fi
 
 # ---------------------------------------------------------------------------
+# Tests 15-17: GH#20807 — closing-keyword-only semantics in sync-on-pr-merge
+# Verifies the issue-sync-reusable.yml extract step uses word-boundary regex
+# for LINKED_ISSUES and that FOR_REF_ISSUES is passed to Apply closing hygiene.
+# ---------------------------------------------------------------------------
+
+# Test 15: LINKED_ISSUES regex uses \b word-boundary anchors
+if [[ -f "$REUSABLE_WF" ]]; then
+	if grep -qE "grep.*\\\\b.*close\[ds\]\?.*resolve\[ds\]\?" "$REUSABLE_WF" 2>/dev/null; then
+		_pass "LINKED_ISSUES regex uses \\b word-boundary anchors (GH#20807)"
+	else
+		_fail "LINKED_ISSUES regex uses \\b word-boundary anchors (GH#20807)" \
+			"expected '\\b(close[ds]?|...) pattern in LINKED_ISSUES extraction — without \\b, substrings like 'discloses' match 'closes'"
+	fi
+fi
+
+# Test 16: FOR_REF_ISSUES is passed to the Apply closing hygiene step
+if [[ -f "$REUSABLE_WF" ]]; then
+	# The env var should appear in the Apply closing hygiene step env block
+	if grep -qE "FOR_REF_ISSUES:.*steps\.extract\.outputs\.for_ref_issues" "$REUSABLE_WF" 2>/dev/null; then
+		_pass "FOR_REF_ISSUES passed to Apply closing hygiene step (GH#20807)"
+	else
+		_fail "FOR_REF_ISSUES passed to Apply closing hygiene step (GH#20807)" \
+			"expected 'FOR_REF_ISSUES: \${{ steps.extract.outputs.for_ref_issues }}' in Apply closing hygiene env — without this, Ref/For issues could receive status:done"
+	fi
+fi
+
+# Test 17: Apply closing hygiene step has explicit FOR_REF_ISSUES veto guard
+if [[ -f "$REUSABLE_WF" ]]; then
+	if grep -qE "grep.*-xv.*_ref_num|for _ref_num in.*FOR_REF" "$REUSABLE_WF" 2>/dev/null; then
+		_pass "Apply closing hygiene has FOR_REF_ISSUES veto guard (GH#20807)"
+	else
+		_fail "Apply closing hygiene has FOR_REF_ISSUES veto guard (GH#20807)" \
+			"expected 'for _ref_num in \$FOR_REF_ISSUES' filter in Apply closing hygiene — this guard prevents Ref/For issues from receiving status:done even if the keyword regex false-positives"
+	fi
+fi
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 

--- a/.github/workflows/issue-sync-reusable.yml
+++ b/.github/workflows/issue-sync-reusable.yml
@@ -417,10 +417,15 @@ jobs:
           fi
           echo "task_id=$TASK_ID" >> "$GITHUB_OUTPUT"
 
-          # Collect linked issue numbers from PR body (Closes #NNN, Fixes #NNN, Resolves #NNN)
+          # Collect linked issue numbers from PR body (Closes #NNN, Fixes #NNN, Resolves #NNN).
+          # GH#20807: Use canonical closing-keyword-only regex from pulse-merge.sh::_extract_linked_issue.
+          # Changes from prior regex:
+          #   1. \b word-boundary anchors prevent substring matches (e.g. "discloses #NNN" → "closes")
+          #   2. close[ds]?  / fix(es|ed)? / resolve[ds]? match all grammatical forms (closed, fixed, etc.)
+          #   3. [[:space:]]+ (mandatory) instead of [[:space:]]* (zero-or-more) prevents "closes#NNN"
           LINKED_ISSUES=""
           if [[ -n "$PR_BODY" ]]; then
-            LINKED_ISSUES=$(echo "$PR_BODY" | grep -oiE '(closes?|fixes?|resolves?)[[:space:]]*#[0-9]+' | grep -oE '[0-9]+' | sort -u | tr '\n' ' ' || true)
+            LINKED_ISSUES=$(printf '%s' "$PR_BODY" | grep -ioE '\b(close[ds]?|fix(es|ed)?|resolve[ds]?)\b[[:space:]]+#[0-9]+' | grep -oE '[0-9]+' | sort -u | tr '\n' ' ' || true)
           fi
           echo "linked_issues=$LINKED_ISSUES" >> "$GITHUB_OUTPUT"
 
@@ -510,6 +515,9 @@ jobs:
           PR_URL: ${{ github.event.pull_request.html_url }}
           LINKED_ISSUES: ${{ steps.extract.outputs.linked_issues }}
           FOUND_ISSUES: ${{ steps.find-issue.outputs.found_issues }}
+          # GH#20807: pass For/Ref issues explicitly so we can guard against false status:done.
+          # "Ref #NNN" / "For #NNN" are non-closing references — must NEVER receive status:done.
+          FOR_REF_ISSUES: ${{ steps.extract.outputs.for_ref_issues }}
           TASK_ID: ${{ steps.extract.outputs.task_id }}
           REPO: ${{ github.repository }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -517,6 +525,19 @@ jobs:
           # Merge all issue numbers (from PR body + fallback search)
           ALL_ISSUES="$LINKED_ISSUES $FOUND_ISSUES"
           ALL_ISSUES=$(echo "$ALL_ISSUES" | tr ' ' '\n' | sort -u | { grep -v '^$' || true; } | tr '\n' ' ')
+
+          # GH#20807: Guard — explicitly remove any For/Ref referenced issues from ALL_ISSUES.
+          # Closing-keyword regex may still produce false positives via substring matches
+          # (e.g. "discloses #NNN" would match the "closes" pattern). For/Ref references are
+          # the authoritative "this PR does NOT close that issue" signal from the author, so
+          # they unconditionally veto status:done regardless of what the keyword scan extracted.
+          if [[ -n "${FOR_REF_ISSUES:-}" ]]; then
+            for _ref_num in $FOR_REF_ISSUES; do
+              [[ -z "$_ref_num" ]] && continue
+              ALL_ISSUES=$(echo "$ALL_ISSUES" | tr ' ' '\n' | grep -xv "$_ref_num" | tr '\n' ' ')
+            done
+            ALL_ISSUES=$(echo "$ALL_ISSUES" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+          fi
 
           if [[ -z "$ALL_ISSUES" ]]; then
             echo "No linked issues found — skipping closing hygiene"


### PR DESCRIPTION
## Summary

Fixes GH#20807: issue-sync mislabels open sibling task as status:done when same PR completes a different task. The LINKED_ISSUES regex now uses \b word-boundary anchors (canonical pattern from pulse-merge.sh) and the Apply closing hygiene step has an explicit For/Ref veto guard that removes non-closing references from ALL_ISSUES before status:done is applied.

## Files Changed

.agents/scripts/tests/test-reusable-workflow-caller.sh,.github/workflows/issue-sync-reusable.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** All 22 tests in test-reusable-workflow-caller.sh pass including 3 new tests (15-17) verifying the fix invariants. ShellCheck clean.

Resolves #20807


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.3 plugin for [OpenCode](https://opencode.ai) v1.14.24 with claude-sonnet-4-6 spent 20m and 55,176 tokens on this as a headless worker.