### PR TITLE
t3070: Native GitHub auto-merge fast-track for sub-30s green-to-merged latency

### DIFF
--- a/.agents/reference/auto-merge.md
+++ b/.agents/reference/auto-merge.md
@@ -76,6 +76,47 @@ The pulse runs as the maintainer's GitHub token, so `needs-maintainer-review` la
 
 Two helpers enforce the split: `_nmr_application_has_automation_signature` (creation defaults only) and `_nmr_application_is_circuit_breaker_trip` (breaker trips only). Regression test: `.agents/scripts/tests/test-pulse-nmr-automation-signature.sh::test_19756_loop_prevention_breaker_trip_preserves_nmr`.
 
+## t3070 — Native Auto-Merge Fast-Track
+
+**Trigger:** every PR that reaches the merge call site in `_process_single_ready_pr` after passing all gates (review, maintainer, scope, review-bot-gate, complexity, admin safety check).
+
+**What it does:** instead of unconditionally calling `gh pr merge --squash --admin` against pending CI, the pulse asks GitHub to merge the PR as soon as the last required check turns green via `gh pr merge --auto --squash`. GitHub then schedules the merge server-side and fires it within seconds of CI green — no further pulse-cycle wait required.
+
+**Decision tree** (`_set_native_auto_merge_or_skip` in `pulse-merge-process.sh`):
+
+| Condition | Action | Caller behaviour |
+|-----------|--------|------------------|
+| PR already has `autoMergeRequest` set | No-op | Caller returns success — GitHub finishes the merge |
+| Repo `allow_auto_merge=false` | Fall through | Caller invokes `gh pr merge --squash --admin` |
+| All required checks already done (no `pending` bucket) | Fall through | Caller invokes `gh pr merge --squash --admin` (immediate is faster than round-tripping through GitHub's auto-merge engine) |
+| At least one required check pending | `gh pr merge --auto --squash` | Caller returns success — GitHub merges on green |
+| `gh pr merge --auto` exits non-zero | Fall through with audit log | Caller invokes `gh pr merge --squash --admin` |
+
+**Repo prerequisite:** `allow_auto_merge=true` on the repo. Bulk-enable across all owned repos:
+
+```bash
+jq -r '.initialized_repos[] | select(.local_only != true) | .slug' \
+    ~/.config/aidevops/repos.json | while read -r slug; do
+  gh api -X PATCH "repos/${slug}" -f allow_auto_merge=true >/dev/null \
+    && printf 'enabled %s\n' "$slug"
+done
+```
+
+**Latency improvement:** baseline measurement on owner/peer green PR push→merged was 3-22 min — dominated by the 120s polling cycle plus per-cycle gate evaluation. With native auto-merge, GitHub fires the merge within ~5-30s of the last required check finishing, regardless of when the next pulse cycle would have polled.
+
+**Trade-offs:**
+
+- **No `--admin` bypass on the auto-scheduled merge.** Native auto-merge respects branch protection. If the repo has required checks that ultimately fail, GitHub will hold the PR indefinitely instead of merging — exactly the safety property branch protection exists to provide. The pulse still falls back to `--admin` for repos that opted out (`allow_auto_merge=false`), preserving the historical bypass-pending behaviour for those repos.
+- **No `_handle_post_merge_actions` invocation on the native-auto path.** The "Merged via PR #N" comment with `merge_summary` is NOT posted on the linked issue when GitHub completes the merge later. GitHub's `Resolves #NNN` keyword still auto-closes the issue — only the structured closing comment is lost. Acceptable for the speedup; users who need the comment can apply `hold-for-review` to opt out.
+
+**Audit log:** `[pulse-merge] PR #N in slug: native auto-merge set (CI K pending), GitHub merges on green (t3070)`.
+
+**Caching:** `_repo_allows_auto_merge` caches the per-repo `allow_auto_merge` flag in a tempdir keyed on PID for the lifetime of the pulse cycle. Avoids repeated `gh api repos/<slug>` calls when iterating multiple PRs from the same repo.
+
+**Test coverage:** `.agents/scripts/tests/test-pulse-merge-native-auto.sh` (4 cases — pending/green/already-set/repo-disallows).
+
+**Bypass:** apply `hold-for-review` to opt out of all auto-merge paths (this gate is upstream of t3070 — a held PR never reaches the native-auto call site). For per-repo opt-out, set `allow_auto_merge=false` via `gh api -X PATCH repos/<slug> -f allow_auto_merge=false`.
+
 ## Webhook-Driven Auto-Merge (t3038)
 
 The 120s `pulse-merge-routine.sh` polling loop is the **backstop**. The fast path is a webhook receiver that fires `pulse-merge.sh::process_pr` within seconds of a GitHub event:

--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -792,7 +792,8 @@ _repo_allows_auto_merge() {
 
 	mkdir -p "$cache_dir" 2>/dev/null || true
 
-	local _flag _f_exit
+	local _flag=""
+	local _f_exit=0
 	_flag=$(gh api "repos/${repo_slug}" --jq '.allow_auto_merge // false' 2>/dev/null)
 	_f_exit=$?
 	if [[ $_f_exit -ne 0 ]]; then
@@ -862,7 +863,8 @@ _set_native_auto_merge_or_skip() {
 	# already done (success/skipped — failures filtered upstream by
 	# _pr_required_checks_pass), the immediate --admin path is faster than
 	# round-tripping through GitHub's auto-merge engine.
-	local pending_count _pc_exit
+	local pending_count=""
+	local _pc_exit=0
 	pending_count=$(gh pr checks "$pr_number" --repo "$repo_slug" --required --json bucket \
 		--jq '[.[] | select(.bucket == "pending")] | length' 2>/dev/null)
 	_pc_exit=$?
@@ -878,7 +880,8 @@ _set_native_auto_merge_or_skip() {
 	fi
 
 	# CI in flight — ask GitHub to merge on green.
-	local _auto_output _auto_exit
+	local _auto_output=""
+	local _auto_exit=0
 	_auto_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --auto --squash 2>&1)
 	_auto_exit=$?
 	if [[ $_auto_exit -eq 0 ]]; then

--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -762,3 +762,130 @@ _check_required_checks_passing() {
 	echo "[pulse-merge] _check_required_checks_passing: all required contexts passing for PR #${pr_number} in ${repo_slug} (t2922)" >>"$LOGFILE"
 	return 0
 }
+
+#######################################
+# Cached check: does the repo have allow_auto_merge enabled (t3070)?
+#
+# Caches per repo slug in a tempdir keyed on PID for the lifetime of the
+# calling process. allow_auto_merge is a repo-level setting that rarely
+# changes; a stale cache at worst falls through to the existing immediate-
+# merge path on the next pulse cycle.
+#
+# Args: $1=repo slug
+# Returns: 0=enabled, 1=disabled or query error (fail-closed)
+#######################################
+_repo_allows_auto_merge() {
+	local repo_slug="$1"
+	local cache_dir="${TMPDIR:-/tmp}/aidevops-pulse-allow-auto-merge-$$"
+	local cache_key
+	cache_key=$(printf '%s' "$repo_slug" | tr '/' '_')
+	local cache_file="${cache_dir}/${cache_key}"
+
+	if [[ -f "$cache_file" ]]; then
+		local cached
+		cached=$(<"$cache_file")
+		case "$cached" in
+			true) return 0 ;;
+			false) return 1 ;;
+		esac
+	fi
+
+	mkdir -p "$cache_dir" 2>/dev/null || true
+
+	local _flag _f_exit
+	_flag=$(gh api "repos/${repo_slug}" --jq '.allow_auto_merge // false' 2>/dev/null)
+	_f_exit=$?
+	if [[ $_f_exit -ne 0 ]]; then
+		# Fail-closed: don't try native auto-merge if we can't verify.
+		echo "[pulse-merge] _repo_allows_auto_merge: gh api failed for ${repo_slug} (exit ${_f_exit}), treating as disabled (t3070)" >>"$LOGFILE"
+		printf '%s' "false" >"$cache_file" 2>/dev/null || true
+		return 1
+	fi
+
+	if [[ "$_flag" == "true" ]]; then
+		printf '%s' "true" >"$cache_file" 2>/dev/null || true
+		return 0
+	fi
+	printf '%s' "false" >"$cache_file" 2>/dev/null || true
+	return 1
+}
+
+#######################################
+# Conditionally hand a PR off to GitHub native auto-merge (t3070).
+#
+# Eliminates the ~120s pulse poll-cycle latency between CI green and merge
+# call. When the repo has allow_auto_merge enabled and at least one
+# required check is currently pending, ask GitHub to merge as soon as CI
+# turns green via `gh pr merge --auto --squash`. GitHub then merges within
+# seconds of the last required check completing instead of waiting for the
+# next pulse cycle to detect green.
+#
+# Decision tree:
+#   * PR already has auto_merge set    → return 0 (no-op, GitHub handles)
+#   * Repo allow_auto_merge=false      → return 1 (caller --admin path)
+#   * No required check pending        → return 1 (caller --admin path —
+#                                                  immediate merge fastest)
+#   * gh pr merge --auto succeeds      → return 0 (caller skips merge)
+#   * gh pr merge --auto fails         → return 1 (caller --admin fallback)
+#
+# Caller MUST verify all other merge gates (review, maintainer, scope,
+# review-bot-gate, complexity) BEFORE invoking. This helper only chooses
+# between native-auto and immediate-merge — it does not gate trust.
+#
+# Native auto-merge respects branch protection (no --admin bypass). Repos
+# bypass-merging through pending checks should keep the immediate-merge
+# fallback (returns 1 path) — this trade-off is acceptable for owned-org
+# repos where allow_auto_merge=true is bulk-enabled and CI is fast.
+#
+# Args: $1=pr_number, $2=repo_slug
+# Returns: 0=native-auto requested (caller skips merge), 1=fall through
+#######################################
+_set_native_auto_merge_or_skip() {
+	local pr_number="$1"
+	local repo_slug="$2"
+
+	# Skip if PR already has auto_merge set — let GitHub finish the job.
+	local _existing_auto
+	_existing_auto=$(gh pr view "$pr_number" --repo "$repo_slug" \
+		--json autoMergeRequest --jq '.autoMergeRequest // empty' 2>/dev/null)
+	if [[ -n "$_existing_auto" ]]; then
+		echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: auto_merge already set, deferring to GitHub (t3070)" >>"$LOGFILE"
+		return 0
+	fi
+
+	# Skip if repo does not allow auto-merge — fall through to immediate merge.
+	if ! _repo_allows_auto_merge "$repo_slug"; then
+		return 1
+	fi
+
+	# Determine if any required check is currently pending. If everything is
+	# already done (success/skipped — failures filtered upstream by
+	# _pr_required_checks_pass), the immediate --admin path is faster than
+	# round-tripping through GitHub's auto-merge engine.
+	local pending_count _pc_exit
+	pending_count=$(gh pr checks "$pr_number" --repo "$repo_slug" --required --json bucket \
+		--jq '[.[] | select(.bucket == "pending")] | length' 2>/dev/null)
+	_pc_exit=$?
+	if [[ $_pc_exit -ne 0 ]]; then
+		echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: gh pr checks --required failed (exit ${_pc_exit}), falling through to immediate merge (t3070)" >>"$LOGFILE"
+		return 1
+	fi
+	[[ "$pending_count" =~ ^[0-9]+$ ]] || pending_count=0
+
+	if [[ "$pending_count" -eq 0 ]]; then
+		# No pending required checks — immediate --admin merge is faster.
+		return 1
+	fi
+
+	# CI in flight — ask GitHub to merge on green.
+	local _auto_output _auto_exit
+	_auto_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --auto --squash 2>&1)
+	_auto_exit=$?
+	if [[ $_auto_exit -eq 0 ]]; then
+		echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: native auto-merge set (CI ${pending_count} pending), GitHub merges on green (t3070)" >>"$LOGFILE"
+		return 0
+	fi
+
+	echo "[pulse-merge] PR #${pr_number} in ${repo_slug}: gh pr merge --auto failed (exit ${_auto_exit}): ${_auto_output} — falling through to immediate merge (t3070)" >>"$LOGFILE"
+	return 1
+}

--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -583,6 +583,15 @@ _process_single_ready_pr() {
 		return 1
 	fi
 
+	# Native auto-merge fast-track (t3070): if CI is still pending and the
+	# repo has allow_auto_merge enabled, hand the merge over to GitHub —
+	# it merges within seconds of green instead of waiting for the next
+	# pulse poll cycle (~120s). Falls through to --admin immediate merge
+	# when CI is already green, repo opts out, or the API call fails.
+	if _set_native_auto_merge_or_skip "$pr_number" "$repo_slug"; then
+		return 0
+	fi
+
 	# Merge
 	local merge_output _merge_exit
 	merge_output=$(gh pr merge "$pr_number" --repo "$repo_slug" --squash --admin 2>&1)

--- a/.agents/scripts/tests/test-pulse-merge-native-auto.sh
+++ b/.agents/scripts/tests/test-pulse-merge-native-auto.sh
@@ -1,0 +1,319 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Tests for native GitHub auto-merge fast-track (t3070).
+#
+# Verifies the 4 decision-tree branches of _set_native_auto_merge_or_skip
+# from `_repo_allows_auto_merge` + `_set_native_auto_merge_or_skip`
+# (pulse-merge-process.sh):
+#
+#   Case (A): CI pending + repo allows auto-merge
+#             → returns 0; `gh pr merge --auto --squash` invoked
+#   Case (B): CI green (no required-bucket pending)
+#             → returns 1; no `gh pr merge --auto` invocation (caller
+#               falls through to immediate --admin merge for speed)
+#   Case (C): PR already has autoMergeRequest set
+#             → returns 0; no new `gh pr merge --auto` invocation
+#               (deferred to GitHub)
+#   Case (D): Repo allow_auto_merge=false
+#             → returns 1; no `gh pr merge --auto` invocation
+#
+# No real repository is touched. The `gh` binary is replaced with a mock
+# stub that serves canned responses from TEST_ROOT fixture files and logs
+# every invocation so we can assert on call shape.
+#
+# Pattern mirrors: test-pulse-merge-worker-briefed.sh (helper extraction
+# via awk + eval into the test shell, gh mocking via PATH manipulation).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+PROCESS_SCRIPT="${SCRIPT_DIR}/../pulse-merge-process.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+GH_LOG=""
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+	mkdir -p "${TEST_ROOT}/bin"
+	export PATH="${TEST_ROOT}/bin:${PATH}"
+	export LOGFILE="${TEST_ROOT}/pulse.log"
+	: >"$LOGFILE"
+	GH_LOG="${TEST_ROOT}/gh-calls.log"
+	: >"$GH_LOG"
+	export TEST_ROOT GH_LOG
+
+	# Default fixtures. Overridden per-test before invocation.
+	#  * auto_merge_request: empty (PR does not have auto-merge set)
+	#  * allow_auto_merge:   true  (repo allows it)
+	#  * pending_count:      1     (one required check pending)
+	printf '' >"${TEST_ROOT}/auto_merge_request.txt"
+	printf 'true' >"${TEST_ROOT}/allow_auto_merge.txt"
+	printf '1' >"${TEST_ROOT}/pending_count.txt"
+
+	# Cache dir is keyed on PID — wipe between tests so allow_auto_merge
+	# fixture changes are honoured (otherwise Case D inherits Case A).
+	rm -rf "${TMPDIR:-/tmp}/aidevops-pulse-allow-auto-merge-$$" 2>/dev/null || true
+
+	# Mock gh: logs every call, dispatches by argument shape.
+	cat >"${TEST_ROOT}/bin/gh" <<'GHEOF'
+#!/usr/bin/env bash
+printf '%s\n' "gh $*" >>"${GH_LOG:-/dev/null}"
+
+# `gh pr view <N> --repo <slug> --json autoMergeRequest --jq ...`
+if [[ "$1" == "pr" && "$2" == "view" && "$*" == *"autoMergeRequest"* ]]; then
+	cat "${TEST_ROOT}/auto_merge_request.txt"
+	echo
+	exit 0
+fi
+
+# `gh api repos/<slug> --jq '.allow_auto_merge // false'`
+if [[ "$1" == "api" && "$2" == repos/* && "$*" == *"allow_auto_merge"* ]]; then
+	cat "${TEST_ROOT}/allow_auto_merge.txt"
+	echo
+	exit 0
+fi
+
+# `gh pr checks <N> --repo <slug> --required --json bucket --jq '...'`
+if [[ "$1" == "pr" && "$2" == "checks" && "$*" == *"--required"* ]]; then
+	cat "${TEST_ROOT}/pending_count.txt"
+	echo
+	exit 0
+fi
+
+# `gh pr merge <N> --repo <slug> --auto --squash`
+if [[ "$1" == "pr" && "$2" == "merge" && "$*" == *"--auto"* ]]; then
+	exit 0
+fi
+
+# Default: succeed silently for any other call shape.
+exit 0
+GHEOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+	return 0
+}
+
+teardown_test_env() {
+	# Wipe cache dir for next test.
+	rm -rf "${TMPDIR:-/tmp}/aidevops-pulse-allow-auto-merge-$$" 2>/dev/null || true
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+# Extract _repo_allows_auto_merge and _set_native_auto_merge_or_skip from
+# pulse-merge-process.sh and eval them into the test shell.
+define_helpers_under_test() {
+	local src_repo_allow src_set_native
+	src_repo_allow=$(awk '
+		/^_repo_allows_auto_merge\(\) \{/,/^\}$/ { print }
+	' "$PROCESS_SCRIPT")
+	src_set_native=$(awk '
+		/^_set_native_auto_merge_or_skip\(\) \{/,/^\}$/ { print }
+	' "$PROCESS_SCRIPT")
+	if [[ -z "$src_repo_allow" || -z "$src_set_native" ]]; then
+		printf 'ERROR: could not extract helpers from %s\n' "$PROCESS_SCRIPT" >&2
+		return 1
+	fi
+	# shellcheck disable=SC1090
+	eval "$src_repo_allow"
+	# shellcheck disable=SC1090
+	eval "$src_set_native"
+	return 0
+}
+
+assert_gh_call_shape() {
+	local pattern="$1"
+	local should_match="$2"  # 0=must match, 1=must NOT match
+	local description="$3"
+
+	if grep -qE "$pattern" "$GH_LOG"; then
+		if [[ "$should_match" -eq 0 ]]; then
+			return 0
+		fi
+		printf '       gh log: %s\n' "$(cat "$GH_LOG")" >&2
+		print_result "${description} (expected NO match for: ${pattern})" 1
+		return 1
+	fi
+	if [[ "$should_match" -eq 1 ]]; then
+		return 0
+	fi
+	printf '       gh log: %s\n' "$(cat "$GH_LOG")" >&2
+	print_result "${description} (expected match for: ${pattern})" 1
+	return 1
+}
+
+# =============================================================================
+# Case (A): CI pending + repo allows auto-merge → set --auto, return 0
+# =============================================================================
+test_case_a_pending_ci_sets_auto_merge() {
+	setup_test_env
+	define_helpers_under_test || { teardown_test_env; return 0; }
+
+	# Defaults already match: auto_merge_request empty, allow_auto_merge=true,
+	# pending_count=1.
+
+	local result=0
+	_set_native_auto_merge_or_skip "100" "owner/repo" || result=$?
+
+	if [[ "$result" -ne 0 ]]; then
+		print_result "Case (A): CI pending + repo allows → returns 0" 1 \
+			"Expected exit 0, got ${result}"
+		teardown_test_env
+		return 0
+	fi
+	if ! grep -qE 'gh pr merge 100 --repo owner/repo --auto --squash' "$GH_LOG"; then
+		print_result "Case (A): CI pending + repo allows → invokes gh pr merge --auto" 1 \
+			"gh log: $(cat "$GH_LOG")"
+		teardown_test_env
+		return 0
+	fi
+	if ! grep -qE 'native auto-merge set.*t3070' "$LOGFILE"; then
+		print_result "Case (A): CI pending → audit log line written" 1 \
+			"pulse log: $(cat "$LOGFILE")"
+		teardown_test_env
+		return 0
+	fi
+	print_result "Case (A): CI pending + repo allows → returns 0 + invokes --auto" 0
+	teardown_test_env
+	return 0
+}
+
+# =============================================================================
+# Case (B): CI green (no pending bucket) → returns 1, no --auto invocation
+# =============================================================================
+test_case_b_ci_green_falls_through() {
+	setup_test_env
+	define_helpers_under_test || { teardown_test_env; return 0; }
+
+	printf '0' >"${TEST_ROOT}/pending_count.txt"
+
+	local result=0
+	_set_native_auto_merge_or_skip "200" "owner/repo" || result=$?
+
+	if [[ "$result" -ne 1 ]]; then
+		print_result "Case (B): CI green → returns 1 (fall-through)" 1 \
+			"Expected exit 1, got ${result}"
+		teardown_test_env
+		return 0
+	fi
+	if grep -qE 'gh pr merge 200 .*--auto' "$GH_LOG"; then
+		print_result "Case (B): CI green → no gh pr merge --auto invocation" 1 \
+			"gh log: $(cat "$GH_LOG")"
+		teardown_test_env
+		return 0
+	fi
+	print_result "Case (B): CI green → returns 1, no --auto invocation" 0
+	teardown_test_env
+	return 0
+}
+
+# =============================================================================
+# Case (C): PR already has autoMergeRequest → returns 0, no new --auto call
+# =============================================================================
+test_case_c_already_set_no_op() {
+	setup_test_env
+	define_helpers_under_test || { teardown_test_env; return 0; }
+
+	# Non-empty autoMergeRequest payload — what GitHub returns when --auto
+	# was previously requested. The `// empty` filter passes the value
+	# through unchanged, so any non-empty string triggers the no-op branch.
+	printf '{"enabledAt":"2026-04-30T12:00:00Z"}' >"${TEST_ROOT}/auto_merge_request.txt"
+
+	local result=0
+	_set_native_auto_merge_or_skip "300" "owner/repo" || result=$?
+
+	if [[ "$result" -ne 0 ]]; then
+		print_result "Case (C): auto_merge already set → returns 0 (no-op)" 1 \
+			"Expected exit 0, got ${result}"
+		teardown_test_env
+		return 0
+	fi
+	if grep -qE 'gh pr merge 300 .*--auto' "$GH_LOG"; then
+		print_result "Case (C): auto_merge already set → no NEW --auto invocation" 1 \
+			"gh log: $(cat "$GH_LOG")"
+		teardown_test_env
+		return 0
+	fi
+	if ! grep -qE 'auto_merge already set.*t3070' "$LOGFILE"; then
+		print_result "Case (C): already-set audit log line written" 1 \
+			"pulse log: $(cat "$LOGFILE")"
+		teardown_test_env
+		return 0
+	fi
+	print_result "Case (C): auto_merge already set → returns 0 (deferred to GitHub)" 0
+	teardown_test_env
+	return 0
+}
+
+# =============================================================================
+# Case (D): allow_auto_merge=false → returns 1, no --auto call
+# =============================================================================
+test_case_d_repo_disallows_falls_through() {
+	setup_test_env
+	define_helpers_under_test || { teardown_test_env; return 0; }
+
+	printf 'false' >"${TEST_ROOT}/allow_auto_merge.txt"
+
+	local result=0
+	_set_native_auto_merge_or_skip "400" "owner/repo" || result=$?
+
+	if [[ "$result" -ne 1 ]]; then
+		print_result "Case (D): allow_auto_merge=false → returns 1 (fall-through)" 1 \
+			"Expected exit 1, got ${result}"
+		teardown_test_env
+		return 0
+	fi
+	if grep -qE 'gh pr merge 400 .*--auto' "$GH_LOG"; then
+		print_result "Case (D): allow_auto_merge=false → no --auto invocation" 1 \
+			"gh log: $(cat "$GH_LOG")"
+		teardown_test_env
+		return 0
+	fi
+	print_result "Case (D): allow_auto_merge=false → returns 1, no --auto invocation" 0
+	teardown_test_env
+	return 0
+}
+
+main() {
+	test_case_a_pending_ci_sets_auto_merge
+	test_case_b_ci_green_falls_through
+	test_case_c_already_set_no_op
+	test_case_d_repo_disallows_falls_through
+
+	printf '\n=================================\n'
+	printf 'Tests run: %d, failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
+	printf '=================================\n'
+
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		exit 1
+	fi
+	exit 0
+}
+
+main "$@"


### PR DESCRIPTION
Switches `pulse-merge.sh::_process_single_ready_pr` to use GitHub native auto-merge (`gh pr merge --auto --squash`) when CI is still pending and the repo has `allow_auto_merge=true`. GitHub then merges within seconds of the last required check finishing instead of waiting up to 120s for the next pulse polling cycle to detect green.

Resolves #21810

## Summary

- New helper `_set_native_auto_merge_or_skip` (pulse-merge-process.sh): decision tree that hands the merge to GitHub when CI is pending + repo allows it; falls through to the existing `--admin --squash` immediate-merge path otherwise.
- New helper `_repo_allows_auto_merge`: per-pulse-cycle cached `allow_auto_merge` lookup keyed on PID + repo slug. Avoids redundant `gh api repos/<slug>` calls when iterating multiple PRs from the same repo.
- 6-line call site addition in `_process_single_ready_pr` between `_pulse_merge_admin_safety_check` and the existing `gh pr merge --admin` line. Native auto-merge runs only AFTER all gates pass — review-bot-gate, maintainer gate, scope guard, complexity gate, admin safety check.

## Latency improvement (per t3070 brief)

Baseline measurement on owner/peer green PR push→merged: 3-22 min, dominated by the 120s polling cycle plus per-cycle gate evaluation. With native auto-merge, GitHub fires the merge ~5-30s after the last required check turns green regardless of when the next pulse cycle would have polled.

## Files

- `EDIT: .agents/scripts/pulse-merge-process.sh` — `+127 lines` (`_repo_allows_auto_merge`, `_set_native_auto_merge_or_skip`)
- `EDIT: .agents/scripts/pulse-merge.sh` — `+9 lines` (call site in `_process_single_ready_pr`)
- `NEW:  .agents/scripts/tests/test-pulse-merge-native-auto.sh` — 4 cases (pending / green / already-set / repo-disallows)
- `EDIT: .agents/reference/auto-merge.md` — new "t3070 — Native Auto-Merge Fast-Track" section between t2449 and Webhook (t3038)

## Decision tree (verified by test)

| Condition | Action | Caller behaviour |
|-----------|--------|------------------|
| PR already has `autoMergeRequest` set | No-op | Caller returns success — GitHub finishes the merge |
| Repo `allow_auto_merge=false` | Fall through | Caller invokes `gh pr merge --squash --admin` |
| All required checks already done (no `pending` bucket) | Fall through | Caller invokes `gh pr merge --squash --admin` (immediate is faster) |
| At least one required check pending | `gh pr merge --auto --squash` | Caller returns success — GitHub merges on green |
| `gh pr merge --auto` exits non-zero | Fall through with audit log | Caller invokes `gh pr merge --squash --admin` |

## Verification

```text
$ bash .agents/scripts/tests/test-pulse-merge-native-auto.sh
PASS Case (A): CI pending + repo allows → returns 0 + invokes --auto
PASS Case (B): CI green → returns 1, no --auto invocation
PASS Case (C): auto_merge already set → returns 0 (deferred to GitHub)
PASS Case (D): allow_auto_merge=false → returns 1, no --auto invocation
Tests run: 4, failed: 0

$ bash .agents/scripts/tests/test-pulse-merge-worker-briefed.sh
Results: 13/13 passed (no regression on t2449 worker-briefed gates)

$ shellcheck .agents/scripts/pulse-merge-process.sh \
            .agents/scripts/pulse-merge.sh \
            .agents/scripts/tests/test-pulse-merge-native-auto.sh
(clean — zero violations)

$ npx --yes markdownlint-cli2 .agents/reference/auto-merge.md
Summary: 0 error(s)
```

## Trade-offs

- **No `--admin` bypass on the auto-scheduled merge.** Native auto-merge respects branch protection. If required checks ultimately fail, GitHub holds the PR indefinitely instead of merging — exactly the safety property branch protection exists to provide. Repos that opt out (`allow_auto_merge=false`) keep the historical bypass-pending behaviour via the fallback path.
- **No `_handle_post_merge_actions` invocation on the native-auto path.** The "Merged via PR #N" comment with `merge_summary` is NOT posted on the linked issue when GitHub completes the merge later. GitHub's `Resolves #NNN` keyword still auto-closes the issue — only the structured closing comment is lost. Acceptable for the speedup.

## Complexity Bump Justification

**Scanner evidence (file:line refs):**

- `pulse-merge.sh:424` — `_process_single_ready_pr` definition (function whose line count grew).
- `pulse-merge.sh:591` — new 4-line guard call site (`if _set_native_auto_merge_or_skip ...; then return 0; fi`) immediately before the existing `gh pr merge --admin --squash` call.
- `pulse-merge-process.sh:777` — new helper `_repo_allows_auto_merge` (cached repo flag lookup).
- `pulse-merge-process.sh:844` — new helper `_set_native_auto_merge_or_skip` (decision tree, isolated outside the parent function).

**Numeric measurements:**

- `_process_single_ready_pr` lines: `base=193, head=202, new=9`. Threshold: function-complexity gate fires at `lines>100`.
- New logic split into `pulse-merge-process.sh`: `+127 lines` across the two new helpers (kept OUT of the parent function to bound the bump).
- New helper file size: `pulse-merge-process.sh` `base=767, head=894, new=127` lines — well below the file-size-debt threshold.

**Why the bump is acceptable:** `_process_single_ready_pr` was already `base=193` lines (over the 100-line gate threshold) before this PR. The 9 added lines are a 5-line block comment plus a 4-line guard; no new control-flow nesting or shared local state is introduced. The bulk of the new logic (~127 lines across `_repo_allows_auto_merge` and `_set_native_auto_merge_or_skip`) lives in the smaller `pulse-merge-process.sh` helper file — not inlined into the parent — specifically to keep the function-complexity bump minimal.

Splitting `_process_single_ready_pr` itself was considered and deferred: the function is a single linear merge pipeline with shared local state (pr_number, pr_mergeable, pr_review, pr_author, linked_issue, merge_summary), and a per-stage extraction would multiply parameter-passing without reducing total complexity. A future task can attempt the split if the gate continues to drift upward; for this change, the inline cost is bounded.

## Repo prerequisite

`allow_auto_merge=true` was bulk-enabled across all 10 pulse-managed owned-org repos on 2026-04-29 (per memory recall). `_repo_allows_auto_merge` fail-closes on missing flag — repos without it fall through to the existing `--admin` path. No behaviour change for opted-out repos.

## Audit log line

`[pulse-merge] PR #N in slug: native auto-merge set (CI K pending), GitHub merges on green (t3070)`

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-opus-4-7 spent 16m and 55,244 tokens on this with the user in an interactive session.

