### PR TITLE
GH#21787: walk full descendant tree in _watchdog_tree_cpu (BFS, not one-level)

### DIFF
--- a/.agents/scripts/tests/test-watchdog-no-false-kill.sh
+++ b/.agents/scripts/tests/test-watchdog-no-false-kill.sh
@@ -381,6 +381,67 @@ assert_contains \
 	"$pulse_wd_source"
 
 #######################################
+# Tests 19-22: t3059 / GH#21787 — _watchdog_tree_cpu walks full descendant tree (BFS)
+#
+# Earlier implementation used `pgrep -P "$root_pid"` (one level only),
+# undercounting CPU on deeper trees like `bash → opencode → node → LSP`.
+# These assertions pin the BFS contract: a shared _get_descendant_pids
+# helper lives in worker-lifecycle-common.sh, the watchdog sources it,
+# and a runtime spawn proves grandchildren are visited. The interval-CPU
+# sampling (t3057) is preserved — t3059 only changes which PIDs are sampled.
+#######################################
+lifecycle_source=$(< "${SCRIPT_DIR}/worker-lifecycle-common.sh")
+assert_contains \
+	"19. _get_descendant_pids defined in worker-lifecycle-common.sh (t3059)" \
+	"_get_descendant_pids()" \
+	"$lifecycle_source"
+
+assert_contains \
+	"20. _watchdog_tree_cpu calls _get_descendant_pids (BFS, not pgrep -P) (t3059)" \
+	"_get_descendant_pids" \
+	"$watchdog_source"
+
+assert_contains \
+	"21. worker-activity-watchdog.sh sources worker-lifecycle-common.sh (t3059)" \
+	"worker-lifecycle-common.sh" \
+	"$watchdog_source"
+
+#######################################
+# Test 22: Runtime — _get_descendant_pids returns >=2 PIDs for a 3-level tree
+#######################################
+# Source the lifecycle helpers in this test shell.
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/worker-lifecycle-common.sh"
+
+# Spawn parent_bash → middle_bash → sleep (grandchild). The trailing
+# `; :` in the inner command prevents bash's tail-call exec optimization
+# (otherwise middle_bash would execve into sleep and the tree would
+# collapse to two levels). 30s sleep gives a stable tree; cleanup
+# below kills it deterministically.
+bash -c 'bash -c "sleep 30; :" & wait' >/dev/null 2>&1 &
+test_root_pid=$!
+sleep 1 # let fork+exec settle so pgrep sees the children
+
+descendants=$(_get_descendant_pids "$test_root_pid" 2>/dev/null || true)
+descendant_count=$(echo "$descendants" | grep -c '^[0-9]\+$' 2>/dev/null || true)
+[[ "$descendant_count" =~ ^[0-9]+$ ]] || descendant_count=0
+
+if [[ "$descendant_count" -ge 2 ]]; then
+	TESTS_RUN=$((TESTS_RUN + 1))
+	echo "${TEST_GREEN}PASS${TEST_NC}: 22. _get_descendant_pids walks BFS (descendants=$descendant_count, expected >=2 for parent->child->grandchild) (t3059)"
+else
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	echo "${TEST_RED}FAIL${TEST_NC}: 22. _get_descendant_pids returned $descendant_count descendants, expected >=2 for 3-level tree (t3059)"
+fi
+
+# Cleanup the spawned tree
+for cleanup_pid in $descendants "$test_root_pid"; do
+	kill "$cleanup_pid" 2>/dev/null || true
+done
+wait 2>/dev/null || true
+
+#######################################
 # Summary
 #######################################
 echo ""

--- a/.agents/scripts/worker-activity-watchdog.sh
+++ b/.agents/scripts/worker-activity-watchdog.sh
@@ -58,6 +58,14 @@
 
 set -euo pipefail
 
+# t3059 / GH#21787: Source shared lifecycle helpers for _get_descendant_pids.
+# Avoids inline one-level `pgrep -P` BFS that previously lived in
+# _watchdog_tree_cpu and undercounted CPU when the worker process tree
+# was deeper than one level (e.g., bash → opencode → node → LSP).
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/worker-lifecycle-common.sh"
+
 #######################################
 # Configuration (from args, with defaults)
 #######################################
@@ -234,17 +242,22 @@ _parse_ps_cpu_time() {
 #######################################
 _watchdog_tree_cpu() {
 	local root_pid="$1"
+	[[ "$root_pid" =~ ^[0-9]+$ ]] || {
+		echo "0"
+		return 0
+	}
 	local sample_interval=5
 
-	# Collect PID list: root + direct children.
-	# One level deep covers the typical opencode worker chain
-	# (bash → node → opencode binary).
-	local pid_list=()
+	# t3059: Collect root + ALL descendants via BFS (not just direct children).
+	# The previous one-level `pgrep -P` undercounted recent CPU on deeper
+	# chains (bash → opencode → node → LSP). _get_descendant_pids walks the
+	# full tree using the same primitive _get_process_tree_cpu uses.
+	local pid_list=("$root_pid")
 	local pid
-	for pid in "$root_pid" $(pgrep -P "$root_pid" 2>/dev/null); do
+	while IFS= read -r pid; do
 		[[ "$pid" =~ ^[0-9]+$ ]] || continue
 		pid_list+=("$pid")
-	done
+	done < <(_get_descendant_pids "$root_pid")
 
 	# Sample 1: record cumulative CPU seconds per PID into parallel arrays
 	local t0_pids=() t0_secs_arr=()

--- a/.agents/scripts/worker-lifecycle-common.sh
+++ b/.agents/scripts/worker-lifecycle-common.sh
@@ -289,13 +289,59 @@ _get_pid_cpu() {
 }
 
 #######################################
-# Get CPU usage percentage for a process tree (t1398.3)
+# Walk a process tree breadth-first and emit all descendant PIDs (t3059)
 #
-# Iteratively walks the full descendant tree (BFS) using pgrep -P at
-# each level. Previous implementation only checked direct children,
-# missing grandchildren and deeper descendants — this caused incorrect
-# CPU calculations when active processes were nested deeper than one
-# level (e.g., node -> shell -> language-server).
+# Iteratively walks the full descendant tree using pgrep -P at each
+# level. The root PID itself is NOT emitted — only its descendants
+# (children, grandchildren, …). Output is one PID per line, deduped
+# via sort -u. Returns nothing (zero lines) for a leaf process.
+#
+# pgrep -P only returns DIRECT children. A naive one-level pgrep
+# undercounts when active processes are nested deeper than one level
+# (e.g., parent shell → opencode wrapper → node runtime → language
+# server). Walking BFS preserves the full tree.
+#
+# Used by:
+#   _get_process_tree_cpu (t1398.3) — sum CPU% across whole tree
+#   _watchdog_tree_cpu    (t3059)   — same primitive in worker-activity-watchdog.sh
+#
+# Arguments:
+#   arg1 - root PID
+# Returns: descendant PIDs, one per line, sorted+deduped, via stdout
+#######################################
+_get_descendant_pids() {
+	local root_pid="$1"
+	[[ "$root_pid" =~ ^[0-9]+$ ]] || return 0
+
+	local pids_to_scan=("$root_pid")
+	local descendants=()
+	local i=0
+	while [[ $i -lt ${#pids_to_scan[@]} ]]; do
+		local current_pid="${pids_to_scan[$i]}"
+		local child
+		while IFS= read -r child; do
+			if [[ -n "$child" ]]; then
+				pids_to_scan+=("$child")
+				descendants+=("$child")
+			fi
+		done < <(pgrep -P "$current_pid" 2>/dev/null || true)
+		i=$((i + 1))
+	done
+
+	# Bash 3.2: guard against expanding an empty array under set -u.
+	if [[ ${#descendants[@]} -gt 0 ]]; then
+		printf "%s\n" "${descendants[@]}" | sort -u
+	fi
+	return 0
+}
+
+#######################################
+# Get CPU usage percentage for a process tree (t1398.3, refactored t3059)
+#
+# Walks the full descendant tree (BFS) via _get_descendant_pids, then
+# sums per-PID CPU% (root + descendants) via _get_pid_cpu. Previous
+# inline-BFS implementation was duplicated in worker-activity-watchdog.sh's
+# _watchdog_tree_cpu (one-level pgrep -P only); both now share the helper.
 #
 # Arguments:
 #   arg1 - PID
@@ -303,30 +349,16 @@ _get_pid_cpu() {
 #######################################
 _get_process_tree_cpu() {
 	local pid="$1"
-	local total_cpu=0
+	local total_cpu
+	total_cpu=$(_get_pid_cpu "$pid")
 
-	# Iteratively find the initial PID and all its descendants (BFS).
-	# pgrep -P only returns direct children, so we expand level by level.
-	local pids_to_scan=("$pid")
-	local all_pids=()
-	local i=0
-	while [[ $i -lt ${#pids_to_scan[@]} ]]; do
-		local current_pid="${pids_to_scan[$i]}"
-		all_pids+=("$current_pid")
-		local child
-		while IFS= read -r child; do
-			[[ -n "$child" ]] && pids_to_scan+=("$child")
-		done < <(pgrep -P "$current_pid" 2>/dev/null || true)
-		i=$((i + 1))
-	done
-
-	# Sum CPU for all unique PIDs in the process tree.
-	local p
-	for p in $(printf "%s\n" "${all_pids[@]}" | sort -u); do
+	local descendant
+	while IFS= read -r descendant; do
+		[[ -n "$descendant" ]] || continue
 		local cpu
-		cpu=$(_get_pid_cpu "$p")
+		cpu=$(_get_pid_cpu "$descendant")
 		total_cpu=$((total_cpu + cpu))
-	done
+	done < <(_get_descendant_pids "$pid")
 
 	echo "$total_cpu"
 	return 0


### PR DESCRIPTION
## What

Refactor `_watchdog_tree_cpu` (in `worker-activity-watchdog.sh`) to walk the full descendant tree via BFS, fixing CPU undercount when worker process trees are deeper than one level (typical chain: `bash -> opencode -> node -> LSP`).

Resolves #21787

## Why

`_watchdog_tree_cpu` collected `root_pid` + DIRECT children only via `pgrep -P "$root_pid"`. When the worker chain went 3+ levels deep, CPU activity from grandchildren was invisible. The CPU-deferred-stall logic relies on accurate process-tree CPU readings to distinguish "stuck" from "active but quiet" — undercount caused false-positive stall kills on long node/LSP work.

`_get_process_tree_cpu` in `worker-lifecycle-common.sh` (t1398.3, in production for >1 year) already walks BFS correctly — the watchdog just needed to use the same primitive.

## How

- **Extracted** the BFS expansion that already lived inline inside `_get_process_tree_cpu` into a new helper `_get_descendant_pids` in `worker-lifecycle-common.sh`. Returns descendants (children, grandchildren, ...) of a root PID, deduped, one per line.
- **Refactored** `_get_process_tree_cpu` to consume `_get_descendant_pids` — same behaviour, no duplicated traversal.
- **Refactored** `_watchdog_tree_cpu` `pid_list` collection to consume the same helper. The watchdog now sources `worker-lifecycle-common.sh`.
- **Preserved** the t3057 interval-CPU sampling architecture (two-sample `ps -o time=` delta with `_parse_ps_cpu_time`). t3059 only changes WHICH PIDs are sampled (root + all descendants vs. root + direct children), not HOW (still recent-window CPU%, not lifetime average).
- Bash 3.2 `set -u` empty-array safety preserved via `[[ ${#descendants[@]} -gt 0 ]]` guard before `printf`.

### Files Scope

- .agents/scripts/worker-lifecycle-common.sh
- .agents/scripts/worker-activity-watchdog.sh
- .agents/scripts/tests/test-watchdog-no-false-kill.sh

## Testing

- `shellcheck` clean across all three modified files.
- `bash .agents/scripts/tests/test-watchdog-no-false-kill.sh` — **43/43 pass** (39 prior including t3057 tests 14-17 and t3060 tests 18a-18j; 4 new t3059 tests):
  - **19.** `_get_descendant_pids` defined in `worker-lifecycle-common.sh`
  - **20.** `_watchdog_tree_cpu` calls `_get_descendant_pids` (BFS contract)
  - **21.** `worker-activity-watchdog.sh` sources `worker-lifecycle-common.sh`
  - **22. (runtime)** spawns a 3-level process tree (`parent_bash -> middle_bash -> sleep`) and asserts `_get_descendant_pids` returns ≥2 PIDs. Pinned via the `bash -c "sleep 30; :"` compound-command pattern that defeats bash's tail-call exec optimization (otherwise the middle bash would `execve` into sleep and collapse the tree to two levels — the exact failure mode the BFS fix protects against).
- Pre-existing tests 1-17 and t3060 tests 18a-18j continue to pass — both the t3057 interval-CPU sampling tests and the t3060 enum-prefix kill_reason tests verify those architectures are preserved.

<!-- aidevops:sig -->

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-opus-4-7 spent 52m and 45,849 tokens on this with the user in an interactive session. Overall, 44m since this issue was created.
