### PR TITLE
GH#21445: fix lint-mktemp-portability file discovery and regex robustness

### DIFF
--- a/.agents/scripts/lint-mktemp-portability.sh
+++ b/.agents/scripts/lint-mktemp-portability.sh
@@ -32,7 +32,7 @@
 #   --no-exit-code  always exit 0 (advisory mode)
 #   --help          show this help
 #
-# With no FILES: scans all git-tracked .sh files via `git ls-files '*.sh'`.
+# With no FILES: scans all git-tracked .sh/.bash/.zsh files.
 #
 # Output format: file:line: <offending mktemp template>
 # Exit codes: 0=clean, 1=violations found
@@ -136,13 +136,13 @@ _parse_args "$@"
 # File list resolution
 # ---------------------------------------------------------------------------
 if [[ ${#TARGET_FILES[@]} -eq 0 ]]; then
-	# Default: all tracked .sh files in the repo.
+	# Default: all tracked .sh/.bash/.zsh files in the repo.
 	if ! command -v git >/dev/null 2>&1; then
 		printf 'mktemp-portability: git not found and no FILES given\n' >&2
 		exit 2
 	fi
-	# shellcheck disable=SC2207
-	TARGET_FILES=($(git ls-files '*.sh' 2>/dev/null || true))
+	while IFS= read -r f; do TARGET_FILES+=("$f"); done \
+		< <(git ls-files '*.sh' '*.bash' '*.zsh' 2>/dev/null || true)
 fi
 
 if [[ ${#TARGET_FILES[@]} -eq 0 ]]; then
@@ -155,10 +155,12 @@ fi
 # ---------------------------------------------------------------------------
 # The detection regex:
 #   - mktemp                 — the command
-#   - (?!\s+-[duqQ]\b)       — NOT followed by -d / -u / -q / -Q (file-form only)
+#   - (?![^|;&)]*[[:space:]]-[a-zA-Z]*[duqQ][a-zA-Z]*\b)
+#                            — NOT preceded (anywhere in args) by -d/-u/-q/-Q flag
+#                              (handles combined flags like -dq, -qu, flag ordering)
 #                              NOTE: -t (template prefix) is fine — its template
 #                              still goes through the same X-placement rule.
-#   - .*X{6,}\.[a-zA-Z]      — XXXXXX (or more) followed by `.<letter>` extension
+#   - .*X{6,}\.[a-zA-Z]      — XXXXXX (or more Xs) followed by `.<letter>` extension
 #
 # We use POSIX-friendly grep with -P (PCRE) since rg may not be on the runner.
 # Fall back to grep -P if rg unavailable.
@@ -170,8 +172,8 @@ violation_lines=()
 
 # Build the search pattern. Use a literal-X form to avoid pattern-detection
 # hitting the lint script itself.
-_pattern='mktemp[[:space:]]+(?!-[duqQ][[:space:]])[^|;&)`]*'
-_pattern+='X{6}\.[a-zA-Z]'
+_pattern='mktemp[[:space:]]+(?![^|;&)]*[[:space:]]-[a-zA-Z]*[duqQ][a-zA-Z]*\b)[^|;&)]*'
+_pattern+='X{6,}\.[a-zA-Z]'
 
 scan_file() {
 	local file="$1"


### PR DESCRIPTION

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.5 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-sonnet-4-6 spent 3m and 7,027 tokens on this as a headless worker.