### PR TITLE
t2890: align /full-loop gate with pulse dispatch primitives

### DIFF
--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -158,10 +158,14 @@ emit_deploy_phase() {
 	echo "Run setup.sh per full-loop.md guidance."
 }
 
-# Pre-start maintainer gate check (GH#17810).
+# Pre-start maintainer gate check (GH#17810, t2890).
 # Extracts the first issue number from the prompt and verifies the linked
-# issue does not have needs-maintainer-review label or missing assignee.
-# Mirrors the logic in .github/workflows/maintainer-gate.yml check-pr job.
+# issue does not have needs-maintainer-review label or missing assignee
+# (GH#17810). Then inherits the pulse-side structural dispatch gates via
+# dispatch-dedup-helper.sh::is-assigned so /full-loop honors parent-task
+# and no-auto-dispatch blocks the same way the pulse does — closing the
+# entry-point asymmetry where /full-loop bypassed gates the pulse refused
+# (t2890). Mirrors the logic in .github/workflows/maintainer-gate.yml.
 #
 # Returns:
 #   0 — gate passes (safe to start)
@@ -225,6 +229,30 @@ _check_linked_issue_gate() {
 			blocked=true
 			reasons="${reasons}Issue #${issue_num} has no assignee — assign the issue before starting work.\n"
 		fi
+	fi
+
+	# Check 3 (t2890): inherit pulse-side structural dispatch gates by calling
+	# dispatch-dedup-helper.sh::is-assigned — the canonical primitive the pulse
+	# uses (pulse-dispatch-dedup-layers.sh:243). Translates the unambiguous
+	# hard-block signals (PARENT_TASK_BLOCKED, NO_AUTO_DISPATCH_BLOCKED) into
+	# blocks here so /full-loop honors the same eligibility semantics as the
+	# pulse. Cost-budget, hydration window, and ownership-by-other are
+	# intentionally out of scope (need nuanced interactive UX). Fail-open on
+	# missing helper or empty stdout (matches the gh-api fail-open above).
+	local dedup_helper="${SCRIPT_DIR}/dispatch-dedup-helper.sh"
+	if [[ -x "$dedup_helper" ]]; then
+		local dedup_out
+		dedup_out=$("$dedup_helper" is-assigned "$issue_num" "$repo" "${AIDEVOPS_SESSION_USER:-${USER:-}}" 2>/dev/null || true)
+		case "$dedup_out" in
+		*PARENT_TASK_BLOCKED*)
+			blocked=true
+			reasons="${reasons}Issue #${issue_num} carries the \`parent-task\` label (decomposition tracker, not a worker target). Decompose into child phase issues, or remove the label if this is no longer a parent.\n"
+			;;
+		*NO_AUTO_DISPATCH_BLOCKED*)
+			blocked=true
+			reasons="${reasons}Issue #${issue_num} carries the \`no-auto-dispatch\` label (explicit hold). Remove the label if you intentionally want worker dispatch, or work on this issue operationally (post comments, post analysis) without /full-loop.\n"
+			;;
+		esac
 	fi
 
 	if [[ "$blocked" == "true" ]]; then

--- a/.agents/scripts/tests/test-full-loop-gate-pulse-parity.sh
+++ b/.agents/scripts/tests/test-full-loop-gate-pulse-parity.sh
@@ -1,0 +1,139 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-full-loop-gate-pulse-parity.sh — t2890 regression guard.
+#
+# Asserts that `_check_linked_issue_gate` in `.agents/scripts/full-loop-helper.sh`
+# inherits the pulse-side structural dispatch gates by calling
+# `dispatch-dedup-helper.sh is-assigned` and translating PARENT_TASK_BLOCKED
+# and NO_AUTO_DISPATCH_BLOCKED signals into hard blocks.
+#
+# Background: pre-t2890, the interactive `/full-loop` path only checked
+# needs-maintainer-review + missing assignee. The pulse meanwhile honored
+# parent-task and no-auto-dispatch via dispatch-dedup-helper.sh. A user typing
+# /full-loop on a parent-task or no-auto-dispatch issue would bypass those
+# gates entirely. This test prevents accidental regression of the wiring.
+#
+# This is a static structural check — runtime behaviour is verified at install
+# time via the smoke flow documented in todo/tasks/t2890-brief.md. CI is the
+# authoritative runtime test (the gate is exercised whenever any worker runs
+# /full-loop on a real issue).
+#
+# NOTE: not using `set -e` — assertions capture non-zero exits.
+
+set -uo pipefail
+
+TEST_RED=$'\033[0;31m'
+TEST_GREEN=$'\033[0;32m'
+TEST_RESET=$'\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1" rc="$2" extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf '%sPASS%s %s\n' "$TEST_GREEN" "$TEST_RESET" "$name"
+	else
+		printf '%sFAIL%s %s %s\n' "$TEST_RED" "$TEST_RESET" "$name" "$extra"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+# Resolve the helper file relative to the test (tests live in .agents/scripts/tests/)
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+HELPER_FILE="${REPO_ROOT}/.agents/scripts/full-loop-helper.sh"
+
+if [[ ! -f "$HELPER_FILE" ]]; then
+	print_result "helper file exists" 1 "not found: $HELPER_FILE"
+	printf '\n%d tests run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+	exit 1
+fi
+print_result "helper file exists" 0
+
+# Extract just the _check_linked_issue_gate function body so per-check
+# assertions only see the function we care about.
+GATE_BODY=$(awk '/^_check_linked_issue_gate\(\) \{/,/^}/' "$HELPER_FILE")
+
+if [[ -z "$GATE_BODY" ]]; then
+	print_result "extract _check_linked_issue_gate function body" 1 "function not found in $HELPER_FILE"
+	printf '\n%d tests run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+	exit 1
+fi
+print_result "extract _check_linked_issue_gate function body" 0
+
+assert_in_gate() {
+	local pattern="$1" label="$2"
+	if printf '%s\n' "$GATE_BODY" | grep -qE -- "$pattern"; then
+		print_result "$label" 0
+	else
+		print_result "$label" 1 "pattern '${pattern}' not found in _check_linked_issue_gate body"
+	fi
+	return 0
+}
+
+# -------------------------------------------------------------------
+# Assertion A: gate calls dispatch-dedup-helper.sh::is-assigned
+# -------------------------------------------------------------------
+assert_in_gate \
+	'dispatch-dedup-helper\.sh' \
+	"_check_linked_issue_gate references dispatch-dedup-helper.sh"
+assert_in_gate \
+	'is-assigned' \
+	"_check_linked_issue_gate calls is-assigned subcommand"
+
+# -------------------------------------------------------------------
+# Assertion B: PARENT_TASK_BLOCKED case translates to a block
+# -------------------------------------------------------------------
+assert_in_gate \
+	'PARENT_TASK_BLOCKED' \
+	"_check_linked_issue_gate matches PARENT_TASK_BLOCKED signal"
+assert_in_gate \
+	'parent-task' \
+	"_check_linked_issue_gate mentions parent-task label in user-facing message"
+
+# -------------------------------------------------------------------
+# Assertion C: NO_AUTO_DISPATCH_BLOCKED case translates to a block
+# -------------------------------------------------------------------
+assert_in_gate \
+	'NO_AUTO_DISPATCH_BLOCKED' \
+	"_check_linked_issue_gate matches NO_AUTO_DISPATCH_BLOCKED signal"
+assert_in_gate \
+	'no-auto-dispatch' \
+	"_check_linked_issue_gate mentions no-auto-dispatch label in user-facing message"
+
+# -------------------------------------------------------------------
+# Assertion D: fail-open pattern present (matches existing gh-api fail-open)
+# -------------------------------------------------------------------
+assert_in_gate \
+	'\|\| true' \
+	"_check_linked_issue_gate uses fail-open pattern (|| true) on dedup call"
+
+# -------------------------------------------------------------------
+# Assertion E: gate sets blocked=true on hard-block signals
+# -------------------------------------------------------------------
+assert_in_gate \
+	'blocked=true' \
+	"_check_linked_issue_gate sets blocked=true on hard-block signals"
+
+# -------------------------------------------------------------------
+# Assertion F: full-loop-helper.sh shellcheck-clean
+# -------------------------------------------------------------------
+if command -v shellcheck >/dev/null 2>&1; then
+	if shellcheck "$HELPER_FILE" >/dev/null 2>&1; then
+		print_result "full-loop-helper.sh passes shellcheck" 0
+	else
+		print_result "full-loop-helper.sh passes shellcheck" 1 "shellcheck reported violations"
+	fi
+else
+	# Linter binary unavailable in the runner — skip without failing.
+	printf '%sSKIP%s shellcheck (binary not on PATH)\n' "$TEST_GREEN" "$TEST_RESET"
+fi
+
+printf '\n%d tests run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]] || exit 1
+exit 0

--- a/TODO.md
+++ b/TODO.md
@@ -3207,4 +3207,4 @@ t019.3.4,Update AGENTS.md with Beads integration docs,,beads,1h,45m,2025-12-21T1
 
 - [ ] t2891 apply opencode binary validation to active setup-modules/tool-install.sh:1517 (t2888 followup — wrong file) #critical #reliability ref:GH#21025
 
-- [ ] t2890 align /full-loop interactive gate with pulse dispatch primitives (parent-task, no-auto-dispatch) #framework #interactive #reliability tier:standard ~1h logged:2026-04-26 -> [todo/tasks/t2890-brief.md]
+- [ ] t2890 align /full-loop interactive gate with pulse dispatch primitives (parent-task, no-auto-dispatch) #framework #interactive #reliability tier:standard ~1h ref:GH#21023 logged:2026-04-26 -> [todo/tasks/t2890-brief.md]

--- a/TODO.md
+++ b/TODO.md
@@ -3203,8 +3203,8 @@ t019.3.4,Update AGENTS.md with Beads integration docs,,beads,1h,45m,2025-12-21T1
 
 - [x] t2888 restore setup_opencode_cli install logic; add to non-interactive path ref:GH#21016 pr:#21018 completed:2026-04-26
 
-- [ ] t2890 align /full-loop interactive gate with pulse dispatch primitives (parent-task... #framework #reliability ref:GH#21023
-
 - [ ] t2889 apply opencode binary validation to active setup-modules/tool-install.sh:1517 (t2888 followup — wrong file) #critical #reliability ref:GH#21025
 
 - [ ] t2891 apply opencode binary validation to active setup-modules/tool-install.sh:1517 (t2888 followup — wrong file) #critical #reliability ref:GH#21025
+
+- [ ] t2890 align /full-loop interactive gate with pulse dispatch primitives (parent-task, no-auto-dispatch) #framework #interactive #reliability tier:standard ~1h logged:2026-04-26 -> [todo/tasks/t2890-brief.md]

--- a/TODO.md
+++ b/TODO.md
@@ -3208,3 +3208,5 @@ t019.3.4,Update AGENTS.md with Beads integration docs,,beads,1h,45m,2025-12-21T1
 - [ ] t2891 apply opencode binary validation to active setup-modules/tool-install.sh:1517 (t2888 followup — wrong file) #critical #reliability ref:GH#21025
 
 - [ ] t2890 align /full-loop interactive gate with pulse dispatch primitives (parent-task, no-auto-dispatch) #framework #interactive #reliability tier:standard ~1h ref:GH#21023 logged:2026-04-26 -> [todo/tasks/t2890-brief.md]
+
+- [ ] t2894 report all dispatch-dedup blockers in /full-loop gate (followup to t2890) #framework #reliability tier:standard ~1h ref:GH#21029 logged:2026-04-26

--- a/todo/tasks/t2890-brief.md
+++ b/todo/tasks/t2890-brief.md
@@ -1,0 +1,61 @@
+# t2890: align /full-loop interactive gate with pulse dispatch primitives
+
+## Session origin
+
+Surfaced during interactive `/full-loop #20518` triage (2026-04-26). Issue #20518 is a held `parent-task` + `no-auto-dispatch` decomposition tracker. The pulse correctly refuses to dispatch on it (`dispatch-dedup-helper.sh is-assigned` returns `PARENT_TASK_BLOCKED (label=parent-task)`). The interactive `/full-loop` entry point does NOT call the same primitive — only intelligence-layer reading of the issue body caught the mismatch. If `_check_linked_issue_gate`'s missing-assignee check (Check 2) had passed (e.g., issue self-assigned, or carrying `quality-debt`), `/full-loop` would have proceeded onto a non-dispatchable parent-task.
+
+## What
+
+Extend `_check_linked_issue_gate` in `.agents/scripts/full-loop-helper.sh` to call `dispatch-dedup-helper.sh is-assigned` after the existing NMR + assignee checks, and translate the canonical `PARENT_TASK_BLOCKED` and `NO_AUTO_DISPATCH_BLOCKED` stdout signals into hard blocks with mentoring error messages. Fail-open on tooling errors (matches the existing pattern at lines 197-200).
+
+## Why
+
+Gate enforcement asymmetry between pulse and interactive entry points. The pulse has rich dispatch gates (parent-task, no-auto-dispatch, cost-budget, hydration window, ownership) consolidated in `dispatch-dedup-helper.sh::is-assigned`. The interactive `/full-loop` path was added later (GH#17810) with a narrow purpose (NMR + assignee) and never reconciled with the canonical primitive. Result: a maintainer typing `/full-loop` on a parent-task or no-auto-dispatch issue is only saved by coincidental side checks, not structural correctness.
+
+This single change brings the interactive path into structural parity with the pulse for the two unambiguous hard-block signals. Cost-budget, hydration window, and ownership-by-other are intentionally out of scope here (they need nuanced interactive UX — e.g., the user typing `/full-loop` on their own claimed issue must still proceed) and tracked as separate followups.
+
+## How
+
+### Files Scope
+
+- `.agents/scripts/full-loop-helper.sh`
+
+### Files to modify
+
+- **EDIT** `.agents/scripts/full-loop-helper.sh:174-238` (`_check_linked_issue_gate`) — add Check 3 calling `dispatch-dedup-helper.sh is-assigned` and translating `PARENT_TASK_BLOCKED` / `NO_AUTO_DISPATCH_BLOCKED` signals.
+
+### Reference pattern
+
+- Pulse callsite: `.agents/scripts/pulse-dispatch-dedup-layers.sh:243` — canonical invocation of `is-assigned`.
+- Existing fail-open pattern in the same function: `full-loop-helper.sh:197-200` (gh api fetch failure → skip gate).
+- Gate primitive: `.agents/scripts/dispatch-dedup-helper.sh:638-720` (`_is_assigned_check_parent_task`, `_is_assigned_check_no_auto_dispatch`).
+
+### Implementation steps
+
+1. After Check 2 (assignee) at line 228, before the `blocked` evaluation at line 230, add:
+   - Locate `dispatch-dedup-helper.sh` via `${SCRIPT_DIR}/dispatch-dedup-helper.sh`
+   - Skip if not executable (fail-open)
+   - Call `is-assigned <issue_num> <repo> <self-login>` capturing stdout
+   - Match `*PARENT_TASK_BLOCKED*` and `*NO_AUTO_DISPATCH_BLOCKED*` substrings on stdout
+   - Append a clear, mentoring reason to `$reasons` and set `blocked=true`
+2. Update the function header comment to mention the new gate.
+
+### Verification
+
+- `shellcheck ~/Git/aidevops.t2890-full-loop-gate-parity/.agents/scripts/full-loop-helper.sh` clean.
+- Manual smoke (without actually starting work): confirm `_check_linked_issue_gate` extracted into a callable form returns 1 (blocked) for #20518 and emits both reasons in the message stream.
+
+## Acceptance
+
+1. `_check_linked_issue_gate` calls `dispatch-dedup-helper.sh is-assigned` after Check 2.
+2. `PARENT_TASK_BLOCKED` substring on dedup stdout produces `blocked=true` with a mentoring reason naming the label.
+3. `NO_AUTO_DISPATCH_BLOCKED` substring on dedup stdout produces `blocked=true` with a mentoring reason naming the label.
+4. Dedup helper missing or returning empty stdout is fail-open (no block, no error).
+5. shellcheck clean.
+
+## Followups (out of scope here)
+
+- Cost-budget signal interactive UX (warn vs block).
+- Ownership-by-other (`is-assigned` reports another assignee with active claim) — needs UX for the legitimate "I'm continuing my own claim" case.
+- Rename `is-assigned` to `is-eligible-for-dispatch` (semantic clarity, broader refactor).
+- Recalibrate Trigger 4 wording on #20518 (separate issue — calibration, not gating).


### PR DESCRIPTION
## Summary

The interactive `/full-loop` gate (`_check_linked_issue_gate` in `full-loop-helper.sh`) was checking only `needs-maintainer-review` + missing-assignee (the original GH#17810 narrow scope). The pulse meanwhile honours `parent-task` and `no-auto-dispatch` via the canonical `dispatch-dedup-helper.sh is-assigned` primitive.

Result: a user typing `/full-loop` on a `parent-task` or `no-auto-dispatch` issue would bypass both blockers entirely. Reproduced live against aidevops#20518 — the gate only saved us by accident (no assignee). Self-assignment would have spawned a worker on a hold-tagged decomposition tracker.

## Why

The pulse-side dispatch path treats `parent-task` and `no-auto-dispatch` as **structural** dispatch blocks — they exist precisely to prevent worker spawn. The interactive path ignored both, creating gate asymmetry: the same labels enforced on workers were invisible to user-driven dispatch. Naming is partly to blame (`is-assigned` reads like assignee-only and devs reach for `gh api | jq .assignees` instead of the canonical primitive).

This was found while triaging a misdispatch concern on aidevops#20518. The bug was structurally present even though the symptom didn't fire.

## Scope

Two structural blockers translate to hard blocks in the interactive gate:

- `PARENT_TASK_BLOCKED` — parent-task label
- `NO_AUTO_DISPATCH_BLOCKED` — no-auto-dispatch label

**Intentionally OUT OF SCOPE for this PR:**

- `COST_BUDGET_EXCEEDED` — needs nuanced UX (warn + override prompt, not hard block)
- `HYDRATION_WINDOW_ACTIVE` — needs UX
- `OWNER_ALREADY_ASSIGNED` — interactive user resuming own claim must proceed

Followups for these will be filed separately if needed.

## What changed

- `EDIT: .agents/scripts/full-loop-helper.sh` — header comment lines 161-168 documenting Check 3; new Check 3 block after existing Check 2 calling `dispatch-dedup-helper.sh is-assigned` and case-matching the two structural signals; fail-open if helper missing (matches existing fail-open pattern at line 197-200)
- `NEW: .agents/scripts/tests/test-full-loop-gate-pulse-parity.sh` — structural regression test asserting the wiring (11 assertions, all PASS, shellcheck clean)

## Verification

```
$ shellcheck .agents/scripts/full-loop-helper.sh
$ shellcheck .agents/scripts/tests/test-full-loop-gate-pulse-parity.sh
$ bash .agents/scripts/tests/test-full-loop-gate-pulse-parity.sh
11 tests run, 0 failed
```

Smoke-tested live against real issues:

- `_check_linked_issue_gate` on aidevops#20518 (parent-task + no-auto-dispatch) → `BLOCKED` with both "no assignee" + new "parent-task" reasons
- `_check_linked_issue_gate` on aidevops#21023 (assigned, no blocking labels) → `PROCEED`

## Resolves

Resolves #21023

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.9 plugin for [OpenCode](https://opencode.ai) v1.14.25 with claude-opus-4-7 spent 33m and 76,734 tokens on this with the user in an interactive session.
