### PR TITLE
t2954: nvm path discovery + product validation in pulse runtime resolver

### DIFF
--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -855,18 +855,24 @@ _validate_opencode_binary() {
 }
 
 #######################################
-# t2887: Search common installation paths for a real anomalyco/opencode binary.
+# t2887/t2954: Search common installation paths for a real anomalyco/opencode
+# binary. Used as a self-heal when $OPENCODE_BIN_DEFAULT resolves to the
+# wrong binary (alex-solovyev's runner: `opencode` first on PATH returned
+# claude CLI). Echoes the first candidate that passes _validate_opencode_binary;
+# returns 0 on success, 1 if no valid binary found. Caller plumbs the result
+# through (export OPENCODE_BIN, set local _effective_opencode_bin) since
+# $OPENCODE_BIN_DEFAULT is `readonly`.
 #
-# Used as a self-heal when $OPENCODE_BIN_DEFAULT resolves to the wrong
-# binary (e.g. alex-solovyev's runner where `opencode` first on PATH
-# returns claude CLI). Echoes the first candidate that passes
-# _validate_opencode_binary; returns 0 on success, 1 if no valid binary
-# found. Caller is responsible for plumbing the result through (export
-# OPENCODE_BIN, set local _effective_opencode_bin) -- $OPENCODE_BIN_DEFAULT
-# itself is `readonly` and cannot be reassigned.
+# t2954 (Apr 2026): Node version manager paths (nvm, volta, fnm) added.
+# nvm is overwhelmingly the most common Node manager on Linux; the
+# absence of nvm here mirrored the gap in setup-modules/schedulers.sh
+# and silently broke dispatch for ~9 days on alex-solovyev's runner
+# every time the persisted scheduler-runtime-bin file got dropped or
+# the canary fired against a freshly missing binary.
 #######################################
 _find_alternative_opencode_binary() {
-	local candidates=(
+	# Fixed install paths (Homebrew, npm-global, Snap, etc.).
+	local fixed_candidates=(
 		"/opt/homebrew/bin/opencode"
 		"/usr/local/bin/opencode"
 		"${HOME}/.local/bin/opencode"
@@ -874,12 +880,35 @@ _find_alternative_opencode_binary() {
 		"/snap/bin/opencode"
 	)
 	local candidate
-	for candidate in "${candidates[@]}"; do
+	for candidate in "${fixed_candidates[@]}"; do
 		if [[ -x "$candidate" ]] && _validate_opencode_binary "$candidate"; then
 			printf '%s\n' "$candidate"
 			return 0
 		fi
 	done
+
+	# t2954: Node version manager sweep (nvm, volta, fnm). Newest version
+	# wins (sort -rV) so users on multiple Node versions get the most-
+	# recent opencode build by default.
+	local nvm_root version_dir
+	for nvm_root in \
+		"${HOME}/.nvm/versions/node" \
+		"${HOME}/.volta/tools/image/node" \
+		"${HOME}/.local/share/fnm/node-versions"; do
+		[[ -d "$nvm_root" ]] || continue
+		while IFS= read -r version_dir; do
+			# nvm + volta: <ver>/bin/opencode; fnm: <ver>/installation/bin/opencode
+			for candidate in \
+				"$version_dir/bin/opencode" \
+				"$version_dir/installation/bin/opencode"; do
+				if [[ -x "$candidate" ]] && _validate_opencode_binary "$candidate"; then
+					printf '%s\n' "$candidate"
+					return 0
+				fi
+			done
+		done < <(find "$nvm_root" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort -rV)
+	done
+
 	return 1
 }
 

--- a/.agents/scripts/tests/test-resolve-pulse-runtime-binary.sh
+++ b/.agents/scripts/tests/test-resolve-pulse-runtime-binary.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-resolve-pulse-runtime-binary.sh — t2954 / GH#21199 regression guard.
+#
+# Verifies that `_resolve_pulse_runtime_binary` in setup-modules/schedulers.sh:
+#
+#   1. Sweeps Node version manager install roots ($HOME/.nvm,
+#      $HOME/.volta, $HOME/.local/share/fnm) for an opencode binary —
+#      not just the legacy fixed paths. Pre-fix, an nvm-only Linux
+#      runner would never hit any candidate in step 4 and silently fall
+#      through to step 5 (/opt/homebrew/bin/opencode, which doesn't
+#      exist on Linux).
+#
+#   2. Validates every accepted candidate with
+#      _setup_validate_opencode_binary — rejects the Anthropic claude
+#      CLI even when it occupies the `opencode` bin name, so a wrong
+#      product cannot be persisted.
+#
+#   3. Validates the persisted file at read-time and re-resolves on
+#      failure (rather than trusting a stale wrong-product entry from
+#      a pre-fix runner that locked in claude as OPENCODE_BIN).
+#
+#   4. Picks the most-recent Node version when multiple are installed
+#      (sort -rV).
+#
+#   5. Fnm-style paths (with the extra `installation/` segment) are
+#      detected alongside nvm/volta `bin/` paths.
+#
+# Failure history: alex-solovyev's Linux runner went 9 days (Apr 18-27,
+# 2026) with 0/3 workers dispatching after the t2176 setup re-run wrote
+# `~/.config/aidevops/scheduler-runtime-bin = ~/.local/bin/claude`,
+# which the legacy step-4 candidate loop happily accepted because no
+# product validation existed and `~/.nvm/versions/node/v24.13.1/bin/opencode`
+# was never even considered.
+
+set -uo pipefail
+
+TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_REPO_ROOT="$(cd "$TEST_SCRIPTS_DIR/../.." && pwd)"
+TEST_RED=$'\033[0;31m'
+TEST_GREEN=$'\033[0;32m'
+TEST_RESET=$'\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1" rc="$2" extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf '%sPASS%s %s\n' "$TEST_GREEN" "$TEST_RESET" "$name"
+	else
+		printf '%sFAIL%s %s %s\n' "$TEST_RED" "$TEST_RESET" "$name" "$extra"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+# Build a fake $HOME with a synthetic Node version manager layout.
+# $1 = fixture root (will become $HOME).
+# $2 = "opencode" or "claude" — controls product identity emitted by binaries.
+# $3 = Node manager: "nvm" | "volta" | "fnm".
+# $4 = Node version label (e.g. "v24.13.1" or "20.10.0").
+build_fixture_node_install() {
+	local _home="$1" _product="$2" _mgr="$3" _ver="$4"
+	local _bin_dir _bin_path _ver_str
+
+	case "$_product" in
+		opencode) _ver_str="1.14.27" ;;
+		claude)   _ver_str="2.1.120 (Claude Code)" ;;
+		*) printf 'unknown product: %s\n' "$_product" >&2; return 1 ;;
+	esac
+
+	case "$_mgr" in
+		nvm)
+			_bin_dir="$_home/.nvm/versions/node/$_ver/bin"
+			;;
+		volta)
+			_bin_dir="$_home/.volta/tools/image/node/$_ver/bin"
+			;;
+		fnm)
+			_bin_dir="$_home/.local/share/fnm/node-versions/$_ver/installation/bin"
+			;;
+		*) printf 'unknown mgr: %s\n' "$_mgr" >&2; return 1 ;;
+	esac
+
+	mkdir -p "$_bin_dir"
+	# Stub binary always named "opencode" (the bin slot is product-agnostic;
+	# `command -v opencode` finds whatever owns the name). The product
+	# identity is what `--version` prints — that's what the validator reads.
+	_bin_path="$_bin_dir/opencode"
+	cat >"$_bin_path" <<EOF
+#!/bin/sh
+case "\$1" in
+	--version) echo '$_ver_str' ;;
+	*) echo "stub" ;;
+esac
+EOF
+	chmod +x "$_bin_path"
+	printf '%s' "$_bin_path"
+	return 0
+}
+
+# Build a fake legacy fixed path (e.g. ~/.local/bin/opencode).
+build_fixture_fixed_path() {
+	local _home="$1" _product="$2" _path="$3"
+	local _bin_dir _ver_str
+
+	case "$_product" in
+		opencode) _ver_str="1.14.27" ;;
+		claude)   _ver_str="2.1.120 (Claude Code)" ;;
+		*) return 1 ;;
+	esac
+
+	_bin_dir=$(dirname "$_home/$_path")
+	mkdir -p "$_bin_dir"
+	cat >"$_home/$_path" <<EOF
+#!/bin/sh
+case "\$1" in
+	--version) echo '$_ver_str' ;;
+	*) echo "stub" ;;
+esac
+EOF
+	chmod +x "$_home/$_path"
+	printf '%s' "$_home/$_path"
+	return 0
+}
+
+# Run the resolver in a subshell with overridden $HOME and a sanitized
+# PATH (no real opencode on PATH so step 3 falls through). Returns
+# resolver stdout.
+run_resolver() {
+	local _fixture_home="$1"
+	# Subshell isolates env modifications from the parent test harness.
+	(
+		export HOME="$_fixture_home"
+		# Strip system bin dirs that might host a real opencode/claude;
+		# keep /usr/bin and /bin so head/find/sort/printf still resolve.
+		export PATH="/usr/bin:/bin"
+		_resolve_pulse_runtime_binary
+	)
+}
+
+# --- Source the resolver and validator ---
+# tool-install.sh defines _setup_validate_opencode_binary;
+# schedulers.sh defines _resolve_pulse_runtime_binary and the helpers.
+# Both have `set -euo pipefail` at the top — capture and restore.
+set +e
+# shellcheck disable=SC1091
+source "$TEST_REPO_ROOT/setup-modules/tool-install.sh" 2>/dev/null || true
+# shellcheck disable=SC1091
+source "$TEST_REPO_ROOT/setup-modules/schedulers.sh" 2>/dev/null || true
+set +e
+
+if ! declare -F _resolve_pulse_runtime_binary >/dev/null; then
+	echo "FAIL: _resolve_pulse_runtime_binary not defined after sourcing"
+	exit 1
+fi
+
+if ! declare -F _setup_validate_opencode_binary >/dev/null; then
+	echo "FAIL: _setup_validate_opencode_binary not defined after sourcing"
+	exit 1
+fi
+
+# --- Tests ---
+
+# Test 1: nvm path discovery. Plain $HOME with only ~/.nvm populated.
+fixture1=$(mktemp -d 2>/dev/null || mktemp -d -t t2954a)
+expected1=$(build_fixture_node_install "$fixture1" "opencode" "nvm" "v24.13.1")
+result1=$(run_resolver "$fixture1")
+if [[ "$result1" == "$expected1" ]]; then
+	print_result "nvm path discovery — finds opencode in ~/.nvm/versions/node" 0
+else
+	print_result "nvm path discovery — finds opencode in ~/.nvm/versions/node" 1 \
+		"expected=$expected1 got=$result1"
+fi
+rm -rf "$fixture1"
+
+# Test 2: volta path discovery.
+fixture2=$(mktemp -d 2>/dev/null || mktemp -d -t t2954b)
+expected2=$(build_fixture_node_install "$fixture2" "opencode" "volta" "20.10.0")
+result2=$(run_resolver "$fixture2")
+if [[ "$result2" == "$expected2" ]]; then
+	print_result "volta path discovery — finds opencode in ~/.volta/tools/image/node" 0
+else
+	print_result "volta path discovery — finds opencode in ~/.volta/tools/image/node" 1 \
+		"expected=$expected2 got=$result2"
+fi
+rm -rf "$fixture2"
+
+# Test 3: fnm path discovery (extra `installation/` segment).
+fixture3=$(mktemp -d 2>/dev/null || mktemp -d -t t2954c)
+expected3=$(build_fixture_node_install "$fixture3" "opencode" "fnm" "v22.5.0")
+result3=$(run_resolver "$fixture3")
+if [[ "$result3" == "$expected3" ]]; then
+	print_result "fnm path discovery — finds opencode in ~/.local/share/fnm/node-versions" 0
+else
+	print_result "fnm path discovery — finds opencode in ~/.local/share/fnm/node-versions" 1 \
+		"expected=$expected3 got=$result3"
+fi
+rm -rf "$fixture3"
+
+# Test 4: Most-recent Node version wins (sort -rV).
+fixture4=$(mktemp -d 2>/dev/null || mktemp -d -t t2954d)
+build_fixture_node_install "$fixture4" "opencode" "nvm" "v18.20.0" >/dev/null
+build_fixture_node_install "$fixture4" "opencode" "nvm" "v22.5.0" >/dev/null
+expected4=$(build_fixture_node_install "$fixture4" "opencode" "nvm" "v24.13.1")
+result4=$(run_resolver "$fixture4")
+if [[ "$result4" == "$expected4" ]]; then
+	print_result "most-recent Node version wins — v24 over v22 over v18" 0
+else
+	print_result "most-recent Node version wins — v24 over v22 over v18" 1 \
+		"expected=$expected4 got=$result4"
+fi
+rm -rf "$fixture4"
+
+# Test 5: Claude rejection at sweep-time. nvm contains a claude-stub
+# (wrong product) — resolver must skip it and fall through to step 5
+# (/opt/homebrew/bin/opencode), which doesn't exist in the fixture.
+# Result: step 5 default returned but NOT persisted (validator rejects
+# the stub, and step 5's hardcoded path also fails -x check in persistence).
+fixture5=$(mktemp -d 2>/dev/null || mktemp -d -t t2954e)
+build_fixture_node_install "$fixture5" "claude" "nvm" "v24.13.1" >/dev/null
+result5=$(run_resolver "$fixture5")
+# Resolver returns the step-5 default ("/opt/homebrew/bin/opencode")
+# even though it doesn't exist — that's the documented last-resort.
+# The test we care about: the claude path was NOT returned and NOT
+# persisted.
+persisted_file5="$fixture5/.config/aidevops/scheduler-runtime-bin"
+claude_path5="$fixture5/.nvm/versions/node/v24.13.1/bin/opencode"
+if [[ "$result5" != "$claude_path5" ]]; then
+	print_result "claude binary in nvm path — rejected by validator, not returned" 0
+else
+	print_result "claude binary in nvm path — rejected by validator, not returned" 1 \
+		"resolver returned the claude path: $result5"
+fi
+if [[ ! -f "$persisted_file5" ]] || \
+	[[ "$(cat "$persisted_file5" 2>/dev/null)" != "$claude_path5" ]]; then
+	print_result "claude binary — not persisted as OPENCODE_BIN" 0
+else
+	print_result "claude binary — not persisted as OPENCODE_BIN" 1 \
+		"persisted file contains claude path"
+fi
+rm -rf "$fixture5"
+
+# Test 6: Stale wrong-product persisted file — validator drops it and
+# resolver re-resolves to the real opencode binary present in nvm.
+# Mirrors alex-solovyev's runner state pre-heal: persisted = claude.
+fixture6=$(mktemp -d 2>/dev/null || mktemp -d -t t2954f)
+expected6=$(build_fixture_node_install "$fixture6" "opencode" "nvm" "v24.13.1")
+# Plant a claude stub at a separate fixed path and persist that path.
+claude_stub6=$(build_fixture_fixed_path "$fixture6" "claude" ".local/bin/claude")
+mkdir -p "$fixture6/.config/aidevops"
+printf '%s\n' "$claude_stub6" >"$fixture6/.config/aidevops/scheduler-runtime-bin"
+result6=$(run_resolver "$fixture6")
+if [[ "$result6" == "$expected6" ]]; then
+	print_result "stale claude in persisted file — dropped, re-resolves to nvm opencode" 0
+else
+	print_result "stale claude in persisted file — dropped, re-resolves to nvm opencode" 1 \
+		"expected=$expected6 got=$result6"
+fi
+# After re-resolution, persisted file should now point at the real opencode.
+persisted6=$(cat "$fixture6/.config/aidevops/scheduler-runtime-bin" 2>/dev/null || true)
+if [[ "$persisted6" == "$expected6" ]]; then
+	print_result "persistence updated to validated opencode after stale-claude drop" 0
+else
+	print_result "persistence updated to validated opencode after stale-claude drop" 1 \
+		"persisted=$persisted6 expected=$expected6"
+fi
+rm -rf "$fixture6"
+
+# Test 7: Persistence round-trip — valid opencode is persisted and re-read.
+fixture7=$(mktemp -d 2>/dev/null || mktemp -d -t t2954g)
+expected7=$(build_fixture_node_install "$fixture7" "opencode" "nvm" "v22.5.0")
+# First run: discovers via nvm sweep, persists.
+run_resolver "$fixture7" >/dev/null
+persisted7=$(cat "$fixture7/.config/aidevops/scheduler-runtime-bin" 2>/dev/null || true)
+if [[ "$persisted7" == "$expected7" ]]; then
+	print_result "persistence — valid opencode written to scheduler-runtime-bin" 0
+else
+	print_result "persistence — valid opencode written to scheduler-runtime-bin" 1 \
+		"persisted=$persisted7 expected=$expected7"
+fi
+# Second run: reads from persisted file (validation passes), returns same path.
+result7b=$(run_resolver "$fixture7")
+if [[ "$result7b" == "$expected7" ]]; then
+	print_result "persistence — second run reads from scheduler-runtime-bin" 0
+else
+	print_result "persistence — second run reads from scheduler-runtime-bin" 1 \
+		"got=$result7b expected=$expected7"
+fi
+rm -rf "$fixture7"
+
+# Test 8: Legacy fixed path still works as fallback (Linux ~/.local/bin).
+fixture8=$(mktemp -d 2>/dev/null || mktemp -d -t t2954h)
+expected8=$(build_fixture_fixed_path "$fixture8" "opencode" ".local/bin/opencode")
+result8=$(run_resolver "$fixture8")
+if [[ "$result8" == "$expected8" ]]; then
+	print_result "legacy fixed path — finds opencode in ~/.local/bin (fallback)" 0
+else
+	print_result "legacy fixed path — finds opencode in ~/.local/bin (fallback)" 1 \
+		"expected=$expected8 got=$result8"
+fi
+rm -rf "$fixture8"
+
+# --- Summary ---
+echo ""
+echo "Tests run: $TESTS_RUN"
+echo "Failed:    $TESTS_FAILED"
+
+if [[ "$TESTS_FAILED" -eq 0 ]]; then
+	exit 0
+fi
+exit 1

--- a/TODO.md
+++ b/TODO.md
@@ -3340,7 +3340,7 @@ t019.3.4,Update AGENTS.md with Beads integration docs,,beads,1h,45m,2025-12-21T1
 
 - [ ] t2953 fast-fail _ff_with_lock orphan-lock detection: empty lockdir without owner.pid never cleaned, blocks all dispatches #auto-dispatch #bug #enhancement #framework ref:GH#21197
 
-- [ ] t2954 fix _resolve_pulse_runtime_binary nvm path discovery + product validation (Li... #bug #framework ref:GH#21199
+- [ ] t2954 fix _resolve_pulse_runtime_binary nvm path discovery + product validation (Linux dispatch broke 9d on alex-solovyev runner) #interactive #bug #framework ref:GH#21199
 
 - [ ] t2956 investigate watchdog_stall_continue 21.6% rate (avg 38min wasted vs 16min success) — biggest overnight throughput drain #auto-dispatch #bug #enhancement #framework ref:GH#21201
 

--- a/setup-modules/schedulers.sh
+++ b/setup-modules/schedulers.sh
@@ -175,31 +175,121 @@ _is_pulse_installed() {
 	return 1
 }
 
+# t2954: Sweep Node version manager install roots (nvm, volta, fnm) for
+# an opencode binary. Linux runners overwhelmingly install Node via nvm,
+# which the legacy fixed-paths sweep in step 4b misses entirely — the
+# alex-solovyev runner (Apr 2026, 9-day dispatch outage) is the canonical
+# failure mode. Most-recent Node version wins (sort -rV). Each candidate
+# is product-validated when the validator is in scope; nvm/volta/fnm can
+# all host either anomalyco/opencode (from `npm i -g opencode`) or the
+# Anthropic claude CLI (from `npm i -g @anthropic-ai/claude-code`) under
+# the same `opencode` bin name, so validation is mandatory.
+# $1 = "1" if _setup_validate_opencode_binary is callable, else "0".
+# Returns 0 + prints path on hit, 1 on miss.
+_sweep_nvm_volta_fnm_for_opencode() {
+	local _have_validator="${1:-0}"
+	local _root _version_dir _candidate
+	for _root in \
+		"$HOME/.nvm/versions/node" \
+		"$HOME/.volta/tools/image/node" \
+		"$HOME/.local/share/fnm/node-versions"; do
+		[[ -d "$_root" ]] || continue
+		while IFS= read -r _version_dir; do
+			# nvm + volta: <ver>/bin/opencode; fnm: <ver>/installation/bin/opencode
+			for _candidate in \
+				"$_version_dir/bin/opencode" \
+				"$_version_dir/installation/bin/opencode"; do
+				[[ -x "$_candidate" ]] || continue
+				if [[ "$_have_validator" -eq 1 ]] && \
+					! _setup_validate_opencode_binary "$_candidate"; then
+					continue
+				fi
+				printf '%s' "$_candidate"
+				return 0
+			done
+		done < <(find "$_root" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | sort -rV)
+	done
+	return 1
+}
+
+# t2954: Legacy fixed-install-paths sweep for an opencode binary. Used as
+# a last-resort discovery when persistence, runtime registry, live PATH,
+# and the Node-version-manager sweep all came up empty. Each candidate
+# is product-validated when the validator is in scope; the claude entries
+# remain in the list for documentation but always fail validation and
+# are skipped (they were the alex-solovyev silent-product-swap source).
+# $1 = "1" if _setup_validate_opencode_binary is callable, else "0".
+# Returns 0 + prints path on hit, 1 on miss.
+_sweep_legacy_install_paths_for_opencode() {
+	local _have_validator="${1:-0}"
+	local _candidate
+	for _candidate in \
+		/opt/homebrew/bin/opencode \
+		/usr/local/bin/opencode \
+		/home/linuxbrew/.linuxbrew/bin/opencode \
+		"$HOME/.npm-global/bin/opencode" \
+		"$HOME/.local/bin/opencode" \
+		"$HOME/.bun/bin/opencode" \
+		/opt/homebrew/bin/claude \
+		/usr/local/bin/claude \
+		"$HOME/.local/bin/claude"; do
+		[[ -x "$_candidate" ]] || continue
+		if [[ "$_have_validator" -eq 1 ]] && \
+			! _setup_validate_opencode_binary "$_candidate"; then
+			continue
+		fi
+		printf '%s' "$_candidate"
+		return 0
+	done
+	return 1
+}
+
+# t2954: Persist a resolved runtime path with product validation. Persisting
+# an unvalidated path is exactly how the alex-solovyev runner locked in
+# its 9-day dispatch outage — claude was persisted as OPENCODE_BIN and
+# every subsequent canary fired `config_error` against the 1h negative
+# cache. With validation, a wrong-product result silently no-ops the
+# write and the next resolver run gets a fresh shot at finding a real
+# opencode binary.
+# $1 = path to persist; $2 = persistence file path; $3 = "1"/"0" validator-available flag.
+_persist_pulse_runtime_path() {
+	local _bin="${1:-}" _file="${2:-}" _have_validator="${3:-0}"
+	[[ -n "$_bin" ]] && [[ -x "$_bin" ]] || return 0
+	if [[ "$_have_validator" -eq 1 ]]; then
+		_setup_validate_opencode_binary "$_bin" || return 0
+	fi
+	mkdir -p "$(dirname "$_file")" 2>/dev/null || true
+	printf '%s\n' "$_bin" >"$_file" 2>/dev/null || true
+	return 0
+}
+
 _resolve_pulse_runtime_binary() {
-	# GH#18439 Bug 2: Persist the resolved binary path across setup.sh
-	# invocations. aidevops-auto-update.timer runs setup.sh under systemd's
-	# minimal PATH, so re-resolving from live `$PATH` alone yields the
-	# legacy macOS-biased `/opt/homebrew/bin/opencode` fallback on Linux.
-	# Reading from persistence first (populated during an interactive
-	# setup.sh run with a rich `$PATH`) prevents the auto-update cycle
-	# from silently degrading the service file.
+	# GH#18439 + t2954. Persist the resolved binary across setup.sh
+	# invocations so aidevops-auto-update.timer (systemd minimal PATH)
+	# does not silently regenerate cron with the legacy macOS fallback,
+	# AND validate every accepted candidate so the wrong product (claude
+	# CLI under the opencode bin name) cannot silently take the slot.
 	local _persisted_file="$HOME/.config/aidevops/scheduler-runtime-bin"
 	local opencode_bin=""
+	local _have_validator=0
+	declare -F _setup_validate_opencode_binary >/dev/null 2>&1 && _have_validator=1
 
-	# 1. Prefer persisted path if it still points at an executable file.
+	# 1. Persisted path (validated). Drop+re-resolve on validation failure.
 	if [[ -f "$_persisted_file" ]]; then
 		local _persisted
 		_persisted=$(head -n1 "$_persisted_file" 2>/dev/null || true)
 		if [[ -n "$_persisted" ]] && [[ -x "$_persisted" ]]; then
-			printf '%s' "$_persisted"
-			return 0
+			if [[ "$_have_validator" -eq 0 ]] || \
+				_setup_validate_opencode_binary "$_persisted"; then
+				printf '%s' "$_persisted"
+				return 0
+			fi
 		fi
 	fi
 
-	# 2. Try runtime-registry lookup via live PATH.
+	# 2. Runtime-registry lookup via live PATH.
 	if type rt_list_headless &>/dev/null; then
-		local _sched_rt_id=""
-		local _sched_bin=""
+		local _sched_rt_id="" _sched_bin=""
 		while IFS= read -r _sched_rt_id; do
 			_sched_bin=$(rt_binary "$_sched_rt_id") || continue
 			if [[ -n "$_sched_bin" ]] && command -v "$_sched_bin" &>/dev/null; then
@@ -209,45 +299,20 @@ _resolve_pulse_runtime_binary() {
 		done < <(rt_list_headless)
 	fi
 
-	# 3. Direct PATH lookup for the default runtime.
-	if [[ -z "$opencode_bin" ]]; then
-		opencode_bin=$(command -v opencode 2>/dev/null || true)
-	fi
+	# 3. Direct PATH lookup.
+	[[ -z "$opencode_bin" ]] && opencode_bin=$(command -v opencode 2>/dev/null || true)
 
-	# 4. OS-aware common-install-location sweep. Used when live `$PATH` is
-	# minimal (systemd-spawned setup.sh) and persistence hasn't been
-	# seeded yet. Covers Homebrew (macOS + Linuxbrew), /usr/local, npm
-	# global, Python/uv pipx-style `.local/bin`, and bun.
-	if [[ -z "$opencode_bin" ]]; then
-		local _candidate
-		for _candidate in \
-			/opt/homebrew/bin/opencode \
-			/usr/local/bin/opencode \
-			/home/linuxbrew/.linuxbrew/bin/opencode \
-			"$HOME/.npm-global/bin/opencode" \
-			"$HOME/.local/bin/opencode" \
-			"$HOME/.bun/bin/opencode" \
-			/opt/homebrew/bin/claude \
-			/usr/local/bin/claude \
-			"$HOME/.local/bin/claude"; do
-			if [[ -x "$_candidate" ]]; then
-				opencode_bin="$_candidate"
-				break
-			fi
-		done
-	fi
+	# 4a. Node version manager sweep (nvm, volta, fnm). Linux-friendly.
+	[[ -z "$opencode_bin" ]] && opencode_bin=$(_sweep_nvm_volta_fnm_for_opencode "$_have_validator" || true)
 
-	# 5. Last-resort legacy fallback (preserves pre-GH#18439 behaviour so
-	# setup.sh never exits the resolver empty-handed).
+	# 4b. Legacy fixed-install-paths sweep (Homebrew, npm-global, bun, .local/bin).
+	[[ -z "$opencode_bin" ]] && opencode_bin=$(_sweep_legacy_install_paths_for_opencode "$_have_validator" || true)
+
+	# 5. Last-resort legacy fallback (pre-GH#18439 behaviour).
 	[[ -z "$opencode_bin" ]] && opencode_bin="/opt/homebrew/bin/opencode"
 
-	# Persist the resolved path for subsequent non-interactive invocations
-	# (auto-update timer, cron regeneration). Only write when we actually
-	# found a real executable — don't persist the legacy fallback.
-	if [[ -x "$opencode_bin" ]]; then
-		mkdir -p "$(dirname "$_persisted_file")" 2>/dev/null || true
-		printf '%s\n' "$opencode_bin" >"$_persisted_file" 2>/dev/null || true
-	fi
+	# Persist (validated). Wrong-product results silently no-op the write.
+	_persist_pulse_runtime_path "$opencode_bin" "$_persisted_file" "$_have_validator"
 
 	printf '%s' "$opencode_bin"
 	return 0

--- a/todo/tasks/t2954-brief.md
+++ b/todo/tasks/t2954-brief.md
@@ -1,0 +1,149 @@
+---
+mode: subagent
+---
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+# t2954: fix _resolve_pulse_runtime_binary nvm path discovery + product validation
+
+## Pre-flight
+
+- [x] Memory recall: `pulse runtime binary resolver opencode nvm` → 0 hits — no relevant prior lessons
+- [x] Discovery pass: 0 commits / 0 merged PRs / 0 open PRs touch `setup-modules/schedulers.sh::_resolve_pulse_runtime_binary` in last 14d (last touch was t2176, Apr 18, the upgrade that exposed this bug)
+- [x] File refs verified: 3 refs checked, all present at HEAD (`setup-modules/schedulers.sh:178-254`, `.agents/scripts/headless-runtime-lib.sh:836-884`, `setup-modules/tool-install.sh:1547-1572`)
+- [x] Tier: `tier:standard` — touches 3 files, includes regression test, dispatch-path file (auto-elevated to opus per t2819)
+
+## Origin
+
+- **Created:** 2026-04-27
+- **Session:** Claude Code interactive (marcusquinn)
+- **Created by:** ai-interactive (driven by external bug report from alex-solovyev's runner)
+- **Parent task:** none (leaf)
+- **Conversation context:** alex-solovyev's Linux runner ran the broken resolver for ~9 days (Apr 18-27), dispatching 0 workers across 3 slots after `aidevops-auto-update.timer` regenerated the systemd service file under a minimal PATH. The resolver swept its hardcoded path list, missed nvm (the most popular Node version manager on Linux), fell through to `~/.local/bin/claude` (Anthropic's Claude Code CLI — different product), and persisted that path as `OPENCODE_BIN`. From then on every canary check returned `config_error` and the negative cache trapped the failure for 1h cycles. He's asked for the systemic fix so update doesn't break Linux users again.
+
+## What
+
+Two fixes in one PR:
+
+1. **nvm/volta/fnm path discovery** in `_resolve_pulse_runtime_binary` (setup-modules/schedulers.sh) and `_find_alternative_opencode_binary` (.agents/scripts/headless-runtime-lib.sh). The current sweeps cover macOS install paths (Homebrew, npm-global, .local/bin, bun) but not Linux Node-version-manager paths. Both functions hit the same blind spot — fix in the same PR.
+
+2. **Product validation before persisting** in `_resolve_pulse_runtime_binary`. Currently the resolver checks only `[[ -x ]]` (file is executable). When opencode is missing and `~/.local/bin/claude` exists, it persists claude as `OPENCODE_BIN` and the dispatch path silently breaks for ~1h cycles (the canary's negative-cache TTL). Validate at BOTH read-time (rejecting an existing wrong-product persisted file) AND write-time (refusing to persist a wrong-product result).
+
+Plus a regression test that fails without these fixes.
+
+## Why
+
+Per alex-solovyev's incident report:
+
+- **Duration:** ~9 days (Apr 18-27)
+- **Workers active:** 0/3 slots (100% deficit)
+- **Runnable tasks queued:** ~170-200
+- **`no_worker_process` events:** 3,294
+- **Canary failures:** 85
+- **Root cause:** the binary resolver was written for macOS install paths; misses nvm (most-common Linux Node version manager) AND has no product validation, so it silently swaps OpenCode for Claude Code CLI when only the latter is on disk.
+
+`aidevops update` is the framework's auto-update path — when it breaks dispatch this badly on Linux, every Linux runner is affected silently. This fix makes the resolver Linux-native and product-aware so the same class of failure cannot recur.
+
+## Tier
+
+### Tier checklist
+
+- [x] **2 or fewer files to modify?** — NO (3 files: 2 source + 1 new test). Use `tier:standard`.
+- [x] **Dispatch-path classification (t2821):** YES — `headless-runtime-lib.sh` is in `.agents/configs/self-hosting-files.conf`. Per t2920, use `#auto-dispatch` as normal; t2819 pre-dispatch detector auto-elevates to opus. **This task is being implemented interactively — auto-dispatch is moot, no `#auto-dispatch` tag.**
+
+**Selected tier:** `tier:standard`
+
+**Tier rationale:** Multi-file change (2 sources + test) with validation logic that needs careful boundary testing. Pattern is well-established (mirror `_setup_validate_opencode_binary`), so no novel design — `standard` suffices.
+
+## PR Conventions
+
+Leaf task. PR body will use `Resolves #NNN` (issue number assigned by `issue-sync-helper.sh push t2954` once this brief lands).
+
+## How (Approach)
+
+### Files to Modify
+
+- `EDIT: setup-modules/schedulers.sh:178-254` — `_resolve_pulse_runtime_binary` function. Add nvm/volta/fnm sweep before the legacy fallback; validate persisted file at read-time (step 1); validate before persisting (step 5).
+- `EDIT: .agents/scripts/headless-runtime-lib.sh:868-884` — `_find_alternative_opencode_binary` function. Add nvm/volta/fnm sweep before the existing candidate loop. Same product validator already used (`_validate_opencode_binary` at line 836).
+- `NEW: .agents/scripts/tests/test-resolve-pulse-runtime-binary.sh` — regression test. Model on `.agents/scripts/tests/test-basename-collision-resolver.sh` (existing fixture-driven sourced-resolver test). Cover: nvm path discovery, claude rejection at read-time, claude rejection at write-time, persistence round-trip with valid binary.
+
+### Implementation Steps
+
+**Step 1 — schedulers.sh nvm/volta/fnm sweep.**
+
+Insert a new "Step 4a" block in `_resolve_pulse_runtime_binary` BEFORE the existing fixed-paths sweep (line 221). Sort version dirs newest-first (`sort -rV`) so users with multiple Node versions get the most recent opencode.
+
+Roots to sweep:
+
+- `$HOME/.nvm/versions/node/<ver>/bin/opencode` (nvm)
+- `$HOME/.volta/tools/image/node/<ver>/bin/opencode` (volta)
+- `$HOME/.local/share/fnm/node-versions/<ver>/installation/bin/opencode` (fnm — note the extra `installation/` segment)
+
+**Step 2 — schedulers.sh product validation.**
+
+Use `_setup_validate_opencode_binary` (already defined at `setup-modules/tool-install.sh:1553`). Both modules are sourced by `setup.sh` in the same invocation, so the function is in scope. Guard with `declare -F _setup_validate_opencode_binary >/dev/null 2>&1` so the resolver still degrades gracefully if invoked outside the setup.sh context (e.g., direct sourcing for tests).
+
+Validation points:
+
+- **Read (step 1, `$_persisted_file`):** if the persisted file points at an executable that fails validation, drop it and continue to re-resolve. This heals existing alex-solovyev-class state.
+- **Write (just before `printf '%s\n' >"$_persisted_file"`):** only persist if validation passes. The legacy `/opt/homebrew/bin/opencode` fallback (line 242) MUST be excluded from persistence on Linux machines where that path doesn't exist.
+
+For each candidate in the legacy fixed-paths loop (step 4), validate before accepting. The `claude` paths in that list (lines 230-232) will fail validation against the opencode signature and be skipped — effectively neutralising the broken claude fallback without removing the candidates (preserves diff scope).
+
+**Step 3 — headless-runtime-lib.sh nvm sweep.**
+
+Add the same three nvm/volta/fnm roots to `_find_alternative_opencode_binary` (line 868). The existing per-candidate `_validate_opencode_binary` check (line 878) already does product validation — just extend the candidate set.
+
+**Step 4 — regression test.**
+
+Model on `test-basename-collision-resolver.sh`. Build a fixture HOME with synthetic nvm tree (`fixture_home/.nvm/versions/node/v24.13.1/bin/opencode`), source `setup-modules/schedulers.sh` AND `setup-modules/tool-install.sh` (for the validator), override `HOME`, and assert:
+
+1. Resolver finds the nvm-installed opencode binary.
+2. When `$_persisted_file` is pre-seeded with `~/.local/bin/claude` (a real claude binary), resolver rejects it and re-resolves.
+3. Resolver does NOT persist the legacy `/opt/homebrew/bin/opencode` fallback when no real opencode is reachable.
+4. Round-trip: resolver finds, persists, and re-reads the same valid path.
+
+Synthetic binaries: write tiny shell scripts that print the right `--version` output (`echo "1.14.27"` for opencode, `echo "2.1.120 (Claude Code)"` for claude), `chmod +x`. The validator in tool-install.sh runs `--version` and checks the output — these stubs satisfy it.
+
+### Files Scope
+
+- `setup-modules/schedulers.sh`
+- `.agents/scripts/headless-runtime-lib.sh`
+- `.agents/scripts/tests/test-resolve-pulse-runtime-binary.sh`
+- `todo/tasks/t2954-brief.md`
+- `TODO.md`
+
+### Complexity Impact
+
+Estimated growth on `_resolve_pulse_runtime_binary`: current ~45 lines (function body, 178-254). Adding nvm sweep (~15 lines) + read-time validation (~6 lines) + write-time validation (~6 lines) → ~72 lines. Below the 80-line advisory threshold, well below the 100-line `function-complexity` gate. No refactor required.
+
+`_find_alternative_opencode_binary`: current ~17 lines. Adding nvm sweep (~15 lines) → ~32 lines. Comfortably under all thresholds.
+
+### Verification
+
+```bash
+# 1. Static checks
+shellcheck setup-modules/schedulers.sh .agents/scripts/headless-runtime-lib.sh \
+           .agents/scripts/tests/test-resolve-pulse-runtime-binary.sh
+
+# 2. Regression test
+bash .agents/scripts/tests/test-resolve-pulse-runtime-binary.sh
+
+# 3. Existing test suite still passes
+bash .agents/scripts/tests/test-basename-collision-resolver.sh
+
+# 4. Manual smoke (on macOS — sanity check the validator path)
+source setup-modules/tool-install.sh
+_setup_validate_opencode_binary "$(which opencode)"; echo "opencode rc=$?"  # expect 0
+_setup_validate_opencode_binary "$(which claude)";   echo "claude rc=$?"    # expect 1
+```
+
+## Acceptance
+
+- [x] `_resolve_pulse_runtime_binary` discovers `$HOME/.nvm/versions/node/*/bin/opencode` (and volta + fnm equivalents) before falling through to legacy paths.
+- [x] `_resolve_pulse_runtime_binary` rejects a persisted-file path that fails `_setup_validate_opencode_binary`, then re-resolves and overwrites with a valid path.
+- [x] `_resolve_pulse_runtime_binary` does NOT write `/opt/homebrew/bin/opencode` to `$_persisted_file` on machines where that path is non-existent or wrong-product.
+- [x] `_find_alternative_opencode_binary` discovers the same nvm/volta/fnm roots.
+- [x] New regression test passes locally; covers nvm discovery, claude rejection at read+write, persistence round-trip.
+- [x] `shellcheck` zero violations across the three modified/new files.
+- [x] Existing `test-basename-collision-resolver.sh` still passes.


### PR DESCRIPTION
## Summary

`_resolve_pulse_runtime_binary` (setup-modules/schedulers.sh) and `_find_alternative_opencode_binary` (headless-runtime-lib.sh) — the two paths that resolve which `opencode` binary the pulse should run — both lacked nvm path discovery AND product-identity validation. On Linux runners that install Node via nvm (the dominant Node manager), this combination silently broke pulse dispatch:

- nvm-installed `opencode` at `~/.nvm/versions/node/<ver>/bin/opencode` was never considered (only fixed paths swept).
- Step 5's last-resort default `/opt/homebrew/bin/opencode` doesn't exist on Linux, so the resolver returned a non-existent path.
- Worse, when the Anthropic claude CLI parked itself under `~/.local/bin/opencode` (or `~/.local/bin/claude` was the first hit), it was accepted without validation and persisted to `scheduler-runtime-bin`. Every subsequent canary fired `config_error` against the 1h negative-cache. Pulse dispatched 0 workers indefinitely.

## Canonical incident

alex-solovyev's runner: 9-day outage (Apr 18-27, 2026), 0/3 workers, ~170-200 queued tasks, 3,294 `no_worker_process` events. `~/.config/aidevops/scheduler-runtime-bin` contained `~/.local/bin/claude`.

## Fixes

In **setup-modules/schedulers.sh** (`_resolve_pulse_runtime_binary`):

1. **nvm/volta/fnm sweep before fall-through.** New helper `_sweep_nvm_volta_fnm_for_opencode` walks `~/.nvm/versions/node`, `~/.volta/tools/image/node`, `~/.local/share/fnm/node-versions`. Most-recent Node version wins (`sort -rV`). fnm's extra `installation/` path segment is handled.
2. **Product validation on every accepted candidate.** Calls existing `_setup_validate_opencode_binary` (`tool-install.sh:1553`) — rejects Anthropic claude CLI (signature: `(Claude Code)` in `--version` or major version 2+).
3. **Read-time persistence validation.** Stale wrong-product persistence (from pre-fix runners) is dropped silently and the resolver re-resolves on the same invocation.

In **.agents/scripts/headless-runtime-lib.sh** (`_find_alternative_opencode_binary` — the canary-time self-heal): same nvm/volta/fnm roots added. Existing `_validate_opencode_binary` check at the inner loop already rejected wrong products; the gap was purely "no nvm root in the candidate set".

## Refactor

The 76-line `_resolve_pulse_runtime_binary` was decomposed into a 54-line orchestrator plus three single-responsibility helpers:

- `_sweep_nvm_volta_fnm_for_opencode` (24 lines, validator-aware)
- `_sweep_legacy_install_paths_for_opencode` (23 lines, validator-aware)
- `_persist_pulse_runtime_path` (10 lines, validator-aware)

Same `$1='1'|'0'` validator-flag pattern in both sweeps for symmetry.

## Test coverage

`.agents/scripts/tests/test-resolve-pulse-runtime-binary.sh` — 11 assertions:

| # | Assertion |
|---|-----------|
| 1 | nvm path discovery — finds opencode in `~/.nvm/versions/node` |
| 2 | volta path discovery — finds opencode in `~/.volta/tools/image/node` |
| 3 | fnm path discovery — finds opencode in `~/.local/share/fnm/node-versions` |
| 4 | most-recent Node version wins — v24 over v22 over v18 |
| 5 | claude binary in nvm path — rejected by validator, not returned |
| 6 | claude binary — not persisted as OPENCODE_BIN |
| 7 | stale claude in persisted file — dropped, re-resolves to nvm opencode |
| 8 | persistence updated to validated opencode after stale-claude drop |
| 9 | persistence — valid opencode written to scheduler-runtime-bin |
| 10 | persistence — second run reads from scheduler-runtime-bin |
| 11 | legacy fixed path — finds opencode in ~/.local/bin (fallback) |

Synthetic bin stubs emit semver vs `(Claude Code)` so the validator exercises the real product-detection paths.

## Verification

- `shellcheck setup-modules/schedulers.sh .agents/scripts/headless-runtime-lib.sh .agents/scripts/tests/test-resolve-pulse-runtime-binary.sh` → clean (only pre-existing SC2016 info on schedulers.sh:33 — the BASH_VERSINFO check intentionally uses single quotes to pass the expression to a candidate bash for evaluation).
- `bash .agents/scripts/tests/test-resolve-pulse-runtime-binary.sh` → 11/11 PASS.
- `bash .agents/scripts/tests/test-basename-collision-resolver.sh` → 7/7 PASS (regression check on sibling resolver).
- `complexity-regression-helper.sh check --dry-run` → 38 violations (was 39, improved by 1). None of the modified or new functions appear in the violators list.

## Files Scope

- `setup-modules/schedulers.sh`
- `.agents/scripts/headless-runtime-lib.sh`
- `.agents/scripts/tests/test-resolve-pulse-runtime-binary.sh`

Resolves #21199

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.27 with claude-opus-4-7 spent 20m and 71,284 tokens on this with the user in an interactive session.
