### PR TITLE
t2964: add competitive sensitivity tier + _campaigns/intel/ enforcement

### DIFF
--- a/.agents/scripts/sensitivity-detector-helper.sh
+++ b/.agents/scripts/sensitivity-detector-helper.sh
@@ -19,11 +19,12 @@
 #   sensitivity-detector-helper.sh help
 #
 # Sensitivity tiers (lowest to highest):
-#   public     No restrictions — marketing copy, public docs
-#   internal   Internal business docs — not public, not personal
-#   pii        Personal data — names, addresses, ID/payment numbers
-#   sensitive  Sensitive business — board minutes, strategy, HR
-#   privileged Legally privileged — attorney-client, court filings
+#   public      No restrictions — marketing copy, public docs
+#   internal    Internal business docs — not public, not personal
+#   pii         Personal data — names, addresses, ID/payment numbers
+#   sensitive   Sensitive business — board minutes, strategy, HR
+#   competitive Competitive intel — _campaigns/intel/ enforced, local-LLM-only (Ollama), never cloud, retention months not years
+#   privileged  Legally privileged — attorney-client, court filings
 #
 # Audit log: <knowledge-root>/index/sensitivity-audit.log (JSONL)
 # Config:    <knowledge-root>/_config/sensitivity.json (falls back to template)
@@ -34,7 +35,7 @@
 #   2  Source not found
 #   3  Knowledge root not found
 #
-# t2846 / GH#20899
+# t2846 / GH#20899 | competitive tier: t2964 / GH#21252
 
 set -euo pipefail
 
@@ -77,7 +78,7 @@ SCRIPT_TEMPLATES_DIR="${SCRIPT_DIR%/scripts}/templates"
 SENSITIVITY_CONFIG_TEMPLATE="${SCRIPT_TEMPLATES_DIR}/sensitivity-config.json"
 
 # Tier precedence order (highest to lowest) — position 0 is strongest
-TIER_PRECEDENCE="privileged sensitive pii internal public"
+TIER_PRECEDENCE="privileged competitive sensitive pii internal public"
 # Tier string constants (avoids repeated literals)
 _T_PUBLIC="public"
 _T_INTERNAL="internal"

--- a/.agents/templates/sensitivity-config.json
+++ b/.agents/templates/sensitivity-config.json
@@ -25,6 +25,12 @@
       "retention_years": 7,
       "description": "Sensitive business data — board minutes, strategy, HR records"
     },
+    "competitive": {
+      "redact": true,
+      "llm": "local-only-hard-fail",
+      "retention_months": 12,
+      "description": "Competitive intel — campaign-scoped, local-LLM-only (Ollama), never cloud, short retention"
+    },
     "privileged": {
       "redact": true,
       "llm": "local-only-hard-fail",
@@ -75,18 +81,19 @@
     }
   },
   "path_heuristics": [
-    { "glob": "**/legal/**",           "tier": "privileged" },
-    { "glob": "**/privileged/**",      "tier": "privileged" },
-    { "glob": "**/attorney-client/**", "tier": "privileged" },
-    { "glob": "**/board-minutes/**",   "tier": "sensitive" },
-    { "glob": "**/board/**",           "tier": "sensitive" },
-    { "glob": "**/strategy/**",        "tier": "sensitive" },
-    { "glob": "**/hr/**",              "tier": "sensitive" },
-    { "glob": "**/personnel/**",       "tier": "sensitive" },
-    { "glob": "**/payroll/**",         "tier": "sensitive" },
-    { "glob": "**/salary/**",          "tier": "sensitive" }
+    { "glob": "**/legal/**",              "tier": "privileged" },
+    { "glob": "**/privileged/**",         "tier": "privileged" },
+    { "glob": "**/attorney-client/**",    "tier": "privileged" },
+    { "glob": "**/_campaigns/intel/**",   "tier": "competitive" },
+    { "glob": "**/board-minutes/**",      "tier": "sensitive" },
+    { "glob": "**/board/**",              "tier": "sensitive" },
+    { "glob": "**/strategy/**",           "tier": "sensitive" },
+    { "glob": "**/hr/**",                 "tier": "sensitive" },
+    { "glob": "**/personnel/**",          "tier": "sensitive" },
+    { "glob": "**/payroll/**",            "tier": "sensitive" },
+    { "glob": "**/salary/**",             "tier": "sensitive" }
   ],
-  "tier_precedence": ["privileged", "sensitive", "pii", "internal", "public"],
+  "tier_precedence": ["privileged", "competitive", "sensitive", "pii", "internal", "public"],
   "precautionary_upgrade": true,
   "note": "precautionary_upgrade: ambiguous content defaults to next-higher tier until local-LLM (P0.5c) ships"
 }

--- a/.agents/tests/test-sensitivity-detector.sh
+++ b/.agents/tests/test-sensitivity-detector.sh
@@ -22,6 +22,9 @@
 #   13. Invalid tier rejected by override
 #   14. Missing source-id returns error
 #   15. show subcommand displays tier and audit log
+#   16. _campaigns/intel/ path → tier competitive (t2964)
+#   17. competitive tier outranks sensitive for mixed-signal sources (t2964)
+#   18. competitive is a valid override tier (t2964)
 
 set -euo pipefail
 
@@ -344,6 +347,65 @@ test_show_displays_tier() {
 }
 
 # ---------------------------------------------------------------------------
+# Competitive tier tests (t2964 / GH#21252)
+# ---------------------------------------------------------------------------
+
+test_campaigns_intel_competitive() {
+	local name="_campaigns/intel/ path → competitive tier"
+	local kroot
+	kroot=$(make_knowledge_root "intel-test" \
+		"file:///Users/user/_campaigns/intel/competitor-a-ads-2026.pdf" \
+		"Market analysis: general public content, no PII")
+	local tier
+	tier=$(run_classify "intel-test" "$kroot")
+	if [[ "$tier" == "competitive" ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected competitive for _campaigns/intel/ path, got $tier"
+	fi
+	return 0
+}
+
+test_competitive_outranks_sensitive() {
+	local name="competitive tier outranks sensitive for mixed-signal sources"
+	local kroot
+	# Path is _campaigns/intel/ (competitive) AND board/ (sensitive) — competitive wins
+	kroot=$(make_knowledge_root "intel-board-test" \
+		"file:///Users/user/_campaigns/intel/board/competitor-analysis.pdf" \
+		"Competitor pricing strategy analysis")
+	local tier
+	tier=$(run_classify "intel-board-test" "$kroot")
+	if [[ "$tier" == "competitive" ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected competitive to outrank sensitive, got $tier"
+	fi
+	return 0
+}
+
+test_competitive_valid_override_tier() {
+	local name="competitive is a valid override tier"
+	local kroot
+	kroot=$(make_knowledge_root "competitive-override-test" \
+		"file:///tmp/general/market-research.pdf" \
+		"General market research document")
+	# First classify to set initial tier
+	run_classify "competitive-override-test" "$kroot" >/dev/null 2>&1
+	# Override to competitive explicitly
+	bash "$DETECTOR" override "competitive-override-test" "competitive" \
+		--reason "Competitive intel confirmed by review" \
+		--knowledge-root "$kroot" >/dev/null 2>&1
+	local tier
+	tier=$(run_classify "competitive-override-test" "$kroot")
+	if [[ "$tier" == "competitive" ]]; then
+		pass "$name"
+	else
+		fail "$name" "expected competitive after override, got $tier"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
 # Suite runner
 # ---------------------------------------------------------------------------
 
@@ -365,6 +427,9 @@ run_all_tests() {
 	test_invalid_tier_rejected
 	test_missing_source_id_error
 	test_show_displays_tier
+	test_campaigns_intel_competitive
+	test_competitive_outranks_sensitive
+	test_competitive_valid_override_tier
 
 	teardown
 


### PR DESCRIPTION
## What

Integrates the `competitive` sensitivity tier into the P0.5a sensitivity classifier (t2846), and enforces that any file under `_campaigns/intel/` is automatically classified as `competitive` regardless of front-matter.

## Changes

**EDIT: `.agents/templates/sensitivity-config.json`**
- Added `competitive` tier:
  - `redact: true` — content is business-confidential
  - `llm: "local-only-hard-fail"` — Ollama only, no cloud LLM ever
  - `retention_months: 12` — months not years (campaign-scoped, short lifecycle)
  - Description: "Competitive intel — campaign-scoped, local-LLM-only (Ollama), never cloud, short retention"
- Added `**/_campaigns/intel/**` path heuristic → `competitive` tier
- Updated `tier_precedence` to include `competitive`: `privileged > competitive > sensitive > pii > internal > public`

**EDIT: `.agents/scripts/sensitivity-detector-helper.sh`**
- Updated `TIER_PRECEDENCE` constant to include `competitive` between `privileged` and `sensitive`
- Updated header comment to document the `competitive` tier definition
- Added t2964 / GH#21252 reference

**EDIT: `.agents/tests/test-sensitivity-detector.sh`**
- Added 3 new tests:
  - Test 16: `_campaigns/intel/` path → `competitive` tier
  - Test 17: `competitive` outranks `sensitive` for mixed-signal sources
  - Test 18: `competitive` is a valid override tier

## Verification

All 18 tests pass: bash .agents/tests/test-sensitivity-detector.sh → Results: 18 passed, 0 failed

shellcheck zero violations on both modified shell files. JSON config valid.

## Behaviour

- Any file at a path matching `**/_campaigns/intel/**` is auto-classified as `competitive` regardless of content
- The `competitive` tier enforces local-LLM-only routing (`local-only-hard-fail`) — Ollama only, no cloud
- Distinct from `privileged`: same LLM gate but different purpose (campaign intel vs legal) and shorter retention (12 months vs 10 years)
- `competitive` sits between `privileged` and `sensitive` in tier hierarchy
- Path heuristic is enforced independent of content — no regex match needed

## Dependencies

- Builds on t2846 sensitivity schema (GH#20899)
- Local-LLM routing (`local-only-hard-fail`) enforced by llm-routing-helper.sh (t2847) reading `sensitivity` from meta.json

Resolves #21252
For #20929


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.1 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-sonnet-4-6 spent 8m and 12,574 tokens on this as a headless worker.