### PR TITLE
t2879: docs(README): add per-repo platform setup section pointing to /setup-git

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,23 @@ This creates:
 
 **Available features:** `planning`, `git-workflow`, `code-quality`, `time-tracking`, `beads`
 
+### Per-repo platform setup
+
+After `aidevops init` registers a new repo, run `/setup-git` in your AI assistant
+to apply per-repo platform secrets. Most notably, this sets `SYNC_PAT` — a
+GitHub Actions secret that lets `issue-sync.yml` push TODO.md auto-completion
+past branch protection.
+
+This is distinct from `/onboarding` (per-account credentials like `gh auth login`):
+GitHub Actions secrets are scoped per-repo, so each repo needs its own. You need
+`gh auth login` to succeed before any per-repo helper can run, so `/onboarding`
+comes first, `/setup-git` second.
+
+Run `/setup-git` again whenever you register a new repo with `aidevops repos add`
+or when a `SYNC_PAT` advisory appears in the session greeting toast. If you skip
+this step, `issue-sync.yml` will post a remediation comment when it hits branch
+protection — `/setup-git` walks through the fix.
+
 ### Upgrade Planning Files
 
 When aidevops templates evolve, upgrade existing projects to the latest format:


### PR DESCRIPTION
## Summary

Adds a `### Per-repo platform setup` subsection to `README.md` under the Quick Start section, positioned immediately after the "Use aidevops in Any Project" subsection. This gives new operators a breadcrumb to `/setup-git` before they hit branch-protection failures from `issue-sync.yml`.

## What changed

- **File:** `README.md` — 17 lines added after line 239
- **Section:** `### Per-repo platform setup`
- **Content:** Explains `SYNC_PAT`, the per-account (`/onboarding`) vs per-repo (`/setup-git`) distinction, and when to re-run `/setup-git`

## Acceptance criteria

- [x] README.md contains a "Per-repo platform setup" subsection
- [x] Section mentions `SYNC_PAT` and `/setup-git` by name
- [x] Section explains why setup is per-repo (vs per-account `/onboarding`)
- [x] Insertion point flows naturally after `aidevops init` / "Use aidevops in Any Project"
- [x] `markdownlint-cli2 README.md` — no new violations introduced (MD040 at line 491 is pre-existing, shifted by 17 lines from original line 474)
- [x] No new `aidevops security scan` findings (no private slugs in new content)

## Verification

```bash
npx markdownlint-cli2 README.md
grep -n "Per-repo platform setup\|SYNC_PAT\|setup-git" README.md
```

Resolves #20980

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.27 with claude-sonnet-4-6 spent 4m and 5,996 tokens on this as a headless worker.
