### PR TITLE
t3064: extend PR #21733 fix — use gh_issue_edit_safe in remaining hot-path body updates

### DIFF
--- a/.agents/scripts/post-merge-review-scanner.sh
+++ b/.agents/scripts/post-merge-review-scanner.sh
@@ -811,7 +811,11 @@ _refresh_one_issue() {
 		return 0
 	fi
 
-	if gh issue edit "$issue_number" --repo "$repo" \
+	# Use gh_issue_edit_safe (not bare `gh issue edit`) so the REST fallback
+	# in shared-gh-wrappers-safe-edit.sh fires when GraphQL is rate-limited.
+	# Bare `gh issue edit` always uses GraphQL and silently fails the body
+	# update when the 5000/hr GraphQL budget is exhausted. PR #21733 model.
+	if gh_issue_edit_safe "$issue_number" --repo "$repo" \
 		--body "$new_body_with_sig" >/dev/null 2>&1; then
 		log "issue #${issue_number}: body updated"
 		return 0

--- a/.agents/scripts/pulse-merge-conflict.sh
+++ b/.agents/scripts/pulse-merge-conflict.sh
@@ -1016,7 +1016,11 @@ ${fence}
 
 ${new_section}"
 
-	if gh issue edit "$linked_issue" --repo "$repo_slug" \
+	# Use gh_issue_edit_safe (not bare `gh issue edit`) so the REST fallback
+	# in shared-gh-wrappers-safe-edit.sh fires when GraphQL is rate-limited.
+	# Bare `gh issue edit` always uses GraphQL and silently fails the body
+	# update when the 5000/hr GraphQL budget is exhausted. PR #21733 model.
+	if gh_issue_edit_safe "$linked_issue" --repo "$repo_slug" \
 		--body "$new_body" >/dev/null 2>&1; then
 		echo "[pulse-wrapper] _carry_forward_pr_diff: appended diff from PR #${pr_number} to issue #${linked_issue} in ${repo_slug} (t2118)" >>"$LOGFILE"
 	else

--- a/.agents/scripts/pulse-merge-feedback.sh
+++ b/.agents/scripts/pulse-merge-feedback.sh
@@ -165,7 +165,11 @@ _append_feedback_to_issue() {
 
 ${marker}
 ${feedback_section}"
-	gh issue edit "$linked_issue" --repo "$repo_slug" \
+	# Use gh_issue_edit_safe (not bare `gh issue edit`) so the REST fallback
+	# in shared-gh-wrappers-safe-edit.sh fires when GraphQL is rate-limited.
+	# Bare `gh issue edit` always uses GraphQL and silently fails the body
+	# update when the 5000/hr GraphQL budget is exhausted. PR #21733 model.
+	gh_issue_edit_safe "$linked_issue" --repo "$repo_slug" \
 		--body "$new_body" >/dev/null 2>&1 || {
 		echo "[pulse-wrapper] ${caller}: failed to update issue #${linked_issue} body — aborting" >>"$LOGFILE"
 		return 1


### PR DESCRIPTION
## Summary

Replace bare `gh issue edit --body` with `gh_issue_edit_safe` at three pulse-driven hot-path call sites, applying the same REST-fallback fix from PR #21733 to the remaining locations identified in GH#21798.

## Sites fixed

- `post-merge-review-scanner.sh:818` — review-followup issue body refresh (runs every pulse cycle)
- `pulse-merge-conflict.sh:1023` — t2118 carry-forward of PR diff into linked issue body (merge-close path)
- `pulse-merge-feedback.sh:172` — PR feedback append (every PR feedback routing)

Each replacement includes the 4-line PR #21733 rationale comment block explaining why the wrapper is needed.

## Why

Bare `gh issue edit --body` always uses GraphQL. When the 5000/hr GraphQL budget is exhausted, the call silently fails — body update is lost until the budget resets (up to 1h). `gh_issue_edit_safe` falls back to REST `PATCH /repos/{owner}/{repo}/issues/{N}` using the separate 5000/hr core API budget. Same root cause as PR #21733; same fix applied to three additional pulse-driven sites.

## Verification

- `shellcheck` passes on all three files with zero violations
- `grep -n 'gh_issue_edit_safe'` confirms wrapper present at all three sites
- Diff shows no new bare `gh issue edit --body` calls introduced
- `gh-wrapper-guard check-full` shows same 9 pre-existing violations (none in modified files)

Resolves #21798

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-sonnet-4-6 spent 3m and 9,048 tokens on this as a headless worker.
