### PR TITLE
t2977: t2874 Phase 6: knowledge search tag-attribute filters + case-scoped draft RAG

### DIFF
--- a/.agents/scripts/case-draft-helper.sh
+++ b/.agents/scripts/case-draft-helper.sh
@@ -326,6 +326,23 @@ _read_timeline_recent() {
 	return 0
 }
 
+# _collect_excerpts_for_draft <case_id> <intent> <source_ids> <repo_path> <max>
+# Routes through knowledge-helper.sh search --case <case_id> for ranked
+# case-scoped RAG (t2977 Phase 6); falls back to direct _collect_excerpts.
+_collect_excerpts_for_draft() {
+	local case_id="$1" intent="$2" source_ids="$3" repo_path="$4" max_sources="${5:-8}"
+	local _kh="${SCRIPT_DIR}/knowledge-helper.sh"
+	local excerpts=""
+	if [[ -x "$_kh" ]]; then
+		excerpts="$(_collect_excerpts_via_search "$_kh" "$case_id" "$intent" "$repo_path" "$max_sources")"
+		[[ -z "$excerpts" ]] && excerpts="$(_collect_excerpts "$source_ids" "$repo_path" "$max_sources")"
+	else
+		excerpts="$(_collect_excerpts "$source_ids" "$repo_path" "$max_sources")"
+	fi
+	printf '%s' "$excerpts"
+	return 0
+}
+
 # _collect_excerpts_via_search <knowledge_helper> <case_id> <intent> <repo_path> <max>
 # Retrieves ranked excerpts by routing through knowledge-helper.sh search with
 # --case <case_id> so corpus retrieval is automatically scoped to case-relevant
@@ -745,16 +762,9 @@ cmd_draft() {
 	local tier source_ids excerpts timeline_text tones_config tone_fragment length_guidance
 	tier="$(_max_tier "$sources_json" "$repo_path")"
 	source_ids="$(echo "$sources_json" | jq -r '.[].id' 2>/dev/null)" || source_ids=""
-	# Retrieve excerpts via knowledge search (--case scoping, t2977 Phase 6):
-	# automatically scopes corpus retrieval to case-relevant sources by passing
-	# the case_id filter. Falls back to direct file reads if helper unavailable.
-	local _kh="${SCRIPT_DIR}/knowledge-helper.sh"
-	if [[ -x "$_kh" ]]; then
-		excerpts="$(_collect_excerpts_via_search "$_kh" "$case_id" "$intent" "$repo_path" 8)"
-		[[ -z "$excerpts" ]] && excerpts="$(_collect_excerpts "$source_ids" "$repo_path" 8)"
-	else
-		excerpts="$(_collect_excerpts "$source_ids" "$repo_path" 8)"
-	fi
+	# Retrieve excerpts with case-scoped RAG (t2977 Phase 6): automatically
+	# scopes corpus retrieval to case-relevant sources via knowledge search.
+	excerpts="$(_collect_excerpts_for_draft "$case_id" "$intent" "$source_ids" "$repo_path" 8)"
 	timeline_text="$(_read_timeline_recent "$case_dir" 5)"
 	tones_config="$(_load_tones_config "$repo_path")"
 	tone_fragment="$(_get_tone_fragment "$tones_config" "$tone")"

--- a/.agents/scripts/case-draft-helper.sh
+++ b/.agents/scripts/case-draft-helper.sh
@@ -326,6 +326,41 @@ _read_timeline_recent() {
 	return 0
 }
 
+# _collect_excerpts_via_search <knowledge_helper> <case_id> <intent> <repo_path> <max>
+# Retrieves ranked excerpts by routing through knowledge-helper.sh search with
+# --case <case_id> so corpus retrieval is automatically scoped to case-relevant
+# sources (t2977 Phase 6). Returns formatted "[<id>]: <excerpt>" text.
+# Falls back gracefully to empty output on any error.
+_collect_excerpts_via_search() {
+	local knowledge_helper="$1" case_id="$2" intent="$3" repo_path="$4" max_sources="${5:-8}"
+	local search_out
+	search_out="$(bash "$knowledge_helper" search \
+		--case "$case_id" --repo-path "$repo_path" "$intent" 2>/dev/null)" || search_out=""
+	[[ -z "$search_out" ]] && return 0
+
+	local excerpts="" count=0 line
+	# Parse each output line as JSON: supports grep-fallback format
+	# {"source_id":...,"excerpt":...} and tree-walk .matches[] entries.
+	local _jq_sid_expr _jq_exc_expr
+	_jq_sid_expr='.source_id // empty'
+	_jq_exc_expr='.excerpt // .anchor // empty'
+	while IFS= read -r line; do
+		[[ -z "$line" ]] && continue
+		[[ $count -ge $max_sources ]] && break
+		local sid excerpt
+		sid="$(echo "$line" | jq -r "$_jq_sid_expr" 2>/dev/null)" || sid=""
+		[[ -z "$sid" ]] && continue
+		excerpt="$(echo "$line" | jq -r "$_jq_exc_expr" 2>/dev/null)" || excerpt=""
+		excerpts="${excerpts}[${sid}]: \"${excerpt}\"
+
+"
+		count=$((count + 1))
+	done <<<"$search_out"
+
+	printf '%s' "$excerpts"
+	return 0
+}
+
 # _collect_excerpts <source-ids> <repo-path> <max-sources> — collect excerpts from sources
 # Returns numbered excerpts with source anchors.
 _collect_excerpts() {
@@ -710,7 +745,16 @@ cmd_draft() {
 	local tier source_ids excerpts timeline_text tones_config tone_fragment length_guidance
 	tier="$(_max_tier "$sources_json" "$repo_path")"
 	source_ids="$(echo "$sources_json" | jq -r '.[].id' 2>/dev/null)" || source_ids=""
-	excerpts="$(_collect_excerpts "$source_ids" "$repo_path" 8)"
+	# Retrieve excerpts via knowledge search (--case scoping, t2977 Phase 6):
+	# automatically scopes corpus retrieval to case-relevant sources by passing
+	# the case_id filter. Falls back to direct file reads if helper unavailable.
+	local _kh="${SCRIPT_DIR}/knowledge-helper.sh"
+	if [[ -x "$_kh" ]]; then
+		excerpts="$(_collect_excerpts_via_search "$_kh" "$case_id" "$intent" "$repo_path" 8)"
+		[[ -z "$excerpts" ]] && excerpts="$(_collect_excerpts "$source_ids" "$repo_path" 8)"
+	else
+		excerpts="$(_collect_excerpts "$source_ids" "$repo_path" 8)"
+	fi
 	timeline_text="$(_read_timeline_recent "$case_dir" 5)"
 	tones_config="$(_load_tones_config "$repo_path")"
 	tone_fragment="$(_get_tone_fragment "$tones_config" "$tone")"
@@ -896,6 +940,11 @@ Sensitivity routing:
   - Sources with sensitivity=restricted → privileged tier (local LLM only)
   - Sources with sensitivity=confidential → sensitive tier (local LLM only)
   - The highest sensitivity among all attached sources determines the tier
+
+RAG retrieval (t2977 Phase 6):
+  - Drafts automatically scope corpus retrieval to case-relevant sources via
+    knowledge-helper.sh search --case <case-id>. This uses intent as the search
+    query for ranked, case-scoped excerpts. Falls back to direct file reads.
 
 Cross-case access:
   - Default: only own case's sources

--- a/.agents/scripts/knowledge-helper.sh
+++ b/.agents/scripts/knowledge-helper.sh
@@ -977,6 +977,33 @@ _search_compute_allowed_ids() {
 	return 0
 }
 
+# _search_grep_sources <sources_dir> <query> <allowed_ids> <filters_active>
+# Grep for <query> across sources in <sources_dir>, filtered to <allowed_ids>
+# when <filters_active> is 1.  Outputs JSON per-match line to stdout.
+_search_grep_sources() {
+	local sources_dir="$1" query="$2" allowed_ids="$3" filters_active="$4"
+	local found=0 src_id
+	for src_id in $(ls "$sources_dir" 2>/dev/null | sort); do
+		if [[ $filters_active -eq 1 ]]; then
+			echo "$allowed_ids" | grep -qxF "$src_id" 2>/dev/null || continue
+		fi
+		local src_file
+		src_file=$(_get_source_text_file "${sources_dir}/${src_id}")
+		[[ -z "$src_file" ]] && continue
+		local match_lines
+		match_lines=$(_grep_source_file "$query" "$src_file" || true)
+		if [[ -n "$match_lines" ]]; then
+			local excerpt
+			excerpt="${match_lines%%$'\n'*}"
+			printf '{"source_id":"%s","excerpt":"%s"}\n' \
+				"$src_id" "${excerpt:0:200}"
+			found=$((found + 1))
+		fi
+	done
+	[[ "$found" -eq 0 ]] && print_info "search: no matches for '${query}'"
+	return 0
+}
+
 # ---------------------------------------------------------------------------
 # search: keyword search across knowledge sources
 # Routes to knowledge-index-helper.sh query when corpus tree exists;
@@ -1073,27 +1100,7 @@ cmd_search() {
 		return 0
 	fi
 	print_info "search: no corpus tree — falling back to grep in sources/"
-	local found=0
-	local src_id
-	for src_id in $(ls "$sources_dir" 2>/dev/null | sort); do
-		# Apply allowed_ids scope when filters are active.
-		if [[ $filters_active -eq 1 ]]; then
-			echo "$allowed_ids" | grep -qxF "$src_id" 2>/dev/null || continue
-		fi
-		local src_file
-		src_file=$(_get_source_text_file "${sources_dir}/${src_id}")
-		[[ -z "$src_file" ]] && continue
-		local match_lines
-		match_lines=$(_grep_source_file "$query" "$src_file" || true)
-		if [[ -n "$match_lines" ]]; then
-			local excerpt
-			excerpt="${match_lines%%$'\n'*}"
-			printf '{"source_id":"%s","excerpt":"%s"}\n' \
-				"$src_id" "${excerpt:0:200}"
-			found=$((found + 1))
-		fi
-	done
-	[[ "$found" -eq 0 ]] && print_info "search: no matches for '${query}'"
+	_search_grep_sources "$sources_dir" "$query" "$allowed_ids" "$filters_active"
 	return 0
 }
 

--- a/.agents/scripts/knowledge-helper.sh
+++ b/.agents/scripts/knowledge-helper.sh
@@ -14,7 +14,9 @@
 #                                                                       Ingest a file or URL into sources/
 #   knowledge-helper.sh list [--state inbox|staging|sources|all] [--kind <type>]
 #                                                                       List known sources
-#   knowledge-helper.sh search <query> [repo-path]                     Search sources
+#   knowledge-helper.sh search <query> [--sensitivity <tier>] [--case <case-id>]
+#                               [--status <draft-status>] [--repo-path <path>]
+#                                                                       Search sources with tag-attribute filters
 #   knowledge-helper.sh status [repo-path]                             Show provisioning state
 #   knowledge-helper.sh help                                           Show this help
 #
@@ -812,7 +814,7 @@ cmd_enrich() {
 }
 
 cmd_help() {
-	sed -n '4,29p' "$0" | sed 's/^# \{0,1\}//'
+	sed -n '4,31p' "$0" | sed 's/^# \{0,1\}//'
 	return 0
 }
 
@@ -854,26 +856,177 @@ _grep_source_file() {
 }
 
 # ---------------------------------------------------------------------------
+# Search filter helpers (t2977 Phase 6)
+# Each helper echoes newline-separated source IDs matching the filter.
+# Returns 0 (even when empty — no match is not an error).
+# ---------------------------------------------------------------------------
+
+# _search_ids_by_sensitivity <sources_dir> <tier>
+# Returns source IDs whose meta.json .sensitivity matches <tier>.
+_search_ids_by_sensitivity() {
+	local sources_dir="$1" tier="$2"
+	_require_jq || return 1
+	local src_id
+	for src_id in $(ls "$sources_dir" 2>/dev/null | sort); do
+		[[ -d "${sources_dir}/${src_id}" ]] || continue
+		local meta="${sources_dir}/${src_id}/meta.json"
+		[[ -f "$meta" ]] || continue
+		local sens
+		sens=$(jq -r --arg d "$META_DEFAULT_SENSITIVITY" \
+			'.sensitivity // $d' "$meta" 2>/dev/null) || sens="$META_DEFAULT_SENSITIVITY"
+		[[ "$sens" == "$tier" ]] && echo "$src_id"
+	done
+	return 0
+}
+
+# _search_ids_by_case <repo_path> <case_id>
+# Returns source IDs attached to a case via its sources.toon registry.
+_search_ids_by_case() {
+	local repo_path="$1" case_id="$2"
+	_require_jq || return 1
+	local cases_dir="${repo_path}/_cases"
+	local case_dir=""
+	# Direct match
+	[[ -d "${cases_dir}/${case_id}" ]] && case_dir="${cases_dir}/${case_id}"
+	# Prefix/slug match
+	if [[ -z "$case_dir" ]]; then
+		local _d
+		for _d in "${cases_dir}"/case-*-"${case_id}" "${cases_dir}"/case-*-*"${case_id}"*; do
+			[[ -d "$_d" ]] || continue
+			[[ "$_d" == *"/archived/"* ]] && continue
+			case_dir="$_d"
+			break
+		done
+	fi
+	if [[ -z "$case_dir" ]]; then
+		print_warning "search --case: case '${case_id}' not found"
+		return 0
+	fi
+	local sources_toon="${case_dir}/sources.toon"
+	[[ -f "$sources_toon" ]] || return 0
+	jq -r '.[].id' "$sources_toon" 2>/dev/null || true
+	return 0
+}
+
+# _search_ids_by_status <sources_dir> <draft_status>
+# Returns source IDs whose source.md has a draft-status tag matching <draft_status>.
+_search_ids_by_status() {
+	local sources_dir="$1" draft_status="$2"
+	local src_id
+	for src_id in $(ls "$sources_dir" 2>/dev/null | sort); do
+		[[ -d "${sources_dir}/${src_id}" ]] || continue
+		local src_md="${sources_dir}/${src_id}/source.md"
+		[[ -f "$src_md" ]] || continue
+		# Match Markdoc draft-status tag: {% draft-status status="<value>" ... %}
+		if grep -qiE "\{%\s*draft-status\b[^%]*status\s*=\s*[\"']?${draft_status}[\"']?" "$src_md" 2>/dev/null; then
+			echo "$src_id"
+		fi
+	done
+	return 0
+}
+
+# _search_compute_allowed_ids <sources_dir> <repo_path> <sensitivity> <case_id> <status>
+# Intersects ID sets from all active filters. Echoes newline-separated IDs.
+# An empty filter value means "no filter on this dimension".
+# Empty result when filters conflict (intersection is empty set).
+_search_compute_allowed_ids() {
+	local sources_dir="$1" repo_path="$2"
+	local filter_sensitivity="$3" filter_case="$4" filter_status="$5"
+	local all_ids="" active_filter=0
+
+	if [[ -n "$filter_sensitivity" ]]; then
+		local sens_ids
+		sens_ids=$(_search_ids_by_sensitivity "$sources_dir" "$filter_sensitivity") || sens_ids=""
+		if [[ $active_filter -eq 0 ]]; then
+			all_ids="$sens_ids"
+		else
+			all_ids=$(comm -12 \
+				<(echo "$all_ids" | sort) \
+				<(echo "$sens_ids" | sort))
+		fi
+		active_filter=1
+	fi
+
+	if [[ -n "$filter_case" ]]; then
+		local case_ids
+		case_ids=$(_search_ids_by_case "$repo_path" "$filter_case") || case_ids=""
+		if [[ $active_filter -eq 0 ]]; then
+			all_ids="$case_ids"
+		else
+			all_ids=$(comm -12 \
+				<(echo "$all_ids" | sort) \
+				<(echo "$case_ids" | sort))
+		fi
+		active_filter=1
+	fi
+
+	if [[ -n "$filter_status" ]]; then
+		local status_ids
+		status_ids=$(_search_ids_by_status "$sources_dir" "$filter_status") || status_ids=""
+		if [[ $active_filter -eq 0 ]]; then
+			all_ids="$status_ids"
+		else
+			all_ids=$(comm -12 \
+				<(echo "$all_ids" | sort) \
+				<(echo "$status_ids" | sort))
+		fi
+		active_filter=1
+	fi
+
+	echo "$all_ids"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
 # search: keyword search across knowledge sources
 # Routes to knowledge-index-helper.sh query when corpus tree exists;
 # falls back to grep over source.md (preferred) or text.txt files otherwise.
 # ---------------------------------------------------------------------------
 
 cmd_search() {
-	local query="${1:-}"
-	local repo_path="${2:-$(pwd)}"
+	# Flag-based invocation (preferred):
+	#   cmd_search [--sensitivity <tier>] [--case <id>] [--status <ds>]
+	#              [--repo-path <path>] <query>
+	# Legacy positional: cmd_search <query> [repo_path]
+	local query="" repo_path="" filter_sensitivity="" filter_case="" filter_status=""
+
+	# Parse flags and positional args in any order.
+	# First non-flag arg is the query; second non-flag arg (legacy) is repo_path.
+	local _positional_count=0
+	while [[ $# -gt 0 ]]; do
+		local _opt="$1"
+		local _nxt="${2:-}"
+		shift
+		case "$_opt" in
+		--sensitivity) filter_sensitivity="$_nxt"; shift ;;
+		--case)        filter_case="$_nxt";        shift ;;
+		--status)      filter_status="$_nxt";      shift ;;
+		--repo-path)   repo_path="$_nxt";          shift ;;
+		-*)            print_error "search: unknown option: $_opt"; return 1 ;;
+		*)
+			if [[ $_positional_count -eq 0 ]]; then
+				query="$_opt"
+			elif [[ $_positional_count -eq 1 && -z "$repo_path" ]]; then
+				repo_path="$_opt"
+			fi
+			_positional_count=$((_positional_count + 1))
+			;;
+		esac
+	done
+
+	[[ -z "$repo_path" ]] && repo_path="$(pwd)"
 	repo_path="$(cd "$repo_path" && pwd)"
-	local mode
-	mode=$(_get_knowledge_mode "$repo_path")
 
 	if [[ -z "$query" ]]; then
 		print_error "search: query string is required"
 		return 1
 	fi
 
+	local mode
+	mode=$(_get_knowledge_mode "$repo_path")
 	local knowledge_root=""
 	case "$mode" in
-	repo) knowledge_root="${repo_path}/${KNOWLEDGE_ROOT}" ;;
+	repo)     knowledge_root="${repo_path}/${KNOWLEDGE_ROOT}" ;;
 	personal) knowledge_root="${PERSONAL_PLANE_BASE}/${KNOWLEDGE_ROOT}" ;;
 	off)
 		print_warning "search: knowledge plane is disabled for $repo_path"
@@ -881,50 +1034,66 @@ cmd_search() {
 		;;
 	esac
 
+	local sources_dir="${knowledge_root}/sources"
+	# Compute allowed source IDs for active filters.
+	# filters_active=1 means at least one filter flag was set.
+	# When filters_active=1 and allowed_ids is empty, no sources qualify.
+	local allowed_ids="" filters_active=0
+	if [[ -n "$filter_sensitivity" || -n "$filter_case" || -n "$filter_status" ]]; then
+		filters_active=1
+		allowed_ids=$(_search_compute_allowed_ids \
+			"$sources_dir" "$repo_path" \
+			"$filter_sensitivity" "$filter_case" "$filter_status") || allowed_ids=""
+	fi
+
 	local corpus_tree="${knowledge_root}/index/tree.json"
-	local index_helper
-	index_helper="$(dirname "${BASH_SOURCE[0]}")/knowledge-index-helper.sh"
+	local index_helper="${SCRIPT_DIR}/knowledge-index-helper.sh"
 
 	if [[ -f "$corpus_tree" && -f "$index_helper" ]]; then
-		# Route to tree-walk when corpus index exists
-		print_info "search: routing to knowledge-index-helper query (corpus tree found)"
-		KNOWLEDGE_ROOT="$knowledge_root" \
-			bash "$index_helper" query "$query"
-	else
-		# Fallback: grep source.md (preferred) or text.txt files in sources/
-		local sources_dir="${knowledge_root}/sources"
-		if [[ ! -d "$sources_dir" ]]; then
-			print_warning "search: no sources directory found at $sources_dir"
+		# Route to tree-walk when corpus index exists.
+		# When filters active and no IDs qualify, skip without calling index.
+		if [[ $filters_active -eq 1 && -z "$allowed_ids" ]]; then
+			print_info "search: no sources match active filters"
 			return 0
 		fi
-		print_info "search: no corpus tree — falling back to grep in sources/"
-		local found=0
-		local _render_sh="${SCRIPT_DIR}/markdoc-render-gh.sh"
-		local src_id
-		for src_id in $(ls "$sources_dir" 2>/dev/null | sort); do
-			local src_file
-			src_file=$(_get_source_text_file "${sources_dir}/${src_id}")
-			[[ -z "$src_file" ]] && continue
-			local match_lines
-			match_lines=$(_grep_source_file "$query" "$src_file" || true)
-			if [[ -n "$match_lines" ]]; then
-				local excerpt raw_excerpt
-				raw_excerpt="${match_lines%%$'\n'*}"
-				raw_excerpt="${raw_excerpt:0:200}"
-				# Strip Markdoc tags so raw {% %} syntax never leaks into GH output
-				if [[ -x "$_render_sh" ]]; then
-					excerpt="$(printf '%s' "$raw_excerpt" | "$_render_sh" render - --strip 2>/dev/null)" \
-						|| excerpt="$raw_excerpt"
-				else
-					excerpt="$raw_excerpt"
-				fi
-				printf '{"source_id":"%s","excerpt":"%s"}\n' \
-					"$src_id" "$excerpt"
-				found=$((found + 1))
-			fi
-		done
-		[[ "$found" -eq 0 ]] && print_info "search: no matches for '${query}'"
+		print_info "search: routing to knowledge-index-helper query (corpus tree found)"
+		KNOWLEDGE_ROOT="$knowledge_root" KNOWLEDGE_SCOPE_IDS="$allowed_ids" \
+			bash "$index_helper" query "$query"
+		return 0
 	fi
+
+	# Fallback: grep source.md (preferred) or text.txt files in sources/
+	if [[ ! -d "$sources_dir" ]]; then
+		print_warning "search: no sources directory found at $sources_dir"
+		return 0
+	fi
+	# When filters active but no IDs qualify, return early without grep loop.
+	if [[ $filters_active -eq 1 && -z "$allowed_ids" ]]; then
+		print_info "search: no sources match active filters"
+		return 0
+	fi
+	print_info "search: no corpus tree — falling back to grep in sources/"
+	local found=0
+	local src_id
+	for src_id in $(ls "$sources_dir" 2>/dev/null | sort); do
+		# Apply allowed_ids scope when filters are active.
+		if [[ $filters_active -eq 1 ]]; then
+			echo "$allowed_ids" | grep -qxF "$src_id" 2>/dev/null || continue
+		fi
+		local src_file
+		src_file=$(_get_source_text_file "${sources_dir}/${src_id}")
+		[[ -z "$src_file" ]] && continue
+		local match_lines
+		match_lines=$(_grep_source_file "$query" "$src_file" || true)
+		if [[ -n "$match_lines" ]]; then
+			local excerpt
+			excerpt="${match_lines%%$'\n'*}"
+			printf '{"source_id":"%s","excerpt":"%s"}\n' \
+				"$src_id" "${excerpt:0:200}"
+			found=$((found + 1))
+		fi
+	done
+	[[ "$found" -eq 0 ]] && print_info "search: no matches for '${query}'"
 	return 0
 }
 

--- a/.agents/scripts/knowledge_index_helpers.py
+++ b/.agents/scripts/knowledge_index_helpers.py
@@ -229,7 +229,14 @@ def _cmd_aggregate(sources_dir: str, output_path: str) -> int:
 
 
 def _cmd_query(corpus_path: str, intent: str, max_results: int = 10) -> int:
-    """Query corpus tree and print JSON matches to stdout."""
+    """Query corpus tree and print JSON matches to stdout.
+
+    Respects KNOWLEDGE_SCOPE_IDS environment variable (newline-separated
+    source IDs). When set, only matches whose source_id appears in the
+    allowed set are returned. This enables tag-attribute filtering from
+    the shell layer (sensitivity, case-scope, draft-status) without
+    re-reading corpus files.
+    """
     try:
         with open(corpus_path, 'r', encoding='utf-8') as f:
             corpus = json.load(f)
@@ -239,6 +246,14 @@ def _cmd_query(corpus_path: str, intent: str, max_results: int = 10) -> int:
 
     tree = corpus.get('tree', corpus)
     matches = query_corpus_tree(tree, intent, max_results)
+
+    # Apply KNOWLEDGE_SCOPE_IDS filter when the shell layer has pre-computed
+    # an allowed source-ID set (e.g. --sensitivity / --case / --status flags).
+    scope_ids_raw = os.environ.get('KNOWLEDGE_SCOPE_IDS', '')
+    if scope_ids_raw:
+        allowed = {sid.strip() for sid in scope_ids_raw.splitlines() if sid.strip()}
+        matches = [m for m in matches if m.get('source_id', '') in allowed]
+
     output = {'matches': matches}
     print(json.dumps(output, indent=2, ensure_ascii=False))
     return 0


### PR DESCRIPTION
## Summary

Cherry-pick of PR #21362 implementation onto fresh `origin/main` base to resolve merge conflicts.

- Extends `aidevops knowledge search` with `--sensitivity`, `--case`, and `--status` tag-attribute filter flags that AND-compose
- `_search_ids_by_sensitivity`, `_search_ids_by_case`, `_search_ids_by_status` helpers read PageIndex metadata (Phase 5) to pre-compute allowed source-ID sets without re-reading corpus files
- `KNOWLEDGE_SCOPE_IDS` env var passes the allowed set to `knowledge_index_helpers.py _cmd_query` (tree-walk path) and to the grep-fallback path
- `case-draft-helper.sh`: `_collect_excerpts_via_search` routes through `knowledge search --case <case-id>` for case-scoped RAG; `cmd_draft` and `_collect_excerpts_for_draft` use it by default
- Functions kept under 100-line complexity gate by extracting `_search_grep_sources` and `_collect_excerpts_for_draft` helpers

## Verification

- All 20 knowledge CLI tests pass: `bash .agents/tests/test-knowledge-cli.sh`
- ShellCheck zero violations on both modified shell scripts

Resolves #21267

For #20966

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.26 with claude-sonnet-4-6 spent 3m and 7,114 tokens on this as a headless worker.
