### PR TITLE
GH#21634: fix(claim-task-id): update fallback to (no title), remove dead LONG_DESC

### DIFF
--- a/.agents/scripts/claim-task-id-issue.sh
+++ b/.agents/scripts/claim-task-id-issue.sh
@@ -641,7 +641,7 @@ _ensure_todo_entry_written() {
 	local safe_desc
 	safe_desc=$(printf '%s' "$title" \
 		| tr '\n\t' '  ' | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')
-	[[ -z "$safe_desc" ]] && safe_desc="(no description)"
+	[[ -z "$safe_desc" ]] && safe_desc="(no title)"
 	local todo_line="- [ ] ${task_id} ${safe_desc}"
 	[[ -n "$tags_str" ]] && todo_line="${todo_line} ${tags_str}"
 	# GH#20834: append blocked-by tag when predecessor refs were auto-detected.

--- a/.agents/scripts/tests/test-claim-todo-entry-title.sh
+++ b/.agents/scripts/tests/test-claim-todo-entry-title.sh
@@ -182,8 +182,6 @@ run_ensure() {
 # Test cases
 # ---------------------------------------------------------------------------
 
-LONG_DESC="$(printf '## Task\n\nUpdate 6 downstream briefs.\n\n## Why\n\nThe enum counts changed.\n\n## How\n\nEdit each brief file.\n')"
-
 # 1. GH#21473 regression: title used, not multi-paragraph description
 result1="$(run_ensure "t344" "2107" "align 6 downstream briefs" "" )"
 assert_eq "title_not_description_in_todo_line" \
@@ -207,11 +205,11 @@ assert_eq "title_whitespace_trimmed" \
 	"$result3" \
 	"- [ ] t100 spaced title ref:GH#999"
 
-# 4. Empty title falls back to (no description)
+# 4. Empty title falls back to (no title)
 result4="$(run_ensure "t101" "888" "" "")"
 assert_eq "empty_title_fallback" \
 	"$result4" \
-	"- [ ] t101 (no description) ref:GH#888"
+	"- [ ] t101 (no title) ref:GH#888"
 
 # 5. Labels are appended as #tags, reserved prefixes skipped
 result5="$(run_ensure "t200" "777" "my task title" "auto-dispatch,status:available,tier:standard,bug")"


### PR DESCRIPTION
## Summary

Applied 3 Gemini review suggestions from PR #21535:

1. **`claim-task-id-issue.sh:644`** — changed fallback text from `(no description)` to `(no title)` since the variable now operates on `$title` (per GH#21473 fix in PR #21535). The old text was misleading.
2. **`test-claim-todo-entry-title.sh:185`** — removed unused `LONG_DESC` variable (dead code — defined but never referenced in any test case).
3. **`test-claim-todo-entry-title.sh:214`** — updated test expectation from `(no description)` to `(no title)` to align with the fix in (1).

## Verification

- `shellcheck .agents/scripts/claim-task-id-issue.sh` — zero violations
- `shellcheck .agents/scripts/tests/test-claim-todo-entry-title.sh` — zero violations
- `bash .agents/scripts/tests/test-claim-todo-entry-title.sh` — 11/11 tests pass

Resolves #21634

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-sonnet-4-6 spent 4m and 5,311 tokens on this as a headless worker.
