### PR TITLE
t3020: add brief-filename-guard pre-commit hook to block unclaimed t-IDs in brief filenames

### DIFF
--- a/.agents/hooks/brief-filename-guard.sh
+++ b/.agents/hooks/brief-filename-guard.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# brief-filename-guard.sh — git pre-commit hook (t3020).
+#
+# Blocks a commit that ADDS a todo/tasks/tNNN-brief.md file whose t-ID has
+# never been allocated via a `chore: claim tNNN` commit anywhere in git history.
+#
+# This closes the bypass vector where unclaimed t-IDs appear first as brief
+# FILENAMES rather than commit subjects. The commit-msg guard
+# (install-task-id-guard.sh) only covers commit subjects; this hook covers the
+# complementary entry point.
+#
+# Install: see .agents/scripts/install-pre-push-guards.sh
+#   install-pre-push-guards.sh install --guard brief-filename
+#
+# Git pre-commit protocol: no arguments; hook reads staged index directly.
+#
+# Exit 0 = allow commit. Exit 1 = block commit.
+#
+# Environment:
+#   BRIEF_FILENAME_GUARD_DISABLE=1  — bypass for this invocation
+#   BRIEF_FILENAME_GUARD_DEBUG=1    — verbose stderr trace
+#
+# Fail-open cases (exit 0):
+#   - no todo/tasks/tNNN-brief.md files are in the staged added set
+#   - a staged file is being deleted (cleanup must always work)
+#   - file is a modification of an existing brief (already committed previously)
+#   - git is unavailable or repo is not initialised
+#
+# Fail-closed cases (exit 1):
+#   - a brief file is ADDED (new to index) AND its t-ID has no
+#     `chore: claim tNNN` commit in the full git history
+
+set -u
+
+GUARD_NAME="brief-filename-guard"
+
+_log() {
+	local _level="$1"
+	local _msg="$2"
+	printf '[%s][%s] %s\n' "$GUARD_NAME" "$_level" "$_msg" >&2
+	return 0
+}
+
+_dbg() {
+	local _msg="$1"
+	[[ "${BRIEF_FILENAME_GUARD_DEBUG:-0}" == "1" ]] || return 0
+	_log DEBUG "$_msg"
+	return 0
+}
+
+if [[ "${BRIEF_FILENAME_GUARD_DISABLE:-0}" == "1" ]]; then
+	_log INFO "BRIEF_FILENAME_GUARD_DISABLE=1 — bypassing"
+	exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Verify we are inside a git repo.
+# ---------------------------------------------------------------------------
+_repo_root() {
+	git rev-parse --show-toplevel 2>/dev/null
+	return 0
+}
+
+REPO_ROOT=$(_repo_root)
+if [[ -z "$REPO_ROOT" ]]; then
+	_log WARN "not inside a git repo — fail-open"
+	exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Collect staged ADDED files matching the brief filename pattern.
+# --diff-filter=A: Added files only. Modified/deleted files are skipped:
+#   - Modified: brief already existed (t-ID was previously claimed)
+#   - Deleted:  cleanup — must always pass
+# ---------------------------------------------------------------------------
+_raw_added=$(git diff --cached --name-only --diff-filter=A 2>/dev/null)
+added_briefs=()
+if [[ -n "$_raw_added" ]]; then
+	while IFS= read -r _file; do
+		[[ -z "$_file" ]] && continue
+		if [[ "$_file" =~ ^todo/tasks/t[0-9]+-brief\.md$ ]]; then
+			added_briefs+=("$_file")
+		fi
+	done <<< "$_raw_added"
+fi
+
+if [[ "${#added_briefs[@]}" -eq 0 ]]; then
+	_dbg "no added brief files staged — pass"
+	exit 0
+fi
+
+_dbg "${#added_briefs[@]} added brief file(s) staged"
+
+# ---------------------------------------------------------------------------
+# For each added brief file, extract the t-ID and verify it has a claim commit.
+# A valid claim commit has the form: "chore: claim tNNN" (any subject match).
+# ---------------------------------------------------------------------------
+exit_code=0
+for _brief_file in "${added_briefs[@]}"; do
+	# Extract the t-ID from the filename
+	# Pattern: todo/tasks/tNNN-brief.md → tNNN
+	if [[ "$_brief_file" =~ ^todo/tasks/(t[0-9]+)-brief\.md$ ]]; then
+		_tid="${BASH_REMATCH[1]}"
+	else
+		_dbg "  cannot extract t-ID from: $_brief_file — skip"
+		continue
+	fi
+
+	_dbg "checking: $_brief_file (task ID: $_tid)"
+
+	# Search the full history (all branches/tags) for a claim commit.
+	# git log --all --grep performs a case-sensitive substring search on the
+	# commit subject. The canonical claim subject is: "chore: claim tNNN"
+	_claim_hit=$(git log --all --oneline --grep="chore: claim ${_tid}" 2>/dev/null | head -1)
+
+	if [[ -n "$_claim_hit" ]]; then
+		_dbg "  PASS: claim commit found: $_claim_hit"
+		continue
+	fi
+
+	# No claim commit found — block with mentoring error.
+	exit_code=1
+	printf '\n[%s][BLOCK] Brief staged for unclaimed task ID\n\n' "$GUARD_NAME" >&2
+	printf '  File:    %s\n' "$_brief_file" >&2
+	printf '  Task ID: %s\n' "$_tid" >&2
+	printf '  Reason:  no "chore: claim %s" commit found in git history\n' "$_tid" >&2
+	printf '\n' >&2
+	printf '  Remediation:\n' >&2
+	printf '    1. Allocate the task ID properly:\n' >&2
+	printf '         claim-task-id.sh --title "your-task-description"\n' >&2
+	printf '       This creates the "chore: claim tNNN" commit that registers a valid t-ID.\n' >&2
+	printf '    2. Rename the brief file to match the claimed t-ID.\n' >&2
+	printf '    3. Bypass (with audit trail): BRIEF_FILENAME_GUARD_DISABLE=1 git commit ...\n' >&2
+	printf '    4. Bypass (no audit trail):   git commit --no-verify\n' >&2
+	printf '\n' >&2
+done
+
+exit "$exit_code"

--- a/.agents/scripts/install-pre-push-guards.sh
+++ b/.agents/scripts/install-pre-push-guards.sh
@@ -2,29 +2,35 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 #
-# install-pre-push-guards.sh — Install aidevops git pre-push hooks (t2198, t2446, t2458, t2745).
+# install-pre-push-guards.sh — Install aidevops git pre-push/pre-commit hooks (t2198, t2446, t2458, t2745, t3020).
 #
-# Manages five pre-push guards in the current repository:
-#   - privacy-guard      blocks pushes leaking private repo slugs
-#   - complexity-guard   blocks pushes introducing complexity regressions
-#   - scope-guard        blocks pushes touching files outside the brief's Files Scope
-#   - credential-guard   blocks pushes emitting unsanitised remote URLs (t2458)
-#   - dup-todo-guard     blocks pushes where TODO.md has duplicate task-ID checkbox lines (t2745)
+# Manages six guards in the current repository:
+#
+# Pre-push guards (installed to .git/hooks/pre-push):
+#   - privacy-guard        blocks pushes leaking private repo slugs
+#   - complexity-guard     blocks pushes introducing complexity regressions
+#   - scope-guard          blocks pushes touching files outside the brief's Files Scope
+#   - credential-guard     blocks pushes emitting unsanitised remote URLs (t2458)
+#   - dup-todo-guard       blocks pushes where TODO.md has duplicate task-ID checkbox lines (t2745)
+#
+# Pre-commit guards (installed to .git/hooks/pre-commit):
+#   - brief-filename-guard blocks commits adding todo/tasks/tNNN-brief.md with unclaimed t-IDs (t3020)
 #
 # Usage:
 #   install-pre-push-guards.sh install [--guard <name>]
 #         Install (or refresh) guard(s).
-#         --guard: privacy|complexity|scope|credential|dup-todo|all (default: all)
+#         --guard: privacy|complexity|scope|credential|dup-todo|brief-filename|all (default: all)
 #
 #   install-pre-push-guards.sh uninstall [--guard <name>]
 #         Remove guard entry/entries.
-#         --guard: privacy|complexity|scope|credential|dup-todo|all (default: all)
+#         --guard: privacy|complexity|scope|credential|dup-todo|brief-filename|all (default: all)
 #
 #   install-pre-push-guards.sh status
 #         Report which guards are present and their hook source locations.
 #
-# The installer writes .git/hooks/pre-push targeting `git rev-parse
+# Pre-push installer writes .git/hooks/pre-push targeting `git rev-parse
 # --git-common-dir` so worktrees share the hook with the parent repo.
+# Pre-commit installer writes .git/hooks/pre-commit (same common-dir logic).
 #
 # Existing hooks NOT managed by aidevops are refused and left untouched.
 #
@@ -33,8 +39,10 @@
 #   COMPLEXITY_GUARD_DISABLE=1       skip complexity check for this push
 #   SCOPE_GUARD_DISABLE=1            skip scope check for this push
 #   CREDENTIAL_GUARD_DISABLE=1       skip credential check for this push
-#   DUP_TODO_GUARD_DISABLE=1          skip duplicate TODO check for this push
-#   git push --no-verify             skip all hooks
+#   DUP_TODO_GUARD_DISABLE=1         skip duplicate TODO check for this push
+#   BRIEF_FILENAME_GUARD_DISABLE=1   skip brief-filename check for this commit
+#   git push --no-verify             skip all pre-push hooks
+#   git commit --no-verify           skip all pre-commit hooks
 
 set -euo pipefail
 
@@ -68,17 +76,20 @@ print_error() {
 
 # Marker strings embedded in the managed hook file — used for detect/update.
 HOOK_MARKER_MANAGED="# aidevops-pre-push-guards"
+HOOK_MARKER_PRECOMMIT_MANAGED="# aidevops-pre-commit-guards"
 HOOK_MARKER_PRIVACY="# guard:privacy"
 HOOK_MARKER_COMPLEXITY="# guard:complexity"
 HOOK_MARKER_SCOPE="# guard:scope"
 HOOK_MARKER_CREDENTIAL="# guard:credential"
 HOOK_MARKER_DUP_TODO="# guard:dup-todo"
+HOOK_MARKER_BRIEF_FILENAME="# guard:brief-filename"
 
 DEPLOYED_PRIVACY_HOOK="$HOME/.aidevops/agents/hooks/privacy-guard-pre-push.sh"
 DEPLOYED_COMPLEXITY_HOOK="$HOME/.aidevops/agents/hooks/complexity-regression-pre-push.sh"
 DEPLOYED_SCOPE_HOOK="$HOME/.aidevops/agents/hooks/scope-guard-pre-push.sh"
 DEPLOYED_CREDENTIAL_HOOK="$HOME/.aidevops/agents/hooks/credential-emission-pre-push.sh"
 DEPLOYED_DUP_TODO_HOOK="$HOME/.aidevops/agents/hooks/pre-push-dup-todo-guard.sh"
+DEPLOYED_BRIEF_FILENAME_HOOK="$HOME/.aidevops/agents/hooks/brief-filename-guard.sh"
 
 #######################################
 # Resolve the script's own directory (symlink-safe).
@@ -125,6 +136,10 @@ _find_hook_src() {
 		_repo_hook="${_sd}/../hooks/pre-push-dup-todo-guard.sh"
 		_deployed_hook="$DEPLOYED_DUP_TODO_HOOK"
 		;;
+	brief-filename)
+		_repo_hook="${_sd}/../hooks/brief-filename-guard.sh"
+		_deployed_hook="$DEPLOYED_BRIEF_FILENAME_HOOK"
+		;;
 	*)
 		print_error "_find_hook_src: unknown guard: $_guard"
 		return 1
@@ -153,12 +168,106 @@ _git_common_dir() {
 }
 
 #######################################
-# Return the canonical hook file path.
+# Return the canonical pre-push hook file path.
 #######################################
 _hook_path() {
 	local _cdir
 	_cdir=$(_git_common_dir) || return 1
 	printf '%s/hooks/pre-push' "$_cdir"
+	return 0
+}
+
+#######################################
+# Return the canonical pre-commit hook file path.
+#######################################
+_commit_hook_path() {
+	local _cdir
+	_cdir=$(_git_common_dir) || return 1
+	printf '%s/hooks/pre-commit' "$_cdir"
+	return 0
+}
+
+#######################################
+# Install (or refresh) the pre-commit dispatcher containing the brief-filename guard.
+# Creates .git/hooks/pre-commit managed by aidevops.
+# Returns 1 if an existing unmanaged pre-commit hook is found.
+#######################################
+_install_precommit_brief_filename() {
+	local _chook_path
+	_chook_path=$(_commit_hook_path) || return 1
+
+	# Refuse to overwrite an unmanaged pre-commit hook.
+	if [[ -f "$_chook_path" ]]; then
+		if ! grep -q "$HOOK_MARKER_PRECOMMIT_MANAGED" "$_chook_path" 2>/dev/null; then
+			print_error "existing pre-commit hook at $_chook_path is NOT managed by aidevops"
+			print_error "Refusing to overwrite. To chain manually, add the guard to your hook:"
+			# shellcheck disable=SC2016
+			print_error '  ${REPO}/.agents/hooks/brief-filename-guard.sh "$@"'
+			return 1
+		fi
+	fi
+
+	local _hook_src
+	if ! _hook_src=$(_find_hook_src brief-filename 2>/dev/null); then
+		print_warning "brief-filename hook source not found — skipping pre-commit guard"
+		return 0
+	fi
+
+	local _repo_rel=".agents/hooks/brief-filename-guard.sh"
+
+	mkdir -p "$(dirname "$_chook_path")"
+
+	# shellcheck disable=SC2016
+	cat >"$_chook_path" <<COMMIT_HOOK
+#!/usr/bin/env bash
+# aidevops-pre-commit-guards
+# Managed by .agents/scripts/install-pre-push-guards.sh — do not edit.
+# Chains installed aidevops pre-commit guards in order.
+# Bypass all:  git commit --no-verify
+# Bypass each: BRIEF_FILENAME_GUARD_DISABLE=1
+
+set -u
+
+_git_root=\$(git rev-parse --show-toplevel 2>/dev/null || true)
+_exit_code=0
+
+# guard:brief-filename
+_brief_filename_hook=""
+if [[ -n "\$_git_root" && -f "\${_git_root}/${_repo_rel}" ]]; then
+  _brief_filename_hook="\${_git_root}/${_repo_rel}"
+elif [[ -f "${_hook_src}" ]]; then
+  _brief_filename_hook="${_hook_src}"
+fi
+if [[ -n "\$_brief_filename_hook" ]]; then
+  "\$_brief_filename_hook" "\$@" || _exit_code=\$?
+else
+  printf '[pre-commit][WARN] brief-filename hook not found -- skipping\n' >&2
+fi
+
+exit "\$_exit_code"
+COMMIT_HOOK
+
+	chmod +x "$_chook_path"
+	return 0
+}
+
+#######################################
+# Uninstall the aidevops-managed pre-commit hook.
+# No-ops if not installed or not managed by us.
+#######################################
+_uninstall_precommit_brief_filename() {
+	local _chook_path
+	_chook_path=$(_commit_hook_path) || return 1
+
+	if [[ ! -f "$_chook_path" ]]; then
+		return 0
+	fi
+	if ! grep -q "$HOOK_MARKER_PRECOMMIT_MANAGED" "$_chook_path" 2>/dev/null; then
+		print_warning "pre-commit hook at $_chook_path is NOT managed by aidevops — leaving it alone"
+		return 0
+	fi
+	rm -f "$_chook_path"
+	print_success "removed pre-commit hook (brief-filename guard)"
 	return 0
 }
 
@@ -307,6 +416,7 @@ _install_reject_unmanaged_hook() {
 		# shellcheck disable=SC2016
 		print_error '  ${REPO}/.agents/hooks/'"$_gh"' "$@" < /dev/stdin'
 	done
+	print_error "(pre-commit: brief-filename-guard.sh is installed separately to .git/hooks/pre-commit)"
 	return 1
 }
 
@@ -334,15 +444,17 @@ cmd_install() {
 
 	# Determine which guards to add based on filter
 	local _want_privacy=0 _want_complexity=0 _want_scope=0 _want_credential=0 _want_dup_todo=0
+	local _want_brief_filename=0
 	case "$_guard_filter" in
-	all)        _want_privacy=1; _want_complexity=1; _want_scope=1; _want_credential=1; _want_dup_todo=1 ;;
-	privacy)    _want_privacy=1 ;;
-	complexity) _want_complexity=1 ;;
-	scope)      _want_scope=1 ;;
-	credential) _want_credential=1 ;;
-	dup-todo)   _want_dup_todo=1 ;;
+	all)            _want_privacy=1; _want_complexity=1; _want_scope=1; _want_credential=1; _want_dup_todo=1; _want_brief_filename=1 ;;
+	privacy)        _want_privacy=1 ;;
+	complexity)     _want_complexity=1 ;;
+	scope)          _want_scope=1 ;;
+	credential)     _want_credential=1 ;;
+	dup-todo)       _want_dup_todo=1 ;;
+	brief-filename) _want_brief_filename=1 ;;
 	*)
-		print_error "unknown guard: $_guard_filter (valid: all, privacy, complexity, scope, credential, dup-todo)"
+		print_error "unknown guard: $_guard_filter (valid: all, privacy, complexity, scope, credential, dup-todo, brief-filename)"
 		return 1
 		;;
 	esac
@@ -398,16 +510,33 @@ cmd_install() {
 		fi
 	fi
 
+	# brief-filename is a pre-commit guard — handled separately from the pre-push dispatcher.
+	if [[ "$_want_brief_filename" -eq 1 ]]; then
+		if _find_hook_src brief-filename >/dev/null 2>&1; then
+			if _install_precommit_brief_filename; then
+				_installed_list="${_installed_list}brief-filename(pre-commit) "
+			fi
+		else
+			print_warning "brief-filename hook source not found — omitting brief-filename guard"
+		fi
+	fi
+
 	if [[ "$_inc_privacy" -eq 0 && "$_inc_complexity" -eq 0 && "$_inc_scope" -eq 0 && "$_inc_credential" -eq 0 && "$_inc_dup_todo" -eq 0 ]]; then
-		print_warning "no guards to install (sources not found)"
+		# Only brief-filename was requested (or all others were missing): acceptable
+		if [[ -n "${_installed_list:-}" ]]; then
+			print_success "installed guards: ${_installed_list% }"
+		else
+			print_warning "no guards to install (sources not found)"
+		fi
 		return 0
 	fi
 
 	_write_dispatcher "$_hook_path" "$_inc_privacy" "$_inc_complexity" "$_inc_scope" "$_inc_credential" "$_inc_dup_todo"
-	print_success "installed pre-push guards: ${_installed_list% }"
-	print_info "hook: $_hook_path"
-	print_info "bypass all: git push --no-verify"
-	print_info "bypass individual: PRIVACY_GUARD_DISABLE=1, COMPLEXITY_GUARD_DISABLE=1, SCOPE_GUARD_DISABLE=1, CREDENTIAL_GUARD_DISABLE=1, or DUP_TODO_GUARD_DISABLE=1"
+	print_success "installed guards: ${_installed_list% }"
+	print_info "pre-push hook: $_hook_path"
+	print_info "bypass pre-push: git push --no-verify"
+	print_info "bypass pre-commit: git commit --no-verify"
+	print_info "bypass individual: PRIVACY_GUARD_DISABLE=1, COMPLEXITY_GUARD_DISABLE=1, SCOPE_GUARD_DISABLE=1, CREDENTIAL_GUARD_DISABLE=1, DUP_TODO_GUARD_DISABLE=1, or BRIEF_FILENAME_GUARD_DISABLE=1"
 	return 0
 }
 
@@ -445,10 +574,17 @@ cmd_uninstall() {
 	if [[ "$_guard_filter" == "all" ]]; then
 		rm -f "$_hook_path"
 		print_success "removed pre-push hook"
+		_uninstall_precommit_brief_filename
 		return 0
 	fi
 
-	# Remove one guard: read current state, rebuild without the removed guard
+	# brief-filename is a pre-commit guard — uninstall handled separately.
+	if [[ "$_guard_filter" == "brief-filename" ]]; then
+		_uninstall_precommit_brief_filename
+		return 0
+	fi
+
+	# Remove one pre-push guard: read current state, rebuild without the removed guard
 	local _cur_privacy=0 _cur_complexity=0 _cur_scope=0 _cur_credential=0 _cur_dup_todo=0
 	grep -q "$HOOK_MARKER_PRIVACY" "$_hook_path" 2>/dev/null && _cur_privacy=1
 	grep -q "$HOOK_MARKER_COMPLEXITY" "$_hook_path" 2>/dev/null && _cur_complexity=1
@@ -463,17 +599,17 @@ cmd_uninstall() {
 	credential) _cur_credential=0 ;;
 	dup-todo)   _cur_dup_todo=0 ;;
 	*)
-		print_error "unknown guard: $_guard_filter"
+		print_error "unknown guard: $_guard_filter (valid: all, privacy, complexity, scope, credential, dup-todo, brief-filename)"
 		return 1
 		;;
 	esac
 
 	if [[ "$_cur_privacy" -eq 0 && "$_cur_complexity" -eq 0 && "$_cur_scope" -eq 0 && "$_cur_credential" -eq 0 && "$_cur_dup_todo" -eq 0 ]]; then
 		rm -f "$_hook_path"
-		print_success "removed last guard — hook deleted"
+		print_success "removed last pre-push guard — hook deleted"
 	else
 		_write_dispatcher "$_hook_path" "$_cur_privacy" "$_cur_complexity" "$_cur_scope" "$_cur_credential" "$_cur_dup_todo"
-		print_success "removed $_guard_filter guard from hook"
+		print_success "removed $_guard_filter guard from pre-push hook"
 	fi
 	return 0
 }
@@ -511,6 +647,24 @@ cmd_status() {
 	_status_report_guard "scope"      "$_has_scope"
 	_status_report_guard "credential" "$_has_credential"
 	_status_report_guard "dup-todo"   "$_has_dup_todo"
+
+	# Pre-commit guards (separate hook file)
+	local _chook_path
+	_chook_path=$(_commit_hook_path) || return 1
+	local _has_brief_filename=0
+	if [[ -f "$_chook_path" ]]; then
+		grep -q "$HOOK_MARKER_BRIEF_FILENAME" "$_chook_path" 2>/dev/null && _has_brief_filename=1
+	fi
+	printf 'pre-commit hook: %s\n' "$(
+		if [[ -f "$_chook_path" ]] && grep -q "$HOOK_MARKER_PRECOMMIT_MANAGED" "$_chook_path" 2>/dev/null; then
+			printf 'installed (aidevops managed)\n  path: %s' "$_chook_path"
+		elif [[ -f "$_chook_path" ]]; then
+			printf 'installed (unknown manager — not managed by aidevops)\n  path: %s' "$_chook_path"
+		else
+			printf 'NOT INSTALLED'
+		fi
+	)"
+	_status_report_guard "brief-filename" "$_has_brief_filename"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-brief-filename-guard.sh
+++ b/.agents/scripts/tests/test-brief-filename-guard.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-brief-filename-guard.sh — t3020 regression guard.
+#
+# Asserts that .agents/hooks/brief-filename-guard.sh blocks commits that ADD
+# todo/tasks/tNNN-brief.md files whose t-ID has no "chore: claim tNNN" commit
+# in git history, and that claimed IDs, deletions, multi-file scenarios, and
+# the BRIEF_FILENAME_GUARD_DISABLE bypass all behave correctly.
+#
+# Test strategy: create an isolated temp repo with one claim commit for a
+# known t-ID, then stage various combinations of brief files and run the guard
+# directly (without committing) to assert exit code and output.
+
+set -uo pipefail
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPT_DIR_TEST}/../../.." && pwd)" || exit 1
+GUARD="${REPO_ROOT}/.agents/hooks/brief-filename-guard.sh"
+
+if [[ ! -x "$GUARD" ]]; then
+	printf 'guard not found or not executable: %s\n' "$GUARD" >&2
+	exit 1
+fi
+
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf '  %sPASS%s %s\n' "$TEST_GREEN" "$TEST_NC" "$1"
+	return 0
+}
+
+fail() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '  %sFAIL%s %s\n' "$TEST_RED" "$TEST_NC" "$1"
+	[[ -n "${2:-}" ]] && printf '       %s\n' "$2"
+	return 0
+}
+
+# =============================================================================
+# Sandbox setup
+# =============================================================================
+TMP=$(mktemp -d -t t3020-brief-guard.XXXXXX)
+trap 'rm -rf "$TMP"' EXIT
+
+cd "$TMP" || exit 1
+git init -q
+git config user.email "test@example.com"
+git config user.name "Test"
+# Disable commit signing — tests run in CI without GPG/SSH keys.
+git config commit.gpgsign false
+git config tag.gpgsign false
+git config gpg.format openpgp
+
+# Establish an initial (empty) commit so there is a HEAD.
+git commit --allow-empty -q -m "initial"
+
+# Commit a claim for a known t-ID (t99001) — the canonical "claimed" case.
+# The guard searches git log --all --grep for "chore: claim tNNN".
+git commit --allow-empty -q -m "chore: claim t99001 [test_claim]"
+
+# Ensure the todo/tasks directory exists
+mkdir -p todo/tasks
+
+# =============================================================================
+# Case 1: No staged brief files → guard should exit 0 (pass).
+# =============================================================================
+printf '\n[test] Case 1: no staged brief files\n'
+
+exit_code=0
+bash "$GUARD" >/dev/null 2>&1 || exit_code=$?
+
+if [[ "$exit_code" -eq 0 ]]; then
+	pass "no staged brief files → exit 0"
+else
+	fail "expected exit 0, got $exit_code"
+fi
+
+# =============================================================================
+# Case 2: Staged brief for UNCLAIMED t-ID → guard should block (exit 1).
+# =============================================================================
+printf '\n[test] Case 2: staged brief for unclaimed t-ID (t99999)\n'
+
+printf 'placeholder\n' > todo/tasks/t99999-brief.md
+git add todo/tasks/t99999-brief.md
+
+output=""
+exit_code=0
+output=$(bash "$GUARD" 2>&1) || exit_code=$?
+
+# Restore staged state for subsequent tests
+git restore --staged todo/tasks/t99999-brief.md
+rm -f todo/tasks/t99999-brief.md
+
+if [[ "$exit_code" -eq 1 ]]; then
+	pass "unclaimed t-ID → exit 1"
+else
+	fail "expected exit 1, got $exit_code" "$output"
+fi
+
+if [[ "$output" == *"t99999"* ]]; then
+	pass "error output names the unclaimed task ID"
+else
+	fail "error output does not mention t99999" "$output"
+fi
+
+if [[ "$output" == *"not claimed"* || "$output" == *"unclaimed"* || "$output" == *"chore: claim"* ]]; then
+	pass "error output contains remediation guidance"
+else
+	fail "error output lacks remediation guidance" "$output"
+fi
+
+# =============================================================================
+# Case 3: Staged brief for CLAIMED t-ID (t99001) → guard should pass (exit 0).
+# =============================================================================
+printf '\n[test] Case 3: staged brief for claimed t-ID (t99001)\n'
+
+printf 'placeholder\n' > todo/tasks/t99001-brief.md
+git add todo/tasks/t99001-brief.md
+
+exit_code=0
+bash "$GUARD" >/dev/null 2>&1 || exit_code=$?
+
+git restore --staged todo/tasks/t99001-brief.md
+rm -f todo/tasks/t99001-brief.md
+
+if [[ "$exit_code" -eq 0 ]]; then
+	pass "claimed t-ID → exit 0"
+else
+	fail "expected exit 0, got $exit_code"
+fi
+
+# =============================================================================
+# Case 4: Deleted brief file → guard should pass (exit 0).
+# Deletions are not in --diff-filter=A (Added), so the guard ignores them.
+# =============================================================================
+printf '\n[test] Case 4: deleting a brief file (any t-ID)\n'
+
+# Create and commit a brief file first (so it can be staged for deletion)
+printf 'placeholder\n' > todo/tasks/t99998-brief.md
+git add todo/tasks/t99998-brief.md
+git commit -q -m "add t99998 brief for deletion test"
+
+# Stage the deletion
+git rm -q todo/tasks/t99998-brief.md
+
+exit_code=0
+bash "$GUARD" >/dev/null 2>&1 || exit_code=$?
+
+# Restore
+git restore --staged todo/tasks/t99998-brief.md 2>/dev/null || true
+git checkout -- todo/tasks/t99998-brief.md 2>/dev/null || true
+
+if [[ "$exit_code" -eq 0 ]]; then
+	pass "deleting a brief file → exit 0"
+else
+	fail "expected exit 0 on deletion, got $exit_code"
+fi
+
+# =============================================================================
+# Case 5: Multi-file stage — one claimed + one unclaimed → exit 1.
+# Both files staged: t99001 (claimed) + t99002 (unclaimed).
+# Guard must block because t99002 is invalid.
+# =============================================================================
+printf '\n[test] Case 5: multi-file stage (one claimed, one unclaimed)\n'
+
+printf 'placeholder\n' > todo/tasks/t99001-brief.md
+printf 'placeholder\n' > todo/tasks/t99002-brief.md
+git add todo/tasks/t99001-brief.md todo/tasks/t99002-brief.md
+
+output=""
+exit_code=0
+output=$(bash "$GUARD" 2>&1) || exit_code=$?
+
+git restore --staged todo/tasks/t99001-brief.md todo/tasks/t99002-brief.md
+rm -f todo/tasks/t99001-brief.md todo/tasks/t99002-brief.md
+
+if [[ "$exit_code" -eq 1 ]]; then
+	pass "mixed stage (one unclaimed) → exit 1"
+else
+	fail "expected exit 1 for mixed stage, got $exit_code" "$output"
+fi
+
+if [[ "$output" == *"t99002"* ]]; then
+	pass "error output names the unclaimed t-ID (t99002)"
+else
+	fail "error output does not mention unclaimed t99002" "$output"
+fi
+
+if [[ "$output" != *"t99001"* || "$output" == *"BLOCK"*"t99001"* ]]; then
+	# t99001 should NOT be named as an error; if it appears at all it should not be in a BLOCK line
+	# Simplest check: the BLOCK message should not mention t99001 as unclaimed
+	pass "claimed t-ID (t99001) not blocked in mixed stage"
+else
+	fail "t99001 was incorrectly blocked" "$output"
+fi
+
+# =============================================================================
+# Case 6: BRIEF_FILENAME_GUARD_DISABLE=1 bypass
+# =============================================================================
+printf '\n[test] Case 6: BRIEF_FILENAME_GUARD_DISABLE=1 bypass\n'
+
+printf 'placeholder\n' > todo/tasks/t99999-brief.md
+git add todo/tasks/t99999-brief.md
+
+exit_code=0
+BRIEF_FILENAME_GUARD_DISABLE=1 bash "$GUARD" >/dev/null 2>&1 || exit_code=$?
+
+git restore --staged todo/tasks/t99999-brief.md
+rm -f todo/tasks/t99999-brief.md
+
+if [[ "$exit_code" -eq 0 ]]; then
+	pass "BRIEF_FILENAME_GUARD_DISABLE=1 bypasses the guard"
+else
+	fail "bypass via env var did not work, exit=$exit_code"
+fi
+
+# =============================================================================
+# Summary
+# =============================================================================
+printf '\n'
+printf '%d test(s), %d failure(s)\n' "$TESTS_RUN" "$TESTS_FAILED"
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Closes the bypass vector where unclaimed t-IDs can enter the system via brief filenames (`todo/tasks/tNNN-brief.md`) rather than commit subjects. The existing commit-msg guard only covers commit subjects; this hook covers the complementary entry-point identified in the t2377 post-mortem.

## What

- **NEW** `.agents/hooks/brief-filename-guard.sh` — pre-commit hook that iterates staged *added* brief files, extracts the t-ID from the filename, and verifies a `chore: claim tNNN` commit exists in the full git history. Blocks with a mentoring error naming the unclaimed ID and the `claim-task-id.sh` remediation. Deletions and modifications are always allowed. Bypass: `BRIEF_FILENAME_GUARD_DISABLE=1` or `git commit --no-verify`.
- **EDIT** `.agents/scripts/install-pre-push-guards.sh` — registers `brief-filename` as a sixth guard; installs to `.git/hooks/pre-commit` (separate from the pre-push dispatcher); adds `_commit_hook_path()`, `_install_precommit_brief_filename()`, `_uninstall_precommit_brief_filename()` helpers; updates `cmd_install`, `cmd_uninstall`, `cmd_status` to handle the new guard.
- **NEW** `.agents/scripts/tests/test-brief-filename-guard.sh` — 10 assertions across 6 cases: no-staged-briefs, unclaimed block, claimed pass, deletion pass, multi-file-mixed block, and env-var bypass.

## Verification

All 10 test assertions pass (`10 test(s), 0 failure(s)`). All three files pass `shellcheck` with zero violations. Pre-commit and pre-push quality gates passed on push.

## Testing

```bash
bash .agents/scripts/tests/test-brief-filename-guard.sh
# 10 test(s), 0 failure(s)

shellcheck .agents/hooks/brief-filename-guard.sh \
           .agents/scripts/install-pre-push-guards.sh \
           .agents/scripts/tests/test-brief-filename-guard.sh
# no output = clean

bash .agents/scripts/install-pre-push-guards.sh install
# installed guards: privacy complexity scope credential dup-todo brief-filename(pre-commit)
```

Resolves #21576

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.7 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-sonnet-4-6 spent 11m and 31,214 tokens on this as a headless worker.
