### PR TITLE
t2887: canary detect wrong opencode binary, long backoff on config errors

### DIFF
--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -806,6 +806,83 @@ CANARY_TIMEOUT_SECONDS="${CANARY_TIMEOUT_SECONDS:-60}"
 # unaffected; success always wins and clears the negative cache.
 CANARY_NEGATIVE_TTL_SECONDS="${CANARY_NEGATIVE_TTL_SECONDS:-90}"
 
+# t2887: Long backoff for STRUCTURAL config errors (wrong binary, missing
+# binary, malformed config). Unlike transient API blips, structural errors
+# do not self-resolve in 90s — they require either a runner upgrade
+# (`aidevops update`) or maintainer intervention. Hammering an issue with
+# DISPATCH_CLAIM/CLAIM_RELEASED comment pairs every 90s on a structurally
+# broken runner destroys signal in issue threads (~120 spam comments/hour
+# on alex-solovyev's runner pre-fix). 1h backoff reduces noise ~40x while
+# still allowing recovery within a single pulse-update cycle.
+CANARY_CONFIG_ERROR_TTL_SECONDS="${CANARY_CONFIG_ERROR_TTL_SECONDS:-3600}"
+
+#######################################
+# t2887: Validate that an opencode binary path is the real anomalyco/opencode.
+#
+# Distinguishes anomalyco/opencode (the intended runtime) from anthropic's
+# `claude` CLI (`@anthropic-ai/claude-code`), which workers may have on
+# PATH and which the canary cannot use because it does not accept
+# opencode's `-m` flag.
+#
+# Signatures observed in the wild:
+#   anomalyco/opencode --version  -> "1.14.25"          (semver only)
+#   anthropic/claude --version    -> "2.1.120 (Claude Code)"
+#
+# Returns:
+#   0 = valid anomalyco/opencode (semver-shaped, no Claude Code marker, major <= 1)
+#   1 = wrong binary (Claude Code marker OR major version >= 2)
+#   2 = missing or unrunnable binary
+#######################################
+_validate_opencode_binary() {
+	local bin="${1:-}"
+	[[ -n "$bin" ]] || return 2
+	command -v "$bin" >/dev/null 2>&1 || return 2
+
+	local version_output
+	version_output=$("$bin" --version 2>/dev/null || echo "")
+	[[ -n "$version_output" ]] || return 2
+
+	# Anthropic claude CLI signature -- highest-confidence rejection
+	[[ "$version_output" == *"(Claude Code)"* ]] && return 1
+
+	# opencode is at 1.x; any 2.x+ is wrong (claude CLI is 2.1.x)
+	[[ "$version_output" =~ ^[2-9][0-9]*\. ]] && return 1
+
+	# Sanity check: must look like a semver (X.Y.Z)
+	[[ "$version_output" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]] || return 1
+
+	return 0
+}
+
+#######################################
+# t2887: Search common installation paths for a real anomalyco/opencode binary.
+#
+# Used as a self-heal when $OPENCODE_BIN_DEFAULT resolves to the wrong
+# binary (e.g. alex-solovyev's runner where `opencode` first on PATH
+# returns claude CLI). Echoes the first candidate that passes
+# _validate_opencode_binary; returns 0 on success, 1 if no valid binary
+# found. Caller is responsible for plumbing the result through (export
+# OPENCODE_BIN, set local _effective_opencode_bin) -- $OPENCODE_BIN_DEFAULT
+# itself is `readonly` and cannot be reassigned.
+#######################################
+_find_alternative_opencode_binary() {
+	local candidates=(
+		"/opt/homebrew/bin/opencode"
+		"/usr/local/bin/opencode"
+		"${HOME}/.local/bin/opencode"
+		"${HOME}/.opencode/bin/opencode"
+		"/snap/bin/opencode"
+	)
+	local candidate
+	for candidate in "${candidates[@]}"; do
+		if [[ -x "$candidate" ]] && _validate_opencode_binary "$candidate"; then
+			printf '%s\n' "$candidate"
+			return 0
+		fi
+	done
+	return 1
+}
+
 #######################################
 # Version guard -- enforce OPENCODE_PINNED_VERSION before worker launch.
 #
@@ -843,6 +920,10 @@ _run_canary_test() {
 	local requested_model="${1:-}"
 	local cache_file="${STATE_DIR}/canary-last-pass"
 	local fail_cache_file="${STATE_DIR}/canary-last-fail"
+	# t2887: sibling reason file -- categorises the most-recent failure so
+	# the negative-cache TTL can be tuned to the failure class (transient
+	# vs structural).
+	local fail_reason_file="${fail_cache_file}.reason"
 
 	# Check cache -- skip if last canary passed recently
 	if [[ -f "$cache_file" ]]; then
@@ -857,17 +938,68 @@ _run_canary_test() {
 	fi
 
 	# t2814 (Phase 3, fix #4): Negative cache short-circuit. If the canary
-	# failed within CANARY_NEGATIVE_TTL_SECONDS, fail-fast instead of
-	# re-running. Without this, every dispatch attempt during a 90s auth
-	# blip spends up to CANARY_TIMEOUT_SECONDS (default 60s) running a
-	# canary that will fail identically. Bypass: AIDEVOPS_SKIP_CANARY_NEG_CACHE=1.
+	# failed within the relevant TTL, fail-fast instead of re-running.
+	# Without this, every dispatch attempt during a 90s auth blip spends
+	# up to CANARY_TIMEOUT_SECONDS (default 60s) running a canary that
+	# will fail identically. Bypass: AIDEVOPS_SKIP_CANARY_NEG_CACHE=1.
+	#
+	# t2887: TTL is now reason-aware. Structural errors (wrong binary,
+	# missing binary -- "config_error") use CANARY_CONFIG_ERROR_TTL_SECONDS
+	# (default 1h) since they don't self-resolve in 90s. Transient errors
+	# (auth blip, rate limit, provider outage -- "transient" or absent)
+	# keep the original 90s TTL.
 	if [[ "${AIDEVOPS_SKIP_CANARY_NEG_CACHE:-0}" != "1" ]] && [[ -f "$fail_cache_file" ]]; then
-		local last_fail neg_now neg_age
+		local last_fail neg_now neg_age active_ttl fail_reason
 		last_fail=$(cat "$fail_cache_file" 2>/dev/null || echo "0")
 		neg_now=$(date +%s)
 		neg_age=$((neg_now - last_fail))
-		if [[ "$last_fail" =~ ^[0-9]+$ ]] && [[ "$neg_age" -ge 0 ]] && [[ "$neg_age" -lt "$CANARY_NEGATIVE_TTL_SECONDS" ]]; then
-			print_warning "Canary negative cache active (age=${neg_age}s, ttl=${CANARY_NEGATIVE_TTL_SECONDS}s) — failing fast (t2814)"
+		fail_reason=$(cat "$fail_reason_file" 2>/dev/null || echo "transient")
+		if [[ "$fail_reason" == "config_error" ]]; then
+			active_ttl="$CANARY_CONFIG_ERROR_TTL_SECONDS"
+		else
+			active_ttl="$CANARY_NEGATIVE_TTL_SECONDS"
+		fi
+		if [[ "$last_fail" =~ ^[0-9]+$ ]] && [[ "$neg_age" -ge 0 ]] && [[ "$neg_age" -lt "$active_ttl" ]]; then
+			print_warning "Canary negative cache active (age=${neg_age}s, ttl=${active_ttl}s, reason=${fail_reason}) — failing fast (t2814/t2887)"
+			return 1
+		fi
+	fi
+
+	# t2887: Pre-canary binary validation. Detect the case where
+	# $OPENCODE_BIN_DEFAULT resolves to anthropic/claude CLI instead of
+	# anomalyco/opencode (alex-solovyev runner symptom: 468
+	# launch_recovery:no_worker_process failures in 48h). Recover via
+	# alternative-path search if a real opencode is installed elsewhere on
+	# the system; fail loud with structured diagnostic if not. The
+	# resolved path is stored in _effective_opencode_bin (the local
+	# variable used by the canary command) AND exported as OPENCODE_BIN so
+	# downstream worker dispatch picks up the same binary.
+	#
+	# OPENCODE_BIN_DEFAULT is `readonly` (headless-runtime-helper.sh:38),
+	# so we cannot reassign it -- _effective_opencode_bin is the local
+	# override that flows through.
+	local _effective_opencode_bin="$OPENCODE_BIN_DEFAULT"
+	local _validate_rc=0
+	_validate_opencode_binary "$OPENCODE_BIN_DEFAULT" || _validate_rc=$?
+	if [[ "$_validate_rc" -ne 0 ]]; then
+		local wrong_version
+		wrong_version=$("$OPENCODE_BIN_DEFAULT" --version 2>/dev/null || echo "<missing>")
+		local alt_bin=""
+		if alt_bin=$(_find_alternative_opencode_binary); then
+			print_warning "Canary: OPENCODE_BIN_DEFAULT='${OPENCODE_BIN_DEFAULT}' is invalid (version='${wrong_version}', rc=${_validate_rc}) — falling back to '${alt_bin}' (t2887)"
+			_effective_opencode_bin="$alt_bin"
+			export OPENCODE_BIN="$alt_bin"
+		else
+			# Structural failure: no valid opencode anywhere. Stamp
+			# config_error so the next ~1h of dispatch attempts
+			# fail-fast on the cache hit instead of re-discovering this
+			# state every 90s.
+			print_warning "Canary: OPENCODE_BIN_DEFAULT='${OPENCODE_BIN_DEFAULT}' returns '${wrong_version}' (rc=${_validate_rc}) — not anomalyco/opencode."
+			print_warning "Canary: searched /opt/homebrew/bin, /usr/local/bin, ~/.local/bin, ~/.opencode/bin, /snap/bin — no valid binary found."
+			print_warning "Canary: install with 'npm install -g opencode-ai' or set OPENCODE_BIN to a valid binary (t2887)."
+			mkdir -p "${STATE_DIR}" 2>/dev/null || true
+			date +%s >"$fail_cache_file" 2>/dev/null || true
+			printf 'config_error\n' >"$fail_reason_file" 2>/dev/null || true
 			return 1
 		fi
 	fi
@@ -939,9 +1071,12 @@ _run_canary_test() {
 		_canary_timeout_cmd=(perl -e "alarm $CANARY_TIMEOUT_SECONDS; exec @ARGV" --)
 	fi
 
+	# t2887: use _effective_opencode_bin (resolved above), not
+	# $OPENCODE_BIN_DEFAULT directly. Identical to the default in the
+	# happy path; differs only when alternative-path fallback fired.
 	XDG_DATA_HOME="$_canary_data_dir" \
 		"${_canary_timeout_cmd[@]}" \
-		"$OPENCODE_BIN_DEFAULT" run "Reply with exactly: CANARY_OK" \
+		"$_effective_opencode_bin" run "Reply with exactly: CANARY_OK" \
 		-m "$canary_model" --dir "${HOME}" \
 		${canary_attach_args[@]+"${canary_attach_args[@]}"} \
 		>"$canary_output" 2>&1 || canary_exit=$?
@@ -964,7 +1099,10 @@ _run_canary_test() {
 		date +%s >"$cache_file"
 		# t2814: success clears the negative cache so the next failure
 		# starts a fresh TTL window instead of inheriting a stale one.
+		# t2887: also clear the reason file so a subsequent transient
+		# failure is not mis-categorised as a structural error.
 		rm -f "$fail_cache_file" 2>/dev/null || true
+		rm -f "$fail_reason_file" 2>/dev/null || true
 		rm -f "$canary_output"
 		return 0
 	fi
@@ -972,13 +1110,17 @@ _run_canary_test() {
 	# Canary failed -- log diagnostics (capture enough output to surface API errors,
 	# not just startup hooks which is all head -5 typically showed)
 	local oc_version
-	oc_version=$("$OPENCODE_BIN_DEFAULT" --version 2>/dev/null || echo "unknown")
+	oc_version=$("$_effective_opencode_bin" --version 2>/dev/null || echo "unknown")
 	print_warning "Canary test FAILED (exit=$canary_exit, model=$canary_model, opencode=$oc_version, timeout=${CANARY_TIMEOUT_SECONDS}s)"
 	print_warning "Output (last 20 lines): $(tail -20 "$canary_output" 2>/dev/null || echo '<empty>')"
 	# t2814 (Phase 3, fix #4): Stamp the negative cache so subsequent
 	# dispatches within CANARY_NEGATIVE_TTL_SECONDS short-circuit.
+	# t2887: stamp reason as "transient" -- the binary is valid (we
+	# pre-validated above) but the actual run failed. Keeps the standard
+	# 90s TTL for API/auth/timeout-class failures.
 	mkdir -p "${STATE_DIR}" 2>/dev/null || true
 	date +%s >"$fail_cache_file" 2>/dev/null || true
+	printf 'transient\n' >"$fail_reason_file" 2>/dev/null || true
 	rm -f "$canary_output"
 	return 1
 }

--- a/todo/tasks/t2887-brief.md
+++ b/todo/tasks/t2887-brief.md
@@ -1,0 +1,167 @@
+# t2887 — Headless canary: detect wrong opencode binary, fail loud with long backoff
+
+## Session Origin
+
+Interactive (marcusquinn). Discovered while investigating awardsapp/awardsapp#3046, which showed alex-solovyev's runner posting `CLAIM_RELEASED reason=launch_recovery:no_worker_process` 468 times in 48h. The worker log tail showed `Canary test FAILED ... opencode=2.1.119 (Claude Code) ... error: unknown option '-m'`. anomalyco/opencode is at v1.14.x — the `2.1.119 (Claude Code)` version string is Anthropic's `claude` CLI (`@anthropic-ai/claude-code`). On alex's runner, `$OPENCODE_BIN_DEFAULT` is resolving to the wrong binary, the canary feeds it `-m` (an opencode flag claude doesn't accept), and every dispatch attempt fails identically. The current 90s negative-cache backoff (t2814 `CANARY_NEGATIVE_TTL_SECONDS=90`) means each issue accumulates ~40 dispatch-claim comment pairs per hour while the runner stays broken.
+
+## What
+
+In `.agents/scripts/headless-runtime-lib.sh`:
+
+1. **`_validate_opencode_binary <bin>`** — new function. Runs `<bin> --version`, returns:
+   - `0` if output matches `^[01]\.[0-9]+\.[0-9]+` AND does **not** contain `(Claude Code)` (real anomalyco/opencode signature).
+   - `1` if output contains `(Claude Code)` or starts with `2-9` (Anthropic claude CLI signature).
+   - `2` if binary is missing or `--version` returns nothing.
+
+2. **`_find_alternative_opencode_binary`** — new function. Searches `/opt/homebrew/bin/opencode`, `/usr/local/bin/opencode`, `$HOME/.local/bin/opencode`, `$HOME/.opencode/bin/opencode`, `/snap/bin/opencode`. Echoes the first path that passes `_validate_opencode_binary`. Returns 0/1.
+
+3. **Pre-canary validation in `_run_canary_test`** — call `_validate_opencode_binary "$OPENCODE_BIN_DEFAULT"` BEFORE the existing canary command. On failure:
+   - Try `_find_alternative_opencode_binary`. If found, set a local `_effective_opencode_bin` to that path, export `OPENCODE_BIN` so worker dispatch picks it up too, and continue with the canary using the resolved binary.
+   - If no alternative found, print a single clear error message identifying the wrong-binary case (`OPENCODE_BIN_DEFAULT='$bin' returns '$ver' — Anthropic claude CLI, not anomalyco/opencode. Install: 'npm install -g opencode-ai'`), stamp the negative cache with reason `config_error`, and return 1.
+
+4. **Long backoff for `config_error`** — when reading the negative cache, check for an adjacent `${fail_cache_file}.reason` file. If contents are `config_error`, use `CANARY_CONFIG_ERROR_TTL_SECONDS` (default 3600 = 1h) instead of `CANARY_NEGATIVE_TTL_SECONDS` (90s). Successful canary clears both the cache and the reason file (existing behaviour clears the cache; extend to also `rm -f ${fail_cache_file}.reason`).
+
+5. **Use `_effective_opencode_bin` (not `$OPENCODE_BIN_DEFAULT`) in the canary command** at line 944. `OPENCODE_BIN_DEFAULT` is `readonly`, so passing the resolved path through a local variable is the only safe option.
+
+## Why
+
+The current canary fail-fast (t2814) only addresses *transient* failures (auth blip, rate limit). It does **not** distinguish structural runner misconfiguration from API-side problems. When a runner has the wrong binary installed, every 90s the pulse:
+
+1. Attempts dispatch on the next eligible issue
+2. Posts `DISPATCH_CLAIM` comment
+3. Posts `Dispatching worker` comment
+4. Runs canary → fails on `unknown option '-m'`
+5. Posts `CLAIM_RELEASED reason=launch_recovery:no_worker_process` comment with worker log tail
+
+That's **3 spam comments per dispatch attempt × ~40 attempts/hour = ~120 noise comments per hour per runner**. Across 7 issues currently being hammered (#3058, #3076, #3077, #3078, #3081, #3082, #3093), this is destroying signal in the issue threads and burning GitHub API budget.
+
+A 1h backoff for config errors reduces this to **~2-3 attempts/hour per issue** until the runner is fixed (manually or via a future aidevops update that ships a self-heal). The clear diagnostic message means when the runner-owner comes online and reads the worker log, they immediately know what to fix.
+
+The path-fallback search self-heals the common case where opencode IS installed somewhere on the system but `OPENCODE_BIN` env var or PATH order is wrong.
+
+## How
+
+### Files Scope
+
+- `.agents/scripts/headless-runtime-lib.sh`
+- `todo/tasks/t2887-brief.md`
+
+### Implementation
+
+Model on the existing pattern in `_enforce_opencode_version_pin` (lines 817-840) for shape — small focused function that runs `--version`, inspects output, takes corrective action.
+
+The new `_validate_opencode_binary`:
+
+```bash
+# Returns: 0=valid anomalyco/opencode, 1=wrong binary (claude CLI), 2=missing
+_validate_opencode_binary() {
+    local bin="${1:-}"
+    [[ -n "$bin" ]] || return 2
+    command -v "$bin" >/dev/null 2>&1 || return 2
+
+    local version_output
+    version_output=$("$bin" --version 2>/dev/null || echo "")
+
+    # Anthropic claude CLI signature
+    [[ "$version_output" == *"(Claude Code)"* ]] && return 1
+
+    # opencode is at 1.x; anything 2.x+ is wrong (claude CLI is 2.1.x)
+    [[ "$version_output" =~ ^[2-9][0-9]*\. ]] && return 1
+
+    # Sanity check: must look like a semver
+    [[ "$version_output" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]] || return 1
+
+    return 0
+}
+```
+
+The path search:
+
+```bash
+_find_alternative_opencode_binary() {
+    local candidates=(
+        "/opt/homebrew/bin/opencode"
+        "/usr/local/bin/opencode"
+        "${HOME}/.local/bin/opencode"
+        "${HOME}/.opencode/bin/opencode"
+        "/snap/bin/opencode"
+    )
+    local candidate
+    for candidate in "${candidates[@]}"; do
+        if [[ -x "$candidate" ]] && _validate_opencode_binary "$candidate"; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+    return 1
+}
+```
+
+Pre-canary integration goes immediately after the negative-cache check (line 873) and before the `canary_output=$(mktemp ...)` line (line 875).
+
+### Verification
+
+1. **Locally simulate alex's misconfig**:
+
+   ```bash
+   # In the worktree:
+   OPENCODE_BIN=$(which claude) bash -c 'source .agents/scripts/headless-runtime-lib.sh; _validate_opencode_binary "$OPENCODE_BIN"; echo "exit=$?"'
+   ```
+
+   Expected: `exit=1`.
+
+2. **Verify path fallback finds local opencode**:
+
+   ```bash
+   bash -c 'source .agents/scripts/headless-runtime-lib.sh; _find_alternative_opencode_binary'
+   ```
+
+   Expected: `/opt/homebrew/bin/opencode` (or wherever opencode is installed locally).
+
+3. **Run a real canary and confirm it still passes**:
+
+   ```bash
+   bash -c 'source .agents/scripts/headless-runtime-lib.sh; _run_canary_test "anthropic/claude-sonnet-4-6" && echo PASS || echo FAIL'
+   ```
+
+   Expected: `PASS` (because local binary is valid opencode 1.14.x).
+
+4. **Simulate alex's case and confirm structured failure + 1h cache**:
+
+   ```bash
+   OPENCODE_BIN=$(which claude) bash -c 'source .agents/scripts/headless-runtime-lib.sh; _run_canary_test || true; cat ~/.aidevops/state/canary-last-fail.reason 2>/dev/null'
+   ```
+
+   Expected: stderr shows the structured error message; `.reason` file contains `config_error`.
+
+5. **ShellCheck clean**: `shellcheck .agents/scripts/headless-runtime-lib.sh` returns 0.
+
+## Acceptance
+
+- [x] `_validate_opencode_binary` distinguishes anomalyco/opencode from anthropic/claude via the `(Claude Code)` signature in `--version` output.
+- [x] `_find_alternative_opencode_binary` searches 5 common installation paths and returns the first valid one.
+- [x] `_run_canary_test` validates the binary before the canary command and uses the resolved alternative if the default is wrong.
+- [x] Wrong-binary case writes `config_error` to a sibling reason file and triggers a 1h backoff (vs 90s for transient failures).
+- [x] Local canary still passes on this machine (existing `opencode` is valid).
+- [x] ShellCheck clean.
+- [x] Bash 3.2 compatible (no associative arrays, no `${var,,}`, no `mapfile`).
+
+## Complexity Impact
+
+`_run_canary_test` currently 142 lines (842-984). Adding pre-canary validation inline would push it past the 100-line function-complexity gate. **Mitigation**: the validation logic is fully contained in two new helper functions (`_validate_opencode_binary`, `_find_alternative_opencode_binary`) — the call site in `_run_canary_test` is a 6-8 line block. Net function size: ~150 lines (still over the gate, but unchanged from baseline; the gate is a ratchet on regressions, not absolute).
+
+If the gate trips, apply `complexity-bump-ok` label with the justification block:
+
+```
+## Complexity Bump Justification
+
+`_run_canary_test` already exceeds 100 lines pre-change (142 lines).
+This PR adds 8 lines for pre-canary validation; net change: 142 → ~150.
+Refactor to split is out of scope — would file as a follow-up task if needed.
+
+base=142, head=150, new=8
+```
+
+## PR Conventions
+
+`Resolves #21000` (leaf task — no parent-task chain).


### PR DESCRIPTION
## Summary

Fixes the canary spam loop on alex-solovyev's runner: when `$OPENCODE_BIN_DEFAULT` resolves to anthropic/claude CLI (`@anthropic-ai/claude-code`) instead of anomalyco/opencode, every dispatch attempt failed identically with `error: unknown option '-m'` (claude doesn't accept opencode's `-m` flag), and the existing 90s negative-cache TTL re-tried every ~90s — accumulating ~40 dispatch attempts per issue per hour, each posting 3 spam comments (`DISPATCH_CLAIM`, `Dispatching worker`, `CLAIM_RELEASED reason=launch_recovery:no_worker_process`). 48h observed: 468 failures, 0 successes, ~120 noise comments/hour across 7 awardsapp issues.

## Approach

1. **Detect** wrong-binary case via `_validate_opencode_binary` — checks for `(Claude Code)` marker in `--version` output and rejects major version ≥ 2 (opencode is at 1.x; claude is at 2.1.x).
2. **Self-heal** via `_find_alternative_opencode_binary` — searches `/opt/homebrew/bin`, `/usr/local/bin`, `~/.local/bin`, `~/.opencode/bin`, `/snap/bin`. If a valid binary is found, the canary uses it via a local `_effective_opencode_bin` (since `$OPENCODE_BIN_DEFAULT` is `readonly`) and exports `OPENCODE_BIN` so downstream worker dispatch picks up the same path.
3. **Fail loud** with a structured diagnostic when no valid binary is anywhere on the system, stamping a sibling `.reason` file with `config_error`.
4. **Long backoff** for `config_error` failures: new `CANARY_CONFIG_ERROR_TTL_SECONDS` (default 3600 = 1h) gates re-tries on structural failures, while transient failures (auth blip, rate limit, timeout) keep the existing 90s `CANARY_NEGATIVE_TTL_SECONDS`. Reduces spam comment rate ~40x while still allowing self-heal within a single `aidevops update` cycle.

## Verification

**Helper-level (9 cases, all pass):**
- real anomalyco/opencode → rc=0
- anthropic/claude CLI → rc=1 (rejected via Claude Code marker)
- missing binary → rc=2
- empty arg → rc=2
- alt-path search finds local opencode → returns `/opt/homebrew/bin/opencode`
- synthetic `2.1.119 (Claude Code)` → rc=1
- synthetic `1.14.25` → rc=0
- synthetic empty `--version` → rc=2
- synthetic non-semver garbage → rc=1

**Integration (alex-shaped misconfig, all pass):**
- `_run_canary_test` with `OPENCODE_BIN_DEFAULT=$(which claude)` and no alternative → rc=1, `.reason` contains `config_error`
- Re-run within TTL → `Canary negative cache active (age=0s, ttl=3600s, reason=config_error) — failing fast (t2814/t2887)` and rc=1
- Self-heal path: same misconfig but real opencode in `/opt/homebrew/bin` → falls back transparently and the canary command runs against the resolved binary; reason file cleared on success

**Local canary still passes** on this machine (existing `opencode` 1.14.25 is valid). ShellCheck clean. Pre-commit + pre-push hooks pass.

## Files Changed

- `.agents/scripts/headless-runtime-lib.sh` — adds `CANARY_CONFIG_ERROR_TTL_SECONDS` constant, `_validate_opencode_binary`, `_find_alternative_opencode_binary`; modifies `_run_canary_test` to read/write reason file and use `_effective_opencode_bin`
- `todo/tasks/t2887-brief.md` — full implementation context, trace rationale, acceptance criteria

## Complexity Impact

`_run_canary_test` grew from 142 lines to 207 lines (+65 lines). Pre-existing function exceeds the 100-line `function-complexity` gate; this PR adds 65 lines for the pre-canary validation block and reason-file handling. Net change is contained to the canary entry point — extracting the validation block to a separate function would add a layer of indirection without reducing total complexity.

If the gate trips, apply `complexity-bump-ok` with:

```
## Complexity Bump Justification

`_run_canary_test` exceeds the 100-line gate pre-change (142 lines).
This PR adds 65 lines for pre-canary binary validation + reason-aware
TTL. The new logic is tightly coupled to canary state (cache files,
TTL selection, _effective_opencode_bin threading) and would require
multi-arg passing if extracted. Refactor would be a separate follow-up task if needed.

base=142, head=207, new=65
```

## Why Interactive (no auto-dispatch)

`headless-runtime-lib.sh` is on the canonical self-hosting list (`.agents/configs/self-hosting-files.conf`). Workers fixing dispatch run through the code being fixed — a tautology loop. Per t2821 dispatch-path default: `no-auto-dispatch` + `origin:interactive`. Maintainer-implemented; auto-merge will fire once CI is green.

Resolves #21000

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.6 plugin for [OpenCode](https://opencode.ai) v1.14.25 with claude-opus-4-7 spent 4h 23m and 326,424 tokens on this with the user in an interactive session.

