### PR TITLE
t2966: Markdoc tag namespace — define 7 JSON schemas (Phase 1)

### DIFF
--- a/.agents/tools/markdoc/schemas/README.md
+++ b/.agents/tools/markdoc/schemas/README.md
@@ -1,0 +1,45 @@
+# Markdoc Tag Schemas
+
+Canonical JSON schemas for the aidevops Markdoc tag namespace. These schemas define the attributes, types, scope rules, and examples for each tag. All subsequent phases (validator, extractor, migration, consumers) parse against these schemas as the single source of truth.
+
+## Namespace Convention
+
+Tags follow the [Markdoc tag grammar](https://markdoc.dev/docs/tags):
+
+- **Block tags** (wrap content): `{% tag attr="value" %} ... {% /tag %}`
+- **Self-closing tags** (inline markers): `{% tag attr="value" /%}`
+
+Tag names are lowercase, hyphenated. Attribute values use double quotes for strings; numbers are unquoted.
+
+## Tag Inventory
+
+| Tag | Scope | Description |
+|-----|-------|-------------|
+| `sensitivity` | file, section, inline | Data-sensitivity classification tier |
+| `provenance` | file, section | Source origin and extraction metadata |
+| `case-attach` | section, inline | Links content to a legal/business case |
+| `citation` | inline | Inline source citation with optional page reference |
+| `redaction` | section, inline | Marks content for redaction in output |
+| `draft-status` | file, section | Editorial lifecycle status tracking |
+| `link` | inline | Typed link with semantic kind classification |
+
+## Schema Structure
+
+Each JSON schema file contains:
+
+- `name` — tag identifier (matches filename without extension)
+- `description` — purpose and usage context
+- `attributes` — object with each attribute's `type`, `required`, `enum` (where applicable), and `description`
+- `scope_rules` — `allowed` array (file/section/inline) and scope `description`
+- `example` — valid Markdoc syntax demonstrating the tag
+
+## Validation
+
+```bash
+# Verify all schemas are valid JSON
+for f in .agents/tools/markdoc/schemas/*.json; do jq . "$f" > /dev/null && echo "OK: $f"; done
+```
+
+## Parent Task
+
+Decomposition child of t2874 (parent: GH#20966). Phase 1 of 5.

--- a/.agents/tools/markdoc/schemas/case-attach.json
+++ b/.agents/tools/markdoc/schemas/case-attach.json
@@ -1,0 +1,22 @@
+{
+  "name": "case-attach",
+  "description": "Links content to a legal or business case, establishing the relationship between the tagged content and the case record.",
+  "attributes": {
+    "case-id": {
+      "type": "string",
+      "required": true,
+      "description": "Unique case identifier (e.g. docket number, internal case reference, matter ID)."
+    },
+    "relation": {
+      "type": "string",
+      "required": false,
+      "enum": ["evidence", "timeline", "exhibit", "correspondence"],
+      "description": "Nature of the relationship. evidence = supporting fact; timeline = chronological event; exhibit = formal attachment; correspondence = communication record."
+    }
+  },
+  "scope_rules": {
+    "allowed": ["section", "inline"],
+    "description": "Section-level attaches a block of content to a case. Inline attaches a specific reference or mention."
+  },
+  "example": "{% case-attach case-id=\"CASE-2026-0042\" relation=\"exhibit\" %}\nEmail thread between parties dated 2026-01-10.\n{% /case-attach %}"
+}

--- a/.agents/tools/markdoc/schemas/citation.json
+++ b/.agents/tools/markdoc/schemas/citation.json
@@ -1,0 +1,28 @@
+{
+  "name": "citation",
+  "description": "Inline citation linking a claim or quote to its source document, with optional page reference and confidence score.",
+  "attributes": {
+    "source-id": {
+      "type": "string",
+      "required": true,
+      "description": "Identifier of the cited source (matches a provenance source-id or an external reference key)."
+    },
+    "page": {
+      "type": "string",
+      "required": false,
+      "description": "Page, section, or paragraph locator within the source (e.g. \"p.12\", \"s.3.1\", \"para.7\")."
+    },
+    "confidence": {
+      "type": "number",
+      "required": false,
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Confidence that the citation accurately represents the source (0.0 = paraphrased loosely, 1.0 = verbatim quote)."
+    }
+  },
+  "scope_rules": {
+    "allowed": ["inline"],
+    "description": "Citations are always inline — they annotate a specific claim or quote within running text."
+  },
+  "example": "The contract requires delivery by Q3 {% citation source-id=\"exhibit-A-contract.pdf\" page=\"p.4\" confidence=1.0 /%}"
+}

--- a/.agents/tools/markdoc/schemas/draft-status.json
+++ b/.agents/tools/markdoc/schemas/draft-status.json
@@ -1,0 +1,22 @@
+{
+  "name": "draft-status",
+  "description": "Tracks the editorial lifecycle status of a document or section. Used to gate publication, flag review needs, and record approval state.",
+  "attributes": {
+    "status": {
+      "type": "string",
+      "required": true,
+      "enum": ["draft", "review", "approved", "archived"],
+      "description": "Current lifecycle stage. draft = work in progress; review = awaiting sign-off; approved = cleared for use; archived = superseded or withdrawn."
+    },
+    "assignee": {
+      "type": "string",
+      "required": false,
+      "description": "Person or role responsible for the current status transition (e.g. reviewer username, approver name)."
+    }
+  },
+  "scope_rules": {
+    "allowed": ["file", "section"],
+    "description": "File-level sets the status for the entire document. Section-level allows different parts of a document to be at different lifecycle stages."
+  },
+  "example": "{% draft-status status=\"review\" assignee=\"jane.doe\" %}\nThis analysis is pending legal review before client distribution.\n{% /draft-status %}"
+}

--- a/.agents/tools/markdoc/schemas/link.json
+++ b/.agents/tools/markdoc/schemas/link.json
@@ -1,0 +1,22 @@
+{
+  "name": "link",
+  "description": "Typed link to an external or internal resource. Extends standard markdown links with a semantic kind attribute for classification and indexing.",
+  "attributes": {
+    "target": {
+      "type": "string",
+      "required": true,
+      "description": "URI, file path, or resource identifier that the link points to."
+    },
+    "kind": {
+      "type": "string",
+      "required": false,
+      "enum": ["brand-asset", "reference", "source", "exhibit"],
+      "description": "Semantic type of the linked resource. brand-asset = logo/trademark; reference = background reading; source = primary source material; exhibit = formal case exhibit."
+    }
+  },
+  "scope_rules": {
+    "allowed": ["inline"],
+    "description": "Links are always inline — they annotate a specific reference point within running text."
+  },
+  "example": "See the original filing {% link target=\"exhibits/filing-2026-001.pdf\" kind=\"exhibit\" /%} for full details."
+}

--- a/.agents/tools/markdoc/schemas/provenance.json
+++ b/.agents/tools/markdoc/schemas/provenance.json
@@ -1,0 +1,29 @@
+{
+  "name": "provenance",
+  "description": "Records the origin of extracted or ingested content — which source document it came from, when it was extracted, and the extraction confidence score.",
+  "attributes": {
+    "source-id": {
+      "type": "string",
+      "required": true,
+      "description": "Unique identifier for the source document (e.g. filename, URL, case exhibit ID)."
+    },
+    "extracted-at": {
+      "type": "string",
+      "required": true,
+      "format": "iso-date",
+      "description": "ISO 8601 date (YYYY-MM-DD or full datetime) when the content was extracted from the source."
+    },
+    "confidence": {
+      "type": "number",
+      "required": false,
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Extraction confidence score (0.0 = uncertain, 1.0 = verbatim). Omit when extraction is manual/verified."
+    }
+  },
+  "scope_rules": {
+    "allowed": ["file", "section"],
+    "description": "File-level marks the entire document as originating from one source. Section-level marks a block extracted from a specific source within a multi-source document."
+  },
+  "example": "{% provenance source-id=\"exhibit-A-contract.pdf\" extracted-at=\"2026-03-15\" confidence=0.95 %}\nThe vendor agrees to deliver by Q3 2026.\n{% /provenance %}"
+}

--- a/.agents/tools/markdoc/schemas/redaction.json
+++ b/.agents/tools/markdoc/schemas/redaction.json
@@ -1,0 +1,21 @@
+{
+  "name": "redaction",
+  "description": "Marks content for redaction in output renders. The tagged content is replaced with a redaction placeholder, preserving the reason and optional redactor identity for audit trails.",
+  "attributes": {
+    "reason": {
+      "type": "string",
+      "required": true,
+      "description": "Why the content is redacted (e.g. \"PII\", \"attorney-client privilege\", \"trade secret\", \"ongoing investigation\")."
+    },
+    "redacted-by": {
+      "type": "string",
+      "required": false,
+      "description": "Identity of the person or process that applied the redaction (e.g. username, role, or automated pipeline name)."
+    }
+  },
+  "scope_rules": {
+    "allowed": ["section", "inline"],
+    "description": "Section-level redacts an entire block. Inline redacts a specific phrase or value within running text."
+  },
+  "example": "The payment was made to {% redaction reason=\"PII\" redacted-by=\"legal-review\" %}John Smith at 123 Main St{% /redaction %} on 2026-02-14."
+}

--- a/.agents/tools/markdoc/schemas/sensitivity.json
+++ b/.agents/tools/markdoc/schemas/sensitivity.json
@@ -1,0 +1,23 @@
+{
+  "name": "sensitivity",
+  "description": "Marks content with a data-sensitivity classification tier. Applied at file, section, or inline scope to control visibility, redaction policy, and access gating.",
+  "attributes": {
+    "tier": {
+      "type": "string",
+      "required": true,
+      "enum": ["public", "internal", "confidential", "privileged", "redacted"],
+      "description": "Classification level. public = unrestricted; internal = org-visible; confidential = need-to-know; privileged = legal hold; redacted = scrubbed output."
+    },
+    "scope": {
+      "type": "string",
+      "required": false,
+      "enum": ["file", "section", "inline"],
+      "description": "Granularity of the classification. Defaults to the tag's positional scope when omitted."
+    }
+  },
+  "scope_rules": {
+    "allowed": ["file", "section", "inline"],
+    "description": "File-level wraps the entire document. Section-level wraps a heading block. Inline marks a phrase or span."
+  },
+  "example": "{% sensitivity tier=\"confidential\" scope=\"section\" %}\nThis section contains client-confidential analysis.\n{% /sensitivity %}"
+}


### PR DESCRIPTION
## Summary

Defines the Markdoc-compatible tag namespace and 7 JSON schemas that all subsequent phases (validator, extractor, migration, consumers) depend on.

## What Changed

Created `.agents/tools/markdoc/schemas/` with 8 files:

- `sensitivity.json` — data-sensitivity classification tiers (public/internal/confidential/privileged/redacted)
- `provenance.json` — source origin and extraction metadata
- `case-attach.json` — legal/business case linking
- `citation.json` — inline source citations with page reference
- `redaction.json` — content redaction markers
- `draft-status.json` — editorial lifecycle status tracking
- `link.json` — typed semantic links
- `README.md` — namespace convention and tag inventory

Each schema includes: `name`, `description`, `attributes` (with types, required flags, enums), `scope_rules`, and `example`.

## Testing

- All 7 JSON schemas validate via `jq . <file>` (exit 0)
- Pre-commit hooks passed
- Directory contains expected 8 files

## MERGE_SUMMARY

**Implementation:** Created 7 Markdoc tag JSON schemas and README in `.agents/tools/markdoc/schemas/`. Schema-first approach: each schema defines the canonical attribute shapes that Phase 2 (validator), Phase 3 (extractor), Phase 4 (migration), and Phase 5 (PageIndex consumer) will parse against.

Resolves #21254

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.26 with claude-opus-4-6 spent 2m and 6,347 tokens on this as a headless worker.
