### PR TITLE
t3010: fix: pre-jitter fast-fail to prevent launchd-respawn pile-up

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -129,6 +129,44 @@ else
 	done
 	unset _pulse_arg
 fi
+
+# GH#21471: Pre-jitter fast-fail (t3010).
+# If another pulse instance holds the lock, exit 0 BEFORE sleeping the
+# jitter. Prevents launchd-respawn pile-up when cycles exceed StartInterval:
+# each new instance was sleeping 0-30s of jitter before the is-running
+# check in main(), causing 5+ queued instances during long cycles.
+# Uses hardcoded paths — pulse-wrapper-config.sh is not yet sourced here.
+# Biased toward false negatives: if PID file is absent, stat fails, or the
+# holder exceeds the max-age ceiling, fall through to main() where
+# acquire_instance_lock handles stale-lock reclaim properly.
+if [[ "$_pulse_skip_jitter" -eq 0 ]]; then
+	_pw_ffjit_lockdir="${HOME}/.aidevops/logs/pulse-wrapper.lockdir"
+	_pw_ffjit_pid_file="${_pw_ffjit_lockdir}/pid"
+	if [[ -f "$_pw_ffjit_pid_file" ]]; then
+		_pw_ffjit_pid=$(cat "$_pw_ffjit_pid_file" 2>/dev/null || true)
+		if [[ "$_pw_ffjit_pid" =~ ^[0-9]+$ ]] && kill -0 "$_pw_ffjit_pid" 2>/dev/null; then
+			# Age check mirrors main()'s is-running short-circuit (t2829).
+			# Use lockdir mtime as lock-acquired timestamp (mkdir is atomic).
+			# BSD stat (macOS): -f '%m'; GNU stat (Linux): -c '%Y'.
+			_pw_ffjit_mtime=$(stat -f '%m' "$_pw_ffjit_lockdir" 2>/dev/null \
+				|| stat -c '%Y' "$_pw_ffjit_lockdir" 2>/dev/null \
+				|| echo "0")
+			_pw_ffjit_now=$(date +%s)
+			[[ "$_pw_ffjit_mtime" =~ ^[0-9]+$ ]] || _pw_ffjit_mtime=0
+			_pw_ffjit_age=$(( _pw_ffjit_now - _pw_ffjit_mtime ))
+			if [[ "$_pw_ffjit_age" -le "${PULSE_LOCK_MAX_AGE_S:-1800}" ]]; then
+				printf '[pulse-wrapper] another instance running (PID %s, age %ss), skipping\n' \
+					"$_pw_ffjit_pid" "$_pw_ffjit_age" \
+					>>"${HOME}/.aidevops/logs/pulse-wrapper.log" 2>/dev/null || true
+				exit 0
+			fi
+			# Holder exceeds age ceiling — fall through to main() for stale-lock reclaim.
+		fi
+	fi
+	unset _pw_ffjit_lockdir _pw_ffjit_pid_file _pw_ffjit_pid \
+		_pw_ffjit_mtime _pw_ffjit_now _pw_ffjit_age
+fi
+
 if [[ "$_pulse_skip_jitter" -eq 0 && "$PULSE_JITTER_MAX" =~ ^[0-9]+$ && "$PULSE_JITTER_MAX" -gt 0 ]]; then
 	# $RANDOM is 0-32767; modulo gives 0 to PULSE_JITTER_MAX
 	jitter_seconds=$((RANDOM % (PULSE_JITTER_MAX + 1)))


### PR DESCRIPTION
## What

Add a pre-jitter fast-fail check at the top-level of `pulse-wrapper.sh` that exits 0 immediately when another pulse instance holds the lock — before the 0-30s jitter sleep is entered.

## Why

With `StartInterval=120s` and cycles taking 9-12 min, launchd fires new instances every 120s while the cycle is still running. Each arriving instance was sleeping the full jitter window (0-30s) before reaching the is-running check in `main()`. This caused observed pile-ups of 5+ queued instances (as reported in t3005 session: lock holder PID 41356 at 6:47 uptime, 5 instances queued at 0-37s uptime).

Root cause: the is-running short-circuit (GH#20611) is inside `main()`, but the jitter is top-level code that runs *before* `main()` is called. `pulse-wrapper-config.sh` (which defines `LOCKDIR`) is also not yet sourced at jitter time.

## How

New block at lines 133-168 (before the jitter sleep at line 170):

1. Reads `${HOME}/.aidevops/logs/pulse-wrapper.lockdir/pid` (hardcoded path matching `pulse-wrapper-config.sh`'s `LOCKDIR` definition)
2. If PID exists, is numeric, and `kill -0` confirms it's alive:
   - Gets lockdir mtime as proxy for lock-acquisition time (BSD stat / GNU stat fallback)
   - If age <= `PULSE_LOCK_MAX_AGE_S` (default 1800s): logs to `pulse-wrapper.log` and `exit 0`
   - If age > ceiling: falls through (main() handles stale-lock reclaim via `_handle_existing_lock`)
3. All uncertain cases (no PID file, stat failure, non-numeric mtime) fall through — biased toward false negatives exactly like the existing is-running check

The existing is-running check in `main()` and `acquire_instance_lock` are unchanged — they remain the authoritative serialization logic.

## Files Changed

- `EDIT: .agents/scripts/pulse-wrapper.sh:131-177` — 38 lines added

## Verification

```bash
# ShellCheck clean:
shellcheck .agents/scripts/pulse-wrapper.sh

# After deploy, monitor for 30 min:
~/.aidevops/agents/scripts/pulse-lifecycle-helper.sh status | grep -E "running \([0-9]+ instance"
# Expect: always 1 instance, never multiple
```

Resolves #21471

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.5 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-sonnet-4-6 spent 13m and 26,642 tokens on this as a headless worker.
