### PR TITLE
t3014: default fill-floor parallelism to effective_slots

### DIFF
--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -52,14 +52,26 @@ _PULSE_DISPATCH_ENGINE_LOADED=1
 # cadence collapsed from ~2min to ~40min. 30s is generous: dedup check +
 # nohup worker spawn normally completes in <5s.
 : "${FILL_FLOOR_PER_CANDIDATE_TIMEOUT:=30}"
-# t3005: parallel dispatch concurrency for dispatch_deterministic_fill_floor.
-# Each successful dispatch takes ~100s (most in worktree-helper.sh add) so the
-# previous serial loop capped throughput at ~1 dispatch per pulse cycle.
-# 6 concurrent dispatches × ~100s = full 24-slot pool reachable in ~1 cycle.
-# Set to 1 to retain the legacy serial behavior (regression escape hatch).
-# Capped at _effective_slots inside the function so parallelism never exceeds
-# the slot budget.
-: "${DISPATCH_FILL_FLOOR_PARALLEL:=6}"
+# t3005/t3014: parallel dispatch concurrency for dispatch_deterministic_fill_floor.
+# Each successful dispatch takes ~30-180s (gh API ceremony + worktree-helper.sh
+# add + worker spawn) so the previous serial loop capped throughput at ~1
+# dispatch per pulse cycle.
+#
+# Default (t3014): unset → max_parallel = _effective_slots (typically 24, the
+# full slot budget). The cap inside _dff_compute_max_parallel still clamps at
+# _effective_slots, so the default never exceeds capacity. Setting an explicit
+# integer overrides the default. Set to 1 to retain the legacy serial behavior
+# (regression escape hatch); set to a smaller integer to ration concurrency.
+#
+# Pre-t3014 default was 6 — too low to saturate the 24-slot budget under the
+# adaptive-timeout / probe-mode regime where each dispatch retries through gh
+# rate-limit backoff. Measured failure mode (cycle 21126, 2026-04-28): 10
+# candidates dispatched in parallel, only 3/10 succeeded; steady-state worker
+# count = 4 against 24-slot budget. Raising the default to _effective_slots
+# allows the 24-slot pool to fill in 1-2 cycles instead of 6+.
+#
+# Intentionally left as soft default (`:-` form, no `:=` global default) so
+# the variable stays unset for callers that read it for diagnostics.
 : "${PULSE_ACTIVE_REFILL_INTERVAL:=120}"
 : "${PULSE_ACTIVE_REFILL_IDLE_MIN:=60}"
 : "${PULSE_ACTIVE_REFILL_STALL_MIN:=120}"
@@ -697,13 +709,20 @@ _dff_maybe_engage_throttle() {
 }
 
 #######################################
-# t3005: Decide the parallelism level for the deterministic fill-floor loop.
+# t3005/t3014: Decide the parallelism level for the deterministic fill-floor loop.
 #
-# Defaults to DISPATCH_FILL_FLOOR_PARALLEL (env, default 6). Capped at the
-# effective slot budget — never schedule more concurrent dispatches than
-# slots we'd consume. Forced to 1 when the adaptive throttle file is present
-# (degraded runtime — the existing serial throttle behavior is preserved as
-# the regression escape hatch and the "test the waters" semantics).
+# Defaults to DISPATCH_FILL_FLOOR_PARALLEL when set to a positive integer.
+# When unset, empty, or non-numeric, defaults to effective_slots — i.e. the
+# full slot budget — so the parallel loop saturates the worker pool in one
+# cycle (t3014). The pre-t3014 default of 6 capped throughput at 6 dispatches
+# per cycle even when the slot budget was 24, leaving ~17 idle slots per cycle
+# under adaptive-timeout / probe-mode regimes that produce 30-180s per-candidate
+# dispatch latency.
+#
+# Always capped at the effective slot budget — never schedule more concurrent
+# dispatches than slots we'd consume. Forced to 1 when the adaptive throttle
+# file is present (degraded runtime — the existing serial throttle behavior is
+# preserved as the regression escape hatch and the "test the waters" semantics).
 #
 # Arguments:
 #   $1 - effective_slots (already throttle-aware: 1 in throttle mode)
@@ -711,8 +730,13 @@ _dff_maybe_engage_throttle() {
 #######################################
 _dff_compute_max_parallel() {
 	local effective_slots="$1"
-	local max_parallel="${DISPATCH_FILL_FLOOR_PARALLEL:-6}"
-	[[ "$max_parallel" =~ ^[1-9][0-9]*$ ]] || max_parallel=6
+	# t3014: when unset/empty/invalid, default to effective_slots (full budget)
+	# instead of the historical 6. Env override still wins when set to a valid
+	# positive integer; the cap below still clamps at effective_slots.
+	local max_parallel="${DISPATCH_FILL_FLOOR_PARALLEL:-}"
+	if ! [[ "$max_parallel" =~ ^[1-9][0-9]*$ ]]; then
+		max_parallel="$effective_slots"
+	fi
 	if ((max_parallel > effective_slots)); then
 		max_parallel="$effective_slots"
 	fi
@@ -972,12 +996,12 @@ _dff_aggregate_outcomes() {
 # and fills empty local slots. Ranking remains simple and auditable; judgment
 # stays with the pulse LLM for merges, blockers, and unusual edge cases.
 #
-# t3005: Loop body extracted into _dff_dispatch_loop_serial /
+# t3005/t3014: Loop body extracted into _dff_dispatch_loop_serial /
 # _dff_dispatch_loop_parallel — the orchestrator picks one based on
-# DISPATCH_FILL_FLOOR_PARALLEL (default 6) and adaptive throttle state.
-# Throttle mode forces serial (1 dispatch per round) to preserve the existing
-# "test the waters" recovery semantics; otherwise parallel is preferred so
-# the 24-slot pool fills in 1-2 cycles instead of 40 minutes.
+# DISPATCH_FILL_FLOOR_PARALLEL (t3014 default = effective_slots when unset)
+# and adaptive throttle state. Throttle mode forces serial (1 dispatch per
+# round) to preserve the existing "test the waters" recovery semantics;
+# otherwise parallel is preferred so the 24-slot pool fills in 1 cycle.
 #
 # Returns: dispatched worker count via stdout
 #######################################
@@ -1066,7 +1090,7 @@ dispatch_deterministic_fill_floor() {
 	_dff_line_count=$(wc -l <"$_dff_candidate_file" 2>/dev/null | tr -d ' ' || echo 0)
 	echo "[pulse-wrapper] Deterministic fill floor: candidate enumeration produced ${_dff_line_count} lines in ${_dff_candidate_file}" >>"$LOGFILE"
 
-	# Branch: serial (legacy / throttle / DISPATCH_FILL_FLOOR_PARALLEL=1) vs parallel.
+	# Branch: serial (throttle / DISPATCH_FILL_FLOOR_PARALLEL=1 / effective_slots=1) vs parallel.
 	local dispatched_count=0 processed_count=0 loop_output=""
 	local _dff_outcomes_file=""
 	if ((_dff_max_parallel <= 1)); then

--- a/.agents/scripts/tests/test-fill-floor-parallel.sh
+++ b/.agents/scripts/tests/test-fill-floor-parallel.sh
@@ -61,19 +61,20 @@ source "${SCRIPT_DIR}/pulse-dispatch-engine.sh"
 # Test 1: _dff_compute_max_parallel honours DISPATCH_FILL_FLOOR_PARALLEL
 # =============================================================================
 test_compute_max_parallel_default() {
+	# t3014: when DISPATCH_FILL_FLOOR_PARALLEL is unset, default is now
+	# effective_slots (full slot budget), not the historical 6. Pre-t3014
+	# the default capped throughput at 6/cycle even with a 24-slot budget,
+	# leaving ~17 slots idle per cycle under adaptive-timeout regimes.
 	unset DISPATCH_FILL_FLOOR_PARALLEL || true
-	# Re-source to pick up default — but the guard prevents that. Instead
-	# re-init the var manually using the same default.
-	: "${DISPATCH_FILL_FLOOR_PARALLEL:=6}"
 	_DFF_THROTTLE_FILE="${HOME}/.aidevops/logs/dispatch-throttle"
 	rm -f "$_DFF_THROTTLE_FILE"
 	local result
-	# effective_slots=24 → expect 6 (capped at default)
+	# effective_slots=24 → expect 24 (full budget, t3014 default)
 	result=$(_dff_compute_max_parallel 24)
-	if [[ "$result" == "6" ]]; then
-		print_result "compute_max_parallel: default=6 with slots=24" 0
+	if [[ "$result" == "24" ]]; then
+		print_result "compute_max_parallel: default=effective_slots(24) when unset" 0
 	else
-		print_result "compute_max_parallel: default=6 with slots=24" 1 "got=${result}"
+		print_result "compute_max_parallel: default=effective_slots(24) when unset" 1 "got=${result}"
 	fi
 	return 0
 }
@@ -106,17 +107,19 @@ test_compute_max_parallel_throttle_forces_serial() {
 }
 
 test_compute_max_parallel_invalid_var() {
+	# t3014: invalid value falls back to effective_slots (was 6 pre-t3014).
+	# This keeps the validator graceful — a typo'd env var doesn't trap the
+	# pulse at degraded throughput; it gets the safe full-budget default.
 	export DISPATCH_FILL_FLOOR_PARALLEL="not-a-number"
 	rm -f "$_DFF_THROTTLE_FILE"
 	local result
 	result=$(_dff_compute_max_parallel 24)
-	# Invalid → falls back to default 6
-	if [[ "$result" == "6" ]]; then
-		print_result "compute_max_parallel: invalid env falls back to 6" 0
+	if [[ "$result" == "24" ]]; then
+		print_result "compute_max_parallel: invalid env falls back to effective_slots(24)" 0
 	else
-		print_result "compute_max_parallel: invalid env falls back to 6" 1 "got=${result}"
+		print_result "compute_max_parallel: invalid env falls back to effective_slots(24)" 1 "got=${result}"
 	fi
-	export DISPATCH_FILL_FLOOR_PARALLEL=6
+	unset DISPATCH_FILL_FLOOR_PARALLEL || true
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Two related dispatch-system fixes bundled — both surfaced during live testing of #21551:

- **Bottleneck A from #21551:** `_dff_compute_max_parallel` defaulted parallelism to `6` even when the slot budget was 24, capping fill-floor throughput at 6 dispatches/cycle. Live evidence (cycle 21126, 2026-04-28): 10 candidates dispatched in parallel, only 3/10 succeeded, steady-state worker count = 4 against 24-slot budget.
- **#21557 (canary regression):** PR #21553 (the `pulse-wrapper.sh` split) moved `_pulse_is_sourced()` into the sourced library `pulse-wrapper-cycle.sh`. Inside that function, `${BASH_SOURCE[0]}` resolves to the function's *defining* file, not the entry script — so the gate at the bottom of `pulse-wrapper.sh` always evaluated `sourced=true` and `main()` never ran. Production survived only because the deployed copy (`Apr 28 08:24`) predated the merge (`17:53`). Setup ran while testing this PR and deployed the broken version — pulse went dark for ~30 min until hot-deployed fix from this branch landed.

Resolves #21551 (Bottleneck A only — Bottleneck B follow-up filed if observation shows <20 sustained workers).

Resolves #21557

## Changes

### Bottleneck A — fill-floor parallelism (t3014)

- `pulse-dispatch-engine.sh:55-74` — replaced `:= 6` global default with documented `:-` soft default (variable stays unset for diagnostic callers).
- `pulse-dispatch-engine.sh:711-742` — `_dff_compute_max_parallel` now falls through to `effective_slots` when env unset/empty/non-numeric. Env override still wins when set to a positive integer.
- `pulse-dispatch-engine.sh:999-1004` — orchestrator-comment block updated with t3014 attribution.
- `tests/test-fill-floor-parallel.sh` — `test_compute_max_parallel_default` and `test_compute_max_parallel_invalid_var` updated for the new contract (24 not 6).

### Canary main-gate fix (t3016 / #21557)

- `pulse-wrapper.sh:1471-1473` — replaced `if ! _pulse_is_sourced; then main "$@"; fi` with an inline top-level `${BASH_SOURCE[0]} == ${0}` check. Evaluated at file scope, `BASH_SOURCE[0]` correctly references `pulse-wrapper.sh` itself. `_pulse_is_sourced()` left in `pulse-wrapper-cycle.sh` for callers that want a function-shaped helper.
- `tests/test-pulse-wrapper-canary.sh` — seed sandbox `HOME` with canonical `aidevops.defaults.jsonc` so bootstrap's `_load_config` succeeds; updated Test 3 to look for `_pulse_setup_canary_mode()` in `pulse-wrapper-bootstrap.sh` (its post-#21553 location).

## Test Plan

- `shellcheck .agents/scripts/pulse-dispatch-engine.sh .agents/scripts/pulse-wrapper.sh tests/*.sh` — clean.
- `bash .agents/scripts/tests/test-fill-floor-parallel.sh` — 16/17 pass. The single failure (`parallel_loop: respects effective_slots=4 budget got s=3`) reproduces on origin/main pre-edit and is a pre-existing race in the subshell-timing assertion (`4 <= s <= 8`); not a regression from this change.
- `bash .agents/scripts/tests/test-pulse-wrapper-canary.sh` — 4/4 pass.
- **Live recovery proven:** hot-deployed pulse-wrapper.sh from this branch to `~/.aidevops/agents/scripts/`, cleared stale `SETUP:65921` PID marker, restarted pulse. Pulse is running (PID 61244, single instance), main is being called, log shows new cycle invocations.
- **Live saturation observed earlier:** pre-canary-deploy, fill-floor reached `effective_slots=20, max_parallel=20, candidates=152` from PID 79032 — Bottleneck A confirmed fixed.

## Why this is safe

### Bottleneck A safety

1. **Cap preserved**: `if ((max_parallel > effective_slots))` still clamps the value to the slot budget — never schedules more concurrent dispatches than slots we'd consume.
2. **Throttle preserved**: `_DFF_THROTTLE_FILE` short-circuit still forces `max_parallel=1` in degraded runtime — the "test the waters" recovery semantics are intact.
3. **Env override preserved**: `DISPATCH_FILL_FLOOR_PARALLEL=1` still produces serial mode if a regression escape hatch is needed.
4. **Rate-limit budget**: 24 parallel × ~2 GraphQL pts × 30 cycles/hr ≈ 1440 pts/hr — fits within 5000/hr GitHub budget; existing t2690 circuit breaker handles overflow.

### Canary fix safety

1. **No behavior change for direct invocation** (the canonical path): `pulse-wrapper.sh` still runs `main` when executed by launchd/lifecycle-helper/manual run.
2. **Sourced-mode preserved**: when another script does `source pulse-wrapper.sh`, `BASH_SOURCE[0]` is `pulse-wrapper.sh` but `${0}` is the sourcing script — they differ, `main` is skipped, and the helper functions remain available for the pulse agent's `check_external_contributor_pr`/`check_permission_failure_pr` use case.
3. **Function in cycle.sh kept** for callers that want a function-shaped helper — no breaking change.

## Risk Assessment

- **Bottleneck B unaddressed**: per-candidate ceremony 100-305s; under load 7/10 candidates time out (rc=124). With 24 parallel slots and ~33% success rate, throughput is ~8 dispatches/cycle vs. the previous ~2 dispatches/cycle — ~4× improvement. If <20 sustained workers persist after deploy, follow-up issue will be filed for ceremony optimization (probe-mode cap, dedup-gate parallelization, prefetch-cache reuse).
- **Hidden production breakage now blocked**: this PR closes a hole where any future `aidevops update` would silently brick the pulse loop after #21553 merged. The canary CI gate now fails closed if the source-detection logic regresses again.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.6 plugin for [OpenCode](https://opencode.ai) v1.14.28 with claude-opus-4-7 spent 2h 44m and 114,850 tokens on this with the user in an interactive session.