### PR TITLE
t2839: dispatch-issue CLI status PID liveness + model inference alignment

### DIFF
--- a/.agents/scripts/commands/dispatch-issue.md
+++ b/.agents/scripts/commands/dispatch-issue.md
@@ -39,10 +39,18 @@ helper deliberately does not.
    - Other exit code (helper missing, network error, etc.) → fail closed,
      refuse to dispatch, exit 1.
    - Dry-run: surface all three states as info, still print the planned dispatch.
-4. Resolve tier/model:
-   - `--model <id>` wins.
-   - Else infer from `tier:thinking|standard|simple` and `model:<id>` labels.
-   - Default tier = `standard`, default model family = `sonnet`.
+4. Resolve tier/model (mirrors `pulse-model-routing.sh::resolve_dispatch_model_for_labels`):
+   - `--model <id>` wins (operator explicit intent, highest priority).
+   - `model:opus-4-7` label wins over all tier labels (t2239 — same as pulse).
+   - Else tier labels: `tier:thinking` → opus, `tier:standard` → sonnet,
+     `tier:simple` → haiku. Default = `standard` / sonnet.
+   - Other `model:*` labels (e.g. `model:sonnet-4-6`) map to the named model.
+   - **Known divergence from pulse (t2839):** the pulse applies a dispatch-path
+     safety net (t2819) that auto-elevates issues touching self-hosting files
+     (pulse-wrapper.sh, headless-runtime-helper.sh, etc.) to `opus-4-7`. This
+     CLI does NOT apply that check — it would require parsing the issue body and
+     brief file scope. If you're manually dispatching a dispatch-path issue, pass
+     `--model anthropic/claude-opus-4-7` explicitly to match pulse behaviour.
 5. Dispatch (real path):
    - Pre-create worktree via `worktree-helper.sh add` (`auto-<ts>-gh<N>`),
      resolve actual path back from `git worktree list` (worktree-helper has

--- a/.agents/scripts/dispatch-single-issue-helper.sh
+++ b/.agents/scripts/dispatch-single-issue-helper.sh
@@ -143,43 +143,74 @@ _dsi_check_parent_task() {
 
 #######################################
 # Resolve model + tier for dispatch.
+# Priority order (mirrors pulse-model-routing.sh::resolve_dispatch_model_for_labels):
+#   1. Explicit --model CLI flag (operator intent, always wins)
+#   2. model:opus-4-7 label (highest-priority override, t2239 — before tier labels)
+#   3. Tier labels: tier:thinking → opus, tier:standard → sonnet, tier:simple → haiku
+#   4. Default tier: sonnet
+#
+# NOTE: the pulse additionally applies a dispatch-path safety net (t2819) that
+# auto-elevates issues touching self-hosting files to opus-4-7. That safety net
+# is not replicated here because it requires inspecting the issue body + brief
+# file scope, which is a heavier operation than this helper performs. If you are
+# dispatching a dispatch-path issue manually and want the safety-net tier, pass
+# --model anthropic/claude-opus-4-7 explicitly.
+#
 # Args:
 #   $1 - labels CSV
 #   $2 - --model override (may be empty)
-# Sets: _DSI_TIER (haiku|sonnet|opus), _DSI_SELECTED_MODEL (may be empty)
+# Sets: _DSI_TIER (haiku|sonnet|opus), _DSI_SELECTED_MODEL (full model id or empty)
 #######################################
 _dsi_resolve_model() {
 	local labels_csv="$1"
 	local model_override="$2"
 
-	# Default tier
-	_DSI_TIER="sonnet"
-
-	# Tier label takes precedence
-	local needle=",${labels_csv},"
-	if [[ "$needle" == *",tier:simple,"* ]]; then
-		_DSI_TIER="haiku"
-	elif [[ "$needle" == *",tier:standard,"* ]]; then
-		_DSI_TIER="sonnet"
-	elif [[ "$needle" == *",tier:thinking,"* ]]; then
-		_DSI_TIER="opus"
-	fi
-
-	# Explicit --model wins
+	# Explicit --model CLI flag takes highest priority (operator intent).
+	# Infer tier from the model string for display purposes only.
 	if [[ -n "$model_override" ]]; then
 		_DSI_SELECTED_MODEL="$model_override"
+		case "$model_override" in
+		*opus*) _DSI_TIER="opus" ;;
+		*haiku*) _DSI_TIER="haiku" ;;
+		*) _DSI_TIER="sonnet" ;;
+		esac
 		return 0
 	fi
 
-	# Otherwise inspect model:* label (e.g., model:opus-4-7)
+	# Default tier: sonnet. Labels below may override.
+	_DSI_TIER="sonnet"
+	_DSI_SELECTED_MODEL=""
+
+	# Normalise labels to lowercase for case-insensitive matching
+	# (mirrors _resolve_worker_tier in pulse-dispatch-core.sh).
+	local labels_lower
+	labels_lower=$(printf '%s' "$labels_csv" | tr '[:upper:]' '[:lower:]')
+	local needle=",${labels_lower},"
+
+	# model:opus-4-7 label and tier:thinking both elevate to the opus tier.
+	# model:opus-4-7 also pins the specific model and takes precedence over
+	# tier:* labels (t2239 — same priority order as pulse-model-routing.sh
+	# resolve_dispatch_model_for_labels).
+	if [[ "$needle" == *",model:opus-4-7,"* || "$needle" == *",tier:thinking,"* ]]; then
+		_DSI_TIER="opus"
+		if [[ "$needle" == *",model:opus-4-7,"* ]]; then
+			_DSI_SELECTED_MODEL="anthropic/claude-opus-4-7"
+		fi
+		return 0
+	fi
+
+	# Remaining tier labels (sonnet is already the default; only haiku changes it)
+	if [[ "$needle" == *",tier:simple,"* ]]; then
+		_DSI_TIER="haiku"
+	fi
+
+	# Other model:* labels (e.g. model:sonnet-4-6) — lower priority than
+	# model:opus-4-7 (handled above) but takes effect over tier default.
 	local m
-	m=$(printf '%s\n' "${labels_csv//,/$'\n'}" | grep -oE '^model:[a-z0-9.-]+' | head -1 || true)
+	m=$(printf '%s\n' "${labels_lower//,/$'\n'}" | grep -oE '^model:[a-z0-9.-]+' | head -1 || true)
 	if [[ -n "$m" ]]; then
-		# Map model:opus-4-7 → anthropic/claude-opus-4-7 (canonical form)
 		local short="${m#model:}"
 		_DSI_SELECTED_MODEL="anthropic/claude-${short}"
-	else
-		_DSI_SELECTED_MODEL=""
 	fi
 	return 0
 }
@@ -560,6 +591,10 @@ cmd_dispatch() {
 
 #######################################
 # Subcommand: status <issue> <slug>
+# Reads the dispatch ledger for the given issue and pretty-prints the state,
+# including a PID liveness check via kill -0 (same as dispatch-ledger-helper.sh
+# cmd_check_issue). This ensures `status` and the pulse agree on whether a
+# worker is actually running — not just recorded in the ledger.
 #######################################
 cmd_status() {
 	local issue_number="${1:-}"
@@ -578,20 +613,41 @@ cmd_status() {
 		return 0
 	fi
 
-	# Pretty-print key fields
-	local pid session_key launched_by status started_at
+	# Extract ledger fields (use actual field names from ledger schema:
+	# session_key, issue_number, repo_slug, pid, dispatched_at, status,
+	# updated_at, tier, model)
+	local pid session_key ledger_status dispatched_at tier model
 	pid=$(printf '%s' "$entry" | jq -r '.pid // "?"')
 	session_key=$(printf '%s' "$entry" | jq -r '.session_key // "?"')
-	launched_by=$(printf '%s' "$entry" | jq -r '.launched_by // "?"')
-	status=$(printf '%s' "$entry" | jq -r '.status // "?"')
-	started_at=$(printf '%s' "$entry" | jq -r '.started_at // "?"')
+	ledger_status=$(printf '%s' "$entry" | jq -r '.status // "?"')
+	dispatched_at=$(printf '%s' "$entry" | jq -r '.dispatched_at // "?"')
+	tier=$(printf '%s' "$entry" | jq -r '.tier // "?"')
+	model=$(printf '%s' "$entry" | jq -r '.model // "?"')
 
-	_dsi_ok "Active dispatch for #${issue_number} (${repo_slug}):"
-	_dsi_info "  PID:          ${pid}"
+	# PID liveness check (kill -0 tests whether the process exists, without
+	# sending a real signal). Mirrors the check in dispatch-ledger-helper.sh
+	# cmd_check_issue so the manual CLI and the pulse agree on liveness.
+	local liveness="unknown"
+	if [[ "$pid" =~ ^[0-9]+$ ]] && [[ "$pid" -gt 0 ]]; then
+		if kill -0 "$pid" 2>/dev/null; then
+			liveness="running"
+		else
+			liveness="dead"
+		fi
+	fi
+
+	_dsi_ok "Dispatch for #${issue_number} (${repo_slug}):"
+	_dsi_info "  PID:          ${pid} (${liveness})"
 	_dsi_info "  Session key:  ${session_key}"
-	_dsi_info "  Launched by:  ${launched_by}"
-	_dsi_info "  Status:       ${status}"
-	_dsi_info "  Started:      ${started_at}"
+	_dsi_info "  Ledger status: ${ledger_status}"
+	_dsi_info "  Dispatched:   ${dispatched_at}"
+	_dsi_info "  Tier:         ${tier}"
+	_dsi_info "  Model:        ${model}"
+
+	if [[ "$liveness" == "dead" ]]; then
+		_dsi_warn "Worker PID ${pid} is no longer running — ledger may be stale"
+		_dsi_info "  If no other worker is active, the issue is safe to re-dispatch."
+	fi
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Two additive quality-of-life improvements to `dispatch-single-issue-helper.sh`, surfaced by bot reviews on PR #20887.

## Changes

### (1) PID liveness in `cmd_status`

Previously `cmd_status` printed whatever PID was in the dispatch ledger with no signal that the worker might have died. Now it runs `kill -0 <pid>` (same pattern as `dispatch-ledger-helper.sh cmd_check_issue`) and displays `running` / `dead` / `unknown` alongside the PID.

Also fixes ledger field name alignment: `started_at` → `dispatched_at` (the actual ledger field), replaces the non-existent `launched_by` field with the real `tier` and `model` fields from the ledger.

### (2) Model inference alignment with pulse (`_dsi_resolve_model`)

Aligns label priority with `pulse-model-routing.sh::resolve_dispatch_model_for_labels` (t2239):
- `model:opus-4-7` label now checked **before** tier labels (was checked after)
- Case-insensitive label matching via `tr` (mirrors `_resolve_worker_tier`)
- `model:opus-4-7` and `tier:thinking` both route to the opus tier
- `tier:simple` → haiku; default → sonnet (tier:standard no longer redundantly set)

Documents the one remaining divergence: the t2819 dispatch-path auto-elevation safety net (requires issue body + brief file parsing) is not replicated. Documented in `commands/dispatch-issue.md` with `--model` workaround.

## Verification

- shellcheck clean on `dispatch-single-issue-helper.sh`
- Pre-commit ratchets passed (string literals, positional params, return statements, ShellCheck)
- `cmd_status` field names verified against `dispatch-ledger-helper.sh` register schema
- Model priority matches `pulse-model-routing.sh::resolve_dispatch_model_for_labels`

## Files changed

- `EDIT: .agents/scripts/dispatch-single-issue-helper.sh` — `cmd_status` + `_dsi_resolve_model`
- `EDIT: .agents/scripts/commands/dispatch-issue.md` — model resolution docs + divergence note

Resolves #20889


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.27 with claude-sonnet-4-6 spent 9m and 22,844 tokens on this as a headless worker. Overall, 1d 11h since this issue was created.