### PR TITLE
GH#21734: skip sudo-requiring tool updates, print manual command

### DIFF
--- a/.agents/scripts/tool-version-check.sh
+++ b/.agents/scripts/tool-version-check.sh
@@ -160,6 +160,7 @@ INSTALLED_COUNT=0
 NOT_INSTALLED_COUNT=0
 TIMEOUT_COUNT=0
 UNKNOWN_COUNT=0
+SUDO_SKIP_COUNT=0
 declare -a OUTDATED_PACKAGES=()
 declare -a JSON_RESULTS=()
 
@@ -591,31 +592,61 @@ _output_summary_and_updates() {
 		if [[ "$AUTO_UPDATE" == "true" ]]; then
 			echo -e "${BLUE}Updating outdated tools...${NC}"
 			echo ""
-			for update_cmd in "${OUTDATED_PACKAGES[@]}"; do
-				echo "  Running: $update_cmd"
-				# Run update command directly (not via eval for security)
-				# Commands are hardcoded in tool definitions, not user input
-				# Timeout prevents hangs on slow registries/network issues
-				# Use timeout_sec for macOS compatibility (no native timeout)
-				# NOTE: Do NOT pipe timeout_sec output to tail/head — on macOS the
-				# perl alarm fallback doesn't close the pipe's write end on SIGALRM,
-				# causing tail to block forever. Use a temp file instead.
-				local _update_log
-				if ! _update_log=$(mktemp "${TMPDIR:-/tmp}/tool-update.XXXXXX"); then
-					echo -e "  ${RED}✗ Failed to create temp log${NC}"
+		for update_cmd in "${OUTDATED_PACKAGES[@]}"; do
+			echo "  Running: $update_cmd"
+			# Sudo safety gate (GH#21734): commands routed through apt-get/dnf/yum
+			# require sudo. Probe for passwordless sudo first; if not available,
+			# skip and print the manual command instead of hanging on an
+			# interactive password prompt during unattended `aidevops update`.
+			if [[ "$update_cmd" == *" sudo "* ]]; then
+				if ! sudo -n true 2>/dev/null; then
+					local _manual_cmd
+					_manual_cmd=""
+					if command -v apt-get >/dev/null 2>&1; then
+						_manual_cmd=$(grep -oE 'sudo apt-get[^;]+' <<<"$update_cmd" | head -1)
+					elif command -v dnf >/dev/null 2>&1; then
+						_manual_cmd=$(grep -oE 'sudo dnf[^;]+' <<<"$update_cmd" | head -1)
+					elif command -v yum >/dev/null 2>&1; then
+						_manual_cmd=$(grep -oE 'sudo yum[^;]+' <<<"$update_cmd" | head -1)
+					fi
+					echo -e "  ${YELLOW}⊘ Skipped: requires sudo. Run manually:${NC}"
+					if [[ -n "$_manual_cmd" ]]; then
+						echo "    ${_manual_cmd}"
+					else
+						echo "    $update_cmd"
+					fi
+					((++SUDO_SKIP_COUNT))
+					echo ""
 					continue
 				fi
-				if timeout_sec 120 bash -c "$update_cmd" >"$_update_log" 2>&1; then
-					tail -2 "$_update_log"
-					echo -e "  ${GREEN}✓ Updated${NC}"
-				else
-					tail -2 "$_update_log"
-					echo -e "  ${RED}✗ Failed${NC}"
-				fi
-				rm -f "$_update_log"
-				echo ""
-			done
+			fi
+			# Run update command directly (not via eval for security)
+			# Commands are hardcoded in tool definitions, not user input
+			# Timeout prevents hangs on slow registries/network issues
+			# Use timeout_sec for macOS compatibility (no native timeout)
+			# NOTE: Do NOT pipe timeout_sec output to tail/head — on macOS the
+			# perl alarm fallback doesn't close the pipe's write end on SIGALRM,
+			# causing tail to block forever. Use a temp file instead.
+			local _update_log
+			if ! _update_log=$(mktemp "${TMPDIR:-/tmp}/tool-update.XXXXXX"); then
+				echo -e "  ${RED}✗ Failed to create temp log${NC}"
+				continue
+			fi
+			if timeout_sec 120 bash -c "$update_cmd" >"$_update_log" 2>&1; then
+				tail -2 "$_update_log"
+				echo -e "  ${GREEN}✓ Updated${NC}"
+			else
+				tail -2 "$_update_log"
+				echo -e "  ${RED}✗ Failed${NC}"
+			fi
+			rm -f "$_update_log"
+			echo ""
+		done
+		if [[ $SUDO_SKIP_COUNT -gt 0 ]]; then
+			echo -e "${GREEN}Updates complete (${SUDO_SKIP_COUNT} skipped — manual sudo required).${NC}"
+		else
 			echo -e "${GREEN}Updates complete. Re-run to verify.${NC}"
+		fi
 		else
 			echo "To update all outdated tools, run:"
 			echo "  tool-version-check.sh --update"


### PR DESCRIPTION
## Summary

On Ubuntu 24.04 without NOPASSWD sudoers, `aidevops update → Run full tool update check? y` would hang on an interactive `sudo` password prompt (with visible echo due to the `timeout`/`use_pty` interaction) when updating `gh`, `glab`, `jq`, or any other brew-origin tool via apt-get/dnf/yum. This was unmasked by PR #21709 which removed the Linux brew-category gate.

## What Changed

`EDIT: .agents/scripts/tool-version-check.sh`

**Sudo safety gate in the update execution loop:**
- Before running any `update_cmd` that contains ` sudo `, probe with `sudo -n true 2>/dev/null`
- If passwordless sudo is **not** available: extract the specific package manager command from the multi-branch bash payload, print a `⊘ Skipped: requires sudo. Run manually:` message with the exact command, increment `SUDO_SKIP_COUNT`, and `continue` to the next tool
- If passwordless sudo **is** available (NOPASSWD or recently authenticated): run the command as before
- Closing summary reports skip count: `Updates complete (N skipped — manual sudo required).`

**Counter added:**
- `SUDO_SKIP_COUNT=0` global counter (mirrors existing `OUTDATED_COUNT`, `INSTALLED_COUNT`, etc.)

## Acceptance Criteria Met

- [x] No password prompt on Ubuntu 24.04 without NOPASSWD
- [x] Skip message clearly states the skipped tool and prints exact manual command
- [x] npm/pip/pipx/brew updates (no sudo) continue unaffected
- [x] NOPASSWD sudo systems run automatically (no skip)
- [x] macOS brew path: no behavior change
- [x] `shellcheck .agents/scripts/tool-version-check.sh` passes (zero violations, confirmed)

## Verification

```bash
shellcheck .agents/scripts/tool-version-check.sh
```

Resolves #21734

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-sonnet-4-6 spent 7m and 15,962 tokens on this as a headless worker.
