### PR TITLE
t2852: case CLI surface (attach/status/close/archive/list/show/note/deadline/party/comm)

### DIFF
--- a/.agents/aidevops/cases-plane.md
+++ b/.agents/aidevops/cases-plane.md
@@ -1,0 +1,193 @@
+# Cases Plane
+
+<!-- AI-CONTEXT-START -->
+
+The cases plane (`_cases/`) is an audit-trail-driven matter management system for legal, compliance, dispute, and operational case work. Each case is a directory with a structured dossier, a chronological timeline, pointers to attached knowledge sources, and sub-files for notes, communications, and drafts.
+
+## Directory Contract
+
+```
+_cases/
+├── .gitignore          # Excludes drafts/ by default
+├── .case-counter       # Per-repo sequential counter: YYYY:NNNN
+├── README.md
+├── archived/           # Closed/archived cases (git mv from active)
+└── case-YYYY-NNNN-<slug>/
+    ├── dossier.toon    # ToonSON (JSON) metadata file
+    ├── timeline.jsonl  # Chronological event log (one JSON per line)
+    ├── sources.toon    # JSON array of attached knowledge source pointers
+    ├── notes/
+    │   └── notes.md   # Internal context notes
+    ├── comms/
+    │   └── comms.log  # Communications log (paper-trail entries)
+    └── drafts/         # Work-in-progress (gitignored by default)
+```
+
+### Case ID Scheme
+
+Format: `case-YYYY-NNNN-<slug>`
+
+- `YYYY` — 4-digit year (resets sequence on year change)
+- `NNNN` — zero-padded 4-digit sequence number per repo per year
+- `<slug>` — kebab-case human identifier (e.g. `acme-dispute`, `gdpr-audit-2026`)
+
+Example: `case-2026-0001-acme-dispute`
+
+The counter is stored at `_cases/.case-counter` in format `YYYY:N` and incremented atomically via an `mkdir` lock to prevent collisions in concurrent sessions.
+
+## dossier.toon Schema
+
+The dossier is a plain JSON file (`.toon` indicates ToonSON — human-friendly versioned JSON config). See `.agents/templates/case-dossier-schema.json` for the JSON Schema.
+
+```json
+{
+  "id":              "case-2026-0001-acme-dispute",
+  "slug":            "acme-dispute",
+  "kind":            "dispute",
+  "opened_at":       "2026-04-26T00:00:00Z",
+  "status":          "open",
+  "outcome":         "",
+  "outcome_summary": "",
+  "parties": [
+    {"name": "ACME Ltd", "role": "client"}
+  ],
+  "deadlines": [
+    {"label": "filing deadline", "date": "2026-08-31"}
+  ],
+  "related_cases":  [],
+  "related_repos":  []
+}
+```
+
+**Status values:** `open` | `hold` | `closed`
+
+**Outcome values (when closed):** free-text — e.g. `settled`, `withdrawn`, `resolved`, `dismissed`, `referred`
+
+## timeline.jsonl Format
+
+Each line is a JSON event object. Timeline is append-only — no event is ever deleted.
+
+```json
+{"ts":"2026-04-26T00:00:00Z","kind":"open","actor":"Marcus Quinn","content":"Case opened: case-2026-0001-acme-dispute","ref":""}
+{"ts":"2026-04-26T10:00:00Z","kind":"attach","actor":"Marcus Quinn","content":"Attached source: src-001 (role: evidence)","ref":"src-001"}
+{"ts":"2026-04-26T11:00:00Z","kind":"status_change","actor":"Marcus Quinn","content":"Status changed: open → hold. Reason: awaiting client","ref":""}
+{"ts":"2026-04-26T12:00:00Z","kind":"note","actor":"Marcus Quinn","content":"Reviewed contract terms","ref":"notes/notes.md"}
+{"ts":"2026-04-26T13:00:00Z","kind":"comm","actor":"Marcus Quinn","content":"Comm logged: in via email — Received settlement offer","ref":"comms/comms.log"}
+{"ts":"2026-04-26T14:00:00Z","kind":"deadline","actor":"Marcus Quinn","content":"Deadline added: filing deadline on 2026-08-31","ref":""}
+{"ts":"2026-04-26T15:00:00Z","kind":"party","actor":"Marcus Quinn","content":"Party added: Opposing Counsel (opponent)","ref":""}
+{"ts":"2026-04-27T09:00:00Z","kind":"status_change","actor":"Marcus Quinn","content":"Case closed. Outcome: settled. Agreed in mediation","ref":""}
+{"ts":"2026-04-27T09:01:00Z","kind":"archive","actor":"Marcus Quinn","content":"Case archived","ref":""}
+```
+
+**Event kinds:** `open` | `status_change` | `attach` | `note` | `comm` | `deadline` | `party` | `archive`
+
+## sources.toon Format
+
+Plain JSON array. Each entry is a pointer to a `_knowledge/sources/<id>/` directory — no content duplication.
+
+```json
+[
+  {"id": "src-001", "attached_at": "2026-04-26T10:00:00Z", "attached_by": "Marcus Quinn", "role": "evidence"},
+  {"id": "src-002", "attached_at": "2026-04-26T10:01:00Z", "attached_by": "Marcus Quinn", "role": "background"}
+]
+```
+
+**Roles:** `evidence` | `reference` | `background`
+
+**Cross-case privilege firewall (design only — enforced in P6a):** by default each case sees only its own `sources.toon`. Cross-case search will require explicit `--include-case <id>` and will be logged in the timeline.
+
+## CLI Reference
+
+Provided by `case-helper.sh`. Route via `aidevops case <subcommand>`.
+
+### Provisioning
+
+```bash
+aidevops case init [<repo-path>]
+```
+
+Creates `_cases/`, `.case-counter`, `.gitignore`, `archived/`, and `README.md`. Safe to run on existing repos.
+
+### Open a case
+
+```bash
+aidevops case open <slug> [--kind <type>] [--party <name>] [--party-role <role>] \
+  [--deadline <ISO-date>] [--deadline-label <text>] [--json]
+```
+
+### View cases
+
+```bash
+aidevops case list [--status open|hold|closed|archived|all] [--kind <type>] [--party <name>] [--json]
+aidevops case show <case-id> [--json]
+```
+
+### Lifecycle operations
+
+```bash
+aidevops case status <case-id> <open|hold> [--reason "..."] [--json]
+aidevops case close <case-id> --outcome <outcome> [--summary "..."] [--json]
+aidevops case archive <case-id> [--json]
+```
+
+**Closing requires `--outcome`** — attempting `case close` without it returns an error.
+
+### Attach a knowledge source
+
+```bash
+aidevops case attach <case-id> <source-id> [--role evidence|reference|background] [--json]
+```
+
+Source must exist in `_knowledge/sources/<id>/` (promoted from inbox/staging). Refuses to attach non-promoted sources.
+
+### Notes
+
+```bash
+aidevops case note <case-id> --message "Internal context here" [--json]
+```
+
+Appends to `notes/notes.md` AND timeline (timeline points to file location).
+
+### Deadlines
+
+```bash
+aidevops case deadline add    <case-id> --date 2026-08-31 --label "filing deadline" [--json]
+aidevops case deadline remove <case-id> --label "filing deadline" [--json]
+```
+
+### Parties
+
+```bash
+aidevops case party add    <case-id> --name "Opposing Counsel" --role "opponent" [--json]
+aidevops case party remove <case-id> --name "Opposing Counsel" [--json]
+```
+
+### Communications log
+
+```bash
+aidevops case comm log <case-id> --direction in|out --channel email --summary "Received offer" [--json]
+```
+
+Paper-trail entry — full email content attaches via P5 (inbox-to-case filter). Each entry lands in `comms/comms.log` and the timeline.
+
+## Archived Cases
+
+`archive` uses `git mv` (when inside a git repo) to move the case directory to `_cases/archived/`. Archived cases:
+
+- Are excluded from the default `list` output
+- Are visible with `--status archived` or `--status all`
+- Require `--unarchive` flag for all mutating operations
+
+## JSON Output Mode
+
+All read-side commands (`list`, `show`) and all mutating commands support `--json` for machine consumption. Use for scripting, P5 filter integration, and P4c alarming.
+
+## Dependencies
+
+- **Provisioned by:** `aidevops case init`
+- **Sources come from:** `_knowledge/sources/` (managed by knowledge plane, t2844)
+- **Alarming reads:** `dossier.deadlines` (t2853 P4c)
+- **Comms agent operates on:** cases (P6)
+- **Filter→case-attach:** uses `aidevops case attach` (P5c)
+
+<!-- AI-CONTEXT-END -->

--- a/.agents/scripts/case-helper.sh
+++ b/.agents/scripts/case-helper.sh
@@ -1,0 +1,1374 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# shellcheck disable=SC2034
+set -euo pipefail
+
+# =============================================================================
+# Case Helper (t2851 foundation + t2852 extended CLI)
+# =============================================================================
+# Manages the _cases/ plane: provisioning, open, attach, status, close,
+# archive, list, show, note, deadline, party, comm.
+#
+# Usage:
+#   case-helper.sh <command> [args] [options]
+#
+# Commands:
+#   init [<repo-path>]              Provision _cases/ skeleton for a repo
+#   open <slug> [options]           Open a new case
+#   attach <case-id> <source-id>    Attach a knowledge source to a case
+#   status <case-id> <new-status>   Update case status (open|hold|closed)
+#   close <case-id> --outcome <x>   Close a case with outcome (shorthand)
+#   archive <case-id>               Move case to _cases/archived/
+#   list [options]                  List cases (default: open, table output)
+#   show <case-id>                  Pretty-print dossier + timeline + sources
+#   note <case-id> [options]        Append a note to case
+#   deadline add|remove <case-id>   Manage case deadlines
+#   party add|remove <case-id>      Manage case parties
+#   comm log <case-id>              Log a communication entry
+#   help                            Show this help
+# =============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/shared-constants.sh"
+
+init_log_file
+
+# =============================================================================
+# Constants
+# =============================================================================
+
+readonly CASES_DIR_NAME="_cases"
+readonly CASE_COUNTER_FILE=".case-counter"
+readonly CASE_DOSSIER_FILE="dossier.toon"
+readonly CASE_TIMELINE_FILE="timeline.jsonl"
+readonly CASE_SOURCES_FILE="sources.toon"
+readonly CASES_ARCHIVE_DIR="archived"
+readonly CASE_NOTES_DIR="notes"
+readonly CASE_COMMS_DIR="comms"
+readonly CASE_DRAFTS_DIR="drafts"
+readonly CASE_NOTES_FILE="notes.md"
+
+CASES_SCHEMA_FILE="${SCRIPT_DIR}/../templates/case-dossier-schema.json"
+CASES_GITIGNORE_TEMPLATE="${SCRIPT_DIR}/../templates/cases-gitignore.txt"
+
+# =============================================================================
+# Error helpers — centralise repeated messages to satisfy string-literal ratchet
+# =============================================================================
+
+_err_opt_unknown() {
+	local _o="${1:-}"
+	print_error "Unknown option: ${_o}"
+	return 1
+}
+
+_err_case_missing() {
+	local _id="${1:-}"
+	print_error "Case not found: ${_id}"
+	return 1
+}
+
+_err_case_archived() {
+	print_error "Case is archived. Use --unarchive to operate on it."
+	return 1
+}
+
+# =============================================================================
+# Internal helpers
+# =============================================================================
+
+# _iso_ts_full — current UTC timestamp ISO 8601 full
+_iso_ts_full() {
+	date -u '+%Y%m%dT%H%M%SZ'
+	return 0
+}
+
+# _current_year — 4-digit current year
+_current_year() {
+	date -u '+%Y'
+	return 0
+}
+
+# _resolve_cases_dir <repo-path>
+_resolve_cases_dir() {
+	local repo_path="${1:-$(pwd)}"
+	echo "${repo_path}/${CASES_DIR_NAME}"
+	return 0
+}
+
+# _current_actor — best-effort actor name (git user, env, or "unknown")
+_current_actor() {
+	local actor
+	actor="$(git config user.name 2>/dev/null)" || true
+	[[ -z "$actor" ]] && actor="${USER:-unknown}"
+	echo "$actor"
+	return 0
+}
+
+# _require_jq — error if jq is not available
+_require_jq() {
+	if ! command -v jq >/dev/null 2>&1; then
+		print_error "jq is required but not found. Install: brew install jq"
+		return 1
+	fi
+	return 0
+}
+
+# _case_id_claim <cases-dir> — claim the next sequential case ID atomically.
+# Returns the full case ID string: case-YYYY-NNNN
+_case_id_claim() {
+	local cases_dir="$1"
+	local counter_file="${cases_dir}/${CASE_COUNTER_FILE}"
+	local year seq new_seq padded
+	year="$(_current_year)"
+
+	# Acquire lock via atomic mkdir (POSIX-compatible)
+	local lock_dir="${counter_file}.lock"
+	local max_wait=10 waited=0
+	while ! mkdir "$lock_dir" 2>/dev/null; do
+		sleep 0.2
+		waited=$((waited + 1))
+		if [[ $waited -ge $((max_wait * 5)) ]]; then
+			print_error "Timeout waiting for case counter lock"
+			return 1
+		fi
+	done
+	# Ensure lock is always released
+	# shellcheck disable=SC2064
+	trap "rmdir '${lock_dir}' 2>/dev/null || true" EXIT
+
+	if [[ -f "$counter_file" ]]; then
+		local stored_year stored_seq
+		stored_year="$(cut -d: -f1 "$counter_file")"
+		stored_seq="$(cut -d: -f2 "$counter_file")"
+		if [[ "$stored_year" == "$year" ]]; then
+			seq=$((stored_seq + 1))
+		else
+			seq=1
+		fi
+	else
+		seq=1
+	fi
+
+	padded="$(printf '%04d' "$seq")"
+	printf '%s:%s\n' "$year" "$seq" >"$counter_file"
+	rmdir "$lock_dir" 2>/dev/null || true
+	trap - EXIT
+
+	echo "case-${year}-${padded}"
+	return 0
+}
+
+# _case_find <cases-dir> <case-id-or-slug> — resolve full case directory path.
+# Accepts full case-id (case-YYYY-NNNN-slug) or partial slug match.
+_case_find() {
+	local cases_dir="$1" query="$2"
+	local matched=""
+
+	# Direct directory match first
+	if [[ -d "${cases_dir}/${query}" ]]; then
+		echo "${cases_dir}/${query}"
+		return 0
+	fi
+
+	# Prefix match: case-YYYY-NNNN-<slug>
+	local dir
+	for dir in "${cases_dir}"/case-*-"${query}" "${cases_dir}"/case-*-*"${query}"*; do
+		[[ -d "$dir" ]] || continue
+		# Skip archived sub-dir entries when searching active
+		[[ "$dir" == *"/archived/"* ]] && continue
+		matched="$dir"
+		break
+	done
+
+	if [[ -z "$matched" ]]; then
+		# Try archived
+		for dir in "${cases_dir}/${CASES_ARCHIVE_DIR}"/case-*-"${query}" \
+			"${cases_dir}/${CASES_ARCHIVE_DIR}"/case-*-*"${query}"*; do
+			[[ -d "$dir" ]] || continue
+			matched="$dir"
+			break
+		done
+	fi
+
+	if [[ -n "$matched" ]]; then
+		echo "$matched"
+		return 0
+	fi
+
+	return 1
+}
+
+# _dossier_load <case-dir> — prints dossier JSON to stdout
+_dossier_load() {
+	local case_dir="$1"
+	local dossier_path="${case_dir}/${CASE_DOSSIER_FILE}"
+	if [[ ! -f "$dossier_path" ]]; then
+		print_error "Dossier not found: ${dossier_path}"
+		return 1
+	fi
+	jq '.' "$dossier_path"
+	return 0
+}
+
+# _dossier_save <case-dir> — reads JSON from stdin, writes to dossier.toon
+_dossier_save() {
+	local case_dir="$1"
+	local dossier_path="${case_dir}/${CASE_DOSSIER_FILE}"
+	jq '.' >"$dossier_path"
+	return 0
+}
+
+# _timeline_append <case-dir> <kind> <actor> <content> [ref]
+# Appends a JSONL event line to timeline.jsonl
+_timeline_append() {
+	local case_dir="$1" kind="$2" actor="$3" content="$4" ref="${5:-}"
+	local timeline_path="${case_dir}/${CASE_TIMELINE_FILE}"
+	local ts
+	ts="$(_iso_ts_full)"
+	local event
+	# Use -c (compact) so each event is a single line — proper JSONL format.
+	event="$(jq -cn \
+		--arg ts "$ts" \
+		--arg kind "$kind" \
+		--arg actor "$actor" \
+		--arg content "$content" \
+		--arg ref "$ref" \
+		'{ts:$ts, kind:$kind, actor:$actor, content:$content, ref:$ref}')"
+	echo "$event" >>"$timeline_path"
+	return 0
+}
+
+# _is_archived <case-dir> — returns 0 if case is in archived/ sub-dir
+_is_archived() {
+	local case_dir="$1"
+	[[ "$case_dir" == *"/${CASES_ARCHIVE_DIR}/"* ]]
+	return $?
+}
+
+# =============================================================================
+# cmd_init — provision _cases/ skeleton for a repo
+# =============================================================================
+
+cmd_init() {
+	local repo_path="${1:-$(pwd)}"
+	local cases_dir
+	cases_dir="$(_resolve_cases_dir "$repo_path")"
+
+	print_info "Provisioning cases plane at: ${cases_dir}"
+
+	mkdir -p "${cases_dir}"
+	mkdir -p "${cases_dir}/${CASES_ARCHIVE_DIR}"
+
+	# .gitignore
+	local gitignore_path="${cases_dir}/.gitignore"
+	if [[ ! -f "$gitignore_path" ]]; then
+		if [[ -f "$CASES_GITIGNORE_TEMPLATE" ]]; then
+			cp "$CASES_GITIGNORE_TEMPLATE" "$gitignore_path"
+		else
+			printf '# _cases/ — drafts excluded\ndrafts/\n.DS_Store\n' >"$gitignore_path"
+		fi
+	fi
+
+	# Case counter
+	local counter_path="${cases_dir}/${CASE_COUNTER_FILE}"
+	if [[ ! -f "$counter_path" ]]; then
+		local year
+		year="$(_current_year)"
+		printf '%s:0\n' "$year" >"$counter_path"
+	fi
+
+	# README
+	local readme_path="${cases_dir}/README.md"
+	if [[ ! -f "$readme_path" ]]; then
+		printf '%s\n' \
+			"# Cases" \
+			"" \
+			"Managed by \`aidevops case\`. See \`.agents/aidevops/cases-plane.md\`." \
+			>"$readme_path"
+	fi
+
+	print_success "Cases plane provisioned: ${cases_dir}"
+	return 0
+}
+
+# =============================================================================
+# cmd_open — open a new case
+# =============================================================================
+
+cmd_open() {
+	_require_jq || return 1
+
+	local slug='' kind='' party_name='' party_role="client" deadline_date='' deadline_label=''
+	local repo_path="" json_mode=false
+
+	while [[ $# -gt 0 ]]; do
+		local _cur="${1:-}" _nxt="${2:-}"
+		case "$_cur" in
+		--kind) kind="$_nxt"; shift 2 ;;
+		--party) party_name="$_nxt"; shift 2 ;;
+		--party-role) party_role="$_nxt"; shift 2 ;;
+		--deadline) deadline_date="$_nxt"; shift 2 ;;
+		--deadline-label) deadline_label="$_nxt"; shift 2 ;;
+		--repo) repo_path="$_nxt"; shift 2 ;;
+		--json) json_mode=true; shift ;;
+		-*) _err_opt_unknown "$_cur"; return 1 ;;
+		*) slug="$_cur"; shift ;;
+		esac
+	done
+
+	[[ -z "$slug" ]] && { print_error "Usage: case open <slug> [--kind <type>] [--party <name>]"; return 1; }
+	[[ -z "$repo_path" ]] && repo_path="$(pwd)"
+
+	local cases_dir
+	cases_dir="$(_resolve_cases_dir "$repo_path")"
+	[[ ! -d "$cases_dir" ]] && { print_error "Cases plane not provisioned. Run: aidevops case init"; return 1; }
+
+	local case_prefix
+	case_prefix="$(_case_id_claim "$cases_dir")"
+	local case_id="${case_prefix}-${slug}"
+	local case_dir="${cases_dir}/${case_id}"
+
+	mkdir -p "${case_dir}/${CASE_NOTES_DIR}"
+	mkdir -p "${case_dir}/${CASE_COMMS_DIR}"
+	mkdir -p "${case_dir}/${CASE_DRAFTS_DIR}"
+
+	local actor ts
+	actor="$(_current_actor)"
+	ts="$(_iso_ts_full)"
+
+	# Build parties JSON array
+	local parties_json="[]"
+	if [[ -n "$party_name" ]]; then
+		parties_json="$(jq -n --arg n "$party_name" --arg r "$party_role" \
+			'[{name:$n, role:$r}]')"
+	fi
+
+	# Build deadlines JSON array
+	local deadlines_json="[]"
+	if [[ -n "$deadline_date" ]]; then
+		local dl_label="${deadline_label:-deadline}"
+		deadlines_json="$(jq -n --arg d "$deadline_date" --arg l "$dl_label" \
+			'[{label:$l, date:$d}]')"
+	fi
+
+	# Write dossier.toon
+	jq -n \
+		--arg id "$case_id" \
+		--arg slug "$slug" \
+		--arg kind "${kind:-general}" \
+		--arg opened_at "$ts" \
+		--arg initial_status "open" \
+		--argjson parties "$parties_json" \
+		--argjson deadlines "$deadlines_json" \
+		'{id:$id, slug:$slug, kind:$kind, opened_at:$opened_at,
+		  status:$initial_status, outcome:"", outcome_summary:"",
+		  parties:$parties, deadlines:$deadlines,
+		  related_cases:[], related_repos:[]}' \
+		>"${case_dir}/${CASE_DOSSIER_FILE}"
+
+	# Initialize timeline
+	printf '' >"${case_dir}/${CASE_TIMELINE_FILE}"
+	_timeline_append "$case_dir" "open" "$actor" "Case opened: ${case_id}" ""
+
+	# Initialize sources.toon as empty array
+	printf '[]\n' >"${case_dir}/${CASE_SOURCES_FILE}"
+
+	# Initialize notes file
+	printf '# Notes: %s\n\n' "$case_id" >"${case_dir}/${CASE_NOTES_DIR}/${CASE_NOTES_FILE}"
+
+	if [[ "$json_mode" == true ]]; then
+		jq '.' "${case_dir}/${CASE_DOSSIER_FILE}"
+	else
+		print_success "Case opened: ${case_id}"
+		echo "  Path:   ${case_dir}"
+		echo "  Kind:   ${kind:-general}"
+		echo "  Status: open"
+		[[ -n "$party_name" ]] && echo "  Party:  ${party_name} (${party_role})"
+	fi
+	return 0
+}
+
+# =============================================================================
+# cmd_attach — attach a knowledge source to a case
+# =============================================================================
+
+cmd_attach() {
+	_require_jq || return 1
+
+	local case_id='' source_id='' role="reference"
+	local repo_path="" json_mode=false unarchive=false
+
+	while [[ $# -gt 0 ]]; do
+		local _cur="${1:-}" _nxt="${2:-}"
+		case "$_cur" in
+		--role) role="$_nxt"; shift 2 ;;
+		--repo) repo_path="$_nxt"; shift 2 ;;
+		--json) json_mode=true; shift ;;
+		--unarchive) unarchive=true; shift ;;
+		-*) _err_opt_unknown "$_cur"; return 1 ;;
+		*) [[ -z "$case_id" ]] && { case_id="$_cur"; shift; } || { source_id="$_cur"; shift; } ;;
+		esac
+	done
+
+	[[ -z "$case_id" || -z "$source_id" ]] && {
+		print_error "Usage: case attach <case-id> <source-id> [--role evidence|reference|background]"
+		return 1
+	}
+	[[ -z "$repo_path" ]] && repo_path="$(pwd)"
+
+	local cases_dir
+	cases_dir="$(_resolve_cases_dir "$repo_path")"
+	local case_dir
+	case_dir="$(_case_find "$cases_dir" "$case_id")" || {
+		_err_case_missing "$case_id"
+		return 1
+	}
+
+	# Refuse to operate on archived case without --unarchive
+	if _is_archived "$case_dir" && [[ "$unarchive" != true ]]; then
+		_err_case_archived
+		return 1
+	fi
+
+	# Validate role
+	case "$role" in
+	evidence | reference | background) ;;
+	*) print_error "Invalid role: ${role}. Must be evidence|reference|background"; return 1 ;;
+	esac
+
+	# Verify source exists in _knowledge/sources/
+	local knowledge_src="${repo_path}/_knowledge/sources/${source_id}"
+	if [[ ! -d "$knowledge_src" ]]; then
+		print_error "Source not found: ${knowledge_src}"
+		print_error "Sources must be promoted from _knowledge before attaching."
+		return 1
+	fi
+
+	# Check not already attached
+	local sources_file="${case_dir}/${CASE_SOURCES_FILE}"
+	local already
+	already="$(jq -r --arg id "$source_id" '.[] | select(.id == $id) | .id' "$sources_file" 2>/dev/null)" || true
+	if [[ -n "$already" ]]; then
+		print_error "Source already attached: ${source_id}"
+		return 1
+	fi
+
+	local actor ts
+	actor="$(_current_actor)"
+	ts="$(_iso_ts_full)"
+
+	# Append to sources.toon
+	local entry
+	entry="$(jq -n --arg id "$source_id" --arg ts "$ts" --arg by "$actor" --arg role "$role" \
+		'{id:$id, attached_at:$ts, attached_by:$by, role:$role}')"
+	local updated
+	updated="$(jq --argjson e "$entry" '. + [$e]' "$sources_file")"
+	echo "$updated" >"$sources_file"
+
+	_timeline_append "$case_dir" "attach" "$actor" \
+		"Attached source: ${source_id} (role: ${role})" "$source_id"
+
+	if [[ "$json_mode" == true ]]; then
+		echo "$entry"
+	else
+		print_success "Source attached: ${source_id} → ${case_id} (${role})"
+	fi
+	return 0
+}
+
+# =============================================================================
+# cmd_status — update case status
+# =============================================================================
+
+cmd_status() {
+	_require_jq || return 1
+
+	local case_id='' new_status='' reason=''
+	local repo_path="" json_mode=false unarchive=false
+
+	while [[ $# -gt 0 ]]; do
+		local _cur="${1:-}" _nxt="${2:-}"
+		case "$_cur" in
+		--reason) reason="$_nxt"; shift 2 ;;
+		--repo) repo_path="$_nxt"; shift 2 ;;
+		--json) json_mode=true; shift ;;
+		--unarchive) unarchive=true; shift ;;
+		-*) _err_opt_unknown "$_cur"; return 1 ;;
+		*) [[ -z "$case_id" ]] && { case_id="$_cur"; shift; } || { new_status="$_cur"; shift; } ;;
+		esac
+	done
+
+	[[ -z "$case_id" || -z "$new_status" ]] && {
+		print_error "Usage: case status <case-id> <open|hold|closed> [--reason \"...\"]"
+		return 1
+	}
+	[[ -z "$repo_path" ]] && repo_path="$(pwd)"
+
+	case "$new_status" in
+	open | hold | closed) ;;
+	*) print_error "Invalid status: ${new_status}. Must be open|hold|closed"; return 1 ;;
+	esac
+
+	local cases_dir
+	cases_dir="$(_resolve_cases_dir "$repo_path")"
+	local case_dir
+	case_dir="$(_case_find "$cases_dir" "$case_id")" || {
+		_err_case_missing "$case_id"
+		return 1
+	}
+
+	if _is_archived "$case_dir" && [[ "$unarchive" != true ]]; then
+		_err_case_archived
+		return 1
+	fi
+
+	# Closed without outcome goes through cmd_close which enforces --outcome
+	if [[ "$new_status" == "closed" ]]; then
+		print_error "Use 'case close <case-id> --outcome <x>' to close a case (outcome is required)."
+		return 1
+	fi
+
+	local actor
+	actor="$(_current_actor)"
+
+	local dossier
+	dossier="$(_dossier_load "$case_dir")"
+	local old_status
+	old_status="$(echo "$dossier" | jq -r '.status')"
+
+	local updated
+	updated="$(echo "$dossier" | jq --arg s "$new_status" '.status = $s')"
+	echo "$updated" | _dossier_save "$case_dir"
+
+	local content="Status changed: ${old_status} → ${new_status}"
+	[[ -n "$reason" ]] && content="${content}. Reason: ${reason}"
+	_timeline_append "$case_dir" "status_change" "$actor" "$content" ""
+
+	if [[ "$json_mode" == true ]]; then
+		echo "$updated"
+	else
+		print_success "Case status updated: ${case_id} → ${new_status}"
+	fi
+	return 0
+}
+
+# =============================================================================
+# cmd_close — close a case with outcome (shorthand for status closed + outcome)
+# =============================================================================
+
+cmd_close() {
+	_require_jq || return 1
+
+	local case_id='' outcome='' summary=''
+	local repo_path="" json_mode=false unarchive=false
+
+	while [[ $# -gt 0 ]]; do
+		local _cur="${1:-}" _nxt="${2:-}"
+		case "$_cur" in
+		--outcome) outcome="$_nxt"; shift 2 ;;
+		--summary) summary="$_nxt"; shift 2 ;;
+		--repo) repo_path="$_nxt"; shift 2 ;;
+		--json) json_mode=true; shift ;;
+		--unarchive) unarchive=true; shift ;;
+		-*) _err_opt_unknown "$_cur"; return 1 ;;
+		*) case_id="$_cur"; shift ;;
+		esac
+	done
+
+	[[ -z "$case_id" ]] && { print_error "Usage: case close <case-id> --outcome <outcome>"; return 1; }
+	[[ -z "$outcome" ]] && { print_error "Outcome is required when closing a case. Use --outcome <x>"; return 1; }
+	[[ -z "$repo_path" ]] && repo_path="$(pwd)"
+
+	local cases_dir
+	cases_dir="$(_resolve_cases_dir "$repo_path")"
+	local case_dir
+	case_dir="$(_case_find "$cases_dir" "$case_id")" || {
+		_err_case_missing "$case_id"
+		return 1
+	}
+
+	if _is_archived "$case_dir" && [[ "$unarchive" != true ]]; then
+		_err_case_archived
+		return 1
+	fi
+
+	local actor
+	actor="$(_current_actor)"
+
+	local dossier
+	dossier="$(_dossier_load "$case_dir")"
+	local updated
+	updated="$(echo "$dossier" | jq \
+		--arg outcome "$outcome" \
+		--arg summary "$summary" \
+		'.status = "closed" | .outcome = $outcome | .outcome_summary = $summary')"
+	echo "$updated" | _dossier_save "$case_dir"
+
+	local content="Case closed. Outcome: ${outcome}"
+	[[ -n "$summary" ]] && content="${content}. ${summary}"
+	_timeline_append "$case_dir" "status_change" "$actor" "$content" ""
+
+	if [[ "$json_mode" == true ]]; then
+		echo "$updated"
+	else
+		print_success "Case closed: ${case_id} (outcome: ${outcome})"
+	fi
+	return 0
+}
+
+# =============================================================================
+# cmd_archive — move case directory to _cases/archived/
+# =============================================================================
+
+cmd_archive() {
+	local case_id='' repo_path='' json_mode=false
+
+	while [[ $# -gt 0 ]]; do
+		local _cur="${1:-}" _nxt="${2:-}"
+		case "$_cur" in
+		--repo) repo_path="$_nxt"; shift 2 ;;
+		--json) json_mode=true; shift ;;
+		-*) _err_opt_unknown "$_cur"; return 1 ;;
+		*) case_id="$_cur"; shift ;;
+		esac
+	done
+
+	[[ -z "$case_id" ]] && { print_error "Usage: case archive <case-id>"; return 1; }
+	[[ -z "$repo_path" ]] && repo_path="$(pwd)"
+	_require_jq || return 1
+
+	local cases_dir
+	cases_dir="$(_resolve_cases_dir "$repo_path")"
+	local case_dir
+	case_dir="$(_case_find "$cases_dir" "$case_id")" || {
+		_err_case_missing "$case_id"
+		return 1
+	}
+
+	if _is_archived "$case_dir"; then
+		print_error "Case is already archived."
+		return 1
+	fi
+
+	local actor
+	actor="$(_current_actor)"
+	local case_basename
+	case_basename="$(basename "$case_dir")"
+	local archive_dir="${cases_dir}/${CASES_ARCHIVE_DIR}"
+	mkdir -p "$archive_dir"
+	local dest="${archive_dir}/${case_basename}"
+
+	_timeline_append "$case_dir" "archive" "$actor" "Case archived" ""
+
+	if command -v git >/dev/null 2>&1 && git -C "$repo_path" rev-parse --git-dir >/dev/null 2>&1; then
+		git -C "$repo_path" mv "$case_dir" "$dest" 2>/dev/null || mv "$case_dir" "$dest"
+	else
+		mv "$case_dir" "$dest"
+	fi
+
+	if [[ "$json_mode" == true ]]; then
+		jq -n --arg id "$case_basename" --arg dest "$dest" \
+			--arg arch_status "${CASES_ARCHIVE_DIR}" \
+			'{status:$arch_status, case_id:$id, path:$dest}'
+	else
+		print_success "Case archived: ${case_basename}"
+		echo "  Path: ${dest}"
+	fi
+	return 0
+}
+
+# =============================================================================
+# cmd_list — list cases
+# =============================================================================
+
+cmd_list() {
+	_require_jq || return 1
+
+	local status_filter='open' kind_filter='' party_filter=''
+	local repo_path="" json_mode=false
+
+	while [[ $# -gt 0 ]]; do
+		local _cur="${1:-}" _nxt="${2:-}"
+		case "$_cur" in
+		--status) status_filter="$_nxt"; shift 2 ;;
+		--kind) kind_filter="$_nxt"; shift 2 ;;
+		--party) party_filter="$_nxt"; shift 2 ;;
+		--repo) repo_path="$_nxt"; shift 2 ;;
+		--json) json_mode=true; shift ;;
+		-*) _err_opt_unknown "$_cur"; return 1 ;;
+		*) shift ;;
+		esac
+	done
+
+	[[ -z "$repo_path" ]] && repo_path="$(pwd)"
+
+	local cases_dir
+	cases_dir="$(_resolve_cases_dir "$repo_path")"
+	[[ ! -d "$cases_dir" ]] && { print_error "Cases plane not provisioned. Run: aidevops case init"; return 1; }
+
+	# Collect cases to inspect
+	local -a case_dirs=()
+	local dir
+	for dir in "${cases_dir}"/case-*/; do
+		[[ -d "$dir" ]] || continue
+		[[ "$dir" == *"/${CASES_ARCHIVE_DIR}/"* ]] && continue
+		case_dirs+=("$dir")
+	done
+
+	if [[ "$status_filter" == "all" || "$status_filter" == "${CASES_ARCHIVE_DIR}" ]]; then
+		for dir in "${cases_dir}/${CASES_ARCHIVE_DIR}"/case-*/; do
+			[[ -d "$dir" ]] || continue
+			case_dirs+=("$dir")
+		done
+	fi
+
+	# Filter and format
+	local -a rows=()
+	local results_json="[]"
+	for case_dir in "${case_dirs[@]:-}"; do
+		[[ -z "$case_dir" ]] && continue
+		local dossier_path="${case_dir}/${CASE_DOSSIER_FILE}"
+		[[ ! -f "$dossier_path" ]] && continue
+
+		local dossier
+		dossier="$(jq '.' "$dossier_path" 2>/dev/null)" || continue
+
+		local cs_status cs_kind cs_id cs_slug cs_opened
+		cs_status="$(echo "$dossier" | jq -r '.status')"
+		cs_kind="$(echo "$dossier" | jq -r '.kind')"
+		cs_id="$(echo "$dossier" | jq -r '.id')"
+		cs_slug="$(echo "$dossier" | jq -r '.slug')"
+		cs_opened="$(echo "$dossier" | jq -r '.opened_at')"
+
+		# Apply status filter
+		if [[ "$status_filter" != "all" ]]; then
+			[[ "$cs_status" != "$status_filter" ]] && {
+				# Also show archived if in archive dir
+				_is_archived "$case_dir" && [[ "$status_filter" != "${CASES_ARCHIVE_DIR}" ]] && continue
+				! _is_archived "$case_dir" && [[ "$cs_status" != "$status_filter" ]] && continue
+			}
+		fi
+
+		# Apply kind filter
+		[[ -n "$kind_filter" && "$cs_kind" != "$kind_filter" ]] && continue
+
+		# Apply party filter
+		if [[ -n "$party_filter" ]]; then
+			local party_match
+			party_match="$(echo "$dossier" | jq -r \
+				--arg p "$party_filter" '.parties[] | select(.name | test($p;"i")) | .name' \
+				2>/dev/null)" || true
+			[[ -z "$party_match" ]] && continue
+		fi
+
+		local cs_parties cs_deadline
+		cs_parties="$(echo "$dossier" | jq -r '[.parties[].name] | join(", ")')"
+		cs_deadline="$(echo "$dossier" | jq -r '(.deadlines | sort_by(.date) | first | .date) // ""')"
+
+		if [[ "$json_mode" == true ]]; then
+			results_json="$(echo "$results_json" | jq --argjson d "$dossier" '. + [$d]')"
+		else
+			rows+=("$(printf '%-36s %-16s %-8s %-24s %-12s' \
+				"$cs_id" "$cs_kind" "$cs_status" "${cs_parties:0:24}" "${cs_deadline}")")
+		fi
+	done
+
+	if [[ "$json_mode" == true ]]; then
+		echo "$results_json"
+		return 0
+	fi
+
+	if [[ ${#rows[@]} -eq 0 ]]; then
+		echo "No cases found (status: ${status_filter})"
+		return 0
+	fi
+
+	printf '%-36s %-16s %-8s %-24s %-12s\n' "CASE-ID" "KIND" "STATUS" "PARTIES" "NEXT-DEADLINE"
+	printf '%s\n' "$(printf '%.0s-' {1..100})"
+	for row in "${rows[@]}"; do
+		echo "$row"
+	done
+	return 0
+}
+
+# =============================================================================
+# cmd_show — pretty-print a case
+# =============================================================================
+
+cmd_show() {
+	_require_jq || return 1
+
+	local case_id='' repo_path='' json_mode=false
+
+	while [[ $# -gt 0 ]]; do
+		local _cur="${1:-}" _nxt="${2:-}"
+		case "$_cur" in
+		--repo) repo_path="$_nxt"; shift 2 ;;
+		--json) json_mode=true; shift ;;
+		-*) _err_opt_unknown "$_cur"; return 1 ;;
+		*) case_id="$_cur"; shift ;;
+		esac
+	done
+
+	[[ -z "$case_id" ]] && { print_error "Usage: case show <case-id>"; return 1; }
+	[[ -z "$repo_path" ]] && repo_path="$(pwd)"
+
+	local cases_dir
+	cases_dir="$(_resolve_cases_dir "$repo_path")"
+	local case_dir
+	case_dir="$(_case_find "$cases_dir" "$case_id")" || {
+		_err_case_missing "$case_id"
+		return 1
+	}
+
+	local dossier
+	dossier="$(_dossier_load "$case_dir")"
+
+	if [[ "$json_mode" == true ]]; then
+		local sources timeline_events
+		sources="$(jq '.' "${case_dir}/${CASE_SOURCES_FILE}" 2>/dev/null)" || sources="[]"
+		timeline_events="$(jq -s '.' "${case_dir}/${CASE_TIMELINE_FILE}" 2>/dev/null)" || timeline_events="[]"
+		jq -n \
+			--argjson dossier "$dossier" \
+			--argjson sources "$sources" \
+			--argjson timeline "$timeline_events" \
+			'{dossier:$dossier, sources:$sources, timeline:$timeline}'
+		return 0
+	fi
+
+	_show_dossier_text "$dossier" "$case_dir"
+	return 0
+}
+
+# _show_dossier_text <dossier-json> <case-dir>
+_show_dossier_text() {
+	local dossier="$1" case_dir="$2"
+
+	local cs_id cs_kind cs_status cs_opened cs_outcome
+	cs_id="$(echo "$dossier" | jq -r '.id')"
+	cs_kind="$(echo "$dossier" | jq -r '.kind')"
+	cs_status="$(echo "$dossier" | jq -r '.status')"
+	cs_opened="$(echo "$dossier" | jq -r '.opened_at')"
+	cs_outcome="$(echo "$dossier" | jq -r '.outcome // ""')"
+	local _none='  (none)'
+
+	echo ""
+	echo "## Case: ${cs_id}"
+	echo ""
+	printf '  Kind:    %s\n' "$cs_kind"
+	printf '  Status:  %s\n' "$cs_status"
+	printf '  Opened:  %s\n' "$cs_opened"
+	[[ -n "$cs_outcome" ]] && printf '  Outcome: %s\n' "$cs_outcome"
+
+	echo ""
+	echo "### Parties"
+	echo "$dossier" | jq -r '.parties[] | "  - \(.name) (\(.role))"' 2>/dev/null || echo "$_none"
+
+	echo ""
+	echo "### Deadlines"
+	echo "$dossier" | jq -r '.deadlines[] | "  - \(.label): \(.date)"' 2>/dev/null || echo "$_none"
+
+	echo ""
+	echo "### Attached Sources"
+	local sources_file="${case_dir}/${CASE_SOURCES_FILE}"
+	if [[ -f "$sources_file" ]]; then
+		jq -r '.[] | "  - \(.id) (\(.role), attached \(.attached_at))"' "$sources_file" 2>/dev/null || echo "$_none"
+	else
+		echo "$_none"
+	fi
+
+	echo ""
+	echo "### Timeline"
+	local timeline_file="${case_dir}/${CASE_TIMELINE_FILE}"
+	if [[ -f "$timeline_file" ]]; then
+		while IFS= read -r line; do
+			[[ -z "$line" ]] && continue
+			local ts kind content
+			ts="$(echo "$line" | jq -r '.ts')"
+			kind="$(echo "$line" | jq -r '.kind')"
+			content="$(echo "$line" | jq -r '.content')"
+			printf '  [%s] %s: %s\n' "$ts" "$kind" "$content"
+		done <"$timeline_file"
+	else
+		echo "  (empty)"
+	fi
+	echo ""
+	return 0
+}
+
+# =============================================================================
+# cmd_note — append a note to the case
+# =============================================================================
+
+cmd_note() {
+	_require_jq || return 1
+
+	local case_id='' message='' repo_path='' json_mode=false unarchive=false
+
+	while [[ $# -gt 0 ]]; do
+		local _cur="${1:-}" _nxt="${2:-}"
+		case "$_cur" in
+		--message | -m) message="$_nxt"; shift 2 ;;
+		--repo) repo_path="$_nxt"; shift 2 ;;
+		--json) json_mode=true; shift ;;
+		--unarchive) unarchive=true; shift ;;
+		-*) _err_opt_unknown "$_cur"; return 1 ;;
+		*) case_id="$_cur"; shift ;;
+		esac
+	done
+
+	[[ -z "$case_id" ]] && { print_error "Usage: case note <case-id> --message \"...\""; return 1; }
+	[[ -z "$message" ]] && { print_error "Note message required. Use --message \"...\""; return 1; }
+	[[ -z "$repo_path" ]] && repo_path="$(pwd)"
+
+	local cases_dir
+	cases_dir="$(_resolve_cases_dir "$repo_path")"
+	local case_dir
+	case_dir="$(_case_find "$cases_dir" "$case_id")" || {
+		_err_case_missing "$case_id"
+		return 1
+	}
+
+	if _is_archived "$case_dir" && [[ "$unarchive" != true ]]; then
+		_err_case_archived
+		return 1
+	fi
+
+	local actor ts
+	actor="$(_current_actor)"
+	ts="$(_iso_ts_full)"
+
+	# Append to notes/notes.md
+	local notes_file="${case_dir}/${CASE_NOTES_DIR}/${CASE_NOTES_FILE}"
+	mkdir -p "${case_dir}/${CASE_NOTES_DIR}"
+	[[ ! -f "$notes_file" ]] && printf '# Notes: %s\n\n' "$case_id" >"$notes_file"
+	printf '\n---\n**%s** (%s)\n\n%s\n' "$actor" "$ts" "$message" >>"$notes_file"
+
+	local ref="${CASE_NOTES_DIR}/${CASE_NOTES_FILE}"
+	_timeline_append "$case_dir" "note" "$actor" "$message" "$ref"
+
+	if [[ "$json_mode" == true ]]; then
+		jq -n --arg ts "$ts" --arg actor "$actor" --arg msg "$message" --arg ref "$ref" \
+			'{kind:"note", ts:$ts, actor:$actor, content:$msg, ref:$ref}'
+	else
+		print_success "Note appended to: ${case_id}"
+	fi
+	return 0
+}
+
+# =============================================================================
+# cmd_deadline — add or remove a deadline from a case
+# =============================================================================
+
+cmd_deadline() {
+	_require_jq || return 1
+
+	local action="${1:-add}"
+	shift || true
+
+	case "$action" in
+	add) _cmd_deadline_add "$@" ;;
+	remove | rm) _cmd_deadline_remove "$@" ;;
+	*) print_error "Usage: case deadline add|remove <case-id> [--date ISO] [--label \"...\"]"; return 1 ;;
+	esac
+	return 0
+}
+
+_cmd_deadline_add() {
+	local case_id='' date_val='' label='' repo_path='' json_mode=false unarchive=false
+
+	while [[ $# -gt 0 ]]; do
+		local _cur="${1:-}" _nxt="${2:-}"
+		case "$_cur" in
+		--date) date_val="$_nxt"; shift 2 ;;
+		--label) label="$_nxt"; shift 2 ;;
+		--repo) repo_path="$_nxt"; shift 2 ;;
+		--json) json_mode=true; shift ;;
+		--unarchive) unarchive=true; shift ;;
+		-*) _err_opt_unknown "$_cur"; return 1 ;;
+		*) case_id="$_cur"; shift ;;
+		esac
+	done
+
+	[[ -z "$case_id" ]] && { print_error "Usage: case deadline add <case-id> --date ISO --label \"...\""; return 1; }
+	[[ -z "$date_val" ]] && { print_error "--date is required"; return 1; }
+	[[ -z "$repo_path" ]] && repo_path="$(pwd)"
+
+	local cases_dir
+	cases_dir="$(_resolve_cases_dir "$repo_path")"
+	local case_dir
+	case_dir="$(_case_find "$cases_dir" "$case_id")" || { _err_case_missing "$case_id"; return 1; }
+
+	if _is_archived "$case_dir" && [[ "$unarchive" != true ]]; then
+		_err_case_archived
+		return 1
+	fi
+
+	local actor dl_label
+	actor="$(_current_actor)"
+	dl_label="${label:-deadline}"
+
+	local dossier
+	dossier="$(_dossier_load "$case_dir")"
+	local entry
+	entry="$(jq -n --arg d "$date_val" --arg l "$dl_label" '{label:$l, date:$d}')"
+	local updated
+	updated="$(echo "$dossier" | jq --argjson e "$entry" '.deadlines += [$e]')"
+	echo "$updated" | _dossier_save "$case_dir"
+
+	_timeline_append "$case_dir" "deadline" "$actor" \
+		"Deadline added: ${dl_label} on ${date_val}" ""
+
+	if [[ "$json_mode" == true ]]; then
+		echo "$entry"
+	else
+		print_success "Deadline added: ${dl_label} (${date_val}) to ${case_id}"
+	fi
+	return 0
+}
+
+_cmd_deadline_remove() {
+	local case_id='' label='' repo_path='' json_mode=false unarchive=false
+
+	while [[ $# -gt 0 ]]; do
+		local _cur="${1:-}" _nxt="${2:-}"
+		case "$_cur" in
+		--label) label="$_nxt"; shift 2 ;;
+		--repo) repo_path="$_nxt"; shift 2 ;;
+		--json) json_mode=true; shift ;;
+		--unarchive) unarchive=true; shift ;;
+		-*) _err_opt_unknown "$_cur"; return 1 ;;
+		*) case_id="$_cur"; shift ;;
+		esac
+	done
+
+	[[ -z "$case_id" || -z "$label" ]] && {
+		print_error "Usage: case deadline remove <case-id> --label \"deadline label\""
+		return 1
+	}
+	[[ -z "$repo_path" ]] && repo_path="$(pwd)"
+
+	local cases_dir
+	cases_dir="$(_resolve_cases_dir "$repo_path")"
+	local case_dir
+	case_dir="$(_case_find "$cases_dir" "$case_id")" || { _err_case_missing "$case_id"; return 1; }
+
+	if _is_archived "$case_dir" && [[ "$unarchive" != true ]]; then
+		_err_case_archived
+		return 1
+	fi
+
+	local actor
+	actor="$(_current_actor)"
+	local dossier
+	dossier="$(_dossier_load "$case_dir")"
+	local updated
+	updated="$(echo "$dossier" | jq --arg l "$label" '.deadlines = [.deadlines[] | select(.label != $l)]')"
+	echo "$updated" | _dossier_save "$case_dir"
+
+	_timeline_append "$case_dir" "deadline" "$actor" "Deadline removed: ${label}" ""
+
+	if [[ "$json_mode" == true ]]; then
+		echo "$updated"
+	else
+		print_success "Deadline removed: ${label} from ${case_id}"
+	fi
+	return 0
+}
+
+# =============================================================================
+# cmd_party — add or remove a party from a case
+# =============================================================================
+
+cmd_party() {
+	_require_jq || return 1
+
+	local action="${1:-add}"
+	shift || true
+
+	case "$action" in
+	add) _cmd_party_add "$@" ;;
+	remove | rm) _cmd_party_remove "$@" ;;
+	*) print_error "Usage: case party add|remove <case-id> --name \"...\" --role \"...\""; return 1 ;;
+	esac
+	return 0
+}
+
+_cmd_party_add() {
+	local case_id='' name='' role='' repo_path='' json_mode=false unarchive=false
+
+	while [[ $# -gt 0 ]]; do
+		local _cur="${1:-}" _nxt="${2:-}"
+		case "$_cur" in
+		--name) name="$_nxt"; shift 2 ;;
+		--role) role="$_nxt"; shift 2 ;;
+		--repo) repo_path="$_nxt"; shift 2 ;;
+		--json) json_mode=true; shift ;;
+		--unarchive) unarchive=true; shift ;;
+		-*) _err_opt_unknown "$_cur"; return 1 ;;
+		*) case_id="$_cur"; shift ;;
+		esac
+	done
+
+	[[ -z "$case_id" || -z "$name" || -z "$role" ]] && {
+		print_error "Usage: case party add <case-id> --name \"name\" --role \"role\""
+		return 1
+	}
+	[[ -z "$repo_path" ]] && repo_path="$(pwd)"
+
+	local cases_dir
+	cases_dir="$(_resolve_cases_dir "$repo_path")"
+	local case_dir
+	case_dir="$(_case_find "$cases_dir" "$case_id")" || { _err_case_missing "$case_id"; return 1; }
+
+	if _is_archived "$case_dir" && [[ "$unarchive" != true ]]; then
+		_err_case_archived
+		return 1
+	fi
+
+	local actor
+	actor="$(_current_actor)"
+	local entry
+	entry="$(jq -n --arg n "$name" --arg r "$role" '{name:$n, role:$r}')"
+	local dossier
+	dossier="$(_dossier_load "$case_dir")"
+	local updated
+	updated="$(echo "$dossier" | jq --argjson e "$entry" '.parties += [$e]')"
+	echo "$updated" | _dossier_save "$case_dir"
+
+	_timeline_append "$case_dir" "party" "$actor" "Party added: ${name} (${role})" ""
+
+	if [[ "$json_mode" == true ]]; then
+		echo "$entry"
+	else
+		print_success "Party added: ${name} (${role}) to ${case_id}"
+	fi
+	return 0
+}
+
+_cmd_party_remove() {
+	local case_id='' name='' repo_path='' json_mode=false unarchive=false
+
+	while [[ $# -gt 0 ]]; do
+		local _cur="${1:-}" _nxt="${2:-}"
+		case "$_cur" in
+		--name) name="$_nxt"; shift 2 ;;
+		--repo) repo_path="$_nxt"; shift 2 ;;
+		--json) json_mode=true; shift ;;
+		--unarchive) unarchive=true; shift ;;
+		-*) _err_opt_unknown "$_cur"; return 1 ;;
+		*) case_id="$_cur"; shift ;;
+		esac
+	done
+
+	[[ -z "$case_id" || -z "$name" ]] && {
+		print_error "Usage: case party remove <case-id> --name \"name\""
+		return 1
+	}
+	[[ -z "$repo_path" ]] && repo_path="$(pwd)"
+
+	local cases_dir
+	cases_dir="$(_resolve_cases_dir "$repo_path")"
+	local case_dir
+	case_dir="$(_case_find "$cases_dir" "$case_id")" || { _err_case_missing "$case_id"; return 1; }
+
+	if _is_archived "$case_dir" && [[ "$unarchive" != true ]]; then
+		_err_case_archived
+		return 1
+	fi
+
+	local actor
+	actor="$(_current_actor)"
+	local dossier
+	dossier="$(_dossier_load "$case_dir")"
+	local updated
+	updated="$(echo "$dossier" | jq --arg n "$name" '.parties = [.parties[] | select(.name != $n)]')"
+	echo "$updated" | _dossier_save "$case_dir"
+
+	_timeline_append "$case_dir" "party" "$actor" "Party removed: ${name}" ""
+
+	if [[ "$json_mode" == true ]]; then
+		echo "$updated"
+	else
+		print_success "Party removed: ${name} from ${case_id}"
+	fi
+	return 0
+}
+
+# =============================================================================
+# cmd_comm — log a communication entry
+# =============================================================================
+
+cmd_comm() {
+	_require_jq || return 1
+
+	local action="${1:-log}"
+	shift || true
+
+	case "$action" in
+	log) _cmd_comm_log "$@" ;;
+	*) print_error "Usage: case comm log <case-id> --direction in|out --channel <c> --summary \"...\""; return 1 ;;
+	esac
+	return 0
+}
+
+_cmd_comm_log() {
+	local case_id='' direction='' channel='' summary='' repo_path='' json_mode=false unarchive=false
+
+	while [[ $# -gt 0 ]]; do
+		local _cur="${1:-}" _nxt="${2:-}"
+		case "$_cur" in
+		--direction) direction="$_nxt"; shift 2 ;;
+		--channel) channel="$_nxt"; shift 2 ;;
+		--summary) summary="$_nxt"; shift 2 ;;
+		--repo) repo_path="$_nxt"; shift 2 ;;
+		--json) json_mode=true; shift ;;
+		--unarchive) unarchive=true; shift ;;
+		-*) _err_opt_unknown "$_cur"; return 1 ;;
+		*) case_id="$_cur"; shift ;;
+		esac
+	done
+
+	[[ -z "$case_id" || -z "$direction" || -z "$channel" || -z "$summary" ]] && {
+		print_error "Usage: case comm log <case-id> --direction in|out --channel <c> --summary \"...\""
+		return 1
+	}
+	case "$direction" in
+	in | out) ;;
+	*) print_error "Invalid direction: ${direction}. Must be in|out"; return 1 ;;
+	esac
+	[[ -z "$repo_path" ]] && repo_path="$(pwd)"
+
+	local cases_dir
+	cases_dir="$(_resolve_cases_dir "$repo_path")"
+	local case_dir
+	case_dir="$(_case_find "$cases_dir" "$case_id")" || {
+		_err_case_missing "$case_id"
+		return 1
+	}
+
+	if _is_archived "$case_dir" && [[ "$unarchive" != true ]]; then
+		_err_case_archived
+		return 1
+	fi
+
+	local actor ts
+	actor="$(_current_actor)"
+	ts="$(_iso_ts_full)"
+
+	mkdir -p "${case_dir}/${CASE_COMMS_DIR}"
+	local comm_file="${case_dir}/${CASE_COMMS_DIR}/comms.log"
+	printf '\n---\n[%s] %s via %s (%s)\n\n%s\n' \
+		"$ts" "$direction" "$channel" "$actor" "$summary" >>"$comm_file"
+
+	local ref="${CASE_COMMS_DIR}/comms.log"
+	local content="Comm logged: ${direction} via ${channel} — ${summary}"
+	_timeline_append "$case_dir" "comm" "$actor" "$content" "$ref"
+
+	if [[ "$json_mode" == true ]]; then
+		jq -n --arg ts "$ts" --arg dir "$direction" --arg ch "$channel" \
+			--arg actor "$actor" --arg summary "$summary" --arg ref "$ref" \
+			'{kind:"comm", ts:$ts, direction:$dir, channel:$ch, actor:$actor, summary:$summary, ref:$ref}'
+	else
+		print_success "Communication logged on: ${case_id}"
+	fi
+	return 0
+}
+
+# =============================================================================
+# cmd_help
+# =============================================================================
+
+cmd_help() {
+	cat <<'HELP'
+Case Helper — manage case dossiers with timeline audit trail
+
+Usage: case-helper.sh <command> [args] [options]
+
+Commands:
+  init [<repo-path>]                    Provision _cases/ plane for a repo
+  open <slug> [options]                 Open a new case
+  attach <case-id> <source-id>          Attach a knowledge source
+  status <case-id> <open|hold>          Update case status
+  close <case-id> --outcome <x>         Close a case with required outcome
+  archive <case-id>                     Move to _cases/archived/
+  list [options]                        List cases (default: open)
+  show <case-id>                        Show dossier + timeline + sources
+  note <case-id> --message "..."        Append internal note
+  deadline add|remove <case-id>         Manage deadlines
+  party add|remove <case-id>            Manage parties
+  comm log <case-id>                    Log a communication entry
+  help                                  Show this help
+
+Open options:
+  --kind <type>           Case type (dispute, contract, compliance, ...)
+  --party <name>          Initial party name
+  --party-role <role>     Initial party role (default: client)
+  --deadline <ISO-date>   Initial deadline date
+  --deadline-label <txt>  Deadline label
+
+List options:
+  --status <open|hold|closed|archived|all>  Filter by status (default: open)
+  --kind <type>                              Filter by kind
+  --party <name>                             Filter by party name (regex)
+  --json                                     Machine-readable JSON output
+
+Attach options:
+  --role <evidence|reference|background>   Source role (default: reference)
+
+All mutating commands support:
+  --json          Output result as JSON
+  --unarchive     Allow operating on archived cases
+  --repo <path>   Target repo path (default: current directory)
+
+Examples:
+  case-helper.sh init
+  case-helper.sh open acme-dispute --kind dispute --party "ACME Ltd" --deadline 2026-08-31
+  case-helper.sh list
+  case-helper.sh list --status all --json
+  case-helper.sh show case-2026-0001-acme-dispute
+  case-helper.sh attach case-2026-0001-acme-dispute src-001 --role evidence
+  case-helper.sh status case-2026-0001-acme-dispute hold --reason "awaiting client"
+  case-helper.sh close case-2026-0001-acme-dispute --outcome settled --summary "Agreed in mediation"
+  case-helper.sh note case-2026-0001-acme-dispute --message "Reviewed contract terms"
+  case-helper.sh deadline add case-2026-0001-acme-dispute --date 2026-08-31 --label "filing deadline"
+  case-helper.sh party add case-2026-0001-acme-dispute --name "Opposing Counsel" --role "opponent"
+  case-helper.sh comm log case-2026-0001-acme-dispute --direction in --channel email --summary "Received settlement offer"
+  case-helper.sh archive case-2026-0001-acme-dispute
+HELP
+	return 0
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+
+main() {
+	local command="${1:-help}"
+	shift || true
+
+	case "$command" in
+	init) cmd_init "$@" ;;
+	open | new) cmd_open "$@" ;;
+	attach) cmd_attach "$@" ;;
+	status) cmd_status "$@" ;;
+	close) cmd_close "$@" ;;
+	archive) cmd_archive "$@" ;;
+	list | ls) cmd_list "$@" ;;
+	show | view) cmd_show "$@" ;;
+	note) cmd_note "$@" ;;
+	deadline | dl) cmd_deadline "$@" ;;
+	party) cmd_party "$@" ;;
+	comm | comms) cmd_comm "$@" ;;
+	help | --help | -h) cmd_help ;;
+	*)
+		print_error "Unknown command: ${command}"
+		cmd_help
+		return 1
+		;;
+	esac
+}
+
+main "$@"

--- a/.agents/templates/case-dossier-schema.json
+++ b/.agents/templates/case-dossier-schema.json
@@ -1,0 +1,79 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "case-dossier-schema.json",
+  "title": "Case Dossier",
+  "description": "Schema for dossier.toon — the metadata file for an aidevops case",
+  "type": "object",
+  "required": ["id", "slug", "kind", "opened_at", "status", "parties"],
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "Unique case ID in format case-YYYY-NNNN-slug",
+      "pattern": "^case-[0-9]{4}-[0-9]{4}-.+$"
+    },
+    "slug": {
+      "type": "string",
+      "description": "Human-readable slug (kebab-case)"
+    },
+    "kind": {
+      "type": "string",
+      "description": "Case type — e.g. dispute, contract, compliance, inquiry, support"
+    },
+    "opened_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "ISO 8601 timestamp when the case was opened"
+    },
+    "status": {
+      "type": "string",
+      "enum": ["open", "hold", "closed"],
+      "description": "Current lifecycle status"
+    },
+    "outcome": {
+      "type": "string",
+      "description": "Outcome when status=closed — e.g. settled, withdrawn, resolved, dismissed"
+    },
+    "outcome_summary": {
+      "type": "string",
+      "description": "Free-text summary of the outcome"
+    },
+    "parties": {
+      "type": "array",
+      "description": "Named parties involved in the case",
+      "items": {
+        "type": "object",
+        "required": ["name", "role"],
+        "additionalProperties": false,
+        "properties": {
+          "name": { "type": "string" },
+          "role": { "type": "string" }
+        }
+      },
+      "minItems": 1
+    },
+    "deadlines": {
+      "type": "array",
+      "description": "Key dates and deadlines",
+      "items": {
+        "type": "object",
+        "required": ["label", "date"],
+        "additionalProperties": false,
+        "properties": {
+          "label": { "type": "string" },
+          "date": { "type": "string", "format": "date" }
+        }
+      }
+    },
+    "related_cases": {
+      "type": "array",
+      "description": "IDs of related cases in the same repo",
+      "items": { "type": "string" }
+    },
+    "related_repos": {
+      "type": "array",
+      "description": "Slugs of related repos (owner/repo format)",
+      "items": { "type": "string" }
+    }
+  }
+}

--- a/.agents/templates/cases-gitignore.txt
+++ b/.agents/templates/cases-gitignore.txt
@@ -1,0 +1,10 @@
+# _cases/ gitignore template
+# Drafts and work-in-progress are excluded by default.
+# Committed: dossier.toon, timeline.jsonl, sources.toon, notes/, comms/
+# Excluded:  drafts/ (work-in-progress, not for audit trail)
+
+# Exclude drafts sub-directory
+drafts/
+
+# Exclude macOS metadata
+.DS_Store

--- a/.agents/tests/test-case-cli.sh
+++ b/.agents/tests/test-case-cli.sh
@@ -1,0 +1,613 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# shellcheck disable=SC2034
+#
+# Tests for case-helper.sh (t2852)
+# Covers each subcommand happy path + failure paths
+#
+# Usage: bash .agents/tests/test-case-cli.sh
+# Requires: jq
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+CASE_HELPER="${SCRIPT_DIR}/../scripts/case-helper.sh"
+
+# =============================================================================
+# Test framework
+# =============================================================================
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+TEST_TMPDIR=""
+
+_setup() {
+	TEST_TMPDIR="$(mktemp -d)"
+	# Initialize a minimal git repo for git mv support
+	git -C "$TEST_TMPDIR" init -q
+	git -C "$TEST_TMPDIR" config user.email "test@test.local"
+	git -C "$TEST_TMPDIR" config user.name "Test User"
+	return 0
+}
+
+_teardown() {
+	[[ -n "$TEST_TMPDIR" && -d "$TEST_TMPDIR" ]] && rm -rf "$TEST_TMPDIR"
+	return 0
+}
+
+_pass() {
+	local name="$1"
+	TESTS_PASSED=$((TESTS_PASSED + 1))
+	printf '  [PASS] %s\n' "$name"
+	return 0
+}
+
+_fail() {
+	local name="$1" reason="${2:-}"
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '  [FAIL] %s%s\n' "$name" "${reason:+ — $reason}"
+	return 0
+}
+
+_assert_exit_0() {
+	local name="$1"
+	shift
+	if "$@" >/dev/null 2>&1; then
+		_pass "$name"
+		return 0
+	else
+		_fail "$name" "expected exit 0, got non-zero"
+		return 0
+	fi
+}
+
+_assert_exit_nonzero() {
+	local name="$1"
+	shift
+	if ! "$@" >/dev/null 2>&1; then
+		_pass "$name"
+		return 0
+	else
+		_fail "$name" "expected non-zero exit, got 0"
+		return 0
+	fi
+}
+
+_assert_file_exists() {
+	local name="$1" path="$2"
+	if [[ -f "$path" ]]; then
+		_pass "$name"
+		return 0
+	else
+		_fail "$name" "file not found: ${path}"
+		return 0
+	fi
+}
+
+_assert_dir_exists() {
+	local name="$1" path="$2"
+	if [[ -d "$path" ]]; then
+		_pass "$name"
+		return 0
+	else
+		_fail "$name" "dir not found: ${path}"
+		return 0
+	fi
+}
+
+_assert_json_field() {
+	local name="$1" file="$2" query="$3" expected="$4"
+	local actual
+	actual="$(jq -r "$query" "$file" 2>/dev/null)" || actual=""
+	if [[ "$actual" == "$expected" ]]; then
+		_pass "$name"
+		return 0
+	else
+		_fail "$name" "expected '${expected}', got '${actual}'"
+		return 0
+	fi
+}
+
+_assert_contains() {
+	local name="$1" file="$2" pattern="$3"
+	if grep -q "$pattern" "$file" 2>/dev/null; then
+		_pass "$name"
+		return 0
+	else
+		_fail "$name" "pattern '${pattern}' not found in ${file}"
+		return 0
+	fi
+}
+
+# =============================================================================
+# Tests
+# =============================================================================
+
+test_init() {
+	echo ""
+	echo "=== init ==="
+	local repo="$TEST_TMPDIR"
+
+	_assert_exit_0 "init provisions _cases/" \
+		bash "$CASE_HELPER" init "$repo"
+	_assert_dir_exists "init creates _cases/" "${repo}/_cases"
+	_assert_dir_exists "init creates archived/" "${repo}/_cases/archived"
+	_assert_file_exists "init creates .gitignore" "${repo}/_cases/.gitignore"
+	_assert_file_exists "init creates .case-counter" "${repo}/_cases/.case-counter"
+	_assert_file_exists "init creates README.md" "${repo}/_cases/README.md"
+
+	# Idempotent: running again is safe
+	_assert_exit_0 "init is idempotent" \
+		bash "$CASE_HELPER" init "$repo"
+	return 0
+}
+
+test_open_happy() {
+	echo ""
+	echo "=== open (happy path) ==="
+	local repo="$TEST_TMPDIR"
+
+	bash "$CASE_HELPER" init "$repo" >/dev/null 2>&1
+
+	# Open with all flags
+	_assert_exit_0 "open with all flags" \
+		bash "$CASE_HELPER" open acme-dispute \
+		--kind dispute \
+		--party "ACME Ltd" \
+		--party-role "client" \
+		--deadline "2026-08-31" \
+		--deadline-label "filing deadline" \
+		--repo "$repo"
+
+	local case_dir="${repo}/_cases/case-2026-0001-acme-dispute"
+	_assert_dir_exists "open creates case directory" "$case_dir"
+	_assert_file_exists "open creates dossier.toon" "${case_dir}/dossier.toon"
+	_assert_file_exists "open creates timeline.jsonl" "${case_dir}/timeline.jsonl"
+	_assert_file_exists "open creates sources.toon" "${case_dir}/sources.toon"
+	_assert_dir_exists "open creates notes/" "${case_dir}/notes"
+	_assert_dir_exists "open creates comms/" "${case_dir}/comms"
+	_assert_dir_exists "open creates drafts/" "${case_dir}/drafts"
+
+	_assert_json_field "dossier has correct id" \
+		"${case_dir}/dossier.toon" '.id' "case-2026-0001-acme-dispute"
+	_assert_json_field "dossier has correct slug" \
+		"${case_dir}/dossier.toon" '.slug' "acme-dispute"
+	_assert_json_field "dossier has correct kind" \
+		"${case_dir}/dossier.toon" '.kind' "dispute"
+	_assert_json_field "dossier status is open" \
+		"${case_dir}/dossier.toon" '.status' "open"
+	_assert_json_field "dossier has party" \
+		"${case_dir}/dossier.toon" '.parties[0].name' "ACME Ltd"
+	_assert_json_field "dossier has deadline" \
+		"${case_dir}/dossier.toon" '.deadlines[0].date' "2026-08-31"
+
+	# sources.toon initialised as empty array
+	_assert_json_field "sources.toon is empty array" \
+		"${case_dir}/sources.toon" 'length' "0"
+
+	# timeline has open event
+	_assert_contains "timeline has open event" \
+		"${case_dir}/timeline.jsonl" '"kind":"open"'
+	return 0
+}
+
+test_open_sequential_ids() {
+	echo ""
+	echo "=== open (sequential IDs) ==="
+	local repo="$TEST_TMPDIR"
+
+	bash "$CASE_HELPER" open second-case --kind contract --repo "$repo" >/dev/null 2>&1
+
+	local case2_dir="${repo}/_cases/case-2026-0002-second-case"
+	_assert_dir_exists "second case gets 0002" "$case2_dir"
+	return 0
+}
+
+test_open_json_mode() {
+	echo ""
+	echo "=== open (--json) ==="
+	local repo="$TEST_TMPDIR"
+
+	local output
+	output="$(bash "$CASE_HELPER" open json-test-case --kind inquiry --repo "$repo" --json 2>/dev/null)"
+	local valid
+	valid="$(echo "$output" | jq '.id' 2>/dev/null)" || valid=""
+	if [[ -n "$valid" ]]; then
+		_pass "open --json returns valid JSON with id field"
+	else
+		_fail "open --json returns valid JSON with id field" "got: ${output}"
+	fi
+	return 0
+}
+
+test_list() {
+	echo ""
+	echo "=== list ==="
+	local repo="$TEST_TMPDIR"
+
+	_assert_exit_0 "list works with open cases" \
+		bash "$CASE_HELPER" list --repo "$repo"
+
+	local json_out
+	json_out="$(bash "$CASE_HELPER" list --json --repo "$repo" --status open 2>/dev/null)"
+	local count
+	count="$(echo "$json_out" | jq 'length' 2>/dev/null)" || count="0"
+	if [[ "$count" -ge 1 ]]; then
+		_pass "list --json returns array with open cases"
+	else
+		_fail "list --json returns array with open cases" "got count=${count}"
+	fi
+
+	# list with no matches
+	_assert_exit_0 "list with no matches exits 0" \
+		bash "$CASE_HELPER" list --status closed --repo "$repo"
+	return 0
+}
+
+test_list_filter_party() {
+	echo ""
+	echo "=== list --party filter ==="
+	local repo="$TEST_TMPDIR"
+
+	local json_out
+	json_out="$(bash "$CASE_HELPER" list --party "ACME" --json --repo "$repo" 2>/dev/null)"
+	local count
+	count="$(echo "$json_out" | jq 'length' 2>/dev/null)" || count="0"
+	if [[ "$count" -ge 1 ]]; then
+		_pass "list --party filters to matching cases"
+	else
+		_fail "list --party filters to matching cases" "got count=${count}"
+	fi
+
+	# Non-matching party
+	json_out="$(bash "$CASE_HELPER" list --party "NoSuchParty999" --json --repo "$repo" 2>/dev/null)"
+	count="$(echo "$json_out" | jq 'length' 2>/dev/null)" || count="0"
+	if [[ "$count" -eq 0 ]]; then
+		_pass "list --party returns empty for no-match"
+	else
+		_fail "list --party returns empty for no-match" "got count=${count}"
+	fi
+	return 0
+}
+
+test_show() {
+	echo ""
+	echo "=== show ==="
+	local repo="$TEST_TMPDIR"
+	local case_id="case-2026-0001-acme-dispute"
+
+	_assert_exit_0 "show exits 0 for valid case" \
+		bash "$CASE_HELPER" show "$case_id" --repo "$repo"
+
+	local json_out
+	json_out="$(bash "$CASE_HELPER" show "$case_id" --json --repo "$repo" 2>/dev/null)"
+	local has_dossier
+	has_dossier="$(echo "$json_out" | jq '.dossier.id' 2>/dev/null)" || has_dossier=""
+	if [[ -n "$has_dossier" ]]; then
+		_pass "show --json includes dossier"
+	else
+		_fail "show --json includes dossier"
+	fi
+
+	# Failure: non-existent case
+	_assert_exit_nonzero "show exits non-zero for missing case" \
+		bash "$CASE_HELPER" show no-such-case-id-xyz --repo "$repo"
+	return 0
+}
+
+test_status() {
+	echo ""
+	echo "=== status ==="
+	local repo="$TEST_TMPDIR"
+	local case_id="case-2026-0001-acme-dispute"
+	local case_dir="${repo}/_cases/${case_id}"
+
+	_assert_exit_0 "status hold succeeds" \
+		bash "$CASE_HELPER" status "$case_id" hold \
+		--reason "awaiting client response" --repo "$repo"
+	_assert_json_field "dossier status updated to hold" \
+		"${case_dir}/dossier.toon" '.status' "hold"
+	_assert_contains "timeline has status_change event" \
+		"${case_dir}/timeline.jsonl" '"kind":"status_change"'
+
+	# status back to open
+	_assert_exit_0 "status open succeeds" \
+		bash "$CASE_HELPER" status "$case_id" open --repo "$repo"
+	_assert_json_field "dossier status updated to open" \
+		"${case_dir}/dossier.toon" '.status' "open"
+
+	# Failure: trying to set status=closed via status command
+	_assert_exit_nonzero "status closed is rejected (use close instead)" \
+		bash "$CASE_HELPER" status "$case_id" closed --repo "$repo"
+	return 0
+}
+
+test_close() {
+	echo ""
+	echo "=== close ==="
+	local repo="$TEST_TMPDIR"
+	# Use the second case for close test (leave acme open for other tests)
+	local case_id="case-2026-0002-second-case"
+	local case_dir="${repo}/_cases/${case_id}"
+
+	# Failure: close without --outcome
+	_assert_exit_nonzero "close without --outcome fails" \
+		bash "$CASE_HELPER" close "$case_id" --repo "$repo"
+
+	# Happy: close with outcome
+	_assert_exit_0 "close with --outcome succeeds" \
+		bash "$CASE_HELPER" close "$case_id" --outcome "settled" \
+		--summary "Agreed in mediation" --repo "$repo"
+	_assert_json_field "dossier status is closed" \
+		"${case_dir}/dossier.toon" '.status' "closed"
+	_assert_json_field "dossier outcome is set" \
+		"${case_dir}/dossier.toon" '.outcome' "settled"
+	return 0
+}
+
+test_attach() {
+	echo ""
+	echo "=== attach ==="
+	local repo="$TEST_TMPDIR"
+	local case_id="case-2026-0001-acme-dispute"
+	local case_dir="${repo}/_cases/${case_id}"
+
+	# Create a fake knowledge source directory
+	mkdir -p "${repo}/_knowledge/sources/src-001"
+
+	_assert_exit_0 "attach valid source" \
+		bash "$CASE_HELPER" attach "$case_id" "src-001" \
+		--role "evidence" --repo "$repo"
+	_assert_json_field "sources.toon has 1 entry" \
+		"${case_dir}/sources.toon" 'length' "1"
+	_assert_json_field "sources.toon has correct id" \
+		"${case_dir}/sources.toon" '.[0].id' "src-001"
+	_assert_json_field "sources.toon has correct role" \
+		"${case_dir}/sources.toon" '.[0].role' "evidence"
+	_assert_contains "timeline has attach event" \
+		"${case_dir}/timeline.jsonl" '"kind":"attach"'
+
+	# Failure: attach non-existent source
+	_assert_exit_nonzero "attach non-existent source fails" \
+		bash "$CASE_HELPER" attach "$case_id" "src-nonexistent-xyz" --repo "$repo"
+
+	# Failure: attach already-attached source
+	_assert_exit_nonzero "attach duplicate source fails" \
+		bash "$CASE_HELPER" attach "$case_id" "src-001" --repo "$repo"
+	return 0
+}
+
+test_note() {
+	echo ""
+	echo "=== note ==="
+	local repo="$TEST_TMPDIR"
+	local case_id="case-2026-0001-acme-dispute"
+	local case_dir="${repo}/_cases/${case_id}"
+	local notes_file="${case_dir}/notes/notes.md"
+
+	_assert_exit_0 "note appends to notes.md" \
+		bash "$CASE_HELPER" note "$case_id" \
+		--message "Reviewed contract terms carefully" --repo "$repo"
+	_assert_file_exists "notes.md exists" "$notes_file"
+	_assert_contains "notes.md has content" "$notes_file" "Reviewed contract terms"
+	_assert_contains "timeline has note event" \
+		"${case_dir}/timeline.jsonl" '"kind":"note"'
+
+	# Failure: note without --message
+	_assert_exit_nonzero "note without --message fails" \
+		bash "$CASE_HELPER" note "$case_id" --repo "$repo"
+	return 0
+}
+
+test_deadline() {
+	echo ""
+	echo "=== deadline ==="
+	local repo="$TEST_TMPDIR"
+	local case_id="case-2026-0001-acme-dispute"
+	local case_dir="${repo}/_cases/${case_id}"
+
+	_assert_exit_0 "deadline add succeeds" \
+		bash "$CASE_HELPER" deadline add "$case_id" \
+		--date "2026-10-01" --label "response deadline" --repo "$repo"
+
+	# dossier should have 2 deadlines now (1 from open + 1 added)
+	local count
+	count="$(jq '.deadlines | length' "${case_dir}/dossier.toon" 2>/dev/null)" || count="0"
+	if [[ "$count" -ge 2 ]]; then
+		_pass "deadline add adds to dossier"
+	else
+		_fail "deadline add adds to dossier" "count=${count}"
+	fi
+
+	_assert_exit_0 "deadline remove succeeds" \
+		bash "$CASE_HELPER" deadline remove "$case_id" \
+		--label "response deadline" --repo "$repo"
+
+	count="$(jq '.deadlines | length' "${case_dir}/dossier.toon" 2>/dev/null)" || count="0"
+	if [[ "$count" -lt 2 ]]; then
+		_pass "deadline remove removes from dossier"
+	else
+		_fail "deadline remove removes from dossier" "count=${count}"
+	fi
+	return 0
+}
+
+test_party() {
+	echo ""
+	echo "=== party ==="
+	local repo="$TEST_TMPDIR"
+	local case_id="case-2026-0001-acme-dispute"
+	local case_dir="${repo}/_cases/${case_id}"
+
+	_assert_exit_0 "party add succeeds" \
+		bash "$CASE_HELPER" party add "$case_id" \
+		--name "Opposing Counsel" --role "opponent" --repo "$repo"
+
+	_assert_json_field "party added to dossier" \
+		"${case_dir}/dossier.toon" \
+		'.parties[] | select(.name == "Opposing Counsel") | .role' \
+		"opponent"
+	_assert_contains "timeline has party event" \
+		"${case_dir}/timeline.jsonl" '"kind":"party"'
+
+	_assert_exit_0 "party remove succeeds" \
+		bash "$CASE_HELPER" party remove "$case_id" \
+		--name "Opposing Counsel" --repo "$repo"
+
+	local still_there
+	still_there="$(jq -r '.parties[] | select(.name == "Opposing Counsel") | .name' \
+		"${case_dir}/dossier.toon" 2>/dev/null)" || still_there=""
+	if [[ -z "$still_there" ]]; then
+		_pass "party removed from dossier"
+	else
+		_fail "party removed from dossier" "still present"
+	fi
+	return 0
+}
+
+test_comm() {
+	echo ""
+	echo "=== comm ==="
+	local repo="$TEST_TMPDIR"
+	local case_id="case-2026-0001-acme-dispute"
+	local case_dir="${repo}/_cases/${case_id}"
+
+	_assert_exit_0 "comm log succeeds" \
+		bash "$CASE_HELPER" comm log "$case_id" \
+		--direction in --channel email \
+		--summary "Received settlement offer from ACME" --repo "$repo"
+
+	_assert_file_exists "comms.log exists" "${case_dir}/comms/comms.log"
+	_assert_contains "comms.log has content" \
+		"${case_dir}/comms/comms.log" "Received settlement offer"
+	_assert_contains "timeline has comm event" \
+		"${case_dir}/timeline.jsonl" '"kind":"comm"'
+
+	# Failure: comm log without required fields
+	_assert_exit_nonzero "comm log without --direction fails" \
+		bash "$CASE_HELPER" comm log "$case_id" \
+		--channel email --summary "test" --repo "$repo"
+
+	# Failure: invalid direction
+	_assert_exit_nonzero "comm log with invalid direction fails" \
+		bash "$CASE_HELPER" comm log "$case_id" \
+		--direction sideways --channel email --summary "test" --repo "$repo"
+	return 0
+}
+
+test_archive() {
+	echo ""
+	echo "=== archive ==="
+	local repo="$TEST_TMPDIR"
+	# Use the json-test-case (3rd one opened)
+	local case_id="case-2026-0003-json-test-case"
+	local case_dir="${repo}/_cases/${case_id}"
+	local archived_dir="${repo}/_cases/archived/${case_id}"
+
+	_assert_exit_0 "archive moves case directory" \
+		bash "$CASE_HELPER" archive "$case_id" --repo "$repo"
+
+	_assert_dir_exists "archived case exists in archived/" "$archived_dir"
+
+	if [[ ! -d "$case_dir" ]]; then
+		_pass "active case directory removed after archive"
+	else
+		_fail "active case directory removed after archive" "dir still exists"
+	fi
+
+	# list should not show archived case by default
+	local list_out
+	list_out="$(bash "$CASE_HELPER" list --json --repo "$repo" 2>/dev/null)"
+	local found
+	found="$(echo "$list_out" | jq -r '.[] | select(.id == "case-2026-0003-json-test-case") | .id' 2>/dev/null)" || found=""
+	if [[ -z "$found" ]]; then
+		_pass "archived case excluded from default list"
+	else
+		_fail "archived case excluded from default list" "found in list"
+	fi
+
+	# list --status archived should show it
+	list_out="$(bash "$CASE_HELPER" list --status archived --json --repo "$repo" 2>/dev/null)"
+	found="$(echo "$list_out" | jq -r '.[] | select(.id == "case-2026-0003-json-test-case") | .id' 2>/dev/null)" || found=""
+	if [[ -n "$found" ]]; then
+		_pass "archived case visible with --status archived"
+	else
+		_fail "archived case visible with --status archived" "not found"
+	fi
+
+	# Failure: archive already-archived case
+	_assert_exit_nonzero "archive already-archived case fails" \
+		bash "$CASE_HELPER" archive "$case_id" --repo "$repo"
+
+	# Failure: mutate archived case without --unarchive
+	_assert_exit_nonzero "note on archived case fails without --unarchive" \
+		bash "$CASE_HELPER" note "$case_id" --message "test" --repo "$repo"
+	return 0
+}
+
+test_missing_prereq() {
+	echo ""
+	echo "=== error paths ==="
+	local repo="$TEST_TMPDIR"
+
+	# open on non-provisioned repo
+	local fresh_dir
+	fresh_dir="$(mktemp -d)"
+	_assert_exit_nonzero "open without init fails" \
+		bash "$CASE_HELPER" open some-case --repo "$fresh_dir"
+	rm -rf "$fresh_dir"
+
+	# list on non-provisioned repo
+	fresh_dir="$(mktemp -d)"
+	_assert_exit_nonzero "list without init fails" \
+		bash "$CASE_HELPER" list --repo "$fresh_dir"
+	rm -rf "$fresh_dir"
+
+	# show non-existent case
+	_assert_exit_nonzero "show non-existent case fails" \
+		bash "$CASE_HELPER" show no-such-case-xyz999 --repo "$repo"
+	return 0
+}
+
+# =============================================================================
+# Runner
+# =============================================================================
+
+main() {
+	echo "Running case-helper.sh tests..."
+
+	if ! command -v jq >/dev/null 2>&1; then
+		echo "SKIP: jq not found. Install: brew install jq"
+		exit 0
+	fi
+
+	_setup
+
+	test_init
+	test_open_happy
+	test_open_sequential_ids
+	test_open_json_mode
+	test_list
+	test_list_filter_party
+	test_show
+	test_status
+	test_close
+	test_attach
+	test_note
+	test_deadline
+	test_party
+	test_comm
+	test_archive
+	test_missing_prereq
+
+	_teardown
+
+	echo ""
+	echo "Results: ${TESTS_PASSED} passed, ${TESTS_FAILED} failed"
+	if [[ $TESTS_FAILED -gt 0 ]]; then
+		exit 1
+	fi
+	exit 0
+}
+
+main "$@"

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -1841,6 +1841,11 @@ main() {
 		[[ $# -eq 0 ]] && set -- status
 		_dispatch_helper "inbox-helper.sh" "inbox-helper.sh" "$@"
 		;;
+	case | cases)
+		# Bare `aidevops case` defaults to list (most common use).
+		[[ $# -eq 0 ]] && set -- list
+		_dispatch_helper "case-helper.sh" "case-helper.sh" "$@"
+		;;
 	stats | observability) _dispatch_helper "observability-helper.sh" "observability-helper.sh" "$@" ;;
 	tabby) _dispatch_helper "tabby-helper.sh" "tabby-helper.sh" "$@" ;;
 	init-routines) _dispatch_helper "init-routines-helper.sh" "init-routines-helper.sh" "$@" ;;


### PR DESCRIPTION
## Summary

Ships the complete `aidevops case` CLI surface for the cases plane (P4b):
- Foundation from t2851: `init`, `open`, `case-id` sequential counter, `dossier.toon`, `timeline.jsonl`, `sources.toon`
- Extended CLI from t2852: `attach`, `status`, `close`, `archive`, `list`, `show`, `note`, `deadline add/remove`, `party add/remove`, `comm log`

## What ships

- **`.agents/scripts/case-helper.sh`** — full cases plane CLI (560 lines, all subcommands)
- **`aidevops.sh`** — routes `aidevops case` to `case-helper.sh`; bare `aidevops case` defaults to `list`
- **`.agents/aidevops/cases-plane.md`** — directory contract and CLI reference documentation
- **`.agents/templates/case-dossier-schema.json`** — JSON Schema for `dossier.toon` validation
- **`.agents/templates/cases-gitignore.txt`** — default gitignore for `_cases/` (excludes `drafts/`)
- **`.agents/tests/test-case-cli.sh`** — 80 tests covering happy paths and failure paths for all subcommands

## Design decisions

- Timeline writes compact JSONL (one event per line) for proper line-by-line parsing
- `close` requires `--outcome` — attempting to close without one returns a friendly error
- Archived cases require `--unarchive` for any mutating operation
- `attach` verifies source exists in `_knowledge/sources/<id>/` before accepting
- `--json` flag on all commands for machine consumption (scripting, P5/P4c integration)
- Error messages centralised in `_err_opt_unknown`, `_err_case_missing`, `_err_case_archived` helpers to satisfy string-literal ratchet

## Verification

```
bash .agents/tests/test-case-cli.sh  # 80 passed, 0 failed
shellcheck .agents/scripts/case-helper.sh  # zero violations
```

Resolves #20905

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.17 plugin for [OpenCode](https://opencode.ai) v1.14.25 with claude-sonnet-4-6 spent 31m and 80,576 tokens on this as a headless worker.
