### PR TITLE
t2987: add pattern-aware conflict resolution guidance to conflict-feedback brief

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -857,6 +857,33 @@ Background and infinite-loop root cause (t2386): `reference/auto-merge.md` (NMR 
 
 Full workflow: `workflows/git-workflow.md`, `reference/session.md`
 
+## Conflict Resolution Patterns (t2987)
+
+When a worker PR develops merge conflicts that `gh pr update-branch` cannot resolve,
+`_dispatch_conflict_fix_worker` in `pulse-merge-feedback.sh` classifies the conflicting
+files using the declarative pattern registry at `.agents/configs/conflict-patterns.conf`.
+The next worker's brief receives targeted, one-shot resolution steps instead of generic
+cherry-pick guidance — breaking the repeat-reroute loop.
+
+**Pattern registry** (`.agents/configs/conflict-patterns.conf`):
+
+| Pattern (grep substring) | Classification | Resolution strategy |
+|--------------------------|----------------|---------------------|
+| `/migrations/meta/` | `DRIZZLE_MIGRATION` | Renumber migration idx + `db:generate` |
+| `pnpm-lock.yaml`, `package-lock.json`, `yarn.lock` | `LOCKFILE` | `pnpm/npm/yarn install` after rebase |
+| `/translations/`, `/locales/` | `I18N_JSON` | `jq -s '.[0] * .[1]'` union merge |
+| `_snapshot.sql`, `.generated.ts`, `__generated__/` | `GENERATED` | Delete and regenerate |
+| _(unmatched)_ | `CODE` | Generic cherry-pick guidance |
+
+**Implementation**: `_classify_conflicts_by_pattern()` reads the conf (first match wins,
+`grep -F` substring), `_emit_conflict_pattern_guidance()` emits the Markdown block per
+non-CODE class. Both are called from `_build_conflict_feedback_section()`.
+
+**Adding a new pattern**: add one `grep_substring | CLASSIFICATION | hint` line to
+`.agents/configs/conflict-patterns.conf`. No shell edits required for new patterns
+within the five existing classes. For a new class, also add a `case` arm to
+`_emit_conflict_pattern_guidance()` in `pulse-merge-feedback.sh`.
+
 ---
 
 ## Operational Routines (Non-Code Work)

--- a/.agents/configs/conflict-patterns.conf
+++ b/.agents/configs/conflict-patterns.conf
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Conflict pattern registry for _classify_conflicts_by_pattern() (t2987)
+# Used by pulse-merge-feedback.sh::_build_conflict_feedback_section to embed
+# targeted resolution guidance in conflict-feedback briefs, breaking the
+# recurring reroute loop where workers hit the same pattern-specific conflict
+# because the generic brief gave no resolution hint.
+#
+# Format (pipe-delimited, one entry per line):
+#   grep_substring | CLASSIFICATION | one_line_resolution_hint
+#
+# grep_substring is matched against the full file path via grep -F (fixed-string,
+# case-sensitive). Entries are evaluated in order; first match wins.
+# CLASSIFICATION must be one of: DRIZZLE_MIGRATION LOCKFILE I18N_JSON GENERATED
+# CODE is the implicit fallback — do NOT add CODE entries; unmatched files are
+# classified CODE automatically.
+#
+# Blank lines and lines starting with '#' are ignored.
+# This file is the single source of truth for pattern → guidance mapping.
+# To add a new pattern, add an entry here. To change guidance text, edit
+# _emit_conflict_pattern_guidance() in pulse-merge-feedback.sh.
+#
+# Override path: set AIDEVOPS_CONFLICT_PATTERNS_CONF to a custom path.
+
+# ── Drizzle migration meta files ────────────────────────────────────────────
+# _journal.json and NNNN_snapshot.json live under migrations/meta/ in monorepos.
+# The collision class is always an idx numbering conflict — the PR numbered its
+# migration for an idx that develop has since consumed. Regeneration required.
+/migrations/meta/ | DRIZZLE_MIGRATION | renumber migration idx and run db:generate
+
+# ── Lockfiles ────────────────────────────────────────────────────────────────
+# Lockfiles are fully auto-generated. Any conflict is resolved by regenerating
+# after rebasing — never manually merge lockfile content.
+pnpm-lock.yaml    | LOCKFILE | pnpm install --no-frozen-lockfile
+package-lock.json | LOCKFILE | npm install
+yarn.lock         | LOCKFILE | yarn install
+bun.lockb         | LOCKFILE | bun install
+
+# ── i18n / translation JSON files ───────────────────────────────────────────
+# Translation JSON files are mechanically union-mergeable: keys from both sides
+# are independently valid. Use jq union merge — never pick "ours" or "theirs".
+/translations/    | I18N_JSON | jq -s '.[0] * .[1]' base.json pr.json > merged.json
+/locales/         | I18N_JSON | jq -s '.[0] * .[1]' base.json pr.json > merged.json
+
+# ── Generated files ──────────────────────────────────────────────────────────
+# Schema snapshots, GraphQL schemas, and typed output files are generated
+# artefacts — always delete and regenerate, never manually merge.
+_snapshot.sql     | GENERATED | delete and run db:generate
+.graphql          | GENERATED | run graphql codegen
+.generated.ts     | GENERATED | run the codegen step
+.generated.js     | GENERATED | run the codegen step
+__generated__/    | GENERATED | run the codegen step

--- a/.agents/scripts/pulse-merge-feedback.sh
+++ b/.agents/scripts/pulse-merge-feedback.sh
@@ -353,7 +353,7 @@ _classify_conflicts_by_pattern() {
 	local file_list="$1"
 	local conf_override="${2:-}"
 	local conf_file="$conf_override"
-	local script_dir raw_pattern classification hint_unused pattern filepath matched
+	local script_dir="" raw_pattern="" classification="" hint_unused="" pattern="" filepath="" matched=""
 
 	if [[ -z "$conf_file" ]]; then
 		script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || script_dir=""

--- a/.agents/scripts/pulse-merge-feedback.sh
+++ b/.agents/scripts/pulse-merge-feedback.sh
@@ -335,6 +335,188 @@ _Closed by deterministic merge pass (pulse-merge.sh)._" \
 }
 
 #######################################
+# Classify a newline-separated list of file paths into known conflict
+# pattern classes using the declarative registry in conflict-patterns.conf.
+#
+# Pattern registry: .agents/configs/conflict-patterns.conf (t2987)
+# Format: grep_substring | CLASSIFICATION | one_line_hint
+#
+# Known classifications: DRIZZLE_MIGRATION LOCKFILE I18N_JSON GENERATED CODE
+# CODE is the implicit fallback for unmatched files — no conf entry needed.
+#
+# Args: $1=newline-separated file paths
+#       $2=optional conf file path override (defaults to auto-detected)
+# Stdout: one line per classification: "CLASS file1 file2 ..."
+# Exit 0 always (fail-open).
+#######################################
+_classify_conflicts_by_pattern() {
+	local file_list="$1"
+	local conf_override="${2:-}"
+	local conf_file="$conf_override"
+	local script_dir raw_pattern classification hint_unused pattern filepath matched
+
+	if [[ -z "$conf_file" ]]; then
+		script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || script_dir=""
+		conf_file="${script_dir}/../configs/conflict-patterns.conf"
+	fi
+
+	# Per-class accumulators (bash 3.2 compat — no declare -A)
+	local drizzle_files="" lockfile_files="" i18n_files="" generated_files="" code_files=""
+
+	while IFS= read -r filepath; do
+		[[ -z "$filepath" ]] && continue
+		matched="CODE"
+
+		if [[ -f "$conf_file" ]]; then
+			while IFS='|' read -r raw_pattern classification hint_unused; do
+				case "$raw_pattern" in
+					'#'*|'') continue ;;
+				esac
+				# Strip surrounding whitespace from pattern and classification.
+				pattern="${raw_pattern#"${raw_pattern%%[![:space:]]*}"}"
+				pattern="${pattern%"${pattern##*[![:space:]]}"}"
+				classification="${classification#"${classification%%[![:space:]]*}"}"
+				classification="${classification%"${classification##*[![:space:]]}"}"
+				[[ -z "$pattern" || -z "$classification" ]] && continue
+				if printf '%s' "$filepath" | grep -qF "$pattern" 2>/dev/null; then
+					matched="$classification"
+					break
+				fi
+			done < "$conf_file"
+		fi
+
+		case "$matched" in
+			DRIZZLE_MIGRATION) drizzle_files="${drizzle_files:+$drizzle_files }$filepath" ;;
+			LOCKFILE)          lockfile_files="${lockfile_files:+$lockfile_files }$filepath" ;;
+			I18N_JSON)         i18n_files="${i18n_files:+$i18n_files }$filepath" ;;
+			GENERATED)         generated_files="${generated_files:+$generated_files }$filepath" ;;
+			*)                 code_files="${code_files:+$code_files }$filepath" ;;
+		esac
+	done <<< "$file_list"
+
+	[[ -n "$drizzle_files" ]]   && printf 'DRIZZLE_MIGRATION %s\n' "$drizzle_files"
+	[[ -n "$lockfile_files" ]]  && printf 'LOCKFILE %s\n' "$lockfile_files"
+	[[ -n "$i18n_files" ]]      && printf 'I18N_JSON %s\n' "$i18n_files"
+	[[ -n "$generated_files" ]] && printf 'GENERATED %s\n' "$generated_files"
+	[[ -n "$code_files" ]]      && printf 'CODE %s\n' "$code_files"
+	return 0
+}
+
+#######################################
+# Emit a "### Pattern-Specific Resolution Guidance" Markdown block for the
+# non-CODE classifications returned by _classify_conflicts_by_pattern.
+#
+# Reads the classification lines (one per class: "CLASS file1 file2 ...") and
+# emits targeted guidance per detected pattern. CODE lines are silently skipped.
+# Emits nothing if only CODE patterns are present.
+#
+# Args: $1=classification output from _classify_conflicts_by_pattern
+#       $2=default_branch (e.g. "main", "develop")
+# Stdout: Markdown guidance block (may be empty)
+# Exit 0 always (fail-open).
+#######################################
+_emit_conflict_pattern_guidance() {
+	local classifications="$1"
+	local default_branch="${2:-main}"
+	local class_line cls files header_emitted=""
+
+	while IFS= read -r class_line; do
+		[[ -z "$class_line" ]] && continue
+		cls="${class_line%% *}"; files="${class_line#* }"
+		[[ "$cls" == "CODE" ]] && continue
+
+		if [[ -z "$header_emitted" ]]; then
+			printf '### Pattern-Specific Resolution Guidance\n\nThe conflicting files match known patterns. Targeted steps below break the reroute loop — generic cherry-pick guidance alone is insufficient.\n\n'
+			header_emitted="yes"
+		fi
+
+		case "$cls" in
+			DRIZZLE_MIGRATION)
+				cat <<-EOF
+					#### Pattern: Drizzle migration meta conflict
+
+					Affected files: \`${files}\`
+
+					Drizzle migration index collisions: this PR numbered its migration for an
+					idx that \`${default_branch}\` has since consumed.
+
+					Resolution (verbatim — do NOT manually merge snapshot content):
+
+					1. Rebase on \`origin/${default_branch}\`:
+					   \`git fetch origin && git rebase origin/${default_branch}\`
+					2. Find the next available idx in the upstream journal:
+					   \`git show origin/${default_branch}:packages/db/migrations/meta/_journal.json | jq '.entries | sort_by(.idx) | last'\`
+					3. Renumber your migration SQL + snapshot file to idx+1.
+					4. Regenerate the canonical schema snapshot:
+					   \`pnpm --filter @<scope>/db db:generate\`
+					5. Commit the renamed SQL + new snapshot — do NOT include any manually
+					   merged snapshot content from both branches.
+
+					> **WARNING**: Snapshots are cumulative, not deltas. Manual merging of
+					> \`*_snapshot.json\` content from both sides corrupts the schema chain.
+					> Delete your snapshot, rename the SQL to the new idx, then regenerate.
+
+				EOF
+				;;
+			LOCKFILE)
+				cat <<-EOF
+					#### Pattern: Lockfile conflict
+
+					Affected files: \`${files}\`
+
+					Lockfiles are fully auto-generated. Regenerate after rebasing —
+					never merge lockfile content manually.
+
+					Resolution:
+					\`\`\`bash
+					git fetch origin && git rebase origin/${default_branch}
+					# Then regenerate the lockfile:
+					# pnpm-lock.yaml   → pnpm install --no-frozen-lockfile
+					# package-lock.json → npm install
+					# yarn.lock        → yarn install
+					\`\`\`
+
+				EOF
+				;;
+			I18N_JSON)
+				cat <<-EOF
+					#### Pattern: i18n / translation JSON conflict
+
+					Affected files: \`${files}\`
+
+					Translation JSON files are mechanically union-mergeable — keys from both
+					branches are independently valid. Use \`jq\` union merge; do NOT choose
+					"ours" or "theirs".
+
+					Resolution (per conflicting file):
+					\`\`\`bash
+					git show origin/${default_branch}:<path> > /tmp/base.json
+					git show HEAD:<path> > /tmp/pr.json
+					jq -s '.[0] * .[1]' /tmp/base.json /tmp/pr.json > <path>
+					\`\`\`
+
+				EOF
+				;;
+			GENERATED)
+				cat <<-EOF
+					#### Pattern: Generated file conflict
+
+					Affected files: \`${files}\`
+
+					Generated files must be regenerated — never manually merged.
+
+					Resolution: rebase on \`origin/${default_branch}\`, delete the conflicted
+					generated file(s), then run the relevant generator (see \`package.json\`
+					scripts for \`codegen\`, \`generate\`, \`build:types\`, or similar).
+				EOF
+				;;
+		esac
+	done <<< "$classifications"
+
+	return 0
+}
+
+#######################################
 # Build the conflict-feedback Markdown section for a closed-conflict PR.
 #
 # Produces the "## Merge Conflict Feedback" block appended to the linked
@@ -394,6 +576,19 @@ _build_conflict_feedback_section() {
 		scope_block=$'\n'"${scope_leak_warning}"$'\n'
 	fi
 
+	# Pattern-aware conflict classification (t2987). Classify the file list
+	# using the declarative registry and emit targeted guidance so the next
+	# worker gets a one-shot resolution path instead of hitting the same
+	# pattern-specific conflict again.
+	local pattern_classifications="" pattern_guidance_block=""
+	if [[ -n "$pr_files" ]] && [[ "$pr_files" != "(could not fetch)" ]]; then
+		pattern_classifications=$(_classify_conflicts_by_pattern "$pr_files")
+	fi
+	if [[ -n "$pattern_classifications" ]]; then
+		pattern_guidance_block=$(_emit_conflict_pattern_guidance \
+			"$pattern_classifications" "$default_branch")
+	fi
+
 	cat <<-EOF
 		## Merge Conflict Feedback (from PR #${pr_number})
 
@@ -407,6 +602,7 @@ _build_conflict_feedback_section() {
 		${pr_files}
 		\`\`\`
 
+		${pattern_guidance_block}
 		### Worker guidance
 
 		The prior PR's head commit is \`${pr_head_sha:-<lookup via gh pr view ${pr_number} --json headRefOid>}\`. Choose the cheapest path that works:

--- a/.agents/scripts/tests/test-conflict-pattern-detection.sh
+++ b/.agents/scripts/tests/test-conflict-pattern-detection.sh
@@ -1,0 +1,452 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Tests for pattern-aware conflict classification (t2987 / GH#21379).
+#
+# Background: _dispatch_conflict_fix_worker in pulse-merge-feedback.sh used to
+# write a generic conflict-feedback section. Workers picking up the rerouted
+# issue would hit the same pattern-specific conflict again (e.g. Drizzle
+# migration idx collision), causing a reroute loop. Three consecutive reroutes
+# were observed in a managed private repo for the same migration conflict.
+#
+# This PR adds:
+#   - _classify_conflicts_by_pattern(): reads .agents/configs/conflict-patterns.conf
+#     and classifies file paths into DRIZZLE_MIGRATION / LOCKFILE / I18N_JSON /
+#     GENERATED / CODE classes.
+#   - _emit_conflict_pattern_guidance(): emits a "### Pattern-Specific Resolution
+#     Guidance" Markdown block for non-CODE classifications.
+#   - _build_conflict_feedback_section(): calls the two helpers and embeds
+#     the pattern guidance between the file list and the generic worker guidance.
+#
+# Test strategy:
+#   1. Source pulse-merge-feedback.sh directly (it sets LOGFILE default, no deps).
+#   2. Unit-test _classify_conflicts_by_pattern with synthetic file lists.
+#   3. Unit-test _emit_conflict_pattern_guidance output.
+#   4. Smoke-test _build_conflict_feedback_section: verify the brief contains
+#      "### Pattern-Specific Resolution Guidance" when a non-CODE pattern is
+#      detected, and does NOT contain it for CODE-only input.
+#
+# Run: bash .agents/scripts/tests/test-conflict-pattern-detection.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+FEEDBACK_SCRIPT="${REPO_ROOT}/.agents/scripts/pulse-merge-feedback.sh"
+CONF_FILE="${REPO_ROOT}/.agents/configs/conflict-patterns.conf"
+
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf '  %sPASS%s %s\n' "$TEST_GREEN" "$TEST_NC" "$1"
+	return 0
+}
+
+fail() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '  %sFAIL%s %s\n' "$TEST_RED" "$TEST_NC" "$1"
+	if [[ $# -ge 2 && -n "$2" ]]; then
+		printf '       %s\n' "$2"
+	fi
+	return 0
+}
+
+# ── Prerequisites ────────────────────────────────────────────────────────────
+
+check_prerequisites() {
+	if [[ ! -f "$FEEDBACK_SCRIPT" ]]; then
+		printf '%sFAIL%s pulse-merge-feedback.sh not found at %s\n' \
+			"$TEST_RED" "$TEST_NC" "$FEEDBACK_SCRIPT"
+		return 1
+	fi
+	if [[ ! -f "$CONF_FILE" ]]; then
+		printf '%sFAIL%s conflict-patterns.conf not found at %s\n' \
+			"$TEST_RED" "$TEST_NC" "$CONF_FILE"
+		return 1
+	fi
+	# Source the feedback module. LOGFILE defaults internally via : "${LOGFILE:=...}".
+	# shellcheck source=/dev/null
+	if ! source "$FEEDBACK_SCRIPT" 2>/dev/null; then
+		printf '%sFAIL%s could not source %s\n' \
+			"$TEST_RED" "$TEST_NC" "$FEEDBACK_SCRIPT"
+		return 1
+	fi
+	pass "prerequisites: conf file + feedback script present and sourceable"
+	return 0
+}
+
+# ── Conf file structural checks ──────────────────────────────────────────────
+
+test_conf_has_drizzle_pattern() {
+	if grep -qF '/migrations/meta/' "$CONF_FILE"; then
+		pass "conf: DRIZZLE_MIGRATION pattern present (/migrations/meta/)"
+		return 0
+	fi
+	fail "conf: DRIZZLE_MIGRATION pattern missing" \
+		"Expected '/migrations/meta/' entry in conflict-patterns.conf"
+	return 0
+}
+
+test_conf_has_lockfile_patterns() {
+	local missing=0
+	for lf in pnpm-lock.yaml package-lock.json yarn.lock; do
+		if ! grep -qF "$lf" "$CONF_FILE"; then
+			fail "conf: lockfile pattern missing: $lf" ""
+			missing=$((missing + 1))
+		fi
+	done
+	if [[ "$missing" -eq 0 ]]; then
+		pass "conf: all three primary lockfile patterns present"
+	fi
+	return 0
+}
+
+test_conf_has_i18n_pattern() {
+	if grep -qF '/translations/' "$CONF_FILE"; then
+		pass "conf: I18N_JSON pattern present (/translations/)"
+		return 0
+	fi
+	fail "conf: I18N_JSON pattern missing" \
+		"Expected '/translations/' entry in conflict-patterns.conf"
+	return 0
+}
+
+# ── _classify_conflicts_by_pattern unit tests ────────────────────────────────
+
+assert_class() {
+	local label="$1"
+	local file_list="$2"
+	local expected_class="$3"
+	local got
+	got=$(_classify_conflicts_by_pattern "$file_list" "$CONF_FILE")
+	if echo "$got" | grep -q "^${expected_class} "; then
+		pass "classify: $label → $expected_class"
+		return 0
+	fi
+	fail "classify: $label → expected $expected_class" \
+		"Got: $(echo "$got" | head -5)"
+	return 0
+}
+
+assert_no_class() {
+	local label="$1"
+	local file_list="$2"
+	local absent_class="$3"
+	local got
+	got=$(_classify_conflicts_by_pattern "$file_list" "$CONF_FILE")
+	if echo "$got" | grep -q "^${absent_class} "; then
+		fail "classify: $label — expected NO $absent_class line" \
+			"Got: $(echo "$got" | head -5)"
+		return 0
+	fi
+	pass "classify: $label → no spurious $absent_class"
+	return 0
+}
+
+test_classify_drizzle_journal() {
+	assert_class "Drizzle journal" \
+		"packages/db/migrations/meta/_journal.json" \
+		"DRIZZLE_MIGRATION"
+	return 0
+}
+
+test_classify_drizzle_snapshot() {
+	assert_class "Drizzle snapshot" \
+		"packages/db/migrations/meta/0084_snapshot.json" \
+		"DRIZZLE_MIGRATION"
+	return 0
+}
+
+test_classify_pnpm_lockfile() {
+	assert_class "pnpm lockfile" "pnpm-lock.yaml" "LOCKFILE"
+	return 0
+}
+
+test_classify_npm_lockfile() {
+	assert_class "npm lockfile" "package-lock.json" "LOCKFILE"
+	return 0
+}
+
+test_classify_yarn_lockfile() {
+	assert_class "yarn lockfile" "yarn.lock" "LOCKFILE"
+	return 0
+}
+
+test_classify_i18n_translation() {
+	assert_class "i18n translation" \
+		"packages/i18n/src/translations/en/dashboard.json" \
+		"I18N_JSON"
+	return 0
+}
+
+test_classify_code_fallback() {
+	assert_class "CODE fallback" \
+		"packages/api/src/routes/users.ts" \
+		"CODE"
+	return 0
+}
+
+test_classify_code_no_drizzle_spurious() {
+	# Normal TS file should NOT be classified as DRIZZLE_MIGRATION
+	assert_no_class "no spurious DRIZZLE for .ts" \
+		"apps/web/src/pages/settings.tsx" \
+		"DRIZZLE_MIGRATION"
+	return 0
+}
+
+test_classify_mixed_patterns() {
+	# A mixed PR: Drizzle + lockfile + code
+	local file_list
+	file_list=$(printf '%s\n' \
+		"packages/db/migrations/meta/_journal.json" \
+		"pnpm-lock.yaml" \
+		"packages/api/src/users.ts")
+	local got
+	got=$(_classify_conflicts_by_pattern "$file_list" "$CONF_FILE")
+
+	local ok=0
+	if echo "$got" | grep -q "^DRIZZLE_MIGRATION "; then ok=$((ok + 1)); fi
+	if echo "$got" | grep -q "^LOCKFILE ";           then ok=$((ok + 1)); fi
+	if echo "$got" | grep -q "^CODE ";               then ok=$((ok + 1)); fi
+
+	if [[ "$ok" -eq 3 ]]; then
+		pass "classify: mixed PR → DRIZZLE_MIGRATION + LOCKFILE + CODE"
+		return 0
+	fi
+	fail "classify: mixed PR — expected 3 classes, found $ok" \
+		"Got: $got"
+	return 0
+}
+
+test_classify_code_only_no_drizzle() {
+	# All CODE — no pattern guidance should fire
+	local file_list
+	file_list=$(printf '%s\n' \
+		"apps/web/src/pages/index.tsx" \
+		"packages/api/src/routes/health.ts")
+	local got
+	got=$(_classify_conflicts_by_pattern "$file_list" "$CONF_FILE")
+	if echo "$got" | grep -qE "^(DRIZZLE_MIGRATION|LOCKFILE|I18N_JSON|GENERATED) "; then
+		fail "classify: code-only PR — unexpected non-CODE classification" \
+			"Got: $got"
+		return 0
+	fi
+	pass "classify: code-only PR → CODE only, no pattern lines"
+	return 0
+}
+
+# ── _emit_conflict_pattern_guidance unit tests ───────────────────────────────
+
+test_guidance_emits_header_for_drizzle() {
+	local classifications="DRIZZLE_MIGRATION packages/db/migrations/meta/_journal.json"
+	local got
+	got=$(_emit_conflict_pattern_guidance "$classifications" "develop")
+	if echo "$got" | grep -q "### Pattern-Specific Resolution Guidance"; then
+		pass "guidance: header emitted for DRIZZLE_MIGRATION"
+		return 0
+	fi
+	fail "guidance: header missing for DRIZZLE_MIGRATION" \
+		"Output: $(echo "$got" | head -5)"
+	return 0
+}
+
+test_guidance_drizzle_mentions_db_generate() {
+	local classifications="DRIZZLE_MIGRATION packages/db/migrations/meta/0084_snapshot.json"
+	local got
+	got=$(_emit_conflict_pattern_guidance "$classifications" "main")
+	if echo "$got" | grep -q "db:generate"; then
+		pass "guidance: DRIZZLE_MIGRATION mentions db:generate"
+		return 0
+	fi
+	fail "guidance: DRIZZLE_MIGRATION missing db:generate step" \
+		"Output: $(echo "$got" | head -10)"
+	return 0
+}
+
+test_guidance_drizzle_has_warning() {
+	local classifications="DRIZZLE_MIGRATION packages/db/migrations/meta/_journal.json"
+	local got
+	got=$(_emit_conflict_pattern_guidance "$classifications" "main")
+	if echo "$got" | grep -iq "WARNING"; then
+		pass "guidance: DRIZZLE_MIGRATION includes WARNING about snapshot corruption"
+		return 0
+	fi
+	fail "guidance: DRIZZLE_MIGRATION missing WARNING block" \
+		"Output: $(echo "$got" | head -15)"
+	return 0
+}
+
+test_guidance_lockfile_mentions_no_frozen() {
+	local classifications="LOCKFILE pnpm-lock.yaml"
+	local got
+	got=$(_emit_conflict_pattern_guidance "$classifications" "main")
+	if echo "$got" | grep -q "no-frozen-lockfile"; then
+		pass "guidance: LOCKFILE mentions --no-frozen-lockfile"
+		return 0
+	fi
+	fail "guidance: LOCKFILE missing --no-frozen-lockfile hint" \
+		"Output: $(echo "$got" | head -10)"
+	return 0
+}
+
+test_guidance_i18n_mentions_jq_union() {
+	local classifications="I18N_JSON packages/i18n/src/translations/en/dashboard.json"
+	local got
+	got=$(_emit_conflict_pattern_guidance "$classifications" "main")
+	if echo "$got" | grep -q "jq"; then
+		pass "guidance: I18N_JSON mentions jq union merge"
+		return 0
+	fi
+	fail "guidance: I18N_JSON missing jq union merge step" \
+		"Output: $(echo "$got" | head -10)"
+	return 0
+}
+
+test_guidance_code_only_is_empty() {
+	local classifications="CODE packages/api/src/users.ts"
+	local got
+	got=$(_emit_conflict_pattern_guidance "$classifications" "main")
+	if [[ -z "$got" ]]; then
+		pass "guidance: CODE-only input produces empty output"
+		return 0
+	fi
+	fail "guidance: CODE-only input should produce no output" \
+		"Got: $got"
+	return 0
+}
+
+test_guidance_empty_input_is_empty() {
+	local got
+	got=$(_emit_conflict_pattern_guidance "" "main")
+	if [[ -z "$got" ]]; then
+		pass "guidance: empty input produces empty output"
+		return 0
+	fi
+	fail "guidance: empty input should produce no output" \
+		"Got: $got"
+	return 0
+}
+
+# ── _build_conflict_feedback_section integration smoke tests ─────────────────
+
+test_brief_has_pattern_guidance_for_drizzle() {
+	local files="packages/db/migrations/meta/_journal.json"
+	local got
+	got=$(_build_conflict_feedback_section \
+		"3047" "feat: add voice usage" "$files" "abc1234" "develop" "1")
+	if echo "$got" | grep -q "### Pattern-Specific Resolution Guidance"; then
+		pass "brief: contains Pattern-Specific Resolution Guidance for Drizzle file"
+		return 0
+	fi
+	fail "brief: Pattern-Specific Resolution Guidance missing for Drizzle file" \
+		"Output (first 20 lines): $(echo "$got" | head -20)"
+	return 0
+}
+
+test_brief_has_pattern_guidance_mixed_pr() {
+	local files
+	files=$(printf '%s\n' \
+		"packages/db/migrations/meta/_journal.json" \
+		"pnpm-lock.yaml" \
+		"packages/i18n/src/translations/en/dashboard.json" \
+		"packages/api/src/users.ts")
+	local got
+	got=$(_build_conflict_feedback_section \
+		"3088" "feat: add dashboard i18n" "$files" "def5678" "main" "4")
+
+	local ok=0
+	if echo "$got" | grep -q "### Pattern-Specific Resolution Guidance"; then ok=$((ok + 1)); fi
+	if echo "$got" | grep -q "db:generate"; then ok=$((ok + 1)); fi
+	if echo "$got" | grep -q "jq"; then ok=$((ok + 1)); fi
+	if echo "$got" | grep -q "no-frozen-lockfile"; then ok=$((ok + 1)); fi
+	if echo "$got" | grep -q "### Worker guidance"; then ok=$((ok + 1)); fi
+
+	if [[ "$ok" -eq 5 ]]; then
+		pass "brief: mixed PR — pattern guidance + worker guidance all present"
+		return 0
+	fi
+	fail "brief: mixed PR — only $ok/5 expected sections present" \
+		"Output (first 40 lines): $(echo "$got" | head -40)"
+	return 0
+}
+
+test_brief_no_pattern_guidance_for_code_only() {
+	local files
+	files=$(printf '%s\n' \
+		"apps/web/src/pages/index.tsx" \
+		"packages/api/src/routes/health.ts")
+	local got
+	got=$(_build_conflict_feedback_section \
+		"3326" "fix: correct user lookup" "$files" "fed9012" "main" "2")
+	if echo "$got" | grep -q "### Pattern-Specific Resolution Guidance"; then
+		fail "brief: code-only PR should NOT have Pattern-Specific Resolution Guidance" \
+			"Output (first 20 lines): $(echo "$got" | head -20)"
+		return 0
+	fi
+	if echo "$got" | grep -q "### Worker guidance"; then
+		pass "brief: code-only PR → no pattern guidance, worker guidance present"
+		return 0
+	fi
+	fail "brief: code-only PR missing ### Worker guidance" \
+		"Output: $(echo "$got" | head -20)"
+	return 0
+}
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+
+main_test() {
+	if ! check_prerequisites; then
+		return 1
+	fi
+
+	printf '\nConf file checks:\n'
+	test_conf_has_drizzle_pattern
+	test_conf_has_lockfile_patterns
+	test_conf_has_i18n_pattern
+
+	printf '\n_classify_conflicts_by_pattern unit tests:\n'
+	test_classify_drizzle_journal
+	test_classify_drizzle_snapshot
+	test_classify_pnpm_lockfile
+	test_classify_npm_lockfile
+	test_classify_yarn_lockfile
+	test_classify_i18n_translation
+	test_classify_code_fallback
+	test_classify_code_no_drizzle_spurious
+	test_classify_mixed_patterns
+	test_classify_code_only_no_drizzle
+
+	printf '\n_emit_conflict_pattern_guidance unit tests:\n'
+	test_guidance_emits_header_for_drizzle
+	test_guidance_drizzle_mentions_db_generate
+	test_guidance_drizzle_has_warning
+	test_guidance_lockfile_mentions_no_frozen
+	test_guidance_i18n_mentions_jq_union
+	test_guidance_code_only_is_empty
+	test_guidance_empty_input_is_empty
+
+	printf '\n_build_conflict_feedback_section integration tests:\n'
+	test_brief_has_pattern_guidance_for_drizzle
+	test_brief_has_pattern_guidance_mixed_pr
+	test_brief_no_pattern_guidance_for_code_only
+
+	printf '\nRan %d tests, %d failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main_test "$@"


### PR DESCRIPTION
## Summary

Add pattern-aware conflict resolution guidance to the `_build_conflict_feedback_section`
in `pulse-merge-feedback.sh`, breaking the repeat-reroute loop where workers hit the same
pattern-specific conflict shape 3+ times because the generic brief offered no targeted fix.

## What

- **NEW** `.agents/configs/conflict-patterns.conf` — declarative registry mapping `grep_substring | CLASSIFICATION | hint` for DRIZZLE_MIGRATION, LOCKFILE, I18N_JSON, GENERATED patterns. Single source of truth: add new patterns here with no shell edits required.
- **NEW** `_classify_conflicts_by_pattern()` in `pulse-merge-feedback.sh` — reads the conf (first match wins, `grep -F` substring), outputs `CLASS file1 file2 ...` per classification. Bash 3.2 compat (no `declare -A`). Function body: 51 lines.
- **NEW** `_emit_conflict_pattern_guidance()` — emits a `### Pattern-Specific Resolution Guidance` Markdown block per non-CODE class, with targeted one-shot steps. CODE-only input produces no output. Function body: 99 lines.
- **EDIT** `_build_conflict_feedback_section()` — calls the two helpers and embeds the pattern guidance between the file list and the generic "Worker guidance" section. Function body: 90 lines.
- **NEW** `.agents/scripts/tests/test-conflict-pattern-detection.sh` — 24 tests covering each pattern, mixed patterns, integration smoke tests for the full brief output.
- **EDIT** `.agents/AGENTS.md` — "Conflict Resolution Patterns (t2987)" subsection with registry table and extension guide.

## Why

Evidence from a managed private repo: 3 reroutes on the same issue (PR #3047 → #3088 → #3326), all DIRTY with `packages/db/migrations/meta/_journal.json` + snapshot add/add conflicts. Generic "files conflicted, rebuild on develop" tells the next worker nothing about the Drizzle migration idx collision root cause — they hit the same conflict, get rerouted, repeat. Pattern-aware briefs give a one-shot resolution path.

## Verification

```bash
shellcheck .agents/scripts/pulse-merge-feedback.sh
bash .agents/scripts/tests/test-conflict-pattern-detection.sh
# 24 tests, 0 failed
```

## Complexity Bump Justification

`_build_conflict_feedback_section`: base=76, head=90, new=90 lines. Growth of 14 lines is the direct cost of embedding the classifier call (8 lines) and pattern_guidance_block variable into the existing heredoc (2 lines). The function stays well under the 100-line gate. Two new helper functions extracted (51 + 99 lines) to keep each unit focused and testable.

Resolves #21379


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.1 plugin for [OpenCode](https://opencode.ai) v1.14.26 with claude-sonnet-4-6 spent 11m and 39,485 tokens on this as a headless worker.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.1 plugin for [OpenCode](https://opencode.ai) v1.14.26 with claude-sonnet-4-6 spent 11m and 40,466 tokens on this as a headless worker.
