### PR TITLE
GH#21645: use project cleanup pattern for mktemp in transport_matrix_send

### DIFF
--- a/.agents/scripts/mail-helper-transport.sh
+++ b/.agents/scripts/mail-helper-transport.sh
@@ -204,6 +204,11 @@ transport_matrix_send() {
 
 	local http_code curl_stderr
 	curl_stderr=$(mktemp) || curl_stderr="/dev/null"
+	_save_cleanup_scope
+	trap '_run_cleanups' RETURN
+	if [[ "$curl_stderr" != "/dev/null" ]]; then
+		push_cleanup "rm -f '${curl_stderr}'"
+	fi
 	http_code=$(curl -sS -o /dev/null -w '%{http_code}' \
 		-X PUT "$endpoint" \
 		-H "Authorization: Bearer $access_token" \
@@ -212,6 +217,7 @@ transport_matrix_send() {
 	if [[ "$http_code" != "200" && -s "$curl_stderr" ]]; then
 		log_warn "Matrix curl error to endpoint $endpoint: $(cat "$curl_stderr")"
 	fi
+	# Fast-path cleanup — remove as soon as content has been read
 	rm -f "$curl_stderr"
 
 	if [[ "$http_code" == "200" ]]; then


### PR DESCRIPTION
## Summary

Apply the project's canonical temp-file cleanup pattern to `transport_matrix_send` in `.agents/scripts/mail-helper-transport.sh`, addressing the Gemini review bot finding from PR #21529.

## What changed

`transport_matrix_send` created a temp file via `mktemp` for capturing `curl` stderr but managed cleanup with only a manual `rm -f` at the end of the normal execution path. While this covered all explicit return paths, it did not use the project's established cleanup pattern (`_save_cleanup_scope` + `trap '_run_cleanups' RETURN` + `push_cleanup`).

**Fix:**
- Added `_save_cleanup_scope` and `trap '_run_cleanups' RETURN` immediately after `mktemp`
- Added `push_cleanup "rm -f '${curl_stderr}'"` to register cleanup on any exit path (only when mktemp succeeded — not for the `/dev/null` fallback)
- Kept the existing `rm -f "$curl_stderr"` as an explicit fast-path cleanup (removes file as soon as content has been read, per bot recommendation)

## Verification

- `shellcheck .agents/scripts/mail-helper-transport.sh` — passes clean (zero violations)
- Pre-commit hook — passed
- Pre-push hook — passed

Resolves #21645

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-sonnet-4-6 spent 8m and 9,588 tokens on this as a headless worker.
