### PR TITLE
t3031: fix dispatch counter accounting (subshell stdout pollution at engine.sh:902)

### DIFF
--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -899,7 +899,7 @@ _dff_dispatch_loop_parallel() {
 		# canary cache) and the outcomes file write propagate.
 		(
 			local _rc=0
-			_dff_process_candidate "$candidate_json" "$self_login" "$available_slots" || _rc=$?
+			_dff_process_candidate "$candidate_json" "$self_login" "$available_slots" >>"$LOGFILE" 2>&1 || _rc=$?
 			local issue_num
 			issue_num=$(printf '%s' "$candidate_json" | jq -r '.number // 0' 2>/dev/null)
 			if [[ "$_rc" -eq 0 ]]; then


### PR DESCRIPTION
## Summary

Seals the backgrounded subshell stdout in `_dff_dispatch_loop_parallel` so stray dispatch-chain output no longer corrupts the `dispatched_count` capture in the caller.

## Root Cause

`_dff_process_candidate` at `pulse-dispatch-engine.sh:902` ran inside a backgrounded subshell that inherited the parent function's stdout. Any echo/printf from the dispatch chain (jq error noise on null inputs, `dispatch_with_dedup` progress output, `gh` API rate-limit retry messages) flowed up through the subshell and mixed with the single `printf '%d %d\n'` sentinel at line 918. The caller captured everything via `loop_output=$(_dff_dispatch_loop_parallel ...)`, then `read -r dispatched_count processed_count <<<"$loop_output"` read only the first line — if that line was pollution (e.g. `null`, a jq error), the regex guard at line 1124 zeroed `dispatched_count`, making cycle summaries report `dispatched=0` even when `Dispatched worker PID` lines fired in the same cycle.

## Fix

One-line change (Option A from issue body — minimum blast radius):

```diff
-    _dff_process_candidate "$candidate_json" "$self_login" "$available_slots" || _rc=$?
+    _dff_process_candidate "$candidate_json" "$self_login" "$available_slots" >>"$LOGFILE" 2>&1 || _rc=$?
```

Appends all dispatch-chain stdout/stderr to LOGFILE (where it belongs). The `printf ... >>"$outcomes_file"` calls at lines 906-908 write to the outcomes file directly — not stdout — so they are unaffected.

## Testing

- `shellcheck .agents/scripts/pulse-dispatch-engine.sh` — clean (no output)
- Pre-commit hooks passed (return-statement, positional-parameter, string-literal, ShellCheck ratchets)
- Runtime: 10 consecutive cycles must show `dispatched_from_summary == actual_PIDs` per the verification script in the issue body

Resolves #21600