### PR TITLE
GH#21501: add fallback guards for audit-worktree-removal-helper sourcing in skill-update-helper.sh

### DIFF
--- a/.agents/scripts/skill-update-helper.sh
+++ b/.agents/scripts/skill-update-helper.sh
@@ -29,11 +29,15 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 source "${SCRIPT_DIR}/shared-constants.sh"
 
-# t2976: canonical audit logger for worktree-removal events
-if [[ -f "${SCRIPT_DIR}/audit-worktree-removal-helper.sh" ]]; then
-	# shellcheck source=audit-worktree-removal-helper.sh
-	source "${SCRIPT_DIR}/audit-worktree-removal-helper.sh"
-fi
+# t2976: canonical audit logger for worktree-removal events.
+# Provide fallbacks so variables and the function are defined even if the
+# helper is absent (guards against 'unbound variable' errors under set -u
+# when sub-libraries reference these symbols after set -euo pipefail).
+_WTAR_REMOVED="${_WTAR_REMOVED:-removed}"
+_WTAR_SKIPPED="${_WTAR_SKIPPED:-skipped}"
+log_worktree_removal_event() { return 0; }
+# shellcheck source=audit-worktree-removal-helper.sh
+source "${SCRIPT_DIR}/audit-worktree-removal-helper.sh" || true
 # Caller ID constant (avoids repeated literals).
 _WTAR_SU_CALLER="skill-update-helper.sh"
 


### PR DESCRIPTION
## Summary

Addresses Gemini review feedback from PR #21372 on `.agents/scripts/skill-update-helper.sh`.

The previous `if [[ -f ... ]]; then source; fi` guard left `_WTAR_REMOVED`, `_WTAR_SKIPPED`, and `log_worktree_removal_event` undefined when `audit-worktree-removal-helper.sh` is absent. Sub-library `skill-update-pr-lib.sh` references these symbols after `set -euo pipefail` is active — an absent variable triggers an "unbound variable" error under `set -u`.

## Changes

**EDIT: `.agents/scripts/skill-update-helper.sh:32-42`**

- Define `_WTAR_REMOVED` and `_WTAR_SKIPPED` with `${VAR:-value}` defaults before sourcing
- Define a no-op `log_worktree_removal_event() { return 0; }` fallback function before sourcing
- Replace `if [[ -f ]]; then source; fi` with unconditional `source ... || true`

The `audit-worktree-removal-helper.sh` double-source guard (`_AUDIT_WORKTREE_REMOVAL_HELPER_LOADED`) ensures the real definitions take effect when the file is present.

## Verification

```bash
shellcheck -x .agents/scripts/skill-update-helper.sh  # 0 violations
```

Resolves #21501


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.5 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-sonnet-4-6 spent 4m and 7,280 tokens on this as a headless worker.