### PR TITLE
t3026: floor per-candidate fill_floor timeout at 360s to unblock dispatch

### DIFF
--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -535,6 +535,24 @@ _dff_dispatch_with_timeout() {
 		fi
 	fi
 
+	# t3026: floor per-candidate timeout to cover full ceremony cost.
+	# Pulse dispatch ceremony (gh issue view + brief check + eligibility +
+	# pre-dispatch validators + CLAIM_WON audit comment + body composition
+	# with footer + worker spawn / npm install / node startup) takes ~75-160s
+	# baseline; with backpressure it adds 20-40s. The adaptive helper's MIN
+	# (DISPATCH_TIMING_MIN_TIMEOUT_MS, default 30s) is sized for the simplest
+	# case (dedup-skip path that returns in <5s) and is too low for the full
+	# ceremony — when adaptive recommended drops below ceremony cost, EVERY
+	# candidate timeouts at rc=124 and dispatched=0/N. Canonical failure:
+	# 2026-04-28 fill_floor cycle iter=62, 148 candidates, dispatched=0,
+	# adaptive timeout collapsed to 180s. Floor at 360s gives ceremony +
+	# backpressure margin without inflating fast-path probe budget.
+	local floor_seconds="${FILL_FLOOR_PER_CANDIDATE_TIMEOUT_FLOOR:-360}"
+	if [[ "$floor_seconds" =~ ^[0-9]+$ ]] && ((timeout_seconds < floor_seconds)); then
+		timeout_seconds="$floor_seconds"
+		timeout_ms=$((floor_seconds * 1000))
+	fi
+
 	local start_ms dispatch_rc=0 outcome elapsed_ms
 	start_ms=$(_dff_now_ms)
 	run_stage_with_timeout "fill_floor_candidate_${issue_number}" "$timeout_seconds" \

--- a/.agents/scripts/tests/test-pulse-dispatch-engine-timeout-floor.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-engine-timeout-floor.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# shellcheck disable=SC2016  # single-quoted regex patterns are literal by design
+#
+# test-pulse-dispatch-engine-timeout-floor.sh — regression guard for t3026
+#
+# Verifies that _dff_dispatch_with_timeout in pulse-dispatch-engine.sh applies
+# a floor to the adaptive per-candidate timeout, so the dispatch ceremony
+# (~75-160s baseline, +20-40s under backpressure) cannot be killed by a
+# learned-low timeout from the EWMA+p95 recommender.
+#
+# Background: 2026-04-28 production failure — adaptive timeout collapsed to
+# 180s after a sequence of "fast" cycles that included dedup-skip outcomes
+# in the EWMA window. Every fill_floor_candidate stage subsequently timed
+# out at rc=124, yielding `dispatched=0/148` for multiple cycles. Pulse
+# could not maintain 24-worker concurrency.
+#
+# Contract pinned by this test:
+#   1. The function declares a `floor_seconds` local sourced from
+#      FILL_FLOOR_PER_CANDIDATE_TIMEOUT_FLOOR with a default of 360.
+#   2. The floor block runs AFTER the adaptive helper has populated
+#      timeout_seconds — i.e., it sits between the `dispatch-timing-helper.sh
+#      recommend` block and the run_stage_with_timeout call.
+#   3. The floor mutates BOTH timeout_seconds (used by run_stage_with_timeout)
+#      and timeout_ms (recorded back to the helper for learning) so the
+#      learning loop also sees the floored value.
+
+set -u
+
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+assert_grep() {
+	local label="$1" pattern="$2" file="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if grep -qE "$pattern" "$file" 2>/dev/null; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  expected pattern: $pattern"
+		echo "  in file:          $file"
+	fi
+	return 0
+}
+
+# Verify the floor block appears AFTER the helper recommend block AND BEFORE
+# run_stage_with_timeout. We confirm ordering by line numbers.
+assert_block_ordering() {
+	local label="$1" file="$2"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	local helper_line floor_line stage_line
+	helper_line=$(grep -nE 'dispatch-timing-helper\.sh recommend' "$file" | head -1 | cut -d: -f1)
+	floor_line=$(grep -nE 'FILL_FLOOR_PER_CANDIDATE_TIMEOUT_FLOOR' "$file" | head -1 | cut -d: -f1)
+	stage_line=$(grep -nE 'run_stage_with_timeout "fill_floor_candidate_' "$file" | head -1 | cut -d: -f1)
+	if [[ -z "$helper_line" || -z "$floor_line" || -z "$stage_line" ]]; then
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  could not locate one or more anchors:"
+		echo "    helper recommend line: ${helper_line:-NOT FOUND}"
+		echo "    floor block line:      ${floor_line:-NOT FOUND}"
+		echo "    run_stage line:        ${stage_line:-NOT FOUND}"
+		return 0
+	fi
+	if ((helper_line < floor_line && floor_line < stage_line)); then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label (helper@${helper_line} < floor@${floor_line} < stage@${stage_line})"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  block ordering wrong: helper=${helper_line} floor=${floor_line} stage=${stage_line}"
+	fi
+	return 0
+}
+
+# Resolve paths relative to this test file
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENGINE="$SCRIPT_DIR/pulse-dispatch-engine.sh"
+
+echo "=== t3026: per-candidate timeout floor regression tests ==="
+echo "Engine: $ENGINE"
+echo ""
+
+assert_grep \
+	"1: env var FILL_FLOOR_PER_CANDIDATE_TIMEOUT_FLOOR is consulted with default 360" \
+	'\$\{FILL_FLOOR_PER_CANDIDATE_TIMEOUT_FLOOR:-360\}' \
+	"$ENGINE"
+
+assert_grep \
+	"2: floor compares against timeout_seconds (post-adaptive value)" \
+	'timeout_seconds < floor_seconds' \
+	"$ENGINE"
+
+assert_grep \
+	"3: floor mutates timeout_seconds when below floor" \
+	'timeout_seconds="\$floor_seconds"' \
+	"$ENGINE"
+
+assert_grep \
+	"4: floor also recomputes timeout_ms so the learning loop sees the floored value" \
+	'timeout_ms=\$\(\(floor_seconds \* 1000\)\)' \
+	"$ENGINE"
+
+assert_grep \
+	"5: floor block is integer-validated (defensive against malformed env)" \
+	'floor_seconds.*=~.*\^\[0-9\]\+\$' \
+	"$ENGINE"
+
+assert_block_ordering \
+	"6: floor block runs AFTER helper recommend AND BEFORE run_stage_with_timeout" \
+	"$ENGINE"
+
+echo ""
+echo "Tests run: $TESTS_RUN, failed: $TESTS_FAILED"
+if ((TESTS_FAILED > 0)); then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

`_dff_dispatch_with_timeout` in `pulse-dispatch-engine.sh` was using the adaptive helper's recommended timeout without a domain-specific floor. After a sequence of "fast" cycles (mostly dedup-skip outcomes) the EWMA+p95 recommendation collapsed to ~180s — below the actual fill_floor ceremony cost (75-160s baseline + 20-40s under backpressure). Every fill_floor candidate then timed out at rc=124, yielding `dispatched=0/148` in production for multiple cycles. Pulse could not maintain 24-worker concurrency.

## Fix

Adds a configurable floor (`FILL_FLOOR_PER_CANDIDATE_TIMEOUT_FLOOR`, default 360s) applied AFTER the `dispatch-timing-helper.sh recommend` call. The floor mutates BOTH `timeout_seconds` (used by `run_stage_with_timeout`) AND `timeout_ms` (recorded back to the helper) so the adaptive learning loop converges to the floored value rather than fighting against it.

## Why engine-level, not helper-level

The helper's `DISPATCH_TIMING_MIN_TIMEOUT_MS=30000` (30s) is sized for the simplest dispatch use case (dedup-skip path returning in <5s). The full fill_floor ceremony (`gh issue view` + brief check + eligibility + pre-dispatch validators + CLAIM_WON audit + body composition + worker spawn) is a fundamentally different workload. Different floors live at different layers.

## Files changed

- `EDIT: .agents/scripts/pulse-dispatch-engine.sh` (around line 538) — floor block after the helper recommend call inside `_dff_dispatch_with_timeout`.
- `NEW: .agents/scripts/tests/test-pulse-dispatch-engine-timeout-floor.sh` — 6 regression assertions (env var presence, floor comparison, mutation of both `timeout_seconds` and `timeout_ms`, integer validation, block-ordering check pinning the helper→floor→stage sequence).

## Verification

```text
shellcheck pulse-dispatch-engine.sh                           clean
shellcheck test-pulse-dispatch-engine-timeout-floor.sh        clean
test-pulse-dispatch-engine-timeout-floor.sh                   6/6 PASS
test-dispatch-timing-helper.sh                                18/18 PASS (no regression)
```

Live runtime evidence (post-deploy verification gated): `~/.aidevops/logs/pulse.log` showed `Stage timeout: fill_floor_candidate_* exceeded 180s` followed by `dispatched=0/148` for multiple cycles before the fix. Will confirm `dispatched > 0` after merge + setup.sh redeploy + pulse restart in the monitoring step of this loop.

## Acceptance (from #21583)

- [x] Per-candidate timeout floors at 360s (default) — env override `FILL_FLOOR_PER_CANDIDATE_TIMEOUT_FLOOR` available.
- [ ] After deploy, fresh pulse cycles dispatch >0 candidates per cycle — verified post-merge in monitoring step.
- [ ] `pulse-stats.json fill_floor_per_candidate_timeout` counter stops growing — verified post-merge.
- [ ] `gh pr list --state merged --search 'merged:>=NOW-30M'` returns >5 worker PRs after the fix is live — verified post-merge.

runtime-verified: pre-merge unit tests (engine + helper) pass; runtime end-to-end verification gated to post-deploy monitoring step (live pulse log confirmation).

Resolves #21583

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.7 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-opus-4-7 spent 8m and 28,998 tokens on this with the user in an interactive session.