### PR TITLE
GH#21633: fix blocked-by:GH#NNN regex and failed auto-create validation

### DIFF
--- a/.agents/scripts/claim-task-id.sh
+++ b/.agents/scripts/claim-task-id.sh
@@ -675,10 +675,12 @@ _extract_github_slug() {
 	return 0
 }
 
-# _auto_create_blocked_by_label — create a missing blocked-by:tNNN or blocked-by:#NNN
-# label in the repo when it does not yet exist. Updates the session label cache on success.
+# _auto_create_blocked_by_label — create a missing blocked-by:tNNN / blocked-by:GH#NNN /
+# blocked-by:#NNN label in the repo when it does not yet exist.
+# Updates the session label cache on success.
 # Args: $1 repo_slug (owner/repo), $2 label name (e.g. "blocked-by:t324"), $3 cache_file path.
 # Returns: 0 = label created (or already exists), 1 = creation failed (rate limit / permission).
+# Callers MUST treat a non-zero return as a validation error — do NOT use || true (GH#21633).
 _auto_create_blocked_by_label() {
 	local repo_slug="$1"
 	local label="$2"
@@ -703,9 +705,10 @@ _auto_create_blocked_by_label() {
 # Args: $1 repo_slug (owner/repo), $2 comma-separated label names.
 # Returns: 0 = all valid (or fail-open), 1 = invalid labels found.
 #
-# Auto-create exception (GH#21474): labels matching ^blocked-by:(t[0-9]+|#[0-9]+)$
+# Auto-create exception (GH#21474): labels matching ^blocked-by:(t[0-9]+|GH#[0-9]+|#[0-9]+)$
 # are auto-created when missing — they are a deterministic function of the predecessor
-# task ID and safe to create on demand. All other invalid labels still abort (exit 3).
+# task ID and safe to create on demand. Creation failure aborts the claim (GH#21633).
+# All other invalid labels still abort (exit 3).
 _validate_labels_exist() {
 	local repo_slug="$1"
 	local labels_csv="$2"
@@ -735,9 +738,11 @@ _validate_labels_exist() {
 		fi
 	fi
 
-	# Regex for the auto-create exception class (blocked-by:tNNN or blocked-by:#NNN).
-	# These labels are auto-created when missing — all other invalid labels still abort.
-	local _BLOCKED_BY_AUTO_CREATE_REGEX='^blocked-by:(t[0-9]+|#[0-9]+)$'
+	# Regex for the auto-create exception class (blocked-by:tNNN / blocked-by:GH#NNN / blocked-by:#NNN).
+	# _normalise_ref() in _detect_predecessor_refs produces GH#NNN for GitHub issue refs,
+	# so the GH# prefix must be included or those normalised labels fail the check and abort.
+	# All other invalid labels still abort.
+	local _BLOCKED_BY_AUTO_CREATE_REGEX='^blocked-by:(t[0-9]+|GH#[0-9]+|#[0-9]+)$'
 
 	# Check each label against the cache
 	local invalid_labels=""
@@ -754,14 +759,20 @@ _validate_labels_exist() {
 		label="${label%"${label##*[![:space:]]}"}"  # trim trailing whitespace
 		[[ -z "$label" ]] && continue
 		if ! grep -Fxq "$label" "$cache_file" 2>/dev/null; then
-			# Auto-create exception: blocked-by:tNNN / blocked-by:#NNN labels are
-			# synthesised by t2823 from description text and may not exist yet in fresh
-			# consumer repos. Create them on demand and continue — best-effort (t2800/GH#21474).
+			# Auto-create exception: blocked-by:tNNN / blocked-by:GH#NNN / blocked-by:#NNN
+			# labels are synthesised by t2823 from description text and may not exist yet in
+			# fresh consumer repos. Create them on demand (t2800/GH#21474).
+			# If creation fails (e.g. insufficient permissions), treat the label as invalid
+			# so the claim aborts BEFORE the counter is advanced — preserves atomic-claim
+			# guarantee (GH#21633: stranded task ID on failed auto-create).
 			if [[ "$label" =~ $_BLOCKED_BY_AUTO_CREATE_REGEX ]]; then
-				_auto_create_blocked_by_label "$repo_slug" "$label" "$cache_file" || true
-				# Whether creation succeeded or not, don't abort — body text still records
-				# the dependency for pulse-dep-graph.sh and pulse-issue-reconcile-actions.sh.
-				continue
+				if ! _auto_create_blocked_by_label "$repo_slug" "$label" "$cache_file"; then
+					# Creation failed — fall through to the invalid_labels accumulator below.
+					: # (intentional — do not continue, let the guard below record the label)
+				else
+					# Creation succeeded — skip normal validation for this label.
+					continue
+				fi
 			fi
 			if [[ -n "$invalid_labels" ]]; then
 				invalid_labels="${invalid_labels}, '${label}'"

--- a/.agents/scripts/tests/test-claim-label-auto-create.sh
+++ b/.agents/scripts/tests/test-claim-label-auto-create.sh
@@ -258,7 +258,9 @@ STUB
 }
 
 # ---------------------------------------------------------------------------
-# Test 4: blocked-by:#999 (issue-number variant), gh create succeeds → returns 0
+# Test 4: blocked-by:GH#999 (normalised GitHub issue ref), gh create succeeds → returns 0
+# _normalise_ref() in _detect_predecessor_refs produces GH#NNN (not bare #NNN), so
+# the regex must match the GH# prefix — this test covers that path (GH#21633).
 # ---------------------------------------------------------------------------
 _run_test4() {
 	local stub_dir
@@ -287,16 +289,16 @@ STUB
 	unset AIDEVOPS_LABEL_CACHE_FILE
 
 	local rc=0
-	_validate_labels_exist "owner/repo" "bug,blocked-by:#999" 2>/dev/null || rc=$?
+	_validate_labels_exist "owner/repo" "bug,blocked-by:GH#999" 2>/dev/null || rc=$?
 
 	PATH="$saved_path"
 	[[ -n "$saved_cache" ]] && export AIDEVOPS_LABEL_CACHE_FILE="$saved_cache" || true
 
-	assert_return "test4_blocked_by_hash_variant_returns_0" "$rc" "0"
+	assert_return "test4_blocked_by_gh_hash_variant_returns_0" "$rc" "0"
 
 	local create_called=""
 	[[ -f "$create_called_file" ]] && create_called="$(cat "$create_called_file")"
-	assert_eq "test4_gh_label_create_was_called_for_hash_variant" "$create_called" "called"
+	assert_eq "test4_gh_label_create_was_called_for_gh_hash_variant" "$create_called" "called"
 
 	return 0
 }


### PR DESCRIPTION
## Summary

Three fixes from Gemini review of PR #21536 (GH#21474):

### Fix 1 — Missing `GH#` prefix in auto-create regex

`_normalise_ref()` inside `_detect_predecessor_refs` canonicalises GitHub issue refs to `GH#NNN` format. The previous regex `^blocked-by:(t[0-9]+|#[0-9]+)$` did not include `GH#[0-9]+`, so labels like `blocked-by:GH#999` fell through to the `invalid_labels` accumulator and aborted the claim — defeating the purpose of the fix for GitHub-hosted predecessors.

Fixed: `.agents/scripts/claim-task-id.sh` — regex updated to `^blocked-by:(t[0-9]+|GH#[0-9]+|#[0-9]+)$`.

### Fix 2 — Failed auto-create must abort claim (not be silently swallowed)

The previous `_auto_create_blocked_by_label ... || true` pattern meant: if label creation fails (e.g. insufficient permissions), the code would `continue` past the label without adding it to `invalid_labels`. Validation then returns 0, the counter IS advanced, and the subsequent `gh issue create --label blocked-by:t999` fails because the label still doesn't exist — a stranded task ID.

Fixed: failure of `_auto_create_blocked_by_label` now falls through to the `invalid_labels` accumulator so the claim aborts BEFORE the counter is advanced, preserving the atomic-claim guarantee from t2800.

### Fix 3 — Test 4 updated to cover normalised `GH#` form

Test 4 previously used `blocked-by:#999`. After fix 1, the `GH#NNN` path is the critical one (it's what `_detect_predecessor_refs` actually emits). Test updated to `blocked-by:GH#999` with updated assertion names and an explanatory comment.

## Files modified

- `EDIT: .agents/scripts/claim-task-id.sh` — regex + auto-create failure handling + function-level doc
- `EDIT: .agents/scripts/tests/test-claim-label-auto-create.sh` — test 4 updated to GH#999

## Testing

- `shellcheck .agents/scripts/claim-task-id.sh` — clean
- `shellcheck .agents/scripts/tests/test-claim-label-auto-create.sh` — clean
- Pre-commit hook passed

Resolves #21633

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-sonnet-4-6 spent 11m and 13,976 tokens on this as a headless worker.