### PR TITLE
t2871: pulse-canonical-recovery: switch to local advisory channel (privacy fix)

### DIFF
--- a/.agents/scripts/pulse-canonical-recovery.sh
+++ b/.agents/scripts/pulse-canonical-recovery.sh
@@ -16,8 +16,13 @@
 #
 # Recovery strategy: optionally `git merge --abort` (for unmerged state) →
 # stash → retry pull → pop. Stash-and-pop is content-safe (no `-X theirs`
-# auto-resolve). On persistent failure, file an advisory issue with the exact
-# remediation commands the user can run.
+# auto-resolve). On persistent failure, write a LOCAL advisory file
+# (`~/.aidevops/advisories/canonical-recovery-<basename>.advisory`) with
+# the exact remediation commands the user can run. The local file is
+# surfaced in the session-start greeting via aidevops-update-check.sh —
+# we never file GitHub issues for canonical-recovery failures because
+# the advisory describes user-local state and would leak filesystem paths
+# (username, drive topology) into the public maintainer tracker (t2871).
 #
 # Scope:
 #   - Canonical repo paths only (`~/Git/<repo>/`). Worktrees have separate
@@ -52,13 +57,11 @@ fi
 source "${SCRIPT_DIR}/shared-constants.sh" 2>/dev/null || true
 init_log_file 2>/dev/null || true
 
-# shared-gh-wrappers.sh provides gh_create_issue (auto-injects signature
-# footer + origin label). Source it here so standalone invocations have the
-# wrapper available; pulse-wrapper context already loaded it via its own
-# include chain so this re-source is a no-op via the wrapper's include guard.
-# shellcheck source=shared-gh-wrappers.sh
-# shellcheck disable=SC1091
-source "${SCRIPT_DIR}/shared-gh-wrappers.sh" 2>/dev/null || true
+# shared-gh-wrappers.sh was previously sourced here so `_pcr_file_advisory`
+# could call `gh_create_issue`. Removed in t2871: advisories now write to
+# the local channel (`~/.aidevops/advisories/`) and never touch GitHub.
+# Reintroduce the source line ONLY if a future feature in this module needs
+# a real `gh` call.
 
 # -----------------------------------------------------------------------------
 # Configuration constants
@@ -72,12 +75,23 @@ PULSE_CANONICAL_RECOVERY_MAX_ATTEMPTS="${PULSE_CANONICAL_RECOVERY_MAX_ATTEMPTS:-
 # State file for attempt timestamps. JSON: {"<repo_path>": [ts1, ts2, ...]}.
 PULSE_CANONICAL_RECOVERY_STATE="${PULSE_CANONICAL_RECOVERY_STATE:-${HOME}/.aidevops/.agent-workspace/supervisor/canonical-recovery-state.json}"
 
+# Local advisory directory — surfaced in session greeting via
+# aidevops-update-check.sh::_check_advisories.  This is the canonical channel
+# for user-actionable warnings about local-machine state.  Filing a GitHub
+# issue here would leak `${repo_path}` (username, drive topology, possibly
+# private repo names) into a public maintainer tracker — only the affected
+# user can act on canonical-recovery failures, so cloud filing has zero
+# diagnostic value to maintainers and a non-trivial privacy cost (t2871).
+PULSE_CANONICAL_RECOVERY_ADVISORY_DIR="${PULSE_CANONICAL_RECOVERY_ADVISORY_DIR:-${HOME}/.aidevops/advisories}"
+
 # The audit-log-helper's event-type allowlist is closed. `operation.verify`
 # is the closest fit for "pulse took a verified deterministic action".
 readonly _CANONICAL_RECOVERY_AUDIT_EVENT="operation.verify"
 
-# Canonical advisory issue title prefix — used for idempotency lookup so we
-# don't refile the same advisory cycle after cycle.
+# Advisory headline used in both the local advisory file (line 1, surfaced
+# in session greeting) and the legacy GitHub-issue title-suffix constant.
+# Kept under the legacy name so downstream tooling that searched for filed
+# issues by title can still recognise pre-t2871 issues if any survive.
 readonly _CANONICAL_RECOVERY_ADVISORY_TITLE_SUFFIX="canonical worktree conflict — manual intervention required"
 
 # Dry-run flag — CLI `--dry-run` or env `DRY_RUN=1`. Module-local copy so we
@@ -225,107 +239,187 @@ _pcr_record_attempt() {
 # -----------------------------------------------------------------------------
 # Advisory filing
 # -----------------------------------------------------------------------------
+#
+# Channel design (t2871 — privacy fix):
+#
+# Canonical-recovery failures describe the affected user's local machine state
+# (their worktree, their stash, their merge conflicts). Only the affected user
+# can run the remediation commands; maintainers cannot act on these reports.
+#
+# We therefore write to the LOCAL advisory channel
+# (`~/.aidevops/advisories/*.advisory`) which `aidevops-update-check.sh::
+# _check_advisories` surfaces in the session-start TUI toast. This avoids
+# leaking filesystem paths (username, drive topology, repo names) into the
+# public framework issue tracker.
+#
+# Pre-t2871 behaviour filed GitHub issues against `marcusquinn/aidevops` with
+# `${repo_path}` substituted verbatim — that channel was the wrong design
+# (cloud-filing local advisories) AND a privacy bug. See GH#20934, #20936-
+# 20941 for the leaked issues that motivated this rewrite.
 
-# Compose the advisory issue body. Captures the failure mode and exact
-# remediation commands the user can run.
+# Sanitise an absolute filesystem path for any context that might be
+# transmitted off the user's machine (logs, telemetry, future scanners).
+# Defence-in-depth: the local advisory channel does not transmit, but if a
+# log line gets shipped to OTEL or a future contribution-watch scanner picks
+# up advisory text, the substitution still applies.
+#
+# Substitutions:
+#   $HOME prefix              → ~
+#   /Users/<name>/            → /Users/<user>/
+#   /home/<name>/             → /home/<user>/
+#   /mnt/data/<name>/         → /mnt/data/<user>/   (and similar /mnt/* roots)
+#
+# The original `repo_path` is NEVER stored — we recompute the basename
+# separately so the advisory file name uses only the leaf repo identifier.
+_pcr_sanitise_path() {
+	local raw="$1"
+	[[ -n "$raw" ]] || { printf ''; return 0; }
+
+	# 1. $HOME prefix → ~ (covers macOS /Users/<me> and Linux /home/<me>
+	#    when the user is the current login).
+	if [[ -n "${HOME:-}" && "$raw" == "$HOME"* ]]; then
+		printf '~%s' "${raw#"$HOME"}"
+		return 0
+	fi
+
+	# 2. Other users' home directories — strip the username segment.
+	#    Bash 3.2 compatible: no =~ named captures.
+	case "$raw" in
+		/Users/*/*)
+			# /Users/<name>/<rest> → /Users/<user>/<rest>
+			local rest="${raw#/Users/}"
+			rest="${rest#*/}"
+			printf '/Users/<user>/%s' "$rest"
+			return 0
+			;;
+		/home/*/*)
+			local rest="${raw#/home/}"
+			rest="${rest#*/}"
+			printf '/home/<user>/%s' "$rest"
+			return 0
+			;;
+		/mnt/*/*/*)
+			# /mnt/<volume>/<name>/<rest> — strip the user segment but keep
+			# the volume label since that's not PII (e.g. /mnt/data/<user>/Git).
+			local volume="${raw#/mnt/}"
+			volume="${volume%%/*}"
+			local rest_after_volume="${raw#"/mnt/${volume}/"}"
+			rest_after_volume="${rest_after_volume#*/}"
+			printf '/mnt/%s/<user>/%s' "$volume" "$rest_after_volume"
+			return 0
+			;;
+	esac
+
+	# 3. Fallback — emit the basename only. We never want to emit unknown
+	#    absolute paths verbatim because they may carry usernames or other
+	#    PII that the cases above didn't catch.
+	printf '<repo>/%s' "$(basename "$raw")"
+	return 0
+}
+
+# Compose the advisory body. The body is read by humans in their own
+# terminal (via session greeting) and may also be eyeballed in the
+# advisory file directly. Paths are sanitised — the user can mentally
+# re-substitute their own home directory.
 _pcr_advisory_body() {
 	local repo_path="$1"
 	local failure_mode="$2"
+	local repo_basename
+	repo_basename=$(basename "$repo_path")
+	local sanitised
+	sanitised=$(_pcr_sanitise_path "$repo_path")
 	cat <<EOF
-## Session Origin
+[CANONICAL RECOVERY] ${repo_basename} stash conflict — manual intervention required
 
-Auto-filed by \`pulse-canonical-recovery.sh\` after exhausting auto-recovery
-attempts for canonical repo \`${repo_path}\`. Pulse cannot \`git pull --ff-only\`
-this repo, blocking PR processing, CI failure routing, and completion sweep.
+  Pulse cannot \`git pull --ff-only\` your canonical repo at:
+      ${sanitised}
 
-## What
+  Failure mode: ${failure_mode}
+  Effect:       PR processing, CI failure routing, and completion sweep are
+                paused for this repo until the working tree is clean.
 
-Failure mode: \`${failure_mode}\`. Pulse attempted stash + retry + pop and
-either could not stash, could not pull after stashing, or hit a conflict on
-\`git stash pop\`. The stash (if created) is preserved on the stash list so no
-work is lost.
+  Recovery commands (run in a SEPARATE terminal, not in AI chat):
 
-## Recovery commands
+    cd ${sanitised}
+    git status
+    # If you see UU/AA/DD entries (unmerged):
+    git merge --abort 2>/dev/null || true
 
-\`\`\`bash
-cd ${repo_path}
-git status
-# If you see UU/AA/DD entries (unmerged):
-git merge --abort 2>/dev/null || true
+    # Inspect the auto-stash if one was retained:
+    git stash list | grep pulse-auto-stash
 
-# Inspect the auto-stash if one was retained:
-git stash list | grep pulse-auto-stash
+    # Restore the stash (resolve conflicts if any):
+    git stash pop          # or: git stash drop  (if the stash content is obsolete)
 
-# Restore the stash (resolve conflicts if any):
-git stash pop          # or: git stash drop  (if the stash content is obsolete)
+    # Then refresh:
+    git fetch origin
+    git pull --ff-only
 
-# Then refresh:
-git fetch origin
-git pull --ff-only
-\`\`\`
+  Acceptance:
+  - \`git status\` shows nothing to commit, working tree clean
+  - \`git pull --ff-only\` succeeds without intervention
+  - Pulse resumes processing PRs/issues for this repo on the next cycle
 
-## Why
-
-Pulse repeatedly logging \`error: Pulling is not possible because you have
-unmerged files\` or \`Your local changes ... would be overwritten by merge\`
-silently degrades the affected repo's processing. This advisory surfaces the
-condition with actionable remediation rather than letting it accumulate.
-
-## Acceptance Criteria
-
-- \`git status\` shows nothing to commit, working tree clean
-- \`git pull --ff-only\` succeeds without intervention
-- Pulse resumes processing PRs/issues for this repo on the next cycle
-
-#framework #pulse #reliability #priority:medium #no-auto-dispatch
+  Dismiss after fixing:  aidevops security dismiss canonical-recovery-${repo_basename}
 EOF
+	return 0
 }
 
-# File a framework advisory if one is not already open. Idempotent across
-# pulse cycles via title-substring search. Honours dry-run.
+# File a local advisory. Idempotent — overwriting an existing advisory file
+# is fine because the content is deterministic from (repo_basename,
+# failure_mode) and any concurrent failure for the same repo describes the
+# same condition. Honours dry-run.
+#
+# Advisory file naming: `canonical-recovery-<basename>.advisory`. Surfaced in
+# session greeting by `aidevops-update-check.sh::_check_advisories` (line 1
+# becomes the toast summary). Dismissable via
+# `aidevops security dismiss canonical-recovery-<basename>`.
 _pcr_file_advisory() {
 	local repo_path="$1"
 	local failure_mode="$2"
 	local repo_basename
 	repo_basename=$(basename "$repo_path")
-	local title="${repo_basename} ${_CANONICAL_RECOVERY_ADVISORY_TITLE_SUFFIX}"
 
-	command -v gh >/dev/null 2>&1 || {
-		_pcr_log "gh unavailable — cannot file advisory for $repo_path"
-		return 0
-	}
+	# Sanitise the basename for filesystem safety — strip anything that
+	# isn't [A-Za-z0-9._-]. Practically all repo basenames are safe, but
+	# defensive: a basename containing `/` or shell metacharacters could
+	# escape the advisory directory if we trusted it raw. Bash 3.2 safe.
+	local safe_basename
+	safe_basename=$(printf '%s' "$repo_basename" | tr -c 'A-Za-z0-9._-' '_')
+	[[ -n "$safe_basename" ]] || safe_basename="unknown"
 
-	# Idempotency: scan open issues for matching title in aidevops repo.
-	local existing
-	existing=$(gh issue list --repo marcusquinn/aidevops --state open \
-		--search "in:title \"${repo_basename} ${_CANONICAL_RECOVERY_ADVISORY_TITLE_SUFFIX}\"" \
-		--json number --jq '.[0].number // empty' 2>/dev/null) || existing=""
-	if [[ -n "$existing" ]]; then
-		_pcr_log "advisory already filed: GH#${existing} for $repo_path"
-		return 0
-	fi
+	local advisory_file="${PULSE_CANONICAL_RECOVERY_ADVISORY_DIR}/canonical-recovery-${safe_basename}.advisory"
 
 	if _pcr_is_dry_run; then
-		_pcr_log "[dry-run] would file advisory: ${title}"
+		_pcr_log "[dry-run] would write advisory: ${advisory_file}"
 		return 0
 	fi
 
+	# Ensure the advisory directory exists. mkdir -p is a no-op if present.
+	if ! mkdir -p "$PULSE_CANONICAL_RECOVERY_ADVISORY_DIR" 2>/dev/null; then
+		_pcr_log "could not create advisory dir: $PULSE_CANONICAL_RECOVERY_ADVISORY_DIR"
+		return 0
+	fi
+
+	# Compose body — sanitised paths only; no username/drive-topology leak.
 	local body
 	body=$(_pcr_advisory_body "$repo_path" "$failure_mode")
 
-	# gh_create_issue is provided by shared-gh-wrappers.sh (sourced at top).
-	# It auto-injects the signature footer and origin label; no bare gh
-	# fallback so the gh-wrapper-guard pre-push hook stays happy.
-	if ! declare -F gh_create_issue >/dev/null 2>&1; then
-		_pcr_log "gh_create_issue wrapper unavailable — cannot file advisory for $repo_path"
+	# Atomic write via tmp+rename so a partial write never leaves a torn
+	# advisory file (which would surface garbled in the session greeting).
+	local tmp="${advisory_file}.tmp.$$"
+	if ! printf '%s\n' "$body" >"$tmp" 2>/dev/null; then
+		_pcr_log "could not write advisory tmp file: $tmp"
+		rm -f "$tmp" 2>/dev/null
 		return 0
 	fi
-	gh_create_issue --repo marcusquinn/aidevops \
-		--title "$title" \
-		--body "$body" \
-		--label "framework,pulse,reliability,priority:medium,no-auto-dispatch" \
-		>/dev/null 2>&1 \
-		|| _pcr_log "gh_create_issue failed for $repo_path"
+	if ! mv "$tmp" "$advisory_file" 2>/dev/null; then
+		_pcr_log "could not finalise advisory file: $advisory_file"
+		rm -f "$tmp" 2>/dev/null
+		return 0
+	fi
+
+	_pcr_log "advisory filed locally: ${advisory_file}"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-canonical-recovery.sh
+++ b/.agents/scripts/tests/test-canonical-recovery.sh
@@ -124,6 +124,14 @@ export PATH="${GH_STUB_DIR}:${PATH}"
 # coverage that wasn't real.
 export _PCR_AUDIT_HELPER="${TEST_ROOT}/stubs/audit-log-helper.sh"
 
+# Override the advisory directory to point at the sandbox BEFORE sourcing
+# the helper, so the helper picks up the sandboxed default. (The helper
+# uses parameter expansion `:-` so the env var wins over the in-script
+# default at source time.)
+PULSE_CANONICAL_RECOVERY_ADVISORY_DIR="${TEST_ROOT}/advisories"
+export PULSE_CANONICAL_RECOVERY_ADVISORY_DIR
+mkdir -p "$PULSE_CANONICAL_RECOVERY_ADVISORY_DIR"
+
 # Source the recovery helper. shellcheck disable=SC1091
 # shellcheck source=../pulse-canonical-recovery.sh
 source "${TEST_SCRIPTS_DIR}/pulse-canonical-recovery.sh" || {
@@ -131,20 +139,25 @@ source "${TEST_SCRIPTS_DIR}/pulse-canonical-recovery.sh" || {
 	exit 1
 }
 
-# Sanity-check: gh_create_issue must be defined now that we're sourcing the
-# real shared-gh-wrappers.sh from the real SCRIPT_DIR. If this fails the
-# test is silently exercising the wrapper-unavailable branch and assertions
-# below cannot prove advisory coverage.
-if ! declare -F gh_create_issue >/dev/null 2>&1; then
-	echo "FAIL: gh_create_issue undefined after sourcing helper — test setup broken" >&2
-	exit 1
-fi
-
 # Override state file to point at the sandbox.
 PULSE_CANONICAL_RECOVERY_STATE="${HOME}/.aidevops/.agent-workspace/supervisor/canonical-recovery-state.json"
 export PULSE_CANONICAL_RECOVERY_STATE
 PULSE_CANONICAL_RECOVERY_HOT_WINDOW=3600
 PULSE_CANONICAL_RECOVERY_MAX_ATTEMPTS=3
+
+# Helper for advisory-file assertions. After t2871, advisories are written
+# to a local file rather than filed as GitHub issues. Mirror the production
+# safe-basename derivation in `_pcr_file_advisory` exactly — `printf '%s'`
+# avoids the trailing newline that `basename` would otherwise produce
+# (which `tr -c` would convert to `_`, breaking the filename match).
+advisory_file_for() {
+	local repo_path="$1"
+	local raw safe
+	raw=$(basename "$repo_path")
+	safe=$(printf '%s' "$raw" | tr -c 'A-Za-z0-9._-' '_')
+	printf '%s/canonical-recovery-%s.advisory' "$PULSE_CANONICAL_RECOVERY_ADVISORY_DIR" "$safe"
+	return 0
+}
 
 # -----------------------------------------------------------------------------
 # Helpers: synthetic git fixtures
@@ -196,6 +209,11 @@ reset_call_logs() {
 	: >"$GH_CALL_LOG"
 	: >"$AUDIT_CALL_LOG"
 	rm -f "$PULSE_CANONICAL_RECOVERY_STATE" 2>/dev/null || true
+	# Clear any advisory files from prior tests so per-test assertions are
+	# independent. Bash 3.2-safe glob expansion.
+	if [[ -d "$PULSE_CANONICAL_RECOVERY_ADVISORY_DIR" ]]; then
+		rm -f "$PULSE_CANONICAL_RECOVERY_ADVISORY_DIR"/*.advisory 2>/dev/null || true
+	fi
 	return 0
 }
 
@@ -338,7 +356,7 @@ state=$(_pcr_detect_state "$CANON_DIR")
 	|| print_result "unmerged: working tree clean after merge --abort" 1 "state: $state"
 
 # =============================================================================
-# Test 5: failure path — pull fails after stash → advisory + return 1
+# Test 5: failure path — pull fails after stash → local advisory file + return 1
 # =============================================================================
 
 make_repo_pair "fail-pull"
@@ -361,9 +379,15 @@ else
 	print_result "fail-pull: persistent failure returns 1" 0
 fi
 
-grep -q "issue create" "$GH_CALL_LOG" \
-	&& print_result "fail-pull: gh issue create invoked for advisory" 0 \
-	|| print_result "fail-pull: gh issue create invoked for advisory" 1 "log: $(cat "$GH_CALL_LOG")"
+# Local advisory file MUST be created and MUST NOT trigger any gh call.
+adv_file=$(advisory_file_for "$CANON_DIR")
+[[ -f "$adv_file" ]] \
+	&& print_result "fail-pull: local advisory file created" 0 \
+	|| print_result "fail-pull: local advisory file created" 1 "expected: $adv_file"
+
+[[ ! -s "$GH_CALL_LOG" ]] \
+	&& print_result "fail-pull: NO gh call (privacy: t2871)" 0 \
+	|| print_result "fail-pull: NO gh call (privacy: t2871)" 1 "log: $(cat "$GH_CALL_LOG")"
 
 grep -q "operation.verify" "$AUDIT_CALL_LOG" \
 	&& print_result "fail-pull: audit log records failure entry" 0 \
@@ -389,9 +413,15 @@ else
 	print_result "hot-loop: returns 1 after MAX_ATTEMPTS exhausted" 0
 fi
 
-grep -q "issue create" "$GH_CALL_LOG" \
-	&& print_result "hot-loop: advisory issue create invoked on escalation" 0 \
-	|| print_result "hot-loop: advisory issue create invoked on escalation" 1 "log: $(cat "$GH_CALL_LOG")"
+# Local advisory file is the new escalation channel (t2871).
+adv_file=$(advisory_file_for "$CANON_DIR")
+[[ -f "$adv_file" ]] \
+	&& print_result "hot-loop: local advisory file created on escalation" 0 \
+	|| print_result "hot-loop: local advisory file created on escalation" 1 "expected: $adv_file"
+
+[[ ! -s "$GH_CALL_LOG" ]] \
+	&& print_result "hot-loop: NO gh call (privacy: t2871)" 0 \
+	|| print_result "hot-loop: NO gh call (privacy: t2871)" 1 "log: $(cat "$GH_CALL_LOG")"
 
 # Verify recovery did NOT actually try to stash (escalation short-circuit).
 state=$(_pcr_detect_state "$CANON_DIR")
@@ -429,6 +459,12 @@ stash_count=$(git -C "$CANON_DIR" stash list 2>/dev/null | wc -l | tr -d ' ')
 [[ ! -s "$GH_CALL_LOG" ]] \
 	&& print_result "dry-run: no gh advisory call" 0 \
 	|| print_result "dry-run: no gh advisory call" 1 "log: $(cat "$GH_CALL_LOG")"
+
+# No local advisory file written either.
+adv_file=$(advisory_file_for "$CANON_DIR")
+[[ ! -e "$adv_file" ]] \
+	&& print_result "dry-run: no local advisory file written" 0 \
+	|| print_result "dry-run: no local advisory file written" 1 "found: $adv_file"
 
 _PULSE_CANONICAL_RECOVERY_DRY_RUN=0
 
@@ -487,15 +523,114 @@ else
 	print_result "no-jq: fail-closed returns 1 on first call" 0
 fi
 
-grep -q "issue create" "$GH_CALL_LOG" \
-	&& print_result "no-jq: advisory filed via gh issue create" 0 \
-	|| print_result "no-jq: advisory filed via gh issue create" 1 "log: $(cat "$GH_CALL_LOG")"
+# Local advisory still files even with jq missing — escalation path is
+# unchanged by t2871; only the channel changed.
+adv_file=$(advisory_file_for "$CANON_DIR")
+[[ -f "$adv_file" ]] \
+	&& print_result "no-jq: local advisory file created" 0 \
+	|| print_result "no-jq: local advisory file created" 1 "expected: $adv_file"
+
+[[ ! -s "$GH_CALL_LOG" ]] \
+	&& print_result "no-jq: NO gh call (privacy: t2871)" 0 \
+	|| print_result "no-jq: NO gh call (privacy: t2871)" 1 "log: $(cat "$GH_CALL_LOG")"
 
 # Repo state must be preserved — fail-closed does not stash, pull, or pop.
 state=$(_pcr_detect_state "$CANON_DIR")
 [[ "$state" == "uncommitted" ]] \
 	&& print_result "no-jq: repo state preserved (no stash attempted)" 0 \
 	|| print_result "no-jq: repo state preserved (no stash attempted)" 1 "state: $state"
+
+# =============================================================================
+# Test 10: privacy regression (t2871) — advisory body contains no raw
+# absolute paths that would leak username, drive topology, or repo prefix.
+# =============================================================================
+#
+# This test replaces the no-op repo path with a representative leaky path
+# and asserts the composed advisory body never contains:
+#   - the raw username segment (e.g. /home/dave/, /Users/dave/)
+#   - the drive/mount segment in the form that exposes user identity
+#   - the legacy "Auto-filed by `pulse-canonical-recovery.sh` after exhausting
+#     auto-recovery attempts for canonical repo `<absolute path>`" preamble
+#
+# `_pcr_advisory_body` is sourced from the helper and we call it directly —
+# no need to fully simulate a failure. This is a pure body-composition test.
+
+# Restore the real jq gate (if still overridden from Test 9 — it's a function
+# definition leak, not actually used in this synthetic path, but be tidy).
+unset -f _pcr_jq_required 2>/dev/null || true
+
+# Synthetic "user paths" — these never touch a real filesystem.
+declare -a leak_test_paths=(
+	"/home/dave/Git/request-handler"
+	"/Users/marcusquinn/Git/awardsapp"
+	"/mnt/data/dave/Git/php-src"
+)
+
+for raw_path in "${leak_test_paths[@]}"; do
+	body=$(_pcr_advisory_body "$raw_path" "stash-push-failed")
+
+	# Username segment must not appear verbatim. We test the leaf segment
+	# right after the home/users/mount root.
+	case "$raw_path" in
+		/home/*) leaked_user="/home/dave/" ;;
+		/Users/*) leaked_user="/Users/marcusquinn/" ;;
+		/mnt/*) leaked_user="/mnt/data/dave/" ;;
+		*) leaked_user="" ;;
+	esac
+
+	if [[ -n "$leaked_user" ]]; then
+		if printf '%s' "$body" | grep -qF "$leaked_user"; then
+			print_result "privacy: '${raw_path}' — username segment NOT in advisory body" 1 "leaked: $leaked_user"
+		else
+			print_result "privacy: '${raw_path}' — username segment NOT in advisory body" 0
+		fi
+	fi
+
+	# Sanity: the basename SHOULD appear (it identifies the affected repo
+	# for the user — that's the whole point of the advisory) AND a
+	# sanitised <user> placeholder SHOULD appear.
+	basename=$(basename "$raw_path")
+	printf '%s' "$body" | grep -qF "$basename" \
+		&& print_result "privacy: '${raw_path}' — basename '$basename' present (identifies affected repo)" 0 \
+		|| print_result "privacy: '${raw_path}' — basename '$basename' present (identifies affected repo)" 1
+done
+
+# Direct unit test of _pcr_sanitise_path — exercise each substitution rule.
+# /Users/<name>/<rest>
+got=$(_pcr_sanitise_path "/Users/dave/Git/php-src")
+[[ "$got" == "/Users/<user>/Git/php-src" ]] \
+	&& print_result "sanitise: /Users/<name>/ → /Users/<user>/" 0 \
+	|| print_result "sanitise: /Users/<name>/ → /Users/<user>/" 1 "got: $got"
+
+# /home/<name>/<rest>
+got=$(_pcr_sanitise_path "/home/dave/Git/request-handler")
+[[ "$got" == "/home/<user>/Git/request-handler" ]] \
+	&& print_result "sanitise: /home/<name>/ → /home/<user>/" 0 \
+	|| print_result "sanitise: /home/<name>/ → /home/<user>/" 1 "got: $got"
+
+# /mnt/<volume>/<name>/<rest> — keep volume label, strip user
+got=$(_pcr_sanitise_path "/mnt/data/dave/Git/php-src")
+[[ "$got" == "/mnt/data/<user>/Git/php-src" ]] \
+	&& print_result "sanitise: /mnt/<volume>/<name>/ → /mnt/<volume>/<user>/" 0 \
+	|| print_result "sanitise: /mnt/<volume>/<name>/ → /mnt/<volume>/<user>/" 1 "got: $got"
+
+# $HOME-prefixed → ~ (uses sandbox HOME from this test setup). The helper
+# deliberately emits a literal `~` byte rather than a shell-expandable
+# tilde, so SC2088 is the right warning to silence here — there is no
+# expansion semantics involved, the test asserts the exact byte sequence
+# the helper writes into the advisory file.
+# shellcheck disable=SC2088
+expected_home_subst='~/Git/awardsapp'
+got=$(_pcr_sanitise_path "${HOME}/Git/awardsapp")
+[[ "$got" == "$expected_home_subst" ]] \
+	&& print_result "sanitise: \$HOME/ → ~/" 0 \
+	|| print_result "sanitise: \$HOME/ → ~/" 1 "got: $got"
+
+# Unknown root → fallback to <repo>/<basename>
+got=$(_pcr_sanitise_path "/some/weird/place/myrepo")
+[[ "$got" == "<repo>/myrepo" ]] \
+	&& print_result "sanitise: unknown root → <repo>/basename" 0 \
+	|| print_result "sanitise: unknown root → <repo>/basename" 1 "got: $got"
 
 # =============================================================================
 # Summary


### PR DESCRIPTION
## Summary

Fixes a privacy bug in `pulse-canonical-recovery.sh` (introduced in PR #20928,
t2865): the auto-recovery routine was filing public GitHub issues against
`marcusquinn/aidevops` whenever a user's pulse couldn't recover their
canonical worktree, embedding the user's filesystem path verbatim in the
title and body — leaking username, drive topology, and local repo names into
the public maintainer issue tracker. Affected: GH#20934, #20936-20941 (8
issues across 3 different aidevops users in ~6h).

The advisory describes user-local state (their stash, their merge conflict)
that **only the affected user can resolve** — maintainers cannot act on it,
so cloud filing was the wrong channel design AND a privacy bug.

## What changed

- `_pcr_file_advisory` now writes to the local advisory channel
  (`~/.aidevops/advisories/canonical-recovery-<basename>.advisory`) which
  is surfaced in the session-start TUI toast via
  `aidevops-update-check.sh::_check_advisories` — the same channel used
  for security and SYNC_PAT advisories.
- New `_pcr_sanitise_path` helper as defence-in-depth: maps `$HOME → ~`,
  `/Users/<name>/ → /Users/<user>/`, `/home/<name>/ → /home/<user>/`,
  `/mnt/<vol>/<name>/ → /mnt/<vol>/<user>/`, and falls back to
  `<repo>/<basename>` for unknown roots. Currently used in the local
  advisory body, but available for any future telemetry path so a
  regression that re-introduces cloud transmission won't re-leak.
- Removes the now-unused `shared-gh-wrappers.sh` source line.
- File-header comment block updated to document the new channel and the
  privacy rationale.

## Test changes (27 → 45)

- Three existing advisory tests (Test 5 fail-pull, Test 6 hot-loop,
  Test 9 no-jq) updated: assertions now verify a local advisory file is
  written AND no `gh` call is invoked (privacy regression guard).
- Test 7 dry-run extended: assert no advisory file is written either.
- New Test 10 — privacy regression: composes `_pcr_advisory_body` with
  three representative leaky paths (`/home/dave/...`, `/Users/marcusquinn/...`,
  `/mnt/data/dave/...`) and asserts (a) the username segment never appears
  in the body, (b) the basename does (it identifies the affected repo).
- New unit tests for each `_pcr_sanitise_path` substitution rule.
- Test setup: `PULSE_CANONICAL_RECOVERY_ADVISORY_DIR` exported into the
  sandbox before sourcing the helper, so the test sees its own file
  writes; obsolete `gh_create_issue`-defined sanity-check removed.

## Cleanup actions (separate from this PR)

- All 8 leaked issues will have their bodies redacted and be closed as
  not-planned with a comment pointing at this fix and instructing the
  user to re-run recovery commands in their own terminal.
- Patch release `v3.11.x` will follow this PR so other users' pulses
  pick up the fix on the next `aidevops update` cycle (every ~10 min).

## Verification

```bash
shellcheck .agents/scripts/pulse-canonical-recovery.sh \
  .agents/scripts/tests/test-canonical-recovery.sh
bash .agents/scripts/tests/test-canonical-recovery.sh
# 45 test(s) run, 0 failed.
```

Resolves #20942

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.4 plugin for [OpenCode](https://opencode.ai) v1.14.25 with claude-opus-4-7 spent 17m and 49,818 tokens on this with the user in an interactive session.
