### PR TITLE
t2820: pulse: extend no_work reclassification to worker_failed using Phase 3 log-tail data

### DIFF
--- a/.agents/reference/worker-diagnostics.md
+++ b/.agents/reference/worker-diagnostics.md
@@ -372,6 +372,70 @@ escalation entirely. Observable change:
 | `premature_exit` | caller-supplied (explicit crash type from watchdog) | Depends on crash_type | Worker exited during execution |
 | `stale_timeout` | caller-supplied (from stale-recovery) | Depends on crash_type | Worker was stalled |
 
+#### Phase 5 — `worker_failed` reclassification via log tail (t2820)
+
+**Problem.** Phases 3-4 fixed the `no_worker_process` slice — the worker
+never spawned. The remaining `worker_failed` bucket conflates two distinct
+modes that demand opposite responses:
+
+- **Real coding failure** — worker spawned, loaded context, executed tool
+  calls, produced bad code. Escalation to opus-4-7 is correct.
+- **Late infra failure** — worker spawned, ran canary OK, hit a mid-session
+  blip (auth refresh timeout, plugin hook deadlock, provider rate limit)
+  BEFORE producing tool calls. Escalation wastes opus tokens.
+
+**Fix.** `escalate_issue_tier` (worker-lifecycle-common.sh) now consults
+the worker-log tail (Phase 3 t2814 collection) BEFORE deciding between
+escalation and skip. When `crash_type` is empty AND `reason` matches a
+generic worker-failure bucket (`worker_failed`, `premature_exit`,
+`worker_noop_zero_output`), the helper `_maybe_reclassify_worker_failed_as_no_work`
+inspects the log tail and applies one of these rules:
+
+| Log tail signal | Subtype assigned | Cascade fires? | Skip-comment marker |
+|-----------------|------------------|----------------|---------------------|
+| `[t2814:early_exit]` marker OR `canary` keyword | `canary_post_spawn_failure` | No (skip via t2387 path) | `<!-- no-work-escalation-skip -->` |
+| No tool-use markers AND log age ≤ `NO_WORK_RECLASS_ELAPSED_MAX` (default 180s) | `no_tool_calls_in_log` | No | `<!-- no-work-escalation-skip -->` |
+| Tool-use / Edit / Write / Bash / `git commit` markers present | `real_coding` (no reclassification) | Yes (normal cascade) | n/a |
+| Log file missing OR tail empty | `unknown` (no reclassification) | Yes (existing behaviour) | n/a |
+
+**DRY architecture.** The log-tail reader is now a shared helper —
+`_read_worker_log_tail_classified` in `shared-claim-lifecycle.sh` — used by
+both consumers:
+
+1. `_post_launch_recovery_claim_released` (pulse-cleanup.sh) — embeds the
+   tail in the `CLAIM_RELEASED` comment for diagnosability.
+2. `_maybe_reclassify_worker_failed_as_no_work` (worker-lifecycle-common.sh)
+   — uses the classification for the reclassification decision above.
+
+This keeps log-path conventions and bounds (last 20 lines, 4KB cap) in one
+place. A future refactor that touches one consumer cannot drift the other.
+
+**Tunables.**
+
+- `NO_WORK_RECLASS_ELAPSED_MAX` (default `180` seconds) — the runtime cap
+  under which a `no_tool_calls` tail triggers reclassification. The
+  `canary_post_spawn` rule fires regardless of runtime (explicit infra
+  marker is decisive). Override via env when investigating long-running
+  incidents that should not reclassify.
+
+**Backward compatibility.** When the log file is missing (e.g., older
+dispatch records pre-Phase 3, or rotated-away logs), the reclassification
+helper returns 1 and the existing `worker_failed` → escalation behaviour
+fires unchanged. No regression on pre-Phase 3 records.
+
+**Verification.**
+
+```bash
+shellcheck .agents/scripts/worker-lifecycle-common.sh \
+           .agents/scripts/shared-claim-lifecycle.sh
+bash .agents/scripts/tests/test-no-work-reclassification.sh
+# After deploy: audit the reclassification subtypes that fired
+gh api repos/marcusquinn/aidevops/issues/<N>/comments --jq \
+  '.[] | select(.body | test("no_work.*(no_tool_calls_in_log|canary_post_spawn_failure)")) | .body' | head -20
+# Tail-side audit (operator log)
+grep -E '\[worker-lifecycle\]\[t2820\]' /tmp/pulse-*.log | head
+```
+
 #### Self-hosting tier override — t2819
 
 **Pre-dispatch short-circuit for dispatch-path tasks.**

--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -735,30 +735,28 @@ _post_launch_recovery_claim_released() {
 	# diagnosable from the audit trail alone (no log-file forensics needed).
 	# Bounded to last 20 lines and 4KB to keep comments readable and avoid
 	# accidental credential leakage from verbose stack traces.
-	local safe_slug log_file log_tail
-	safe_slug=$(echo "$repo_slug" | tr '/:' '--')
-	local -a log_candidates=(
-		"/tmp/pulse-${safe_slug}-${issue_number}.log"
-		"/tmp/pulse-${issue_number}.log"
-	)
-	for log_file in "${log_candidates[@]}"; do
-		if [[ -f "$log_file" ]] && [[ -s "$log_file" ]]; then
-			log_tail=$(tail -20 "$log_file" 2>/dev/null | head -c 4096 || true)
-			if [[ -n "$log_tail" ]]; then
-				body="${body}
+	#
+	# t2820: extracted to `_read_worker_log_tail_classified` in
+	# shared-claim-lifecycle.sh — same bounds + path enumeration. The
+	# classification side-output is unused here (the comment just embeds
+	# the raw tail); escalate_issue_tier consumes the classification for
+	# its no_work reclassification path. Keeping a single reader prevents
+	# the two consumers from drifting on log-path conventions.
+	if declare -F _read_worker_log_tail_classified >/dev/null 2>&1; then
+		_read_worker_log_tail_classified "$issue_number" "$repo_slug"
+		if [[ -n "${_WORKER_LOG_TAIL_FILE:-}" && -n "${_WORKER_LOG_TAIL_CONTENT:-}" ]]; then
+			body="${body}
 
 <details>
-<summary>worker log tail (last 20 lines, source: ${log_file})</summary>
+<summary>worker log tail (last 20 lines, source: ${_WORKER_LOG_TAIL_FILE})</summary>
 
 \`\`\`text
-${log_tail}
+${_WORKER_LOG_TAIL_CONTENT}
 \`\`\`
 
 </details>"
-			fi
-			break
 		fi
-	done
+	fi
 
 	gh api "repos/${repo_slug}/issues/${issue_number}/comments" \
 		--method POST \

--- a/.agents/scripts/shared-claim-lifecycle.sh
+++ b/.agents/scripts/shared-claim-lifecycle.sh
@@ -225,3 +225,130 @@ _attempt_orphan_recovery_pr() {
 		>/dev/null 2>&1
 	return $?
 }
+
+#######################################
+# _read_worker_log_tail_classified — locate worker log + classify the tail (t2820)
+#
+# Shared helper extracted from `_post_launch_recovery_claim_released` (Phase 3,
+# t2814) so that two consumers can share parsing logic:
+#   1. pulse-cleanup.sh — embeds the tail in CLAIM_RELEASED comments.
+#   2. worker-lifecycle-common.sh::escalate_issue_tier — uses the classification
+#      to reclassify `worker_failed` events as `no_work` when the log shows the
+#      worker never produced tool calls (Phase 5 / t2820).
+#
+# Locates the worker log by enumerating the same candidate paths
+# `_post_launch_recovery_claim_released` uses:
+#     /tmp/pulse-${safe_slug}-${issue_number}.log
+#     /tmp/pulse-${issue_number}.log
+#
+# Reads the last 20 lines (capped at 4KB to match Phase 3's bounds — keeps
+# comments readable and limits credential-leak surface). Classifies the tail
+# into one of four shapes:
+#
+#   real_coding          — tail contains tool-use / edit / commit markers
+#                          → worker reached implementation; escalate normally
+#   no_tool_calls        — tail is non-empty but lacks any tool-use markers
+#                          → worker spawned but stalled before implementation
+#   canary_post_spawn    — tail contains canary diagnostics or t2814 early-exit
+#                          marker → infra failure post-spawn, opus cannot help
+#   unknown              — log file missing or empty → no signal available
+#
+# Side-effects (on success):
+#   sets the following variables in the *caller's* scope (no subshell):
+#     _WORKER_LOG_TAIL_FILE         path to the log file that was read
+#     _WORKER_LOG_TAIL_CONTENT      log tail content (may be empty)
+#     _WORKER_LOG_TAIL_CLASS        one of: real_coding|no_tool_calls|
+#                                            canary_post_spawn|unknown
+#     _WORKER_LOG_TAIL_AGE_SECS     log file age in seconds (now - mtime), or
+#                                   empty when no log file exists
+#
+# Why caller-scope vars: callers need both the raw content (for embedding in
+# comments) AND the classification (for branching). Returning a single string
+# would force one or the other; setting two named vars is the cheapest way to
+# share both without subshell overhead. Tests can `unset` the vars between runs.
+#
+# Args:
+#   $1 - issue_number
+#   $2 - repo_slug (owner/repo) — used to derive safe_slug for the log path
+#
+# Returns: 0 always (best-effort; missing log → unknown classification)
+#######################################
+_read_worker_log_tail_classified() {
+	local issue_number="$1"
+	local repo_slug="$2"
+
+	# Reset caller-scope vars on every call.
+	_WORKER_LOG_TAIL_FILE=""
+	_WORKER_LOG_TAIL_CONTENT=""
+	_WORKER_LOG_TAIL_CLASS="unknown"
+	_WORKER_LOG_TAIL_AGE_SECS=""
+
+	[[ -n "$issue_number" && -n "$repo_slug" ]] || return 0
+
+	local safe_slug
+	safe_slug=$(printf '%s' "$repo_slug" | tr '/:' '--')
+	local -a log_candidates=(
+		"/tmp/pulse-${safe_slug}-${issue_number}.log"
+		"/tmp/pulse-${issue_number}.log"
+	)
+
+	local log_file=""
+	for log_file in "${log_candidates[@]}"; do
+		if [[ -f "$log_file" ]] && [[ -s "$log_file" ]]; then
+			_WORKER_LOG_TAIL_FILE="$log_file"
+			# Bounded read: last 20 lines, capped at 4KB. Same bounds as
+			# Phase 3 to keep comments readable + limit credential-leak.
+			_WORKER_LOG_TAIL_CONTENT=$(tail -20 "$log_file" 2>/dev/null \
+				| head -c 4096 || true)
+			# File age = now - mtime. Approximates worker runtime well
+			# enough for the reclassification threshold check (the log is
+			# created at spawn and written-to throughout execution).
+			local now mtime
+			now=$(date +%s 2>/dev/null) || now=""
+			mtime=$(stat -c '%Y' "$log_file" 2>/dev/null \
+				|| stat -f '%m' "$log_file" 2>/dev/null \
+				|| echo "")
+			if [[ -n "$now" && -n "$mtime" && "$mtime" =~ ^[0-9]+$ ]]; then
+				_WORKER_LOG_TAIL_AGE_SECS=$((now - mtime))
+				# Defensive: clamp negatives to 0 (clock skew / FS race)
+				[[ "$_WORKER_LOG_TAIL_AGE_SECS" -lt 0 ]] && _WORKER_LOG_TAIL_AGE_SECS=0
+			fi
+			break
+		fi
+	done
+
+	# No log found → unknown (caller should fall through to default behaviour).
+	if [[ -z "$_WORKER_LOG_TAIL_FILE" ]]; then
+		return 0
+	fi
+
+	# Empty content (rare: file existed at -s check but emptied between calls)
+	if [[ -z "$_WORKER_LOG_TAIL_CONTENT" ]]; then
+		return 0
+	fi
+
+	# Classification — order matters: canary signals are most specific, check
+	# them first. Tool-call markers next (positive signal of real work). The
+	# absence-of-tool-calls case is the catch-all when the log has *something*
+	# but no implementation evidence.
+	#
+	# Markers chosen for stability (not session-format details):
+	#   - `[t2814:early_exit]` — explicit marker emitted by Phase 3 Fix 2
+	#   - `canary` (case-insensitive) — appears in canary diagnostic output
+	#   - `tool_use|tool-use|"tool":` — OpenCode tool-call frames in JSON
+	#   - `edit|Edit|Write|Bash` — tool names that imply real implementation
+	#   - `git commit|git push` — strongest evidence of implementation
+	if printf '%s' "$_WORKER_LOG_TAIL_CONTENT" \
+		| grep -qE '\[t2814:early_exit\]|[Cc]anary'; then
+		_WORKER_LOG_TAIL_CLASS="canary_post_spawn"
+	elif printf '%s' "$_WORKER_LOG_TAIL_CONTENT" \
+		| grep -qE 'tool_use|tool-use|"tool":|"name":\s*"(Edit|Write|Bash|Read)"|git\s+(commit|push)'; then
+		_WORKER_LOG_TAIL_CLASS="real_coding"
+	else
+		# Log has content but no implementation markers → worker stalled
+		# before reaching tool-call execution.
+		_WORKER_LOG_TAIL_CLASS="no_tool_calls"
+	fi
+
+	return 0
+}

--- a/.agents/scripts/tests/test-no-work-reclassification.sh
+++ b/.agents/scripts/tests/test-no-work-reclassification.sh
@@ -1,0 +1,427 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression test for t2820 (Phase 5): no_work reclassification via log tail.
+#
+# This test asserts that escalate_issue_tier reclassifies generic
+# `worker_failed`-class events as `no_work` when the Phase 3 worker-log tail
+# (t2814) shows no implementation evidence — preventing wasteful tier
+# escalation to opus on infrastructure failures the worker never recovered
+# from.
+#
+# Coverage:
+#   1. _read_worker_log_tail_classified — exists in shared-claim-lifecycle.sh
+#      and produces the documented caller-scope variables.
+#   2. Classification correctness across the 4 documented log shapes:
+#        a. real_coding         — tool-use frames present → no reclass
+#        b. no_tool_calls       — log content but no tool markers → reclass
+#        c. canary_post_spawn   — canary diagnostics OR t2814 marker → reclass
+#        d. unknown             — missing log → fall-through (no reclass)
+#   3. _maybe_reclassify_worker_failed_as_no_work — fires on the expected
+#      reason buckets (worker_failed, premature_exit, worker_noop_zero_output)
+#      and is a no-op for unrelated reasons (rate_limit, etc.).
+#   4. NO_WORK_RECLASS_ELAPSED_MAX env var honoured — stale logs do NOT
+#      reclassify on the no_tool_calls path (only canary_post_spawn fires
+#      regardless of age).
+#   5. Pre-Phase 3 records (no log file) do NOT regress — function returns 1
+#      so caller falls through to existing escalation behaviour unchanged.
+#
+# Test strategy: structural greps + behavioural unit tests against the real
+# functions sourced from the actual shell libraries. Stubs out gh CLI and
+# _log_no_work_skip_escalation to capture invocations without network calls.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+AGENT_SCRIPT_DIR="${SCRIPT_DIR}/.."
+SHARED_CLAIM_LIFECYCLE="${AGENT_SCRIPT_DIR}/shared-claim-lifecycle.sh"
+WORKER_LIFECYCLE="${AGENT_SCRIPT_DIR}/worker-lifecycle-common.sh"
+PULSE_CLEANUP="${AGENT_SCRIPT_DIR}/pulse-cleanup.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Static structural checks
+# ---------------------------------------------------------------------------
+
+test_shared_helper_exists() {
+	if grep -q '^_read_worker_log_tail_classified()' "$SHARED_CLAIM_LIFECYCLE"; then
+		print_result "shared: _read_worker_log_tail_classified() defined" 0
+	else
+		print_result "shared: _read_worker_log_tail_classified() defined" 1 \
+			"Expected function in $SHARED_CLAIM_LIFECYCLE"
+	fi
+	return 0
+}
+
+test_reclassify_helper_exists() {
+	if grep -q '^_maybe_reclassify_worker_failed_as_no_work()' "$WORKER_LIFECYCLE"; then
+		print_result "worker: _maybe_reclassify_worker_failed_as_no_work() defined" 0
+	else
+		print_result "worker: _maybe_reclassify_worker_failed_as_no_work() defined" 1 \
+			"Expected function in $WORKER_LIFECYCLE"
+	fi
+	return 0
+}
+
+test_escalate_calls_reclassify() {
+	# Assert the reclassify call appears inside escalate_issue_tier — the
+	# only safe place where the empty-crash_type branch should fire.
+	if awk '/^escalate_issue_tier\(\)/,/^}$/' "$WORKER_LIFECYCLE" \
+		| grep -q '_maybe_reclassify_worker_failed_as_no_work'; then
+		print_result "wired: escalate_issue_tier() calls _maybe_reclassify_..." 0
+	else
+		print_result "wired: escalate_issue_tier() calls _maybe_reclassify_..." 1 \
+			"Reclassification call missing from escalate_issue_tier in $WORKER_LIFECYCLE"
+	fi
+	return 0
+}
+
+test_pulse_cleanup_uses_shared_reader() {
+	# Confirm _post_launch_recovery_claim_released no longer duplicates
+	# the log-tail reading logic — DRY with shared helper (acceptance #4).
+	if awk '/_post_launch_recovery_claim_released\(\)/,/^}$/' "$PULSE_CLEANUP" \
+		| grep -q '_read_worker_log_tail_classified'; then
+		print_result "DRY: pulse-cleanup uses _read_worker_log_tail_classified" 0
+	else
+		print_result "DRY: pulse-cleanup uses _read_worker_log_tail_classified" 1 \
+			"Expected pulse-cleanup.sh to delegate log-tail reading to shared helper"
+	fi
+	return 0
+}
+
+test_env_override_documented() {
+	if grep -q 'NO_WORK_RECLASS_ELAPSED_MAX' "$WORKER_LIFECYCLE"; then
+		print_result "env: NO_WORK_RECLASS_ELAPSED_MAX referenced" 0
+	else
+		print_result "env: NO_WORK_RECLASS_ELAPSED_MAX referenced" 1 \
+			"Expected NO_WORK_RECLASS_ELAPSED_MAX env var in $WORKER_LIFECYCLE"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Behavioural — _read_worker_log_tail_classified classification matrix
+# ---------------------------------------------------------------------------
+
+# Source the shared helper directly. The include guard makes this safe to
+# repeat across tests.
+# shellcheck source=../shared-claim-lifecycle.sh
+source "$SHARED_CLAIM_LIFECYCLE"
+
+# Helper: write a fake log to a fresh /tmp path (the canonical location the
+# reader scans), invoke the reader, capture classification + content.
+_run_classifier_with_log() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local log_content="$3"
+	local safe_slug
+	safe_slug=$(printf '%s' "$repo_slug" | tr '/:' '--')
+	local log_file="/tmp/pulse-${safe_slug}-${issue_number}.log"
+	# Clean any prior fixture
+	rm -f "$log_file" "/tmp/pulse-${issue_number}.log" 2>/dev/null || true
+	if [[ -n "$log_content" ]]; then
+		printf '%s\n' "$log_content" >"$log_file"
+	fi
+	# Reset before invocation
+	_WORKER_LOG_TAIL_FILE=""
+	_WORKER_LOG_TAIL_CONTENT=""
+	_WORKER_LOG_TAIL_CLASS="unknown"
+	_WORKER_LOG_TAIL_AGE_SECS=""
+	_read_worker_log_tail_classified "$issue_number" "$repo_slug"
+	# Cleanup
+	rm -f "$log_file" 2>/dev/null || true
+	return 0
+}
+
+test_classify_real_coding() {
+	# Realistic OpenCode tool-call frame fragment
+	_run_classifier_with_log 90001 "test/repo-real" '[2026-04-25T00:00:00Z] starting opencode run
+{"type":"tool_use","name":"Edit","input":{"file":"foo.sh"}}
+{"type":"step","name":"Bash","input":{"command":"git commit -m wip"}}
+git commit succeeded'
+	if [[ "$_WORKER_LOG_TAIL_CLASS" == "real_coding" ]]; then
+		print_result "classify: real_coding (tool-use markers)" 0
+	else
+		print_result "classify: real_coding (tool-use markers)" 1 \
+			"Expected real_coding, got: $_WORKER_LOG_TAIL_CLASS"
+	fi
+	return 0
+}
+
+test_classify_no_tool_calls() {
+	# Log that has content but no tool calls (e.g. session setup messages
+	# repeating without ever reaching exec)
+	_run_classifier_with_log 90002 "test/repo-noop" '[2026-04-25T00:00:00Z] session init
+[2026-04-25T00:00:01Z] loading plugins
+[2026-04-25T00:00:02Z] waiting for stream
+[2026-04-25T00:00:30Z] still waiting
+[2026-04-25T00:00:45Z] connection refused'
+	if [[ "$_WORKER_LOG_TAIL_CLASS" == "no_tool_calls" ]]; then
+		print_result "classify: no_tool_calls (content but no tool markers)" 0
+	else
+		print_result "classify: no_tool_calls (content but no tool markers)" 1 \
+			"Expected no_tool_calls, got: $_WORKER_LOG_TAIL_CLASS"
+	fi
+	return 0
+}
+
+test_classify_canary_post_spawn() {
+	_run_classifier_with_log 90003 "test/repo-canary" '[2026-04-25T00:00:00Z] starting canary test
+[2026-04-25T00:00:05Z] [t2814:early_exit] worker PID 12345 for issue #90003 exited within 4s spawn window at 2026-04-25T00:00:04Z
+[2026-04-25T00:00:05Z] cleanup'
+	if [[ "$_WORKER_LOG_TAIL_CLASS" == "canary_post_spawn" ]]; then
+		print_result "classify: canary_post_spawn (t2814 marker)" 0
+	else
+		print_result "classify: canary_post_spawn (t2814 marker)" 1 \
+			"Expected canary_post_spawn, got: $_WORKER_LOG_TAIL_CLASS"
+	fi
+	return 0
+}
+
+test_classify_canary_text_marker() {
+	# Canary text marker variant (no t2814 marker, just canary in text)
+	_run_classifier_with_log 90004 "test/repo-canary2" '[2026-04-25T00:00:00Z] running canary
+[2026-04-25T00:00:01Z] canary returned 1, aborting'
+	if [[ "$_WORKER_LOG_TAIL_CLASS" == "canary_post_spawn" ]]; then
+		print_result "classify: canary_post_spawn (canary text marker)" 0
+	else
+		print_result "classify: canary_post_spawn (canary text marker)" 1 \
+			"Expected canary_post_spawn, got: $_WORKER_LOG_TAIL_CLASS"
+	fi
+	return 0
+}
+
+test_classify_unknown_missing_log() {
+	# No log file at all
+	_run_classifier_with_log 90005 "test/repo-missing" ""
+	if [[ "$_WORKER_LOG_TAIL_CLASS" == "unknown" && -z "$_WORKER_LOG_TAIL_FILE" ]]; then
+		print_result "classify: unknown (missing log → no reclass)" 0
+	else
+		print_result "classify: unknown (missing log → no reclass)" 1 \
+			"Expected unknown + empty file, got: class=$_WORKER_LOG_TAIL_CLASS file=$_WORKER_LOG_TAIL_FILE"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Behavioural — _maybe_reclassify_worker_failed_as_no_work decision matrix
+# ---------------------------------------------------------------------------
+
+# Source worker-lifecycle-common.sh to bring _maybe_reclassify... and the
+# stubbable _log_no_work_skip_escalation into scope.
+# shellcheck source=../worker-lifecycle-common.sh
+source "$WORKER_LIFECYCLE"
+
+# Stub _log_no_work_skip_escalation: capture all invocations to a tmpfile.
+RECLASS_CAPTURE="$(mktemp "${TMPDIR:-/tmp}/aidevops-t2820-capture.XXXXXX")"
+trap 'rm -f "$RECLASS_CAPTURE" 2>/dev/null || true' EXIT
+
+_log_no_work_skip_escalation() {
+	# Args: issue_number, repo_slug, failure_count, reason
+	printf 'CALLED: issue=%s repo=%s count=%s reason=%s\n' \
+		"$1" "$2" "$3" "$4" >>"$RECLASS_CAPTURE"
+	return 0
+}
+
+# Fixture with tool-call markers — real_coding → return 1 (no reclass)
+test_reclassify_real_coding_no_op() {
+	: >"$RECLASS_CAPTURE"
+	local safe_slug
+	safe_slug=$(printf '%s' "test/repo-r1" | tr '/:' '--')
+	local log_file="/tmp/pulse-${safe_slug}-91001.log"
+	printf 'tool_use Edit foo.sh\ngit commit succeeded\n' >"$log_file"
+	# Make the log "young" so the no_tool_calls timing path is irrelevant
+	if _maybe_reclassify_worker_failed_as_no_work 91001 "test/repo-r1" 1 "worker_failed"; then
+		print_result "reclass: real_coding falls through (returns 1)" 1 \
+			"Expected return 1 for real_coding, but reclassification fired"
+	else
+		# Confirm no skip-escalation call happened
+		if [[ -s "$RECLASS_CAPTURE" ]]; then
+			print_result "reclass: real_coding falls through (returns 1)" 1 \
+				"Expected no _log_no_work_skip_escalation call. Got: $(cat "$RECLASS_CAPTURE")"
+		else
+			print_result "reclass: real_coding falls through (returns 1)" 0
+		fi
+	fi
+	rm -f "$log_file"
+	return 0
+}
+
+# Fixture with no tool calls + young log → reclass with no_tool_calls_in_log
+test_reclassify_no_tool_calls_fires() {
+	: >"$RECLASS_CAPTURE"
+	local safe_slug
+	safe_slug=$(printf '%s' "test/repo-r2" | tr '/:' '--')
+	local log_file="/tmp/pulse-${safe_slug}-91002.log"
+	printf 'session init\nwaiting for stream\nconnection refused\n' >"$log_file"
+	# Force a young mtime (now)
+	touch "$log_file"
+	if _maybe_reclassify_worker_failed_as_no_work 91002 "test/repo-r2" 1 "worker_failed"; then
+		# Confirm capture contains the subtype marker
+		if grep -q 'reason=no_work:no_tool_calls_in_log' "$RECLASS_CAPTURE"; then
+			print_result "reclass: no_tool_calls (young log) → fires with subtype" 0
+		else
+			print_result "reclass: no_tool_calls (young log) → fires with subtype" 1 \
+				"Reclass returned 0 but capture missing subtype. Got: $(cat "$RECLASS_CAPTURE")"
+		fi
+	else
+		print_result "reclass: no_tool_calls (young log) → fires with subtype" 1 \
+			"Expected return 0 (reclassified) for young no_tool_calls log"
+	fi
+	rm -f "$log_file"
+	return 0
+}
+
+# Fixture with canary marker → reclass with canary_post_spawn_failure
+test_reclassify_canary_fires() {
+	: >"$RECLASS_CAPTURE"
+	local safe_slug
+	safe_slug=$(printf '%s' "test/repo-r3" | tr '/:' '--')
+	local log_file="/tmp/pulse-${safe_slug}-91003.log"
+	printf '[t2814:early_exit] worker PID 12345 exited\ncanary diagnostics\n' >"$log_file"
+	if _maybe_reclassify_worker_failed_as_no_work 91003 "test/repo-r3" 1 "worker_failed"; then
+		if grep -q 'reason=no_work:canary_post_spawn_failure' "$RECLASS_CAPTURE"; then
+			print_result "reclass: canary_post_spawn → fires with subtype" 0
+		else
+			print_result "reclass: canary_post_spawn → fires with subtype" 1 \
+				"Reclass returned 0 but capture missing subtype. Got: $(cat "$RECLASS_CAPTURE")"
+		fi
+	else
+		print_result "reclass: canary_post_spawn → fires with subtype" 1 \
+			"Expected return 0 (reclassified) for canary log"
+	fi
+	rm -f "$log_file"
+	return 0
+}
+
+# NO_WORK_RECLASS_ELAPSED_MAX honoured — old log + no_tool_calls → no reclass
+test_reclassify_old_no_tool_calls_skipped() {
+	: >"$RECLASS_CAPTURE"
+	local safe_slug
+	safe_slug=$(printf '%s' "test/repo-r4" | tr '/:' '--')
+	local log_file="/tmp/pulse-${safe_slug}-91004.log"
+	printf 'session init\nwaiting\n' >"$log_file"
+	# Use a low elapsed-max, then backdate the log to exceed it.
+	local saved_max="$NO_WORK_RECLASS_ELAPSED_MAX"
+	NO_WORK_RECLASS_ELAPSED_MAX=10
+	# Backdate mtime by 60s
+	touch -d '60 seconds ago' "$log_file" 2>/dev/null || \
+		touch -t "$(date -d '60 seconds ago' '+%Y%m%d%H%M.%S' 2>/dev/null || echo '202604250000.00')" "$log_file" 2>/dev/null || true
+	if _maybe_reclassify_worker_failed_as_no_work 91004 "test/repo-r4" 1 "worker_failed"; then
+		print_result "reclass: old no_tool_calls log → no reclass (elapsed cap)" 1 \
+			"Expected return 1 for old log but reclassification fired. Capture: $(cat "$RECLASS_CAPTURE")"
+	else
+		if [[ -s "$RECLASS_CAPTURE" ]]; then
+			print_result "reclass: old no_tool_calls log → no reclass (elapsed cap)" 1 \
+				"Expected no skip-escalation call. Got: $(cat "$RECLASS_CAPTURE")"
+		else
+			print_result "reclass: old no_tool_calls log → no reclass (elapsed cap)" 0
+		fi
+	fi
+	NO_WORK_RECLASS_ELAPSED_MAX="$saved_max"
+	rm -f "$log_file"
+	return 0
+}
+
+# Pre-Phase 3 records (no log file) → fall-through (no regression)
+test_reclassify_no_log_falls_through() {
+	: >"$RECLASS_CAPTURE"
+	# Ensure no log file exists for this issue
+	rm -f /tmp/pulse-test--repo-r5-91005.log /tmp/pulse-91005.log 2>/dev/null || true
+	if _maybe_reclassify_worker_failed_as_no_work 91005 "test/repo-r5" 1 "worker_failed"; then
+		print_result "reclass: no log file → fall-through (no regression)" 1 \
+			"Expected return 1 (fall-through) for missing log"
+	else
+		if [[ -s "$RECLASS_CAPTURE" ]]; then
+			print_result "reclass: no log file → fall-through (no regression)" 1 \
+				"Expected no skip-escalation call. Got: $(cat "$RECLASS_CAPTURE")"
+		else
+			print_result "reclass: no log file → fall-through (no regression)" 0
+		fi
+	fi
+	return 0
+}
+
+# Reasons that should NOT reclassify (rate_limit, etc.)
+test_reclassify_skips_rate_limit() {
+	: >"$RECLASS_CAPTURE"
+	local safe_slug
+	safe_slug=$(printf '%s' "test/repo-r6" | tr '/:' '--')
+	local log_file="/tmp/pulse-${safe_slug}-91006.log"
+	# Even with a no_tool_calls log, rate_limit should fall through.
+	printf 'session init\nwaiting\n' >"$log_file"
+	touch "$log_file"
+	if _maybe_reclassify_worker_failed_as_no_work 91006 "test/repo-r6" 1 "rate_limit"; then
+		print_result "reclass: rate_limit reason → fall-through (out of scope)" 1 \
+			"Expected return 1 for rate_limit reason but reclassification fired"
+	else
+		if [[ -s "$RECLASS_CAPTURE" ]]; then
+			print_result "reclass: rate_limit reason → fall-through (out of scope)" 1 \
+				"Expected no skip-escalation call. Got: $(cat "$RECLASS_CAPTURE")"
+		else
+			print_result "reclass: rate_limit reason → fall-through (out of scope)" 0
+		fi
+	fi
+	rm -f "$log_file"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Run
+# ---------------------------------------------------------------------------
+
+printf 'Running t2820 no_work reclassification regression tests\n\n'
+
+# Static checks
+test_shared_helper_exists
+test_reclassify_helper_exists
+test_escalate_calls_reclassify
+test_pulse_cleanup_uses_shared_reader
+test_env_override_documented
+
+# Classification matrix
+test_classify_real_coding
+test_classify_no_tool_calls
+test_classify_canary_post_spawn
+test_classify_canary_text_marker
+test_classify_unknown_missing_log
+
+# Reclassification decision matrix
+test_reclassify_real_coding_no_op
+test_reclassify_no_tool_calls_fires
+test_reclassify_canary_fires
+test_reclassify_old_no_tool_calls_skipped
+test_reclassify_no_log_falls_through
+test_reclassify_skips_rate_limit
+
+printf '\n'
+if [[ "$TESTS_FAILED" -eq 0 ]]; then
+	printf '%bAll %d tests passed%b\n' "$TEST_GREEN" "$TESTS_RUN" "$TEST_RESET"
+	exit 0
+fi
+printf '%b%d/%d tests failed%b\n' "$TEST_RED" "$TESTS_FAILED" "$TESTS_RUN" "$TEST_RESET"
+exit 1

--- a/.agents/scripts/tests/test-no-worker-process-fix.sh
+++ b/.agents/scripts/tests/test-no-worker-process-fix.sh
@@ -68,30 +68,45 @@ print_result() {
 # ---------------------------------------------------------------------------
 
 # Static check: the helper reads the worker log path candidates.
+#
+# t2820 update: log-path enumeration was extracted from
+# `_post_launch_recovery_claim_released` (pulse-cleanup.sh) into
+# `_read_worker_log_tail_classified` (shared-claim-lifecycle.sh) so that the
+# pulse-cleanup CLAIM_RELEASED comment AND the worker-lifecycle no_work
+# reclassification (Phase 5) share one parser. Assert both: pulse-cleanup
+# delegates to the shared helper, and the shared helper enumerates the
+# canonical log paths.
 test_claim_released_reads_log() {
+	local shared_lifecycle="${AGENT_SCRIPT_DIR}/shared-claim-lifecycle.sh"
 	# shellcheck disable=SC2016  # literal text in source — no expansion intended
-	if grep -q '/tmp/pulse-\${safe_slug}-\${issue_number}.log' "$PULSE_CLEANUP" \
-		&& grep -q 'log_candidates=' "$PULSE_CLEANUP"; then
+	if grep -q '/tmp/pulse-\${safe_slug}-\${issue_number}.log' "$shared_lifecycle" \
+		&& grep -q 'log_candidates=' "$shared_lifecycle" \
+		&& grep -q '_read_worker_log_tail_classified' "$PULSE_CLEANUP"; then
 		print_result "fix #1: _post_launch_recovery_claim_released enumerates worker-log paths" 0
 		return 0
 	fi
 	print_result "fix #1: _post_launch_recovery_claim_released enumerates worker-log paths" 1 \
-		"Expected log_candidates with /tmp/pulse-...log paths in $PULSE_CLEANUP"
+		"Expected shared helper in $shared_lifecycle and delegation from $PULSE_CLEANUP (t2820 extraction)"
 	return 0
 }
 
 # Static check: tail is bounded so we cannot accidentally embed a 10MB
 # stack trace into a GitHub comment.
+#
+# t2820 update: same extraction note — bounds now live in the shared helper.
 test_claim_released_bounds_tail() {
-	# tail -20 lines, head -c 4096 byte cap
-	if grep -q 'tail -20.*head -c 4096' "$PULSE_CLEANUP"; then
+	local shared_lifecycle="${AGENT_SCRIPT_DIR}/shared-claim-lifecycle.sh"
+	# tail -20 lines AND head -c 4096 byte cap (may be on adjacent lines
+	# joined with `|`, so use a windowed grep instead of a single-line regex).
+	if grep -q 'tail -20' "$shared_lifecycle" \
+		&& grep -q 'head -c 4096' "$shared_lifecycle"; then
 		print_result "fix #1: log tail bounded to 20 lines / 4KB" 0
 		return 0
 	fi
 	print_result "fix #1: log tail bounded to 20 lines / 4KB" 1 \
-		"Expected 'tail -20 ... head -c 4096' in $PULSE_CLEANUP — without this, \
-giant logs could be embedded in CLAIM_RELEASED comments and leak credentials \
-or blow the GitHub 65535-byte body limit."
+		"Expected 'tail -20' AND 'head -c 4096' in $shared_lifecycle (t2820 extraction) — \
+without this, giant logs could be embedded in CLAIM_RELEASED comments and leak \
+credentials or blow the GitHub 65535-byte body limit."
 	return 0
 }
 

--- a/.agents/scripts/worker-lifecycle-common.sh
+++ b/.agents/scripts/worker-lifecycle-common.sh
@@ -947,6 +947,135 @@ _Automated by \`escalate_issue_tier()\` no_work skip (t2387) in worker-lifecycle
 ESCALATION_FAILURE_THRESHOLD="${ESCALATION_FAILURE_THRESHOLD:-2}"
 ESCALATION_OVERWHELMED_THRESHOLD="${ESCALATION_OVERWHELMED_THRESHOLD:-1}"
 NO_WORK_NMR_THRESHOLD="${NO_WORK_NMR_THRESHOLD:-3}"
+# t2820: maximum log-file age (seconds) under which a `worker_failed` event
+# with no tool-call markers in the log tail will be reclassified as `no_work`.
+# Workers that ran for longer are likely real coding failures (worker engaged,
+# read files, attempted edits) where escalation IS appropriate. The default
+# (180s) is conservative — most real coding work produces tool-call frames in
+# the first minute. Override via env when investigating specific incidents.
+NO_WORK_RECLASS_ELAPSED_MAX="${NO_WORK_RECLASS_ELAPSED_MAX:-180}"
+
+#######################################
+# _maybe_reclassify_worker_failed_as_no_work — Phase 5 reclassification (t2820)
+#
+# When `escalate_issue_tier` is called with `crash_type == ""` and a
+# `worker_failed`-class reason, inspect the worker log tail to decide whether
+# this is a genuine coding failure (escalate) or a late infra failure that the
+# pulse currently mis-classifies (`worker_failed` is the catch-all bucket — see
+# issue body for the false-merge background).
+#
+# Reclassification rules (in order of precedence):
+#
+#   1. Log tail contains canary diagnostics OR `[t2814:early_exit]` marker
+#      → reclassify as `no_work` with subtype `canary_post_spawn_failure`.
+#      The worker spawned but died before any real work — opus cannot help.
+#
+#   2. Log file age <= NO_WORK_RECLASS_ELAPSED_MAX AND log tail contains no
+#      tool-use markers → reclassify as `no_work` with subtype
+#      `no_tool_calls_in_log`. The worker was alive long enough to run, but
+#      never reached implementation. Same opus-cannot-help reasoning.
+#
+#   3. Otherwise (real_coding signals, log too old, or log missing) → no
+#      reclassification. Caller's existing escalation logic runs unchanged.
+#
+# When a rule fires, the helper invokes `_log_no_work_skip_escalation` with
+# the subtype embedded in the `reason` arg so the diagnostic comment explains
+# which rule fired. Returns 0 to signal "reclassified, skip cascade"; returns
+# 1 to signal "fall through to normal escalation".
+#
+# Args:
+#   $1 - issue_number
+#   $2 - repo_slug
+#   $3 - failure_count
+#   $4 - original reason (e.g. worker_failed, premature_exit)
+#
+# Returns: 0 on reclassification (caller MUST short-circuit), 1 otherwise.
+#######################################
+_maybe_reclassify_worker_failed_as_no_work() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local failure_count="$3"
+	local original_reason="$4"
+
+	# Only reclassify worker_failed-class reasons. Rate-limit and explicit
+	# crash_type cases are handled elsewhere; we should not touch them.
+	#
+	# Reasons that map to "spawned but produced no useful output":
+	#   - worker_failed             (catch-all from headless-runtime-helper)
+	#   - premature_exit            (watchdog-detected early exit)
+	#   - worker_noop_zero_output   (post-completion zero-output check)
+	case "$original_reason" in
+	worker_failed | premature_exit | worker_noop_zero_output) ;;
+	*) return 1 ;;
+	esac
+
+	# Need the shared log-tail reader. If not loaded, fall through — better
+	# to escalate normally than to mis-classify on missing tooling.
+	if ! declare -F _read_worker_log_tail_classified >/dev/null 2>&1; then
+		return 1
+	fi
+
+	# Reset caller-scope vars (the reader resets them too, but be explicit).
+	_WORKER_LOG_TAIL_FILE=""
+	_WORKER_LOG_TAIL_CONTENT=""
+	_WORKER_LOG_TAIL_CLASS="unknown"
+	_WORKER_LOG_TAIL_AGE_SECS=""
+
+	_read_worker_log_tail_classified "$issue_number" "$repo_slug"
+
+	# Design constraint (per issue body): if Phase 3's log-tail data is
+	# absent (older dispatch records, log file rotated away), fall through
+	# to existing worker_failed → escalation behaviour unchanged. No
+	# regression on pre-Phase 3 records.
+	[[ -n "${_WORKER_LOG_TAIL_FILE:-}" ]] || return 1
+	[[ "${_WORKER_LOG_TAIL_CLASS:-unknown}" != "unknown" ]] || return 1
+
+	local subtype=""
+	case "$_WORKER_LOG_TAIL_CLASS" in
+	canary_post_spawn)
+		# Highest-precedence rule: explicit infra-failure markers in the
+		# log tail. Fire regardless of runtime — a canary-failure tail
+		# 10 minutes after spawn is still a canary failure.
+		subtype="canary_post_spawn_failure"
+		;;
+	no_tool_calls)
+		# Runtime-bounded rule: only reclassify when the log file is
+		# young enough that "no tool calls" credibly means "didn't get
+		# to coding". For longer runtimes, the worker may have legitimately
+		# coded and only the tail visible (a 20-line tail at 30 minutes
+		# of runtime can easily miss the implementation phase).
+		local age="${_WORKER_LOG_TAIL_AGE_SECS:-}"
+		if [[ -n "$age" && "$age" =~ ^[0-9]+$ \
+			&& "$age" -le "$NO_WORK_RECLASS_ELAPSED_MAX" ]]; then
+			subtype="no_tool_calls_in_log"
+		fi
+		;;
+	real_coding)
+		# Worker did real implementation work. Original escalation is
+		# the right response.
+		return 1
+		;;
+	esac
+
+	# No subtype assigned → no reclassification (e.g. no_tool_calls but
+	# log too old). Fall through to normal escalation.
+	[[ -n "$subtype" ]] || return 1
+
+	# Compose the reason that will appear in the skip-escalation comment.
+	# Prefix with the subtype so operators can grep for the specific rule
+	# that fired (auditable per the issue's verification example).
+	local reclass_reason="no_work:${subtype} (reclassified from ${original_reason} via log-tail at ${_WORKER_LOG_TAIL_FILE})"
+
+	# Single-line audit log for log tailers — keeps the reclassification
+	# observable even when the GH comment fails to post.
+	printf '[worker-lifecycle][t2820] reclassified worker_failed→no_work for #%s (%s) subtype=%s age=%ss class=%s\n' \
+		"$issue_number" "$repo_slug" "$subtype" \
+		"${_WORKER_LOG_TAIL_AGE_SECS:-?}" "${_WORKER_LOG_TAIL_CLASS}" >&2 || true
+
+	_log_no_work_skip_escalation "$issue_number" "$repo_slug" \
+		"$failure_count" "$reclass_reason"
+	return 0
+}
 
 escalate_issue_tier() {
 	local issue_number="$1"
@@ -960,6 +1089,26 @@ escalate_issue_tier() {
 
 	# Validate failure_count is numeric (CodeRabbit review)
 	[[ "$failure_count" =~ ^[0-9]+$ ]] || return 0
+
+	# t2820 (Phase 5): when crash_type is empty AND reason looks like a
+	# generic worker-failure bucket, try to reclassify as no_work using the
+	# Phase 3 log-tail signal. The reclassification rule fires only when the
+	# log tail provides positive evidence of an infra-class failure (canary
+	# diagnostics, t2814:early_exit marker) OR no implementation evidence
+	# combined with short runtime. Otherwise the reason is treated as a real
+	# coding failure and falls through to the normal cascade.
+	#
+	# This must run BEFORE the existing no_work short-circuit so that the
+	# reclassification path can call the skip-escalation helper with a
+	# descriptive subtype-aware reason instead of the original generic
+	# bucket name. (See _maybe_reclassify_worker_failed_as_no_work above
+	# for the full rule list and reference-pattern fixture coverage.)
+	if [[ -z "$crash_type" ]]; then
+		if _maybe_reclassify_worker_failed_as_no_work \
+			"$issue_number" "$repo_slug" "$failure_count" "$reason"; then
+			return 0
+		fi
+	fi
 
 	# Select threshold based on crash type:
 	# - "overwhelmed" = model attempted real work but couldn't complete.


### PR DESCRIPTION
## Summary

Extend `no_work` classification (currently only triggered by `launch_recovery:no_worker_process` via t2815) to also cover generic `worker_failed` events where the Phase 3 worker-log tail (t2814) shows no implementation evidence — preventing wasteful tier escalation to opus on infrastructure failures the worker never recovered from.

## Why

The current fast-fail classification has two buckets — `no_worker_process` (t2387 skip) and `worker_failed` (cascade escalation) — but `worker_failed` is a false-merge that conflates two distinct failure modes:

- **Real coding failure** — worker spawned, loaded context (~20K tokens), executed tool calls, produced bad code. Escalation to opus-4-7 is correct.
- **Late infra failure** — worker spawned, ran canary, canary passed, then hit a mid-session blip (auth refresh timeout, plugin hook deadlock, provider rate limit) BEFORE producing any tool calls. Escalation wastes opus tokens on a model that cannot fix infrastructure.

Phase 3 (t2814) lands the log-tail collection in the `CLAIM_RELEASED` comment. That same log-tail data can drive an automatic reclassification.

## Implementation

- **NEW** `_read_worker_log_tail_classified` in `shared-claim-lifecycle.sh` — extracts log-tail reading + classification from Phase 3's `_post_launch_recovery_claim_released`. Sets caller-scope vars (`_WORKER_LOG_TAIL_FILE`, `_WORKER_LOG_TAIL_CONTENT`, `_WORKER_LOG_TAIL_CLASS`, `_WORKER_LOG_TAIL_AGE_SECS`). Classifies into one of `real_coding | no_tool_calls | canary_post_spawn | unknown`.
- **EDIT** `pulse-cleanup.sh::_post_launch_recovery_claim_released` — now delegates log-tail reading to the shared helper (DRY: same parser used by both consumers).
- **NEW** `_maybe_reclassify_worker_failed_as_no_work` in `worker-lifecycle-common.sh` — inspects the log tail when `crash_type` is empty AND reason matches a generic worker-failure bucket (`worker_failed`, `premature_exit`, `worker_noop_zero_output`). Reclassifies with one of two distinct subtypes:
  - `canary_post_spawn_failure` — canary diagnostics or `[t2814:early_exit]` marker present, fires regardless of runtime
  - `no_tool_calls_in_log` — no tool-use markers AND log age ≤ `NO_WORK_RECLASS_ELAPSED_MAX` (default 180s, env-overridable)
- **EDIT** `worker-lifecycle-common.sh::escalate_issue_tier` — calls the reclassification helper BEFORE the existing `crash_type == "no_work"` short-circuit so the descriptive subtype-aware reason flows through `_log_no_work_skip_escalation` (t2387).
- **NEW** `tests/test-no-work-reclassification.sh` — 16 assertions covering all 4 log shapes + 6 reclassification decision branches.
- **EDIT** `tests/test-no-worker-process-fix.sh` — re-pointed log-path-enumeration and tail-bound assertions at the shared helper's new home (still passing 15/15).
- **EDIT** `reference/worker-diagnostics.md` — new Phase 5 section with the 4-row classification matrix.

## Backward compatibility

When the log file is missing (older dispatch records pre-Phase 3, or rotated-away logs), the reclassification helper returns 1 and the existing `worker_failed` → escalation behaviour fires unchanged. **No regression on pre-Phase 3 records.**

## Testing

```bash
shellcheck .agents/scripts/worker-lifecycle-common.sh \
           .agents/scripts/shared-claim-lifecycle.sh \
           .agents/scripts/pulse-cleanup.sh
bash .agents/scripts/tests/test-no-work-reclassification.sh   # 16/16 pass
bash .agents/scripts/tests/test-no-worker-process-fix.sh      # 15/15 pass (Phase 3 regression)
```

Verified `tests/test-worker-reliability-self-heal.sh` 'escalate: no_work tier-cascade skip (t2387)' still passes — the existing tier-mutation guard ordering is preserved, my new pre-guard runs before it.

Resolves #20853

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.0 plugin for [OpenCode](https://opencode.ai) v1.14.24 with claude-opus-4-7 spent 14m and 53,787 tokens on this as a headless worker.