### PR TITLE
GH#21757: clean up stale stat comments, add pre-commit gate for raw stat

### DIFF
--- a/.agents/scripts/pre-commit-hook.sh
+++ b/.agents/scripts/pre-commit-hook.sh
@@ -371,6 +371,47 @@ validate_string_literals() {
 	return $violations
 }
 
+# ABSOLUTE gate (not ratchet): raw stat -c / stat -f in .agents/scripts/ is
+# always wrong after the portable-stat.sh migration (GH#21742). Use
+# _file_mtime_epoch, _file_size_bytes, _file_perms, _file_owner, _stat_batch,
+# or _stat_translate_fmt instead.
+# Allowlist: portable-stat.sh (defines the wrappers), lint-shell-portability.sh
+# (detects raw stat in other repos), and test files.
+validate_portable_stat() {
+	local violations=0
+
+	print_info "Validating portable-stat usage (absolute)..."
+
+	for file in "$@"; do
+		[[ ! -f "$file" ]] && continue
+		local base
+		base=$(basename "$file")
+		# Allowlisted files that legitimately reference raw stat
+		case "$base" in
+			portable-stat.sh|lint-shell-portability.sh|test-*) continue ;;
+		esac
+
+		local raw_count
+		# Match stat -c or stat -f in code lines (skip comments)
+		raw_count=$(grep -cE '(^|[[:space:]])stat[[:space:]]+-[cf][[:space:]%]' "$file" 2>/dev/null || true)
+		# Subtract comment lines
+		local comment_count
+		comment_count=$(grep -cE '^[[:space:]]*#.*stat[[:space:]]+-[cf]' "$file" 2>/dev/null || true)
+		[[ -z "$raw_count" ]] && raw_count=0
+		[[ -z "$comment_count" ]] && comment_count=0
+		local code_count=$((raw_count - comment_count))
+		[[ "$code_count" =~ ^[0-9]+$ ]] || code_count=0
+
+		if ((code_count > 0)); then
+			print_error "Raw stat -c/-f in $file ($code_count call(s)). Use portable-stat.sh wrappers instead."
+			grep -nE '(^|[[:space:]])stat[[:space:]]+-[cf][[:space:]%]' "$file" | grep -v '^[[:space:]]*#' >&2 || true
+			((++violations))
+		fi
+	done
+
+	return $violations
+}
+
 run_shellcheck() {
 	local violations=0
 
@@ -949,6 +990,9 @@ main_pre_commit() {
 	echo "" >&2
 
 	run_shellcheck "${modified_files[@]}" || ((total_violations += $?))
+	echo "" >&2
+
+	validate_portable_stat "${modified_files[@]}" || ((total_violations += $?))
 	echo "" >&2
 
 	# Final decision

--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -274,7 +274,7 @@ _worktree_owner_alive() {
 #######################################
 # Get worktree creation epoch from the .git file's mtime.
 #
-# Linux uses `stat -c '%Y'`; macOS uses `stat -f '%m'`. Writes 0 to stdout
+# Uses _file_mtime_epoch from portable-stat.sh. Writes 0 to stdout
 # when the .git file is missing or stat fails, and logs a diagnostic in
 # that case (GH#18346: this path was previously a silent continue).
 #

--- a/.agents/scripts/pulse-instance-lock.sh
+++ b/.agents/scripts/pulse-instance-lock.sh
@@ -206,7 +206,7 @@ _handle_stale_llm_lock() {
 	fi
 
 	# Tier 3: Owner alive — check PID reuse + age-based ceiling
-	# Use _get_process_age (portable ps-etime) instead of stat -c '%Y' (GNU-only)
+	# Use _get_process_age (portable ps-etime) for lock holder age
 	local lock_age
 	lock_age=$(_get_process_age "$lock_pid")
 	local owner_cmd=""

--- a/.agents/scripts/pulse-logging.sh
+++ b/.agents/scripts/pulse-logging.sh
@@ -38,7 +38,7 @@ _PULSE_LOGGING_LOADED=1
 #   - Atomic: uses a tmp file + mv to avoid partial archives.
 #   - Non-fatal: any failure is logged to WRAPPER_LOGFILE and silently
 #     ignored so the pulse cycle is never blocked by log housekeeping.
-#   - macOS compatible: uses stat -f %z (BSD stat) with fallback to wc -c.
+#   - Cross-platform: uses _file_size_bytes from portable-stat.sh.
 #   - No external deps beyond gzip (standard on macOS and Linux).
 #######################################
 rotate_pulse_log() {

--- a/.agents/scripts/shared-todo-commit.sh
+++ b/.agents/scripts/shared-todo-commit.sh
@@ -47,7 +47,7 @@
 # Dependencies:
 #   - git (must be on PATH).
 #   - bash 4+ (uses `${var:-default}` and trap EXIT).
-#   - GNU coreutils OR macOS BSD coreutils (handles `stat -f` vs `stat -c`).
+#   - portable-stat.sh (cross-platform stat via shared-constants.sh).
 #   - $AIDEVOPS_LOG_FILE (optional — log target for lock + retry diagnostics;
 #     defaults to /dev/null).
 #


### PR DESCRIPTION
## Summary

- Clean up 4 stale comments referencing raw `stat -c`/`stat -f` after portable-stat.sh migration (GH#21742)
- Add `validate_portable_stat` absolute gate to `pre-commit-hook.sh` — blocks any raw `stat -c`/`stat -f` in `.agents/scripts/` (allowlist: `portable-stat.sh`, `lint-shell-portability.sh`, test files)
- Prevents future regressions: new code must use `_file_mtime_epoch`, `_file_size_bytes`, `_file_perms`, `_file_owner`, `_stat_batch`, or `_stat_translate_fmt`

Resolves #21757

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-opus-4-6 spent 2d 17h and 108,522 tokens on this with the user in an interactive session.
