### PR TITLE
GH#21496: fix: pass technology via env var to prevent Python command injection

### DIFF
--- a/.agents/scripts/tech-stack-bq-lib.sh
+++ b/.agents/scripts/tech-stack-bq-lib.sh
@@ -574,7 +574,7 @@ builtwith_reverse_lookup() {
 	print_info "Querying BuiltWith API for: $technology"
 
 	local encoded_tech
-	encoded_tech=$(python3 -c "import urllib.parse; print(urllib.parse.quote('$technology'))" 2>/dev/null || echo "$technology")
+	encoded_tech=$(TECH="$technology" python3 -c "import urllib.parse, os; print(urllib.parse.quote(os.environ.get('TECH', '')))" 2>/dev/null || echo "$technology")
 
 	local result curl_stderr
 	curl_stderr=$(mktemp)


### PR DESCRIPTION
## Summary

Fixed command injection vulnerability in tech-stack-bq-lib.sh:577. The $technology variable was being expanded directly into a Python script string, allowing injection if a technology name contained a single quote followed by Python code. Now passes the value via environment variable (TECH=$technology python3 -c '... os.environ.get("TECH", "") ...') which is safe regardless of the value's content.

## Files Changed

.agents/scripts/tech-stack-bq-lib.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tech-stack-bq-lib.sh — passes clean (0 violations). Verified fix at line 577 matches the suggested pattern from the Gemini review.

Resolves #21496


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.5 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-sonnet-4-6 spent 1m and 1,591 tokens on this as a headless worker.