### PR TITLE
t2845: feat(t2845): knowledge review gate routine + NMR integration

### DIFF
--- a/.agents/aidevops/knowledge-plane.md
+++ b/.agents/aidevops/knowledge-plane.md
@@ -127,6 +127,103 @@ The helper: `.agents/scripts/knowledge-helper.sh`.
 
 ---
 
+## Review Gate (t2845)
+
+The pulse-driven `r040` routine runs every 15 minutes, scans
+`_knowledge/inbox/` for pending sources, and classifies them using the trust
+ladder defined in `_knowledge/_config/knowledge.json`.
+
+### Trust Ladder
+
+Three trust classes determine what happens to each inbox item:
+
+| Class | Trigger | Action |
+|-------|---------|--------|
+| `auto_promote` | `meta.json` `trust: "trusted"\|"authoritative"`, OR `ingested_by` matches a configured bot/email, OR `source_uri` starts with a trusted path | Direct promotion: inbox → staging → sources + audit entry |
+| `review_gate` | `ingested_by` matches `trust.review_gate.from_emails` | Staged + `kind:knowledge-review` issue filed with `auto-dispatch` (light review, worker-handled) |
+| `untrusted` | Default (`"*"`) | Staged + `kind:knowledge-review` issue filed with `needs-maintainer-review` (requires crypto-approval) |
+
+### Trust Config
+
+Defined in `_knowledge/_config/knowledge.json` (written at provision time from
+`.agents/templates/knowledge-config.json`):
+
+```json
+{
+  "trust": {
+    "auto_promote": {
+      "from_paths": ["~/Drops/maintainer-knowledge/"],
+      "from_emails": ["you@yourdomain.com"],
+      "from_bots":   ["my-internal-bot"]
+    },
+    "review_gate": {
+      "from_emails": ["partner@example.com"]
+    },
+    "untrusted": "*"
+  }
+}
+```
+
+Override per-repo after provisioning: edit `_knowledge/_config/knowledge.json`
+directly. The config is versioned in `sources/` — changes are tracked in git.
+
+### NMR Issues
+
+Untrusted and review_gate sources produce `kind:knowledge-review` GitHub
+issues. Each issue body includes:
+
+- Source ID, kind, SHA256, size, ingested_by, sensitivity
+- Trust class and review instructions
+- Text preview (first 500 chars) of the source content
+
+**Untrusted**: issues carry `needs-maintainer-review`. Approve with:
+
+```bash
+sudo aidevops approve issue <N>
+```
+
+This triggers `knowledge-review-helper.sh promote <source-id>`, which moves
+the source from `_knowledge/staging/` to `_knowledge/sources/`, updates
+`meta.json` with `state: "promoted"`, and closes the issue.
+
+**Review-gate**: issues carry `auto-dispatch`. A worker reviews and can promote
+by calling the same `promote` subcommand.
+
+### Audit Log
+
+Every action is appended to `_knowledge/index/audit.log` (JSONL):
+
+```json
+{"ts":"2026-04-27T00:00:00Z","action":"auto_promoted","source_id":"my-doc","actor":"tick","extra":"actor:tick"}
+{"ts":"2026-04-27T00:01:00Z","action":"nmr_filed","source_id":"ext-doc","actor":"tick","extra":"issue:https://github.com/… trust_class:untrusted"}
+{"ts":"2026-04-27T12:00:00Z","action":"promoted","source_id":"ext-doc","actor":"maintainer","extra":"actor:maintainer path:approve_hook"}
+```
+
+`_knowledge/index/` is gitignored — the audit log is local only.
+
+### Routine r040
+
+```
+- [x] r040 Knowledge review gate — classify inbox items by trust, auto-promote or NMR-file repeat:cron(*/15 * * * *) ~1m run:scripts/knowledge-review-helper.sh tick
+```
+
+To disable: change `[x]` to `[ ]` in `TODO.md` and commit.
+
+### Helper CLI
+
+```bash
+# Manual tick (same as r040 routine)
+~/.aidevops/agents/scripts/knowledge-review-helper.sh tick
+
+# Explicit promotion (called automatically by approve hook)
+~/.aidevops/agents/scripts/knowledge-review-helper.sh promote <source-id>
+
+# Manual audit entry
+~/.aidevops/agents/scripts/knowledge-review-helper.sh audit-log <action> <source-id> [extra]
+```
+
+---
+
 ## IMAP Polling (t2855)
 
 The pulse-driven `r044` routine polls configured IMAP mailboxes every 10 minutes,

--- a/.agents/scripts/knowledge-review-helper.sh
+++ b/.agents/scripts/knowledge-review-helper.sh
@@ -1,0 +1,750 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# knowledge-review-helper.sh — Knowledge plane review gate routine (t2845)
+#
+# Scans _knowledge/inbox/ for pending sources, classifies them by trust ladder,
+# auto-promotes maintainer/trusted drops, and files NMR-gated GitHub issues for
+# untrusted sources. Designed to be run as pulse routine r040 every 15 minutes.
+#
+# Usage (pulse routine r040):
+#   scripts/knowledge-review-helper.sh tick
+#
+# Usage (crypto-approval hook, called by pulse-nmr-approval.sh):
+#   knowledge-review-helper.sh promote <source-id>
+#
+# Usage (manual audit entry):
+#   knowledge-review-helper.sh audit-log <action> <source-id> [extra]
+#
+# Trust classification (from _knowledge/_config/knowledge.json → trust):
+#   auto_promote  → maintainer drops / trusted paths+emails+bots → promote directly
+#   review_gate   → trusted partner emails → file kind:knowledge-review + auto-dispatch
+#   untrusted     → default ("*") → file kind:knowledge-review + needs-maintainer-review
+#
+# Audit log: _knowledge/index/audit.log (JSONL, one record per action)
+#
+# Pattern reference: .agents/scripts/knowledge-helper.sh (provisioning)
+#                    .agents/scripts/email-poll-helper.sh (pulse routine)
+#                    .agents/scripts/pulse-nmr-approval.sh (NMR flow)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=shared-constants.sh
+[[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
+# shellcheck source=shared-gh-wrappers.sh
+[[ -f "${SCRIPT_DIR}/shared-gh-wrappers.sh" ]] && source "${SCRIPT_DIR}/shared-gh-wrappers.sh"
+
+# Guard color fallbacks when shared-constants.sh is absent
+[[ -z "${GREEN+x}" ]] && GREEN='\033[0;32m'
+[[ -z "${YELLOW+x}" ]] && YELLOW='\033[1;33m'
+[[ -z "${RED+x}" ]] && RED='\033[0;31m'
+[[ -z "${BLUE+x}" ]] && BLUE='\033[0;34m'
+[[ -z "${NC+x}" ]] && NC='\033[0m'
+
+if ! declare -f print_info >/dev/null 2>&1; then
+	print_info() { local _m="$1"; printf "${BLUE}[INFO]${NC} %s\n" "$_m"; return 0; }
+fi
+if ! declare -f print_success >/dev/null 2>&1; then
+	print_success() { local _m="$1"; printf "${GREEN}[OK]${NC} %s\n" "$_m"; return 0; }
+fi
+if ! declare -f print_warning >/dev/null 2>&1; then
+	print_warning() { local _m="$1"; printf "${YELLOW}[WARN]${NC} %s\n" "$_m"; return 0; }
+fi
+if ! declare -f print_error >/dev/null 2>&1; then
+	print_error() { local _m="$1"; printf "${RED}[ERROR]${NC} %s\n" "$_m"; return 0; }
+fi
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+REPOS_FILE="${REPOS_FILE:-${HOME}/.config/aidevops/repos.json}"
+PERSONAL_PLANE_BASE="${PERSONAL_PLANE_BASE:-${HOME}/.aidevops/.agent-workspace/knowledge}"
+KNOWLEDGE_ROOT="${KNOWLEDGE_ROOT:-_knowledge}"
+AUDIT_LOG_NAME="audit.log"
+LOGFILE="${LOGFILE:-/dev/null}"
+
+SCRIPT_TEMPLATES_DIR="${SCRIPT_DIR%/scripts}/templates"
+
+# ---------------------------------------------------------------------------
+# _find_knowledge_root — locate the active knowledge plane root
+# ---------------------------------------------------------------------------
+
+_find_knowledge_root() {
+	local cwd
+	cwd="$(pwd)"
+
+	if [[ -d "${cwd}/${KNOWLEDGE_ROOT}" ]]; then
+		printf '%s\n' "${cwd}/${KNOWLEDGE_ROOT}"
+		return 0
+	fi
+
+	if [[ -d "${PERSONAL_PLANE_BASE}" ]]; then
+		printf '%s\n' "${PERSONAL_PLANE_BASE}"
+		return 0
+	fi
+
+	return 1
+}
+
+# ---------------------------------------------------------------------------
+# _read_trust_config — read the .trust block from knowledge.json
+# ---------------------------------------------------------------------------
+
+_read_trust_config() {
+	local root="$1"
+	local config_file="${root}/_config/knowledge.json"
+
+	if [[ ! -f "$config_file" ]]; then
+		printf '{}\n'
+		return 0
+	fi
+
+	local content
+	content=$(jq -r '.trust // {}' "$config_file" 2>/dev/null) || content="{}"
+	printf '%s\n' "$content"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# _check_auto_promote_rules — check ingested_by and source_uri against config
+# Returns 0 if matches an auto_promote rule, 1 otherwise
+# ---------------------------------------------------------------------------
+
+_check_auto_promote_rules() {
+	local ingested_by="$1"
+	local source_uri="$2"
+	local trust_config="$3"
+
+	local entry
+	local auto_bots auto_emails auto_paths
+
+	auto_bots=$(printf '%s' "$trust_config" \
+		| jq -r '.auto_promote.from_bots // [] | .[]' 2>/dev/null) || auto_bots=""
+	auto_emails=$(printf '%s' "$trust_config" \
+		| jq -r '.auto_promote.from_emails // [] | .[]' 2>/dev/null) || auto_emails=""
+	auto_paths=$(printf '%s' "$trust_config" \
+		| jq -r '.auto_promote.from_paths // [] | .[]' 2>/dev/null) || auto_paths=""
+
+	while IFS= read -r entry; do
+		[[ -z "$entry" ]] && continue
+		[[ "$ingested_by" == "$entry" ]] && return 0
+	done <<< "$auto_bots"
+
+	while IFS= read -r entry; do
+		[[ -z "$entry" ]] && continue
+		[[ "$ingested_by" == "$entry" ]] && return 0
+	done <<< "$auto_emails"
+
+	while IFS= read -r entry; do
+		[[ -z "$entry" ]] && continue
+		local expanded="${entry/#\~/$HOME}"
+		[[ "$source_uri" == "${expanded}"* ]] && return 0
+	done <<< "$auto_paths"
+
+	return 1
+}
+
+# ---------------------------------------------------------------------------
+# _resolve_trust_class — classify a source: auto_promote / review_gate / untrusted
+# ---------------------------------------------------------------------------
+
+_resolve_trust_class() {
+	local meta_json="$1"
+	local trust_config="$2"
+
+	local trust ingested_by source_uri
+	trust=$(printf '%s' "$meta_json" | jq -r '.trust // "unverified"' 2>/dev/null) \
+		|| trust="unverified"
+	ingested_by=$(printf '%s' "$meta_json" | jq -r '.ingested_by // ""' 2>/dev/null) \
+		|| ingested_by=""
+	source_uri=$(printf '%s' "$meta_json" | jq -r '.source_uri // ""' 2>/dev/null) \
+		|| source_uri=""
+
+	# Explicit trust fields override config rules
+	if [[ "$trust" == "authoritative" || "$trust" == "trusted" ]]; then
+		printf 'auto_promote\n'
+		return 0
+	fi
+
+	# Check config auto_promote rules
+	if _check_auto_promote_rules "$ingested_by" "$source_uri" "$trust_config"; then
+		printf 'auto_promote\n'
+		return 0
+	fi
+
+	# Check review_gate emails
+	local rg_emails entry
+	rg_emails=$(printf '%s' "$trust_config" \
+		| jq -r '.review_gate.from_emails // [] | .[]' 2>/dev/null) || rg_emails=""
+	while IFS= read -r entry; do
+		[[ -z "$entry" ]] && continue
+		[[ "$ingested_by" == "$entry" ]] && { printf 'review_gate\n'; return 0; }
+	done <<< "$rg_emails"
+
+	printf 'untrusted\n'
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# _append_audit_log — write JSONL record to _knowledge/index/audit.log
+# ---------------------------------------------------------------------------
+
+_append_audit_log() {
+	local root="$1"
+	local action="$2"
+	local source_id="$3"
+	local extra="${4:-}"
+
+	local index_dir="${root}/index"
+	mkdir -p "$index_dir" 2>/dev/null || true
+	local audit_file="${index_dir}/${AUDIT_LOG_NAME}"
+
+	local ts actor
+	ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null) || ts=""
+	actor="${AIDEVOPS_ACTOR:-$(whoami 2>/dev/null || echo "agent")}"
+
+	local record
+	record=$(jq -nc \
+		--arg ts "$ts" \
+		--arg action "$action" \
+		--arg source_id "$source_id" \
+		--arg actor "$actor" \
+		--arg extra "$extra" \
+		'{ts:$ts,action:$action,source_id:$source_id,actor:$actor,extra:$extra}' \
+		2>/dev/null) \
+		|| record="{\"ts\":\"${ts}\",\"action\":\"${action}\",\"source_id\":\"${source_id}\"}"
+
+	printf '%s\n' "$record" >> "$audit_file"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# _move_to_staging — move source directory from inbox/ to staging/
+# ---------------------------------------------------------------------------
+
+_move_to_staging() {
+	local root="$1"
+	local source_id="$2"
+	local inbox_path="${root}/inbox/${source_id}"
+	local staging_path="${root}/staging/${source_id}"
+
+	[[ -e "$inbox_path" ]] || return 1
+	mkdir -p "${root}/staging" 2>/dev/null || true
+	mv "$inbox_path" "$staging_path" 2>/dev/null || return 1
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# _update_meta_state — patch .state (and optional timestamp) into meta.json
+# ---------------------------------------------------------------------------
+
+_update_meta_state() {
+	local meta_file="$1"
+	local new_state="$2"
+	local ts_field="${3:-}"
+	local extra_key="${4:-}"
+	local extra_val="${5:-}"
+
+	[[ -f "$meta_file" ]] || return 0
+
+	local ts
+	ts=$(date -u +"%Y-%m-%dT%H:%M:%SZ" 2>/dev/null) || ts=""
+	local parent_dir
+	parent_dir="$(dirname "$meta_file")"
+	local tmp
+	tmp=$(mktemp "${parent_dir}/.meta.XXXXXX" 2>/dev/null) || return 0
+
+	# SC2016: single-quoted $state/$ts/$extra are jq arg references, not shell vars
+	# shellcheck disable=SC2016
+	local jq_filter='.state = $state'
+	[[ -n "$ts_field" ]] && jq_filter="${jq_filter} | .${ts_field} = \$ts"
+	[[ -n "$extra_key" ]] && jq_filter="${jq_filter} | .${extra_key} = \$extra"
+
+	if jq --arg state "$new_state" --arg ts "$ts" --arg extra "$extra_val" \
+		"$jq_filter" "$meta_file" > "$tmp" 2>/dev/null; then
+		mv "$tmp" "$meta_file"
+	else
+		rm -f "$tmp"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# _move_to_sources — move source directory from staging/ to sources/
+# ---------------------------------------------------------------------------
+
+_move_to_sources() {
+	local root="$1"
+	local source_id="$2"
+	local staging_path="${root}/staging/${source_id}"
+	local sources_path="${root}/sources/${source_id}"
+
+	[[ -e "$staging_path" ]] || return 1
+	mkdir -p "${root}/sources" 2>/dev/null || true
+	mv "$staging_path" "$sources_path" 2>/dev/null || return 1
+	_update_meta_state "${sources_path}/meta.json" "promoted" "promoted_at"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# _extract_preview — extract up to N chars from first text file in a dir
+# ---------------------------------------------------------------------------
+
+_extract_preview() {
+	local source_dir="$1"
+	local max_chars="${2:-500}"
+	local preview=""
+
+	local found_file
+	found_file=$(find "$source_dir" -maxdepth 1 \
+		\( -name "*.txt" -o -name "*.md" -o -name "*.json" \) \
+		2>/dev/null | head -1)
+
+	if [[ -n "$found_file" && -f "$found_file" ]]; then
+		preview=$(dd if="$found_file" bs=1 count="$max_chars" 2>/dev/null \
+			| tr -d '\0' | tr '\n' ' ')
+	fi
+
+	printf '%s' "${preview:-(no preview available)}"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# _build_nmr_body_file — write NMR issue body to a temp file, return path
+# ---------------------------------------------------------------------------
+
+_build_nmr_body_file() {
+	local root="$1"
+	local source_id="$2"
+	local meta_json="$3"
+	local trust_class="$4"
+
+	local kind sha256 size_bytes ingested_by sensitivity
+	kind=$(printf '%s' "$meta_json" | jq -r '.kind // "unknown"' 2>/dev/null) \
+		|| kind=""
+	sha256=$(printf '%s' "$meta_json" | jq -r '.sha256 // ""' 2>/dev/null) \
+		|| sha256=""
+	size_bytes=$(printf '%s' "$meta_json" | jq -r '.size_bytes // 0' 2>/dev/null) \
+		|| size_bytes=0
+	ingested_by=$(printf '%s' "$meta_json" | jq -r '.ingested_by // "unknown"' 2>/dev/null) \
+		|| ingested_by=""
+	sensitivity=$(printf '%s' "$meta_json" | jq -r '.sensitivity // "internal"' 2>/dev/null) \
+		|| sensitivity="internal"
+
+	local staging_dir="${root}/staging/${source_id}"
+	local preview
+	preview=$(_extract_preview "$staging_dir" 500)
+
+	local body_file
+	body_file=$(mktemp /tmp/knowledge-review-body.XXXXXX.md 2>/dev/null) || return 1
+
+	local tmpl="${SCRIPT_TEMPLATES_DIR}/knowledge-review-nmr-body.md"
+	if [[ -f "$tmpl" ]]; then
+		sed -e "s|{{SOURCE_ID}}|${source_id}|g" \
+			-e "s|{{KIND}}|${kind}|g" \
+			-e "s|{{SHA256}}|${sha256}|g" \
+			-e "s|{{SIZE_BYTES}}|${size_bytes}|g" \
+			-e "s|{{INGESTED_BY}}|${ingested_by}|g" \
+			-e "s|{{SENSITIVITY}}|${sensitivity}|g" \
+			-e "s|{{TRUST_CLASS}}|${trust_class}|g" \
+			"$tmpl" > "$body_file" 2>/dev/null || true
+		printf "\n\n**Preview (first 500 chars):**\n\n\`\`\`\n%s\n\`\`\`\n" "$preview" \
+			>> "$body_file"
+	else
+		cat > "$body_file" <<BODY
+<!-- aidevops:knowledge-review source_id:${source_id} -->
+
+## Knowledge Source Review Request
+
+A new knowledge source requires review before promotion to \`sources/\`.
+
+| Field | Value |
+|-------|-------|
+| Source ID | \`${source_id}\` |
+| Kind | ${kind} |
+| SHA256 | \`${sha256}\` |
+| Size | ${size_bytes} bytes |
+| Ingested by | ${ingested_by} |
+| Sensitivity | ${sensitivity} |
+| Trust class | ${trust_class} |
+
+**Preview (first 500 chars):**
+
+\`\`\`
+${preview}
+\`\`\`
+
+## Review Actions
+
+- Approve: \`sudo aidevops approve issue <this-issue-number>\`
+  This triggers \`knowledge-review-helper.sh promote ${source_id}\`
+- Reject: close the issue without approving (source stays in staging/)
+
+Source staged at: \`_knowledge/staging/${source_id}/\`
+BODY
+	fi
+
+	printf '%s\n' "$body_file"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# _file_nmr_issue — create a GitHub issue for a review-required source
+# Returns the issue URL on success
+# ---------------------------------------------------------------------------
+
+_file_nmr_issue() {
+	local root="$1"
+	local source_id="$2"
+	local meta_json="$3"
+	local trust_class="$4"
+	local repo_slug="$5"
+
+	[[ -z "$repo_slug" ]] && return 1
+
+	local body_file
+	body_file=$(_build_nmr_body_file "$root" "$source_id" "$meta_json" "$trust_class") \
+		|| return 1
+
+	# Append signature footer (two-call pattern: write file, then post)
+	if command -v gh-signature-helper.sh >/dev/null 2>&1; then
+		gh-signature-helper.sh footer --model "${AIDEVOPS_MODEL:-unknown}" \
+			>> "$body_file" 2>/dev/null || true
+	fi
+
+	local labels="kind:knowledge-review"
+	if [[ "$trust_class" == "untrusted" ]]; then
+		labels="${labels},needs-maintainer-review"
+	else
+		labels="${labels},auto-dispatch"
+	fi
+
+	local kind
+	kind=$(printf '%s' "$meta_json" | jq -r '.kind' 2>/dev/null) || kind=""
+	local issue_title="Knowledge review: ${source_id} (${kind:-document})"
+
+	local issue_url
+	if declare -f gh_create_issue >/dev/null 2>&1; then
+		issue_url=$(gh_create_issue \
+			--repo "$repo_slug" \
+			--title "$issue_title" \
+			--label "$labels" \
+			--body-file "$body_file" \
+			2>/dev/null) || issue_url=""
+	else
+		issue_url=$(gh issue create \
+			--repo "$repo_slug" \
+			--title "$issue_title" \
+			--label "$labels" \
+			--body-file "$body_file" \
+			2>/dev/null) || issue_url=""
+	fi
+
+	rm -f "$body_file"
+
+	if [[ -n "$issue_url" ]]; then
+		printf '%s\n' "$issue_url"
+		_append_audit_log "$root" "nmr_filed" "$source_id" \
+			"issue:${issue_url} trust_class:${trust_class}"
+		return 0
+	fi
+
+	return 1
+}
+
+# ---------------------------------------------------------------------------
+# _auto_promote — inbox → staging → sources for a trusted source
+# ---------------------------------------------------------------------------
+
+_auto_promote() {
+	local root="$1"
+	local source_id="$2"
+	local actor="${3:-auto}"
+
+	if ! _move_to_staging "$root" "$source_id"; then
+		print_warning "knowledge-review: auto-promote: failed to move ${source_id} to staging"
+		return 1
+	fi
+
+	if ! _move_to_sources "$root" "$source_id"; then
+		print_warning "knowledge-review: auto-promote: failed to move ${source_id} to sources"
+		return 1
+	fi
+
+	_append_audit_log "$root" "auto_promoted" "$source_id" "actor:${actor}"
+	print_success "knowledge-review: auto-promoted ${source_id}"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# _is_already_processed — idempotency guard
+# Returns 0 if source was already processed, 1 if new/pending
+# ---------------------------------------------------------------------------
+
+_is_already_processed() {
+	local root="$1"
+	local source_id="$2"
+
+	[[ -e "${root}/sources/${source_id}" ]] && return 0
+
+	local meta_file="${root}/staging/${source_id}/meta.json"
+	if [[ -f "$meta_file" ]]; then
+		local state
+		state=$(jq -r '.state // ""' "$meta_file" 2>/dev/null) || state=""
+		case "$state" in
+		nmr_filed | staged | promoted)
+			return 0
+			;;
+		esac
+	fi
+
+	return 1
+}
+
+# ---------------------------------------------------------------------------
+# _get_repo_slug — resolve owner/repo from repos.json or git remote
+# ---------------------------------------------------------------------------
+
+_get_repo_slug() {
+	local cwd="${1:-$(pwd)}"
+	local slug=""
+
+	if [[ -f "$REPOS_FILE" ]] && command -v jq >/dev/null 2>&1; then
+		slug=$(jq -r --arg p "$cwd" \
+			'.initialized_repos[] | select(.path == $p) | .slug // ""' \
+			"$REPOS_FILE" 2>/dev/null | head -1)
+	fi
+
+	if [[ -z "$slug" ]]; then
+		local remote_url
+		remote_url=$(git -C "$cwd" remote get-url origin 2>/dev/null) || remote_url=""
+		if [[ -n "$remote_url" ]]; then
+			slug=$(printf '%s' "$remote_url" \
+				| sed 's|.*github\.com[:/]\(.*\)\.git$|\1|;s|.*github\.com[:/]\(.*\)$|\1|' \
+				2>/dev/null)
+		fi
+	fi
+
+	printf '%s\n' "$slug"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# _process_inbox_item — handle a single inbox source during tick
+# ---------------------------------------------------------------------------
+
+_process_inbox_item() {
+	local root="$1"
+	local source_id="$2"
+	local meta_json="$3"
+	local trust_config="$4"
+	local repo_slug="$5"
+
+	local trust_class
+	trust_class=$(_resolve_trust_class "$meta_json" "$trust_config")
+
+	if [[ "$trust_class" == "auto_promote" ]]; then
+		_auto_promote "$root" "$source_id" "tick"
+		return $?
+	fi
+
+	# review_gate or untrusted: move to staging, then file issue
+	if ! _move_to_staging "$root" "$source_id"; then
+		print_warning "knowledge-review: failed to stage ${source_id}"
+		return 1
+	fi
+
+	if [[ -z "$repo_slug" ]]; then
+		print_warning "knowledge-review: no repo slug, staged ${source_id} without issue"
+		_append_audit_log "$root" "staged_no_slug" "$source_id" "trust_class:${trust_class}"
+		return 0
+	fi
+
+	local issue_url=""
+	issue_url=$(_file_nmr_issue "$root" "$source_id" "$meta_json" "$trust_class" "$repo_slug") \
+		|| issue_url=""
+
+	if [[ -n "$issue_url" ]]; then
+		_update_meta_state "${root}/staging/${source_id}/meta.json" \
+			"nmr_filed" "staged_at" "nmr_issue_url" "$issue_url"
+		return 0
+	fi
+
+	print_warning "knowledge-review: failed to file issue for ${source_id}"
+	_append_audit_log "$root" "nmr_file_failed" "$source_id" "trust_class:${trust_class}"
+	return 1
+}
+
+# ---------------------------------------------------------------------------
+# cmd_tick — pulse-driven review gate scan (subcommand: tick)
+# ---------------------------------------------------------------------------
+
+cmd_tick() {
+	local root
+	root=$(_find_knowledge_root) || {
+		print_info "knowledge-review tick: no knowledge plane found, skipping"
+		return 0
+	}
+
+	local inbox_dir="${root}/inbox"
+	if [[ ! -d "$inbox_dir" ]]; then
+		print_info "knowledge-review tick: inbox not found, skipping"
+		return 0
+	fi
+
+	local repo_slug trust_config
+	repo_slug=$(_get_repo_slug) || repo_slug=""
+	trust_config=$(_read_trust_config "$root")
+
+	local processed=0 auto_promoted=0 nmr_filed_count=0 skipped=0
+
+	local meta_file
+	while IFS= read -r -d '' meta_file; do
+		local source_dir source_id meta_json
+		source_dir="$(dirname "$meta_file")"
+		source_id="$(basename "$source_dir")"
+
+		if _is_already_processed "$root" "$source_id"; then
+			skipped=$((skipped + 1))
+			continue
+		fi
+
+		meta_json=$(jq '.' "$meta_file" 2>/dev/null) || meta_json="{}"
+		local trust_class
+		trust_class=$(_resolve_trust_class "$meta_json" "$trust_config")
+
+		if _process_inbox_item "$root" "$source_id" "$meta_json" "$trust_config" "$repo_slug"; then
+			processed=$((processed + 1))
+			if [[ "$trust_class" == "auto_promote" ]]; then
+				auto_promoted=$((auto_promoted + 1))
+			else
+				nmr_filed_count=$((nmr_filed_count + 1))
+			fi
+		fi
+	done < <(find "$inbox_dir" -mindepth 2 -maxdepth 2 -name "meta.json" -print0 2>/dev/null \
+		| sort -z)
+
+	echo "[knowledge-review] tick: processed=${processed} auto_promoted=${auto_promoted} nmr_filed=${nmr_filed_count} skipped=${skipped}" >> "$LOGFILE"
+
+	if [[ "$processed" -gt 0 ]]; then
+		print_info "knowledge-review tick: processed=${processed} (auto_promoted=${auto_promoted} nmr_filed=${nmr_filed_count} skipped=${skipped})"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# cmd_promote — explicit promotion from staging -> sources (approve hook)
+# ---------------------------------------------------------------------------
+
+cmd_promote() {
+	local source_id="${1:-}"
+	[[ -z "$source_id" ]] && { print_error "promote: source-id required"; return 1; }
+
+	local root
+	root=$(_find_knowledge_root) || {
+		print_error "promote: no knowledge plane found"
+		return 1
+	}
+
+	if [[ ! -e "${root}/staging/${source_id}" ]]; then
+		print_error "promote: ${source_id} not found in staging/"
+		return 1
+	fi
+
+	if ! _move_to_sources "$root" "$source_id"; then
+		print_error "promote: failed to move ${source_id} to sources/"
+		return 1
+	fi
+
+	local actor
+	actor="${AIDEVOPS_ACTOR:-$(whoami 2>/dev/null || echo "maintainer")}"
+	_append_audit_log "$root" "promoted" "$source_id" \
+		"actor:${actor} path:approve_hook"
+	print_success "knowledge-review: promoted ${source_id} to sources/"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# cmd_audit_log — append a manual audit log entry
+# ---------------------------------------------------------------------------
+
+cmd_audit_log() {
+	local action="${1:-}"
+	local source_id="${2:-}"
+	local extra="${3:-}"
+
+	if [[ -z "$action" || -z "$source_id" ]]; then
+		print_error "audit-log: action and source-id required"
+		return 1
+	fi
+
+	local root
+	root=$(_find_knowledge_root) || {
+		print_error "audit-log: no knowledge plane found"
+		return 1
+	}
+
+	_append_audit_log "$root" "$action" "$source_id" "$extra"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# cmd_help
+# ---------------------------------------------------------------------------
+
+cmd_help() {
+	cat <<'HELP'
+knowledge-review-helper.sh — Knowledge plane review gate routine (t2845)
+
+Subcommands:
+  tick                       Scan inbox, classify trust, auto-promote or NMR-file
+  promote <source-id>        Promote from staging -> sources (called by approve hook)
+  audit-log <action> <id>    Append JSONL entry to _knowledge/index/audit.log
+  help                       Show this help
+
+Trust classification (from _knowledge/_config/knowledge.json .trust):
+  auto_promote  maintainer/trusted drops → promoted directly + audit-logged
+  review_gate   trusted partner email   → kind:knowledge-review + auto-dispatch
+  untrusted     default ("*")           → kind:knowledge-review + needs-maintainer-review
+
+Crypto-approval flow (untrusted sources):
+  sudo aidevops approve issue <N>  →  promotes source from staging/ to sources/
+
+Audit log location: _knowledge/index/audit.log (JSONL)
+HELP
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+main() {
+	local cmd="${1:-help}"
+	shift || true
+
+	case "$cmd" in
+	tick)
+		cmd_tick "$@"
+		;;
+	promote)
+		cmd_promote "$@"
+		;;
+	audit-log)
+		cmd_audit_log "$@"
+		;;
+	help | --help | -h)
+		cmd_help
+		;;
+	*)
+		print_error "Unknown subcommand: ${cmd}"
+		cmd_help
+		return 1
+		;;
+	esac
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/knowledge-review-helper.sh
+++ b/.agents/scripts/knowledge-review-helper.sh
@@ -426,21 +426,18 @@ _file_nmr_issue() {
 	local issue_title="Knowledge review: ${source_id} (${kind:-document})"
 
 	local issue_url
-	if declare -f gh_create_issue >/dev/null 2>&1; then
-		issue_url=$(gh_create_issue \
-			--repo "$repo_slug" \
-			--title "$issue_title" \
-			--label "$labels" \
-			--body-file "$body_file" \
-			2>/dev/null) || issue_url=""
-	else
-		issue_url=$(gh issue create \
-			--repo "$repo_slug" \
-			--title "$issue_title" \
-			--label "$labels" \
-			--body-file "$body_file" \
-			2>/dev/null) || issue_url=""
+	# gh_create_issue from shared-gh-wrappers.sh is required (sourced at script top)
+	if ! declare -f gh_create_issue >/dev/null 2>&1; then
+		echo "[knowledge-review] _file_nmr_issue: gh_create_issue not available, cannot file issue" >> "$LOGFILE"
+		rm -f "$body_file"
+		return 1
 	fi
+	issue_url=$(gh_create_issue \
+		--repo "$repo_slug" \
+		--title "$issue_title" \
+		--label "$labels" \
+		--body-file "$body_file" \
+		2>/dev/null) || issue_url=""
 
 	rm -f "$body_file"
 

--- a/.agents/scripts/pulse-nmr-approval.sh
+++ b/.agents/scripts/pulse-nmr-approval.sh
@@ -577,6 +577,81 @@ notify_ever_nmr_without_approval() {
 }
 
 #######################################
+# t2845: Handle knowledge-review issue promotion after cryptographic approval.
+#
+# When auto_approve_maintainer_issues clears NMR on a kind:knowledge-review
+# issue, this function extracts the source_id from the body marker
+# (<!-- aidevops:knowledge-review source_id:xxx -->), calls
+# knowledge-review-helper.sh promote <source_id> to move staging -> sources,
+# posts a closing comment, and closes the issue.
+#
+# Arguments:
+#   $1 - issue_num  : GitHub issue number
+#   $2 - slug       : repo slug (owner/repo)
+#
+# Returns: 0 always (fail-open — a missed promotion is better than a broken
+#          approval loop).
+#######################################
+_handle_knowledge_review_promotion() {
+	local issue_num="$1"
+	local slug="$2"
+
+	[[ -n "$issue_num" && -n "$slug" ]] || return 0
+
+	# Shared API path (avoids repeated literal, which would trip the string-literal ratchet)
+	local issue_api="repos/${slug}/issues/${issue_num}"
+
+	# Only act on kind:knowledge-review issues
+	local has_kr_label
+	has_kr_label=$(gh api "$issue_api" \
+		--jq '.labels | map(.name) | map(select(. == "kind:knowledge-review")) | length' \
+		2>/dev/null) || has_kr_label=0
+	[[ "$has_kr_label" =~ ^[0-9]+$ ]] || has_kr_label=0
+	[[ "$has_kr_label" -gt 0 ]] || return 0
+
+	# Extract source_id from body marker <!-- aidevops:knowledge-review source_id:xxx -->
+	local issue_body
+	issue_body=$(gh api "$issue_api" \
+		--jq '.body // ""' 2>/dev/null) || issue_body=""
+
+	local source_id
+	source_id=$(printf '%s' "$issue_body" \
+		| grep -oE 'source_id:[a-zA-Z0-9_.-]+' \
+		| head -1 \
+		| cut -d: -f2 2>/dev/null) || source_id=""
+
+	if [[ -z "$source_id" ]]; then
+		echo "[pulse-wrapper] _handle_knowledge_review_promotion: #${issue_num} in ${slug} — no source_id in body, skipping" >>"$LOGFILE"
+		return 0
+	fi
+
+	# Locate knowledge-review-helper.sh in the deployed agents dir
+	local kr_helper="${AGENTS_DIR:-$HOME/.aidevops/agents}/scripts/knowledge-review-helper.sh"
+	if [[ ! -f "$kr_helper" ]]; then
+		echo "[pulse-wrapper] _handle_knowledge_review_promotion: helper not found at ${kr_helper}" >>"$LOGFILE"
+		return 0
+	fi
+
+	# Promote source from staging -> sources
+	if ! bash "$kr_helper" promote "$source_id" 2>/dev/null; then
+		echo "[pulse-wrapper] _handle_knowledge_review_promotion: #${issue_num} — promote '${source_id}' failed, issue stays open" >>"$LOGFILE"
+		return 0
+	fi
+
+	echo "[pulse-wrapper] _handle_knowledge_review_promotion: #${issue_num} in ${slug} — promoted '${source_id}' to sources/" >>"$LOGFILE"
+
+	# Post closing comment then close the issue
+	gh_issue_comment "$issue_num" --repo "$slug" \
+		--body "<!-- aidevops:knowledge-review-complete -->
+Knowledge source \`${source_id}\` promoted from staging to \`sources/\` after cryptographic approval. Audit log updated." \
+		2>/dev/null || true
+
+	gh issue close "$issue_num" --repo "$slug" 2>/dev/null || true
+	echo "[pulse-wrapper] _handle_knowledge_review_promotion: #${issue_num} in ${slug} — closed" >>"$LOGFILE"
+	return 0
+}
+
+#######################################
 # Auto-approve needs-maintainer-review issues using cryptographic
 # signature verification (t1894, replaces GH#16842 comment-based check).
 #
@@ -671,6 +746,8 @@ Auto-approved: ${approval_reason}. Stale recovery tick reset." \
 				if [[ "$edit_exit" -eq 0 ]]; then
 					echo "[pulse-wrapper] Auto-approved #${issue_num} in ${slug} — ${approval_reason} (locked + approval marker + tick reset)" >>"$LOGFILE"
 					total_approved=$((total_approved + 1))
+					# t2845: promote knowledge-review source if this is a kind:knowledge-review issue
+					_handle_knowledge_review_promotion "$issue_num" "$slug" || true
 				else
 					echo "[pulse-wrapper] Auto-approve label update FAILED for #${issue_num} in ${slug} (exit: ${edit_exit}) — approval marker posted but labels unchanged" >>"$LOGFILE"
 				fi

--- a/.agents/templates/knowledge-config.json
+++ b/.agents/templates/knowledge-config.json
@@ -8,5 +8,16 @@
   "ingest_policy": {
     "auto_sha256": true,
     "require_meta": true
+  },
+  "trust": {
+    "auto_promote": {
+      "from_paths": [],
+      "from_emails": [],
+      "from_bots": []
+    },
+    "review_gate": {
+      "from_emails": []
+    },
+    "untrusted": "*"
   }
 }

--- a/.agents/templates/knowledge-review-nmr-body.md
+++ b/.agents/templates/knowledge-review-nmr-body.md
@@ -1,0 +1,44 @@
+<!-- aidevops:knowledge-review source_id:{{SOURCE_ID}} -->
+
+## Knowledge Source Review Request
+
+A new knowledge source requires review before promotion to `sources/`.
+
+| Field | Value |
+|-------|-------|
+| Source ID | `{{SOURCE_ID}}` |
+| Kind | {{KIND}} |
+| SHA256 | `{{SHA256}}` |
+| Size | {{SIZE_BYTES}} bytes |
+| Ingested by | {{INGESTED_BY}} |
+| Sensitivity | {{SENSITIVITY}} |
+| Trust class | {{TRUST_CLASS}} |
+
+## Why This Requires Review
+
+Trust class `{{TRUST_CLASS}}` requires maintainer sign-off before the source
+can be promoted to versioned `sources/` storage. Review the preview below and
+verify the content is safe to commit.
+
+## Review Actions
+
+**Approve** (promote source to `sources/` and close this issue):
+
+```bash
+sudo aidevops approve issue <this-issue-number>
+```
+
+This triggers `knowledge-review-helper.sh promote {{SOURCE_ID}}`, which moves
+the source from `_knowledge/staging/{{SOURCE_ID}}/` to
+`_knowledge/sources/{{SOURCE_ID}}/` and updates the audit log.
+
+**Reject** (keep source in staging, do not promote):
+
+Close the issue without approving. The source stays in
+`_knowledge/staging/{{SOURCE_ID}}/` indefinitely.
+
+## Source Location
+
+Staged at: `_knowledge/staging/{{SOURCE_ID}}/`
+
+<!-- preview appended by knowledge-review-helper.sh -->

--- a/.agents/tests/test-knowledge-review.sh
+++ b/.agents/tests/test-knowledge-review.sh
@@ -1,0 +1,438 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# Tests for knowledge-review-helper.sh (t2845)
+# =============================================================================
+# Run: bash .agents/tests/test-knowledge-review.sh
+#
+# Tests:
+#   1. shellcheck — zero violations
+#   2. auto-promotion path — maintainer trust → moves inbox → sources + audit
+#   3. NMR-file path — untrusted → moves to staging, audit record written
+#   4. review_gate path — review_gate email → staged (no GH slug, no issue filed)
+#   5. idempotent tick — re-run on already-staged source does not double-process
+#   6. promote subcommand — moves staging → sources, updates meta.json state
+#   7. audit-log subcommand — appends JSONL record to index/audit.log
+#   8. trust ladder — explicit trust:trusted meta field triggers auto-promote
+#   9. trusted/authoritative meta field — both trigger auto-promote
+#  10. missing meta.json — skipped gracefully
+#
+# Mocking strategy: create a minimal _knowledge/ directory tree in a temp dir,
+# set KNOWLEDGE_ROOT and CWD so the helper picks it up, then inspect results.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCRIPTS_DIR="${SCRIPT_DIR}/../scripts"
+HELPER="${SCRIPTS_DIR}/knowledge-review-helper.sh"
+
+PASS=0
+FAIL=0
+TEST_TMPDIR=""
+
+# ---------------------------------------------------------------------------
+# Test infrastructure
+# ---------------------------------------------------------------------------
+
+setup() {
+	TEST_TMPDIR=$(mktemp -d)
+	return 0
+}
+
+teardown() {
+	[[ -n "${TEST_TMPDIR:-}" ]] && rm -rf "$TEST_TMPDIR"
+	return 0
+}
+
+pass() {
+	local name="$1"
+	PASS=$((PASS + 1))
+	echo "[PASS] $name"
+	return 0
+}
+
+fail() {
+	local name="$1" reason="${2:-}"
+	FAIL=$((FAIL + 1))
+	echo "[FAIL] $name${reason:+ — $reason}"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Factory: create a minimal knowledge plane with one inbox source
+# ---------------------------------------------------------------------------
+
+make_plane() {
+	local plane_dir="$1"
+	mkdir -p "${plane_dir}/inbox" \
+		"${plane_dir}/staging" \
+		"${plane_dir}/sources" \
+		"${plane_dir}/index" \
+		"${plane_dir}/_config"
+	return 0
+}
+
+make_source() {
+	local plane_dir="$1"
+	local source_id="$2"
+	local trust="${3:-unverified}"
+	local ingested_by="${4:-unknown}"
+	local kind="${5:-document}"
+
+	mkdir -p "${plane_dir}/inbox/${source_id}"
+	cat > "${plane_dir}/inbox/${source_id}/meta.json" <<META
+{
+  "version": 1,
+  "id": "${source_id}",
+  "kind": "${kind}",
+  "sha256": "abc123def456",
+  "ingested_at": "2026-04-27T00:00:00Z",
+  "ingested_by": "${ingested_by}",
+  "sensitivity": "internal",
+  "trust": "${trust}",
+  "size_bytes": 1024
+}
+META
+	printf 'Sample content for %s\n' "$source_id" \
+		> "${plane_dir}/inbox/${source_id}/content.txt"
+	return 0
+}
+
+make_trust_config() {
+	local plane_dir="$1"
+	cat > "${plane_dir}/_config/knowledge.json" <<CFG
+{
+  "version": 1,
+  "trust": {
+    "auto_promote": {
+      "from_paths": [],
+      "from_emails": ["trusted@example.com"],
+      "from_bots": ["my-internal-bot"]
+    },
+    "review_gate": {
+      "from_emails": ["partner@example.com"]
+    },
+    "untrusted": "*"
+  }
+}
+CFG
+	return 0
+}
+
+# Run helper with KNOWLEDGE_ROOT overridden to a temp subdirectory
+run_helper() {
+	local plane_dir="$1"
+	shift
+	# Override KNOWLEDGE_ROOT to the plane dir name, CWD to its parent
+	local plane_parent plane_name
+	plane_parent="$(dirname "$plane_dir")"
+	plane_name="$(basename "$plane_dir")"
+
+	(
+		cd "$plane_parent" || exit 1
+		KNOWLEDGE_ROOT="$plane_name" \
+		REPOS_FILE="/dev/null" \
+		LOGFILE="/dev/null" \
+		bash "$HELPER" "$@" 2>/dev/null
+	)
+	return $?
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: shellcheck zero violations
+# ---------------------------------------------------------------------------
+
+test_shellcheck() {
+	local name="shellcheck: knowledge-review-helper.sh zero violations"
+	if ! command -v shellcheck &>/dev/null; then
+		pass "$name (shellcheck not installed, skipped)"
+		return 0
+	fi
+	if shellcheck "$HELPER" 2>/dev/null; then
+		pass "$name"
+	else
+		fail "$name" "shellcheck reported violations"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: auto-promotion — trusted meta field → inbox goes straight to sources
+# ---------------------------------------------------------------------------
+
+test_auto_promote_trusted_meta() {
+	local name="tick: trusted meta field → auto-promoted to sources/"
+	local plane="${TEST_TMPDIR}/t2"
+	make_plane "$plane"
+	make_trust_config "$plane"
+	make_source "$plane" "src-trusted-001" "trusted" "unknown"
+
+	run_helper "$plane" tick
+
+	if [[ -d "${plane}/sources/src-trusted-001" ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected sources/src-trusted-001 to exist"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: NMR-file path — unverified source moves to staging + audit entry
+# ---------------------------------------------------------------------------
+
+test_untrusted_staged_and_audited() {
+	local name="tick: unverified source → moved to staging + audit-logged"
+	local plane="${TEST_TMPDIR}/t3"
+	make_plane "$plane"
+	make_trust_config "$plane"
+	make_source "$plane" "src-untrusted-001" "unverified" "stranger@external.com"
+
+	run_helper "$plane" tick
+
+	local in_staging audit_count
+	if [[ -d "${plane}/staging/src-untrusted-001" ]]; then
+		in_staging=1
+	else
+		in_staging=0
+	fi
+
+	audit_count=$(grep -c '"staged_no_slug"\|"nmr_filed"\|"nmr_file_failed"' \
+		"${plane}/index/audit.log" 2>/dev/null || echo "0")
+	[[ "$audit_count" =~ ^[0-9]+$ ]] || audit_count=0
+
+	if [[ "$in_staging" -eq 1 && "$audit_count" -ge 1 ]]; then
+		pass "$name"
+	else
+		fail "$name" "in_staging=${in_staging} audit_count=${audit_count}"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: review_gate — partner email moves to staging, audit entry
+# ---------------------------------------------------------------------------
+
+test_review_gate_staged() {
+	local name="tick: review_gate email → staged + audit-logged (no GH slug)"
+	local plane="${TEST_TMPDIR}/t4"
+	make_plane "$plane"
+	make_trust_config "$plane"
+	make_source "$plane" "src-rg-001" "unverified" "partner@example.com"
+
+	run_helper "$plane" tick
+
+	local in_staging audit_count
+	[[ -d "${plane}/staging/src-rg-001" ]] && in_staging=1 || in_staging=0
+
+	audit_count=$(grep -c '"staged_no_slug"\|"nmr_filed"\|"nmr_file_failed"' \
+		"${plane}/index/audit.log" 2>/dev/null || echo "0")
+	[[ "$audit_count" =~ ^[0-9]+$ ]] || audit_count=0
+
+	if [[ "$in_staging" -eq 1 && "$audit_count" -ge 1 ]]; then
+		pass "$name"
+	else
+		fail "$name" "in_staging=${in_staging} audit_count=${audit_count}"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 5: idempotent tick — re-run on already-staged source does not re-stage
+# ---------------------------------------------------------------------------
+
+test_idempotent_tick() {
+	local name="tick: idempotent — re-run does not double-process staged sources"
+	local plane="${TEST_TMPDIR}/t5"
+	make_plane "$plane"
+	make_trust_config "$plane"
+	make_source "$plane" "src-idem-001" "unverified" "nobody"
+
+	# First tick — should stage
+	run_helper "$plane" tick
+
+	# Patch state to "nmr_filed" (simulates already-processed)
+	local meta="${plane}/staging/src-idem-001/meta.json"
+	if [[ -f "$meta" ]]; then
+		local tmp
+		tmp=$(mktemp)
+		jq '.state = "nmr_filed"' "$meta" > "$tmp" && mv "$tmp" "$meta"
+	fi
+
+	# Count audit entries before second tick
+	local count_before count_after
+	count_before=$(wc -l < "${plane}/index/audit.log" 2>/dev/null || echo "0")
+	[[ "$count_before" =~ ^[0-9]+$ ]] || count_before=0
+
+	# Second tick — should skip (already staged)
+	run_helper "$plane" tick
+
+	count_after=$(wc -l < "${plane}/index/audit.log" 2>/dev/null || echo "0")
+	[[ "$count_after" =~ ^[0-9]+$ ]] || count_after=0
+
+	if [[ "$count_after" -eq "$count_before" ]]; then
+		pass "$name"
+	else
+		fail "$name" "audit grew from ${count_before} to ${count_after} on second tick"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 6: promote subcommand — staging -> sources + meta state updated
+# ---------------------------------------------------------------------------
+
+test_promote_subcommand() {
+	local name="promote: moves staging/src -> sources/, sets meta.state=promoted"
+	local plane="${TEST_TMPDIR}/t6"
+	make_plane "$plane"
+	make_trust_config "$plane"
+
+	# Place source directly in staging (simulates already-staged)
+	mkdir -p "${plane}/staging/src-promo-001"
+	cat > "${plane}/staging/src-promo-001/meta.json" <<META
+{"id":"src-promo-001","kind":"document","state":"nmr_filed","sha256":"abc","size_bytes":512}
+META
+
+	run_helper "$plane" promote "src-promo-001"
+
+	local in_sources state
+	[[ -d "${plane}/sources/src-promo-001" ]] && in_sources=1 || in_sources=0
+	state=$(jq -r '.state // ""' "${plane}/sources/src-promo-001/meta.json" 2>/dev/null) \
+		|| state=""
+
+	if [[ "$in_sources" -eq 1 && "$state" == "promoted" ]]; then
+		pass "$name"
+	else
+		fail "$name" "in_sources=${in_sources} state=${state}"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 7: audit-log subcommand — appends JSONL record
+# ---------------------------------------------------------------------------
+
+test_audit_log_subcommand() {
+	local name="audit-log: appends JSONL record to index/audit.log"
+	local plane="${TEST_TMPDIR}/t7"
+	make_plane "$plane"
+
+	run_helper "$plane" audit-log "test_action" "src-audit-001" "extra=hello"
+
+	local audit_file="${plane}/index/audit.log"
+	if [[ ! -f "$audit_file" ]]; then
+		fail "$name" "audit.log not created"
+		return 0
+	fi
+
+	local action_found source_found
+	action_found=$(grep -c '"test_action"' "$audit_file" 2>/dev/null || echo "0")
+	[[ "$action_found" =~ ^[0-9]+$ ]] || action_found=0
+	source_found=$(grep -c '"src-audit-001"' "$audit_file" 2>/dev/null || echo "0")
+	[[ "$source_found" =~ ^[0-9]+$ ]] || source_found=0
+
+	if [[ "$action_found" -ge 1 && "$source_found" -ge 1 ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected action+source in audit.log (action_found=${action_found} source_found=${source_found})"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 8: trusted bot ingested_by → auto-promote
+# ---------------------------------------------------------------------------
+
+test_auto_promote_trusted_bot() {
+	local name="tick: trusted bot in config → auto-promoted to sources/"
+	local plane="${TEST_TMPDIR}/t8"
+	make_plane "$plane"
+	make_trust_config "$plane"
+	make_source "$plane" "src-bot-001" "unverified" "my-internal-bot"
+
+	run_helper "$plane" tick
+
+	if [[ -d "${plane}/sources/src-bot-001" ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected sources/src-bot-001 to exist"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 9: authoritative meta trust → auto-promote
+# ---------------------------------------------------------------------------
+
+test_auto_promote_authoritative() {
+	local name="tick: authoritative meta trust → auto-promoted to sources/"
+	local plane="${TEST_TMPDIR}/t9"
+	make_plane "$plane"
+	make_trust_config "$plane"
+	make_source "$plane" "src-auth-001" "authoritative" "someone"
+
+	run_helper "$plane" tick
+
+	if [[ -d "${plane}/sources/src-auth-001" ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected sources/src-auth-001 to exist"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 10: missing meta.json — skipped gracefully (no crash)
+# ---------------------------------------------------------------------------
+
+test_missing_meta() {
+	local name="tick: inbox dir without meta.json — skipped gracefully"
+	local plane="${TEST_TMPDIR}/t10"
+	make_plane "$plane"
+	make_trust_config "$plane"
+
+	# Inbox entry with no meta.json
+	mkdir -p "${plane}/inbox/src-nometa-001"
+	printf 'raw content\n' > "${plane}/inbox/src-nometa-001/data.txt"
+
+	local exit_rc=0
+	run_helper "$plane" tick || exit_rc=$?
+
+	# Source should still be in inbox (not processed)
+	if [[ -d "${plane}/inbox/src-nometa-001" && "$exit_rc" -eq 0 ]]; then
+		pass "$name"
+	else
+		fail "$name" "exit_rc=${exit_rc} inbox_still_exists=$(test -d "${plane}/inbox/src-nometa-001" && echo 1 || echo 0)"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Run all tests
+# ---------------------------------------------------------------------------
+
+main() {
+	setup
+
+	test_shellcheck
+	test_auto_promote_trusted_meta
+	test_untrusted_staged_and_audited
+	test_review_gate_staged
+	test_idempotent_tick
+	test_promote_subcommand
+	test_audit_log_subcommand
+	test_auto_promote_trusted_bot
+	test_auto_promote_authoritative
+	test_missing_meta
+
+	teardown
+
+	echo ""
+	echo "Results: $PASS passed, $FAIL failed"
+	if [[ "$FAIL" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/TODO.md
+++ b/TODO.md
@@ -85,6 +85,7 @@ Compatible with [todo-md](https://github.com/todo-md/todo-md), [todomd](https://
 ## Routines
 
 - [x] r-gh-audit-scan Scan gh-audit.log for anomalies repeat:daily(@09:00) run:scripts/gh-audit-anomaly-helper.sh scan
+- [x] r040 Knowledge review gate — classify inbox items by trust, auto-promote or NMR-file repeat:cron(*/15 * * * *) ~1m run:scripts/knowledge-review-helper.sh tick
 - [x] r044 IMAP mailbox polling — fetch new emails to _knowledge/inbox/ repeat:cron(*/10 * * * *) ~1m run:scripts/email-poll-helper.sh tick
 - [x] r045 Email filter tick: auto-attach matched email sources to cases repeat:cron(*/15 * * * *) run:scripts/email-filter-helper.sh tick
 


### PR DESCRIPTION
## Summary

Ships the review gate routine: knowledge-review-helper.sh tick scans inbox, auto-promotes trusted sources, files kind:knowledge-review NMR issues for untrusted sources. Adds _handle_knowledge_review_promotion hook in pulse-nmr-approval.sh to promote staging->sources after crypto-approval. Includes trust ladder config, NMR body template, r040 routine entry, and knowledge-plane.md docs.

## Files Changed

.agents/aidevops/knowledge-plane.md,.agents/scripts/knowledge-review-helper.sh,.agents/scripts/pulse-nmr-approval.sh,.agents/templates/knowledge-config.json,.agents/templates/knowledge-review-nmr-body.md,.agents/tests/test-knowledge-review.sh,TODO.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/tests/test-knowledge-review.sh — 10/10 passed; shellcheck zero violations on all modified scripts

Resolves #20897


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.12.0 plugin for [OpenCode](https://opencode.ai) v1.14.26 with claude-sonnet-4-6 spent 31m and 61,903 tokens on this as a headless worker.