### PR TITLE
GH#21135: peer-productivity-monitor — observe claim activity for regression detection

### DIFF
--- a/.agents/scripts/peer-productivity-monitor.sh
+++ b/.agents/scripts/peer-productivity-monitor.sh
@@ -29,9 +29,9 @@
 #   peer-productivity-monitor.sh reset <peer>   # reset hysteresis state for a peer
 #
 # Decision rules per peer:
-#   - 0 worker PRs merged in 24h + 1+ active claims = vote `ignore` (peer broken)
+#   - 0 worker PRs merged in 24h + 2+ origin:worker claims = vote `ignore` (peer broken)
 #   - 1+ worker PRs merged in 24h = vote `honour` (peer healthy)
-#   - 0 of each = vote `keep` (insufficient signal, no change)
+#   - 0 merged PRs + 0–1 worker claims = vote `keep` (insufficient signal, no change)
 #
 # Default for unknown peers: ignore (compete-by-default — safer for new peers
 # until they prove productivity).
@@ -171,10 +171,12 @@ _observe_peer() {
 	local worker_prs=0
 	local interactive_prs=0
 
-	# Active claims: open issues currently assigned to peer.
-	# (We don't filter by label here — any open assignment is the signal.)
+	# Active worker claims: open issues with origin:worker label assigned to peer.
+	# Filtering by label ensures interactive work never counts as a broken-pulse
+	# signal — only automated worker claims matter for productivity assessment.
 	local claims_json
 	claims_json=$(gh issue list --repo "$repo" --assignee "$login" --state open \
+		--label origin:worker \
 		--limit 100 --json number 2>/dev/null || echo '[]')
 	active_claims=$(printf '%s' "$claims_json" | jq 'length' 2>/dev/null || echo 0)
 
@@ -296,13 +298,18 @@ discover_and_observe() {
 # ============================================================================
 
 # Compute vote for a peer: ignore | honour | keep
+#
+# Ratio-based decision:
+#   - merges >= 1                        → honour  (peer is productive)
+#   - merges == 0 && claims >= 2         → ignore  (peer is broken: claims but never delivers)
+#   - merges == 0 && claims 0–1          → keep    (insufficient data; 1 in-flight task is normal)
 _vote_for_peer() {
 	local active_claims="$1"
 	local worker_prs="$2"
 
 	if [[ "$worker_prs" -ge 1 ]]; then
 		printf '%s' "$ACTION_HONOUR"
-	elif [[ "$active_claims" -ge 1 ]]; then
+	elif [[ "$active_claims" -ge 2 ]]; then
 		printf '%s' "$ACTION_IGNORE"
 	else
 		printf '%s' "$ACTION_KEEP"

--- a/tests/test-peer-productivity-monitor.sh
+++ b/tests/test-peer-productivity-monitor.sh
@@ -177,11 +177,14 @@ test_vote_for_peer() {
 	local cases=(
 		# active_claims:worker_prs:expected_vote
 		"0:0:keep"      # no signal → keep
-		"5:0:ignore"    # claims but no PRs → broken pulse → ignore
+		"1:0:keep"      # single claim, no PRs → insufficient data (< 2 threshold) → keep
+		"2:0:ignore"    # 2 claims, no PRs → broken pulse (meets >=2 threshold) → ignore
+		"5:0:ignore"    # 5 claims but no PRs → broken pulse → ignore
 		"0:1:honour"    # no claims, 1 PR → recovered → honour
+		"1:1:honour"    # 1 claim + 1 PR → productive → honour (merges win)
 		"5:1:honour"    # claims AND PRs → working, just slow → honour
 		"10:3:honour"   # productive peer → honour
-		"3:0:ignore"    # silent peer with claims → ignore
+		"3:0:ignore"    # 3 claims, no PRs → broken → ignore
 	)
 	for c in "${cases[@]}"; do
 		IFS=: read -r ac wp expected <<<"$c"
@@ -412,6 +415,83 @@ EOF
 	return 0
 }
 test_rewrite_drops_honour_entries
+
+# ============================================================================
+section "Claim regression — broken-peer detection (GH#21135)"
+# ============================================================================
+# These tests specifically exercise the claim-but-no-merge regression case:
+# a peer whose runner CLAIMS issues but never merges should trigger `ignore`
+# after 3 consecutive cycles of >=2 claims with 0 worker PRs.
+
+test_claim_regression_single_claim_is_keep() {
+	# A peer with exactly 1 open claim and 0 merges must vote `keep`
+	# (insufficient data — 1 in-flight task is normal).
+	local result
+	result=$(_vote_for_peer 1 0)
+	if [[ "$result" == "keep" ]]; then
+		pass "1 claim + 0 merges = keep (single in-flight task is normal)"
+	else
+		fail "1 claim + 0 merges: expected keep, got $result"
+	fi
+	return 0
+}
+test_claim_regression_single_claim_is_keep
+
+test_claim_regression_two_claims_is_ignore() {
+	# 2+ open worker-labeled claims with 0 merges triggers the ignore vote.
+	local r2 r3
+	r2=$(_vote_for_peer 2 0)
+	r3=$(_vote_for_peer 3 0)
+	if [[ "$r2" == "ignore" ]] && [[ "$r3" == "ignore" ]]; then
+		pass "2+ claims + 0 merges = ignore (broken peer)"
+	else
+		fail "2+ claims + 0 merges: expected ignore, got r2=$r2 r3=$r3"
+	fi
+	return 0
+}
+test_claim_regression_two_claims_is_ignore
+
+test_claim_regression_hysteresis_three_cycles() {
+	# Simulate a peer that was healthy, now breaks (claims but no merges).
+	# After 3 consecutive cycles of ignore votes, the action flips to ignore.
+	local state='{"brokenbot":{"current_action":"honour","vote_history":["honour","honour","honour"],"last_observed":"2026-01-01T00:00:00Z"}}'
+	local r
+	for _ in 1 2 3; do
+		r=$(_apply_hysteresis "$state" "brokenbot" "ignore")
+		state=$(printf '%s\n%s' "$state" "$r" | jq -s '.[0] * .[1]')
+	done
+	local action
+	action=$(_extract_action "$state" "brokenbot")
+	if [[ "$action" == "ignore" ]]; then
+		pass "regression: 3x ignore cycles flip honour → ignore"
+	else
+		fail "regression: expected ignore after 3 cycles, got $action"
+	fi
+	return 0
+}
+test_claim_regression_hysteresis_three_cycles
+
+test_claim_regression_merges_block_ignore() {
+	# A peer with 2+ claims BUT also has merged PRs → vote is honour (productive).
+	# The monitor must not penalise a peer that is both claiming and delivering.
+	local cases=(
+		"2:1"   # 2 claims, 1 merge → honour
+		"5:1"   # 5 claims, 1 merge → honour
+		"10:2"  # 10 claims, 2 merges → honour
+	)
+	for c in "${cases[@]}"; do
+		IFS=: read -r claims prs <<<"$c"
+		local result
+		result=$(_vote_for_peer "$claims" "$prs")
+		if [[ "$result" == "honour" ]]; then
+			pass "vote(claims=$claims, merges=$prs) = honour (merges block ignore)"
+		else
+			fail "vote(claims=$claims, merges=$prs): expected honour, got $result"
+		fi
+	done
+	return 0
+}
+test_claim_regression_merges_block_ignore
 
 # ============================================================================
 section "CLI smoke (help/report)"


### PR DESCRIPTION
## What

Extends `peer-productivity-monitor.sh` (t2932) to also observe **claim activity** so it can detect regression (a peer that was healthy but is now broken — claiming issues but never merging).

## Changes

### `.agents/scripts/peer-productivity-monitor.sh`

**`_observe_peer()`**: Added `--label origin:worker` filter to the `active_claims` query.
- Previously counted ALL open issues assigned to a peer (including interactive work)
- Now counts only `origin:worker`-labeled open issues — the worker-pulse claims
- Interactive work by the same person never penalises their productivity score

**`_vote_for_peer()`**: Updated broken-peer threshold from `>= 1` claim to `>= 2` claims.

New decision rules (replacing old single-signal logic):
| Condition | Vote | Rationale |
|---|---|---|
| `merges >= 1` | `honour` | Productive — claims are being delivered |
| `merges == 0 && claims >= 2` | `ignore` | Broken — accumulating claims, delivering nothing |
| `merges == 0 && claims 0–1` | `keep` | Insufficient data — 1 in-flight task is normal |

**Top comment**: Updated to reflect new 2-claim threshold and `origin:worker` filter.

### `tests/test-peer-productivity-monitor.sh`

- Added `"1:0:keep"` and `"2:0:ignore"` boundary cases to the existing vote test matrix
- Added `"1:1:honour"` (claim + merge → productive) to the vote matrix
- New section **"Claim regression — broken-peer detection (GH#21135)"** with 4 targeted tests:
  1. Single claim (< 2) → `keep` (not a broken signal)
  2. 2+ claims, 0 merges → `ignore` 
  3. 3-cycle hysteresis flip from `honour` → `ignore` (regression scenario)
  4. Merges present → `honour` even when claims are high (delivering peer)

## Verification

```
bash tests/test-peer-productivity-monitor.sh  # 47/47 pass (was 38/38)
shellcheck .agents/scripts/peer-productivity-monitor.sh  # 0 violations
shellcheck tests/test-peer-productivity-monitor.sh  # 0 violations
```

Resolves #21135

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.26 with claude-sonnet-4-6 spent 4m and 11,231 tokens on this as a headless worker.
