### PR TITLE
GH#21541: fix(auto-update): guard NextElapse grep against systemd 255 rename

### DIFF
--- a/.agents/scripts/auto-update-helper-status.sh
+++ b/.agents/scripts/auto-update-helper-status.sh
@@ -85,9 +85,19 @@ _cmd_status_scheduler() {
 			local enabled_state
 			enabled_state=$(systemctl --user is-enabled "${SYSTEMD_UNIT_NAME}.timer" 2>/dev/null || echo "unknown")
 			local timer_props next_elapse last_trigger
-			timer_props=$(systemctl --user show -p NextElapse,LastTriggerUSec "${SYSTEMD_UNIT_NAME}.timer" 2>/dev/null || true)
-			next_elapse=$(echo "$timer_props" | grep '^NextElapse=' | cut -d= -f2-)
-			last_trigger=$(echo "$timer_props" | grep '^LastTriggerUSec=' | cut -d= -f2-)
+			# Request all NextElapse variants: NextElapse (pre-255) and
+			# NextElapseUSecRealtime/NextElapseUSecMonotonic (systemd 255+)
+			timer_props=$(systemctl --user show -p NextElapse,NextElapseUSecRealtime,NextElapseUSecMonotonic,LastTriggerUSec "${SYSTEMD_UNIT_NAME}.timer" 2>/dev/null || true)
+			# Guard each grep with || true — under set -euo pipefail a no-match
+			# exit 1 propagates and kills the entire script (GH#21541)
+			next_elapse=$(echo "$timer_props" | grep '^NextElapse=' | cut -d= -f2- || true)
+			if [[ -z "$next_elapse" ]]; then
+				next_elapse=$(echo "$timer_props" | grep '^NextElapseUSecRealtime=' | cut -d= -f2- || true)
+			fi
+			if [[ -z "$next_elapse" ]]; then
+				next_elapse=$(echo "$timer_props" | grep '^NextElapseUSecMonotonic=' | cut -d= -f2- || true)
+			fi
+			last_trigger=$(echo "$timer_props" | grep '^LastTriggerUSec=' | cut -d= -f2- || true)
 			echo -e "  Scheduler: systemd (user timer)"
 			if [[ "$enabled_state" == "enabled" ]] || [[ "$enabled_state" == "enabled-runtime" ]]; then
 				echo -e "  Status:    ${GREEN}${enabled_state}${NC}"

--- a/.agents/scripts/auto-update-helper.sh
+++ b/.agents/scripts/auto-update-helper.sh
@@ -1209,9 +1209,19 @@ _cmd_status_scheduler() {
 			local enabled_state
 			enabled_state=$(systemctl --user is-enabled "${SYSTEMD_UNIT_NAME}.timer" 2>/dev/null || echo "unknown")
 			local timer_props next_elapse last_trigger
-			timer_props=$(systemctl --user show -p NextElapse,LastTriggerUSec "${SYSTEMD_UNIT_NAME}.timer" 2>/dev/null || true)
-			next_elapse=$(echo "$timer_props" | grep '^NextElapse=' | cut -d= -f2-)
-			last_trigger=$(echo "$timer_props" | grep '^LastTriggerUSec=' | cut -d= -f2-)
+			# Request all NextElapse variants: NextElapse (pre-255) and
+			# NextElapseUSecRealtime/NextElapseUSecMonotonic (systemd 255+)
+			timer_props=$(systemctl --user show -p NextElapse,NextElapseUSecRealtime,NextElapseUSecMonotonic,LastTriggerUSec "${SYSTEMD_UNIT_NAME}.timer" 2>/dev/null || true)
+			# Guard each grep with || true — under set -euo pipefail a no-match
+			# exit 1 propagates and kills the entire script (GH#21541)
+			next_elapse=$(echo "$timer_props" | grep '^NextElapse=' | cut -d= -f2- || true)
+			if [[ -z "$next_elapse" ]]; then
+				next_elapse=$(echo "$timer_props" | grep '^NextElapseUSecRealtime=' | cut -d= -f2- || true)
+			fi
+			if [[ -z "$next_elapse" ]]; then
+				next_elapse=$(echo "$timer_props" | grep '^NextElapseUSecMonotonic=' | cut -d= -f2- || true)
+			fi
+			last_trigger=$(echo "$timer_props" | grep '^LastTriggerUSec=' | cut -d= -f2- || true)
 			echo -e "  Scheduler: systemd (user timer)"
 			if [[ "$enabled_state" == "enabled" ]] || [[ "$enabled_state" == "enabled-runtime" ]]; then
 				echo -e "  Status:    ${GREEN}${enabled_state}${NC}"


### PR DESCRIPTION
## Summary

Fixed _cmd_status_scheduler crash on Linux systemd 255 where NextElapse property was renamed. Now requests all three property variants and guards each grep with || true to prevent set -euo pipefail pipeline failure. Applied fix to both auto-update-helper.sh and the extracted sub-module auto-update-helper-status.sh.

## Files Changed

.agents/scripts/auto-update-helper-status.sh,.agents/scripts/auto-update-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck passes zero violations on both modified files; verified fix covers all property name variants across systemd versions

Resolves #21541


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-sonnet-4-6 spent 9m and 13,028 tokens on this as a headless worker.