### PR TITLE
t2917: feat: add _resolve_log_dir to shared-constants.sh, replace hardcoded log paths in runners

### DIFF
--- a/.agents/scripts/complexity-scan-runner.sh
+++ b/.agents/scripts/complexity-scan-runner.sh
@@ -78,7 +78,8 @@ source "${SCRIPT_DIR}/pulse-simplification-state.sh"
 # Runner-level state files
 # =============================================================================
 
-RUNNER_LOG_FILE="${HOME}/.aidevops/logs/complexity-scan-runner.log"
+RUNNER_LOG_DIR=$(_resolve_log_dir)
+RUNNER_LOG_FILE="${RUNNER_LOG_DIR}/complexity-scan-runner.log"
 LOCK_DIR="${HOME}/.aidevops/.agent-workspace/locks/complexity-scan.lock"
 
 mkdir -p "$(dirname "$RUNNER_LOG_FILE")" "$(dirname "$LOCK_DIR")"

--- a/.agents/scripts/efficiency-analysis-runner.sh
+++ b/.agents/scripts/efficiency-analysis-runner.sh
@@ -42,7 +42,8 @@ LOG_PREFIX="EFFICIENCY-RUNNER"
 # Constants
 # =============================================================================
 
-readonly LOGS_DIR="${HOME}/.aidevops/logs"
+LOGS_DIR=$(_resolve_log_dir)
+readonly LOGS_DIR
 readonly AGENT_WORKSPACE="${HOME}/.aidevops/.agent-workspace"
 readonly COLLECTOR_SCRIPT="${SCRIPT_DIR}/orchestration-efficiency-collector.sh"
 readonly HEADLESS_RUNTIME="${SCRIPT_DIR}/headless-runtime-helper.sh"

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -756,13 +756,32 @@ _file_perms() {
 #   - sqlite3, gh, curl, git push/merge: use log_stderr (errors matter)
 #   - rm, mkdir with || true: keep 2>/dev/null (race conditions)
 
+# Resolve the canonical aidevops log directory at runtime.
+# Reads paths.log_dir from ~/.aidevops/config/paths.jsonc when config-helper.sh
+# is sourced (provides _jsonc_get), falls back to ~/.aidevops/logs otherwise.
+# Tilde-expansion handled. Prints the resolved absolute path.
+_resolve_log_dir() {
+	local resolved
+	# shellcheck disable=SC2088  # Tilde is intentionally literal; expanded below
+	if type _jsonc_get >/dev/null 2>&1; then
+		resolved=$(_jsonc_get "paths.log_dir" "~/.aidevops/logs")
+	else
+		resolved="~/.aidevops/logs"
+	fi
+	# Tilde expansion
+	resolved="${resolved/#\~/$HOME}"
+	printf '%s\n' "$resolved"
+	return 0
+}
+
 # Initialize log file for the calling script.
-# Sets AIDEVOPS_LOG_FILE to ~/.aidevops/logs/<script-name>.log
+# Sets AIDEVOPS_LOG_FILE to <log_dir>/<script-name>.log
 # Call once at script start after sourcing shared-constants.sh.
 init_log_file() {
 	local script_name
 	script_name="$(basename "${BASH_SOURCE[1]:-${0:-unknown}}" .sh)"
-	local log_dir="${HOME}/.aidevops/logs"
+	local log_dir
+	log_dir=$(_resolve_log_dir)
 	mkdir -p "$log_dir" 2>/dev/null || true
 	AIDEVOPS_LOG_FILE="${log_dir}/${script_name}.log"
 	export AIDEVOPS_LOG_FILE

--- a/.agents/scripts/tests/test-shared-constants-log-dir.sh
+++ b/.agents/scripts/tests/test-shared-constants-log-dir.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# Test: _resolve_log_dir from shared-constants.sh
+# Verifies that the resolver reads paths.log_dir from JSONC config and falls
+# back to ~/.aidevops/logs when no config is present.
+# =============================================================================
+set -euo pipefail
+
+PASS=0
+FAIL=0
+TESTS=0
+
+_test() {
+	local desc="$1"
+	local expected="$2"
+	local actual="$3"
+	TESTS=$((TESTS + 1))
+	if [[ "$actual" == "$expected" ]]; then
+		echo "  PASS: $desc"
+		PASS=$((PASS + 1))
+	else
+		echo "  FAIL: $desc"
+		echo "    expected: $expected"
+		echo "    actual:   $actual"
+		FAIL=$((FAIL + 1))
+	fi
+	return 0
+}
+
+# --- Setup ---
+SCRIPT_DIR="${BASH_SOURCE[0]%/*}/.."
+[[ "$SCRIPT_DIR" == "${BASH_SOURCE[0]}" ]] && SCRIPT_DIR="."
+SCRIPT_DIR="$(cd "$SCRIPT_DIR" && pwd)"
+
+TMPDIR_TEST="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+# Save original HOME
+ORIG_HOME="$HOME"
+
+echo "=== _resolve_log_dir tests ==="
+
+# --- Test 1: Default fallback (no JSONC config) ---
+# Use a temp HOME with no config files so _jsonc_get is irrelevant
+HOME="$TMPDIR_TEST/home-default"
+mkdir -p "$HOME"
+
+# Source shared-constants.sh (but NOT config-helper.sh — _jsonc_get unavailable)
+# We need to isolate: unset the function if it exists
+unset -f _jsonc_get 2>/dev/null || true
+
+# Source only shared-constants.sh
+source "$SCRIPT_DIR/shared-constants.sh"
+
+result=$(_resolve_log_dir)
+_test "Default fallback when no _jsonc_get" "$HOME/.aidevops/logs" "$result"
+
+# --- Test 2: Custom paths.log_dir via _jsonc_get mock ---
+HOME="$TMPDIR_TEST/home-custom"
+mkdir -p "$HOME"
+
+# Mock _jsonc_get to return a custom path
+_jsonc_get() {
+	local dotpath="$1"
+	local default="${2:-}"
+	if [[ "$dotpath" == "paths.log_dir" ]]; then
+		printf '%s' "/tmp/custom-aidevops-logs"
+	else
+		printf '%s' "$default"
+	fi
+	return 0
+}
+
+result=$(_resolve_log_dir)
+_test "Custom paths.log_dir via _jsonc_get" "/tmp/custom-aidevops-logs" "$result"
+
+# --- Test 3: Tilde expansion ---
+_jsonc_get() {
+	local dotpath="$1"
+	local default="${2:-}"
+	if [[ "$dotpath" == "paths.log_dir" ]]; then
+		# shellcheck disable=SC2088  # Tilde intentionally literal — testing expansion
+		printf '%s' "~/.aidevops/custom-logs"
+	else
+		printf '%s' "$default"
+	fi
+	return 0
+}
+
+result=$(_resolve_log_dir)
+_test "Tilde expansion in paths.log_dir" "$HOME/.aidevops/custom-logs" "$result"
+
+# --- Test 4: _jsonc_get returns default ---
+_jsonc_get() {
+	local dotpath="$1"
+	local default="${2:-}"
+	printf '%s' "$default"
+	return 0
+}
+
+result=$(_resolve_log_dir)
+_test "_jsonc_get returns default value" "$HOME/.aidevops/logs" "$result"
+
+# --- Restore HOME ---
+HOME="$ORIG_HOME"
+
+# --- Summary ---
+echo ""
+echo "Results: $PASS passed, $FAIL failed, $TESTS total"
+
+if [[ $FAIL -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/setup-modules/schedulers-platform.sh
+++ b/setup-modules/schedulers-platform.sh
@@ -47,27 +47,22 @@ fi
 # --- Functions ---
 
 # Resolve and validate the log directory from config for contribution watch.
-# Reads paths.log_dir from jsonc config, validates characters, expands tilde.
+# Delegates resolution to _resolve_log_dir (shared-constants.sh), then applies
+# install-time character validation (safe for shell paths and cron lines).
 # Prints the resolved absolute path. Returns 1 on invalid characters.
 _resolve_cw_log_dir() {
 	local _cw_log_dir
-	# shellcheck disable=SC2088  # Tilde is intentionally literal here; expanded below via ${/#\~/$HOME}
-	if type _jsonc_get &>/dev/null; then
-		_cw_log_dir=$(_jsonc_get "paths.log_dir" "~/.aidevops/logs")
-	else
-		_cw_log_dir="~/.aidevops/logs"
-	fi
+	_cw_log_dir=$(_resolve_log_dir)
 	# Whitelist: only allow characters safe in shell paths and cron lines.
-	# Reject anything outside [A-Za-z0-9_./ ~-] (tilde allowed before expansion).
+	# Reject anything outside [A-Za-z0-9_./ -] (tilde already expanded by _resolve_log_dir).
 	# Store regex in variable — bash [[ =~ ]] requires unquoted RHS for regex,
 	# and a variable avoids quoting issues with special chars in the pattern.
-	local _cw_log_dir_re='^[A-Za-z0-9_./ ~-]+$'
+	local _cw_log_dir_re='^[A-Za-z0-9_./ -]+$'
 	if ! [[ "$_cw_log_dir" =~ $_cw_log_dir_re ]]; then
 		# Redirect to stderr so $() captures only the path result
-		print_error "Invalid characters in paths.log_dir (only [A-Za-z0-9_./ ~-] allowed): $_cw_log_dir" >&2
+		print_error "Invalid characters in paths.log_dir (only [A-Za-z0-9_./ -] allowed): $_cw_log_dir" >&2
 		return 1
 	fi
-	_cw_log_dir="${_cw_log_dir/#\~/$HOME}"
 	printf '%s' "$_cw_log_dir"
 	return 0
 }


### PR DESCRIPTION
## Summary

Added _resolve_log_dir() to shared-constants.sh that reads paths.log_dir from JSONC config with ~/.aidevops/logs fallback. Updated complexity-scan-runner.sh, efficiency-analysis-runner.sh, init_log_file(), and _resolve_cw_log_dir in schedulers-platform.sh to use the shared resolver. Added 4-case regression test.

## Files Changed

.agents/scripts/complexity-scan-runner.sh,.agents/scripts/efficiency-analysis-runner.sh,.agents/scripts/shared-constants.sh,.agents/scripts/tests/test-shared-constants-log-dir.sh,setup-modules/schedulers-platform.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** ShellCheck clean on all 5 modified files. Regression test passes (4/4): default fallback, custom path, tilde expansion, _jsonc_get returning default.

Resolves #21076


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-opus-4-6 spent 10m and 9,862 tokens on this as a headless worker.