### PR TITLE
t2905: document prefetch_state architectural rationale (audit #21051)

### DIFF
--- a/.agents/scripts/pulse-prefetch.sh
+++ b/.agents/scripts/pulse-prefetch.sh
@@ -256,6 +256,63 @@ _prefetch_batch_refresh() {
 #
 # This is a deterministic data-fetch utility. The intelligence about
 # what to DO with this data stays in pulse.md.
+#
+# -----------------------------------------------------------------------------
+# Architectural rationale (t2905, audit #21051) — DO NOT REMOVE THIS STAGE
+# -----------------------------------------------------------------------------
+# Measured cost: ~170s avg (156s-224s range, 30-cycle sample, Apr 2026).
+# Naive view: "184s of housekeeping per pulse, can we drop it?" — NO.
+#
+# prefetch_state is NOT a downstream-call amortisation optimisation. It is
+# the ONLY mechanism that produces three outputs the dispatch pipeline
+# cannot operate without:
+#
+# 1. STATE_FILE (cross-repo PR/issue/missions/FOSS/contribution-watch
+#    summary). This is INJECTED into the pulse agent's prompt at
+#    pulse-wrapper.sh:428-434 — the LLM reads it via Read tool because
+#    the payload routinely exceeds Linux execve() MAX_ARG_STRLEN (#4257).
+#    Without STATE_FILE the LLM has zero cross-repo visibility and the
+#    cycle is useless.
+#
+# 2. PULSE_SCOPE_REPOS export (line ~350) + SCOPE_FILE persistence.
+#    Every worker checks PULSE_SCOPE_REPOS to gate branch/PR creation
+#    (t1405, GH#2928). Without it, workers either dispatch with no scope
+#    (all repos allowed = security regression) or refuse to dispatch.
+#
+# 3. STATE_FILE is also read directly by shell-stage consumers:
+#      - prefetch_foss_scan / FOSS dispatch (pulse-wrapper.sh:1726).
+#      - dispatch_foss_workers reads pre-fetched FOSS data from STATE_FILE.
+#    Removing prefetch_state would force these stages to fetch on demand
+#    or skip silently.
+#
+# What ALREADY makes this stage cheap:
+#   - L3 batch prefetch via gh search (GH#19963) — _prefetch_batch_refresh
+#     consolidates per-repo fetches when the org search cache hits.
+#   - Idle-repo skip (t2098) — repos with no recent activity bypass the
+#     full per-repo gh sweep.
+#   - Read-side REST fallback (t2689) — when GraphQL is constrained,
+#     individual sub-fetches route via the separate 5000/hr REST pool
+#     instead of failing.
+#   - Per-repo schedule check (pulse_hours / pulse_expires) — repos
+#     outside their schedule window contribute zero gh calls.
+#   - Hard timeout (120s for parallel pids, t1482, GH#15060) — bounded
+#     worst case even when GraphQL is slow.
+#
+# Hypothesis ruled out (audit #21051): the issue body framed prefetch_state
+# as cost-amortisation across "downstream stages" and asked whether those
+# stages still benefit. The framing was wrong — the primary downstream
+# consumer is the LLM agent (output 1 above), not subsequent shell stages.
+# REST-fallback and dispatch-dedup REST routing (t2689, #20991) reduce the
+# cost of OTHER gh paths but do not displace this stage's role.
+#
+# If you find yourself auditing this stage again because the cycle is slow:
+#   - Look at preflight_ownership_reconcile (~600s, see t2904 — separate
+#     audit).
+#   - Look at complexity_scan (~470s, moved to standalone plist in t2903).
+#   - Move the pulse interval up (180s -> 600s in settings.json) instead
+#     of removing structurally-required stages. The cycle is naturally
+#     long because it is a cross-repo state observer; running it more
+#     often does not produce better outcomes.
 #######################################
 prefetch_state() {
 	local repos_json="$REPOS_JSON"


### PR DESCRIPTION
## Summary

Audit of `prefetch_state` (issue #21051, t2905) — premise of the issue body was falsified, but the audit produced lasting value as a defensive header comment.

## Audit Outcome: B (Keep + Document)

**Premise check (t2204):** the issue body framed `prefetch_state` as cost-amortisation across "downstream stages" and asked whether they still benefit (since t2689 added read-side REST fallback). Reading `pulse-wrapper.sh:419-433` shows the actual primary downstream consumer is the **LLM pulse agent itself** — STATE_FILE is injected into its prompt because the payload exceeds Linux `execve()` MAX_ARG_STRLEN (#4257). So the cost-amortisation framing was wrong; this stage is structurally required, not an optimisation.

## Evidence

Measured `prefetch_state` cost over 30 most-recent samples in `~/.aidevops/logs/pulse-stage-timings.log`:

- count=30, avg=169.9s, min=156s, max=224s, total=5097s
- The 184s figure cited in the issue body is within range (recent value is 224s).

## Three Hard Dependencies on `prefetch_state`

1. **STATE_FILE → pulse agent prompt** (`pulse-wrapper.sh:428-434`): the LLM has zero cross-repo visibility without it. Cycle becomes useless.
2. **`PULSE_SCOPE_REPOS` export + SCOPE_FILE** (`pulse-prefetch.sh:348-352`): every worker gates branch/PR creation on this (t1405, GH#2928). Removing it either breaks worker dispatch or removes the security boundary.
3. **Shell consumers reading STATE_FILE directly**:
   - FOSS dispatch (`pulse-wrapper.sh:1726`)
   - Mission summary, contribution watch, hygiene anomalies, CI failures all append to STATE_FILE here.

## What Already Makes This Stage Cheap

- L3 batch prefetch via `gh search` (GH#19963)
- Idle-repo skip (t2098)
- Read-side REST fallback (t2689) for sub-fetches when GraphQL constrained
- Per-repo schedule check (`pulse_hours`/`pulse_expires`)
- Hard 120s timeout on parallel pids (t1482, GH#15060)

## Change

`.agents/scripts/pulse-prefetch.sh` — added a 50-line architectural rationale comment block to the `prefetch_state()` function header. Documents:

- Measured cost (170s avg, 156-224s range, 30-sample window)
- Why this stage cannot be removed (three structural dependencies above)
- What already makes it cheap (5 mitigations enumerated)
- Hypothesis ruled out so the next audit doesn't re-tread this ground
- Pointer to actual cycle-time culprits: `preflight_ownership_reconcile` (~600s, t2904), `complexity_scan` (~470s, t2903 moved to standalone plist), or moving the pulse interval up.

No logic changes. Comment-only.

## Acceptance (per issue body)

> **Outcome B**: `prefetch_state` remains; `pulse-prefetch.sh` orchestrator function header includes a comment block measuring the savings ratio.

Done — but framed as cost-vs-structural-dependency rather than savings ratio, because the savings-ratio framing was the falsified premise.

## Verification

```bash
shellcheck .agents/scripts/pulse-prefetch.sh   # exit 0
grep -A 5 "Architectural rationale (t2905" .agents/scripts/pulse-prefetch.sh
# Expected: 5+ lines of the rationale block.
```

Resolves #21051

## Runtime Testing

Comment-only change. No runtime testing required (low-risk class).


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.16 plugin for [OpenCode](https://opencode.ai) v1.14.25 with claude-opus-4-7 spent 6m and 17,603 tokens on this as a headless worker.