### PR TITLE
t3049: auto-notify stale-recovery NMR when subsequent worker produces approved PR

### DIFF
--- a/.agents/scripts/pulse-nmr-approval.sh
+++ b/.agents/scripts/pulse-nmr-approval.sh
@@ -616,7 +616,7 @@ _find_qualifying_pr_for_stale_recovery() {
 
 	local j=0
 	while [[ "$j" -lt "$pr_count" ]]; do
-		local pr_num pr_review pr_author_assoc pr_created_at
+		local pr_num="" pr_review="" pr_author_assoc="" pr_created_at=""
 		pr_num=$(printf '%s' "$pr_json" | jq -r ".[$j].number // empty" 2>/dev/null) || pr_num=""
 		pr_review=$(printf '%s' "$pr_json" | jq -r ".[$j].reviewDecision // empty" 2>/dev/null) || pr_review=""
 		pr_author_assoc=$(printf '%s' "$pr_json" | jq -r ".[$j].authorAssociation // empty" 2>/dev/null) || pr_author_assoc=""

--- a/.agents/scripts/pulse-nmr-approval.sh
+++ b/.agents/scripts/pulse-nmr-approval.sh
@@ -24,6 +24,7 @@
 #   - issue_has_required_approval
 #   - _nmr_applied_by_maintainer
 #   - notify_ever_nmr_without_approval
+#   - _notify_stale_recovery_resolved_by_pr
 #   - auto_approve_maintainer_issues
 #
 # This is a pure move from pulse-wrapper.sh. The function bodies are
@@ -479,6 +480,10 @@ _nmr_applied_by_maintainer() {
 		# scanner labels persist for the issue's lifetime.
 		if _nmr_application_is_circuit_breaker_trip "$issue_num" "$slug" "$nmr_at"; then
 			echo "[pulse-wrapper] _nmr_applied_by_maintainer: #${issue_num} in ${slug} — circuit breaker tripped — PRESERVING NMR, requires 'sudo aidevops approve issue ${issue_num}' (t2386/GH#20758)" >>"$LOGFILE"
+			# t3049: check if a subsequent worker produced a clean approved PR
+			# that resolves the stale-recovery false positive. Posts a one-shot
+			# notification to the maintainer if so. Does NOT clear NMR.
+			_notify_stale_recovery_resolved_by_pr "$issue_num" "$slug" "$nmr_at" || true
 			return 0
 		fi
 		if _nmr_application_has_automation_signature "$issue_num" "$slug" "$nmr_at"; then
@@ -571,6 +576,165 @@ notify_ever_nmr_without_approval() {
 > This gate cannot be bypassed by label manipulation (security design — see \`reference/auto-merge.md\` NMR section)." \
 		2>/dev/null || {
 		echo "[pulse-wrapper] notify_ever_nmr_without_approval: #${issue_number} in ${repo_slug} — failed to post remediation comment" >>"$LOGFILE"
+	}
+
+	return 0
+}
+
+#######################################
+# t3049: Post a one-shot notification when a stale-recovery NMR is resolved
+# by a subsequent worker producing an APPROVED PR.
+#
+# When stale-recovery applies NMR (via stale-recovery-tick:escalated), a
+# subsequent worker may still produce a clean PR. If that PR is APPROVED with
+# all non-maintainer-gate CI green and authored by OWNER/MEMBER with
+# origin:worker or origin:interactive, the maintainer only needs to run
+# `sudo aidevops approve issue N` to unblock the merge — but has no signal.
+# This function posts exactly that signal, once.
+#
+# <!-- aidevops:trust-boundary -->
+# Self-validates: PR author association (OWNER/MEMBER only), PR origin label
+# (origin:worker or origin:interactive only), PR createdAt > NMR labelledAt,
+# reviewDecision==APPROVED, all non-maintainer-gate CI SUCCESS.
+# Does NOT trust upstream checks — each gate is evaluated at invocation time.
+#
+# SECURITY: NMR is NOT auto-cleared. The notification only prompts the
+# maintainer to run the cryptographic approval command. The bypass surface
+# is closed because:
+#   - Only OWNER/MEMBER-authored PRs qualify (no contributor injection)
+#   - Only origin:worker/origin:interactive PRs qualify (no takeover)
+#   - Maintainer-gate is not auto-cleared — human must run crypto approval
+#
+# Arguments:
+#   $1 - issue_num  : GitHub issue number
+#   $2 - slug       : repo slug (owner/repo)
+#   $3 - nmr_at     : ISO8601 timestamp when NMR was applied
+#
+# Returns: 0 always (fail-open — a missed notification is better than a broken
+#          approval loop).
+#######################################
+_notify_stale_recovery_resolved_by_pr() {
+	local issue_num="$1"
+	local slug="$2"
+	local nmr_at="$3"
+
+	[[ -n "$issue_num" && -n "$slug" && -n "$nmr_at" ]] || return 0
+
+	# Shared API path — constructed via printf to avoid string-literal ratchet regression
+	local comments_api
+	printf -v comments_api 'repos/%s/issues/%s/comments' "$slug" "$issue_num"
+
+	# Gate 1: Only act on stale-recovery-tick:escalated breaker trips.
+	# Cost-circuit-breaker:fired and cost-circuit-breaker:no_work_loop indicate
+	# budget/infra problems where merging is itself unsafe.
+	local has_stale_recovery
+	has_stale_recovery=$(gh api "$comments_api" --paginate \
+		--jq "[.[] | select(.body | test(\"stale-recovery-tick:escalated\")) | select(.body | test(\"cost-circuit-breaker:fired|cost-circuit-breaker:no_work_loop\") | not)] | length" \
+		2>/dev/null) || has_stale_recovery=0
+	[[ "$has_stale_recovery" =~ ^[0-9]+$ ]] || has_stale_recovery=0
+	if [[ "$has_stale_recovery" -le 0 ]]; then
+		return 0
+	fi
+
+	# Gate 2: Idempotency — never post twice.
+	local already_notified
+	already_notified=$(gh api "$comments_api" --paginate \
+		--jq '[.[] | select(.body | test("nmr-stale-recovery-resolution-notice"))] | length' \
+		2>/dev/null) || already_notified=0
+	[[ "$already_notified" =~ ^[0-9]+$ ]] || already_notified=0
+	if [[ "$already_notified" -gt 0 ]]; then
+		echo "[pulse-wrapper] _notify_stale_recovery_resolved_by_pr: #${issue_num} in ${slug} — notification already posted, skipping" >>"$LOGFILE"
+		return 0
+	fi
+
+	# Gate 3: Find linked OPEN PRs with Resolves #N in body.
+	local pr_json
+	pr_json=$(gh pr list --search "Resolves #${issue_num} in:body" --state open \
+		--repo "$slug" --json number,reviewDecision,statusCheckRollup,authorAssociation,labels,createdAt \
+		--limit 10 2>/dev/null) || pr_json="[]"
+	[[ -n "$pr_json" && "$pr_json" != "null" ]] || pr_json="[]"
+
+	local pr_count
+	pr_count=$(printf '%s' "$pr_json" | jq 'length' 2>/dev/null) || pr_count=0
+	[[ "$pr_count" -gt 0 ]] || return 0
+
+	# Evaluate each candidate PR against the trust boundary gates.
+	local j=0
+	local matching_pr=""
+	while [[ "$j" -lt "$pr_count" ]]; do
+		local pr_num pr_review pr_author_assoc pr_created_at
+		pr_num=$(printf '%s' "$pr_json" | jq -r ".[$j].number // empty" 2>/dev/null) || pr_num=""
+		pr_review=$(printf '%s' "$pr_json" | jq -r ".[$j].reviewDecision // empty" 2>/dev/null) || pr_review=""
+		pr_author_assoc=$(printf '%s' "$pr_json" | jq -r ".[$j].authorAssociation // empty" 2>/dev/null) || pr_author_assoc=""
+		pr_created_at=$(printf '%s' "$pr_json" | jq -r ".[$j].createdAt // empty" 2>/dev/null) || pr_created_at=""
+		j=$((j + 1))
+
+		# Gate 3a: PR must be created AFTER NMR was applied.
+		if [[ -n "$pr_created_at" && -n "$nmr_at" ]]; then
+			local pr_after_nmr
+			pr_after_nmr=$(jq -n --arg p "$pr_created_at" --arg n "$nmr_at" \
+				'(($p | fromdateiso8601) > ($n | fromdateiso8601))' 2>/dev/null) || pr_after_nmr="false"
+			if [[ "$pr_after_nmr" != "true" ]]; then
+				continue
+			fi
+		else
+			continue
+		fi
+
+		# Gate 3b: reviewDecision must be APPROVED.
+		if [[ "$pr_review" != "APPROVED" ]]; then
+			continue
+		fi
+
+		# Gate 3c: authorAssociation must be OWNER or MEMBER (not COLLABORATOR/external).
+		if [[ "$pr_author_assoc" != "OWNER" && "$pr_author_assoc" != "MEMBER" ]]; then
+			continue
+		fi
+
+		# Gate 3d: PR must have origin:worker or origin:interactive label.
+		local has_valid_origin
+		has_valid_origin=$(printf '%s' "$pr_json" | jq -r \
+			"[.[$((j - 1))].labels[]?.name] | map(select(. == \"origin:worker\" or . == \"origin:interactive\")) | length" \
+			2>/dev/null) || has_valid_origin=0
+		[[ "$has_valid_origin" =~ ^[0-9]+$ ]] || has_valid_origin=0
+		if [[ "$has_valid_origin" -le 0 ]]; then
+			continue
+		fi
+
+		# Gate 3e: All non-maintainer-gate CI checks must be SUCCESS.
+		local failing_checks
+		failing_checks=$(printf '%s' "$pr_json" | jq -r \
+			"[.[$((j - 1))].statusCheckRollup[]? | select(.name != null) | select(.name | test(\"Maintainer Review\"; \"i\") | not) | select(.conclusion != \"SUCCESS\" and .conclusion != \"NEUTRAL\" and .conclusion != \"SKIPPED\" and .status != \"COMPLETED\")] | length" \
+			2>/dev/null) || failing_checks=0
+		[[ "$failing_checks" =~ ^[0-9]+$ ]] || failing_checks=0
+		if [[ "$failing_checks" -gt 0 ]]; then
+			continue
+		fi
+
+		# All gates passed — this PR qualifies.
+		matching_pr="$pr_num"
+		break
+	done
+
+	if [[ -z "$matching_pr" ]]; then
+		# No qualifying PR found — silent no-op.
+		return 0
+	fi
+
+	# Post the one-shot notification.
+	echo "[pulse-wrapper] _notify_stale_recovery_resolved_by_pr: #${issue_num} in ${slug} — PR #${matching_pr} qualifies, posting notification" >>"$LOGFILE"
+
+	gh_issue_comment "$issue_num" --repo "$slug" \
+		--body "<!-- nmr-stale-recovery-resolution-notice -->
+PR #${matching_pr} is APPROVED with all quality/security gates green. To merge, run:
+
+\`\`\`
+sudo aidevops approve issue ${issue_num}
+\`\`\`
+
+This issue's NMR was applied by stale-recovery (t2008) — the cryptographic approval clears it and the merge gate flips to PASS." \
+		2>/dev/null || {
+		echo "[pulse-wrapper] _notify_stale_recovery_resolved_by_pr: #${issue_num} in ${slug} — failed to post notification" >>"$LOGFILE"
 	}
 
 	return 0

--- a/.agents/scripts/pulse-nmr-approval.sh
+++ b/.agents/scripts/pulse-nmr-approval.sh
@@ -24,6 +24,7 @@
 #   - issue_has_required_approval
 #   - _nmr_applied_by_maintainer
 #   - notify_ever_nmr_without_approval
+#   - _find_qualifying_pr_for_stale_recovery
 #   - _notify_stale_recovery_resolved_by_pr
 #   - auto_approve_maintainer_issues
 #
@@ -582,6 +583,87 @@ notify_ever_nmr_without_approval() {
 }
 
 #######################################
+# t3049: Evaluate linked OPEN PRs against the trust boundary gates and return
+# the number of the first qualifying PR, or empty string if none qualifies.
+#
+# <!-- aidevops:trust-boundary -->
+# Self-validates each gate: PR createdAt > NMR labelledAt, APPROVED review,
+# OWNER/MEMBER authorAssociation, origin:worker or origin:interactive label,
+# all non-maintainer-gate CI SUCCESS.
+#
+# Arguments:
+#   $1 - issue_num  : GitHub issue number
+#   $2 - slug       : repo slug (owner/repo)
+#   $3 - nmr_at     : ISO8601 timestamp when NMR was applied
+#
+# Outputs: PR number on stdout (empty if no match).
+# Returns: 0 always.
+#######################################
+_find_qualifying_pr_for_stale_recovery() {
+	local issue_num="$1"
+	local slug="$2"
+	local nmr_at="$3"
+
+	local pr_json
+	pr_json=$(gh pr list --search "Resolves #${issue_num} in:body" --state open \
+		--repo "$slug" --json number,reviewDecision,statusCheckRollup,authorAssociation,labels,createdAt \
+		--limit 10 2>/dev/null) || pr_json="[]"
+	[[ -n "$pr_json" && "$pr_json" != "null" ]] || pr_json="[]"
+
+	local pr_count
+	pr_count=$(printf '%s' "$pr_json" | jq 'length' 2>/dev/null) || pr_count=0
+	[[ "$pr_count" -gt 0 ]] || return 0
+
+	local j=0
+	while [[ "$j" -lt "$pr_count" ]]; do
+		local pr_num pr_review pr_author_assoc pr_created_at
+		pr_num=$(printf '%s' "$pr_json" | jq -r ".[$j].number // empty" 2>/dev/null) || pr_num=""
+		pr_review=$(printf '%s' "$pr_json" | jq -r ".[$j].reviewDecision // empty" 2>/dev/null) || pr_review=""
+		pr_author_assoc=$(printf '%s' "$pr_json" | jq -r ".[$j].authorAssociation // empty" 2>/dev/null) || pr_author_assoc=""
+		pr_created_at=$(printf '%s' "$pr_json" | jq -r ".[$j].createdAt // empty" 2>/dev/null) || pr_created_at=""
+		j=$((j + 1))
+
+		# PR must be created AFTER NMR was applied.
+		if [[ -n "$pr_created_at" && -n "$nmr_at" ]]; then
+			local pr_after_nmr
+			pr_after_nmr=$(jq -n --arg p "$pr_created_at" --arg n "$nmr_at" \
+				'(($p | fromdateiso8601) > ($n | fromdateiso8601))' 2>/dev/null) || pr_after_nmr="false"
+			[[ "$pr_after_nmr" == "true" ]] || continue
+		else
+			continue
+		fi
+
+		# reviewDecision must be APPROVED.
+		[[ "$pr_review" == "APPROVED" ]] || continue
+
+		# authorAssociation must be OWNER or MEMBER (not COLLABORATOR/external).
+		[[ "$pr_author_assoc" == "OWNER" || "$pr_author_assoc" == "MEMBER" ]] || continue
+
+		# PR must have origin:worker or origin:interactive label.
+		local has_valid_origin
+		has_valid_origin=$(printf '%s' "$pr_json" | jq -r \
+			"[.[$((j - 1))].labels[]?.name] | map(select(. == \"origin:worker\" or . == \"origin:interactive\")) | length" \
+			2>/dev/null) || has_valid_origin=0
+		[[ "$has_valid_origin" =~ ^[0-9]+$ ]] || has_valid_origin=0
+		[[ "$has_valid_origin" -gt 0 ]] || continue
+
+		# All non-maintainer-gate CI checks must have a passing conclusion.
+		local failing_checks
+		failing_checks=$(printf '%s' "$pr_json" | jq -r \
+			"[.[$((j - 1))].statusCheckRollup[]? | select(.name != null) | select(.name | test(\"Maintainer Review\"; \"i\") | not) | select(.conclusion != \"SUCCESS\" and .conclusion != \"NEUTRAL\" and .conclusion != \"SKIPPED\")] | length" \
+			2>/dev/null) || failing_checks=0
+		[[ "$failing_checks" =~ ^[0-9]+$ ]] || failing_checks=0
+		[[ "$failing_checks" -le 0 ]] || continue
+
+		# All gates passed — output the PR number.
+		printf '%s' "$pr_num"
+		return 0
+	done
+
+	return 0
+}
+
+#######################################
 # t3049: Post a one-shot notification when a stale-recovery NMR is resolved
 # by a subsequent worker producing an APPROVED PR.
 #
@@ -647,80 +729,10 @@ _notify_stale_recovery_resolved_by_pr() {
 		return 0
 	fi
 
-	# Gate 3: Find linked OPEN PRs with Resolves #N in body.
-	local pr_json
-	pr_json=$(gh pr list --search "Resolves #${issue_num} in:body" --state open \
-		--repo "$slug" --json number,reviewDecision,statusCheckRollup,authorAssociation,labels,createdAt \
-		--limit 10 2>/dev/null) || pr_json="[]"
-	[[ -n "$pr_json" && "$pr_json" != "null" ]] || pr_json="[]"
-
-	local pr_count
-	pr_count=$(printf '%s' "$pr_json" | jq 'length' 2>/dev/null) || pr_count=0
-	[[ "$pr_count" -gt 0 ]] || return 0
-
-	# Evaluate each candidate PR against the trust boundary gates.
-	local j=0
-	local matching_pr=""
-	while [[ "$j" -lt "$pr_count" ]]; do
-		local pr_num pr_review pr_author_assoc pr_created_at
-		pr_num=$(printf '%s' "$pr_json" | jq -r ".[$j].number // empty" 2>/dev/null) || pr_num=""
-		pr_review=$(printf '%s' "$pr_json" | jq -r ".[$j].reviewDecision // empty" 2>/dev/null) || pr_review=""
-		pr_author_assoc=$(printf '%s' "$pr_json" | jq -r ".[$j].authorAssociation // empty" 2>/dev/null) || pr_author_assoc=""
-		pr_created_at=$(printf '%s' "$pr_json" | jq -r ".[$j].createdAt // empty" 2>/dev/null) || pr_created_at=""
-		j=$((j + 1))
-
-		# Gate 3a: PR must be created AFTER NMR was applied.
-		if [[ -n "$pr_created_at" && -n "$nmr_at" ]]; then
-			local pr_after_nmr
-			pr_after_nmr=$(jq -n --arg p "$pr_created_at" --arg n "$nmr_at" \
-				'(($p | fromdateiso8601) > ($n | fromdateiso8601))' 2>/dev/null) || pr_after_nmr="false"
-			if [[ "$pr_after_nmr" != "true" ]]; then
-				continue
-			fi
-		else
-			continue
-		fi
-
-		# Gate 3b: reviewDecision must be APPROVED.
-		if [[ "$pr_review" != "APPROVED" ]]; then
-			continue
-		fi
-
-		# Gate 3c: authorAssociation must be OWNER or MEMBER (not COLLABORATOR/external).
-		if [[ "$pr_author_assoc" != "OWNER" && "$pr_author_assoc" != "MEMBER" ]]; then
-			continue
-		fi
-
-		# Gate 3d: PR must have origin:worker or origin:interactive label.
-		local has_valid_origin
-		has_valid_origin=$(printf '%s' "$pr_json" | jq -r \
-			"[.[$((j - 1))].labels[]?.name] | map(select(. == \"origin:worker\" or . == \"origin:interactive\")) | length" \
-			2>/dev/null) || has_valid_origin=0
-		[[ "$has_valid_origin" =~ ^[0-9]+$ ]] || has_valid_origin=0
-		if [[ "$has_valid_origin" -le 0 ]]; then
-			continue
-		fi
-
-		# Gate 3e: All non-maintainer-gate CI checks must have a passing conclusion.
-		# A check passes if conclusion is SUCCESS, NEUTRAL, or SKIPPED.
-		# Anything else (FAILURE, CANCELLED, TIMED_OUT, ACTION_REQUIRED, STALE,
-		# or still in-progress with no conclusion yet) counts as failing.
-		local failing_checks
-		failing_checks=$(printf '%s' "$pr_json" | jq -r \
-			"[.[$((j - 1))].statusCheckRollup[]? | select(.name != null) | select(.name | test(\"Maintainer Review\"; \"i\") | not) | select(.conclusion != \"SUCCESS\" and .conclusion != \"NEUTRAL\" and .conclusion != \"SKIPPED\")] | length" \
-			2>/dev/null) || failing_checks=0
-		[[ "$failing_checks" =~ ^[0-9]+$ ]] || failing_checks=0
-		if [[ "$failing_checks" -gt 0 ]]; then
-			continue
-		fi
-
-		# All gates passed — this PR qualifies.
-		matching_pr="$pr_num"
-		break
-	done
-
+	# Gate 3: Find a qualifying linked PR via the extracted helper.
+	local matching_pr
+	matching_pr=$(_find_qualifying_pr_for_stale_recovery "$issue_num" "$slug" "$nmr_at")
 	if [[ -z "$matching_pr" ]]; then
-		# No qualifying PR found — silent no-op.
 		return 0
 	fi
 

--- a/.agents/scripts/pulse-nmr-approval.sh
+++ b/.agents/scripts/pulse-nmr-approval.sh
@@ -701,10 +701,13 @@ _notify_stale_recovery_resolved_by_pr() {
 			continue
 		fi
 
-		# Gate 3e: All non-maintainer-gate CI checks must be SUCCESS.
+		# Gate 3e: All non-maintainer-gate CI checks must have a passing conclusion.
+		# A check passes if conclusion is SUCCESS, NEUTRAL, or SKIPPED.
+		# Anything else (FAILURE, CANCELLED, TIMED_OUT, ACTION_REQUIRED, STALE,
+		# or still in-progress with no conclusion yet) counts as failing.
 		local failing_checks
 		failing_checks=$(printf '%s' "$pr_json" | jq -r \
-			"[.[$((j - 1))].statusCheckRollup[]? | select(.name != null) | select(.name | test(\"Maintainer Review\"; \"i\") | not) | select(.conclusion != \"SUCCESS\" and .conclusion != \"NEUTRAL\" and .conclusion != \"SKIPPED\" and .status != \"COMPLETED\")] | length" \
+			"[.[$((j - 1))].statusCheckRollup[]? | select(.name != null) | select(.name | test(\"Maintainer Review\"; \"i\") | not) | select(.conclusion != \"SUCCESS\" and .conclusion != \"NEUTRAL\" and .conclusion != \"SKIPPED\")] | length" \
 			2>/dev/null) || failing_checks=0
 		[[ "$failing_checks" =~ ^[0-9]+$ ]] || failing_checks=0
 		if [[ "$failing_checks" -gt 0 ]]; then

--- a/.agents/scripts/tests/test-pulse-nmr-approval.sh
+++ b/.agents/scripts/tests/test-pulse-nmr-approval.sh
@@ -178,18 +178,23 @@ gh_issue_comment() {
 }
 export -f gh_issue_comment
 
-# Extract the function under test from the source file.
+# Extract the functions under test from the source file.
 define_helper_under_test() {
-	local func_src
-	func_src=$(awk '
+	local finder_src notify_src
+	finder_src=$(awk '
+		/^_find_qualifying_pr_for_stale_recovery\(\) \{/,/^}$/ { print }
+	' "$NMR_SCRIPT")
+	notify_src=$(awk '
 		/^_notify_stale_recovery_resolved_by_pr\(\) \{/,/^}$/ { print }
 	' "$NMR_SCRIPT")
-	if [[ -z "$func_src" ]]; then
-		printf 'ERROR: could not extract _notify_stale_recovery_resolved_by_pr from %s\n' "$NMR_SCRIPT" >&2
+	if [[ -z "$finder_src" || -z "$notify_src" ]]; then
+		printf 'ERROR: could not extract helpers from %s\n' "$NMR_SCRIPT" >&2
 		return 1
 	fi
 	# shellcheck disable=SC1090
-	eval "$func_src"
+	eval "$finder_src"
+	# shellcheck disable=SC1090
+	eval "$notify_src"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-pulse-nmr-approval.sh
+++ b/.agents/scripts/tests/test-pulse-nmr-approval.sh
@@ -1,0 +1,429 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Tests for `_notify_stale_recovery_resolved_by_pr` in pulse-nmr-approval.sh
+# (GH#21752 / t3049).
+#
+# Verifies that the notification helper correctly:
+#   a. Posts a notification when stale-recovery NMR + OWNER-authored approved
+#      PR with origin:worker and all green CI exists
+#   b. Does NOT post for non-collaborator PRs (contributor injection vector)
+#   c. Does NOT post for COLLABORATOR PRs (mid-trust injection vector)
+#   d. Does NOT post for origin:worker-takeover PRs (weaker provenance)
+#   e. Posts when maintainer-gate is the only failing check
+#   f. Does NOT post when a security/quality check fails
+#   g. Does NOT post for cost-circuit-breaker:fired NMR
+#   h. Does NOT post a duplicate when the marker already exists
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+NMR_SCRIPT="${SCRIPT_DIR}/../pulse-nmr-approval.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+COMMENTS_FIXTURE=""
+PR_LIST_FIXTURE=""
+POSTED_COMMENT=""
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+	mkdir -p "${TEST_ROOT}/bin"
+	export PATH="${TEST_ROOT}/bin:${PATH}"
+	export LOGFILE="${TEST_ROOT}/pulse.log"
+	: >"$LOGFILE"
+	COMMENTS_FIXTURE="${TEST_ROOT}/comments.json"
+	PR_LIST_FIXTURE="${TEST_ROOT}/pr-list.json"
+	POSTED_COMMENT="${TEST_ROOT}/posted-comment.txt"
+	export COMMENTS_FIXTURE PR_LIST_FIXTURE POSTED_COMMENT
+
+	# gh stub: serves comments from COMMENTS_FIXTURE for 'gh api ...comments',
+	# serves PR list from PR_LIST_FIXTURE for 'gh pr list', and captures
+	# comment posts for 'gh issue comment'.
+	cat >"${TEST_ROOT}/bin/gh" <<'GHEOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "${1:-}" == "api" ]]; then
+	path="${2:-}"
+	jq_filter=""
+	shift 2 2>/dev/null || true
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+			--paginate) shift ;;
+			--jq) jq_filter="$2"; shift 2 ;;
+			*) shift ;;
+		esac
+	done
+	if [[ "$path" == */comments ]]; then
+		if [[ -n "$jq_filter" ]]; then
+			jq -r "$jq_filter" <"$COMMENTS_FIXTURE" 2>/dev/null || echo "0"
+		else
+			cat "$COMMENTS_FIXTURE"
+		fi
+		exit 0
+	fi
+fi
+if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
+	shift 2
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+			--search|--state|--repo|--limit) shift 2 ;;
+			--json) shift 2 ;;
+			*) shift ;;
+		esac
+	done
+	cat "$PR_LIST_FIXTURE"
+	exit 0
+fi
+if [[ "${1:-}" == "issue" && "${2:-}" == "comment" ]]; then
+	shift 2
+	issue_num=""
+	body=""
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+			--repo) shift 2 ;;
+			--body) body="$2"; shift 2 ;;
+			*) issue_num="$1"; shift ;;
+		esac
+	done
+	printf '%s\n' "$body" >"$POSTED_COMMENT"
+	exit 0
+fi
+printf 'unsupported gh invocation: %s\n' "$*" >&2
+exit 1
+GHEOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+
+	# Seed empty fixtures
+	printf '[]\n' >"$COMMENTS_FIXTURE"
+	printf '[]\n' >"$PR_LIST_FIXTURE"
+	: >"$POSTED_COMMENT"
+
+	return 0
+}
+
+teardown_test_env() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+set_comments() {
+	local body="$1"
+	printf '%s\n' "$body" >"$COMMENTS_FIXTURE"
+	return 0
+}
+
+set_pr_list() {
+	local body="$1"
+	printf '%s\n' "$body" >"$PR_LIST_FIXTURE"
+	return 0
+}
+
+reset_posted_comment() {
+	: >"$POSTED_COMMENT"
+	return 0
+}
+
+was_comment_posted() {
+	[[ -s "$POSTED_COMMENT" ]]
+	return $?
+}
+
+posted_comment_contains() {
+	local pattern="$1"
+	grep -q "$pattern" "$POSTED_COMMENT" 2>/dev/null
+	return $?
+}
+
+# Also stub gh_issue_comment to the same captured output (the function
+# may be called instead of bare gh issue comment)
+gh_issue_comment() {
+	local issue_num=""
+	local body=""
+	local repo=""
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+			--repo) repo="$2"; shift 2 ;;
+			--body) body="$2"; shift 2 ;;
+			*) issue_num="$1"; shift ;;
+		esac
+	done
+	printf '%s\n' "$body" >"$POSTED_COMMENT"
+	return 0
+}
+export -f gh_issue_comment
+
+# Extract the function under test from the source file.
+define_helper_under_test() {
+	local func_src
+	func_src=$(awk '
+		/^_notify_stale_recovery_resolved_by_pr\(\) \{/,/^}$/ { print }
+	' "$NMR_SCRIPT")
+	if [[ -z "$func_src" ]]; then
+		printf 'ERROR: could not extract _notify_stale_recovery_resolved_by_pr from %s\n' "$NMR_SCRIPT" >&2
+		return 1
+	fi
+	# shellcheck disable=SC1090
+	eval "$func_src"
+	return 0
+}
+
+# --- Helper: build a PR JSON object for the fixture ---
+build_pr_json() {
+	local num="${1:-100}"
+	local review="${2:-APPROVED}"
+	local author_assoc="${3:-OWNER}"
+	local created_at="${4:-2026-04-29T10:00:00Z}"
+	local origin_label="${5:-origin:worker}"
+	local ci_status="${6:-SUCCESS}"
+	local maintainer_gate_status="${7:-FAILURE}"
+
+	local labels_json
+	labels_json=$(jq -n --arg l "$origin_label" '[{"name": $l}]')
+
+	local checks_json
+	checks_json=$(jq -n \
+		--arg ci "$ci_status" \
+		--arg mg "$maintainer_gate_status" \
+		'[
+			{"name": "quality / ShellCheck", "conclusion": $ci, "status": "COMPLETED"},
+			{"name": "quality / Codacy", "conclusion": $ci, "status": "COMPLETED"},
+			{"name": "gate / Maintainer Review & Assignee Gate", "conclusion": $mg, "status": "COMPLETED"}
+		]')
+
+	jq -n \
+		--argjson num "$num" \
+		--arg review "$review" \
+		--arg assoc "$author_assoc" \
+		--arg created "$created_at" \
+		--argjson labels "$labels_json" \
+		--argjson checks "$checks_json" \
+		'{
+			number: $num,
+			reviewDecision: $review,
+			authorAssociation: $assoc,
+			createdAt: $created,
+			labels: $labels,
+			statusCheckRollup: $checks
+		}'
+	return 0
+}
+
+# ============================================================
+# Test cases
+# ============================================================
+
+# Case A: stale-recovery NMR + OWNER-authored OPEN approved PR (origin:worker,
+# green CI) -> notification posted
+test_a_stale_recovery_with_approved_pr_posts_notification() {
+	reset_posted_comment
+	# Comments: stale-recovery-tick:escalated marker, no prior notification
+	set_comments '[{"created_at":"2026-04-29T09:14:00Z","body":"<!-- stale-recovery-tick:escalated (threshold=2) -->\n**Stale recovery threshold reached**"}]'
+	# PR: OWNER, APPROVED, origin:worker, all CI green, created after NMR
+	local pr_data
+	pr_data=$(build_pr_json 21716 "APPROVED" "OWNER" "2026-04-29T09:19:00Z" "origin:worker" "SUCCESS" "FAILURE")
+	set_pr_list "[${pr_data}]"
+
+	_notify_stale_recovery_resolved_by_pr 21699 "marcusquinn/aidevops" "2026-04-29T09:14:00Z"
+
+	if was_comment_posted && posted_comment_contains "nmr-stale-recovery-resolution-notice"; then
+		print_result "Case A: stale-recovery + approved OWNER PR -> notification posted" 0
+	else
+		print_result "Case A: stale-recovery + approved OWNER PR -> notification posted" 1 \
+			"Expected notification comment to be posted"
+	fi
+	return 0
+}
+
+# Case B: stale-recovery NMR + non-collaborator PR with APPROVED state -> no notification
+test_b_non_collaborator_pr_no_notification() {
+	reset_posted_comment
+	set_comments '[{"created_at":"2026-04-29T09:14:00Z","body":"<!-- stale-recovery-tick:escalated (threshold=2) -->"}]'
+	local pr_data
+	pr_data=$(build_pr_json 200 "APPROVED" "NONE" "2026-04-29T09:19:00Z" "origin:worker" "SUCCESS" "FAILURE")
+	set_pr_list "[${pr_data}]"
+
+	_notify_stale_recovery_resolved_by_pr 21699 "marcusquinn/aidevops" "2026-04-29T09:14:00Z"
+
+	if was_comment_posted; then
+		print_result "Case B: non-collaborator PR -> no notification" 1 \
+			"Notification should NOT be posted for non-collaborator PRs"
+	else
+		print_result "Case B: non-collaborator PR -> no notification" 0
+	fi
+	return 0
+}
+
+# Case C: stale-recovery NMR + COLLABORATOR PR with APPROVED state -> no notification
+test_c_collaborator_pr_no_notification() {
+	reset_posted_comment
+	set_comments '[{"created_at":"2026-04-29T09:14:00Z","body":"<!-- stale-recovery-tick:escalated (threshold=2) -->"}]'
+	local pr_data
+	pr_data=$(build_pr_json 201 "APPROVED" "COLLABORATOR" "2026-04-29T09:19:00Z" "origin:worker" "SUCCESS" "FAILURE")
+	set_pr_list "[${pr_data}]"
+
+	_notify_stale_recovery_resolved_by_pr 21699 "marcusquinn/aidevops" "2026-04-29T09:14:00Z"
+
+	if was_comment_posted; then
+		print_result "Case C: COLLABORATOR PR -> no notification" 1 \
+			"Notification should NOT be posted for COLLABORATOR PRs"
+	else
+		print_result "Case C: COLLABORATOR PR -> no notification" 0
+	fi
+	return 0
+}
+
+# Case D: stale-recovery NMR + origin:worker-takeover PR -> no notification
+test_d_worker_takeover_pr_no_notification() {
+	reset_posted_comment
+	set_comments '[{"created_at":"2026-04-29T09:14:00Z","body":"<!-- stale-recovery-tick:escalated (threshold=2) -->"}]'
+	local pr_data
+	pr_data=$(build_pr_json 202 "APPROVED" "OWNER" "2026-04-29T09:19:00Z" "origin:worker-takeover" "SUCCESS" "FAILURE")
+	set_pr_list "[${pr_data}]"
+
+	_notify_stale_recovery_resolved_by_pr 21699 "marcusquinn/aidevops" "2026-04-29T09:14:00Z"
+
+	if was_comment_posted; then
+		print_result "Case D: origin:worker-takeover PR -> no notification" 1 \
+			"Notification should NOT be posted for worker-takeover PRs"
+	else
+		print_result "Case D: origin:worker-takeover PR -> no notification" 0
+	fi
+	return 0
+}
+
+# Case E: stale-recovery NMR + PR with maintainer-gate as only failing check -> notification posted
+test_e_maintainer_gate_only_failure_posts_notification() {
+	reset_posted_comment
+	set_comments '[{"created_at":"2026-04-29T09:14:00Z","body":"<!-- stale-recovery-tick:escalated (threshold=2) -->"}]'
+	# PR with all quality checks SUCCESS, only maintainer gate FAILURE
+	local pr_data
+	pr_data=$(build_pr_json 21716 "APPROVED" "OWNER" "2026-04-29T09:19:00Z" "origin:worker" "SUCCESS" "FAILURE")
+	set_pr_list "[${pr_data}]"
+
+	_notify_stale_recovery_resolved_by_pr 21699 "marcusquinn/aidevops" "2026-04-29T09:14:00Z"
+
+	if was_comment_posted && posted_comment_contains "nmr-stale-recovery-resolution-notice"; then
+		print_result "Case E: maintainer-gate only failing check -> notification posted" 0
+	else
+		print_result "Case E: maintainer-gate only failing check -> notification posted" 1 \
+			"Expected notification when maintainer-gate is the only failing check"
+	fi
+	return 0
+}
+
+# Case F: stale-recovery NMR + PR with a failing security/quality check -> no notification
+test_f_failing_quality_check_no_notification() {
+	reset_posted_comment
+	set_comments '[{"created_at":"2026-04-29T09:14:00Z","body":"<!-- stale-recovery-tick:escalated (threshold=2) -->"}]'
+	# PR with shellcheck FAILURE
+	local pr_data
+	pr_data=$(build_pr_json 203 "APPROVED" "OWNER" "2026-04-29T09:19:00Z" "origin:worker" "FAILURE" "FAILURE")
+	set_pr_list "[${pr_data}]"
+
+	_notify_stale_recovery_resolved_by_pr 21699 "marcusquinn/aidevops" "2026-04-29T09:14:00Z"
+
+	if was_comment_posted; then
+		print_result "Case F: failing quality check -> no notification" 1 \
+			"Notification should NOT be posted when quality/security checks fail"
+	else
+		print_result "Case F: failing quality check -> no notification" 0
+	fi
+	return 0
+}
+
+# Case G: cost-circuit-breaker:fired NMR + green approved PR -> no notification
+test_g_cost_breaker_no_notification() {
+	reset_posted_comment
+	# Comments: cost-circuit-breaker:fired marker (no stale-recovery)
+	set_comments '[{"created_at":"2026-04-29T09:14:00Z","body":"<!-- cost-circuit-breaker:fired tier=standard spent=120000 budget=100000 -->"}]'
+	local pr_data
+	pr_data=$(build_pr_json 21716 "APPROVED" "OWNER" "2026-04-29T09:19:00Z" "origin:worker" "SUCCESS" "FAILURE")
+	set_pr_list "[${pr_data}]"
+
+	_notify_stale_recovery_resolved_by_pr 21699 "marcusquinn/aidevops" "2026-04-29T09:14:00Z"
+
+	if was_comment_posted; then
+		print_result "Case G: cost-circuit-breaker:fired NMR -> no notification" 1 \
+			"Notification should NOT be posted for cost-circuit-breaker trips"
+	else
+		print_result "Case G: cost-circuit-breaker:fired NMR -> no notification" 0
+	fi
+	return 0
+}
+
+# Case H: duplicate invocation with marker already present -> no second comment
+test_h_idempotency_no_duplicate() {
+	reset_posted_comment
+	# Comments: stale-recovery marker + EXISTING notification marker
+	set_comments '[{"created_at":"2026-04-29T09:14:00Z","body":"<!-- stale-recovery-tick:escalated (threshold=2) -->"},{"created_at":"2026-04-29T09:20:00Z","body":"<!-- nmr-stale-recovery-resolution-notice -->\nPR #21716 is APPROVED"}]'
+	local pr_data
+	pr_data=$(build_pr_json 21716 "APPROVED" "OWNER" "2026-04-29T09:19:00Z" "origin:worker" "SUCCESS" "FAILURE")
+	set_pr_list "[${pr_data}]"
+
+	_notify_stale_recovery_resolved_by_pr 21699 "marcusquinn/aidevops" "2026-04-29T09:14:00Z"
+
+	if was_comment_posted; then
+		print_result "Case H: idempotency -> no duplicate comment" 1 \
+			"Should NOT post a second notification when marker already exists"
+	else
+		print_result "Case H: idempotency -> no duplicate comment" 0
+	fi
+	return 0
+}
+
+# ============================================================
+# Main
+# ============================================================
+
+main() {
+	setup_test_env
+	trap teardown_test_env EXIT
+
+	define_helper_under_test || {
+		printf 'FATAL: could not define helper under test\n' >&2
+		exit 1
+	}
+
+	test_a_stale_recovery_with_approved_pr_posts_notification
+	test_b_non_collaborator_pr_no_notification
+	test_c_collaborator_pr_no_notification
+	test_d_worker_takeover_pr_no_notification
+	test_e_maintainer_gate_only_failure_posts_notification
+	test_f_failing_quality_check_no_notification
+	test_g_cost_breaker_no_notification
+	test_h_idempotency_no_duplicate
+
+	printf '\n%d tests run, %d failures\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		exit 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Add `_notify_stale_recovery_resolved_by_pr` and `_find_qualifying_pr_for_stale_recovery` to `pulse-nmr-approval.sh`. When stale-recovery applies NMR and a subsequent worker produces an APPROVED PR with all quality gates green (OWNER/MEMBER author, `origin:worker` or `origin:interactive` label), posts a one-shot notification prompting the maintainer to run `sudo aidevops approve issue N`.

**NMR is NOT auto-cleared** -- the notification is a UX improvement, not a privilege escalation. The cryptographic approval gate stays intact.

## Changes

- **NEW** `_find_qualifying_pr_for_stale_recovery` (63 lines) -- evaluates linked OPEN PRs against 5 trust-boundary gates (createdAt > NMR, APPROVED, OWNER/MEMBER, origin:worker|interactive, non-maintainer-gate CI green)
- **NEW** `_notify_stale_recovery_resolved_by_pr` (59 lines) -- checks for stale-recovery breaker signature, idempotency guard, then calls the finder and posts a one-shot `<!-- nmr-stale-recovery-resolution-notice -->` comment
- **EDIT** `_nmr_applied_by_maintainer` -- calls the notification helper as a side-effect in the breaker-trip path (line ~486). Does NOT change the PRESERVE NMR decision.
- **NEW** `test-pulse-nmr-approval.sh` -- 8 regression test cases covering all acceptance criteria

## Testing

```bash
shellcheck .agents/scripts/pulse-nmr-approval.sh   # clean
bash .agents/scripts/tests/test-pulse-nmr-approval.sh  # 8/8 PASS
```

## Security Notes

- NMR is NOT auto-cleared. The notification only prompts the maintainer to run the cryptographic approval command.
- PR author/origin/CI gates are belt-and-braces with the existing maintainer-gate.
- `<!-- aidevops:trust-boundary -->` comment blocks document the self-validation contract per t2933.

Resolves #21752

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-opus-4-6 spent 10m and 30,182 tokens on this as a headless worker.
