### PR TITLE
t3032: reconcile pulse-health.json workers_active with dispatch ledger and post-LLM snapshot

### DIFF
--- a/.agents/scripts/pulse-logging.sh
+++ b/.agents/scripts/pulse-logging.sh
@@ -242,6 +242,12 @@ write_pulse_health_file() {
 	local ts
 	ts=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
+	# t3032: declare ledger helper once — used for both workers reconciliation
+	# and issues_dispatched. The ledger is written synchronously at dispatch
+	# time so it reliably reflects workers just launched, while the process
+	# list (list_active_worker_processes via count_active_workers) has a brief
+	# race window after nohup launch before the process appears in ps.
+	local _ledger_helper="${SCRIPT_DIR}/dispatch-ledger-helper.sh"
 	local workers_active workers_max
 	workers_active=$(count_active_workers 2>/dev/null || echo "0")
 	[[ "$workers_active" =~ ^[0-9]+$ ]] || workers_active=0
@@ -250,11 +256,20 @@ write_pulse_health_file() {
 
 	# issues_dispatched: in-flight worker count from dispatch ledger
 	local issues_dispatched=0
-	local _ledger_helper="${SCRIPT_DIR}/dispatch-ledger-helper.sh"
 	if [[ -x "$_ledger_helper" ]]; then
 		local _ledger_count
 		_ledger_count=$("$_ledger_helper" count 2>/dev/null || echo "0")
 		[[ "$_ledger_count" =~ ^[0-9]+$ ]] && issues_dispatched="$_ledger_count"
+		# Reconcile workers_active with ledger count (t3032): the
+		# _adaptive_launch_settle_wait is skipped when the dispatched
+		# counter is 0 (C2 stdout-pollution bug), so workers just
+		# dispatched via nohup may not yet appear in ps when the health
+		# file is written. Use the higher of the two counts — process
+		# list is more accurate for long-running workers; ledger is more
+		# accurate immediately post-dispatch.
+		if [[ "$_ledger_count" =~ ^[0-9]+$ ]] && [[ "$_ledger_count" -gt "$workers_active" ]]; then
+			workers_active="$_ledger_count"
+		fi
 	fi
 
 	# models_backed_off: count active backoff entries in provider_backoff DB

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1541,6 +1541,14 @@ main() {
 	# GH#18689: extracted to _pulse_maybe_run_llm_supervisor().
 	_pulse_maybe_run_llm_supervisor
 
+	# t3032: post-LLM health snapshot — captures workers dispatched by the
+	# LLM supervisor session, which runs after the deterministic pipeline's
+	# own health write (in _pulse_run_deterministic_pipeline). Without this
+	# second write, the health file would reflect pre-LLM state (often 0
+	# workers) until the NEXT cycle, even when the LLM supervisor launched
+	# 9-25 workers. Non-fatal — failures are silently ignored.
+	write_pulse_health_file || true
+
 	return 0
 }
 


### PR DESCRIPTION
## What

Fixes `pulse-health.json` reporting `workers_active=0` when workers are active. Two-part fix:

### Part 1: Dispatch ledger reconciliation in `write_pulse_health_file` (pulse-logging.sh)

`workers_active` now uses `max(count_active_workers, dispatch_ledger_count)` instead of `count_active_workers` alone.

**Root cause chain:**
1. Workers are dispatched via `nohup ... &` — asynchronous launch with a brief race window before they appear in `ps`
2. The C2 bug (GH#21600) causes `fill_dispatched=0` from stdout pollution, which causes `_adaptive_launch_settle_wait` to skip the settle wait entirely
3. `write_pulse_health_file` is called immediately after dispatch, while workers haven't yet appeared in the process list
4. `count_active_workers` returns 0 despite real workers running

The dispatch ledger is written **synchronously** at dispatch time, so `dispatch-ledger-helper.sh count` reliably reflects workers just launched. Using `max(process_count, ledger_count)` closes the race window without adding latency.

### Part 2: Post-LLM health snapshot at end of `run_pulse` (pulse-wrapper.sh)

Adds a second `write_pulse_health_file` call after `_pulse_maybe_run_llm_supervisor` completes.

**Why:** The LLM supervisor runs after the instance lock is released (so new cycles can run concurrently). It can dispatch 9-25 workers over 20+ minutes. Without this second write, the health file reflects pre-LLM state until the NEXT cycle, even when the LLM supervisor has launched many workers.

## Scope

- `issues_dispatched` counter accuracy still depends on C2 (GH#21600 — subshell stdout pollution fix). This PR fixes `workers_active` only per the issue acceptance criteria.
- ShellCheck: 0 violations on both files.

## Testing

```bash
# After 2+ dispatch cycles with workers running:
HEALTH_WORKERS=$(jq -r '.workers_active' ~/.aidevops/logs/pulse-health.json)
ACTUAL_WORKERS=$(~/.aidevops/agents/scripts/worker-lifecycle-common.sh list_active_worker_processes 2>/dev/null | wc -l | tr -d ' ')
echo "Health: $HEALTH_WORKERS | Actual: $ACTUAL_WORKERS"
# Should be within +-1 (or higher due to ledger > process count just after dispatch)
```

Ref #21598
Resolves #21601

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.8 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-sonnet-4-6 spent 22m and 53,395 tokens on this as a headless worker.
