### PR TITLE
fix: add PID liveness check to dispatch status display (GH#20961)

### DIFF
--- a/.agents/scripts/dispatch-single-issue-helper.sh
+++ b/.agents/scripts/dispatch-single-issue-helper.sh
@@ -579,15 +579,21 @@ cmd_status() {
 	fi
 
 	# Pretty-print key fields
-	local pid session_key launched_by status started_at
+	local pid session_key launched_by status started_at liveness
 	pid=$(printf '%s' "$entry" | jq -r '.pid // "?"')
 	session_key=$(printf '%s' "$entry" | jq -r '.session_key // "?"')
 	launched_by=$(printf '%s' "$entry" | jq -r '.launched_by // "?"')
 	status=$(printf '%s' "$entry" | jq -r '.status // "?"')
 	started_at=$(printf '%s' "$entry" | jq -r '.started_at // "?"')
 
+	# Check PID liveness (as documented in dispatch-issue.md line 60)
+	liveness="dead"
+	if [[ "$pid" =~ ^[0-9]+$ ]] && kill -0 "$pid" 2>/dev/null; then
+		liveness="running"
+	fi
+
 	_dsi_ok "Active dispatch for #${issue_number} (${repo_slug}):"
-	_dsi_info "  PID:          ${pid}"
+	_dsi_info "  PID:          ${pid} (${liveness})"
 	_dsi_info "  Session key:  ${session_key}"
 	_dsi_info "  Launched by:  ${launched_by}"
 	_dsi_info "  Status:       ${status}"


### PR DESCRIPTION
## Summary

`cmd_status` in `dispatch-single-issue-helper.sh` displays the active dispatch ledger entry including PID. The documentation in `dispatch-issue.md` line 60 explicitly says the status command reports "PID liveness", but the code only showed the raw PID number without checking whether the worker process is still alive.

### Fix (Outcome B)

Add a `kill -0` liveness check and annotate the PID output line with `(running)` or `(dead)`:

```bash
liveness="dead"
if [[ "$pid" =~ ^[0-9]+$ ]] && kill -0 "$pid" 2>/dev/null; then
    liveness="running"
fi
_dsi_info "  PID:          ${pid} (${liveness})"
```

stderr is suppressed on `kill -0` per repository conventions for status display functions.

### Falsified premises (Outcome A — no code change needed)

**Line 390 (HIGH):** Bot suggested adding a `$# -lt 2` guard before `shift 2` on `--model`. The guard was already added in the final merged code at line 384:
```bash
if [[ $# -lt 2 || -z "${2:-}" || "${2:-}" == --* ]]; then
```
The bot reviewed a pre-merge version of the diff where it was missing.

**Line 255 (MEDIUM):** Bot suggested changing `--launched-by "manual-cli"` to include the user login. That code was not what was merged — the comment at lines 236-238 of the merged file explicitly documents that `dispatch-ledger-helper.sh register` accepts `--session-key, --issue, --repo, --pid` only, with no `--launched-by` flag.

## Verification

- `shellcheck` passes with zero violations
- `cmd_status` output now shows `PID: 12345 (running)` or `PID: 12345 (dead)` matching the documented behaviour

Resolves #20961

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.27 with claude-sonnet-4-6 spent 5m and 8,739 tokens on this as a headless worker.
