### PR TITLE
t2823: auto-emit blocked-by from predecessor references in claim-task-id.sh

### DIFF
--- a/.agents/scripts/claim-task-id-issue.sh
+++ b/.agents/scripts/claim-task-id-issue.sh
@@ -517,6 +517,12 @@ _ensure_todo_entry_written() {
 	[[ -z "$safe_desc" ]] && safe_desc="(no description)"
 	local todo_line="- [ ] ${task_id} ${safe_desc}"
 	[[ -n "$tags_str" ]] && todo_line="${todo_line} ${tags_str}"
+	# GH#20834: append blocked-by tag when predecessor refs were auto-detected.
+	# _CLAIM_BLOCKED_BY_REFS is populated by _apply_blocked_by_detection in
+	# claim-task-id.sh before _ensure_todo_entry_written is called.
+	if [[ -n "${_CLAIM_BLOCKED_BY_REFS:-}" ]]; then
+		todo_line="${todo_line} blocked-by:${_CLAIM_BLOCKED_BY_REFS}"
+	fi
 	todo_line="${todo_line} ref:GH#${issue_num}"
 
 	_insert_todo_line "$todo_file" "$todo_line"

--- a/.agents/scripts/claim-task-id.sh
+++ b/.agents/scripts/claim-task-id.sh
@@ -26,6 +26,8 @@
 #                              or value from .aidevops.json "counter_branch" key)
 #   --skip-label-validation    Skip pre-flight label existence check (useful for
 #                              bulk --count N allocation or when gh is rate-limited)
+#   --no-blocked-by            Suppress auto-detection of predecessor references
+#                              and blocked-by tag emission (GH#20834)
 #
 # Project-level config (.aidevops.json in repo root):
 #   {
@@ -123,9 +125,12 @@ OFFLINE_MODE=false
 DRY_RUN=false
 NO_ISSUE=false
 SKIP_LABEL_VALIDATION=false
+NO_BLOCKED_BY=false
 TASK_TITLE=""
 TASK_DESCRIPTION=""
 TASK_LABELS=""
+# GH#20834: populated by _detect_predecessor_refs; read by _ensure_todo_entry_written
+_CLAIM_BLOCKED_BY_REFS=""
 REPO_PATH="$PWD"
 ALLOC_COUNT=1
 OFFLINE_OFFSET=100
@@ -242,6 +247,10 @@ parse_args() {
 			;;
 		--skip-label-validation)
 			SKIP_LABEL_VALIDATION=true
+			shift
+			;;
+		--no-blocked-by)
+			NO_BLOCKED_BY=true
 			shift
 			;;
 		--dry-run)
@@ -863,6 +872,11 @@ _main_output_results() {
 		echo "ref=none"
 	fi
 
+	# GH#20834: emit blocked-by refs when auto-detected from description
+	if [[ -n "${_CLAIM_BLOCKED_BY_REFS:-}" ]]; then
+		echo "blocked_by=${_CLAIM_BLOCKED_BY_REFS}"
+	fi
+
 	return 0
 }
 
@@ -1030,6 +1044,106 @@ _pre_claim_discovery_pass() {
 	return $?
 }
 
+# ---------------------------------------------------------------------------
+# Predecessor reference detection (GH#20834)
+#
+# Scans description text for prose references to predecessor tasks and
+# emits a comma-separated list of IDs for automatic blocked-by tagging.
+#
+# Recognised patterns (case-insensitive):
+#   1. "Follow-up from tNNN" / "Follow-up from GH#NNN"
+#   2. "tracked in GH#NNN" / "tracked in #NNN"
+#   3. "blocked-by: tNNN" / "blocked-by:GH#NNN"  (explicit pass-through)
+#   4. "after tNNN ships/merges/lands"
+#
+# Outputs comma-separated IDs on stdout. Empty output means no refs found.
+# Bare "#NNN" references in pattern 2 are normalised to "GH#NNN".
+#
+# The caller stores the result in the global _CLAIM_BLOCKED_BY_REFS.
+# _ensure_todo_entry_written reads _CLAIM_BLOCKED_BY_REFS to append the
+# blocked-by tag to the TODO.md line it writes.
+# ---------------------------------------------------------------------------
+_detect_predecessor_refs() {
+	local text="$1"
+	[[ -z "$text" ]] && return 0
+
+	local -a all_refs=()
+	local ref _tmpout
+
+	# Pattern 1: "Follow-up from tNNN" or "Follow-up from GH#NNN"
+	_tmpout=$(printf '%s' "$text" \
+		| grep -oiE 'follow-up from (t[0-9]+|GH#[0-9]+)' \
+		| grep -oE '(t[0-9]+|GH#[0-9]+)' 2>/dev/null || true)
+	while IFS= read -r ref; do
+		[[ -n "$ref" ]] && all_refs+=("$ref")
+	done <<<"$_tmpout"
+
+	# Pattern 2: "tracked in GH#NNN" or "tracked in #NNN"
+	_tmpout=$(printf '%s' "$text" \
+		| grep -oiE 'tracked in (GH#[0-9]+|#[0-9]+)' \
+		| grep -oE '(GH#[0-9]+|#[0-9]+)' 2>/dev/null || true)
+	while IFS= read -r ref; do
+		[[ -z "$ref" ]] && continue
+		# Normalise bare #NNN → GH#NNN
+		[[ "$ref" =~ ^#[0-9]+$ ]] && ref="GH${ref}"
+		all_refs+=("$ref")
+	done <<<"$_tmpout"
+
+	# Pattern 3: explicit "blocked-by:tNNN" or "blocked-by: GH#NNN" (pass-through)
+	_tmpout=$(printf '%s' "$text" \
+		| grep -oiE 'blocked-by:?[[:space:]]*(t[0-9]+|GH#[0-9]+)' \
+		| grep -oE '(t[0-9]+|GH#[0-9]+)' 2>/dev/null || true)
+	while IFS= read -r ref; do
+		[[ -n "$ref" ]] && all_refs+=("$ref")
+	done <<<"$_tmpout"
+
+	# Pattern 4: "after tNNN ships/merges/lands"
+	_tmpout=$(printf '%s' "$text" \
+		| grep -oiE 'after t[0-9]+ (ships|merges|lands)' \
+		| grep -oE 't[0-9]+' 2>/dev/null || true)
+	while IFS= read -r ref; do
+		[[ -n "$ref" ]] && all_refs+=("$ref")
+	done <<<"$_tmpout"
+
+	[[ ${#all_refs[@]} -eq 0 ]] && return 0
+
+	# Deduplicate preserving insertion order.
+	local -a deduped=()
+	local seen=""
+	for ref in "${all_refs[@]}"; do
+		if [[ ",${seen}," != *",${ref},"* ]]; then
+			deduped+=("$ref")
+			seen="${seen:+${seen},}${ref}"
+		fi
+	done
+
+	# Output comma-separated
+	local csv=""
+	for ref in "${deduped[@]}"; do
+		csv="${csv:+${csv},}${ref}"
+	done
+	printf '%s' "$csv"
+	return 0
+}
+
+# _apply_blocked_by_detection — populate _CLAIM_BLOCKED_BY_REFS from description.
+# Skipped when NO_BLOCKED_BY=true, TASK_DESCRIPTION is empty, or dry-run.
+# Emits advisory to stderr when predecessor refs are found.
+_apply_blocked_by_detection() {
+	_CLAIM_BLOCKED_BY_REFS=""
+	[[ "$NO_BLOCKED_BY" == "true" ]] && return 0
+	[[ -z "$TASK_DESCRIPTION" ]] && return 0
+	[[ "$DRY_RUN" == "true" ]] && return 0
+
+	local detected
+	detected=$(_detect_predecessor_refs "$TASK_DESCRIPTION") || true
+	[[ -z "$detected" ]] && return 0
+
+	_CLAIM_BLOCKED_BY_REFS="$detected"
+	log_warn "GH#20834: Detected predecessor reference(s) in description; auto-emitting blocked-by:${detected}. Override with --no-blocked-by."
+	return 0
+}
+
 # Main execution
 main() {
 	parse_args "$@"
@@ -1037,6 +1151,10 @@ main() {
 	# Load project config after parse_args so REPO_PATH is resolved,
 	# but before detect_platform so REMOTE_NAME is set correctly.
 	load_project_config "$REPO_PATH"
+
+	# GH#20834: detect predecessor refs in description and populate
+	# _CLAIM_BLOCKED_BY_REFS for use by _ensure_todo_entry_written.
+	_apply_blocked_by_detection
 
 	if [[ "$DRY_RUN" == "true" ]]; then
 		log_info "DRY RUN mode - no changes will be made"

--- a/.agents/scripts/tests/test-claim-blocked-by-detection.sh
+++ b/.agents/scripts/tests/test-claim-blocked-by-detection.sh
@@ -1,0 +1,225 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-claim-blocked-by-detection.sh — GH#20834 regression guard.
+#
+# Validates _detect_predecessor_refs() in claim-task-id.sh correctly extracts
+# predecessor references from description text and emits comma-separated IDs.
+#
+# Cases covered:
+#   1. Pattern 1: "Follow-up from tNNN"          → t-style ref
+#   2. Pattern 1: "Follow-up from GH#NNN"         → GH# ref
+#   3. Pattern 2: "tracked in GH#NNN"             → GH# ref
+#   4. Pattern 2: "tracked in #NNN"               → normalised to GH#NNN
+#   5. Pattern 3: "blocked-by:tNNN"               → explicit pass-through
+#   6. Pattern 3: "blocked-by: GH#NNN" (space)    → explicit pass-through
+#   7. Pattern 4: "after tNNN ships"              → t-style ref
+#   8. Pattern 4: "after tNNN merges"             → t-style ref
+#   9. Pattern 4: "after tNNN lands"              → t-style ref
+#  10. Multiple patterns in one description        → comma-separated, ordered
+#  11. Deduplication: same ref via two patterns    → emitted only once
+#  12. No-match description                        → empty output
+#  13. Empty description                           → empty output
+#  14. --no-blocked-by suppresses detection        → _CLAIM_BLOCKED_BY_REFS stays empty
+#
+# NOTE: not using `set -e` — assertions rely on capturing non-zero exits.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+CLAIM_SCRIPT="${SCRIPT_DIR}/../claim-task-id.sh"
+
+RED=$'\033[0;31m'
+GREEN=$'\033[0;32m'
+NC=$'\033[0m'
+
+PASS=0
+FAIL=0
+ERRORS=""
+
+# ---------------------------------------------------------------------------
+# Test framework helpers
+# ---------------------------------------------------------------------------
+
+pass() {
+	local name="${1:-}"
+	printf '%s[PASS]%s %s\n' "$GREEN" "$NC" "$name"
+	PASS=$((PASS + 1))
+	return 0
+}
+
+fail() {
+	local name="${1:-}"
+	local detail="${2:-}"
+	printf '%s[FAIL]%s %s\n' "$RED" "$NC" "$name"
+	[[ -n "$detail" ]] && printf '       expected: %s\n' "$detail"
+	FAIL=$((FAIL + 1))
+	ERRORS="${ERRORS}\n  - ${name}: ${detail}"
+	return 0
+}
+
+assert_eq() {
+	local name="$1" got="$2" want="$3"
+	if [[ "$got" == "$want" ]]; then
+		pass "$name"
+	else
+		fail "$name" "want='${want}' got='${got}'"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Source claim-task-id.sh to access _detect_predecessor_refs and
+# _apply_blocked_by_detection. The BASH_SOURCE guard prevents main() from
+# running on source.
+# ---------------------------------------------------------------------------
+_setup() {
+	# Provide minimal stubs so sub-library sourcing succeeds in a test env.
+	local stub_dir
+	stub_dir=$(mktemp -d)
+	trap 'rm -rf '"$stub_dir"'' EXIT
+
+	# Fake git: return empty string for remote get-url (silences detect_platform)
+	cat >"${stub_dir}/git" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+	chmod +x "${stub_dir}/git"
+
+	# Fake gh: auth ok, everything else no-op
+	cat >"${stub_dir}/gh" <<'STUB'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "auth" && "${2:-}" == "status" ]]; then exit 0; fi
+exit 0
+STUB
+	chmod +x "${stub_dir}/gh"
+
+	# Fake jq: return empty string (so label validation skips)
+	cat >"${stub_dir}/jq" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+	chmod +x "${stub_dir}/jq"
+
+	export PATH="${stub_dir}:${PATH}"
+	export HOME="${stub_dir}/home"
+	mkdir -p "${HOME}/.aidevops/logs"
+
+	# shellcheck disable=SC1090
+	if ! source "$CLAIM_SCRIPT" 2>/dev/null; then
+		printf '%s[FATAL]%s Failed to source %s\n' "$RED" "$NC" "$CLAIM_SCRIPT" >&2
+		exit 1
+	fi
+
+	return 0
+}
+
+_setup
+
+# ---------------------------------------------------------------------------
+# Helper: run _detect_predecessor_refs and capture output
+# ---------------------------------------------------------------------------
+detect() {
+	local text="$1"
+	_detect_predecessor_refs "$text" 2>/dev/null || true
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test cases
+# ---------------------------------------------------------------------------
+
+# 1. Pattern 1 — t-style ref
+assert_eq "pattern1_t_style" \
+	"$(detect 'Follow-up from t2799 after one release cycle')" \
+	"t2799"
+
+# 2. Pattern 1 — GH# ref
+assert_eq "pattern1_gh_style" \
+	"$(detect 'Follow-up from GH#20774 per discussion')" \
+	"GH#20774"
+
+# 3. Pattern 2 — GH# ref
+assert_eq "pattern2_gh_style" \
+	"$(detect 'This work is tracked in GH#20734 roadmap')" \
+	"GH#20734"
+
+# 4. Pattern 2 — bare #NNN normalised to GH#NNN
+assert_eq "pattern2_bare_hash_normalised" \
+	"$(detect 'This work is tracked in #20734')" \
+	"GH#20734"
+
+# 5. Pattern 3 — explicit blocked-by (no space)
+assert_eq "pattern3_explicit_no_space" \
+	"$(detect 'blocked-by:t2799 and nothing else')" \
+	"t2799"
+
+# 6. Pattern 3 — explicit blocked-by with space
+assert_eq "pattern3_explicit_with_space" \
+	"$(detect 'This is blocked-by: GH#20774 until that lands')" \
+	"GH#20774"
+
+# 7. Pattern 4 — after tNNN ships
+assert_eq "pattern4_ships" \
+	"$(detect 'Clean up the old API after t2799 ships')" \
+	"t2799"
+
+# 8. Pattern 4 — after tNNN merges
+assert_eq "pattern4_merges" \
+	"$(detect 'Run after t2800 merges into main')" \
+	"t2800"
+
+# 9. Pattern 4 — after tNNN lands
+assert_eq "pattern4_lands" \
+	"$(detect 'Deploy after t2801 lands in production')" \
+	"t2801"
+
+# 10. Multiple patterns → comma-separated in detection order
+assert_eq "multiple_patterns_ordered" \
+	"$(detect 'Follow-up from t2799 — do X after t2800 ships')" \
+	"t2799,t2800"
+
+# 11. Deduplication — same ref via two patterns → emitted once
+assert_eq "deduplication_same_ref" \
+	"$(detect 'Follow-up from t2799, blocked-by:t2799 explicitly')" \
+	"t2799"
+
+# 12. No match — unrelated description → empty
+assert_eq "no_match_returns_empty" \
+	"$(detect 'Completely unrelated task with no predecessor')" \
+	""
+
+# 13. Empty description → empty
+assert_eq "empty_description_returns_empty" \
+	"$(detect '')" \
+	""
+
+# 14. --no-blocked-by suppresses detection via _apply_blocked_by_detection
+# Save and restore globals so this test doesn't pollute other state.
+_saved_no_blocked_by="$NO_BLOCKED_BY"
+_saved_task_desc="$TASK_DESCRIPTION"
+_saved_dry_run="$DRY_RUN"
+_saved_blocked_refs="$_CLAIM_BLOCKED_BY_REFS"
+NO_BLOCKED_BY=true
+TASK_DESCRIPTION="Follow-up from t2799 after one release cycle"
+DRY_RUN=false
+_CLAIM_BLOCKED_BY_REFS=""
+_apply_blocked_by_detection 2>/dev/null
+assert_eq "no_blocked_by_suppresses_detection" "$_CLAIM_BLOCKED_BY_REFS" ""
+NO_BLOCKED_BY="$_saved_no_blocked_by"
+TASK_DESCRIPTION="$_saved_task_desc"
+DRY_RUN="$_saved_dry_run"
+_CLAIM_BLOCKED_BY_REFS="$_saved_blocked_refs"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\n%d tests run: %d passed, %d failed\n' "$((PASS + FAIL))" "$PASS" "$FAIL"
+
+if [[ "$FAIL" -gt 0 ]]; then
+	printf '\nFailed tests:%b\n' "$ERRORS"
+	exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Closes the sibling-task scheduling gap identified in GH#20834: when a follow-up issue body references a predecessor task in prose, `claim-task-id.sh` now auto-emits a `blocked-by:tNNN` tag in the TODO.md entry it writes.

## What

- **`_detect_predecessor_refs()`** — pure function that scans description text for 4 predecessor patterns:
  1. `Follow-up from tNNN` / `Follow-up from GH#NNN`
  2. `tracked in GH#NNN` / `tracked in #NNN` (normalised to `GH#NNN`)
  3. `blocked-by: tNNN` / `blocked-by:GH#NNN` (explicit pass-through)
  4. `after tNNN ships/merges/lands`
  - Deduplicates refs, preserves insertion order, outputs comma-separated.
- **`_apply_blocked_by_detection()`** — orchestrator called from `main()` after `parse_args`; populates `_CLAIM_BLOCKED_BY_REFS` and emits a stderr advisory when refs are found.
- **`--no-blocked-by` flag** — suppresses detection for legitimate parallel work.
- **`_ensure_todo_entry_written`** (in `claim-task-id-issue.sh`) — reads `_CLAIM_BLOCKED_BY_REFS` and appends `blocked-by:<refs>` to the new TODO line before `ref:GH#NNN`.
- **Machine-readable output** — `blocked_by=<refs>` added to stdout when detected.

## Why

Canonical cost without this fix: GH#20774 was filed as "Follow-up from t2799 ... after one release cycle" but emitted no `blocked-by` tag → both PRs dispatched simultaneously → PR #20775 conflicted → recovery via PR #20817 → ~25K extra opus tokens and ~3.5h wall time.

## Verification

```bash
shellcheck .agents/scripts/claim-task-id.sh
shellcheck .agents/scripts/claim-task-id-issue.sh
shellcheck .agents/scripts/tests/test-claim-blocked-by-detection.sh
bash .agents/scripts/tests/test-claim-blocked-by-detection.sh
# 14 tests run: 14 passed, 0 failed
```

## Complexity Considerations

New functions added to `claim-task-id.sh` (not modifying existing functions):
- `_detect_predecessor_refs`: 47 lines (well under 100-line function gate)
- `_apply_blocked_by_detection`: 13 lines
- 6-line addition to `_ensure_todo_entry_written` in the sub-library

## Files Scope

- `.agents/scripts/claim-task-id.sh`
- `.agents/scripts/claim-task-id-issue.sh`
- `.agents/scripts/tests/test-claim-blocked-by-detection.sh` (new)

Resolves #20834

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.10.3 plugin for [OpenCode](https://opencode.ai) v1.14.24 with claude-sonnet-4-6 spent 15m and 27,728 tokens on this as a headless worker.