### PR TITLE
GH#21632: pre-compute _canon_norm once per workflow type in _process_rows

### DIFF
--- a/.agents/scripts/check-workflows-helper.sh
+++ b/.agents/scripts/check-workflows-helper.sh
@@ -462,6 +462,15 @@ _process_rows() {
 		# Pre-compute once per workflow (loop-invariant); avoids a subshell per repo.
 		local _reusable_escaped
 		_reusable_escaped=$(printf '%s' "$_reusable_file" | sed 's/\./\\./g')
+		# Pre-compute normalised canonical content once per workflow type (not once per
+		# repo). Passes _canon_norm to _classify_row → _classify_workflow, activating
+		# the pre-computed path at _classify_workflow:193-194 and skipping the per-repo
+		# _normalize_wf_for_compare subshell. Guard for empty _canonical (template not
+		# found) — _classify_row handles that path; _canon_norm is not needed there.
+		local _canon_norm=""
+		if [[ -n "$_canonical" ]]; then
+			_canon_norm=$(_normalize_wf_for_compare "$_canonical" "$_reusable_escaped")
+		fi
 
 		local _path _local_only_flag _slug
 		while IFS=$'\t' read -r _path _local_only_flag _slug; do
@@ -475,7 +484,7 @@ _process_rows() {
 			local _class _note
 			IFS=$'\t' read -r _class _note < <(_classify_row \
 				"$_path" "$_local_only_flag" "$_canonical" \
-				"$_reusable_escaped" "$_workflow_file" "")
+				"$_reusable_escaped" "$_workflow_file" "$_canon_norm")
 
 			case "$_class" in
 			LOCAL-ONLY) _local_only=$((_local_only + 1)) ;;


### PR DESCRIPTION
## Summary

Activates the dormant loop-invariant optimisation for `_canon_norm` pre-computation in `_process_rows`.

**Root cause:** PR #21537 (GH#21477) fixed a DRIFTED/CALLER false positive by dropping the broken TSV transport in `_resolve_wf_canonical`. The fix correctly reverted to computing `_canon_norm` per-repo inside `_classify_workflow`. However, the pre-computation infrastructure introduced in PR #20809 — `_classify_workflow`'s optional `_canon_norm_pre` parameter (line 160) and `_classify_row`'s 6th argument (line 369) — was left dormant: `_process_rows` passed `""` for that slot, so `_classify_workflow` always fell through to the per-repo `_normalize_wf_for_compare` subshell.

**Fix:** Compute `_canon_norm` once per workflow type in `_process_rows` (already outside the per-repo `while` loop) and pass it as the 6th argument to `_classify_row`. `_classify_workflow` uses the pre-computed value at lines 193-194, skipping the per-repo sed pipeline. Guard: skip when `_canonical` is empty (template not found), consistent with `_classify_row`'s own early-exit at line 382.

**Impact:** Reduces `_normalize_wf_for_compare` calls from ~150 (3 workflows × ~50 repos) to 3 per run.

## Files changed

- `EDIT: .agents/scripts/check-workflows-helper.sh:460-473` — add `_canon_norm` pre-computation block; update `_classify_row` call to pass `"$_canon_norm"` instead of `""`

## Verification

- `shellcheck .agents/scripts/check-workflows-helper.sh` — passes clean (zero violations)
- `bash .agents/scripts/tests/test-check-workflows-helper.sh` — all 12 tests pass
- `bash .agents/scripts/tests/test-check-workflows-classifier.sh` — all 12 tests pass

Resolves #21632

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-sonnet-4-6 spent 9m and 10,567 tokens on this as a headless worker.