### PR TITLE
GH#21510: fix source_pdf propagation and redundant conditional in pageindex-generator

### DIFF
--- a/.agents/scripts/pageindex-generator.py
+++ b/.agents/scripts/pageindex-generator.py
@@ -224,6 +224,7 @@ def build_headingless_result(
     frontmatter: Dict[str, str],
     content_lines: List[str],
     ctx: TreeContext,
+    source_pdf: str = '',
 ) -> Dict[str, Any]:
     """Build a single-node result when the document has no headings.
 
@@ -240,7 +241,7 @@ def build_headingless_result(
     return {
         "version": "1.0",
         "generator": "aidevops/document-creation-helper",
-        "source_file": frontmatter.get('source_file', ''),
+        "source_file": frontmatter.get('source_file', source_pdf),
         "content_hash": frontmatter.get('content_hash', ''),
         "page_count": ctx.page_count,
         "tree": {
@@ -289,7 +290,7 @@ def build_pageindex_tree(
     sections = parse_sections(content_lines)
 
     if not sections:
-        result = build_headingless_result(frontmatter, content_lines, ctx)
+        result = build_headingless_result(frontmatter, content_lines, ctx, source_pdf)
         root_node = result['tree']
         for tag_rec in open_tags:
             _inject_tag_record(root_node, tag_rec)
@@ -328,7 +329,7 @@ def build_pageindex_tree(
     result = {
         "version": "1.0",
         "generator": "aidevops/document-creation-helper",
-        "source_file": frontmatter.get('source_file', source_pdf if source_pdf else ''),
+        "source_file": frontmatter.get('source_file', source_pdf),
         "content_hash": content_hash,
         "page_count": page_count,
         "tree": tree,


### PR DESCRIPTION
## Summary

Fix two medium-severity Gemini review findings from PR #21365 on `.agents/scripts/pageindex-generator.py`:

1. **`build_headingless_result` missing `source_pdf` argument** — the function was called without `source_pdf`, so `source_file` in headingless documents always fell back to `''` rather than the actual PDF path. Updated the function signature to accept `source_pdf: str = ''` as a fourth parameter, and passed `source_pdf` at the call site.

2. **Redundant conditional** — `source_pdf if source_pdf else ''` simplified to `source_pdf` (line 331). `source_pdf` is typed as `str` and always defaults to `''`, so the conditional was a no-op.

## Files Changed

- `EDIT: .agents/scripts/pageindex-generator.py:223-227` — added `source_pdf: str = ''` parameter to `build_headingless_result`
- `EDIT: .agents/scripts/pageindex-generator.py:243` — use `source_pdf` as fallback in function body
- `EDIT: .agents/scripts/pageindex-generator.py:292-293` — pass `source_pdf` at call site
- `EDIT: .agents/scripts/pageindex-generator.py:331` — simplify redundant conditional

## Verification

```
python3 -c "import ast; ast.parse(open('.agents/scripts/pageindex-generator.py').read()); print('syntax OK')"
# syntax OK
```

Resolves #21510


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.5 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-sonnet-4-6 spent 3m and 4,260 tokens on this as a headless worker.