### PR TITLE
fix: GH#20954 — use jq fallback operator and SCRIPT_DIR in framework-routing-helper

### DIFF
--- a/.agents/scripts/framework-routing-helper.sh
+++ b/.agents/scripts/framework-routing-helper.sh
@@ -305,8 +305,8 @@ _lfi_check_dedup() {
 		local existing
 		existing=$(gh issue list --repo "$slug" \
 			--state open --search "$search_terms" \
-			--json number,url --limit 1 -q '.[0].url' 2>/dev/null || echo "")
-		if [[ -n "$existing" && "$existing" != "null" ]]; then
+			--json number,url --limit 1 -q '.[0].url // ""' || echo "")
+		if [[ -n "$existing" ]]; then
 			log_info "Duplicate found (search): $existing"
 			_LFI_DEDUP_URL="$existing"
 			return 2
@@ -329,7 +329,7 @@ _lfi_create_and_record() {
 
 	# Append signature footer for API call (body without sig used for fingerprinting)
 	local sig_footer=""
-	sig_footer=$("${HOME}/.aidevops/agents/scripts/gh-signature-helper.sh" footer --body "$body" 2>/dev/null || true)
+	sig_footer=$("${SCRIPT_DIR}/gh-signature-helper.sh" footer --body "$body" || true)
 	local body_for_api="${body}${sig_footer}"
 
 	local issue_url


### PR DESCRIPTION
## Summary

Addresses review bot feedback on PR #20927 (`_lfi_check_dedup` and `_lfi_create_and_record` functions in `framework-routing-helper.sh`). Both suggestions were verified correct — Outcome B.

## Changes

**`.agents/scripts/framework-routing-helper.sh` — two targeted fixes:**

1. **jq fallback operator (line 308–309):** Replace `'.[0].url'` with `'.[0].url // ""'` so jq returns an empty string instead of `null` when no matching issue is found. Removes the redundant `"$existing" != "null"` check and the `2>/dev/null` stderr suppression (the `|| echo ""` fallback already handles `gh` exit-code failures; keeping stderr visible improves diagnostics).

2. **Portable helper path (line 332):** Replace hardcoded `"${HOME}/.aidevops/agents/scripts/gh-signature-helper.sh"` with `"${SCRIPT_DIR}/gh-signature-helper.sh"` (`SCRIPT_DIR` is defined at line 31). Removes `2>/dev/null` so errors from the helper are visible; the `|| true` already makes failures non-fatal.

## Verification

- `shellcheck .agents/scripts/framework-routing-helper.sh` → zero violations
- Pre-commit and pre-push hooks pass

Resolves #20954

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.27 with claude-sonnet-4-6 spent 11m and 7,122 tokens on this as a headless worker.
