### PR TITLE
t2944: fix bash 3.2 heredoc-in-$() in bounty-spam-detector.sh blocking macOS shellcheck CI

### DIFF
--- a/.agents/scripts/bounty-spam-detector.sh
+++ b/.agents/scripts/bounty-spam-detector.sh
@@ -499,6 +499,31 @@ cmd_scan_body() {
 	return "$rc"
 }
 
+# _bsd_compose_close_comment <markers>
+#
+# Emits the canonical dismissal comment to stdout. Defined as a function with a
+# top-level heredoc rather than as `comment_body=$(cat <<EOF ... EOF)` inside
+# cmd_close because Bash 3.2 (macOS /bin/bash) cannot parse heredocs nested
+# inside command substitutions — it reports a syntax error at the next case-arm
+# token, masking the real cause. The function form parses cleanly on Bash 3.2,
+# 4.x, and 5.x. See t2944.
+_bsd_compose_close_comment() {
+	local markers="$1"
+	cat <<EOF
+Auto-closed as templated bounty-hunter spam.
+
+Detected markers:
+
+${markers}
+This pattern matches an automated bounty-hunter bot known to file templated PRs across many public repositories with claims of one-dollar bounty rewards. The PR body matches verbatim phrases or markdown structures used exclusively by this bot.
+
+If filed in error, please contact the maintainer through the repository's normal contact channel — do **not** edit the PR body and reopen, as the auto-close trigger will fire again.
+
+Reference: ${BSD_REFERENCE_URL}
+EOF
+	return 0
+}
+
 cmd_close() {
 	local type="${1:-}"
 	local num="${2:-}"
@@ -569,20 +594,7 @@ cmd_close() {
 	[[ "$fields" == "BOTH" ]] && markers="${markers}- Markdown table: \`Reward: \$N\` + \`Source: GitHub-Bounty/Paid\`"$'\n'
 
 	local comment_body
-	comment_body=$(
-		cat <<EOF
-Auto-closed as templated bounty-hunter spam.
-
-Detected markers:
-
-${markers}
-This pattern matches an automated bounty-hunter bot known to file templated PRs across many public repositories with claims of one-dollar bounty rewards. The PR body matches verbatim phrases or markdown structures used exclusively by this bot.
-
-If filed in error, please contact the maintainer through the repository's normal contact channel — do **not** edit the PR body and reopen, as the auto-close trigger will fire again.
-
-Reference: ${BSD_REFERENCE_URL}
-EOF
-	)
+	comment_body="$(_bsd_compose_close_comment "$markers")"
 
 	if [[ "$dry_run" -eq 1 ]]; then
 		_bsd_log_warn "[DRY RUN] Would close PR #${num} in ${slug} with comment:"


### PR DESCRIPTION
## P0 hotfix — bash 3.2 syntax error blocking ALL PR merges

`bounty-spam-detector.sh` at line 572 had a heredoc nested inside a command substitution:

```bash
comment_body=$(
    cat <<EOF
...
EOF
)
```

Bash 3.2 (the default `/bin/bash` on macOS — what the `ShellCheck (macos-latest)` CI job runs under) cannot parse this construct and emits a misleading error pointing at line 676 (the next `;;`). Bash 4+ and 5+ accept it. The `ShellCheck (macos-latest)` job was failing on ALL open PRs across the repo because shellcheck refuses to lint a file that bash itself cannot parse.

This PR extracts the heredoc body into a sibling helper function `_bsd_compose_close_comment` and calls it via plain `comment_body="$(_bsd_compose_close_comment "$markers")"` — which parses cleanly on Bash 3.2, 4.x, and 5.x.

## Verification

- `/bin/bash -n .agents/scripts/bounty-spam-detector.sh` → exit 0 (was: `syntax error near unexpected token ';;'`).
- `shellcheck .agents/scripts/bounty-spam-detector.sh` → zero violations.
- Sourcing smoke test: `_bsd_compose_close_comment` produces the exact same comment body as the original inline heredoc — verbatim string match including the markers interpolation, the body prose, and the `Reference:` URL.
- Pre-commit + pre-push hooks all pass locally.

## Why this is P0

Every open PR in this repo currently has a red `ShellCheck (macos-latest)` check that has nothing to do with the PR's own diff — it's the parser choking on this one file in the base branch. Until this lands, no PR can satisfy the required-checks gate, including #21159 (t2942 stampless threshold) and the rest of the dispatch backlog.

## Rationale for the helper-fn pattern

The functionally-equivalent `printf` or single-line concatenation alternatives lose markdown readability and require careful escaping of the literal `$N` substring inside the body. Extracting the heredoc into a function preserves the heredoc's quoting semantics, keeps the markdown source readable, and is a known Bash 3.2-safe pattern documented in `reference/bash-compat.md`.

A code comment above the new helper records the t2944 attribution and the Bash 3.2 root cause so the next reader doesn't have to re-discover the pattern.

Resolves #21162

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.26 with claude-opus-4-7 spent 8h 41m and 777,998 tokens on this with the user in an interactive session.
