### PR TITLE
t20958: pulse-issue-reconcile: remove stale line number from t2841 comment

### DIFF
--- a/.agents/scripts/pulse-issue-reconcile.sh
+++ b/.agents/scripts/pulse-issue-reconcile.sh
@@ -2009,7 +2009,7 @@ _action_cpt_single() {
 	# sources (e.g. `graph+body`, `body`, `graph+body+prose`) so the log line
 	# in `_try_close_parent_tracker` records which extractors found children.
 	# t2841: explicit init — under set -u, _b_nums is referenced at the
-	# union step (line ~2007) regardless of whether children_section is
+	# union step below regardless of whether children_section is
 	# non-empty. Without init, an issue body with no children-section
 	# triggers `_b_nums: unbound variable` and aborts the function.
 	local _g_nums="" _b_nums="" _p_nums="" child_nums=""


### PR DESCRIPTION
## Summary

Removes the fragile `(line ~2007)` reference from the t2841 code comment in `_action_cpt_single`. The union step the comment refers to is now at line ~2030 (not 2007), making the inline reference already stale. Replacing it with `below` keeps the comment accurate as the file grows.

## Change

`pulse-issue-reconcile.sh` line ~2012:

**Before:**
```bash
# t2841: explicit init — under set -u, _b_nums is referenced at the
# union step (line ~2007) regardless of whether children_section is
```

**After:**
```bash
# t2841: explicit init — under set -u, _b_nums is referenced at the
# union step below regardless of whether children_section is
```

## Verification

- shellcheck: no violations
- Pre-commit and pre-push hooks: passed

Resolves #20958


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.27 with claude-sonnet-4-6 spent 5m and 5,074 tokens on this as a headless worker.