### PR TITLE
GH#21546: add screenshot-import-helper.sh for macOS U+202F filename bug

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -263,6 +263,8 @@ Reference code as `file_path:line_number` for easy navigation.
 
 Images >8000px crash session irrecoverably. NEVER `fullPage: true` for AI review. Max 1568px longest side. Use `browser-qa-helper.sh screenshot` (only guarded path). Full rules: `reference/screenshot-limits.md`.
 
+**macOS screenshot filename bug (U+202F):** macOS inserts a narrow no-break space (U+202F, UTF-8: `e2 80 af`) before AM/PM in screenshot filenames. The Read tool truncates paths at this character and returns `File not found: /Users`. If this happens, run `screenshot-import-helper.sh sanitize <path>` — it copies the file to a clean temp path and prints it. Full details: `reference/screenshot-limits.md` "macOS Filename Hygiene".
+
 ### Error Prevention (top recurring patterns)
 
 **1. webfetch failures (46.8% failure rate — 94% are guessed URLs)**

--- a/.agents/reference/screenshot-limits.md
+++ b/.agents/reference/screenshot-limits.md
@@ -21,3 +21,33 @@ through at least 5 other paths that bypass those guardrails entirely.
 - Anthropic hard limit: 8000px on any single dimension. Images at or above this are rejected outright.
 - The Playwright MCP `browser_screenshot` tool returns base64 images directly into conversation context with NO resize hook. There is no way to intercept or resize these images after the tool returns. Prefer `browser-qa-helper.sh screenshot` which has built-in guardrails, or use viewport-sized screenshots via Playwright direct.
 - The `browser-qa-helper.sh screenshot` command is the ONLY screenshot path with automatic size guardrails (post-capture resize to `--max-dim`, default 4000px). All other paths — Playwright MCP, dev-browser scripts, raw Playwright code — have zero size protection.
+
+## macOS Filename Hygiene
+
+macOS inserts a narrow no-break space (U+202F, UTF-8 bytes: `e2 80 af`) before AM/PM in screenshot filenames. Example: `Screenshot 2026-04-28 at 8.16.59 PM.png` — the space before "PM" is U+202F, not a regular ASCII space (U+0020).
+
+The Claude Code Read tool truncates paths at this character and returns `File not found: /Users`, which is uninformative. Users have no way to tell that the filename contains an invisible non-standard space.
+
+### Recovery workflow
+
+When Read returns `File not found: /Users` on a screenshot path:
+
+1. Glob for the file to confirm it exists:
+
+   ```bash
+   ls ~/Downloads/Screenshot*.png
+   ```
+
+2. Sanitize the path with the helper:
+
+   ```bash
+   clean=$(screenshot-import-helper.sh sanitize ~/Downloads/"Screenshot 2026-04-28 at 8.16.59 PM.png")
+   ```
+
+3. Use the returned `$clean` path with the Read tool. The helper copies the file to `~/.aidevops/.agent-workspace/tmp/session-PID/` with the U+202F bytes removed from the filename.
+
+### Notes
+
+- The helper is idempotent — calling it on an already-clean path prints the path unchanged without copying.
+- The temp copy persists for the session (tied to the shell PID). On session end, it can be cleaned up with `rm -rf ~/.aidevops/.agent-workspace/tmp/session-PID/`.
+- This is a workaround for an upstream Claude Code limitation. The root cause (path truncation at U+202F in the Read tool's error handling) is not fixable at the framework level.

--- a/.agents/scripts/screenshot-import-helper.sh
+++ b/.agents/scripts/screenshot-import-helper.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# screenshot-import-helper.sh — sanitize macOS screenshot paths containing U+202F
+# Commands: sanitize | help
+#
+# macOS inserts U+202F (narrow no-break space, UTF-8: e2 80 af) before AM/PM
+# in screenshot filenames. The Claude Code Read tool truncates paths at this
+# character, returning "File not found: /Users". This helper detects the byte
+# sequence, copies the file to a clean temp path, and prints the clean path.
+#
+# See reference/screenshot-limits.md "macOS Filename Hygiene" for the full
+# failure mode and recovery workflow.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+# shellcheck source=shared-constants.sh
+source "${SCRIPT_DIR}/shared-constants.sh"
+set -euo pipefail
+init_log_file
+
+# U+202F (NARROW NO-BREAK SPACE) as raw UTF-8 bytes (e2 80 af).
+# macOS inserts this before AM/PM in screenshot filenames.
+# shellcheck disable=SC2034
+readonly U202F=$'\xe2\x80\xaf'
+
+# =============================================================================
+# Sanitize
+# =============================================================================
+
+# Sanitize a file path that may contain U+202F (narrow no-break space).
+#
+# If the path contains the U+202F byte sequence, copies the file to a clean
+# temp path under ~/.aidevops/.agent-workspace/tmp/session-PID/ and prints
+# the new path. If the path is already clean, prints it unchanged (idempotent).
+#
+# Args: $1 = source path (may include U+202F)
+# Output: clean path on stdout
+# Exit: 0 on success, 1 on error (missing path arg, source not found, copy fail)
+cmd_sanitize() {
+	local src="${1:-}"
+
+	if [[ -z "$src" ]]; then
+		log_error "Usage: screenshot-import-helper.sh sanitize <path>"
+		return 1
+	fi
+
+	# Detect U+202F in the path. LC_ALL=C ensures byte-literal matching.
+	if ! printf '%s' "$src" | LC_ALL=C grep -q "$U202F"; then
+		# Path is already clean — print unchanged.
+		printf '%s\n' "$src"
+		return 0
+	fi
+
+	# Path contains U+202F. Verify source file exists before attempting copy.
+	if [[ ! -f "$src" ]]; then
+		log_error "File not found: ${src}"
+		return 1
+	fi
+
+	# Build clean basename by stripping U+202F bytes.
+	# LC_ALL=C + sed treats the 3-byte sequence as a literal pattern.
+	local clean_name
+	clean_name=$(basename "$src" | LC_ALL=C sed "s/${U202F}//g")
+
+	if [[ -z "$clean_name" ]]; then
+		log_error "Failed to compute clean filename from: $(basename "$src")"
+		return 1
+	fi
+
+	# Build temp destination under the agent workspace session directory.
+	local tmp_dir="${HOME}/.aidevops/.agent-workspace/tmp/session-$$"
+	mkdir -p "$tmp_dir" || {
+		log_error "Failed to create temp dir: ${tmp_dir}"
+		return 1
+	}
+
+	local dest="${tmp_dir}/${clean_name}"
+
+	# Copy source to clean destination.
+	if ! cp "$src" "$dest"; then
+		log_error "Failed to copy '${src}' to '${dest}'"
+		return 1
+	fi
+
+	log_info "Sanitized: '$(basename "$src")' → '${clean_name}' at ${tmp_dir}"
+	printf '%s\n' "$dest"
+	return 0
+}
+
+# =============================================================================
+# Help
+# =============================================================================
+
+cmd_help() {
+	cat <<'HELP'
+screenshot-import-helper.sh — sanitize macOS screenshot paths containing U+202F
+
+macOS inserts a narrow no-break space (U+202F, UTF-8: e2 80 af) before AM/PM
+in screenshot filenames. The Claude Code Read tool truncates paths at this
+character, returning "File not found: /Users". This helper copies the file
+to a clean temporary path and returns the clean path for the Read tool.
+
+Usage:
+  screenshot-import-helper.sh sanitize <path>
+  screenshot-import-helper.sh help
+
+Commands:
+  sanitize <path>   Check path for U+202F. If found, copy to a clean temp
+                    path and print it. If not found, print path unchanged.
+                    Idempotent — safe to call on already-clean paths.
+  help              Show this message.
+
+Examples:
+  # Read tool returns "File not found: /Users" on a screenshot — recover:
+  clean=$(screenshot-import-helper.sh sanitize ~/Downloads/"Screenshot 2026-04-28 at 8.16.59 AM.png")
+  # Then use $clean with the Read tool.
+
+Recovery workflow when Read returns "File not found: /Users":
+  1. Glob for the screenshot:
+       ls ~/Downloads/Screenshot*.png
+  2. Sanitize the path:
+       clean=$(screenshot-import-helper.sh sanitize <path>)
+  3. Read from $clean.
+
+Full details: reference/screenshot-limits.md "macOS Filename Hygiene"
+HELP
+	return 0
+}
+
+# =============================================================================
+# Main Dispatch
+# =============================================================================
+
+main() {
+	local command="${1:-help}"
+	shift || true
+
+	case "$command" in
+	sanitize) cmd_sanitize "$@" ;;
+	help | --help | -h) cmd_help ;;
+	*)
+		log_error "${ERROR_UNKNOWN_COMMAND}: ${command}"
+		cmd_help
+		return 1
+		;;
+	esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+	main "$@"
+fi

--- a/.agents/scripts/tests/test-screenshot-import-helper.sh
+++ b/.agents/scripts/tests/test-screenshot-import-helper.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Unit tests for screenshot-import-helper.sh
+#
+# Three cases:
+#   1. Clean filename   — passthrough, no copy
+#   2. U+202F filename  — sanitized, file copied to temp dir, clean path returned
+#   3. Missing source   — non-existent path with U+202F, exit non-zero with error
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+HELPER="${SCRIPT_DIR}/../screenshot-import-helper.sh"
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+TEST_TMPDIR=""
+
+# U+202F (narrow no-break space) as raw UTF-8 bytes.
+readonly U202F=$'\xe2\x80\xaf'
+
+print_result() {
+	local test_name="$1"
+	local status="$2"
+	local message="${3:-}"
+
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$status" -eq 0 ]]; then
+		echo "PASS ${test_name}"
+		TESTS_PASSED=$((TESTS_PASSED + 1))
+	else
+		echo "FAIL ${test_name}"
+		if [[ -n "$message" ]]; then
+			echo "  ${message}"
+		fi
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+setup() {
+	TEST_TMPDIR=$(mktemp -d)
+	trap teardown EXIT
+	return 0
+}
+
+teardown() {
+	if [[ -n "${TEST_TMPDIR:-}" && -d "${TEST_TMPDIR}" ]]; then
+		rm -rf "${TEST_TMPDIR}"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Case 1: clean filename — no U+202F → path returned unchanged, no copy made
+# ---------------------------------------------------------------------------
+test_clean_filename_passthrough() {
+	local clean_src="${TEST_TMPDIR}/Screenshot_2026-04-28_at_8.16.59_AM.png"
+	# Create a real file with a clean name.
+	printf 'pixel' >"${clean_src}"
+
+	local result
+	result=$(HOME="${TEST_TMPDIR}" bash "${HELPER}" sanitize "${clean_src}" 2>/dev/null)
+
+	if [[ "${result}" == "${clean_src}" ]]; then
+		print_result "clean filename: returned unchanged" 0
+	else
+		print_result "clean filename: returned unchanged" 1 \
+			"expected '${clean_src}', got '${result}'"
+	fi
+
+	# Verify no copy was created (only the original file exists).
+	local copy_count
+	copy_count=$(find "${TEST_TMPDIR}" -type f | wc -l | tr -d ' ')
+	if [[ "${copy_count}" -eq 1 ]]; then
+		print_result "clean filename: no copy created" 0
+	else
+		print_result "clean filename: no copy created" 1 \
+			"expected 1 file in tmpdir, found ${copy_count}"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Case 2: U+202F filename — sanitized, file copied, clean path returned
+# ---------------------------------------------------------------------------
+test_u202f_filename_sanitized() {
+	# Build a filename with U+202F before AM (same pattern macOS produces).
+	local dirty_name="Screenshot 2026-04-28 at 8.16.59${U202F}AM.png"
+	# Use a dedicated subdirectory so this file does not bleed into case 3.
+	local case_dir="${TEST_TMPDIR}/case2"
+	mkdir -p "${case_dir}"
+	local dirty_src="${case_dir}/${dirty_name}"
+	printf 'pixel' >"${dirty_src}"
+
+	local result
+	result=$(HOME="${case_dir}" bash "${HELPER}" sanitize "${dirty_src}" 2>/dev/null)
+
+	# Result must not contain U+202F.
+	if ! printf '%s' "${result}" | LC_ALL=C grep -q "${U202F}"; then
+		print_result "u202f filename: result path has no U+202F" 0
+	else
+		print_result "u202f filename: result path has no U+202F" 1 \
+			"result still contains U+202F bytes: ${result}"
+	fi
+
+	# Result must point to an existing file.
+	if [[ -f "${result}" ]]; then
+		print_result "u202f filename: copied file exists at clean path" 0
+	else
+		print_result "u202f filename: copied file exists at clean path" 1 \
+			"file not found at returned path: ${result}"
+	fi
+
+	# Clean basename must equal dirty basename with U+202F removed.
+	local expected_basename="Screenshot 2026-04-28 at 8.16.59AM.png"
+	local actual_basename
+	actual_basename=$(basename "${result}")
+	if [[ "${actual_basename}" == "${expected_basename}" ]]; then
+		print_result "u202f filename: clean basename is correct" 0
+	else
+		print_result "u202f filename: clean basename is correct" 1 \
+			"expected '${expected_basename}', got '${actual_basename}'"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Case 3: missing source file with U+202F — exit non-zero with clear error
+# ---------------------------------------------------------------------------
+test_missing_file_exits_nonzero() {
+	# Use a fresh subdirectory so the file definitely does not exist.
+	local case_dir="${TEST_TMPDIR}/case3"
+	mkdir -p "${case_dir}"
+	local missing_src="${case_dir}/Screenshot 2026-04-28 at 8.16.59${U202F}AM.png"
+	# Explicitly ensure the file does not exist.
+
+	local rc=0
+	local stderr_output
+	stderr_output=$(HOME="${case_dir}" bash "${HELPER}" sanitize "${missing_src}" 2>&1 >/dev/null) || rc=$?
+
+	if [[ "${rc}" -ne 0 ]]; then
+		print_result "missing file: exits non-zero" 0
+	else
+		print_result "missing file: exits non-zero" 1 \
+			"expected non-zero exit, got 0"
+	fi
+
+	# Error output must mention "not found" or "File not found".
+	if echo "${stderr_output}" | grep -qi "not found"; then
+		print_result "missing file: error mentions 'not found'" 0
+	else
+		print_result "missing file: error mentions 'not found'" 1 \
+			"expected 'not found' in stderr, got: ${stderr_output}"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Case 4: help / no args — exits 0 and prints usage
+# ---------------------------------------------------------------------------
+test_help_exits_zero() {
+	local rc=0
+	local output
+	output=$(bash "${HELPER}" help 2>&1) || rc=$?
+
+	if [[ "${rc}" -eq 0 ]]; then
+		print_result "help: exits 0" 0
+	else
+		print_result "help: exits 0" 1 "got exit code ${rc}"
+	fi
+
+	if echo "${output}" | grep -q "sanitize"; then
+		print_result "help: output mentions 'sanitize'" 0
+	else
+		print_result "help: output mentions 'sanitize'" 1 \
+			"'sanitize' not found in help output"
+	fi
+	return 0
+}
+
+main() {
+	setup
+
+	test_clean_filename_passthrough
+	test_u202f_filename_sanitized
+	test_missing_file_exits_nonzero
+	test_help_exits_zero
+
+	echo ""
+	echo "Tests run: ${TESTS_RUN}, passed: ${TESTS_PASSED}, failed: ${TESTS_FAILED}"
+
+	if [[ "${TESTS_FAILED}" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Implements the maintainer-approved Option B workaround for the macOS screenshot
U+202F filename bug (GH#21546): a shell helper + prompt rule rather than a
Read-interceptor hook.

## Changes

- **NEW:** `.agents/scripts/screenshot-import-helper.sh` — `sanitize <path>` detects U+202F (UTF-8: `e2 80 af`) in a file path, copies the file to a clean temp path under `~/.aidevops/.agent-workspace/tmp/session-PID/`, and prints the clean path. Idempotent on already-clean paths.
- **NEW:** `.agents/scripts/tests/test-screenshot-import-helper.sh` — 9 tests covering clean-filename passthrough, U+202F sanitize+copy, and missing-source-file error exit.
- **EDIT:** `.agents/AGENTS.md` — bullet added under `Screenshot Size Limits` pointing agents to the helper and the reference doc.
- **EDIT:** `.agents/reference/screenshot-limits.md` — `## macOS Filename Hygiene` section added with root cause, recovery workflow, and helper usage.

## Verification

```
bash .agents/scripts/tests/test-screenshot-import-helper.sh
# Tests run: 9, passed: 9, failed: 0

shellcheck .agents/scripts/screenshot-import-helper.sh
# (no output = zero violations)
```

markdownlint: 4 pre-existing errors in AGENTS.md (lines 422/506/507/716), none introduced by this PR.

Resolves #21546

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.8 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-sonnet-4-6 spent 9m and 18,333 tokens on this as a headless worker.
