### PR TITLE
t2939: pulse defense-in-depth — KeepAlive dict + watchdog plist

### DIFF
--- a/.agents/scripts/pulse-watchdog-tick.sh
+++ b/.agents/scripts/pulse-watchdog-tick.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# Pulse Watchdog Tick (t2939) — independent revival of dead pulse
+# =============================================================================
+# Runs every 60s via the sh.aidevops.pulse-watchdog launchd job. Independent
+# of the pulse plist itself — survives `aidevops update` plist regeneration.
+#
+# Layered defense:
+#   Layer 1 (pulse plist KeepAlive=<dict><SuccessfulExit=false>): launchd
+#     auto-restarts pulse on crash within seconds, but on clean exit the
+#     StartInterval (default 600s) governs the next launch.
+#   Layer 2 (this script): if pulse has been dead longer than
+#     (StartInterval + grace), revive it. Catches the "clean exit + lost
+#     launchd schedule" failure mode (system sleep/wake races, plist drift,
+#     race during plist reload, OOM-kill misclassified as success, etc.).
+#
+# Idempotence: cheap. If pulse is alive, this script exits 0 with no work.
+# If pulse is dead but within the grace window, also exit 0 (let launchd's
+# own StartInterval fire it). Only invokes pulse-lifecycle-helper.sh start
+# when the gap exceeds the grace period — preserves user's pulse-interval
+# tuning for GraphQL rate-limit conservation.
+#
+# Env:
+#   AIDEVOPS_PULSE_WATCHDOG_GRACE     Seconds beyond StartInterval to wait
+#                                     before reviving (default: 120)
+#   AIDEVOPS_PULSE_WATCHDOG_DISABLE=1 Disable the watchdog (no-op exit 0)
+#   AIDEVOPS_AGENTS_DIR=<path>        Override ~/.aidevops/agents
+#
+# Exit codes:
+#   0  Always (even on revival failure — log and continue, not fail).
+#
+# Part of aidevops framework: https://aidevops.sh
+
+set -uo pipefail
+
+# Honour explicit disable flag (debugging / maintenance windows).
+if [[ "${AIDEVOPS_PULSE_WATCHDOG_DISABLE:-0}" == "1" ]]; then
+	exit 0
+fi
+
+_AGENTS_DIR="${AIDEVOPS_AGENTS_DIR:-${HOME}/.aidevops/agents}"
+_LIFECYCLE_HELPER="${_AGENTS_DIR}/scripts/pulse-lifecycle-helper.sh"
+_LOG_DIR="${HOME}/.aidevops/logs"
+_WATCHDOG_LOG="${_LOG_DIR}/pulse-watchdog.log"
+_LAST_RUN_FILE="${_LOG_DIR}/pulse-wrapper-last-run.ts"
+_SETTINGS_FILE="${HOME}/.config/aidevops/settings.json"
+
+mkdir -p "$_LOG_DIR" 2>/dev/null || true
+
+_wd_log() {
+	local _msg="$1"
+	printf '[%s] [pulse-watchdog] %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$_msg" >>"$_WATCHDOG_LOG" 2>/dev/null || true
+	return 0
+}
+
+# Resolve the configured pulse interval from settings.json (default 180s).
+# Mirrors _read_pulse_interval_seconds in setup-modules/schedulers.sh.
+_read_pulse_interval() {
+	local _interval=180
+	if command -v jq >/dev/null 2>&1 && [[ -f "$_SETTINGS_FILE" ]]; then
+		local _raw
+		_raw=$(jq -r '.supervisor.pulse_interval_seconds // empty' "$_SETTINGS_FILE" 2>/dev/null) || _raw=""
+		if [[ -n "$_raw" && "$_raw" =~ ^[0-9]+$ ]]; then
+			_interval="$_raw"
+		fi
+	fi
+	# Clamp to validated range (mirrors settings-helper.sh: 30-3600)
+	if [[ "$_interval" -lt 30 ]]; then
+		_interval=30
+	elif [[ "$_interval" -gt 3600 ]]; then
+		_interval=3600
+	fi
+	printf '%d' "$_interval"
+	return 0
+}
+
+# Bail early if the lifecycle helper is missing — nothing to revive with.
+if [[ ! -x "$_LIFECYCLE_HELPER" ]]; then
+	_wd_log "lifecycle-helper missing or non-executable: $_LIFECYCLE_HELPER"
+	exit 0
+fi
+
+# Fast path: pulse alive → no work.
+if "$_LIFECYCLE_HELPER" is-running >/dev/null 2>&1; then
+	exit 0
+fi
+
+# Pulse is dead. Decide whether to revive based on age vs grace window.
+_INTERVAL=$(_read_pulse_interval)
+_GRACE="${AIDEVOPS_PULSE_WATCHDOG_GRACE:-120}"
+# Validate grace is numeric; fall back to 120 on bad input.
+if ! [[ "$_GRACE" =~ ^[0-9]+$ ]]; then
+	_GRACE=120
+fi
+_THRESHOLD=$((_INTERVAL + _GRACE))
+
+_LAST_RUN=0
+if [[ -f "$_LAST_RUN_FILE" ]]; then
+	_raw_ts=$(tr -d '[:space:]' <"$_LAST_RUN_FILE" 2>/dev/null) || _raw_ts=""
+	if [[ "$_raw_ts" =~ ^[0-9]+$ ]]; then
+		_LAST_RUN="$_raw_ts"
+	fi
+fi
+
+_NOW=$(date +%s)
+_AGE=$((_NOW - _LAST_RUN))
+
+# If we have no last-run record, treat as "very old" — revive immediately.
+# This catches first-boot and post-clean-install scenarios where the watchdog
+# fires before the pulse has ever recorded a timestamp.
+if [[ "$_LAST_RUN" -eq 0 ]]; then
+	_wd_log "no last-run timestamp — reviving pulse"
+	"$_LIFECYCLE_HELPER" start >>"$_WATCHDOG_LOG" 2>&1 || _wd_log "revival exit=$?"
+	exit 0
+fi
+
+# Within grace window — let launchd's own StartInterval fire on its schedule.
+if [[ "$_AGE" -lt "$_THRESHOLD" ]]; then
+	exit 0
+fi
+
+# Past grace window — revive.
+_wd_log "pulse dead for ${_AGE}s (threshold ${_THRESHOLD}s = interval ${_INTERVAL} + grace ${_GRACE}) — reviving"
+"$_LIFECYCLE_HELPER" start >>"$_WATCHDOG_LOG" 2>&1 || _wd_log "revival exit=$?"
+exit 0

--- a/.agents/scripts/tests/test-pulse-defense-restart.sh
+++ b/.agents/scripts/tests/test-pulse-defense-restart.sh
@@ -1,0 +1,346 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# t2939 regression tests — pulse defense-in-depth restart reliability.
+# Covers:
+#   (1) Pulse plist KeepAlive is dict form with SuccessfulExit=false
+#   (2) Pulse plist ThrottleInterval is set
+#   (3) Watchdog plist generation produces valid XML
+#   (4) Watchdog plist StartInterval=60s
+#   (5) pulse-watchdog-tick.sh: alive → exit 0 silently
+#   (6) pulse-watchdog-tick.sh: dead within grace → exit 0 silently
+#   (7) pulse-watchdog-tick.sh: dead past grace → revives via lifecycle helper
+#   (8) pulse-watchdog-tick.sh: missing last-run timestamp → revives immediately
+#   (9) pulse-watchdog-tick.sh: AIDEVOPS_PULSE_WATCHDOG_DISABLE=1 → no-op exit 0
+#
+# Usage: bash .agents/scripts/tests/test-pulse-defense-restart.sh
+# Platform: macOS-specific tests (plist generation) skip on Linux.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)" || exit 1
+SCHEDULERS_SH="$REPO_ROOT/setup-modules/schedulers.sh"
+TICK_SH="$REPO_ROOT/.agents/scripts/pulse-watchdog-tick.sh"
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+TEST_DIR=""
+
+print_result() {
+	local test_name="$1"
+	local status="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$status" -eq 0 ]]; then
+		echo "PASS $test_name"
+		TESTS_PASSED=$((TESTS_PASSED + 1))
+	else
+		echo "FAIL $test_name"
+		if [[ -n "$message" ]]; then
+			echo "  $message"
+		fi
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+teardown() {
+	if [[ -n "$TEST_DIR" ]] && [[ -d "$TEST_DIR" ]]; then
+		rm -rf "$TEST_DIR"
+	fi
+	return 0
+}
+
+setup() {
+	TEST_DIR=$(mktemp -d)
+	trap teardown EXIT
+	return 0
+}
+
+# Generate plists in a subshell with stubs for _xml_escape, _resolve_modern_bash,
+# _read_pulse_interval_seconds, _build_pulse_headless_env_xml,
+# _build_plist_env_overrides_xml.
+_render_pulse_plist() {
+	local out_file="$1"
+	bash -c '
+		set -uo pipefail
+		export PULSE_STALE_THRESHOLD_SECONDS=1800
+		_xml_escape() {
+			local val="$1"
+			val="${val//&/&amp;}"
+			val="${val//</&lt;}"
+			val="${val//>/&gt;}"
+			val="${val//\"/&quot;}"
+			val="${val//\x27/&apos;}"
+			printf "%s" "$val"
+		}
+		_resolve_modern_bash() { echo "/opt/homebrew/bin/bash"; }
+		_read_pulse_interval_seconds() { echo "600"; }
+		_build_pulse_headless_env_xml() { return 0; }
+		_build_plist_env_overrides_xml() { return 0; }
+		print_info() { :; }
+		print_warning() { :; }
+		source "'"$SCHEDULERS_SH"'" 2>/dev/null || true
+		# Re-define after source in case schedulers.sh defined real ones.
+		_resolve_modern_bash() { echo "/opt/homebrew/bin/bash"; }
+		_read_pulse_interval_seconds() { echo "600"; }
+		_build_pulse_headless_env_xml() { return 0; }
+		_build_plist_env_overrides_xml() { return 0; }
+		_generate_pulse_plist_content "com.test.pulse" "/path/to/pulse.sh" "/opt/homebrew/bin/opencode"
+	' >"$out_file"
+}
+
+_render_watchdog_plist() {
+	local out_file="$1"
+	bash -c '
+		set -uo pipefail
+		_xml_escape() {
+			local val="$1"
+			val="${val//&/&amp;}"
+			val="${val//</&lt;}"
+			val="${val//>/&gt;}"
+			val="${val//\"/&quot;}"
+			val="${val//\x27/&apos;}"
+			printf "%s" "$val"
+		}
+		print_info() { :; }
+		print_warning() { :; }
+		source "'"$SCHEDULERS_SH"'" 2>/dev/null || true
+		_generate_pulse_watchdog_plist_content "sh.aidevops.pulse-watchdog" "/path/to/tick.sh" "/opt/homebrew/bin/bash"
+	' >"$out_file"
+}
+
+# ---------------------------------------------------------------------------
+# Tests for plist generation (macOS only — plutil/grep-based)
+# ---------------------------------------------------------------------------
+
+test_pulse_plist_keepalive_dict() {
+	local plist="$TEST_DIR/pulse.plist"
+	_render_pulse_plist "$plist"
+
+	# Inline grep-based check (avoids plutil dependency for cross-platform CI).
+	local rc=0
+	if ! grep -A 3 "<key>KeepAlive</key>" "$plist" | grep -q "<key>SuccessfulExit</key>"; then
+		rc=1
+	fi
+	print_result "test_pulse_plist_keepalive_dict" "$rc" \
+		"KeepAlive must be a dict containing SuccessfulExit (t2939 layer 1)"
+	return 0
+}
+
+test_pulse_plist_throttle_interval() {
+	local plist="$TEST_DIR/pulse.plist"
+	_render_pulse_plist "$plist"
+	local rc=0
+	if ! grep -q "<key>ThrottleInterval</key>" "$plist"; then
+		rc=1
+	fi
+	print_result "test_pulse_plist_throttle_interval" "$rc" \
+		"ThrottleInterval prevents rapid-restart loops (t2939 layer 1)"
+	return 0
+}
+
+test_watchdog_plist_label() {
+	local plist="$TEST_DIR/watchdog.plist"
+	_render_watchdog_plist "$plist"
+	local rc=0
+	if ! grep -q "<string>sh.aidevops.pulse-watchdog</string>" "$plist"; then
+		rc=1
+	fi
+	print_result "test_watchdog_plist_label" "$rc" \
+		"Watchdog label must be sh.aidevops.pulse-watchdog (t2939 layer 2)"
+	return 0
+}
+
+test_watchdog_plist_start_interval() {
+	local plist="$TEST_DIR/watchdog.plist"
+	_render_watchdog_plist "$plist"
+	local rc=0
+	# StartInterval should be 60 seconds.
+	if ! grep -B 1 "<integer>60</integer>" "$plist" | grep -q "StartInterval"; then
+		rc=1
+	fi
+	print_result "test_watchdog_plist_start_interval" "$rc" \
+		"Watchdog must run every 60s (t2939 layer 2)"
+	return 0
+}
+
+test_watchdog_plist_valid_xml() {
+	local plist="$TEST_DIR/watchdog.plist"
+	_render_watchdog_plist "$plist"
+	local rc=0
+	if command -v plutil >/dev/null 2>&1; then
+		plutil -lint "$plist" >/dev/null 2>&1 || rc=1
+	else
+		# Fall back to xmllint or basic structural check on Linux.
+		grep -q '<plist version="1.0">' "$plist" && grep -q '</plist>' "$plist" || rc=1
+	fi
+	print_result "test_watchdog_plist_valid_xml" "$rc" \
+		"Watchdog plist must be valid XML (t2939 layer 2)"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Tests for pulse-watchdog-tick.sh logic
+# ---------------------------------------------------------------------------
+
+# Returns the watchdog log path from a stubbed HOME.
+_setup_tick_env() {
+	local stub_home="$1"
+	local helper_state="$2" # "alive" or "dead"
+	mkdir -p "$stub_home/.aidevops/logs" "$stub_home/.config/aidevops" \
+		"$stub_home/.aidevops/agents/scripts"
+	echo '{"supervisor":{"pulse_interval_seconds":600}}' >"$stub_home/.config/aidevops/settings.json"
+
+	# Stub lifecycle helper. Records every invocation.
+	cat >"$stub_home/.aidevops/agents/scripts/pulse-lifecycle-helper.sh" <<STUB
+#!/usr/bin/env bash
+echo "stub:\$*" >>"$stub_home/.aidevops/logs/stub-helper-invocations.log"
+case "\$1" in
+  is-running) [[ "$helper_state" == "alive" ]] && exit 0 || exit 1 ;;
+  start) echo "stub start invoked"; exit 0 ;;
+  *) exit 0 ;;
+esac
+STUB
+	chmod +x "$stub_home/.aidevops/agents/scripts/pulse-lifecycle-helper.sh"
+	return 0
+}
+
+test_tick_alive_fast_exit() {
+	local stub_home="$TEST_DIR/alive"
+	_setup_tick_env "$stub_home" "alive"
+	local rc=0
+	HOME="$stub_home" AIDEVOPS_AGENTS_DIR="$stub_home/.aidevops/agents" \
+		bash "$TICK_SH" || rc=$?
+	# Must exit 0 with no revival attempt.
+	local invocations=""
+	if [[ -f "$stub_home/.aidevops/logs/stub-helper-invocations.log" ]]; then
+		invocations=$(cat "$stub_home/.aidevops/logs/stub-helper-invocations.log")
+	fi
+	if [[ "$rc" -eq 0 ]] && [[ "$invocations" == "stub:is-running" ]]; then
+		print_result "test_tick_alive_fast_exit" 0
+	else
+		print_result "test_tick_alive_fast_exit" 1 \
+			"expected exit=0 + only is-running call; got exit=$rc invocations=$invocations"
+	fi
+	return 0
+}
+
+test_tick_dead_within_grace_no_revive() {
+	local stub_home="$TEST_DIR/within-grace"
+	_setup_tick_env "$stub_home" "dead"
+	# Recent timestamp (NOW) — within (600 + 120) grace window.
+	date +%s >"$stub_home/.aidevops/logs/pulse-wrapper-last-run.ts"
+	local rc=0
+	HOME="$stub_home" AIDEVOPS_AGENTS_DIR="$stub_home/.aidevops/agents" \
+		bash "$TICK_SH" || rc=$?
+	local invocations
+	invocations=$(cat "$stub_home/.aidevops/logs/stub-helper-invocations.log" 2>/dev/null || echo "")
+	# Should call is-running but NOT start.
+	if [[ "$rc" -eq 0 ]] && [[ "$invocations" == "stub:is-running" ]]; then
+		print_result "test_tick_dead_within_grace_no_revive" 0
+	else
+		print_result "test_tick_dead_within_grace_no_revive" 1 \
+			"expected exit=0 + no start call within grace; got exit=$rc invocations='$invocations'"
+	fi
+	return 0
+}
+
+test_tick_dead_past_grace_revives() {
+	local stub_home="$TEST_DIR/past-grace"
+	_setup_tick_env "$stub_home" "dead"
+	# Timestamp 1000s ago > (600 interval + 120 grace) = 720s threshold.
+	echo "$(($(date +%s) - 1000))" >"$stub_home/.aidevops/logs/pulse-wrapper-last-run.ts"
+	local rc=0
+	HOME="$stub_home" AIDEVOPS_AGENTS_DIR="$stub_home/.aidevops/agents" \
+		bash "$TICK_SH" || rc=$?
+	local invocations
+	invocations=$(cat "$stub_home/.aidevops/logs/stub-helper-invocations.log" 2>/dev/null || echo "")
+	# Should call is-running AND start.
+	if [[ "$rc" -eq 0 ]] && [[ "$invocations" == *"stub:is-running"* ]] && [[ "$invocations" == *"stub:start"* ]]; then
+		print_result "test_tick_dead_past_grace_revives" 0
+	else
+		print_result "test_tick_dead_past_grace_revives" 1 \
+			"expected exit=0 + is-running + start; got exit=$rc invocations='$invocations'"
+	fi
+	return 0
+}
+
+test_tick_no_last_run_revives() {
+	local stub_home="$TEST_DIR/no-last-run"
+	_setup_tick_env "$stub_home" "dead"
+	# Intentionally no last-run.ts file.
+	local rc=0
+	HOME="$stub_home" AIDEVOPS_AGENTS_DIR="$stub_home/.aidevops/agents" \
+		bash "$TICK_SH" || rc=$?
+	local invocations
+	invocations=$(cat "$stub_home/.aidevops/logs/stub-helper-invocations.log" 2>/dev/null || echo "")
+	if [[ "$rc" -eq 0 ]] && [[ "$invocations" == *"stub:start"* ]]; then
+		print_result "test_tick_no_last_run_revives" 0
+	else
+		print_result "test_tick_no_last_run_revives" 1 \
+			"expected exit=0 + start call when last-run missing; got exit=$rc invocations='$invocations'"
+	fi
+	return 0
+}
+
+test_tick_disable_flag() {
+	local stub_home="$TEST_DIR/disabled"
+	_setup_tick_env "$stub_home" "dead"
+	echo "0" >"$stub_home/.aidevops/logs/pulse-wrapper-last-run.ts"
+	local rc=0
+	HOME="$stub_home" AIDEVOPS_AGENTS_DIR="$stub_home/.aidevops/agents" \
+		AIDEVOPS_PULSE_WATCHDOG_DISABLE=1 \
+		bash "$TICK_SH" || rc=$?
+	local invocations
+	invocations=$(cat "$stub_home/.aidevops/logs/stub-helper-invocations.log" 2>/dev/null || echo "")
+	# Should exit 0 with no helper invocations.
+	if [[ "$rc" -eq 0 ]] && [[ -z "$invocations" ]]; then
+		print_result "test_tick_disable_flag" 0
+	else
+		print_result "test_tick_disable_flag" 1 \
+			"expected exit=0 + zero invocations when DISABLE=1; got exit=$rc invocations='$invocations'"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Run all tests
+# ---------------------------------------------------------------------------
+
+main() {
+	echo "Running pulse defense-in-depth regression tests (t2939)..."
+	echo
+
+	setup
+
+	# Plist generation tests (macOS-only path — generation works on Linux too,
+	# we only skip the plutil-lint validation).
+	test_pulse_plist_keepalive_dict
+	test_pulse_plist_throttle_interval
+	test_watchdog_plist_label
+	test_watchdog_plist_start_interval
+	test_watchdog_plist_valid_xml
+
+	# Tick logic tests (cross-platform).
+	test_tick_alive_fast_exit
+	test_tick_dead_within_grace_no_revive
+	test_tick_dead_past_grace_revives
+	test_tick_no_last_run_revives
+	test_tick_disable_flag
+
+	echo
+	echo "Tests run:    $TESTS_RUN"
+	echo "Tests passed: $TESTS_PASSED"
+	echo "Tests failed: $TESTS_FAILED"
+
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/setup-modules/schedulers.sh
+++ b/setup-modules/schedulers.sh
@@ -14,6 +14,11 @@ PULSE_STALE_THRESHOLD_SECONDS=1800
 # future cadence shift only touches one place.
 CRON_HOURLY="0 * * * *"
 
+# Cron expression: every minute. Shared by process-guard, memory-pressure
+# monitor, and pulse-watchdog schedulers (cron's minimum granularity).
+# Kept DRY for the same reason as CRON_HOURLY.
+CRON_EVERY_MINUTE="* * * * *"
+
 # Resolve the modern bash binary path for use in launchd ProgramArguments.
 # Launchd bypasses the shebang when ProgramArguments specifies an explicit
 # interpreter, so we must resolve the path at plist generation time.
@@ -668,7 +673,12 @@ ${_env_overrides_xml}	</dict>
 	<key>RunAtLoad</key>
 	<true/>
 	<key>KeepAlive</key>
-	<false/>
+	<dict>
+		<key>SuccessfulExit</key>
+		<false/>
+	</dict>
+	<key>ThrottleInterval</key>
+	<integer>30</integer>
 </dict>
 </plist>
 PLIST
@@ -727,6 +737,161 @@ _install_pulse_launchd() {
 		_log_plist_env_overrides "$pulse_label"
 	else
 		print_warning "Failed to load supervisor pulse LaunchAgent"
+	fi
+	return 0
+}
+
+# Generate the pulse-watchdog launchd plist XML content.
+# Args: $1=label, $2=tick_script, $3=bash_bin
+# Prints the complete plist XML to stdout.
+#
+# The watchdog is an independent launchd job that runs every 60s and revives
+# pulse if it has been dead longer than (StartInterval + grace). Layered
+# defense alongside the pulse plist's KeepAlive=<dict><SuccessfulExit=false>
+# (auto-restart on crash) and StartInterval (scheduled cadence). Catches the
+# "clean exit + lost launchd schedule" failure mode that no other layer covers.
+# (t2939)
+_generate_pulse_watchdog_plist_content() {
+	local watchdog_label="$1"
+	local tick_script="$2"
+	local bash_bin="$3"
+
+	local _xml_label _xml_tick _xml_bash _xml_home _xml_path
+	_xml_label=$(_xml_escape "$watchdog_label")
+	_xml_tick=$(_xml_escape "$tick_script")
+	_xml_bash=$(_xml_escape "$bash_bin")
+	_xml_home=$(_xml_escape "$HOME")
+	_xml_path=$(_xml_escape "$PATH")
+
+	cat <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>${_xml_label}</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>${_xml_bash}</string>
+		<string>${_xml_tick}</string>
+	</array>
+	<key>StartInterval</key>
+	<integer>60</integer>
+	<key>StandardOutPath</key>
+	<string>${_xml_home}/.aidevops/logs/pulse-watchdog-launchd.log</string>
+	<key>StandardErrorPath</key>
+	<string>${_xml_home}/.aidevops/logs/pulse-watchdog-launchd.log</string>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>PATH</key>
+		<string>${_xml_path}</string>
+		<key>HOME</key>
+		<string>${_xml_home}</string>
+	</dict>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<false/>
+	<key>ThrottleInterval</key>
+	<integer>30</integer>
+</dict>
+</plist>
+PLIST
+	return 0
+}
+
+# Install the pulse-watchdog via launchd (macOS).
+# t2939: independent revival mechanism — see _generate_pulse_watchdog_plist_content
+# header for the layering rationale.
+_install_pulse_watchdog_launchd() {
+	local watchdog_label="sh.aidevops.pulse-watchdog"
+	local tick_script="$HOME/.aidevops/agents/scripts/pulse-watchdog-tick.sh"
+	local watchdog_plist="$HOME/Library/LaunchAgents/${watchdog_label}.plist"
+
+	# Refuse to install if the tick script is missing — the watchdog would
+	# fire-and-fail every 60s, polluting logs without doing useful work.
+	if [[ ! -x "$tick_script" ]]; then
+		print_warning "Pulse watchdog tick script missing or non-executable: $tick_script"
+		return 1
+	fi
+
+	local _xml_bash_bin
+	_xml_bash_bin=$(_resolve_modern_bash)
+
+	local watchdog_plist_content
+	watchdog_plist_content=$(_generate_pulse_watchdog_plist_content "$watchdog_label" "$tick_script" "$_xml_bash_bin")
+
+	if [[ -z "$watchdog_plist_content" ]]; then
+		print_warning "Pulse watchdog plist generation produced empty content — skipping"
+		return 1
+	fi
+
+	# shell-portability: ignore next — _install_pulse_watchdog_launchd is macOS-only
+	if _launchd_install_if_changed "$watchdog_label" "$watchdog_plist" "$watchdog_plist_content"; then
+		print_info "Pulse watchdog enabled (launchd, every 60s)"
+	else
+		print_warning "Failed to load pulse watchdog LaunchAgent"
+	fi
+	return 0
+}
+
+# Install the pulse-watchdog via systemd (Linux).
+# t2939: parallels _install_pulse_watchdog_launchd for systems with systemd --user.
+_install_pulse_watchdog_systemd() {
+	local tick_script="$HOME/.aidevops/agents/scripts/pulse-watchdog-tick.sh"
+	local watchdog_systemd="aidevops-pulse-watchdog"
+	local watchdog_log="$HOME/.aidevops/logs/pulse-watchdog-launchd.log"
+
+	if [[ ! -x "$tick_script" ]]; then
+		print_warning "Pulse watchdog tick script missing or non-executable: $tick_script"
+		return 1
+	fi
+
+	# Reuse the standard scheduler installer (cron-fallback aware).
+	# StartInterval=60 maps to every-minute cron schedule.
+	# shell-portability: ignore next — _install_scheduler_linux is Linux-only
+	_install_scheduler_linux \
+		"$watchdog_systemd" \
+		"aidevops: pulse-watchdog" \
+		"$CRON_EVERY_MINUTE" \
+		"\"${tick_script}\"" \
+		"60" \
+		"$watchdog_log" \
+		"" \
+		"Pulse watchdog enabled (every 60s)" \
+		"Failed to install pulse watchdog scheduler" \
+		"true" \
+		"false"
+	return 0
+}
+
+# Setup the pulse-watchdog scheduler (parallels setup_supervisor_pulse).
+# t2939: layered defense — only installs when supervisor pulse is enabled,
+# since a watchdog without a pulse to watch is a no-op every 60s.
+#
+# Args: $1 = pulse effective state ("true"/"false")
+setup_pulse_watchdog() {
+	local _pulse_effective="$1"
+	local watchdog_label="sh.aidevops.pulse-watchdog"
+	local watchdog_systemd="aidevops-pulse-watchdog"
+
+	if [[ "$_pulse_effective" != "true" ]]; then
+		# Pulse disabled — uninstall the watchdog if present.
+		_uninstall_scheduler \
+			"$(uname -s)" \
+			"$watchdog_label" \
+			"$watchdog_systemd" \
+			"aidevops: pulse-watchdog" \
+			"Pulse watchdog disabled (pulse is off)"
+		return 0
+	fi
+
+	mkdir -p "$HOME/.aidevops/logs"
+
+	if [[ "$(uname -s)" == "Darwin" ]]; then
+		_install_pulse_watchdog_launchd
+	else
+		_install_pulse_watchdog_systemd
 	fi
 	return 0
 }
@@ -1352,7 +1517,7 @@ GUARD_PLIST
 		_install_scheduler_linux \
 			"$guard_systemd" \
 			"aidevops: process-guard" \
-			"* * * * *" \
+			"$CRON_EVERY_MINUTE" \
 			"\"${guard_script}\" kill-runaways" \
 			"30" \
 			"$guard_log" \
@@ -1444,7 +1609,7 @@ MONITOR_PLIST
 		_install_scheduler_linux \
 			"$monitor_systemd" \
 			"aidevops: memory-pressure-monitor" \
-			"* * * * *" \
+			"$CRON_EVERY_MINUTE" \
 			"\"${monitor_script}\"" \
 			"60" \
 			"$monitor_log" \

--- a/setup.sh
+++ b/setup.sh
@@ -1246,6 +1246,12 @@ _setup_noninteractive_schedulers() {
 	if _should_setup_noninteractive_supervisor_pulse; then
 		setup_supervisor_pulse "$os"
 	fi
+	# t2939: pulse-watchdog (independent revival mechanism). Always installed
+	# alongside the pulse — it is a no-op when pulse is disabled. Skipping the
+	# `_should_setup_noninteractive_*` guard intentionally: this is layered
+	# defense, the cost of installing it is one plist file, and the user opts
+	# in by enabling the pulse itself.
+	setup_pulse_watchdog "${PULSE_ENABLED:-}"
 	# Regenerate other schedulers if already installed (GH#17695 Finding B).
 	# Stats wrapper is a pulse dependency — also install on first run when
 	# the supervisor pulse is consented (t2418, GH#20016).
@@ -1331,6 +1337,8 @@ _setup_post_setup_steps() {
 	# Post-setup: auto-update, schedulers, final instructions (GH#5793)
 	setup_auto_update
 	setup_supervisor_pulse "$os"
+	# t2939: pulse-watchdog — independent revival mechanism, layered defense.
+	setup_pulse_watchdog "${PULSE_ENABLED:-}"
 	setup_stats_wrapper "${PULSE_ENABLED:-}"
 	setup_failure_miner "${PULSE_ENABLED:-}"
 	setup_repo_sync

--- a/todo/tasks/t2939-brief.md
+++ b/todo/tasks/t2939-brief.md
@@ -1,0 +1,17 @@
+# t2939 — pulse defense-in-depth restart reliability
+
+This task is fully specified in the linked GitHub issue body.
+
+**Issue:** [marcusquinn/aidevops#21148](https://github.com/marcusquinn/aidevops/issues/21148)
+
+The issue body contains: problem statement, root cause analysis, four-layer
+solution design, files to modify, acceptance criteria, and verification
+commands. No additional brief content is needed (t2417 worker-ready heuristic).
+
+### Files Scope
+
+- setup-modules/schedulers.sh
+- setup.sh
+- .agents/scripts/pulse-watchdog-tick.sh
+- .agents/scripts/tests/test-pulse-defense-restart.sh
+- todo/tasks/t2939-brief.md


### PR DESCRIPTION
## Summary

Pulse is mission-critical infrastructure but historically died for up to 10 minutes after each cycle exit. The launchd plist had `KeepAlive=false` + `StartInterval=600s`, leaving a 10-min recovery gap if pulse exited between cycles (deploy, OOM, signal, plist reload race).

This PR adds **two defense-in-depth layers** to guarantee pulse survives any failure mode (Layer 3 = `pulse-lifecycle-helper.sh start` auto-call in `aidevops update` already shipped in t2914):

### Layer 1 — `KeepAlive` dict in pulse plist

```xml
<key>KeepAlive</key>
<dict>
    <key>SuccessfulExit</key>
    <false/>
</dict>
<key>ThrottleInterval</key>
<integer>30</integer>
```

- Auto-restarts on **crash / SIGKILL** within seconds.
- Still respects `StartInterval` on **clean exit** — preserves user's 600s GraphQL rate-limit tuning.
- `ThrottleInterval=30` prevents rapid-restart loops if pulse keeps crashing.

### Layer 2 — Independent pulse-watchdog launchd job

New plist `sh.aidevops.pulse-watchdog` runs every 60s, calling `pulse-watchdog-tick.sh`:

- **Alive fast path** — exits 0 if pulse running (idempotent no-op, cheap).
- **Within grace window** — exits 0 if pulse dead but `(now - last_run) <= (interval + 120s)` (lets launchd's `StartInterval` handle scheduled wakeups).
- **Past grace window** — calls `pulse-lifecycle-helper.sh start` (idempotent revival).
- **Cold-start** — no `last-run.ts` file → revive immediately.
- **Disable flag** — `AIDEVOPS_PULSE_WATCHDOG_DISABLE=1`.

Independent of the pulse plist itself — survives plist reload races, catches lost launchd registration, and handles the "clean exit + lost schedule" failure mode that no other layer covers.

## Files changed

| File | Change |
|---|---|
| `setup-modules/schedulers.sh` | `KeepAlive` dict in `_generate_pulse_plist_content`. New `_generate_pulse_watchdog_plist_content`, `_install_pulse_watchdog_launchd`, `_install_pulse_watchdog_systemd`, `setup_pulse_watchdog`. Adds shared `CRON_EVERY_MINUTE` constant (matching existing `CRON_HOURLY` pattern, DRY); refactors process-guard and memory-pressure-monitor call sites to use it. |
| `setup.sh` | Wires `setup_pulse_watchdog` into both interactive (line ~1335) and non-interactive (line ~1252) flows after `setup_supervisor_pulse`. |
| `.agents/scripts/pulse-watchdog-tick.sh` | NEW grace-aware tick script. Reads `supervisor.pulse_interval_seconds` from `~/.config/aidevops/settings.json`. Fail-safe logging to `~/.aidevops/logs/pulse-watchdog.log`. |
| `.agents/scripts/tests/test-pulse-defense-restart.sh` | NEW 10-test regression suite. |
| `todo/tasks/t2939-brief.md` | Brief stub linking to issue (t2417 worker-ready heuristic). |

## Verification

- **All 10 regression tests pass**: `bash .agents/scripts/tests/test-pulse-defense-restart.sh`
  - Layer 1: `test_pulse_plist_keepalive_dict`, `test_pulse_plist_throttle_interval`
  - Layer 2 plist: `test_watchdog_plist_label`, `test_watchdog_plist_start_interval`, `test_watchdog_plist_valid_xml`
  - Layer 2 tick: `test_tick_alive_fast_exit`, `test_tick_dead_within_grace_no_revive`, `test_tick_dead_past_grace_revives`, `test_tick_no_last_run_revives`, `test_tick_disable_flag`
- **Zero new shellcheck findings** vs `origin/main` baseline (only pre-existing SC2016 at `schedulers.sh:28`).
- **Zero new repeated string literals** — `CRON_EVERY_MINUTE` constant neutralises the new-literal ratchet trip from the third `"* * * * *"` site.
- **Plutil validation**: both generated plists parse `OK`.

## Post-merge verification (manual)

1. `aidevops update` regenerates plists from new source-of-truth.
2. `plutil -p ~/Library/LaunchAgents/com.aidevops.aidevops-supervisor-pulse.plist` — confirm `KeepAlive => { SuccessfulExit => false }`.
3. `launchctl list | grep pulse-watchdog` — confirm `sh.aidevops.pulse-watchdog` registered.
4. End-to-end revival test: `pkill -KILL -f pulse-wrapper && sleep 65 && pgrep -af pulse-wrapper` — watchdog should revive within ~60s.

## Related work

- t2914 (already shipped) — Layer 3: `pulse-lifecycle-helper.sh start` after every `aidevops update`. Belt-and-braces against update-time death.
- This PR — Layers 1 + 2 + 4: between-update reliability.

Resolves #21148

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.12.0 plugin for [OpenCode](https://opencode.ai) v1.14.26 with claude-opus-4-7 spent 7h 51m and 684,428 tokens on this with the user in an interactive session.
