### PR TITLE
GH#21440: fix _dt_json_field to use grep -oE instead of greedy sed

### DIFF
--- a/.agents/scripts/dispatch-timing-helper.sh
+++ b/.agents/scripts/dispatch-timing-helper.sh
@@ -284,22 +284,27 @@ _dt_cmd_recommend() {
 }
 
 # Extract value of $field from a single JSONL record on stdin.
-# Uses a simple regex-based extractor — avoids jq for hot-path speed.
+# Uses grep -oE to isolate the specific key-value pair, which avoids the
+# greedy-prefix issue where sed's .* can match a field name that appears as
+# a substring inside a preceding field's value.  Bash 3.2 compatible — no
+# jq dependency.
 # Args: $1 = field name (string-valued or numeric).
 _dt_json_field() {
 	local field="$1"
 	local line
 	IFS= read -r line
-	# Match "field":"value" (string) OR "field":NUMBER (numeric)
+	# Match "field":"value" (string) OR "field":NUMBER (numeric).
+	# grep -oE emits only the matching text; tail -1 handles the rare
+	# duplicate-key edge case by preferring the last occurrence.
 	# Try string first
 	local val
-	val=$(printf '%s' "$line" | sed -nE "s/.*\"${field}\":\"([^\"]*)\".*/\1/p")
+	val=$(printf '%s' "$line" | grep -oE "\"${field}\"[[:space:]]*:[[:space:]]*\"[^\"]*\"" | tail -1 | cut -d'"' -f4)
 	if [[ -n "$val" ]]; then
 		echo "$val"
 		return 0
 	fi
 	# Try numeric
-	val=$(printf '%s' "$line" | sed -nE "s/.*\"${field}\":([0-9]+).*/\1/p")
+	val=$(printf '%s' "$line" | grep -oE "\"${field}\"[[:space:]]*:[[:space:]]*[0-9]+" | tail -1 | cut -d: -f2 | tr -d ' ')
 	echo "$val"
 	return 0
 }


### PR DESCRIPTION
## Summary

Replace the greedy `sed` extraction in `_dt_json_field` with `grep -oE`, addressing the Gemini review feedback on PR #21435.

## What changed

- `.agents/scripts/dispatch-timing-helper.sh`: `_dt_json_field` now uses `grep -oE '"field"[[:space:]]*:[[:space:]]*...'` instead of `sed -nE 's/.*"field":...'`
- Added `tail -1` to handle the duplicate-key edge case (returns last match, consistent with previous greedy-right behaviour)
- Comment updated to explain the rationale

## Why

The greedy `.*` prefix in the `sed` substitution pattern can theoretically match a field name that appears as an exact substring within a preceding field's value. The `grep -oE` approach isolates only the specific `"fieldname":value` token, making the extraction robust regardless of surrounding field values.

## Testing

- All 15 applicable unit tests pass (`test-dispatch-timing-helper.sh`; 3 pre-existing failures due to `mapfile` bash 4+ incompatibility in Test 13, unrelated to this change)
- `shellcheck` passes with zero violations

Resolves #21440

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.5 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-sonnet-4-6 spent 10m and 17,502 tokens on this as a headless worker.
