### PR TITLE
GH#21636: fix jq optional operator on nested components/incident_updates fields

### DIFF
--- a/.agents/scripts/gh-status-helper.sh
+++ b/.agents/scripts/gh-status-helper.sh
@@ -195,7 +195,7 @@ cmd_incidents() {
 	fi
 
 	if [[ "$ARG_JSON" -eq 1 ]]; then
-		jq '{incidents: [.incidents[]? | {name, impact, started_at, latest_update: (.incident_updates[0].body // ""), components: [.components[].name]}]}' "$CACHE_INCIDENTS"
+		jq '{incidents: [.incidents[]? | {name, impact, started_at, latest_update: (.incident_updates[0].body? // ""), components: [.components[]?.name]}]}' "$CACHE_INCIDENTS"
 	else
 		# Human-readable listing. Empty list = healthy.
 		local count
@@ -233,7 +233,7 @@ cmd_correlate() {
 		count=$(jq '.incidents | length' "$CACHE_INCIDENTS")
 		if [[ "$count" -gt 0 ]]; then
 			printf 'Active incidents:\n\n'
-			jq -r '.incidents[]? | "- **[\(.impact)]** \(.name) — components: \([.components[].name] | join(", ")) (started \(.started_at))"' "$CACHE_INCIDENTS"
+			jq -r '.incidents[]? | "- **[\(.impact)]** \(.name) — components: \([.components[]?.name] | join(", ")) (started \(.started_at))"' "$CACHE_INCIDENTS"
 			printf '\n'
 		fi
 	fi


### PR DESCRIPTION
## Summary

Apply the jq optional operator (`?`) to nested field accesses in `gh-status-helper.sh` to prevent `TypeError` when GitHub Statuspage API responses contain null or missing `components` or `incident_updates` fields.

## Changes

**`.agents/scripts/gh-status-helper.sh:198`** (`cmd_incidents` — JSON output path):
- `.incident_updates[0].body` → `.incident_updates[0].body?` — defensive against null/missing `incident_updates[0]`
- `.components[].name` → `.components[]?.name` — prevents error when `components` is null or absent

**`.agents/scripts/gh-status-helper.sh:236`** (`cmd_correlate` — incident listing path):
- `.components[].name` → `.components[]?.name` — consistent with the fix above

## Verification

- `shellcheck .agents/scripts/gh-status-helper.sh` — passes clean (zero violations)
- Pre-commit and pre-push quality gates passed

Resolves #21636

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-sonnet-4-6 spent 4m and 3,863 tokens on this as a headless worker.