### PR TITLE
t2995: distinguish file-size-debt dedup lookup-failure from no-match

### DIFF
--- a/.agents/scripts/pulse-dispatch-large-file-gate.sh
+++ b/.agents/scripts/pulse-dispatch-large-file-gate.sh
@@ -368,26 +368,52 @@ _large_file_gate_verify_prior_reduced_size() {
 }
 
 #######################################
-# t2164 helper — find an open or recently-closed file-size-debt issue
-# that mentions `_lf_basename`. Prints "<state>:<number>" on stdout when
-# found (state is "open" or "closed"); prints nothing otherwise.
+# t2164 / t2995 helper — find an open or recently-closed file-size-debt
+# issue that mentions `_lf_basename`. Prints "<state>:<number>" on stdout
+# when found (state is "open" or "closed"); prints nothing otherwise.
 #
 # State is emitted as a stdout prefix instead of via `printf -v` because the
 # caller invokes this helper in a command substitution `$(…)`, which runs in
 # a subshell — `printf -v` in the subshell cannot reach the caller's scope.
 # Encoding both values in stdout sidesteps the subshell boundary entirely.
 #
+# t2995: distinguish three outcomes via exit code so the caller can defer
+# instead of duplicating on a transient lookup failure (the historical bug
+# where a 15s gh wall-clock timeout was swallowed by `|| _open=""` and
+# treated as "no match", causing the gate to file a duplicate on every
+# scanner cycle that timed out — observed 7 duplicates for worktree-helper.sh
+# alone over 30 days).
+#
 # Arguments: repo_slug, lf_basename
 # Stdout: "open:12345", "closed:18706", or empty
+# Exit codes:
+#   0 — match found (stdout populated)
+#   1 — no match (stdout empty, lookup succeeded)
+#   2 — lookup failed (timeout, network error, gh non-zero) — caller should
+#       defer. The next pulse cycle will retry.
 #######################################
 _large_file_gate_find_existing_debt_issue() {
 	local repo_slug="$1"
 	local lf_basename="$2"
 
-	local _open
+	# Open-state lookup. One retry with 2s backoff covers GitHub search
+	# index lag (typically 1-3s after issue creation) — t2995 investigation
+	# step 4. We only retry when the call SUCCEEDED but returned empty;
+	# retrying a real failure would just hit the same timeout twice.
+	local _open _open_rc=0
 	_open=$(gh_issue_list --repo "$repo_slug" --state open \
 		--label "file-size-debt" --search "$lf_basename" \
-		--json number --jq '.[0].number // empty' --limit 5 2>/dev/null) || _open=""
+		--json number --jq '.[0].number // empty' --limit 5 2>/dev/null) || _open_rc=$?
+	if [[ $_open_rc -eq 0 && -z "$_open" ]]; then
+		sleep 2
+		_open=$(gh_issue_list --repo "$repo_slug" --state open \
+			--label "file-size-debt" --search "$lf_basename" \
+			--json number --jq '.[0].number // empty' --limit 5 2>/dev/null) || _open_rc=$?
+	fi
+	if [[ $_open_rc -ne 0 ]]; then
+		echo "[pulse-wrapper] WARN: file-size-debt dedup open-search failed for ${lf_basename} (rc=${_open_rc}); deferring (t2995)" >>"$LOGFILE"
+		return 2
+	fi
 	if [[ -n "$_open" ]]; then
 		printf 'open:%s' "$_open"
 		return 0
@@ -401,12 +427,16 @@ _large_file_gate_find_existing_debt_issue() {
 		return 1
 	fi
 
-	local _closed
+	local _closed _closed_rc=0
 	_closed=$(gh_issue_list --repo "$repo_slug" \
 		--state closed --label "file-size-debt" \
 		--search "$lf_basename closed:>$_recent_date" \
 		--json number --jq '.[0].number // empty' \
-		--limit 5 2>/dev/null) || _closed=""
+		--limit 5 2>/dev/null) || _closed_rc=$?
+	if [[ $_closed_rc -ne 0 ]]; then
+		echo "[pulse-wrapper] WARN: file-size-debt dedup closed-search failed for ${lf_basename} (rc=${_closed_rc}); deferring (t2995)" >>"$LOGFILE"
+		return 2
+	fi
 	if [[ -n "$_closed" ]]; then
 		printf 'closed:%s' "$_closed"
 		return 0
@@ -519,8 +549,16 @@ _large_file_gate_create_debt_issue() {
 
 	# t2164: helper encodes state in stdout as "<state>:<number>" — subshell
 	# boundary prevents `printf -v` from crossing the command substitution.
-	local _existing_combined _existing _existing_state
-	_existing_combined=$(_large_file_gate_find_existing_debt_issue "$repo_slug" "$_lf_basename") || _existing_combined=""
+	# t2995: helper now returns 2 when lookup fails (timeout / gh failure),
+	# distinct from 1 = no match. On lookup failure we MUST NOT fall through
+	# to filing a fresh issue — that's the duplicate-creation bug. Defer to
+	# the next pulse cycle.
+	local _existing_combined _existing _existing_state _lookup_rc=0
+	_existing_combined=$(_large_file_gate_find_existing_debt_issue "$repo_slug" "$_lf_basename") || _lookup_rc=$?
+	if [[ "$_lookup_rc" -eq 2 ]]; then
+		echo "[pulse-wrapper] file-size-debt dedup lookup failed for ${_lf_basename} (parent #${parent_issue}); deferring filing to next cycle (t2995)" >>"$LOGFILE"
+		return 0
+	fi
 	if [[ -n "$_existing_combined" && "$_existing_combined" == *:* ]]; then
 		_existing_state="${_existing_combined%%:*}"
 		_existing="${_existing_combined#*:}"

--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -881,3 +881,107 @@ _rest_issue_list() {
 	fi
 	return $?
 }
+
+#######################################
+# _rest_issue_search: GET /search/issues?q=...  (t2995)
+# REST-side equivalent of `gh issue list --search`. Used by the gh_issue_list
+# wrapper when GraphQL is exhausted AND the call carried a --search filter.
+# The plain /repos/{owner}/{repo}/issues endpoint does NOT support full-text
+# search, so the prior REST translator silently dropped --search and returned
+# label-only results — a silent-correctness bug that caused the file-size-debt
+# dedup helper to match wrong issues during exhaustion windows.
+#
+# Translation:
+#   gh issue list --repo OWNER/REPO --state open \
+#     --label LABEL --search QUERY --json number --jq '.[0].number'
+# becomes:
+#   gh api /search/issues?q=QUERY+repo:OWNER/REPO+is:issue+is:open+label:LABEL \
+#     --jq '.items[0].number'
+#
+# Notes:
+#   - Search API has its own quota (30 req/min for authenticated users) —
+#     separate from both core REST and GraphQL pools.
+#   - Multiple --label flags are AND-joined into multiple `+label:"X"` qualifiers.
+#   - --json FIELDS is accepted for parity but ignored (caller uses --jq).
+#   - --jq expressions written for `gh issue list` operate on a flat array
+#     (e.g. `.[0].number`). The /search/issues endpoint wraps results in
+#     `{items:[...]}`. To preserve drop-in semantics, we extract `.items`
+#     before applying the user's jq filter.
+#
+# Returns the underlying gh api exit code.
+#######################################
+_rest_issue_search() {
+	gh_record_call rest 2>/dev/null || true
+	local repo=""
+	local state=""
+	local search=""
+	local limit=30
+	local jq_expr=""
+	local -a labels
+	local _tok
+	labels=()
+
+	while [[ $# -gt 0 ]]; do
+		local _arg="$1"
+		case "$_arg" in
+		--repo) repo="${2:-}"; shift 2 ;;
+		--repo=*) repo="${_arg#--repo=}"; shift ;;
+		--state) state="${2:-}"; shift 2 ;;
+		--state=*) state="${_arg#--state=}"; shift ;;
+		--label) while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_gh_split_csv "${2:-}"); shift 2 ;;
+		--label=*) while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_gh_split_csv "${_arg#--label=}"); shift ;;
+		--limit) limit="${2:-}"; shift 2 ;;
+		--limit=*) limit="${_arg#--limit=}"; shift ;;
+		--search) search="${2:-}"; shift 2 ;;
+		--search=*) search="${_arg#--search=}"; shift ;;
+		--json) shift 2 ;;
+		--json=*) shift ;;
+		--jq) jq_expr="${2:-}"; shift 2 ;;
+		--jq=*) jq_expr="${_arg#--jq=}"; shift ;;
+		*) shift ;;
+		esac
+	done
+
+	if [[ -z "$repo" || -z "$search" ]]; then
+		printf '_rest_issue_search: --repo and --search are required\n' >&2
+		return 1
+	fi
+
+	# Build the q= parameter. Each token is URI-encoded individually then
+	# joined with `+`. The repo:/is:issue/state qualifiers go AFTER the
+	# user-supplied search to preserve the user's term ordering.
+	local _q
+	_q=$(jq -rn --arg v "$search" '$v | @uri')
+	local _repo_enc
+	_repo_enc=$(jq -rn --arg v "$repo" '$v | @uri')
+	_q="${_q}+repo:${_repo_enc}+is:issue"
+	if [[ -n "$state" && "$state" != "all" ]]; then
+		# /search/issues uses `is:open` / `is:closed`, not `state:`.
+		_q="${_q}+is:${state}"
+	fi
+	local _label
+	for _label in "${labels[@]}"; do
+		local _label_enc
+		_label_enc=$(jq -rn --arg v "$_label" '$v | @uri')
+		_q="${_q}+label:%22${_label_enc}%22"
+	done
+
+	local _path="/search/issues?q=${_q}&per_page=${limit}"
+
+	# Translate caller's jq (which expects a flat array) into one that
+	# operates on .items. If no --jq, just return .items as a JSON array.
+	local _final_jq
+	if [[ -n "$jq_expr" ]]; then
+		_final_jq=".items | ${jq_expr}"
+	else
+		_final_jq=".items"
+	fi
+
+	local _gh_cmd=(gh api "$_path" --jq "$_final_jq")
+	if command -v _gh_with_timeout >/dev/null 2>&1; then
+		_gh_with_timeout read "${_gh_cmd[@]}"
+	else
+		"${_gh_cmd[@]}"
+	fi
+	return $?
+}

--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -1749,12 +1749,20 @@ gh_pr_list() {
 }
 
 #######################################
-# gh_issue_list — drop-in replacement for gh issue list.  (t2689)
-# Falls back to REST (`gh api GET /repos/{owner}/{repo}/issues`) when the
-# primary call fails AND GraphQL is exhausted. Supports --state, --label
-# (multiple), --assignee, --limit, --json, --jq. The --search flag is
-# accepted but silently skipped in the REST path (not supported by the
-# /repos/.../issues endpoint).
+# gh_issue_list — drop-in replacement for gh issue list.  (t2689, t2995)
+# Falls back to REST when the primary call fails AND GraphQL is exhausted.
+# Supports --state, --label (multiple), --assignee, --limit, --json, --jq,
+# --search.
+#
+# Routing (t2995):
+#   - --search non-empty → _rest_issue_search uses /search/issues?q=...
+#     (separate quota: 30 req/min). Preserves search semantics so the
+#     caller does not silently get a label-only result on fallback.
+#   - --search empty → _rest_issue_list uses /repos/{owner}/{repo}/issues.
+#
+# Pre-t2995 behaviour silently dropped --search in the REST path, causing
+# `_large_file_gate_find_existing_debt_issue` to match the wrong issue
+# during GraphQL exhaustion windows.
 #
 #   gh_issue_list --repo owner/repo --state open --label bug --json number,title
 #   gh_issue_list --repo owner/repo --state open --limit 500 --json number --jq length
@@ -1766,9 +1774,26 @@ gh_issue_list() {
 	_gh_with_timeout read gh issue list "$@"
 	local rc=$?
 	if [[ $rc -ne 0 ]] && _gh_should_fallback_to_rest; then
-		print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to REST for issue list"
-		_rest_issue_list "$@"
-		rc=$?
+		# t2995: use search-aware REST fallback when --search is supplied.
+		# Walk argv to detect --search; the helper itself re-parses, but we
+		# need to know whether to dispatch to /search/issues (which preserves
+		# search semantics) or /repos/.../issues (which doesn't support it).
+		local _has_search=0
+		local _arg
+		for _arg in "$@"; do
+			case "$_arg" in
+			--search|--search=*) _has_search=1; break ;;
+			esac
+		done
+		if [[ $_has_search -eq 1 ]]; then
+			print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to /search/issues for issue list (--search preserved, t2995)"
+			_rest_issue_search "$@"
+			rc=$?
+		else
+			print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to REST for issue list"
+			_rest_issue_list "$@"
+			rc=$?
+		fi
 	fi
 	return $rc
 }

--- a/.agents/scripts/tests/test-large-file-gate-continuation-verify.sh
+++ b/.agents/scripts/tests/test-large-file-gate-continuation-verify.sh
@@ -92,6 +92,20 @@ GH_CREATE_RESPONSE_URL=""
 # shellcheck source=/dev/null
 source "$GATE_SCRIPT"
 
+# t2995: define wrapper stubs so the gate's gh_issue_list calls reach the
+# gh() shell-function stub below. Without these, gh_issue_list resolves to
+# a missing external command (rc=127), which the old gate code path
+# swallowed as "no match" but the new t2995 path correctly treats as
+# "lookup failed → defer".
+gh_issue_list() {
+	gh issue list "$@"
+	return $?
+}
+
+# t2995: no-op the 2-second retry sleep introduced for search-index lag
+# so the test doesn't actually pause.
+sleep() { return 0; }
+
 gh() {
 	# Log every call for debugging
 	printf '%s\n' "gh $*" >>"$GH_CALLS_LOG"

--- a/.agents/scripts/tests/test-large-file-gate-dedup.sh
+++ b/.agents/scripts/tests/test-large-file-gate-dedup.sh
@@ -1,0 +1,422 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-large-file-gate-dedup.sh — t2995 regression guard.
+#
+# Asserts that `_large_file_gate_find_existing_debt_issue` and its caller
+# `_large_file_gate_create_debt_issue` distinguish three outcomes from the
+# `gh_issue_list` lookup:
+#
+#   rc=0 (match)     → return existing issue reference, no creation.
+#   rc=1 (no match)  → file a new debt issue.
+#   rc=2 (lookup err)→ defer; do NOT create a fresh debt issue.
+#
+# Background:
+#   Pre-t2995, the helper swallowed gh_issue_list failures via
+#   `|| _open=""` and treated lookup-error as no-match. When the gh wall-
+#   clock timeout fired (15s, AIDEVOPS_GH_READ_TIMEOUT), every cycle that
+#   timed out filed a duplicate. Worktree-helper.sh accumulated 7 open
+#   file-size-debt duplicates over 30 days; aidevops.sh accumulated 2;
+#   shared-constants.sh accumulated 2.
+#
+# Tests (in source order):
+#   1. helper:match-open      → rc=0, stdout="open:NNN"
+#   2. helper:match-closed    → rc=0, stdout="closed:NNN"
+#   3. helper:no-match        → rc=1, stdout=""
+#   4. helper:lookup-failed   → rc=2, stdout="", logs WARN
+#   5. caller:lookup-failed-defers → does NOT call _large_file_gate_file_new_debt_issue
+#   6. caller:no-match-files-new   → DOES call _large_file_gate_file_new_debt_issue
+#   7. helper:retry-on-empty  → first call returns empty, retry returns match
+#                                (catches search index lag, t2995 step 4)
+#   8. wrapper:gh_issue_list-with-search-routes-via-search-issues
+#                                → REST fallback uses /search/issues, not
+#                                  /repos/.../issues, when --search is non-empty
+#                                  (catches t2995 silent-correctness bug)
+#
+# Stub strategy: define `gh_issue_list`, `gh`, and `_large_file_gate_file_new_debt_issue`
+# as shell functions BEFORE sourcing the gate script. Per-test env vars control
+# stub behaviour deterministically.
+
+set -uo pipefail
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR_TEST}/.." && pwd)" || exit 1
+
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf '  %sPASS%s %s\n' "$TEST_GREEN" "$TEST_NC" "$1"
+	return 0
+}
+
+fail() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '  %sFAIL%s %s\n' "$TEST_RED" "$TEST_NC" "$1"
+	[[ -n "${2:-}" ]] && printf '       %s\n' "$2"
+	return 0
+}
+
+# =============================================================================
+# Sandbox + stubs
+# =============================================================================
+TMP=$(mktemp -d -t t2995.XXXXXX)
+trap 'rm -rf "$TMP"' EXIT
+
+LOGFILE="${TMP}/pulse-wrapper.log"
+export LOGFILE
+: >"$LOGFILE"
+
+NEW_ISSUE_CALLS="${TMP}/new_issue_calls.log"
+GH_ISSUE_LIST_CALLS="${TMP}/gh_issue_list_calls.log"
+: >"$NEW_ISSUE_CALLS"
+: >"$GH_ISSUE_LIST_CALLS"
+
+# Quiet logging deps that the gate script sources transitively.
+print_info() { return 0; }
+print_warning() { return 0; }
+print_error() { return 0; }
+print_success() { return 0; }
+log_verbose() { return 0; }
+export -f print_info print_warning print_error print_success log_verbose
+
+# Stub the gh_issue_list wrapper. Per-test env vars:
+#   STUB_GH_LIST_RC          — exit code (default 0)
+#   STUB_GH_LIST_OPEN_OUT    — stdout for open-state queries (--state open)
+#   STUB_GH_LIST_CLOSED_OUT  — stdout for closed-state queries (--state closed)
+#   STUB_GH_LIST_RETRY_OUT   — stdout on the SECOND open-state call only
+#                              (set to simulate retry-after-empty, t2995 step 4)
+#
+# Counter is kept in a temp file so increments survive subshells (the helpers
+# under test invoke gh_issue_list inside `$(...)` command substitutions).
+OPEN_CALL_COUNTER="${TMP}/open_call_counter"
+echo 0 >"$OPEN_CALL_COUNTER"
+export OPEN_CALL_COUNTER
+gh_issue_list() {
+	printf '%s\n' "$*" >>"$GH_ISSUE_LIST_CALLS"
+	local _state=""
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		--state) _state="$2"; shift 2 ;;
+		*) shift ;;
+		esac
+	done
+	if [[ "$_state" == "open" ]]; then
+		local _n
+		_n=$(cat "$OPEN_CALL_COUNTER" 2>/dev/null || echo 0)
+		_n=$((_n + 1))
+		echo "$_n" >"$OPEN_CALL_COUNTER"
+		# On the SECOND open call, return STUB_GH_LIST_RETRY_OUT if set.
+		if [[ "$_n" -ge 2 && -n "${STUB_GH_LIST_RETRY_OUT:-}" ]]; then
+			printf '%s' "$STUB_GH_LIST_RETRY_OUT"
+			return 0
+		fi
+		printf '%s' "${STUB_GH_LIST_OPEN_OUT:-}"
+	elif [[ "$_state" == "closed" ]]; then
+		printf '%s' "${STUB_GH_LIST_CLOSED_OUT:-}"
+	fi
+	return "${STUB_GH_LIST_RC:-0}"
+}
+export -f gh_issue_list
+
+# Stub _large_file_gate_file_new_debt_issue so we can detect when the
+# caller decides to file a fresh issue. Records the call and emits the
+# deterministic "#N (new)" return shape the real helper produces.
+_large_file_gate_file_new_debt_issue() {
+	printf '%s\n' "lf_path=$1 parent=$2 repo=$3 prior=${4:-}" >>"$NEW_ISSUE_CALLS"
+	printf '#9999 (new)'
+	return 0
+}
+export -f _large_file_gate_file_new_debt_issue
+
+# Stub _large_file_gate_verify_prior_reduced_size so the closed-match path
+# can be exercised without filesystem inspection.
+_large_file_gate_verify_prior_reduced_size() {
+	# Default: prior PR DID reduce size → continuation path fires.
+	# Tests that need the failed-prior path can override via env.
+	return "${STUB_VERIFY_REDUCED_RC:-0}"
+}
+export -f _large_file_gate_verify_prior_reduced_size
+
+# Stub sleep so the retry-on-empty path doesn't pause 2s in tests. The real
+# helper uses `sleep 2` between the first empty result and the retry; we
+# short-circuit it for deterministic test runtime.
+sleep() { return 0; }
+export -f sleep
+
+# Bash 3.2 + LARGE_FILE_LINE_THRESHOLD (referenced by the gate script via
+# nested helpers). The dedup helper itself does not depend on this — but
+# downstream calls in the create helper do, so set it for completeness.
+export LARGE_FILE_LINE_THRESHOLD=1000
+
+# Source the gate script. NOTE: the gate script DOES define
+# _large_file_gate_file_new_debt_issue and _large_file_gate_verify_prior_reduced_size
+# itself, which would shadow our stubs. We re-define them AFTER sourcing.
+# `gh_issue_list` is NOT defined in the gate script (it lives in
+# shared-gh-wrappers.sh, which we deliberately don't source here), so our
+# stub survives.
+unset _PULSE_DISPATCH_LARGE_FILE_GATE_LOADED || true
+# shellcheck source=../pulse-dispatch-large-file-gate.sh
+source "${SCRIPTS_DIR}/pulse-dispatch-large-file-gate.sh" >/dev/null 2>&1 || {
+	printf '%sFATAL%s could not source gate script\n' "$TEST_RED" "$TEST_NC"
+	exit 1
+}
+
+# Re-define the helper stubs that the gate script overwrote with its real
+# implementations.
+_large_file_gate_file_new_debt_issue() {
+	printf '%s\n' "lf_path=$1 parent=$2 repo=$3 prior=${4:-}" >>"$NEW_ISSUE_CALLS"
+	printf '#9999 (new)'
+	return 0
+}
+_large_file_gate_verify_prior_reduced_size() {
+	return "${STUB_VERIFY_REDUCED_RC:-0}"
+}
+export -f _large_file_gate_file_new_debt_issue _large_file_gate_verify_prior_reduced_size
+
+# Re-export the print_* stubs in case any sourced lib overrode them.
+export -f print_info print_warning print_error print_success log_verbose
+
+# Helper: reset per-test stub state. The counter file (OPEN_CALL_COUNTER)
+# is also reset so retry-tracking starts fresh per test.
+_reset_stubs() {
+	echo 0 >"$OPEN_CALL_COUNTER"
+	export STUB_GH_LIST_RC=0
+	export STUB_GH_LIST_OPEN_OUT=""
+	export STUB_GH_LIST_CLOSED_OUT=""
+	export STUB_GH_LIST_RETRY_OUT=""
+	export STUB_VERIFY_REDUCED_RC=0
+	: >"$NEW_ISSUE_CALLS"
+	: >"$GH_ISSUE_LIST_CALLS"
+	: >"$LOGFILE"
+}
+
+# =============================================================================
+# Helper-level tests
+# =============================================================================
+printf '\n=== test-large-file-gate-dedup.sh (t2995) ===\n\n'
+printf '%s\n\n' '--- Helper: _large_file_gate_find_existing_debt_issue ---'
+
+# Test 1: open match → rc=0, stdout="open:1234"
+_reset_stubs
+export STUB_GH_LIST_OPEN_OUT="1234"
+out=""
+rc=0
+out=$(_large_file_gate_find_existing_debt_issue "owner/repo" "worktree-helper.sh") || rc=$?
+if [[ "$rc" == "0" && "$out" == "open:1234" ]]; then
+	pass "helper:match-open returns rc=0 stdout=open:1234"
+else
+	fail "helper:match-open" "rc=$rc out='$out'"
+fi
+
+# Test 2: closed match → rc=0, stdout="closed:5678" (open returns empty,
+# closed returns 5678)
+_reset_stubs
+export STUB_GH_LIST_OPEN_OUT=""
+export STUB_GH_LIST_CLOSED_OUT="5678"
+# Avoid the retry path by ensuring no STUB_GH_LIST_RETRY_OUT is set
+# (the retry returns empty too, then closed search runs).
+out=""
+rc=0
+out=$(_large_file_gate_find_existing_debt_issue "owner/repo" "worktree-helper.sh") || rc=$?
+if [[ "$rc" == "0" && "$out" == "closed:5678" ]]; then
+	pass "helper:match-closed returns rc=0 stdout=closed:5678"
+else
+	fail "helper:match-closed" "rc=$rc out='$out'"
+fi
+
+# Test 3: no match → rc=1, stdout=""
+_reset_stubs
+export STUB_GH_LIST_OPEN_OUT=""
+export STUB_GH_LIST_CLOSED_OUT=""
+out=""
+rc=0
+out=$(_large_file_gate_find_existing_debt_issue "owner/repo" "worktree-helper.sh") || rc=$?
+if [[ "$rc" == "1" && -z "$out" ]]; then
+	pass "helper:no-match returns rc=1 stdout=empty"
+else
+	fail "helper:no-match" "rc=$rc out='$out'"
+fi
+
+# Test 4: lookup failure → rc=2, stdout="", logs WARN (THE t2995 fix)
+_reset_stubs
+export STUB_GH_LIST_RC=124
+out=""
+rc=0
+out=$(_large_file_gate_find_existing_debt_issue "owner/repo" "worktree-helper.sh") || rc=$?
+if [[ "$rc" == "2" && -z "$out" ]]; then
+	pass "helper:lookup-failed returns rc=2 stdout=empty"
+else
+	fail "helper:lookup-failed" "rc=$rc out='$out'"
+fi
+if grep -q "file-size-debt dedup open-search failed for worktree-helper.sh" "$LOGFILE"; then
+	pass "helper:lookup-failed logs WARN with basename"
+else
+	fail "helper:lookup-failed logs WARN" "log contents: $(cat "$LOGFILE")"
+fi
+
+# Test 7: retry on empty (search index lag, t2995 step 4). The `sleep`
+# call inside the helper is no-op'd by the global stub.
+_reset_stubs
+export STUB_GH_LIST_OPEN_OUT=""
+export STUB_GH_LIST_RETRY_OUT="9001"
+out=""
+rc=0
+out=$(_large_file_gate_find_existing_debt_issue "owner/repo" "worktree-helper.sh") || rc=$?
+calls=$(cat "$OPEN_CALL_COUNTER" 2>/dev/null || echo "?")
+if [[ "$rc" == "0" && "$out" == "open:9001" ]]; then
+	pass "helper:retry-on-empty catches search index lag (calls=$calls)"
+else
+	fail "helper:retry-on-empty" "rc=$rc out='$out' calls=$calls"
+fi
+
+# =============================================================================
+# Caller-level tests
+# =============================================================================
+printf '\n%s\n\n' '--- Caller: _large_file_gate_create_debt_issue ---'
+
+# Test 5: lookup failure → caller defers (does NOT call file-new helper)
+_reset_stubs
+export STUB_GH_LIST_RC=124
+out=""
+rc=0
+out=$(_large_file_gate_create_debt_issue ".agents/scripts/worktree-helper.sh" "21406" "owner/repo" "/tmp/repo") || rc=$?
+new_calls=$(wc -l <"$NEW_ISSUE_CALLS" | tr -d ' ')
+if [[ "$rc" == "0" && "$new_calls" == "0" ]]; then
+	pass "caller:lookup-failed-defers (does NOT file new issue)"
+else
+	fail "caller:lookup-failed-defers" "rc=$rc new_calls=$new_calls out='$out'"
+fi
+if grep -q "file-size-debt dedup lookup failed for worktree-helper.sh" "$LOGFILE"; then
+	pass "caller:lookup-failed-defers logs deferral with parent ref"
+else
+	fail "caller:lookup-failed-defers logs" "log contents: $(cat "$LOGFILE")"
+fi
+
+# Test 6: no-match → caller files new issue
+_reset_stubs
+export STUB_GH_LIST_OPEN_OUT=""
+export STUB_GH_LIST_CLOSED_OUT=""
+out=""
+rc=0
+out=$(_large_file_gate_create_debt_issue ".agents/scripts/worktree-helper.sh" "21406" "owner/repo" "/tmp/repo") || rc=$?
+new_calls=$(wc -l <"$NEW_ISSUE_CALLS" | tr -d ' ')
+if [[ "$rc" == "0" && "$new_calls" == "1" && "$out" == "#9999 (new)" ]]; then
+	pass "caller:no-match-files-new (files new issue)"
+else
+	fail "caller:no-match-files-new" "rc=$rc new_calls=$new_calls out='$out'"
+fi
+
+# =============================================================================
+# Wrapper-level test: gh_issue_list --search routes via /search/issues
+# =============================================================================
+printf '\n%s\n\n' '--- Wrapper: gh_issue_list REST fallback parity for --search ---'
+
+# Source shared-gh-wrappers (which also sources rest-fallback) in a fresh
+# subshell context. We override `gh` to record the api path it gets called
+# with, and force the fallback via _GH_SHOULD_FALLBACK_OVERRIDE=1.
+(
+	# Shadow the gh_issue_list stub (defined in the parent test) so the real
+	# wrapper runs in this subshell.
+	unset -f gh_issue_list || true
+	unset _SHARED_GH_WRAPPERS_LOADED _SHARED_GH_WRAPPERS_REST_FALLBACK_LOADED || true
+
+	GH_API_PATHS="${TMP}/gh_api_paths.log"
+	: >"$GH_API_PATHS"
+
+	# shellcheck source=../shared-gh-wrappers.sh
+	source "${SCRIPTS_DIR}/shared-gh-wrappers.sh" >/dev/null 2>&1 || true
+
+	# Override _gh_with_timeout AFTER sourcing. The default implementation
+	# uses `timeout 15 "$@"` when the timeout binary is on PATH, which fork-
+	# execs the gh binary directly and bypasses our shell-function stub. We
+	# replace it with a passthrough so our `gh()` stub captures every call.
+	_gh_with_timeout() {
+		shift # drop op_class
+		"$@"
+		return $?
+	}
+
+	# Stub gh as a shell function — captures both the primary `gh issue list`
+	# call and the fallback `gh api ...` calls. The shell function takes
+	# precedence over PATH binaries.
+	gh() {
+		printf '%s\n' "$*" >>"$GH_API_PATHS"
+		case "$1" in
+		issue)
+			# Primary `gh issue list` — force failure to trigger fallback.
+			return 1
+			;;
+		api)
+			if [[ "$2" == "rate_limit" ]]; then
+				# _GH_SHOULD_FALLBACK_OVERRIDE short-circuits this anyway.
+				printf '0\n'
+				return 0
+			fi
+			if [[ "$2" =~ ^/search/issues ]]; then
+				# Real endpoint shape: { "items": [{ "number": 4242 }] }.
+				# After --jq ".items | .[0].number // empty" the result is "4242".
+				printf '4242\n'
+				return 0
+			fi
+			if [[ "$2" =~ ^/repos/ ]]; then
+				# Plain issues endpoint — the OLD silent-drop path. If this
+				# fires when --search was supplied, the routing fix regressed.
+				printf '[]\n'
+				return 0
+			fi
+			;;
+		esac
+		return 1
+	}
+
+	export _GH_SHOULD_FALLBACK_OVERRIDE=1
+
+	out=$(gh_issue_list --repo owner/repo --state open --label file-size-debt \
+		--search worktree-helper.sh --json number --jq '.[0].number // empty' --limit 5 2>/dev/null)
+
+	# Verify /search/issues was called AND /repos/owner/repo/issues was NOT.
+	if grep -q "api /search/issues" "$GH_API_PATHS"; then
+		printf 'PASS_SEARCH\n' >"${TMP}/wrapper_result"
+	else
+		printf 'FAIL_SEARCH out=%s paths=%s\n' "$out" "$(cat "$GH_API_PATHS")" >"${TMP}/wrapper_result"
+	fi
+	if ! grep -qE 'api /repos/[^/]+/[^/]+/issues\?' "$GH_API_PATHS"; then
+		printf 'PASS_NO_REPOS\n' >>"${TMP}/wrapper_result"
+	else
+		printf 'FAIL_NO_REPOS paths=%s\n' "$(cat "$GH_API_PATHS")" >>"${TMP}/wrapper_result"
+	fi
+)
+wrapper_result=$(cat "${TMP}/wrapper_result" 2>/dev/null || true)
+if grep -q "PASS_SEARCH" <<<"$wrapper_result"; then
+	pass "wrapper:gh_issue_list-with-search routes via /search/issues"
+else
+	fail "wrapper:gh_issue_list-with-search routes via /search/issues" "$wrapper_result"
+fi
+if grep -q "PASS_NO_REPOS" <<<"$wrapper_result"; then
+	pass "wrapper:gh_issue_list-with-search does NOT hit /repos/.../issues"
+else
+	fail "wrapper:gh_issue_list-with-search does NOT hit /repos/.../issues" "$wrapper_result"
+fi
+
+# =============================================================================
+# Summary
+# =============================================================================
+printf '\n=== Results: %d/%d passed ===\n\n' "$((TESTS_RUN - TESTS_FAILED))" "$TESTS_RUN"
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+	printf '%sFAILED%s — %d test(s) failed\n' "$TEST_RED" "$TEST_NC" "$TESTS_FAILED"
+	exit 1
+fi
+printf '%sALL PASSED%s\n' "$TEST_GREEN" "$TEST_NC"
+exit 0


### PR DESCRIPTION
## Summary

Fix `large-file-simplification-gate` filing duplicate `file-size-debt:` issues for the same file (worktree-helper.sh accumulated 7 in 30 days; aidevops.sh and shared-constants.sh each accumulated 2).

## Root Causes

### 1. Lookup failure conflated with no-match (primary)

`_large_file_gate_find_existing_debt_issue` swallowed every non-zero `gh` exit:

```bash
_open=$(gh_issue_list ... 2>/dev/null) || _open=""
```

This treats `rc=124` (timeout — fires routinely under load given `AIDEVOPS_GH_READ_TIMEOUT=15`), `rc=non-zero` (network error, rate-limit), or `rc=127` (missing command) as "no existing debt issue, file new one". Every dedup lookup that fails for transient reasons becomes a duplicate.

### 2. `--search` silently dropped on REST fallback (secondary)

When GraphQL is exhausted (`AIDEVOPS_GH_REST_FALLBACK_THRESHOLD=1500`), `gh_issue_list` falls back to `_rest_issue_list` which queried `/repos/.../issues` — **an endpoint that does not support text search**. Results were filtered by label only, so the helper picked an arbitrary `file-size-debt` issue regardless of basename.

## Fix

### Three-state return code

```text
rc=0  match found     stdout: "<state>:<number>"
rc=1  no match        stdout: empty (lookup succeeded)
rc=2  lookup failed   stdout: empty, WARN logged — caller must defer
```

The caller (`_large_file_gate_create_debt_issue`) now defers (returns 0 without filing) on rc=2 with `[pulse-wrapper] file-size-debt dedup lookup failed for ${basename} (parent #N); deferring filing to next cycle (t2995)`. The next pulse cycle retries.

### Search-index lag retry

Added a single 2-second retry on empty open-search result (covers GitHub search-index lag, typically 1-3s after issue creation). We only retry on success-with-empty — retrying a real failure would just hit the same timeout twice.

### Search-aware REST fallback

New `_rest_issue_search` helper routes `--search` queries through `/search/issues` (separate 30/min quota) with proper qualifiers (`is:open`/`is:closed`, `label:<name>`, `repo:<slug>`). `gh_issue_list` detects `--search` in argv and dispatches accordingly.

## Tests

New: `.agents/scripts/tests/test-large-file-gate-dedup.sh` — 11 assertions across helper / caller / wrapper layers covering all three rc states, retry-on-empty, defer-on-failure, and REST routing for `--search`.

```text
$ bash .agents/scripts/tests/test-large-file-gate-dedup.sh
=== Results: 11/11 passed ===
ALL PASSED

$ bash .agents/scripts/tests/test-large-file-gate-continuation-verify.sh
7 run, 0 failed
```

The continuation-verify test was previously 5/7 failing on `main` due to an undefined `gh_issue_list` stub (rc=127 was being swallowed by `|| _open=""` so the test "passed" by accident). The fix to that test (`gh_issue_list() { gh issue list "$@"; }` stub + `sleep` no-op) is in this PR — t2995 surfaced the latent stub bug by no longer swallowing rc=127.

## Verification

- `shellcheck` clean on all 5 modified files (only pre-existing SC2016 info findings)
- `gh issue list --repo marcusquinn/aidevops --label file-size-debt --search worktree-helper.sh` after deploy should return at most one open issue across many pulse cycles.

Resolves #21406

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.3 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-opus-4-7 spent 16m and 65,378 tokens on this with the user in an interactive session.
