### PR TITLE
t3006: add capture-don't-advise + turn-end brevity + proactive memory rules

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -82,6 +82,7 @@ Every prompt, issue body, PR description, comment, and brief you write is mentor
 - Minimize tokens. Match detail to query complexity. If 1-3 sentences suffice, stop there.
 - NO preamble/postamble. Avoid: "The answer is...", "Here is the content of...", "Based on the information provided...", "Here is what I will do next...". Answer directly.
 - Verbosity calibration: "2+2"→"4"; "is 11 prime?"→"Yes"; "what command lists files?"→"ls". Brevity proportional to question. Complex analysis deserves detail; trivia deserves a word.
+- Turn-end brevity (t3006 — MANDATORY): status/progress turn-ends ≤ 200 words. Use bare markdown links for actionable items: `[#NNN](url) BLOCKED` not paragraph explanations. Group by action — **Done**, **In-flight**, **User-action** — not narrative. The user clicks links to see detail; you don't write detail in chat. User attention is finite; long turn-ends train them to skim or stop reading. If turn-end > 200 words: cut.
 
 ### Professional objectivity
 
@@ -123,6 +124,17 @@ You do the thinking. User gets your recommendation with reasoning — not a menu
   - Action is destructive/irreversible, touches production, or changes billing/security posture.
   - You need a secret/credential/value that cannot be inferred.
 - Never ask permission ("Should I proceed?", "Do you want me to run tests?"). Proceed with the most reasonable option, mention what you did.
+
+### Capture-don't-advise (t3006 — MANDATORY)
+
+When you identify a fixable issue (bug, gap, improvement, framework debt, recurring failure mode) during any session, file it as an auto-dispatch task IMMEDIATELY — DO NOT just describe it to the user.
+
+- File: `claim-task-id.sh --title "<desc>" --description "<worker-ready body per t1900>" --labels "auto-dispatch,tier:standard,bug"`. Worker pipeline picks it up.
+- Tell the user ONE LINE: `Filed as #NNN`. Link, no paragraph.
+- Anti-pattern — "the advisory trap": listing N framework bugs in turn-end prose without filing them. The user is busy; the framework has dispatch capacity. Use it. The user has explicitly stated this trap costs them attention they cannot spare.
+- Applies to: framework bugs, perf issues, missing tests, missing docs, bot review followups, dispatch-path debt, ANY worker-dispatchable task.
+- Exception — genuinely architecture/policy decisions that need maintainer input (not auto-dispatchable): say so explicitly with one sentence, ask one specific yes/no question, don't pretend it's the only option.
+- Self-improvement reinforcement: if you spend more than ~50 words describing a problem in turn-end prose, that's a signal to stop and FILE IT instead. Capture-then-route, not capture-then-narrate.
 
 ### Worker triage responsibility (GH#18538)
 
@@ -188,6 +200,7 @@ Cross-session lessons are invisible unless queried — a session that skips reca
 - This recall is independent from the t2046 git/gh discovery pass. Run BOTH. Git tells you about in-flight code; memory tells you about accumulated lessons. They are complementary, not overlapping.
 - Exception: purely conversational exchanges (greetings, status questions, "what does this do") do not require a recall. Any exchange that will result in a file edit, a git operation, a gh command with side effects, or a non-trivial recommendation DOES require one.
 - Store new lessons at the end of any session that produced one. Use `memory-helper.sh store --content "<lesson>" --confidence high|medium|low` for hard-won insights, medium for likely-general patterns, low for speculative. The store call is cheap; omitting it wastes the lesson.
+- **Proactive storage (t3006 — MANDATORY)**: store IMMEDIATELY after any breakthrough, unexpected discovery, or recovery action — DO NOT wait for session end. Context compaction can wipe an unstored lesson, and long-running sessions are the ones most likely to produce lessons AND most likely to compact. Store-while-fresh triggers: framework bug + workaround pair, race condition discovery, API limit hit + recovery pattern, dispatch-path fix, surprising failure mode, any insight you'd want a future session to find via a 1-query recall. Cost is one helper call (seconds). Skipping wastes the lesson and trains future sessions to repeat the same mistake.
 
 ### Claim discipline (turn-end gate)
 


### PR DESCRIPTION
## Summary

Three new framework rules added to `.agents/AGENTS.md` to address recurring AI-session failure modes observed in t3005 session.

## Rules

| Rule | Section | Trigger | Action |
|------|---------|---------|--------|
| **Turn-end brevity** | Tone and style | status/progress turn-ends | ≤200 words, links over prose, group by action |
| **Capture-don't-advise** | Reasoning responsibility | identified fixable issue | file as auto-dispatch, tell user one line |
| **Proactive memory storage** | Memory recall | breakthrough/discovery | `memory-helper.sh store` immediately, not session-end |

## Why now

User feedback (Apr 28 2026):

> "you have a habit of telling me things that need doing, but not utilising the todo & issues pipeline to set the fixes in motion"
> "the amount for human reading at each ai turn end, it's a lot... maybe it could be more succinct, and give links"
> "preserving human attention (finite, fallible) and making sure ai takes on the things it knows and has proven it can fix"

Concrete failure modes observed in same session:
- 4 framework bugs identified but not filed as issues (just listed in turn-end prose) — would have been lost without explicit user prompting
- Multiple 600+ word turn-ends with paragraph explanations the user could have clicked links for
- Lessons stored only at end of session — would have been lost if context compacted mid-stream

## Verification

```bash
grep -c "Turn-end brevity (t3006" .agents/AGENTS.md      # 1
grep -c "Capture-don't-advise (t3006" .agents/AGENTS.md  # 1
grep -c "Proactive storage (t3006"  .agents/AGENTS.md    # 1
```

No new markdownlint errors introduced (4 pre-existing errors at lines 420, 504, 505, 714 unrelated to this PR).

Resolves #21472

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.5 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-opus-4-7 spent 1d 2h and 92,783 tokens on this with the user in an interactive session.
