### PR TITLE
GH#21004: fix privacy_scan_text — last-line read, ERE escaping, single-pass full-slug matching

### DIFF
--- a/.agents/scripts/privacy-guard-helper.sh
+++ b/.agents/scripts/privacy-guard-helper.sh
@@ -275,8 +275,34 @@ privacy_scan_text() {
 	fi
 
 	local hits=0
-	local slug owner basename
-	while IFS= read -r slug; do
+	local matched_full_slugs=""
+
+	# Phase 1: Full-slug fixed-string matching — single grep -F -f pass over all
+	# owner/repo entries at once. Reduces O(N) grep forks (one per slug) to one
+	# call regardless of slug count. Only lines with '/' are full slugs; single-
+	# token (legacy) entries are handled exclusively in Phase 2 below.
+	local full_slugs_tmp
+	full_slugs_tmp=$(mktemp) || return 2
+	grep '/' "$slugs_file" 2>/dev/null >"$full_slugs_tmp" || true
+	if [[ -s "$full_slugs_tmp" ]]; then
+		matched_full_slugs=$(printf '%s' "$text" | grep -oF -f "$full_slugs_tmp" 2>/dev/null | sort -u || true)
+		if [[ -n "$matched_full_slugs" ]]; then
+			local match
+			while IFS= read -r match; do
+				[[ -z "$match" ]] && continue
+				printf '%s\n' "$match"
+				hits=$((hits + 1))
+			done <<< "$matched_full_slugs"
+		fi
+	fi
+	rm -f "$full_slugs_tmp"
+
+	# Phase 2: Bare-basename word-boundary matching — per-slug loop.
+	# Word-boundary patterns are slug-specific (variable basename length guard,
+	# per-slug output format) and require per-slug ERE calls. Full slugs already
+	# emitted in Phase 1 are skipped to prevent duplicate hits.
+	local slug owner basename escaped_basename
+	while IFS= read -r slug || [[ -n "$slug" ]]; do
 		# Skip blanks and comment lines.
 		[[ -z "$slug" || "$slug" == \#* ]] && continue
 		# Trim leading/trailing whitespace.
@@ -293,18 +319,21 @@ privacy_scan_text() {
 		fi
 		[[ -z "$basename" ]] && continue
 
-		# Form 1: full slug fixed-string match (only if owner present).
-		if [[ -n "$owner" ]] && printf '%s' "$text" | grep -qF "$slug" 2>/dev/null; then
-			printf '%s\n' "$slug"
-			hits=$((hits + 1))
+		# If the full slug was already matched in Phase 1, skip to avoid duplicate output.
+		if [[ -n "$owner" && -n "$matched_full_slugs" ]] &&
+			printf '%s\n' "$matched_full_slugs" | grep -qF "$slug" 2>/dev/null; then
 			continue
 		fi
 
 		# Form 2: bare basename with word boundaries — only for distinctive lengths.
 		if [[ ${#basename} -ge "$PRIVACY_BARE_BASENAME_MIN_LEN" ]]; then
+			# Escape regex metacharacters in basename for ERE. GitHub repo names can
+			# contain '.' (e.g. "my.project"), which is a special char in ERE —
+			# escaping prevents false positives from matching unintended characters.
+			escaped_basename=$(printf '%s' "$basename" | sed 's/\./\\./g')
 			# Word boundary regex: must NOT be flanked by [a-zA-Z0-9_-].
 			# Note: we use grep -E (POSIX ERE), not PCRE, so \b is unreliable.
-			if printf '%s' "$text" | grep -qE "(^|[^a-zA-Z0-9_-])${basename}([^a-zA-Z0-9_-]|$)" 2>/dev/null; then
+			if printf '%s' "$text" | grep -qE "(^|[^a-zA-Z0-9_-])${escaped_basename}([^a-zA-Z0-9_-]|$)" 2>/dev/null; then
 				if [[ -n "$owner" ]]; then
 					printf '%s (basename of %s)\n' "$basename" "$slug"
 				else

--- a/.agents/scripts/test-privacy-guard.sh
+++ b/.agents/scripts/test-privacy-guard.sh
@@ -449,6 +449,81 @@ else
 	fi
 fi
 
+# =============================================================================
+# privacy_scan_text tests (GH#21004 — review feedback on PR #20974)
+# =============================================================================
+
+TEXT_SLUGS_FILE="${TMP}/text-slugs.txt"
+printf 'testorg/private-mirror\ntestorg/local-only\n' >"$TEXT_SLUGS_FILE"
+
+# Test: full slug match in text body → returns 1 with slug on stdout
+hits=$(privacy_scan_text "See testorg/private-mirror for details" "$TEXT_SLUGS_FILE")
+rc=$?
+if [[ "$rc" -eq 1 ]] && printf '%s' "$hits" | grep -qF 'testorg/private-mirror'; then
+	pass "scan_text: full slug in text → flagged"
+else
+	fail "scan_text: full slug in text should be flagged (rc=$rc hits=$hits)"
+fi
+
+# Test: clean text → returns 0, no hits
+hits=$(privacy_scan_text "See testorg/public-repo for details" "$TEXT_SLUGS_FILE")
+rc=$?
+if [[ "$rc" -eq 0 && -z "$hits" ]]; then
+	pass "scan_text: clean text → not flagged"
+else
+	fail "scan_text: clean text should not be flagged (rc=$rc hits=$hits)"
+fi
+
+# Test: bare basename word-boundary match → returns 1
+hits=$(privacy_scan_text "Syncing private-mirror with upstream" "$TEXT_SLUGS_FILE")
+rc=$?
+if [[ "$rc" -eq 1 ]] && printf '%s' "$hits" | grep -q 'private-mirror'; then
+	pass "scan_text: bare basename with word boundaries → flagged"
+else
+	fail "scan_text: bare basename should be flagged (rc=$rc hits=$hits)"
+fi
+
+# Test: bare basename embedded inside a longer token → NOT flagged (word boundary)
+hits=$(privacy_scan_text "syncing myprivate-mirrorcopy with upstream" "$TEXT_SLUGS_FILE")
+rc=$?
+if [[ "$rc" -eq 0 ]]; then
+	pass "scan_text: basename embedded in longer token → not flagged (word boundary guard)"
+else
+	fail "scan_text: basename embedded in longer token should not be flagged (rc=$rc hits=$hits)"
+fi
+
+# Test: GH#21004 — repo name with '.' (ERE metachar) does not false-positive
+# "local.only" should not match "local-only" or any arbitrary char.
+DOTSLUG_FILE="${TMP}/dot-slug.txt"
+printf 'testorg/my.project\n' >"$DOTSLUG_FILE"
+hits=$(privacy_scan_text "discussing myXproject integration" "$DOTSLUG_FILE")
+rc=$?
+if [[ "$rc" -eq 0 ]]; then
+	pass "scan_text: dot in repo name escaped — no false-positive on non-dot char"
+else
+	fail "scan_text: dot in repo name must be escaped to prevent false-positive (rc=$rc hits=$hits)"
+fi
+
+# Test: GH#21004 — repo name with '.' correctly matches literal dot
+hits=$(privacy_scan_text "discussing my.project integration" "$DOTSLUG_FILE")
+rc=$?
+if [[ "$rc" -eq 1 ]] && printf '%s' "$hits" | grep -q 'my\.project\|my.project'; then
+	pass "scan_text: dot in repo name escaped — literal dot still matches"
+else
+	fail "scan_text: literal dot in repo name should still match (rc=$rc hits=$hits)"
+fi
+
+# Test: GH#21004 — last-line handling (slugs file without trailing newline)
+NONL_FILE="${TMP}/no-newline-slugs.txt"
+printf 'testorg/no-newline-slug' >"$NONL_FILE"   # intentionally no trailing \n
+hits=$(privacy_scan_text "see testorg/no-newline-slug for details" "$NONL_FILE")
+rc=$?
+if [[ "$rc" -eq 1 ]] && printf '%s' "$hits" | grep -qF 'testorg/no-newline-slug'; then
+	pass "scan_text: last line without trailing newline is processed"
+else
+	fail "scan_text: last line without trailing newline should be processed (rc=$rc hits=$hits)"
+fi
+
 # -----------------------------------------------------------------------------
 # Summary
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Addresses three review findings from gemini and augment on PR #20974 (`privacy_scan_text` in `.agents/scripts/privacy-guard-helper.sh`):

1. **Last-line handling** — `while IFS= read -r slug` now uses `|| [[ -n "$slug" ]]` so the last line of the slugs file is processed even when it lacks a trailing newline.

2. **ERE metacharacter escaping** — GitHub repo names can contain `.` (e.g. `my.project`), which is a special char in POSIX ERE. Interpolating `${basename}` unescaped into the word-boundary `grep -E` pattern could match any char instead of a literal dot. Fixed via `sed 's/\./\\./g'` before interpolation — prevents false positives and false negatives for dot-named repos.

3. **Single-pass full-slug matching** — restructured `privacy_scan_text` into two phases. Phase 1 uses a single `grep -F -f` call against a temp file of all `owner/repo` slugs, replacing the O(N) per-slug grep loop for full-slug matching. Phase 2 retains per-slug ERE for bare-basename word-boundary matching. Full slugs matched in Phase 1 are skipped in Phase 2 to prevent duplicate output.

## Changes

- `EDIT: .agents/scripts/privacy-guard-helper.sh` — restructured `privacy_scan_text` (fixes all three findings)
- `EDIT: .agents/scripts/test-privacy-guard.sh` — 7 new test cases covering full slug detection, clean text, bare basename word boundary, embedded-token false-positive guard, dot-in-name escaping (both directions), and last-line-without-newline handling

## Verification

```bash
GIT_CONFIG_GLOBAL=/dev/null GIT_CONFIG_SYSTEM=/dev/null bash .agents/scripts/test-privacy-guard.sh
# All 24 test(s) passed

shellcheck .agents/scripts/privacy-guard-helper.sh
shellcheck .agents/scripts/test-privacy-guard.sh
# zero violations
```

Resolves #21004

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.27 with claude-sonnet-4-6 spent 7m and 25,672 tokens on this as a headless worker. Overall, 1d 1h since this issue was created.
