### PR TITLE
GH#20979: add missing labels field to t2148 test stub fixtures

### DIFF
--- a/.agents/scripts/tests/test-interactive-session-claim.sh
+++ b/.agents/scripts/tests/test-interactive-session-claim.sh
@@ -468,8 +468,8 @@ rm -f "${claim_dir}"/*.json 2>/dev/null || true
 
 # Stub `gh issue list` to return two origin:interactive + assigned issues
 export STUB_ISSUE_LIST_JSON='[
-  {"number": 91001, "updatedAt": "2025-01-01T00:00:00Z"},
-  {"number": 91002, "updatedAt": "2025-01-01T00:00:00Z"}
+  {"number": 91001, "updatedAt": "2025-01-01T00:00:00Z", "labels": []},
+  {"number": 91002, "updatedAt": "2025-01-01T00:00:00Z", "labels": []}
 ]'
 
 stampless_rows=$(_isc_list_stampless_interactive_claims testuser stamp/test 2>&1)


### PR DESCRIPTION
## Summary

- Added `"labels": []` to `STUB_ISSUE_LIST_JSON` fixture objects in `test-interactive-session-claim.sh`
- After GH#20048 added `_filter_non_task_issues`, the jq predicate errored on null labels and silently returned empty output via `|| echo "[]"` fallback
- All 3 t2148 tests now pass (21/21 total)

## Testing

- `shellcheck .agents/scripts/tests/test-interactive-session-claim.sh` — clean
- `bash .agents/scripts/tests/test-interactive-session-claim.sh` — 21 run, 0 failed

Resolves #20979


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.7 plugin for [OpenCode](https://opencode.ai) v1.14.24 with claude-opus-4-6 spent 1m and 2,797 tokens on this as a headless worker.