### PR TITLE
t2960: fix: use AGENTS_DIR for pulse helper path in cmd_update

### DIFF
--- a/aidevops.sh
+++ b/aidevops.sh
@@ -779,7 +779,7 @@ cmd_update() {
 	# 'restart-if-running' do). Non-fatal: a pulse start failure should
 	# not fail the update.
 	if [[ "${AIDEVOPS_SKIP_PULSE_RESTART:-0}" != "1" ]]; then
-		local _pulse_helper="${HOME}/.aidevops/agents/scripts/pulse-lifecycle-helper.sh"
+		local _pulse_helper="${AGENTS_DIR}/scripts/pulse-lifecycle-helper.sh"
 		if [[ -x "$_pulse_helper" ]]; then
 			"$_pulse_helper" start >/dev/null 2>&1 || print_warning "Pulse start failed (non-fatal)"
 		fi


### PR DESCRIPTION
## What

Use `${AGENTS_DIR}/scripts/pulse-lifecycle-helper.sh` instead of
`${HOME}/.aidevops/agents/scripts/pulse-lifecycle-helper.sh` in `cmd_update()`.

## Why

When `aidevops update` is run with `sudo`, `${HOME}` resolves to `/root`
while the agents are installed under the real user's home directory.
`AGENTS_DIR` is already set from `$_AIDEVOPS_REAL_HOME` (lines 30–38),
which correctly resolves the real home via `getent` even under sudo,
making this consistent with every other `AGENTS_DIR` reference in the script.

**File changed:** `aidevops.sh:782` — one-line substitution.

## How

Single-line edit replacing `${HOME}/.aidevops/agents` with `${AGENTS_DIR}`.
ShellCheck zero violations before and after.

## Verification

- `shellcheck aidevops.sh` — passes (no output)
- Pre-commit and pre-push hooks passed cleanly

Resolves #21167


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.27 with claude-sonnet-4-6 spent 4m and 3,639 tokens on this as a headless worker.