### PR TITLE
t2895: bound task-id-guard check-pr scan range and cache subjects to prevent CI hang

### DIFF
--- a/.agents/hooks/task-id-collision-guard.sh
+++ b/.agents/hooks/task-id-collision-guard.sh
@@ -130,11 +130,12 @@ _resolve_current_counter() {
 # Falls back to the root commit.
 # ---------------------------------------------------------------------------
 _find_merge_base() {
-	local base=""
+	local base="" ref
 	# Try main first, then master
 	for branch in main master; do
-		if git rev-parse --verify "origin/${branch}" >/dev/null 2>&1; then
-			base=$(git merge-base HEAD "origin/${branch}" 2>/dev/null) && break
+		ref="origin/${branch}"
+		if git rev-parse --verify "$ref" >/dev/null 2>&1; then
+			base=$(git merge-base HEAD "$ref" 2>/dev/null) && break
 		elif git rev-parse --verify "$branch" >/dev/null 2>&1; then
 			base=$(git merge-base HEAD "$branch" 2>/dev/null) && break
 		fi
@@ -144,6 +145,93 @@ _find_merge_base() {
 		base=$(git rev-list --max-parents=0 HEAD 2>/dev/null | head -1)
 	fi
 	printf '%s' "$base"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Resolve the best ref for "the upstream default branch tip" for use as the
+# left-hand side of `git log A..HEAD`. Prefers origin/main, then origin/master,
+# then local main, then local master. Returns empty if none found.
+#
+# Used by _run_check_pr (t2895) to scope the commit list to the PR's unique
+# commits, excluding upstream commits brought in via a merge from main. This
+# is critical for performance when a PR has merged main to resolve conflicts —
+# the merge-base..HEAD range expands to include all commits between fork-point
+# and the new main tip, which can be hundreds of commits on long-lived branches.
+# ---------------------------------------------------------------------------
+_find_default_branch_ref() {
+	local branch ref
+	for branch in main master; do
+		ref="origin/${branch}"
+		if git rev-parse --verify "$ref" >/dev/null 2>&1; then
+			printf '%s' "$ref"
+			return 0
+		fi
+	done
+	for branch in main master; do
+		if git rev-parse --verify "$branch" >/dev/null 2>&1; then
+			printf '%s' "$branch"
+			return 0
+		fi
+	done
+	return 1
+}
+
+# ---------------------------------------------------------------------------
+# Subject caches (t2895 performance fix).
+#
+# When invoked in check-pr mode, _check_message is called per commit in the
+# PR range. Each call may trigger _branch_has_claim and _repo_has_claim, both
+# of which run `git log` against the same data set. Without caching, these
+# scans are repeated O(N_commits × M_tids) times — for a PR with 143 commits
+# brought in via a merge from main, this caused 21+ minute hangs in CI before
+# being cancelled (canonical: PR #20913).
+#
+# These caches are populated once per check-pr invocation and read by the
+# subject-list helpers below. Commit-msg hook mode does NOT populate these,
+# so its behavior is unchanged (single-commit scope, caching not worthwhile).
+# ---------------------------------------------------------------------------
+_TASK_ID_GUARD_BRANCH_SUBJECTS=""
+_TASK_ID_GUARD_BRANCH_SUBJECTS_HOT="0"
+_TASK_ID_GUARD_REPO_SUBJECTS=""
+_TASK_ID_GUARD_REPO_SUBJECTS_HOT="0"
+
+# Emit `git log --format='%s' BASE..HEAD` output, using the cache when hot.
+# Args:
+#   arg1 = base ref (e.g. merge-base SHA)
+_branch_subjects() {
+	local base="${1:-}"
+	if [[ "$_TASK_ID_GUARD_BRANCH_SUBJECTS_HOT" == "1" ]]; then
+		printf '%s' "$_TASK_ID_GUARD_BRANCH_SUBJECTS"
+		return 0
+	fi
+	[[ -n "$base" ]] && git log --format='%s' "${base}..HEAD" 2>/dev/null
+	return 0
+}
+
+# Emit `git log --all --format='%s'` output, using the cache when hot.
+_repo_subjects() {
+	if [[ "$_TASK_ID_GUARD_REPO_SUBJECTS_HOT" == "1" ]]; then
+		printf '%s' "$_TASK_ID_GUARD_REPO_SUBJECTS"
+		return 0
+	fi
+	git log --all --format='%s' 2>/dev/null
+	return 0
+}
+
+# Pre-populate both subject caches. Call once at entry of _run_check_pr so
+# subsequent _branch_has_claim / _repo_has_claim calls hit the cache instead
+# of forking git per (commit, t-ID) pair.
+# Args:
+#   arg1 = base ref for branch subjects (typically the merge-base SHA)
+_populate_check_pr_caches() {
+	local base="${1:-}"
+	if [[ -n "$base" ]]; then
+		_TASK_ID_GUARD_BRANCH_SUBJECTS=$(git log --format='%s' "${base}..HEAD" 2>/dev/null)
+		_TASK_ID_GUARD_BRANCH_SUBJECTS_HOT="1"
+	fi
+	_TASK_ID_GUARD_REPO_SUBJECTS=$(git log --all --format='%s' 2>/dev/null)
+	_TASK_ID_GUARD_REPO_SUBJECTS_HOT="1"
 	return 0
 }
 
@@ -172,8 +260,7 @@ _branch_has_claim() {
 		return 1
 	fi
 	# Look for an exact single-ID claim first.
-	if git log --format='%s' "${base}..HEAD" 2>/dev/null |
-		grep -qE "^chore: claim t0*${num}( |\$|\\[)"; then
+	if _branch_subjects "$base" | grep -qE "^chore: claim t0*${num}( |\$|\\[)"; then
 		return 0
 	fi
 	# Look for a range claim that covers num: chore: claim tA..tB
@@ -187,7 +274,7 @@ _branch_has_claim() {
 				return 0
 			fi
 		fi
-	done < <(git log --format='%s' "${base}..HEAD" 2>/dev/null)
+	done < <(_branch_subjects "$base")
 	return 1
 }
 
@@ -208,8 +295,7 @@ _repo_has_claim() {
 		return 1
 	fi
 	# Look for an exact single-ID claim first.
-	if git log --all --format='%s' 2>/dev/null |
-		grep -qE "^chore: claim t0*${num}( |\$|\\[)"; then
+	if _repo_subjects | grep -qE "^chore: claim t0*${num}( |\$|\\[)"; then
 		return 0
 	fi
 	# Look for a range claim that covers num: chore: claim tA..tB
@@ -223,7 +309,7 @@ _repo_has_claim() {
 				return 0
 			fi
 		fi
-	done < <(git log --all --format='%s' 2>/dev/null)
+	done < <(_repo_subjects)
 	return 1
 }
 
@@ -477,22 +563,51 @@ _run_check_pr() {
 		return 1
 	fi
 
-	local merge_base
-	merge_base=$(_find_merge_base)
-	_debug "Merge base for PR #${pr_number}: $merge_base"
-
-	if [[ -z "$merge_base" ]]; then
-		_warn "Could not determine merge base — fail-open"
-		return 0
+	# Resolve the upstream default-branch ref (origin/main, then origin/master,
+	# then local main/master). Use it as the left-hand side of `git log A..HEAD`
+	# to bound the scan to commits unique to the PR — excluding upstream
+	# commits brought in via a merge from main. This is the t2895 fix: a
+	# merge-from-main on a long-lived branch can pull in hundreds of upstream
+	# commits whose t-IDs were claimed via prior merged PRs; scanning all of
+	# them once was timing out CI at 21+ min (canonical: PR #20913).
+	#
+	# When neither origin/main nor a local main/master exists (rare — fork
+	# without remote, fresh clone with no upstream tracking), fall back to the
+	# merge-base of HEAD against the root commit. This preserves the prior
+	# behavior for that edge case.
+	local default_ref base
+	if default_ref=$(_find_default_branch_ref); then
+		base="$default_ref"
+		_debug "Using default-branch ref for PR scan range: $base"
+	else
+		base=$(_find_merge_base)
+		_debug "No default-branch ref found; falling back to merge-base: $base"
+		if [[ -z "$base" ]]; then
+			_warn "Could not determine PR scan base — fail-open"
+			return 0
+		fi
 	fi
 
-	# Get commits in the PR range
+	# Get commits unique to the branch, excluding merge commits via --no-merges.
+	# `git log A..B` already excludes commits reachable from A; combined with
+	# `--no-merges` we skip both upstream commits and the merge commit that
+	# brought them in. fixup!/squash! commits are handled by _check_message.
 	local commits
-	commits=$(git log "${merge_base}..HEAD" --format='%H' 2>/dev/null)
+	commits=$(git log --no-merges "${base}..HEAD" --format='%H' 2>/dev/null)
 	if [[ -z "$commits" ]]; then
 		_info "No commits in PR range — nothing to check"
 		return 0
 	fi
+
+	# Pre-populate subject caches once. _branch_has_claim and _repo_has_claim
+	# called from _check_message would otherwise fork `git log` per (commit,
+	# t-ID) pair, which is the actual cost driver behind the timeout. Compute
+	# the merge-base for the branch-subjects cache; this is independent of
+	# `base` above (which may be origin/main directly) — we want claims that
+	# live on the branch since fork-point, not since the current main tip.
+	local merge_base
+	merge_base=$(_find_merge_base)
+	_populate_check_pr_caches "$merge_base"
 
 	local total_violations=0
 	local commit_hash
@@ -505,9 +620,9 @@ _run_check_pr() {
 
 		_debug "Checking commit $commit_hash: $subject"
 
-		# Skip merge commits
-		if printf '%s' "$subject" | grep -qE '^(Merge|fixup!|squash!)'; then
-			_debug "Skipping merge/fixup/squash: $commit_hash"
+		# Skip fixup/squash commits (merges already excluded by --no-merges)
+		if printf '%s' "$subject" | grep -qE '^(fixup!|squash!)'; then
+			_debug "Skipping fixup/squash: $commit_hash"
 			continue
 		fi
 

--- a/.agents/hooks/task-id-collision-guard.sh
+++ b/.agents/hooks/task-id-collision-guard.sh
@@ -553,6 +553,40 @@ _run_hook() {
 }
 
 # ---------------------------------------------------------------------------
+# Check the PR title (and body, for cross-reference footers) for invented
+# t-IDs. Extracted from _run_check_pr (t2895) to keep that function under the
+# 100-line function-complexity gate.
+#
+# Strategy: concatenate PR title + PR body and run _check_message on the
+# combined string. The PR body typically contains the Resolves/Closes/Fixes
+# footer that supplies the cross-reference context, so title + body together
+# give _check_message everything it needs to distinguish a valid tNNN from
+# an invented one. Fail-open if gh is unavailable or the fetch fails.
+#
+# Returns 1 on violation, 0 otherwise (including fail-open paths).
+# ---------------------------------------------------------------------------
+_check_pr_title() {
+	local pr_number="$1"
+	if ! command -v gh >/dev/null 2>&1; then
+		_warn "gh not available — skipping PR title check (fail-open)"
+		return 0
+	fi
+	local pr_title pr_body pr_combined title_rc
+	pr_title=$(gh pr view "$pr_number" --json title --jq '.title' 2>/dev/null)
+	if [[ -z "$pr_title" ]]; then
+		_warn "Could not fetch PR #${pr_number} title via gh — skipping title check (fail-open)"
+		return 0
+	fi
+	pr_body=$(gh pr view "$pr_number" --json body --jq '.body' 2>/dev/null)
+	pr_combined="${pr_title}"$'\n\n'"${pr_body:-}"
+	_debug "Checking PR #${pr_number} title: $pr_title"
+	_check_message "$pr_combined" "PR #${pr_number} title: ${pr_title}"
+	title_rc=$?
+	[[ "$title_rc" -eq 1 ]] && printf '[task-id-guard][VIOLATION] PR #%s title references invented t-ID: %s\n' "$pr_number" "$pr_title" >&2
+	return "$title_rc"
+}
+
+# ---------------------------------------------------------------------------
 # CI mode: check-pr <PR_NUMBER>
 # Scans every commit in the PR range (merge-base..HEAD).
 # ---------------------------------------------------------------------------
@@ -635,35 +669,13 @@ _run_check_pr() {
 		fi
 	done <<<"$commits"
 
-	# Also check the PR title for invented t-IDs (GH#19987).
-	# Commits-only scanning misses the case where a worker opens a PR whose
-	# title advertises a tNNN that never appears in any commit subject or body
-	# and was never claimed via claim-task-id.sh.
-	#
-	# Strategy: concatenate PR title + PR body and run _check_message on the
-	# combined string. The PR body typically contains the Resolves/Closes/Fixes
-	# footer that supplies the cross-reference context, so title + body together
-	# give _check_message everything it needs to distinguish a valid tNNN from
-	# an invented one. Fail-open if gh is unavailable or the fetch fails.
-	if command -v gh >/dev/null 2>&1; then
-		local pr_title pr_body pr_combined title_rc
-		pr_title=$(gh pr view "$pr_number" --json title --jq '.title' 2>/dev/null)
-		if [[ -n "$pr_title" ]]; then
-			pr_body=$(gh pr view "$pr_number" --json body --jq '.body' 2>/dev/null)
-			pr_combined="${pr_title}"$'\n\n'"${pr_body:-}"
-			_debug "Checking PR #${pr_number} title: $pr_title"
-			_check_message "$pr_combined" "PR #${pr_number} title: ${pr_title}"
-			title_rc=$?
-			# Avoid a third nesting level (awk NEST depth gate); use [[ ]] &&
-			# one-liner instead of if/fi for the violation print.
-			[[ "$title_rc" -eq 1 ]] && printf '[task-id-guard][VIOLATION] PR #%s title references invented t-ID: %s\n' "$pr_number" "$pr_title" >&2
-			total_violations=$((total_violations + (title_rc == 1 ? 1 : 0)))
-		else
-			_warn "Could not fetch PR #${pr_number} title via gh — skipping title check (fail-open)"
-		fi
-	else
-		_warn "gh not available — skipping PR title check (fail-open)"
-	fi
+	# Also check the PR title for invented t-IDs (GH#19987). See
+	# _check_pr_title for the strategy. Extracted to keep _run_check_pr
+	# under the 100-line function-complexity gate (t2895).
+	local title_rc
+	_check_pr_title "$pr_number"
+	title_rc=$?
+	total_violations=$((total_violations + (title_rc == 1 ? 1 : 0)))
 
 	if [[ "$total_violations" -gt 0 ]]; then
 		printf '\n[task-id-guard][SUMMARY] %d violation(s) found in PR #%s\n' "$total_violations" "$pr_number" >&2

--- a/.agents/scripts/tests/test-task-id-collision-guard.sh
+++ b/.agents/scripts/tests/test-task-id-collision-guard.sh
@@ -4,7 +4,7 @@
 #
 # test-task-id-collision-guard.sh — Test harness for task-id-collision-guard.sh
 #
-# Covers all 14 acceptance criteria cases:
+# Covers all 16 acceptance criteria cases:
 #   1. Reject: t-ID > counter AND not in linked issue title
 #   2. Allow: t-ID ≤ counter (claimed)
 #   3. Allow: cross-reference confirmed via linked issue title
@@ -19,6 +19,8 @@
 #  12. Reject: Ref #NNN where linked issue title does NOT contain the t-ID (GH#19783)
 #  13. Reject: PR title tNNN not in any commit AND not confirmed via linked issue (GH#19987)
 #  14. Allow: PR title tNNN confirmed via PR body Resolves #NNN with matching issue title (GH#19987)
+#  15. Allow: t-ID ≤ counter when claimed in repo history (GH#20291)
+#  16. Allow: check-pr skips merge commits via --no-merges regardless of subject (t2895)
 
 set -u
 
@@ -789,10 +791,97 @@ EOF
 }
 
 # ---------------------------------------------------------------------------
+# Case 16: check-pr skips merge commits via --no-merges regardless of subject
+# (t2895 — the previous `^(Merge|fixup!|squash!)` subject-regex filter was
+# bypassed by custom merge subjects, e.g. "feat: pulled main into feature".
+# `--no-merges` filters structurally on commit topology, not subject text.)
+#
+# This is the canonical regression test for the t2895 perf fix. With the OLD
+# range (`merge-base..HEAD`) and the OLD subject filter:
+#   - merge commit with subject "feat: pull main (mentions t99999)" was scanned
+#   - t99999 > counter, no Resolves, no branch claim → REJECT
+# With the NEW range (`origin/main..HEAD --no-merges`):
+#   - merge commit excluded structurally, regardless of subject text
+#   - only the feature-branch commit is scanned (clean, no t-IDs) → ALLOW
+# ---------------------------------------------------------------------------
+test_check_pr_skips_merge_commits_via_no_merges() {
+	local name="case-16: check-pr skips merge commits via --no-merges (custom merge subject)"
+
+	local tmpdir
+	tmpdir=$(mktemp -d)
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir'" RETURN
+
+	# Base/origin repo with .task-counter=100
+	local base_repo="${tmpdir}/base"
+	mkdir -p "$base_repo"
+	git -C "$base_repo" init -q -b main
+	git -C "$base_repo" config user.email "test@test.local"
+	git -C "$base_repo" config user.name "Test"
+	git -C "$base_repo" config commit.gpgsign false
+	git -C "$base_repo" config tag.gpgsign false
+	printf '100' >"${base_repo}/.task-counter"
+	git -C "$base_repo" add .task-counter
+	git -C "$base_repo" commit -q -m "init: counter=100"
+
+	# Clone work_repo (origin/main = init)
+	local work_repo="${tmpdir}/work"
+	git clone -q "$base_repo" "$work_repo" 2>/dev/null
+	git -C "$work_repo" config user.email "test@test.local"
+	git -C "$work_repo" config user.name "Test"
+	git -C "$work_repo" config commit.gpgsign false
+	git -C "$work_repo" config tag.gpgsign false
+
+	# Feature branch off main
+	git -C "$work_repo" checkout -q -b feature/test-branch
+
+	# Clean feature commit (no t-IDs)
+	printf 'feature' >"${work_repo}/feature.txt"
+	git -C "$work_repo" add feature.txt
+	git -C "$work_repo" commit -q -m "feat: clean feature commit"
+
+	# Move main forward with an upstream commit (any subject, no invented IDs)
+	printf 'upstream' >"${base_repo}/upstream.txt"
+	git -C "$base_repo" add upstream.txt
+	git -C "$base_repo" commit -q -m "feat: upstream change"
+
+	# Fetch upstream commit into work_repo (updates origin/main)
+	git -C "$work_repo" fetch -q origin main
+
+	# Merge origin/main into feature with a CUSTOM SUBJECT containing an
+	# invented t-ID. The OLD subject-regex filter `^(Merge|fixup!|squash!)`
+	# does NOT match "feat: pull main..." and would scan this merge commit,
+	# finding t99999 in the subject and rejecting. The NEW `--no-merges`
+	# filter excludes it structurally regardless of subject text.
+	git -C "$work_repo" merge -q --no-ff \
+		-m "feat: pull main into feature (mentions t99999)" \
+		origin/main
+
+	# Stub gh to fail so PR title scan fails-open and doesn't affect the result
+	local fake_bin="${tmpdir}/bin"
+	mkdir -p "$fake_bin"
+	printf '#!/usr/bin/env bash\nexit 1\n' >"${fake_bin}/gh"
+	chmod +x "${fake_bin}/gh"
+
+	local rc
+	PATH="${fake_bin}:$PATH" \
+		GIT_DIR="${work_repo}/.git" \
+		bash "$GUARD" check-pr 9999 2>/dev/null
+	rc=$?
+
+	if [[ "$rc" -eq 0 ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected exit 0 (merge commit excluded by --no-merges regardless of subject text), got $rc"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
 main() {
-	printf 'Running ta[redacted-credential] tests...\n\n'
+	printf 'Running task-id-collision-guard tests...\n\n'
 
 	test_rejects_invented_tid
 	test_allows_claimed_tid
@@ -809,6 +898,7 @@ main() {
 	test_check_pr_rejects_invented_tid_in_title
 	test_check_pr_allows_pr_title_tid_confirmed_via_body
 	test_repo_wide_claim_in_prose
+	test_check_pr_skips_merge_commits_via_no_merges
 
 	printf '\n'
 	printf 'Results: %s passed, %s failed\n' "$PASS" "$FAIL"

--- a/.github/workflows/task-id-collision-check.yml
+++ b/.github/workflows/task-id-collision-check.yml
@@ -17,6 +17,11 @@ on:
       - 'CHANGELOG.md'
   pull_request:
     branches: [main]
+    paths-ignore:
+      - 'TODO.md'
+      - 'todo/**'
+      - 'README.md'
+      - 'CHANGELOG.md'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
@@ -26,6 +31,12 @@ jobs:
   task-id-collision-check:
     name: Task-ID Collision Guard
     runs-on: ubuntu-latest
+    # Belt: cap the job at 5 minutes. Healthy runs complete in 16-52s on
+    # small PRs; the t2895 fix bounds the scan range to commits unique to
+    # the branch (excluding upstream commits brought in by merges from main).
+    # If a regression slips through, the cap surfaces it as a CI failure
+    # instead of a 21+ minute hang that has to be cancelled by hand.
+    timeout-minutes: 5
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

- `check-pr` mode used `merge_base..HEAD` which on PRs that merged main expanded to hundreds of upstream commits, scanning each via two unbounded `git log --all` invocations per t-ID per commit (PR #20913 hung 21:26 on run 24938392490 vs 16-52s baseline).
- Switch the commit-list range to `origin/<default>..HEAD --no-merges` (with merge-base fallback when no default ref is available). This restricts the scan to commits unique to the PR head.
- Add per-invocation subject caches populated once at `_run_check_pr` entry: `git log --all --format=%s` and `git log <merge-base>..HEAD --format=%s`. `_repo_has_claim` and `_branch_has_claim` consult the caches via cache-or-miss helpers; commit-msg hook mode keeps the original direct `git log` path (no caching cost).
- `_branch_has_claim` retains its `merge-base..HEAD` semantics so "claimed on this branch" checks remain correct even when check-pr scans a narrower range.
- Workflow gains `timeout-minutes: 5` plus `paths-ignore` on `pull_request` mirroring the existing `push` allowlist (skips docs-only/TODO-only PRs).
- Refactor `_find_merge_base` and `_find_default_branch_ref` to extract the `"origin/${branch}"` literal into a local `ref` var, satisfying the repeated-string-literal ratchet.
- Extract PR-title check from `_run_check_pr` into `_check_pr_title` so the function stays under the 100-line `function-complexity` gate.

Resolves #21033

## Files Changed

`.agents/hooks/task-id-collision-guard.sh`, `.agents/scripts/tests/test-task-id-collision-guard.sh`, `.github/workflows/task-id-collision-check.yml`

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts).
- `shellcheck .agents/hooks/task-id-collision-guard.sh` — clean.
- `.agents/scripts/tests/test-task-id-collision-guard.sh` — 16/16 pass, including the new case-16 regression covering `--no-merges` skipping a merge commit whose subject does **not** match the prior `^(Merge|fixup!|squash!)` filter (e.g. a custom-subject merge that mentions an unclaimed task-ID reference).
- Repeated string literal `"origin/${branch}"` count in the modified hook: 2 (down from 4), below the ratchet threshold.
- `_run_check_pr` body length: 95 lines after the `_check_pr_title` extraction (was 117 before; threshold 100).

## Decisions

- Range: `origin/<default>..HEAD --no-merges` rather than `merge_base..HEAD`. Excludes upstream commits brought in by a merge-from-main and skips merge commits regardless of subject pattern.
- Caching scoped to `_run_check_pr` only — the commit-msg hook is per-commit and short, so the cache-population cost would be net negative there. Cache-miss fallback in `_repo_has_claim` / `_branch_has_claim` preserves the original behaviour for hook callers.
- `_branch_has_claim` cache key intentionally keyed on `merge-base..HEAD` to keep "claims established on this branch" semantics; using the new check-pr range would weaken claim recognition on long-lived branches that pulled main.
- Workflow `paths-ignore` mirrors the `push` allowlist exactly so docs-only PRs short-circuit before the scan; `timeout-minutes: 5` is a backstop in case a future regression reintroduces unbounded scanning.
- `_find_merge_base` / `_find_default_branch_ref` refactor is purely textual — extracting `"origin/${branch}"` into a local `ref` var preserves bash 3.2 semantics and shellcheck cleanliness while satisfying the repeated-literal ratchet.
- `_check_pr_title` extraction was forced by the function-complexity gate (>100 lines). The helper has a single caller and is `#region`-style — purely a readability split rather than an API change.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.11 plugin for [OpenCode](https://opencode.ai) v1.14.25 with claude-opus-4-7 spent 33m and 105,933 tokens on this with the user in an interactive session.
