### PR TITLE
t3044: server-side issue dedup via fingerprint in issue-sync-reusable.yml

### DIFF
--- a/.agents/scripts/lib/issue-fingerprint.sh
+++ b/.agents/scripts/lib/issue-fingerprint.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# aidevops Issue Fingerprint Library
+# =============================================================================
+# Shared fingerprint algorithm for deduplication of near-identical issues.
+# Consumed by:
+#   - log-issue-helper.sh  (client-side dedup via local state file)
+#   - issue-sync-reusable.yml  (server-side dedup via GitHub Actions)
+#
+# Usage: source "$(dirname "${BASH_SOURCE[0]}")/lib/issue-fingerprint.sh"
+#        fingerprint=$(_compute_issue_fingerprint "$title" "$body")
+#
+# Env vars honoured (by callers, not this lib directly):
+#   LOG_ISSUE_DEDUP_WINDOW_SECONDS      — client-side window (default 120)
+#   ISSUE_SYNC_DEDUP_WINDOW_SECONDS     — server-side window (default 120)
+
+# _normalize_body_for_fingerprint <body>
+# Strips aidevops sig footer, source-context trailers, trailing blank lines,
+# and standalone "---" separator lines so that two issues differing only in
+# token-count or timing metadata in the footer are treated as identical.
+#
+# This is the canonical normalisation algorithm; any change here affects BOTH
+# the client-side (log-issue-helper.sh) and server-side (workflow) dedup.
+_normalize_body_for_fingerprint() {
+	local body="$1"
+	# Strip aidevops sig footer (everything from <!-- aidevops:sig --> to end)
+	body=$(printf '%s' "$body" | awk '/<!-- aidevops:sig -->/{exit} {print}')
+	# Strip "*Detected by ... in `...`.*" source-context trailer lines
+	# shellcheck disable=SC2016
+	body=$(printf '%s' "$body" | sed '/^\*Detected by .*\*[[:space:]]*$/d')
+	# Strip trailing blank lines and standalone "---" separator lines
+	body=$(printf '%s' "$body" | awk '
+		{lines[NR]=$0}
+		END {
+			n=NR
+			while (n>0 && (lines[n]=="" || lines[n]=="---")) n--
+			for (i=1; i<=n; i++) print lines[i]
+		}
+	')
+	printf '%s' "$body"
+	return 0
+}
+
+# _compute_issue_fingerprint <title> <body>
+# Prints the SHA-256 hex digest of "<title>|<normalized_body>".
+# Falls back to openssl dgst then cksum when sha256 is unavailable.
+# The pipe separator ensures a title change always produces a different hash.
+_compute_issue_fingerprint() {
+	local title="$1"
+	local body="$2"
+	local normalized_body
+	normalized_body=$(_normalize_body_for_fingerprint "$body")
+	local input="${title}|${normalized_body}"
+	local hash=""
+
+	if command -v shasum &>/dev/null; then
+		hash=$(printf '%s' "$input" | shasum -a 256 | awk '{print $1}')
+	elif command -v sha256sum &>/dev/null; then
+		hash=$(printf '%s' "$input" | sha256sum | awk '{print $1}')
+	elif command -v openssl &>/dev/null; then
+		hash=$(printf '%s' "$input" | openssl dgst -sha256 | awk '{print $NF}')
+	else
+		# Fallback: cksum — not cryptographic but sufficient for dedup within a session
+		hash=$(printf '%s' "$input" | cksum | awk '{print $1}')
+	fi
+
+	echo "$hash"
+	return 0
+}

--- a/.agents/scripts/log-issue-helper.sh
+++ b/.agents/scripts/log-issue-helper.sh
@@ -13,6 +13,10 @@ set -euo pipefail
 # shellcheck source=lib/version.sh
 source "$(dirname "${BASH_SOURCE[0]}")/lib/version.sh"
 
+# Shared fingerprint algorithm (also used by issue-sync-reusable.yml server-side dedup)
+# shellcheck source=lib/issue-fingerprint.sh
+source "$(dirname "${BASH_SOURCE[0]}")/lib/issue-fingerprint.sh"
+
 # -----------------------------------------------------------------------------
 # Diagnostic Information Gathering
 # -----------------------------------------------------------------------------
@@ -204,48 +208,9 @@ _log_issue_dedup_window() {
 	return 0
 }
 
-_normalize_body_for_fingerprint() {
-	local body="$1"
-	# Strip aidevops sig footer (everything from <!-- aidevops:sig --> to end)
-	body=$(printf '%s' "$body" | awk '/<!-- aidevops:sig -->/{exit} {print}')
-	# Strip "*Detected by ... in `...`.*" source-context trailer lines
-	# shellcheck disable=SC2016
-	body=$(printf '%s' "$body" | sed '/^\*Detected by .*\*[[:space:]]*$/d')
-	# Strip trailing blank lines and standalone "---" separator lines
-	body=$(printf '%s' "$body" | awk '
-		{lines[NR]=$0}
-		END {
-			n=NR
-			while (n>0 && (lines[n]=="" || lines[n]=="---")) n--
-			for (i=1; i<=n; i++) print lines[i]
-		}
-	')
-	printf '%s' "$body"
-	return 0
-}
-
-_compute_issue_fingerprint() {
-	local title="$1"
-	local body="$2"
-	local normalized_body
-	normalized_body=$(_normalize_body_for_fingerprint "$body")
-	local input="${title}|${normalized_body}"
-	local hash=""
-
-	if command -v shasum &>/dev/null; then
-		hash=$(printf '%s' "$input" | shasum -a 256 | awk '{print $1}')
-	elif command -v sha256sum &>/dev/null; then
-		hash=$(printf '%s' "$input" | sha256sum | awk '{print $1}')
-	elif command -v openssl &>/dev/null; then
-		hash=$(printf '%s' "$input" | openssl dgst -sha256 | awk '{print $NF}')
-	else
-		# Fallback: cksum — not cryptographic but sufficient for dedup within a session
-		hash=$(printf '%s' "$input" | cksum | awk '{print $1}')
-	fi
-
-	echo "$hash"
-	return 0
-}
+# _normalize_body_for_fingerprint and _compute_issue_fingerprint are now provided
+# by lib/issue-fingerprint.sh (sourced above). This single source of truth is
+# shared with the issue-sync-reusable.yml server-side dedup workflow (GH#21744).
 
 # check_recent_filing <title> <body>
 # Exits 0 and prints "OK" if no duplicate is found within the dedup window.

--- a/.agents/scripts/tests/test-issue-fingerprint.sh
+++ b/.agents/scripts/tests/test-issue-fingerprint.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Unit tests for .agents/scripts/lib/issue-fingerprint.sh
+#
+# Pins the dedup contract (GH#21744 / t3044):
+#   1. Byte-identical bodies → same fingerprint
+#   2. Bodies differing only in aidevops sig footer → same fingerprint
+#   3. Bodies with different actual content → different fingerprints
+#   4. Bodies differing only in trailing whitespace / "---" separators → same fingerprint
+#   5. "*Detected by ...*" trailer stripped → same fingerprint as body without it
+#   6. Different titles with identical bodies → different fingerprints
+#   7. Same title + same body → deterministic (stable across calls)
+#
+# Run: bash .agents/scripts/tests/test-issue-fingerprint.sh
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+LIB_FILE="${SCRIPT_DIR}/../lib/issue-fingerprint.sh"
+
+if [[ ! -f "$LIB_FILE" ]]; then
+	echo "FATAL: lib not found at ${LIB_FILE}" >&2
+	exit 1
+fi
+
+# shellcheck source=../lib/issue-fingerprint.sh
+source "$LIB_FILE"
+
+PASS=0
+FAIL=0
+
+check() {
+	local ok="$1" tc="$2" detail="$3"
+	if [[ "$ok" == "1" ]]; then
+		PASS=$((PASS + 1))
+		echo "PASS: $tc"
+	else
+		FAIL=$((FAIL + 1))
+		echo "FAIL: $tc — $detail"
+	fi
+	return 0
+}
+
+# ============================================================
+# Shared fixtures
+# ============================================================
+
+SIG_FOOTER='<!-- aidevops:sig -->
+---
+[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-opus-4-7 spent 9m and 9,371 tokens on this as a headless worker.'
+
+BODY_CORE='## Description
+
+Some bug in the framework.
+
+## Reproducer
+
+Steps to reproduce.'
+
+BODY_WITH_FOOTER="${BODY_CORE}
+
+${SIG_FOOTER}"
+
+BODY_WITH_DIFFERENT_FOOTER="${BODY_CORE}
+
+<!-- aidevops:sig -->
+---
+[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-opus-4-7 spent 12m and 15,043 tokens on this as a headless worker."
+
+BODY_WITH_TRAILING_BLANKS="${BODY_CORE}
+
+
+"
+
+BODY_WITH_TRAILING_SEPARATOR="${BODY_CORE}
+
+---
+"
+
+BODY_DIFFERENT_CONTENT='## Description
+
+A completely different bug.
+
+## Reproducer
+
+Different steps.'
+
+BODY_WITH_DETECTED_BY="${BODY_CORE}
+*Detected by quality-scanner in \`pulse-wrapper.sh\`.*"
+
+TITLE="bug(pulse): example title"
+TITLE_DIFFERENT="feat(pulse): completely different title"
+
+# ============================================================
+# Test 1: Byte-identical bodies → same fingerprint
+# ============================================================
+fp1a=$(_compute_issue_fingerprint "$TITLE" "$BODY_CORE")
+fp1b=$(_compute_issue_fingerprint "$TITLE" "$BODY_CORE")
+[[ "$fp1a" == "$fp1b" ]] && ok=1 || ok=0
+check "$ok" "Test 1: byte-identical bodies → same fingerprint" "got $fp1a vs $fp1b"
+
+# ============================================================
+# Test 2: Bodies differing only in sig footer → same fingerprint
+# ============================================================
+fp2a=$(_compute_issue_fingerprint "$TITLE" "$BODY_WITH_FOOTER")
+fp2b=$(_compute_issue_fingerprint "$TITLE" "$BODY_WITH_DIFFERENT_FOOTER")
+[[ "$fp2a" == "$fp2b" ]] && ok=1 || ok=0
+check "$ok" "Test 2a: different sig footer token counts → same fingerprint" "got $fp2a vs $fp2b"
+
+# Body with footer should also match bare core body
+fp2c=$(_compute_issue_fingerprint "$TITLE" "$BODY_CORE")
+[[ "$fp2a" == "$fp2c" ]] && ok=1 || ok=0
+check "$ok" "Test 2b: footer-stripped body matches bare core body" "got $fp2a vs $fp2c"
+
+# ============================================================
+# Test 3: Different actual content → different fingerprints
+# ============================================================
+fp3a=$(_compute_issue_fingerprint "$TITLE" "$BODY_CORE")
+fp3b=$(_compute_issue_fingerprint "$TITLE" "$BODY_DIFFERENT_CONTENT")
+[[ "$fp3a" != "$fp3b" ]] && ok=1 || ok=0
+check "$ok" "Test 3: different body content → different fingerprints" "got same fingerprint: $fp3a"
+
+# ============================================================
+# Test 4: Trailing whitespace and "---" separator stripped
+# ============================================================
+fp4a=$(_compute_issue_fingerprint "$TITLE" "$BODY_CORE")
+fp4b=$(_compute_issue_fingerprint "$TITLE" "$BODY_WITH_TRAILING_BLANKS")
+[[ "$fp4a" == "$fp4b" ]] && ok=1 || ok=0
+check "$ok" "Test 4a: trailing blank lines stripped → same fingerprint" "got $fp4a vs $fp4b"
+
+fp4c=$(_compute_issue_fingerprint "$TITLE" "$BODY_WITH_TRAILING_SEPARATOR")
+[[ "$fp4a" == "$fp4c" ]] && ok=1 || ok=0
+check "$ok" "Test 4b: trailing '---' separator stripped → same fingerprint" "got $fp4a vs $fp4c"
+
+# ============================================================
+# Test 5: "*Detected by ...*" trailer stripped
+# ============================================================
+fp5a=$(_compute_issue_fingerprint "$TITLE" "$BODY_CORE")
+fp5b=$(_compute_issue_fingerprint "$TITLE" "$BODY_WITH_DETECTED_BY")
+[[ "$fp5a" == "$fp5b" ]] && ok=1 || ok=0
+check "$ok" "Test 5: '*Detected by ...*' trailer stripped → same fingerprint" "got $fp5a vs $fp5b"
+
+# ============================================================
+# Test 6: Different titles with identical bodies → different fingerprints
+# ============================================================
+fp6a=$(_compute_issue_fingerprint "$TITLE" "$BODY_CORE")
+fp6b=$(_compute_issue_fingerprint "$TITLE_DIFFERENT" "$BODY_CORE")
+[[ "$fp6a" != "$fp6b" ]] && ok=1 || ok=0
+check "$ok" "Test 6: different titles → different fingerprints" "got same fingerprint: $fp6a"
+
+# ============================================================
+# Test 7: Fingerprint is non-empty
+# ============================================================
+fp7=$(_compute_issue_fingerprint "$TITLE" "$BODY_CORE")
+[[ -n "$fp7" ]] && ok=1 || ok=0
+check "$ok" "Test 7: fingerprint is non-empty" "got empty string"
+
+# ============================================================
+# Test 8: Empty body produces a fingerprint (no crash)
+# ============================================================
+fp8=$(_compute_issue_fingerprint "$TITLE" "")
+[[ -n "$fp8" ]] && ok=1 || ok=0
+check "$ok" "Test 8: empty body produces a fingerprint (no crash)" "got empty string"
+
+# ============================================================
+# Test 9: Empty body + different titles → different fingerprints
+# ============================================================
+fp9a=$(_compute_issue_fingerprint "$TITLE" "")
+fp9b=$(_compute_issue_fingerprint "$TITLE_DIFFERENT" "")
+[[ "$fp9a" != "$fp9b" ]] && ok=1 || ok=0
+check "$ok" "Test 9: empty body + different titles → different fingerprints" "got same fingerprint: $fp9a"
+
+# ============================================================
+# Test 10: Canonical reproducer — issues 21729 and 21730 scenario
+#           Two identical bodies from the same session double-fire
+# ============================================================
+CANONICAL_TITLE='bug(pulse): _dff_dispatch_loop_parallel wait -n tight loop grows pulse-wrapper.log to 679GB'
+# shellcheck disable=SC2016 # backticks are markdown code ticks, not command substitution
+CANONICAL_BODY='## Description
+
+The `_dff_dispatch_loop_parallel` function uses `wait -n` in a tight polling loop.
+
+## Evidence
+
+Log grew to 679GB overnight.
+
+## Acceptance
+
+Fix the tight loop.'
+
+# Simulate two issues with the same content but different sig footers
+ISSUE_A_BODY="${CANONICAL_BODY}
+
+<!-- aidevops:sig -->
+---
+[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-opus-4-7 spent 9m and 9,371 tokens."
+
+ISSUE_B_BODY="${CANONICAL_BODY}
+
+<!-- aidevops:sig -->
+---
+[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-opus-4-7 spent 9m and 9,371 tokens."
+
+fp10a=$(_compute_issue_fingerprint "$CANONICAL_TITLE" "$ISSUE_A_BODY")
+fp10b=$(_compute_issue_fingerprint "$CANONICAL_TITLE" "$ISSUE_B_BODY")
+[[ "$fp10a" == "$fp10b" ]] && ok=1 || ok=0
+check "$ok" "Test 10: canonical GH#21729/21730 scenario → same fingerprint" "got $fp10a vs $fp10b"
+
+# ============================================================
+# Summary
+# ============================================================
+echo ""
+echo "Results: ${PASS} passed, ${FAIL} failed"
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/.github/workflows/issue-sync-reusable.yml
+++ b/.github/workflows/issue-sync-reusable.yml
@@ -286,6 +286,146 @@ jobs:
             exit 1
           fi
 
+  # =========================================================================
+  # GH#21744: Server-side issue dedup (t3044)
+  # =========================================================================
+  # When a new issue is opened, compute its fingerprint and compare with
+  # other open issues by the same author filed within the dedup window.
+  # If a match is found, close the new issue as a duplicate.
+  #
+  # This catches the two failure modes that bypass the client-side dedup in
+  # log-issue-helper.sh: workflow-bypass (direct gh issue create calls) and
+  # same-session double-fire (transient retries inside an AI session).
+  #
+  # Algorithm: _compute_issue_fingerprint from lib/issue-fingerprint.sh
+  # (SHA-256 of "<title>|<normalised_body>" with sig footer stripped).
+  # State lives in GitHub itself — no per-runner state file needed.
+  #
+  # Env: ISSUE_SYNC_DEDUP_WINDOW_SECONDS (default 120)
+  dedup-on-issue-open:
+    name: Server-Side Issue Dedup
+    if: github.event_name == 'issues' && github.event.action == 'opened'
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    concurrency:
+      group: issue-dedup-${{ github.event.issue.number }}
+      cancel-in-progress: false
+    permissions:
+      issues: write
+
+    steps:
+      - name: Checkout aidevops framework scripts
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: marcusquinn/aidevops
+          path: __aidevops
+          ref: ${{ inputs.aidevops_ref || 'main' }}
+          fetch-depth: 1
+
+      - name: Check for duplicate issue and close if found
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+          ISSUE_CREATED_AT: ${{ github.event.issue.created_at }}
+          REPO: ${{ github.repository }}
+          ISSUE_SYNC_DEDUP_WINDOW_SECONDS: '120'
+        run: |
+          set -euo pipefail
+
+          # Source the shared fingerprint algorithm (extracted from log-issue-helper.sh)
+          # shellcheck source=__aidevops/.agents/scripts/lib/issue-fingerprint.sh
+          source __aidevops/.agents/scripts/lib/issue-fingerprint.sh
+
+          WINDOW="${ISSUE_SYNC_DEDUP_WINDOW_SECONDS:-120}"
+          echo "[dedup] Checking issue #${ISSUE_NUMBER} by @${ISSUE_AUTHOR} (window: ${WINDOW}s)"
+
+          # Fetch the full issue title and body via API (avoids env-var size limits
+          # and injection risks from untrusted content in the event payload).
+          issue_json=$(gh api "repos/${REPO}/issues/${ISSUE_NUMBER}" --jq '{title:.title,body:(.body//""),createdAt:.created_at}' 2>/dev/null || echo '{}')
+          ISSUE_TITLE=$(printf '%s' "$issue_json" | jq -r '.title // ""')
+          ISSUE_BODY=$(printf '%s' "$issue_json" | jq -r '.body // ""')
+          ISSUE_CREATED_AT_RESOLVED=$(printf '%s' "$issue_json" | jq -r '.createdAt // ""')
+
+          if [[ -z "$ISSUE_TITLE" ]]; then
+            echo "[dedup] Could not fetch issue #${ISSUE_NUMBER} — skipping dedup check"
+            exit 0
+          fi
+
+          # Compute fingerprint of the newly opened issue
+          new_fingerprint=$(_compute_issue_fingerprint "$ISSUE_TITLE" "$ISSUE_BODY")
+          echo "[dedup] Fingerprint: ${new_fingerprint}"
+
+          # Parse creation epoch for window comparison (GNU date on ubuntu-latest)
+          new_epoch=$(date -d "${ISSUE_CREATED_AT_RESOLVED:-$ISSUE_CREATED_AT}" +%s 2>/dev/null || echo "0")
+          if [[ "$new_epoch" -eq 0 ]]; then
+            echo "[dedup] Cannot parse creation time — skipping dedup check"
+            exit 0
+          fi
+
+          echo "[dedup] Fetching recent open issues by @${ISSUE_AUTHOR}..."
+          issues_json=$(gh issue list --repo "$REPO" \
+            --author "$ISSUE_AUTHOR" --state open \
+            --limit 20 --json number,title,body,createdAt 2>/dev/null || echo "[]")
+
+          cand_count=$(printf '%s' "$issues_json" | jq 'length')
+          echo "[dedup] Found ${cand_count} open issue(s) by @${ISSUE_AUTHOR}"
+
+          canonical_num=""
+          for i in $(seq 0 $((cand_count - 1))); do
+            cand_num=$(printf '%s' "$issues_json" | jq -r ".[$i].number")
+
+            # Skip self
+            if [[ "$cand_num" == "$ISSUE_NUMBER" ]]; then continue; fi
+
+            cand_created=$(printf '%s' "$issues_json" | jq -r ".[$i].createdAt // empty")
+            [[ -z "$cand_created" ]] && continue
+
+            cand_epoch=$(date -d "$cand_created" +%s 2>/dev/null || echo "0")
+            [[ "$cand_epoch" -eq 0 ]] && continue
+
+            # Only close the new issue when the candidate is strictly older and
+            # within the dedup window. Positive time_diff = candidate is older.
+            time_diff=$((new_epoch - cand_epoch))
+            if [[ "$time_diff" -le 0 ]] || [[ "$time_diff" -gt "$WINDOW" ]]; then
+              echo "[dedup] Issue #${cand_num} not a prior duplicate (gap: ${time_diff}s) — skipping"
+              continue
+            fi
+
+            cand_title=$(printf '%s' "$issues_json" | jq -r ".[$i].title")
+            cand_body=$(printf '%s' "$issues_json" | jq -r ".[$i].body // \"\"")
+
+            cand_fingerprint=$(_compute_issue_fingerprint "$cand_title" "$cand_body")
+
+            if [[ "$cand_fingerprint" == "$new_fingerprint" ]]; then
+              canonical_num="$cand_num"
+              echo "[dedup] Match: #${ISSUE_NUMBER} fingerprint matches #${canonical_num} (${time_diff}s apart)"
+              break
+            fi
+          done
+
+          if [[ -z "$canonical_num" ]]; then
+            echo "[dedup] No duplicate found — issue is unique"
+            exit 0
+          fi
+
+          echo "[dedup] Closing #${ISSUE_NUMBER} as duplicate of #${canonical_num}"
+
+          # Ensure duplicate label exists before applying it
+          gh label create "duplicate" --color "cfd3d7" \
+            --description "This issue or pull request already exists" \
+            --repo "$REPO" --force 2>/dev/null || true
+
+          gh issue comment "$ISSUE_NUMBER" --repo "$REPO" \
+            --body "This issue appears to be a duplicate of #${canonical_num}, filed within ${WINDOW}s with identical content. Closing automatically — please continue the discussion in #${canonical_num}.
+
+          <!-- issue-dedup:auto-closed -->"
+
+          gh issue edit "$ISSUE_NUMBER" --repo "$REPO" --add-label "duplicate" 2>/dev/null || true
+          gh issue close "$ISSUE_NUMBER" --repo "$REPO" --reason "not planned" 2>/dev/null || true
+
+          echo "[dedup] Done — issue #${ISSUE_NUMBER} closed as duplicate of #${canonical_num}"
+
   manual-sync:
     name: Manual Sync
     if: github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
## Summary

Adds a server-side fingerprint dedup guard to `issue-sync-reusable.yml` that automatically closes duplicate issues filed within a configurable window (default 120s).

## Problem

Two failure modes bypassed the existing client-side dedup in `log-issue-helper.sh`:

1. **Workflow-bypass**: `gh issue create` calls outside `/log-issue-aidevops` never consult `log-issue-helper.sh check-fingerprint`, so they can't detect or be detected by siblings.
2. **Same-session double-fire**: An AI session that retries on a perceived transient error fires `gh issue create` twice. Both calls succeed because GitHub's 2-10s search-index lag means the first issue isn't visible yet.

Canonical evidence: GH#21729 + GH#21730 (byte-identical, filed 7 seconds apart).

## Changes

### `NEW: .agents/scripts/lib/issue-fingerprint.sh`
Extracts `_normalize_body_for_fingerprint` and `_compute_issue_fingerprint` from `log-issue-helper.sh` into a sourceable lib. Single source of truth — both the client-side and server-side dedup share the same algorithm.

### `EDIT: .agents/scripts/log-issue-helper.sh`
Sources the new lib instead of defining the functions inline. No behaviour change.

### `EDIT: .github/workflows/issue-sync-reusable.yml`
New `dedup-on-issue-open` job (triggers on `issues.opened`):
- Fetches the new issue title + body via API (avoids env-var injection risk)
- Computes SHA-256 fingerprint using the shared lib
- Queries GitHub for other open issues by the same author (`gh issue list --author --state open --limit 20`)
- For each candidate older than the new issue and within the 120s window, computes its fingerprint
- If a match is found: labels the new issue `duplicate`, posts a comment linking to the canonical issue, closes with `state_reason: not_planned`

### `NEW: .agents/scripts/tests/test-issue-fingerprint.sh`
12 unit tests covering the full contract: identical bodies, sig-footer-only differences, real content differences, trailing whitespace, `*Detected by ...*` trailers, title changes, empty bodies, and the canonical GH#21729/21730 reproducer.

## Verification

```bash
# Unit tests
bash .agents/scripts/tests/test-issue-fingerprint.sh  # 12 passed, 0 failed

# ShellCheck
shellcheck .agents/scripts/lib/issue-fingerprint.sh  # 0 violations
shellcheck .agents/scripts/log-issue-helper.sh  # 0 violations
shellcheck .agents/scripts/tests/test-issue-fingerprint.sh  # 0 violations
```

## Acceptance Criteria

- [x] 1. Two byte-identical issues filed by the same author within 120s → second auto-closed
- [x] 2. Bodies differing only in sig footer → treated as identical (sig footer normalised)
- [x] 3. Issues differing in actual content → NOT deduped
- [x] 4. Fingerprint algorithm shared with `log-issue-helper.sh` (single source of truth in `lib/issue-fingerprint.sh`)
- [x] 5. Window configurable via `ISSUE_SYNC_DEDUP_WINDOW_SECONDS` (default 120)
- [x] 6. No false positives: uses `--state open` and per-author filtering with strict window check

Resolves #21744

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-sonnet-4-6 spent 11m and 29,528 tokens on this as a headless worker.
