### PR TITLE
fix(cli): add issue) dispatch case and help entry to aidevops.sh

### DIFF
--- a/aidevops.sh
+++ b/aidevops.sh
@@ -1567,6 +1567,7 @@ _help_commands() {
 	echo "  client-format      Client request format alignment (extract/check/canary/monitor)"
 	echo "  opencode-sandbox   Test OpenCode versions in isolation (install/run/check/clean)"
 	echo "  approve <cmd>      Cryptographic issue/PR approval (setup/issue/pr/verify/status)"
+	echo "  issue <cmd>        Interactive issue ownership (claim/release/status/scan-stale)"
 	echo "  security [cmd]     Full security assessment (posture + hygiene + supply chain)"
 	echo "  contributions      External contributions inbox (bare: status | seed/scan/stop/restart/install/uninstall)"
 	echo "  inbox [cmd]        Capture transit zone (bare: status | provision/add/find/digest/help)"
@@ -2019,6 +2020,7 @@ main() {
 	review-gate | review_gate) _dispatch_helper "review-gate-config-helper.sh" "review-gate-config-helper.sh" "$@" ;;
 	secret | secrets) _dispatch_helper "secret-helper.sh" "secret-helper.sh" "$@" ;;
 	approve) _dispatch_helper "approval-helper.sh" "approval-helper.sh" "$@" ;;
+	issue) _dispatch_helper "interactive-session-helper.sh" "interactive-session-helper.sh" "$@" ;;
 	signing) _dispatch_helper "signing-setup.sh" "signing-setup.sh" "$@" ;;
 	contributions | contrib)
 		# Bare `aidevops contributions` defaults to status (most common use).


### PR DESCRIPTION
## Summary

- Add `issue)` dispatch case to `aidevops.sh` dispatch table after `approve)`, routing to `interactive-session-helper.sh`
- Add `issue <cmd>` help line to `cmd_help()` after `approve <cmd>`

## Problem

`aidevops issue release/claim/status/scan-stale` fell through to the `*) Unknown command` catch-all with error `[ERROR] Unknown command: issue`. This broke the documented CLI fallback for interactive claim management — critically, `scan-stale` output actively suggests `aidevops issue release <N>` as the remediation command, guiding users to a broken path.

## Root Cause

Regression of #19042 (t2105). The original fix was specified in the brief but the PRs that auto-closed #19042 (#19052, #19057) only modified `pulse-cleanup.sh` and `pulse-dispatch-worker-launch.sh` — neither touched `aidevops.sh`.

## Changes

- `aidevops.sh:2023` — `issue) _dispatch_helper "interactive-session-helper.sh" "interactive-session-helper.sh" "$@" ;;`
- `aidevops.sh:1570` — `echo "  issue <cmd>        Interactive issue ownership (claim/release/status/scan-stale)"`

## Verification

- `shellcheck aidevops.sh` exits 0 ✓
- `bash aidevops.sh issue` reaches `interactive-session-helper.sh` usage text ✓
- `bash aidevops.sh issue release 9999 owner/repo` reaches helper (no `Unknown command` error) ✓
- `bash aidevops.sh help | grep 'issue <cmd>'` matches ✓

Resolves #20971


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.27 with claude-sonnet-4-6 spent 2m and 4,146 tokens on this as a headless worker.