### PR TITLE
GH#21631: use bash parameter expansion instead of tr in _dt_json_field numeric path

### DIFF
--- a/.agents/scripts/dispatch-timing-helper.sh
+++ b/.agents/scripts/dispatch-timing-helper.sh
@@ -304,7 +304,8 @@ _dt_json_field() {
 		return 0
 	fi
 	# Try numeric
-	val=$(printf '%s' "$line" | grep -oE "\"${field}\"[[:space:]]*:[[:space:]]*[0-9]+" | tail -1 | cut -d: -f2 | tr -d ' ')
+	val=$(printf '%s' "$line" | grep -oE "\"${field}\"[[:space:]]*:[[:space:]]*[0-9]+" | tail -1 | cut -d: -f2)
+	val=${val// /}
 	echo "$val"
 	return 0
 }


### PR DESCRIPTION
## Summary

Replace `| tr -d ' '` (subprocess) with Bash built-in `${val// /}` (parameter expansion) in the numeric branch of `_dt_json_field` in `.agents/scripts/dispatch-timing-helper.sh`.

This eliminates an unnecessary `tr` subprocess spawn on every numeric field extraction. The change is functionally equivalent: both remove space characters from the extracted value. Bash 3.2 compatible — `${var//pattern/replacement}` is supported since bash 2.0.

## Changes

- `EDIT: .agents/scripts/dispatch-timing-helper.sh:307` — split the numeric `val` pipeline to terminate at `cut -d: -f2`, then apply `${val// /}` as a second statement instead of piping through `tr`.

## Verification

- `shellcheck .agents/scripts/dispatch-timing-helper.sh` passes clean (zero violations)
- Logic is identical: `cut -d: -f2` extracts the number with possible leading space; `${val// /}` strips spaces inline without forking.

Resolves #21631

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-sonnet-4-6 spent 3m and 4,495 tokens on this as a headless worker.
