### PR TITLE
GH#21505: fix _validate_opencode_binary stale side-effect var and canary redundant --version call

### DIFF
--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -890,6 +890,9 @@ CANARY_CONFIG_ERROR_TTL_SECONDS="${CANARY_CONFIG_ERROR_TTL_SECONDS:-3600}"
 #######################################
 _validate_opencode_binary() {
 	local bin="${1:-}"
+	# GH#21505: clear side-effect variable first so callers never see a stale
+	# version from a previous successful call when this invocation returns early.
+	_VALIDATE_OC_VERSION=""
 	[[ -n "$bin" ]] || return 2
 	command -v "$bin" >/dev/null 2>&1 || return 2
 
@@ -1199,8 +1202,8 @@ _run_canary_test() {
 
 	# Canary failed -- log diagnostics (capture enough output to surface API errors,
 	# not just startup hooks which is all head -5 typically showed)
-	local oc_version
-	oc_version=$("$_effective_opencode_bin" --version 2>/dev/null || echo "unknown")
+	# GH#21505: reuse _VALIDATE_OC_VERSION set earlier instead of a redundant --version call.
+	local oc_version="${_VALIDATE_OC_VERSION:-unknown}"
 	print_warning "Canary test FAILED (exit=$canary_exit, model=$canary_model, opencode=$oc_version, timeout=${CANARY_TIMEOUT_SECONDS}s)"
 	print_warning "Output (last 20 lines): $(tail -20 "$canary_output" 2>/dev/null || echo '<empty>')"
 	# t2814 (Phase 3, fix #4): Stamp the negative cache so subsequent


### PR DESCRIPTION
## Summary

Addresses 2 of 3 Gemini review findings from PR #21369 on `_validate_opencode_binary` and `_run_canary_test`. Finding 2 is a false positive (already correctly implemented).

## Findings

### Finding 1 — Clear `_VALIDATE_OC_VERSION` on early return (FIXED)

`_validate_opencode_binary` had three early `return 2` paths (empty bin arg, `command -v` miss, empty `--version` output) that occurred **before** the `_VALIDATE_OC_VERSION="$version_output"` assignment. On those paths callers received a stale value from the previous successful invocation, leading to incorrect version strings in `_run_canary_test` diagnostics.

Fix: `_VALIDATE_OC_VERSION=""` is now the first statement in the function, guaranteeing callers see `""` rather than a stale value on any non-zero return.

### Finding 2 — `version_output` `local` declaration (PREMISE FALSIFIED)

The reviewer suggested separating `local` declaration from command-substitution assignment. The code at PR #21369 already does this correctly:

```bash
local version_output
version_output=$("$bin" --version 2>/dev/null || echo "")
```

No action required.

### Finding 3 — Redundant `--version` call in canary failure path (FIXED)

`_run_canary_test` called `"$_effective_opencode_bin" --version` again at the failure diagnostic path (after `CANARY_OK` was not found), despite `_validate_opencode_binary` having already captured the version into `_VALIDATE_OC_VERSION` earlier in the same function call. The redundant spawn is eliminated — `_VALIDATE_OC_VERSION` is used directly.

## Verification

- `shellcheck .agents/scripts/headless-runtime-lib.sh` passes with zero violations
- Pre-commit and pre-push hooks passed

Resolves #21505
