### PR TITLE
GH#21650: guard log_worktree_removal_event stub with command -v to prevent overwrite

### DIFF
--- a/.agents/scripts/worktree-helper.sh
+++ b/.agents/scripts/worktree-helper.sh
@@ -46,9 +46,13 @@ fi
 # t2976: canonical audit logger for worktree-removal events (removed / skipped).
 # Fallback definitions guard against set -u failures when the helper is absent
 # (e.g. older deployments). The source block below overrides these when the file exists.
+# The stub uses command -v so it is only defined when the real function is not yet
+# loaded — prevents unconditional overwrite when audit-worktree-removal-helper.sh was
+# already sourced by a caller (e.g. pulse-cleanup.sh) before worktree-helper.sh is
+# re-sourced; the double-source guard in that helper would otherwise prevent restore.
 _WTAR_REMOVED="${_WTAR_REMOVED:-removed}"
 _WTAR_SKIPPED="${_WTAR_SKIPPED:-skipped}"
-log_worktree_removal_event() { :; }
+command -v log_worktree_removal_event >/dev/null 2>&1 || log_worktree_removal_event() { :; }
 if [[ -f "${SCRIPT_DIR}/audit-worktree-removal-helper.sh" ]]; then
 	# shellcheck source=audit-worktree-removal-helper.sh
 	source "${SCRIPT_DIR}/audit-worktree-removal-helper.sh"


### PR DESCRIPTION
## Summary

Guards the `log_worktree_removal_event` stub in `worktree-helper.sh` with `command -v` so it only defines the no-op when the real function is not already loaded.

## Problem

`pulse-cleanup.sh` (and `skill-update-helper.sh`) source `audit-worktree-removal-helper.sh` directly, setting `_AUDIT_WORKTREE_REMOVAL_HELPER_LOADED=1` and defining the real `log_worktree_removal_event`. If `worktree-helper.sh` is then sourced (or re-sourced) in the same shell:

1. Line 51 (old): `log_worktree_removal_event() { :; }` — **unconditionally overwrites** the real function with the stub.
2. Lines 52–55: `source audit-worktree-removal-helper.sh` — the double-source guard fires (`_AUDIT_WORKTREE_REMOVAL_HELPER_LOADED=1` already set), returns immediately. The real function is **not restored**.

Result: all worktree-removal audit log writes silently become no-ops.

## Fix

Guards the stub with `command -v ... || ...` so it is only defined when the real function is absent, preventing the overwrite.

## Verification

- `shellcheck .agents/scripts/worktree-helper.sh` — clean (zero violations)

Resolves #21650

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-sonnet-4-6 spent 8m and 7,869 tokens on this as a headless worker.
