### PR TITLE
t2929: cut preflight_cleanup_and_ledger by ~47s — async DB archive + single-pass jq ledger

### DIFF
--- a/.agents/scripts/dispatch-ledger-helper.sh
+++ b/.agents/scripts/dispatch-ledger-helper.sh
@@ -652,50 +652,83 @@ cmd_expire() {
 	local tmp_file
 	tmp_file=$(mktemp "${LEDGER_DIR}/dispatch-ledger.XXXXXX")
 
-	while IFS= read -r line; do
-		[[ -z "$line" ]] && continue
-		local status
-		status=$(printf '%s' "$line" | jq -r '.status // ""' 2>/dev/null) || status=""
+	# GH#21105: single-pass jq extraction. The previous loop forked jq up to
+	# 3x per line (status, dispatched_at, pid) — for 600+ ledger entries this
+	# was ~10s per cycle. One jq invocation produces all needed metadata as TSV;
+	# bash then performs the kill -0 liveness checks (which jq cannot do) and
+	# decides which entries to expire. Final rewrite uses a single jq pass too.
+	local tsv_data
+	tsv_data=$(jq -nr '
+		[inputs] | to_entries[]
+		| .key as $idx | .value as $v
+		| "\($idx)\t\($v.status // "")\t\($v.dispatched_at // "")\t\($v.pid // 0)"
+	' "$LEDGER_FILE" 2>/dev/null) || tsv_data=""
 
-		if [[ "$status" != "in-flight" ]]; then
-			printf '%s\n' "$line" >>"$tmp_file"
-			continue
-		fi
+	# Walk the TSV and collect ledger line indices that need to be expired.
+	# should_expire is an integer (0/1) rather than a "true"/"false" string
+	# to avoid tripping the repeated-string-literal ratchet on the value.
+	local -a expire_indices=()
+	local idx status dispatched_at entry_pid dispatch_epoch age
+	local -i should_expire
+	while IFS=$'\t' read -r idx status dispatched_at entry_pid; do
+		[[ -z "$idx" ]] && continue
+		[[ "$status" != "in-flight" ]] && continue
 
-		local should_expire=false
-
-		# Check TTL expiry
-		local dispatched_at
-		dispatched_at=$(printf '%s' "$line" | jq -r '.dispatched_at // ""' 2>/dev/null) || dispatched_at=""
+		should_expire=0
 		if [[ -n "$dispatched_at" ]]; then
-			local dispatch_epoch
 			dispatch_epoch=$(_iso_to_epoch "$dispatched_at")
-			local age=$((now_epoch - dispatch_epoch))
-			if [[ "$age" -gt "$ttl" ]]; then
-				should_expire=true
-			fi
-		fi
-
-		# Check PID liveness
-		if [[ "$should_expire" != "true" ]]; then
-			local entry_pid
-			entry_pid=$(printf '%s' "$line" | jq -r '.pid // 0' 2>/dev/null) || entry_pid=0
-			if [[ "$entry_pid" =~ ^[0-9]+$ ]] && [[ "$entry_pid" -gt 0 ]]; then
-				if ! kill -0 "$entry_pid" 2>/dev/null; then
-					should_expire=true
+			if [[ "$dispatch_epoch" =~ ^[0-9]+$ ]] && [[ "$dispatch_epoch" -gt 0 ]]; then
+				age=$((now_epoch - dispatch_epoch))
+				if [[ "$age" -gt "$ttl" ]]; then
+					should_expire=1
 				fi
 			fi
 		fi
-
-		if [[ "$should_expire" == "true" ]]; then
-			printf '%s\n' "$line" | jq -c --arg ts "$now_ts" '.status = "failed" | .updated_at = $ts' >>"$tmp_file" 2>/dev/null || printf '%s\n' "$line" >>"$tmp_file"
-			expired_count=$((expired_count + 1))
-		else
-			printf '%s\n' "$line" >>"$tmp_file"
+		if ((!should_expire)) && [[ "$entry_pid" =~ ^[0-9]+$ ]] && [[ "$entry_pid" -gt 0 ]]; then
+			if ! kill -0 "$entry_pid" 2>/dev/null; then
+				should_expire=1
+			fi
 		fi
-	done <"$LEDGER_FILE"
 
-	mv "$tmp_file" "$LEDGER_FILE"
+		if ((should_expire)); then
+			expire_indices+=("$idx")
+		fi
+	done <<<"$tsv_data"
+
+	expired_count=${#expire_indices[@]}
+
+	if [[ "$expired_count" -gt 0 ]]; then
+		# Single jq pass rewrites the file: entries at the listed indices have
+		# their status flipped to "failed" with a fresh updated_at timestamp.
+		local indices_csv
+		indices_csv=$(IFS=,; printf '%s' "${expire_indices[*]}")
+		# Two subtleties learned the hard way during GH#21105:
+		#   1. -n is REQUIRED: without it, jq consumes the first JSON line as
+		#      its initial input, then `[inputs]` collects only entries 2..N.
+		#      Indices in $exp (assigned by the matching -n TSV pass above)
+		#      become off-by-one, and the first ledger entry is silently
+		#      dropped from the rewritten file.
+		#   2. .key MUST be bound to $k BEFORE the pipe into $exp. Writing
+		#      `$exp | index(.key)` evaluates `.key` against $exp (an array)
+		#      and jq raises "Cannot index array with string 'key'", which
+		#      `2>/dev/null` would swallow into the cp fallback path.
+		if ! jq -nc --arg ts "$now_ts" --argjson exp "[${indices_csv}]" '
+			[inputs] | to_entries[]
+			| .key as $k
+			| if (($exp | index($k)) != null)
+			  then .value | .status = "failed" | .updated_at = $ts
+			  else .value
+			  end
+		' "$LEDGER_FILE" >"$tmp_file" 2>/dev/null; then
+			# jq failure: preserve original file rather than risk corruption.
+			cp "$LEDGER_FILE" "$tmp_file"
+			expired_count=0
+		fi
+		mv "$tmp_file" "$LEDGER_FILE"
+	else
+		rm -f "$tmp_file"
+	fi
+
 	_release_lock
 
 	printf '%s\n' "$expired_count"
@@ -798,39 +831,43 @@ cmd_prune() {
 		return 0
 	fi
 
-	local now_epoch prune_threshold pruned_count
+	local now_epoch prune_threshold pruned_count orig_count new_count
 	now_epoch=$(_now_epoch)
 	prune_threshold=86400 # 24 hours
 	pruned_count=0
 	local tmp_file
 	tmp_file=$(mktemp "${LEDGER_DIR}/dispatch-ledger.XXXXXX")
 
-	while IFS= read -r line; do
-		[[ -z "$line" ]] && continue
-		local status
-		status=$(printf '%s' "$line" | jq -r '.status // ""' 2>/dev/null) || status=""
+	# GH#21105: single-pass jq filter. Previously this loop forked jq up to 2x
+	# per line (status, updated_at) — for 600+ ledger entries this was ~7s per
+	# cycle. The new filter processes all entries in one jq invocation:
+	# in-flight entries are always kept; completed/failed entries are kept only
+	# when updated_at is within the prune threshold (default 24h). Empty/
+	# unparseable updated_at values are kept (fail-open) to avoid silent loss.
+	#
+	# fromdateiso8601 in jq parses RFC 3339 / ISO 8601 with the 'Z' suffix
+	# directly; the try/catch falls back to "$now" so unparseable timestamps
+	# keep the entry rather than dropping it.
+	if ! jq -c --argjson now "$now_epoch" --argjson threshold "$prune_threshold" '
+		select(
+			(.status == "in-flight")
+			or
+			(((.updated_at // "") | length) == 0)
+			or
+			(($now - ((.updated_at) | try fromdateiso8601 catch $now)) <= $threshold)
+		)
+	' "$LEDGER_FILE" >"$tmp_file" 2>/dev/null; then
+		# jq failure: preserve original ledger rather than risk corruption.
+		cp "$LEDGER_FILE" "$tmp_file"
+	fi
 
-		# Keep in-flight entries always
-		if [[ "$status" == "in-flight" ]]; then
-			printf '%s\n' "$line" >>"$tmp_file"
-			continue
-		fi
-
-		# Prune completed/failed entries older than threshold
-		local updated_at
-		updated_at=$(printf '%s' "$line" | jq -r '.updated_at // ""' 2>/dev/null) || updated_at=""
-		if [[ -n "$updated_at" ]]; then
-			local update_epoch
-			update_epoch=$(_iso_to_epoch "$updated_at")
-			local age=$((now_epoch - update_epoch))
-			if [[ "$age" -gt "$prune_threshold" ]]; then
-				pruned_count=$((pruned_count + 1))
-				continue
-			fi
-		fi
-
-		printf '%s\n' "$line" >>"$tmp_file"
-	done <"$LEDGER_FILE"
+	# Pruned count = original line count - kept line count.
+	orig_count=$(wc -l <"$LEDGER_FILE" | tr -d ' ')
+	new_count=$(wc -l <"$tmp_file" | tr -d ' ')
+	[[ "$orig_count" =~ ^[0-9]+$ ]] || orig_count=0
+	[[ "$new_count" =~ ^[0-9]+$ ]] || new_count=0
+	pruned_count=$((orig_count - new_count))
+	[[ "$pruned_count" -lt 0 ]] && pruned_count=0
 
 	mv "$tmp_file" "$LEDGER_FILE"
 	_release_lock

--- a/.agents/scripts/opencode-db-archive-async-helper.sh
+++ b/.agents/scripts/opencode-db-archive-async-helper.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# opencode-db-archive-async-helper.sh — Async background OpenCode DB archive runner (GH#21105).
+#
+# Designed to be invoked via nohup from _preflight_cleanup_and_ledger in
+# pulse-dispatch-engine.sh so the up-to-30s archive budget never blocks the
+# pulse's main dispatch cycle.
+#
+# Background (GH#21105):
+#   The synchronous call `opencode-db-archive.sh archive --max-duration-seconds 30`
+#   was consuming its full 30s time budget every preflight cycle, contributing
+#   ~30s to the parent stage's 60-133s total. Archiving is catch-up work — it
+#   does not need to complete within a single pulse cycle. Mirroring the
+#   cleanup-worktrees-async-helper.sh pattern (GH#20554) moves the workload
+#   off the critical path while preserving correctness.
+#
+# Lifecycle:
+#   1. Acquire a mkdir-based single-runner lock (~/.aidevops/logs/opencode-db-archive.lock).
+#   2. Check cadence gate: skip if last successful run < N minutes ago.
+#   3. Invoke opencode-db-archive.sh archive with the configured budget.
+#   4. Update ~/.aidevops/logs/opencode-db-archive.last-run on success.
+#   5. Release lock on EXIT/INT/TERM (trap).
+#
+# Usage (from pulse-dispatch-engine.sh):
+#   nohup "${SCRIPT_DIR}/opencode-db-archive-async-helper.sh" \
+#     >>"${HOME}/.aidevops/logs/opencode-db-archive.log" 2>&1 &
+#   disown $! 2>/dev/null || true
+#
+# Environment:
+#   OPENCODE_DB_ARCHIVE_ASYNC_CADENCE_MIN — min minutes between runs (default 10)
+#   OPENCODE_DB_ARCHIVE_ASYNC_BUDGET_SEC  — seconds per run (default 60; was 30 inline)
+#
+# Observability (for pulse-diagnose-helper.sh):
+#   ~/.aidevops/logs/opencode-db-archive.log      — progress log
+#   ~/.aidevops/logs/opencode-db-archive.last-run — epoch of last successful run
+#   ~/.aidevops/logs/opencode-db-archive.lock/    — lock dir (present = running)
+#   ~/.aidevops/logs/opencode-db-archive.lock/pid — PID of holder
+
+set -euo pipefail
+
+# ============================================================
+# PATHS
+# ============================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly LOG_DIR="${HOME}/.aidevops/logs"
+readonly LOGFILE="${LOG_DIR}/opencode-db-archive.log"
+readonly LOCK_DIR="${LOG_DIR}/opencode-db-archive.lock"
+readonly PID_FILE="${LOCK_DIR}/pid"
+readonly LAST_RUN_FILE="${LOG_DIR}/opencode-db-archive.last-run"
+readonly ARCHIVE_HELPER="${SCRIPT_DIR}/opencode-db-archive.sh"
+
+# Minimum minutes between successful runs. The async wrapper can be invoked
+# every pulse cycle (~3 min) but only actually runs every CADENCE minutes.
+OPENCODE_DB_ARCHIVE_ASYNC_CADENCE_MIN="${OPENCODE_DB_ARCHIVE_ASYNC_CADENCE_MIN:-10}"
+OPENCODE_DB_ARCHIVE_ASYNC_CADENCE_MIN="${OPENCODE_DB_ARCHIVE_ASYNC_CADENCE_MIN//[!0-9]/}"
+[[ -n "$OPENCODE_DB_ARCHIVE_ASYNC_CADENCE_MIN" ]] || OPENCODE_DB_ARCHIVE_ASYNC_CADENCE_MIN=10
+
+# Per-run time budget. Larger than the inline 30s default — async runs are not
+# on the critical path, so we let each invocation make more progress.
+OPENCODE_DB_ARCHIVE_ASYNC_BUDGET_SEC="${OPENCODE_DB_ARCHIVE_ASYNC_BUDGET_SEC:-60}"
+OPENCODE_DB_ARCHIVE_ASYNC_BUDGET_SEC="${OPENCODE_DB_ARCHIVE_ASYNC_BUDGET_SEC//[!0-9]/}"
+[[ -n "$OPENCODE_DB_ARCHIVE_ASYNC_BUDGET_SEC" ]] || OPENCODE_DB_ARCHIVE_ASYNC_BUDGET_SEC=60
+
+mkdir -p "$LOG_DIR"
+
+# ============================================================
+# LOCK MANAGEMENT (mkdir-based — POSIX atomic, macOS-safe)
+# ============================================================
+
+_lock_release() {
+	rm -rf "$LOCK_DIR" 2>/dev/null || true
+	return 0
+}
+
+# Check whether the PID that holds the lock is still alive.
+# Uses kill -0 (existence) + ps comm= (command-aware, guards against PID reuse).
+# Returns 0 if alive, 1 if dead or indeterminate.
+_is_pid_alive() {
+	local pid="$1"
+	[[ -z "$pid" ]] && return 1
+	[[ "$pid" =~ ^[0-9]+$ ]] || return 1
+
+	if ! kill -0 "$pid" 2>/dev/null; then
+		return 1
+	fi
+
+	local comm
+	comm=$(ps -p "$pid" -o comm= 2>/dev/null || true)
+	if [[ -z "$comm" ]]; then
+		return 1
+	fi
+
+	return 0
+}
+
+# Attempt to acquire the lock directory. On success, writes PID file and
+# registers a trap. Returns 1 (skip this run) if another live instance holds
+# the lock. Reclaims the lock if the holder PID is dead (crash recovery).
+_lock_acquire() {
+	if mkdir "$LOCK_DIR" 2>/dev/null; then
+		printf '%s\n' "$$" >"$PID_FILE" 2>/dev/null || true
+		# shellcheck disable=SC2064
+		trap "_lock_release" EXIT INT TERM
+		return 0
+	fi
+
+	if [[ -f "$PID_FILE" ]]; then
+		local lock_pid
+		lock_pid=$(cat "$PID_FILE" 2>/dev/null || echo "")
+		if [[ -n "$lock_pid" ]] && ! _is_pid_alive "$lock_pid"; then
+			echo "[opencode-db-archive-async] Reclaiming stale lock (PID ${lock_pid} no longer alive)" >>"$LOGFILE"
+			rm -rf "$LOCK_DIR" 2>/dev/null || true
+			if mkdir "$LOCK_DIR" 2>/dev/null; then
+				printf '%s\n' "$$" >"$PID_FILE" 2>/dev/null || true
+				# shellcheck disable=SC2064
+				trap "_lock_release" EXIT INT TERM
+				return 0
+			fi
+		fi
+	fi
+
+	return 1
+}
+
+# ============================================================
+# CADENCE GATE
+# ============================================================
+
+# Returns 0 (proceed) if enough time has elapsed since the last successful run.
+# Returns 1 (skip) if we are within the cadence window.
+_cadence_ok() {
+	if [[ ! -f "$LAST_RUN_FILE" ]]; then
+		return 0
+	fi
+
+	local last_run now elapsed cadence_secs
+	last_run=$(cat "$LAST_RUN_FILE" 2>/dev/null || echo "0")
+	if ! [[ "$last_run" =~ ^[0-9]+$ ]]; then
+		return 0
+	fi
+
+	now=$(date +%s)
+	elapsed=$((now - last_run))
+	cadence_secs=$((OPENCODE_DB_ARCHIVE_ASYNC_CADENCE_MIN * 60))
+
+	if [[ "$elapsed" -lt "$cadence_secs" ]]; then
+		echo "[opencode-db-archive-async] Cadence gate: last run ${elapsed}s ago (threshold ${cadence_secs}s). Skipping." >>"$LOGFILE"
+		return 1
+	fi
+
+	return 0
+}
+
+_update_last_run() {
+	date +%s >"$LAST_RUN_FILE" 2>/dev/null || true
+	return 0
+}
+
+# ============================================================
+# MAIN
+# ============================================================
+
+main() {
+	echo "[opencode-db-archive-async] PID=$$ starting at $(date -u '+%Y-%m-%dT%H:%M:%SZ')" >>"$LOGFILE"
+
+	if [[ ! -x "$ARCHIVE_HELPER" ]]; then
+		echo "[opencode-db-archive-async] ERROR: $ARCHIVE_HELPER not found or not executable — skipping" >>"$LOGFILE"
+		return 0
+	fi
+
+	if ! _lock_acquire; then
+		echo "[opencode-db-archive-async] Lock held by live instance — skipping this invocation" >>"$LOGFILE"
+		return 0
+	fi
+
+	if ! _cadence_ok; then
+		return 0
+	fi
+
+	echo "[opencode-db-archive-async] Starting archive (budget=${OPENCODE_DB_ARCHIVE_ASYNC_BUDGET_SEC}s, cadence=${OPENCODE_DB_ARCHIVE_ASYNC_CADENCE_MIN}m)" >>"$LOGFILE"
+
+	local rc=0
+	"$ARCHIVE_HELPER" archive --max-duration-seconds "$OPENCODE_DB_ARCHIVE_ASYNC_BUDGET_SEC" >>"$LOGFILE" 2>&1 || rc=$?
+
+	if [[ "$rc" -eq 0 ]]; then
+		_update_last_run
+		echo "[opencode-db-archive-async] Completed successfully at $(date -u '+%Y-%m-%dT%H:%M:%SZ'). last-run updated." >>"$LOGFILE"
+	else
+		echo "[opencode-db-archive-async] archive exited with rc=${rc} — last-run NOT updated" >>"$LOGFILE"
+	fi
+
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -1178,10 +1178,25 @@ _preflight_cleanup_and_ledger() {
 
 	# GH#17549: Archive old OpenCode sessions to keep the active DB small.
 	# Concurrent workers hit SQLITE_BUSY on a bloated DB (busy_timeout=0).
-	# Runs daily with a 30s budget — catches up over multiple pulse cycles.
-	local _archive_helper="${SCRIPT_DIR}/opencode-db-archive.sh"
-	if [[ -x "$_archive_helper" ]]; then
-		"$_archive_helper" archive --max-duration-seconds 30 >>"$LOGFILE" 2>&1 || true
+	# GH#21105: Moved to an async background job so the per-cycle 30s budget
+	# stops contributing to preflight_cleanup_and_ledger wall time. The async
+	# helper enforces a single-runner lock and a cadence gate
+	# (OPENCODE_DB_ARCHIVE_ASYNC_CADENCE_MIN, default 10 min) so concurrent
+	# pulse invocations do not spawn duplicate archive processes. With archiving
+	# off the critical path, each invocation can use a larger budget
+	# (OPENCODE_DB_ARCHIVE_ASYNC_BUDGET_SEC, default 60s) and still not block
+	# dispatch. Progress and last-run timestamp: ~/.aidevops/logs/opencode-db-archive.*
+	local _archive_async_helper="${SCRIPT_DIR}/opencode-db-archive-async-helper.sh"
+	if [[ -x "$_archive_async_helper" ]]; then
+		nohup "$_archive_async_helper" \
+			>>"${HOME}/.aidevops/logs/opencode-db-archive.log" 2>&1 &
+		disown $! 2>/dev/null || true
+	else
+		# Fallback: synchronous with short timeout (pre-GH#21105 behaviour)
+		local _archive_helper="${SCRIPT_DIR}/opencode-db-archive.sh"
+		if [[ -x "$_archive_helper" ]]; then
+			"$_archive_helper" archive --max-duration-seconds 30 >>"$LOGFILE" 2>&1 || true
+		fi
 	fi
 
 	# t1751: Reap zombie workers whose PRs have been merged by the deterministic merge pass.


### PR DESCRIPTION
## Summary

Cuts `_preflight_cleanup_and_ledger` (in `pulse-dispatch-engine.sh`) by an estimated ~47s per pulse cycle by removing the two largest synchronous costs from the critical path. Issue body reported 60-133s per cycle at 180s pulse interval.

Two changes:

1. **OpenCode DB archive moved off the critical path** — modeled on `cleanup-worktrees-async-helper.sh` (GH#20554). Same `mkdir`-based single-runner lock, same cadence gate, same fallback to inline if the helper is missing. Async invocation gets a 60s budget by default (vs the inline 30s) since it no longer blocks dispatch.

2. **`dispatch-ledger expire` and `prune` rewritten as single-pass jq** — both previously forked jq 2-3x per ledger line; for ~600 entries that was ~10s + ~7s of fork overhead per cycle. New form does one TSV-extract pass + one rewrite/select pass.

## Trap mitigations (documented in code comments so the next reader doesn't pay for them)

- `[inputs] | to_entries[]` requires `jq -n` — without it the first ledger line is consumed as initial input and `[inputs]` collects only entries 2..N. Indices passed via `--argjson exp` (computed by the matching `-n` TSV pass) become off-by-one and the first entry is silently dropped from the rewritten file. `2>/dev/null` swallows the failure into a benign-looking `cp` fallback path.
- `($exp | index(.key))` evaluates `.key` against `$exp` (the array context after the pipe) and raises `Cannot index array with string "key"`, also swallowed by `2>/dev/null`. The fix is to bind `.key` to `$k` BEFORE piping into `$exp`.

Both bugs would have been silent corruption — the helper would have looked healthy while never actually expiring stale in-flight entries (dispatch slot exhaustion) and dropping the first ledger entry on every expire pass.

## Files

- `NEW: .agents/scripts/opencode-db-archive-async-helper.sh` — 197 lines, lock + cadence + invocation. Mirrors `cleanup-worktrees-async-helper.sh`.
- `EDIT: .agents/scripts/pulse-dispatch-engine.sh:1179-1200` — swap inline archive call for async wrapper, keep synchronous fallback for the no-helper case.
- `EDIT: .agents/scripts/dispatch-ledger-helper.sh::cmd_expire,cmd_prune` — single-pass jq rewrites with the trap mitigations above.

## Verification

- `shellcheck` clean on all three files.
- End-to-end synthetic ledger test (4 entries — dead PID, completed, live PID + recent, live PID + TTL exceeded): `expire` correctly flips the dead-PID and TTL-exceeded entries to `failed` (count=2); `prune` correctly drops the >24h completed entry (count=1).
- Async helper smoke test: lock acquired/released cleanly on success and failure paths; cadence gate fires only on prior **successful** run (failed runs leave `last-run` unchanged so the next pulse retries).

## Acceptance criteria from the issue body

- [x] Synchronous DB archive removed from the critical path.
- [x] Ledger `expire`/`prune` jq fork-storm eliminated.
- [ ] git fetch staggering / parallelization across repos — `_preflight_cleanup_and_ledger` does not call `git fetch` directly. The fetch work happens in `pulse-batch-prefetch-helper.sh` and `cleanup-worktrees-async-helper.sh`, both already async. The 60-133s figure was dominated by the items addressed here. If a follow-up profile shows fetch overhead remains the bottleneck, that should be filed as a separate task targeting the actual call sites — the issue body's "fetches every repo per cycle" premise was inaccurate for this function.


## Complexity Bump Justification

`.agents/scripts/dispatch-ledger-helper.sh:225` (function `cmd_expire`) grew from <100 to **119 lines** (function-complexity gate measured `base=1, head=2, new=1`). The growth is intrinsic to the single-pass jq rewrite that delivers the ~47s/cycle preflight latency reduction:

- The previous multi-fork form (`jq -r '.field' | while read; do jq -c 'select(...)'; done`) was short because every line forked jq again.
- The single-pass form must inline two trap mitigations documented in PR summary (`[inputs] | to_entries[]` requires `jq -n`; `($exp | index(.key))` needs explicit `.key as $k` rebinding before pipe). Both are silent-corruption traps if dropped — the verbose form is the safe form.
- Splitting `cmd_expire` further would require either re-introducing the fork overhead it was rewritten to eliminate, or duplicating the jq filter logic across helpers (worse maintenance).

Trade-off accepted: 119-line function (19 over the 100-line threshold) in exchange for ~47s/cycle = ~4 hours/day of recovered worker capacity at 180s pulse interval. The simplification routine can revisit if a cleaner decomposition emerges; the perf cost of the multi-fork form is the ratchet floor we don't want to walk back into.

## Note on the parent issue

Issue #21105 is `tier:thinking` + `model:opus-4-7` (auto-elevated by `pre-dispatch-validator-helper.sh` per the dispatch-path classifier). Resolving the issue here for the work that landed; the deferred git-fetch optimization will get its own focused issue if profiling justifies it.

Resolves #21105


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.12.0 plugin for [OpenCode](https://opencode.ai) v1.14.26 with claude-opus-4-7 spent 8h 8m and 703,854 tokens on this with the user in an interactive session.

