### PR TITLE
t2932: peer-productivity-monitor for adaptive cross-runner coordination

### DIFF
--- a/.agents/configs/dispatch-override.conf.txt
+++ b/.agents/configs/dispatch-override.conf.txt
@@ -85,6 +85,34 @@ DISPATCH_CLAIM_IGNORE_RUNNERS=""
 DISPATCH_OVERRIDE_ENABLED=true
 
 # ==============================================================================
+# Auto-managed section (t2932 — peer-productivity-monitor)
+# ==============================================================================
+#
+# When `peer-productivity-monitor.sh` is installed (it runs every 30 min via
+# launchd/systemd), it manages a section of THIS file between the BEGIN and
+# END markers below. It observes peer GitHub activity and writes
+# `DISPATCH_OVERRIDE_<SLUG>="ignore"` entries for peers whose pulse appears
+# broken (claiming issues but never merging worker PRs in the last 24h),
+# and clears the entry once the peer recovers (1+ merged worker PR resumes).
+#
+# Manual entries placed ABOVE the BEGIN marker take precedence and are NEVER
+# overwritten by the monitor — this is the user-override channel.
+#
+# The monitor:
+#   - Counts only peer's `origin:worker` PRs, never their interactive PRs
+#     (their human work doesn't count toward "broken pulse" signal).
+#   - Requires 3 consecutive same-vote observations before flipping (hysteresis,
+#     prevents flapping during transient outages).
+#   - Skips bot accounts (dependabot, renovate, github-actions, *-bot).
+#   - Default for unknown peers: honour (override that with the monitor's
+#     compete-by-default policy via env if you want stricter behaviour).
+#
+# To disable temporarily: set AIDEVOPS_PEER_MONITOR_DISABLE=1 in the launchd
+# environment, or `launchctl unload ~/Library/LaunchAgents/sh.aidevops.peer-productivity-monitor.plist`.
+#
+# To inspect state and decisions: `peer-productivity-monitor.sh report`.
+
+# ==============================================================================
 # Safety
 # ==============================================================================
 #

--- a/.agents/configs/sh.aidevops.peer-productivity-monitor.plist
+++ b/.agents/configs/sh.aidevops.peer-productivity-monitor.plist
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>sh.aidevops.peer-productivity-monitor</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>/bin/bash</string>
+		<string>-c</string>
+		<string>$HOME/.aidevops/agents/scripts/peer-productivity-monitor.sh observe &gt;&gt; $HOME/.aidevops/logs/peer-productivity-launchd.log 2&gt;&amp;1</string>
+	</array>
+	<key>StartInterval</key>
+	<integer>1800</integer>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<false/>
+	<key>ProcessType</key>
+	<string>Background</string>
+	<key>LowPriorityBackgroundIO</key>
+	<true/>
+	<key>Nice</key>
+	<integer>10</integer>
+	<key>StandardOutPath</key>
+	<string>/dev/null</string>
+	<key>StandardErrorPath</key>
+	<string>/dev/null</string>
+</dict>
+</plist>

--- a/.agents/scripts/peer-productivity-monitor.sh
+++ b/.agents/scripts/peer-productivity-monitor.sh
@@ -1,0 +1,632 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# peer-productivity-monitor.sh — adaptive cross-runner dispatch coordination (t2932)
+#
+# Observes peer GitHub activity and updates dispatch-override.conf automatically:
+#   - When peer's pulse degrades (their workers claim issues but never PR),
+#     this monitor flips them to `ignore` so our pulse can compete.
+#   - When peer's pulse recovers (their workers start merging again),
+#     monitor flips them back to `honour` so collaboration resumes.
+#
+# Self-healing across the ecosystem: each runner observes peers independently,
+# no central coordinator needed. When one runner regresses in a release,
+# every other runner detects and routes around them within ~30 min.
+#
+# Architecture:
+#   - Runs every 30 min via launchd (sh.aidevops.peer-productivity-monitor.plist)
+#   - Per-peer rolling 24h window stats
+#   - Distinguishes worker PRs (origin:worker) from interactive PRs
+#     (origin:interactive) — peer's human work never triggers ignore mode
+#   - Hysteresis: 3 consecutive same-vote required to flip (avoid flapping)
+#   - Manages a section of dispatch-override.conf between BEGIN/END markers
+#     — manual entries above the marker are sticky (user override always wins)
+#
+# Usage:
+#   peer-productivity-monitor.sh observe        # one observation cycle (called by launchd)
+#   peer-productivity-monitor.sh report         # show current state + decisions
+#   peer-productivity-monitor.sh dry-run        # observe without writing config
+#   peer-productivity-monitor.sh reset <peer>   # reset hysteresis state for a peer
+#
+# Decision rules per peer:
+#   - 0 worker PRs merged in 24h + 1+ active claims = vote `ignore` (peer broken)
+#   - 1+ worker PRs merged in 24h = vote `honour` (peer healthy)
+#   - 0 of each = vote `keep` (insufficient signal, no change)
+#
+# Default for unknown peers: ignore (compete-by-default — safer for new peers
+# until they prove productivity).
+#
+# Env:
+#   AIDEVOPS_PEER_MONITOR_DISABLE=1   — short-circuit, do nothing
+#   AIDEVOPS_PEER_MONITOR_DRY_RUN=1   — observe + log, don't write config
+#   AIDEVOPS_PEER_MONITOR_WINDOW_H=24 — rolling window in hours (default 24)
+#   AIDEVOPS_PEER_MONITOR_HYSTERESIS=3 — vote count for flip (default 3)
+
+set -euo pipefail
+
+# ============================================================================
+# Setup
+# ============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# Source shared constants if available (color codes, log helpers).
+if [[ -f "${SCRIPT_DIR}/shared-constants.sh" ]]; then
+	# shellcheck source=/dev/null
+	source "${SCRIPT_DIR}/shared-constants.sh"
+else
+	# Fallback when not deployed
+	[[ -z "${RED+x}" ]] && RED=''
+	[[ -z "${GREEN+x}" ]] && GREEN=''
+	[[ -z "${YELLOW+x}" ]] && YELLOW=''
+	[[ -z "${BLUE+x}" ]] && BLUE=''
+	[[ -z "${NC+x}" ]] && NC=''
+fi
+
+# Config paths
+OVERRIDE_CONF="${HOME}/.config/aidevops/dispatch-override.conf"
+STATE_DIR="${HOME}/.aidevops/state"
+STATE_FILE="${STATE_DIR}/peer-productivity-state.json"
+LOG_FILE="${HOME}/.aidevops/logs/peer-productivity.log"
+REPOS_JSON="${HOME}/.config/aidevops/repos.json"
+
+# Markers for managed section of override config
+MARKER_BEGIN="# BEGIN auto-managed by peer-productivity-monitor (t2932)"
+MARKER_END="# END auto-managed by peer-productivity-monitor"
+
+# Defaults
+WINDOW_HOURS="${AIDEVOPS_PEER_MONITOR_WINDOW_H:-24}"
+HYSTERESIS="${AIDEVOPS_PEER_MONITOR_HYSTERESIS:-3}"
+DRY_RUN="${AIDEVOPS_PEER_MONITOR_DRY_RUN:-0}"
+
+# Vote / action constants — keep in sync with _sanitize_action.
+readonly ACTION_HONOUR="honour"
+readonly ACTION_IGNORE="ignore"
+readonly ACTION_KEEP="keep"
+
+# Bot account suffixes / patterns to skip (we never compete with bots)
+BOT_PATTERNS=("[bot]" "-bot" "dependabot" "renovate" "github-actions")
+
+mkdir -p "$STATE_DIR" "$(dirname "$LOG_FILE")"
+
+# ============================================================================
+# Logging
+# ============================================================================
+
+log_msg() {
+	local level="$1"
+	shift
+	local msg="$*"
+	local ts
+	ts=$(date -u '+%Y-%m-%dT%H:%M:%SZ')
+	printf '%s %s %s\n' "$ts" "$level" "$msg" >>"$LOG_FILE"
+	return 0
+}
+
+# ============================================================================
+# Helpers
+# ============================================================================
+
+# Return 0 if login matches a bot pattern.
+_is_bot() {
+	local login="$1"
+	local pattern
+	for pattern in "${BOT_PATTERNS[@]}"; do
+		if [[ "$login" == *"$pattern"* ]]; then
+			return 0
+		fi
+	done
+	return 1
+}
+
+# Get our own GitHub login.
+_self_login() {
+	gh api user --jq '.login' 2>/dev/null || echo ""
+	return 0
+}
+
+# List pulse-enabled repos with GitHub remotes from repos.json.
+# Output: one slug per line.
+_list_pulse_repos() {
+	if [[ ! -f "$REPOS_JSON" ]]; then
+		return 0
+	fi
+	jq -r '.initialized_repos[]
+		| select(.pulse == true)
+		| select(.local_only != true)
+		| select(.slug != null and .slug != "")
+		| .slug' "$REPOS_JSON" 2>/dev/null || true
+	return 0
+}
+
+# Convert a GitHub login to its DISPATCH_OVERRIDE_<UPPER> variable name.
+_login_to_var() {
+	local login="$1"
+	printf '%s' "$login" | tr 'a-z-' 'A-Z_'
+	return 0
+}
+
+# Sanitize a single value for shell config. Keep simple alnum + a few safe chars.
+_sanitize_action() {
+	local v="$1"
+	case "$v" in
+		ignore | honour | warn) printf '%s' "$v" ;;
+		*) printf '%s' "$ACTION_HONOUR" ;;
+	esac
+	return 0
+}
+
+# ============================================================================
+# Observation
+# ============================================================================
+
+# For a given peer, count active claims and worker PRs in window.
+# Outputs JSON: {"login": ..., "active_claims": N, "worker_prs": N, "interactive_prs": N}
+_observe_peer() {
+	local login="$1"
+	local repo="$2"
+	local since_iso="$3"
+
+	local active_claims=0
+	local worker_prs=0
+	local interactive_prs=0
+
+	# Active claims: open issues currently assigned to peer.
+	# (We don't filter by label here — any open assignment is the signal.)
+	local claims_json
+	claims_json=$(gh issue list --repo "$repo" --assignee "$login" --state open \
+		--limit 100 --json number 2>/dev/null || echo '[]')
+	active_claims=$(printf '%s' "$claims_json" | jq 'length' 2>/dev/null || echo 0)
+
+	# Worker PRs merged in window (peer is author + origin:worker label).
+	local worker_json
+	worker_json=$(gh pr list --repo "$repo" --author "$login" --state merged \
+		--label origin:worker --limit 50 \
+		--json number,mergedAt 2>/dev/null || echo '[]')
+	worker_prs=$(printf '%s' "$worker_json" | jq --arg since "$since_iso" \
+		'[.[] | select(.mergedAt > $since)] | length' 2>/dev/null || echo 0)
+
+	# Interactive PRs (informational only — never triggers ignore).
+	local interactive_json
+	interactive_json=$(gh pr list --repo "$repo" --author "$login" --state merged \
+		--label origin:interactive --limit 50 \
+		--json number,mergedAt 2>/dev/null || echo '[]')
+	interactive_prs=$(printf '%s' "$interactive_json" | jq --arg since "$since_iso" \
+		'[.[] | select(.mergedAt > $since)] | length' 2>/dev/null || echo 0)
+
+	jq -nc \
+		--arg login "$login" \
+		--arg repo "$repo" \
+		--argjson active_claims "$active_claims" \
+		--argjson worker_prs "$worker_prs" \
+		--argjson interactive_prs "$interactive_prs" \
+		'{login: $login, repo: $repo,
+		  active_claims: $active_claims,
+		  worker_prs: $worker_prs,
+		  interactive_prs: $interactive_prs}'
+	return 0
+}
+
+# Discover all peers across all pulse-enabled repos.
+# Outputs JSON array: [{"login": ..., "active_claims": N, ...}, ...]
+# Aggregated across repos (sums active_claims, worker_prs, interactive_prs).
+discover_and_observe() {
+	local self_login since_iso
+	self_login="$(_self_login)"
+	# Compute since timestamp
+	since_iso=$(date -u -v "-${WINDOW_HOURS}H" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null ||
+		date -u -d "${WINDOW_HOURS} hours ago" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null ||
+		echo "1970-01-01T00:00:00Z")
+
+	log_msg INFO "discover_and_observe: self=$self_login window_since=$since_iso"
+
+	local -a observations=()
+	local repo
+
+	while IFS= read -r repo; do
+		[[ -z "$repo" ]] && continue
+		log_msg DEBUG "scanning repo=$repo"
+
+		# Find all logins that have authored merged PRs OR have active assignments
+		# in this repo over the window. Both populated peers and silent peers
+		# (claims but no PRs) are surfaced.
+
+		local peer_logins=()
+
+		# From assignees on open issues
+		local assigned_json
+		assigned_json=$(gh issue list --repo "$repo" --state open \
+			--limit 200 --json assignees 2>/dev/null || echo '[]')
+		while IFS= read -r login; do
+			[[ -z "$login" ]] && continue
+			[[ "$login" == "$self_login" ]] && continue
+			_is_bot "$login" && continue
+			peer_logins+=("$login")
+		done < <(printf '%s' "$assigned_json" |
+			jq -r '.[].assignees[].login' 2>/dev/null | sort -u)
+
+		# From recent merged PR authors
+		local pr_json
+		pr_json=$(gh pr list --repo "$repo" --state merged --limit 50 \
+			--json author,mergedAt 2>/dev/null || echo '[]')
+		while IFS= read -r login; do
+			[[ -z "$login" ]] && continue
+			[[ "$login" == "$self_login" ]] && continue
+			_is_bot "$login" && continue
+			peer_logins+=("$login")
+		done < <(printf '%s' "$pr_json" |
+			jq -r --arg since "$since_iso" \
+				'.[] | select(.mergedAt > $since) | .author.login' 2>/dev/null | sort -u)
+
+		# Dedupe
+		local unique_peers=()
+		while IFS= read -r p; do
+			[[ -z "$p" ]] && continue
+			unique_peers+=("$p")
+		done < <(printf '%s\n' "${peer_logins[@]:-}" | sort -u)
+
+		local peer
+		for peer in "${unique_peers[@]:-}"; do
+			[[ -z "$peer" ]] && continue
+			local obs
+			obs=$(_observe_peer "$peer" "$repo" "$since_iso")
+			observations+=("$obs")
+		done
+	done < <(_list_pulse_repos)
+
+	# Aggregate across repos by login
+	if [[ ${#observations[@]} -eq 0 ]]; then
+		printf '[]\n'
+		return 0
+	fi
+
+	printf '%s\n' "${observations[@]}" | jq -s '
+		group_by(.login) | map({
+			login: .[0].login,
+			active_claims: (map(.active_claims) | add),
+			worker_prs: (map(.worker_prs) | add),
+			interactive_prs: (map(.interactive_prs) | add),
+			repos: (map(.repo))
+		})'
+	return 0
+}
+
+# ============================================================================
+# Decision logic + hysteresis
+# ============================================================================
+
+# Compute vote for a peer: ignore | honour | keep
+_vote_for_peer() {
+	local active_claims="$1"
+	local worker_prs="$2"
+
+	if [[ "$worker_prs" -ge 1 ]]; then
+		printf '%s' "$ACTION_HONOUR"
+	elif [[ "$active_claims" -ge 1 ]]; then
+		printf '%s' "$ACTION_IGNORE"
+	else
+		printf '%s' "$ACTION_KEEP"
+	fi
+	return 0
+}
+
+# Read state file, return JSON (or empty object if missing).
+_load_state() {
+	if [[ -f "$STATE_FILE" ]]; then
+		cat "$STATE_FILE" 2>/dev/null || echo '{}'
+	else
+		echo '{}'
+	fi
+	return 0
+}
+
+# Apply hysteresis to a peer's new vote. Returns the resolved action:
+# ignore | honour. Updates state in place via stdout (caller saves).
+#
+# Args:
+#   $1 = current state JSON
+#   $2 = login
+#   $3 = new vote (ignore | honour | keep)
+# Output: updated state JSON for this peer
+_apply_hysteresis() {
+	local state_json="$1"
+	local login="$2"
+	local vote="$3"
+
+	# Get existing peer state
+	local peer_state
+	peer_state=$(printf '%s' "$state_json" | jq --arg l "$login" '.[$l] // {}')
+
+	# Existing fields
+	local current_action
+	current_action=$(printf '%s' "$peer_state" | jq -r --arg default "$ACTION_HONOUR" '.current_action // $default')
+	local history_json
+	history_json=$(printf '%s' "$peer_state" | jq -c '.vote_history // []')
+
+	# "keep" vote: preserve current state, append to history (truncated)
+	if [[ "$vote" == "keep" ]]; then
+		# Append "keep" but don't change action
+		history_json=$(printf '%s' "$history_json" |
+			jq --arg v "$vote" --argjson max "$HYSTERESIS" \
+				'. + [$v] | if length > ($max + 2) then .[(-($max + 2)):] else . end')
+		jq -nc --arg l "$login" \
+			--arg ca "$current_action" \
+			--argjson h "$history_json" \
+			--arg ts "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+			'{($l): {current_action: $ca, vote_history: $h, last_observed: $ts}}'
+		return 0
+	fi
+
+	# Append the new vote, keep last (HYSTERESIS+2) entries
+	history_json=$(printf '%s' "$history_json" |
+		jq --arg v "$vote" --argjson max "$HYSTERESIS" \
+			'. + [$v] | if length > ($max + 2) then .[(-($max + 2)):] else . end')
+
+	# Determine if we should flip: last HYSTERESIS entries all match `vote`,
+	# and `vote` differs from `current_action`. Use `-r` so jq emits the raw
+	# string `yes`/`no`, not the JSON-quoted form `"yes"`/`"no"` — the bash
+	# comparison below would otherwise never match.
+	local should_flip
+	should_flip=$(printf '%s' "$history_json" |
+		jq -r --arg v "$vote" --argjson n "$HYSTERESIS" --arg ca "$current_action" \
+			'if length >= $n and (.[(-$n):] | all(. == $v)) and ($v != $ca) then "yes" else "no" end')
+
+	local new_action="$current_action"
+	if [[ "$should_flip" == "yes" ]]; then
+		new_action="$vote"
+		log_msg INFO "FLIP: peer=$login action=$current_action -> $new_action (last $HYSTERESIS votes all '$vote')"
+	fi
+
+	jq -nc --arg l "$login" \
+		--arg ca "$new_action" \
+		--argjson h "$history_json" \
+		--arg ts "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" \
+		'{($l): {current_action: $ca, vote_history: $h, last_observed: $ts}}'
+	return 0
+}
+
+# ============================================================================
+# Override config rewrite
+# ============================================================================
+
+# Rewrite the managed section of dispatch-override.conf based on state.
+# Manual entries above the BEGIN marker are preserved verbatim. Anything
+# between BEGIN and END markers is replaced. Anything after END is preserved.
+_rewrite_override_config() {
+	local state_json="$1"
+
+	# Build the managed section content
+	local managed_lines=""
+	managed_lines+="${MARKER_BEGIN}"$'\n'
+	managed_lines+="# Auto-updated by peer-productivity-monitor every 30 min."$'\n'
+	managed_lines+="# Last rewrite: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"$'\n'
+	managed_lines+="# To pin a peer manually, add an entry ABOVE this marker — manual"$'\n'
+	managed_lines+="# entries take precedence and are never overwritten."$'\n'
+	managed_lines+=""$'\n'
+
+	# Extract per-peer entries
+	local peers
+	peers=$(printf '%s' "$state_json" | jq -r 'keys[]' 2>/dev/null || true)
+	if [[ -n "$peers" ]]; then
+		while IFS= read -r peer; do
+			[[ -z "$peer" ]] && continue
+			local action
+			action=$(printf '%s' "$state_json" | jq -r --arg l "$peer" --arg default "$ACTION_HONOUR" '.[$l].current_action // $default')
+			action=$(_sanitize_action "$action")
+			# Skip honour entries — honour is the implicit default, writing
+			# it would just clutter the config.
+			if [[ "$action" == "$ACTION_HONOUR" ]]; then
+				continue
+			fi
+			local var
+			var=$(_login_to_var "$peer")
+			managed_lines+="DISPATCH_OVERRIDE_${var}=\"${action}\""$'\n'
+		done <<<"$peers"
+	fi
+	managed_lines+="${MARKER_END}"$'\n'
+
+	# Compose the new file: preserve content before BEGIN, replace BEGIN..END,
+	# preserve content after END.
+	local existing_pre existing_post existing_full
+	if [[ -f "$OVERRIDE_CONF" ]]; then
+		existing_full=$(cat "$OVERRIDE_CONF")
+	else
+		existing_full=""
+	fi
+
+	if printf '%s' "$existing_full" | grep -qF "$MARKER_BEGIN"; then
+		# Replace existing managed section
+		existing_pre=$(printf '%s' "$existing_full" | awk -v m="$MARKER_BEGIN" '
+			$0 == m { exit }
+			{ print }
+		')
+		existing_post=$(printf '%s' "$existing_full" | awk -v m="$MARKER_END" '
+			BEGIN { found=0 }
+			$0 == m { found=1; next }
+			found == 1 { print }
+		')
+	else
+		# No managed section yet — append
+		existing_pre="$existing_full"
+		existing_post=""
+	fi
+	# Ensure separator newline if existing_pre is non-empty and lacks trailing
+	# newline — applies whether we are appending or replacing. Command
+	# substitution always strips the trailing newline, so without this guard
+	# the BEGIN marker would be glued onto the last preserved line on every
+	# iteration after the first (idempotency failure).
+	if [[ -n "$existing_pre" ]] && [[ "${existing_pre: -1}" != $'\n' ]]; then
+		existing_pre+=$'\n'
+	fi
+
+	# Compose final
+	local new_content
+	new_content="${existing_pre}${managed_lines}${existing_post}"
+
+	# Write atomically
+	mkdir -p "$(dirname "$OVERRIDE_CONF")"
+	local tmp
+	tmp=$(mktemp)
+	printf '%s' "$new_content" >"$tmp"
+	mv "$tmp" "$OVERRIDE_CONF"
+	chmod 600 "$OVERRIDE_CONF" 2>/dev/null || true
+	log_msg INFO "rewrote managed section: peers_in_state=$(printf '%s' "$state_json" | jq 'keys | length')"
+	return 0
+}
+
+# ============================================================================
+# Public commands
+# ============================================================================
+
+cmd_observe() {
+	if [[ "${AIDEVOPS_PEER_MONITOR_DISABLE:-0}" == "1" ]]; then
+		log_msg INFO "AIDEVOPS_PEER_MONITOR_DISABLE=1 — skipping cycle"
+		return 0
+	fi
+
+	log_msg INFO "=== observe cycle start ==="
+
+	local observations
+	observations=$(discover_and_observe)
+	local count
+	count=$(printf '%s' "$observations" | jq 'length' 2>/dev/null || echo 0)
+
+	if [[ "$count" -eq 0 ]]; then
+		log_msg INFO "no peers found across pulse-enabled repos"
+		return 0
+	fi
+
+	log_msg INFO "found $count peer(s) to evaluate"
+
+	# Load existing state
+	local state_json
+	state_json=$(_load_state)
+
+	# Apply hysteresis per peer, accumulating updated state
+	local updated_state="$state_json"
+	while IFS= read -r obs; do
+		[[ -z "$obs" ]] && continue
+		local login active_claims worker_prs interactive_prs
+		login=$(printf '%s' "$obs" | jq -r '.login')
+		active_claims=$(printf '%s' "$obs" | jq -r '.active_claims')
+		worker_prs=$(printf '%s' "$obs" | jq -r '.worker_prs')
+		interactive_prs=$(printf '%s' "$obs" | jq -r '.interactive_prs')
+
+		local vote
+		vote=$(_vote_for_peer "$active_claims" "$worker_prs")
+		log_msg INFO "peer=$login active_claims=$active_claims worker_prs=$worker_prs interactive_prs=$interactive_prs vote=$vote"
+
+		local peer_state
+		peer_state=$(_apply_hysteresis "$updated_state" "$login" "$vote")
+		# Merge peer_state into updated_state
+		updated_state=$(printf '%s\n%s' "$updated_state" "$peer_state" |
+			jq -s '.[0] * .[1]')
+	done < <(printf '%s' "$observations" | jq -c '.[]')
+
+	# Save updated state
+	if [[ "$DRY_RUN" == "1" ]]; then
+		log_msg INFO "DRY_RUN — not writing state or override config"
+		printf '%s\n' "$updated_state" | jq .
+		return 0
+	fi
+
+	printf '%s\n' "$updated_state" | jq . >"$STATE_FILE"
+	chmod 600 "$STATE_FILE" 2>/dev/null || true
+
+	# Rewrite override config
+	_rewrite_override_config "$updated_state"
+
+	log_msg INFO "=== observe cycle complete ==="
+	return 0
+}
+
+cmd_report() {
+	if [[ ! -f "$STATE_FILE" ]]; then
+		printf 'No state yet. Run: peer-productivity-monitor.sh observe\n'
+		return 0
+	fi
+	printf '%bPeer productivity state%b (%s)\n' "$BLUE" "$NC" "$STATE_FILE"
+	printf '%-25s %-10s %-3s votes\n' "PEER" "ACTION" "N"
+	jq -r 'to_entries[] | [.key, .value.current_action, (.value.vote_history | length), (.value.vote_history | join(","))] | @tsv' "$STATE_FILE" |
+		while IFS=$'\t' read -r peer action n votes; do
+			local color="$NC"
+			[[ "$action" == "$ACTION_IGNORE" ]] && color="$YELLOW"
+			[[ "$action" == "$ACTION_HONOUR" ]] && color="$GREEN"
+			printf '%-25s %b%-10s%b %-3s %s\n' "$peer" "$color" "$action" "$NC" "$n" "$votes"
+		done
+	return 0
+}
+
+cmd_dry_run() {
+	AIDEVOPS_PEER_MONITOR_DRY_RUN=1 DRY_RUN=1 cmd_observe
+	return 0
+}
+
+cmd_reset() {
+	local peer="${1:-}"
+	if [[ -z "$peer" ]]; then
+		printf 'Usage: peer-productivity-monitor.sh reset <peer-login>\n' >&2
+		return 1
+	fi
+	if [[ ! -f "$STATE_FILE" ]]; then
+		printf 'No state file at %s\n' "$STATE_FILE"
+		return 0
+	fi
+	local tmp
+	tmp=$(mktemp)
+	jq --arg p "$peer" 'del(.[$p])' "$STATE_FILE" >"$tmp" && mv "$tmp" "$STATE_FILE"
+	log_msg INFO "reset state for peer=$peer"
+	printf 'Reset state for %s\n' "$peer"
+	return 0
+}
+
+cmd_help() {
+	cat <<EOF
+peer-productivity-monitor.sh — adaptive cross-runner dispatch coordination (t2932)
+
+Usage:
+  peer-productivity-monitor.sh observe       # one observation cycle
+  peer-productivity-monitor.sh report        # show current state + decisions
+  peer-productivity-monitor.sh dry-run       # observe without writing config
+  peer-productivity-monitor.sh reset <peer>  # reset state for a peer
+  peer-productivity-monitor.sh help
+
+Env:
+  AIDEVOPS_PEER_MONITOR_DISABLE=1     # short-circuit, do nothing
+  AIDEVOPS_PEER_MONITOR_DRY_RUN=1     # observe + log, don't write config
+  AIDEVOPS_PEER_MONITOR_WINDOW_H=24   # rolling window in hours (default 24)
+  AIDEVOPS_PEER_MONITOR_HYSTERESIS=3  # vote count for flip (default 3)
+
+Config file:
+  $OVERRIDE_CONF
+  Manual entries above the BEGIN marker take precedence.
+
+Logs:
+  $LOG_FILE
+EOF
+	return 0
+}
+
+# ============================================================================
+# Main
+# ============================================================================
+
+main() {
+	local cmd="${1:-help}"
+	shift || true
+	case "$cmd" in
+		observe) cmd_observe "$@" ;;
+		report) cmd_report "$@" ;;
+		dry-run | dry_run) cmd_dry_run "$@" ;;
+		reset) cmd_reset "$@" ;;
+		help | --help | -h) cmd_help ;;
+		*)
+			printf 'Error: unknown command: %s\n' "$cmd" >&2
+			cmd_help
+			return 1
+			;;
+	esac
+	return 0
+}
+
+main "$@"

--- a/setup-modules/schedulers.sh
+++ b/setup-modules/schedulers.sh
@@ -2399,3 +2399,126 @@ setup_repo_aidevops_health() {
 	fi
 	return 0
 }
+
+# ============================================================================
+# Peer productivity monitor (t2932)
+# ============================================================================
+#
+# Adaptive cross-runner dispatch coordination: observes peer GitHub activity
+# every 30 min and updates ~/.config/aidevops/dispatch-override.conf to
+# `ignore` peers whose pulse is broken (claims issues but never PRs) and
+# back to `honour` when they recover. Self-healing across the ecosystem —
+# each runner observes peers independently, no central coordinator needed.
+# Manual entries in dispatch-override.conf above the auto-managed marker
+# always take precedence.
+
+# Install peer-productivity-monitor launchd plist (macOS).
+# Args: $1=label $2=script $3=log_dir
+_install_peer_productivity_monitor_launchd() {
+	local ppm_label="$1"
+	local ppm_script="$2"
+	local _ppm_log_dir="$3"
+	local ppm_plist="$HOME/Library/LaunchAgents/${ppm_label}.plist"
+
+	local _xml_ppm_script _xml_ppm_home _xml_ppm_log_dir
+	_xml_ppm_script=$(_xml_escape "$ppm_script")
+	_xml_ppm_home=$(_xml_escape "$HOME")
+	_xml_ppm_log_dir=$(_xml_escape "$_ppm_log_dir")
+
+	local ppm_plist_content
+	ppm_plist_content=$(
+		cat <<PPM_PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>${ppm_label}</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>$(_xml_escape "$(_resolve_modern_bash)")</string>
+		<string>${_xml_ppm_script}</string>
+		<string>observe</string>
+	</array>
+	<key>StartInterval</key>
+	<integer>1800</integer>
+	<key>StandardOutPath</key>
+	<string>${_xml_ppm_log_dir}/peer-productivity-launchd.log</string>
+	<key>StandardErrorPath</key>
+	<string>${_xml_ppm_log_dir}/peer-productivity-launchd.log</string>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>PATH</key>
+		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+		<key>HOME</key>
+		<string>${_xml_ppm_home}</string>
+	</dict>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<false/>
+	<key>ProcessType</key>
+	<string>Background</string>
+	<key>LowPriorityBackgroundIO</key>
+	<true/>
+	<key>Nice</key>
+	<integer>10</integer>
+</dict>
+</plist>
+PPM_PLIST
+	)
+
+	if _launchd_install_if_changed "$ppm_label" "$ppm_plist" "$ppm_plist_content"; then
+		print_info "Peer productivity monitor enabled (launchd, every 30 min)"
+	else
+		print_warning "Failed to load peer-productivity-monitor LaunchAgent"
+	fi
+	return 0
+}
+
+# Install peer-productivity-monitor via systemd or cron (Linux).
+# Args: $1=script path, $2=log dir
+_install_peer_productivity_monitor_linux() {
+	local ppm_script="$1"
+	local _ppm_log_dir="$2"
+	local ppm_systemd="aidevops-peer-productivity-monitor"
+	_install_scheduler_linux \
+		"$ppm_systemd" \
+		"aidevops: peer-productivity-monitor" \
+		"*/30 * * * *" \
+		"\"${ppm_script}\" observe" \
+		"1800" \
+		"${_ppm_log_dir}/peer-productivity-launchd.log" \
+		"" \
+		"Peer productivity monitor enabled (every 30 min)" \
+		"Failed to install peer-productivity-monitor scheduler" \
+		"true" \
+		"true"
+	return 0
+}
+
+# Setup peer-productivity-monitor (t2932) — observes peer GitHub activity
+# every 30 min and updates ~/.config/aidevops/dispatch-override.conf so the
+# local pulse competes with broken peers and collaborates with healthy ones.
+# Manual entries in dispatch-override.conf above the auto-managed marker
+# always take precedence.
+setup_peer_productivity_monitor() {
+	local ppm_script="$HOME/.aidevops/agents/scripts/peer-productivity-monitor.sh"
+	local ppm_label="sh.aidevops.peer-productivity-monitor"
+	if ! [[ -x "$ppm_script" ]]; then
+		return 0
+	fi
+
+	# Reuse contribution-watch's log-dir resolver (same logic, same config key).
+	local _ppm_log_dir
+	_ppm_log_dir=$(_resolve_cw_log_dir) || return 1
+	mkdir -p "$_ppm_log_dir"
+
+	# Install/update scheduled runner
+	if [[ "$(uname -s)" == "Darwin" ]]; then
+		_install_peer_productivity_monitor_launchd "$ppm_label" "$ppm_script" "$_ppm_log_dir"
+	else
+		_install_peer_productivity_monitor_linux "$ppm_script" "$_ppm_log_dir"
+	fi
+	return 0
+}

--- a/setup.sh
+++ b/setup.sh
@@ -1275,6 +1275,11 @@ _setup_noninteractive_schedulers() {
 	if _should_setup_noninteractive_scheduler "Pulse merge routine" "sh.aidevops.pulse-merge-routine" "aidevops: pulse-merge-routine" "aidevops-pulse-merge-routine"; then
 		setup_pulse_merge_routine
 	fi
+	# t2932 (GH#21125): peer productivity monitor — adaptive cross-runner
+	# dispatch coordination, runs every 30 min.
+	if _should_setup_noninteractive_scheduler "Peer productivity monitor" "sh.aidevops.peer-productivity-monitor" "aidevops: peer-productivity-monitor" "aidevops-peer-productivity-monitor"; then
+		setup_peer_productivity_monitor
+	fi
 	# Repo sync handles non-interactive mode internally (systemd detection fixed in GH#17861)
 	setup_repo_sync
 	# r914 repo-aidevops-health — daily drift keeper (t2366)

--- a/tests/test-peer-productivity-monitor.sh
+++ b/tests/test-peer-productivity-monitor.sh
@@ -1,0 +1,455 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-peer-productivity-monitor.sh
+#
+# Unit tests for peer-productivity-monitor.sh (t2932). Covers the pure-logic
+# helpers that don't touch the GitHub API:
+#   - bot detection (_is_bot)
+#   - login → variable name conversion (_login_to_var)
+#   - action sanitization (_sanitize_action)
+#   - vote computation (_vote_for_peer)
+#   - hysteresis (_apply_hysteresis): flap-prevention, flip-after-3-cycles,
+#     keep-vote preserves current action, manual-override sticky
+#   - dispatch-override.conf rewrite preserves manual entries above marker
+#   - default action for unknown peers (honour, since "ignore" requires
+#     active claims observed in the API path)
+#
+# Uses isolated temp HOME to avoid touching production state.
+#
+# Usage: bash tests/test-peer-productivity-monitor.sh
+# Exit codes: 0 = all pass, 1 = failures found
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT_UNDER_TEST="$REPO_DIR/.agents/scripts/peer-productivity-monitor.sh"
+
+# --- Test framework ---
+PASS_COUNT=0
+FAIL_COUNT=0
+TOTAL_COUNT=0
+
+pass() {
+	PASS_COUNT=$((PASS_COUNT + 1))
+	TOTAL_COUNT=$((TOTAL_COUNT + 1))
+	printf "  \033[0;32mPASS\033[0m %s\n" "$1"
+	return 0
+}
+
+fail() {
+	FAIL_COUNT=$((FAIL_COUNT + 1))
+	TOTAL_COUNT=$((TOTAL_COUNT + 1))
+	printf "  \033[0;31mFAIL\033[0m %s\n" "$1"
+	[[ -n "${2:-}" ]] && printf "       %s\n" "$2"
+	return 0
+}
+
+section() {
+	echo ""
+	printf "\033[1m=== %s ===\033[0m\n" "$1"
+	return 0
+}
+
+# --- Isolated env ---
+TEST_DIR=$(mktemp -d)
+HOME_BACKUP="$HOME"
+export HOME="$TEST_DIR/home"
+mkdir -p "$HOME/.aidevops/state" "$HOME/.aidevops/logs" "$HOME/.config/aidevops"
+
+# shellcheck disable=SC2064
+trap "HOME='$HOME_BACKUP'; rm -rf '$TEST_DIR'" EXIT
+
+# --- Prereq ---
+if [[ ! -x "$SCRIPT_UNDER_TEST" ]]; then
+	echo "ERROR: $SCRIPT_UNDER_TEST not executable"
+	exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+	echo "ERROR: jq required for tests"
+	exit 1
+fi
+
+# Source script with main() stripped so we can call helpers directly. The
+# script's `set -euo pipefail` would otherwise abort the test runner on the
+# first helper that returns non-zero (e.g. `_is_bot alice` → 1). Restore the
+# permissive mode after sourcing.
+eval "$(sed 's/^main "$@"$//' "$SCRIPT_UNDER_TEST")"
+set +e
+set +u
+set +o pipefail
+
+# ============================================================================
+section "Bot detection (_is_bot)"
+# ============================================================================
+
+test_bot_detection() {
+	local cases=(
+		"dependabot[bot]:0"
+		"renovate[bot]:0"
+		"github-actions[bot]:0"
+		"some-bot:0"
+		"my-cool-bot:0"
+		"alice:1"
+		"alex-solovyev:1"
+		"marcusquinn:1"
+	)
+	for c in "${cases[@]}"; do
+		local login="${c%:*}"
+		local expected="${c##*:}"
+		_is_bot "$login"
+		local actual=$?
+		if [[ "$actual" == "$expected" ]]; then
+			pass "_is_bot $login = $actual"
+		else
+			fail "_is_bot $login: expected $expected, got $actual"
+		fi
+	done
+	return 0
+}
+test_bot_detection
+
+# ============================================================================
+section "Login → variable name (_login_to_var)"
+# ============================================================================
+
+test_login_to_var() {
+	local result
+	result=$(_login_to_var "alex-solovyev")
+	if [[ "$result" == "ALEX_SOLOVYEV" ]]; then
+		pass "alex-solovyev → ALEX_SOLOVYEV"
+	else
+		fail "alex-solovyev: expected ALEX_SOLOVYEV, got $result"
+	fi
+
+	result=$(_login_to_var "marcusquinn")
+	if [[ "$result" == "MARCUSQUINN" ]]; then
+		pass "marcusquinn → MARCUSQUINN"
+	else
+		fail "marcusquinn: expected MARCUSQUINN, got $result"
+	fi
+
+	result=$(_login_to_var "user-with-many-dashes")
+	if [[ "$result" == "USER_WITH_MANY_DASHES" ]]; then
+		pass "multi-dash login converted"
+	else
+		fail "multi-dash: got $result"
+	fi
+	return 0
+}
+test_login_to_var
+
+# ============================================================================
+section "Action sanitization (_sanitize_action)"
+# ============================================================================
+
+test_sanitize_action() {
+	local cases=(
+		"ignore:ignore"
+		"honour:honour"
+		"warn:warn"
+		"; rm -rf /:honour"
+		"\${EVIL}:honour"
+		"random_value:honour"
+		":honour"
+	)
+	for c in "${cases[@]}"; do
+		local input="${c%:*}"
+		local expected="${c##*:}"
+		local actual
+		actual=$(_sanitize_action "$input")
+		if [[ "$actual" == "$expected" ]]; then
+			pass "_sanitize_action '$input' = '$actual'"
+		else
+			fail "_sanitize_action '$input': expected '$expected', got '$actual'"
+		fi
+	done
+	return 0
+}
+test_sanitize_action
+
+# ============================================================================
+section "Vote computation (_vote_for_peer)"
+# ============================================================================
+
+test_vote_for_peer() {
+	local cases=(
+		# active_claims:worker_prs:expected_vote
+		"0:0:keep"      # no signal → keep
+		"5:0:ignore"    # claims but no PRs → broken pulse → ignore
+		"0:1:honour"    # no claims, 1 PR → recovered → honour
+		"5:1:honour"    # claims AND PRs → working, just slow → honour
+		"10:3:honour"   # productive peer → honour
+		"3:0:ignore"    # silent peer with claims → ignore
+	)
+	for c in "${cases[@]}"; do
+		IFS=: read -r ac wp expected <<<"$c"
+		local actual
+		actual=$(_vote_for_peer "$ac" "$wp")
+		if [[ "$actual" == "$expected" ]]; then
+			pass "vote(claims=$ac, prs=$wp) = $actual"
+		else
+			fail "vote(claims=$ac, prs=$wp): expected $expected, got $actual"
+		fi
+	done
+	return 0
+}
+test_vote_for_peer
+
+# ============================================================================
+section "Hysteresis (_apply_hysteresis)"
+# ============================================================================
+
+# Helper to extract a peer's current_action from the merged state JSON returned
+# by _apply_hysteresis (single-peer slice).
+_extract_action() {
+	local peer_state="$1"
+	local login="$2"
+	printf '%s' "$peer_state" | jq -r --arg l "$login" '.[$l].current_action'
+	return 0
+}
+
+_extract_history() {
+	local peer_state="$1"
+	local login="$2"
+	printf '%s' "$peer_state" | jq -r --arg l "$login" '.[$l].vote_history | join(",")'
+	return 0
+}
+
+test_hysteresis_first_observation_no_flip() {
+	# First "ignore" vote on a fresh peer (default current_action=honour) — must
+	# NOT flip yet. History gets one entry, but current_action stays honour.
+	local state='{}'
+	local result
+	result=$(_apply_hysteresis "$state" "alice" "ignore")
+	local action history
+	action=$(_extract_action "$result" "alice")
+	history=$(_extract_history "$result" "alice")
+	if [[ "$action" == "honour" ]] && [[ "$history" == "ignore" ]]; then
+		pass "first ignore vote: action=honour history=ignore"
+	else
+		fail "first ignore vote: action=$action history=$history"
+	fi
+	return 0
+}
+test_hysteresis_first_observation_no_flip
+
+test_hysteresis_three_consecutive_flips() {
+	# Three consecutive "ignore" votes flip honour → ignore.
+	local state='{}'
+	local r1 r2 r3
+	r1=$(_apply_hysteresis "$state" "alice" "ignore")
+	state=$(printf '%s\n%s' "$state" "$r1" | jq -s '.[0] * .[1]')
+	r2=$(_apply_hysteresis "$state" "alice" "ignore")
+	state=$(printf '%s\n%s' "$state" "$r2" | jq -s '.[0] * .[1]')
+	r3=$(_apply_hysteresis "$state" "alice" "ignore")
+	local action history
+	action=$(_extract_action "$r3" "alice")
+	history=$(_extract_history "$r3" "alice")
+	if [[ "$action" == "ignore" ]] && [[ "$history" == "ignore,ignore,ignore" ]]; then
+		pass "3x ignore flips honour → ignore"
+	else
+		fail "3x ignore: action=$action history=$history"
+	fi
+	return 0
+}
+test_hysteresis_three_consecutive_flips
+
+test_hysteresis_flap_prevention() {
+	# 2 ignore + 1 honour + 2 ignore should NOT flip — the run isn't 3 in a row.
+	local state='{}'
+	local r
+	for vote in ignore ignore honour ignore ignore; do
+		r=$(_apply_hysteresis "$state" "alice" "$vote")
+		state=$(printf '%s\n%s' "$state" "$r" | jq -s '.[0] * .[1]')
+	done
+	local action history
+	action=$(_extract_action "$state" "alice")
+	history=$(_extract_history "$state" "alice")
+	if [[ "$action" == "honour" ]]; then
+		pass "interleaved votes don't flip (action=honour, history=$history)"
+	else
+		fail "interleaved votes flipped early: action=$action history=$history"
+	fi
+	return 0
+}
+test_hysteresis_flap_prevention
+
+test_hysteresis_recovery_flip_back() {
+	# Peer ignored, then 3 honour votes restore honour.
+	local state='{"alice":{"current_action":"ignore","vote_history":["ignore","ignore","ignore"],"last_observed":"2026-01-01T00:00:00Z"}}'
+	local r
+	for vote in honour honour honour; do
+		r=$(_apply_hysteresis "$state" "alice" "$vote")
+		state=$(printf '%s\n%s' "$state" "$r" | jq -s '.[0] * .[1]')
+	done
+	local action
+	action=$(_extract_action "$state" "alice")
+	if [[ "$action" == "honour" ]]; then
+		pass "3x honour restores ignored peer to honour"
+	else
+		fail "recovery: expected honour, got $action"
+	fi
+	return 0
+}
+test_hysteresis_recovery_flip_back
+
+test_hysteresis_keep_preserves_action() {
+	# A "keep" vote should not change current_action even if it's the only
+	# vote so far.
+	local state='{}'
+	local r
+	r=$(_apply_hysteresis "$state" "bob" "keep")
+	local action
+	action=$(_extract_action "$r" "bob")
+	if [[ "$action" == "honour" ]]; then
+		pass "keep vote on fresh peer leaves action=honour"
+	else
+		fail "keep vote: expected honour, got $action"
+	fi
+
+	# Keep votes on an already-ignored peer must not flip back.
+	state='{"bob":{"current_action":"ignore","vote_history":["ignore","ignore","ignore"],"last_observed":"2026-01-01T00:00:00Z"}}'
+	for _ in 1 2 3 4 5; do
+		r=$(_apply_hysteresis "$state" "bob" "keep")
+		state=$(printf '%s\n%s' "$state" "$r" | jq -s '.[0] * .[1]')
+	done
+	action=$(_extract_action "$state" "bob")
+	if [[ "$action" == "ignore" ]]; then
+		pass "5x keep on ignored peer preserves ignore"
+	else
+		fail "keep on ignored: expected ignore, got $action"
+	fi
+	return 0
+}
+test_hysteresis_keep_preserves_action
+
+# ============================================================================
+section "Override config rewrite preserves manual entries"
+# ============================================================================
+
+test_rewrite_preserves_manual_entries() {
+	local conf="$HOME/.config/aidevops/dispatch-override.conf"
+	# Manual content above (and after) the marker block must survive rewrite.
+	cat >"$conf" <<'EOF'
+# User's manual config
+DISPATCH_OVERRIDE_ENABLED=true
+DISPATCH_OVERRIDE_MY_TRUSTED_PEER="honour"
+EOF
+
+	# Override the OVERRIDE_CONF inside the sourced script for this test
+	OVERRIDE_CONF="$conf"
+
+	local state='{"alice":{"current_action":"ignore","vote_history":["ignore","ignore","ignore"],"last_observed":"2026-01-01T00:00:00Z"}}'
+	_rewrite_override_config "$state"
+
+	if grep -qF 'DISPATCH_OVERRIDE_MY_TRUSTED_PEER="honour"' "$conf"; then
+		pass "manual entry above marker preserved"
+	else
+		fail "manual entry lost"
+	fi
+	if grep -qF 'DISPATCH_OVERRIDE_ENABLED=true' "$conf"; then
+		pass "DISPATCH_OVERRIDE_ENABLED preserved"
+	else
+		fail "DISPATCH_OVERRIDE_ENABLED lost"
+	fi
+	if grep -qF 'DISPATCH_OVERRIDE_ALICE="ignore"' "$conf"; then
+		pass "auto-managed entry written"
+	else
+		fail "auto-managed entry missing"
+	fi
+	if grep -qF 'BEGIN auto-managed by peer-productivity-monitor' "$conf"; then
+		pass "BEGIN marker present"
+	else
+		fail "BEGIN marker missing"
+	fi
+	return 0
+}
+test_rewrite_preserves_manual_entries
+
+test_rewrite_idempotent() {
+	# Running rewrite twice must produce the same content for the same state
+	# (modulo the timestamp comment line).
+	local conf="$HOME/.config/aidevops/dispatch-override.conf"
+	cat >"$conf" <<'EOF'
+DISPATCH_OVERRIDE_ENABLED=true
+EOF
+	OVERRIDE_CONF="$conf"
+
+	local state='{"alice":{"current_action":"ignore","vote_history":["ignore","ignore","ignore"],"last_observed":"2026-01-01T00:00:00Z"}}'
+	_rewrite_override_config "$state"
+	local first_rewrite
+	first_rewrite=$(grep -v "Last rewrite:" "$conf")
+	_rewrite_override_config "$state"
+	local second_rewrite
+	second_rewrite=$(grep -v "Last rewrite:" "$conf")
+	if [[ "$first_rewrite" == "$second_rewrite" ]]; then
+		pass "rewrite is idempotent (modulo timestamp)"
+	else
+		fail "rewrite produces drift"
+	fi
+	return 0
+}
+test_rewrite_idempotent
+
+test_rewrite_drops_honour_entries() {
+	# A peer with current_action=honour should NOT produce a config line
+	# (honour is the implicit default — no need to clutter the file).
+	local conf="$HOME/.config/aidevops/dispatch-override.conf"
+	cat >"$conf" <<'EOF'
+DISPATCH_OVERRIDE_ENABLED=true
+EOF
+	OVERRIDE_CONF="$conf"
+
+	local state='{"alice":{"current_action":"honour","vote_history":["honour","honour","honour"],"last_observed":"2026-01-01T00:00:00Z"}}'
+	_rewrite_override_config "$state"
+	if ! grep -qF 'DISPATCH_OVERRIDE_ALICE' "$conf"; then
+		pass "honour-state peer not written to config"
+	else
+		fail "honour-state peer leaked into config"
+	fi
+	return 0
+}
+test_rewrite_drops_honour_entries
+
+# ============================================================================
+section "CLI smoke (help/report)"
+# ============================================================================
+
+test_cli_help() {
+	if "$SCRIPT_UNDER_TEST" help 2>&1 | grep -q "peer-productivity-monitor"; then
+		pass "help output contains script name"
+	else
+		fail "help output missing"
+	fi
+	return 0
+}
+test_cli_help
+
+test_cli_report_no_state() {
+	# With no state file, report should say so without erroring.
+	rm -f "$HOME/.aidevops/state/peer-productivity-state.json"
+	if "$SCRIPT_UNDER_TEST" report 2>&1 | grep -qiE "no state|state\.json"; then
+		pass "report on empty state returns gracefully"
+	else
+		fail "report on empty state should report missing state"
+	fi
+	return 0
+}
+test_cli_report_no_state
+
+# ============================================================================
+section "Summary"
+# ============================================================================
+
+echo ""
+printf "  Total:   %d\n" "$TOTAL_COUNT"
+printf "  \033[0;32mPassed:  %d\033[0m\n" "$PASS_COUNT"
+if [[ "$FAIL_COUNT" -gt 0 ]]; then
+	printf "  \033[0;31mFailed:  %d\033[0m\n" "$FAIL_COUNT"
+	exit 1
+fi
+echo ""
+echo "All tests passed."
+exit 0


### PR DESCRIPTION
## Summary

Adds **peer-productivity-monitor** (t2932) — a launchd/systemd-scheduled
job (every 30 min) that observes peer GitHub activity and updates
`~/.config/aidevops/dispatch-override.conf` automatically.

When a peer's pulse appears broken (claims issues but never merges
worker PRs in the last 24h), the monitor flips them to `ignore` so this
runner competes for the claim. When the peer recovers (1+ merged
`origin:worker` PR), it flips back to `honour`.

Self-healing across the ecosystem — each runner observes peers
independently. When one runner regresses in a release, every other
runner detects and routes around it within ~30 min, with no central
coordinator and no operator action required.

## Why

Today, broken peer runners poison cross-runner dispatch coordination
for the full 1800s claim TTL. The current mitigation is manual editing
of `dispatch-override.conf` to flip a degraded peer to `ignore`, then
flipping back when they recover. This is reactive operator toil that
scales linearly with the number of peer runners and the frequency of
their regressions. The monitor automates both directions — compete-on-
break, collaborate-on-recovery — and keeps the user-override channel
intact (manual entries above the BEGIN marker are never overwritten).

## How

- **NEW:** `.agents/scripts/peer-productivity-monitor.sh` — core script.
  Subcommands: `observe` (one cycle, called by launchd), `report`
  (state inspection), `dry-run` (observe without writing), `reset
  <peer>` (clear hysteresis state for a peer).
- **NEW:** `.agents/configs/sh.aidevops.peer-productivity-monitor.plist`
  — launchd plist (`StartInterval=1800`, `RunAtLoad=true`, Background,
  Nice 10). Models on `sh.aidevops.pulse-merge-routine.plist`.
- **NEW:** `tests/test-peer-productivity-monitor.sh` — 38 unit tests
  with isolated `$HOME`. Covers bot detection, login slug conversion,
  action sanitization, vote computation, hysteresis flip / recovery /
  flap-prevention, override config rewrite (manual-entry preservation,
  idempotency, honour-state pruning), CLI smoke.
- **EDIT:** `setup-modules/schedulers.sh` — adds
  `setup_peer_productivity_monitor` with macOS (launchd) and Linux
  (systemd/cron) install paths. Models on `setup_pulse_merge_routine`.
- **EDIT:** `setup.sh` — registers the new scheduler in
  `_setup_noninteractive_schedulers` alongside the other 30-min
  scheduled jobs.
- **EDIT:** `.agents/configs/dispatch-override.conf.txt` — documents
  the auto-managed section behaviour, BEGIN/END markers, and the
  manual-override channel.

## Design

- **Counts only `origin:worker` PRs**, never `origin:interactive`. Peer's
  human work never triggers compete mode — matters when a peer's runner
  is broken but they're still merging interactive PRs manually.
- **3-cycle hysteresis** (configurable via
  `AIDEVOPS_PEER_MONITOR_HYSTERESIS`) prevents flapping during transient
  outages. State persists in
  `~/.aidevops/state/peer-productivity-state.json`.
- **Bot accounts** (dependabot, renovate, `*-bot`, github-actions) are
  filtered out — never compete with bots.
- **Honour-state peers are not written** to the config (honour is the
  implicit default).
- **API calls use the existing `gh` PATH shim** — automatically benefits
  from t2574/t2744/t2902 GraphQL→REST routing under rate-limit pressure
  and t2902 instrumentation.

## Verification

- `bash tests/test-peer-productivity-monitor.sh` — all 38 tests pass.
- `shellcheck .agents/scripts/peer-productivity-monitor.sh
  tests/test-peer-productivity-monitor.sh` — clean.
- Pre-commit ratchet (return statements, repeated literals, ShellCheck)
  — clean on the new files; pre-existing setup.sh/schedulers.sh
  warnings unchanged (not blocking).

## Operational notes

- Inspect state: `peer-productivity-monitor.sh report`.
- Disable: `launchctl unload
  ~/Library/LaunchAgents/sh.aidevops.peer-productivity-monitor.plist`
  or `AIDEVOPS_PEER_MONITOR_DISABLE=1` in the launchd environment.
- Reset a peer's hysteresis: `peer-productivity-monitor.sh reset
  <login>`.
- Audit log: `~/.aidevops/logs/peer-productivity.log`.

Resolves #21125

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.11.17 plugin for [OpenCode](https://opencode.ai) v1.14.26 with claude-opus-4-7 spent 6h 29m and 557,247 tokens on this with the user in an interactive session.
