### PR TITLE
fix: canonical caller templates use explicit secret pass-through (GH#20976)

### DIFF
--- a/.agents/reference/reusable-workflows.md
+++ b/.agents/reference/reusable-workflows.md
@@ -95,7 +95,8 @@ jobs:
     uses: marcusquinn/aidevops/.github/workflows/issue-sync-reusable.yml@v3.9.0
     #                                                                   ^^^^^^^
     #                                                                   change this
-    secrets: inherit
+    secrets:
+      SYNC_PAT: ${{ secrets.SYNC_PAT }}
 ```
 
 Keep pinned callers in sync with aidevops releases via:
@@ -109,7 +110,29 @@ See also [`auto-dispatch.md`](auto-dispatch.md) for the `SYNC_PAT` requirement (
 
 ## Security model
 
-- **`secrets: inherit`** in the caller grants the reusable workflow access to all the caller's secrets. This is intentional — `SYNC_PAT` is the only secret the reusable workflow needs, and it varies per-repo. `inherit` is the simplest way to expose it without listing every secret by name.
+- **`secrets: inherit` only works within the same GitHub account/org (GH#20976).** Cross-account callers (every downstream user — `marcusquinn/aidevops` is the only same-account consumer) receive empty values for caller-repo secrets when using `secrets: inherit` against a reusable workflow in a different account. Explicit secret pass-through is required:
+
+  ```yaml
+  # CORRECT for cross-account consumers (canonical template uses this):
+  jobs:
+    sync:
+      uses: marcusquinn/aidevops/.github/workflows/issue-sync-reusable.yml@main
+      secrets:
+        SYNC_PAT: ${{ secrets.SYNC_PAT }}
+
+  # BROKEN for cross-account consumers (SYNC_PAT resolves to empty):
+  jobs:
+    sync:
+      uses: marcusquinn/aidevops/.github/workflows/issue-sync-reusable.yml@main
+      secrets: inherit   # ← only works within the same account/org
+  ```
+
+  The canonical caller templates (`issue-sync-caller.yml`, `loc-badge-caller.yml`) use explicit pass-through. `review-bot-gate-caller.yml` and `maintainer-gate-caller.yml` keep `secrets: inherit` because they only reference `secrets.GITHUB_TOKEN` internally — `GITHUB_TOKEN` is always provided by the runner and is unaffected by the cross-account limitation.
+
+  If a new user-defined secret is added to a reusable workflow's `secrets:` input block, the matching caller template MUST also add it as an explicit `secrets: MySecret: ${{ secrets.MySecret }}` entry. This is the enumeration trade-off of explicit pass-through — adding a new optional secret upstream requires a template bump + `aidevops sync-workflows --apply` on consumers. It is preferable to silently broken cross-account inherit.
+
+  **Symptom of the cross-account bug**: `gh secret list` shows `SYNC_PAT` set and recent, but the workflow's `Check SYNC_PAT visibility` step logs `SYNC_PAT_PRESENT:` (empty). Fix: `aidevops sync-workflows --apply`.
+
 - **Referencing `@main` is a trust boundary.** You're trusting whoever controls aidevops's `main` branch. For higher-trust deployments, pin to a version tag (`@v3.9.0`) and update explicitly.
 - **`pull_request_target` vs `pull_request`.** The reusable workflow's job guards accept either event type. The caller picks based on its security model:
   - **Private repo with trusted contributors**: `pull_request` is simpler and has fewer footguns.
@@ -117,6 +140,20 @@ See also [`auto-dispatch.md`](auto-dispatch.md) for the `SYNC_PAT` requirement (
 - **`default_workflow_permissions: read` repos (GH#20967).** GitHub's recommended security default is `default_workflow_permissions: read`. Reusable workflow job-level `permissions:` declarations cannot exceed the CALLER's ceiling — they are capped at whatever the caller workflow grants. A caller with no `permissions:` block inherits the repo's restrictive default, so GitHub refuses to create any jobs (`conclusion: startup_failure`, zero jobs). The canonical caller templates include a top-level `permissions:` block that is the union of all job-level permissions used by the reusable workflow. If you add a new permission to a reusable workflow job, also update the matching caller template.
 
   Verification: `gh api repos/OWNER/REPO/actions/permissions/workflow --jq .default_workflow_permissions` returns `"read"` or `"write"`. A `"read"` repo will fail without the caller's `permissions:` block.
+
+## Framework self-test assumption guard
+
+Both GH#20967 (missing `permissions:` block) and GH#20976 (`secrets: inherit` cross-account failure) share the same root cause class: the canonical caller templates were authored against the framework's own self-test scenario (`marcusquinn/aidevops` calling itself) which has same-account and same-repo semantics that don't hold for downstream consumers.
+
+When authoring or reviewing a canonical caller template, apply this checklist to catch the pattern before it ships:
+
+| Check | Self-test passes? | Downstream breaks? | Gate |
+|---|---|---|---|
+| `secrets: inherit` for user-defined secrets | Yes (same-account) | Yes (cross-account empty) | Always use explicit `secrets: MySecret: ${{ secrets.MySecret }}` for user-defined secrets |
+| Missing `permissions:` block | Yes (`default_workflow_permissions: write` on framework repo) | Yes (`startup_failure` on read-default repos) | Always include a top-level `permissions:` block with the union of all job-level permissions |
+| Hardcoded `marcusquinn` org references | Yes (same repo) | Possible (wrong org) | Use `github.repository_owner` or `inputs:` for org-specific values |
+
+This checklist lives here so the next "framework self-test passes, downstream broken" instance surfaces during template authoring, not after a downstream user files a bug report.
 
 ## Migration: from copied workflow to caller
 
@@ -162,6 +199,8 @@ To make a new aidevops workflow reusable by downstream repos:
 - Issue [#20648](https://github.com/marcusquinn/aidevops/issues/20648) — Phase 1 drift detector
 - Issue [#20649](https://github.com/marcusquinn/aidevops/issues/20649) — Phase 2 opt-in resync
 - Issue [#20727](https://github.com/marcusquinn/aidevops/issues/20727) — review-bot-gate migration (SHA-pin stale drift)
+- Issue [#20967](https://github.com/marcusquinn/aidevops/issues/20967) — missing `permissions:` block in caller template (sister bug, same root cause class)
+- Issue [#20976](https://github.com/marcusquinn/aidevops/issues/20976) — `secrets: inherit` fails cross-account; canonical template switched to explicit pass-through
 - Issue [#21154](https://github.com/marcusquinn/aidevops/issues/21154) — maintainer-gate migration (layer-1 defense-in-depth propagation)
 - Reference [incident-gh17671-supply-chain.md](incident-gh17671-supply-chain.md) — postmortem that motivated maintainer-gate propagation
 - GitHub docs: [Reusing workflows](https://docs.github.com/en/actions/using-workflows/reusing-workflows)

--- a/.agents/templates/workflows/issue-sync-caller.yml
+++ b/.agents/templates/workflows/issue-sync-caller.yml
@@ -55,6 +55,12 @@ on:
 jobs:
   sync:
     uses: marcusquinn/aidevops/.github/workflows/issue-sync-reusable.yml@main
-    secrets: inherit
+    # GH#20976: `secrets: inherit` only works within the same GitHub account/org.
+    # Cross-account consumers (every downstream user) receive empty values for any
+    # caller-repo secret when using `secrets: inherit` against a cross-account
+    # reusable workflow. Explicit pass-through is required for secrets to resolve.
+    # If a new secret is added to issue-sync-reusable.yml, add it here too.
+    secrets:
+      SYNC_PAT: ${{ secrets.SYNC_PAT }}
     with:
       command: ${{ inputs.command || '' }}

--- a/.agents/templates/workflows/loc-badge-caller.yml
+++ b/.agents/templates/workflows/loc-badge-caller.yml
@@ -34,7 +34,11 @@ on:
 jobs:
   badges:
     uses: marcusquinn/aidevops/.github/workflows/loc-badge-reusable.yml@main
-    secrets: inherit
+    # GH#20976: `secrets: inherit` only works within the same GitHub account/org.
+    # Cross-account consumers (every downstream user) must pass secrets explicitly.
+    # If a new secret is added to loc-badge-reusable.yml, add it here too.
+    secrets:
+      SYNC_PAT: ${{ secrets.SYNC_PAT }}
     # Optional input overrides — uncomment and edit as needed:
     # with:
     #   top_n: 8

--- a/.github/workflows/issue-sync-reusable.yml
+++ b/.github/workflows/issue-sync-reusable.yml
@@ -65,6 +65,8 @@ jobs:
       # t2166: emit a visible warning when SYNC_PAT is unset so operators
       # see on every run — not just after GH006 — that TODO.md push will
       # fall back to GITHUB_TOKEN and be rejected by branch protection.
+      # GH#20976: SYNC_PAT can also appear empty if the caller uses
+      # `secrets: inherit` against a cross-account reusable workflow.
       - name: Check SYNC_PAT visibility (t2166)
         if: steps.check-author.outputs.skip != 'true'
         env:
@@ -72,9 +74,9 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           if [[ -z "${SYNC_PAT_PRESENT:-}" ]]; then
-            echo "::warning::SYNC_PAT secret is not set — TODO.md auto-sync push will be rejected by branch protection (GH006)."
-            echo "::warning::Fix: gh secret set SYNC_PAT --repo ${REPO} --body \"<FINE_GRAINED_PAT>\" (Contents: Read and write)"
-            echo "::warning::See todo/tasks/t2166-brief.md for the SYNC_PAT setup walkthrough."
+            echo "::warning::SYNC_PAT not present in this run — TODO.md push will be rejected by branch protection (GH006)."
+            echo "::warning::Cause A (secret not set): gh secret set SYNC_PAT --repo ${REPO} --body '<FINE_GRAINED_PAT>' (Contents: Read and write)"
+            echo "::warning::Cause B (cross-account caller): your caller uses 'secrets: inherit' which fails cross-account — run: aidevops sync-workflows --apply (see GH#20976)"
           else
             echo "::notice::SYNC_PAT present — TODO.md push will use PAT (bypasses branch protection via enforce_admins:false)"
           fi
@@ -211,6 +213,8 @@ jobs:
       # t2166: SYNC_PAT visibility — this job also pushes TODO.md updates
       # on every issue-opened/closed event, so it hits the same GH006 when
       # SYNC_PAT is unset. Warn explicitly before doing any work.
+      # GH#20976: SYNC_PAT can also appear empty if the caller uses
+      # `secrets: inherit` against a cross-account reusable workflow.
       - name: Check SYNC_PAT visibility (t2166)
         if: steps.check-issue.outputs.sync == 'true'
         env:
@@ -218,8 +222,9 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           if [[ -z "${SYNC_PAT_PRESENT:-}" ]]; then
-            echo "::warning::SYNC_PAT secret is not set — TODO.md auto-sync push will be rejected by branch protection (GH006)."
-            echo "::warning::Fix: gh secret set SYNC_PAT --repo ${REPO} --body \"<FINE_GRAINED_PAT>\" (Contents: Read and write)"
+            echo "::warning::SYNC_PAT not present in this run — TODO.md push will be rejected by branch protection (GH006)."
+            echo "::warning::Cause A (secret not set): gh secret set SYNC_PAT --repo ${REPO} --body '<FINE_GRAINED_PAT>' (Contents: Read and write)"
+            echo "::warning::Cause B (cross-account caller): your caller uses 'secrets: inherit' which fails cross-account — run: aidevops sync-workflows --apply (see GH#20976)"
           else
             echo "::notice::SYNC_PAT present — TODO.md push will use PAT"
           fi
@@ -295,14 +300,17 @@ jobs:
 
     steps:
       # t2166: SYNC_PAT visibility for manual dispatch runs too.
+      # GH#20976: SYNC_PAT can also appear empty if the caller uses
+      # `secrets: inherit` against a cross-account reusable workflow.
       - name: Check SYNC_PAT visibility (t2166)
         env:
           SYNC_PAT_PRESENT: ${{ secrets.SYNC_PAT != '' && 'true' || '' }}
           REPO: ${{ github.repository }}
         run: |
           if [[ -z "${SYNC_PAT_PRESENT:-}" ]]; then
-            echo "::warning::SYNC_PAT secret is not set — any TODO.md push from this manual run will be rejected by branch protection (GH006)."
-            echo "::warning::Fix: gh secret set SYNC_PAT --repo ${REPO} --body \"<FINE_GRAINED_PAT>\" (Contents: Read and write)"
+            echo "::warning::SYNC_PAT not present in this run — any TODO.md push from this manual run will be rejected by branch protection (GH006)."
+            echo "::warning::Cause A (secret not set): gh secret set SYNC_PAT --repo ${REPO} --body '<FINE_GRAINED_PAT>' (Contents: Read and write)"
+            echo "::warning::Cause B (cross-account caller): your caller uses 'secrets: inherit' which fails cross-account — run: aidevops sync-workflows --apply (see GH#20976)"
           else
             echo "::notice::SYNC_PAT present — TODO.md push will use PAT"
           fi
@@ -391,14 +399,17 @@ jobs:
       # Ensures the warning/notice emits unconditionally on every merged PR,
       # not just when the downstream TODO.md proof-log path actually runs
       # (which is skipped by range-syntax titles and planning-only PR bodies).
+      # GH#20976: SYNC_PAT can also appear empty if the caller uses
+      # `secrets: inherit` against a cross-account reusable workflow.
       - name: Check SYNC_PAT visibility (t2166)
         env:
           SYNC_PAT_PRESENT: ${{ secrets.SYNC_PAT != '' && 'true' || '' }}
           REPO: ${{ github.repository }}
         run: |
           if [[ -z "${SYNC_PAT_PRESENT:-}" ]]; then
-            echo "::warning::SYNC_PAT secret is not set — TODO.md auto-sync push will be rejected by branch protection (GH006)."
-            echo "::warning::Fix: gh secret set SYNC_PAT --repo ${REPO} --body \"<FINE_GRAINED_PAT>\" (Contents: Read and write)"
+            echo "::warning::SYNC_PAT not present in this run — TODO.md auto-sync push will be rejected by branch protection (GH006)."
+            echo "::warning::Cause A (secret not set): gh secret set SYNC_PAT --repo ${REPO} --body '<FINE_GRAINED_PAT>' (Contents: Read and write)"
+            echo "::warning::Cause B (cross-account caller): your caller uses 'secrets: inherit' which fails cross-account — run: aidevops sync-workflows --apply (see GH#20976)"
           else
             echo "::notice::SYNC_PAT present — TODO.md push will use PAT"
           fi

--- a/.github/workflows/loc-badge-reusable.yml
+++ b/.github/workflows/loc-badge-reusable.yml
@@ -71,6 +71,8 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
+      # GH#20976: SYNC_PAT can appear empty even when set on the caller if the
+      # caller uses `secrets: inherit` against a cross-account reusable workflow.
       - name: Check SYNC_PAT visibility
         if: steps.check-author.outputs.skip != 'true'
         env:
@@ -78,8 +80,9 @@ jobs:
           REPO: ${{ github.repository }}
         run: |
           if [[ -z "${SYNC_PAT_PRESENT:-}" ]]; then
-            echo "::warning::SYNC_PAT is not set — badge commit may be rejected by branch protection (GH006)."
-            echo "::warning::Fix: gh secret set SYNC_PAT --repo ${REPO} (Contents: Read and write)"
+            echo "::warning::SYNC_PAT not present in this run — badge commit may be rejected by branch protection (GH006)."
+            echo "::warning::Cause A (secret not set): gh secret set SYNC_PAT --repo ${REPO} (Contents: Read and write)"
+            echo "::warning::Cause B (cross-account caller): your caller uses 'secrets: inherit' which fails cross-account — run: aidevops sync-workflows --apply (see GH#20976)"
           else
             echo "::notice::SYNC_PAT present — badge commit will use PAT"
           fi


### PR DESCRIPTION
## Summary

Fixes the cross-account `secrets: inherit` failure that caused `SYNC_PAT` to arrive empty in reusable workflow runs for every downstream consumer (every repo not in the `marcusquinn` account).

### Root cause

GitHub Actions `secrets: inherit` only passes caller secrets to reusable workflows within the same account/org. Cross-account callers — which is every downstream user of these templates — receive empty strings for any user-defined secret passed via `secrets: inherit`. The canonical caller templates were authored against the framework's own self-test (`marcusquinn/aidevops` calling itself), which has same-account semantics that do not hold for downstream consumers.

### Changes

- `.agents/templates/workflows/issue-sync-caller.yml` — `secrets: inherit` → explicit `SYNC_PAT: ${{ secrets.SYNC_PAT }}` (primary fix, AC#1+2)
- `.agents/templates/workflows/loc-badge-caller.yml` — same fix (`loc-badge-reusable.yml` also declares `SYNC_PAT`, same failure mode)
- `.github/workflows/issue-sync-reusable.yml` — all 4 `Check SYNC_PAT visibility` steps updated: was "SYNC_PAT secret is not set" (misleading), now distinguishes Cause A (secret not set) from Cause B (cross-account inherit failure) with actionable fix for each (AC#4)
- `.github/workflows/loc-badge-reusable.yml` — same diagnostic update
- `.agents/reference/reusable-workflows.md` — documents the cross-account inherit limitation, explicit pass-through rationale, enumeration trade-off, and a framework self-test assumption guard checklist (AC#3+5)

`review-bot-gate-caller.yml` and `maintainer-gate-caller.yml` keep `secrets: inherit` — they only reference `secrets.GITHUB_TOKEN` which is always provided by the runner and unaffected by cross-account limitations.

### Verification

After `aidevops sync-workflows --apply` on a downstream consumer repo, the generated caller will use explicit secret pass-through and `SYNC_PAT` will resolve correctly inside the reusable workflow.

Sister bug: #20967 (same root cause class).

Resolves #20976

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.27 with claude-sonnet-4-6 as a headless worker.