### PR TITLE
GH#21007: fix worktree path enumeration for paths with spaces

### DIFF
--- a/.agents/scripts/worktree-exclusions-helper.sh
+++ b/.agents/scripts/worktree-exclusions-helper.sh
@@ -183,16 +183,18 @@ _we_enumerate_worktrees() {
 		# repos but the field signals user intent to skip framework ops).
 		# git worktree list works fine — we just enumerate.
 
-		# Format: "<path>  <sha>  [branch]" or similar.
+		# Use --porcelain so paths with spaces are handled correctly.
+		# Each worktree block starts with "worktree <path>"; the last
+		# variable in read captures the remainder of the line verbatim.
 		# We emit only paths that are NOT the canonical repo path.
-		local _line="" _wt=""
-		while IFS= read -r _line; do
-			_wt=$(printf '%s' "$_line" | awk '{print $1}') || _wt=""
+		local _key="" _wt=""
+		while read -r _key _wt; do
+			[[ "$_key" == "worktree" ]] || continue
 			[[ -n "$_wt" ]] || continue
 			[[ "$_wt" == "$repo_path" ]] && continue
 			[[ -d "$_wt" ]] || continue
 			printf '%s\n' "$_wt"
-		done < <(git -C "$repo_path" worktree list 2>/dev/null)
+		done < <(git -C "$repo_path" worktree list --porcelain 2>/dev/null)
 	done < <(jq -r '.initialized_repos[]?.path // empty' "$REPOS_JSON" 2>/dev/null)
 	return 0
 }


### PR DESCRIPTION
## What was done

Replaced `git worktree list` + `awk '{print $1}'` with `git worktree list --porcelain` in `_we_enumerate_worktrees()` in `.agents/scripts/worktree-exclusions-helper.sh`.

The previous awk-based approach split output on whitespace, silently truncating paths that contain spaces (e.g. `/Users/name/My Projects/repo`), causing those worktrees to be missed during Spotlight/Time Machine backfill exclusion.

With `--porcelain`, each worktree block opens with a `worktree <path>` line. Using `read -r _key _wt` assigns the first word to `_key` and the **entire remainder of the line** to `_wt`, preserving spaces in paths verbatim.

## How verified

- `shellcheck .agents/scripts/worktree-exclusions-helper.sh` → zero violations
- Pre-commit and pre-push hooks passed

Resolves #21007


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.7 plugin for [OpenCode](https://opencode.ai) v1.14.25 with claude-sonnet-4-6 spent 2m and 5,869 tokens on this as a headless worker.