### PR TITLE
t2914: ensure pulse running after every aidevops update via idempotent start

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -518,6 +518,7 @@ See also `reference/pre-commit-hooks.md` for the full playbook and "Stale-sympto
 **Pulse restart after deploying pulse script fixes (MANDATORY):**
 
 - `aidevops update` and `setup.sh` auto-restart the pulse (t2579). For manual hot-deploys (`cp` to `~/.aidevops/agents/scripts/`), restart manually: `pulse-lifecycle-helper.sh restart-if-running`. Fallback: `pkill -f "(^|/)pulse-wrapper\.sh( |$)" || true; sleep 3; nohup ~/.aidevops/agents/scripts/pulse-wrapper.sh >> ~/.aidevops/logs/pulse-wrapper.log 2>&1 &`. Subcommands: `is-running | status | start | stop | restart | restart-if-running`.
+- **Ensure-running guarantee (t2914):** every `aidevops update` ends with an idempotent `pulse-lifecycle-helper.sh start` call (in `aidevops.sh::cmd_update`). The earlier `restart-if-running` paths in `setup.sh:1329` / `agent-deploy.sh:601` are silent no-ops when pulse is **dead**, so a crashed pulse used to stay dead through subsequent updates. The `start` subcommand is idempotent — no-op when running, starts when dead — closing that gap. Honours `AIDEVOPS_SKIP_PULSE_RESTART=1` at the call site for parity with restart paths.
 
 ### Quality Standards
 

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -651,6 +651,27 @@ cmd_update() {
 		_update_check_daemon_health
 	fi
 
+	# t2914: ensure pulse is running after every update. The existing
+	# restart paths (setup.sh:1329, agent-deploy.sh:601) call
+	# pulse-lifecycle-helper.sh restart-if-running which is a silent no-op
+	# when pulse is dead — so a dead pulse stays dead through any number
+	# of subsequent updates. The 'start' subcommand is idempotent
+	# (pulse-lifecycle-helper.sh:127-131): no-op when running, starts when
+	# dead. This belt-and-braces call after the daemon health check
+	# guarantees the pulse is alive when 'aidevops update' returns,
+	# regardless of whether scripts were redeployed.
+	#
+	# Honour AIDEVOPS_SKIP_PULSE_RESTART=1 at the call site (the helper's
+	# 'start' subcommand does not check it directly — only 'restart' and
+	# 'restart-if-running' do). Non-fatal: a pulse start failure should
+	# not fail the update.
+	if [[ "${AIDEVOPS_SKIP_PULSE_RESTART:-0}" != "1" ]]; then
+		local _pulse_helper="${HOME}/.aidevops/agents/scripts/pulse-lifecycle-helper.sh"
+		if [[ -x "$_pulse_helper" ]]; then
+			"$_pulse_helper" start >/dev/null 2>&1 || print_warning "Pulse start failed (non-fatal)"
+		fi
+	fi
+
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Add an idempotent `pulse-lifecycle-helper.sh start` at the end of `cmd_update` in `aidevops.sh`. Closes the gap where a dead pulse stays dead through any number of subsequent `aidevops update` invocations.

## Why

The existing pulse-restart mechanism (t2579) only fires when `setup.sh` runs (remote change, VERSION mismatch, or deploy-SHA drift). When `aidevops update` reports "Framework already up to date!", the restart path is skipped entirely. `pulse-lifecycle-helper.sh restart-if-running` (the canonical entry in `setup.sh:1329` and `agent-deploy.sh:601`) is also a silent no-op when pulse is **dead** — see `pulse-lifecycle-helper.sh:176-179`. Result: a crashed pulse stays dead through any number of subsequent updates.

Observed today: `Pulse: not running` at session start despite recent updates. The launchd auto-restart cycle is meant to recover this within ~180s, but pulse cycle hangs (t2901, still open) push restart latency to tens of minutes — exactly the productivity-killer pattern triggering this PR.

## Change

`aidevops.sh::cmd_update` — adds an idempotent `start` subcommand call after the daemon health check, just before the final `return 0`. The `start` subcommand is already idempotent (`pulse-lifecycle-helper.sh:127-131`): no-op when running, starts when dead. Honours `AIDEVOPS_SKIP_PULSE_RESTART=1` at the call site for parity with the restart paths (the helper's `start` doesn't check the env directly — only `restart` and `restart-if-running` do).

`.agents/AGENTS.md` — documents the new ensure-running guarantee in the existing "Pulse restart" section.

## Verification

End-to-end on the maintainer machine:

```bash
# default behaviour: dead pulse → ensure-running fires → pulse alive
pulse-lifecycle-helper.sh stop
bash aidevops.sh update --skip-project-sync   # "Framework already up to date!"
pulse-lifecycle-helper.sh status              # "Pulse: running" ✓

# skip-env honoured: dead pulse stays dead
pulse-lifecycle-helper.sh stop
AIDEVOPS_SKIP_PULSE_RESTART=1 bash aidevops.sh update --skip-project-sync
pulse-lifecycle-helper.sh status              # "Pulse: not running" ✓
```

Both passed in this session.

## Test impact

- `shellcheck aidevops.sh`: clean.
- `bash .agents/scripts/tests/test-pulse-lifecycle-helper.sh`: 16/16 passing (no new tests required — `start` idempotency is already covered by existing test cases).

## Risk surface

Minimal: 5-line addition behind two guards (`AIDEVOPS_SKIP_PULSE_RESTART` env opt-out + helper-presence check). Failure to start pulse is non-fatal (`print_warning` only, doesn't fail the update). Belt-and-braces relative to existing `restart-if-running` paths in `setup.sh` and `agent-deploy.sh` — no existing behaviour changed.

Resolves #21069

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.15 plugin for [OpenCode](https://opencode.ai) v1.14.25 with claude-opus-4-7 spent 21m and 56,704 tokens on this with the user in an interactive session.
