### PR TITLE
fix(t2932): add setup_peer_productivity_monitor to interactive setup flow

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1350,6 +1350,7 @@ _setup_post_setup_steps() {
 	setup_contribution_watch
 	setup_complexity_scan
 	setup_pulse_merge_routine
+	setup_peer_productivity_monitor
 	setup_draft_responses
 	setup_profile_readme
 	setup_oauth_token_refresh


### PR DESCRIPTION
## Summary

Add `setup_peer_productivity_monitor` to the interactive setup flow in `setup.sh`.

## What

The interactive path (`_setup_post_setup_steps`) called scheduler-setup functions
for `setup_complexity_scan` and `setup_pulse_merge_routine` but was missing
`setup_peer_productivity_monitor` (added to non-interactive path in t2932). On
fresh runners using interactive setup, the plist was never installed and the monitor
never ran.

## Change

```diff
 setup_complexity_scan
 setup_pulse_merge_routine
+setup_peer_productivity_monitor
 setup_draft_responses
```

## Verification

- ShellCheck: zero violations
- Non-interactive path unchanged (line 1287)
- Interactive flow now matches non-interactive ordering

Resolves #21136


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.26 with claude-sonnet-4-6 spent 2m and 3,554 tokens on this as a headless worker.