### PR TITLE
t2972: PageIndex Phase 5 — lift Markdoc tag attributes into tree node metadata

### DIFF
--- a/.agents/scripts/pageindex-generator.py
+++ b/.agents/scripts/pageindex-generator.py
@@ -20,7 +20,11 @@ import json
 import hashlib
 from typing import Any, Dict, List, Optional
 
-from pageindex_helpers import extract_first_sentence, get_ollama_summary
+from pageindex_helpers import (
+    extract_first_sentence,
+    get_ollama_summary,
+    extract_markdoc_tags,
+)
 
 
 def extract_frontmatter(lines: List[str]) -> Dict[str, str]:
@@ -101,7 +105,12 @@ def build_tree_recursive(
     parent_level: int,
     ctx: TreeContext,
 ) -> tuple:
-    """Recursively build tree from sections starting at start_idx."""
+    """Recursively build tree from sections starting at start_idx.
+
+    Each node gains private ``_line_start`` / ``_line_end`` fields (relative
+    to the content array, i.e. after frontmatter) used during tag injection.
+    Call ``_strip_internal_fields`` to remove them before serialising.
+    """
     children = []
     i = start_idx
 
@@ -111,23 +120,68 @@ def build_tree_recursive(
         if section['level'] <= parent_level:
             break
 
+        child_children, next_i = build_tree_recursive(
+            sections_list, i + 1, section['level'], ctx
+        )
+
+        # Line end: start of next sibling (or cousin at same/higher level) - 1.
+        if next_i < len(sections_list):
+            line_end = sections_list[next_i]['line_idx'] - 1
+        else:
+            line_end = ctx.total_lines - 1
+
         node: Dict[str, Any] = {
             "title": section['title'],
             "level": section['level'],
             "summary": get_section_summary(section, ctx),
             "page": get_section_page(section, ctx),
-            "children": [],
+            "metadata": {},
+            "_line_start": section['line_idx'],
+            "_line_end": line_end,
+            "children": child_children,
         }
-
-        child_children, next_i = build_tree_recursive(
-            sections_list, i + 1, section['level'], ctx
-        )
-        node['children'] = child_children
 
         children.append(node)
         i = next_i
 
     return children, i
+
+
+def _inject_tag_record(node: Dict[str, Any], tag_rec: Dict[str, Any]) -> bool:
+    """Inject a tag record into the deepest tree node containing its line.
+
+    Walks depth-first so the most specific (deepest) node wins.  Returns True
+    if the tag was consumed by this node or one of its descendants.
+    """
+    line = tag_rec['line_num']
+    if not (node.get('_line_start', 0) <= line <= node.get('_line_end', 0)):
+        return False
+
+    # Try children first — deepest match wins.
+    for child in node.get('children', []):
+        if _inject_tag_record(child, tag_rec):
+            return True
+
+    # No child claimed it — inject into this node.
+    tag_name = tag_rec['tag']
+    attrs = tag_rec['attrs']
+    meta = node.setdefault('metadata', {})
+    existing = meta.get(tag_name)
+    if existing is None:
+        meta[tag_name] = attrs
+    elif isinstance(existing, list):
+        existing.append(attrs)
+    else:
+        meta[tag_name] = [existing, attrs]
+    return True
+
+
+def _strip_internal_fields(node: Dict[str, Any]) -> None:
+    """Remove private line-range fields from a node tree in-place (recursive)."""
+    node.pop('_line_start', None)
+    node.pop('_line_end', None)
+    for child in node.get('children', []):
+        _strip_internal_fields(child)
 
 
 def parse_sections(content_lines: List[str]) -> List[Dict[str, Any]]:
@@ -171,7 +225,11 @@ def build_headingless_result(
     content_lines: List[str],
     ctx: TreeContext,
 ) -> Dict[str, Any]:
-    """Build a single-node result when the document has no headings."""
+    """Build a single-node result when the document has no headings.
+
+    The root node carries ``_line_start``/``_line_end`` so that callers can
+    inject Markdoc tag metadata before stripping internal fields.
+    """
     full_content = '\n'.join(content_lines).strip()
     title = frontmatter.get('title', 'Untitled')
     summary = ""
@@ -190,6 +248,9 @@ def build_headingless_result(
             "level": 1,
             "summary": summary,
             "page": 1 if ctx.page_count > 0 else None,
+            "metadata": {},
+            "_line_start": 0,
+            "_line_end": max(0, len(content_lines) - 1),
             "children": [],
         },
     }
@@ -202,16 +263,40 @@ def build_pageindex_tree(
     source_pdf: str,
     page_count: int,
 ) -> Dict[str, Any]:
-    """Build a hierarchical PageIndex tree from markdown headings."""
+    """Build a hierarchical PageIndex tree from markdown headings.
+
+    Markdoc tag attributes from the content are lifted into per-node
+    ``metadata`` fields (t2972):
+
+    - File-scope tags (before the first heading) → root node ``metadata``.
+    - Section-scope tags → the deepest subtree node whose line range
+      contains the tag's line.
+    - Inline tags → same depth-first injection rule.
+
+    ``{% citation ... %}`` tags are additionally aggregated into a top-level
+    ``cross_references`` array for fast retrieval without full-corpus re-reads.
+    """
     frontmatter = extract_frontmatter(lines)
     content_start = get_frontmatter_end(lines)
     content_lines = lines[content_start:]
     ctx = TreeContext(len(content_lines), page_count, use_ollama, ollama_model)
 
+    # Extract Markdoc tags once; skip bare closing tags (no attrs to lift).
+    all_tag_records = extract_markdoc_tags(content_lines)
+    open_tags = [t for t in all_tag_records if not t['is_close']]
+    citation_tags = [t for t in open_tags if t['tag'] == 'citation']
+
     sections = parse_sections(content_lines)
 
     if not sections:
-        return build_headingless_result(frontmatter, content_lines, ctx)
+        result = build_headingless_result(frontmatter, content_lines, ctx)
+        root_node = result['tree']
+        for tag_rec in open_tags:
+            _inject_tag_record(root_node, tag_rec)
+        _strip_internal_fields(root_node)
+        if citation_tags:
+            result['cross_references'] = [t['attrs'] for t in citation_tags]
+        return result
 
     root_section = sections[0]
     root_summary = get_section_summary(root_section, ctx)
@@ -222,14 +307,25 @@ def build_pageindex_tree(
         "level": root_section['level'],
         "summary": root_summary,
         "page": 1 if page_count > 0 else None,
+        "metadata": {},
+        # Root spans from line 0 so pre-heading tags are captured at root level.
+        "_line_start": 0,
+        "_line_end": max(0, len(content_lines) - 1),
         "children": root_children,
     }
+
+    # Inject all open tags into the deepest containing node.
+    for tag_rec in open_tags:
+        _inject_tag_record(tree, tag_rec)
+
+    # Remove line-range bookkeeping before serialising.
+    _strip_internal_fields(tree)
 
     content_hash = frontmatter.get('content_hash', '')
     if not content_hash:
         content_hash = hashlib.sha256('\n'.join(lines).encode('utf-8')).hexdigest()
 
-    return {
+    result = {
         "version": "1.0",
         "generator": "aidevops/document-creation-helper",
         "source_file": frontmatter.get('source_file', source_pdf if source_pdf else ''),
@@ -237,6 +333,12 @@ def build_pageindex_tree(
         "page_count": page_count,
         "tree": tree,
     }
+
+    # Cross-reference index: all citation tags aggregated at document root.
+    if citation_tags:
+        result['cross_references'] = [t['attrs'] for t in citation_tags]
+
+    return result
 
 
 def main() -> None:

--- a/.agents/scripts/pageindex_helpers.py
+++ b/.agents/scripts/pageindex_helpers.py
@@ -2,14 +2,14 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 """
-pageindex_helpers.py - Summary extraction helpers for pageindex-generator.py.
+pageindex_helpers.py - Summary extraction and Markdoc tag helpers for pageindex-generator.py.
 
 Extracted to reduce file-level complexity below the qlty maintainability threshold.
 """
 
 import re
 import json
-from typing import Optional
+from typing import Any, Dict, List, Optional
 
 
 def extract_first_sentence(text: str) -> str:
@@ -76,3 +76,99 @@ def get_ollama_summary(text: str, model: str) -> Optional[str]:
             return summary if summary else None
     except (urllib.error.URLError, TimeoutError, json.JSONDecodeError, OSError):
         return None
+
+
+def parse_tag_attrs(attrs_string: str) -> Dict[str, Any]:
+    """Parse a Markdoc attribute string into a dict.
+
+    Handles quoted strings, single-quoted strings, and bare values.
+    Numeric bare values (integer or float) are coerced to Python numbers.
+
+    Examples:
+      'tier="privileged" scope="file"' → {'tier': 'privileged', 'scope': 'file'}
+      'confidence=0.95'                → {'confidence': 0.95}
+    """
+    attrs: Dict[str, Any] = {}
+    if not attrs_string:
+        return attrs
+    # Match: key="val"  key='val'  key=bare_val (no spaces/quotes/braces)
+    for m in re.finditer(
+        r'([\w-]+)\s*=\s*(?:"([^"]*)"|\'([^\']*)\'|([^\s"\'{}]+))',
+        attrs_string,
+    ):
+        key = m.group(1)
+        raw: Any
+        if m.group(2) is not None:
+            raw = m.group(2)
+        elif m.group(3) is not None:
+            raw = m.group(3)
+        else:
+            raw = m.group(4) or ''
+        # Coerce bare numeric values
+        try:
+            if '.' in str(raw):
+                raw = float(raw)
+            else:
+                raw = int(str(raw))
+        except (ValueError, TypeError):
+            pass
+        attrs[key] = raw
+    return attrs
+
+
+def extract_markdoc_tags(lines: List[str]) -> List[Dict[str, Any]]:
+    """Parse all Markdoc {%...%} tags from a list of lines (0-indexed).
+
+    Returns one record per tag occurrence:
+      {
+        'tag':          str,   tag name
+        'attrs':        dict,  parsed attribute key→value mapping
+        'is_close':     bool,  True for {%  /tag %}
+        'is_self_close': bool, True for {% tag /%}
+        'line_num':     int,   0-indexed line number
+      }
+
+    Multi-line tags ({% ... across two lines ... %}) are not supported
+    and are silently skipped.  Closing tags have empty attrs dicts.
+    """
+    records: List[Dict[str, Any]] = []
+    tag_re = re.compile(r'^[a-zA-Z][a-zA-Z0-9_-]*$')
+
+    for line_num, line in enumerate(lines):
+        rest = line
+        while '{%' in rest:
+            rest = rest[rest.index('{%') + 2:]
+            if '%}' not in rest:
+                break  # Multi-line tag — not supported
+            inner = rest[:rest.index('%}')]
+            rest = rest[rest.index('%}') + 2:]
+
+            inner = inner.strip()
+            is_close = False
+            is_self_close = False
+
+            if inner.startswith('/'):
+                is_close = True
+                inner = inner[1:].strip()
+
+            if inner.endswith('/'):
+                is_self_close = True
+                inner = inner[:-1].strip()
+
+            parts = inner.split(None, 1)
+            if not parts:
+                continue
+            tag_name = parts[0]
+            attrs_str = parts[1] if len(parts) > 1 else ''
+
+            if not tag_re.match(tag_name):
+                continue
+
+            records.append({
+                'tag': tag_name,
+                'attrs': {} if is_close else parse_tag_attrs(attrs_str),
+                'is_close': is_close,
+                'is_self_close': is_self_close,
+                'line_num': line_num,
+            })
+    return records

--- a/tests/test-pageindex-tag-lifting.py
+++ b/tests/test-pageindex-tag-lifting.py
@@ -1,0 +1,318 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+"""
+tests/test-pageindex-tag-lifting.py — Unit tests for t2972 PageIndex tag lifting.
+
+Verifies that Markdoc tag attributes are injected into the correct tree-node
+``metadata`` fields and that citation tags produce a ``cross_references`` array
+at the document root.
+
+Usage:  python3 tests/test-pageindex-tag-lifting.py
+Exit:   0 all pass, 1 any fail
+"""
+
+import sys
+import os
+import json
+
+# Resolve the scripts directory so we can import the modules under test.
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+_SCRIPTS_DIR = os.path.join(_REPO_ROOT, '.agents', 'scripts')
+sys.path.insert(0, _SCRIPTS_DIR)
+
+from pageindex_helpers import parse_tag_attrs, extract_markdoc_tags  # noqa: E402
+
+# pageindex-generator.py uses a hyphen — load via importlib.
+import importlib.util  # noqa: E402
+_spec = importlib.util.spec_from_file_location(
+    'pageindex_generator',
+    os.path.join(_SCRIPTS_DIR, 'pageindex-generator.py'),
+)
+_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(_mod)
+build_pageindex_tree = _mod.build_pageindex_tree
+
+PASS_COUNT = 0
+FAIL_COUNT = 0
+
+
+def _pass(desc: str) -> None:
+    global PASS_COUNT
+    PASS_COUNT += 1
+    print(f"  PASS  {desc}")
+
+
+def _fail(desc: str, reason: str = "") -> None:
+    global FAIL_COUNT
+    FAIL_COUNT += 1
+    print(f"  FAIL  {desc}")
+    if reason:
+        print(f"        {reason}")
+
+
+def assert_equal(actual, expected, desc: str) -> None:
+    if actual == expected:
+        _pass(desc)
+    else:
+        _fail(desc, f"expected {expected!r}, got {actual!r}")
+
+
+def assert_in(key, container, desc: str) -> None:
+    if key in container:
+        _pass(desc)
+    else:
+        _fail(desc, f"{key!r} not in {container!r}")
+
+
+def assert_not_in(key, container, desc: str) -> None:
+    if key not in container:
+        _pass(desc)
+    else:
+        _fail(desc, f"{key!r} unexpectedly in {container!r}")
+
+
+# ---------------------------------------------------------------------------
+# parse_tag_attrs
+# ---------------------------------------------------------------------------
+
+def test_parse_tag_attrs_double_quoted():
+    attrs = parse_tag_attrs('tier="privileged" scope="file"')
+    assert_equal(attrs.get('tier'), 'privileged', "parse_tag_attrs: double-quoted tier")
+    assert_equal(attrs.get('scope'), 'file', "parse_tag_attrs: double-quoted scope")
+
+
+def test_parse_tag_attrs_numeric():
+    attrs = parse_tag_attrs('confidence=0.95')
+    assert_equal(attrs.get('confidence'), 0.95, "parse_tag_attrs: float coercion")
+
+
+def test_parse_tag_attrs_bare_int():
+    attrs = parse_tag_attrs('page=42')
+    assert_equal(attrs.get('page'), 42, "parse_tag_attrs: int coercion")
+
+
+def test_parse_tag_attrs_empty():
+    attrs = parse_tag_attrs('')
+    assert_equal(attrs, {}, "parse_tag_attrs: empty string yields empty dict")
+
+
+def test_parse_tag_attrs_hyphenated_key():
+    attrs = parse_tag_attrs('source-id="exhibit-A"')
+    assert_equal(attrs.get('source-id'), 'exhibit-A', "parse_tag_attrs: hyphenated key")
+
+
+# ---------------------------------------------------------------------------
+# extract_markdoc_tags
+# ---------------------------------------------------------------------------
+
+def test_extract_self_closing():
+    lines = ['{% sensitivity tier="privileged" /%}']
+    tags = extract_markdoc_tags(lines)
+    assert_equal(len(tags), 1, "extract: one tag from one line")
+    assert_equal(tags[0]['tag'], 'sensitivity', "extract: tag name")
+    assert_equal(tags[0]['is_self_close'], True, "extract: is_self_close")
+    assert_equal(tags[0]['is_close'], False, "extract: not is_close")
+    assert_equal(tags[0]['attrs'].get('tier'), 'privileged', "extract: tier attr")
+
+
+def test_extract_opening_and_closing():
+    lines = ['{% sensitivity tier="internal" %}', 'content', '{% /sensitivity %}']
+    tags = extract_markdoc_tags(lines)
+    open_tags = [t for t in tags if not t['is_close']]
+    close_tags = [t for t in tags if t['is_close']]
+    assert_equal(len(open_tags), 1, "extract: one open tag")
+    assert_equal(len(close_tags), 1, "extract: one close tag")
+    assert_equal(close_tags[0]['attrs'], {}, "extract: close tag has empty attrs")
+
+
+def test_extract_multiple_tags_on_one_line():
+    lines = ['{% provenance source-id="a" extracted-at="2026-01-01" %} text {% /provenance %}']
+    tags = extract_markdoc_tags(lines)
+    assert_equal(len(tags), 2, "extract: two tags on one line")
+    assert_equal(tags[0]['line_num'], 0, "extract: correct line_num")
+
+
+def test_extract_no_tags():
+    lines = ['# Heading', 'plain text']
+    tags = extract_markdoc_tags(lines)
+    assert_equal(tags, [], "extract: no tags in plain markdown")
+
+
+# ---------------------------------------------------------------------------
+# build_pageindex_tree — tag injection
+# ---------------------------------------------------------------------------
+
+def _make_source_md_lines(body: str) -> list:
+    """Split a multi-line string into a list of lines (no trailing newline)."""
+    return body.splitlines()
+
+
+FILE_SCOPE_SOURCE = """\
+{% sensitivity tier="privileged" scope="file" /%}
+{% provenance source-id="contract-2026.pdf" extracted-at="2026-04-27" /%}
+
+# Contract Review
+
+This section covers the main contract.
+
+## Delivery Terms
+
+Delivery is expected by Q3 {% citation source-id="contract-2026.pdf" page="p.4" confidence=1.0 /%}.
+"""
+
+SECTION_SCOPE_SOURCE = """\
+# Document Root
+
+Intro paragraph.
+
+## Section A
+
+{% sensitivity tier="confidential" scope="section" %}
+Confidential content here.
+{% /sensitivity %}
+
+## Section B
+
+Public content.
+"""
+
+HEADINGLESS_SOURCE = """\
+{% sensitivity tier="internal" /%}
+{% provenance source-id="memo-001.txt" extracted-at="2026-04-01" /%}
+
+This is a flat document with no headings at all.
+"""
+
+
+def test_file_scope_tag_on_root_node():
+    """File-scope sensitivity tag must appear in root node metadata."""
+    lines = _make_source_md_lines(FILE_SCOPE_SOURCE)
+    result = build_pageindex_tree(lines, False, 'llama3.2:1b', '', 0)
+    tree = result['tree']
+    assert_in('metadata', tree, "file-scope: root node has metadata")
+    meta = tree['metadata']
+    assert_in('sensitivity', meta, "file-scope: sensitivity in root metadata")
+    assert_equal(
+        meta['sensitivity'].get('tier'), 'privileged',
+        "file-scope: sensitivity.tier == 'privileged'"
+    )
+
+
+def test_file_scope_provenance_on_root_node():
+    """File-scope provenance tag must appear in root node metadata."""
+    lines = _make_source_md_lines(FILE_SCOPE_SOURCE)
+    result = build_pageindex_tree(lines, False, 'llama3.2:1b', '', 0)
+    meta = result['tree']['metadata']
+    assert_in('provenance', meta, "provenance in root metadata")
+    assert_equal(
+        meta['provenance'].get('source-id'), 'contract-2026.pdf',
+        "provenance source-id correct"
+    )
+
+
+def test_section_scope_tag_on_child_not_root():
+    """Section-scope tag must appear on the child node, not the root."""
+    lines = _make_source_md_lines(SECTION_SCOPE_SOURCE)
+    result = build_pageindex_tree(lines, False, 'llama3.2:1b', '', 0)
+    tree = result['tree']
+    # Root metadata must NOT contain sensitivity
+    root_meta = tree.get('metadata', {})
+    assert_not_in('sensitivity', root_meta, "section-scope: sensitivity NOT on root")
+    # Find child node titled "Section A"
+    section_a = next(
+        (c for c in tree.get('children', []) if c['title'] == 'Section A'),
+        None
+    )
+    if section_a is None:
+        _fail("section-scope: Section A node found", "Section A child missing from tree")
+        return
+    child_meta = section_a.get('metadata', {})
+    assert_in('sensitivity', child_meta, "section-scope: sensitivity on Section A node")
+    assert_equal(
+        child_meta['sensitivity'].get('tier'), 'confidential',
+        "section-scope: sensitivity.tier == 'confidential'"
+    )
+
+
+def test_citation_produces_cross_references():
+    """Citation tags must produce a cross_references array at document root."""
+    lines = _make_source_md_lines(FILE_SCOPE_SOURCE)
+    result = build_pageindex_tree(lines, False, 'llama3.2:1b', '', 0)
+    assert_in('cross_references', result, "cross_references key present at document root")
+    refs = result['cross_references']
+    assert_equal(len(refs), 1, "cross_references has one entry")
+    assert_equal(refs[0].get('source-id'), 'contract-2026.pdf', "citation source-id correct")
+    assert_equal(refs[0].get('page'), 'p.4', "citation page correct")
+    assert_equal(refs[0].get('confidence'), 1.0, "citation confidence correct")
+
+
+def test_no_cross_references_when_no_citations():
+    """Document with no citation tags must not have a cross_references key."""
+    lines = _make_source_md_lines(SECTION_SCOPE_SOURCE)
+    result = build_pageindex_tree(lines, False, 'llama3.2:1b', '', 0)
+    assert_not_in('cross_references', result, "no cross_references when no citation tags")
+
+
+def test_headingless_document_tag_on_root():
+    """Tags in a headingless document must appear on the single root node."""
+    lines = _make_source_md_lines(HEADINGLESS_SOURCE)
+    result = build_pageindex_tree(lines, False, 'llama3.2:1b', '', 0)
+    tree = result['tree']
+    meta = tree.get('metadata', {})
+    assert_in('sensitivity', meta, "headingless: sensitivity on root node")
+    assert_equal(meta['sensitivity'].get('tier'), 'internal', "headingless: tier == 'internal'")
+    assert_in('provenance', meta, "headingless: provenance on root node")
+
+
+def test_no_internal_line_fields_in_output():
+    """_line_start / _line_end must not appear in the final JSON output."""
+    lines = _make_source_md_lines(FILE_SCOPE_SOURCE)
+    result = build_pageindex_tree(lines, False, 'llama3.2:1b', '', 0)
+    serialised = json.dumps(result)
+    assert_not_in('_line_start', serialised, "no _line_start in serialised output")
+    assert_not_in('_line_end', serialised, "no _line_end in serialised output")
+
+
+def test_plain_document_has_empty_metadata():
+    """A document with no Markdoc tags must have an empty metadata dict (not absent)."""
+    lines = _make_source_md_lines("# My Doc\n\nNo tags here.\n")
+    result = build_pageindex_tree(lines, False, 'llama3.2:1b', '', 0)
+    tree = result['tree']
+    assert_in('metadata', tree, "plain doc: metadata key present")
+    assert_equal(tree['metadata'], {}, "plain doc: metadata is empty dict")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main() -> int:
+    print("=== pageindex tag-lifting tests (t2972) ===")
+
+    test_parse_tag_attrs_double_quoted()
+    test_parse_tag_attrs_numeric()
+    test_parse_tag_attrs_bare_int()
+    test_parse_tag_attrs_empty()
+    test_parse_tag_attrs_hyphenated_key()
+
+    test_extract_self_closing()
+    test_extract_opening_and_closing()
+    test_extract_multiple_tags_on_one_line()
+    test_extract_no_tags()
+
+    test_file_scope_tag_on_root_node()
+    test_file_scope_provenance_on_root_node()
+    test_section_scope_tag_on_child_not_root()
+    test_citation_produces_cross_references()
+    test_no_cross_references_when_no_citations()
+    test_headingless_document_tag_on_root()
+    test_no_internal_line_fields_in_output()
+    test_plain_document_has_empty_metadata()
+
+    print(f"\n{PASS_COUNT} passed, {FAIL_COUNT} failed")
+    return 0 if FAIL_COUNT == 0 else 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Implements t2972 — Phase 5 of the t2874 knowledge plane: lifts Markdoc tag attributes from `source.md` into per-node `metadata` fields in the PageIndex tree.

## What changed

**`.agents/scripts/pageindex_helpers.py`**
- `parse_tag_attrs(attrs_string)` — parses `key="val"` / `key='val'` / `key=bare` Markdoc attribute strings into a dict; coerces bare numeric values to Python `int`/`float`
- `extract_markdoc_tags(lines)` — tokenises all `{% ... %}` patterns from a list of lines; returns records with `tag`, `attrs`, `is_close`, `is_self_close`, `line_num`

**`.agents/scripts/pageindex-generator.py`**
- `build_tree_recursive` — gains private `_line_start`/`_line_end` fields and a `metadata: {}` field per node
- `_inject_tag_record(node, tag_rec)` — depth-first walk injects a tag record into the deepest node whose line range contains the tag's line
- `_strip_internal_fields(node)` — recursive cleanup removes `_line_start`/`_line_end` before JSON serialisation
- `build_headingless_result` — root node now includes `metadata`, `_line_start=0`, `_line_end`
- `build_pageindex_tree` — calls `extract_markdoc_tags`, injects all open tags into the tree, appends `cross_references` array when citation tags are present

## Injection rules

| Tag position | Target node |
|---|---|
| Before first heading (file-scope) | Root node `metadata` |
| Within a section (section-scope) | Deepest subtree node containing tag line |
| Inline within a section | Same depth-first rule |
| `{% citation ... /%}` | Node metadata **+** document-root `cross_references` array |

## Tests

`tests/test-pageindex-tag-lifting.py` — 38 tests covering all acceptance criteria.
All 38 tests pass locally.

## Acceptance criteria

- [x] File-scope `{% sensitivity tier="privileged" /%}` produces `metadata.sensitivity.tier == "privileged"` on root node
- [x] Section-scope tags appear on the subtree node, not the root
- [x] Citation tags produce a `cross_references` array at document root
- [x] ShellCheck zero violations (no shell files modified)

Resolves #21264

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.27 with claude-sonnet-4-6 spent 7m and 29,266 tokens on this as a headless worker.