### PR TITLE
t3027: route gh issue view through wrapper + top-of-cycle GraphQL skip

### DIFF
--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -813,10 +813,14 @@ _is_task_committed_to_main() {
 
 	[[ -n "$issue_number" && -n "$repo_slug" && -n "$repo_path" ]] || return 1
 
-	# Get the issue creation date for --since filtering
+	# Get the issue creation date for --since filtering.
+	# t3027: route through gh_issue_view wrapper for REST fallback under
+	# GraphQL exhaustion. The `// .created_at` jq fallback handles both
+	# camelCase (gh native) and snake_case (REST) field names — the REST
+	# endpoint /repos/.../issues/N returns `created_at`, gh returns `createdAt`.
 	local created_at
-	created_at=$(gh issue view "$issue_number" --repo "$repo_slug" \
-		--json createdAt -q '.createdAt' 2>/dev/null) || created_at=""
+	created_at=$(gh_issue_view "$issue_number" --repo "$repo_slug" \
+		--json createdAt --jq '.createdAt // .created_at' 2>/dev/null) || created_at=""
 	if [[ -z "$created_at" ]]; then
 		return 1
 	fi
@@ -1108,8 +1112,16 @@ dispatch_with_dedup() {
 	# fetch + the large-file labels/title fetches + the brief-freshness body
 	# fetch) with a single call. See .agents/reference/dispatch-architecture.md
 	# "gh API call budget" for the full inventory.
+	#
+	# t3027: route through gh_issue_view wrapper for REST fallback under
+	# GraphQL exhaustion. Without this, every per-candidate dedup check in a
+	# 100+ candidate cycle fails identically with "unable to load issue
+	# metadata" once GraphQL hits 0/5000, burning ceremony cost (claim
+	# acquisition, advisory comments) for zero dispatches. Downstream consumers
+	# of this JSON access only .number, .title, .state, .labels[].name,
+	# .assignees, .body — all of which exist in REST shape unchanged.
 	local issue_meta_json
-	issue_meta_json=$(gh issue view "$issue_number" --repo "$repo_slug" \
+	issue_meta_json=$(gh_issue_view "$issue_number" --repo "$repo_slug" \
 		--json number,title,state,labels,assignees,body 2>/dev/null) || issue_meta_json=""
 	if [[ -z "$issue_meta_json" ]]; then
 		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: unable to load issue metadata" >>"$LOGFILE"
@@ -1230,7 +1242,10 @@ _ensure_issue_body_has_brief() {
 		&& printf '%s' "$pre_fetched_json" | jq -e '.body' >/dev/null 2>&1; then
 		current_body=$(printf '%s' "$pre_fetched_json" | jq -r '.body // ""' 2>/dev/null) || current_body=""
 	else
-		current_body=$(gh issue view "$issue_number" --repo "$repo_slug" --json body -q .body 2>/dev/null || echo "")
+		# t3027: route through gh_issue_view wrapper for REST fallback under
+		# GraphQL exhaustion. The `body` field name is identical between gh
+		# native and REST shape, so --jq '.body' works on both paths.
+		current_body=$(gh_issue_view "$issue_number" --repo "$repo_slug" --json body --jq '.body' 2>/dev/null || echo "")
 	fi
 	if [[ "$current_body" == *"## Task Brief"* ]] || [[ "$current_body" == *"## Worker Guidance"* ]]; then
 		return 0

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -1112,14 +1112,6 @@ dispatch_with_dedup() {
 	# fetch + the large-file labels/title fetches + the brief-freshness body
 	# fetch) with a single call. See .agents/reference/dispatch-architecture.md
 	# "gh API call budget" for the full inventory.
-	#
-	# t3027: route through gh_issue_view wrapper for REST fallback under
-	# GraphQL exhaustion. Without this, every per-candidate dedup check in a
-	# 100+ candidate cycle fails identically with "unable to load issue
-	# metadata" once GraphQL hits 0/5000, burning ceremony cost (claim
-	# acquisition, advisory comments) for zero dispatches. Downstream consumers
-	# of this JSON access only .number, .title, .state, .labels[].name,
-	# .assignees, .body — all of which exist in REST shape unchanged.
 	local issue_meta_json
 	issue_meta_json=$(gh_issue_view "$issue_number" --repo "$repo_slug" \
 		--json number,title,state,labels,assignees,body 2>/dev/null) || issue_meta_json=""

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1479,6 +1479,28 @@ main() {
 		return 0
 	fi
 
+	# t3027: orchestration-level GraphQL-aware idle skip. is_graphql_budget_sufficient
+	# (sourced via pulse-dispatch-engine.sh → pulse-rate-limit-circuit-breaker.sh)
+	# returns 1 when GraphQL remaining is at or below the configured threshold
+	# (default 30% via .agents/configs/pulse-rate-limit.conf). Hoisting this
+	# check above prefetch_state and the LLM run prevents the cycle from
+	# burning a doomed ~210s prefetch + multi-minute LLM run + dispatch
+	# ceremony when budget is exhausted — the canonical t2690 invocation
+	# sits inside the deterministic fill floor and only stops dispatch, not
+	# the upstream API consumers. Fail-open (rc=2) proceeds so a flaky
+	# rate_limit endpoint can't wedge the pulse permanently.
+	if declare -F is_graphql_budget_sufficient >/dev/null 2>&1; then
+		local _t3027_rl_rc=0
+		is_graphql_budget_sufficient || _t3027_rl_rc=$?
+		if [[ "$_t3027_rl_rc" -eq 1 ]]; then
+			echo "[pulse-wrapper] Cycle skipped: GraphQL budget below circuit-breaker threshold (t3027 — orchestration-level skip; saves prefetch + LLM run cost)" >>"$LOGFILE"
+			if declare -F pulse_stats_increment >/dev/null 2>&1; then
+				pulse_stats_increment "pulse_cycle_skipped_graphql_low" 2>/dev/null || true
+			fi
+			return 0
+		fi
+	fi
+
 	# t2994: pre-warm L3 caches when sentinel is stale. Runs after lock,
 	# canary, session, and dedup gates have all passed (so a real cycle is
 	# about to run) and BEFORE prefetch_state inside the cycle. Steady-state

--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -694,8 +694,12 @@ _rest_issue_view() {
 		--repo=*) repo="${_arg#--repo=}"; shift ;;
 		--json) shift 2 ;;
 		--json=*) shift ;;
-		--jq) jq_expr="${2:-}"; shift 2 ;;
-		--jq=*) jq_expr="${_arg#--jq=}"; shift ;;
+		# t3027: accept -q as gh's documented shorthand for --jq. Without this,
+		# callers using `gh issue view ... -q '.field'` (the idiomatic gh form)
+		# silently lost the jq filter on REST fallback and got the full issue
+		# object, breaking downstream string assignments.
+		--jq | -q) jq_expr="${2:-}"; shift 2 ;;
+		--jq=* | -q=*) jq_expr="${_arg#*=}"; shift ;;
 		*) shift ;;
 		esac
 	done


### PR DESCRIPTION
## Summary

P0 framework stability fix: route bare `gh issue view` callsites in the per-candidate dedup ceremony through the existing `gh_issue_view` wrapper (which has REST fallback), and add an orchestration-level GraphQL-budget check that skips the entire cycle when budget is exhausted — not just the dispatch step.

Refs #21584 (parent), complements #21596

## What

Three minimal changes that work together:

1. **`shared-gh-wrappers-rest-fallback.sh::_rest_issue_view`** — accept gh's `-q` shorthand for `--jq` in the REST fallback path. Without this, callers using `gh issue view ... -q '.field'` (the idiomatic gh form) silently lost the jq filter when REST fallback engaged and got the full issue object, breaking downstream string assignments.

2. **`pulse-dispatch-core.sh`** — route 3 bare `gh issue view` callsites through `gh_issue_view`:
   - **Line 818** (`_is_task_committed_to_main`) — `--jq '.createdAt // .created_at'` handles both gh native (camelCase) and REST (snake_case) shapes. The `created_at` field is the only known shape mismatch in the dispatch path.
   - **Line 1112** (`dispatch_with_dedup` — the canonical t2996 single-call meta fetch) — drop-in. Downstream consumers access only `.number`, `.title`, `.state`, `.labels[].name`, `.assignees`, `.body` — all identical between gh and REST shapes.
   - **Line 1233** (`_ensure_issue_body_has_brief` body fallback) — `--jq '.body'`. Body field is identical in both shapes.

3. **`pulse-wrapper.sh::main()`** — hoist `is_graphql_budget_sufficient` check above `_pulse_prime_caches_if_stale` and `prefetch_state`. The canonical t2690 invocation lives inside the deterministic fill floor (`pulse-dispatch-engine.sh:296`) — too late to prevent the ~210s prefetch and multi-minute LLM run from burning budget that's already gone. The new orchestration-level skip exits the cycle entirely when budget is at/below the configured 30% threshold (canonical `.agents/configs/pulse-rate-limit.conf`).

Counter: `pulse_cycle_skipped_graphql_low` in `pulse-stats.json`. Fail-open on rate-limit API errors (rc=2) so a flaky endpoint cannot wedge pulse permanently.

## Why

Operational evidence collected on the marcusquinn runtime (Apr 28, GraphQL=0/5000):

- **Dispatched=0 in 70% of cycles** (1456 of 2065 today). Each dispatched=0 cycle still paid the prefetch cost (~210s, many GraphQL points) and ran the LLM supervisor, accumulating exhaustion faster than the configured threshold could catch.
- **Per-candidate ceremony failure pattern**: iter=62 at 22:30Z evaluated 148 candidates, all 148 exceeded the 180s timeout, dispatched=0. CLAIM_WON markers appeared on #21547, #21329, #21303, #21302, #21314, #21289, #21286 — ceremony reached claim acquisition (~120s) but the meta-fetch at line 1112 returned empty and aborted with "unable to load issue metadata" before `dispatch_with_dedup` could complete. The claim comment was already posted; ceremony cost was paid for zero dispatches.
- **Why bare `gh issue view` failed under exhaustion**: GraphQL exhausted → `gh issue view` returns empty → empty `issue_meta_json` → return 1. The wrapper exists and has REST fallback for exactly this case, but these three callsites bypassed it.

The fix is asymmetric: the cheap fix (wrapper routing, +1 line per callsite) eliminates the largest visible failure mode; the orchestration-level skip prevents future cycles from re-burning budget when the first read already proved exhaustion.

## Verification

- ShellCheck zero violations on all 3 modified files (verified locally).
- Existing tests pass: `test-shared-gh-wrappers-standalone.sh` (8/8), `test-pulse-dispatch-core-bot-cleanup.sh` (9/9).
- `bash -n` syntax check passes on all 3 files.
- `_rest_issue_view` `-q` shorthand verified in live function definition via `declare -f`.
- The `gh_issue_view` wrapper is already exercised by the proven t2689/t2902 deployment — this PR just expands its coverage to 3 missed callsites.

Acceptance criteria from issue:

- [x] Per-candidate ceremony succeeds under GraphQL exhaustion (REST fallback engages on the meta fetch).
- [x] Cycles skip cleanly when budget is exhausted (orchestration-level GraphQL check).
- [x] Counter `pulse_cycle_skipped_graphql_low` exposes the new skip path for observability.
- [x] No change to dispatch behaviour when budget is sufficient (declare-F guard, fail-open on API errors).
- [ ] Telemetry repair (`gh-api-calls.log` empty, `prefetch_calls=null`) — deferred to follow-up.
- [ ] Canonical-recovery routine (auto-stash + ff pull) — deferred to follow-up.

## Files Scope

- `.agents/scripts/pulse-dispatch-core.sh`
- `.agents/scripts/pulse-wrapper.sh`
- `.agents/scripts/shared-gh-wrappers-rest-fallback.sh`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.7 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-opus-4-7 spent 3h 10m and 19,339 tokens on this with the user in an interactive session.