### PR TITLE
t2959: fix generate-runtime-config.sh stat portability and redundant hash recompute

### DIFF
--- a/.agents/scripts/generate-runtime-config.sh
+++ b/.agents/scripts/generate-runtime-config.sh
@@ -84,14 +84,31 @@ RUNTIME_CACHE_HASH_FILE_PREFIX="${AGENTS_DIR}/.runtime-config-source-hash"
 # Includes: the script itself + all source .md/.toml/.json files under AGENTS_DIR.
 # Uses file metadata (name/size/mtime) for speed (~10ms for 1600 files)
 # rather than content hashing (~80s per runtime).
-# NOTE: stat -f is macOS/BSD syntax; on Linux it silently fails (2>/dev/null)
-# producing an empty hash, which forces regeneration — acceptable behaviour.
+# Portable: stat -f is macOS/BSD; stat -c is Linux/GNU. Detected via uname.
+# If metadata collection fails entirely, returns a unique no-cache sentinel so
+# the cache is safely bypassed rather than producing a stale constant hash.
 compute_runtime_source_hash() {
-	{
-		stat -f '%N %z %m' "${BASH_SOURCE[0]}" 2>/dev/null
-		find "$AGENTS_DIR" -type f \( -name "*.md" -o -name "*.toml" -o -name "*.json" \) \
-			-exec stat -f '%N %z %m' {} + 2>/dev/null
-	} | LC_ALL=C sort | shasum -a 256 | cut -d' ' -f1
+	local metadata
+	if [[ "$(uname -s)" == "Darwin" ]]; then
+		metadata=$({
+			stat -f '%N %z %m' "${BASH_SOURCE[0]}"
+			find "$AGENTS_DIR" -type f \( -name "*.md" -o -name "*.toml" -o -name "*.json" \) \
+				-exec stat -f '%N %z %m' {} + 2>/dev/null
+		})
+	else
+		# Linux/GNU stat uses -c instead of -f
+		metadata=$({
+			stat -c '%n %s %Y' "${BASH_SOURCE[0]}"
+			find "$AGENTS_DIR" -type f \( -name "*.md" -o -name "*.toml" -o -name "*.json" \) \
+				-exec stat -c '%n %s %Y' {} + 2>/dev/null
+		})
+	fi
+
+	# If metadata collection failed entirely, return a unique sentinel so the
+	# cache is bypassed rather than storing a false constant-hash cache hit.
+	[[ -z "$metadata" ]] && { echo "no-cache-${RANDOM}"; return 0; }
+
+	echo "$metadata" | LC_ALL=C sort | shasum -a 256 | cut -d' ' -f1
 	return 0
 }
 
@@ -1404,10 +1421,10 @@ _generate_for_runtime() {
 
 	# Write the source hash after successful generation so the next invocation
 	# can skip regeneration when inputs are unchanged.
+	# Reuse current_hash computed at the top of this function — avoids a
+	# redundant stat scan across 1600+ files.
 	if [[ "$_SKIP_CACHE" == false ]]; then
-		local new_hash
-		new_hash=$(compute_runtime_source_hash)
-		echo "$new_hash" >"${RUNTIME_CACHE_HASH_FILE_PREFIX}-${runtime_id}"
+		echo "$current_hash" >"${RUNTIME_CACHE_HASH_FILE_PREFIX}-${runtime_id}"
 	fi
 
 	return 0

--- a/.agents/scripts/generate-runtime-config.sh
+++ b/.agents/scripts/generate-runtime-config.sh
@@ -96,12 +96,14 @@ compute_runtime_source_hash() {
 				-exec stat -f '%N %z %m' {} + 2>/dev/null
 		})
 	else
-		# Linux/GNU stat uses -c instead of -f
-		metadata=$({
-			stat -c '%n %s %Y' "${BASH_SOURCE[0]}"
-			find "$AGENTS_DIR" -type f \( -name "*.md" -o -name "*.toml" -o -name "*.json" \) \
-				-exec stat -c '%n %s %Y' {} + 2>/dev/null
-		})
+		# Linux/GNU stat uses -c instead of -f; guarded by uname branch above.
+		local script_meta find_meta
+		# shell-portability: ignore next
+		script_meta=$(stat -c '%n %s %Y' "${BASH_SOURCE[0]}" 2>/dev/null || true)
+		# shell-portability: ignore next
+		find_meta=$(find "$AGENTS_DIR" -type f \( -name "*.md" -o -name "*.toml" -o -name "*.json" \) \
+			-exec stat -c '%n %s %Y' {} + 2>/dev/null || true)
+		metadata="${script_meta}"$'\n'"${find_meta}"
 	fi
 
 	# If metadata collection failed entirely, return a unique sentinel so the


### PR DESCRIPTION
## Summary

Addresses two review bot findings from PR #21064 (t2910: cache generate-runtime-config.sh):

**1. Linux portability fix (high priority — gemini-code-assist)**

`compute_runtime_source_hash` used `stat -f '%N %z %m'` (macOS/BSD syntax) unconditionally. On Linux, `stat -f` fails silently, producing an empty string that `shasum` turns into a fixed constant hash. This caused a cache correctness bug: after the first generation, the constant hash would be stored, and every subsequent run would match it regardless of actual file changes, causing the cache to always report a false hit on Linux.

Fix: detect OS via `uname -s`, use `stat -c '%n %s %Y'` (GNU stat) on Linux. Empty-metadata fallback emits `no-cache-${RANDOM}` to force regeneration safely rather than caching a constant empty-hash false positive.

**2. Redundant hash recomputation (medium priority — gemini-code-assist)**

`_generate_for_runtime` called `compute_runtime_source_hash` twice: once at the top for the cache check (stored in `current_hash`), and again at the bottom to write the updated hash file after generation. The second call scanned 1600+ files unnecessarily.

Fix: reuse `current_hash` (already in scope from the first block) when writing the hash file.

## Files modified

- `EDIT: .agents/scripts/generate-runtime-config.sh:89-96` — `compute_runtime_source_hash` portability + sentinel
- `EDIT: .agents/scripts/generate-runtime-config.sh:1407-1411` — reuse `current_hash`, remove redundant scan

## Verification

- `shellcheck .agents/scripts/generate-runtime-config.sh` → zero violations
- Pre-commit hook passed (no regressions)

Resolves #21170

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.27 with claude-sonnet-4-6 spent 5m and 10,761 tokens on this as a headless worker.
