### PR TITLE
t2882: add unsolicited_disclosure_marketing patterns to prompt-injection-patterns.yaml

### DIFF
--- a/.agents/configs/prompt-injection-patterns.yaml
+++ b/.agents/configs/prompt-injection-patterns.yaml
@@ -655,3 +655,44 @@ credential_exposure:
   - severity: MEDIUM
     description: "URL query param: webhook_secret"
     pattern: '[?&]webhook_secret=[^&\s]{8,}'
+
+# ================================================================
+# UNSOLICITED DISCLOSURE MARKETING (parent #20983)
+# ================================================================
+# Detects content-spam dressed as security disclosure: external
+# scanners that mass-file "responsible disclosure" issues with an
+# embedded product install CTA. Real responsible disclosure goes
+# through SECURITY.md / private security advisories, not public
+# issues with marketing footers.
+#
+# Canonical example: aidevops#20978 (Pentesterra DevGuard).
+# Threat model: Issue body invites worker/maintainer to install
+# adversary-controlled tooling, fetch tracking URLs, or email
+# adversary-controlled addresses. The patterns below detect the
+# CTA shapes; structural checks (non-collaborator author,
+# single-domain repetition) live in Phase C.
+# ================================================================
+unsolicited_disclosure_marketing:
+  - severity: HIGH
+    description: "Pip install solicitation"
+    pattern: '(?im)^[\s>`]*pip\s+install\s+[a-z][-a-z0-9_]+'
+
+  - severity: HIGH
+    description: "NPM install solicitation"
+    pattern: '(?im)^[\s>`]*npm\s+install\s+[a-z@][-a-z0-9_/]+'
+
+  - severity: HIGH
+    description: "Curl-pipe-bash install pattern"
+    pattern: '(?i)\bcurl\s+(-[a-zA-Z]+\s+)*[^|\s]+\s*\|\s*(bash|sh|zsh)\b'
+
+  - severity: HIGH
+    description: "Brew install solicitation"
+    pattern: '(?im)^[\s>`]*brew\s+install\s+[a-z][-a-z0-9_]+'
+
+  - severity: MEDIUM
+    description: "False-positive out-clause"
+    pattern: '(?i)(if\s+(this|you\s+believe).{1,40}false\s+positive|believe\s+this\s+is\s+a\s+false\s+positive)'
+
+  - severity: MEDIUM
+    description: "Disclosure marketing footer"
+    pattern: '(?i)responsible\s+disclosure.{1,200}(security\s+research|security\s+policy)'


### PR DESCRIPTION
## Summary

Add new `unsolicited_disclosure_marketing` category to `.agents/configs/prompt-injection-patterns.yaml` with 6 PCRE patterns covering:

- **HIGH**: Pip install solicitation (`pip install <pkg>`)
- **HIGH**: NPM install solicitation (`npm install <pkg>`)
- **HIGH**: Curl-pipe-bash install pattern (`curl ... | bash`)
- **HIGH**: Brew install solicitation (`brew install <pkg>`)
- **MEDIUM**: False-positive out-clause ("if you believe this is a false positive")
- **MEDIUM**: Disclosure marketing footer ("responsible disclosure ... security research/policy")

## Why

The pattern store had no coverage for content-spam dressed as responsible disclosure. External scanners (canonical: #20978 Pentesterra DevGuard) mass-file issues with embedded product install CTAs, then use "if false positive contact us" to appear legitimate. These patterns flow through the existing two-tier scanner with no new infrastructure required.

## What Changed

- `EDIT: .agents/configs/prompt-injection-patterns.yaml` — appended `unsolicited_disclosure_marketing` block (41 lines) after `credential_exposure`

## Verification

Pattern count: 127 → 133 (+6 HIGH:4 MEDIUM:2). Fixture scan of #20978 body flags 2 matches: pip install solicitation (HIGH) and false-positive out-clause (MEDIUM).

## Acceptance Criteria Status

- [x] New category `unsolicited_disclosure_marketing` present in YAML
- [x] `prompt-guard-helper.sh test` — pre-existing tests pass (CRITICAL/HIGH blocks confirmed)
- [x] `prompt-guard-helper.sh status` — pattern count increased 127 → 133
- [x] #20978 fixture body flags 2 patterns from the new category
- [x] PR body uses `For #20983` (parent-task keyword rule) — NOT Closes/Resolves

For #20983
Resolves #20984

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.7 plugin for [OpenCode](https://opencode.ai) v1.14.25 with claude-sonnet-4-6 spent 10m and 7,734 tokens on this as a headless worker.
