### PR TITLE
t3025: guard jq startswith() against null inputs

### DIFF
--- a/.agents/scripts/aidevops-update-check.sh
+++ b/.agents/scripts/aidevops-update-check.sh
@@ -513,7 +513,7 @@ _check_hotfix_available() {
 
 	# Fetch the latest hotfix tag from the remote repo
 	local latest_hotfix_tag latest_hotfix_version
-	latest_hotfix_tag=$(gh api "repos/${slug}/tags" --jq '[.[] | select(.name | startswith("hotfix-v"))] | sort_by(.name) | last | .name // empty' 2>/dev/null || echo "")
+	latest_hotfix_tag=$(gh api "repos/${slug}/tags" --jq '[.[] | select((.name // "") | startswith("hotfix-v"))] | sort_by(.name) | last | .name // empty' 2>/dev/null || echo "")
 
 	if [[ -z "$latest_hotfix_tag" ]]; then
 		echo ""

--- a/.agents/scripts/pulse-capacity-alloc.sh
+++ b/.agents/scripts/pulse-capacity-alloc.sh
@@ -432,7 +432,7 @@ _count_dispatchable_product_repos() {
 				pr_json="[]"
 			fi
 			rm -f "$pr_alloc_err"
-			daily_pr_count=$(echo "$pr_json" | jq --arg today "$today_utc" '[.[] | select(.createdAt | startswith($today))] | length' 2>/dev/null) || daily_pr_count=0
+			daily_pr_count=$(echo "$pr_json" | jq --arg today "$today_utc" '[.[] | select((.createdAt // "") | startswith($today))] | length' 2>/dev/null) || daily_pr_count=0
 			[[ "$daily_pr_count" =~ ^[0-9]+$ ]] || daily_pr_count=0
 			if [[ "$daily_pr_count" -lt "$DAILY_PR_CAP" ]]; then
 				dispatchable=$((dispatchable + 1))

--- a/.agents/scripts/pulse-prefetch-fetch.sh
+++ b/.agents/scripts/pulse-prefetch-fetch.sh
@@ -292,7 +292,7 @@ _prefetch_repo_daily_cap() {
 	rm -f "$daily_cap_err"
 	local daily_pr_count
 	daily_pr_count=$(echo "$daily_cap_json" | jq --arg today "$today_utc" \
-		'[.[] | select(.createdAt | startswith($today))] | length') || daily_pr_count=0
+		'[.[] | select((.createdAt // "") | startswith($today))] | length') || daily_pr_count=0
 	[[ "$daily_pr_count" =~ ^[0-9]+$ ]] || daily_pr_count=0
 	local daily_pr_remaining=$((DAILY_PR_CAP - daily_pr_count))
 	if [[ "$daily_pr_remaining" -lt 0 ]]; then

--- a/.agents/scripts/quality-feedback-issues-lib.sh
+++ b/.agents/scripts/quality-feedback-issues-lib.sh
@@ -135,7 +135,7 @@ _backfill_priority_labels() {
 	issues_to_label=$(gh issue list --repo "$repo_slug" \
 		--label "quality-debt" --state open --limit 500 \
 		--json number,title,labels \
-		--jq '.[] | select([.labels[].name] | any(startswith("priority:")) | not) | "\(.number)|\(.title)"' ||
+		--jq '.[] | select([.labels[].name // ""] | any(startswith("priority:")) | not) | "\(.number)|\(.title)"' ||
 		echo "")
 
 	[[ -z "$issues_to_label" ]] && return 0
@@ -530,7 +530,7 @@ _create_or_append_file_issue() {
 	local existing_file_issue=""
 	if [[ "$file" != "general" ]]; then
 		existing_file_issue=$(echo "$existing_open_issues_json" | jq -r --arg f "$file" \
-			'[.[] | select(.title | startswith("quality-debt: \($f) —"))] | .[0].number // empty' ||
+			'[.[] | select((.title // "") | startswith("quality-debt: \($f) —"))] | .[0].number // empty' ||
 			echo "")
 	fi
 


### PR DESCRIPTION
## Summary

Five jq pipelines fed by `gh` / `gh api` output called `startswith()` without a null guard. When the upstream payload omitted the field (transient API blip, partial write, deleted object), jq exited with `null (null) cannot be matched` and the entire shell pipeline aborted — burning a pulse cycle without dispatching anything.

## Fix

Each call now uses the canonical `(.field // "")` guard so missing keys coerce to empty string and the predicate evaluates false rather than throwing.

## Files

- `.agents/scripts/pulse-capacity-alloc.sh:435` — daily PR cap window
- `.agents/scripts/pulse-prefetch-fetch.sh:295` — parallel callsite for daily PR cap
- `.agents/scripts/quality-feedback-issues-lib.sh:138` — priority label dedup
- `.agents/scripts/quality-feedback-issues-lib.sh:533` — cross-PR file dedup lookup
- `.agents/scripts/aidevops-update-check.sh:516` — hotfix tag discovery

## Out of Scope

`dispatch-dedup-helper.sh:736` and `:1273` were named in the original report but are already null-guarded (`. != null` / `// ""` patterns) — verified pre-fix. They are not the source of the runtime flood.

## Verification

- ShellCheck: clean across all four modified files.
- jq syntax: `[{"createdAt":null},{"createdAt":"2026-04-29T..."}] | jq '[.[] | select((.createdAt // "") | startswith($today))] | length'` returns `1` (correctly skips null + matches valid).
- Pre-commit ratchets: passed.

Resolves #21582

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.7 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-opus-4-7 spent 2h 51m and 19,339 tokens on this with the user in an interactive session.
