### PR TITLE
GH#21363: tighten return type hints in email_poll.py helper functions

### DIFF
--- a/.agents/scripts/email_poll.py
+++ b/.agents/scripts/email_poll.py
@@ -166,7 +166,7 @@ def _connect_imap(host: str, port: int, user: str, password: str) -> imaplib.IMA
 
 def _search_uids_since(
     conn: imaplib.IMAP4_SSL, folder: str, last_uid: int, max_uids: int = 0
-) -> list:
+) -> list[int]:
     """SELECT folder and return UIDs > last_uid, optionally capped at max_uids.
 
     Returns a plain list[int]. Raises RuntimeError on IMAP errors.
@@ -201,7 +201,7 @@ def _search_uids_since(
 
 def _parse_fetch_response(
     fetch_data: list, valid_uids: list, last_uid: int = 0
-) -> list:
+) -> list[tuple[int, bytes]]:
     """Parse an imaplib RFC822 FETCH response into (uid, raw_bytes) tuples.
 
     Returns list[tuple[int, bytes]], sorted by UID ascending.
@@ -230,7 +230,7 @@ def _parse_fetch_response(
 
 def _uid_fetch_since(
     conn: imaplib.IMAP4_SSL, folder: str, last_uid: int, max_uids: int = 0
-) -> list:
+) -> list[tuple[int, bytes]]:
     """Fetch messages with UID > last_uid in folder.
 
     Args:
@@ -253,7 +253,7 @@ def _uid_fetch_since(
 
 def _uid_fetch_since_date(
     conn: imaplib.IMAP4_SSL, folder: str, since_date: str
-) -> list:
+) -> list[tuple[int, bytes]]:
     """Fetch all messages in folder with INTERNALDATE >= since_date.
 
     since_date: ISO date string, e.g. '2026-01-01'.


### PR DESCRIPTION
## Summary

Fixed 4 generic list return type hints: _search_uids_since -> list[int], _parse_fetch_response/_uid_fetch_since/_uid_fetch_since_date -> list[tuple[int, bytes]]. All match the actual return types and align with specific type hints elsewhere in the file.

## Files Changed

.agents/scripts/email_poll.py

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Python AST parse confirms syntax valid. Verified all 4 functions now have specific types matching their documented return values.

Resolves #21363


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-sonnet-4-6 spent 1m and 3,367 tokens on this as a headless worker.