### PR TITLE
chore: add TODO entries for t3066/t3068/t3069 (lost to t3069 bug)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3565,3 +3565,9 @@ t019.3.4,Update AGENTS.md with Beads integration docs,,beads,1h,45m,2025-12-21T1
 - [ ] t3064 extend PR #21733 fix — use gh_issue_edit_safe in remaining hot-path body updates #auto-dispatch #bug ref:GH#21798
 
 - [ ] t3065 worktree-helper.sh remove emits BSD sed regex error after cleanup #auto-dispatch #bug #framework ref:GH#21801
+
+- [ ] t3066 extend approve_collaborator_pr to honour crypto-approval as CONTRIBUTOR-author bypass (sibling of t3052) #auto-dispatch #bug ref:GH#21803
+
+- [ ] t3068 kick pulse-merge cycle when sudo aidevops approve posts a verified signature (eliminate up-to-120s latency) #auto-dispatch #enhancement ref:GH#21806
+
+- [ ] t3069 harden issue_num extraction against multi-line gh_create_issue output (TODO.md append silently fails) #auto-dispatch #bug #framework ref:GH#21807


### PR DESCRIPTION
## Summary

Restore TODO.md traceability for three issues filed in sequence on 2026-04-29 whose entries were silently swallowed by the `claim-task-id.sh` multi-line `issue_num` bug now filed as t3069.

- t3066 (#21803) — extend `approve_collaborator_pr` to honour crypto-approval (sibling of t3052)
- t3068 (#21806) — kick pulse-merge when `sudo aidevops approve` posts a signature (eliminate ~120s latency)
- t3069 (#21807) — harden `claim-task-id.sh:535` `grep -oE '[0-9]+$'` against multi-line `gh_create_issue` output

All three issues exist on GitHub with `auto-dispatch` labels — workers will pick them up regardless of TODO state. This PR is purely traceability bookkeeping so future sessions can see the open work via TODO.md and avoid filing duplicates.

## Why a separate PR

The bug that caused the gap (t3069) is itself one of the three filed issues. Workers fixing t3069 will prevent recurrence; this PR closes the existing gap left by it.

Ref #21803, Ref #21806, Ref #21807
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-opus-4-7 spent 54m and 9,736 tokens on this as a headless worker.