### PR TITLE
GH#20967: add permissions block to caller templates — fix startup_failure on read-only default repos

### DIFF
--- a/.agents/reference/reusable-workflows.md
+++ b/.agents/reference/reusable-workflows.md
@@ -105,6 +105,9 @@ See also [`auto-dispatch.md`](auto-dispatch.md) for the `SYNC_PAT` requirement (
 - **`pull_request_target` vs `pull_request`.** The reusable workflow's job guards accept either event type. The caller picks based on its security model:
   - **Private repo with trusted contributors**: `pull_request` is simpler and has fewer footguns.
   - **Public repo accepting external PRs**: `pull_request_target` is required if the workflow needs write permissions or secrets (but bring standard `pull_request_target` hygiene — don't check out the PR's head code if you trust it to run with elevated privileges).
+- **`default_workflow_permissions: read` repos (GH#20967).** GitHub's recommended security default is `default_workflow_permissions: read`. Reusable workflow job-level `permissions:` declarations cannot exceed the CALLER's ceiling — they are capped at whatever the caller workflow grants. A caller with no `permissions:` block inherits the repo's restrictive default, so GitHub refuses to create any jobs (`conclusion: startup_failure`, zero jobs). The canonical caller templates include a top-level `permissions:` block that is the union of all job-level permissions used by the reusable workflow. If you add a new permission to a reusable workflow job, also update the matching caller template.
+
+  Verification: `gh api repos/OWNER/REPO/actions/permissions/workflow --jq .default_workflow_permissions` returns `"read"` or `"write"`. A `"read"` repo will fail without the caller's `permissions:` block.
 
 ## Migration: from copied workflow to caller
 
@@ -138,7 +141,7 @@ To make a new aidevops workflow reusable by downstream repos:
 
 1. Author the logic in `.github/workflows/<name>-reusable.yml` with `on: workflow_call:`.
 2. Add a thin caller for aidevops itself at `.github/workflows/<name>.yml` using `uses: ./.github/workflows/<name>-reusable.yml`.
-3. Add a canonical template at `.agents/templates/workflows/<name>-caller.yml` using `uses: marcusquinn/aidevops/.github/workflows/<name>-reusable.yml@main`.
+3. Add a canonical template at `.agents/templates/workflows/<name>-caller.yml` using `uses: marcusquinn/aidevops/.github/workflows/<name>-reusable.yml@main`. Include a top-level `permissions:` block that is the union of all job-level permissions declared in the reusable workflow — callers for repos with `default_workflow_permissions: read` cannot create any jobs without this (GH#20967).
 4. If the workflow depends on framework scripts, ensure each job includes an `actions/checkout` of `marcusquinn/aidevops` into `__aidevops/` before invoking those scripts. Reference scripts via `__aidevops/.agents/scripts/...`.
 5. Update `aidevops check-workflows` manifest to include the new template name (Phase 1 helper).
 6. Run `aidevops sync-workflows` to propagate to repos that have the predecessor workflow.

--- a/.agents/scripts/tests/test-reusable-workflow-caller.sh
+++ b/.agents/scripts/tests/test-reusable-workflow-caller.sh
@@ -448,6 +448,36 @@ if [[ -f "$REUSABLE_WF" ]]; then
 fi
 
 # ---------------------------------------------------------------------------
+# Tests 18-19: GH#20967 — every caller template must declare permissions:
+# Repos with default_workflow_permissions: read cause startup_failure unless
+# the caller sets a permissions ceiling. Both templates must declare permissions.
+# ---------------------------------------------------------------------------
+
+# Test 18: issue-sync-caller.yml declares a permissions: block
+if [[ -f "$DOWNSTREAM_TEMPLATE" ]]; then
+	if grep -qE "^permissions:" "$DOWNSTREAM_TEMPLATE" 2>/dev/null; then
+		_pass "issue-sync-caller.yml declares top-level permissions: block (GH#20967)"
+	else
+		_fail "issue-sync-caller.yml declares top-level permissions: block (GH#20967)" \
+			"missing 'permissions:' in $DOWNSTREAM_TEMPLATE — repos with default_workflow_permissions: read will get startup_failure"
+	fi
+else
+	_skip "issue-sync-caller.yml permissions check" "template file missing"
+fi
+
+# Test 19: review-bot-gate-caller.yml declares a permissions: block
+if [[ -f "$RBG_DOWNSTREAM_TEMPLATE" ]]; then
+	if grep -qE "^permissions:" "$RBG_DOWNSTREAM_TEMPLATE" 2>/dev/null; then
+		_pass "review-bot-gate-caller.yml declares top-level permissions: block (GH#20967)"
+	else
+		_fail "review-bot-gate-caller.yml declares top-level permissions: block (GH#20967)" \
+			"missing 'permissions:' in $RBG_DOWNSTREAM_TEMPLATE — repos with default_workflow_permissions: read will get startup_failure"
+	fi
+else
+	_skip "review-bot-gate-caller.yml permissions check" "template file missing"
+fi
+
+# ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------
 

--- a/.agents/templates/workflows/issue-sync-caller.yml
+++ b/.agents/templates/workflows/issue-sync-caller.yml
@@ -18,6 +18,14 @@ name: Issue Sync - Bi-directional TODO.md ↔ GitHub Issues
 #   @v3.9.0         ← pin to a specific aidevops version for stability
 #                     (bump via aidevops sync-workflows after upgrades)
 
+# Permissions ceiling for downstream repos with default_workflow_permissions: read.
+# Reusable workflow job-level permissions cannot exceed the caller's ceiling.
+# This block sets the union of all job-level permissions used by issue-sync-reusable.yml.
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
 on:
   push:
     branches: [main]

--- a/.agents/templates/workflows/review-bot-gate-caller.yml
+++ b/.agents/templates/workflows/review-bot-gate-caller.yml
@@ -26,6 +26,14 @@ name: Review Bot Gate
 #   @v3.9.0         ← pin to a specific aidevops version for stability
 #                     (bump via aidevops sync-workflows after upgrades)
 
+# Permissions ceiling for downstream repos with default_workflow_permissions: read.
+# Reusable workflow job-level permissions cannot exceed the caller's ceiling.
+# This block sets the union of all job-level permissions used by review-bot-gate-reusable.yml.
+permissions:
+  pull-requests: read
+  contents: read
+  statuses: read
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]


### PR DESCRIPTION
## Summary

Caller templates for `issue-sync` and `review-bot-gate` lacked a `permissions:` block. On repos with `default_workflow_permissions: read` (GitHub's recommended secure default), this caused `startup_failure` — GitHub refuses to create jobs when the caller inherits a read-only ceiling that the reusable workflow's job-level permissions would need to exceed.

**Root cause chain** (from issue body):
1. Caller has no `permissions:` → inherits repo default → GITHUB_TOKEN ceiling is read-only
2. Reusable workflow's per-job `permissions:` cannot exceed the caller's ceiling
3. GitHub validates this at startup → zero jobs, `startup_failure`

## Changes

- **`issue-sync-caller.yml`**: added `permissions: contents/issues/pull-requests: write` (union of all job-level permissions in `issue-sync-reusable.yml`)
- **`review-bot-gate-caller.yml`**: added `permissions: pull-requests/contents/statuses: read` (the gate only needs read)
- **`test-reusable-workflow-caller.sh`**: added tests 18-19 — invariant that every caller template declares a top-level `permissions:` block (24/24 tests pass)
- **`reusable-workflows.md`**: documented the `default_workflow_permissions` interaction, failure mode, and fix; updated new-workflow authoring checklist

## Verification

```bash
bash .agents/scripts/tests/test-reusable-workflow-caller.sh
# 24/24 PASS

grep '^permissions:' .agents/templates/workflows/*-caller.yml
# Both templates output a permissions: block
```

Resolves #20967


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.7 plugin for [OpenCode](https://opencode.ai) v1.14.25 with claude-sonnet-4-6 spent 7m and 9,389 tokens on this as a headless worker.
