### PR TITLE
GH#21446: fix: harden _pulse_prime_caches_if_stale against non-numeric AIDEVOPS_PULSE_PRIME_MAX_AGE and empty epoch vars

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1484,7 +1484,9 @@ _pulse_prime_caches_if_stale() {
 	_prime_helper="${SCRIPT_DIR}/pulse-cache-prime.sh"
 	_prime_sentinel="${HOME}/.aidevops/cache/pulse-cache-prime-last-run"
 	_prime_max_age="${AIDEVOPS_PULSE_PRIME_MAX_AGE:-1800}"
+	[[ "$_prime_max_age" =~ ^[0-9]+$ ]] || _prime_max_age=1800
 
+	mkdir -p "$(dirname "$_prime_sentinel")"
 	[[ ! -x "$_prime_helper" ]] && return 0
 
 	local _should_prime=0
@@ -1492,9 +1494,9 @@ _pulse_prime_caches_if_stale() {
 		_should_prime=1
 	else
 		local _now_epoch="" _stamp_epoch="" _age_s=""
-		_now_epoch=$(date +%s)
-		_stamp_epoch=$(stat -f %m "$_prime_sentinel" 2>/dev/null || stat -c %Y "$_prime_sentinel" 2>/dev/null || echo 0)
-		_age_s=$((_now_epoch - _stamp_epoch))
+		_now_epoch=$(date +%s 2>/dev/null)
+		_stamp_epoch=$(stat -f %m "$_prime_sentinel" 2>/dev/null || stat -c %Y "$_prime_sentinel" 2>/dev/null)
+		_age_s=$(( ${_now_epoch:-0} - ${_stamp_epoch:-0} ))
 		[[ "$_age_s" -gt "$_prime_max_age" ]] && _should_prime=1
 	fi
 


### PR DESCRIPTION
## Summary

Added numeric validation for AIDEVOPS_PULSE_PRIME_MAX_AGE env var (falls back to 1800 if non-numeric), ensured sentinel directory exists via mkdir -p, added 2>/dev/null guard on date +%s, and switched arithmetic expansion to use ${_now_epoch:-0}/${_stamp_epoch:-0} defaults. All three changes prevent set -e failures when the env var is misconfigured or date/stat commands fail.

## Files Changed

.agents/scripts/pulse-wrapper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-wrapper.sh passes with zero violations

Resolves #21446


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.5 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-sonnet-4-6 spent 2m and 5,091 tokens on this as a headless worker.