### PR TITLE
GH#21445: fix lint-mktemp-portability safe array fill and combined-flag lookahead

### DIFF
--- a/.agents/scripts/lint-mktemp-portability.sh
+++ b/.agents/scripts/lint-mktemp-portability.sh
@@ -32,7 +32,7 @@
 #   --no-exit-code  always exit 0 (advisory mode)
 #   --help          show this help
 #
-# With no FILES: scans all git-tracked .sh files via `git ls-files '*.sh'`.
+# With no FILES: scans all git-tracked .sh, .bash, and .zsh files.
 #
 # Output format: file:line: <offending mktemp template>
 # Exit codes: 0=clean, 1=violations found
@@ -141,8 +141,8 @@ if [[ ${#TARGET_FILES[@]} -eq 0 ]]; then
 		printf 'mktemp-portability: git not found and no FILES given\n' >&2
 		exit 2
 	fi
-	# shellcheck disable=SC2207
-	TARGET_FILES=($(git ls-files '*.sh' 2>/dev/null || true))
+	while IFS= read -r _f; do TARGET_FILES+=("$_f"); done \
+		< <(git ls-files '*.sh' '*.bash' '*.zsh' 2>/dev/null || true)
 fi
 
 if [[ ${#TARGET_FILES[@]} -eq 0 ]]; then
@@ -155,7 +155,8 @@ fi
 # ---------------------------------------------------------------------------
 # The detection regex:
 #   - mktemp                 — the command
-#   - (?!\s+-[duqQ]\b)       — NOT followed by -d / -u / -q / -Q (file-form only)
+#   - (?!-[a-zA-Z]*[duqQ][a-zA-Z]*[[:space:]]) — NOT if first flag contains
+#                              d/u/q/Q (handles combined flags like -dq, -qu).
 #                              NOTE: -t (template prefix) is fine — its template
 #                              still goes through the same X-placement rule.
 #   - .*X{6,}\.[a-zA-Z]      — XXXXXX (or more) followed by `.<letter>` extension
@@ -170,8 +171,8 @@ violation_lines=()
 
 # Build the search pattern. Use a literal-X form to avoid pattern-detection
 # hitting the lint script itself.
-_pattern='mktemp[[:space:]]+(?!-[duqQ][[:space:]])[^|;&)`]*'
-_pattern+='X{6}\.[a-zA-Z]'
+_pattern='mktemp[[:space:]]+(?!-[a-zA-Z]*[duqQ][a-zA-Z]*[[:space:]])[^|;&)`]*'
+_pattern+='X{6,}\.[a-zA-Z]'
 
 scan_file() {
 	local file="$1"


### PR DESCRIPTION
Two Gemini bot suggestions from PR #21421 — both premises verified against the code before acting.

## Changes

### 1. Safe file discovery + extended extensions (line 145)

**Premise verified:** `TARGET_FILES=($(git ls-files '*.sh'))` at line 145 had two real bugs:
- Word splitting: `$()` inside an unquoted array expands on whitespace, corrupting filenames with spaces.
- Incomplete coverage: `scan_file()` (lines 182–183) accepts `.sh`, `.bash`, and `.zsh`, but the default discovery only fetched `*.sh`.

**Fix:** replaced the SC2207-suppressed assignment with a `while IFS= read -r` process-substitution loop and extended the glob to include `*.bash` and `*.zsh`.

### 2. Combined-flag regex lookahead (lines 173–174)

**Premise verified:** `(?!-[duqQ][[:space:]])` only excluded single-letter flags separated by exactly one space. The pattern would **false-positive** on `mktemp -dq XXXXXX.ext` (combined flags) because `q` following `d` is not `[[:space:]]`, so the negative lookahead did not fire.

**Fix:** widened to `(?!-[a-zA-Z]*[duqQ][a-zA-Z]*[[:space:]])` so any leading flag that contains `d`, `u`, `q`, or `Q` anywhere in its letter sequence is correctly excluded. Also tightened `X{6}` to `X{6,}` for robustness.

Both concerns are correctness bugs in the linter (false negatives / false positives), not additive scope.

## Verification

```
shellcheck .agents/scripts/lint-mktemp-portability.sh  # zero violations
```

Resolves #21445

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.5 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-sonnet-4-6 spent 5m and 13,227 tokens on this as a headless worker.
