### PR TITLE
t2880: feat(setup-debt): detect cross-account secrets:inherit in issue-sync.yml

### DIFF
--- a/.agents/scripts/commands/setup-git.md
+++ b/.agents/scripts/commands/setup-git.md
@@ -24,6 +24,7 @@ gate refuses to merge worker PRs.
 **Use `/setup-git` when**:
 
 - The toast shows `[WARN] N repos need SYNC_PAT setup`
+- The toast shows `[WARN] N repos need workflow re-sync` (cross-account secrets:inherit)
 - A worker PR sits BLOCKED with all-green CI
 - You just registered a new repo via `aidevops init` or hand-edited `repos.json`
 - You're onboarding a new operator and want every active repo's secrets right
@@ -66,10 +67,11 @@ Run the aggregator and present the result:
 ~/.aidevops/agents/scripts/setup-debt-helper.sh summary --format=human
 ```
 
-Then list the affected repos:
+Then list both debt classes:
 
 ```bash
 ~/.aidevops/agents/scripts/setup-debt-helper.sh list-sync-pat-missing
+~/.aidevops/agents/scripts/setup-debt-helper.sh list-cross-account-inherit
 ```
 
 For each slug, also fetch the platform from `~/.config/aidevops/repos.json`
@@ -81,6 +83,38 @@ jq -r --arg slug "$SLUG" '.initialized_repos[] | select(.slug == $slug) | .platf
 
 If `setup-debt-helper.sh summary` returns empty, congratulate the operator
 and exit — there is nothing to do.
+
+### Phase 1.5 — Cross-Account secrets:inherit Remediation (t2880)
+
+For each repo returned by `list-cross-account-inherit`, present this template:
+
+```text
+=== Repo: <SLUG> — workflow re-sync needed ===
+
+Why this matters: your .github/workflows/issue-sync.yml was installed before
+#20976 fixed the canonical caller template. It uses `secrets: inherit` instead
+of an explicit SYNC_PAT mapping. GitHub only propagates secrets:inherit within
+the same org/enterprise — callers from a different account receive no secrets,
+so issue-sync silently fails.
+
+Fix (one command — run in a separate terminal):
+
+  aidevops sync-workflows --apply --repo <SLUG>
+
+This replaces the secrets:inherit line in issue-sync.yml with the explicit
+mapping from the updated template and opens a PR in <SLUG> to apply the change.
+
+After the PR merges, verify:
+
+  aidevops check-workflows --repo <SLUG>
+
+The workflow should be classified as CURRENT/CALLER with no drift.
+
+Dismiss without re-syncing (e.g., intentional fork with own secrets):
+  aidevops security dismiss cross-account-inherit-<SLUG_SAFE>
+```
+
+After the operator confirms the re-sync PR is merged, move on.
 
 ### Phase 2 — Per-Repo Walkthrough
 
@@ -192,11 +226,13 @@ walkthrough.
 
 - `aidevops/onboarding.md` — per-account auth (the `/onboarding` command)
 - `reference/sync-pat-platforms.md` — PAT URL templates and scopes per platform
+- `reference/reusable-workflows.md` — cross-account secrets architecture and caller template
 - `prompts/build.txt` "Security Rules" — secret handling principles
 - `tools/credentials/gopass.md` — preferred secret store for AIDEVOPS env vars
 - t2449 (auto-merge.md) — why SYNC_PAT matters for worker auto-merge
 - t2374 (auto-dispatch.md) — original SYNC_PAT advisory infrastructure
 - t2806 / GH#20745 — rulesets-protected repo detection (sibling fix)
+- t2880 / GH#20981 — cross-account secrets:inherit detection (this command's Phase 1.5)
 
 ## Related issues
 

--- a/.agents/scripts/security-posture-helper-repo.sh
+++ b/.agents/scripts/security-posture-helper-repo.sh
@@ -787,6 +787,158 @@ check_sync_pat() {
 	return 0
 }
 
+# Phase 8: Cross-account secrets:inherit detection helpers (t2880)
+
+# Detect whether a repo's issue-sync.yml uses the cross-account secrets:inherit
+# pattern — i.e., it calls the marcusquinn/aidevops reusable workflow AND relies
+# on secrets:inherit rather than mapping SYNC_PAT explicitly.
+#
+# GitHub policy: secrets:inherit only propagates within the same org/enterprise.
+# A caller in a different org will silently receive no secrets, causing
+# issue-sync to fail with insufficient permissions.
+#
+# Usage: _detect_cross_account_inherit <slug>
+# Returns:
+#   0 — broken pattern detected (caller + secrets:inherit present)
+#   1 — not broken (explicit mapping, OR not a marcusquinn/aidevops caller)
+#   2 — file missing or unfetchable (skip silently)
+_detect_cross_account_inherit() {
+	local slug="$1"
+
+	local workflow_content
+	workflow_content=$(gh api "repos/${slug}/contents/.github/workflows/issue-sync.yml" \
+		--jq '.content' 2>/dev/null) || return 2
+
+	if [[ -z "$workflow_content" ]]; then
+		return 2
+	fi
+
+	local decoded
+	decoded=$(printf '%s' "$workflow_content" | base64 -d 2>/dev/null) || return 2
+
+	# Must be a marcusquinn/aidevops reusable-workflow caller
+	if ! printf '%s' "$decoded" | grep -q 'uses:.*marcusquinn/aidevops/'; then
+		return 1
+	fi
+
+	# Must use secrets:inherit (the broken cross-account pattern)
+	if ! printf '%s' "$decoded" | grep -q 'secrets:[[:space:]]*inherit'; then
+		return 1
+	fi
+
+	return 0
+}
+
+# Emit a cross-account-inherit advisory file for a repo that uses secrets:inherit.
+# Usage: _emit_cross_account_inherit_advisory <slug> <slug_sanitised>
+_emit_cross_account_inherit_advisory() {
+	local slug="$1"
+	local slug_sanitised="$2"
+
+	local advisory_dir="$HOME/.aidevops/advisories"
+	local advisory_file="$advisory_dir/cross-account-inherit-${slug_sanitised}.advisory"
+
+	mkdir -p "$advisory_dir"
+
+	cat >"$advisory_file" <<ADVISORY_EOF
+[ADVISORY] Cross-account secrets:inherit detected for ${slug}
+
+This repo's .github/workflows/issue-sync.yml calls the marcusquinn/aidevops
+reusable workflow with \`secrets: inherit\` instead of an explicit
+\`secrets: SYNC_PAT: \${{ secrets.SYNC_PAT }}\` mapping.
+
+GitHub only propagates secrets:inherit within the same org/enterprise. Callers
+from a different account (org or personal) silently receive no secrets — so
+issue-sync will fail with permission errors on every run without any obvious
+error message pointing at this root cause.
+
+The fix is to re-sync the workflow from the updated canonical template:
+
+  aidevops sync-workflows --apply --repo ${slug}
+
+This replaces the secrets:inherit line with the explicit SYNC_PAT mapping that
+works across org/account boundaries (fix landed in #20976).
+
+For a guided walkthrough across all affected repos, run \`/setup-git\` in
+your AI assistant (OpenCode or Claude Code).
+
+Dismiss once fixed:
+  aidevops security dismiss cross-account-inherit-${slug_sanitised}
+
+See reference/reusable-workflows.md for the cross-account secrets architecture.
+ADVISORY_EOF
+
+	print_info "  Advisory written to: $advisory_file"
+	return 0
+}
+
+# Phase 8: Check for cross-account secrets:inherit in issue-sync.yml (t2880)
+# For each repo using the marcusquinn/aidevops reusable workflow with
+# secrets:inherit, emits a cross-account-inherit advisory so setup-debt-helper.sh
+# can surface it in the toast and /setup-git can walk the operator through the fix.
+check_cross_account_inherit() {
+	local repo_path="$1"
+
+	print_header "Phase 8: Cross-Account secrets:inherit Detection (t2880)"
+
+	if ! command -v gh &>/dev/null; then
+		print_skip "GitHub CLI (gh) not installed — cannot check cross-account inherit"
+		add_finding "$SEVERITY_INFO" "$CAT_SYNC_PAT" "gh CLI not available (cross-account check)"
+		return 0
+	fi
+
+	if ! gh auth status &>/dev/null 2>&1; then
+		print_skip "gh not authenticated — cross-account inherit check skipped"
+		add_finding "$SEVERITY_INFO" "$CAT_SYNC_PAT" "gh not authenticated (cross-account check)"
+		return 0
+	fi
+
+	local slug
+	if ! slug=$(resolve_slug "$repo_path"); then
+		print_skip "No GitHub remote — cross-account inherit check skipped"
+		add_finding "$SEVERITY_INFO" "$CAT_SYNC_PAT" "No GitHub remote (cross-account check)"
+		return 0
+	fi
+
+	local slug_sanitised
+	slug_sanitised="${slug//\//-}"
+
+	local advisory_dir="$HOME/.aidevops/advisories"
+	local dismissed_file="$advisory_dir/dismissed.txt"
+
+	# If already dismissed, skip silently
+	local adv_id="cross-account-inherit-${slug_sanitised}"
+	if [[ -f "$dismissed_file" ]] && grep -qxF "$adv_id" "$dismissed_file" 2>/dev/null; then
+		print_pass "cross-account-inherit advisory dismissed for $slug"
+		add_finding "$SEVERITY_PASS" "$CAT_SYNC_PAT" "cross-account-inherit advisory dismissed for $slug"
+		return 0
+	fi
+
+	local detect_result=0
+	_detect_cross_account_inherit "$slug" || detect_result=$?
+
+	case "$detect_result" in
+	0)
+		# Broken pattern detected
+		print_warn "Cross-account secrets:inherit detected for $slug — run: aidevops sync-workflows --apply --repo $slug"
+		add_finding "$SEVERITY_WARNING" "$CAT_SYNC_PAT" "Cross-account secrets:inherit in issue-sync.yml for $slug"
+		_emit_cross_account_inherit_advisory "$slug" "$slug_sanitised"
+		;;
+	1)
+		# Not broken
+		print_pass "issue-sync.yml cross-account pattern OK for $slug"
+		add_finding "$SEVERITY_PASS" "$CAT_SYNC_PAT" "issue-sync.yml cross-account pattern OK for $slug"
+		;;
+	2)
+		# Missing / unfetchable — skip silently
+		print_skip "issue-sync.yml not found for $slug — cross-account inherit check skipped"
+		add_finding "$SEVERITY_INFO" "$CAT_SYNC_PAT" "issue-sync.yml missing for $slug"
+		;;
+	esac
+
+	return 0
+}
+
 # Store security posture in .aidevops.json
 store_posture() {
 	local repo_path="$1"
@@ -934,6 +1086,7 @@ run_all_checks() {
 	check_collaborators "$repo_path"
 	check_repo_security "$repo_path"
 	check_sync_pat "$repo_path"
+	check_cross_account_inherit "$repo_path"
 	print_report
 
 	return 0

--- a/.agents/scripts/setup-debt-helper.sh
+++ b/.agents/scripts/setup-debt-helper.sh
@@ -178,6 +178,91 @@ _collect_cross_account_slugs() {
 # Subcommand: summary
 # -----------------------------------------------------------------------------
 
+# _fmt_slug_list: render comma-separated slug list capped at 3, with "+N more".
+# Args: $1 = newline-separated slug list, $2 = count
+_fmt_slug_list() {
+	local slugs="$1"
+	local count="$2"
+	local list
+	list="$(printf '%s\n' "$slugs" | head -3 | tr '\n' ',' | sed 's/,$//;s/,/, /g')"
+	if [[ "$count" -gt 3 ]]; then
+		list="${list}, +$((count - 3)) more"
+	fi
+	printf '%s' "$list"
+	return 0
+}
+
+# _summary_human: emit human-readable lines for both debt classes.
+_summary_human() {
+	local slugs="$1" count="$2" ca_slugs="$3" ca_count="$4"
+	[[ "$count" -eq 0 && "$ca_count" -eq 0 ]] && return 0
+	if [[ "$count" -gt 0 ]]; then
+		local slug_list
+		slug_list="$(_fmt_slug_list "$slugs" "$count")"
+		printf '%d SYNC_PAT advisor%s (%s)\n' \
+			"$count" "$([[ "$count" -eq 1 ]] && echo "y" || echo "ies")" "$slug_list"
+	fi
+	if [[ "$ca_count" -gt 0 ]]; then
+		local ca_list
+		ca_list="$(_fmt_slug_list "$ca_slugs" "$ca_count")"
+		printf '%d cross-account-inherit advisor%s (%s)\n' \
+			"$ca_count" "$([[ "$ca_count" -eq 1 ]] && echo "y" || echo "ies")" "$ca_list"
+	fi
+	return 0
+}
+
+# _summary_toast: emit [WARN] lines for both debt classes.
+_summary_toast() {
+	local count="$1" ca_count="$2"
+	[[ "$count" -eq 0 && "$ca_count" -eq 0 ]] && return 0
+	# Each non-zero class emits its own [WARN] line so greeting.mjs
+	# classifyLines buckets each into the warning tier independently.
+	if [[ "$count" -gt 0 ]]; then
+		if [[ "$count" -eq 1 ]]; then
+			printf '[WARN] 1 repo needs SYNC_PAT setup — run /setup-git in OpenCode or Claude Code\n'
+		else
+			printf '[WARN] %d repos need SYNC_PAT setup — run /setup-git in OpenCode or Claude Code\n' "$count"
+		fi
+	fi
+	if [[ "$ca_count" -gt 0 ]]; then
+		if [[ "$ca_count" -eq 1 ]]; then
+			printf '[WARN] 1 repo needs workflow re-sync — run /setup-git in OpenCode or Claude Code\n'
+		else
+			printf '[WARN] %d repos need workflow re-sync — run /setup-git in OpenCode or Claude Code\n' "$ca_count"
+		fi
+	fi
+	return 0
+}
+
+# _summary_json: emit JSON object covering both debt classes.
+_summary_json() {
+	local slugs="$1" count="$2" ca_slugs="$3" ca_count="$4"
+	if ! command -v jq >/dev/null 2>&1; then
+		print_error "--format=json requires jq"
+		return 1
+	fi
+	local slugs_json ca_slugs_json total_count
+	if [[ -n "$slugs" ]]; then
+		slugs_json="$(printf '%s\n' "$slugs" | jq -R . | jq -s .)"
+	else
+		slugs_json="[]"
+	fi
+	if [[ -n "$ca_slugs" ]]; then
+		ca_slugs_json="$(printf '%s\n' "$ca_slugs" | jq -R . | jq -s .)"
+	else
+		ca_slugs_json="[]"
+	fi
+	total_count=$((count + ca_count))
+	jq -n \
+		--argjson slugs "$slugs_json" \
+		--argjson count "$count" \
+		--argjson ca_slugs "$ca_slugs_json" \
+		--argjson ca_count "$ca_count" \
+		--argjson total "$total_count" \
+		'{sync_pat_missing: $slugs, count: $count, cross_account_inherit: $ca_slugs, cross_account_count: $ca_count, total_count: $total}'
+	return 0
+}
+
 _cmd_summary() {
 	local format="human"
 	local -a args=("$@")
@@ -207,97 +292,19 @@ _cmd_summary() {
 		i=$((i + 1))
 	done
 
-	local slugs
+	local slugs count ca_slugs ca_count
 	slugs="$(_collect_sync_pat_slugs)"
+	count=0
+	[[ -n "$slugs" ]] && count=$(printf '%s\n' "$slugs" | wc -l | tr -d ' ')
 
-	local count=0
-	if [[ -n "$slugs" ]]; then
-		count=$(printf '%s\n' "$slugs" | wc -l | tr -d ' ')
-	fi
-
-	# Collect cross-account-inherit debt class (t2880)
-	local ca_slugs
 	ca_slugs="$(_collect_cross_account_slugs)"
-
-	local ca_count=0
-	if [[ -n "$ca_slugs" ]]; then
-		ca_count=$(printf '%s\n' "$ca_slugs" | wc -l | tr -d ' ')
-	fi
+	ca_count=0
+	[[ -n "$ca_slugs" ]] && ca_count=$(printf '%s\n' "$ca_slugs" | wc -l | tr -d ' ')
 
 	case "$format" in
-	human)
-		if [[ "$count" -eq 0 && "$ca_count" -eq 0 ]]; then
-			# Suppress on zero-debt: empty stdout, exit 0
-			return 0
-		fi
-		if [[ "$count" -gt 0 ]]; then
-			# Comma-separated slug list, capped at 3 with " ..."
-			local slug_list
-			slug_list="$(printf '%s\n' "$slugs" | head -3 | tr '\n' ',' | sed 's/,$//;s/,/, /g')"
-			if [[ "$count" -gt 3 ]]; then
-				slug_list="${slug_list}, +$((count - 3)) more"
-			fi
-			printf '%d SYNC_PAT advisor%s (%s)\n' "$count" "$([[ "$count" -eq 1 ]] && echo "y" || echo "ies")" "$slug_list"
-		fi
-		if [[ "$ca_count" -gt 0 ]]; then
-			local ca_slug_list
-			ca_slug_list="$(printf '%s\n' "$ca_slugs" | head -3 | tr '\n' ',' | sed 's/,$//;s/,/, /g')"
-			if [[ "$ca_count" -gt 3 ]]; then
-				ca_slug_list="${ca_slug_list}, +$((ca_count - 3)) more"
-			fi
-			printf '%d cross-account-inherit advisor%s (%s)\n' "$ca_count" "$([[ "$ca_count" -eq 1 ]] && echo "y" || echo "ies")" "$ca_slug_list"
-		fi
-		;;
-	toast)
-		if [[ "$count" -eq 0 && "$ca_count" -eq 0 ]]; then
-			# Suppress on zero-debt: empty stdout, exit 0. The plugin will
-			# omit the warning-tier line when nothing is emitted here.
-			return 0
-		fi
-		# Each non-zero class emits its own [WARN] line so greeting.mjs
-		# classifyLines buckets each into the warning tier independently.
-		# Singular: "1 repo needs"; plural: "N repos need"
-		if [[ "$count" -gt 0 ]]; then
-			if [[ "$count" -eq 1 ]]; then
-				printf '[WARN] 1 repo needs SYNC_PAT setup — run /setup-git in OpenCode or Claude Code\n'
-			else
-				printf '[WARN] %d repos need SYNC_PAT setup — run /setup-git in OpenCode or Claude Code\n' "$count"
-			fi
-		fi
-		if [[ "$ca_count" -gt 0 ]]; then
-			if [[ "$ca_count" -eq 1 ]]; then
-				printf '[WARN] 1 repo needs workflow re-sync — run /setup-git in OpenCode or Claude Code\n'
-			else
-				printf '[WARN] %d repos need workflow re-sync — run /setup-git in OpenCode or Claude Code\n' "$ca_count"
-			fi
-		fi
-		;;
-	json)
-		if ! command -v jq >/dev/null 2>&1; then
-			print_error "--format=json requires jq"
-			return 1
-		fi
-		local slugs_json
-		if [[ -n "$slugs" ]]; then
-			slugs_json="$(printf '%s\n' "$slugs" | jq -R . | jq -s .)"
-		else
-			slugs_json="[]"
-		fi
-		local ca_slugs_json
-		if [[ -n "$ca_slugs" ]]; then
-			ca_slugs_json="$(printf '%s\n' "$ca_slugs" | jq -R . | jq -s .)"
-		else
-			ca_slugs_json="[]"
-		fi
-		local total_count=$((count + ca_count))
-		jq -n \
-			--argjson slugs "$slugs_json" \
-			--argjson count "$count" \
-			--argjson ca_slugs "$ca_slugs_json" \
-			--argjson ca_count "$ca_count" \
-			--argjson total "$total_count" \
-			'{sync_pat_missing: $slugs, count: $count, cross_account_inherit: $ca_slugs, cross_account_count: $ca_count, total_count: $total}'
-		;;
+	human)   _summary_human "$slugs" "$count" "$ca_slugs" "$ca_count" ;;
+	toast)   _summary_toast "$count" "$ca_count" ;;
+	json)    _summary_json  "$slugs" "$count" "$ca_slugs" "$ca_count" ;;
 	*)
 		print_error "Unknown format: $format (expected: human, toast, json)"
 		return 1

--- a/.agents/scripts/setup-debt-helper.sh
+++ b/.agents/scripts/setup-debt-helper.sh
@@ -5,9 +5,10 @@
 # setup-debt-helper.sh — Aggregate per-repo platform-secret setup debt
 #
 # DESCRIPTION:
-#   Reads ~/.aidevops/advisories/sync-pat-*.advisory files (written by
-#   security-posture-helper.sh::_emit_sync_pat_advisory, t2374) and exposes
-#   the aggregated count + slug list to two consumers:
+#   Reads ~/.aidevops/advisories/sync-pat-*.advisory and
+#   ~/.aidevops/advisories/cross-account-inherit-*.advisory files (written by
+#   security-posture-helper.sh during `aidevops security check`, t2374/t2880)
+#   and exposes the aggregated count + slug list to two consumers:
 #
 #     1. aidevops-update-check.sh — emits a single [WARN] toast line so the
 #        OpenCode plugin classifier (greeting.mjs) escalates the toast to
@@ -24,16 +25,24 @@
 #
 # COMMANDS:
 #   summary [--format=human|toast|json]
-#       Aggregate count + summary line.
+#       Aggregate count + summary line across both debt classes.
 #       human (default): 3 SYNC_PAT advisories (awardsapp/awardsapp, ...)
+#                        1 cross-account-inherit advisory (org/repo, ...)
 #       toast:           [WARN] 3 repos need SYNC_PAT setup — run /setup-git ...
-#       json:            {"sync_pat_missing": [...], "count": 3}
-#       Empty stdout, exit 0 when count == 0 (suppresses toast lines).
+#                        [WARN] 1 repo needs workflow re-sync — run /setup-git ...
+#       json:            {"sync_pat_missing": [...], "count": 3,
+#                         "cross_account_inherit": [...], "cross_account_count": 1,
+#                         "total_count": 4}
+#       Empty stdout, exit 0 when both counts == 0 (suppresses toast lines).
 #
 #   list-sync-pat-missing
 #       One slug per line for repos with active (non-dismissed) SYNC_PAT
 #       advisories. Suitable for piping to xargs / for-loop in /setup-git.
 #       Empty stdout when none.
+#
+#   list-cross-account-inherit
+#       One slug per line for repos with active (non-dismissed) cross-account
+#       secrets:inherit advisories (t2880). Empty stdout when none.
 #
 #   verify-secret <slug> <secret_name>
 #       Returns 0 if the named secret exists on the repo, 1 otherwise.
@@ -71,6 +80,7 @@ set -euo pipefail
 readonly ADVISORIES_DIR="${HOME}/.aidevops/advisories"
 readonly DISMISSED_FILE="${ADVISORIES_DIR}/dismissed.txt"
 readonly SYNC_PAT_PREFIX="sync-pat-"
+readonly CROSS_ACCOUNT_PREFIX="cross-account-inherit-"
 
 # -----------------------------------------------------------------------------
 # Internal helpers
@@ -135,6 +145,35 @@ _collect_sync_pat_slugs() {
 	return 0
 }
 
+# _collect_cross_account_slugs: emit one slug per line for non-dismissed
+# cross-account-inherit advisories (t2880). Mirrors _collect_sync_pat_slugs.
+_collect_cross_account_slugs() {
+	if [[ ! -d "$ADVISORIES_DIR" ]]; then
+		return 0
+	fi
+
+	local advisory_file
+	# shellcheck disable=SC2231
+	for advisory_file in "$ADVISORIES_DIR"/${CROSS_ACCOUNT_PREFIX}*.advisory; do
+		[[ -f "$advisory_file" ]] || continue
+
+		local basename adv_id stem slug
+		basename="$(basename "$advisory_file" .advisory)"
+		adv_id="$basename"
+		stem="${basename#"$CROSS_ACCOUNT_PREFIX"}"
+
+		if _is_dismissed "$adv_id"; then
+			continue
+		fi
+
+		slug="$(_slug_from_filename "$stem")"
+		[[ -n "$slug" ]] || continue
+
+		echo "$slug"
+	done | sort -u
+	return 0
+}
+
 # -----------------------------------------------------------------------------
 # Subcommand: summary
 # -----------------------------------------------------------------------------
@@ -176,34 +215,61 @@ _cmd_summary() {
 		count=$(printf '%s\n' "$slugs" | wc -l | tr -d ' ')
 	fi
 
+	# Collect cross-account-inherit debt class (t2880)
+	local ca_slugs
+	ca_slugs="$(_collect_cross_account_slugs)"
+
+	local ca_count=0
+	if [[ -n "$ca_slugs" ]]; then
+		ca_count=$(printf '%s\n' "$ca_slugs" | wc -l | tr -d ' ')
+	fi
+
 	case "$format" in
 	human)
-		if [[ "$count" -eq 0 ]]; then
+		if [[ "$count" -eq 0 && "$ca_count" -eq 0 ]]; then
 			# Suppress on zero-debt: empty stdout, exit 0
 			return 0
 		fi
-		# Comma-separated slug list, capped at 3 with " ..."
-		local slug_list
-		slug_list="$(printf '%s\n' "$slugs" | head -3 | tr '\n' ',' | sed 's/,$//;s/,/, /g')"
-		if [[ "$count" -gt 3 ]]; then
-			slug_list="${slug_list}, +$((count - 3)) more"
+		if [[ "$count" -gt 0 ]]; then
+			# Comma-separated slug list, capped at 3 with " ..."
+			local slug_list
+			slug_list="$(printf '%s\n' "$slugs" | head -3 | tr '\n' ',' | sed 's/,$//;s/,/, /g')"
+			if [[ "$count" -gt 3 ]]; then
+				slug_list="${slug_list}, +$((count - 3)) more"
+			fi
+			printf '%d SYNC_PAT advisor%s (%s)\n' "$count" "$([[ "$count" -eq 1 ]] && echo "y" || echo "ies")" "$slug_list"
 		fi
-		printf '%d SYNC_PAT advisor%s (%s)\n' "$count" "$([[ "$count" -eq 1 ]] && echo "y" || echo "ies")" "$slug_list"
+		if [[ "$ca_count" -gt 0 ]]; then
+			local ca_slug_list
+			ca_slug_list="$(printf '%s\n' "$ca_slugs" | head -3 | tr '\n' ',' | sed 's/,$//;s/,/, /g')"
+			if [[ "$ca_count" -gt 3 ]]; then
+				ca_slug_list="${ca_slug_list}, +$((ca_count - 3)) more"
+			fi
+			printf '%d cross-account-inherit advisor%s (%s)\n' "$ca_count" "$([[ "$ca_count" -eq 1 ]] && echo "y" || echo "ies")" "$ca_slug_list"
+		fi
 		;;
 	toast)
-		if [[ "$count" -eq 0 ]]; then
+		if [[ "$count" -eq 0 && "$ca_count" -eq 0 ]]; then
 			# Suppress on zero-debt: empty stdout, exit 0. The plugin will
 			# omit the warning-tier line when nothing is emitted here.
 			return 0
 		fi
-		# Single line, [WARN] prefix so greeting.mjs::classifyLines buckets
-		# this into the warning tier (15s display, more prominent than the
-		# per-repo [ADVISORY] info-tier lines below).
+		# Each non-zero class emits its own [WARN] line so greeting.mjs
+		# classifyLines buckets each into the warning tier independently.
 		# Singular: "1 repo needs"; plural: "N repos need"
-		if [[ "$count" -eq 1 ]]; then
-			printf '[WARN] 1 repo needs SYNC_PAT setup — run /setup-git in OpenCode or Claude Code\n'
-		else
-			printf '[WARN] %d repos need SYNC_PAT setup — run /setup-git in OpenCode or Claude Code\n' "$count"
+		if [[ "$count" -gt 0 ]]; then
+			if [[ "$count" -eq 1 ]]; then
+				printf '[WARN] 1 repo needs SYNC_PAT setup — run /setup-git in OpenCode or Claude Code\n'
+			else
+				printf '[WARN] %d repos need SYNC_PAT setup — run /setup-git in OpenCode or Claude Code\n' "$count"
+			fi
+		fi
+		if [[ "$ca_count" -gt 0 ]]; then
+			if [[ "$ca_count" -eq 1 ]]; then
+				printf '[WARN] 1 repo needs workflow re-sync — run /setup-git in OpenCode or Claude Code\n'
+			else
+				printf '[WARN] %d repos need workflow re-sync — run /setup-git in OpenCode or Claude Code\n' "$ca_count"
+			fi
 		fi
 		;;
 	json)
@@ -217,8 +283,20 @@ _cmd_summary() {
 		else
 			slugs_json="[]"
 		fi
-		jq -n --argjson slugs "$slugs_json" --argjson count "$count" \
-			'{sync_pat_missing: $slugs, count: $count}'
+		local ca_slugs_json
+		if [[ -n "$ca_slugs" ]]; then
+			ca_slugs_json="$(printf '%s\n' "$ca_slugs" | jq -R . | jq -s .)"
+		else
+			ca_slugs_json="[]"
+		fi
+		local total_count=$((count + ca_count))
+		jq -n \
+			--argjson slugs "$slugs_json" \
+			--argjson count "$count" \
+			--argjson ca_slugs "$ca_slugs_json" \
+			--argjson ca_count "$ca_count" \
+			--argjson total "$total_count" \
+			'{sync_pat_missing: $slugs, count: $count, cross_account_inherit: $ca_slugs, cross_account_count: $ca_count, total_count: $total}'
 		;;
 	*)
 		print_error "Unknown format: $format (expected: human, toast, json)"
@@ -235,6 +313,15 @@ _cmd_summary() {
 
 _cmd_list_sync_pat_missing() {
 	_collect_sync_pat_slugs
+	return 0
+}
+
+# -----------------------------------------------------------------------------
+# Subcommand: list-cross-account-inherit (t2880)
+# -----------------------------------------------------------------------------
+
+_cmd_list_cross_account_inherit() {
+	_collect_cross_account_slugs
 	return 0
 }
 
@@ -285,8 +372,9 @@ Usage:
   setup-debt-helper.sh <command> [args]
 
 Commands:
-  summary [--format=human|toast|json]   Aggregate count + summary line
-  list-sync-pat-missing                 One slug per line, non-dismissed only
+  summary [--format=human|toast|json]   Aggregate count + summary line (both classes)
+  list-sync-pat-missing                 One slug per line, non-dismissed SYNC_PAT only
+  list-cross-account-inherit            One slug per line, non-dismissed cross-account-inherit only
   verify-secret <slug> <secret_name>    Check if a secret exists on a repo
   help                                  Show this help
 
@@ -294,16 +382,22 @@ Examples:
   setup-debt-helper.sh summary
   setup-debt-helper.sh summary --format=toast
   setup-debt-helper.sh list-sync-pat-missing
+  setup-debt-helper.sh list-cross-account-inherit
   setup-debt-helper.sh verify-secret awardsapp/awardsapp SYNC_PAT
 
 Emits no output and returns 0 when there is no setup debt; this is the
 intended quiet-on-clean signal for toast suppression.
 
+Debt classes:
+  sync-pat-*               SYNC_PAT secret not set for repo using issue-sync.yml
+  cross-account-inherit-*  issue-sync.yml uses secrets:inherit across org boundary (t2880)
+
 See also:
   /setup-git                       Slash command that consumes this helper
-  aidevops security check          Generates the SYNC_PAT advisories
+  aidevops security check          Generates the SYNC_PAT + cross-account advisories
   scripts/commands/setup-git.md    Slash command spec
   reference/sync-pat-platforms.md  PAT URL templates and scopes per platform
+  reference/reusable-workflows.md  Cross-account secrets architecture
 EOF
 	return 0
 }
@@ -318,6 +412,9 @@ main() {
 		;;
 	list-sync-pat-missing)
 		_cmd_list_sync_pat_missing
+		;;
+	list-cross-account-inherit)
+		_cmd_list_cross_account_inherit
 		;;
 	verify-secret)
 		_cmd_verify_secret "$@"

--- a/.agents/scripts/tests/test-setup-debt-helper.sh
+++ b/.agents/scripts/tests/test-setup-debt-helper.sh
@@ -209,6 +209,115 @@ test_unknown_command_returns_error() {
 }
 
 # -----------------------------------------------------------------------------
+# Test cases: cross-account-inherit debt class (t2880)
+# These tests use advisory files created manually (no live gh API calls).
+# They mirror how test-sync-pat-detection.sh tests the sync-pat advisory files
+# by treating the advisory file as the source of truth for the aggregator.
+# -----------------------------------------------------------------------------
+
+# (a) cross-account caller advisory is detected by list-cross-account-inherit
+test_cross_account_advisory_detected() {
+	_setup_sandbox
+	echo "[ADVISORY] Cross-account secrets:inherit detected for org/repo" \
+		>"$HOME/.aidevops/advisories/cross-account-inherit-org-repo.advisory"
+	local out
+	out="$("$HELPER" list-cross-account-inherit)"
+	if [[ "$out" != *"org/repo"* ]]; then
+		echo "    expected slug in output, got: '$out'" >&2
+		return 1
+	fi
+	return 0
+}
+
+# (b) Same-account caller (different prefix) is NOT returned by list-cross-account-inherit
+test_same_account_advisory_not_detected() {
+	_setup_sandbox
+	# sync-pat advisory should NOT appear in list-cross-account-inherit
+	echo "[ADVISORY] SYNC_PAT not set for sameorg/repo" \
+		>"$HOME/.aidevops/advisories/sync-pat-sameorg-repo.advisory"
+	local out
+	out="$("$HELPER" list-cross-account-inherit)"
+	_assert_empty "$out" "sync-pat advisory should not appear in list-cross-account-inherit"
+}
+
+# (c) Explicit SYNC_PAT mapping (post-#20976 caller) — no advisory → empty list
+test_explicit_mapping_no_advisory() {
+	_setup_sandbox
+	# No cross-account-inherit-*.advisory file means no advisory → empty
+	local out
+	out="$("$HELPER" list-cross-account-inherit)"
+	_assert_empty "$out" "no advisory should produce empty list"
+}
+
+# (d) Missing workflow file → no false positive, list is empty
+test_missing_workflow_no_false_positive() {
+	_setup_sandbox
+	# Advisories dir exists but contains no cross-account-inherit files
+	touch "$HOME/.aidevops/advisories/unrelated.txt"
+	local out
+	out="$("$HELPER" list-cross-account-inherit)"
+	_assert_empty "$out" "missing workflow should not produce cross-account advisory"
+}
+
+# (e) summary aggregation reports both sync-pat and cross-account-inherit classes
+test_summary_aggregates_both_classes() {
+	_setup_sandbox
+	echo "[ADVISORY] SYNC_PAT not set for org/a" \
+		>"$HOME/.aidevops/advisories/sync-pat-org-a.advisory"
+	echo "[ADVISORY] Cross-account detected for org/b" \
+		>"$HOME/.aidevops/advisories/cross-account-inherit-org-b.advisory"
+
+	local out_human
+	out_human="$("$HELPER" summary --format=human)"
+	# Both lines must appear
+	if [[ "$out_human" != *"SYNC_PAT"* ]]; then
+		echo "    human format missing SYNC_PAT line; got: '$out_human'" >&2
+		return 1
+	fi
+	if [[ "$out_human" != *"cross-account-inherit"* ]]; then
+		echo "    human format missing cross-account-inherit line; got: '$out_human'" >&2
+		return 1
+	fi
+
+	local out_toast
+	out_toast="$("$HELPER" summary --format=toast)"
+	# Must include both [WARN] lines
+	if [[ "$out_toast" != *"SYNC_PAT setup"* ]]; then
+		echo "    toast missing SYNC_PAT line; got: '$out_toast'" >&2
+		return 1
+	fi
+	if [[ "$out_toast" != *"workflow re-sync"* ]]; then
+		echo "    toast missing workflow re-sync line; got: '$out_toast'" >&2
+		return 1
+	fi
+
+	if command -v jq >/dev/null 2>&1; then
+		local out_json
+		out_json="$("$HELPER" summary --format=json)"
+		local sp_count ca_count total
+		sp_count="$(printf '%s' "$out_json" | jq -r '.count')"
+		ca_count="$(printf '%s' "$out_json" | jq -r '.cross_account_count')"
+		total="$(printf '%s' "$out_json" | jq -r '.total_count')"
+		_assert_eq "1" "$sp_count" "json sync_pat count" || return 1
+		_assert_eq "1" "$ca_count" "json cross_account_count" || return 1
+		_assert_eq "2" "$total" "json total_count" || return 1
+	fi
+
+	return 0
+}
+
+# dismissed cross-account advisory excluded from list
+test_cross_account_dismissed_excluded() {
+	_setup_sandbox
+	echo "[ADVISORY] Cross-account detected for org/repo" \
+		>"$HOME/.aidevops/advisories/cross-account-inherit-org-repo.advisory"
+	echo "cross-account-inherit-org-repo" >"$HOME/.aidevops/advisories/dismissed.txt"
+	local out
+	out="$("$HELPER" list-cross-account-inherit)"
+	_assert_empty "$out" "dismissed cross-account advisory should be excluded"
+}
+
+# -----------------------------------------------------------------------------
 # Run
 # -----------------------------------------------------------------------------
 
@@ -225,6 +334,13 @@ _run_test "list returns reconstructed slugs" test_list_returns_slugs
 _run_test "json format has expected structure" test_json_format_structure
 _run_test "help command emits banner" test_help_command
 _run_test "unknown command returns error" test_unknown_command_returns_error
+# cross-account-inherit class (t2880)
+_run_test "[t2880] cross-account advisory detected by list-cross-account-inherit" test_cross_account_advisory_detected
+_run_test "[t2880] sync-pat advisory not returned by list-cross-account-inherit" test_same_account_advisory_not_detected
+_run_test "[t2880] no advisory (explicit mapping) produces empty list" test_explicit_mapping_no_advisory
+_run_test "[t2880] missing workflow produces no false positive" test_missing_workflow_no_false_positive
+_run_test "[t2880] summary aggregates both sync-pat and cross-account classes" test_summary_aggregates_both_classes
+_run_test "[t2880] dismissed cross-account advisory excluded from list" test_cross_account_dismissed_excluded
 
 echo ""
 echo "PASS: $PASS"


### PR DESCRIPTION
## What

Adds cross-account `secrets:inherit` detection as a new debt class in the aidevops setup-debt framework (t2880, companion to #20976).

GitHub policy: `secrets:inherit` only propagates within the same org/enterprise. Repos that installed the issue-sync caller template before #20976 fixed it use `secrets:inherit`, which silently fails when the caller org differs from `marcusquinn`. Operators have no visibility into this failure until issue-sync jobs start producing cryptic permission errors.

## Changes

### `security-posture-helper-repo.sh` — detector + advisory writer
- `_detect_cross_account_inherit(slug)`: fetches `.github/workflows/issue-sync.yml` via `gh api`, returns 0 if file contains both `uses: marcusquinn/aidevops/...` and `secrets: inherit` (broken pattern), 1 if clean, 2 if missing/unfetchable.
- `_emit_cross_account_inherit_advisory(slug, slug_sanitised)`: writes `~/.aidevops/advisories/cross-account-inherit-<slug>.advisory` with remediation instructions (`aidevops sync-workflows --apply`).
- `check_cross_account_inherit(repo_path)`: Phase 8 check integrated into `run_all_checks` alongside existing `check_sync_pat`.

### `setup-debt-helper.sh` — aggregator
- `CROSS_ACCOUNT_PREFIX` constant and `_collect_cross_account_slugs()` mirroring existing `_collect_sync_pat_slugs()`.
- `list-cross-account-inherit` CLI command (new).
- `summary` extended to aggregate both classes: human format emits both lines, toast emits separate `[WARN]` per class, json includes `cross_account_inherit` + `cross_account_count` + `total_count` fields.
- Refactored `_cmd_summary` (was 133 lines, over 100-line gate) into four focused helpers: `_fmt_slug_list`, `_summary_human`, `_summary_toast`, `_summary_json`.

### `commands/setup-git.md` — slash command
- Phase 1 inventory: now lists both `list-sync-pat-missing` and `list-cross-account-inherit`.
- Phase 1.5 (new): walkthrough for `aidevops sync-workflows --apply` remediation with dismiss path.
- Updated "Use when" trigger list and cross-references.

### `tests/test-setup-debt-helper.sh` — tests
- 6 new tests for the cross-account class (in addition to 11 existing): advisory detected, sync-pat not returned by wrong list command, no advisory = empty, missing workflow = no false positive, dual-class summary aggregation, dismissed advisory excluded.
- All 17 tests pass.

## Verification

```
shellcheck .agents/scripts/setup-debt-helper.sh .agents/scripts/security-posture-helper-repo.sh .agents/scripts/tests/test-setup-debt-helper.sh
# → zero violations

bash .agents/scripts/tests/test-setup-debt-helper.sh
# PASS: 17  FAIL: 0
```

Resolves #20981

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-sonnet-4-6 spent 9m and 33,229 tokens on this as a headless worker.
