### PR TITLE
t2899: fix branch_orphan false-positive when worker exits on default branch

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -1156,17 +1156,38 @@ _worker_produced_output() {
 	fi
 
 	# Signal 2: branch pushed to remote
+	# Default-branch guard (t2899): when HEAD ends on the repo's default branch
+	# (main/master), Signal 2 ALWAYS matches because the default branch exists
+	# on the remote — every worker that exits without checking out a feature
+	# branch was previously misclassified as branch_orphan. Resolve the default
+	# branch via origin/HEAD symbolic-ref (with env + literal fallback) and skip
+	# Signal 2 entirely when branch_name matches it. The signal is meaningless
+	# on default branches: there is no orphan branch to recover.
 	local has_pushed_branch=0
 	local branch_name=""
+	local default_branch=""
 	branch_name=$(git -C "$work_dir" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
-	if [[ -n "$branch_name" && "$branch_name" != "HEAD" ]]; then
+	default_branch=$(git -C "$work_dir" symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null \
+		| sed 's|^origin/||' || true)
+	[[ -z "$default_branch" ]] && default_branch="${DISPATCH_REPO_DEFAULT_BRANCH:-main}"
+	if [[ -n "$branch_name" && "$branch_name" != "HEAD" && "$branch_name" != "$default_branch" ]]; then
 		local remote_ref=""
 		remote_ref=$(git -C "$work_dir" ls-remote origin "refs/heads/$branch_name" 2>/dev/null || true)
 		[[ -n "$remote_ref" ]] && has_pushed_branch=1
 	fi
 
 	# Early exit: no commits, no pushed branch → definitely noop (no PR check needed)
+	# Also covers the t2899 default-branch case: HEAD on main with no/any commits
+	# but no feature branch pushed → noop, not branch_orphan.
 	if [[ "$has_commits" -eq 0 && "$has_pushed_branch" -eq 0 ]]; then
+		printf 'noop'
+		return 0
+	fi
+	# t2899: HEAD on default branch with commits ahead but no feature branch pushed.
+	# This is "worker landed on main with local commits" — not an orphan branch.
+	# Without a feature branch to recover, Signal 1 alone cannot produce a meaningful
+	# branch_orphan classification, so collapse to noop.
+	if [[ "$has_pushed_branch" -eq 0 && "$branch_name" == "$default_branch" ]]; then
 		printf 'noop'
 		return 0
 	fi
@@ -1252,7 +1273,24 @@ _handle_worker_branch_orphan() {
 	local issue_number=""
 	issue_number=$(printf '%s' "$session_key" | grep -oE '[0-9]+$' || true)
 
-	print_info "[lifecycle] worker_branch_orphan session=${session_key} branch=${branch_name:-<none>}"
+	# t2899: extended diagnostic — surface what the worker actually produced so
+	# the next regression in this classifier is debuggable from a single log line.
+	# target_branch is the branch the worker was DISPATCHED to operate on
+	# (set by the dispatch path via WORKER_TARGET_BRANCH env if present);
+	# final_head is the HEAD SHA the worker exited on; ahead_count is commits
+	# ahead of origin/main (or origin/master); work_dir is the worktree path.
+	local target_branch="${WORKER_TARGET_BRANCH:-<unset>}"
+	local final_head=""
+	final_head=$(git -C "$work_dir" rev-parse --short=12 HEAD 2>/dev/null || printf '<unreadable>')
+	local ahead_count=0
+	ahead_count=$(git -C "$work_dir" rev-list --count "origin/main..HEAD" 2>/dev/null || true)
+	[[ "$ahead_count" =~ ^[0-9]+$ ]] || ahead_count=0
+	if [[ "$ahead_count" -eq 0 ]]; then
+		ahead_count=$(git -C "$work_dir" rev-list --count "origin/master..HEAD" 2>/dev/null || true)
+		[[ "$ahead_count" =~ ^[0-9]+$ ]] || ahead_count=0
+	fi
+
+	print_info "[lifecycle] worker_branch_orphan session=${session_key} branch=${branch_name:-<none>} target_branch=${target_branch} final_head=${final_head} ahead_count=${ahead_count} work_dir=${work_dir:-<unset>}"
 
 	# Always increment counter — failure or success
 	_increment_orphan_count_stat

--- a/.agents/scripts/tests/test-worker-output-classification.sh
+++ b/.agents/scripts/tests/test-worker-output-classification.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-worker-output-classification.sh — Regression tests for
+# `_worker_produced_output` in headless-runtime-helper.sh (t2899).
+#
+# Background: workers were misclassified as `worker_branch_orphan` when their
+# final HEAD ended up on the default branch (main). Signal 2 of the
+# classifier ("branch pushed to remote") ALWAYS matched on main because main
+# exists on origin — so any worker that exited on main with no feature
+# branch and no PR got reclassified as an orphan and its output discarded.
+#
+# This test pins the four canonical classification outcomes against the
+# default-branch guard so the next regression in this hot path is caught
+# before it reaches production.
+#
+# Cases (all share: session_key=issue-NNN, work_dir is a synthetic git repo
+# with origin set, gh stubbed):
+#
+#   1. branch=main, ahead=0, no PR → noop
+#      (Worker exited on main with nothing to ship.)
+#
+#   2. branch=main, ahead=N, no PR → noop  [default-branch guard, t2899]
+#      (Worker landed on main with local commits but no feature branch.
+#      Pre-fix behaviour: branch_orphan. Post-fix: noop, because there is
+#      no orphan branch — Signal 2 must NOT fire on the default branch.)
+#
+#   3. branch=feature/tNNN-foo, ahead=N, no PR → branch_orphan
+#      (Legitimate orphan: feature branch pushed but no PR opened. This is
+#      the case the orphan-recovery PR machinery was designed for and must
+#      survive the t2899 guard untouched.)
+#
+#   4. branch=feature/tNNN-foo, ahead=N, PR exists → pr_exists
+#      (Normal worker completion. Signal 3 short-circuits to pr_exists.)
+#
+# `gh` is stubbed via PATH to return a controllable PR-list count without
+# touching the network. `git` is real — each case spins up its own
+# disposable origin+clone pair so the classifier sees authentic refs.
+
+set -uo pipefail
+
+TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)" || exit 1
+HELPER_SCRIPT="${TEST_SCRIPTS_DIR}/headless-runtime-helper.sh"
+
+TEST_RED=$'\033[0;31m'
+TEST_GREEN=$'\033[0;32m'
+TEST_RESET=$'\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1"
+	local rc="$2"
+	local extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf '%sPASS%s %s\n' "$TEST_GREEN" "$TEST_RESET" "$name"
+	else
+		printf '%sFAIL%s %s%s\n' "$TEST_RED" "$TEST_RESET" "$name" "${extra:+ — $extra}"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+# -----------------------------------------------------------------------------
+# Sandbox setup
+# -----------------------------------------------------------------------------
+
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+ORIGINAL_HOME="$HOME"
+export HOME="${TEST_ROOT}/home"
+mkdir -p "${HOME}/.aidevops/logs"
+
+# Stub `gh`. The classifier's Signal 3 calls:
+#   gh pr list --repo <slug> --search <issue> --json number --jq 'length'
+# We control the returned count via STUB_PR_COUNT (default 0).
+GH_STUB_DIR="${TEST_ROOT}/stubs"
+mkdir -p "$GH_STUB_DIR"
+cat >"${GH_STUB_DIR}/gh" <<'STUB'
+#!/usr/bin/env bash
+# Minimal stub: `gh pr list ... --jq 'length'` returns ${STUB_PR_COUNT:-0}.
+# Other invocations exit 0 silently so source-time `gh api user` calls
+# from sourced helpers don't crash the test.
+case "${1:-}" in
+	pr)
+		case "${2:-}" in
+			list) printf '%s\n' "${STUB_PR_COUNT:-0}" ;;
+			*) ;;
+		esac
+		;;
+	api)
+		# `_gh_wrapper_auto_sig` and friends call `gh api user --jq .login`.
+		# Emit a JSON object so callers that consume stdout don't break.
+		printf '{}\n'
+		;;
+	*) ;;
+esac
+exit 0
+STUB
+chmod +x "${GH_STUB_DIR}/gh"
+export PATH="${GH_STUB_DIR}:${PATH}"
+
+# Source the helper. set -e is disabled while sourcing so transient command
+# failures (auth checks, optional helper presence) don't abort the test.
+set +e
+# shellcheck source=/dev/null
+source "$HELPER_SCRIPT" >/dev/null 2>&1
+SOURCE_RC=$?
+set -e
+if [[ "$SOURCE_RC" -ne 0 ]]; then
+	# Soft-fail: many test machines lack the runtime deps the helper sources.
+	# The function under test is self-contained — try to source again with
+	# errors visible if the function itself is unreachable.
+	if ! declare -F _worker_produced_output >/dev/null 2>&1; then
+		printf '%sFAIL%s sourcing %s — _worker_produced_output not defined\n' \
+			"$TEST_RED" "$TEST_RESET" "$HELPER_SCRIPT"
+		exit 1
+	fi
+fi
+
+# Confirm function is now reachable.
+if ! declare -F _worker_produced_output >/dev/null 2>&1; then
+	printf '%sFAIL%s _worker_produced_output not defined after source\n' \
+		"$TEST_RED" "$TEST_RESET"
+	exit 1
+fi
+
+# -----------------------------------------------------------------------------
+# Synthetic git fixture
+# -----------------------------------------------------------------------------
+
+# make_repo_pair <label>
+# Creates ORIGIN_DIR (non-bare repo serving as origin) and WORK_DIR (a clone
+# of origin) with one initial commit on `main`. Sets ORIGIN_DIR / WORK_DIR
+# globals so callers can manipulate them.
+make_repo_pair() {
+	local label="$1"
+	ORIGIN_DIR="${TEST_ROOT}/origin-${label}"
+	WORK_DIR="${TEST_ROOT}/work-${label}"
+	rm -rf "$ORIGIN_DIR" "$WORK_DIR"
+	mkdir -p "$ORIGIN_DIR"
+	(
+		cd "$ORIGIN_DIR" || exit 1
+		git init -q -b main
+		git config user.email "test@example.com"
+		git config user.name "Test"
+		git commit --allow-empty -q -m "init"
+	) || return 1
+	git clone -q "$ORIGIN_DIR" "$WORK_DIR" || return 1
+	git -C "$WORK_DIR" config user.email "test@example.com"
+	git -C "$WORK_DIR" config user.name "Test"
+	# Push origin/HEAD so symbolic-ref refs/remotes/origin/HEAD resolves.
+	git -C "$WORK_DIR" remote set-head origin main >/dev/null 2>&1 || true
+	return 0
+}
+
+# -----------------------------------------------------------------------------
+# Tests
+# -----------------------------------------------------------------------------
+
+# Always set DISPATCH_REPO_SLUG so Signal 3 fires (without it the function
+# fail-opens to pr_exists).
+export DISPATCH_REPO_SLUG="owner/repo"
+
+test_main_no_commits_no_pr_returns_noop() {
+	make_repo_pair "case1" || {
+		print_result "case 1: branch=main, ahead=0, no PR → noop" 1 "fixture setup failed"
+		return 0
+	}
+	export STUB_PR_COUNT=0
+	local got
+	got=$(_worker_produced_output "issue-1001" "$WORK_DIR")
+	if [[ "$got" == "noop" ]]; then
+		print_result "case 1: branch=main, ahead=0, no PR → noop" 0
+	else
+		print_result "case 1: branch=main, ahead=0, no PR → noop" 1 "got: $got"
+	fi
+	return 0
+}
+
+test_main_with_local_commits_no_pr_returns_noop_t2899() {
+	make_repo_pair "case2" || {
+		print_result "case 2: branch=main, ahead=N, no PR → noop (default-branch guard)" 1 "fixture setup failed"
+		return 0
+	}
+	# Add local commits on main WITHOUT pushing — pre-fix this misclassified
+	# as branch_orphan because Signal 2 (origin has main) always matched.
+	(
+		cd "$WORK_DIR" || exit 1
+		echo "local change" > local.txt
+		git add local.txt
+		git commit -q -m "local commit on main"
+		echo "local change 2" > local2.txt
+		git add local2.txt
+		git commit -q -m "another local commit on main"
+	) || {
+		print_result "case 2: branch=main, ahead=N, no PR → noop (default-branch guard)" 1 "commit setup failed"
+		return 0
+	}
+	export STUB_PR_COUNT=0
+	local got
+	got=$(_worker_produced_output "issue-1002" "$WORK_DIR")
+	if [[ "$got" == "noop" ]]; then
+		print_result "case 2: branch=main, ahead=N, no PR → noop (default-branch guard)" 0
+	else
+		print_result "case 2: branch=main, ahead=N, no PR → noop (default-branch guard)" 1 "got: $got (expected noop — default-branch guard)"
+	fi
+	return 0
+}
+
+test_feature_branch_pushed_no_pr_returns_branch_orphan() {
+	make_repo_pair "case3" || {
+		print_result "case 3: branch=feature/tNNN-foo, ahead=N, no PR → branch_orphan" 1 "fixture setup failed"
+		return 0
+	}
+	# Create a feature branch, commit, push.
+	(
+		cd "$WORK_DIR" || exit 1
+		git checkout -q -b feature/t9999-orphan
+		echo "feature change" > feature.txt
+		git add feature.txt
+		git commit -q -m "feature commit"
+		git push -q origin feature/t9999-orphan
+	) || {
+		print_result "case 3: branch=feature/tNNN-foo, ahead=N, no PR → branch_orphan" 1 "feature branch setup failed"
+		return 0
+	}
+	export STUB_PR_COUNT=0
+	local got
+	got=$(_worker_produced_output "issue-1003" "$WORK_DIR")
+	if [[ "$got" == "branch_orphan" ]]; then
+		print_result "case 3: branch=feature/tNNN-foo, ahead=N, no PR → branch_orphan" 0
+	else
+		print_result "case 3: branch=feature/tNNN-foo, ahead=N, no PR → branch_orphan" 1 "got: $got"
+	fi
+	return 0
+}
+
+test_feature_branch_with_pr_returns_pr_exists() {
+	make_repo_pair "case4" || {
+		print_result "case 4: branch=feature/tNNN-foo, ahead=N, PR exists → pr_exists" 1 "fixture setup failed"
+		return 0
+	}
+	(
+		cd "$WORK_DIR" || exit 1
+		git checkout -q -b feature/t9999-with-pr
+		echo "feature change" > feature.txt
+		git add feature.txt
+		git commit -q -m "feature commit"
+		git push -q origin feature/t9999-with-pr
+	) || {
+		print_result "case 4: branch=feature/tNNN-foo, ahead=N, PR exists → pr_exists" 1 "feature branch setup failed"
+		return 0
+	}
+	export STUB_PR_COUNT=1
+	local got
+	got=$(_worker_produced_output "issue-1004" "$WORK_DIR")
+	if [[ "$got" == "pr_exists" ]]; then
+		print_result "case 4: branch=feature/tNNN-foo, ahead=N, PR exists → pr_exists" 0
+	else
+		print_result "case 4: branch=feature/tNNN-foo, ahead=N, PR exists → pr_exists" 1 "got: $got"
+	fi
+	return 0
+}
+
+# -----------------------------------------------------------------------------
+# Run
+# -----------------------------------------------------------------------------
+
+test_main_no_commits_no_pr_returns_noop
+test_main_with_local_commits_no_pr_returns_noop_t2899
+test_feature_branch_pushed_no_pr_returns_branch_orphan
+test_feature_branch_with_pr_returns_pr_exists
+
+printf '\nRan %d test(s), %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+
+# Restore original HOME for any post-trap cleanup.
+export HOME="$ORIGINAL_HOME"
+
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Fixes the `worker_branch_orphan` false-positive that was discarding 9 of 10 successful worker exits per the [t2899 audit](https://github.com/marcusquinn/aidevops/issues/21040).

`_worker_produced_output()` at `headless-runtime-helper.sh:1128` misclassified worker completions on the default branch as `branch_orphan` because Signal 2 (origin has `refs/heads/<branch>`) ALWAYS matched on `main` (main exists on the remote). Combined with no PR linked yet (Signal 3 returns 0), every worker that exited cleanly on main got reclassified as an orphan, the claim was released as `worker_branch_orphan`, and the run was discarded. Counter fired 31 times in 24h, ~20-30 worker-hours/day wasted.

For #21040

## What changed

### `_worker_produced_output` — default-branch guard

- Resolves the repo's default branch via `git symbolic-ref --short refs/remotes/origin/HEAD` once per call, with `DISPATCH_REPO_DEFAULT_BRANCH` env override and literal `main` as ultimate fallback.
- Skips Signal 2 entirely when `branch_name` matches the default branch — the signal is meaningless there because the default branch always exists on remote.
- Adds a second early-exit covering the "main + commits ahead + no feature branch pushed" case so it collapses to `noop` instead of falling through to the (broken) Signal 3 path.

### `_handle_worker_branch_orphan` — diagnostic logging

Per the brief: extends the `[lifecycle] worker_branch_orphan ...` log line to include `target_branch` (from `WORKER_TARGET_BRANCH` env, default `<unset>`), `final_head` (12-char SHA), `ahead_count` (commits beyond `origin/main`, with `origin/master` fallback), and `work_dir`. Mentorship for the next session that hits a regression in this hot path.

### New test — `tests/test-worker-output-classification.sh`

Pins all four canonical classification outcomes:

| Case | branch | ahead | PR | Expected |
|---|---|---|---|---|
| 1 | `main` | 0 | none | `noop` |
| 2 | `main` | N | none | `noop` *(default-branch guard, t2899)* |
| 3 | `feature/tNNN-foo` | N | none | `branch_orphan` *(unchanged — legitimate orphan path)* |
| 4 | `feature/tNNN-foo` | N | exists | `pr_exists` *(unchanged)* |

Counter-test: running the test suite against the pre-fix code (`git show origin/main:.agents/scripts/headless-runtime-helper.sh`) makes cases 1 AND 2 fail (both got `branch_orphan` instead of `noop`) — proves the test catches the bug it pins. Cases 3 and 4 still pass pre-fix because they exercise paths the fix preserves.

## Verification

```bash
shellcheck .agents/scripts/headless-runtime-helper.sh   # 1 pre-existing finding (unrelated SC2016)
shellcheck .agents/scripts/tests/test-worker-output-classification.sh   # clean
.agents/scripts/tests/test-worker-output-classification.sh   # 4 pass / 0 fail
```

Post-deploy verification (24h watch):

```bash
jq '.counters.worker_branch_orphan_count | length' ~/.aidevops/logs/pulse-stats.json
```

Expected: drop from current 31/24h (~9/10 workers) to <10% of completed workers.

## What this PR does NOT do

The brief calls out a separate investigation: **why do workers end up on main at all?** That's a follow-up — the legitimate orphan path is "feature branch + commits + no PR", but the observed pattern is "main + no feature branch", which suggests `_cmd_run_prepare` worktree-creation may be silently failing or `work_dir` may be passed as the canonical repo path. Will be filed as a follow-up issue once this fix lands and produces clean diagnostic logs to triage from.

## Complexity Impact

- `_worker_produced_output`: 70 → 91 lines (under 100-line `function-complexity` gate).
- `_handle_worker_branch_orphan`: 33 → 52 lines (under gate).

Brief estimated 80 lines for the classifier; actual is 91 because the second early-exit (for the "main + commits + no pushed branch" case) adds ~6 lines beyond the pure guard. Still under the gate.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.11 plugin for [OpenCode](https://opencode.ai) v1.14.25 with claude-opus-4-7 spent 10m and 37,047 tokens on this with the user in an interactive session.
