### PR TITLE
t3056: add kill_reason instrumentation + CPU semantic check to reduce headless worker kill rate

### DIFF
--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -569,6 +569,11 @@ _dff_dispatch_with_timeout() {
 		outcome="timeout"
 		# t2989 + t3003: per-candidate timeout — log distinctly, bump counter,
 		# record outcome so the next recommendation enters probe mode.
+		# t3056 / GH#21781: Structured lifecycle line for kill-reason telemetry
+		printf '[lifecycle] worker_killed pid=dispatch reason=wait_loop_timeout_%ss trigger_age=%sms session=issue-%s ts=%s\n' \
+			"$timeout_seconds" "$elapsed_ms" "$issue_number" \
+			"$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+			>>"${LOGFILE:-/dev/null}" 2>/dev/null || true
 		echo "[pulse-wrapper] Deterministic fill floor: per-candidate timeout (${timeout_seconds}s) on #${issue_number} (${repo_slug}) — killing candidate, continuing loop" >>"$LOGFILE"
 		if declare -F pulse_stats_increment >/dev/null 2>&1; then
 			pulse_stats_increment "fill_floor_per_candidate_timeout" 2>/dev/null || true

--- a/.agents/scripts/pulse-watchdog.sh
+++ b/.agents/scripts/pulse-watchdog.sh
@@ -108,6 +108,11 @@ guard_child_processes() {
 			# crafted process names containing control characters. (GH#2892)
 			local safe_cmd_base
 			safe_cmd_base=$(_sanitize_log_field "$cmd_base")
+			# t3056 / GH#21781: Structured lifecycle line for kill-reason telemetry
+			printf '[lifecycle] worker_killed pid=%s reason=process_guard_%s trigger_age=%ss session=pulse ts=%s\n' \
+				"$pid" "$safe_cmd_base" "$age_seconds" \
+				"$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+				>>"${LOGFILE:-/dev/null}" 2>/dev/null || true
 			echo "[pulse-wrapper] Process guard: killing PID $pid ($safe_cmd_base) — $violation" >>"$LOGFILE"
 			_kill_tree "$pid" || true
 			sleep 1
@@ -207,6 +212,11 @@ run_stage_with_timeout() {
 		now=$(date +%s)
 		local elapsed=$((now - stage_start))
 		if [[ "$elapsed" -gt "$timeout_seconds" ]]; then
+			# t3056 / GH#21781: Structured lifecycle line for kill-reason telemetry
+			printf '[lifecycle] worker_killed pid=%s reason=stage_timeout_%ss trigger_age=%ss session=%s ts=%s\n' \
+				"$stage_pid" "$timeout_seconds" "$elapsed" "$stage_name" \
+				"$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+				>>"${LOGFILE:-/dev/null}" 2>/dev/null || true
 			echo "[pulse-wrapper] Stage timeout: ${stage_name} exceeded ${timeout_seconds}s (pid ${stage_pid})" >>"$LOGFILE"
 			_kill_tree "$stage_pid" || true
 			sleep 2
@@ -514,6 +524,20 @@ _run_pulse_watchdog() {
 
 		# Single kill block — avoids duplicating the kill+force-kill sequence.
 		if [[ -n "$kill_reason" ]]; then
+			# t3056 / GH#21781: Classify kill reason for structured telemetry.
+			local _pw_reason_class="pulse_unknown"
+			case "$kill_reason" in
+			*"stale threshold"*) _pw_reason_class="wall_clock_stale" ;;
+			*"cold-start stalled"*) _pw_reason_class="cold_start_timeout" ;;
+			*"stalled for"*) _pw_reason_class="progress_timeout" ;;
+			*"idle for"*) _pw_reason_class="idle_timeout" ;;
+			*"Stop flag"*) _pw_reason_class="stop_flag" ;;
+			esac
+			local _pw_elapsed=$(( $(date +%s) - start_epoch ))
+			printf '[lifecycle] worker_killed pid=%s reason=%s trigger_age=%ss session=pulse ts=%s\n' \
+				"$opencode_pid" "$_pw_reason_class" "$_pw_elapsed" \
+				"$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+				>>"${LOGFILE:-/dev/null}" 2>/dev/null || true
 			echo "[pulse-wrapper] ${kill_reason} — killing" >>"$LOGFILE"
 			_kill_tree "$opencode_pid" || true
 			sleep 2

--- a/.agents/scripts/tests/test-watchdog-no-false-kill.sh
+++ b/.agents/scripts/tests/test-watchdog-no-false-kill.sh
@@ -1,0 +1,282 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-watchdog-no-false-kill.sh — Regression tests for t3056 / GH#21781
+# (94% headless worker kill rate investigation).
+#
+# Verifies:
+#   1. _watchdog_tree_cpu function exists in worker-activity-watchdog.sh
+#   2. STALL_TIMEOUT default is 600s (raised from 300s)
+#   3. Structured [lifecycle] worker_killed lines are emitted by _kill_worker
+#   4. CPU semantic check defers kill when tree_cpu >= STALL_CPU_THRESHOLD
+#   5. Hard-kill fires regardless of CPU (safety net)
+#   6. pulse-watchdog.sh kill sites emit [lifecycle] lines
+#   7. pulse-dispatch-engine.sh timeout handler emits [lifecycle] line
+#   8. All modified scripts pass ShellCheck
+#
+# Tests are structural — no live worker processes required.
+
+set -u
+
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_BLUE=$'\033[0;34m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_BLUE="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+assert_contains() {
+	local label="$1" needle="$2" haystack="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if printf '%s' "$haystack" | grep -qF -- "$needle" 2>/dev/null; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  expected to find: $(printf '%q' "$needle")"
+		echo "  in output starting with: $(printf '%.200s' "$haystack")"
+	fi
+	return 0
+}
+
+assert_not_contains() {
+	local label="$1" needle="$2" haystack="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if ! printf '%s' "$haystack" | grep -qF -- "$needle" 2>/dev/null; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  expected NOT to find: $(printf '%q' "$needle")"
+	fi
+	return 0
+}
+
+assert_equals() {
+	local label="$1" expected="$2" actual="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$expected" == "$actual" ]]; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  expected: $(printf '%q' "$expected")"
+		echo "  actual:   $(printf '%q' "$actual")"
+	fi
+	return 0
+}
+
+assert_match() {
+	local label="$1" pattern="$2" haystack="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if printf '%s' "$haystack" | grep -qE -- "$pattern" 2>/dev/null; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  expected pattern: $pattern"
+		echo "  in output starting with: $(printf '%.200s' "$haystack")"
+	fi
+	return 0
+}
+
+# Resolve script directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+echo "${TEST_BLUE}=== t3056: Watchdog No-False-Kill Regression Tests ===${TEST_NC}"
+echo ""
+
+#######################################
+# Test 1: _watchdog_tree_cpu function exists
+#######################################
+watchdog_source=$(< "${SCRIPT_DIR}/worker-activity-watchdog.sh")
+assert_contains \
+	"1. _watchdog_tree_cpu function exists in worker-activity-watchdog.sh" \
+	"_watchdog_tree_cpu()" \
+	"$watchdog_source"
+
+#######################################
+# Test 2: STALL_TIMEOUT default raised from 300 to 600
+#######################################
+# shellcheck disable=SC2016  # Literal string for grep match — not variable expansion
+assert_contains \
+	"2. STALL_TIMEOUT default is 600s (raised from 300)" \
+	'STALL_TIMEOUT="${WORKER_STALL_TIMEOUT:-600}"' \
+	"$watchdog_source"
+
+#######################################
+# Test 3: [lifecycle] worker_killed line in _kill_worker
+#######################################
+assert_contains \
+	"3. _kill_worker emits [lifecycle] worker_killed structured line" \
+	"[lifecycle] worker_killed pid=" \
+	"$watchdog_source"
+
+#######################################
+# Test 4: CPU semantic check exists (STALL_CPU_THRESHOLD)
+#######################################
+# shellcheck disable=SC2016  # Literal string for grep match
+assert_contains \
+	"4a. STALL_CPU_THRESHOLD config variable exists" \
+	'STALL_CPU_THRESHOLD="${WORKER_STALL_CPU_THRESHOLD:-2}"' \
+	"$watchdog_source"
+assert_contains \
+	"4b. CPU check defers kill (WATCHDOG_STALL_DEFERRED marker)" \
+	"WATCHDOG_STALL_DEFERRED" \
+	"$watchdog_source"
+
+#######################################
+# Test 5: Hard-kill fires regardless of CPU
+# (The hard-kill block must come BEFORE the CPU check in the code)
+#######################################
+# Verify hard-kill check comes before CPU check by checking line order
+hard_kill_line=$(grep -n "HARD_KILL_SECONDS.*elapsed_total.*HARD_KILL_SECONDS" "${SCRIPT_DIR}/worker-activity-watchdog.sh" | head -1 | cut -d: -f1)
+cpu_check_line=$(grep -n "_watchdog_tree_cpu.*WORKER_PID" "${SCRIPT_DIR}/worker-activity-watchdog.sh" | head -1 | cut -d: -f1)
+if [[ -n "$hard_kill_line" && -n "$cpu_check_line" && "$hard_kill_line" -lt "$cpu_check_line" ]]; then
+	TESTS_RUN=$((TESTS_RUN + 1))
+	echo "${TEST_GREEN}PASS${TEST_NC}: 5. Hard-kill check precedes CPU check (line $hard_kill_line < $cpu_check_line)"
+else
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	echo "${TEST_RED}FAIL${TEST_NC}: 5. Hard-kill check must precede CPU check (hard_kill=$hard_kill_line, cpu=$cpu_check_line)"
+fi
+
+#######################################
+# Test 6: pulse-watchdog.sh kill sites emit [lifecycle] lines
+#######################################
+pulse_wd_source=$(< "${SCRIPT_DIR}/pulse-watchdog.sh")
+assert_contains \
+	"6a. pulse-watchdog.sh guard_child_processes emits [lifecycle] line" \
+	"reason=process_guard_" \
+	"$pulse_wd_source"
+assert_contains \
+	"6b. pulse-watchdog.sh run_stage_with_timeout emits [lifecycle] line" \
+	"reason=stage_timeout_" \
+	"$pulse_wd_source"
+assert_contains \
+	"6c. pulse-watchdog.sh _run_pulse_watchdog emits [lifecycle] line" \
+	"_pw_reason_class" \
+	"$pulse_wd_source"
+
+#######################################
+# Test 7: pulse-dispatch-engine.sh timeout handler emits [lifecycle] line
+#######################################
+dispatch_source=$(< "${SCRIPT_DIR}/pulse-dispatch-engine.sh")
+assert_contains \
+	"7. pulse-dispatch-engine.sh per-candidate timeout emits [lifecycle] line" \
+	"reason=wait_loop_timeout_" \
+	"$dispatch_source"
+
+#######################################
+# Test 8: All modified scripts pass ShellCheck
+#######################################
+echo ""
+echo "${TEST_BLUE}--- ShellCheck validation ---${TEST_NC}"
+
+shellcheck_pass=true
+for script in \
+	"${SCRIPT_DIR}/worker-activity-watchdog.sh" \
+	"${SCRIPT_DIR}/pulse-watchdog.sh" \
+	"${SCRIPT_DIR}/pulse-dispatch-engine.sh"; do
+
+	local_name="$(basename "$script")"
+	if command -v shellcheck >/dev/null 2>&1; then
+		sc_out=$(shellcheck -S error "$script" 2>&1) || true
+		if [[ -n "$sc_out" ]]; then
+			TESTS_RUN=$((TESTS_RUN + 1))
+			TESTS_FAILED=$((TESTS_FAILED + 1))
+			echo "${TEST_RED}FAIL${TEST_NC}: 8. ShellCheck ${local_name}"
+			echo "  $sc_out"
+			shellcheck_pass=false
+		else
+			TESTS_RUN=$((TESTS_RUN + 1))
+			echo "${TEST_GREEN}PASS${TEST_NC}: 8. ShellCheck ${local_name}"
+		fi
+	else
+		TESTS_RUN=$((TESTS_RUN + 1))
+		echo "${TEST_GREEN}PASS${TEST_NC}: 8. ShellCheck ${local_name} (skipped — shellcheck not installed)"
+	fi
+done
+
+#######################################
+# Test 9: kill_reason classification covers all call sites
+#######################################
+# Verify that each kill reason class is mapped in _kill_worker
+assert_contains \
+	"9a. kill_reason class: phase1_zero_output mapped" \
+	"phase1_zero_output" \
+	"$watchdog_source"
+assert_contains \
+	"9b. kill_reason class: hard_kill_stall mapped" \
+	"hard_kill_stall" \
+	"$watchdog_source"
+assert_contains \
+	"9c. kill_reason class: no_output_stall mapped" \
+	"no_output_stall" \
+	"$watchdog_source"
+
+#######################################
+# Test 10: Lifecycle log path is configurable via env
+#######################################
+# shellcheck disable=SC2016  # Literal string for grep match
+assert_contains \
+	"10. LIFECYCLE_LOG configurable via WORKER_LIFECYCLE_LOG env" \
+	'LIFECYCLE_LOG="${WORKER_LIFECYCLE_LOG:-' \
+	"$watchdog_source"
+
+#######################################
+# Test 11: _watchdog_tree_cpu validates PID input
+#######################################
+# shellcheck disable=SC2016  # Literal string for grep match
+assert_contains \
+	"11. _watchdog_tree_cpu validates PID is numeric" \
+	'[[ "$pid" =~ ^[0-9]+$ ]]' \
+	"$watchdog_source"
+
+#######################################
+# Test 12: Deferred stall seconds tracked cumulatively
+#######################################
+assert_contains \
+	"12. Deferred stall seconds tracked cumulatively" \
+	"deferred_stall_seconds=\$((deferred_stall_seconds + stall_seconds))" \
+	"$watchdog_source"
+
+#######################################
+# Test 13: pulse-watchdog reason class mapping is complete
+#######################################
+assert_contains \
+	"13a. pulse-watchdog maps wall_clock_stale" \
+	"wall_clock_stale" \
+	"$pulse_wd_source"
+assert_contains \
+	"13b. pulse-watchdog maps cold_start_timeout" \
+	"cold_start_timeout" \
+	"$pulse_wd_source"
+assert_contains \
+	"13c. pulse-watchdog maps progress_timeout" \
+	"progress_timeout" \
+	"$pulse_wd_source"
+assert_contains \
+	"13d. pulse-watchdog maps idle_timeout" \
+	"idle_timeout" \
+	"$pulse_wd_source"
+assert_contains \
+	"13e. pulse-watchdog maps stop_flag" \
+	"stop_flag" \
+	"$pulse_wd_source"
+
+#######################################
+# Summary
+#######################################
+echo ""
+echo "${TEST_BLUE}=== Results: ${TESTS_RUN} tests, ${TESTS_FAILED} failures ===${TEST_NC}"
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/.agents/scripts/worker-activity-watchdog.sh
+++ b/.agents/scripts/worker-activity-watchdog.sh
@@ -67,7 +67,7 @@ EXIT_CODE_FILE=""
 SESSION_KEY=""
 REPO_SLUG=""
 WORKTREE_PATH=""
-STALL_TIMEOUT=300
+STALL_TIMEOUT="${WORKER_STALL_TIMEOUT:-600}"
 PHASE1_TIMEOUT=30
 POLL_INTERVAL=10
 # t2956 / Issue #21231: Hard-kill threshold (default 1500s = 25 min).
@@ -75,6 +75,14 @@ POLL_INTERVAL=10
 # flag overrides the env var. Set to 0 to disable hard-kill (stall continues
 # indefinitely up to the runtime's wall-clock cap — legacy behaviour).
 HARD_KILL_SECONDS="${WORKER_STALL_HARD_KILL_SECONDS:-1500}"
+# t3056 / GH#21781: CPU threshold below which a stalled worker is considered
+# truly stuck (vs just not writing output). Process tree CPU >= this value
+# defers the stall kill — the worker is alive but doing non-output work
+# (API roundtrip, shellcheck, file read). Default 2% matches PULSE_IDLE_CPU_THRESHOLD.
+STALL_CPU_THRESHOLD="${WORKER_STALL_CPU_THRESHOLD:-2}"
+# t3056: Lifecycle log for structured kill-reason telemetry. Aggregatable
+# across all workers. Default: pulse-dispatch.log (same file the pulse reads).
+LIFECYCLE_LOG="${WORKER_LIFECYCLE_LOG:-${HOME}/.aidevops/logs/pulse-dispatch.log}"
 
 #######################################
 # Parse arguments
@@ -171,6 +179,36 @@ _worker_alive() {
 }
 
 #######################################
+# Get CPU usage of the worker's process tree (t3056 / GH#21781)
+#
+# Checks the worker PID and its direct children for CPU activity.
+# Used to distinguish "worker stuck" (0% CPU) from "worker alive but
+# not writing output" (>0% CPU) — e.g., API roundtrip, shellcheck run,
+# large file read.
+#
+# Arguments:
+#   $1 - root PID to check
+# Output: integer CPU percentage (summed across tree) via stdout
+#######################################
+_watchdog_tree_cpu() {
+	local root_pid="$1"
+	local total=0
+	local pid
+	# Check root pid and all direct children. One level deep covers the
+	# typical opencode worker chain (bash → node → opencode binary).
+	for pid in $(pgrep -P "$root_pid" 2>/dev/null) "$root_pid"; do
+		[[ "$pid" =~ ^[0-9]+$ ]] || continue
+		local cpu_str
+		cpu_str=$(ps -p "$pid" -o %cpu= 2>/dev/null | tr -d ' ') || continue
+		local cpu_int="${cpu_str%%.*}"
+		[[ "$cpu_int" =~ ^[0-9]+$ ]] || cpu_int=0
+		total=$((total + cpu_int))
+	done
+	echo "$total"
+	return 0
+}
+
+#######################################
 # Get current size of the output file in bytes
 # Output: size in bytes (0 if file doesn't exist)
 #######################################
@@ -252,6 +290,25 @@ _push_wip_before_kill() {
 _kill_worker() {
 	local reason="$1"
 	local kill_kind="${2:-}"
+
+	# t3056 / GH#21781: Classify the kill reason for structured telemetry.
+	# Maps the human-readable reason string to a machine-readable class.
+	local reason_class="unknown"
+	case "$reason" in
+	phase1:*) reason_class="phase1_zero_output" ;;
+	hard_kill:*) reason_class="hard_kill_stall" ;;
+	stall:*) reason_class="no_output_stall" ;;
+	*) reason_class="other" ;;
+	esac
+
+	# t3056: Emit structured lifecycle line for kill-reason telemetry.
+	# Format matches the t3056 spec so aggregation scripts can classify kills.
+	local _trigger_age=0
+	_trigger_age=$(( $(date +%s) - _WATCHDOG_START_EPOCH ))
+	printf '[lifecycle] worker_killed pid=%s reason=%s trigger_age=%ss session=%s ts=%s\n' \
+		"$WORKER_PID" "$reason_class" "$_trigger_age" "${SESSION_KEY:-none}" \
+		"$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+		>>"$LIFECYCLE_LOG" 2>/dev/null || true
 
 	# t2923: Push WIP commits before killing so the work is reachable on origin.
 	# Must happen before SIGTERM so git operations complete cleanly.
@@ -359,6 +416,10 @@ _monitor() {
 	local phase1_elapsed=0
 	local last_size=0
 	local stall_seconds=0
+	# t3056: Track cumulative deferred stall seconds — how long the watchdog
+	# has deferred kills due to CPU activity. Logged on eventual kill for
+	# Phase 2 analysis.
+	local deferred_stall_seconds=0
 	# t2956: Wall-clock start so HARD_KILL_SECONDS is measured against the
 	# total time the watchdog has been monitoring this worker — not just the
 	# duration of the current stall window. A worker that's been alternately
@@ -366,6 +427,8 @@ _monitor() {
 	# that's been silent the whole time.
 	local start_epoch
 	start_epoch=$(date +%s)
+	# t3056: Export start epoch for _kill_worker's trigger_age calculation
+	_WATCHDOG_START_EPOCH="$start_epoch"
 
 	while true; do
 		# Worker exited on its own — watchdog not needed
@@ -412,13 +475,36 @@ _monitor() {
 			local now_epoch elapsed_total
 			now_epoch=$(date +%s)
 			elapsed_total=$((now_epoch - start_epoch))
+
+			# t3056 / GH#21781: Hard-kill always fires at the cumulative
+			# threshold — safety net regardless of CPU activity.
 			if [[ "$HARD_KILL_SECONDS" -gt 0 && "$elapsed_total" -ge "$HARD_KILL_SECONDS" ]]; then
 				_kill_worker \
-					"hard_kill: stall confirmed and total elapsed ${elapsed_total}s ≥ hard-kill threshold ${HARD_KILL_SECONDS}s (stuck at ${current_size}b) — slot freed for re-dispatch" \
+					"hard_kill: stall confirmed and total elapsed ${elapsed_total}s ≥ hard-kill threshold ${HARD_KILL_SECONDS}s (stuck at ${current_size}b, deferred=${deferred_stall_seconds}s) — slot freed for re-dispatch" \
 					"stall_killed"
 				return 0
 			fi
-			_kill_worker "stall: no output growth for ${STALL_TIMEOUT}s (stuck at ${current_size}b, total elapsed ${elapsed_total}s)"
+
+			# t3056 / GH#21781: Semantic stall check — before killing,
+			# check if the worker's process tree has CPU activity. Workers
+			# doing API roundtrips, shellcheck runs, or large file reads
+			# consume CPU but produce no log output. Killing them is a
+			# false positive. Defer the kill and reset the stall counter.
+			# The hard-kill threshold above is the absolute safety net.
+			local tree_cpu
+			tree_cpu=$(_watchdog_tree_cpu "$WORKER_PID")
+			if [[ "$tree_cpu" -ge "$STALL_CPU_THRESHOLD" ]]; then
+				deferred_stall_seconds=$((deferred_stall_seconds + stall_seconds))
+				printf '[WATCHDOG_STALL_DEFERRED] timestamp=%s cpu=%s%% stall=%ss deferred_total=%ss elapsed=%ss\n' \
+					"$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$tree_cpu" "$stall_seconds" \
+					"$deferred_stall_seconds" "$elapsed_total" \
+					>>"$OUTPUT_FILE" 2>/dev/null || true
+				stall_seconds=0
+				sleep "$POLL_INTERVAL"
+				continue
+			fi
+
+			_kill_worker "stall: no output growth for ${STALL_TIMEOUT}s (stuck at ${current_size}b, total elapsed ${elapsed_total}s, cpu=${tree_cpu}%, deferred=${deferred_stall_seconds}s)"
 			return 0
 		fi
 
@@ -436,6 +522,11 @@ main() {
 	if ! _worker_alive; then
 		return 0
 	fi
+
+	# t3056: Initialize start epoch for lifecycle line trigger_age.
+	# Set here (not in _monitor) so _kill_worker can reference it
+	# from any context.
+	_WATCHDOG_START_EPOCH=$(date +%s)
 
 	_monitor
 	return 0


### PR DESCRIPTION
## Summary

Resolves #21781

Phase 1 + Phase 3 + Phase 4 of the t3056 investigation into the 94% headless worker kill rate.

### Phase 1: Kill-reason instrumentation

Added structured `[lifecycle] worker_killed` lines to all 5 SIGTERM call sites:

| # | File | Reason class(es) |
|---|---|---|
| 1 | `worker-activity-watchdog.sh:_kill_worker` | `phase1_zero_output`, `hard_kill_stall`, `no_output_stall` |
| 2 | `pulse-watchdog.sh:_run_pulse_watchdog` | `wall_clock_stale`, `cold_start_timeout`, `progress_timeout`, `idle_timeout`, `stop_flag` |
| 3 | `pulse-watchdog.sh:run_stage_with_timeout` | `stage_timeout_<N>s` |
| 4 | `pulse-watchdog.sh:guard_child_processes` | `process_guard_<cmd>` |
| 5 | `pulse-dispatch-engine.sh` (per-candidate timeout) | `wait_loop_timeout_<N>s` |

Format: `[lifecycle] worker_killed pid=<N> reason=<class> trigger_age=<N>s session=<key> ts=<ISO>`

Aggregation query for Phase 2 measurement:
```bash
grep "worker_killed" ~/.aidevops/logs/pulse-dispatch.log \
  | sed -E 's/.*reason=([a-z_0-9]+).*/\1/' | sort | uniq -c | sort -rn
```

### Phase 3: Targeted fix for `no_output_stall` (predicted dominant class)

Two complementary fixes to reduce false-positive kills:

1. **Raised STALL_TIMEOUT from 300s to 600s** (`WORKER_STALL_TIMEOUT` env override). Workers doing API roundtrips, shellcheck runs, or large file reads that take 300-600s were being killed unnecessarily.

2. **Added CPU-aware semantic stall check** in `worker-activity-watchdog.sh`. Before killing for stall, the watchdog now checks the worker's process tree CPU usage via `_watchdog_tree_cpu()`. If CPU >= `STALL_CPU_THRESHOLD` (default 2%, env `WORKER_STALL_CPU_THRESHOLD`), the kill is deferred and the stall counter resets. This catches workers that are alive and doing useful work (API calls, tool execution) but not writing to the output file. The hard-kill safety net at `HARD_KILL_SECONDS` (25 min) always fires regardless of CPU.

Deferred kills are logged with `[WATCHDOG_STALL_DEFERRED]` markers for observability.

### Phase 4: Regression test

`tests/test-watchdog-no-false-kill.sh` — 24 structural assertions covering:
- Function existence and config defaults
- Lifecycle line emission at all kill sites
- CPU check ordering (hard-kill before CPU check)
- Reason class coverage
- ShellCheck validation of all modified scripts

### Verification

```bash
# Regression test
bash .agents/scripts/tests/test-watchdog-no-false-kill.sh
# → 24 tests, 0 failures

# ShellCheck
shellcheck .agents/scripts/worker-activity-watchdog.sh .agents/scripts/pulse-watchdog.sh .agents/scripts/pulse-dispatch-engine.sh
# → clean (0 errors, 0 warnings)
```

### Files changed

- `EDIT: .agents/scripts/worker-activity-watchdog.sh` — instrumentation, CPU check, timeout raise
- `EDIT: .agents/scripts/pulse-watchdog.sh` — instrumentation (3 kill sites)
- `EDIT: .agents/scripts/pulse-dispatch-engine.sh` — instrumentation (1 kill site)
- `NEW: .agents/scripts/tests/test-watchdog-no-false-kill.sh` — 24-assertion regression test

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-opus-4-6 spent 12m and 29,255 tokens on this as a headless worker.
