### PR TITLE
GH#21447: fix _tier_rank hardcoded rank, retention_years schema, header comment

### DIFF
--- a/.agents/scripts/sensitivity-detector-helper.sh
+++ b/.agents/scripts/sensitivity-detector-helper.sh
@@ -23,7 +23,7 @@
 #   internal    Internal business docs — not public, not personal
 #   pii         Personal data — names, addresses, ID/payment numbers
 #   sensitive   Sensitive business — board minutes, strategy, HR
-#   competitive Competitive intel — _campaigns/intel/ enforced, local-LLM-only (Ollama), never cloud, retention months not years
+#   competitive Competitive intel — _campaigns/intel/ enforced, local-LLM-only (Ollama), never cloud, 1-year retention
 #   privileged  Legally privileged — attorney-client, court filings
 #
 # Audit log: <knowledge-root>/index/sensitivity-audit.log (JSONL)
@@ -148,9 +148,9 @@ _tier_rank() {
 		fi
 		rank=$((rank + 1))
 	done
-	# Unknown tier — treat as internal (rank 3)
-	echo "3"
-	return 0
+	# Unknown tier — treat as internal (dynamic rank, not hardcoded)
+	_tier_rank "internal"
+	return $?
 }
 
 _higher_tier() {

--- a/.agents/templates/sensitivity-config.json
+++ b/.agents/templates/sensitivity-config.json
@@ -28,7 +28,7 @@
     "competitive": {
       "redact": true,
       "llm": "local-only-hard-fail",
-      "retention_months": 12,
+      "retention_years": 1,
       "description": "Competitive intel — campaign-scoped, local-LLM-only (Ollama), never cloud, short retention"
     },
     "privileged": {


### PR DESCRIPTION
## Summary

Three correctness fixes for the `competitive` sensitivity tier introduced in PR #21400 (t2964), surfaced by Gemini code review:

### Fix 1 — `_tier_rank` hardcoded fallback rank (bug)

`_tier_rank` fell back to `echo "3"` for unknown tiers, intended to represent "internal". Before PR #21400, `TIER_PRECEDENCE="privileged sensitive pii internal public"` put `internal` at rank 3 — correct. After inserting `competitive` at position 1, the order became `privileged competitive sensitive pii internal public`, moving `internal` to rank **4**. The hardcoded `3` now returns the rank of `pii` for unknown tiers — silently wrong. Fix: replace `echo "3"` with a recursive `_tier_rank "internal"` call so the fallback always tracks the live precedence list.

### Fix 2 — `retention_months` to `retention_years` schema consistency

`sensitivity-config.json` used `retention_months: 12` for the `competitive` tier while all other tiers use `retention_years`. Mixed keys break consumers (cleanup/auditing scripts) that iterate tiers and read the retention field uniformly. Changed to `retention_years: 1`.

### Fix 3 — Header comment update

Updated the header comment for `competitive` from "retention months not years" to "1-year retention" to match the schema fix above.

## Verification

- `shellcheck .agents/scripts/sensitivity-detector-helper.sh` — zero violations
- `jq . .agents/templates/sensitivity-config.json` — JSON valid

Resolves #21447

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.5 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-sonnet-4-6 spent 3m and 6,666 tokens on this as a headless worker.
