### PR TITLE
t2862: TODO.md add t2865 + link blocked-by between t2862 and t2863

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3147,6 +3147,8 @@ t019.3.4,Update AGENTS.md with Beads integration docs,,beads,1h,45m,2025-12-21T1
 
 - [ ] t2864 pre-write function complexity advisory hook #auto-dispatch #framework #quality ref:GH#20921
 
-- [ ] t2863 sweep pulse-*.sh for set -u unbound variable bugs #bug #framework #pulse ref:GH#20920
+- [ ] t2863 sweep pulse-*.sh for set -u unbound variable bugs #bug #framework #interactive #no-auto-dispatch #priority:high #pulse ref:GH#20920
 
-- [ ] t2862 decouple pulse-merge into a fast standalone routine #framework #performance #pulse ref:GH#20919
+- [ ] t2862 decouple pulse-merge into a fast standalone routine #framework #interactive #no-auto-dispatch #performance #priority:high #pulse blocked-by:t2863 ref:GH#20919
+
+- [ ] t2865 pulse canonical-worktree conflict auto-recovery #framework #interactive #no-auto-dispatch #priority:medium #pulse #reliability ref:GH#20922


### PR DESCRIPTION
## Summary

Adds `t2865` (worktree-conflict auto-recovery) to TODO.md and links blocking relationship between `t2862` and `t2863`.

## Background

This session identified 4 systemic improvements while triaging post-t2842 pipeline productivity:

| Task | Issue | Status |
|------|-------|--------|
| t2862 | #20919 — decouple pulse-merge into fast routine | blocked-by t2863 |
| t2863 | #20920 — sweep pulse-*.sh for set-u unbound bugs | filed, ready |
| t2864 | #20921 — pre-write complexity advisory hook | filed, auto-dispatch |
| t2865 | #20922 — pulse canonical-worktree conflict recovery | filed, standalone |

`t2862` depends on `t2863` because decoupling pulse-merge as a standalone routine requires the script to be safe-to-source without the full `pulse-wrapper.sh` context — currently blocked by `STOP_FLAG`, `REPOS_JSON`, `PULSE_MERGE_BATCH_LIMIT` unbound variables (same class as t2841 `_b_nums`).

## Changes

- TODO.md: add t2865 entry, add `blocked-by:t2863` to t2862 entry, add `#priority:high` and origin tags

For #20922
Ref #20919


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.3 plugin for [OpenCode](https://opencode.ai) v1.14.25 with claude-opus-4-7 spent 18h 35m and 429,607 tokens on this with the user in an interactive session.
