### PR TITLE
t2894: enumerate all dispatch-dedup blockers in /full-loop gate

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -1047,6 +1047,83 @@ is_assigned() {
 	return 0
 }
 
+#######################################
+# enumerate_blockers — report ALL structural dispatch blockers for an issue.
+#
+# Unlike is_assigned() which short-circuits on the first match, this function
+# runs every unconditional structural check (parent-task, no-auto-dispatch)
+# and emits ALL matching signals as newline-separated tokens on stdout.
+#
+# Intentionally excludes cost-budget, hydration window, and assignee checks —
+# those have nuanced interactive UX that the caller handles separately.
+# GUARD_UNCERTAIN is emitted when the gh API call fails (fail-closed).
+#
+# Args:
+#   $1 = issue_number
+#   $2 = repo_slug
+#   $3 = self_login (optional, reserved for future extension)
+#
+# Stdout: newline-separated blocker tokens; empty when no structural blockers.
+# Returns:
+#   0 — at least one blocker token was emitted
+#   1 — no structural blockers found (safe to dispatch for label-based checks)
+#
+# t2894: used by _check_linked_issue_gate in full-loop-helper.sh to surface
+# ALL label-based blockers in a single pass rather than stopping at the first.
+#######################################
+enumerate_blockers() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	# self_login reserved for future extension — not used by structural checks
+	# local self_login="${3:-}"
+
+	if [[ -z "$issue_number" || -z "$repo_slug" ]]; then
+		return 1
+	fi
+
+	if [[ ! "$issue_number" =~ ^[0-9]+$ ]]; then
+		return 1
+	fi
+
+	# Re-use pre-fetched JSON when the caller has already loaded issue metadata.
+	local issue_meta_json gh_rc=0
+	if [[ -n "${ISSUE_META_JSON:-}" ]] \
+		&& printf '%s' "$ISSUE_META_JSON" | jq -e '.assignees and .labels' >/dev/null 2>&1; then
+		issue_meta_json="$ISSUE_META_JSON"
+	else
+		issue_meta_json=$(gh_issue_view "$issue_number" --repo "$repo_slug" \
+			--json state,assignees,labels,createdAt 2>/dev/null) || gh_rc=$?
+	fi
+
+	if [[ "$gh_rc" -ne 0 || -z "$issue_meta_json" ]]; then
+		printf 'GUARD_UNCERTAIN (reason=gh-api-failure issue=%s repo=%s rc=%s)\n' \
+			"$issue_number" "$repo_slug" "$gh_rc"
+		return 0
+	fi
+
+	local _found=false
+	local _blocker_out
+
+	# Check 1: parent-task / meta unconditional block (t1986).
+	_blocker_out=$(_is_assigned_check_parent_task "$issue_meta_json" "$issue_number" "$repo_slug" 2>/dev/null) || true
+	if [[ -n "$_blocker_out" ]]; then
+		printf '%s\n' "$_blocker_out"
+		_found=true
+	fi
+
+	# Check 2: no-auto-dispatch unconditional block (t2832).
+	_blocker_out=$(_is_assigned_check_no_auto_dispatch "$issue_meta_json" "$issue_number" "$repo_slug" 2>/dev/null) || true
+	if [[ -n "$_blocker_out" ]]; then
+		printf '%s\n' "$_blocker_out"
+		_found=true
+	fi
+
+	if [[ "$_found" == "true" ]]; then
+		return 0
+	fi
+	return 1
+}
+
 # PR evidence dedup check functions are in dispatch-dedup-pr.sh (GH#18916).
 
 #######################################
@@ -1278,6 +1355,11 @@ Usage:
                                                      Check for recent "Dispatching worker" comment (exit 0=found, 1=none)
   dispatch-dedup-helper.sh is-assigned <issue> <slug> [self-login]
                                                        Check if assigned to another login (exit 0=blocked, 1=free)
+  dispatch-dedup-helper.sh enumerate-blockers <issue> <slug> [runner]
+                                                       Report ALL structural label blockers (exit 0=blocked, 1=none)
+                                                       Emits newline-separated tokens: PARENT_TASK_BLOCKED,
+                                                       NO_AUTO_DISPATCH_BLOCKED, GUARD_UNCERTAIN. Unlike is-assigned,
+                                                       does not short-circuit on first match. t2894.
   dispatch-dedup-helper.sh check-cost-budget <issue> <slug> [tier]
                                                        t2007: cost circuit breaker (exit 0=tripped, 1=under budget)
   dispatch-dedup-helper.sh sum-issue-token-spend <issue> <slug>
@@ -1323,6 +1405,11 @@ Examples:
     echo "No merged PR evidence — safe to dispatch"
   fi
 
+  # Report ALL structural label blockers in one pass (t2894)
+  while IFS= read -r blocker; do
+    echo "Blocker: $blocker"
+  done < <(dispatch-dedup-helper.sh enumerate-blockers 2300 owner/repo)
+
   # Cross-machine claim lock (t1686)
   if dispatch-dedup-helper.sh claim 2300 owner/repo mylogin; then
     echo "Claim won — safe to dispatch"
@@ -1354,6 +1441,13 @@ main() {
 	is-assigned)
 		_require_args is-assigned 2 "$#" "<issue-number> <repo-slug> [self-login]" || return 1
 		is_assigned "$1" "$2" "${3:-}"
+		;;
+	enumerate-blockers)
+		# t2894: report ALL structural label blockers in a single pass.
+		# local capture avoids positional-param ratchet violation in main().
+		_require_args enumerate-blockers 2 "$#" "<issue-number> <repo-slug> [runner]" || return 1
+		local _eb_issue="$1" _eb_repo="$2" _eb_runner="${3:-}"
+		enumerate_blockers "$_eb_issue" "$_eb_repo" "$_eb_runner"
 		;;
 	check-cost-budget)
 		# t2007: cost-per-issue circuit breaker. Direct entry point for tests

--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -231,28 +231,33 @@ _check_linked_issue_gate() {
 		fi
 	fi
 
-	# Check 3 (t2890): inherit pulse-side structural dispatch gates by calling
-	# dispatch-dedup-helper.sh::is-assigned — the canonical primitive the pulse
-	# uses (pulse-dispatch-dedup-layers.sh:243). Translates the unambiguous
-	# hard-block signals (PARENT_TASK_BLOCKED, NO_AUTO_DISPATCH_BLOCKED) into
-	# blocks here so /full-loop honors the same eligibility semantics as the
-	# pulse. Cost-budget, hydration window, and ownership-by-other are
-	# intentionally out of scope (need nuanced interactive UX). Fail-open on
-	# missing helper or empty stdout (matches the gh-api fail-open above).
+	# Check 3 (t2890, t2894): inherit pulse-side structural dispatch gates by
+	# calling dispatch-dedup-helper.sh::enumerate-blockers — which runs ALL
+	# unconditional label checks in a single pass and emits each matching
+	# signal on a separate line. Replaces the former is-assigned call + case
+	# statement that short-circuited on the first match, so users now see
+	# every blocker in one /full-loop invocation instead of one per retry.
+	# Cost-budget, hydration window, and ownership-by-other are intentionally
+	# out of scope (need nuanced interactive UX). Fail-open on missing helper
+	# or empty stdout (matches the gh-api fail-open above).
 	local dedup_helper="${SCRIPT_DIR}/dispatch-dedup-helper.sh"
 	if [[ -x "$dedup_helper" ]]; then
 		local dedup_out
-		dedup_out=$("$dedup_helper" is-assigned "$issue_num" "$repo" "${AIDEVOPS_SESSION_USER:-${USER:-}}" 2>/dev/null || true)
-		case "$dedup_out" in
-		*PARENT_TASK_BLOCKED*)
-			blocked=true
-			reasons="${reasons}Issue #${issue_num} carries the \`parent-task\` label (decomposition tracker, not a worker target). Decompose into child phase issues, or remove the label if this is no longer a parent.\n"
-			;;
-		*NO_AUTO_DISPATCH_BLOCKED*)
-			blocked=true
-			reasons="${reasons}Issue #${issue_num} carries the \`no-auto-dispatch\` label (explicit hold). Remove the label if you intentionally want worker dispatch, or work on this issue operationally (post comments, post analysis) without /full-loop.\n"
-			;;
-		esac
+		dedup_out=$("$dedup_helper" enumerate-blockers "$issue_num" "$repo" "${AIDEVOPS_SESSION_USER:-${USER:-}}" 2>/dev/null || true)
+		local _blocker_line
+		while IFS= read -r _blocker_line; do
+			[[ -z "$_blocker_line" ]] && continue
+			case "$_blocker_line" in
+			*PARENT_TASK_BLOCKED*)
+				blocked=true
+				reasons="${reasons}Issue #${issue_num} carries the \`parent-task\` label (decomposition tracker, not a worker target). Decompose into child phase issues, or remove the label if this is no longer a parent.\n"
+				;;
+			*NO_AUTO_DISPATCH_BLOCKED*)
+				blocked=true
+				reasons="${reasons}Issue #${issue_num} carries the \`no-auto-dispatch\` label (explicit hold). Remove the label if you intentionally want worker dispatch, or work on this issue operationally (post comments, post analysis) without /full-loop.\n"
+				;;
+			esac
+		done <<<"$dedup_out"
 	fi
 
 	if [[ "$blocked" == "true" ]]; then

--- a/.agents/scripts/tests/test-dispatch-dedup-helper-enumerate-blockers.sh
+++ b/.agents/scripts/tests/test-dispatch-dedup-helper-enumerate-blockers.sh
@@ -1,0 +1,337 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-dispatch-dedup-helper-enumerate-blockers.sh — t2894 regression guard.
+#
+# Verifies that enumerate_blockers() in dispatch-dedup-helper.sh:
+#   - Reports ALL structural label blockers, not just the first
+#   - Emits newline-separated tokens for each matched signal
+#   - Returns exit 0 when at least one blocker is found, exit 1 when none
+#   - Is backward-compatible with the is-assigned API (that contract unchanged)
+#
+# Modeled on test-dispatch-dedup-helper-is-assigned.sh.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+HELPER_SCRIPT="${SCRIPT_DIR}/../dispatch-dedup-helper.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+TEST_ROOT=""
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+
+	mkdir -p "${TEST_ROOT}/bin"
+	mkdir -p "${TEST_ROOT}/config/aidevops"
+	export PATH="${TEST_ROOT}/bin:${PATH}"
+
+	# Minimal repos.json so the helper can resolve owner/maintainer.
+	cat >"${TEST_ROOT}/config/aidevops/repos.json" <<'EOF'
+{
+  "initialized_repos": [
+    {
+      "path": "/home/user/Git/aidevops",
+      "slug": "marcusquinn/aidevops",
+      "pulse": true,
+      "maintainer": "marcusquinn-bot"
+    }
+  ]
+}
+EOF
+
+	export REPOS_JSON="${TEST_ROOT}/config/aidevops/repos.json"
+	return 0
+}
+
+teardown_test_env() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+# Create a gh stub that returns issue metadata with the given labels.
+# Assignees default to empty (structural label checks don't need assignees).
+create_gh_stub() {
+	local labels_csv="${1:-}"
+	local assignees_csv="${2:-}"
+	local state="${3:-OPEN}"
+	local assignees_json labels_json recent_ts
+
+	assignees_json=$(
+		ASSIGNEES_CSV="$assignees_csv" python3 - <<'PY'
+import json, os
+items=[i for i in os.environ.get('ASSIGNEES_CSV','').split(',') if i]
+print(json.dumps([{"login": i} for i in items]))
+PY
+	)
+	labels_json=$(
+		LABELS_CSV="$labels_csv" python3 - <<'PY'
+import json, os
+items=[i for i in os.environ.get('LABELS_CSV','').split(',') if i]
+print(json.dumps([{"name": i} for i in items]))
+PY
+	)
+
+	recent_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+	cat >"${TEST_ROOT}/bin/gh" <<GHEOF
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "\${1:-}" == "issue" && "\${2:-}" == "view" ]]; then
+	printf '%s\n' '{"state":"${state}","assignees":${assignees_json},"labels":${labels_json},"createdAt":"${recent_ts}"}'
+	exit 0
+fi
+
+if [[ "\${1:-}" == "api" ]] && printf '%s' "\${2:-}" | grep -q '/comments'; then
+	printf '%s\n' '[{"created_at":"${recent_ts}","author":"runner1","body_start":"Dispatching worker (PID 12345)"}]'
+	exit 0
+fi
+
+if [[ "\${1:-}" == "issue" && ("\${2:-}" == "edit" || "\${2:-}" == "comment") ]]; then
+	exit 0
+fi
+
+printf 'unsupported gh invocation in test stub: %s\n' "\$*" >&2
+exit 1
+GHEOF
+
+	chmod +x "${TEST_ROOT}/bin/gh"
+	return 0
+}
+
+# -------------------------------------------------------------------
+# Test: no blockers → exit 1 (safe), empty stdout
+# -------------------------------------------------------------------
+test_no_blockers_returns_safe() {
+	create_gh_stub "bug,tier:standard"
+
+	local output exit_code=0
+	output=$("$HELPER_SCRIPT" enumerate-blockers 100 marcusquinn/aidevops 2>/dev/null) || exit_code=$?
+
+	if [[ "$exit_code" -eq 0 ]]; then
+		print_result "no structural blockers → exit 1 (safe)" 1 "Expected exit 1 but got exit 0; output: '${output}'"
+		return 0
+	fi
+
+	if [[ -n "$output" ]]; then
+		print_result "no structural blockers → empty stdout" 1 "Expected empty stdout but got: '${output}'"
+		return 0
+	fi
+
+	print_result "no structural blockers → exit 1 (safe) with empty stdout" 0
+	return 0
+}
+
+# -------------------------------------------------------------------
+# Test: only parent-task → exit 0, PARENT_TASK_BLOCKED emitted
+# -------------------------------------------------------------------
+test_parent_task_only() {
+	create_gh_stub "parent-task,tier:standard"
+
+	local output exit_code=0
+	output=$("$HELPER_SCRIPT" enumerate-blockers 100 marcusquinn/aidevops 2>/dev/null) || exit_code=$?
+
+	if [[ "$exit_code" -ne 0 ]]; then
+		print_result "parent-task only → exit 0 (blocked)" 1 "Expected exit 0 but got exit ${exit_code}"
+		return 0
+	fi
+
+	if printf '%s\n' "$output" | grep -q 'PARENT_TASK_BLOCKED'; then
+		print_result "parent-task only → emits PARENT_TASK_BLOCKED" 0
+	else
+		print_result "parent-task only → emits PARENT_TASK_BLOCKED" 1 "Signal not in output: '${output}'"
+	fi
+	return 0
+}
+
+# -------------------------------------------------------------------
+# Test: only no-auto-dispatch → exit 0, NO_AUTO_DISPATCH_BLOCKED emitted
+# -------------------------------------------------------------------
+test_no_auto_dispatch_only() {
+	create_gh_stub "no-auto-dispatch,tier:standard"
+
+	local output exit_code=0
+	output=$("$HELPER_SCRIPT" enumerate-blockers 100 marcusquinn/aidevops 2>/dev/null) || exit_code=$?
+
+	if [[ "$exit_code" -ne 0 ]]; then
+		print_result "no-auto-dispatch only → exit 0 (blocked)" 1 "Expected exit 0 but got exit ${exit_code}"
+		return 0
+	fi
+
+	if printf '%s\n' "$output" | grep -q 'NO_AUTO_DISPATCH_BLOCKED'; then
+		print_result "no-auto-dispatch only → emits NO_AUTO_DISPATCH_BLOCKED" 0
+	else
+		print_result "no-auto-dispatch only → emits NO_AUTO_DISPATCH_BLOCKED" 1 "Signal not in output: '${output}'"
+	fi
+	return 0
+}
+
+# -------------------------------------------------------------------
+# Test: BOTH parent-task AND no-auto-dispatch → exit 0, BOTH signals emitted
+# This is the core multi-blocker regression guard (t2894).
+# -------------------------------------------------------------------
+test_multi_blocker_both_signals_emitted() {
+	create_gh_stub "parent-task,no-auto-dispatch,tier:standard"
+
+	local output exit_code=0
+	output=$("$HELPER_SCRIPT" enumerate-blockers 100 marcusquinn/aidevops 2>/dev/null) || exit_code=$?
+
+	if [[ "$exit_code" -ne 0 ]]; then
+		print_result "multi-blocker: parent-task + no-auto-dispatch → exit 0 (blocked)" 1 \
+			"Expected exit 0 but got exit ${exit_code}"
+		return 0
+	fi
+
+	local parent_found=false nad_found=false
+	if printf '%s\n' "$output" | grep -q 'PARENT_TASK_BLOCKED'; then
+		parent_found=true
+	fi
+	if printf '%s\n' "$output" | grep -q 'NO_AUTO_DISPATCH_BLOCKED'; then
+		nad_found=true
+	fi
+
+	if [[ "$parent_found" == "true" && "$nad_found" == "true" ]]; then
+		print_result "multi-blocker: both PARENT_TASK_BLOCKED and NO_AUTO_DISPATCH_BLOCKED emitted" 0
+	else
+		print_result "multi-blocker: both PARENT_TASK_BLOCKED and NO_AUTO_DISPATCH_BLOCKED emitted" 1 \
+			"Missing signals — parent_found=${parent_found} nad_found=${nad_found}; output: '${output}'"
+	fi
+
+	# Count lines — must be exactly 2
+	local line_count
+	line_count=$(printf '%s\n' "$output" | grep -c '.' 2>/dev/null || true)
+	if [[ "$line_count" -eq 2 ]]; then
+		print_result "multi-blocker: exactly 2 lines emitted (one per signal)" 0
+	else
+		print_result "multi-blocker: exactly 2 lines emitted (one per signal)" 1 \
+			"Expected 2 lines, got ${line_count}; output: '${output}'"
+	fi
+	return 0
+}
+
+# -------------------------------------------------------------------
+# Test: gh API failure → exit 0, GUARD_UNCERTAIN emitted (fail-closed)
+# -------------------------------------------------------------------
+test_api_failure_emits_guard_uncertain() {
+	# gh stub that fails on issue view
+	cat >"${TEST_ROOT}/bin/gh" <<'GHEOF'
+#!/usr/bin/env bash
+exit 1
+GHEOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+
+	local output exit_code=0
+	output=$("$HELPER_SCRIPT" enumerate-blockers 100 marcusquinn/aidevops 2>/dev/null) || exit_code=$?
+
+	if [[ "$exit_code" -ne 0 ]]; then
+		print_result "gh API failure → exit 0 (fail-closed)" 1 "Expected exit 0 but got exit ${exit_code}"
+		return 0
+	fi
+
+	if printf '%s\n' "$output" | grep -q 'GUARD_UNCERTAIN'; then
+		print_result "gh API failure → emits GUARD_UNCERTAIN" 0
+	else
+		print_result "gh API failure → emits GUARD_UNCERTAIN" 1 "Signal not in output: '${output}'"
+	fi
+	return 0
+}
+
+# -------------------------------------------------------------------
+# Test: meta label (alias for parent-task) is also caught
+# -------------------------------------------------------------------
+test_meta_label_caught() {
+	create_gh_stub "meta"
+
+	local output exit_code=0
+	output=$("$HELPER_SCRIPT" enumerate-blockers 100 marcusquinn/aidevops 2>/dev/null) || exit_code=$?
+
+	if [[ "$exit_code" -ne 0 ]]; then
+		print_result "meta label → exit 0 (blocked)" 1 "Expected exit 0 but got exit ${exit_code}"
+		return 0
+	fi
+
+	if printf '%s\n' "$output" | grep -q 'PARENT_TASK_BLOCKED'; then
+		print_result "meta label alias → emits PARENT_TASK_BLOCKED" 0
+	else
+		print_result "meta label alias → emits PARENT_TASK_BLOCKED" 1 "Signal not in output: '${output}'"
+	fi
+	return 0
+}
+
+# -------------------------------------------------------------------
+# Test: backward compat — is-assigned API still returns first-match behavior
+# -------------------------------------------------------------------
+test_is_assigned_still_short_circuits() {
+	create_gh_stub "parent-task,no-auto-dispatch"
+
+	local output exit_code=0
+	output=$("$HELPER_SCRIPT" is-assigned 100 marcusquinn/aidevops runner1 2>/dev/null) || exit_code=$?
+
+	# is-assigned must still exit 0 (blocked) on first match
+	if [[ "$exit_code" -ne 0 ]]; then
+		print_result "is-assigned backward compat: still blocks on parent-task" 1 \
+			"Expected exit 0 (blocked) but got exit ${exit_code}"
+		return 0
+	fi
+	print_result "is-assigned backward compat: still blocks on parent-task" 0
+
+	# is-assigned should emit exactly ONE signal (short-circuit, not both)
+	local line_count
+	line_count=$(printf '%s\n' "$output" | grep -c '.' 2>/dev/null || true)
+	if [[ "$line_count" -le 1 ]]; then
+		print_result "is-assigned backward compat: emits at most 1 signal (short-circuit preserved)" 0
+	else
+		print_result "is-assigned backward compat: emits at most 1 signal (short-circuit preserved)" 1 \
+			"Expected ≤1 lines, got ${line_count}; output: '${output}'"
+	fi
+	return 0
+}
+
+main() {
+	trap teardown_test_env EXIT
+	setup_test_env
+
+	test_no_blockers_returns_safe
+	test_parent_task_only
+	test_no_auto_dispatch_only
+	test_multi_blocker_both_signals_emitted
+	test_api_failure_emits_guard_uncertain
+	test_meta_label_caught
+	test_is_assigned_still_short_circuits
+
+	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-full-loop-gate-pulse-parity.sh
+++ b/.agents/scripts/tests/test-full-loop-gate-pulse-parity.sh
@@ -77,14 +77,14 @@ assert_in_gate() {
 }
 
 # -------------------------------------------------------------------
-# Assertion A: gate calls dispatch-dedup-helper.sh::is-assigned
+# Assertion A: gate calls dispatch-dedup-helper.sh::enumerate-blockers (t2894)
 # -------------------------------------------------------------------
 assert_in_gate \
 	'dispatch-dedup-helper\.sh' \
 	"_check_linked_issue_gate references dispatch-dedup-helper.sh"
 assert_in_gate \
-	'is-assigned' \
-	"_check_linked_issue_gate calls is-assigned subcommand"
+	'enumerate-blockers' \
+	"_check_linked_issue_gate calls enumerate-blockers subcommand (t2894)"
 
 # -------------------------------------------------------------------
 # Assertion B: PARENT_TASK_BLOCKED case translates to a block
@@ -119,6 +119,17 @@ assert_in_gate \
 assert_in_gate \
 	'blocked=true' \
 	"_check_linked_issue_gate sets blocked=true on hard-block signals"
+
+# -------------------------------------------------------------------
+# Assertion G (t2894): gate iterates over enumerate-blockers output
+# with a loop so ALL blockers are reported (not just the first).
+# -------------------------------------------------------------------
+assert_in_gate \
+	'while.*read.*_blocker_line' \
+	"_check_linked_issue_gate iterates enumerate-blockers output with a loop (t2894)"
+assert_in_gate \
+	'done.*dedup_out' \
+	"_check_linked_issue_gate loop reads from dedup_out heredoc string (t2894)"
 
 # -------------------------------------------------------------------
 # Assertion F: full-loop-helper.sh shellcheck-clean


### PR DESCRIPTION
## What

Adds `enumerate_blockers()` to `dispatch-dedup-helper.sh` and wires it into `_check_linked_issue_gate` in `full-loop-helper.sh` so `/full-loop` surfaces **all** label-based structural blockers in a single pass.

**Before (t2890):** the gate called `is-assigned`, matched the first signal via `case`, stopped. An issue carrying both `parent-task` AND `no-auto-dispatch` required two round-trips to see both blockers.

**After (t2894):** the gate calls `enumerate-blockers`, iterates every emitted line, and accumulates all matching signals into `reasons`. One invocation surfaces every hold.

## Why

Gemini code-assist surfaced this on PR #21027 (the t2890 fix). Additive scope per the t1382 review-bot-gate rule, filed as separate task (#21029). Real-world impact: GH#20518 had `parent-task` + `no-auto-dispatch`; post-t2890 the gate would have blocked on `parent-task` first, requiring a second attempt to see `no-auto-dispatch`.

## How

### Files modified

- `EDIT: .agents/scripts/dispatch-dedup-helper.sh` — new `enumerate_blockers()` function (runs ALL structural checks without short-circuiting), `enumerate-blockers` subcommand in `main()`, help text + usage example
- `EDIT: .agents/scripts/full-loop-helper.sh` — `_check_linked_issue_gate` Check 3 replaces `is-assigned` case statement with an `enumerate-blockers` while-read loop
- `NEW: .agents/scripts/tests/test-dispatch-dedup-helper-enumerate-blockers.sh` — 9-case test suite (no-blockers, parent-task-only, no-auto-dispatch-only, **BOTH signals** [core multi-blocker case], API failure, meta alias, is-assigned backward compat)
- `EDIT: .agents/scripts/tests/test-full-loop-gate-pulse-parity.sh` — Assertion A updated to expect `enumerate-blockers`; Assertion G added (loop pattern present)

### Verification

```bash
# New test suite (9 cases):
bash .agents/scripts/tests/test-dispatch-dedup-helper-enumerate-blockers.sh
# Expected: Ran 9 tests, 0 failed.

# Structural gate parity (13 assertions, all pass):
bash .agents/scripts/tests/test-full-loop-gate-pulse-parity.sh
# Expected: 13 tests run, 0 failed

# Backward compat: is-assigned API unchanged
bash .agents/scripts/tests/test-dispatch-dedup-helper-is-assigned.sh
# (same pass/fail as HEAD on main — pre-existing failures unrelated to this PR)

# ShellCheck
shellcheck .agents/scripts/dispatch-dedup-helper.sh .agents/scripts/full-loop-helper.sh
```

## Backward compatibility

`is-assigned` API and exit-code contract are **unchanged**. All callers continue to work unmodified. `enumerate-blockers` is a new additive subcommand.

## Design note

Follows Option B from the issue: single source of truth in the helper. The gate is a consumer, not a parallel implementation. `enumerate_blockers()` reuses the same `_is_assigned_check_parent_task` / `_is_assigned_check_no_auto_dispatch` sub-helpers that `is_assigned()` uses — no label knowledge duplication.

## Complexity Bump Justification

`.agents/scripts/dispatch-dedup-helper.sh` crossed the 1500-line file-size gate:

- Evidence: `.agents/scripts/dispatch-dedup-helper.sh` — base=1419 lines, head=1513 lines, new=1 violation (threshold: 1500 lines)
- The 94-line increase is the `enumerate_blockers()` function body + header docstring + case entry + help text + usage example — all required for a complete, documented, testable API addition
- No existing code was inflated; the function is new additive scope
- A follow-on file-size-debt issue is appropriate after this PR merges; this helper has multiple candidates for extraction (the `main()` dispatch table + `show_help()` alone account for ~120 lines)

Resolves #21029

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.27 with claude-sonnet-4-6 spent 32m and 37,966 tokens on this as a headless worker.
