### PR TITLE
GH#21448: fix _log date capture to avoid set -e abort in pulse-cache-prime.sh

### DIFF
--- a/.agents/scripts/pulse-cache-prime.sh
+++ b/.agents/scripts/pulse-cache-prime.sh
@@ -42,7 +42,8 @@ mkdir -p "$LOG_DIR" "$CACHE_DIR" 2>/dev/null || true
 
 _log() {
 	local msg="$1"
-	printf '[%s] %s\n' "$(date -u +'%Y-%m-%dT%H:%M:%SZ')" "$msg" >>"$LOG_FILE" 2>/dev/null || true
+	local timestamp; timestamp=$(date -u +'%Y-%m-%dT%H:%M:%SZ') || timestamp="unknown"
+	printf '[%s] %s\n' "$timestamp" "$msg" >>"$LOG_FILE" || true
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Captures the `date` timestamp in a local variable before passing to `printf` in the `_log` function of `pulse-cache-prime.sh`. Under `set -euo pipefail`, a failing command substitution inside a function argument aborts the script before `|| true` is reached — the variable pattern with `|| timestamp="unknown"` properly handles the error. Also removes the `2>/dev/null` suppression so genuine write failures (disk full, permissions) are visible for debugging.

## Change

- `EDIT: .agents/scripts/pulse-cache-prime.sh:43-47` — capture timestamp via `local timestamp; timestamp=$(date ...) || timestamp="unknown"` then remove `2>/dev/null` from the `printf` redirect

## Verification

- `shellcheck .agents/scripts/pulse-cache-prime.sh` — passes clean (zero violations)

Resolves #21448

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.5 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-sonnet-4-6 spent 2m and 3,839 tokens on this as a headless worker.
