### PR TITLE
GH#21336: split upstream-watch-helper.sh into focused sub-modules

### DIFF
--- a/.agents/scripts/upstream-watch-helper-check.sh
+++ b/.agents/scripts/upstream-watch-helper-check.sh
@@ -1,0 +1,598 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# Upstream Watch Check -- Probe, compare, and report upstream changes
+# =============================================================================
+# Sub-library for upstream-watch-helper.sh. Contains all GitHub API probing,
+# update checking, diff display, and the cmd_check command.
+#
+# Usage: source "${SCRIPT_DIR}/upstream-watch-helper-check.sh"
+#
+# Dependencies:
+#   - shared-constants.sh (colour vars, gh wrappers)
+#   - upstream-watch-helper-state.sh (_log_*, _read_state, _write_state, etc.)
+#   - upstream-watch-helper-issues.sh (_file_upstream_update_issue)
+#   - Expects CONFIG_FILE, STATE_FILE globals set by orchestrator
+#
+# Part of aidevops framework: https://aidevops.sh
+
+# Apply strict mode only when executed directly (not when sourced)
+[[ "${BASH_SOURCE[0]}" == "${0}" ]] && set -euo pipefail
+
+# Include guard
+[[ -n "${_UPSTREAM_WATCH_CHECK_LIB_LOADED:-}" ]] && return 0
+_UPSTREAM_WATCH_CHECK_LIB_LOADED=1
+
+# Defensive SCRIPT_DIR fallback
+if [[ -z "${SCRIPT_DIR:-}" ]]; then
+	_lib_path="${BASH_SOURCE[0]%/*}"
+	[[ "$_lib_path" == "${BASH_SOURCE[0]}" ]] && _lib_path="."
+	SCRIPT_DIR="$(cd "$_lib_path" && pwd)"
+	unset _lib_path
+fi
+
+# =============================================================================
+# GitHub API probes
+# =============================================================================
+
+#######################################
+# Probe GitHub API for the latest release of a repository.
+# Echoes release JSON on success; empty string if no releases (404).
+# Arguments:
+#   $1 - Repository slug (owner/repo)
+# Outputs: release JSON via stdout (empty if no releases)
+# Returns: 0 on success or 404 (no releases), 1 on real API error
+#######################################
+_probe_github_release() {
+	local slug="$1"
+	local api_stderr
+	api_stderr=$(mktemp -t upstream-watch-err.XXXXXX)
+	local release_json=""
+
+	if release_json=$(gh api "repos/${slug}/releases/latest" 2>"$api_stderr"); then
+		rm -f "$api_stderr"
+		printf '%s' "$release_json"
+		return 0
+	fi
+
+	local release_err
+	release_err=$(<"$api_stderr")
+	rm -f "$api_stderr"
+
+	# 404 = no releases (normal, not an error)
+	if [[ "$release_err" == *"Not Found"* || "$release_err" == *"404"* ]]; then
+		return 0
+	fi
+
+	_log_warn "gh api releases failed for ${slug}: ${release_err}"
+	echo -e "${YELLOW}Warning${NC}: Could not fetch releases for ${slug}" >&2
+	return 1
+}
+
+#######################################
+# Probe GitHub API for the latest commit of a repository.
+# Echoes commit JSON on success; empty string on error.
+# Arguments:
+#   $1 - Repository slug (owner/repo)
+# Outputs: commit JSON via stdout (empty on error)
+# Returns: 0 on success, 1 on API error
+#######################################
+_probe_github_commit() {
+	local slug="$1"
+	local api_stderr
+	api_stderr=$(mktemp -t upstream-watch-err.XXXXXX)
+	local commit_json=""
+
+	if commit_json=$(gh api "repos/${slug}/commits?per_page=1" --jq '.[0]' 2>"$api_stderr"); then
+		rm -f "$api_stderr"
+		printf '%s' "$commit_json"
+		return 0
+	fi
+
+	local commit_err
+	commit_err=$(<"$api_stderr")
+	rm -f "$api_stderr"
+
+	_log_warn "gh api commits failed for ${slug}: ${commit_err}"
+	echo -e "${YELLOW}Warning${NC}: Could not fetch commits for ${slug}" >&2
+	return 1
+}
+
+# =============================================================================
+# Update reporting
+# =============================================================================
+
+#######################################
+# Report update status for a single GitHub repo and update shared counters.
+# Arguments:
+#   $1 - slug
+#   $2 - relevance
+#   $3 - has_new_release (true/false)
+#   $4 - has_new_commits (true/false)
+#   $5 - last_release_seen
+#   $6 - last_commit_seen
+#   $7 - latest_release_tag
+#   $8 - latest_release_name
+#   $9 - latest_release_date
+#   $10 - latest_commit (full SHA)
+#   $11 - latest_commit_date
+#   $12 - verbose (true/false)
+# Side-effects: increments _check_updates_found
+#######################################
+_report_github_repo_update() {
+	local slug="$1"
+	local relevance="$2"
+	local has_new_release="$3"
+	local has_new_commits="$4"
+	local last_release_seen="$5"
+	local last_commit_seen="$6"
+	local latest_release_tag="$7"
+	local latest_release_name="$8"
+	local latest_release_date="$9"
+	local latest_commit="${10}"
+	local latest_commit_date="${11}"
+	local verbose="${12}"
+
+	if [[ "$has_new_release" == true ]]; then
+		_check_updates_found=$((_check_updates_found + 1))
+		echo ""
+		echo -e "${YELLOW}NEW RELEASE${NC}: ${slug}"
+		[[ -n "$relevance" ]] && echo -e "  Relevance: ${CYAN}${relevance}${NC}"
+		echo "  Previous:  ${last_release_seen:-none}"
+		echo "  Latest:    ${latest_release_tag} (${latest_release_date:-unknown})"
+		[[ -n "$latest_release_name" && "$latest_release_name" != "$latest_release_tag" ]] &&
+			echo "  Name:      ${latest_release_name}"
+		_show_release_diff "$slug" "$last_release_seen" "$latest_release_tag"
+		if [[ "$verbose" == true ]]; then
+			_show_commit_diff "$slug" "$last_commit_seen" "${latest_commit:0:7}"
+		fi
+		echo "  Action:    Review changes, then run: upstream-watch-helper.sh ack ${slug}"
+	elif [[ "$has_new_commits" == true ]]; then
+		_check_updates_found=$((_check_updates_found + 1))
+		echo ""
+		echo -e "${BLUE}NEW COMMITS${NC}: ${slug} (no new release)"
+		[[ -n "$relevance" ]] && echo -e "  Relevance: ${CYAN}${relevance}${NC}"
+		if [[ "$verbose" == true ]]; then
+			_show_commit_diff "$slug" "$last_commit_seen" "${latest_commit:0:7}"
+		else
+			echo "  Latest commit: ${latest_commit:0:7} (${latest_commit_date:-unknown})"
+			echo "  Action:        Review changes, then run: upstream-watch-helper.sh ack ${slug}"
+		fi
+	else
+		echo -e "${GREEN}Up to date${NC}: ${slug} (${latest_release_tag:-no releases})"
+	fi
+	return 0
+}
+
+# =============================================================================
+# Diff display
+# =============================================================================
+
+#######################################
+# Display release changelog between two tags
+# Shows all releases between from_tag and to_tag, plus latest release notes.
+# Arguments:
+#   $1 - Repository slug (owner/repo)
+#   $2 - From tag (last seen, empty for first check)
+#   $3 - To tag (latest release)
+#######################################
+_show_release_diff() {
+	local slug="$1"
+	local from_tag="$2"
+	local to_tag="$3"
+
+	if [[ -z "$from_tag" ]]; then
+		# First time -- just show the latest release notes
+		echo "  Release notes:"
+		local body
+		body=$(gh api "repos/${slug}/releases/latest" --jq '.body // "No release notes"' 2>/dev/null) || body="Could not fetch"
+		sed -n '1,20{s/^/    /;p;}' <<<"$body"
+		local line_count
+		line_count=$(wc -l <<<"$body" | tr -d ' ')
+		if [[ "$line_count" -gt 20 ]]; then
+			echo "    ... (${line_count} lines total -- view full notes on GitHub)"
+		fi
+		return 0
+	fi
+
+	# Show all releases between from_tag and to_tag
+	local releases
+	releases=$(gh api --paginate "repos/${slug}/releases" --jq '.[].tag_name' 2>/dev/null) || {
+		echo "  (Could not fetch release list)"
+		return 0
+	}
+
+	# Find releases newer than from_tag
+	local in_range=true
+	local release_count=0
+	echo "  Releases since ${from_tag}:"
+	while IFS= read -r tag; do
+		[[ -z "$tag" ]] && continue
+		if [[ "$tag" == "$from_tag" ]]; then
+			in_range=false
+			continue
+		fi
+		if [[ "$in_range" == true ]]; then
+			release_count=$((release_count + 1))
+			# Get one-line summary for each release
+			local rel_name rel_date
+			rel_name=$(gh api "repos/${slug}/releases/tags/${tag}" --jq '.name // .tag_name' 2>/dev/null) || rel_name="$tag"
+			rel_date=$(gh api "repos/${slug}/releases/tags/${tag}" --jq '.published_at // ""' 2>/dev/null) || rel_date=""
+			local date_short="${rel_date:0:10}"
+			echo "    ${tag} (${date_short}) -- ${rel_name}"
+		fi
+	done <<<"$releases"
+
+	if [[ "$release_count" -eq 0 ]]; then
+		echo "    (none found -- tags may not match release list)"
+	fi
+
+	# Show latest release notes
+	echo ""
+	echo "  Latest release notes (${to_tag}):"
+	local body
+	body=$(gh api "repos/${slug}/releases/tags/${to_tag}" --jq '.body // "No release notes"' 2>/dev/null) || body="Could not fetch"
+	sed -n '1,30{s/^/    /;p;}' <<<"$body"
+	local line_count
+	line_count=$(wc -l <<<"$body" | tr -d ' ')
+	if [[ "$line_count" -gt 30 ]]; then
+		echo "    ... (${line_count} lines total)"
+	fi
+	return 0
+}
+
+#######################################
+# Display recent commits between two SHAs
+# Shows up to 10 commits newer than from_sha.
+# Arguments:
+#   $1 - Repository slug (owner/repo)
+#   $2 - From SHA (7-char, last seen)
+#   $3 - To SHA (7-char, latest)
+#######################################
+_show_commit_diff() {
+	local slug="$1"
+	local from_sha="$2"
+	local to_sha="$3"
+
+	if [[ -z "$from_sha" || "$from_sha" == "$to_sha" ]]; then
+		return 0
+	fi
+
+	echo "  Recent commits:"
+	local commits
+	commits=$(gh api "repos/${slug}/commits?per_page=10" \
+		--jq '.[] | "\(.sha[0:7]) \(.commit.message | split("\n")[0])"' 2>/dev/null) || {
+		echo "    (Could not fetch commits)"
+		return 0
+	}
+
+	local count=0
+	while IFS= read -r line; do
+		[[ -z "$line" ]] && continue
+		local sha="${line%% *}"
+		if [[ "$sha" == "$from_sha" ]]; then
+			break
+		fi
+		count=$((count + 1))
+		echo "    ${line}"
+		if [[ "$count" -ge 10 ]]; then
+			echo "    ... (showing first 10)"
+			break
+		fi
+	done <<<"$commits"
+
+	if [[ "$count" -eq 0 ]]; then
+		echo "    (no new commits found in recent history)"
+	fi
+	return 0
+}
+
+# =============================================================================
+# Single-repo check
+# =============================================================================
+
+#######################################
+# Check a single GitHub repo for new releases and commits.
+# Updates state in-place (passed by reference via global _check_state).
+# Arguments:
+#   $1 - Repository slug (owner/repo)
+#   $2 - Config JSON
+#   $3 - Current ISO timestamp
+#   $4 - Verbose flag (true/false)
+# Outputs: prints update report to stdout
+# Returns: 0 if up to date or updated, 1 if probe failed
+# Side-effects: sets _check_updates_found, _check_had_probe_failure globals
+#######################################
+_check_single_github_repo() {
+	local slug="$1"
+	local config="$2"
+	local now="$3"
+	local verbose="$4"
+
+	# Get relevance from config
+	local relevance
+	relevance=$(echo "$config" | jq -r --arg slug "$slug" '.repos[] | select(.slug == $slug) | .relevance // ""')
+
+	# Get last-seen state
+	local last_release_seen last_commit_seen updates_pending_before
+	last_release_seen=$(echo "$_check_state" | jq -r --arg slug "$slug" '.repos[$slug].last_release_seen // ""')
+	last_commit_seen=$(echo "$_check_state" | jq -r --arg slug "$slug" '.repos[$slug].last_commit_seen // ""')
+	updates_pending_before=$(echo "$_check_state" | jq -r --arg slug "$slug" '.repos[$slug].updates_pending // 0')
+
+	# --- Check releases ---
+	local release_json="" probe_failed=false
+	local latest_release_tag="" latest_release_name="" latest_release_date=""
+	if ! release_json=$(_probe_github_release "$slug"); then
+		probe_failed=true
+	fi
+	if [[ -n "$release_json" ]]; then
+		latest_release_tag=$(echo "$release_json" | jq -r '.tag_name // ""')
+		latest_release_name=$(echo "$release_json" | jq -r '.name // ""')
+		latest_release_date=$(echo "$release_json" | jq -r '.published_at // ""')
+	fi
+
+	local has_new_release=false
+	if [[ -n "$latest_release_tag" && "$latest_release_tag" != "$last_release_seen" ]]; then
+		has_new_release=true
+	fi
+
+	# --- Check commits (even if no new release) ---
+	local commit_json="" latest_commit="" latest_commit_date=""
+	if ! commit_json=$(_probe_github_commit "$slug"); then
+		probe_failed=true
+	fi
+	if [[ -n "$commit_json" ]]; then
+		latest_commit=$(echo "$commit_json" | jq -r '.sha // ""')
+		latest_commit_date=$(echo "$commit_json" | jq -r '.commit.committer.date // ""')
+	fi
+
+	local has_new_commits=false
+	if [[ -n "$latest_commit" && "${latest_commit:0:7}" != "$last_commit_seen" ]]; then
+		has_new_commits=true
+	fi
+
+	# --- Report ---
+	_report_github_repo_update "$slug" "$relevance" \
+		"$has_new_release" "$has_new_commits" \
+		"$last_release_seen" "$last_commit_seen" \
+		"$latest_release_tag" "$latest_release_name" "$latest_release_date" \
+		"$latest_commit" "$latest_commit_date" "$verbose"
+
+	# Update last_checked and updates_pending (not last_seen -- requires explicit ack)
+	# Skip state update if probes failed to avoid masking errors as "up to date"
+	if [[ "$probe_failed" != true ]]; then
+		local new_pending
+		new_pending=$([[ "$has_new_release" == true || "$has_new_commits" == true ]] && echo 1 || echo 0)
+		_check_state=$(echo "$_check_state" | jq --arg slug "$slug" --arg now "$now" \
+			--argjson pending "$new_pending" \
+			'.repos[$slug].last_checked = $now | .repos[$slug].updates_pending = $pending')
+
+		# File GitHub issue on 0->1 transition (t2810)
+		if [[ "$updates_pending_before" != "1" && "$new_pending" == "1" ]]; then
+			local update_kind="commit"
+			local update_old="$last_commit_seen"
+			local update_new="${latest_commit:0:7}"
+			if [[ "$has_new_release" == true ]]; then
+				update_kind="release"
+				update_old="$last_release_seen"
+				update_new="$latest_release_tag"
+			fi
+			local config_entry
+			config_entry=$(echo "$config" | jq --arg slug "$slug" '.repos[] | select(.slug == $slug)')
+			_file_upstream_update_issue "$slug" "$update_kind" "$update_old" "$update_new" "$config_entry"
+		fi
+	else
+		_check_had_probe_failure=true
+	fi
+	return 0
+}
+
+# =============================================================================
+# Non-GitHub upstream checks
+# =============================================================================
+
+#######################################
+# Check all non-GitHub upstreams (Docker Hub, GitLab, Forgejo, etc.)
+# Updates _check_state in-place via global.
+# Arguments:
+#   $1 - Config JSON
+#   $2 - Target name (empty = all)
+#   $3 - Current ISO timestamp
+# Side-effects: sets _check_updates_found, _check_had_probe_failure globals
+#######################################
+_check_non_github_upstreams() {
+	local config="$1"
+	local target_name="$2"
+	local now="$3"
+
+	local non_github_names
+	if [[ -n "$target_name" ]]; then
+		non_github_names="$target_name"
+	else
+		non_github_names=$(echo "$config" | jq -r '.non_github_upstreams // [] | .[].name')
+	fi
+
+	while IFS= read -r entry_name; do
+		[[ -z "$entry_name" ]] && continue
+
+		local entry_json
+		entry_json=$(echo "$config" | jq --arg name "$entry_name" '.non_github_upstreams[] | select(.name == $name)')
+
+		local check_cmd source_type description relevance entry_url
+		check_cmd=$(echo "$entry_json" | jq -r '.check_command // ""')
+		source_type=$(echo "$entry_json" | jq -r '.source_type // "unknown"')
+		description=$(echo "$entry_json" | jq -r '.description // ""')
+		relevance=$(echo "$entry_json" | jq -r '.relevance // ""')
+		entry_url=$(echo "$entry_json" | jq -r '.url // ""')
+
+		if [[ -z "$check_cmd" ]]; then
+			echo -e "${YELLOW}Warning${NC}: No check_command for ${entry_name}, skipping" >&2
+			continue
+		fi
+
+		# Get last-seen state
+		local last_seen_value ng_updates_pending_before
+		last_seen_value=$(echo "$_check_state" | jq -r --arg name "$entry_name" '.non_github[$name].last_seen // ""')
+		ng_updates_pending_before=$(echo "$_check_state" | jq -r --arg name "$entry_name" '.non_github[$name].updates_pending // 0')
+
+		# Run the check command (curl + jq) in a subshell for isolation
+		# Note: check_command comes from a committed config file, not user input
+		local current_value=""
+		local probe_failed=false
+		current_value=$(bash -c "$check_cmd" 2>/dev/null) || {
+			_log_warn "check_command failed for ${entry_name}"
+			echo -e "${YELLOW}Warning${NC}: Could not check ${entry_name} (${source_type})" >&2
+			probe_failed=true
+		}
+
+		# Trim whitespace
+		current_value=$(echo "$current_value" | tr -d '[:space:]')
+
+		local has_update=false
+		if [[ "$probe_failed" != true && -n "$current_value" && "$current_value" != "$last_seen_value" ]]; then
+			has_update=true
+		fi
+
+		if [[ "$has_update" == true ]]; then
+			_check_updates_found=$((_check_updates_found + 1))
+			echo ""
+			echo -e "${YELLOW}UPDATE DETECTED${NC}: ${entry_name} (${source_type})"
+			echo "  Description: ${description}"
+			[[ -n "$relevance" ]] && echo -e "  Relevance:   ${CYAN}${relevance}${NC}"
+			echo "  Previous:    ${last_seen_value:-none}"
+			echo "  Current:     ${current_value}"
+			[[ -n "$entry_url" ]] && echo "  URL:         ${entry_url}"
+
+			# Show affected files
+			local affects
+			affects=$(echo "$entry_json" | jq -r '.affects // [] | .[]' 2>/dev/null)
+			if [[ -n "$affects" ]]; then
+				echo "  Affects:"
+				while IFS= read -r affected_file; do
+					[[ -n "$affected_file" ]] && echo "    - ${affected_file}"
+				done <<<"$affects"
+			fi
+
+			echo "  Action:      Review changes, then run: upstream-watch-helper.sh ack ${entry_name}"
+		elif [[ "$probe_failed" != true ]]; then
+			echo -e "${GREEN}Up to date${NC}: ${entry_name} (${source_type}: ${current_value:-unknown})"
+		fi
+
+		# Update state (but not last_seen -- that requires explicit ack)
+		if [[ "$probe_failed" != true ]]; then
+			local ng_new_pending
+			ng_new_pending=$([[ "$has_update" == true ]] && echo 1 || echo 0)
+			_check_state=$(echo "$_check_state" | jq --arg name "$entry_name" --arg now "$now" \
+				--arg current "$current_value" \
+				--argjson pending "$ng_new_pending" \
+				'.non_github[$name].last_checked = $now | .non_github[$name].current_value = $current | .non_github[$name].updates_pending = $pending')
+
+			# File GitHub issue on 0->1 transition (t2810)
+			if [[ "$ng_updates_pending_before" != "1" && "$ng_new_pending" == "1" ]]; then
+				_file_upstream_update_issue "$entry_name" "update" "$last_seen_value" "$current_value" "$entry_json"
+			fi
+		else
+			_check_had_probe_failure=true
+		fi
+
+	done <<<"$non_github_names"
+	return 0
+}
+
+# =============================================================================
+# cmd_check
+# =============================================================================
+
+#######################################
+# Check watched repos for new releases and commits
+# Compares current GitHub state against last-seen state. Reports new
+# releases with changelog diffs and new commits. Does NOT advance
+# last_seen -- that requires explicit ack. Returns 1 if any probe failed.
+# Also checks non-GitHub upstreams (Docker Hub, GitLab, Forgejo) via
+# their configured check_command.
+# Arguments:
+#   $1 - Optional target slug/name to check a single repo
+# Globals:
+#   VERBOSE - Show commit-level detail when true
+#######################################
+cmd_check() {
+	local target_slug="${1:-}"
+	local verbose="${VERBOSE:-false}"
+
+	_check_prerequisites || return 1
+
+	local config
+	config=$(_read_config)
+	# Use a global so sub-functions can update state in-place
+	_check_state=$(_read_state)
+
+	# Check if target is a non-GitHub upstream name
+	local target_is_non_github=false
+	if [[ -n "$target_slug" ]]; then
+		if echo "$config" | jq -e --arg name "$target_slug" '.non_github_upstreams // [] | .[] | select(.name == $name)' >/dev/null 2>&1; then
+			target_is_non_github=true
+		fi
+	fi
+
+	local slugs=""
+	if [[ -n "$target_slug" && "$target_is_non_github" != true ]]; then
+		# Validate that the target slug is on the GitHub watchlist
+		if ! echo "$config" | jq -e --arg slug "$target_slug" '.repos[] | select(.slug == $slug)' >/dev/null 2>&1; then
+			echo -e "${RED}Error: Not watching ${target_slug}. Add it first with 'upstream-watch-helper.sh add ${target_slug}'.${NC}" >&2
+			return 1
+		fi
+		slugs="$target_slug"
+	elif [[ "$target_is_non_github" != true ]]; then
+		slugs=$(echo "$config" | jq -r '.repos[].slug')
+	fi
+
+	local has_github_repos=false
+	local has_non_github=false
+	[[ -n "$slugs" ]] && has_github_repos=true
+	if echo "$config" | jq -e '.non_github_upstreams // [] | length > 0' >/dev/null 2>&1; then
+		has_non_github=true
+	fi
+
+	if [[ "$has_github_repos" != true && "$has_non_github" != true ]]; then
+		echo -e "${BLUE}No repos being watched. Use 'add' to start watching.${NC}"
+		return 0
+	fi
+
+	# Shared counters updated by sub-functions
+	_check_updates_found=0
+	_check_had_probe_failure=false
+	local now
+	now=$(_now_iso)
+
+	# Check GitHub repos
+	while IFS= read -r slug; do
+		[[ -z "$slug" ]] && continue
+		_check_single_github_repo "$slug" "$config" "$now" "$verbose"
+	done <<<"$slugs"
+
+	# Check non-GitHub upstreams
+	if [[ "$has_non_github" == true ]]; then
+		local ng_target=""
+		[[ "$target_is_non_github" == true ]] && ng_target="$target_slug"
+		_check_non_github_upstreams "$config" "$ng_target" "$now"
+	fi
+
+	# Only advance global last_check if all probes succeeded -- partial failures
+	# should not advance the 24h gate so the caller retries on the next cycle
+	if [[ "$_check_had_probe_failure" != true ]]; then
+		_check_state=$(echo "$_check_state" | jq --arg now "$now" '.last_check = $now')
+	fi
+	_write_state "$_check_state"
+
+	echo ""
+	if [[ "$_check_updates_found" -gt 0 ]]; then
+		echo -e "${YELLOW}${_check_updates_found} repo(s) have updates to review.${NC}"
+	else
+		echo -e "${GREEN}All watched repos are up to date.${NC}"
+	fi
+
+	_log_info "Check complete: ${_check_updates_found} updates found"
+	[[ "$_check_had_probe_failure" == true ]] && return 1
+	return 0
+}

--- a/.agents/scripts/upstream-watch-helper-issues.sh
+++ b/.agents/scripts/upstream-watch-helper-issues.sh
@@ -1,0 +1,281 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# Upstream Watch Issues -- GitHub issue filing and closing (t2810)
+# =============================================================================
+# Sub-library for upstream-watch-helper.sh. Handles filing and closing GitHub
+# issues when upstream updates are detected or acknowledged.
+#
+# Usage: source "${SCRIPT_DIR}/upstream-watch-helper-issues.sh"
+#
+# Dependencies:
+#   - shared-constants.sh (gh_create_issue, gh_issue_comment, gh_issue_edit_safe, etc.)
+#   - upstream-watch-helper-state.sh (_log_info, _log_warn)
+#   - Expects SCRIPT_DIR, UPSTREAM_WATCH_LABEL globals set by orchestrator
+#
+# Part of aidevops framework: https://aidevops.sh
+
+# Apply strict mode only when executed directly (not when sourced)
+[[ "${BASH_SOURCE[0]}" == "${0}" ]] && set -euo pipefail
+
+# Include guard
+[[ -n "${_UPSTREAM_WATCH_ISSUES_LIB_LOADED:-}" ]] && return 0
+_UPSTREAM_WATCH_ISSUES_LIB_LOADED=1
+
+# Defensive SCRIPT_DIR fallback
+if [[ -z "${SCRIPT_DIR:-}" ]]; then
+	_lib_path="${BASH_SOURCE[0]%/*}"
+	[[ "$_lib_path" == "${BASH_SOURCE[0]}" ]] && _lib_path="."
+	SCRIPT_DIR="$(cd "$_lib_path" && pwd)"
+	unset _lib_path
+fi
+
+# =============================================================================
+# GitHub issue filing (t2810)
+# =============================================================================
+
+#######################################
+# Look up the local aidevops repo slug for issue filing
+# Outputs: owner/repo slug string
+# Returns: 0 always
+#######################################
+_get_aidevops_slug() {
+	local slug=""
+	if [[ -f "${HOME}/.config/aidevops/repos.json" ]]; then
+		slug=$(jq -r '.initialized_repos[] | select(.is_framework_dir == true) | .slug' \
+			"${HOME}/.config/aidevops/repos.json" 2>/dev/null | head -1) || slug=""
+	fi
+	[[ -z "$slug" ]] && slug="marcusquinn/aidevops"
+	printf '%s' "$slug"
+	return 0
+}
+
+#######################################
+# Compose the issue body for an upstream update notification.
+# Extracted from _file_upstream_update_issue() to reduce complexity.
+# Arguments:
+#   $1 - slug_or_name
+#   $2 - kind
+#   $3 - old_display   (previous version/commit or "none")
+#   $4 - new_value_short
+#   $5 - relevance     (may be empty)
+#   $6 - affects       (newline-separated list, may be empty)
+#   $7 - compare_url   (may be empty)
+# Outputs: issue body text via stdout
+#######################################
+_compose_upstream_issue_body() {
+	local slug_or_name="$1"
+	local kind="$2"
+	local old_display="$3"
+	local new_value_short="$4"
+	local relevance="$5"
+	local affects="$6"
+	local compare_url="$7"
+
+	# Build affects section
+	local affects_section="See relevance text above."
+	if [[ -n "$affects" ]]; then
+		affects_section=""
+		while IFS= read -r af; do
+			[[ -n "$af" ]] && affects_section="${affects_section}\n- \`${af}\`"
+		done <<<"$affects"
+	fi
+
+	cat <<ISSUEEOF
+## Summary
+
+${relevance:-Upstream repo monitored for relevant changes.}
+
+## What Changed
+
+| Field | Value |
+|-------|-------|
+| Upstream | \`${slug_or_name}\` |
+| Kind | ${kind} |
+| Previous | \`${old_display}\` |
+| Current | \`${new_value_short}\` |
+$(if [[ -n "$compare_url" ]]; then echo "| Compare | [view diff](${compare_url}) |"; fi)
+
+## Affects
+
+$(printf '%b' "$affects_section")
+
+## Action
+
+1. Review the upstream changes${compare_url:+ at the [compare link](${compare_url})}
+2. Determine if adoption is needed (new feature, bug fix, security patch)
+3. If adopting: create a PR with the relevant changes
+4. Mark as reviewed: \`upstream-watch-helper.sh ack ${slug_or_name}\`
+
+<!-- aidevops:generator=upstream-watch upstream_slug=${slug_or_name} -->
+<!-- upstream-watch:slug=${slug_or_name} -->
+ISSUEEOF
+	return 0
+}
+
+#######################################
+# File a GitHub issue when an upstream update is detected (0->1 transition).
+# Deduplicates by searching for open issues with the same title prefix.
+# If a matching open issue exists and the upstream has advanced further,
+# the existing issue body is updated instead of creating a duplicate.
+#
+# Arguments:
+#   $1 - slug_or_name  (upstream repo slug or non-GitHub entry name)
+#   $2 - kind          (release|commit|update)
+#   $3 - old_value     (previous version/commit, may be empty)
+#   $4 - new_value     (new version/commit)
+#   $5 - entry_json    (config entry JSON for relevance, affects, etc.)
+# Returns: 0 on success or gh offline, 1 on unexpected error
+#######################################
+_file_upstream_update_issue() {
+	local slug_or_name="$1"
+	local kind="$2"
+	local old_value="$3"
+	local new_value="$4"
+	local entry_json="$5"
+
+	# Bail if gh is not available (offline mode -- don't break the check loop)
+	if ! command -v gh &>/dev/null || ! gh auth status &>/dev/null; then
+		_log_warn "gh unavailable -- skipping issue filing for ${slug_or_name}"
+		return 0
+	fi
+
+	local aidevops_slug
+	aidevops_slug=$(_get_aidevops_slug)
+
+	local new_value_short="${new_value:0:12}"
+	local title="upstream: ${slug_or_name} ${kind} -> ${new_value_short} (review adoption)"
+
+	# --- Dedup: check for existing open issue ---
+	local existing_number=""
+	existing_number=$(gh issue list --repo "$aidevops_slug" --state open \
+		--label "$UPSTREAM_WATCH_LABEL" \
+		--search "in:title upstream: ${slug_or_name}" \
+		--json number --jq '.[0].number // empty' 2>/dev/null) || existing_number=""
+
+	# Extract relevance, affects, and upstream URL from config entry
+	local relevance="" affects="" upstream_url=""
+	if [[ -n "$entry_json" ]]; then
+		relevance=$(printf '%s' "$entry_json" | jq -r '.relevance // ""' 2>/dev/null) || relevance=""
+		affects=$(printf '%s' "$entry_json" | jq -r '.affects // [] | .[]' 2>/dev/null) || affects=""
+		local entry_slug=""
+		entry_slug=$(printf '%s' "$entry_json" | jq -r '.slug // ""' 2>/dev/null) || entry_slug=""
+		if [[ -n "$entry_slug" ]]; then
+			upstream_url="https://github.com/${entry_slug}"
+		else
+			upstream_url=$(printf '%s' "$entry_json" | jq -r '.url // ""' 2>/dev/null) || upstream_url=""
+		fi
+	fi
+
+	# Build compare URL for GitHub repos
+	local compare_url=""
+	if [[ -n "$old_value" && -n "$upstream_url" && "$upstream_url" == *"github.com"* ]]; then
+		compare_url="${upstream_url}/compare/${old_value}...${new_value_short}"
+	fi
+
+	# Compose body via helper and append signature footer
+	local body
+	body=$(_compose_upstream_issue_body "$slug_or_name" "$kind" "${old_value:-none}" \
+		"$new_value_short" "$relevance" "$affects" "$compare_url")
+	local sig_footer=""
+	if [[ -x "${SCRIPT_DIR}/gh-signature-helper.sh" ]]; then
+		sig_footer=$("${SCRIPT_DIR}/gh-signature-helper.sh" footer 2>/dev/null || true)
+	fi
+	[[ -n "$sig_footer" ]] && body="${body}
+
+${sig_footer}"
+
+	if [[ -n "$existing_number" ]]; then
+		# Update existing issue title and body if upstream advanced further
+		_log_info "Updating existing issue #${existing_number} for ${slug_or_name}"
+		gh_issue_edit_safe "$existing_number" --repo "$aidevops_slug" \
+			--title "$title" --body "$body" >/dev/null 2>&1 || {
+			_log_warn "Failed to update issue #${existing_number} for ${slug_or_name}"
+			return 0
+		}
+		echo -e "  ${BLUE}Updated issue #${existing_number}${NC}"
+	else
+		# Create new issue
+		_log_info "Filing issue for upstream update: ${slug_or_name} ${kind} -> ${new_value_short}"
+		local issue_url=""
+		issue_url=$(gh_create_issue --repo "$aidevops_slug" \
+			--title "$title" \
+			--label "$UPSTREAM_WATCH_LABEL" \
+			--label "auto-dispatch" \
+			--label "tier:standard" \
+			--label "origin:worker" \
+			--body "$body" 2>/dev/null) || {
+			_log_warn "Failed to file issue for ${slug_or_name} -- will retry next cycle"
+			return 0
+		}
+		if [[ -n "$issue_url" ]]; then
+			_log_info "Filed issue: ${issue_url}"
+			echo -e "  ${BLUE}Filed issue: ${issue_url}${NC}"
+		fi
+	fi
+	return 0
+}
+
+#######################################
+# Close the open upstream-watch issue for a given slug/name on ack.
+# Searches for open issues with the source:upstream-watch label and
+# matching title, then posts an ack comment and closes.
+#
+# Arguments:
+#   $1 - slug_or_name  (upstream repo slug or non-GitHub entry name)
+#   $2 - note          (optional user-supplied note for the close comment)
+# Returns: 0 always (offline/failure is non-fatal)
+#######################################
+_close_upstream_update_issue() {
+	local slug_or_name="$1"
+	local note="${2:-}"
+
+	# Bail if gh is not available
+	if ! command -v gh &>/dev/null || ! gh auth status &>/dev/null; then
+		_log_warn "gh unavailable -- skipping issue close for ${slug_or_name}"
+		return 0
+	fi
+
+	local aidevops_slug
+	aidevops_slug=$(_get_aidevops_slug)
+
+	# Find matching open issue
+	local issue_number=""
+	issue_number=$(gh issue list --repo "$aidevops_slug" --state open \
+		--label "$UPSTREAM_WATCH_LABEL" \
+		--search "in:title upstream: ${slug_or_name}" \
+		--json number --jq '.[0].number // empty' 2>/dev/null) || issue_number=""
+
+	if [[ -z "$issue_number" ]]; then
+		_log_info "No open upstream-watch issue found for ${slug_or_name} -- nothing to close"
+		return 0
+	fi
+
+	# Build ack comment
+	local comment_body="> Acked by user."
+	if [[ -n "$note" ]]; then
+		comment_body="> Acked by user. Adoption: ${note}"
+	fi
+
+	# Append signature footer
+	local sig_footer=""
+	if [[ -x "${SCRIPT_DIR}/gh-signature-helper.sh" ]]; then
+		sig_footer=$("${SCRIPT_DIR}/gh-signature-helper.sh" footer --issue "${aidevops_slug}#${issue_number}" --solved 2>/dev/null || true)
+	fi
+	[[ -n "$sig_footer" ]] && comment_body="${comment_body}
+
+${sig_footer}"
+
+	# Post comment and close
+	gh_issue_comment "$issue_number" --repo "$aidevops_slug" --body "$comment_body" >/dev/null 2>&1 || {
+		_log_warn "Failed to post ack comment on issue #${issue_number}"
+	}
+	gh issue close "$issue_number" --repo "$aidevops_slug" --reason "completed" >/dev/null 2>&1 || {
+		_log_warn "Failed to close issue #${issue_number}"
+	}
+
+	_log_info "Closed upstream-watch issue #${issue_number} for ${slug_or_name}"
+	echo -e "  ${GREEN}Closed issue #${issue_number}${NC}"
+	return 0
+}

--- a/.agents/scripts/upstream-watch-helper-state.sh
+++ b/.agents/scripts/upstream-watch-helper-state.sh
@@ -1,0 +1,213 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# Upstream Watch State Management -- Logging, prerequisites, state/config I/O
+# =============================================================================
+# Sub-library for upstream-watch-helper.sh. Contains all state and config file
+# management, logging, prerequisite checks, and ISO timestamp helpers.
+#
+# Usage: source "${SCRIPT_DIR}/upstream-watch-helper-state.sh"
+#
+# Dependencies:
+#   - shared-constants.sh (print_error, print_info, etc.)
+#   - Expects LOGFILE, STATE_FILE, CONFIG_FILE globals set by orchestrator
+#
+# Part of aidevops framework: https://aidevops.sh
+
+# Apply strict mode only when executed directly (not when sourced)
+[[ "${BASH_SOURCE[0]}" == "${0}" ]] && set -euo pipefail
+
+# Include guard
+[[ -n "${_UPSTREAM_WATCH_STATE_LIB_LOADED:-}" ]] && return 0
+_UPSTREAM_WATCH_STATE_LIB_LOADED=1
+
+# Defensive SCRIPT_DIR fallback
+if [[ -z "${SCRIPT_DIR:-}" ]]; then
+	_lib_path="${BASH_SOURCE[0]%/*}"
+	[[ "$_lib_path" == "${BASH_SOURCE[0]}" ]] && _lib_path="."
+	SCRIPT_DIR="$(cd "$_lib_path" && pwd)"
+	unset _lib_path
+fi
+
+# =============================================================================
+# Logging (standalone -- shared-constants.sh log_* may not be available)
+# =============================================================================
+
+#######################################
+# Write a timestamped log entry to the upstream-watch log file
+# Arguments:
+#   $1 - Log level (INFO, WARN, ERROR)
+#   $@ - Log message
+#######################################
+_log() {
+	local level="$1"
+	shift
+	local msg="$*"
+	local timestamp
+	timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+	local log_dir
+	log_dir=$(dirname "$LOGFILE")
+	mkdir -p "$log_dir" 2>/dev/null || true
+	echo "[${timestamp}] [${level}] ${msg}" >>"$LOGFILE"
+	return 0
+}
+
+#######################################
+# Log an informational message
+#######################################
+_log_info() {
+	_log "INFO" "$@"
+	return 0
+}
+
+#######################################
+# Log a warning message
+#######################################
+_log_warn() {
+	_log "WARN" "$@"
+	return 0
+}
+
+#######################################
+# Log an error message
+#######################################
+_log_error() {
+	_log "ERROR" "$@"
+	return 0
+}
+
+# =============================================================================
+# Prerequisites
+# =============================================================================
+
+#######################################
+# Verify required tools (gh, jq) are installed and gh is authenticated
+# Returns: 0 if all prerequisites met, 1 otherwise
+#######################################
+_check_prerequisites() {
+	if ! command -v gh &>/dev/null; then
+		echo -e "${RED}Error: gh CLI not found. Install from https://cli.github.com/${NC}" >&2
+		return 1
+	fi
+	if ! command -v jq &>/dev/null; then
+		echo -e "${RED}Error: jq not found. Install with: brew install jq${NC}" >&2
+		return 1
+	fi
+	if ! gh auth status &>/dev/null; then
+		echo -e "${RED}Error: gh not authenticated. Run: gh auth login${NC}" >&2
+		return 1
+	fi
+	return 0
+}
+
+# =============================================================================
+# State file management
+# =============================================================================
+
+#######################################
+# Create the state file with empty defaults if it doesn't exist
+#######################################
+_ensure_state_file() {
+	local state_dir
+	state_dir=$(dirname "$STATE_FILE")
+	mkdir -p "$state_dir" 2>/dev/null || true
+
+	if [[ ! -f "$STATE_FILE" ]]; then
+		echo '{"last_check":"","repos":{},"non_github":{}}' >"$STATE_FILE"
+		_log_info "Created new state file: $STATE_FILE"
+	fi
+	# Migrate existing state files that lack the non_github key
+	if ! jq -e '.non_github' "$STATE_FILE" >/dev/null 2>&1; then
+		local migrated
+		migrated=$(jq '. + {non_github: {}}' "$STATE_FILE")
+		echo "$migrated" >"$STATE_FILE"
+	fi
+	return 0
+}
+
+#######################################
+# Read and output the current state JSON
+#######################################
+_read_state() {
+	_ensure_state_file
+	cat "$STATE_FILE"
+	return 0
+}
+
+#######################################
+# Write state JSON to the state file, validating JSON first
+# Arguments:
+#   $1 - JSON string to write
+#######################################
+_write_state() {
+	local state="$1"
+	_ensure_state_file
+	local jq_err
+	jq_err=$(echo "$state" | jq '.' 2>&1 >"$STATE_FILE") || {
+		_log_error "Failed to write state file (invalid JSON): ${jq_err}"
+		return 1
+	}
+	return 0
+}
+
+# =============================================================================
+# Config file management
+# =============================================================================
+
+#######################################
+# Create the config file with empty defaults if it doesn't exist
+#######################################
+_ensure_config_file() {
+	local config_dir
+	config_dir=$(dirname "$CONFIG_FILE")
+	mkdir -p "$config_dir" 2>/dev/null || true
+
+	if [[ ! -f "$CONFIG_FILE" ]]; then
+		cat >"$CONFIG_FILE" <<'DEFAULTCONFIG'
+{
+  "$comment": "Upstream repos to watch for releases and significant changes. Managed by upstream-watch-helper.sh.",
+  "repos": []
+}
+DEFAULTCONFIG
+		_log_info "Created new config file: $CONFIG_FILE"
+	fi
+	return 0
+}
+
+#######################################
+# Read and output the current config JSON
+#######################################
+_read_config() {
+	_ensure_config_file
+	cat "$CONFIG_FILE"
+	return 0
+}
+
+#######################################
+# Write config JSON to the config file, validating JSON first
+# Arguments:
+#   $1 - JSON string to write
+#######################################
+_write_config() {
+	local config="$1"
+	_ensure_config_file
+	local jq_err
+	jq_err=$(echo "$config" | jq '.' 2>&1 >"$CONFIG_FILE") || {
+		_log_error "Failed to write config file (invalid JSON): ${jq_err}"
+		return 1
+	}
+	return 0
+}
+
+# =============================================================================
+# ISO 8601 helpers
+# =============================================================================
+
+#######################################
+# Output the current UTC time in ISO 8601 format
+#######################################
+_now_iso() {
+	date -u +%Y-%m-%dT%H:%M:%SZ
+	return 0
+}

--- a/.agents/scripts/upstream-watch-helper.sh
+++ b/.agents/scripts/upstream-watch-helper.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
-# upstream-watch-helper.sh — Track external repos for release monitoring (t1426)
+# upstream-watch-helper.sh -- Track external repos for release monitoring (t1426)
 #
 # Maintains a watchlist of external repos we've borrowed ideas/code from.
 # Checks for new releases and significant commits, shows changelog diffs
 # between our last-seen version and latest. Distinct from:
-#   - skill-sources.json (imported skills — tracked by add-skill-helper.sh)
+#   - skill-sources.json (imported skills -- tracked by add-skill-helper.sh)
 #   - contribution-watch (repos we've contributed to)
 #
-# This covers "inspiration repos" — repos we want to passively monitor
+# This covers "inspiration repos" -- repos we want to passively monitor
 # for improvements relevant to our implementation.
 #
 # Usage:
@@ -24,6 +24,11 @@
 # Config: ~/.aidevops/agents/configs/upstream-watch.json (template committed)
 # State:  ~/.aidevops/cache/upstream-watch-state.json (runtime, gitignored)
 # Log:    ~/.aidevops/logs/upstream-watch.log
+#
+# Sub-libraries (sourced below):
+#   upstream-watch-helper-state.sh   -- logging, prerequisites, state/config I/O
+#   upstream-watch-helper-issues.sh  -- GitHub issue filing/closing (t2810)
+#   upstream-watch-helper-check.sh   -- probe, check, diff display, cmd_check
 
 set -euo pipefail
 
@@ -51,442 +56,27 @@ AGENTS_DIR="${AIDEVOPS_AGENTS_DIR:-$HOME/.aidevops/agents}"
 CONFIG_FILE="${AGENTS_DIR}/configs/upstream-watch.json"
 STATE_FILE="${HOME}/.aidevops/cache/upstream-watch-state.json"
 LOGFILE="${HOME}/.aidevops/logs/upstream-watch.log"
-UPSTREAM_WATCH_LABEL="$UPSTREAM_WATCH_LABEL"
+UPSTREAM_WATCH_LABEL="${UPSTREAM_WATCH_LABEL:-source:upstream-watch}"
 
 # Logging prefix for shared log_* functions
 # shellcheck disable=SC2034
 LOG_PREFIX="upstream-watch"
 
 # =============================================================================
-# Logging (standalone — shared-constants.sh log_* may not be available)
+# Source sub-libraries
 # =============================================================================
 
-#######################################
-# Write a timestamped log entry to the upstream-watch log file
-# Arguments:
-#   $1 - Log level (INFO, WARN, ERROR)
-#   $@ - Log message
-#######################################
-_log() {
-	local level="$1"
-	shift
-	local msg="$*"
-	local timestamp
-	timestamp=$(date -u +%Y-%m-%dT%H:%M:%SZ)
-	local log_dir
-	log_dir=$(dirname "$LOGFILE")
-	mkdir -p "$log_dir" 2>/dev/null || true
-	echo "[${timestamp}] [${level}] ${msg}" >>"$LOGFILE"
-	return 0
-}
+# shellcheck source=./upstream-watch-helper-state.sh
+# shellcheck disable=SC1091  # sub-library resolved at runtime via $SCRIPT_DIR
+source "${SCRIPT_DIR}/upstream-watch-helper-state.sh"
 
-#######################################
-# Log an informational message
-#######################################
-_log_info() {
-	_log "INFO" "$@"
-	return 0
-}
+# shellcheck source=./upstream-watch-helper-issues.sh
+# shellcheck disable=SC1091  # sub-library resolved at runtime via $SCRIPT_DIR
+source "${SCRIPT_DIR}/upstream-watch-helper-issues.sh"
 
-#######################################
-# Log a warning message
-#######################################
-_log_warn() {
-	_log "WARN" "$@"
-	return 0
-}
-
-#######################################
-# Log an error message
-#######################################
-_log_error() {
-	_log "ERROR" "$@"
-	return 0
-}
-
-# =============================================================================
-# Prerequisites
-# =============================================================================
-
-#######################################
-# Verify required tools (gh, jq) are installed and gh is authenticated
-# Returns: 0 if all prerequisites met, 1 otherwise
-#######################################
-_check_prerequisites() {
-	if ! command -v gh &>/dev/null; then
-		echo -e "${RED}Error: gh CLI not found. Install from https://cli.github.com/${NC}" >&2
-		return 1
-	fi
-	if ! command -v jq &>/dev/null; then
-		echo -e "${RED}Error: jq not found. Install with: brew install jq${NC}" >&2
-		return 1
-	fi
-	if ! gh auth status &>/dev/null; then
-		echo -e "${RED}Error: gh not authenticated. Run: gh auth login${NC}" >&2
-		return 1
-	fi
-	return 0
-}
-
-# =============================================================================
-# State file management
-# =============================================================================
-
-#######################################
-# Create the state file with empty defaults if it doesn't exist
-#######################################
-_ensure_state_file() {
-	local state_dir
-	state_dir=$(dirname "$STATE_FILE")
-	mkdir -p "$state_dir" 2>/dev/null || true
-
-	if [[ ! -f "$STATE_FILE" ]]; then
-		echo '{"last_check":"","repos":{},"non_github":{}}' >"$STATE_FILE"
-		_log_info "Created new state file: $STATE_FILE"
-	fi
-	# Migrate existing state files that lack the non_github key
-	if ! jq -e '.non_github' "$STATE_FILE" >/dev/null 2>&1; then
-		local migrated
-		migrated=$(jq '. + {non_github: {}}' "$STATE_FILE")
-		echo "$migrated" >"$STATE_FILE"
-	fi
-	return 0
-}
-
-#######################################
-# Read and output the current state JSON
-#######################################
-_read_state() {
-	_ensure_state_file
-	cat "$STATE_FILE"
-	return 0
-}
-
-#######################################
-# Write state JSON to the state file, validating JSON first
-# Arguments:
-#   $1 - JSON string to write
-#######################################
-_write_state() {
-	local state="$1"
-	_ensure_state_file
-	local jq_err
-	jq_err=$(echo "$state" | jq '.' 2>&1 >"$STATE_FILE") || {
-		_log_error "Failed to write state file (invalid JSON): ${jq_err}"
-		return 1
-	}
-	return 0
-}
-
-# =============================================================================
-# Config file management
-# =============================================================================
-
-#######################################
-# Create the config file with empty defaults if it doesn't exist
-#######################################
-_ensure_config_file() {
-	local config_dir
-	config_dir=$(dirname "$CONFIG_FILE")
-	mkdir -p "$config_dir" 2>/dev/null || true
-
-	if [[ ! -f "$CONFIG_FILE" ]]; then
-		cat >"$CONFIG_FILE" <<'DEFAULTCONFIG'
-{
-  "$comment": "Upstream repos to watch for releases and significant changes. Managed by upstream-watch-helper.sh.",
-  "repos": []
-}
-DEFAULTCONFIG
-		_log_info "Created new config file: $CONFIG_FILE"
-	fi
-	return 0
-}
-
-#######################################
-# Read and output the current config JSON
-#######################################
-_read_config() {
-	_ensure_config_file
-	cat "$CONFIG_FILE"
-	return 0
-}
-
-#######################################
-# Write config JSON to the config file, validating JSON first
-# Arguments:
-#   $1 - JSON string to write
-#######################################
-_write_config() {
-	local config="$1"
-	_ensure_config_file
-	local jq_err
-	jq_err=$(echo "$config" | jq '.' 2>&1 >"$CONFIG_FILE") || {
-		_log_error "Failed to write config file (invalid JSON): ${jq_err}"
-		return 1
-	}
-	return 0
-}
-
-# =============================================================================
-# ISO 8601 helpers
-# =============================================================================
-
-#######################################
-# Output the current UTC time in ISO 8601 format
-#######################################
-_now_iso() {
-	date -u +%Y-%m-%dT%H:%M:%SZ
-	return 0
-}
-
-# =============================================================================
-# GitHub issue filing (t2810)
-# =============================================================================
-
-#######################################
-# Look up the local aidevops repo slug for issue filing
-# Outputs: owner/repo slug string
-# Returns: 0 always
-#######################################
-_get_aidevops_slug() {
-	local slug=""
-	if [[ -f "${HOME}/.config/aidevops/repos.json" ]]; then
-		slug=$(jq -r '.initialized_repos[] | select(.is_framework_dir == true) | .slug' \
-			"${HOME}/.config/aidevops/repos.json" 2>/dev/null | head -1) || slug=""
-	fi
-	[[ -z "$slug" ]] && slug="marcusquinn/aidevops"
-	printf '%s' "$slug"
-	return 0
-}
-
-#######################################
-# Compose the issue body for an upstream update notification.
-# Extracted from _file_upstream_update_issue() to reduce complexity.
-# Arguments:
-#   $1 - slug_or_name
-#   $2 - kind
-#   $3 - old_display   (previous version/commit or "none")
-#   $4 - new_value_short
-#   $5 - relevance     (may be empty)
-#   $6 - affects       (newline-separated list, may be empty)
-#   $7 - compare_url   (may be empty)
-# Outputs: issue body text via stdout
-#######################################
-_compose_upstream_issue_body() {
-	local slug_or_name="$1"
-	local kind="$2"
-	local old_display="$3"
-	local new_value_short="$4"
-	local relevance="$5"
-	local affects="$6"
-	local compare_url="$7"
-
-	# Build affects section
-	local affects_section="See relevance text above."
-	if [[ -n "$affects" ]]; then
-		affects_section=""
-		while IFS= read -r af; do
-			[[ -n "$af" ]] && affects_section="${affects_section}\n- \`${af}\`"
-		done <<<"$affects"
-	fi
-
-	cat <<ISSUEEOF
-## Summary
-
-${relevance:-Upstream repo monitored for relevant changes.}
-
-## What Changed
-
-| Field | Value |
-|-------|-------|
-| Upstream | \`${slug_or_name}\` |
-| Kind | ${kind} |
-| Previous | \`${old_display}\` |
-| Current | \`${new_value_short}\` |
-$(if [[ -n "$compare_url" ]]; then echo "| Compare | [view diff](${compare_url}) |"; fi)
-
-## Affects
-
-$(printf '%b' "$affects_section")
-
-## Action
-
-1. Review the upstream changes${compare_url:+ at the [compare link](${compare_url})}
-2. Determine if adoption is needed (new feature, bug fix, security patch)
-3. If adopting: create a PR with the relevant changes
-4. Mark as reviewed: \`upstream-watch-helper.sh ack ${slug_or_name}\`
-
-<!-- aidevops:generator=upstream-watch upstream_slug=${slug_or_name} -->
-<!-- upstream-watch:slug=${slug_or_name} -->
-ISSUEEOF
-	return 0
-}
-
-#######################################
-# File a GitHub issue when an upstream update is detected (0→1 transition).
-# Deduplicates by searching for open issues with the same title prefix.
-# If a matching open issue exists and the upstream has advanced further,
-# the existing issue body is updated instead of creating a duplicate.
-#
-# Arguments:
-#   $1 - slug_or_name  (upstream repo slug or non-GitHub entry name)
-#   $2 - kind          (release|commit|update)
-#   $3 - old_value     (previous version/commit, may be empty)
-#   $4 - new_value     (new version/commit)
-#   $5 - entry_json    (config entry JSON for relevance, affects, etc.)
-# Returns: 0 on success or gh offline, 1 on unexpected error
-#######################################
-_file_upstream_update_issue() {
-	local slug_or_name="$1"
-	local kind="$2"
-	local old_value="$3"
-	local new_value="$4"
-	local entry_json="$5"
-
-	# Bail if gh is not available (offline mode — don't break the check loop)
-	if ! command -v gh &>/dev/null || ! gh auth status &>/dev/null; then
-		_log_warn "gh unavailable — skipping issue filing for ${slug_or_name}"
-		return 0
-	fi
-
-	local aidevops_slug
-	aidevops_slug=$(_get_aidevops_slug)
-
-	local new_value_short="${new_value:0:12}"
-	local title="upstream: ${slug_or_name} ${kind} → ${new_value_short} (review adoption)"
-
-	# --- Dedup: check for existing open issue ---
-	local existing_number=""
-	existing_number=$(gh issue list --repo "$aidevops_slug" --state open \
-		--label "$UPSTREAM_WATCH_LABEL" \
-		--search "in:title upstream: ${slug_or_name}" \
-		--json number --jq '.[0].number // empty' 2>/dev/null) || existing_number=""
-
-	# Extract relevance, affects, and upstream URL from config entry
-	local relevance="" affects="" upstream_url=""
-	if [[ -n "$entry_json" ]]; then
-		relevance=$(printf '%s' "$entry_json" | jq -r '.relevance // ""' 2>/dev/null) || relevance=""
-		affects=$(printf '%s' "$entry_json" | jq -r '.affects // [] | .[]' 2>/dev/null) || affects=""
-		local entry_slug=""
-		entry_slug=$(printf '%s' "$entry_json" | jq -r '.slug // ""' 2>/dev/null) || entry_slug=""
-		if [[ -n "$entry_slug" ]]; then
-			upstream_url="https://github.com/${entry_slug}"
-		else
-			upstream_url=$(printf '%s' "$entry_json" | jq -r '.url // ""' 2>/dev/null) || upstream_url=""
-		fi
-	fi
-
-	# Build compare URL for GitHub repos
-	local compare_url=""
-	if [[ -n "$old_value" && -n "$upstream_url" && "$upstream_url" == *"github.com"* ]]; then
-		compare_url="${upstream_url}/compare/${old_value}...${new_value_short}"
-	fi
-
-	# Compose body via helper and append signature footer
-	local body
-	body=$(_compose_upstream_issue_body "$slug_or_name" "$kind" "${old_value:-none}" \
-		"$new_value_short" "$relevance" "$affects" "$compare_url")
-	local sig_footer=""
-	if [[ -x "${SCRIPT_DIR}/gh-signature-helper.sh" ]]; then
-		sig_footer=$("${SCRIPT_DIR}/gh-signature-helper.sh" footer 2>/dev/null || true)
-	fi
-	[[ -n "$sig_footer" ]] && body="${body}
-
-${sig_footer}"
-
-	if [[ -n "$existing_number" ]]; then
-		# Update existing issue title and body if upstream advanced further
-		_log_info "Updating existing issue #${existing_number} for ${slug_or_name}"
-		gh_issue_edit_safe "$existing_number" --repo "$aidevops_slug" \
-			--title "$title" --body "$body" >/dev/null 2>&1 || {
-			_log_warn "Failed to update issue #${existing_number} for ${slug_or_name}"
-			return 0
-		}
-		echo -e "  ${BLUE}Updated issue #${existing_number}${NC}"
-	else
-		# Create new issue
-		_log_info "Filing issue for upstream update: ${slug_or_name} ${kind} → ${new_value_short}"
-		local issue_url=""
-		issue_url=$(gh_create_issue --repo "$aidevops_slug" \
-			--title "$title" \
-			--label "$UPSTREAM_WATCH_LABEL" \
-			--label "auto-dispatch" \
-			--label "tier:standard" \
-			--label "origin:worker" \
-			--body "$body" 2>/dev/null) || {
-			_log_warn "Failed to file issue for ${slug_or_name} — will retry next cycle"
-			return 0
-		}
-		if [[ -n "$issue_url" ]]; then
-			_log_info "Filed issue: ${issue_url}"
-			echo -e "  ${BLUE}Filed issue: ${issue_url}${NC}"
-		fi
-	fi
-	return 0
-}
-
-#######################################
-# Close the open upstream-watch issue for a given slug/name on ack.
-# Searches for open issues with the source:upstream-watch label and
-# matching title, then posts an ack comment and closes.
-#
-# Arguments:
-#   $1 - slug_or_name  (upstream repo slug or non-GitHub entry name)
-#   $2 - note          (optional user-supplied note for the close comment)
-# Returns: 0 always (offline/failure is non-fatal)
-#######################################
-_close_upstream_update_issue() {
-	local slug_or_name="$1"
-	local note="${2:-}"
-
-	# Bail if gh is not available
-	if ! command -v gh &>/dev/null || ! gh auth status &>/dev/null; then
-		_log_warn "gh unavailable — skipping issue close for ${slug_or_name}"
-		return 0
-	fi
-
-	local aidevops_slug
-	aidevops_slug=$(_get_aidevops_slug)
-
-	# Find matching open issue
-	local issue_number=""
-	issue_number=$(gh issue list --repo "$aidevops_slug" --state open \
-		--label "$UPSTREAM_WATCH_LABEL" \
-		--search "in:title upstream: ${slug_or_name}" \
-		--json number --jq '.[0].number // empty' 2>/dev/null) || issue_number=""
-
-	if [[ -z "$issue_number" ]]; then
-		_log_info "No open upstream-watch issue found for ${slug_or_name} — nothing to close"
-		return 0
-	fi
-
-	# Build ack comment
-	local comment_body="> Acked by user."
-	if [[ -n "$note" ]]; then
-		comment_body="> Acked by user. Adoption: ${note}"
-	fi
-
-	# Append signature footer
-	local sig_footer=""
-	if [[ -x "${SCRIPT_DIR}/gh-signature-helper.sh" ]]; then
-		sig_footer=$("${SCRIPT_DIR}/gh-signature-helper.sh" footer --issue "${aidevops_slug}#${issue_number}" --solved 2>/dev/null || true)
-	fi
-	[[ -n "$sig_footer" ]] && comment_body="${comment_body}
-
-${sig_footer}"
-
-	# Post comment and close
-	gh_issue_comment "$issue_number" --repo "$aidevops_slug" --body "$comment_body" >/dev/null 2>&1 || {
-		_log_warn "Failed to post ack comment on issue #${issue_number}"
-	}
-	gh issue close "$issue_number" --repo "$aidevops_slug" --reason "completed" >/dev/null 2>&1 || {
-		_log_warn "Failed to close issue #${issue_number}"
-	}
-
-	_log_info "Closed upstream-watch issue #${issue_number} for ${slug_or_name}"
-	echo -e "  ${GREEN}Closed issue #${issue_number}${NC}"
-	return 0
-}
+# shellcheck source=./upstream-watch-helper-check.sh
+# shellcheck disable=SC1091  # sub-library resolved at runtime via $SCRIPT_DIR
+source "${SCRIPT_DIR}/upstream-watch-helper-check.sh"
 
 # =============================================================================
 # Commands
@@ -637,547 +227,6 @@ cmd_remove() {
 }
 
 #######################################
-# Report update status for a single GitHub repo and update shared counters.
-# Arguments:
-#   $1 - slug
-#   $2 - relevance
-#   $3 - has_new_release (true/false)
-#   $4 - has_new_commits (true/false)
-#   $5 - last_release_seen
-#   $6 - last_commit_seen
-#   $7 - latest_release_tag
-#   $8 - latest_release_name
-#   $9 - latest_release_date
-#   $10 - latest_commit (full SHA)
-#   $11 - latest_commit_date
-#   $12 - verbose (true/false)
-# Side-effects: increments _check_updates_found
-#######################################
-_report_github_repo_update() {
-	local slug="$1"
-	local relevance="$2"
-	local has_new_release="$3"
-	local has_new_commits="$4"
-	local last_release_seen="$5"
-	local last_commit_seen="$6"
-	local latest_release_tag="$7"
-	local latest_release_name="$8"
-	local latest_release_date="$9"
-	local latest_commit="${10}"
-	local latest_commit_date="${11}"
-	local verbose="${12}"
-
-	if [[ "$has_new_release" == true ]]; then
-		_check_updates_found=$((_check_updates_found + 1))
-		echo ""
-		echo -e "${YELLOW}NEW RELEASE${NC}: ${slug}"
-		[[ -n "$relevance" ]] && echo -e "  Relevance: ${CYAN}${relevance}${NC}"
-		echo "  Previous:  ${last_release_seen:-none}"
-		echo "  Latest:    ${latest_release_tag} (${latest_release_date:-unknown})"
-		[[ -n "$latest_release_name" && "$latest_release_name" != "$latest_release_tag" ]] &&
-			echo "  Name:      ${latest_release_name}"
-		_show_release_diff "$slug" "$last_release_seen" "$latest_release_tag"
-		if [[ "$verbose" == true ]]; then
-			_show_commit_diff "$slug" "$last_commit_seen" "${latest_commit:0:7}"
-		fi
-		echo "  Action:    Review changes, then run: upstream-watch-helper.sh ack ${slug}"
-	elif [[ "$has_new_commits" == true ]]; then
-		_check_updates_found=$((_check_updates_found + 1))
-		echo ""
-		echo -e "${BLUE}NEW COMMITS${NC}: ${slug} (no new release)"
-		[[ -n "$relevance" ]] && echo -e "  Relevance: ${CYAN}${relevance}${NC}"
-		if [[ "$verbose" == true ]]; then
-			_show_commit_diff "$slug" "$last_commit_seen" "${latest_commit:0:7}"
-		else
-			echo "  Latest commit: ${latest_commit:0:7} (${latest_commit_date:-unknown})"
-			echo "  Action:        Review changes, then run: upstream-watch-helper.sh ack ${slug}"
-		fi
-	else
-		echo -e "${GREEN}Up to date${NC}: ${slug} (${latest_release_tag:-no releases})"
-	fi
-	return 0
-}
-
-#######################################
-# Probe GitHub API for the latest release of a repository.
-# Echoes release JSON on success; empty string if no releases (404).
-# Arguments:
-#   $1 - Repository slug (owner/repo)
-# Outputs: release JSON via stdout (empty if no releases)
-# Returns: 0 on success or 404 (no releases), 1 on real API error
-#######################################
-_probe_github_release() {
-	local slug="$1"
-	local api_stderr
-	api_stderr=$(mktemp -t upstream-watch-err.XXXXXX)
-	local release_json=""
-
-	if release_json=$(gh api "repos/${slug}/releases/latest" 2>"$api_stderr"); then
-		rm -f "$api_stderr"
-		printf '%s' "$release_json"
-		return 0
-	fi
-
-	local release_err
-	release_err=$(<"$api_stderr")
-	rm -f "$api_stderr"
-
-	# 404 = no releases (normal, not an error)
-	if [[ "$release_err" == *"Not Found"* || "$release_err" == *"404"* ]]; then
-		return 0
-	fi
-
-	_log_warn "gh api releases failed for ${slug}: ${release_err}"
-	echo -e "${YELLOW}Warning${NC}: Could not fetch releases for ${slug}" >&2
-	return 1
-}
-
-#######################################
-# Probe GitHub API for the latest commit of a repository.
-# Echoes commit JSON on success; empty string on error.
-# Arguments:
-#   $1 - Repository slug (owner/repo)
-# Outputs: commit JSON via stdout (empty on error)
-# Returns: 0 on success, 1 on API error
-#######################################
-_probe_github_commit() {
-	local slug="$1"
-	local api_stderr
-	api_stderr=$(mktemp -t upstream-watch-err.XXXXXX)
-	local commit_json=""
-
-	if commit_json=$(gh api "repos/${slug}/commits?per_page=1" --jq '.[0]' 2>"$api_stderr"); then
-		rm -f "$api_stderr"
-		printf '%s' "$commit_json"
-		return 0
-	fi
-
-	local commit_err
-	commit_err=$(<"$api_stderr")
-	rm -f "$api_stderr"
-
-	_log_warn "gh api commits failed for ${slug}: ${commit_err}"
-	echo -e "${YELLOW}Warning${NC}: Could not fetch commits for ${slug}" >&2
-	return 1
-}
-
-#######################################
-# Check a single GitHub repo for new releases and commits.
-# Updates state in-place (passed by reference via global _check_state).
-# Arguments:
-#   $1 - Repository slug (owner/repo)
-#   $2 - Config JSON
-#   $3 - Current ISO timestamp
-#   $4 - Verbose flag (true/false)
-# Outputs: prints update report to stdout
-# Returns: 0 if up to date or updated, 1 if probe failed
-# Side-effects: sets _check_updates_found, _check_had_probe_failure globals
-#######################################
-_check_single_github_repo() {
-	local slug="$1"
-	local config="$2"
-	local now="$3"
-	local verbose="$4"
-
-	# Get relevance from config
-	local relevance
-	relevance=$(echo "$config" | jq -r --arg slug "$slug" '.repos[] | select(.slug == $slug) | .relevance // ""')
-
-	# Get last-seen state
-	local last_release_seen last_commit_seen updates_pending_before
-	last_release_seen=$(echo "$_check_state" | jq -r --arg slug "$slug" '.repos[$slug].last_release_seen // ""')
-	last_commit_seen=$(echo "$_check_state" | jq -r --arg slug "$slug" '.repos[$slug].last_commit_seen // ""')
-	updates_pending_before=$(echo "$_check_state" | jq -r --arg slug "$slug" '.repos[$slug].updates_pending // 0')
-
-	# --- Check releases ---
-	local release_json="" probe_failed=false
-	local latest_release_tag="" latest_release_name="" latest_release_date=""
-	if ! release_json=$(_probe_github_release "$slug"); then
-		probe_failed=true
-	fi
-	if [[ -n "$release_json" ]]; then
-		latest_release_tag=$(echo "$release_json" | jq -r '.tag_name // ""')
-		latest_release_name=$(echo "$release_json" | jq -r '.name // ""')
-		latest_release_date=$(echo "$release_json" | jq -r '.published_at // ""')
-	fi
-
-	local has_new_release=false
-	if [[ -n "$latest_release_tag" && "$latest_release_tag" != "$last_release_seen" ]]; then
-		has_new_release=true
-	fi
-
-	# --- Check commits (even if no new release) ---
-	local commit_json="" latest_commit="" latest_commit_date=""
-	if ! commit_json=$(_probe_github_commit "$slug"); then
-		probe_failed=true
-	fi
-	if [[ -n "$commit_json" ]]; then
-		latest_commit=$(echo "$commit_json" | jq -r '.sha // ""')
-		latest_commit_date=$(echo "$commit_json" | jq -r '.commit.committer.date // ""')
-	fi
-
-	local has_new_commits=false
-	if [[ -n "$latest_commit" && "${latest_commit:0:7}" != "$last_commit_seen" ]]; then
-		has_new_commits=true
-	fi
-
-	# --- Report ---
-	_report_github_repo_update "$slug" "$relevance" \
-		"$has_new_release" "$has_new_commits" \
-		"$last_release_seen" "$last_commit_seen" \
-		"$latest_release_tag" "$latest_release_name" "$latest_release_date" \
-		"$latest_commit" "$latest_commit_date" "$verbose"
-
-	# Update last_checked and updates_pending (not last_seen — requires explicit ack)
-	# Skip state update if probes failed to avoid masking errors as "up to date"
-	if [[ "$probe_failed" != true ]]; then
-		local new_pending
-		new_pending=$([[ "$has_new_release" == true || "$has_new_commits" == true ]] && echo 1 || echo 0)
-		_check_state=$(echo "$_check_state" | jq --arg slug "$slug" --arg now "$now" \
-			--argjson pending "$new_pending" \
-			'.repos[$slug].last_checked = $now | .repos[$slug].updates_pending = $pending')
-
-		# File GitHub issue on 0→1 transition (t2810)
-		if [[ "$updates_pending_before" != "1" && "$new_pending" == "1" ]]; then
-			local update_kind="commit"
-			local update_old="$last_commit_seen"
-			local update_new="${latest_commit:0:7}"
-			if [[ "$has_new_release" == true ]]; then
-				update_kind="release"
-				update_old="$last_release_seen"
-				update_new="$latest_release_tag"
-			fi
-			local config_entry
-			config_entry=$(echo "$config" | jq --arg slug "$slug" '.repos[] | select(.slug == $slug)')
-			_file_upstream_update_issue "$slug" "$update_kind" "$update_old" "$update_new" "$config_entry"
-		fi
-	else
-		_check_had_probe_failure=true
-	fi
-	return 0
-}
-
-#######################################
-# Check all non-GitHub upstreams (Docker Hub, GitLab, Forgejo, etc.)
-# Updates _check_state in-place via global.
-# Arguments:
-#   $1 - Config JSON
-#   $2 - Target name (empty = all)
-#   $3 - Current ISO timestamp
-# Side-effects: sets _check_updates_found, _check_had_probe_failure globals
-#######################################
-_check_non_github_upstreams() {
-	local config="$1"
-	local target_name="$2"
-	local now="$3"
-
-	local non_github_names
-	if [[ -n "$target_name" ]]; then
-		non_github_names="$target_name"
-	else
-		non_github_names=$(echo "$config" | jq -r '.non_github_upstreams // [] | .[].name')
-	fi
-
-	while IFS= read -r entry_name; do
-		[[ -z "$entry_name" ]] && continue
-
-		local entry_json
-		entry_json=$(echo "$config" | jq --arg name "$entry_name" '.non_github_upstreams[] | select(.name == $name)')
-
-		local check_cmd source_type description relevance entry_url
-		check_cmd=$(echo "$entry_json" | jq -r '.check_command // ""')
-		source_type=$(echo "$entry_json" | jq -r '.source_type // "unknown"')
-		description=$(echo "$entry_json" | jq -r '.description // ""')
-		relevance=$(echo "$entry_json" | jq -r '.relevance // ""')
-		entry_url=$(echo "$entry_json" | jq -r '.url // ""')
-
-		if [[ -z "$check_cmd" ]]; then
-			echo -e "${YELLOW}Warning${NC}: No check_command for ${entry_name}, skipping" >&2
-			continue
-		fi
-
-		# Get last-seen state
-		local last_seen_value ng_updates_pending_before
-		last_seen_value=$(echo "$_check_state" | jq -r --arg name "$entry_name" '.non_github[$name].last_seen // ""')
-		ng_updates_pending_before=$(echo "$_check_state" | jq -r --arg name "$entry_name" '.non_github[$name].updates_pending // 0')
-
-		# Run the check command (curl + jq) in a subshell for isolation
-		# Note: check_command comes from a committed config file, not user input
-		local current_value=""
-		local probe_failed=false
-		current_value=$(bash -c "$check_cmd" 2>/dev/null) || {
-			_log_warn "check_command failed for ${entry_name}"
-			echo -e "${YELLOW}Warning${NC}: Could not check ${entry_name} (${source_type})" >&2
-			probe_failed=true
-		}
-
-		# Trim whitespace
-		current_value=$(echo "$current_value" | tr -d '[:space:]')
-
-		local has_update=false
-		if [[ "$probe_failed" != true && -n "$current_value" && "$current_value" != "$last_seen_value" ]]; then
-			has_update=true
-		fi
-
-		if [[ "$has_update" == true ]]; then
-			_check_updates_found=$((_check_updates_found + 1))
-			echo ""
-			echo -e "${YELLOW}UPDATE DETECTED${NC}: ${entry_name} (${source_type})"
-			echo "  Description: ${description}"
-			[[ -n "$relevance" ]] && echo -e "  Relevance:   ${CYAN}${relevance}${NC}"
-			echo "  Previous:    ${last_seen_value:-none}"
-			echo "  Current:     ${current_value}"
-			[[ -n "$entry_url" ]] && echo "  URL:         ${entry_url}"
-
-			# Show affected files
-			local affects
-			affects=$(echo "$entry_json" | jq -r '.affects // [] | .[]' 2>/dev/null)
-			if [[ -n "$affects" ]]; then
-				echo "  Affects:"
-				while IFS= read -r affected_file; do
-					[[ -n "$affected_file" ]] && echo "    - ${affected_file}"
-				done <<<"$affects"
-			fi
-
-			echo "  Action:      Review changes, then run: upstream-watch-helper.sh ack ${entry_name}"
-		elif [[ "$probe_failed" != true ]]; then
-			echo -e "${GREEN}Up to date${NC}: ${entry_name} (${source_type}: ${current_value:-unknown})"
-		fi
-
-		# Update state (but not last_seen — that requires explicit ack)
-		if [[ "$probe_failed" != true ]]; then
-			local ng_new_pending
-			ng_new_pending=$([[ "$has_update" == true ]] && echo 1 || echo 0)
-			_check_state=$(echo "$_check_state" | jq --arg name "$entry_name" --arg now "$now" \
-				--arg current "$current_value" \
-				--argjson pending "$ng_new_pending" \
-				'.non_github[$name].last_checked = $now | .non_github[$name].current_value = $current | .non_github[$name].updates_pending = $pending')
-
-			# File GitHub issue on 0→1 transition (t2810)
-			if [[ "$ng_updates_pending_before" != "1" && "$ng_new_pending" == "1" ]]; then
-				_file_upstream_update_issue "$entry_name" "update" "$last_seen_value" "$current_value" "$entry_json"
-			fi
-		else
-			_check_had_probe_failure=true
-		fi
-
-	done <<<"$non_github_names"
-	return 0
-}
-
-#######################################
-# Check watched repos for new releases and commits
-# Compares current GitHub state against last-seen state. Reports new
-# releases with changelog diffs and new commits. Does NOT advance
-# last_seen — that requires explicit ack. Returns 1 if any probe failed.
-# Also checks non-GitHub upstreams (Docker Hub, GitLab, Forgejo) via
-# their configured check_command.
-# Arguments:
-#   $1 - Optional target slug/name to check a single repo
-# Globals:
-#   VERBOSE - Show commit-level detail when true
-#######################################
-cmd_check() {
-	local target_slug="${1:-}"
-	local verbose="${VERBOSE:-false}"
-
-	_check_prerequisites || return 1
-
-	local config
-	config=$(_read_config)
-	# Use a global so sub-functions can update state in-place
-	_check_state=$(_read_state)
-
-	# Check if target is a non-GitHub upstream name
-	local target_is_non_github=false
-	if [[ -n "$target_slug" ]]; then
-		if echo "$config" | jq -e --arg name "$target_slug" '.non_github_upstreams // [] | .[] | select(.name == $name)' >/dev/null 2>&1; then
-			target_is_non_github=true
-		fi
-	fi
-
-	local slugs=""
-	if [[ -n "$target_slug" && "$target_is_non_github" != true ]]; then
-		# Validate that the target slug is on the GitHub watchlist
-		if ! echo "$config" | jq -e --arg slug "$target_slug" '.repos[] | select(.slug == $slug)' >/dev/null 2>&1; then
-			echo -e "${RED}Error: Not watching ${target_slug}. Add it first with 'upstream-watch-helper.sh add ${target_slug}'.${NC}" >&2
-			return 1
-		fi
-		slugs="$target_slug"
-	elif [[ "$target_is_non_github" != true ]]; then
-		slugs=$(echo "$config" | jq -r '.repos[].slug')
-	fi
-
-	local has_github_repos=false
-	local has_non_github=false
-	[[ -n "$slugs" ]] && has_github_repos=true
-	if echo "$config" | jq -e '.non_github_upstreams // [] | length > 0' >/dev/null 2>&1; then
-		has_non_github=true
-	fi
-
-	if [[ "$has_github_repos" != true && "$has_non_github" != true ]]; then
-		echo -e "${BLUE}No repos being watched. Use 'add' to start watching.${NC}"
-		return 0
-	fi
-
-	# Shared counters updated by sub-functions
-	_check_updates_found=0
-	_check_had_probe_failure=false
-	local now
-	now=$(_now_iso)
-
-	# Check GitHub repos
-	while IFS= read -r slug; do
-		[[ -z "$slug" ]] && continue
-		_check_single_github_repo "$slug" "$config" "$now" "$verbose"
-	done <<<"$slugs"
-
-	# Check non-GitHub upstreams
-	if [[ "$has_non_github" == true ]]; then
-		local ng_target=""
-		[[ "$target_is_non_github" == true ]] && ng_target="$target_slug"
-		_check_non_github_upstreams "$config" "$ng_target" "$now"
-	fi
-
-	# Only advance global last_check if all probes succeeded — partial failures
-	# should not advance the 24h gate so the caller retries on the next cycle
-	if [[ "$_check_had_probe_failure" != true ]]; then
-		_check_state=$(echo "$_check_state" | jq --arg now "$now" '.last_check = $now')
-	fi
-	_write_state "$_check_state"
-
-	echo ""
-	if [[ "$_check_updates_found" -gt 0 ]]; then
-		echo -e "${YELLOW}${_check_updates_found} repo(s) have updates to review.${NC}"
-	else
-		echo -e "${GREEN}All watched repos are up to date.${NC}"
-	fi
-
-	_log_info "Check complete: ${_check_updates_found} updates found"
-	[[ "$_check_had_probe_failure" == true ]] && return 1
-	return 0
-}
-
-#######################################
-# Display release changelog between two tags
-# Shows all releases between from_tag and to_tag, plus latest release notes.
-# Arguments:
-#   $1 - Repository slug (owner/repo)
-#   $2 - From tag (last seen, empty for first check)
-#   $3 - To tag (latest release)
-#######################################
-_show_release_diff() {
-	local slug="$1"
-	local from_tag="$2"
-	local to_tag="$3"
-
-	if [[ -z "$from_tag" ]]; then
-		# First time — just show the latest release notes
-		echo "  Release notes:"
-		local body
-		body=$(gh api "repos/${slug}/releases/latest" --jq '.body // "No release notes"' 2>/dev/null) || body="Could not fetch"
-		sed -n '1,20{s/^/    /;p;}' <<<"$body"
-		local line_count
-		line_count=$(wc -l <<<"$body" | tr -d ' ')
-		if [[ "$line_count" -gt 20 ]]; then
-			echo "    ... (${line_count} lines total — view full notes on GitHub)"
-		fi
-		return 0
-	fi
-
-	# Show all releases between from_tag and to_tag
-	local releases
-	releases=$(gh api --paginate "repos/${slug}/releases" --jq '.[].tag_name' 2>/dev/null) || {
-		echo "  (Could not fetch release list)"
-		return 0
-	}
-
-	# Find releases newer than from_tag
-	local in_range=true
-	local release_count=0
-	echo "  Releases since ${from_tag}:"
-	while IFS= read -r tag; do
-		[[ -z "$tag" ]] && continue
-		if [[ "$tag" == "$from_tag" ]]; then
-			in_range=false
-			continue
-		fi
-		if [[ "$in_range" == true ]]; then
-			release_count=$((release_count + 1))
-			# Get one-line summary for each release
-			local rel_name rel_date
-			rel_name=$(gh api "repos/${slug}/releases/tags/${tag}" --jq '.name // .tag_name' 2>/dev/null) || rel_name="$tag"
-			rel_date=$(gh api "repos/${slug}/releases/tags/${tag}" --jq '.published_at // ""' 2>/dev/null) || rel_date=""
-			local date_short="${rel_date:0:10}"
-			echo "    ${tag} (${date_short}) — ${rel_name}"
-		fi
-	done <<<"$releases"
-
-	if [[ "$release_count" -eq 0 ]]; then
-		echo "    (none found — tags may not match release list)"
-	fi
-
-	# Show latest release notes
-	echo ""
-	echo "  Latest release notes (${to_tag}):"
-	local body
-	body=$(gh api "repos/${slug}/releases/tags/${to_tag}" --jq '.body // "No release notes"' 2>/dev/null) || body="Could not fetch"
-	sed -n '1,30{s/^/    /;p;}' <<<"$body"
-	local line_count
-	line_count=$(wc -l <<<"$body" | tr -d ' ')
-	if [[ "$line_count" -gt 30 ]]; then
-		echo "    ... (${line_count} lines total)"
-	fi
-	return 0
-}
-
-#######################################
-# Display recent commits between two SHAs
-# Shows up to 10 commits newer than from_sha.
-# Arguments:
-#   $1 - Repository slug (owner/repo)
-#   $2 - From SHA (7-char, last seen)
-#   $3 - To SHA (7-char, latest)
-#######################################
-_show_commit_diff() {
-	local slug="$1"
-	local from_sha="$2"
-	local to_sha="$3"
-
-	if [[ -z "$from_sha" || "$from_sha" == "$to_sha" ]]; then
-		return 0
-	fi
-
-	echo "  Recent commits:"
-	local commits
-	commits=$(gh api "repos/${slug}/commits?per_page=10" \
-		--jq '.[] | "\(.sha[0:7]) \(.commit.message | split("\n")[0])"' 2>/dev/null) || {
-		echo "    (Could not fetch commits)"
-		return 0
-	}
-
-	local count=0
-	while IFS= read -r line; do
-		[[ -z "$line" ]] && continue
-		local sha="${line%% *}"
-		if [[ "$sha" == "$from_sha" ]]; then
-			break
-		fi
-		count=$((count + 1))
-		echo "    ${line}"
-		if [[ "$count" -ge 10 ]]; then
-			echo "    ... (showing first 10)"
-			break
-		fi
-	done <<<"$commits"
-
-	if [[ "$count" -eq 0 ]]; then
-		echo "    (no new commits found in recent history)"
-	fi
-	return 0
-}
-
-#######################################
 # Acknowledge the latest release/commit for a watched repo
 # Updates last_release_seen and last_commit_seen to current, clears
 # updates_pending. Validates slug against config watchlist first.
@@ -1204,7 +253,7 @@ cmd_ack() {
 
 	# Check if this is a non-GitHub upstream name
 	if echo "$config" | jq -e --arg name "$slug" '.non_github_upstreams // [] | .[] | select(.name == $name)' >/dev/null 2>&1; then
-		# Non-GitHub upstream — run check_command to get current value and store as last_seen
+		# Non-GitHub upstream -- run check_command to get current value and store as last_seen
 		local check_cmd
 		check_cmd=$(echo "$config" | jq -r --arg name "$slug" '.non_github_upstreams[] | select(.name == $name) | .check_command // ""')
 
@@ -1234,7 +283,7 @@ cmd_ack() {
 		return 0
 	fi
 
-	# GitHub repo — original logic
+	# GitHub repo -- original logic
 	_check_prerequisites || return 1
 
 	# Validate against config watchlist (consistent with cmd_check)
@@ -1359,7 +408,7 @@ cmd_status() {
 #######################################
 cmd_help() {
 	cat <<'EOF'
-upstream-watch-helper.sh — Track external repos for release monitoring
+upstream-watch-helper.sh -- Track external repos for release monitoring
 
 USAGE:
     upstream-watch-helper.sh <command> [options]
@@ -1376,7 +425,7 @@ COMMANDS:
 EXAMPLES:
     # Watch a repo
     upstream-watch-helper.sh add vercel-labs/portless \
-      --relevance "Local dev hosting — compare against localdev-helper.sh"
+      --relevance "Local dev hosting -- compare against localdev-helper.sh"
 
     # Check for updates
     upstream-watch-helper.sh check
@@ -1406,7 +455,7 @@ NON-GITHUB UPSTREAMS:
 INTEGRATION:
     The pulse can call 'upstream-watch-helper.sh check' to surface
     updates during supervisor sweeps. When an update is detected
-    (updates_pending transitions 0→1), a GitHub issue is filed
+    (updates_pending transitions 0->1), a GitHub issue is filed
     automatically with labels source:upstream-watch, auto-dispatch,
     tier:standard. The 'ack' command closes the matching issue.
     Both GitHub repos and non-GitHub upstreams are checked in a
@@ -1424,7 +473,7 @@ EOF
 # =============================================================================
 
 #######################################
-# Main entry point — parse command and dispatch to handler
+# Main entry point -- parse command and dispatch to handler
 # Arguments:
 #   $1 - Command (add, remove, check, ack, status, help)
 #   $@ - Command-specific arguments


### PR DESCRIPTION
## Summary

Split `upstream-watch-helper.sh` (1519 lines) into 4 focused files so every shell
script is under the 1500-line file-size-debt threshold. Function groups
move verbatim; no behavioural changes.

| file | lines | scope |
|---|---|---|
| `upstream-watch-helper.sh` | 568 | thin orchestrator: globals, source calls, cmd_add/remove/ack/status/help/main |
| `upstream-watch-helper-state.sh` | 213 | logging, prerequisites, state/config file I/O, ISO helpers |
| `upstream-watch-helper-issues.sh` | 281 | GitHub issue filing/closing (t2810) |
| `upstream-watch-helper-check.sh` | 598 | probe, check, diff display, cmd_check |

Mirrors the `issue-sync-helper.sh` / `issue-sync-lib.sh` split precedent.
Each sub-library has an include guard and a `# shellcheck source=./...`
directive paired with an SC1091 disable (runtime-resolved via `$SCRIPT_DIR`,
cannot be statically followed without `-x`).

## Changes

1. **4 files** -- 3 new sub-libraries + rewritten orchestrator. No
   caller-facing API changes; callers continue to source/invoke only
   `upstream-watch-helper.sh`.
2. **Defensive `SCRIPT_DIR` fallback** in each sub-library (derived from
   `BASH_SOURCE[0]`, matches the `issue-sync-lib.sh` pattern).
3. **Fixed pre-existing `UPSTREAM_WATCH_LABEL` unbound variable bug** --
   added `${UPSTREAM_WATCH_LABEL:-source:upstream-watch}` default so the
   script actually runs under `set -u` (original and deployed versions
   both fail with "unbound variable").

## Testing

- `shellcheck` on all 4 files -- zero violations
- `bash upstream-watch-helper.sh help` -- resolves all functions, prints help
- `bash upstream-watch-helper.sh status` -- runs through full source chain, shows 7 GitHub + 3 non-GitHub upstreams
- All 19 sub-library functions resolve via `type` check
- `wc -l`: 568 + 213 + 281 + 598 = 1660 total (all under 1500 individually)

## Related

- Resolves #21336
- For #21146
- Reference: `reference/large-file-split.md`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.5 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-opus-4-6 spent 11m and 32,101 tokens on this as a headless worker.
