### PR TITLE
GH#21507: perf: batch jq/grep invocations in knowledge search helpers

### DIFF
--- a/.agents/scripts/knowledge-helper.sh
+++ b/.agents/scripts/knowledge-helper.sh
@@ -866,16 +866,10 @@ _grep_source_file() {
 _search_ids_by_sensitivity() {
 	local sources_dir="$1" tier="$2"
 	_require_jq || return 1
-	local src_id
-	for src_id in $(ls "$sources_dir" 2>/dev/null | sort); do
-		[[ -d "${sources_dir}/${src_id}" ]] || continue
-		local meta="${sources_dir}/${src_id}/meta.json"
-		[[ -f "$meta" ]] || continue
-		local sens
-		sens=$(jq -r --arg d "$META_DEFAULT_SENSITIVITY" \
-			'.sensitivity // $d' "$meta" 2>/dev/null) || sens="$META_DEFAULT_SENSITIVITY"
-		[[ "$sens" == "$tier" ]] && echo "$src_id"
-	done
+	find "$sources_dir" -maxdepth 2 -name "meta.json" \
+		-exec jq -r --arg tier "$tier" --arg def "$META_DEFAULT_SENSITIVITY" \
+		'select((.sensitivity // $def) == $tier) | .id' {} + \
+		| sort
 	return 0
 }
 
@@ -912,16 +906,12 @@ _search_ids_by_case() {
 # Returns source IDs whose source.md has a draft-status tag matching <draft_status>.
 _search_ids_by_status() {
 	local sources_dir="$1" draft_status="$2"
-	local src_id
-	for src_id in $(ls "$sources_dir" 2>/dev/null | sort); do
-		[[ -d "${sources_dir}/${src_id}" ]] || continue
-		local src_md="${sources_dir}/${src_id}/source.md"
-		[[ -f "$src_md" ]] || continue
-		# Match Markdoc draft-status tag: {% draft-status status="<value>" ... %}
-		if grep -qiE "\{%\s*draft-status\b[^%]*status\s*=\s*[\"']?${draft_status}[\"']?" "$src_md" 2>/dev/null; then
-			echo "$src_id"
-		fi
-	done
+	# Match Markdoc draft-status tag: {% draft-status status="<value>" ... %}
+	local pattern="\\{%\\s*draft-status\\b[^%]*status\\s*=\\s*[\"']?${draft_status}[\"']?"
+	find "$sources_dir" -maxdepth 2 -name "source.md" \
+		-exec grep -liE "$pattern" {} + \
+		| while read -r path; do basename "$(dirname "$path")"; done \
+		| sort || true
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Replaced per-file jq and grep loops in _search_ids_by_sensitivity and _search_ids_by_status with find+exec batching. Reduces process spawn overhead proportional to the number of knowledge sources. Removed stderr suppression (2>/dev/null) per Gemini review feedback for diagnostic visibility. ShellCheck zero violations.

## Files Changed

.agents/scripts/knowledge-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/knowledge-helper.sh passes with zero violations

Resolves #21507


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.5 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-sonnet-4-6 spent 9m and 15,878 tokens on this as a headless worker.