### PR TITLE
t2868: inbox triage routine: sensitivity gate → classification → routing

### DIFF
--- a/.agents/scripts/inbox-helper.sh
+++ b/.agents/scripts/inbox-helper.sh
@@ -56,6 +56,14 @@ readonly WORKSPACE_INBOX_DIR="${HOME}/.aidevops/.agent-workspace/inbox"
 # Path to the README template
 readonly README_TEMPLATE="${SCRIPT_DIR}/../templates/inbox-readme.md"
 
+# Triage log JSON field names and status values — defined as constants to
+# avoid repeated string literals triggering the pre-commit ratchet gate.
+# Each name appears once here; all other uses reference the variable.
+readonly TRIAGE_KEY_SENSITIVITY="sensitivity"
+readonly TRIAGE_KEY_STATUS="status"
+readonly TRIAGE_KEY_PATH="path"
+readonly TRIAGE_VAL_PENDING="pending"
+
 # =============================================================================
 # Helpers
 # =============================================================================
@@ -79,6 +87,24 @@ _iso_ts() {
 # Returns current UTC timestamp in ISO 8601 full form: 2026-04-25T19:00:00Z
 _iso_ts_full() {
 	date -u '+%Y-%m-%dT%H:%M:%SZ'
+	return 0
+}
+
+# _json_field <json-line> <field-name>
+# Extracts a string value from a flat JSON line: {"field":"value",...}
+# Uses only grep + cut — no jq dependency.
+_json_field() {
+	local json="$1"
+	local field="$2"
+	printf '%s' "$json" | grep -o "\"${field}\":\"[^\"]*\"" | cut -d'"' -f4 || true
+	return 0
+}
+
+# _json_escape <string>
+# Escapes double quotes so the value can be embedded in a JSON string literal.
+_json_escape() {
+	local raw="$1"
+	printf '%s' "$raw" | sed 's/"/\\"/g'
 	return 0
 }
 
@@ -324,7 +350,7 @@ _add_file() {
 	# Relative path for the log entry
 	local rel_path="${INBOX_DIR_NAME}/${sub}/${dest_name}"
 
-	_append_triage_log "$inbox_dir" "cli-add" "$sub" "$abs_src" "$rel_path" "pending"
+	_append_triage_log "$inbox_dir" "cli-add" "$sub" "$abs_src" "$rel_path" "$TRIAGE_VAL_PENDING"
 
 	print_success "Captured: ${rel_path}"
 	return 0
@@ -400,7 +426,7 @@ _add_url() {
 
 	# Triage log entry
 	local rel_path="${INBOX_DIR_NAME}/web/${base_name}.meta.json"
-	_append_triage_log "$inbox_dir" "cli-url" "web" "$url" "$rel_path" "pending"
+	_append_triage_log "$inbox_dir" "cli-url" "web" "$url" "$rel_path" "$TRIAGE_VAL_PENDING"
 
 	print_success "Captured URL: ${rel_path}"
 	return 0
@@ -526,11 +552,350 @@ cmd_status() {
 }
 
 # =============================================================================
+# cmd_triage — sensitivity gate → classification → routing (t2868)
+# =============================================================================
+# Processes pending items in _inbox/, classifies them, and routes to target plane.
+#
+# Triage flow per item:
+#   1. Sensitivity gate (LOCAL ONLY via sensitivity-detect.sh — never cloud)
+#   2. LLM classification (tier per sensitivity: cloud OK for public/confidential,
+#      local-only for privileged/competitive) via llm-routing-helper.sh
+#   3. Confidence check: < TRIAGE_CONFIDENCE_THRESHOLD → _needs-review/
+#   4. Route: move file + write meta.json + update triage.log
+#
+# Graceful degradation: if sensitivity-detect.sh or llm-routing-helper.sh are not
+# installed yet (P0.5a / P0.5b pending), items route to _needs-review/ with reason
+# "dependency-unavailable". The code is fully functional once those land.
+
+# Sensitivity levels — ordered from most to least sensitive
+readonly SENSITIVITY_LEVELS="unknown privileged competitive confidential public"
+# Tiers requiring local-only LLM (no cloud exposure)
+readonly SENSITIVITY_LOCAL_ONLY_TIERS="unknown privileged competitive"
+# Default confidence threshold (0-100 integer, matching LLM's 0.0-1.0 * 100)
+readonly TRIAGE_CONFIDENCE_THRESHOLD_DEFAULT=85
+# Default rate limit per pulse cycle
+readonly TRIAGE_RATE_LIMIT_DEFAULT=50
+# Default consecutive needs-review backoff threshold
+readonly TRIAGE_BACKOFF_THRESHOLD_DEFAULT=10
+
+cmd_triage() {
+	local dry_run=0
+	local limit="${TRIAGE_RATE_LIMIT:-${TRIAGE_RATE_LIMIT_DEFAULT}}"
+	local confidence_threshold="${TRIAGE_CONFIDENCE_THRESHOLD:-${TRIAGE_CONFIDENCE_THRESHOLD_DEFAULT}}"
+	local backoff_threshold="${TRIAGE_BACKOFF_THRESHOLD:-${TRIAGE_BACKOFF_THRESHOLD_DEFAULT}}"
+
+	# Parse flags
+	while [[ $# -gt 0 ]]; do
+		local cur_arg="$1"
+		case "$cur_arg" in
+		--dry-run) dry_run=1; shift ;;
+		--limit)   limit="${2:-$limit}"; shift 2 ;;
+		--limit=*) limit="${cur_arg#--limit=}"; shift ;;
+		--confidence-threshold)  confidence_threshold="${2:-$confidence_threshold}"; shift 2 ;;
+		--confidence-threshold=*) confidence_threshold="${cur_arg#--confidence-threshold=}"; shift ;;
+		*)
+			print_error "Unknown triage flag: $cur_arg"
+			return 1
+			;;
+		esac
+	done
+
+	local repo_root
+	repo_root="$(pwd)"
+	local inbox_dir="${repo_root}/${INBOX_DIR_NAME}"
+
+	if [[ ! -d "$inbox_dir" ]]; then
+		print_warning "_inbox/ not found at ${inbox_dir}. Run: aidevops inbox provision"
+		return 0
+	fi
+
+	local log_path="${inbox_dir}/${TRIAGE_LOG}"
+	if [[ ! -f "$log_path" ]]; then
+		print_warning "triage.log not found at ${log_path}. Nothing to triage."
+		return 0
+	fi
+
+	# Check availability of dependency scripts
+	local has_sensitivity_detect=0
+	local has_llm_routing=0
+	if command -v sensitivity-detect.sh >/dev/null 2>&1 \
+		|| [[ -x "${SCRIPT_DIR}/sensitivity-detect.sh" ]]; then
+		has_sensitivity_detect=1
+	fi
+	if command -v llm-routing-helper.sh >/dev/null 2>&1 \
+		|| [[ -x "${SCRIPT_DIR}/llm-routing-helper.sh" ]]; then
+		has_llm_routing=1
+	fi
+
+	if [[ "$has_sensitivity_detect" -eq 0 ]]; then
+		print_warning "sensitivity-detect.sh not found (P0.5a pending). Items will route to _needs-review/."
+	fi
+	if [[ "$has_llm_routing" -eq 0 ]]; then
+		print_warning "llm-routing-helper.sh not found (P0.5b pending). Items will route to _needs-review/."
+	fi
+
+	[[ "$dry_run" -eq 1 ]] && print_info "[DRY RUN] No files will be moved."
+
+	# Collect pending items from triage.log
+	local pending_paths=()
+	while IFS= read -r line; do
+		[[ -z "$line" ]] && continue
+		local status_field
+		status_field="$(_json_field "$line" "$TRIAGE_KEY_STATUS")"
+		if [[ "$status_field" == "$TRIAGE_VAL_PENDING" ]]; then
+			local path_field
+			path_field="$(_json_field "$line" "$TRIAGE_KEY_PATH")"
+			[[ -n "$path_field" ]] && pending_paths+=("$path_field")
+		fi
+	done < "$log_path"
+
+	if [[ ${#pending_paths[@]} -eq 0 ]]; then
+		print_info "No pending items found in triage.log."
+		return 0
+	fi
+
+	print_info "Found ${#pending_paths[@]} pending item(s). Processing up to ${limit}."
+
+	local processed=0
+	local routed=0
+	local needs_review=0
+	local consecutive_needs_review=0
+	local skipped=0
+
+	local rel_path
+	for rel_path in "${pending_paths[@]}"; do
+		if [[ "$processed" -ge "$limit" ]]; then
+			skipped=$(( ${#pending_paths[@]} - processed ))
+			print_warning "Rate limit reached (${limit}). Skipping ${skipped} item(s)."
+			break
+		fi
+
+		# Backoff: too many consecutive needs-review → classifier may be broken
+		if [[ "$consecutive_needs_review" -ge "$backoff_threshold" ]]; then
+			print_warning "Backoff: ${consecutive_needs_review} consecutive needs-review results. Halting to avoid classifier loop."
+			break
+		fi
+
+		local abs_path="${repo_root}/${rel_path}"
+		if [[ ! -f "$abs_path" ]]; then
+			print_warning "Skipping missing file: ${rel_path}"
+			processed=$(( processed + 1 ))
+			continue
+		fi
+
+		print_info "Triaging: ${rel_path}"
+
+		# --- Step 1: Sensitivity gate (LOCAL ONLY) ---
+		local sensitivity="unknown"
+		if [[ "$has_sensitivity_detect" -eq 1 ]]; then
+			local detect_script="${SCRIPT_DIR}/sensitivity-detect.sh"
+			if ! command -v sensitivity-detect.sh >/dev/null 2>&1; then
+				detect_script="sensitivity-detect.sh"
+			fi
+			sensitivity="$("$detect_script" "$abs_path" 2>/dev/null || echo "unknown")"
+			# Sanitise output to known values
+			case "$sensitivity" in
+			public | confidential | privileged | competitive | unknown) ;;
+			*) sensitivity="unknown" ;;
+			esac
+		fi
+
+		# --- Step 2: Classification (LLM tier per sensitivity) ---
+		local classification_plane=""
+		local classification_sub_folder=""
+		local classification_confidence=0
+		local classification_reasoning="dependency-unavailable"
+		local needs_review_reason=""
+
+		if [[ "$has_sensitivity_detect" -eq 0 || "$has_llm_routing" -eq 0 ]]; then
+			needs_review_reason="dependency-unavailable"
+		else
+			# Determine LLM tier based on sensitivity
+			local use_local_only=0
+			local tier_check
+			for tier_check in $SENSITIVITY_LOCAL_ONLY_TIERS; do
+				if [[ "$sensitivity" == "$tier_check" ]]; then
+					use_local_only=1
+					break
+				fi
+			done
+
+			local routing_script="${SCRIPT_DIR}/llm-routing-helper.sh"
+			if ! command -v llm-routing-helper.sh >/dev/null 2>&1; then
+				routing_script="llm-routing-helper.sh"
+			fi
+
+			# Build classification prompt content (first 2KB — no full binary content)
+			local content_preview
+			content_preview="$(dd if="$abs_path" bs=1 count=2048 2>/dev/null | strings 2>/dev/null | head -40 || true)"
+
+		# Call LLM routing helper
+		local llm_output
+		local llm_flags=("--task" "classify-inbox")
+		[[ "$use_local_only" -eq 1 ]] && llm_flags+=("--local-only")
+
+		llm_output="$("$routing_script" "${llm_flags[@]}" --content "$content_preview" 2>/dev/null || true)"
+
+			if [[ -n "$llm_output" ]]; then
+				# Parse JSON response fields via helper (avoids repeated grep+cut literals)
+				classification_plane="$(_json_field "$llm_output" "target_plane")"
+				classification_sub_folder="$(_json_field "$llm_output" "sub_folder")"
+				local conf_raw
+				conf_raw="$(printf '%s' "$llm_output" | grep -o '"confidence":[0-9.]*' | cut -d':' -f2 || true)"
+				# Convert 0.0-1.0 to 0-100 integer
+				if [[ -n "$conf_raw" ]]; then
+					classification_confidence="$(printf '%.0f' "$(echo "$conf_raw * 100" | bc 2>/dev/null || echo 0)" 2>/dev/null || echo 0)"
+				fi
+				classification_reasoning="$(_json_field "$llm_output" "reasoning")"
+			fi
+
+			# Validate required fields
+			if [[ -z "$classification_plane" || "$classification_confidence" -lt "$confidence_threshold" ]]; then
+				if [[ -z "$classification_plane" ]]; then
+					needs_review_reason="classifier-no-output"
+				else
+					needs_review_reason="low-confidence:${classification_confidence}"
+				fi
+			fi
+		fi
+
+		processed=$(( processed + 1 ))
+
+		if [[ -n "$needs_review_reason" ]]; then
+			# --- Route to _needs-review/ ---
+			_triage_route_needs_review \
+				"$inbox_dir" "$abs_path" "$rel_path" \
+				"$sensitivity" "$needs_review_reason" \
+				"$dry_run" "$log_path"
+			needs_review=$(( needs_review + 1 ))
+			consecutive_needs_review=$(( consecutive_needs_review + 1 ))
+		else
+			# --- Route to target plane ---
+			_triage_route_to_plane \
+				"$inbox_dir" "$abs_path" "$rel_path" \
+				"$sensitivity" "$classification_plane" "$classification_sub_folder" \
+				"$classification_confidence" "$classification_reasoning" \
+				"$dry_run" "$log_path" "$use_local_only"
+			routed=$(( routed + 1 ))
+			consecutive_needs_review=0
+		fi
+	done
+
+	print_info "Triage complete: routed=${routed} needs-review=${needs_review} skipped=${skipped}"
+	return 0
+}
+
+# _triage_route_needs_review <inbox-dir> <abs-path> <rel-path> <sensitivity> <reason> <dry-run> <log-path>
+_triage_route_needs_review() {
+	local inbox_dir="$1"
+	local abs_path="$2"
+	local rel_path="$3"
+	local sensitivity="$4"
+	local reason="$5"
+	local dry_run="$6"
+	local log_path="$7"
+
+	local needs_review_dir="${inbox_dir}/_needs-review"
+	local dest_name
+	dest_name="$(_conflict_safe_name "$needs_review_dir" "$abs_path")"
+	local dest_path="${needs_review_dir}/${dest_name}"
+	local dest_rel="${INBOX_DIR_NAME}/_needs-review/${dest_name}"
+	local ts
+	ts="$(_iso_ts_full)"
+
+	if [[ "$dry_run" -eq 1 ]]; then
+		print_info "  [DRY RUN] Would route to _needs-review/: ${dest_name} (reason: ${reason})"
+		return 0
+	fi
+
+	mkdir -p "$needs_review_dir"
+	mv "$abs_path" "$dest_path"
+
+	# Write meta.json adjacent (field names via constants to avoid repeated literals)
+	local meta_path="${dest_path}.meta.json"
+	printf '{"%s":"%s","needs_review_reason":"%s","triaged_at":"%s","original_path":"%s"}\n' \
+		"$TRIAGE_KEY_SENSITIVITY" "$sensitivity" "$reason" "$ts" "$rel_path" > "$meta_path"
+
+	# Append triage.log entry
+	printf '{"ts":"%s","%s":"needs-review","from":"%s","to":"%s","%s":"%s","reason":"%s"}\n' \
+		"$ts" "$TRIAGE_KEY_STATUS" "$rel_path" "$dest_rel" \
+		"$TRIAGE_KEY_SENSITIVITY" "$sensitivity" "$reason" >> "$log_path"
+
+	# Mark original entry as triaged in log (append superseding entry)
+	printf '{"ts":"%s","%s":"superseded","%s":"%s","action":"moved-to-needs-review"}\n' \
+		"$ts" "$TRIAGE_KEY_STATUS" "$TRIAGE_KEY_PATH" "$rel_path" >> "$log_path"
+
+	print_info "  -> _needs-review/ (${reason}): ${dest_name}"
+	return 0
+}
+
+# _triage_route_to_plane <inbox-dir> <abs-path> <rel-path> <sensitivity>
+#   <plane> <sub-folder> <confidence> <reasoning> <dry-run> <log-path> <use-local-only>
+_triage_route_to_plane() {
+	local inbox_dir="$1"
+	local abs_path="$2"
+	local rel_path="$3"
+	local sensitivity="$4"
+	local plane="$5"
+	local sub_folder="$6"
+	local confidence="$7"
+	local reasoning="$8"
+	local dry_run="$9"
+	local log_path="${10}"
+	local use_local_only="${11}"
+
+	# Resolve the target plane root relative to the repo root (parent of _inbox/)
+	local repo_root
+	repo_root="$(dirname "$inbox_dir")"
+	local plane_dir="${repo_root}/_${plane}"
+	[[ -n "$sub_folder" ]] && plane_dir="${plane_dir}/${sub_folder}"
+
+	local dest_name
+	dest_name="$(_conflict_safe_name "$plane_dir" "$abs_path")"
+	local dest_path="${plane_dir}/${dest_name}"
+	local dest_rel="_${plane}/${sub_folder:+${sub_folder}/}${dest_name}"
+	local ts
+	ts="$(_iso_ts_full)"
+
+	local llm_tier="cloud"
+	[[ "$use_local_only" -eq 1 ]] && llm_tier="local-only"
+
+	if [[ "$dry_run" -eq 1 ]]; then
+		print_info "  [DRY RUN] Would route to ${dest_rel} (sensitivity=${sensitivity}, confidence=${confidence}%, tier=${llm_tier})"
+		return 0
+	fi
+
+	mkdir -p "$plane_dir"
+	mv "$abs_path" "$dest_path"
+
+	# Write meta.json adjacent (field names via constants to avoid repeated literals)
+	local meta_path="${dest_path}.meta.json"
+	local reasoning_escaped
+	reasoning_escaped="$(_json_escape "$reasoning")"
+	printf '{"%s":"%s","classification":{"plane":"%s","sub_folder":"%s"},"confidence":%s,"llm_tier":"%s","reasoning":"%s","triaged_at":"%s","original_path":"%s"}\n' \
+		"$TRIAGE_KEY_SENSITIVITY" "$sensitivity" "$plane" "$sub_folder" "$confidence" "$llm_tier" \
+		"$reasoning_escaped" "$ts" "$rel_path" > "$meta_path"
+
+	# Append triage.log entry
+	printf '{"ts":"%s","%s":"routed","from":"%s","to":"%s","dest_plane":"%s","dest_path":"%s","confidence":%s,"%s":"%s","llm_tier":"%s","reasoning":"%s"}\n' \
+		"$ts" "$TRIAGE_KEY_STATUS" "$rel_path" "$dest_rel" "$plane" "$dest_path" \
+		"$confidence" "$TRIAGE_KEY_SENSITIVITY" "$sensitivity" "$llm_tier" \
+		"$reasoning_escaped" >> "$log_path"
+
+	# Mark original pending entry as superseded
+	printf '{"ts":"%s","%s":"superseded","%s":"%s","action":"routed-to-plane"}\n' \
+		"$ts" "$TRIAGE_KEY_STATUS" "$TRIAGE_KEY_PATH" "$rel_path" >> "$log_path"
+
+	print_success "  -> _${plane}/${sub_folder:+${sub_folder}/}${dest_name} (sensitivity=${sensitivity}, confidence=${confidence}%, tier=${llm_tier})"
+	return 0
+}
+
+# =============================================================================
 # cmd_help
 # =============================================================================
 cmd_help() {
 	cat <<'EOF'
-inbox-helper.sh — _inbox/ transit zone manager (t2866 + t2867)
+inbox-helper.sh — _inbox/ transit zone manager (t2866 + t2867 + t2868)
 
 Commands:
   provision [<repo-path>]   Create _inbox/ structure (default: current dir)
@@ -539,6 +904,8 @@ Commands:
   add --url <url>           Capture a web page (saves HTML + text + metadata)
   find <query>              Search triage.log for entries matching query (last 30 days)
   status [<repo-path>]      Show item counts per sub-folder
+  triage [--dry-run] [--limit N] [--confidence-threshold N]
+                            Process pending items: sensitivity → classify → route
   help                      Show this help
 
 Sub-folder routing:
@@ -548,9 +915,22 @@ Sub-folder routing:
   web/     URLs (--url flag)
   _drop/   Everything else (or drag-drop target for watch folder)
 
+Triage routing (when dependencies available):
+  _needs-review/  Low-confidence or unknown-sensitivity items
+  _knowledge/     General reference material
+  _cases/         Case/matter specific files
+  _campaigns/     Marketing and campaign material
+  _projects/      Project artefacts
+  _feedback/      Feedback and surveys
+
 Audit log:
-  _inbox/triage.log — append-only JSONL; one entry per capture
-  Fields: ts, source, sub, orig, path, status, sensitivity
+  _inbox/triage.log — append-only JSONL; one entry per capture/triage
+  Fields: ts, source, sub, orig, path, status, sensitivity, confidence, reasoning
+
+Environment variables (triage):
+  TRIAGE_CONFIDENCE_THRESHOLD  Integer 0-100 (default: 85)
+  TRIAGE_RATE_LIMIT            Max items per run (default: 50)
+  TRIAGE_BACKOFF_THRESHOLD     Consecutive needs-review before halt (default: 10)
 
 EOF
 	return 0
@@ -568,6 +948,7 @@ main() {
 	add) cmd_add "$@" ;;
 	find) cmd_find "$@" ;;
 	status) cmd_status "$@" ;;
+	triage) cmd_triage "$@" ;;
 	help | -h | --help) cmd_help ;;
 	*)
 		print_error "Unknown inbox command: $cmd"

--- a/.agents/scripts/inbox-helper.sh
+++ b/.agents/scripts/inbox-helper.sh
@@ -578,13 +578,155 @@ readonly TRIAGE_RATE_LIMIT_DEFAULT=50
 # Default consecutive needs-review backoff threshold
 readonly TRIAGE_BACKOFF_THRESHOLD_DEFAULT=10
 
+# _triage_check_deps
+# Checks availability of P0.5a (sensitivity-detect.sh) and P0.5b
+# (llm-routing-helper.sh). Prints warnings and sets caller's has_* variables.
+# Returns: sets HAS_SENSITIVITY_DETECT and HAS_LLM_ROUTING in caller scope via echo.
+_triage_check_deps() {
+	local _sens=0 _llm=0
+	if command -v sensitivity-detect.sh >/dev/null 2>&1 \
+		|| [[ -x "${SCRIPT_DIR}/sensitivity-detect.sh" ]]; then
+		_sens=1
+	else
+		print_warning "sensitivity-detect.sh not found (P0.5a pending). Items will route to _needs-review/."
+	fi
+	if command -v llm-routing-helper.sh >/dev/null 2>&1 \
+		|| [[ -x "${SCRIPT_DIR}/llm-routing-helper.sh" ]]; then
+		_llm=1
+	else
+		print_warning "llm-routing-helper.sh not found (P0.5b pending). Items will route to _needs-review/."
+	fi
+	echo "${_sens} ${_llm}"
+	return 0
+}
+
+# _triage_collect_pending <log-path>
+# Reads triage.log and prints one relative path per line for pending items.
+_triage_collect_pending() {
+	local log_path="$1"
+	while IFS= read -r line; do
+		[[ -z "$line" ]] && continue
+		local status_field
+		status_field="$(_json_field "$line" "$TRIAGE_KEY_STATUS")"
+		if [[ "$status_field" == "$TRIAGE_VAL_PENDING" ]]; then
+			local path_field
+			path_field="$(_json_field "$line" "$TRIAGE_KEY_PATH")"
+			[[ -n "$path_field" ]] && printf '%s\n' "$path_field"
+		fi
+	done < "$log_path"
+	return 0
+}
+
+# _triage_run_sensitivity_gate <abs-path>
+# Runs sensitivity-detect.sh on a file. Returns the sensitivity tier string on
+# stdout: public | confidential | privileged | competitive | unknown.
+# Always returns 0; never fails.
+_triage_run_sensitivity_gate() {
+	local abs_path="$1"
+	local detect_script="${SCRIPT_DIR}/sensitivity-detect.sh"
+	command -v sensitivity-detect.sh >/dev/null 2>&1 && detect_script="sensitivity-detect.sh"
+	local result
+	result="$("$detect_script" "$abs_path" 2>/dev/null || echo "unknown")"
+	case "$result" in
+	public | confidential | privileged | competitive | unknown) printf '%s' "$result" ;;
+	*) printf 'unknown' ;;
+	esac
+	return 0
+}
+
+# _triage_run_classification <abs-path> <sensitivity> <confidence-threshold>
+# Runs llm-routing-helper.sh to classify a file.
+# Outputs space-separated: <plane> <sub-folder> <confidence> <use-local-only> <reason>
+# On failure, outputs: "" "" 0 0 <reason>
+_triage_run_classification() {
+	local abs_path="$1" sensitivity="$2" confidence_threshold="$3"
+	local use_local_only=0
+	local tier_check
+	for tier_check in $SENSITIVITY_LOCAL_ONLY_TIERS; do
+		[[ "$sensitivity" == "$tier_check" ]] && use_local_only=1 && break
+	done
+
+	local routing_script="${SCRIPT_DIR}/llm-routing-helper.sh"
+	command -v llm-routing-helper.sh >/dev/null 2>&1 && routing_script="llm-routing-helper.sh"
+
+	local content_preview
+	content_preview="$(dd if="$abs_path" bs=1 count=2048 2>/dev/null | strings 2>/dev/null | head -40 || true)"
+
+	local llm_flags=("--task" "classify-inbox")
+	[[ "$use_local_only" -eq 1 ]] && llm_flags+=("--local-only")
+	local llm_output
+	llm_output="$("$routing_script" "${llm_flags[@]}" --content "$content_preview" 2>/dev/null || true)"
+
+	local plane="" sub_folder="" confidence=0 reasoning="" reason=""
+	if [[ -n "$llm_output" ]]; then
+		plane="$(_json_field "$llm_output" "target_plane")"
+		sub_folder="$(_json_field "$llm_output" "sub_folder")"
+		local conf_raw
+		conf_raw="$(printf '%s' "$llm_output" | grep -o '"confidence":[0-9.]*' | cut -d':' -f2 || true)"
+		[[ -n "$conf_raw" ]] && confidence="$(printf '%.0f' "$(echo "$conf_raw * 100" | bc 2>/dev/null || echo 0)" 2>/dev/null || echo 0)"
+		reasoning="$(_json_field "$llm_output" "reasoning")"
+	fi
+
+	if [[ -z "$plane" ]]; then
+		reason="classifier-no-output"
+	elif [[ "$confidence" -lt "$confidence_threshold" ]]; then
+		reason="low-confidence:${confidence}"
+	fi
+
+	printf '%s\t%s\t%s\t%s\t%s\t%s\n' \
+		"$plane" "$sub_folder" "$confidence" "$use_local_only" "$reason" "$reasoning"
+	return 0
+}
+
+# _triage_process_item <inbox-dir> <repo-root> <rel-path>
+#   <has-sensitivity-detect> <has-llm-routing>
+#   <confidence-threshold> <dry-run> <log-path>
+# Processes a single pending item through the full triage pipeline.
+# Outputs: "routed" or "needs-review" on stdout.
+_triage_process_item() {
+	local inbox_dir="$1" repo_root="$2" rel_path="$3"
+	local has_sd="$4" has_llm="$5"
+	local confidence_threshold="$6" dry_run="$7" log_path="$8"
+
+	local abs_path="${repo_root}/${rel_path}"
+
+	# Step 1: Sensitivity gate (LOCAL ONLY)
+	local sensitivity="unknown"
+	[[ "$has_sd" -eq 1 ]] && sensitivity="$(_triage_run_sensitivity_gate "$abs_path")"
+
+	# Step 2: Classification (or immediate needs-review if deps missing)
+	local needs_review_reason=""
+	local plane="" sub_folder="" confidence=0 use_local_only=0 reasoning=""
+	if [[ "$has_sd" -eq 0 || "$has_llm" -eq 0 ]]; then
+		needs_review_reason="dependency-unavailable"
+	else
+		local class_out
+		class_out="$(_triage_run_classification "$abs_path" "$sensitivity" "$confidence_threshold")"
+		IFS=$'\t' read -r plane sub_folder confidence use_local_only needs_review_reason reasoning <<< "$class_out"
+	fi
+
+	# Step 3: Route
+	if [[ -n "$needs_review_reason" ]]; then
+		_triage_route_needs_review \
+			"$inbox_dir" "$abs_path" "$rel_path" \
+			"$sensitivity" "$needs_review_reason" "$dry_run" "$log_path"
+		printf 'needs-review'
+	else
+		_triage_route_to_plane \
+			"$inbox_dir" "$abs_path" "$rel_path" \
+			"$sensitivity" "$plane" "$sub_folder" \
+			"$confidence" "$reasoning" "$dry_run" "$log_path" "$use_local_only"
+		printf 'routed'
+	fi
+	return 0
+}
+
 cmd_triage() {
 	local dry_run=0
 	local limit="${TRIAGE_RATE_LIMIT:-${TRIAGE_RATE_LIMIT_DEFAULT}}"
 	local confidence_threshold="${TRIAGE_CONFIDENCE_THRESHOLD:-${TRIAGE_CONFIDENCE_THRESHOLD_DEFAULT}}"
 	local backoff_threshold="${TRIAGE_BACKOFF_THRESHOLD:-${TRIAGE_BACKOFF_THRESHOLD_DEFAULT}}"
 
-	# Parse flags
 	while [[ $# -gt 0 ]]; do
 		local cur_arg="$1"
 		case "$cur_arg" in
@@ -593,75 +735,36 @@ cmd_triage() {
 		--limit=*) limit="${cur_arg#--limit=}"; shift ;;
 		--confidence-threshold)  confidence_threshold="${2:-$confidence_threshold}"; shift 2 ;;
 		--confidence-threshold=*) confidence_threshold="${cur_arg#--confidence-threshold=}"; shift ;;
-		*)
-			print_error "Unknown triage flag: $cur_arg"
-			return 1
-			;;
+		*) print_error "Unknown triage flag: $cur_arg"; return 1 ;;
 		esac
 	done
 
 	local repo_root
 	repo_root="$(pwd)"
 	local inbox_dir="${repo_root}/${INBOX_DIR_NAME}"
-
-	if [[ ! -d "$inbox_dir" ]]; then
-		print_warning "_inbox/ not found at ${inbox_dir}. Run: aidevops inbox provision"
-		return 0
-	fi
-
+	[[ ! -d "$inbox_dir" ]] && print_warning "_inbox/ not found. Run: aidevops inbox provision" && return 0
 	local log_path="${inbox_dir}/${TRIAGE_LOG}"
-	if [[ ! -f "$log_path" ]]; then
-		print_warning "triage.log not found at ${log_path}. Nothing to triage."
-		return 0
-	fi
+	[[ ! -f "$log_path" ]] && print_warning "triage.log not found. Nothing to triage." && return 0
 
-	# Check availability of dependency scripts
-	local has_sensitivity_detect=0
-	local has_llm_routing=0
-	if command -v sensitivity-detect.sh >/dev/null 2>&1 \
-		|| [[ -x "${SCRIPT_DIR}/sensitivity-detect.sh" ]]; then
-		has_sensitivity_detect=1
-	fi
-	if command -v llm-routing-helper.sh >/dev/null 2>&1 \
-		|| [[ -x "${SCRIPT_DIR}/llm-routing-helper.sh" ]]; then
-		has_llm_routing=1
-	fi
-
-	if [[ "$has_sensitivity_detect" -eq 0 ]]; then
-		print_warning "sensitivity-detect.sh not found (P0.5a pending). Items will route to _needs-review/."
-	fi
-	if [[ "$has_llm_routing" -eq 0 ]]; then
-		print_warning "llm-routing-helper.sh not found (P0.5b pending). Items will route to _needs-review/."
-	fi
+	local dep_out has_sd has_llm
+	dep_out="$(_triage_check_deps)"
+	has_sd="${dep_out%% *}"
+	has_llm="${dep_out##* }"
 
 	[[ "$dry_run" -eq 1 ]] && print_info "[DRY RUN] No files will be moved."
 
-	# Collect pending items from triage.log
-	local pending_paths=()
-	while IFS= read -r line; do
-		[[ -z "$line" ]] && continue
-		local status_field
-		status_field="$(_json_field "$line" "$TRIAGE_KEY_STATUS")"
-		if [[ "$status_field" == "$TRIAGE_VAL_PENDING" ]]; then
-			local path_field
-			path_field="$(_json_field "$line" "$TRIAGE_KEY_PATH")"
-			[[ -n "$path_field" ]] && pending_paths+=("$path_field")
-		fi
-	done < "$log_path"
+	local -a pending_paths
+	while IFS= read -r p; do
+		[[ -n "$p" ]] && pending_paths+=("$p")
+	done < <(_triage_collect_pending "$log_path")
 
 	if [[ ${#pending_paths[@]} -eq 0 ]]; then
 		print_info "No pending items found in triage.log."
 		return 0
 	fi
-
 	print_info "Found ${#pending_paths[@]} pending item(s). Processing up to ${limit}."
 
-	local processed=0
-	local routed=0
-	local needs_review=0
-	local consecutive_needs_review=0
-	local skipped=0
-
+	local processed=0 routed=0 needs_review=0 consecutive_needs_review=0 skipped=0
 	local rel_path
 	for rel_path in "${pending_paths[@]}"; do
 		if [[ "$processed" -ge "$limit" ]]; then
@@ -669,115 +772,29 @@ cmd_triage() {
 			print_warning "Rate limit reached (${limit}). Skipping ${skipped} item(s)."
 			break
 		fi
-
-		# Backoff: too many consecutive needs-review → classifier may be broken
 		if [[ "$consecutive_needs_review" -ge "$backoff_threshold" ]]; then
-			print_warning "Backoff: ${consecutive_needs_review} consecutive needs-review results. Halting to avoid classifier loop."
+			print_warning "Backoff: ${consecutive_needs_review} consecutive needs-review. Halting."
 			break
 		fi
-
 		local abs_path="${repo_root}/${rel_path}"
 		if [[ ! -f "$abs_path" ]]; then
 			print_warning "Skipping missing file: ${rel_path}"
 			processed=$(( processed + 1 ))
 			continue
 		fi
-
 		print_info "Triaging: ${rel_path}"
-
-		# --- Step 1: Sensitivity gate (LOCAL ONLY) ---
-		local sensitivity="unknown"
-		if [[ "$has_sensitivity_detect" -eq 1 ]]; then
-			local detect_script="${SCRIPT_DIR}/sensitivity-detect.sh"
-			if ! command -v sensitivity-detect.sh >/dev/null 2>&1; then
-				detect_script="sensitivity-detect.sh"
-			fi
-			sensitivity="$("$detect_script" "$abs_path" 2>/dev/null || echo "unknown")"
-			# Sanitise output to known values
-			case "$sensitivity" in
-			public | confidential | privileged | competitive | unknown) ;;
-			*) sensitivity="unknown" ;;
-			esac
-		fi
-
-		# --- Step 2: Classification (LLM tier per sensitivity) ---
-		local classification_plane=""
-		local classification_sub_folder=""
-		local classification_confidence=0
-		local classification_reasoning="dependency-unavailable"
-		local needs_review_reason=""
-
-		if [[ "$has_sensitivity_detect" -eq 0 || "$has_llm_routing" -eq 0 ]]; then
-			needs_review_reason="dependency-unavailable"
-		else
-			# Determine LLM tier based on sensitivity
-			local use_local_only=0
-			local tier_check
-			for tier_check in $SENSITIVITY_LOCAL_ONLY_TIERS; do
-				if [[ "$sensitivity" == "$tier_check" ]]; then
-					use_local_only=1
-					break
-				fi
-			done
-
-			local routing_script="${SCRIPT_DIR}/llm-routing-helper.sh"
-			if ! command -v llm-routing-helper.sh >/dev/null 2>&1; then
-				routing_script="llm-routing-helper.sh"
-			fi
-
-			# Build classification prompt content (first 2KB — no full binary content)
-			local content_preview
-			content_preview="$(dd if="$abs_path" bs=1 count=2048 2>/dev/null | strings 2>/dev/null | head -40 || true)"
-
-		# Call LLM routing helper
-		local llm_output
-		local llm_flags=("--task" "classify-inbox")
-		[[ "$use_local_only" -eq 1 ]] && llm_flags+=("--local-only")
-
-		llm_output="$("$routing_script" "${llm_flags[@]}" --content "$content_preview" 2>/dev/null || true)"
-
-			if [[ -n "$llm_output" ]]; then
-				# Parse JSON response fields via helper (avoids repeated grep+cut literals)
-				classification_plane="$(_json_field "$llm_output" "target_plane")"
-				classification_sub_folder="$(_json_field "$llm_output" "sub_folder")"
-				local conf_raw
-				conf_raw="$(printf '%s' "$llm_output" | grep -o '"confidence":[0-9.]*' | cut -d':' -f2 || true)"
-				# Convert 0.0-1.0 to 0-100 integer
-				if [[ -n "$conf_raw" ]]; then
-					classification_confidence="$(printf '%.0f' "$(echo "$conf_raw * 100" | bc 2>/dev/null || echo 0)" 2>/dev/null || echo 0)"
-				fi
-				classification_reasoning="$(_json_field "$llm_output" "reasoning")"
-			fi
-
-			# Validate required fields
-			if [[ -z "$classification_plane" || "$classification_confidence" -lt "$confidence_threshold" ]]; then
-				if [[ -z "$classification_plane" ]]; then
-					needs_review_reason="classifier-no-output"
-				else
-					needs_review_reason="low-confidence:${classification_confidence}"
-				fi
-			fi
-		fi
-
+		local outcome
+		outcome="$(_triage_process_item \
+			"$inbox_dir" "$repo_root" "$rel_path" \
+			"$has_sd" "$has_llm" \
+			"$confidence_threshold" "$dry_run" "$log_path")"
 		processed=$(( processed + 1 ))
-
-		if [[ -n "$needs_review_reason" ]]; then
-			# --- Route to _needs-review/ ---
-			_triage_route_needs_review \
-				"$inbox_dir" "$abs_path" "$rel_path" \
-				"$sensitivity" "$needs_review_reason" \
-				"$dry_run" "$log_path"
-			needs_review=$(( needs_review + 1 ))
-			consecutive_needs_review=$(( consecutive_needs_review + 1 ))
-		else
-			# --- Route to target plane ---
-			_triage_route_to_plane \
-				"$inbox_dir" "$abs_path" "$rel_path" \
-				"$sensitivity" "$classification_plane" "$classification_sub_folder" \
-				"$classification_confidence" "$classification_reasoning" \
-				"$dry_run" "$log_path" "$use_local_only"
+		if [[ "$outcome" == "routed" ]]; then
 			routed=$(( routed + 1 ))
 			consecutive_needs_review=0
+		else
+			needs_review=$(( needs_review + 1 ))
+			consecutive_needs_review=$(( consecutive_needs_review + 1 ))
 		fi
 	done
 

--- a/.agents/scripts/inbox-triage-routine.sh
+++ b/.agents/scripts/inbox-triage-routine.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# shellcheck disable=SC2034
+# =============================================================================
+# inbox-triage-routine.sh — Pulse-callable wrapper for inbox triage (t2868)
+# =============================================================================
+# Processes pending items in _inbox/ for all configured inboxes:
+#   sensitivity gate → LLM classification → route to plane or _needs-review/
+#
+# Designed to be called by the pulse at configurable intervals (default: 60 min)
+# or invoked directly via: aidevops inbox triage
+#
+# Usage:
+#   inbox-triage-routine.sh [--dry-run] [--limit N] [--repo-path <path>]
+#                           [--workspace]
+#
+# Options:
+#   --dry-run              Show what would be done; no files are moved
+#   --limit N              Max items per run (default: TRIAGE_RATE_LIMIT env or 50)
+#   --repo-path <path>     Process inbox at specific repo root
+#   --workspace            Process workspace-level inbox
+#   --confidence N         Confidence threshold 0-100 (default: 85)
+#
+# Exit codes:
+#   0  All items processed cleanly (routed or needs-review)
+#   1  Classifier error or critical failure
+#
+# Environment:
+#   TRIAGE_RATE_LIMIT            Max items per cycle (default: 50)
+#   TRIAGE_CONFIDENCE_THRESHOLD  Min confidence to route (default: 85)
+#   TRIAGE_BACKOFF_THRESHOLD     Consecutive needs-review before halt (default: 10)
+#   INBOX_TRIAGE_INTERVAL_MINUTES  Minimum minutes between runs (default: 60)
+#
+# Pulse registration (TODO.md routine entry):
+#   - [ ] r_inbox_triage Inbox triage routine
+#     repeat:cron(0 * * * *)
+#     run:scripts/inbox-triage-routine.sh
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+# shellcheck source=shared-constants.sh
+source "${SCRIPT_DIR}/shared-constants.sh"
+
+# =============================================================================
+# Configuration
+# =============================================================================
+
+readonly INBOX_DIR_NAME="_inbox"
+readonly WORKSPACE_INBOX_DIR="${HOME}/.aidevops/.agent-workspace/inbox"
+readonly TRIAGE_LOCKFILE="${TMPDIR:-/tmp}/aidevops-inbox-triage.lock"
+readonly TRIAGE_STAMP_FILE="${TMPDIR:-/tmp}/aidevops-inbox-triage.last"
+readonly INBOX_TRIAGE_INTERVAL_MINUTES="${INBOX_TRIAGE_INTERVAL_MINUTES:-60}"
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+# _within_rate_window
+# Returns 0 (true) if enough time has elapsed since last run; 1 if too soon.
+_within_rate_window() {
+	if [[ ! -f "$TRIAGE_STAMP_FILE" ]]; then
+		return 0
+	fi
+	local last_run now elapsed_secs interval_secs
+	last_run="$(cat "$TRIAGE_STAMP_FILE" 2>/dev/null || echo 0)"
+	now="$(date +%s)"
+	elapsed_secs=$(( now - last_run ))
+	interval_secs=$(( INBOX_TRIAGE_INTERVAL_MINUTES * 60 ))
+	if [[ "$elapsed_secs" -lt "$interval_secs" ]]; then
+		local remaining=$(( interval_secs - elapsed_secs ))
+		print_info "Inbox triage: next run in ${remaining}s (interval: ${INBOX_TRIAGE_INTERVAL_MINUTES}min)"
+		return 1
+	fi
+	return 0
+}
+
+# _stamp_last_run
+_stamp_last_run() {
+	date +%s > "$TRIAGE_STAMP_FILE" 2>/dev/null || true
+	return 0
+}
+
+# _acquire_lock
+# Uses mkdir for atomic lock (bash 3.2 compatible).
+_acquire_lock() {
+	if mkdir "$TRIAGE_LOCKFILE" 2>/dev/null; then
+		return 0
+	fi
+	print_warning "Inbox triage already running (lock: ${TRIAGE_LOCKFILE})"
+	return 1
+}
+
+# _release_lock
+_release_lock() {
+	rmdir "$TRIAGE_LOCKFILE" 2>/dev/null || true
+	return 0
+}
+
+# _triage_inbox <inbox-helper-args...>
+# Calls inbox-helper.sh triage with the given arguments.
+_triage_inbox() {
+	local helper="${SCRIPT_DIR}/inbox-helper.sh"
+	if [[ ! -x "$helper" ]]; then
+		print_error "inbox-helper.sh not found at ${helper}"
+		return 1
+	fi
+	"$helper" triage "$@"
+	return $?
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+
+main() {
+	local dry_run=0
+	local limit="${TRIAGE_RATE_LIMIT:-50}"
+	local confidence="${TRIAGE_CONFIDENCE_THRESHOLD:-85}"
+	local repo_path=""
+	local process_workspace=0
+
+	while [[ $# -gt 0 ]]; do
+		local cur_arg="$1"
+		case "$cur_arg" in
+		--dry-run)         dry_run=1; shift ;;
+		--workspace)       process_workspace=1; shift ;;
+		--limit)           limit="${2:-$limit}"; shift 2 ;;
+		--limit=*)         limit="${cur_arg#--limit=}"; shift ;;
+		--repo-path)       repo_path="${2:-}"; shift 2 ;;
+		--repo-path=*)     repo_path="${cur_arg#--repo-path=}"; shift ;;
+		--confidence)      confidence="${2:-$confidence}"; shift 2 ;;
+		--confidence=*)    confidence="${cur_arg#--confidence=}"; shift ;;
+		*)
+			print_error "Unknown flag: $cur_arg"
+			exit 1
+			;;
+		esac
+	done
+
+	# Rate-window guard (skip if interval not elapsed, unless --dry-run)
+	if [[ "$dry_run" -eq 0 ]] && ! _within_rate_window; then
+		exit 0
+	fi
+
+	# Exclusive lock (skip if already running)
+	if ! _acquire_lock; then
+		exit 0
+	fi
+
+	# Ensure lock is released on exit
+	trap '_release_lock' EXIT INT TERM
+
+	local exit_code=0
+
+	# Build common triage args
+	local triage_args=("--limit" "$limit" "--confidence-threshold" "$confidence")
+	[[ "$dry_run" -eq 1 ]] && triage_args+=("--dry-run")
+
+	# --- Process repo-level inbox ---
+	if [[ -n "$repo_path" ]]; then
+		print_info "Processing inbox at: ${repo_path}"
+		local orig_dir
+		orig_dir="$(pwd)"
+		if cd "$repo_path" 2>/dev/null; then
+			_triage_inbox "${triage_args[@]}" || exit_code=$?
+			cd "$orig_dir" || true
+		else
+			print_error "Cannot cd to repo path: ${repo_path}"
+			exit_code=1
+		fi
+	elif [[ "$process_workspace" -eq 1 ]]; then
+		# --- Process workspace inbox ---
+		if [[ -d "$WORKSPACE_INBOX_DIR" ]]; then
+			print_info "Processing workspace inbox at: ${WORKSPACE_INBOX_DIR}"
+			local ws_parent
+			ws_parent="$(dirname "$WORKSPACE_INBOX_DIR")"
+			local orig_dir2
+			orig_dir2="$(pwd)"
+			if cd "$ws_parent" 2>/dev/null; then
+				_triage_inbox "${triage_args[@]}" || exit_code=$?
+				cd "$orig_dir2" || true
+			fi
+		else
+			print_info "Workspace inbox not provisioned. Skipping."
+		fi
+	else
+		# Default: process current directory's inbox
+		local cur_inbox="${PWD}/${INBOX_DIR_NAME}"
+		if [[ -d "$cur_inbox" ]]; then
+			print_info "Processing inbox at: ${PWD}"
+			_triage_inbox "${triage_args[@]}" || exit_code=$?
+		else
+			print_info "No _inbox/ found in current directory (${PWD}). Skipping."
+		fi
+	fi
+
+	# Stamp last run time (only on real runs without error)
+	if [[ "$dry_run" -eq 0 && "$exit_code" -eq 0 ]]; then
+		_stamp_last_run
+	fi
+
+	return "$exit_code"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Implements `aidevops inbox triage` — the routine that processes captured items in `_inbox/`, classifies them via sensitivity gate + LLM, and routes to the appropriate plane.

### Changes

**`inbox-helper.sh`** — adds `triage` subcommand:
- `cmd_triage [--dry-run] [--limit N] [--confidence-threshold N]`: scans `triage.log` for `pending` items, runs the sensitivity gate → LLM classification → routing pipeline.
- `_triage_route_needs_review`: moves low-confidence or unknown-sensitivity items to `_needs-review/` with adjacent `meta.json` and triage.log entry.
- `_triage_route_to_plane`: moves classified items to target plane (`_knowledge/`, `_cases/`, etc.) with full provenance `meta.json` and triage.log entry.
- New helpers: `_json_field()` (grep+cut JSON field extractor, no jq dep), `_json_escape()` (quote escaping for JSON embedding).
- New constants: `TRIAGE_KEY_SENSITIVITY`, `TRIAGE_KEY_STATUS`, `TRIAGE_KEY_PATH`, `TRIAGE_VAL_PENDING` — eliminates repeated string literals, passes pre-commit ratchet gate.
- Graceful degradation: when `sensitivity-detect.sh` (P0.5a) or `llm-routing-helper.sh` (P0.5b) are not yet installed, all items route to `_needs-review/` with `reason: dependency-unavailable`. The code is fully functional once those dependencies land.

**`inbox-triage-routine.sh`** (new) — pulse-callable wrapper:
- Rate-limit guard: respects `INBOX_TRIAGE_INTERVAL_MINUTES` (default 60), skips run if interval not elapsed.
- Exclusive lock via `mkdir` (bash 3.2 compatible, atomic).
- Accepts `--dry-run`, `--limit`, `--repo-path`, `--workspace`, `--confidence` flags.
- Exit 0: all items processed (routed or needs-review). Exit 1: classifier error.

### Security invariant upheld

The sensitivity gate runs **LOCAL ONLY** (via `sensitivity-detect.sh`). Items classified `privileged` or `competitive` are routed using local-only LLM tier only. Cloud LLM never sees privileged content. This is enforced structurally: `SENSITIVITY_LOCAL_ONLY_TIERS="unknown privileged competitive"` gates the `--local-only` flag on all LLM calls for those tiers.

### Verification

```bash
shellcheck .agents/scripts/inbox-helper.sh .agents/scripts/inbox-triage-routine.sh
# Both pass with zero violations.

# Dry-run sanity (no files moved)
aidevops inbox triage --dry-run --limit 5

# Privileged content stays local (once P0.5a/P0.5b land):
echo "Subject: Re: legal advice from counsel" > /tmp/privileged.eml
aidevops inbox add /tmp/privileged.eml
aidevops inbox triage --dry-run --limit 1
# Expected: sensitivity=privileged, llm_tier=local-only, never reaches cloud.
```

For #20892

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.17 plugin for [OpenCode](https://opencode.ai) v1.14.25 with claude-sonnet-4-6 spent 17m and 43,975 tokens on this as a headless worker.
