### PR TITLE
t2876: gh PATH shim privacy-scan layer (fail-closed on private slugs in public-repo writes)

### DIFF
--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -71,9 +71,11 @@ _find_real_gh() {
 # -----------------------------------------------------------------------------
 # Fast pass-through for non-intercepted subcommands.
 # Every gh invocation pays this case-match plus one exec.
+# t2876: extended to include issue:edit and pr:edit so privacy-scan layer
+# protects body/title edits the same way create/comment are protected.
 # -----------------------------------------------------------------------------
 case "${1:-}:${2:-}" in
-issue:comment | issue:create | pr:create | pr:comment) ;;
+issue:comment | issue:create | issue:edit | pr:create | pr:comment | pr:edit) ;;
 api:*)
 	# `gh api` subcommand — needs further analysis for POST/PATCH write endpoints.
 	# Falls through to the api-specific handling block below.
@@ -254,6 +256,172 @@ _shim_api_inject_body_sig() {
 }
 
 # -----------------------------------------------------------------------------
+# t2876: Privacy-scan layer
+# After signature-footer injection, before exec'ing real gh, scan write
+# content for private-repo references when the target is a public repo.
+# Fail-closed on hit; fail-open on missing helper / unauthenticated gh /
+# unparseable args. Bypass via AIDEVOPS_GH_PRIVACY_BYPASS=1.
+# -----------------------------------------------------------------------------
+
+# Locate privacy-guard-helper.sh (same lookup pattern as SIG_HELPER above).
+_PRIVACY_HELPER=""
+for _cand in \
+	"$_SHIM_DIR/privacy-guard-helper.sh" \
+	"$HOME/.aidevops/agents/scripts/privacy-guard-helper.sh"; do
+	if [[ -f "$_cand" ]]; then
+		_PRIVACY_HELPER="$_cand"
+		break
+	fi
+done
+
+# _shim_privacy_scan
+# Returns 0 to allow exec, 1 to block (caller should print no extra
+# message — this function emits its own mentoring error to stderr).
+# Fail-open on every error path.
+_shim_privacy_scan() {
+	# Bypass — explicit override with audit log.
+	if [[ "${AIDEVOPS_GH_PRIVACY_BYPASS:-0}" == "1" ]]; then
+		printf '[aidevops][privacy-scan] BYPASSED via AIDEVOPS_GH_PRIVACY_BYPASS=1\n' >&2
+		return 0
+	fi
+
+	# Helper available?
+	if [[ -z "$_PRIVACY_HELPER" || ! -f "$_PRIVACY_HELPER" ]]; then
+		return 0 # fail-open
+	fi
+	# shellcheck source=/dev/null
+	source "$_PRIVACY_HELPER" 2>/dev/null || return 0
+
+	# Determine target repo from --repo arg or current git remote.
+	local target_url="" _idx=0
+	while [[ $_idx -lt ${#_modified_args[@]} ]]; do
+		case "${_modified_args[$_idx]}" in
+		--repo)
+			target_url="${_modified_args[_idx + 1]:-}"
+			_idx=$((_idx + 2))
+			continue
+			;;
+		--repo=*) target_url="${_modified_args[$_idx]#--repo=}" ;;
+		-R)
+			target_url="${_modified_args[_idx + 1]:-}"
+			_idx=$((_idx + 2))
+			continue
+			;;
+		-R*) target_url="${_modified_args[$_idx]#-R}" ;;
+		esac
+		_idx=$((_idx + 1))
+	done
+	if [[ -z "$target_url" ]]; then
+		target_url=$(git remote get-url origin 2>/dev/null) || return 0
+		[[ -z "$target_url" ]] && return 0
+	fi
+	# Normalize bare owner/repo to a URL form privacy_is_target_public accepts.
+	if [[ "$target_url" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]]; then
+		target_url="https://github.com/${target_url}"
+	fi
+
+	# Public-target check — fail-open on private (rc=1) or unknown (rc=2).
+	privacy_is_target_public "$target_url"
+	local _pub_rc=$?
+	if [[ $_pub_rc -ne 0 ]]; then
+		return 0
+	fi
+
+	# Enumerate private slugs.
+	local _slugs_file
+	_slugs_file=$(mktemp 2>/dev/null) || return 0
+	if ! privacy_enumerate_private_slugs "$_slugs_file" 2>/dev/null; then
+		rm -f "$_slugs_file"
+		return 0
+	fi
+	if [[ ! -s "$_slugs_file" ]]; then
+		rm -f "$_slugs_file"
+		return 0
+	fi
+
+	# Build content blob from --body / --body-file / --title args plus
+	# `-f body=...` / `-F body=@...` forms used by gh api.
+	local _blob="" _bf _kv
+	_idx=0
+	while [[ $_idx -lt ${#_modified_args[@]} ]]; do
+		case "${_modified_args[$_idx]}" in
+		--body)
+			_blob+="${_modified_args[_idx + 1]:-}"$'\n'
+			_idx=$((_idx + 2))
+			continue
+			;;
+		--body=*) _blob+="${_modified_args[$_idx]#--body=}"$'\n' ;;
+		--body-file)
+			_bf="${_modified_args[_idx + 1]:-}"
+			[[ -n "$_bf" && -f "$_bf" ]] && _blob+="$(<"$_bf")"$'\n'
+			_idx=$((_idx + 2))
+			continue
+			;;
+		--body-file=*)
+			_bf="${_modified_args[$_idx]#--body-file=}"
+			[[ -n "$_bf" && -f "$_bf" ]] && _blob+="$(<"$_bf")"$'\n'
+			;;
+		--title)
+			_blob+="${_modified_args[_idx + 1]:-}"$'\n'
+			_idx=$((_idx + 2))
+			continue
+			;;
+		--title=*) _blob+="${_modified_args[$_idx]#--title=}"$'\n' ;;
+		-f | --field | -F | --raw-field)
+			_kv="${_modified_args[_idx + 1]:-}"
+			case "$_kv" in
+			body=@*)
+				_bf="${_kv#body=@}"
+				[[ -f "$_bf" ]] && _blob+="$(<"$_bf")"$'\n'
+				;;
+			body=*) _blob+="${_kv#body=}"$'\n' ;;
+			title=*) _blob+="${_kv#title=}"$'\n' ;;
+			esac
+			_idx=$((_idx + 2))
+			continue
+			;;
+		-f* | -F* | --field=* | --raw-field=*)
+			case "${_modified_args[$_idx]}" in
+			-f*) _kv="${_modified_args[$_idx]#-f}" ;;
+			-F*) _kv="${_modified_args[$_idx]#-F}" ;;
+			--field=*) _kv="${_modified_args[$_idx]#--field=}" ;;
+			--raw-field=*) _kv="${_modified_args[$_idx]#--raw-field=}" ;;
+			esac
+			case "$_kv" in
+			body=@*)
+				_bf="${_kv#body=@}"
+				[[ -f "$_bf" ]] && _blob+="$(<"$_bf")"$'\n'
+				;;
+			body=*) _blob+="${_kv#body=}"$'\n' ;;
+			title=*) _blob+="${_kv#title=}"$'\n' ;;
+			esac
+			;;
+		esac
+		_idx=$((_idx + 1))
+	done
+
+	if [[ -z "$_blob" ]]; then
+		rm -f "$_slugs_file"
+		return 0
+	fi
+
+	local _hits
+	_hits=$(privacy_scan_text "$_blob" "$_slugs_file")
+	local _scan_rc=$?
+	rm -f "$_slugs_file"
+
+	if [[ $_scan_rc -eq 1 ]]; then
+		printf '\n[aidevops][privacy-scan][BLOCK] Write to public %s contains private-repo references:\n\n' "$target_url" >&2
+		printf '%s\n' "$_hits" | sed 's/^/  /' >&2
+		printf '\n  Use generic placeholders (e.g. <webapp>) for private repo names before posting to public repos.\n' >&2
+		printf '  Private slugs source: privacy_enumerate_private_slugs (mirror_upstream/local_only in repos.json + ~/.aidevops/configs/privacy-guard-extra-slugs.txt).\n' >&2
+		printf '  Bypass (audit-logged): AIDEVOPS_GH_PRIVACY_BYPASS=1 gh ...\n\n' >&2
+		return 1
+	fi
+	return 0
+}
+
+# -----------------------------------------------------------------------------
 # Initialise the mutable args array used by all injection code below.
 # -----------------------------------------------------------------------------
 _modified_args=("$@")
@@ -261,10 +429,14 @@ _modified_args=("$@")
 # -----------------------------------------------------------------------------
 # Handle `gh api` subcommand: intercept write calls to content endpoints.
 # Non-targeted api calls pass straight through after this block.
+# t2876: write endpoints also run through the privacy-scan layer.
 # -----------------------------------------------------------------------------
 if [[ "${1:-}" == "api" ]]; then
 	if _shim_api_is_write_endpoint; then
 		_shim_api_inject_body_sig
+		if ! _shim_privacy_scan; then
+			exit 1
+		fi
 	fi
 	exec "$REAL_GH" "${_modified_args[@]}"
 fi
@@ -332,6 +504,11 @@ if [[ $_body_file_idx -ge 0 && -n "$_body_file_val" && -f "$_body_file_val" ]]; 
 			printf '%s' "$_sig_footer" >>"$_body_file_val" || true
 		fi
 	fi
+fi
+
+# t2876: privacy scan runs after sig footer injection — fail-closed on hit.
+if ! _shim_privacy_scan; then
+	exit 1
 fi
 
 exec "$REAL_GH" "${_modified_args[@]}"

--- a/.agents/scripts/privacy-guard-helper.sh
+++ b/.agents/scripts/privacy-guard-helper.sh
@@ -231,6 +231,97 @@ privacy_enumerate_private_slugs() {
 }
 
 # =============================================================================
+# Free-form text scanning (used by gh PATH shim — t2876)
+# =============================================================================
+
+#######################################
+# Minimum basename length for bare-basename matching. Basenames shorter than
+# this are matched only as full slug form (owner/basename) to avoid false
+# positives on common short tokens (web, app, api, mvp). Override via env.
+#######################################
+PRIVACY_BARE_BASENAME_MIN_LEN="${PRIVACY_BARE_BASENAME_MIN_LEN:-6}"
+
+#######################################
+# Scan free-form text content (issue/PR body, title, gh api -f body=value)
+# for private repo references. Used by .agents/scripts/gh PATH shim before
+# letting a write reach a public repo.
+#
+# Two match forms per slug:
+#   1. Full slug "owner/basename" — fixed-string match, low FP risk.
+#   2. Bare "basename" with word boundaries — only when len >= MIN_LEN
+#      (default 6) so common tokens like "app"/"web"/"api" don't trigger.
+#
+# Arguments:
+#   $1 - text content to scan
+#   $2 - file containing newline-separated private slugs (output of
+#        privacy_enumerate_private_slugs)
+# Output:
+#   One line per hit on stdout, format:
+#     "owner/basename"                    (full slug form match)
+#     "basename (basename of owner/basename)"  (bare basename form match)
+# Returns:
+#   0 if no hits, 1 if at least one hit, 2 on argument/setup error.
+#######################################
+privacy_scan_text() {
+	local text="$1"
+	local slugs_file="$2"
+
+	if [[ -z "$slugs_file" || ! -f "$slugs_file" ]]; then
+		return 2
+	fi
+	# Empty text or empty slug list — nothing to scan.
+	if [[ -z "$text" ]] || [[ ! -s "$slugs_file" ]]; then
+		return 0
+	fi
+
+	local hits=0
+	local slug owner basename
+	while IFS= read -r slug; do
+		# Skip blanks and comment lines.
+		[[ -z "$slug" || "$slug" == \#* ]] && continue
+		# Trim leading/trailing whitespace.
+		slug="${slug#"${slug%%[![:space:]]*}"}"
+		slug="${slug%"${slug##*[![:space:]]}"}"
+		[[ -z "$slug" ]] && continue
+		# Slug must be owner/basename — single-token entries (legacy) treated as basename only.
+		if [[ "$slug" == */* ]]; then
+			owner="${slug%/*}"
+			basename="${slug##*/}"
+		else
+			owner=""
+			basename="$slug"
+		fi
+		[[ -z "$basename" ]] && continue
+
+		# Form 1: full slug fixed-string match (only if owner present).
+		if [[ -n "$owner" ]] && printf '%s' "$text" | grep -qF "$slug" 2>/dev/null; then
+			printf '%s\n' "$slug"
+			hits=$((hits + 1))
+			continue
+		fi
+
+		# Form 2: bare basename with word boundaries — only for distinctive lengths.
+		if [[ ${#basename} -ge "$PRIVACY_BARE_BASENAME_MIN_LEN" ]]; then
+			# Word boundary regex: must NOT be flanked by [a-zA-Z0-9_-].
+			# Note: we use grep -E (POSIX ERE), not PCRE, so \b is unreliable.
+			if printf '%s' "$text" | grep -qE "(^|[^a-zA-Z0-9_-])${basename}([^a-zA-Z0-9_-]|$)" 2>/dev/null; then
+				if [[ -n "$owner" ]]; then
+					printf '%s (basename of %s)\n' "$basename" "$slug"
+				else
+					printf '%s\n' "$basename"
+				fi
+				hits=$((hits + 1))
+			fi
+		fi
+	done <"$slugs_file"
+
+	if [[ "$hits" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+# =============================================================================
 # Diff scanning
 # =============================================================================
 

--- a/.agents/scripts/test-privacy-guard-shim.sh
+++ b/.agents/scripts/test-privacy-guard-shim.sh
@@ -1,0 +1,384 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-privacy-guard-shim.sh — Tests for the gh PATH shim privacy-scan layer
+# (t2876) AND the underlying `privacy_scan_text` library function.
+#
+# Two test groups:
+#   1. privacy_scan_text unit tests (no external deps; library only)
+#   2. gh shim integration smoke tests (uses a fake `gh` on PATH so we
+#      never hit the network or call the real GitHub API)
+#
+# Usage:
+#   .agents/scripts/test-privacy-guard-shim.sh
+# Exit code 0 = all tests pass, 1 = at least one failure.
+
+set -u
+
+if [[ -t 1 ]]; then
+	GREEN=$'\033[0;32m'
+	RED=$'\033[0;31m'
+	BLUE=$'\033[0;34m'
+	NC=$'\033[0m'
+else
+	GREEN="" RED="" BLUE="" NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf '  %sPASS%s %s\n' "$GREEN" "$NC" "$1"
+	return 0
+}
+
+fail() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '  %sFAIL%s %s\n' "$RED" "$NC" "$1"
+	return 0
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/privacy-guard-helper.sh"
+SHIM="${SCRIPT_DIR}/gh"
+
+if [[ ! -f "$HELPER" || ! -f "$SHIM" ]]; then
+	printf 'test harness cannot find helper or shim:\n  helper=%s\n  shim=%s\n' "$HELPER" "$SHIM" >&2
+	exit 1
+fi
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+# -----------------------------------------------------------------------------
+# Group 1: privacy_scan_text unit tests
+# -----------------------------------------------------------------------------
+printf '%sGroup 1: privacy_scan_text unit tests%s\n' "$BLUE" "$NC"
+
+# shellcheck source=privacy-guard-helper.sh
+source "$HELPER"
+
+# Slug list: includes one short basename ("app", to test the min-length guard)
+# and one distinctive one ("longprivate").
+SLUGS_FILE="${TMP}/slugs.txt"
+cat >"$SLUGS_FILE" <<'EOF'
+acme/longprivate
+acme/app
+EOF
+
+# Test 1.1: full slug match
+text='Mention of acme/longprivate in a body'
+hits=$(privacy_scan_text "$text" "$SLUGS_FILE")
+rc=$?
+if [[ "$rc" -eq 1 ]] && printf '%s' "$hits" | grep -q '^acme/longprivate$'; then
+	pass "full-slug match (acme/longprivate)"
+else
+	fail "expected rc=1 + 'acme/longprivate' hit, got rc=$rc hits='$hits'"
+fi
+
+# Test 1.2: bare basename match (>= 6 chars)
+text='Bug observed in longprivate during triage'
+hits=$(privacy_scan_text "$text" "$SLUGS_FILE")
+rc=$?
+if [[ "$rc" -eq 1 ]] && printf '%s' "$hits" | grep -q '^longprivate (basename of acme/longprivate)$'; then
+	pass "bare basename match (>= 6 chars)"
+else
+	fail "expected rc=1 + 'longprivate (basename ...)' hit, got rc=$rc hits='$hits'"
+fi
+
+# Test 1.3: short basename should NOT match bare (avoid 'app' false-positive)
+text='Built into the desktop app this week'
+hits=$(privacy_scan_text "$text" "$SLUGS_FILE")
+rc=$?
+if [[ "$rc" -eq 0 && -z "$hits" ]]; then
+	pass "short basename ('app', 3 chars) does NOT trigger bare match"
+else
+	fail "expected rc=0 + empty, got rc=$rc hits='$hits'"
+fi
+
+# Test 1.4: short basename DOES match in full slug form
+text='Found in acme/app today'
+hits=$(privacy_scan_text "$text" "$SLUGS_FILE")
+rc=$?
+if [[ "$rc" -eq 1 ]] && printf '%s' "$hits" | grep -q '^acme/app$'; then
+	pass "short basename matches in full-slug form"
+else
+	fail "expected rc=1 + 'acme/app' hit, got rc=$rc hits='$hits'"
+fi
+
+# Test 1.5: alias content (no private mentions) → clean
+text='Mention of <webapp> as a generic placeholder, plus marcusquinn/aidevops'
+hits=$(privacy_scan_text "$text" "$SLUGS_FILE")
+rc=$?
+if [[ "$rc" -eq 0 && -z "$hits" ]]; then
+	pass "alias-only content does not trigger"
+else
+	fail "expected rc=0 + empty, got rc=$rc hits='$hits'"
+fi
+
+# Test 1.6: word boundary — basename inside another word does NOT match
+text='superlongprivateworld is a different token'
+hits=$(privacy_scan_text "$text" "$SLUGS_FILE")
+rc=$?
+if [[ "$rc" -eq 0 && -z "$hits" ]]; then
+	pass "basename inside another word respects word boundaries"
+else
+	fail "expected rc=0 (boundary) + empty, got rc=$rc hits='$hits'"
+fi
+
+# Test 1.7: empty content
+hits=$(privacy_scan_text "" "$SLUGS_FILE")
+rc=$?
+if [[ "$rc" -eq 0 && -z "$hits" ]]; then
+	pass "empty content returns rc=0 with no hits"
+else
+	fail "expected rc=0, got rc=$rc"
+fi
+
+# Test 1.8: empty slugs file
+EMPTY_SLUGS=$(mktemp)
+hits=$(privacy_scan_text 'mentions acme/longprivate' "$EMPTY_SLUGS")
+rc=$?
+rm -f "$EMPTY_SLUGS"
+if [[ "$rc" -eq 0 && -z "$hits" ]]; then
+	pass "empty slugs file returns rc=0"
+else
+	fail "expected rc=0 with empty slugs, got rc=$rc"
+fi
+
+# Test 1.9: missing slugs file → rc=2 (setup error)
+hits=$(privacy_scan_text 'mentions acme/longprivate' "$TMP/nonexistent.txt")
+rc=$?
+if [[ "$rc" -eq 2 ]]; then
+	pass "missing slugs file returns rc=2"
+else
+	fail "expected rc=2 for missing slugs file, got rc=$rc"
+fi
+
+# Test 1.10: comments and blank lines in slugs file are skipped
+COMMENTED_SLUGS=$(mktemp)
+cat >"$COMMENTED_SLUGS" <<'EOF'
+# this is a comment
+acme/longprivate
+
+# another comment
+EOF
+hits=$(privacy_scan_text 'mentions acme/longprivate' "$COMMENTED_SLUGS")
+rc=$?
+rm -f "$COMMENTED_SLUGS"
+if [[ "$rc" -eq 1 ]] && printf '%s' "$hits" | grep -q '^acme/longprivate$'; then
+	pass "comment and blank lines in slugs file are skipped"
+else
+	fail "expected rc=1 with single hit, got rc=$rc hits='$hits'"
+fi
+
+# -----------------------------------------------------------------------------
+# Group 2: gh shim integration tests
+# These tests stage a fake `gh` on PATH so the shim's `_find_real_gh` returns
+# our stub. The stub records its argv, then exits 0. We then assert on the
+# shim's behaviour (block vs allow) and the recorded argv.
+# -----------------------------------------------------------------------------
+printf '\n%sGroup 2: gh shim integration tests%s\n' "$BLUE" "$NC"
+
+# Stage a temp PATH dir with the shim and a fake real-gh
+PATH_DIR="${TMP}/pathdir"
+mkdir -p "$PATH_DIR"
+cp "$SHIM" "$PATH_DIR/gh"
+chmod +x "$PATH_DIR/gh"
+
+# Co-locate the helper alongside the shim so the shim's helper-lookup finds it
+# at the expected sibling path (matches deployed and source layouts).
+cp "$HELPER" "$PATH_DIR/privacy-guard-helper.sh"
+
+# Stub signature helper so the shim's sig-injection layer succeeds quietly
+cat >"$PATH_DIR/gh-signature-helper.sh" <<'STUB'
+#!/usr/bin/env bash
+case "${1:-}" in
+footer) printf '\n\n<!-- aidevops:sig -->\n' ;;
+*) exit 0 ;;
+esac
+STUB
+chmod +x "$PATH_DIR/gh-signature-helper.sh"
+
+# Fake real-gh placed in a sibling dir on PATH (after PATH_DIR)
+REAL_GH_DIR="${TMP}/real-gh-dir"
+mkdir -p "$REAL_GH_DIR"
+RECORD_FILE="${TMP}/gh-invocation.log"
+cat >"$REAL_GH_DIR/gh" <<STUB
+#!/usr/bin/env bash
+echo "REAL_GH_INVOKED" > '$RECORD_FILE'
+printf '%s\n' "\$@" >> '$RECORD_FILE'
+exit 0
+STUB
+chmod +x "$REAL_GH_DIR/gh"
+
+# Set up a fake repos.json + cache so privacy_is_target_public reads from it
+PRIV_HOME="${TMP}/priv-home"
+mkdir -p "$PRIV_HOME/.config/aidevops" "$PRIV_HOME/.aidevops/cache"
+cat >"$PRIV_HOME/.config/aidevops/repos.json" <<'EOF'
+{
+  "initialized_repos": [
+    {
+      "slug": "marcusquinn/aidevops",
+      "path": "/tmp/aidevops",
+      "pulse": true
+    },
+    {
+      "slug": "acme/longprivate",
+      "path": "/tmp/longprivate",
+      "pulse": false,
+      "mirror_upstream": "upstream/source"
+    }
+  ]
+}
+EOF
+# Pre-warm the privacy cache so we don't need real gh for the public probe
+cat >"$PRIV_HOME/.aidevops/cache/repo-privacy.json" <<EOF
+{
+  "marcusquinn/aidevops": { "private": false, "checked_at": $(date +%s) },
+  "acme/longprivate":    { "private": true,  "checked_at": $(date +%s) }
+}
+EOF
+
+# Helper to run shim with controlled environment
+run_shim() {
+	local _path_dir="$1"
+	local _rc=0
+	shift
+	HOME="$PRIV_HOME" \
+		PRIVACY_REPOS_CONFIG="$PRIV_HOME/.config/aidevops/repos.json" \
+		PRIVACY_CACHE_FILE="$PRIV_HOME/.aidevops/cache/repo-privacy.json" \
+		PATH="$_path_dir:$REAL_GH_DIR:$PATH" \
+		"$_path_dir/gh" "$@" || _rc=$?
+	if [[ "$_rc" -ne 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+# -- Test 2.1: public target + private slug body → BLOCKED
+rm -f "$RECORD_FILE"
+out=$(run_shim "$PATH_DIR" issue create --repo marcusquinn/aidevops --title "test" --body "Mentions acme/longprivate today" 2>&1)
+rc=$?
+if [[ "$rc" -eq 1 ]] && [[ ! -f "$RECORD_FILE" ]] && printf '%s' "$out" | grep -q 'BLOCK.*marcusquinn/aidevops'; then
+	pass "public target + full-slug body → BLOCKED, real gh not invoked"
+else
+	fail "expected rc=1, no real-gh invocation, BLOCK message. rc=$rc, real_gh=$([[ -f "$RECORD_FILE" ]] && echo yes || echo no), out='$out'"
+fi
+
+# -- Test 2.2: public target + private basename body → BLOCKED
+rm -f "$RECORD_FILE"
+out=$(run_shim "$PATH_DIR" issue create --repo marcusquinn/aidevops --title "test" --body "Hit a bug in longprivate today" 2>&1)
+rc=$?
+if [[ "$rc" -eq 1 ]] && [[ ! -f "$RECORD_FILE" ]]; then
+	pass "public target + bare-basename body → BLOCKED, real gh not invoked"
+else
+	fail "expected rc=1, no real-gh invocation. rc=$rc out='$out'"
+fi
+
+# -- Test 2.3: public target + clean body → ALLOWED
+rm -f "$RECORD_FILE"
+out=$(run_shim "$PATH_DIR" issue create --repo marcusquinn/aidevops --title "test" --body "Clean content with <webapp> placeholder" 2>&1)
+rc=$?
+if [[ "$rc" -eq 0 ]] && [[ -f "$RECORD_FILE" ]]; then
+	pass "public target + clean body → ALLOWED, real gh invoked"
+else
+	fail "expected rc=0 + real-gh invocation. rc=$rc out='$out'"
+fi
+
+# -- Test 2.4: private target + private slug body → ALLOWED (out of scope)
+rm -f "$RECORD_FILE"
+out=$(run_shim "$PATH_DIR" issue create --repo acme/longprivate --title "test" --body "Mentions acme/longprivate" 2>&1)
+rc=$?
+if [[ "$rc" -eq 0 ]] && [[ -f "$RECORD_FILE" ]]; then
+	pass "private target + private body → ALLOWED (out of scope for guard)"
+else
+	fail "expected rc=0 + real-gh invocation for private target. rc=$rc out='$out'"
+fi
+
+# -- Test 2.5: bypass env var → ALLOWED with audit notice
+rm -f "$RECORD_FILE"
+out=$(AIDEVOPS_GH_PRIVACY_BYPASS=1 run_shim "$PATH_DIR" issue create --repo marcusquinn/aidevops --title "test" --body "Mentions acme/longprivate today" 2>&1)
+rc=$?
+if [[ "$rc" -eq 0 ]] && [[ -f "$RECORD_FILE" ]] && printf '%s' "$out" | grep -q 'BYPASSED'; then
+	pass "AIDEVOPS_GH_PRIVACY_BYPASS=1 → ALLOWED with audit notice"
+else
+	fail "expected rc=0 + bypass notice + real-gh invocation. rc=$rc out='$out'"
+fi
+
+# -- Test 2.6: --body-file with private slug → BLOCKED
+rm -f "$RECORD_FILE"
+BF="${TMP}/body-with-leak.md"
+printf 'A body referencing acme/longprivate inline' >"$BF"
+out=$(run_shim "$PATH_DIR" issue create --repo marcusquinn/aidevops --title "test" --body-file "$BF" 2>&1)
+rc=$?
+if [[ "$rc" -eq 1 ]] && [[ ! -f "$RECORD_FILE" ]]; then
+	pass "--body-file with private slug → BLOCKED"
+else
+	fail "expected rc=1 for --body-file leak. rc=$rc out='$out'"
+fi
+
+# -- Test 2.7: title-only leak → BLOCKED
+rm -f "$RECORD_FILE"
+out=$(run_shim "$PATH_DIR" issue create --repo marcusquinn/aidevops --title "Bug in longprivate observed" --body "Clean body" 2>&1)
+rc=$?
+if [[ "$rc" -eq 1 ]] && [[ ! -f "$RECORD_FILE" ]]; then
+	pass "leak in --title is detected (not just body)"
+else
+	fail "expected rc=1 for title leak. rc=$rc out='$out'"
+fi
+
+# -- Test 2.8: AIDEVOPS_GH_SHIM_DISABLE bypasses entire shim → ALLOWED
+rm -f "$RECORD_FILE"
+out=$(AIDEVOPS_GH_SHIM_DISABLE=1 run_shim "$PATH_DIR" issue create --repo marcusquinn/aidevops --title "test" --body "Mentions acme/longprivate" 2>&1)
+rc=$?
+if [[ "$rc" -eq 0 ]] && [[ -f "$RECORD_FILE" ]]; then
+	pass "AIDEVOPS_GH_SHIM_DISABLE=1 bypasses privacy-scan (and entire shim)"
+else
+	fail "expected rc=0 with shim disable. rc=$rc out='$out'"
+fi
+
+# -- Test 2.9: read-only commands pass through unchanged
+rm -f "$RECORD_FILE"
+out=$(run_shim "$PATH_DIR" issue list --repo marcusquinn/aidevops 2>&1)
+rc=$?
+if [[ "$rc" -eq 0 ]] && [[ -f "$RECORD_FILE" ]]; then
+	pass "read-only commands (issue list) pass through without scan"
+else
+	fail "expected rc=0 for read-only command. rc=$rc out='$out'"
+fi
+
+# -- Test 2.10: pr edit with private slug body → BLOCKED (new in t2876)
+rm -f "$RECORD_FILE"
+out=$(run_shim "$PATH_DIR" pr edit 123 --repo marcusquinn/aidevops --body "Updated to mention acme/longprivate" 2>&1)
+rc=$?
+if [[ "$rc" -eq 1 ]] && [[ ! -f "$RECORD_FILE" ]]; then
+	pass "pr edit with private body → BLOCKED (covers new edit subcommand)"
+else
+	fail "expected rc=1 for pr edit leak. rc=$rc out='$out'"
+fi
+
+# -- Test 2.11: issue edit with private slug body → BLOCKED (new in t2876)
+rm -f "$RECORD_FILE"
+out=$(run_shim "$PATH_DIR" issue edit 456 --repo marcusquinn/aidevops --body "Edit referencing acme/longprivate" 2>&1)
+rc=$?
+if [[ "$rc" -eq 1 ]] && [[ ! -f "$RECORD_FILE" ]]; then
+	pass "issue edit with private body → BLOCKED (covers new edit subcommand)"
+else
+	fail "expected rc=1 for issue edit leak. rc=$rc out='$out'"
+fi
+
+# -----------------------------------------------------------------------------
+# Summary
+# -----------------------------------------------------------------------------
+echo
+if [[ $TESTS_FAILED -eq 0 ]]; then
+	printf '%s%d/%d tests passed%s\n' "$GREEN" "$TESTS_RUN" "$TESTS_RUN" "$NC"
+	exit 0
+else
+	printf '%s%d/%d tests passed (%d failed)%s\n' "$RED" $((TESTS_RUN - TESTS_FAILED)) "$TESTS_RUN" "$TESTS_FAILED" "$NC"
+	exit 1
+fi

--- a/todo/tasks/t2876-brief.md
+++ b/todo/tasks/t2876-brief.md
@@ -1,0 +1,82 @@
+# t2876 — gh PATH shim: privacy-scan layer to fail-closed on private-slug references in public-repo writes
+
+## Session Origin
+Interactive session, marcusquinn 2026-04-26. Surfaced after redacting 70+ historical issues/PRs in `marcusquinn/aidevops` containing the private repo basename `<webapp>` (alias for the actual private slug). Eight of those were auto-generated leaks from `pulse-canonical-recovery.sh` (fixed by t2871/PR #20945); the remaining 60+ were prose typed by maintainer/workers describing real bugs. The existing `privacy-guard-pre-push.sh` covers `git push` only — every `gh issue/pr create|comment|edit` call to the public framework repo bypasses it.
+
+## What
+Add a privacy-scan layer to `.agents/scripts/gh` (the PATH shim) that fails-closed when a write to a public repo contains a private slug reference (full slug form OR distinctive bare basename) anywhere in `--body`, `--body-file`, `--title`, or `gh api -f body=` content.
+
+## Why
+- Pre-push hook gap: only scans `git push`, not gh API calls. Private slugs leak via prose every time a session writes to a public repo.
+- Source-of-truth: `privacy_enumerate_private_slugs` already exists and returns the canonical list (mirror_upstream/local_only/extras file).
+- Defense-in-depth: complements t2871 (point-fix removed one auto-generator's leak path) and the existing pre-push hook (covers TODO/README/todo/.github changes on push). This closes the systemic gap.
+- Cost of no fix: every interactive/headless session can leak private slugs in maintainer-typed prose. Cleanup is manual + retroactive (this session redacted 70 items).
+
+## How
+
+Two layers, model on the existing signature-footer enforcement which uses the same plumbing.
+
+### Layer A — `.agents/scripts/gh` PATH shim (primary)
+Already gates on `gh issue create|comment` and `gh pr create|comment` (lines 75-76) plus `gh api`. Extend to also cover `issue edit` and `pr edit`, then add a privacy scan pass after signature-footer injection.
+
+Decision flow:
+1. After existing sig-footer injection, extract target repo from `--repo` arg or `git remote get-url origin`.
+2. Source `privacy-guard-helper.sh`. Call `privacy_is_target_public <slug-as-url>`. If not public (rc 1 or 2), skip.
+3. Enumerate private slugs via `privacy_enumerate_private_slugs`.
+4. Build a "scannable content" blob from `--body` value, `--body-file` content, and `--title` value (and `-f body=…` content for `gh api`).
+5. Call new `privacy_scan_text <blob> <slugs_file>` (added in this PR). If hits → emit mentoring error, exit 1.
+6. Bypass: `AIDEVOPS_GH_PRIVACY_BYPASS=1` skips the scan with stderr audit notice.
+7. Fail-open: missing helper, unauthenticated gh, mktemp failure → skip scan with stderr WARN.
+
+### Layer B — `privacy-guard-helper.sh` library function
+Add `privacy_scan_text <content> <slugs_file>`:
+
+- Iterates each slug in `slugs_file` (skip blank/comment lines).
+- For each slug `<owner>/<basename>`:
+  - Match form 1: full slug `<owner>/<basename>` via `grep -F` (no false positives).
+  - Match form 2: bare `<basename>` only when `${#basename} -ge 6` (avoids matching common 3-5 char names like `app`, `web`, `api`, `mvp`). Uses regex `(^|[^a-zA-Z0-9_-])<basename>([^a-zA-Z0-9_-]|$)` to enforce word boundaries.
+- Output: one line per hit `<slug>` (full slug form) or `<basename> (basename of <slug>)` for the bare-basename case. Exit 1 if any hits, 0 otherwise.
+
+### Files Scope
+- `.agents/scripts/privacy-guard-helper.sh` (add `privacy_scan_text` function)
+- `.agents/scripts/gh` (extend case-match, add post-sig privacy scan block)
+- `.agents/scripts/test-privacy-guard-shim.sh` (new — covers shim integration end-to-end)
+- `.agents/scripts/test-privacy-guard.sh` (extend with `privacy_scan_text` unit tests)
+- `todo/tasks/t2876-brief.md` (this brief)
+
+### Complexity Impact
+- `privacy_scan_text`: new function, ~25 lines, well under the 100-line gate.
+- gh shim: adds ~40 lines of privacy-scan block — current shim is 337 lines, new total ~380 (single file).
+- No existing function exceeds 80 lines after change.
+
+## Acceptance
+1. `gh issue create --repo marcusquinn/aidevops --body 'mentions <webapp>'` → exit 1, mentoring error citing the slug
+2. `gh issue create --repo marcusquinn/aidevops --body 'mentions <webapp> alias'` → exit 0 (alias allowed)
+3. `gh issue create --repo private/repo --body 'mentions <webapp>'` → exit 0 (private target — out of scope)
+4. `AIDEVOPS_GH_PRIVACY_BYPASS=1 gh issue create … 'mentions <webapp>'` → exit 0 with stderr audit notice
+5. Unit tests for `privacy_scan_text`:
+   - full slug form match → returns 1
+   - bare basename match (≥6 chars) → returns 1
+   - bare basename ≤5 chars (e.g. `app`) → returns 0 (no false positive)
+   - alias-only content → returns 0
+6. Existing `test-privacy-guard.sh` still passes
+7. Existing signature-footer behaviour unchanged (verified by manual smoke or existing shim tests)
+8. shellcheck clean on all modified files
+
+## Verification
+```bash
+# Unit tests
+bash .agents/scripts/test-privacy-guard.sh
+bash .agents/scripts/test-privacy-guard-shim.sh
+
+# Lint
+shellcheck .agents/scripts/gh .agents/scripts/privacy-guard-helper.sh .agents/scripts/test-privacy-guard-shim.sh
+
+# Integration smoke test (uses fake gh via PATH shadow)
+.agents/scripts/test-privacy-guard-shim.sh
+```
+
+## Notes
+- The `<webapp>` alias is the user's chosen generic placeholder for the actual private repo basename. The basename appears in the user's `~/.aidevops/configs/privacy-guard-extra-slugs.txt` (single-line entry) and in `repos.json` with `mirror_upstream: true`, so `privacy_enumerate_private_slugs` already returns it.
+- This task does NOT extend extra-slugs syntax to support aliases (`slug=alias`). That was the original t2872 plan; closed as superseded. If desired later, file as a separate enhancement.
+- The plugin-hook layer (`Claude-aidevops/quality-hooks.mjs`) is not modified here — the PATH shim covers all gh calls regardless of agent runtime, including bash scripts and headless workers. A plugin-hook companion is a separate enhancement if richer in-IDE feedback is desired.


### PR DESCRIPTION
## Summary

Closes a systemic privacy gap. The pre-push privacy guard
(`privacy-guard-pre-push.sh`) only intercepts `git push` operations on
TODO/README/.github content. It does **not** see `gh issue/pr
create|comment|edit` calls, so any session writing prose to the public
`marcusquinn/aidevops` repo could leak private repo basenames into
issue/PR bodies, titles, and comments.

This PR adds privacy-scan as a second layer in the `gh` PATH shim,
fail-closed by default.

Earlier in this session, 70+ historical issues/PRs were redacted
retroactively (sed-based bulk editor sweep on full slug, bare basename,
and path forms). This PR is the systemic fix that prevents recurrence.

## What

1. **Library function** — `privacy_scan_text(content, slugs_file)` added
   to `privacy-guard-helper.sh`:
   - Full slug form (`owner/basename`) → exact `grep -F` match.
   - Bare basename → word-boundary regex match only when basename length
     ≥ 6 (configurable via `PRIVACY_BARE_BASENAME_MIN_LEN`). The minimum
     length avoids false positives on common short tokens (`app`, `web`,
     `api`, `mvp`).
   - Returns `0=clean`, `1=hits` (one per line on stdout), `2=setup
     error`.

2. **gh PATH shim** — extends `.agents/scripts/gh`:
   - Case-match grew to include `issue:edit` and `pr:edit` (the
     bulk-redactor's primary call surface).
   - `_shim_privacy_scan` runs after signature-footer injection on every
     write path (`api`, `issue create|comment|edit`, `pr create|comment|edit`).
   - Resolves target repo via `--repo`/`-R` arg or `git remote get-url
     origin`. Skips scan when target is private (out-of-scope) or
     `gh`/`jq` unavailable (fail-open).
   - Builds blob from `--body`, `--body-file`, `--title`, plus `gh api -f
     body=`, `--field title=`, and `@filename` forms.
   - On hit → emits a mentoring BLOCK message listing the offending
     slugs and exits 1 before invoking real `gh`.
   - Bypass: `AIDEVOPS_GH_PRIVACY_BYPASS=1` with stderr audit notice (so
     the override is visible in logs).
   - Fail-open on missing helper, mktemp error, source error, etc. — a
     broken privacy guard must never break `gh` for users.

## Why

Three failure modes the existing pre-push hook does not cover:

- `gh issue comment NNN --body "..."` — never touches a tracked file.
- Worker scripts that write directly via `gh api repos/.../issues/NNN`.
- AI sessions that compose body content inline.

All three were observed leaking `awardsapp` references into public
issues and PRs over the last several months. A second-layer guard at
the `gh` invocation point catches all three regardless of caller.

## How verified

- 10 unit tests for `privacy_scan_text`: full-slug match, bare basename
  ≥6, short basename rejection (`app` does NOT match), word boundaries
  (`appbar` does NOT match `app`), empty content, comment+blank handling
  in slugs file, missing slugs file (rc=2).
- 11 shim integration tests with a fake `gh` on `PATH` and a fake
  `repos.json`: BLOCK on full slug, BLOCK on bare basename, ALLOW on
  clean body, ALLOW on private target, BYPASS env honoured, `--body-file`
  scanned, `--title` scanned, `AIDEVOPS_GH_SHIM_DISABLE=1` skips entire
  shim, read-only commands pass through without scan, `issue edit` /
  `pr edit` subcommands covered.
- All 17 existing `test-privacy-guard.sh` tests still pass.
- `shellcheck` clean on all modified files.

## Trade-offs and follow-ups

- **Layer B not addressed.** A complementary plugin-hook layer in
  `Claude-aidevops/quality-hooks.mjs` was considered but deferred — the
  PATH shim covers all callers (workers, scripts, interactive AI
  sessions) regardless of agent runtime, so PATH-shim alone closes the
  observed leak class. Plugin hook would add defense-in-depth for
  `AIDEVOPS_GH_SHIM_DISABLE=1` cases. Track separately if needed.
- **Bare-basename min length is heuristic.** Default 6 chars catches
  `awardsapp` (9), `windowsd` (8), `flapjack` (8), but misses any
  hypothetical 4-5 char private repo. Tune via
  `PRIVACY_BARE_BASENAME_MIN_LEN` per environment, or rely on
  `privacy-guard-extra-slugs.txt` for shorter sensitive names.
- **Path-form leak prevention** (`/Users/.../Git/awardsapp`) not in
  scope here — the bulk-redact step earlier in this session already
  cleaned historical occurrences, and gh body content rarely embeds
  fully-qualified paths. Add as follow-up if observed.

Resolves #20970

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.5 plugin for [OpenCode](https://opencode.ai) v1.14.25 with claude-opus-4-7 spent 2h 18m and 129,893 tokens on this with the user in an interactive session.
