### PR TITLE
t2948: reduce idle interactive PR handover threshold 24h→4h (IDLE_INTERACTIVE_HANDOVER_SECONDS)

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -795,7 +795,7 @@ Worktrees: `wt switch -c {type}/{name}`. Keep the canonical repo directory on `m
 - **Offline `gh`:** the helper warns and continues (exit 0). A collision with a worker is harmless — the interactive work naturally becomes its own issue/PR.
 - **`sudo aidevops approve issue <N>`** (crypto-approval flow for contributor-filed NMR issues) also clears `status:in-review` idempotently when present — no new user-facing command, it's a passive side effect of the already-required approval step.
 - `/release-issue <N>` and `aidevops issue release <N>` exist as fallbacks only.
-- **Idle interactive PR handover (t2189):** `origin:interactive` PRs idle >24h with no active claim stamp auto-transfer to `origin:worker-takeover` for CI-fix/conflict pipelines. Apply `no-takeover` to opt out. Full detail and env controls: `reference/session.md`.
+- **Idle interactive PR handover (t2189):** `origin:interactive` PRs idle >4h with no active claim stamp auto-transfer to `origin:worker-takeover` for CI-fix/conflict pipelines. Apply `no-takeover` to opt out. Override via `IDLE_INTERACTIVE_HANDOVER_SECONDS` env var (default 14400). Full detail and env controls: `reference/session.md`.
 
 **Traceability and signature footer:** Hard rules: see "Framework Rules > Git Workflow > Traceability" and "Framework Rules > Signature footer hallucination" above. Link both sides when closing (issue→PR, PR→issue). Do NOT pass `--issue` when creating new issues (the issue doesn't exist yet). See `scripts/commands/pulse.md` for dispatch/kill/merge comment templates.
 

--- a/.agents/reference/session.md
+++ b/.agents/reference/session.md
@@ -45,7 +45,7 @@ worktree-helper.sh add feature/x  # Fallback
 
 ## Idle Interactive PR Handover (t2189)
 
-When an `origin:interactive` PR sits >24h with a failing required check, a conflict, or an idle review, and the human session has demonstrably ended — no active `status:*` label on the linked issue AND no live claim stamp in `$CLAIM_STAMP_DIR` — the deterministic merge pass:
+When an `origin:interactive` PR sits >4h with a failing required check, a conflict, or an idle review, and the human session has demonstrably ended — no active `status:*` label on the linked issue AND no live claim stamp in `$CLAIM_STAMP_DIR` — the deterministic merge pass:
 
 1. Applies the `origin:worker-takeover` label
 2. Posts a one-time handover comment (`<!-- pulse-interactive-handover -->`)
@@ -59,7 +59,7 @@ When an `origin:interactive` PR sits >24h with a failing required check, a confl
 
 Env controls:
 - `AIDEVOPS_INTERACTIVE_PR_HANDOVER_MODE=off|detect|enforce` (default `detect` — logs `would-handover` without acting). Flip to `enforce` after 2-3 pulse cycles of clean `detect` telemetry.
-- `AIDEVOPS_INTERACTIVE_PR_HANDOVER_HOURS` (default 24)
+- `IDLE_INTERACTIVE_HANDOVER_SECONDS` (default 14400 = 4h; t2948 reduced from 86400 = 24h). Set to 86400 to restore the prior 24h behaviour.
 
 ## Browser Automation
 

--- a/.agents/scripts/pulse-diagnose-helper.sh
+++ b/.agents/scripts/pulse-diagnose-helper.sh
@@ -113,7 +113,7 @@ pw-route-review-fix|pulse-merge-feedback.sh|574|_dispatch_pr_fix_worker: routed 
 pw-route-review-empty|pulse-merge-feedback.sh|536|_dispatch_pr_fix_worker: PR #.*CHANGES_REQUESTED but no substantive|Review fix skipped — CHANGES_REQUESTED but no substantive review content
 pw-feedback-routed|pulse-merge-feedback.sh|153|already has routed feedback marker|Feedback routing skipped — already routed for this PR
 pw-feedback-body-fail|pulse-merge-feedback.sh|145|failed to fetch issue.*body.*skipping body edit|Feedback routing skipped — failed to fetch issue body
-pmc-handover|pulse-merge-conflict.sh|308|handover: PR #.*handed over to worker pipeline|Interactive PR handed over to worker pipeline (idle >24h)
+pmc-handover|pulse-merge-conflict.sh|308|handover: PR #.*handed over to worker pipeline|Interactive PR handed over to worker pipeline (idle >IDLE_INTERACTIVE_HANDOVER_SECONDS, default 4h)
 pmc-would-handover|pulse-merge-conflict.sh|212|would-handover: PR #|Would-handover detected (detect mode — not acting)
 pmc-handover-no-takeover|pulse-merge-conflict.sh|166|_interactive_pr_is_stale: PR #.*has no-takeover label|Handover skipped — PR has no-takeover label
 pmc-skip-interactive-close|pulse-merge-conflict.sh|583|Deterministic merge: skipping auto-close of origin:interactive PR|Skipped auto-close of origin:interactive PR — maintainer work never auto-closed

--- a/.agents/scripts/pulse-merge-conflict.sh
+++ b/.agents/scripts/pulse-merge-conflict.sh
@@ -45,6 +45,11 @@ _PULSE_MERGE_CONFLICT_LOADED=1
 # is sourced outside the pulse-wrapper.sh bootstrap context.
 : "${LOGFILE:=${HOME}/.aidevops/logs/pulse.log}"
 
+# t2948: Idle interactive PR handover threshold in seconds (default 4h).
+# Override via IDLE_INTERACTIVE_HANDOVER_SECONDS env var.
+# See _interactive_pr_is_stale / _interactive_pr_trigger_handover.
+: "${IDLE_INTERACTIVE_HANDOVER_SECONDS:=14400}"
+
 #######################################
 # GH#18650 (Fix 4): Post a one-time rebase nudge on an origin:interactive
 # CONFLICTING PR that the pulse is about to skip.
@@ -201,7 +206,7 @@ Every pulse cycle the deterministic merge pass evaluates open PRs with merge con
 #      in-review, claimed) — an active status means a human is driving it
 #   3. No live claim stamp file in $CLAIM_STAMP_DIR for the linked issue
 #      (session is gone; no interactive-session-helper.sh claim active)
-#   4. PR updatedAt older than AIDEVOPS_INTERACTIVE_PR_HANDOVER_HOURS (24h)
+#   4. PR updatedAt older than IDLE_INTERACTIVE_HANDOVER_SECONDS (default 14400 = 4h)
 #   5. Linked issue is open (don't touch PRs whose issue was already closed)
 #
 # Env controls:
@@ -209,7 +214,7 @@ Every pulse cycle the deterministic merge pass evaluates open PRs with merge con
 #     off:     returns 1 unconditionally (feature disabled)
 #     detect:  evaluates signal and logs would-handover decisions; still returns signal
 #     enforce: evaluates signal and returns it; caller acts
-#   AIDEVOPS_INTERACTIVE_PR_HANDOVER_HOURS — age threshold hours, default 24
+#   IDLE_INTERACTIVE_HANDOVER_SECONDS — age threshold seconds, default 14400 (4h; t2948)
 #
 # Args: $1 = pr_number, $2 = repo_slug
 # Returns: 0 if stale (handover-eligible), 1 otherwise
@@ -242,13 +247,13 @@ _interactive_pr_is_stale() {
 	fi
 
 	# Gate 4: age threshold (check before any other gh calls — cheapest filter)
-	local threshold_hours updated_at now_epoch updated_epoch pr_age_hours
-	threshold_hours="${AIDEVOPS_INTERACTIVE_PR_HANDOVER_HOURS:-24}"
+	local threshold_secs updated_at now_epoch updated_epoch pr_age_secs
+	threshold_secs="${IDLE_INTERACTIVE_HANDOVER_SECONDS:-14400}"  # default 4h (t2948; was 24h)
 	# t2383 Fix 2: validate threshold is a positive integer before arithmetic.
-	# A non-numeric value (e.g. "24h", empty, negative) triggers bash
+	# A non-numeric value (e.g. "4h", empty, negative) triggers bash
 	# "value too great for base" and silently breaks stale detection.
-	if [[ ! "$threshold_hours" =~ ^[0-9]+$ ]] || [[ "$threshold_hours" -eq 0 ]]; then
-		echo "[pulse-wrapper] _interactive_pr_is_stale: invalid AIDEVOPS_INTERACTIVE_PR_HANDOVER_HOURS='${threshold_hours}' — must be a positive integer, returning not-stale (t2383)" >>"$LOGFILE"
+	if [[ ! "$threshold_secs" =~ ^[0-9]+$ ]] || [[ "$threshold_secs" -eq 0 ]]; then
+		echo "[pulse-wrapper] _interactive_pr_is_stale: invalid IDLE_INTERACTIVE_HANDOVER_SECONDS='${threshold_secs}' — must be a positive integer, returning not-stale (t2383)" >>"$LOGFILE"
 		return 1
 	fi
 	updated_at=$(printf '%s' "$pr_meta" | jq -r '.updatedAt // empty')
@@ -258,8 +263,8 @@ _interactive_pr_is_stale() {
 	updated_epoch=$(date -d "$updated_at" +%s 2>/dev/null) || \
 		updated_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$updated_at" +%s 2>/dev/null) || \
 		return 1
-	pr_age_hours=$(( (now_epoch - updated_epoch) / 3600 ))
-	[[ "$pr_age_hours" -lt "$threshold_hours" ]] && return 1
+	pr_age_secs=$(( now_epoch - updated_epoch ))
+	[[ "$pr_age_secs" -lt "$threshold_secs" ]] && return 1
 
 	# Gate 2 + 5: resolve linked issue, verify open, check status labels
 	local linked_issue
@@ -283,7 +288,7 @@ _interactive_pr_is_stale() {
 
 	# All gates passed — PR is stale. Log in detect mode.
 	if [[ "$mode" == "detect" ]]; then
-		echo "[pulse-wrapper] would-handover: PR #${pr_number} in ${repo_slug} (idle ${pr_age_hours}h >= ${threshold_hours}h, linked issue #${linked_issue})" >>"$LOGFILE"
+		echo "[pulse-wrapper] would-handover: PR #${pr_number} in ${repo_slug} (idle $((pr_age_secs / 3600))h >= $((threshold_secs / 3600))h, linked issue #${linked_issue})" >>"$LOGFILE"
 	fi
 	return 0
 }
@@ -348,10 +353,10 @@ _interactive_pr_trigger_handover() {
 	# Post one-time handover comment via _gh_idempotent_comment
 	if declare -F _gh_idempotent_comment >/dev/null 2>&1; then
 		local marker="<!-- pulse-interactive-handover -->"
-		local threshold="${AIDEVOPS_INTERACTIVE_PR_HANDOVER_HOURS:-24}"
+		local threshold_h=$(( ${IDLE_INTERACTIVE_HANDOVER_SECONDS:-14400} / 3600 ))
 		local body
 		body="${marker}
-## Worker takeover — no interactive session activity for ${threshold}h
+## Worker takeover — no interactive session activity for ${threshold_h}h
 
 This \`origin:interactive\` PR has been idle past the handover threshold. The pulse is now routing it through the worker pipeline to drive it to merge:
 

--- a/.agents/scripts/pulse-merge-conflict.sh
+++ b/.agents/scripts/pulse-merge-conflict.sh
@@ -247,8 +247,8 @@ _interactive_pr_is_stale() {
 	fi
 
 	# Gate 4: age threshold (check before any other gh calls — cheapest filter)
-	local threshold_secs updated_at now_epoch updated_epoch pr_age_secs
-	threshold_secs="${IDLE_INTERACTIVE_HANDOVER_SECONDS:-14400}"  # default 4h (t2948; was 24h)
+	local threshold_secs="${IDLE_INTERACTIVE_HANDOVER_SECONDS:-14400}"  # default 4h (t2948; was 24h)
+	local updated_at="" now_epoch=0 updated_epoch=0 pr_age_secs=0
 	# t2383 Fix 2: validate threshold is a positive integer before arithmetic.
 	# A non-numeric value (e.g. "4h", empty, negative) triggers bash
 	# "value too great for base" and silently breaks stale detection.


### PR DESCRIPTION
## Summary

Reduces the idle interactive PR handover threshold (t2189) from 24h to 4h and exposes it as an env-controlled constant, matching the pattern established by t2942 (STAMPLESS_INTERACTIVE_AGE_THRESHOLD 24h→1h).

## Changes

### `pulse-merge-conflict.sh`
- Replaced `AIDEVOPS_INTERACTIVE_PR_HANDOVER_HOURS` (hours-based, default 24) with `IDLE_INTERACTIVE_HANDOVER_SECONDS` (seconds-based, default 14400 = 4h)
- Added module-level default constant (`: "${IDLE_INTERACTIVE_HANDOVER_SECONDS:=14400}"`) for set -u safety
- Consistent with `STAMPLESS_INTERACTIVE_AGE_THRESHOLD` pattern from t2942

### `AGENTS.md`
- Updated t2189 paragraph: 24h → 4h, added `IDLE_INTERACTIVE_HANDOVER_SECONDS` env var note

### `reference/session.md`
- Updated threshold to 4h; documented `IDLE_INTERACTIVE_HANDOVER_SECONDS` with restore-to-24h hint

### `pulse-diagnose-helper.sh`
- Updated event inventory description to reference the env var instead of hardcoded 24h

## Precedent

- t2942: STAMPLESS_INTERACTIVE_AGE_THRESHOLD 24h→1h
- t2947: sibling backoff reduction in same audit pass

## Verification

```bash
# Default reflects new threshold
unset IDLE_INTERACTIVE_HANDOVER_SECONDS
bash -c 'source .agents/scripts/pulse-merge-conflict.sh 2>/dev/null; echo "${IDLE_INTERACTIVE_HANDOVER_SECONDS}"'
# expected: 14400

# AGENTS.md mentions 4h and the env var
grep -A2 "Idle interactive PR handover" .agents/AGENTS.md | grep -E "4h|IDLE_INTERACTIVE_HANDOVER_SECONDS"

# ShellCheck clean
shellcheck .agents/scripts/pulse-merge-conflict.sh
```

Resolves #21183

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.27 with claude-sonnet-4-6 spent 5m and 16,686 tokens on this as a headless worker.