### PR TITLE
t2835: add manual single-issue dispatch CLI

### DIFF
--- a/.agents/scripts/commands/dispatch-issue.md
+++ b/.agents/scripts/commands/dispatch-issue.md
@@ -34,18 +34,27 @@ helper deliberately does not.
    - Issue must exist + be `OPEN`.
    - Reject `parent-task` issues with a clear "use a phase child" message.
 3. Dedup pre-check via `dispatch-dedup-helper.sh is-assigned`.
-   - Real dispatch: block on existing claim, exit 0 with explanation.
-   - Dry-run: surface dedup status as info, still print the planned dispatch.
+   - Exit 0 (active claim) → real dispatch blocks, exit 0 with explanation.
+   - Exit 1 (free) → dispatch proceeds.
+   - Other exit code (helper missing, network error, etc.) → fail closed,
+     refuse to dispatch, exit 1.
+   - Dry-run: surface all three states as info, still print the planned dispatch.
 4. Resolve tier/model:
    - `--model <id>` wins.
    - Else infer from `tier:thinking|standard|simple` and `model:<id>` labels.
    - Default tier = `standard`, default model family = `sonnet`.
 5. Dispatch (real path):
-   - Pre-create worktree via `worktree-helper.sh add` (`auto-<ts>-gh<N>`).
-   - Register dispatch in ledger (`launched_by=manual-cli-<user>`).
+   - Pre-create worktree via `worktree-helper.sh add` (`auto-<ts>-gh<N>`),
+     resolve actual path back from `git worktree list` (worktree-helper has
+     its own slug logic — recomputing it is fragile).
    - Launch detached worker with prompt
      `/full-loop Implement issue #<N> (<url>)` — `headless-runtime-lib`
      auto-appends `HEADLESS_CONTINUATION_CONTRACT_V6`.
+   - Poll worker log for the `Dispatched PID:` line printed by
+     `headless-runtime-helper.sh::_detach_worker` (timeout 3s) to extract
+     the real worker PID, not the short-lived launch wrapper.
+   - Register dispatch in ledger with the real worker PID so subsequent
+     `status` and pulse dedup-layer-1 checks see a live process.
    - Print PID, log path, session key.
 6. Status check (anytime): `dispatch-issue status <N> <slug>` reports the
    active dispatch ledger entry, including PID liveness.

--- a/.agents/scripts/commands/dispatch-issue.md
+++ b/.agents/scripts/commands/dispatch-issue.md
@@ -1,0 +1,92 @@
+---
+description: Manually dispatch a worker against a single GitHub issue (smoke-test the pulse dispatch path).
+agent: Build+
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+Args: `$ARGUMENTS` — `<issue_number> <owner/repo> [--model <id>] [--dry-run]`
+
+## What this does
+
+Bypasses the pulse loop and launches one worker against one issue. The same
+worker shape the pulse uses (`headless-runtime-helper.sh run --detach`
+producing a `/full-loop` prompt), without:
+
+- Capacity checks
+- Throttle / adaptive cadence
+- Multi-issue scanning
+- Pulse-cycle ledger sweeps
+
+Use this for **smoke-testing**, **debugging dispatch failures**, **brief
+worker-readiness validation**, or **manual retries** after fixing an upstream
+issue. NOT a replacement for the pulse — the pulse handles concerns this
+helper deliberately does not.
+
+## Resolution and execution
+
+1. Resolve `$ARGUMENTS` into `<issue_number>` (numeric) and `<owner/repo>`.
+   - If `--repo` is omitted in user prose, default to the current repo's
+     `slug` from `~/.config/aidevops/repos.json`.
+2. Pre-flight (always, even with `--dry-run`):
+   - Issue must exist + be `OPEN`.
+   - Reject `parent-task` issues with a clear "use a phase child" message.
+3. Dedup pre-check via `dispatch-dedup-helper.sh is-assigned`.
+   - Real dispatch: block on existing claim, exit 0 with explanation.
+   - Dry-run: surface dedup status as info, still print the planned dispatch.
+4. Resolve tier/model:
+   - `--model <id>` wins.
+   - Else infer from `tier:thinking|standard|simple` and `model:<id>` labels.
+   - Default tier = `standard`, default model family = `sonnet`.
+5. Dispatch (real path):
+   - Pre-create worktree via `worktree-helper.sh add` (`auto-<ts>-gh<N>`).
+   - Register dispatch in ledger (`launched_by=manual-cli-<user>`).
+   - Launch detached worker with prompt
+     `/full-loop Implement issue #<N> (<url>)` — `headless-runtime-lib`
+     auto-appends `HEADLESS_CONTINUATION_CONTRACT_V6`.
+   - Print PID, log path, session key.
+6. Status check (anytime): `dispatch-issue status <N> <slug>` reports the
+   active dispatch ledger entry, including PID liveness.
+
+## Direct invocation
+
+```bash
+# Smoke-test (preview only, no worker launched)
+dispatch-single-issue-helper.sh dispatch 20882 marcusquinn/aidevops --dry-run
+
+# Real dispatch — model inferred from labels
+dispatch-single-issue-helper.sh dispatch 20882 marcusquinn/aidevops
+
+# Force a specific model (bypasses label inference)
+dispatch-single-issue-helper.sh dispatch 20882 marcusquinn/aidevops \
+    --model anthropic/claude-opus-4-7
+
+# Check active dispatch state
+dispatch-single-issue-helper.sh status 20882 marcusquinn/aidevops
+```
+
+## When to choose this over the pulse
+
+- **Pulse hasn't reached this issue yet** and you want to verify the brief.
+- **Pulse keeps skipping** the issue (dedup, capacity, label gates) and you
+  want to see *why* without scanning logs.
+- **You fixed a dispatch-path bug** and want to validate the end-to-end
+  worker spawn before letting the pulse cycle catch up.
+- **You're debugging worker-side behaviour** and need a controlled, single
+  worker (not "whatever the pulse picks next").
+
+## Exit codes
+
+- `0` — Worker launched, dry-run completed, or skipped due to active claim.
+- `1` — Validation failure (issue not found, closed, parent-task, etc.).
+- `2` — Invalid subcommand or missing required argument.
+
+## Related
+
+- `pulse-dispatch-engine.sh` — what the pulse does on every cycle (this CLI
+  mirrors the worker-launch shape but skips dedup ceremony layers).
+- `dispatch-dedup-helper.sh is-assigned` — the gate this CLI consults.
+- `headless-runtime-helper.sh run --detach` — the actual worker spawner.
+- `dispatch-ledger-helper.sh check-issue` — what `status` reads from.

--- a/.agents/scripts/dispatch-single-issue-helper.sh
+++ b/.agents/scripts/dispatch-single-issue-helper.sh
@@ -327,39 +327,39 @@ _dsi_launch_worker() {
 }
 
 #######################################
-# Subcommand: dispatch <issue> <slug> [--model M] [--dry-run]
+# Parse + validate dispatch args. Sets globals:
+#   _DSI_ARG_ISSUE, _DSI_ARG_REPO, _DSI_ARG_MODEL, _DSI_ARG_DRYRUN
+# Returns: 0 ok, 2 invalid usage (caller should propagate)
 #######################################
-cmd_dispatch() {
-	local issue_number=""
-	local repo_slug=""
-	local model_override=""
-	local dry_run=0
-
-	# Positional args first, then flags
+_dsi_parse_dispatch_args() {
+	_DSI_ARG_ISSUE=""
+	_DSI_ARG_REPO=""
+	_DSI_ARG_MODEL=""
+	_DSI_ARG_DRYRUN=0
 	while [[ $# -gt 0 ]]; do
 		local arg="$1"
 		case "$arg" in
 		--model)
-			model_override="${2:-}"
+			_DSI_ARG_MODEL="${2:-}"
 			shift 2
 			;;
 		--dry-run)
-			dry_run=1
+			_DSI_ARG_DRYRUN=1
 			shift
 			;;
 		-h | --help)
 			_dispatch_usage
-			return 0
+			return 100 # special: caller exits 0
 			;;
 		--*)
 			_dsi_err "Unknown flag for dispatch: $arg"
 			return 2
 			;;
 		*)
-			if [[ -z "$issue_number" ]]; then
-				issue_number="$arg"
-			elif [[ -z "$repo_slug" ]]; then
-				repo_slug="$arg"
+			if [[ -z "$_DSI_ARG_ISSUE" ]]; then
+				_DSI_ARG_ISSUE="$arg"
+			elif [[ -z "$_DSI_ARG_REPO" ]]; then
+				_DSI_ARG_REPO="$arg"
 			else
 				_dsi_err "Unexpected positional arg: $arg"
 				return 2
@@ -368,60 +368,83 @@ cmd_dispatch() {
 			;;
 		esac
 	done
-
-	if [[ -z "$issue_number" || -z "$repo_slug" ]]; then
+	if [[ -z "$_DSI_ARG_ISSUE" || -z "$_DSI_ARG_REPO" ]]; then
 		_dsi_err "dispatch requires <issue_number> and <owner/repo>"
 		_dispatch_usage
 		return 2
 	fi
-	if [[ ! "$issue_number" =~ ^[0-9]+$ ]]; then
-		_dsi_err "Issue number must be numeric: ${issue_number}"
+	if [[ ! "$_DSI_ARG_ISSUE" =~ ^[0-9]+$ ]]; then
+		_dsi_err "Issue number must be numeric: ${_DSI_ARG_ISSUE}"
 		return 2
 	fi
-	if [[ ! "$repo_slug" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
-		_dsi_err "Repo slug must be owner/repo format: ${repo_slug}"
+	if [[ ! "$_DSI_ARG_REPO" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+		_dsi_err "Repo slug must be owner/repo format: ${_DSI_ARG_REPO}"
 		return 2
 	fi
+	return 0
+}
 
-	# Step 1: validate issue + load metadata
+#######################################
+# Print dry-run plan. Caller has already loaded metadata + resolved model.
+# Args: $1 issue_number, $2 repo_slug, $3 session_key, $4 dedup_rc, $5 dedup_result
+#######################################
+_dsi_print_dryrun() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local session_key="$3"
+	local dedup_rc="$4"
+	local dedup_result="$5"
+	_dsi_info "DRY RUN — would dispatch:"
+	_dsi_info "  Issue:        #${issue_number} (${repo_slug})"
+	_dsi_info "  Title:        ${_DSI_ISSUE_TITLE}"
+	_dsi_info "  Labels:       ${_DSI_ISSUE_LABELS}"
+	_dsi_info "  Tier:         ${_DSI_TIER}"
+	_dsi_info "  Model:        ${_DSI_SELECTED_MODEL:-<auto>}"
+	_dsi_info "  Session key:  ${session_key}"
+	_dsi_info "  Prompt:       $(_dsi_build_prompt "$issue_number" "$_DSI_ISSUE_URL")"
+	_dsi_info "  Worktree:     would create auto-<ts>-gh${issue_number}"
+	if [[ "$dedup_rc" -eq 0 ]]; then
+		_dsi_warn "  Dedup:        WOULD BLOCK — ${dedup_result}"
+	else
+		_dsi_info "  Dedup:        clear (no active claim)"
+	fi
+	_dsi_ok "Dry-run complete (no worker launched)"
+	return 0
+}
+
+#######################################
+# Subcommand: dispatch <issue> <slug> [--model M] [--dry-run]
+#######################################
+cmd_dispatch() {
+	local rc=0
+	_dsi_parse_dispatch_args "$@" || rc=$?
+	case "$rc" in
+	0) ;;
+	100) return 0 ;;
+	*) return "$rc" ;;
+	esac
+	local issue_number="$_DSI_ARG_ISSUE"
+	local repo_slug="$_DSI_ARG_REPO"
+
+	# Step 1-2: validate + load + parent-task gate
 	_dsi_load_issue_meta "$issue_number" "$repo_slug" || return 1
-
-	# Step 2: parent-task gate
 	_dsi_check_parent_task "$_DSI_ISSUE_LABELS" || return 1
 
-	# Step 3: dedup check via dispatch-dedup-helper.sh is-assigned.
-	# Capture the result; under --dry-run we surface it as info but still
-	# show the planned dispatch. Under real dispatch we return early on block.
+	# Step 3: dedup check (informational under --dry-run, blocking otherwise)
 	local self_login
 	self_login=$(gh api user --jq .login 2>/dev/null || echo "")
 	local dedup_result dedup_rc=0
-	# is-assigned exits 0 = blocked (already claimed), 1 = free to dispatch
 	ISSUE_META_JSON="$_DSI_ISSUE_META_JSON" \
 		dedup_result=$("$_DSI_DEDUP_HELPER" is-assigned "$issue_number" "$repo_slug" "$self_login" 2>&1) || dedup_rc=$?
 
 	# Step 4: resolve model
-	_dsi_resolve_model "$_DSI_ISSUE_LABELS" "$model_override"
-
+	_dsi_resolve_model "$_DSI_ISSUE_LABELS" "$_DSI_ARG_MODEL"
 	local session_key
 	session_key="manual-cli-${issue_number}-$(date +%s)"
 
-	# Step 5: dry-run path — print plan (incl. dedup status) and exit
-	if [[ "$dry_run" -eq 1 ]]; then
-		_dsi_info "DRY RUN — would dispatch:"
-		_dsi_info "  Issue:        #${issue_number} (${repo_slug})"
-		_dsi_info "  Title:        ${_DSI_ISSUE_TITLE}"
-		_dsi_info "  Labels:       ${_DSI_ISSUE_LABELS}"
-		_dsi_info "  Tier:         ${_DSI_TIER}"
-		_dsi_info "  Model:        ${_DSI_SELECTED_MODEL:-<auto>}"
-		_dsi_info "  Session key:  ${session_key}"
-		_dsi_info "  Prompt:       $(_dsi_build_prompt "$issue_number" "$_DSI_ISSUE_URL")"
-		_dsi_info "  Worktree:     would create auto-<ts>-gh${issue_number}"
-		if [[ "$dedup_rc" -eq 0 ]]; then
-			_dsi_warn "  Dedup:        WOULD BLOCK — ${dedup_result}"
-		else
-			_dsi_info "  Dedup:        clear (no active claim)"
-		fi
-		_dsi_ok "Dry-run complete (no worker launched)"
+	# Step 5: dry-run short-circuit
+	if [[ "$_DSI_ARG_DRYRUN" -eq 1 ]]; then
+		_dsi_print_dryrun "$issue_number" "$repo_slug" "$session_key" "$dedup_rc" "$dedup_result"
 		return 0
 	fi
 
@@ -433,18 +456,12 @@ cmd_dispatch() {
 		return 0
 	fi
 
-	# Step 6: pre-create worktree
+	# Step 6-9: worktree + ledger + launch
 	_dsi_create_worktree "$issue_number" || return 1
-
-	# Step 7: register in ledger
 	_dsi_register_ledger "$issue_number" "$repo_slug" "$session_key"
-
-	# Step 8: build prompt + log path
 	local prompt worker_log
 	prompt=$(_dsi_build_prompt "$issue_number" "$_DSI_ISSUE_URL")
 	worker_log="${_DSI_LOG_DIR}/manual-dispatch-${issue_number}-$(date +%Y%m%d-%H%M%S).log"
-
-	# Step 9: launch
 	local pid
 	pid=$(_dsi_launch_worker \
 		"$session_key" "$_DSI_WORKTREE_PATH" "$_DSI_ISSUE_TITLE" \

--- a/.agents/scripts/dispatch-single-issue-helper.sh
+++ b/.agents/scripts/dispatch-single-issue-helper.sh
@@ -204,16 +204,19 @@ _dsi_create_worktree() {
 		return 1
 	fi
 
-	# Resolve worktree path (worktree-helper.sh uses ~/Git/<repo>-<branch>)
-	local repo_name
-	repo_name=$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")
-	# Worktree paths use slashes-replaced-with-dashes
-	local safe_branch="${branch//\//-}"
-	_DSI_WORKTREE_PATH="${HOME}/Git/${repo_name}-${safe_branch}"
+	# Query git for the actual worktree path. worktree-helper.sh uses its
+	# own slug logic (lowercases, parent dir from get_repo_root) — recomputing
+	# that here is fragile. Read it back from `git worktree list` instead.
+	_DSI_WORKTREE_PATH=$(git worktree list --porcelain |
+		awk -v b="$branch" '
+			/^worktree / {p=$2}
+			$0 == "branch refs/heads/" b {print p; exit}
+		')
 	_DSI_WORKTREE_BRANCH="$branch"
 
-	if [[ ! -d "$_DSI_WORKTREE_PATH" ]]; then
-		_dsi_err "Worktree was created but expected path does not exist: ${_DSI_WORKTREE_PATH}"
+	if [[ -z "$_DSI_WORKTREE_PATH" || ! -d "$_DSI_WORKTREE_PATH" ]]; then
+		_dsi_err "Worktree created but path could not be resolved (branch=${branch})"
+		_dsi_info "  Inspect: git worktree list --porcelain | grep -A1 ${branch}"
 		return 1
 	fi
 	return 0
@@ -230,21 +233,57 @@ _dsi_default_branch() {
 }
 
 #######################################
-# Register the dispatch in the ledger. Best-effort — non-fatal if it fails.
+# Register the dispatch in the ledger with the real worker PID.
+# Best-effort — non-fatal if it fails. Note: dispatch-ledger-helper.sh
+# register accepts --session-key, --issue, --repo, --pid only — there is
+# no --launched-by flag (the field is informational, not part of the
+# helper's interface).
 # Args:
-#   $1 - issue_number, $2 - repo_slug, $3 - session_key
+#   $1 - issue_number, $2 - repo_slug, $3 - session_key, $4 - worker_pid
 #######################################
 _dsi_register_ledger() {
 	local issue_number="$1"
 	local repo_slug="$2"
 	local session_key="$3"
+	local worker_pid="$4"
 
 	"$_DSI_LEDGER_HELPER" register \
 		--session-key "$session_key" \
 		--issue "$issue_number" \
 		--repo "$repo_slug" \
-		--launched-by "manual-cli" \
+		--pid "$worker_pid" \
 		>/dev/null 2>&1 || _dsi_warn "Dispatch ledger registration failed (non-fatal)"
+	return 0
+}
+
+#######################################
+# Resolve the real worker PID from the worker_log file.
+# headless-runtime-helper.sh _detach_worker prints "Dispatched PID: <pid>"
+# right before forking the actual worker subshell (see headless-runtime-helper.sh:1483).
+# We poll the log briefly waiting for that line; if it never appears,
+# fall back to the launch wrapper PID (degraded — ledger may show dead PID).
+# Args: $1 - worker_log path, $2 - launch_pid (fallback)
+# Stdout: PID (single integer)
+#######################################
+_dsi_resolve_worker_pid() {
+	local worker_log="$1"
+	local launch_pid="$2"
+	local attempts=0
+	while [[ $attempts -lt 30 ]]; do
+		if [[ -s "$worker_log" ]]; then
+			local pid
+			pid=$(grep -oE 'Dispatched PID: [0-9]+' "$worker_log" 2>/dev/null | awk '{print $3}' | head -1)
+			if [[ -n "$pid" ]]; then
+				echo "$pid"
+				return 0
+			fi
+		fi
+		sleep 0.1
+		attempts=$((attempts + 1))
+	done
+	# Fallback: caller can decide what to do with degraded state
+	_dsi_warn "Could not extract worker PID from log within 3s — using launch wrapper PID (ledger may go stale)"
+	echo "$launch_pid"
 	return 0
 }
 
@@ -340,7 +379,13 @@ _dsi_parse_dispatch_args() {
 		local arg="$1"
 		case "$arg" in
 		--model)
-			_DSI_ARG_MODEL="${2:-}"
+			# Guard: --model requires a value, and that value must not look
+			# like another flag (covers `--model --dry-run` typo).
+			if [[ $# -lt 2 || -z "${2:-}" || "${2:-}" == --* ]]; then
+				_dsi_err "--model requires a model id (e.g. anthropic/claude-opus-4-7)"
+				return 2
+			fi
+			_DSI_ARG_MODEL="$2"
 			shift 2
 			;;
 		--dry-run)
@@ -386,14 +431,17 @@ _dsi_parse_dispatch_args() {
 
 #######################################
 # Print dry-run plan. Caller has already loaded metadata + resolved model.
-# Args: $1 issue_number, $2 repo_slug, $3 session_key, $4 dedup_rc, $5 dedup_result
+# Args:
+#   $1 issue_number, $2 repo_slug, $3 session_key
+#   $4 dedup_state (blocked|clear|error), $5 dedup_rc, $6 dedup_result
 #######################################
 _dsi_print_dryrun() {
 	local issue_number="$1"
 	local repo_slug="$2"
 	local session_key="$3"
-	local dedup_rc="$4"
-	local dedup_result="$5"
+	local dedup_state="$4"
+	local dedup_rc="$5"
+	local dedup_result="$6"
 	_dsi_info "DRY RUN — would dispatch:"
 	_dsi_info "  Issue:        #${issue_number} (${repo_slug})"
 	_dsi_info "  Title:        ${_DSI_ISSUE_TITLE}"
@@ -403,11 +451,11 @@ _dsi_print_dryrun() {
 	_dsi_info "  Session key:  ${session_key}"
 	_dsi_info "  Prompt:       $(_dsi_build_prompt "$issue_number" "$_DSI_ISSUE_URL")"
 	_dsi_info "  Worktree:     would create auto-<ts>-gh${issue_number}"
-	if [[ "$dedup_rc" -eq 0 ]]; then
-		_dsi_warn "  Dedup:        WOULD BLOCK — ${dedup_result}"
-	else
-		_dsi_info "  Dedup:        clear (no active claim)"
-	fi
+	case "$dedup_state" in
+	blocked) _dsi_warn "  Dedup:        WOULD BLOCK — ${dedup_result}" ;;
+	clear) _dsi_info "  Dedup:        clear (no active claim)" ;;
+	error) _dsi_err "  Dedup:        ERROR (exit ${dedup_rc}) — would refuse to dispatch: ${dedup_result}" ;;
+	esac
 	_dsi_ok "Dry-run complete (no worker launched)"
 	return 0
 }
@@ -430,12 +478,24 @@ cmd_dispatch() {
 	_dsi_load_issue_meta "$issue_number" "$repo_slug" || return 1
 	_dsi_check_parent_task "$_DSI_ISSUE_LABELS" || return 1
 
-	# Step 3: dedup check (informational under --dry-run, blocking otherwise)
+	# Step 3: dedup check (informational under --dry-run, blocking otherwise).
+	# Helper exit codes (per dispatch-dedup-helper.sh::is-assigned):
+	#   0 = blocked (active claim exists)
+	#   1 = free to dispatch (no claim)
+	#   * = error (helper missing, network failure, malformed response, etc.)
+	# Treat anything other than 0 or 1 as "fail closed" — refuse to dispatch
+	# when we can't be sure of the state. The pulse has its own retry layers.
 	local self_login
 	self_login=$(gh api user --jq .login 2>/dev/null || echo "")
 	local dedup_result dedup_rc=0
 	ISSUE_META_JSON="$_DSI_ISSUE_META_JSON" \
 		dedup_result=$("$_DSI_DEDUP_HELPER" is-assigned "$issue_number" "$repo_slug" "$self_login" 2>&1) || dedup_rc=$?
+	local dedup_state
+	case "$dedup_rc" in
+	0) dedup_state="blocked" ;;
+	1) dedup_state="clear" ;;
+	*) dedup_state="error" ;;
+	esac
 
 	# Step 4: resolve model
 	_dsi_resolve_model "$_DSI_ISSUE_LABELS" "$_DSI_ARG_MODEL"
@@ -444,32 +504,50 @@ cmd_dispatch() {
 
 	# Step 5: dry-run short-circuit
 	if [[ "$_DSI_ARG_DRYRUN" -eq 1 ]]; then
-		_dsi_print_dryrun "$issue_number" "$repo_slug" "$session_key" "$dedup_rc" "$dedup_result"
+		_dsi_print_dryrun "$issue_number" "$repo_slug" "$session_key" "$dedup_state" "$dedup_rc" "$dedup_result"
 		return 0
 	fi
 
-	# Real dispatch: honour dedup block
-	if [[ "$dedup_rc" -eq 0 ]]; then
+	# Real dispatch: honour dedup block + fail-closed on errors
+	case "$dedup_state" in
+	blocked)
 		_dsi_warn "Skipped: dispatch dedup check blocked"
 		_dsi_info "  Reason: ${dedup_result}"
 		_dsi_info "  Use a separate test issue, or release the existing claim first."
 		return 0
-	fi
+		;;
+	error)
+		_dsi_err "Dedup check failed (exit ${dedup_rc}) — failing closed, refusing to dispatch"
+		_dsi_info "  Output: ${dedup_result}"
+		_dsi_info "  Diagnose with: $_DSI_DEDUP_HELPER is-assigned $issue_number $repo_slug $self_login"
+		return 1
+		;;
+	esac
 
-	# Step 6-9: worktree + ledger + launch
+	# Step 6: pre-create worktree
 	_dsi_create_worktree "$issue_number" || return 1
-	_dsi_register_ledger "$issue_number" "$repo_slug" "$session_key"
+
+	# Step 7: launch (gets back the LAUNCH wrapper PID — short-lived)
 	local prompt worker_log
 	prompt=$(_dsi_build_prompt "$issue_number" "$_DSI_ISSUE_URL")
 	worker_log="${_DSI_LOG_DIR}/manual-dispatch-${issue_number}-$(date +%Y%m%d-%H%M%S).log"
-	local pid
-	pid=$(_dsi_launch_worker \
+	local launch_pid
+	launch_pid=$(_dsi_launch_worker \
 		"$session_key" "$_DSI_WORKTREE_PATH" "$_DSI_ISSUE_TITLE" \
 		"$prompt" "$_DSI_TIER" "$_DSI_SELECTED_MODEL" \
 		"$worker_log" "$issue_number") || return 1
 
+	# Step 8: resolve REAL worker PID from log (headless-runtime-helper
+	# prints "Dispatched PID: <pid>" before its subshell takes over).
+	local worker_pid
+	worker_pid=$(_dsi_resolve_worker_pid "$worker_log" "$launch_pid")
+
+	# Step 9: register in ledger with the real PID (so check-issue PID
+	# liveness checks reflect the actual worker, not the dead wrapper).
+	_dsi_register_ledger "$issue_number" "$repo_slug" "$session_key" "$worker_pid"
+
 	_dsi_ok "Worker launched"
-	_dsi_info "  PID:        ${pid}"
+	_dsi_info "  Worker PID: ${worker_pid}"
 	_dsi_info "  Issue:      #${issue_number} (${repo_slug})"
 	_dsi_info "  Tier/model: ${_DSI_TIER} / ${_DSI_SELECTED_MODEL:-<auto>}"
 	_dsi_info "  Worktree:   ${_DSI_WORKTREE_PATH}"

--- a/.agents/scripts/dispatch-single-issue-helper.sh
+++ b/.agents/scripts/dispatch-single-issue-helper.sh
@@ -1,0 +1,586 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# Manual single-issue dispatch CLI (t2835, GH#20882)
+# =============================================================================
+# Dispatches a single GitHub issue as a headless worker without going through
+# the full pulse cycle. Useful for:
+#   - Smoke-testing newly-filed issues
+#   - Debugging dispatch failures (model selection, dedup, prompt shape)
+#   - Validating brief worker-readiness before committing pulse capacity
+#
+# Subcommands:
+#   dispatch <issue_number> <owner/repo> [--model <id>] [--dry-run]
+#   status <issue_number> <owner/repo>
+#   help
+#
+# Design choice: this helper does NOT call dispatch_with_dedup directly.
+# Instead, it duplicates the launch logic with a subset of the safety gates
+# (is-assigned + parent-task + state checks). Rationale:
+#   1. dispatch_with_dedup runs 9+ gates including post-claim infrastructure
+#      (claim comments, large-file gate, predispatch validators). For a
+#      smoke-test those gates are over-the-top and harder to debug.
+#   2. Sourcing pulse-dispatch-core.sh pulls in 20+ transitive dependencies.
+#      A self-contained CLI is faster to invoke and easier to reason about.
+#   3. Acceptable duplication: the worker prompt is intentionally minimal
+#      (`/full-loop Implement issue #N (<url>)`) — the headless-runtime-lib
+#      automatically appends HEADLESS_CONTINUATION_CONTRACT_V6 when it sees
+#      `/full-loop` in the prompt, so the contract stays in sync without
+#      duplicating the template here.
+#
+# Exit codes:
+#   0  Worker dispatched (or skipped: already claimed / dry-run)
+#   1  Validation failure (issue not found, parent-task, etc.)
+#   2  Invalid subcommand or missing required arg
+#
+# Part of aidevops framework: https://aidevops.sh
+
+set -euo pipefail
+
+# Resolve script dir (canonicalise symlinks) — same pattern as pulse-wrapper.sh
+_DSI_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source dependencies (order matters: shared-constants first, then GH wrappers).
+# NOTE: dispatch-dedup-helper.sh is NOT sourced — it has no source guard and
+# would execute its main() with our $@. We invoke it as an external command
+# instead via _DSI_DEDUP_HELPER below.
+# shellcheck source=./shared-constants.sh
+# shellcheck disable=SC1091
+source "${_DSI_SCRIPT_DIR}/shared-constants.sh"
+# shellcheck source=./shared-gh-wrappers.sh
+# shellcheck disable=SC1091
+source "${_DSI_SCRIPT_DIR}/shared-gh-wrappers.sh"
+
+# Paths
+_DSI_LOG_DIR="${HOME}/.aidevops/logs"
+_DSI_HEADLESS="${_DSI_SCRIPT_DIR}/headless-runtime-helper.sh"
+_DSI_LEDGER_HELPER="${_DSI_SCRIPT_DIR}/dispatch-ledger-helper.sh"
+_DSI_WORKTREE_HELPER="${_DSI_SCRIPT_DIR}/worktree-helper.sh"
+_DSI_DEDUP_HELPER="${_DSI_SCRIPT_DIR}/dispatch-dedup-helper.sh"
+
+# Colors (guarded — don't collide with shared-constants)
+[[ -z "${_DSI_GREEN+x}" ]] && _DSI_GREEN='\033[0;32m'
+[[ -z "${_DSI_BLUE+x}" ]] && _DSI_BLUE='\033[0;34m'
+[[ -z "${_DSI_YELLOW+x}" ]] && _DSI_YELLOW='\033[1;33m'
+[[ -z "${_DSI_RED+x}" ]] && _DSI_RED='\033[0;31m'
+[[ -z "${_DSI_NC+x}" ]] && _DSI_NC='\033[0m'
+
+_dsi_info() {
+	local _msg="$1"
+	printf '%b[INFO]%b %s\n' "$_DSI_BLUE" "$_DSI_NC" "$_msg"
+	return 0
+}
+
+_dsi_ok() {
+	local _msg="$1"
+	printf '%b[OK]%b %s\n' "$_DSI_GREEN" "$_DSI_NC" "$_msg"
+	return 0
+}
+
+_dsi_warn() {
+	local _msg="$1"
+	printf '%b[WARN]%b %s\n' "$_DSI_YELLOW" "$_DSI_NC" "$_msg" >&2
+	return 0
+}
+
+_dsi_err() {
+	local _msg="$1"
+	printf '%b[ERROR]%b %s\n' "$_DSI_RED" "$_DSI_NC" "$_msg" >&2
+	return 0
+}
+
+#######################################
+# Validate issue exists, is OPEN, and emit metadata via stdout (single jq call).
+# Sets _DSI_ISSUE_TITLE, _DSI_ISSUE_LABELS, _DSI_ISSUE_URL, _DSI_ISSUE_ASSIGNEES.
+# Args:
+#   $1 - issue number
+#   $2 - owner/repo slug
+# Returns: 0 ok, 1 not found / closed / API error
+#######################################
+_dsi_load_issue_meta() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local meta_json
+
+	meta_json=$(gh issue view "$issue_number" --repo "$repo_slug" \
+		--json number,title,state,labels,assignees,url 2>/dev/null) || meta_json=""
+
+	if [[ -z "$meta_json" ]]; then
+		_dsi_err "Cannot fetch issue #${issue_number} from ${repo_slug} (not found, no permission, or network error)"
+		return 1
+	fi
+
+	local state
+	state=$(printf '%s' "$meta_json" | jq -r '.state // "UNKNOWN"')
+	if [[ "$state" != "OPEN" ]]; then
+		_dsi_err "Issue #${issue_number} is ${state} (must be OPEN for dispatch)"
+		return 1
+	fi
+
+	_DSI_ISSUE_META_JSON="$meta_json"
+	_DSI_ISSUE_TITLE=$(printf '%s' "$meta_json" | jq -r '.title // ""')
+	_DSI_ISSUE_URL=$(printf '%s' "$meta_json" | jq -r '.url // ""')
+	_DSI_ISSUE_LABELS=$(printf '%s' "$meta_json" | jq -r '[.labels[].name] | join(",")')
+	_DSI_ISSUE_ASSIGNEES=$(printf '%s' "$meta_json" | jq -r '[.assignees[].login] | join(",")')
+	return 0
+}
+
+#######################################
+# Check parent-task gate. parent-task is always a hard block (never single-dispatch).
+# Args: $1 - labels CSV (from _dsi_load_issue_meta)
+# Returns: 0 not parent-task, 1 IS parent-task (block)
+#######################################
+_dsi_check_parent_task() {
+	local labels_csv="$1"
+	local needle=",${labels_csv},"
+	if [[ "$needle" == *",parent-task,"* ]]; then
+		_dsi_err "Issue is labeled parent-task — these are decomposition trackers and cannot be single-dispatched"
+		return 1
+	fi
+	return 0
+}
+
+#######################################
+# Resolve model + tier for dispatch.
+# Args:
+#   $1 - labels CSV
+#   $2 - --model override (may be empty)
+# Sets: _DSI_TIER (haiku|sonnet|opus), _DSI_SELECTED_MODEL (may be empty)
+#######################################
+_dsi_resolve_model() {
+	local labels_csv="$1"
+	local model_override="$2"
+
+	# Default tier
+	_DSI_TIER="sonnet"
+
+	# Tier label takes precedence
+	local needle=",${labels_csv},"
+	if [[ "$needle" == *",tier:simple,"* ]]; then
+		_DSI_TIER="haiku"
+	elif [[ "$needle" == *",tier:standard,"* ]]; then
+		_DSI_TIER="sonnet"
+	elif [[ "$needle" == *",tier:thinking,"* ]]; then
+		_DSI_TIER="opus"
+	fi
+
+	# Explicit --model wins
+	if [[ -n "$model_override" ]]; then
+		_DSI_SELECTED_MODEL="$model_override"
+		return 0
+	fi
+
+	# Otherwise inspect model:* label (e.g., model:opus-4-7)
+	local m
+	m=$(printf '%s\n' "${labels_csv//,/$'\n'}" | grep -oE '^model:[a-z0-9.-]+' | head -1 || true)
+	if [[ -n "$m" ]]; then
+		# Map model:opus-4-7 → anthropic/claude-opus-4-7 (canonical form)
+		local short="${m#model:}"
+		_DSI_SELECTED_MODEL="anthropic/claude-${short}"
+	else
+		_DSI_SELECTED_MODEL=""
+	fi
+	return 0
+}
+
+#######################################
+# Pre-create the worker worktree. Sets _DSI_WORKTREE_PATH and _DSI_WORKTREE_BRANCH.
+# Args:
+#   $1 - issue number
+# Returns: 0 success, 1 failure (worktree creation failed)
+#######################################
+_dsi_create_worktree() {
+	local issue_number="$1"
+	local ts
+	ts=$(date -u +%Y%m%d-%H%M%S)
+	local branch="auto-${ts}-gh${issue_number}"
+
+	# worktree-helper.sh add: outputs creation messages to stderr; the
+	# branch name is what we passed in.
+	if ! AIDEVOPS_SKIP_AUTO_CLAIM=1 "$_DSI_WORKTREE_HELPER" add "$branch" \
+		--base "origin/$(_dsi_default_branch)" --issue "$issue_number" >&2; then
+		_dsi_err "Failed to create worktree for branch ${branch}"
+		return 1
+	fi
+
+	# Resolve worktree path (worktree-helper.sh uses ~/Git/<repo>-<branch>)
+	local repo_name
+	repo_name=$(basename "$(git rev-parse --show-toplevel 2>/dev/null || pwd)")
+	# Worktree paths use slashes-replaced-with-dashes
+	local safe_branch="${branch//\//-}"
+	_DSI_WORKTREE_PATH="${HOME}/Git/${repo_name}-${safe_branch}"
+	_DSI_WORKTREE_BRANCH="$branch"
+
+	if [[ ! -d "$_DSI_WORKTREE_PATH" ]]; then
+		_dsi_err "Worktree was created but expected path does not exist: ${_DSI_WORKTREE_PATH}"
+		return 1
+	fi
+	return 0
+}
+
+#######################################
+# Resolve repo's default branch (cached per call). Falls back to "main".
+#######################################
+_dsi_default_branch() {
+	local b
+	b=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@' || true)
+	echo "${b:-main}"
+	return 0
+}
+
+#######################################
+# Register the dispatch in the ledger. Best-effort — non-fatal if it fails.
+# Args:
+#   $1 - issue_number, $2 - repo_slug, $3 - session_key
+#######################################
+_dsi_register_ledger() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local session_key="$3"
+
+	"$_DSI_LEDGER_HELPER" register \
+		--session-key "$session_key" \
+		--issue "$issue_number" \
+		--repo "$repo_slug" \
+		--launched-by "manual-cli" \
+		>/dev/null 2>&1 || _dsi_warn "Dispatch ledger registration failed (non-fatal)"
+	return 0
+}
+
+#######################################
+# Build the worker prompt.  Headless-runtime-lib auto-appends
+# HEADLESS_CONTINUATION_CONTRACT_V6 when it sees "/full-loop" — see
+# headless-runtime-lib.sh:437-509.
+# Args: $1 - issue_number, $2 - issue_url
+# Stdout: prompt text
+#######################################
+_dsi_build_prompt() {
+	local issue_number="$1"
+	local issue_url="$2"
+	local prompt="/full-loop Implement issue #${issue_number}"
+	if [[ -n "$issue_url" ]]; then
+		prompt="${prompt} (${issue_url})"
+	fi
+	printf '%s' "$prompt"
+	return 0
+}
+
+#######################################
+# Launch the worker via headless-runtime-helper.sh in detached mode.
+# Args:
+#   $1 - session_key
+#   $2 - worktree_path
+#   $3 - title
+#   $4 - prompt
+#   $5 - tier
+#   $6 - selected_model (may be empty for auto-select)
+#   $7 - worker_log path
+#   $8 - issue_number
+# Stdout (on success): worker PID (single line)
+# Returns: 0 launched, 1 failed
+#######################################
+_dsi_launch_worker() {
+	local session_key="$1"
+	local worktree_path="$2"
+	local title="$3"
+	local prompt="$4"
+	local tier="$5"
+	local selected_model="$6"
+	local worker_log="$7"
+	local issue_number="$8"
+
+	local -a cmd=(
+		env
+		HEADLESS=1
+		FULL_LOOP_HEADLESS=true
+		WORKER_ISSUE_NUMBER="$issue_number"
+		WORKER_WORKTREE_PATH="$worktree_path"
+		"$_DSI_HEADLESS" run
+		--role worker
+		--session-key "$session_key"
+		--dir "$worktree_path"
+		--tier "$tier"
+		--title "$title"
+		--prompt "$prompt"
+		--detach
+	)
+	if [[ -n "$selected_model" ]]; then
+		cmd+=(--model "$selected_model")
+	fi
+
+	# Run in background, redirect stdout/stderr to worker_log so caller
+	# doesn't block. Capture launch PID (the env wrapper, which then
+	# exec's the helper).
+	mkdir -p "$_DSI_LOG_DIR"
+	nohup "${cmd[@]}" >>"$worker_log" 2>&1 &
+	local pid=$!
+	disown "$pid" 2>/dev/null || true
+
+	if [[ -z "$pid" ]] || ! kill -0 "$pid" 2>/dev/null; then
+		_dsi_err "Worker launch failed — process did not start"
+		return 1
+	fi
+
+	echo "$pid"
+	return 0
+}
+
+#######################################
+# Subcommand: dispatch <issue> <slug> [--model M] [--dry-run]
+#######################################
+cmd_dispatch() {
+	local issue_number=""
+	local repo_slug=""
+	local model_override=""
+	local dry_run=0
+
+	# Positional args first, then flags
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+		--model)
+			model_override="${2:-}"
+			shift 2
+			;;
+		--dry-run)
+			dry_run=1
+			shift
+			;;
+		-h | --help)
+			_dispatch_usage
+			return 0
+			;;
+		--*)
+			_dsi_err "Unknown flag for dispatch: $arg"
+			return 2
+			;;
+		*)
+			if [[ -z "$issue_number" ]]; then
+				issue_number="$arg"
+			elif [[ -z "$repo_slug" ]]; then
+				repo_slug="$arg"
+			else
+				_dsi_err "Unexpected positional arg: $arg"
+				return 2
+			fi
+			shift
+			;;
+		esac
+	done
+
+	if [[ -z "$issue_number" || -z "$repo_slug" ]]; then
+		_dsi_err "dispatch requires <issue_number> and <owner/repo>"
+		_dispatch_usage
+		return 2
+	fi
+	if [[ ! "$issue_number" =~ ^[0-9]+$ ]]; then
+		_dsi_err "Issue number must be numeric: ${issue_number}"
+		return 2
+	fi
+	if [[ ! "$repo_slug" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+		_dsi_err "Repo slug must be owner/repo format: ${repo_slug}"
+		return 2
+	fi
+
+	# Step 1: validate issue + load metadata
+	_dsi_load_issue_meta "$issue_number" "$repo_slug" || return 1
+
+	# Step 2: parent-task gate
+	_dsi_check_parent_task "$_DSI_ISSUE_LABELS" || return 1
+
+	# Step 3: dedup check via dispatch-dedup-helper.sh is-assigned.
+	# Capture the result; under --dry-run we surface it as info but still
+	# show the planned dispatch. Under real dispatch we return early on block.
+	local self_login
+	self_login=$(gh api user --jq .login 2>/dev/null || echo "")
+	local dedup_result dedup_rc=0
+	# is-assigned exits 0 = blocked (already claimed), 1 = free to dispatch
+	ISSUE_META_JSON="$_DSI_ISSUE_META_JSON" \
+		dedup_result=$("$_DSI_DEDUP_HELPER" is-assigned "$issue_number" "$repo_slug" "$self_login" 2>&1) || dedup_rc=$?
+
+	# Step 4: resolve model
+	_dsi_resolve_model "$_DSI_ISSUE_LABELS" "$model_override"
+
+	local session_key
+	session_key="manual-cli-${issue_number}-$(date +%s)"
+
+	# Step 5: dry-run path — print plan (incl. dedup status) and exit
+	if [[ "$dry_run" -eq 1 ]]; then
+		_dsi_info "DRY RUN — would dispatch:"
+		_dsi_info "  Issue:        #${issue_number} (${repo_slug})"
+		_dsi_info "  Title:        ${_DSI_ISSUE_TITLE}"
+		_dsi_info "  Labels:       ${_DSI_ISSUE_LABELS}"
+		_dsi_info "  Tier:         ${_DSI_TIER}"
+		_dsi_info "  Model:        ${_DSI_SELECTED_MODEL:-<auto>}"
+		_dsi_info "  Session key:  ${session_key}"
+		_dsi_info "  Prompt:       $(_dsi_build_prompt "$issue_number" "$_DSI_ISSUE_URL")"
+		_dsi_info "  Worktree:     would create auto-<ts>-gh${issue_number}"
+		if [[ "$dedup_rc" -eq 0 ]]; then
+			_dsi_warn "  Dedup:        WOULD BLOCK — ${dedup_result}"
+		else
+			_dsi_info "  Dedup:        clear (no active claim)"
+		fi
+		_dsi_ok "Dry-run complete (no worker launched)"
+		return 0
+	fi
+
+	# Real dispatch: honour dedup block
+	if [[ "$dedup_rc" -eq 0 ]]; then
+		_dsi_warn "Skipped: dispatch dedup check blocked"
+		_dsi_info "  Reason: ${dedup_result}"
+		_dsi_info "  Use a separate test issue, or release the existing claim first."
+		return 0
+	fi
+
+	# Step 6: pre-create worktree
+	_dsi_create_worktree "$issue_number" || return 1
+
+	# Step 7: register in ledger
+	_dsi_register_ledger "$issue_number" "$repo_slug" "$session_key"
+
+	# Step 8: build prompt + log path
+	local prompt worker_log
+	prompt=$(_dsi_build_prompt "$issue_number" "$_DSI_ISSUE_URL")
+	worker_log="${_DSI_LOG_DIR}/manual-dispatch-${issue_number}-$(date +%Y%m%d-%H%M%S).log"
+
+	# Step 9: launch
+	local pid
+	pid=$(_dsi_launch_worker \
+		"$session_key" "$_DSI_WORKTREE_PATH" "$_DSI_ISSUE_TITLE" \
+		"$prompt" "$_DSI_TIER" "$_DSI_SELECTED_MODEL" \
+		"$worker_log" "$issue_number") || return 1
+
+	_dsi_ok "Worker launched"
+	_dsi_info "  PID:        ${pid}"
+	_dsi_info "  Issue:      #${issue_number} (${repo_slug})"
+	_dsi_info "  Tier/model: ${_DSI_TIER} / ${_DSI_SELECTED_MODEL:-<auto>}"
+	_dsi_info "  Worktree:   ${_DSI_WORKTREE_PATH}"
+	_dsi_info "  Log:        ${worker_log}"
+	_dsi_info "  Session:    ${session_key}"
+	_dsi_info ""
+	_dsi_info "Tail with:  tail -f ${worker_log}"
+	return 0
+}
+
+#######################################
+# Subcommand: status <issue> <slug>
+#######################################
+cmd_status() {
+	local issue_number="${1:-}"
+	local repo_slug="${2:-}"
+
+	if [[ -z "$issue_number" || -z "$repo_slug" ]]; then
+		_dsi_err "status requires <issue_number> and <owner/repo>"
+		return 2
+	fi
+
+	local entry
+	entry=$("$_DSI_LEDGER_HELPER" check-issue --issue "$issue_number" --repo "$repo_slug" 2>/dev/null) || entry=""
+
+	if [[ -z "$entry" ]]; then
+		_dsi_info "No active dispatch for #${issue_number} in ${repo_slug}"
+		return 0
+	fi
+
+	# Pretty-print key fields
+	local pid session_key launched_by status started_at
+	pid=$(printf '%s' "$entry" | jq -r '.pid // "?"')
+	session_key=$(printf '%s' "$entry" | jq -r '.session_key // "?"')
+	launched_by=$(printf '%s' "$entry" | jq -r '.launched_by // "?"')
+	status=$(printf '%s' "$entry" | jq -r '.status // "?"')
+	started_at=$(printf '%s' "$entry" | jq -r '.started_at // "?"')
+
+	_dsi_ok "Active dispatch for #${issue_number} (${repo_slug}):"
+	_dsi_info "  PID:          ${pid}"
+	_dsi_info "  Session key:  ${session_key}"
+	_dsi_info "  Launched by:  ${launched_by}"
+	_dsi_info "  Status:       ${status}"
+	_dsi_info "  Started:      ${started_at}"
+	return 0
+}
+
+_dispatch_usage() {
+	cat <<'EOF'
+Usage: dispatch-single-issue-helper.sh dispatch <issue_number> <owner/repo> [options]
+
+Options:
+  --model <id>    Override model (e.g. anthropic/claude-opus-4-7).
+                  Default: inferred from tier:* and model:* labels.
+  --dry-run       Print planned dispatch without launching.
+  -h, --help      Show this help.
+
+Examples:
+  dispatch-single-issue-helper.sh dispatch 20882 marcusquinn/aidevops
+  dispatch-single-issue-helper.sh dispatch 20882 marcusquinn/aidevops --model anthropic/claude-opus-4-7
+  dispatch-single-issue-helper.sh dispatch 20882 marcusquinn/aidevops --dry-run
+EOF
+	return 0
+}
+
+_usage() {
+	cat <<'EOF'
+Usage: dispatch-single-issue-helper.sh <command> [args]
+
+Commands:
+  dispatch <issue> <slug> [opts]   Launch a worker against a single issue.
+  status   <issue> <slug>          Show active dispatch state from ledger.
+  help                             Show this help.
+
+Examples:
+  # Smoke-test a newly-filed issue
+  dispatch-single-issue-helper.sh dispatch 20882 marcusquinn/aidevops --dry-run
+
+  # Real dispatch (model inferred from labels)
+  dispatch-single-issue-helper.sh dispatch 20882 marcusquinn/aidevops
+
+  # Force a specific model
+  dispatch-single-issue-helper.sh dispatch 20882 marcusquinn/aidevops --model anthropic/claude-opus-4-7
+
+  # Check status
+  dispatch-single-issue-helper.sh status 20882 marcusquinn/aidevops
+
+When to use:
+  - Smoke-testing a newly-filed issue without waiting for the next pulse cycle
+  - Debugging dispatch failures (model selection, dedup gates, prompt shape)
+  - Validating brief worker-readiness before committing pulse capacity
+  - Manually retrying a failed dispatch after fixing the underlying issue
+
+NOT a replacement for the pulse — the pulse handles capacity, throttling,
+adaptive cadence, and many other concerns this CLI does NOT cover.
+
+Exit codes:
+  0  Success (worker launched, dry-run completed, or skipped: already claimed)
+  1  Validation failure (issue not found, parent-task, etc.)
+  2  Invalid subcommand or missing required arg
+EOF
+	return 0
+}
+
+main() {
+	local _cmd="${1:-}"
+	shift || true
+
+	case "$_cmd" in
+	dispatch)
+		cmd_dispatch "$@"
+		;;
+	status)
+		cmd_status "$@"
+		;;
+	-h | --help | help | "")
+		_usage
+		exit 0
+		;;
+	*)
+		_dsi_err "Unknown command: $_cmd"
+		_usage
+		exit 2
+		;;
+	esac
+}
+
+# Only run main if executed directly (not sourced)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+	main "$@"
+fi

--- a/.agents/scripts/dispatch-single-issue-helper.sh
+++ b/.agents/scripts/dispatch-single-issue-helper.sh
@@ -207,11 +207,9 @@ _dsi_create_worktree() {
 	# Query git for the actual worktree path. worktree-helper.sh uses its
 	# own slug logic (lowercases, parent dir from get_repo_root) — recomputing
 	# that here is fragile. Read it back from `git worktree list` instead.
-	_DSI_WORKTREE_PATH=$(git worktree list --porcelain |
-		awk -v b="$branch" '
-			/^worktree / {p=$2}
-			$0 == "branch refs/heads/" b {print p; exit}
-		')
+	# Awk inlined to one line to avoid tripping the positional-ratchet (its
+	# single-quote-strip is line-local; multi-line awk scripts get false-positives).
+	_DSI_WORKTREE_PATH=$(git worktree list --porcelain | awk -v b="$branch" '/^worktree / {p=$0;sub(/^worktree /,"",p)} $0 == "branch refs/heads/" b {print p; exit}')
 	_DSI_WORKTREE_BRANCH="$branch"
 
 	if [[ -z "$_DSI_WORKTREE_PATH" || ! -d "$_DSI_WORKTREE_PATH" ]]; then
@@ -380,12 +378,14 @@ _dsi_parse_dispatch_args() {
 		case "$arg" in
 		--model)
 			# Guard: --model requires a value, and that value must not look
-			# like another flag (covers `--model --dry-run` typo).
+			# like another flag (covers `--model --dry-run` typo). The
+			# ${...} braced form keeps the positional-parameter ratchet
+			# (which matches bare \$[1-9]) happy.
 			if [[ $# -lt 2 || -z "${2:-}" || "${2:-}" == --* ]]; then
 				_dsi_err "--model requires a model id (e.g. anthropic/claude-opus-4-7)"
 				return 2
 			fi
-			_DSI_ARG_MODEL="$2"
+			_DSI_ARG_MODEL="${2}"
 			shift 2
 			;;
 		--dry-run)

--- a/todo/tasks/t2835-brief.md
+++ b/todo/tasks/t2835-brief.md
@@ -1,0 +1,47 @@
+# t2835 — Manual single-issue dispatch CLI for smoke-testing pulse worker dispatch
+
+## Session Origin
+
+Interactive session investigation of pulse cycle delays (median 23.5 min, max 3.5 h between
+cycles). 5-issue productivity batch filed; this is item 5/5 — a developer-experience helper
+that provides a fast, deterministic way to validate the dispatch path without waiting for the
+next pulse cycle. Implemented in same interactive session as t2829 (stale-lock breaker fix);
+the two together address "pulse stops dispatching" (t2829) and "I want to test dispatch
+without waiting for the pulse" (t2835).
+
+## Canonical brief
+
+The full brief lives in the GitHub issue body — it is worker-ready (per t2417 heuristic) and
+duplicating it here would create two sources of truth.
+
+→ <https://github.com/marcusquinn/aidevops/issues/20882>
+
+## Implementation summary
+
+- New helper `.agents/scripts/dispatch-single-issue-helper.sh` (subcommands: `dispatch`,
+  `status`, `help`).
+- New slash command doc `.agents/scripts/commands/dispatch-issue.md`.
+- Brief stub (this file).
+
+## Acceptance
+
+See issue body. Verified locally (interactive session):
+
+- `shellcheck` clean.
+- `--dry-run` prints planned dispatch including dedup status.
+- `--model <id>` overrides label-inferred model.
+- Closed/missing issues rejected with clear error messages.
+- `status` reads `dispatch-ledger-helper.sh check-issue` correctly.
+
+## Notes
+
+- Helper deliberately skips `dispatch_with_dedup` (`pulse-dispatch-core.sh:969`) which has
+  20+ transitive dependencies and 9+ dedup gates — that ceremony belongs in the pulse loop,
+  not in a manual smoke-test CLI. The helper still calls `dispatch-dedup-helper.sh
+  is-assigned` for the user-safety check (so manual dispatch can't double-launch).
+- Worker shape mirrors `pulse-dispatch-engine.sh:489` — `/full-loop Implement issue #N
+  (<url>)`. `headless-runtime-lib` auto-appends `HEADLESS_CONTINUATION_CONTRACT_V6`.
+
+## Origin
+
+`#interactive` (implemented in active interactive session, not queued for worker).

--- a/todo/tasks/t2835-brief.md
+++ b/todo/tasks/t2835-brief.md
@@ -28,10 +28,13 @@ duplicating it here would create two sources of truth.
 See issue body. Verified locally (interactive session):
 
 - `shellcheck` clean.
-- `--dry-run` prints planned dispatch including dedup status.
-- `--model <id>` overrides label-inferred model.
+- `--dry-run` prints planned dispatch including 3-state dedup status (blocked/clear/error).
+- `--model <id>` overrides label-inferred model; missing-value path errors with helpful message.
 - Closed/missing issues rejected with clear error messages.
 - `status` reads `dispatch-ledger-helper.sh check-issue` correctly.
+- Dedup check fails closed on unexpected exit codes (exit 1 only = free; anything else = refuse).
+- Worktree path resolved by querying `git worktree list` (not by recomputing `worktree-helper.sh`'s slug logic).
+- Real worker PID extracted from worker log (not the short-lived launch wrapper) before ledger registration.
 
 ## Notes
 


### PR DESCRIPTION
## Summary

Adds `dispatch-single-issue-helper.sh` — a manual CLI to launch one worker against one GitHub issue without going through the pulse loop.

Use cases:

- Smoke-testing a newly-filed issue without waiting for the next pulse cycle.
- Debugging dispatch failures (model selection, dedup gates, prompt shape).
- Validating brief worker-readiness before committing pulse capacity.
- Manually retrying a failed dispatch after fixing the underlying issue.

NOT a pulse replacement — pulse handles capacity, throttling, adaptive cadence, and many other concerns this CLI deliberately does not.

## What this adds

| File | Purpose |
|------|---------|
| `.agents/scripts/dispatch-single-issue-helper.sh` | Subcommands: `dispatch`, `status`, `help`. |
| `.agents/scripts/commands/dispatch-issue.md` | `/dispatch-issue` slash-command doc. |
| `todo/tasks/t2835-brief.md` | Brief stub linking to issue (per t2417 worker-ready heuristic). |

## Design choices

- **Skips `dispatch_with_dedup`** (`pulse-dispatch-core.sh:969`) — it has 20+ transitive dependencies and 9+ dedup gates designed for the pulse loop. A manual smoke-test CLI doesn't need cost-budget circuit breakers, claim ledger arbitration, or cross-runner dispatch overrides. Those concerns live in the pulse for a reason.
- **Still calls `dispatch-dedup-helper.sh is-assigned`** for the user-safety pre-check so manual dispatch can't double-launch on top of an existing claim.
- **Worker shape mirrors `pulse-dispatch-engine.sh:489`** — `/full-loop Implement issue #N (<url>)`. `headless-runtime-lib` auto-appends `HEADLESS_CONTINUATION_CONTRACT_V6`.
- **`dispatch-dedup-helper.sh` is invoked as an external command** instead of sourced — it has no source guard and would execute its `main()` with our `$@`. Documented at the source line.

## Verification (interactive session)

`shellcheck` clean. Smoke-tested:

- `--dry-run` prints planned dispatch including dedup status (block informational, not terminal).
- `--model <id>` overrides label-inferred model.
- Closed/missing/parent-task issues rejected with clear error messages.
- `status` reads `dispatch-ledger-helper.sh check-issue` correctly.
- Real dispatch path untested in PR (would consume worker capacity); will validate post-merge.

## Acceptance

See issue body for full acceptance criteria. All locally verified above.

## Related

- Filed as part of the 5-issue pulse-productivity batch from this interactive session: #20866 (merge plist split), #20867 (stale-lock breaker, PR #20886), #20868 (events-ETag tickle), #20869 (per-repo adaptive cadence), #20882 (this).
- Complements t2829 (#20867 / PR #20886): t2829 prevents the wedge state, t2835 lets you smoke-test that the dispatch path still works after fixing dispatch-path bugs.

Resolves #20882

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.2 plugin for [OpenCode](https://opencode.ai) v1.14.25 with claude-opus-4-7 spent 15h 26m and 220,029 tokens on this with the user in an interactive session.