### PR TITLE
t2891: add binary validator + auto-heal to active setup_opencode_cli (t2888 wrong-file followup)

### DIFF
--- a/.agents/scripts/tests/test-tool-install-opencode.sh
+++ b/.agents/scripts/tests/test-tool-install-opencode.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# t2891: Smoke test for the active setup_opencode_cli function in
+# setup-modules/tool-install.sh — the function that's actually sourced
+# by setup.sh (line 753), as opposed to the orphan stub in
+# .agents/scripts/setup/_services.sh that t2888 fixed.
+#
+# Strategy: source tool-install.sh in a sandbox, stub print_*, setup_prompt,
+# run_with_spinner, npm_global_install. Verify the validator + force-heal
+# logic without actually installing global packages.
+#
+# This complements .agents/scripts/tests/test-setup-opencode-cli.sh (t2888),
+# which tests the orphan _services.sh stub. Both must keep their validator
+# semantics in lockstep with t2887's headless-runtime-lib.sh::_validate_opencode_binary.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+TOOL_INSTALL="$REPO_ROOT/setup-modules/tool-install.sh"
+
+if [[ ! -f "$TOOL_INSTALL" ]]; then
+	echo "FAIL: cannot find $TOOL_INSTALL" >&2
+	exit 1
+fi
+
+SANDBOX="$(mktemp -d -t t2891-XXXXXX)"
+trap 'rm -rf "$SANDBOX"' EXIT
+
+mkdir -p "$SANDBOX/home" "$SANDBOX/bin" "$SANDBOX/npm-stub"
+export HOME="$SANDBOX/home"
+
+PASS=0
+FAIL=0
+
+assert_eq() {
+	local desc="$1" expected="$2" actual="$3"
+	if [[ "$expected" == "$actual" ]]; then
+		echo "  PASS: $desc"
+		PASS=$((PASS + 1))
+		return 0
+	fi
+	echo "  FAIL: $desc -- expected '$expected', got '$actual'" >&2
+	FAIL=$((FAIL + 1))
+	return 1
+}
+
+# Source tool-install.sh in a subshell with stubs. tool-install.sh is large
+# (~1900 lines) so we extract just the three relevant functions to avoid
+# pulling in unrelated dependencies.
+extract_functions() {
+	# Use awk to extract the three functions by name.
+	awk '
+		/^_setup_validate_opencode_binary\(\)/, /^}$/ { print; next }
+		/^_setup_opencode_force_heal\(\)/, /^}$/ { print; next }
+		/^setup_opencode_cli\(\)/, /^}$/ { print; next }
+	' "$TOOL_INSTALL" >"$SANDBOX/extract.sh"
+	# Verify extraction worked
+	if ! grep -q "^_setup_validate_opencode_binary()" "$SANDBOX/extract.sh"; then
+		echo "FAIL: extraction did not capture _setup_validate_opencode_binary" >&2
+		exit 1
+	fi
+	return 0
+}
+extract_functions
+
+source_extracted() {
+	# shellcheck disable=SC2317
+	print_info() { echo "INFO: $*"; return 0; }
+	# shellcheck disable=SC2317
+	print_success() { echo "OK: $*"; return 0; }
+	# shellcheck disable=SC2317
+	print_warning() { echo "WARN: $*"; return 0; }
+	# shellcheck disable=SC2317
+	setup_prompt() { local _var="$1" _prompt="$2" _default="$3"; eval "$_var='$_default'"; return 0; }
+	# shellcheck disable=SC2317
+	run_with_spinner() { shift; "$@"; return $?; }
+	# shellcheck disable=SC2317
+	npm_global_install() {
+		# Simulate install: drop a fake 'opencode' shim into the sandbox PATH
+		# that returns a real-shaped opencode version.
+		echo "[npm_global_install stub] $*" >&2
+		cat >"$SANDBOX/bin/opencode" <<'INNER_EOF'
+#!/usr/bin/env bash
+[[ "${1:-}" == "--version" ]] && echo "1.14.25"
+INNER_EOF
+		chmod +x "$SANDBOX/bin/opencode"
+		return 0
+	}
+	export -f print_info print_success print_warning setup_prompt run_with_spinner npm_global_install 2>/dev/null || true
+	# shellcheck disable=SC1090
+	source "$SANDBOX/extract.sh"
+	return 0
+}
+
+# --- Test 1: validator on real opencode ------------------------------------
+echo "Test 1: _setup_validate_opencode_binary on real opencode shim"
+cat >"$SANDBOX/bin/opencode-real" <<'EOF'
+#!/usr/bin/env bash
+[[ "${1:-}" == "--version" ]] && echo "1.14.25"
+EOF
+chmod +x "$SANDBOX/bin/opencode-real"
+(
+	source_extracted
+	rc=0
+	_setup_validate_opencode_binary "$SANDBOX/bin/opencode-real" || rc=$?
+	echo "$rc"
+) >"$SANDBOX/out1" 2>&1
+assert_eq "real opencode -> rc=0" "0" "$(tail -1 "$SANDBOX/out1")"
+
+# --- Test 2: validator on claude CLI shim ----------------------------------
+echo "Test 2: _setup_validate_opencode_binary on claude CLI shim"
+cat >"$SANDBOX/bin/opencode-claude" <<'EOF'
+#!/usr/bin/env bash
+[[ "${1:-}" == "--version" ]] && echo "2.1.119 (Claude Code)"
+EOF
+chmod +x "$SANDBOX/bin/opencode-claude"
+(
+	source_extracted
+	rc=0
+	_setup_validate_opencode_binary "$SANDBOX/bin/opencode-claude" || rc=$?
+	echo "$rc"
+) >"$SANDBOX/out2" 2>&1
+assert_eq "claude shim -> rc=1" "1" "$(tail -1 "$SANDBOX/out2")"
+
+# --- Test 3: validator on missing path -------------------------------------
+echo "Test 3: _setup_validate_opencode_binary on missing path"
+(
+	source_extracted
+	rc=0
+	_setup_validate_opencode_binary "$SANDBOX/bin/does-not-exist" || rc=$?
+	echo "$rc"
+) >"$SANDBOX/out3" 2>&1
+assert_eq "missing path -> rc=2" "2" "$(tail -1 "$SANDBOX/out3")"
+
+# --- Test 4: setup_opencode_cli skip when valid + persists path ------------
+echo "Test 4: setup_opencode_cli skip-when-valid path"
+rm -f "$HOME/.aidevops/.opencode-bin-resolved"
+cp "$SANDBOX/bin/opencode-real" "$SANDBOX/bin/opencode"
+(
+	source_extracted
+	export PATH="$SANDBOX/bin:$PATH"
+	rc=0
+	setup_opencode_cli || rc=$?
+	echo "rc=$rc"
+	cat "$HOME/.aidevops/.opencode-bin-resolved" 2>/dev/null || echo "MISSING"
+) >"$SANDBOX/out4" 2>&1
+rc4=$(grep '^rc=' "$SANDBOX/out4" | tail -1)
+resolved4=$(tail -1 "$SANDBOX/out4")
+assert_eq "skip-when-valid rc" "rc=0" "$rc4"
+assert_eq "skip-when-valid resolved-path file" "$SANDBOX/bin/opencode" "$resolved4"
+
+# --- Test 5: setup_opencode_cli auto-heal on wrong package -----------------
+# Critical t2891 path: when 'opencode' resolves to claude CLI (rc=1),
+# the function MUST trigger force-heal (calls npm_global_install) and
+# NOT return early like the pre-fix code did.
+echo "Test 5: setup_opencode_cli force-heal on claude CLI shim"
+rm -f "$HOME/.aidevops/.opencode-bin-resolved"
+cp "$SANDBOX/bin/opencode-claude" "$SANDBOX/bin/opencode"
+(
+	source_extracted
+	export PATH="$SANDBOX/bin:$PATH"
+	rc=0
+	setup_opencode_cli || rc=$?
+	echo "rc=$rc"
+) >"$SANDBOX/out5" 2>&1
+rc5=$(grep '^rc=' "$SANDBOX/out5" | tail -1)
+heal_warned=$(grep -c "wrong package" "$SANDBOX/out5" || true)
+heal_invoked=$(grep -c "npm_global_install stub" "$SANDBOX/out5" || true)
+post_heal_success=$(grep -c "OpenCode CLI:.*1\.14\.25" "$SANDBOX/out5" || true)
+assert_eq "force-heal rc" "rc=0" "$rc5"
+assert_eq "force-heal warned about wrong package" "1" "$heal_warned"
+assert_eq "force-heal invoked installer" "1" "$heal_invoked"
+assert_eq "post-heal validation success" "1" "$post_heal_success"
+
+# --- Test 6: post-heal persists resolved path ------------------------------
+echo "Test 6: post-heal persisted resolved path"
+[[ -f "$HOME/.aidevops/.opencode-bin-resolved" ]] && resolved6=$(cat "$HOME/.aidevops/.opencode-bin-resolved") || resolved6="MISSING"
+assert_eq "post-heal resolved-path file populated" "$SANDBOX/bin/opencode" "$resolved6"
+
+echo ""
+echo "===== Results: $PASS passed, $FAIL failed ====="
+[[ $FAIL -eq 0 ]] || exit 1
+exit 0

--- a/setup-modules/tool-install.sh
+++ b/setup-modules/tool-install.sh
@@ -1514,24 +1514,124 @@ setup_nodejs() {
 	return 0
 }
 
-setup_opencode_cli() {
-	print_info "Setting up OpenCode CLI..."
+# t2891: Validate that an opencode binary is real anomalyco/opencode.
+# Mirrors the t2887 runtime canary validator (headless-runtime-lib.sh) and
+# the t2888 setup module validator (.agents/scripts/setup/_services.sh).
+# Inlined to keep tool-install.sh self-contained — sourced from setup.sh
+# during early bootstrap before headless-runtime-lib.sh is on the path.
+# Returns: 0=valid, 1=wrong package (e.g. claude CLI), 2=missing/unrunnable.
+_setup_validate_opencode_binary() {
+	local bin="${1:-}"
+	[[ -n "$bin" ]] || return 2
+	command -v "$bin" >/dev/null 2>&1 || return 2
 
-	# Check if OpenCode is already installed
-	if command -v opencode >/dev/null 2>&1; then
-		local oc_version
-		oc_version=$(opencode --version 2>/dev/null | head -1 || echo "unknown")
-		print_success "OpenCode already installed: $oc_version"
+	local v
+	v=$("$bin" --version 2>/dev/null || echo "")
+	[[ -n "$v" ]] || return 2
+
+	# Anthropic claude CLI signature — highest-confidence rejection.
+	[[ "$v" == *"(Claude Code)"* ]] && return 1
+
+	# opencode is at 1.x; any 2.x+ is wrong (claude CLI is 2.1.x).
+	[[ "$v" =~ ^[2-9][0-9]*\. ]] && return 1
+
+	# Sanity: must look like a semver (X.Y.Z).
+	[[ "$v" =~ ^[0-9]+\.[0-9]+\.[0-9]+ ]] || return 1
+
+	return 0
+}
+
+# t2891: detect-and-heal when 'opencode' bin name is owned by a wrong
+# package (canonical case: @anthropic-ai/claude-code shadowing
+# anomalyco/opencode after a npm install collision). Auto-installs
+# without prompt because:
+#   1) it's healing a broken state, not first-time setup
+#   2) non-interactive runners (the canonical victim) would auto-Y anyway
+# Idempotent. Fail-open if no installer available.
+_setup_opencode_force_heal() {
+	local install_pkg="$1" wrong_bin="$2" wrong_v="$3"
+	print_warning "OpenCode binary at '$wrong_bin' is the wrong package ('$wrong_v')"
+	print_info "Forcing reinstall of $install_pkg to heal bin collision (t2891)..."
+
+	local installer=""
+	if command -v bun >/dev/null 2>&1; then
+		installer="bun"
+	elif command -v npm >/dev/null 2>&1; then
+		installer="npm"
+	else
+		print_warning "Neither bun nor npm found — cannot heal OpenCode binary"
+		print_info "Install Node.js or Bun first, then re-run 'aidevops update'"
 		return 0
 	fi
 
-	# Need either bun or npm to install
-	local installer=""
+	if run_with_spinner "Reinstalling OpenCode (heal)" npm_global_install "$install_pkg"; then
+		print_success "OpenCode reinstalled via $installer"
+	else
+		print_warning "Heal install failed via $installer"
+		print_info "Try manually: $installer install -g $install_pkg"
+	fi
+
+	# Re-validate post-heal.
+	local new_bin
+	new_bin=$(command -v opencode 2>/dev/null || echo "")
+	if [[ -n "$new_bin" ]] && _setup_validate_opencode_binary "$new_bin"; then
+		local new_v
+		new_v=$("$new_bin" --version 2>/dev/null | head -1 || echo "unknown")
+		print_success "OpenCode CLI: $new_bin ($new_v)"
+		mkdir -p "${HOME}/.aidevops" 2>/dev/null || true
+		printf '%s\n' "$new_bin" >"${HOME}/.aidevops/.opencode-bin-resolved" 2>/dev/null || true
+	else
+		local v_after
+		v_after=$("$new_bin" --version 2>/dev/null | head -1 || echo "<missing>")
+		print_warning "Post-heal validation still failing: '$new_bin' returns '$v_after'"
+		print_info "Check PATH: 'which -a opencode' — npm/bun global bin dir must come first"
+	fi
+	return 0
+}
+
+setup_opencode_cli() {
+	print_info "Setting up OpenCode CLI..."
+
 	# Respect OPENCODE_PINNED_VERSION from shared-constants.sh if sourced,
 	# otherwise fall back to latest.
 	local pin_ver="${OPENCODE_PINNED_VERSION:-latest}"
 	local install_pkg="opencode-ai@${pin_ver}"
 
+	# t2891: validate the resolved binary is anomalyco/opencode, not a
+	# wrong package (claude CLI etc) that took the 'opencode' bin name.
+	# Without this, alex-solovyev's runner — where command -v opencode
+	# resolves to @anthropic-ai/claude-code — silently passes through
+	# this function, leaving t2887's runtime canary to throttle the spam
+	# without ever healing the binary.
+	local current_bin
+	current_bin=$(command -v opencode 2>/dev/null || echo "")
+	local validate_rc=0
+	if [[ -n "$current_bin" ]]; then
+		_setup_validate_opencode_binary "$current_bin" || validate_rc=$?
+	else
+		validate_rc=2
+	fi
+
+	# Already valid → record + early return.
+	if [[ $validate_rc -eq 0 ]]; then
+		local oc_version
+		oc_version=$("$current_bin" --version 2>/dev/null | head -1 || echo "unknown")
+		print_success "OpenCode already installed: $oc_version"
+		mkdir -p "${HOME}/.aidevops" 2>/dev/null || true
+		printf '%s\n' "$current_bin" >"${HOME}/.aidevops/.opencode-bin-resolved" 2>/dev/null || true
+		return 0
+	fi
+
+	# Wrong package → auto-heal (no prompt).
+	if [[ $validate_rc -eq 1 ]]; then
+		local wrong_v
+		wrong_v=$("$current_bin" --version 2>/dev/null | head -1 || echo "<unknown>")
+		_setup_opencode_force_heal "$install_pkg" "$current_bin" "$wrong_v"
+		return 0
+	fi
+
+	# Missing → first-time install path (preserves prompt for interactive UX).
+	local installer=""
 	if command -v bun >/dev/null 2>&1; then
 		installer="bun"
 	elif command -v npm >/dev/null 2>&1; then
@@ -1551,6 +1651,14 @@ setup_opencode_cli() {
 	if [[ "$install_oc" =~ ^[Yy]?$ ]]; then
 		if run_with_spinner "Installing OpenCode" npm_global_install "$install_pkg"; then
 			print_success "OpenCode installed"
+
+			# Persist resolved path on first-time success too (t2891).
+			local new_bin
+			new_bin=$(command -v opencode 2>/dev/null || echo "")
+			if [[ -n "$new_bin" ]] && _setup_validate_opencode_binary "$new_bin"; then
+				mkdir -p "${HOME}/.aidevops" 2>/dev/null || true
+				printf '%s\n' "$new_bin" >"${HOME}/.aidevops/.opencode-bin-resolved" 2>/dev/null || true
+			fi
 
 			# Offer authentication
 			echo ""


### PR DESCRIPTION
## Summary

PR #21018 (t2888) restored install logic to `.agents/scripts/setup/_services.sh`, but discovery during local deployment verification revealed that file is **orphan code** — `setup.sh` sources `setup-modules/tool-install.sh` (line 753), not `.agents/scripts/setup/_services.sh`. The active `setup_opencode_cli` at `setup-modules/tool-install.sh:1517` still had the underlying bug: short-circuits on `command -v opencode` success without validating the binary is actually `anomalyco/opencode`.

On alex-solovyev's runner, `command -v opencode` resolves to `@anthropic-ai/claude-code` (`2.1.119 (Claude Code)`) — the function returns 0, leaving t2887's runtime canary to throttle the spam without ever healing.

This PR applies the t2888 logic to the **actual active code path**.

## How

- `setup-modules/tool-install.sh:1517-1683` — replace 54-line short-circuiting function with three sub-functions (all under the 100-line `function-complexity` gate):
  - `_setup_validate_opencode_binary` (20 lines) — validator mirroring t2887/t2888. rc=0 valid, rc=1 wrong package (Claude Code marker OR major>=2 OR non-semver), rc=2 missing.
  - `_setup_opencode_force_heal` (40 lines) — auto-installer for wrong-package case. No prompt (healing, not first-time). Re-validates post-heal, persists `~/.aidevops/.opencode-bin-resolved`.
  - `setup_opencode_cli` (87 lines) — orchestrator. validate -> rc=0 early return / rc=1 force-heal / rc=2 first-install (preserves existing `setup_prompt` UX).

- `.agents/scripts/tests/test-tool-install-opencode.sh` (NEW) — 10 smoke tests via function extraction.

## Verification

```
$ bash .agents/scripts/tests/test-tool-install-opencode.sh
===== Results: 10 passed, 0 failed =====
```

Post-merge, `aidevops update` on alex-solovyev's runner will detect the wrong-package binary and force-reinstall opencode-ai@latest, closing the detect-but-don't-heal loop t2887 exposed.

## Related

- t2887 PR #21001 — runtime canary fail-fast
- t2888 PR #21018 — orphan-file fix (harmless but ineffective for healing)
- This PR — the **actual** fix in the active code path

Resolves #21025

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.9 plugin for [OpenCode](https://opencode.ai) v1.14.25 with claude-opus-4-7 spent 11h 27m and 463,599 tokens on this with the user in an interactive session.
