### PR TITLE
GH#20979: fix: t2148 test fixtures - add missing labels field

### DIFF
--- a/.agents/scripts/tests/test-interactive-session-claim.sh
+++ b/.agents/scripts/tests/test-interactive-session-claim.sh
@@ -468,8 +468,8 @@ rm -f "${claim_dir}"/*.json 2>/dev/null || true
 
 # Stub `gh issue list` to return two origin:interactive + assigned issues
 export STUB_ISSUE_LIST_JSON='[
-  {"number": 91001, "updatedAt": "2025-01-01T00:00:00Z"},
-  {"number": 91002, "updatedAt": "2025-01-01T00:00:00Z"}
+  {"number": 91001, "updatedAt": "2025-01-01T00:00:00Z", "labels": []},
+  {"number": 91002, "updatedAt": "2025-01-01T00:00:00Z", "labels": []}
 ]'
 
 stampless_rows=$(_isc_list_stampless_interactive_claims testuser stamp/test 2>&1)


### PR DESCRIPTION
## Summary

Added missing 'labels' field to STUB_ISSUE_LIST_JSON fixtures in test-interactive-session-claim.sh. The _filter_non_task_issues function expects every issue object to have a labels array, but the test stub was omitting this field, causing jq errors and silent failures. All three t2148 tests now pass.

## Files Changed

.agents/scripts/tests/test-interactive-session-claim.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Ran test suite: all 21 tests pass, 0 failed. Verified with shellcheck: no violations.

Resolves #20979


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.7 plugin for [OpenCode](https://opencode.ai) v1.14.25 with claude-haiku-4-5 spent 7m and 1,391 tokens on this as a headless worker.