### PR TITLE
t3003: adaptive per-candidate dispatch timeout

### DIFF
--- a/.agents/scripts/dispatch-timing-helper.sh
+++ b/.agents/scripts/dispatch-timing-helper.sh
@@ -1,0 +1,581 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+# dispatch-timing-helper.sh — t3003: adaptive per-candidate dispatch timeout.
+#
+# Replaces the fixed FILL_FLOOR_PER_CANDIDATE_TIMEOUT (default 30s) with a
+# rolling-window measurement of recent dispatch attempts. Recommends a timeout
+# based on EWMA + p95 of recent successes, with PROBE mode after a timeout to
+# re-measure under degraded conditions.
+#
+# WHY (incident 2026-04-27):
+#   Direct measurements showed `gh issue edit` taking 3-5s/call. The launch
+#   path (assign_and_label, lock, post_launch_hooks) makes 4-6 such calls,
+#   exceeding the 30s budget. Result: every dispatch timed out, zero workers
+#   spawned, 30+ minutes of pulse cycles with no progress. Fixed timeouts
+#   cannot adapt to gh API latency drift.
+#
+# DESIGN:
+#   - Append-only JSONL state file: ~/.aidevops/.agent-workspace/tmp/dispatch-timing-stats.jsonl
+#   - Mutex via mkdir lock (no flock dependency — bash 3.2 / macOS compat)
+#   - All times in MILLISECONDS (integer math throughout — no float deps)
+#   - Bash 3.2 compatible (no associative arrays)
+#
+# ALGORITHM (recommend):
+#   1. Read last N records (default 20).
+#   2. Filter to outcome=success, get elapsed_ms array.
+#   3. <3 successes → bootstrap default (90000ms).
+#   4. Compute EWMA(alpha=0.3) over successes.
+#   5. recommended = max(EWMA * 2.0, p95(elapsed_ms))
+#   6. If LAST record was a timeout AND it was the immediate previous attempt
+#      → PROBE mode: recommended = max(recommended, last_timeout_used * 2).
+#   7. Clamp [MIN_TIMEOUT_MS, MAX_TIMEOUT_MS].
+#
+# USAGE:
+#   dispatch-timing-helper.sh recommend [--repo SLUG]
+#       → prints recommended timeout in ms (integer)
+#   dispatch-timing-helper.sh record \
+#       --repo SLUG --issue N --outcome (success|timeout|skip) \
+#       --elapsed-ms N --timeout-used-ms N [--probe true|false]
+#   dispatch-timing-helper.sh stats [--json]
+#   dispatch-timing-helper.sh reset
+#   dispatch-timing-helper.sh help
+
+set -uo pipefail
+
+# Source shared constants for color codes + bash 4 self-heal guard
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+[[ -f "$SCRIPT_DIR/shared-constants.sh" ]] && source "$SCRIPT_DIR/shared-constants.sh"
+
+# ---------------------------------------------------------------------------
+# Tunables — env-overridable, all in milliseconds
+# ---------------------------------------------------------------------------
+
+# Hard floor: never recommend below this (gives the simplest possible dispatch
+# enough breathing room).
+: "${DISPATCH_TIMING_MIN_TIMEOUT_MS:=30000}"
+
+# Hard ceiling: never recommend above this (prevents one runaway latency from
+# locking the entire pulse cycle).
+: "${DISPATCH_TIMING_MAX_TIMEOUT_MS:=300000}"
+
+# Bootstrap default when we have <3 success measurements.
+: "${DISPATCH_TIMING_BOOTSTRAP_MS:=90000}"
+
+# Window size — last N records considered for recommendations.
+: "${DISPATCH_TIMING_WINDOW:=20}"
+
+# EWMA alpha (fixed-point, scaled by 100 — alpha=0.3 means 30).
+# Higher = more responsive to recent measurements.
+: "${DISPATCH_TIMING_EWMA_ALPHA_PCT:=30}"
+
+# Safety multiplier on recent average (fixed-point ×100). Default 200 = 2.0x.
+: "${DISPATCH_TIMING_SAFETY_MULT_PCT:=200}"
+
+# Probe-mode multiplier (fixed-point ×100). Default 200 = 2.0x last_timeout.
+: "${DISPATCH_TIMING_PROBE_MULT_PCT:=200}"
+
+# Maximum log size — trim to this many lines when exceeded.
+: "${DISPATCH_TIMING_MAX_LINES:=1000}"
+
+# State file location.
+WORKSPACE_DIR="${AIDEVOPS_WORKSPACE_DIR:-${HOME}/.aidevops/.agent-workspace}"
+STATE_DIR="${WORKSPACE_DIR}/tmp"
+STATE_FILE="${DISPATCH_TIMING_STATE_FILE:-${STATE_DIR}/dispatch-timing-stats.jsonl}"
+LOCK_DIR="${STATE_FILE}.lock.d"
+
+# Lock acquisition timeout (mkdir-based busy-wait).
+: "${DISPATCH_TIMING_LOCK_TIMEOUT_S:=5}"
+
+# JSONL field-name constants — extracted to satisfy repeated-literal ratchet
+# and to centralise the schema in one place.
+readonly _DT_FIELD_OUTCOME="outcome"
+readonly _DT_FIELD_ELAPSED_MS="elapsed_ms"
+readonly _DT_FIELD_TIMEOUT_USED_MS="timeout_used_ms"
+
+# ---------------------------------------------------------------------------
+# Lock helpers — mkdir-based mutex (atomic on POSIX filesystems)
+# ---------------------------------------------------------------------------
+
+_dt_acquire_lock() {
+	local timeout_s="${DISPATCH_TIMING_LOCK_TIMEOUT_S}"
+	local elapsed=0
+	mkdir -p "$STATE_DIR" 2>/dev/null
+	while ! mkdir "$LOCK_DIR" 2>/dev/null; do
+		# Check for stale lock (>30s old → assume crashed)
+		if [[ -d "$LOCK_DIR" ]]; then
+			local lock_mtime now_epoch age_s
+			lock_mtime=$(stat -f %m "$LOCK_DIR" 2>/dev/null || stat -c %Y "$LOCK_DIR" 2>/dev/null || echo "0")
+			now_epoch=$(date +%s)
+			age_s=$((now_epoch - lock_mtime))
+			if ((age_s > 30)); then
+				rmdir "$LOCK_DIR" 2>/dev/null || true
+				continue
+			fi
+		fi
+		sleep 0.1
+		elapsed=$((elapsed + 1))
+		if ((elapsed > timeout_s * 10)); then
+			# Lock acquisition timeout — record helper must remain non-fatal,
+			# so callers proceed without recording rather than blocking dispatch.
+			return 1
+		fi
+	done
+	# Stamp lock with PID for diagnostics
+	echo "$$" >"${LOCK_DIR}/pid" 2>/dev/null || true
+	return 0
+}
+
+_dt_release_lock() {
+	rm -f "${LOCK_DIR}/pid" 2>/dev/null || true
+	rmdir "$LOCK_DIR" 2>/dev/null || true
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Read helpers — return last N JSONL records
+# ---------------------------------------------------------------------------
+
+_dt_read_window() {
+	local n="${1:-$DISPATCH_TIMING_WINDOW}"
+	[[ -f "$STATE_FILE" ]] || return 0
+	tail -n "$n" "$STATE_FILE" 2>/dev/null
+	return 0
+}
+
+# Compute integer p95 of a newline-separated list of integers.
+# Args: $1 = newline-separated values (via stdin would also work).
+# Output: p95 value.
+_dt_p95() {
+	local values="$1"
+	local count
+	count=$(printf '%s\n' "$values" | grep -c .)
+	if ((count == 0)); then
+		echo "0"
+		return 0
+	fi
+	local sorted idx p95
+	sorted=$(printf '%s\n' "$values" | sort -n)
+	# 95th percentile: index = ceil(count * 0.95) - 1, 0-based
+	idx=$(((count * 95 + 99) / 100 - 1))
+	((idx < 0)) && idx=0
+	((idx >= count)) && idx=$((count - 1))
+	p95=$(printf '%s\n' "$sorted" | awk -v i="$idx" 'NR==i+1 {print; exit}')
+	echo "${p95:-0}"
+	return 0
+}
+
+# Compute EWMA over a newline-separated list of integers (oldest first).
+# alpha = DISPATCH_TIMING_EWMA_ALPHA_PCT / 100.
+# Output: integer EWMA value.
+_dt_ewma() {
+	local values="$1"
+	local alpha="${DISPATCH_TIMING_EWMA_ALPHA_PCT}"
+	local count
+	count=$(printf '%s\n' "$values" | grep -c .)
+	if ((count == 0)); then
+		echo "0"
+		return 0
+	fi
+	# EWMA = alpha * value + (1 - alpha) * prev_ewma
+	# Fixed-point: alpha is /100, so ewma = (alpha * v + (100 - alpha) * prev) / 100
+	local ewma=0 first=1 v
+	while IFS= read -r v; do
+		[[ -z "$v" ]] && continue
+		[[ "$v" =~ ^[0-9]+$ ]] || continue
+		if ((first)); then
+			ewma="$v"
+			first=0
+		else
+			ewma=$(((alpha * v + (100 - alpha) * ewma) / 100))
+		fi
+	done <<<"$values"
+	echo "$ewma"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Subcommand: recommend
+# ---------------------------------------------------------------------------
+
+_dt_cmd_recommend() {
+	# Note: --repo is accepted for forward compatibility (per-repo timing in
+	# the future), but currently the recommendation is global. Parsed and
+	# discarded.
+	while (("$#")); do
+		local arg="$1"
+		case "$arg" in
+		--repo)
+			shift
+			;;
+		--repo=*)
+			:
+			;;
+		esac
+		shift
+	done
+
+	# Read window
+	local window
+	window=$(_dt_read_window "$DISPATCH_TIMING_WINDOW")
+
+	if [[ -z "$window" ]]; then
+		# No history → bootstrap default
+		echo "$DISPATCH_TIMING_BOOTSTRAP_MS"
+		return 0
+	fi
+
+	# Extract success elapsed_ms values (oldest first for EWMA)
+	local successes
+	successes=$(printf '%s\n' "$window" | _dt_extract_field "success" "$_DT_FIELD_ELAPSED_MS")
+	local success_count
+	success_count=$(printf '%s\n' "$successes" | grep -c .)
+
+	local recommended
+
+	if ((success_count < 3)); then
+		# Insufficient data → bootstrap
+		recommended="$DISPATCH_TIMING_BOOTSTRAP_MS"
+	else
+		# EWMA + p95 + safety multiplier
+		local ewma p95 ewma_safe
+		ewma=$(_dt_ewma "$successes")
+		p95=$(_dt_p95 "$successes")
+		ewma_safe=$(((ewma * DISPATCH_TIMING_SAFETY_MULT_PCT) / 100))
+		# recommended = max(ewma_safe, p95)
+		if ((ewma_safe > p95)); then
+			recommended="$ewma_safe"
+		else
+			recommended="$p95"
+		fi
+	fi
+
+	# Probe mode: if LAST record is a timeout, recommend at least 2× last_timeout_used
+	local last_outcome last_timeout_used
+	last_outcome=$(printf '%s\n' "$window" | tail -n 1 | _dt_json_field "$_DT_FIELD_OUTCOME")
+	if [[ "$last_outcome" == "timeout" ]]; then
+		last_timeout_used=$(printf '%s\n' "$window" | tail -n 1 | _dt_json_field "$_DT_FIELD_TIMEOUT_USED_MS")
+		if [[ "$last_timeout_used" =~ ^[0-9]+$ ]]; then
+			local probe_recommended=$(((last_timeout_used * DISPATCH_TIMING_PROBE_MULT_PCT) / 100))
+			if ((probe_recommended > recommended)); then
+				recommended="$probe_recommended"
+			fi
+		fi
+	fi
+
+	# Clamp to [MIN, MAX]
+	if ((recommended < DISPATCH_TIMING_MIN_TIMEOUT_MS)); then
+		recommended="$DISPATCH_TIMING_MIN_TIMEOUT_MS"
+	fi
+	if ((recommended > DISPATCH_TIMING_MAX_TIMEOUT_MS)); then
+		recommended="$DISPATCH_TIMING_MAX_TIMEOUT_MS"
+	fi
+
+	# Round to nearest 1000 (whole seconds)
+	recommended=$(((recommended + 500) / 1000 * 1000))
+
+	echo "$recommended"
+	return 0
+}
+
+# Extract value of $field from a single JSONL record on stdin.
+# Uses a simple regex-based extractor — avoids jq for hot-path speed.
+# Args: $1 = field name (string-valued or numeric).
+_dt_json_field() {
+	local field="$1"
+	local line
+	IFS= read -r line
+	# Match "field":"value" (string) OR "field":NUMBER (numeric)
+	# Try string first
+	local val
+	val=$(printf '%s' "$line" | sed -nE "s/.*\"${field}\":\"([^\"]*)\".*/\1/p")
+	if [[ -n "$val" ]]; then
+		echo "$val"
+		return 0
+	fi
+	# Try numeric
+	val=$(printf '%s' "$line" | sed -nE "s/.*\"${field}\":([0-9]+).*/\1/p")
+	echo "$val"
+	return 0
+}
+
+# Filter records on stdin where outcome matches $target_outcome, then extract
+# the value of $field. Output: one value per line (oldest first, matching
+# input order). Delegates to _dt_json_field to avoid duplicating sed patterns.
+_dt_extract_field() {
+	local target_outcome="$1"
+	local field="$2"
+	local line line_outcome val
+	while IFS= read -r line; do
+		[[ -z "$line" ]] && continue
+		line_outcome=$(printf '%s\n' "$line" | _dt_json_field "$_DT_FIELD_OUTCOME")
+		[[ "$line_outcome" == "$target_outcome" ]] || continue
+		val=$(printf '%s\n' "$line" | _dt_json_field "$field")
+		[[ -n "$val" ]] && echo "$val"
+	done
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Subcommand: record
+# ---------------------------------------------------------------------------
+
+_dt_cmd_record() {
+	local repo="" issue="" outcome="" elapsed_ms="" timeout_used_ms="" probe="false"
+	while (("$#")); do
+		local arg="$1"
+		case "$arg" in
+		--repo)
+			repo="${2:-}"
+			shift 2
+			;;
+		--issue)
+			issue="${2:-}"
+			shift 2
+			;;
+		--outcome)
+			outcome="${2:-}"
+			shift 2
+			;;
+		--elapsed-ms)
+			elapsed_ms="${2:-}"
+			shift 2
+			;;
+		--timeout-used-ms)
+			timeout_used_ms="${2:-}"
+			shift 2
+			;;
+		--probe)
+			probe="${2:-false}"
+			shift 2
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+
+	# Validate required fields
+	if [[ -z "$repo" || -z "$issue" || -z "$outcome" || -z "$elapsed_ms" || -z "$timeout_used_ms" ]]; then
+		echo "Error: record requires --repo, --issue, --outcome, --elapsed-ms, --timeout-used-ms" >&2
+		return 1
+	fi
+	[[ "$elapsed_ms" =~ ^[0-9]+$ ]] || {
+		echo "Error: --elapsed-ms must be integer" >&2
+		return 1
+	}
+	[[ "$timeout_used_ms" =~ ^[0-9]+$ ]] || {
+		echo "Error: --timeout-used-ms must be integer" >&2
+		return 1
+	}
+	case "$outcome" in
+	success | timeout | skip) ;;
+	*)
+		echo "Error: --outcome must be success|timeout|skip" >&2
+		return 1
+		;;
+	esac
+
+	local ts
+	ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+	# Acquire lock — fail-open if we can't, so dispatch is never blocked
+	# by recording machinery.
+	_dt_acquire_lock || {
+		echo "[dispatch-timing] WARN: lock timeout — skipping record (non-fatal)" >&2
+		return 0
+	}
+
+	# Append record (atomic on POSIX <= PIPE_BUF=4096)
+	mkdir -p "$STATE_DIR"
+	printf '{"ts":"%s","repo":"%s","issue":%s,"outcome":"%s","elapsed_ms":%s,"timeout_used_ms":%s,"probe":%s}\n' \
+		"$ts" "$repo" "$issue" "$outcome" "$elapsed_ms" "$timeout_used_ms" "$probe" \
+		>>"$STATE_FILE"
+
+	# Trim if oversized
+	_dt_trim_if_needed
+
+	_dt_release_lock
+	return 0
+}
+
+_dt_trim_if_needed() {
+	[[ -f "$STATE_FILE" ]] || return 0
+	local line_count
+	line_count=$(wc -l <"$STATE_FILE" 2>/dev/null || echo "0")
+	[[ "$line_count" =~ ^[0-9]+$ ]] || line_count=0
+	if ((line_count > DISPATCH_TIMING_MAX_LINES)); then
+		# Rotate: keep last MAX_LINES, archive rest
+		local archive="${STATE_FILE}.1"
+		local keep="$DISPATCH_TIMING_MAX_LINES"
+		# Copy older lines to archive (append-only)
+		head -n $((line_count - keep)) "$STATE_FILE" >>"$archive" 2>/dev/null || true
+		# Keep last `keep` lines in place
+		local tmp="${STATE_FILE}.tmp.$$"
+		tail -n "$keep" "$STATE_FILE" >"$tmp" && mv "$tmp" "$STATE_FILE"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Subcommand: stats
+# ---------------------------------------------------------------------------
+
+_dt_cmd_stats() {
+	local json_mode=0
+	while (("$#")); do
+		local arg="$1"
+		case "$arg" in
+		--json) json_mode=1 ;;
+		esac
+		shift
+	done
+
+	local window total_records successes timeouts skips
+	window=$(_dt_read_window "$DISPATCH_TIMING_WINDOW")
+	total_records=0
+	successes=0
+	timeouts=0
+	skips=0
+	if [[ -n "$window" ]]; then
+		total_records=$(printf '%s\n' "$window" | grep -c .)
+		# Build the outcome-key prefix once so the field name only appears in
+		# one place per scan (satisfies the repeated-literal ratchet).
+		local outcome_key_prefix='"'"$_DT_FIELD_OUTCOME"'":"'
+		successes=$(printf '%s\n' "$window" | grep -c "${outcome_key_prefix}success\"" 2>/dev/null || true)
+		timeouts=$(printf '%s\n' "$window" | grep -c "${outcome_key_prefix}timeout\"" 2>/dev/null || true)
+		skips=$(printf '%s\n' "$window" | grep -c "${outcome_key_prefix}skip\"" 2>/dev/null || true)
+		[[ "$successes" =~ ^[0-9]+$ ]] || successes=0
+		[[ "$timeouts" =~ ^[0-9]+$ ]] || timeouts=0
+		[[ "$skips" =~ ^[0-9]+$ ]] || skips=0
+	fi
+
+	local success_values ewma p50 p95 recommended
+	success_values=""
+	ewma=0
+	p50=0
+	p95=0
+	if ((successes > 0)); then
+		success_values=$(printf '%s\n' "$window" | _dt_extract_field "success" "$_DT_FIELD_ELAPSED_MS")
+		ewma=$(_dt_ewma "$success_values")
+		# p50 = median = same algorithm as p95 with idx 50
+		local sorted count idx
+		count=$(printf '%s\n' "$success_values" | grep -c .)
+		sorted=$(printf '%s\n' "$success_values" | sort -n)
+		idx=$(((count * 50 + 99) / 100 - 1))
+		((idx < 0)) && idx=0
+		p50=$(printf '%s\n' "$sorted" | awk -v i="$idx" 'NR==i+1 {print; exit}')
+		[[ -z "$p50" ]] && p50=0
+		p95=$(_dt_p95 "$success_values")
+	fi
+	recommended=$(_dt_cmd_recommend)
+
+	if ((json_mode)); then
+		printf '{"window":%s,"total_records":%s,"successes":%s,"timeouts":%s,"skips":%s,"ewma_ms":%s,"p50_ms":%s,"p95_ms":%s,"recommended_ms":%s}\n' \
+			"$DISPATCH_TIMING_WINDOW" "$total_records" "$successes" "$timeouts" "$skips" \
+			"$ewma" "$p50" "$p95" "$recommended"
+	else
+		printf 'Dispatch timing stats (window=%s)\n' "$DISPATCH_TIMING_WINDOW"
+		printf '  total records: %s\n' "$total_records"
+		printf '  successes:     %s\n' "$successes"
+		printf '  timeouts:      %s\n' "$timeouts"
+		printf '  skips:         %s\n' "$skips"
+		printf '  ewma_ms:       %s\n' "$ewma"
+		printf '  p50_ms:        %s\n' "$p50"
+		printf '  p95_ms:        %s\n' "$p95"
+		printf '  recommended:   %sms (next dispatch budget)\n' "$recommended"
+		printf '  state_file:    %s\n' "$STATE_FILE"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Subcommand: reset
+# ---------------------------------------------------------------------------
+
+_dt_cmd_reset() {
+	_dt_acquire_lock || {
+		echo "Error: lock timeout" >&2
+		return 1
+	}
+	rm -f "$STATE_FILE" "${STATE_FILE}.1" 2>/dev/null
+	_dt_release_lock
+	echo "Reset: state file removed"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Subcommand: help
+# ---------------------------------------------------------------------------
+
+_dt_show_help() {
+	cat <<'EOF'
+dispatch-timing-helper.sh — t3003: adaptive per-candidate dispatch timeout.
+
+USAGE:
+  dispatch-timing-helper.sh recommend [--repo SLUG]
+      Print recommended timeout (integer ms). Used by pulse-dispatch-engine
+      to set per-candidate budget based on rolling-window measurement.
+
+  dispatch-timing-helper.sh record \
+      --repo SLUG --issue N --outcome (success|timeout|skip) \
+      --elapsed-ms N --timeout-used-ms N [--probe true|false]
+      Append a measurement record. Called by pulse-dispatch-engine after
+      each dispatch attempt.
+
+  dispatch-timing-helper.sh stats [--json]
+      Print rolling-window statistics (EWMA, p50, p95, recommended).
+
+  dispatch-timing-helper.sh reset
+      Truncate state file. Used in tests and after major incidents.
+
+  dispatch-timing-helper.sh help
+      Show this help.
+
+ENVIRONMENT:
+  DISPATCH_TIMING_MIN_TIMEOUT_MS        Floor (default 30000)
+  DISPATCH_TIMING_MAX_TIMEOUT_MS        Ceiling (default 300000)
+  DISPATCH_TIMING_BOOTSTRAP_MS          Default when <3 successes (90000)
+  DISPATCH_TIMING_WINDOW                Rolling window size (default 20)
+  DISPATCH_TIMING_EWMA_ALPHA_PCT        EWMA alpha ×100 (default 30 = 0.3)
+  DISPATCH_TIMING_SAFETY_MULT_PCT       Safety multiplier ×100 (default 200 = 2.0x)
+  DISPATCH_TIMING_PROBE_MULT_PCT        Probe-mode multiplier ×100 (default 200)
+  DISPATCH_TIMING_MAX_LINES             Trim threshold (default 1000)
+  DISPATCH_TIMING_STATE_FILE            Override state file path
+  DISPATCH_TIMING_LOCK_TIMEOUT_S        Lock acquisition timeout (default 5)
+
+EXIT CODES:
+  0  success
+  1  invalid args / unrecoverable error
+EOF
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# CLI entry
+# ---------------------------------------------------------------------------
+
+main() {
+	local cmd="${1:-help}"
+	shift || true
+	case "$cmd" in
+	recommend) _dt_cmd_recommend "$@" ;;
+	record) _dt_cmd_record "$@" ;;
+	stats) _dt_cmd_stats "$@" ;;
+	reset) _dt_cmd_reset "$@" ;;
+	help | --help | -h) _dt_show_help ;;
+	*)
+		echo "Error: unknown command '$cmd'" >&2
+		_dt_show_help >&2
+		return 1
+		;;
+	esac
+	return $?
+}
+
+# Don't execute main if sourced (for tests)
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+	main "$@"
+fi

--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -490,19 +490,74 @@ _dff_dispatch_with_timeout() {
 	local issue_number="$1"
 	local repo_slug="$2"
 
-	local dispatch_rc=0
-	run_stage_with_timeout "fill_floor_candidate_${issue_number}" "$FILL_FLOOR_PER_CANDIDATE_TIMEOUT" \
+	# t3003: adaptive per-candidate timeout. When DISPATCH_TIMING_ADAPTIVE=1
+	# (default), dispatch-timing-helper.sh recommends a budget based on the
+	# EWMA + p95 of recent successful dispatches; on timeouts it switches to
+	# probe mode (2x last_timeout). Old fixed FILL_FLOOR_PER_CANDIDATE_TIMEOUT
+	# is preserved as the legacy fallback when the helper is unavailable or
+	# DISPATCH_TIMING_ADAPTIVE=0.
+	local timeout_seconds="$FILL_FLOOR_PER_CANDIDATE_TIMEOUT"
+	local timeout_ms=$((timeout_seconds * 1000))
+	if [[ "${DISPATCH_TIMING_ADAPTIVE:-1}" == "1" ]] && command -v dispatch-timing-helper.sh >/dev/null 2>&1; then
+		local recommended_ms
+		recommended_ms=$(dispatch-timing-helper.sh recommend --repo "$repo_slug" 2>/dev/null || echo "")
+		if [[ "$recommended_ms" =~ ^[0-9]+$ ]] && ((recommended_ms > 0)); then
+			timeout_ms="$recommended_ms"
+			timeout_seconds=$((recommended_ms / 1000))
+			((timeout_seconds < 1)) && timeout_seconds=1
+		fi
+	fi
+
+	local start_ms dispatch_rc=0 outcome elapsed_ms
+	start_ms=$(_dff_now_ms)
+	run_stage_with_timeout "fill_floor_candidate_${issue_number}" "$timeout_seconds" \
 		dispatch_with_dedup "$@" || dispatch_rc=$?
-	echo "[pulse-wrapper] Deterministic fill floor: dispatch_with_dedup returned rc=${dispatch_rc} for #${issue_number}" >>"$LOGFILE"
+	elapsed_ms=$(($(_dff_now_ms) - start_ms))
+	echo "[pulse-wrapper] Deterministic fill floor: dispatch_with_dedup returned rc=${dispatch_rc} for #${issue_number} elapsed_ms=${elapsed_ms} timeout_used_ms=${timeout_ms}" >>"$LOGFILE"
+
 	if [[ "$dispatch_rc" -eq 124 ]]; then
-		# t2989: per-candidate timeout — log distinctly + bump observability
-		# counter so cadence regressions are visible in pulse-stats.json.
-		echo "[pulse-wrapper] Deterministic fill floor: per-candidate timeout (${FILL_FLOOR_PER_CANDIDATE_TIMEOUT}s) on #${issue_number} (${repo_slug}) — killing candidate, continuing loop" >>"$LOGFILE"
+		outcome="timeout"
+		# t2989 + t3003: per-candidate timeout — log distinctly, bump counter,
+		# record outcome so the next recommendation enters probe mode.
+		echo "[pulse-wrapper] Deterministic fill floor: per-candidate timeout (${timeout_seconds}s) on #${issue_number} (${repo_slug}) — killing candidate, continuing loop" >>"$LOGFILE"
 		if declare -F pulse_stats_increment >/dev/null 2>&1; then
 			pulse_stats_increment "fill_floor_per_candidate_timeout" 2>/dev/null || true
 		fi
+	elif [[ "$dispatch_rc" -eq 0 ]]; then
+		outcome="success"
+	else
+		outcome="skip"
 	fi
+
+	# t3003: record outcome for adaptive timing. Non-fatal — never block the
+	# dispatch loop on a recording failure.
+	if command -v dispatch-timing-helper.sh >/dev/null 2>&1; then
+		dispatch-timing-helper.sh record \
+			--repo "$repo_slug" --issue "$issue_number" --outcome "$outcome" \
+			--elapsed-ms "$elapsed_ms" --timeout-used-ms "$timeout_ms" \
+			>/dev/null 2>&1 || true
+	fi
+
 	return "$dispatch_rc"
+}
+
+#######################################
+# t3003: bash 3.2-compatible millisecond timestamp.
+# GNU date supports %N (nanoseconds); macOS BSD date does not. We strip the
+# trailing 6 digits to convert ns→ms when GNU date is present, otherwise fall
+# back to seconds×1000 (sufficient resolution for ≥1s timeouts).
+#######################################
+_dff_now_ms() {
+	local ns
+	ns=$(date +%s%N 2>/dev/null)
+	if [[ "$ns" =~ ^[0-9]+$ ]] && ((${#ns} >= 13)); then
+		# GNU date: epoch_seconds + 9-digit nanoseconds → strip 6 → ms
+		echo "${ns%??????}"
+	else
+		# BSD date or unsupported %N — fall back to second resolution
+		echo $(($(date +%s) * 1000))
+	fi
+	return 0
 }
 
 #######################################

--- a/.agents/scripts/tests/test-dispatch-timing-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-timing-helper.sh
@@ -1,0 +1,383 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+# test-dispatch-timing-helper.sh — t3003 helper unit tests.
+#
+# Covers:
+#   1. Bootstrap default with no records
+#   2. Bootstrap default with <3 successes
+#   3. EWMA convergence after sufficient successes
+#   4. Probe-mode escalation after timeout
+#   5. MIN/MAX clamps
+#   6. File-corruption recovery (malformed JSONL line ignored)
+#   7. Concurrent-write safety (two parallel record calls don't corrupt state)
+#   8. Stats output (text + JSON)
+#   9. Reset clears state
+#   10. Window trimming (>WINDOW records → only last N considered)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../dispatch-timing-helper.sh"
+
+if [[ ! -x "$HELPER" ]]; then
+	echo "FAIL: helper not found or not executable at $HELPER" >&2
+	exit 1
+fi
+
+# Isolate state to a temp file so we don't pollute production state
+TEST_STATE_FILE="$(mktemp -t t3003-test.XXXXXX.jsonl)"
+export DISPATCH_TIMING_STATE_FILE="$TEST_STATE_FILE"
+export DISPATCH_TIMING_BOOTSTRAP_MS=90000
+export DISPATCH_TIMING_MIN_TIMEOUT_MS=30000
+export DISPATCH_TIMING_MAX_TIMEOUT_MS=300000
+export DISPATCH_TIMING_WINDOW=20
+export DISPATCH_TIMING_EWMA_ALPHA_PCT=30
+export DISPATCH_TIMING_SAFETY_MULT_PCT=200
+export DISPATCH_TIMING_PROBE_MULT_PCT=200
+
+PASS=0
+FAIL=0
+FAILURES=()
+
+cleanup() {
+	rm -f "$TEST_STATE_FILE" "${TEST_STATE_FILE}.1" 2>/dev/null
+	rm -rf "${TEST_STATE_FILE}.lock.d" 2>/dev/null
+	return 0
+}
+trap cleanup EXIT
+
+_assert_eq() {
+	local label="$1"
+	local actual="$2"
+	local expected="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		PASS=$((PASS + 1))
+		printf '  PASS: %s (got %s)\n' "$label" "$actual"
+	else
+		FAIL=$((FAIL + 1))
+		FAILURES+=("$label: expected '$expected', got '$actual'")
+		printf '  FAIL: %s — expected %s, got %s\n' "$label" "$expected" "$actual"
+	fi
+	return 0
+}
+
+_assert_in_range() {
+	local label="$1"
+	local actual="$2"
+	local lo="$3"
+	local hi="$4"
+	if [[ "$actual" =~ ^[0-9]+$ ]] && ((actual >= lo && actual <= hi)); then
+		PASS=$((PASS + 1))
+		printf '  PASS: %s (got %s in [%s,%s])\n' "$label" "$actual" "$lo" "$hi"
+	else
+		FAIL=$((FAIL + 1))
+		FAILURES+=("$label: expected $lo<=value<=$hi, got '$actual'")
+		printf '  FAIL: %s — expected [%s,%s], got %s\n' "$label" "$lo" "$hi" "$actual"
+	fi
+	return 0
+}
+
+_reset_state() {
+	rm -f "$DISPATCH_TIMING_STATE_FILE" "${DISPATCH_TIMING_STATE_FILE}.1" 2>/dev/null
+	rm -rf "${DISPATCH_TIMING_STATE_FILE}.lock.d" 2>/dev/null
+	return 0
+}
+
+_record() {
+	local outcome="$1"
+	local elapsed_ms="$2"
+	local timeout_ms="${3:-30000}"
+	"$HELPER" record \
+		--repo "owner/repo" --issue "1" --outcome "$outcome" \
+		--elapsed-ms "$elapsed_ms" --timeout-used-ms "$timeout_ms" \
+		>/dev/null 2>&1
+	return $?
+}
+
+# ---------------------------------------------------------------------------
+# Test 1: Bootstrap default (no records)
+# ---------------------------------------------------------------------------
+test_bootstrap_no_records() {
+	echo "Test 1: bootstrap with no records"
+	_reset_state
+	local result
+	result=$("$HELPER" recommend)
+	_assert_eq "no records → bootstrap default" "$result" "90000"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: Bootstrap with <3 successes
+# ---------------------------------------------------------------------------
+test_bootstrap_insufficient_successes() {
+	echo "Test 2: bootstrap with <3 successes"
+	_reset_state
+	_record success 5000
+	_record success 5500
+	local result
+	result=$("$HELPER" recommend)
+	_assert_eq "2 successes → bootstrap default" "$result" "90000"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: EWMA convergence — 5 successes ~5s should give recommendation
+#         floor-clamped to 30000ms (since EWMA*2 ~ 10s < 30s floor)
+# ---------------------------------------------------------------------------
+test_ewma_low_avg_clamped_to_floor() {
+	echo "Test 3: EWMA with low avg → clamped to MIN floor"
+	_reset_state
+	_record success 4500
+	_record success 5000
+	_record success 5500
+	_record success 4800
+	_record success 5200
+	local result
+	result=$("$HELPER" recommend)
+	_assert_eq "5 successes ~5s → clamped to MIN floor 30000" "$result" "30000"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: EWMA — high avg, recommendation reflects EWMA*2 (above floor)
+# ---------------------------------------------------------------------------
+test_ewma_high_avg_above_floor() {
+	echo "Test 4: EWMA with high avg → recommendation tracks EWMA*2"
+	_reset_state
+	# 5 successes averaging ~25s: EWMA*2 ~ 50s = 50000ms (above 30s floor)
+	_record success 25000
+	_record success 26000
+	_record success 24000
+	_record success 25500
+	_record success 24500
+	local result
+	result=$("$HELPER" recommend)
+	# Expected range: EWMA*2 should be ~50000, p95 ~26000, max → ~50000
+	# Allow wide range since EWMA depends on order
+	_assert_in_range "5 successes ~25s → ~50000ms" "$result" "40000" "65000"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 5: Probe mode after timeout
+# ---------------------------------------------------------------------------
+test_probe_mode_after_timeout() {
+	echo "Test 5: probe mode after timeout (last record = timeout)"
+	_reset_state
+	# Establish baseline of low successes first
+	_record success 4000
+	_record success 5000
+	_record success 4500
+	_record success 5500
+	_record success 5000
+	# Then timeout at 30s
+	_record timeout 30000 30000
+	local result
+	result=$("$HELPER" recommend)
+	# Probe mode: max(recommended, last_timeout × 2) = max(~30s, 60s) = 60000
+	_assert_eq "timeout → probe = 2×timeout = 60000" "$result" "60000"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 6: Probe mode escalates with successive timeouts
+# ---------------------------------------------------------------------------
+test_probe_mode_escalation() {
+	echo "Test 6: probe mode escalates with successive timeouts"
+	_reset_state
+	_record success 5000
+	_record success 5000
+	_record success 5000
+	_record success 5000
+	_record success 5000
+	_record timeout 60000 60000
+	local result
+	result=$("$HELPER" recommend)
+	# Last timeout used 60000 → probe = 60000 × 2 = 120000
+	_assert_eq "60s timeout → probe = 120000" "$result" "120000"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 7: MAX_TIMEOUT clamp
+# ---------------------------------------------------------------------------
+test_max_timeout_clamp() {
+	echo "Test 7: MAX_TIMEOUT clamp"
+	_reset_state
+	# Establish high baseline so EWMA pushes above MAX
+	_record success 200000
+	_record success 200000
+	_record success 200000
+	_record success 200000
+	_record success 200000
+	local result
+	result=$("$HELPER" recommend)
+	# EWMA*2 = 400000, but MAX = 300000 → clamped
+	_assert_eq "EWMA above MAX → clamped to 300000" "$result" "300000"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 8: File-corruption recovery — malformed line is ignored
+# ---------------------------------------------------------------------------
+test_corruption_recovery() {
+	echo "Test 8: corruption recovery — malformed JSONL ignored"
+	_reset_state
+	_record success 5000
+	# Inject corruption directly
+	printf 'NOT VALID JSON\n' >>"$DISPATCH_TIMING_STATE_FILE"
+	printf '{"ts":"foo","outcome":"" broken\n' >>"$DISPATCH_TIMING_STATE_FILE"
+	_record success 5500
+	_record success 4800
+	_record success 5200
+	local result
+	result=$("$HELPER" recommend)
+	# Should still produce a valid recommendation, not crash.
+	_assert_in_range "corruption tolerated → valid output" "$result" "30000" "300000"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 9: Concurrent-write safety
+# ---------------------------------------------------------------------------
+test_concurrent_writes() {
+	echo "Test 9: concurrent writes don't corrupt state"
+	_reset_state
+	# Fire 10 concurrent record calls. Use direct backgrounding (not subshell
+	# wrapping) so the outer `wait` actually blocks until each child exits.
+	local i pids=()
+	for i in $(seq 1 10); do
+		_record success $((4000 + i * 100)) &
+		pids+=($!)
+	done
+	# Wait for each PID explicitly (more robust than bare `wait`)
+	for i in "${pids[@]}"; do
+		wait "$i" 2>/dev/null || true
+	done
+	# All 10 records should be present, no half-written lines
+	local line_count
+	line_count=$(wc -l <"$DISPATCH_TIMING_STATE_FILE" 2>/dev/null | tr -d ' ')
+	[[ -z "$line_count" ]] && line_count=0
+	_assert_eq "10 concurrent writes → 10 lines" "$line_count" "10"
+	# Each line should be valid JSON-ish (starts with `{`, ends with `}`)
+	local malformed_count
+	malformed_count=$(grep -cv '^{.*}$' "$DISPATCH_TIMING_STATE_FILE" 2>/dev/null || true)
+	[[ "$malformed_count" =~ ^[0-9]+$ ]] || malformed_count=0
+	_assert_eq "no malformed lines from concurrent writes" "$malformed_count" "0"
+	# Recommend should still produce valid output
+	local result
+	result=$("$HELPER" recommend)
+	_assert_in_range "post-concurrent recommend valid" "$result" "30000" "300000"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 10: Stats output (text + JSON)
+# ---------------------------------------------------------------------------
+test_stats_output() {
+	echo "Test 10: stats output"
+	_reset_state
+	_record success 5000
+	_record success 6000
+	_record success 7000
+	_record timeout 30000 30000
+	# Text
+	local text_out
+	text_out=$("$HELPER" stats 2>&1)
+	if [[ "$text_out" == *"successes:"* && "$text_out" == *"recommended:"* ]]; then
+		PASS=$((PASS + 1))
+		echo "  PASS: stats text contains expected fields"
+	else
+		FAIL=$((FAIL + 1))
+		FAILURES+=("stats text missing fields: $text_out")
+		echo "  FAIL: stats text missing fields"
+	fi
+	# JSON
+	local json_out
+	json_out=$("$HELPER" stats --json 2>&1)
+	if [[ "$json_out" == *'"recommended_ms":'* && "$json_out" == *'"successes":3'* ]]; then
+		PASS=$((PASS + 1))
+		echo "  PASS: stats --json valid"
+	else
+		FAIL=$((FAIL + 1))
+		FAILURES+=("stats --json malformed: $json_out")
+		echo "  FAIL: stats --json malformed"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 11: Reset clears state
+# ---------------------------------------------------------------------------
+test_reset() {
+	echo "Test 11: reset clears state"
+	_reset_state
+	_record success 5000
+	"$HELPER" reset >/dev/null
+	local result
+	result=$("$HELPER" recommend)
+	_assert_eq "after reset → bootstrap default" "$result" "90000"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 12: Window trimming — only last N records considered
+# ---------------------------------------------------------------------------
+test_window_limit() {
+	echo "Test 12: window limits how many records contribute"
+	_reset_state
+	# 25 records: first 5 are huge (200000), last 20 are small (5000)
+	# Window is 20 → only the small ones should drive EWMA.
+	local i
+	for i in $(seq 1 5); do
+		_record success 200000 >/dev/null 2>&1
+	done
+	for i in $(seq 1 20); do
+		_record success 5000 >/dev/null 2>&1
+	done
+	local result
+	result=$("$HELPER" recommend)
+	# Only last 20 small records → EWMA ~5000 → *2 = 10000 → clamped to MIN 30000
+	_assert_eq "window=20 ignores oldest 5 huge records" "$result" "30000"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Runner
+# ---------------------------------------------------------------------------
+
+_run_tests() {
+	echo "===== dispatch-timing-helper.sh tests ====="
+	test_bootstrap_no_records
+	test_bootstrap_insufficient_successes
+	test_ewma_low_avg_clamped_to_floor
+	test_ewma_high_avg_above_floor
+	test_probe_mode_after_timeout
+	test_probe_mode_escalation
+	test_max_timeout_clamp
+	test_corruption_recovery
+	test_concurrent_writes
+	test_stats_output
+	test_reset
+	test_window_limit
+
+	echo ""
+	echo "===== Summary ====="
+	echo "PASS: $PASS"
+	echo "FAIL: $FAIL"
+	if ((FAIL > 0)); then
+		echo ""
+		echo "Failures:"
+		local f
+		for f in "${FAILURES[@]}"; do
+			echo "  - $f"
+		done
+		return 1
+	fi
+	return 0
+}
+
+_run_tests
+exit $?

--- a/.agents/scripts/tests/test-dispatch-timing-helper.sh
+++ b/.agents/scripts/tests/test-dispatch-timing-helper.sh
@@ -26,8 +26,10 @@ if [[ ! -x "$HELPER" ]]; then
 	exit 1
 fi
 
-# Isolate state to a temp file so we don't pollute production state
-TEST_STATE_FILE="$(mktemp -t t3003-test.XXXXXX.jsonl)"
+# Isolate state to a temp file so we don't pollute production state.
+# Note: extension dropped — mktemp portability rule (t2997) requires XXXXXX
+# at the end of the template. The helper accepts any path via env var.
+TEST_STATE_FILE="$(mktemp "${TMPDIR:-/tmp}/t3003-test-XXXXXX")"
 export DISPATCH_TIMING_STATE_FILE="$TEST_STATE_FILE"
 export DISPATCH_TIMING_BOOTSTRAP_MS=90000
 export DISPATCH_TIMING_MIN_TIMEOUT_MS=30000


### PR DESCRIPTION
## Summary

Replaces the fixed `FILL_FLOOR_PER_CANDIDATE_TIMEOUT` (default 30s) with a rolling-window adaptive timeout driven by `dispatch-timing-helper.sh`. EWMA over recent successes plus p95 sets the budget; on timeouts the next attempt enters probe mode (2× last_timeout) to re-measure under degraded conditions. Clamped to [30s, 5min].

## Why

Incident 2026-04-27: 0 headless workers spawned for 30+ minutes despite 100+ eligible issues. Direct empirical timings showed:

- `gh issue edit … --add-label X --add-assignee Y` (multi-flag): **15.4s**
- `gh issue edit … --add-label X` (single-flag): **3.6-4.7s**
- `_dlw_assign_and_label` + `lock_issue_for_worker` + worktree + post-launch hooks: cumulative **15-30s+**

Every dispatch was hitting the fixed 30s timeout (`fill_floor_candidate_NNNNN exceeded 30s`), killing the candidate and looping. Even after manually bumping the env var to 90s, the underlying issue persists — the bottleneck is GitHub-API-side latency drift that no fixed value can adapt to.

## How

**Algorithm** (per `dispatch-timing-helper.sh recommend`):

1. Read last 20 records from JSONL state file (`~/.aidevops/.agent-workspace/tmp/dispatch-timing-stats.jsonl`)
2. Filter to outcome=success, get elapsed_ms array
3. <3 successes → bootstrap default (90000ms)
4. Compute EWMA(α=0.3) over successes + p95
5. recommended = `max(EWMA × 2.0, p95)`
6. **Probe mode**: if last record was timeout → `recommended = max(recommended, last_timeout × 2)`
7. Clamp to `[MIN=30000, MAX=300000]` ms

**Wire-in** (`pulse-dispatch-engine.sh::_dff_dispatch_with_timeout`):

- Call `dispatch-timing-helper.sh recommend --repo <slug>` before each dispatch (controlled by `DISPATCH_TIMING_ADAPTIVE=1` default)
- Time the dispatch in milliseconds
- After completion, call `dispatch-timing-helper.sh record …` with outcome (success/timeout/skip), elapsed_ms, timeout_used_ms

**Concurrency safety**: mkdir-based mutex (no flock dependency for macOS bash 3.2 compat). Stale-lock detection (>30s) self-heals.

**Bash 3.2 compat**: `_dff_now_ms` falls back to second-resolution on BSD `date` (no `%N` support).

## Files

- **NEW** `.agents/scripts/dispatch-timing-helper.sh` (575 lines): `recommend`, `record`, `stats`, `reset`, `help` subcommands. Pure-bash math (EWMA, p95) — no jq dependency in hot path.
- **EDIT** `.agents/scripts/pulse-dispatch-engine.sh`: `_dff_dispatch_with_timeout` (53 lines, well under 100-line gate) calls helper for budget + records outcome. Adds `_dff_now_ms` (11 lines) for portable ms timing.
- **NEW** `.agents/scripts/tests/test-dispatch-timing-helper.sh`: 15 test cases — bootstrap, EWMA convergence (low/high), probe escalation, MIN/MAX clamps, corruption recovery, concurrent writes, stats output, reset, window trimming. All pass.

## Verification

```text
===== dispatch-timing-helper.sh tests =====
PASS: 15
FAIL: 0
```

Empirical smoke test (5 successes ~5s, then timeout):

- After 5 successes: recommended=30000ms (clamped to MIN floor)
- After timeout: recommended=60000ms (probe mode = 2× last_timeout) ✓

ShellCheck zero NEW violations. Function complexity: 53/100 + 11/100 (gate at 100). Counter-stack lint clean. Positional-param ratchet clean. String-literal ratchet clean (refactored `_dt_extract_field` to delegate to `_dt_json_field`).

## Backward compatibility

- `FILL_FLOOR_PER_CANDIDATE_TIMEOUT` remains as the legacy fixed-timeout fallback when `DISPATCH_TIMING_ADAPTIVE=0` or helper unavailable
- All measurement state is fail-open: lock timeouts, file errors, malformed JSONL → fall through to fixed timeout
- New env vars all have sensible defaults (`DISPATCH_TIMING_*`)

## Tunables

| Env var | Default | Purpose |
|---|---|---|
| `DISPATCH_TIMING_ADAPTIVE` | `1` | Enable adaptive (set `0` for legacy) |
| `DISPATCH_TIMING_MIN_TIMEOUT_MS` | `30000` | Floor |
| `DISPATCH_TIMING_MAX_TIMEOUT_MS` | `300000` | Ceiling |
| `DISPATCH_TIMING_BOOTSTRAP_MS` | `90000` | <3 successes default |
| `DISPATCH_TIMING_WINDOW` | `20` | Rolling window size |
| `DISPATCH_TIMING_EWMA_ALPHA_PCT` | `30` | EWMA α × 100 |
| `DISPATCH_TIMING_SAFETY_MULT_PCT` | `200` | Multiplier on EWMA |
| `DISPATCH_TIMING_PROBE_MULT_PCT` | `200` | Probe mode multiplier on last_timeout |

Resolves #21434

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.4 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-opus-4-7 spent 22h 25m and 92,783 tokens on this with the user in an interactive session.
