### PR TITLE
GH#21774: fix jq ARG_MAX overflow in pulse-prefetch-fetch.sh

### DIFF
--- a/.agents/scripts/pulse-prefetch-fetch.sh
+++ b/.agents/scripts/pulse-prefetch-fetch.sh
@@ -150,9 +150,11 @@ _prefetch_prs_format_output() {
 
 	echo "### Open PRs ($pr_count)"
 	if [[ -n "$checks_json" && "$checks_json" != "[]" ]]; then
-		echo "$pr_json" | jq -r --argjson checks "${checks_json:-[]}" '
-			($checks | map({(.number | tostring): .statusCheckRollup}) | add // {}) as $check_map |
-			.[] |
+		# GH#21774: checks_json (~245KB+) overflows jq ARG_MAX via --argjson.
+		# Pass checks through stdin (unlimited), pr_json (~14KB) via --argjson.
+		echo "$checks_json" | jq -r --argjson prs "$pr_json" '
+			(. | map({(.number | tostring): .statusCheckRollup}) | add // {}) as $check_map |
+			$prs[] |
 			(.number | tostring) as $num |
 			($check_map[$num] // null) as $rolls |
 			"- PR #\(.number): \(.title) [checks: \(


### PR DESCRIPTION
## Summary

- Fix `jq: Argument list too long` in `pulse-prefetch-fetch.sh:153` — `statusCheckRollup` JSON (~285KB for 12+ PRs) overflowed jq argv limit via `--argjson`
- Pass `checks_json` through stdin (unlimited), keep `pr_json` (~9KB) via `--argjson prs`
- Other `--argjson` calls in the file audited — all pass small data (<15KB), no fix needed

Resolves #21774

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-opus-4-6 spent 2d 19h and 108,522 tokens on this with the user in an interactive session.