### PR TITLE
t2983: Fix C — resolve V6 headless contract worktree contradiction

### DIFF
--- a/.agents/reference/worker-branch-classification.md
+++ b/.agents/reference/worker-branch-classification.md
@@ -173,20 +173,35 @@ into) with the issue number in its branch name will be discovered. The
 `work_dir` fallback preserves current behaviour when no
 issue-numbered worktree exists.
 
-### Fix C — Resolve the V6 contract contradiction
+### Fix C — Resolve the V6 contract contradiction (IMPLEMENTED — t2983 / GH#21355)
 
-`headless-runtime-lib.sh:418-460` tells the worker both not to use
-`worktree-helper.sh` and to use it as a fallback. Pick one:
+**Status:** Implemented. Path 1 (recommended) chosen.
 
-- If pre-creation must always succeed (recommended), forbid worker
-  worktree creation absolutely and have headless-runtime exit with a
-  clear error if `WORKER_WORKTREE_PATH` is unset.
-- If pre-creation can fail, document the worker-creates-own-worktree
-  path explicitly, *and* have the worker echo the new path into a
-  well-known file that `_worker_produced_output` reads.
+**Path taken:** Pre-creation must always succeed; worker never creates worktrees.
 
-The current contract makes Mode B nearly inevitable on any
-pre-creation hiccup.
+**What changed (PR for GH#21355):**
+
+1. `headless-runtime-lib.sh::append_worker_headless_contract` — contract bumped
+   from V6 to V7. The contradictory "If not set, create a worktree yourself via
+   `worktree-helper.sh add`" clause is removed. The prohibition is now
+   unconditional with rationale: "Pre-creation is guaranteed by the dispatcher
+   (GH#21353 / t2983 Fix C). If WORKER_WORKTREE_PATH is unset, the headless
+   runtime has already aborted — you are not running."
+
+2. `headless-runtime-helper.sh::_cmd_run_prepare` — early guard added: if
+   `WORKER_ISSUE_NUMBER` is set (worker dispatch) but `WORKER_WORKTREE_PATH` is
+   unset, the function logs a fatal error and returns non-zero immediately.
+   This turns a silent mis-dispatch into an observable error.
+
+3. `.agents/scripts/tests/test-headless-contract-clarity.sh` — new test that
+   verifies the emitted contract does NOT contain both "Do NOT call" and
+   "create a worktree" clauses simultaneously, and that V7 is the active
+   contract version.
+
+**Depends on:** Fix A (GH#21353, t2981) — merged PR #21359 on 2026-04-27.
+Without Fix A's non-silent pre-creation failure, WORKER_WORKTREE_PATH could
+still be unset at worker launch time. Fix C's guard in `_cmd_run_prepare`
+catches this as an explicit fatal rather than a silent wrong-directory error.
 
 ## Diagnosing in production
 

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -1464,6 +1464,16 @@ _cmd_run_prepare() {
 	local session_key="$1"
 	local work_dir="$2"
 
+	# t2983 Fix C: Worker-role guard — WORKER_WORKTREE_PATH must be set.
+	# After GH#21353 (Fix A), the dispatcher never launches a worker when
+	# pre-creation fails. If WORKER_WORKTREE_PATH is somehow unset here despite
+	# WORKER_ISSUE_NUMBER being set, a dispatcher bug bypassed pre-creation.
+	# Abort immediately rather than proceeding in the canonical repo on main.
+	if [[ -n "${WORKER_ISSUE_NUMBER:-}" && -z "${WORKER_WORKTREE_PATH:-}" ]]; then
+		printf '[fatal] WORKER_WORKTREE_PATH unset — pre-creation skipped or failed silently; aborting per t2980 Fix C\n' >&2
+		return 1
+	fi
+
 	# GH#20542: Export DISPATCH_REPO_SLUG BEFORE arming the EXIT trap so
 	# _release_dispatch_claim always has a non-empty slug, even when the
 	# process exits between prepare and _execute_run_attempt (e.g. under

--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -447,15 +447,17 @@ append_worker_headless_contract() {
 	local contract
 	contract=$(
 		cat <<'EOF'
-[HEADLESS_CONTINUATION_CONTRACT_V6]
+[HEADLESS_CONTINUATION_CONTRACT_V7]
 This is a HEADLESS worker session. No user is present. No user input is available.
 You must drive autonomously to completion or an evidence-backed BLOCKED outcome.
 
 Setup shortcuts -- the dispatcher has already done these for you:
-- Your worktree is pre-created. Check $WORKER_WORKTREE_PATH env var for the path.
-  If set, you are already in the worktree on a feature branch. Do NOT call
-  pre-edit-check.sh, worktree-helper.sh, or session-rename tools.
-  If not set, create a worktree yourself via worktree-helper.sh add.
+- Your worktree is pre-created. $WORKER_WORKTREE_PATH contains the path. You are
+  already in the worktree on a feature branch. Do NOT call pre-edit-check.sh,
+  worktree-helper.sh, or session-rename tools under any circumstances.
+  Pre-creation is guaranteed by the dispatcher (GH#21353 / t2983 Fix C). If
+  WORKER_WORKTREE_PATH is unset, the headless runtime has already aborted — you
+  are not running. Do NOT attempt to create a worktree yourself.
 - Do NOT call aidevops-update-check.sh -- it exits immediately for headless workers.
 - Do NOT call session-rename or session-rename_sync_branch -- your session title
   is already set to the issue title by the dispatcher.

--- a/.agents/scripts/tests/test-headless-contract-clarity.sh
+++ b/.agents/scripts/tests/test-headless-contract-clarity.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Test: headless contract clarity (t2983 / GH#21355, Fix C from t2980)
+#
+# Verifies that `append_worker_headless_contract` does NOT emit a contract
+# that simultaneously tells the worker "do not call worktree-helper.sh" and
+# "create a worktree via worktree-helper.sh add". The contradiction (present in
+# V6) caused Mode B orphan log lines and was fixed by removing the fallback
+# clause in V7.
+#
+# References:
+#   - headless-runtime-lib.sh::append_worker_headless_contract
+#   - reference/worker-branch-classification.md "Mode B", "Fix C"
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit 1
+PARENT_DIR="${SCRIPT_DIR}/.."
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+# ---------------------------------------------------------------------------
+# Test harness
+# ---------------------------------------------------------------------------
+
+_pass() {
+	local test_name="$1"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_PASSED=$((TESTS_PASSED + 1))
+	printf 'PASS %s\n' "$test_name"
+	return 0
+}
+
+_fail() {
+	local test_name="$1"
+	local message="${2:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf 'FAIL %s\n' "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '  %s\n' "$message"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Setup: source headless-runtime-lib.sh in a subshell so the test stays
+# isolated. The sub-libraries (headless-runtime-provider.sh, etc.) have no
+# file-scope function calls — sourcing them only defines functions that are
+# never invoked here. SCRIPT_DIR is set to the real scripts dir so the
+# sub-library `source` directives resolve correctly.
+# ---------------------------------------------------------------------------
+
+SCRIPTS_DIR="$PARENT_DIR"
+
+# Verify the target file exists.
+LIB_FILE="${SCRIPTS_DIR}/headless-runtime-lib.sh"
+if [[ ! -f "$LIB_FILE" ]]; then
+	printf 'FAIL setup: %s not found\n' "$LIB_FILE"
+	exit 1
+fi
+
+# Source the lib. Sub-libraries will resolve via SCRIPT_DIR.
+SCRIPT_DIR="$SCRIPTS_DIR"
+export SCRIPT_DIR
+export AIDEVOPS_BASH_REEXECED=1
+# shellcheck source=/dev/null
+source "$LIB_FILE"
+
+# ---------------------------------------------------------------------------
+# Case 1: Contract marker is V7 (not the contradictory V6)
+# ---------------------------------------------------------------------------
+test_contract_version_is_v7() {
+	local output
+	output=$(append_worker_headless_contract "/full-loop Implement GH#1")
+
+	if [[ "$output" == *"HEADLESS_CONTINUATION_CONTRACT_V7"* ]]; then
+		_pass "contract_version_is_v7"
+	else
+		_fail "contract_version_is_v7" \
+			"Expected HEADLESS_CONTINUATION_CONTRACT_V7 in output, not found"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Case 2: The fallback "create a worktree yourself via worktree-helper.sh add"
+# clause is absent (removed in Fix C / V7)
+# ---------------------------------------------------------------------------
+test_no_worktree_creation_fallback() {
+	local output
+	output=$(append_worker_headless_contract "/full-loop Implement GH#1")
+
+	if [[ "$output" == *"create a worktree yourself via worktree-helper.sh add"* ]]; then
+		_fail "no_worktree_creation_fallback" \
+			"Contradiction: contract still contains the forbidden fallback clause"
+	else
+		_pass "no_worktree_creation_fallback"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Case 3: The unconditional prohibition on worktree-helper.sh is present
+# ---------------------------------------------------------------------------
+test_unconditional_do_not_call_worktree_helper() {
+	local output
+	output=$(append_worker_headless_contract "/full-loop Implement GH#1")
+
+	if [[ "$output" == *"worktree-helper.sh"* ]]; then
+		_pass "unconditional_do_not_call_worktree_helper"
+	else
+		_fail "unconditional_do_not_call_worktree_helper" \
+			"Expected 'worktree-helper.sh' mention (prohibition) in contract output"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Case 4: V6 contradiction pattern does NOT appear
+#   - "do not call worktree-helper.sh" (prohibition) AND
+#   - "create a worktree ... via worktree-helper.sh" (fallback)
+# Both must not appear together.
+# ---------------------------------------------------------------------------
+test_no_simultaneous_prohibit_and_permit() {
+	local output
+	output=$(append_worker_headless_contract "/full-loop Implement GH#1")
+
+	local has_prohibit=0
+	local has_fallback=0
+
+	# Prohibition clause — present in both V6 and V7
+	if [[ "$output" == *"Do NOT call"*"worktree-helper.sh"* ]] || \
+	   [[ "$output" == *"worktree-helper.sh"*"under any circumstances"* ]]; then
+		has_prohibit=1
+	fi
+
+	# Fallback clause — was present in V6, must be absent in V7
+	if [[ "$output" == *"create a worktree"*"worktree-helper.sh"* ]] || \
+	   [[ "$output" == *"worktree-helper.sh add"* ]]; then
+		has_fallback=1
+	fi
+
+	if [[ "$has_prohibit" -eq 1 && "$has_fallback" -eq 1 ]]; then
+		_fail "no_simultaneous_prohibit_and_permit" \
+			"Both the prohibition and the fallback clause are present (V6 contradiction)"
+	else
+		_pass "no_simultaneous_prohibit_and_permit"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Case 5: Non-/full-loop prompts pass through unchanged
+# ---------------------------------------------------------------------------
+test_non_fullloop_passthrough() {
+	local prompt="Just a regular prompt with no slash commands"
+	local output
+	output=$(append_worker_headless_contract "$prompt")
+
+	if [[ "$output" == "$prompt" ]]; then
+		_pass "non_fullloop_passthrough"
+	else
+		_fail "non_fullloop_passthrough" \
+			"Non-/full-loop prompt was modified when it should pass through unchanged"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Case 6: Already-contracted prompts are not double-injected
+# ---------------------------------------------------------------------------
+test_no_double_injection() {
+	local first
+	first=$(append_worker_headless_contract "/full-loop Implement GH#1")
+
+	local second
+	second=$(append_worker_headless_contract "$first")
+
+	# The contract marker should appear exactly once.
+	local count
+	count=$(printf '%s' "$second" | grep -c "HEADLESS_CONTINUATION_CONTRACT_V" 2>/dev/null || true)
+	[[ "$count" =~ ^[0-9]+$ ]] || count=0
+
+	if [[ "$count" -eq 1 ]]; then
+		_pass "no_double_injection"
+	else
+		_fail "no_double_injection" \
+			"Contract injected ${count} times, expected 1"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Case 7: AIDEVOPS_HEADLESS_APPEND_CONTRACT=0 suppresses injection
+# ---------------------------------------------------------------------------
+test_opt_out_env_var() {
+	local prompt="/full-loop Implement GH#1"
+	local output
+	output=$(AIDEVOPS_HEADLESS_APPEND_CONTRACT=0 append_worker_headless_contract "$prompt")
+
+	if [[ "$output" == "$prompt" ]]; then
+		_pass "opt_out_env_var"
+	else
+		_fail "opt_out_env_var" \
+			"AIDEVOPS_HEADLESS_APPEND_CONTRACT=0 did not suppress injection"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Run all tests
+# ---------------------------------------------------------------------------
+test_contract_version_is_v7
+test_no_worktree_creation_fallback
+test_unconditional_do_not_call_worktree_helper
+test_no_simultaneous_prohibit_and_permit
+test_non_fullloop_passthrough
+test_no_double_injection
+test_opt_out_env_var
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\n%d tests, %d passed, %d failed\n' \
+	"$TESTS_RUN" "$TESTS_PASSED" "$TESTS_FAILED"
+
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Resolves the V6 headless contract contradiction that told workers both "do not call worktree-helper.sh" and "create a worktree via worktree-helper.sh add". Implements Path 1 (recommended) from the GH#21355 issue: pre-creation must always succeed, workers never create worktrees.

## Path chosen: Path 1 (Pre-creation must always succeed)

Fix A (GH#21353, merged PR #21359, 2026-04-27) ensures pre-creation either succeeds or dispatch is aborted. With that guarantee in place, the worker can rely on `WORKER_WORKTREE_PATH` always being set, making the fallback clause both unnecessary and misleading.

## Changes

### headless-runtime-lib.sh — contract V6 to V7

- Removed the contradictory "If WORKER_WORKTREE_PATH not set, create a worktree yourself via worktree-helper.sh add" clause.
- Strengthened the prohibition to be unconditional with rationale citing GH#21353 (Fix A) and this fix (t2983 Fix C).
- Contract version bumped to V7.

### headless-runtime-helper.sh::_cmd_run_prepare — early fatal guard

If `WORKER_ISSUE_NUMBER` is set but `WORKER_WORKTREE_PATH` is empty, log fatal and return 1. Turns a silent wrong-directory execution into an observable dispatcher bug.

### tests/test-headless-contract-clarity.sh — new test (7 cases)

All 7 tests pass. Tests: contract version is V7, fallback clause absent, prohibition present, no simultaneous prohibit+permit, non-fullloop passthrough, no double injection, opt-out env var.

### reference/worker-branch-classification.md — Fix C section updated

Marked as IMPLEMENTED with Path 1 details.

## Testing

```
bash .agents/scripts/tests/test-headless-contract-clarity.sh
# 7 tests, 7 passed, 0 failed
```

Resolves #21355

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-sonnet-4-6 spent 7m and 21,600 tokens on this as a headless worker.
