### PR TITLE
GH#21547: fix review-bot-gate commit status posting to restore branch protection contract

### DIFF
--- a/.agents/templates/workflows/review-bot-gate-caller.yml
+++ b/.agents/templates/workflows/review-bot-gate-caller.yml
@@ -32,7 +32,7 @@ name: Review Bot Gate
 permissions:
   pull-requests: read
   contents: read
-  statuses: read
+  statuses: write
 
 on:
   pull_request:

--- a/.github/workflows/review-bot-gate-reusable.yml
+++ b/.github/workflows/review-bot-gate-reusable.yml
@@ -64,7 +64,7 @@ jobs:
     permissions:
       pull-requests: read
       contents: read
-      statuses: read
+      statuses: write
 
     steps:
       - name: Checkout aidevops framework scripts
@@ -180,6 +180,57 @@ jobs:
           echo "  2. This check re-runs automatically when a bot posts or edits a comment"
           echo "  3. If no bots are configured, add 'skip-review-gate' label"
           exit 1
+
+      - name: Post review-bot-gate commit status
+        # GH#21547: reusable-workflow caller-job naming produces "gate / review-bot-gate"
+        # as the CheckRun name (GitHub prefixes with caller job id). Branch protection
+        # requiring the bare "review-bot-gate" name would wait forever.
+        # Mirror the maintainer-gate-reusable.yml pattern (lines 115-128, 213-218):
+        # explicitly POST a StatusContext so branch protection sees "review-bot-gate".
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
+          REPO: ${{ github.repository }}
+          GATE_PASSED: ${{ steps.check.outputs.gate_passed }}
+          SKIP_GATE: ${{ steps.skip.outputs.skip }}
+          RESULT: ${{ steps.check.outputs.result }}
+        run: |
+          # Resolve HEAD SHA. pull_request / pull_request_review expose it via
+          # github.event.pull_request.head.sha. issue_comment does not — the event
+          # is issue-scoped, so we fall back to a gh pr view lookup.
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          if [[ -z "${HEAD_SHA}" ]]; then
+            HEAD_SHA=$(gh pr view "${PR_NUMBER}" --repo "${REPO}" \
+              --json headRefOid --jq '.headRefOid' 2>/dev/null || true)
+          fi
+          if [[ -z "${HEAD_SHA}" ]]; then
+            echo "::warning::Could not resolve HEAD SHA for PR #${PR_NUMBER} — skipping status post"
+            exit 0
+          fi
+
+          if [[ "${GATE_PASSED}" == "true" ]] || [[ "${SKIP_GATE}" == "true" ]]; then
+            STATE=success
+            DESC="Review bot gate passed (${RESULT:-SKIP})"
+          else
+            STATE=failure
+            DESC="Review bot gate WAITING — no real bot review yet"
+          fi
+
+          gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
+            --method POST \
+            -f state="${STATE}" \
+            -f context="review-bot-gate" \
+            -f description="${DESC}" \
+            2>/dev/null || { sleep 5 && gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
+            --method POST \
+            -f state="${STATE}" \
+            -f context="review-bot-gate" \
+            -f description="${DESC}"; } || {
+            echo "::error::Failed to post review-bot-gate commit status after retry"
+            exit 1
+          }
+          echo "Posted review-bot-gate status: ${STATE} (${DESC})"
 
       - name: Summary
         if: always()


### PR DESCRIPTION
## Summary

Restores the documented `review-bot-gate` branch protection contract broken by PR #20748's reusable-workflow migration (GH#20727).

**Root cause:** GitHub names CheckRuns from reusable workflows as `<caller_job_id> / <reusable_job_id>`, so the migrated workflow produces `gate / review-bot-gate` instead of the bare `review-bot-gate` that downstream branch protection rules require. This is the same bug class as GH#5365, reintroduced via a different vector.

## Changes

- **EDIT: `.github/workflows/review-bot-gate-reusable.yml`**
  - `statuses: read` → `statuses: write` (job-level permissions)
  - New step **Post review-bot-gate commit status** (`if: always()`) — POSTs a `review-bot-gate` StatusContext via `gh api repos/{REPO}/statuses/{HEAD_SHA}` with retry, mirroring the `maintainer-gate-reusable.yml` pattern (GH#14277).
  - Handles `issue_comment` event path (no `github.event.pull_request.head.sha`) via `gh pr view … --json headRefOid` fallback.

- **EDIT: `.agents/templates/workflows/review-bot-gate-caller.yml`**
  - `statuses: read` → `statuses: write` (caller ceiling — reusable job permissions cannot exceed it)

## Verification

After merge, downstream repos picking up the latest `@main` ref (or resynced via `aidevops sync-workflows --apply`) will have the `review-bot-gate` StatusContext posted on every PR run, satisfying existing branch protection rules without any per-repo changes.

Manual verification on next triggered PR:
```bash
gh api repos/marcusquinn/aidevops/commits/<head_sha>/status \
  --jq '.statuses[] | select(.context == "review-bot-gate")'
# Expected: entry with state=success or state=failure
```

## Reference

- Prior fix: GH#5365 (March 2026) — same bug class, fixed via `name:` removal
- Pattern: `maintainer-gate-reusable.yml` lines 115-128, 213-218 (explicit status POST)
- Live reporter: robstiles/qs-agency PR #2114

Resolves #21547


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-sonnet-4-6 spent 6m and 5,517 tokens on this as a headless worker.