### PR TITLE
t2999: dispatch-ledger-helper stale-lock recovery

### DIFF
--- a/.agents/scripts/dispatch-ledger-helper.sh
+++ b/.agents/scripts/dispatch-ledger-helper.sh
@@ -59,8 +59,108 @@ _ensure_ledger() {
 }
 
 #######################################
+# Get the age in seconds of a directory's mtime.
+# Args: $1 = directory path
+# Returns: age in seconds via stdout (0 if directory absent or stat fails)
+# Portable across BSD (macOS) and GNU (Linux) stat invocations.
+#######################################
+_lock_dir_age() {
+	local dir="$1"
+	local mtime=""
+	local now=""
+	if [[ ! -d "$dir" ]]; then
+		echo "0"
+		return 0
+	fi
+	# BSD stat (macOS) first, then GNU stat (Linux)
+	mtime=$(stat -f '%m' "$dir" 2>/dev/null || stat -c '%Y' "$dir" 2>/dev/null || echo "")
+	if [[ -z "$mtime" ]] || [[ ! "$mtime" =~ ^[0-9]+$ ]]; then
+		echo "0"
+		return 0
+	fi
+	now=$(date -u '+%s')
+	echo "$((now - mtime))"
+	return 0
+}
+
+#######################################
+# Detect a stale ledger lock and clear it if so.
+#
+# Three-tier detection mirroring pulse-instance-lock.sh::_handle_existing_lock
+# (GH#20025), but with ledger-appropriate semantics:
+#   1. No valid PID in the lockdir → corrupt or pre-PID-file lock from
+#      an older client. Use mtime as the staleness signal.
+#   2. Owner PID dead → stale from SIGKILL/OOM/crash. Clear immediately.
+#   3. Owner alive but lock age > AIDEVOPS_LEDGER_LOCK_MAX_AGE_S
+#      (default 60s) → hung holder. Clear so we can re-acquire. Unlike
+#      pulse-instance-lock we do NOT kill the owner — ledger ops should
+#      complete in <100ms; a 60s+ hold means the holder is stuck and
+#      the safe move is to steal the lock. Worst-case race outcome is a
+#      single corrupted JSONL line, which the helper already tolerates
+#      (registration failures are logged non-fatal upstream).
+#
+# Args:
+#   $1 = lock directory path
+#   $2 = pid file path (lock_dir/pid)
+#   $3 = max age in seconds (threshold for force-reclaim)
+# Returns: 0 if the lock was stale and was cleared, 1 if still live
+#######################################
+_ledger_lock_is_stale() {
+	local lock_dir="$1"
+	local pid_file="$2"
+	local max_age="$3"
+	local lock_pid=""
+	local lock_age=""
+
+	# Must still exist — race: another waiter may have just cleared it.
+	if [[ ! -d "$lock_dir" ]]; then
+		return 1
+	fi
+
+	if [[ -f "$pid_file" ]]; then
+		lock_pid=$(cat "$pid_file" 2>/dev/null || echo "")
+	fi
+
+	# Tier 1: no valid PID file (corrupt, or pre-PID lock from old client)
+	# Use mtime as the staleness signal.
+	if [[ -z "$lock_pid" ]] || [[ ! "$lock_pid" =~ ^[0-9]+$ ]]; then
+		lock_age=$(_lock_dir_age "$lock_dir")
+		if [[ "$lock_age" -gt "$max_age" ]]; then
+			rm -rf "$lock_dir" 2>/dev/null || true
+			return 0
+		fi
+		return 1
+	fi
+
+	# Tier 2: owner PID is dead → stale (SIGKILL, OOM, crash)
+	if ! ps -p "$lock_pid" >/dev/null 2>&1; then
+		rm -rf "$lock_dir" 2>/dev/null || true
+		return 0
+	fi
+
+	# Tier 3: owner alive but lock too old → hung holder, steal lock
+	lock_age=$(_lock_dir_age "$lock_dir")
+	if [[ "$lock_age" -gt "$max_age" ]]; then
+		rm -rf "$lock_dir" 2>/dev/null || true
+		return 0
+	fi
+
+	return 1
+}
+
+#######################################
 # Acquire file lock (fail-closed — aborts if lock cannot be obtained)
 # Uses flock when available, falls back to mkdir-based lock.
+#
+# Stale-lock recovery (t2999): when the mkdir fallback path is used,
+# each failed mkdir attempt checks whether the existing lock is stale
+# (dead PID, corrupt PID file with old mtime, or hung-holder age
+# ceiling) via _ledger_lock_is_stale. If stale, the lockdir is cleared
+# and mkdir is retried. Without this, a worker killed mid-registration
+# leaves a permanent lockdir that blocks all subsequent ledger writes.
+# Canonical incident: marcusquinn/aidevops#21427 — a 24-day-old stale
+# lockdir suppressed registration for the entire dispatch fleet.
+#
 # Returns: 0 on success, 1 on failure (caller must abort write)
 #######################################
 _acquire_lock() {
@@ -70,33 +170,49 @@ _acquire_lock() {
 			echo "Error: could not acquire ledger lock: $LEDGER_LOCK" >&2
 			return 1
 		fi
-	else
-		# Portable fallback: mkdir is atomic on all POSIX systems
-		local lock_dir="${LEDGER_LOCK}.d"
-		local attempts=0
-		local max_attempts=50 # 50 × 0.1s = 5s timeout
-		while ! mkdir "$lock_dir" 2>/dev/null; do
-			attempts=$((attempts + 1))
-			if [[ "$attempts" -ge "$max_attempts" ]]; then
-				echo "Error: could not acquire ledger lock (mkdir): $lock_dir" >&2
-				return 1
-			fi
-			sleep 0.1
-		done
+		return 0
 	fi
+
+	# Portable fallback: mkdir is atomic on all POSIX systems
+	local lock_dir="${LEDGER_LOCK}.d"
+	local pid_file="${lock_dir}/pid"
+	local max_age="${AIDEVOPS_LEDGER_LOCK_MAX_AGE_S:-60}"
+	local attempts=0
+	local max_attempts=50 # 50 × 0.1s = 5s timeout
+
+	while ! mkdir "$lock_dir" 2>/dev/null; do
+		# Stale-lock recovery (t2999): if the existing lock is stale,
+		# clear it and retry mkdir immediately without burning an attempt.
+		if _ledger_lock_is_stale "$lock_dir" "$pid_file" "$max_age"; then
+			continue
+		fi
+		attempts=$((attempts + 1))
+		if [[ "$attempts" -ge "$max_attempts" ]]; then
+			echo "Error: could not acquire ledger lock (mkdir): $lock_dir" >&2
+			return 1
+		fi
+		sleep 0.1
+	done
+
+	# Record holder PID inside the lockdir so future waiters can
+	# detect a stale lock if we die before _release_lock runs.
+	echo "$$" >"$pid_file" 2>/dev/null || true
 	return 0
 }
 
 #######################################
 # Release file lock
+# Note: mkdir-based lock now contains a PID file (t2999), so we use
+# `rm -rf` instead of `rmdir`. Backward-compatible — rm -rf also
+# removes empty lockdirs left by older clients.
 #######################################
 _release_lock() {
 	if command -v flock &>/dev/null; then
 		flock -u 8 2>/dev/null || true
 	else
-		# Remove mkdir-based lock
+		# Remove mkdir-based lock (and any PID file inside it)
 		local lock_dir="${LEDGER_LOCK}.d"
-		rmdir "$lock_dir" 2>/dev/null || true
+		rm -rf "$lock_dir" 2>/dev/null || true
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-dispatch-ledger-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-ledger-helper.sh
@@ -474,6 +474,231 @@ test_empty_ledger_operations() {
 }
 
 #######################################
+# t2999: stale-lock recovery — dead-PID stale lock
+#
+# Place a fake pid file with a PID known to be dead inside the lockdir.
+# The next register call should detect the stale lock, clear it, and
+# succeed.
+#######################################
+test_stale_lock_recovered_dead_pid() {
+	setup_test_env
+
+	# Skip when flock is available — flock path doesn't use mkdir lockdir.
+	if command -v flock &>/dev/null; then
+		print_result "stale-lock recovered (dead PID)" 0 "skipped: flock present, mkdir path not exercised"
+		teardown_test_env
+		return 0
+	fi
+
+	local ledger_dir="${AIDEVOPS_DISPATCH_LEDGER_DIR}"
+	local lock_dir="${ledger_dir}/dispatch-ledger.lock.d"
+	mkdir -p "$lock_dir"
+	# A PID very unlikely to be in use. ps returns non-zero on absent PID.
+	echo "999999" >"${lock_dir}/pid"
+
+	run_helper "$LEDGER_HELPER" register --session-key "stale-test-1" --issue 1 --repo "owner/repo" --pid $$
+	local register_exit="$LAST_EXIT"
+
+	local result=0
+	if [[ "$register_exit" -ne 0 ]]; then
+		result=1
+	fi
+	# Lock should be released after register completes.
+	if [[ -d "$lock_dir" ]]; then
+		result=1
+	fi
+	# Entry should have been written.
+	if [[ ! -s "${ledger_dir}/dispatch-ledger.jsonl" ]]; then
+		result=1
+	fi
+
+	print_result "stale-lock recovered (dead PID 999999)" "$result" \
+		"register_exit=${register_exit}, lock_dir_present=$([[ -d $lock_dir ]] && echo yes || echo no)"
+	teardown_test_env
+	return 0
+}
+
+#######################################
+# t2999: stale-lock recovery — no PID file, old mtime (legacy/corrupt)
+#
+# Simulates the actual production bug: a lockdir from an old client
+# (no PID file written), abandoned 24 days ago. mtime-based staleness
+# detection should reclaim it.
+#######################################
+test_stale_lock_recovered_no_pid_old_mtime() {
+	setup_test_env
+
+	if command -v flock &>/dev/null; then
+		print_result "stale-lock recovered (no PID, old mtime)" 0 "skipped: flock present, mkdir path not exercised"
+		teardown_test_env
+		return 0
+	fi
+
+	local ledger_dir="${AIDEVOPS_DISPATCH_LEDGER_DIR}"
+	local lock_dir="${ledger_dir}/dispatch-ledger.lock.d"
+	mkdir -p "$lock_dir"
+	# Backdate the directory mtime well beyond the 60s default ceiling.
+	# touch -t YYYYMMDDhhmm — set to 1 hour in the past.
+	local backdate
+	backdate=$(date -u -v-1H '+%Y%m%d%H%M' 2>/dev/null || date -u -d '1 hour ago' '+%Y%m%d%H%M' 2>/dev/null || echo "")
+	if [[ -n "$backdate" ]]; then
+		touch -t "$backdate" "$lock_dir" 2>/dev/null || true
+	fi
+
+	run_helper "$LEDGER_HELPER" register --session-key "stale-test-2" --issue 2 --repo "owner/repo" --pid $$
+	local register_exit="$LAST_EXIT"
+
+	local result=0
+	if [[ "$register_exit" -ne 0 ]]; then
+		result=1
+	fi
+	if [[ -d "$lock_dir" ]]; then
+		result=1
+	fi
+	if [[ ! -s "${ledger_dir}/dispatch-ledger.jsonl" ]]; then
+		result=1
+	fi
+
+	print_result "stale-lock recovered (no PID file, old mtime)" "$result" \
+		"register_exit=${register_exit}, lock_dir_present=$([[ -d $lock_dir ]] && echo yes || echo no)"
+	teardown_test_env
+	return 0
+}
+
+#######################################
+# t2999: live owner within max_age must NOT be reclaimed
+#
+# A lockdir owned by a live PID with fresh mtime must survive — stealing
+# it would corrupt concurrent registrations. Verify by setting a very
+# high max_age (1 hour) and confirming register fails to acquire within
+# the 5s mkdir timeout.
+#######################################
+test_stale_lock_blocks_on_live_owner_within_max_age() {
+	setup_test_env
+
+	if command -v flock &>/dev/null; then
+		print_result "live owner blocks within max_age" 0 "skipped: flock present, mkdir path not exercised"
+		teardown_test_env
+		return 0
+	fi
+
+	local ledger_dir="${AIDEVOPS_DISPATCH_LEDGER_DIR}"
+	local lock_dir="${ledger_dir}/dispatch-ledger.lock.d"
+	mkdir -p "$lock_dir"
+	# Use this test process's own PID — guaranteed alive.
+	echo "$$" >"${lock_dir}/pid"
+
+	# Set a generous max_age so age-based reclaim cannot fire.
+	export AIDEVOPS_LEDGER_LOCK_MAX_AGE_S=3600
+
+	run_helper "$LEDGER_HELPER" register --session-key "live-owner-test" --issue 3 --repo "owner/repo" --pid $$
+	local register_exit="$LAST_EXIT"
+
+	unset AIDEVOPS_LEDGER_LOCK_MAX_AGE_S
+
+	local result=0
+	# Expect register to fail (lock contention) — the live lock must hold.
+	if [[ "$register_exit" -eq 0 ]]; then
+		result=1
+	fi
+	# Live lock must still be present.
+	if [[ ! -d "$lock_dir" ]]; then
+		result=1
+	fi
+	# Our PID must still be in the lock file (not overwritten).
+	local recorded_pid
+	recorded_pid=$(cat "${lock_dir}/pid" 2>/dev/null || echo "")
+	if [[ "$recorded_pid" != "$$" ]]; then
+		result=1
+	fi
+
+	# Cleanup the live lock manually since release_lock didn't run.
+	rm -rf "$lock_dir" 2>/dev/null || true
+
+	print_result "live owner blocks within max_age" "$result" \
+		"register_exit=${register_exit}, recorded_pid=${recorded_pid}, expected=${$}"
+	teardown_test_env
+	return 0
+}
+
+#######################################
+# t2999: backward-compat — legacy lockdir without PID file
+#
+# Older clients did not write a PID file. A fresh legacy lockdir
+# (mtime <= max_age, no PID file) must NOT be reclaimed (would steal
+# from a live old-client). After max_age expires, mtime-based recovery
+# fires (covered by test_stale_lock_recovered_no_pid_old_mtime).
+#######################################
+test_stale_lock_recovered_legacy_no_pid_lockdir() {
+	setup_test_env
+
+	if command -v flock &>/dev/null; then
+		print_result "legacy no-PID lockdir respected within max_age" 0 "skipped: flock present, mkdir path not exercised"
+		teardown_test_env
+		return 0
+	fi
+
+	local ledger_dir="${AIDEVOPS_DISPATCH_LEDGER_DIR}"
+	local lock_dir="${ledger_dir}/dispatch-ledger.lock.d"
+	mkdir -p "$lock_dir"
+	# No PID file — fresh legacy lockdir.
+
+	# Default max_age=60s; a freshly-created lockdir is age 0.
+	run_helper "$LEDGER_HELPER" register --session-key "legacy-fresh" --issue 4 --repo "owner/repo" --pid $$
+	local register_exit="$LAST_EXIT"
+
+	local result=0
+	# Expect register to fail (lock contention) — the fresh legacy lock holds.
+	if [[ "$register_exit" -eq 0 ]]; then
+		result=1
+	fi
+
+	# Cleanup
+	rm -rf "$lock_dir" 2>/dev/null || true
+
+	print_result "legacy no-PID lockdir respected within max_age" "$result" \
+		"register_exit=${register_exit} (expected non-zero)"
+	teardown_test_env
+	return 0
+}
+
+#######################################
+# t2999: _release_lock must clear lockdir even when it contains a PID file
+#
+# After register, the lockdir should be gone. Catches regression where
+# a switch back to rmdir would fail silently on a non-empty dir.
+#######################################
+test_release_clears_lockdir_with_pid_file() {
+	setup_test_env
+
+	if command -v flock &>/dev/null; then
+		print_result "release clears lockdir with PID file" 0 "skipped: flock present, mkdir path not exercised"
+		teardown_test_env
+		return 0
+	fi
+
+	local ledger_dir="${AIDEVOPS_DISPATCH_LEDGER_DIR}"
+	local lock_dir="${ledger_dir}/dispatch-ledger.lock.d"
+
+	run_helper "$LEDGER_HELPER" register --session-key "release-test" --issue 5 --repo "owner/repo" --pid $$
+	local register_exit="$LAST_EXIT"
+
+	local result=0
+	if [[ "$register_exit" -ne 0 ]]; then
+		result=1
+	fi
+	# Lockdir must be gone after register completes.
+	if [[ -d "$lock_dir" ]]; then
+		result=1
+	fi
+
+	print_result "release clears lockdir with PID file" "$result" \
+		"register_exit=${register_exit}, lock_dir_present=$([[ -d $lock_dir ]] && echo yes || echo no)"
+	teardown_test_env
+	return 0
+}
+
+#######################################
 # Run all tests
 #######################################
 main() {
@@ -508,6 +733,12 @@ main() {
 	test_prune_old_entries
 	test_status_runs
 	test_empty_ledger_operations
+	# t2999: stale-lock recovery
+	test_stale_lock_recovered_dead_pid
+	test_stale_lock_recovered_no_pid_old_mtime
+	test_stale_lock_blocks_on_live_owner_within_max_age
+	test_stale_lock_recovered_legacy_no_pid_lockdir
+	test_release_clears_lockdir_with_pid_file
 
 	echo ""
 	echo "=== Results: ${TESTS_RUN} tests, ${TESTS_FAILED} failed ==="


### PR DESCRIPTION
## Summary

The mkdir-fallback path in `dispatch-ledger-helper.sh::_acquire_lock` had no
stale-lock detection. A worker killed mid-registration (SIGKILL, OOM, crash)
left a permanent lockdir that blocked **all subsequent** ledger writes. Fail-
closed semantics then suppressed every `register`, `complete`, `fail`, and
`expire` call from every dispatch path framework-wide.

This was discovered during the 2026-04-27 GitHub search degradation incident
when manual workers backfilled into the ledger surfaced a stale lockdir at
`~/.aidevops/.agent-workspace/tmp/dispatch-ledger.lock.d` from **April 3
17:12 UTC** — over 24 days (1.7M seconds) old. During that window the pulse
was blind to in-flight workers; 396 of 633 historical ledger entries (62%)
were `failed` because of this — registration calls aborted before writing,
not because dispatches genuinely failed.

## Root Cause

`_acquire_lock` mkdir branch was a pure busy-wait:

```bash
while ! mkdir "$lock_dir" 2>/dev/null; do
    attempts=$((attempts + 1))
    if [[ "$attempts" -ge "$max_attempts" ]]; then
        echo "Error: could not acquire ledger lock (mkdir): $lock_dir" >&2
        return 1
    fi
    sleep 0.1
done
```

No PID tracking. No staleness detection. No mtime check. Once the lockdir
existed, it stayed forever unless something external cleaned it up. Nothing
was responsible for that.

By contrast, `pulse-instance-lock.sh::_handle_existing_lock` (GH#20025) has
the canonical pattern: PID-file + liveness check + age-based force-reclaim.
The ledger helper just hadn't received the same treatment.

## Fix

Three-tier stale detection mirroring `pulse-instance-lock.sh::_handle_existing_lock`:

| Tier | Condition | Action |
|------|-----------|--------|
| 1 | No valid PID file | mtime > `max_age` → reclaim (legacy/corrupt) |
| 2 | Owner PID dead | reclaim immediately (SIGKILL/OOM/crash) |
| 3 | Owner alive but lock age > `max_age` | reclaim without killing owner |

**Difference from pulse-instance-lock**: ledger ops are sub-second, so a 60s
hold means the holder is stuck. Stealing is safe — worst-case race outcome
is a single corrupted JSONL line, which the helper already tolerates because
registration failures are logged as non-fatal upstream.

Lock holders now write `$$` to `$lockdir/pid` after a successful `mkdir`
so future waiters can detect a stale lock if the holder dies before
`_release_lock` runs. `_release_lock` switches from `rmdir` to `rm -rf`
to handle the new PID file (backward-compatible — also clears empty
legacy lockdirs from older clients).

**Threshold**: `AIDEVOPS_LEDGER_LOCK_MAX_AGE_S` env var (default 60s).
Compare to `PULSE_LOCK_MAX_AGE_S=1800s` for the pulse instance lock —
ledger ops are 30× shorter so the threshold is 30× tighter.

## Files Changed

- `EDIT: .agents/scripts/dispatch-ledger-helper.sh:62-100` — replaced
  `_acquire_lock` and `_release_lock`; added private helpers
  `_lock_dir_age` and `_ledger_lock_is_stale`.
- `EDIT: .agents/scripts/tests/test-dispatch-ledger-helper.sh` — added
  5 regression tests.

## Tests

Five new regression tests cover all paths:

1. **`test_stale_lock_recovered_dead_pid`** — Tier 2: dead-PID stale lock
   (PID 999999 fake) reclaimed.
2. **`test_stale_lock_recovered_no_pid_old_mtime`** — Tier 1: the actual
   production bug. lockdir backdated 1 hour, no PID file, mtime-based
   reclaim fires.
3. **`test_stale_lock_blocks_on_live_owner_within_max_age`** — correctness:
   own PID + `max_age=3600`, register must FAIL (cannot steal a live lock).
4. **`test_stale_lock_recovered_legacy_no_pid_lockdir`** — backward-compat:
   fresh legacy lockdir (no PID file, age 0) must NOT be stolen within
   `max_age`.
5. **`test_release_clears_lockdir_with_pid_file`** — regression: catches
   any future revert from `rm -rf` to `rmdir` (which fails silently on
   non-empty dir).

```text
=== Results: 21 tests, 0 failed ===
```

ShellCheck clean. All tests skip cleanly when `flock` is available
(non-mkdir path is unchanged).

## Backward Compatibility

| Scenario | Behaviour |
|----------|-----------|
| Old client (no PID file) writes lock; new client waits | Tier 1 fires after `max_age` (60s default) — clean recovery |
| New client writes lock; old client waits | Old client busy-waits 5s, fails with original error — same as before |
| Two new clients | PID file resolves precedence; second client either steals (Tier 2/3) or waits (Tier 1 within `max_age`) |
| Empty legacy lockdir (no contents) | `rm -rf` clears it — same effect as old `rmdir` |

The fix does not change the lockdir path or naming, so concurrent old/new
clients coexist without coordination.

## Verification

```bash
shellcheck .agents/scripts/dispatch-ledger-helper.sh
shellcheck .agents/scripts/tests/test-dispatch-ledger-helper.sh
bash .agents/scripts/tests/test-dispatch-ledger-helper.sh
```

All commands exit 0. Test output: 21 PASS, 0 FAIL.

## Reference

- Canonical pattern: `.agents/scripts/pulse-instance-lock.sh:70-115`
  (`_handle_existing_lock`, GH#20025).
- Incident discovered while filing #21406, #21407, #21408 during the
  2026-04-27 GitHub search degradation incident — manual workers
  registered into the ledger via the helper and surfaced the stale lock
  via the "Dispatch ledger registration failed (non-fatal)" warning.

Resolves #21427

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.3 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-opus-4-7 spent 20h 26m and 92,783 tokens on this with the user in an interactive session.
