### PR TITLE
GH#21503: fix t2980→t2983 typo in WORKER_WORKTREE_PATH fatal error message

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -1471,7 +1471,7 @@ _cmd_run_prepare() {
 	# WORKER_ISSUE_NUMBER being set, a dispatcher bug bypassed pre-creation.
 	# Abort immediately rather than proceeding in the canonical repo on main.
 	if [[ -n "${WORKER_ISSUE_NUMBER:-}" && -z "${WORKER_WORKTREE_PATH:-}" ]]; then
-		printf '[fatal] WORKER_WORKTREE_PATH unset — pre-creation skipped or failed silently; aborting per t2980 Fix C\n' >&2
+		printf '[fatal] WORKER_WORKTREE_PATH unset — pre-creation skipped or failed silently; aborting per t2983 Fix C\n' >&2
 		return 1
 	fi
 


### PR DESCRIPTION
Fix typo in fatal error message: `t2980 Fix C` → `t2983 Fix C`

## What

The error message on line 1474 of `headless-runtime-helper.sh` referenced `t2980 Fix C`, while the comment immediately above it (line 1468) and `headless-runtime-lib.sh:458` both correctly reference `t2983 Fix C`. This one-character difference makes the fatal error message inconsistent with the surrounding code and the PR (#21371) that introduced it.

## How

Single `printf` string update: `t2980` → `t2983`.

EDIT: `.agents/scripts/headless-runtime-helper.sh:1474`

## Verification

```bash
grep -n "t298[0-9] Fix C" .agents/scripts/headless-runtime-helper.sh
```

Expected: only `t2983 Fix C` references, no `t2980`.

Resolves #21503

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.6 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-sonnet-4-6 spent 2m and 2,458 tokens on this as a headless worker.
