### PR TITLE
GH#21649: fix conversation-helper review followup — JSON empty guard, query elim, sed combine

### DIFF
--- a/.agents/scripts/conversation-helper-context.sh
+++ b/.agents/scripts/conversation-helper-context.sh
@@ -42,27 +42,23 @@ _context_output_json() {
 	local esc_entity="$2"
 	local recent_messages="$3"
 
-	echo "{"
+	# Capture each query result; sqlite3 -json may return empty string (not [])
+	# for zero-row results on some SQLite builds — guard with ${var:-[]} to
+	# ensure the hand-assembled JSON object is always valid.
+	local _conv_json _profile_json _summary_json _messages_json
 
-	# Conversation metadata
-	echo "\"conversation\":"
-	conv_db -json "$CONV_MEMORY_DB" "SELECT id, entity_id, channel, channel_id, topic, status, interaction_count, last_interaction_at FROM conversations WHERE id = '$esc_id';"
-	echo ","
+	_conv_json=$(conv_db -json "$CONV_MEMORY_DB" "SELECT id, entity_id, channel, channel_id, topic, status, interaction_count, last_interaction_at FROM conversations WHERE id = '$esc_id';")
 
-	# Entity profile (current, non-superseded entries)
-	echo "\"entity_profile\":"
-	conv_db -json "$CONV_MEMORY_DB" <<EOF
+	_profile_json=$(conv_db -json "$CONV_MEMORY_DB" <<EOF
 SELECT profile_key, profile_value, confidence
 FROM entity_profiles
 WHERE entity_id = '$esc_entity'
   AND id NOT IN (SELECT supersedes_id FROM entity_profiles WHERE supersedes_id IS NOT NULL)
 ORDER BY profile_key;
 EOF
-	echo ","
+)
 
-	# Latest summary
-	echo "\"latest_summary\":"
-	conv_db -json "$CONV_MEMORY_DB" <<EOF
+	_summary_json=$(conv_db -json "$CONV_MEMORY_DB" <<EOF
 SELECT cs.id, cs.summary, cs.source_range_start, cs.source_range_end,
     cs.source_interaction_count, cs.tone_profile, cs.pending_actions, cs.created_at
 FROM conversation_summaries cs
@@ -71,18 +67,29 @@ WHERE cs.conversation_id = '$esc_id'
 ORDER BY cs.created_at DESC
 LIMIT 1;
 EOF
-	echo ","
+)
 
-	# Recent messages
-	echo "\"recent_messages\":"
-	conv_db -json "$CONV_MEMORY_DB" <<EOF
+	_messages_json=$(conv_db -json "$CONV_MEMORY_DB" <<EOF
 SELECT i.id, i.direction, i.content, i.created_at
 FROM interactions i
 WHERE i.conversation_id = '$esc_id'
 ORDER BY i.created_at DESC
 LIMIT $recent_messages;
 EOF
+)
 
+	echo "{"
+	echo "\"conversation\":"
+	echo "${_conv_json:-[]}"
+	echo ","
+	echo "\"entity_profile\":"
+	echo "${_profile_json:-[]}"
+	echo ","
+	echo "\"latest_summary\":"
+	echo "${_summary_json:-[]}"
+	echo ","
+	echo "\"recent_messages\":"
+	echo "${_messages_json:-[]}"
 	echo "}"
 	return 0
 }
@@ -180,9 +187,10 @@ EOF
 		echo "  (no messages yet)"
 	else
 		if [[ "$privacy_filter" == true ]]; then
-			messages=$(echo "$messages" | sed 's/[a-zA-Z0-9._%+-]\+@[a-zA-Z0-9.-]\+\.[a-zA-Z]\{2,\}/[EMAIL]/g')
-			messages=$(echo "$messages" | sed 's/\b[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\b/[IP]/g')
-			messages=$(echo "$messages" | sed 's/sk-[a-zA-Z0-9_-]\{20,\}/[API_KEY]/g')
+			messages=$(echo "$messages" | sed \
+				-e 's/[a-zA-Z0-9._%+-]\+@[a-zA-Z0-9.-]\+\.[a-zA-Z]\{2,\}/[EMAIL]/g' \
+				-e 's/\b[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\.[0-9]\{1,3\}\b/[IP]/g' \
+				-e 's/sk-[a-zA-Z0-9_-]\{20,\}/[API_KEY]/g')
 		fi
 		echo "$messages"
 	fi
@@ -287,12 +295,11 @@ EOF
 		return 1
 	fi
 
-	local entity_id entity_name entity_type channel topic
-	entity_id=$(conv_db "$CONV_MEMORY_DB" "SELECT entity_id FROM conversations WHERE id = '$esc_id';")
-	entity_name=$(conv_db "$CONV_MEMORY_DB" "SELECT e.name FROM conversations c JOIN entities e ON c.entity_id = e.id WHERE c.id = '$esc_id';")
-	entity_type=$(conv_db "$CONV_MEMORY_DB" "SELECT e.type FROM conversations c JOIN entities e ON c.entity_id = e.id WHERE c.id = '$esc_id';")
-	channel=$(conv_db "$CONV_MEMORY_DB" "SELECT channel FROM conversations WHERE id = '$esc_id';")
-	topic=$(conv_db "$CONV_MEMORY_DB" "SELECT topic FROM conversations WHERE id = '$esc_id';")
+	# Parse all required fields from conv_data (already fetched above) instead
+	# of issuing 5 more round-trips to SQLite.
+	# SELECT order: entity_id | channel | channel_id | topic | status | interaction_count | entity_name | entity_type
+	local entity_id channel topic entity_name entity_type _channel_id _status _int_count
+	IFS='|' read -r entity_id channel _channel_id topic _status _int_count entity_name entity_type <<<"$conv_data"
 
 	local esc_entity
 	esc_entity=$(conv_sql_escape "$entity_id")
@@ -597,11 +604,11 @@ EOF
 	)
 
 	# Generate summary via AI (with heuristic fallback)
+	# _summarise_call_ai prints exactly 3 newline-separated lines; parse with
+	# read instead of spawning 3 sed processes.
 	local ai_output summary tone_profile pending_actions
 	ai_output=$(_summarise_call_ai "$entity_name" "$int_count" "$formatted_interactions" "$interaction_data")
-	summary=$(echo "$ai_output" | sed -n '1p')
-	tone_profile=$(echo "$ai_output" | sed -n '2p')
-	pending_actions=$(echo "$ai_output" | sed -n '3p')
+	{ read -r summary; read -r tone_profile; read -r pending_actions; } <<<"$ai_output"
 
 	# Store and return the new summary ID
 	_summarise_store "$esc_id" "$conv_id" "$summary" "$tone_profile" "$pending_actions" \

--- a/.agents/scripts/conversation-helper-interaction.sh
+++ b/.agents/scripts/conversation-helper-interaction.sh
@@ -115,9 +115,12 @@ check_single_conversation_idle() {
 	local esc_id
 	esc_id=$(conv_sql_escape "$conv_id")
 
-	# Get conversation metadata
-	local last_activity
-	last_activity=$(conv_db "$CONV_MEMORY_DB" "SELECT last_interaction_at FROM conversations WHERE id = '$esc_id';" 2>/dev/null || echo "")
+	# Get conversation metadata in a single query instead of two round-trips.
+	# Columns: last_interaction_at | interaction_count
+	local _conv_row last_activity interaction_count
+	_conv_row=$(conv_db "$CONV_MEMORY_DB" "SELECT last_interaction_at, interaction_count FROM conversations WHERE id = '$esc_id';" 2>/dev/null || echo "")
+	IFS='|' read -r last_activity interaction_count <<<"$_conv_row"
+	interaction_count="${interaction_count:-0}"
 
 	if [[ -z "$last_activity" ]]; then
 		echo "idle"
@@ -167,8 +170,7 @@ Respond with ONLY one word: 'idle' or 'active'"
 	# - Medium conversations (5-20 messages): idle after 30 minutes
 	# - Long conversations (> 20 messages): idle after 1 hour
 	# - If last message looks like a farewell/acknowledgment: idle after 5 minutes
-	local interaction_count
-	interaction_count=$(conv_db "$CONV_MEMORY_DB" "SELECT interaction_count FROM conversations WHERE id = '$esc_id';" 2>/dev/null || echo "0")
+	# interaction_count already fetched in the combined query at the top of this function.
 
 	# Check for farewell patterns in last message
 	local last_message
@@ -377,8 +379,11 @@ _add_message_direct_log() {
 
 	log_warn "entity-helper.sh not found — logging interaction directly"
 
-	# Privacy filter
-	content=$(echo "$content" | sed 's/<private>[^<]*<\/private>//g' | sed 's/  */ /g' | sed 's/^ *//;s/ *$//')
+	# Privacy filter — single sed invocation with multiple -e expressions
+	content=$(echo "$content" | sed \
+		-e 's/<private>[^<]*<\/private>//g' \
+		-e 's/  */ /g' \
+		-e 's/^ *//;s/ *$//')
 	if echo "$content" | grep -qE '(sk-[a-zA-Z0-9_-]{20,}|AKIA[0-9A-Z]{16}|ghp_[a-zA-Z0-9]{36})'; then
 		log_error "Content appears to contain secrets. Refusing to log."
 		return 1
@@ -471,25 +476,20 @@ cmd_add_message() {
 	local esc_id
 	esc_id=$(conv_sql_escape "$conv_id")
 
-	# Get conversation details
-	local conv_entity_id channel channel_id
-	conv_entity_id=$(conv_db "$CONV_MEMORY_DB" "SELECT entity_id FROM conversations WHERE id = '$esc_id';" 2>/dev/null || echo "")
-	if [[ -z "$conv_entity_id" ]]; then
+	# Get all conversation details in a single query instead of 4 round-trips.
+	# Columns: entity_id | channel | channel_id | status
+	local _conv_row conv_entity_id channel channel_id status
+	_conv_row=$(conv_db "$CONV_MEMORY_DB" "SELECT entity_id, channel, channel_id, status FROM conversations WHERE id = '$esc_id';" 2>/dev/null || echo "")
+	if [[ -z "$_conv_row" ]]; then
 		log_error "Conversation not found: $conv_id"
 		return 1
 	fi
-
-	channel=$(conv_db "$CONV_MEMORY_DB" "SELECT channel FROM conversations WHERE id = '$esc_id';")
-	channel_id=$(conv_db "$CONV_MEMORY_DB" "SELECT channel_id FROM conversations WHERE id = '$esc_id';")
+	IFS='|' read -r conv_entity_id channel channel_id status <<<"$_conv_row"
 
 	# Use provided entity_id or fall back to conversation's entity
 	if [[ -z "$entity_id" ]]; then
 		entity_id="$conv_entity_id"
 	fi
-
-	# If conversation is idle/closed, resume it
-	local status
-	status=$(conv_db "$CONV_MEMORY_DB" "SELECT status FROM conversations WHERE id = '$esc_id';")
 	if [[ "$status" != "active" ]]; then
 		log_info "Resuming $status conversation $conv_id"
 		cmd_resume "$conv_id" >/dev/null


### PR DESCRIPTION
## Summary

Addresses all 7 inline review comments from Gemini on PR #21526 (`conversation-helper-context.sh` and `conversation-helper-interaction.sh`).

All findings verified against current code — every premise was correct. All fixes are Outcome B (correct premise, obvious fix).

### Changes

**conversation-helper-context.sh**

- `_context_output_json`: Capture each `conv_db -json` result into a local variable and emit `${var:-[]}` — guards against `sqlite3 -json` returning empty string (not `[]`) for zero-row results on older SQLite builds, which would produce invalid JSON like `"latest_summary": ,`
- `_context_text_recent_messages:185`: Combine 3 sequential `sed` calls into a single `sed -e … -e … -e …` invocation (reduces process forks)
- `cmd_context:295`: Replace 5 redundant SQLite round-trips (same row already fetched in `conv_data`) with `IFS='|' read` from the existing result
- `cmd_summarise:604`: Replace `sed -n '1p'` / `sed -n '2p'` / `sed -n '3p'` line extractions with `{ read -r summary; read -r tone_profile; read -r pending_actions; } <<<"$ai_output"`

**conversation-helper-interaction.sh**

- `check_single_conversation_idle:171`: Combine `last_interaction_at` and `interaction_count` from 2 separate queries into 1 at the top of the function; remove the now-redundant second query
- `_add_message_direct_log:381`: Combine 3 sequential `sed` calls into a single `sed -e … -e … -e …` invocation
- `cmd_add_message:492`: Combine 4 separate `entity_id`, `channel`, `channel_id`, `status` queries into 1 `SELECT … FROM conversations WHERE id` query parsed with `IFS='|' read`

### Verification

```
shellcheck .agents/scripts/conversation-helper-context.sh
shellcheck .agents/scripts/conversation-helper-interaction.sh
```

Both pass clean (zero violations).

Resolves #21649

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-sonnet-4-6 spent 10m and 16,993 tokens on this as a headless worker.
