### PR TITLE
t2985: batch oimp search per-repo to eliminate per-issue gh API calls

### DIFF
--- a/.agents/scripts/pulse-issue-reconcile-actions.sh
+++ b/.agents/scripts/pulse-issue-reconcile-actions.sh
@@ -532,23 +532,41 @@ _action_rsd_single() {
 # Stage 3 action: close an open issue whose linked PR has already merged.
 # (Per-issue body of reconcile_open_issues_with_merged_prs — no slug loop.)
 #
-# Args: $1=slug, $2=issue_num, $3=verify_helper
+# t2985: looks up the merged PR via the per-repo prefetched lookup string
+# (built once by _build_oimp_lookup_for_slug). Replaces the previous
+# per-issue gh search + gh pr view body-recheck pair, which was the
+# dominant cost driver in reconcile_issues_single_pass (~600s/cycle at
+# steady-state, the t2984 budget threshold). Body-keyword filtering is
+# built into the lookup builder itself, so the redundant body-grep is
+# also gone.
+#
+# Args:
+#   $1 = slug
+#   $2 = issue_num
+#   $3 = verify_helper (path to verify-issue-close-helper.sh)
+#   $4 = oimp_lookup (pipe-delimited |num=pr|...| string from
+#        _build_oimp_lookup_for_slug; may be empty if prefetch failed)
 # Returns: 0 if closed, 1 otherwise
 #######################################
 _action_oimp_single() {
 	local slug="$1" issue_num="$2" verify_helper="$3"
+	local oimp_lookup="${4:-}"
 
+	# t2985: lookup PR number locally instead of `gh pr list --search`.
+	# Empty lookup → no merged PR found → return 1 (next-cycle retry).
 	local merged_pr_num=""
-	merged_pr_num=$(_gh_pr_list_merged --repo "$slug" --state merged \
-		--search "Resolves #${issue_num} OR Closes #${issue_num} OR Fixes #${issue_num}" \
-		--json number --jq '.[0].number // ""' --limit 1 2>/dev/null) || merged_pr_num=""
+	if [[ -n "$oimp_lookup" ]]; then
+		merged_pr_num=$(printf '%s' "$oimp_lookup" \
+			| grep -oE "\|${issue_num}=[0-9]+" 2>/dev/null \
+			| head -1 \
+			| cut -d= -f2) || merged_pr_num=""
+	fi
 	[[ -n "$merged_pr_num" && "$merged_pr_num" =~ ^[0-9]+$ ]] || return 1
 
-	local pr_body
-	pr_body=$(gh pr view "$merged_pr_num" --repo "$slug" --json body --jq '.body // ""' 2>/dev/null) || pr_body=""
-	if ! printf '%s' "$pr_body" | grep -qiE "(Resolves|Closes|Fixes)\s+#${issue_num}\b"; then
-		return 1
-	fi
+	# Body keyword check is built into the lookup builder — the jq scan
+	# only emits pairs from PR bodies actually containing
+	# Resolves|Closes|Fixes #N. The previous `gh pr view ... body` re-grep
+	# is now redundant and removed (t2985).
 
 	if [[ -x "$verify_helper" ]]; then
 		if ! "$verify_helper" check "$issue_num" "$merged_pr_num" "$slug" >/dev/null 2>&1; then

--- a/.agents/scripts/pulse-issue-reconcile.sh
+++ b/.agents/scripts/pulse-issue-reconcile.sh
@@ -123,6 +123,69 @@ _gh_pr_list_merged() {
 	return $?
 }
 
+#######################################
+# t2985: Build a per-repo "issue → merged PR" lookup string for stage-3
+# reconcile (oimp).
+#
+# Replaces the per-issue `gh pr list --search "Resolves #N OR Closes #N OR
+# Fixes #N"` call previously made by _action_oimp_single. At cross-repo
+# scale (8 pulse-enabled repos × ~30 non-parent open issues each ≈ 200+
+# search calls per cycle, ~3s each) the per-issue search is the dominant
+# cost driver — this is what t2984's 360s time budget exists to contain
+# rather than fix. With this prefetch: 1 batched call per repo per cycle
+# (8 calls total), local string lookup for each issue.
+#
+# Output format: pipe-delimited "|issue_num=pr_num|...|" string. Bash 3.2
+# does not support associative arrays; a string + grep is the most
+# portable lookup primitive (matches issue body's stated approach).
+#
+# Lookup contract (caller side):
+#   merged_pr=$(printf '%s' "$lookup" | grep -oE "\|${issue_num}=[0-9]+" \
+#       | head -1 | cut -d= -f2)
+# The leading + trailing "|" and the "=" separator together prevent
+# prefix-substring false matches (e.g. lookup `|10=`, search `|1=` — the
+# required `=` after the issue number anchors the match boundary).
+#
+# Body-keyword check is built into the lookup itself: the jq scan only
+# emits pairs from PR bodies actually containing Resolves|Closes|Fixes #N.
+# This collapses what was previously two gh API calls per issue (search +
+# pr view --json body) into the single per-repo prefetch.
+#
+# Limit 200 most-recent merged PRs per repo. Sufficient for the typical
+# case (open issue resolved by a PR within days/weeks of merge); a 6-month
+# old open-but-already-merged-by-an-old-PR is degenerate and falls
+# through to next-cycle retry without harm (issue stays open).
+#
+# Args:    $1 = slug (owner/repo)
+# Returns: prints lookup string on stdout (may be empty); exit 0 always.
+#######################################
+_build_oimp_lookup_for_slug() {
+	local slug="$1"
+	[[ -n "$slug" ]] || return 0
+
+	# One gh call per repo per cycle (replaces ~30 per-issue calls).
+	# --json body costs more bytes per call but the trip count goes from
+	# ~200/cycle to 8/cycle — net ~30x reduction in API round-trips.
+	local merged_prs_json
+	merged_prs_json=$(_gh_pr_list_merged --repo "$slug" --state merged \
+		--json number,body --limit 200 2>/dev/null) || merged_prs_json="[]"
+	[[ -n "$merged_prs_json" && "$merged_prs_json" != "null" ]] || return 0
+
+	# jq scan() with one capture group returns ["issue_num"] per match.
+	# (?i) makes the keyword case-insensitive — mirrors the original
+	# `grep -iE` pattern in _action_oimp_single.
+	# Output `|num=pr|...|` so callers can grep with anchored boundaries.
+	printf '%s' "$merged_prs_json" | jq -r '
+		[
+			.[] | . as $pr |
+			(.body // "") |
+			scan("(?i)(?:resolves|closes|fixes)\\s+#([0-9]+)") |
+			"\(.[0])=\($pr.number)"
+		] | if length > 0 then "|" + join("|") + "|" else "" end
+	' 2>/dev/null || true
+	return 0
+}
+
 # t2375: stale-recovery subsystem extracted to keep this file below the 1500-
 # line complexity gate. SCRIPT_DIR is set by pulse-wrapper.sh when sourced by
 # the orchestrator; fall back to BASH_SOURCE-derived path when sourced directly
@@ -650,6 +713,12 @@ reconcile_open_issues_with_merged_prs() {
 			jq -r --arg pt "$_PIR_PT_LABEL" '.[] | select((.labels // []) | map(.name) | index($pt) != null) | .number' \
 			2>/dev/null) || parent_task_nums=""
 
+		# t2985: per-repo merged-PR prefetch (replaces per-issue gh search).
+		# Same pattern as reconcile_issues_single_pass — one gh call here
+		# replaces N per-issue gh search calls in _action_oimp_single.
+		local oimp_lookup=""
+		oimp_lookup=$(_build_oimp_lookup_for_slug "$slug")
+
 		local i=0
 		while [[ "$i" -lt "$issue_count" ]] && [[ "$total_closed" -lt "$max_closes" ]]; do
 			local issue_num
@@ -662,7 +731,8 @@ reconcile_open_issues_with_merged_prs() {
 			_should_oimp "$issue_num" "$parent_task_nums" || continue
 
 			# t2776: delegate per-issue action to shared helper (_action_oimp_single).
-			if _action_oimp_single "$slug" "$issue_num" "$verify_helper"; then
+			# t2985: pass oimp_lookup as 4th arg.
+			if _action_oimp_single "$slug" "$issue_num" "$verify_helper" "$oimp_lookup"; then
 				total_closed=$((total_closed + 1))
 			fi
 		done
@@ -1497,6 +1567,13 @@ reconcile_issues_single_pass() {
 		') || issues_tsv=""
 		[[ -n "$issues_tsv" ]] || continue
 
+		# t2985: per-repo merged-PR prefetch for stage 3 (oimp).
+		# One gh call per repo replaces ~30 per-issue gh search calls.
+		# Empty lookup is safe — _action_oimp_single returns 1 on empty
+		# lookup, deferring stage 3 closes to the next cycle.
+		local oimp_lookup=""
+		oimp_lookup=$(_build_oimp_lookup_for_slug "$slug")
+
 		while IFS='|' read -r issue_num issue_title_b64 labels_csv issue_body_b64; do
 			[[ "$issue_num" =~ ^[0-9]+$ ]] || continue
 
@@ -1549,7 +1626,7 @@ reconcile_issues_single_pass() {
 			# Stage 3: close open issues whose linked PR already merged (global cap)
 			if [[ "$oimp_total_closed" -lt "$oimp_max" ]] && \
 				_should_oimp "$issue_num" "$parent_task_nums"; then
-				if _action_oimp_single "$slug" "$issue_num" "$verify_helper"; then
+				if _action_oimp_single "$slug" "$issue_num" "$verify_helper" "$oimp_lookup"; then
 					oimp_total_closed=$((oimp_total_closed + 1))
 					continue
 				fi

--- a/.agents/scripts/tests/test-pulse-issue-reconcile.sh
+++ b/.agents/scripts/tests/test-pulse-issue-reconcile.sh
@@ -481,6 +481,137 @@ test_t2984_budget_env_validation() {
 }
 
 # ---------------------------------------------------------------------------
+# Test 13 (t2985): _build_oimp_lookup_for_slug — extracts |issue=pr| pairs
+# ---------------------------------------------------------------------------
+# Verifies the per-repo prefetch helper that replaces _action_oimp_single's
+# per-issue `gh pr list --search` calls. The helper:
+#   1. Calls _gh_pr_list_merged for the slug (stubbed in test).
+#   2. jq scan() extracts (issue_num, pr_num) pairs from PR bodies that
+#      contain Resolves|Closes|Fixes #N (case-insensitive).
+#   3. Returns a "|num=pr|...|" string for grep-based lookup downstream.
+#
+# Test fixture covers:
+#   - Multiple keywords (Resolves, Fixes, Closes) in one PR body.
+#   - Multiple issues closed by one PR.
+#   - PRs with no closing keyword (must be skipped).
+#   - PRs with null body (must not crash).
+#   - Case-insensitivity (resolves/RESOLVES/Resolves all match).
+# ---------------------------------------------------------------------------
+test_t2985_oimp_lookup_builder() {
+	# Fixture: 4 PRs covering the cases above.
+	local fixture_json
+	fixture_json=$(jq -nc '[
+		{number: 1234, body: "Resolves #42\nFixes #99\nCloses #50"},
+		{number: 5678, body: "closes #100"},
+		{number: 9999, body: "merge candidate, no keyword"},
+		{number: 1111, body: null}
+	]')
+
+	# Extract the helper definition from RECONCILE_SH.
+	# The function spans ~10 lines from declaration to closing brace.
+	local helper_def
+	helper_def=$(sed -n '/^_build_oimp_lookup_for_slug()/,/^}$/p' "${RECONCILE_SH}")
+	if [[ -z "$helper_def" ]]; then
+		_fail "t2985: _build_oimp_lookup_for_slug not found in ${RECONCILE_SH}"
+		return 0
+	fi
+
+	# Run the helper in a subshell with a stub _gh_pr_list_merged.
+	local result
+	result=$(bash -c "
+		${helper_def}
+		_gh_pr_list_merged() { printf '%s' '${fixture_json}'; return 0; }
+		_build_oimp_lookup_for_slug 'test/repo'
+	" 2>/dev/null)
+
+	# Expected output: pipe-delimited |num=pr| pairs, one per scan match.
+	# PR 1234 contributes 3 pairs (42, 99, 50); PR 5678 contributes 1 (100);
+	# PRs 9999 and 1111 contribute 0.
+	local expected="|42=1234|99=1234|50=1234|100=5678|"
+	if [[ "$result" == "$expected" ]]; then
+		_pass "t2985: lookup builder extracts 4 pairs from 2 keyword-bearing PRs"
+	else
+		_fail "t2985: lookup builder — expected '${expected}', got '${result}'"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 14 (t2985): grep-based lookup avoids prefix-substring false matches
+# ---------------------------------------------------------------------------
+# Critical correctness test: with input lookup |1=100|10=200|11=300|, a
+# search for issue #1 must NOT match #10 or #11. The leading "|" plus the
+# "=" separator anchor each pair so grep -oE "\|1=[0-9]+" only matches the
+# #1 entry. Without the "=" anchor, a regex like "|1[0-9]+" would falsely
+# match "|10=" or "|11=".
+# ---------------------------------------------------------------------------
+test_t2985_oimp_lookup_no_prefix_collision() {
+	# Three issues with prefix-overlap numbers all in the same lookup.
+	local lookup="|1=100|10=200|11=300|"
+
+	local m1 m10 m11
+	m1=$(printf '%s' "$lookup" | grep -oE "\|1=[0-9]+" 2>/dev/null | head -1 | cut -d= -f2)
+	m10=$(printf '%s' "$lookup" | grep -oE "\|10=[0-9]+" 2>/dev/null | head -1 | cut -d= -f2)
+	m11=$(printf '%s' "$lookup" | grep -oE "\|11=[0-9]+" 2>/dev/null | head -1 | cut -d= -f2)
+
+	local all_ok=1
+	[[ "$m1"  == "100" ]] || { _fail "t2985: |1=  matched '${m1}', expected 100"; all_ok=0; }
+	[[ "$m10" == "200" ]] || { _fail "t2985: |10= matched '${m10}', expected 200"; all_ok=0; }
+	[[ "$m11" == "300" ]] || { _fail "t2985: |11= matched '${m11}', expected 300"; all_ok=0; }
+
+	[[ "$all_ok" == "1" ]] && _pass "t2985: |N= boundary anchors prevent prefix-substring false matches (#1 vs #10/#11)"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 15 (t2985): _action_oimp_single takes the lookup as 4th arg
+# ---------------------------------------------------------------------------
+# Verify the signature change in pulse-issue-reconcile-actions.sh and
+# both call sites in pulse-issue-reconcile.sh pass the lookup. This
+# catches the partial-rollout case where the helper exists but a caller
+# still uses the 3-arg form.
+# ---------------------------------------------------------------------------
+test_t2985_action_oimp_single_signature() {
+	local actions_sh="${SCRIPT_DIR}/../pulse-issue-reconcile-actions.sh"
+	local all_ok=1
+
+	# 1. _action_oimp_single body must read the 4th arg as oimp_lookup.
+	# SC2016: single-quoted pattern intentionally contains literal ${4:-} —
+	# grepping for the literal source string, no expansion wanted.
+	# shellcheck disable=SC2016
+	if ! grep -q 'oimp_lookup="${4:-}"' "${actions_sh}"; then
+		_fail "t2985: _action_oimp_single signature missing oimp_lookup 4th arg"
+		all_ok=0
+	fi
+
+	# 2. _action_oimp_single must NOT call _gh_pr_list_merged directly anymore.
+	#    The acceptance criterion: only the per-repo prefetch builder calls it.
+	if grep -q '_gh_pr_list_merged' "${actions_sh}"; then
+		_fail "t2985: _action_oimp_single still calls _gh_pr_list_merged directly (should use lookup)"
+		all_ok=0
+	fi
+
+	# 3. Both call sites in RECONCILE_SH pass 4 args (slug, issue, verify, lookup).
+	#    Use grep -E to match the multi-arg form and require oimp_lookup at end.
+	# SC2016: single-quoted pattern intentionally contains literal $slug etc. —
+	# grepping for the literal source string, no expansion wanted.
+	local call_count
+	# shellcheck disable=SC2016
+	call_count=$(grep -cE '_action_oimp_single "\$slug" "\$issue_num" "\$verify_helper" "\$oimp_lookup"' \
+		"${RECONCILE_SH}" 2>/dev/null || true)
+	[[ "$call_count" =~ ^[0-9]+$ ]] || call_count=0
+	if [[ "$call_count" -ge 2 ]]; then
+		_pass "t2985: ${call_count} call site(s) pass oimp_lookup to _action_oimp_single"
+	else
+		_fail "t2985: expected ≥2 call sites passing oimp_lookup, got ${call_count}"
+		all_ok=0
+	fi
+
+	[[ "$all_ok" == "1" ]] && _pass "t2985: _action_oimp_single signature contract enforced"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
 test_cache_miss_no_file
@@ -495,6 +626,9 @@ test_single_pass_wired_in_engine
 test_batched_field_extraction_parity
 test_t2984_time_budget_present
 test_t2984_budget_env_validation
+test_t2985_oimp_lookup_builder
+test_t2985_oimp_lookup_no_prefix_collision
+test_t2985_action_oimp_single_signature
 
 echo ""
 echo "Results: ${pass} passed, ${fail} failed"


### PR DESCRIPTION
## Summary

Replaces per-issue gh pr list --search in _action_oimp_single with one batched per-repo prefetch. Cuts gh API calls from ~200/cycle to 8/cycle (one per pulse-enabled repo).

## Files Changed

.agents/scripts/pulse-issue-reconcile-actions.sh,.agents/scripts/pulse-issue-reconcile.sh,.agents/scripts/tests/test-pulse-issue-reconcile.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean across all 3 modified files; 3 new t2985 tests pass; budget-isolation regression test still passes (5/5)

Resolves #21375


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.1 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-opus-4-7 spent 12m and 36,182 tokens on this as a headless worker.