### PR TITLE
t2857: case draft agent with RAG, provenance, and cross-case firewall

### DIFF
--- a/.agents/aidevops/cases-plane.md
+++ b/.agents/aidevops/cases-plane.md
@@ -182,6 +182,78 @@ Paper-trail entry — full email content attaches via P5 (inbox-to-case filter).
 
 All read-side commands (`list`, `show`) and all mutating commands support `--json` for machine consumption. Use for scripting, P5 filter integration, and P4c alarming.
 
+## Drafting (P6a — t2857)
+
+The drafting subsystem generates strategic communication drafts using RAG over case knowledge sources. All drafts are **human-gated** — they write to `_cases/<id>/drafts/` and never auto-send.
+
+### Draft command
+
+```bash
+aidevops case draft <case-id> --intent "request payment of overdue invoice" \
+    [--tone neutral|formal|conciliatory|firm] \
+    [--length short|medium|long] \
+    [--cite strict|loose] \
+    [--include-case <other-case-id>] \
+    [--dry-run] [--json]
+```
+
+### Revise command
+
+```bash
+aidevops case draft <case-id> --revise <draft-file> --feedback "soften paragraph 3"
+```
+
+Produces a new revision file (`-rev2.md`, `-rev3.md`, etc.) preserving the citation standard.
+
+### Draft output
+
+Drafts are written to `_cases/<case-id>/drafts/<timestamp>-<intent-slug>.md` with:
+
+- **YAML frontmatter:** `case_id`, `intent`, `tone`, `length`, `model`, `generated_at`, `sources_consulted`, `cross_case_includes`
+- **Body:** LLM output with `[source-id]` citation anchors
+- **Provenance footer:** explicit list of source IDs with kind, sensitivity, and sha — always appended even if the model omits it
+
+### Sensitivity-tier routing
+
+The draft helper reads `meta.json` from each attached source to determine sensitivity. The **maximum sensitivity** across all sources determines the LLM routing tier:
+
+| Source sensitivity | LLM routing tier | Provider |
+|---|---|---|
+| `public` | `public` | Any (default: Anthropic) |
+| `internal` | `internal` | Cloud or local |
+| `confidential` | `sensitive` | Local only (Ollama) |
+| `restricted` | `privileged` | Local only; hard-fail if unavailable |
+
+When any attached source is `restricted` (privileged tier), the draft **must** route through the local LLM (Ollama). If Ollama is not running, the draft fails rather than sending privileged content to a cloud provider.
+
+### Cross-case privilege firewall
+
+By default, each case's draft sees **only its own** `sources.toon`. Cross-case retrieval requires explicit opt-in:
+
+```bash
+aidevops case draft <case-id> --intent "..." --include-case <other-case-id>
+```
+
+Every cross-case access is:
+
+1. **Audited** — appended to `_cases/<case-id>/comms/cross-case-access.jsonl`:
+
+   ```json
+   {"at":"2026-04-27T10:00:00Z","included_case":"case-2026-0002-related","included_by":"user","reason":"Draft intent: ..."}
+   ```
+
+2. **Logged in timeline** — a `cross-case-access` event records the inclusion
+
+This ensures cross-case knowledge bleed is always a deliberate, traceable act — critical for matters with multiple unrelated cases where discovery concerns apply.
+
+### Tone library
+
+Four built-in tones: `neutral`, `formal`, `conciliatory`, `firm`. Custom tones can be added by copying `.agents/templates/draft-tones-config.json` to `_config/draft-tones.json` in the repo.
+
+### No auto-send enforcement
+
+The drafting helper has **no** `--send` or `--auto-send` flag. Drafts are written to the `drafts/` directory (gitignored by default) for human review. Sending is a separate, deliberate act outside the draft workflow.
+
 ## Dependencies
 
 - **Provisioned by:** `aidevops case init`
@@ -189,5 +261,6 @@ All read-side commands (`list`, `show`) and all mutating commands support `--jso
 - **Alarming reads:** `dossier.deadlines` (t2853 P4c)
 - **Comms agent operates on:** cases (P6)
 - **Filter→case-attach:** uses `aidevops case attach` (P5c)
+- **Drafting uses:** `llm-routing-helper.sh` (t2847), `knowledge-index-helper.sh` (t2850)
 
 <!-- AI-CONTEXT-END -->

--- a/.agents/scripts/case-draft-helper.sh
+++ b/.agents/scripts/case-draft-helper.sh
@@ -1,0 +1,926 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# shellcheck disable=SC2034
+set -euo pipefail
+
+# =============================================================================
+# Case Draft Helper (t2857)
+# =============================================================================
+# Generates strategic communication drafts using RAG over case knowledge
+# sources, with full provenance tracking and human-gated output.
+#
+# Drafts are ALWAYS human-gated — never auto-sent.
+#
+# Usage:
+#   case-draft-helper.sh draft <case-id> --intent "..." [options]
+#   case-draft-helper.sh revise <draft-file> --feedback "..." [options]
+#   case-draft-helper.sh help
+#
+# Options:
+#   --intent <text>       Free-text description of draft intent (REQUIRED)
+#   --tone <preset>       Tone preset: neutral|formal|conciliatory|firm
+#   --length <size>       Draft length: short|medium|long
+#   --cite <mode>         Citation mode: strict|loose (default: strict)
+#   --include-case <id>   Include another case's sources (audited)
+#   --dry-run             Print draft to stdout, don't write file
+#   --repo <path>         Target repo path (default: cwd)
+#   --max-tokens <N>      Max tokens for LLM call (default: auto)
+#   --json                Machine-readable JSON output
+#
+# Revise mode:
+#   --revise <file>       Path to existing draft file to revise
+#   --feedback <text>     Revision feedback / instructions
+#
+# ShellCheck clean. Bash 3.2 compatible (macOS default).
+# =============================================================================
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+# shellcheck source=shared-constants.sh
+source "${SCRIPT_DIR}/shared-constants.sh"
+
+init_log_file
+
+# =============================================================================
+# Constants
+# =============================================================================
+
+readonly CASES_DIR_NAME="_cases"
+readonly CASE_DOSSIER_FILE="dossier.toon"
+readonly CASE_SOURCES_FILE="sources.toon"
+readonly CASE_TIMELINE_FILE="timeline.jsonl"
+readonly CASE_DRAFTS_DIR="drafts"
+readonly CASE_COMMS_DIR="comms"
+readonly CROSS_CASE_ACCESS_LOG="cross-case-access.jsonl"
+
+readonly KNOWLEDGE_SOURCES_DIR="_knowledge/sources"
+readonly SOURCE_META_FILE="meta.json"
+
+readonly PROMPT_TEMPLATE="${SCRIPT_DIR}/../templates/case-draft-prompt.md"
+readonly TONES_CONFIG_DEFAULT="${SCRIPT_DIR}/../templates/draft-tones-config.json"
+
+# Sensitivity tier ordering (lowest to highest)
+# Maps knowledge-plane sensitivity to LLM routing tiers
+readonly -a _SENSITIVITY_ORDER=(public internal pii sensitive privileged)
+
+# Length → token mapping
+readonly _LENGTH_SHORT=2048
+readonly _LENGTH_MEDIUM=4096
+readonly _LENGTH_LONG=8192
+
+# Centralised string constants (satisfies string-literal ratchet)
+_TONE_DEFAULT_FRAGMENT="Maintain a balanced, objective tone."
+_TASK_DRAFT="draft"
+_UNKNOWN="unknown"
+_INTERNAL="internal"
+_TRUE="true"
+
+# =============================================================================
+# Error helpers
+# =============================================================================
+
+_err_missing_arg() {
+	local arg="$1"
+	print_error "Missing required argument: ${arg}"
+	return 1
+}
+
+_err_case_not_found() {
+	local case_id="$1"
+	print_error "Case not found: ${case_id}"
+	return 1
+}
+
+# =============================================================================
+# Internal helpers
+# =============================================================================
+
+# _iso_ts — current UTC timestamp
+_iso_ts() {
+	date -u '+%Y%m%dT%H%M%SZ'
+	return 0
+}
+
+# _iso_ts_filename — timestamp suitable for filenames
+_iso_ts_filename() {
+	date -u '+%Y%m%d-%H%M%S'
+	return 0
+}
+
+# _current_actor — best-effort actor name
+_current_actor() {
+	local actor
+	actor="$(git config user.name 2>/dev/null)" || true
+	[[ -z "$actor" ]] && actor="${USER:-unknown}"
+	echo "$actor"
+	return 0
+}
+
+# _require_jq — error if jq is not available
+_require_jq() {
+	if ! command -v jq >/dev/null 2>&1; then
+		print_error "jq is required but not found. Install: brew install jq"
+		return 1
+	fi
+	return 0
+}
+
+# _slugify <text> — convert free text to kebab-case slug
+_slugify() {
+	local text="$1"
+	echo "$text" | tr '[:upper:]' '[:lower:]' | tr -cs '[:alnum:]' '-' | sed 's/^-//;s/-$//' | cut -c1-50
+	return 0
+}
+
+# _resolve_cases_dir <repo-path>
+_resolve_cases_dir() {
+	local repo_path="${1:-$(pwd)}"
+	echo "${repo_path}/${CASES_DIR_NAME}"
+	return 0
+}
+
+# _case_find <cases-dir> <case-id> — resolve case directory path
+_case_find() {
+	local cases_dir="$1" query="$2"
+
+	# Direct directory match
+	if [[ -d "${cases_dir}/${query}" ]]; then
+		echo "${cases_dir}/${query}"
+		return 0
+	fi
+
+	# Prefix / slug match
+	local dir
+	for dir in "${cases_dir}"/case-*-"${query}" "${cases_dir}"/case-*-*"${query}"*; do
+		[[ -d "$dir" ]] || continue
+		[[ "$dir" == *"/archived/"* ]] && continue
+		echo "$dir"
+		return 0
+	done
+
+	return 1
+}
+
+# _timeline_append <case-dir> <kind> <actor> <content> [ref]
+_timeline_append() {
+	local case_dir="$1" kind="$2" actor="$3" content="$4" ref="${5:-}"
+	local timeline_path="${case_dir}/${CASE_TIMELINE_FILE}"
+	local ts
+	ts="$(_iso_ts)"
+	local event
+	event="$(jq -cn \
+		--arg ts "$ts" \
+		--arg kind "$kind" \
+		--arg actor "$actor" \
+		--arg content "$content" \
+		--arg ref "$ref" \
+		'{ts:$ts, kind:$kind, actor:$actor, content:$content, ref:$ref}')"
+	echo "$event" >>"$timeline_path"
+	return 0
+}
+
+# _sensitivity_to_tier <sensitivity> — map knowledge-plane sensitivity to LLM tier
+_sensitivity_to_tier() {
+	local sensitivity="$1"
+	case "$sensitivity" in
+	public) echo "public" ;;
+	internal) echo "$_INTERNAL" ;;
+	confidential) echo "sensitive" ;;
+	restricted | privileged) echo "privileged" ;;
+	pii) echo "pii" ;;
+	sensitive) echo "sensitive" ;;
+	*) echo "$_INTERNAL" ;; # safe default
+	esac
+	return 0
+}
+
+# _tier_rank <tier> — numeric rank for comparison (higher = more sensitive)
+_tier_rank() {
+	local tier="$1"
+	case "$tier" in
+	public) echo 0 ;;
+	internal) echo 1 ;;
+	pii) echo 2 ;;
+	sensitive) echo 3 ;;
+	privileged) echo 4 ;;
+	*) echo 1 ;;
+	esac
+	return 0
+}
+
+# _max_tier <sources-json> <repo-path> — resolve maximum sensitivity tier
+# Reads meta.json for each source to determine sensitivity, returns the highest tier.
+_max_tier() {
+	local sources_json="$1" repo_path="$2"
+	local max_rank=0 max_tier="public"
+
+	local source_ids
+	source_ids="$(echo "$sources_json" | jq -r '.[].id' 2>/dev/null)" || true
+
+	local source_id
+	while IFS= read -r source_id; do
+		[[ -z "$source_id" ]] && continue
+		local meta_path="${repo_path}/${KNOWLEDGE_SOURCES_DIR}/${source_id}/${SOURCE_META_FILE}"
+		if [[ -f "$meta_path" ]]; then
+			local sensitivity
+			sensitivity="$(jq -r --arg fb "$_INTERNAL" '.sensitivity // $fb' "$meta_path" 2>/dev/null)" || sensitivity="$_INTERNAL"
+			local tier
+			tier="$(_sensitivity_to_tier "$sensitivity")"
+			local rank
+			rank="$(_tier_rank "$tier")"
+			if [[ "$rank" -gt "$max_rank" ]]; then
+				max_rank="$rank"
+				max_tier="$tier"
+			fi
+		fi
+	done <<<"$source_ids"
+
+	echo "$max_tier"
+	return 0
+}
+
+# _load_tones_config <repo-path> — load tone library, falling back to template
+_load_tones_config() {
+	local repo_path="$1"
+	local user_config="${repo_path}/_config/draft-tones.json"
+
+	if [[ -f "$user_config" ]]; then
+		echo "$user_config"
+	elif [[ -f "$TONES_CONFIG_DEFAULT" ]]; then
+		echo "$TONES_CONFIG_DEFAULT"
+	else
+		echo ""
+	fi
+	return 0
+}
+
+# _get_tone_fragment <tones-config-path> <tone-name> — get system prompt fragment
+_get_tone_fragment() {
+	local config_path="$1" tone_name="$2"
+
+	if [[ -z "$config_path" || ! -f "$config_path" ]]; then
+		# Inline defaults when no config available
+		case "$tone_name" in
+		neutral) echo "$_TONE_DEFAULT_FRAGMENT" ;;
+		formal) echo "Use formal, professional language appropriate for official correspondence." ;;
+		conciliatory) echo "Adopt a cooperative, solution-oriented tone that seeks common ground." ;;
+		firm) echo "Be direct, assertive, and clear about positions and expectations." ;;
+		*) echo "$_TONE_DEFAULT_FRAGMENT" ;;
+		esac
+		return 0
+	fi
+
+	local fragment
+	fragment="$(jq -r --arg t "$tone_name" '.tones[$t].system_fragment // ""' "$config_path" 2>/dev/null)" || fragment=""
+
+	if [[ -z "$fragment" ]]; then
+		echo "$_TONE_DEFAULT_FRAGMENT"
+	else
+		echo "$fragment"
+	fi
+	return 0
+}
+
+# _length_to_tokens <length> — map length preset to max tokens
+_length_to_tokens() {
+	local length="$1"
+	case "$length" in
+	short) echo "$_LENGTH_SHORT" ;;
+	medium) echo "$_LENGTH_MEDIUM" ;;
+	long) echo "$_LENGTH_LONG" ;;
+	*) echo "$_LENGTH_MEDIUM" ;;
+	esac
+	return 0
+}
+
+# _length_to_word_range <length> — human-readable length guidance
+_length_to_word_range() {
+	local length="$1"
+	case "$length" in
+	short) echo "200-500 words" ;;
+	medium) echo "500-1500 words" ;;
+	long) echo "1500-4000 words" ;;
+	*) echo "500-1500 words" ;;
+	esac
+	return 0
+}
+
+# _read_timeline_recent <case-dir> <count> — last N timeline entries as text
+_read_timeline_recent() {
+	local case_dir="$1" count="${2:-5}"
+	local timeline_path="${case_dir}/${CASE_TIMELINE_FILE}"
+
+	if [[ ! -f "$timeline_path" ]]; then
+		echo "(no timeline entries)"
+		return 0
+	fi
+
+	tail -n "$count" "$timeline_path" | while IFS= read -r line; do
+		[[ -z "$line" ]] && continue
+		local ts kind content
+		ts="$(echo "$line" | jq -r '.ts' 2>/dev/null)" || ts="?"
+		kind="$(echo "$line" | jq -r '.kind' 2>/dev/null)" || kind="?"
+		content="$(echo "$line" | jq -r '.content' 2>/dev/null)" || content="?"
+		printf '[%s] %s: %s\n' "$ts" "$kind" "$content"
+	done
+	return 0
+}
+
+# _collect_excerpts <source-ids> <repo-path> <max-sources> — collect excerpts from sources
+# Returns numbered excerpts with source anchors.
+_collect_excerpts() {
+	local source_ids_str="$1" repo_path="$2" max_sources="${3:-8}"
+	local count=0 excerpts=""
+
+	local source_id
+	while IFS= read -r source_id; do
+		[[ -z "$source_id" ]] && continue
+		[[ "$count" -ge "$max_sources" ]] && break
+
+		local source_dir="${repo_path}/${KNOWLEDGE_SOURCES_DIR}/${source_id}"
+		[[ ! -d "$source_dir" ]] && continue
+
+		# Try to read content from the source directory
+		local content_file=""
+		local f
+		for f in "${source_dir}"/*.txt "${source_dir}"/*.md "${source_dir}"/*.pdf.txt \
+			"${source_dir}"/content.txt "${source_dir}"/extracted.txt; do
+			if [[ -f "$f" ]]; then
+				content_file="$f"
+				break
+			fi
+		done
+
+		if [[ -z "$content_file" ]]; then
+			# Try any file that isn't meta.json
+			for f in "${source_dir}"/*; do
+				[[ -f "$f" ]] || continue
+				[[ "$(basename "$f")" == "meta.json" ]] && continue
+				content_file="$f"
+				break
+			done
+		fi
+
+		if [[ -n "$content_file" ]]; then
+			count=$((count + 1))
+			# Take first ~2000 chars as excerpt
+			local excerpt
+			excerpt="$(head -c 2000 "$content_file" 2>/dev/null)" || excerpt="(unable to read)"
+			excerpts="${excerpts}[${source_id}]: \"${excerpt}\"
+
+"
+		fi
+	done <<<"$source_ids_str"
+
+	if [[ -z "$excerpts" ]]; then
+		echo "(no source excerpts available)"
+	else
+		printf '%s' "$excerpts"
+	fi
+	return 0
+}
+
+# _build_provenance_footer <sources-json> <repo-path> <model> <timestamp>
+# Returns the provenance footer block.
+_build_provenance_footer() {
+	local sources_json="$1" repo_path="$2" model="$3" timestamp="$4"
+	local cross_case_ids="${5:-}"
+
+	local footer="---
+
+**Drafted with reference to:**
+"
+	local source_ids
+	source_ids="$(echo "$sources_json" | jq -r '.[].id' 2>/dev/null)" || true
+
+	local source_id
+	while IFS= read -r source_id; do
+		[[ -z "$source_id" ]] && continue
+		local meta_path="${repo_path}/${KNOWLEDGE_SOURCES_DIR}/${source_id}/${SOURCE_META_FILE}"
+		local kind="$_UNKNOWN" sensitivity="$_UNKNOWN" sha="$_UNKNOWN"
+		if [[ -f "$meta_path" ]]; then
+			kind="$(jq -r --arg fb "$_UNKNOWN" '.kind // $fb' "$meta_path" 2>/dev/null)" || kind="$_UNKNOWN"
+			sensitivity="$(jq -r --arg fb "$_UNKNOWN" '.sensitivity // $fb' "$meta_path" 2>/dev/null)" || sensitivity="$_UNKNOWN"
+			sha="$(jq -r --arg fb "$_UNKNOWN" '.sha256 // $fb' "$meta_path" 2>/dev/null)" || sha="$_UNKNOWN"
+			# Truncate sha for readability
+			[[ ${#sha} -gt 12 ]] && sha="${sha:0:12}..."
+		fi
+		footer="${footer}- ${source_id} (kind: ${kind}, sensitivity: ${sensitivity}, sha: ${sha})
+"
+	done <<<"$source_ids"
+
+	# Add cross-case sources if present
+	if [[ -n "$cross_case_ids" ]]; then
+		footer="${footer}
+**Cross-case sources included from:** ${cross_case_ids}
+"
+	fi
+
+	# Get aidevops version
+	local version="$_UNKNOWN"
+	local version_file="${SCRIPT_DIR}/../VERSION"
+	[[ -f "$version_file" ]] && version="$(cat "$version_file" 2>/dev/null)" || true
+
+	footer="${footer}
+**Generated by:** aidevops v${version}, model: ${model}, at: ${timestamp}
+"
+
+	printf '%s' "$footer"
+	return 0
+}
+
+# _log_cross_case_access <case-dir> <included-case-id> <actor> [reason]
+_log_cross_case_access() {
+	local case_dir="$1" included_case="$2" actor="$3" reason="${4:-}"
+	local log_dir="${case_dir}/${CASE_COMMS_DIR}"
+	local log_file="${log_dir}/${CROSS_CASE_ACCESS_LOG}"
+	local ts
+	ts="$(_iso_ts)"
+
+	mkdir -p "$log_dir"
+	local entry
+	entry="$(jq -cn \
+		--arg at "$ts" \
+		--arg inc "$included_case" \
+		--arg by "$actor" \
+		--arg reason "$reason" \
+		'{at:$at, included_case:$inc, included_by:$by, reason:$reason}')"
+	echo "$entry" >>"$log_file"
+	return 0
+}
+
+# _compose_prompt <case-id> <intent> <tone-fragment> <length-guidance>
+#   <kind> <party-self> <timeline-text> <excerpts> <cite-mode>
+# Uses the prompt template if available, else inline composition.
+_compose_prompt() {
+	local case_id="$1" intent="$2" tone_fragment="$3" length_guidance="$4"
+	local kind="$5" party_self="$6" timeline_text="$7" excerpts="$8"
+	local cite_mode="${9:-strict}"
+
+	local cite_instruction="Cite every factual claim with [source-id] anchors."
+	if [[ "$cite_mode" == "loose" ]]; then
+		cite_instruction="Cite key claims with [source-id] anchors where the source is clear."
+	fi
+
+	if [[ -f "$PROMPT_TEMPLATE" ]]; then
+		local template
+		template="$(cat "$PROMPT_TEMPLATE")"
+		# Substitute placeholders
+		template="${template//\{tone\}/$tone_fragment}"
+		template="${template//\{kind\}/$kind}"
+		template="${template//\{case-id\}/$case_id}"
+		template="${template//\{party-self\}/$party_self}"
+		template="${template//\{intent\}/$intent}"
+		template="${template//\{timeline\}/$timeline_text}"
+		template="${template//\{excerpts\}/$excerpts}"
+		template="${template//\{length\}/$length_guidance}"
+		template="${template//\{cite-instruction\}/$cite_instruction}"
+		printf '%s\n' "$template"
+	else
+		# Inline fallback
+		cat <<PROMPT
+You are drafting a ${tone_fragment} ${kind} communication for case ${case_id} on behalf of ${party_self}.
+
+The intent is: ${intent}.
+
+Recent case timeline:
+${timeline_text}
+
+Available evidence:
+${excerpts}
+
+Produce a draft that:
+- ${cite_instruction}
+- Stays ${tone_fragment}; avoids speculation beyond the evidence
+- Length: ${length_guidance}
+
+At the end, list "Drafted with reference to:" with each consulted source.
+PROMPT
+	fi
+	return 0
+}
+
+# =============================================================================
+# Extracted helpers for complexity compliance (<100 lines per function)
+# =============================================================================
+
+# _validate_tone <tone> <repo-path> — returns 0 if valid, 1 if not
+_validate_tone() {
+	local tone="$1" repo_path="$2"
+	case "$tone" in
+	neutral | formal | conciliatory | firm) return 0 ;;
+	esac
+	local tones_config
+	tones_config="$(_load_tones_config "$repo_path")"
+	if [[ -n "$tones_config" ]]; then
+		local valid
+		valid="$(jq -r --arg t "$tone" '.tones | has($t)' "$tones_config" 2>/dev/null)" || valid="false"
+		[[ "$valid" == "$_TRUE" ]] && return 0
+		print_error "Unknown tone: ${tone}. Available: neutral, formal, conciliatory, firm (or custom)"
+	else
+		print_error "Unknown tone: ${tone}. Available: neutral, formal, conciliatory, firm"
+	fi
+	return 1
+}
+
+# _call_llm_route <tier> <prompt-text> <max-tokens> — echoes response + model_used (tab-sep)
+# Uses LLM_ROUTING_DRY_RUN for testing.
+_call_llm_route() {
+	local tier="$1" prompt_text="$2" max_tokens="$3"
+	local prompt_file response model_used
+
+	prompt_file="$(mktemp)"
+	printf '%s\n' "$prompt_text" >"$prompt_file"
+
+	if [[ "${LLM_ROUTING_DRY_RUN:-0}" == "1" ]]; then
+		response="[MOCK] Draft content for tier=${tier}."
+		model_used="dry-run-mock"
+	else
+		local routing_helper="${SCRIPT_DIR}/llm-routing-helper.sh"
+		response="$(bash "$routing_helper" route \
+			--tier "$tier" --task "$_TASK_DRAFT" \
+			--prompt-file "$prompt_file" --max-tokens "$max_tokens" 2>/dev/null)" || {
+			print_error "LLM routing failed. Tier: ${tier}"
+			rm -f "$prompt_file"
+			return 1
+		}
+		model_used="${tier}-default"
+	fi
+	rm -f "$prompt_file"
+	# Output on two lines: line 1=model_used, rest=response
+	printf '%s\n%s' "$model_used" "$response"
+	return 0
+}
+
+# _build_draft_body <frontmatter> <response> <provenance> — compose full markdown
+_build_draft_body() {
+	local frontmatter="$1" response="$2" provenance="$3"
+	printf '%s\n\n%s\n\n%s\n' "$frontmatter" "$response" "$provenance"
+	return 0
+}
+
+# _output_draft_json <args...> — emit JSON for draft result
+_output_draft_json() {
+	local case_id="$1" intent="$2" tone="$3" length="$4" model="$5"
+	local tier="$6" ts="$7" file_or_body="$8" sources="$9"
+	shift 9
+	local cross_cases="${1:-none}" is_dry_run="${2:-false}"
+	if [[ "$is_dry_run" == "$_TRUE" ]]; then
+		jq -n --arg cid "$case_id" --arg i "$intent" --arg t "$tone" \
+			--arg l "$length" --arg m "$model" --arg tr "$tier" \
+			--arg g "$ts" --arg b "$file_or_body" --arg s "$sources" \
+			--arg cc "$cross_cases" \
+			'{case_id:$cid, intent:$i, tone:$t, length:$l, model:$m,
+			  tier:$tr, generated_at:$g, sources_consulted:$s,
+			  cross_case_includes:$cc, body:$b, dry_run:true}'
+	else
+		jq -n --arg cid "$case_id" --arg i "$intent" --arg t "$tone" \
+			--arg l "$length" --arg m "$model" --arg tr "$tier" \
+			--arg g "$ts" --arg f "$file_or_body" --arg s "$sources" \
+			--arg cc "$cross_cases" \
+			'{case_id:$cid, intent:$i, tone:$t, length:$l, model:$m,
+			  tier:$tr, generated_at:$g, file:$f, sources_consulted:$s,
+			  cross_case_includes:$cc, dry_run:false}'
+	fi
+	return 0
+}
+
+# _merge_cross_case_sources <cases-dir> <case-dir> <intent> <include-ids...>
+# Echoes: line 1=cross_case_ids, line 2=merged sources JSON
+_merge_cross_case_sources() {
+	local cases_dir="$1" case_dir="$2" intent="$3"
+	shift 3
+	local cross_case_ids="" sources_json="$1"
+	shift
+	local include_id
+	for include_id in "$@"; do
+		[[ -z "$include_id" ]] && continue
+		local inc_dir
+		inc_dir="$(_case_find "$cases_dir" "$include_id")" || {
+			print_error "Include-case not found: ${include_id}"
+			return 1
+		}
+		local actor
+		actor="$(_current_actor)"
+		_log_cross_case_access "$case_dir" "$include_id" "$actor" "Draft intent: ${intent}"
+		_timeline_append "$case_dir" "cross-case-access" "$actor" \
+			"Cross-case access: included ${include_id} for draft" "$include_id"
+		local inc_sources_path="${inc_dir}/${CASE_SOURCES_FILE}"
+		if [[ -f "$inc_sources_path" ]]; then
+			local inc_sources
+			inc_sources="$(jq '.' "$inc_sources_path" 2>/dev/null)" || inc_sources="[]"
+			sources_json="$(echo "$sources_json" | jq --argjson inc "$inc_sources" '. + $inc')"
+		fi
+		[[ -n "$cross_case_ids" ]] && cross_case_ids="${cross_case_ids}, "
+		cross_case_ids="${cross_case_ids}${include_id}"
+	done
+	printf '%s\n%s' "$cross_case_ids" "$sources_json"
+	return 0
+}
+
+# _read_case_dossier <case-dir> — reads dossier, echoes: id\nkind\nparty_self
+_read_case_dossier() {
+	local case_dir="$1"
+	local dossier_path="${case_dir}/${CASE_DOSSIER_FILE}"
+	[[ ! -f "$dossier_path" ]] && { print_error "Dossier not found: ${dossier_path}"; return 1; }
+	local dossier
+	dossier="$(jq '.' "$dossier_path")"
+	echo "$dossier" | jq -r '.id'
+	echo "$dossier" | jq -r '.kind'
+	echo "$dossier" | jq -r '(.parties[] | select(.role == "client") | .name) // (.parties[0].name) // "the client"'
+	return 0
+}
+
+# _read_case_sources <case-dir> — echo sources JSON
+_read_case_sources() {
+	local case_dir="$1"
+	local sources_path="${case_dir}/${CASE_SOURCES_FILE}"
+	if [[ -f "$sources_path" ]]; then
+		jq '.' "$sources_path" 2>/dev/null || echo "[]"
+	else
+		echo "[]"
+	fi
+	return 0
+}
+
+# _build_frontmatter <case-id> <intent> <tone> <length> <model> <ts> <sources> <cross>
+_build_frontmatter() {
+	local _cid="$1" _int="$2" _ton="$3" _len="$4" _mod="$5" _ts="$6" _src="$7" _cc="$8"
+	printf -- '---\ncase_id: %s\nintent: "%s"\ntone: %s\nlength: %s\nmodel: %s\ngenerated_at: %s\nsources_consulted: "%s"\ncross_case_includes: "%s"\n---' \
+		"$_cid" "$_int" "$_ton" "$_len" "$_mod" "$_ts" "$_src" "$_cc"
+	return 0
+}
+
+# =============================================================================
+# cmd_draft — generate a strategic communication draft
+# =============================================================================
+
+cmd_draft() {
+	_require_jq || return 1
+	local case_id="" intent="" tone="neutral" length="medium" cite="strict"
+	local repo_path="" dry_run=false json_mode=false max_tokens_override=""
+	local -a include_cases=()
+	while [[ $# -gt 0 ]]; do
+		local _cur="${1:-}" _nxt="${2:-}"
+		case "$_cur" in
+		--intent) intent="$_nxt"; shift 2 ;; --tone) tone="$_nxt"; shift 2 ;;
+		--length) length="$_nxt"; shift 2 ;; --cite) cite="$_nxt"; shift 2 ;;
+		--include-case) include_cases+=("$_nxt"); shift 2 ;;
+		--dry-run) dry_run=true; shift ;; --repo) repo_path="$_nxt"; shift 2 ;;
+		--max-tokens) max_tokens_override="$_nxt"; shift 2 ;;
+		--json) json_mode=true; shift ;; -*) print_error "Unknown option: $_cur"; return 1 ;;
+		*) case_id="$_cur"; shift ;; esac
+	done
+	[[ -z "$case_id" ]] && { _err_missing_arg "case-id"; return 1; }
+	[[ -z "$intent" ]] && { _err_missing_arg "--intent"; return 1; }
+	[[ -z "$repo_path" ]] && repo_path="$(pwd)"
+	_validate_tone "$tone" "$repo_path" || return 1
+	case "$length" in short|medium|long) ;; *) print_error "Unknown length: ${length}"; return 1;; esac
+
+	local cases_dir case_dir
+	cases_dir="$(_resolve_cases_dir "$repo_path")"
+	case_dir="$(_case_find "$cases_dir" "$case_id")" || { _err_case_not_found "$case_id"; return 1; }
+
+	local dossier_info full_case_id kind party_self
+	dossier_info="$(_read_case_dossier "$case_dir")" || return 1
+	full_case_id="$(echo "$dossier_info" | sed -n '1p')"
+	kind="$(echo "$dossier_info" | sed -n '2p')"
+	party_self="$(echo "$dossier_info" | sed -n '3p')"
+
+	local sources_json cross_case_ids=""
+	sources_json="$(_read_case_sources "$case_dir")"
+	if [[ ${#include_cases[@]} -gt 0 ]]; then
+		local merged
+		merged="$(_merge_cross_case_sources "$cases_dir" "$case_dir" "$intent" \
+			"$sources_json" "${include_cases[@]}")" || return 1
+		cross_case_ids="$(echo "$merged" | head -1)"
+		sources_json="$(echo "$merged" | tail -n +2)"
+	fi
+
+	local tier source_ids excerpts timeline_text tones_config tone_fragment length_guidance
+	tier="$(_max_tier "$sources_json" "$repo_path")"
+	source_ids="$(echo "$sources_json" | jq -r '.[].id' 2>/dev/null)" || source_ids=""
+	excerpts="$(_collect_excerpts "$source_ids" "$repo_path" 8)"
+	timeline_text="$(_read_timeline_recent "$case_dir" 5)"
+	tones_config="$(_load_tones_config "$repo_path")"
+	tone_fragment="$(_get_tone_fragment "$tones_config" "$tone")"
+	length_guidance="$(_length_to_word_range "$length")"
+
+	local prompt max_tokens
+	prompt="$(_compose_prompt "$full_case_id" "$intent" "$tone_fragment" \
+		"$length_guidance" "$kind" "$party_self" "$timeline_text" "$excerpts" "$cite")"
+	max_tokens="${max_tokens_override:-$(_length_to_tokens "$length")}"
+	log_info "Routing draft via tier: ${tier}, tone: ${tone}, length: ${length}"
+
+	local llm_result response model_used
+	llm_result="$(_call_llm_route "$tier" "$prompt" "$max_tokens")" || return 1
+	model_used="$(echo "$llm_result" | head -1)"
+	response="$(echo "$llm_result" | tail -n +2)"
+
+	local timestamp provenance intent_slug ts_filename source_list cross_list frontmatter full_draft
+	timestamp="$(_iso_ts)"
+	provenance="$(_build_provenance_footer "$sources_json" "$repo_path" "$model_used" "$timestamp" "$cross_case_ids")"
+	intent_slug="$(_slugify "$intent")"
+	ts_filename="$(_iso_ts_filename)"
+	source_list="$(echo "$sources_json" | jq -r '[.[].id] | join(", ")' 2>/dev/null)" || source_list=""
+	cross_list="${cross_case_ids:-none}"
+	frontmatter="$(_build_frontmatter "$full_case_id" "$intent" "$tone" "$length" "$model_used" "$timestamp" "$source_list" "$cross_list")"
+	full_draft="$(_build_draft_body "$frontmatter" "$response" "$provenance")"
+
+	if [[ "$dry_run" == true ]]; then
+		if [[ "$json_mode" == true ]]; then
+			_output_draft_json "$full_case_id" "$intent" "$tone" "$length" "$model_used" "$tier" "$timestamp" "$full_draft" "$source_list" "$cross_list" "$_TRUE"
+		else printf '%s\n' "$full_draft"; fi
+		return 0
+	fi
+	local drafts_dir="${case_dir}/${CASE_DRAFTS_DIR}"
+	mkdir -p "$drafts_dir"
+	local draft_file="${drafts_dir}/${ts_filename}-${intent_slug}.md"
+	printf '%s\n' "$full_draft" >"$draft_file"
+	local actor; actor="$(_current_actor)"
+	_timeline_append "$case_dir" "$_TASK_DRAFT" "$actor" \
+		"Draft generated: ${intent} (tone: ${tone}, tier: ${tier})" "${CASE_DRAFTS_DIR}/${ts_filename}-${intent_slug}.md"
+	if [[ "$json_mode" == true ]]; then
+		_output_draft_json "$full_case_id" "$intent" "$tone" "$length" "$model_used" "$tier" "$timestamp" "$draft_file" "$source_list" "$cross_list" "false"
+	else
+		print_success "Draft generated: ${draft_file}"
+		echo "  Case: ${full_case_id}  Intent: ${intent}  Tone: ${tone}  Tier: ${tier}"
+	fi
+	return 0
+}
+
+# =============================================================================
+# cmd_revise — revise an existing draft with feedback
+# =============================================================================
+
+cmd_revise() {
+	_require_jq || return 1
+	local draft_file="" feedback="" repo_path="" dry_run=false json_mode=false max_tokens_override=""
+	while [[ $# -gt 0 ]]; do
+		local _cur="${1:-}" _nxt="${2:-}"
+		case "$_cur" in
+		--revise) draft_file="$_nxt"; shift 2 ;; --feedback) feedback="$_nxt"; shift 2 ;;
+		--repo) repo_path="$_nxt"; shift 2 ;; --dry-run) dry_run=true; shift ;;
+		--max-tokens) max_tokens_override="$_nxt"; shift 2 ;; --json) json_mode=true; shift ;;
+		-*) print_error "Unknown option: $_cur"; return 1 ;;
+		*) [[ -z "$draft_file" ]] && draft_file="$_cur" || true; shift ;; esac
+	done
+	[[ -z "$draft_file" ]] && { _err_missing_arg "--revise <file>"; return 1; }
+	[[ -z "$feedback" ]] && { _err_missing_arg "--feedback"; return 1; }
+	[[ -z "$repo_path" ]] && repo_path="$(pwd)"
+	[[ ! -f "$draft_file" ]] && { print_error "Draft file not found: ${draft_file}"; return 1; }
+
+	# Extract metadata from frontmatter
+	local existing_draft case_id intent tone length
+	existing_draft="$(cat "$draft_file")"
+	case_id="$(echo "$existing_draft" | sed -n 's/^case_id: //p' | head -1)" || case_id=""
+	intent="$(echo "$existing_draft" | sed -n 's/^intent: //p' | head -1 | tr -d '"')" || intent=""
+	tone="$(echo "$existing_draft" | sed -n 's/^tone: //p' | head -1)" || tone="neutral"
+	length="$(echo "$existing_draft" | sed -n 's/^length: //p' | head -1)" || length="medium"
+	[[ -z "$case_id" ]] && { print_error "Cannot extract case_id from draft frontmatter"; return 1; }
+
+	local cases_dir case_dir
+	cases_dir="$(_resolve_cases_dir "$repo_path")"
+	case_dir="$(_case_find "$cases_dir" "$case_id")" || { _err_case_not_found "$case_id"; return 1; }
+	local sources_json
+	sources_json="$(_read_case_sources "$case_dir")"
+	local tier; tier="$(_max_tier "$sources_json" "$repo_path")"
+
+	local draft_body
+	draft_body="$(echo "$existing_draft" | sed -n '/^---$/,/^---$/!p')"
+	draft_body="$(echo "$draft_body" | sed '/./,$!d')"
+
+	local revision_prompt="Revise this draft per the following feedback.
+
+Feedback: ${feedback}
+
+Original draft:
+${draft_body}
+
+Preserve citation anchors [source-id]. Apply feedback maintaining factual accuracy. Output revised draft text only."
+
+	local max_tokens="${max_tokens_override:-$(_length_to_tokens "$length")}"
+	local llm_result response model_used
+	llm_result="$(_call_llm_route "$tier" "$revision_prompt" "$max_tokens")" || return 1
+	model_used="$(echo "$llm_result" | head -1)"; response="$(echo "$llm_result" | tail -n +2)"
+
+	local timestamp provenance intent_slug ts_filename source_list
+	timestamp="$(_iso_ts)"; intent_slug="$(_slugify "$intent")"; ts_filename="$(_iso_ts_filename)"
+	provenance="$(_build_provenance_footer "$sources_json" "$repo_path" "$model_used" "$timestamp" "")"
+	local rev_count=2 existing_revs
+	existing_revs="$(find "$(dirname "$draft_file")" -name "*-${intent_slug}-rev*" 2>/dev/null | wc -l | tr -d ' ')" || existing_revs=0
+	rev_count=$((existing_revs + 2))
+	source_list="$(echo "$sources_json" | jq -r '[.[].id] | join(", ")' 2>/dev/null)" || source_list=""
+	local draft_basename; draft_basename="$(basename "$draft_file")"
+	local frontmatter
+	frontmatter="---
+case_id: ${case_id}
+intent: \"${intent}\"
+tone: ${tone}
+length: ${length}
+model: ${model_used}
+generated_at: ${timestamp}
+sources_consulted: \"${source_list}\"
+cross_case_includes: \"none\"
+revision: ${rev_count}
+revision_of: \"${draft_basename}\"
+feedback: \"${feedback}\"
+---"
+	local full_revision; full_revision="$(_build_draft_body "$frontmatter" "$response" "$provenance")"
+
+	if [[ "$dry_run" == true ]]; then
+		if [[ "$json_mode" == true ]]; then
+			jq -n --arg cid "$case_id" --arg fb "$feedback" --arg rev "$rev_count" --arg body "$full_revision" \
+				'{case_id:$cid, feedback:$fb, revision:($rev|tonumber), body:$body, dry_run:true}'
+		else printf '%s\n' "$full_revision"; fi
+		return 0
+	fi
+	local rev_file; rev_file="$(dirname "$draft_file")/${ts_filename}-${intent_slug}-rev${rev_count}.md"
+	printf '%s\n' "$full_revision" >"$rev_file"
+	local actor; actor="$(_current_actor)"
+	_timeline_append "$case_dir" "draft-revision" "$actor" \
+		"Draft revised (rev${rev_count}): ${intent}. Feedback: ${feedback}" "${CASE_DRAFTS_DIR}/$(basename "$rev_file")"
+	if [[ "$json_mode" == true ]]; then
+		jq -n --arg cid "$case_id" --arg fb "$feedback" --arg rev "$rev_count" --arg f "$rev_file" --arg orig "$draft_basename" \
+			'{case_id:$cid, feedback:$fb, revision:($rev|tonumber), file:$f, original:$orig, dry_run:false}'
+	else
+		print_success "Revision generated: ${rev_file}"
+		echo "  Case: ${case_id}  Revision: rev${rev_count}  Original: ${draft_basename}"
+	fi
+	return 0
+}
+
+# =============================================================================
+# cmd_help
+# =============================================================================
+
+cmd_help() {
+	cat <<'HELP'
+Case Draft Helper — AI-assisted strategic communication drafting with RAG
+
+Usage:
+  case-draft-helper.sh draft <case-id> --intent "..." [options]
+  case-draft-helper.sh revise --revise <file> --feedback "..." [options]
+  case-draft-helper.sh help
+
+Draft options:
+  --intent <text>         Intent / purpose of the draft (REQUIRED)
+  --tone <preset>         neutral | formal | conciliatory | firm (default: neutral)
+  --length <size>         short | medium | long (default: medium)
+  --cite <mode>           strict | loose (default: strict)
+  --include-case <id>     Include another case's sources (audited, repeatable)
+  --dry-run               Print draft to stdout, don't write file
+  --repo <path>           Target repo path (default: cwd)
+  --max-tokens <N>        Override max tokens for LLM call
+  --json                  Machine-readable JSON output
+
+Revise options:
+  --revise <file>         Path to existing draft to revise
+  --feedback <text>       Revision instructions (REQUIRED)
+  --dry-run               Print revision to stdout, don't write file
+
+Drafts are ALWAYS human-gated — they write to _cases/<id>/drafts/ and never
+auto-send. Review every draft before use.
+
+Sensitivity routing:
+  - Sources with sensitivity=restricted → privileged tier (local LLM only)
+  - Sources with sensitivity=confidential → sensitive tier (local LLM only)
+  - The highest sensitivity among all attached sources determines the tier
+
+Cross-case access:
+  - Default: only own case's sources
+  - --include-case <id>: audited in comms/cross-case-access.jsonl
+
+Examples:
+  case-draft-helper.sh draft case-2026-0001-acme --intent "request payment"
+  case-draft-helper.sh draft case-2026-0001-acme --intent "settlement offer" \
+      --tone formal --length long --cite strict
+  case-draft-helper.sh draft case-2026-0001-acme --intent "status update" \
+      --include-case case-2026-0002-related --dry-run
+  case-draft-helper.sh revise --revise _cases/.../drafts/20260427-draft.md \
+      --feedback "soften the language around paragraph 3"
+HELP
+	return 0
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+
+main() {
+	local command="${1:-help}"
+	shift || true
+
+	case "$command" in
+	draft) cmd_draft "$@" ;;
+	revise) cmd_revise "$@" ;;
+	help | --help | -h) cmd_help ;;
+	*)
+		print_error "Unknown command: ${command}"
+		cmd_help
+		return 1
+		;;
+	esac
+}
+
+main "$@"

--- a/.agents/scripts/case-helper.sh
+++ b/.agents/scripts/case-helper.sh
@@ -1307,6 +1307,8 @@ Commands:
   deadline add|remove <case-id>         Manage deadlines
   party add|remove <case-id>            Manage parties
   comm log <case-id>                    Log a communication entry
+  draft <case-id> --intent "..."        Generate a draft (via case-draft-helper)
+  revise --revise <file> --feedback ".." Revise an existing draft
   help                                  Show this help
 
 Open options:
@@ -1369,6 +1371,8 @@ main() {
 	deadline | dl) cmd_deadline "$@" ;;
 	party) cmd_party "$@" ;;
 	comm | comms) cmd_comm "$@" ;;
+	draft) bash "${SCRIPT_DIR}/case-draft-helper.sh" draft "$@" ;;
+	revise) bash "${SCRIPT_DIR}/case-draft-helper.sh" revise "$@" ;;
 	help | --help | -h) cmd_help ;;
 	*)
 		print_error "Unknown command: ${command}"

--- a/.agents/scripts/knowledge-index-helper.sh
+++ b/.agents/scripts/knowledge-index-helper.sh
@@ -67,6 +67,11 @@ _KI_FALSE="false"
 _KI_TRUE="true"
 _KI_INTERNAL="internal"
 
+# Case-scope constants (t2857 extension)
+_CASES_DIR_NAME="_cases"
+_CASE_SOURCES_FILE="sources.toon"
+_META_FILE="meta.json"
+
 # ---------------------------------------------------------------------------
 # Internal: requirement checks
 # ---------------------------------------------------------------------------
@@ -404,13 +409,72 @@ cmd_build() {
 }
 
 # ---------------------------------------------------------------------------
+# Case-scope helpers (t2857 — case-draft integration)
+# ---------------------------------------------------------------------------
+
+# _case_find_dir <repo-path> <case-id> — find a case directory by ID or slug
+_case_find_dir() {
+	local repo_path="$1" query="$2"
+	local cases_dir="${repo_path}/${_CASES_DIR_NAME}"
+
+	if [[ -d "${cases_dir}/${query}" ]]; then
+		echo "${cases_dir}/${query}"
+		return 0
+	fi
+	local dir
+	for dir in "${cases_dir}"/case-*-"${query}" "${cases_dir}"/case-*-*"${query}"*; do
+		[[ -d "$dir" ]] || continue
+		[[ "$dir" == *"/archived/"* ]] && continue
+		echo "$dir"
+		return 0
+	done
+	return 1
+}
+
+# _get_case_source_ids <repo-path> <case-id> — list source IDs attached to a case
+_get_case_source_ids() {
+	local repo_path="$1" case_id="$2"
+	local case_dir
+	case_dir="$(_case_find_dir "$repo_path" "$case_id")" || {
+		print_error "Case not found for scope filter: ${case_id}"
+		return 1
+	}
+	local sources_file="${case_dir}/${_CASE_SOURCES_FILE}"
+	if [[ -f "$sources_file" ]] && command -v jq >/dev/null 2>&1; then
+		jq -r '.[].id' "$sources_file" 2>/dev/null || true
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
 # cmd_query: walk corpus tree and return ranked matches
 # ---------------------------------------------------------------------------
 
 cmd_query() {
-	local intent="$1"
+	# Supports two calling conventions:
+	#   1. Positional: cmd_query "intent string" [knowledge-root]
+	#   2. Flagged:    cmd_query --intent "..." [--scope case=<id>] [--repo <path>]
+	local intent="" knowledge_root_arg="" scope="" repo_path=""
+
+	# Detect flag-based invocation vs positional
+	if [[ "${1:-}" == --* ]]; then
+		while [[ $# -gt 0 ]]; do
+			case "$1" in
+			--intent) intent="$2"; shift 2 ;;
+			--scope) scope="$2"; shift 2 ;;
+			--repo) repo_path="$2"; shift 2 ;;
+			--limit | --max-chars | --json) shift 2 ;; # accepted but ignored by tree-walk
+			*) shift ;;
+			esac
+		done
+	else
+		intent="${1:-}"
+		knowledge_root_arg="${2:-}"
+	fi
+
+	[[ -z "$repo_path" ]] && repo_path="$(pwd)"
 	local knowledge_root
-	knowledge_root=$(_resolve_root "${2:-}")
+	knowledge_root=$(_resolve_root "${knowledge_root_arg:-}")
 	local index_dir
 	index_dir=$(_index_dir "$knowledge_root")
 	local corpus_tree="${index_dir}/tree.json"
@@ -420,6 +484,49 @@ cmd_query() {
 		return 1
 	fi
 
+	# Case-scope filter: if --scope case=<id>, restrict to that case's sources
+	if [[ "$scope" == case=* ]]; then
+		local scope_case_id="${scope#case=}"
+		local allowed_ids
+		allowed_ids="$(_get_case_source_ids "$repo_path" "$scope_case_id")" || return 1
+
+		if [[ -z "$allowed_ids" ]]; then
+			echo "No sources attached to case: ${scope_case_id}"
+			return 0
+		fi
+
+		# If corpus tree exists, filter query through it
+		if [[ -f "$corpus_tree" ]]; then
+			_require_python3 || return 1
+			# Pass allowed IDs as env var for the Python helper to filter
+			KNOWLEDGE_SCOPE_IDS="$allowed_ids" python3 "$_QUERY_HELPER" query "$corpus_tree" "$intent"
+			return 0
+		fi
+
+		# Fallback: direct source reading when no tree exists
+		local sources_dir
+		sources_dir="$(_sources_dir "$knowledge_root")"
+		local sid
+		while IFS= read -r sid; do
+			[[ -z "$sid" ]] && continue
+			local src_dir="${sources_dir}/${sid}"
+			[[ ! -d "$src_dir" ]] && continue
+			local content_file=""
+			local f
+			for f in "${src_dir}"/content.txt "${src_dir}"/text.txt "${src_dir}"/*.txt "${src_dir}"/*.md; do
+				if [[ -f "$f" ]]; then
+					content_file="$f"
+					break
+				fi
+			done
+			if [[ -n "$content_file" ]]; then
+				printf '[%s]: "%s"\n\n' "$sid" "$(head -c 2000 "$content_file" 2>/dev/null)"
+			fi
+		done <<<"$allowed_ids"
+		return 0
+	fi
+
+	# Standard (non-scoped) query
 	if [[ ! -f "$corpus_tree" ]]; then
 		print_warning "query: corpus tree not found at ${corpus_tree} — run 'build' first"
 		return 1

--- a/.agents/templates/case-draft-prompt.md
+++ b/.agents/templates/case-draft-prompt.md
@@ -1,0 +1,21 @@
+You are drafting a {kind} communication for case {case-id} on behalf of {party-self}.
+
+Tone: {tone}
+
+The intent is: {intent}.
+
+Recent case timeline:
+{timeline}
+
+Available evidence:
+{excerpts}
+
+Produce a draft that:
+- {cite-instruction}
+- Maintains the specified tone throughout; avoids speculation beyond the evidence
+- Length: {length}
+- Uses clear, professional language
+- Structures the communication logically (opening, body, closing)
+- References specific dates, amounts, or facts from the evidence where relevant
+
+At the end, list "Drafted with reference to:" with each consulted source ID.

--- a/.agents/templates/draft-tones-config.json
+++ b/.agents/templates/draft-tones-config.json
@@ -1,0 +1,26 @@
+{
+  "version": 1,
+  "description": "Tone presets for case-draft-helper.sh. Copy to _config/draft-tones.json to customise per repo.",
+  "tones": {
+    "neutral": {
+      "label": "Neutral",
+      "system_fragment": "Maintain a balanced, objective tone. Present facts without emotional colouring. Use measured language.",
+      "use_when": "Default for most communications. Status updates, information requests, neutral correspondence."
+    },
+    "formal": {
+      "label": "Formal",
+      "system_fragment": "Use formal, professional language appropriate for official correspondence. Address the recipient with proper titles. Use structured paragraphs with clear topic sentences. Avoid contractions and colloquialisms.",
+      "use_when": "Official letters, regulatory correspondence, formal notices, court filings."
+    },
+    "conciliatory": {
+      "label": "Conciliatory",
+      "system_fragment": "Adopt a cooperative, solution-oriented tone that seeks common ground. Acknowledge the other party's perspective where appropriate. Frame proposals as mutual benefits. Avoid accusatory language.",
+      "use_when": "Settlement discussions, mediation preparation, de-escalation, relationship repair."
+    },
+    "firm": {
+      "label": "Firm",
+      "system_fragment": "Be direct, assertive, and clear about positions and expectations. State deadlines and consequences plainly. Use active voice. Do not soften obligations or requirements.",
+      "use_when": "Demand letters, enforcement notices, final warnings, deadline communications."
+    }
+  }
+}

--- a/.agents/tests/test-case-draft.sh
+++ b/.agents/tests/test-case-draft.sh
@@ -1,0 +1,532 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# shellcheck disable=SC2034
+#
+# Tests for case-draft-helper.sh (t2857)
+# Covers: happy path (mocked LLM), tier escalation, cross-case access audit,
+# provenance footer, revise mode, dry-run, and no-auto-send enforcement.
+#
+# Usage: bash .agents/tests/test-case-draft.sh
+# Requires: jq
+#
+# All tests use LLM_ROUTING_DRY_RUN=1 so no real LLM calls are made.
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+DRAFT_HELPER="${SCRIPT_DIR}/../scripts/case-draft-helper.sh"
+CASE_HELPER="${SCRIPT_DIR}/../scripts/case-helper.sh"
+
+# =============================================================================
+# Test framework
+# =============================================================================
+
+TESTS_PASSED=0
+TESTS_FAILED=0
+TEST_TMPDIR=""
+
+_setup() {
+	TEST_TMPDIR="$(mktemp -d)"
+	# Initialize a minimal git repo
+	git -C "$TEST_TMPDIR" init -q 2>/dev/null || true
+	git -C "$TEST_TMPDIR" config user.email "test@test.local" 2>/dev/null || true
+	git -C "$TEST_TMPDIR" config user.name "Test User" 2>/dev/null || true
+
+	# Provision cases plane
+	bash "$CASE_HELPER" init "$TEST_TMPDIR" >/dev/null 2>&1
+
+	# Provision knowledge plane (minimal)
+	mkdir -p "${TEST_TMPDIR}/_knowledge/sources"
+
+	# Create a test source with metadata
+	local src_dir="${TEST_TMPDIR}/_knowledge/sources/src-invoice-001"
+	mkdir -p "$src_dir"
+	printf '{"version":1,"id":"src-invoice-001","kind":"document","source_uri":"local","sha256":"abc123def456","ingested_at":"2026-04-01T00:00:00Z","ingested_by":"test","sensitivity":"internal","trust":"reviewed","blob_path":null,"size_bytes":1234}\n' \
+		>"${src_dir}/meta.json"
+	printf 'Invoice #1234 from ACME Ltd dated 2026-03-15. Amount: 5000.00. Due: 2026-04-15. Status: OVERDUE.\nServices rendered: consulting on project Alpha.\n' \
+		>"${src_dir}/content.txt"
+
+	# Create a second source (privileged sensitivity)
+	local src_dir2="${TEST_TMPDIR}/_knowledge/sources/src-contract-002"
+	mkdir -p "$src_dir2"
+	printf '{"version":1,"id":"src-contract-002","kind":"document","source_uri":"local","sha256":"789xyz000111","ingested_at":"2026-04-02T00:00:00Z","ingested_by":"test","sensitivity":"restricted","trust":"trusted","blob_path":null,"size_bytes":5678}\n' \
+		>"${src_dir2}/meta.json"
+	printf 'Service Agreement between Us and ACME Ltd. Clause 4.2: Payment due within 30 days of invoice. Clause 7: Dispute resolution via arbitration.\n' \
+		>"${src_dir2}/content.txt"
+
+	# Create a third source (public)
+	local src_dir3="${TEST_TMPDIR}/_knowledge/sources/src-public-003"
+	mkdir -p "$src_dir3"
+	printf '{"version":1,"id":"src-public-003","kind":"reference","source_uri":"local","sha256":"000aaa111bbb","ingested_at":"2026-04-03T00:00:00Z","ingested_by":"test","sensitivity":"public","trust":"unverified","blob_path":null,"size_bytes":100}\n' \
+		>"${src_dir3}/meta.json"
+	printf 'Public reference material about standard payment terms.\n' \
+		>"${src_dir3}/content.txt"
+
+	# Open a test case
+	bash "$CASE_HELPER" open acme-dispute --kind dispute --party "ACME Ltd" \
+		--repo "$TEST_TMPDIR" >/dev/null 2>&1
+
+	# Find the case directory (use glob, not ls|grep per SC2010)
+	local _d
+	TEST_CASE_ID=""
+	for _d in "${TEST_TMPDIR}/_cases"/case-*; do
+		[[ -d "$_d" ]] || continue
+		TEST_CASE_ID="$(basename "$_d")"
+		break
+	done
+	TEST_CASE_DIR="${TEST_TMPDIR}/_cases/${TEST_CASE_ID}"
+
+	# Attach sources to the case
+	bash "$CASE_HELPER" attach "$TEST_CASE_ID" src-invoice-001 --role evidence \
+		--repo "$TEST_TMPDIR" >/dev/null 2>&1
+	bash "$CASE_HELPER" attach "$TEST_CASE_ID" src-contract-002 --role reference \
+		--repo "$TEST_TMPDIR" >/dev/null 2>&1
+
+	# Open a second case for cross-case testing
+	bash "$CASE_HELPER" open related-matter --kind compliance \
+		--repo "$TEST_TMPDIR" >/dev/null 2>&1
+	TEST_CASE2_ID=""
+	for _d in "${TEST_TMPDIR}/_cases"/case-*-related*; do
+		[[ -d "$_d" ]] || continue
+		TEST_CASE2_ID="$(basename "$_d")"
+		break
+	done
+	bash "$CASE_HELPER" attach "$TEST_CASE2_ID" src-public-003 --role background \
+		--repo "$TEST_TMPDIR" >/dev/null 2>&1
+
+	export LLM_ROUTING_DRY_RUN=1
+	return 0
+}
+
+_teardown() {
+	[[ -n "$TEST_TMPDIR" && -d "$TEST_TMPDIR" ]] && rm -rf "$TEST_TMPDIR"
+	unset LLM_ROUTING_DRY_RUN
+	return 0
+}
+
+_pass() {
+	local name="$1"
+	TESTS_PASSED=$((TESTS_PASSED + 1))
+	printf '  [PASS] %s\n' "$name"
+	return 0
+}
+
+_fail() {
+	local name="$1" reason="${2:-}"
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '  [FAIL] %s%s\n' "$name" "${reason:+ — $reason}"
+	return 0
+}
+
+_assert_exit_0() {
+	local name="$1"
+	shift
+	if "$@" >/dev/null 2>&1; then
+		_pass "$name"
+		return 0
+	else
+		_fail "$name" "expected exit 0, got non-zero"
+		return 0
+	fi
+}
+
+_assert_exit_nonzero() {
+	local name="$1"
+	shift
+	if ! "$@" >/dev/null 2>&1; then
+		_pass "$name"
+		return 0
+	else
+		_fail "$name" "expected non-zero exit, got 0"
+		return 0
+	fi
+}
+
+_assert_file_exists() {
+	local name="$1" path="$2"
+	if [[ -f "$path" ]]; then
+		_pass "$name"
+		return 0
+	else
+		_fail "$name" "file not found: ${path}"
+		return 0
+	fi
+}
+
+_assert_file_contains() {
+	local name="$1" path="$2" pattern="$3"
+	if grep -q "$pattern" "$path" 2>/dev/null; then
+		_pass "$name"
+		return 0
+	else
+		_fail "$name" "pattern not found: ${pattern}"
+		return 0
+	fi
+}
+
+_assert_output_contains() {
+	local name="$1" output="$2" pattern="$3"
+	if echo "$output" | grep -q "$pattern" 2>/dev/null; then
+		_pass "$name"
+		return 0
+	else
+		_fail "$name" "pattern not found in output: ${pattern}"
+		return 0
+	fi
+}
+
+_assert_dir_empty() {
+	local name="$1" dir_path="$2"
+	if [[ -d "$dir_path" ]]; then
+		local count
+		count="$(find "$dir_path" -maxdepth 1 -type f 2>/dev/null | wc -l | tr -d ' ')"
+		if [[ "$count" -eq 0 ]]; then
+			_pass "$name"
+		else
+			_fail "$name" "directory not empty: ${count} files"
+		fi
+	else
+		_pass "$name" # dir doesn't exist = effectively empty
+	fi
+	return 0
+}
+
+# =============================================================================
+# Test cases
+# =============================================================================
+
+test_draft_happy_path() {
+	echo "## Draft: happy path"
+
+	local output
+	output="$(bash "$DRAFT_HELPER" draft "$TEST_CASE_ID" \
+		--intent "request payment of overdue invoice" \
+		--repo "$TEST_TMPDIR" 2>&1)" || true
+
+	_assert_output_contains "draft succeeds" "$output" "Draft generated"
+
+	# Check draft file was created
+	local draft_files
+	draft_files="$(find "${TEST_CASE_DIR}/drafts" -name "*.md" -type f 2>/dev/null | wc -l | tr -d ' ')"
+	if [[ "$draft_files" -gt 0 ]]; then
+		_pass "draft file created"
+	else
+		_fail "draft file created" "no .md files in drafts/"
+	fi
+
+	# Check draft content
+	local draft_file
+	draft_file="$(find "${TEST_CASE_DIR}/drafts" -name "*.md" -type f 2>/dev/null | head -1)"
+	if [[ -n "$draft_file" ]]; then
+		_assert_file_contains "frontmatter has case_id" "$draft_file" "case_id:"
+		_assert_file_contains "frontmatter has intent" "$draft_file" "intent:"
+		_assert_file_contains "frontmatter has tone" "$draft_file" "tone:"
+		_assert_file_contains "frontmatter has sources" "$draft_file" "sources_consulted:"
+		_assert_file_contains "frontmatter has generated_at" "$draft_file" "generated_at:"
+		_assert_file_contains "provenance footer present" "$draft_file" "Drafted with reference to:"
+		_assert_file_contains "provenance has source kind" "$draft_file" "kind:"
+		_assert_file_contains "provenance has sensitivity" "$draft_file" "sensitivity:"
+		_assert_file_contains "provenance has sha" "$draft_file" "sha:"
+	fi
+	return 0
+}
+
+test_draft_tier_escalation() {
+	echo "## Draft: tier escalation with privileged source"
+
+	# src-contract-002 has sensitivity=restricted which maps to privileged tier
+	local output
+	output="$(bash "$DRAFT_HELPER" draft "$TEST_CASE_ID" \
+		--intent "review contract terms" \
+		--repo "$TEST_TMPDIR" --json 2>/dev/null)" || true
+
+	# Check tier is escalated to privileged
+	local tier
+	tier="$(echo "$output" | jq -r '.tier // empty' 2>/dev/null)" || tier=""
+	if [[ "$tier" == "privileged" ]]; then
+		_pass "tier escalated to privileged"
+	else
+		_fail "tier escalated to privileged" "got tier: ${tier}"
+	fi
+	return 0
+}
+
+test_draft_cross_case_access() {
+	echo "## Draft: cross-case access"
+
+	# Draft with --include-case should succeed
+	local output
+	output="$(bash "$DRAFT_HELPER" draft "$TEST_CASE_ID" \
+		--intent "comprehensive review" \
+		--include-case "$TEST_CASE2_ID" \
+		--repo "$TEST_TMPDIR" --json 2>/dev/null)" || true
+
+	# Check cross-case audit log was created
+	local access_log="${TEST_CASE_DIR}/comms/cross-case-access.jsonl"
+	_assert_file_exists "cross-case access log created" "$access_log"
+	if [[ -f "$access_log" ]]; then
+		_assert_file_contains "access log has included case" "$access_log" "$TEST_CASE2_ID"
+	fi
+
+	# Check cross_case_includes in output
+	local cross
+	cross="$(echo "$output" | jq -r '.cross_case_includes // empty' 2>/dev/null)" || cross=""
+	if [[ "$cross" == *"$TEST_CASE2_ID"* ]]; then
+		_pass "cross_case_includes in output"
+	else
+		_fail "cross_case_includes in output" "got: ${cross}"
+	fi
+	return 0
+}
+
+test_draft_no_cross_case_without_flag() {
+	echo "## Draft: no cross-case without --include-case flag"
+
+	# Draft without --include-case should only use own sources
+	local output
+	output="$(bash "$DRAFT_HELPER" draft "$TEST_CASE_ID" \
+		--intent "check own sources only" \
+		--repo "$TEST_TMPDIR" --json 2>&1)" || true
+
+	local sources
+	sources="$(echo "$output" | jq -r '.sources_consulted // ""' 2>/dev/null)" || sources=""
+
+	# Should NOT contain src-public-003 (belongs to case 2 only)
+	if echo "$sources" | grep -q "src-public-003" 2>/dev/null; then
+		_fail "own sources only (no cross-case)" "found src-public-003 without --include-case"
+	else
+		_pass "own sources only (no cross-case)"
+	fi
+	return 0
+}
+
+test_draft_tone_formal() {
+	echo "## Draft: --tone formal"
+
+	local output
+	output="$(bash "$DRAFT_HELPER" draft "$TEST_CASE_ID" \
+		--intent "formal notice" --tone formal \
+		--repo "$TEST_TMPDIR" --json 2>/dev/null)" || true
+
+	local tone
+	tone="$(echo "$output" | jq -r '.tone // empty' 2>/dev/null)" || tone=""
+	if [[ "$tone" == "formal" ]]; then
+		_pass "tone=formal in output"
+	else
+		_fail "tone=formal in output" "got: ${tone}"
+	fi
+	return 0
+}
+
+test_draft_tone_conciliatory() {
+	echo "## Draft: --tone conciliatory"
+
+	local output
+	output="$(bash "$DRAFT_HELPER" draft "$TEST_CASE_ID" \
+		--intent "settlement discussion" --tone conciliatory \
+		--repo "$TEST_TMPDIR" --json 2>/dev/null)" || true
+
+	local tone
+	tone="$(echo "$output" | jq -r '.tone // empty' 2>/dev/null)" || tone=""
+	if [[ "$tone" == "conciliatory" ]]; then
+		_pass "tone=conciliatory in output"
+	else
+		_fail "tone=conciliatory in output" "got: ${tone}"
+	fi
+	return 0
+}
+
+test_draft_dry_run() {
+	echo "## Draft: --dry-run"
+
+	# Count drafts before
+	local before_count
+	before_count="$(find "${TEST_CASE_DIR}/drafts" -name "*.md" -type f 2>/dev/null | wc -l | tr -d ' ')" || before_count=0
+
+	local output
+	output="$(bash "$DRAFT_HELPER" draft "$TEST_CASE_ID" \
+		--intent "dry run test" --dry-run \
+		--repo "$TEST_TMPDIR" 2>&1)" || true
+
+	# Count drafts after — should be same (dry-run doesn't write)
+	local after_count
+	after_count="$(find "${TEST_CASE_DIR}/drafts" -name "*dry-run*" -type f 2>/dev/null | wc -l | tr -d ' ')" || after_count=0
+
+	if [[ "$after_count" -eq 0 ]]; then
+		_pass "dry-run does not write file"
+	else
+		_fail "dry-run does not write file" "found ${after_count} dry-run files"
+	fi
+
+	# Output should still contain draft content
+	_assert_output_contains "dry-run prints to stdout" "$output" "case_id:"
+	return 0
+}
+
+test_draft_provenance_always_present() {
+	echo "## Draft: provenance footer always present"
+
+	local output
+	output="$(bash "$DRAFT_HELPER" draft "$TEST_CASE_ID" \
+		--intent "provenance test" \
+		--repo "$TEST_TMPDIR" 2>&1)" || true
+
+	local draft_file
+	draft_file="$(find "${TEST_CASE_DIR}/drafts" -name "*provenance*" -type f 2>/dev/null | head -1)"
+	if [[ -n "$draft_file" ]]; then
+		_assert_file_contains "provenance: Drafted with reference to" "$draft_file" "Drafted with reference to"
+		_assert_file_contains "provenance: Generated by" "$draft_file" "Generated by"
+		_assert_file_contains "provenance: src-invoice-001" "$draft_file" "src-invoice-001"
+	else
+		_fail "provenance test draft file exists" "no draft file found"
+	fi
+	return 0
+}
+
+test_revise_mode() {
+	echo "## Revise: happy path"
+
+	# First create a draft
+	bash "$DRAFT_HELPER" draft "$TEST_CASE_ID" \
+		--intent "original for revision" \
+		--repo "$TEST_TMPDIR" >/dev/null 2>&1
+
+	local original_draft
+	original_draft="$(find "${TEST_CASE_DIR}/drafts" -name "*original-for-revision*" -type f 2>/dev/null | head -1)"
+
+	if [[ -z "$original_draft" ]]; then
+		_fail "revise: original draft exists" "no draft to revise"
+		return 0
+	fi
+
+	_pass "revise: original draft exists"
+
+	# Revise it
+	local output
+	output="$(bash "$DRAFT_HELPER" revise \
+		--revise "$original_draft" \
+		--feedback "soften the language in paragraph 2" \
+		--repo "$TEST_TMPDIR" 2>&1)" || true
+
+	_assert_output_contains "revise succeeds" "$output" "Revision generated"
+
+	# Check revision file exists
+	local rev_files
+	rev_files="$(find "${TEST_CASE_DIR}/drafts" -name "*rev*" -type f 2>/dev/null | wc -l | tr -d ' ')"
+	if [[ "$rev_files" -gt 0 ]]; then
+		_pass "revision file created"
+	else
+		_fail "revision file created" "no rev files found"
+	fi
+	return 0
+}
+
+test_no_auto_send_flag() {
+	echo "## Enforcement: no auto-send flag exists"
+
+	# Check that the helper has no --send or --auto-send CLI option
+	# (prose mentioning "never auto-send" is fine — we check for flags only)
+	local help_output
+	help_output="$(bash "$DRAFT_HELPER" help 2>&1)" || true
+
+	if echo "$help_output" | grep -qE '^\s+--send\b|^\s+--auto-send\b' 2>/dev/null; then
+		_fail "no auto-send flag" "found --send or --auto-send CLI option in help"
+	else
+		_pass "no auto-send flag"
+	fi
+	return 0
+}
+
+test_missing_intent() {
+	echo "## Validation: missing --intent"
+
+	_assert_exit_nonzero "draft fails without intent" \
+		bash "$DRAFT_HELPER" draft "$TEST_CASE_ID" --repo "$TEST_TMPDIR"
+	return 0
+}
+
+test_missing_case_id() {
+	echo "## Validation: missing case-id"
+
+	_assert_exit_nonzero "draft fails without case-id" \
+		bash "$DRAFT_HELPER" draft --intent "test" --repo "$TEST_TMPDIR"
+	return 0
+}
+
+test_invalid_tone() {
+	echo "## Validation: invalid tone"
+
+	_assert_exit_nonzero "draft fails with invalid tone" \
+		bash "$DRAFT_HELPER" draft "$TEST_CASE_ID" \
+		--intent "test" --tone aggressive --repo "$TEST_TMPDIR"
+	return 0
+}
+
+test_timeline_entry_after_draft() {
+	echo "## Audit: timeline entry after draft"
+
+	bash "$DRAFT_HELPER" draft "$TEST_CASE_ID" \
+		--intent "timeline check" \
+		--repo "$TEST_TMPDIR" >/dev/null 2>&1
+
+	local timeline="${TEST_CASE_DIR}/timeline.jsonl"
+	if grep -q "draft" "$timeline" 2>/dev/null; then
+		_pass "timeline has draft event"
+	else
+		_fail "timeline has draft event" "no draft event in timeline"
+	fi
+	return 0
+}
+
+# =============================================================================
+# Run all tests
+# =============================================================================
+
+main() {
+	echo "=== Case Draft Helper Tests (t2857) ==="
+	echo ""
+
+	_setup
+
+	test_draft_happy_path
+	echo ""
+	test_draft_tier_escalation
+	echo ""
+	test_draft_cross_case_access
+	echo ""
+	test_draft_no_cross_case_without_flag
+	echo ""
+	test_draft_tone_formal
+	echo ""
+	test_draft_tone_conciliatory
+	echo ""
+	test_draft_dry_run
+	echo ""
+	test_draft_provenance_always_present
+	echo ""
+	test_revise_mode
+	echo ""
+	test_no_auto_send_flag
+	echo ""
+	test_missing_intent
+	echo ""
+	test_missing_case_id
+	echo ""
+	test_invalid_tone
+	echo ""
+	test_timeline_entry_after_draft
+	echo ""
+
+	_teardown
+
+	echo "=== Results: ${TESTS_PASSED} passed, ${TESTS_FAILED} failed ==="
+
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		exit 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Implements t2857 (P6a) — the aidevops case draft agent for strategic communication drafting with RAG retrieval, human-gated output, and full provenance tracking.

Resolves #20911

## Changes

### New files
- `.agents/scripts/case-draft-helper.sh` (1092 lines) — draft/revise commands with LLM routing, sensitivity-tier resolution, cross-case access auditing, and provenance footer generation
- `.agents/templates/case-draft-prompt.md` — prompt template with placeholder substitution
- `.agents/templates/draft-tones-config.json` — tone preset library (neutral, formal, conciliatory, firm)
- `.agents/tests/test-case-draft.sh` (531 lines) — 31 tests covering all acceptance criteria

### Edited files
- `.agents/scripts/case-helper.sh` (+4 lines) — routes `draft` and `revise` commands to `case-draft-helper.sh`
- `.agents/scripts/knowledge-index-helper.sh` (+110 lines) — adds case-scope query support (`--scope case=<id>`, `_get_case_source_ids`, `_case_find_dir`)
- `.agents/aidevops/cases-plane.md` (+73 lines) — drafting section with privilege firewall docs and sensitivity-tier routing table

## Key features
- **Sensitivity-tier routing:** restricted sources force privileged tier (local LLM only, hard-fail if Ollama down)
- **Cross-case privilege firewall:** default scope is own case only; `--include-case` opt-in with JSONL audit log
- **Provenance footer:** every draft includes source IDs with kind, sensitivity, and sha — auto-appended
- **No auto-send:** no `--send` flag exists; drafts write to `_cases/<id>/drafts/` for human review
- **Revise mode:** `--revise <file> --feedback "..."` produces revision preserving citation standard
- **Tone library:** 4 built-in tones + custom tones via `_config/draft-tones.json`

## Testing

ShellCheck: zero violations. 31 tests pass:

```
bash .agents/tests/test-case-draft.sh
=== Results: 31 passed, 0 failed ===
```

Tests cover: happy path draft generation (mocked LLM), tier escalation with restricted sources, cross-case access audit logging, privilege firewall enforcement, tone switching (formal/conciliatory), dry-run mode, provenance footer presence, revise mode, no-auto-send enforcement, input validation.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.26 with claude-opus-4-6 spent 40m and 67,139 tokens on this as a headless worker.