### PR TITLE
GH#21813: split headless-runtime-helper.sh below 2000-line file-size-debt threshold

### DIFF
--- a/.agents/scripts/headless-runtime-helper-cmds.sh
+++ b/.agents/scripts/headless-runtime-helper-cmds.sh
@@ -1,0 +1,208 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# headless-runtime-helper-cmds.sh — CLI subcommand handlers
+# =============================================================================
+# CLI command implementations extracted from headless-runtime-helper.sh:
+#   cmd_select, cmd_backoff, cmd_session, cmd_metrics
+#
+# Usage: source "${SCRIPT_DIR}/headless-runtime-helper-cmds.sh"
+#
+# Dependencies:
+#   - shared-constants.sh (print_error, print_info, etc.)
+#   - headless-runtime-lib.sh (choose_model, db_query, resolve_model_tier,
+#     clear_provider_backoff, record_provider_backoff, extract_provider,
+#     sql_escape, _execute_metrics_analysis, etc.)
+#
+# Part of aidevops framework: https://aidevops.sh
+
+# Apply strict mode only when executed directly (not when sourced)
+[[ "${BASH_SOURCE[0]}" == "${0}" ]] && set -euo pipefail
+
+# Include guard
+[[ -n "${_HEADLESS_RUNTIME_CMDS_LOADED:-}" ]] && return 0
+_HEADLESS_RUNTIME_CMDS_LOADED=1
+
+# SCRIPT_DIR fallback for when sourced directly (e.g., in tests)
+if [[ -z "${SCRIPT_DIR:-}" ]]; then
+	_lib_path="${BASH_SOURCE[0]%/*}"
+	[[ "$_lib_path" == "${BASH_SOURCE[0]}" ]] && _lib_path="."
+	SCRIPT_DIR="$(cd "$_lib_path" && pwd)"
+	unset _lib_path
+fi
+
+# =============================================================================
+# CLI subcommands — select, backoff, session
+# =============================================================================
+
+cmd_select() {
+	local role="worker"
+	local model_override=""
+	local tier_override=""
+	while [[ $# -gt 0 ]]; do
+		case "${1:-}" in
+		--role)
+			role="${2:-}"
+			shift 2
+			;;
+		--model)
+			model_override="${2:-}"
+			shift 2
+			;;
+		--tier)
+			tier_override="${2:-}"
+			shift 2
+			;;
+		*)
+			print_error "Unknown option for select: ${1:-}"
+			return 1
+			;;
+		esac
+	done
+
+	# When a tier is specified, resolve the concrete model for that tier and
+	# use it as the explicit model override. This ensures the round-robin
+	# selects from the correct tier's model pool (e.g., haiku for tier:simple,
+	# opus for tier:thinking) rather than always defaulting to sonnet.
+	if [[ -n "$tier_override" && -z "$model_override" ]]; then
+		local tier_model=""
+		tier_model=$(resolve_model_tier "$tier_override" 2>/dev/null) || tier_model=""
+		if [[ -n "$tier_model" ]]; then
+			model_override="$tier_model"
+		fi
+	fi
+
+	local selected
+	selected=$(choose_model "$role" "$model_override") || return $?
+	printf '%s\n' "$selected"
+	return 0
+}
+
+cmd_backoff() {
+	local action="${1:-status}"
+	shift || true
+	case "$action" in
+	status)
+		db_query "SELECT provider || '|' || reason || '|' || retry_after || '|' || updated_at FROM provider_backoff ORDER BY provider;"
+		return 0
+		;;
+	clear)
+		local key="${1:-}"
+		[[ -n "$key" ]] || {
+			print_error "Usage: backoff clear <provider-or-model>"
+			return 1
+		}
+		clear_provider_backoff "$key"
+		return 0
+		;;
+	set)
+		local key="${1:-}"
+		local reason="${2:-provider_error}"
+		local retry_seconds="${3:-300}"
+		[[ -n "$key" ]] || {
+			print_error "Usage: backoff set <provider-or-model> <reason> [retry_seconds]"
+			return 1
+		}
+		local provider
+		provider=$(extract_provider "$key" 2>/dev/null || printf '%s' "$key")
+		local tmp_file
+		tmp_file=$(mktemp)
+		printf 'manual backoff %s %s %s\n' "$key" "$reason" "$retry_seconds" >"$tmp_file"
+		record_provider_backoff "$provider" "$reason" "$tmp_file" "$key"
+		if [[ "$retry_seconds" != "300" ]]; then
+			if [[ ! "$retry_seconds" =~ ^[0-9]+$ ]]; then
+				print_error "retry_seconds must be an integer"
+				return 1
+			fi
+			local retry_after
+			retry_after=$(date -u -v+"${retry_seconds}"S '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -d "+${retry_seconds} seconds" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || printf '%s' "")
+			db_query "UPDATE provider_backoff SET retry_after = '$(sql_escape "$retry_after")' WHERE provider = '$(sql_escape "$key")';" >/dev/null
+		fi
+		rm -f "$tmp_file"
+		return 0
+		;;
+	*)
+		print_error "Unknown backoff action: $action"
+		return 1
+		;;
+	esac
+}
+
+cmd_session() {
+	local action="${1:-status}"
+	shift || true
+	case "$action" in
+	status)
+		db_query "SELECT provider || '|' || session_key || '|' || session_id || '|' || model || '|' || updated_at FROM provider_sessions ORDER BY provider, session_key;"
+		return 0
+		;;
+	clear)
+		local provider="${1:-}"
+		local session_key="${2:-}"
+		[[ -n "$provider" && -n "$session_key" ]] || {
+			print_error "Usage: session clear <provider> <session_key>"
+			return 1
+		}
+		db_query "DELETE FROM provider_sessions WHERE provider = '$(sql_escape "$provider")' AND session_key = '$(sql_escape "$session_key")';" >/dev/null
+		return 0
+		;;
+	*)
+		print_error "Unknown session action: $action"
+		return 1
+		;;
+	esac
+}
+
+# =============================================================================
+# Metrics subcommand
+# =============================================================================
+
+cmd_metrics() {
+	local role_filter="pulse"
+	local hours="24"
+	local model_filter=""
+	local fast_threshold_secs="120"
+
+	while [[ $# -gt 0 ]]; do
+		case "${1:-}" in
+		--role)
+			role_filter="${2:-pulse}"
+			shift 2
+			;;
+		--hours)
+			hours="${2:-24}"
+			shift 2
+			;;
+		--model)
+			model_filter="${2:-}"
+			shift 2
+			;;
+		--fast-threshold)
+			fast_threshold_secs="${2:-120}"
+			shift 2
+			;;
+		*)
+			print_error "Unknown option for metrics: ${1:-}"
+			return 1
+			;;
+		esac
+	done
+
+	if [[ ! "$hours" =~ ^[0-9]+$ ]]; then
+		print_error "--hours must be an integer"
+		return 1
+	fi
+	if [[ ! "$fast_threshold_secs" =~ ^[0-9]+$ ]]; then
+		print_error "--fast-threshold must be an integer"
+		return 1
+	fi
+
+	if [[ ! -f "$METRICS_FILE" ]]; then
+		print_info "No runtime metrics recorded yet: $METRICS_FILE"
+		return 0
+	fi
+
+	_execute_metrics_analysis "$role_filter" "$hours" "$model_filter" "$fast_threshold_secs"
+	return 0
+}

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -52,134 +52,18 @@ readonly METRICS_FILE="${METRICS_DIR}/headless-runtime-metrics.jsonl"
 # shellcheck source=./headless-runtime-lib.sh
 source "${SCRIPT_DIR}/headless-runtime-lib.sh"
 
+# CLI subcommand handlers (cmd_select, cmd_backoff, cmd_session, cmd_metrics).
+# Extracted to reduce orchestrator line count below the file-size-debt threshold.
+# shellcheck source=./headless-runtime-helper-cmds.sh
+# shellcheck disable=SC1091  # sub-library resolved at runtime via $SCRIPT_DIR
+source "${SCRIPT_DIR}/headless-runtime-helper-cmds.sh"
+
 # Orphan-recovery helpers: _attempt_orphan_recovery_pr used by _handle_worker_branch_orphan
 # shellcheck source=./shared-claim-lifecycle.sh
 source "${SCRIPT_DIR}/shared-claim-lifecycle.sh"
 
 # Activity watchdog timeout — used by _invoke_opencode and the inline watchdog fallback.
 HEADLESS_ACTIVITY_TIMEOUT_SECONDS="${HEADLESS_ACTIVITY_TIMEOUT_SECONDS:-300}"
-
-# =============================================================================
-# CLI subcommands — select, backoff, session
-# =============================================================================
-
-cmd_select() {
-	local role="worker"
-	local model_override=""
-	local tier_override=""
-	while [[ $# -gt 0 ]]; do
-		case "$1" in
-		--role)
-			role="${2:-}"
-			shift 2
-			;;
-		--model)
-			model_override="${2:-}"
-			shift 2
-			;;
-		--tier)
-			tier_override="${2:-}"
-			shift 2
-			;;
-		*)
-			print_error "Unknown option for select: $1"
-			return 1
-			;;
-		esac
-	done
-
-	# When a tier is specified, resolve the concrete model for that tier and
-	# use it as the explicit model override. This ensures the round-robin
-	# selects from the correct tier's model pool (e.g., haiku for tier:simple,
-	# opus for tier:thinking) rather than always defaulting to sonnet.
-	if [[ -n "$tier_override" && -z "$model_override" ]]; then
-		local tier_model=""
-		tier_model=$(resolve_model_tier "$tier_override" 2>/dev/null) || tier_model=""
-		if [[ -n "$tier_model" ]]; then
-			model_override="$tier_model"
-		fi
-	fi
-
-	local selected
-	selected=$(choose_model "$role" "$model_override") || return $?
-	printf '%s\n' "$selected"
-	return 0
-}
-
-cmd_backoff() {
-	local action="${1:-status}"
-	shift || true
-	case "$action" in
-	status)
-		db_query "SELECT provider || '|' || reason || '|' || retry_after || '|' || updated_at FROM provider_backoff ORDER BY provider;"
-		return 0
-		;;
-	clear)
-		local key="${1:-}"
-		[[ -n "$key" ]] || {
-			print_error "Usage: backoff clear <provider-or-model>"
-			return 1
-		}
-		clear_provider_backoff "$key"
-		return 0
-		;;
-	set)
-		local key="${1:-}"
-		local reason="${2:-provider_error}"
-		local retry_seconds="${3:-300}"
-		[[ -n "$key" ]] || {
-			print_error "Usage: backoff set <provider-or-model> <reason> [retry_seconds]"
-			return 1
-		}
-		local provider
-		provider=$(extract_provider "$key" 2>/dev/null || printf '%s' "$key")
-		local tmp_file
-		tmp_file=$(mktemp)
-		printf 'manual backoff %s %s %s\n' "$key" "$reason" "$retry_seconds" >"$tmp_file"
-		record_provider_backoff "$provider" "$reason" "$tmp_file" "$key"
-		if [[ "$retry_seconds" != "300" ]]; then
-			if [[ ! "$retry_seconds" =~ ^[0-9]+$ ]]; then
-				print_error "retry_seconds must be an integer"
-				return 1
-			fi
-			local retry_after
-			retry_after=$(date -u -v+"${retry_seconds}"S '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || date -u -d "+${retry_seconds} seconds" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || printf '%s' "")
-			db_query "UPDATE provider_backoff SET retry_after = '$(sql_escape "$retry_after")' WHERE provider = '$(sql_escape "$key")';" >/dev/null
-		fi
-		rm -f "$tmp_file"
-		return 0
-		;;
-	*)
-		print_error "Unknown backoff action: $action"
-		return 1
-		;;
-	esac
-}
-
-cmd_session() {
-	local action="${1:-status}"
-	shift || true
-	case "$action" in
-	status)
-		db_query "SELECT provider || '|' || session_key || '|' || session_id || '|' || model || '|' || updated_at FROM provider_sessions ORDER BY provider, session_key;"
-		return 0
-		;;
-	clear)
-		local provider="${1:-}"
-		local session_key="${2:-}"
-		[[ -n "$provider" && -n "$session_key" ]] || {
-			print_error "Usage: session clear <provider> <session_key>"
-			return 1
-		}
-		db_query "DELETE FROM provider_sessions WHERE provider = '$(sql_escape "$provider")' AND session_key = '$(sql_escape "$session_key")';" >/dev/null
-		return 0
-		;;
-	*)
-		print_error "Unknown session action: $action"
-		return 1
-		;;
-	esac
-}
 
 # =============================================================================
 # Run argument parsing and validation
@@ -1190,59 +1074,6 @@ _execute_run_attempt() {
 	fi
 	append_runtime_metric "$role" "$session_key" "$selected_model" "$provider" "${_run_result_label:-failed}" "$handle_exit" "${_run_failure_reason:-}" "${_run_activity_detected:-0}" "$duration_ms"
 	return "$handle_exit"
-}
-
-# =============================================================================
-# Metrics subcommand
-# =============================================================================
-
-cmd_metrics() {
-	local role_filter="pulse"
-	local hours="24"
-	local model_filter=""
-	local fast_threshold_secs="120"
-
-	while [[ $# -gt 0 ]]; do
-		case "$1" in
-		--role)
-			role_filter="${2:-pulse}"
-			shift 2
-			;;
-		--hours)
-			hours="${2:-24}"
-			shift 2
-			;;
-		--model)
-			model_filter="${2:-}"
-			shift 2
-			;;
-		--fast-threshold)
-			fast_threshold_secs="${2:-120}"
-			shift 2
-			;;
-		*)
-			print_error "Unknown option for metrics: $1"
-			return 1
-			;;
-		esac
-	done
-
-	if [[ ! "$hours" =~ ^[0-9]+$ ]]; then
-		print_error "--hours must be an integer"
-		return 1
-	fi
-	if [[ ! "$fast_threshold_secs" =~ ^[0-9]+$ ]]; then
-		print_error "--fast-threshold must be an integer"
-		return 1
-	fi
-
-	if [[ ! -f "$METRICS_FILE" ]]; then
-		print_info "No runtime metrics recorded yet: $METRICS_FILE"
-		return 0
-	fi
-
-	_execute_metrics_analysis "$role_filter" "$hours" "$model_filter" "$fast_threshold_secs"
-	return 0
 }
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Split `headless-runtime-helper.sh` (2153 lines) into 2 focused files so the orchestrator is below the 2000-line file-size-debt threshold (and ultimately below the 1500-line scanner gate).

| file | lines | scope |
|---|---|---|
| `headless-runtime-helper.sh` | 1984 | thin orchestrator: run lifecycle, invocation, result handling |
| `headless-runtime-helper-cmds.sh` | 208 | CLI commands: select, backoff, session, metrics |

Mirrors the `issue-sync-helper.sh` / `issue-sync-lib.sh` split precedent. Each sub-library has an include guard and a `# shellcheck source=./...` directive paired with an SC1091 disable (runtime-resolved via `$SCRIPT_DIR`, cannot be statically followed without `-x`).

## Changes

1. **2 files** — 1 new sub-library + rewritten orchestrator. No caller-facing API changes; `main()` continues to dispatch all subcommands unchanged.
2. **Defensive `SCRIPT_DIR` fallback** in `headless-runtime-helper-cmds.sh` (derived from `BASH_SOURCE[0]`, matches the `issue-sync-lib.sh` pattern).
3. **Compliant while-loop option parsing** — changed `case "$1" in` to `case "${1:-}" in` (brace form) in the extracted functions so the positional-parameter ratchet gate passes on the new file (pre-existing baseline was 0).
4. **Large functions stay in orchestrator** — `cmd_run` (255 lines), `_invoke_opencode` (227), `_execute_run_attempt` (218), `_handle_run_result` (141), `_cmd_run_finish` (107) all remain in the original file to preserve their `(file, fname)` identity keys.

## Testing

- `shellcheck .agents/scripts/headless-runtime-helper.sh .agents/scripts/headless-runtime-helper-cmds.sh` — clean (SC2016 info is pre-existing at original line 1533)
- Smoke test: `source .agents/scripts/headless-runtime-helper-cmds.sh && type cmd_select cmd_backoff cmd_session cmd_metrics` — all 4 functions resolve
- `wc -l .agents/scripts/headless-runtime-helper.sh` — 1984 (below 2000 threshold)
- Pre-commit hooks: PASS (zero new violations)

## Complexity Bump Justification

**No `complexity-bump-ok` needed.** This split moves functions under 100 lines to a new file:
- `file-size`: orchestrator reduced from 2153 → 1984, new sub-library 208 lines (under 1500 threshold). new=0 regressions.
- `function-complexity`: all functions > 100 lines stayed in the original file. new=0.
- `bash32-compat`: splitting is neutral. new=0.
- `nesting-depth`: using shfmt AST walker (GH#20105); false positives from the old AWK scanner no longer apply.

No `complexity-bump-ok` label required — the split is clean.

Resolves #21813

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-sonnet-4-6 spent 9m and 26,378 tokens on this as a headless worker.
