### PR TITLE
fix: add mktemp -t template for BSD/macOS portability in probe functions

### DIFF
--- a/.agents/scripts/upstream-watch-helper.sh
+++ b/.agents/scripts/upstream-watch-helper.sh
@@ -709,7 +709,7 @@ _report_github_repo_update() {
 _probe_github_release() {
 	local slug="$1"
 	local api_stderr
-	api_stderr=$(mktemp)
+	api_stderr=$(mktemp -t upstream-watch-err.XXXXXX)
 	local release_json=""
 
 	if release_json=$(gh api "repos/${slug}/releases/latest" 2>"$api_stderr"); then
@@ -743,7 +743,7 @@ _probe_github_release() {
 _probe_github_commit() {
 	local slug="$1"
 	local api_stderr
-	api_stderr=$(mktemp)
+	api_stderr=$(mktemp -t upstream-watch-err.XXXXXX)
 	local commit_json=""
 
 	if commit_json=$(gh api "repos/${slug}/commits?per_page=1" --jq '.[0]' 2>"$api_stderr"); then


### PR DESCRIPTION
## Summary

Add `-t upstream-watch-err.XXXXXX` template to both `mktemp` calls in `_probe_github_release` (line 712) and `_probe_github_commit` (line 746) in `.agents/scripts/upstream-watch-helper.sh`.

This improves portability across BSD/macOS systems. While `mktemp` without a template works in practice on macOS, the template form is the recommended portable approach and makes the temporary file's purpose explicit in any `ps`/`lsof` output.

The `local` declaration is already correctly separated from the assignment, and temp files are already cleaned up immediately after use — both other bot suggestions were already addressed in the original implementation.

## Changes

- `EDIT: .agents/scripts/upstream-watch-helper.sh:712` — `mktemp` → `mktemp -t upstream-watch-err.XXXXXX`
- `EDIT: .agents/scripts/upstream-watch-helper.sh:746` — `mktemp` → `mktemp -t upstream-watch-err.XXXXXX`

## Testing

- `shellcheck` passes with zero new violations (1 pre-existing SC2269 at line 54 unrelated to this change)
- Both functions compile and have identical logic; only the temp file naming changes

Resolves #20955
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.27 with claude-sonnet-4-6 spent 4m and 4,100 tokens on this as a headless worker.
