### PR TITLE
t3072: runtime-health-audit routine surfaces operational regressions invisible to supervisor LLM

### DIFF
--- a/.agents/reference/routines.md
+++ b/.agents/reference/routines.md
@@ -52,3 +52,34 @@ Use `run:` for scripts, exports, health checks. Use `agent:` when judgment or su
 - Running deterministic scripts through an LLM agent
 - Schedule semantics outside version control
 - Collapsing SOP, targets, and schedule into a single prompt — keep them independent
+
+## Runtime Health Audit (r-runtime-audit, t3072)
+
+The supervisor LLM cycle triages GitHub state — issues, PRs, labels, scanner findings — but never inspects processes, logs, pulse-stats counters, or deployed-script mtimes. That gap is a structural blind spot: bugs visible to any operator running `ps`, `jq`, `tail` go unraised for hours.
+
+`r-runtime-audit` runs a registry of small detectors against **local files only** — no GitHub API or GraphQL calls (which would amplify the blind spot many of the detectors surface). When a detector fires, the orchestrator either prints the finding (`--dry-run`, default) or files an auto-dispatch issue tagged with `<!-- aidevops:generator=runtime-audit detector=<id> -->`. The pre-dispatch validator re-runs the cited detector before any worker spawns, so transient regressions (the kind that resolve before a worker arrives) are auto-closed instead of consuming worker time.
+
+### Detectors
+
+| ID | Surfaces |
+|----|----------|
+| `counter-trend-delta` | 3x regression in any pulse-stats counter over the last 4h vs prior 4h |
+| `process-count-anomaly` | More than 5 `pulse-wrapper.sh` processes (lifecycle reap leak) |
+| `deployed-vs-source-mtime-drift` | Hot deployed script lags source by >24h (stale deploy) |
+| `log-pattern-novelty` | New high-frequency log template absent from prior baseline |
+| `idle-state-stuck` | `pulse.pid` shows `SETUP:<pid>` with a dead PID (lifecycle wedged) |
+
+Each detector lives in `.agents/scripts/runtime-audit-rules/<id>.sh` as a self-contained file with `runtime_audit_id` + `runtime_audit_check` functions. To add a new detector, copy any existing rule file and add a fixture pair to `.agents/scripts/tests/test-runtime-audit-detectors.sh`.
+
+### Operator workflow
+
+1. **Dry-run first.** The routine ships **disabled** in `TODO.md` so the operator can review baseline noise: `runtime-health-audit-helper.sh --dry-run`.
+2. **Tune thresholds.** Each detector has env-overridable inputs (e.g. `REGRESSION_MULT`, `LEAK_THRESHOLD`, `DRIFT_SECONDS`). If the dry-run flags benign conditions, raise the threshold or add the routine entry to `~/.aidevops/cron-overrides.conf` with custom env.
+3. **Enable.** Flip the `[ ]` to `[x]` in the `## Routines` block once you're satisfied.
+4. **Investigate findings.** Filed issues are real — they cite local files an operator can confirm in seconds. Close with rationale if benign; otherwise the issue body itself contains the worker-ready brief (file paths, verification commands, acceptance criteria) per t1900.
+
+### Anti-patterns specific to this routine
+
+- **Adding a detector that calls `gh`, `curl`, or any network API.** The whole point is local-only inspection — network calls amplify the very blind spot we're closing.
+- **Filing a finding without a marker.** The marker is what the pre-dispatch validator uses to re-check before dispatch. Without it, stale findings consume worker time.
+- **Lowering thresholds to surface "everything".** Every false positive trains the operator to ignore the routine. Tune for high precision; the supervisor's task triage is the lower-precision layer.

--- a/.agents/scripts/pre-dispatch-validator-helper.sh
+++ b/.agents/scripts/pre-dispatch-validator-helper.sh
@@ -106,6 +106,7 @@ _register_validators() {
 	_VALIDATOR_REGISTRY["large-file-simplification-gate"]="_validator_large_file_simplification_gate"
 	_VALIDATOR_REGISTRY["function-complexity-gate"]="_validator_function_complexity_gate"
 	_VALIDATOR_REGISTRY["upstream-watch"]="_validator_upstream_watch"
+	_VALIDATOR_REGISTRY["runtime-audit"]="_validator_runtime_audit"
 	return 0
 }
 
@@ -255,6 +256,62 @@ _validator_function_complexity_gate() {
 		VALIDATOR_RATIONALE="File \`${CITED_FILE}\` has 0 functions exceeding ${CITED_THRESHOLD} lines on HEAD. Premise falsified. Not dispatching."
 		return 10
 	fi
+
+# ---------------------------------------------------------------------------
+# Runtime-audit validator (t3072)
+#
+# Re-runs the cited detector against current local state. Detectors are
+# self-contained and read local files only — no GitHub API calls — so
+# the re-validation cost is seconds and bounded.
+#
+# Expects DETECTOR_ID to be set by cmd_validate() after parsing the
+# detector=<id> attribute from the generator marker. If the detector now
+# returns 0 (no finding), the premise is falsified — the underlying
+# regression has resolved between detection and dispatch.
+# ---------------------------------------------------------------------------
+_validator_runtime_audit() {
+	local slug="$1"
+	# slug is passed for parity with other validators but is unused: the
+	# detectors run against local pulse state, not remote git state.
+	# (lint-friendly no-op assignment to mark intent)
+	: "$slug"
+
+	if [[ -z "${DETECTOR_ID:-}" ]]; then
+		_log "WARN" "runtime-audit validator: missing detector=<id> attribute in marker"
+		return 20
+	fi
+
+	local rules_dir="${RUNTIME_AUDIT_RULES_DIR:-${SCRIPT_DIR}/runtime-audit-rules}"
+	local detector_file="${rules_dir}/${DETECTOR_ID}.sh"
+
+	if [[ ! -f "$detector_file" ]]; then
+		_log "WARN" "runtime-audit validator: detector file not found: ${detector_file}"
+		return 20
+	fi
+
+	# Re-run the detector in a clean subshell so its globals do not leak.
+	local detector_rc=0
+	bash -c "
+		set -u
+		source '${SCRIPT_DIR}/shared-constants.sh'
+		source '${detector_file}'
+		runtime_audit_check >/dev/null
+	" || detector_rc=$?
+
+	if [[ "$detector_rc" -eq 0 ]]; then
+		_log "INFO" "runtime-audit validator: detector=${DETECTOR_ID} now returns clean — premise falsified"
+		VALIDATOR_RATIONALE="Re-running detector \`${DETECTOR_ID}\` against current local state shows no finding. The underlying regression resolved between detection and dispatch."
+		return 10
+	fi
+
+	if [[ "$detector_rc" -eq 1 ]]; then
+		_log "INFO" "runtime-audit validator: detector=${DETECTOR_ID} still firing — premise holds"
+		return 0
+	fi
+
+	_log "WARN" "runtime-audit validator: detector=${DETECTOR_ID} returned rc=${detector_rc} (unexpected) — validator error"
+	return 20
+}
 
 	_log "INFO" "function-complexity-gate validator: ${violation_count} function(s) still exceed ${CITED_THRESHOLD} lines in ${CITED_FILE} — premise holds"
 	return 0
@@ -599,12 +656,13 @@ cmd_validate() {
 		return 0
 	fi
 
-	# Extract optional attributes: cited_file, threshold, upstream_slug
+	# Extract optional attributes: cited_file, threshold, upstream_slug, detector
 	CITED_FILE=$(printf '%s' "$generator_line" | grep -oE 'cited_file=[^ >]+' | sed 's/cited_file=//' 2>/dev/null) || CITED_FILE=""
 	CITED_THRESHOLD=$(printf '%s' "$generator_line" | grep -oE 'threshold=[0-9]+' | sed 's/threshold=//' 2>/dev/null) || CITED_THRESHOLD=""
 	UPSTREAM_SLUG=$(printf '%s' "$generator_line" | grep -oE 'upstream_slug=[^ >]+' | sed 's/upstream_slug=//' 2>/dev/null) || UPSTREAM_SLUG=""
+	DETECTOR_ID=$(printf '%s' "$generator_line" | grep -oE 'detector=[a-z0-9_-]+' | sed 's/detector=//' 2>/dev/null) || DETECTOR_ID=""
 
-	_log "INFO" "#${issue_number}: generator=${generator} cited_file=${CITED_FILE:-<none>} threshold=${CITED_THRESHOLD:-<none>}"
+	_log "INFO" "#${issue_number}: generator=${generator} cited_file=${CITED_FILE:-<none>} threshold=${CITED_THRESHOLD:-<none>} detector=${DETECTOR_ID:-<none>}"
 
 	# Look up validator
 	_register_validators

--- a/.agents/scripts/runtime-audit-rules/counter-trend-delta.sh
+++ b/.agents/scripts/runtime-audit-rules/counter-trend-delta.sh
@@ -1,0 +1,126 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# counter-trend-delta.sh — Detect 3x regression in pulse counter rate (t3072).
+#
+# Reads $STATS_FILE (default ~/.aidevops/logs/pulse-stats.json) and computes
+# the count of timestamps in the last $WINDOW_SECONDS vs the prior window of
+# the same length. Flags any counter where recent_count >= prior_count*3 AND
+# prior_count >= MIN_BASELINE (so a quiet period followed by a single tick
+# does not trip the detector).
+#
+# Output (stdout, only when returning 1):
+#   One JSON object per line: {id, title, body}
+#
+# Inputs (env, all overridable for tests):
+#   STATS_FILE        path to pulse-stats.json (default ~/.aidevops/logs/pulse-stats.json)
+#   NOW_EPOCH         "current" epoch (default $(date +%s))
+#   WINDOW_SECONDS    window size in seconds (default 14400 = 4h)
+#   REGRESSION_MULT   multiplier threshold (default 3)
+#   MIN_BASELINE      minimum prior-window count to flag (default 3)
+#
+# Function contract:
+#   runtime_audit_check  — returns 0 (no finding) or 1 (finding)
+#
+# Anti-pattern guard: this detector never makes a network or gh call.
+# It reads pulse-stats.json only; reading the file we want to surface
+# regressions in is the entire point.
+
+# shellcheck shell=bash
+
+runtime_audit_id() { printf 'counter-trend-delta\n'; return 0; }
+
+runtime_audit_check() {
+	local stats_file="${STATS_FILE:-${HOME}/.aidevops/logs/pulse-stats.json}"
+	local now_epoch="${NOW_EPOCH:-$(date +%s)}"
+	local window="${WINDOW_SECONDS:-14400}"
+	local mult="${REGRESSION_MULT:-3}"
+	local min_baseline="${MIN_BASELINE:-3}"
+
+	if [[ ! -f "$stats_file" ]]; then
+		return 0
+	fi
+
+	local recent_start=$((now_epoch - window))
+	local prior_start=$((recent_start - window))
+
+	# Use jq to compute regressions in one pass. Output is one line per
+	# regressed counter: "<name>\t<recent>\t<prior>\t<ratio>".
+	local regressions
+	regressions=$(jq -r --argjson now "$now_epoch" --argjson win "$window" \
+		--argjson mult "$mult" --argjson min_base "$min_baseline" '
+		.counters // {}
+		| to_entries
+		| map(select(.value | type == "array"))
+		| map({
+			name: .key,
+			recent: ([.value[] | select(. >= ($now - $win) and . <= $now)] | length),
+			prior:  ([.value[] | select(. >= ($now - 2*$win) and . < ($now - $win))] | length)
+		})
+		| map(select(.prior >= $min_base and .recent >= .prior * $mult))
+		| .[] | "\(.name)\t\(.recent)\t\(.prior)\t\((.recent/.prior)|tostring|.[0:5])"
+	' "$stats_file" 2>/dev/null) || regressions=""
+
+	if [[ -z "$regressions" ]]; then
+		return 0
+	fi
+
+	# Build evidence table for the body
+	local evidence_table
+	evidence_table=$(printf '| Counter | Last %dh | Prior %dh | Ratio |\n| --- | --- | --- | --- |\n' \
+		"$((window / 3600))" "$((window / 3600))")
+	while IFS=$'\t' read -r name recent prior ratio; do
+		# shellcheck disable=SC2016  # intentional literal markdown backticks
+		evidence_table+=$(printf '\n| `%s` | %s | %s | %sx |' "$name" "$recent" "$prior" "$ratio")
+	done <<<"$regressions"
+
+	local first_counter
+	first_counter=$(printf '%s\n' "$regressions" | head -1 | cut -f1)
+
+	local title="runtime-audit: counter regression detected (\`${first_counter}\`)"
+	local body
+	body=$(cat <<MARKDOWN
+## Task
+
+A pulse counter has regressed sharply in the last $((window / 3600))h compared to the prior $((window / 3600))h window. This is the kind of trend shift that the supervisor LLM cycle does not detect because it never reads \`pulse-stats.json\` directly — it relies on issue and PR state.
+
+## Evidence
+
+${evidence_table}
+
+Counter source: \`${stats_file/#$HOME/\~}\`
+
+## Why
+
+Sharp counter regressions are the supervisor's structural blind spot — they appear in operational state long before they manifest as failed issues. Each regression cited above warrants investigation: a 3x-or-greater jump on a counter usually means a config change, a new bottleneck, or a regression in a recently-deployed script.
+
+## How
+
+1. Read the relevant pulse-stats counter array directly: \`jq '.counters.${first_counter}' $stats_file\` and look for the time-stamp clusters.
+2. Cross-reference with \`~/.aidevops/logs/pulse-wrapper.log\` for the same window using \`grep\` on the counter name or related script names.
+3. Check recent commits to the script that emits this counter: \`git log --since="24 hours ago" -- .agents/scripts/\`.
+4. If a fix is identified, file a separate task with the implementation pattern.
+5. If no fix is needed (e.g. the regression is a healthy response to load), close this issue with that rationale.
+
+## Acceptance Criteria
+
+1. Root cause identified for each regressed counter listed above.
+2. Either a fix PR linked to this issue, or a closing comment explaining why the regression is benign.
+
+## Verification
+
+Run the audit again after the fix lands:
+\`\`\`
+~/.aidevops/agents/scripts/runtime-health-audit-helper.sh --dry-run
+\`\`\`
+The regression block for the cited counters should no longer appear.
+
+<!-- aidevops:generator=runtime-audit detector=counter-trend-delta -->
+MARKDOWN
+)
+
+	jq -n --arg id "counter-trend-delta" --arg title "$title" --arg body "$body" \
+		'{id: $id, title: $title, body: $body}'
+	return 1
+}

--- a/.agents/scripts/runtime-audit-rules/deployed-vs-source-mtime-drift.sh
+++ b/.agents/scripts/runtime-audit-rules/deployed-vs-source-mtime-drift.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# deployed-vs-source-mtime-drift.sh — Flag stale deployed scripts (t3072).
+#
+# For each hot file in $WATCHED_FILES, compares the deployed copy at
+# ~/.aidevops/agents/scripts/<f> to the source at ~/Git/aidevops/.agents/
+# scripts/<f>. If the deployed mtime is older than the source mtime by
+# more than $DRIFT_SECONDS (default 86400 = 24h), files a finding.
+#
+# This catches the canonical "fix landed in source but never deployed"
+# bug that t2036 documented as a recurring footgun.
+#
+# Inputs (env):
+#   AIDEVOPS_DEPLOYED_DIR  default ~/.aidevops/agents/scripts
+#   AIDEVOPS_SOURCE_DIR    default ~/Git/aidevops/.agents/scripts
+#   DRIFT_SECONDS          default 86400 (24h)
+#   WATCHED_FILES          default canonical hot-file set (space-separated)
+#
+# Function contract: runtime_audit_check returns 0/1; emits one JSON line.
+
+# shellcheck shell=bash
+
+runtime_audit_id() { printf 'deployed-vs-source-mtime-drift\n'; return 0; }
+
+runtime_audit_check() {
+	local deployed_dir="${AIDEVOPS_DEPLOYED_DIR:-${HOME}/.aidevops/agents/scripts}"
+	local source_dir="${AIDEVOPS_SOURCE_DIR:-${HOME}/Git/aidevops/.agents/scripts}"
+	local drift="${DRIFT_SECONDS:-86400}"
+	# Default watched set: hot files most likely to be runtime-relevant
+	local files="${WATCHED_FILES:-pulse-wrapper.sh pulse-merge.sh pulse-merge-process.sh pulse-cleanup.sh dispatch-dedup-helper.sh}"
+
+	if [[ ! -d "$deployed_dir" || ! -d "$source_dir" ]]; then
+		return 0
+	fi
+
+	local now_epoch="${NOW_EPOCH:-$(date +%s)}"
+	local drifted=()
+	local f deployed_mtime source_mtime delta
+	# shellcheck disable=SC2086  # word-splitting is intentional for $files
+	for f in $files; do
+		[[ -f "${deployed_dir}/${f}" && -f "${source_dir}/${f}" ]] || continue
+		deployed_mtime=$(_file_mtime_epoch "${deployed_dir}/${f}" 2>/dev/null) || deployed_mtime=0
+		source_mtime=$(_file_mtime_epoch "${source_dir}/${f}" 2>/dev/null) || source_mtime=0
+		[[ -z "$deployed_mtime" || -z "$source_mtime" ]] && continue
+		delta=$((source_mtime - deployed_mtime))
+		if [[ "$delta" -gt "$drift" ]]; then
+			drifted+=("${f}|${delta}|${deployed_mtime}|${source_mtime}")
+		fi
+		# Sanity: also flag if deployed is ahead of "now" + 1h (clock skew)
+		if [[ "$deployed_mtime" -gt $((now_epoch + 3600)) ]]; then
+			drifted+=("${f}|FUTURE_MTIME|${deployed_mtime}|${now_epoch}")
+		fi
+	done
+
+	if [[ ${#drifted[@]} -eq 0 ]]; then
+		return 0
+	fi
+
+	local evidence_table="| File | Drift | Deployed mtime | Source mtime |\n| --- | --- | --- | --- |"
+	local entry name d_str dm sm
+	for entry in "${drifted[@]}"; do
+		IFS='|' read -r name d_str dm sm <<<"$entry"
+		evidence_table+="\n| \`${name}\` | ${d_str}s | $(date -r "$dm" '+%Y-%m-%d %H:%M:%SZ' 2>/dev/null || echo "$dm") | $(date -r "$sm" '+%Y-%m-%d %H:%M:%SZ' 2>/dev/null || echo "$sm") |"
+	done
+
+	local first_file
+	first_file="${drifted[0]%%|*}"
+
+	local title="runtime-audit: deployed script lags source by >$((drift / 3600))h (\`${first_file}\`)"
+	local drift_hours=$((drift / 3600))
+	# Render evidence table with embedded \n escapes resolved
+	local evidence_rendered
+	evidence_rendered=$(printf '%b' "$evidence_table")
+	local body
+	body=$(cat <<MARKDOWN
+## Task
+
+The pulse executes scripts from \`${deployed_dir}/\`, but the source of truth is \`${source_dir}/\`. The files below have a source-newer-than-deployed delta exceeding ${drift}s (${drift_hours}h).
+
+## Evidence
+
+${evidence_rendered}
+
+## Why
+
+This is the canonical t2036 footgun — debugging a runtime symptom by reading source instead of the deployed copy. When source is committed but the deploy never ran (or the user skipped \`aidevops update\`), the running pulse keeps the old behaviour while the operator believes the new fix is live.
+
+## How
+
+1. Compare the diff: \`diff <(cat ${deployed_dir}/<file>) <(cat ${source_dir}/<file>)\` for each drifted file.
+2. If the source-side change is desired live: run \`aidevops update\` (or \`setup.sh --non-interactive\` from the source repo).
+3. Restart pulse if pulse-* files were touched: \`pulse-lifecycle-helper.sh restart-if-running\`.
+4. If the source-side change should NOT be deployed yet (work-in-progress): note that here and close. The drift will resolve when the work merges and a deploy fires.
+
+## Acceptance Criteria
+
+1. Each drifted file is either deployed (delta becomes <60s) or has a documented reason for staying out-of-sync.
+2. Re-running the audit shows the drift block is gone.
+
+## Verification
+
+Re-run the audit; the cited files should no longer appear:
+
+\`\`\`
+~/.aidevops/agents/scripts/runtime-health-audit-helper.sh --dry-run --only deployed-vs-source-mtime-drift
+\`\`\`
+
+<!-- aidevops:generator=runtime-audit detector=deployed-vs-source-mtime-drift -->
+MARKDOWN
+)
+
+	jq -n --arg id "deployed-vs-source-mtime-drift" --arg title "$title" --arg body "$body" \
+		'{id: $id, title: $title, body: $body}'
+	return 1
+}

--- a/.agents/scripts/runtime-audit-rules/idle-state-stuck.sh
+++ b/.agents/scripts/runtime-audit-rules/idle-state-stuck.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# idle-state-stuck.sh — Detect stale SETUP marker in pulse.pid (t3072).
+#
+# Reads $PID_FILE (default ~/.aidevops/logs/pulse.pid). If it shows
+# `SETUP:<pid>` and that PID is no longer alive, the lifecycle helper
+# crashed during pulse setup and never released the marker. This blocks
+# all subsequent pulse cycles — the lifecycle treats SETUP as "in flight"
+# and refuses to start.
+#
+# Inputs (env):
+#   PID_FILE       default ~/.aidevops/logs/pulse.pid
+#   PID_ALIVE_FN   override for tests; if set, called as: $PID_ALIVE_FN <pid>
+#                  must exit 0 if alive, non-zero if dead
+
+# shellcheck shell=bash
+
+runtime_audit_id() { printf 'idle-state-stuck\n'; return 0; }
+
+runtime_audit_check() {
+	local pid_file="${PID_FILE:-${HOME}/.aidevops/logs/pulse.pid}"
+	local alive_fn="${PID_ALIVE_FN:-}"
+
+	if [[ ! -f "$pid_file" ]]; then
+		return 0
+	fi
+
+	local content
+	content=$(cat "$pid_file" 2>/dev/null) || return 0
+	# Pattern: "SETUP:<pid>" possibly with trailing whitespace/newline
+	if [[ ! "$content" =~ ^SETUP:[0-9]+ ]]; then
+		return 0
+	fi
+
+	local stuck_pid
+	stuck_pid=$(printf '%s\n' "$content" | head -1 | sed -nE 's/^SETUP:([0-9]+).*/\1/p')
+	[[ -z "$stuck_pid" ]] && return 0
+
+	# Liveness check
+	local alive=0
+	if [[ -n "$alive_fn" ]]; then
+		"$alive_fn" "$stuck_pid" && alive=1 || alive=0
+	else
+		kill -0 "$stuck_pid" 2>/dev/null && alive=1 || alive=0
+	fi
+
+	if [[ "$alive" == "1" ]]; then
+		return 0
+	fi
+
+	# Stale: SETUP marker references a dead PID
+	local mtime
+	mtime=$(_file_mtime_epoch "$pid_file" 2>/dev/null) || mtime=0
+	local age=$(( ${NOW_EPOCH:-$(date +%s)} - mtime ))
+
+	local title="runtime-audit: pulse.pid stuck on SETUP:${stuck_pid} (PID dead)"
+	local body
+	body=$(cat <<MARKDOWN
+## Task
+
+\`${pid_file/#$HOME/\~}\` shows \`SETUP:${stuck_pid}\` but PID ${stuck_pid} is no longer alive. The pulse lifecycle helper treats SETUP as "in flight" — until this marker is cleared, no new pulse cycle can start.
+
+## Evidence
+
+\`\`\`
+$ cat ${pid_file}
+${content}
+
+$ kill -0 ${stuck_pid}
+$? = $([[ "$alive" == "1" ]] && echo "0 (alive)" || echo "non-zero (dead)")
+
+PID file age: ${age}s ($(printf '%dh%dm' $((age/3600)) $(((age%3600)/60))))
+\`\`\`
+
+## Why
+
+This is the t-equivalent of an idle-state-stuck condition. The supervisor LLM cycle never reads \`pulse.pid\`, so a crash inside the SETUP phase produces a permanently wedged pulse with NO issue, NO log warning, NO surface signal. Operators only notice when they observe that no new dispatches have happened for >${age}s.
+
+## How
+
+1. Confirm the PID is dead: \`kill -0 ${stuck_pid}\` — should return non-zero exit.
+2. Inspect what was in flight when SETUP started: \`grep -A 20 "SETUP" ~/.aidevops/logs/pulse-wrapper.log | tail -30\`.
+3. Clear the marker: \`echo > ~/.aidevops/logs/pulse.pid\` (or remove the file).
+4. Restart pulse: \`pulse-lifecycle-helper.sh start\` (idempotent — no-op if already running, starts cleanly if not).
+5. Investigate the SETUP-phase crash. Look at \`pulse-lifecycle-helper.sh\` and \`pulse-wrapper.sh\` for the SETUP path. Likely candidates: a synchronous helper call that hangs, a missing mkdir, a permission error on a write target.
+
+## Acceptance Criteria
+
+1. Pulse back to running with a clean PID line in pulse.pid (no SETUP prefix).
+2. Root cause identified for the SETUP crash. Either fixed or filed as a separate task.
+
+## Verification
+
+\`\`\`
+cat ~/.aidevops/logs/pulse.pid
+# Should show a single integer (the running pulse PID), no "SETUP:" prefix.
+~/.aidevops/agents/scripts/pulse-lifecycle-helper.sh status
+# Should report "running"
+\`\`\`
+
+<!-- aidevops:generator=runtime-audit detector=idle-state-stuck -->
+MARKDOWN
+)
+
+	jq -n --arg id "idle-state-stuck" --arg title "$title" --arg body "$body" \
+		'{id: $id, title: $title, body: $body}'
+	return 1
+}

--- a/.agents/scripts/runtime-audit-rules/log-pattern-novelty.sh
+++ b/.agents/scripts/runtime-audit-rules/log-pattern-novelty.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# log-pattern-novelty.sh — Surface new high-frequency log patterns (t3072).
+#
+# Tails the last $RECENT_LINES lines of $LOG_FILE, normalises each line to
+# a template (strip timestamps, PIDs, hashes, numbers), counts templates,
+# and flags any template appearing >= $NOVELTY_THRESHOLD times in the
+# recent window that did NOT appear in the prior $PRIOR_LINES.
+#
+# This is the "what changed in pulse log behaviour today vs yesterday"
+# question that the supervisor LLM never asks because logs are out of band.
+#
+# Inputs (env):
+#   LOG_FILE             default ~/.aidevops/logs/pulse-wrapper.log
+#   RECENT_LINES         default 1000
+#   PRIOR_LINES          default 5000
+#   NOVELTY_THRESHOLD    default 5
+
+# shellcheck shell=bash
+
+runtime_audit_id() { printf 'log-pattern-novelty\n'; return 0; }
+
+runtime_audit_check() {
+	local log_file="${LOG_FILE:-${HOME}/.aidevops/logs/pulse-wrapper.log}"
+	local recent="${RECENT_LINES:-1000}"
+	local prior="${PRIOR_LINES:-5000}"
+	local threshold="${NOVELTY_THRESHOLD:-5}"
+
+	if [[ ! -f "$log_file" ]]; then
+		return 0
+	fi
+
+	# Total lines available
+	local total
+	total=$(wc -l <"$log_file" 2>/dev/null | tr -d ' ')
+	[[ "$total" =~ ^[0-9]+$ ]] || return 0
+	[[ "$total" -lt "$((recent + 100))" ]] && return 0
+
+	# Template normalisation: strip timestamps, PIDs, hex hashes, ISO dates,
+	# pure numbers, then collapse whitespace. Conservative — keeps function
+	# names, error categories, and quoted identifiers intact.
+	# BSD sed (macOS) does not honor \b word boundaries — use a portable
+	# pattern. Order matters: timestamps and epoch-length numbers consume
+	# their digit runs first, so the bare [0-9]+ rule catches what remains
+	# (small numeric IDs, iteration counts, error codes).
+	_normalise_template() {
+		sed -E \
+			-e 's/[0-9]{4}-[0-9]{2}-[0-9]{2}[T ][0-9]{2}:[0-9]{2}:[0-9]{2}(Z|[+-][0-9:]+)?/<TS>/g' \
+			-e 's/[0-9]{10,}/<EPOCH>/g' \
+			-e 's/[a-f0-9]{7,40}/<HASH>/g' \
+			-e 's/PID[ =:]?[0-9]+/PID=<N>/g' \
+			-e 's/[0-9]+/<N>/g' \
+			-e 's/[[:space:]]+/ /g'
+	}
+
+	local recent_block prior_block
+	recent_block=$(tail -n "$recent" "$log_file" 2>/dev/null) || return 0
+	# Prior: skip the recent tail, take up to $prior lines preceding it
+	local skip_from_end=$((recent + prior))
+	if [[ "$total" -ge "$skip_from_end" ]]; then
+		prior_block=$(head -n "$((total - recent))" "$log_file" 2>/dev/null | tail -n "$prior")
+	else
+		prior_block=$(head -n "$((total - recent))" "$log_file" 2>/dev/null)
+	fi
+
+	local recent_templates prior_templates
+	recent_templates=$(printf '%s\n' "$recent_block" | _normalise_template | sort | uniq -c | sort -rn)
+	prior_templates=$(printf '%s\n' "$prior_block" | _normalise_template | sort -u)
+
+	# Find templates with count >= threshold in recent that are missing from prior.
+	# Format of recent_templates: "  <count> <template>"
+	local novel=()
+	while IFS= read -r line; do
+		[[ -z "$line" ]] && continue
+		local count tmpl
+		count=$(printf '%s' "$line" | awk '{print $1}')
+		tmpl=$(printf '%s' "$line" | sed -E 's/^[[:space:]]*[0-9]+[[:space:]]+//')
+		[[ -z "$tmpl" ]] && continue
+		[[ "$count" -lt "$threshold" ]] && break  # sorted desc, can stop
+		# Skip very short templates (noise like single chars, log level headers)
+		[[ "${#tmpl}" -lt 30 ]] && continue
+		if ! printf '%s\n' "$prior_templates" | grep -qF -- "$tmpl"; then
+			novel+=("${count}|${tmpl}")
+			[[ ${#novel[@]} -ge 5 ]] && break  # cap evidence
+		fi
+	done <<<"$recent_templates"
+
+	if [[ ${#novel[@]} -eq 0 ]]; then
+		return 0
+	fi
+
+	local evidence_table="| Recent count | Normalised template |\n| --- | --- |"
+	local entry c t
+	for entry in "${novel[@]}"; do
+		IFS='|' read -r c t <<<"$entry"
+		# Truncate long templates for table display
+		[[ ${#t} -gt 200 ]] && t="${t:0:200}..."
+		# Escape pipes inside template for markdown
+		t="${t//|/\\|}"
+		evidence_table+="\n| ${c} | \`${t}\` |"
+	done
+
+	local title="runtime-audit: ${#novel[@]} novel high-frequency log pattern(s) in last ${recent} lines"
+	local body
+	# shellcheck disable=SC2016  # intentional literal markdown backticks in format string
+	body=$(printf '## Task\n\nThe last %s lines of `%s` contain log templates that appear >= %s times AND were not present in the prior %s lines. Sudden new high-frequency patterns are the supervisor LLM blind spot — logs are out-of-band, so a new error class can compound for hours before any issue is filed.\n\n## Evidence\n\n%b\n\nLog file: `%s`\n\n## Why\n\nNovel log templates almost always trace to a recently-deployed change. The supervisor never reads the log file directly, so the only way these patterns surface today is when an interactive operator runs `tail -f`. This detector closes that gap.\n\n## How\n\n1. Locate the source of each novel template:\n   - `grep -F "<sample-fragment>" .agents/scripts/*.sh` to find the emitting script.\n2. Check recent commits for that script: `git log --since="36 hours ago" -- <path>`.\n3. Cross-check `pulse-stats.json` for any counter that rose in the same window — see the `counter-trend-delta` detector.\n4. If the new pattern is benign (e.g. a new INFO line from a planned feature): close with rationale. If actionable (new error class, new warning): file a separate task with the implementation pattern.\n\n## Acceptance Criteria\n\n1. Each novel template is either traced to a known intentional change OR has a follow-up task linked.\n2. Re-running this detector shows the templates either drop below the threshold or move into the prior-window baseline.\n\n## Verification\n\n```\n~/.aidevops/agents/scripts/runtime-health-audit-helper.sh --dry-run --only log-pattern-novelty\n```\n\n<!-- aidevops:generator=runtime-audit detector=log-pattern-novelty -->\n' \
+		"$recent" "$log_file" "$threshold" "$prior" \
+		"$evidence_table" \
+		"$log_file")
+
+	jq -n --arg id "log-pattern-novelty" --arg title "$title" --arg body "$body" \
+		'{id: $id, title: $title, body: $body}'
+	return 1
+}

--- a/.agents/scripts/runtime-audit-rules/process-count-anomaly.sh
+++ b/.agents/scripts/runtime-audit-rules/process-count-anomaly.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# process-count-anomaly.sh — Detect pulse-wrapper process leak (t3072).
+#
+# Healthy state: at most a parent + a single in-flight child = 2 processes.
+# A count > $LEAK_THRESHOLD (default 5) indicates the lifecycle helper is
+# failing to reap children, or a launchd/systemd respawn loop is firing
+# without killing the predecessor. This is invisible to the supervisor LLM
+# cycle which never inspects the process table.
+#
+# Inputs (env):
+#   PS_OUTPUT_OVERRIDE  fixture for tests; if set, used instead of `ps`
+#   LEAK_THRESHOLD      max acceptable count (default 5)
+#   PROC_PATTERN        pattern to match (default 'pulse-wrapper.sh')
+#
+# Function contract: runtime_audit_check returns 0/1; emits one JSON line
+# on stdout when a finding is present.
+
+# shellcheck shell=bash
+
+runtime_audit_id() { printf 'process-count-anomaly\n'; return 0; }
+
+runtime_audit_check() {
+	local threshold="${LEAK_THRESHOLD:-5}"
+	local pattern="${PROC_PATTERN:-pulse-wrapper.sh}"
+	local ps_out
+	if [[ -n "${PS_OUTPUT_OVERRIDE:-}" ]]; then
+		ps_out="$PS_OUTPUT_OVERRIDE"
+	else
+		ps_out=$(ps -ax -o pid=,command= 2>/dev/null) || ps_out=""
+	fi
+
+	if [[ -z "$ps_out" ]]; then
+		return 0
+	fi
+
+	# Count lines that contain the pattern but exclude greps of itself
+	local matches
+	matches=$(printf '%s\n' "$ps_out" | grep -F "$pattern" | grep -vE 'grep|runtime-audit|runtime-health-audit')
+	local count
+	count=$(printf '%s\n' "$matches" | grep -cE '\S' 2>/dev/null || true)
+	[[ "$count" =~ ^[0-9]+$ ]] || count=0
+
+	if [[ "$count" -le "$threshold" ]]; then
+		return 0
+	fi
+
+	local title="runtime-audit: ${pattern} process count anomaly (${count} > ${threshold})"
+	local body
+	body=$(cat <<MARKDOWN
+## Task
+
+The process table shows ${count} processes matching \`${pattern}\`, exceeding the threshold of ${threshold}. Healthy state is parent + at-most-one in-flight child = 2 processes. A count this high indicates either a lifecycle reaping failure or a respawn loop without predecessor kill.
+
+## Evidence
+
+\`\`\`
+$(printf '%s\n' "$matches" | head -20)
+\`\`\`
+
+(Showing first 20 of ${count} matches.)
+
+## Why
+
+This is a structural blind spot of the supervisor LLM — it never inspects \`ps\`. Process leaks accumulate silently for hours until the operator notices CPU/memory pressure. Each lingering process holds open fds, scratch dirs, and (worse) may hold the pulse lock.
+
+## How
+
+1. Inspect the listed PIDs: \`ps -ax -o pid,etime,command | grep ${pattern}\` to see uptime per process.
+2. Identify the launchd/systemd path: \`launchctl list | grep aidevops\` (macOS) or \`systemctl list-units --user | grep aidevops\` (Linux).
+3. Read \`pulse-lifecycle-helper.sh\` for the reap path. Look for orphaned PIDs in \`~/.aidevops/logs/pulse.pid\` and \`~/.aidevops/cache/pulse-state/\`.
+4. If launchd is respawning without kill: check \`KeepAlive\` semantics in the plist (typical bug: \`SuccessfulExit:false\` causes infinite loop on segfault).
+5. Once root cause is fixed, kill the stragglers: \`pkill -f "(^|/)${pattern}( |$)" || true\` and let lifecycle restart cleanly.
+
+## Acceptance Criteria
+
+1. Root cause identified (lifecycle reap bug, respawn loop, or external killer).
+2. Fix landed; subsequent audit runs show count <= 2 in steady state.
+
+## Verification
+
+After fix and pulse restart:
+\`\`\`
+ps -ax -o command | grep -c "${pattern}\$"
+\`\`\`
+should return 1 (parent only) or 2 (parent + in-flight child).
+
+<!-- aidevops:generator=runtime-audit detector=process-count-anomaly -->
+MARKDOWN
+)
+
+	jq -n --arg id "process-count-anomaly" --arg title "$title" --arg body "$body" \
+		'{id: $id, title: $title, body: $body}'
+	return 1
+}

--- a/.agents/scripts/runtime-health-audit-helper.sh
+++ b/.agents/scripts/runtime-health-audit-helper.sh
@@ -1,0 +1,291 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# shellcheck disable=SC1091
+#
+# runtime-health-audit-helper.sh — Surface operational bugs the supervisor blind-spots (t3072).
+#
+# The supervisor LLM cycle triages GitHub state — issues, PRs, labels, scanner
+# findings — but never inspects processes, logs, pulse-stats counters, or
+# deployed-script mtimes. That is a structural blind spot. Bugs visible to
+# any interactive operator running `ps`, `jq`, `tail` go unraised for hours.
+#
+# This helper runs a registry of small detectors against local files only
+# (no GitHub or GraphQL calls — that would amplify the very problem several
+# of the detectors surface). When a detector fires, the helper either
+# prints the finding (--dry-run, default) or files an auto-dispatch issue
+# tagged with a generator marker that the pre-dispatch validator can
+# re-evaluate before a worker is spawned.
+#
+# Detector files live in `.agents/scripts/runtime-audit-rules/*.sh`. Each
+# file sources a single function: `runtime_audit_check`. See any rule file
+# for the contract.
+#
+# Usage:
+#   runtime-health-audit-helper.sh [--dry-run|--apply] [--only <id>] [--repo <slug>] [--json]
+#
+# Subcommands:
+#   list        — list registered detectors
+#   help        — print usage
+#   (default)   — run all detectors
+#
+# Exit codes:
+#   0  — completed (with or without findings)
+#   1  — fatal error (missing dependency, unreadable rules dir)
+#
+# Idempotency: each filed issue uses the marker
+#   <!-- aidevops:generator=runtime-audit detector=<id> -->
+# Before filing, the helper searches for an existing OPEN issue with the
+# same marker. If one is found, the new finding is appended as a comment
+# rather than re-filing.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit 1
+
+# shellcheck source=./shared-constants.sh
+source "${SCRIPT_DIR}/shared-constants.sh"
+
+# Optional: gh wrappers (only required for --apply path)
+GH_WRAPPERS="${SCRIPT_DIR}/shared-gh-wrappers.sh"
+
+RULES_DIR="${RUNTIME_AUDIT_RULES_DIR:-${SCRIPT_DIR}/runtime-audit-rules}"
+
+# ---------------------------------------------------------------------------
+# CLI parsing
+# ---------------------------------------------------------------------------
+readonly MODE_DRY_RUN="dry-run"
+readonly MODE_APPLY="apply"
+
+MODE="$MODE_DRY_RUN"
+ONLY_ID=""
+REPO_SLUG=""
+JSON_OUTPUT=0
+SUBCMD=""
+
+_usage() {
+	cat <<EOF
+Usage: $(basename "$0") [options] [list|help]
+
+Options:
+  --dry-run        Print findings to stdout, do not file issues (default)
+  --apply          File auto-dispatch issues for findings
+  --only <id>      Run only the detector with the given id
+  --repo <slug>    Target repo for --apply (default: current repo from gh)
+  --json           Emit JSONL findings (machine-readable; implies --dry-run)
+
+Subcommands:
+  list             List registered detectors and exit
+  help, --help     Print this help
+
+Detector contract: each file in ${RULES_DIR}/*.sh must define
+runtime_audit_check (returns 0 = clean, 1 = finding) and runtime_audit_id
+(prints stable identifier).
+
+EOF
+	return 0
+}
+
+_parse_args() {
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		local next="${2:-}"
+		case "$arg" in
+			--dry-run) MODE="$MODE_DRY_RUN"; shift ;;
+			--apply)   MODE="$MODE_APPLY"; shift ;;
+			--only)    ONLY_ID="$next"; shift 2 ;;
+			--repo)    REPO_SLUG="$next"; shift 2 ;;
+			--json)    JSON_OUTPUT=1; shift ;;
+			list)      SUBCMD="list"; shift ;;
+			help|--help|-h) _usage; exit 0 ;;
+			*) print_warning "Unknown argument: $arg"; _usage; exit 1 ;;
+		esac
+	done
+	return 0
+}
+_parse_args "$@"
+
+# ---------------------------------------------------------------------------
+# Detector discovery
+# ---------------------------------------------------------------------------
+_list_detectors() {
+	local f
+	if [[ ! -d "$RULES_DIR" ]]; then
+		return 0
+	fi
+	for f in "$RULES_DIR"/*.sh; do
+		[[ -f "$f" ]] || continue
+		printf '%s\n' "$f"
+	done
+	return 0
+}
+
+if [[ "$SUBCMD" == "list" ]]; then
+	for f in $(_list_detectors); do
+		# Source in subshell to extract id without polluting parent env
+		id=$(bash -c "source '$f'; runtime_audit_id" 2>/dev/null) || id="?"
+		printf '%-40s  %s\n' "$id" "$(basename "$f")"
+	done
+	exit 0
+fi
+
+# ---------------------------------------------------------------------------
+# Apply path: idempotency check via marker search
+# ---------------------------------------------------------------------------
+_resolve_repo_slug() {
+	if [[ -n "$REPO_SLUG" ]]; then
+		printf '%s\n' "$REPO_SLUG"
+		return 0
+	fi
+	# Try gh repo view
+	gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null
+	return 0
+}
+
+_existing_open_issue_for_detector() {
+	local slug="$1"
+	local detector_id="$2"
+	# The marker we embed in every body
+	local marker="aidevops:generator=runtime-audit detector=${detector_id}"
+	# Search within the repo. Pull number+url for the first match.
+	gh issue list --repo "$slug" --state open --search "in:body \"${marker}\"" \
+		--limit 1 --json number,url 2>/dev/null \
+		| jq -r '.[0] // empty | "\(.number)\t\(.url)"' 2>/dev/null
+	return 0
+}
+
+_apply_finding() {
+	local slug="$1"
+	local detector_id="$2"
+	local title="$3"
+	local body="$4"
+
+	# Idempotency check
+	local existing
+	existing=$(_existing_open_issue_for_detector "$slug" "$detector_id")
+	if [[ -n "$existing" ]]; then
+		local exist_num exist_url
+		IFS=$'\t' read -r exist_num exist_url <<<"$existing"
+		print_info "runtime-audit: detector=${detector_id} already has open issue #${exist_num} (${exist_url}) — skipping new file, posting refresh comment"
+		# Optional: append a refresh comment (small)
+		local refresh_body
+		# shellcheck disable=SC2016  # intentional literal markdown backticks in format string
+		refresh_body=$(printf '> Detector \`%s\` re-fired at %s. Most recent evidence:\n\n%s\n' \
+			"$detector_id" "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" "$body")
+		# shellcheck source=./shared-gh-wrappers.sh
+		if [[ -f "$GH_WRAPPERS" ]]; then
+			source "$GH_WRAPPERS"
+			gh_issue_comment "$exist_num" --repo "$slug" --body "$refresh_body" >/dev/null 2>&1 \
+				|| print_warning "runtime-audit: refresh comment failed for #${exist_num}"
+		fi
+		return 0
+	fi
+
+	# Create a fresh issue
+	if [[ ! -f "$GH_WRAPPERS" ]]; then
+		print_error "runtime-audit: gh wrappers not found at ${GH_WRAPPERS} — cannot --apply"
+		return 1
+	fi
+	# shellcheck source=./shared-gh-wrappers.sh
+	source "$GH_WRAPPERS"
+	local labels="auto-dispatch,tier:standard,bug,framework,source:runtime-audit"
+	local issue_url
+	issue_url=$(gh_create_issue --repo "$slug" --title "$title" --body "$body" --label "$labels" 2>&1) || {
+		print_error "runtime-audit: gh issue create failed for detector=${detector_id}: $issue_url"
+		return 1
+	}
+	print_success "runtime-audit: filed ${issue_url} for detector=${detector_id}"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Main loop
+# ---------------------------------------------------------------------------
+if [[ ! -d "$RULES_DIR" ]]; then
+	print_error "runtime-audit: rules directory not found: $RULES_DIR"
+	exit 1
+fi
+
+# Resolve apply-mode prerequisites once
+APPLY_SLUG=""
+if [[ "$MODE" == "$MODE_APPLY" ]]; then
+	APPLY_SLUG=$(_resolve_repo_slug)
+	if [[ -z "$APPLY_SLUG" ]]; then
+		print_error "runtime-audit: --apply requires --repo <slug> or a gh repo context"
+		exit 1
+	fi
+fi
+
+DETECTOR_FILES=$(_list_detectors)
+if [[ -z "$DETECTOR_FILES" ]]; then
+	print_warning "runtime-audit: no detectors found in $RULES_DIR"
+	exit 0
+fi
+
+FINDINGS_COUNT=0
+RAN_COUNT=0
+
+for f in $DETECTOR_FILES; do
+	# Resolve detector id (cheap subshell)
+	id=$(bash -c "source '$f'; runtime_audit_id" 2>/dev/null) || id=""
+	[[ -z "$id" ]] && continue
+	if [[ -n "$ONLY_ID" && "$ONLY_ID" != "$id" ]]; then
+		continue
+	fi
+	RAN_COUNT=$((RAN_COUNT + 1))
+
+	# Run check in a subshell so detector globals do not leak between rules.
+	# The check function emits exactly one JSON object on stdout when it
+	# finds something, and exits 1. Otherwise it exits 0 with no output.
+	local_output=""
+	local_rc=0
+	local_output=$(bash -c "
+		set -u
+		source '${SCRIPT_DIR}/shared-constants.sh'
+		source '$f'
+		runtime_audit_check
+	" 2>/dev/null) || local_rc=$?
+
+	if [[ "$local_rc" -eq 0 ]]; then
+		print_info "runtime-audit: detector=${id} clean"
+		continue
+	fi
+
+	if [[ -z "$local_output" ]]; then
+		print_warning "runtime-audit: detector=${id} returned non-zero but emitted no output — skipping"
+		continue
+	fi
+
+	# Parse the JSON
+	finding_id=$(printf '%s' "$local_output" | jq -r '.id // empty' 2>/dev/null)
+	finding_title=$(printf '%s' "$local_output" | jq -r '.title // empty' 2>/dev/null)
+	finding_body=$(printf '%s' "$local_output" | jq -r '.body // empty' 2>/dev/null)
+
+	if [[ -z "$finding_id" || -z "$finding_title" || -z "$finding_body" ]]; then
+		print_warning "runtime-audit: detector=${id} produced unparseable output — skipping"
+		continue
+	fi
+
+	FINDINGS_COUNT=$((FINDINGS_COUNT + 1))
+
+	if [[ "$JSON_OUTPUT" -eq 1 ]]; then
+		printf '%s\n' "$local_output"
+		continue
+	fi
+
+	if [[ "$MODE" == "$MODE_DRY_RUN" ]]; then
+		printf '\n========================================================================\n'
+		printf 'FINDING: %s\n' "$finding_title"
+		printf 'detector=%s\n' "$finding_id"
+		printf '========================================================================\n\n'
+		printf '%s\n' "$finding_body"
+		continue
+	fi
+
+	# apply mode
+	_apply_finding "$APPLY_SLUG" "$finding_id" "$finding_title" "$finding_body" \
+		|| print_warning "runtime-audit: apply failed for detector=${finding_id}"
+done
+
+print_info "runtime-audit: ran ${RAN_COUNT} detector(s), ${FINDINGS_COUNT} finding(s) (mode=${MODE})"
+exit 0

--- a/.agents/scripts/runtime-health-audit-helper.sh
+++ b/.agents/scripts/runtime-health-audit-helper.sh
@@ -191,7 +191,7 @@ _apply_finding() {
 	local labels="auto-dispatch,tier:standard,bug,framework,source:runtime-audit"
 	local issue_url
 	issue_url=$(gh_create_issue --repo "$slug" --title "$title" --body "$body" --label "$labels" 2>&1) || {
-		print_error "runtime-audit: gh issue create failed for detector=${detector_id}: $issue_url"
+		print_error "runtime-audit: gh_create_issue wrapper failed for detector=${detector_id}: $issue_url"
 		return 1
 	}
 	print_success "runtime-audit: filed ${issue_url} for detector=${detector_id}"

--- a/.agents/scripts/tests/test-runtime-audit-detectors.sh
+++ b/.agents/scripts/tests/test-runtime-audit-detectors.sh
@@ -1,0 +1,429 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-runtime-audit-detectors.sh — Structural tests for t3072 runtime-audit
+# detectors and orchestrator.
+#
+# Each detector is exercised twice: once with a fixture that should fire
+# (return 1 + JSON), once with a fixture that should NOT fire (return 0).
+# The orchestrator is exercised in --dry-run --only mode against the
+# fixture so end-to-end JSON parsing is covered.
+#
+# Tests are pure-shell — no GitHub API, no pulse state mutation.
+
+set -u
+
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_BLUE=$'\033[0;34m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_BLUE="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+assert_rc() {
+	local label="$1" expected="$2" actual="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$expected" == "$actual" ]]; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  expected rc=$expected, got rc=$actual"
+	fi
+	return 0
+}
+
+assert_contains() {
+	local label="$1" needle="$2" haystack="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if printf '%s' "$haystack" | grep -qF -- "$needle" 2>/dev/null; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  expected to find: $(printf '%q' "$needle")"
+		echo "  in: $(printf '%q' "${haystack:0:200}")"
+	fi
+	return 0
+}
+
+assert_empty() {
+	local label="$1" value="$2"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ -z "$value" ]]; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  expected empty, got: $(printf '%q' "${value:0:200}")"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Setup
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RULES_DIR="$SCRIPT_DIR/runtime-audit-rules"
+ORCHESTRATOR="$SCRIPT_DIR/runtime-health-audit-helper.sh"
+SHARED_CONSTANTS="$SCRIPT_DIR/shared-constants.sh"
+
+if [[ ! -d "$RULES_DIR" ]]; then
+	echo "${TEST_RED}FATAL${TEST_NC}: rules dir not found: $RULES_DIR"
+	exit 1
+fi
+if [[ ! -x "$ORCHESTRATOR" ]]; then
+	echo "${TEST_RED}FATAL${TEST_NC}: orchestrator not executable: $ORCHESTRATOR"
+	exit 1
+fi
+
+# Tmp dir per test run; cleaned up on exit
+TMPDIR_TEST=$(mktemp -d /tmp/runtime-audit-test.XXXXXX)
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+# Helper: run a detector in a clean subshell with an env block, capture
+# stdout and rc.
+_run_detector() {
+	local detector_file="$1"; shift
+	local out
+	local rc=0
+	# shellcheck disable=SC2068  # passing through env assignments
+	out=$(env "$@" bash -c "
+		set -u
+		source '$SHARED_CONSTANTS'
+		source '$detector_file'
+		runtime_audit_check
+	" 2>/dev/null) || rc=$?
+	printf '%s\n' "$out"
+	return "$rc"
+}
+
+echo "${TEST_BLUE}=== t3072: runtime-audit detector tests ===${TEST_NC}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Test 1: counter-trend-delta
+# ---------------------------------------------------------------------------
+echo "--- Section 1: counter-trend-delta ---"
+
+STATS_FIRING="$TMPDIR_TEST/stats-firing.json"
+cat >"$STATS_FIRING" <<'JSON'
+{
+  "counters": {
+    "test_regressed": [850, 901, 920, 950, 970, 990, 999],
+    "test_steady":    [810, 820, 910, 920, 930, 950, 970]
+  }
+}
+JSON
+
+# now=1000, window=100
+# recent [900..1000]: regressed=6, steady=5
+# prior  [800..900):  regressed=1, steady=2
+# regressed: 6 >= 1*2 ✓ → fires
+# steady:    5 >= 2*2 = 4 ✓ → also fires (more conservative test would
+# pick mult=3, but mult=2 with min_baseline=1 keeps the fixture compact)
+out=$(_run_detector "$RULES_DIR/counter-trend-delta.sh" \
+	"STATS_FILE=$STATS_FIRING" \
+	"NOW_EPOCH=1000" \
+	"WINDOW_SECONDS=100" \
+	"REGRESSION_MULT=2" \
+	"MIN_BASELINE=1") && rc=0 || rc=$?
+assert_rc "1.1 firing fixture returns 1" "1" "$rc"
+assert_contains "1.2 firing JSON has correct id" '"id": "counter-trend-delta"' "$out"
+assert_contains "1.3 firing JSON references regressed counter" "test_regressed" "$out"
+assert_contains "1.4 firing body has marker" 'detector=counter-trend-delta' "$out"
+
+# Clean fixture: only steady counter, no regression
+STATS_CLEAN="$TMPDIR_TEST/stats-clean.json"
+cat >"$STATS_CLEAN" <<'JSON'
+{
+  "counters": {
+    "test_steady": [810, 820, 910, 920, 930]
+  }
+}
+JSON
+
+out=$(_run_detector "$RULES_DIR/counter-trend-delta.sh" \
+	"STATS_FILE=$STATS_CLEAN" \
+	"NOW_EPOCH=1000" \
+	"WINDOW_SECONDS=100" \
+	"REGRESSION_MULT=10" \
+	"MIN_BASELINE=10") && rc=0 || rc=$?
+assert_rc "1.5 clean fixture returns 0" "0" "$rc"
+assert_empty "1.6 clean fixture emits no output" "$out"
+
+# Missing stats file → no-op (return 0, no output)
+out=$(_run_detector "$RULES_DIR/counter-trend-delta.sh" \
+	"STATS_FILE=/nonexistent/path/stats.json") && rc=0 || rc=$?
+assert_rc "1.7 missing stats file returns 0" "0" "$rc"
+
+# ---------------------------------------------------------------------------
+# Test 2: process-count-anomaly
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Section 2: process-count-anomaly ---"
+
+PS_FIRING=$(printf '%s\n' \
+	"  101 /bin/bash /Users/x/.aidevops/agents/scripts/pulse-wrapper.sh" \
+	"  102 /bin/bash /Users/x/.aidevops/agents/scripts/pulse-wrapper.sh" \
+	"  103 /bin/bash /Users/x/.aidevops/agents/scripts/pulse-wrapper.sh" \
+	"  104 /bin/bash /Users/x/.aidevops/agents/scripts/pulse-wrapper.sh" \
+	"  105 /bin/bash /Users/x/.aidevops/agents/scripts/pulse-wrapper.sh" \
+	"  106 /bin/bash /Users/x/.aidevops/agents/scripts/pulse-wrapper.sh" \
+	"  107 /usr/bin/some-other-process")
+
+out=$(_run_detector "$RULES_DIR/process-count-anomaly.sh" \
+	"PS_OUTPUT_OVERRIDE=$PS_FIRING" \
+	"LEAK_THRESHOLD=3" \
+	"PROC_PATTERN=pulse-wrapper.sh") && rc=0 || rc=$?
+assert_rc "2.1 firing fixture returns 1" "1" "$rc"
+assert_contains "2.2 firing body has correct id" '"id": "process-count-anomaly"' "$out"
+assert_contains "2.3 firing title cites count" "count anomaly (6 > 3)" "$out"
+assert_contains "2.4 firing body has marker" 'detector=process-count-anomaly' "$out"
+
+# Clean fixture: 2 matches, threshold 5 → no-op
+PS_CLEAN=$(printf '%s\n' \
+	"  101 /bin/bash /Users/x/.aidevops/agents/scripts/pulse-wrapper.sh" \
+	"  102 /bin/bash /Users/x/.aidevops/agents/scripts/pulse-wrapper.sh")
+out=$(_run_detector "$RULES_DIR/process-count-anomaly.sh" \
+	"PS_OUTPUT_OVERRIDE=$PS_CLEAN" \
+	"LEAK_THRESHOLD=5" \
+	"PROC_PATTERN=pulse-wrapper.sh") && rc=0 || rc=$?
+assert_rc "2.5 below-threshold fixture returns 0" "0" "$rc"
+assert_empty "2.6 below-threshold emits no output" "$out"
+
+# ---------------------------------------------------------------------------
+# Test 3: deployed-vs-source-mtime-drift
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Section 3: deployed-vs-source-mtime-drift ---"
+
+DRIFT_DEPLOYED="$TMPDIR_TEST/deployed"
+DRIFT_SOURCE="$TMPDIR_TEST/source"
+mkdir -p "$DRIFT_DEPLOYED" "$DRIFT_SOURCE"
+
+# pulse-wrapper.sh: deployed touched 3 days ago, source touched 1 minute ago
+# → drift = ~3 days = 259200 > DRIFT_SECONDS (3600 in this test)
+echo "deployed-content" > "$DRIFT_DEPLOYED/pulse-wrapper.sh"
+echo "source-content"   > "$DRIFT_SOURCE/pulse-wrapper.sh"
+
+# Use touch -t to set deployed mtime in the past
+# Format: [[CC]YY]MMDDhhmm[.SS]
+# Pick a fixed reference point so the test is deterministic regardless of
+# wall-clock at runtime: deployed = 200 days ago, source = now
+old_ts=$(date -v-200d '+%Y%m%d%H%M' 2>/dev/null || date -d '200 days ago' '+%Y%m%d%H%M' 2>/dev/null)
+if [[ -n "$old_ts" ]]; then
+	touch -t "$old_ts" "$DRIFT_DEPLOYED/pulse-wrapper.sh"
+fi
+
+out=$(_run_detector "$RULES_DIR/deployed-vs-source-mtime-drift.sh" \
+	"AIDEVOPS_DEPLOYED_DIR=$DRIFT_DEPLOYED" \
+	"AIDEVOPS_SOURCE_DIR=$DRIFT_SOURCE" \
+	"DRIFT_SECONDS=3600" \
+	"WATCHED_FILES=pulse-wrapper.sh") && rc=0 || rc=$?
+assert_rc "3.1 firing fixture returns 1" "1" "$rc"
+assert_contains "3.2 firing body has correct id" '"id": "deployed-vs-source-mtime-drift"' "$out"
+assert_contains "3.3 firing references file" "pulse-wrapper.sh" "$out"
+assert_contains "3.4 firing body has marker" 'detector=deployed-vs-source-mtime-drift' "$out"
+
+# Clean fixture: same mtime on both sides
+DRIFT_DEPLOYED2="$TMPDIR_TEST/deployed2"
+DRIFT_SOURCE2="$TMPDIR_TEST/source2"
+mkdir -p "$DRIFT_DEPLOYED2" "$DRIFT_SOURCE2"
+echo "x" > "$DRIFT_DEPLOYED2/pulse-wrapper.sh"
+echo "x" > "$DRIFT_SOURCE2/pulse-wrapper.sh"
+# Touch both with same reference — touch -r preserves mtime exactly.
+touch -r "$DRIFT_DEPLOYED2/pulse-wrapper.sh" "$DRIFT_SOURCE2/pulse-wrapper.sh"
+
+out=$(_run_detector "$RULES_DIR/deployed-vs-source-mtime-drift.sh" \
+	"AIDEVOPS_DEPLOYED_DIR=$DRIFT_DEPLOYED2" \
+	"AIDEVOPS_SOURCE_DIR=$DRIFT_SOURCE2" \
+	"DRIFT_SECONDS=3600" \
+	"WATCHED_FILES=pulse-wrapper.sh") && rc=0 || rc=$?
+assert_rc "3.5 same-mtime fixture returns 0" "0" "$rc"
+assert_empty "3.6 same-mtime emits no output" "$out"
+
+# Missing dirs → no-op
+out=$(_run_detector "$RULES_DIR/deployed-vs-source-mtime-drift.sh" \
+	"AIDEVOPS_DEPLOYED_DIR=/nonexistent/x" \
+	"AIDEVOPS_SOURCE_DIR=/nonexistent/y") && rc=0 || rc=$?
+assert_rc "3.7 missing dirs returns 0" "0" "$rc"
+
+# ---------------------------------------------------------------------------
+# Test 4: log-pattern-novelty
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Section 4: log-pattern-novelty ---"
+
+LOG_FIRING="$TMPDIR_TEST/log-firing.log"
+# Build 1100 lines: first 1000 "old line N", last 100 contain a novel
+# template that normalises to a stable string and appears > threshold.
+# Threshold = 5; we use 50 occurrences in the recent block.
+{
+	for i in $(seq 1 1000); do
+		printf '2026-04-01T00:00:00Z OLD pattern - existing baseline iteration %d\n' "$i"
+	done
+	for i in $(seq 1 50); do
+		# Each line normalises to:
+		# "<TS> NOVEL_ERROR: dispatch_with_dedup unexpected return code <N> from worker_lifecycle iteration <N>"
+		printf '2026-04-30T00:00:00Z NOVEL_ERROR: dispatch_with_dedup unexpected return code 99 from worker_lifecycle iteration %d\n' "$i"
+	done
+	# Pad recent block to >= RECENT_LINES
+	for i in $(seq 1 50); do
+		printf '2026-04-30T00:00:00Z OTHER recent line padding iteration %d\n' "$i"
+	done
+} > "$LOG_FIRING"
+
+out=$(_run_detector "$RULES_DIR/log-pattern-novelty.sh" \
+	"LOG_FILE=$LOG_FIRING" \
+	"RECENT_LINES=100" \
+	"PRIOR_LINES=1000" \
+	"NOVELTY_THRESHOLD=10") && rc=0 || rc=$?
+assert_rc "4.1 firing fixture returns 1" "1" "$rc"
+assert_contains "4.2 firing body has correct id" '"id": "log-pattern-novelty"' "$out"
+assert_contains "4.3 firing body cites novel template" "NOVEL_ERROR" "$out"
+assert_contains "4.4 firing body has marker" 'detector=log-pattern-novelty' "$out"
+
+# Clean fixture: log too short → no-op
+LOG_SHORT="$TMPDIR_TEST/log-short.log"
+for i in $(seq 1 50); do
+	printf 'short line %d\n' "$i"
+done > "$LOG_SHORT"
+
+out=$(_run_detector "$RULES_DIR/log-pattern-novelty.sh" \
+	"LOG_FILE=$LOG_SHORT" \
+	"RECENT_LINES=100") && rc=0 || rc=$?
+assert_rc "4.5 too-short log returns 0" "0" "$rc"
+
+# Missing log → no-op
+out=$(_run_detector "$RULES_DIR/log-pattern-novelty.sh" \
+	"LOG_FILE=/nonexistent/log.log") && rc=0 || rc=$?
+assert_rc "4.6 missing log returns 0" "0" "$rc"
+
+# ---------------------------------------------------------------------------
+# Test 5: idle-state-stuck
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Section 5: idle-state-stuck ---"
+
+PID_FIRING="$TMPDIR_TEST/pid-firing.pid"
+echo "SETUP:99999" > "$PID_FIRING"
+
+# Fake "PID dead" callable
+FAKE_DEAD="$TMPDIR_TEST/pid-dead.sh"
+cat >"$FAKE_DEAD" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+chmod +x "$FAKE_DEAD"
+
+out=$(_run_detector "$RULES_DIR/idle-state-stuck.sh" \
+	"PID_FILE=$PID_FIRING" \
+	"PID_ALIVE_FN=$FAKE_DEAD") && rc=0 || rc=$?
+assert_rc "5.1 firing fixture (dead PID) returns 1" "1" "$rc"
+assert_contains "5.2 firing body has correct id" '"id": "idle-state-stuck"' "$out"
+assert_contains "5.3 firing title cites stuck PID" "SETUP:99999" "$out"
+assert_contains "5.4 firing body has marker" 'detector=idle-state-stuck' "$out"
+
+# Clean fixture: PID alive
+FAKE_ALIVE="$TMPDIR_TEST/pid-alive.sh"
+cat >"$FAKE_ALIVE" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+chmod +x "$FAKE_ALIVE"
+
+out=$(_run_detector "$RULES_DIR/idle-state-stuck.sh" \
+	"PID_FILE=$PID_FIRING" \
+	"PID_ALIVE_FN=$FAKE_ALIVE") && rc=0 || rc=$?
+assert_rc "5.5 alive-PID fixture returns 0" "0" "$rc"
+assert_empty "5.6 alive-PID emits no output" "$out"
+
+# No SETUP marker → no-op
+PID_CLEAN="$TMPDIR_TEST/pid-clean.pid"
+echo "12345" > "$PID_CLEAN"
+out=$(_run_detector "$RULES_DIR/idle-state-stuck.sh" \
+	"PID_FILE=$PID_CLEAN") && rc=0 || rc=$?
+assert_rc "5.7 no-SETUP-marker returns 0" "0" "$rc"
+assert_empty "5.8 no-SETUP emits no output" "$out"
+
+# Missing PID file → no-op
+out=$(_run_detector "$RULES_DIR/idle-state-stuck.sh" \
+	"PID_FILE=/nonexistent/pulse.pid") && rc=0 || rc=$?
+assert_rc "5.9 missing PID file returns 0" "0" "$rc"
+
+# ---------------------------------------------------------------------------
+# Test 6: orchestrator end-to-end (--dry-run, --only)
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Section 6: orchestrator integration ---"
+
+# Use the firing counter-trend fixture from Section 1.
+# --json should emit one finding object on stdout.
+out=$(STATS_FILE="$STATS_FIRING" \
+	NOW_EPOCH=1000 \
+	WINDOW_SECONDS=100 \
+	REGRESSION_MULT=2 \
+	MIN_BASELINE=1 \
+	"$ORCHESTRATOR" --dry-run --only counter-trend-delta --json 2>/dev/null) && rc=0 || rc=$?
+assert_rc "6.1 orchestrator --json --only returns 0" "0" "$rc"
+assert_contains "6.2 orchestrator --json emits id field" '"id"' "$out"
+assert_contains "6.3 orchestrator --json emits counter-trend-delta" 'counter-trend-delta' "$out"
+
+# `list` subcommand should print all 5 detectors
+out=$("$ORCHESTRATOR" list 2>/dev/null) && rc=0 || rc=$?
+assert_rc "6.4 orchestrator list returns 0" "0" "$rc"
+assert_contains "6.5 list shows counter-trend-delta" "counter-trend-delta" "$out"
+assert_contains "6.6 list shows process-count-anomaly" "process-count-anomaly" "$out"
+assert_contains "6.7 list shows deployed-vs-source-mtime-drift" "deployed-vs-source-mtime-drift" "$out"
+assert_contains "6.8 list shows log-pattern-novelty" "log-pattern-novelty" "$out"
+assert_contains "6.9 list shows idle-state-stuck" "idle-state-stuck" "$out"
+
+# --only with non-existent detector should run nothing and exit 0
+out=$("$ORCHESTRATOR" --dry-run --only nonexistent-detector --json 2>/dev/null) && rc=0 || rc=$?
+assert_rc "6.10 --only nonexistent detector returns 0" "0" "$rc"
+assert_empty "6.11 --only nonexistent emits no JSON output" "$out"
+
+# ---------------------------------------------------------------------------
+# Test 7: shellcheck on all new files
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Section 7: shellcheck ---"
+
+if command -v shellcheck >/dev/null 2>&1; then
+	for f in "$RULES_DIR"/*.sh "$ORCHESTRATOR"; do
+		[[ -f "$f" ]] || continue
+		if shellcheck -x "$f" >/dev/null 2>&1; then
+			TESTS_RUN=$((TESTS_RUN + 1))
+			echo "${TEST_GREEN}PASS${TEST_NC}: shellcheck clean on $(basename "$f")"
+		else
+			TESTS_RUN=$((TESTS_RUN + 1))
+			TESTS_FAILED=$((TESTS_FAILED + 1))
+			echo "${TEST_RED}FAIL${TEST_NC}: shellcheck violations on $(basename "$f")"
+			shellcheck -x "$f" 2>&1 | head -10 | sed 's/^/    /'
+		fi
+	done
+else
+	echo "${TEST_BLUE}SKIP${TEST_NC}: shellcheck not installed"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "${TEST_BLUE}=== Summary ===${TEST_NC}"
+echo "Tests run:    $TESTS_RUN"
+echo "Tests failed: $TESTS_FAILED"
+if [[ "$TESTS_FAILED" -eq 0 ]]; then
+	echo "${TEST_GREEN}ALL TESTS PASSED${TEST_NC}"
+	exit 0
+else
+	echo "${TEST_RED}$TESTS_FAILED TEST(S) FAILED${TEST_NC}"
+	exit 1
+fi

--- a/TODO.md
+++ b/TODO.md
@@ -92,6 +92,7 @@ Compatible with [todo-md](https://github.com/todo-md/todo-md), [todomd](https://
 - [x] r043 Case deadline alarming — classify open-case deadlines, fire gh-issue + ntfy alarms by stage repeat:cron(*/15 * * * *) ~1m run:scripts/case-alarm-helper.sh tick
 - [x] r045 Email filter tick: auto-attach matched email sources to cases repeat:cron(*/15 * * * *) run:scripts/email-filter-helper.sh tick
 - [x] r046 Canonical-recovery sweep — re-attempt failed git pull/stash for repos with active advisory files (t3027) repeat:cron(*/10 * * * *) ~1m run:scripts/canonical-recovery-routine.sh tick
+- [ ] r-runtime-audit Runtime health audit — surface operational regressions invisible to the supervisor LLM (counter trends, process leaks, deploy mtime drift, log novelty, stuck pulse state) (t3072) repeat:cron(*/30 * * * *) ~2m run:scripts/runtime-health-audit-helper.sh --apply
 
 ## Ready
 


### PR DESCRIPTION
## Summary

Implementation for issue #21820.

## Files Changed

.agents/reference/routines.md,.agents/scripts/pre-dispatch-validator-helper.sh,.agents/scripts/runtime-audit-rules/counter-trend-delta.sh,.agents/scripts/runtime-audit-rules/deployed-vs-source-mtime-drift.sh,.agents/scripts/runtime-audit-rules/idle-state-stuck.sh,.agents/scripts/runtime-audit-rules/log-pattern-novelty.sh,.agents/scripts/runtime-audit-rules/process-count-anomaly.sh,.agents/scripts/runtime-health-audit-helper.sh,.agents/scripts/tests/test-runtime-audit-detectors.sh,TODO.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean, self-assessed

Resolves #21820


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.11 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-opus-4-7 spent 28m and 90,398 tokens on this with the user in an interactive session.