### PR TITLE
t2921: fix worker-watchdog find_workers regex broken by t2421 alternation

### DIFF
--- a/.agents/scripts/tests/test-worker-watchdog-find-workers.sh
+++ b/.agents/scripts/tests/test-worker-watchdog-find-workers.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-worker-watchdog-find-workers.sh — Regression test for t2921 (GH#21091)
+#
+# Verifies find_workers in worker-watchdog-detect.sh handles the
+# WORKER_PROCESS_PATTERN alternation introduced in t2421/PR #20126
+# (`opencode|claude|Claude` in shared-constants.sh:1088).
+#
+# The historical pattern used basic `grep "$bracket_trick_pattern"` which
+# silently failed on alternation:
+#   - basic regex treats `|` as literal -> pattern matched nothing
+#   - watchdog became silent no-op (last log entry 2026-04-20 17:14:18)
+#
+# This test catches regression of:
+#   1. Missing `-E` flag on the worker-binary grep
+#   2. Self-match where the grep pipeline appears in its own ps output
+#   3. False positives on processes lacking `/full-loop` (interactive opencode)
+#   4. False positives on the watchdog's own ps line
+#
+# Stubs ps via PATH override so the test is hermetic and does not depend
+# on the live system's process table.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+LIB_DIR="${SCRIPT_DIR}/.."
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+ORIGINAL_PATH="${PATH}"
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+# Build a stub `ps` whose canned output exercises the filter chain.
+# The fixture rows are documented inline so future regressions land
+# exactly the row they violate.
+write_ps_stub() {
+	local stub_dir="$1"
+	cat >"${stub_dir}/ps" <<'STUB'
+#!/usr/bin/env bash
+# Stub ps for find_workers regression test (t2921).
+# Ignore all flags — find_workers only cares about pid,command output.
+#
+# PIDs picked to be mutually non-substring (no "1000" inside "41000")
+# so simple glob assertions cannot false-positive.
+printf '%s\n' \
+	'81234 bash /Users/u/.aidevops/agents/scripts/headless-runtime-helper.sh run --role worker /full-loop Implement issue #1 --model anthropic/claude-sonnet-4-6' \
+	'82345 node /opt/homebrew/bin/opencode run --print-logs /full-loop Implement issue #2' \
+	'83456 /opt/homebrew/lib/node_modules/opencode-ai/bin/.opencode run /full-loop Implement issue #3' \
+	'84567 /opt/homebrew/bin/claude run /full-loop Implement issue #4' \
+	'70001 /Applications/Claude.app/Contents/MacOS/Claude' \
+	'70002 grep -E opencode|claude|Claude' \
+	'70003 bash /home/u/.aidevops/agents/scripts/worker-watchdog.sh --check' \
+	'70004 /opt/homebrew/bin/opencode' \
+	'70005 /bin/zsh -l -i -c opencode' \
+	'70006 sshd: user@pts/0' \
+	''
+STUB
+	chmod +x "${stub_dir}/ps"
+	return 0
+}
+
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+	write_ps_stub "$TEST_ROOT"
+	export PATH="${TEST_ROOT}:${ORIGINAL_PATH}"
+	# Stub _get_process_age so find_workers does not need real PIDs.
+	_get_process_age() { echo 123; }
+	export -f _get_process_age
+	# Source shared-constants for WORKER_PROCESS_PATTERN.
+	# shellcheck source=/dev/null
+	source "${LIB_DIR}/shared-constants.sh" >/dev/null 2>&1
+	# Source the detect lib under test.
+	# shellcheck source=/dev/null
+	source "${LIB_DIR}/worker-watchdog-detect.sh" >/dev/null 2>&1
+	return 0
+}
+
+teardown_test_env() {
+	export PATH="${ORIGINAL_PATH}"
+	unset -f _get_process_age 2>/dev/null || true
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+# ──────────────────────────────────────────────────────────────────────────────
+# Tests
+# ──────────────────────────────────────────────────────────────────────────────
+
+test_alternation_pattern_matches_headless_with_model_flag() {
+	# Bash wrapper proc carries `--model anthropic/claude-...` -> matches `claude`.
+	local output
+	output=$(find_workers)
+	if [[ "$output" == *"81234|"* ]]; then
+		print_result "alternation matches headless wrapper via --model claude (81234)" 0
+		return 0
+	fi
+	print_result "alternation matches headless wrapper via --model claude" 1 "expected 81234 in: $output"
+	return 0
+}
+
+test_alternation_pattern_matches_opencode_workers() {
+	local output
+	output=$(find_workers)
+	if [[ "$output" == *"82345|"* && "$output" == *"83456|"* ]]; then
+		print_result "alternation matches opencode workers (82345, 83456)" 0
+		return 0
+	fi
+	print_result "alternation matches opencode workers" 1 "missing 82345/83456 in: $output"
+	return 0
+}
+
+test_alternation_pattern_matches_claude_worker() {
+	local output
+	output=$(find_workers)
+	if [[ "$output" == *"84567|"* ]]; then
+		print_result "alternation matches claude worker (84567)" 0
+		return 0
+	fi
+	print_result "alternation matches claude worker" 1 "expected 84567 in: $output"
+	return 0
+}
+
+test_grep_self_excluded() {
+	# The `grep -E opencode|claude|Claude` pipeline appears in its own ps view;
+	# must be filtered or it self-detects and skews active-worker counts.
+	local output
+	output=$(find_workers)
+	if [[ "$output" != *"70002|"* ]]; then
+		print_result "grep -E pipeline self-match excluded (PID 70002)" 0
+		return 0
+	fi
+	print_result "grep -E pipeline self-match excluded" 1 "PID 70002 leaked through: $output"
+	return 0
+}
+
+test_watchdog_excluded() {
+	# worker-watchdog.sh itself contains "opencode" in its substring search,
+	# so the regex matches; the `*worker-watchdog*` skip in the loop must drop it.
+	local output
+	output=$(find_workers)
+	if [[ "$output" != *"70003|"* ]]; then
+		print_result "worker-watchdog process excluded (PID 70003)" 0
+		return 0
+	fi
+	print_result "worker-watchdog process excluded" 1 "PID 70003 leaked through: $output"
+	return 0
+}
+
+test_interactive_opencode_excluded() {
+	# Bare opencode / shell launchers without `/full-loop` in argv are interactive
+	# user sessions, NOT headless workers — must NOT show up.
+	local output
+	output=$(find_workers)
+	if [[ "$output" != *"70001|"* && "$output" != *"70004|"* && "$output" != *"70005|"* ]]; then
+		print_result "interactive opencode/Claude procs excluded (70001, 70004, 70005)" 0
+		return 0
+	fi
+	print_result "interactive opencode/Claude procs excluded" 1 "leaked: $output"
+	return 0
+}
+
+test_unrelated_process_excluded() {
+	local output
+	output=$(find_workers)
+	if [[ "$output" != *"70006|"* ]]; then
+		print_result "unrelated process excluded (PID 70006)" 0
+		return 0
+	fi
+	print_result "unrelated process excluded" 1 "PID 70006 leaked: $output"
+	return 0
+}
+
+test_output_shape_pid_elapsed_command() {
+	local output first_line
+	output=$(find_workers)
+	first_line="${output%%$'\n'*}"
+	# Format: PID|ELAPSED|COMMAND  with elapsed=123 from stub
+	if [[ "$first_line" == *"|123|"* ]]; then
+		print_result "output shape PID|ELAPSED|COMMAND honoured" 0
+		return 0
+	fi
+	print_result "output shape PID|ELAPSED|COMMAND honoured" 1 "first line: $first_line"
+	return 0
+}
+
+run_all() {
+	setup_test_env
+	test_alternation_pattern_matches_headless_with_model_flag
+	test_alternation_pattern_matches_opencode_workers
+	test_alternation_pattern_matches_claude_worker
+	test_grep_self_excluded
+	test_watchdog_excluded
+	test_interactive_opencode_excluded
+	test_unrelated_process_excluded
+	test_output_shape_pid_elapsed_command
+	teardown_test_env
+	return 0
+}
+
+main() {
+	run_all
+	printf '\nSummary: %d run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/worker-watchdog-detect.sh
+++ b/.agents/scripts/worker-watchdog-detect.sh
@@ -44,11 +44,22 @@ fi
 # Output: one line per worker: "PID|ELAPSED_SECS|COMMAND"
 #######################################
 find_workers() {
-	# Match worker processes with /full-loop (headless workers)
-	# Build grep pattern: bracket-trick on first char excludes grep from results
-	local pattern_char="${WORKER_PROCESS_PATTERN:0:1}"
-	local pattern_rest="${WORKER_PROCESS_PATTERN:1}"
-	local grep_pattern="[${pattern_char}]${pattern_rest}"
+	# Match worker processes with /full-loop (headless workers).
+	#
+	# WORKER_PROCESS_PATTERN is an extended-regex alternation
+	# (e.g. "opencode|claude|Claude" — see shared-constants.sh § "Process
+	# pattern constants"). It MUST be passed to grep -E. The historical
+	# bracket-trick that excluded grep from its own output (`[o]pencode`)
+	# only worked for single-word patterns; with alternation present, the
+	# pattern itself contains words that would match the grep argv. Filter
+	# grep out explicitly via `grep -v -- 'grep -E'` instead.
+	#
+	# Filters layered on the ps stream:
+	#   1. grep -E "$WORKER_PROCESS_PATTERN" — match opencode/claude binaries
+	#   2. grep -v -- 'grep -E'              — skip the grep pipeline itself
+	#   3. grep -F '/full-loop'              — keep only headless dispatch
+	# The in-loop "$line == *worker-watchdog*" guard is a defence-in-depth
+	# skip for the watchdog's own ps line; it does not replace filter #2.
 	local line pid cmd elapsed_seconds
 
 	while IFS= read -r line; do
@@ -68,7 +79,11 @@ find_workers() {
 
 		# Output: PID|ELAPSED|COMMAND
 		echo "${pid}|${elapsed_seconds}|${cmd}"
-	done < <(ps axwwo pid,command | grep "$grep_pattern" | grep '/full-loop' || true)
+	done < <(ps axwwo pid,command \
+		| grep -E "${WORKER_PROCESS_PATTERN:-opencode}" \
+		| grep -v -- 'grep -E' \
+		| grep -F '/full-loop' \
+		|| true)
 
 	return 0
 }


### PR DESCRIPTION
## Summary
Restore worker-watchdog detection that has been silently broken since t2421/PR #20126 (2026-04-20). The watchdog has not killed a stuck worker in 6 days — `~/.aidevops/logs/worker-watchdog.log` last entry: `2026-04-20 17:14:18`.

## Root cause
`shared-constants.sh:1088` (PR #20126) widened `WORKER_PROCESS_PATTERN` from the single word `opencode` to the alternation `opencode|claude|Claude`. `find_workers()` in `worker-watchdog-detect.sh` was untouched and still used:

```bash
local grep_pattern="[${pattern_char}]${pattern_rest}"   # bracket-trick
ps … | grep "$grep_pattern" | grep '/full-loop'         # basic grep
```

Two failures:
1. **Basic `grep` treats `|` as literal** — the entire pattern `[o]pencode|claude|Claude` matches nothing → empty input → watchdog sees zero workers, never kills.
2. **Even with `-E`**, the bracket-trick only protects the first alternative. The literal substrings `claude` and `Claude` in the grep argv would self-match via the alternation, re-introducing the self-detection problem the bracket-trick was added to prevent.

Result: stuck workers (>14min etime) accumulated on the canonical host without auto-kill, burning slots from the 24-worker pool. Three were manually killed in the prior session.

## Fix
- Use `grep -E "$WORKER_PROCESS_PATTERN"` (proper alternation).
- Drop the bracket-trick.
- Filter the grep pipeline itself via `grep -v -- 'grep -E'`.
- Keep `/full-loop` as `grep -F` (literal — it's a fixed string).
- Defence-in-depth: in-loop `*worker-watchdog*` skip retained.
- Inline comment documents the alternation incompatibility so the next reader doesn't reintroduce the bracket-trick.

The architecture is the same as `pulse-cleanup.sh:993` and `list_active_workers.awk:18-19` (the canonical reference impl).

## Verification
- `bash -n` and `shellcheck` clean on both files.
- New regression test `.agents/scripts/tests/test-worker-watchdog-find-workers.sh` (8 assertions):
  - PID 81234 (bash wrapper, matches `claude` only via `--model anthropic/claude-…`).
  - PIDs 82345, 83456 (opencode workers).
  - PID 84567 (claude worker).
  - Excludes the `grep -E` pipeline itself, the watchdog process, interactive opencode/Claude (no `/full-loop`), unrelated processes.
  - Asserts output shape `PID|ELAPSED|COMMAND`.
- **Mutation test confirms regression coverage**: reverting `grep -E` → `grep` causes 4 tests to fail (zero workers detected — exact production symptom); restoring `-E` → all 8 pass.
- Live functional check on the canonical host: sourced `find_workers` returns the active worker chain for issue #20919 (PIDs 40540/41374/41381).

## Why now
The 24-worker pool capacity is meaningless if stuck workers don't get killed — they pin slots indefinitely. With t2920 just merged (lifting the t2821 dispatch-path block), dispatch volume is rising; without the watchdog, every dead worker becomes a permanent capacity loss.

## Out of scope (deferred to follow-ups)
- `worker-watchdog.sh:85` defines `WORKER_PROCESS_PATTERN="${WORKER_PROCESS_PATTERN:-opencode}"` — redundant override of the canonical `shared-constants.sh:1088` value. Currently harmless because source-order makes shared-constants win, but should be removed for clarity. Tracking separately per the one-fix-per-PR convention.

Resolves #21091


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.17 plugin for [OpenCode](https://opencode.ai) v1.14.25 with claude-opus-4-7 spent 3h 19m and 274,472 tokens on this with the user in an interactive session.