### PR TITLE
GH#21647: use timeout_sec in pulse canary check for macOS portability

### DIFF
--- a/.agents/scripts/linters-local-analysis.sh
+++ b/.agents/scripts/linters-local-analysis.sh
@@ -26,7 +26,7 @@
 #
 # Dependencies:
 #   - shared-constants.sh (print_error, print_info, print_success, print_warning,
-#     safe_grep_count, _save_cleanup_scope, push_cleanup, _run_cleanups)
+#     safe_grep_count, timeout_sec, _save_cleanup_scope, push_cleanup, _run_cleanups)
 #   - lint-file-discovery.sh (lint_python_files_local, LINT_PY_FILES_LOCAL)
 #   - Constants: MAX_TOTAL_ISSUES, MAX_FUNCTION_LENGTH_WARN, MAX_FUNCTION_LENGTH_BLOCK,
 #     MAX_FUNCTION_LENGTH_VIOLATIONS, MAX_NESTING_DEPTH_WARN, MAX_NESTING_DEPTH_BLOCK,
@@ -876,11 +876,10 @@ check_pulse_canary() {
 
 	local sandbox rc output
 	sandbox=$(mktemp -d)
-	# shell-portability: ignore next — timeout: use _timeout_cmd wrapper (GH#18787)
 	output=$(
 		HOME="${sandbox}/home" \
 			FULL_LOOP_HEADLESS=1 \
-			timeout 30 bash "$wrapper_script" --canary 2>&1
+			timeout_sec 30 bash "$wrapper_script" --canary 2>&1
 	)
 	rc=$?
 	rm -rf "$sandbox"


### PR DESCRIPTION
## Summary

Addresses two review bot findings from PR #21527 on `linters-local-analysis.sh`:

1. **Dependency comment (line 29):** Added `timeout_sec` to the `shared-constants.sh` dependency list in the file header. This function is now used in the file and should be documented.

2. **Portability fix (line 884):** Replaced bare `timeout 30` with `timeout_sec 30` in the pulse-wrapper canary check. `timeout` is not available on default macOS; `timeout_sec` from `shared-constants.sh` provides a portable fallback (native `timeout` → `gtimeout` → background-kill). The stale `# shell-portability: ignore next` comment that acknowledged the issue but deferred the fix (GH#18787) is also removed.

## Verification

- Both premises confirmed against actual code before editing (Outcome B — premise correct + fix obvious).
- `shellcheck` run: no new violations introduced (2 pre-existing SC2016 info-level warnings at lines 923/926 are unchanged).
- Pre-commit + pre-push quality gates passed.

Resolves #21647

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-sonnet-4-6 spent 7m and 6,141 tokens on this as a headless worker.
