### PR TITLE
GH#21426: split pulse-merge.sh — extract author-check helpers to sub-library

### DIFF
--- a/.agents/scripts/pulse-merge-author-checks.sh
+++ b/.agents/scripts/pulse-merge-author-checks.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# pulse-merge-author-checks.sh — PR Author Permission Helpers
+# =============================================================================
+# Author permission check helpers extracted from pulse-merge.sh (GH#21426)
+# to bring the parent file below the 2000-line file-size-debt threshold.
+#
+# Covers three focused helpers:
+#   - _is_collaborator_author      -- tests admin/maintain/write permission
+#   - _is_owner_or_member_author   -- stricter: admin/maintain only (t2411)
+#   - _check_interactive_pr_gates  -- draft + hold-for-review gate (t2411)
+#
+# Usage: source "${SCRIPT_DIR}/pulse-merge-author-checks.sh"
+#        (sourced by pulse-merge.sh immediately after shared-phase-filing.sh)
+#
+# Dependencies:
+#   - gh CLI (GitHub API calls)
+#   - LOGFILE variable (set by pulse-merge.sh module defaults or orchestrator)
+#
+# Part of aidevops framework: https://aidevops.sh
+
+# Apply strict mode only when executed directly (not when sourced)
+[[ "${BASH_SOURCE[0]}" == "${0}" ]] && set -euo pipefail
+
+# Include guard
+[[ -n "${_PULSE_MERGE_AUTHOR_CHECKS_LOADED:-}" ]] && return 0
+_PULSE_MERGE_AUTHOR_CHECKS_LOADED=1
+
+# Guard LOGFILE in case this sub-library is sourced standalone outside the
+# pulse-merge.sh orchestrator bootstrap.
+: "${LOGFILE:=${HOME}/.aidevops/logs/pulse.log}"
+
+#######################################
+# Check if a PR author is a collaborator (admin/maintain/write).
+# Args: $1=author login, $2=repo slug
+# Returns: 0=collaborator, 1=not collaborator or error
+#######################################
+_is_collaborator_author() {
+	local author="$1"
+	local repo_slug="$2"
+	local perm_url="repos/${repo_slug}/collaborators/${author}/permission"
+	local perm_response
+	perm_response=$(gh api -i "$perm_url" 2>/dev/null | head -1)
+	if [[ "$perm_response" == *"200"* ]]; then
+		local perm
+		perm=$(gh api "$perm_url" --jq '.permission' 2>/dev/null)
+		case "$perm" in
+		admin | maintain | write) return 0 ;;
+		esac
+	fi
+	return 1
+}
+
+#######################################
+# Check if a PR author is an OWNER or org MEMBER (admin or maintain level).
+# Stricter than _is_collaborator_author — does NOT accept write-only
+# collaborators (outside contributors). Used by the origin:interactive
+# auto-merge gate (t2411).
+# Args: $1=author login, $2=repo slug
+# Returns: 0=owner or member, 1=collaborator/not collaborator or error
+#######################################
+_is_owner_or_member_author() {
+	local author="$1"
+	local repo_slug="$2"
+	local perm_url="repos/${repo_slug}/collaborators/${author}/permission"
+	local perm_response
+	perm_response=$(gh api -i "$perm_url" 2>/dev/null | head -1)
+	if [[ "$perm_response" == *"200"* ]]; then
+		local perm
+		perm=$(gh api "$perm_url" --jq '.permission' 2>/dev/null)
+		case "$perm" in
+		admin | maintain) return 0 ;;
+		esac
+	fi
+	return 1
+}
+
+#######################################
+# Check origin:interactive-specific gates (t2411): draft status and the
+# hold-for-review opt-out label. Called from _check_pr_merge_gates when
+# the PR carries origin:interactive. These checks apply regardless of
+# author role — OWNER, MEMBER, and COLLABORATOR interactive PRs are all
+# subject to draft and hold-for-review blocking.
+#
+# Args: $1=pr_number, $2=repo_slug, $3=labels_str, $4=is_draft
+# Returns: 0=gates pass (continue to review bot gate), 1=blocked (skip PR)
+#######################################
+_check_interactive_pr_gates() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local labels_str="$3"
+	local is_draft="$4"
+
+	if [[ "$is_draft" == "true" ]]; then
+		echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — origin:interactive draft PR not eligible for auto-merge (t2411)" >>"$LOGFILE"
+		return 1
+	fi
+	if [[ ",${labels_str}," == *",hold-for-review,"* ]]; then
+		echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — origin:interactive PR has hold-for-review opt-out label (t2411)" >>"$LOGFILE"
+		return 1
+	fi
+	return 0
+}

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -54,9 +54,9 @@
 #   - _release_interactive_claim_on_merge  (t2413, extracted to shared-claim-lifecycle.sh in t2429)
 #   - _handle_post_merge_actions
 #   - _process_single_ready_pr
-#   - _is_collaborator_author
-#   - _is_owner_or_member_author
-#   - _check_interactive_pr_gates            (t2411)
+#   - _is_collaborator_author           (pulse-merge-author-checks.sh, GH#21426)
+#   - _is_owner_or_member_author        (pulse-merge-author-checks.sh, GH#21426)
+#   - _check_interactive_pr_gates       (pulse-merge-author-checks.sh, GH#21426, t2411)
 #   - _attempt_worker_briefed_auto_merge     (t2449)
 #   - _check_required_checks_passing         (t2922)
 #   - _extract_linked_issue
@@ -105,6 +105,12 @@ source "${_PULSE_MERGE_DIR}/shared-claim-lifecycle.sh"
 # from _handle_post_merge_actions to auto-file the next phase child issue
 # when a phase child PR merges for a parent-task issue.
 source "${_PULSE_MERGE_DIR}/shared-phase-filing.sh"
+
+# Source author permission check helpers (GH#21426 — extracted to bring
+# pulse-merge.sh below the 2000-line file-size-debt threshold).
+# shellcheck source=./pulse-merge-author-checks.sh
+# shellcheck disable=SC1091  # sub-library resolved at runtime via _PULSE_MERGE_DIR
+source "${_PULSE_MERGE_DIR}/pulse-merge-author-checks.sh"
 
 #######################################
 # Check and flag external-contributor PRs (t1391)
@@ -1630,78 +1636,6 @@ _process_single_ready_pr() {
 		echo "[pulse-wrapper] Deterministic merge: FAILED PR #${pr_number} in ${repo_slug}: ${merge_output}" >>"$LOGFILE"
 		return 3
 	fi
-}
-
-#######################################
-# Check if a PR author is a collaborator (admin/maintain/write).
-# Args: $1=author login, $2=repo slug
-# Returns: 0=collaborator, 1=not collaborator or error
-#######################################
-_is_collaborator_author() {
-	local author="$1"
-	local repo_slug="$2"
-	local perm_url="repos/${repo_slug}/collaborators/${author}/permission"
-	local perm_response
-	perm_response=$(gh api -i "$perm_url" 2>/dev/null | head -1)
-	if [[ "$perm_response" == *"200"* ]]; then
-		local perm
-		perm=$(gh api "$perm_url" --jq '.permission' 2>/dev/null)
-		case "$perm" in
-		admin | maintain | write) return 0 ;;
-		esac
-	fi
-	return 1
-}
-
-#######################################
-# Check if a PR author is an OWNER or org MEMBER (admin or maintain level).
-# Stricter than _is_collaborator_author — does NOT accept write-only
-# collaborators (outside contributors). Used by the origin:interactive
-# auto-merge gate (t2411).
-# Args: $1=author login, $2=repo slug
-# Returns: 0=owner or member, 1=collaborator/not collaborator or error
-#######################################
-_is_owner_or_member_author() {
-	local author="$1"
-	local repo_slug="$2"
-	local perm_url="repos/${repo_slug}/collaborators/${author}/permission"
-	local perm_response
-	perm_response=$(gh api -i "$perm_url" 2>/dev/null | head -1)
-	if [[ "$perm_response" == *"200"* ]]; then
-		local perm
-		perm=$(gh api "$perm_url" --jq '.permission' 2>/dev/null)
-		case "$perm" in
-		admin | maintain) return 0 ;;
-		esac
-	fi
-	return 1
-}
-
-#######################################
-# Check origin:interactive-specific gates (t2411): draft status and the
-# hold-for-review opt-out label. Called from _check_pr_merge_gates when
-# the PR carries origin:interactive. These checks apply regardless of
-# author role — OWNER, MEMBER, and COLLABORATOR interactive PRs are all
-# subject to draft and hold-for-review blocking.
-#
-# Args: $1=pr_number, $2=repo_slug, $3=labels_str, $4=is_draft
-# Returns: 0=gates pass (continue to review bot gate), 1=blocked (skip PR)
-#######################################
-_check_interactive_pr_gates() {
-	local pr_number="$1"
-	local repo_slug="$2"
-	local labels_str="$3"
-	local is_draft="$4"
-
-	if [[ "$is_draft" == "true" ]]; then
-		echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — origin:interactive draft PR not eligible for auto-merge (t2411)" >>"$LOGFILE"
-		return 1
-	fi
-	if [[ ",${labels_str}," == *",hold-for-review,"* ]]; then
-		echo "[pulse-wrapper] Merge pass: skipping PR #${pr_number} in ${repo_slug} — origin:interactive PR has hold-for-review opt-out label (t2411)" >>"$LOGFILE"
-		return 1
-	fi
-	return 0
 }
 
 #######################################

--- a/.agents/scripts/tests/test-pulse-merge-approve-collaborator-guard.sh
+++ b/.agents/scripts/tests/test-pulse-merge-approve-collaborator-guard.sh
@@ -34,6 +34,8 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 MERGE_SCRIPT="${SCRIPT_DIR}/../pulse-merge.sh"
+# _is_collaborator_author was extracted to pulse-merge-author-checks.sh (GH#21426)
+AUTHOR_CHECKS_SCRIPT="${SCRIPT_DIR}/../pulse-merge-author-checks.sh"
 
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
@@ -152,24 +154,26 @@ teardown_test_env() {
 	return 0
 }
 
-# Extract approve_collaborator_pr AND its dependency _is_collaborator_author
-# from pulse-merge.sh. Both are needed; the guard calls the helper.
+# Extract approve_collaborator_pr from pulse-merge.sh AND its dependency
+# _is_collaborator_author from pulse-merge-author-checks.sh (GH#21426 split).
+# Both are needed; the guard calls the helper.
 define_helpers_under_test() {
 	local approve_src
 	local collab_src
 	approve_src=$(awk '
 		/^approve_collaborator_pr\(\) \{/,/^}$/ { print }
 	' "$MERGE_SCRIPT")
+	# _is_collaborator_author was extracted to pulse-merge-author-checks.sh (GH#21426)
 	collab_src=$(awk '
 		/^_is_collaborator_author\(\) \{/,/^}$/ { print }
-	' "$MERGE_SCRIPT")
+	' "$AUTHOR_CHECKS_SCRIPT")
 
 	if [[ -z "$approve_src" ]]; then
 		printf 'ERROR: could not extract approve_collaborator_pr from %s\n' "$MERGE_SCRIPT" >&2
 		return 1
 	fi
 	if [[ -z "$collab_src" ]]; then
-		printf 'ERROR: could not extract _is_collaborator_author from %s\n' "$MERGE_SCRIPT" >&2
+		printf 'ERROR: could not extract _is_collaborator_author from %s\n' "$AUTHOR_CHECKS_SCRIPT" >&2
 		return 1
 	fi
 	# shellcheck disable=SC1090


### PR DESCRIPTION
## Summary

Split `pulse-merge.sh` (2028 lines) into 2 focused files so the orchestrator file is under the 2000-line file-size-debt threshold. Function groups move verbatim; no behavioural changes.

| file | lines | scope |
|---|---|---|
| `.agents/scripts/pulse-merge.sh` | 1962 | thin orchestrator: PR gates + merge — sources sub-library |
| `.agents/scripts/pulse-merge-author-checks.sh` | 105 | author permission helpers: `_is_collaborator_author`, `_is_owner_or_member_author`, `_check_interactive_pr_gates` |

Mirrors the `pulse-merge.sh` / `shared-claim-lifecycle.sh` and `shared-phase-filing.sh` split precedent. The sub-library has an include guard, a `LOGFILE` fallback, and a `# shellcheck source=./...` directive paired with an SC1091 disable (runtime-resolved via `_PULSE_MERGE_DIR`, cannot be statically followed without `-x`).

## Changes

1. **New sub-library** `pulse-merge-author-checks.sh` — 3 author/permission check helpers extracted from `pulse-merge.sh`.
2. **Source call added** to `pulse-merge.sh` after the existing `shared-phase-filing.sh` source, using `_PULSE_MERGE_DIR` (consistent with existing source calls in this module).
3. **LOGFILE fallback** in sub-library guards standalone sourcing (same pattern as `pulse-merge.sh:79`).
4. **`_check_interactive_pr_gates` stays caller-compatible** — function signature and log messages unchanged, no callers need updating.

## Testing

- `shellcheck .agents/scripts/pulse-merge.sh .agents/scripts/pulse-merge-author-checks.sh` — clean (zero warnings/errors)
- Smoke test via direct source: all 3 functions resolve and `type` confirms correct definitions
- `wc -l .agents/scripts/pulse-merge.sh` → 1962 (was 2028, threshold is 2000)

## Complexity Bump Justification

No complexity-bump-ok label needed for this split — the extracted functions are all well under the 100-line `function-complexity` threshold (largest is `_check_interactive_pr_gates` at 16 lines), so no new `(file, fname)` violations are introduced. The nesting-depth scanner (GH#20105) now uses shfmt AST walking with per-function reset, eliminating the identity-key false positives that previously required the label on file splits.

## Related

Resolves #21426
Reference: `reference/large-file-split.md`
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.5 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-sonnet-4-6 spent 6m and 16,315 tokens on this as a headless worker.
