### PR TITLE
GH#21474: auto-create blocked-by:tNNN labels in pre-flight validation to resolve t2800/t2823 collision

### DIFF
--- a/.agents/scripts/claim-task-id.sh
+++ b/.agents/scripts/claim-task-id.sh
@@ -674,9 +674,37 @@ _extract_github_slug() {
 	return 0
 }
 
+# _auto_create_blocked_by_label — create a missing blocked-by:tNNN or blocked-by:#NNN
+# label in the repo when it does not yet exist. Updates the session label cache on success.
+# Args: $1 repo_slug (owner/repo), $2 label name (e.g. "blocked-by:t324"), $3 cache_file path.
+# Returns: 0 = label created (or already exists), 1 = creation failed (rate limit / permission).
+_auto_create_blocked_by_label() {
+	local repo_slug="$1"
+	local label="$2"
+	local cache_file="$3"
+	local predecessor="${label#blocked-by:}"
+
+	if gh label create "$label" --repo "$repo_slug" \
+		--color "5319E7" \
+		--description "Blocked by predecessor task ${predecessor}" \
+		>/dev/null 2>&1; then
+		# Append to session cache so subsequent lookups in this invocation hit
+		printf '%s\n' "$label" >>"$cache_file" 2>/dev/null || true
+		log_info "Auto-created label '${label}' in ${repo_slug} (t2823/t2800 auto-create exception)"
+		return 0
+	else
+		log_warn "Could not auto-create label '${label}' in ${repo_slug} (rate limit or permission) — proceeding without it"
+		return 1
+	fi
+}
+
 # _validate_labels_exist — check that every label in $2 exists in repo $1.
 # Args: $1 repo_slug (owner/repo), $2 comma-separated label names.
 # Returns: 0 = all valid (or fail-open), 1 = invalid labels found.
+#
+# Auto-create exception (GH#21474): labels matching ^blocked-by:(t[0-9]+|#[0-9]+)$
+# are auto-created when missing — they are a deterministic function of the predecessor
+# task ID and safe to create on demand. All other invalid labels still abort (exit 3).
 _validate_labels_exist() {
 	local repo_slug="$1"
 	local labels_csv="$2"
@@ -706,6 +734,10 @@ _validate_labels_exist() {
 		fi
 	fi
 
+	# Regex for the auto-create exception class (blocked-by:tNNN or blocked-by:#NNN).
+	# These labels are auto-created when missing — all other invalid labels still abort.
+	local _BLOCKED_BY_AUTO_CREATE_REGEX='^blocked-by:(t[0-9]+|#[0-9]+)$'
+
 	# Check each label against the cache
 	local invalid_labels=""
 	local label
@@ -721,6 +753,15 @@ _validate_labels_exist() {
 		label="${label%"${label##*[![:space:]]}"}"  # trim trailing whitespace
 		[[ -z "$label" ]] && continue
 		if ! grep -Fxq "$label" "$cache_file" 2>/dev/null; then
+			# Auto-create exception: blocked-by:tNNN / blocked-by:#NNN labels are
+			# synthesised by t2823 from description text and may not exist yet in fresh
+			# consumer repos. Create them on demand and continue — best-effort (t2800/GH#21474).
+			if [[ "$label" =~ $_BLOCKED_BY_AUTO_CREATE_REGEX ]]; then
+				_auto_create_blocked_by_label "$repo_slug" "$label" "$cache_file" || true
+				# Whether creation succeeded or not, don't abort — body text still records
+				# the dependency for pulse-dep-graph.sh and pulse-issue-reconcile-actions.sh.
+				continue
+			fi
 			if [[ -n "$invalid_labels" ]]; then
 				invalid_labels="${invalid_labels}, '${label}'"
 			else
@@ -730,8 +771,15 @@ _validate_labels_exist() {
 	done
 
 	if [[ -n "$invalid_labels" ]]; then
-		log_error "Pre-flight label validation failed — invalid label(s): ${invalid_labels}"
-		log_error "  Run: gh label list --repo \"${repo_slug}\" | grep -i '<name>'"
+		log_error "Pre-flight label validation failed — label(s) do not exist in this repo: ${invalid_labels}"
+		log_error ""
+		log_error "Each invalid label must be created before claiming, OR use one of these options:"
+		log_error "  (a) Create the label and re-run:"
+		log_error "        gh label create '<name>' --repo \"${repo_slug}\" --color '0075ca' --description '...'"
+		log_error "  (b) If the label was auto-emitted from a --description predecessor reference,"
+		log_error "      skip it: re-run with --no-blocked-by (dependency still recorded in body text)"
+		log_error "  (c) Use a different blocking label that already exists, e.g. 'status:blocked'"
+		log_error ""
 		log_error "  Claim aborted — counter NOT advanced."
 		return 1
 	fi

--- a/.agents/scripts/tests/test-claim-label-auto-create.sh
+++ b/.agents/scripts/tests/test-claim-label-auto-create.sh
@@ -1,0 +1,370 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-claim-label-auto-create.sh — GH#21474 regression guard.
+#
+# Validates the auto-create exception in _validate_labels_exist(): when a label
+# matching ^blocked-by:(t[0-9]+|#[0-9]+)$ is missing from the repo, the helper
+# auto-creates it via gh label create and continues instead of aborting.
+#
+# Cases covered:
+#   1. blocked-by:t999 missing, gh label create succeeds   → label created in cache,
+#                                                             _validate_labels_exist returns 0
+#   2. blocked-by:t999 missing, gh label create fails       → warning only, returns 0
+#                                                             (best-effort / fail-open)
+#   3. tier:standrad (typo) missing                         → still aborts with return 1
+#                                                             (t2800 typo-protection preserved)
+#   4. blocked-by:#999 (issue-number variant) missing,
+#      gh label create succeeds                             → label created, returns 0
+#   5. blocked-by:t999 already exists in cache              → no create called, returns 0
+#
+# NOTE: not using `set -e` — assertions rely on capturing non-zero exits.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+CLAIM_SCRIPT="${SCRIPT_DIR}/../claim-task-id.sh"
+
+RED=$'\033[0;31m'
+GREEN=$'\033[0;32m'
+NC=$'\033[0m'
+
+PASS=0
+FAIL=0
+ERRORS=""
+
+# ---------------------------------------------------------------------------
+# Test framework helpers
+# ---------------------------------------------------------------------------
+
+pass() {
+	local name="${1:-}"
+	printf '%s[PASS]%s %s\n' "$GREEN" "$NC" "$name"
+	PASS=$((PASS + 1))
+	return 0
+}
+
+fail() {
+	local name="${1:-}"
+	local detail="${2:-}"
+	printf '%s[FAIL]%s %s\n' "$RED" "$NC" "$name"
+	[[ -n "$detail" ]] && printf '       detail: %s\n' "$detail"
+	FAIL=$((FAIL + 1))
+	ERRORS="${ERRORS}\n  - ${name}: ${detail}"
+	return 0
+}
+
+assert_eq() {
+	local name="$1" got="$2" want="$3"
+	if [[ "$got" == "$want" ]]; then
+		pass "$name"
+	else
+		fail "$name" "want='${want}' got='${got}'"
+	fi
+	return 0
+}
+
+assert_return() {
+	local name="$1" actual_rc="$2" want_rc="$3"
+	if [[ "$actual_rc" == "$want_rc" ]]; then
+		pass "$name"
+	else
+		fail "$name" "want exit=${want_rc} got exit=${actual_rc}"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Shared setup: source claim-task-id.sh with minimal stubs.
+# The BASH_SOURCE guard in the script prevents main() from running on source.
+# ---------------------------------------------------------------------------
+
+# Create a temp dir for stubs and state shared across all tests
+BASE_STUB_DIR=""
+BASE_STUB_DIR=$(mktemp -d)
+trap 'rm -rf '"$BASE_STUB_DIR"'' EXIT
+
+# Fake git: no-op (silences detect_platform remote calls)
+cat >"${BASE_STUB_DIR}/git" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "${BASE_STUB_DIR}/git"
+
+# Fake jq: no-op
+cat >"${BASE_STUB_DIR}/jq" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+chmod +x "${BASE_STUB_DIR}/jq"
+
+export HOME="${BASE_STUB_DIR}/home"
+mkdir -p "${HOME}/.aidevops/logs"
+
+# ---------------------------------------------------------------------------
+# Helper: build a per-test gh stub in a new subdir and prepend it to PATH.
+# The stub file is written by the caller to configure per-test behavior.
+# ---------------------------------------------------------------------------
+_make_stub_dir() {
+	local stub_dir
+	stub_dir=$(mktemp -d "${BASE_STUB_DIR}/test-XXXXXX")
+	# Copy shared stubs
+	cp "${BASE_STUB_DIR}/git" "${stub_dir}/git"
+	cp "${BASE_STUB_DIR}/jq" "${stub_dir}/jq"
+	printf '%s' "$stub_dir"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Source the script once (functions are loaded into shell; main() is guarded)
+# ---------------------------------------------------------------------------
+# We need a gh stub available at source time for the auth check:
+cat >"${BASE_STUB_DIR}/gh" <<'STUB'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "auth" && "${2:-}" == "status" ]]; then exit 0; fi
+exit 0
+STUB
+chmod +x "${BASE_STUB_DIR}/gh"
+export PATH="${BASE_STUB_DIR}:${PATH}"
+
+# shellcheck disable=SC1090
+if ! source "$CLAIM_SCRIPT" 2>/dev/null; then
+	printf '%s[FATAL]%s Failed to source %s\n' "$RED" "$NC" "$CLAIM_SCRIPT" >&2
+	exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Test 1: blocked-by:t999 missing, gh create succeeds → returns 0, label in cache
+# ---------------------------------------------------------------------------
+_run_test1() {
+	local stub_dir
+	stub_dir=$(_make_stub_dir)
+
+	# Track whether gh label create was invoked
+	local create_called_file="${stub_dir}/create_called"
+
+	cat >"${stub_dir}/gh" <<STUB
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "auth" && "\${2:-}" == "status" ]]; then exit 0; fi
+if [[ "\${1:-}" == "label" && "\${2:-}" == "list" ]]; then
+  # Return known labels (not including blocked-by:t999)
+  printf 'tier:standard\nauto-dispatch\nbug\n'
+  exit 0
+fi
+if [[ "\${1:-}" == "label" && "\${2:-}" == "create" ]]; then
+  printf '%s' "called" > "${create_called_file}"
+  exit 0
+fi
+exit 0
+STUB
+	chmod +x "${stub_dir}/gh"
+
+	# Temporarily prepend our per-test stub
+	local saved_path="$PATH"
+	PATH="${stub_dir}:${PATH}"
+
+	# Reset session cache so the function fetches fresh
+	local saved_cache="${AIDEVOPS_LABEL_CACHE_FILE:-}"
+	unset AIDEVOPS_LABEL_CACHE_FILE
+
+	local rc=0
+	_validate_labels_exist "owner/repo" "tier:standard,blocked-by:t999" 2>/dev/null || rc=$?
+
+	PATH="$saved_path"
+	[[ -n "$saved_cache" ]] && export AIDEVOPS_LABEL_CACHE_FILE="$saved_cache" || true
+
+	assert_return "test1_blocked_by_create_succeeds_returns_0" "$rc" "0"
+
+	local create_called=""
+	[[ -f "$create_called_file" ]] && create_called="$(cat "$create_called_file")"
+	assert_eq "test1_gh_label_create_was_called" "$create_called" "called"
+
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: blocked-by:t999 missing, gh create fails → still returns 0 (best-effort)
+# ---------------------------------------------------------------------------
+_run_test2() {
+	local stub_dir
+	stub_dir=$(_make_stub_dir)
+
+	cat >"${stub_dir}/gh" <<'STUB'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "auth" && "${2:-}" == "status" ]]; then exit 0; fi
+if [[ "${1:-}" == "label" && "${2:-}" == "list" ]]; then
+  printf 'tier:standard\nauto-dispatch\nbug\n'
+  exit 0
+fi
+if [[ "${1:-}" == "label" && "${2:-}" == "create" ]]; then
+  # Simulate permission/rate-limit failure
+  exit 1
+fi
+exit 0
+STUB
+	chmod +x "${stub_dir}/gh"
+
+	local saved_path="$PATH"
+	PATH="${stub_dir}:${PATH}"
+
+	local saved_cache="${AIDEVOPS_LABEL_CACHE_FILE:-}"
+	unset AIDEVOPS_LABEL_CACHE_FILE
+
+	local rc=0
+	_validate_labels_exist "owner/repo" "tier:standard,blocked-by:t999" 2>/dev/null || rc=$?
+
+	PATH="$saved_path"
+	[[ -n "$saved_cache" ]] && export AIDEVOPS_LABEL_CACHE_FILE="$saved_cache" || true
+
+	assert_return "test2_blocked_by_create_fails_still_returns_0" "$rc" "0"
+
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: tier:standrad (typo) still aborts — typo-protection preserved (t2800)
+# ---------------------------------------------------------------------------
+_run_test3() {
+	local stub_dir
+	stub_dir=$(_make_stub_dir)
+
+	cat >"${stub_dir}/gh" <<'STUB'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "auth" && "${2:-}" == "status" ]]; then exit 0; fi
+if [[ "${1:-}" == "label" && "${2:-}" == "list" ]]; then
+  printf 'tier:standard\nauto-dispatch\nbug\n'
+  exit 0
+fi
+exit 0
+STUB
+	chmod +x "${stub_dir}/gh"
+
+	local saved_path="$PATH"
+	PATH="${stub_dir}:${PATH}"
+
+	local saved_cache="${AIDEVOPS_LABEL_CACHE_FILE:-}"
+	unset AIDEVOPS_LABEL_CACHE_FILE
+
+	local rc=0
+	_validate_labels_exist "owner/repo" "tier:standrad,bug" 2>/dev/null || rc=$?
+
+	PATH="$saved_path"
+	[[ -n "$saved_cache" ]] && export AIDEVOPS_LABEL_CACHE_FILE="$saved_cache" || true
+
+	assert_return "test3_typo_label_still_aborts" "$rc" "1"
+
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: blocked-by:#999 (issue-number variant), gh create succeeds → returns 0
+# ---------------------------------------------------------------------------
+_run_test4() {
+	local stub_dir
+	stub_dir=$(_make_stub_dir)
+	local create_called_file="${stub_dir}/create_called"
+
+	cat >"${stub_dir}/gh" <<STUB
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "auth" && "\${2:-}" == "status" ]]; then exit 0; fi
+if [[ "\${1:-}" == "label" && "\${2:-}" == "list" ]]; then
+  printf 'tier:standard\nauto-dispatch\nbug\n'
+  exit 0
+fi
+if [[ "\${1:-}" == "label" && "\${2:-}" == "create" ]]; then
+  printf '%s' "called" > "${create_called_file}"
+  exit 0
+fi
+exit 0
+STUB
+	chmod +x "${stub_dir}/gh"
+
+	local saved_path="$PATH"
+	PATH="${stub_dir}:${PATH}"
+
+	local saved_cache="${AIDEVOPS_LABEL_CACHE_FILE:-}"
+	unset AIDEVOPS_LABEL_CACHE_FILE
+
+	local rc=0
+	_validate_labels_exist "owner/repo" "bug,blocked-by:#999" 2>/dev/null || rc=$?
+
+	PATH="$saved_path"
+	[[ -n "$saved_cache" ]] && export AIDEVOPS_LABEL_CACHE_FILE="$saved_cache" || true
+
+	assert_return "test4_blocked_by_hash_variant_returns_0" "$rc" "0"
+
+	local create_called=""
+	[[ -f "$create_called_file" ]] && create_called="$(cat "$create_called_file")"
+	assert_eq "test4_gh_label_create_was_called_for_hash_variant" "$create_called" "called"
+
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 5: blocked-by:t999 already in cache → gh label create NOT called, returns 0
+# ---------------------------------------------------------------------------
+_run_test5() {
+	local stub_dir
+	stub_dir=$(_make_stub_dir)
+	local create_called_file="${stub_dir}/create_called"
+
+	cat >"${stub_dir}/gh" <<STUB
+#!/usr/bin/env bash
+if [[ "\${1:-}" == "auth" && "\${2:-}" == "status" ]]; then exit 0; fi
+if [[ "\${1:-}" == "label" && "\${2:-}" == "list" ]]; then
+  # Include blocked-by:t999 so it's already in the cache
+  printf 'tier:standard\nauto-dispatch\nbug\nblocked-by:t999\n'
+  exit 0
+fi
+if [[ "\${1:-}" == "label" && "\${2:-}" == "create" ]]; then
+  printf '%s' "called" > "${create_called_file}"
+  exit 0
+fi
+exit 0
+STUB
+	chmod +x "${stub_dir}/gh"
+
+	local saved_path="$PATH"
+	PATH="${stub_dir}:${PATH}"
+
+	local saved_cache="${AIDEVOPS_LABEL_CACHE_FILE:-}"
+	unset AIDEVOPS_LABEL_CACHE_FILE
+
+	local rc=0
+	_validate_labels_exist "owner/repo" "bug,blocked-by:t999" 2>/dev/null || rc=$?
+
+	PATH="$saved_path"
+	[[ -n "$saved_cache" ]] && export AIDEVOPS_LABEL_CACHE_FILE="$saved_cache" || true
+
+	assert_return "test5_blocked_by_already_in_cache_returns_0" "$rc" "0"
+
+	local create_called=""
+	[[ -f "$create_called_file" ]] && create_called="$(cat "$create_called_file")"
+	assert_eq "test5_no_create_call_when_label_exists" "$create_called" ""
+
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Run all tests
+# ---------------------------------------------------------------------------
+printf '\n=== test-claim-label-auto-create.sh (GH#21474) ===\n\n'
+
+_run_test1
+_run_test2
+_run_test3
+_run_test4
+_run_test5
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\n%d tests run: %d passed, %d failed\n' "$((PASS + FAIL))" "$PASS" "$FAIL"
+
+if [[ "$FAIL" -gt 0 ]]; then
+	printf '\nFailed tests:%b\n' "$ERRORS"
+	exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary

Fixes the t2800/t2823 composition collision that hard-walled users in fresh consumer repos when `claim-task-id.sh` auto-detected a predecessor reference via t2823 but then aborted (exit 3) because the `blocked-by:tNNN` label didn't exist — per t2800's pre-flight validation.

**Root cause**: t2823 auto-emits `blocked-by:tNNN` labels from description text; t2800 requires every requested label to pre-exist. The intersection is a label class synthesised at runtime that no setup step ever seeds.

**Fix (Option A — approved by maintainer in GH#21474)**: add an auto-create exception for the `^blocked-by:(t[0-9]+|#[0-9]+)$` namespace only. All other invalid labels still abort (t2800 typo-protection preserved).

## Changes

**EDIT** `.agents/scripts/claim-task-id.sh`:
- New `_auto_create_blocked_by_label()` helper: calls `gh label create` with color `5319E7`; on success appends to session cache; on failure logs a warning and returns 1 (caller continues — best-effort).
- In `_validate_labels_exist()`: before adding a missing label to `invalid_labels`, match against `_BLOCKED_BY_AUTO_CREATE_REGEX`; if matched, call the new helper and `continue` (whether creation succeeds or fails). All other missing labels still trigger abort.
- Replace the terse 2-line error message (lines 733-735) with the reporter's proposed 3-option explanation.

**NEW** `.agents/scripts/tests/test-claim-label-auto-create.sh`:
- 8 assertions covering: gh-create-succeeds, gh-create-fails (best-effort), typo-label-still-aborts (t2800 preserved), issue-number variant (`#NNN`), label-already-in-cache.

## Verification

```
# shellcheck passes
shellcheck .agents/scripts/claim-task-id.sh

# New test suite: 8/8 pass
bash .agents/scripts/tests/test-claim-label-auto-create.sh

# Existing regression suite: 14/14 pass
bash .agents/scripts/tests/test-claim-blocked-by-detection.sh
```

## Architecture alignment

Matches the existing pattern used by `quality-feedback-issues-lib.sh:225-229`, `backfill-closure-labels.sh`, and `stuck-detection-helper.sh` — all of which call `gh label create` for their own required label namespaces. The `blocked-by:tNNN` namespace is now the sixth self-bootstrapping label class in the framework.

Resolves #21474
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.5 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-sonnet-4-6 spent 9m and 14,911 tokens on this as a headless worker.