### PR TITLE
GH#21006: guard nohup log redirection against unwritable path in _worktree_exclusions

### DIFF
--- a/.agents/scripts/setup/_worktree_exclusions.sh
+++ b/.agents/scripts/setup/_worktree_exclusions.sh
@@ -63,8 +63,15 @@ setup_worktree_exclusions() {
 		local log_dir="${HOME}/.aidevops/logs"
 		mkdir -p "$log_dir" 2>/dev/null || true
 		local log_file="${log_dir}/worktree-exclusions-backfill.log"
-		print_info "Applying worktree exclusions in background → $log_file"
-		nohup "$helper" backfill >>"$log_file" 2>&1 </dev/null &
+		# Guard the log-file redirection: if $log_dir was not created above
+		# (e.g. unwritable parent directory), a bare >>"$log_file" would fail
+		# and abort the caller (setup.sh runs with set -Eeuo pipefail +
+		# inherit_errexit).  Probe writability; fall back to /dev/null so the
+		# nohup launch is always best-effort regardless of disk/permission state.
+		local log_dest="$log_file"
+		{ true >> "$log_dest"; } 2>/dev/null || log_dest="/dev/null"
+		print_info "Applying worktree exclusions in background → $log_dest"
+		nohup "$helper" backfill >> "$log_dest" 2>&1 </dev/null &
 		disown 2>/dev/null || true
 	fi
 


### PR DESCRIPTION
## Summary

Guard the `nohup` log-file redirection in `setup_worktree_exclusions` against an
unwritable `$HOME/.aidevops/logs` directory.

`setup.sh` runs with `set -Eeuo pipefail` + `inherit_errexit`. If `mkdir -p "$log_dir"`
silently fails (suppressed by `2>/dev/null || true`), a bare `>> "$log_file"` on the
`nohup` line aborts the entire `aidevops update`/setup path — the opposite of the
intended best-effort behaviour.

## Fix

Before the `nohup` launch, probe writability with a null append:

```bash
local log_dest="$log_file"
{ true >> "$log_dest"; } 2>/dev/null || log_dest="/dev/null"
```

If the probe fails (permission denied, path unresolvable), `log_dest` falls back to
`/dev/null` and the background backfill runs without logging rather than aborting
setup. ShellCheck passes at zero violations.

## Files

- `EDIT: .agents/scripts/setup/_worktree_exclusions.sh:62-76` — writability probe +
  `log_dest` variable replacing the bare `log_file` redirect

## Verification

```
shellcheck .agents/scripts/setup/_worktree_exclusions.sh
```
Expected: no output (zero violations).

Resolves #21006

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.26 with claude-sonnet-4-6 spent 4m and 10,715 tokens on this as a headless worker.
