### PR TITLE
t3017: add aidevops circuit-breaker CLI subcommand

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -681,7 +681,7 @@ Observed in t2178: Codacy's one-click "Apply fix" / "AutoFix" diffs corrupt mark
 
 ## Quick Reference
 
-- **CLI**: `aidevops [init|update|status|repos|skills|features|check-workflows|sync-workflows|badges|knowledge]`
+- **CLI**: `aidevops [init|update|status|repos|skills|features|check-workflows|sync-workflows|badges|knowledge|circuit-breaker]`
 - **Knowledge plane**: `aidevops knowledge [init|status|provision]` — opt-in file staging area for AI-assisted ingestion. Set `"knowledge": "repo"|"personal"` in `repos.json`. Full contract: `aidevops/knowledge-plane.md`.
 - **Scripts**: `~/.aidevops/agents/scripts/[service]-helper.sh [command] [account] [target]`
 - **Scripts (editing)**: `~/.aidevops/agents/scripts/` is a **deployed copy** — edits there are overwritten by `aidevops update` (every ~10 min). For personal scripts, use `~/.aidevops/agents/custom/scripts/` (survives updates). To fix framework scripts, edit `~/Git/aidevops/.agents/scripts/<name>.sh` and run `setup.sh --non-interactive`. See `reference/customization.md`.

--- a/.agents/scripts/circuit-breaker-helper.sh
+++ b/.agents/scripts/circuit-breaker-helper.sh
@@ -564,10 +564,12 @@ Supervisor dispatch is **paused**. No new tasks will be dispatched until the cir
 ### Resolution
 1. Investigate the recent failures (check worker logs)
 2. Fix the underlying issue
-3. Reset the circuit breaker:
+3. Reset the circuit breaker (one-line copy/paste):
    \`\`\`bash
-   circuit-breaker-helper.sh reset
+   aidevops circuit-breaker reset
    \`\`\`
+   Or use the short alias: \`aidevops cb reset\`.
+   Direct helper path (if \`aidevops\` CLI unavailable): \`circuit-breaker-helper.sh reset\`.
    Or wait for auto-reset after ${CIRCUIT_BREAKER_COOLDOWN_SECS}s cooldown.
 
 ### Recent failure context
@@ -713,7 +715,10 @@ _cb_close_issue() {
 cmd_help() {
 	echo "circuit-breaker-helper.sh — Supervisor circuit breaker (t1331)"
 	echo ""
-	echo "Usage:"
+	echo "Preferred CLI (one-line copy/paste):"
+	echo "  aidevops circuit-breaker [status|reset|check|trip]   (alias: cb)"
+	echo ""
+	echo "Direct helper usage:"
 	echo "  circuit-breaker-helper.sh check                         Check if dispatch is allowed (exit 0=yes, 1=no)"
 	echo "  circuit-breaker-helper.sh status                        Show circuit breaker state"
 	echo "  circuit-breaker-helper.sh record-failure <task> [reason] Record a task failure"

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -1568,6 +1568,7 @@ _help_commands() {
 	echo "  client-format      Client request format alignment (extract/check/canary/monitor)"
 	echo "  opencode-sandbox   Test OpenCode versions in isolation (install/run/check/clean)"
 	echo "  approve <cmd>      Cryptographic issue/PR approval (setup/issue/pr/verify/status)"
+	echo "  circuit-breaker    Supervisor circuit breaker (status/reset/check/trip) — alias: cb"
 	echo "  issue <cmd>        Interactive issue ownership (claim/release/status/scan-stale)"
 	echo "  security [cmd]     Full security assessment (posture + hygiene + supply chain)"
 	echo "  contributions      External contributions inbox (bare: status | seed/scan/stop/restart/install/uninstall)"
@@ -1694,6 +1695,17 @@ _help_detailed_sections() {
 	echo "  aidevops stats trend         # Usage trends over time"
 	echo "  aidevops stats ingest        # Parse new Claude JSONL log entries"
 	echo "  aidevops stats sync-budget   # Sync to budget tracker (t1100)"
+	echo ""
+	echo "Supervisor Circuit Breaker (t1331):"
+	echo "  aidevops circuit-breaker             # Show breaker state (alias: cb)"
+	echo "  aidevops circuit-breaker status      # Show breaker state"
+	echo "  aidevops circuit-breaker reset       # Manually reset (resumes worker dispatch)"
+	echo "  aidevops circuit-breaker check       # Exit 0 if dispatch allowed, 1 if paused"
+	echo "  aidevops circuit-breaker trip        # Manually trip (testing)"
+	echo "  aidevops cb reset                    # Short alias for reset"
+	echo ""
+	echo "  When the breaker trips (auto-filed GH issue), copy/paste:"
+	echo "    aidevops circuit-breaker reset"
 	echo ""
 	_help_management_sections
 	return 0
@@ -2108,6 +2120,12 @@ main() {
 	review-gate | review_gate) _dispatch_helper "review-gate-config-helper.sh" "review-gate-config-helper.sh" "$@" ;;
 	secret | secrets) _dispatch_helper "secret-helper.sh" "secret-helper.sh" "$@" ;;
 	approve) _dispatch_helper "approval-helper.sh" "approval-helper.sh" "$@" ;;
+	circuit-breaker | circuit_breaker | cb)
+		# Supervisor circuit breaker control (t1331). Bare invocation defaults to status.
+		# Subcommands forward verbatim: check | status | record-failure | record-success | reset | trip | help
+		[[ $# -eq 0 ]] && set -- status
+		_dispatch_helper "circuit-breaker-helper.sh" "circuit-breaker-helper.sh" "$@"
+		;;
 	issue) _dispatch_helper "interactive-session-helper.sh" "interactive-session-helper.sh" "$@" ;;
 	signing) _dispatch_helper "signing-setup.sh" "signing-setup.sh" "$@" ;;
 	contributions | contrib)


### PR DESCRIPTION
## Why

When the supervisor circuit breaker trips and auto-files a GitHub issue, the reset is currently a three-step lookup: `cd` to the scripts directory, find `circuit-breaker-helper.sh`, then run the subcommand. The user explicitly asked for a one-line copy/paste route to make breaker recovery operationally cheap. This is the same pattern as `aidevops approve issue`, `aidevops issue claim`, etc. — surface deeply-nested helpers through the top-level CLI.

## What

- `aidevops circuit-breaker [subcommand]` — new subcommand that delegates to `~/.aidevops/agents/scripts/circuit-breaker-helper.sh` via the existing `_dispatch_helper` plumbing.
- Aliases: `circuit-breaker | circuit_breaker | cb`.
- Bare invocation (`aidevops circuit-breaker`) defaults to `status`.
- All helper subcommands pass through unchanged: `status | reset | check | trip | record-failure | record-success | help`.
- Help surface updated in three places so the new route is discoverable from any direction:
  - `aidevops help` (one-liner under "Help shortcuts")
  - `aidevops --help-detailed` ("Supervisor Circuit Breaker (t1331)" worked-example block, including the copy/paste reset line)
  - `circuit-breaker-helper.sh help` (now leads with `aidevops circuit-breaker`, falls back to direct helper path)
- Auto-filed GH issue body Resolution section now recommends `aidevops circuit-breaker reset` first, with the direct helper path as fallback for environments without the `aidevops` CLI on PATH.
- `.agents/AGENTS.md` Quick Reference CLI line gains `circuit-breaker` so AI assistants surface it without a docs lookup.

## How

- `aidevops.sh:2110` — added `circuit-breaker | circuit_breaker | cb)` case in the dispatch switch, modelled on the existing `inbox)` and `contributions)` branches. Bare-invocation default-to-`status` matches the bare-invocation behaviour pattern used by `inbox)`.
- `aidevops.sh:1570` — added one-liner under "Help shortcuts".
- `aidevops.sh:1700` — added "Supervisor Circuit Breaker (t1331)" worked-example block in `_help_detailed_sections` between LLM Stats and `_help_management_sections`.
- `.agents/scripts/circuit-breaker-helper.sh:567-570` — Resolution block in the auto-filed issue body now recommends the CLI route first.
- `.agents/scripts/circuit-breaker-helper.sh:713-731` — `cmd_help` updated to surface the CLI route at the top.
- `.agents/AGENTS.md:684` — `circuit-breaker` added to the CLI Quick Reference list.

No new helper logic — pure plumbing. The breaker semantics (threshold, cooldown, state file, GH issue creation) are unchanged.

## Verification

```bash
# All four invocation routes work and exit clean:
aidevops circuit-breaker status   # → CLOSED, counter 0/3
aidevops cb status                # → same (alias)
aidevops circuit-breaker          # → bare → defaults to status
aidevops circuit-breaker help     # → helper cmd_help with CLI hint at top
aidevops help | grep circuit-breaker  # → one-liner present
```

ShellCheck clean on both edited shell files. No CI gate changes; ratchet warnings on aidevops.sh string-literal counts are pre-existing.

## Files

- `aidevops.sh` (+18 lines: dispatch case + help shortcut line + worked-example block)
- `.agents/scripts/circuit-breaker-helper.sh` (+8/-3 lines: issue body Resolution + cmd_help)
- `.agents/AGENTS.md` (+1/-1 line: Quick Reference CLI list)

Resolves #21567
