### PR TITLE
t2819: add pre-dispatch self-hosting detector for dispatch-path tasks

### DIFF
--- a/.agents/reference/pre-dispatch-validators.md
+++ b/.agents/reference/pre-dispatch-validators.md
@@ -39,6 +39,25 @@ Emergency recovery when a validator bug blocks legitimate dispatches. Bypass is 
 
 Prevents workers spawning only to find no ratchet-down work exists (GH#19024).
 
+### Self-hosting dispatch-path detector (t2819)
+
+**Type:** Advisory pre-step (not a generator-marker validator)
+**Marker:** None — scans issue body for dispatch-path file patterns regardless of generator
+**Bypass:** `AIDEVOPS_SKIP_SELF_HOSTING_DETECTOR=1`
+**Dry-run:** `AIDEVOPS_SELF_HOSTING_DETECTOR_DRY_RUN=1`
+
+Runs BEFORE generator-marker validators in `cmd_validate()`. Detects issues that modify the worker dispatch/spawn path by scanning the body's `## Files to modify` / `## How` sections for canonical dispatch-path file patterns (`pulse-wrapper.sh`, `pulse-dispatch-*.sh`, `headless-runtime-helper.sh`, `worker-lifecycle-common.sh`, `shared-dispatch-dedup.sh`, etc.).
+
+When detected on a `tier:thinking` issue lacking `model:opus-4-7`:
+
+1. Applies `model:opus-4-7` label via `gh issue edit`
+2. Posts a provenance-wrapped audit comment (`<!-- self-hosting-tier-override -->` marker for idempotency)
+3. Returns 0 (never blocks dispatch)
+
+**Rationale:** Self-hosting tasks (fixing the dispatch path) trigger a tautology loop — the workers run through the code being fixed. Starting at opus-4-6 wastes 1-2 cascade attempts (~40K tokens, observed on GH#20765). Applying `model:opus-4-7` upfront eliminates this waste.
+
+**Tests:** `tests/test-self-hosting-detector.sh` — 7 cases covering positive/negative/mixed-scope/idempotency/bypass/dry-run/tier-guard.
+
 ## Adding a validator
 
 1. Define the generator function in `pulse-simplification.sh` or the issue-creation script.
@@ -62,6 +81,7 @@ Prevents workers spawning only to find no ratchet-down work exists (GH#19024).
 
 ```bash
 bash .agents/scripts/tests/test-pre-dispatch-validator.sh
+bash .agents/scripts/tests/test-self-hosting-detector.sh
 .agents/scripts/pre-dispatch-validator-helper.sh validate <issue-number> marcusquinn/aidevops
 ```
 
@@ -73,3 +93,4 @@ bash .agents/scripts/tests/test-pre-dispatch-validator.sh
 - `pulse-simplification.sh` — `_complexity_scan_ratchet_check` (ratchet-down generator)
 - `reference/worker-diagnostics.md` — full worker lifecycle
 - GH#19118 (feature), GH#19024 (post-mortem), GH#19036, GH#19037 (root causes)
+- GH#20825 (self-hosting detector, t2819), GH#20765 (post-mortem triggering t2819)

--- a/.agents/reference/worker-diagnostics.md
+++ b/.agents/reference/worker-diagnostics.md
@@ -309,6 +309,24 @@ escalation entirely. Observable change:
 | `premature_exit` | caller-supplied (explicit crash type from watchdog) | Depends on crash_type | Worker exited during execution |
 | `stale_timeout` | caller-supplied (from stale-recovery) | Depends on crash_type | Worker was stalled |
 
+#### Self-hosting tier override — t2819
+
+**Pre-dispatch short-circuit for dispatch-path tasks.**
+
+Issues that modify the worker dispatch path (`pulse-wrapper.sh`, `pulse-dispatch-*.sh`, `headless-runtime-helper.sh`, `worker-lifecycle-common.sh`, etc.) have a self-referential property: workers dispatched to fix them run through the code being fixed. When `tier:thinking` starts at opus-4-6, the cascade wastes 1-2 attempts before reaching opus-4-7, which these task sizes require.
+
+The self-hosting detector in `pre-dispatch-validator-helper.sh` runs BEFORE generator-marker validators. It scans the issue body for dispatch-path file patterns and, when found on a `tier:thinking` issue without `model:opus-4-7`, applies the label pre-dispatch. This eliminates wasted cascade attempts.
+
+- **Trigger:** issue body references any of the canonical dispatch-path files (array in `_SELF_HOSTING_PATTERNS`)
+- **Precondition:** issue has `tier:thinking` label, lacks `model:opus-4-7`
+- **Action:** applies `model:opus-4-7` label + posts provenance-wrapped audit comment
+- **Non-blocking:** always exits 0 (advisory, not a dispatch gate)
+- **Idempotent:** marker comment `<!-- self-hosting-tier-override -->` prevents duplicate posts
+- **Bypass:** `AIDEVOPS_SKIP_SELF_HOSTING_DETECTOR=1`
+- **Dry-run:** `AIDEVOPS_SELF_HOSTING_DETECTOR_DRY_RUN=1`
+
+Observed on GH#20765 (t2814): 2 opus-4-6 attempts (~40K wasted tokens) before cascade reached opus-4-7. This short-circuit eliminates that waste for the self-hosting task class.
+
 ## Diagnostic Quick Reference
 
 | Symptom | Check | Likely cause |

--- a/.agents/scripts/pre-dispatch-validator-helper.sh
+++ b/.agents/scripts/pre-dispatch-validator-helper.sh
@@ -54,6 +54,31 @@ _log() {
 # ---------------------------------------------------------------------------
 declare -A _VALIDATOR_REGISTRY=()
 
+# ---------------------------------------------------------------------------
+# Self-hosting dispatch-path file patterns (t2819)
+#
+# When an issue body references any of these files, the issue modifies the
+# worker dispatch/spawn path. Workers dispatched to fix this code run through
+# the code being fixed — a tautology loop that wastes cascade attempts.
+#
+# Maintained as a shell array constant so future additions are one-line edits.
+# ---------------------------------------------------------------------------
+# Label applied when self-hosting pattern is detected
+_SELF_HOSTING_TARGET_LABEL="model:opus-4-7"
+_SELF_HOSTING_TIER_REQUIRED="tier:thinking"
+
+_SELF_HOSTING_PATTERNS=(
+	"pulse-wrapper.sh"
+	"pulse-dispatch-"
+	"pulse-cleanup.sh"
+	"headless-runtime-helper.sh"
+	"headless-runtime-lib.sh"
+	"worker-lifecycle-common.sh"
+	"shared-dispatch-dedup.sh"
+	"shared-claim-lifecycle.sh"
+	"worker-activity-watchdog.sh"
+)
+
 _register_validators() {
 	_VALIDATOR_REGISTRY["ratchet-down"]="_validator_ratchet_down"
 	_VALIDATOR_REGISTRY["large-file-simplification-gate"]="_validator_large_file_simplification_gate"
@@ -266,6 +291,128 @@ _validator_upstream_watch() {
 }
 
 # ---------------------------------------------------------------------------
+# Self-hosting dispatch-path detector (t2819)
+#
+# Scans the issue body for references to dispatch-path scripts. When found
+# on a tier:thinking issue without model:opus-4-7, applies the label to
+# short-circuit the cascade (which would eventually reach opus-4-7 anyway
+# after 1-2 wasted attempts at opus-4-6).
+#
+# Always returns 0 — this is an advisory pre-step, not a dispatch blocker.
+#
+# Arguments:
+#   $1 - issue_number
+#   $2 - slug (owner/repo)
+#   $3 - issue_body (already fetched by cmd_validate)
+#
+# Environment:
+#   AIDEVOPS_SKIP_SELF_HOSTING_DETECTOR=1    — skip entirely
+#   AIDEVOPS_SELF_HOSTING_DETECTOR_DRY_RUN=1 — emit what-would-be-applied
+# ---------------------------------------------------------------------------
+_detect_self_hosting_task() {
+	local issue_number="$1"
+	local slug="$2"
+	local issue_body="$3"
+
+	# Bypass guard
+	if [[ "${AIDEVOPS_SKIP_SELF_HOSTING_DETECTOR:-}" == "1" ]]; then
+		_log "INFO" "AIDEVOPS_SKIP_SELF_HOSTING_DETECTOR=1 — skipping self-hosting detector"
+		return 0
+	fi
+
+	# Quick-exit: empty body has nothing to scan
+	if [[ -z "$issue_body" ]]; then
+		return 0
+	fi
+
+	# Check if body references any dispatch-path files
+	local matched_pattern=""
+	local pattern
+	for pattern in "${_SELF_HOSTING_PATTERNS[@]}"; do
+		if printf '%s' "$issue_body" | grep -qF "$pattern"; then
+			matched_pattern="$pattern"
+			break
+		fi
+	done
+
+	if [[ -z "$matched_pattern" ]]; then
+		_log "INFO" "#${issue_number}: no dispatch-path patterns found — self-hosting detector skips"
+		return 0
+	fi
+
+	_log "INFO" "#${issue_number}: dispatch-path pattern detected: ${matched_pattern}"
+
+	# Fetch issue labels to check tier and existing model label
+	local labels
+	labels=$(gh api "repos/${slug}/issues/${issue_number}" --jq '[.labels[].name] | join(",")' 2>/dev/null) || labels=""
+
+	# Must have the required tier label
+	if ! printf '%s' "$labels" | grep -qF "$_SELF_HOSTING_TIER_REQUIRED"; then
+		_log "INFO" "#${issue_number}: not ${_SELF_HOSTING_TIER_REQUIRED} — self-hosting detector skips"
+		return 0
+	fi
+
+	# Already has target label — idempotent no-op
+	if printf '%s' "$labels" | grep -qF "$_SELF_HOSTING_TARGET_LABEL"; then
+		_log "INFO" "#${issue_number}: already has ${_SELF_HOSTING_TARGET_LABEL} — self-hosting detector no-op"
+		return 0
+	fi
+
+	# Idempotency check: look for existing comment marker
+	local marker='<!-- self-hosting-tier-override -->'
+	local existing=""
+	existing=$(gh api "repos/${slug}/issues/${issue_number}/comments" \
+		--jq "[.[] | select(.body | contains(\"${marker}\"))] | length" \
+		2>/dev/null) || existing=""
+	if [[ "$existing" =~ ^[1-9][0-9]*$ ]]; then
+		_log "INFO" "#${issue_number}: self-hosting comment already posted — ensuring label"
+		# Ensure label even if comment exists (in case label was manually removed)
+		if [[ "${AIDEVOPS_SELF_HOSTING_DETECTOR_DRY_RUN:-}" != "1" ]]; then
+			gh issue edit "$issue_number" --repo "$slug" \
+				--add-label "$_SELF_HOSTING_TARGET_LABEL" >/dev/null 2>&1 || true
+		fi
+		return 0
+	fi
+
+	# Dry-run mode
+	if [[ "${AIDEVOPS_SELF_HOSTING_DETECTOR_DRY_RUN:-}" == "1" ]]; then
+		_log "INFO" "#${issue_number}: DRY-RUN — would apply ${_SELF_HOSTING_TARGET_LABEL} (matched: ${matched_pattern})"
+		return 0
+	fi
+
+	# Apply the label
+	if ! gh issue edit "$issue_number" --repo "$slug" \
+		--add-label "$_SELF_HOSTING_TARGET_LABEL" >/dev/null 2>&1; then
+		_log "WARN" "#${issue_number}: failed to apply ${_SELF_HOSTING_TARGET_LABEL} label — continuing"
+		return 0
+	fi
+
+	_log "INFO" "#${issue_number}: applied ${_SELF_HOSTING_TARGET_LABEL} label (self-hosting dispatch-path task)"
+
+	# Post provenance-wrapped audit comment
+	local comment_body
+	comment_body="${marker}
+<!-- provenance:start -->
+## Self-Hosting Tier Override
+
+Pre-dispatch self-hosting detector applied \`${_SELF_HOSTING_TARGET_LABEL}\` to this \`${_SELF_HOSTING_TIER_REQUIRED}\` issue.
+
+**Matched pattern:** \`${matched_pattern}\` in issue body
+
+**Rationale:** Issues modifying the dispatch path have a self-referential property — workers dispatched to fix them run through the code being fixed. Starting at opus-4-6 wastes 1-2 attempts before the cascade reaches the tier needed for these task sizes. Applying \`${_SELF_HOSTING_TARGET_LABEL}\` upfront eliminates wasted dispatch cycles.
+
+**Bypass:** \`AIDEVOPS_SKIP_SELF_HOSTING_DETECTOR=1\`
+
+_Automated by \`pre-dispatch-validator-helper.sh\` (t2819). This comment is posted once via the \`${marker}\` marker; re-runs are no-ops._
+<!-- provenance:end -->"
+
+	gh_issue_comment "$issue_number" --repo "$slug" --body "$comment_body" \
+		>/dev/null 2>&1 || _log "WARN" "#${issue_number}: self-hosting audit comment post failed — label still applied"
+
+	return 0
+}
+
+# ---------------------------------------------------------------------------
 # Compose and post the falsified-premise closure comment, then close the issue.
 # ---------------------------------------------------------------------------
 _close_with_rationale() {
@@ -337,6 +484,10 @@ cmd_validate() {
 		_log "WARN" "Failed to fetch issue body for #${issue_number} — proceeding (validator error)"
 		return 20
 	}
+
+	# Run self-hosting detector BEFORE generator-marker validators (t2819).
+	# Always returns 0; label mutation is advisory, not a dispatch block.
+	_detect_self_hosting_task "$issue_number" "$slug" "$issue_body"
 
 	# Extract generator marker (supports both simple and attributed forms):
 	#   <!-- aidevops:generator=<name> -->

--- a/.agents/scripts/tests/test-self-hosting-detector.sh
+++ b/.agents/scripts/tests/test-self-hosting-detector.sh
@@ -1,0 +1,469 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-self-hosting-detector.sh — Regression tests for the self-hosting
+# dispatch-path detector in pre-dispatch-validator-helper.sh (t2819)
+#
+# Tests:
+#   test_positive_detection        — body with pulse-wrapper.sh triggers label
+#   test_negative_detection        — docs-only body does not trigger
+#   test_mixed_scope               — dispatch file + unrelated file → triggers
+#   test_idempotency               — re-run on already-labeled issue is no-op
+#   test_bypass_env_var            — AIDEVOPS_SKIP_SELF_HOSTING_DETECTOR=1
+#   test_dry_run_mode              — dry-run emits intent without mutation
+#   test_not_tier_thinking         — non-tier:thinking issues are skipped
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+HELPER_SCRIPT="${SCRIPT_DIR}/../pre-dispatch-validator-helper.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+
+# ---------------------------------------------------------------------------
+# Test framework helpers
+# ---------------------------------------------------------------------------
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+	mkdir -p "${TEST_ROOT}/bin"
+	# Prepend stub bin dir so our stubs override real commands
+	export PATH="${TEST_ROOT}/bin:${PATH}"
+	# Track label mutations and comments posted by the stub
+	export GH_LABEL_LOG="${TEST_ROOT}/label_log.txt"
+	export GH_COMMENT_LOG="${TEST_ROOT}/comment_log.txt"
+	: >"$GH_LABEL_LOG"
+	: >"$GH_COMMENT_LOG"
+	return 0
+}
+
+teardown_test_env() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	# Unset test-specific env vars
+	unset GH_LABEL_LOG GH_COMMENT_LOG 2>/dev/null || true
+	unset AIDEVOPS_SKIP_SELF_HOSTING_DETECTOR AIDEVOPS_SELF_HOSTING_DETECTOR_DRY_RUN 2>/dev/null || true
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Stub factories
+# ---------------------------------------------------------------------------
+
+# Create a gh stub.
+#
+# Arguments:
+#   $1 - body_file: path to a file containing the issue body text
+#   $2 - labels: comma-separated label names (e.g. "tier:thinking,auto-dispatch")
+#   $3 - existing_comments: "0" (no prior marker comment) or "1" (marker exists)
+create_gh_stub() {
+	local body_file="$1"
+	local labels="$2"
+	local existing_comments="${3:-0}"
+
+	cat >"${TEST_ROOT}/bin/gh" <<GHEOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+_label_log="${GH_LABEL_LOG}"
+_comment_log="${GH_COMMENT_LOG}"
+
+# Collect all args into a single string for pattern matching
+_all_args="\$*"
+
+# gh api repos/<slug>/issues/<num>/comments — comment existence check
+# (Check this BEFORE the /issues/<num> pattern to avoid false match)
+if [[ "\${1:-}" == "api" ]] && printf '%s' "\${2:-}" | grep -qE '/issues/[0-9]+/comments\$'; then
+	printf '%s\n' "${existing_comments}"
+	exit 0
+fi
+
+# gh api repos/<slug>/issues/<num> --jq '...'
+if [[ "\${1:-}" == "api" ]] && printf '%s' "\${2:-}" | grep -qE '/issues/[0-9]+\$'; then
+	# Distinguish body vs labels call by scanning for the jq expression
+	if printf '%s' "\$_all_args" | grep -qF 'labels'; then
+		printf '%s\n' "${labels}"
+		exit 0
+	fi
+
+	# Default: return issue body
+	cat "${body_file}" 2>/dev/null || printf ''
+	exit 0
+fi
+
+# gh issue edit — label application
+if [[ "\${1:-}" == "issue" && "\${2:-}" == "edit" ]]; then
+	printf '%s\n' "\$*" >> "\$_label_log"
+	exit 0
+fi
+
+# gh issue comment — comment posting
+if [[ "\${1:-}" == "issue" && "\${2:-}" == "comment" ]]; then
+	printf '%s\n' "\$*" >> "\$_comment_log"
+	exit 0
+fi
+
+# Fallback for any other gh invocation
+exit 0
+GHEOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+	return 0
+}
+
+# Create a body file with dispatch-path content
+create_body_with_dispatch_path() {
+	local body_file="${TEST_ROOT}/issue_body.txt"
+	cat >"$body_file" <<'EOF'
+## What
+
+Fix the worker dispatch timeout handling.
+
+## How
+
+### Files to modify
+
+- EDIT: `.agents/scripts/pulse-wrapper.sh:200-250` — fix timeout handling
+- EDIT: `.agents/scripts/headless-runtime-helper.sh:400-420` — add retry logic
+
+### Verification
+
+```bash
+shellcheck .agents/scripts/pulse-wrapper.sh
+```
+EOF
+	printf '%s' "$body_file"
+	return 0
+}
+
+# Create a body file with docs-only content (no dispatch-path files)
+create_body_docs_only() {
+	local body_file="${TEST_ROOT}/issue_body.txt"
+	cat >"$body_file" <<'EOF'
+## What
+
+Update the contribution guide with new setup instructions.
+
+## How
+
+### Files to modify
+
+- EDIT: `CONTRIBUTING.md` — add Docker setup section
+- EDIT: `docs/getting-started.md` — update prerequisites
+EOF
+	printf '%s' "$body_file"
+	return 0
+}
+
+# Create a mixed-scope body (dispatch file + unrelated file)
+create_body_mixed_scope() {
+	local body_file="${TEST_ROOT}/issue_body.txt"
+	cat >"$body_file" <<'EOF'
+## What
+
+Refactor dispatch logging and update docs.
+
+## How
+
+### Files to modify
+
+- EDIT: `docs/architecture.md` — update diagrams
+- EDIT: `.agents/scripts/pulse-dispatch-engine.sh:100-150` — add structured logging
+- EDIT: `.agents/reference/worker-diagnostics.md` — document new log format
+EOF
+	printf '%s' "$body_file"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+# test_positive_detection — body references pulse-wrapper.sh → label applied
+test_positive_detection() {
+	setup_test_env
+	local body_file
+	body_file=$(create_body_with_dispatch_path)
+	create_gh_stub "$body_file" "tier:thinking,auto-dispatch" "0"
+
+	local rc=0
+	"$HELPER_SCRIPT" validate "100" "marcusquinn/aidevops" >/dev/null 2>&1 || rc=$?
+
+	# Should exit 0 (self-hosting detector is non-blocking)
+	local exit_ok=1
+	[[ "$rc" -eq 0 ]] && exit_ok=0
+
+	# Check that the label was applied
+	local label_applied=1
+	if grep -qF "model:opus-4-7" "$GH_LABEL_LOG" 2>/dev/null; then
+		label_applied=0
+	fi
+
+	# Check that a comment was posted
+	local comment_posted=1
+	if [[ -s "$GH_COMMENT_LOG" ]]; then
+		comment_posted=0
+	fi
+
+	if [[ "$exit_ok" -eq 0 && "$label_applied" -eq 0 && "$comment_posted" -eq 0 ]]; then
+		print_result "positive_detection: label applied + comment posted" 0
+	else
+		print_result "positive_detection: label applied + comment posted" 1 \
+			"exit=${rc} (want 0), label_applied=${label_applied} (want 0), comment_posted=${comment_posted} (want 0)"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
+# test_negative_detection — docs-only body → no label applied
+test_negative_detection() {
+	setup_test_env
+	local body_file
+	body_file=$(create_body_docs_only)
+	create_gh_stub "$body_file" "tier:thinking,auto-dispatch" "0"
+
+	local rc=0
+	"$HELPER_SCRIPT" validate "101" "marcusquinn/aidevops" >/dev/null 2>&1 || rc=$?
+
+	local exit_ok=1
+	[[ "$rc" -eq 0 ]] && exit_ok=0
+
+	# Label should NOT have been applied
+	local label_not_applied=1
+	if ! grep -qF "model:opus-4-7" "$GH_LABEL_LOG" 2>/dev/null; then
+		label_not_applied=0
+	fi
+
+	if [[ "$exit_ok" -eq 0 && "$label_not_applied" -eq 0 ]]; then
+		print_result "negative_detection: no label for docs-only" 0
+	else
+		print_result "negative_detection: no label for docs-only" 1 \
+			"exit=${rc} (want 0), label_not_applied=${label_not_applied} (want 0)"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
+# test_mixed_scope — dispatch file + unrelated file → still triggers
+test_mixed_scope() {
+	setup_test_env
+	local body_file
+	body_file=$(create_body_mixed_scope)
+	create_gh_stub "$body_file" "tier:thinking,auto-dispatch" "0"
+
+	local rc=0
+	"$HELPER_SCRIPT" validate "102" "marcusquinn/aidevops" >/dev/null 2>&1 || rc=$?
+
+	local exit_ok=1
+	[[ "$rc" -eq 0 ]] && exit_ok=0
+
+	local label_applied=1
+	if grep -qF "model:opus-4-7" "$GH_LABEL_LOG" 2>/dev/null; then
+		label_applied=0
+	fi
+
+	if [[ "$exit_ok" -eq 0 && "$label_applied" -eq 0 ]]; then
+		print_result "mixed_scope: dispatch file + docs → label applied" 0
+	else
+		print_result "mixed_scope: dispatch file + docs → label applied" 1 \
+			"exit=${rc} (want 0), label_applied=${label_applied} (want 0)"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
+# test_idempotency — issue already has model:opus-4-7 → no new label or comment
+test_idempotency() {
+	setup_test_env
+	local body_file
+	body_file=$(create_body_with_dispatch_path)
+	# Labels include model:opus-4-7 already
+	create_gh_stub "$body_file" "tier:thinking,auto-dispatch,model:opus-4-7" "1"
+
+	local rc=0
+	"$HELPER_SCRIPT" validate "103" "marcusquinn/aidevops" >/dev/null 2>&1 || rc=$?
+
+	local exit_ok=1
+	[[ "$rc" -eq 0 ]] && exit_ok=0
+
+	# No new label application should occur
+	local no_label_mutation=1
+	if [[ ! -s "$GH_LABEL_LOG" ]]; then
+		no_label_mutation=0
+	fi
+
+	# No new comment should be posted
+	local no_comment=1
+	if [[ ! -s "$GH_COMMENT_LOG" ]]; then
+		no_comment=0
+	fi
+
+	if [[ "$exit_ok" -eq 0 && "$no_label_mutation" -eq 0 && "$no_comment" -eq 0 ]]; then
+		print_result "idempotency: already-labeled → no mutation" 0
+	else
+		print_result "idempotency: already-labeled → no mutation" 1 \
+			"exit=${rc} (want 0), no_label=${no_label_mutation} (want 0), no_comment=${no_comment} (want 0)"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
+# test_bypass_env_var — AIDEVOPS_SKIP_SELF_HOSTING_DETECTOR=1 → skips
+test_bypass_env_var() {
+	setup_test_env
+	local body_file
+	body_file=$(create_body_with_dispatch_path)
+	create_gh_stub "$body_file" "tier:thinking,auto-dispatch" "0"
+
+	export AIDEVOPS_SKIP_SELF_HOSTING_DETECTOR=1
+
+	local rc=0
+	"$HELPER_SCRIPT" validate "104" "marcusquinn/aidevops" >/dev/null 2>&1 || rc=$?
+
+	local exit_ok=1
+	[[ "$rc" -eq 0 ]] && exit_ok=0
+
+	# No label should be applied (bypassed)
+	local no_label=1
+	if ! grep -qF "model:opus-4-7" "$GH_LABEL_LOG" 2>/dev/null; then
+		no_label=0
+	fi
+
+	if [[ "$exit_ok" -eq 0 && "$no_label" -eq 0 ]]; then
+		print_result "bypass_env_var: SKIP=1 prevents mutation" 0
+	else
+		print_result "bypass_env_var: SKIP=1 prevents mutation" 1 \
+			"exit=${rc} (want 0), no_label=${no_label} (want 0)"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
+# test_dry_run_mode — emits what-would-be-applied without mutation
+test_dry_run_mode() {
+	setup_test_env
+	local body_file
+	body_file=$(create_body_with_dispatch_path)
+	create_gh_stub "$body_file" "tier:thinking,auto-dispatch" "0"
+
+	export AIDEVOPS_SELF_HOSTING_DETECTOR_DRY_RUN=1
+
+	local rc=0
+	local output
+	output=$("$HELPER_SCRIPT" validate "105" "marcusquinn/aidevops" 2>&1) || rc=$?
+
+	local exit_ok=1
+	[[ "$rc" -eq 0 ]] && exit_ok=0
+
+	# Should mention DRY-RUN in output
+	local dry_run_logged=1
+	if printf '%s' "$output" | grep -qF "DRY-RUN"; then
+		dry_run_logged=0
+	fi
+
+	# No label should be applied
+	local no_label=1
+	if ! grep -qF "model:opus-4-7" "$GH_LABEL_LOG" 2>/dev/null; then
+		no_label=0
+	fi
+
+	if [[ "$exit_ok" -eq 0 && "$dry_run_logged" -eq 0 && "$no_label" -eq 0 ]]; then
+		print_result "dry_run_mode: logs intent without mutation" 0
+	else
+		print_result "dry_run_mode: logs intent without mutation" 1 \
+			"exit=${rc} (want 0), dry_run_logged=${dry_run_logged} (want 0), no_label=${no_label} (want 0)"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
+# test_not_tier_thinking — non-tier:thinking issues are skipped
+test_not_tier_thinking() {
+	setup_test_env
+	local body_file
+	body_file=$(create_body_with_dispatch_path)
+	# Labels do NOT include tier:thinking
+	create_gh_stub "$body_file" "tier:standard,auto-dispatch" "0"
+
+	local rc=0
+	"$HELPER_SCRIPT" validate "106" "marcusquinn/aidevops" >/dev/null 2>&1 || rc=$?
+
+	local exit_ok=1
+	[[ "$rc" -eq 0 ]] && exit_ok=0
+
+	# No label should be applied (not tier:thinking)
+	local no_label=1
+	if ! grep -qF "model:opus-4-7" "$GH_LABEL_LOG" 2>/dev/null; then
+		no_label=0
+	fi
+
+	if [[ "$exit_ok" -eq 0 && "$no_label" -eq 0 ]]; then
+		print_result "not_tier_thinking: tier:standard → no mutation" 0
+	else
+		print_result "not_tier_thinking: tier:standard → no mutation" 1 \
+			"exit=${rc} (want 0), no_label=${no_label} (want 0)"
+	fi
+
+	teardown_test_env
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+	printf 'Running self-hosting detector tests (t2819)...\n\n'
+
+	if [[ ! -x "$HELPER_SCRIPT" ]]; then
+		printf '%bERROR%b: Helper script not found or not executable: %s\n' \
+			"$TEST_RED" "$TEST_RESET" "$HELPER_SCRIPT" >&2
+		exit 1
+	fi
+
+	test_positive_detection
+	test_negative_detection
+	test_mixed_scope
+	test_idempotency
+	test_bypass_env_var
+	test_dry_run_mode
+	test_not_tier_thinking
+
+	printf '\n%d test(s) run, %d failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		exit 1
+	fi
+	exit 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

- Added self-hosting dispatch-path detector to `pre-dispatch-validator-helper.sh` that scans issue bodies for dispatch-path file patterns and applies `model:opus-4-7` pre-dispatch on `tier:thinking` issues
- Created 7-case regression test suite (`test-self-hosting-detector.sh`) covering positive/negative/mixed-scope/idempotency/bypass/dry-run/tier-guard
- Updated `reference/worker-diagnostics.md` and `reference/pre-dispatch-validators.md` with self-hosting short-circuit documentation

## MERGE_SUMMARY

### What changed
New pre-dispatch advisory validator in `pre-dispatch-validator-helper.sh` that detects self-hosting tasks (those modifying `pulse-wrapper.sh`, `pulse-dispatch-*.sh`, `headless-runtime-helper.sh`, `worker-lifecycle-common.sh`, `shared-dispatch-dedup.sh`, `shared-claim-lifecycle.sh`, `worker-activity-watchdog.sh`). When found on a `tier:thinking` issue without `model:opus-4-7`, applies the label and posts a provenance-wrapped audit comment. Always exits 0 (advisory, not a dispatch gate). Idempotent via `<!-- self-hosting-tier-override -->` marker.

### Testing
- `shellcheck` passes on all modified files
- 7/7 self-hosting detector tests pass (positive/negative/mixed-scope/idempotency/bypass/dry-run/tier-guard)
- 5/5 existing pre-dispatch validator tests still pass
- Dry-run smoke test against GH#20765 correctly detects `pulse-wrapper.sh` pattern and reports no-op (label already present)

### Files changed
- EDIT: `.agents/scripts/pre-dispatch-validator-helper.sh` — added `_SELF_HOSTING_PATTERNS` array, `_detect_self_hosting_task()` function, call from `cmd_validate()`
- NEW: `.agents/scripts/tests/test-self-hosting-detector.sh` — 7-case regression test suite
- EDIT: `.agents/reference/worker-diagnostics.md` — documented self-hosting tier override in cascade section
- EDIT: `.agents/reference/pre-dispatch-validators.md` — added validator inventory entry and test reference

Resolves #20825

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.0 plugin for [OpenCode](https://opencode.ai) v1.14.24 with claude-opus-4-6 spent 11m and 29,325 tokens on this as a headless worker.
