### PR TITLE
t2866: _inbox/ directory contract + per-repo provisioning

### DIFF
--- a/.agents/scripts/inbox-helper.sh
+++ b/.agents/scripts/inbox-helper.sh
@@ -1,0 +1,445 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# shellcheck disable=SC2034
+
+# =============================================================================
+# Inbox Helper Script (t2866)
+# =============================================================================
+# Establishes and manages the _inbox/ directory contract for aidevops-managed
+# repos. The inbox is a transit zone — files land here until triage routes them
+# to the appropriate knowledge plane or discards them.
+#
+# Usage:
+#   inbox-helper.sh <command> [options]
+#
+# Commands:
+#   provision <repo-path>      Create _inbox/ directory contract in a repo
+#   provision-workspace        Provision cross-repo inbox at
+#                              ~/.aidevops/.agent-workspace/inbox/
+#   status [repo-path]         Report item counts per sub-folder and oldest age
+#   validate [repo-path]       Check that _inbox/ structure is complete
+#   help                       Show this help
+#
+# Sub-folders created under _inbox/:
+#   _drop/          General-purpose drop (paste, quick captures)
+#   email/          Email captures (forwarded messages, exported threads)
+#   web/            Web page captures (saved HTML, PDFs, screenshots)
+#   scan/           Scanned documents / OCR input
+#   voice/          Voice memos / audio transcripts awaiting triage
+#   import/         Bulk imports from external sources
+#   _needs-review/  Items flagged as needing manual review before routing
+#
+# Sensitivity contract:
+#   Nothing in _inbox/ flows to cloud LLMs until triage classifies it.
+#   The LLM routing helper (P0.5b) checks plane membership: _inbox/
+#   membership = local-only routing until a sensitivity label is assigned.
+#
+# Examples:
+#   inbox-helper.sh provision ~/Git/myproject
+#   inbox-helper.sh provision-workspace
+#   inbox-helper.sh status ~/Git/myproject
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+
+# Source shared constants for colour vars and utilities.
+# Guard: older deployments may not have shared-constants.sh.
+if [[ -f "${SCRIPT_DIR}/shared-constants.sh" ]]; then
+	# shellcheck source=/dev/null
+	source "${SCRIPT_DIR}/shared-constants.sh"
+else
+	[[ -z "${GREEN+x}" ]] && GREEN='\033[0;32m'
+	[[ -z "${YELLOW+x}" ]] && YELLOW='\033[0;33m'
+	[[ -z "${RED+x}" ]] && RED='\033[0;31m'
+	[[ -z "${CYAN+x}" ]] && CYAN='\033[0;36m'
+	[[ -z "${NC+x}" ]] && NC='\033[0m'
+fi
+
+# Template path for _inbox/README.md content.
+INBOX_README_TEMPLATE="${SCRIPT_DIR}/../templates/inbox-readme.md"
+
+# Sub-folders that make up the _inbox/ directory contract.
+INBOX_SUBFOLDERS=("_drop" "email" "web" "scan" "voice" "import" "_needs-review")
+
+# =============================================================================
+# Internal helpers
+# =============================================================================
+
+_print_info() {
+	local msg="$1"
+	printf "${CYAN}[inbox]${NC} %s\n" "$msg"
+	return 0
+}
+
+_print_success() {
+	local msg="$1"
+	printf "${GREEN}[inbox]${NC} %s\n" "$msg"
+	return 0
+}
+
+_print_warning() {
+	local msg="$1"
+	printf "${YELLOW}[inbox] WARNING:${NC} %s\n" "$msg" >&2
+	return 0
+}
+
+_print_error() {
+	local msg="$1"
+	printf "${RED}[inbox] ERROR:${NC} %s\n" "$msg" >&2
+	return 0
+}
+
+# Resolve the inbox root for a given repo path.
+# Usage: _inbox_root <repo-path>
+_inbox_root() {
+	local repo_path="$1"
+	echo "${repo_path}/_inbox"
+	return 0
+}
+
+# Write _inbox/README.md from template or embedded fallback.
+# Usage: _write_inbox_readme <inbox-root>
+_write_inbox_readme() {
+	local inbox_root="$1"
+	local readme_path="${inbox_root}/README.md"
+
+	if [[ -f "$INBOX_README_TEMPLATE" ]]; then
+		cp "$INBOX_README_TEMPLATE" "$readme_path"
+	else
+		# Embedded fallback if template is not deployed yet.
+		cat >"$readme_path" <<'EOF'
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+# _inbox/ — Transit Zone
+
+This directory is a **transit zone**: captures land here first, then triage
+routes them to the appropriate knowledge plane or discards them.
+
+## Sub-folders
+
+| Folder | Purpose |
+|--------|---------|
+| `_drop/` | General-purpose drop — quick paste, text snippets |
+| `email/` | Email captures — forwarded messages, exported threads |
+| `web/` | Web captures — saved HTML, PDFs, screenshots |
+| `scan/` | Scanned documents awaiting OCR / classification |
+| `voice/` | Voice memos and audio transcripts |
+| `import/` | Bulk imports from external sources |
+| `_needs-review/` | Flagged items requiring manual review before routing |
+
+## Sensitivity Contract
+
+**Nothing in `_inbox/` may be sent to cloud LLMs until triage assigns a
+sensitivity label.** The LLM routing helper treats `_inbox/` membership as
+`local-only` by default. After classification (P2c), items move to their
+target plane and inherit that plane's sensitivity baseline.
+
+## Triage Log
+
+`triage.log` is a JSONL audit file recording routing decisions. Each line is a
+JSON object: `{"ts":"ISO8601","file":"path","action":"routed|discarded",
+"target":"plane/subfolder","sensitivity":"unverified|public|private|privileged"}`.
+
+Do not edit `triage.log` by hand — append via the triage CLI (P2c).
+
+## What Does Not Belong Here
+
+- Final classified content (move to the target plane)
+- Secrets or credentials (use `aidevops secret set`)
+- Build artefacts or generated files (use .gitignore)
+EOF
+	fi
+	return 0
+}
+
+# Write _inbox/.gitignore — exclude binary sub-folder contents, keep
+# README.md and triage.log.
+# Usage: _write_inbox_gitignore <inbox-root>
+_write_inbox_gitignore() {
+	local inbox_root="$1"
+	local gitignore_path="${inbox_root}/.gitignore"
+
+	cat >"$gitignore_path" <<'EOF'
+# _inbox/.gitignore (t2866)
+# Transit-zone captures: exclude binary and bulk content from git.
+# README.md and triage.log are committed for visibility and audit trail.
+
+# Exclude everything by default…
+*
+
+# …then re-include files that belong in version control.
+!README.md
+!.gitignore
+!triage.log
+
+# Sub-folders are excluded entirely (binary captures, PDFs, audio, images)
+# When triage routes an item to a plane, it is copied/moved; the plane
+# applies its own .gitignore policy.
+EOF
+	return 0
+}
+
+# Write an empty triage.log (JSONL append target for P2c triage CLI).
+# Usage: _write_triage_log <inbox-root>
+_write_triage_log() {
+	local inbox_root="$1"
+	local log_path="${inbox_root}/triage.log"
+	[[ -f "$log_path" ]] && return 0
+	: >"$log_path"
+	return 0
+}
+
+# Core provisioning logic — shared between provision and provision-workspace.
+# Usage: _provision_inbox_at <inbox-root> <label>
+_provision_inbox_at() {
+	local inbox_root="$1"
+	local label="$2"
+	local created=0
+	local already_ok=0
+
+	if [[ ! -d "$inbox_root" ]]; then
+		mkdir -p "$inbox_root"
+		_print_info "Created $label/_inbox/"
+		created=1
+	fi
+
+	# Create sub-folders (idempotent).
+	local folder
+	for folder in "${INBOX_SUBFOLDERS[@]}"; do
+		local sub="${inbox_root}/${folder}"
+		if [[ ! -d "$sub" ]]; then
+			mkdir -p "$sub"
+			_print_info "  + $folder/"
+			created=1
+		fi
+	done
+
+	# Write supporting files (idempotent — only create, never overwrite).
+	if [[ ! -f "${inbox_root}/README.md" ]]; then
+		_write_inbox_readme "$inbox_root"
+		_print_info "  + README.md"
+		created=1
+	fi
+
+	if [[ ! -f "${inbox_root}/.gitignore" ]]; then
+		_write_inbox_gitignore "$inbox_root"
+		_print_info "  + .gitignore"
+		created=1
+	fi
+
+	_write_triage_log "$inbox_root"
+
+	if [[ "$created" -eq 0 ]]; then
+		already_ok=1
+	fi
+
+	if [[ "$already_ok" -eq 1 ]]; then
+		_print_success "$label/_inbox/ already provisioned (idempotent)"
+	else
+		_print_success "$label/_inbox/ provisioned successfully"
+	fi
+	return 0
+}
+
+# =============================================================================
+# Commands
+# =============================================================================
+
+# cmd_provision: provision _inbox/ in a given repo path.
+# Usage: cmd_provision <repo-path>
+cmd_provision() {
+	local repo_path="${1:-}"
+	if [[ -z "$repo_path" ]]; then
+		_print_error "Usage: inbox-helper.sh provision <repo-path>"
+		return 1
+	fi
+	if [[ ! -d "$repo_path" ]]; then
+		_print_error "Directory not found: $repo_path"
+		return 1
+	fi
+	local inbox_root
+	inbox_root="$(_inbox_root "$repo_path")"
+	_provision_inbox_at "$inbox_root" "$(basename "$repo_path")"
+	return 0
+}
+
+# cmd_provision_workspace: provision cross-repo inbox at
+# ~/.aidevops/.agent-workspace/inbox/
+# Usage: cmd_provision_workspace
+cmd_provision_workspace() {
+	local workspace_inbox="${HOME}/.aidevops/.agent-workspace/inbox"
+	_print_info "Provisioning workspace inbox at $workspace_inbox"
+
+	if [[ ! -d "${HOME}/.aidevops/.agent-workspace" ]]; then
+		mkdir -p "${HOME}/.aidevops/.agent-workspace"
+	fi
+
+	_provision_inbox_at "$workspace_inbox" "${HOME}/.aidevops/.agent-workspace"
+	return 0
+}
+
+# cmd_status: report item counts per sub-folder and oldest item age.
+# Usage: cmd_status [repo-path]
+cmd_status() {
+	local repo_path="${1:-$(pwd)}"
+	local inbox_root
+	inbox_root="$(_inbox_root "$repo_path")"
+
+	if [[ ! -d "$inbox_root" ]]; then
+		_print_warning "_inbox/ not found at $inbox_root — run: inbox-helper.sh provision $repo_path"
+		return 1
+	fi
+
+	printf "\n${CYAN}_inbox/ status for ${NC}%s\n\n" "$(basename "$repo_path")"
+	printf "  %-20s %s\n" "Folder" "Items"
+	printf "  %s\n" "-----------------------------"
+
+	local total=0
+	local oldest_age=-1
+	local oldest_file=""
+	local now
+	now=$(date +%s)
+
+	local folder
+	for folder in "${INBOX_SUBFOLDERS[@]}"; do
+		local sub="${inbox_root}/${folder}"
+		local count=0
+		if [[ -d "$sub" ]]; then
+			# Count non-hidden files only; stat for oldest mtime.
+			# Use find to avoid globbing issues with empty dirs.
+			while IFS= read -r -d '' fpath; do
+				count=$((count + 1))
+				total=$((total + 1))
+				local fmtime
+				# macOS stat: -f %m; GNU stat: -c %Y
+				if fmtime=$(stat -f '%m' "$fpath" 2>/dev/null); then
+					: # macOS
+				elif fmtime=$(stat -c '%Y' "$fpath" 2>/dev/null); then
+					: # GNU/Linux
+				else
+					fmtime=0
+				fi
+				if [[ "$oldest_age" -eq -1 ]] || [[ "$fmtime" -lt "$oldest_age" ]]; then
+					oldest_age="$fmtime"
+					oldest_file="$fpath"
+				fi
+			done < <(find "$sub" -maxdepth 1 -not -name '.*' -type f -print0 2>/dev/null)
+		fi
+		printf "  %-20s %d\n" "$folder/" "$count"
+	done
+
+	printf "\n  Total items:  %d\n" "$total"
+
+	if [[ "$total" -gt 0 ]] && [[ "$oldest_age" -gt 0 ]]; then
+		local age_secs=$(( now - oldest_age ))
+		local age_days=$(( age_secs / 86400 ))
+		local age_hours=$(( (age_secs % 86400) / 3600 ))
+		printf "  Oldest item:  %dd %dh ago (%s)\n" "$age_days" "$age_hours" \
+			"$(basename "$oldest_file")"
+	fi
+
+	printf "\n"
+	return 0
+}
+
+# cmd_validate: verify that _inbox/ has all required structure.
+# Usage: cmd_validate [repo-path]
+cmd_validate() {
+	local repo_path="${1:-$(pwd)}"
+	local inbox_root
+	inbox_root="$(_inbox_root "$repo_path")"
+	local fail=0
+
+	if [[ ! -d "$inbox_root" ]]; then
+		_print_error "Missing: $inbox_root"
+		return 1
+	fi
+
+	local folder
+	for folder in "${INBOX_SUBFOLDERS[@]}"; do
+		if [[ ! -d "${inbox_root}/${folder}" ]]; then
+			_print_error "Missing sub-folder: $folder/"
+			fail=1
+		fi
+	done
+
+	for reqfile in "README.md" ".gitignore" "triage.log"; do
+		if [[ ! -f "${inbox_root}/${reqfile}" ]]; then
+			_print_error "Missing required file: $reqfile"
+			fail=1
+		fi
+	done
+
+	if [[ "$fail" -eq 0 ]]; then
+		_print_success "_inbox/ structure valid at $inbox_root"
+	fi
+	return "$fail"
+}
+
+cmd_help() {
+	cat <<EOF
+Usage: inbox-helper.sh <command> [options]
+
+Commands:
+  provision <repo-path>      Create _inbox/ directory contract in a repo
+  provision-workspace        Provision cross-repo inbox at
+                             ~/.aidevops/.agent-workspace/inbox/
+  status [repo-path]         Report item counts per sub-folder and oldest age
+  validate [repo-path]       Check that _inbox/ structure is complete
+  help                       Show this help
+
+Sub-folders:
+  _drop/          General-purpose quick captures
+  email/          Email message captures
+  web/            Web page captures (HTML, PDFs, screenshots)
+  scan/           Scanned documents / OCR input
+  voice/          Voice memos / audio transcripts
+  import/         Bulk imports from external sources
+  _needs-review/  Flagged items requiring manual review
+
+Examples:
+  inbox-helper.sh provision ~/Git/myproject
+  inbox-helper.sh provision-workspace
+  inbox-helper.sh status ~/Git/myproject
+  inbox-helper.sh validate ~/Git/myproject
+EOF
+	return 0
+}
+
+# =============================================================================
+# MAIN
+# =============================================================================
+
+main() {
+	local command="${1:-help}"
+	shift || true
+
+	case "$command" in
+	provision)
+		cmd_provision "$@"
+		;;
+	provision-workspace | workspace)
+		cmd_provision_workspace "$@"
+		;;
+	status | st)
+		cmd_status "$@"
+		;;
+	validate | check)
+		cmd_validate "$@"
+		;;
+	help | --help | -h)
+		cmd_help
+		;;
+	*)
+		_print_error "Unknown command: $command"
+		echo ""
+		cmd_help
+		return 1
+		;;
+	esac
+}
+
+main "$@"

--- a/.agents/scripts/test-inbox-provision.sh
+++ b/.agents/scripts/test-inbox-provision.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Smoke test for t2866: inbox-helper.sh provision + provision-workspace
+# must create the full _inbox/ directory contract idempotently.
+#
+# Tests:
+#   1. provision creates all required sub-folders under a sandbox repo.
+#   2. provision is idempotent (re-run does not fail or duplicate).
+#   3. Required files (README.md, .gitignore, triage.log) are present.
+#   4. .gitignore policy is correct (README.md + triage.log not excluded,
+#      arbitrary captures excluded).
+#   5. status reports the correct zero-count table on a fresh inbox.
+#   6. validate passes on a correctly provisioned inbox.
+#   7. provision-workspace creates structure under a temp AIDEVOPS_HOME.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INBOX_HELPER="${SCRIPT_DIR}/inbox-helper.sh"
+
+declare -i FAIL_COUNT=0
+
+fail() {
+	local msg="$1"
+	echo "FAIL: $msg" >&2
+	FAIL_COUNT=$((FAIL_COUNT + 1))
+	return 0
+}
+
+pass() {
+	local msg="$1"
+	echo "PASS: $msg"
+	return 0
+}
+
+assert_dir() {
+	local path="$1" label="$2"
+	if [[ -d "$path" ]]; then
+		pass "$label exists"
+	else
+		fail "$label missing: $path"
+	fi
+	return 0
+}
+
+assert_file() {
+	local path="$1" label="$2"
+	if [[ -f "$path" ]]; then
+		pass "$label exists"
+	else
+		fail "$label missing: $path"
+	fi
+	return 0
+}
+
+# Create a temp sandbox repo directory that is cleaned up on exit.
+SANDBOX=""
+cleanup() {
+	[[ -n "$SANDBOX" ]] && rm -rf "$SANDBOX"
+	return 0
+}
+trap cleanup EXIT
+
+SANDBOX="$(mktemp -d)"
+
+# =============================================================================
+# Test 1: provision creates all required directories and files
+# =============================================================================
+echo ""
+echo "=== Test 1: provision creates full _inbox/ directory contract ==="
+
+"$INBOX_HELPER" provision "$SANDBOX" >/dev/null
+
+assert_dir  "$SANDBOX/_inbox"                   "_inbox/"
+assert_dir  "$SANDBOX/_inbox/_drop"             "_inbox/_drop/"
+assert_dir  "$SANDBOX/_inbox/email"             "_inbox/email/"
+assert_dir  "$SANDBOX/_inbox/web"               "_inbox/web/"
+assert_dir  "$SANDBOX/_inbox/scan"              "_inbox/scan/"
+assert_dir  "$SANDBOX/_inbox/voice"             "_inbox/voice/"
+assert_dir  "$SANDBOX/_inbox/import"            "_inbox/import/"
+assert_dir  "$SANDBOX/_inbox/_needs-review"     "_inbox/_needs-review/"
+assert_file "$SANDBOX/_inbox/README.md"         "_inbox/README.md"
+assert_file "$SANDBOX/_inbox/.gitignore"        "_inbox/.gitignore"
+assert_file "$SANDBOX/_inbox/triage.log"        "_inbox/triage.log"
+
+# =============================================================================
+# Test 2: provision is idempotent (re-run succeeds, no duplicates)
+# =============================================================================
+echo ""
+echo "=== Test 2: provision is idempotent ==="
+
+if "$INBOX_HELPER" provision "$SANDBOX" >/dev/null 2>&1; then
+	pass "idempotent re-run exits 0"
+else
+	fail "idempotent re-run failed"
+fi
+
+assert_dir  "$SANDBOX/_inbox/_drop"   "_inbox/_drop/ still exists after re-run"
+assert_file "$SANDBOX/_inbox/README.md" "README.md not overwritten"
+
+# =============================================================================
+# Test 3: .gitignore excludes captures but keeps README.md and triage.log
+# =============================================================================
+echo ""
+echo "=== Test 3: .gitignore policy ==="
+
+GITIGNORE="$SANDBOX/_inbox/.gitignore"
+if grep -q "README.md" "$GITIGNORE" && grep -q "triage.log" "$GITIGNORE"; then
+	pass ".gitignore whitelists README.md and triage.log"
+else
+	fail ".gitignore does not whitelist README.md and/or triage.log"
+fi
+
+if grep -qE '^\*$' "$GITIGNORE"; then
+	pass ".gitignore has catch-all exclude (*)"
+else
+	fail ".gitignore missing catch-all exclude (*)"
+fi
+
+# =============================================================================
+# Test 4: validate passes on a correctly provisioned inbox
+# =============================================================================
+echo ""
+echo "=== Test 4: validate reports success on correctly provisioned inbox ==="
+
+if "$INBOX_HELPER" validate "$SANDBOX" >/dev/null 2>&1; then
+	pass "validate exits 0 on correct structure"
+else
+	fail "validate failed on correctly provisioned inbox"
+fi
+
+# =============================================================================
+# Test 5: status reports zero items on a fresh empty inbox
+# =============================================================================
+echo ""
+echo "=== Test 5: status reports zero total items on fresh inbox ==="
+
+status_output="$("$INBOX_HELPER" status "$SANDBOX" 2>&1 || true)"
+if echo "$status_output" | grep -q "Total items:  0"; then
+	pass "status reports 0 total items on fresh inbox"
+else
+	fail "status did not report 0 total items; output was: $status_output"
+fi
+
+# =============================================================================
+# Test 6: provision-workspace provisions under a custom HOME
+# =============================================================================
+echo ""
+echo "=== Test 6: provision-workspace creates workspace inbox ==="
+
+FAKE_HOME="$(mktemp -d)"
+# Override HOME so provision-workspace targets our sandbox location.
+# inbox-helper.sh uses $HOME/.aidevops/.agent-workspace/inbox
+HOME="$FAKE_HOME" "$INBOX_HELPER" provision-workspace >/dev/null
+
+assert_dir  "$FAKE_HOME/.aidevops/.agent-workspace/inbox"               "workspace inbox root"
+assert_dir  "$FAKE_HOME/.aidevops/.agent-workspace/inbox/_drop"         "workspace inbox/_drop/"
+assert_dir  "$FAKE_HOME/.aidevops/.agent-workspace/inbox/email"         "workspace inbox/email/"
+assert_file "$FAKE_HOME/.aidevops/.agent-workspace/inbox/README.md"     "workspace inbox/README.md"
+assert_file "$FAKE_HOME/.aidevops/.agent-workspace/inbox/.gitignore"    "workspace inbox/.gitignore"
+assert_file "$FAKE_HOME/.aidevops/.agent-workspace/inbox/triage.log"    "workspace inbox/triage.log"
+
+rm -rf "$FAKE_HOME"
+
+# =============================================================================
+# Test 7: provision-workspace is idempotent
+# =============================================================================
+echo ""
+echo "=== Test 7: provision-workspace is idempotent ==="
+
+FAKE_HOME2="$(mktemp -d)"
+HOME="$FAKE_HOME2" "$INBOX_HELPER" provision-workspace >/dev/null
+if HOME="$FAKE_HOME2" "$INBOX_HELPER" provision-workspace >/dev/null 2>&1; then
+	pass "provision-workspace idempotent re-run exits 0"
+else
+	fail "provision-workspace idempotent re-run failed"
+fi
+rm -rf "$FAKE_HOME2"
+
+# =============================================================================
+# Summary
+# =============================================================================
+echo ""
+if [[ "$FAIL_COUNT" -eq 0 ]]; then
+	echo "=== All tests passed ==="
+	exit 0
+else
+	echo "=== $FAIL_COUNT test(s) failed ==="
+	exit 1
+fi

--- a/.agents/templates/inbox-readme.md
+++ b/.agents/templates/inbox-readme.md
@@ -1,0 +1,67 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+# _inbox/ — Transit Zone
+
+This directory is a **transit zone**: captures land here first, then triage
+routes them to the appropriate knowledge plane or discards them.
+
+> **Sensitivity contract:** Nothing in `_inbox/` may be sent to cloud LLMs
+> until triage assigns a sensitivity label. The LLM routing helper treats
+> `_inbox/` membership as `local-only` by default. After classification
+> (P2c), items move to their target plane and inherit that plane's sensitivity
+> baseline.
+
+## Sub-folders
+
+| Folder | Purpose |
+|--------|---------|
+| `_drop/` | General-purpose drop — quick paste, text snippets, anything uncategorised |
+| `email/` | Email captures — forwarded messages, exported threads |
+| `web/` | Web captures — saved HTML, PDFs, screenshots |
+| `scan/` | Scanned documents awaiting OCR / classification |
+| `voice/` | Voice memos and audio transcripts |
+| `import/` | Bulk imports from external sources |
+| `_needs-review/` | Items flagged as requiring manual review before routing |
+
+## Triage Log
+
+`triage.log` is a JSONL audit file recording routing decisions. Each line:
+
+```json
+{"ts":"ISO8601","file":"path","action":"routed|discarded","target":"plane/subfolder","sensitivity":"unverified|public|private|privileged"}
+```
+
+Do not edit `triage.log` by hand — append via the triage CLI (P2c).
+
+## .gitignore Contract
+
+`_inbox/.gitignore` excludes all binary and bulk content (PDFs, audio, images,
+HTML). Only `README.md`, `.gitignore`, and `triage.log` are committed:
+- `README.md` — visibility (users see the inbox in the repo)
+- `.gitignore` — self-documenting policy
+- `triage.log` — audit trail for routing decisions
+
+When triage routes an item to a plane, it is copied or moved out of `_inbox/`.
+The target plane applies its own `.gitignore` policy.
+
+## What Does Not Belong Here
+
+- Final classified content — move to the target plane
+- Secrets or credentials — use `aidevops secret set`
+- Build artefacts or generated files — use `.gitignore` at repo root
+
+## Provisioning
+
+```bash
+# Provision this repo's inbox:
+inbox-helper.sh provision .
+
+# Provision the workspace-level cross-repo inbox:
+inbox-helper.sh provision-workspace
+
+# Check status:
+inbox-helper.sh status .
+
+# Validate structure:
+inbox-helper.sh validate .
+```

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -1839,6 +1839,7 @@ main() {
 	tabby) _dispatch_helper "tabby-helper.sh" "tabby-helper.sh" "$@" ;;
 	init-routines) _dispatch_helper "init-routines-helper.sh" "init-routines-helper.sh" "$@" ;;
 	parent-status | ps) _dispatch_helper "parent-status-helper.sh" "parent-status-helper.sh" "$@" ;;
+	inbox) _dispatch_helper "inbox-helper.sh" "inbox-helper.sh" "$@" ;;
 	config | configure) _dispatch_config "$@" ;;
 	uninstall | remove) cmd_uninstall ;;
 	version | v | -v | --version) cmd_version ;;

--- a/setup.sh
+++ b/setup.sh
@@ -1076,6 +1076,15 @@ _setup_run_non_interactive() {
 	# copies doesn't burn CPU (t2885). Idempotent. macOS only — Linux
 	# indexers tracked separately.
 	setup_worktree_exclusions
+	# Provision the cross-repo workspace inbox at
+	# ~/.aidevops/.agent-workspace/inbox/ (t2866). Idempotent — safe to
+	# re-run on every update. Fail-open: a missing helper (first install
+	# before agent deploy) is not fatal.
+	local _inbox_helper="${AGENTS_DIR}/scripts/inbox-helper.sh"
+	[[ ! -f "$_inbox_helper" ]] && _inbox_helper="${INSTALL_DIR}/.agents/scripts/inbox-helper.sh"
+	if [[ -f "$_inbox_helper" ]]; then
+		bash "$_inbox_helper" provision-workspace || print_warning "inbox-helper.sh provision-workspace failed (non-critical)"
+	fi
 	return 0
 }
 

--- a/setup.sh
+++ b/setup.sh
@@ -982,6 +982,19 @@ _setup_install_pulse_plist_early() {
 	return 0
 }
 
+# Provision the cross-repo workspace inbox at
+# ~/.aidevops/.agent-workspace/inbox/ (t2866). Idempotent — safe to
+# re-run on every update. Fail-open: a missing helper (first install
+# before agent deploy) is not fatal.
+setup_inbox_provision() {
+	local _inbox_helper="${AGENTS_DIR}/scripts/inbox-helper.sh"
+	[[ ! -f "$_inbox_helper" ]] && _inbox_helper="${INSTALL_DIR}/.agents/scripts/inbox-helper.sh"
+	if [[ -f "$_inbox_helper" ]]; then
+		bash "$_inbox_helper" provision-workspace || print_warning "inbox-helper.sh provision-workspace failed (non-critical)"
+	fi
+	return 0
+}
+
 # Non-interactive path: deploy agents and run safe migrations only (no prompts).
 _setup_run_non_interactive() {
 	print_info "Non-interactive mode: deploying agents and running safe migrations only"
@@ -1076,15 +1089,7 @@ _setup_run_non_interactive() {
 	# copies doesn't burn CPU (t2885). Idempotent. macOS only — Linux
 	# indexers tracked separately.
 	setup_worktree_exclusions
-	# Provision the cross-repo workspace inbox at
-	# ~/.aidevops/.agent-workspace/inbox/ (t2866). Idempotent — safe to
-	# re-run on every update. Fail-open: a missing helper (first install
-	# before agent deploy) is not fatal.
-	local _inbox_helper="${AGENTS_DIR}/scripts/inbox-helper.sh"
-	[[ ! -f "$_inbox_helper" ]] && _inbox_helper="${INSTALL_DIR}/.agents/scripts/inbox-helper.sh"
-	if [[ -f "$_inbox_helper" ]]; then
-		bash "$_inbox_helper" provision-workspace || print_warning "inbox-helper.sh provision-workspace failed (non-critical)"
-	fi
+	setup_inbox_provision
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Implements the `_inbox/` directory contract for aidevops-managed repos — the transit zone that makes capture-then-classify workflows practical.

## What

- `inbox-helper.sh` — `provision`, `provision-workspace`, `status`, `validate`, `help` subcommands. Shellcheck clean.
- `inbox-readme.md` — template explaining transit-zone semantics, sensitivity contract, triage log format.
- `aidevops.sh` — `inbox` subcommand registered via `_dispatch_helper`.
- `setup.sh` — `inbox-helper.sh provision-workspace` wired into non-interactive path (fail-open).
- `test-inbox-provision.sh` — 7-test smoke suite, all passing.

## Testing

```
shellcheck .agents/scripts/inbox-helper.sh → PASS
shellcheck .agents/scripts/test-inbox-provision.sh → PASS
.agents/scripts/test-inbox-provision.sh → 7/7 PASS
```

## MERGE_SUMMARY

Implements the `_inbox/` directory contract for aidevops-managed repos (t2866, P2a of t2840 knowledge planes MVP).

Sub-folders created: `_drop/`, `email/`, `web/`, `scan/`, `voice/`, `import/`, `_needs-review/`. Supporting files: `README.md`, `.gitignore`, `triage.log`.

Workspace-level inbox provisioned at `~/.aidevops/.agent-workspace/inbox/` on `setup.sh` run. `aidevops inbox provision <repo>` available immediately. `status` and `validate` commands ready for downstream P2b/P2c consumers.

For #20892
Resolves #20930

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.17 plugin for [OpenCode](https://opencode.ai) v1.14.25 with claude-sonnet-4-6 spent 8m and 18,554 tokens on this as a headless worker.
