### PR TITLE
GH#21723: fix(claim-task-id): strip tNNN: prefix in TODO line to prevent doubling

### DIFF
--- a/.agents/scripts/claim-task-id-issue.sh
+++ b/.agents/scripts/claim-task-id-issue.sh
@@ -642,6 +642,14 @@ _ensure_todo_entry_written() {
 	safe_desc=$(printf '%s' "$title" \
 		| tr '\n\t' '  ' | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//')
 	[[ -z "$safe_desc" ]] && safe_desc="(no title)"
+	# GH#21723: strip the tNNN: prefix if the caller passed the GitHub issue
+	# title (which has the task-ID prepended as "tNNN: description"). The TODO
+	# line already carries task_id as a separate leading field, so the prefix
+	# would otherwise produce "- [ ] tNNN tNNN: description" doubling.
+	if [[ -n "$task_id" && "$safe_desc" == "${task_id}: "* ]]; then
+		safe_desc="${safe_desc#"${task_id}: "}"
+		[[ -z "$safe_desc" ]] && safe_desc="(no title)"
+	fi
 	local todo_line="- [ ] ${task_id} ${safe_desc}"
 	[[ -n "$tags_str" ]] && todo_line="${todo_line} ${tags_str}"
 	# GH#20834: append blocked-by tag when predecessor refs were auto-detected.

--- a/.agents/scripts/tests/test-claim-todo-entry-title.sh
+++ b/.agents/scripts/tests/test-claim-todo-entry-title.sh
@@ -228,6 +228,20 @@ assert_eq "multiword_title_preserved" \
 	"$result7" \
 	"- [ ] t400 fix the frobnicator bug ref:GH#111"
 
+# 8. GH#21723 regression: tNNN: prefix in title must NOT be doubled in TODO line.
+# create_github_issue passes the GitHub issue title (which has "tNNN: " prepended)
+# to _ensure_todo_entry_written — the TODO line must strip it to avoid
+# "- [ ] tNNN tNNN: description".
+result8="$(run_ensure "t3041" "21656" "t3041: investigate pulse-merge-routine hang" "")"
+assert_eq "no_doubled_task_id_prefix" \
+	"$result8" \
+	"- [ ] t3041 investigate pulse-merge-routine hang ref:GH#21656"
+
+# 9. GH#21723: Verify the stripped desc is still correct when labels are present.
+result9="$(run_ensure "t500" "99999" "t500: add new feature" "auto-dispatch,bug")"
+assert_contains "no_doubled_prefix_with_labels_task_id" "$result9" "- [ ] t500 add new feature"
+assert_not_contains "no_doubled_prefix_with_labels_t500" "$result9" "t500: add new feature"
+
 # ---------------------------------------------------------------------------
 # Summary
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes the doubled task-ID prefix in `TODO.md` entries written by `claim-task-id.sh`.

**Root cause:** `_main_create_issues` builds the GitHub issue title as `"tNNN: ${TASK_TITLE}"` (e.g. `t3041: investigate foo`). This prefixed title is then passed to `create_github_issue`, which forwards it to `_ensure_todo_entry_written` as the `title` argument. Since the TODO line format is `- [ ] {task_id} {title}`, the result was a doubled prefix: `- [ ] t3041 t3041: investigate foo`.

## Changes

### `claim-task-id-issue.sh`

In `_ensure_todo_entry_written`: after whitespace-normalising `safe_desc`, strip the leading `${task_id}: ` prefix if present. The GitHub issue title is unchanged; only the TODO.md line is fixed.

### `tests/test-claim-todo-entry-title.sh`

Two new regression test cases:
- **case 8** — asserts `t3041: investigate pulse-merge-routine hang` produces `- [ ] t3041 investigate pulse-merge-routine hang ref:GH#21656` (no doubled prefix)
- **case 9** — asserts correct behaviour with labels present

## Verification

```
bash .agents/scripts/tests/test-claim-todo-entry-title.sh
# → 14 tests run: 14 passed, 0 failed
```

All 14 tests pass (12 pre-existing + 2 new). ShellCheck clean on both files.

Resolves #21723

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-sonnet-4-6 spent 12m and 16,079 tokens on this as a headless worker.
