### PR TITLE
GH#21618: source portable-stat.sh before pre-jitter fast-fail in pulse-wrapper.sh

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -142,6 +142,9 @@ fi
 # Biased toward false negatives: if PID file is absent, stat fails, or the
 # holder exceeds the max-age ceiling, fall through to main() where
 # acquire_instance_lock handles stale-lock reclaim properly.
+# Early source: _file_mtime_epoch needed before shared-constants.sh is loaded.
+# shellcheck source=./portable-stat.sh
+source "${BASH_SOURCE[0]%/*}/portable-stat.sh"
 if [[ "$_pulse_skip_jitter" -eq 0 ]]; then
 	_pw_ffjit_lockdir="${HOME}/.aidevops/logs/pulse-wrapper.lockdir"
 	_pw_ffjit_pid_file="${_pw_ffjit_lockdir}/pid"


### PR DESCRIPTION
## Summary

- Fix `_file_mtime_epoch: command not found` in `pulse-wrapper.sh:153`
- The pre-jitter fast-fail block (line 136-163) calls `_file_mtime_epoch` but `shared-constants.sh` is sourced at line 192
- Add early `source portable-stat.sh` before the pre-jitter block
- The `_PORTABLE_STAT_LOADED` guard prevents double-sourcing when `shared-constants.sh` loads it again later

Introduced by PR #21689 which replaced inline `stat` calls with `_file_mtime_epoch` but missed the source ordering.

Resolves #21618

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-opus-4-6 spent 2d 11h and 103,794 tokens on this with the user in an interactive session.
