### PR TITLE
GH#21442: fix jq null-safety and stderr suppression in dispatch-single-issue-helper

### DIFF
--- a/.agents/scripts/dispatch-single-issue-helper.sh
+++ b/.agents/scripts/dispatch-single-issue-helper.sh
@@ -309,7 +309,7 @@ _dsi_apply_dispatch_ceremony() {
 	while IFS= read -r _prev_login; do
 		[[ -n "$_prev_login" && "$_prev_login" != "$self_login" ]] \
 			&& _extra_flags+=(--remove-assignee "$_prev_login")
-	done < <(printf '%s' "$issue_meta_json" | jq -r '.assignees[].login' 2>/dev/null)
+	done < <(printf '%s' "$issue_meta_json" | jq -r '.assignees[].login // ""')
 
 	if ! set_issue_status "$issue_number" "$repo_slug" "queued" "${_extra_flags[@]}" >/dev/null 2>&1; then
 		_dsi_warn "Dispatch ceremony failed (non-fatal — worker will still launch; fix labels manually if needed)"


### PR DESCRIPTION
## Summary

Applied gemini-code-assist review suggestion from PR #21430:
- Replaced `jq -r '.assignees[].login' 2>/dev/null` with `jq -r '.assignees[].login // ""'`

## Changes

**`.agents/scripts/dispatch-single-issue-helper.sh:312`**

- Added `// ""` jq fallback operator so null `login` values produce an empty string rather than the literal `"null"`. The existing `[[ -n "$_prev_login" ]]` guard already handles empty strings correctly.
- Removed `2>/dev/null` stderr suppression so real jq syntax errors and system errors remain visible for debugging.

## Verification

```bash
shellcheck .agents/scripts/dispatch-single-issue-helper.sh
```

Passes with zero violations.

Resolves #21442

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.5 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-sonnet-4-6 spent 2m and 4,074 tokens on this as a headless worker.