### PR TITLE
t3032: P0 fix Framework Validation — repoint approve_collaborator_pr extract to pulse-merge-gates.sh

### DIFF
--- a/.agents/scripts/tests/test-pulse-merge-approve-collaborator-guard.sh
+++ b/.agents/scripts/tests/test-pulse-merge-approve-collaborator-guard.sh
@@ -33,7 +33,13 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
-MERGE_SCRIPT="${SCRIPT_DIR}/../pulse-merge.sh"
+# approve_collaborator_pr was extracted to pulse-merge-gates.sh during the
+# pulse-merge split. The test extracts it via awk for isolated execution under
+# a mock gh stub, so the source file must point at where the function actually
+# lives — not the orchestrator that only calls it. Without this repoint the
+# extraction returns empty and the test exits FATAL, blocking every PR via the
+# Framework Validation required check (t3032).
+MERGE_SCRIPT="${SCRIPT_DIR}/../pulse-merge-gates.sh"
 # _is_collaborator_author was extracted to pulse-merge-author-checks.sh (GH#21426)
 AUTHOR_CHECKS_SCRIPT="${SCRIPT_DIR}/../pulse-merge-author-checks.sh"
 


### PR DESCRIPTION
## Summary

P0 framework stability — `Framework Validation` required CI check has been failing on **every PR** to this repo (and on `main` for the last 3+ commits) since the pulse-merge split landed. This one-line repoint fixes the test's source-file pointer, unblocking all in-flight PRs (#21596, #21597, #21606) and main.

Resolves #21608

## What

`test-pulse-merge-approve-collaborator-guard.sh` extracts `approve_collaborator_pr()` from a source file via `awk` so the function can run under a mock `gh` stub in isolation. The pulse-merge split moved that function from `pulse-merge.sh` → `pulse-merge-gates.sh:353`, but `MERGE_SCRIPT` in the test was not updated. Result: awk returns empty, test exits `FATAL: helper extraction failed`, CI required check fails, no PR can merge.

## Why

The test extracts the function rather than sourcing the orchestrator because the orchestrator pulls in dozens of unrelated dependencies. The extract-and-`eval` pattern is intentional — it keeps the test fast and isolated. The fix preserves that pattern and just repoints at the right file.

The companion `_is_collaborator_author` extraction at line 38 was already updated when that function was extracted to `pulse-merge-author-checks.sh` (GH#21426); this PR brings the sibling extraction in line with the same pattern.

## Verification

Reproduced the failure locally before the fix:

```text
$ bash .agents/scripts/tests/test-pulse-merge-approve-collaborator-guard.sh
ERROR: could not extract approve_collaborator_pr from .../pulse-merge.sh
FATAL: helper extraction failed
```

After the fix:

```text
$ bash .agents/scripts/tests/test-pulse-merge-approve-collaborator-guard.sh
PASS Case A: collaborator author — approves PR with accurate body
PASS Case B: non-collaborator author — refused with audit-trail log
PASS Case C: self-authored — skipped (--admin handles it)
PASS Case D: runner lacks write access — skipped
Ran 4 tests, 0 failed.

$ shellcheck .agents/scripts/tests/test-pulse-merge-approve-collaborator-guard.sh
$ echo $?
0
```

## Acceptance Criteria

- [x] Test passes locally (`bash .agents/scripts/tests/test-pulse-merge-approve-collaborator-guard.sh`)
- [ ] `Framework Validation` job passes on this PR
- [ ] Re-runs on PRs #21596, #21597, #21606 pass after this merges

## Files Scope

- .agents/scripts/tests/test-pulse-merge-approve-collaborator-guard.sh

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.7 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-haiku-4-5 spent 10d 18h and 278 tokens on this as a headless worker.
