### PR TITLE
t2927: fix(pulse): FOOTPRINT_OVERLAP cache leaks closed-issue defers — invalidate when issue closes

### DIFF
--- a/.agents/scripts/dispatch-dedup-footprint.sh
+++ b/.agents/scripts/dispatch-dedup-footprint.sh
@@ -36,7 +36,11 @@ _FOOTPRINT_CACHE_DATA=""
 _FOOTPRINT_CACHE_EPOCH=0
 
 # Maximum age of the footprint cache in seconds. After this, rebuild.
-_FOOTPRINT_CACHE_TTL=120
+# 30s: long enough to catch concurrent same-file dispatch races (the
+# original use-case), short enough to limit blast radius when issues
+# close mid-window. See invalidate_footprint_cache_for_issue() for
+# immediate eviction on known-close events (t2927/GH#21103).
+_FOOTPRINT_CACHE_TTL=30
 
 #######################################
 # Extract file paths from an issue body.
@@ -253,4 +257,42 @@ _footprint_check_overlap() {
 	fi
 
 	return 1
+}
+
+#######################################
+# Evict all cache entries for a specific issue number.
+#
+# Called after an issue closes (PR merge, worktree cleanup, stale reset,
+# claim release) so the next _footprint_check_overlap call does not
+# produce a stale FOOTPRINT_OVERLAP defer against the already-closed
+# issue. This provides immediate eviction on known-close events;
+# _FOOTPRINT_CACHE_TTL bounds the maximum stale window for untracked
+# closes. (t2927/GH#21103)
+#
+# Safe to call when the cache is empty or the issue is not in the cache —
+# both are no-ops. Safe to call when dispatch-dedup-footprint.sh is not
+# sourced — callers guard with `declare -F ... && ...`.
+#
+# Args:
+#   $1 = issue_num (number of the issue to evict)
+# Exit: always 0
+#######################################
+invalidate_footprint_cache_for_issue() {
+	local issue_num="$1"
+	[[ -n "$issue_num" ]] || return 0
+	[[ -n "$_FOOTPRINT_CACHE_DATA" ]] || return 0
+
+	# Rebuild cache without entries for this issue.
+	# Cache stores "file_path|issue_num\n" (literal \n separators).
+	# printf '%b' expands \n to actual newlines for line-by-line filtering.
+	local _new_cache_data=""
+	local _cache_entry _cache_issue
+	while IFS= read -r _cache_entry; do
+		[[ -n "$_cache_entry" ]] || continue
+		_cache_issue="${_cache_entry##*|}"
+		[[ "$_cache_issue" == "$issue_num" ]] && continue
+		_new_cache_data="${_new_cache_data}${_cache_entry}\n"
+	done <<<"$(printf '%b' "$_FOOTPRINT_CACHE_DATA")"
+	_FOOTPRINT_CACHE_DATA="$_new_cache_data"
+	return 0
 }

--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -787,6 +787,7 @@ ${_WORKER_LOG_TAIL_CONTENT}
 		--method POST \
 		--field body="$body" \
 		>/dev/null 2>&1 || true
+	declare -F invalidate_footprint_cache_for_issue >/dev/null 2>&1 && invalidate_footprint_cache_for_issue "$issue_number" || true
 	return 0
 }
 

--- a/.agents/scripts/pulse-issue-reconcile-stale.sh
+++ b/.agents/scripts/pulse-issue-reconcile-stale.sh
@@ -46,6 +46,7 @@ _normalize_clear_status_labels() {
 
 	# t2033: atomic transition to status:available, clearing all sibling
 	# core status labels in one edit (not just queued/in-progress).
+	declare -F invalidate_footprint_cache_for_issue >/dev/null 2>&1 && invalidate_footprint_cache_for_issue "$issue_num" || true
 	set_issue_status "$issue_num" "$slug" "available" \
 		--remove-assignee "$runner_user" >/dev/null 2>&1
 	return $?

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -1261,6 +1261,7 @@ _Merged by deterministic merge pass (pulse-wrapper.sh). Neither MERGE_SUMMARY co
 	if [[ -n "$linked_issue" && "${_parent_task_guard:-0}" -eq 0 ]]; then
 		auto_file_next_phase "$linked_issue" "$repo_slug" || true
 	fi
+	declare -F invalidate_footprint_cache_for_issue >/dev/null 2>&1 && invalidate_footprint_cache_for_issue "${linked_issue:-}" || true
 	return 0
 }
 


### PR DESCRIPTION
## MERGE_SUMMARY

**What was done**: Added `invalidate_footprint_cache_for_issue()` to `dispatch-dedup-footprint.sh` to evict stale cache entries on issue close events, and reduced `_FOOTPRINT_CACHE_TTL` from 120s → 30s.

**Root cause**: `_FOOTPRINT_CACHE_DATA` was built once per pulse cycle with a 120s TTL. When issues closed mid-window (PR merge, worktree recovery, stale reset), the cache still flagged their files as "in-flight", producing `FOOTPRINT_OVERLAP` defers on legitimate new dispatches for up to 2 minutes. During burst-merge waves (5 PRs in 30s), this cut effective dispatch throughput by 30–50%.

**Changes**:
- `dispatch-dedup-footprint.sh`: `invalidate_footprint_cache_for_issue(issue_num)` — filters `_FOOTPRINT_CACHE_DATA` entries matching the closed issue; TTL reduced 120s→30s
- `pulse-merge.sh::_handle_post_merge_actions`: invalidates after successful merge
- `pulse-cleanup.sh::_post_launch_recovery_claim_released`: invalidates after failed-launch claim release
- `pulse-issue-reconcile-stale.sh::_normalize_clear_status_labels`: invalidates before stale status transition

**Verification**: All callers use `declare -F invalidate_footprint_cache_for_issue >/dev/null 2>&1 && ...` guard — safe no-op when not sourced. ShellCheck clean on all 4 files. `_handle_post_merge_actions` stays at `NR-start=100` (threshold is `>100`).

Resolves #21103

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.17 plugin for [OpenCode](https://opencode.ai) v1.14.25 with claude-sonnet-4-6 spent 12m and 30,492 tokens on this as a headless worker.
