### PR TITLE
GH#20962: fix age-check failure bias in is_running short-circuit

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1534,7 +1534,7 @@ main() {
 				# Fix: enforce PULSE_LOCK_MAX_AGE_S as a fall-through trigger so
 				# stale-but-alive locks reach the proper reclaim path below.
 				local _ir_age _ir_max
-				_ir_age=$(_get_process_age "$_ir_pid" 2>/dev/null || echo 0)
+				_ir_age=$(_get_process_age "$_ir_pid" 2>/dev/null || true)
 				_ir_max="${PULSE_LOCK_MAX_AGE_S:-1800}"
 				if [[ "$_ir_age" =~ ^[0-9]+$ ]] && [[ "$_ir_age" -le "$_ir_max" ]]; then
 					echo "[pulse-wrapper] Pulse already running (PID: ${_ir_pid}, age ${_ir_age}s), skipping" >>"$WRAPPER_LOGFILE"

--- a/.agents/scripts/tests/test-pulse-is-running-stale-lock-breaker.sh
+++ b/.agents/scripts/tests/test-pulse-is-running-stale-lock-breaker.sh
@@ -116,7 +116,7 @@ _is_running_short_circuit() {
 	if [[ "$_ir_pid" =~ ^[0-9]+$ ]] && [[ "$_ir_pid" != "$$" ]] && kill -0 "$_ir_pid" 2>/dev/null; then
 		# t2829: age check
 		local _ir_age _ir_max
-		_ir_age=$(_get_process_age "$_ir_pid" 2>/dev/null || echo 0)
+		_ir_age=$(_get_process_age "$_ir_pid" 2>/dev/null || true)
 		_ir_max="${PULSE_LOCK_MAX_AGE_S:-1800}"
 		if [[ "$_ir_age" =~ ^[0-9]+$ ]] && [[ "$_ir_age" -le "$_ir_max" ]]; then
 			echo "[pulse-wrapper] Pulse already running (PID: ${_ir_pid}, age ${_ir_age}s), skipping" >>"$WRAPPER_LOGFILE"
@@ -469,6 +469,37 @@ test_dry_run_mode_bypasses() {
 }
 
 #######################################
+# Test 12: _get_process_age exits non-zero (helper failure)
+# With || echo 0 the result was age=0 → skip cycle (wrong: treats failure
+# as "process is young"). With || echo "unknown" the regex guard kicks in
+# and we fall through to reclaim — the safe failure mode. GH#20962.
+#######################################
+test_age_helper_failure_falls_through() {
+	reset_state
+
+	local live_pid
+	_spawn_live_pid
+	live_pid="$_SPAWNED_PID"
+
+	mkdir -p "$LOCKDIR"
+	echo "$live_pid" >"${LOCKDIR}/pid"
+
+	# Override stub to simulate _get_process_age exiting non-zero with no output
+	_get_process_age() { return 1; }
+
+	PULSE_LOCK_MAX_AGE_S=1800
+
+	local result=0
+	_is_running_short_circuit || result=$?
+
+	# Restore default stub so subsequent tests are unaffected
+	_get_process_age() { echo "$STUB_PROCESS_AGE"; return 0; }
+
+	assert_equals "age helper failure: returns 1 (fall through to reclaim)" "1" "$result"
+	return 0
+}
+
+#######################################
 # Main
 #######################################
 main() {
@@ -489,6 +520,7 @@ main() {
 	test_log_marker_format
 	test_canary_mode_bypasses
 	test_dry_run_mode_bypasses
+	test_age_helper_failure_falls_through
 
 	teardown_sandbox
 


### PR DESCRIPTION
## Summary

`_get_process_age` failure in the `is_running` short-circuit incorrectly biased toward **skipping** cycles instead of deferring to `acquire_instance_lock`.

### Root cause

```bash
# old (wrong)
_ir_age=$(_get_process_age "$_ir_pid" 2>/dev/null || echo 0)
```

`|| echo 0` → age=0 → passes `^[0-9]+$` AND `0 <= 1800` → **returns 0 (skip cycle)**.
The design comment says the short-circuit is *"biased toward false negatives (defer to acquire_instance_lock when uncertain)"*. Age=0 defers nothing — it silently skips, identical to a healthy pulse.

### Fix

```bash
# new (correct)
_ir_age=$(_get_process_age "$_ir_pid" 2>/dev/null || true)
```

`|| true` → empty string on failure → fails `^[0-9]+$` regex guard → falls through to `acquire_instance_lock` for proper handling. Empty and non-numeric output are already handled by the existing guard; no extra parameter expansion needed.

## Changes

- `pulse-wrapper.sh`: fix production `is_running` block
- test file: sync extracted `_is_running_short_circuit` copy + add **Test 12** (`age helper failure → returns 1`) that explicitly pins the corrected failure-mode behaviour

**Verification:** `bash .agents/scripts/tests/test-pulse-is-running-stale-lock-breaker.sh` → 15/15 passed

Addresses both gemini-code-assist inline comments from PR #20886 (#discussion_r3142243157, #discussion_r3142243160).

Resolves #20962

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.27 with claude-sonnet-4-6 spent 15m and 16,658 tokens on this as a headless worker.
