### PR TITLE
t2861: fix gh PATH shim --body-file source mutation — use temp file

### DIFF
--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -520,12 +520,37 @@ if [[ $_body_idx -ge 0 && -n "$_body_val" ]]; then
 fi
 
 # --- --body-file case --------------------------------------------------------
+# t2861: write the augmented content to a fresh temp file rather than appending
+# to the user's source. The user's brief on disk stays byte-identical after the
+# gh call. The temp file is cleaned up by a background reaper (the shim ends
+# with exec, which replaces the process and clears traps).
 if [[ $_body_file_idx -ge 0 && -n "$_body_file_val" && -f "$_body_file_val" ]]; then
 	if ! grep -q "<!-- aidevops:sig -->" "$_body_file_val" 2>/dev/null; then
 		_file_content=$(<"$_body_file_val") || _file_content=""
 		_sig_footer=$("$SIG_HELPER" footer --body "$_file_content" 2>/dev/null || echo "")
 		if [[ -n "$_sig_footer" ]]; then
-			printf '%s' "$_sig_footer" >>"$_body_file_val" || true
+			# Build augmented body in a temp file we own — never mutate the source.
+			_tmp_body_file=$(mktemp -t aidevops-gh-shim-body.XXXXXX 2>/dev/null) || _tmp_body_file=""
+			if [[ -n "$_tmp_body_file" ]]; then
+				if printf '%s%s' "$_file_content" "$_sig_footer" >"$_tmp_body_file" 2>/dev/null; then
+					# Substitute the arg pointing at user's file with our temp file.
+					if [[ $_body_file_eq -eq 1 ]]; then
+						_modified_args[_body_file_idx]="--body-file=${_tmp_body_file}"
+					else
+						_modified_args[_body_file_idx + 1]="$_tmp_body_file"
+					fi
+					# Background reaper: exec replaces this process so EXIT traps
+					# never fire. Fork a sleep-then-rm to clean up the temp file
+					# after gh has had time to read it (30s >> typical gh runtime).
+					( sleep 30 && rm -f "$_tmp_body_file" ) &
+					disown
+				else
+					rm -f "$_tmp_body_file"
+					# Fall through: gh receives original file, footer is omitted.
+					# Better than corrupting the user's source on a write failure.
+				fi
+			fi
+			# If mktemp failed, fall through silently — same safe degradation.
 		fi
 	fi
 fi
@@ -533,6 +558,25 @@ fi
 # t2876: privacy scan runs after sig footer injection — fail-closed on hit.
 if ! _shim_privacy_scan; then
 	exit 1
+fi
+
+# t2861: test-mode hook — short-circuits exec so regression tests can inspect
+# the resolved --body-file path without actually calling the real gh binary.
+# Usage: SHIM_TEST_MODE=1 ./gh issue create --body-file <file> ...
+if [[ "${SHIM_TEST_MODE:-}" == "1" ]]; then
+	_shim_t=0
+	while [[ $_shim_t -lt ${#_modified_args[@]} ]]; do
+		case "${_modified_args[$_shim_t]}" in
+		--body-file)
+			printf 'resolved_body_file=%s\n' "${_modified_args[_shim_t + 1]}"
+			;;
+		--body-file=*)
+			printf 'resolved_body_file=%s\n' "${_modified_args[$_shim_t]#--body-file=}"
+			;;
+		esac
+		_shim_t=$((_shim_t + 1))
+	done
+	exit 0
 fi
 
 exec "$REAL_GH" "${_modified_args[@]}"

--- a/.agents/scripts/test-gh-shim-body-file-immutable.sh
+++ b/.agents/scripts/test-gh-shim-body-file-immutable.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# Regression test for t2861: gh PATH shim must NOT mutate --body-file source
+# =============================================================================
+#
+# Verifies that `gh issue create --body-file <file>` leaves the source file
+# byte-identical before and after the shim runs. Uses SHIM_TEST_MODE=1 to
+# short-circuit the exec step so no real gh binary is required.
+#
+# Usage:
+#   .agents/scripts/test-gh-shim-body-file-immutable.sh
+#   # Expected output: PASS: --body-file source unchanged after shim
+#
+# =============================================================================
+set -euo pipefail
+
+SHIM="$(cd "$(dirname "$0")" && pwd)/gh"
+
+if [[ ! -x "$SHIM" ]]; then
+	printf 'SKIP: shim not found at %s\n' "$SHIM"
+	exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Test 1: --body-file <space-separated> form — source file must be unchanged
+# ---------------------------------------------------------------------------
+_fixture=$(mktemp -t aidevops-test-brief.XXXXXX)
+printf 'Test body\n\nSecond paragraph.\n' >"$_fixture"
+_hash_before=$(shasum -a 256 "$_fixture" | awk '{print $1}')
+
+# Run the shim in test mode. SIG_HELPER may emit output — capture to /dev/null.
+# REAL_GH is set to a no-op so the shim's _find_real_gh fallback doesn't error
+# if the test machine has no gh binary.
+_resolved=$(SHIM_TEST_MODE=1 AIDEVOPS_GH_SHIM_DISABLE=0 \
+	"$SHIM" issue create --body-file "$_fixture" --title "test" 2>/dev/null) || true
+
+_hash_after=$(shasum -a 256 "$_fixture" | awk '{print $1}')
+
+if [[ "$_hash_before" != "$_hash_after" ]]; then
+	printf 'FAIL: --body-file source was mutated (space form)\n'
+	printf '  before: %s\n' "$_hash_before"
+	printf '  after:  %s\n' "$_hash_after"
+	rm -f "$_fixture"
+	exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Test 2: resolved_body_file must differ from the source (a temp file was used)
+# or be empty (sig helper unavailable). It must NOT equal the source path.
+# ---------------------------------------------------------------------------
+if [[ -n "$_resolved" ]]; then
+	_resolved_path="${_resolved#resolved_body_file=}"
+	if [[ "$_resolved_path" == "$_fixture" ]]; then
+		printf 'FAIL: resolved_body_file is the source file — shim did not use a temp copy\n'
+		printf '  resolved: %s\n' "$_resolved_path"
+		printf '  source:   %s\n' "$_fixture"
+		rm -f "$_fixture"
+		exit 1
+	fi
+fi
+
+rm -f "$_fixture"
+
+# ---------------------------------------------------------------------------
+# Test 3: --body-file=<attached> form
+# ---------------------------------------------------------------------------
+_fixture2=$(mktemp -t aidevops-test-brief.XXXXXX)
+printf 'Attached form test\n' >"$_fixture2"
+_hash_before2=$(shasum -a 256 "$_fixture2" | awk '{print $1}')
+
+SHIM_TEST_MODE=1 AIDEVOPS_GH_SHIM_DISABLE=0 \
+	"$SHIM" issue create "--body-file=${_fixture2}" --title "test" 2>/dev/null || true
+
+_hash_after2=$(shasum -a 256 "$_fixture2" | awk '{print $1}')
+
+if [[ "$_hash_before2" != "$_hash_after2" ]]; then
+	printf 'FAIL: --body-file source was mutated (attached = form)\n'
+	rm -f "$_fixture2"
+	exit 1
+fi
+
+rm -f "$_fixture2"
+
+printf 'PASS: --body-file source unchanged after shim\n'
+exit 0


### PR DESCRIPTION
## Summary

- **Bug:** `gh` PATH shim was appending the signature footer directly to the user's `--body-file` source on disk, mutating committed brief files on every `gh issue create` call.
- **Fix:** Write the augmented body to a fresh `mktemp` temp file, substitute only the `--body-file` arg in `_modified_args`, and clean up via a background reaper (`sleep 30 && rm`). The user's source stays byte-identical.
- **Test:** New regression test `test-gh-shim-body-file-immutable.sh` verifies both the space-arg and `=`-arg forms using `SHIM_TEST_MODE=1`.

## Root Cause

`.agents/scripts/gh:528` used `printf '%s' "$_sig_footer" >> "$_body_file_val"` — appending directly to the user-provided path. The `--body` (string) branch at line 512 was already correct (modifies `_modified_args` in-memory); the `--body-file` branch should have mirrored that pattern using a temp file.

## Changes

- `EDIT: .agents/scripts/gh:522-531` — replace 9-line in-place append with 25-line temp-file substitution + background reaper
- `EDIT: .agents/scripts/gh:533-581` — add `SHIM_TEST_MODE=1` hook just before final `exec` (enables regression testing without a real gh binary)
- `NEW: .agents/scripts/test-gh-shim-body-file-immutable.sh` — regression test with 3 assertions

## Verification

```
shellcheck .agents/scripts/gh                          # clean
shellcheck .agents/scripts/test-gh-shim-body-file-immutable.sh  # clean
.agents/scripts/test-gh-shim-body-file-immutable.sh   # PASS
```

Resolves #20918

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.17 plugin for [OpenCode](https://opencode.ai) v1.14.25 with claude-sonnet-4-6 spent 5m and 8,672 tokens on this as a headless worker.
