### PR TITLE
chore(planning): worker productivity fixes (t2899-t2902)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3216,3 +3216,11 @@ t019.3.4,Update AGENTS.md with Beads integration docs,,beads,1h,45m,2025-12-21T1
 - [x] t2893 harness gh signature-gate JS hook errors with misleading message when --body-file is created in same bash call #bug #enhancement #framework ref:GH#21030 pr:#21032 completed:2026-04-26
 
 - [ ] t2892 credential-scrub regex lacks word-boundary anchor — corrupts identifiers like ta[redacted-credential] / task-decompose / task-runner when worker output writes to disk; actively damaging code in awardsapp/develop #bug #framework #priority:high #security ref:GH#21026
+
+- [ ] t2899 fix branch_orphan false-positive: workers complete on main, work discarded (90% rate, 31/24h) #bug #framework #priority:high #worker-lifecycle #parent #interactive ref:GH#21040 logged:2026-04-26
+
+- [ ] t2900 eliminate SQLite database lock errors during concurrent worker startup (100% of workers) #bug #framework #priority:high #worker-lifecycle #interactive ref:GH#21041 logged:2026-04-26 blocked-by:t2899
+
+- [ ] t2901 reduce pulse cycle duration below launchd interval to stop cascading skips and force-kills (25-30min cycle vs 3min interval) #bug #framework #priority:high #pulse #parent #interactive ref:GH#21042 logged:2026-04-26
+
+- [ ] t2902 stop recurring GraphQL budget exhaustion despite REST fallback (11 circuit fires/24h) #bug #framework #priority:high #pulse #interactive ref:GH#21043 logged:2026-04-26


### PR DESCRIPTION
## Summary

Files 4 GH issues with worker-ready briefs covering the bottlenecks killing throughput today, plus their TODO entries. Also documents the immediate operational mitigations applied this session.

## Filed issues

| Task | Issue | Symptom | 24h evidence |
|---|---|---|---|
| t2899 | #21040 | branch_orphan false-positive — workers complete on main, run discarded | 9/10 workers, 31 fires |
| t2900 | #21041 | SQLite lock during concurrent worker startup | 10/10 workers |
| t2901 | #21042 | Pulse cycle 25-30min vs launchd 3min interval | 162 skip events, 12 force-kills |
| t2902 | #21043 | GraphQL exhaustion despite REST fallback (t2574, t2689) | 11 circuit fires |

All four touch dispatch-path code (`.agents/configs/self-hosting-files.conf`), so they are filed `no-auto-dispatch` per t2821.

## Operational mitigations applied this session

1. Released 16 dead claim stamps (t2840-knowledge-planes-mvp series, #20895-20912 + #21026) — these were blocking pulse dispatch on those issues. `interactive-session-helper.sh scan-stale --auto-release`.
2. Migrated `~/.config/aidevops/dispatch-override.conf` from TIER 3 legacy `DISPATCH_CLAIM_IGNORE_RUNNERS` to TIER 1 structured `DISPATCH_OVERRIDE_ALEX_SOLOVYEV="honour-only-above:3.10.0"` so the override auto-sunsets when the peer upgrades. Legacy line retained as belt-and-braces during transition.

## What this PR does NOT do

Planning-only PR — does NOT close the linked issues. Implementation lands in separate per-issue PRs after maintainer review of the briefs. Uses `For #NNNN` (not `Resolves`) so the linkage shows in the sidebar without auto-closing.

## Footnotes

For #21040
For #21041
For #21042
For #21043
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.11 plugin for [OpenCode](https://opencode.ai) v1.14.25 with claude-opus-4-7 spent 14m and 49,636 tokens on this as a headless worker.