### PR TITLE
GH#21740: fix is_worktree_owned_by_others to use _resolve_worktree_owner_pid for self-check

### DIFF
--- a/.agents/scripts/shared-worktree-registry.sh
+++ b/.agents/scripts/shared-worktree-registry.sh
@@ -456,8 +456,14 @@ is_worktree_owned_by_others() {
 	# No owner registered
 	[[ -z "$owner_pid" ]] && return 1
 
-	# We own it
-	[[ "$owner_pid" == "$$" ]] && return 1
+	# We own it — use the same PID resolution as register_worktree so that
+	# transient bash subprocess PIDs ($$) match the stored stable AI runtime PID.
+	# GH#21740: previously compared against raw $$ which is always a transient
+	# bash subprocess PID in AI runtime sessions (OpenCode, Claude Code), and
+	# can never match the OPENCODE_PID/grandparent PID stored at registration.
+	local my_pid
+	my_pid=$(_resolve_worktree_owner_pid "")
+	[[ "$owner_pid" == "$my_pid" ]] && return 1
 
 	# Owner process is dead — stale entry, safe to remove
 	if ! kill -0 "$owner_pid" 2>/dev/null; then


### PR DESCRIPTION
## Summary

`is_worktree_owned_by_others()` compared the stored `owner_pid` against raw `$$` to determine self-ownership. In AI runtime sessions (OpenCode, Claude Code), `$$` is always a transient bash subprocess PID — never the stable runtime PID that `register_worktree` stores via `_resolve_worktree_owner_pid`. The check could never succeed, so `worktree-helper.sh remove` always falsely reported "owned by another active session" and required `--force`.

## Root Cause

Asymmetric PID resolution: the write path (`register_worktree`) calls `_resolve_worktree_owner_pid` (which honours `OPENCODE_PID`, `CLAUDE_SESSION_ID`, or grandparent comm detection per GH#18090). The read path (`is_worktree_owned_by_others`) used raw `$$`. They could never match in AI runtime sessions.

## Fix

Replace the `$$` comparison with a call to `_resolve_worktree_owner_pid ""` — the same resolution as the write path. `my_pid` now resolves to `OPENCODE_PID` (or the equivalent stable AI runtime PID), which matches the stored value and correctly identifies self-ownership.

**Changed file:** `EDIT: .agents/scripts/shared-worktree-registry.sh:460` — replace `[[ "$owner_pid" == "$$" ]]` with `_resolve_worktree_owner_pid ""` comparison.

## Verification

```bash
shellcheck .agents/scripts/shared-worktree-registry.sh  # zero violations
# Functional: worktree-helper.sh remove <branch> should succeed without --force
# in the same interactive session that created the worktree
```

Resolves #21740

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-sonnet-4-6 spent 3m and 3,651 tokens on this as a headless worker.
