### PR TITLE
fix(stats-health-dashboard): use gh_issue_edit_safe for body updates to survive GraphQL rate limits

### DIFF
--- a/.agents/scripts/stats-health-dashboard.sh
+++ b/.agents/scripts/stats-health-dashboard.sh
@@ -176,7 +176,12 @@ _update_health_issue_for_repo() {
 		"$cross_repo_md" "$cross_repo_session_time_md" "$cross_repo_person_stats_md")
 
 	local body_edit_stderr
-	body_edit_stderr=$(gh issue edit "$health_issue_number" --repo "$repo_slug" \
+	# Use gh_issue_edit_safe (not bare `gh issue edit`) so the REST fallback
+	# in shared-gh-wrappers-safe-edit.sh fires when GraphQL is rate-limited.
+	# Bare `gh issue edit` always uses GraphQL and silently fails the body
+	# update when the 5000/hr GraphQL budget is exhausted, leaving the
+	# dashboard stale until the budget resets (up to 1h). GH#33.
+	body_edit_stderr=$(gh_issue_edit_safe "$health_issue_number" --repo "$repo_slug" \
 		--body "$body" 2>&1 >/dev/null) || {
 		echo "[stats] Health issue: failed to update body for #${health_issue_number}: ${body_edit_stderr}" \
 			>>"$LOGFILE"


### PR DESCRIPTION
## Summary

`_update_health_issue_for_repo` in `stats-health-dashboard.sh` used bare `gh issue edit` for updating the health dashboard body. This bypasses the REST API fallback in `gh_issue_edit_safe`, causing all body updates to fail silently when the GraphQL rate limit is exhausted.

Result: dashboards go stale for up to 1hr until the GraphQL budget resets. Observed as 2d23h staleness in `superdav42/aidevops-routines#26` (issue #33).

## Root cause

`gh issue edit` always uses GraphQL. `gh_issue_edit_safe` has an `_gh_should_fallback_to_rest` check that fires when GraphQL remaining ≤ `_GH_REST_FALLBACK_THRESHOLD` (default 1500), calling `_gh_issue_edit_rest` which uses `PATCH /repos/superdav42/aidevops-routines/issues/{N}` REST endpoint.

Note: the title update in the same function already correctly used `gh_issue_edit_safe` — this was an inconsistency.

## Fix

Changed `gh issue edit` → `gh_issue_edit_safe` for the body update. Added comment explaining why.

## Verification

```bash
shellcheck .agents/scripts/stats-health-dashboard.sh
```

Resolves superdav42/aidevops-routines#33