### PR TITLE
GH#21499: fix: resolve SC2027/SC2086 quoting bug in _cmd_enable_systemd printf

### DIFF
--- a/.agents/scripts/auto-update-helper.sh
+++ b/.agents/scripts/auto-update-helper.sh
@@ -872,7 +872,7 @@ _cmd_enable_systemd() {
 
 	mkdir -p "${SYSTEMD_SERVICE_DIR}"
 
-	# shellcheck disable=SC1078,SC1079,SC2027,SC2086  # systemd ExecStart wraps a single-quoted shell command; bash interpolates "${script_path}" into the systemd directive value, embedded single+double quotes are intentional
+	# shellcheck disable=SC1078,SC1079  # multi-line printf with single quotes inside a double-quoted string; ${script_path} kept inside outer double quotes for safe expansion
 	printf '%s' "[Unit]
 Description=aidevops auto-update
 After=network.target
@@ -880,7 +880,7 @@ After=network.target
 [Service]
 Type=oneshot
 KillMode=process
-ExecStart=/bin/bash -lc '"${script_path}" check'
+ExecStart=/bin/bash -lc '${script_path} check'
 TimeoutStartSec=120
 Nice=10
 IOSchedulingClass=idle


### PR DESCRIPTION
## Summary

Fixed a real quoting bug in _cmd_enable_systemd where the ExecStart systemd directive used '"" check' inside a double-quoted printf argument, which terminated the outer string and left ${script_path} unquoted. Changed to '${script_path} check' to keep the variable inside the outer double quotes for safe expansion. Also dropped the now-unnecessary SC2027 and SC2086 shellcheck disables from the comment, retaining SC1078/SC1079 for the multi-line printf pattern.

## Files Changed

.agents/scripts/auto-update-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/auto-update-helper.sh passes clean (zero violations). The generated systemd service file will now correctly contain ExecStart=/bin/bash -lc '/path/to/script check' even when the path contains spaces.

Resolves #21499


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.5 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-sonnet-4-6 spent 2m and 7,057 tokens on this as a headless worker.