### PR TITLE
GH#21637: fix source_pdf fallback for empty strings and content_hash for headingless docs

### DIFF
--- a/.agents/scripts/pageindex-generator.py
+++ b/.agents/scripts/pageindex-generator.py
@@ -241,7 +241,7 @@ def build_headingless_result(
     return {
         "version": "1.0",
         "generator": "aidevops/document-creation-helper",
-        "source_file": frontmatter.get('source_file', source_pdf),
+        "source_file": frontmatter.get('source_file') or source_pdf,
         "content_hash": frontmatter.get('content_hash', ''),
         "page_count": ctx.page_count,
         "tree": {
@@ -290,7 +290,9 @@ def build_pageindex_tree(
     sections = parse_sections(content_lines)
 
     if not sections:
+        content_hash = frontmatter.get('content_hash') or hashlib.sha256('\n'.join(lines).encode('utf-8')).hexdigest()
         result = build_headingless_result(frontmatter, content_lines, ctx, source_pdf)
+        result['content_hash'] = content_hash
         root_node = result['tree']
         for tag_rec in open_tags:
             _inject_tag_record(root_node, tag_rec)
@@ -329,7 +331,7 @@ def build_pageindex_tree(
     result = {
         "version": "1.0",
         "generator": "aidevops/document-creation-helper",
-        "source_file": frontmatter.get('source_file', source_pdf),
+        "source_file": frontmatter.get('source_file') or source_pdf,
         "content_hash": content_hash,
         "page_count": page_count,
         "tree": tree,


### PR DESCRIPTION
## Summary

Three review feedback items from Gemini on PR #21531, all verified as correct premises:

1. **`source_file` empty-string fallback** (`build_headingless_result` line 244): `.get('source_file', source_pdf)` only uses `source_pdf` when the key is absent; using `or` also handles the case where frontmatter has `source_file: ""`.

2. **`content_hash` missing for headingless documents** (line 293): The early return path bypassed the SHA-256 computation at lines 325-327. Headingless docs consistently received an empty `content_hash` whenever the frontmatter field was absent. Fixed by computing it before the early return.

3. **`source_file` empty-string fallback** (`build_pageindex_tree` headed path, line 332): Same issue as #1.

## Files Modified

- `EDIT: .agents/scripts/pageindex-generator.py` — 4 lines changed, 2 deletions

## Verification

```
python3 -m py_compile .agents/scripts/pageindex-generator.py  # Syntax OK
```

Resolves #21637

<!-- aidevops:sig -->