### PR TITLE
t2833: fix(orphan-recovery) SC2215 broken line continuation silently dropped PR creation args

### DIFF
--- a/.agents/scripts/shared-claim-lifecycle.sh
+++ b/.agents/scripts/shared-claim-lifecycle.sh
@@ -215,14 +215,23 @@ _attempt_orphan_recovery_pr() {
 	# Raw gh pr create (not gh_create_pr wrapper) is intentional: gh_create_pr
 	# auto-applies origin:worker which conflicts with origin:worker-takeover
 	# (mutually exclusive labels). See GH#20819 for rationale.
-	gh pr create \ # aidevops-allow: raw-gh-wrapper
-		--repo "$repo_slug" \
-		--head "$branch_name" \
-		--base "$default_branch" \
-		--title "$pr_title" \
-		--body "$pr_body" \
-		--label "origin:worker-takeover" \
-		>/dev/null 2>&1
+	#
+	# Args built as an array so the gh-wrapper-guard allowlist marker can stay
+	# on the same line as `gh pr create` (its line-by-line scanner requires
+	# co-location) without needing a line continuation. Previous form used
+	# `gh pr create \ # marker` followed by indented args — but `\<space>#` is
+	# NOT a line continuation in bash (`\` escapes the space, `#` starts a
+	# comment, the line terminates), so the args were silently dropped and
+	# this entire orphan-recovery path never produced a PR. SC2215 caught it.
+	local create_args=(
+		--repo "$repo_slug"
+		--head "$branch_name"
+		--base "$default_branch"
+		--title "$pr_title"
+		--body "$pr_body"
+		--label "origin:worker-takeover"
+	)
+	gh pr create "${create_args[@]}" >/dev/null 2>&1 # aidevops-allow: raw-gh-wrapper
 	return $?
 }
 


### PR DESCRIPTION
## Summary

Fixes SC2215 in `shared-claim-lifecycle.sh:218`. The orphan-recovery PR creation path was broken bash — `\<space>#` is not a line continuation, so the recovery PR never produced any actual PR.

## Why

Two layers of failure:

1. **Silent runtime breakage:** `_create_orphan_recovery_pr` would invoke the PR-creation command with zero arguments, then attempt to run each indented `--flag value` line as a separate shell command. Every orphan-recovery attempt since today's commit `d8635f6be7` failed silently with `--repo: command not found` etc., and the rest of the function returned `$?` of the last failed line. No PR ever materialized. The function's only effect was log noise.

2. **Pre-flight blocker:** ShellCheck SC2215 in `version-manager.sh release` pre-flight, which forced v3.11.1 to ship via `--skip-preflight`.

## How

Replaced the broken `<command> \ # marker` form with array expansion:

```bash
local create_args=(
    --repo "$repo_slug"
    --head "$branch_name"
    ...
)
<command> "${create_args[@]}" >/dev/null 2>&1 # aidevops-allow: raw-gh-wrapper
```

This satisfies three constraints simultaneously:
1. ShellCheck happy — no malformed line continuation
2. `gh-wrapper-guard.sh` happy — line-based scanner finds the marker on the same line as the raw `gh` invocation it's trying to allowlist
3. Bash happy — single-line invocation, no escaping gotchas

Added a 7-line comment block explaining the bash semantics so the next reader does not reintroduce the bug.

## Verification

- `shellcheck .agents/scripts/shared-claim-lifecycle.sh` — clean (was: SC2215)
- `bash -n .agents/scripts/shared-claim-lifecycle.sh` — parses cleanly
- `gh-wrapper-guard.sh check --base origin/main` — clean (marker still co-located)
- Pre-commit ratchet checks — pass

## Acceptance

- [x] SC2215 cleared in `shared-claim-lifecycle.sh`
- [x] `aidevops-allow:` marker still co-located with the raw `gh` invocation per scanner contract
- [x] ShellCheck clean across the modified file
- [x] Future `version-manager.sh release patch` runs pre-flight without `--skip-preflight` on this account

Resolves #20873

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.1 plugin for [OpenCode](https://opencode.ai) v1.14.25 with claude-opus-4-7 spent 13h 40m and 69,969 tokens on this with the user in an interactive session.
