### PR TITLE
t2831: pulse: per-repo adaptive cadence (hot/warm/cold tiers)

### DIFF
--- a/.agents/scripts/pulse-prefetch-fetch.sh
+++ b/.agents/scripts/pulse-prefetch-fetch.sh
@@ -13,12 +13,14 @@
 #   5. State assembly and sub-helper runner
 #   6. Per-repo pulse schedule checking
 #   7. Per-repo pulse interval throttle (GH#20660)
+#   8. Per-repo activity tier skip (t2831) — hot/warm/cold cadence control
 #
 # Usage: source "${SCRIPT_DIR}/pulse-prefetch-fetch.sh"
 #
 # Dependencies:
 #   - pulse-prefetch-infra.sh (cache helpers, rate-limit helpers)
 #   - shared-constants.sh
+#   - pulse-repo-tier.sh (t2831: tier-of command, optional — degrades gracefully)
 #   - Environment vars: LOGFILE, PULSE_PREFETCH_PR_LIMIT, PULSE_PREFETCH_ISSUE_LIMIT,
 #     DAILY_PR_CAP, STATE_FILE, TRIAGE_STATE_FILE, REPOS_JSON, FOSS_SCAN_TIMEOUT
 #
@@ -471,6 +473,42 @@ _prefetch_single_repo() {
 	local slug="$1"
 	local path="$2"
 	local outfile="$3"
+
+	# t2831 Tier-based skip (before ANY gh API calls):
+	# Hot repos proceed every cycle; warm/cold repos skip when last check
+	# is more recent than their tier interval. Falls back to "proceed" when
+	# PULSE_TIER_CLASSIFICATION_ENABLED != 1 or the tier script is missing.
+	if ! check_repo_tier_skip "$slug"; then
+		# Tier skip: emit cached data so the state file still has an entry
+		# for this repo, then return without making any gh API calls.
+		local _tier_cache
+		_tier_cache=$(_prefetch_cache_get "$slug")
+		{
+			echo "## ${slug} (${path})"
+			echo ""
+			echo "> **Tier skip** — this repo is below hot tier and was checked recently."
+			echo "> Using cached state from last full prefetch."
+			echo ""
+			if [[ -n "$_tier_cache" && "$_tier_cache" != "null" ]]; then
+				PREFETCH_UPDATED_PRS="[]"
+				PREFETCH_UPDATED_ISSUES="[]"
+				_prefetch_single_repo_idle_skip "$slug" "$_tier_cache"
+			else
+				echo "### Open PRs [tier-skipped, no cache]"
+				echo "- None"
+				echo ""
+				echo "### Open Issues [tier-skipped, no cache]"
+				echo "- None"
+				echo ""
+			fi
+		} >"$outfile"
+		echo "[pulse-wrapper] _prefetch_single_repo: TIER SKIP for ${slug} — cached data replayed" >>"$LOGFILE"
+		_PULSE_HEALTH_IDLE_REPO_SKIPS=$((_PULSE_HEALTH_IDLE_REPO_SKIPS + 1))
+		return 0
+	fi
+
+	# Record that we are doing a full prefetch for this repo (for tier interval tracking).
+	update_repo_tier_check_timestamp "$slug"
 
 	# GH#15286: Determine sweep mode from cache
 	local cache_entry
@@ -927,5 +965,158 @@ check_repo_pulse_schedule() {
 		fi
 	fi
 
+	return 0
+}
+
+# =============================================================================
+# Per-Repo Activity Tier Skip (t2831)
+# =============================================================================
+# Controls how often each repo is evaluated based on its activity tier.
+# Hot repos: check every cycle (PULSE_TIER_HOT_INTERVAL=0, no skip).
+# Warm repos: skip if last full check < PULSE_TIER_WARM_INTERVAL seconds ago.
+# Cold repos: skip if last full check < PULSE_TIER_COLD_INTERVAL seconds ago.
+#
+# Tier assignment is performed hourly by pulse-repo-tier-classifier-routine.sh
+# and cached at ~/.aidevops/cache/pulse-repo-tiers.json.
+# The tier-of command reads from the cache and falls back to "warm" on miss.
+#
+# State file: PULSE_TIER_LAST_CHECK_FILE (separate from PULSE_LAST_PER_REPO_FILE
+# so tier-based throttle is independent of repos.json pulse_interval).
+# =============================================================================
+
+########################################
+# State file for per-repo tier-based last-check timestamps.
+########################################
+PULSE_TIER_LAST_CHECK_FILE="${PULSE_TIER_LAST_CHECK_FILE:-${HOME}/.aidevops/logs/pulse-tier-last-check.json}"
+
+########################################
+# Tier classifier script path.
+########################################
+PULSE_TIER_SCRIPT="${PULSE_TIER_SCRIPT:-${SCRIPT_DIR}/pulse-repo-tier.sh}"
+
+########################################
+# Check whether a repo should be skipped this cycle based on its activity tier.
+#
+# Reads the tier via pulse-repo-tier.sh tier-of (cache-backed, < 1ms typical).
+# Compares elapsed time since last full prefetch against the tier interval.
+#
+# Hot:  PULSE_TIER_HOT_INTERVAL=0 — never skip (every cycle)
+# Warm: skip if elapsed < PULSE_TIER_WARM_INTERVAL (default 180s)
+# Cold: skip if elapsed < PULSE_TIER_COLD_INTERVAL (default 600s)
+#
+# Feature-flag: returns 0 (proceed) immediately when
+# PULSE_TIER_CLASSIFICATION_ENABLED is unset or 0.
+#
+# Arguments:
+#   $1 - repo_slug (owner/repo)
+#   $2 - state_file (optional; defaults to PULSE_TIER_LAST_CHECK_FILE)
+#
+# Exit codes:
+#   0 - proceed with this repo (not skipped)
+#   1 - skip this repo (tier interval not elapsed)
+########################################
+check_repo_tier_skip() {
+	local slug="$1"
+	local state_file="${2:-$PULSE_TIER_LAST_CHECK_FILE}"
+
+	# Feature flag — enabled by default (set to 0 to disable for rollback)
+	if [[ "${PULSE_TIER_CLASSIFICATION_ENABLED:-1}" != "1" ]]; then
+		return 0
+	fi
+
+	local warm_interval="${PULSE_TIER_WARM_INTERVAL:-180}"
+	local cold_interval="${PULSE_TIER_COLD_INTERVAL:-600}"
+
+	# Get tier from cache (fast — reads local JSON file); default to warm on error.
+	local tier
+	tier="warm"
+	if [[ -x "$PULSE_TIER_SCRIPT" ]]; then
+		local _t
+		_t=$("$PULSE_TIER_SCRIPT" tier-of "$slug" 2>/dev/null) || true
+		# Accept only known tier values; anything else stays at the default.
+		case "$_t" in hot|warm|cold) tier="$_t" ;; esac
+	fi
+
+	# Hot repos always proceed (no skip)
+	if [[ "$tier" == "hot" ]]; then
+		return 0
+	fi
+
+	# Determine minimum interval for this tier
+	local min_interval=0
+	case "$tier" in
+		warm) min_interval="$warm_interval" ;;
+		cold) min_interval="$cold_interval" ;;
+		*)    return 0 ;;
+	esac
+
+	if [[ "$min_interval" -le 0 ]]; then
+		return 0
+	fi
+
+	# Read last full prefetch epoch from state file
+	local last_check=0
+	if [[ -f "$state_file" ]] && command -v jq &>/dev/null; then
+		local val
+		val=$(jq -r --arg slug "$slug" '.last_check[$slug] // 0' "$state_file" 2>/dev/null)
+		[[ "$val" =~ ^[0-9]+$ ]] && last_check="$val"
+	fi
+
+	local now elapsed
+	now=$(date +%s)
+	elapsed=$((now - last_check))
+
+	if [[ "$elapsed" -lt "$min_interval" ]]; then
+		echo "[pulse-wrapper] tier_skip repo=${slug} tier=${tier} interval=${min_interval}s elapsed=${elapsed}s" >>"$LOGFILE"
+		return 1
+	fi
+
+	return 0
+}
+
+########################################
+# Record the current epoch as the last full prefetch time for a repo (tier tracking).
+# Uses atomic mktemp+mv pattern (same as update_repo_pulse_timestamp).
+#
+# Arguments:
+#   $1 - repo_slug (owner/repo)
+#   $2 - state_file (optional; defaults to PULSE_TIER_LAST_CHECK_FILE)
+#
+# Returns: 0 always (non-fatal)
+########################################
+update_repo_tier_check_timestamp() {
+	local slug="$1"
+	local state_file="${2:-$PULSE_TIER_LAST_CHECK_FILE}"
+
+	command -v jq &>/dev/null || return 0
+
+	local now
+	now=$(date +%s)
+
+	local existing='{}'
+	if [[ -f "$state_file" ]]; then
+		existing=$(jq '.' "$state_file" 2>/dev/null) || existing='{}'
+		[[ -n "$existing" ]] || existing='{}'
+	fi
+
+	local state_dir
+	state_dir="${state_file%/*}"
+	[[ -d "$state_dir" ]] || mkdir -p "$state_dir" 2>/dev/null || true
+
+	local tmp_state
+	tmp_state=$(mktemp "${state_dir}/.pulse-tier-last-check-XXXXXX.json") || {
+		echo "[pulse-wrapper] update_repo_tier_check_timestamp: mktemp failed for ${slug}" >>"$LOGFILE"
+		return 0
+	}
+
+	if printf '%s' "$existing" | jq --arg slug "$slug" --argjson ts "$now" '
+		if .last_check then .last_check[$slug] = $ts
+		else .last_check = {($slug): $ts} end
+	' >"$tmp_state" 2>/dev/null && jq empty "$tmp_state" 2>/dev/null; then
+		mv "$tmp_state" "$state_file"
+	else
+		rm -f "$tmp_state"
+		echo "[pulse-wrapper] WARNING: update_repo_tier_check_timestamp: jq produced invalid JSON for ${slug}" >>"$LOGFILE"
+	fi
 	return 0
 }

--- a/.agents/scripts/pulse-repo-tier-classifier-routine.sh
+++ b/.agents/scripts/pulse-repo-tier-classifier-routine.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# pulse-repo-tier-classifier-routine.sh — Hourly tier-classifier routine (t2831)
+#
+# Standalone runner for the per-repo activity tier classification.
+# Runs hourly under launchd (sh.aidevops.repo-tier-classify plist).
+# Calls pulse-repo-tier.sh classify to refresh ~/.aidevops/cache/pulse-repo-tiers.json.
+#
+# Architecture: identical to complexity-scan-runner.sh — independent file-based
+# lock so the classifier never overlaps itself and never blocks pulse dispatch.
+#
+# Usage:
+#   pulse-repo-tier-classifier-routine.sh [run]   Run the classification (default)
+#   pulse-repo-tier-classifier-routine.sh help     Show usage
+#
+# Lock:    ~/.aidevops/.agent-workspace/locks/repo-tier-classify.lock
+# Log:     ~/.aidevops/logs/repo-tier-classify.log
+# Cache:   ~/.aidevops/cache/pulse-repo-tiers.json
+#
+# Part of aidevops framework: https://aidevops.sh
+
+set -euo pipefail
+
+# PATH normalisation for launchd/cron environments where PATH is minimal.
+export PATH="/opt/homebrew/bin:/usr/local/bin:/home/linuxbrew/.linuxbrew/bin:/bin:/usr/bin:${PATH}"
+
+# SCRIPT_DIR resolution — uses BASH_SOURCE[0]:-$0 for zsh portability (GH#3931).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+
+LOCK_DIR="${HOME}/.aidevops/.agent-workspace/locks/repo-tier-classify.lock"
+RUNNER_LOG="${HOME}/.aidevops/logs/repo-tier-classify.log"
+TIER_SCRIPT="${SCRIPT_DIR}/pulse-repo-tier.sh"
+
+_usage() {
+	cat <<EOF
+Usage: $(basename "${BASH_SOURCE[0]:-$0}") [run|help]
+
+  run    Run the tier classification (default when called by launchd)
+  help   Show this message
+
+This script is normally invoked by launchd every hour. It acquires a
+mkdir-based lock to prevent overlapping runs, then calls pulse-repo-tier.sh
+classify to refresh the tier cache.
+EOF
+	return 0
+}
+
+cmd_run() {
+	echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] repo-tier-classify: starting" >>"$RUNNER_LOG"
+
+	# Ensure lock directory exists
+	local lock_parent
+	lock_parent="${LOCK_DIR%/*}"
+	[[ -d "$lock_parent" ]] || mkdir -p "$lock_parent" 2>/dev/null || true
+
+	# Acquire mkdir-based lock (POSIX atomic on local FS)
+	if ! mkdir "$LOCK_DIR" 2>/dev/null; then
+		echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] repo-tier-classify: already running (lock held), skipping" >>"$RUNNER_LOG"
+		return 0
+	fi
+
+	# Register cleanup on exit
+	# shellcheck disable=SC2064
+	trap "rmdir '$LOCK_DIR' 2>/dev/null || true" EXIT
+
+	if [[ ! -x "$TIER_SCRIPT" ]]; then
+		echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] repo-tier-classify: ERROR: ${TIER_SCRIPT} not found or not executable" >>"$RUNNER_LOG"
+		return 1
+	fi
+
+	local start_ts end_ts elapsed
+	start_ts=$(date +%s)
+
+	"$TIER_SCRIPT" classify >>"$RUNNER_LOG" 2>&1 || {
+		echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] repo-tier-classify: classify exited non-zero (see above)" >>"$RUNNER_LOG"
+	}
+
+	end_ts=$(date +%s)
+	elapsed=$((end_ts - start_ts))
+	echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] repo-tier-classify: done in ${elapsed}s" >>"$RUNNER_LOG"
+	return 0
+}
+
+main() {
+	local cmd="${1:-run}"
+	case "$cmd" in
+		run)
+			cmd_run
+			;;
+		help|--help|-h)
+			_usage
+			;;
+		*)
+			echo "[repo-tier-classify] Unknown command: ${cmd}" >&2
+			_usage >&2
+			return 1
+			;;
+	esac
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/pulse-repo-tier.sh
+++ b/.agents/scripts/pulse-repo-tier.sh
@@ -1,0 +1,408 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# pulse-repo-tier.sh — Per-repo activity tier classifier (t2831)
+# =============================================================================
+# Classifies pulse-enabled repos into activity tiers (hot/warm/cold) based on
+# rolling 7-day GitHub event count and open PR presence. The tier controls how
+# often each repo is evaluated by the prefetch stage — hot repos are checked
+# every cycle, warm every ~3 cycles, cold every ~10 cycles.
+#
+# Commands:
+#   classify   — classify all pulse-enabled repos and write to cache
+#   tier-of <slug>  — return cached tier for one repo (warm on cache miss)
+#
+# Cache:
+#   ~/.aidevops/cache/pulse-repo-tiers.json
+#   Schema: { "<slug>": { "tier": "hot|warm|cold", "event_count": N, "ts": epoch } }
+#
+# Called by:
+#   pulse-repo-tier-classifier-routine.sh (hourly via launchd)
+#   pulse-prefetch-fetch.sh (tier-of, per cycle, per repo)
+#
+# Tier thresholds (overridable via env):
+#   hot:  >= PULSE_TIER_HOT_EVENT_THRESHOLD (default 30) events in 7 days
+#         OR has an open PR with status:in-progress label
+#   warm: >= PULSE_TIER_WARM_EVENT_THRESHOLD (default 5) events in 7 days
+#   cold: < PULSE_TIER_WARM_EVENT_THRESHOLD events
+#
+# Part of aidevops framework: https://aidevops.sh
+
+set -euo pipefail
+
+# PATH normalisation for launchd/cron environments.
+export PATH="/opt/homebrew/bin:/usr/local/bin:/home/linuxbrew/.linuxbrew/bin:/bin:/usr/bin:${PATH}"
+
+# SCRIPT_DIR resolution — uses BASH_SOURCE[0]:-$0 for zsh portability.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+
+# =============================================================================
+# Shared constants (sourced for color vars, safe_grep_count, etc.)
+# =============================================================================
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/shared-constants.sh" 2>/dev/null || true
+
+# =============================================================================
+# Tier name constants (avoid repeated literal violations in linter)
+# =============================================================================
+_TIER_HOT="hot"
+_TIER_WARM="warm"
+_TIER_COLD="cold"
+
+# =============================================================================
+# Configuration (env-overridable, consistent with pulse-wrapper-config.sh)
+# =============================================================================
+REPOS_JSON="${REPOS_JSON:-${HOME}/.config/aidevops/repos.json}"
+PULSE_TIER_CACHE_FILE="${PULSE_TIER_CACHE_FILE:-${HOME}/.aidevops/cache/pulse-repo-tiers.json}"
+PULSE_TIER_CACHE_MAX_AGE_S="${PULSE_TIER_CACHE_MAX_AGE_S:-7200}"   # 2h stale threshold for tier-of fallback
+PULSE_TIER_HOT_EVENT_THRESHOLD="${PULSE_TIER_HOT_EVENT_THRESHOLD:-30}"   # >= N events in 7d → hot
+PULSE_TIER_WARM_EVENT_THRESHOLD="${PULSE_TIER_WARM_EVENT_THRESHOLD:-5}"  # >= N events in 7d → warm; <N → cold
+PULSE_TIER_LOOKBACK_DAYS="${PULSE_TIER_LOOKBACK_DAYS:-7}"
+PULSE_TIER_EVENTS_PER_PAGE="${PULSE_TIER_EVENTS_PER_PAGE:-100}"
+PULSE_TIER_MAX_PAGES="${PULSE_TIER_MAX_PAGES:-3}"  # Max pagination pages per repo (~300 events max)
+
+# LOGFILE for log messages (use pulse.log when available, else /dev/null)
+LOGFILE="${LOGFILE:-${HOME}/.aidevops/logs/pulse.log}"
+
+# =============================================================================
+# Internal helpers
+# =============================================================================
+
+#######################################
+# Ensure cache directory exists.
+#######################################
+_tier_ensure_cache_dir() {
+	local cache_dir
+	cache_dir="$(dirname "${PULSE_TIER_CACHE_FILE}")"
+	[[ -d "$cache_dir" ]] || mkdir -p "$cache_dir" 2>/dev/null || true
+	return 0
+}
+
+#######################################
+# Count GitHub events for a repo in the last N days.
+# Uses REST events API (no GraphQL — avoids expensive rate-limit quota).
+# Paginates up to PULSE_TIER_MAX_PAGES pages.
+#
+# Arguments:
+#   $1 - slug (owner/repo)
+#   $2 - lookback_days (integer)
+#
+# Outputs: integer count to stdout
+# Returns: 0 always (safe default = 0 on API failure)
+#######################################
+_tier_count_events() {
+	local slug="$1"
+	local lookback_days="$2"
+
+	local cutoff_epoch
+	cutoff_epoch=$(date -v -"${lookback_days}"d +%s 2>/dev/null) || \
+		cutoff_epoch=$(date -d "${lookback_days} days ago" +%s 2>/dev/null) || \
+		cutoff_epoch=0
+
+	local total=0
+	local page=1
+	local done_paging=false
+
+	while [[ "$done_paging" != "true" ]] && [[ "$page" -le "$PULSE_TIER_MAX_PAGES" ]]; do
+		local events_json
+		events_json=$(gh api "/repos/${slug}/events?per_page=${PULSE_TIER_EVENTS_PER_PAGE}&page=${page}" \
+			--jq '[.[] | select(.created_at != null) | {ts: (.created_at | split("T")[0])}]' \
+			2>/dev/null) || events_json="[]"
+
+		# Empty page → done
+		local page_count
+		page_count=$(printf '%s' "$events_json" | jq 'length' 2>/dev/null) || page_count=0
+		[[ "$page_count" =~ ^[0-9]+$ ]] || page_count=0
+		if [[ "$page_count" -eq 0 ]]; then
+			done_paging=true
+			break
+		fi
+
+		# Check each event: count those within cutoff; if we hit one outside, stop paging
+		local in_window
+		in_window=$(printf '%s' "$events_json" | jq --argjson cutoff "$cutoff_epoch" \
+			'[.[] | select((.ts | strptime("%Y-%m-%d") | mktime) >= $cutoff)] | length' \
+			2>/dev/null) || in_window=0
+		[[ "$in_window" =~ ^[0-9]+$ ]] || in_window=0
+
+		total=$((total + in_window))
+
+		# If fewer events within window than page size, remaining pages have older events
+		if [[ "$in_window" -lt "$page_count" ]]; then
+			done_paging=true
+		fi
+
+		page=$((page + 1))
+	done
+
+	echo "$total"
+	return 0
+}
+
+#######################################
+# Check if a repo has any open PR with status:in-progress label.
+# Uses REST search (not GraphQL) to stay within rate limits.
+#
+# Arguments:
+#   $1 - slug (owner/repo)
+#
+# Returns: 0 if found, 1 if not
+#######################################
+_tier_has_inprogress_pr() {
+	local slug="$1"
+
+	local result
+	result=$(gh search prs --repo "$slug" --state open --label "status:in-progress" \
+		--limit 1 --json number 2>/dev/null) || result="[]"
+
+	local count
+	count=$(printf '%s' "$result" | jq 'length' 2>/dev/null) || count=0
+	[[ "$count" =~ ^[0-9]+$ ]] || count=0
+	[[ "$count" -gt 0 ]] && return 0
+	return 1
+}
+
+#######################################
+# Classify a single repo into hot/warm/cold.
+#
+# Arguments:
+#   $1 - slug (owner/repo)
+#
+# Outputs: "hot", "warm", or "cold" to stdout
+# Returns: 0 always
+#######################################
+_tier_classify_one() {
+	local slug="$1"
+
+	local event_count
+	event_count=$(_tier_count_events "$slug" "$PULSE_TIER_LOOKBACK_DAYS")
+	[[ "$event_count" =~ ^[0-9]+$ ]] || event_count=0
+
+	local tier="$_TIER_COLD"
+	if [[ "$event_count" -ge "$PULSE_TIER_HOT_EVENT_THRESHOLD" ]]; then
+		tier="$_TIER_HOT"
+	elif [[ "$event_count" -ge "$PULSE_TIER_WARM_EVENT_THRESHOLD" ]]; then
+		tier="$_TIER_WARM"
+	else
+		# Cold by event count, but promote to hot if has in-progress PR
+		if _tier_has_inprogress_pr "$slug" 2>/dev/null; then
+			tier="$_TIER_HOT"
+		fi
+	fi
+
+	# Also promote warm to hot if has in-progress PR
+	if [[ "$tier" == "$_TIER_WARM" ]] && _tier_has_inprogress_pr "$slug" 2>/dev/null; then
+		tier="$_TIER_HOT"
+	fi
+
+	echo "$tier"
+	return 0
+}
+
+#######################################
+# Write a single slug's tier entry atomically to the cache file.
+# Uses jq to merge into the existing JSON object (atomic mktemp+mv).
+#
+# Arguments:
+#   $1 - slug
+#   $2 - tier (hot|warm|cold)
+#   $3 - event_count (integer)
+#######################################
+_tier_cache_write_one() {
+	local slug="$1"
+	local tier="$2"
+	local event_count="$3"
+
+	local now_epoch
+	now_epoch=$(date +%s)
+
+	local cache_dir
+	cache_dir="$(dirname "${PULSE_TIER_CACHE_FILE}")"
+
+	local existing='{}'
+	if [[ -f "$PULSE_TIER_CACHE_FILE" ]]; then
+		existing=$(jq '.' "$PULSE_TIER_CACHE_FILE" 2>/dev/null) || existing='{}'
+		[[ -n "$existing" ]] || existing='{}'
+	fi
+
+	local tmp_cache
+	tmp_cache=$(mktemp "${cache_dir}/.pulse-repo-tiers-XXXXXX.json") || return 0
+
+	if printf '%s' "$existing" | jq \
+		--arg slug "$slug" \
+		--arg tier "$tier" \
+		--argjson event_count "$event_count" \
+		--argjson ts "$now_epoch" \
+		'.[$slug] = {tier: $tier, event_count: $event_count, ts: $ts}' \
+		>"$tmp_cache" 2>/dev/null && jq empty "$tmp_cache" 2>/dev/null; then
+		mv "$tmp_cache" "$PULSE_TIER_CACHE_FILE"
+	else
+		rm -f "$tmp_cache"
+		echo "[pulse-repo-tier] WARNING: jq failed writing tier for ${slug}" >>"$LOGFILE" 2>/dev/null || true
+	fi
+	return 0
+}
+
+# =============================================================================
+# Public commands
+# =============================================================================
+
+#######################################
+# classify — classify all pulse-enabled repos and write tiers to cache.
+# Runs each repo sequentially (event API calls are already rate-limit sensitive).
+#######################################
+cmd_classify() {
+	if [[ ! -f "$REPOS_JSON" ]]; then
+		echo "[pulse-repo-tier] ERROR: repos.json not found at ${REPOS_JSON}" >&2
+		return 1
+	fi
+
+	_tier_ensure_cache_dir
+
+	local slugs
+	slugs=$(jq -r '.initialized_repos[] |
+		select(.pulse == true and (.local_only // false) == false and .slug != "") |
+		.slug
+	' "$REPOS_JSON" 2>/dev/null) || slugs=""
+
+	if [[ -z "$slugs" ]]; then
+		echo "[pulse-repo-tier] No pulse-enabled repos found in ${REPOS_JSON}" >&2
+		return 0
+	fi
+
+	echo "[pulse-repo-tier] classify: starting for $(printf '%s\n' "$slugs" | wc -l | tr -d ' ') repos" >>"$LOGFILE" 2>/dev/null || true
+
+	local failed=0
+	while IFS= read -r slug; do
+		[[ -n "$slug" ]] || continue
+		local tier event_count
+		event_count=$(_tier_count_events "$slug" "$PULSE_TIER_LOOKBACK_DAYS")
+		[[ "$event_count" =~ ^[0-9]+$ ]] || event_count=0
+
+		if [[ "$event_count" -ge "$PULSE_TIER_HOT_EVENT_THRESHOLD" ]]; then
+			tier="$_TIER_HOT"
+		elif [[ "$event_count" -ge "$PULSE_TIER_WARM_EVENT_THRESHOLD" ]]; then
+			tier="$_TIER_WARM"
+		else
+			tier="$_TIER_COLD"
+		fi
+
+		# Promote to hot if has in-progress PR (regardless of event count)
+		if [[ "$tier" != "$_TIER_HOT" ]]; then
+			if _tier_has_inprogress_pr "$slug" 2>/dev/null; then
+				tier="$_TIER_HOT"
+			fi
+		fi
+
+		_tier_cache_write_one "$slug" "$tier" "$event_count"
+		echo "[pulse-repo-tier] classify: ${slug} → ${tier} (${event_count} events/7d)" >>"$LOGFILE" 2>/dev/null || true
+	done <<<"$slugs"
+
+	echo "[pulse-repo-tier] classify: complete (${failed} errors)" >>"$LOGFILE" 2>/dev/null || true
+	return 0
+}
+
+#######################################
+# tier-of <slug> — return cached tier for one repo.
+# Falls back to "warm" on cache miss or stale cache (>PULSE_TIER_CACHE_MAX_AGE_S old).
+#
+# Arguments:
+#   $1 - slug (owner/repo)
+#
+# Outputs: "hot", "warm", or "cold" to stdout
+#######################################
+cmd_tier_of() {
+	local slug="$1"
+
+	if [[ -z "$slug" ]]; then
+		echo "[pulse-repo-tier] ERROR: tier-of requires a slug argument" >&2
+		echo "$_TIER_WARM"
+		return 0
+	fi
+
+	# Cache miss → default
+	if [[ ! -f "$PULSE_TIER_CACHE_FILE" ]]; then
+		echo "$_TIER_WARM"
+		return 0
+	fi
+
+	local entry
+	entry=$(jq -r --arg slug "$slug" '.[$slug] // empty' "$PULSE_TIER_CACHE_FILE" 2>/dev/null) || entry=""
+
+	if [[ -z "$entry" || "$entry" == "null" ]]; then
+		echo "$_TIER_WARM"
+		return 0
+	fi
+
+	# Check age
+	local cached_ts
+	cached_ts=$(printf '%s' "$entry" | jq -r '.ts // 0' 2>/dev/null) || cached_ts=0
+	[[ "$cached_ts" =~ ^[0-9]+$ ]] || cached_ts=0
+
+	local now_epoch
+	now_epoch=$(date +%s)
+	local age=$(( now_epoch - cached_ts ))
+
+	if [[ "$age" -gt "$PULSE_TIER_CACHE_MAX_AGE_S" ]]; then
+		# Cache stale → safe default (warm so we don't permanently skip active repos)
+		echo "$_TIER_WARM"
+		return 0
+	fi
+
+	local tier
+	tier=$(printf '%s' "$entry" | jq -r '.tier // "warm"' 2>/dev/null) || tier="$_TIER_WARM"
+	case "$tier" in
+		hot|warm|cold) echo "$tier" ;;
+		*) echo "$_TIER_WARM" ;;
+	esac
+	return 0
+}
+
+# =============================================================================
+# Main dispatcher
+# =============================================================================
+
+_usage() {
+	cat <<EOF
+Usage: $(basename "${BASH_SOURCE[0]:-$0}") <command> [args]
+
+Commands:
+  classify         Classify all pulse-enabled repos into tiers and write cache
+  tier-of <slug>   Return cached tier for one repo (warm on miss/stale)
+  help             Show this message
+
+Environment:
+  REPOS_JSON                   Path to repos.json (default: ~/.config/aidevops/repos.json)
+  PULSE_TIER_CACHE_FILE        Cache output path (default: ~/.aidevops/cache/pulse-repo-tiers.json)
+  PULSE_TIER_HOT_EVENT_THRESHOLD   Events/7d to classify as hot (default: 30)
+  PULSE_TIER_WARM_EVENT_THRESHOLD  Events/7d to classify as warm (default: 5)
+  PULSE_TIER_CACHE_MAX_AGE_S   Stale threshold for tier-of fallback (default: 7200)
+EOF
+	return 0
+}
+
+main() {
+	local cmd="${1:-help}"
+	shift || true
+
+	case "$cmd" in
+		classify)
+			cmd_classify "$@"
+			;;
+		tier-of)
+			cmd_tier_of "${1:-}"
+			;;
+		help|--help|-h)
+			_usage
+			;;
+		*)
+			echo "[pulse-repo-tier] Unknown command: ${cmd}" >&2
+			_usage >&2
+			return 1
+			;;
+	esac
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/pulse-wrapper-config.sh
+++ b/.agents/scripts/pulse-wrapper-config.sh
@@ -135,6 +135,20 @@ PULSE_BATCH_PREFETCH_ENABLED="${PULSE_BATCH_PREFETCH_ENABLED:-1}"               
 PULSE_BATCH_PREFETCH_CACHE_DIR="${PULSE_BATCH_PREFETCH_CACHE_DIR:-${HOME}/.aidevops/logs/batch-prefetch}"  # GH#19963: Directory for batch prefetch per-slug cache files
 PULSE_BATCH_SEARCH_LIMIT="${PULSE_BATCH_SEARCH_LIMIT:-200}"                                                # GH#19963: Max results per gh search call (Search API --limit cap)
 
+# Per-repo activity tier classification (t2831)
+#
+# Classifies repos into hot/warm/cold based on rolling 7-day event count.
+# Controls prefetch cadence: hot=every cycle, warm=every ~3 cycles, cold=every ~10 cycles.
+# Tier cache refreshed hourly by pulse-repo-tier-classifier-routine.sh (launchd).
+#
+# Intervals are minimum seconds between full prefetches per tier.
+# Hot (interval=0) repos are never skipped — they always get a fresh prefetch.
+PULSE_TIER_CLASSIFICATION_ENABLED="${PULSE_TIER_CLASSIFICATION_ENABLED:-1}"                               # t2831: 1=enable, 0=disable tier-based cadence (rollback switch)
+PULSE_TIER_HOT_INTERVAL="${PULSE_TIER_HOT_INTERVAL:-0}"                                                   # t2831: hot repos: 0=never skip (check every cycle)
+PULSE_TIER_WARM_INTERVAL="${PULSE_TIER_WARM_INTERVAL:-180}"                                               # t2831: warm repos: skip if last check < 180s ago (~3 cycles at 60s base)
+PULSE_TIER_COLD_INTERVAL="${PULSE_TIER_COLD_INTERVAL:-600}"                                               # t2831: cold repos: skip if last check < 600s ago (~10 cycles at 60s base)
+export PULSE_TIER_CLASSIFICATION_ENABLED PULSE_TIER_HOT_INTERVAL PULSE_TIER_WARM_INTERVAL PULSE_TIER_COLD_INTERVAL
+
 # Per-issue retry state (t1888, GH#2076, GH#17384)
 #
 # Cause-aware retry backoff per issue. Different failure types get

--- a/.agents/scripts/tests/test-pulse-repo-tier.sh
+++ b/.agents/scripts/tests/test-pulse-repo-tier.sh
@@ -1,0 +1,534 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-pulse-repo-tier.sh — Tests for pulse-repo-tier.sh and tier-based skip (t2831)
+#
+# Tests:
+#   pulse-repo-tier.sh tier-of:
+#     - Cache miss → "warm" (safe default)
+#     - Stale cache (>2h) → "warm"
+#     - Hot entry → "hot"
+#     - Warm entry → "warm"
+#     - Cold entry → "cold"
+#     - Unknown tier value → "warm"
+#     - No slug argument → "warm"
+#   check_repo_tier_skip (from pulse-prefetch-fetch.sh):
+#     - PULSE_TIER_CLASSIFICATION_ENABLED=0 → always proceed (returns 0)
+#     - Tier=hot → always proceed (returns 0)
+#     - Tier=warm, elapsed < warm_interval → skip (returns 1)
+#     - Tier=warm, elapsed > warm_interval → proceed (returns 0)
+#     - Tier=cold, elapsed < cold_interval → skip (returns 1)
+#     - Tier=cold, elapsed > cold_interval → proceed (returns 0)
+#   update_repo_tier_check_timestamp:
+#     - Writes current epoch for repo
+#     - Creates state file if missing
+#     - Updates are independent per repo
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+TIER_SCRIPT="${SCRIPT_DIR}/../pulse-repo-tier.sh"
+PREFETCH_FETCH_SCRIPT="${SCRIPT_DIR}/../pulse-prefetch-fetch.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+ORIGINAL_HOME="${HOME}"
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_test_env() {
+	# Use a per-test subdirectory under the global TEST_ROOT so the root
+	# stays available across all tests and the global trap cleans it up.
+	local test_subdir
+	test_subdir=$(mktemp -d "${TEST_ROOT}/test-XXXXXX")
+	export HOME="${test_subdir}/home"
+	mkdir -p "${HOME}/.aidevops/logs" "${HOME}/.aidevops/cache" "${HOME}/.config/aidevops"
+	export LOGFILE="${HOME}/.aidevops/logs/pulse.log"
+	export PULSE_TIER_CACHE_FILE="${HOME}/.aidevops/cache/pulse-repo-tiers.json"
+	export PULSE_TIER_LAST_CHECK_FILE="${HOME}/.aidevops/logs/pulse-tier-last-check.json"
+	export PULSE_TIER_CLASSIFICATION_ENABLED=1
+	export PULSE_TIER_HOT_INTERVAL=0
+	export PULSE_TIER_WARM_INTERVAL=180
+	export PULSE_TIER_COLD_INTERVAL=600
+	return 0
+}
+
+teardown_test_env() {
+	# Restore HOME; the subdir is inside TEST_ROOT and cleaned by the global trap.
+	export HOME="$ORIGINAL_HOME"
+	return 0
+}
+
+# =============================================================================
+# pulse-repo-tier.sh tier-of tests
+# =============================================================================
+
+test_tier_of_cache_miss() {
+	# No cache file → should return "warm"
+	local result
+	result=$(PULSE_TIER_CACHE_FILE="${TEST_ROOT}/nonexistent.json" \
+		bash "$TIER_SCRIPT" tier-of "owner/repo" 2>/dev/null)
+	if [[ "$result" == "warm" ]]; then
+		print_result "tier-of: cache miss → warm" 0
+	else
+		print_result "tier-of: cache miss → warm" 1 "Expected 'warm', got '${result}'"
+	fi
+	return 0
+}
+
+test_tier_of_stale_cache() {
+	# Cache file exists but entry is >2h old → should return "warm"
+	local cache_file="${TEST_ROOT}/tier-stale.json"
+	local old_epoch
+	old_epoch=$(( $(date +%s) - 9000 ))  # 2.5 hours ago
+	printf '{"owner/repo": {"tier": "cold", "event_count": 1, "ts": %d}}\n' "$old_epoch" >"$cache_file"
+
+	local result
+	result=$(PULSE_TIER_CACHE_FILE="$cache_file" \
+		PULSE_TIER_CACHE_MAX_AGE_S=7200 \
+		bash "$TIER_SCRIPT" tier-of "owner/repo" 2>/dev/null)
+	if [[ "$result" == "warm" ]]; then
+		print_result "tier-of: stale cache → warm" 0
+	else
+		print_result "tier-of: stale cache → warm" 1 "Expected 'warm' for stale entry, got '${result}'"
+	fi
+	return 0
+}
+
+test_tier_of_hot() {
+	local cache_file="${TEST_ROOT}/tier-hot.json"
+	local now
+	now=$(date +%s)
+	printf '{"owner/repo": {"tier": "hot", "event_count": 50, "ts": %d}}\n' "$now" >"$cache_file"
+
+	local result
+	result=$(PULSE_TIER_CACHE_FILE="$cache_file" \
+		bash "$TIER_SCRIPT" tier-of "owner/repo" 2>/dev/null)
+	if [[ "$result" == "hot" ]]; then
+		print_result "tier-of: hot entry → hot" 0
+	else
+		print_result "tier-of: hot entry → hot" 1 "Expected 'hot', got '${result}'"
+	fi
+	return 0
+}
+
+test_tier_of_warm() {
+	local cache_file="${TEST_ROOT}/tier-warm.json"
+	local now
+	now=$(date +%s)
+	printf '{"owner/repo": {"tier": "warm", "event_count": 10, "ts": %d}}\n' "$now" >"$cache_file"
+
+	local result
+	result=$(PULSE_TIER_CACHE_FILE="$cache_file" \
+		bash "$TIER_SCRIPT" tier-of "owner/repo" 2>/dev/null)
+	if [[ "$result" == "warm" ]]; then
+		print_result "tier-of: warm entry → warm" 0
+	else
+		print_result "tier-of: warm entry → warm" 1 "Expected 'warm', got '${result}'"
+	fi
+	return 0
+}
+
+test_tier_of_cold() {
+	local cache_file="${TEST_ROOT}/tier-cold.json"
+	local now
+	now=$(date +%s)
+	printf '{"owner/repo": {"tier": "cold", "event_count": 2, "ts": %d}}\n' "$now" >"$cache_file"
+
+	local result
+	result=$(PULSE_TIER_CACHE_FILE="$cache_file" \
+		bash "$TIER_SCRIPT" tier-of "owner/repo" 2>/dev/null)
+	if [[ "$result" == "cold" ]]; then
+		print_result "tier-of: cold entry → cold" 0
+	else
+		print_result "tier-of: cold entry → cold" 1 "Expected 'cold', got '${result}'"
+	fi
+	return 0
+}
+
+test_tier_of_unknown_tier_value() {
+	local cache_file="${TEST_ROOT}/tier-unknown.json"
+	local now
+	now=$(date +%s)
+	printf '{"owner/repo": {"tier": "bogus", "event_count": 5, "ts": %d}}\n' "$now" >"$cache_file"
+
+	local result
+	result=$(PULSE_TIER_CACHE_FILE="$cache_file" \
+		bash "$TIER_SCRIPT" tier-of "owner/repo" 2>/dev/null)
+	if [[ "$result" == "warm" ]]; then
+		print_result "tier-of: unknown tier value → warm" 0
+	else
+		print_result "tier-of: unknown tier value → warm" 1 "Expected 'warm' for unknown tier, got '${result}'"
+	fi
+	return 0
+}
+
+test_tier_of_no_slug() {
+	# No slug argument → should print "warm" and not error out
+	local result
+	result=$(PULSE_TIER_CACHE_FILE="${TEST_ROOT}/any.json" \
+		bash "$TIER_SCRIPT" tier-of "" 2>/dev/null)
+	if [[ "$result" == "warm" ]]; then
+		print_result "tier-of: no slug → warm" 0
+	else
+		print_result "tier-of: no slug → warm" 1 "Expected 'warm' for empty slug, got '${result}'"
+	fi
+	return 0
+}
+
+test_tier_of_missing_slug_in_cache() {
+	# Cache file exists but doesn't have the requested slug
+	local cache_file="${TEST_ROOT}/tier-other.json"
+	local now
+	now=$(date +%s)
+	printf '{"other/repo": {"tier": "hot", "event_count": 50, "ts": %d}}\n' "$now" >"$cache_file"
+
+	local result
+	result=$(PULSE_TIER_CACHE_FILE="$cache_file" \
+		bash "$TIER_SCRIPT" tier-of "owner/repo" 2>/dev/null)
+	if [[ "$result" == "warm" ]]; then
+		print_result "tier-of: slug not in cache → warm" 0
+	else
+		print_result "tier-of: slug not in cache → warm" 1 "Expected 'warm' for missing slug, got '${result}'"
+	fi
+	return 0
+}
+
+# =============================================================================
+# check_repo_tier_skip tests (sourced from pulse-prefetch-fetch.sh)
+# Requires sourcing the lib rather than calling the script.
+# =============================================================================
+
+_source_prefetch_fetch() {
+	# Source the minimum environment needed for pulse-prefetch-fetch.sh
+	# We only need check_repo_tier_skip and update_repo_tier_check_timestamp.
+	# Stub out LOGFILE and functions that may not be available in test context.
+	export LOGFILE="${HOME}/.aidevops/logs/pulse.log"
+	export PULSE_TIER_SCRIPT="$TIER_SCRIPT"
+	# shellcheck source=/dev/null
+	source "$PREFETCH_FETCH_SCRIPT" 2>/dev/null || true
+	return 0
+}
+
+test_tier_skip_disabled() {
+	# PULSE_TIER_CLASSIFICATION_ENABLED=0 → always proceed
+	setup_test_env
+	_source_prefetch_fetch
+
+	local state_file="${HOME}/.aidevops/logs/pulse-tier-last-check.json"
+	if PULSE_TIER_CLASSIFICATION_ENABLED=0 check_repo_tier_skip "owner/repo" "$state_file"; then
+		print_result "check_repo_tier_skip: disabled → always proceed" 0
+	else
+		print_result "check_repo_tier_skip: disabled → always proceed" 1 "Expected proceed (0) when feature disabled"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_tier_skip_hot_no_skip() {
+	# Hot repos always proceed regardless of last check time
+	setup_test_env
+	_source_prefetch_fetch
+
+	local cache_file="${HOME}/.aidevops/cache/pulse-repo-tiers.json"
+	local now
+	now=$(date +%s)
+	printf '{"owner/repo": {"tier": "hot", "event_count": 50, "ts": %d}}\n' "$now" >"$cache_file"
+
+	# Write a very recent last-check timestamp
+	local state_file="${HOME}/.aidevops/logs/pulse-tier-last-check.json"
+	printf '{"last_check": {"owner/repo": %d}}\n' "$now" >"$state_file"
+
+	if PULSE_TIER_CACHE_FILE="$cache_file" check_repo_tier_skip "owner/repo" "$state_file"; then
+		print_result "check_repo_tier_skip: hot → never skip" 0
+	else
+		print_result "check_repo_tier_skip: hot → never skip" 1 "Expected proceed (0) for hot repo"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_tier_skip_warm_recent() {
+	# Warm repo, last check 30s ago, interval=180s → skip
+	setup_test_env
+	_source_prefetch_fetch
+
+	local cache_file="${HOME}/.aidevops/cache/pulse-repo-tiers.json"
+	local now
+	now=$(date +%s)
+	printf '{"owner/repo": {"tier": "warm", "event_count": 10, "ts": %d}}\n' "$now" >"$cache_file"
+
+	local recent
+	recent=$(( now - 30 ))  # 30s ago
+	local state_file="${HOME}/.aidevops/logs/pulse-tier-last-check.json"
+	printf '{"last_check": {"owner/repo": %d}}\n' "$recent" >"$state_file"
+
+	if PULSE_TIER_CACHE_FILE="$cache_file" \
+	   PULSE_TIER_WARM_INTERVAL=180 \
+	   check_repo_tier_skip "owner/repo" "$state_file"; then
+		print_result "check_repo_tier_skip: warm + recent check → skip" 1 "Expected skip (1) for warm repo checked 30s ago"
+	else
+		print_result "check_repo_tier_skip: warm + recent check → skip" 0
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_tier_skip_warm_elapsed() {
+	# Warm repo, last check 300s ago, interval=180s → proceed
+	setup_test_env
+	_source_prefetch_fetch
+
+	local cache_file="${HOME}/.aidevops/cache/pulse-repo-tiers.json"
+	local now
+	now=$(date +%s)
+	printf '{"owner/repo": {"tier": "warm", "event_count": 10, "ts": %d}}\n' "$now" >"$cache_file"
+
+	local old
+	old=$(( now - 300 ))  # 300s ago
+	local state_file="${HOME}/.aidevops/logs/pulse-tier-last-check.json"
+	printf '{"last_check": {"owner/repo": %d}}\n' "$old" >"$state_file"
+
+	if PULSE_TIER_CACHE_FILE="$cache_file" \
+	   PULSE_TIER_WARM_INTERVAL=180 \
+	   check_repo_tier_skip "owner/repo" "$state_file"; then
+		print_result "check_repo_tier_skip: warm + elapsed check → proceed" 0
+	else
+		print_result "check_repo_tier_skip: warm + elapsed check → proceed" 1 "Expected proceed (0) for warm repo checked 300s ago with 180s interval"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_tier_skip_cold_recent() {
+	# Cold repo, last check 60s ago, interval=600s → skip
+	setup_test_env
+	_source_prefetch_fetch
+
+	local cache_file="${HOME}/.aidevops/cache/pulse-repo-tiers.json"
+	local now
+	now=$(date +%s)
+	printf '{"owner/repo": {"tier": "cold", "event_count": 1, "ts": %d}}\n' "$now" >"$cache_file"
+
+	local recent
+	recent=$(( now - 60 ))  # 60s ago
+	local state_file="${HOME}/.aidevops/logs/pulse-tier-last-check.json"
+	printf '{"last_check": {"owner/repo": %d}}\n' "$recent" >"$state_file"
+
+	if PULSE_TIER_CACHE_FILE="$cache_file" \
+	   PULSE_TIER_COLD_INTERVAL=600 \
+	   check_repo_tier_skip "owner/repo" "$state_file"; then
+		print_result "check_repo_tier_skip: cold + recent check → skip" 1 "Expected skip (1) for cold repo checked 60s ago"
+	else
+		print_result "check_repo_tier_skip: cold + recent check → skip" 0
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_tier_skip_cold_elapsed() {
+	# Cold repo, last check 1200s ago, interval=600s → proceed
+	setup_test_env
+	_source_prefetch_fetch
+
+	local cache_file="${HOME}/.aidevops/cache/pulse-repo-tiers.json"
+	local now
+	now=$(date +%s)
+	printf '{"owner/repo": {"tier": "cold", "event_count": 1, "ts": %d}}\n' "$now" >"$cache_file"
+
+	local old
+	old=$(( now - 1200 ))  # 1200s ago
+	local state_file="${HOME}/.aidevops/logs/pulse-tier-last-check.json"
+	printf '{"last_check": {"owner/repo": %d}}\n' "$old" >"$state_file"
+
+	if PULSE_TIER_CACHE_FILE="$cache_file" \
+	   PULSE_TIER_COLD_INTERVAL=600 \
+	   check_repo_tier_skip "owner/repo" "$state_file"; then
+		print_result "check_repo_tier_skip: cold + elapsed check → proceed" 0
+	else
+		print_result "check_repo_tier_skip: cold + elapsed check → proceed" 1 "Expected proceed (0) for cold repo checked 1200s ago with 600s interval"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_tier_skip_no_state_file() {
+	# No state file → last_check=0 → elapsed is huge → always proceed
+	setup_test_env
+	_source_prefetch_fetch
+
+	local cache_file="${HOME}/.aidevops/cache/pulse-repo-tiers.json"
+	local now
+	now=$(date +%s)
+	printf '{"owner/repo": {"tier": "cold", "event_count": 0, "ts": %d}}\n' "$now" >"$cache_file"
+
+	local state_file="${TEST_ROOT}/nonexistent-state.json"
+	rm -f "$state_file"
+
+	if PULSE_TIER_CACHE_FILE="$cache_file" \
+	   PULSE_TIER_COLD_INTERVAL=600 \
+	   check_repo_tier_skip "owner/repo" "$state_file"; then
+		print_result "check_repo_tier_skip: no state file → proceed" 0
+	else
+		print_result "check_repo_tier_skip: no state file → proceed" 1 "Expected proceed (0) when state file missing"
+	fi
+	teardown_test_env
+	return 0
+}
+
+# =============================================================================
+# update_repo_tier_check_timestamp tests
+# =============================================================================
+
+test_update_tier_timestamp_writes_epoch() {
+	setup_test_env
+	_source_prefetch_fetch
+
+	local state_file="${HOME}/.aidevops/logs/pulse-tier-ts-test.json"
+	local before after written_ts
+	before=$(date +%s)
+	update_repo_tier_check_timestamp "write/test" "$state_file"
+	after=$(date +%s)
+
+	if command -v jq &>/dev/null && [[ -f "$state_file" ]]; then
+		written_ts=$(jq -r '.last_check["write/test"]' "$state_file" 2>/dev/null) || written_ts=0
+		if [[ "$written_ts" -ge "$before" && "$written_ts" -le "$after" ]]; then
+			print_result "update_repo_tier_check_timestamp: writes current epoch" 0
+		else
+			print_result "update_repo_tier_check_timestamp: writes current epoch" 1 \
+				"Timestamp ${written_ts} not in range [${before}, ${after}]"
+		fi
+	else
+		print_result "update_repo_tier_check_timestamp: writes current epoch" 0 "(jq not available or state file missing — skipped)"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_update_tier_timestamp_creates_file() {
+	setup_test_env
+	_source_prefetch_fetch
+
+	local state_file="${HOME}/.aidevops/logs/tier-create-test.json"
+	rm -f "$state_file"
+
+	update_repo_tier_check_timestamp "create/test" "$state_file"
+
+	if [[ -f "$state_file" ]]; then
+		print_result "update_repo_tier_check_timestamp: creates state file if missing" 0
+	else
+		print_result "update_repo_tier_check_timestamp: creates state file if missing" 1 \
+			"State file not created at ${state_file}"
+	fi
+	teardown_test_env
+	return 0
+}
+
+test_update_tier_timestamp_independent_per_repo() {
+	setup_test_env
+	_source_prefetch_fetch
+
+	local state_file="${HOME}/.aidevops/logs/tier-indep-test.json"
+	local old_ts=$(( $(date +%s) - 100 ))
+
+	# Pre-populate alpha with an old timestamp
+	printf '{"last_check": {"alpha/repo": %d}}\n' "$old_ts" >"$state_file"
+
+	# Update only beta
+	update_repo_tier_check_timestamp "beta/repo" "$state_file"
+
+	if command -v jq &>/dev/null; then
+		local alpha_ts beta_ts
+		alpha_ts=$(jq -r '.last_check["alpha/repo"]' "$state_file" 2>/dev/null) || alpha_ts=0
+		beta_ts=$(jq -r '.last_check["beta/repo"]' "$state_file" 2>/dev/null) || beta_ts=0
+		if [[ "$alpha_ts" == "$old_ts" && "$beta_ts" -gt 0 ]]; then
+			print_result "update_repo_tier_check_timestamp: updates are independent per repo" 0
+		else
+			print_result "update_repo_tier_check_timestamp: updates are independent per repo" 1 \
+				"alpha=${alpha_ts} (expected ${old_ts}), beta=${beta_ts} (expected >0)"
+		fi
+	else
+		print_result "update_repo_tier_check_timestamp: updates are independent per repo" 0 "(jq not available — skipped)"
+	fi
+	teardown_test_env
+	return 0
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+
+main() {
+	echo "=== test-pulse-repo-tier.sh ==="
+	echo ""
+
+	if [[ ! -x "$TIER_SCRIPT" ]]; then
+		echo "ERROR: ${TIER_SCRIPT} not found or not executable" >&2
+		exit 1
+	fi
+
+	# Global setup: create a shared TEST_ROOT for all tests.
+	# Per-test teardown calls restore HOME and clean TEST_ROOT.
+	# The tier-of tests (which don't call setup/teardown) use this shared root.
+	TEST_ROOT=$(mktemp -d)
+	# shellcheck disable=SC2064
+	trap "rm -rf '${TEST_ROOT}'" EXIT
+
+	# tier-of tests (standalone script invocation)
+	test_tier_of_cache_miss
+	test_tier_of_stale_cache
+	test_tier_of_hot
+	test_tier_of_warm
+	test_tier_of_cold
+	test_tier_of_unknown_tier_value
+	test_tier_of_no_slug
+	test_tier_of_missing_slug_in_cache
+
+	# check_repo_tier_skip and update_repo_tier_check_timestamp tests
+	# Only run if prefetch-fetch script can be sourced
+	if [[ -f "$PREFETCH_FETCH_SCRIPT" ]]; then
+		test_tier_skip_disabled
+		test_tier_skip_hot_no_skip
+		test_tier_skip_warm_recent
+		test_tier_skip_warm_elapsed
+		test_tier_skip_cold_recent
+		test_tier_skip_cold_elapsed
+		test_tier_skip_no_state_file
+		test_update_tier_timestamp_writes_epoch
+		test_update_tier_timestamp_creates_file
+		test_update_tier_timestamp_independent_per_repo
+	else
+		echo "SKIP pulse-prefetch-fetch.sh tests (script not found at: ${PREFETCH_FETCH_SCRIPT})"
+	fi
+
+	echo ""
+	echo "Results: ${TESTS_RUN} run, $((TESTS_RUN - TESTS_FAILED)) passed, ${TESTS_FAILED} failed"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		exit 1
+	fi
+	exit 0
+}
+
+main "$@"

--- a/.agents/templates/launchd/sh.aidevops.repo-tier-classify.plist.tmpl
+++ b/.agents/templates/launchd/sh.aidevops.repo-tier-classify.plist.tmpl
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>Label</key>
+	<string>sh.aidevops.repo-tier-classify</string>
+	<key>ProgramArguments</key>
+	<array>
+		<string>{{BASH_BIN}}</string>
+		<string>{{AIDEVOPS_AGENTS_SCRIPTS}}/pulse-repo-tier-classifier-routine.sh</string>
+		<string>run</string>
+	</array>
+	<key>StartInterval</key>
+	<integer>3600</integer>
+	<key>StandardOutPath</key>
+	<string>{{HOME}}/.aidevops/logs/repo-tier-classify.log</string>
+	<key>StandardErrorPath</key>
+	<string>{{HOME}}/.aidevops/logs/repo-tier-classify.log</string>
+	<key>EnvironmentVariables</key>
+	<dict>
+		<key>PATH</key>
+		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+		<key>HOME</key>
+		<string>{{HOME}}</string>
+	</dict>
+	<key>RunAtLoad</key>
+	<true/>
+	<key>KeepAlive</key>
+	<false/>
+	<key>ProcessType</key>
+	<string>Background</string>
+	<key>LowPriorityBackgroundIO</key>
+	<true/>
+	<key>Nice</key>
+	<integer>10</integer>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary

Implements per-repo activity tier classification for the pulse prefetch stage (GH#20869). Classifies repos into hot/warm/cold based on rolling 7-day GitHub event count and presence of in-progress PRs. Uses the tier to control prefetch cadence:

- hot (>=30 events/7d or has status:in-progress PR): checked every cycle
- warm (5-29 events/7d): skipped if last check <180s ago (~3 cycles)
- cold (<5 events/7d): skipped if last check <600s ago (~10 cycles)

When skipped, cached state is replayed to the state file (no empty sections), and no gh API calls are made. Feature flag PULSE_TIER_CLASSIFICATION_ENABLED=0 for safe rollback.

Files Changed:
- NEW: .agents/scripts/pulse-repo-tier.sh (classify + tier-of commands)
- NEW: .agents/scripts/pulse-repo-tier-classifier-routine.sh (hourly runner)
- NEW: .agents/templates/launchd/sh.aidevops.repo-tier-classify.plist.tmpl
- NEW: .agents/scripts/tests/test-pulse-repo-tier.sh (18 synthetic tests, all passing)
- EDIT: .agents/scripts/pulse-prefetch-fetch.sh (tier check in _prefetch_single_repo)
- EDIT: .agents/scripts/pulse-wrapper-config.sh (PULSE_TIER_* config vars)

ShellCheck clean; pre-commit/pre-push hooks pass.

Resolves #20869
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) worker