### PR TITLE
t3058: route worker stall defer marker to LIFECYCLE_LOG (not OUTPUT_FILE)

### DIFF
--- a/.agents/scripts/tests/test-watchdog-no-false-kill.sh
+++ b/.agents/scripts/tests/test-watchdog-no-false-kill.sh
@@ -127,8 +127,8 @@ assert_contains \
 	'STALL_CPU_THRESHOLD="${WORKER_STALL_CPU_THRESHOLD:-2}"' \
 	"$watchdog_source"
 assert_contains \
-	"4b. CPU check defers kill (WATCHDOG_STALL_DEFERRED marker)" \
-	"WATCHDOG_STALL_DEFERRED" \
+	"4b. CPU check defers kill (worker_stall_deferred lifecycle marker)" \
+	"worker_stall_deferred" \
 	"$watchdog_source"
 
 #######################################

--- a/.agents/scripts/worker-activity-watchdog.sh
+++ b/.agents/scripts/worker-activity-watchdog.sh
@@ -567,10 +567,17 @@ _monitor() {
 			tree_cpu=$(_watchdog_tree_cpu "$WORKER_PID")
 			if [[ "$tree_cpu" -ge "$STALL_CPU_THRESHOLD" ]]; then
 				deferred_stall_seconds=$((deferred_stall_seconds + stall_seconds))
-				printf '[WATCHDOG_STALL_DEFERRED] timestamp=%s cpu=%s%% stall=%ss deferred_total=%ss elapsed=%ss\n' \
-					"$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$tree_cpu" "$stall_seconds" \
-					"$deferred_stall_seconds" "$elapsed_total" \
-					>>"$OUTPUT_FILE" 2>/dev/null || true
+				# t3058 / GH#21786: write defer marker to LIFECYCLE_LOG, NOT
+				# OUTPUT_FILE. Writing to OUTPUT_FILE grew the monitored file
+				# and falsely advanced last_size, defeating the stall counter
+				# and silently neutering STALL_TIMEOUT (only HARD_KILL_SECONDS
+				# at 1500s remained as a real cap). Format aligned with the
+				# `[lifecycle] worker_killed` line emitted by _kill_worker so
+				# Phase 2 aggregation can join defer events alongside kills.
+				printf '[lifecycle] worker_stall_deferred pid=%s cpu=%s%% stall_seconds=%ss deferred_total=%ss ts=%s\n' \
+					"$WORKER_PID" "$tree_cpu" "$stall_seconds" \
+					"$deferred_stall_seconds" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+					>>"$LIFECYCLE_LOG" 2>/dev/null || true
 				stall_seconds=0
 				sleep "$POLL_INTERVAL"
 				continue


### PR DESCRIPTION
## Summary

When the watchdog detects a stall (no output for STALL_TIMEOUT seconds) but the worker tree CPU is still above STALL_CPU_THRESHOLD, it defers the kill and emits a marker. Previously the marker was written via '>>"$OUTPUT_FILE"', which grew the file the watchdog itself was monitoring for stalls. This advanced last_size on the next loop, the byte-delta check evaluated as 'progress', stall_seconds reset to zero, and the deferred-kill code path that the marker was meant to instrument was therefore never reached for stuck-but-busy workers — STALL_TIMEOUT was silently neutered, leaving only HARD_KILL_SECONDS=1500 as a real cap. The marker is now written to LIFECYCLE_LOG ($WORKER_LIFECYCLE_LOG, defaults to ~/.aidevops/logs/pulse-dispatch.log) which the watchdog never monitors, and reformatted to the same '[lifecycle] worker_<event>' shape used by _kill_worker so Phase 2 aggregation can join defer events with kill events on the same key. Two-line diff in worker-activity-watchdog.sh:570-583 plus a one-line update to test 4b in tests/test-watchdog-no-false-kill.sh:130-132.

## Files Changed

.agents/scripts/tests/test-watchdog-no-false-kill.sh,.agents/scripts/worker-activity-watchdog.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/worker-activity-watchdog.sh: clean (0 violations). bash .agents/scripts/tests/test-watchdog-no-false-kill.sh: 29/29 pass — including test 4b ('CPU check defers kill (worker_stall_deferred lifecycle marker)') which now asserts the new marker name. No new tests added: the existing assertion was tight enough to be re-pointed at the new convention, and a runtime test of the byte-growth bug would require running a stall scenario for >STALL_TIMEOUT seconds — disproportionate for a literal-string fix where the bug is structurally evident from the diff.

Resolves #21786


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-opus-4-7 spent 35m and 41,904 tokens on this with the user in an interactive session.