### PR TITLE
t2968: Markdoc schema conformance validator + pre-commit hook + CI gate

### DIFF
--- a/.agents/scripts/install-hooks-helper.sh
+++ b/.agents/scripts/install-hooks-helper.sh
@@ -46,6 +46,10 @@ PRE_COMMIT_DEPLOYED="$HOME/.aidevops/agents/scripts/pre-commit-hook.sh"
 # pre-push quality-validation hook (t2207) — slow network checks split from pre-commit
 PRE_PUSH_QUALITY_MARKER="# aidevops-pre-push-quality-hook"
 
+# markdoc schema conformance pre-commit hook (t2968) — opt-in for knowledge plane repos
+MARKDOC_VALIDATE_MARKER="# aidevops-markdoc-validate-hook"
+MARKDOC_VALIDATE_DEPLOYED="$HOME/.aidevops/agents/scripts/markdoc-validate.sh"
+
 print_info() {
 	local msg="$1"
 	printf "${BLUE}[INFO]${NC} %s\n" "$msg"
@@ -354,6 +358,109 @@ HOOKEOF
 	return 0
 }
 
+# --- Markdoc schema conformance pre-commit hook (t2968) ---
+# Opt-in: installed when the repo has at least one knowledge plane directory
+# OR when AIDEVOPS_MARKDOC_VALIDATE=1 is set. The validate-staged command
+# is a no-op (exit 0) when no knowledge plane *.md files are staged.
+
+_kp_dirs=(
+	"_knowledge" "_cases" "_projects"
+	"_performance" "_feedback" "_campaigns" "_inbox"
+)
+
+_has_knowledge_plane_dir() {
+	local repo_root
+	repo_root=$(git rev-parse --show-toplevel 2>/dev/null) || return 1
+	local _d
+	for _d in "${_kp_dirs[@]}"; do
+		[[ -d "${repo_root}/${_d}" ]] && return 0
+	done
+	return 1
+}
+
+install_markdoc_validate_hook() {
+	# Opt-in: skip unless KP dirs exist or env flag set
+	if [[ "${AIDEVOPS_MARKDOC_VALIDATE:-0}" != "1" ]] && ! _has_knowledge_plane_dir; then
+		print_info "markdoc-validate: no knowledge plane dirs found — skipping (set AIDEVOPS_MARKDOC_VALIDATE=1 to force)"
+		return 0
+	fi
+
+	local common_dir
+	if ! common_dir=$(git rev-parse --git-common-dir 2>/dev/null); then
+		print_info "markdoc-validate: not in a git repo — skipping"
+		return 0
+	fi
+
+	local hook_path="${common_dir}/hooks/pre-commit"
+
+	if [[ -f "$hook_path" ]] && grep -q "$MARKDOC_VALIDATE_MARKER" "$hook_path" 2>/dev/null; then
+		print_info "markdoc-validate pre-commit hook already installed — skipping"
+		return 0
+	fi
+
+	# Build the hook body with a single-quoted heredoc (no \$ escaping needed).
+	# AIDEVOPS_DEPLOYED_PLACEHOLDER is substituted for the actual path after the
+	# heredoc, keeping the body text free of double-heredoc duplication which
+	# would trigger the repeated-string-literal ratchet gate (t2968).
+	local _deployed="${MARKDOC_VALIDATE_DEPLOYED}"
+	local hook_snippet
+	hook_snippet=$(cat <<'SNIPPET'
+_mkdv_hook=""
+if _mkdv_root=$(git rev-parse --show-toplevel 2>/dev/null); then
+	_mkdv_hook="${_mkdv_root}/.agents/scripts/markdoc-validate.sh"
+fi
+_mkdv_deployed="AIDEVOPS_DEPLOYED_PLACEHOLDER"
+if [[ -f "$_mkdv_hook" ]]; then
+	"$_mkdv_hook" validate-staged || exit $?
+elif [[ -f "$_mkdv_deployed" ]]; then
+	"$_mkdv_deployed" validate-staged || exit $?
+else
+	printf '[markdoc-validate][WARN] markdoc-validate.sh not found — skipping\n' >&2
+fi
+SNIPPET
+	)
+	hook_snippet="${hook_snippet//AIDEVOPS_DEPLOYED_PLACEHOLDER/$_deployed}"
+
+	local _header
+	_header="$MARKDOC_VALIDATE_MARKER
+# Managed by install-hooks-helper.sh — do not edit.
+# Validates staged Markdoc-tagged knowledge plane files. Bypass: git commit --no-verify"
+
+	if [[ ! -f "$hook_path" ]]; then
+		# No existing hook — create a standalone dispatcher
+		printf '#!/usr/bin/env bash\n%s\n\nset -u\n\n%s\n' \
+			"$_header" "$hook_snippet" >"$hook_path"
+		chmod +x "$hook_path"
+		print_success "installed markdoc-validate pre-commit hook at $hook_path"
+		return 0
+	fi
+
+	# Existing hook — append the snippet
+	if grep -q "$MARKDOC_VALIDATE_MARKER" "$hook_path" 2>/dev/null; then
+		print_info "markdoc-validate: already chained in $hook_path"
+		return 0
+	fi
+
+	printf '\n%s\n\n%s\n' "$_header" "$hook_snippet" >>"$hook_path"
+	print_success "chained markdoc-validate into existing pre-commit hook at $hook_path"
+	return 0
+}
+
+_check_status_markdoc_validate_hook() {
+	local common_dir hook_path
+	if ! common_dir=$(git rev-parse --git-common-dir 2>/dev/null); then
+		print_info "markdoc-validate: not in a git repo — skipped"
+		return 0
+	fi
+	hook_path="${common_dir}/hooks/pre-commit"
+	if [[ -f "$hook_path" ]] && grep -q "$MARKDOC_VALIDATE_MARKER" "$hook_path" 2>/dev/null; then
+		print_success "markdoc-validate: installed in pre-commit hook"
+	else
+		print_info "markdoc-validate: not installed (set AIDEVOPS_MARKDOC_VALIDATE=1 and run: install-hooks-helper.sh install)"
+	fi
+	return 0
+}
+
 # --- Pre-install validator dry-run (t2226) ---
 # Runs all validate_* functions from pre-commit-hook.sh against HEAD state.
 # If any validator fails a no-op commit, the hook is buggy and would strand
@@ -525,6 +632,9 @@ install_hook() {
 
 	# Also install the pre-push quality-validation hook (t2207)
 	install_pre_push_quality_hook
+
+	# Also install the markdoc-validate pre-commit hook (t2968, opt-in)
+	install_markdoc_validate_hook
 
 	return 0
 }
@@ -1000,6 +1110,11 @@ check_status() {
 	echo "Pre-push Quality Hook (t2207)"
 	echo "------------------------------"
 	_check_status_prepush_quality_hook
+
+	echo ""
+	echo "Markdoc Validate Hook (t2968, opt-in)"
+	echo "--------------------------------------"
+	_check_status_markdoc_validate_hook
 
 	echo ""
 	if [[ "$all_ok" == "true" ]]; then

--- a/.agents/scripts/markdoc-validate.sh
+++ b/.agents/scripts/markdoc-validate.sh
@@ -1,0 +1,548 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# markdoc-validate.sh — Markdoc tag schema conformance checker (t2968)
+#
+# Validates Markdoc-tagged knowledge plane files against the JSON schemas at
+# .agents/tools/markdoc/schemas/. No JS runtime required — pure regex parser.
+#
+# Usage:
+#   markdoc-validate.sh validate <file> [<file2> ...]
+#   markdoc-validate.sh validate-staged          # validate staged *.md files
+#   markdoc-validate.sh list-schemas             # list known tag names
+#   markdoc-validate.sh help                     # show usage
+#
+# Exit codes:
+#   0 — valid (no errors)
+#   1 — schema errors (unknown tag, missing required attr, bad enum, unclosed tag)
+#   2 — parse / invocation error (file not found, schema dir missing, bad args)
+#
+# Output format (one per line, grep-friendly):
+#   <file>:<line>:<col>: [error|warning] <message>
+#
+# Environment:
+#   MARKDOC_SCHEMA_DIR  — path to schemas directory
+#                         (default: <script-dir>/../tools/markdoc/schemas)
+
+set -uo pipefail
+
+SCRIPT_NAME=$(basename "$0")
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# --- colour constants (guarded — do not clobber shared-constants.sh exports) ---
+[[ -z "${RED+x}" ]] && RED='\033[0;31m'
+[[ -z "${GREEN+x}" ]] && GREEN='\033[0;32m'
+[[ -z "${YELLOW+x}" ]] && YELLOW='\033[1;33m'
+[[ -z "${NC+x}" ]] && NC='\033[0m'
+
+# Default schema directory — relative to script location
+SCHEMA_DIR="${MARKDOC_SCHEMA_DIR:-${SCRIPT_DIR}/../tools/markdoc/schemas}"
+
+# Counters (session-level)
+TOTAL_ERRORS=0
+TOTAL_WARNINGS=0
+
+# ---------------------------------------------------------------------------
+# Logging helpers
+# ---------------------------------------------------------------------------
+
+_log_error() {
+	local _file="$1"
+	local _line="$2"
+	local _col="$3"
+	local _msg="$4"
+	printf '%s:%s:%s: error: %s\n' "$_file" "$_line" "$_col" "$_msg"
+	TOTAL_ERRORS=$(( TOTAL_ERRORS + 1 ))
+	return 0
+}
+
+_log_warning() {
+	local _file="$1"
+	local _line="$2"
+	local _col="$3"
+	local _msg="$4"
+	printf '%s:%s:%s: warning: %s\n' "$_file" "$_line" "$_col" "$_msg"
+	TOTAL_WARNINGS=$(( TOTAL_WARNINGS + 1 ))
+	return 0
+}
+
+_die() {
+	local _msg="$1"
+	printf '%s[%s] ERROR: %s%s\n' "$RED" "$SCRIPT_NAME" "$_msg" "$NC" >&2
+	exit 2
+}
+
+# ---------------------------------------------------------------------------
+# Schema loading — parse JSON with grep/sed (no jq required at runtime)
+# ---------------------------------------------------------------------------
+
+# _schema_exists <tag_name>
+# Returns 0 if a schema file exists for the tag, 1 otherwise.
+_schema_exists() {
+	local _tag="$1"
+	local _schema_file="${SCHEMA_DIR}/${_tag}.json"
+	[[ -f "$_schema_file" ]]
+	return $?
+}
+
+# _get_required_attrs <tag_name>
+# Prints one required attribute name per line.
+_get_required_attrs() {
+	local _tag="$1"
+	local _schema_file="${SCHEMA_DIR}/${_tag}.json"
+	[[ -f "$_schema_file" ]] || return 0
+
+	# Extract attrs where "required": true using grep context lines.
+	# Pattern: capture attribute key names preceding a "required": true line.
+	# Works for the canonical schema format (one key per line, key before required).
+	python3 - "$_schema_file" <<'PYEOF'
+import json, sys
+with open(sys.argv[1]) as f:
+    schema = json.load(f)
+for attr, meta in schema.get("attributes", {}).items():
+    if meta.get("required", False):
+        print(attr)
+PYEOF
+	return 0
+}
+
+# _get_enum_values <tag_name> <attr_name>
+# Prints allowed enum values one per line, or nothing if attr has no enum.
+_get_enum_values() {
+	local _tag="$1"
+	local _attr="$2"
+	local _schema_file="${SCHEMA_DIR}/${_tag}.json"
+	[[ -f "$_schema_file" ]] || return 0
+
+	python3 - "$_schema_file" "$_attr" <<'PYEOF'
+import json, sys
+with open(sys.argv[1]) as f:
+    schema = json.load(f)
+attr_meta = schema.get("attributes", {}).get(sys.argv[2], {})
+for v in attr_meta.get("enum", []):
+    print(v)
+PYEOF
+	return 0
+}
+
+# _get_known_tags
+# Prints all known tag names (one per line) from schema file basenames.
+_get_known_tags() {
+	local _f
+	for _f in "${SCHEMA_DIR}"/*.json; do
+		[[ -f "$_f" ]] || continue
+		basename "$_f" .json
+	done
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Tag parser — extract Markdoc tags from a file with line/col info
+# ---------------------------------------------------------------------------
+
+# _parse_tags <file>
+# Prints one record per line:  <line_num> <col_num> <tag_name> <is_close> <is_self_close> <attrs_string>
+#   is_close:      1 = closing tag  {% /tag %}   0 = opening or self-closing
+#   is_self_close: 1 = self-closing {% tag /%}   0 = opening or closing
+#   attrs_string:  everything between the tag name and the closing %}
+_parse_tags() {
+	local _file="$1"
+	local _line_num=0
+	local _line
+
+	while IFS= read -r _line || [[ -n "$_line" ]]; do
+		_line_num=$(( _line_num + 1 ))
+
+		# Find all {% ... %} patterns on this line using a loop.
+		# We process the line character-by-character-ish using bash substring ops.
+		local _rest="$_line"
+		local _col=0
+
+		while [[ "$_rest" == *'{%'* ]]; do
+			# Find position of next {%
+			local _before="${_rest%%\{%*}"
+			local _start_col=$(( _col + ${#_before} + 1 ))
+			_rest="${_rest#*\{%}"
+			_col=$(( _start_col + 1 ))
+
+			# Extract content up to next %}
+			if [[ "$_rest" != *'%}'* ]]; then
+				# No closing %} on this line — multi-line tag not supported, skip
+				break
+			fi
+
+			local _inner="${_rest%%%\}*}"
+			_rest="${_rest#*\%\}}"
+			_col=$(( _col + ${#_inner} + 2 ))
+
+			# Trim leading/trailing whitespace from inner
+			_inner="${_inner#"${_inner%%[![:space:]]*}"}"
+			_inner="${_inner%"${_inner##*[![:space:]]}"}"
+
+			# Detect closing tag: starts with /
+			local _is_close=0
+			local _is_self_close=0
+
+			if [[ "$_inner" == /* ]]; then
+				_is_close=1
+				_inner="${_inner#/}"
+				_inner="${_inner#"${_inner%%[![:space:]]*}"}"
+			fi
+
+			# Detect self-closing: ends with /
+			if [[ "$_inner" == */ ]]; then
+				_is_self_close=1
+				_inner="${_inner%/}"
+				_inner="${_inner%"${_inner##*[![:space:]]}"}"
+			fi
+
+			# Extract tag name (first token)
+			local _tag_name="${_inner%% *}"
+			local _attrs=""
+			if [[ "$_inner" == *' '* ]]; then
+				_attrs="${_inner#* }"
+			fi
+
+			# Skip non-tag patterns (e.g. empty, comment-like)
+			[[ -z "$_tag_name" ]] && continue
+			# Tag names must be word chars + hyphens only
+			if [[ ! "$_tag_name" =~ ^[a-zA-Z][a-zA-Z0-9_-]*$ ]]; then
+				continue
+			fi
+
+			printf '%d\t%d\t%s\t%d\t%d\t%s\n' \
+				"$_line_num" "$_start_col" "$_tag_name" "$_is_close" "$_is_self_close" "$_attrs"
+		done
+	done <"$_file"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Attribute parser
+# ---------------------------------------------------------------------------
+
+# _parse_attr_value <attrs_string> <attr_name>
+# Prints the value of the named attribute, or exits 1 if not found.
+_parse_attr_value() {
+	local _attrs="$1"
+	local _attr="$2"
+	local _val
+
+	# Match: attr="value"  or  attr='value'  or  attr=bare_value
+	if [[ "$_attrs" =~ (^|[[:space:]])"${_attr}"=\"([^\"]*)\" ]]; then
+		_val="${BASH_REMATCH[2]}"
+	elif [[ "$_attrs" =~ (^|[[:space:]])"${_attr}"=\'([^\']*)\' ]]; then
+		_val="${BASH_REMATCH[2]}"
+	elif [[ "$_attrs" =~ (^|[[:space:]])"${_attr}"=([^[:space:]\"\']+) ]]; then
+		_val="${BASH_REMATCH[2]}"
+	else
+		return 1
+	fi
+	printf '%s\n' "$_val"
+	return 0
+}
+
+# _extract_attr_names <attrs_string>
+# Prints all attribute names present in the attrs string.
+_extract_attr_names() {
+	local _attrs="$1"
+	# Use python for reliability; fallback to grep
+	python3 - "$_attrs" <<'PYEOF' 2>/dev/null || true
+import re, sys
+attrs = sys.argv[1]
+for m in re.finditer(r'(?:^|\s)([\w-]+)\s*=', attrs):
+    print(m.group(1))
+PYEOF
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Validation logic
+# ---------------------------------------------------------------------------
+
+# _validate_tag_occurrence <file> <line> <col> <tag_name> <is_close> <is_self_close> <attrs>
+_validate_tag_occurrence() {
+	local _file="$1"
+	local _line="$2"
+	local _col="$3"
+	local _tag="$4"
+	local _is_close="$5"
+	local _is_self_close="$6"
+	local _attrs="$7"
+	local _errs=0
+
+	# Check 1: unknown tag name
+	if ! _schema_exists "$_tag"; then
+		_log_error "$_file" "$_line" "$_col" \
+			"unknown tag '${_tag}' (not in schema set at ${SCHEMA_DIR})"
+		return 1
+	fi
+
+	# Closing tags and self-closing tags don't carry attributes to validate
+	if [[ "$_is_close" -eq 1 ]]; then
+		return 0
+	fi
+
+	# Check 2: missing required attributes
+	local _req_attr
+	while IFS= read -r _req_attr; do
+		[[ -z "$_req_attr" ]] && continue
+		if ! _parse_attr_value "$_attrs" "$_req_attr" >/dev/null 2>&1; then
+			_log_error "$_file" "$_line" "$_col" \
+				"tag '${_tag}': missing required attribute '${_req_attr}'"
+			_errs=$(( _errs + 1 ))
+		fi
+	done < <(_get_required_attrs "$_tag")
+
+	# Check 3: enum constraint validation for all present attributes
+	local _present_attr
+	while IFS= read -r _present_attr; do
+		[[ -z "$_present_attr" ]] && continue
+		local _enum_vals
+		_enum_vals=$(_get_enum_values "$_tag" "$_present_attr") || continue
+		[[ -z "$_enum_vals" ]] && continue
+
+		local _actual_val
+		_actual_val=$(_parse_attr_value "$_attrs" "$_present_attr") || continue
+
+		# Check the actual value is in the enum
+		local _found=0
+		local _ev
+		while IFS= read -r _ev; do
+			[[ "$_ev" == "$_actual_val" ]] && _found=1 && break
+		done <<< "$_enum_vals"
+
+		if [[ "$_found" -eq 0 ]]; then
+			local _allowed
+			_allowed=$(printf '%s' "$_enum_vals" | tr '\n' '|' | sed 's/|$//')
+			_log_error "$_file" "$_line" "$_col" \
+				"tag '${_tag}': attribute '${_present_attr}' value '${_actual_val}' not in enum [${_allowed}]"
+			_errs=$(( _errs + 1 ))
+		fi
+	done < <(_extract_attr_names "$_attrs")
+
+	[[ "$_errs" -gt 0 ]] && return 1
+	return 0
+}
+
+# _validate_file <file>
+# Returns 0 if the file is valid, 1 if schema errors, 2 if parse errors.
+_validate_file() {
+	local _file="$1"
+	local _file_errors=0
+
+	if [[ ! -f "$_file" ]]; then
+		_die "file not found: ${_file}"
+	fi
+
+	# Stack for open block tags: entries are "line:tag_name"
+	local _open_tags=()
+	local _row
+
+	while IFS=$'\t' read -r _ln _col _tag _is_close _is_self _attrs; do
+		[[ -z "$_tag" ]] && continue
+
+		if [[ "$_is_close" -eq 1 ]]; then
+			# Verify there is a matching open tag (we track the most-recent only
+			# for simplicity — full nesting validation is Phase 3 territory)
+			local _matched=0
+			local _i
+			for (( _i = ${#_open_tags[@]} - 1; _i >= 0; _i-- )); do
+				local _entry="${_open_tags[$_i]}"
+				local _open_tag="${_entry#*:}"
+				if [[ "$_open_tag" == "$_tag" ]]; then
+					# Remove matched entry
+					unset '_open_tags[$_i]'
+					_open_tags=("${_open_tags[@]+"${_open_tags[@]}"}")
+					_matched=1
+					break
+				fi
+			done
+			if [[ "$_matched" -eq 0 ]]; then
+				# Closing tag with no open tag — still validate the tag name
+				if ! _schema_exists "$_tag"; then
+					_log_error "$_file" "$_ln" "$_col" \
+						"unknown tag '${_tag}' (not in schema set)"
+					_file_errors=$(( _file_errors + 1 ))
+				fi
+			fi
+			continue
+		fi
+
+		# Validate opening / self-closing tag
+		if ! _validate_tag_occurrence "$_file" "$_ln" "$_col" "$_tag" "$_is_close" "$_is_self" "$_attrs"; then
+			_file_errors=$(( _file_errors + 1 ))
+		fi
+
+		# Track open block tags (not self-closing, not closing)
+		if [[ "$_is_self" -eq 0 ]]; then
+			# Only track if it's a known schema tag (unknown already reported above)
+			if _schema_exists "$_tag"; then
+				_open_tags+=("${_ln}:${_tag}")
+			fi
+		fi
+
+	done < <(_parse_tags "$_file")
+
+	# Check 4: unclosed block tags
+	local _entry
+	for _entry in "${_open_tags[@]+"${_open_tags[@]}"}"; do
+		local _open_line="${_entry%%:*}"
+		local _open_tag="${_entry#*:}"
+		_log_error "$_file" "$_open_line" "1" \
+			"unclosed block tag '${_open_tag}' (no matching {% /${_open_tag} %})"
+		_file_errors=$(( _file_errors + 1 ))
+	done
+
+	[[ "$_file_errors" -gt 0 ]] && return 1
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+cmd_validate() {
+	if [[ $# -eq 0 ]]; then
+		printf '%s[%s] ERROR: validate requires at least one file argument%s\n' \
+			"$RED" "$SCRIPT_NAME" "$NC" >&2
+		exit 2
+	fi
+
+	if [[ ! -d "$SCHEMA_DIR" ]]; then
+		_die "schema directory not found: ${SCHEMA_DIR} (set MARKDOC_SCHEMA_DIR or run from repo root)"
+	fi
+
+	local _any_error=0
+	local _f
+	for _f in "$@"; do
+		if ! _validate_file "$_f"; then
+			_any_error=1
+		fi
+	done
+
+	[[ "$_any_error" -ne 0 ]] && exit 1
+	exit 0
+}
+
+cmd_validate_staged() {
+	if [[ ! -d "$SCHEMA_DIR" ]]; then
+		_die "schema directory not found: ${SCHEMA_DIR}"
+	fi
+
+	# Knowledge plane directories the hook watches
+	local _kp_dirs=(
+		"_knowledge"
+		"_cases"
+		"_projects"
+		"_performance"
+		"_feedback"
+		"_campaigns"
+		"_inbox"
+	)
+
+	local _staged_files=()
+	local _f
+	while IFS= read -r _f; do
+		[[ -z "$_f" ]] && continue
+		# Check if file is in a knowledge plane directory and is a .md file
+		local _in_kp=0
+		local _dir
+		for _dir in "${_kp_dirs[@]}"; do
+			if [[ "$_f" == "${_dir}/"* || "$_f" == *"/${_dir}/"* ]]; then
+				_in_kp=1
+				break
+			fi
+		done
+		[[ "$_in_kp" -eq 0 ]] && continue
+		[[ "$_f" != *.md ]] && continue
+		[[ -f "$_f" ]] && _staged_files+=("$_f")
+	done < <(git diff --cached --name-only --diff-filter=ACM 2>/dev/null)
+
+	if [[ ${#_staged_files[@]} -eq 0 ]]; then
+		exit 0
+	fi
+
+	printf '[%s] Validating %d staged knowledge plane file(s)...\n' \
+		"$SCRIPT_NAME" "${#_staged_files[@]}" >&2
+
+	local _any_error=0
+	for _f in "${_staged_files[@]}"; do
+		if ! _validate_file "$_f"; then
+			_any_error=1
+		fi
+	done
+
+	[[ "$_any_error" -ne 0 ]] && exit 1
+	exit 0
+}
+
+cmd_list_schemas() {
+	if [[ ! -d "$SCHEMA_DIR" ]]; then
+		_die "schema directory not found: ${SCHEMA_DIR}"
+	fi
+	printf 'Known Markdoc tags (from %s):\n' "$SCHEMA_DIR"
+	local _tag
+	while IFS= read -r _tag; do
+		printf '  %s\n' "$_tag"
+	done < <(_get_known_tags)
+	return 0
+}
+
+usage() {
+	cat <<EOF
+markdoc-validate.sh — Markdoc tag schema conformance checker (t2968)
+
+Usage:
+  $SCRIPT_NAME validate <file> [<file2> ...]   Validate one or more files
+  $SCRIPT_NAME validate-staged                  Validate staged knowledge plane *.md files
+  $SCRIPT_NAME list-schemas                     List known tag names
+  $SCRIPT_NAME help                             Show this usage
+
+Exit codes:
+  0  valid (no errors)
+  1  schema errors
+  2  parse / invocation error
+
+Output format: <file>:<line>:<col>: [error|warning] <message>
+
+Environment:
+  MARKDOC_SCHEMA_DIR   Path to schemas directory
+                       (default: <script-dir>/../tools/markdoc/schemas)
+EOF
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+main() {
+	local _cmd="${1:-}"
+	shift || true
+
+	case "$_cmd" in
+	validate)
+		cmd_validate "$@"
+		;;
+	validate-staged)
+		cmd_validate_staged
+		;;
+	list-schemas)
+		cmd_list_schemas
+		;;
+	help | -h | --help | "")
+		usage
+		exit 0
+		;;
+	*)
+		printf '%s[%s] ERROR: unknown command: %s%s\n' \
+			"$RED" "$SCRIPT_NAME" "$_cmd" "$NC" >&2
+		usage >&2
+		exit 2
+		;;
+	esac
+}
+
+main "$@"

--- a/.agents/tools/markdoc/schemas/README.md
+++ b/.agents/tools/markdoc/schemas/README.md
@@ -1,0 +1,66 @@
+# Markdoc Tag Namespace — AI DevOps Knowledge Plane
+
+This directory defines the 7 Markdoc tag schemas used by the knowledge plane
+(t2874). The validator (`markdoc-validate.sh`), extractor (Phase 3), and
+migration tooling (Phase 4) all parse against these schemas as the single source
+of truth.
+
+## Namespace Convention
+
+Tags follow the [Markdoc tag grammar](https://markdoc.dev/docs/tags):
+
+- **Block tag** (opens/closes around content):
+  ```
+  {% tag_name attr="value" %}
+  content
+  {% /tag_name %}
+  ```
+- **Self-closing tag** (no body content):
+  ```
+  {% tag_name attr="value" /%}
+  ```
+
+Attribute values: strings use `"double quotes"`, numbers are bare (`confidence=0.95`).
+Attribute names with hyphens are valid (`source-id`, `case-id`, `redacted-by`).
+
+## Tag Index
+
+| Tag | Scope | Description |
+|-----|-------|-------------|
+| `sensitivity` | file / section / inline | Data classification tier (public → redacted) |
+| `provenance` | file / section | Source document origin and extraction metadata |
+| `case-attach` | section / inline | Links content to a legal or business case record |
+| `citation` | inline | Inline source citation with optional page + confidence |
+| `redaction` | section / inline | Marks content for redaction in output renders |
+| `draft-status` | file / section | Editorial lifecycle status (draft → archived) |
+| `link` | inline | Typed link to an external or internal resource |
+
+## Schema Structure
+
+Each `.json` file contains:
+
+```jsonc
+{
+  "name": "<tag-name>",
+  "description": "...",
+  "attributes": {
+    "<attr-name>": {
+      "type": "string|number",
+      "required": true|false,
+      "enum": ["val1", "val2"],   // present when value is constrained
+      "description": "..."
+    }
+  },
+  "scope_rules": {
+    "allowed": ["file", "section", "inline"],
+    "description": "..."
+  },
+  "example": "..."
+}
+```
+
+## Scope Definitions
+
+- **file** — tag wraps the entire document (appears at the top level before any headings, or spans the full file)
+- **section** — tag wraps a heading block (between two headings, or from a heading to end of file)
+- **inline** — tag annotates a phrase or value within a paragraph

--- a/.agents/tools/markdoc/schemas/case-attach.json
+++ b/.agents/tools/markdoc/schemas/case-attach.json
@@ -1,0 +1,22 @@
+{
+  "name": "case-attach",
+  "description": "Links content to a legal or business case, establishing the relationship between the tagged content and the case record.",
+  "attributes": {
+    "case-id": {
+      "type": "string",
+      "required": true,
+      "description": "Unique case identifier (e.g. docket number, internal case reference, matter ID)."
+    },
+    "relation": {
+      "type": "string",
+      "required": false,
+      "enum": ["evidence", "timeline", "exhibit", "correspondence"],
+      "description": "Nature of the relationship. evidence = supporting fact; timeline = chronological event; exhibit = formal attachment; correspondence = communication record."
+    }
+  },
+  "scope_rules": {
+    "allowed": ["section", "inline"],
+    "description": "Section-level attaches a block of content to a case. Inline attaches a specific reference or mention."
+  },
+  "example": "{% case-attach case-id=\"CASE-2026-0042\" relation=\"exhibit\" %}\nEmail thread between parties dated 2026-01-10.\n{% /case-attach %}"
+}

--- a/.agents/tools/markdoc/schemas/citation.json
+++ b/.agents/tools/markdoc/schemas/citation.json
@@ -1,0 +1,28 @@
+{
+  "name": "citation",
+  "description": "Inline citation linking a claim or quote to its source document, with optional page reference and confidence score.",
+  "attributes": {
+    "source-id": {
+      "type": "string",
+      "required": true,
+      "description": "Identifier of the cited source (matches a provenance source-id or an external reference key)."
+    },
+    "page": {
+      "type": "string",
+      "required": false,
+      "description": "Page, section, or paragraph locator within the source (e.g. \"p.12\", \"s.3.1\", \"para.7\")."
+    },
+    "confidence": {
+      "type": "number",
+      "required": false,
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Confidence that the citation accurately represents the source (0.0 = paraphrased loosely, 1.0 = verbatim quote)."
+    }
+  },
+  "scope_rules": {
+    "allowed": ["inline"],
+    "description": "Citations are always inline — they annotate a specific claim or quote within running text."
+  },
+  "example": "The contract requires delivery by Q3 {% citation source-id=\"exhibit-A-contract.pdf\" page=\"p.4\" confidence=1.0 /%}"
+}

--- a/.agents/tools/markdoc/schemas/draft-status.json
+++ b/.agents/tools/markdoc/schemas/draft-status.json
@@ -1,0 +1,22 @@
+{
+  "name": "draft-status",
+  "description": "Tracks the editorial lifecycle status of a document or section. Used to gate publication, flag review needs, and record approval state.",
+  "attributes": {
+    "status": {
+      "type": "string",
+      "required": true,
+      "enum": ["draft", "review", "approved", "archived"],
+      "description": "Current lifecycle stage. draft = work in progress; review = awaiting sign-off; approved = cleared for use; archived = superseded or withdrawn."
+    },
+    "assignee": {
+      "type": "string",
+      "required": false,
+      "description": "Person or role responsible for the current status transition (e.g. reviewer username, approver name)."
+    }
+  },
+  "scope_rules": {
+    "allowed": ["file", "section"],
+    "description": "File-level sets the status for the entire document. Section-level allows different parts of a document to be at different lifecycle stages."
+  },
+  "example": "{% draft-status status=\"review\" assignee=\"jane.doe\" %}\nThis analysis is pending legal review before client distribution.\n{% /draft-status %}"
+}

--- a/.agents/tools/markdoc/schemas/link.json
+++ b/.agents/tools/markdoc/schemas/link.json
@@ -1,0 +1,22 @@
+{
+  "name": "link",
+  "description": "Typed link to an external or internal resource. Extends standard markdown links with a semantic kind attribute for classification and indexing.",
+  "attributes": {
+    "target": {
+      "type": "string",
+      "required": true,
+      "description": "URI, file path, or resource identifier that the link points to."
+    },
+    "kind": {
+      "type": "string",
+      "required": false,
+      "enum": ["brand-asset", "reference", "source", "exhibit"],
+      "description": "Semantic type of the linked resource. brand-asset = logo/trademark; reference = background reading; source = primary source material; exhibit = formal case exhibit."
+    }
+  },
+  "scope_rules": {
+    "allowed": ["inline"],
+    "description": "Links are always inline — they annotate a specific reference point within running text."
+  },
+  "example": "See the original filing {% link target=\"exhibits/filing-2026-001.pdf\" kind=\"exhibit\" /%} for full details."
+}

--- a/.agents/tools/markdoc/schemas/provenance.json
+++ b/.agents/tools/markdoc/schemas/provenance.json
@@ -1,0 +1,29 @@
+{
+  "name": "provenance",
+  "description": "Records the origin of extracted or ingested content — which source document it came from, when it was extracted, and the extraction confidence score.",
+  "attributes": {
+    "source-id": {
+      "type": "string",
+      "required": true,
+      "description": "Unique identifier for the source document (e.g. filename, URL, case exhibit ID)."
+    },
+    "extracted-at": {
+      "type": "string",
+      "required": true,
+      "format": "iso-date",
+      "description": "ISO 8601 date (YYYY-MM-DD or full datetime) when the content was extracted from the source."
+    },
+    "confidence": {
+      "type": "number",
+      "required": false,
+      "minimum": 0,
+      "maximum": 1,
+      "description": "Extraction confidence score (0.0 = uncertain, 1.0 = verbatim). Omit when extraction is manual/verified."
+    }
+  },
+  "scope_rules": {
+    "allowed": ["file", "section"],
+    "description": "File-level marks the entire document as originating from one source. Section-level marks a block extracted from a specific source within a multi-source document."
+  },
+  "example": "{% provenance source-id=\"exhibit-A-contract.pdf\" extracted-at=\"2026-03-15\" confidence=0.95 %}\nThe vendor agrees to deliver by Q3 2026.\n{% /provenance %}"
+}

--- a/.agents/tools/markdoc/schemas/redaction.json
+++ b/.agents/tools/markdoc/schemas/redaction.json
@@ -1,0 +1,21 @@
+{
+  "name": "redaction",
+  "description": "Marks content for redaction in output renders. The tagged content is replaced with a redaction placeholder, preserving the reason and optional redactor identity for audit trails.",
+  "attributes": {
+    "reason": {
+      "type": "string",
+      "required": true,
+      "description": "Why the content is redacted (e.g. \"PII\", \"attorney-client privilege\", \"trade secret\", \"ongoing investigation\")."
+    },
+    "redacted-by": {
+      "type": "string",
+      "required": false,
+      "description": "Identity of the person or process that applied the redaction (e.g. username, role, or automated pipeline name)."
+    }
+  },
+  "scope_rules": {
+    "allowed": ["section", "inline"],
+    "description": "Section-level redacts an entire block. Inline redacts a specific phrase or value within running text."
+  },
+  "example": "The payment was made to {% redaction reason=\"PII\" redacted-by=\"legal-review\" %}John Smith at 123 Main St{% /redaction %} on 2026-02-14."
+}

--- a/.agents/tools/markdoc/schemas/sensitivity.json
+++ b/.agents/tools/markdoc/schemas/sensitivity.json
@@ -1,0 +1,23 @@
+{
+  "name": "sensitivity",
+  "description": "Marks content with a data-sensitivity classification tier. Applied at file, section, or inline scope to control visibility, redaction policy, and access gating.",
+  "attributes": {
+    "tier": {
+      "type": "string",
+      "required": true,
+      "enum": ["public", "internal", "confidential", "privileged", "redacted"],
+      "description": "Classification level. public = unrestricted; internal = org-visible; confidential = need-to-know; privileged = legal hold; redacted = scrubbed output."
+    },
+    "scope": {
+      "type": "string",
+      "required": false,
+      "enum": ["file", "section", "inline"],
+      "description": "Granularity of the classification. Defaults to the tag's positional scope when omitted."
+    }
+  },
+  "scope_rules": {
+    "allowed": ["file", "section", "inline"],
+    "description": "File-level wraps the entire document. Section-level wraps a heading block. Inline marks a phrase or span."
+  },
+  "example": "{% sensitivity tier=\"confidential\" scope=\"section\" %}\nThis section contains client-confidential analysis.\n{% /sensitivity %}"
+}

--- a/.github/workflows/markdoc-validate.yml
+++ b/.github/workflows/markdoc-validate.yml
@@ -1,0 +1,96 @@
+name: Markdoc Schema Validation
+
+on:
+  push:
+    branches: [ main, develop ]
+    paths:
+      - '_knowledge/**/*.md'
+      - '_cases/**/*.md'
+      - '_projects/**/*.md'
+      - '_performance/**/*.md'
+      - '_feedback/**/*.md'
+      - '_campaigns/**/*.md'
+      - '_inbox/**/*.md'
+      - '.agents/tools/markdoc/schemas/**'
+      - '.agents/scripts/markdoc-validate.sh'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '_knowledge/**/*.md'
+      - '_cases/**/*.md'
+      - '_projects/**/*.md'
+      - '_performance/**/*.md'
+      - '_feedback/**/*.md'
+      - '_campaigns/**/*.md'
+      - '_inbox/**/*.md'
+      - '.agents/tools/markdoc/schemas/**'
+      - '.agents/scripts/markdoc-validate.sh'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref == 'refs/heads/main' && github.sha || github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  markdoc-validate:
+    name: Markdoc Schema Conformance
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Validate markdoc-validate.sh (ShellCheck)
+        run: |
+          shellcheck .agents/scripts/markdoc-validate.sh
+
+      - name: Validate knowledge plane *.md files
+        run: |
+          set -euo pipefail
+          VALIDATOR=".agents/scripts/markdoc-validate.sh"
+          chmod +x "$VALIDATOR"
+
+          # Knowledge plane directories
+          KP_DIRS=(
+            "_knowledge" "_cases" "_projects"
+            "_performance" "_feedback" "_campaigns" "_inbox"
+          )
+
+          # Collect all .md files in knowledge plane directories
+          TARGETS=()
+          for dir in "${KP_DIRS[@]}"; do
+            if [[ -d "$dir" ]]; then
+              while IFS= read -r f; do
+                [[ -n "$f" ]] && TARGETS+=("$f")
+              done < <(find "$dir" -name '*.md' -type f 2>/dev/null)
+            fi
+          done
+
+          if [[ ${#TARGETS[@]} -eq 0 ]]; then
+            echo "No knowledge plane Markdown files found — skipping validation."
+            exit 0
+          fi
+
+          echo "Validating ${#TARGETS[@]} knowledge plane file(s)..."
+          "$VALIDATOR" validate "${TARGETS[@]}"
+          echo "All files valid."
+
+      - name: Validate schemas lint cleanly (jq)
+        run: |
+          SCHEMA_DIR=".agents/tools/markdoc/schemas"
+          if [[ ! -d "$SCHEMA_DIR" ]]; then
+            echo "Schema directory $SCHEMA_DIR not found — skipping."
+            exit 0
+          fi
+          errors=0
+          for f in "$SCHEMA_DIR"/*.json; do
+            [[ -f "$f" ]] || continue
+            if ! jq . "$f" > /dev/null 2>&1; then
+              echo "ERROR: $f is not valid JSON"
+              errors=$((errors + 1))
+            fi
+          done
+          if [[ "$errors" -gt 0 ]]; then
+            echo "$errors schema file(s) failed JSON validation."
+            exit 1
+          fi
+          echo "All schema files are valid JSON."


### PR DESCRIPTION
## Summary

Implements t2968 — Markdoc schema conformance checker (Phase 2 of t2874 knowledge plane Markdoc tag format).

This PR also includes the 7 JSON schemas from Phase 1 (#21254, still open) since the validator depends on them. If #21254 merges first, the conflict will be trivial (identical content).

## What

- **7 JSON tag schemas** at `.agents/tools/markdoc/schemas/` — single source of truth for the Markdoc tag namespace
- **`.agents/scripts/markdoc-validate.sh`** — pure-bash tag parser + schema conformance checker (no JS runtime)
- **`install-hooks-helper.sh`** edited to add opt-in `install_markdoc_validate_hook` (auto-enables for repos with knowledge plane dirs)
- **`.github/workflows/markdoc-validate.yml`** CI gate

## How verified

```bash
shellcheck .agents/scripts/markdoc-validate.sh   # zero violations
.agents/scripts/markdoc-validate.sh validate /tmp/test-valid.md   # exit 0
.agents/scripts/markdoc-validate.sh validate /tmp/test-missing-attr.md   # exit 1, file:line:col: error: missing required attribute 'tier'
.agents/scripts/markdoc-validate.sh validate /tmp/test-unknown-tag.md    # exit 1, error: unknown tag
.agents/scripts/markdoc-validate.sh validate /tmp/test-unclosed.md       # exit 1, error: unclosed block tag
.agents/scripts/markdoc-validate.sh validate /tmp/test-bad-enum.md       # exit 1, error: value not in enum
```

All acceptance criteria from issue #21256 met.

Resolves #21256
For #20966

## MERGE_SUMMARY

**t2968: Markdoc schema conformance validator (Phase 2)**

### What was implemented

1. **7 JSON schemas** at `.agents/tools/markdoc/schemas/` — also covers Phase 1 (#21254) content
2. **`.agents/scripts/markdoc-validate.sh`** — regex-based tag parser (no JS), exit 0/1/2, grep-friendly output
3. **`install-hooks-helper.sh`** — opt-in `install_markdoc_validate_hook`, auto-enables for KP repos
4. **`.github/workflows/markdoc-validate.yml`** — CI gate on KP path changes

### Acceptance criteria verified

- Exit 0 on well-formed file ✓
- Exit 1 + `file:line:col: error:` on missing required attribute ✓
- Exit 1 on unknown tag ✓
- Exit 1 on unclosed block tag ✓
- ShellCheck zero violations ✓
- Pre-commit hook wired in `install-hooks-helper.sh` ✓
- CI workflow at `.github/workflows/markdoc-validate.yml` ✓

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.26 with claude-sonnet-4-6 spent 11m and 41,699 tokens on this as a headless worker.
