### PR TITLE
t3043: raise per-candidate timeout floor 360s -> 600s

### DIFF
--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -545,9 +545,14 @@ _dff_dispatch_with_timeout() {
 	# ceremony — when adaptive recommended drops below ceremony cost, EVERY
 	# candidate timeouts at rc=124 and dispatched=0/N. Canonical failure:
 	# 2026-04-28 fill_floor cycle iter=62, 148 candidates, dispatched=0,
-	# adaptive timeout collapsed to 180s. Floor at 360s gives ceremony +
-	# backpressure margin without inflating fast-path probe budget.
-	local floor_seconds="${FILL_FLOOR_PER_CANDIDATE_TIMEOUT_FLOOR:-360}"
+	# adaptive timeout collapsed to 180s. Floor at 360s was insufficient
+	# (post-t3040 evidence: ceremony_total avg=341s, max=341s — every
+	# candidate hit rc=124 timeout). t3043 raises to 600s to give the
+	# 419s avg ceremony (gh_issue_view 3s + dedup_check 134s + assign 35s
+	# + precreate_worktree 75s + lock 7s + eligibility 11s + predispatch 8s
+	# + tier 4s + worker_launch 142s) ~50% headroom for tail variance.
+	# Follow-up t3043 (#21659) targets reducing per-stage cost to <60s.
+	local floor_seconds="${FILL_FLOOR_PER_CANDIDATE_TIMEOUT_FLOOR:-600}"
 	if [[ "$floor_seconds" =~ ^[0-9]+$ ]] && ((timeout_seconds < floor_seconds)); then
 		timeout_seconds="$floor_seconds"
 		timeout_ms=$((floor_seconds * 1000))

--- a/.agents/scripts/tests/test-pulse-dispatch-engine-timeout-floor.sh
+++ b/.agents/scripts/tests/test-pulse-dispatch-engine-timeout-floor.sh
@@ -19,7 +19,9 @@
 #
 # Contract pinned by this test:
 #   1. The function declares a `floor_seconds` local sourced from
-#      FILL_FLOOR_PER_CANDIDATE_TIMEOUT_FLOOR with a default of 360.
+#      FILL_FLOOR_PER_CANDIDATE_TIMEOUT_FLOOR with a default of 600
+#      (raised from 360 in t3043 — see ceremony breakdown in
+#      pulse-dispatch-engine.sh comment block).
 #   2. The floor block runs AFTER the adaptive helper has populated
 #      timeout_seconds — i.e., it sits between the `dispatch-timing-helper.sh
 #      recommend` block and the run_stage_with_timeout call.
@@ -91,8 +93,8 @@ echo "Engine: $ENGINE"
 echo ""
 
 assert_grep \
-	"1: env var FILL_FLOOR_PER_CANDIDATE_TIMEOUT_FLOOR is consulted with default 360" \
-	'\$\{FILL_FLOOR_PER_CANDIDATE_TIMEOUT_FLOOR:-360\}' \
+	"1: env var FILL_FLOOR_PER_CANDIDATE_TIMEOUT_FLOOR is consulted with default 600" \
+	'\$\{FILL_FLOOR_PER_CANDIDATE_TIMEOUT_FLOOR:-600\}' \
 	"$ENGINE"
 
 assert_grep \


### PR DESCRIPTION
## Summary

Raises `FILL_FLOOR_PER_CANDIDATE_TIMEOUT_FLOOR` default from 360s → 600s. Operational hotfix: every fill_floor candidate post-t3040 deploy was hitting `rc=124` (stage timeout) at 360s, resulting in **0 successful dispatches per cycle** despite candidates being dispatchable.

## Evidence (from `~/.aidevops/logs/dispatch-stages.tsv`, n=42 post-t3040)

| Stage | avg (ms) | max (ms) |
|---|---|---|
| `gh_issue_view` | 3,063 | 6,308 |
| `dedup_check` | **134,065** | 323,683 |
| `tier_body_shape` | 4,137 | 5,949 |
| `eligibility_gate` | 11,499 | 15,678 |
| `predispatch_validator` | 8,484 | 12,662 |
| `lock_issue` | 7,296 | 11,873 |
| `assign_and_label` | 34,966 | 39,520 |
| `precreate_worktree` | 75,030 | 91,427 |
| `worker_launch_total` | 142,410 | 142,410 |
| **ceremony_total** | **340,823** | **340,823** |

Sum of stage means = 419s. The 360s ceiling caught every dispatch.

## Why now

Pulse PID 47974 has been cycling for ~5 hours since t3040 deploy with **0 active workers** despite 163 dispatchable candidates queued (61 aidevops + 96 <webapp>). Every candidate that reaches `dispatch_with_dedup` hits rc=124 at 360s, and the post-spawn `Dispatched worker PID` log line sometimes fires *after* the stage abort — workers spawn but in a half-killed state.

P0 demo tomorrow requires throughput restored.

## Why 600s, not larger

- 50% headroom on the 419s avg ceremony covers tail variance (max observed ceremony_total = 340s, max dedup_check = 323s).
- Larger budgets compound failure cost — if a worker hangs, we want the watchdog to kick in.
- Follow-up #21659 (t3043 analysis task) targets reducing per-stage cost to <60s where appropriate, after which the floor can drop again.

## Tests

- `test-pulse-dispatch-engine-timeout-floor.sh`: 6/6 PASS — header comment + assertion updated to 600.
- `test-pulse-dispatch-core-t3040-gate-removed.sh`: 2/2 PASS (no impact).
- `test-pulse-dispatch-engine-stage-wiring.sh`: 14/14 PASS (no impact).

## Files changed

- `EDIT: .agents/scripts/pulse-dispatch-engine.sh:550` — bump default 360 → 600 with rationale comment.
- `EDIT: .agents/scripts/tests/test-pulse-dispatch-engine-timeout-floor.sh:22, 94-95` — update test contract to 600.

## Verification

```bash
bash .agents/scripts/tests/test-pulse-dispatch-engine-timeout-floor.sh
# Tests run: 6, failed: 0
```

Resolves #21659

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.9 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-opus-4-7 spent 6h 47m and 19,339 tokens on this with the user in an interactive session.
