### PR TITLE
fix: complexity advisory parser — one-liner and next-line brace (GH#20956)

### DIFF
--- a/.agents/hooks/complexity_advisory_pre_edit.py
+++ b/.agents/hooks/complexity_advisory_pre_edit.py
@@ -49,7 +49,8 @@ def _is_shell_file(file_path: str) -> bool:
     return ext.lower() in SHELL_EXTENSIONS
 
 
-# Regex to detect bash function declaration lines (module-level, compiled once)
+# Regex to detect bash function declaration lines with same-line opening brace.
+# (module-level, compiled once)
 _FUNC_RE = re.compile(
     r"""
     ^\s*
@@ -62,17 +63,37 @@ _FUNC_RE = re.compile(
     re.VERBOSE,
 )
 
+# Regex for function declarations where the opening brace is on the *next* line.
+# Matches only when the declaration line ends with optional whitespace (no trailing {).
+_FUNC_RE_NOBRACE = re.compile(
+    r"""
+    ^\s*
+    (?:
+        function\s+(\w+)\s*(?:\(\s*\))?\s*$   # function name() or function name (no {)
+        |
+        (\w+)\s*\(\s*\)\s*$                    # name() with no trailing { (brace on next line)
+    )
+    """,
+    re.VERBOSE,
+)
+
 
 def _find_close_brace(lines: list[str], start: int) -> int:
     """Return the index of the closing brace for the function starting at `start`.
 
-    Uses a simple brace-depth counter (fast heuristic, sufficient for advisory).
-    Returns -1 if no matching close is found before end-of-input.
+    `start` is the line index where brace counting begins (i.e. the line
+    containing the opening ``{``).  Uses a simple brace-depth counter (fast
+    heuristic, sufficient for advisory).  Returns -1 if no matching close is
+    found before end-of-input.
+
+    The guard ``j > start`` was intentionally removed so that one-liner
+    functions (``func() { :; }``) are handled correctly: depth reaches 0 on
+    the declaration line itself, which is the correct closing position.
     """
     depth = 0
     for j in range(start, len(lines)):
         depth += lines[j].count("{") - lines[j].count("}")
-        if depth <= 0 and j > start:
+        if depth <= 0:
             return j
     return -1
 
@@ -80,12 +101,14 @@ def _find_close_brace(lines: list[str], start: int) -> int:
 def _iter_function_blocks(text: str) -> Generator[tuple[str, int], None, None]:
     """Yield (function_name, line_count) for each bash function in text.
 
-    Handles both declaration styles:
-      - func_name() {
-      - function func_name {
-      - function func_name() {
+    Handles all three common declaration styles:
+      - func_name() {          (same-line brace)
+      - function func_name {   (same-line brace, keyword form)
+      - function func_name() { (same-line brace, keyword + parens)
+      - func_name()\\n{        (next-line brace)
+      - function func_name\\n{ (next-line brace, keyword form)
 
-    Line count includes the opening brace line and the closing brace line.
+    Line count includes the declaration line and the closing brace line.
     Raises no exceptions — malformed bash is silently skipped.
     """
     lines = text.splitlines()
@@ -93,11 +116,16 @@ def _iter_function_blocks(text: str) -> Generator[tuple[str, int], None, None]:
     i = 0
     while i < n:
         m = _FUNC_RE.match(lines[i])
+        brace_start = i  # line where brace counting starts (contains opening {)
         if not m:
-            i += 1
-            continue
+            # Try next-line brace: declaration on line i, { on line i+1
+            m = _FUNC_RE_NOBRACE.match(lines[i])
+            if not m or i + 1 >= n or lines[i + 1].strip() != "{":
+                i += 1
+                continue
+            brace_start = i + 1  # brace is on the following line
         func_name = m.group(1) or m.group(2)
-        close = _find_close_brace(lines, i)
+        close = _find_close_brace(lines, brace_start)
         if close >= 0:
             yield (func_name, close - i + 1)
             i = close + 1

--- a/.agents/scripts/tests/test-complexity-advisory.sh
+++ b/.agents/scripts/tests/test-complexity-advisory.sh
@@ -266,6 +266,73 @@ assert 'kw_style' in r.get('permissionDecisionReason', ''), 'func name missing f
 	return 0
 }
 
+# --- Test 11: one-liner function → no spurious advisory (fix for j>start bug) ---
+test_oneliner_function_no_spurious_advisory() {
+	# A one-liner followed by an unrelated large function.
+	# Before the fix, the parser treated the entire rest of the file as the
+	# one-liner's body because depth reached 0 at j==start and j>start was False.
+	local large_body
+	large_body=$(python3 -c "print('  echo x\n' * 10)")
+	local content
+	content="$(printf 'oneliner() { :; }\n\nsmall_after() {\n%s}\n' "$large_body")"
+	local result
+	result=$(_edit_payload "test.sh" "$content" | python3 "$HOOK_SCRIPT" 2>/dev/null)
+	if [[ -z "$result" ]]; then
+		print_result "one-liner function → no spurious advisory for following small function" 0
+	else
+		print_result "one-liner function → no spurious advisory for following small function" 1 "unexpected output: $result"
+	fi
+	return 0
+}
+
+# --- Test 12: next-line brace style → detected and counted correctly ---
+test_next_line_brace_style() {
+	# func()
+	# {
+	#   body lines...
+	# }
+	local body_lines
+	body_lines=$(python3 -c "print('  echo x\n' * 90)")
+	local content
+	content="$(printf 'nextline_func()\n{\n%s}\n' "$body_lines")"
+	local result
+	result=$(_edit_payload "test.sh" "$content" | python3 "$HOOK_SCRIPT" 2>/dev/null)
+	if echo "$result" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+r = d.get('hookSpecificOutput', {})
+assert r.get('permissionDecision') == 'allow', 'permissionDecision != allow'
+assert 'nextline_func' in r.get('permissionDecisionReason', ''), 'func name missing'
+" 2>/dev/null; then
+		print_result "next-line brace style → detected and advisory emitted" 0
+	else
+		print_result "next-line brace style → detected and advisory emitted" 1 "output: $result"
+	fi
+	return 0
+}
+
+# --- Test 13: next-line brace with 'function' keyword style ---
+test_next_line_brace_keyword_style() {
+	local body_lines
+	body_lines=$(python3 -c "print('  echo x\n' * 90)")
+	local content
+	content="$(printf 'function kw_nextline\n{\n%s}\n' "$body_lines")"
+	local result
+	result=$(_edit_payload "test.sh" "$content" | python3 "$HOOK_SCRIPT" 2>/dev/null)
+	if echo "$result" | python3 -c "
+import json, sys
+d = json.load(sys.stdin)
+r = d.get('hookSpecificOutput', {})
+assert r.get('permissionDecision') == 'allow', 'permissionDecision != allow'
+assert 'kw_nextline' in r.get('permissionDecisionReason', ''), 'func name missing'
+" 2>/dev/null; then
+		print_result "next-line brace keyword style → detected and advisory emitted" 0
+	else
+		print_result "next-line brace keyword style → detected and advisory emitted" 1 "output: $result"
+	fi
+	return 0
+}
+
 # --- Main ---
 if [[ ! -f "$HOOK_SCRIPT" ]]; then
 	printf '%sFAIL%s Hook script not found: %s\n' "$TEST_RED" "$TEST_RESET" "$HOOK_SCRIPT"
@@ -282,6 +349,9 @@ test_write_tool_checked
 test_bash_tool_ignored
 test_always_allow
 test_function_keyword_style
+test_oneliner_function_no_spurious_advisory
+test_next_line_brace_style
+test_next_line_brace_keyword_style
 
 echo ""
 if [[ "$TESTS_FAILED" -eq 0 ]]; then


### PR DESCRIPTION
## Summary

Fixes two parser bugs in `.agents/hooks/complexity_advisory_pre_edit.py` surfaced by Gemini code review on PR #20924.

### Fix 1 — One-liner function false advisory (high priority)

**Root cause:** `_find_close_brace` had `if depth <= 0 and j > start`. For a one-liner like `func() { :; }`, brace depth reaches 0 on the declaration line (`j == start`), so `j > start` is `False` and the function never returns a valid close index. The parser fell through to the `else` branch and yielded the entire remaining file as the function body — producing false complexity advisories on any code that followed.

**Fix:** Remove `and j > start`. Depth 0 at `j == start` is only possible when braces are balanced on the declaration line (one-liner), which is exactly the case that should return immediately.

### Fix 2 — Next-line brace style not detected (medium priority)

**Root cause:** `_FUNC_RE` required `{` on the same line as the function declaration. Functions declared as `func()\n{` (brace on the following line) were silently skipped — false negatives in the advisory.

**Fix:** Added `_FUNC_RE_NOBRACE` regex for no-brace declarations and a look-ahead in `_iter_function_blocks` that checks whether the next line is exactly `{`. When matched, brace counting starts from `i+1` instead of `i`.

## Files changed

- `EDIT: .agents/hooks/complexity_advisory_pre_edit.py` — parser fixes
- `EDIT: .agents/scripts/tests/test-complexity-advisory.sh` — tests 11–13

## Tests

All 13 tests pass (10 pre-existing + 3 new regression tests):

- Test 11: one-liner function → no spurious advisory for code that follows it
- Test 12: next-line brace `func()\n{` → advisory emitted when large
- Test 13: next-line brace with `function` keyword → advisory emitted when large

Resolves #20956


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.27 with claude-sonnet-4-6 spent 13m and 13,980 tokens on this as a headless worker.