### PR TITLE
t2930: honor dispatch-override.conf 'ignore' at assignee level

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -963,6 +963,41 @@ is_assigned() {
 		return 1
 	fi
 
+	# t2930: Honor dispatch-override.conf "ignore" entries at the ASSIGNEE level.
+	# The dispatch-claim-helper filters claim COMMENTS by override config, but
+	# ignored peers can still raw-assign themselves via gh issue edit
+	# --add-assignee — and is_assigned previously honored that unconditionally,
+	# creating a permanent dispatch block. With this filter, an "ignore"-listed
+	# peer is treated as if not assigned, allowing competitive dispatch (winner's
+	# PR closes the issue; loser wastes tokens but doesn't block throughput).
+	# Self-runner and parent-task / no-auto-dispatch / cost circuit-breaker /
+	# hydration window guards above remain in effect.
+	local override_conf="${HOME}/.config/aidevops/dispatch-override.conf"
+	if [[ -f "$override_conf" ]]; then
+		local _filtered_assignees=""
+		local _saved_ifs="${IFS:-}"
+		local -a _override_array=()
+		IFS=',' read -ra _override_array <<<"$assignees"
+		IFS="$_saved_ifs"
+		local _a _upper _override_val
+		for _a in "${_override_array[@]}"; do
+			_upper="$(printf '%s' "$_a" | tr 'a-z-' 'A-Z_')"
+			_override_val=$(grep -E "^DISPATCH_OVERRIDE_${_upper}=" "$override_conf" 2>/dev/null | tail -n1 | cut -d= -f2- | tr -d '"' | tr -d "'")
+			if [[ "$_override_val" == "ignore" ]]; then
+				continue
+			fi
+			if [[ -n "$_filtered_assignees" ]]; then
+				_filtered_assignees="${_filtered_assignees},${_a}"
+			else
+				_filtered_assignees="$_a"
+			fi
+		done
+		assignees="$_filtered_assignees"
+		if [[ -z "$assignees" ]]; then
+			return 1
+		fi
+	fi
+
 	local repo_owner repo_maintainer
 	repo_owner=$(_get_repo_owner "$repo_slug")
 	repo_maintainer=$(_get_repo_maintainer "$repo_slug")


### PR DESCRIPTION
## Summary

Honor `dispatch-override.conf` `"ignore"` entries at the GitHub assignee level (not just the claim comment level). Closes a dispatch starvation gap where ignored peers can raw-assign themselves and block our pulse from dispatching even though their claims are filtered.

## Why

Observed today: a peer runner repeatedly raw-assigned themselves to newly-filed framework issues. The legacy `dispatch-claim-helper` correctly filtered their CLAIM COMMENTS, but `is_assigned()` at the assignee-list level honored their bare `--add-assignee` unconditionally — so the pulse fill floor stayed stuck at 4-7 workers despite 174 candidates being available.

## Fix

In `is_assigned()`, after extracting the assignees list and before computing blocking_assignees, drop any login whose `DISPATCH_OVERRIDE_<UPPER>=ignore` is set in `~/.config/aidevops/dispatch-override.conf`. If only ignored peers remain, return 1 (safe to dispatch).

## Verification

After deployment, pulse fill floor ramps up to capacity (target 24 workers); multiple runners can race for the merge.

Resolves #21119

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.17 plugin for [OpenCode](https://opencode.ai) v1.14.25 with claude-opus-4-7 spent 5h 45m and 470,168 tokens on this with the user in an interactive session.
