### PR TITLE
t2885: exclude worktrees from macOS Spotlight + Time Machine

### DIFF
--- a/.agents/scripts/setup/_worktree_exclusions.sh
+++ b/.agents/scripts/setup/_worktree_exclusions.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Setup module: worktree exclusions (t2885).
+#
+# Worktrees are ephemeral working copies — persistent state lives on the git
+# remote. Backing them up duplicates work the remote already does, and
+# indexing them inflates fseventsd/mds load when workers cp node_modules.
+# This module:
+#
+#   1. Runs `worktree-exclusions-helper.sh backfill` to apply Spotlight +
+#      Time Machine exclusions to every existing worktree across registered
+#      repos. Idempotent — fast no-op when already applied.
+#   2. If Backblaze is detected, posts a one-time advisory pointing to the
+#      `setup-backblaze` subcommand for the manual sudo step (root-owned
+#      config — never auto-applied from setup).
+#
+# Sourced by setup.sh — do not execute directly.
+#
+# Opt out:  AIDEVOPS_WORKTREE_EXCLUSIONS_INSTALL=false
+# Skip backfill (apply only new worktrees via the helper hook):
+#           AIDEVOPS_WORKTREE_EXCLUSIONS_BACKFILL=false
+
+setup_worktree_exclusions() {
+	local label="Worktree exclusions"
+	if [[ "${AIDEVOPS_WORKTREE_EXCLUSIONS_INSTALL:-true}" == "false" ]]; then
+		print_info "$label disabled via AIDEVOPS_WORKTREE_EXCLUSIONS_INSTALL=false"
+		setup_track_skipped "$label" "opted out via env var"
+		return 0
+	fi
+
+	# Linux + others: helper short-circuits, just record the skip.
+	if [[ "$(uname -s)" != "Darwin" ]]; then
+		setup_track_skipped "$label" "non-macOS — see GH#<linux-followup>"
+		return 0
+	fi
+
+	# Locate the helper. Prefer in-repo (we're inside setup.sh, so the repo
+	# copy is canonical here); fall back to deployed copy if running from a
+	# bootstrap-light context.
+	local helper=""
+	local script_dir
+	script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || return 0
+	if [[ -x "$script_dir/../worktree-exclusions-helper.sh" ]]; then
+		helper="$script_dir/../worktree-exclusions-helper.sh"
+	elif [[ -x "${HOME}/.aidevops/agents/scripts/worktree-exclusions-helper.sh" ]]; then
+		helper="${HOME}/.aidevops/agents/scripts/worktree-exclusions-helper.sh"
+	fi
+
+	if [[ -z "$helper" ]]; then
+		print_warning "worktree-exclusions-helper.sh not found — skipping"
+		setup_track_skipped "$label" "helper not found"
+		return 0
+	fi
+
+	# Backfill existing worktrees unless explicitly skipped. Backgrounded:
+	# `tmutil addexclusion` takes ~11s per directory on cold start, which
+	# would block `aidevops update` (every ~10 min) for several minutes on
+	# machines with many worktrees. Once exclusions land, subsequent runs
+	# short-circuit at ~0.13s/worktree via the `isexcluded` check.
+	if [[ "${AIDEVOPS_WORKTREE_EXCLUSIONS_BACKFILL:-true}" != "false" ]]; then
+		local log_dir="${HOME}/.aidevops/logs"
+		mkdir -p "$log_dir" 2>/dev/null || true
+		local log_file="${log_dir}/worktree-exclusions-backfill.log"
+		print_info "Applying worktree exclusions in background → $log_file"
+		nohup "$helper" backfill >>"$log_file" 2>&1 </dev/null &
+		disown 2>/dev/null || true
+	fi
+
+	# One-time Backblaze advisory (cheap, foreground).
+	_setup_worktree_exclusions_backblaze_advisory "$helper"
+
+	setup_track_configured "$label"
+	return 0
+}
+
+#######################################
+# Post a one-time advisory if Backblaze is detected and the user has not yet
+# dismissed it. Advisory file is written under ~/.aidevops/advisories/ per the
+# existing pattern documented in prompts/build.txt "Security".
+#######################################
+_setup_worktree_exclusions_backblaze_advisory() {
+	local helper="$1"
+	# Detect first — cheap, prints to stdout. We only care about exit + lines.
+	local detect_out=""
+	detect_out=$("$helper" detect 2>&1 || true)
+	if ! grep -q 'Backblaze: detected' <<<"$detect_out"; then
+		return 0
+	fi
+
+	local advisory_dir="${HOME}/.aidevops/advisories"
+	local advisory_file="${advisory_dir}/worktree-exclusions-backblaze.advisory"
+	mkdir -p "$advisory_dir" 2>/dev/null || return 0
+
+	# Already posted and not dismissed? Touch the timestamp and return.
+	if [[ -f "$advisory_file" ]]; then
+		return 0
+	fi
+
+	# Write the advisory body.
+	cat >"$advisory_file" <<'EOF'
+[advisory:worktree-exclusions-backblaze]
+title: Backblaze worktree exclusion needs a one-time sudo step
+severity: info
+action: run `worktree-exclusions-helper.sh setup-backblaze` to print the
+        sudo + GUI steps that exclude ~/Git/<repo>-{feature,bugfix,...}-*
+        worktree paths from your Backblaze backup. Worktrees are ephemeral
+        and the canonical repo + git remote already provide the backup.
+dismiss: aidevops security dismiss worktree-exclusions-backblaze
+EOF
+	print_info "Backblaze detected — wrote advisory to $advisory_file"
+	print_info "Run 'worktree-exclusions-helper.sh setup-backblaze' for the manual step"
+	return 0
+}

--- a/.agents/scripts/worktree-exclusions-helper.sh
+++ b/.agents/scripts/worktree-exclusions-helper.sh
@@ -1,0 +1,387 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# worktree-exclusions-helper.sh (t2885)
+# Exclude git worktrees from macOS Spotlight, Time Machine, and Backblaze.
+#
+# Background: every worker dispatch deep-copies node_modules into a fresh
+# worktree (see worktree-helper.sh::_restore_worktree_node_modules). With many
+# concurrent worktrees, fseventsd / mds / bztransmit cascade and saturate the
+# CPU. Worktrees are ephemeral by design — the persistent state lives on the
+# git remote — so opting them out of OS indexers and backup tools is correct
+# default behaviour, not just a perf hack.
+#
+# Subcommands:
+#   apply <worktree-path>   - exclude one worktree (Spotlight + Time Machine).
+#                             Idempotent. Always exits 0 (best-effort).
+#   backfill [--dry-run]    - apply to every worktree in every repo registered
+#                             in ~/.config/aidevops/repos.json.
+#   detect                  - report which tools are installed and which are
+#                             scriptable vs require a manual setup step.
+#   setup-backblaze         - print the sudo commands needed to add a Backblaze
+#                             exclusion rule covering ~/Git/<repo>-* worktree
+#                             prefixes (root-only config file).
+#   help                    - print usage.
+#
+# Linux: subcommands print "not implemented" and exit 0. See GH#<linux-followup>.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+# shellcheck source=shared-constants.sh disable=SC1091
+[[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
+
+# Color/log fallbacks if shared-constants.sh is unavailable (defensive).
+[[ -z "${RED+x}" ]] && RED=''
+[[ -z "${GREEN+x}" ]] && GREEN=''
+[[ -z "${YELLOW+x}" ]] && YELLOW=''
+[[ -z "${BLUE+x}" ]] && BLUE=''
+[[ -z "${NC+x}" ]] && NC=''
+
+REPOS_JSON="${AIDEVOPS_REPOS_JSON:-${HOME}/.config/aidevops/repos.json}"
+BACKBLAZE_RULES_FILE="/Library/Backblaze.bzpkg/bzdata/bzexcluderules_editable.xml"
+
+###############################################################################
+# Logging — fall back to printf if shared-constants.sh helpers are absent.
+###############################################################################
+_we_info() {
+	local msg="$1"
+	if declare -F print_info >/dev/null 2>&1; then
+		print_info "$msg"
+	else
+		printf '%s[INFO]%s %s\n' "$BLUE" "$NC" "$msg"
+	fi
+	return 0
+}
+
+_we_ok() {
+	local msg="$1"
+	if declare -F print_success >/dev/null 2>&1; then
+		print_success "$msg"
+	else
+		printf '%s[OK]%s %s\n' "$GREEN" "$NC" "$msg"
+	fi
+	return 0
+}
+
+_we_warn() {
+	local msg="$1"
+	if declare -F print_warning >/dev/null 2>&1; then
+		print_warning "$msg"
+	else
+		printf '%s[WARN]%s %s\n' "$YELLOW" "$NC" "$msg"
+	fi
+	return 0
+}
+
+_we_err() {
+	local msg="$1"
+	if declare -F print_error >/dev/null 2>&1; then
+		print_error "$msg"
+	else
+		printf '%s[ERROR]%s %s\n' "$RED" "$NC" "$msg" >&2
+	fi
+	return 0
+}
+
+###############################################################################
+# Platform detection.
+###############################################################################
+_we_is_macos() {
+	[[ "$(uname -s)" == "Darwin" ]]
+}
+
+_we_has_tmutil() {
+	command -v tmutil >/dev/null 2>&1
+}
+
+_we_has_backblaze() {
+	[[ -d /Library/Backblaze.bzpkg ]] || [[ -d /Applications/Backblaze.app ]]
+}
+
+###############################################################################
+# Apply Spotlight exclusion (touch .metadata_never_index inside the worktree).
+# Idempotent. Returns 0 even if it could not write — best-effort.
+###############################################################################
+_we_apply_spotlight() {
+	local wt_path="$1"
+	[[ -d "$wt_path" ]] || return 0
+	local marker="${wt_path}/.metadata_never_index"
+	if [[ -e "$marker" ]]; then
+		return 0
+	fi
+	# Touch the marker. Failure is non-fatal — worktree creation must not be
+	# blocked by exclusion failure.
+	touch "$marker" 2>/dev/null || true
+	return 0
+}
+
+###############################################################################
+# Apply Time Machine exclusion via tmutil. Idempotent — checks isexcluded first.
+#
+# Uses `tmutil addexclusion` without `-p`: the unflagged form sets a per-path
+# xattr (com.apple.metadata:com_apple_backup_excludeItem) that any user can
+# write. The `-p` (sticky path) form requires root and isn't necessary for
+# worktrees — we want xattr-based "this directory" exclusion, which travels
+# with the path naturally. Failure is non-fatal — worktree creation must not
+# be blocked by exclusion failure.
+###############################################################################
+_we_apply_timemachine() {
+	local wt_path="$1"
+	[[ -d "$wt_path" ]] || return 0
+	_we_has_tmutil || return 0
+	# tmutil isexcluded prints "[Excluded]" or "[Included]" prefix.
+	local already=""
+	already=$(tmutil isexcluded "$wt_path" 2>/dev/null || true)
+	if [[ "$already" == *"[Excluded]"* ]]; then
+		return 0
+	fi
+	tmutil addexclusion "$wt_path" >/dev/null 2>&1 || true
+	return 0
+}
+
+###############################################################################
+# cmd_apply <worktree-path>
+# Apply all in-scope exclusions to a single worktree path. Always exits 0.
+###############################################################################
+cmd_apply() {
+	local wt_path="${1:-}"
+	if [[ -z "$wt_path" ]]; then
+		_we_err "apply: worktree path required"
+		return 1
+	fi
+	if [[ ! -d "$wt_path" ]]; then
+		# Path may have been removed in a race — silent.
+		return 0
+	fi
+
+	if ! _we_is_macos; then
+		# Linux indexers (tracker, baloo) tracked separately. Silent skip.
+		return 0
+	fi
+
+	_we_apply_spotlight "$wt_path"
+	_we_apply_timemachine "$wt_path"
+	# Backblaze is glob-based and root-only — applied via setup-backblaze, not
+	# per-worktree.
+	return 0
+}
+
+###############################################################################
+# Enumerate worktree paths across all registered repos.
+# Prints one absolute path per line on stdout. Skips the canonical repo dirs
+# (only worktrees attached to them).
+###############################################################################
+_we_enumerate_worktrees() {
+	[[ -f "$REPOS_JSON" ]] || return 0
+	command -v jq >/dev/null 2>&1 || return 0
+
+	local repo_path=""
+	while IFS= read -r repo_path; do
+		[[ -n "$repo_path" && -d "$repo_path/.git" || -f "$repo_path/.git" ]] || continue
+		# Skip local_only repos with no git remote (they'd still be valid
+		# repos but the field signals user intent to skip framework ops).
+		# git worktree list works fine — we just enumerate.
+
+		# Format: "<path>  <sha>  [branch]" or similar.
+		# We emit only paths that are NOT the canonical repo path.
+		local _line="" _wt=""
+		while IFS= read -r _line; do
+			_wt=$(printf '%s' "$_line" | awk '{print $1}') || _wt=""
+			[[ -n "$_wt" ]] || continue
+			[[ "$_wt" == "$repo_path" ]] && continue
+			[[ -d "$_wt" ]] || continue
+			printf '%s\n' "$_wt"
+		done < <(git -C "$repo_path" worktree list 2>/dev/null)
+	done < <(jq -r '.initialized_repos[]?.path // empty' "$REPOS_JSON" 2>/dev/null)
+	return 0
+}
+
+###############################################################################
+# cmd_backfill [--dry-run]
+###############################################################################
+cmd_backfill() {
+	local dry_run=0
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+			--dry-run) dry_run=1; shift ;;
+			*) _we_err "backfill: unknown arg: $arg"; return 1 ;;
+		esac
+	done
+
+	if ! _we_is_macos; then
+		_we_warn "backfill: non-macOS — Linux indexers not supported yet (see GH#<linux-followup>)"
+		return 0
+	fi
+
+	local count=0
+	local wt=""
+	while IFS= read -r wt; do
+		[[ -n "$wt" ]] || continue
+		count=$((count + 1))
+		if (( dry_run )); then
+			printf '  [dry-run] %s\n' "$wt"
+		else
+			cmd_apply "$wt"
+			printf '  [applied] %s\n' "$wt"
+		fi
+	done < <(_we_enumerate_worktrees)
+
+	if (( dry_run )); then
+		_we_info "backfill: would apply to $count worktree(s)"
+	else
+		_we_ok "backfill: applied to $count worktree(s)"
+	fi
+	return 0
+}
+
+###############################################################################
+# cmd_detect — report which tools are installed and which require manual setup.
+###############################################################################
+cmd_detect() {
+	if ! _we_is_macos; then
+		_we_info "Platform: $(uname -s) — exclusions not implemented yet on non-macOS"
+		_we_info "See GH#<linux-followup>"
+		return 0
+	fi
+
+	_we_info "Platform: macOS"
+
+	# Spotlight — no detection needed; .metadata_never_index works on any macOS.
+	_we_ok "Spotlight: scriptable via .metadata_never_index marker file"
+
+	# Time Machine — tmutil exists on every macOS; we report whether it has a
+	# destination configured (informational only).
+	if _we_has_tmutil; then
+		local tm_dest=""
+		tm_dest=$(tmutil destinationinfo 2>/dev/null | head -5 || true)
+		if [[ -n "$tm_dest" ]]; then
+			_we_ok "Time Machine: scriptable via tmutil addexclusion (destination configured)"
+		else
+			_we_ok "Time Machine: scriptable via tmutil addexclusion (no destination yet — exclusions still apply)"
+		fi
+	else
+		_we_warn "Time Machine: tmutil not found (unexpected on macOS)"
+	fi
+
+	# Backblaze — manual setup only (root-only XML config).
+	if _we_has_backblaze; then
+		_we_warn "Backblaze: detected — requires manual setup (run 'worktree-exclusions-helper.sh setup-backblaze')"
+	else
+		_we_info "Backblaze: not installed — skipping"
+	fi
+	return 0
+}
+
+###############################################################################
+# cmd_setup_backblaze — print the sudo commands to add a worktree exclusion
+# rule. Does NOT execute anything (security policy: sudo never runs from inside
+# AI sessions). Prints copy-paste-ready commands.
+###############################################################################
+cmd_setup_backblaze() {
+	if ! _we_is_macos; then
+		_we_info "setup-backblaze: macOS only"
+		return 0
+	fi
+
+	if ! _we_has_backblaze; then
+		_we_info "setup-backblaze: Backblaze not installed — nothing to do"
+		return 0
+	fi
+
+	if [[ ! -f "$BACKBLAZE_RULES_FILE" ]]; then
+		_we_warn "setup-backblaze: rules file not found at $BACKBLAZE_RULES_FILE"
+		_we_warn "setup-backblaze: Backblaze may be a different version — skipping"
+		return 0
+	fi
+
+	cat <<'EOF'
+
+Backblaze worktree exclusion — manual sudo step required
+========================================================
+
+The Backblaze exclude rules file is owned by root. To exclude all aidevops
+worktrees (paths matching ~/Git/<repo>-{feature,bugfix,hotfix,refactor,chore,
+experiment,release}-*), run the following in a separate terminal:
+
+  # 1. Back up the current rules
+  sudo cp /Library/Backblaze.bzpkg/bzdata/bzexcluderules_editable.xml \
+          /Library/Backblaze.bzpkg/bzdata/bzexcluderules_editable.xml.bak
+
+  # 2. Open Backblaze GUI: Settings → Exclusions → Add Exclusion (path)
+  #    Or alternatively: open System Settings → Backblaze → Exclusions
+
+Recommended exclusion patterns (add via the GUI):
+
+  ~/Git/*-feature-*
+  ~/Git/*-bugfix-*
+  ~/Git/*-hotfix-*
+  ~/Git/*-refactor-*
+  ~/Git/*-chore-*
+  ~/Git/*-experiment-*
+  ~/Git/*-release-*
+
+Rationale: aidevops worktrees are ephemeral working copies. Their persistent
+state lives on the git remote, so backing them up duplicates work the remote
+already does. Excluding them removes the bztransmit/bzfilelist load triggered
+by per-worktree node_modules copies.
+
+EOF
+	return 0
+}
+
+###############################################################################
+# cmd_help
+###############################################################################
+cmd_help() {
+	cat <<'EOF'
+worktree-exclusions-helper.sh - exclude worktrees from macOS indexers/backup
+
+Usage:
+  worktree-exclusions-helper.sh apply <worktree-path>
+  worktree-exclusions-helper.sh backfill [--dry-run]
+  worktree-exclusions-helper.sh detect
+  worktree-exclusions-helper.sh setup-backblaze
+  worktree-exclusions-helper.sh help
+
+Subcommands:
+  apply           Apply Spotlight + Time Machine exclusions to one worktree.
+                  Idempotent. Best-effort (always exits 0).
+  backfill        Apply to every worktree across registered repos.
+                  Use --dry-run to preview without writing.
+  detect          Report which tools are installed and scriptable.
+  setup-backblaze Print the sudo command for the manual Backblaze step.
+  help            This message.
+
+Environment:
+  AIDEVOPS_REPOS_JSON  Override path to repos.json (default: ~/.config/aidevops/repos.json)
+EOF
+	return 0
+}
+
+###############################################################################
+# Main dispatch.
+###############################################################################
+main() {
+	local cmd="${1:-help}"
+	[[ $# -gt 0 ]] && shift
+	case "$cmd" in
+		apply)            cmd_apply "$@" ;;
+		backfill)         cmd_backfill "$@" ;;
+		detect)           cmd_detect "$@" ;;
+		setup-backblaze)  cmd_setup_backblaze "$@" ;;
+		help|-h|--help)   cmd_help ;;
+		*)
+			_we_err "unknown subcommand: $cmd"
+			cmd_help
+			return 1
+			;;
+	esac
+}
+
+# Only run main when invoked directly (not when sourced).
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+	main "$@"
+fi

--- a/.agents/scripts/worktree-helper.sh
+++ b/.agents/scripts/worktree-helper.sh
@@ -711,6 +711,27 @@ _restore_worktree_node_modules() {
 	return 0
 }
 
+# t2885: exclude a fresh worktree from macOS Spotlight + Time Machine.
+# Backed by .agents/scripts/worktree-exclusions-helper.sh. Best-effort —
+# never blocks worktree creation. Silent on missing helper or non-macOS.
+_apply_worktree_exclusions() {
+	local wt_path="$1"
+	[[ -n "$wt_path" && -d "$wt_path" ]] || return 0
+
+	# Prefer deployed copy (runtime source of truth); fall back to in-repo
+	# copy when running pre-deploy.
+	local helper=""
+	if [[ -x "${HOME}/.aidevops/agents/scripts/worktree-exclusions-helper.sh" ]]; then
+		helper="${HOME}/.aidevops/agents/scripts/worktree-exclusions-helper.sh"
+	elif [[ -x "${SCRIPT_DIR}/worktree-exclusions-helper.sh" ]]; then
+		helper="${SCRIPT_DIR}/worktree-exclusions-helper.sh"
+	fi
+	[[ -n "$helper" ]] || return 0
+
+	"$helper" apply "$wt_path" >/dev/null 2>&1 || true
+	return 0
+}
+
 # Print the success banner and editor hints after a worktree is created.
 _print_worktree_add_success() {
 	local wt_path="$1"
@@ -1049,6 +1070,11 @@ cmd_add() {
 	local _repo_root=""
 	_repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || _repo_root=""
 	_restore_worktree_node_modules "$path" "$_repo_root"
+
+	# t2885: exclude the new worktree from macOS Spotlight + Time Machine.
+	# Worktrees are ephemeral — persistent state lives on the git remote.
+	# Best-effort, never fails worktree creation.
+	_apply_worktree_exclusions "$path"
 
 	# t2057: interactive issue auto-claim. When the branch name encodes an
 	# issue number AND this is an interactive session, immediately apply

--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,8 @@ bun.lock
 .Trashes
 ehthumbs.db
 Thumbs.db
+# Spotlight exclusion marker, written by worktree-exclusions-helper.sh (t2885)
+.metadata_never_index
 
 # Editor files
 .vscode/

--- a/TODO.md
+++ b/TODO.md
@@ -3193,4 +3193,4 @@ t019.3.4,Update AGENTS.md with Beads integration docs,,beads,1h,45m,2025-12-21T1
 
 - [ ] t2886 Extend pulse triage prefetch to supply evidence-verification data to triage-review agent #auto-dispatch #framework #pulse #security ref:GH#20987
 
-- [ ] t2885 exclude worktrees from macOS Spotlight, Time Machine, and Backblaze at creation time + backfill existing #framework #performance ref:GH#20988
+- [ ] t2885 Exclude worktrees from macOS Spotlight, Time Machine, and Backblaze at creation time + backfill #framework #performance #interactive ref:GH#20988

--- a/setup.sh
+++ b/setup.sh
@@ -95,6 +95,8 @@ if [[ -d "$SETUP_MODULES_DIR" ]]; then
 	source "$SETUP_MODULES_DIR/_task_id_guard.sh"
 	# shellcheck disable=SC1091
 	source "$SETUP_MODULES_DIR/_canonical_guard.sh"
+	# shellcheck disable=SC1091
+	source "$SETUP_MODULES_DIR/_worktree_exclusions.sh"
 fi
 
 print_info() { local _m="$1"; echo -e "${BLUE}[INFO]${NC} $_m"; return 0; }
@@ -1024,8 +1026,13 @@ _setup_run_non_interactive() {
 	# Install/refresh the task-id collision guard commit-msg hook in every
 	# initialized repo so invented t-IDs in commit subjects are rejected
 	# at commit time (t2047). Belt-and-braces with the CI check in
-	# .github/workflows/task-id-collision-check.yml.
+	# .github/workflows/ta[redacted-credential].yml.
 	setup_task_id_guard
+	# Apply Spotlight + Time Machine exclusions to every worktree across
+	# registered repos so the backup/index cascade triggered by node_modules
+	# copies doesn't burn CPU (t2885). Idempotent. macOS only — Linux
+	# indexers tracked separately.
+	setup_worktree_exclusions
 	return 0
 }
 

--- a/todo/tasks/t2885-brief.md
+++ b/todo/tasks/t2885-brief.md
@@ -1,0 +1,97 @@
+# t2885: exclude worktrees from macOS indexers and backup tools at creation time
+
+## Session Origin
+
+Interactive session 2026-04-26. User reported sustained 100% CPU during pulse worker activity on awardsapp. Investigation traced to `_dlw_restore_worktree_deps` (deployed at `pulse-dispatch-worker-launch.sh:236-262`, mirrored at `worktree-helper.sh:694` as `_restore_worktree_node_modules`) doing `cp -a` of `node_modules` per worktree. With 15 concurrent awardsapp worktrees on disk (~30 GB of duplicated `node_modules`), the dominant cost wasn't the cp itself — it was the cascade triggered by the file events:
+
+- fseventsd 131.8% CPU (file events from every cp'd file)
+- bztransmit 73.5% + 51.3% (Backblaze re-uploading every duplicate)
+- mds 44.0% (Spotlight re-indexing every duplicate)
+- kernel_task 126.5% (I/O + thermal mitigation)
+
+System time hit 81.59% vs user 18.41% — kernel/filesystem-bound, not computation. The cp is a real fix for a real bug (workers crash without `node_modules` because opencode tools `import` from it), so we can't remove it. But worktrees are ephemeral by design — the canonical repo + git remote IS the backup — so backing them up and indexing them is pure waste.
+
+## What
+
+Add post-creation hooks to `worktree-helper.sh add` that exclude every new worktree from macOS Spotlight, Time Machine, and (where scriptable) Backblaze. Also provide a backfill mode for existing worktrees, and integrate detection + one-time setup prompts into `setup.sh` and `aidevops update`.
+
+## Why
+
+1. **Universal failure mode.** Every macOS aidevops user with backup/index tools running hits this identically — not specific to one machine. It's structural: parallel pulse workers × `node_modules` × OS file watchers.
+2. **Worktrees are ephemeral.** Backing them up is double-counting — the persistent state lives on the git remote. The only thing worth preserving is uncommitted WIP, which is stash-recoverable on demand.
+3. **Self-improvement principle (`prompts/build.txt`).** Observable failure (user CPU spike) → universal pattern → root-cause fix in framework default behaviour.
+
+## How
+
+### Files to modify
+
+- **NEW:** `.agents/scripts/worktree-exclusions-helper.sh` — model on `.agents/scripts/install-hooks-helper.sh` (similar shape: detect-installed → apply → backfill).
+  - Subcommands: `apply <path>` (single worktree), `backfill` (all worktrees in `~/.config/aidevops/repos.json`), `detect` (report which tools are present), `setup-backblaze` (print sudo command for manual run).
+  - Apply for each worktree: `touch <path>/.metadata_never_index` (Spotlight) + `tmutil addexclusion -p <path>` (Time Machine).
+  - Backblaze: NOT scripted automatically (root-only `bzexcluderules_editable.xml`, requires service restart). The `setup-backblaze` subcommand prints the rule XML and the sudo+restart commands for the user to run manually.
+  - Idempotent: `tmutil isexcluded` check before adding; skip `.metadata_never_index` if file exists.
+  - Source `shared-constants.sh` for color/log helpers (per shell-style rules).
+  - Linux: print "not implemented yet — see GH#<linux-followup>" and exit 0 (non-fatal).
+
+- **EDIT:** `.agents/scripts/worktree-helper.sh:1051-1063` — call `_apply_worktree_exclusions "$path"` immediately after the existing `_restore_worktree_node_modules` call. Function added to worktree-helper.sh as a thin wrapper that invokes `worktree-exclusions-helper.sh apply` with `2>/dev/null || true` (must never fail worktree creation).
+
+- **EDIT:** `setup.sh` — add a section near the existing posture/tool-detection blocks that calls `worktree-exclusions-helper.sh detect` and prints the Backblaze sudo command if Backblaze is detected and the user hasn't already added the exclude rule. Idempotent — skip if rule already present.
+
+- **EDIT:** `.agents/scripts/aidevops-update-check.sh` (or wherever `aidevops update` orchestrates) — same detection + advisory pattern as setup.sh. One-time advisory file in `~/.aidevops/advisories/` so it doesn't nag.
+
+- **EDIT:** `TODO.md` — add the t2885 line with `ref:GH#NNN` (issue number filled in by claim-task-id.sh).
+
+### Reference patterns
+
+- Detection + idempotent apply: pattern from `.agents/scripts/install-hooks-helper.sh:install` and `.agents/scripts/install-task-id-guard.sh:install`.
+- macOS sub-shell logic: `setup.sh` already uses `[[ "$(uname -s)" == "Darwin" ]]` guards.
+- Advisory mechanism: `~/.aidevops/advisories/*.advisory` files documented in `prompts/build.txt` "Security" section.
+
+### Verification
+
+```bash
+# Lint
+shellcheck .agents/scripts/worktree-exclusions-helper.sh
+shellcheck .agents/scripts/worktree-helper.sh
+
+# Behaviour: create a temp worktree and confirm exclusions applied
+TMPWT=$(mktemp -d)/wt
+git -C ~/Git/aidevops worktree add -b chore/t2885-test "$TMPWT" main
+test -f "$TMPWT/.metadata_never_index" && echo "spotlight: ok"
+tmutil isexcluded "$TMPWT" | grep -q '\[Excluded\]' && echo "tmutil: ok"
+git -C ~/Git/aidevops worktree remove --force "$TMPWT"
+
+# Backfill: dry-run
+worktree-exclusions-helper.sh backfill --dry-run
+
+# Detect
+worktree-exclusions-helper.sh detect
+```
+
+### Files Scope
+
+- .agents/scripts/worktree-exclusions-helper.sh
+- .agents/scripts/worktree-helper.sh
+- setup.sh
+- .agents/scripts/aidevops-update-check.sh
+- TODO.md
+- todo/tasks/t2885-brief.md
+
+### Complexity Impact
+
+- `worktree-helper.sh::cmd_add` grows by ~3 lines (one helper call). No risk to the 100-line function gate.
+- New file `worktree-exclusions-helper.sh` is a fresh script with discrete subcommand functions, each well under the threshold.
+- No existing function body grows past 80 lines.
+
+## Acceptance
+
+1. Creating a new worktree via `worktree-helper.sh add` (or `wt switch -c`) automatically applies Spotlight + Time Machine exclusions on macOS.
+2. `worktree-exclusions-helper.sh backfill` applies exclusions to all worktrees registered across `~/.config/aidevops/repos.json` repos. Idempotent.
+3. `worktree-exclusions-helper.sh detect` reports which tools are installed (Spotlight, Time Machine, Backblaze) and which ones are scripted vs require manual setup.
+4. `setup.sh` and `aidevops update` detect installed backup tools and print the Backblaze sudo command once. Advisory dismissable per existing mechanism.
+5. shellcheck zero violations on both modified and new files.
+6. Worktree creation is never blocked by exclusion failure (all calls wrapped `|| true`).
+
+## PR Conventions
+
+Resolves #<filled-in-after-issue-creation>.


### PR DESCRIPTION
## Summary

Exclude aidevops worktrees from Spotlight, Time Machine, and (via guided one-shot) Backblaze.

Worktrees are ephemeral working copies — persistent state lives on the git remote and the canonical repo. Backing them up duplicates work the remote already does, and indexing them inflates fseventsd/mds load when workers `cp -a node_modules` across many concurrent worktrees.

## Root cause (observed)

15 concurrent awardsapp worktrees on the maintainer's machine drove:

- `fseventsd` 131.8% CPU
- `mds` 44% CPU
- `bztransmit` 73.5% + 51.3%
- `kernel_task` 126.5%
- system time 81.59% vs user 18.41%

Each worker dispatches with `_dlw_restore_worktree_deps` (`pulse-dispatch-worker-launch.sh:236-262`) which `cp -a`s node_modules from canonical, generating a flood of fsevents that all three indexers + Backblaze try to process per worktree.

## Implementation

- **`.agents/scripts/worktree-exclusions-helper.sh`** (new) — `apply | backfill | detect | setup-backblaze | help`
  - Spotlight: `.metadata_never_index` marker (no sudo).
  - Time Machine: `tmutil addexclusion` without `-p` (the `-p` sticky-path form requires root; the unflagged form sets a per-path xattr that any user can write).
  - Backblaze: detection only — sudo one-liner via `setup-backblaze` (root-only XML config, never auto-applied).
- **`.agents/scripts/worktree-helper.sh`** — calls `_apply_worktree_exclusions` on every worktree create. Failure is non-fatal — worktree creation must not block on exclusion failure.
- **`.agents/scripts/setup/_worktree_exclusions.sh`** (new) — runs at every `aidevops update` via `setup.sh` non-interactive path. Backfill runs **backgrounded** (`tmutil addexclusion` is ~11s/dir cold; ~0.13s/dir on subsequent runs via the `isexcluded` short-circuit). Posts a one-time advisory under `~/.aidevops/advisories/` when Backblaze is detected.
- **`.gitignore`** — adds `.metadata_never_index` to the OS generated files section so worktree creation doesn't dirty the working tree.

## Verification

Backfill applied to all 28 active worktrees on the maintainer's machine:

```text
[applied] /Users/marcusquinn/Git/aidevops-feature-t2885-worktree-os-exclusions
[applied] /Users/marcusquinn/Git/awardsapp-feature-auto-20260426-051220-gh3004
[applied] /Users/marcusquinn/Git/wpallstars.com-chore-aidevops-init
[... 25 more ...]
[SUCCESS] backfill: applied to 28 worktree(s)
```

Spot-check on 5 random worktrees:

```text
awardsapp-feature-auto-20260426-035241-gh3044  [spotlight:OK] [Excluded]
awardsapp-feature-auto-20260426-051220-gh3004  [spotlight:OK] [Excluded]
awardsapp-feature-auto-20260426-044956-gh2927  [spotlight:OK] [Excluded]
aidevops-feature-t2885-worktree-os-exclusions  [spotlight:OK] [Excluded]
wpallstars.com-chore-aidevops-init             [spotlight:OK] [Excluded]
```

shellcheck clean. Pre-commit ratchet checks pass.

## Scope notes

- macOS-only for v1. Linux indexers (`tracker`, `baloo`, plasma file indexer) tracked in a follow-up issue.
- Backblaze stays manual (sudo + service restart on root-owned XML config).
- The node_modules duplication efficiency itself (cp -c clonefile vs current cp -a, hardlink/pnpm strategies) is tracked separately — different fix mechanism, different risk profile, cleaner audit.

Resolves #20988


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.5 plugin for [OpenCode](https://opencode.ai) v1.14.25 with claude-opus-4-7 spent 39m and 48,365 tokens on this with the user in an interactive session. Overall, 17m since this issue was created.
