### PR TITLE
t2877: parse parent-task body cross-phase dep declarations into blocked-by markers

### DIFF
--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -1723,6 +1723,7 @@ Issue Sync Helper — stateless TODO.md <-> GitHub Issues sync via gh CLI.
 Usage: issue-sync-helper.sh [command] [options]
 Commands: push [tNNN] | enrich [tNNN] | pull | close [tNNN] | reopen
           reconcile | relationships [tNNN] | backfill-sub-issues [--issue N]
+          backfill-cross-phase-blocked-by --issue N
           status | help
 Options: --repo SLUG | --dry-run | --verbose | --force (skip evidence on close; bypass enrich body-gate)
          --force-push (allow bulk push outside CI — use with caution, risk of duplicates)
@@ -1749,6 +1750,15 @@ Sub-issue backfill (t2114):
                          line in body, (3) `Blocked by: tNNN` where the blocker
                          carries the `parent-task` label. Idempotent; supports
                          --dry-run.
+
+Cross-phase blocked-by backfill (t2877):
+  backfill-cross-phase-blocked-by --issue N
+                       — parse prose dependency declarations (e.g.
+                         "P1 children blocked by P0a + P0b") from the body
+                         of the given parent-task issue and emit the
+                         corresponding addBlockedBy GitHub relationships.
+                         Per-issue entry point called by the pulse t2877
+                         reconcile stage. Idempotent; supports --dry-run.
 
 Note: Bulk push (no task ID) is CI-only by default to prevent duplicate issues.
       Use 'push <task_id>' for single tasks, or --force-push to override.
@@ -1801,6 +1811,13 @@ main() {
 			cmd_backfill_sub_issues "${positional_args[@]:1}"
 		else
 			cmd_backfill_sub_issues
+		fi
+		;;
+	backfill-cross-phase-blocked-by)
+		if [[ ${#positional_args[@]} -gt 1 ]]; then
+			cmd_backfill_cross_phase_blocked_by "${positional_args[@]:1}"
+		else
+			cmd_backfill_cross_phase_blocked_by
 		fi
 		;;
 	status) cmd_status ;; help) cmd_help ;;

--- a/.agents/scripts/issue-sync-relationships.sh
+++ b/.agents/scripts/issue-sync-relationships.sh
@@ -1004,6 +1004,345 @@ _backfill_process_loop() {
 	return 0
 }
 
+# =============================================================================
+# Cross-Phase Blocked-By Backfill (t2877 — GH#20972)
+# =============================================================================
+# Parses prose dependency declarations from parent-task issue bodies (e.g.,
+# "P1 children blocked by P0a + P0b") and emits the corresponding GitHub
+# addBlockedBy relationships. Closes the gap identified in t2875: decomposition
+# parents encode rich dependency graphs in narrative prose that the existing
+# relationship-sync (which only reads explicit blocked-by:tNNN from TODO.md)
+# cannot reach.
+#
+# Three helpers compose the pipeline:
+#   _resolve_single_phase_ref  — resolves one phase ID (exact or prefix match)
+#   _expand_phase_refs_to_nums — tokenises a raw ref string and resolves each
+#   _parse_parent_phase_deps   — full parser: phases table + dep section → PAIR lines
+# Plus cmd_backfill_cross_phase_blocked_by — the public entry point.
+
+# Resolve a single phase reference to one or more issue numbers using a
+# pre-built phase_map (one "phase_id=issue_num" per line).
+#
+# Two resolution modes:
+#   - Specific (trailing letter, e.g. P0a, P0.5b): exact key lookup.
+#   - Bare (no trailing letter, e.g. P1, P4, P0.5): prefix match returns all
+#     children whose ID starts with the given prefix followed by a letter.
+#     The prefix's dots are escaped to avoid regex ambiguity (P0.5 → P0\.5).
+#
+# Arguments:
+#   $1 - phase ref (e.g., P0a, P1, P0.5)
+#   $2 - phase_map text
+# Echo: issue numbers — one per line (zero or more)
+# Returns: 0 always
+_resolve_single_phase_ref() {
+	local ref="$1" phase_map="$2"
+	[[ -z "$ref" || -z "$phase_map" ]] && return 0
+
+	if [[ "$ref" =~ [a-z]$ ]]; then
+		# Specific child — exact key lookup (grep -F to treat as fixed string)
+		local num
+		num=$(printf '%s' "$phase_map" | grep -F "${ref}=" | head -1 | cut -d= -f2- || true)
+		[[ -n "$num" ]] && printf '%s\n' "$num"
+	else
+		# Bare phase — prefix match: Pn or Pn.m followed by exactly one letter
+		local escaped_ref
+		escaped_ref=$(printf '%s' "$ref" | sed 's/\./\\./g')
+		printf '%s' "$phase_map" | grep -E "^${escaped_ref}[a-z]=" | cut -d= -f2- || true
+	fi
+	return 0
+}
+
+# Expand slash notation (e.g., P0.5b/c or P4a/P4b) to issue numbers.
+#
+# Parts after the first that do not start with 'P' inherit the numeric prefix
+# of the first part (all characters before its trailing letter). Examples:
+#   P0.5b/c  → P0.5b, P0.5c
+#   P4a/P4b  → P4a, P4b  (both start with P, no inheritance needed)
+#   P2a/b    → P2a, P2b
+#
+# Arguments:
+#   $1 - slash token (e.g., P0.5b/c)
+#   $2 - phase_map text
+# Echo: issue numbers — one per line
+# Returns: 0 always
+_expand_slash_notation() {
+	local token="$1" phase_map="$2"
+	[[ -z "$token" ]] && return 0
+
+	# Numeric prefix of the first part — used when subsequent parts lack 'P'
+	local first_part
+	first_part=$(printf '%s' "$token" | cut -d/ -f1)
+	local numeric_prefix
+	numeric_prefix=$(printf '%s' "$first_part" | sed -E 's/[a-z]+$//')
+
+	# Iterate over slash-separated parts (tr splits cleanly in bash 3.2)
+	local _part
+	while IFS= read -r _part; do
+		[[ -z "$_part" ]] && continue
+		if [[ "$_part" =~ ^P ]]; then
+			_resolve_single_phase_ref "$_part" "$phase_map"
+		else
+			_resolve_single_phase_ref "${numeric_prefix}${_part}" "$phase_map"
+		fi
+	done < <(printf '%s\n' "$token" | tr '/' '\n')
+	return 0
+}
+
+# Expand a raw phase reference string to a list of issue numbers.
+#
+# Handles separators (+ and ,) between phase refs, and slash notation within
+# individual refs. Examples:
+#   "P0a + P0b"        → (issue for P0a, issue for P0b)
+#   "P4 + P1c + P0.5b/c" → (all P4 issues, P1c issue, P0.5b issue, P0.5c issue)
+#   "P1 children"      → all P1 children (strip "children" first)
+#
+# Arguments:
+#   $1 - raw phase ref string (may contain +, comma, slash)
+#   $2 - phase_map text
+# Echo: issue numbers — one per line (may contain duplicates if phase_map has them)
+# Returns: 0 always
+_expand_phase_refs_to_nums() {
+	local raw="$1" phase_map="$2"
+	[[ -z "$raw" || -z "$phase_map" ]] && return 0
+
+	# Normalise: strip "children" keyword, replace + and , with spaces
+	local normalised
+	normalised=$(printf '%s' "$raw" \
+		| sed 's/[[:space:]]*children[[:space:]]*//' \
+		| sed 's/+/ /g' \
+		| sed 's/,/ /g')
+
+	# Iterate over whitespace-separated tokens.
+	# Word-split is intentional here (IFS=default, no quoting).
+	local token
+	# shellcheck disable=SC2086
+	for token in $normalised; do
+		token=$(printf '%s' "$token" | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')
+		[[ -z "$token" ]] && continue
+
+		if printf '%s' "$token" | grep -q '/'; then
+			_expand_slash_notation "$token" "$phase_map"
+		else
+			_resolve_single_phase_ref "$token" "$phase_map"
+		fi
+	done
+	return 0
+}
+
+# Parse cross-phase dependency declarations from a parent-task issue body and
+# resolve them to (child_issue_num, blocker_issue_num) pairs.
+#
+# Parsing pipeline:
+#   1. Scan the full body for table rows of the form
+#      "| tNNN / #MMM | PXYz: description |" and build a phase_id → issue_num
+#      map (e.g. "P0a=20896").
+#   2. Extract the "## Cross-Phase Dependencies" section (or heading variations
+#      matching "cross.phase dep", "phase dep", or "dependencies").
+#   3. For each list item in the section that contains "blocked by" (and does NOT
+#      contain "in parallel"), split into (left/blocked, right/blocker) sides,
+#      expand each via _expand_phase_refs_to_nums, and emit pairs.
+#
+# Handled line shapes (all 8+ patterns from t2840 / #20892):
+#   - "P0.5 children blocked by P0a"
+#   - "P1 children blocked by P0a + P0b"
+#   - "P2c blocked by P0.5a + P0.5c"
+#   - "P2d blocked by P2c"
+#   - "P4 children blocked by P0a + P0b + P0.5a"
+#   - "P5 children blocked by P0a + P0b + P1a"
+#   - "P5c blocked by P4a + P4b"
+#   - "P6 blocked by P4 + P1c + P0.5b/c"
+#   (Lines containing "in parallel" are intentionally skipped.)
+#
+# Arguments:
+#   $1 - issue body text
+# Echo: "PAIR:child_num:blocker_num" lines (zero or more; may have duplicates
+#        that callers should tolerate — _gh_add_blocked_by is idempotent)
+# Returns: 0 always
+_parse_parent_phase_deps() {
+	local body="$1"
+	[[ -z "$body" ]] && return 0
+
+	# --- Step 1: Build phase_id → issue_num map from table rows ---
+	# Table row format: | tNNN / #MMM | PXYz: description |
+	# We scan the entire body (not just the Phases section) so that
+	# split-across-sections tables still resolve correctly.
+	local phase_map=""
+	while IFS= read -r tline; do
+		# Quick pre-filter: must start with | and contain / #
+		[[ "$tline" =~ ^\|[[:space:]]* ]] || continue
+		printf '%s' "$tline" | grep -q '/ #' || continue
+
+		local _iss_num _phase_id
+		_iss_num=$(printf '%s' "$tline" | sed -nE \
+			's/^[[:space:]]*\|[[:space:]]*t[0-9]+[[:space:]]*\/[[:space:]]*#([0-9]+)[[:space:]]*\|.*/\1/p' \
+			| head -1 || true)
+		_phase_id=$(printf '%s' "$tline" | sed -nE \
+			's/^[[:space:]]*\|[^|]+\|[[:space:]]*(P[0-9]+(\.[0-9]+)*[a-z]).*/\1/p' \
+			| head -1 || true)
+		[[ -z "$_iss_num" || -z "$_phase_id" ]] && continue
+		phase_map+="${_phase_id}=${_iss_num}"$'\n'
+	done < <(printf '%s\n' "$body")
+
+	[[ -z "$phase_map" ]] && return 0
+
+	# --- Step 2: Extract cross-phase dependency section ---
+	# Matches headings (case-insensitive) containing:
+	#   "cross-phase dep…", "cross phase dep…", "phase dep…", or "dependencies"
+	local dep_section
+	dep_section=$(printf '%s\n' "$body" | awk '
+		BEGIN { in_sec = 0 }
+		{
+			lc = tolower($0)
+			if (lc ~ /^##[[:space:]]+(cross.phase[[:space:]]+dep|cross[[:space:]]+phase[[:space:]]+dep|phase[[:space:]]+dep)/ ||
+			    lc ~ /^##[[:space:]]+dependencies/) {
+				in_sec = 1; next
+			}
+			if (/^##[[:space:]]/) { if (in_sec) exit }
+			if (in_sec) print
+		}
+	')
+	[[ -z "$dep_section" ]] && return 0
+
+	# --- Step 3: Parse dep lines and emit PAIR:child:blocker ---
+	while IFS= read -r dep_line; do
+		printf '%s' "$dep_line" | grep -qi "blocked by" || continue
+		printf '%s' "$dep_line" | grep -qi "in parallel" && continue
+		[[ "$dep_line" =~ ^[[:space:]]*- ]] || continue
+
+		# Normalise "Blocked by" / "blocked By" → "blocked by" for sed extraction
+		local norm_line
+		norm_line=$(printf '%s' "$dep_line" \
+			| sed 's/[Bb][Ll][Oo][Cc][Kk][Ee][Dd][[:space:]]\{1,\}[Bb][Yy]/blocked by/g')
+
+		# Left side: text between "- " and " blocked by", strip trailing "children"
+		local _left _right
+		_left=$(printf '%s' "$norm_line" | sed -nE \
+			's/^[[:space:]]*-[[:space:]]+([^(]+)[[:space:]]+blocked by.*/\1/p' \
+			| sed -E 's/[[:space:]]*(children)?[[:space:]]*$//' \
+			| head -1 || true)
+		# Right side: text after "blocked by ", up to "(" (optional trailing comment)
+		_right=$(printf '%s' "$norm_line" | sed -nE \
+			's/^.*blocked by[[:space:]]+([^(]+).*/\1/p' \
+			| sed -E 's/[[:space:]]*$//' \
+			| head -1 || true)
+
+		[[ -z "$_left" || -z "$_right" ]] && continue
+
+		# Resolve left (blocked) and right (blocker) to issue numbers
+		local blocked_nums blocker_nums
+		blocked_nums=$(_expand_phase_refs_to_nums "$_left" "$phase_map")
+		blocker_nums=$(_expand_phase_refs_to_nums "$_right" "$phase_map")
+
+		[[ -z "$blocked_nums" || -z "$blocker_nums" ]] && continue
+
+		# Emit pairs (nested loops over newline-separated lists)
+		local _bn _lr
+		while IFS= read -r _bn; do
+			[[ -z "$_bn" ]] && continue
+			while IFS= read -r _lr; do
+				[[ -z "$_lr" ]] && continue
+				[[ "$_bn" == "$_lr" ]] && continue
+				printf 'PAIR:%s:%s\n' "$_bn" "$_lr"
+			done <<< "$blocker_nums"
+		done <<< "$blocked_nums"
+	done < <(printf '%s\n' "$dep_section")
+
+	return 0
+}
+
+# Backfill cross-phase blocked-by relationships for a single parent-task issue.
+# Parses the issue body for prose dependency declarations and calls
+# addBlockedBy for each resolved (child, blocker) pair. Idempotent —
+# _gh_add_blocked_by silently ignores already-existing relationships.
+#
+# Usage:
+#   cmd_backfill_cross_phase_blocked_by --issue N
+#
+# --issue N is mandatory; this command is designed for per-issue invocation
+# from the pulse reconcile loop (t2877 stage, mirroring t2838 sub-issue
+# backfill).
+#
+# Returns: 0 on success, 1 on setup error
+cmd_backfill_cross_phase_blocked_by() {
+	local target_issue=""
+	while [[ $# -gt 0 ]]; do
+		local _cbb_arg="$1"
+		case "$_cbb_arg" in
+		--issue)
+			target_issue="${2:-}"
+			shift 2
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+
+	_init_cmd || return 1
+	local repo="$_CMD_REPO"
+
+	if [[ -z "$target_issue" ]]; then
+		print_error "backfill-cross-phase-blocked-by: --issue N is required"
+		return 1
+	fi
+
+	# Fetch the parent issue body
+	local body
+	body=$(gh issue view "$target_issue" --repo "$repo" \
+		--json body --jq '.body // ""' 2>/dev/null) || body=""
+
+	if [[ -z "$body" ]]; then
+		log_verbose "#$target_issue: empty body — no cross-phase deps to backfill"
+		printf '\n=== Cross-Phase Blocked-By Backfill ===\nPairs: 0\n'
+		return 0
+	fi
+
+	# Initialise node-ID cache for this invocation
+	_init_node_id_cache
+
+	# Parse dependency pairs from the body
+	local pairs
+	pairs=$(_parse_parent_phase_deps "$body")
+
+	if [[ -z "$pairs" ]]; then
+		log_verbose "#$target_issue: no cross-phase dependency declarations found"
+		printf '\n=== Cross-Phase Blocked-By Backfill ===\nPairs: 0\n'
+		return 0
+	fi
+
+	local pairs_set=0 pairs_skipped=0
+	local _bn _lr child_node blocker_node
+
+	while IFS= read -r pair_line; do
+		[[ "$pair_line" =~ ^PAIR:([0-9]+):([0-9]+)$ ]] || continue
+		_bn="${BASH_REMATCH[1]}"
+		_lr="${BASH_REMATCH[2]}"
+
+		child_node=$(_cached_node_id "$_bn" "$repo")
+		blocker_node=$(_cached_node_id "$_lr" "$repo")
+
+		if [[ -z "$child_node" || -z "$blocker_node" ]]; then
+			log_verbose "#$_bn blocked-by #$_lr: could not resolve node IDs — skipping"
+			pairs_skipped=$((pairs_skipped + 1))
+			continue
+		fi
+
+		if [[ "$DRY_RUN" == "true" ]]; then
+			print_info "[DRY-RUN] Would set #$_bn blocked-by #$_lr"
+			pairs_set=$((pairs_set + 1))
+		elif _gh_add_blocked_by "$child_node" "$blocker_node"; then
+			log_verbose "#$_bn blocked-by #$_lr ✓"
+			pairs_set=$((pairs_set + 1))
+		else
+			pairs_skipped=$((pairs_skipped + 1))
+		fi
+	done <<< "$pairs"
+
+	printf '\n=== Cross-Phase Blocked-By Backfill ===\nPairs set: %d | Skipped: %d\n' \
+		"$pairs_set" "$pairs_skipped"
+	return 0
+}
+
 # Backfill sub-issue parent-child links for issues in the current repo.
 # Detects parents from title/body only — no TODO.md or brief file required.
 #

--- a/.agents/scripts/pulse-issue-reconcile.sh
+++ b/.agents/scripts/pulse-issue-reconcile.sh
@@ -2253,6 +2253,26 @@ reconcile_issues_single_pass() {
 	fi
 	local pbf_total_run=0 pbf_max_per_cycle=10
 
+	# t2877: periodic cross-phase blocked-by backfill — gated by a separate
+	# interval state file (same default 3600s as t2838 sub-issue backfill).
+	# The backfill is idempotent (addBlockedBy swallows duplicates) so this
+	# is purely a cost-control gate, not a correctness requirement. Shares
+	# _pbf_now as the "current epoch" to avoid a second date(1) call.
+	local _cbb_state_file="${HOME}/.aidevops/state/cross-phase-blocked-by-last-run.epoch"
+	local _cbb_interval="${AIDEVOPS_CROSS_PHASE_BLOCKED_BY_INTERVAL_SECS:-3600}"
+	[[ "$_cbb_interval" =~ ^[1-9][0-9]*$ ]] || _cbb_interval=3600
+	local _cbb_this_cycle=0 _cbb_last_run=0
+	if [[ -r "$_cbb_state_file" ]]; then
+		_cbb_last_run=$(cat "$_cbb_state_file" 2>/dev/null || echo 0)
+		[[ "$_cbb_last_run" =~ ^[0-9]+$ ]] || _cbb_last_run=0
+	fi
+	if [[ "$_pbf_now" -gt 0 ]] && \
+		[[ $((_pbf_now - _cbb_last_run)) -ge "$_cbb_interval" ]] && \
+		[[ -n "$issue_sync_helper" ]]; then
+		_cbb_this_cycle=1
+	fi
+	local cbb_total_run=0 cbb_max_per_cycle=10
+
 	# Cycle-wide counters for log summary
 	local ciw_closed=0 rsd_closed=0 rsd_reset=0 lia_fixed=0
 
@@ -2366,21 +2386,32 @@ reconcile_issues_single_pass() {
 					[[ "$_SP_CPT_NUDGED" -eq 1 ]] && cpt_total_nudged=$((cpt_total_nudged + 1))
 					[[ "$_SP_CPT_ESCALATED" -eq 1 ]] && cpt_total_escalated=$((cpt_total_escalated + 1))
 				fi
-				# t2838: periodic sub-issue backfill — only if cycle-gate fired
-				# AND parent didn't just close (no point linking to closed parent).
-				# Idempotent and silent on no-op (already-linked children).
-				# Counter increments only on success — failed backfills (rate
-				# limit, network error) leave the gate state for next cycle's
-				# retry rather than advancing the clock on broken work.
-				if [[ "$_pbf_this_cycle" -eq 1 ]] && \
-					[[ "$pbf_total_run" -lt "$pbf_max_per_cycle" ]] && \
-					[[ "${_SP_CPT_CLOSED:-0}" -ne 1 ]]; then
-					if "$issue_sync_helper" backfill-sub-issues --repo "$slug" \
-						--issue "$issue_num" >/dev/null 2>&1; then
-						pbf_total_run=$((pbf_total_run + 1))
-					fi
+			# t2838: periodic sub-issue backfill — only if cycle-gate fired
+			# AND parent didn't just close (no point linking to closed parent).
+			# Idempotent and silent on no-op (already-linked children).
+			# Counter increments only on success — failed backfills (rate
+			# limit, network error) leave the gate state for next cycle's
+			# retry rather than advancing the clock on broken work.
+			if [[ "$_pbf_this_cycle" -eq 1 ]] && \
+				[[ "$pbf_total_run" -lt "$pbf_max_per_cycle" ]] && \
+				[[ "${_SP_CPT_CLOSED:-0}" -ne 1 ]]; then
+				if "$issue_sync_helper" backfill-sub-issues --repo "$slug" \
+					--issue "$issue_num" >/dev/null 2>&1; then
+					pbf_total_run=$((pbf_total_run + 1))
 				fi
-				continue  # parent-task issues do not flow to stage 5
+			fi
+			# t2877: periodic cross-phase blocked-by backfill — mirrors t2838
+			# gate pattern. Only runs if the parent didn't just close and the
+			# cycle-gate fired. Idempotent (addBlockedBy swallows duplicates).
+			if [[ "$_cbb_this_cycle" -eq 1 ]] && \
+				[[ "$cbb_total_run" -lt "$cbb_max_per_cycle" ]] && \
+				[[ "${_SP_CPT_CLOSED:-0}" -ne 1 ]]; then
+				if "$issue_sync_helper" backfill-cross-phase-blocked-by \
+					--repo "$slug" --issue "$issue_num" >/dev/null 2>&1; then
+					cbb_total_run=$((cbb_total_run + 1))
+				fi
+			fi
+			continue  # parent-task issues do not flow to stage 5
 			fi
 
 			# Stage 5: backfill labelless aidevops-shaped issues (per-repo cap)
@@ -2401,10 +2432,16 @@ reconcile_issues_single_pass() {
 		printf '%s\n' "$_pbf_now" >"$_pbf_state_file" 2>/dev/null || true
 	fi
 
+	# t2877: persist last-run epoch for cross-phase blocked-by backfill.
+	if [[ "$_cbb_this_cycle" -eq 1 ]] && [[ "$cbb_total_run" -gt 0 ]]; then
+		mkdir -p "$(dirname "$_cbb_state_file")" 2>/dev/null || true
+		printf '%s\n' "$_pbf_now" >"$_cbb_state_file" 2>/dev/null || true
+	fi
+
 	local _total_actions
-	_total_actions=$((ciw_closed + rsd_closed + rsd_reset + oimp_total_closed + cpt_total_closed + cpt_total_nudged + cpt_total_escalated + lia_fixed + pbf_total_run))
+	_total_actions=$((ciw_closed + rsd_closed + rsd_reset + oimp_total_closed + cpt_total_closed + cpt_total_nudged + cpt_total_escalated + lia_fixed + pbf_total_run + cbb_total_run))
 	if [[ "$_total_actions" -gt 0 ]]; then
-		echo "[pulse-wrapper] reconcile_issues_single_pass: ciw_closed=${ciw_closed} rsd_closed=${rsd_closed} rsd_reset=${rsd_reset} oimp_closed=${oimp_total_closed} cpt_closed=${cpt_total_closed} cpt_nudged=${cpt_total_nudged} cpt_escalated=${cpt_total_escalated} lia_fixed=${lia_fixed} pbf_run=${pbf_total_run}" >>"$LOGFILE"
+		echo "[pulse-wrapper] reconcile_issues_single_pass: ciw_closed=${ciw_closed} rsd_closed=${rsd_closed} rsd_reset=${rsd_reset} oimp_closed=${oimp_total_closed} cpt_closed=${cpt_total_closed} cpt_nudged=${cpt_total_nudged} cpt_escalated=${cpt_total_escalated} lia_fixed=${lia_fixed} pbf_run=${pbf_total_run} cbb_run=${cbb_total_run}" >>"$LOGFILE"
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-parent-phase-dep-parser.sh
+++ b/.agents/scripts/tests/test-parent-phase-dep-parser.sh
@@ -127,7 +127,12 @@ assert_empty() {
 
 count_lines() {
 	local text="$1"
-	printf '%s' "$text" | grep -c '.' 2>/dev/null || echo "0"
+	# Use safe grep-c pattern (t2763): grep -c exits 1 on zero-match and still
+	# prints "0"; "|| echo 0" would stack "0\n0". Use || true and validate instead.
+	local _n
+	_n=$(printf '%s' "$text" | grep -c '.' 2>/dev/null || true)
+	[[ "$_n" =~ ^[0-9]+$ ]] || _n=0
+	printf '%s\n' "$_n"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-parent-phase-dep-parser.sh
+++ b/.agents/scripts/tests/test-parent-phase-dep-parser.sh
@@ -1,0 +1,673 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# shellcheck disable=SC2016  # single-quoted regex/grep patterns are literal by design
+#
+# test-parent-phase-dep-parser.sh — tests for t2877 (GH#20972)
+#
+# Tests for the cross-phase dependency parser helpers added to
+# issue-sync-relationships.sh:
+#
+#   _resolve_single_phase_ref  — exact and prefix-match phase → issue num
+#   _expand_slash_notation     — P0.5b/c → P0.5b + P0.5c
+#   _expand_phase_refs_to_nums — full tokeniser: handles +, comma, slash
+#   _parse_parent_phase_deps   — full parser: phases table + dep section → PAIRs
+#
+# Test coverage:
+#
+#   Class A — _resolve_single_phase_ref
+#     1.  Exact match returns correct issue number
+#     2.  Bare phase (P1) returns all children (P1a, P1c)
+#     3.  Decimal bare phase (P0.5) returns all children (P0.5a, P0.5b, P0.5c)
+#     4.  Unknown phase returns empty
+#
+#   Class B — _expand_slash_notation
+#     5.  P0.5b/c expands to both P0.5b and P0.5c issue numbers
+#     6.  P4a/P4b (both start with P) expands to both issue numbers
+#     7.  Single element (no slash) returns the one issue number
+#
+#   Class C — _expand_phase_refs_to_nums
+#     8.  "P0a + P0b" returns two numbers
+#     9.  "P4 + P1c + P0.5b/c" returns all expanded numbers
+#    10.  "P1 children" strips "children" and returns P1 prefix matches
+#    11.  Empty / whitespace input returns nothing
+#
+#   Class D — _parse_parent_phase_deps (full t2840 dependency line shapes)
+#    12.  No phases table → no output
+#    13.  Phases table present, no dep section → no output
+#    14.  "P2d blocked by P2c" → one PAIR
+#    15.  "P1 children blocked by P0a + P0b" → four PAIRs (2×2)
+#    16.  "P2c blocked by P0.5a + P0.5c" → two PAIRs
+#    17.  "P0.5 children blocked by P0a" → three PAIRs (3 P0.5 children × 1)
+#    18.  "P5c blocked by P4a + P4b" → two PAIRs
+#    19.  "P6 blocked by P4 + P1c + P0.5b/c" → 2×5 = 10 PAIRs
+#    20.  "P2a/P2b can ship in parallel with P0" → zero PAIRs (skip)
+#    21.  Idempotent: same body → same PAIR output (deterministic)
+#    22.  cmd_backfill_cross_phase_blocked_by --dry-run prints DRY-RUN lines
+#    23.  Missing --issue flag → non-zero exit
+#
+# Strategy:
+#   - Source issue-sync-helper.sh (which sources issue-sync-relationships.sh)
+#     with a stubbed gh binary that returns success for all mutations and
+#     canned node IDs for all issue views.
+#   - Pure string-processing tests (Class A-D) need no network.
+#   - Class E (cmd_*) uses a stub gh to record mutations.
+
+set -u
+
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_BLUE=$'\033[0;34m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_BLUE="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf '  %sPASS%s %s\n' "$TEST_GREEN" "$TEST_NC" "$1"
+	return 0
+}
+
+fail() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '  %sFAIL%s %s\n' "$TEST_RED" "$TEST_NC" "$1"
+	if [[ -n "${2:-}" ]]; then
+		printf '       %s\n' "$2"
+	fi
+	return 0
+}
+
+assert_contains() {
+	local label="$1" needle="$2" haystack="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$haystack" == *"$needle"* ]]; then
+		printf '  %sPASS%s %s\n' "$TEST_GREEN" "$TEST_NC" "$label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		printf '  %sFAIL%s %s\n' "$TEST_RED" "$TEST_NC" "$label"
+		printf '       expected to contain: %s\n' "$needle"
+		printf '       actual: %s\n' "$haystack"
+	fi
+	return 0
+}
+
+assert_not_contains() {
+	local label="$1" needle="$2" haystack="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$haystack" != *"$needle"* ]]; then
+		printf '  %sPASS%s %s\n' "$TEST_GREEN" "$TEST_NC" "$label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		printf '  %sFAIL%s %s\n' "$TEST_RED" "$TEST_NC" "$label"
+		printf '       expected NOT to contain: %s\n' "$needle"
+		printf '       actual: %s\n' "$haystack"
+	fi
+	return 0
+}
+
+assert_empty() {
+	local label="$1" val="$2"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ -z "$val" ]]; then
+		printf '  %sPASS%s %s\n' "$TEST_GREEN" "$TEST_NC" "$label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		printf '  %sFAIL%s %s\n' "$TEST_RED" "$TEST_NC" "$label"
+		printf '       expected empty, got: %s\n' "$val"
+	fi
+	return 0
+}
+
+count_lines() {
+	local text="$1"
+	printf '%s' "$text" | grep -c '.' 2>/dev/null || echo "0"
+	return 0
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)" || exit 1
+HELPER="${SCRIPTS_DIR}/issue-sync-helper.sh"
+
+if [[ ! -f "$HELPER" ]]; then
+	printf 'test harness cannot find helper at %s\n' "$HELPER" >&2
+	exit 1
+fi
+
+TMP=$(mktemp -d -t t2877-phase-dep.XXXXXX)
+trap 'rm -rf "$TMP"' EXIT
+
+# -----------------------------------------------------------------------------
+# Stubbed gh binary
+# -----------------------------------------------------------------------------
+GH_LOG="${TMP}/gh.log"
+export GH_LOG
+: >"$GH_LOG"
+
+mkdir -p "${TMP}/bin"
+cat >"${TMP}/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${GH_LOG:-/dev/null}"
+
+cmd1="${1:-}"
+cmd2="${2:-}"
+
+# gh issue view <N> --json body
+if [[ "$cmd1" == "issue" && "$cmd2" == "view" ]]; then
+	num="${3:-}"
+	var="GH_ISSUE_${num}_JSON"
+	payload="${!var:-}"
+	if [[ -z "$payload" ]]; then
+		payload='{"title":"","body":"","labels":[]}'
+	fi
+	# honour --jq if jq available
+	jq_filter=""
+	prev=""
+	for arg in "$@"; do
+		if [[ "$prev" == "--jq" ]]; then jq_filter="$arg"; fi
+		prev="$arg"
+	done
+	if [[ -n "$jq_filter" ]] && command -v jq >/dev/null 2>&1; then
+		printf '%s\n' "$payload" | jq -r "$jq_filter"
+	else
+		printf '%s\n' "$payload"
+	fi
+	exit 0
+fi
+
+# gh api graphql -f query=...
+if [[ "$cmd1" == "api" && "$cmd2" == "graphql" ]]; then
+	for arg in "$@"; do
+		if [[ "$arg" == *"addBlockedBy"* ]]; then
+			printf '%s\n' '{"data":{"addBlockedBy":{"issue":{"number":99}}}}'
+			exit 0
+		fi
+		if [[ "$arg" == *"issue(number"* ]]; then
+			printf '%s\n' 'NODE_STUB_ID'
+			exit 0
+		fi
+	done
+	printf '%s\n' '{}'
+	exit 0
+fi
+
+# gh api rate_limit
+if [[ "$cmd1" == "api" && "$cmd2" == "rate_limit" ]]; then
+	printf '%s\n' '{"resources":{"graphql":{"remaining":5000}}}'
+	exit 0
+fi
+
+# gh api /repos/.../issues/NNN → REST node_id fallback
+if [[ "$cmd1" == "api" && "$cmd2" =~ ^/repos/ ]]; then
+	printf '%s\n' '{"node_id":"REST_NODE_STUB"}'
+	exit 0
+fi
+
+printf '%s\n' '{}'
+exit 0
+STUB
+chmod +x "${TMP}/bin/gh"
+
+# Prepend stub directory to PATH so both the helper and sub-processes use it.
+export PATH="${TMP}/bin:${PATH}"
+
+# Source the helper (which sources issue-sync-relationships.sh)
+DRY_RUN="false"
+VERBOSE="false"
+REPO_SLUG="marcusquinn/aidevops"
+FORCE_CLOSE="false"
+FORCE_ENRICH="false"
+FORCE_PUSH="false"
+# shellcheck disable=SC1090
+source "$HELPER" >/dev/null 2>&1 || true
+# Re-prepend stub: issue-sync-helper.sh resets PATH to system paths internally
+# (line 32: export PATH="/usr/local/bin:/usr/bin:/bin:${PATH:-}"), which pushes
+# the stub binary to the end and lets the real gh take over. Re-adding here
+# ensures sub-process calls from cmd_* functions use the stub, not real gh.
+export PATH="${TMP}/bin:${PATH}"
+
+# Expose functions loaded via sourced sub-files
+# (issue-sync-relationships.sh is sourced inside issue-sync-helper.sh)
+
+# Minimal _init_cmd stub so cmd_backfill_cross_phase_blocked_by can initialise.
+# In real usage _init_cmd sets _CMD_REPO and _CMD_TODO. Here we set them directly.
+_CMD_REPO="${REPO_SLUG:-marcusquinn/aidevops}"
+_CMD_TODO="${TMP}/TODO.md"
+printf '' >"$_CMD_TODO"
+
+# Override _init_cmd so command tests don't require a full TODO.md / repo context.
+_init_cmd() {
+	_CMD_REPO="${REPO_SLUG:-marcusquinn/aidevops}"
+	_CMD_TODO="${TMP}/TODO.md"
+	return 0
+}
+
+# --------------------------------------------------------------------------
+# Shared fixture: phase_map matching t2840 / #20892 subset
+# --------------------------------------------------------------------------
+# P0 children
+PHASE_MAP=""
+PHASE_MAP+="P0a=20896"$'\n'
+PHASE_MAP+="P0b=20895"$'\n'
+PHASE_MAP+="P0c=20897"$'\n'
+# P0.5 children
+PHASE_MAP+="P0.5a=20899"$'\n'
+PHASE_MAP+="P0.5b=20900"$'\n'
+PHASE_MAP+="P0.5c=20901"$'\n'
+# P1 children
+PHASE_MAP+="P1a=20902"$'\n'
+PHASE_MAP+="P1c=20903"$'\n'
+# P2 children
+PHASE_MAP+="P2a=20930"$'\n'
+PHASE_MAP+="P2b=20931"$'\n'
+PHASE_MAP+="P2c=20932"$'\n'
+PHASE_MAP+="P2d=20933"$'\n'
+# P4 children
+PHASE_MAP+="P4a=20904"$'\n'
+PHASE_MAP+="P4b=20905"$'\n'
+PHASE_MAP+="P4c=20906"$'\n'
+# P5 children
+PHASE_MAP+="P5a=20908"$'\n'
+PHASE_MAP+="P5b=20909"$'\n'
+PHASE_MAP+="P5c=20910"$'\n'
+# P6 children
+PHASE_MAP+="P6a=20911"$'\n'
+PHASE_MAP+="P6b=20912"$'\n'
+
+# Build a synthetic parent body that matches the t2840 format.
+# Used by Class D tests.
+read -r -d '' PARENT_BODY <<'BODY' || true
+## Phases & Children
+
+### P0 — knowledge plane skeleton
+
+| Child | Title |
+|---|---|
+| t2844 / #20896 | P0a: knowledge plane directory contract + provisioning |
+| t2843 / #20895 | P0b: knowledge CLI surface |
+| t2845 / #20897 | P0c: knowledge review gate routine |
+
+### P0.5 — sensitivity + LLM routing layer
+
+| Child | Title |
+|---|---|
+| t2846 / #20899 | P0.5a: sensitivity classification schema |
+| t2847 / #20900 | P0.5b: LLM routing helper |
+| t2848 / #20901 | P0.5c: Ollama integration |
+
+### P1 — kind-aware enrichment
+
+| Child | Title |
+|---|---|
+| t2849 / #20902 | P1a: kind-aware enrichment |
+| t2850 / #20903 | P1c: PageIndex tree generation |
+
+### P2 — `_inbox/` capture
+
+| Child | Title |
+|---|---|
+| t2866 / #20930 | P2a: _inbox/ directory contract |
+| t2867 / #20931 | P2b: inbox capture CLI |
+| t2868 / #20932 | P2c: inbox triage routine |
+| t2869 / #20933 | P2d: pulse digest |
+
+### P4 — cases plane
+
+| Child | Title |
+|---|---|
+| t2851 / #20904 | P4a: case dossier contract |
+| t2852 / #20905 | P4b: case CLI surface |
+| t2853 / #20906 | P4c: case milestone |
+
+### P5 — email channel
+
+| Child | Title |
+|---|---|
+| t2854 / #20908 | P5a: .eml ingestion |
+| t2855 / #20909 | P5b: IMAP polling |
+| t2856 / #20910 | P5c: email thread reconstruction |
+
+### P6 — AI comms agent
+
+| Child | Title |
+|---|---|
+| t2857 / #20911 | P6a: aidevops case draft agent |
+| t2858 / #20912 | P6b: aidevops case chase |
+
+## Cross-Phase Dependencies
+
+- P0.5 children blocked by P0a (need plane substrate to stamp meta.json)
+- P1 children blocked by P0a + P0b (need directory contract + CLI before structured extraction)
+- P2a/P2b can ship in parallel with P0 (independent directory contract)
+- P2c blocked by P0.5a + P0.5c (sensitivity-first triage requires local detector + Ollama)
+- P2d blocked by P2c (digest reads from triage.log)
+- P4 children blocked by P0a + P0b + P0.5a (cases plane uses sensitivity stamps)
+- P5 children blocked by P0a + P0b + P1a (email is a kind of knowledge ingestion)
+- P5c blocked by P4a + P4b (filter→case-attach uses case CLI)
+- P6 blocked by P4 + P1c + P0.5b/c (drafts use cases, RAG, LLM routing)
+
+Within each phase, children that don't depend on each other can run in parallel.
+
+## Reference
+
+Full design: todo/tasks/t2840-brief.md
+BODY
+
+# =============================================================================
+# Class A — _resolve_single_phase_ref
+# =============================================================================
+printf '\n%s--- Class A: _resolve_single_phase_ref ---%s\n' "$TEST_BLUE" "$TEST_NC"
+
+# Test 1: exact match returns correct issue number
+result=$(_resolve_single_phase_ref "P0a" "$PHASE_MAP")
+[[ "$result" == "20896" ]] && pass "1. exact match P0a → 20896" \
+	|| fail "1. exact match P0a → 20896" "got: ${result}"
+
+# Test 2: bare phase P1 returns both P1 children
+result=$(_resolve_single_phase_ref "P1" "$PHASE_MAP")
+assert_contains "2. bare P1 includes P1a (20902)" "20902" "$result"
+assert_contains "2. bare P1 includes P1c (20903)" "20903" "$result"
+
+# Test 3: decimal bare phase P0.5 returns all three children
+result=$(_resolve_single_phase_ref "P0.5" "$PHASE_MAP")
+assert_contains "3. bare P0.5 includes P0.5a (20899)" "20899" "$result"
+assert_contains "3. bare P0.5 includes P0.5b (20900)" "20900" "$result"
+assert_contains "3. bare P0.5 includes P0.5c (20901)" "20901" "$result"
+
+# Test 4: unknown phase returns empty
+result=$(_resolve_single_phase_ref "P9x" "$PHASE_MAP")
+assert_empty "4. unknown phase P9x → empty" "$result"
+
+# =============================================================================
+# Class B — _expand_slash_notation
+# =============================================================================
+printf '\n%s--- Class B: _expand_slash_notation ---%s\n' "$TEST_BLUE" "$TEST_NC"
+
+# Test 5: P0.5b/c expands to P0.5b and P0.5c
+result=$(_expand_slash_notation "P0.5b/c" "$PHASE_MAP")
+assert_contains "5. P0.5b/c includes P0.5b (20900)" "20900" "$result"
+assert_contains "5. P0.5b/c includes P0.5c (20901)" "20901" "$result"
+line_count=$(count_lines "$result")
+[[ "$line_count" -eq 2 ]] && pass "5. P0.5b/c expands to exactly 2 issue numbers" \
+	|| fail "5. P0.5b/c expands to exactly 2 issue numbers" "got count: ${line_count}, val: ${result}"
+
+# Test 6: P4a/P4b (both start with P) expands to both
+result=$(_expand_slash_notation "P4a/P4b" "$PHASE_MAP")
+assert_contains "6. P4a/P4b includes P4a (20904)" "20904" "$result"
+assert_contains "6. P4a/P4b includes P4b (20905)" "20905" "$result"
+
+# Test 7: single element (no slash) returns the one number
+result=$(_expand_slash_notation "P2c" "$PHASE_MAP")
+[[ "$result" == "20932" ]] && pass "7. single P2c → 20932" \
+	|| fail "7. single P2c → 20932" "got: ${result}"
+
+# =============================================================================
+# Class C — _expand_phase_refs_to_nums
+# =============================================================================
+printf '\n%s--- Class C: _expand_phase_refs_to_nums ---%s\n' "$TEST_BLUE" "$TEST_NC"
+
+# Test 8: "P0a + P0b" returns two issue numbers
+result=$(_expand_phase_refs_to_nums "P0a + P0b" "$PHASE_MAP")
+assert_contains "8. P0a + P0b includes 20896" "20896" "$result"
+assert_contains "8. P0a + P0b includes 20895" "20895" "$result"
+
+# Test 9: "P4 + P1c + P0.5b/c" returns all expanded numbers
+result=$(_expand_phase_refs_to_nums "P4 + P1c + P0.5b/c" "$PHASE_MAP")
+assert_contains "9. P4+P1c+P0.5b/c includes P4a (20904)" "20904" "$result"
+assert_contains "9. P4+P1c+P0.5b/c includes P4b (20905)" "20905" "$result"
+assert_contains "9. P4+P1c+P0.5b/c includes P4c (20906)" "20906" "$result"
+assert_contains "9. P4+P1c+P0.5b/c includes P1c (20903)" "20903" "$result"
+assert_contains "9. P4+P1c+P0.5b/c includes P0.5b (20900)" "20900" "$result"
+assert_contains "9. P4+P1c+P0.5b/c includes P0.5c (20901)" "20901" "$result"
+
+# Test 10: "P1 children" strips "children" and returns P1 prefix matches
+result=$(_expand_phase_refs_to_nums "P1 children" "$PHASE_MAP")
+assert_contains "10. P1 children includes P1a (20902)" "20902" "$result"
+assert_contains "10. P1 children includes P1c (20903)" "20903" "$result"
+
+# Test 11: empty input returns nothing
+result=$(_expand_phase_refs_to_nums "" "$PHASE_MAP")
+assert_empty "11. empty input returns empty" "$result"
+
+# =============================================================================
+# Class D — _parse_parent_phase_deps (full parser)
+# =============================================================================
+printf '\n%s--- Class D: _parse_parent_phase_deps ---%s\n' "$TEST_BLUE" "$TEST_NC"
+
+# Test 12: no phases table → no output
+BODY_NO_TABLE="## Cross-Phase Dependencies
+
+- P1 children blocked by P0a
+"
+result=$(_parse_parent_phase_deps "$BODY_NO_TABLE")
+assert_empty "12. no phases table → no PAIR output" "$result"
+
+# Test 13: phases table present, no dep section → no output
+BODY_NO_DEP_SECTION="## Phases & Children
+
+| t100 / #100 | P1a: first child |
+| t101 / #101 | P0a: blocker |
+
+## Other Section
+
+Some other content.
+"
+result=$(_parse_parent_phase_deps "$BODY_NO_DEP_SECTION")
+assert_empty "13. no dep section → no PAIR output" "$result"
+
+# Test 14: simple single-blocker line "P2d blocked by P2c"
+BODY_SIMPLE="## Phases & Children
+
+| t100 / #100 | P2d: digest |
+| t101 / #101 | P2c: triage |
+
+## Cross-Phase Dependencies
+
+- P2d blocked by P2c (digest reads from triage.log)
+"
+result=$(_parse_parent_phase_deps "$BODY_SIMPLE")
+assert_contains "14. P2d blocked by P2c → PAIR:100:101" "PAIR:100:101" "$result"
+line_count=$(count_lines "$result")
+[[ "$line_count" -eq 1 ]] && pass "14. exactly one PAIR" \
+	|| fail "14. exactly one PAIR" "got count: ${line_count}"
+
+# Test 15: "P1 children blocked by P0a + P0b" → 4 pairs (2 children × 2 blockers)
+BODY_P1_DEP="## Phases & Children
+
+| t1 / #1001 | P1a: child A |
+| t2 / #1002 | P1c: child C |
+| t3 / #2001 | P0a: blocker A |
+| t4 / #2002 | P0b: blocker B |
+
+## Cross-Phase Dependencies
+
+- P1 children blocked by P0a + P0b
+"
+result=$(_parse_parent_phase_deps "$BODY_P1_DEP")
+assert_contains "15. P1a blocked by P0a → PAIR:1001:2001" "PAIR:1001:2001" "$result"
+assert_contains "15. P1a blocked by P0b → PAIR:1001:2002" "PAIR:1001:2002" "$result"
+assert_contains "15. P1c blocked by P0a → PAIR:1002:2001" "PAIR:1002:2001" "$result"
+assert_contains "15. P1c blocked by P0b → PAIR:1002:2002" "PAIR:1002:2002" "$result"
+line_count=$(count_lines "$result")
+[[ "$line_count" -eq 4 ]] && pass "15. exactly 4 PAIRs" \
+	|| fail "15. exactly 4 PAIRs (P1×(P0a+P0b))" "got count: ${line_count}, pairs: ${result}"
+
+# Test 16: "P2c blocked by P0.5a + P0.5c" → 2 pairs
+BODY_P2C_DEP="## Phases & Children
+
+| t1 / #3001 | P2c: triage |
+| t2 / #4001 | P0.5a: sensitivity |
+| t3 / #4003 | P0.5c: Ollama |
+
+## Cross-Phase Dependencies
+
+- P2c blocked by P0.5a + P0.5c (sensitivity-first triage)
+"
+result=$(_parse_parent_phase_deps "$BODY_P2C_DEP")
+assert_contains "16. P2c blocked by P0.5a → PAIR:3001:4001" "PAIR:3001:4001" "$result"
+assert_contains "16. P2c blocked by P0.5c → PAIR:3001:4003" "PAIR:3001:4003" "$result"
+line_count=$(count_lines "$result")
+[[ "$line_count" -eq 2 ]] && pass "16. exactly 2 PAIRs" \
+	|| fail "16. exactly 2 PAIRs" "got count: ${line_count}"
+
+# Test 17: "P0.5 children blocked by P0a" → 3 pairs (3 P0.5 children × 1 blocker)
+BODY_P05_DEP="## Phases & Children
+
+| t1 / #5001 | P0.5a: sensitivity schema |
+| t2 / #5002 | P0.5b: LLM routing |
+| t3 / #5003 | P0.5c: Ollama |
+| t4 / #6001 | P0a: dir contract |
+
+## Cross-Phase Dependencies
+
+- P0.5 children blocked by P0a (need plane substrate)
+"
+result=$(_parse_parent_phase_deps "$BODY_P05_DEP")
+assert_contains "17. P0.5a blocked by P0a → PAIR:5001:6001" "PAIR:5001:6001" "$result"
+assert_contains "17. P0.5b blocked by P0a → PAIR:5002:6001" "PAIR:5002:6001" "$result"
+assert_contains "17. P0.5c blocked by P0a → PAIR:5003:6001" "PAIR:5003:6001" "$result"
+line_count=$(count_lines "$result")
+[[ "$line_count" -eq 3 ]] && pass "17. exactly 3 PAIRs" \
+	|| fail "17. exactly 3 PAIRs" "got count: ${line_count}"
+
+# Test 18: "P5c blocked by P4a + P4b" → 2 pairs
+BODY_P5C_DEP="## Phases & Children
+
+| t1 / #7001 | P5c: email thread |
+| t2 / #8001 | P4a: case dossier |
+| t3 / #8002 | P4b: case CLI |
+
+## Cross-Phase Dependencies
+
+- P5c blocked by P4a + P4b (filter→case-attach uses case CLI)
+"
+result=$(_parse_parent_phase_deps "$BODY_P5C_DEP")
+assert_contains "18. P5c blocked by P4a → PAIR:7001:8001" "PAIR:7001:8001" "$result"
+assert_contains "18. P5c blocked by P4b → PAIR:7001:8002" "PAIR:7001:8002" "$result"
+line_count=$(count_lines "$result")
+[[ "$line_count" -eq 2 ]] && pass "18. exactly 2 PAIRs" \
+	|| fail "18. exactly 2 PAIRs" "got count: ${line_count}"
+
+# Test 19: "P6 blocked by P4 + P1c + P0.5b/c" → 2×5 = 10 PAIRs
+BODY_P6_DEP="## Phases & Children
+
+| t1 / #9001 | P6a: draft agent |
+| t2 / #9002 | P6b: case chase |
+| t3 / #10001 | P4a: case dossier |
+| t4 / #10002 | P4b: case CLI |
+| t5 / #10003 | P4c: milestone |
+| t6 / #11001 | P1c: PageIndex |
+| t7 / #12001 | P0.5b: LLM routing |
+| t8 / #12002 | P0.5c: Ollama |
+
+## Cross-Phase Dependencies
+
+- P6 blocked by P4 + P1c + P0.5b/c (drafts use cases, RAG, LLM routing)
+"
+result=$(_parse_parent_phase_deps "$BODY_P6_DEP")
+# P6a blocked by each blocker (5 pairs)
+assert_contains "19. P6a blocked by P4a" "PAIR:9001:10001" "$result"
+assert_contains "19. P6a blocked by P4b" "PAIR:9001:10002" "$result"
+assert_contains "19. P6a blocked by P4c" "PAIR:9001:10003" "$result"
+assert_contains "19. P6a blocked by P1c" "PAIR:9001:11001" "$result"
+assert_contains "19. P6a blocked by P0.5b" "PAIR:9001:12001" "$result"
+assert_contains "19. P6a blocked by P0.5c" "PAIR:9001:12002" "$result"
+# P6b blocked by each blocker (5 pairs)
+assert_contains "19. P6b blocked by P4a" "PAIR:9002:10001" "$result"
+assert_contains "19. P6b blocked by P4b" "PAIR:9002:10002" "$result"
+assert_contains "19. P6b blocked by P4c" "PAIR:9002:10003" "$result"
+assert_contains "19. P6b blocked by P1c" "PAIR:9002:11001" "$result"
+assert_contains "19. P6b blocked by P0.5b" "PAIR:9002:12001" "$result"
+assert_contains "19. P6b blocked by P0.5c" "PAIR:9002:12002" "$result"
+line_count=$(count_lines "$result")
+[[ "$line_count" -eq 12 ]] && pass "19. exactly 12 PAIRs (2×6 blockers)" \
+	|| fail "19. exactly 12 PAIRs (2×6 blockers)" "got count: ${line_count}"
+
+# Test 20: "P2a/P2b can ship in parallel" → zero PAIRs (skipped)
+BODY_PARALLEL="## Phases & Children
+
+| t1 / #13001 | P2a: inbox dir |
+| t2 / #13002 | P2b: inbox capture |
+| t3 / #14001 | P0a: dir contract |
+
+## Cross-Phase Dependencies
+
+- P2a/P2b can ship in parallel with P0 (independent directory contract)
+"
+result=$(_parse_parent_phase_deps "$BODY_PARALLEL")
+assert_empty "20. parallel line generates no PAIRs" "$result"
+
+# Test 21: idempotent — same body → same PAIR output
+result1=$(_parse_parent_phase_deps "$PARENT_BODY")
+result2=$(_parse_parent_phase_deps "$PARENT_BODY")
+[[ "$result1" == "$result2" ]] && pass "21. idempotent: same body → identical PAIR output" \
+	|| fail "21. idempotent: same body → identical PAIR output" "outputs differ"
+
+# Verify the full t2840 body produces expected pairs from the first 8 dep lines
+result_full=$(_parse_parent_phase_deps "$PARENT_BODY")
+# P0.5 children blocked by P0a
+assert_contains "t2840: P0.5a blocked by P0a" "PAIR:20899:20896" "$result_full"
+assert_contains "t2840: P0.5b blocked by P0a" "PAIR:20900:20896" "$result_full"
+assert_contains "t2840: P0.5c blocked by P0a" "PAIR:20901:20896" "$result_full"
+# P1 children blocked by P0a + P0b
+assert_contains "t2840: P1a blocked by P0a" "PAIR:20902:20896" "$result_full"
+assert_contains "t2840: P1a blocked by P0b" "PAIR:20902:20895" "$result_full"
+assert_contains "t2840: P1c blocked by P0a" "PAIR:20903:20896" "$result_full"
+assert_contains "t2840: P1c blocked by P0b" "PAIR:20903:20895" "$result_full"
+# P2c blocked by P0.5a + P0.5c
+assert_contains "t2840: P2c blocked by P0.5a" "PAIR:20932:20899" "$result_full"
+assert_contains "t2840: P2c blocked by P0.5c" "PAIR:20932:20901" "$result_full"
+# P2d blocked by P2c
+assert_contains "t2840: P2d blocked by P2c" "PAIR:20933:20932" "$result_full"
+# P6 blocked by P4 + P1c + P0.5b/c
+assert_contains "t2840: P6a blocked by P4a" "PAIR:20911:20904" "$result_full"
+assert_contains "t2840: P6b blocked by P0.5b" "PAIR:20912:20900" "$result_full"
+assert_contains "t2840: P6b blocked by P0.5c" "PAIR:20912:20901" "$result_full"
+# Parallel line is NOT present
+assert_not_contains "t2840: P2a parallel skipped" "PAIR:20930:" "$result_full"
+
+# =============================================================================
+# Class E — cmd_backfill_cross_phase_blocked_by
+# =============================================================================
+printf '\n%s--- Class E: cmd_backfill_cross_phase_blocked_by ---%s\n' "$TEST_BLUE" "$TEST_NC"
+
+# Test 22: --dry-run prints DRY-RUN lines for each pair (uses stub gh)
+# Set up issue view response: return a body with one simple dep
+export GH_ISSUE_99_JSON='{"body":"## Phases \u0026 Children\n\n| t1 / #101 | P1a: child |\n| t2 / #201 | P0a: blocker |\n\n## Cross-Phase Dependencies\n\n- P1 children blocked by P0a\n"}'
+
+DRY_RUN="true"
+: >"$GH_LOG"
+dry_output=$(cmd_backfill_cross_phase_blocked_by --issue 99 2>&1)
+DRY_RUN="false"
+
+assert_contains "22. --dry-run output contains DRY-RUN" "DRY-RUN" "$dry_output"
+# No addBlockedBy mutation should have been called
+dry_mutations=$(grep "addBlockedBy" "$GH_LOG" 2>/dev/null || true)
+assert_empty "22. --dry-run makes no addBlockedBy mutations" "$dry_mutations"
+
+# Test 23: missing --issue flag → non-zero exit and error message
+set +e
+err_output=$(cmd_backfill_cross_phase_blocked_by 2>&1)
+err_rc=$?
+set -e
+[[ "$err_rc" -ne 0 ]] && pass "23. missing --issue exits non-zero" \
+	|| fail "23. missing --issue exits non-zero" "got rc: ${err_rc}"
+assert_contains "23. error message mentions --issue" "--issue" "$err_output"
+
+# =============================================================================
+# Summary
+# =============================================================================
+printf '\n%s=== Results ===%s\n' "$TEST_BLUE" "$TEST_NC"
+printf 'Tests run: %d\n' "$TESTS_RUN"
+printf 'Tests failed: %d\n' "$TESTS_FAILED"
+
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Automates the manual cross-phase blocked-by backfill work done in t2875 (42 edges for t2840). Parent-task authors naturally write cross-phase dependencies as prose (e.g. "P1 children blocked by P0a + P0b") but the framework's relationship sync only reads explicit `blocked-by:tNNN` from TODO.md. This PR closes that gap permanently.

## Changes

**`issue-sync-relationships.sh`** — new parsing pipeline:
- `_resolve_single_phase_ref`: exact-match (P0a) and prefix-match (P1 → all P1 children)
- `_expand_slash_notation`: `P0.5b/c` → P0.5b + P0.5c (inherited prefix)
- `_expand_phase_refs_to_nums`: tokenises raw ref strings (handles `+`, comma, slash)
- `_parse_parent_phase_deps`: phases table → phase map; dep section → PAIR lines
- `cmd_backfill_cross_phase_blocked_by`: per-issue entry point (`--issue N`)

**`issue-sync-helper.sh`**:
- Registers `backfill-cross-phase-blocked-by` subcommand
- Updated help text

**`pulse-issue-reconcile.sh`**:
- t2877 stage inside Stage 4 (parent-task), alongside t2838 sub-issue backfill
- Rate-limited by `cross-phase-blocked-by-last-run.epoch` (default 3600s)
- `AIDEVOPS_CROSS_PHASE_BLOCKED_BY_INTERVAL_SECS` env override
- `cbb_total_run` in log summary line

**`tests/test-parent-phase-dep-parser.sh`** (new — 76 tests):
- All 8 dependency line shapes from t2840 / #20892
- Resolution, slash-notation expansion, multi-token expansion
- Full t2840 body fixture (correct PAIRs for all declared deps)
- Idempotency, parallel-line skip, dry-run, missing-arg error

## Verification

```bash
bash .agents/scripts/tests/test-parent-phase-dep-parser.sh
# Tests run: 76  Tests failed: 0

# Dry-run against #20892 (already backfilled by t2875 — should produce 0 net changes)
.agents/scripts/issue-sync-helper.sh backfill-cross-phase-blocked-by \
  --repo marcusquinn/aidevops --issue 20892 --dry-run
```

Resolves #20972

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.12.0 plugin for [OpenCode](https://opencode.ai) v1.14.26 with claude-sonnet-4-6 spent 29m and 80,502 tokens on this as a headless worker.
