### PR TITLE
t3012: fix bash 3.2 violations in compare-models-scoring-lib + document-creation-helper

### DIFF
--- a/.agents/scripts/compare-models-scoring-lib.sh
+++ b/.agents/scripts/compare-models-scoring-lib.sh
@@ -184,13 +184,14 @@ list_provider_models() {
 # Check if a provider is available (has valid API key)
 _discover_check_provider() {
 	local provider="$1"
-	local -n found_ref="$2"
-	local -n source_ref="$3"
-	local -n active_key_ref="$4"
+	local _found_var="$2"
+	local _source_var="$3"
+	local _active_key_var="$4"
 
-	found_ref=false
-	source_ref=""
-	active_key_ref=""
+	# Bash 3.2 compatible: use printf -v for indirect scalar writes (no local -n namerefs)
+	printf -v "$_found_var" '%s' "false"
+	printf -v "$_source_var" '%s' ""
+	printf -v "$_active_key_var" '%s' ""
 
 	local key_names
 	key_names=$(echo "$PROVIDER_ENV_KEYS" | grep "^${provider}|" | cut -d'|' -f2)
@@ -200,9 +201,9 @@ _discover_check_provider() {
 	IFS=',' read -ra keys <<<"$key_names"
 	for key_name in "${keys[@]}"; do
 		if check_provider_key "$key_name"; then
-			found_ref=true
-			source_ref="$FOUND_SOURCE"
-			active_key_ref="$key_name"
+			printf -v "$_found_var" '%s' "true"
+			printf -v "$_source_var" '%s' "$FOUND_SOURCE"
+			printf -v "$_active_key_var" '%s' "$key_name"
 			return 0
 		fi
 	done
@@ -446,30 +447,33 @@ SQL
 #        --strengths "Fast, accurate" --weaknesses "Verbose" \
 #        [--model "gpt-4.1" --correctness 8 ...]
 
-# Flush current model state into entries array (nameref).
-# Args: arg1=nameref:entries arg2=model arg3=correct arg4=complete arg5=quality
+# Flush current model state into entries array (variable name pass-through).
+# Args: arg1=varname:entries arg2=model arg3=correct arg4=complete arg5=quality
 #       arg6=clarity arg7=adherence arg8=latency arg9=tokens arg10=strengths arg11=weaknesses arg12=response
+# Bash 3.2 compatible: uses eval for array append (no local -n namerefs).
 _score_flush_model() {
-	local -n _sf_entries="$1"
+	local _sf_entries_var="$1"
 	local model="$2" correct="$3" complete="$4" quality="$5"
 	local clarity="$6" adherence="$7" latency="$8" tokens="$9"
 	local strengths="${10}" weaknesses="${11}" response="${12}"
 	[[ -z "$model" ]] && return 0
 	local overall=$(((correct + complete + quality + clarity + adherence) / 5))
-	_sf_entries+=("${model}|${correct}|${complete}|${quality}|${clarity}|${adherence}|${overall}|${latency}|${tokens}|${strengths}|${weaknesses}|${response}")
+	local _sf_entry="${model}|${correct}|${complete}|${quality}|${clarity}|${adherence}|${overall}|${latency}|${tokens}|${strengths}|${weaknesses}|${response}"
+	eval "${_sf_entries_var}+=(\"\${_sf_entry}\")"
 	return 0
 }
 
-# Parse score CLI arguments into named namerefs and entries array.
-# Args: arg1...arg7 = namerefs (task type eval winner pv pf entries), then remaining argv
+# Parse score CLI arguments into named variable refs and entries array.
+# Args: arg1...arg7 = variable names (task type eval winner pv pf entries), then remaining argv
+# Bash 3.2 compatible: uses printf -v for scalar writes, passes var names for array (no local -n).
 _score_parse_args() {
-	local -n _spa_task="$1"
-	local -n _spa_type="$2"
-	local -n _spa_eval="$3"
-	local -n _spa_winner="$4"
-	local -n _spa_pv="$5"
-	local -n _spa_pf="$6"
-	local -n _spa_entries="$7"
+	local _spa_task_var="$1"
+	local _spa_type_var="$2"
+	local _spa_eval_var="$3"
+	local _spa_winner_var="$4"
+	local _spa_pv_var="$5"
+	local _spa_pf_var="$6"
+	local _spa_entries_var="$7"
 	shift 7
 
 	local cur_model="" cur_correct=0 cur_complete=0 cur_quality=0
@@ -479,31 +483,31 @@ _score_parse_args() {
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--task)
-			_spa_task="$2"
+			printf -v "$_spa_task_var" '%s' "$2"
 			shift 2
 			;;
 		--type)
-			_spa_type="$2"
+			printf -v "$_spa_type_var" '%s' "$2"
 			shift 2
 			;;
 		--evaluator)
-			_spa_eval="$2"
+			printf -v "$_spa_eval_var" '%s' "$2"
 			shift 2
 			;;
 		--winner)
-			_spa_winner="$2"
+			printf -v "$_spa_winner_var" '%s' "$2"
 			shift 2
 			;;
 		--prompt-version)
-			_spa_pv="$2"
+			printf -v "$_spa_pv_var" '%s' "$2"
 			shift 2
 			;;
 		--prompt-file)
-			_spa_pf="$2"
+			printf -v "$_spa_pf_var" '%s' "$2"
 			shift 2
 			;;
 		--model)
-			_score_flush_model _spa_entries "$cur_model" "$cur_correct" "$cur_complete" \
+			_score_flush_model "$_spa_entries_var" "$cur_model" "$cur_correct" "$cur_complete" \
 				"$cur_quality" "$cur_clarity" "$cur_adherence" "$cur_latency" "$cur_tokens" \
 				"$cur_strengths" "$cur_weaknesses" "$cur_response"
 			cur_model="$2" cur_correct=0 cur_complete=0 cur_quality=0
@@ -554,23 +558,25 @@ _score_parse_args() {
 		*) shift ;;
 		esac
 	done
-	_score_flush_model _spa_entries "$cur_model" "$cur_correct" "$cur_complete" \
+	_score_flush_model "$_spa_entries_var" "$cur_model" "$cur_correct" "$cur_complete" \
 		"$cur_quality" "$cur_clarity" "$cur_adherence" "$cur_latency" "$cur_tokens" \
 		"$cur_strengths" "$cur_weaknesses" "$cur_response"
 	return 0
 }
 
 # Parse score arguments and build model entries (orchestrator).
+# Bash 3.2 compatible: forwards variable names directly to _score_parse_args (no local -n).
 _score_parse_and_build() {
-	local -n sp_task="$1"
-	local -n sp_type="$2"
-	local -n sp_eval="$3"
-	local -n sp_winner="$4"
-	local -n sp_pv="$5"
-	local -n sp_pf="$6"
-	local -n sp_entries="$7"
+	local _sp_task_var="$1"
+	local _sp_type_var="$2"
+	local _sp_eval_var="$3"
+	local _sp_winner_var="$4"
+	local _sp_pv_var="$5"
+	local _sp_pf_var="$6"
+	local _sp_entries_var="$7"
 	shift 7
-	_score_parse_args sp_task sp_type sp_eval sp_winner sp_pv sp_pf sp_entries "$@"
+	_score_parse_args "$_sp_task_var" "$_sp_type_var" "$_sp_eval_var" "$_sp_winner_var" \
+		"$_sp_pv_var" "$_sp_pf_var" "$_sp_entries_var" "$@"
 	return 0
 }
 

--- a/.agents/scripts/document-creation-helper.sh
+++ b/.agents/scripts/document-creation-helper.sh
@@ -652,56 +652,60 @@ source "${SCRIPT_DIR}/document-creation-email-lib.sh"
 # ============================================================================
 
 # Helpers for cmd_convert - extract argument parsing
+# Bash 3.2 compatible: uses printf -v for scalar writes, ${!var} for reads (no local -n).
 _convert_parse_args() {
-	local -n input_ref=$1 to_ext_ref=$2 output_ref=$3 force_tool_ref=$4
-	local -n template_ref=$5 extra_args_ref=$6 ocr_provider_ref=$7
-	local -n run_normalise_ref=$8 dedup_registry_ref=$9
+	local _input_var="$1" _to_ext_var="$2" _output_var="$3" _force_tool_var="$4"
+	local _template_var="$5" _extra_args_var="$6" _ocr_provider_var="$7"
+	local _run_normalise_var="$8" _dedup_registry_var="$9"
 	shift 9
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--to)
-			to_ext_ref="$(printf '%s' "$2" | tr '[:upper:]' '[:lower:]')"
+			local _to_ext_val
+			_to_ext_val="$(printf '%s' "$2" | tr '[:upper:]' '[:lower:]')"
+			printf -v "$_to_ext_var" '%s' "$_to_ext_val"
 			shift 2
 			;;
 		--output | -o)
-			output_ref="$2"
+			printf -v "$_output_var" '%s' "$2"
 			shift 2
 			;;
 		--tool)
-			force_tool_ref="$2"
+			printf -v "$_force_tool_var" '%s' "$2"
 			shift 2
 			;;
 		--template)
-			template_ref="$2"
+			printf -v "$_template_var" '%s' "$2"
 			shift 2
 			;;
 		--engine)
-			extra_args_ref="--pdf-engine=$2"
+			printf -v "$_extra_args_var" '%s' "--pdf-engine=$2"
 			shift 2
 			;;
 		--dedup-registry)
-			dedup_registry_ref="$2"
+			printf -v "$_dedup_registry_var" '%s' "$2"
 			shift 2
 			;;
 		--ocr)
-			ocr_provider_ref="${2:-auto}"
+			printf -v "$_ocr_provider_var" '%s' "${2:-auto}"
 			shift
 			[[ $# -gt 0 && "$1" != --* ]] && {
-				ocr_provider_ref="$1"
+				printf -v "$_ocr_provider_var" '%s' "$1"
 				shift
 			}
 			;;
 		--no-normalise | --no-normalize)
-			run_normalise_ref=false
+			eval "${_run_normalise_var}=false"
 			shift
 			;;
 		--*)
-			extra_args_ref="${extra_args_ref} $1"
+			local _cur_extra="${!_extra_args_var}"
+			printf -v "$_extra_args_var" '%s' "${_cur_extra} $1"
 			shift
 			;;
 		*)
-			[[ -z "${input_ref}" ]] && input_ref="$1"
+			[[ -z "${!_input_var}" ]] && printf -v "$_input_var" '%s' "$1"
 			shift
 			;;
 		esac
@@ -710,27 +714,28 @@ _convert_parse_args() {
 }
 
 # Helpers for cmd_create - extract argument parsing
+# Bash 3.2 compatible: uses printf -v for scalar writes, ${!var} for reads (no local -n).
 _create_parse_args() {
-	local -n template_ref=$1 data_ref=$2 output_ref=$3 script_ref=$4
+	local _template_var="$1" _data_var="$2" _output_var="$3" _script_var="$4"
 	shift 4
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--data)
-			data_ref="$2"
+			printf -v "$_data_var" '%s' "$2"
 			shift 2
 			;;
 		--output | -o)
-			output_ref="$2"
+			printf -v "$_output_var" '%s' "$2"
 			shift 2
 			;;
 		--script)
-			script_ref="$2"
+			printf -v "$_script_var" '%s' "$2"
 			shift 2
 			;;
 		--*) shift ;;
 		*)
-			[[ -z "${template_ref}" ]] && template_ref="$1"
+			[[ -z "${!_template_var}" ]] && printf -v "$_template_var" '%s' "$1"
 			shift
 			;;
 		esac
@@ -739,18 +744,19 @@ _create_parse_args() {
 }
 
 # Helpers for cmd_import_emails - extract argument parsing
+# Bash 3.2 compatible: uses printf -v for scalar writes, ${!var} for reads (no local -n).
 _import_parse_args() {
-	local -n input_path_ref=$1 output_dir_ref=$2 skip_contacts_ref=$3
+	local _input_path_var="$1" _output_dir_var="$2" _skip_contacts_var="$3"
 	shift 3
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--output | -o)
-			output_dir_ref="$2"
+			printf -v "$_output_dir_var" '%s' "$2"
 			shift 2
 			;;
 		--skip-contacts)
-			skip_contacts_ref=true
+			eval "${_skip_contacts_var}=true"
 			shift
 			;;
 		--*)
@@ -758,7 +764,7 @@ _import_parse_args() {
 			shift
 			;;
 		*)
-			[[ -z "${input_path_ref}" ]] && input_path_ref="$1"
+			[[ -z "${!_input_path_var}" ]] && printf -v "$_input_path_var" '%s' "$1"
 			shift
 			;;
 		esac
@@ -767,35 +773,36 @@ _import_parse_args() {
 }
 
 # Helpers for cmd_template - extract argument parsing
+# Bash 3.2 compatible: uses printf -v for scalar writes (no local -n).
 _template_parse_args() {
-	local -n doc_type_ref=$1 format_ref=$2 fields_ref=$3
-	local -n header_logo_ref=$4 footer_text_ref=$5 output_ref=$6
+	local _doc_type_var="$1" _format_var="$2" _fields_var="$3"
+	local _header_logo_var="$4" _footer_text_var="$5" _output_var="$6"
 	shift 6
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--type)
-			doc_type_ref="$2"
+			printf -v "$_doc_type_var" '%s' "$2"
 			shift 2
 			;;
 		--format)
-			format_ref="$2"
+			printf -v "$_format_var" '%s' "$2"
 			shift 2
 			;;
 		--fields)
-			fields_ref="$2"
+			printf -v "$_fields_var" '%s' "$2"
 			shift 2
 			;;
 		--header-logo)
-			header_logo_ref="$2"
+			printf -v "$_header_logo_var" '%s' "$2"
 			shift 2
 			;;
 		--footer-text)
-			footer_text_ref="$2"
+			printf -v "$_footer_text_var" '%s' "$2"
 			shift 2
 			;;
 		--output)
-			output_ref="$2"
+			printf -v "$_output_var" '%s' "$2"
 			shift 2
 			;;
 		*) shift ;;
@@ -805,32 +812,33 @@ _template_parse_args() {
 }
 
 # Helpers for cmd_normalise - extract argument parsing
+# Bash 3.2 compatible: uses printf -v for scalar writes, ${!var} for reads (no local -n).
 _normalise_parse_args() {
-	local -n input_ref=$1 output_ref=$2 inplace_ref=$3
-	local -n generate_pageindex_ref=$4 email_mode_ref=$5
+	local _input_var="$1" _output_var="$2" _inplace_var="$3"
+	local _generate_pageindex_var="$4" _email_mode_var="$5"
 	shift 5
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--output | -o)
-			output_ref="$2"
+			printf -v "$_output_var" '%s' "$2"
 			shift 2
 			;;
 		--inplace | -i)
-			inplace_ref=true
+			eval "${_inplace_var}=true"
 			shift
 			;;
 		--pageindex)
-			generate_pageindex_ref=true
+			eval "${_generate_pageindex_var}=true"
 			shift
 			;;
 		--email | -e)
-			email_mode_ref=true
+			eval "${_email_mode_var}=true"
 			shift
 			;;
 		--*) shift ;;
 		*)
-			[[ -z "${input_ref}" ]] && input_ref="$1"
+			[[ -z "${!_input_var}" ]] && printf -v "$_input_var" '%s' "$1"
 			shift
 			;;
 		esac
@@ -839,27 +847,28 @@ _normalise_parse_args() {
 }
 
 # Helpers for cmd_pageindex - extract argument parsing
+# Bash 3.2 compatible: uses printf -v for scalar writes, ${!var} for reads (no local -n).
 _pageindex_parse_args() {
-	local -n input_ref=$1 output_ref=$2 source_pdf_ref=$3 ollama_model_ref=$4
+	local _input_var="$1" _output_var="$2" _source_pdf_var="$3" _ollama_model_var="$4"
 	shift 4
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
 		--output | -o)
-			output_ref="$2"
+			printf -v "$_output_var" '%s' "$2"
 			shift 2
 			;;
 		--source-pdf)
-			source_pdf_ref="$2"
+			printf -v "$_source_pdf_var" '%s' "$2"
 			shift 2
 			;;
 		--ollama-model)
-			ollama_model_ref="$2"
+			printf -v "$_ollama_model_var" '%s' "$2"
 			shift 2
 			;;
 		--*) shift ;;
 		*)
-			[[ -z "${input_ref}" ]] && input_ref="$1"
+			[[ -z "${!_input_var}" ]] && printf -v "$_input_var" '%s' "$1"
 			shift
 			;;
 		esac
@@ -868,8 +877,9 @@ _pageindex_parse_args() {
 }
 
 # Helpers for cmd_generate_manifest - extract argument parsing
+# Bash 3.2 compatible: uses printf -v for scalar writes, ${!var} for reads (no local -n).
 _manifest_parse_args() {
-	local -n output_dir_ref=$1
+	local _output_dir_var="$1"
 	shift
 
 	while [[ $# -gt 0 ]]; do
@@ -879,7 +889,7 @@ _manifest_parse_args() {
 			shift
 			;;
 		*)
-			[[ -z "${output_dir_ref}" ]] && output_dir_ref="$1"
+			[[ -z "${!_output_dir_var}" ]] && printf -v "$_output_dir_var" '%s' "$1"
 			shift
 			;;
 		esac


### PR DESCRIPTION
## Summary

Fix all 29 bash 3.2 incompatibility violations (`local -n` namerefs, bash 4.3+) in `compare-models-scoring-lib.sh` (18) and `document-creation-helper.sh` (11), unblocking clean preflight on releases.

## What Changed

Converted `local -n` namerefs to bash 3.2 compatible patterns following the same idiom used in `compare-models-bench-lib.sh` (t3011 / #21524):

| Pattern | Before | After |
|---|---|---|
| Scalar write | `local -n ref="$N"; ref="val"` | `local _v="$N"; printf -v "$_v" '%s' "val"` |
| Boolean write | `ref=true` | `eval "${_v}=true"` |
| Array append | `ref+=("item")` | `eval "${_v}+=(\"\${_entry}\")"` |
| Scalar read | `${ref}` | `${!_v}` |

### Files

- `EDIT: .agents/scripts/compare-models-scoring-lib.sh` — 4 functions: `_discover_check_provider`, `_score_flush_model`, `_score_parse_args`, `_score_parse_and_build`
- `EDIT: .agents/scripts/document-creation-helper.sh` — 7 functions: `_convert_parse_args`, `_create_parse_args`, `_import_parse_args`, `_template_parse_args`, `_normalise_parse_args`, `_pageindex_parse_args`, `_manifest_parse_args`

## Verification

```bash
# 0 violations in both files
grep -nE '^[[:space:]]*(declare|local)[[:space:]]+-n[[:space:]]' \
  .agents/scripts/compare-models-scoring-lib.sh \
  .agents/scripts/document-creation-helper.sh
# (no output)

# shellcheck clean
shellcheck -x .agents/scripts/compare-models-scoring-lib.sh
shellcheck -x .agents/scripts/document-creation-helper.sh
# (no output)
```

Resolves #21540

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.6 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-sonnet-4-6 spent 22m and 41,101 tokens on this as a headless worker.
