### PR TITLE
t2938: convert file-size pre-commit gate from absolute count to ratchet-based

### DIFF
--- a/.agents/scripts/file-size-regression-helper.sh
+++ b/.agents/scripts/file-size-regression-helper.sh
@@ -1,0 +1,576 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# file-size-regression-helper.sh — ratchet gate for shell/Python file line count (t2938)
+#
+# Converts the absolute file-size gate from linters-local.sh into a net-increase
+# (ratchet) gate. Block only when the PR adds files over the limit, not for
+# pre-existing debt. Mirrors qlty-regression-helper.sh (t2065) and complements
+# complexity-regression-helper.sh (t2171).
+#
+# Subcommands:
+#   scan      <dir>  [--output <file>] [--limit <N>]
+#                    Scan a directory for .sh/.py files over <limit> lines.
+#                    Outputs TSV: relative-path TAB line-count.
+#   scan-ref  <ref>  [--output <file>] [--limit <N>]
+#                    Same as scan but reads content from a git ref (no checkout).
+#                    Outputs TSV: git-tracked-path TAB line-count.
+#   diff      --base-file <f> --head-file <f>
+#             [--base-sha <sha>] [--head-sha <sha>]
+#             [--output-md <file>] [--allow-increase] [--docs-only]
+#                    Compare two scan TSV outputs. Exit 1 on regression.
+#   check     [--base <ref>] [--head <ref>] [--limit <N>]
+#             [--output-md <file>] [--allow-increase] [--dry-run]
+#                    High-level: scan-ref base + scan-ref head + diff.
+#
+# Exit codes:
+#   0 — no regression (or override / dry-run / docs-only)
+#   1 — regression detected
+#   2 — invocation or environment error
+#
+# Regression is triggered by EITHER:
+#   (a) head violation count > base violation count  (net increase)
+#   (b) any file present in head violations but absent from base violations
+#       (prevents gaming by deleting one oversized file and adding another)
+#
+# Override: apply `complexity-bump-ok` label + `## Complexity Bump Justification`
+# section to the PR body. The CI workflow enforces the justification check.
+# See: reference/large-file-split.md §4.1 for override semantics.
+#
+# Design notes:
+# - scan-ref uses `git show <ref>:<path> | wc -l` per file. No worktrees needed.
+#   Slightly slower than worktrees for large repos but avoids tree disturbance.
+# - All subcommands are Bash 3.2 compatible (macOS default shell).
+# - Paths in TSV output are relative to the dir/ref root for portability.
+# - docs-only detection: caller passes --docs-only; the gate exits 0 immediately.
+
+set -uo pipefail
+
+SCRIPT_NAME=$(basename "$0")
+readonly FILE_SIZE_DEFAULT_LIMIT=1500
+
+# ---------------------------------------------------------------------------
+# Logging helpers
+# ---------------------------------------------------------------------------
+
+log() {
+	local _msg="$1"
+	printf '[%s] %s\n' "$SCRIPT_NAME" "$_msg" >&2
+	return 0
+}
+
+die() {
+	local _msg="$1"
+	printf '[%s] ERROR: %s\n' "$SCRIPT_NAME" "$_msg" >&2
+	exit 2
+}
+
+# ---------------------------------------------------------------------------
+# scan_violations_dir <dir> <limit>
+# Scan a plain directory for .sh/.py files with more than <limit> lines.
+# Outputs TSV: path-relative-to-dir TAB line-count  (sorted by path).
+# ---------------------------------------------------------------------------
+scan_violations_dir() {
+	local _dir="$1"
+	local _limit="$2"
+	local _dir_abs
+	_dir_abs=$(cd "$_dir" && pwd) || die "directory not found: $_dir"
+	local _tmp
+	_tmp=$(mktemp)
+	# shellcheck disable=SC2064
+	trap "rm -f '$_tmp'" RETURN
+
+	find "$_dir_abs" -type f \( -name "*.sh" -o -name "*.py" \) | sort | while IFS= read -r _f; do
+		local _lc
+		_lc=$(wc -l < "$_f") || _lc=0
+		_lc=${_lc//[^0-9]/}
+		_lc=${_lc:-0}
+		if [ "$_lc" -gt "$_limit" ]; then
+			local _rel="${_f#"${_dir_abs}"/}"
+			printf '%s\t%d\n' "$_rel" "$_lc"
+		fi
+	done | sort -k1,1 > "$_tmp"
+	cat "$_tmp"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# scan_violations_ref <ref> <limit>
+# Scan a git ref for .sh/.py files with more than <limit> lines.
+# Uses a temporary git worktree so wc -l runs on local files (fast for
+# repos with 1000+ scripts). Worktree is always removed via trap.
+# Outputs TSV: git-path TAB line-count  (sorted by path).
+# ---------------------------------------------------------------------------
+scan_violations_ref() {
+	local _ref="$1"
+	local _limit="$2"
+	local _worktree
+	_worktree=$(mktemp -d)
+	# shellcheck disable=SC2064
+	trap "git worktree remove --force '$_worktree' >/dev/null 2>&1; rm -rf '$_worktree'" RETURN
+
+	if ! git worktree add --detach "$_worktree" "$_ref" > /dev/null 2>&1; then
+		log "WARN: could not create worktree for $_ref — scan skipped"
+		return 0
+	fi
+
+	# scan_violations_dir outputs paths relative to the worktree root.
+	# Git paths use the same relative structure, so output is directly usable.
+	scan_violations_dir "$_worktree" "$_limit"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# count_tsv_lines <file>
+# Count non-empty lines in a TSV file (= number of violation entries).
+# ---------------------------------------------------------------------------
+count_tsv_lines() {
+	local _f="$1"
+	if [ ! -s "$_f" ]; then
+		echo 0
+		return 0
+	fi
+	local _n
+	_n=$(grep -c '.' "$_f" 2>/dev/null || true)
+	_n=${_n//[^0-9]/}
+	echo "${_n:-0}"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# find_new_violations <base_tsv> <head_tsv>
+# Print paths that appear in head_tsv but NOT in base_tsv.
+# Bash 3.2 compatible (no process substitution).
+# ---------------------------------------------------------------------------
+find_new_violations() {
+	local _base="$1"
+	local _head="$2"
+	local _base_paths _head_paths
+	_base_paths=$(mktemp)
+	_head_paths=$(mktemp)
+	# shellcheck disable=SC2064
+	trap "rm -f '$_base_paths' '$_head_paths'" RETURN
+
+	if [ -s "$_base" ]; then
+		awk -F'\t' '{print $1}' "$_base" | sort > "$_base_paths"
+	else
+		: > "$_base_paths"
+	fi
+	if [ -s "$_head" ]; then
+		awk -F'\t' '{print $1}' "$_head" | sort > "$_head_paths"
+	else
+		: > "$_head_paths"
+	fi
+
+	# Lines in head_paths not present in base_paths
+	awk 'NR==FNR{a[$0]=1; next} !a[$0]{print}' "$_base_paths" "$_head_paths"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# write_report <base_count> <head_count> <new_count> <new_paths>
+#              <base_sha> <head_sha> <output_md>
+# ---------------------------------------------------------------------------
+write_report() {
+	local _base_count="$1"
+	local _head_count="$2"
+	local _new_count="$3"
+	local _new_paths="$4"
+	local _base_sha="$5"
+	local _head_sha="$6"
+	local _out="$7"
+	local _net_delta=$((_head_count - _base_count))
+	local _verdict
+	local _is_regression=0
+
+	if [ "$_net_delta" -gt 0 ] || [ "$_new_count" -gt 0 ]; then
+		_is_regression=1
+		_verdict="❌ **Regression** — ${_new_count} new file(s) over the line limit."
+	elif [ "$_net_delta" -lt 0 ]; then
+		_verdict="✅ **Improvement** — $((_net_delta * -1)) file(s) brought under the line limit."
+	else
+		_verdict="✅ **No change** — violation count unchanged."
+	fi
+
+	{
+		printf '## File Size Regression Gate\n\n'
+		printf '%s\n\n' "$_verdict"
+		# shellcheck disable=SC2016
+		printf '| Metric | Base (`%s`) | Head (`%s`) | Delta |\n' \
+			"${_base_sha:0:7}" "${_head_sha:0:7}"
+		printf '|---|---:|---:|---:|\n'
+		printf '| Files >%d lines | %d | %d | %+d |\n\n' \
+			"$FILE_SIZE_DEFAULT_LIMIT" "$_base_count" "$_head_count" "$_net_delta"
+		if [ "$_is_regression" -eq 1 ] && [ -n "$_new_paths" ]; then
+			printf '### New oversized files\n\n'
+			printf '| File |\n|---|\n'
+			printf '%s\n' "$_new_paths" | while IFS= read -r _p; do
+				# shellcheck disable=SC2016
+				[ -n "$_p" ] && printf '| `%s` |\n' "$_p"
+			done
+			printf '\n'
+			# shellcheck disable=SC2016
+			printf '> Override: apply `complexity-bump-ok` label with a `## Complexity Bump Justification` section.\n'
+			# shellcheck disable=SC2016
+			printf '> See `.agents/AGENTS.md` → "Complexity Bump Override" for details.\n'
+		fi
+		printf '\n<!-- file-size-regression-gate -->\n'
+	} > "$_out"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# cmd_scan — subcommand: scan <dir> [--output <file>] [--limit <N>]
+# ---------------------------------------------------------------------------
+cmd_scan() {
+	if [ $# -eq 0 ]; then
+		die "scan: <dir> is required"
+	fi
+	local _dir="$1"
+	shift
+	local _output=""
+	local _limit="$FILE_SIZE_DEFAULT_LIMIT"
+
+	while [ $# -gt 0 ]; do
+		local _cur_opt="$1"
+		shift
+		case "$_cur_opt" in
+		--output)
+			[ $# -ge 1 ] || die "scan: missing value for --output"
+			local _out_val="$1"
+			_output="$_out_val"
+			shift
+			;;
+		--limit)
+			[ $# -ge 1 ] || die "scan: missing value for --limit"
+			local _lim_val="$1"
+			_limit="$_lim_val"
+			shift
+			;;
+		*) die "scan: unknown argument: $_cur_opt" ;;
+		esac
+	done
+
+	[ -d "$_dir" ] || die "scan: not a directory: $_dir"
+
+	local _result
+	_result=$(scan_violations_dir "$_dir" "$_limit")
+	if [ -n "$_output" ]; then
+		printf '%s\n' "$_result" > "$_output"
+	else
+		printf '%s\n' "$_result"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# cmd_scan_ref — subcommand: scan-ref <ref> [--output <file>] [--limit <N>]
+# ---------------------------------------------------------------------------
+cmd_scan_ref() {
+	if [ $# -eq 0 ]; then
+		die "scan-ref: <ref> is required"
+	fi
+	local _ref="$1"
+	shift
+	local _output=""
+	local _limit="$FILE_SIZE_DEFAULT_LIMIT"
+
+	while [ $# -gt 0 ]; do
+		local _cur_opt="$1"
+		shift
+		case "$_cur_opt" in
+		--output)
+			[ $# -ge 1 ] || die "scan-ref: missing value for --output"
+			local _out_val="$1"
+			_output="$_out_val"
+			shift
+			;;
+		--limit)
+			[ $# -ge 1 ] || die "scan-ref: missing value for --limit"
+			local _lim_val="$1"
+			_limit="$_lim_val"
+			shift
+			;;
+		*) die "scan-ref: unknown argument: $_cur_opt" ;;
+		esac
+	done
+
+	if ! git rev-parse --verify --quiet "${_ref}^{commit}" > /dev/null 2>&1; then
+		die "scan-ref: ref not found: $_ref"
+	fi
+
+	local _result
+	_result=$(scan_violations_ref "$_ref" "$_limit")
+	if [ -n "$_output" ]; then
+		printf '%s\n' "$_result" > "$_output"
+	else
+		printf '%s\n' "$_result"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# cmd_diff — subcommand: diff --base-file <f> --head-file <f> [options]
+# ---------------------------------------------------------------------------
+cmd_diff() {
+	local _base_file=""
+	local _head_file=""
+	local _base_sha="base"
+	local _head_sha="head"
+	local _output_md=""
+	local _allow_increase=0
+	local _docs_only=0
+
+	while [ $# -gt 0 ]; do
+		local _cur_opt="$1"
+		shift
+		case "$_cur_opt" in
+		--base-file)
+			[ $# -ge 1 ] || die "diff: missing value for --base-file"
+			local _bf="$1"
+			_base_file="$_bf"
+			shift
+			;;
+		--head-file)
+			[ $# -ge 1 ] || die "diff: missing value for --head-file"
+			local _hf="$1"
+			_head_file="$_hf"
+			shift
+			;;
+		--base-sha)
+			[ $# -ge 1 ] || die "diff: missing value for --base-sha"
+			local _bsha="$1"
+			_base_sha="$_bsha"
+			shift
+			;;
+		--head-sha)
+			[ $# -ge 1 ] || die "diff: missing value for --head-sha"
+			local _hsha="$1"
+			_head_sha="$_hsha"
+			shift
+			;;
+		--output-md)
+			[ $# -ge 1 ] || die "diff: missing value for --output-md"
+			local _omd="$1"
+			_output_md="$_omd"
+			shift
+			;;
+		--allow-increase)
+			_allow_increase=1
+			;;
+		--docs-only)
+			_docs_only=1
+			;;
+		*) die "diff: unknown argument: $_cur_opt" ;;
+		esac
+	done
+
+	[ -n "$_base_file" ] || die "diff: --base-file is required"
+	[ -n "$_head_file" ] || die "diff: --head-file is required"
+	[ -f "$_base_file" ] || die "diff: base-file not found: $_base_file"
+	[ -f "$_head_file" ] || die "diff: head-file not found: $_head_file"
+
+	if [ "$_docs_only" -eq 1 ]; then
+		log "docs-only: skipping file-size regression gate"
+		return 0
+	fi
+
+	local _base_count _head_count _new_paths _new_count
+	_base_count=$(count_tsv_lines "$_base_file")
+	_head_count=$(count_tsv_lines "$_head_file")
+	_new_paths=$(find_new_violations "$_base_file" "$_head_file")
+	_new_count=$(printf '%s\n' "$_new_paths" | grep -c '.' 2>/dev/null || true)
+	_new_count=${_new_count//[^0-9]/}
+	_new_count=${_new_count:-0}
+
+	log "base: $_base_count  head: $_head_count  new: $_new_count"
+
+	if [ -n "$_output_md" ]; then
+		write_report "$_base_count" "$_head_count" "$_new_count" \
+			"$_new_paths" "$_base_sha" "$_head_sha" "$_output_md"
+		log "report written to $_output_md"
+	fi
+
+	local _net_delta=$((_head_count - _base_count))
+	if [ "$_net_delta" -gt 0 ] || [ "$_new_count" -gt 0 ]; then
+		if [ "$_allow_increase" -eq 1 ]; then
+			log "REGRESSION detected but --allow-increase set — warning only"
+			return 0
+		fi
+		log "REGRESSION: net_delta=${_net_delta}  new_violations=${_new_count}"
+		return 1
+	fi
+
+	log "no regression"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# cmd_check — subcommand: check [--base <ref>] [--head <ref>] [options]
+# ---------------------------------------------------------------------------
+cmd_check() {
+	local _base_ref=""
+	local _head_ref="HEAD"
+	local _limit="$FILE_SIZE_DEFAULT_LIMIT"
+	local _output_md=""
+	local _allow_increase=0
+	local _dry_run=0
+
+	while [ $# -gt 0 ]; do
+		local _cur_opt="$1"
+		shift
+		case "$_cur_opt" in
+		--base)
+			[ $# -ge 1 ] || die "check: missing value for --base"
+			local _bref="$1"
+			_base_ref="$_bref"
+			shift
+			;;
+		--head)
+			[ $# -ge 1 ] || die "check: missing value for --head"
+			local _href="$1"
+			_head_ref="$_href"
+			shift
+			;;
+		--limit)
+			[ $# -ge 1 ] || die "check: missing value for --limit"
+			local _lim="$1"
+			_limit="$_lim"
+			shift
+			;;
+		--output-md)
+			[ $# -ge 1 ] || die "check: missing value for --output-md"
+			local _omd="$1"
+			_output_md="$_omd"
+			shift
+			;;
+		--allow-increase)
+			_allow_increase=1
+			;;
+		--dry-run)
+			_dry_run=1
+			;;
+		*) die "check: unknown argument: $_cur_opt" ;;
+		esac
+	done
+
+	# Auto-detect base ref if not provided
+	if [ -z "$_base_ref" ]; then
+		local _default_branch
+		_default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null \
+			| sed 's|refs/remotes/origin/||') || _default_branch=""
+		if [ -n "$_default_branch" ] \
+			&& git rev-parse --verify --quiet "origin/${_default_branch}" > /dev/null 2>&1; then
+			_base_ref="origin/${_default_branch}"
+		elif git rev-parse --verify --quiet "origin/main" > /dev/null 2>&1; then
+			_base_ref="origin/main"
+		elif git rev-parse --verify --quiet "origin/master" > /dev/null 2>&1; then
+			_base_ref="origin/master"
+		fi
+	fi
+
+	local _tmp_dir
+	_tmp_dir=$(mktemp -d)
+	# shellcheck disable=SC2064
+	trap "rm -rf '$_tmp_dir'" EXIT
+
+	local _head_tsv="$_tmp_dir/head.tsv"
+
+	if [ "$_dry_run" -eq 1 ]; then
+		log "dry-run: scanning current working tree"
+		local _repo_root
+		_repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || _repo_root="."
+		scan_violations_dir "$_repo_root" "$_limit" > "$_head_tsv" 2>/dev/null || true
+		local _count
+		_count=$(count_tsv_lines "$_head_tsv")
+		printf 'Total violations (file-size): %d\n' "$_count"
+		return 0
+	fi
+
+	if [ -z "$_base_ref" ]; then
+		log "WARN: no origin ref found — file-size ratchet skipped (fail-open)"
+		return 0
+	fi
+
+	if ! git rev-parse --verify --quiet "${_base_ref}^{commit}" > /dev/null 2>&1; then
+		log "WARN: base ref not available: $_base_ref — ratchet skipped (fail-open)"
+		return 0
+	fi
+
+	local _base_tsv="$_tmp_dir/base.tsv"
+	local _base_sha _head_sha
+	_base_sha=$(git rev-parse --short "$_base_ref" 2>/dev/null) || _base_sha="$_base_ref"
+	_head_sha=$(git rev-parse --short "$_head_ref" 2>/dev/null) || _head_sha="$_head_ref"
+
+	log "scanning base ($_base_sha)"
+	scan_violations_ref "$_base_ref" "$_limit" > "$_base_tsv" 2>/dev/null || true
+
+	log "scanning head ($_head_sha)"
+	# For HEAD, scan the working tree directly (avoids creating a worktree for HEAD).
+	if [ "$_head_ref" = "HEAD" ]; then
+		local _repo_root
+		_repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || _repo_root="."
+		scan_violations_dir "$_repo_root" "$_limit" > "$_head_tsv" 2>/dev/null || true
+	else
+		scan_violations_ref "$_head_ref" "$_limit" > "$_head_tsv" 2>/dev/null || true
+	fi
+
+	# Build optional args without arrays (bash 3.2: empty arrays + set -u = unbound error).
+	local _diff_exit=0
+	local _output_md_flag="" _allow_increase_flag=""
+	[ -n "$_output_md" ] && _output_md_flag="$_output_md"
+	[ "$_allow_increase" -eq 1 ] && _allow_increase_flag="1"
+
+	if [ -n "$_output_md_flag" ] && [ -n "$_allow_increase_flag" ]; then
+		cmd_diff \
+			--base-file "$_base_tsv" --head-file "$_head_tsv" \
+			--base-sha "$_base_sha" --head-sha "$_head_sha" \
+			--output-md "$_output_md_flag" --allow-increase \
+			|| _diff_exit=$?
+	elif [ -n "$_output_md_flag" ]; then
+		cmd_diff \
+			--base-file "$_base_tsv" --head-file "$_head_tsv" \
+			--base-sha "$_base_sha" --head-sha "$_head_sha" \
+			--output-md "$_output_md_flag" \
+			|| _diff_exit=$?
+	elif [ -n "$_allow_increase_flag" ]; then
+		cmd_diff \
+			--base-file "$_base_tsv" --head-file "$_head_tsv" \
+			--base-sha "$_base_sha" --head-sha "$_head_sha" \
+			--allow-increase \
+			|| _diff_exit=$?
+	else
+		cmd_diff \
+			--base-file "$_base_tsv" --head-file "$_head_tsv" \
+			--base-sha "$_base_sha" --head-sha "$_head_sha" \
+			|| _diff_exit=$?
+	fi
+
+	return "$_diff_exit"
+}
+
+# ---------------------------------------------------------------------------
+# main — dispatch to subcommand
+# ---------------------------------------------------------------------------
+main() {
+	if [ $# -eq 0 ]; then
+		die "no subcommand given (scan | scan-ref | diff | check)"
+	fi
+	local _subcmd="$1"
+	shift
+
+	case "$_subcmd" in
+	scan)     cmd_scan "$@" ;;
+	scan-ref) cmd_scan_ref "$@" ;;
+	diff)     cmd_diff "$@" ;;
+	check)    cmd_check "$@" ;;
+	-h | --help)
+		sed -n '4,60p' "$0" | sed 's/^# \{0,1\}//'
+		exit 0
+		;;
+	*) die "unknown subcommand: $_subcmd (valid: scan | scan-ref | diff | check)" ;;
+	esac
+}
+
+main "$@"

--- a/.agents/scripts/linters-local.sh
+++ b/.agents/scripts/linters-local.sh
@@ -56,7 +56,8 @@ readonly MAX_STRING_LITERAL_ISSUES=2300
 #
 # - Function length: warn >50, block >100. Threshold allows current 404 + small margin.
 # - Nesting depth: warn >5, block >8. Threshold allows current 245 + small margin.
-# - File size: warn >800, block >1500. Threshold allows current 33 + small margin.
+# - File size: warn >800, block >1500. Gate is now ratchet-based (t2938) —
+#   MAX_FILE_SIZE_VIOLATIONS removed; ratchet compares against origin/main HEAD.
 readonly MAX_FUNCTION_LENGTH_WARN=50
 readonly MAX_FUNCTION_LENGTH_BLOCK=100
 readonly MAX_FUNCTION_LENGTH_VIOLATIONS=420
@@ -65,7 +66,6 @@ readonly MAX_NESTING_DEPTH_BLOCK=8
 readonly MAX_NESTING_VIOLATIONS=260
 readonly MAX_FILE_LINES_WARN=800
 readonly MAX_FILE_LINES_BLOCK=1500
-readonly MAX_FILE_SIZE_VIOLATIONS=40
 
 print_header() {
 	echo -e "${BLUE}Local Linters - Fast Offline Quality Checks${NC}"
@@ -1031,13 +1031,19 @@ append_file_size_result() {
 }
 
 # =============================================================================
-# File Size Check (Codacy alignment — GH#4939)
+# File Size Check — ratchet-based gate (t2938)
 # =============================================================================
-# Codacy flags files exceeding line count thresholds. Large files are harder
-# to maintain and review. This catches monolithic scripts that should be split.
+# Block only when this commit introduces a net increase in files >1500 lines,
+# or adds a brand-new file >1500 lines. Pre-existing debt does not block.
+# Framework rule: t2228 — "Any gate MUST be ratchet-based: block only on regressions."
+#
+# Parity: matches the per-file regression check in code-quality.yml "File size check"
+# step, which already uses complexity-regression-helper.sh with the same semantics.
+#
+# The WARN advisory (files >800 lines) is unchanged — informational only.
 
 check_file_size() {
-	echo -e "${BLUE}Checking File Size (Codacy alignment)...${NC}"
+	echo -e "${BLUE}Checking File Size (ratchet gate — t2938)...${NC}"
 
 	local block_violations=0
 	local warn_violations=0
@@ -1065,8 +1071,10 @@ check_file_size() {
 		block_violations=${block_violations:-0}
 		warn_violations=${warn_violations:-0}
 
+		# Advisory display — show WARN and BLOCK files for developer awareness.
+		# These are informational; the ratchet gate below decides whether to block.
 		if [[ "$block_violations" -gt 0 ]]; then
-			print_error "File size: $block_violations files exceed ${MAX_FILE_LINES_BLOCK} lines (should be split)"
+			print_warning "File size: $block_violations files exceed ${MAX_FILE_LINES_BLOCK} lines (should be split)"
 			grep '^BLOCK' "$tmp_file" | sed 's/^BLOCK /  /' | head -10
 		fi
 
@@ -1076,13 +1084,44 @@ check_file_size() {
 		fi
 	fi
 
-	if [[ "$block_violations" -le "$MAX_FILE_SIZE_VIOLATIONS" ]]; then
+	# --- Ratchet gate: block only on net regression against origin base ---
+	local helper_script="${SCRIPT_DIR}/file-size-regression-helper.sh"
+
+	if [[ ! -x "$helper_script" ]]; then
 		local total=$((block_violations + warn_violations))
-		print_success "File size: $total oversized files ($block_violations blocking, $warn_violations advisory)"
+		print_warning "File size: helper not found — gate skipped (fail-open). $total oversized files total."
 		return 0
 	fi
 
-	print_error "File size: $block_violations blocking violations (threshold: $MAX_FILE_SIZE_VIOLATIONS)"
+	# Detect docs-only changes: if no .sh or .py files are staged/modified, skip.
+	local changed_code_files
+	changed_code_files=$(git diff --name-only HEAD 2>/dev/null | grep -cE '\.(sh|py)$' || true)
+	changed_code_files=${changed_code_files//[^0-9]/}
+	changed_code_files=${changed_code_files:-0}
+	if [[ "$changed_code_files" -eq 0 ]]; then
+		local staged_code
+		staged_code=$(git diff --cached --name-only 2>/dev/null | grep -cE '\.(sh|py)$' || true)
+		staged_code=${staged_code//[^0-9]/}
+		staged_code=${staged_code:-0}
+		changed_code_files=$((changed_code_files + staged_code))
+	fi
+
+	if [[ "$changed_code_files" -eq 0 ]]; then
+		local total=$((block_violations + warn_violations))
+		print_info "File size: docs-only commit detected — ratchet gate skipped. $total oversized files (advisory)."
+		return 0
+	fi
+
+	local ratchet_exit=0
+	"$helper_script" check || ratchet_exit=$?
+
+	if [[ "$ratchet_exit" -eq 0 ]]; then
+		local total=$((block_violations + warn_violations))
+		print_success "File size: no regression. $total oversized files ($block_violations over ${MAX_FILE_LINES_BLOCK}, $warn_violations advisory). Tracked by #21146."
+		return 0
+	fi
+
+	print_error "File size: regression — new file(s) added over ${MAX_FILE_LINES_BLOCK} lines. Split before committing, or add the 'complexity-bump-ok' label in the PR."
 	return 1
 }
 

--- a/.agents/scripts/tests/test-file-size-regression-helper.sh
+++ b/.agents/scripts/tests/test-file-size-regression-helper.sh
@@ -1,0 +1,305 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-file-size-regression-helper.sh — Unit tests for file-size-regression-helper.sh (t2938)
+#
+# Tests:
+#   1. zero-violation baseline  — no files over limit at base or head → exit 0
+#   2. baseline-equals-head     — same set of violations at base and head → exit 0
+#   3. head-greater-than-base   — head adds a new oversized file → exit 1
+#   4. new-file-over-limit      — new file >1500 lines even though net count is
+#                                 unchanged (one removed, one added) → exit 1
+#   5. docs-only                — --docs-only flag skips gate → exit 0
+#
+# Usage: bash .agents/scripts/tests/test-file-size-regression-helper.sh
+# Requires: the helper at .agents/scripts/file-size-regression-helper.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+HELPER="${SCRIPT_DIR}/../file-size-regression-helper.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+
+# ---------------------------------------------------------------------------
+# print_result <name> <failed> [<message>]
+# ---------------------------------------------------------------------------
+print_result() {
+	local _name="$1"
+	local _failed="$2"
+	local _msg="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [ "$_failed" -eq 0 ]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$_name"
+	if [ -n "$_msg" ]; then
+		printf '       %s\n' "$_msg"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# setup / teardown
+# ---------------------------------------------------------------------------
+setup() {
+	TEST_ROOT=$(mktemp -d)
+	return 0
+}
+
+teardown() {
+	if [ -n "$TEST_ROOT" ] && [ -d "$TEST_ROOT" ]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	TEST_ROOT=""
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# make_sh_file <path> <lines>
+# Create a shell script file with exactly <lines> trivial no-op lines.
+# ---------------------------------------------------------------------------
+make_sh_file() {
+	local _path="$1"
+	local _lines="$2"
+	mkdir -p "$(dirname "$_path")"
+	printf '#!/usr/bin/env bash\n' > "$_path"
+	local _i=1
+	while [ "$_i" -lt "$_lines" ]; do
+		printf ': # pad %d\n' "$_i" >> "$_path"
+		_i=$((_i + 1))
+	done
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# run_diff <base_tsv> <head_tsv> [extra_args...]
+# Runs the diff subcommand; stores exit code in _DIFF_EXIT.
+# ---------------------------------------------------------------------------
+_DIFF_EXIT=0
+run_diff() {
+	local _base="$1"
+	local _head="$2"
+	shift 2
+	_DIFF_EXIT=0
+	"$HELPER" diff --base-file "$_base" --head-file "$_head" "$@" \
+		>/dev/null 2>&1 || _DIFF_EXIT=$?
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# run_scan <dir> <output_tsv>
+# Runs the scan subcommand against <dir>, writing TSV to <output_tsv>.
+# ---------------------------------------------------------------------------
+run_scan() {
+	local _dir="$1"
+	local _out="$2"
+	"$HELPER" scan "$_dir" --output "$_out" 2>/dev/null
+	return 0
+}
+
+# ===========================================================================
+# Test 1: zero-violation baseline — no files over limit at base or head → 0
+# ===========================================================================
+test_zero_violation_baseline() {
+	setup
+	local _base_dir="$TEST_ROOT/base"
+	local _head_dir="$TEST_ROOT/head"
+	mkdir -p "$_base_dir" "$_head_dir"
+
+	# Both base and head have a small file (well under 1500 lines)
+	make_sh_file "$_base_dir/small.sh" 100
+	make_sh_file "$_head_dir/small.sh" 100
+
+	local _base_tsv="$TEST_ROOT/base.tsv"
+	local _head_tsv="$TEST_ROOT/head.tsv"
+	run_scan "$_base_dir" "$_base_tsv"
+	run_scan "$_head_dir" "$_head_tsv"
+
+	run_diff "$_base_tsv" "$_head_tsv"
+
+	if [ "$_DIFF_EXIT" -eq 0 ]; then
+		print_result "zero-violation-baseline: no violations at base or head → exit 0" 0
+	else
+		print_result "zero-violation-baseline: no violations at base or head → exit 0" 1 \
+			"got exit $_DIFF_EXIT, expected 0"
+	fi
+	teardown
+	return 0
+}
+
+# ===========================================================================
+# Test 2: baseline-equals-head — same violations in both → exit 0 (no regression)
+# ===========================================================================
+test_baseline_equals_head() {
+	setup
+	local _base_dir="$TEST_ROOT/base"
+	local _head_dir="$TEST_ROOT/head"
+	mkdir -p "$_base_dir" "$_head_dir"
+
+	# Both base and head have the same large file
+	make_sh_file "$_base_dir/big.sh" 1600
+	make_sh_file "$_head_dir/big.sh" 1600
+
+	local _base_tsv="$TEST_ROOT/base.tsv"
+	local _head_tsv="$TEST_ROOT/head.tsv"
+	run_scan "$_base_dir" "$_base_tsv"
+	run_scan "$_head_dir" "$_head_tsv"
+
+	run_diff "$_base_tsv" "$_head_tsv"
+
+	if [ "$_DIFF_EXIT" -eq 0 ]; then
+		print_result "baseline-equals-head: same violations → exit 0 (no regression)" 0
+	else
+		print_result "baseline-equals-head: same violations → exit 0 (no regression)" 1 \
+			"got exit $_DIFF_EXIT, expected 0"
+	fi
+	teardown
+	return 0
+}
+
+# ===========================================================================
+# Test 3: head-greater-than-base — head adds a new oversized file → exit 1
+# ===========================================================================
+test_head_greater_than_base() {
+	setup
+	local _base_dir="$TEST_ROOT/base"
+	local _head_dir="$TEST_ROOT/head"
+	mkdir -p "$_base_dir" "$_head_dir"
+
+	# Base: one large file
+	make_sh_file "$_base_dir/existing.sh" 1600
+
+	# Head: same file plus a new oversized file
+	make_sh_file "$_head_dir/existing.sh" 1600
+	make_sh_file "$_head_dir/new_giant.sh" 2000
+
+	local _base_tsv="$TEST_ROOT/base.tsv"
+	local _head_tsv="$TEST_ROOT/head.tsv"
+	run_scan "$_base_dir" "$_base_tsv"
+	run_scan "$_head_dir" "$_head_tsv"
+
+	run_diff "$_base_tsv" "$_head_tsv"
+
+	if [ "$_DIFF_EXIT" -eq 1 ]; then
+		print_result "head-greater-than-base: new oversized file → exit 1 (block)" 0
+	else
+		print_result "head-greater-than-base: new oversized file → exit 1 (block)" 1 \
+			"got exit $_DIFF_EXIT, expected 1"
+	fi
+	teardown
+	return 0
+}
+
+# ===========================================================================
+# Test 4: new-file-over-limit — net count unchanged but new file added → exit 1
+#
+# Scenario: base has file A (>1500 lines). Head removes A but adds file B
+# (>1500 lines). Net count: same (1). Still a regression because B is a new
+# oversized file that wasn't in base. The ratchet must catch this to prevent
+# gaming the gate by cycling oversized files.
+# ===========================================================================
+test_new_file_over_limit_net_unchanged() {
+	setup
+	local _base_dir="$TEST_ROOT/base"
+	local _head_dir="$TEST_ROOT/head"
+	mkdir -p "$_base_dir" "$_head_dir"
+
+	# Base: one large file (file_a.sh)
+	make_sh_file "$_base_dir/file_a.sh" 1600
+
+	# Head: file_a.sh removed, file_b.sh added (different path, both >1500 lines)
+	make_sh_file "$_head_dir/file_b.sh" 1600
+
+	local _base_tsv="$TEST_ROOT/base.tsv"
+	local _head_tsv="$TEST_ROOT/head.tsv"
+	run_scan "$_base_dir" "$_base_tsv"
+	run_scan "$_head_dir" "$_head_tsv"
+
+	# Verify both have exactly 1 violation (net unchanged)
+	local _base_count _head_count
+	_base_count=$(grep -c '.' "$_base_tsv" 2>/dev/null || true)
+	_head_count=$(grep -c '.' "$_head_tsv" 2>/dev/null || true)
+
+	run_diff "$_base_tsv" "$_head_tsv"
+
+	if [ "$_DIFF_EXIT" -eq 1 ]; then
+		print_result "new-file-over-limit (net unchanged): new path → exit 1 (block regardless)" 0
+	else
+		print_result "new-file-over-limit (net unchanged): new path → exit 1 (block regardless)" 1 \
+			"got exit $_DIFF_EXIT (base=$_base_count head=$_head_count violations), expected 1"
+	fi
+	teardown
+	return 0
+}
+
+# ===========================================================================
+# Test 5: docs-only — --docs-only flag skips gate → exit 0
+# ===========================================================================
+test_docs_only_skip() {
+	setup
+	local _base_dir="$TEST_ROOT/base"
+	local _head_dir="$TEST_ROOT/head"
+	mkdir -p "$_base_dir" "$_head_dir"
+
+	# Head has more violations than base — would normally fail
+	make_sh_file "$_base_dir/existing.sh" 1600
+	make_sh_file "$_head_dir/existing.sh" 1600
+	make_sh_file "$_head_dir/also_big.sh" 1700
+
+	local _base_tsv="$TEST_ROOT/base.tsv"
+	local _head_tsv="$TEST_ROOT/head.tsv"
+	run_scan "$_base_dir" "$_base_tsv"
+	run_scan "$_head_dir" "$_head_tsv"
+
+	# Pass --docs-only: gate must be skipped regardless of violation delta
+	run_diff "$_base_tsv" "$_head_tsv" "--docs-only"
+
+	if [ "$_DIFF_EXIT" -eq 0 ]; then
+		print_result "docs-only: --docs-only flag skips gate → exit 0" 0
+	else
+		print_result "docs-only: --docs-only flag skips gate → exit 0" 1 \
+			"got exit $_DIFF_EXIT, expected 0"
+	fi
+	teardown
+	return 0
+}
+
+# ===========================================================================
+# Main
+# ===========================================================================
+main() {
+	if [ ! -x "$HELPER" ]; then
+		printf '%bERROR%b helper not found or not executable: %s\n' \
+			"$TEST_RED" "$TEST_RESET" "$HELPER" >&2
+		exit 2
+	fi
+
+	printf '\n=== file-size-regression-helper tests (t2938) ===\n\n'
+
+	test_zero_violation_baseline
+	test_baseline_equals_head
+	test_head_greater_than_base
+	test_new_file_over_limit_net_unchanged
+	test_docs_only_skip
+
+	printf '\n%d/%d tests passed\n' "$((TESTS_RUN - TESTS_FAILED))" "$TESTS_RUN"
+
+	if [ "$TESTS_FAILED" -gt 0 ]; then
+		exit 1
+	fi
+	exit 0
+}
+
+main "$@"

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -635,9 +635,9 @@ jobs:
         exit 1
 
     - name: File size check
-      # t2171: per-file regression model replaces total-count-vs-threshold.
-      # PRs fail only when they introduce NEW >1500-line files, not for
-      # pre-existing debt in base. Raw count is non-blocking warning.
+      # t2171 + t2938: ratchet gate — block only when the PR introduces a net
+      # increase in files >1500 lines, or adds a brand-new oversized file.
+      # Pre-existing debt does not block. Matches linters-local.sh (t2228 rule).
       env:
         BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
         HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
@@ -649,28 +649,12 @@ jobs:
       run: |
         set -euo pipefail
 
-        # --- Non-blocking warning: total violation count ---
-        THRESHOLD=40
-        if [ -f ".agents/configs/complexity-thresholds.conf" ]; then
-          val=$(grep '^FILE_SIZE_THRESHOLD=' .agents/configs/complexity-thresholds.conf \
-            | cut -d= -f2 || true)
-          if [ -n "$val" ] && [ "$val" -eq "$val" ] 2>/dev/null; then
-            THRESHOLD=$val
-          fi
-        fi
-
+        # --- Informational: total violation count (no threshold gate) ---
         echo "Scanning file sizes (>1500 lines)..."
         total_out=$(.agents/scripts/complexity-regression-helper.sh check --dry-run \
           --metric file-size 2>/dev/null \
           | grep '^Total violations' || echo "Total violations (file-size): unknown")
-        echo "$total_out"
-
-        total=$(echo "$total_out" | grep -oE '[0-9]+$' || echo "0")
-        if [ "$total" -gt "$THRESHOLD" ]; then
-          echo "::warning::File size total: $total violations (threshold: $THRESHOLD). See simplification routine."
-        else
-          echo "Within simplification threshold ($THRESHOLD)"
-        fi
+        echo "$total_out (informational — debt tracked by #21146, gate is ratchet-based per t2938)"
 
         # --- Blocking gate: per-file regression check (PRs only) ---
         if [ "${EVENT_NAME}" != "pull_request" ]; then


### PR DESCRIPTION
## Summary

Converts the `check_file_size()` gate in `linters-local.sh` from an absolute count threshold to a ratchet-based gate, following the framework's t2228 rule. Prior behavior blocked every commit once the repo exceeded 40 files >1500 lines (currently 62). New behavior blocks only when a PR introduces a **net increase** in such files or adds a **new** oversized file.

## Changes

- **NEW: `.agents/scripts/file-size-regression-helper.sh`** — standalone helper with `scan`, `scan-ref`, `diff`, `check` subcommands. Uses git worktrees for fast base-ref scanning (avoids 1000+ serial git-show calls). Fail-open when `origin/main` is unavailable. Docs-only commits skip via `--docs-only` flag.
- **EDIT: `.agents/scripts/linters-local.sh`** — `check_file_size()` now delegates the BLOCK gate to the new helper. WARN advisory (>800 lines) is unchanged. `MAX_FILE_SIZE_VIOLATIONS` constant removed.
- **EDIT: `.github/workflows/code-quality.yml`** — removes the absolute threshold comparison from the non-blocking warning step. Total count is now purely informational. The existing per-file regression check (`complexity-regression-helper.sh`) already implements the ratchet for CI — parity achieved.
- **NEW: `.agents/scripts/tests/test-file-size-regression-helper.sh`** — 5 test cases: zero-violation baseline, baseline-equals-head, head-greater-than-base, new-file net-unchanged (prevents cycling violations), docs-only skip.

## Verification

- `bash .agents/scripts/tests/test-file-size-regression-helper.sh` → 5/5 PASS
- `bash .agents/scripts/tests/test-complexity-regression-helper.sh` → 14/14 PASS (no regressions)
- `file-size-regression-helper.sh check --base origin/main` → `no regression` (base: 63, head: 62, new: 0)

Resolves #21147