### PR TITLE
t2992: pre-warm pulse caches before restart to eliminate first-cycle stage cost

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -916,6 +916,8 @@ Headless workers failing, stalling, or stuck in dispatch loops: `reference/worke
 
 **Pulse decision correlation (t2714):** `pulse-diagnose-helper.sh pr <N> [--repo <slug>]` explains what the pulse did on any PR and why, classified against a 60+ rule inventory. Use `--verbose` for raw log lines, `--json` for programmatic output. Full detail: `reference/worker-diagnostics.md`.
 
+**Pulse cache priming (t2992):** Every pulse boot via `pulse-lifecycle-helper.sh::_start` (covering `aidevops update`, `setup.sh`, `restart-if-running`, t2914 ensure-running, manual restart) pre-warms the L3 per-owner JSON caches by invoking `pulse-cache-prime.sh` BEFORE the `nohup pulse-wrapper.sh` spawn. The next pulse cycle's `prefetch_state` then finds warm caches and runs the t1975 delta path (only items with `updatedAt > last_prefetch`) instead of the cold-cache full fetch. Eliminates the structural ~210s `prefetch_state` cost on the first post-restart cycle that t2989 (per-iteration timeout) and t2988 (reconcile budget) cannot address. Counters: `pulse_cache_prime_runs` and `pulse_cache_prime_failures` in `pulse-stats.json`. Sentinel: `~/.aidevops/cache/pulse-cache-prime-last-run`. Log: `~/.aidevops/logs/pulse-cache-prime.log`. Opt out: `AIDEVOPS_SKIP_CACHE_PRIME=1`. The early-return-if-running gate in `_start` makes this a no-op when pulse is already alive — priming only fires on actual startup.
+
 ## Self-Improvement
 
 Every agent session should improve the system, not just complete its task. Full guidance: `reference/self-improvement.md`.

--- a/.agents/scripts/pulse-cache-prime.sh
+++ b/.agents/scripts/pulse-cache-prime.sh
@@ -69,7 +69,7 @@ main() {
 		return 1
 	fi
 
-	local start_t end_t duration
+	local start_t="" end_t="" duration=""
 	start_t=$(date +%s 2>/dev/null) || start_t=0
 
 	_log "Starting cache prime (t2992)..."

--- a/.agents/scripts/pulse-cache-prime.sh
+++ b/.agents/scripts/pulse-cache-prime.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# pulse-cache-prime.sh (t2992) — pre-warm pulse caches before restart.
+#
+# When `aidevops update` deploys new code, the pulse restarts and its
+# first cycle pays the full cold-cache cost: ~210s prefetch_state +
+# ~144s preflight_capacity_and_labels + ~50s preflight_cleanup_and_ledger
+# ≈ 8-10 minutes before any productive work. This script pre-warms the
+# L3 per-owner JSON caches via pulse-batch-prefetch-helper.sh refresh,
+# so the next pulse cycle's prefetch_state finds warm state and runs
+# the delta path (t1975 architecture — only fetches items with
+# updatedAt > last_prefetch).
+#
+# Wired into pulse-lifecycle-helper.sh::_start so every restart path
+# (aidevops update, setup.sh, manual restart, t2914 ensure-running)
+# primes before the pulse boots. Early-return-if-running gate in
+# _start makes this a no-op when pulse is already alive.
+#
+# Standalone use:   pulse-cache-prime.sh
+# Skip:             AIDEVOPS_SKIP_CACHE_PRIME=1 pulse-cache-prime.sh
+#
+# Exit codes:
+#   0 - Success or skipped via env opt-out
+#   1 - Refresh failed (caller logs but should not abort restart)
+#
+# Logs to ~/.aidevops/logs/pulse-cache-prime.log.
+# Sentinel file: ~/.aidevops/cache/pulse-cache-prime-last-run.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LOG_DIR="${HOME}/.aidevops/logs"
+LOG_FILE="${LOG_DIR}/pulse-cache-prime.log"
+CACHE_DIR="${HOME}/.aidevops/cache"
+SENTINEL="${CACHE_DIR}/pulse-cache-prime-last-run"
+PRIME_HELPER="${SCRIPT_DIR}/pulse-batch-prefetch-helper.sh"
+STATS_HELPER="${SCRIPT_DIR}/pulse-stats-helper.sh"
+
+mkdir -p "$LOG_DIR" "$CACHE_DIR" 2>/dev/null || true
+
+_log() {
+	local msg="$1"
+	printf '[%s] %s\n' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "$msg" >>"$LOG_FILE" 2>/dev/null || true
+	return 0
+}
+
+_increment_counter() {
+	local counter_name="$1"
+	[[ -f "$STATS_HELPER" ]] || return 0
+	# shellcheck disable=SC1090
+	source "$STATS_HELPER" 2>/dev/null || return 0
+	if declare -F pulse_stats_increment >/dev/null 2>&1; then
+		pulse_stats_increment "$counter_name" 2>/dev/null || true
+	fi
+	return 0
+}
+
+main() {
+	if [[ "${AIDEVOPS_SKIP_CACHE_PRIME:-0}" == "1" ]]; then
+		_log "AIDEVOPS_SKIP_CACHE_PRIME=1 — skipping cache prime"
+		return 0
+	fi
+
+	if [[ ! -x "$PRIME_HELPER" ]]; then
+		_log "ERROR: pulse-batch-prefetch-helper.sh not found or not executable: $PRIME_HELPER"
+		_increment_counter "pulse_cache_prime_failures"
+		return 1
+	fi
+
+	local start_t end_t duration
+	start_t=$(date +%s 2>/dev/null) || start_t=0
+
+	_log "Starting cache prime (t2992)..."
+
+	if "$PRIME_HELPER" refresh >>"$LOG_FILE" 2>&1; then
+		end_t=$(date +%s 2>/dev/null) || end_t=$start_t
+		duration=$((end_t - start_t))
+		_log "Cache prime succeeded in ${duration}s"
+		date -u +'%Y-%m-%dT%H:%M:%SZ' >"$SENTINEL" 2>/dev/null || true
+		_increment_counter "pulse_cache_prime_runs"
+		return 0
+	fi
+
+	end_t=$(date +%s 2>/dev/null) || end_t=$start_t
+	duration=$((end_t - start_t))
+	_log "Cache prime FAILED after ${duration}s"
+	_increment_counter "pulse_cache_prime_failures"
+	return 1
+}
+
+main "$@"

--- a/.agents/scripts/pulse-lifecycle-helper.sh
+++ b/.agents/scripts/pulse-lifecycle-helper.sh
@@ -136,6 +136,19 @@ _start() {
 	fi
 
 	mkdir -p "${_PULSE_LOG%/*}"
+
+	# t2992: pre-warm the L3 per-owner JSON caches before pulse boots so the
+	# next cycle's prefetch_state finds warm state and runs the delta path
+	# (t1975) instead of the cold-cache full fetch. Eliminates the structural
+	# ~210s prefetch_state cost on the first post-restart cycle. Non-fatal —
+	# a prime failure should not abort startup. Honours
+	# AIDEVOPS_SKIP_CACHE_PRIME=1 for debug.
+	local _prime_helper="${_PULSE_AGENTS_DIR}/scripts/pulse-cache-prime.sh"
+	if [[ -x "$_prime_helper" ]]; then
+		_pl_info "Pre-warming pulse caches (t2992)..."
+		"$_prime_helper" >/dev/null 2>&1 || _pl_warn "Cache prime returned non-zero (non-fatal — first cycle may be slow)"
+	fi
+
 	# GH#20580: set AIDEVOPS_PULSE_SOURCE so pulse-wrapper.sh records this
 	# invocation as "lifecycle-helper" in its invocation_sources counter.
 	AIDEVOPS_PULSE_SOURCE=lifecycle-helper nohup "$_PULSE_SCRIPT" >>"$_PULSE_LOG" 2>&1 &

--- a/.agents/scripts/tests/test-pulse-cache-prime.sh
+++ b/.agents/scripts/tests/test-pulse-cache-prime.sh
@@ -1,0 +1,188 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Tests for pulse-cache-prime.sh (t2992).
+#
+# The helper invokes pulse-batch-prefetch-helper.sh refresh from its own
+# SCRIPT_DIR. Tests stage a temp scripts/ directory containing a copy of
+# pulse-cache-prime.sh next to a mock pulse-batch-prefetch-helper.sh whose
+# exit code we control via TEST_PRIME_HELPER_EXIT.
+#
+# Covers:
+#   1. AIDEVOPS_SKIP_CACHE_PRIME=1 → exit 0, log records skip, no sentinel
+#   2. Missing pulse-batch-prefetch-helper.sh → exit 1
+#   3. Successful refresh → exit 0, sentinel touched, log records duration
+#   4. Failed refresh → exit 1, log records FAILED
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SOURCE_HELPER="${SCRIPT_DIR}/../pulse-cache-prime.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+
+_print_result() {
+	local name="$1"
+	local passed="$2"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$passed" == "1" ]]; then
+		printf '%b[PASS]%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$name"
+	else
+		printf '%b[FAIL]%b %s\n' "$TEST_RED" "$TEST_RESET" "$name"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+_assert_eq() {
+	local name="$1"
+	local expected="$2"
+	local actual="$3"
+	if [[ "$expected" == "$actual" ]]; then
+		_print_result "$name" 1
+	else
+		_print_result "$name (expected='$expected' actual='$actual')" 0
+	fi
+	return 0
+}
+
+_setup() {
+	TEST_ROOT=$(mktemp -d -t pulse-cache-prime-test.XXXXXX)
+	mkdir -p "${TEST_ROOT}/scripts" "${TEST_ROOT}/logs" "${TEST_ROOT}/cache"
+
+	# Stage a copy of the helper under test.
+	cp "$SOURCE_HELPER" "${TEST_ROOT}/scripts/pulse-cache-prime.sh"
+	chmod +x "${TEST_ROOT}/scripts/pulse-cache-prime.sh"
+
+	# Re-route HOME so the helper writes to TEST_ROOT-scoped paths.
+	export HOME="$TEST_ROOT"
+
+	# Mock pulse-batch-prefetch-helper.sh — exit code controlled by env.
+	cat >"${TEST_ROOT}/scripts/pulse-batch-prefetch-helper.sh" <<'SH'
+#!/usr/bin/env bash
+echo "mock prefetch refresh: exit ${TEST_PRIME_HELPER_EXIT:-0}"
+exit "${TEST_PRIME_HELPER_EXIT:-0}"
+SH
+	chmod +x "${TEST_ROOT}/scripts/pulse-batch-prefetch-helper.sh"
+
+	# Default: log + cache directory paths inside TEST_ROOT (HOME re-routed).
+	mkdir -p "${TEST_ROOT}/.aidevops/logs" "${TEST_ROOT}/.aidevops/cache"
+	return 0
+}
+
+_teardown() {
+	[[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]] && rm -rf "$TEST_ROOT"
+	TEST_ROOT=""
+	return 0
+}
+
+# Test 1: AIDEVOPS_SKIP_CACHE_PRIME=1 short-circuits.
+test_skip_env_var() {
+	local rc=0
+	AIDEVOPS_SKIP_CACHE_PRIME=1 "${TEST_ROOT}/scripts/pulse-cache-prime.sh" >/dev/null 2>&1 || rc=$?
+	_assert_eq "skip env var → exit 0" "0" "$rc"
+
+	# Sentinel must NOT exist.
+	if [[ ! -f "${TEST_ROOT}/.aidevops/cache/pulse-cache-prime-last-run" ]]; then
+		_print_result "skip env var → no sentinel" 1
+	else
+		_print_result "skip env var → no sentinel" 0
+	fi
+
+	# Log must contain the skip message.
+	if grep -q "AIDEVOPS_SKIP_CACHE_PRIME=1" "${TEST_ROOT}/.aidevops/logs/pulse-cache-prime.log" 2>/dev/null; then
+		_print_result "skip env var → log records skip" 1
+	else
+		_print_result "skip env var → log records skip" 0
+	fi
+	return 0
+}
+
+# Test 2: Missing pulse-batch-prefetch-helper.sh → exit 1.
+test_missing_helper() {
+	rm -f "${TEST_ROOT}/scripts/pulse-batch-prefetch-helper.sh"
+	local rc=0
+	"${TEST_ROOT}/scripts/pulse-cache-prime.sh" >/dev/null 2>&1 || rc=$?
+	_assert_eq "missing helper → exit 1" "1" "$rc"
+	return 0
+}
+
+# Test 3: Successful refresh → exit 0, sentinel touched, log records duration.
+test_success() {
+	# Re-stage helper (test 2 deleted it).
+	cat >"${TEST_ROOT}/scripts/pulse-batch-prefetch-helper.sh" <<'SH'
+#!/usr/bin/env bash
+echo "mock prefetch refresh: exit ${TEST_PRIME_HELPER_EXIT:-0}"
+exit "${TEST_PRIME_HELPER_EXIT:-0}"
+SH
+	chmod +x "${TEST_ROOT}/scripts/pulse-batch-prefetch-helper.sh"
+
+	rm -f "${TEST_ROOT}/.aidevops/cache/pulse-cache-prime-last-run"
+
+	local rc=0
+	TEST_PRIME_HELPER_EXIT=0 "${TEST_ROOT}/scripts/pulse-cache-prime.sh" >/dev/null 2>&1 || rc=$?
+	_assert_eq "success → exit 0" "0" "$rc"
+
+	if [[ -f "${TEST_ROOT}/.aidevops/cache/pulse-cache-prime-last-run" ]]; then
+		_print_result "success → sentinel touched" 1
+	else
+		_print_result "success → sentinel touched" 0
+	fi
+
+	if grep -q "Cache prime succeeded" "${TEST_ROOT}/.aidevops/logs/pulse-cache-prime.log" 2>/dev/null; then
+		_print_result "success → log records 'succeeded'" 1
+	else
+		_print_result "success → log records 'succeeded'" 0
+	fi
+	return 0
+}
+
+# Test 4: Failed refresh → exit 1, log records FAILED, no sentinel update.
+test_failure() {
+	rm -f "${TEST_ROOT}/.aidevops/cache/pulse-cache-prime-last-run"
+
+	local rc=0
+	TEST_PRIME_HELPER_EXIT=1 "${TEST_ROOT}/scripts/pulse-cache-prime.sh" >/dev/null 2>&1 || rc=$?
+	_assert_eq "failure → exit 1" "1" "$rc"
+
+	if [[ ! -f "${TEST_ROOT}/.aidevops/cache/pulse-cache-prime-last-run" ]]; then
+		_print_result "failure → no new sentinel" 1
+	else
+		_print_result "failure → no new sentinel" 0
+	fi
+
+	if grep -q "Cache prime FAILED" "${TEST_ROOT}/.aidevops/logs/pulse-cache-prime.log" 2>/dev/null; then
+		_print_result "failure → log records FAILED" 1
+	else
+		_print_result "failure → log records FAILED" 0
+	fi
+	return 0
+}
+
+main() {
+	_setup
+	test_skip_env_var
+	test_missing_helper
+	test_success
+	test_failure
+	_teardown
+
+	echo ""
+	echo "Tests run: ${TESTS_RUN}"
+	echo "Tests failed: ${TESTS_FAILED}"
+	if [[ "$TESTS_FAILED" -eq 0 ]]; then
+		printf '%b[OK]%b All tests passed\n' "$TEST_GREEN" "$TEST_RESET"
+		return 0
+	fi
+	printf '%b[FAIL]%b %d test(s) failed\n' "$TEST_RED" "$TEST_RESET" "$TESTS_FAILED"
+	return 1
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Pre-warm the pulse's L3 per-owner JSON caches before the pulse boots, eliminating the ~210s `prefetch_state` cold-cache cost on the first post-restart cycle. Composes with t2989 (per-iteration timeout, PR #21385) and t2988 (reconcile budget, merged PR #21384) to address all three structural causes of "pulse stops being productive after `aidevops update`".

## What changed

- **NEW `.agents/scripts/pulse-cache-prime.sh`** — single-shot wrapper around `pulse-batch-prefetch-helper.sh refresh`. Logs to `~/.aidevops/logs/pulse-cache-prime.log`, touches `~/.aidevops/cache/pulse-cache-prime-last-run`, increments `pulse_cache_prime_runs`/`pulse_cache_prime_failures` counters in `pulse-stats.json`. Honours `AIDEVOPS_SKIP_CACHE_PRIME=1` opt-out.
- **EDIT `.agents/scripts/pulse-lifecycle-helper.sh::_start`** — invoke `pulse-cache-prime.sh` after the early-return-if-running gate but before the `nohup pulse-wrapper.sh` spawn. Non-fatal: a prime failure logs a warning and proceeds with the boot.
- **EDIT `.agents/AGENTS.md`** — document the priming hook under `## Worker Diagnostics`.
- **NEW `.agents/scripts/tests/test-pulse-cache-prime.sh`** — 10 test cases covering env opt-out, missing helper, success, and failure paths. All pass locally.

## Why the lifecycle helper, not auto-update-helper.sh

The original brief proposed editing `auto-update-helper.sh`. Reading the code surfaced a cleaner choke point: every pulse restart path eventually calls `pulse-lifecycle-helper.sh::_start` —

- `aidevops update` → `pulse-lifecycle-helper.sh start` (t2914 ensure-running, line 784 of `aidevops.sh`)
- `setup.sh:1329` → `pulse-lifecycle-helper.sh restart-if-running`
- `agent-deploy.sh:601` → `pulse-lifecycle-helper.sh restart-if-running`
- Manual `pulse-lifecycle-helper.sh restart`

One insertion point, every path benefits. The early-return-if-running gate at the top of `_start` makes priming a no-op when pulse is already alive — priming only fires on actual startup, never on the steady-state idempotent `start` calls that t2914 emits on every update tick.

## Evidence

From `~/.aidevops/logs/pulse-stage-timings.log` (last 30 cycles, 2026-04-27):

| Stage | Avg | n | Fails |
|---|---|---|---|
| `preflight_prefetch_and_scope` | 210s | 5 | 0 |
| `prefetch_state` | 209s | 5 | 0 |
| `preflight_capacity_and_labels` | 144s | 11 | 0 |
| `deterministic_merge_pass` | 139s | 5 | 0 |

These are the **healthy** durations. With t2989 + t2988 both fixing hangs, this is the residual structural cost post-restart cycle 1 must pay because every cache file is cold. Priming reduces that cost by populating the L3 per-owner JSON caches that the next `prefetch_state` reads.

## Test results

```text
Tests run: 10
Tests failed: 0
[OK] All tests passed
```

```text
$ shellcheck pulse-cache-prime.sh pulse-lifecycle-helper.sh test-pulse-cache-prime.sh
(zero violations)
```

## Acceptance verification

- [x] `pulse-cache-prime.sh` exists, ShellCheck zero, parseable
- [x] `pulse-lifecycle-helper.sh::_start` calls it before pulse boots, honouring `AIDEVOPS_SKIP_CACHE_PRIME=1`
- [x] `pulse_cache_prime_runs` counter wired
- [x] `pulse_cache_prime_failures` counter wired
- [x] AGENTS.md gains a "Pulse cache priming" entry under Worker Diagnostics
- [x] No regression in cycle-1 correctness — priming only runs the existing `pulse-batch-prefetch-helper.sh refresh` (already in production)
- [ ] Phase C (standalone routine) — DEFERRED to follow-up; this PR ships the post-restart hook only
- [ ] Real-world verification: first post-restart cycle's `prefetch_state` drops by ≥50% (target: <100s vs current 210s) — measure post-deploy

## Composes with

- PR #21385 (t2989) — per-iteration timeout for hung dispatch (in flight)
- PR #21384 (t2988) — reconcile budget regression (merged)

Together: t2988 + t2989 collapse the *hang* class; this PR collapses the *cold-cache* class. Post-deploy, "pulse stops being productive after update" should drop from ~10-20 min to ~3-5 min.

Resolves #21395

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.1 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-opus-4-7 spent 16h 9m and 92,783 tokens on this with the user in an interactive session.
