### PR TITLE
t3054: fix(pulse) remove redundant group timeout from preflight_early_dispatch

### DIFF
--- a/.agents/reference/worker-diagnostics.md
+++ b/.agents/reference/worker-diagnostics.md
@@ -610,3 +610,11 @@ log lines alongside classifications. Use `--json` for programmatic consumption.
   is a candidate follow-up (`pulse-diagnose-helper.sh issue <N>`).
 - Log lines without timestamps are sorted lexically (best effort).
 - Rotated `.gz` logs require `zcat` to be available.
+
+## Stage Timeout: rc=143 (SIGTERM) in Dispatch Stages (t3054)
+
+When a preflight stage wrapped in `run_stage_with_timeout` exceeds its budget, the watchdog sends SIGTERM to the process tree. In-progress child stages receive rc=143 (signal 15). Prior to t3054, `preflight_early_dispatch` used a 600s group timeout while internally dispatching N candidates (each with its own 600s per-candidate timeout). When cumulative candidate time exceeded the group budget, the group kill terminated in-progress candidates that were still within their individual budgets.
+
+**Fix (t3054):** `preflight_early_dispatch` no longer uses `run_stage_with_timeout`. Per-candidate timeouts (`fill_floor_candidate_*`) provide the safety net; the stage logs timing to `PULSE_STAGE_TIMINGS_LOG` for observability without imposing a hard kill.
+
+**Diagnosis:** If `fill_floor_candidate_*` stages show rc=143 without a corresponding per-candidate timeout log (`Stage timeout: fill_floor_candidate_*`), check whether a parent stage's group timeout fired instead — the parent kill propagates SIGTERM to children. Post-t3054, this should no longer occur for `preflight_early_dispatch`.

--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -1884,8 +1884,27 @@ _run_preflight_stages() {
 		_preflight_cleanup_and_ledger || true
 	run_stage_with_timeout "preflight_capacity_and_labels" "$_pflt_timeout" \
 		_preflight_capacity_and_labels || true
-	run_stage_with_timeout "preflight_early_dispatch" "$_pflt_timeout" \
-		_preflight_early_dispatch || true
+	# t3054: preflight_early_dispatch does NOT use run_stage_with_timeout.
+	# Unlike other preflight stages (single-step operations), this stage
+	# wraps apply_deterministic_fill_floor which iterates N candidates, each
+	# independently protected by run_stage_with_timeout "fill_floor_candidate_*"
+	# (600s per candidate). A 600s GROUP timeout killed in-progress candidates
+	# that were still within their individual budgets (92 timeouts in 1079 runs =
+	# 8.5% failure rate). The group timeout is redundant — per-candidate timeouts
+	# provide the safety net. Timing is still logged for observability.
+	local _pflt_ed_start=$SECONDS
+	local _pflt_ed_rc=0
+	_preflight_early_dispatch || _pflt_ed_rc=$?
+	local _pflt_ed_elapsed=$(( SECONDS - _pflt_ed_start ))
+	echo "[pulse-wrapper] Stage: preflight_early_dispatch (rc=${_pflt_ed_rc}, ${_pflt_ed_elapsed}s)" >>"$LOGFILE"
+	if [[ -n "${PULSE_STAGE_TIMINGS_LOG:-}" ]]; then
+		printf '%s\t%s\t%d\t%d\t%d\n' \
+			"$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+			"preflight_early_dispatch" \
+			"$_pflt_ed_elapsed" \
+			"$_pflt_ed_rc" \
+			"$$" >>"$PULSE_STAGE_TIMINGS_LOG" 2>/dev/null || true
+	fi
 	# t2443: Daily scans promoted to independent top-level stages so each
 	# scanner gets its own timeout budget. Previously wrapped in a single
 	# _preflight_daily_scans() group with a shared 600s budget — a slow


### PR DESCRIPTION
## Summary

Resolves #21763

`preflight_early_dispatch` was wrapped in `run_stage_with_timeout` with a 600s group budget, but internally dispatches N candidates each independently protected by `run_stage_with_timeout "fill_floor_candidate_*"` (also 600s). When cumulative candidate time exceeded the group budget, the group timeout fired SIGTERM (rc=143) and killed in-progress candidates that were still within their own individual timeouts.

**Evidence:** 92 timeouts out of 1079 runs (8.5% failure rate) in `pulse-stage-timings.log`, all at 602s.

## Changes

- **`.agents/scripts/pulse-dispatch-engine.sh`**: Replace `run_stage_with_timeout "preflight_early_dispatch"` with a direct call that logs timing to `PULSE_STAGE_TIMINGS_LOG` without imposing a hard kill. Per-candidate timeouts provide the safety net.
- **`.agents/reference/worker-diagnostics.md`**: Document the rc=143 (SIGTERM) stage timeout path for future diagnosis.

## Complexity Bump Justification

The `_run_preflight_stages` function at `pulse-dispatch-engine.sh:1870` was already at the gate threshold before this change. This PR replaces a 2-line `run_stage_with_timeout` call with 17 lines of inline timing code (direct invocation + structured TSV logging). Measurements: base=102, head=119, new=17. The function is a sequential list of stage invocations — each stage is an independent `run_stage_with_timeout` call or equivalent timing block. Extracting individual stage calls would not reduce nesting or complexity; the linear structure is inherently additive per stage.

## Testing

- `shellcheck` passes clean on modified file
- `test-pulse-diagnose-cycle-health.sh`: 19/30 pass (same as main — pre-existing failures unchanged)
- `test-pulse-dispatch-engine-timeout-floor.sh`: 6/6 pass (per-candidate timeout floor preserved)
- Frequency analysis of `pulse-stage-timings.log` confirmed systematic pattern (92 timeouts at 602s)

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-opus-4-6 spent 15m and 3,840 tokens on this as a headless worker. Overall, 3m since this issue was created.
