### PR TITLE
GH#21618: fix stat -f Linux compat in pulse-wrapper-cycle.sh

### DIFF
--- a/.agents/scripts/pulse-wrapper-cycle.sh
+++ b/.agents/scripts/pulse-wrapper-cycle.sh
@@ -268,7 +268,7 @@ _pulse_prime_caches_if_stale() {
 	else
 		local _now_epoch="" _stamp_epoch="" _age_s=""
 		_now_epoch=$(date +%s 2>/dev/null)
-		_stamp_epoch=$(stat -f %m "$_prime_sentinel" 2>/dev/null || stat -c %Y "$_prime_sentinel" 2>/dev/null)
+		_stamp_epoch=$(stat -c %Y "$_prime_sentinel" 2>/dev/null || stat -f '%m' "$_prime_sentinel" 2>/dev/null)
 		_age_s=$(( ${_now_epoch:-0} - ${_stamp_epoch:-0} ))
 		[[ "$_age_s" -gt "$_prime_max_age" ]] && _should_prime=1
 	fi


### PR DESCRIPTION
## Summary

- Fix Linux compatibility bug in `pulse-wrapper-cycle.sh:271` where `stat -f %m` (macOS filesystem stat) outputs multi-line garbage on Linux and exits 1, contaminating `_stamp_epoch` and causing an `unbound variable` crash on line 272 every pulse cycle
- Swap stat order: try Linux `stat -c %Y` first, fall back to macOS `stat -f '%m'`

## How

- `EDIT: .agents/scripts/pulse-wrapper-cycle.sh:271` — swap `stat -c %Y` (Linux) before `stat -f '%m'` (macOS) in the `||` chain

## Verification

- `shellcheck .agents/scripts/pulse-wrapper-cycle.sh` — passes clean
- On Linux: `stat -c %Y <file>` succeeds, short-circuits before macOS path
- On macOS: `stat -c %Y` fails silently, `stat -f '%m'` succeeds as fallback

Resolves #21618

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.8 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-opus-4-6 spent 2d and 3,284 tokens on this with the user in an interactive session. Overall, 3m since this issue was created.
