### PR TITLE
GH#21623: replace inline stat -f/stat -c with portable _file_size_bytes/_file_perms

### DIFF
--- a/.agents/scripts/aidevops-update-check.sh
+++ b/.agents/scripts/aidevops-update-check.sh
@@ -17,6 +17,8 @@ fi
 # Shared version-finding logic (avoids duplication with log-issue-helper.sh)
 # shellcheck source=lib/version.sh
 source "$(dirname "${BASH_SOURCE[0]}")/lib/version.sh"
+# shellcheck source=./shared-constants.sh
+source "$(dirname "${BASH_SOURCE[0]}")/shared-constants.sh"
 
 get_version() {
 	aidevops_find_version
@@ -488,8 +490,7 @@ _check_hotfix_available() {
 	# Rate-limit: only check every 5 minutes
 	if [[ -f "$hotfix_stamp" ]]; then
 		local stamp_mtime now_epoch age_seconds
-		# Portable mtime: try GNU stat, fall back to BSD stat
-		stamp_mtime=$(stat -c '%Y' "$hotfix_stamp" 2>/dev/null || stat -f '%m' "$hotfix_stamp" 2>/dev/null) || stamp_mtime=0
+		stamp_mtime=$(_file_mtime_epoch "$hotfix_stamp")
 		now_epoch=$(date +%s)
 		age_seconds=$((now_epoch - stamp_mtime))
 		if [[ "$age_seconds" -lt "$hotfix_poll_interval" ]]; then
@@ -838,11 +839,7 @@ _check_pulse_health() {
 	fi
 
 	local health_mtime now_epoch age_seconds
-	if [[ "$(uname)" == "Darwin" ]]; then
-		health_mtime=$(stat -f '%m' "$health_file" 2>/dev/null) || health_mtime=0
-	else
-		health_mtime=$(stat -c '%Y' "$health_file" 2>/dev/null) || health_mtime=0
-	fi
+	health_mtime=$(_file_mtime_epoch "$health_file")
 	now_epoch=$(date +%s)
 	age_seconds=$((now_epoch - health_mtime))
 

--- a/.agents/scripts/approval-helper.sh
+++ b/.agents/scripts/approval-helper.sh
@@ -705,8 +705,8 @@ cmd_status() {
 	echo ""
 	if [[ -d "$APPROVAL_PRIVATE_DIR" ]]; then
 		local owner perms
-		owner=$(stat -f '%Su' "$APPROVAL_PRIVATE_DIR" 2>/dev/null || stat -c '%U' "$APPROVAL_PRIVATE_DIR" 2>/dev/null || echo "unknown")
-		perms=$(stat -f '%A' "$APPROVAL_PRIVATE_DIR" 2>/dev/null || stat -c '%a' "$APPROVAL_PRIVATE_DIR" 2>/dev/null || echo "unknown")
+		owner=$(stat -c '%U' "$APPROVAL_PRIVATE_DIR" 2>/dev/null || stat -f '%Su' "$APPROVAL_PRIVATE_DIR" 2>/dev/null || echo "unknown")
+		perms=$(_file_perms "$APPROVAL_PRIVATE_DIR")
 		if [[ "$owner" == "root" && "$perms" == "700" ]]; then
 			_print_ok "Private key directory is root-protected (owner=$owner, mode=$perms)"
 		else

--- a/.agents/scripts/auto-update-helper.sh
+++ b/.agents/scripts/auto-update-helper.sh
@@ -282,15 +282,10 @@ _lock_holder_is_wedged() {
 	[[ -f "$_log" ]] || return 1
 
 	# Modification time of the log file proxies "last sign of life".
-	# Use Darwin without quotes in [[ ]] — RHS is not word-split, no SC warning.
 	local _log_mtime
 	local _now
 	local _idle
-	if [[ "$(uname)" == Darwin ]]; then
-		_log_mtime=$(stat -f '%m' "$_log" 2>/dev/null || echo "0")
-	else
-		_log_mtime=$(stat -c '%Y' "$_log" 2>/dev/null || echo "0")
-	fi
+	_log_mtime=$(_file_mtime_epoch "$_log")
 	_now=$(date +%s)
 	_idle=$(( _now - _log_mtime ))
 
@@ -336,11 +331,7 @@ acquire_lock() {
 		# Check lock age (safety net for orphaned locks)
 		if [[ -d "$LOCK_FILE" ]]; then
 			local lock_age
-			if [[ "$(uname)" == "Darwin" ]]; then
-				lock_age=$(($(date +%s) - $(stat -f %m "$LOCK_FILE" 2>/dev/null || echo "0")))
-			else
-				lock_age=$(($(date +%s) - $(stat -c %Y "$LOCK_FILE" 2>/dev/null || echo "0")))
-			fi
+			lock_age=$(($(date +%s) - $(_file_mtime_epoch "$LOCK_FILE")))
 			if [[ $lock_age -gt 300 ]]; then
 				log_warn "Removing stale lock (age ${lock_age}s > 300s)"
 				rm -rf "$LOCK_FILE"

--- a/.agents/scripts/codacy-collector-helper.sh
+++ b/.agents/scripts/codacy-collector-helper.sh
@@ -999,11 +999,7 @@ cmd_status() {
 		echo "  Last collection: $last_run"
 
 		local db_size
-		if [[ "$(uname)" == "Darwin" ]]; then
-			db_size=$(stat -f %z "$AUDIT_DB" 2>/dev/null || echo "0")
-		else
-			db_size=$(stat -c %s "$AUDIT_DB" 2>/dev/null || echo "0")
-		fi
+		db_size=$(_file_size_bytes "$AUDIT_DB")
 		echo "  DB size:         $((db_size / 1024)) KB"
 	else
 		echo "Database: not created yet"

--- a/.agents/scripts/code-audit-helper.sh
+++ b/.agents/scripts/code-audit-helper.sh
@@ -1356,11 +1356,7 @@ cmd_status() {
 		echo "  Last audit:     $last_run"
 
 		local db_size
-		if [[ "$(uname)" == "Darwin" ]]; then
-			db_size=$(stat -f %z "$AUDIT_DB" 2>/dev/null || echo "0")
-		else
-			db_size=$(stat -c %s "$AUDIT_DB" 2>/dev/null || echo "0")
-		fi
+		db_size=$(_file_size_bytes "$AUDIT_DB")
 		echo "  DB size:        $((db_size / 1024)) KB"
 	else
 		echo "Database: not created yet"

--- a/.agents/scripts/coderabbit-collector-helper.sh
+++ b/.agents/scripts/coderabbit-collector-helper.sh
@@ -921,11 +921,7 @@ cmd_status() {
 
 		# DB file size
 		local db_size
-		if [[ "$(uname)" == "Darwin" ]]; then
-			db_size=$(stat -f %z "$COLLECTOR_DB" 2>/dev/null || echo "0")
-		else
-			db_size=$(stat -c %s "$COLLECTOR_DB" 2>/dev/null || echo "0")
-		fi
+		db_size=$(_file_size_bytes "$COLLECTOR_DB")
 		echo "  DB size: $((db_size / 1024)) KB"
 	else
 		echo ""

--- a/.agents/scripts/config-helper.sh
+++ b/.agents/scripts/config-helper.sh
@@ -221,11 +221,11 @@ _get_merged_config() {
 	# Check if cache is still valid (based on file mtimes)
 	local current_mtime=""
 	if [[ -f "$JSONC_DEFAULTS" ]]; then
-		current_mtime=$(stat -c %Y "$JSONC_DEFAULTS" 2>/dev/null || stat -f %m "$JSONC_DEFAULTS" 2>/dev/null || echo "0")
+		current_mtime=$(_file_mtime_epoch "$JSONC_DEFAULTS")
 	fi
 	if [[ -f "$JSONC_USER" ]]; then
 		local user_mtime
-		user_mtime=$(stat -c %Y "$JSONC_USER" 2>/dev/null || stat -f %m "$JSONC_USER" 2>/dev/null || echo "0")
+		user_mtime=$(_file_mtime_epoch "$JSONC_USER")
 		current_mtime="${current_mtime}:${user_mtime}"
 	fi
 

--- a/.agents/scripts/content-classifier-helper.sh
+++ b/.agents/scripts/content-classifier-helper.sh
@@ -130,11 +130,7 @@ _cc_cache_get() {
 	local file_age
 	local now
 	now=$(date +%s)
-	if [[ "$(uname)" == "Darwin" ]]; then
-		file_age=$(stat -f %m "$cache_file" 2>/dev/null || echo "0")
-	else
-		file_age=$(stat -c %Y "$cache_file" 2>/dev/null || echo "0")
-	fi
+	file_age=$(_file_mtime_epoch "$cache_file")
 
 	local age=$((now - file_age))
 	if [[ "$age" -gt "$CONTENT_CLASSIFIER_CACHE_TTL" ]]; then
@@ -173,11 +169,7 @@ _cc_collab_cache_get() {
 	local now
 	now=$(date +%s)
 	local file_age
-	if [[ "$(uname)" == "Darwin" ]]; then
-		file_age=$(stat -f %m "$cache_file" 2>/dev/null || echo "0")
-	else
-		file_age=$(stat -c %Y "$cache_file" 2>/dev/null || echo "0")
-	fi
+	file_age=$(_file_mtime_epoch "$cache_file")
 
 	local age=$((now - file_age))
 	if [[ "$age" -gt "$COLLAB_CACHE_TTL" ]]; then

--- a/.agents/scripts/dispatch-ledger-helper.sh
+++ b/.agents/scripts/dispatch-ledger-helper.sh
@@ -42,6 +42,12 @@
 
 set -euo pipefail
 
+_dlh_dir="${BASH_SOURCE[0]%/*}"
+[[ "$_dlh_dir" == "${BASH_SOURCE[0]}" ]] && _dlh_dir="."
+# shellcheck source=./shared-constants.sh
+source "$(cd "$_dlh_dir" && pwd)/shared-constants.sh"
+unset _dlh_dir
+
 LEDGER_DIR="${AIDEVOPS_DISPATCH_LEDGER_DIR:-${HOME}/.aidevops/.agent-workspace/tmp}"
 LEDGER_FILE="${LEDGER_DIR}/dispatch-ledger.jsonl"
 LEDGER_LOCK="${LEDGER_DIR}/dispatch-ledger.lock"
@@ -72,8 +78,7 @@ _lock_dir_age() {
 		echo "0"
 		return 0
 	fi
-	# BSD stat (macOS) first, then GNU stat (Linux)
-	mtime=$(stat -f '%m' "$dir" 2>/dev/null || stat -c '%Y' "$dir" 2>/dev/null || echo "")
+	mtime=$(_file_mtime_epoch "$dir")
 	if [[ -z "$mtime" ]] || [[ ! "$mtime" =~ ^[0-9]+$ ]]; then
 		echo "0"
 		return 0

--- a/.agents/scripts/dispatch-timing-helper.sh
+++ b/.agents/scripts/dispatch-timing-helper.sh
@@ -107,7 +107,7 @@ _dt_acquire_lock() {
 		# Check for stale lock (>30s old → assume crashed)
 		if [[ -d "$LOCK_DIR" ]]; then
 			local lock_mtime now_epoch age_s
-			lock_mtime=$(stat -f %m "$LOCK_DIR" 2>/dev/null || stat -c %Y "$LOCK_DIR" 2>/dev/null || echo "0")
+			lock_mtime=$(_file_mtime_epoch "$LOCK_DIR")
 			now_epoch=$(date +%s)
 			age_s=$((now_epoch - lock_mtime))
 			if ((age_s > 30)); then

--- a/.agents/scripts/document-creation-helper.sh
+++ b/.agents/scripts/document-creation-helper.sh
@@ -72,11 +72,7 @@ has_cmd() {
 human_filesize() {
 	local file="$1"
 	local bytes
-	if [[ "$(uname)" == "Darwin" ]]; then
-		bytes=$(stat -f%z -- "$file" || echo "0")
-	else
-		bytes=$(stat -c%s -- "$file" || echo "0")
-	fi
+	bytes=$(_file_size_bytes "$file")
 	if [[ "$bytes" -ge 1073741824 ]]; then
 		printf '%s.%sG' "$((bytes / 1073741824))" "$(((bytes % 1073741824) * 10 / 1073741824))"
 	elif [[ "$bytes" -ge 1048576 ]]; then
@@ -634,6 +630,8 @@ if [[ -z "${SCRIPT_DIR:-}" ]]; then
 	SCRIPT_DIR="$(cd "$_lib_path" && pwd)"
 	unset _lib_path
 fi
+# shellcheck source=./shared-constants.sh
+source "${SCRIPT_DIR}/shared-constants.sh"
 
 # shellcheck source=./document-creation-convert-lib.sh
 # shellcheck disable=SC1091  # sub-library resolved at runtime via $SCRIPT_DIR

--- a/.agents/scripts/gh-status-helper.sh
+++ b/.agents/scripts/gh-status-helper.sh
@@ -68,15 +68,7 @@ _cache_age() {
 	}
 	local now mtime
 	now=$(date +%s)
-	# stat -c on Linux, stat -f on macOS
-	if mtime=$(stat -f %m "$file" 2>/dev/null); then
-		:
-	elif mtime=$(stat -c %Y "$file" 2>/dev/null); then
-		:
-	else
-		printf '99999\n'
-		return 0
-	fi
+	mtime=$(_file_mtime_epoch "$file")
 	printf '%d\n' "$((now - mtime))"
 	return 0
 }

--- a/.agents/scripts/headless-runtime-provider.sh
+++ b/.agents/scripts/headless-runtime-provider.sh
@@ -72,10 +72,7 @@ file_mtime() {
 		printf '%s' "missing"
 		return 0
 	fi
-	# Linux first (stat -c), then macOS (stat -f). On Linux, stat -f '%m'
-	# returns filesystem metadata (free blocks), not file mtime -- causing
-	# auth signatures to change between calls and clearing backoff state.
-	stat -c '%Y' "$path" 2>/dev/null || stat -f '%m' "$path" 2>/dev/null || printf '%s' "unknown"
+	_file_mtime_epoch "$path"
 	return 0
 }
 

--- a/.agents/scripts/higgsfield-helper.sh
+++ b/.agents/scripts/higgsfield-helper.sh
@@ -290,7 +290,7 @@ cmd_batch_lipsync() {
 cmd_status() {
     if [[ -f "${STATE_FILE}" ]]; then
         local age
-        age=$(( $(date +%s) - $(stat -c %Y "${STATE_FILE}" 2>/dev/null || stat -f %m "${STATE_FILE}" 2>/dev/null || echo 0) ))
+        age=$(( $(date +%s) - $(_file_mtime_epoch "${STATE_FILE}") ))
         local hours=$(( age / 3600 ))
         print_success "Auth state exists (${hours}h old)"
         print_info "State file: ${STATE_FILE}"

--- a/.agents/scripts/humanise-update-helper.sh
+++ b/.agents/scripts/humanise-update-helper.sh
@@ -63,7 +63,7 @@ fetch_upstream() {
 	# Check cache freshness
 	if [[ -f "$CACHE_FILE" && -f "$CACHE_VERSION_FILE" ]]; then
 		local cache_age
-		cache_age=$(($(date +%s) - $(stat -c %Y "$CACHE_FILE" 2>/dev/null || stat -f %m "$CACHE_FILE" 2>/dev/null || echo 0)))
+		cache_age=$(($(date +%s) - $(_file_mtime_epoch "$CACHE_FILE")))
 		if [[ $cache_age -lt $CACHE_TTL ]]; then
 			echo "Using cached upstream ($((cache_age / 60)) minutes old)"
 			return 0

--- a/.agents/scripts/knowledge-index-helper.sh
+++ b/.agents/scripts/knowledge-index-helper.sh
@@ -211,9 +211,7 @@ _compute_corpus_hash() {
 		if [[ -d "${sources_dir}/${src_id}" ]]; then
 			local mtime="0"
 			if [[ -f "$tree_path" ]]; then
-				mtime=$(stat -f '%m' "$tree_path" 2>/dev/null \
-					|| stat --format='%Y' "$tree_path" 2>/dev/null \
-					|| echo "0")
+				mtime=$(_file_mtime_epoch "$tree_path")
 			fi
 			hash_input="${hash_input}${src_id}:${mtime}|"
 		fi

--- a/.agents/scripts/local-model-cleanup.sh
+++ b/.agents/scripts/local-model-cleanup.sh
@@ -59,18 +59,10 @@ _get_days_unused() {
 	fi
 
 	# Fall back to mtime
-	if [[ "$(uname -s)" == "Darwin" ]]; then
-		local mod_epoch
-		mod_epoch="$(stat -f%m "$model_path" 2>/dev/null || echo "0")"
-		if [[ "$mod_epoch" -gt 0 ]]; then
-			days_unused="$(((now_epoch - mod_epoch) / 86400))"
-		fi
-	else
-		local mod_epoch
-		mod_epoch="$(stat -c%Y "$model_path" 2>/dev/null || echo "0")"
-		if [[ "$mod_epoch" -gt 0 ]]; then
-			days_unused="$(((now_epoch - mod_epoch) / 86400))"
-		fi
+	local mod_epoch
+	mod_epoch="$(_file_mtime_epoch "$model_path")"
+	if [[ "$mod_epoch" -gt 0 ]]; then
+		days_unused="$(((now_epoch - mod_epoch) / 86400))"
 	fi
 
 	echo "$days_unused"
@@ -139,11 +131,7 @@ _cleanup_report_models() {
 		local name size_bytes size_human last_used_str status_str days_unused
 		name="$(basename "$model_path")"
 
-		if [[ "$(uname -s)" == "Darwin" ]]; then
-			size_bytes="$(stat -f%z "$model_path" 2>/dev/null || echo "0")"
-		else
-			size_bytes="$(stat -c%s "$model_path" 2>/dev/null || echo "0")"
-		fi
+		size_bytes="$(_file_size_bytes "$model_path")"
 		total_size_bytes=$((total_size_bytes + size_bytes))
 
 		size_human="$(echo "$size_bytes" | awk '{
@@ -252,14 +240,9 @@ cmd_cleanup() {
 	if [[ -n "$remove_model" ]]; then
 		local target="${LOCAL_MODELS_STORE}/${remove_model}"
 		if [[ -f "$target" ]]; then
-			local size_human
-			if [[ "$(uname -s)" == "Darwin" ]]; then
-				local size_bytes
-				size_bytes="$(stat -f%z "$target" 2>/dev/null || echo "0")"
-				size_human="$(echo "$size_bytes" | awk '{printf "%.1f GB", $1/1073741824}')"
-			else
-				size_human="$(du -h "$target" | awk '{print $1}')"
-			fi
+			local size_human size_bytes
+			size_bytes="$(_file_size_bytes "$target")"
+			size_human="$(echo "$size_bytes" | awk '{printf "%.1f GB", $1/1073741824}')"
 			_remove_model_file "$target" "$remove_model" "$size_human"
 		else
 			print_error "Model not found: ${remove_model}"
@@ -407,11 +390,7 @@ _nudge_calculate_stale() {
 		name="$(basename "$model_path")"
 		days_unused="$(_get_days_unused "$model_path" "$now_epoch")"
 
-		if [[ "$(uname -s)" == "Darwin" ]]; then
-			size_bytes="$(stat -f%z "$model_path" 2>/dev/null || echo "0")"
-		else
-			size_bytes="$(stat -c%s "$model_path" 2>/dev/null || echo "0")"
-		fi
+		size_bytes="$(_file_size_bytes "$model_path")"
 
 		if [[ "$days_unused" -gt "$threshold" ]]; then
 			stale_size_bytes=$((stale_size_bytes + size_bytes))

--- a/.agents/scripts/local-model-db.sh
+++ b/.agents/scripts/local-model-db.sh
@@ -445,11 +445,7 @@ sync_model_inventory() {
 		local name size_bytes quant
 		name="$(basename "$model_path")"
 
-		if [[ "$(uname -s)" == "Darwin" ]]; then
-			size_bytes="$(stat -f%z "$model_path" 2>/dev/null || echo "0")"
-		else
-			size_bytes="$(stat -c%s "$model_path" 2>/dev/null || echo "0")"
-		fi
+		size_bytes="$(_file_size_bytes "$model_path")"
 
 		# Extract quantization from filename
 		quant="$(echo "$name" | grep -oiE '(q[0-9]_[a-z0-9_]+|iq[0-9]_[a-z0-9]+|f16|f32|bf16)' | head -1 | tr '[:lower:]' '[:upper:]')"

--- a/.agents/scripts/local-model-models.sh
+++ b/.agents/scripts/local-model-models.sh
@@ -40,17 +40,13 @@ _models_get_size_human() {
 	local model_path="$1"
 	local size_human=""
 
-	if [[ "$(uname -s)" == "Darwin" ]]; then
-		local size_bytes
-		size_bytes="$(stat -f%z "$model_path" 2>/dev/null || echo "0")"
-		size_human="$(echo "$size_bytes" | awk '{
-			if ($1 >= 1073741824) printf "%.1f GB", $1/1073741824;
-			else if ($1 >= 1048576) printf "%.0f MB", $1/1048576;
-			else printf "%.0f KB", $1/1024;
-		}')"
-	else
-		size_human="$(du -h "$model_path" 2>/dev/null | awk '{print $1}')"
-	fi
+	local size_bytes
+	size_bytes="$(_file_size_bytes "$model_path")"
+	size_human="$(echo "$size_bytes" | awk '{
+		if ($1 >= 1073741824) printf "%.1f GB", $1/1073741824;
+		else if ($1 >= 1048576) printf "%.0f MB", $1/1048576;
+		else printf "%.0f KB", $1/1024;
+	}')"
 
 	echo "$size_human"
 	return 0
@@ -135,11 +131,7 @@ cmd_models() {
 		while IFS= read -r model_path; do
 			local name size_bytes last_used
 			name="$(basename "$model_path")"
-			if [[ "$(uname -s)" == "Darwin" ]]; then
-				size_bytes="$(stat -f%z "$model_path" 2>/dev/null || echo "0")"
-			else
-				size_bytes="$(stat -c%s "$model_path" 2>/dev/null || echo "0")"
-			fi
+			size_bytes="$(_file_size_bytes "$model_path")"
 			last_used="$(_models_get_last_used "$name")"
 			[[ "$first" == "true" ]] || echo ","
 			first=false
@@ -289,11 +281,7 @@ cmd_download() {
 	local downloaded_path="${LOCAL_MODELS_STORE}/${filename}"
 	if [[ -f "$downloaded_path" ]]; then
 		local size_human size_bytes_dl
-		if [[ "$(uname -s)" == "Darwin" ]]; then
-			size_bytes_dl="$(stat -f%z "$downloaded_path" 2>/dev/null || echo "0")"
-		else
-			size_bytes_dl="$(stat -c%s "$downloaded_path" 2>/dev/null || echo "0")"
-		fi
+		size_bytes_dl="$(_file_size_bytes "$downloaded_path")"
 		size_human="$(echo "$size_bytes_dl" | awk '{
 			if ($1 >= 1073741824) printf "%.1f GB", $1/1073741824;
 			else printf "%.0f MB", $1/1048576;

--- a/.agents/scripts/mail-helper-management.sh
+++ b/.agents/scripts/mail-helper-management.sh
@@ -200,8 +200,7 @@ prune_execute() {
 	db "$MAIL_DB" "VACUUM;"
 
 	local new_size_bytes
-	# Linux stat -c first (stat -f%z on Linux outputs filesystem info to stdout)
-	new_size_bytes=$(stat -c%s "$MAIL_DB" 2>/dev/null || stat -f%z "$MAIL_DB" 2>/dev/null || echo "0")
+	new_size_bytes=$(_file_size_bytes "$MAIL_DB")
 	local new_size_kb=$((new_size_bytes / 1024))
 	local saved_kb=$((db_size_kb - new_size_kb))
 
@@ -251,8 +250,7 @@ cmd_prune() {
 	ensure_db
 
 	local db_size_bytes
-	# Linux stat -c first (stat -f%z on Linux outputs filesystem info to stdout)
-	db_size_bytes=$(stat -c%s "$MAIL_DB" 2>/dev/null || stat -f%z "$MAIL_DB" 2>/dev/null || echo "0")
+	db_size_bytes=$(_file_size_bytes "$MAIL_DB")
 	local db_size_kb=$((db_size_bytes / 1024))
 
 	local report_output prunable archivable

--- a/.agents/scripts/mail-helper-transport.sh
+++ b/.agents/scripts/mail-helper-transport.sh
@@ -527,8 +527,7 @@ cmd_transport_status() {
 	echo "    Database:  $MAIL_DB"
 	if [[ -f "$MAIL_DB" ]]; then
 		local db_size
-		# Linux stat -c first (stat -f%z on Linux outputs filesystem info to stdout)
-		db_size=$(stat -c%s "$MAIL_DB" 2>/dev/null || stat -f%z "$MAIL_DB" 2>/dev/null || echo "0")
+		db_size=$(_file_size_bytes "$MAIL_DB")
 		echo "    Size:      $((db_size / 1024))KB"
 	else
 		echo "    Size:      (not initialized)"

--- a/.agents/scripts/matrix-dispatch-sessions.sh
+++ b/.agents/scripts/matrix-dispatch-sessions.sh
@@ -133,8 +133,7 @@ _sessions_stats_entity_aware() {
 	active_sessions=$(sqlite3 -cmd ".timeout 5000" "$db_path" "SELECT COUNT(*) FROM matrix_room_sessions WHERE session_id != '';" 2>/dev/null || echo "0")
 	matrix_interactions=$(sqlite3 -cmd ".timeout 5000" "$db_path" "SELECT COUNT(*) FROM interactions WHERE channel = 'matrix';" 2>/dev/null || echo "0")
 	entity_count=$(sqlite3 -cmd ".timeout 5000" "$db_path" "SELECT COUNT(*) FROM entity_channels WHERE channel = 'matrix';" 2>/dev/null || echo "0")
-	# Linux stat -c first (stat -f%z on Linux outputs filesystem info to stdout)
-	db_size=$(stat -c%s "$db_path" 2>/dev/null || stat -f%z "$db_path" 2>/dev/null || echo "0")
+	db_size=$(_file_size_bytes "$db_path")
 
 	echo "Total sessions:       ${total_sessions:-0}"
 	echo "Active sessions:      ${active_sessions:-0}"
@@ -155,8 +154,7 @@ _sessions_stats_legacy() {
 	active_sessions=$(sqlite3 -cmd ".timeout 5000" "$db_path" "SELECT COUNT(*) FROM sessions WHERE session_id != '';" 2>/dev/null || echo "0")
 	total_messages=$(sqlite3 -cmd ".timeout 5000" "$db_path" "SELECT COUNT(*) FROM message_log;" 2>/dev/null || echo "0")
 	context_bytes=$(sqlite3 -cmd ".timeout 5000" "$db_path" "SELECT COALESCE(SUM(length(compacted_context)), 0) FROM sessions;" 2>/dev/null || echo "0")
-	# Linux stat -c first (stat -f%z on Linux outputs filesystem info to stdout)
-	db_size=$(stat -c%s "$db_path" 2>/dev/null || stat -f%z "$db_path" 2>/dev/null || echo "0")
+	db_size=$(_file_size_bytes "$db_path")
 
 	echo "Total sessions:    ${total_sessions:-0} (legacy store)"
 	echo "Active sessions:   ${active_sessions:-0}"

--- a/.agents/scripts/mcp-index-helper.sh
+++ b/.agents/scripts/mcp-index-helper.sh
@@ -125,7 +125,7 @@ needs_refresh() {
 	# Check if opencode.json is newer than last sync
 	if [[ -f "$OPENCODE_CONFIG" ]]; then
 		local config_mtime
-		config_mtime=$(stat -c %Y "$OPENCODE_CONFIG" 2>/dev/null || stat -f %m "$OPENCODE_CONFIG" 2>/dev/null || echo "0")
+		config_mtime=$(_file_mtime_epoch "$OPENCODE_CONFIG")
 		local sync_epoch
 		sync_epoch=$(date -j -f "%Y-%m-%d %H:%M:%S" "$last_sync" +%s 2>/dev/null || date -d "$last_sync" +%s 2>/dev/null || echo "0")
 

--- a/.agents/scripts/memory-audit-pulse.sh
+++ b/.agents/scripts/memory-audit-pulse.sh
@@ -66,7 +66,7 @@ should_run() {
 	fi
 
 	local last_run
-	last_run=$(stat -c %Y "$AUDIT_MARKER" 2>/dev/null || stat -f %m "$AUDIT_MARKER" 2>/dev/null || echo "0")
+	last_run=$(_file_mtime_epoch "$AUDIT_MARKER")
 	local now
 	now=$(date +%s)
 	local elapsed=$((now - last_run))
@@ -855,7 +855,7 @@ cmd_status() {
 	# Last audit
 	if [[ -f "$AUDIT_MARKER" ]]; then
 		local last_run
-		last_run=$(stat -c %Y "$AUDIT_MARKER" 2>/dev/null || stat -f %m "$AUDIT_MARKER" 2>/dev/null || echo "0")
+		last_run=$(_file_mtime_epoch "$AUDIT_MARKER")
 		local now
 		now=$(date +%s)
 		local elapsed=$(((now - last_run) / 3600))

--- a/.agents/scripts/memory/_common.sh
+++ b/.agents/scripts/memory/_common.sh
@@ -11,6 +11,15 @@
 [[ -n "${_MEMORY_COMMON_LOADED:-}" ]] && return 0
 _MEMORY_COMMON_LOADED=1
 
+# Portable stat helpers — source shared-constants.sh if not already loaded.
+if ! declare -f _file_mtime_epoch >/dev/null 2>&1; then
+	_mc_dir="${BASH_SOURCE[0]%/*}"
+	[[ "$_mc_dir" == "${BASH_SOURCE[0]}" ]] && _mc_dir="."
+	# shellcheck source=../shared-constants.sh
+	source "$(cd "$_mc_dir/.." && pwd)/shared-constants.sh"
+	unset _mc_dir
+fi
+
 #######################################
 # Print colored message
 #######################################
@@ -815,7 +824,7 @@ auto_prune() {
 	# Check if we should run
 	if [[ -f "$prune_marker" ]]; then
 		local last_prune
-		last_prune=$(stat -c %Y "$prune_marker" 2>/dev/null || stat -f %m "$prune_marker" 2>/dev/null || echo "0")
+		last_prune=$(_file_mtime_epoch "$prune_marker")
 		local now
 		now=$(date +%s)
 		local elapsed=$((now - last_prune))

--- a/.agents/scripts/migrate-pr-backfill.sh
+++ b/.agents/scripts/migrate-pr-backfill.sh
@@ -27,6 +27,12 @@
 
 set -euo pipefail
 
+_mpb_dir="${BASH_SOURCE[0]%/*}"
+[[ "$_mpb_dir" == "${BASH_SOURCE[0]}" ]] && _mpb_dir="."
+# shellcheck source=./shared-constants.sh
+source "$(cd "$_mpb_dir" && pwd)/shared-constants.sh"
+unset _mpb_dir
+
 # --- Configuration -----------------------------------------------------------
 
 readonly SUPERVISOR_DIR="${HOME}/.aidevops/.agent-workspace/supervisor"
@@ -210,7 +216,7 @@ fetch_merged_prs() {
 	# Use cache if less than 5 minutes old
 	if [[ -f "$cache_file" ]]; then
 		local cache_age
-		cache_age=$(($(date +%s) - $(stat -c %Y "$cache_file" 2>/dev/null || stat -f %m "$cache_file" 2>/dev/null || echo 0)))
+		cache_age=$(($(date +%s) - $(_file_mtime_epoch "$cache_file")))
 		if ((cache_age < 300)); then
 			log "Using cached PR list (${cache_age}s old)"
 			cat "$cache_file"

--- a/.agents/scripts/oauth-pool-diagnose.sh
+++ b/.agents/scripts/oauth-pool-diagnose.sh
@@ -35,6 +35,8 @@ if [[ -z "${SCRIPT_DIR:-}" ]]; then
 	SCRIPT_DIR="$(cd "$_lib_path" && pwd)"
 	unset _lib_path
 fi
+# shellcheck source=./shared-constants.sh
+source "${SCRIPT_DIR}/shared-constants.sh"
 
 # ---------------------------------------------------------------------------
 # Help
@@ -134,7 +136,7 @@ _diag_check_pool() {
 		return 1
 	fi
 	local perms
-	perms=$(stat -f '%Lp' "$POOL_FILE" 2>/dev/null || stat -c '%a' "$POOL_FILE" 2>/dev/null || echo "unknown")
+	perms=$(_file_perms "$POOL_FILE")
 	if [[ "$perms" != "600" ]]; then
 		_diag_print "Pool file permissions" "WARN" "$perms (expected 600)"
 	else

--- a/.agents/scripts/opencode-db-archive.sh
+++ b/.agents/scripts/opencode-db-archive.sh
@@ -21,6 +21,12 @@
 
 set -Eeuo pipefail
 
+_oda_dir="${BASH_SOURCE[0]%/*}"
+[[ "$_oda_dir" == "${BASH_SOURCE[0]}" ]] && _oda_dir="."
+# shellcheck source=./shared-constants.sh
+source "$(cd "$_oda_dir" && pwd)/shared-constants.sh"
+unset _oda_dir
+
 # --- Configuration -----------------------------------------------------------
 
 readonly SCRIPT_NAME="opencode-db-archive"
@@ -103,8 +109,7 @@ get_active_worker_sessions() {
 	for logfile in /tmp/pulse-*.log; do
 		[[ -f "$logfile" ]] || continue
 		local file_mtime
-		# Linux stat -c first (stat -f '%m' on Linux outputs filesystem info to stdout)
-		file_mtime=$(stat -c '%Y' "$logfile" 2>/dev/null || stat -f '%m' "$logfile" 2>/dev/null || echo "0")
+		file_mtime=$(_file_mtime_epoch "$logfile")
 		if ((file_mtime > one_hour_ago)); then
 			# Extract session IDs from log content (UUIDs)
 			local found
@@ -144,8 +149,7 @@ file_size_bytes() {
 		echo "0"
 		return 0
 	fi
-	# Linux stat -c first (stat -f '%z' on Linux outputs filesystem info to stdout, not file size)
-	stat -c '%s' "$filepath" 2>/dev/null || stat -f '%z' "$filepath" 2>/dev/null || echo "0"
+	_file_size_bytes "$filepath"
 	return 0
 }
 

--- a/.agents/scripts/opencode-db-maintenance-helper.sh
+++ b/.agents/scripts/opencode-db-maintenance-helper.sh
@@ -180,13 +180,7 @@ _db_size_bytes() {
 		echo 0
 		return 0
 	}
-	if stat -f%z "$path" >/dev/null 2>&1; then
-		# macOS/BSD
-		stat -f%z "$path"
-	else
-		# GNU
-		stat -c%s "$path"
-	fi
+	_file_size_bytes "$path"
 }
 
 # _db_size_human <bytes> — portable human-readable byte formatter.

--- a/.agents/scripts/opencode-sandbox-helper.sh
+++ b/.agents/scripts/opencode-sandbox-helper.sh
@@ -88,8 +88,7 @@ _latest_sandbox() {
 			local ver
 			ver=$(basename "$dir")
 			local mtime
-			# Linux stat -c first (stat -f '%m' on Linux outputs filesystem info to stdout)
-			mtime=$(stat -c '%Y' "$dir" 2>/dev/null || stat -f '%m' "$dir" 2>/dev/null || echo "0")
+			mtime=$(_file_mtime_epoch "$dir")
 			if [[ "$mtime" -gt "$latest_time" ]]; then
 				latest_time="$mtime"
 				latest="$ver"

--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -245,7 +245,7 @@ _worktree_owner_alive() {
 #######################################
 # Get worktree creation epoch from the .git file's mtime.
 #
-# Linux uses `stat -c '%Y'`; macOS uses `stat -f '%m'`. Writes 0 to stdout
+# Uses _file_mtime_epoch() portable wrapper (GH#21623). Writes 0 to stdout
 # when the .git file is missing or stat fails, and logs a diagnostic in
 # that case (GH#18346: this path was previously a silent continue).
 #
@@ -261,7 +261,7 @@ _worktree_creation_epoch() {
 	local wt_created=0
 
 	if [[ -f "$wt_path/.git" ]]; then
-		wt_created=$(stat -c '%Y' "$wt_path/.git" 2>/dev/null || stat -f '%m' "$wt_path/.git" 2>/dev/null) || wt_created=0
+		wt_created=$(_file_mtime_epoch "$wt_path/.git")
 	fi
 
 	if [[ "$wt_created" -eq 0 ]]; then

--- a/.agents/scripts/pulse-fast-fail.sh
+++ b/.agents/scripts/pulse-fast-fail.sh
@@ -178,10 +178,7 @@ _ff_with_lock() {
 		if [[ -z "$_ff_owner_pid" ]]; then
 			local _orphan_age_threshold="" _lock_mtime="" _lock_now="" _lock_age=""
 			_orphan_age_threshold="${FAST_FAIL_LOCK_ORPHAN_AGE_SECONDS:-5}"
-			# stat -c %Y (GNU/Linux) before stat -f %m (BSD/macOS) to avoid
-			# GNU stat printing filesystem info to stdout when -f is used.
-			_lock_mtime=$(stat -c %Y "$lock_dir" 2>/dev/null || stat -f %m "$lock_dir" 2>/dev/null || echo 0)
-			[[ "$_lock_mtime" =~ ^[0-9]+$ ]] || _lock_mtime=0
+			_lock_mtime=$(_file_mtime_epoch "$lock_dir")
 			_lock_now=$(date +%s)
 			_lock_age=$((_lock_now - _lock_mtime))
 			if [[ "$_lock_age" -ge "$_orphan_age_threshold" ]]; then

--- a/.agents/scripts/pulse-issue-reconcile-stale.sh
+++ b/.agents/scripts/pulse-issue-reconcile-stale.sh
@@ -209,8 +209,7 @@ _normalize_stale_should_skip_reset() {
 	local worker_log="/tmp/pulse-${safe_slug_check}-${stale_num}.log"
 	if [[ -f "$worker_log" ]]; then
 		local log_mtime
-		# Linux stat -c first (stat -f '%m' on macOS outputs file info in a different format)
-		log_mtime=$(stat -c '%Y' "$worker_log" 2>/dev/null || stat -f '%m' "$worker_log" 2>/dev/null) || log_mtime=0
+		log_mtime=$(_file_mtime_epoch "$worker_log")
 		if [[ $((now_epoch - log_mtime)) -lt 600 ]]; then
 			return 0
 		fi

--- a/.agents/scripts/pulse-logging.sh
+++ b/.agents/scripts/pulse-logging.sh
@@ -38,7 +38,7 @@ _PULSE_LOGGING_LOADED=1
 #   - Atomic: uses a tmp file + mv to avoid partial archives.
 #   - Non-fatal: any failure is logged to WRAPPER_LOGFILE and silently
 #     ignored so the pulse cycle is never blocked by log housekeeping.
-#   - macOS compatible: uses stat -f %z (BSD stat) with fallback to wc -c.
+#   - macOS compatible: uses _file_size_bytes() portable wrapper (GH#21623).
 #   - No external deps beyond gzip (standard on macOS and Linux).
 #######################################
 rotate_pulse_log() {
@@ -51,9 +51,7 @@ rotate_pulse_log() {
 	# Check hot log size — skip if under cap or log doesn't exist
 	local hot_size=0
 	if [[ -f "$LOGFILE" ]]; then
-		hot_size=$(stat -f %z "$LOGFILE" 2>/dev/null || wc -c <"$LOGFILE" 2>/dev/null || echo "0")
-		hot_size="${hot_size//[[:space:]]/}"
-		[[ "$hot_size" =~ ^[0-9]+$ ]] || hot_size=0
+		hot_size=$(_file_size_bytes "$LOGFILE")
 	fi
 
 	if [[ "$hot_size" -lt "$PULSE_LOG_HOT_MAX_BYTES" ]]; then
@@ -99,18 +97,14 @@ rotate_pulse_log() {
 	done < <(ls -1 "${PULSE_LOG_ARCHIVE_DIR}"/pulse-*.log.gz 2>/dev/null | sort)
 
 	for archive_file in "${archive_files[@]}"; do
-		archive_size=$(stat -f %z "$archive_file" 2>/dev/null || wc -c <"$archive_file" 2>/dev/null || echo "0")
-		archive_size="${archive_size//[[:space:]]/}"
-		[[ "$archive_size" =~ ^[0-9]+$ ]] || archive_size=0
+		archive_size=$(_file_size_bytes "$archive_file")
 		total_cold=$((total_cold + archive_size))
 	done
 
 	if [[ "$total_cold" -gt "$PULSE_LOG_COLD_MAX_BYTES" ]]; then
 		for archive_file in "${archive_files[@]}"; do
 			[[ "$total_cold" -le "$PULSE_LOG_COLD_MAX_BYTES" ]] && break
-			archive_size=$(stat -f %z "$archive_file" 2>/dev/null || wc -c <"$archive_file" 2>/dev/null || echo "0")
-			archive_size="${archive_size//[[:space:]]/}"
-			[[ "$archive_size" =~ ^[0-9]+$ ]] || archive_size=0
+			archive_size=$(_file_size_bytes "$archive_file")
 			rm -f "$archive_file" && {
 				total_cold=$((total_cold - archive_size))
 				echo "[pulse-wrapper] rotate_pulse_log: pruned cold archive $(basename "$archive_file") (${archive_size}B)" >>"$WRAPPER_LOGFILE"
@@ -123,9 +117,7 @@ rotate_pulse_log() {
 	# so 1MB ≈ 12,500 entries ≈ weeks of data). Archive the old content first.
 	if [[ -n "${PULSE_STAGE_TIMINGS_LOG:-}" ]] && [[ -f "$PULSE_STAGE_TIMINGS_LOG" ]]; then
 		local timings_size=0
-		timings_size=$(stat -f %z "$PULSE_STAGE_TIMINGS_LOG" 2>/dev/null || wc -c <"$PULSE_STAGE_TIMINGS_LOG" 2>/dev/null || echo "0")
-		timings_size="${timings_size//[[:space:]]/}"
-		[[ "$timings_size" =~ ^[0-9]+$ ]] || timings_size=0
+		timings_size=$(_file_size_bytes "$PULSE_STAGE_TIMINGS_LOG")
 		if [[ "$timings_size" -gt 1048576 ]]; then
 			local timings_archive="${PULSE_LOG_ARCHIVE_DIR}/pulse-stage-timings-${ts}.log.gz"
 			if gzip -c "$PULSE_STAGE_TIMINGS_LOG" >"$timings_archive" 2>/dev/null; then

--- a/.agents/scripts/pulse-wrapper-cycle.sh
+++ b/.agents/scripts/pulse-wrapper-cycle.sh
@@ -268,7 +268,7 @@ _pulse_prime_caches_if_stale() {
 	else
 		local _now_epoch="" _stamp_epoch="" _age_s=""
 		_now_epoch=$(date +%s 2>/dev/null)
-		_stamp_epoch=$(stat -f %m "$_prime_sentinel" 2>/dev/null || stat -c %Y "$_prime_sentinel" 2>/dev/null)
+		_stamp_epoch=$(_file_mtime_epoch "$_prime_sentinel")
 		_age_s=$(( ${_now_epoch:-0} - ${_stamp_epoch:-0} ))
 		[[ "$_age_s" -gt "$_prime_max_age" ]] && _should_prime=1
 	fi

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -147,12 +147,8 @@ if [[ "$_pulse_skip_jitter" -eq 0 ]]; then
 		if [[ "$_pw_ffjit_pid" =~ ^[0-9]+$ ]] && kill -0 "$_pw_ffjit_pid" 2>/dev/null; then
 			# Age check mirrors main()'s is-running short-circuit (t2829).
 			# Use lockdir mtime as lock-acquired timestamp (mkdir is atomic).
-			# BSD stat (macOS): -f '%m'; GNU stat (Linux): -c '%Y'.
-			_pw_ffjit_mtime=$(stat -f '%m' "$_pw_ffjit_lockdir" 2>/dev/null \
-				|| stat -c '%Y' "$_pw_ffjit_lockdir" 2>/dev/null \
-				|| echo "0")
+			_pw_ffjit_mtime=$(_file_mtime_epoch "$_pw_ffjit_lockdir")
 			_pw_ffjit_now=$(date +%s)
-			[[ "$_pw_ffjit_mtime" =~ ^[0-9]+$ ]] || _pw_ffjit_mtime=0
 			_pw_ffjit_age=$(( _pw_ffjit_now - _pw_ffjit_mtime ))
 			if [[ "$_pw_ffjit_age" -le "${PULSE_LOCK_MAX_AGE_S:-1800}" ]]; then
 				printf '[pulse-wrapper] another instance running (PID %s, age %ss), skipping\n' \
@@ -1315,13 +1311,9 @@ main() {
 	# we exec at cycle end so the next iteration runs fresh code without waiting
 	# for the next launchd tick. Captured here — before any cycle work — so the
 	# comparison at cycle end detects changes made DURING the cycle, not changes
-	# that were present before it started. Uses BSD stat (-f '%m') with GNU fallback
-	# (-c '%Y'), consistent with the pre-jitter fast-fail stat calls at line ~151.
 	local _pw_self="${BASH_SOURCE[0]:-$0}"
 	local _pw_mtime_loaded
-	_pw_mtime_loaded=$(stat -f '%m' "$_pw_self" 2>/dev/null \
-		|| stat -c '%Y' "$_pw_self" 2>/dev/null \
-		|| echo 0)
+	_pw_mtime_loaded=$(_file_mtime_epoch "$_pw_self")
 
 	# GH#18689: --self-check and --dry-run arg scanning extracted to helpers.
 	# GH#18770: the `_sc_rc=$?` capture MUST be guarded by `|| _sc_rc=$?`
@@ -1604,12 +1596,8 @@ main() {
 	# Opt-out: AIDEVOPS_SKIP_SOURCE_REEXEC=1 (debugging / testing).
 	if [[ "${AIDEVOPS_SKIP_SOURCE_REEXEC:-0}" != "1" ]]; then
 		local _pw_mtime_now
-		_pw_mtime_now=$(stat -f '%m' "$_pw_self" 2>/dev/null \
-			|| stat -c '%Y' "$_pw_self" 2>/dev/null \
-			|| echo 0)
-		if [[ "$_pw_mtime_now" =~ ^[0-9]+$ ]] \
-			&& [[ "$_pw_mtime_loaded" =~ ^[0-9]+$ ]] \
-			&& [[ "$_pw_mtime_now" -gt 0 ]] \
+		_pw_mtime_now=$(_file_mtime_epoch "$_pw_self")
+		if [[ "$_pw_mtime_now" -gt 0 ]] \
 			&& [[ "$_pw_mtime_now" != "$_pw_mtime_loaded" ]]; then
 			echo "[pulse-wrapper] t3033: source modified (${_pw_mtime_loaded} -> ${_pw_mtime_now}) — releasing lock and re-execing for fresh code" >>"$WRAPPER_LOGFILE"
 			release_instance_lock

--- a/.agents/scripts/quality-fix.sh
+++ b/.agents/scripts/quality-fix.sh
@@ -76,7 +76,7 @@ fix_return_statements() {
 		local temp_file
 		temp_file=$(mktemp)
 		local file_mode=""
-		file_mode=$(stat -f "%Lp" "$file" 2>/dev/null || stat -c "%a" "$file" 2>/dev/null || true)
+		file_mode=$(_file_perms "$file")
 		local in_function=false
 		local function_name=""
 		local brace_count=0

--- a/.agents/scripts/quickfile-helper.sh
+++ b/.agents/scripts/quickfile-helper.sh
@@ -492,7 +492,7 @@ cmd_status() {
 		echo "  credentials:    configured (${QF_CREDENTIALS})"
 		# Check file permissions
 		local perms
-		perms="$(stat -f '%Lp' "$QF_CREDENTIALS" 2>/dev/null || stat -c '%a' "$QF_CREDENTIALS" 2>/dev/null || echo "unknown")"
+		perms="$(_file_perms "$QF_CREDENTIALS")"
 		if [[ "$perms" == "600" ]]; then
 			echo "  permissions:    600 (correct)"
 		else

--- a/.agents/scripts/repo-aidevops-health-helper.sh
+++ b/.agents/scripts/repo-aidevops-health-helper.sh
@@ -224,11 +224,7 @@ acquire_lock() {
 		# Safety net: remove locks older than 10 minutes
 		if [[ -d "$LOCK_FILE" ]]; then
 			local lock_age
-			if [[ "$(uname)" == "Darwin" ]]; then
-				lock_age=$(($(date +%s) - $(stat -f %m "$LOCK_FILE" 2>/dev/null || echo "0")))
-			else
-				lock_age=$(($(date +%s) - $(stat -c %Y "$LOCK_FILE" 2>/dev/null || echo "0")))
-			fi
+			lock_age=$(($(date +%s) - $(_file_mtime_epoch "$LOCK_FILE")))
 			if [[ $lock_age -gt 600 ]]; then
 				log_warn "Removing stale lock (age ${lock_age}s > 600s)"
 				rm -rf "$LOCK_FILE"

--- a/.agents/scripts/repo-sync-helper.sh
+++ b/.agents/scripts/repo-sync-helper.sh
@@ -207,11 +207,7 @@ acquire_lock() {
 		# Safety net: remove locks older than 10 minutes
 		if [[ -d "$LOCK_FILE" ]]; then
 			local lock_age
-			if [[ "$(uname)" == "Darwin" ]]; then
-				lock_age=$(($(date +%s) - $(stat -f %m "$LOCK_FILE" 2>/dev/null || echo "0")))
-			else
-				lock_age=$(($(date +%s) - $(stat -c %Y "$LOCK_FILE" 2>/dev/null || echo "0")))
-			fi
+			lock_age=$(($(date +%s) - $(_file_mtime_epoch "$LOCK_FILE")))
 			if [[ $lock_age -gt 600 ]]; then
 				log_warn "Removing stale lock (age ${lock_age}s > 600s)"
 				rm -rf "$LOCK_FILE"

--- a/.agents/scripts/schema-validator-helper.sh
+++ b/.agents/scripts/schema-validator-helper.sh
@@ -269,7 +269,7 @@ cmd_status() {
 
 	if [[ -f "$SCHEMA_CACHE" ]]; then
 		local cache_age
-		cache_age=$((($(date +%s) - $(stat -c %Y "$SCHEMA_CACHE" 2>/dev/null || stat -f %m "$SCHEMA_CACHE" 2>/dev/null || echo 0)) / 3600))
+		cache_age=$((($(date +%s) - $(_file_mtime_epoch "$SCHEMA_CACHE")) / 3600))
 		print_success "Schema cache: ${cache_age}h old (24h TTL)"
 	else
 		print_info "Schema cache: not yet fetched (will download on first run)"

--- a/.agents/scripts/secret-hygiene-helper.sh
+++ b/.agents/scripts/secret-hygiene-helper.sh
@@ -113,11 +113,7 @@ report_finding() {
 
 get_perms() {
 	local file="$1"
-	if [[ "$(uname)" == "Darwin" ]]; then
-		stat -f %Lp "$file" 2>/dev/null || echo "000"
-	else
-		stat -c %a "$file" 2>/dev/null || echo "000"
-	fi
+	_file_perms "$file"
 }
 
 # Scan aidevops credentials.sh (check 1)

--- a/.agents/scripts/security-posture-helper-user.sh
+++ b/.agents/scripts/security-posture-helper-user.sh
@@ -148,11 +148,7 @@ check_secret_storage() {
 	# Fallback: credentials.sh with correct permissions
 	if [[ -f "$CREDENTIALS_FILE" ]]; then
 		local perms
-		if [[ "$(uname)" == "Darwin" ]]; then
-			perms=$(stat -f %Lp "$CREDENTIALS_FILE" || echo "000")
-		else
-			perms=$(stat -c %a "$CREDENTIALS_FILE" || echo "000")
-		fi
+		perms=$(_file_perms "$CREDENTIALS_FILE")
 		if [[ "$perms" == "600" ]]; then
 			CHECK_LABEL="$label (credentials.sh, 600)"
 			return 0

--- a/.agents/scripts/session-checkpoint-helper.sh
+++ b/.agents/scripts/session-checkpoint-helper.sh
@@ -378,11 +378,7 @@ cmd_status() {
 	local file_mtime
 
 	now="$(date +%s)"
-	if [[ "$(uname)" == "Darwin" ]]; then
-		file_mtime="$(stat -f %m "$CHECKPOINT_FILE")"
-	else
-		file_mtime="$(stat -c %Y "$CHECKPOINT_FILE")"
-	fi
+	file_mtime="$(_file_mtime_epoch "$CHECKPOINT_FILE")"
 	file_age_seconds=$((now - file_mtime))
 
 	local age_display

--- a/.agents/scripts/session-miner-pulse.sh
+++ b/.agents/scripts/session-miner-pulse.sh
@@ -24,6 +24,8 @@ set -euo pipefail
 _smp_dir="${BASH_SOURCE[0]%/*}"
 [[ "$_smp_dir" == "${BASH_SOURCE[0]}" ]] && _smp_dir="."
 SCRIPT_DIR="$(cd "$_smp_dir" && pwd)"
+# shellcheck source=./shared-constants.sh
+source "${SCRIPT_DIR}/shared-constants.sh"
 MINER_DIR="${HOME}/.aidevops/.agent-workspace/work/session-miner"
 # Shipped with aidevops; copied to workspace on first run
 EXTRACTOR_SRC="${SCRIPT_DIR}/session-miner/extract.py"
@@ -56,11 +58,8 @@ log_error() {
 check_lock() {
 	if [[ -f "${LOCK_FILE}" ]]; then
 		local lock_age
-		# Cross-platform file mtime: Linux (stat -c) first, macOS (stat -f) fallback
 		local lock_mtime
-		lock_mtime=$(stat -c %Y "${LOCK_FILE}" 2>/dev/null || stat -f %m "${LOCK_FILE}" 2>/dev/null || echo 0)
-		# Guard: ensure numeric (stat -f on Linux produces multi-line text, not a number)
-		[[ "${lock_mtime}" =~ ^[0-9]+$ ]] || lock_mtime=0
+		lock_mtime=$(_file_mtime_epoch "${LOCK_FILE}")
 		lock_age=$(($(date +%s) - lock_mtime))
 		# Stale lock (>1 hour)
 		if [[ "${lock_age}" -gt 3600 ]]; then
@@ -690,10 +689,7 @@ sync_scripts() {
 validate_db_size() {
 	local db_path="$1"
 	local db_size
-	# Cross-platform file size: Linux (stat -c) first, macOS (stat -f) fallback
-	db_size=$(stat -c %s "${db_path}" 2>/dev/null || stat -f %z "${db_path}" 2>/dev/null || echo 0)
-	# Guard: ensure numeric (stat -f on Linux produces multi-line text, not a number)
-	[[ "${db_size}" =~ ^[0-9]+$ ]] || db_size=0
+	db_size=$(_file_size_bytes "${db_path}")
 	if [[ "${db_size}" -lt 1000 ]]; then
 		log_info "Database too small (${db_size} bytes). Nothing to mine."
 		return 1

--- a/.agents/scripts/shared-claim-lifecycle.sh
+++ b/.agents/scripts/shared-claim-lifecycle.sh
@@ -49,6 +49,15 @@
 [[ -n "${_SHARED_CLAIM_LIFECYCLE_LOADED:-}" ]] && return 0
 _SHARED_CLAIM_LIFECYCLE_LOADED=1
 
+# Portable stat helpers — source shared-constants.sh if not already loaded.
+if ! declare -f _file_mtime_epoch >/dev/null 2>&1; then
+	_scl_dir="${BASH_SOURCE[0]%/*}"
+	[[ "$_scl_dir" == "${BASH_SOURCE[0]}" ]] && _scl_dir="."
+	# shellcheck source=./shared-constants.sh
+	source "$(cd "$_scl_dir" && pwd)/shared-constants.sh"
+	unset _scl_dir
+fi
+
 #######################################
 # Release the interactive claim for a linked issue after a PR merge.
 #
@@ -314,10 +323,8 @@ _read_worker_log_tail_classified() {
 			# created at spawn and written-to throughout execution).
 			local now mtime
 			now=$(date +%s 2>/dev/null) || now=""
-			mtime=$(stat -c '%Y' "$log_file" 2>/dev/null \
-				|| stat -f '%m' "$log_file" 2>/dev/null \
-				|| echo "")
-			if [[ -n "$now" && -n "$mtime" && "$mtime" =~ ^[0-9]+$ ]]; then
+			mtime=$(_file_mtime_epoch "$log_file")
+			if [[ -n "$now" && "$mtime" -gt 0 ]]; then
 				_WORKER_LOG_TAIL_AGE_SECS=$((now - mtime))
 				# Defensive: clamp negatives to 0 (clock skew / FS race)
 				[[ "$_WORKER_LOG_TAIL_AGE_SECS" -lt 0 ]] && _WORKER_LOG_TAIL_AGE_SECS=0

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -733,6 +733,34 @@ _file_mtime_epoch() {
 }
 
 # =============================================================================
+# Portable file size (macOS vs GNU/Linux)
+# GNU stat uses -c %s; BSD stat uses -f %z. On Linux, `stat -f %z` does NOT
+# fail — it prints filesystem info (exit 0), capturing garbage into variables.
+# GNU-first order is mandatory.  See GH#21618 / GH#21623.
+# Usage: bytes=$(_file_size_bytes "/path/to/file")
+# Returns: file size in bytes, or 0 if file missing / error.
+# =============================================================================
+
+_file_size_bytes() {
+	local file_path="$1"
+	stat -c %s "$file_path" 2>/dev/null || stat -f %z "$file_path" 2>/dev/null || echo 0
+}
+
+# =============================================================================
+# Portable file permissions (macOS vs GNU/Linux)
+# GNU stat uses -c %a; BSD stat uses -f %Lp. On Linux, `stat -f %Lp` does NOT
+# fail — it prints filesystem info (exit 0), capturing garbage into variables.
+# GNU-first order is mandatory.  See GH#21618 / GH#21623.
+# Usage: perms=$(_file_perms "/path/to/file")
+# Returns: octal permissions (e.g. "600"), or "000" if file missing / error.
+# =============================================================================
+
+_file_perms() {
+	local file_path="$1"
+	stat -c %a "$file_path" 2>/dev/null || stat -f %Lp "$file_path" 2>/dev/null || echo 000
+}
+
+# =============================================================================
 # Stderr Logging Utilities
 # =============================================================================
 # Replace blanket 2>/dev/null with targeted stderr handling.

--- a/.agents/scripts/shared-todo-commit.sh
+++ b/.agents/scripts/shared-todo-commit.sh
@@ -47,7 +47,7 @@
 # Dependencies:
 #   - git (must be on PATH).
 #   - bash 4+ (uses `${var:-default}` and trap EXIT).
-#   - GNU coreutils OR macOS BSD coreutils (handles `stat -f` vs `stat -c`).
+#   - GNU coreutils OR macOS BSD coreutils (uses _file_mtime_epoch() wrapper).
 #   - $AIDEVOPS_LOG_FILE (optional — log target for lock + retry diagnostics;
 #     defaults to /dev/null).
 #
@@ -119,11 +119,7 @@ _todo_acquire_lock() {
 		# Check lock age (safety net for orphaned locks)
 		if [[ -d "$TODO_LOCK_PATH" ]]; then
 			local lock_age
-			if [[ "$(uname)" == "Darwin" ]]; then
-				lock_age=$(($(date +%s) - $(stat -f %m "$TODO_LOCK_PATH" 2>/dev/null || echo "0")))
-			else
-				lock_age=$(($(date +%s) - $(stat -c %Y "$TODO_LOCK_PATH" 2>/dev/null || echo "0")))
-			fi
+			lock_age=$(($(date +%s) - $(_file_mtime_epoch "$TODO_LOCK_PATH")))
 			if [[ $lock_age -gt $TODO_STALE_LOCK_AGE ]]; then
 				echo "[todo_lock] Removing stale lock (age ${lock_age}s > ${TODO_STALE_LOCK_AGE}s)" >>"$log_target"
 				rm -rf "$TODO_LOCK_PATH"

--- a/.agents/scripts/site-crawler-helper.sh
+++ b/.agents/scripts/site-crawler-helper.sh
@@ -247,8 +247,7 @@ _smwm_download_images() {
 
 		if curl -sS -L --max-time 10 -o "${page_images_dir}/${img_filename}" "$img_src" 2>/dev/null; then
 			local file_size
-			# Linux stat -c first (stat -f%z on Linux outputs filesystem info to stdout)
-			file_size=$(stat -c%s "${page_images_dir}/${img_filename}" 2>/dev/null || stat -f%z "${page_images_dir}/${img_filename}" 2>/dev/null || echo "0")
+			file_size=$(_file_size_bytes "${page_images_dir}/${img_filename}")
 			if [[ $file_size -gt 1024 ]]; then
 				printf '%s\n' "${img_filename}|${img_src}|${img_alt}" >>"${_out_images}"
 			else

--- a/.agents/scripts/spdx-headers.sh
+++ b/.agents/scripts/spdx-headers.sh
@@ -9,6 +9,9 @@
 
 set -euo pipefail
 
+# shellcheck source=./shared-constants.sh
+source "$(dirname "${BASH_SOURCE[0]}")/shared-constants.sh"
+
 readonly COPYRIGHT_HOLDER="Marcus Quinn"
 readonly COPYRIGHT_YEARS="2025-2026"
 readonly LICENSE_ID="MIT"
@@ -28,7 +31,7 @@ _safe_replace() {
 	local tmp_file="$1"
 	local target_file="$2"
 	chmod --reference="$target_file" "$tmp_file" 2>/dev/null ||
-		chmod "$(stat -f '%Lp' "$target_file" 2>/dev/null || echo '644')" "$tmp_file" 2>/dev/null ||
+		chmod "$(_file_perms "$target_file")" "$tmp_file" 2>/dev/null ||
 		true
 	mv "$tmp_file" "$target_file"
 	return 0

--- a/.agents/scripts/subagent-index-helper.sh
+++ b/.agents/scripts/subagent-index-helper.sh
@@ -23,6 +23,13 @@
 
 set -euo pipefail
 
+_sih_dir="${BASH_SOURCE[0]%/*}"
+[[ "$_sih_dir" == "${BASH_SOURCE[0]}" ]] && _sih_dir="."
+SCRIPT_DIR="$(cd "$_sih_dir" && pwd)"
+# shellcheck source=./shared-constants.sh
+source "${SCRIPT_DIR}/shared-constants.sh"
+unset _sih_dir
+
 AGENTS_DIR="${HOME}/.aidevops/agents"
 INDEX_FILE="${AGENTS_DIR}/subagent-index.toon"
 
@@ -179,9 +186,8 @@ cmd_check() {
 			{ if (in_block && NF > 0) { count++ } }
 			END { print count }')
 
-	# Cross-platform file mtime: Linux (stat -c) first, macOS (stat -f) fallback
 	local index_mtime
-	index_mtime=$(stat -c %Y "$INDEX_FILE" 2>/dev/null || stat -f %m "$INDEX_FILE" 2>/dev/null || echo "0")
+	index_mtime=$(_file_mtime_epoch "$INDEX_FILE")
 	local index_age=$(($(date +%s) - index_mtime))
 
 	echo "Index: ${INDEX_FILE}"

--- a/.agents/scripts/tech-stack-cache-lib.sh
+++ b/.agents/scripts/tech-stack-cache-lib.sh
@@ -60,15 +60,7 @@ is_cache_valid() {
 	fi
 
 	local file_age_days
-	if [[ "$(uname)" == "Darwin" ]]; then
-		local file_mod
-		file_mod=$(stat -f %m "$cache_file")
-		local now
-		now=$(date +%s)
-		file_age_days=$(((now - file_mod) / 86400))
-	else
-		file_age_days=$((($(date +%s) - $(stat -c %Y "$cache_file")) / 86400))
-	fi
+	file_age_days=$((($(date +%s) - $(_file_mtime_epoch "$cache_file")) / 86400))
 
 	if [[ "$file_age_days" -lt "$ttl_days" ]]; then
 		return 0

--- a/.agents/scripts/thumbnail-helper.sh
+++ b/.agents/scripts/thumbnail-helper.sh
@@ -496,11 +496,7 @@ _score_check_image_properties() {
 	fi
 
 	local file_size_mb
-	if [[ "$OSTYPE" == "darwin"* ]]; then
-		file_size_mb=$(stat -f%z "$image_path" | awk '{print $1/1024/1024}')
-	else
-		file_size_mb=$(stat -c%s "$image_path" | awk '{print $1/1024/1024}')
-	fi
+	file_size_mb=$(_file_size_bytes "$image_path" | awk '{print $1/1024/1024}')
 	print_info "File size: ${file_size_mb}MB (max: ${THUMBNAIL_MAX_SIZE_MB}MB)"
 
 	return 0

--- a/.agents/scripts/worker-token-helper.sh
+++ b/.agents/scripts/worker-token-helper.sh
@@ -388,7 +388,7 @@ read_token_file() {
 
 	# Verify permissions
 	local perms
-	perms=$(stat -f '%Lp' "$token_file" 2>/dev/null || stat -c '%a' "$token_file" 2>/dev/null)
+	perms=$(_file_perms "$token_file")
 	if [[ "$perms" != "600" ]]; then
 		log_token "WARN" "Token file has insecure permissions (${perms}), expected 600"
 	fi

--- a/.agents/scripts/worktree-clean-lib.sh
+++ b/.agents/scripts/worktree-clean-lib.sh
@@ -76,15 +76,7 @@ worktree_is_in_grace_period() {
 	now_epoch=$(date +%s 2>/dev/null) || return 1
 
 	local dir_mtime
-	# macOS: stat -f %m; Linux: stat -c %Y
-	if stat -f %m "$wt_path" >/dev/null 2>&1; then
-		dir_mtime=$(stat -f %m "$wt_path" 2>/dev/null) || return 1
-	elif stat -c %Y "$wt_path" >/dev/null 2>&1; then
-		dir_mtime=$(stat -c %Y "$wt_path" 2>/dev/null) || return 1
-	else
-		# Cannot determine mtime — fail safe (treat as in grace period)
-		return 0
-	fi
+	dir_mtime=$(_file_mtime_epoch "$wt_path")
 
 	local age_seconds=$((now_epoch - dir_mtime))
 	local grace_seconds=$((grace_hours * 3600))

--- a/.agents/scripts/worktree-sessions.sh
+++ b/.agents/scripts/worktree-sessions.sh
@@ -167,12 +167,7 @@ get_branch_start_date() {
 		echo "$first_commit_date"
 	else
 		# No unique commits, use worktree creation time (directory mtime)
-		# Portable stat (BSD: -f "%m", GNU: -c "%Y")
-		if stat --version &>/dev/null 2>&1; then
-			stat -c "%Y" "$worktree_path" 2>/dev/null || echo ""
-		else
-			stat -f "%m" "$worktree_path" 2>/dev/null || echo ""
-		fi
+		_file_mtime_epoch "$worktree_path"
 	fi
 }
 


### PR DESCRIPTION
## What

Add `_file_size_bytes()` and `_file_perms()` portable stat functions to `shared-constants.sh`, then replace all inline `stat -f` / `stat -c` patterns across 55 scripts with calls to these functions.

## Why

`stat -f` on Linux is the `--file-system` flag — it outputs multi-line filesystem metadata (exit 0) rather than failing. This contaminates variables used in arithmetic (GH#21618). The fix from GH#21618 added `_file_mtime_epoch()` but the codebase had 55+ more scripts with inline patterns, creating the same class of bug.

## How

### Phase 1: New functions in shared-constants.sh
```bash
_file_size_bytes() — GNU stat -c %s first, BSD stat -f %z fallback, echo 0 on failure
_file_perms()      — GNU stat -c %a first, BSD stat -f %Lp fallback, echo 000 on failure
```

### Phase 2: Replacements across 55 scripts
- `stat -c %Y ... || stat -f %m ...` → `_file_mtime_epoch "$file"`
- `stat -c %s ... || stat -f %z ...` → `_file_size_bytes "$file"`
- `stat -c %a ... || stat -f %Lp ...` → `_file_perms "$file"`
- Also consolidated platform-guarded `if Darwin; then ... else ...` blocks

### Phase 3: Source added to 11 standalone scripts
Scripts without existing `shared-constants.sh` sourcing received it via `$(dirname "${BASH_SOURCE[0]}")` or conditional guard pattern.

### Not touched
- `tests/` (per issue instructions)
- Compound `stat -f` formats (`%Sm`, `%N %z %m`, `%OLp`, `%Su`) — no portable equivalent
- `generate-skills.sh`, `generate-runtime-config.sh`, `seo-export-helper.sh`, `shannon-helper.sh`, `wp-helper.sh`

## Acceptance Criteria Status

1. ✅ `rg 'stat -f %m' .agents/scripts/ --glob '!tests/*'` → only shared-constants.sh fallback
2. ✅ `rg 'stat -f %z' .agents/scripts/ --glob '!tests/*'` → only shared-constants.sh fallback
3. ✅ `rg 'stat -f %Lp' .agents/scripts/ --glob '!tests/*'` → only shared-constants.sh fallback
4. ✅ `shellcheck .agents/scripts/shared-constants.sh` passes clean
5. ✅ `shellcheck` passes on all 55 modified files
6. ✅ Existing `_file_mtime_epoch` callers unaffected (no signature change)

Resolves #21623

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.8 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-sonnet-4-6 spent 29m and 69,948 tokens on this as a headless worker.
