### PR TITLE
GH#21477: fix DRIFTED/CALLER false positive — drop broken TSV transport in _resolve_wf_canonical

### DIFF
--- a/.agents/scripts/check-workflows-helper.sh
+++ b/.agents/scripts/check-workflows-helper.sh
@@ -400,20 +400,27 @@ _classify_row() {
 	return 0
 }
 
-# _resolve_wf_canonical <template_file> <reusable_file>
-# Emits tab-separated: canonical_path\tcanon_norm (canon_norm may be empty)
+# _resolve_wf_canonical <template_file>
+# Emits the canonical template path on stdout (single line).
+#
+# GH#21477: the previous version emitted a TSV of "canonical_path\tcanon_norm"
+# so that callers could pre-compute the normalised canonical content once per
+# workflow type (loop-invariant optimisation from PR #20809 / GH#20794).
+# The transport was fatally broken: `IFS=$'\t' read -r` reads exactly one line,
+# so _canon_norm was silently truncated to the first line of the multi-line YAML
+# (~50 bytes vs ~2 KB for the full content). _classify_workflow's equality check
+# at line 199 therefore always failed → every caller-pattern workflow was reported
+# as DRIFTED/CALLER regardless of actual content.
+#
+# Fix: emit only the canonical path. _classify_workflow's built-in fallback at
+# lines 195-197 recomputes _canon_norm per-repo via _normalize_wf_for_compare,
+# which is the verified-correct path. Cost: ~150 extra sed pipelines per full
+# run (3 workflows × <50 repos); negligible vs multi-second gh enumeration.
 _resolve_wf_canonical() {
 	local _template_file="$1"
-	local _reusable_file="$2"
 	local _canonical=""
 	_canonical=$(_resolve_canonical_template "$_template_file") || _canonical=""
-	local _canon_norm=""
-	if [[ -n "$_canonical" ]]; then
-		local _reusable_escaped
-		_reusable_escaped=$(printf '%s' "$_reusable_file" | sed 's/\./\\./g')
-		_canon_norm=$(_normalize_wf_for_compare "$_canonical" "$_reusable_escaped")
-	fi
-	printf '%s\t%s\n' "$_canonical" "$_canon_norm"
+	printf '%s\n' "$_canonical"
 	return 0
 }
 
@@ -450,8 +457,8 @@ _process_rows() {
 			[[ "$_workflow_name" != "$_fw_norm" ]] && continue
 		fi
 
-		local _canonical _canon_norm
-		IFS=$'\t' read -r _canonical _canon_norm < <(_resolve_wf_canonical "$_template_file" "$_reusable_file")
+		local _canonical
+		_canonical=$(_resolve_wf_canonical "$_template_file")
 		# Pre-compute once per workflow (loop-invariant); avoids a subshell per repo.
 		local _reusable_escaped
 		_reusable_escaped=$(printf '%s' "$_reusable_file" | sed 's/\./\\./g')
@@ -468,7 +475,7 @@ _process_rows() {
 			local _class _note
 			IFS=$'\t' read -r _class _note < <(_classify_row \
 				"$_path" "$_local_only_flag" "$_canonical" \
-				"$_reusable_escaped" "$_workflow_file" "$_canon_norm")
+				"$_reusable_escaped" "$_workflow_file" "")
 
 			case "$_class" in
 			LOCAL-ONLY) _local_only=$((_local_only + 1)) ;;

--- a/.agents/scripts/tests/test-check-workflows-classifier.sh
+++ b/.agents/scripts/tests/test-check-workflows-classifier.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-check-workflows-classifier.sh — regression test for GH#21477
+#
+# Bug: _resolve_wf_canonical emitted a TSV of "canonical_path\tcanon_norm"
+# but `IFS=$'\t' read -r` reads exactly one line, so _canon_norm was silently
+# truncated to the first line of the multi-line YAML (~50 bytes vs ~2 KB).
+# _classify_workflow's equality check always failed → every caller-pattern
+# workflow reported DRIFTED/CALLER for byte-identical inputs.
+# Introduced in PR #20809 (GH#20794). Fixed in GH#21477.
+#
+# Scenarios covered:
+#   1–3.  Byte-identical caller for each of the three managed workflow types
+#         (issue-sync, review-bot-gate, maintainer-gate) → CURRENT/CALLER
+#   4–6.  Version-pinned (@v3.9.0) variant of each → CURRENT/CALLER (normalised @ref)
+#   7–9.  Non-default-branch variant (branches: [develop]) for each → CURRENT/CALLER
+#  10–12. Actually-drifted caller for each → DRIFTED/CALLER (true positive preserved)
+#
+# Strategy: each scenario copies the canonical caller template byte-for-byte
+# (or with a single normalisation-allowed variant) into a temporary repo tree,
+# runs the helper in --json mode, and asserts the classification.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+HELPER="${SCRIPT_DIR}/../check-workflows-helper.sh"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)" || exit 1
+
+if [[ ! -f "$HELPER" ]]; then
+	echo "SKIP: helper not found at $HELPER" >&2
+	exit 0
+fi
+
+# Workflow tuple: "workflow_file:reusable_file:template_file"
+# Must match _KNOWN_WORKFLOWS in check-workflows-helper.sh.
+readonly -a _WORKFLOWS=(
+	"issue-sync.yml:issue-sync-reusable.yml:issue-sync-caller.yml"
+	"review-bot-gate.yml:review-bot-gate-reusable.yml:review-bot-gate-caller.yml"
+	"maintainer-gate.yml:maintainer-gate-reusable.yml:maintainer-gate-caller.yml"
+)
+
+readonly _T_GREEN='\033[0;32m'
+readonly _T_RED='\033[0;31m'
+readonly _T_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+_pass() {
+	local name="$1"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf '%bPASS%b %s\n' "$_T_GREEN" "$_T_RESET" "$name"
+	return 0
+}
+
+_fail() {
+	local name="$1"
+	local msg="${2:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '%bFAIL%b %s\n' "$_T_RED" "$_T_RESET" "$name"
+	[[ -n "$msg" ]] && printf '       %s\n' "$msg"
+	return 0
+}
+
+# ─── Fixture helpers ──────────────────────────────────────────────────────────
+
+_setup_fake_home() {
+	local _root="$1"
+	mkdir -p "$_root/.config/aidevops"
+	mkdir -p "$_root/.aidevops/agents/templates/workflows"
+	# Copy all managed templates so the helper can resolve any workflow type.
+	local _wf_tuple
+	for _wf_tuple in "${_WORKFLOWS[@]}"; do
+		local _template_file="${_wf_tuple##*:}"
+		local _src="$REPO_ROOT/.agents/templates/workflows/${_template_file}"
+		if [[ -f "$_src" ]]; then
+			cp "$_src" "$_root/.aidevops/agents/templates/workflows/${_template_file}"
+		fi
+	done
+	return 0
+}
+
+_write_repos_json() {
+	local _root="$1"
+	local _json="$2"
+	printf '%s\n' "$_json" > "$_root/.config/aidevops/repos.json"
+	return 0
+}
+
+# _classify_for_workflow <fake-home-root> <slug> <workflow-name-without-.yml>
+# Returns the classification string for the specified workflow in the single
+# repo registered in repos.json.
+_classify_for_workflow() {
+	local _root="$1"
+	local _slug="$2"
+	local _wf_name="$3"
+	HOME="$_root" bash "$HELPER" --json --repo "$_slug" --workflow "$_wf_name" 2>/dev/null \
+		| jq -r 'select(.slug != "") | .classification' \
+		| head -n 1
+	return 0
+}
+
+# ─── Tests ────────────────────────────────────────────────────────────────────
+
+for _wf_tuple in "${_WORKFLOWS[@]}"; do
+	_workflow_file="${_wf_tuple%%:*}"
+	_reusable_file="${_wf_tuple#*:}"; _reusable_file="${_reusable_file%%:*}"
+	_template_file="${_wf_tuple##*:}"
+	_wf_name="${_workflow_file%.yml}"
+
+	_src_template="$REPO_ROOT/.agents/templates/workflows/${_template_file}"
+	if [[ ! -f "$_src_template" ]]; then
+		printf 'SKIP: template not found: %s\n' "$_src_template" >&2
+		continue
+	fi
+
+	# ── Scenario A: byte-identical to canonical → CURRENT/CALLER ─────────────
+	_TD="$(mktemp -d)"
+	_setup_fake_home "$_TD"
+	mkdir -p "$_TD/repos/repo-a/.github/workflows"
+	cp "$_src_template" "$_TD/repos/repo-a/.github/workflows/${_workflow_file}"
+	_write_repos_json "$_TD" \
+		"$(jq -n --arg p "$_TD/repos/repo-a" \
+			'{initialized_repos: [{slug: "x/a", path: $p, local_only: false}]}')"
+	_result=$(_classify_for_workflow "$_TD" "x/a" "$_wf_name")
+	if [[ "$_result" == "CURRENT/CALLER" ]]; then
+		_pass "${_wf_name}: byte-identical caller → CURRENT/CALLER"
+	else
+		_fail "${_wf_name}: byte-identical caller → CURRENT/CALLER" \
+			"got: $_result (GH#21477 regression — read -r truncation bug)"
+	fi
+	rm -rf "$_TD"
+
+	# ── Scenario B: pinned @v3.9.0 variant → CURRENT/CALLER (normalised ref) ─
+	_TD="$(mktemp -d)"
+	_setup_fake_home "$_TD"
+	mkdir -p "$_TD/repos/repo-b/.github/workflows"
+	sed "s|${_reusable_file}@main|${_reusable_file}@v3.9.0|g" \
+		"$_src_template" > "$_TD/repos/repo-b/.github/workflows/${_workflow_file}"
+	_write_repos_json "$_TD" \
+		"$(jq -n --arg p "$_TD/repos/repo-b" \
+			'{initialized_repos: [{slug: "x/b", path: $p, local_only: false}]}')"
+	_result=$(_classify_for_workflow "$_TD" "x/b" "$_wf_name")
+	if [[ "$_result" == "CURRENT/CALLER" ]]; then
+		_pass "${_wf_name}: @v3.9.0-pinned caller → CURRENT/CALLER (normalised @ref)"
+	else
+		_fail "${_wf_name}: @v3.9.0-pinned caller → CURRENT/CALLER (normalised @ref)" \
+			"got: $_result"
+	fi
+	rm -rf "$_TD"
+
+	# ── Scenario C: branches:[develop] variant → CURRENT/CALLER (normalised branch) ─
+	_TD="$(mktemp -d)"
+	_setup_fake_home "$_TD"
+	mkdir -p "$_TD/repos/repo-c/.github/workflows"
+	sed 's/branches: \[main\]/branches: [develop]/' \
+		"$_src_template" > "$_TD/repos/repo-c/.github/workflows/${_workflow_file}"
+	_write_repos_json "$_TD" \
+		"$(jq -n --arg p "$_TD/repos/repo-c" \
+			'{initialized_repos: [{slug: "x/c", path: $p, local_only: false}]}')"
+	_result=$(_classify_for_workflow "$_TD" "x/c" "$_wf_name")
+	if [[ "$_result" == "CURRENT/CALLER" ]]; then
+		_pass "${_wf_name}: branches:[develop] caller → CURRENT/CALLER (normalised branch)"
+	else
+		_fail "${_wf_name}: branches:[develop] caller → CURRENT/CALLER (normalised branch)" \
+			"got: $_result"
+	fi
+	rm -rf "$_TD"
+
+	# ── Scenario D: actually-drifted caller → DRIFTED/CALLER (true positive) ─
+	_TD="$(mktemp -d)"
+	_setup_fake_home "$_TD"
+	mkdir -p "$_TD/repos/repo-d/.github/workflows"
+	{
+		cat "$_src_template"
+		printf '\n# Local customisation — should trigger DRIFTED detection\n'
+	} > "$_TD/repos/repo-d/.github/workflows/${_workflow_file}"
+	_write_repos_json "$_TD" \
+		"$(jq -n --arg p "$_TD/repos/repo-d" \
+			'{initialized_repos: [{slug: "x/d", path: $p, local_only: false}]}')"
+	_result=$(_classify_for_workflow "$_TD" "x/d" "$_wf_name")
+	if [[ "$_result" == "DRIFTED/CALLER" ]]; then
+		_pass "${_wf_name}: locally-modified caller → DRIFTED/CALLER (true positive)"
+	else
+		_fail "${_wf_name}: locally-modified caller → DRIFTED/CALLER (true positive)" \
+			"got: $_result"
+	fi
+	rm -rf "$_TD"
+done
+
+# ─── Summary ─────────────────────────────────────────────────────────────────
+
+echo
+if (( TESTS_FAILED == 0 )); then
+	printf '%bAll %d test(s) passed%b\n' "$_T_GREEN" "$TESTS_RUN" "$_T_RESET"
+	exit 0
+else
+	printf '%b%d of %d test(s) failed%b\n' "$_T_RED" "$TESTS_FAILED" "$TESTS_RUN" "$_T_RESET"
+	exit 1
+fi

--- a/.agents/scripts/tests/test-check-workflows-helper.sh
+++ b/.agents/scripts/tests/test-check-workflows-helper.sh
@@ -277,7 +277,10 @@ else
 fi
 rm -rf "$TMPDIR_9"
 
-# Test 10: --repo filter narrows to one
+# Test 10: --repo + --workflow filters narrow to exactly one row
+# Note: --repo alone returns one row per known workflow type (N rows for N
+# managed workflows). Adding --workflow narrows to a single (repo×workflow)
+# row — this tests both filter flags working in concert.
 TMPDIR_10="$(mktemp -d)"
 _setup_fake_home "$TMPDIR_10"
 _make_repo_with_workflow "$TMPDIR_10/repos/a"
@@ -289,11 +292,11 @@ _write_repos_json "$TMPDIR_10" \
 		--arg pa "$TMPDIR_10/repos/a" \
 		--arg pb "$TMPDIR_10/repos/b" \
 		'{initialized_repos: [{slug: "x/a", path: $pa, local_only: false}, {slug: "x/b", path: $pb, local_only: false}]}')"
-count=$(HOME="$TMPDIR_10" bash "$HELPER" --json --repo "x/a" 2>/dev/null | wc -l | tr -d ' ')
+count=$(HOME="$TMPDIR_10" bash "$HELPER" --json --repo "x/a" --workflow "issue-sync" 2>/dev/null | wc -l | tr -d ' ')
 if [[ "$count" == "1" ]]; then
-	_pass "--repo filter narrows to single row"
+	_pass "--repo + --workflow filters narrow to single row"
 else
-	_fail "--repo filter narrows to single row" "expected 1 row, got $count"
+	_fail "--repo + --workflow filters narrow to single row" "expected 1 row, got $count"
 fi
 rm -rf "$TMPDIR_10"
 


### PR DESCRIPTION
## Summary

`aidevops check-workflows` reported `DRIFTED/CALLER` for caller-pattern workflows that are byte-identical to the canonical templates. This PR fixes the root cause.

## Root Cause

`_resolve_wf_canonical` (`.agents/scripts/check-workflows-helper.sh:405-418`) emitted a tab-separated `canonical_path\tcanon_norm`, where `canon_norm` is the full normalised YAML content (~2 KB for `issue-sync-caller.yml`). The caller consumed it with:

```
IFS=$'\t' read -r _canonical _canon_norm < <(_resolve_wf_canonical ...)
```

`read -r` reads exactly **one line**. `_canon_norm` was silently truncated to the first line of the multi-line YAML (~50 bytes). The equality check in `_classify_workflow` at line 199 always compared ~50 bytes against ~2 KB — always failed — every caller-pattern workflow reported `DRIFTED/CALLER`.

Introduced in PR #20809 (GH#20794) which hoisted `_reusable_escaped` and added the loop-invariant `_canon_norm` pre-computation. The hoist was correct; the TSV transport was the failure.

## Fix

- `_resolve_wf_canonical`: emit only the canonical path (drop TSV and `_canon_norm` computation)
- `_process_rows` caller: replace `IFS=$'\t' read -r` with simple command substitution
- Pass `""` as `_canon_norm` arg to `_classify_row` — `_classify_workflow`'s built-in fallback at lines 195-197 recomputes per-repo via `_normalize_wf_for_compare` (the verified-correct pre-#20809 path)

**Cost**: ~150 extra `sed` pipelines per full run (3 workflows x <50 repos). Negligible vs multi-second `gh` API enumeration.

## Files Changed

- **EDIT** `.agents/scripts/check-workflows-helper.sh` — simplify `_resolve_wf_canonical`; update `_process_rows` caller; pass `""` to `_classify_row`
- **NEW** `.agents/scripts/tests/test-check-workflows-classifier.sh` — 12 regression tests across all 3 managed workflow types (byte-identical, @ref-pinned, branch-normalised, truly-drifted)
- **EDIT** `.agents/scripts/tests/test-check-workflows-helper.sh` — fix pre-existing test 10 (assertion was count==1 but `_KNOWN_WORKFLOWS` now has 3 entries; add `--workflow` filter to maintain single-row assertion)

## Verification

```
bash .agents/scripts/tests/test-check-workflows-helper.sh
# All 12 test(s) passed  (was: 4 of 12 failed before this fix)

bash .agents/scripts/tests/test-check-workflows-classifier.sh
# All 12 test(s) passed  (new regression suite)

shellcheck .agents/scripts/check-workflows-helper.sh
# (no output — clean)
```

Resolves #21477

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.5 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-sonnet-4-6 spent 10m and 17,240 tokens on this as a headless worker.
