### PR TITLE
GH#20835: Phase 1 diagnostic — complexity-regression guard 98s timeout identified

### DIFF
--- a/todo/tasks/GH-20835-brief.md
+++ b/todo/tasks/GH-20835-brief.md
@@ -1,0 +1,26 @@
+# GH-20835: diagnose pre-push hook 60s timeout
+
+## Session Origin
+
+Worker dispatch from issue #20835. Phase 1 investigation only — no code changes.
+
+## What
+
+Timed all four pre-push guards against a realistic diff (1 modified `.sh` file, ahead of `origin/main`).
+
+## Findings
+
+| Guard | Wall time |
+|-------|-----------|
+| `privacy-guard-pre-push.sh` | 104ms |
+| `scope-guard-pre-push.sh` | 11ms |
+| `pre-push-dup-todo-guard.sh` | 1.1s |
+| `complexity-regression-pre-push.sh` | **1m 38s** ← slow guard |
+
+Root cause: `nesting-depth` metric in `complexity-regression-helper.sh` scans all 949 `.sh` files in the repo (via `shfmt --to-json | jq` AST walk, ~50ms/file) × 2 worktrees = 97s. Exceeds the 60s timeout in `full-loop-helper.sh`.
+
+Phase 2 filed as #20842 (change-scoped scan fix).
+
+## Files Scope
+
+- `todo/tasks/GH-20835-brief.md` (this file)


### PR DESCRIPTION
## Summary

Phase 1 diagnostic investigation for the 60s pre-push hook timeout that caused `commit-and-pr --skip-hooks` bypass in the #20732 worker session.

## Findings

All four pre-push guards were timed against a realistic diff (1 `.sh` file modified, ahead of `origin/main`):

| Guard | Wall time |
|-------|-----------|
| `privacy-guard-pre-push.sh` | 104ms |
| `scope-guard-pre-push.sh` | 11ms |
| `pre-push-dup-todo-guard.sh` | 1.1s |
| `complexity-regression-pre-push.sh` | **1m 38s** ← slow guard |

**Root cause:** `nesting-depth` metric in `complexity-regression-helper.sh` scans **all 949 `.sh` files** in the repo via `shfmt --to-json | jq` AST walk (~50ms/file) × 2 worktrees = 97s total. The 60s timeout in `full-loop-helper.sh` kills the push before this completes.

Full diagnostic including per-metric breakdown and profiling detail: https://github.com/marcusquinn/aidevops/issues/20835#issuecomment-4317404507

Phase 2 fix filed as #20842 — change-scoped scan (scan only changed files, not all 949).

## Changes

- Added `todo/tasks/GH-20835-brief.md` with diagnostic findings summary

Resolves #20835

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.0 plugin for [OpenCode](https://opencode.ai) v1.14.24
