### PR TITLE
GH#21557: restore pulse main-gate after source-detection regression

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1468,6 +1468,20 @@ ENRICHMENT_MAX_PER_CYCLE="${ENRICHMENT_MAX_PER_CYCLE:-2}"
 # The pulse agent sources this file to access helper functions
 # (check_external_contributor_pr, check_permission_failure_pr)
 # without triggering the full pulse lifecycle.
-if ! _pulse_is_sourced; then
+#
+# t3014/t3016 (GH#21551, GH#21557): The source check MUST be evaluated
+# inline at top-level here — not delegated to _pulse_is_sourced() in
+# pulse-wrapper-cycle.sh. Inside that function, ${BASH_SOURCE[0]} resolves
+# to the function's *defining* file (pulse-wrapper-cycle.sh), not the
+# entry script. PR #21553 moved the function into the sourced library and
+# silently broke the gate: the comparison `BASH_SOURCE[0] != $0` always
+# evaluated TRUE (cycle.sh != pulse-wrapper.sh), main() never ran, and
+# `pulse-wrapper.sh --canary` returned exit 0 with no output. Production
+# survived only because the deployed copy predated the merge — the next
+# `aidevops update` would have bricked the pulse loop. Fix: do the check
+# at file-scope here, where ${BASH_SOURCE[0]} correctly references this
+# very file. Keep _pulse_is_sourced() in cycle.sh for callers that need a
+# function-shaped helper.
+if [[ "${BASH_SOURCE[0]:-}" == "${0:-}" ]]; then
 	main "$@"
 fi

--- a/.agents/scripts/tests/test-pulse-wrapper-canary.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-canary.sh
@@ -34,6 +34,17 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 WRAPPER_SCRIPT="${SCRIPT_DIR}/../pulse-wrapper.sh"
+# t3016: _pulse_setup_canary_mode was relocated into pulse-wrapper-bootstrap.sh
+# by GH#21311 (the pulse-wrapper.sh split — PR #21553). The canary entrypoint
+# is still pulse-wrapper.sh (which sources bootstrap), but Test 3's static
+# grep needs to look in the new location.
+BOOTSTRAP_SCRIPT="${SCRIPT_DIR}/../pulse-wrapper-bootstrap.sh"
+# t3016: pulse-wrapper-bootstrap.sh::_load_config requires the canonical
+# defaults file to be present at $HOME/.aidevops/agents/configs/. The
+# sandboxed HOME used by Tests 1 and 2 must seed this file or the bootstrap
+# emits "[config] Failed to parse defaults — config system unavailable" and
+# the canary checkpoint never prints.
+DEFAULTS_SOURCE="${SCRIPT_DIR}/../../configs/aidevops.defaults.jsonc"
 
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
@@ -41,6 +52,17 @@ readonly TEST_RESET='\033[0m'
 
 TESTS_RUN=0
 TESTS_FAILED=0
+
+# t3016: Seed a sandbox HOME with the canonical aidevops defaults config so
+# pulse-wrapper-bootstrap.sh::_load_config succeeds. Mirrors what setup.sh
+# does at install time. Idempotent — safe to call repeatedly.
+seed_sandbox_config() {
+	local sandbox_home="$1"
+	mkdir -p "${sandbox_home}/.aidevops/agents/configs"
+	cp "$DEFAULTS_SOURCE" \
+		"${sandbox_home}/.aidevops/agents/configs/aidevops.defaults.jsonc"
+	return 0
+}
 
 print_result() {
 	local test_name="$1"
@@ -72,6 +94,8 @@ test_canary_exits_zero() {
 	local sandbox rc output
 	sandbox=$(mktemp -d)
 	mkdir -p "${sandbox}/home"
+	# t3016: seed canonical defaults so bootstrap's _load_config succeeds
+	seed_sandbox_config "${sandbox}/home"
 
 	output=$(
 		HOME="${sandbox}/home" \
@@ -100,6 +124,8 @@ test_canary_prints_checkpoint() {
 	local sandbox rc output
 	sandbox=$(mktemp -d)
 	mkdir -p "${sandbox}/home"
+	# t3016: seed canonical defaults so bootstrap's _load_config succeeds
+	seed_sandbox_config "${sandbox}/home"
 
 	output=$(
 		HOME="${sandbox}/home" \
@@ -118,17 +144,21 @@ test_canary_prints_checkpoint() {
 	return 0
 }
 
-# Test 3: Static check — _pulse_setup_canary_mode function exists in the wrapper.
+# Test 3: Static check — _pulse_setup_canary_mode function exists in bootstrap.
 #
 # Guards against the function being accidentally removed during refactoring.
 # Catches the regression before runtime.
+#
+# t3016: Function relocated from pulse-wrapper.sh to pulse-wrapper-bootstrap.sh
+# by GH#21311 (PR #21553). pulse-wrapper.sh now only contains the call site
+# (`_pulse_setup_canary_mode "$@"`); the definition lives in bootstrap.
 test_canary_function_exists() {
-	if grep -q "^_pulse_setup_canary_mode()" "$WRAPPER_SCRIPT"; then
-		print_result "_pulse_setup_canary_mode() defined in pulse-wrapper.sh" 0
+	if grep -q "^_pulse_setup_canary_mode()" "$BOOTSTRAP_SCRIPT"; then
+		print_result "_pulse_setup_canary_mode() defined in pulse-wrapper-bootstrap.sh" 0
 		return 0
 	fi
-	print_result "_pulse_setup_canary_mode() defined in pulse-wrapper.sh" 1 \
-		"Function _pulse_setup_canary_mode() not found in $WRAPPER_SCRIPT"
+	print_result "_pulse_setup_canary_mode() defined in pulse-wrapper-bootstrap.sh" 1 \
+		"Function _pulse_setup_canary_mode() not found in $BOOTSTRAP_SCRIPT"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

**P0 hotfix.** Restores pulse loop after PR #21553 broke the source-detection gate at the bottom of `pulse-wrapper.sh`.

## Root cause

PR #21553 ("split pulse-wrapper.sh into bootstrap+cycle sub-libraries") moved `_pulse_is_sourced()` from `pulse-wrapper.sh` into the sourced library `pulse-wrapper-cycle.sh`. The function did:

```bash
[[ "${BASH_SOURCE[0]}" != "${0}" ]]
```

Inside a function, `${BASH_SOURCE[0]}` resolves to the function's *defining file* — not the entry script. After the move:

- `${BASH_SOURCE[0]}` = `pulse-wrapper-cycle.sh`
- `${0}` = `pulse-wrapper.sh`
- They differ → function returns TRUE (sourced) → `main()` is NEVER called

Result: `pulse-wrapper.sh` returned exit 0 immediately on every direct invocation. No cycle ran. The framework's autonomous dispatch loop went dark.

## Why production wasn't immediately affected

The deployed copy at `~/.aidevops/agents/scripts/pulse-wrapper.sh` was from `Apr 28 08:24` — before #21553 merged at `17:53`. Production kept running the pre-split inline version. **The next `aidevops update` deploy would have bricked the pulse loop on every machine that updates.**

This actually happened during the testing of #21551: setup ran at ~17:57, deployed the broken split, and the pulse went dark for ~30 min until a hot-deploy of this fix landed manually.

## Fix

`pulse-wrapper.sh:1471-1490`:

```bash
# Before (broken — function defined in cycle.sh):
if ! _pulse_is_sourced; then
    main "$@"
fi

# After (fix — inline check at top-level):
if [[ "${BASH_SOURCE[0]:-}" == "${0:-}" ]]; then
    main "$@"
fi
```

Evaluated at file scope, `${BASH_SOURCE[0]}` correctly resolves to `pulse-wrapper.sh` itself. Equality with `${0}` is the canonical "executed directly" signal.

`_pulse_is_sourced()` left in `pulse-wrapper-cycle.sh` for callers that want a function-shaped helper.

## Test fixes

`tests/test-pulse-wrapper-canary.sh`:

- **Test 2 (`--canary prints 'canary: ok' checkpoint`):** sandbox `HOME` was missing the canonical `aidevops.defaults.jsonc`, so bootstrap's `_load_config` failed before reaching the checkpoint. Added `seed_sandbox_config()` helper to mirror what `setup.sh` does at install time.
- **Test 3 (`_pulse_setup_canary_mode() defined ...`):** function was relocated to `pulse-wrapper-bootstrap.sh` by #21553. Updated the static grep target.

## Verification

- `bash .agents/scripts/tests/test-pulse-wrapper-canary.sh` → 4/4 pass.
- `shellcheck .agents/scripts/pulse-wrapper.sh .agents/scripts/tests/test-pulse-wrapper-canary.sh` → clean.
- Direct invocation: `pulse-wrapper.sh --canary` → exit 0 + `canary: ok (...passed)` printed.
- **Live recovery proven on local production:** hot-deployed this fix to `~/.aidevops/agents/scripts/`, cleared stale `SETUP:65921` PID marker, restarted via `pulse-lifecycle-helper.sh restart`. Pulse running (PID 61244, single instance), `main()` is being called, log shows fresh cycle invocations.

## Why this is safe

1. **No behavior change for direct invocation** (the canonical path): `pulse-wrapper.sh` runs `main` when executed by launchd/lifecycle-helper/manual run.
2. **Sourced-mode preserved**: when another script does `source pulse-wrapper.sh`, `${BASH_SOURCE[0]}` is `pulse-wrapper.sh` but `${0}` is the sourcing script — they differ, `main` is skipped, helper functions remain available for the pulse agent's `check_external_contributor_pr`/`check_permission_failure_pr` use case.
3. **Function in cycle.sh kept** for callers that want a function-shaped helper — no breaking change.
4. **Canary CI gate** now fails closed if this regresses again (the test file was the early-warning system that actually caught it; #21553 merged with this CI failing).

## Lessons

- The `BASH_SOURCE[0]` invariant differs between top-level and function-scope context. Source-detection helpers MUST be evaluated at file scope (or accept the entry-script path as an argument).
- Sub-library splits (#21553 class) need a smoke test that runs `<entry-script> --canary` against the *deployed* layout, not just `bash -n`/`shellcheck`. Static checks miss this kind of runtime regression.

## Auto-merge

This PR is `origin:interactive` from `OWNER` and meets the t2411 criteria. Once CI passes, auto-merge fires within ~4-10 min.

Resolves #21557
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.6 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-opus-4-7 spent 2h 48m and 122,907 tokens on this with the user in an interactive session.