### PR TITLE
t2931: fix 6 correctness bugs in email polling post-merge review

### DIFF
--- a/.agents/aidevops/knowledge-plane.md
+++ b/.agents/aidevops/knowledge-plane.md
@@ -205,7 +205,7 @@ Field reference:
 | `id` | string | Unique identifier used in state keys and .eml filenames |
 | `provider` | string | Provider slug (matched against `email-providers.json.txt` for host defaults) |
 | `host` | string | IMAP server hostname |
-| `port` | integer | IMAP port (993 = TLS, 143 = STARTTLS) |
+| `port` | integer | IMAP port — use 993 (TLS/SSL). Port 143/STARTTLS is not supported; the implementation uses `IMAP4_SSL` exclusively. |
 | `user` | string | Login username / email address |
 | `password_ref` | string | `gopass:<path>` or environment variable name |
 | `folders` | array | IMAP folders to poll — each tracked independently |

--- a/.agents/scripts/email-mailbox-register-helper.sh
+++ b/.agents/scripts/email-mailbox-register-helper.sh
@@ -58,15 +58,12 @@ _load_or_init_config() {
 		if [[ -f "$MAILBOXES_TEMPLATE" ]]; then
 			cp "$MAILBOXES_TEMPLATE" "$config_path"
 			# Remove example entries from the template copy
-			python3 -c "
-import json, sys
-with open('$config_path') as f:
-    d = json.load(f)
-# Strip entries with _comment fields (they are examples)
+			AIDEVOPS_CFG="$config_path" python3 -c "
+import json, os
+cfg = os.environ['AIDEVOPS_CFG']
+with open(cfg) as f: d = json.load(f)
 d['mailboxes'] = [m for m in d.get('mailboxes', []) if '_comment' not in m]
-with open('$config_path', 'w') as f:
-    json.dump(d, f, indent=2)
-    f.write('\n')
+with open(cfg, 'w') as f: json.dump(d, f, indent=2); f.write('\n')
 "
 		else
 			echo '{"mailboxes":[]}' > "$config_path"
@@ -82,16 +79,13 @@ _provider_defaults() {
 		echo "imap.${provider}.com 993"
 		return 0
 	fi
+	AIDEVOPS_TEMPLATE="$PROVIDERS_TEMPLATE" AIDEVOPS_PROVIDER="$provider" \
 	python3 -c "
-import json, sys
-with open('$PROVIDERS_TEMPLATE') as f:
-    data = json.load(f)
-providers = data.get('providers', {})
-p = providers.get('$provider', {})
+import json, os
+p = json.load(open(os.environ['AIDEVOPS_TEMPLATE'])).get('providers', {}).get(os.environ['AIDEVOPS_PROVIDER'], {})
 imap = p.get('imap', {})
-host = imap.get('host', 'imap.${provider}.com')
-port = imap.get('port', 993)
-print(host, port)
+prov = os.environ['AIDEVOPS_PROVIDER']
+print(imap.get('host', f'imap.{prov}.com'), imap.get('port', 993))
 " 2>/dev/null || echo "imap.${provider}.com 993"
 	return 0
 }
@@ -101,13 +95,35 @@ _list_known_providers() {
 		echo "gmail icloud fastmail cloudron"
 		return 0
 	fi
-	python3 -c "
-import json
-with open('$PROVIDERS_TEMPLATE') as f:
-    data = json.load(f)
-providers = list(data.get('providers', {}).keys())
-print(' '.join(providers))
+	AIDEVOPS_TEMPLATE="$PROVIDERS_TEMPLATE" python3 -c "
+import json, os
+print(' '.join(json.load(open(os.environ['AIDEVOPS_TEMPLATE'])).get('providers', {}).keys()))
 " 2>/dev/null || echo "gmail icloud fastmail cloudron"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Config write helper — uses env vars to avoid shell-interpolation injection
+# ---------------------------------------------------------------------------
+
+_write_mailbox_entry() {
+	local config_path="$1" mb_id="$2" provider="$3" host="$4" port="$5"
+	local user="$6" password_ref="$7" folders_json="$8" since="$9"
+	AIDEVOPS_CFG="$config_path" AIDEVOPS_MBID="$mb_id" \
+	AIDEVOPS_PROV="$provider" AIDEVOPS_HOST="$host" AIDEVOPS_PORT="$port" \
+	AIDEVOPS_USER="$user" AIDEVOPS_PWREF="$password_ref" \
+	AIDEVOPS_FOLDERS="$folders_json" AIDEVOPS_SINCE="$since" \
+	python3 -c "
+import json, os; e = os.environ
+with open(e['AIDEVOPS_CFG']) as f: d = json.load(f)
+entry = {'id': e['AIDEVOPS_MBID'], 'provider': e['AIDEVOPS_PROV'],
+    'host': e['AIDEVOPS_HOST'], 'port': int(e['AIDEVOPS_PORT']),
+    'user': e['AIDEVOPS_USER'], 'password_ref': e['AIDEVOPS_PWREF'],
+    'folders': json.loads(e['AIDEVOPS_FOLDERS']), 'since': e['AIDEVOPS_SINCE']}
+d['mailboxes'] = [m for m in d.get('mailboxes', []) if m.get('id') != entry['id']]
+d['mailboxes'].append(entry)
+with open(e['AIDEVOPS_CFG'], 'w') as f: json.dump(d, f, indent=2); f.write('\n')
+"
 	return 0
 }
 
@@ -187,37 +203,17 @@ cmd_add() {
 		return 0
 	fi
 
-	# Build folders array
+	# Build folders array (env var avoids interpolation issues with user input)
 	local folders_json
-	folders_json=$(python3 -c "
-import json
-folders = [f.strip() for f in '$folders_input'.split(',') if f.strip()]
+	folders_json=$(AIDEVOPS_FOLDERS_INPUT="$folders_input" python3 -c "
+import json, os
+folders = [f.strip() for f in os.environ['AIDEVOPS_FOLDERS_INPUT'].split(',') if f.strip()]
 print(json.dumps(folders))
 ")
 
-	# Add entry to config
-	python3 -c "
-import json
-with open('$config_path') as f:
-    d = json.load(f)
-entry = {
-    'id': '$mb_id',
-    'provider': '$provider',
-    'host': '$host',
-    'port': $port,
-    'user': '$user',
-    'password_ref': '$password_ref',
-    'folders': $folders_json,
-    'since': '$since',
-}
-# Remove existing entry with same id if present
-d['mailboxes'] = [m for m in d.get('mailboxes', []) if m.get('id') != '$mb_id']
-d['mailboxes'].append(entry)
-with open('$config_path', 'w') as f:
-    json.dump(d, f, indent=2)
-    f.write('\n')
-print('Saved')
-"
+	# Add entry to config via helper (env vars, no shell interpolation)
+	_write_mailbox_entry "$config_path" "$mb_id" "$provider" "$host" "$port" \
+		"$user" "$password_ref" "$folders_json" "$since"
 	print_success "Mailbox '$mb_id' registered in $config_path"
 
 	# Test connection (dry-run)
@@ -256,19 +252,14 @@ cmd_remove() {
 		return 1
 	fi
 
-	python3 -c "
-import json, sys
-with open('$config_path') as f:
-    d = json.load(f)
+	AIDEVOPS_CFG="$config_path" AIDEVOPS_MBID="$mailbox_id" python3 -c "
+import json, sys, os
+cfg, mb_id = os.environ['AIDEVOPS_CFG'], os.environ['AIDEVOPS_MBID']
+with open(cfg) as f: d = json.load(f)
 before = len(d.get('mailboxes', []))
-d['mailboxes'] = [m for m in d.get('mailboxes', []) if m.get('id') != '$mailbox_id']
-after = len(d['mailboxes'])
-if before == after:
-    print('ERROR: mailbox not found', file=sys.stderr)
-    sys.exit(1)
-with open('$config_path', 'w') as f:
-    json.dump(d, f, indent=2)
-    f.write('\n')
+d['mailboxes'] = [m for m in d.get('mailboxes', []) if m.get('id') != mb_id]
+if before == len(d['mailboxes']): print('ERROR: not found', file=sys.stderr); sys.exit(1)
+with open(cfg, 'w') as f: json.dump(d, f, indent=2); f.write('\n')
 print('Removed')
 " && print_success "Mailbox '$mailbox_id' removed from $config_path" || {
 		print_error "Mailbox '$mailbox_id' not found in $config_path"

--- a/.agents/scripts/email-poll-helper.sh
+++ b/.agents/scripts/email-poll-helper.sh
@@ -131,14 +131,21 @@ cmd_tick() {
 
 	log_info "Polling mailboxes (config: $config_path)"
 	local result
+	local py_exit=0
+	local _stderr_tmp
+	_stderr_tmp=$(mktemp)
 	result=$(python3 "$POLL_PY" tick \
 		--config "$config_path" \
 		--state "$_STATE_FILE" \
-		--inbox "$_INBOX_DIR" 2>&1) || {
-		log_error "email_poll.py tick failed"
-		log_error "$result"
+		--inbox "$_INBOX_DIR" 2>"$_stderr_tmp") || py_exit=$?
+	local _py_stderr
+	_py_stderr=$(cat "$_stderr_tmp" 2>/dev/null || true)
+	rm -f "$_stderr_tmp"
+	[[ -n "$_py_stderr" ]] && log_warn "email_poll.py: $_py_stderr"
+	if [[ "$py_exit" -ne 0 && -z "$result" ]]; then
+		log_error "email_poll.py tick failed (exit $py_exit)"
 		return 1
-	}
+	fi
 
 	# Parse summary from JSON result
 	local overall_status fetched_count

--- a/.agents/scripts/email_poll.py
+++ b/.agents/scripts/email_poll.py
@@ -145,8 +145,14 @@ def _connect_imap(host: str, port: int, user: str, password: str) -> imaplib.IMA
     return conn
 
 
-def _uid_fetch_since(conn: imaplib.IMAP4_SSL, folder: str, last_uid: int) -> list[tuple[int, bytes]]:
-    """Fetch all messages with UID > last_uid in folder.
+def _uid_fetch_since(
+    conn: imaplib.IMAP4_SSL, folder: str, last_uid: int, max_uids: int = 0
+) -> list[tuple[int, bytes]]:
+    """Fetch messages with UID > last_uid in folder.
+
+    Args:
+        max_uids: If > 0, fetch at most this many messages (oldest first).
+                  Used by cmd_test to avoid fetching entire mailboxes.
 
     Returns a list of (uid, raw_rfc822_bytes) tuples sorted by UID ascending.
     """
@@ -172,6 +178,10 @@ def _uid_fetch_since(conn: imaplib.IMAP4_SSL, folder: str, last_uid: int) -> lis
     valid_uids = [int(u) for u in uid_strings if int(u) > last_uid]
     if not valid_uids:
         return []
+
+    # Limit to max_uids when set (test mode: avoids fetching entire mailboxes)
+    if max_uids > 0:
+        valid_uids = valid_uids[:max_uids]
 
     uid_set = ",".join(str(u) for u in valid_uids)
     status, fetch_data = conn.uid("FETCH", uid_set, "(RFC822)")  # type: ignore[arg-type]
@@ -260,11 +270,16 @@ def _uid_fetch_since_date(
 # .eml file output
 # ---------------------------------------------------------------------------
 
-def _write_eml(inbox_dir: str, mailbox_id: str, uid: int, raw_msg: bytes) -> Path:
-    """Write raw RFC-822 bytes to inbox_dir/email-<mailbox_id>-<uid>.eml."""
+def _write_eml(inbox_dir: str, mailbox_id: str, folder: str, uid: int, raw_msg: bytes) -> Path:
+    """Write raw RFC-822 bytes to inbox_dir/email-<mailbox_id>-<folder>-<uid>.eml.
+
+    Folder is included to prevent UID collisions across folders (UIDs are
+    per-folder on IMAP servers, so the same UID can exist in multiple folders).
+    """
     Path(inbox_dir).mkdir(parents=True, exist_ok=True)
     safe_id = re.sub(r"[^a-zA-Z0-9_-]", "_", mailbox_id)
-    filename = f"email-{safe_id}-{uid}.eml"
+    safe_folder = re.sub(r"[^a-zA-Z0-9_-]", "_", folder)
+    filename = f"email-{safe_id}-{safe_folder}-{uid}.eml"
     out_path = Path(inbox_dir) / filename
     out_path.write_bytes(raw_msg)
     return out_path
@@ -280,6 +295,7 @@ def poll_mailbox(
     inbox_dir: str,
     dry_run: bool = False,
     rate_limit_per_min: int = 0,
+    max_messages: int = 0,
 ) -> dict:
     """Poll a single mailbox; return a per-mailbox result dict.
 
@@ -289,6 +305,7 @@ def poll_mailbox(
         inbox_dir:         Absolute path to the _knowledge/inbox/ directory.
         dry_run:           If True, fetch but do NOT write .eml or update state.
         rate_limit_per_min: Max messages per minute (0 = unlimited).
+        max_messages:      If > 0, fetch at most this many per folder (test mode).
 
     Returns:
         {mailbox_id, status, fetched_count, new_high_uid, error?}
@@ -338,7 +355,7 @@ def poll_mailbox(
 
             folder_result = {"folder": folder, "fetched": 0, "error": None}
             try:
-                messages = _uid_fetch_since(conn, folder, last_uid)
+                messages = _uid_fetch_since(conn, folder, last_uid, max_uids=max_messages)
             except Exception as exc:
                 folder_result["error"] = str(exc)
                 result["folders"][folder] = folder_result
@@ -350,7 +367,7 @@ def poll_mailbox(
 
             for uid, raw_msg in messages:
                 if not dry_run:
-                    _write_eml(inbox_dir, mb_id, uid, raw_msg)
+                    _write_eml(inbox_dir, mb_id, folder, uid, raw_msg)
                 if uid > new_high_uid:
                     new_high_uid = uid
                 total_fetched += 1
@@ -440,7 +457,7 @@ def backfill_mailbox(
                 continue
 
             for uid, raw_msg in messages:
-                _write_eml(inbox_dir, mb_id, uid, raw_msg)
+                _write_eml(inbox_dir, mb_id, folder, uid, raw_msg)
                 total_fetched += 1
                 folder_result["fetched"] += 1
                 if delay > 0:
@@ -517,7 +534,7 @@ def cmd_test(args: argparse.Namespace) -> int:
     mb_config = get_mailbox_config(config, args.mailbox_id)
     state: dict = {}
 
-    res = poll_mailbox(mb_config, state, inbox_dir="/dev/null", dry_run=True)
+    res = poll_mailbox(mb_config, state, inbox_dir="/dev/null", dry_run=True, max_messages=1)
     print(json.dumps(res, indent=2))
     return 0 if res["status"] in ("ok", "partial_error") else 1
 

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -1825,7 +1825,9 @@ _cmd_email() {
 		;;
 	poll)
 		# Direct poll commands forwarded to email-poll-helper.sh
-		_dispatch_helper "$_EPH" "$_EPH" "$action" "$@" ;;
+		local poll_action="${1:-tick}"
+		shift || true
+		_dispatch_helper "$_EPH" "$_EPH" "$poll_action" "$@" ;;
 	thread)
 		# Thread lookup: email thread <message-id> [knowledge-root]
 		local _ETH="email-thread-helper.sh"


### PR DESCRIPTION
## Summary

Fixes 6 correctness bugs identified in the post-merge review of PR #21112 (t2855 IMAP polling).

### Changes

**High severity (crashes / silent data loss):**

- `aidevops.sh` `poll)` branch: `$action` was unbound — added `local poll_action="${1:-tick}"` so `aidevops email poll tick` routes correctly
- `email-poll-helper.sh` `cmd_tick`: `2>&1` was merging Python stderr into the JSON result, corrupting parsing; non-zero exit on `partial_error` was treated as fatal. Fix: stderr captured to temp file (logged as warning), fail-open on partial errors
- `email_poll.py` `_write_eml`: filenames were `email-<id>-<uid>.eml` — UIDs are per-folder on IMAP so two folders with the same UID silently overwrote each other. Fix: filename now includes folder — `email-<id>-<folder>-<uid>.eml`

**Medium severity (expensive / injection / docs):**

- `email_poll.py` `cmd_test`: was fetching from UID 0 (all messages). Fix: added `max_uids` param to `_uid_fetch_since` and `max_messages` to `poll_mailbox`; `cmd_test` passes `max_messages=1`
- `email-mailbox-register-helper.sh`: all `python3 -c` snippets interpolated user input directly into Python source — quotes/backslashes in username, gopass path, or mailbox ID would corrupt execution or write malformed JSON. Fix: replaced shell interpolation with `AIDEVOPS_*` env vars throughout; extracted `_write_mailbox_entry` helper to keep `cmd_add` under the 100-line complexity gate
- `knowledge-plane.md`: documented port 143/STARTTLS but code uses `IMAP4_SSL` exclusively. Fix: corrected to 993/TLS only

### Verification

- `bash .agents/tests/test-email-poll.sh` → 9/9 pass
- `python3 -m py_compile .agents/scripts/email_poll.py` → OK
- `shellcheck .agents/scripts/email-poll-helper.sh .agents/scripts/email-mailbox-register-helper.sh` → clean
- Complexity regression check: 35 violations (same as baseline, no email functions added)

Resolves #21122

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.12.0 plugin for [OpenCode](https://opencode.ai) v1.14.26 with claude-sonnet-4-6 spent 16m and 45,807 tokens on this as a headless worker.
