### PR TITLE
t2972: t2874 Phase 5: PageIndex consumer — lift Markdoc tag attributes into tree node metadata

### DIFF
--- a/.agents/scripts/markdoc-extract.sh
+++ b/.agents/scripts/markdoc-extract.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# markdoc-extract.sh — Extract Markdoc tags from source.md to a -tags.json sidecar (t2972)
+#
+# Reads a Markdoc-tagged source file, extracts all tag occurrences with their
+# attributes, and writes a JSON sidecar consumed by pageindex-generator.py for
+# Phase-5 metadata lifting.
+#
+# Usage:
+#   markdoc-extract.sh extract <source.md>
+#       Writes <basename>-tags.json next to the input file.
+#       Exits 0 on success, 1 on error.
+#
+#   markdoc-extract.sh extract <source.md> --stdout
+#       Writes JSON to stdout instead of a sidecar file.
+#
+#   markdoc-extract.sh help
+#       Show this help.
+#
+# Output format  (<basename>-tags.json):
+#   JSON array of objects, one per tag occurrence:
+#   [
+#     {
+#       "tag":          "sensitivity",
+#       "attrs":        {"tier": "privileged", "scope": "file"},
+#       "line":         3,
+#       "is_close":     false,
+#       "is_self_close":true
+#     },
+#     ...
+#   ]
+#
+# Dependencies: python3, markdoc_tag_extractor.py (same directory as this script)
+#
+# ShellCheck: SC2034 suppressed — colour vars may be indirect-used only.
+# shellcheck disable=SC2034
+
+set -uo pipefail
+
+SCRIPT_NAME=$(basename "$0")
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+# --- colour constants (guarded) ---
+[[ -z "${RED+x}" ]]    && RED='\033[0;31m'
+[[ -z "${GREEN+x}" ]]  && GREEN='\033[0;32m'
+[[ -z "${YELLOW+x}" ]] && YELLOW='\033[1;33m'
+[[ -z "${NC+x}" ]]     && NC='\033[0m'
+
+_die() {
+	local _msg="$1"
+	printf '%b[%s] ERROR: %s%b\n' "$RED" "$SCRIPT_NAME" "$_msg" "$NC" >&2
+	exit 1
+	return 1
+}
+
+_info() {
+	local _msg="$1"
+	printf '%b[%s] %s%b\n' "$GREEN" "$SCRIPT_NAME" "$_msg" "$NC" >&2
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# _require_python3
+# ---------------------------------------------------------------------------
+_require_python3() {
+	if ! command -v python3 >/dev/null 2>&1; then
+		_die "python3 is required but not found in PATH"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# _require_extractor_module
+# ---------------------------------------------------------------------------
+_require_extractor_module() {
+	local _module="${SCRIPT_DIR}/markdoc_tag_extractor.py"
+	if [[ ! -f "$_module" ]]; then
+		_die "markdoc_tag_extractor.py not found at: $_module"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# _extract_tags  <source_file> <output_path|-|--stdout>
+# ---------------------------------------------------------------------------
+_extract_tags() {
+	local _source="$1"
+	local _output="$2"
+
+	if [[ ! -f "$_source" ]]; then
+		_die "file not found: $_source"
+	fi
+
+	# Run the Python extractor inline via sys.path injection
+	local _py_exit
+	python3 - "$_source" "$_output" "$SCRIPT_DIR" <<'PYEOF'
+import sys
+import json
+
+sys.path.insert(0, sys.argv[3])  # add script dir so markdoc_tag_extractor is importable
+from markdoc_tag_extractor import extract_tags_from_lines
+
+source_file = sys.argv[1]
+output_dest = sys.argv[2]  # file path or "-" for stdout
+
+with open(source_file, 'r', encoding='utf-8') as fh:
+    lines = fh.read().splitlines()
+
+tags = extract_tags_from_lines(lines)
+
+output = json.dumps(tags, indent=2, ensure_ascii=False) + '\n'
+
+if output_dest == '-':
+    sys.stdout.write(output)
+else:
+    with open(output_dest, 'w', encoding='utf-8') as fh:
+        fh.write(output)
+PYEOF
+	_py_exit=$?
+	if [[ "$_py_exit" -eq 0 ]]; then
+		return 0
+	fi
+	return 1
+}
+
+# ---------------------------------------------------------------------------
+# cmd_extract
+# ---------------------------------------------------------------------------
+cmd_extract() {
+	local _source=""
+	local _stdout=0
+
+	while [[ $# -gt 0 ]]; do
+		local _key="$1"
+		shift
+		case "$_key" in
+		--stdout)
+			_stdout=1
+			;;
+		-*)
+			_die "Unknown option: $_key"
+			;;
+		*)
+			if [[ -z "$_source" ]]; then
+				_source="$_key"
+			fi
+			;;
+		esac
+	done
+
+	if [[ -z "$_source" ]]; then
+		_die "extract requires <source.md>"
+	fi
+
+	_require_python3
+	_require_extractor_module
+
+	local _output_path
+	if [[ "$_stdout" -eq 1 ]]; then
+		_output_path="-"
+	else
+		# Write sidecar next to source: <basename>-tags.json
+		local _dir
+		_dir="$(dirname "$_source")"
+		local _base
+		_base="$(basename "$_source" .md)"
+		_output_path="${_dir}/${_base}-tags.json"
+	fi
+
+	_extract_tags "$_source" "$_output_path"
+
+	if [[ "$_stdout" -eq 0 ]]; then
+		_info "Extracted tags to: $_output_path"
+	fi
+
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# cmd_help
+# ---------------------------------------------------------------------------
+cmd_help() {
+	sed -n '4,40p' "$0" | sed 's/^# \{0,1\}//'
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+main() {
+	local _subcommand="${1:-help}"
+	shift || true
+	case "$_subcommand" in
+	extract)
+		cmd_extract "$@"
+		;;
+	help | -h | --help)
+		cmd_help
+		;;
+	*)
+		printf '%b[%s] ERROR: unknown subcommand: %s%b\n' \
+			"$RED" "$SCRIPT_NAME" "$_subcommand" "$NC" >&2
+		cmd_help >&2
+		exit 1
+		;;
+	esac
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/markdoc_tag_extractor.py
+++ b/.agents/scripts/markdoc_tag_extractor.py
@@ -20,7 +20,7 @@ Tag output shape (per entry):
 """
 
 import re
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 
 def parse_markdoc_attrs(attrs_str: str) -> Dict[str, Any]:
@@ -147,3 +147,115 @@ def classify_tag_scope(
         return 'file'
 
     return 'section'
+
+
+# ---------------------------------------------------------------------------
+# Higher-level helpers — PageIndex metadata lifting (used by pageindex-generator.py)
+# ---------------------------------------------------------------------------
+
+def first_heading_line(content_lines: List[str]) -> Optional[int]:
+    """Return the 0-indexed line of the first heading in content, or None."""
+    for i, line in enumerate(content_lines):
+        if re.match(r'^#{1,6}\s', line.strip()):
+            return i
+    return None
+
+
+def build_file_metadata(file_tags: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Return metadata dict keyed by tag name from file-scope tag entries.
+
+    Only non-closing tags with at least one attribute are included.
+    If the same tag name appears more than once, the last occurrence wins.
+    """
+    metadata: Dict[str, Any] = {}
+    for entry in file_tags:
+        attrs = entry.get('attrs', {})
+        if not attrs:
+            continue
+        metadata[entry['tag']] = dict(attrs)
+    return metadata
+
+
+def build_cross_references(
+    citation_tags: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Return a cross_references list from non-closing citation tag entries."""
+    return [dict(e['attrs']) for e in citation_tags if e.get('attrs')]
+
+
+def assign_tags_to_sections(
+    section_tags: List[Dict[str, Any]],
+    sections: List[Dict[str, Any]],
+) -> Dict[int, Dict[str, Any]]:
+    """Map section-scope tags to the flat section index they belong to.
+
+    A tag at content line *L* belongs to section *I* when:
+    ``sections[I].line_idx <= L < sections[I+1].line_idx``
+    (for the last section the upper bound is infinity).
+
+    Returns ``{section_idx: {tag_name: attrs}}``.
+    Same-tag-name last-wins within each section.
+    """
+    section_metadata: Dict[int, Dict[str, Any]] = {}
+    if not sections or not section_tags:
+        return section_metadata
+
+    for entry in section_tags:
+        tag_line = entry['line']
+        attrs = entry.get('attrs', {})
+        if not attrs:
+            continue
+
+        owning_idx: Optional[int] = None
+        for i, sec in enumerate(sections):
+            next_start: Any = (
+                sections[i + 1]['line_idx'] if i + 1 < len(sections) else float('inf')
+            )
+            if sec['line_idx'] <= tag_line < next_start:
+                owning_idx = i
+                break
+
+        if owning_idx is not None:
+            if owning_idx not in section_metadata:
+                section_metadata[owning_idx] = {}
+            section_metadata[owning_idx][entry['tag']] = dict(attrs)
+
+    return section_metadata
+
+
+def extract_and_classify_tags(
+    content_lines: List[str],
+    sections: List[Dict[str, Any]],
+) -> Tuple[Dict[str, Any], Dict[int, Dict[str, Any]], List[Dict[str, Any]]]:
+    """Extract Markdoc tags and classify them for PageIndex metadata injection.
+
+    Returns a 3-tuple:
+      file_metadata     — dict to inject into the root tree node ``metadata``
+      section_metadata  — {section_idx: {tag_name: attrs}} for subtree nodes
+      cross_references  — list of citation attrs for the root ``cross_references``
+    """
+    all_tags = extract_tags_from_lines(content_lines)
+    first_hdg = first_heading_line(content_lines)
+
+    file_tags: List[Dict[str, Any]] = []
+    section_tags_raw: List[Dict[str, Any]] = []
+    citation_tags: List[Dict[str, Any]] = []
+
+    for tag in all_tags:
+        # Skip closing tags — structural, not metadata carriers
+        if tag.get('is_close'):
+            continue
+        if tag['tag'] == 'citation':
+            citation_tags.append(tag)
+            continue  # citations are always inline; skip file/section buckets
+        scope = classify_tag_scope(tag, first_hdg)
+        if scope == 'file':
+            file_tags.append(tag)
+        elif scope == 'section':
+            section_tags_raw.append(tag)
+
+    return (
+        build_file_metadata(file_tags),
+        assign_tags_to_sections(section_tags_raw, sections),
+        build_cross_references(citation_tags),
+    )

--- a/.agents/scripts/markdoc_tag_extractor.py
+++ b/.agents/scripts/markdoc_tag_extractor.py
@@ -22,6 +22,14 @@ Tag output shape (per entry):
 import re
 from typing import Any, Dict, List, Optional, Tuple
 
+# Compiled once at module load — tag names: letter followed by word chars + hyphens
+_TAG_NAME_RE = re.compile(r'^[a-zA-Z][a-zA-Z0-9_-]*$')
+
+# Compiled attribute-parser pattern — reused across all calls
+_ATTR_PATTERN = re.compile(
+    r'([\w-]+)\s*=\s*(?:"([^"]*)"|\'([^\']*)\'|([^\s\'"}{%]+))'
+)
+
 
 def parse_markdoc_attrs(attrs_str: str) -> Dict[str, Any]:
     """Parse a Markdoc attribute string into a dict.
@@ -37,11 +45,7 @@ def parse_markdoc_attrs(attrs_str: str) -> Dict[str, Any]:
         {'source-id': 'doc.pdf', 'confidence': 0.95}
     """
     attrs: Dict[str, Any] = {}
-    # Match: name="value" | name='value' | name=bare_value
-    pattern = re.compile(
-        r'([\w-]+)\s*=\s*(?:"([^"]*)"|\'([^\']*)\'|([^\s\'"}{%]+))'
-    )
-    for m in pattern.finditer(attrs_str):
+    for m in _ATTR_PATTERN.finditer(attrs_str):
         key = m.group(1)
         # Prefer group 2 (double-quoted), then 3 (single-quoted), then 4 (unquoted)
         raw: str = (
@@ -49,7 +53,7 @@ def parse_markdoc_attrs(attrs_str: str) -> Dict[str, Any]:
             if m.group(2) is not None
             else (m.group(3) if m.group(3) is not None else (m.group(4) or ''))
         )
-        # Numeric coercion — only for unquoted values (groups 4)
+        # Numeric coercion — only for unquoted values (group 4)
         if m.group(4) is not None:
             try:
                 fval = float(raw)
@@ -59,6 +63,44 @@ def parse_markdoc_attrs(attrs_str: str) -> Dict[str, Any]:
         else:
             attrs[key] = raw
     return attrs
+
+
+def _parse_tag_entry(
+    inner: str, line_idx: int
+) -> Optional[Dict[str, Any]]:
+    """Parse a single tag from the raw content between {% and %}.
+
+    Returns a tag dict or None if the content is not a valid Markdoc tag.
+    """
+    inner = inner.strip()
+
+    is_close = inner.startswith('/')
+    if is_close:
+        inner = inner[1:].strip()
+
+    is_self_close = inner.endswith('/')
+    if is_self_close:
+        inner = inner[:-1].strip()
+
+    name_and_attrs = inner.split(None, 1)
+    if not name_and_attrs:
+        return None
+
+    tag_name = name_and_attrs[0]
+    if not _TAG_NAME_RE.match(tag_name):
+        return None
+
+    attrs_str = name_and_attrs[1] if len(name_and_attrs) > 1 else ''
+    # Closing tags never carry meaningful attrs
+    attrs = parse_markdoc_attrs(attrs_str) if attrs_str and not is_close else {}
+
+    return {
+        'tag': tag_name,
+        'attrs': attrs,
+        'line': line_idx,
+        'is_close': is_close,
+        'is_self_close': is_self_close,
+    }
 
 
 def extract_tags_from_lines(lines: List[str]) -> List[Dict[str, Any]]:
@@ -72,7 +114,6 @@ def extract_tags_from_lines(lines: List[str]) -> List[Dict[str, Any]]:
     silently skipped.
     """
     tags: List[Dict[str, Any]] = []
-    tag_name_re = re.compile(r'^[a-zA-Z][a-zA-Z0-9_-]*$')
 
     for line_idx, raw_line in enumerate(lines):
         rest = raw_line
@@ -80,37 +121,10 @@ def extract_tags_from_lines(lines: List[str]) -> List[Dict[str, Any]]:
             _, _, rest = rest.partition('{%')
             if '%}' not in rest:
                 break  # no closing %} on this line — multi-line tag, skip
-
             inner, _, rest = rest.partition('%}')
-            inner = inner.strip()
-
-            is_close = inner.startswith('/')
-            if is_close:
-                inner = inner[1:].strip()
-
-            is_self_close = inner.endswith('/')
-            if is_self_close:
-                inner = inner[:-1].strip()
-
-            # Extract tag name (first whitespace-delimited token)
-            name_and_attrs = inner.split(None, 1)
-            if not name_and_attrs:
-                continue
-            tag_name = name_and_attrs[0]
-            if not tag_name_re.match(tag_name):
-                continue
-
-            attrs_str = name_and_attrs[1] if len(name_and_attrs) > 1 else ''
-            # Closing tags never carry meaningful attrs
-            attrs = parse_markdoc_attrs(attrs_str) if attrs_str and not is_close else {}
-
-            tags.append({
-                'tag': tag_name,
-                'attrs': attrs,
-                'line': line_idx,
-                'is_close': is_close,
-                'is_self_close': is_self_close,
-            })
+            entry = _parse_tag_entry(inner, line_idx)
+            if entry is not None:
+                tags.append(entry)
 
     return tags
 
@@ -170,9 +184,8 @@ def build_file_metadata(file_tags: List[Dict[str, Any]]) -> Dict[str, Any]:
     metadata: Dict[str, Any] = {}
     for entry in file_tags:
         attrs = entry.get('attrs', {})
-        if not attrs:
-            continue
-        metadata[entry['tag']] = dict(attrs)
+        if attrs:
+            metadata[entry['tag']] = dict(attrs)
     return metadata
 
 
@@ -181,6 +194,19 @@ def build_cross_references(
 ) -> List[Dict[str, Any]]:
     """Return a cross_references list from non-closing citation tag entries."""
     return [dict(e['attrs']) for e in citation_tags if e.get('attrs')]
+
+
+def _find_owning_section(
+    tag_line: int, sections: List[Dict[str, Any]]
+) -> Optional[int]:
+    """Return the index of the section that contains tag_line, or None."""
+    for i, sec in enumerate(sections):
+        next_start: Any = (
+            sections[i + 1]['line_idx'] if i + 1 < len(sections) else float('inf')
+        )
+        if sec['line_idx'] <= tag_line < next_start:
+            return i
+    return None
 
 
 def assign_tags_to_sections(
@@ -201,20 +227,10 @@ def assign_tags_to_sections(
         return section_metadata
 
     for entry in section_tags:
-        tag_line = entry['line']
         attrs = entry.get('attrs', {})
         if not attrs:
             continue
-
-        owning_idx: Optional[int] = None
-        for i, sec in enumerate(sections):
-            next_start: Any = (
-                sections[i + 1]['line_idx'] if i + 1 < len(sections) else float('inf')
-            )
-            if sec['line_idx'] <= tag_line < next_start:
-                owning_idx = i
-                break
-
+        owning_idx = _find_owning_section(entry['line'], sections)
         if owning_idx is not None:
             if owning_idx not in section_metadata:
                 section_metadata[owning_idx] = {}
@@ -242,9 +258,8 @@ def extract_and_classify_tags(
     citation_tags: List[Dict[str, Any]] = []
 
     for tag in all_tags:
-        # Skip closing tags — structural, not metadata carriers
         if tag.get('is_close'):
-            continue
+            continue  # closing tags are structural, not metadata carriers
         if tag['tag'] == 'citation':
             citation_tags.append(tag)
             continue  # citations are always inline; skip file/section buckets

--- a/.agents/scripts/markdoc_tag_extractor.py
+++ b/.agents/scripts/markdoc_tag_extractor.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""markdoc_tag_extractor.py - Extract Markdoc tags from knowledge source files.
+
+Used by pageindex-generator.py to lift tag attributes into PageIndex tree node
+metadata, enabling tag-filtered retrieval without re-reading document bodies.
+
+Part of the t2874 knowledge plane Markdoc pipeline — Phase 5 (t2972).
+
+Tag output shape (per entry):
+
+  {
+    "tag": str,            # tag name, e.g. "sensitivity"
+    "attrs": dict,         # parsed attribute key-value pairs
+    "line": int,           # 0-indexed line number within the lines list provided
+    "is_close": bool,      # True if this is a closing tag {% /tag %}
+    "is_self_close": bool  # True if this is a self-closing tag {% tag /%}
+  }
+"""
+
+import re
+from typing import Any, Dict, List, Optional
+
+
+def parse_markdoc_attrs(attrs_str: str) -> Dict[str, Any]:
+    """Parse a Markdoc attribute string into a dict.
+
+    Handles double-quoted, single-quoted, and unquoted values.
+    Numeric values are coerced to int or float where unambiguous.
+
+    Examples::
+
+        >>> parse_markdoc_attrs('tier="privileged" scope="file"')
+        {'tier': 'privileged', 'scope': 'file'}
+        >>> parse_markdoc_attrs('source-id="doc.pdf" confidence=0.95')
+        {'source-id': 'doc.pdf', 'confidence': 0.95}
+    """
+    attrs: Dict[str, Any] = {}
+    # Match: name="value" | name='value' | name=bare_value
+    pattern = re.compile(
+        r'([\w-]+)\s*=\s*(?:"([^"]*)"|\'([^\']*)\'|([^\s\'"}{%]+))'
+    )
+    for m in pattern.finditer(attrs_str):
+        key = m.group(1)
+        # Prefer group 2 (double-quoted), then 3 (single-quoted), then 4 (unquoted)
+        raw: str = (
+            m.group(2)
+            if m.group(2) is not None
+            else (m.group(3) if m.group(3) is not None else (m.group(4) or ''))
+        )
+        # Numeric coercion — only for unquoted values (groups 4)
+        if m.group(4) is not None:
+            try:
+                fval = float(raw)
+                attrs[key] = int(fval) if fval == int(fval) else fval
+            except (ValueError, TypeError):
+                attrs[key] = raw
+        else:
+            attrs[key] = raw
+    return attrs
+
+
+def extract_tags_from_lines(lines: List[str]) -> List[Dict[str, Any]]:
+    """Extract all Markdoc tag occurrences from a list of lines.
+
+    Returns a list of tag dicts with keys: tag, attrs, line, is_close,
+    is_self_close.  Ordering is document order (line ascending, then
+    left-to-right within each line).
+
+    Multi-line tags ({% ... spanning lines ... %}) are not supported and are
+    silently skipped.
+    """
+    tags: List[Dict[str, Any]] = []
+    tag_name_re = re.compile(r'^[a-zA-Z][a-zA-Z0-9_-]*$')
+
+    for line_idx, raw_line in enumerate(lines):
+        rest = raw_line
+        while '{%' in rest:
+            _, _, rest = rest.partition('{%')
+            if '%}' not in rest:
+                break  # no closing %} on this line — multi-line tag, skip
+
+            inner, _, rest = rest.partition('%}')
+            inner = inner.strip()
+
+            is_close = inner.startswith('/')
+            if is_close:
+                inner = inner[1:].strip()
+
+            is_self_close = inner.endswith('/')
+            if is_self_close:
+                inner = inner[:-1].strip()
+
+            # Extract tag name (first whitespace-delimited token)
+            name_and_attrs = inner.split(None, 1)
+            if not name_and_attrs:
+                continue
+            tag_name = name_and_attrs[0]
+            if not tag_name_re.match(tag_name):
+                continue
+
+            attrs_str = name_and_attrs[1] if len(name_and_attrs) > 1 else ''
+            # Closing tags never carry meaningful attrs
+            attrs = parse_markdoc_attrs(attrs_str) if attrs_str and not is_close else {}
+
+            tags.append({
+                'tag': tag_name,
+                'attrs': attrs,
+                'line': line_idx,
+                'is_close': is_close,
+                'is_self_close': is_self_close,
+            })
+
+    return tags
+
+
+# Tag names that are always inline (per Markdoc schema scope_rules)
+_INLINE_ONLY_TAGS = frozenset({'citation', 'link'})
+
+
+def classify_tag_scope(
+    tag_entry: Dict[str, Any],
+    first_heading_line: Optional[int],
+) -> str:
+    """Return 'file', 'section', or 'inline' for a non-closing tag entry.
+
+    Priority order:
+    1. Citation / link tags → always 'inline'.
+    2. Tags with an explicit ``scope`` attribute → honour it.
+    3. Tags appearing before the first heading in content → 'file'.
+    4. All others → 'section'.
+    """
+    tag = tag_entry['tag']
+    attrs = tag_entry.get('attrs', {})
+    line = tag_entry['line']
+
+    if tag in _INLINE_ONLY_TAGS:
+        return 'inline'
+
+    explicit_scope = attrs.get('scope')
+    if explicit_scope in ('file', 'section', 'inline'):
+        return str(explicit_scope)
+
+    # Positional heuristic: before the first heading → file-scope
+    if first_heading_line is None or line < first_heading_line:
+        return 'file'
+
+    return 'section'

--- a/.agents/scripts/pageindex-generator.py
+++ b/.agents/scripts/pageindex-generator.py
@@ -6,6 +6,11 @@ pageindex-generator.py - Generate .pageindex.json from markdown heading hierarch
 
 Part of aidevops document-creation-helper.sh (extracted for complexity reduction).
 
+Phase 5 (t2972): lifts Markdoc tag attributes from source.md into per-node
+``metadata`` so retrieval can filter and rank by tag attributes without
+re-reading file bodies.  Citation tags produce a ``cross_references`` array
+at the document root.
+
 Usage: pageindex-generator.py <input_file> <output_file> [use_ollama] [ollama_model]
                                [source_pdf] [page_count]
   use_ollama:   'true' or 'false' (default: false)
@@ -21,6 +26,10 @@ import hashlib
 from typing import Any, Dict, List, Optional
 
 from pageindex_helpers import extract_first_sentence, get_ollama_summary
+from markdoc_tag_extractor import (
+    extract_tags_from_lines,
+    classify_tag_scope,
+)
 
 
 def extract_frontmatter(lines: List[str]) -> Dict[str, str]:
@@ -100,10 +109,17 @@ def build_tree_recursive(
     start_idx: int,
     parent_level: int,
     ctx: TreeContext,
+    section_metadata: Optional[Dict[int, Dict[str, Any]]] = None,
 ) -> tuple:
-    """Recursively build tree from sections starting at start_idx."""
+    """Recursively build tree from sections starting at start_idx.
+
+    ``section_metadata`` maps flat section index → metadata dict (tag_name →
+    attrs) to inject into that node.  Passed through unchanged to all
+    recursive calls so every level can look up its own index.
+    """
     children = []
     i = start_idx
+    sm = section_metadata or {}
 
     while i < len(sections_list):
         section = sections_list[i]
@@ -119,8 +135,12 @@ def build_tree_recursive(
             "children": [],
         }
 
+        # Inject section-scope tag metadata when present for this section index
+        if i in sm and sm[i]:
+            node["metadata"] = sm[i]
+
         child_children, next_i = build_tree_recursive(
-            sections_list, i + 1, section['level'], ctx
+            sections_list, i + 1, section['level'], ctx, sm
         )
         node['children'] = child_children
 
@@ -166,6 +186,131 @@ def parse_sections(content_lines: List[str]) -> List[Dict[str, Any]]:
     return sections
 
 
+# ---------------------------------------------------------------------------
+# Tag metadata helpers (Phase 5 — t2972)
+# ---------------------------------------------------------------------------
+
+def _first_heading_line(content_lines: List[str]) -> Optional[int]:
+    """Return the 0-indexed line of the first heading in content, or None."""
+    for i, line in enumerate(content_lines):
+        if re.match(r'^#{1,6}\s', line.strip()):
+            return i
+    return None
+
+
+def _build_file_metadata(file_tags: List[Dict[str, Any]]) -> Dict[str, Any]:
+    """Return metadata dict keyed by tag name from file-scope tag entries.
+
+    Only non-closing tags with at least one attribute are included.
+    If the same tag name appears more than once, the last occurrence wins.
+    """
+    metadata: Dict[str, Any] = {}
+    for entry in file_tags:
+        attrs = entry.get('attrs', {})
+        if not attrs:
+            continue
+        metadata[entry['tag']] = dict(attrs)
+    return metadata
+
+
+def _build_cross_references(
+    all_citation_tags: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Return a cross_references list from non-closing citation tag entries."""
+    refs = []
+    for entry in all_citation_tags:
+        attrs = entry.get('attrs', {})
+        if attrs:
+            refs.append(dict(attrs))
+    return refs
+
+
+def _assign_tags_to_sections(
+    section_tags: List[Dict[str, Any]],
+    sections: List[Dict[str, Any]],
+) -> Dict[int, Dict[str, Any]]:
+    """Map section-scope tags to the flat section index they belong to.
+
+    A tag at content line *L* belongs to section *I* when:
+    ``sections[I].line_idx <= L < sections[I+1].line_idx``
+    (for the last section the upper bound is infinity).
+
+    Returns ``{section_idx: {tag_name: attrs}}``.  The same-tag-name
+    last-wins rule applies within each section.
+    """
+    section_metadata: Dict[int, Dict[str, Any]] = {}
+    if not sections or not section_tags:
+        return section_metadata
+
+    for entry in section_tags:
+        tag_line = entry['line']
+        attrs = entry.get('attrs', {})
+        if not attrs:
+            continue
+
+        owning_idx: Optional[int] = None
+        for i, sec in enumerate(sections):
+            next_start: Any = (
+                sections[i + 1]['line_idx'] if i + 1 < len(sections) else float('inf')
+            )
+            if sec['line_idx'] <= tag_line < next_start:
+                owning_idx = i
+                break
+
+        if owning_idx is not None:
+            if owning_idx not in section_metadata:
+                section_metadata[owning_idx] = {}
+            section_metadata[owning_idx][entry['tag']] = dict(attrs)
+
+    return section_metadata
+
+
+def _extract_and_classify_tags(
+    content_lines: List[str],
+    sections: List[Dict[str, Any]],
+) -> tuple:
+    """Extract Markdoc tags from content and classify them.
+
+    Returns:
+        file_metadata  — dict to inject into the root tree node ``metadata``
+        section_metadata — {section_idx: {tag_name: attrs}} for subtree nodes
+        cross_references — list of citation attrs for the root ``cross_references``
+    """
+    all_tags = extract_tags_from_lines(content_lines)
+    first_heading = _first_heading_line(content_lines)
+
+    file_tags: List[Dict[str, Any]] = []
+    section_tags_raw: List[Dict[str, Any]] = []
+    citation_tags: List[Dict[str, Any]] = []
+
+    for tag in all_tags:
+        # Skip closing tags — they are structural, not metadata carriers
+        if tag.get('is_close'):
+            continue
+
+        if tag['tag'] == 'citation':
+            citation_tags.append(tag)
+            # Citations are always inline; do NOT add to file/section buckets
+            continue
+
+        scope = classify_tag_scope(tag, first_heading)
+        if scope == 'file':
+            file_tags.append(tag)
+        elif scope == 'section':
+            section_tags_raw.append(tag)
+        # inline tags other than citation are not injected into node metadata
+
+    file_metadata = _build_file_metadata(file_tags)
+    section_metadata = _assign_tags_to_sections(section_tags_raw, sections)
+    cross_references = _build_cross_references(citation_tags)
+
+    return file_metadata, section_metadata, cross_references
+
+
+# ---------------------------------------------------------------------------
+# Tree result builders
+# ---------------------------------------------------------------------------
+
 def build_headingless_result(
     frontmatter: Dict[str, str],
     content_lines: List[str],
@@ -202,7 +347,30 @@ def build_pageindex_tree(
     source_pdf: str,
     page_count: int,
 ) -> Dict[str, Any]:
-    """Build a hierarchical PageIndex tree from markdown headings."""
+    """Build a hierarchical PageIndex tree from markdown headings.
+
+    Phase 5 extension (t2972): Markdoc tag attributes found in the source are
+    lifted into per-node ``metadata`` fields so retrieval can filter by tag
+    attributes without re-parsing the document body.  Citation tags produce a
+    ``cross_references`` array at the document root.
+
+    Node metadata shape::
+
+        {
+          "metadata": {
+            "sensitivity": {"tier": "privileged", "scope": "file"},
+            "provenance": {"source-id": "...", "extracted-at": "..."}
+          }
+        }
+
+    Cross-references shape::
+
+        {
+          "cross_references": [
+            {"source-id": "exhibit-A.pdf", "page": "p.4", "confidence": 1.0}
+          ]
+        }
+    """
     frontmatter = extract_frontmatter(lines)
     content_start = get_frontmatter_end(lines)
     content_lines = lines[content_start:]
@@ -210,12 +378,29 @@ def build_pageindex_tree(
 
     sections = parse_sections(content_lines)
 
+    # --- Phase 5: extract and classify Markdoc tag metadata ---
+    file_metadata, section_metadata, cross_references = _extract_and_classify_tags(
+        content_lines, sections
+    )
+
+    content_hash = frontmatter.get('content_hash', '')
+    if not content_hash:
+        content_hash = hashlib.sha256('\n'.join(lines).encode('utf-8')).hexdigest()
+
     if not sections:
-        return build_headingless_result(frontmatter, content_lines, ctx)
+        result = build_headingless_result(frontmatter, content_lines, ctx)
+        # Headingless doc: inject file-scope metadata and cross-references into root
+        if file_metadata:
+            result['tree']['metadata'] = file_metadata
+        if cross_references:
+            result['tree']['cross_references'] = cross_references
+        return result
 
     root_section = sections[0]
     root_summary = get_section_summary(root_section, ctx)
-    root_children, _ = build_tree_recursive(sections, 1, root_section['level'], ctx)
+    root_children, _ = build_tree_recursive(
+        sections, 1, root_section['level'], ctx, section_metadata
+    )
 
     tree: Dict[str, Any] = {
         "title": root_section['title'],
@@ -225,9 +410,16 @@ def build_pageindex_tree(
         "children": root_children,
     }
 
-    content_hash = frontmatter.get('content_hash', '')
-    if not content_hash:
-        content_hash = hashlib.sha256('\n'.join(lines).encode('utf-8')).hexdigest()
+    # File-scope metadata goes on the root tree node (document-level).
+    # Section-scope metadata for section index 0 (the root heading's own range)
+    # is merged into file-scope metadata — root heading owns both.
+    if file_metadata:
+        tree["metadata"] = file_metadata
+    elif 0 in section_metadata and section_metadata[0]:
+        tree["metadata"] = section_metadata[0]
+
+    if cross_references:
+        tree["cross_references"] = cross_references
 
     return {
         "version": "1.0",

--- a/.agents/scripts/pageindex-generator.py
+++ b/.agents/scripts/pageindex-generator.py
@@ -26,10 +26,7 @@ import hashlib
 from typing import Any, Dict, List, Optional
 
 from pageindex_helpers import extract_first_sentence, get_ollama_summary
-from markdoc_tag_extractor import (
-    extract_tags_from_lines,
-    classify_tag_scope,
-)
+from markdoc_tag_extractor import extract_and_classify_tags
 
 
 def extract_frontmatter(lines: List[str]) -> Dict[str, str]:
@@ -114,8 +111,8 @@ def build_tree_recursive(
     """Recursively build tree from sections starting at start_idx.
 
     ``section_metadata`` maps flat section index → metadata dict (tag_name →
-    attrs) to inject into that node.  Passed through unchanged to all
-    recursive calls so every level can look up its own index.
+    attrs) injected into that node.  Passed through unchanged to all recursive
+    calls so every level can look up its own index.
     """
     children = []
     i = start_idx
@@ -186,131 +183,6 @@ def parse_sections(content_lines: List[str]) -> List[Dict[str, Any]]:
     return sections
 
 
-# ---------------------------------------------------------------------------
-# Tag metadata helpers (Phase 5 — t2972)
-# ---------------------------------------------------------------------------
-
-def _first_heading_line(content_lines: List[str]) -> Optional[int]:
-    """Return the 0-indexed line of the first heading in content, or None."""
-    for i, line in enumerate(content_lines):
-        if re.match(r'^#{1,6}\s', line.strip()):
-            return i
-    return None
-
-
-def _build_file_metadata(file_tags: List[Dict[str, Any]]) -> Dict[str, Any]:
-    """Return metadata dict keyed by tag name from file-scope tag entries.
-
-    Only non-closing tags with at least one attribute are included.
-    If the same tag name appears more than once, the last occurrence wins.
-    """
-    metadata: Dict[str, Any] = {}
-    for entry in file_tags:
-        attrs = entry.get('attrs', {})
-        if not attrs:
-            continue
-        metadata[entry['tag']] = dict(attrs)
-    return metadata
-
-
-def _build_cross_references(
-    all_citation_tags: List[Dict[str, Any]],
-) -> List[Dict[str, Any]]:
-    """Return a cross_references list from non-closing citation tag entries."""
-    refs = []
-    for entry in all_citation_tags:
-        attrs = entry.get('attrs', {})
-        if attrs:
-            refs.append(dict(attrs))
-    return refs
-
-
-def _assign_tags_to_sections(
-    section_tags: List[Dict[str, Any]],
-    sections: List[Dict[str, Any]],
-) -> Dict[int, Dict[str, Any]]:
-    """Map section-scope tags to the flat section index they belong to.
-
-    A tag at content line *L* belongs to section *I* when:
-    ``sections[I].line_idx <= L < sections[I+1].line_idx``
-    (for the last section the upper bound is infinity).
-
-    Returns ``{section_idx: {tag_name: attrs}}``.  The same-tag-name
-    last-wins rule applies within each section.
-    """
-    section_metadata: Dict[int, Dict[str, Any]] = {}
-    if not sections or not section_tags:
-        return section_metadata
-
-    for entry in section_tags:
-        tag_line = entry['line']
-        attrs = entry.get('attrs', {})
-        if not attrs:
-            continue
-
-        owning_idx: Optional[int] = None
-        for i, sec in enumerate(sections):
-            next_start: Any = (
-                sections[i + 1]['line_idx'] if i + 1 < len(sections) else float('inf')
-            )
-            if sec['line_idx'] <= tag_line < next_start:
-                owning_idx = i
-                break
-
-        if owning_idx is not None:
-            if owning_idx not in section_metadata:
-                section_metadata[owning_idx] = {}
-            section_metadata[owning_idx][entry['tag']] = dict(attrs)
-
-    return section_metadata
-
-
-def _extract_and_classify_tags(
-    content_lines: List[str],
-    sections: List[Dict[str, Any]],
-) -> tuple:
-    """Extract Markdoc tags from content and classify them.
-
-    Returns:
-        file_metadata  — dict to inject into the root tree node ``metadata``
-        section_metadata — {section_idx: {tag_name: attrs}} for subtree nodes
-        cross_references — list of citation attrs for the root ``cross_references``
-    """
-    all_tags = extract_tags_from_lines(content_lines)
-    first_heading = _first_heading_line(content_lines)
-
-    file_tags: List[Dict[str, Any]] = []
-    section_tags_raw: List[Dict[str, Any]] = []
-    citation_tags: List[Dict[str, Any]] = []
-
-    for tag in all_tags:
-        # Skip closing tags — they are structural, not metadata carriers
-        if tag.get('is_close'):
-            continue
-
-        if tag['tag'] == 'citation':
-            citation_tags.append(tag)
-            # Citations are always inline; do NOT add to file/section buckets
-            continue
-
-        scope = classify_tag_scope(tag, first_heading)
-        if scope == 'file':
-            file_tags.append(tag)
-        elif scope == 'section':
-            section_tags_raw.append(tag)
-        # inline tags other than citation are not injected into node metadata
-
-    file_metadata = _build_file_metadata(file_tags)
-    section_metadata = _assign_tags_to_sections(section_tags_raw, sections)
-    cross_references = _build_cross_references(citation_tags)
-
-    return file_metadata, section_metadata, cross_references
-
-
-# ---------------------------------------------------------------------------
-# Tree result builders
-# ---------------------------------------------------------------------------
-
 def build_headingless_result(
     frontmatter: Dict[str, str],
     content_lines: List[str],
@@ -378,8 +250,8 @@ def build_pageindex_tree(
 
     sections = parse_sections(content_lines)
 
-    # --- Phase 5: extract and classify Markdoc tag metadata ---
-    file_metadata, section_metadata, cross_references = _extract_and_classify_tags(
+    # Phase 5: extract and classify Markdoc tag metadata
+    file_metadata, section_metadata, cross_references = extract_and_classify_tags(
         content_lines, sections
     )
 
@@ -389,7 +261,6 @@ def build_pageindex_tree(
 
     if not sections:
         result = build_headingless_result(frontmatter, content_lines, ctx)
-        # Headingless doc: inject file-scope metadata and cross-references into root
         if file_metadata:
             result['tree']['metadata'] = file_metadata
         if cross_references:
@@ -410,9 +281,7 @@ def build_pageindex_tree(
         "children": root_children,
     }
 
-    # File-scope metadata goes on the root tree node (document-level).
-    # Section-scope metadata for section index 0 (the root heading's own range)
-    # is merged into file-scope metadata — root heading owns both.
+    # File-scope metadata → root node; fall back to section index 0 if no file-scope tags
     if file_metadata:
         tree["metadata"] = file_metadata
     elif 0 in section_metadata and section_metadata[0]:


### PR DESCRIPTION
## Summary

Phase 5 of the t2874 knowledge plane Markdoc pipeline: lifts Markdoc tag attributes from `source.md` into PageIndex tree node metadata, enabling tag-filtered retrieval without re-reading document bodies.

## Changes

### New: `markdoc_tag_extractor.py`
Python module (imported by `pageindex-generator.py`) that:
- Parses all `{% tag ... %}` occurrences from a list of lines
- Handles double-quoted, single-quoted, and unquoted attribute values; coerces numerics
- Classifies each tag as `file`, `section`, or `inline` scope via:
  1. `citation`/`link` tags → always `inline`
  2. Explicit `scope=` attribute → honour it
  3. Positional: before first heading → `file`, after → `section`

### Modified: `pageindex-generator.py`
Extended the PageIndex tree build step (Phase 5 — t2972):
- `_extract_and_classify_tags()`: partitions non-closing tags into file-scope, section-scope, and citation buckets
- `_build_file_metadata()`: builds `{tag_name: attrs}` dict from file-scope tags → injected into root tree node `metadata`
- `_assign_tags_to_sections()`: maps section-scope tags to flat section indices by line range → injected into matching subtree node `metadata`
- `_build_cross_references()`: builds `cross_references` list from citation tags → added at document root
- `build_tree_recursive()` gains `section_metadata` param to inject metadata into nodes
- `build_pageindex_tree()` orchestrates extraction, classification, and injection

**Output schema additions (optional fields):**
- Each node: `"metadata": {"sensitivity": {"tier": "privileged"}, ...}`
- Root node only: `"cross_references": [{"source-id": "...", ...}]`

### New: `markdoc-extract.sh`
Shell CLI wrapper: `markdoc-extract.sh extract <source.md>` writes a `<basename>-tags.json` sidecar. `--stdout` flag for pipeline use. ShellCheck zero violations.

## Acceptance Criteria

- [x] `{% sensitivity tier="privileged" /%}` file-scope tag → root `metadata.sensitivity.tier == "privileged"`
- [x] Section-scope tags (with `scope="section"` or positioned after first heading) appear on subtree node, not root
- [x] Citation tags produce `cross_references` array at document root
- [x] ShellCheck zero violations on `markdoc-extract.sh`

## Verification

```bash
cd .agents/scripts
# Unit tests
python3 -c "from markdoc_tag_extractor import extract_tags_from_lines; ..."

# Integration test (run from .agents/scripts/)
python3 -c "
import sys, json, importlib.util
sys.path.insert(0, '.')
spec = importlib.util.spec_from_file_location('pg', './pageindex-generator.py')
gen = importlib.util.module_from_spec(spec); spec.loader.exec_module(gen)
result = gen.build_pageindex_tree([
  '{% sensitivity tier=\"privileged\" /%}',
  '# Doc',
  'See {% citation source-id=\"x\" /%}.',
], False, '', '', 0)
assert result['tree']['metadata']['sensitivity']['tier'] == 'privileged'
assert result['tree']['cross_references'][0]['source-id'] == 'x'
print('PASSED')
"

# Shell CLI smoke test
echo '{% sensitivity tier=\"public\" /%}' | bash markdoc-extract.sh extract /dev/stdin --stdout
```

Resolves #21264

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.26 with claude-sonnet-4-6 spent 8m and 33,250 tokens on this as a headless worker.
