### PR TITLE
GH#21509: fix slug dedup false-negative and basename escape subprocess forks in privacy-guard-helper

### DIFF
--- a/.agents/scripts/privacy-guard-helper.sh
+++ b/.agents/scripts/privacy-guard-helper.sh
@@ -320,9 +320,12 @@ privacy_scan_text() {
 		[[ -z "$basename" ]] && continue
 
 		# If the full slug was already matched in Phase 1, skip to avoid duplicate output.
-		if [[ -n "$owner" && -n "$matched_full_slugs" ]] &&
-			printf '%s\n' "$matched_full_slugs" | grep -qF "$slug" 2>/dev/null; then
-			continue
+		# Use native Bash pattern match with newline padding for exact line matching —
+		# grep -qF would substring-match (e.g. "org/repo" matches "myorg/repo").
+		if [[ -n "$owner" && -n "$matched_full_slugs" ]]; then
+			if [[ $'\n'"${matched_full_slugs}"$'\n' == *$'\n'"${slug}"$'\n'* ]]; then
+				continue
+			fi
 		fi
 
 		# Form 2: bare basename with word boundaries — only for distinctive lengths.
@@ -330,7 +333,7 @@ privacy_scan_text() {
 			# Escape regex metacharacters in basename for ERE. GitHub repo names can
 			# contain '.' (e.g. "my.project"), which is a special char in ERE —
 			# escaping prevents false positives from matching unintended characters.
-			escaped_basename=$(printf '%s' "$basename" | sed 's/\./\\./g')
+			escaped_basename="${basename//./\\.}"
 			# Word boundary regex: must NOT be flanked by [a-zA-Z0-9_-].
 			# Note: we use grep -E (POSIX ERE), not PCRE, so \b is unreliable.
 			if printf '%s' "$text" | grep -qE "(^|[^a-zA-Z0-9_-])${escaped_basename}([^a-zA-Z0-9_-]|$)" 2>/dev/null; then


### PR DESCRIPTION
## Summary

Two correctness and performance fixes to `privacy_scan_text()` in `.agents/scripts/privacy-guard-helper.sh`, both flagged by Gemini review on PR #21367.

### Fix 1 — HIGH: Exact slug dedup match (lines 322-326)

**Problem:** The Phase 1 → Phase 2 dedup skip used `grep -qF "$slug"` on `$matched_full_slugs`, which does substring matching. A slug like `org/repo` would match against `myorg/repo` in the list, incorrectly suppressing Phase 2 output for `org/repo`.

**Fix:** Replace the `printf | grep -qF` pipeline with a native Bash newline-padded pattern match:
```bash
if [[ $'\n'"${matched_full_slugs}"$'\n' == *$'\n'"${slug}"$'\n'* ]]; then
```
Pads both haystack and needle with `$'\n'` so the `*` globs match full lines only. No subprocess fork; exact line match.

### Fix 2 — MEDIUM: Avoid subprocess fork for dot-escaping (line 333)

**Problem:** `escaped_basename=$(printf '%s' "$basename" | sed 's/\./\\./g')` spawns two processes per slug iteration.

**Fix:** Pure Bash parameter expansion:
```bash
escaped_basename="${basename//./\\.}"
```
Equivalent semantics; no subshell cost.

## Verification

- `shellcheck .agents/scripts/privacy-guard-helper.sh` — passes clean (zero violations)
- Logic review: newline-padded `[[ ]]` match is a well-known exact-element pattern; `${var//./\\.}` replaces all `.` with `\.` identically to the sed command

Resolves #21509

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.5 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-sonnet-4-6 spent 1m and 4,195 tokens on this as a headless worker.
