### PR TITLE
t2886: extend pulse triage prefetch with evidence-verification sections

### DIFF
--- a/.agents/scripts/pulse-ancillary-dispatch.sh
+++ b/.agents/scripts/pulse-ancillary-dispatch.sh
@@ -380,6 +380,130 @@ _triage_prefetch_issue() {
 }
 
 #######################################
+# Fetch evidence-verification sections for the triage review prompt.
+#
+# Supplies three data blocks that let the sandboxed triage-review agent
+# verify file:line claims without needing Bash or network access
+# (t2886 / GH#20987 — closes the gap documented in review-issue-pr.md:293):
+#
+#   1. Recent merged PRs matching the issue title keywords — catches
+#      "this was already fixed in PR #N" cases.
+#   2. Recent commits on files cited in the issue body since the issue was
+#      posted — catches "the file changed after the scan was generated".
+#   3. Current contents of cited files at cited line numbers (±5-line window)
+#      — lets the agent verify claimed code against the actual file.
+#
+# Writes results to caller-supplied named variables via printf -v so the
+# function's "return" values are explicit in the signature (GH#18865).
+#
+# Arguments:
+#   $1 - issue_body (raw issue text; searched for file:line refs)
+#   $2 - issue_json (full issue JSON; used for .title and .createdAt)
+#   $3 - repo_slug  (OWNER/REPO, passed to gh pr list)
+#   $4 - repo_path  (local checkout path for git log and file reads; may be "")
+#   $5 - name of variable to receive merged PRs text
+#   $6 - name of variable to receive recent commits text
+#   $7 - name of variable to receive file contents text
+#
+# Returns: 0
+#######################################
+_triage_fetch_evidence_sections() {
+	local issue_body="$1"
+	local issue_json="$2"
+	local repo_slug="$3"
+	local repo_path="$4"
+	local merged_prs_var="$5"
+	local recent_commits_var="$6"
+	local file_contents_var="$7"
+
+	# Use _ev_ prefix on internal vars to avoid clashing with caller's
+	# named output variables via bash printf -v dynamic scoping (GH#18865).
+
+	# Extract title keywords for PR search (first 4 words, lowercased, stripped)
+	local _ev_title=""
+	_ev_title=$(printf '%s' "$issue_json" | jq -r '.title // ""' 2>/dev/null) \
+		|| _ev_title=""
+	local _ev_keywords=""
+	_ev_keywords=$(printf '%s' "$_ev_title" \
+		| tr '[:upper:]' '[:lower:]' \
+		| tr -cs 'a-z0-9 ' ' ' \
+		| awk '{for(i=1;i<=4&&i<=NF;i++) printf $i" "}' \
+		| xargs) || _ev_keywords=""
+
+	# Extract issue creation timestamp for git log --since
+	local _ev_created_at=""
+	_ev_created_at=$(printf '%s' "$issue_json" | jq -r '.createdAt // ""' 2>/dev/null) \
+		|| _ev_created_at=""
+
+	# 1. Recent merged PRs matching issue keywords
+	local _ev_merged_prs=""
+	if [[ -n "$_ev_keywords" ]]; then
+		_ev_merged_prs=$(gh pr list --repo "$repo_slug" --state merged \
+			--search "$_ev_keywords" --limit 5 \
+			--json number,title,mergedAt \
+			--jq '.[] | "#\(.number) \(.title) (merged: \(.mergedAt))"' \
+			2>/dev/null) || _ev_merged_prs=""
+	fi
+	[[ -z "$_ev_merged_prs" ]] \
+		&& _ev_merged_prs="No recent merged PRs matching issue keywords"
+
+	# 2 + 3. Parse file:line references from issue body (cap at 10).
+	# rg -o (not -E; -E in rg means --encoding, not extended-regexp).
+	local _ev_file_refs=""
+	_ev_file_refs=$(printf '%s' "$issue_body" \
+		| rg -o '[a-zA-Z0-9_./-]+\.[a-zA-Z]+:[0-9]+' 2>/dev/null \
+		| head -10) || _ev_file_refs=""
+
+	local _ev_recent_commits=""
+	local _ev_file_contents=""
+
+	if [[ -n "$_ev_file_refs" && -n "$repo_path" && -d "$repo_path" ]]; then
+		while IFS=: read -r _ev_cited_file _ev_cited_line; do
+			[[ -z "$_ev_cited_file" ]] && continue
+
+			# Recent commits on this file since issue was posted
+			if [[ -n "$_ev_created_at" ]]; then
+				local _ev_file_commits=""
+				_ev_file_commits=$(git -C "$repo_path" log \
+					--since="$_ev_created_at" --oneline \
+					-- "$_ev_cited_file" 2>/dev/null) || _ev_file_commits=""
+				if [[ -n "$_ev_file_commits" ]]; then
+					_ev_recent_commits+="--- ${_ev_cited_file} ---"$'\n'
+					_ev_recent_commits+="${_ev_file_commits}"$'\n'
+				fi
+			fi
+
+			# File contents at cited line ±5-line window
+			local _ev_full_path="${repo_path}/${_ev_cited_file}"
+			if [[ -f "$_ev_full_path" && -n "$_ev_cited_line" ]]; then
+				local _ev_line_start
+				_ev_line_start=$(( _ev_cited_line - 5 ))
+				[[ "$_ev_line_start" -lt 1 ]] && _ev_line_start=1
+				local _ev_line_end
+				_ev_line_end=$(( _ev_cited_line + 5 ))
+				local _ev_snippet=""
+				_ev_snippet=$(sed -n "${_ev_line_start},${_ev_line_end}p" \
+					"$_ev_full_path" 2>/dev/null) || _ev_snippet=""
+				if [[ -n "$_ev_snippet" ]]; then
+					_ev_file_contents+="--- ${_ev_cited_file} (lines ${_ev_line_start}-${_ev_line_end}, cited line: ${_ev_cited_line}) ---"$'\n'
+					_ev_file_contents+="${_ev_snippet}"$'\n'
+				fi
+			fi
+		done <<< "$_ev_file_refs"
+	fi
+
+	[[ -z "$_ev_recent_commits" ]] \
+		&& _ev_recent_commits="No recent commits on cited files since issue was posted"
+	[[ -z "$_ev_file_contents" ]] \
+		&& _ev_file_contents="No file:line references found in issue body, or files not available locally"
+
+	printf -v "$merged_prs_var"     '%s' "$_ev_merged_prs"
+	printf -v "$recent_commits_var" '%s' "$_ev_recent_commits"
+	printf -v "$file_contents_var"  '%s' "$_ev_file_contents"
+	return 0
+}
+
+#######################################
 # Write the triage review prompt to a temp file.
 #
 # Caps issue comments at 8KB, fetches recent closed issues and git log,
@@ -432,6 +556,13 @@ _triage_write_prompt_file() {
 	if [[ -n "$is_pr" && -n "$repo_path" && -d "$repo_path" ]]; then
 		git_log_context=$(git -C "$repo_path" log --oneline -5 2>/dev/null) || git_log_context=""
 	fi
+
+	# t2886: Fetch evidence-verification data for file:line claim validation.
+	local evidence_merged_prs=""
+	local evidence_recent_commits=""
+	local evidence_file_contents=""
+	_triage_fetch_evidence_sections "$issue_body" "$issue_json" "$repo_slug" "$repo_path" \
+		"evidence_merged_prs" "evidence_recent_commits" "evidence_file_contents"
 
 	local prefetch_file=""
 	prefetch_file=$(mktemp)
@@ -507,6 +638,18 @@ ${recent_closed:-No recent closed issues}
 
 ### GIT_LOG
 ${git_log_context:-No git log available}
+
+### EVIDENCE_RECENT_MERGED_PRS
+<!-- prefetch:section=recent-merged-prs -->
+${evidence_merged_prs}
+
+### EVIDENCE_RECENT_COMMITS_ON_CITED_FILES
+<!-- prefetch:section=recent-commits-on-cited-files -->
+${evidence_recent_commits}
+
+### EVIDENCE_CITED_FILE_CONTENTS
+<!-- prefetch:section=cited-file-contents -->
+${evidence_file_contents}
 
 ---
 

--- a/.agents/scripts/tests/test-triage-prefetch-evidence.sh
+++ b/.agents/scripts/tests/test-triage-prefetch-evidence.sh
@@ -1,0 +1,326 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# t2886: Unit tests for evidence-verification prefetch sections added to
+# pulse-ancillary-dispatch.sh (_triage_fetch_evidence_sections +
+# the three new sections in _triage_write_prompt_file).
+#
+# What this guards:
+#   - _triage_fetch_evidence_sections populates merged-PRs variable from
+#     mocked gh pr list output.
+#   - _triage_fetch_evidence_sections populates recent-commits variable
+#     from mocked git log output.
+#   - _triage_fetch_evidence_sections populates file-contents variable
+#     from a fixture file at the cited line (±5-line window).
+#   - _triage_write_prompt_file includes all three
+#     <!-- prefetch:section=NAME --> markers in the output file.
+#   - Empty repo_path is handled gracefully (fallback messages used).
+#
+# Harness style: mocked gh/git, isolated HOME, fixture files.
+# Pattern from test-triage-output-shape.sh.
+
+set -euo pipefail
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+ORIGINAL_HOME="${HOME}"
+LOGFILE=""
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+	export HOME="${TEST_ROOT}/home"
+	mkdir -p "${HOME}/.aidevops/logs"
+	LOGFILE="${HOME}/.aidevops/logs/pulse-wrapper.log"
+	: >"$LOGFILE"
+	return 0
+}
+
+teardown_test_env() {
+	export HOME="${ORIGINAL_HOME}"
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+# Load _triage_fetch_evidence_sections and _triage_write_prompt_file from
+# the production file using awk extraction — same pattern as
+# test-triage-output-shape.sh.
+load_evidence_helpers() {
+	local src
+	local here
+	here=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+	src="${AIDEVOPS_SOURCE:-${here}/../pulse-ancillary-dispatch.sh}"
+	if [[ ! -f "$src" ]]; then
+		printf 'ERROR: cannot locate pulse-ancillary-dispatch.sh (tried %s)\n' \
+			"$src" >&2
+		exit 2
+	fi
+	# Extract from _triage_fetch_evidence_sections through the end of
+	# _triage_write_prompt_file, stopping before _build_triage_review_prompt.
+	local tmp
+	tmp=$(mktemp)
+	awk '
+	/^_triage_fetch_evidence_sections\(\) \{/{flag=1}
+	flag{print}
+	/^_build_triage_review_prompt\(\) \{/{flag=0}
+	' "$src" |
+		sed '/^_build_triage_review_prompt()/,$d' >"$tmp"
+	# shellcheck disable=SC1090
+	source "$tmp"
+	rm -f "$tmp"
+	return 0
+}
+
+# Stub gh_issue_list so _triage_write_prompt_file can fetch recent_closed
+# without real network access.
+# shellcheck disable=SC2317
+gh_issue_list() { printf 'Stub closed issue 1\nStub closed issue 2\n'; return 0; }
+export -f gh_issue_list
+
+# ------------------------------ Tests ------------------------------
+
+test_fetch_evidence_populates_merged_prs() {
+	setup_test_env
+
+	# Mock gh to return one merged PR matching the keyword search.
+	gh() {
+		case "${1:-}" in
+		pr)
+			case "${2:-}" in
+			list)
+				printf '#9001 fix: correct line count (merged: 2026-04-20T10:00:00Z)\n'
+				return 0
+				;;
+			esac
+			;;
+		esac
+		return 0
+	}
+	export -f gh
+
+	# Mock git (not needed for this test but export to avoid command-not-found)
+	git() { return 0; }
+	export -f git
+
+	load_evidence_helpers
+
+	local issue_json
+	issue_json='{"title":"fix line count logic","createdAt":"2026-04-01T00:00:00Z"}'
+	local issue_body="See scripts/foo.sh:42 for the problem."
+
+	local merged_prs="" recent_commits="" file_contents=""
+	_triage_fetch_evidence_sections \
+		"$issue_body" "$issue_json" "owner/repo" "" \
+		"merged_prs" "recent_commits" "file_contents"
+
+	if [[ "$merged_prs" == *"#9001"* && "$merged_prs" == *"fix: correct line count"* ]]; then
+		print_result \
+			"_triage_fetch_evidence_sections populates merged-PRs from gh output" 0
+	else
+		print_result \
+			"_triage_fetch_evidence_sections populates merged-PRs from gh output" 1 \
+			"merged_prs='$merged_prs'"
+	fi
+	teardown_test_env
+}
+
+test_fetch_evidence_populates_recent_commits() {
+	setup_test_env
+
+	gh() { return 0; }
+	export -f gh
+
+	# Create a fake repo directory with the fixture file
+	local fake_repo="${TEST_ROOT}/repo"
+	mkdir -p "${fake_repo}/scripts"
+	printf 'line1\nline2\nline3\nline4\nline5\nline6\nline7\n' \
+		>"${fake_repo}/scripts/foo.sh"
+
+	# Mock git to return a recent commit for the cited file when called
+	# as: git -C <repo_path> log --since=... --oneline -- <file>
+	git() {
+		case "${1:-}" in
+		-C)
+			shift  # -C
+			shift  # <repo_path>
+			if [[ "${1:-}" == "log" ]]; then
+				printf 'abc1234 fix: update foo.sh logic\n'
+				return 0
+			fi
+			;;
+		esac
+		return 0
+	}
+	export -f git
+
+	load_evidence_helpers
+
+	local issue_json
+	issue_json='{"title":"update foo logic","createdAt":"2026-04-01T00:00:00Z"}'
+	local issue_body="Issue at scripts/foo.sh:5"
+
+	local merged_prs="" recent_commits="" file_contents=""
+	_triage_fetch_evidence_sections \
+		"$issue_body" "$issue_json" "owner/repo" "$fake_repo" \
+		"merged_prs" "recent_commits" "file_contents"
+
+	if [[ "$recent_commits" == *"abc1234"* ]]; then
+		print_result \
+			"_triage_fetch_evidence_sections populates recent-commits from git log" 0
+	else
+		print_result \
+			"_triage_fetch_evidence_sections populates recent-commits from git log" 1 \
+			"recent_commits='$recent_commits'"
+	fi
+	teardown_test_env
+}
+
+test_fetch_evidence_populates_file_contents() {
+	setup_test_env
+
+	gh() { return 0; }
+	git() { return 0; }
+	export -f gh git
+
+	# Create a fake repo with a fixture file containing known content at
+	# line 5 ("epsilon") for verification
+	local fake_repo="${TEST_ROOT}/repo"
+	mkdir -p "${fake_repo}/scripts"
+	printf 'alpha\nbeta\ngamma\ndelta\nepsilon\nzeta\neta\ntheta\niota\nkappa\n' \
+		>"${fake_repo}/scripts/fixture.sh"
+
+	load_evidence_helpers
+
+	local issue_json
+	issue_json='{"title":"check fixture content","createdAt":"2026-04-01T00:00:00Z"}'
+	local issue_body="Problem at scripts/fixture.sh:5"
+
+	local merged_prs="" recent_commits="" file_contents=""
+	_triage_fetch_evidence_sections \
+		"$issue_body" "$issue_json" "owner/repo" "$fake_repo" \
+		"merged_prs" "recent_commits" "file_contents"
+
+	# Line 5 is "epsilon"; the ±5 window (lines 1-10) should include it.
+	if [[ "$file_contents" == *"epsilon"* && \
+		"$file_contents" == *"scripts/fixture.sh"* ]]; then
+		print_result \
+			"_triage_fetch_evidence_sections populates file-contents from fixture" 0
+	else
+		print_result \
+			"_triage_fetch_evidence_sections populates file-contents from fixture" 1 \
+			"file_contents='$file_contents'"
+	fi
+	teardown_test_env
+}
+
+test_prompt_file_contains_prefetch_markers() {
+	setup_test_env
+
+	# Stub all external calls needed by _triage_write_prompt_file
+	gh() { return 0; }
+	git() { return 0; }
+	export -f gh git
+
+	load_evidence_helpers
+
+	local issue_json
+	issue_json='{"title":"test markers","createdAt":"2026-04-01T00:00:00Z","number":1}'
+	local issue_body="Test issue body with no file refs."
+
+	local prompt_file
+	prompt_file=$(_triage_write_prompt_file \
+		"1" "owner/repo" "" "$issue_json" "$issue_body" "[]" "" "[]" "")
+
+	local ok=0
+	grep -q '<!-- prefetch:section=recent-merged-prs -->' \
+		"$prompt_file" || ok=1
+	grep -q '<!-- prefetch:section=recent-commits-on-cited-files -->' \
+		"$prompt_file" || ok=1
+	grep -q '<!-- prefetch:section=cited-file-contents -->' \
+		"$prompt_file" || ok=1
+
+	rm -f "$prompt_file"
+
+	if [[ "$ok" -eq 0 ]]; then
+		print_result \
+			"_triage_write_prompt_file includes all three prefetch section markers" 0
+	else
+		print_result \
+			"_triage_write_prompt_file includes all three prefetch section markers" 1 \
+			"one or more <!-- prefetch:section=NAME --> markers missing from prompt file"
+	fi
+	teardown_test_env
+}
+
+test_fetch_evidence_no_repo_path_graceful() {
+	setup_test_env
+
+	gh() { return 0; }
+	export -f gh
+
+	load_evidence_helpers
+
+	local issue_json
+	issue_json='{"title":"no repo path test","createdAt":"2026-04-01T00:00:00Z"}'
+	local issue_body="See scripts/foo.sh:10 for details."
+
+	local merged_prs="" recent_commits="" file_contents=""
+	# repo_path is empty — git and file operations must be skipped gracefully
+	_triage_fetch_evidence_sections \
+		"$issue_body" "$issue_json" "owner/repo" "" \
+		"merged_prs" "recent_commits" "file_contents"
+
+	if [[ "$recent_commits" == *"No recent commits"* && \
+		"$file_contents" == *"not available locally"* ]]; then
+		print_result \
+			"_triage_fetch_evidence_sections handles empty repo_path gracefully" 0
+	else
+		print_result \
+			"_triage_fetch_evidence_sections handles empty repo_path gracefully" 1 \
+			"recent_commits='$recent_commits' file_contents='$file_contents'"
+	fi
+	teardown_test_env
+}
+
+# ------------------------------ Main ------------------------------
+
+main() {
+	test_fetch_evidence_populates_merged_prs
+	test_fetch_evidence_populates_recent_commits
+	test_fetch_evidence_populates_file_contents
+	test_prompt_file_contains_prefetch_markers
+	test_fetch_evidence_no_repo_path_graceful
+
+	echo ""
+	echo "Results: ${TESTS_RUN} tests, $((TESTS_RUN - TESTS_FAILED)) passed, ${TESTS_FAILED} failed"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/.agents/workflows/review-issue-pr.md
+++ b/.agents/workflows/review-issue-pr.md
@@ -290,7 +290,7 @@ Accepted and queued for implementation as #{internal_issue}. We'll link back her
 
 > **Note (t1894):** Pulse-dispatched triage reviews now use the sandboxed `triage-review.md` agent which has NO Bash/network access. This file (`review-issue-pr.md`) is only used for interactive `/review-issue-pr` sessions where the user is present. The sandboxed agent receives all GitHub data pre-fetched by deterministic code.
 >
-> **Gap (t2017):** Section 0 (Pre-Review Discovery), Section 6 (Second-Order Effects), and the new output sections are currently only enforced in the interactive path. The sandboxed `triage-review.md` agent cannot run `gh pr list --state merged --search` or `git log --since` because it has no Bash/network. To bring the same discipline to pulse triage, the prefetch in `pulse-ancillary-dispatch.sh` must be extended to supply: (1) recent merged PRs matching the issue keywords, (2) recent commits on the affected files since the issue was posted, and (3) the current contents of those files at the cited line numbers. Tracked as a follow-up — see the companion issue created with this change.
+> **Closed by t2886 / GH#20987:** The prefetch in `pulse-ancillary-dispatch.sh` now supplies `EVIDENCE_RECENT_MERGED_PRS`, `EVIDENCE_RECENT_COMMITS_ON_CITED_FILES`, and `EVIDENCE_CITED_FILE_CONTENTS` — enabling the sandboxed `triage-review.md` agent to verify `file:line` claims and detect already-fixed issues without Bash or network access.
 
 When invoked by pulse (via `/review-issue-pr <number>`):
 

--- a/.agents/workflows/triage-review.md
+++ b/.agents/workflows/triage-review.md
@@ -52,6 +52,9 @@ The dispatcher builds a prompt that contains every field below under clearly mar
 - `PR_FILES`: JSON array of changed file paths
 - `RECENT_CLOSED`: Up to 15 recently closed issue titles (for duplicate detection)
 - `GIT_LOG`: Up to 5 recent commits on the affected files
+- `EVIDENCE_RECENT_MERGED_PRS`: Up to 5 recently merged PRs matching the issue title keywords — use to detect already-fixed issues (t2886)
+- `EVIDENCE_RECENT_COMMITS_ON_CITED_FILES`: Git log entries since issue was posted for each cited `file:line` — use to detect stale scan findings where the file changed after the report was generated (t2886)
+- `EVIDENCE_CITED_FILE_CONTENTS`: ±5-line window around each cited `file:line` — use to verify whether the issue's claim matches the actual code (t2886)
 
 ## Task
 
@@ -59,8 +62,9 @@ Analyze issue/PR using ONLY the pre-fetched context above. Do not explore the co
 
 ### For Issues
 
+0. **File:line evidence verification** (MANDATORY when `EVIDENCE_CITED_FILE_CONTENTS` is non-empty): For each `file:line` claim in `ISSUE_BODY`, locate the matching entry in `EVIDENCE_CITED_FILE_CONTENTS` and verify that the cited line matches the claimed finding. If the cited line does NOT match the claim (e.g. the line contains different code than the issue asserts, or the file reference is fabricated), mark the finding as **fabricated evidence** and recommend `invalid` closure. Do not accept a `file:line` claim that the evidence section falsifies.
 1. **Problem Validation**: Reproducible? Real bug or expected behavior?
-2. **Duplicate Check**: Compare against `RECENT_CLOSED` titles.
+2. **Duplicate Check**: Compare against `RECENT_CLOSED` titles AND `EVIDENCE_RECENT_MERGED_PRS` — if a matching merged PR exists, the issue may already be fixed.
 3. **Root Cause**: 1-3 sentences based only on the pre-fetched context.
 4. **Scope Assessment**: In scope for project?
 5. **Complexity**: Estimate `tier:simple` (haiku), `tier:standard` (sonnet), or `tier:thinking` (opus).


### PR DESCRIPTION
## Summary

Implements the unfiled t2017 follow-up promised in `review-issue-pr.md:293` — extends the pulse triage prefetch to supply evidence-verification data to the sandboxed `triage-review.md` agent, closing the gap where `file:line` claims could not be verified without Bash or network access.

## Changes

### `.agents/scripts/pulse-ancillary-dispatch.sh`
- New `_triage_fetch_evidence_sections()` private helper (called from `_triage_write_prompt_file`)
- Fetches three new sections appended to the prefetch heredoc:
  - `EVIDENCE_RECENT_MERGED_PRS` — `gh pr list --state merged` matching issue title keywords
  - `EVIDENCE_RECENT_COMMITS_ON_CITED_FILES` — `git log --since=<createdAt>` for each cited `file:line`
  - `EVIDENCE_CITED_FILE_CONTENTS` — `sed -n` ±5-line window around each cited line

### `.agents/workflows/triage-review.md`
- Documents three new input sections in "Input Format"
- Adds step 0 (MANDATORY): file:line evidence verification with explicit **fabricated evidence** / `invalid` closure wording

### `.agents/workflows/review-issue-pr.md`
- Replaces `> **Gap (t2017):**` at line 293 with `> **Closed by t2886 / GH#20987:**`

### `.agents/scripts/tests/test-triage-prefetch-evidence.sh` (new)
- 5 tests, all green: merged-PRs, recent-commits, file-contents, prompt markers, empty-repo-path graceful

## Verification

```
# All triage tests pass
.agents/scripts/tests/test-triage-prefetch-evidence.sh   → 5/5
.agents/scripts/tests/test-triage-output-shape.sh         → 12/12
.agents/scripts/tests/test-triage-failure-escalation.sh   → 8/8

# ShellCheck zero violations
shellcheck .agents/scripts/pulse-ancillary-dispatch.sh
shellcheck .agents/scripts/tests/test-triage-prefetch-evidence.sh

# Gap note gone
rg 'Gap \(t2017\)' .agents/workflows/  # no output

# Evidence wording present
rg 'fabricated evidence' .agents/workflows/triage-review.md  # AC3 confirmed
```

## Complexity Bump Justification

`_triage_write_prompt_file` grows by ~20 lines (6 code + 14 heredoc data lines), from ~112 to ~132 lines. The growth is:
- Fully in the data section (heredoc) — not logic
- Driven by the new `_triage_fetch_evidence_sections` helper (separate function, testable in isolation)
- The existing function was already above the 100-line gate; this PR adds no new cyclomatic complexity, only data volume

base=112 lines (pre-PR), head=132 lines (post-PR), new=20 data lines, 0 new branches.

Resolves #20987
For #20983

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.7 plugin for [OpenCode](https://opencode.ai) v1.14.25 with claude-sonnet-4-6 spent 19m and 54,406 tokens on this as a headless worker.
