### PR TITLE
t3040: drop t2955 already-committed cache from dispatch hot path

### DIFF
--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -943,10 +943,10 @@ _dispatch_dedup_check_layers() {
 		return 1
 	fi
 
-	# GH#17574/GH#18644: commit-subject dedup gate with force-dispatch override.
-	if _check_commit_subject_dedup_gate "$issue_number" "$repo_slug" "$target_title" "$repo_path" "$issue_meta_json"; then
-		return 1
-	fi
+	# t3040: commit-subject dedup gate REMOVED from dispatch hot path
+	# (cost 100-156s/candidate). Workers do their own t2046 duplicate
+	# discovery; helpers retained for diagnostic use. Regression guard:
+	# tests/test-pulse-dispatch-core-t3040-gate-removed.sh.
 
 	# t1927: Blocked-by enforcement — skip dispatch if a dependency is unresolved.
 	# Parses issue body for "blocked-by:tNNN" or "Blocked by #NNN".

--- a/.agents/scripts/tests/test-pulse-dispatch-core-t3040-gate-removed.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-core-t3040-gate-removed.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# t3040 regression test: verify that `_check_commit_subject_dedup_gate` is
+# NOT called from the dispatch hot path inside `dispatch_with_dedup`.
+#
+# Background: the gate cost 100-156s per dispatch candidate (production
+# data, Apr 2026), making it the dominant cost of the pulse fill-floor
+# stage. t3040 removed the call site per the "Intelligence Over
+# Determinism" framework principle — workers do their own t2046 duplicate
+# discovery, which is more reliable than commit-message regex.
+#
+# This test exists so that any future change which re-introduces the call
+# fails CI with a mentoring error, instead of silently regressing the
+# dispatch latency back to the t2955-era baseline.
+#
+# The helper functions themselves (`_check_commit_subject_dedup_gate`,
+# `_is_task_committed_to_main`, etc.) remain in the source — they are
+# tested in isolation by test-pulse-wrapper-main-commit-check.sh and may
+# be useful for audit/diagnostic tooling. This test only checks that they
+# are not invoked from `dispatch_with_dedup` at runtime.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+CORE_SCRIPT="${SCRIPT_DIR}/../pulse-dispatch-core.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+# Extract the body of `dispatch_with_dedup` (or its inner gate function
+# `_dispatch_dedup_check_layers`) from the source file. Both functions
+# live in pulse-dispatch-core.sh; the call site this test guards against
+# was originally inside `_dispatch_dedup_check_layers`.
+extract_dispatch_function_bodies() {
+	awk '
+		/^dispatch_with_dedup\(\) \{/,/^}$/ { print }
+		/^_dispatch_dedup_check_layers\(\) \{/,/^}$/ { print }
+	' "$CORE_SCRIPT"
+}
+
+test_gate_call_absent_from_dispatch_hot_path() {
+	local body
+	body=$(extract_dispatch_function_bodies)
+
+	if [[ -z "$body" ]]; then
+		print_result "extract dispatch function bodies" 1 \
+			"Could not extract dispatch_with_dedup or _dispatch_dedup_check_layers from $CORE_SCRIPT"
+		return 0
+	fi
+
+	# The call site we removed was:
+	#   if _check_commit_subject_dedup_gate "$issue_number" ...
+	# Match any non-comment line that invokes the function.
+	local matches
+	matches=$(printf '%s\n' "$body" |
+		grep -nE '^[[:space:]]*[^#]*_check_commit_subject_dedup_gate' || true)
+
+	if [[ -z "$matches" ]]; then
+		print_result "_check_commit_subject_dedup_gate not called from dispatch hot path" 0
+		return 0
+	fi
+
+	print_result "_check_commit_subject_dedup_gate not called from dispatch hot path" 1 \
+		"t3040 regression: gate call re-introduced. Matches:
+${matches}
+The gate cost 100-156s per dispatch candidate. If you have a new reason to re-add it, document the perf measurement in the PR body and update this test accordingly."
+	return 0
+}
+
+test_helper_functions_still_defined() {
+	# t3040 keeps the helpers in source — only the call site was removed.
+	# This test ensures we did not over-aggressively delete the helpers.
+	local missing=0
+	local helper
+	for helper in \
+		_check_commit_subject_dedup_gate \
+		_is_task_committed_to_main \
+		_has_committed_to_main_cache_label \
+		_apply_committed_to_main_cache_label \
+		_has_force_dispatch_label; do
+		if ! grep -qE "^${helper}\(\) \{" "$CORE_SCRIPT"; then
+			printf 'helper missing: %s\n' "$helper"
+			missing=$((missing + 1))
+		fi
+	done
+
+	if [[ "$missing" -eq 0 ]]; then
+		print_result "all dedup helper functions still defined in source" 0
+		return 0
+	fi
+
+	print_result "all dedup helper functions still defined in source" 1 \
+		"$missing helper(s) missing. t3040 only removes the call site, not the helpers."
+	return 0
+}
+
+main() {
+	test_gate_call_absent_from_dispatch_hot_path
+	test_helper_functions_still_defined
+
+	printf '\n%d tests run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		exit 1
+	fi
+	exit 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Removes the `_check_commit_subject_dedup_gate` call from the pulse dispatch
hot path. The gate cost **100-156s per candidate** in production (Apr 2026),
making fill-floor cycles longer than the cycle interval and starving the
pulse of dispatch slots even when worker capacity was available.

Resolves #21629.

## Why

Workers run a mandatory **t2046 discovery pass** before writing code:

  - `git log --since=… -- <target-files>` (recently-landed commits)
  - `gh pr list --state merged --search "<keywords>"` (recently-merged PRs)
  - `gh pr list --state open --search "<keywords>"` (in-flight collisions)

This is the same semantic check the dispatch gate was approximating —
"has someone already done this?" — except the worker reads the actual
code state, not commit-message regex. The worker is more reliable AND
faster than the gate's 3× `git log --grep` scan + cache lookup.

The **GH#18538 worker triage protocol** already mandates "premise
falsified → close with rationale" as outcome A. Workers SHOULD close
duplicates by design. The gate was a deterministic predictor of what
the worker would conclude — and the prediction cost more than the
worker's own check.

This change aligns with the framework's **"Intelligence Over Determinism"**
core principle: trust the worker (LLM with full context) over a regex on
commit messages.

## What changes

- `pulse-dispatch-core.sh:946-955` — single call site removed from
  `_dispatch_dedup_check_layers`, replaced with a 4-line comment
  pointing to the regression guard.
- `tests/test-pulse-dispatch-core-t3040-gate-removed.sh` (NEW) —
  regression guard that fails if the gate call is re-introduced into
  `dispatch_with_dedup` or `_dispatch_dedup_check_layers`.

## What stays

- All four helper functions remain in source: `_check_commit_subject_dedup_gate`,
  `_is_task_committed_to_main`, `_has_committed_to_main_cache_label`,
  `_apply_committed_to_main_cache_label`. They are exercised in isolation
  by `tests/test-pulse-wrapper-main-commit-check.sh` and may be useful
  for diagnostic or audit tooling. They just no longer run on every
  dispatch candidate.
- Force-dispatch override semantics are preserved — irrelevant here since
  the gate it overrides no longer fires from the hot path.
- All other dedup layers run as before: active-assignment dedup,
  footprint overlap, NMR-no-approval, blocked-by, parent-task. **These
  prevent races, not staleness** — a worker can't self-detect "another
  worker is editing this file RIGHT NOW", so the dispatch layer must.

## Acceptance

- [x] `pulse-dispatch-core.sh` no longer calls `_check_commit_subject_dedup_gate`
      from `_dispatch_dedup_check_layers` (verified by new regression test)
- [x] Helper functions remain defined (verified by new regression test)
- [x] All existing dispatch tests pass:
      - `test-pulse-dispatch-core-ansi-strip.sh` (4/4)
      - `test-pulse-dispatch-core-bot-cleanup.sh` (9/9)
      - `test-pulse-dispatch-core-force-dispatch.sh` (6/6)
      - `test-pulse-dispatch-core-planning-filter.sh` (8/8)
      - `test-pulse-dispatch-engine-stage-wiring.sh` (14/14)
      - `test-pulse-dispatch-engine-timeout-floor.sh` (6/6)
      - `test-pulse-wrapper-main-commit-check.sh` (15/15)
      - `test-pulse-wrapper-characterization.sh` (26/26)
- [x] Net file-size delta = 0 (1579 → 1579 lines)
- [x] Net function-complexity delta = 0 for `_dispatch_dedup_check_layers`
      (143 → 143 lines)
- [x] ShellCheck zero new violations
- [x] Pre-commit string-literal ratchet passes (2 pre-existing literals only)

## Files Scope

- `.agents/scripts/pulse-dispatch-core.sh`
- `.agents/scripts/tests/test-pulse-dispatch-core-t3040-gate-removed.sh`

## Stale label cleanup

Existing `dispatch-blocked:committed-to-main` cache labels on issues
will become stale (no longer block dispatch, but harmless). A follow-up
task can scrub them; not blocking for this PR.

## Production impact

- **Fill-floor latency**: ~140 candidates × 100-156s = ~4-6h/cycle
  → ~140 candidates × <5s = ~10-15min/cycle (other dedup layers only).
- **Dispatch throughput**: pulse can saturate available worker slots
  again instead of timing out the cycle before reaching them.
- **Worker count**: expected to recover from ~6 unique active issues
  back toward `effective_slots` (24 on this host).

## Risk

- A duplicate worker may be dispatched on rare occasions where (a) the
  task was committed to main very recently AND (b) the worker's t2046
  discovery somehow misses it. In that case the worker should close per
  GH#18538 outcome A. The cost of the rare duplicate dispatch (one worker
  cycle + one close) is far below the cost of running the gate on every
  candidate every cycle.
- Helper functions remain in source so a follow-up patch could re-enable
  the gate as opt-in via env flag if production data later disagrees.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.8 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-opus-4-7 spent 5h 57m on this with the user in an interactive session. Overall, 9m since this issue was created.
