### PR TITLE
fix: address gemini review feedback on t2913 gh-wrapper timeout changes

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -715,18 +715,12 @@ _rest_issue_view() {
 	local _path="/repos/${repo}/issues/${num}"
 	# t2913: wall-clock timeout via _gh_with_timeout (defined in shared-gh-wrappers.sh).
 	# Fail-open if helper not loaded — invoke gh api directly.
+	local _gh_cmd=(gh api "$_path")
+	[[ -n "$jq_expr" ]] && _gh_cmd+=(--jq "$jq_expr")
 	if command -v _gh_with_timeout >/dev/null 2>&1; then
-		if [[ -n "$jq_expr" ]]; then
-			_gh_with_timeout read gh api "$_path" --jq "$jq_expr"
-		else
-			_gh_with_timeout read gh api "$_path"
-		fi
+		_gh_with_timeout read "${_gh_cmd[@]}"
 	else
-		if [[ -n "$jq_expr" ]]; then
-			gh api "$_path" --jq "$jq_expr"
-		else
-			gh api "$_path"
-		fi
+		"${_gh_cmd[@]}"
 	fi
 	return $?
 }
@@ -795,18 +789,12 @@ _rest_pr_list() {
 
 	local _path="/repos/${repo}/pulls?${_query}"
 	# t2913: wall-clock timeout via _gh_with_timeout (defined in shared-gh-wrappers.sh).
+	local _gh_cmd=(gh api "$_path")
+	[[ -n "$jq_expr" ]] && _gh_cmd+=(--jq "$jq_expr")
 	if command -v _gh_with_timeout >/dev/null 2>&1; then
-		if [[ -n "$jq_expr" ]]; then
-			_gh_with_timeout read gh api "$_path" --jq "$jq_expr"
-		else
-			_gh_with_timeout read gh api "$_path"
-		fi
+		_gh_with_timeout read "${_gh_cmd[@]}"
 	else
-		if [[ -n "$jq_expr" ]]; then
-			gh api "$_path" --jq "$jq_expr"
-		else
-			gh api "$_path"
-		fi
+		"${_gh_cmd[@]}"
 	fi
 	return $?
 }
@@ -884,18 +872,12 @@ _rest_issue_list() {
 
 	local _path="/repos/${repo}/issues?${_query}"
 	# t2913: wall-clock timeout via _gh_with_timeout (defined in shared-gh-wrappers.sh).
+	local _gh_cmd=(gh api "$_path")
+	[[ -n "$jq_expr" ]] && _gh_cmd+=(--jq "$jq_expr")
 	if command -v _gh_with_timeout >/dev/null 2>&1; then
-		if [[ -n "$jq_expr" ]]; then
-			_gh_with_timeout read gh api "$_path" --jq "$jq_expr"
-		else
-			_gh_with_timeout read gh api "$_path"
-		fi
+		_gh_with_timeout read "${_gh_cmd[@]}"
 	else
-		if [[ -n "$jq_expr" ]]; then
-			gh api "$_path" --jq "$jq_expr"
-		else
-			gh api "$_path"
-		fi
+		"${_gh_cmd[@]}"
 	fi
 	return $?
 }

--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -101,7 +101,7 @@ fi
 # only source the conf file if the env var is unset, so an explicit env
 # override (e.g. for a slow-network runner) is never silently overwritten.
 if [[ -n "$_SHARED_GH_WRAPPERS_DIR" && -f "$_SHARED_GH_WRAPPERS_DIR/../configs/pulse-rate-limit.conf" ]]; then
-	if [[ -z "${AIDEVOPS_GH_READ_TIMEOUT+x}" ]] || [[ -z "${AIDEVOPS_GH_WRITE_TIMEOUT+x}" ]]; then
+	if [[ -z "${AIDEVOPS_GH_READ_TIMEOUT+x}" ]] && [[ -z "${AIDEVOPS_GH_WRITE_TIMEOUT+x}" ]]; then
 		# shellcheck disable=SC1091
 		source "$_SHARED_GH_WRAPPERS_DIR/../configs/pulse-rate-limit.conf"
 	fi


### PR DESCRIPTION
## Summary

Address two classes of review bot feedback from Gemini on PR #21068 (t2913: gh wall-clock timeout wrapper):

- **Bug fix (HIGH):** `shared-gh-wrappers.sh:104` — `||` → `&&` in conf-file guard
- **Refactor (MEDIUM):** `shared-gh-wrappers-rest-fallback.sh:730/810/899` — bash array pattern replaces nested if/else

## Changes

### Bug fix: `||` → `&&` in timeout conf-file guard (`shared-gh-wrappers.sh:104`)

The original condition sourced `pulse-rate-limit.conf` if *either* timeout env var was unset:
```bash
if [[ -z "${AIDEVOPS_GH_READ_TIMEOUT+x}" ]] || [[ -z "${AIDEVOPS_GH_WRITE_TIMEOUT+x}" ]]; then
```
This silently overwrites a user-set env var: if `AIDEVOPS_GH_READ_TIMEOUT=30` is exported but `AIDEVOPS_GH_WRITE_TIMEOUT` is not, the `||` condition is true, the conf file is sourced, and the user's `30` is lost. Fixed to `&&` — the conf file is only sourced when *neither* var is set; the `: "${VAR:=default}"` fallback below handles any individually-unset var.

### Refactor: bash array pattern in REST fallback functions

Three identical nested if/else blocks in `_rest_issue_view`, `_rest_pr_list`, and `_rest_issue_list` are replaced with a bash array that accumulates optional args before the `command -v _gh_with_timeout` check:
```bash
local _gh_cmd=(gh api "$_path")
[[ -n "$jq_expr" ]] && _gh_cmd+=(--jq "$jq_expr")
if command -v _gh_with_timeout >/dev/null 2>&1; then
    _gh_with_timeout read "${_gh_cmd[@]}"
else
    "${_gh_cmd[@]}"
fi
```
Eliminates 18 redundant lines while preserving identical runtime behaviour. Bash array `+=` is supported from bash 3.1+ (macOS default is 3.2).

## Verification

- `shellcheck .agents/scripts/shared-gh-wrappers.sh` — zero new violations (3 pre-existing SC2016 info notices, unchanged)
- `shellcheck .agents/scripts/shared-gh-wrappers-rest-fallback.sh` — zero violations

Resolves #21169
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.27 with claude-sonnet-4-6 spent 5m and 8,982 tokens on this as a headless worker.
