### PR TITLE
t2822: fix(issue-triage-gate): remove title-prefix bypass that lets external contributors evade needs-maintainer-review

### DIFF
--- a/.github/workflows/issue-triage-gate.yml
+++ b/.github/workflows/issue-triage-gate.yml
@@ -22,17 +22,10 @@ jobs:
             const issue = context.payload.issue;
             const author = issue.user.login;
             const association = issue.author_association;
-            const title = issue.title || '';
 
             // Bot accounts always bypass triage (github-actions[bot], dependabot, etc.)
             if (issue.user.type === 'Bot') {
               console.log(`Author ${author} is a bot — bypassing triage`);
-              return;
-            }
-
-            // Issues with task ID prefix (t1234: ...) are from internal tooling — bypass
-            if (/^t\d+/.test(title)) {
-              console.log(`Issue "${title}" has task ID prefix — bypassing triage`);
               return;
             }
 


### PR DESCRIPTION
## Summary

Removes the `/^t\d+/` title-prefix bypass in `issue-triage-gate.yml` that allowed any external contributor to evade `needs-maintainer-review` by opening an issue titled `t1234: ...`.

## Root Cause

The bypass check fired **before** the `authorAssociation` validation:

```js
// Issues with task ID prefix (t1234: ...) are from internal tooling — bypass
if (/^t\d+/.test(title)) {
  return;  // ← skips NMR application, fires for ANY author
}
```

An external `CONTRIBUTOR` or `NONE` author naming their issue `t1234: malicious content` would return early here, bypassing all downstream triage logic.

## Why the Check Was Redundant

- **Bot-created issues** already bypass via `issue.user.type === 'Bot'`
- **OWNER/MEMBER/COLLABORATOR** already bypass via the `trustedRoles` array
- No legitimate external scenario should bypass triage via a title pattern

## Fix

Remove the 5-line bypass block and the now-unused `title` variable. The logic order is now: Bot check → trusted-role check → triage gate.

Resolves #20816


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.3 plugin for [OpenCode](https://opencode.ai) v1.14.24 with claude-sonnet-4-6 spent 8m and 7,944 tokens on this as a headless worker.