### PR TITLE
GH#21573: fix brew category gate skips on Linux in tool-version-check.sh

### DIFF
--- a/.agents/scripts/tool-version-check.sh
+++ b/.agents/scripts/tool-version-check.sh
@@ -525,7 +525,7 @@ _check_all_categories() {
 		if [[ ${#NPM_TOOLS[@]} -gt 0 ]]; then
 			check_category "NPM" "${NPM_TOOLS[@]}"
 		fi
-		if command -v brew &>/dev/null && [[ ${#BREW_TOOLS[@]} -gt 0 ]]; then
+		if [[ ${#BREW_TOOLS[@]} -gt 0 ]]; then
 			check_category "Homebrew" "${BREW_TOOLS[@]}"
 		fi
 		if command -v pip &>/dev/null && [[ ${#PIP_TOOLS[@]} -gt 0 ]]; then


### PR DESCRIPTION
## Summary

Removes the `command -v brew` guard from the `all | *` case in `_check_all_categories()` so brew-origin tools (gh, glab, jq, shellcheck, wt) are checked and updated on Linux systems without Homebrew.

## Root Cause

`_check_all_categories` line 528 gated the entire "Homebrew" category on `command -v brew`, which always returns false on Linux without brew. The platform-aware leaf functions added by PR #6815 (for #6762) never executed as a result.

## Fix

One-line change: drop the `command -v brew &>/dev/null &&` condition from the guard. The category now runs whenever `BREW_TOOLS` is non-empty — matching the pattern of the single-category `brew)` case at line 515-517 which never checked brew availability.

The leaf functions already handle the no-brew case:
- `get_brew_latest()` (line 346): GitHub Releases API fallback for gh, glab, jq, shellcheck, wt
- `_brew_upgrade_cmd()` (line 89): generates `apt-get install --only-upgrade` / `dnf upgrade` when brew absent

## Verification

```bash
shellcheck .agents/scripts/tool-version-check.sh  # zero violations
bash .agents/scripts/tool-version-check.sh --update  # brew category no longer skipped on Linux
```

Resolves #21573

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-sonnet-4-6 spent 7m and 5,131 tokens on this as a headless worker.
