### PR TITLE
GH#21654: fix: wrap script_path in escaped double quotes in systemd ExecStart for space-safe paths

### DIFF
--- a/.agents/scripts/auto-update-helper.sh
+++ b/.agents/scripts/auto-update-helper.sh
@@ -872,7 +872,7 @@ _cmd_enable_systemd() {
 
 	mkdir -p "${SYSTEMD_SERVICE_DIR}"
 
-	# shellcheck disable=SC1078,SC1079  # multi-line printf with single quotes inside a double-quoted string; ${script_path} kept inside outer double quotes for safe expansion
+	# shellcheck disable=SC1078,SC1079  # multi-line printf with single quotes inside a double-quoted string; \"${script_path}\" expands to "path" in the service file, preserving space-safe quoting
 	printf '%s' "[Unit]
 Description=aidevops auto-update
 After=network.target
@@ -880,7 +880,7 @@ After=network.target
 [Service]
 Type=oneshot
 KillMode=process
-ExecStart=/bin/bash -lc '${script_path} check'
+ExecStart=/bin/bash -lc '\"${script_path}\" check'
 TimeoutStartSec=120
 Nice=10
 IOSchedulingClass=idle


### PR DESCRIPTION
## Summary

Wraps `${script_path}` in escaped double quotes in the systemd `ExecStart` directive so paths containing spaces are handled correctly.

## Problem

The PR #21520 introduced a regression: the generated systemd service file contained:

```
ExecStart=/bin/bash -lc '${script_path} check'
```

When `script_path` contains spaces, systemd passes the string to `bash -c` without quoting, causing word-splitting failure. Bash would try to execute the first path segment as a command.

## Fix

Change to:

```
ExecStart=/bin/bash -lc '"" check'
```

The `\"` escape sequences inside the double-quoted printf argument produce literal `"` characters in the output file, so the service file contains:

```
ExecStart=/bin/bash -lc '"/actual/path" check'
```

Bash then correctly interprets the double-quoted path as a single token, regardless of spaces.

Also updated the ShellCheck disable comment to accurately describe the `\"...\"` expansion pattern.

## Verification

- ShellCheck passes clean on the modified file
- Generated service file will contain properly quoted `ExecStart` for space-safe paths

Resolves #21654


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-sonnet-4-6 spent 6m and 5,401 tokens on this as a headless worker.
