### PR TITLE
GH#20858: validate PR title prefix against canonical issue mapping in _compose_pr_title

### DIFF
--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -950,13 +950,22 @@ _derive_pr_title_prefix() {
 # auto-derive path idempotent so callers can safely include a prefix in
 # the commit message without producing a doubled title.
 #
+# Prefix validation (GH#20858): when commit_message already has a prefix,
+# verify it matches the canonical prefix for issue_number. A mismatched
+# prefix (e.g. "t999: ..." for issue that maps to t456) silently breaks
+# TODO auto-completion (issue-sync regex anchored on ^tNNN) and attribution.
+# When a mismatch is detected, the canonical prefix is substituted and a
+# warning is emitted to stderr. Pass-through is preserved when issue_number
+# is empty (can't validate) or when the prefix already matches.
+#
 # Args:
 #   $1 - issue_number
 #   $2 - commit_message
 #   $3 - todo_file (optional; passed through to _derive_pr_title_prefix)
 # Outputs:
-#   commit_message (verbatim) when it already has a tNNN: or GH#NNN: prefix
-#   <derived_prefix>: <commit_message> otherwise
+#   commit_message (verbatim) when it already has a correct tNNN: or GH#NNN: prefix
+#   <canonical_prefix>: <body> when prefix is present but mismatched
+#   <derived_prefix>: <commit_message> when no prefix is present
 # Returns: 0 always.
 _compose_pr_title() {
 	local issue_number="${1:-}"
@@ -964,7 +973,23 @@ _compose_pr_title() {
 	local todo_file="${3:-}"
 
 	if [[ "$commit_message" =~ ^(t[0-9]+|GH#[0-9]+): ]]; then
-		printf '%s\n' "$commit_message"
+		local existing_prefix="${BASH_REMATCH[1]}"
+		# Skip validation when issue_number is unknown — cannot derive canonical.
+		if [[ -z "$issue_number" ]]; then
+			printf '%s\n' "$commit_message"
+			return 0
+		fi
+		local canonical_prefix=""
+		canonical_prefix="$(_derive_pr_title_prefix "$issue_number" "$todo_file")"
+		if [[ "$existing_prefix" == "$canonical_prefix" ]]; then
+			printf '%s\n' "$commit_message"
+		else
+			# Strip the mismatched prefix (everything up to and including the first ": ")
+			# and substitute the canonical one so issue-sync auto-completion works.
+			local body="${commit_message#*: }"
+			print_warning "_compose_pr_title: prefix mismatch — commit has '${existing_prefix}:' but issue #${issue_number} maps to '${canonical_prefix}:'. Using canonical prefix."
+			printf '%s: %s\n' "$canonical_prefix" "$body"
+		fi
 		return 0
 	fi
 


### PR DESCRIPTION
## What

Adds prefix-mismatch validation to `_compose_pr_title` in `.agents/scripts/full-loop-helper.sh`.

Previously, the function returned `commit_message` verbatim whenever it started with a `tNNN:` or `GH#NNN:` prefix, without checking whether that prefix corresponded to the actual `issue_number`. A user accidentally providing `t999: Fix something` for an issue that maps to `t456` in TODO.md would produce a PR titled `t999: Fix...`, silently breaking:
- issue-sync's PR-merge auto-completion (regex anchored on `^tNNN` extracts `t999`, not `t456`, so the TODO entry is never flipped)
- attribution (commit→issue linkage points at the wrong task ID)

## How

In the prefixed path of `_compose_pr_title`:
1. Extract the existing prefix from the regex capture group.
2. Derive the canonical prefix for the given `issue_number` via `_derive_pr_title_prefix`.
3. If they match → return verbatim (idempotent, no behaviour change for the common case).
4. If they mismatch → emit a `print_warning` to stderr, strip the wrong prefix, prepend the canonical one.
5. If `issue_number` is empty → skip validation (can't derive canonical, return verbatim as before).

## Testing

All existing behaviours are preserved:
- Correct prefix → verbatim pass-through ✓
- Mismatched prefix → corrected to canonical with warning ✓
- No prefix → derived prefix prepended ✓
- Empty issue_number with prefix → verbatim pass-through ✓
- Double-prefix prevention (original t2825/RC3 fix) → still works ✓

ShellCheck: zero violations.

Resolves #20858


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.0 plugin for [OpenCode](https://opencode.ai) v1.14.24 with claude-sonnet-4-6 spent 3m and 8,169 tokens on this as a headless worker.