### PR TITLE
t2946: fix settings namespace divergence — read orchestration.pulse_interval_seconds with supervisor.* fallback

### DIFF
--- a/.agents/configs/aidevops-config.schema.json
+++ b/.agents/configs/aidevops-config.schema.json
@@ -106,6 +106,13 @@
           "default": true,
           "description": "Enable the autonomous supervisor pulse scheduler. Env: AIDEVOPS_SUPERVISOR_PULSE"
         },
+        "pulse_interval_seconds": {
+          "type": "integer",
+          "default": 180,
+          "minimum": 30,
+          "maximum": 3600,
+          "description": "Seconds between pulse cycles. Canonical key (t2946). Legacy: supervisor.pulse_interval_seconds (still honoured for one release)."
+        },
         "repo_sync": {
           "type": "boolean",
           "default": true,
@@ -408,6 +415,73 @@
         "log_dir": { "type": "string", "default": "~/.aidevops/logs" },
         "memory_db": { "type": "string", "default": "~/.aidevops/.agent-workspace/memory/memory.db" },
         "worktree_registry_db": { "type": "string", "default": "~/.aidevops/.agent-workspace/worktree-registry.db" }
+      },
+      "additionalProperties": false
+    },
+
+    "supervisor": {
+      "type": "object",
+      "deprecated": true,
+      "description": "DEPRECATED (t2946): Use orchestration.* instead. This namespace is still consumed for one release but will be removed. Run 'aidevops update' to auto-migrate.",
+      "properties": {
+        "pulse_enabled": {
+          "type": "boolean",
+          "deprecated": true,
+          "description": "DEPRECATED: use orchestration.supervisor_pulse"
+        },
+        "pulse_interval_seconds": {
+          "type": "integer",
+          "minimum": 30,
+          "maximum": 3600,
+          "deprecated": true,
+          "description": "DEPRECATED: use orchestration.pulse_interval_seconds"
+        },
+        "stale_threshold_seconds": {
+          "type": "integer",
+          "deprecated": true,
+          "description": "DEPRECATED: use orchestration settings"
+        },
+        "circuit_breaker_max_failures": {
+          "type": "integer",
+          "deprecated": true,
+          "description": "DEPRECATED: use orchestration settings"
+        },
+        "strategic_review_hours": {
+          "type": "integer",
+          "deprecated": true,
+          "description": "DEPRECATED: use orchestration settings"
+        },
+        "peak_hours_enabled": {
+          "type": "boolean",
+          "deprecated": true,
+          "description": "DEPRECATED: use orchestration.peak_hours_enabled"
+        },
+        "peak_hours_start": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 23,
+          "deprecated": true,
+          "description": "DEPRECATED: use orchestration.peak_hours_start"
+        },
+        "peak_hours_end": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 23,
+          "deprecated": true,
+          "description": "DEPRECATED: use orchestration.peak_hours_end"
+        },
+        "peak_hours_tz": {
+          "type": "string",
+          "deprecated": true,
+          "description": "DEPRECATED: use orchestration.peak_hours_tz"
+        },
+        "peak_hours_worker_fraction": {
+          "type": "number",
+          "minimum": 0.01,
+          "maximum": 1.0,
+          "deprecated": true,
+          "description": "DEPRECATED: use orchestration.peak_hours_worker_fraction"
+        }
       },
       "additionalProperties": false
     }

--- a/.agents/scripts/pulse-watchdog-tick.sh
+++ b/.agents/scripts/pulse-watchdog-tick.sh
@@ -57,11 +57,13 @@ _wd_log() {
 
 # Resolve the configured pulse interval from settings.json (default 180s).
 # Mirrors _read_pulse_interval_seconds in setup-modules/schedulers.sh.
+# Reads orchestration.pulse_interval_seconds canonically; falls back to
+# supervisor.pulse_interval_seconds for legacy settings.json files (t2946).
 _read_pulse_interval() {
 	local _interval=180
 	if command -v jq >/dev/null 2>&1 && [[ -f "$_SETTINGS_FILE" ]]; then
 		local _raw
-		_raw=$(jq -r '.supervisor.pulse_interval_seconds // empty' "$_SETTINGS_FILE" 2>/dev/null) || _raw=""
+		_raw=$(jq -r '.orchestration.pulse_interval_seconds // .supervisor.pulse_interval_seconds // empty' "$_SETTINGS_FILE" 2>/dev/null) || _raw=""
 		if [[ -n "$_raw" && "$_raw" =~ ^[0-9]+$ ]]; then
 			_interval="$_raw"
 		fi

--- a/.agents/scripts/settings-helper.sh
+++ b/.agents/scripts/settings-helper.sh
@@ -388,10 +388,28 @@ cmd_validate() {
 		errors=$((errors + 1))
 	fi
 
-	local pulse_interval
-	pulse_interval=$(jq -r '.supervisor.pulse_interval_seconds // 0' "$SETTINGS_FILE" 2>/dev/null)
+	# Read orchestration.pulse_interval_seconds canonically; fall back to
+	# supervisor.pulse_interval_seconds for legacy settings files (t2946).
+	local pulse_interval has_orchestration_interval has_supervisor_interval
+	has_orchestration_interval=$(jq -r 'if .orchestration.pulse_interval_seconds != null then "yes" else "no" end' "$SETTINGS_FILE" 2>/dev/null)
+	has_supervisor_interval=$(jq -r 'if .supervisor.pulse_interval_seconds != null then "yes" else "no" end' "$SETTINGS_FILE" 2>/dev/null)
+	pulse_interval=$(jq -r '.orchestration.pulse_interval_seconds // .supervisor.pulse_interval_seconds // 0' "$SETTINGS_FILE" 2>/dev/null)
+	if [[ "$has_supervisor_interval" == "yes" && "$has_orchestration_interval" == "no" ]]; then
+		print_warning "supervisor.pulse_interval_seconds is deprecated — migrate to orchestration.pulse_interval_seconds"
+		print_info "  Run: aidevops update  (auto-migrates on next update)"
+	elif [[ "$has_supervisor_interval" == "yes" && "$has_orchestration_interval" == "yes" ]]; then
+		local sv_val orch_val
+		sv_val=$(jq -r '.supervisor.pulse_interval_seconds' "$SETTINGS_FILE" 2>/dev/null)
+		orch_val=$(jq -r '.orchestration.pulse_interval_seconds' "$SETTINGS_FILE" 2>/dev/null)
+		if [[ "$sv_val" != "$orch_val" ]]; then
+			print_warning "Both orchestration.pulse_interval_seconds ($orch_val) and supervisor.pulse_interval_seconds ($sv_val) are set with different values"
+			print_info "  orchestration.pulse_interval_seconds wins — remove the stale supervisor.* key"
+		else
+			print_warning "supervisor.pulse_interval_seconds is deprecated — remove it (orchestration.pulse_interval_seconds already set)"
+		fi
+	fi
 	if [[ "$pulse_interval" -lt 30 || "$pulse_interval" -gt 3600 ]]; then
-		print_warning "supervisor.pulse_interval_seconds ($pulse_interval) should be 30-3600"
+		print_warning "orchestration.pulse_interval_seconds ($pulse_interval) should be 30-3600"
 		errors=$((errors + 1))
 	fi
 
@@ -508,7 +526,8 @@ SETTINGS KEYS (dot-notation):
     auto_update.openclaw_auto_update     OpenClaw auto-update (default: true)
     auto_update.openclaw_freshness_hours Hours between OpenClaw checks (default: 24)
     supervisor.pulse_enabled             Supervisor pulse on/off (default: true)
-    supervisor.pulse_interval_seconds    Pulse interval (default: 180)
+    orchestration.pulse_interval_seconds Pulse interval in seconds (default: 180) [canonical]
+    supervisor.pulse_interval_seconds    DEPRECATED: use orchestration.pulse_interval_seconds
     supervisor.stale_threshold_seconds   Stale worker threshold (default: 1800)
     supervisor.circuit_breaker_max_failures  Max failures before pause (default: 3)
     supervisor.strategic_review_hours    Hours between strategic reviews (default: 4)

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -557,6 +557,71 @@ _update_verify_signature() {
 	return 0
 }
 
+# One-shot, idempotent migration of supervisor.* → orchestration.* in settings.json (t2946).
+# Safe: reads value from supervisor.* only when orchestration.* key is absent.
+# Logs to ~/.aidevops/logs/settings-migration.log.
+_migrate_settings_supervisor_to_orchestration() {
+	local _settings_file="${HOME}/.config/aidevops/settings.json"
+	local _log_file="${HOME}/.aidevops/logs/settings-migration.log"
+
+	if ! command -v jq >/dev/null 2>&1; then
+		return 0
+	fi
+	if [[ ! -f "$_settings_file" ]]; then
+		return 0
+	fi
+	if ! jq . "$_settings_file" >/dev/null 2>&1; then
+		return 0
+	fi
+
+	# Check if supervisor.pulse_interval_seconds exists and orchestration.pulse_interval_seconds is absent.
+	local _has_sv _has_orch
+	_has_sv=$(jq -r 'if .supervisor.pulse_interval_seconds != null then "yes" else "no" end' "$_settings_file" 2>/dev/null)
+	_has_orch=$(jq -r 'if .orchestration.pulse_interval_seconds != null then "yes" else "no" end' "$_settings_file" 2>/dev/null)
+
+	if [[ "$_has_sv" != "yes" ]]; then
+		return 0
+	fi
+
+	local _ts
+	_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date +%Y-%m-%dT%H:%M:%SZ)
+	mkdir -p "$(dirname "$_log_file")" 2>/dev/null || true
+
+	local _tmp
+	_tmp=$(mktemp 2>/dev/null) || return 0
+
+	if [[ "$_has_orch" == "no" ]]; then
+		# Migrate: copy supervisor.pulse_interval_seconds to orchestration.pulse_interval_seconds,
+		# then remove supervisor.pulse_interval_seconds.
+		local _sv_val
+		_sv_val=$(jq -r '.supervisor.pulse_interval_seconds' "$_settings_file" 2>/dev/null)
+		if jq --argjson v "$_sv_val" \
+			'(.orchestration.pulse_interval_seconds) = $v | del(.supervisor.pulse_interval_seconds)' \
+			"$_settings_file" >"$_tmp" 2>/dev/null && [[ -s "$_tmp" ]]; then
+			mv "$_tmp" "$_settings_file"
+			printf '[%s] migrated supervisor.pulse_interval_seconds=%s → orchestration.pulse_interval_seconds\n' \
+				"$_ts" "$_sv_val" >>"$_log_file" 2>/dev/null || true
+			print_info "Settings migrated: supervisor.pulse_interval_seconds → orchestration.pulse_interval_seconds ($_sv_val)"
+		else
+			rm -f "$_tmp"
+		fi
+	else
+		# Both present: orchestration wins, remove the stale supervisor key.
+		local _orch_val
+		_orch_val=$(jq -r '.orchestration.pulse_interval_seconds' "$_settings_file" 2>/dev/null)
+		if jq 'del(.supervisor.pulse_interval_seconds)' \
+			"$_settings_file" >"$_tmp" 2>/dev/null && [[ -s "$_tmp" ]]; then
+			mv "$_tmp" "$_settings_file"
+			printf '[%s] removed stale supervisor.pulse_interval_seconds (orchestration.pulse_interval_seconds=%s wins)\n' \
+				"$_ts" "$_orch_val" >>"$_log_file" 2>/dev/null || true
+			print_info "Settings cleaned: removed stale supervisor.pulse_interval_seconds (orchestration value $_orch_val kept)"
+		else
+			rm -f "$_tmp"
+		fi
+	fi
+	return 0
+}
+
 # Update/upgrade command
 cmd_update() {
 	local skip_project_sync=false
@@ -692,6 +757,12 @@ cmd_update() {
 	if [[ -t 0 ]] && [[ -z "${AIDEVOPS_AUTO_UPDATE:-}" ]] && [[ "${NON_INTERACTIVE:-false}" != "true" ]]; then
 		_update_check_daemon_health
 	fi
+
+	# t2946: one-shot idempotent migration from legacy supervisor.* to canonical
+	# orchestration.* namespace in settings.json. Safe: no-op when orchestration.*
+	# is already set. Runs even on "already up to date" updates so users who
+	# install the fix without a new release still get migrated on next 'aidevops update'.
+	_migrate_settings_supervisor_to_orchestration
 
 	# t2914: ensure pulse is running after every update. The existing
 	# restart paths (setup.sh:1329, agent-deploy.sh:601) call


### PR DESCRIPTION
## Summary

Fixes the silent settings namespace divergence where user-configured values under `orchestration.pulse_interval_seconds` were completely ignored at runtime — causing a silent 5x slowdown on pulse cadence for users who configured per the schema.

**Root cause:** The schema (`aidevops-config.schema.json`) declares `orchestration` as the canonical namespace, but production scripts only read `supervisor.*`. Users editing their settings.json per the schema had their changes silently ignored.

## Changes

### `.agents/scripts/pulse-watchdog-tick.sh`
- `_read_pulse_interval()`: reads `.orchestration.pulse_interval_seconds` first (canonical), falls back to `.supervisor.pulse_interval_seconds` for legacy configs (t2946)

### `.agents/scripts/settings-helper.sh`
- `cmd_validate()`: reads canonical key with supervisor fallback; emits deprecation warning when only `supervisor.*` is set; emits conflict warning when both are set with different values (orchestration wins)
- Help text updated: `orchestration.pulse_interval_seconds` listed as canonical; `supervisor.pulse_interval_seconds` marked deprecated

### `.agents/configs/aidevops-config.schema.json`
- Adds `orchestration.pulse_interval_seconds` (integer, 30-3600, default 180)
- Adds a top-level deprecated `supervisor` block so existing `settings.json` files still pass schema validation during migration window

### `aidevops.sh`
- Adds `_migrate_settings_supervisor_to_orchestration()`: one-shot idempotent migration that copies `supervisor.pulse_interval_seconds` to `orchestration.pulse_interval_seconds` and removes the stale key. Logs to `~/.aidevops/logs/settings-migration.log`.
- Calls the migration from `cmd_update`

## Verification

```bash
# orchestration.* takes effect immediately
echo '{"orchestration":{"pulse_interval_seconds":120}}' > /tmp/ts.json
jq -r '.orchestration.pulse_interval_seconds // .supervisor.pulse_interval_seconds // empty' /tmp/ts.json
# expected: 120

# supervisor.* (legacy) still honoured
echo '{"supervisor":{"pulse_interval_seconds":600}}' > /tmp/ts-legacy.json
jq -r '.orchestration.pulse_interval_seconds // .supervisor.pulse_interval_seconds // empty' /tmp/ts-legacy.json
# expected: 600
```

Resolves #21180

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.26 with claude-sonnet-4-6 spent 10m and 18,350 tokens on this as a headless worker.
