### PR TITLE
tGH#21005: fix path prefix and section ref clarity in .agents/AGENTS.md

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -43,7 +43,7 @@ New to aidevops? Type `/onboarding`.
 
 > **Skip this section if you don't have Edit/Write/Bash tools** (e.g., Plan+ agent). Instead, proceed directly to responding to the user.
 
-Hard rules: see "Framework Rules > Git Workflow > Pre-edit rules" below. Details: `workflows/pre-edit.md`.
+Hard rules: see "Framework Rules > Git Workflow > Pre-edit rules" below. Details: `.agents/workflows/pre-edit.md`.
 
 Subagent write restrictions: on `main`/`master`, **headless subagents** may write to `README.md`, `TODO.md`, `todo/PLANS.md`, `todo/tasks/*`. **Interactive subagents** must always use a linked worktree regardless of path — no planning exception (t1990). All other writes → proposed edits in a worktree.
 
@@ -344,7 +344,7 @@ Log security ops: `audit-log-helper.sh log <type> <message>`. NEVER log credenti
 
 ### Git Workflow
 
-Git is the audit trail. Procedures: see "Git Workflow" section below.
+Git is the audit trail. Procedures: see the "## Git Workflow" section below.
 
 **Origin labelling (MANDATORY):**
 


### PR DESCRIPTION
## Summary

Fixes two review findings from PR #20982 on `.agents/AGENTS.md`:

1. **HIGH (line 46)**: Added missing `.agents/` prefix to the `workflows/pre-edit.md` path reference — paths in this file resolve from repo root, so it should be `.agents/workflows/pre-edit.md`.
2. **MEDIUM (line 347)**: Clarified the ambiguous `see "Git Workflow" section below` reference (which was inside a `### Git Workflow` subsection) to `see the "## Git Workflow" section below` — making the target heading level explicit.

## Verification

Both changes are documentation-only (no shell or code changes). Confirmed correct paths:
- `git ls-files .agents/workflows/pre-edit.md` → file exists
- Section `## Git Workflow` exists at line ~561 in the same file

Resolves #21005


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.7 plugin for [OpenCode](https://opencode.ai) v1.14.24 with claude-sonnet-4-6 spent 46s and 1,783 tokens on this as a headless worker.