### PR TITLE
GH#21814: enforce canonical-workspace protection for Edit|Write across all default-branch names

### DIFF
--- a/.agents/hooks/git_safety_guard.py
+++ b/.agents/hooks/git_safety_guard.py
@@ -5,10 +5,17 @@
 Git/filesystem safety guard for Claude Code (PreToolUse hook).
 
 Blocks destructive commands that can lose uncommitted work or delete files.
-Also enforces the main-branch file allowlist (t1712): Edit and Write tool calls
-targeting non-allowlisted paths on main/master are blocked.
+Also enforces the canonical-workspace protection rule (t1712/t1990):
+  - Edit/Write on the default branch: only allowlisted paths permitted
+    (README.md, TODO.md, todo/**) without a linked worktree.
+  - Edit/Write on any non-default branch in the canonical workspace: always
+    denied unless inside a linked worktree. Default branch is auto-detected
+    from origin/HEAD (with fallbacks to init.defaultBranch then "main") so
+    repos using develop/trunk/etc. are covered equally.
 
 This hook runs before Bash/Edit/Write tool calls execute and can deny dangerous operations.
+It is registered under BOTH the 'Bash' AND 'Edit|Write' PreToolUse matchers so that
+the Edit/Write protection branch is reachable (see GH#21814).
 
 Installed by: aidevops setup (setup.sh) or install-hooks-helper.sh
 Location: ~/.aidevops/hooks/git_safety_guard.py
@@ -20,6 +27,10 @@ Adapted for aidevops framework (https://aidevops.sh)
 Exit behavior:
   - Exit 0 with JSON {"hookSpecificOutput": {"permissionDecision": "deny", ...}} = block
   - Exit 0 with no output = allow
+
+Environment overrides:
+  AIDEVOPS_SKIP_CANONICAL_GUARD=1  — bypass the off-default-branch canonical guard
+                                     (use sparingly; document reason at call site)
 """
 import json
 import os
@@ -266,12 +277,98 @@ def _is_main_allowlisted(file_path: str, repo_root: str) -> bool:
     return True
 
 
+def _get_default_branch(repo_root: str) -> str:
+    """Return the default branch name for the repo at repo_root.
+
+    Detection order (first success wins):
+    1. git symbolic-ref --short refs/remotes/origin/HEAD  (strips "origin/" prefix)
+    2. git config --get init.defaultBranch
+    3. literal "main"
+
+    Each step is fail-soft — exceptions and non-zero exits fall through to the next.
+    Result is NOT cached between invocations (the hook runs once per tool call).
+    """
+    # 1. Try origin/HEAD
+    try:
+        result = subprocess.run(
+            ["git", "symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            ref = result.stdout.strip()
+            # Strip "origin/" prefix that git symbolic-ref adds
+            if ref.startswith("origin/"):
+                ref = ref[len("origin/"):]
+            if ref:
+                return ref
+    except Exception:
+        pass
+
+    # 2. Try git config init.defaultBranch
+    try:
+        result = subprocess.run(
+            ["git", "config", "--get", "init.defaultBranch"],
+            capture_output=True,
+            text=True,
+            cwd=repo_root,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            branch = result.stdout.strip()
+            if branch:
+                return branch
+    except Exception:
+        pass
+
+    # 3. Hard fallback
+    return "main"
+
+
+def _build_canonical_off_default_deny(
+    file_path: str, branch: str, default_branch: str
+) -> dict:
+    """Return a deny dict for writes to the canonical workspace on a non-default branch.
+
+    This enforces the t1990 rule: ALL work goes through a linked worktree.
+    The canonical repo directory must stay on the default branch.
+    """
+    return {
+        "hookSpecificOutput": {
+            "hookEventName": "PreToolUse",
+            "permissionDecision": "deny",
+            "permissionDecisionReason": (
+                f"BLOCKED by git_safety_guard.py (aidevops t1990)\n\n"
+                f"Reason: Canonical workspace is on '{branch}' "
+                f"(default branch is '{default_branch}').\n\n"
+                f"Per t1990, ALL work goes through a linked worktree. "
+                f"The canonical repo directory must stay on '{default_branch}'.\n\n"
+                f"Options:\n"
+                f"  (a) Use a linked worktree for this work:\n"
+                f"        wt switch -c feature/your-task-name\n\n"
+                f"  (b) Reset canonical to the default branch:\n"
+                f"        git switch {default_branch}\n\n"
+                f"  (c) Override for this operation (RARE — document reason):\n"
+                f"        AIDEVOPS_SKIP_CANONICAL_GUARD=1 <your-command>"
+            ),
+        }
+    }
+
+
 def _check_main_branch_allowlist(file_path: str) -> "dict | None":
     """Check if an Edit/Write to file_path is allowed on the current branch.
 
+    Enforces two related rules:
+      t1712 — On the default branch: only allowlisted paths may be written
+               without a linked worktree (README.md, TODO.md, todo/**).
+      t1990 — Off the default branch in the canonical workspace: all writes
+               are denied unless inside a linked worktree.
+
     Returns a deny dict if the write should be blocked, None if allowed.
     """
-    # Early exit: invalid inputs or not on protected branch
+    # Early exit: invalid inputs
     if not file_path:
         return None
 
@@ -284,29 +381,46 @@ def _check_main_branch_allowlist(file_path: str) -> "dict | None":
         return None  # Not in a git repo — allow
 
     branch = _get_current_branch(repo_root)
-    if branch not in ("main", "master"):
-        return None  # Not on a protected branch — allow
+    if not branch:
+        return None  # Cannot determine branch — allow
 
-    # On main/master: check if this is a linked worktree (allowed) or main worktree (restricted)
-    if _is_linked_worktree(repo_root) or _is_main_allowlisted(file_path, repo_root):
-        return None  # Linked worktrees or allowlisted paths are allowed
+    # Linked worktrees are always allowed, regardless of branch
+    if _is_linked_worktree(repo_root):
+        return None
 
-    # Deny: not allowlisted
-    return {
-        "hookSpecificOutput": {
-            "hookEventName": "PreToolUse",
-            "permissionDecision": "deny",
-            "permissionDecisionReason": (
-                f"BLOCKED by git_safety_guard.py (aidevops t1712)\n\n"
-                f"Reason: '{file_path}' is not in the main-branch write allowlist.\n\n"
-                f"Allowlisted paths (writable on main without a worktree): "
-                f"README.md, TODO.md, todo/**\n\n"
-                f"All other edits must be made in a linked worktree:\n"
-                f"  wt switch -c feature/your-task-name\n\n"
-                f"This enforces the canonical-repo-on-main policy (t1712)."
-            ),
+    # Explicit escape valve (use sparingly — document reason at call site)
+    if os.environ.get("AIDEVOPS_SKIP_CANONICAL_GUARD"):
+        return None
+
+    # Detect default branch dynamically (replaces hardcoded "main"/"master" check)
+    default_branch = _get_default_branch(repo_root)
+
+    if branch == default_branch:
+        # On the default branch: allowlist governs
+        if _is_main_allowlisted(file_path, repo_root):
+            return None  # Allowlisted path — allow
+
+        # Deny: non-allowlisted path on default branch in canonical workspace
+        return {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": (
+                    f"BLOCKED by git_safety_guard.py (aidevops t1712)\n\n"
+                    f"Reason: '{file_path}' is not in the default-branch write allowlist.\n\n"
+                    f"Allowlisted paths (writable on '{default_branch}' without a worktree): "
+                    f"README.md, TODO.md, todo/**\n\n"
+                    f"All other edits must be made in a linked worktree:\n"
+                    f"  wt switch -c feature/your-task-name\n\n"
+                    f"This enforces the canonical-repo-on-{default_branch} policy (t1712)."
+                ),
+            }
         }
-    }
+    else:
+        # Off the default branch in the canonical workspace: always deny
+        # (workers operate in their own linked worktrees; an off-default canonical
+        # means a prior session left the canonical in a dirty state)
+        return _build_canonical_off_default_deny(file_path, branch, default_branch)
 
 
 def _normalize_absolute_paths(cmd):

--- a/.agents/scripts/install-hooks-helper.sh
+++ b/.agents/scripts/install-hooks-helper.sh
@@ -5,6 +5,9 @@
 #
 # install-hooks-helper.sh
 # Installs Claude Code PreToolUse hooks to block destructive git/filesystem commands
+# and enforce the canonical-workspace protection rule (t1712/t1990, GH#21814).
+# git_safety_guard.py is registered under BOTH the 'Bash' AND 'Edit|Write' matchers
+# so the Edit/Write branch of the hook is reachable by Claude Code.
 #
 # Usage:
 #   install-hooks-helper.sh install              # Install hooks (default)
@@ -663,6 +666,10 @@ settings = {
                 'hooks': [
                     {
                         'type': 'command',
+                        'command': '$HOOK_COMMAND'
+                    },
+                    {
+                        'type': 'command',
                         'command': '$COMPLEXITY_ADVISORY_COMMAND'
                     }
                 ]
@@ -706,19 +713,25 @@ os.rename(tmp, path)
 		return 0
 	fi
 
-	# Check if hook is already configured
+	# Check if hook is already configured (including Edit|Write registration — GH#21814)
 	if python3 -c "
 import json, sys
 with open('$CLAUDE_SETTINGS') as f:
     d = json.load(f)
 hooks = d.get('hooks', {})
-has_pre = False
+has_guard_bash = False
+has_guard_edit_write = False
 has_complexity = False
 for h in hooks.get('PreToolUse', []):
+    matcher = h.get('matcher', '')
     for sub in h.get('hooks', []):
-        if 'git_safety_guard' in sub.get('command', ''):
-            has_pre = True
-        if 'complexity_advisory' in sub.get('command', ''):
+        cmd = sub.get('command', '')
+        if 'git_safety_guard' in cmd:
+            if matcher == 'Bash':
+                has_guard_bash = True
+            if 'Edit' in matcher or 'Write' in matcher:
+                has_guard_edit_write = True
+        if 'complexity_advisory' in cmd:
             has_complexity = True
 
 has_post = False
@@ -730,7 +743,7 @@ for h in hooks.get('PostToolUse', []):
         if 'credential-transcript-scrub' in sub.get('command', ''):
             has_scrub = True
 
-if has_pre and has_complexity and has_post and has_scrub:
+if has_guard_bash and has_guard_edit_write and has_complexity and has_post and has_scrub:
     sys.exit(0)
 sys.exit(1)
 " 2>/dev/null; then
@@ -755,6 +768,28 @@ def has_hook(entries, needle):
                 return True
     return False
 
+def has_hook_in_matcher(entries, matcher_value, needle):
+    # Return True if needle is in hooks of the entry with matcher == matcher_value
+    for entry in entries:
+        if entry.get('matcher') == matcher_value:
+            for sub in entry.get('hooks', []):
+                if needle in sub.get('command', ''):
+                    return True
+    return False
+
+def ensure_hook_in_matcher(entries, matcher_value, hook_cmd):
+    # Ensure hook_cmd is present in the entry with matcher_value (create entry if needed)
+    hook_sub = {'type': 'command', 'command': hook_cmd}
+    for entry in entries:
+        if entry.get('matcher') == matcher_value:
+            cmds = [s.get('command', '') for s in entry.get('hooks', [])]
+            if not any(hook_cmd in c for c in cmds):
+                # Insert at position 0 so git_safety_guard runs before complexity_advisory
+                entry['hooks'].insert(0, hook_sub)
+            return
+    # matcher_value entry not found -- create it
+    entries.append({'matcher': matcher_value, 'hooks': [hook_sub]})
+
 hook_entry = {
     'matcher': 'Bash',
     'hooks': [
@@ -768,6 +803,10 @@ hook_entry = {
 complexity_advisory_entry = {
     'matcher': 'Edit|Write',
     'hooks': [
+        {
+            'type': 'command',
+            'command': '$HOOK_COMMAND'
+        },
         {
             'type': 'command',
             'command': '$COMPLEXITY_ADVISORY_COMMAND'
@@ -800,6 +839,8 @@ if 'PreToolUse' not in settings['hooks']:
 else:
     if not has_hook(settings['hooks']['PreToolUse'], 'git_safety_guard'):
         settings['hooks']['PreToolUse'].append(hook_entry)
+    # Also ensure git_safety_guard is in the Edit|Write matcher (GH#21814)
+    ensure_hook_in_matcher(settings['hooks']['PreToolUse'], 'Edit|Write', '$HOOK_COMMAND')
     if not has_hook(settings['hooks']['PreToolUse'], 'complexity_advisory'):
         settings['hooks']['PreToolUse'].append(complexity_advisory_entry)
 
@@ -951,6 +992,30 @@ _check_status_claude_settings() {
 		print_error "Claude settings: $CLAUDE_SETTINGS not found"
 		return 1
 	fi
+	# Verify git_safety_guard is registered under BOTH Bash AND Edit|Write (GH#21814)
+	if python3 -c "
+import json, sys
+with open('$CLAUDE_SETTINGS') as f:
+    d = json.load(f)
+hooks = d.get('hooks', {}).get('PreToolUse', [])
+has_bash = False
+has_edit_write = False
+for h in hooks:
+    matcher = h.get('matcher', '')
+    for sub in h.get('hooks', []):
+        if 'git_safety_guard' in sub.get('command', ''):
+            if matcher == 'Bash':
+                has_bash = True
+            if 'Edit' in matcher or 'Write' in matcher:
+                has_edit_write = True
+if has_bash and has_edit_write:
+    sys.exit(0)
+sys.exit(1)
+" 2>/dev/null; then
+		print_success "Claude settings: hook configured (Bash + Edit|Write)"
+		return 0
+	fi
+	# Partial registration (old install): only in Bash
 	if python3 -c "
 import json, sys
 with open('$CLAUDE_SETTINGS') as f:
@@ -962,10 +1027,10 @@ for h in hooks:
             sys.exit(0)
 sys.exit(1)
 " 2>/dev/null; then
-		print_success "Claude settings: hook configured"
-		return 0
+		print_warning "Claude settings: hook in Bash only — Edit|Write registration missing (re-run: install-hooks-helper.sh install)"
+		return 1
 	fi
-	print_warning "Claude settings: exists but hook not configured"
+	print_warning "Claude settings: exists but hook not configured (run: install-hooks-helper.sh install)"
 	return 1
 }
 

--- a/.agents/scripts/tests/test-git-safety-guard.sh
+++ b/.agents/scripts/tests/test-git-safety-guard.sh
@@ -1,0 +1,409 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-git-safety-guard.sh
+# Tests for git_safety_guard.py covering GH#21814 changes:
+#   - Dynamic default-branch detection (replaces hardcoded "main"/"master")
+#   - Off-default-branch canonical-workspace protection (t1990)
+#   - AIDEVOPS_SKIP_CANONICAL_GUARD=1 escape valve
+#   - Bash-matcher destructive-command checks (regression)
+#
+# Modelled on test-pre-edit-check.sh for structure.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+HOOK="${SCRIPT_DIR}/../../hooks/git_safety_guard.py"
+
+if [[ ! -f "$HOOK" ]]; then
+	printf 'ERROR: Hook not found at %s\n' "$HOOK" >&2
+	exit 1
+fi
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_test_repo() {
+	TEST_ROOT=$(mktemp -d)
+	# Resolve symlinks so paths are consistent with what git returns
+	# (macOS: mktemp returns /var/... which is a symlink to /private/var/...)
+	TEST_ROOT=$(cd "$TEST_ROOT" && pwd -P)
+	git -C "$TEST_ROOT" init -b main >/dev/null 2>&1 || {
+		git -C "$TEST_ROOT" init >/dev/null 2>&1
+		git -C "$TEST_ROOT" checkout -b main >/dev/null 2>&1
+	}
+	git -C "$TEST_ROOT" config user.name "Aidevops Test"
+	git -C "$TEST_ROOT" config user.email "test@example.com"
+	# Disable commit signing for the test repo so commits don't prompt for a passphrase
+	git -C "$TEST_ROOT" config commit.gpgsign false
+	git -C "$TEST_ROOT" config tag.gpgsign false
+	mkdir -p "${TEST_ROOT}/src" "${TEST_ROOT}/todo"
+	printf 'readme\n' >"${TEST_ROOT}/README.md"
+	printf '# TODO\n' >"${TEST_ROOT}/TODO.md"
+	printf 'tasks\n' >"${TEST_ROOT}/todo/tasks.md"
+	printf 'code\n' >"${TEST_ROOT}/src/foo.ts"
+	git -C "$TEST_ROOT" add .
+	git -C "$TEST_ROOT" commit -m "test: seed repo" >/dev/null 2>&1
+	return 0
+}
+
+teardown_test_repo() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+# Run the hook from a given cwd with JSON on stdin.
+# Additional args are passed as env vars via 'env KEY=VALUE ...'.
+run_hook() {
+	local cwd="$1"
+	local json="$2"
+	shift 2
+	(
+		cd "$cwd" || exit 1
+		if [[ $# -gt 0 ]]; then
+			env "$@" python3 "$HOOK" <<<"$json"
+		else
+			python3 "$HOOK" <<<"$json"
+		fi
+	)
+	return $?
+}
+
+# Helper: assert output contains permissionDecision=deny and an optional keyword in reason.
+output_is_deny() {
+	local output="$1"
+	local keyword="${2:-}"
+	python3 -c "
+import json, sys
+if not '$output'.strip():
+    sys.exit(1)
+try:
+    d = json.loads('$output'.replace(\"'\", '\"'))
+    h = d.get('hookSpecificOutput', {})
+except Exception:
+    sys.exit(1)
+if h.get('permissionDecision') != 'deny':
+    sys.exit(1)
+if '$keyword' and '$keyword' not in h.get('permissionDecisionReason', ''):
+    sys.exit(1)
+sys.exit(0)
+" 2>/dev/null
+}
+
+# Helper: pass JSON output through Python for reliable field extraction.
+hook_is_deny() {
+	local output="$1"
+	local keyword="${2:-}"
+	[[ -n "$output" ]] || return 1
+	python3 - "$output" "$keyword" <<'PYEOF' 2>/dev/null
+import json, sys
+raw = sys.argv[1]
+keyword = sys.argv[2]
+try:
+    d = json.loads(raw)
+except Exception:
+    sys.exit(1)
+h = d.get('hookSpecificOutput', {})
+if h.get('permissionDecision') != 'deny':
+    sys.exit(1)
+if keyword and keyword not in h.get('permissionDecisionReason', ''):
+    sys.exit(1)
+sys.exit(0)
+PYEOF
+}
+
+# =============================================================================
+# Test 1: Default-branch detection from origin/HEAD → origin/develop
+# =============================================================================
+test_default_branch_detection_from_origin_head() {
+	# Create a 'develop' branch and set origin/HEAD to point to it
+	git -C "$TEST_ROOT" checkout -b develop >/dev/null 2>&1
+	git -C "$TEST_ROOT" symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/develop 2>/dev/null || true
+
+	# On the 'develop' branch (now the default), edit a non-allowlisted file
+	local json
+	json=$(printf '{"tool_name":"Edit","tool_input":{"filePath":"%s/src/foo.ts"}}' "$TEST_ROOT")
+
+	local output=""
+	output=$(run_hook "$TEST_ROOT" "$json") || true
+
+	if hook_is_deny "$output" "t1712" && hook_is_deny "$output" "develop"; then
+		print_result "default-branch detection from origin/HEAD (develop denied with t1712)" 0
+	else
+		print_result "default-branch detection from origin/HEAD (develop denied with t1712)" 1 "output=${output}"
+	fi
+
+	# Cleanup: back to main
+	git -C "$TEST_ROOT" checkout main >/dev/null 2>&1 || true
+	git -C "$TEST_ROOT" branch -D develop >/dev/null 2>&1 || true
+	git -C "$TEST_ROOT" symbolic-ref --delete refs/remotes/origin/HEAD 2>/dev/null || true
+	return 0
+}
+
+# =============================================================================
+# Test 2: Off-default-branch in canonical workspace → denied with t1990 reason
+# =============================================================================
+test_off_default_branch_canonical_denied() {
+	git -C "$TEST_ROOT" checkout -b feature/test-off-default >/dev/null 2>&1
+
+	local json
+	json=$(printf '{"tool_name":"Edit","tool_input":{"filePath":"%s/src/foo.ts"}}' "$TEST_ROOT")
+
+	local output=""
+	output=$(run_hook "$TEST_ROOT" "$json") || true
+
+	if hook_is_deny "$output" "t1990" && hook_is_deny "$output" "feature/test-off-default"; then
+		print_result "off-default-branch in canonical workspace is denied (t1990)" 0
+	else
+		print_result "off-default-branch in canonical workspace is denied (t1990)" 1 "output=${output}"
+	fi
+
+	git -C "$TEST_ROOT" checkout main >/dev/null 2>&1 || true
+	git -C "$TEST_ROOT" branch -D feature/test-off-default >/dev/null 2>&1 || true
+	return 0
+}
+
+# =============================================================================
+# Test 3: Off-default-branch in linked worktree → allowed
+# =============================================================================
+test_off_default_branch_in_linked_worktree_allowed() {
+	local worktree_path="${TEST_ROOT}/linked-wt"
+	git -C "$TEST_ROOT" worktree add "$worktree_path" -b feature/linked-test >/dev/null 2>&1
+
+	local json
+	json=$(printf '{"tool_name":"Edit","tool_input":{"filePath":"%s/src/foo.ts"}}' "$worktree_path")
+
+	local output=""
+	output=$(run_hook "$worktree_path" "$json") || true
+
+	if [[ -z "$output" ]]; then
+		print_result "off-default-branch edit in linked worktree is allowed (no output)" 0
+	else
+		print_result "off-default-branch edit in linked worktree is allowed (no output)" 1 "output=${output}"
+	fi
+
+	git -C "$TEST_ROOT" worktree remove "$worktree_path" 2>/dev/null || rm -rf "$worktree_path"
+	git -C "$TEST_ROOT" branch -D feature/linked-test 2>/dev/null || true
+	return 0
+}
+
+# =============================================================================
+# Test 4: Default-branch allowlist preserved (README.md, TODO.md, todo/*)
+# =============================================================================
+test_default_branch_allowlisted_paths_allowed() {
+	# Repo is on main (default branch)
+	local passed=0
+
+	for allowed_path in "README.md" "TODO.md" "todo/tasks.md"; do
+		local json
+		json=$(printf '{"tool_name":"Edit","tool_input":{"filePath":"%s/%s"}}' "$TEST_ROOT" "$allowed_path")
+
+		local output=""
+		output=$(run_hook "$TEST_ROOT" "$json") || true
+
+		if [[ -n "$output" ]]; then
+			print_result "allowlisted path '${allowed_path}' allowed on default branch" 1 "output=${output}"
+			passed=1
+		fi
+	done
+
+	if [[ "$passed" -eq 0 ]]; then
+		print_result "allowlisted paths (README.md, TODO.md, todo/*) allowed on default branch" 0
+	fi
+	return 0
+}
+
+# =============================================================================
+# Test 5: Default-branch non-allowlisted path → denied with t1712 reason
+# =============================================================================
+test_default_branch_non_allowlisted_denied() {
+	local json
+	json=$(printf '{"tool_name":"Edit","tool_input":{"filePath":"%s/src/foo.ts"}}' "$TEST_ROOT")
+
+	local output=""
+	output=$(run_hook "$TEST_ROOT" "$json") || true
+
+	if hook_is_deny "$output" "t1712"; then
+		print_result "non-allowlisted path denied on default branch (t1712)" 0
+	else
+		print_result "non-allowlisted path denied on default branch (t1712)" 1 "output=${output}"
+	fi
+	return 0
+}
+
+# =============================================================================
+# Test 6: Bash matcher — destructive commands still blocked; safe ones allowed
+# =============================================================================
+test_bash_destructive_commands_blocked() {
+	local passed=0
+
+	# rm -rf on non-temp path should be denied
+	local json
+	json='{"tool_name":"Bash","tool_input":{"command":"rm -rf /some/path"}}'
+	local output=""
+	output=$(run_hook "$TEST_ROOT" "$json") || true
+	if ! hook_is_deny "$output" "rm -rf"; then
+		print_result "rm -rf blocked by Bash matcher" 1 "output=${output}"
+		passed=1
+	fi
+
+	# git reset --hard should be denied
+	json='{"tool_name":"Bash","tool_input":{"command":"git reset --hard HEAD"}}'
+	output=$(run_hook "$TEST_ROOT" "$json") || true
+	if ! hook_is_deny "$output" ""; then
+		print_result "git reset --hard blocked by Bash matcher" 1 "output=${output}"
+		passed=1
+	fi
+
+	# git checkout -b (safe branch creation) should be allowed
+	json='{"tool_name":"Bash","tool_input":{"command":"git checkout -b feature/new-branch"}}'
+	output=$(run_hook "$TEST_ROOT" "$json") || true
+	if [[ -n "$output" ]]; then
+		print_result "git checkout -b allowed by Bash matcher (safe)" 1 "output=${output}"
+		passed=1
+	fi
+
+	if [[ "$passed" -eq 0 ]]; then
+		print_result "Bash matcher unchanged: destructive blocked, safe allowed" 0
+	fi
+	return 0
+}
+
+# =============================================================================
+# Test 7: Repo without origin/HEAD → fallback to init.defaultBranch then "main"
+# =============================================================================
+test_no_origin_head_falls_back_to_main() {
+	# Fresh temp repo with no remotes — falls back to "main"
+	local fresh_root
+	fresh_root=$(mktemp -d)
+	fresh_root=$(cd "$fresh_root" && pwd -P)
+	git -C "$fresh_root" init -b main >/dev/null 2>&1 || {
+		git -C "$fresh_root" init >/dev/null 2>&1
+		git -C "$fresh_root" checkout -b main >/dev/null 2>&1
+	}
+	git -C "$fresh_root" config user.name "Test"
+	git -C "$fresh_root" config user.email "test@example.com"
+	git -C "$fresh_root" config commit.gpgsign false
+	git -C "$fresh_root" config tag.gpgsign false
+	mkdir -p "${fresh_root}/src"
+	printf 'code\n' >"${fresh_root}/src/app.ts"
+	git -C "$fresh_root" add .
+	git -C "$fresh_root" commit -m "test: seed" >/dev/null 2>&1
+
+	# On main (default), edit a non-allowlisted file — should get t1712 deny (not crash)
+	local json
+	json=$(printf '{"tool_name":"Edit","tool_input":{"filePath":"%s/src/app.ts"}}' "$fresh_root")
+
+	local output=""
+	local exit_code=0
+	output=$(run_hook "$fresh_root" "$json") || exit_code=$?
+
+	if [[ "$exit_code" -eq 0 ]] && hook_is_deny "$output" "t1712"; then
+		print_result "no origin/HEAD: falls back cleanly, enforces t1712 on main" 0
+	else
+		print_result "no origin/HEAD: falls back cleanly, enforces t1712 on main" 1 "exit=${exit_code} output=${output}"
+	fi
+
+	rm -rf "$fresh_root"
+	return 0
+}
+
+# =============================================================================
+# Test 8: AIDEVOPS_SKIP_CANONICAL_GUARD=1 bypasses off-default-branch deny;
+#          FULL_LOOP_HEADLESS=1 alone does NOT bypass (workers use worktrees)
+# =============================================================================
+test_canonical_guard_skip_env_var() {
+	git -C "$TEST_ROOT" checkout -b feature/guard-skip-test >/dev/null 2>&1
+
+	local json
+	json=$(printf '{"tool_name":"Edit","tool_input":{"filePath":"%s/src/foo.ts"}}' "$TEST_ROOT")
+
+	# Without env var: should be denied
+	local output_default=""
+	output_default=$(run_hook "$TEST_ROOT" "$json") || true
+
+	# With FULL_LOOP_HEADLESS=1 alone: still denied (workers should use worktrees)
+	local output_headless=""
+	output_headless=$(run_hook "$TEST_ROOT" "$json" "FULL_LOOP_HEADLESS=1") || true
+
+	# With AIDEVOPS_SKIP_CANONICAL_GUARD=1: allowed (explicit escape valve)
+	local output_skip=""
+	output_skip=$(run_hook "$TEST_ROOT" "$json" "AIDEVOPS_SKIP_CANONICAL_GUARD=1") || true
+
+	local passed=0
+
+	if ! hook_is_deny "$output_default" "t1990"; then
+		print_result "canonical guard: off-default-branch denied without env override" 1 "output=${output_default}"
+		passed=1
+	fi
+	if ! hook_is_deny "$output_headless" "t1990"; then
+		print_result "canonical guard: FULL_LOOP_HEADLESS=1 alone does NOT bypass deny" 1 "output=${output_headless}"
+		passed=1
+	fi
+	if [[ -n "$output_skip" ]]; then
+		print_result "canonical guard: AIDEVOPS_SKIP_CANONICAL_GUARD=1 bypasses deny (allow)" 1 "output=${output_skip}"
+		passed=1
+	fi
+
+	if [[ "$passed" -eq 0 ]]; then
+		print_result "canonical guard: env-var bypass behaviour correct" 0
+	fi
+
+	git -C "$TEST_ROOT" checkout main >/dev/null 2>&1 || true
+	git -C "$TEST_ROOT" branch -D feature/guard-skip-test >/dev/null 2>&1 || true
+	return 0
+}
+
+# =============================================================================
+# Main
+# =============================================================================
+main() {
+	setup_test_repo
+
+	test_default_branch_detection_from_origin_head
+	test_off_default_branch_canonical_denied
+	test_off_default_branch_in_linked_worktree_allowed
+	test_default_branch_allowlisted_paths_allowed
+	test_default_branch_non_allowlisted_denied
+	test_bash_destructive_commands_blocked
+	test_no_origin_head_falls_back_to_main
+	test_canonical_guard_skip_env_var
+
+	teardown_test_repo
+
+	printf '\n%d tests run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Closes three independent gaps that allowed silent Edit/Write on the canonical workspace (GH#21814).

### Changes

**1. `.agents/hooks/git_safety_guard.py`**
- Adds `_get_default_branch(repo_root)`: detects default branch from `origin/HEAD` symref (strips `origin/` prefix), falls back to `git config init.defaultBranch`, then `"main"`. Removes the hardcoded `("main", "master")` literal.
- Adds `_build_canonical_off_default_deny()`: returns a clear deny dict (t1990 reference) when the canonical workspace is on a non-default branch.
- Rewrites `_check_main_branch_allowlist()`: linked worktrees always allowed; on default branch, allowlist governs (unchanged); off default branch in canonical → denied. `AIDEVOPS_SKIP_CANONICAL_GUARD=1` provides an escape valve.

**2. `.agents/scripts/install-hooks-helper.sh`**
- Adds `git_safety_guard.py` to the `Edit|Write` PreToolUse matcher (as first hook, before `complexity_advisory_pre_edit.py`). The Edit/Write code path in the hook was dead code under the prior install.
- Adds `has_hook_in_matcher()` and `ensure_hook_in_matcher()` helpers for idempotent dual-matcher registration.
- Updates idempotency check to verify hook is in both `Bash` AND `Edit|Write` matchers.
- Updates `_check_status_claude_settings()` to detect partial (Bash-only) registration and prompt reinstall.

**3. `.agents/scripts/tests/test-git-safety-guard.sh`** (NEW)
- 8 test cases: default-branch detection (develop via origin/HEAD), off-default-branch canonical deny (t1990), linked-worktree allow, allowlist preservation (README.md/TODO.md/todo/*), non-allowlisted deny (t1712), Bash-matcher regression (rm -rf/git reset --hard blocked; git checkout -b allowed), origin/HEAD-less fallback to main, AIDEVOPS_SKIP_CANONICAL_GUARD bypass.

### Verification

- `python3 -m py_compile .agents/hooks/git_safety_guard.py` — OK
- `shellcheck .agents/scripts/install-hooks-helper.sh` — zero violations
- `shellcheck .agents/scripts/tests/test-git-safety-guard.sh` — zero violations
- `bash .agents/scripts/tests/test-git-safety-guard.sh` — 8/8 PASS
- `bash .agents/scripts/tests/test-install-hooks-validator-preflight.sh` — 8/8 PASS

Resolves #21814

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-sonnet-4-6 spent 15m and 44,093 tokens on this as a headless worker.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.10 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-sonnet-4-6 spent 16m and 44,995 tokens on this as a headless worker.
