### PR TITLE
t2958: fix observability.mjs command injection and staleness robustness

### DIFF
--- a/.agents/plugins/opencode-aidevops/observability.mjs
+++ b/.agents/plugins/opencode-aidevops/observability.mjs
@@ -15,7 +15,7 @@
  */
 
 import {
-  mkdirSync, readFileSync, writeFileSync, existsSync, rmdirSync, unlinkSync,
+  mkdirSync, readFileSync, writeFileSync, existsSync, rmdirSync, unlinkSync, statSync,
 } from "fs";
 import { join, dirname } from "path";
 import { homedir } from "os";
@@ -200,12 +200,17 @@ function initDatabase() {
 function _isSchemaInitialized() {
   try {
     const result = execSync(
-      `sqlite3 -readonly -separator '|' "${DB_PATH}" ` +
-      `"SELECT ` +
-      `(SELECT COUNT(*) FROM sqlite_master WHERE type='table' ` +
-      `AND name IN ('llm_requests','tool_calls','session_summaries')) AS tbls, ` +
-      `(SELECT COUNT(*) FROM pragma_table_info('tool_calls') WHERE name='intent') AS intent_col;"`,
-      { encoding: "utf-8", timeout: 2000, stdio: ["pipe", "pipe", "pipe"] },
+      "sqlite3 -readonly -separator '|' \"$TARGET_DB\" " +
+      "\"SELECT " +
+      "(SELECT COUNT(*) FROM sqlite_master WHERE type='table' " +
+      "AND name IN ('llm_requests','tool_calls','session_summaries')) AS tbls, " +
+      "(SELECT COUNT(*) FROM pragma_table_info('tool_calls') WHERE name='intent') AS intent_col;\"",
+      {
+        encoding: "utf-8",
+        timeout: 2000,
+        stdio: ["pipe", "pipe", "pipe"],
+        env: { ...process.env, TARGET_DB: DB_PATH },
+      },
     ).trim();
     if (!result) return false;
     const [tbls, intentCol] = result.split("|");
@@ -429,11 +434,24 @@ function _isInitLockStale(ownerFile, staleMs) {
   try {
     const { pid, ts } = JSON.parse(readFileSync(ownerFile, "utf-8"));
     const processGone = (() => {
-      try { process.kill(pid, 0); return false; } catch { return true; }
+      try {
+        process.kill(pid, 0);
+        return false;
+      } catch (e) {
+        // ESRCH = no such process (gone); EPERM = exists but owned by another user
+        return e.code === "ESRCH";
+      }
     })();
     return processGone || (Date.now() - ts > staleMs);
   } catch {
-    return false;
+    // Owner file missing or corrupt (e.g. killed between mkdirSync and writeFileSync).
+    // Fall back to the lock directory's mtime as a reliable staleness signal.
+    try {
+      const stats = statSync(dirname(ownerFile));
+      return (Date.now() - stats.mtimeMs) > staleMs;
+    } catch {
+      return false;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

Review followup for PR #21046 — three improvements to `observability.mjs` flagged by Gemini code review.

## Changes

### 1. Fix command injection in `_isSchemaInitialized` (high priority)

`DB_PATH` was interpolated directly into a shell command string, allowing command injection if `AIDEVOPS_OBS_DB_OVERRIDE` contains shell metacharacters or spaces. Fixed by passing the path via `env.TARGET_DB` and referencing `$TARGET_DB` in the shell command instead.

### 2. Add `statSync` to `fs` imports (medium priority)

`statSync` is now imported alongside the other `fs` functions — required for the directory mtime fallback in `_isInitLockStale`.

### 3. Improve `_isInitLockStale` robustness (medium priority)

Two improvements:
- **ESRCH specificity**: `process.kill(pid, 0)` previously returned `true` on any error including `EPERM`. Now returns `true` only on `ESRCH` — so a lock owned by another user is not incorrectly treated as stale.
- **Missing owner file fallback**: When the owner file is missing or corrupt, falls back to `statSync` on the lock directory mtime instead of returning `false` and waiting the full 30s timeout.

Resolves #21173