### PR TITLE
GH#21443: fix dispatch-ledger stale-lock infinite-loop and _now_epoch consistency

### DIFF
--- a/.agents/scripts/dispatch-ledger-helper.sh
+++ b/.agents/scripts/dispatch-ledger-helper.sh
@@ -78,7 +78,7 @@ _lock_dir_age() {
 		echo "0"
 		return 0
 	fi
-	now=$(date -u '+%s')
+	now=$(_now_epoch)
 	echo "$((now - mtime))"
 	return 0
 }
@@ -127,22 +127,27 @@ _ledger_lock_is_stale() {
 		lock_age=$(_lock_dir_age "$lock_dir")
 		if [[ "$lock_age" -gt "$max_age" ]]; then
 			rm -rf "$lock_dir" 2>/dev/null || true
-			return 0
+			# Only return 0 if the directory was actually removed — if rm -rf
+			# failed silently the caller would loop indefinitely via `continue`.
+			[[ ! -d "$lock_dir" ]] && return 0
 		fi
 		return 1
 	fi
 
 	# Tier 2: owner PID is dead → stale (SIGKILL, OOM, crash)
-	if ! ps -p "$lock_pid" >/dev/null 2>&1; then
+	# Use kill -0 for consistency with cmd_check/cmd_check_issue/cmd_expire.
+	if ! kill -0 "$lock_pid" 2>/dev/null; then
 		rm -rf "$lock_dir" 2>/dev/null || true
-		return 0
+		[[ ! -d "$lock_dir" ]] && return 0
+		return 1
 	fi
 
 	# Tier 3: owner alive but lock too old → hung holder, steal lock
 	lock_age=$(_lock_dir_age "$lock_dir")
 	if [[ "$lock_age" -gt "$max_age" ]]; then
 		rm -rf "$lock_dir" 2>/dev/null || true
-		return 0
+		[[ ! -d "$lock_dir" ]] && return 0
+		return 1
 	fi
 
 	return 1


### PR DESCRIPTION
## Summary

Follow-up to #21428 (t2999: dispatch-ledger stale-lock recovery), addressing two unresolved Gemini review suggestions.

### Fix 1 — `_lock_dir_age`: use `_now_epoch` helper (consistency)

`_lock_dir_age` called `date -u '+%s'` directly instead of the `_now_epoch` helper already defined at line 231. Other epoch callers (`cmd_expire`, `cmd_prune`) use `_now_epoch`. This change makes `_lock_dir_age` consistent.

### Fix 2 — `_ledger_lock_is_stale`: guard `rm -rf` with existence check before `return 0`

All three stale-detection tiers did:
```bash
rm -rf "$lock_dir" 2>/dev/null || true
return 0
```

The `|| true` swallows `rm -rf` failures silently. If removal fails, the function returns 0 (stale/cleared), the `_acquire_lock` loop hits `continue` (retry mkdir immediately), `mkdir` fails again on the still-present lockdir, the function returns 0 again — infinite loop.

Fix: verify the directory is actually gone before returning 0. Applied to all three tiers.

Also replaced `ps -p "$lock_pid"` in Tier 2 with `kill -0 "$lock_pid"` to match the pattern already used in `cmd_check` (line 402), `cmd_check_issue` (line 476), and `cmd_expire` (line 804).

## Verification

- `shellcheck .agents/scripts/dispatch-ledger-helper.sh` — clean
- Pre-commit hooks passed

Resolves #21443

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.5 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-sonnet-4-6 spent 3m and 6,729 tokens on this as a headless worker.