### PR TITLE
t2947: reduce FAST_FAIL_AGE_OUT_SECONDS default 86400→3600 (1h)

### DIFF
--- a/.agents/scripts/pulse-fast-fail.sh
+++ b/.agents/scripts/pulse-fast-fail.sh
@@ -528,7 +528,7 @@ _fast_fail_age_out_locked() {
 	fi
 
 	# Quiet-period check: last failure must be >= AGE_OUT_SECONDS ago.
-	local age_out_secs="${FAST_FAIL_AGE_OUT_SECONDS:-86400}"
+	local age_out_secs="${FAST_FAIL_AGE_OUT_SECONDS:-3600}"
 	local age
 	age=$((now - existing_ts))
 	if [[ "$age" -lt "$age_out_secs" ]]; then


### PR DESCRIPTION
## What

Reduces `FAST_FAIL_AGE_OUT_SECONDS` default in `pulse-fast-fail.sh:531` from 86400 (24h) to 3600 (1h).

## Why

t2942 made the same reduction for `STAMPLESS_INTERACTIVE_AGE_THRESHOLD` (PR #21159, commit `a0cde4adf`) and shipped without incident. This is the parallel fix for the fast-fail age-out path. With 24 concurrent workers and a 600s pulse interval, abandonment is detected within minutes — a 24h recovery window is a 1440× mismatch. Stale fast-fail records block dispatch for up to 24h after they should have aged out.

## Changes

- `EDIT: .agents/scripts/pulse-fast-fail.sh:531` — `:-86400` → `:-3600`

## Verification

- ShellCheck: zero violations
- Default value: `:-3600` confirmed via grep
- Env override: `FAST_FAIL_AGE_OUT_SECONDS=7200` respected (verified)

## Precedent

t2942 (PR #21159, commit `a0cde4adf`) — same env-var-with-default pattern, same threshold magnitude, same justification class.

Resolves #21226
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.26 with claude-sonnet-4-6 spent 1m and 2,967 tokens on this as a headless worker.
