### PR TITLE
t3002: fix(t3002): close pulse-wrapper singleton lock race window (GH#21433)

### DIFF
--- a/.agents/scripts/pulse-instance-lock.sh
+++ b/.agents/scripts/pulse-instance-lock.sh
@@ -71,6 +71,35 @@ _handle_existing_lock() {
 	local lock_pid
 	lock_pid=$(_read_lock_pid)
 
+	# GH#21433 (t3002): Race-window grace period.
+	# acquire_instance_lock writes the PID file AFTER the mkdir succeeds.
+	# If we observe LOCKDIR existing but its PID file is empty/missing, the
+	# owner may simply be in the brief window between mkdir success and the
+	# `echo $$ >LOCKDIR/pid` write. Without this grace period, an empty PID
+	# file falls through to the "stale → clear and re-acquire" path below,
+	# which destroys a freshly-acquired-but-not-yet-stamped owner's LOCKDIR
+	# and lets a second instance acquire its own — yielding two pulses that
+	# both believe they hold the singleton lock.
+	#
+	# Wait briefly (~2s) for the PID to appear before declaring stale.
+	# A genuine SIGKILL/OOM-orphaned LOCKDIR will still have an empty PID
+	# file after the grace expires; live owners stamp the PID well within
+	# this window in practice.
+	if [[ -z "$lock_pid" ]]; then
+		local _grace=0
+		while ((_grace < 20)); do
+			# Fractional sleep on BSD/coreutils sleep; fall back to 1s on
+			# stripped-down shells without decimal sleep support.
+			sleep 0.1 2>/dev/null || sleep 1
+			lock_pid=$(_read_lock_pid)
+			[[ -n "$lock_pid" ]] && break
+			_grace=$((_grace + 1))
+		done
+		if [[ -n "$lock_pid" ]]; then
+			echo "[pulse-wrapper] _handle_existing_lock: PID file appeared after ${_grace} grace iterations (PID ${lock_pid}) — GH#21433 race window observed" >>"$WRAPPER_LOGFILE"
+		fi
+	fi
+
 	if [[ -n "$lock_pid" ]] && [[ "$lock_pid" =~ ^[0-9]+$ ]] && ps -p "$lock_pid" >/dev/null 2>&1; then
 		# Lock owner PID is alive — but is it actually a pulse-wrapper?
 		# GH#20025 Phase C: PID reuse guard + age-based force-reclaim.
@@ -239,6 +268,27 @@ acquire_instance_lock() {
 
 	# Write our PID into the lock directory for stale-lock detection
 	echo "$$" >"${LOCKDIR}/pid"
+
+	# GH#21433 (t3002): Post-acquisition ownership verification.
+	# Defence-in-depth against the mkdir-vs-PID-write race even when the
+	# grace period in _handle_existing_lock fails (e.g., grace too short
+	# under heavy load, or a non-pulse process touched LOCKDIR/pid). If
+	# another instance executed _handle_existing_lock during our PID-write
+	# window — saw the empty PID file, exhausted its grace period, removed
+	# our LOCKDIR, mkdir-recreated it, and stamped its own PID — then the
+	# file we just wrote was either re-overwritten by them or sits inside
+	# their LOCKDIR. Re-read after a brief settle and verify the file still
+	# contains $$. If not, the other instance won; abandon this attempt
+	# and exit without removing LOCKDIR (we don't own it any more).
+	sleep 0.2 2>/dev/null || sleep 1
+	local _verify_pid
+	_verify_pid=$(cat "${LOCKDIR}/pid" 2>/dev/null || echo "")
+	if [[ "$_verify_pid" != "$$" ]]; then
+		echo "[pulse-wrapper] Lock verification failed — LOCKDIR/pid contains '${_verify_pid:-empty}' instead of $$ — another instance won the race, exiting (GH#21433)" >>"$WRAPPER_LOGFILE"
+		# Do NOT remove LOCKDIR — the other instance owns it now.
+		# Leave _LOCK_OWNED=false so release_instance_lock is a no-op.
+		return 1
+	fi
 
 	echo "[pulse-wrapper] Instance lock acquired via mkdir (PID $$)" >>"$WRAPPER_LOGFILE"
 

--- a/.agents/scripts/pulse-lifecycle-helper.sh
+++ b/.agents/scripts/pulse-lifecycle-helper.sh
@@ -27,6 +27,7 @@
 #   0  Success (includes no-op cases)
 #   1  Pulse not running (is-running only)
 #   2  Invalid subcommand or missing pulse-wrapper.sh
+#   3  status: multiple pulse PIDs detected (singleton violation, GH#21433)
 #
 # Part of aidevops framework: https://aidevops.sh
 
@@ -193,7 +194,11 @@ _restart_if_running() {
 	_start
 }
 
-# _status: human-readable PID + age.
+# _status: human-readable PID + age. Reports lock-holder PID and warns when
+# multiple pulse PIDs are alive simultaneously — the singleton invariant
+# (GH#4513, GH#21433) requires exactly one. Multiple PIDs indicate a race
+# escaped the lock (e.g., trap-cleanup vs launchd respawn vs lifecycle-helper
+# concurrent start) and operator intervention is needed.
 _status() {
 	local _pids
 	_pids=$(_pulse_pids)
@@ -202,13 +207,40 @@ _status() {
 		return 0
 	fi
 
-	printf 'Pulse: running\n'
+	# Count PIDs (newline-separated). Use wc -l + tr to be portable.
+	local _pid_count
+	_pid_count=$(printf '%s\n' "$_pids" | wc -l | tr -d ' ')
+	[[ "$_pid_count" =~ ^[0-9]+$ ]] || _pid_count=0
+
+	printf 'Pulse: running (%s instance%s)\n' "$_pid_count" "$([[ $_pid_count -eq 1 ]] || printf 's')"
+
+	# Read lock-holder PID for cross-reference (GH#21433 acceptance criterion).
+	local _lockdir="${HOME}/.aidevops/logs/pulse-wrapper.lockdir"
+	local _lock_pid=""
+	if [[ -f "${_lockdir}/pid" ]]; then
+		_lock_pid=$(cat "${_lockdir}/pid" 2>/dev/null || echo "")
+	fi
+	if [[ -n "$_lock_pid" ]]; then
+		printf '  Lock holder PID: %s\n' "$_lock_pid"
+	else
+		printf '  Lock holder PID: (LOCKDIR/pid missing or empty)\n'
+	fi
+
 	local _pid
 	while IFS= read -r _pid; do
 		local _etime
 		_etime=$(ps -p "$_pid" -o etime= 2>/dev/null | tr -d ' ')
-		printf '  PID %s (uptime %s)\n' "$_pid" "${_etime:-unknown}"
+		local _marker=""
+		[[ "$_pid" == "$_lock_pid" ]] && _marker=" (lock holder)"
+		printf '  PID %s%s (uptime %s)\n' "$_pid" "$_marker" "${_etime:-unknown}"
 	done <<<"$_pids"
+
+	if [[ "$_pid_count" -gt 1 ]]; then
+		_pl_warn "MULTIPLE pulse instances detected (GH#21433) — singleton invariant violated"
+		_pl_warn "Recommendation: $(basename "$0") restart    # full stop+start to recover"
+		# Exit non-zero so callers (scripts, monitoring) can detect the anomaly.
+		return 3
+	fi
 	return 0
 }
 
@@ -234,6 +266,7 @@ Exit codes:
   0  Success
   1  Pulse not running (is-running only) / pulse failed to start
   2  Invalid subcommand or missing pulse-wrapper.sh
+  3  status: multiple pulse PIDs detected (singleton violation, GH#21433)
 EOF
 	return 0
 }

--- a/.agents/scripts/tests/test-pulse-singleton-lock.sh
+++ b/.agents/scripts/tests/test-pulse-singleton-lock.sh
@@ -1,0 +1,386 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression tests for pulse-wrapper singleton lock under racy conditions
+# (GH#21433 / t3002).
+#
+# Background: pulse-instance-lock.sh's mkdir-based singleton lock had a
+# real race between mkdir success and the subsequent `echo $$ >LOCKDIR/pid`
+# write. _handle_existing_lock treated an empty PID file as "stale" and
+# rm -rf'd LOCKDIR — destroying a freshly-acquired-but-not-yet-stamped
+# owner's lock and letting a second instance acquire its own. Symptom: 4
+# concurrent pulse-wrapper.sh PIDs, each logging "Instance lock acquired
+# via mkdir" simultaneously.
+#
+# This test covers the two defences added in t3002:
+#   1. _handle_existing_lock grace period: empty PID file is retried
+#      briefly before treating as stale.
+#   2. acquire_instance_lock post-write verification: re-read PID file
+#      after writing $$ and confirm we still own the lock.
+#
+# Asserts:
+#   T1. _handle_existing_lock with an empty PID file waits for the PID
+#       to appear (grace period) and treats the live owner as live.
+#   T2. _handle_existing_lock with an empty PID file that NEVER appears
+#       eventually times out and proceeds to the stale-clear path.
+#   T3. acquire_instance_lock detects ownership loss when LOCKDIR/pid
+#       is mutated between write and verify (simulates the race winner).
+#   T4. Singleton invariant: when two acquire_instance_lock attempts run
+#       concurrently, only one returns 0 and ends up in the PID file.
+
+set -euo pipefail
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_YELLOW='\033[0;33m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+TEST_ROOT=""
+PULSE_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+readonly PULSE_SCRIPTS_DIR
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+assert_equals() {
+	local name="$1"
+	local expected="$2"
+	local actual="$3"
+	if [[ "$expected" == "$actual" ]]; then
+		print_result "$name" 0
+	else
+		print_result "$name" 1 "expected='${expected}' actual='${actual}'"
+	fi
+	return 0
+}
+
+# Source pulse-instance-lock.sh with a minimal stub environment, mirroring
+# test-pulse-instance-lock-mkdir-only.sh.
+setup_sandbox() {
+	TEST_ROOT=$(mktemp -d)
+	export HOME="${TEST_ROOT}/home"
+	mkdir -p "${HOME}/.aidevops/logs"
+
+	LOCKDIR="${HOME}/.aidevops/logs/pulse-wrapper.lockdir"
+	WRAPPER_LOGFILE="${HOME}/.aidevops/logs/pulse-wrapper.log"
+	LOGFILE="${HOME}/.aidevops/logs/pulse.log"
+	PIDFILE="${HOME}/.aidevops/logs/pulse.pid"
+	_LOCK_OWNED=false
+	PULSE_STALE_THRESHOLD=3600
+	export LOCKDIR WRAPPER_LOGFILE LOGFILE PIDFILE _LOCK_OWNED PULSE_STALE_THRESHOLD
+
+	_get_process_age() { echo "42"; }
+	_kill_tree() { return 0; }
+	_force_kill_tree() { return 0; }
+	get_max_workers_target() { echo "1"; }
+	count_active_workers() { echo "0"; }
+	export -f _get_process_age _kill_tree _force_kill_tree
+	export -f get_max_workers_target count_active_workers
+
+	# shellcheck source=/dev/null
+	source "${PULSE_SCRIPTS_DIR}/pulse-instance-lock.sh"
+	return 0
+}
+
+teardown_sandbox() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	if [[ -n "${LOCKDIR:-}" && -d "$LOCKDIR" ]]; then
+		rm -rf "$LOCKDIR"
+	fi
+	_LOCK_OWNED=false
+	return 0
+}
+
+reset_state() {
+	if [[ -n "${LOCKDIR:-}" && -d "$LOCKDIR" ]]; then
+		rm -rf "$LOCKDIR"
+	fi
+	_LOCK_OWNED=false
+	return 0
+}
+
+#######################################
+# T1: Grace period — _handle_existing_lock with an empty PID file waits
+# for the PID to appear before declaring stale.
+#
+# Setup: pre-create LOCKDIR (simulating mkdir-succeeded-but-PID-not-written
+# state), then schedule a background task to write a live pulse-wrapper PID
+# 500ms later. _handle_existing_lock must wait through its grace window,
+# read the appearing PID, and return 1 (owner is live, do not reclaim).
+#######################################
+test_grace_period_empty_pid_file() {
+	reset_state
+
+	# Background pulse-wrapper-like process (so PID-reuse guard sees a
+	# pulse-wrapper command name). NOTE: do NOT use `exec sleep` here —
+	# exec replaces the bash process and ps -o command= then shows
+	# "sleep N" without "pulse-wrapper" in argv, tripping the PID-reuse
+	# force-reclaim path. Plain `sleep N` keeps bash alive with the
+	# original argv intact.
+	local fake_script="${TEST_ROOT}/pulse-wrapper.sh"
+	cat >"$fake_script" <<'FAKEOF'
+#!/usr/bin/env bash
+sleep 60
+FAKEOF
+	chmod +x "$fake_script"
+	"$fake_script" &
+	local fake_pid=$!
+
+	# Pre-create LOCKDIR with NO PID file (the race state).
+	mkdir -p "$LOCKDIR"
+
+	# Schedule a delayed PID write to simulate the racy owner stamping
+	# their PID 500ms after mkdir.
+	(
+		sleep 0.5
+		echo "$fake_pid" >"${LOCKDIR}/pid"
+	) &
+	local writer_pid=$!
+
+	# _handle_existing_lock should see empty PID file, wait through grace,
+	# read the now-stamped fake_pid, see it is alive + pulse-wrapper, and
+	# return 1.
+	local rc=0
+	_handle_existing_lock || rc=$?
+	assert_equals "T1: grace period waited for late PID write — returns 1 (live owner)" "1" "$rc"
+
+	# LOCKDIR must NOT have been removed (live owner case preserves it).
+	if [[ -d "$LOCKDIR" ]]; then
+		print_result "T1: LOCKDIR preserved after grace-detected live owner" 0
+	else
+		print_result "T1: LOCKDIR preserved after grace-detected live owner" 1
+	fi
+
+	# Cleanup
+	wait "$writer_pid" 2>/dev/null || true
+	kill "$fake_pid" 2>/dev/null || true
+	wait "$fake_pid" 2>/dev/null || true
+	rm -rf "$LOCKDIR"
+	return 0
+}
+
+#######################################
+# T2: Grace period times out — when the PID never appears (true SIGKILL/
+# OOM mid-mkdir orphan), _handle_existing_lock proceeds to clear and
+# re-acquire after the grace window.
+#######################################
+test_grace_period_timeout() {
+	reset_state
+
+	# Pre-create LOCKDIR with NO PID file. No background writer — this
+	# simulates a process killed between mkdir and PID stamp.
+	mkdir -p "$LOCKDIR"
+
+	# _handle_existing_lock should grace, time out, then clear and
+	# re-acquire (returns 0).
+	local rc=0
+	_handle_existing_lock || rc=$?
+	assert_equals "T2: grace period times out → clears and re-acquires (returns 0)" "0" "$rc"
+
+	# LOCKDIR must exist (we re-acquired it).
+	if [[ -d "$LOCKDIR" ]]; then
+		print_result "T2: LOCKDIR re-created after grace timeout" 0
+	else
+		print_result "T2: LOCKDIR re-created after grace timeout" 1
+	fi
+
+	rm -rf "$LOCKDIR"
+	return 0
+}
+
+#######################################
+# T3: Post-write verification — acquire_instance_lock detects when the
+# PID file is mutated between write and verify (race winner overwrote
+# our PID with theirs).
+#######################################
+test_post_write_verification() {
+	reset_state
+
+	# Override the verify-step sleep to be longer so we have a window to
+	# mutate the PID file. sleep is a builtin via /bin/sleep; we shadow
+	# it as a function in our subshell context. Then mutate during the
+	# sleep.
+	#
+	# To inject the mutation without modifying the function, we use a
+	# background process that watches LOCKDIR/pid and overwrites it.
+	#
+	# Wait for the file to exist, then overwrite with a foreign PID.
+	local foreign_pid=99999998
+	(
+		# Wait for our PID to appear, then immediately overwrite.
+		while [[ ! -f "${LOCKDIR}/pid" ]]; do sleep 0.01 2>/dev/null || sleep 1; done
+		echo "$foreign_pid" >"${LOCKDIR}/pid"
+	) &
+	local mutator_pid=$!
+
+	local rc=0
+	acquire_instance_lock || rc=$?
+	assert_equals "T3: post-write verify detects PID mutation → returns 1" "1" "$rc"
+
+	# _LOCK_OWNED must remain false (we never owned it).
+	assert_equals "T3: _LOCK_OWNED remains false on verify failure" "false" "$_LOCK_OWNED"
+
+	wait "$mutator_pid" 2>/dev/null || true
+	rm -rf "$LOCKDIR"
+	return 0
+}
+
+#######################################
+# T4: Singleton invariant under concurrent acquire — spawn two real
+# pulse-wrapper.sh-named processes that each attempt acquire_instance_lock,
+# and verify exactly ONE ends up as the recorded lock holder.
+#
+# Note on test architecture: subshells `( ... ) &` inherit the parent test
+# script's argv, so `ps -o command=` for them shows "bash test-pulse-...".
+# That fails the PID-reuse guard inside _handle_existing_lock (which
+# requires "pulse-wrapper" in the owner command) and triggers force-reclaim.
+# To model the real production race we therefore spawn external bash
+# processes via scripts physically named `pulse-wrapper.sh`. Each child
+# sources pulse-instance-lock.sh, calls acquire_instance_lock, and writes
+# its rc to a tagged file.
+#######################################
+test_concurrent_acquire_singleton() {
+	reset_state
+
+	# Worker script template — physically named pulse-wrapper.sh so the
+	# PID-reuse guard sees "pulse-wrapper" in argv via ps.
+	local worker_dir="${TEST_ROOT}/workers"
+	mkdir -p "$worker_dir"
+
+	# Helper writes a tagged worker that imports our test stubs + sources
+	# the lock module, then calls acquire_instance_lock and reports rc.
+	# The parent provides LOCKDIR/WRAPPER_LOGFILE/etc via env export.
+	local _worker_template="${TEST_ROOT}/worker-template.sh"
+	cat >"$_worker_template" <<EOF_TPL
+#!/usr/bin/env bash
+set -u
+TAG="\$1"
+RC_FILE="\$2"
+LOCKDIR="${LOCKDIR}"
+WRAPPER_LOGFILE="${WRAPPER_LOGFILE}"
+LOGFILE="${LOGFILE}"
+PIDFILE="${PIDFILE}"
+PULSE_STALE_THRESHOLD=3600
+_LOCK_OWNED=false
+export LOCKDIR WRAPPER_LOGFILE LOGFILE PIDFILE PULSE_STALE_THRESHOLD _LOCK_OWNED
+
+_get_process_age() { echo "1"; }
+_kill_tree() { return 0; }
+_force_kill_tree() { return 0; }
+get_max_workers_target() { echo "1"; }
+count_active_workers() { echo "0"; }
+
+# shellcheck source=/dev/null
+source "${PULSE_SCRIPTS_DIR}/pulse-instance-lock.sh"
+
+_rc=0
+acquire_instance_lock || _rc=\$?
+echo "\$_rc" >"\$RC_FILE"
+
+# If we acquired it, hold briefly so the contender observes the live
+# owner before exiting.
+if [[ "\$_rc" == "0" ]]; then
+	sleep 0.5
+	release_instance_lock
+fi
+exit 0
+EOF_TPL
+	chmod +x "$_worker_template"
+
+	# Two concrete pulse-wrapper.sh-named worker scripts that exec the
+	# template. Their physical filename satisfies the "pulse-wrapper"-in-
+	# command check inside _handle_existing_lock.
+	local worker_A="${worker_dir}/pulse-wrapper.sh"
+	cat >"$worker_A" <<EOF_A
+#!/usr/bin/env bash
+exec bash "${_worker_template}" "\$@"
+EOF_A
+	chmod +x "$worker_A"
+
+	# Spawn two contenders simultaneously.
+	"$worker_A" "A" "${TEST_ROOT}/rc-A" &
+	local pid_A=$!
+	"$worker_A" "B" "${TEST_ROOT}/rc-B" &
+	local pid_B=$!
+
+	wait "$pid_A" 2>/dev/null || true
+	wait "$pid_B" 2>/dev/null || true
+
+	local rc_A rc_B
+	rc_A=$(cat "${TEST_ROOT}/rc-A" 2>/dev/null || echo "missing")
+	rc_B=$(cat "${TEST_ROOT}/rc-B" 2>/dev/null || echo "missing")
+
+	# Exactly one of {A, B} must have returned 0; the other must have
+	# returned non-zero.
+	local zero_count=0
+	[[ "$rc_A" == "0" ]] && zero_count=$((zero_count + 1))
+	[[ "$rc_B" == "0" ]] && zero_count=$((zero_count + 1))
+
+	if [[ "$zero_count" -eq 1 ]]; then
+		print_result "T4: exactly one concurrent acquire returns 0 (singleton)" 0
+	else
+		print_result "T4: exactly one concurrent acquire returns 0 (singleton)" 1 \
+			"rc-A=${rc_A} rc-B=${rc_B} zero_count=${zero_count}"
+	fi
+
+	# After both workers exit, LOCKDIR should be cleaned up by the
+	# winner's release_instance_lock. The loser never owned it.
+	if [[ ! -d "$LOCKDIR" ]]; then
+		print_result "T4: LOCKDIR cleaned up after winner releases" 0
+	else
+		print_result "T4: LOCKDIR cleaned up after winner releases" 1 \
+			"residual LOCKDIR=${LOCKDIR}"
+		rm -rf "$LOCKDIR"
+	fi
+	return 0
+}
+
+#######################################
+# Main
+#######################################
+main() {
+	printf '%b==> pulse singleton lock race tests (GH#21433 / t3002)%b\n' \
+		"$TEST_YELLOW" "$TEST_RESET"
+	printf '    PULSE_SCRIPTS_DIR=%s\n' "$PULSE_SCRIPTS_DIR"
+
+	setup_sandbox
+
+	test_grace_period_empty_pid_file
+	test_grace_period_timeout
+	test_post_write_verification
+	test_concurrent_acquire_singleton
+
+	teardown_sandbox
+
+	printf '\n'
+	if [[ "$TESTS_FAILED" -eq 0 ]]; then
+		printf '%bAll %d tests passed%b\n' "$TEST_GREEN" "$TESTS_RUN" "$TEST_RESET"
+		return 0
+	fi
+	printf '%b%d of %d tests failed%b\n' "$TEST_RED" "$TESTS_FAILED" "$TESTS_RUN" "$TEST_RESET"
+	return 1
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Add a grace period in _handle_existing_lock for the mkdir-success-but-PID-not-yet-written window, plus a post-acquisition ownership verification step in acquire_instance_lock. Without these, a contender that arrives during the brief gap between LOCKDIR creation and the PID stamp sees an empty PID file, falls through to the stale-lock-clear path, and mkdir-recreates LOCKDIR — yielding two pulses that both believe they hold the singleton. pulse-lifecycle-helper.sh status now reports the lock-holder PID and exits 3 with a warning when multiple pulse PIDs are alive (operator signal that the singleton invariant has slipped).

## Files Changed

.agents/scripts/pulse-instance-lock.sh,.agents/scripts/pulse-lifecycle-helper.sh,.agents/scripts/tests/test-pulse-singleton-lock.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** New regression test test-pulse-singleton-lock.sh covers (T1) grace period waits for late PID write and treats live owner as live, (T2) grace period times out for a truly orphan LOCKDIR and re-acquires, (T3) post-write verification detects PID mutation by a race winner, (T4) two real pulse-wrapper.sh-named worker processes contending for the lock — exactly one returns 0. All 8 new asserts pass; the existing 20 mkdir-only characterisation tests, 16 lifecycle-helper tests, 33 lock-force-reclaim tests, and 15 is-running stale-lock-breaker tests all still pass. shellcheck clean across all three modified files.

Resolves #21433


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.5 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-opus-4-7 spent 12m and 38,691 tokens on this as a headless worker.