### PR TITLE
t2895: add TODO entry for slow task-id-guard check-pr mode

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3210,3 +3210,5 @@ t019.3.4,Update AGENTS.md with Beads integration docs,,beads,1h,45m,2025-12-21T1
 - [x] t2890 align /full-loop interactive gate with pulse dispatch primitives (parent-task, no-auto-dispatch) #framework #interactive #reliability tier:standard ~1h ref:GH#21023 logged:2026-04-26 -> [todo/tasks/t2890-brief.md] pr:#21027 completed:2026-04-26
 
 - [ ] t2894 report all dispatch-dedup blockers in /full-loop gate (followup to t2890) #framework #reliability tier:standard ~1h ref:GH#21029 logged:2026-04-26
+
+- [ ] t2895 task-id-guard check-pr mode hangs on PRs with large merge commit sets #bug #framework #performance #auto-dispatch tier:standard ~2h ref:GH#21033 logged:2026-04-26


### PR DESCRIPTION
## Summary
- Add TODO.md entry for t2895 (issue #21033 already filed via REST due to GraphQL exhaustion)
- Planning-only entry; no code changes

For #21033


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.10 plugin for [OpenCode](https://opencode.ai) v1.14.25 with claude-opus-4-7 spent 50m and 69,156 tokens on this with the user in an interactive session.