### PR TITLE
GH#21502: add fallback stubs for set -u safety in worktree-helper.sh

### DIFF
--- a/.agents/scripts/worktree-helper.sh
+++ b/.agents/scripts/worktree-helper.sh
@@ -44,6 +44,11 @@ if [[ -f "${SCRIPT_DIR}/canonical-guard-helper.sh" ]]; then
 fi
 
 # t2976: canonical audit logger for worktree-removal events (removed / skipped).
+# Fallback definitions guard against set -u failures when the helper is absent
+# (e.g. older deployments). The source block below overrides these when the file exists.
+_WTAR_REMOVED="${_WTAR_REMOVED:-removed}"
+_WTAR_SKIPPED="${_WTAR_SKIPPED:-skipped}"
+log_worktree_removal_event() { :; }
 if [[ -f "${SCRIPT_DIR}/audit-worktree-removal-helper.sh" ]]; then
 	# shellcheck source=audit-worktree-removal-helper.sh
 	source "${SCRIPT_DIR}/audit-worktree-removal-helper.sh"


### PR DESCRIPTION
## Summary

Adds fallback definitions for `_WTAR_REMOVED`, `_WTAR_SKIPPED`, and a no-op stub for `log_worktree_removal_event` before the `audit-worktree-removal-helper.sh` source block in `worktree-helper.sh`.

## Problem

When `audit-worktree-removal-helper.sh` is absent (e.g. older deployments), `_WTAR_REMOVED` and `_WTAR_SKIPPED` are unbound. These variables are expanded at lines 1195 and 1239 **after** `set -euo pipefail` is active (line 54), causing an unbound variable abort. Similarly, `log_worktree_removal_event` would be an unresolved command call.

## Fix

- `_WTAR_REMOVED="${_WTAR_REMOVED:-removed}"` — fallback to the canonical value
- `_WTAR_SKIPPED="${_WTAR_SKIPPED:-skipped}"` — fallback to the canonical value
- `log_worktree_removal_event() { :; }` — no-op stub (overridden when helper loads)

The existing `[[ -f ]]` guard is preserved for consistency with the `canonical-guard-helper.sh` sourcing pattern already in this file. When the helper IS present, it sources normally and overrides the stubs (the helper's double-source guard `_AUDIT_WORKTREE_REMOVAL_HELPER_LOADED` remains intact).

## Verification

```bash
shellcheck .agents/scripts/worktree-helper.sh  # zero violations
```

Resolves #21502

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.5 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-sonnet-4-6 spent 3m and 11,060 tokens on this as a headless worker.
