### PR TITLE
t2974: add ownership guards and fixture path-shape assertions at worktree-removal call sites

### DIFF
--- a/.agents/scripts/complexity-regression-helper.sh
+++ b/.agents/scripts/complexity-regression-helper.sh
@@ -58,10 +58,20 @@ HEAD_WORKTREE=""
 
 cleanup() {
 	if [ -n "$BASE_WORKTREE" ] && [ -d "$BASE_WORKTREE" ]; then
-		git worktree remove --force "$BASE_WORKTREE" >/dev/null 2>&1 || true
+		# Path-shape assertion (t2974): only remove paths matching the fixture pattern
+		if [[ "$BASE_WORKTREE" != */base-worktree ]]; then
+			log "WARN: Path '$BASE_WORKTREE' does not match fixture pattern — skipping remove"
+		else
+			git worktree remove --force "$BASE_WORKTREE" >/dev/null 2>&1 || true
+		fi
 	fi
 	if [ -n "$HEAD_WORKTREE" ] && [ -d "$HEAD_WORKTREE" ]; then
-		git worktree remove --force "$HEAD_WORKTREE" >/dev/null 2>&1 || true
+		# Path-shape assertion (t2974): only remove paths matching the fixture pattern
+		if [[ "$HEAD_WORKTREE" != */head-worktree ]]; then
+			log "WARN: Path '$HEAD_WORKTREE' does not match fixture pattern — skipping remove"
+		else
+			git worktree remove --force "$HEAD_WORKTREE" >/dev/null 2>&1 || true
+		fi
 	fi
 	if [ -n "$TMP_DIR" ] && [ -d "$TMP_DIR" ]; then
 		rm -rf "$TMP_DIR"

--- a/.agents/scripts/markdownlint-diff-helper.sh
+++ b/.agents/scripts/markdownlint-diff-helper.sh
@@ -33,7 +33,12 @@ BASE_WORKTREE=""
 
 cleanup() {
 	if [ -n "$BASE_WORKTREE" ] && [ -d "$BASE_WORKTREE" ]; then
-		git worktree remove --force "$BASE_WORKTREE" >/dev/null 2>&1 || true
+		# Path-shape assertion (t2974): only remove paths matching the fixture pattern
+		if [[ "$BASE_WORKTREE" != */base-tree ]]; then
+			log "WARN: Path '$BASE_WORKTREE' does not match fixture pattern — skipping remove"
+		else
+			git worktree remove --force "$BASE_WORKTREE" >/dev/null 2>&1 || true
+		fi
 	fi
 	if [ -n "$TMP_DIR" ] && [ -d "$TMP_DIR" ]; then
 		rm -rf "$TMP_DIR"

--- a/.agents/scripts/qlty-regression-helper.sh
+++ b/.agents/scripts/qlty-regression-helper.sh
@@ -42,10 +42,20 @@ HEAD_WORKTREE=""
 
 cleanup() {
 	if [ -n "$BASE_WORKTREE" ] && [ -d "$BASE_WORKTREE" ]; then
-		git worktree remove --force "$BASE_WORKTREE" >/dev/null 2>&1 || true
+		# Path-shape assertion (t2974): only remove paths matching the fixture pattern
+		if [[ "$BASE_WORKTREE" != */base-worktree ]]; then
+			log "WARN: Path '$BASE_WORKTREE' does not match fixture pattern — skipping remove"
+		else
+			git worktree remove --force "$BASE_WORKTREE" >/dev/null 2>&1 || true
+		fi
 	fi
 	if [ -n "$HEAD_WORKTREE" ] && [ -d "$HEAD_WORKTREE" ]; then
-		git worktree remove --force "$HEAD_WORKTREE" >/dev/null 2>&1 || true
+		# Path-shape assertion (t2974): only remove paths matching the fixture pattern
+		if [[ "$HEAD_WORKTREE" != */head-worktree ]]; then
+			log "WARN: Path '$HEAD_WORKTREE' does not match fixture pattern — skipping remove"
+		else
+			git worktree remove --force "$HEAD_WORKTREE" >/dev/null 2>&1 || true
+		fi
 	fi
 	if [ -n "$TMP_DIR" ] && [ -d "$TMP_DIR" ]; then
 		rm -rf "$TMP_DIR"

--- a/.agents/scripts/skill-update-helper.sh
+++ b/.agents/scripts/skill-update-helper.sh
@@ -1401,6 +1401,11 @@ _cleanup_worktree() {
 	ahead=$(git -C "$wt_path" rev-list --count "${default_branch}..HEAD" 2>/dev/null || echo "0")
 
 	if [[ "$ahead" -eq 0 ]]; then
+		# Ownership check (t2974): refuse to remove worktrees owned by other sessions
+		if is_worktree_owned_by_others "$wt_path"; then
+			log_warn "Skipping removal of worktree owned by another session: $wt_path"
+			return 0
+		fi
 		log_info "Cleaning up empty worktree: $wt_path"
 		git worktree remove "$wt_path" --force 2>/dev/null || true
 		git branch -D "$branch" 2>/dev/null || true


### PR DESCRIPTION
## Summary

Closes the worktree-removal bypass identified in Phase 1 (t2973/#21272) by adding two complementary defenses at unprotected call sites:

1. **Registry ownership check** (`skill-update-helper.sh`) — `_cleanup_worktree` now calls `is_worktree_owned_by_others` before executing `git worktree remove --force`, modelled on `worktree-helper.sh:1183`. A worktree owned by another session is skipped with a `log_warn` and the function returns `0` (non-blocking — the script's other cleanup still proceeds).

2. **Fixture path-shape assertions** (`qlty-regression-helper.sh`, `complexity-regression-helper.sh`, `markdownlint-diff-helper.sh`) — each `cleanup()` EXIT-trap function now guards the `git worktree remove --force` call with a substring match before executing. If the path does not match the expected fixture suffix (e.g. `*/base-worktree`, `*/head-worktree`, `*/base-tree`), the remove is skipped and a `WARN` log line is emitted instead. The `TMP_DIR` cleanup still runs regardless, so the function never leaves temp state behind.

### `orphan-defaultbranch-guard.sh` — rationale for exemption

The file `orphan-defaultbranch-guard.sh` does not exist in this repository (confirmed via `git ls-files`). The Phase 1 issue (#21272) references it as a potential site but the file has not been created. No registry check can be added to a non-existent file. This is documented here for the Phase 3 worker.

## Files changed

- `EDIT: .agents/scripts/skill-update-helper.sh:1403-1412` — ownership guard
- `EDIT: .agents/scripts/qlty-regression-helper.sh:43-62` — path-shape assertions
- `EDIT: .agents/scripts/complexity-regression-helper.sh:59-78` — path-shape assertions
- `EDIT: .agents/scripts/markdownlint-diff-helper.sh:34-46` — path-shape assertion

## Verification

```
shellcheck .agents/scripts/skill-update-helper.sh
shellcheck .agents/scripts/qlty-regression-helper.sh
shellcheck .agents/scripts/complexity-regression-helper.sh
shellcheck .agents/scripts/markdownlint-diff-helper.sh
```

All four pass with zero violations (confirmed locally before commit).

Resolves #21274
For #21055


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.26 with claude-sonnet-4-6 spent 4m and 13,945 tokens on this as a headless worker.
