### PR TITLE
t2892: anchor credential-scrub regex to word boundary

### DIFF
--- a/.agents/hooks/credential-transcript-scrub.py
+++ b/.agents/hooks/credential-transcript-scrub.py
@@ -47,8 +47,15 @@ import time
 # Regex mirrors shared-constants.sh scrub_credentials sed pattern exactly.
 # Group 1: token prefix family (one of the 9 families).
 # Suffix: 10+ alphanumeric / dash / underscore chars (token body).
+#
+# Word-boundary anchor `(?:^|(?<=[^A-Za-z0-9_-]))` prevents false positives
+# where a credential prefix appears mid-word — e.g. `task-failure-handler`
+# contains the literal `sk-failure-handler` (16 chars, matches the body) but
+# is NOT a credential. Without this anchor the regex corrupts identifiers
+# into `ta[redacted-credential]` and similar (see GH#21026 / t2892 for the
+# canonical incident on awardsapp/develop).
 CREDENTIAL_PATTERN = re.compile(
-    r"(sk-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}",
+    r"(?:^|(?<=[^A-Za-z0-9_-]))(sk-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}",
     re.ASCII,
 )
 

--- a/.agents/scripts/contributor-insight-helper.sh
+++ b/.agents/scripts/contributor-insight-helper.sh
@@ -86,7 +86,10 @@ sanitize_text() {
 	text=$(printf '%s' "$text" | sed -E 's|~/Git/[^ ]*|[local-path]|g')
 
 	# 3. Strip credential patterns (API keys, tokens)
-	text=$(printf '%s' "$text" | sed -E 's/(sk-|ghp_|gho_|ghs_|ghu_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}/[redacted-credential]/g')
+	# Word-boundary anchor — see shared-constants.sh::scrub_credentials for the
+	# t2892 rationale. Mid-word matches like `task-failure-handler` must not be
+	# corrupted into `ta[redacted-credential]`.
+	text=$(printf '%s' "$text" | sed -E 's/(^|[^A-Za-z0-9_-])(sk-|ghp_|gho_|ghs_|ghu_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}/\1[redacted-credential]/g')
 
 	# 4. Strip email addresses
 	text=$(printf '%s' "$text" | sed -E 's/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/[email]/g')

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -299,7 +299,13 @@ readonly TASK_SIBLING_NON_ACTIVE_STATES_SQL="'verified','cancelled','deployed','
 
 scrub_credentials() {
 	local text="$1"
-	printf '%s' "$text" | sed -E 's/(sk-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}/[redacted-credential]/g'
+	# Word-boundary anchor (^|non-word-char) prevents false positives where a
+	# credential prefix appears mid-word — e.g. `task-failure-handler` contains
+	# the literal `sk-failure-handler` (16 chars, matches `sk-[A-Za-z0-9_-]{10,}`)
+	# but is NOT a credential. macOS BSD sed has no `\b`, so we capture the
+	# preceding boundary character and restore it via \1 in the replacement.
+	# (t2892, GH#21026)
+	printf '%s' "$text" | sed -E 's/(^|[^A-Za-z0-9_-])(sk-|ghp_|gho_|ghs_|ghu_|github_pat_|glpat-|xoxb-|xoxp-)[A-Za-z0-9_-]{10,}/\1[redacted-credential]/g'
 	return 0
 }
 

--- a/.agents/scripts/tests/test-credential-sanitizer.sh
+++ b/.agents/scripts/tests/test-credential-sanitizer.sh
@@ -127,6 +127,52 @@ _assert_eq "no tokens → verbatim" \
 	"$(scrub_credentials "the quick brown fox")"
 
 echo ""
+echo "[test] scrub_credentials — word-boundary anchor (t2892, GH#21026)"
+# These strings contain literal credential prefixes (sk-, ghp_, etc.) embedded
+# inside identifiers, but are NOT credentials. Without the word-boundary
+# anchor in the regex, `task-failure-handler` matched the substring
+# `sk-failure-handler` (16-char body suffix passes the {10,} length gate)
+# and was corrupted to `ta[redacted-credential]` in tool output and
+# (more critically) in committed source files written by workers whose
+# tool stream was scrubbed before the worker read it.
+_assert_eq "task-failure-handler NOT scrubbed (mid-word sk-)" \
+	"./task-failure-handler" \
+	"$(scrub_credentials "./task-failure-handler")"
+
+_assert_eq "task-decompose-helper NOT scrubbed (mid-word sk-)" \
+	"task-decompose-helper.sh" \
+	"$(scrub_credentials "task-decompose-helper.sh")"
+
+_assert_eq "task-runner-helper NOT scrubbed (mid-word sk-)" \
+	"task-runner-helper.sh" \
+	"$(scrub_credentials "task-runner-helper.sh")"
+
+_assert_eq "task-id-collision-guard NOT scrubbed" \
+	"task-id-collision-guard.yml" \
+	"$(scrub_credentials "task-id-collision-guard.yml")"
+
+_assert_eq "agent-task-failure-handler id NOT scrubbed" \
+	"agent-task-failure-handler" \
+	"$(scrub_credentials "agent-task-failure-handler")"
+
+# Real credentials must still be redacted across boundary contexts.
+_assert_notcontains "real sk- at start-of-line still redacted" \
+	"sk-abcdefghij1234567890" \
+	"$(scrub_credentials "sk-abcdefghij1234567890")"
+
+_assert_notcontains "real ghp_ after space still redacted" \
+	"ghp_abcdefghij1234567890" \
+	"$(scrub_credentials "Bearer ghp_abcdefghij1234567890")"
+
+_assert_notcontains "real sk- after colon still redacted" \
+	"sk-abcdefghij1234567890" \
+	"$(scrub_credentials "key:sk-abcdefghij1234567890")"
+
+_assert_notcontains "real github_pat_ in URL query still redacted" \
+	"github_pat_abcdefghij1234567890" \
+	"$(scrub_credentials "https://example.com/?token=github_pat_abcdefghij1234567890")"
+
+echo ""
 printf '%d test(s), %d failure(s)\n' "$TESTS_RUN" "$TESTS_FAILED"
 if [[ "$TESTS_FAILED" -gt 0 ]]; then
 	exit 1

--- a/.agents/scripts/tests/test-credential-transcript-scrub.sh
+++ b/.agents/scripts/tests/test-credential-transcript-scrub.sh
@@ -197,6 +197,42 @@ fi
 assert_exit_zero "14. Malformed JSON exits 0 (fail-open)" \
 	"not-valid-json"
 
+# ── Word-boundary anchor regression (t2892, GH#21026) ──────────────────────
+
+printf '\n%s\n' "${TEST_BLUE}Word-boundary anchor (t2892)${TEST_NC}"
+
+# Without the word-boundary anchor `(?:^|(?<=[^A-Za-z0-9_-]))`, the regex
+# matches credential prefixes embedded inside identifiers. Canonical failure:
+# `task-failure-handler` matched the substring `sk-failure-handler`
+# (16-char body suffix passes the {10,} gate) and was rewritten to
+# `ta[redacted-credential]` — corrupting committed source on
+# awardsapp/develop and breaking 4 PRs (#3168, #3155, #3068, #2984).
+# The hook scrubs tool stream content fed to the model; the same regex bug
+# in `shared-constants.sh::scrub_credentials` corrupts source files at
+# write-time. All three locations must agree on the boundary anchor.
+
+assert_no_output "16. task-failure-handler NOT scrubbed (mid-word sk-)" \
+	'{"tool_response": "import { handler } from \"./task-failure-handler\""}'
+
+assert_no_output "17. task-decompose-helper NOT scrubbed (mid-word sk-)" \
+	'{"tool_response": "Calling task-decompose-helper.sh now"}'
+
+assert_no_output "18. agent-task-failure-handler id NOT scrubbed" \
+	'{"tool_response": "inngest function id: agent-task-failure-handler"}'
+
+assert_no_output "19. task-id-collision-guard NOT scrubbed" \
+	'{"tool_response": "workflow: task-id-collision-guard.yml"}'
+
+# Real credentials must still be redacted across boundary contexts.
+assert_redacted "20. real sk- after space still redacted (control)" \
+	'{"tool_response": "API key sk-abcdefghij1234567890 invalid"}'
+
+assert_redacted "21. real sk- at start of string still redacted" \
+	'{"tool_response": "sk-abcdefghij1234567890"}'
+
+assert_redacted "22. real ghp_ after colon still redacted" \
+	'{"tool_response": "token:ghp_abcdefghij1234567890"}'
+
 # ── Performance budget ─────────────────────────────────────────────────────
 
 printf '\n%s\n' "${TEST_BLUE}Performance (<5ms per 10KB)${TEST_NC}"


### PR DESCRIPTION

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.9 plugin for [OpenCode](https://opencode.ai) v1.14.25 with claude-opus-4-7 spent 48m and 83,785 tokens on this with the user in an interactive session.