### PR TITLE
t2997: fix BSD-incompatible mktemp templates (XXXXXX before .ext)

### DIFF
--- a/.agents/reference/shell-style-guide.md
+++ b/.agents/reference/shell-style-guide.md
@@ -252,6 +252,71 @@ Both must be empty before commit.
 4. Test standalone (`bash ./the-script.sh --help`) and sourced (`setup.sh --non-interactive`). `shellcheck` must pass.
 5. Commit. The lint gate (`shell-init-pattern-check.sh`) automates detection and PR enforcement.
 
+## mktemp portability (t2997)
+
+`mktemp` template arguments must end the `XXXXXX` placeholder at the END of the path. macOS BSD `mktemp` does **not** substitute `XXXXXX` when followed by a literal extension — it returns the literal template name unchanged on first call and `mkstemp failed: File exists` on every subsequent call (until the literal-named file is removed).
+
+```bash
+# BANNED — macOS-broken
+mktemp /tmp/foo-XXXXXX.json    # first: /tmp/foo-XXXXXX.json (literal)
+                               # next:  mkstemp failed: File exists
+mktemp /tmp/foo.XXXXXX.log     # same — XXXXXX is not at end
+```
+
+### Allowed pattern A — drop the extension (preferred)
+
+```bash
+tmp=$(mktemp "${TMPDIR:-/tmp}/foo-XXXXXX")
+```
+
+Most temp files (data, scripts run by interpreter via `python "$tmp"`, `bash "$tmp"`, log buffers, intermediate JSON read by `jq < "$tmp"`) do NOT need an extension. The interpreter or content-type detection works on bytes, not filename suffix. Drop the extension and the BSD bug disappears.
+
+### Allowed pattern B — extension before the placeholder
+
+```bash
+tmp=$(mktemp "${TMPDIR:-/tmp}/foo.json.XXXXXX")
+```
+
+Use only when downstream code matches on the extension as a substring (rare). The placeholder MUST be the final segment.
+
+### Allowed pattern C — `mktemp -d` + fixed filename (extension-required tools)
+
+```bash
+tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/foo-XXXXXX")
+script_file="$tmp_dir/script.mjs"
+# ... write/use $script_file ...
+rm -rf "$tmp_dir"
+```
+
+REQUIRED for `node` ESM (`.mjs` / `.cjs`) — node 22+ refuses to load the file unless the extension is exact. Use a unique directory + fixed-name child file. Cleanup is `rm -rf "$tmp_dir"`.
+
+### Enforcement
+
+CI gate `.github/workflows/mktemp-portability-check.yml` runs `lint-mktemp-portability.sh` against PR-changed `.sh` files and blocks any new instance of `XXXXXX.<ext>` in a `mktemp` template argument.
+
+```bash
+# Local check (whole tree)
+bash .agents/scripts/lint-mktemp-portability.sh
+
+# Local check (specific files)
+bash .agents/scripts/lint-mktemp-portability.sh path/to/script.sh
+```
+
+The lint deliberately ignores `mktemp -d` and `mktemp -u` invocations (the bug only triggers on file-creation form), and excludes test fixtures that intentionally test the bug.
+
+### Originating incident
+
+GH#21408 (t2997) — `pulse-prefetch-fetch.sh:1107` `update_repo_tier_check_timestamp` produced 142 `mkstemp failed` lines/day in `pulse-wrapper.log` during launchd respawn races. 42 production callsites had the same bug. Reproduction:
+
+```bash
+$ mktemp /tmp/x-XXXXXX.json    # macOS: /tmp/x-XXXXXX.json (literal!)
+$ mktemp /tmp/x-XXXXXX.json    # macOS: mkstemp failed: File exists
+$ mktemp /tmp/x.json.XXXXXX    # macOS: /tmp/x.json.TW5AIa (correct)
+$ mktemp /tmp/x-XXXXXX         # macOS: /tmp/x-mGVJcx (correct)
+```
+
+GNU `mktemp` (Linux) accepts both forms, masking the bug in CI. The lint gate enforces the BSD-safe form everywhere so future macOS regressions are caught at PR time.
+
 ## Related
 
 - **Originating incident**: PR #18728, GH#18702 (primary), GH#18693 (cascade)

--- a/.agents/scripts/anti-detect-helper.sh
+++ b/.agents/scripts/anti-detect-helper.sh
@@ -1031,7 +1031,9 @@ warmup_write_script() {
 	local duration="$4"
 
 	local tmp_script
-	tmp_script=$(mktemp /tmp/warmup_XXXXXX.py)
+	# t2997: drop .py — XXXXXX must be at end for BSD mktemp; python doesn't
+	# need a .py extension to execute a script.
+	tmp_script=$(mktemp /tmp/warmup-XXXXXX)
 
 	cat >"$tmp_script" <<PYEOF
 import json, asyncio, random, time

--- a/.agents/scripts/browser-qa-helper.sh
+++ b/.agents/scripts/browser-qa-helper.sh
@@ -395,8 +395,12 @@ cmd_screenshot() {
 	max_dim=$(resolve_max_image_dim "$max_dim")
 	mkdir -p "$output_dir"
 
-	local script_file
-	script_file=$(mktemp "${TMPDIR:-/tmp}/browser-qa-screenshot-XXXXXX.mjs")
+	# t2997: node ESM requires exact .mjs extension; use mktemp -d for a unique
+	# directory + fixed-name script.mjs inside (XXXXXX must be at end for BSD
+	# mktemp). Cleanup is rm -rf on the directory.
+	local script_dir script_file
+	script_dir=$(mktemp -d "${TMPDIR:-/tmp}/browser-qa-screenshot-XXXXXX")
+	script_file="$script_dir/script.mjs"
 
 	local viewport_array
 	viewport_array=$(_build_viewports_js_array "$viewports")
@@ -411,7 +415,7 @@ cmd_screenshot() {
 	log_info "Capturing screenshots for ${pages} at viewports: ${viewports}"
 	local exit_code=0
 	node "$script_file" || exit_code=$?
-	rm -f "$script_file"
+	rm -rf "$script_dir"
 
 	if [[ "$exit_code" -ne 0 ]]; then
 		return "$exit_code"
@@ -463,8 +467,10 @@ cmd_links() {
 		return 1
 	fi
 
-	local script_file
-	script_file=$(mktemp "${TMPDIR:-/tmp}/browser-qa-links-XXXXXX.mjs")
+	# t2997: node ESM requires exact .mjs extension; mktemp -d + fixed filename.
+	local script_dir script_file
+	script_dir=$(mktemp -d "${TMPDIR:-/tmp}/browser-qa-links-XXXXXX")
+	script_file="$script_dir/script.mjs"
 
 	cat >"$script_file" <<'SCRIPT'
 import { chromium } from 'playwright';
@@ -533,7 +539,7 @@ SCRIPT
 	log_info "Checking links from ${url} (depth: ${depth})"
 	local exit_code=0
 	node "$script_file" "$url" "$depth" "$timeout" || exit_code=$?
-	rm -f "$script_file"
+	rm -rf "$script_dir"
 	return $exit_code
 }
 
@@ -776,8 +782,10 @@ cmd_a11y() {
 	local contrast_json
 	contrast_json=$(_run_contrast_checks "$url" "$pages" "$level")
 
-	local script_file
-	script_file=$(mktemp "${TMPDIR:-/tmp}/browser-qa-a11y-XXXXXX.mjs")
+	# t2997: node ESM requires exact .mjs extension; mktemp -d + fixed filename.
+	local script_dir script_file
+	script_dir=$(mktemp -d "${TMPDIR:-/tmp}/browser-qa-a11y-XXXXXX")
+	script_file="$script_dir/script.mjs"
 
 	local pages_array
 	pages_array=$(_build_pages_js_array "$pages")
@@ -788,7 +796,7 @@ cmd_a11y() {
 
 	local exit_code=0
 	node "$script_file" "$contrast_json" || exit_code=$?
-	rm -f "$script_file"
+	rm -rf "$script_dir"
 	return $exit_code
 }
 
@@ -1040,8 +1048,10 @@ cmd_stability() {
 		return 1
 	fi
 
-	local script_file
-	script_file=$(mktemp "${TMPDIR:-/tmp}/browser-qa-stability-XXXXXX.mjs")
+	# t2997: node ESM requires exact .mjs extension; mktemp -d + fixed filename.
+	local script_dir script_file
+	script_dir=$(mktemp -d "${TMPDIR:-/tmp}/browser-qa-stability-XXXXXX")
+	script_file="$script_dir/script.mjs"
 
 	local pages_array
 	pages_array=$(_build_pages_js_array "$pages")
@@ -1055,7 +1065,7 @@ cmd_stability() {
 	local exit_code=0
 	local output
 	output=$(node "$script_file") || exit_code=$?
-	rm -f "$script_file"
+	rm -rf "$script_dir"
 
 	if [[ $exit_code -ne 0 ]]; then
 		printf '%s\n' "$output"
@@ -1252,8 +1262,10 @@ cmd_smoke() {
 		return 1
 	fi
 
-	local script_file
-	script_file=$(mktemp "${TMPDIR:-/tmp}/browser-qa-smoke-XXXXXX.mjs")
+	# t2997: node ESM requires exact .mjs extension; mktemp -d + fixed filename.
+	local script_dir script_file
+	script_dir=$(mktemp -d "${TMPDIR:-/tmp}/browser-qa-smoke-XXXXXX")
+	script_file="$script_dir/script.mjs"
 
 	local pages_array
 	pages_array=$(_build_pages_js_array "$pages")
@@ -1266,7 +1278,7 @@ cmd_smoke() {
 	local exit_code=0
 	local output
 	output=$(node "$script_file") || exit_code=$?
-	rm -f "$script_file"
+	rm -rf "$script_dir"
 
 	if [[ $exit_code -ne 0 ]]; then
 		printf '%s\n' "$output"

--- a/.agents/scripts/document-extraction-helper.sh
+++ b/.agents/scripts/document-extraction-helper.sh
@@ -458,7 +458,9 @@ with open('${text_file}', 'w') as f:
 		elif [[ "$ext" == "pdf" ]]; then
 			# Convert first page to image for classification
 			local tmp_img
-			tmp_img="$(mktemp /tmp/classify-XXXXXX.png)"
+			# t2997: drop .png — image classifiers detect format from magic bytes,
+			# not filename extension. XXXXXX must be at end for BSD mktemp.
+			tmp_img="$(mktemp /tmp/classify-XXXXXX)"
 			if command -v magick &>/dev/null; then
 				magick -density 150 "${input_file}[0]" -quality 80 "$tmp_img" 2>/dev/null
 			elif command -v convert &>/dev/null; then

--- a/.agents/scripts/email-receipt-forward-helper.sh
+++ b/.agents/scripts/email-receipt-forward-helper.sh
@@ -590,7 +590,8 @@ forward_to_accounts() {
 
 		# Build forwarding message with original email as attachment
 		local tmp_msg
-		tmp_msg=$(mktemp /tmp/receipt-forward-XXXXXX.json)
+		# t2997: drop .json — XXXXXX must be at end for BSD mktemp.
+		tmp_msg=$(mktemp /tmp/receipt-forward-XXXXXX)
 		# Ensure cleanup on exit
 		trap 'rm -f "$tmp_msg"' EXIT
 

--- a/.agents/scripts/email-sieve-helper.sh
+++ b/.agents/scripts/email-sieve-helper.sh
@@ -877,7 +877,8 @@ deploy_sieve() {
 
 	# Write Python helper to temp file
 	local helper_tmp
-	helper_tmp="$(mktemp /tmp/aidevops-managesieve-XXXXXX.py)"
+	# t2997: drop .py — XXXXXX must be at end for BSD mktemp.
+	helper_tmp="$(mktemp /tmp/aidevops-managesieve-XXXXXX)"
 	# Ensure cleanup on exit
 	trap 'rm -f "$helper_tmp"' EXIT
 
@@ -910,7 +911,8 @@ list_scripts() {
 	fi
 
 	local helper_tmp
-	helper_tmp="$(mktemp /tmp/aidevops-managesieve-XXXXXX.py)"
+	# t2997: drop .py — XXXXXX must be at end for BSD mktemp.
+	helper_tmp="$(mktemp /tmp/aidevops-managesieve-XXXXXX)"
 	trap 'rm -f "$helper_tmp"' EXIT
 
 	write_managesieve_helper "$helper_tmp"
@@ -939,7 +941,8 @@ show_script() {
 	fi
 
 	local helper_tmp
-	helper_tmp="$(mktemp /tmp/aidevops-managesieve-XXXXXX.py)"
+	# t2997: drop .py — XXXXXX must be at end for BSD mktemp.
+	helper_tmp="$(mktemp /tmp/aidevops-managesieve-XXXXXX)"
 	trap 'rm -f "$helper_tmp"' EXIT
 
 	write_managesieve_helper "$helper_tmp"
@@ -968,7 +971,8 @@ delete_script() {
 	fi
 
 	local helper_tmp
-	helper_tmp="$(mktemp /tmp/aidevops-managesieve-XXXXXX.py)"
+	# t2997: drop .py — XXXXXX must be at end for BSD mktemp.
+	helper_tmp="$(mktemp /tmp/aidevops-managesieve-XXXXXX)"
 	trap 'rm -f "$helper_tmp"' EXIT
 
 	write_managesieve_helper "$helper_tmp"

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -1277,7 +1277,8 @@ _increment_orphan_count_stat() {
 	[[ -f "$_stats_file" ]] || printf '{"counters":{}}\n' >"$_stats_file" 2>/dev/null || return 0
 	local _ts _tmp
 	_ts=$(date +%s 2>/dev/null) || _ts=0
-	_tmp=$(mktemp "${TMPDIR:-/tmp}/pulse-stats-orphan-XXXXXX.json") || return 0
+	# t2997: drop .json — XXXXXX must be at end for BSD mktemp.
+	_tmp=$(mktemp "${TMPDIR:-/tmp}/pulse-stats-orphan-XXXXXX") || return 0
 	jq --argjson ts "$_ts" \
 		'.counters.worker_branch_orphan_count += [$ts]' \
 		"$_stats_file" >"$_tmp" 2>/dev/null \

--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -207,7 +207,9 @@ _log_empty_result_gaps() {
 	mkdir -p "$(dirname "$diag_log")" 2>/dev/null || true
 
 	local _py_script
-	_py_script=$(mktemp "${TMPDIR:-/tmp}/aidevops-empty-gaps.XXXXXX.py") || return 0
+	# t2997: drop .py — XXXXXX must be at end for BSD mktemp; python doesn't
+	# need .py to execute via `python "$path"`.
+	_py_script=$(mktemp "${TMPDIR:-/tmp}/aidevops-empty-gaps-XXXXXX") || return 0
 	cat >"$_py_script" <<'EMPTYPY'
 import json, sys, os, datetime
 from pathlib import Path

--- a/.agents/scripts/issue-sync-helper.sh
+++ b/.agents/scripts/issue-sync-helper.sh
@@ -1115,7 +1115,8 @@ _enrich_prefetch_issues_map() {
 	fi
 	# Write to temp file so the enrich loop can read it per-task without
 	# passing a large string through every subshell invocation.
-	ENRICH_PREFETCH_FILE=$(mktemp /tmp/enrich-prefetch-XXXXXX.json 2>/dev/null || echo "")
+	# t2997: drop .json — XXXXXX must be at end for BSD mktemp.
+	ENRICH_PREFETCH_FILE=$(mktemp /tmp/enrich-prefetch-XXXXXX 2>/dev/null || echo "")
 	if [[ -z "$ENRICH_PREFETCH_FILE" ]]; then
 		return 1
 	fi

--- a/.agents/scripts/knowledge-review-helper.sh
+++ b/.agents/scripts/knowledge-review-helper.sh
@@ -338,7 +338,9 @@ _build_nmr_body_file() {
 	preview=$(_extract_preview "$staging_dir" 500)
 
 	local body_file
-	body_file=$(mktemp /tmp/knowledge-review-body.XXXXXX.md 2>/dev/null) || return 1
+	# t2997: drop .md — XXXXXX must be at end for BSD mktemp; gh issue body-file
+	# reads content regardless of extension.
+	body_file=$(mktemp /tmp/knowledge-review-body-XXXXXX 2>/dev/null) || return 1
 
 	local tmpl="${SCRIPT_TEMPLATES_DIR}/knowledge-review-nmr-body.md"
 	if [[ -f "$tmpl" ]]; then

--- a/.agents/scripts/lint-mktemp-portability.sh
+++ b/.agents/scripts/lint-mktemp-portability.sh
@@ -1,0 +1,258 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# lint-mktemp-portability.sh — static scanner for BSD-incompatible mktemp
+# template patterns (XXXXXX followed by an extension).
+#
+# Issue: GH#21408 (t2997)
+# Reference: .agents/reference/shell-style-guide.md § mktemp portability
+#
+# Bug class:
+#   On macOS BSD mktemp, `mktemp prefix-XXXXXX.ext` does NOT substitute the
+#   X placeholder when followed by a literal extension. First call returns the
+#   literal template; subsequent calls fail with `mkstemp failed: File exists`.
+#   GNU mktemp (Linux) accepts both forms, so the bug is invisible in CI until
+#   it ships.
+#
+# Detection rule:
+#   - Match `mktemp` invocations whose template argument contains XXXXXX
+#     followed by `.<letter>` (i.e. an extension).
+#   - Skip `mktemp -d ...` and `mktemp -u ...` (directory and dry-run forms
+#     don't trigger the bug).
+#   - Skip lines marked `# mktemp-portability: ignore` (inline suppression).
+#   - Skip files in this scanner's own ignore list (test fixtures that
+#     intentionally exercise the bug — currently none, but reserved).
+#
+# Usage:
+#   .agents/scripts/lint-mktemp-portability.sh [OPTIONS] [FILES...]
+#
+# Options:
+#   --summary       print only the summary line (no per-violation output)
+#   --no-exit-code  always exit 0 (advisory mode)
+#   --help          show this help
+#
+# With no FILES: scans all git-tracked .sh files via `git ls-files '*.sh'`.
+#
+# Output format: file:line: <offending mktemp template>
+# Exit codes: 0=clean, 1=violations found
+# =============================================================================
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Colour helpers (no-op when stdout is not a terminal)
+# ---------------------------------------------------------------------------
+if [[ -t 1 ]]; then
+	_MTP_RED=$'\033[0;31m'
+	_MTP_YELLOW=$'\033[1;33m'
+	_MTP_GREEN=$'\033[0;32m'
+	_MTP_BLUE=$'\033[0;34m'
+	_MTP_NC=$'\033[0m'
+else
+	_MTP_RED=''
+	_MTP_YELLOW=''
+	_MTP_GREEN=''
+	_MTP_BLUE=''
+	_MTP_NC=''
+fi
+readonly _MTP_RED _MTP_YELLOW _MTP_GREEN _MTP_BLUE _MTP_NC
+
+_mtp_info() {
+	local msg="$1"
+	printf '%b[mktemp-portability]%b %s\n' "${_MTP_BLUE}" "${_MTP_NC}" "${msg}"
+	return 0
+}
+
+_mtp_violation() {
+	local file_line="$1"
+	local snippet="$2"
+	printf '%b%s%b: %s\n' "${_MTP_RED}" "${file_line}" "${_MTP_NC}" "${snippet}"
+	return 0
+}
+
+_mtp_ok() {
+	local msg="$1"
+	printf '%b[mktemp-portability]%b %s\n' "${_MTP_GREEN}" "${_MTP_NC}" "${msg}"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Arg parsing
+# ---------------------------------------------------------------------------
+SUMMARY_ONLY=0
+NO_EXIT_CODE=0
+TARGET_FILES=()
+
+usage() {
+	local script_path="${BASH_SOURCE[0]}"
+	sed -n '/^# ===/,/^# ===/p' "$script_path" | sed 's/^# \?//'
+	return 0
+}
+
+# Wrap arg parsing in a function so $1/$2 are accessed via `local var="$1"`
+# (per .agents/reference/shell-style-guide.md positional-parameter rule).
+_parse_args() {
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+			--summary)
+				SUMMARY_ONLY=1
+				shift
+				;;
+			--no-exit-code)
+				NO_EXIT_CODE=1
+				shift
+				;;
+			-h|--help)
+				usage
+				exit 0
+				;;
+			--)
+				shift
+				while [[ $# -gt 0 ]]; do
+					local pos="$1"
+					TARGET_FILES+=("$pos")
+					shift
+				done
+				;;
+			-*)
+				printf 'Unknown option: %s\n' "$arg" >&2
+				usage >&2
+				exit 2
+				;;
+			*)
+				TARGET_FILES+=("$arg")
+				shift
+				;;
+		esac
+	done
+	return 0
+}
+
+_parse_args "$@"
+
+# ---------------------------------------------------------------------------
+# File list resolution
+# ---------------------------------------------------------------------------
+if [[ ${#TARGET_FILES[@]} -eq 0 ]]; then
+	# Default: all tracked .sh files in the repo.
+	if ! command -v git >/dev/null 2>&1; then
+		printf 'mktemp-portability: git not found and no FILES given\n' >&2
+		exit 2
+	fi
+	# shellcheck disable=SC2207
+	TARGET_FILES=($(git ls-files '*.sh' 2>/dev/null || true))
+fi
+
+if [[ ${#TARGET_FILES[@]} -eq 0 ]]; then
+	[[ "$SUMMARY_ONLY" -eq 0 ]] && _mtp_ok "no shell files to scan"
+	exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Scan
+# ---------------------------------------------------------------------------
+# The detection regex:
+#   - mktemp                 — the command
+#   - (?!\s+-[duqQ]\b)       — NOT followed by -d / -u / -q / -Q (file-form only)
+#                              NOTE: -t (template prefix) is fine — its template
+#                              still goes through the same X-placement rule.
+#   - .*X{6,}\.[a-zA-Z]      — XXXXXX (or more) followed by `.<letter>` extension
+#
+# We use POSIX-friendly grep with -P (PCRE) since rg may not be on the runner.
+# Fall back to grep -P if rg unavailable.
+#
+# Suppression: a line with the comment `# mktemp-portability: ignore` is excluded.
+
+violations_found=0
+violation_lines=()
+
+# Build the search pattern. Use a literal-X form to avoid pattern-detection
+# hitting the lint script itself.
+_pattern='mktemp[[:space:]]+(?!-[duqQ][[:space:]])[^|;&)`]*'
+_pattern+='X{6}\.[a-zA-Z]'
+
+scan_file() {
+	local file="$1"
+	[[ -f "$file" ]] || return 0
+
+	# Skip non-shell files (defensive).
+	case "$file" in
+		*.sh|*.bash|*.zsh) ;;
+		*) return 0 ;;
+	esac
+
+	# Skip this script itself — its examples and patterns will trip the regex.
+	# (also covers tests/test-lint-mktemp-portability.sh via the *lint... glob)
+	case "$file" in
+		*lint-mktemp-portability.sh) return 0 ;;
+	esac
+
+	local matches
+	if command -v rg >/dev/null 2>&1; then
+		matches=$(rg --no-heading --line-number --color=never -P "$_pattern" "$file" 2>/dev/null || true)
+	else
+		matches=$(grep -nP "$_pattern" "$file" 2>/dev/null || true)
+	fi
+
+	[[ -z "$matches" ]] && return 0
+
+	# Filter out lines that carry the inline-ignore comment.
+	local filtered_lines=()
+	while IFS= read -r line; do
+		[[ -z "$line" ]] && continue
+		if [[ "$line" == *"# mktemp-portability: ignore"* ]]; then
+			continue
+		fi
+		filtered_lines+=("$line")
+	done <<< "$matches"
+
+	[[ ${#filtered_lines[@]} -eq 0 ]] && return 0
+
+	local entry
+	for entry in "${filtered_lines[@]}"; do
+		# entry format: LINE_NO:CONTENT (ripgrep) or grep variant
+		local line_no="${entry%%:*}"
+		local content="${entry#*:}"
+		# Trim leading whitespace from the offending content for compactness.
+		content="${content#"${content%%[![:space:]]*}"}"
+		violation_lines+=("${file}:${line_no}: ${content}")
+		violations_found=$((violations_found + 1))
+	done
+
+	return 0
+}
+
+for f in "${TARGET_FILES[@]}"; do
+	scan_file "$f"
+done
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+if [[ "$violations_found" -eq 0 ]]; then
+	[[ "$SUMMARY_ONLY" -eq 0 ]] && _mtp_ok "0 violations across ${#TARGET_FILES[@]} file(s)"
+	exit 0
+fi
+
+if [[ "$SUMMARY_ONLY" -eq 0 ]]; then
+	printf '\n'
+	printf '%b[mktemp-portability]%b %d violation(s) — XXXXXX must be at end of mktemp template:\n\n' \
+		"${_MTP_YELLOW}" "${_MTP_NC}" "$violations_found"
+	for line in "${violation_lines[@]}"; do
+		# Split file:line: prefix from snippet.
+		local_pre="${line%%: *}"
+		local_snip="${line#*: }"
+		_mtp_violation "$local_pre" "$local_snip"
+	done
+	printf '\n'
+	# shellcheck disable=SC2016
+	printf 'Fix: drop the extension OR use `mktemp -d` + fixed filename.\n'
+	printf 'See: .agents/reference/shell-style-guide.md § mktemp portability\n\n'
+fi
+
+if [[ "$NO_EXIT_CODE" -eq 1 ]]; then
+	exit 0
+fi
+exit 1

--- a/.agents/scripts/pulse-logging.sh
+++ b/.agents/scripts/pulse-logging.sh
@@ -66,7 +66,8 @@ rotate_pulse_log() {
 	local archive_name="pulse-${ts}.log.gz"
 	local archive_path="${PULSE_LOG_ARCHIVE_DIR}/${archive_name}"
 	local tmp_archive
-	tmp_archive=$(mktemp "${PULSE_LOG_ARCHIVE_DIR}/.pulse-archive-XXXXXX.gz") || {
+	# t2997: drop .gz — XXXXXX must be at end for BSD mktemp.
+	tmp_archive=$(mktemp "${PULSE_LOG_ARCHIVE_DIR}/.pulse-archive-XXXXXX") || {
 		echo "[pulse-wrapper] rotate_pulse_log: mktemp failed for archive" >>"$WRAPPER_LOGFILE"
 		return 0
 	}
@@ -201,7 +202,8 @@ append_cycle_index() {
 	if [[ "$line_count" -gt "$PULSE_CYCLE_INDEX_MAX_LINES" ]]; then
 		local excess=$((line_count - PULSE_CYCLE_INDEX_MAX_LINES))
 		local tmp_index
-		tmp_index=$(mktemp "${HOME}/.aidevops/logs/.pulse-cycle-index-XXXXXX.jsonl") || {
+		# t2997: drop .jsonl — XXXXXX must be at end for BSD mktemp.
+		tmp_index=$(mktemp "${HOME}/.aidevops/logs/.pulse-cycle-index-XXXXXX") || {
 			echo "[pulse-wrapper] append_cycle_index: mktemp failed for index prune" >>"$WRAPPER_LOGFILE"
 			return 0
 		}
@@ -264,7 +266,8 @@ write_pulse_health_file() {
 	fi
 
 	local tmp_health
-	tmp_health=$(mktemp "${HOME}/.aidevops/logs/.pulse-health-XXXXXX.json") || {
+	# t2997: drop .json — XXXXXX must be at end for BSD mktemp.
+	tmp_health=$(mktemp "${HOME}/.aidevops/logs/.pulse-health-XXXXXX") || {
 		echo "[pulse-wrapper] write_pulse_health_file: mktemp failed — skipping health write" >>"$LOGFILE"
 		return 0
 	}

--- a/.agents/scripts/pulse-prefetch-fetch.sh
+++ b/.agents/scripts/pulse-prefetch-fetch.sh
@@ -883,7 +883,8 @@ update_repo_pulse_timestamp() {
 	[[ -d "$state_dir" ]] || mkdir -p "$state_dir" 2>/dev/null || true
 
 	local tmp_state
-	tmp_state=$(mktemp "${state_dir}/.pulse-last-per-repo-XXXXXX.json") || {
+	# t2997: drop .json — XXXXXX must be at end for BSD mktemp.
+	tmp_state=$(mktemp "${state_dir}/.pulse-last-per-repo-XXXXXX") || {
 		echo "[pulse-wrapper] update_repo_pulse_timestamp: mktemp failed for ${slug} — skipping write" >>"$LOGFILE"
 		return 0
 	}
@@ -1104,7 +1105,9 @@ update_repo_tier_check_timestamp() {
 	[[ -d "$state_dir" ]] || mkdir -p "$state_dir" 2>/dev/null || true
 
 	local tmp_state
-	tmp_state=$(mktemp "${state_dir}/.pulse-tier-last-check-XXXXXX.json") || {
+	# t2997: drop .json — XXXXXX must be at end for BSD mktemp. This was the
+	# canonical 142-spam-lines/day offender in pulse-wrapper.log (GH#21408).
+	tmp_state=$(mktemp "${state_dir}/.pulse-tier-last-check-XXXXXX") || {
 		echo "[pulse-wrapper] update_repo_tier_check_timestamp: mktemp failed for ${slug}" >>"$LOGFILE"
 		return 0
 	}

--- a/.agents/scripts/pulse-repo-tier.sh
+++ b/.agents/scripts/pulse-repo-tier.sh
@@ -227,7 +227,8 @@ _tier_cache_write_one() {
 	fi
 
 	local tmp_cache
-	tmp_cache=$(mktemp "${cache_dir}/.pulse-repo-tiers-XXXXXX.json") || return 0
+	# t2997: drop .json — XXXXXX must be at end for BSD mktemp.
+	tmp_cache=$(mktemp "${cache_dir}/.pulse-repo-tiers-XXXXXX") || return 0
 
 	if printf '%s' "$existing" | jq \
 		--arg slug "$slug" \

--- a/.agents/scripts/pulse-stats-helper.sh
+++ b/.agents/scripts/pulse-stats-helper.sh
@@ -72,7 +72,8 @@ pulse_stats_increment() {
 	_pulse_stats_ensure_file || return 0
 
 	local tmp_file
-	tmp_file=$(mktemp "${TMPDIR:-/tmp}/pulse-stats-XXXXXX.json") || return 0
+	# t2997: drop .json — XXXXXX must be at end for BSD mktemp.
+	tmp_file=$(mktemp "${TMPDIR:-/tmp}/pulse-stats-XXXXXX") || return 0
 
 	# Append timestamp to counter array; create counter if absent.
 	# jq -e fails if the input JSON is invalid → we fall back to no-op.
@@ -162,7 +163,8 @@ pulse_stats_reset() {
 	fi
 
 	local tmp_file
-	tmp_file=$(mktemp "${TMPDIR:-/tmp}/pulse-stats-XXXXXX.json") || return 1
+	# t2997: drop .json — XXXXXX must be at end for BSD mktemp.
+	tmp_file=$(mktemp "${TMPDIR:-/tmp}/pulse-stats-XXXXXX") || return 1
 
 	jq --arg name "$counter_name" \
 		'del(.counters[$name])' \

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1452,7 +1452,8 @@ _record_invocation_source() {
 	[[ -d "$_dir" ]] || mkdir -p "$_dir" 2>/dev/null || return 0
 	[[ -f "$stats_file" ]] || printf '{"counters":{}}\n' >"$stats_file" 2>/dev/null || return 0
 
-	_tmp=$(mktemp "${TMPDIR:-/tmp}/pulse-stats-src-XXXXXX.json") || return 0
+	# t2997: drop .json — XXXXXX must be at end for BSD mktemp.
+	_tmp=$(mktemp "${TMPDIR:-/tmp}/pulse-stats-src-XXXXXX") || return 0
 	jq --arg src "$source" \
 		'.invocation_sources[$src] = ((.invocation_sources[$src] // 0) + 1)' \
 		"$stats_file" >"$_tmp" 2>/dev/null || { rm -f "$_tmp"; return 0; }

--- a/.agents/scripts/setup/_common.sh
+++ b/.agents/scripts/setup/_common.sh
@@ -187,7 +187,9 @@ verified_install() {
 
 	# Create secure temp file
 	local tmp_script
-	tmp_script=$(mktemp "${TMPDIR:-/tmp}/aidevops-install-XXXXXX.sh") || {
+	# t2997: drop .sh — XXXXXX must be at end for BSD mktemp; bash executes by
+	# content, not extension.
+	tmp_script=$(mktemp "${TMPDIR:-/tmp}/aidevops-install-XXXXXX") || {
 		print_error "Failed to create temp file for $description"
 		return 1
 	}

--- a/.agents/scripts/simplex-helper.sh
+++ b/.agents/scripts/simplex-helper.sh
@@ -243,7 +243,8 @@ cmd_install() {
 	log_warn "Review the script at the URL above before proceeding."
 	log_info "Downloading SimpleX Chat installer..."
 	local installer
-	installer="$(mktemp /tmp/simplex-install-XXXXXX.sh)"
+	# t2997: drop .sh — XXXXXX must be at end for BSD mktemp.
+	installer="$(mktemp /tmp/simplex-install-XXXXXX)"
 
 	if ! curl -fsSLo "$installer" "$INSTALL_URL"; then
 		log_error "Failed to download installer from ${INSTALL_URL}"
@@ -806,7 +807,8 @@ _cmd_server_init() {
 	log_warn "Review the script at the URL above before proceeding."
 	log_info "Downloading SimpleX server installer..."
 	local installer
-	installer="$(mktemp /tmp/simplex-server-install-XXXXXX.sh)"
+	# t2997: drop .sh — XXXXXX must be at end for BSD mktemp.
+	installer="$(mktemp /tmp/simplex-server-install-XXXXXX)"
 
 	if ! curl -fsSLo "$installer" "$SERVER_INSTALL_URL"; then
 		log_error "Failed to download server installer"

--- a/.agents/scripts/site-crawler-helper.sh
+++ b/.agents/scripts/site-crawler-helper.sh
@@ -927,7 +927,8 @@ _c4ai_generate_xlsx() {
 	"$PYTHON_CMD" -c "import openpyxl" 2>/dev/null || return 0
 
 	local xlsx_script
-	xlsx_script=$(mktemp /tmp/xlsx_gen_XXXXXX.py)
+	# t2997: drop .py — XXXXXX must be at end for BSD mktemp.
+	xlsx_script=$(mktemp /tmp/xlsx_gen-XXXXXX)
 	_save_cleanup_scope
 	trap '_run_cleanups' RETURN
 	push_cleanup "rm -f '${xlsx_script}'"
@@ -1459,7 +1460,8 @@ _do_crawl_run_python() {
 	print_info "Using: $PYTHON_CMD"
 
 	local crawler_script
-	crawler_script=$(mktemp /tmp/site_crawler_XXXXXX.py)
+	# t2997: drop .py — XXXXXX must be at end for BSD mktemp.
+	crawler_script=$(mktemp /tmp/site_crawler-XXXXXX)
 	_save_cleanup_scope
 	trap '_run_cleanups' RETURN
 	push_cleanup "rm -f '${crawler_script}'"

--- a/.agents/scripts/sops-helper.sh
+++ b/.agents/scripts/sops-helper.sh
@@ -105,7 +105,9 @@ cmd_install() {
 		arch=$(dpkg --print-architecture 2>/dev/null || echo "amd64")
 		local latest_url="https://github.com/getsops/sops/releases/latest/download/sops_3.9.4_${arch}.deb"
 		local tmp_deb
-		tmp_deb=$(mktemp /tmp/sops-XXXXXX.deb)
+		# t2997: drop .deb — XXXXXX must be at end for BSD mktemp; dpkg detects
+		# package format from magic bytes, not filename extension.
+		tmp_deb=$(mktemp /tmp/sops-XXXXXX)
 		_save_cleanup_scope
 		trap '_run_cleanups' RETURN
 		push_cleanup "rm -f '${tmp_deb}'"

--- a/.agents/scripts/test-inbox-capture.sh
+++ b/.agents/scripts/test-inbox-capture.sh
@@ -114,7 +114,8 @@ assert_file_exists "${SANDBOX}/_inbox/triage.log"     "_inbox/triage.log"
 # ============================================================================
 echo ""
 echo "--- Test 2: add file (email) ---"
-local_eml="$(mktemp /tmp/test-XXXXXXXX.eml)"
+		# t2997: drop .eml — XXXXXX must be at end for BSD mktemp.
+local_eml="$(mktemp /tmp/test-XXXXXXXX)"
 printf 'From: test@example.com\nSubject: Test\n\nBody\n' > "$local_eml"
 # shellcheck disable=SC2064
 trap "rm -f '${local_eml}'; rm -rf '${SANDBOX}'" EXIT

--- a/.agents/scripts/tests/test-bounty-spam-detector.sh
+++ b/.agents/scripts/tests/test-bounty-spam-detector.sh
@@ -212,7 +212,8 @@ test_score_rc0_contract_on_spam() {
 	# verdict string is correct; this test asserts the rc difference.
 
 	local tmp rc_scan=0
-	tmp=$(mktemp -t bsd-test-score-rc.XXXXXX.md) || {
+	# t2997: drop .md — XXXXXX must be at end for BSD mktemp.
+	tmp=$(mktemp -t bsd-test-score-rc.XXXXXX) || {
 		print_result "score rc=0 contract: cmd_score returns 0 on spam-likely content" 1 "could not mktemp"
 		return 0
 	}
@@ -261,7 +262,8 @@ test_score_json_well_formed() {
 	# command via fixture-based test produces parseable JSON when --json
 	# is implied through manual invocation.
 	local tmp
-	tmp=$(mktemp -t bsd-test.XXXXXX.md) || {
+	# t2997: drop .md — XXXXXX must be at end for BSD mktemp.
+	tmp=$(mktemp -t bsd-test.XXXXXX) || {
 		print_result "json: well-formed output" 1 "could not mktemp"
 		return 0
 	}

--- a/.agents/scripts/tests/test-browser-qa-helper.sh
+++ b/.agents/scripts/tests/test-browser-qa-helper.sh
@@ -192,8 +192,10 @@ test_stability_unknown_option_rejected() {
 }
 
 test_stability_script_generation() {
-	local script_file
-	script_file=$(mktemp "${TMPDIR:-/tmp}/test-stability-XXXXXX.mjs")
+	# t2997: node ESM requires exact .mjs extension; mktemp -d + fixed filename.
+	local script_dir script_file
+	script_dir=$(mktemp -d "${TMPDIR:-/tmp}/test-stability-XXXXXX")
+	script_file="$script_dir/script.mjs"
 	_generate_stability_script "$script_file" "http://localhost:3000" "'/'," "3" "30000" "500" "10000"
 	local exit_code=$?
 	if [[ "$exit_code" -eq 0 ]] && [[ -s "$script_file" ]]; then
@@ -205,7 +207,7 @@ test_stability_script_generation() {
 	else
 		print_result "stability: script generation produces non-empty file" 1 "exit=${exit_code} or empty file"
 	fi
-	rm -f "$script_file"
+	rm -rf "$script_dir"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-enrich-batch-prefetch.sh
+++ b/.agents/scripts/tests/test-enrich-batch-prefetch.sh
@@ -222,7 +222,8 @@ STUB
 chmod +x "${STUB_DIR4}/gh"
 
 # Create a valid prefetch file with issue 123
-PREFETCH_FILE=$(mktemp /tmp/test-prefetch-XXXXXX.json)
+# t2997: drop .json — XXXXXX must be at end for BSD mktemp.
+PREFETCH_FILE=$(mktemp /tmp/test-prefetch-XXXXXX)
 printf '[{"number":123,"title":"t9999: Test issue","body":"original body","labels":[{"name":"bug"}],"state":"OPEN","assignees":[]}]\n' \
 	>"$PREFETCH_FILE"
 

--- a/.agents/scripts/tests/test-gh-wrapper-zsh-compat.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-zsh-compat.sh
@@ -111,7 +111,8 @@ extract_function() {
 	return 0
 }
 
-TMPFILE=$(mktemp "${TMPDIR:-/tmp}/t2688-zsh-snippet.XXXXXX.sh")
+# t2997: drop .sh — XXXXXX must be at end for BSD mktemp.
+TMPFILE=$(mktemp "${TMPDIR:-/tmp}/t2688-zsh-snippet.XXXXXX")
 trap 'rm -f "$TMPFILE"' EXIT
 
 {

--- a/.agents/scripts/tests/test-issue-sync-pull-seeds-orphans.sh
+++ b/.agents/scripts/tests/test-issue-sync-pull-seeds-orphans.sh
@@ -50,7 +50,8 @@ check() {
 
 make_todo() {
 	local f
-	f=$(mktemp /tmp/test-todo-XXXXXX.md)
+	# t2997: drop .md — XXXXXX must be at end for BSD mktemp.
+	f=$(mktemp /tmp/test-todo-XXXXXX)
 	cat >"$f" <<'EOF'
 # Tasks
 

--- a/.agents/scripts/tests/test-setup-tools-zsh-compat.sh
+++ b/.agents/scripts/tests/test-setup-tools-zsh-compat.sh
@@ -102,7 +102,8 @@ extract_function() {
 # Stub out command -v to return 1 (no tools installed) so the check function
 # populates _SETUP_TOOLS_LINUX_MISSING with all four packages.
 
-TMPFILE=$(mktemp "${TMPDIR:-/tmp}/t2719-zsh-snippet.XXXXXX.sh")
+# t2997: drop .sh — XXXXXX must be at end for BSD mktemp.
+TMPFILE=$(mktemp "${TMPDIR:-/tmp}/t2719-zsh-snippet.XXXXXX")
 trap 'rm -f "$TMPFILE"' EXIT
 
 {

--- a/.agents/scripts/verify-brief.sh
+++ b/.agents/scripts/verify-brief.sh
@@ -659,7 +659,8 @@ _runtime_start_dev_env() {
 
 	log_info "  Starting dev environment: $start_cmd"
 	local start_log
-	start_log=$(mktemp "${TMPDIR:-/tmp}/verify-brief-runtime-XXXXXX.log")
+	# t2997: drop .log — XXXXXX must be at end for BSD mktemp.
+	start_log=$(mktemp "${TMPDIR:-/tmp}/verify-brief-runtime-XXXXXX")
 	(cd "$repo_path" && bash -c "$start_cmd" >"$start_log" 2>&1) &
 	local start_pid=$!
 	log_debug "Dev env started with PID $start_pid, log: $start_log"

--- a/.agents/scripts/watercrawl-helper.sh
+++ b/.agents/scripts/watercrawl-helper.sh
@@ -590,11 +590,13 @@ scrape_url() {
 	print_info "Using API: ${WATERCRAWL_API_URL:-}"
 
 	# Create Node.js script for scraping
-	local temp_script
-	temp_script=$(mktemp /tmp/watercrawl_scrape_XXXXXX.mjs)
+	# t2997: node ESM requires exact .mjs extension; mktemp -d + fixed filename.
+	local temp_dir temp_script
+	temp_dir=$(mktemp -d /tmp/watercrawl_scrape_XXXXXX)
+	temp_script="$temp_dir/script.mjs"
 	_save_cleanup_scope
 	trap '_run_cleanups' RETURN
-	push_cleanup "rm -f '${temp_script}'"
+	push_cleanup "rm -rf '${temp_dir}'"
 
 	cat >"$temp_script" <<'SCRIPT'
 import { WaterCrawlAPIClient } from '@watercrawl/nodejs';
@@ -641,11 +643,11 @@ SCRIPT
 		print_success "Scrape completed"
 	else
 		print_error "Scrape failed: $result"
-		rm -f "$temp_script"
+		rm -rf "$temp_dir"
 		return 1
 	fi
 
-	rm -f "$temp_script"
+	rm -rf "$temp_dir"
 	return 0
 }
 
@@ -738,11 +740,13 @@ crawl_website() {
 	print_info "Using API: ${WATERCRAWL_API_URL:-}"
 	print_info "Max depth: $max_depth, Page limit: $page_limit"
 
-	local temp_script
-	temp_script=$(mktemp /tmp/watercrawl_crawl_XXXXXX.mjs)
+	# t2997: node ESM requires exact .mjs extension; mktemp -d + fixed filename.
+	local temp_dir temp_script
+	temp_dir=$(mktemp -d /tmp/watercrawl_crawl_XXXXXX)
+	temp_script="$temp_dir/script.mjs"
 	_save_cleanup_scope
 	trap '_run_cleanups' RETURN
-	push_cleanup "rm -f '${temp_script}'"
+	push_cleanup "rm -rf '${temp_dir}'"
 
 	_crawl_write_script "$temp_script"
 
@@ -753,11 +757,11 @@ crawl_website() {
 	else
 		print_error "Crawl failed"
 		printf '%s\n' "$result" >&2
-		rm -f "$temp_script"
+		rm -rf "$temp_dir"
 		return 1
 	fi
 
-	rm -f "$temp_script"
+	rm -rf "$temp_dir"
 	return 0
 }
 
@@ -784,11 +788,13 @@ search_web() {
 	print_info "Result limit: $limit"
 
 	# Create Node.js script for searching
-	local temp_script
-	temp_script=$(mktemp /tmp/watercrawl_search_XXXXXX.mjs)
+	# t2997: node ESM requires exact .mjs extension; mktemp -d + fixed filename.
+	local temp_dir temp_script
+	temp_dir=$(mktemp -d /tmp/watercrawl_search_XXXXXX)
+	temp_script="$temp_dir/script.mjs"
 	_save_cleanup_scope
 	trap '_run_cleanups' RETURN
-	push_cleanup "rm -f '${temp_script}'"
+	push_cleanup "rm -rf '${temp_dir}'"
 
 	cat >"$temp_script" <<'SCRIPT'
 import { WaterCrawlAPIClient } from '@watercrawl/nodejs';
@@ -844,11 +850,11 @@ SCRIPT
 	else
 		print_error "Search failed"
 		echo "$result" >&2
-		rm -f "$temp_script"
+		rm -rf "$temp_dir"
 		return 1
 	fi
 
-	rm -f "$temp_script"
+	rm -rf "$temp_dir"
 	return 0
 }
 
@@ -940,11 +946,13 @@ generate_sitemap() {
 	print_info "Using API: ${WATERCRAWL_API_URL:-}"
 	print_info "Format: $format"
 
-	local temp_script
-	temp_script=$(mktemp /tmp/watercrawl_sitemap_XXXXXX.mjs)
+	# t2997: node ESM requires exact .mjs extension; mktemp -d + fixed filename.
+	local temp_dir temp_script
+	temp_dir=$(mktemp -d /tmp/watercrawl_sitemap_XXXXXX)
+	temp_script="$temp_dir/script.mjs"
 	_save_cleanup_scope
 	trap '_run_cleanups' RETURN
-	push_cleanup "rm -f '${temp_script}'"
+	push_cleanup "rm -rf '${temp_dir}'"
 
 	_sitemap_write_script "$temp_script"
 
@@ -955,11 +963,11 @@ generate_sitemap() {
 	else
 		print_error "Sitemap generation failed"
 		printf '%s\n' "$result" >&2
-		rm -f "$temp_script"
+		rm -rf "$temp_dir"
 		return 1
 	fi
 
-	rm -f "$temp_script"
+	rm -rf "$temp_dir"
 	return 0
 }
 

--- a/.github/workflows/mktemp-portability-check.yml
+++ b/.github/workflows/mktemp-portability-check.yml
@@ -1,0 +1,154 @@
+name: mktemp Portability Check
+
+# t2997: CI lint gate that detects BSD-incompatible mktemp templates.
+# Scans only PR-changed .sh files (diff-scoped) so existing violations on main
+# don't block.
+#
+# Bug class: `mktemp prefix-XXXXXX.ext` is silently broken on macOS BSD mktemp.
+# First call returns the literal template name; subsequent calls fail with
+# `mkstemp failed: File exists`. Canonical failure: GH#21408 (142 spam lines/day
+# in pulse-wrapper.log from a single offender).
+#
+# Violations posted as a PR comment linking to the style guide.
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - '**/*.sh'
+      - '**/*.bash'
+      - '**/*.zsh'
+
+permissions:
+  pull-requests: write
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: mktemp Portability Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+
+      - name: Get changed shell files
+        id: changed
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          changed=$(git diff --name-only --diff-filter=ACMR "$BASE_SHA" "$HEAD_SHA" -- \
+            '*.sh' '*.bash' '*.zsh' || true)
+          if [ -z "$changed" ]; then
+            echo "No shell files changed."
+            echo "has_files=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          printf 'Changed files:\n%s\n' "$changed"
+          echo "has_files=true" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "$changed" > /tmp/changed-shell-files.txt
+
+      - name: Run mktemp portability lint
+        if: steps.changed.outputs.has_files == 'true'
+        id: scan
+        run: |
+          set +e
+          # shellcheck disable=SC2046
+          output=$(bash .agents/scripts/lint-mktemp-portability.sh \
+            $(tr '\n' ' ' < /tmp/changed-shell-files.txt) 2>&1)
+          exit_code=$?
+          set -e
+          echo "exit_code=$exit_code" >> "$GITHUB_OUTPUT"
+          printf '%s\n' "$output"
+          printf '%s\n' "$output" > /tmp/mktemp-portability-report.txt
+
+      - name: Post PR comment on failure
+        if: steps.changed.outputs.has_files == 'true' && steps.scan.outputs.exit_code == '1'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          report=$(cat /tmp/mktemp-portability-report.txt)
+          marker="<!-- mktemp-portability-check -->"
+          body=$(cat <<EOF
+          ${marker}
+          ## mktemp Portability Violations
+
+          The following \`mktemp\` templates have \`XXXXXX\` followed by a literal
+          extension. This silently breaks on macOS BSD mktemp — the first call
+          returns the literal template name, and every subsequent call fails
+          with \`mkstemp failed: File exists\`. GNU mktemp (Linux) accepts both
+          forms, so the bug is invisible in CI until it ships.
+
+          \`\`\`text
+          ${report}
+          \`\`\`
+
+          **Fix options** (see [style guide](.agents/reference/shell-style-guide.md#mktemp-portability-t2997)):
+
+          1. **Drop the extension** (preferred for most cases — interpreters and
+             tools that read content via magic bytes do not need a filename
+             extension):
+
+             \`\`\`bash
+             tmp=\$(mktemp "\${TMPDIR:-/tmp}/foo-XXXXXX")
+             \`\`\`
+
+          2. **Move the extension before the placeholder**:
+
+             \`\`\`bash
+             tmp=\$(mktemp "\${TMPDIR:-/tmp}/foo.json.XXXXXX")
+             \`\`\`
+
+          3. **\`mktemp -d\` + fixed filename** (REQUIRED for \`.mjs\` / \`.cjs\`
+             where node refuses to load files without the exact extension):
+
+             \`\`\`bash
+             tmp_dir=\$(mktemp -d "\${TMPDIR:-/tmp}/foo-XXXXXX")
+             script_file="\$tmp_dir/script.mjs"
+             # ... use \$script_file ...
+             rm -rf "\$tmp_dir"
+             \`\`\`
+
+          Local check: \`bash .agents/scripts/lint-mktemp-portability.sh\`.
+
+          Canonical failure: #21408 (t2997).
+          EOF
+          )
+
+          existing=$(gh api "repos/${REPO}/issues/${PR_NUMBER}/comments" \
+            --jq "[.[] | select(.body | contains(\"$marker\")) | .id] | .[0] // empty" \
+            2>/dev/null || true)
+          if [ -n "$existing" ]; then
+            gh api "repos/${REPO}/issues/comments/${existing}" \
+              --method PATCH -F body="$body" >/dev/null 2>&1 || true
+          else
+            gh pr comment "$PR_NUMBER" --repo "$REPO" --body "$body" \
+              >/dev/null 2>&1 || true
+          fi
+
+      - name: Enforce gate
+        if: steps.changed.outputs.has_files == 'true'
+        env:
+          EXIT_CODE: ${{ steps.scan.outputs.exit_code }}
+        run: |
+          set -euo pipefail
+          if [ "${EXIT_CODE:-0}" = "0" ]; then
+            echo "mktemp portability check: clean."
+            exit 0
+          fi
+          if [ "$EXIT_CODE" = "1" ]; then
+            echo "::error::mktemp portability violations found. See PR comment for details."
+            exit 1
+          fi
+          echo "::error::mktemp portability check failed with unexpected exit code: $EXIT_CODE"
+          exit 1

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -290,7 +290,8 @@ cmd_status() {
 _update_fresh_install() {
 	print_warning "Repository not found, performing fresh install..."
 	local tmp_setup
-	tmp_setup=$(mktemp "${TMPDIR:-/tmp}/aidevops-setup-XXXXXX.sh") || {
+	# t2997: drop .sh — XXXXXX must be at end for BSD mktemp.
+	tmp_setup=$(mktemp "${TMPDIR:-/tmp}/aidevops-setup-XXXXXX") || {
 		print_error "Failed to create temp file for setup script"
 		return 1
 	}

--- a/setup-modules/agent-deploy.sh
+++ b/setup-modules/agent-deploy.sh
@@ -224,7 +224,9 @@ _resolve_model_tiers_in_frontmatter() {
 	#   model: sonnet        → model: anthropic/claude-sonnet-4-6
 	#   model: sonnet  # ... → model: anthropic/claude-sonnet-4-6  # ...
 	local sed_file
-	sed_file=$(mktemp "${TMPDIR:-/tmp}/model-resolve-XXXXXX.sed")
+	# t2997: drop .sed — XXXXXX must be at end for BSD mktemp; sed -f reads
+	# script content regardless of extension.
+	sed_file=$(mktemp "${TMPDIR:-/tmp}/model-resolve-XXXXXX")
 	if [[ -f "$custom_table" ]]; then
 		# Merge: custom tiers override default tiers (jq * operator)
 		jq -r -s '

--- a/setup.sh
+++ b/setup.sh
@@ -490,7 +490,8 @@ verified_install() {
 
 	# Create secure temp file
 	local tmp_script
-	tmp_script=$(mktemp "${TMPDIR:-/tmp}/aidevops-install-XXXXXX.sh") || {
+	# t2997: drop .sh — XXXXXX must be at end for BSD mktemp.
+	tmp_script=$(mktemp "${TMPDIR:-/tmp}/aidevops-install-XXXXXX") || {
 		print_error "Failed to create temp file for $description"
 		return 1
 	}

--- a/tests/test-opencode-response-helpers.sh
+++ b/tests/test-opencode-response-helpers.sh
@@ -65,8 +65,10 @@ if command -v node >/dev/null 2>&1; then
 fi
 
 # --- 2. Runtime behaviour -------------------------------------------------
-TMP_SCRIPT="$(mktemp -t response-helpers-test.XXXXXX.mjs)"
-trap 'rm -f "$TMP_SCRIPT"' EXIT
+# t2997: node ESM requires exact .mjs extension; mktemp -d + fixed filename.
+TMP_DIR="$(mktemp -d -t response-helpers-test.XXXXXX)"
+TMP_SCRIPT="$TMP_DIR/script.mjs"
+trap 'rm -rf "$TMP_DIR"' EXIT
 
 cat >"$TMP_SCRIPT" <<EOF
 import { jsonResponse, jsonResponseFallback, textResponse } from "$PLUGIN_DIR/response-helpers.mjs";


### PR DESCRIPTION
## Summary

Fix 46 mktemp callsites where XXXXXX was followed by an extension — silently broken on macOS BSD mktemp (returns literal name on first call, fails 'mkstemp failed: File exists' thereafter). Add lint-mktemp-portability.sh + CI workflow + shell-style-guide section. Canonical 142-spam-lines/day offender (pulse-prefetch-fetch.sh:1107) fixed. .mjs files use mktemp -d + fixed filename to preserve node ESM extension matching.

## Files Changed

.agents/reference/shell-style-guide.md,.agents/scripts/anti-detect-helper.sh,.agents/scripts/browser-qa-helper.sh,.agents/scripts/document-extraction-helper.sh,.agents/scripts/email-receipt-forward-helper.sh,.agents/scripts/email-sieve-helper.sh,.agents/scripts/headless-runtime-helper.sh,.agents/scripts/headless-runtime-lib.sh,.agents/scripts/issue-sync-helper.sh,.agents/scripts/knowledge-review-helper.sh,.agents/scripts/lint-mktemp-portability.sh,.agents/scripts/pulse-logging.sh,.agents/scripts/pulse-prefetch-fetch.sh,.agents/scripts/pulse-repo-tier.sh,.agents/scripts/pulse-stats-helper.sh,.agents/scripts/pulse-wrapper.sh,.agents/scripts/setup/_common.sh,.agents/scripts/simplex-helper.sh,.agents/scripts/site-crawler-helper.sh,.agents/scripts/sops-helper.sh,.agents/scripts/test-inbox-capture.sh,.agents/scripts/tests/test-bounty-spam-detector.sh,.agents/scripts/tests/test-browser-qa-helper.sh,.agents/scripts/tests/test-enrich-batch-prefetch.sh,.agents/scripts/tests/test-gh-wrapper-zsh-compat.sh,.agents/scripts/tests/test-issue-sync-pull-seeds-orphans.sh,.agents/scripts/tests/test-setup-tools-zsh-compat.sh,.agents/scripts/verify-brief.sh,.agents/scripts/watercrawl-helper.sh,.github/workflows/mktemp-portability-check.yml,aidevops.sh,setup-modules/agent-deploy.sh,setup.sh,tests/test-opencode-response-helpers.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Reproduced bug on macOS, verified all 3 fix forms (drop-ext, ext-before-X, mktemp -d). lint script: 0 violations across 1075 files (was 46). shellcheck: clean. actionlint: clean.

Resolves #21408


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.3 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-opus-4-7 spent 16m and 57,002 tokens on this as a headless worker.