### PR TITLE
t2928: fix(observability): add missing icon_url_override column to archive.project schema

### DIFF
--- a/.agents/scripts/opencode-db-archive.sh
+++ b/.agents/scripts/opencode-db-archive.sh
@@ -178,7 +178,8 @@ CREATE TABLE IF NOT EXISTS `project` (
 	`time_updated` integer NOT NULL,
 	`time_initialized` integer,
 	`sandboxes` text NOT NULL,
-	`commands` text
+	`commands` text,
+	`icon_url_override` text
 );
 
 CREATE TABLE IF NOT EXISTS `session` (
@@ -255,6 +256,18 @@ CREATE TABLE IF NOT EXISTS `session_share` (
 -- WAL mode for the archive too (better read concurrency)
 PRAGMA journal_mode=WAL;
 SCHEMA_SQL
+
+	# Migrate existing archive DBs that predate the icon_url_override column.
+	# CREATE TABLE IF NOT EXISTS won't update an already-existing table, so we
+	# use ALTER TABLE ADD COLUMN guarded by a column-existence check.
+	local has_icon_url_override
+	has_icon_url_override=$(sqlite3 "$archive_db" \
+		"SELECT COUNT(*) FROM pragma_table_info('project') WHERE name='icon_url_override';")
+	if [[ "$has_icon_url_override" -eq 0 ]]; then
+		sqlite3 "$archive_db" "ALTER TABLE project ADD COLUMN icon_url_override text;"
+		print_info "Migrated archive.project schema: added icon_url_override column"
+	fi
+
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Fixes the recurring `Parse error near line 6: table archive.project has 11 columns but 12 values were supplied` error that polluted the pulse log on every archive cycle.

## Root Cause

The OpenCode `project` table gained an `icon_url_override TEXT` column at some point, but the archive schema in `opencode-db-archive.sh` was never updated. The `INSERT OR IGNORE INTO archive.project SELECT p.* FROM project p` statement expands `p.*` to all 12 source columns, but `archive.project` only had 11 — causing the column-count mismatch on every batch.

**File:** `.agents/scripts/opencode-db-archive.sh`  
**Function:** `create_archive_schema()` (line 165)

## Changes

- `EDIT: .agents/scripts/opencode-db-archive.sh:182` — added `icon_url_override text` to `CREATE TABLE IF NOT EXISTS project` so new archive DBs are created with the correct 12-column schema.
- `EDIT: .agents/scripts/opencode-db-archive.sh:260-269` — added an idempotent migration step after the schema SQL: runs `ALTER TABLE project ADD COLUMN icon_url_override text` on existing archive DBs, guarded by `pragma_table_info` to avoid double-run errors.

## Verification

```
# Schema before migration: 11 columns
sqlite3 ~/.local/share/opencode/opencode-archive.db "PRAGMA table_info(project);" | wc -l
# => 11

# Schema after migration (simulated on copy): 12 columns
cp ~/.local/share/opencode/opencode-archive.db /tmp/test.db
sqlite3 /tmp/test.db "ALTER TABLE project ADD COLUMN icon_url_override text;"
sqlite3 /tmp/test.db "PRAGMA table_info(project);" | wc -l
# => 12 ✓

# shellcheck: no violations
shellcheck .agents/scripts/opencode-db-archive.sh
# => (no output) ✓
```

The next archive cycle will: (1) call `create_archive_schema` which runs the migration, adding the column to the existing archive DB, and (2) the `INSERT OR IGNORE INTO archive.project SELECT p.*` will then match the 12-column target — no more parse error.

Resolves #21104

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.12.0 plugin for [OpenCode](https://opencode.ai) v1.14.26 with claude-sonnet-4-6 spent 2m and 5,627 tokens on this as a headless worker.
