### PR TITLE
t2906: fix 0-byte pulse plist on interrupted setup

### DIFF
--- a/setup-modules/schedulers.sh
+++ b/setup-modules/schedulers.sh
@@ -683,10 +683,16 @@ _install_pulse_launchd() {
 	local _pulse_installed="$4"
 	local pulse_plist="$HOME/Library/LaunchAgents/${pulse_label}.plist"
 
-	_cleanup_old_pulse_plists "$pulse_label" "$pulse_plist"
+	# Capture plist content before touching the existing file.
+	# This avoids the "unload old, then write fails" window that leaves a 0-byte plist.
+	local pulse_plist_content
+	pulse_plist_content=$(_generate_pulse_plist_content "$pulse_label" "$wrapper_script" "$opencode_bin")
 
-	# Write the plist (always regenerated to pick up config changes)
-	_generate_pulse_plist_content "$pulse_label" "$wrapper_script" "$opencode_bin" >"$pulse_plist"
+	# Defensive: if generation produced empty content, refuse to touch the existing plist.
+	if [[ -z "$pulse_plist_content" ]]; then
+		print_warning "Pulse plist generation produced empty content — leaving existing plist untouched"
+		return 1
+	fi
 
 	# Resolve interval for the user-facing message (matches what the plist contains).
 	local _interval_sec _interval_label
@@ -697,8 +703,10 @@ _install_pulse_launchd() {
 		_interval_label="${_interval_sec}s"
 	fi
 
+	# _launchd_install_if_changed handles unload-before-replace only when content
+	# has changed, and writes atomically via tmp+rename (see setup.sh).
 	# shell-portability: ignore next — _install_pulse_launchd is macOS-only (launchd)
-	if launchctl load "$pulse_plist"; then
+	if _launchd_install_if_changed "$pulse_label" "$pulse_plist" "$pulse_plist_content"; then
 		if [[ "$_pulse_installed" == "true" ]]; then
 			print_info "Supervisor pulse updated (launchd config regenerated, every ${_interval_label})"
 		else

--- a/setup.sh
+++ b/setup.sh
@@ -241,8 +241,20 @@ _launchd_install_if_changed() {
 		fi
 	fi
 
-	# Write new plist and load
-	printf '%s\n' "$new_content" >"$plist_path"
+	# Atomic write: build at sibling tmp path, then rename into place.
+	# If printf is killed mid-write, the destination is untouched.
+	local tmp_plist="${plist_path}.tmp.$$"
+	if ! printf '%s\n' "$new_content" >"$tmp_plist"; then
+		rm -f "$tmp_plist"
+		return 1
+	fi
+	# Defensive: refuse to install an empty file (should be guaranteed by the
+	# caller's content check, but guard here too).
+	if [[ ! -s "$tmp_plist" ]]; then
+		rm -f "$tmp_plist"
+		return 1
+	fi
+	mv -f "$tmp_plist" "$plist_path"
 	launchctl load "$plist_path" 2>/dev/null || return 1
 	return 0
 }


### PR DESCRIPTION
## Summary

Fix the two cooperating defects in `setup.sh` and `setup-modules/schedulers.sh` that together cause a 0-byte pulse plist when `_generate_pulse_plist_content` is interrupted during `setup.sh --non-interactive`.

### Defect A — `_install_pulse_launchd` (schedulers.sh)

Eliminated the unsafe "unload old plist before writing new one" sequence. The function now:
1. Captures `_generate_pulse_plist_content` output into a shell variable
2. Guards against empty content (returns 1 without touching the existing plist)
3. Delegates to `_launchd_install_if_changed` — which only unloads when replacement content is ready in memory

This matches the established pattern used by stats wrapper (`schedulers.sh:1085-1124`), session-miner, and the guard scheduler.

### Defect B — `_launchd_install_if_changed` (setup.sh)

Replaced the non-atomic `printf > $plist_path` with a `tmp-file + mv` pattern:
- Writes to `${plist_path}.tmp.$$`
- Checks the tmp file is non-empty before renaming
- Atomically renames into place with `mv -f`
- Cleans up tmp on any failure

If `printf` is killed mid-write, the destination is untouched.

## Verification

- `shellcheck setup.sh setup-modules/schedulers.sh` — no new violations (pre-existing SC2016 info at line 28 of schedulers.sh is unrelated and unchanged)
- Both defects fixed per the patterns described in the issue body
- `_launchd_install_if_changed` shape matches the existing reference implementations

Resolves #21054


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.14 plugin for [OpenCode](https://opencode.ai) v1.14.24 with claude-sonnet-4-6 spent 2m and 5,976 tokens on this as a headless worker.