### PR TITLE
t2924: filter non-dispatchable management labels at candidate-build time

### DIFF
--- a/.agents/scripts/pulse-repo-meta.sh
+++ b/.agents/scripts/pulse-repo-meta.sh
@@ -178,7 +178,19 @@ get_repo_role_by_slug() {
 #   - status:blocked (explicit hold)
 #   - needs-* (waiting for maintainer action)
 #   - supervisor/persistent/routine-tracking (non-work telemetry)
+#   - parent-task (decomposition tracker, never directly dispatchable; t2924)
+#   - no-auto-dispatch (explicit dispatch opt-out; t2924)
+#   - status:in-progress, status:in-review, status:claimed, status:done
+#     (active or completed claims that the dispatcher would always block; t2924)
 # Everything else passes through for the downstream dedup layers to decide.
+#
+# t2924 rationale: filtering these at candidate-build time (instead of dispatch
+# time) avoids re-evaluating the same blocked candidates on every pulse cycle
+# (~10s interval). With 200+ candidates and parent-task issues frequently
+# appearing in the top of the ranked list, this saves measurable GraphQL+CPU
+# per cycle. The dispatch-time check (dispatch-dedup-helper.sh::is-assigned)
+# remains as defense-in-depth for the race window between candidate build and
+# dispatch.
 #
 # Arguments:
 #   $1 - repo slug (owner/repo)
@@ -217,6 +229,18 @@ list_dispatchable_issue_candidates_json() {
 			select(($labels | index("supervisor")) == null) |
 			select(($labels | index("persistent")) == null) |
 			select(($labels | index("routine-tracking")) == null) |
+			# t2924: filter non-dispatchable management labels at candidate-build
+			# time, not dispatch time. Reduces wasted GraphQL+CPU on every pulse cycle
+			# re-evaluating issues the dispatcher would always block.
+			# The dispatch-time check (dispatch-dedup-helper.sh) remains as
+			# defense-in-depth for race conditions where labels are added between
+			# candidate build and dispatch.
+			select(($labels | index("parent-task")) == null) |
+			select(($labels | index("no-auto-dispatch")) == null) |
+			select(($labels | index("status:in-progress")) == null) |
+			select(($labels | index("status:in-review")) == null) |
+			select(($labels | index("status:claimed")) == null) |
+			select(($labels | index("status:done")) == null) |
 			{
 				number,
 				title,


### PR DESCRIPTION
## Summary

Filters parent-task, no-auto-dispatch, and active-status labels at candidate-build time in `list_dispatchable_issue_candidates_json`, instead of letting them flow through to the dispatch loop where they were re-evaluated every pulse cycle.

## Why

Pulse log evidence (Apr 26):
- 200+ candidates per cycle, with `parent-task` issues like #21056, #20966, #20929, #20892 ALWAYS at the top of the ranked list (highest `bug` priority + bumped score).
- Each cycle the dispatch loop iterated these, called `dispatch_with_dedup`, got `Dispatch blocked: non-dispatchable management label present`, and moved on.
- At ~10s pulse interval, this is hundreds of wasted GraphQL + CPU calls per hour.
- This is one of the systemic causes of the observed 4 PRs/hr throughput vs the 24/hr target.

## How

EDIT: `.agents/scripts/pulse-repo-meta.sh` — add 6 jq `select(...)` filter lines to the existing filter chain at lines 215-219.

The 6 new filters exclude:
- `parent-task` (decomposition trackers, never directly dispatchable)
- `no-auto-dispatch` (explicit dispatch opt-out)
- `status:in-progress`, `status:in-review`, `status:claimed`, `status:done` (active or completed claims)

The dispatch-time check (`dispatch-dedup-helper.sh::is-assigned`) remains as defense-in-depth.

## Verification

\`\`\`bash
shellcheck .agents/scripts/pulse-repo-meta.sh  # zero violations
bash -n .agents/scripts/pulse-repo-meta.sh     # syntax OK
\`\`\`

jq filter behaviour verified:
- Issue with \`parent-task\` label → filtered (returns \`[]\`)
- Issue with \`bug\` label only → passes through

## Acceptance Criteria

- [x] \`shellcheck\` zero violations
- [x] jq filter syntax valid
- [x] All 6 management labels filtered
- [x] Dispatch-time check preserved as defense-in-depth
- [x] Docstring updated with rationale and t2924 reference

Resolves #21099
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.17 plugin for [OpenCode](https://opencode.ai) v1.14.25 with claude-opus-4-7 spent 4h 49m and 406,634 tokens on this with the user in an interactive session.