### PR TITLE
t2980: docs(t2980): map worker branch classification residual modes

### DIFF
--- a/.agents/reference/worker-branch-classification.md
+++ b/.agents/reference/worker-branch-classification.md
@@ -1,0 +1,209 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Worker Branch Classification (t2980)
+
+How the pulse decides whether a worker "produced output" — and where the
+classification can lie about which branch the worker was actually on.
+
+This document maps the full dispatch → exit chain and names three concrete
+failure modes that produce `branch=main` (or `branch=develop`)
+`worker_branch_orphan` log lines even when the worker did successful work
+on a feature branch. It is the post-mortem companion to t2899
+(`reference/worker-diagnostics.md` Phase 5) which fixed the *signal-2
+false-positive* slice; the modes below are the residual slice.
+
+## The dispatch chain
+
+The worker spawn path is a six-step chain. Each step has one job and
+exactly one input that it threads forward:
+
+1. `pulse-dispatch-worker-launch.sh::dispatch_with_dedup` — receives the
+   issue number and `repo_path` (canonical repo, always on default branch).
+2. `_dlw_precreate_worktree(issue_number, repo_path)` — tries to create
+   `feature/auto-<ts>-gh<N>` linked to `repo_path`. Sets
+   `_DLW_WORKTREE_PATH` / `_DLW_WORKTREE_BRANCH` on success. **Always
+   returns 0** (line 340) — failure is logged but not propagated.
+3. `_dlw_nohup_launch(...)` — composes the worker `env` invocation. Two
+   things to track:
+   - Sets `WORKER_WORKTREE_PATH` / `WORKER_WORKTREE_BRANCH` env vars
+     **only** when pre-creation succeeded (line 587-592).
+   - Passes `--dir "${worker_worktree_path:-$repo_path}"` to the
+     headless runtime (line 602) — **the smoking-gun fallback**. If
+     pre-creation silently failed, `--dir` resolves to `$repo_path`,
+     which is the canonical repo on the default branch.
+4. `headless-runtime-helper.sh cmd_run` → `_cmd_run_prepare` — sets
+   `_WORKER_WORKTREE_PATH=$work_dir` and stores `work_dir` in the EXIT
+   trap closure. **Crucially, this function does NOT create or check a
+   worktree**; it only records `work_dir` for later inspection. (The
+   issue body for #21273 hypothesised that `_cmd_run_prepare` creates a
+   worktree — that hypothesis is falsified.)
+5. The OpenCode/Claude session runs. The worker may move the cwd, check
+   out a different branch, create its own worktree via
+   `worktree-helper.sh add`, merge a PR, or do all four. None of this
+   updates `work_dir`.
+6. `_cmd_run_finish` (EXIT trap) → `_worker_produced_output(work_dir)`
+   reads `git rev-parse --abbrev-ref HEAD` **inside `work_dir`**, the
+   path captured at step 4. This is a one-shot snapshot, not a
+   follow-the-worker check.
+
+The classification produced in step 6 is what populates the
+`[lifecycle] worker_branch_orphan session=… branch=… work_dir=…` line at
+`headless-runtime-helper.sh:1336`.
+
+## Three failure modes
+
+### Mode A — Silent pre-creation failure → fallback to canonical repo
+
+**Symptom.** `branch=main` (or the repo's default branch) on a worker
+that produced no PR.
+
+**Cause.** `_dlw_precreate_worktree` returned 0 (the silent-fail
+contract on line 340) because `worktree-helper.sh add` produced output
+that path-regex extraction couldn't parse, OR the canonical repo was
+in a state that blocked worktree creation. The `WORKER_WORKTREE_PATH`
+env var is unset, so the worker enters the canonical repo on the
+default branch via the `${worker_worktree_path:-$repo_path}` fallback.
+
+**Evidence.** Look for the line
+`[dispatch_with_dedup] Warning: worktree pre-creation failed for #N`
+immediately preceding the dispatch in `~/.aidevops/logs/pulse.log`. If
+present, the subsequent `branch=main` classification for that issue is
+this mode.
+
+**Falsifying check.** `git -C <repo_path> worktree list | grep gh<N>`
+at the time of the failure should show **no** matching worktree.
+
+### Mode B — Worker creates its own worktree, dispatcher's snapshot stays stale
+
+**Symptom.** `branch=main`, but a feature-branch worktree for the same
+issue exists, AND a PR was successfully created.
+
+**Cause.** Pre-creation succeeded, `WORKER_WORKTREE_PATH` was set, but
+the worker (legitimately) created a different worktree — for example,
+the LLM read the contradictory clause in the V6 contract
+(`headless-runtime-lib.sh:418-460` says both "Do NOT call
+worktree-helper.sh" AND "If WORKER_WORKTREE_PATH not set, create a
+worktree via worktree-helper.sh add"). The worker `cd`s into its own
+worktree, opens a PR from the new branch, exits cleanly. `work_dir` in
+the EXIT trap closure still points at the dispatcher-allocated path,
+which may have been left on `main` (or never had a commit).
+
+**Canonical evidence.** `~/.aidevops/logs/worker-20967.log` — worker
+created `aidevops-bugfix-gh-20967-caller-permissions/` worktree
+manually, merged PR #21012 from there, exited successfully. The
+`worker_branch_orphan` line classified `branch=main` because the
+dispatcher's `work_dir` snapshot was the wrong worktree.
+
+**Falsifying check.** `git worktree list --porcelain` shows two
+worktrees with `gh-?20967` in the branch name; PR for that issue is
+merged. The "orphan" claim is false.
+
+### Mode C — Snapshot is wrong by design after worker moves
+
+**Symptom.** `branch=main` or `branch=<default>` on a worker that did
+real work, with no second worktree.
+
+**Cause.** The worker started in the pre-created worktree, did its
+work, ran `full-loop-helper.sh merge` on its PR — which checks out the
+default branch back in the same worktree to verify the merge — and
+exited. `_worker_produced_output` then sees the post-merge state:
+HEAD on default branch, working tree clean. It cannot distinguish
+"worker did everything right and just merged" from "worker never left
+main".
+
+**Why this is a design issue, not a fix-able bug.** The function
+inspects state at the wrong time. By the time the EXIT trap fires, the
+branch the worker did work on may have been deleted by the merge step.
+A point-in-time snapshot of HEAD will lie unless we also check
+`git reflog` or PR state.
+
+**Differentiator vs Mode A.** A Mode-C orphan has a corresponding
+merged PR within the worker's session window. A Mode-A orphan has
+nothing.
+
+## What's already mitigated
+
+t2899 (PR #21045) added two guards in `_worker_produced_output`:
+
+- Default-branch + zero-ahead state returns `noop` instead of `pr_exists`.
+- Diagnostic line `[lifecycle] worker_branch_orphan session=… branch=…
+  target_branch=… final_head=… ahead_count=… work_dir=…` is logged
+  every time signal-2 (`pr_exists` from the branch reading) would have
+  fired.
+
+These caught the worst case (false `pr_exists` claims). They do not
+fix the three modes above — those still log the wrong `branch=` value.
+
+## Recommended fixes (filed separately)
+
+### Fix A — Make `_dlw_precreate_worktree` failure visible
+
+Drop the unconditional `return 0` at line 340. Have the function
+return non-zero on path-extraction failure, and have `_dlw_nohup_launch`
+either:
+
+1. Skip the worker entirely (preferred — fail fast, observable in
+   `pulse-stats.json` as a new `worktree_precreation_failed_count`
+   counter), OR
+2. Treat the canonical repo as a hard error in the `--dir` argument:
+   drop the `:-$repo_path` fallback. Workers should never be dispatched
+   into the canonical repo on default.
+
+Plus an observability increment so we can see how often this happens
+in production.
+
+### Fix B — `_worker_produced_output` should follow the worker, not trust `work_dir`
+
+Replace the dispatch-time `work_dir` snapshot with a discovery step at
+classification time:
+
+```sh
+# Pseudocode
+candidate=$(git -C "$repo_path" worktree list --porcelain \
+  | awk -v n="$WORKER_ISSUE_NUMBER" '
+    /^worktree / { p=$2 }
+    /^branch / && $2 ~ "gh-?" n { print p; exit }')
+[[ -z "$candidate" ]] && candidate="$work_dir"
+branch=$(git -C "$candidate" rev-parse --abbrev-ref HEAD 2>/dev/null)
+```
+
+This handles Modes B and C: any worktree the worker created (or moved
+into) with the issue number in its branch name will be discovered. The
+`work_dir` fallback preserves current behaviour when no
+issue-numbered worktree exists.
+
+### Fix C — Resolve the V6 contract contradiction
+
+`headless-runtime-lib.sh:418-460` tells the worker both not to use
+`worktree-helper.sh` and to use it as a fallback. Pick one:
+
+- If pre-creation must always succeed (recommended), forbid worker
+  worktree creation absolutely and have headless-runtime exit with a
+  clear error if `WORKER_WORKTREE_PATH` is unset.
+- If pre-creation can fail, document the worker-creates-own-worktree
+  path explicitly, *and* have the worker echo the new path into a
+  well-known file that `_worker_produced_output` reads.
+
+The current contract makes Mode B nearly inevitable on any
+pre-creation hiccup.
+
+## Diagnosing in production
+
+| Log line | Likely mode | Next check |
+|----------|-------------|-----------|
+| `Warning: worktree pre-creation failed for #N` ahead of dispatch | A | No worktree exists for `#N` |
+| `branch=main`, no PR created, no warning | A or pulse anomaly | `git worktree list \| grep gh<N>` |
+| `branch=main`, PR exists and merged from `gh-?N` branch | B or C | Compare PR head ref to `work_dir` |
+| `branch=main`, PR exists from feature branch but worktree is gone | C | `git reflog` in `work_dir` |
+| `branch=develop` or other non-default branch unrelated to `<N>` | Pre-created worktree drift | Check repo's default-branch config |
+
+## Cross-references
+
+- Phase 5 / t2820 — log-tail-based reclassification of `worker_failed`:
+  `reference/worker-diagnostics.md:375`
+- t2899 — default-branch guard on signal 2: PR #21045
+- Headless contract: `headless-runtime-lib.sh::append_worker_headless_contract`
+- Pre-creation: `pulse-dispatch-worker-launch.sh::_dlw_precreate_worktree`
+- Classification: `headless-runtime-helper.sh::_worker_produced_output`
+- Orphan log emitter: `headless-runtime-helper.sh::_handle_worker_branch_orphan`

--- a/.agents/reference/worker-diagnostics.md
+++ b/.agents/reference/worker-diagnostics.md
@@ -454,6 +454,22 @@ The self-hosting detector in `pre-dispatch-validator-helper.sh` runs BEFORE gene
 
 Observed on GH#20765 (t2814): 2 opus-4-6 attempts (~40K wasted tokens) before cascade reached opus-4-7. This short-circuit eliminates that waste for the self-hosting task class.
 
+#### Phase 6 — Worker branch classification residual modes (t2980)
+
+**Problem.** Phase 5 (t2820) reclassified `worker_failed`, and t2899 closed the signal-2 false-positive on default-branch + zero-ahead state. The remaining `worker_branch_orphan branch=main` log lines fall into three modes that can't be fixed by tightening `_worker_produced_output`'s point-in-time check alone — the chain itself loses information between dispatch and exit.
+
+**Three residual modes** (full investigation: `reference/worker-branch-classification.md`):
+
+- **Mode A — Silent pre-creation failure.** `_dlw_precreate_worktree` returns 0 even on path-extraction failure (`pulse-dispatch-worker-launch.sh:340`); the worker falls back to `--dir "$repo_path"` (`pulse-dispatch-worker-launch.sh:602`) and runs in the canonical repo on the default branch.
+- **Mode B — Worker creates its own worktree.** Pre-creation succeeded but the V6 contract contradiction (`headless-runtime-lib.sh:418-460`) sends the worker into a different worktree it created itself; the dispatcher's `work_dir` snapshot stays stale.
+- **Mode C — Snapshot wrong by design.** Worker did real work, merged its PR, exited cleanly; the post-merge HEAD-on-default state at EXIT-trap time looks identical to "worker never left main".
+
+**Recommended fixes** (filed as separate follow-up issues):
+
+- Drop the silent-fail contract in `_dlw_precreate_worktree`; emit a `worktree_precreation_failed_count` counter; remove the `:-$repo_path` fallback in `_dlw_nohup_launch`.
+- Replace the `work_dir` snapshot in `_worker_produced_output` with a `git worktree list --porcelain` scan keyed off `WORKER_ISSUE_NUMBER`.
+- Resolve the V6 contract contradiction — pick "pre-creation always succeeds" or "worker creates own + writes path back to a known file", not both.
+
 ## Diagnostic Quick Reference
 
 | Symptom | Check | Likely cause |


### PR DESCRIPTION
## Summary

Investigation deliverable for #21273. Maps the dispatch chain (pulse-dispatch-worker-launch.sh:267-340 -> :602 -> headless-runtime-helper.sh _cmd_run_prepare -> _worker_produced_output) and identifies three residual failure modes that produce 'branch=main' classifications even when workers do real work: silent pre-creation failure (line 340 always returns 0), worker creates own worktree (V6 contract contradiction in headless-runtime-lib.sh:418-460), and EXIT-trap snapshot taken after merge looks identical to never-left-main. Falsifies the issue's hypothesis that _cmd_run_prepare creates worktrees. Recommends three follow-up fixes to be filed as separate issues.

## Files Changed

.agents/reference/worker-branch-classification.md,.agents/reference/worker-diagnostics.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** markdownlint-cli2 .agents/reference/worker-branch-classification.md (clean). Pre-existing MD031/MD040 violations at worker-diagnostics.md:95-100 are unchanged - not in modified region.

Resolves #21273


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.27 with claude-opus-4-7 spent 11m and 36,485 tokens on this with the user in an interactive session.