### PR TITLE
t3030: fix 7 pulse-merge regression tests broken by sub-module split

### DIFF
--- a/.agents/scripts/tests/test-pulse-merge-admin-safety-check.sh
+++ b/.agents/scripts/tests/test-pulse-merge-admin-safety-check.sh
@@ -25,7 +25,12 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+# _extract_linked_issue still lives in pulse-merge.sh; the three other
+# helpers (_external_pr_has_linked_issue, _external_pr_linked_issue_crypto_approved,
+# _pulse_merge_admin_safety_check) were moved to pulse-merge-gates.sh by
+# GH#21595, t3030.
 MERGE_SCRIPT="${SCRIPT_DIR}/../pulse-merge.sh"
+GATES_SCRIPT="${SCRIPT_DIR}/../pulse-merge-gates.sh"
 
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
@@ -131,24 +136,35 @@ teardown_test_env() {
 	return 0
 }
 
-# Extract the function under test plus its delegates from pulse-merge.sh.
-# The function calls _external_pr_has_linked_issue and
-# _external_pr_linked_issue_crypto_approved, which themselves call
-# _extract_linked_issue. All four are pure functions — no module-level state.
+# Extract the function under test plus its delegates. After GH#21595, the
+# functions live in two modules:
+#   - _extract_linked_issue                       → pulse-merge.sh ($MERGE_SCRIPT)
+#   - _external_pr_has_linked_issue              → pulse-merge-gates.sh ($GATES_SCRIPT)
+#   - _external_pr_linked_issue_crypto_approved  → pulse-merge-gates.sh ($GATES_SCRIPT)
+#   - _pulse_merge_admin_safety_check            → pulse-merge-gates.sh ($GATES_SCRIPT)
+# All four are pure functions — no module-level state.
 define_helpers_under_test() {
-	local src
-	src=$(awk '
+	local merge_src gates_src
+	merge_src=$(awk '
 		/^_extract_linked_issue\(\) \{/,/^}$/ { print }
+	' "$MERGE_SCRIPT")
+	gates_src=$(awk '
 		/^_external_pr_has_linked_issue\(\) \{/,/^}$/ { print }
 		/^_external_pr_linked_issue_crypto_approved\(\) \{/,/^}$/ { print }
 		/^_pulse_merge_admin_safety_check\(\) \{/,/^}$/ { print }
-	' "$MERGE_SCRIPT")
-	if [[ -z "$src" ]]; then
-		printf 'ERROR: could not extract helpers from %s\n' "$MERGE_SCRIPT" >&2
+	' "$GATES_SCRIPT")
+	if [[ -z "$merge_src" ]]; then
+		printf 'ERROR: could not extract _extract_linked_issue from %s\n' "$MERGE_SCRIPT" >&2
+		return 1
+	fi
+	if [[ -z "$gates_src" ]]; then
+		printf 'ERROR: could not extract gates helpers from %s\n' "$GATES_SCRIPT" >&2
 		return 1
 	fi
 	# shellcheck disable=SC1090
-	eval "$src"
+	eval "$merge_src"
+	# shellcheck disable=SC1090
+	eval "$gates_src"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-pulse-merge-coderabbit-nits-ok.sh
+++ b/.agents/scripts/tests/test-pulse-merge-coderabbit-nits-ok.sh
@@ -16,7 +16,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
-MERGE_SCRIPT="${SCRIPT_DIR}/../pulse-merge.sh"
+# _pulse_merge_dismiss_coderabbit_nits was moved to pulse-merge-process.sh
+# (GH#21595, t3030).
+MERGE_SCRIPT="${SCRIPT_DIR}/../pulse-merge-process.sh"
 
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'

--- a/.agents/scripts/tests/test-pulse-merge-parent-task-close-guard.sh
+++ b/.agents/scripts/tests/test-pulse-merge-parent-task-close-guard.sh
@@ -89,10 +89,23 @@ exit 0
 EOF
 	chmod +x "${TEST_ROOT}/bin/gh"
 
-	# Stub external helpers the function calls
+	# Stub external helpers the function calls. _release_interactive_claim_on_merge
+	# lives in shared-claim-lifecycle.sh (added to the call chain by t2413, and now
+	# unguarded — no `|| true` — so the test must stub it explicitly).
+	# auto_file_next_phase has `|| true` and invalidate_footprint_cache_for_issue
+	# is gated on `declare -F`, so neither needs stubbing.
 	unlock_issue_after_worker() { return 0; }
 	fast_fail_reset() { return 0; }
-	export -f unlock_issue_after_worker fast_fail_reset 2>/dev/null || true
+	_release_interactive_claim_on_merge() { return 0; }
+	export -f unlock_issue_after_worker fast_fail_reset _release_interactive_claim_on_merge 2>/dev/null || true
+
+	# Shim shared-gh-wrappers.sh wrappers → gh binary stub. The function was
+	# refactored post-GH#21595 to use gh_pr_comment / gh_issue_comment instead
+	# of `gh pr comment` / `gh issue comment` directly. Without these shims,
+	# wrapper calls vanish into "command not found" and never reach $GH_CALL_LOG.
+	gh_pr_comment() { gh pr comment "$@"; }
+	gh_issue_comment() { gh issue comment "$@"; }
+	export -f gh_pr_comment gh_issue_comment 2>/dev/null || true
 
 	# gh-signature-helper.sh is invoked via $_sig_helper — stub it to empty.
 	export AGENTS_DIR="${TEST_ROOT}"
@@ -115,10 +128,15 @@ teardown_test_env() {
 	return 0
 }
 
-# Extract the function under test from pulse-merge.sh and eval it.
+# Extract the function under test (and its _pm_issue_api dependency, also
+# in pulse-merge.sh) and eval them. _pm_issue_api is the module-level helper
+# that _handle_post_merge_actions calls to fetch issue metadata; without it
+# the eval'd function fails with "_pm_issue_api: command not found"
+# (post-GH#21595 helper introduction, t3030).
 define_function_under_test() {
 	local fn_src
 	fn_src=$(awk '
+		/^_pm_issue_api\(\) \{/,/^}$/ { print }
 		/^_handle_post_merge_actions\(\) \{/,/^}$/ { print }
 	' "$MERGE_SCRIPT")
 	if [[ -z "$fn_src" ]]; then

--- a/.agents/scripts/tests/test-pulse-merge-phantom-pending-checks.sh
+++ b/.agents/scripts/tests/test-pulse-merge-phantom-pending-checks.sh
@@ -40,7 +40,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
-MERGE_SCRIPT="${SCRIPT_DIR}/../pulse-merge.sh"
+# _check_required_checks_passing was moved to pulse-merge-process.sh
+# (GH#21595, t3030).
+MERGE_SCRIPT="${SCRIPT_DIR}/../pulse-merge-process.sh"
 
 readonly TEST_RED=$'\033[0;31m'
 readonly TEST_GREEN=$'\033[0;32m'

--- a/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
+++ b/.agents/scripts/tests/test-pulse-merge-required-checks-filter.sh
@@ -28,7 +28,9 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
-MERGE_SCRIPT="${SCRIPT_DIR}/../pulse-merge.sh"
+# _pr_required_checks_pass was moved to pulse-merge-process.sh
+# (GH#21595, t3030).
+MERGE_SCRIPT="${SCRIPT_DIR}/../pulse-merge-process.sh"
 
 readonly TEST_RED=$'\033[0;31m'
 readonly TEST_GREEN=$'\033[0;32m'

--- a/.agents/scripts/tests/test-pulse-merge-retarget-stacked.sh
+++ b/.agents/scripts/tests/test-pulse-merge-retarget-stacked.sh
@@ -24,7 +24,11 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+# _retarget_stacked_children was moved to pulse-merge-process.sh (GH#21595, t3030).
+# _process_single_ready_pr stays in pulse-merge.sh — the static check below
+# (test_retarget_called_before_merge) reads it from $MERGE_SCRIPT.
 MERGE_SCRIPT="${SCRIPT_DIR}/../pulse-merge.sh"
+PROCESS_SCRIPT="${SCRIPT_DIR}/../pulse-merge-process.sh"
 
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
@@ -63,6 +67,12 @@ setup_test_env() {
 	LAST_GH_ARGS_FILE="${TEST_ROOT}/gh-args.log"
 	export LAST_GH_ARGS_FILE
 	: >"$LAST_GH_ARGS_FILE"
+
+	# Shim gh_pr_list (from shared-gh-wrappers.sh) → forward to the gh stub.
+	# _retarget_stacked_children was refactored to use the wrapper post-GH#21595
+	# so the test must surface the same args through the gh-args.log path.
+	gh_pr_list() { gh pr list "$@"; }
+	export -f gh_pr_list 2>/dev/null || true
 	return 0
 }
 
@@ -136,14 +146,15 @@ STUB_EOF
 	return 0
 }
 
-# Extract `_retarget_stacked_children` from pulse-merge.sh and eval it.
+# Extract `_retarget_stacked_children` from pulse-merge-process.sh (post-GH#21595)
+# and eval it.
 define_helper_under_test() {
 	local helper_src
 	helper_src=$(awk '
 		/^_retarget_stacked_children\(\) \{/,/^}$/ { print }
-	' "$MERGE_SCRIPT")
+	' "$PROCESS_SCRIPT")
 	if [[ -z "$helper_src" ]]; then
-		printf 'ERROR: could not extract _retarget_stacked_children from %s\n' "$MERGE_SCRIPT" >&2
+		printf 'ERROR: could not extract _retarget_stacked_children from %s\n' "$PROCESS_SCRIPT" >&2
 		return 1
 	fi
 	# shellcheck disable=SC1090

--- a/.agents/scripts/tests/test-pulse-merge-update-branch.sh
+++ b/.agents/scripts/tests/test-pulse-merge-update-branch.sh
@@ -18,7 +18,12 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+# _attempt_pr_update_branch was moved to pulse-merge-process.sh (GH#21595, t3030).
+# _process_single_ready_pr stays in pulse-merge.sh — the static checks below
+# (test_nmr_guard_exists_before_close, test_mergeable_refetch_after_update_branch)
+# read it from $MERGE_SCRIPT.
 MERGE_SCRIPT="${SCRIPT_DIR}/../pulse-merge.sh"
+PROCESS_SCRIPT="${SCRIPT_DIR}/../pulse-merge-process.sh"
 
 readonly TEST_RED='\033[0;31m'
 readonly TEST_GREEN='\033[0;32m'
@@ -84,16 +89,16 @@ EOF
 	return 0
 }
 
-# Extract `_attempt_pr_update_branch` from pulse-merge.sh and eval it into
-# the test shell. Matches the define_helper_under_test pattern used by
-# test-pulse-merge-rebase-nudge.sh.
+# Extract `_attempt_pr_update_branch` from pulse-merge-process.sh (post-GH#21595)
+# and eval it into the test shell. Matches the define_helper_under_test
+# pattern used by test-pulse-merge-rebase-nudge.sh.
 define_helper_under_test() {
 	local helper_src
 	helper_src=$(awk '
 		/^_attempt_pr_update_branch\(\) \{/,/^}$/ { print }
-	' "$MERGE_SCRIPT")
+	' "$PROCESS_SCRIPT")
 	if [[ -z "$helper_src" ]]; then
-		printf 'ERROR: could not extract _attempt_pr_update_branch from %s\n' "$MERGE_SCRIPT" >&2
+		printf 'ERROR: could not extract _attempt_pr_update_branch from %s\n' "$PROCESS_SCRIPT" >&2
 		return 1
 	fi
 	# shellcheck disable=SC1090


### PR DESCRIPTION
## Summary

PR #21595 split `pulse-merge.sh` into `pulse-merge-gates.sh` and `pulse-merge-process.sh`. The regression-guard tests still pointed `MERGE_SCRIPT` at `pulse-merge.sh`, so awk-extraction of moved helpers returned empty and the tests failed FATAL. Framework Validation CI red on main since 2026-04-28.

This recovers PR #21607 (closed with conflicts) — main already absorbed the `approve-collaborator-guard` fix, so this PR ships the remaining **7** test fixes.

## Function-to-module mapping

- `pulse-merge-gates.sh`: `_pulse_merge_admin_safety_check`, `_external_pr_has_linked_issue`, `_external_pr_linked_issue_crypto_approved`, `approve_collaborator_pr`
- `pulse-merge-process.sh`: `_pulse_merge_dismiss_coderabbit_nits`, `_check_required_checks_passing`, `_pr_required_checks_pass`, `_retarget_stacked_children`, `_attempt_pr_update_branch`
- `pulse-merge.sh` (still): `_extract_linked_issue`, `_handle_post_merge_actions`, `_pm_issue_api`, `_process_single_ready_pr`

## Per-file changes

| Test | Fix |
|------|-----|
| `test-pulse-merge-coderabbit-nits-ok.sh` | `MERGE_SCRIPT` → `pulse-merge-process.sh` |
| `test-pulse-merge-phantom-pending-checks.sh` | `MERGE_SCRIPT` → `pulse-merge-process.sh` |
| `test-pulse-merge-required-checks-filter.sh` | `MERGE_SCRIPT` → `pulse-merge-process.sh` |
| `test-pulse-merge-admin-safety-check.sh` | Split extraction: `MERGE_SCRIPT` for `_extract_linked_issue`, new `GATES_SCRIPT` for the three gates helpers |
| `test-pulse-merge-retarget-stacked.sh` | Keep `MERGE_SCRIPT` for static checks on `_process_single_ready_pr`; add `PROCESS_SCRIPT` for `_retarget_stacked_children`; shim `gh_pr_list` → `gh` binary stub |
| `test-pulse-merge-update-branch.sh` | Keep `MERGE_SCRIPT` for static checks; add `PROCESS_SCRIPT` for `_attempt_pr_update_branch` |
| `test-pulse-merge-parent-task-close-guard.sh` | Extend awk extraction to include `_pm_issue_api` (callee dependency post-split); stub `_release_interactive_claim_on_merge`; shim `gh_pr_comment` / `gh_issue_comment` |

## Testing

All 8 regression-guard tests run locally — **66 cases pass, 0 fail**:

| Test | Result |
|---|---|
| admin-safety-check | 6/6 |
| approve-collaborator-guard | 4/4 |
| coderabbit-nits-ok | 4/4 |
| parent-task-close-guard | 7/7 |
| phantom-pending-checks | 18/18 |
| required-checks-filter | 16/16 |
| retarget-stacked | 6/6 |
| update-branch | 5/5 |

`shellcheck` clean on all 7 modified files.

## Note on issue scope

The original issue body describes a singleton-invariant bug ("4-37 pulse instances"). The conflict-feedback section reroutes us to the test-fix work that PR #21607 attempted. The singleton false-positive count was already addressed by t3013 / fe5187041 (`_pulse_pids` PPID filter), which landed 2026-04-29 02:23Z — after this issue was filed at 2026-04-28 23:47Z. Whether genuine multi-instance still occurs is a separate observation that would warrant a fresh issue with post-t3013 evidence.

Resolves #21599
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-opus-4-7 spent 5m and 13,878 tokens on this as a headless worker.