### PR TITLE
GH#21756: feat(pulse): add runaway-log self-healing detector

### DIFF
--- a/.agents/scripts/pulse-log-runaway-detector.sh
+++ b/.agents/scripts/pulse-log-runaway-detector.sh
@@ -1,0 +1,285 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# pulse-log-runaway-detector.sh — Detect and heal runaway pulse-wrapper.log growth.
+#
+# Catches the failure mode demonstrated by GH#21729: pulse-wrapper.log growing
+# 6GB+ because a tight error loop bleeds the same line millions of times.
+# Existing rotation (pulse-logging.sh) only covers pulse.log, not wrapper log.
+# Existing watchdog (pulse-watchdog.sh) interprets fast log growth as "healthy".
+#
+# Three checks:
+#   1. Absolute size cap — wrapper log exceeds PULSE_WRAPPER_LOG_RUNAWAY_BYTES
+#   2. Growth rate — growth exceeds PULSE_WRAPPER_LOG_GROWTH_BYTES_PER_MIN
+#   3. Repetition pattern — >95% of recent lines are identical
+#
+# Integration: called from pulse-wrapper.sh::main() with sentinel-gated cadence
+# (every 5 min), modelled on the pulse-cache-prime pattern (t2994).
+#
+# Usage:
+#   pulse-log-runaway-detector.sh check-and-heal
+#   WRAPPER_LOGFILE=/path/to/log pulse-log-runaway-detector.sh check-and-heal
+#
+# Fail-open: any internal error returns 0. Never blocks the pulse cycle.
+
+set -euo pipefail
+
+# Resolve SCRIPT_DIR for sourcing siblings
+SCRIPT_DIR="${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+
+# Source portable-stat.sh for _file_size_bytes (fail-open)
+# shellcheck source=portable-stat.sh
+if [[ -f "${SCRIPT_DIR}/portable-stat.sh" ]]; then
+	# shellcheck disable=SC1091
+	source "${SCRIPT_DIR}/portable-stat.sh"
+fi
+
+# Defaults — all overridable via env
+WRAPPER_LOGFILE="${WRAPPER_LOGFILE:-${HOME}/.aidevops/logs/pulse-wrapper.log}"
+PULSE_WRAPPER_LOG_RUNAWAY_BYTES="${PULSE_WRAPPER_LOG_RUNAWAY_BYTES:-524288000}"       # 500 MB
+PULSE_WRAPPER_LOG_GROWTH_BYTES_PER_MIN="${PULSE_WRAPPER_LOG_GROWTH_BYTES_PER_MIN:-104857600}" # 100 MB/min
+PULSE_WRAPPER_LOG_LAST_SIZE_FILE="${PULSE_WRAPPER_LOG_LAST_SIZE_FILE:-${HOME}/.aidevops/cache/pulse-wrapper-log-last-size}"
+PULSE_LOG_ARCHIVE_DIR="${PULSE_LOG_ARCHIVE_DIR:-${HOME}/.aidevops/logs/pulse-archive}"
+PULSE_WRAPPER_LOG_REPETITION_THRESHOLD="${PULSE_WRAPPER_LOG_REPETITION_THRESHOLD:-5}" # unique lines < this % = runaway
+
+#######################################
+# _log — emit a timestamped log line to stderr.
+# Arguments:
+#   $1 — message
+# Returns: 0
+#######################################
+_log() {
+	local msg="$1"
+	printf '[pulse-log-runaway-detector] %s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "unknown")" "$msg" >&2
+	return 0
+}
+
+#######################################
+# _write_advisory — write a runaway advisory stamp for session greeting.
+# Arguments:
+#   $1 — advisory message
+# Returns: 0
+#######################################
+_write_advisory() {
+	local msg="$1"
+	local advisory_dir="${HOME}/.aidevops/cache"
+	local advisory_file="${advisory_dir}/pulse-wrapper-log-runaway-advisory.txt"
+	mkdir -p "$advisory_dir" 2>/dev/null || return 0
+	printf '%s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "unknown")" "$msg" >"$advisory_file" 2>/dev/null || true
+	return 0
+}
+
+#######################################
+# _rotate_wrapper_log — compress and truncate the wrapper log.
+# Mirrors the gzip-and-truncate flow from rotate_pulse_log in pulse-logging.sh.
+# Arguments: none (uses WRAPPER_LOGFILE, PULSE_LOG_ARCHIVE_DIR globals)
+# Returns: 0
+#######################################
+_rotate_wrapper_log() {
+	mkdir -p "$PULSE_LOG_ARCHIVE_DIR" 2>/dev/null || {
+		_log "cannot create archive dir ${PULSE_LOG_ARCHIVE_DIR}"
+		return 0
+	}
+
+	local ts=""
+	ts=$(date -u +%Y%m%d-%H%M%S 2>/dev/null || echo "unknown")
+	local archive_name="pulse-wrapper-${ts}.log.gz"
+	local archive_path="${PULSE_LOG_ARCHIVE_DIR}/${archive_name}"
+	local tmp_archive=""
+	tmp_archive=$(mktemp "${PULSE_LOG_ARCHIVE_DIR}/.pulse-wrapper-archive-XXXXXX") || {
+		_log "mktemp failed for archive"
+		return 0
+	}
+
+	if gzip -c "$WRAPPER_LOGFILE" >"$tmp_archive" 2>/dev/null; then
+		mv "$tmp_archive" "$archive_path" 2>/dev/null || {
+			rm -f "$tmp_archive"
+			_log "mv failed for ${archive_name}"
+			return 0
+		}
+		# Truncate (not delete) — preserves file descriptor for launchd redirect
+		: >"$WRAPPER_LOGFILE" 2>/dev/null || true
+		_log "rotated wrapper log → ${archive_name}"
+	else
+		rm -f "$tmp_archive"
+		_log "gzip failed for ${WRAPPER_LOGFILE}"
+	fi
+
+	return 0
+}
+
+#######################################
+# _check_absolute_cap — rotate if wrapper log exceeds absolute size cap.
+# Arguments: none (uses globals)
+# Returns: 0 (always; sets _RUNAWAY_DETECTED=1 on finding)
+#######################################
+_check_absolute_cap() {
+	local current_size=0
+	if [[ -f "$WRAPPER_LOGFILE" ]]; then
+		if command -v _file_size_bytes >/dev/null 2>&1; then
+			current_size=$(_file_size_bytes "$WRAPPER_LOGFILE")
+		else
+			current_size=$(wc -c <"$WRAPPER_LOGFILE" 2>/dev/null || echo "0")
+			current_size="${current_size//[[:space:]]/}"
+		fi
+	fi
+	[[ "$current_size" =~ ^[0-9]+$ ]] || current_size=0
+
+	if [[ "$current_size" -gt "$PULSE_WRAPPER_LOG_RUNAWAY_BYTES" ]]; then
+		local size_mb=$(( current_size / 1048576 ))
+		_log "RUNAWAY DETECTED: wrapper log is ${size_mb}MB (cap: $(( PULSE_WRAPPER_LOG_RUNAWAY_BYTES / 1048576 ))MB)"
+		_write_advisory "Runaway wrapper log detected: ${size_mb}MB. Rotated automatically."
+		_rotate_wrapper_log
+		_RUNAWAY_DETECTED=1
+	fi
+
+	return 0
+}
+
+#######################################
+# _check_growth_rate — rotate if wrapper log is growing too fast.
+# Compares current size against last recorded size from sentinel file.
+# Arguments: none (uses globals)
+# Returns: 0 (always; sets _RUNAWAY_DETECTED=1 on finding)
+#######################################
+_check_growth_rate() {
+	local current_size=0
+	if [[ -f "$WRAPPER_LOGFILE" ]]; then
+		if command -v _file_size_bytes >/dev/null 2>&1; then
+			current_size=$(_file_size_bytes "$WRAPPER_LOGFILE")
+		else
+			current_size=$(wc -c <"$WRAPPER_LOGFILE" 2>/dev/null || echo "0")
+			current_size="${current_size//[[:space:]]/}"
+		fi
+	fi
+	[[ "$current_size" =~ ^[0-9]+$ ]] || current_size=0
+
+	# Read last recorded size
+	local last_size=0
+	if [[ -f "$PULSE_WRAPPER_LOG_LAST_SIZE_FILE" ]]; then
+		last_size=$(cat "$PULSE_WRAPPER_LOG_LAST_SIZE_FILE" 2>/dev/null || echo "0")
+		last_size="${last_size//[[:space:]]/}"
+	fi
+	[[ "$last_size" =~ ^[0-9]+$ ]] || last_size=0
+
+	# Calculate growth and time delta
+	local growth=$(( current_size - last_size ))
+	if [[ "$growth" -lt 0 ]]; then
+		growth=0  # Log was truncated between checks
+	fi
+
+	# Get sentinel file age to compute rate
+	local age_s=300  # default 5 min (the check cadence)
+	if [[ -f "$PULSE_WRAPPER_LOG_LAST_SIZE_FILE" ]]; then
+		local now_epoch="" stamp_epoch=""
+		now_epoch=$(date +%s 2>/dev/null || echo "0")
+		if command -v _file_mtime_epoch >/dev/null 2>&1; then
+			stamp_epoch=$(_file_mtime_epoch "$PULSE_WRAPPER_LOG_LAST_SIZE_FILE")
+		else
+			# Fallback: use date on the file via find -printf (GNU) or perl
+			stamp_epoch=$(perl -e 'print((stat($ARGV[0]))[9])' "$PULSE_WRAPPER_LOG_LAST_SIZE_FILE" 2>/dev/null || echo "0")
+		fi
+		[[ "$now_epoch" =~ ^[0-9]+$ ]] || now_epoch=0
+		[[ "$stamp_epoch" =~ ^[0-9]+$ ]] || stamp_epoch=0
+		if [[ "$now_epoch" -gt "$stamp_epoch" ]] && [[ "$stamp_epoch" -gt 0 ]]; then
+			age_s=$(( now_epoch - stamp_epoch ))
+		fi
+	fi
+	# Avoid division by zero
+	[[ "$age_s" -lt 1 ]] && age_s=1
+
+	local growth_per_min=$(( growth * 60 / age_s ))
+
+	if [[ "$growth_per_min" -gt "$PULSE_WRAPPER_LOG_GROWTH_BYTES_PER_MIN" ]] && [[ "$growth" -gt 0 ]]; then
+		local rate_mb=$(( growth_per_min / 1048576 ))
+		_log "RUNAWAY DETECTED: wrapper log growing at ${rate_mb}MB/min (cap: $(( PULSE_WRAPPER_LOG_GROWTH_BYTES_PER_MIN / 1048576 ))MB/min)"
+		_write_advisory "Runaway wrapper log growth: ${rate_mb}MB/min. Rotated automatically."
+		_rotate_wrapper_log
+		_RUNAWAY_DETECTED=1
+	fi
+
+	# Update sentinel with current size
+	mkdir -p "$(dirname "$PULSE_WRAPPER_LOG_LAST_SIZE_FILE")" 2>/dev/null || true
+	printf '%s' "$current_size" >"$PULSE_WRAPPER_LOG_LAST_SIZE_FILE" 2>/dev/null || true
+
+	return 0
+}
+
+#######################################
+# _check_repetition_pattern — detect if >95% of recent lines are identical.
+# Arguments: none (uses globals)
+# Returns: 0 (always; sets _RUNAWAY_DETECTED=1 on finding)
+#######################################
+_check_repetition_pattern() {
+	[[ -f "$WRAPPER_LOGFILE" ]] || return 0
+
+	# Only check files > 100KB (small files can't be meaningfully analysed)
+	local current_size=0
+	if command -v _file_size_bytes >/dev/null 2>&1; then
+		current_size=$(_file_size_bytes "$WRAPPER_LOGFILE")
+	else
+		current_size=$(wc -c <"$WRAPPER_LOGFILE" 2>/dev/null || echo "0")
+		current_size="${current_size//[[:space:]]/}"
+	fi
+	[[ "$current_size" =~ ^[0-9]+$ ]] || current_size=0
+	[[ "$current_size" -lt 102400 ]] && return 0
+
+	local total_lines=0 unique_lines=0
+	total_lines=1000  # We sample 1000 lines
+	unique_lines=$(tail -n 1000 "$WRAPPER_LOGFILE" 2>/dev/null | sort -u | wc -l 2>/dev/null || echo "0")
+	unique_lines="${unique_lines//[[:space:]]/}"
+	[[ "$unique_lines" =~ ^[0-9]+$ ]] || unique_lines=0
+
+	# Calculate unique percentage: (unique / total) * 100
+	if [[ "$unique_lines" -gt 0 ]]; then
+		local unique_pct=$(( unique_lines * 100 / total_lines ))
+		if [[ "$unique_pct" -lt "$PULSE_WRAPPER_LOG_REPETITION_THRESHOLD" ]]; then
+			# Extract the dominant repeated line for triage
+			local dominant_line=""
+			dominant_line=$(tail -n 1000 "$WRAPPER_LOGFILE" 2>/dev/null | sort | uniq -c | sort -rn | head -1 | sed 's/^[[:space:]]*[0-9]* //' 2>/dev/null || echo "unknown")
+			_log "RUNAWAY DETECTED: ${unique_pct}% unique lines in last 1000 (threshold: ${PULSE_WRAPPER_LOG_REPETITION_THRESHOLD}%). Dominant line: ${dominant_line:0:200}"
+			_write_advisory "Runaway repetition detected: ${unique_pct}% unique lines. Dominant: ${dominant_line:0:200}"
+			_RUNAWAY_DETECTED=1
+		fi
+	fi
+
+	return 0
+}
+
+#######################################
+# check_and_heal — run all three checks. Fail-open.
+# Arguments: none
+# Returns: 0
+#######################################
+check_and_heal() {
+	_RUNAWAY_DETECTED=0
+
+	_check_absolute_cap || true
+	# Skip further checks if we already rotated
+	if [[ "$_RUNAWAY_DETECTED" == "0" ]]; then
+		_check_growth_rate || true
+	fi
+	if [[ "$_RUNAWAY_DETECTED" == "0" ]]; then
+		_check_repetition_pattern || true
+	fi
+
+	if [[ "$_RUNAWAY_DETECTED" == "1" ]]; then
+		_log "Self-healing complete. Advisory written."
+	fi
+
+	return 0
+}
+
+# CLI entry point
+case "${1:-}" in
+	check-and-heal)
+		check_and_heal
+		;;
+	"")
+		check_and_heal
+		;;
+	*)
+		printf 'Usage: %s check-and-heal\n' "$(basename "$0")" >&2
+		exit 1
+		;;
+esac

--- a/.agents/scripts/pulse-logging.sh
+++ b/.agents/scripts/pulse-logging.sh
@@ -27,70 +27,58 @@
 _PULSE_LOGGING_LOADED=1
 
 #######################################
-# rotate_pulse_log — hot/cold log sharding (t1886)
+# _rotate_single_log — gzip-compress and truncate a single log file.
+# Extracted from rotate_pulse_log to keep function complexity under 100 lines.
 #
-# Called once per cycle, before any log writes. If pulse.log exceeds
-# PULSE_LOG_HOT_MAX_BYTES, it is gzip-compressed and moved to the cold
-# archive directory. The cold archive is then pruned to stay within
-# PULSE_LOG_COLD_MAX_BYTES by removing the oldest archives first.
-#
-# Design constraints:
-#   - Atomic: uses a tmp file + mv to avoid partial archives.
-#   - Non-fatal: any failure is logged to WRAPPER_LOGFILE and silently
-#     ignored so the pulse cycle is never blocked by log housekeeping.
-#   - Cross-platform: uses _file_size_bytes from portable-stat.sh.
-#   - No external deps beyond gzip (standard on macOS and Linux).
+# Arguments:
+#   $1 — source log file path
+#   $2 — archive file basename (e.g. "pulse-20260429-123456.log.gz")
+#   $3 — label for log messages (e.g. "hot log", "wrapper")
+# Returns: 0 (always — non-fatal on any error)
 #######################################
-rotate_pulse_log() {
-	# Ensure archive directory exists
-	mkdir -p "$PULSE_LOG_ARCHIVE_DIR" 2>/dev/null || {
-		echo "[pulse-wrapper] rotate_pulse_log: cannot create archive dir ${PULSE_LOG_ARCHIVE_DIR}" >>"$WRAPPER_LOGFILE"
-		return 0
-	}
+_rotate_single_log() {
+	local source_file="$1"
+	local archive_name="$2"
+	local label="$3"
 
-	# Check hot log size — skip if under cap or log doesn't exist
-	local hot_size=0
-	if [[ -f "$LOGFILE" ]]; then
-		hot_size=$(_file_size_bytes "$LOGFILE")
-	fi
-
-	if [[ "$hot_size" -lt "$PULSE_LOG_HOT_MAX_BYTES" ]]; then
-		return 0
-	fi
-
-	# Rotate: compress hot log to archive
-	local ts
-	ts=$(date -u +%Y%m%d-%H%M%S)
-	local archive_name="pulse-${ts}.log.gz"
 	local archive_path="${PULSE_LOG_ARCHIVE_DIR}/${archive_name}"
-	local tmp_archive
-	# t2997: drop .gz — XXXXXX must be at end for BSD mktemp.
+	local source_size=0
+	source_size=$(_file_size_bytes "$source_file")
+
+	local tmp_archive=""
+	# t2997: XXXXXX must be at end for BSD mktemp.
 	tmp_archive=$(mktemp "${PULSE_LOG_ARCHIVE_DIR}/.pulse-archive-XXXXXX") || {
-		echo "[pulse-wrapper] rotate_pulse_log: mktemp failed for archive" >>"$WRAPPER_LOGFILE"
+		echo "[pulse-wrapper] rotate_pulse_log: mktemp failed for ${label} archive" >>"$WRAPPER_LOGFILE"
 		return 0
 	}
 
-	if gzip -c "$LOGFILE" >"$tmp_archive" 2>/dev/null; then
+	if gzip -c "$source_file" >"$tmp_archive" 2>/dev/null; then
 		mv "$tmp_archive" "$archive_path" 2>/dev/null || {
 			rm -f "$tmp_archive"
 			echo "[pulse-wrapper] rotate_pulse_log: mv failed for ${archive_name}" >>"$WRAPPER_LOGFILE"
 			return 0
 		}
-		# Truncate hot log (not delete — preserves file descriptor for any
-		# concurrent writers that still have it open)
-		: >"$LOGFILE" 2>/dev/null || true
-		echo "[pulse-wrapper] rotate_pulse_log: rotated ${hot_size}B → ${archive_name}" >>"$WRAPPER_LOGFILE"
+		# Truncate (not delete — preserves file descriptor for concurrent writers)
+		: >"$source_file" 2>/dev/null || true
+		echo "[pulse-wrapper] rotate_pulse_log: rotated ${label} ${source_size}B → ${archive_name}" >>"$WRAPPER_LOGFILE"
 	else
 		rm -f "$tmp_archive"
-		echo "[pulse-wrapper] rotate_pulse_log: gzip failed for ${LOGFILE}" >>"$WRAPPER_LOGFILE"
-		return 0
+		echo "[pulse-wrapper] rotate_pulse_log: gzip failed for ${label} (${source_file})" >>"$WRAPPER_LOGFILE"
 	fi
 
-	# Prune cold archive to stay within PULSE_LOG_COLD_MAX_BYTES
-	# Sum archive sizes; remove oldest (lexicographic = chronological) until under cap.
+	return 0
+}
+
+#######################################
+# _prune_cold_archive — remove oldest archives until total size <= cap.
+# Extracted from rotate_pulse_log to keep function complexity under 100 lines.
+#
+# Arguments: none (uses PULSE_LOG_ARCHIVE_DIR, PULSE_LOG_COLD_MAX_BYTES globals)
+# Returns: 0
+#######################################
+_prune_cold_archive() {
 	local total_cold=0
-	local archive_file archive_size
-	# Build sorted list (oldest first via lexicographic sort on timestamp-named files)
+	local archive_file="" archive_size=0
 	local -a archive_files=()
 	while IFS= read -r archive_file; do
 		archive_files+=("$archive_file")
@@ -112,18 +100,62 @@ rotate_pulse_log() {
 		done
 	fi
 
-	# GH#20025: Rotate stage timings log alongside the main log.
-	# Simpler rotation: just truncate when over 1MB (one TSV line ≈ 80 bytes,
-	# so 1MB ≈ 12,500 entries ≈ weeks of data). Archive the old content first.
+	return 0
+}
+
+#######################################
+# rotate_pulse_log — hot/cold log sharding (t1886)
+#
+# Called once per cycle, before any log writes. If pulse.log exceeds
+# PULSE_LOG_HOT_MAX_BYTES, it is gzip-compressed and moved to the cold
+# archive directory. The cold archive is then pruned to stay within
+# PULSE_LOG_COLD_MAX_BYTES by removing the oldest archives first.
+# GH#21756: also rotates WRAPPER_LOGFILE (pulse-wrapper.log) and
+# stage-timings log when over their respective caps.
+#
+# Design constraints:
+#   - Atomic: uses a tmp file + mv to avoid partial archives.
+#   - Non-fatal: any failure is logged to WRAPPER_LOGFILE and silently
+#     ignored so the pulse cycle is never blocked by log housekeeping.
+#   - Cross-platform: uses _file_size_bytes from portable-stat.sh.
+#   - No external deps beyond gzip (standard on macOS and Linux).
+#######################################
+rotate_pulse_log() {
+	# Ensure archive directory exists
+	mkdir -p "$PULSE_LOG_ARCHIVE_DIR" 2>/dev/null || {
+		echo "[pulse-wrapper] rotate_pulse_log: cannot create archive dir ${PULSE_LOG_ARCHIVE_DIR}" >>"$WRAPPER_LOGFILE"
+		return 0
+	}
+
+	local ts=""
+	ts=$(date -u +%Y%m%d-%H%M%S)
+
+	# Rotate LOGFILE (pulse.log) if over cap
+	local hot_size=0
+	if [[ -f "$LOGFILE" ]]; then
+		hot_size=$(_file_size_bytes "$LOGFILE")
+	fi
+	if [[ "$hot_size" -ge "$PULSE_LOG_HOT_MAX_BYTES" ]]; then
+		_rotate_single_log "$LOGFILE" "pulse-${ts}.log.gz" "hot log"
+		_prune_cold_archive
+	fi
+
+	# GH#20025: Rotate stage timings log (1MB cap).
 	if [[ -n "${PULSE_STAGE_TIMINGS_LOG:-}" ]] && [[ -f "$PULSE_STAGE_TIMINGS_LOG" ]]; then
 		local timings_size=0
 		timings_size=$(_file_size_bytes "$PULSE_STAGE_TIMINGS_LOG")
 		if [[ "$timings_size" -gt 1048576 ]]; then
-			local timings_archive="${PULSE_LOG_ARCHIVE_DIR}/pulse-stage-timings-${ts}.log.gz"
-			if gzip -c "$PULSE_STAGE_TIMINGS_LOG" >"$timings_archive" 2>/dev/null; then
-				: >"$PULSE_STAGE_TIMINGS_LOG" 2>/dev/null || true
-				echo "[pulse-wrapper] rotate_pulse_log: rotated stage-timings ${timings_size}B → $(basename "$timings_archive")" >>"$WRAPPER_LOGFILE"
-			fi
+			_rotate_single_log "$PULSE_STAGE_TIMINGS_LOG" "pulse-stage-timings-${ts}.log.gz" "stage-timings"
+		fi
+	fi
+
+	# GH#21756: Rotate WRAPPER_LOGFILE (pulse-wrapper.log) — same cap as hot log.
+	# This was the gap that allowed GH#21729's 6GB runaway.
+	if [[ -n "${WRAPPER_LOGFILE:-}" ]] && [[ -f "$WRAPPER_LOGFILE" ]]; then
+		local wrapper_size=0
+		wrapper_size=$(_file_size_bytes "$WRAPPER_LOGFILE")
+		if [[ "$wrapper_size" -gt "$PULSE_LOG_HOT_MAX_BYTES" ]]; then
+			_rotate_single_log "$WRAPPER_LOGFILE" "pulse-wrapper-${ts}.log.gz" "wrapper"
 		fi
 	fi
 

--- a/.agents/scripts/pulse-wrapper-cycle.sh
+++ b/.agents/scripts/pulse-wrapper-cycle.sh
@@ -281,6 +281,49 @@ _pulse_prime_caches_if_stale() {
 }
 
 #######################################
+# _pulse_check_runaway_log — sentinel-gated runaway-log detector (GH#21756)
+#
+# Calls pulse-log-runaway-detector.sh check-and-heal every 5 minutes
+# (configurable via PULSE_RUNAWAY_LOG_CHECK_INTERVAL). Catches wrapper
+# log growing at MB/s from tight error loops before disk fills.
+# Modelled on _pulse_prime_caches_if_stale (t2994).
+#
+# Fail-open: any internal error returns 0. Never blocks the pulse cycle.
+#######################################
+_pulse_check_runaway_log() {
+	[[ "${AIDEVOPS_SKIP_RUNAWAY_LOG_CHECK:-0}" == "1" ]] && return 0
+
+	local _detector_helper=""
+	local _detector_sentinel=""
+	local _detector_max_age=""
+	_detector_helper="${SCRIPT_DIR}/pulse-log-runaway-detector.sh"
+	_detector_sentinel="${HOME}/.aidevops/cache/pulse-runaway-log-check-last-run"
+	_detector_max_age="${PULSE_RUNAWAY_LOG_CHECK_INTERVAL:-300}"
+	[[ "$_detector_max_age" =~ ^[0-9]+$ ]] || _detector_max_age=300
+
+	mkdir -p "$(dirname "$_detector_sentinel")" 2>/dev/null || return 0
+	[[ ! -x "$_detector_helper" ]] && return 0
+
+	local _should_check=0
+	if [[ ! -f "$_detector_sentinel" ]]; then
+		_should_check=1
+	else
+		local _now_epoch="" _stamp_epoch="" _age_s=""
+		_now_epoch=$(date +%s 2>/dev/null)
+		_stamp_epoch=$(_file_mtime_epoch "$_detector_sentinel")
+		_age_s=$(( ${_now_epoch:-0} - ${_stamp_epoch:-0} ))
+		[[ "$_age_s" -gt "$_detector_max_age" ]] && _should_check=1
+	fi
+
+	if [[ "$_should_check" == "1" ]]; then
+		"$_detector_helper" check-and-heal 2>>"$WRAPPER_LOGFILE" || true
+		# Touch sentinel regardless of outcome (fail-open)
+		touch "$_detector_sentinel" 2>/dev/null || true
+	fi
+	return 0
+}
+
+#######################################
 # sync_todo_refs_for_repo
 #
 # Pull issue→TODO refs, close completed entries, and reopen entries whose

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -1549,6 +1549,12 @@ main() {
 	# the launchd-bypass rationale.
 	_pulse_prime_caches_if_stale || true
 
+	# GH#21756: Runaway-log self-healing detector. Catches pulse-wrapper.log
+	# growing at MB/s from tight error loops (the GH#21729 failure mode).
+	# Sentinel-gated (every 5 min) — modelled on cache-prime pattern (t2994).
+	# Fail-open: never blocks the pulse cycle.
+	_pulse_check_runaway_log || true
+
 	# Rotate hot log to cold archive if over cap (t1886)
 	# Run before any log writes so the new cycle starts with a fresh hot log.
 	rotate_pulse_log || true

--- a/.agents/scripts/tests/test-pulse-log-runaway-detector.sh
+++ b/.agents/scripts/tests/test-pulse-log-runaway-detector.sh
@@ -1,0 +1,222 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-pulse-log-runaway-detector.sh — Unit tests for pulse-log-runaway-detector.sh
+#
+# Covers: absolute cap hit, growth rate hit, repetition pattern hit,
+# healthy-log no-op, missing-file fail-open.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DETECTOR="${SCRIPT_DIR}/pulse-log-runaway-detector.sh"
+
+_PASS=0
+_FAIL=0
+_TEST_TMPDIR=""
+
+#######################################
+# _setup — create a fresh temp directory for each test.
+# Returns: 0
+#######################################
+_setup() {
+	_TEST_TMPDIR=$(mktemp -d)
+	export WRAPPER_LOGFILE="${_TEST_TMPDIR}/pulse-wrapper.log"
+	export PULSE_WRAPPER_LOG_LAST_SIZE_FILE="${_TEST_TMPDIR}/last-size"
+	export PULSE_LOG_ARCHIVE_DIR="${_TEST_TMPDIR}/archive"
+	mkdir -p "$PULSE_LOG_ARCHIVE_DIR"
+	return 0
+}
+
+#######################################
+# _teardown — clean up temp directory.
+# Returns: 0
+#######################################
+_teardown() {
+	[[ -n "$_TEST_TMPDIR" ]] && rm -rf "$_TEST_TMPDIR"
+	return 0
+}
+
+#######################################
+# _assert — check condition and record result.
+# Arguments:
+#   $1 — test name
+#   $2 — condition (0=pass, non-zero=fail)
+# Returns: 0
+#######################################
+_assert() {
+	local name="$1"
+	local result="$2"
+	if [[ "$result" == "0" ]]; then
+		printf '  PASS: %s\n' "$name"
+		_PASS=$((_PASS + 1))
+	else
+		printf '  FAIL: %s\n' "$name" >&2
+		_FAIL=$((_FAIL + 1))
+	fi
+	return 0
+}
+
+# ===== Test 1: Absolute cap hit =====
+test_absolute_cap_hit() {
+	printf 'Test 1: Absolute cap hit\n'
+	_setup
+
+	# Create a file larger than the default 500MB cap
+	# Use truncate for speed (creates a sparse file)
+	truncate -s 600M "$WRAPPER_LOGFILE"
+
+	# Run detector
+	bash "$DETECTOR" check-and-heal 2>/dev/null
+
+	# Verify: wrapper log was truncated (size should be near 0)
+	local after_size=0
+	after_size=$(wc -c <"$WRAPPER_LOGFILE" 2>/dev/null || echo "999999999")
+	after_size="${after_size//[[:space:]]/}"
+	[[ "$after_size" =~ ^[0-9]+$ ]] || after_size=999999999
+
+	local result=1
+	[[ "$after_size" -lt 1048576 ]] && result=0
+	_assert "wrapper log truncated after cap hit" "$result"
+
+	# Verify: archive was created
+	local archive_count=0
+	archive_count=$(find "$PULSE_LOG_ARCHIVE_DIR" -name "pulse-wrapper-*.log.gz" 2>/dev/null | wc -l)
+	archive_count="${archive_count//[[:space:]]/}"
+	local archive_result=1
+	[[ "$archive_count" -gt 0 ]] && archive_result=0
+	_assert "archive file created" "$archive_result"
+
+	# Verify: advisory written
+	local advisory_result=1
+	[[ -f "${_TEST_TMPDIR}/../cache/pulse-wrapper-log-runaway-advisory.txt" ]] || \
+	[[ -f "${HOME}/.aidevops/cache/pulse-wrapper-log-runaway-advisory.txt" ]] && advisory_result=0
+	_assert "advisory stamp written" "$advisory_result"
+
+	_teardown
+	return 0
+}
+
+# ===== Test 2: Growth rate hit =====
+test_growth_rate_hit() {
+	printf 'Test 2: Growth rate hit\n'
+	_setup
+
+	# Seed a last-size sentinel with a small number, very recently
+	printf '0' >"$PULSE_WRAPPER_LOG_LAST_SIZE_FILE"
+	# Touch to set mtime to now (age ~0s)
+	touch "$PULSE_WRAPPER_LOG_LAST_SIZE_FILE"
+	# Brief sleep so age > 0
+	sleep 1
+
+	# Create a 200MB file (growth of 200MB in ~1s = >>100MB/min)
+	truncate -s 200M "$WRAPPER_LOGFILE"
+
+	bash "$DETECTOR" check-and-heal 2>/dev/null
+
+	# Verify: wrapper log was truncated
+	local after_size=0
+	after_size=$(wc -c <"$WRAPPER_LOGFILE" 2>/dev/null || echo "999999999")
+	after_size="${after_size//[[:space:]]/}"
+	[[ "$after_size" =~ ^[0-9]+$ ]] || after_size=999999999
+
+	local result=1
+	[[ "$after_size" -lt 1048576 ]] && result=0
+	_assert "wrapper log truncated on growth-rate hit" "$result"
+
+	_teardown
+	return 0
+}
+
+# ===== Test 3: Repetition pattern hit =====
+test_repetition_pattern_hit() {
+	printf 'Test 3: Repetition pattern hit\n'
+	_setup
+
+	# Create a file with highly repetitive content (>100KB, <500MB cap)
+	# 200KB of the same line repeated
+	export PULSE_WRAPPER_LOG_RUNAWAY_BYTES=1073741824  # Set cap high so absolute check doesn't trigger
+	local i=0
+	while [[ "$i" -lt 5000 ]]; do
+		printf 'wait: pid 12345 is not a child of this shell\n' >>"$WRAPPER_LOGFILE"
+		i=$((i + 1))
+	done
+
+	# Run without growth rate sentinel so only repetition check fires
+	# (remove sentinel to give growth check a pass since it'll record first size)
+	rm -f "$PULSE_WRAPPER_LOG_LAST_SIZE_FILE"
+
+	bash "$DETECTOR" check-and-heal 2>/dev/null
+
+	# Check that advisory was written (repetition detection is advisory-only,
+	# doesn't necessarily rotate on its own if under size cap)
+	local advisory_result=1
+	[[ -f "${HOME}/.aidevops/cache/pulse-wrapper-log-runaway-advisory.txt" ]] && advisory_result=0
+	_assert "advisory written on repetition pattern" "$advisory_result"
+
+	_teardown
+	return 0
+}
+
+# ===== Test 4: Healthy log no-op =====
+test_healthy_log_noop() {
+	printf 'Test 4: Healthy log no-op\n'
+	_setup
+
+	# Create a small, diverse log (well under cap)
+	local i=0
+	while [[ "$i" -lt 50 ]]; do
+		printf '[pulse-wrapper] cycle %d complete at %s\n' "$i" "$(date)" >>"$WRAPPER_LOGFILE"
+		i=$((i + 1))
+	done
+
+	# Remove any previous advisory
+	rm -f "${HOME}/.aidevops/cache/pulse-wrapper-log-runaway-advisory.txt" 2>/dev/null || true
+
+	bash "$DETECTOR" check-and-heal 2>/dev/null
+
+	# Verify: no archive was created
+	local archive_count=0
+	archive_count=$(find "$PULSE_LOG_ARCHIVE_DIR" -name "pulse-wrapper-*.log.gz" 2>/dev/null | wc -l)
+	archive_count="${archive_count//[[:space:]]/}"
+
+	local result=1
+	[[ "$archive_count" == "0" ]] && result=0
+	_assert "no rotation on healthy log" "$result"
+
+	_teardown
+	return 0
+}
+
+# ===== Test 5: Missing file fail-open =====
+test_missing_file_failopen() {
+	printf 'Test 5: Missing file fail-open\n'
+	_setup
+
+	# Remove the wrapper log — detector should exit 0 gracefully
+	rm -f "$WRAPPER_LOGFILE"
+
+	local exit_code=0
+	bash "$DETECTOR" check-and-heal 2>/dev/null || exit_code=$?
+
+	_assert "exit 0 on missing file" "$exit_code"
+
+	_teardown
+	return 0
+}
+
+# ===== Run all tests =====
+printf '=== pulse-log-runaway-detector tests ===\n\n'
+
+test_absolute_cap_hit
+test_growth_rate_hit
+test_repetition_pattern_hit
+test_healthy_log_noop
+test_missing_file_failopen
+
+printf '\n=== Results: %d passed, %d failed ===\n' "$_PASS" "$_FAIL"
+
+if [[ "$_FAIL" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Add a runaway-log self-healing detector that catches the failure mode demonstrated by GH#21729: pulse-wrapper.log growing 6GB+ because a tight error loop bleeds the same line millions of times. Three independent detection layers, all fail-open.

## What Changed

### NEW: `.agents/scripts/pulse-log-runaway-detector.sh`
Standalone check-and-heal helper with three detection layers:
1. **Absolute size cap** — rotates when WRAPPER_LOGFILE > 500MB (env: `PULSE_WRAPPER_LOG_RUNAWAY_BYTES`)
2. **Growth rate** — rotates when growth > 100MB/min (env: `PULSE_WRAPPER_LOG_GROWTH_BYTES_PER_MIN`)
3. **Repetition pattern** — advisory when >95% of last 1000 lines are identical

### EDIT: `.agents/scripts/pulse-logging.sh`
- Refactored `rotate_pulse_log` into three functions (`_rotate_single_log`, `_prune_cold_archive`, `rotate_pulse_log`) to stay under the 100-line complexity gate
- Extended rotation to cover `WRAPPER_LOGFILE` (the gap that allowed the 6GB runaway)

### EDIT: `.agents/scripts/pulse-wrapper-cycle.sh`
- Added `_pulse_check_runaway_log()` — sentinel-gated (5min cadence), modelled on `_pulse_prime_caches_if_stale` (t2994)

### EDIT: `.agents/scripts/pulse-wrapper.sh`
- Wired `_pulse_check_runaway_log` into `main()` after cache priming, before log rotation

### NEW: `.agents/scripts/tests/test-pulse-log-runaway-detector.sh`
5 test cases (7 assertions): absolute cap hit, growth rate hit, repetition pattern hit, healthy-log no-op, missing-file fail-open. All pass.

## Verification

```bash
shellcheck .agents/scripts/pulse-log-runaway-detector.sh  # clean
shellcheck .agents/scripts/pulse-logging.sh                # clean
shellcheck .agents/scripts/pulse-wrapper.sh                # clean
shellcheck .agents/scripts/pulse-wrapper-cycle.sh          # clean
bash .agents/scripts/tests/test-pulse-log-runaway-detector.sh  # 7/7 pass
```

Resolves #21756

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-opus-4-6 spent 9m and 28,064 tokens on this as a headless worker.