### PR TITLE
GH#21630: harden knowledge search find pipelines under pipefail

### DIFF
--- a/.agents/scripts/knowledge-helper.sh
+++ b/.agents/scripts/knowledge-helper.sh
@@ -868,8 +868,8 @@ _search_ids_by_sensitivity() {
 	_require_jq || return 1
 	find "$sources_dir" -maxdepth 2 -name "meta.json" \
 		-exec jq -r --arg tier "$tier" --arg def "$META_DEFAULT_SENSITIVITY" \
-		'select((.sensitivity // $def) == $tier) | .id' {} + \
-		| sort
+		'select((.sensitivity // $def) == $tier) | (.id // empty)' {} + 2>/dev/null \
+		| sort || true
 	return 0
 }
 
@@ -909,8 +909,8 @@ _search_ids_by_status() {
 	# Match Markdoc draft-status tag: {% draft-status status="<value>" ... %}
 	local pattern="\\{%\\s*draft-status\\b[^%]*status\\s*=\\s*[\"']?${draft_status}[\"']?"
 	find "$sources_dir" -maxdepth 2 -name "source.md" \
-		-exec grep -liE "$pattern" {} + \
-		| while read -r path; do basename "$(dirname "$path")"; done \
+		-exec grep -liE "$pattern" {} + 2>/dev/null \
+		| sed 's|/source.md$||; s|.*/||' \
 		| sort || true
 	return 0
 }


### PR DESCRIPTION
## Summary

Addresses Gemini review bot feedback from PR #21539 (GH#21630):

- **`_search_ids_by_sensitivity`** (`knowledge-helper.sh:869-872`):
  - Add `2>/dev/null` (after `{} +` to avoid ShellCheck SC2227) to suppress `find` stderr when `sources_dir` is absent — required under `set -euo pipefail`
  - Add `|| true` to prevent pipeline non-zero exit from aborting the script under `pipefail`
  - Change `.id` → `(.id // empty)` to suppress literal `null` output for `meta.json` files lacking an `id` field

- **`_search_ids_by_status`** (`knowledge-helper.sh:911-914`):
  - Add `2>/dev/null` (after `{} +`) for same pipefail resilience
  - Replace `while read -r path; do basename "$(dirname "$path")"; done` with `sed 's|/source.md$||; s|.*/||'` — eliminates a subshell-per-match loop, consistent with the performance goals of PR #21539

## Verification

- `shellcheck .agents/scripts/knowledge-helper.sh` — zero violations (SC2227 avoided by canonical end-of-find placement)
- Pre-commit hook passed

Resolves #21630

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-sonnet-4-6 spent 8m and 18,443 tokens on this as a headless worker.
