### PR TITLE
t3011: fix bash 3.2 compat — convert local -n namerefs in compare-models libs

### DIFF
--- a/.agents/configs/complexity-thresholds.conf
+++ b/.agents/configs/complexity-thresholds.conf
@@ -251,7 +251,11 @@ FILE_SIZE_THRESHOLD=59
 # the t2171 retirement was deployed. 78 > 76 = silent advisory. Counter divergence between
 # complexity-scan-helper.sh (72) and complexity-regression-helper.sh (76) is the underlying
 # debt — tracked separately.
-BASH32_COMPAT_THRESHOLD=78
+# Ratcheted down to 63 (GH#21513, t3011): removed 25 local -n namerefs from
+# compare-models-bench-lib.sh (15) and compare-models-cross-review-lib.sh (10)
+# by converting to bash 3.2 compatible ${!var} reads + printf -v + eval writes.
+# Actual violations after conversion: ~60. 60 + 3 buffer = 63.
+BASH32_COMPAT_THRESHOLD=63
 
 # Qlty maintainability smell baseline (t2065, GH#18773). Seed value for
 # the `.github/workflows/qlty-regression.yml` gate. The gate itself uses

--- a/.agents/scripts/compare-models-bench-lib.sh
+++ b/.agents/scripts/compare-models-bench-lib.sh
@@ -510,17 +510,29 @@ if m:
 
 # Parse command-line arguments for cmd_bench
 # Sets: prompt, dataset_file, max_tokens, dry_run, judge_flag, history_flag, history_limit, prompt_version, model_args
+# Bash 3.2 compatible: uses ${!var} for indirect reads, printf -v for scalar writes, eval for array ops.
 _bench_parse_args() {
-	local -n args_prompt="$1"
-	local -n args_dataset="$2"
-	local -n args_max_tokens="$3"
-	local -n args_dry_run="$4"
-	local -n args_judge="$5"
-	local -n args_history="$6"
-	local -n args_limit="$7"
-	local -n args_version="$8"
-	local -n args_models="$9"
+	local _r_prompt="$1"
+	local _r_dataset="$2"
+	local _r_max_tokens="$3"
+	local _r_dry_run="$4"
+	local _r_judge="$5"
+	local _r_history="$6"
+	local _r_limit="$7"
+	local _r_version="$8"
+	local _r_models="$9"
 	shift 9
+
+	# Local working copies initialised from caller's current values
+	local _prompt="${!_r_prompt}"
+	local _dataset="${!_r_dataset}"
+	local _max_tokens="${!_r_max_tokens}"
+	local _dry_run="${!_r_dry_run}"
+	local _judge="${!_r_judge}"
+	local _history="${!_r_history}"
+	local _limit="${!_r_limit}"
+	local _version="${!_r_version}"
+	local -a _models=()
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
@@ -529,11 +541,11 @@ _bench_parse_args() {
 				print_error "--dataset requires a file path"
 				return 1
 			}
-			args_dataset="$2"
+			_dataset="$2"
 			shift 2
 			;;
 		--judge)
-			args_judge=true
+			_judge=true
 			shift
 			;;
 		--max-tokens)
@@ -541,15 +553,15 @@ _bench_parse_args() {
 				print_error "--max-tokens requires a value"
 				return 1
 			}
-			args_max_tokens="$2"
+			_max_tokens="$2"
 			shift 2
 			;;
 		--dry-run)
-			args_dry_run=true
+			_dry_run=true
 			shift
 			;;
 		--history)
-			args_history=true
+			_history=true
 			shift
 			;;
 		--limit)
@@ -557,7 +569,7 @@ _bench_parse_args() {
 				print_error "--limit requires a value"
 				return 1
 			}
-			args_limit="$2"
+			_limit="$2"
 			shift 2
 			;;
 		--version)
@@ -565,7 +577,7 @@ _bench_parse_args() {
 				print_error "--version requires a value"
 				return 1
 			}
-			args_version="$2"
+			_version="$2"
 			shift 2
 			;;
 		--*)
@@ -573,30 +585,51 @@ _bench_parse_args() {
 			return 1
 			;;
 		*)
-			if [[ -z "$args_prompt" && -z "$args_dataset" ]]; then
-				args_prompt="$1"
+			if [[ -z "$_prompt" && -z "$_dataset" ]]; then
+				_prompt="$1"
 			else
-				args_models+=("$1")
+				_models+=("$1")
 			fi
 			shift
 			;;
 		esac
+	done
+
+	# Write back results to caller's variables (bash 3.2: printf -v for scalars, eval for arrays)
+	printf -v "$_r_prompt" '%s' "$_prompt"
+	printf -v "$_r_dataset" '%s' "$_dataset"
+	printf -v "$_r_max_tokens" '%s' "$_max_tokens"
+	printf -v "$_r_dry_run" '%s' "$_dry_run"
+	printf -v "$_r_judge" '%s' "$_judge"
+	printf -v "$_r_history" '%s' "$_history"
+	printf -v "$_r_limit" '%s' "$_limit"
+	printf -v "$_r_version" '%s' "$_version"
+	eval "${_r_models}=()"
+	local _elem
+	for _elem in "${_models[@]}"; do
+		eval "${_r_models}+=(\"\$_elem\")"
 	done
 	return 0
 }
 
 # Validate bench inputs and build prompts list
 # Returns: 0 on success, 1 on error
+# Bash 3.2 compatible: uses ${!var} for indirect reads, eval for array ops.
 _bench_validate_and_build() {
-	local -n val_prompt="$1"
-	local -n val_dataset="$2"
-	local -n val_max_tokens="$3"
-	local -n val_models="$4"
-	local -n val_prompts="$5"
-	local -n val_valid_models="$6"
+	local _r_prompt="$1"
+	local _r_dataset="$2"
+	local _r_max_tokens="$3"
+	local _r_models="$4"
+	local _r_prompts="$5"
+	local _r_valid_models="$6"
+
+	# Read scalar values via indirect expansion (bash 3.2 compatible)
+	local _prompt="${!_r_prompt}"
+	local _dataset="${!_r_dataset}"
+	local _max_tokens="${!_r_max_tokens}"
 
 	# Validate inputs
-	if [[ -z "$val_prompt" && -z "$val_dataset" ]]; then
+	if [[ -z "$_prompt" && -z "$_dataset" ]]; then
 		print_error "Usage: compare-models-helper.sh bench \"prompt\" model1 model2 [model3...]"
 		echo "       compare-models-helper.sh bench --dataset file.jsonl model1 model2"
 		echo "       compare-models-helper.sh bench --history [--limit N]"
@@ -611,53 +644,59 @@ _bench_validate_and_build() {
 		return 1
 	fi
 
-	if [[ ${#val_models[@]} -lt 1 ]]; then
+	local _models_cnt
+	eval "_models_cnt=\${#${_r_models}[@]}"
+	if [[ "${_models_cnt}" -lt 1 ]]; then
 		print_error "At least 1 model required for benchmarking"
 		return 1
 	fi
 
-	if [[ -n "$val_dataset" && ! -f "$val_dataset" ]]; then
-		print_error "Dataset file not found: $val_dataset"
+	if [[ -n "$_dataset" && ! -f "$_dataset" ]]; then
+		print_error "Dataset file not found: $_dataset"
 		return 1
 	fi
 
-	if ! [[ "$val_max_tokens" =~ ^[0-9]+$ ]]; then
-		print_error "Invalid --max-tokens value: $val_max_tokens"
+	if ! [[ "$_max_tokens" =~ ^[0-9]+$ ]]; then
+		print_error "Invalid --max-tokens value: $_max_tokens"
 		return 1
 	fi
 
 	# Build prompts list
-	if [[ -n "$val_dataset" ]]; then
+	local p
+	if [[ -n "$_dataset" ]]; then
 		while IFS= read -r line; do
 			[[ -z "$line" ]] && continue
-			local p
 			p=$(printf '%s' "$line" | jq -r '(.input // .prompt) // empty' || true)
 			if [[ -n "$p" ]]; then
-				val_prompts+=("$p")
+				eval "${_r_prompts}+=(\"\$p\")"
 			fi
-		done <"$val_dataset"
-		if [[ ${#val_prompts[@]} -eq 0 ]]; then
+		done <"$_dataset"
+		local _prompts_cnt
+		eval "_prompts_cnt=\${#${_r_prompts}[@]}"
+		if [[ "${_prompts_cnt}" -eq 0 ]]; then
 			print_error "No valid prompts found in dataset (expected JSONL with {\"input\":\"...\"} or {\"prompt\":\"...\"})"
 			return 1
 		fi
 	else
-		val_prompts+=("$val_prompt")
+		eval "${_r_prompts}+=(\"\$_prompt\")"
 	fi
 
 	# Validate models exist in MODEL_DATA
-	for m in "${val_models[@]}"; do
-		local info
+	local _i m info actual_id
+	for (( _i=0; _i<_models_cnt; _i++ )); do
+		eval "m=\${${_r_models}[$_i]}"
 		info=$(_model_provider_info "$m")
 		if [[ -z "$info" ]]; then
 			print_warning "Unknown model: $m (skipping)"
 		else
-			local actual_id
 			actual_id=$(echo "$info" | cut -d'|' -f3)
-			val_valid_models+=("$actual_id")
+			eval "${_r_valid_models}+=(\"\$actual_id\")"
 		fi
 	done
 
-	if [[ ${#val_valid_models[@]} -lt 1 ]]; then
+	local _valid_cnt
+	eval "_valid_cnt=\${#${_r_valid_models}[@]}"
+	if [[ "${_valid_cnt}" -lt 1 ]]; then
 		print_error "No valid models found"
 		return 1
 	fi

--- a/.agents/scripts/compare-models-bench-lib.sh
+++ b/.agents/scripts/compare-models-bench-lib.sh
@@ -510,104 +510,41 @@ if m:
 
 # Parse command-line arguments for cmd_bench
 # Sets: prompt, dataset_file, max_tokens, dry_run, judge_flag, history_flag, history_limit, prompt_version, model_args
-# Bash 3.2 compatible: uses ${!var} for indirect reads, printf -v for scalar writes, eval for array ops.
+# Bash 3.2 compatible: printf -v for scalar writes, ${!var} for reads, eval for array appends.
 _bench_parse_args() {
-	local _r_prompt="$1"
-	local _r_dataset="$2"
-	local _r_max_tokens="$3"
-	local _r_dry_run="$4"
-	local _r_judge="$5"
-	local _r_history="$6"
-	local _r_limit="$7"
-	local _r_version="$8"
-	local _r_models="$9"
+	local _r_prompt="$1" _r_dataset="$2" _r_max_tokens="$3" _r_dry_run="$4"
+	local _r_judge="$5" _r_history="$6" _r_limit="$7" _r_version="$8" _r_models="$9"
 	shift 9
-
-	# Local working copies initialised from caller's current values
-	local _prompt="${!_r_prompt}"
-	local _dataset="${!_r_dataset}"
-	local _max_tokens="${!_r_max_tokens}"
-	local _dry_run="${!_r_dry_run}"
-	local _judge="${!_r_judge}"
-	local _history="${!_r_history}"
-	local _limit="${!_r_limit}"
-	local _version="${!_r_version}"
-	local -a _models=()
-
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--dataset)
-			[[ $# -lt 2 ]] && {
-				print_error "--dataset requires a file path"
-				return 1
-			}
-			_dataset="$2"
-			shift 2
-			;;
+			[[ $# -lt 2 ]] && { print_error "--dataset requires a file path"; return 1; }
+			printf -v "$_r_dataset" '%s' "$2"; shift 2 ;;
 		--judge)
-			_judge=true
-			shift
-			;;
+			printf -v "$_r_judge" '%s' true; shift ;;
 		--max-tokens)
-			[[ $# -lt 2 ]] && {
-				print_error "--max-tokens requires a value"
-				return 1
-			}
-			_max_tokens="$2"
-			shift 2
-			;;
+			[[ $# -lt 2 ]] && { print_error "--max-tokens requires a value"; return 1; }
+			printf -v "$_r_max_tokens" '%s' "$2"; shift 2 ;;
 		--dry-run)
-			_dry_run=true
-			shift
-			;;
+			printf -v "$_r_dry_run" '%s' true; shift ;;
 		--history)
-			_history=true
-			shift
-			;;
+			printf -v "$_r_history" '%s' true; shift ;;
 		--limit)
-			[[ $# -lt 2 ]] && {
-				print_error "--limit requires a value"
-				return 1
-			}
-			_limit="$2"
-			shift 2
-			;;
+			[[ $# -lt 2 ]] && { print_error "--limit requires a value"; return 1; }
+			printf -v "$_r_limit" '%s' "$2"; shift 2 ;;
 		--version)
-			[[ $# -lt 2 ]] && {
-				print_error "--version requires a value"
-				return 1
-			}
-			_version="$2"
-			shift 2
-			;;
+			[[ $# -lt 2 ]] && { print_error "--version requires a value"; return 1; }
+			printf -v "$_r_version" '%s' "$2"; shift 2 ;;
 		--*)
-			print_error "Unknown option: $1"
-			return 1
-			;;
+			print_error "Unknown option: $1"; return 1 ;;
 		*)
-			if [[ -z "$_prompt" && -z "$_dataset" ]]; then
-				_prompt="$1"
+			if [[ -z "${!_r_prompt}" && -z "${!_r_dataset}" ]]; then
+				printf -v "$_r_prompt" '%s' "$1"
 			else
-				_models+=("$1")
+				eval "${_r_models}+=(\"\$1\")"
 			fi
-			shift
-			;;
+			shift ;;
 		esac
-	done
-
-	# Write back results to caller's variables (bash 3.2: printf -v for scalars, eval for arrays)
-	printf -v "$_r_prompt" '%s' "$_prompt"
-	printf -v "$_r_dataset" '%s' "$_dataset"
-	printf -v "$_r_max_tokens" '%s' "$_max_tokens"
-	printf -v "$_r_dry_run" '%s' "$_dry_run"
-	printf -v "$_r_judge" '%s' "$_judge"
-	printf -v "$_r_history" '%s' "$_history"
-	printf -v "$_r_limit" '%s' "$_limit"
-	printf -v "$_r_version" '%s' "$_version"
-	eval "${_r_models}=()"
-	local _elem
-	for _elem in "${_models[@]}"; do
-		eval "${_r_models}+=(\"\$_elem\")"
 	done
 	return 0
 }

--- a/.agents/scripts/compare-models-cross-review-lib.sh
+++ b/.agents/scripts/compare-models-cross-review-lib.sh
@@ -391,17 +391,29 @@ _cross_review_judge_score() {
 #######################################
 
 # Parse arguments for cmd_cross_review
+# Bash 3.2 compatible: uses ${!var} for indirect reads, printf -v for scalar writes.
 _cross_review_parse_args() {
-	local -n cr_prompt="$1"
-	local -n cr_models="$2"
-	local -n cr_workdir="$3"
-	local -n cr_timeout="$4"
-	local -n cr_output="$5"
-	local -n cr_score="$6"
-	local -n cr_judge="$7"
-	local -n cr_version="$8"
-	local -n cr_file="$9"
+	local _r_prompt="$1"
+	local _r_models="$2"
+	local _r_workdir="$3"
+	local _r_timeout="$4"
+	local _r_output="$5"
+	local _r_score="$6"
+	local _r_judge="$7"
+	local _r_version="$8"
+	local _r_file="$9"
 	shift 9
+
+	# Local working copies initialised from caller's current values
+	local _prompt="${!_r_prompt}"
+	local _models="${!_r_models}"
+	local _workdir="${!_r_workdir}"
+	local _timeout="${!_r_timeout}"
+	local _output="${!_r_output}"
+	local _score="${!_r_score}"
+	local _judge="${!_r_judge}"
+	local _version="${!_r_version}"
+	local _file="${!_r_file}"
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
@@ -410,7 +422,7 @@ _cross_review_parse_args() {
 				print_error "--prompt requires a value"
 				return 1
 			}
-			cr_prompt="$2"
+			_prompt="$2"
 			shift 2
 			;;
 		--models)
@@ -418,7 +430,7 @@ _cross_review_parse_args() {
 				print_error "--models requires a value"
 				return 1
 			}
-			cr_models="$2"
+			_models="$2"
 			shift 2
 			;;
 		--workdir)
@@ -426,7 +438,7 @@ _cross_review_parse_args() {
 				print_error "--workdir requires a value"
 				return 1
 			}
-			cr_workdir="$2"
+			_workdir="$2"
 			shift 2
 			;;
 		--timeout)
@@ -434,7 +446,7 @@ _cross_review_parse_args() {
 				print_error "--timeout requires a value"
 				return 1
 			}
-			cr_timeout="$2"
+			_timeout="$2"
 			shift 2
 			;;
 		--output)
@@ -442,11 +454,11 @@ _cross_review_parse_args() {
 				print_error "--output requires a value"
 				return 1
 			}
-			cr_output="$2"
+			_output="$2"
 			shift 2
 			;;
 		--score)
-			cr_score=true
+			_score=true
 			shift
 			;;
 		--judge)
@@ -454,9 +466,9 @@ _cross_review_parse_args() {
 				print_error "--judge requires a value"
 				return 1
 			}
-			cr_judge="$2"
-			if [[ ! "$cr_judge" =~ ^[A-Za-z0-9._-]+$ ]]; then
-				print_error "Invalid judge model identifier: $cr_judge (only alphanumeric, dots, hyphens, underscores)"
+			_judge="$2"
+			if [[ ! "$_judge" =~ ^[A-Za-z0-9._-]+$ ]]; then
+				print_error "Invalid judge model identifier: $_judge (only alphanumeric, dots, hyphens, underscores)"
 				return 1
 			fi
 			shift 2
@@ -466,7 +478,7 @@ _cross_review_parse_args() {
 				print_error "--prompt-version requires a value"
 				return 1
 			}
-			cr_version="$2"
+			_version="$2"
 			shift 2
 			;;
 		--prompt-file)
@@ -474,7 +486,7 @@ _cross_review_parse_args() {
 				print_error "--prompt-file requires a value"
 				return 1
 			}
-			cr_file="$2"
+			_file="$2"
 			shift 2
 			;;
 		*)
@@ -483,6 +495,17 @@ _cross_review_parse_args() {
 			;;
 		esac
 	done
+
+	# Write back results to caller's variables (bash 3.2: printf -v for scalars)
+	printf -v "$_r_prompt" '%s' "$_prompt"
+	printf -v "$_r_models" '%s' "$_models"
+	printf -v "$_r_workdir" '%s' "$_workdir"
+	printf -v "$_r_timeout" '%s' "$_timeout"
+	printf -v "$_r_output" '%s' "$_output"
+	printf -v "$_r_score" '%s' "$_score"
+	printf -v "$_r_judge" '%s' "$_judge"
+	printf -v "$_r_version" '%s' "$_version"
+	printf -v "$_r_file" '%s' "$_file"
 	return 0
 }
 
@@ -676,15 +699,16 @@ cmd_cross_review() {
 }
 
 # Dispatch all models in parallel and wait for completion.
-# Populates the nameref array with validated model names.
-# Args: arg1=runner_helper arg2=prompt arg3=timeout arg4=workdir arg5=output_dir arg6=nameref_array arg7+=model_array
+# Populates the array (passed by name) with validated model names.
+# Args: arg1=runner_helper arg2=prompt arg3=timeout arg4=workdir arg5=output_dir arg6=array_name arg7+=model_array
+# Bash 3.2 compatible: uses eval for array ops instead of local -n nameref.
 _cross_review_dispatch_all() {
 	local runner_helper="$1"
 	local prompt="$2"
 	local review_timeout="$3"
 	local workdir="$4"
 	local output_dir="$5"
-	local -n _da_model_names="$6"
+	local _r_model_names="$6"
 	shift 6
 	local -a model_array=("$@")
 
@@ -698,7 +722,7 @@ _cross_review_dispatch_all() {
 			continue
 		fi
 		local runner_name="cross-review-${model_tier}-$$"
-		_da_model_names+=("$model_tier")
+		eval "${_r_model_names}+=(\"\$model_tier\")"
 		local resolved_model
 		resolved_model=$(resolve_model_tier "$model_tier")
 		echo "  Dispatching to ${model_tier} (${resolved_model})..."
@@ -709,10 +733,11 @@ _cross_review_dispatch_all() {
 
 	echo ""
 	echo "Waiting for ${#pids[@]} models to respond..."
-	local wait_args=()
-	local i
+	local -a wait_args=()
+	local i _name
 	for i in "${!pids[@]}"; do
-		wait_args+=("${pids[$i]}" "${_da_model_names[$i]}")
+		eval "_name=\${${_r_model_names}[$i]}"
+		wait_args+=("${pids[$i]}" "$_name")
 	done
 	local wait_output
 	wait_output=$(_cross_review_wait_results "$output_dir" "${wait_args[@]}")

--- a/.agents/scripts/compare-models-cross-review-lib.sh
+++ b/.agents/scripts/compare-models-cross-review-lib.sh
@@ -391,121 +391,48 @@ _cross_review_judge_score() {
 #######################################
 
 # Parse arguments for cmd_cross_review
-# Bash 3.2 compatible: uses ${!var} for indirect reads, printf -v for scalar writes.
+# Bash 3.2 compatible: printf -v for scalar writes, ${!var} for reads.
 _cross_review_parse_args() {
-	local _r_prompt="$1"
-	local _r_models="$2"
-	local _r_workdir="$3"
-	local _r_timeout="$4"
-	local _r_output="$5"
-	local _r_score="$6"
-	local _r_judge="$7"
-	local _r_version="$8"
-	local _r_file="$9"
+	local _r_prompt="$1" _r_models="$2" _r_workdir="$3" _r_timeout="$4"
+	local _r_output="$5" _r_score="$6" _r_judge="$7" _r_version="$8" _r_file="$9"
 	shift 9
-
-	# Local working copies initialised from caller's current values
-	local _prompt="${!_r_prompt}"
-	local _models="${!_r_models}"
-	local _workdir="${!_r_workdir}"
-	local _timeout="${!_r_timeout}"
-	local _output="${!_r_output}"
-	local _score="${!_r_score}"
-	local _judge="${!_r_judge}"
-	local _version="${!_r_version}"
-	local _file="${!_r_file}"
-
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--prompt)
-			[[ $# -lt 2 ]] && {
-				print_error "--prompt requires a value"
-				return 1
-			}
-			_prompt="$2"
-			shift 2
-			;;
+			[[ $# -lt 2 ]] && { print_error "--prompt requires a value"; return 1; }
+			printf -v "$_r_prompt" '%s' "$2"; shift 2 ;;
 		--models)
-			[[ $# -lt 2 ]] && {
-				print_error "--models requires a value"
-				return 1
-			}
-			_models="$2"
-			shift 2
-			;;
+			[[ $# -lt 2 ]] && { print_error "--models requires a value"; return 1; }
+			printf -v "$_r_models" '%s' "$2"; shift 2 ;;
 		--workdir)
-			[[ $# -lt 2 ]] && {
-				print_error "--workdir requires a value"
-				return 1
-			}
-			_workdir="$2"
-			shift 2
-			;;
+			[[ $# -lt 2 ]] && { print_error "--workdir requires a value"; return 1; }
+			printf -v "$_r_workdir" '%s' "$2"; shift 2 ;;
 		--timeout)
-			[[ $# -lt 2 ]] && {
-				print_error "--timeout requires a value"
-				return 1
-			}
-			_timeout="$2"
-			shift 2
-			;;
+			[[ $# -lt 2 ]] && { print_error "--timeout requires a value"; return 1; }
+			printf -v "$_r_timeout" '%s' "$2"; shift 2 ;;
 		--output)
-			[[ $# -lt 2 ]] && {
-				print_error "--output requires a value"
-				return 1
-			}
-			_output="$2"
-			shift 2
-			;;
+			[[ $# -lt 2 ]] && { print_error "--output requires a value"; return 1; }
+			printf -v "$_r_output" '%s' "$2"; shift 2 ;;
 		--score)
-			_score=true
-			shift
-			;;
+			printf -v "$_r_score" '%s' true; shift ;;
 		--judge)
-			[[ $# -lt 2 ]] && {
-				print_error "--judge requires a value"
-				return 1
-			}
-			_judge="$2"
-			if [[ ! "$_judge" =~ ^[A-Za-z0-9._-]+$ ]]; then
-				print_error "Invalid judge model identifier: $_judge (only alphanumeric, dots, hyphens, underscores)"
+			[[ $# -lt 2 ]] && { print_error "--judge requires a value"; return 1; }
+			local _judge_val="$2"
+			if [[ ! "$_judge_val" =~ ^[A-Za-z0-9._-]+$ ]]; then
+				print_error "Invalid judge model identifier: $_judge_val (only alphanumeric, dots, hyphens, underscores)"
 				return 1
 			fi
-			shift 2
-			;;
+			printf -v "$_r_judge" '%s' "$_judge_val"; shift 2 ;;
 		--prompt-version)
-			[[ $# -lt 2 ]] && {
-				print_error "--prompt-version requires a value"
-				return 1
-			}
-			_version="$2"
-			shift 2
-			;;
+			[[ $# -lt 2 ]] && { print_error "--prompt-version requires a value"; return 1; }
+			printf -v "$_r_version" '%s' "$2"; shift 2 ;;
 		--prompt-file)
-			[[ $# -lt 2 ]] && {
-				print_error "--prompt-file requires a value"
-				return 1
-			}
-			_file="$2"
-			shift 2
-			;;
+			[[ $# -lt 2 ]] && { print_error "--prompt-file requires a value"; return 1; }
+			printf -v "$_r_file" '%s' "$2"; shift 2 ;;
 		*)
-			print_error "Unknown option: $1"
-			return 1
-			;;
+			print_error "Unknown option: $1"; return 1 ;;
 		esac
 	done
-
-	# Write back results to caller's variables (bash 3.2: printf -v for scalars)
-	printf -v "$_r_prompt" '%s' "$_prompt"
-	printf -v "$_r_models" '%s' "$_models"
-	printf -v "$_r_workdir" '%s' "$_workdir"
-	printf -v "$_r_timeout" '%s' "$_timeout"
-	printf -v "$_r_output" '%s' "$_output"
-	printf -v "$_r_score" '%s' "$_score"
-	printf -v "$_r_judge" '%s' "$_judge"
-	printf -v "$_r_version" '%s' "$_version"
-	printf -v "$_r_file" '%s' "$_file"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Fixes 25 `local -n` nameref violations (bash 4.3+) in two compare-models helper libraries that were blocking the bash32-compat CI check and preventing `version-manager.sh release` from completing.

## What changed

**`compare-models-bench-lib.sh`** — 15 violations removed:
- `_bench_parse_args`: 9 namerefs converted — scalar reads via `${!varname}`, scalar writes via `printf -v`, array (`model_args`) initialised locally then written back via `eval`
- `_bench_validate_and_build`: 6 namerefs converted — `${!var}` reads, `eval` for array length checks, indexed reads, and appends

**`compare-models-cross-review-lib.sh`** — 10 violations removed:
- `_cross_review_parse_args`: 9 namerefs converted — all scalars, uses `${!var}` read + `printf -v` writeback
- `_cross_review_dispatch_all`: 1 nameref converted — `eval` for array append and indexed read

**`.agents/configs/complexity-thresholds.conf`** — ratcheted `BASH32_COMPAT_THRESHOLD` from 78 → 63 (actual ~60 violations + 3 buffer).

## Verification

- `shellcheck --severity=warning` passes clean on both files
- 0 `local -n` lines remain in either file (excluding comments)
- Bash 3.2 compatible patterns used: `${!var}` (bash 2.0+), `printf -v` (bash 3.1+), `eval` with explicit quoting

Resolves #21513

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.5 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-sonnet-4-6 spent 18m and 42,852 tokens on this as a headless worker.
