### PR TITLE
GH#20953: fix _pcr_sanitise_path path-boundary guard to prevent shared-prefix username leak

### DIFF
--- a/.agents/scripts/pulse-canonical-recovery.sh
+++ b/.agents/scripts/pulse-canonical-recovery.sh
@@ -277,8 +277,10 @@ _pcr_sanitise_path() {
 
 	# 1. $HOME prefix → ~ (covers macOS /Users/<me> and Linux /home/<me>
 	#    when the user is the current login).
-	if [[ -n "${HOME:-}" && "$raw" == "$HOME"* ]]; then
-		printf '~%s' "${raw#"$HOME"}"
+	# Strip any trailing slash so the boundary check works reliably.
+	local h="${HOME%/}"
+	if [[ -n "$h" && ( "$raw" == "$h" || "$raw" == "$h/"* ) ]]; then
+		printf '~%s' "${raw#"$h"}"
 		return 0
 	fi
 


### PR DESCRIPTION
## Summary

Fixes a privacy bug in `_pcr_sanitise_path` (introduced in t2871 / PR #20945) where the `$HOME` prefix glob check `"$raw" == "$HOME"*` could incorrectly match a path belonging to a different user whose username is a prefix of the current user's home path.

**Example failure:** `$HOME=/Users/marcus`, `$raw=/Users/marcusquinn/repo` → the glob fires, producing `~quinn/repo` instead of passing to the `/Users/<user>/` fallback which would correctly output `/Users/<user>/repo`.

## Changes

**`.agents/scripts/pulse-canonical-recovery.sh`** — `_pcr_sanitise_path()` lines 278-285:
- Strip trailing slash from `$HOME` into local `h` to handle edge cases
- Replace single glob `"$raw" == "$HOME"*` with explicit two-case guard:
  - Exact match: `"$raw" == "$h"` (bare home dir with no trailing slash)
  - Subdirectory match: `"$raw" == "$h/"*` (enforces path component boundary)

## Verification

- `shellcheck` passes with zero violations
- Pre-commit and pre-push hooks passed
- The fix matches the suggestion from gemini-code-assist on PR #20945

Resolves #20953

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.27 with claude-sonnet-4-6 spent 4m and 5,330 tokens on this as a headless worker.
