### PR TITLE
GH#21441: fix jq optional operator in gh-status-helper to handle null incidents key

### DIFF
--- a/.agents/scripts/gh-status-helper.sh
+++ b/.agents/scripts/gh-status-helper.sh
@@ -195,7 +195,7 @@ cmd_incidents() {
 	fi
 
 	if [[ "$ARG_JSON" -eq 1 ]]; then
-		jq '{incidents: [.incidents[] | {name, impact, started_at, latest_update: (.incident_updates[0].body // ""), components: [.components[].name]}]}' "$CACHE_INCIDENTS"
+		jq '{incidents: [.incidents[]? | {name, impact, started_at, latest_update: (.incident_updates[0].body // ""), components: [.components[].name]}]}' "$CACHE_INCIDENTS"
 	else
 		# Human-readable listing. Empty list = healthy.
 		local count
@@ -233,7 +233,7 @@ cmd_correlate() {
 		count=$(jq '.incidents | length' "$CACHE_INCIDENTS")
 		if [[ "$count" -gt 0 ]]; then
 			printf 'Active incidents:\n\n'
-			jq -r '.incidents[] | "- **[\(.impact)]** \(.name) — components: \([.components[].name] | join(", ")) (started \(.started_at))"' "$CACHE_INCIDENTS"
+			jq -r '.incidents[]? | "- **[\(.impact)]** \(.name) — components: \([.components[].name] | join(", ")) (started \(.started_at))"' "$CACHE_INCIDENTS"
 			printf '\n'
 		fi
 	fi


### PR DESCRIPTION
## MERGE_SUMMARY

Fixed two jq expressions in `.agents/scripts/gh-status-helper.sh` to use the optional operator `.incidents[]?` instead of `.incidents[]`. This prevents jq TypeErrors when the GitHub Statuspage API returns a null or absent `incidents` key.

**Changes:**
- Line 198 (`cmd_incidents` JSON path): `.incidents[]` → `.incidents[]?`
- Line 236 (`cmd_correlate` display path): `.incidents[]` → `.incidents[]?`

**Verification:** `shellcheck .agents/scripts/gh-status-helper.sh` — zero violations.

Resolves #21441

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.5 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-sonnet-4-6 spent 5m and 4,921 tokens on this as a headless worker.
