### PR TITLE
t2923: feat(worker): push WIP commits to origin on worker exit/kill

### DIFF
--- a/.agents/scripts/headless-runtime-failure.sh
+++ b/.agents/scripts/headless-runtime-failure.sh
@@ -182,6 +182,55 @@ classify_worker_exit() {
 }
 
 #######################################
+# Push any local-only WIP commits to origin before worker exits.
+# Best-effort, fail-open — never blocks claim release or shutdown.
+#
+# t2923: Prevents workers dying mid-implementation from abandoning
+# unreachable commits. Next dispatch can continue from the pushed branch
+# instead of rewriting the same code from scratch.
+#
+# Globals consumed:
+#   _WORKER_WORKTREE_PATH  — set by _cmd_run_prepare in headless-runtime-helper.sh
+#   WORKER_NO_EXIT_PUSH    — escape hatch: set to "1" to disable push
+#######################################
+_push_wip_commits_on_exit() {
+	# Escape hatch: WORKER_NO_EXIT_PUSH=1 disables the push (e.g. in tests)
+	[[ "${WORKER_NO_EXIT_PUSH:-0}" == "1" ]] && return 0
+
+	local work_dir="${_WORKER_WORKTREE_PATH:-}"
+	if [[ -z "$work_dir" || ! -d "$work_dir" ]]; then
+		return 0
+	fi
+
+	# Get the branch name — skip if detached HEAD or default branch
+	local branch_name=""
+	branch_name=$(git -C "$work_dir" rev-parse --abbrev-ref HEAD 2>/dev/null) || return 0
+	case "$branch_name" in
+	HEAD | main | master | "")
+		return 0
+		;;
+	esac
+
+	# Count commits ahead of origin/main (or origin/master) — fail-open
+	local ahead_count=0
+	ahead_count=$(git -C "$work_dir" rev-list --count "origin/main..HEAD" 2>/dev/null || true)
+	[[ "$ahead_count" =~ ^[0-9]+$ ]] || ahead_count=0
+	if [[ "$ahead_count" -eq 0 ]]; then
+		ahead_count=$(git -C "$work_dir" rev-list --count "origin/master..HEAD" 2>/dev/null || true)
+		[[ "$ahead_count" =~ ^[0-9]+$ ]] || ahead_count=0
+	fi
+	if [[ "$ahead_count" -eq 0 ]]; then
+		return 0
+	fi
+
+	# Push best-effort — never block exit on push failure
+	print_info "[lifecycle] worker_exit_pushing_wip branch=${branch_name} ahead=${ahead_count}"
+	git -C "$work_dir" push -u origin "${branch_name}" 2>/dev/null || true
+	print_info "[lifecycle] worker_exit_pushed_wip branch=${branch_name} ahead=${ahead_count}"
+	return 0
+}
+
+#######################################
 # EXIT trap handler — classify worker termination and post CLAIM_RELEASED.
 # Replaces the inline 'process_exit' reason in the EXIT trap with a
 # classified reason from classify_worker_exit. Falls back to process_exit
@@ -193,6 +242,7 @@ classify_worker_exit() {
 # Globals consumed:
 #   _WORKER_START_EPOCH_MS   — ms epoch set by _cmd_run_prepare
 #   _WORKER_ISOLATED_DB_PATH — isolated DB path set by _invoke_opencode
+#   _WORKER_WORKTREE_PATH    — worktree path set by _cmd_run_prepare (t2923)
 #######################################
 _exit_trap_handler() {
 	local session_key="$1"
@@ -228,6 +278,9 @@ _exit_trap_handler() {
 	fi
 
 	print_info "[exit-trap] session=$session_key exit=$exit_status reason=$reason session_count=$session_count"
+	# t2923: Push any WIP commits before releasing the claim so re-dispatch
+	# can continue from the pushed branch instead of starting over.
+	_push_wip_commits_on_exit
 	_release_dispatch_claim "$session_key" "$reason" "$exit_status" "$session_count"
 	_release_session_lock "$session_key"
 	_update_dispatch_ledger "$session_key" "fail"

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -534,6 +534,7 @@ _invoke_opencode() {
 			--exit-code-file "$exit_code_file" \
 			--session-key "${_invoke_session_key:-}" \
 			--repo-slug "${DISPATCH_REPO_SLUG:-}" \
+			--worktree-path "${_WORKER_WORKTREE_PATH:-}" \
 			--stall-timeout "$_stall_timeout" \
 			--phase1-timeout "$_phase1_timeout" \
 			</dev/null >/dev/null 2>&1 &
@@ -1452,6 +1453,10 @@ _cmd_run_prepare() {
 	# session created since start) from crash_during_execution (session found).
 	# Uses the same python3 ms-epoch pattern as _execute_run_attempt metrics.
 	_WORKER_START_EPOCH_MS=$(python3 -c 'import time; print(int(time.time() * 1000))' 2>/dev/null || printf '%s' "0")
+
+	# t2923: Expose worktree path to exit trap handler so _push_wip_commits_on_exit
+	# can push any local-only commits before the worker releases its claim.
+	export _WORKER_WORKTREE_PATH="$work_dir"
 
 	# GH#6696: Register this dispatch in the in-flight ledger so the pulse
 	# can detect workers that haven't created PRs yet. The ledger bridges

--- a/.agents/scripts/worker-activity-watchdog.sh
+++ b/.agents/scripts/worker-activity-watchdog.sh
@@ -54,6 +54,7 @@ WORKER_PID=""
 EXIT_CODE_FILE=""
 SESSION_KEY=""
 REPO_SLUG=""
+WORKTREE_PATH=""
 STALL_TIMEOUT=300
 PHASE1_TIMEOUT=30
 POLL_INTERVAL=10
@@ -82,6 +83,10 @@ _parse_args() {
 			;;
 		--repo-slug)
 			REPO_SLUG="$2"
+			shift 2
+			;;
+		--worktree-path)
+			WORKTREE_PATH="$2"
 			shift 2
 			;;
 		--stall-timeout)
@@ -154,6 +159,59 @@ _get_output_size() {
 }
 
 #######################################
+# Push any local-only WIP commits to origin before killing the worker.
+# Best-effort, fail-open — never blocks the kill sequence.
+#
+# t2923: Ensures commits made before the stall are reachable on origin
+# so the next worker dispatch can continue from the branch instead of
+# rewriting the same code from scratch.
+#
+# Globals consumed:
+#   WORKTREE_PATH        — set via --worktree-path arg
+#   WORKER_NO_EXIT_PUSH  — escape hatch: set to "1" to disable push
+#######################################
+_push_wip_before_kill() {
+	# Escape hatch
+	[[ "${WORKER_NO_EXIT_PUSH:-0}" == "1" ]] && return 0
+
+	local work_dir="$WORKTREE_PATH"
+	if [[ -z "$work_dir" || ! -d "$work_dir" ]]; then
+		return 0
+	fi
+
+	# Get branch name — skip if detached HEAD or default branch
+	local branch_name=""
+	branch_name=$(git -C "$work_dir" rev-parse --abbrev-ref HEAD 2>/dev/null) || return 0
+	case "$branch_name" in
+	HEAD | main | master | "")
+		return 0
+		;;
+	esac
+
+	# Count commits ahead of origin/main (or origin/master)
+	local ahead_count=0
+	ahead_count=$(git -C "$work_dir" rev-list --count "origin/main..HEAD" 2>/dev/null || true)
+	[[ "$ahead_count" =~ ^[0-9]+$ ]] || ahead_count=0
+	if [[ "$ahead_count" -eq 0 ]]; then
+		ahead_count=$(git -C "$work_dir" rev-list --count "origin/master..HEAD" 2>/dev/null || true)
+		[[ "$ahead_count" =~ ^[0-9]+$ ]] || ahead_count=0
+	fi
+	if [[ "$ahead_count" -eq 0 ]]; then
+		return 0
+	fi
+
+	# Push best-effort — never block the kill sequence on push failure
+	printf '[WATCHDOG_WIP_PUSH] timestamp=%s branch=%s ahead=%s\n' \
+		"$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$branch_name" "$ahead_count" \
+		>>"$OUTPUT_FILE" 2>/dev/null || true
+	git -C "$work_dir" push -u origin "$branch_name" 2>/dev/null || true
+	printf '[WATCHDOG_WIP_PUSHED] branch=%s ahead=%s\n' \
+		"$branch_name" "$ahead_count" \
+		>>"$OUTPUT_FILE" 2>/dev/null || true
+	return 0
+}
+
+#######################################
 # Kill the worker process tree and write markers
 #
 # Args:
@@ -161,6 +219,10 @@ _get_output_size() {
 #######################################
 _kill_worker() {
 	local reason="$1"
+
+	# t2923: Push WIP commits before killing so the work is reachable on origin.
+	# Must happen before SIGTERM so git operations complete cleanly.
+	_push_wip_before_kill
 
 	# Write the .watchdog_killed sentinel BEFORE killing. The dying
 	# subshell may overwrite exit_code_file with its own exit code


### PR DESCRIPTION
## What

Workers spawned by pulse can die mid-implementation (timeout, OOM, killed) leaving local WIP commits that never reach origin. This PR adds best-effort WIP commit pushing on worker exit/kill so subsequent dispatches can continue from the pushed branch instead of rewriting the same code from scratch.

## Changes

### `headless-runtime-failure.sh`
- New `_push_wip_commits_on_exit()` function: detects commits ahead of `origin/main` in `_WORKER_WORKTREE_PATH`, pushes them best-effort, logs `worker_exit_pushing_wip` / `worker_exit_pushed_wip` to stderr
- Called from `_exit_trap_handler` before `_release_dispatch_claim` — WIP lands on origin before the claim is released and re-dispatched

### `headless-runtime-helper.sh`
- `_cmd_run_prepare`: exports `_WORKER_WORKTREE_PATH="$work_dir"` so the exit trap can find the worktree
- Watchdog launch: passes `--worktree-path "${_WORKER_WORKTREE_PATH:-}"` to the standalone watchdog

### `worker-activity-watchdog.sh`
- New `--worktree-path` argument (global `WORKTREE_PATH`)
- New `_push_wip_before_kill()` function: same logic as above, writes `[WATCHDOG_WIP_PUSH]` / `[WATCHDOG_WIP_PUSHED]` markers to the output file
- Called from `_kill_worker` BEFORE `pkill`/`kill` so git operations complete cleanly before the process tree is terminated

## Escape Hatch

Set `WORKER_NO_EXIT_PUSH=1` to disable WIP push in both paths (e.g. for tests or isolated environments without git remote access).

## Acceptance Criteria

- [x] EXIT trap pushes any local-only commits to origin before worker exits
- [x] Watchdog kill path also pushes WIP before SIGKILL
- [x] `WORKER_NO_EXIT_PUSH=1` escape hatch documented and implemented
- [x] No regression on workers that complete normally (push happens in exit trap only on abnormal exits; normal exits clear the trap via `trap - EXIT`)
- [x] `shellcheck` zero violations on modified files

## Complexity Bump Justification

No function exceeded 80 lines. `_push_wip_commits_on_exit` is 35 lines; `_push_wip_before_kill` is 40 lines. No complexity gate concerns.

Resolves #21098

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.17 plugin for [OpenCode](https://opencode.ai) v1.14.25 with claude-sonnet-4-6 spent 8m and 20,233 tokens on this as a headless worker.
