### PR TITLE
t3025: fix jq null-input flood in dispatch-dedup-helper.sh tier extraction

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -733,7 +733,7 @@ _is_assigned_check_cost_budget() {
 
 	local _t2007_tier
 	_t2007_tier=$(printf '%s' "$meta_json" |
-		jq -r '[(.labels // [])[].name] | map(select(startswith("tier:"))) | .[0] // "tier:standard"' 2>/dev/null)
+		jq -r '[(.labels // [])[].name] | map(select(. != null and startswith("tier:"))) | .[0] // "tier:standard"' 2>/dev/null)
 	[[ -z "$_t2007_tier" || "$_t2007_tier" == "null" ]] && _t2007_tier="tier:standard"
 
 	local _t2007_signal _t2007_rc=0
@@ -1270,7 +1270,7 @@ has_dispatch_comment() {
 	# Find the most recent dispatch comment (newest first)
 	local last_dispatch_json
 	last_dispatch_json=$(printf '%s' "$comments_json" | jq -c '
-		[.[] | select(.body_start | startswith("Dispatching worker"))]
+		[.[] | select((.body_start // "") | startswith("Dispatching worker"))]
 		| sort_by(.created_at) | reverse | first // empty
 	' 2>/dev/null) || last_dispatch_json=""
 


### PR DESCRIPTION
## Summary

Fixed two jq null-input errors by adding null guards: (1) line 736 guards label.name against null before startswith(), (2) line 1273 guards body_start against null before startswith(). These fixes prevent silent issue skipping when labels lack names or comments lack body_start fields.

## Files Changed

.agents/scripts/dispatch-dedup-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Verified with shellcheck; no syntax errors. After deploy, grep -c 'startswith() requires string inputs' ~/.aidevops/logs/pulse-wrapper.log should drop to 0 over time.

Resolves #21582


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v2.44.2 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-haiku-4-5 spent 2m and 1,413 tokens on this as a headless worker.