### PR TITLE
t2961: fix batch jq delimiter, missing input redirection, and base64 portability in reconcile_issues_single_pass

### DIFF
--- a/.agents/scripts/pulse-issue-reconcile.sh
+++ b/.agents/scripts/pulse-issue-reconcile.sh
@@ -2290,6 +2290,11 @@ reconcile_issues_single_pass() {
 	# Cycle-wide counters for log summary
 	local ciw_closed=0 rsd_closed=0 rsd_reset=0 lia_fixed=0
 
+	# Cross-platform base64 decode flag: GNU uses -d, BSD/macOS canonical is -D.
+	# Both flags work on modern macOS (10.15+), but -D is the documented BSD form.
+	local _b64d_flag="-d"
+	[[ "$(uname -s)" == "Darwin" ]] && _b64d_flag="-D"
+
 	while IFS= read -r slug; do
 		[[ -n "$slug" ]] || continue
 
@@ -2324,9 +2329,11 @@ reconcile_issues_single_pass() {
 		# into ~8 — eliminating the dominant per-cycle CPU overhead that
 		# pushed reconcile_issues_single_pass past the 600s
 		# PRE_RUN_STAGE_TIMEOUT in #21042. Title and body are base64-wrapped
-		# so embedded newlines/tabs survive round-trip; @tsv would otherwise
-		# escape \n / \t into literal markers and break consumers like
-		# _extract_children_section that need real newlines.
+		# so embedded newlines/tabs survive round-trip. join("|") is used
+		# instead of @tsv: IFS=$'\t' with read collapses consecutive tabs
+		# (empty fields) into a single delimiter, corrupting field offsets
+		# when labels_csv is empty. "|" is not an IFS whitespace character
+		# so consecutive "|" separators are never collapsed. See bash(1) IFS.
 		local issues_tsv
 		issues_tsv=$(printf '%s' "$issues_json" | jq -r '
 			.[] | [
@@ -2334,19 +2341,19 @@ reconcile_issues_single_pass() {
 				((.title // "") | @base64),
 				((.labels // []) | map(.name) | join(",")),
 				((.body // "") | @base64)
-			] | @tsv
-		' 2>/dev/null) || issues_tsv=""
+			] | join("|")
+		') || issues_tsv=""
 		[[ -n "$issues_tsv" ]] || continue
 
-		while IFS=$'\t' read -r issue_num issue_title_b64 labels_csv issue_body_b64; do
+		while IFS='|' read -r issue_num issue_title_b64 labels_csv issue_body_b64; do
 			[[ "$issue_num" =~ ^[0-9]+$ ]] || continue
 
 			local issue_title="" issue_body=""
 			if [[ -n "$issue_title_b64" ]]; then
-				issue_title=$(printf '%s' "$issue_title_b64" | base64 -d 2>/dev/null) || issue_title=""
+				issue_title=$(printf '%s' "$issue_title_b64" | base64 "$_b64d_flag" 2>/dev/null) || issue_title=""
 			fi
 			if [[ -n "$issue_body_b64" ]]; then
-				issue_body=$(printf '%s' "$issue_body_b64" | base64 -d 2>/dev/null) || issue_body=""
+				issue_body=$(printf '%s' "$issue_body_b64" | base64 "$_b64d_flag" 2>/dev/null) || issue_body=""
 			fi
 
 			# Stage 1: close issues whose dedup guard detects a merged PR
@@ -2436,7 +2443,7 @@ reconcile_issues_single_pass() {
 					lia_per_repo=$((lia_per_repo + 1))
 				fi
 			fi
-		done
+		done <<< "$issues_tsv"
 	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug // ""' "$repos_json" || true)
 
 	# t2838: persist last-run epoch when backfill actually ran this cycle.

--- a/.agents/scripts/tests/test-pulse-issue-reconcile.sh
+++ b/.agents/scripts/tests/test-pulse-issue-reconcile.sh
@@ -339,8 +339,8 @@ test_batched_field_extraction_parity() {
 			((.title // "") | @base64),
 			((.labels // []) | map(.name) | join(",")),
 			((.body // "") | @base64)
-		] | @tsv
-	' 2>/dev/null)
+		] | join("|")
+	')
 
 	local row_count
 	row_count=$(printf '%s\n' "$extracted" | grep -c .)
@@ -354,7 +354,7 @@ test_batched_field_extraction_parity() {
 
 	# Decode and verify row 1 (multiline + tab + UTF-8 body).
 	local r1_num r1_title_b64 r1_labels r1_body_b64 r1_title r1_body
-	IFS=$'\t' read -r r1_num r1_title_b64 r1_labels r1_body_b64 < <(printf '%s\n' "$extracted" | sed -n 1p)
+	IFS='|' read -r r1_num r1_title_b64 r1_labels r1_body_b64 < <(printf '%s\n' "$extracted" | sed -n 1p)
 	r1_title=$(printf '%s' "$r1_title_b64" | base64 -d 2>/dev/null)
 	r1_body=$(printf '%s' "$r1_body_b64" | base64 -d 2>/dev/null)
 
@@ -375,7 +375,7 @@ test_batched_field_extraction_parity() {
 
 	# Decode and verify row 2 (empty body, empty labels).
 	local r2_num r2_title_b64 r2_labels r2_body_b64 r2_title r2_body
-	IFS=$'\t' read -r r2_num r2_title_b64 r2_labels r2_body_b64 < <(printf '%s\n' "$extracted" | sed -n 2p)
+	IFS='|' read -r r2_num r2_title_b64 r2_labels r2_body_b64 < <(printf '%s\n' "$extracted" | sed -n 2p)
 	r2_title=$(printf '%s' "$r2_title_b64" | base64 -d 2>/dev/null)
 	# Empty body — base64-decode of empty input is empty.
 	r2_body=$(printf '%s' "$r2_body_b64" | base64 -d 2>/dev/null)


### PR DESCRIPTION
## Summary

Fixes four issues flagged in the Gemini review of PR #21073:

**Critical — missing input redirection** (`done` → `done <<< "$issues_tsv"`):
The inner `while IFS=... read` loop had no input source, so it silently consumed slugs from the outer loop's process substitution stdin. Every repo iteration would mis-parse its own slug data as issue rows, producing wrong reconciliation results across all stages.

**High — tab-collapsing field corruption** (`@tsv` → `join("|")`, `IFS=$'\t'` → `IFS='|'`):
`IFS=$'\t'` treats consecutive tabs as a single delimiter (Bash IFS whitespace-collapsing rule). Any issue with empty `labels_csv` produced `\t\t` in the `@tsv` output; the body base64 would shift into `labels_csv` and `issue_body_b64` would become empty. The `|` separator is non-whitespace, so consecutive `||` is never collapsed.

**Medium — jq stderr suppression removed** (`2>/dev/null` removed from `jq` call):
jq syntax errors were silently swallowed, making debugging impossible when jq fails.

**Medium — base64 portability** (`base64 -d` → `base64 "$_b64d_flag"`):
macOS BSD `base64` canonical decode flag is `-D`; GNU uses `-d`. Follows the existing `uname -s` pattern used for `date` portability at lines 93-97.

## Testing

- `bash .agents/scripts/tests/test-pulse-issue-reconcile.sh` → 12 passed, 0 failed
- `shellcheck .agents/scripts/pulse-issue-reconcile.sh` → no violations
- `shellcheck .agents/scripts/tests/test-pulse-issue-reconcile.sh` → no violations

Resolves #21166

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.27 with claude-sonnet-4-6 spent 12m and 25,892 tokens on this as a headless worker.
