### PR TITLE
t2841: pulse-issue-reconcile: init _b_nums to prevent unbound-variable abort

### DIFF
--- a/.agents/scripts/pulse-issue-reconcile.sh
+++ b/.agents/scripts/pulse-issue-reconcile.sh
@@ -1987,7 +1987,11 @@ _action_cpt_single() {
 	# Source label remains informative: dash-joined list of contributing
 	# sources (e.g. `graph+body`, `body`, `graph+body+prose`) so the log line
 	# in `_try_close_parent_tracker` records which extractors found children.
-	local _g_nums _b_nums _p_nums child_nums
+	# t2841: explicit init — under set -u, _b_nums is referenced at the
+	# union step (line ~2007) regardless of whether children_section is
+	# non-empty. Without init, an issue body with no children-section
+	# triggers `_b_nums: unbound variable` and aborts the function.
+	local _g_nums="" _b_nums="" _p_nums="" child_nums=""
 	local _src_parts=""
 	_g_nums=$(_fetch_subissue_numbers "$slug" "$issue_num" | sort -un | grep -v "^${issue_num}$" | grep -v '^$' || true)
 	[[ -n "$_g_nums" ]] && _src_parts="${_src_parts:+${_src_parts}+}graph"


### PR DESCRIPTION
## Summary

Fix `_b_nums: unbound variable` abort in `pulse-issue-reconcile.sh::_try_close_parent_tracker` that was firing 3-7x per pulse cycle whenever a parent-tracker issue's body lacked an explicit `## Children` section.

## Root cause

Line 1990 declared four union vars without initializing them:

```bash
local _g_nums _b_nums _p_nums child_nums
```

Under `set -u` (the script default), if `_extract_children_section` returned empty (no `## Children` heading in the body), `_b_nums` was never assigned. Line 2007's union step then referenced `"$_b_nums"` directly:

```bash
child_nums=$(printf '%s\n%s\n%s\n' "$_g_nums" "$_b_nums" "$_p_nums" \
    | grep -E '^[0-9]+$' | sort -un | grep -v "^${issue_num}$" || true)
```

→ `unbound variable` → function aborts → parent-tracker auto-close skipped silently.

## Impact

- Parent-tracker issues with prose-only or graph-only children never auto-closed
- Pulse log noise: 3-7 `_b_nums: unbound variable` lines per cycle
- Affected issues stayed open indefinitely, accumulating as bookkeeping debt

## Fix

One-line change: explicit init of all four locals to empty string.

```bash
local _g_nums="" _b_nums="" _p_nums="" child_nums=""
```

`_g_nums` and `_p_nums` were already getting assigned unconditionally (their `_fetch_*` / `_extract_*` calls are always made), so the explicit init is defensive but not strictly required for those. `_b_nums` is the actual fix.

## Verification

- Bash syntax: pass
- Shellcheck: clean
- Replicated logic locally with empty `children_section` — no abort, `child_nums=[]` returned correctly
- Behavior unchanged for issues that DO have a `## Children` section

## Related

- t2842 (full-loop project validators, PR #20898) is in flight; both fix pulse-cycle reliability issues uncovered while triaging the <webapp> PR backlog.

Resolves #20893

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.2 plugin for [OpenCode](https://opencode.ai) v1.14.25 with claude-opus-4-7 spent 17h 37m and 365,925 tokens on this with the user in an interactive session.