### PR TITLE
t2958: fix review followup for t2902 instrumentation — printf builtin, slash-guard, prefetch dedup

### DIFF
--- a/.agents/scripts/gh-api-instrument.sh
+++ b/.agents/scripts/gh-api-instrument.sh
@@ -99,8 +99,14 @@ gh_record_call() {
 		[[ -z "$caller" || "$caller" == "-bash" || "$caller" == "bash" ]] && caller="unknown"
 	fi
 	local ts
-	ts=$(date +%s 2>/dev/null) || return 0
-	mkdir -p "${GH_API_LOG%/*}" 2>/dev/null || true
+	# Use bash builtin printf for timestamp when available (bash 4.2+) to avoid
+	# forking a date subprocess on every call in this high-frequency path.
+	# Falls back to date(1) for bash < 4.2; fails safe by returning 0.
+	printf -v ts '%(%s)T' -1 || ts=$(date +%s) || return 0
+	# Only create the parent dir when the path contains a slash — avoids
+	# creating a directory named like the log file on relative paths (e.g.
+	# AIDEVOPS_GH_API_LOG="gh.log" would expand ${GH_API_LOG%/*} to "gh.log").
+	[[ "$GH_API_LOG" == */* ]] && mkdir -p "${GH_API_LOG%/*}" 2>/dev/null || true
 	# Tab-separated; printf is atomic for short lines on POSIX file systems.
 	printf '%s\t%s\t%s\n' "$ts" "$caller" "$path" >>"$GH_API_LOG" 2>/dev/null || true
 	return 0

--- a/.agents/scripts/pulse-batch-prefetch-helper.sh
+++ b/.agents/scripts/pulse-batch-prefetch-helper.sh
@@ -346,14 +346,18 @@ _write_per_slug_caches() {
 # Fetch and cache issues for a single owner.
 # Sets _OWNER_SEARCH_CALLS, _OWNER_CACHE_WRITES, _OWNER_ERRORS (Bash 3.2 namerefs workaround)
 # Arguments: $1=owner  $2=slugs (comma-separated owner/repo list for REST fallback)
+#            $3=graphql_remaining (optional pre-computed integer; pass to avoid redundant
+#                                  rate-limit API calls when iterating over many owners)
 _refresh_owner_issues() {
 	local owner="$1"
 	local slugs="${2:-}"
+	local graphql_remaining="${3:-}"
 	# Proactive REST fallback (t2902): if GraphQL is at/below the fallback
 	# threshold, skip `gh search issues` (which uses the GraphQL Search API,
 	# ~30 points/call) and go straight to per-slug REST iteration. Avoids
 	# burning points on a call that will fail and then be retried via REST.
-	if _gh_should_fallback_to_rest 2>/dev/null; then
+	# Pass pre-computed remaining to avoid a redundant rate-limit API call per owner.
+	if _gh_should_fallback_to_rest "$graphql_remaining" 2>/dev/null; then
 		_log "GraphQL <= threshold — skipping gh search issues for owner=${owner}, going straight to REST"
 		gh_record_call search-rest 2>/dev/null || true
 		_prefetch_rest_per_slug issues "$slugs"
@@ -401,11 +405,15 @@ _refresh_owner_issues() {
 # Fetch and cache PRs for a single owner.
 # Sets _OWNER_SEARCH_CALLS, _OWNER_CACHE_WRITES, _OWNER_ERRORS
 # Arguments: $1=owner  $2=slugs (comma-separated owner/repo list for REST fallback)
+#            $3=graphql_remaining (optional pre-computed integer; pass to avoid redundant
+#                                  rate-limit API calls when iterating over many owners)
 _refresh_owner_prs() {
 	local owner="$1"
 	local slugs="${2:-}"
+	local graphql_remaining="${3:-}"
 	# Proactive REST fallback (t2902): same pattern as _refresh_owner_issues.
-	if _gh_should_fallback_to_rest 2>/dev/null; then
+	# Pass pre-computed remaining to avoid a redundant rate-limit API call per owner.
+	if _gh_should_fallback_to_rest "$graphql_remaining" 2>/dev/null; then
 		_log "GraphQL <= threshold — skipping gh search prs for owner=${owner}, going straight to REST"
 		gh_record_call search-rest 2>/dev/null || true
 		_prefetch_rest_per_slug prs "$slugs"
@@ -482,11 +490,21 @@ _cmd_refresh() {
 	_OWNER_CACHE_WRITES=0
 	_OWNER_ERRORS=0
 
+	# Pre-fetch GraphQL remaining once per refresh cycle (t2902 review followup).
+	# Both _refresh_owner_issues and _refresh_owner_prs call _gh_should_fallback_to_rest,
+	# which issues a `gh api rate_limit` call when no pre-computed value is supplied.
+	# With N owners that produces 2×N redundant API calls. Fetch here and pass the
+	# integer down so each per-owner function can reuse it without hitting the API again.
+	# Fail-open: if the fetch fails, an empty string is passed and the per-owner functions
+	# fall back to their own rate-limit call (the existing behaviour).
+	local _graphql_remaining=""
+	_graphql_remaining=$(gh api rate_limit --jq '.resources.graphql.remaining' 2>/dev/null) || _graphql_remaining=""
+
 	local owner slugs
 	while IFS='|' read -r owner slugs; do
 		[[ -n "$owner" ]] || continue
-		_refresh_owner_issues "$owner" "$slugs" || true
-		_refresh_owner_prs "$owner" "$slugs" || true
+		_refresh_owner_issues "$owner" "$slugs" "$_graphql_remaining" || true
+		_refresh_owner_prs "$owner" "$slugs" "$_graphql_remaining" || true
 	done <<<"$owner_groups"
 
 	_log "refresh complete: search_calls=${_OWNER_SEARCH_CALLS} cache_writes=${_OWNER_CACHE_WRITES} errors=${_OWNER_ERRORS}"


### PR DESCRIPTION
## Summary

Address three review bot findings from PR #21053 (t2902 instrumentation):

1. **`gh-api-instrument.sh` — use bash `printf` builtin for timestamp** (lines 101-102): Replace `ts=$(date +%s 2>/dev/null)` with `printf -v ts '%(%s)T' -1 || ts=$(date +%s) || return 0`. The bash 4.2+ builtin avoids forking a `date` subprocess on every call in a high-frequency instrumentation path. Falls back to `date` for older bash.

2. **`gh-api-instrument.sh` — slash-guard on `mkdir -p`** (line 103): Replace `mkdir -p "${GH_API_LOG%/*}"` with `[[ "$GH_API_LOG" == */* ]] && mkdir -p "${GH_API_LOG%/*}"`. Without the guard, a relative path without slashes (e.g. `AIDEVOPS_GH_API_LOG="gh.log"`) causes `${GH_API_LOG%/*}` to expand to the full filename, creating a directory named `gh.log` and causing the subsequent `printf >>` to fail silently.

3. **`pulse-batch-prefetch-helper.sh` — pre-fetch GraphQL remaining once per refresh cycle** (lines 356, 408, ~488): Add `_graphql_remaining=$(gh api rate_limit ...)` once in `_cmd_refresh` before the owner loop, and thread it down as a third arg to `_refresh_owner_issues` and `_refresh_owner_prs`. Both already called `_gh_should_fallback_to_rest` without args, triggering one `gh api rate_limit` call per owner per kind — 2×N calls per refresh cycle. The function already accepts an optional pre-computed arg; this change uses it.

All three findings are **Outcome B** (premise correct, fix obvious):
- ShellCheck passes on both files (zero violations).
- Pre-commit quality gate: passed.
- No behaviour change under normal conditions; changes only add efficiency or fix an edge case with unusual env-var values.

Resolves #21172

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.27 with claude-sonnet-4-6 spent 6m and 11,036 tokens on this as a headless worker.
