### PR TITLE
t3043: per-sub-stage timing + parallel API calls in dedup_check

### DIFF
--- a/.agents/scripts/dispatch-dedup-footprint.sh
+++ b/.agents/scripts/dispatch-dedup-footprint.sh
@@ -130,24 +130,39 @@ _footprint_get_inflight() {
 		return 0
 	fi
 
-	# Cache miss — rebuild
-	# Query for issues with active worker labels
-	local inflight_issues
-	inflight_issues=$(gh issue list --repo "$repo_slug" \
-		--label "status:in-progress" --state open \
-		--json number,body --limit 50 2>/dev/null) || inflight_issues="[]"
+	# Cache miss — rebuild.
+	# t3043: parallelise the 3 gh issue list calls. Previously serial
+	# (3x 5-15s = 15-45s on cold cache); now concurrent via temp files
+	# and background jobs (max(5-15s) ≈ 5-15s — 3x faster on cache miss).
+	local _fp_tmpdir
+	_fp_tmpdir=$(mktemp -d 2>/dev/null) || _fp_tmpdir="/tmp/fp-$$"
+	mkdir -p "$_fp_tmpdir" 2>/dev/null || true
 
-	# Also include status:in-review (worker still running, PR opened)
-	local review_issues
-	review_issues=$(gh issue list --repo "$repo_slug" \
-		--label "status:in-review" --state open \
-		--json number,body --limit 50 2>/dev/null) || review_issues="[]"
+	# Launch all 3 queries in parallel
+	(gh issue list --repo "$repo_slug" --label "status:in-progress" --state open \
+		--json number,body --limit 50 2>/dev/null || echo "[]") >"${_fp_tmpdir}/in-progress.json" &
+	local _fp_pid1=$!
 
-	# Also include status:claimed (just dispatched, worker starting)
-	local claimed_issues
-	claimed_issues=$(gh issue list --repo "$repo_slug" \
-		--label "status:claimed" --state open \
-		--json number,body --limit 50 2>/dev/null) || claimed_issues="[]"
+	(gh issue list --repo "$repo_slug" --label "status:in-review" --state open \
+		--json number,body --limit 50 2>/dev/null || echo "[]") >"${_fp_tmpdir}/in-review.json" &
+	local _fp_pid2=$!
+
+	(gh issue list --repo "$repo_slug" --label "status:claimed" --state open \
+		--json number,body --limit 50 2>/dev/null || echo "[]") >"${_fp_tmpdir}/claimed.json" &
+	local _fp_pid3=$!
+
+	# Wait for all to complete
+	wait "$_fp_pid1" 2>/dev/null || true
+	wait "$_fp_pid2" 2>/dev/null || true
+	wait "$_fp_pid3" 2>/dev/null || true
+
+	local inflight_issues review_issues claimed_issues
+	inflight_issues=$(cat "${_fp_tmpdir}/in-progress.json" 2>/dev/null) || inflight_issues="[]"
+	review_issues=$(cat "${_fp_tmpdir}/in-review.json" 2>/dev/null) || review_issues="[]"
+	claimed_issues=$(cat "${_fp_tmpdir}/claimed.json" 2>/dev/null) || claimed_issues="[]"
+
+	# Cleanup temp files
+	rm -rf "$_fp_tmpdir" 2>/dev/null || true
 
 	# Merge all three lists into one (jq handles dedup by number)
 	local all_inflight

--- a/.agents/scripts/dispatch-dedup-pr.sh
+++ b/.agents/scripts/dispatch-dedup-pr.sh
@@ -249,22 +249,61 @@ has_open_pr() {
 		return 1
 	fi
 
-	# Check 1: open PRs whose commits reference this issue.
-	_has_open_pr_check_open_commits "$issue_number" "$repo_slug" && return 0
+	# t3043: parallelise the 4 sub-checks. Previously serial (4x 3-10s =
+	# 12-40s); now concurrent via temp files and background jobs. The common
+	# case is "no PR evidence" where all 4 checks run — parallelising turns
+	# 12-40s into max(3-10s) ≈ 3-10s (4x faster). When evidence IS found
+	# early, the wasted parallel calls don't affect the critical path (the
+	# candidate is blocked regardless).
+	local _pr_tmpdir
+	_pr_tmpdir=$(mktemp -d 2>/dev/null) || _pr_tmpdir="/tmp/pr-dedup-$$"
+	mkdir -p "$_pr_tmpdir" 2>/dev/null || true
 
-	# Check 1b (t2085): open PRs with closing-keyword in body. Required because
-	# the framework convention writes `Resolves #NNN` in the PR body, not in
-	# commit subjects — so Check 1's commit-subject matcher misses every
-	# routine implementation PR. Without this, Layer 4 dedup is blind to
-	# in-flight work and produces cross-runner duplicate dispatch (the
-	# marcusquinn-vs-alex-solovyev race on issue #18779 → PR #18906).
-	_has_open_pr_check_open_body_keyword "$issue_number" "$repo_slug" && return 0
+	# Launch all 4 checks in parallel, each writing exit code + output to a file
+	(
+		_result=$(_has_open_pr_check_open_commits "$issue_number" "$repo_slug" 2>/dev/null) && \
+			printf '%s' "$_result" >"${_pr_tmpdir}/check1.out" || true
+	) &
+	local _pr_pid1=$!
 
-	# Check 2: merged PRs with closing-keyword in body.
-	_has_open_pr_check_merged_keywords "$issue_number" "$repo_slug" && return 0
+	(
+		_result=$(_has_open_pr_check_open_body_keyword "$issue_number" "$repo_slug" 2>/dev/null) && \
+			printf '%s' "$_result" >"${_pr_tmpdir}/check1b.out" || true
+	) &
+	local _pr_pid2=$!
 
-	# Check 3: task-ID title match on merged PRs (planning-aware).
-	_has_open_pr_check_task_id_title "$issue_number" "$repo_slug" "$issue_title" && return 0
+	(
+		_result=$(_has_open_pr_check_merged_keywords "$issue_number" "$repo_slug" 2>/dev/null) && \
+			printf '%s' "$_result" >"${_pr_tmpdir}/check2.out" || true
+	) &
+	local _pr_pid3=$!
 
+	(
+		_result=$(_has_open_pr_check_task_id_title "$issue_number" "$repo_slug" "$issue_title" 2>/dev/null) && \
+			printf '%s' "$_result" >"${_pr_tmpdir}/check3.out" || true
+	) &
+	local _pr_pid4=$!
+
+	# Wait for all to complete
+	wait "$_pr_pid1" 2>/dev/null || true
+	wait "$_pr_pid2" 2>/dev/null || true
+	wait "$_pr_pid3" 2>/dev/null || true
+	wait "$_pr_pid4" 2>/dev/null || true
+
+	# Check results — any hit means PR evidence exists
+	local _check_file _check_output
+	for _check_file in "${_pr_tmpdir}/check1.out" "${_pr_tmpdir}/check1b.out" \
+		"${_pr_tmpdir}/check2.out" "${_pr_tmpdir}/check3.out"; do
+		if [[ -f "$_check_file" ]]; then
+			_check_output=$(cat "$_check_file" 2>/dev/null) || _check_output=""
+			if [[ -n "$_check_output" ]]; then
+				printf '%s\n' "$_check_output"
+				rm -rf "$_pr_tmpdir" 2>/dev/null || true
+				return 0
+			fi
+		fi
+	done
+
+	rm -rf "$_pr_tmpdir" 2>/dev/null || true
 	return 1
 }

--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -880,6 +880,11 @@ _dispatch_dedup_check_layers() {
 	local repo_path="$6"
 	local issue_meta_json="$7"
 
+	# t3043: per-sub-stage timing inside dedup_check. The outer
+	# dispatch_with_dedup records "dedup_check" as one blob; these
+	# sub-stage records let us identify which gate dominates the 235s avg.
+	local _dss_t0
+
 	local target_state target_title
 	target_state=$(printf '%s' "$issue_meta_json" | jq -r '.state // ""' 2>/dev/null)
 	target_title=$(printf '%s' "$issue_meta_json" | jq -r '.title // ""' 2>/dev/null)
@@ -888,26 +893,34 @@ _dispatch_dedup_check_layers() {
 	# has less than 5 GB available. Prevents cascading failures where workers
 	# create worktrees + node_modules that fill the volume entirely.
 	# Uses $HOME as the reference path (portable; covers Linux /home mounts).
+	_dss_t0=$(_ds_now_ns)
 	local _avail_kb
 	_avail_kb=$(df "$HOME" 2>/dev/null | awk 'NR==2{print $4}')
 	if [[ -n "$_avail_kb" ]] && [[ "$_avail_kb" -lt 5242880 ]]; then
 		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: disk space critical (${_avail_kb}KB avail on \$HOME filesystem, need 5242880KB/5G). Run: worktree-helper.sh clean --auto --force-merged" >>"$LOGFILE"
+		_ds_record "$issue_number" "$repo_slug" "dedup.disk_space" "$_dss_t0"
 		return 1
 	fi
+	_ds_record "$issue_number" "$repo_slug" "dedup.disk_space" "$_dss_t0"
 
 	# GH#18987: Worktree count cap — refuse dispatch when the repo has 200+
 	# registered git worktrees. At that scale, new worktrees risk consuming
 	# tens of GB; stale merged ones should be cleaned before adding more.
+	_dss_t0=$(_ds_now_ns)
 	local _wt_count _wt_max
 	_wt_max="${AIDEVOPS_MAX_WORKTREES:-200}"
 	_wt_count=$(git -C "$repo_path" worktree list 2>/dev/null | wc -l | tr -d ' ')
 	if [[ -n "$_wt_count" ]] && [[ "$_wt_count" -ge "$_wt_max" ]]; then
 		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: worktree count ${_wt_count} >= cap ${_wt_max}. Run: worktree-helper.sh clean --auto --force-merged" >>"$LOGFILE"
+		_ds_record "$issue_number" "$repo_slug" "dedup.worktree_cap" "$_dss_t0"
 		return 1
 	fi
+	_ds_record "$issue_number" "$repo_slug" "dedup.worktree_cap" "$_dss_t0"
 
+	_dss_t0=$(_ds_now_ns)
 	if [[ "$target_state" != "OPEN" ]]; then
 		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: issue state is ${target_state:-unknown}" >>"$LOGFILE"
+		_ds_record "$issue_number" "$repo_slug" "dedup.state_check" "$_dss_t0"
 		return 1
 	fi
 
@@ -921,6 +934,7 @@ _dispatch_dedup_check_layers() {
 	# the label being continuously present.
 	if printf '%s' "$issue_meta_json" | jq -e '.labels | map(.name) | (index("supervisor") or index("contributor") or index("persistent") or index("quality-review") or index("on hold") or index("blocked") or index("parent-task") or index("meta"))' >/dev/null 2>&1; then
 		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: non-dispatchable management label present" >>"$LOGFILE"
+		_ds_record "$issue_number" "$repo_slug" "dedup.mgmt_label" "$_dss_t0"
 		return 1
 	fi
 
@@ -929,14 +943,19 @@ _dispatch_dedup_check_layers() {
 	# dedup layers) catches these before the more expensive eligibility check fires.
 	if printf '%s' "$issue_meta_json" | jq -e '.labels | map(.name) | (index("status:done") or index("status:resolved"))' >/dev/null 2>&1; then
 		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: status:done or status:resolved label present (t2424)" >>"$LOGFILE"
+		_ds_record "$issue_number" "$repo_slug" "dedup.label_checks" "$_dss_t0"
 		return 1
 	fi
+	_ds_record "$issue_number" "$repo_slug" "dedup.label_checks" "$_dss_t0"
 
 	# t1894/GH#18648: Cryptographic approval gate (ever-NMR) with
 	# review-followup exemption for bot-generated cleanup issues.
+	_dss_t0=$(_ds_now_ns)
 	if _check_nmr_approval_gate "$issue_number" "$repo_slug" "$issue_meta_json"; then
+		_ds_record "$issue_number" "$repo_slug" "dedup.nmr_gate" "$_dss_t0"
 		return 1
 	fi
+	_ds_record "$issue_number" "$repo_slug" "dedup.nmr_gate" "$_dss_t0"
 
 	if [[ "$target_title" == \[Supervisor:* ]]; then
 		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: supervisor telemetry title" >>"$LOGFILE"
@@ -954,12 +973,15 @@ _dispatch_dedup_check_layers() {
 	# canonical gh call); extract once and reuse for the consolidation,
 	# large-file, and footprint gates below — eliminating 1-2 extra gh calls
 	# per dispatch candidate.
+	_dss_t0=$(_ds_now_ns)
 	local _dispatch_issue_body
 	_dispatch_issue_body=$(printf '%s' "$issue_meta_json" | jq -r '.body // ""' 2>/dev/null) || _dispatch_issue_body=""
 	if [[ -n "$_dispatch_issue_body" ]] && is_blocked_by_unresolved "$_dispatch_issue_body" "$repo_slug" "$issue_number"; then
 		echo "[dispatch_with_dedup] Dispatch blocked for #${issue_number} in ${repo_slug}: unresolved blocked-by dependency (t1927)" >>"$LOGFILE"
+		_ds_record "$issue_number" "$repo_slug" "dedup.blocked_by" "$_dss_t0"
 		return 1
 	fi
+	_ds_record "$issue_number" "$repo_slug" "dedup.blocked_by" "$_dss_t0"
 
 	# Pre-dispatch: issue consolidation check. If an issue has accumulated
 	# multiple substantive comments that change scope (not dispatch/approval
@@ -968,11 +990,14 @@ _dispatch_dedup_check_layers() {
 	# tokens reconstructing scope from comment archaeology.
 	# t2996: pass meta_json through so the consolidation helper skips its
 	# `gh issue view --json labels` call (label CSV derived from JSON instead).
+	_dss_t0=$(_ds_now_ns)
 	if _issue_needs_consolidation "$issue_number" "$repo_slug" "$issue_meta_json"; then
 		_dispatch_issue_consolidation "$issue_number" "$repo_slug" "$repo_path"
 		echo "[dispatch_with_dedup] Dispatch deferred for #${issue_number} in ${repo_slug}: issue needs comment consolidation" >>"$LOGFILE"
+		_ds_record "$issue_number" "$repo_slug" "dedup.consolidation" "$_dss_t0"
 		return 1
 	fi
+	_ds_record "$issue_number" "$repo_slug" "dedup.consolidation" "$_dss_t0"
 
 	# Pre-dispatch: large-file simplification gate. If the issue body
 	# references files that exceed LARGE_FILE_LINE_THRESHOLD, create a
@@ -980,21 +1005,27 @@ _dispatch_dedup_check_layers() {
 	# shouldn't pay the complexity tax of navigating a 12,000-line file.
 	# t2996: pass meta_json through so the gate skips its `gh issue view --json
 	# labels` AND `--json title` calls (both derived from the bundled JSON).
+	_dss_t0=$(_ds_now_ns)
 	if _issue_targets_large_files "$issue_number" "$repo_slug" "$_dispatch_issue_body" "$repo_path" "false" "$issue_meta_json"; then
 		echo "[dispatch_with_dedup] Dispatch deferred for #${issue_number} in ${repo_slug}: targets large file(s), simplification gate" >>"$LOGFILE"
+		_ds_record "$issue_number" "$repo_slug" "dedup.large_file" "$_dss_t0"
 		return 1
 	fi
+	_ds_record "$issue_number" "$repo_slug" "dedup.large_file" "$_dss_t0"
 
 	# t2117/GH#19109: File-footprint overlap throttle. If another in-flight
 	# worker is already modifying the same files, defer this dispatch to
 	# prevent CONFLICTING cascades. The check is cheap (cached per repo per
 	# cycle) and decays naturally when the blocking issue's status labels clear.
+	_dss_t0=$(_ds_now_ns)
 	local _footprint_signal=""
 	_footprint_signal=$(_footprint_check_overlap "$issue_number" "$repo_slug" "$_dispatch_issue_body" 2>/dev/null) || true
 	if [[ -n "$_footprint_signal" ]]; then
 		echo "[dispatch_with_dedup] (t2117) Dispatch deferred for #${issue_number} in ${repo_slug}: ${_footprint_signal}" >>"$LOGFILE"
+		_ds_record "$issue_number" "$repo_slug" "dedup.footprint" "$_dss_t0"
 		return 1
 	fi
+	_ds_record "$issue_number" "$repo_slug" "dedup.footprint" "$_dss_t0"
 
 	# All 7 dedup layers — cannot be skipped.
 	# t2996: ISSUE_META_JSON forwards the canonical bundle to
@@ -1004,13 +1035,16 @@ _dispatch_dedup_check_layers() {
 	# `gh issue view --json labels,assignees` call when present. Without this
 	# export, those layers re-fetch the same JSON we just bundled — wasting
 	# 1-2 more gh calls under load.
+	_dss_t0=$(_ds_now_ns)
 	local _dedup_rc=0
 	ISSUE_META_JSON="$issue_meta_json" \
 		check_dispatch_dedup "$issue_number" "$repo_slug" "$dispatch_title" "$issue_title" "$self_login" || _dedup_rc=$?
 	if [[ "$_dedup_rc" -eq 0 ]]; then
 		echo "[dispatch_with_dedup] Dedup guard blocked #${issue_number} in ${repo_slug}" >>"$LOGFILE"
+		_ds_record "$issue_number" "$repo_slug" "dedup.7_layers" "$_dss_t0"
 		return 1
 	fi
+	_ds_record "$issue_number" "$repo_slug" "dedup.7_layers" "$_dss_t0"
 
 	return 0
 }


### PR DESCRIPTION
## Summary

Resolves #21659

Three changes to bring `dedup_check` from ~235s avg toward <60s:

### 1. Per-sub-stage instrumentation (`pulse-dispatch-core.sh`)

Added `_ds_record` timing around each sub-check inside `_dispatch_dedup_check_layers`. Records 11 sub-stage names to `dispatch-stages.tsv`:

- `dedup.disk_space`, `dedup.worktree_cap`, `dedup.state_check`
- `dedup.mgmt_label`, `dedup.label_checks`
- `dedup.nmr_gate`, `dedup.blocked_by`
- `dedup.consolidation`, `dedup.large_file`
- `dedup.footprint`, `dedup.7_layers`

Future hot-spot investigations can now locate the dominant sub-stage in one `dispatch-stage-instrument.sh report` query.

### 2. Parallel footprint overlap API calls (`dispatch-dedup-footprint.sh`)

The 3 serial `gh issue list` calls (`status:in-progress`, `status:in-review`, `status:claimed`) now run concurrently via background jobs + temp files.

- **Before:** 3x 5-15s = 15-45s serial on cold cache
- **After:** max(5-15s) = 5-15s parallel (3x faster)

### 3. Parallel PR evidence checks (`dispatch-dedup-pr.sh`)

The 4 serial `gh pr list` calls in `has_open_pr` (Layer 4) now run concurrently.

- **Before:** 4x 3-10s = 12-40s serial
- **After:** max(3-10s) = 3-10s parallel (4x faster)

### Combined impact

~27-85s eliminated from the critical path (candidate that passes all checks). Together with footprint's existing 30s TTL cache (amortised across candidates per cycle), total `dedup_check` should drop from ~235s to ~40-70s for the first candidate and <10s for subsequent candidates.

## Testing

- All 7 existing dispatch tests pass (45 total test cases, 0 failures)
- ShellCheck clean on all 3 modified files

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.9 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-opus-4-6 spent 16m and 42,407 tokens on this as a headless worker.