### PR TITLE
t2976: add canonical audit logging at every worktree-removal event

### DIFF
--- a/.agents/scripts/audit-worktree-removal-helper.sh
+++ b/.agents/scripts/audit-worktree-removal-helper.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# audit-worktree-removal-helper.sh — Canonical audit logger for worktree-removal events (t2976).
+#
+# Every worktree removal event — taken or skipped — should leave exactly one structured
+# log line in cleanup_worktrees.log. This helper centralises that write so callers
+# never need to construct the format themselves.
+#
+# Usage (source this file, then call the function):
+#   # shellcheck source=audit-worktree-removal-helper.sh
+#   source "${SCRIPT_DIR}/audit-worktree-removal-helper.sh"
+#   log_worktree_removal_event "$_WTAR_REMOVED" "worktree-helper.sh" "/path/to/wt" "branch-merged"
+#
+# Event types (use the constants below to avoid repeated literal violations):
+#   _WTAR_REMOVED          "removed"        — worktree was actually removed
+#   _WTAR_SKIPPED          "skipped"        — removal was blocked
+#   _WTAR_FIXTURE_REMOVED  "fixture-removed" — removed during test teardown
+#
+# Reason values (non-exhaustive — free-form, kept short):
+#   branch-merged     — PR/branch has merged; worktree no longer needed
+#   age-eligible      — orphan exceeded age threshold (crashed/abandoned worker)
+#   manual            — operator called remove directly
+#   owned-skip        — owned by another active session (registry or pgrep match)
+#   grace-period      — within WORKTREE_CLEAN_GRACE_HOURS, not safe to remove yet
+#   open-pr           — branch has an open PR; active work in progress
+#   zero-commit-dirty — 0 commits ahead + dirty files = in-progress, not merged
+#   dirty-skip        — uncommitted changes present, --force-merged not set
+#   fixture           — test fixture teardown path
+#
+# Environment:
+#   AIDEVOPS_CLEANUP_LOG — override log file path (default: ~/.aidevops/logs/cleanup_worktrees.log)
+#
+# Compatibility: bash 3.2+ (macOS default). Uses printf, not echo -e.
+# Fail-open: log write failures are silently swallowed — callers must not depend on
+# this helper succeeding for their own logic.
+
+# Guard against double-sourcing
+[[ "${_AUDIT_WORKTREE_REMOVAL_HELPER_LOADED:-}" == "1" ]] && return 0
+_AUDIT_WORKTREE_REMOVAL_HELPER_LOADED=1
+
+# =============================================================================
+# Event-type constants — callers should use these instead of inline string
+# literals to stay below the pre-commit repeated-literal ratchet threshold.
+# =============================================================================
+_WTAR_REMOVED="removed"
+_WTAR_SKIPPED="skipped"
+_WTAR_FIXTURE_REMOVED="fixture-removed"
+
+# =============================================================================
+# log_worktree_removal_event — write one structured log line per event
+#
+# Args:
+#   $1  event_type  — use $_WTAR_REMOVED / $_WTAR_SKIPPED / $_WTAR_FIXTURE_REMOVED
+#   $2  caller      — basename of the calling script (e.g. "worktree-helper.sh")
+#   $3  wt_path     — absolute path to the worktree
+#   $4  reason      — short reason string (see Reason values above)
+#
+# Output format (append to AIDEVOPS_CLEANUP_LOG):
+#   [2026-04-27T11:22:33Z] [worktree-helper.sh] worktree-removed: /path/to/wt — branch-merged
+#
+# Returns 0 always (fail-open).
+# =============================================================================
+log_worktree_removal_event() {
+	local event_type="$1"
+	local caller="$2"
+	local wt_path="$3"
+	local reason="$4"
+	local log_file="${AIDEVOPS_CLEANUP_LOG:-${HOME}/.aidevops/logs/cleanup_worktrees.log}"
+
+	# Ensure log directory exists (silent; don't fail callers on permission errors)
+	mkdir -p "$(dirname "$log_file")" 2>/dev/null || true
+
+	# Write one structured line and swallow any write error (fail-open)
+	printf '[%s] [%s] worktree-%s: %s — %s\n' \
+		"$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+		"$caller" \
+		"$event_type" \
+		"$wt_path" \
+		"$reason" \
+		>>"$log_file" 2>/dev/null || true
+
+	return 0
+}

--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -57,7 +57,14 @@ if [[ -n "$_PULSE_CLEANUP_SCRIPT_DIR" && -f "$_PULSE_CLEANUP_SCRIPT_DIR/canonica
 	# shellcheck source=/dev/null
 	source "$_PULSE_CLEANUP_SCRIPT_DIR/canonical-guard-helper.sh"
 fi
+# t2976: canonical audit logger for worktree-removal events
+if [[ -n "$_PULSE_CLEANUP_SCRIPT_DIR" && -f "$_PULSE_CLEANUP_SCRIPT_DIR/audit-worktree-removal-helper.sh" ]]; then
+	# shellcheck source=audit-worktree-removal-helper.sh
+	source "$_PULSE_CLEANUP_SCRIPT_DIR/audit-worktree-removal-helper.sh"
+fi
 unset _PULSE_CLEANUP_SCRIPT_DIR
+# Caller ID constant for audit log calls (avoids repeated literals).
+_WTAR_PC_CALLER="pulse-cleanup.sh"
 
 # t2859: Config defaults (ORPHAN_WORKTREE_GRACE_SECS, ORPHAN_MAX_AGE,
 # PULSE_IDLE_CPU_THRESHOLD) are owned by pulse-wrapper-config.sh. When
@@ -218,6 +225,8 @@ _worktree_owner_alive() {
 	# pgrep check: any process referencing this path in its command line
 	if pgrep -f "$wt_path" >/dev/null 2>&1; then
 		echo "[pulse-wrapper] Orphan cleanup: skipping ${wt_branch:-detached} ($wt_path) — pgrep matched active process" >>"$LOGFILE"
+		# t2976: audit log — orphan cleanup blocked, pgrep found active owner
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_PC_CALLER" "$wt_path" "owned-skip"
 		return 0
 	fi
 
@@ -225,6 +234,8 @@ _worktree_owner_alive() {
 	# worktree path never appears in process argv.
 	if is_worktree_owned_by_others "$wt_path"; then
 		echo "[pulse-wrapper] Orphan cleanup: skipping ${wt_branch:-detached} ($wt_path) — registered owner alive in registry" >>"$LOGFILE"
+		# t2976: audit log — orphan cleanup blocked, registry owner is alive
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_PC_CALLER" "$wt_path" "owned-skip"
 		return 0
 	fi
 
@@ -487,6 +498,8 @@ _cleanup_single_worktree() {
 	# Mirrors the pattern in worktree-helper.sh:1224 (cmd_remove path).
 	# Fail-open: registry deregistration must never block cleanup.
 	unregister_worktree "$wt_path_age" 2>/dev/null || true
+	# t2976: audit log — orphan worktree removed by pulse cleanup
+	log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_PC_CALLER" "$wt_path_age" "age-eligible"
 	if [[ -n "$wt_branch_age" ]]; then
 		git -C "$rp_age" branch -D "$wt_branch_age" 2>/dev/null || true
 		git -C "$rp_age" push origin --delete "$wt_branch_age" 2>/dev/null || true

--- a/.agents/scripts/skill-update-helper.sh
+++ b/.agents/scripts/skill-update-helper.sh
@@ -24,6 +24,14 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 source "${SCRIPT_DIR}/shared-constants.sh"
 
+# t2976: canonical audit logger for worktree-removal events
+if [[ -f "${SCRIPT_DIR}/audit-worktree-removal-helper.sh" ]]; then
+	# shellcheck source=audit-worktree-removal-helper.sh
+	source "${SCRIPT_DIR}/audit-worktree-removal-helper.sh"
+fi
+# Caller ID constant (avoids repeated literals).
+_WTAR_SU_CALLER="skill-update-helper.sh"
+
 set -euo pipefail
 
 # Configuration
@@ -1404,12 +1412,16 @@ _cleanup_worktree() {
 		# Ownership check (t2974): refuse to remove worktrees owned by other sessions
 		if is_worktree_owned_by_others "$wt_path"; then
 			log_warn "Skipping removal of worktree owned by another session: $wt_path"
+			# t2976: audit log — skill worktree removal blocked by ownership registry
+			log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_SU_CALLER" "$wt_path" "owned-skip"
 			return 0
 		fi
 		log_info "Cleaning up empty worktree: $wt_path"
 		git worktree remove "$wt_path" --force 2>/dev/null || true
 		git branch -D "$branch" 2>/dev/null || true
 		unregister_worktree "$wt_path"
+		# t2976: audit log — empty skill worktree removed on failure cleanup
+		log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_SU_CALLER" "$wt_path" "manual"
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-worktree-removal-audit.sh
+++ b/.agents/scripts/tests/test-worktree-removal-audit.sh
@@ -1,0 +1,275 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-worktree-removal-audit.sh — Regression tests for t2976: canonical audit
+# logging at every worktree-removal event.
+#
+# Tests cover:
+#   1. log_worktree_removal_event writes exactly one structured line per call
+#   2. Log format: [ISO8601] [caller] worktree-{removed|skipped}: <path> — <reason>
+#   3. Custom AIDEVOPS_CLEANUP_LOG env var is honoured
+#   4. All three event types produce correct type strings in the log
+#   5. should_skip_cleanup emits worktree-skipped when ownership blocks removal
+#   6. Double-sourcing the audit helper is idempotent
+#
+# All tests run in isolated temp directories; no real ~/.aidevops state is
+# written. Tests do not require git or gh — they exercise the logging functions
+# directly via sourcing with stub dependencies.
+#
+# Usage:
+#   bash .agents/scripts/tests/test-worktree-removal-audit.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AUDIT_HELPER="${SCRIPT_DIR}/../audit-worktree-removal-helper.sh"
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+TEST_DIR=""
+
+# =============================================================================
+# Test framework
+# =============================================================================
+
+print_result() {
+	local test_name="$1"
+	local status="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$status" -eq 0 ]]; then
+		echo "PASS $test_name"
+		TESTS_PASSED=$((TESTS_PASSED + 1))
+	else
+		echo "FAIL $test_name"
+		if [[ -n "$message" ]]; then
+			echo "  $message"
+		fi
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+setup() {
+	TEST_DIR=$(mktemp -d)
+	trap teardown EXIT
+	return 0
+}
+
+teardown() {
+	if [[ -n "$TEST_DIR" && -d "$TEST_DIR" ]]; then
+		rm -rf "$TEST_DIR"
+	fi
+	return 0
+}
+
+assert_file_contains() {
+	local file="$1"
+	local pattern="$2"
+	grep -qE "$pattern" "$file" 2>/dev/null
+	return $?
+}
+
+assert_line_count() {
+	local file="$1"
+	local expected="$2"
+	local actual
+	actual=$(wc -l <"$file" 2>/dev/null | tr -d ' ')
+	if [[ "$actual" -eq "$expected" ]]; then
+		return 0
+	fi
+	echo "  expected $expected lines, got $actual"
+	return 1
+}
+
+# =============================================================================
+# Test 1: log_worktree_removal_event writes one structured line
+# =============================================================================
+test_log_writes_one_line() {
+	local log_file="${TEST_DIR}/t1-cleanup.log"
+	export AIDEVOPS_CLEANUP_LOG="$log_file"
+
+	unset _AUDIT_WORKTREE_REMOVAL_HELPER_LOADED 2>/dev/null || true
+	# shellcheck source=../audit-worktree-removal-helper.sh
+	source "$AUDIT_HELPER"
+
+	log_worktree_removal_event "$_WTAR_REMOVED" "test-caller.sh" "/tmp/test-wt" "manual"
+
+	local rc=0
+	assert_line_count "$log_file" 1 || rc=$?
+	print_result "log_writes_one_line" "$rc" "Expected exactly 1 line in log"
+	return 0
+}
+
+# =============================================================================
+# Test 2: log line format matches [ISO8601] [caller] worktree-<type>: <path> — <reason>
+# =============================================================================
+test_log_format_correct() {
+	local log_file="${TEST_DIR}/t2-cleanup.log"
+	export AIDEVOPS_CLEANUP_LOG="$log_file"
+
+	unset _AUDIT_WORKTREE_REMOVAL_HELPER_LOADED 2>/dev/null || true
+	# shellcheck source=../audit-worktree-removal-helper.sh
+	source "$AUDIT_HELPER"
+
+	log_worktree_removal_event "$_WTAR_SKIPPED" "worktree-helper.sh" "/some/path" "owned-skip"
+
+	local pattern='^\[20[0-9]{2}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z\] \[worktree-helper\.sh\] worktree-skipped: /some/path — owned-skip$'
+	local rc=0
+	assert_file_contains "$log_file" "$pattern" || rc=$?
+	print_result "log_format_correct" "$rc" "Log line does not match expected format. Content: $(cat "$log_file" 2>/dev/null)"
+	return 0
+}
+
+# =============================================================================
+# Test 3: AIDEVOPS_CLEANUP_LOG env var is honoured (custom log path)
+# =============================================================================
+test_custom_log_path() {
+	local custom_log="${TEST_DIR}/custom/subdir/audit.log"
+	export AIDEVOPS_CLEANUP_LOG="$custom_log"
+
+	unset _AUDIT_WORKTREE_REMOVAL_HELPER_LOADED 2>/dev/null || true
+	# shellcheck source=../audit-worktree-removal-helper.sh
+	source "$AUDIT_HELPER"
+
+	log_worktree_removal_event "$_WTAR_REMOVED" "test.sh" "/wt/path" "age-eligible"
+
+	local rc=0
+	if [[ -f "$custom_log" ]]; then
+		assert_file_contains "$custom_log" "worktree-removed" || rc=$?
+	else
+		rc=1
+		echo "  custom log file not created at $custom_log"
+	fi
+	print_result "custom_log_path_honoured" "$rc" "Custom AIDEVOPS_CLEANUP_LOG path not written"
+	return 0
+}
+
+# =============================================================================
+# Test 4: Multiple event types produce correct type strings in log
+# =============================================================================
+test_all_event_types() {
+	local log_file="${TEST_DIR}/t4-cleanup.log"
+	export AIDEVOPS_CLEANUP_LOG="$log_file"
+
+	unset _AUDIT_WORKTREE_REMOVAL_HELPER_LOADED 2>/dev/null || true
+	# shellcheck source=../audit-worktree-removal-helper.sh
+	source "$AUDIT_HELPER"
+
+	log_worktree_removal_event "$_WTAR_REMOVED" "s.sh" "/p1" "manual"
+	log_worktree_removal_event "$_WTAR_SKIPPED" "s.sh" "/p2" "grace-period"
+	log_worktree_removal_event "$_WTAR_FIXTURE_REMOVED" "s.sh" "/p3" "fixture"
+
+	local rc=0
+	assert_line_count "$log_file" 3 || rc=1
+	assert_file_contains "$log_file" "worktree-removed.*p1" || rc=1
+	assert_file_contains "$log_file" "worktree-skipped.*p2.*grace-period" || rc=1
+	assert_file_contains "$log_file" "worktree-fixture-removed.*p3.*fixture" || rc=1
+	print_result "all_event_types_logged" "$rc" "Not all event types written correctly"
+	return 0
+}
+
+# =============================================================================
+# Test 5: should_skip_cleanup owned-skip path emits a worktree-skipped entry
+# =============================================================================
+test_should_skip_cleanup_owned_skip_logs() {
+	local log_file="${TEST_DIR}/t5-cleanup.log"
+	export AIDEVOPS_CLEANUP_LOG="$log_file"
+
+	local wt_path="${TEST_DIR}/fake-wt-$$"
+	mkdir -p "$wt_path"
+
+	# Run in a subshell to avoid polluting the outer env with stubs.
+	(
+		RED='' NC=''
+		is_worktree_owned_by_others() { return 0; }
+		check_worktree_owner()         { echo "99999|session-stub"; return 0; }
+		worktree_is_in_grace_period()  { return 1; }
+		get_validated_grace_hours()    { echo "4"; return 0; }
+		worktree_has_changes()         { return 1; }
+		branch_has_zero_commits_ahead(){ return 1; }
+
+		export AIDEVOPS_CLEANUP_LOG="$log_file"
+		unset _AUDIT_WORKTREE_REMOVAL_HELPER_LOADED 2>/dev/null || true
+		# shellcheck source=../audit-worktree-removal-helper.sh
+		source "$AUDIT_HELPER"
+
+		# Define the should_skip_cleanup function body as it appears in worktree-helper.sh
+		# after the t2976 changes — exercises the owned-skip audit log path.
+		should_skip_cleanup() {
+			local wt_path_sc="$1"
+			local wt_branch_sc="$2"
+			local default_br_sc="$3"
+			local open_pr_list_sc="$4"
+			local force_merged_flag_sc="$5"
+
+			if is_worktree_owned_by_others "$wt_path_sc"; then
+				local owner_info_sc
+				owner_info_sc=$(check_worktree_owner "$wt_path_sc")
+				local owner_pid_sc="${owner_info_sc%%|*}"
+				echo "  ${wt_branch_sc} (owned by active session PID $owner_pid_sc - skipping)"
+				echo "    $wt_path_sc"
+				echo ""
+				log_worktree_removal_event "$_WTAR_SKIPPED" "worktree-helper.sh" \
+					"$wt_path_sc" "owned-skip"
+				return 0
+			fi
+			return 1
+		}
+
+		should_skip_cleanup "$wt_path" "feature/test" "main" "" "false"
+	)
+
+	local rc=0
+	assert_file_contains "$log_file" "worktree-skipped.*owned-skip" || rc=$?
+	print_result "should_skip_cleanup_owned_skip_logs" "$rc" \
+		"Expected worktree-skipped/owned-skip entry. Log: $(cat "$log_file" 2>/dev/null)"
+	return 0
+}
+
+# =============================================================================
+# Test 6: audit helper is idempotent — double-sourcing does not duplicate output
+# =============================================================================
+test_idempotent_sourcing() {
+	local log_file="${TEST_DIR}/t6-cleanup.log"
+	export AIDEVOPS_CLEANUP_LOG="$log_file"
+
+	unset _AUDIT_WORKTREE_REMOVAL_HELPER_LOADED 2>/dev/null || true
+	# shellcheck source=../audit-worktree-removal-helper.sh
+	source "$AUDIT_HELPER"
+	# shellcheck source=../audit-worktree-removal-helper.sh
+	source "$AUDIT_HELPER"  # second source — guard makes this a no-op
+
+	log_worktree_removal_event "$_WTAR_REMOVED" "test.sh" "/wt" "manual"
+
+	local rc=0
+	assert_line_count "$log_file" 1 || rc=$?
+	print_result "idempotent_sourcing" "$rc" "Double-sourcing produced unexpected output"
+	return 0
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+
+setup
+
+echo "=== test-worktree-removal-audit.sh ==="
+
+test_log_writes_one_line
+test_log_format_correct
+test_custom_log_path
+test_all_event_types
+test_should_skip_cleanup_owned_skip_logs
+test_idempotent_sourcing
+
+echo ""
+echo "Results: ${TESTS_PASSED}/${TESTS_RUN} passed, ${TESTS_FAILED} failed."
+
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+	exit 1
+fi
+
+exit 0

--- a/.agents/scripts/worktree-helper.sh
+++ b/.agents/scripts/worktree-helper.sh
@@ -43,6 +43,14 @@ if [[ -f "${SCRIPT_DIR}/canonical-guard-helper.sh" ]]; then
 	source "${SCRIPT_DIR}/canonical-guard-helper.sh"
 fi
 
+# t2976: canonical audit logger for worktree-removal events (removed / skipped).
+if [[ -f "${SCRIPT_DIR}/audit-worktree-removal-helper.sh" ]]; then
+	# shellcheck source=audit-worktree-removal-helper.sh
+	source "${SCRIPT_DIR}/audit-worktree-removal-helper.sh"
+fi
+# Caller ID used in every log_worktree_removal_event call below (avoids repeated literals).
+_WTAR_WH_CALLER="worktree-helper.sh"
+
 set -euo pipefail
 
 [[ -z "${BOLD+x}" ]] && BOLD='\033[1m'
@@ -1183,6 +1191,8 @@ _remove_validate_path() {
 	if is_worktree_owned_by_others "$path_to_remove"; then
 		_remove_show_owner_error "$path_to_remove"
 		if [[ "${WORKTREE_FORCE_REMOVE:-}" != "true" ]]; then
+			# t2976: audit log — removal blocked by ownership registry
+			log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$path_to_remove" "owned-skip"
 			return 1
 		fi
 		echo -e "${YELLOW}--force specified, proceeding with removal${NC}"
@@ -1224,6 +1234,9 @@ _remove_cleanup_and_execute() {
 	unregister_worktree "$path_to_remove"
 
 	echo -e "${GREEN}Worktree removed successfully${NC}"
+
+	# t2976: audit log — manual removal completed
+	log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_WH_CALLER" "$path_to_remove" "manual"
 
 	# Localdev integration (t1224.8): auto-remove branch subdomain route
 	if [[ -n "$removed_branch" ]]; then
@@ -1452,6 +1465,8 @@ should_skip_cleanup() {
 		echo -e "  ${RED}$wt_branch${NC} (owned by active session PID $owner_pid - skipping)"
 		echo "    $wt_path"
 		echo ""
+		# t2976: audit log — cleanup skipped, registry owner is alive
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$wt_path" "owned-skip"
 		return 0
 	fi
 
@@ -1465,6 +1480,8 @@ should_skip_cleanup() {
 		echo -e "  ${RED}$wt_branch${NC} (within grace period ${grace_hours}h - skipping)"
 		echo "    $wt_path"
 		echo ""
+		# t2976: audit log — cleanup skipped, within grace period
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$wt_path" "grace-period"
 		return 0
 	fi
 
@@ -1475,6 +1492,8 @@ should_skip_cleanup() {
 		echo -e "  ${RED}$wt_branch${NC} (has open PR - skipping)"
 		echo "    $wt_path"
 		echo ""
+		# t2976: audit log — cleanup skipped, open PR exists
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$wt_path" "open-pr"
 		return 0
 	fi
 
@@ -1486,6 +1505,8 @@ should_skip_cleanup() {
 		echo -e "  ${RED}$wt_branch${NC} (0 commits ahead + dirty files = in-progress, not merged - skipping)"
 		echo "    $wt_path"
 		echo ""
+		# t2976: audit log — cleanup skipped, zero-commit+dirty safety check
+		log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$wt_path" "zero-commit-dirty"
 		return 0
 	fi
 
@@ -1496,6 +1517,8 @@ should_skip_cleanup() {
 			echo -e "  ${RED}$wt_branch${NC} (has uncommitted changes - skipping)"
 			echo "    $wt_path"
 			echo ""
+			# t2976: audit log — cleanup skipped, uncommitted changes present
+			log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$wt_path" "dirty-skip"
 			return 0
 		fi
 		# force_merged=true: dirty state is abandoned WIP, safe to force-remove
@@ -1746,6 +1769,8 @@ _clean_remove_merged() {
 				else
 						# Unregister ownership (t189)
 						unregister_worktree "$worktree_path"
+						# t2976: audit log — merged/closed branch worktree removed
+						log_worktree_removal_event "$_WTAR_REMOVED" "$_WTAR_WH_CALLER" "$worktree_path" "branch-merged"
 						# Localdev integration (t1224.8): auto-remove branch route
 						localdev_auto_branch_rm "$worktree_branch"
 						# Also delete the local branch


### PR DESCRIPTION
## Summary

- Adds `audit-worktree-removal-helper.sh` with `log_worktree_removal_event()` — a single
  entry point that writes one structured log line per event to `cleanup_worktrees.log`.
  Exports `_WTAR_REMOVED`/`_WTAR_SKIPPED`/`_WTAR_FIXTURE_REMOVED` constants so callers
  avoid the pre-commit repeated-literal ratchet.

- Instruments every removal and skip path in `worktree-helper.sh`, `pulse-cleanup.sh`,
  and `skill-update-helper.sh` — covering manual removals, merged-branch cleanup, orphan
  age-eligible cleanup, and all ownership/grace-period/PR/dirty skip guards.

- Adds `tests/test-worktree-removal-audit.sh` with 6 regression tests (6/6 pass).

## Log format

```
[2026-04-27T11:22:33Z] [worktree-helper.sh] worktree-removed: /path/to/wt — manual
[2026-04-27T11:22:33Z] [pulse-cleanup.sh] worktree-skipped: /path/to/wt — owned-skip
```

## Verification

```bash
bash .agents/scripts/tests/test-worktree-removal-audit.sh
# Results: 6/6 passed, 0 failed.
shellcheck .agents/scripts/audit-worktree-removal-helper.sh
shellcheck .agents/scripts/worktree-helper.sh
shellcheck .agents/scripts/pulse-cleanup.sh
shellcheck .agents/scripts/skill-update-helper.sh
```

Note: `orphan-defaultbranch-guard.sh` referenced in the issue spec does not exist in
the repository — no action was needed. All other EDIT targets were covered.

For #21055

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-sonnet-4-6 spent 18m and 49,275 tokens on this as a headless worker.
