### PR TITLE
t2986: suppress shellcheck false positives blocking release preflight

### DIFF
--- a/.agents/scripts/auto-update-helper.sh
+++ b/.agents/scripts/auto-update-helper.sh
@@ -872,6 +872,7 @@ _cmd_enable_systemd() {
 
 	mkdir -p "${SYSTEMD_SERVICE_DIR}"
 
+	# shellcheck disable=SC1078,SC1079,SC2027,SC2086  # systemd ExecStart wraps a single-quoted shell command; bash interpolates "${script_path}" into the systemd directive value, embedded single+double quotes are intentional
 	printf '%s' "[Unit]
 Description=aidevops auto-update
 After=network.target

--- a/setup-modules/tool-install.sh
+++ b/setup-modules/tool-install.sh
@@ -51,6 +51,7 @@ setup_git_clis() {
 			echo ""
 			setup_prompt install_git_clis "Install Git CLI tools (${missing_packages[*]}) using $pkg_manager? [Y/n]: " "Y"
 
+			# shellcheck disable=SC2154  # set indirectly by setup_prompt via read
 			if [[ "$install_git_clis" =~ ^[Yy]?$ ]]; then
 				print_info "Installing ${missing_packages[*]}..."
 				if install_packages "$pkg_manager" "${missing_packages[@]}"; then
@@ -233,6 +234,7 @@ setup_file_discovery_tools() {
 		if [[ "$pkg_manager" != "unknown" ]]; then
 			setup_prompt install_fd_tools "Install file discovery tools (${missing_packages[*]}) using $pkg_manager? [Y/n]: " "Y"
 
+			# shellcheck disable=SC2154  # set indirectly by setup_prompt via read
 			if [[ "$install_fd_tools" =~ ^[Yy]?$ ]]; then
 				_install_file_discovery_packages "$pkg_manager" "${missing_packages[@]}"
 			else
@@ -272,6 +274,7 @@ setup_rtk() {
 
 		setup_prompt install_rtk "Install rtk for token-optimized CLI output? [y/N]: " "n"
 
+		# shellcheck disable=SC2154  # set indirectly by setup_prompt via read
 		if [[ "$install_rtk" =~ ^[Yy]$ ]]; then
 			VERIFIED_INSTALL_SHELL="sh"
 			if command -v brew >/dev/null 2>&1; then
@@ -1922,6 +1925,7 @@ setup_orbstack_vm() {
 	fi
 
 	setup_prompt install_orb "Install OrbStack? [y/N]: " "n"
+	# shellcheck disable=SC2154  # set indirectly by setup_prompt via read
 	if [[ "$install_orb" =~ ^[Yy]$ ]]; then
 		if run_with_spinner "Installing OrbStack" brew install --cask orbstack; then
 			print_success "OrbStack installed"


### PR DESCRIPTION
## What

Suppress 5 shellcheck false positives blocking release preflight since v3.13.0:

- `auto-update-helper.sh:876,883` — systemd ExecStart in `printf '%s'` template
  - SC1078 (unclosed double-quote), SC1079 (suspect end-quote), SC2027 (unquoted-by-quotes), SC2086 (globbing)
  - All false positives: systemd `ExecStart=/bin/bash -lc 'CMD'` requires single-quoted shell command; bash interpolates `${script_path}` into the systemd directive value before the file is written. The embedded single+double quote pattern is intentional.

- `tool-install.sh:54,236,275,1925` — `setup_prompt VAR_NAME "prompt" "default"` followed by `[[ "$VAR_NAME" =~ ... ]]`
  - SC2154 (referenced but not assigned)
  - False positive: `setup_prompt` is a helper that uses `read` to set the var by indirect name. ShellCheck cannot track dynamic assignment via name-passing.

## Why

Release preflight currently fails for any patch/minor/major release after v3.13.0:

```
[ERROR] ShellCheck failed on 2 file(s) changed since v3.13.0
```

This blocks cutting v3.13.1 with the t2984 productivity unblock (reconcile_issues_single_pass 600s→4s, 150x improvement) from reaching all runners.

## How

Add narrow `# shellcheck disable=` annotations with explanatory comments at each false-positive line. No code behaviour change.

### Files Scope

- `.agents/scripts/auto-update-helper.sh`
- `setup-modules/tool-install.sh`

## Verification

- `shellcheck .agents/scripts/auto-update-helper.sh` → zero findings
- `shellcheck setup-modules/tool-install.sh` → zero findings
- `.agents/scripts/version-manager.sh preflight patch` → passes from worktree

Resolves #21377
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.0 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-opus-4-7 spent 12h 50m and 92,783 tokens on this with the user in an interactive session.