### PR TITLE
t2869: inbox digest subcommand + weekly pulse routine + advisory integration

### DIFF
--- a/.agents/scripts/inbox-digest-routine.sh
+++ b/.agents/scripts/inbox-digest-routine.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# shellcheck disable=SC2034
+# =============================================================================
+# inbox-digest-routine.sh — Pulse-callable stale inbox digest + advisory (t2869)
+# =============================================================================
+# Iterates all pulse-enabled repos and the workspace inbox, identifies items
+# in _inbox/_drop/ and _inbox/_needs-review/ older than AIDEVOPS_INBOX_DIGEST_AGE_DAYS
+# (default: 7), and writes/removes advisories in ~/.aidevops/advisories/.
+#
+# Advisory filename: inbox-stale-{slug-sanitized}.advisory (stable; overwritten)
+# Advisory ID used by: aidevops security dismiss inbox-stale-{slug-sanitized}
+# Advisory first line is surfaced in session greeting via _check_advisories().
+# Advisories self-clear when stale item count drops to zero.
+#
+# Usage:
+#   inbox-digest-routine.sh [--age-days N] [--dry-run] [--force]
+#
+# Pulse routine entry (TODO.md):
+#   - [x] r_inbox_digest Inbox stale item digest
+#     repeat:weekly(sun@08:00)
+#     run:scripts/inbox-digest-routine.sh
+#
+# Environment:
+#   AIDEVOPS_INBOX_DIGEST_AGE_DAYS         Age threshold in days (default: 7)
+#   AIDEVOPS_INBOX_DIGEST_INTERVAL_HOURS   Re-run guard interval (default: 168)
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+# shellcheck source=shared-constants.sh
+source "${SCRIPT_DIR}/shared-constants.sh"
+
+# =============================================================================
+# Configuration
+# =============================================================================
+
+readonly REPOS_JSON="${HOME}/.config/aidevops/repos.json"
+readonly ADVISORIES_DIR="${HOME}/.aidevops/advisories"
+readonly WORKSPACE_INBOX_DIR="${HOME}/.aidevops/.agent-workspace/inbox"
+readonly DIGEST_STAMP_FILE="${TMPDIR:-/tmp}/aidevops-inbox-digest.last"
+
+INBOX_DIGEST_AGE_DAYS="${AIDEVOPS_INBOX_DIGEST_AGE_DAYS:-7}"
+INBOX_DIGEST_INTERVAL_HOURS="${AIDEVOPS_INBOX_DIGEST_INTERVAL_HOURS:-168}"
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+# _slug_sanitize <slug>
+# Converts owner/repo → owner-repo for safe use in advisory filenames.
+_slug_sanitize() {
+	local slug="$1"
+	printf '%s' "$slug" | sed 's|/|-|g; s|[^a-zA-Z0-9._-]|-|g'
+	return 0
+}
+
+# _within_rate_window
+# Returns 0 if enough time has elapsed since the last run; 1 if too soon.
+_within_rate_window() {
+	[[ ! -f "$DIGEST_STAMP_FILE" ]] && return 0
+	local last_run now elapsed interval_secs
+	last_run="$(cat "$DIGEST_STAMP_FILE" 2>/dev/null || echo 0)"
+	now="$(date +%s)"
+	elapsed=$(( now - last_run ))
+	interval_secs=$(( INBOX_DIGEST_INTERVAL_HOURS * 3600 ))
+	[[ "$elapsed" -lt "$interval_secs" ]] && return 1
+	return 0
+}
+
+# _stamp_last_run
+_stamp_last_run() {
+	date +%s > "$DIGEST_STAMP_FILE" 2>/dev/null || true
+	return 0
+}
+
+# _count_stale <json_output>
+# Counts items in digest --json output by counting "age_days" key occurrences.
+# Uses the safe counter pattern (grep -c || true with type guard).
+_count_stale() {
+	local json_out="$1"
+	local count
+	count=$(printf '%s' "$json_out" | grep -c '"age_days"' 2>/dev/null || true)
+	[[ "$count" =~ ^[0-9]+$ ]] || count=0
+	echo "$count"
+	return 0
+}
+
+# _write_advisory <adv_id> <count> <age_days> <label> <repo_path>
+# Creates/overwrites an advisory file and removes the ID from dismissed.txt
+# so the advisory re-appears after a clean period followed by new stale items.
+_write_advisory() {
+	local adv_id="$1"
+	local count="$2"
+	local age_days="$3"
+	local label="$4"
+	local repo_path="$5"
+
+	local adv_file="${ADVISORIES_DIR}/${adv_id}.advisory"
+	local dismissed_file="${ADVISORIES_DIR}/dismissed.txt"
+
+	mkdir -p "$ADVISORIES_DIR"
+
+	printf '[INBOX] %s stale item(s) >= %sd in %s/_inbox/\n\nRun: aidevops inbox digest --repo %s\n' \
+		"$count" "$age_days" "$label" "$repo_path" > "$adv_file"
+
+	# Remove this ID from dismissed.txt so it re-appears after a clean period
+	if [[ -f "$dismissed_file" ]]; then
+		local tmp_dis
+		tmp_dis="$(mktemp)"
+		grep -vxF "$adv_id" "$dismissed_file" > "$tmp_dis" 2>/dev/null || true
+		mv "$tmp_dis" "$dismissed_file" 2>/dev/null || rm -f "$tmp_dis" || true
+	fi
+
+	print_success "Advisory written: ${adv_id}"
+	return 0
+}
+
+# _clear_advisory <adv_id>
+# Removes an advisory file when no stale items remain (self-clear).
+_clear_advisory() {
+	local adv_id="$1"
+	local adv_file="${ADVISORIES_DIR}/${adv_id}.advisory"
+	if [[ -f "$adv_file" ]]; then
+		rm -f "$adv_file"
+		print_info "Advisory cleared: ${adv_id}"
+	fi
+	return 0
+}
+
+# _process_inbox <label> <repo_path> <age_days> <dry_run>
+# Runs digest --json for the given repo root and manages the advisory.
+# Skips silently if _inbox/ does not exist at repo_path.
+_process_inbox() {
+	local label="$1"
+	local repo_path="$2"
+	local age_days="$3"
+	local dry_run="$4"
+
+	[[ -d "${repo_path}/_inbox" ]] || return 0
+
+	local helper="${SCRIPT_DIR}/inbox-helper.sh"
+	[[ -x "$helper" ]] || { print_error "inbox-helper.sh not found at ${helper}"; return 1; }
+
+	local json_out
+	json_out="$("$helper" digest --json --age-days "$age_days" \
+		--repo "$repo_path" 2>/dev/null || echo '[]')"
+
+	local count
+	count="$(_count_stale "$json_out")"
+
+	local adv_id
+	adv_id="inbox-stale-$(_slug_sanitize "$label")"
+
+	if [[ "$count" -gt 0 ]]; then
+		print_info "${label}: ${count} stale item(s) >= ${age_days}d"
+		if [[ "$dry_run" -eq 1 ]]; then
+			print_info "[DRY RUN] Would write advisory: ${adv_id}"
+		else
+			_write_advisory "$adv_id" "$count" "$age_days" "$label" "$repo_path"
+		fi
+	else
+		print_info "${label}: inbox clean (< ${age_days}d)"
+		if [[ "$dry_run" -eq 1 ]]; then
+			print_info "[DRY RUN] Would clear advisory: ${adv_id} (if present)"
+		else
+			_clear_advisory "$adv_id"
+		fi
+	fi
+	return 0
+}
+
+# _process_workspace_inbox <age_days> <dry_run>
+# Scans the workspace-level inbox using --include-workspace flag.
+# Passes workspace parent as --repo so the repo _inbox/ scan finds nothing,
+# and only the workspace inbox (inbox/) is scanned.
+_process_workspace_inbox() {
+	local age_days="$1"
+	local dry_run="$2"
+
+	[[ -d "$WORKSPACE_INBOX_DIR" ]] || return 0
+
+	local helper="${SCRIPT_DIR}/inbox-helper.sh"
+	[[ -x "$helper" ]] || return 0
+
+	# Pass workspace parent as --repo: ~/.aidevops/.agent-workspace has no _inbox/
+	# so repo scanning finds nothing; --include-workspace adds the real inbox/.
+	local workspace_parent
+	workspace_parent="$(dirname "$WORKSPACE_INBOX_DIR")"
+
+	local json_out
+	json_out="$("$helper" digest --json --age-days "$age_days" \
+		--repo "$workspace_parent" --include-workspace 2>/dev/null || echo '[]')"
+
+	local count
+	count="$(_count_stale "$json_out")"
+
+	local adv_id="inbox-stale-workspace"
+
+	if [[ "$count" -gt 0 ]]; then
+		print_info "workspace: ${count} stale item(s) >= ${age_days}d"
+		if [[ "$dry_run" -eq 1 ]]; then
+			print_info "[DRY RUN] Would write advisory: ${adv_id}"
+		else
+			_write_advisory "$adv_id" "$count" "$age_days" "workspace" "$workspace_parent"
+		fi
+	else
+		print_info "workspace: inbox clean (< ${age_days}d)"
+		if [[ "$dry_run" -eq 1 ]]; then
+			print_info "[DRY RUN] Would clear advisory: ${adv_id} (if present)"
+		else
+			_clear_advisory "$adv_id"
+		fi
+	fi
+	return 0
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+
+main() {
+	local age_days="${INBOX_DIGEST_AGE_DAYS}"
+	local dry_run=0
+	local force=0
+
+	while [[ $# -gt 0 ]]; do
+		local cur_arg="$1"
+		case "$cur_arg" in
+		--age-days)    age_days="${2:-7}"; shift 2 ;;
+		--age-days=*)  age_days="${cur_arg#--age-days=}"; shift ;;
+		--dry-run)     dry_run=1; shift ;;
+		--force)       force=1; shift ;;
+		*)
+			print_error "Unknown flag: $cur_arg"
+			exit 1
+			;;
+		esac
+	done
+
+	# Rate-window guard (skip unless --force or --dry-run)
+	if [[ "$force" -eq 0 && "$dry_run" -eq 0 ]] && ! _within_rate_window; then
+		print_info "Inbox digest: not yet due (interval: ${INBOX_DIGEST_INTERVAL_HOURS}h). Use --force to override."
+		exit 0
+	fi
+
+	# jq is required to iterate repos.json
+	if ! command -v jq &>/dev/null; then
+		print_warning "jq not found. Skipping cross-repo digest. Install jq to enable."
+		exit 0
+	fi
+
+	local processed=0
+
+	# Iterate pulse-enabled repos from repos.json
+	if [[ -f "$REPOS_JSON" ]]; then
+		while IFS='|' read -r repo_path slug; do
+			[[ -z "$repo_path" || -z "$slug" ]] && continue
+			# Expand ~ to $HOME (repos.json may use unexpanded tildes)
+			repo_path="${repo_path/#\~/$HOME}"
+			[[ -d "$repo_path" ]] || continue
+			_process_inbox "$slug" "$repo_path" "$age_days" "$dry_run" || true
+			processed=$(( processed + 1 ))
+		done < <(jq -r \
+			'.initialized_repos[]? | select(.pulse == true and .local_only != true) | "\(.path)|\(.slug)"' \
+			"$REPOS_JSON" 2>/dev/null)
+	else
+		print_warning "repos.json not found at ${REPOS_JSON}. Skipping repo scan."
+	fi
+
+	# Workspace inbox (always scanned, independent of repos.json)
+	_process_workspace_inbox "$age_days" "$dry_run" || true
+	processed=$(( processed + 1 ))
+
+	print_info "Digest complete: ${processed} inbox(es) checked."
+
+	if [[ "$dry_run" -eq 0 ]]; then
+		_stamp_last_run
+	fi
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/inbox-helper.sh
+++ b/.agents/scripts/inbox-helper.sh
@@ -64,6 +64,12 @@ readonly TRIAGE_KEY_STATUS="status"
 readonly TRIAGE_KEY_PATH="path"
 readonly TRIAGE_VAL_PENDING="pending"
 
+# Sub-folders scanned by digest for stale/unprocessed items (transit zones).
+# Reference INBOX_SUB_DIRS by index to avoid repeating the string literals.
+# INBOX_SUB_DIRS = ("_drop" "email" "web" "scan" "voice" "import" "_needs-review")
+#                    [0]                                                [6]
+readonly DIGEST_SCAN_SUBS=("${INBOX_SUB_DIRS[0]}" "${INBOX_SUB_DIRS[6]}")
+
 # =============================================================================
 # Helpers
 # =============================================================================
@@ -908,11 +914,165 @@ _triage_route_to_plane() {
 }
 
 # =============================================================================
+# cmd_digest — stale inbox item digest (t2869)
+# =============================================================================
+# Flags:
+#   --age-days N          Age threshold in days (default: 7)
+#   --repo PATH           Repo root to scan (default: pwd)
+#   --include-workspace   Also scan ~/.aidevops/.agent-workspace/inbox/
+#   --json                Machine-readable JSON array output
+#
+# Sub-folders scanned: _drop/ _needs-review/ (transit zones awaiting triage)
+# Output sorted by age descending.
+# =============================================================================
+
+# _file_age_days <filepath>
+# Returns the age of the file in whole days (integer).
+_file_age_days() {
+	local filepath="$1"
+	local file_ts now_ts
+	file_ts="$(date -r "$filepath" +%s 2>/dev/null || stat -c '%Y' "$filepath" 2>/dev/null || echo 0)"
+	now_ts="$(date +%s)"
+	echo $(( (now_ts - file_ts) / 86400 ))
+	return 0
+}
+
+# _triage_prior_attempts <log-path> <rel-path>
+# Returns count of triage log entries for rel-path with status != pending.
+_triage_prior_attempts() {
+	local log_path="$1"
+	local rel_path="$2"
+	local count=0
+	[[ ! -f "$log_path" ]] && echo "0" && return 0
+	while IFS= read -r line; do
+		[[ -z "$line" ]] && continue
+		local path_field status_field
+		path_field="$(_json_field "$line" "$TRIAGE_KEY_PATH")"
+		status_field="$(_json_field "$line" "$TRIAGE_KEY_STATUS")"
+		if [[ "$path_field" == "$rel_path" && "$status_field" != "$TRIAGE_VAL_PENDING" ]]; then
+			count=$(( count + 1 ))
+		fi
+	done < "$log_path"
+	echo "$count"
+	return 0
+}
+
+# _digest_scan_inbox <inbox-dir> <age-days>
+# Scans _drop/ and _needs-review/ for files older than age-days.
+# Prints lines: "<age_days>\t<sub_folder>\t<rel_path>\t<prior_attempts>"
+_digest_scan_inbox() {
+	local inbox_dir="$1"
+	local age_days="$2"
+	local log_path="${inbox_dir}/${TRIAGE_LOG}"
+	local inbox_parent
+	inbox_parent="$(dirname "$inbox_dir")"
+
+	local sub
+	for sub in "${DIGEST_SCAN_SUBS[@]}"; do
+		local sub_dir="${inbox_dir}/${sub}"
+		[[ -d "$sub_dir" ]] || continue
+		local f
+		while IFS= read -r -d '' f; do
+			local age
+			age="$(_file_age_days "$f")"
+			if [[ "$age" -ge "$age_days" ]]; then
+				local rel_path="${f#"${inbox_parent}"/}"
+				local attempts
+				attempts="$(_triage_prior_attempts "$log_path" "$rel_path")"
+				printf '%s\t%s\t%s\t%s\n' "$age" "$sub" "$rel_path" "$attempts"
+			fi
+		done < <(find "$sub_dir" -maxdepth 1 -type f ! -name '.*' -print0 2>/dev/null)
+	done
+	return 0
+}
+
+cmd_digest() {
+	local age_days=7
+	local repo_path
+	repo_path="$(pwd)"
+	local include_workspace=0
+	local json_output=0
+
+	while [[ $# -gt 0 ]]; do
+		local cur_arg="$1"
+		case "$cur_arg" in
+		--age-days)          age_days="${2:-7}"; shift 2 ;;
+		--age-days=*)        age_days="${cur_arg#--age-days=}"; shift ;;
+		--repo)              repo_path="${2:-$(pwd)}"; shift 2 ;;
+		--repo=*)            repo_path="${cur_arg#--repo=}"; shift ;;
+		--include-workspace) include_workspace=1; shift ;;
+		--json)              json_output=1; shift ;;
+		*) print_error "Unknown digest flag: $cur_arg"; return 1 ;;
+		esac
+	done
+
+	repo_path="$(cd "$repo_path" && pwd)"
+	local inbox_dir="${repo_path}/${INBOX_DIR_NAME}"
+
+	# Collect rows: age_days TAB sub_folder TAB rel_path TAB prior_attempts
+	local -a rows=()
+	if [[ -d "$inbox_dir" ]]; then
+		while IFS= read -r row; do
+			[[ -n "$row" ]] && rows+=("$row")
+		done < <(_digest_scan_inbox "$inbox_dir" "$age_days")
+	fi
+
+	if [[ "$include_workspace" -eq 1 && -d "$WORKSPACE_INBOX_DIR" ]]; then
+		while IFS= read -r row; do
+			[[ -n "$row" ]] && rows+=("$row")
+		done < <(_digest_scan_inbox "$WORKSPACE_INBOX_DIR" "$age_days")
+	fi
+
+	# Sort by age descending (field 1, numeric)
+	local -a sorted_rows=()
+	if [[ ${#rows[@]} -gt 0 ]]; then
+		while IFS= read -r row; do
+			[[ -n "$row" ]] && sorted_rows+=("$row")
+		done < <(printf '%s\n' "${rows[@]}" | sort -t$'\t' -k1 -rn)
+	fi
+
+	if [[ "$json_output" -eq 1 ]]; then
+		local first=1
+		printf '['
+		local row
+		for row in "${sorted_rows[@]}"; do
+			IFS=$'\t' read -r age sub rel_path attempts <<< "$row"
+			[[ "$first" -eq 1 ]] && first=0 || printf ','
+			printf '{"age_days":%s,"sub_folder":"%s","file_path":"%s","prior_attempts":%s}' \
+				"$age" \
+				"$(_json_escape "$sub")" \
+				"$(_json_escape "$rel_path")" \
+				"$attempts"
+		done
+		printf ']\n'
+	else
+		if [[ ${#sorted_rows[@]} -eq 0 ]]; then
+			print_info "No items >= ${age_days} day(s) old in _inbox/ transit folders."
+			return 0
+		fi
+		printf '\nStale _inbox/ items (>= %d day(s) old)\n\n' "$age_days"
+		printf '  %-8s  %-20s  %-60s  %s\n' \
+			"AGE" "SUB_FOLDER" "FILE_PATH" "PRIOR_ATTEMPTS"
+		printf '  %-8s  %-20s  %-60s  %s\n' \
+			"--------" "--------------------" \
+			"------------------------------------------------------------" "--------------"
+		local row
+		for row in "${sorted_rows[@]}"; do
+			IFS=$'\t' read -r age sub rel_path attempts <<< "$row"
+			printf '  %-8s  %-20s  %-60s  %s\n' \
+				"${age}d" "$sub" "$rel_path" "$attempts"
+		done
+		printf '\nTotal: %d stale item(s)\n\n' "${#sorted_rows[@]}"
+	fi
+	return 0
+}
+
+# =============================================================================
 # cmd_help
 # =============================================================================
 cmd_help() {
 	cat <<'EOF'
-inbox-helper.sh — _inbox/ transit zone manager (t2866 + t2867 + t2868)
+inbox-helper.sh — _inbox/ transit zone manager (t2866 + t2867 + t2868 + t2869)
 
 Commands:
   provision [<repo-path>]   Create _inbox/ structure (default: current dir)
@@ -921,6 +1081,11 @@ Commands:
   add --url <url>           Capture a web page (saves HTML + text + metadata)
   find <query>              Search triage.log for entries matching query (last 30 days)
   status [<repo-path>]      Show item counts per sub-folder
+  digest [options]          Show stale items in _drop/ and _needs-review/ (default: >= 7d old)
+    --age-days N              Age threshold in days (default: 7)
+    --repo PATH               Repo root to scan (default: current dir)
+    --include-workspace       Also scan workspace inbox (~/.aidevops/.agent-workspace/inbox/)
+    --json                    Machine-readable JSON array output
   triage [--dry-run] [--limit N] [--confidence-threshold N]
                             Process pending items: sensitivity → classify → route
   help                      Show this help
@@ -965,6 +1130,7 @@ main() {
 	add) cmd_add "$@" ;;
 	find) cmd_find "$@" ;;
 	status) cmd_status "$@" ;;
+	digest) cmd_digest "$@" ;;
 	triage) cmd_triage "$@" ;;
 	help | -h | --help) cmd_help ;;
 	*)

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -1498,7 +1498,7 @@ _help_commands() {
 	echo "  approve <cmd>      Cryptographic issue/PR approval (setup/issue/pr/verify/status)"
 	echo "  security [cmd]     Full security assessment (posture + hygiene + supply chain)"
 	echo "  contributions      External contributions inbox (bare: status | seed/scan/stop/restart/install/uninstall)"
-	echo "  inbox [cmd]        Capture transit zone (bare: status | provision/add/find/help)"
+	echo "  inbox [cmd]        Capture transit zone (bare: status | provision/add/find/digest/help)"
 	echo "  email [cmd]        Email mailbox management (mailbox add/list/test/remove)"
 	echo "  ip-check <cmd>     IP reputation checks (check/batch/report/providers)"
 	echo "  review-gate <cmd>  Configure review_gate.rate_limit_behavior (list/set/unset)"


### PR DESCRIPTION
## Summary

Implements `aidevops inbox digest` (t2869 / P2d) — passive escalation for stale inbox items so `_inbox/` doesn't become an abandoned dumping ground.

## What was done

- **`inbox-helper.sh` — `digest` subcommand:** walks `_inbox/_drop/` and `_inbox/_needs-review/` for files older than `--age-days` (default 7), cross-references `triage.log` for prior attempt count, and outputs a human-readable table or `--json` array sorted by age descending. Flags: `--age-days N`, `--repo PATH`, `--include-workspace`, `--json`.
- **`inbox-digest-routine.sh` — pulse routine:** iterates all `pulse: true` repos from `repos.json` plus the workspace inbox, writes `~/.aidevops/advisories/inbox-stale-{slug}.advisory` when stale items exist, and self-clears the advisory when the count drops to zero. Rate-limited via stamp file (default: 168h / weekly).
- **Advisory integration:** reuses the existing `_check_advisories()` flow — no changes to `aidevops-update-check.sh`. Advisory first line (`[INBOX] N stale item(s) >= Md in slug/_inbox/`) surfaces in session greeting. Dismiss via `aidevops security dismiss inbox-stale-{slug}`.
- **`aidevops.sh`:** updated help text to mention `digest`.

## Testing

```bash
touch -t 202604010000 /tmp/_inbox/_drop/old.txt
aidevops inbox digest --age-days 7 --repo /tmp
aidevops inbox digest --age-days 7 --repo /tmp --json
.agents/scripts/inbox-digest-routine.sh --force --dry-run
shellcheck .agents/scripts/inbox-helper.sh .agents/scripts/inbox-digest-routine.sh
```

All verified locally. Pre-commit and pre-push quality gates passed.

For #20892

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.17 plugin for [OpenCode](https://opencode.ai) v1.14.25 with claude-sonnet-4-6 spent 15m and 38,263 tokens on this as a headless worker.
