### PR TITLE
GH#21057: fix Phase 1 auto-release GitHub gap (scan-stale leaves status:in-review + assignee)

### DIFF
--- a/.agents/scripts/interactive-session-helper.sh
+++ b/.agents/scripts/interactive-session-helper.sh
@@ -840,12 +840,18 @@ _isc_cmd_release() {
 		fi
 	fi
 
-	if set_issue_status "$issue" "$slug" "available" ${extra_flags[@]+"${extra_flags[@]}"} >/dev/null 2>&1; then
+	# Capture stderr so failures surface with the actual gh error message
+	# rather than being silently swallowed. Previously >/dev/null 2>&1 hid
+	# the root cause of stuck-claim incidents (GH#21057).
+	local _set_status_err
+	_set_status_err=$(set_issue_status "$issue" "$slug" "available" \
+		${extra_flags[@]+"${extra_flags[@]}"} 2>&1 >/dev/null)
+	local _set_status_rc=$?
+	if [[ $_set_status_rc -eq 0 ]]; then
 		_isc_info "release: #$issue → status:available"
 		return 0
 	fi
-
-	_isc_warn "release: gh failed on #$issue — label may still be set"
+	_isc_warn "release: gh failed on #$issue (rc=$_set_status_rc): $_set_status_err"
 	return 0
 }
 
@@ -1123,8 +1129,13 @@ _isc_release_claim_by_stamp_path() {
 	fi
 
 	# Delegate to canonical release flow: stamp deletion + label transition.
+	# --unassign is mandatory here: auto-release is the dead-stamp recovery
+	# path, the runner that owned the claim is gone, so the self-assignment
+	# is meaningless and must clear. Without it, the owner self-assignment
+	# persists and keeps dispatch blocked per the t1996 invariant even after
+	# the label transitions (GH#21057).
 	# _isc_cmd_release is idempotent and fail-open on offline gh.
-	_isc_cmd_release "$r_issue" "$r_slug"
+	_isc_cmd_release --unassign "$r_issue" "$r_slug"
 	return 0
 }
 

--- a/.agents/scripts/reconcile-stuck-claims.sh
+++ b/.agents/scripts/reconcile-stuck-claims.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# reconcile-stuck-claims.sh (GH#21057 — Phase 1 auto-release GitHub gap)
+#
+# One-shot reconciler that heals issues left in the stuck-claim state: the
+# Phase 1 auto-release path in scan-stale previously deleted the local stamp
+# but skipped the GitHub-side cleanup (status:in-review + self-assignment
+# persisted), causing the footprint-overlap cache to treat those issues as
+# in-flight indefinitely and blocking dispatch on every issue touching an
+# overlapping file path.
+#
+# This script is the systemic heal after deploying the fix in
+# interactive-session-helper.sh (GH#21057). Run once after deploy to clear
+# the backlog. Idempotent; safe to re-run.
+#
+# Stuck-claim definition:
+#   - Issue is OPEN
+#   - Carries origin:interactive label
+#   - Carries status:in-review OR status:claimed
+#   - Is assigned to $current_user
+#   - Has NO live stamp at ~/.aidevops/.agent-workspace/claim-stamps/<slug>-<num>.json
+#
+# Usage:
+#   reconcile-stuck-claims.sh [--dry-run] [--repo slug] [--apply]
+#
+# --dry-run   (default) Print what would change without applying.
+# --apply     Actually release the stuck claims.
+# --repo SLUG Limit to a specific repo. Default: all pulse-enabled repos.
+#
+# Exit codes:
+#   0 — all eligible issues processed (or no changes needed)
+#   1 — fatal error
+#   2 — at least one issue failed to update (partial success)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/shared-constants.sh" 2>/dev/null || {
+	printf 'ERROR: cannot source shared-constants.sh\n' >&2
+	exit 1
+}
+
+# Source the interactive-session helper so we can call _isc_cmd_release.
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/interactive-session-helper.sh" 2>/dev/null || {
+	printf 'ERROR: cannot source interactive-session-helper.sh\n' >&2
+	exit 1
+}
+
+# 1=dry-run (default, safe); 0=apply
+DRY_RUN=1
+REPO_FILTER=""
+
+usage() {
+	printf 'Usage: %s [--dry-run] [--apply] [--repo owner/repo]\n' "$(basename "$0")"
+	printf '\n'
+	printf 'One-shot reconciler for stuck interactive claims (GH#21057).\n'
+	printf 'Default: --dry-run (safe, no changes made).\n'
+	return 0
+}
+
+parse_args() {
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+		--dry-run) DRY_RUN=1 ;;
+		--apply) DRY_RUN=0 ;;
+		--repo)
+			REPO_FILTER="${2:-}"
+			shift
+			;;
+		--help | -h)
+			usage
+			exit 0
+			;;
+		*)
+			printf 'Unknown argument: %s\n' "$arg" >&2
+			usage >&2
+			exit 1
+			;;
+		esac
+		shift
+	done
+	return 0
+}
+
+# List pulse-enabled repos from repos.json (same pattern as reconcile-origin-labels.sh).
+list_repos() {
+	local repos_json="${HOME}/.config/aidevops/repos.json"
+	if [[ -n "$REPO_FILTER" ]]; then
+		printf '%s\n' "$REPO_FILTER"
+		return 0
+	fi
+	[[ -f "$repos_json" ]] || {
+		printf 'ERROR: repos.json not found at %s\n' "$repos_json" >&2
+		return 1
+	}
+	jq -r '
+		.initialized_repos[]
+		| select(.pulse == true and (.local_only // false) == false)
+		| .slug
+	' "$repos_json" 2>/dev/null
+	return 0
+}
+
+# Check whether a live stamp exists for the given issue+slug.
+# Returns 0 if stamp is absent (issue is stuck), 1 if stamp is present (skip).
+_has_no_live_stamp() {
+	local issue="$1"
+	local slug="$2"
+	local stamp_dir="${HOME}/.aidevops/.agent-workspace/claim-stamps"
+
+	# Normalise slug: owner/repo → owner-repo for filename matching
+	local slug_safe
+	slug_safe="${slug//\//-}"
+
+	local stamp_path="${stamp_dir}/${slug_safe}-${issue}.json"
+
+	# If stamp exists, the claim is still live — do NOT release.
+	[[ -f "$stamp_path" ]] && return 1
+
+	# No stamp → issue is potentially stuck.
+	return 0
+}
+
+# Find stuck claims in a given repo.
+# Emits NDJSON lines: {"number":N,"title":"...","labels":["..."]}
+find_stuck_claims() {
+	local repo="$1"
+	local current_user="$2"
+
+	local json
+	json=$(gh issue list --repo "$repo" \
+		--state open \
+		--assignee "$current_user" \
+		--limit 200 \
+		--json number,title,labels,assignees 2>/dev/null) || json="[]"
+
+	# Filter: origin:interactive AND (status:in-review OR status:claimed)
+	printf '%s' "$json" | jq -rc --arg user "$current_user" '
+		.[]
+		| . as $issue
+		| [.labels[].name] as $labels
+		| select(
+			($labels | index("origin:interactive")) != null
+			and (
+				($labels | index("status:in-review")) != null
+				or ($labels | index("status:claimed")) != null
+			)
+			and (
+				[.assignees[].login] | index($user) != null
+			)
+		)
+		| {
+			number,
+			title: (.title | .[0:80]),
+			labels: $labels
+		}
+	' 2>/dev/null
+	return 0
+}
+
+release_stuck_claim() {
+	local repo="$1"
+	local issue_number="$2"
+	local title="$3"
+
+	if [[ "$DRY_RUN" -eq 1 ]]; then
+		printf '  DRY-RUN: #%s → release --unassign (%s)\n' "$issue_number" "$title"
+		return 0
+	fi
+
+	# Use _isc_cmd_release with --unassign (the fix from GH#21057).
+	# This clears status:in-review → status:available AND removes self-assignment.
+	if _isc_cmd_release --unassign "$issue_number" "$repo"; then
+		printf '  RELEASED: #%s → status:available + unassigned (%s)\n' \
+			"$issue_number" "$title"
+		return 0
+	fi
+	# _isc_cmd_release is fail-open (exit 0 always), so failure is already
+	# logged via _isc_warn. Report here for summary counters.
+	printf '  FAILED:   #%s — see warning above (%s)\n' "$issue_number" "$title" >&2
+	return 1
+}
+
+main() {
+	parse_args "$@"
+
+	command -v gh >/dev/null 2>&1 || {
+		printf 'ERROR: gh CLI not found\n' >&2
+		exit 1
+	}
+
+	command -v jq >/dev/null 2>&1 || {
+		printf 'ERROR: jq not found\n' >&2
+		exit 1
+	}
+
+	local current_user
+	current_user=$(gh api user --jq '.login' 2>/dev/null) || {
+		printf 'ERROR: cannot resolve current gh user (is gh auth valid?)\n' >&2
+		exit 1
+	}
+	[[ -z "$current_user" ]] && {
+		printf 'ERROR: gh user is empty\n' >&2
+		exit 1
+	}
+
+	if [[ "$DRY_RUN" -eq 1 ]]; then
+		printf 'DRY-RUN mode (use --apply to release). Scanning for stuck claims...\n'
+		printf 'Current user: %s\n\n' "$current_user"
+	else
+		printf 'APPLY mode. Releasing stuck claims for user: %s\n\n' "$current_user"
+	fi
+
+	local repos
+	repos=$(list_repos) || exit 1
+	[[ -z "$repos" ]] && {
+		printf 'No pulse-enabled repos found.\n'
+		exit 0
+	}
+
+	local total_found=0
+	local total_released=0
+	local total_failed=0
+	local total_skipped=0
+
+	while IFS= read -r repo; do
+		[[ -z "$repo" ]] && continue
+		printf 'Scanning %s...\n' "$repo"
+
+		local issues
+		issues=$(find_stuck_claims "$repo" "$current_user")
+		if [[ -z "$issues" ]]; then
+			printf '  No stuck claims found.\n'
+			continue
+		fi
+
+		while IFS= read -r issue_json; do
+			[[ -z "$issue_json" ]] && continue
+			local num title
+			num=$(printf '%s' "$issue_json" | jq -r '.number')
+			title=$(printf '%s' "$issue_json" | jq -r '.title')
+
+			total_found=$((total_found + 1))
+
+			# Skip if a live stamp exists (claim is active, not stuck).
+			if ! _has_no_live_stamp "$num" "$repo"; then
+				printf '  SKIP:     #%s — live stamp present, claim is active\n' "$num"
+				total_skipped=$((total_skipped + 1))
+				continue
+			fi
+
+			if release_stuck_claim "$repo" "$num" "$title"; then
+				total_released=$((total_released + 1))
+			else
+				total_failed=$((total_failed + 1))
+			fi
+		done <<<"$issues"
+	done <<<"$repos"
+
+	printf '\nSummary: found=%d released=%d skipped=%d failed=%d\n' \
+		"$total_found" "$total_released" "$total_skipped" "$total_failed"
+
+	if [[ "$total_found" -eq 0 ]]; then
+		printf 'No stuck claims found.\n'
+	fi
+
+	if [[ "$DRY_RUN" -eq 1 && "$total_found" -gt 0 ]]; then
+		printf '\nRe-run with --apply to release %d stuck claim(s).\n' \
+			"$((total_found - total_skipped))"
+	fi
+
+	[[ "$total_failed" -gt 0 ]] && exit 2
+	exit 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-stamp-release-github-gap.sh
+++ b/.agents/scripts/tests/test-stamp-release-github-gap.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-stamp-release-github-gap.sh (GH#21057)
+#
+# Synthetic regression test for the Phase 1 auto-release GitHub gap:
+#   - _isc_release_claim_by_stamp_path MUST call _isc_cmd_release --unassign
+#   - _isc_cmd_release MUST surface gh failures, not silently swallow them
+#
+# Usage:
+#   bash .agents/scripts/tests/test-stamp-release-github-gap.sh
+#
+# No external dependencies. Uses a mocked gh and set_issue_status to avoid
+# touching real GitHub repos. All tests self-contained; cleans up after itself.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+ISH="${REPO_ROOT}/.agents/scripts/interactive-session-helper.sh"
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+TEST_DIR=""
+
+# ---------------------------------------------------------------------------
+# Test framework
+# ---------------------------------------------------------------------------
+
+print_result() {
+	local test_name="$1"
+	local status="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$status" -eq 0 ]]; then
+		printf 'PASS %s\n' "$test_name"
+		TESTS_PASSED=$((TESTS_PASSED + 1))
+	else
+		printf 'FAIL %s\n' "$test_name"
+		[[ -n "$message" ]] && printf '  %s\n' "$message"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+assert_equals() {
+	local desc="$1" expected="$2" actual="$3"
+	if [[ "$expected" == "$actual" ]]; then
+		print_result "$desc" 0
+	else
+		print_result "$desc" 1 "expected='$expected' actual='$actual'"
+	fi
+	return 0
+}
+
+assert_contains() {
+	local desc="$1" needle="$2" haystack="$3"
+	if [[ "$haystack" == *"$needle"* ]]; then
+		print_result "$desc" 0
+	else
+		print_result "$desc" 1 "expected to contain '$needle'; got '$haystack'"
+	fi
+	return 0
+}
+
+setup() {
+	TEST_DIR=$(mktemp -d)
+	trap teardown EXIT
+	return 0
+}
+
+teardown() {
+	[[ -n "$TEST_DIR" && -d "$TEST_DIR" ]] && rm -rf "$TEST_DIR"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Helper: write a minimal stamp file for testing
+# ---------------------------------------------------------------------------
+write_stamp() {
+	local stamp_dir="$1" issue="$2" slug="$3" pid="${4:-9999999}"
+	mkdir -p "$stamp_dir"
+	local slug_safe="${slug//\//-}"
+	local stamp_path="${stamp_dir}/${slug_safe}-${issue}.json"
+	printf '{"issue":"%s","slug":"%s","pid":%d}\n' "$issue" "$slug" "$pid" >"$stamp_path"
+	printf '%s\n' "$stamp_path"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: _isc_release_claim_by_stamp_path passes --unassign to _isc_cmd_release
+#
+# Strategy: source the helper with CLAIM_STAMP_DIR pointing at our temp dir,
+# stub _isc_cmd_release and _isc_gh_reachable so we can capture call args.
+# ---------------------------------------------------------------------------
+test_auto_release_passes_unassign() {
+	local stamp_dir="${TEST_DIR}/stamps"
+	local captured_args_file="${TEST_DIR}/captured_args"
+
+	# Create a fake stamp
+	local stamp_path
+	stamp_path=$(write_stamp "$stamp_dir" "12345" "owner/repo")
+
+	# Source helper in a subshell so stubs don't leak
+	local result
+	result=$(
+		# Minimal stubs required to prevent actual network calls
+		_isc_gh_reachable() { return 0; }
+		_isc_current_user() { printf 'testuser'; return 0; }
+		set_issue_status() {
+			# Record what we were called with
+			printf 'set_issue_status %s\n' "$*" >>"$captured_args_file"
+			return 0
+		}
+		_isc_has_in_review() {
+			# Pretend the issue IS in-review (rc=0)
+			return 0
+		}
+		_isc_delete_stamp() { return 0; }
+		_isc_info() { printf 'INFO: %s\n' "$*"; return 0; }
+		_isc_warn() { printf 'WARN: %s\n' "$*"; return 0; }
+		_isc_err() { printf 'ERR: %s\n' "$*"; return 0; }
+		export -f _isc_gh_reachable _isc_current_user set_issue_status
+		export -f _isc_has_in_review _isc_delete_stamp _isc_info _isc_warn _isc_err
+		CLAIM_STAMP_DIR="$stamp_dir"
+		export CLAIM_STAMP_DIR
+
+		# Source only the functions we need (avoid full init)
+		# We extract and eval the two target functions from the helper.
+		eval "$(sed -n '/^_isc_cmd_release()/,/^}/p' "$ISH")"
+		eval "$(sed -n '/^_isc_release_claim_by_stamp_path()/,/^}/p' "$ISH")"
+
+		_isc_release_claim_by_stamp_path "$stamp_path"
+		printf 'EXIT:%d\n' $?
+	) 2>&1 || true
+
+	# Verify: set_issue_status was called with --remove-assignee
+	local captured=""
+	[[ -f "$captured_args_file" ]] && captured=$(cat "$captured_args_file")
+
+	assert_contains \
+		"auto-release passes --remove-assignee to set_issue_status" \
+		"--remove-assignee" \
+		"$captured"
+
+	assert_contains \
+		"auto-release calls set_issue_status with available" \
+		"available" \
+		"$captured"
+
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: _isc_cmd_release surfaces gh failures with actual error text
+# (previously swallowed by >/dev/null 2>&1)
+# ---------------------------------------------------------------------------
+test_release_surfaces_failure_message() {
+	local captured_warn_file="${TEST_DIR}/captured_warn"
+
+	local result
+	result=$(
+		_isc_gh_reachable() { return 0; }
+		_isc_current_user() { printf 'testuser'; return 0; }
+		set_issue_status() {
+			# Simulate a gh failure with an error message on stderr
+			printf 'gh: HTTP 422: bad credentials\n' >&2
+			return 1
+		}
+		_isc_has_in_review() { return 0; }
+		_isc_delete_stamp() { return 0; }
+		_isc_info() { printf 'INFO: %s\n' "$*"; return 0; }
+		_isc_warn() {
+			printf 'WARN: %s\n' "$*"
+			printf '%s\n' "$*" >>"$captured_warn_file"
+			return 0
+		}
+		_isc_err() { printf 'ERR: %s\n' "$*"; return 0; }
+		export -f _isc_gh_reachable _isc_current_user set_issue_status
+		export -f _isc_has_in_review _isc_delete_stamp _isc_info _isc_warn _isc_err
+
+		eval "$(sed -n '/^_isc_cmd_release()/,/^}/p' "$ISH")"
+
+		_isc_cmd_release "99999" "owner/repo"
+		printf 'EXIT:%d\n' $?
+	) 2>&1 || true
+
+	local warn_content=""
+	[[ -f "$captured_warn_file" ]] && warn_content=$(cat "$captured_warn_file")
+
+	# The warning MUST contain the rc and the gh error text
+	assert_contains \
+		"release surfaces gh error rc in warning" \
+		"rc=1" \
+		"$warn_content"
+
+	assert_contains \
+		"release surfaces gh error message in warning" \
+		"HTTP 422" \
+		"$warn_content"
+
+	# The function MUST still exit 0 (fail-open)
+	assert_contains \
+		"release exits 0 even on gh failure (fail-open)" \
+		"EXIT:0" \
+		"$result"
+
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: _isc_release_claim_by_stamp_path skips gracefully on missing stamp
+# ---------------------------------------------------------------------------
+test_missing_stamp_is_noop() {
+	local result
+	result=$(
+		_isc_gh_reachable() { return 0; }
+		_isc_current_user() { printf 'testuser'; return 0; }
+		set_issue_status() { printf 'SHOULD_NOT_BE_CALLED\n'; return 0; }
+		_isc_has_in_review() { return 0; }
+		_isc_delete_stamp() { return 0; }
+		_isc_info() { printf 'INFO: %s\n' "$*"; return 0; }
+		_isc_warn() { printf 'WARN: %s\n' "$*"; return 0; }
+		_isc_err() { printf 'ERR: %s\n' "$*"; return 0; }
+		export -f _isc_gh_reachable _isc_current_user set_issue_status
+		export -f _isc_has_in_review _isc_delete_stamp _isc_info _isc_warn _isc_err
+
+		eval "$(sed -n '/^_isc_release_claim_by_stamp_path()/,/^}/p' "$ISH")"
+
+		_isc_release_claim_by_stamp_path "/nonexistent/stamp.json"
+		printf 'EXIT:%d\n' $?
+	) 2>&1 || true
+
+	local status=0
+	[[ "$result" == *"SHOULD_NOT_BE_CALLED"* ]] && status=1
+	print_result "missing stamp is noop (does not call set_issue_status)" "$status"
+
+	assert_contains "missing stamp exits 0" "EXIT:0" "$result"
+
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: offline gh → stamp deleted locally, warning printed, exit 0
+# ---------------------------------------------------------------------------
+test_offline_gh_is_fail_open() {
+	local stamp_dir="${TEST_DIR}/stamps_offline"
+	local stamp_path
+	stamp_path=$(write_stamp "$stamp_dir" "11111" "owner/repo2")
+
+	local result
+	result=$(
+		_isc_gh_reachable() { return 1; }  # offline
+		_isc_delete_stamp() {
+			# Verify the stamp is actually deleted
+			[[ -f "$stamp_path" ]] && rm -f "$stamp_path"
+			return 0
+		}
+		_isc_info() { printf 'INFO: %s\n' "$*"; return 0; }
+		_isc_warn() { printf 'WARN: %s\n' "$*"; return 0; }
+		_isc_err() { printf 'ERR: %s\n' "$*"; return 0; }
+		export -f _isc_gh_reachable _isc_delete_stamp _isc_info _isc_warn _isc_err
+
+		eval "$(sed -n '/^_isc_cmd_release()/,/^}/p' "$ISH")"
+
+		_isc_cmd_release "11111" "owner/repo2"
+		printf 'EXIT:%d\n' $?
+	) 2>&1 || true
+
+	assert_contains "offline gh exits 0 (fail-open)" "EXIT:0" "$result"
+	assert_contains "offline gh prints warning" "offline" "$result"
+
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+	setup
+
+	printf 'Running GH#21057 regression tests (stamp-release GitHub gap)...\n\n'
+
+	test_auto_release_passes_unassign
+	test_release_surfaces_failure_message
+	test_missing_stamp_is_noop
+	test_offline_gh_is_fail_open
+
+	printf '\n--- Results: %d/%d passed, %d failed ---\n' \
+		"$TESTS_PASSED" "$TESTS_RUN" "$TESTS_FAILED"
+
+	[[ "$TESTS_FAILED" -eq 0 ]] && exit 0
+	exit 1
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Three coordinated fixes for the Phase 1 auto-release GitHub gap (GH#21057) — `scan-stale --auto-release` was deleting local stamp files but leaving `status:in-review` + self-assignment on GitHub, causing the footprint-overlap cache to poison dispatch for ~20 issues per hour.

## Root Cause

`_isc_release_claim_by_stamp_path` delegated to `_isc_cmd_release` **without** `--unassign`. Even when the label transition succeeded, the owner self-assignment persisted — and per the t1996 invariant `(active status label) AND (non-self assignee)`, the owner assignee alone keeps dispatch blocked (GH#18352). The `set_issue_status` call was also silenced with `>/dev/null 2>&1`, hiding the actual failure reason for the other 14 stuck claims.

## Changes

### 1. `interactive-session-helper.sh` — two fixes

**Fix A** (`_isc_release_claim_by_stamp_path:1127`): pass `--unassign` unconditionally. Auto-release is the dead-stamp recovery path; the runner is gone, the assignment is meaningless and must clear.

**Fix B** (`_isc_cmd_release:843`): replace silent `>/dev/null 2>&1` with captured-stderr pattern. Warning now includes `rc=N` and the actual `gh` error text. Previously a `HTTP 422` or rate-limit error would leave 14 issues stuck with no log evidence.

### 2. `reconcile-stuck-claims.sh` — new one-shot reconciler

Scans all pulse-enabled repos for issues matching:
- `origin:interactive` + (`status:in-review` OR `status:claimed`)
- assigned to `$current_user`
- no live stamp at `~/.aidevops/.agent-workspace/claim-stamps/<slug>-<issue>.json`

For each match calls `_isc_cmd_release --unassign`. Dry-run by default; `--apply` to commit. Idempotent; skips issues with live stamps.

Reference pattern: `reconcile-origin-labels.sh` (t2200, same structure/UX).

### 3. `tests/test-stamp-release-github-gap.sh` — 9/9 regression tests

Covers: `--unassign` propagation to `set_issue_status`, gh error surfacing (rc + message), missing-stamp noop, offline-gh fail-open.

## Verification

```bash
# Regression tests pass
bash .agents/scripts/tests/test-stamp-release-github-gap.sh
# → 9/9 passed, 0 failed

# Dry-run reconciler (verify stuck backlog count)
.agents/scripts/reconcile-stuck-claims.sh --dry-run

# After deploy, to heal the existing backlog:
.agents/scripts/reconcile-stuck-claims.sh --apply
```

## Complexity Bump Justification

`_isc_cmd_release` grows from 84 to ~90 lines (base=84, head=90, new=+6). Remains within the 80-100 advisory window; below the 100-line `function-complexity` gate.

Resolves #21057

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.17 plugin for [OpenCode](https://opencode.ai) v1.14.25 with claude-sonnet-4-6 spent 8m and 20,001 tokens on this as a headless worker.
