### PR TITLE
t2909: file ref:GH#21057 — auto-release leaves GitHub state stale

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3240,7 +3240,7 @@ t019.3.4,Update AGENTS.md with Beads integration docs,,beads,1h,45m,2025-12-21T1
 
 - [ ] t2908 setup.sh non-interactive resilience: caching, instrumentation, lock recovery #bug #framework #parent #setup ref:GH#21056
 
-- [ ] t2909 Auto-release path leaves status:in-review and self-assignment on GitHub #bug ref:GH#21057
+- [ ] t2909 Auto-release path leaves status:in-review and self-assignment on GitHub, poisoning footprint cache and blocking dispatch #bug #framework #pulse #interactive ref:GH#21057
 
 - [ ] t2910 Cache generate-runtime-config.sh on input hash (saves 135s/cycle) #auto-dispatch #bug #framework #performance #setup ref:GH#21059
 


### PR DESCRIPTION
## Summary

Files t2909 in TODO.md tracking ref:GH#21057 — auto-release path doesn't propagate to GitHub.

## Context

This morning's session ran `interactive-session-helper.sh scan-stale --auto-release` to clean up the t2840 series of dead stamps. The local cleanup worked — 16 stamp files deleted from `~/.aidevops/.agent-workspace/claim-stamps/`. The GitHub side did not. 14 of those 16 issues stayed `status:in-review` + `assignees=marcusquinn` on the remote, and the footprint-overlap cache (`dispatch-dedup-footprint.sh`, 120s TTL) kept treating them as in-flight, blocking dispatch on every issue with an overlapping file path. Pulse log showed ~20 `FOOTPRINT_OVERLAP (issue=#20895/#20896/#20897 ...)` deferrals in the last hour.

Tactical fix already applied: cleared all 14 stuck claims via `interactive-session-helper.sh release --unassign <num> <slug>` to unblock dispatch immediately.

Systemic fix queued in #21057.

## What This PR Does

- Adds the t2909 entry to TODO.md with ref:GH#21057
- No code changes (planning-only PR)

## Files

- `TODO.md`

## Why This Is a Planning PR

This PR only files the task. The TODO entry uses `For #21057` (planning keyword) so the issue stays open until the fix PR lands. The fix lands in a follow-up PR per the issue's How section (3 changes: `_isc_release_claim_by_stamp_path` `--unassign` propagation, `_isc_cmd_release` failure surfacing, `reconcile-stuck-claims.sh` reconciler).

For #21057

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.14 plugin for [OpenCode](https://opencode.ai) v1.14.25 with claude-opus-4-7 spent 1h 16m and 94,788 tokens on this with the user in an interactive session.

