### PR TITLE
t2918: fix(pulse): invert tooling/product priority boost so tooling lifts product

### DIFF
--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -163,7 +163,7 @@ build_ranked_dispatch_candidates_json() {
 				repo_path: $path,
 				repo_priority: $priority,
 				score: (
-					(if $priority == "product" then 2000 elif $priority == "tooling" then 1000 else 0 end) +
+					(if $priority == "tooling" then 2000 elif $priority == "product" then 1000 else 0 end) +
 					(if (.labels | index("priority:critical")) != null then 10000
 					 elif (.labels | index("priority:high")) != null then 8000
 					 elif (.labels | index("bug")) != null then 7000


### PR DESCRIPTION
## Summary

Single-line jq swap in pulse-dispatch-engine.sh:166. Tooling repo (aidevops) now wins score-tied dispatch competitions over product repos, since tooling efficiency unblocks product development.

## Files Changed

.agents/scripts/pulse-dispatch-engine.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified edit at line 166 (grep tooling.*then 2000 returns the line). ShellCheck clean. The change is a tiebreaker — label-based score (+3000-10000) still dominates the priority boost (+1000-2000), so single-class candidate sorting is unaffected.

Resolves #21079


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.17 plugin for [OpenCode](https://opencode.ai) v1.14.25 with claude-opus-4-7 spent 1h 53m and 143,592 tokens on this with the user in an interactive session.