### PR TITLE
t3009: add per-substage timing to slow preflight stages

### DIFF
--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -1574,26 +1574,46 @@ _preflight_cleanup_and_ledger() {
 # and priority allocations are current.
 #######################################
 _preflight_capacity_and_labels() {
+	# GH#21470: per-substage timing so slow callers are identifiable in
+	# pulse-stage-timings.log. Each _log_substage_timing call writes one TSV
+	# record with the same format as run_stage_with_timeout outer records.
+	local _ss0=$SECONDS
 	calculate_max_workers
+	_log_substage_timing "substage:cap_labels/calculate_max_workers" "$_ss0" 0
+
+	local _ss1=$SECONDS
 	calculate_priority_allocations
+	_log_substage_timing "substage:cap_labels/calculate_priority_allocations" "$_ss1" 0
+
+	local _ss2=$SECONDS
 	local _session_ct
 	_session_ct=$(check_session_count)
 	if [[ "${_session_ct:-0}" -gt "$SESSION_COUNT_WARN" ]]; then
 		echo "[pulse-wrapper] Session warning: $_session_ct interactive sessions open (threshold: $SESSION_COUNT_WARN). Each consumes 100-440MB + language servers. Consider closing unused tabs." >>"$LOGFILE"
 	fi
+	_log_substage_timing "substage:cap_labels/check_session_count" "$_ss2" 0
 
 	# Re-evaluate needs-consolidation labels before dispatch. Issues labeled
 	# by an earlier (less precise) filter may no longer trigger under the
 	# current filter. Auto-clearing here makes them dispatchable immediately
 	# instead of stuck forever behind a label that list_dispatchable_issue_candidates_json
 	# filters out (needs-* exclusion at line 6703).
+	local _ss3=$SECONDS
 	_reevaluate_consolidation_labels
+	_log_substage_timing "substage:cap_labels/reevaluate_consolidation_labels" "$_ss3" 0
+
 	# t1982: Backfill pass for stuck needs-consolidation issues that never
 	# got a consolidation-task child created (pre-t1982 dispatches just
 	# labelled and returned). Dispatches a child retroactively so the
 	# parent can actually be consolidated instead of sitting forever.
+	local _ss4=$SECONDS
 	_backfill_stale_consolidation_labels
+	_log_substage_timing "substage:cap_labels/backfill_consolidation_labels" "$_ss4" 0
+
+	local _ss5=$SECONDS
 	_reevaluate_simplification_labels
+	_log_substage_timing "substage:cap_labels/reevaluate_simplification_labels" "$_ss5" 0
+
 	return 0
 }
 
@@ -1634,8 +1654,13 @@ _preflight_early_dispatch() {
 # stuck states, and auto-approves maintainer-created issues.
 #######################################
 _preflight_ownership_reconcile() {
+	# GH#21470: per-substage timing for the unwrapped prefetch_contribution_watch
+	# call. The three run_stage_with_timeout calls below are already individually
+	# timed by that wrapper; prefetch_contribution_watch was the blind spot.
+	local _ss0=$SECONDS
 	# Contribution watch: lightweight scan of external issues/PRs (t1419).
 	prefetch_contribution_watch
+	_log_substage_timing "substage:ownership_reconcile/prefetch_contribution_watch" "$_ss0" 0
 
 	# Ensure active labels reflect ownership to prevent multi-worker overlap.
 	run_stage_with_timeout "normalize_active_issue_assignments" "$PRE_RUN_STAGE_TIMEOUT" normalize_active_issue_assignments || true

--- a/.agents/scripts/pulse-issue-reconcile.sh
+++ b/.agents/scripts/pulse-issue-reconcile.sh
@@ -1508,6 +1508,11 @@ reconcile_issues_single_pass() {
 
 	while IFS= read -r slug; do
 		[[ -n "$slug" ]] || continue
+		# GH#21470: per-slug timing so slow repos are identifiable in the
+		# substage timing log. The _log_substage_timing helper (pulse-watchdog.sh)
+		# writes to PULSE_STAGE_TIMINGS_LOG with the same TSV format as outer
+		# run_stage_with_timeout records.
+		local _slug_start=$SECONDS
 
 		# t2984: per-slug budget gate (cheap — runs once per repo, ~8 times/cycle)
 		if [[ "$_t2984_budget" -gt 0 ]] && [[ "$_t2984_start_ts" -gt 0 ]]; then
@@ -1684,6 +1689,10 @@ reconcile_issues_single_pass() {
 				fi
 			fi
 		done <<< "$issues_tsv"
+		# GH#21470: log per-repo elapsed time so slow slugs are identifiable.
+		# Slash in slug would break log parsing; replace with underscore.
+		local _slug_safe="${slug//\//_}"
+		_log_substage_timing "substage:reconcile_sp/repo:${_slug_safe}" "$_slug_start" 0
 	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | .slug // ""' "$repos_json" || true)
 
 	# t2838: persist last-run epoch when backfill actually ran this cycle.

--- a/.agents/scripts/pulse-watchdog.sh
+++ b/.agents/scripts/pulse-watchdog.sh
@@ -255,6 +255,42 @@ run_stage_with_timeout() {
 }
 
 #######################################
+# Log per-substage timing to PULSE_STAGE_TIMINGS_LOG and LOGFILE. (GH#21470)
+#
+# Used inside functions that run under run_stage_with_timeout (i.e. in a
+# backgrounded subshell). Captures the elapsed time between a $SECONDS
+# snapshot taken before the substage call and the current $SECONDS value.
+#
+# Usage:
+#   local _ss0=$SECONDS
+#   some_function
+#   _log_substage_timing "substage:parent_name/substage_name" "$_ss0" "$?"
+#
+# Writes the same TSV format as run_stage_with_timeout so both outer stage
+# and substage records land in one log and can be analysed uniformly:
+#   ISO-timestamp <TAB> stage_name <TAB> duration_s <TAB> exit_code <TAB> pid
+#
+# Returns: 0 (always — never fails the caller)
+#######################################
+_log_substage_timing() {
+	local substage_name="$1"
+	local start_secs="${2:-0}"
+	local exit_code="${3:-0}"
+	local duration=$(( SECONDS - start_secs ))
+	[[ "$duration" =~ ^[0-9]+$ ]] || duration=0
+	echo "[pulse-wrapper] Substage: ${substage_name} (${exit_code}, ${duration}s)" >>"${LOGFILE:-/dev/null}"
+	if [[ -n "${PULSE_STAGE_TIMINGS_LOG:-}" ]]; then
+		printf '%s\t%s\t%d\t%d\t%d\n' \
+			"$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+			"$substage_name" \
+			"$duration" \
+			"$exit_code" \
+			"$$" >>"$PULSE_STAGE_TIMINGS_LOG" 2>/dev/null || true
+	fi
+	return 0
+}
+
+#######################################
 # Run the pulse — with internal watchdog timeout (t1397, t1398, t1398.3, GH#2958)
 #
 # The pulse runs until opencode exits naturally. A watchdog loop checks


### PR DESCRIPTION
## Summary

Phase 1 of GH#21470: add per-substage SECONDS-based timing to the three preflight stages that dominate pulse cycle time (`preflight_capacity_and_labels=204s`, `preflight_ownership_reconcile=535s`, `reconcile_issues_single_pass=368s`).

## What

- **`pulse-watchdog.sh`**: New `_log_substage_timing()` helper — writes the same TSV format (`ISO-timestamp 	 stage_name 	 duration_s 	 exit_code 	 pid`) as `run_stage_with_timeout` to `PULSE_STAGE_TIMINGS_LOG` so substage records land in the same file and are analysable with existing tools.

- **`pulse-dispatch-engine.sh`**: Instruments `_preflight_capacity_and_labels` (6 substages: `calculate_max_workers`, `calculate_priority_allocations`, `check_session_count`, `reevaluate_consolidation_labels`, `backfill_consolidation_labels`, `reevaluate_simplification_labels`) and `_preflight_ownership_reconcile` (1 substage: `prefetch_contribution_watch` — the only call not already wrapped in `run_stage_with_timeout`).

- **`pulse-issue-reconcile.sh`**: Adds per-slug wall-time in `reconcile_issues_single_pass` outer `while` loop so slow repos are identifiable by `owner_repo` slug name.

## Verification

After the next pulse cycle, substage records appear in `~/.aidevops/logs/pulse-stage-timings.log`:

```bash
# Which substage of _preflight_capacity_and_labels is slow?
grep 'substage:cap_labels' ~/.aidevops/logs/pulse-stage-timings.log | awk -F'	' '{print $2, $3"s"}' | sort -k2 -rn | head -10

# Which repos dominate reconcile_issues_single_pass?
grep 'substage:reconcile_sp' ~/.aidevops/logs/pulse-stage-timings.log | awk -F'	' '{print $2, $3"s"}' | sort -k2 -rn | head -10
```

Acceptance criterion 1 from the issue: "Per-substage timing visible in `~/.aidevops/logs/pulse-stage-timings.log`" — satisfied.

## Complexity

- `_preflight_capacity_and_labels`: 22 lines → 43 lines (under 100-line gate)
- `_preflight_ownership_reconcile`: 18 lines → 23 lines (under 100-line gate)
- `reconcile_issues_single_pass`: pre-existing 310-line function, +9 lines — no new violation introduced (ratchet gate)

Resolves #21470

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.5 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-sonnet-4-6 spent 14m and 20,828 tokens on this as a headless worker.
