### PR TITLE
GH#21497: fix incomplete backslash escaping in sqlite3_param .param set values

### DIFF
--- a/.agents/scripts/tech-stack-cache-lib.sh
+++ b/.agents/scripts/tech-stack-cache-lib.sh
@@ -103,8 +103,10 @@ sqlite3_param() {
 		local pname="$1"
 		local pval="$2"
 		shift 2
-		# Double-quote values for .param set — sqlite3 handles escaping internally
-		param_cmds+=".param set ${pname} \"${pval//\"/\\\"}\""$'\n'
+		# Escape backslashes first, then double-quotes for .param set
+		local escaped_pval="${pval//\\/\\\\}"
+		escaped_pval="${escaped_pval//\"/\\\"}"
+		param_cmds+=".param set ${pname} \"${escaped_pval}\""$'\n'
 	done
 
 	sqlite3 "$db" <<EOSQL


### PR DESCRIPTION
## Summary

Fixed incomplete escaping in sqlite3_param() in tech-stack-cache-lib.sh. Backslashes in .param set values were not escaped, causing data mangling or syntax errors. Now escapes backslashes before double-quotes.

## Files Changed

.agents/scripts/tech-stack-cache-lib.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/tech-stack-cache-lib.sh passes clean (zero violations)

Resolves #21497


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.5 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-sonnet-4-6 spent 1m and 2,403 tokens on this as a headless worker.