### PR TITLE
GH#20856: GH#20856: write no-changes report to --output-md when no .sh/.py files changed

### DIFF
--- a/.agents/scripts/complexity-regression-helper.sh
+++ b/.agents/scripts/complexity-regression-helper.sh
@@ -973,6 +973,20 @@ _check_regression() {
 		| grep -E '\.(sh|py)$' || true)
 	if [ -z "$_changed_source" ]; then
 		log "[$_metric] no .sh/.py changes between ${_base_sha:0:7}..${_head_sha:0:7} — skipping"
+		# Write a clean "no applicable changes" report so any previously-posted
+		# stale report (from a prior run with .sh/.py changes that were later
+		# reverted back to doc-only) is replaced via the CI upsert path.
+		if [ -n "$_output_md" ]; then
+			local _title_str
+			_title_str=$(metric_title "$_metric")
+			{
+				printf '## %s Regression Gate\n\n' "$_title_str"
+				# shellcheck disable=SC2016
+				printf '✅ **No applicable changes** — no `.sh`/`.py` files changed in this PR.\n\n'
+				printf '<!-- complexity-regression-gate:%s -->\n' "$_metric"
+			} >"$_output_md"
+			log "[$_metric] wrote no-changes report to $_output_md"
+		fi
 		exit 0
 	fi
 	local _changed_count


### PR DESCRIPTION
## Summary

Added a clean 'no applicable changes' report written to --output-md when the diff-scoped fast path finds no .sh/.py changes. This replaces any stale complexity-regression report posted by a previous run on the same PR (e.g., PR had shell changes later reverted to doc-only). The report includes the metric-specific marker so CI upsert replaces the old comment.

## Files Changed

.agents/scripts/complexity-regression-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck passes with zero violations; manually verified the if [ -n "$_output_md" ] branch writes correct markdown with the <!-- complexity-regression-gate:$_metric --> marker

Resolves #20856


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.0 plugin for [OpenCode](https://opencode.ai) v1.14.24 with claude-sonnet-4-6 spent 2m and 4,761 tokens on this as a headless worker.