### PR TITLE
t3074: fix duplicate Code Audit Routines dashboard issues — fail-closed dedup + title-prefix fallback + self-healing sweep

### DIFF
--- a/.agents/scripts/cleanup-quality-dashboard-dupes.sh
+++ b/.agents/scripts/cleanup-quality-dashboard-dupes.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# cleanup-quality-dashboard-dupes.sh — ONE-SHOT cleanup for GH#21830
+# =============================================================================
+# Closes the three duplicate "Code Audit Routines" dashboard issues that
+# accumulated due to the fail-open label-search bug (t3074).
+#
+# Survivor: #21670 (most recent, latest stats)
+# Closed:   #2632, #20409, #20845
+#
+# Usage: bash .agents/scripts/cleanup-quality-dashboard-dupes.sh
+#        REPO_SLUG=owner/repo bash .agents/scripts/cleanup-quality-dashboard-dupes.sh
+#
+# This script is idempotent — re-running it on already-closed issues is safe.
+# =============================================================================
+
+set -euo pipefail
+
+REPO_SLUG="${REPO_SLUG:-marcusquinn/aidevops}"
+SURVIVOR=21670
+# shellcheck disable=SC2206
+DUPES=(2632 20409 20845)
+
+if [[ -t 1 ]]; then
+	GREEN=$'\033[0;32m'
+	RED=$'\033[0;31m'
+	NC=$'\033[0m'
+else
+	GREEN="" RED="" NC=""
+fi
+
+_close_dupe() {
+	local num="$1"
+	local repo_slug="$2"
+	local survivor="$3"
+
+	# Check current state — skip if already closed
+	local state
+	state=$(gh issue view "$num" --repo "$repo_slug" --json state --jq '.state' 2>/dev/null || echo "")
+	if [[ "${state,,}" == "closed" ]]; then
+		printf '  %sSKIP%s #%s (already closed)\n' "$GREEN" "$NC" "$num"
+		return 0
+	fi
+
+	local close_body
+	close_body="> Auto-closed: superseded by #${survivor} as duplicate quality dashboard (t3074 one-time cleanup)."
+	gh issue comment "$num" --repo "$repo_slug" --body "$close_body" 2>/dev/null || true
+	gh issue close "$num" --repo "$repo_slug" 2>/dev/null || {
+		printf '  %sFAIL%s #%s — could not close\n' "$RED" "$NC" "$num"
+		return 1
+	}
+	printf '  %sCLOSED%s #%s\n' "$GREEN" "$NC" "$num"
+	return 0
+}
+
+main() {
+	local repo_slug="$1"
+	local survivor="$2"
+	local failed=0
+
+	printf 'Closing duplicate quality dashboards in %s (survivor: #%s)\n' "$repo_slug" "$survivor"
+
+	local num
+	for num in "${DUPES[@]}"; do
+		_close_dupe "$num" "$repo_slug" "$survivor" || failed=$((failed + 1))
+	done
+
+	if [[ "$failed" -gt 0 ]]; then
+		printf '%sFailed to close %d issue(s).%s\n' "$RED" "$failed" "$NC"
+		return 1
+	fi
+
+	printf '%sDone. %d duplicates closed.%s\n' "$GREEN" "${#DUPES[@]}" "$NC"
+	return 0
+}
+
+main "$REPO_SLUG" "$SURVIVOR"

--- a/.agents/scripts/runtime-audit-rules/counter-trend-delta.sh
+++ b/.agents/scripts/runtime-audit-rules/counter-trend-delta.sh
@@ -79,9 +79,7 @@ runtime_audit_check() {
 	first_counter=$(printf '%s\n' "$regressions" | head -1 | cut -f1)
 
 	local title="runtime-audit: counter regression detected (\`${first_counter}\`)"
-	# Build body via temp file — avoids heredoc-inside-$() which breaks Bash 3.2
-	# (single quotes in heredoc content confuse the Bash 3.2 $() nesting parser).
-	# GH#21782: pre-existing Bash 3.2 compat fix bundled with PyYAML/sed PR.
+	# Bash 3.2 compat: heredoc inside $() fails parse; write to tmp file instead.
 	local _body_tmp
 	_body_tmp=$(mktemp)
 	cat >"$_body_tmp" <<MARKDOWN
@@ -97,7 +95,7 @@ Counter source: \`${stats_file/#$HOME/\~}\`
 
 ## Why
 
-Sharp counter regressions are the supervisor’s structural blind spot — they appear in operational state long before they manifest as failed issues. Each regression cited above warrants investigation: a 3x-or-greater jump on a counter usually means a config change, a new bottleneck, or a regression in a recently-deployed script.
+Sharp counter regressions are the supervisor's structural blind spot — they appear in operational state long before they manifest as failed issues. Each regression cited above warrants investigation: a 3x-or-greater jump on a counter usually means a config change, a new bottleneck, or a regression in a recently-deployed script.
 
 ## How
 

--- a/.agents/scripts/stats-quality-sweep-issues.sh
+++ b/.agents/scripts/stats-quality-sweep-issues.sh
@@ -38,15 +38,126 @@ fi
 # --- Functions ---
 
 #######################################
-# Ensure persistent quality review issue exists for a repo
+# Search for an open quality dashboard issue by labels.
 #
-# Creates or finds the "Daily Code Quality Review" issue. Uses labels
-# "quality-review" + "persistent" for dedup. Pins the issue.
+# Fail-closed: returns 1 on any gh API error so the caller aborts
+# instead of falling through to creation (the original fail-open bug).
+#
+# Arguments:
+#   $1 - repo_slug
+#   $2 - quality-review label name
+#   $3 - persistent label name
+# Output: issue number to stdout (empty if not found)
+# Returns: 0 on success (even if not found), 1 on API error
+#######################################
+_quality_issue_label_search() {
+	local repo_slug="$1"
+	local lbl_review="$2"
+	local lbl_persist="$3"
+
+	local raw_output exit_code
+	raw_output=$(gh issue list --repo "$repo_slug" \
+		--label "$lbl_review" --label "$lbl_persist" \
+		--state open --json number \
+		--jq '.[0].number // empty' 2>&1)
+	exit_code=$?
+
+	if [[ "$exit_code" -ne 0 ]]; then
+		echo "[stats] Quality sweep: label search API error (exit ${exit_code}): ${raw_output}" >>"${LOGFILE:-/dev/null}"
+		return 1
+	fi
+
+	printf '%s' "$raw_output"
+	return 0
+}
+
+#######################################
+# Search for an open quality dashboard issue by title prefix.
+#
+# Used as a fallback when label search returns empty but succeeds.
+# Labels can be stripped by reconcilers; the title prefix is invariant.
+# Fail-closed: returns 1 on any gh API error.
+#
+# Arguments:
+#   $1 - repo_slug
+# Output: issue number to stdout (empty if not found)
+# Returns: 0 on success (even if not found), 1 on API error
+#######################################
+_quality_issue_title_search() {
+	local repo_slug="$1"
+
+	local raw_output exit_code
+	raw_output=$(gh issue list --repo "$repo_slug" \
+		--state open --search "\"Code Audit Routines\" in:title" \
+		--json number --jq '.[0].number // empty' 2>&1)
+	exit_code=$?
+
+	if [[ "$exit_code" -ne 0 ]]; then
+		echo "[stats] Quality sweep: title search API error (exit ${exit_code}): ${raw_output}" >>"${LOGFILE:-/dev/null}"
+		return 1
+	fi
+
+	printf '%s' "$raw_output"
+	return 0
+}
+
+#######################################
+# Close all open "Code Audit Routines" sibling issues except the survivor.
+#
+# Self-healing sweep: called post-create to close any duplicates that
+# accumulated during prior label-search failures. Models on
+# pulse-merge.sh::_close_superseded_prs — close with comment, best-effort.
+#
+# Arguments:
+#   $1 - repo_slug
+#   $2 - survivor_issue_number (the one to keep open)
+# Returns: 0 always (best-effort, never blocks the caller)
+#######################################
+_quality_issue_close_duplicates() {
+	local repo_slug="$1"
+	local survivor="$2"
+
+	local siblings_json
+	siblings_json=$(gh issue list --repo "$repo_slug" \
+		--state open --search "\"Code Audit Routines\" in:title" \
+		--json number --jq '[.[].number]' 2>/dev/null) || return 0
+
+	[[ -z "$siblings_json" ]] && return 0
+
+	local num
+	while IFS= read -r num; do
+		[[ -z "$num" ]] && continue
+		[[ "$num" == "$survivor" ]] && continue
+		local close_body="> Auto-closed: superseded by #${survivor} as duplicate quality dashboard."
+		gh issue comment "$num" --repo "$repo_slug" --body "$close_body" 2>/dev/null || true
+		gh issue close "$num" --repo "$repo_slug" 2>/dev/null || true
+		echo "[stats] Quality sweep: closed duplicate dashboard #${num} (survivor: #${survivor})" >>"${LOGFILE:-/dev/null}"
+	done < <(printf '%s\n' "$siblings_json" | jq -r '.[]' 2>/dev/null)
+
+	return 0
+}
+
+#######################################
+# Ensure persistent quality review issue exists for a repo.
+#
+# Creates or finds the "Code Audit Routines" dashboard issue.
+# Dedup strategy (fail-closed, t3074):
+#   1. Try per-machine cache (fast path).
+#   2. Validate cache via gh issue view — only invalidate on definitive
+#      non-OPEN state; transient API errors keep the cache to prevent
+#      false-create.
+#   3. Label search (fail-closed) — abort entire sweep on API error.
+#   4. Title-prefix fallback — runs only when label search returns empty.
+#      Abort if this API call also fails.
+#   5. Create only when BOTH searches confirmed zero matches.
+#   6. Post-create: run _quality_issue_close_duplicates to reclaim any
+#      siblings created during prior failures.
 #
 # Arguments:
 #   $1 - repo slug
 # Output: issue number to stdout
-# Returns: 0 on success, 1 if issue could not be created/found
+# Returns: 0 on success, 1 if issue could not be found/created or if
+#          any dedup API call fails (fail-closed)
 #######################################
 _ensure_quality_issue() {
 	local repo_slug="$1"
@@ -65,25 +176,42 @@ _ensure_quality_issue() {
 		issue_number=$(cat "$cache_file" 2>/dev/null || echo "")
 	fi
 
-	# Validate cached issue is still open
+	# Validate cached issue — only invalidate on a definitive non-OPEN
+	# response. Transient API failures (non-zero exit, empty state) keep
+	# the cache to avoid triggering the creation path erroneously.
 	if [[ -n "$issue_number" ]]; then
-		local state
-		state=$(gh issue view "$issue_number" --repo "$repo_slug" --json state --jq '.state' 2>/dev/null || echo "")
-		if [[ "$state" != "OPEN" ]]; then
+		local state gh_exit
+		state=$(gh issue view "$issue_number" --repo "$repo_slug" --json state --jq '.state' 2>/dev/null)
+		gh_exit=$?
+		if [[ "$gh_exit" -eq 0 && -n "$state" && "$state" != "OPEN" ]]; then
+			# Definitively closed/merged — invalidate cache
 			issue_number=""
 			rm -f "$cache_file" 2>/dev/null || true
 		fi
+		# Transient failure: keep cache and proceed as if valid
 	fi
 
-	# Search by labels
+	# Label search — fail-closed: abort sweep on any API error
 	if [[ -z "$issue_number" ]]; then
-		issue_number=$(gh issue list --repo "$repo_slug" \
-			--label "$lbl_review" --label "$lbl_persist" \
-			--state open --json number \
-			--jq '.[0].number // empty' 2>/dev/null || echo "")
+		local label_result
+		label_result=$(_quality_issue_label_search "$repo_slug" "$lbl_review" "$lbl_persist") || {
+			echo "[stats] Quality sweep: aborting — label search API failure for ${repo_slug}" >>"${LOGFILE:-/dev/null}"
+			return 1
+		}
+		issue_number="$label_result"
 	fi
 
-	# Create if missing
+	# Title-prefix fallback — only runs when label search returned empty
+	if [[ -z "$issue_number" ]]; then
+		local title_result
+		title_result=$(_quality_issue_title_search "$repo_slug") || {
+			echo "[stats] Quality sweep: aborting — title search API failure for ${repo_slug}" >>"${LOGFILE:-/dev/null}"
+			return 1
+		}
+		issue_number="$title_result"
+	fi
+
+	# Create only when BOTH searches confirmed zero open matches
 	if [[ -z "$issue_number" ]]; then
 		# Ensure labels exist
 		gh label create "$lbl_review" --repo "$repo_slug" --color "7057FF" \
@@ -104,7 +232,7 @@ _ensure_quality_issue() {
 			--label "$lbl_review" --label "$lbl_persist" --label "$lbl_source" 2>/dev/null | grep -oE '[0-9]+$' || echo "")
 
 		if [[ -z "$issue_number" ]]; then
-			echo "[stats] Quality sweep: could not create issue for ${repo_slug}" >>"$LOGFILE"
+			echo "[stats] Quality sweep: could not create issue for ${repo_slug}" >>"${LOGFILE:-/dev/null}"
 			return 1
 		fi
 
@@ -120,10 +248,13 @@ _ensure_quality_issue() {
 				}" >/dev/null 2>&1 || true
 		fi
 
-		echo "[stats] Quality sweep: created and pinned issue #${issue_number} in ${repo_slug}" >>"$LOGFILE"
+		echo "[stats] Quality sweep: created and pinned issue #${issue_number} in ${repo_slug}" >>"${LOGFILE:-/dev/null}"
+
+		# Post-create defensive sweep: close any siblings from prior failures
+		_quality_issue_close_duplicates "$repo_slug" "$issue_number"
 	fi
 
-	# Cache
+	# Cache the winner
 	echo "$issue_number" >"$cache_file"
 	echo "$issue_number"
 	return 0

--- a/.agents/scripts/tests/test-stats-quality-sweep-issues.sh
+++ b/.agents/scripts/tests/test-stats-quality-sweep-issues.sh
@@ -1,0 +1,347 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-stats-quality-sweep-issues.sh — t3074 regression guard.
+#
+# Guards the three changes in _ensure_quality_issue() that fix the
+# cross-runner duplicate "Code Audit Routines" dashboard bug:
+#
+#   (a) label-search-fails-do-not-create:
+#       When gh issue list exits nonzero, _ensure_quality_issue returns 1
+#       and does NOT call gh_create_issue.
+#
+#   (b) title-prefix-fallback-finds-existing:
+#       When label search returns empty (but succeeds), a title-prefix
+#       search runs. If it finds an issue, no new issue is created.
+#
+#   (c) post-create-sweep-closes-siblings:
+#       After a new dashboard is created, _quality_issue_close_duplicates
+#       closes all open sibling issues except the new one.
+#
+# Stub strategy: define `gh`, `gh_create_issue`, `jq` as shell functions
+# AFTER sourcing the library. Shell functions take precedence over PATH
+# binaries. Each test case redefines the stubs to its scenario.
+#
+# Cross-references: GH#21830 / t3074 (fix), GH#10308 (prior class-fix).
+
+set -uo pipefail
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR_TEST}/.." && pwd)" || exit 1
+
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_BLUE=$'\033[0;34m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_BLUE="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf '  %sPASS%s %s\n' "$TEST_GREEN" "$TEST_NC" "$1"
+	return 0
+}
+
+fail() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '  %sFAIL%s %s\n' "$TEST_RED" "$TEST_NC" "$1"
+	if [[ -n "${2:-}" ]]; then
+		printf '       %s\n' "$2"
+	fi
+	return 0
+}
+
+# =============================================================================
+# Sandbox setup
+# =============================================================================
+TMP=$(mktemp -d -t t3074.XXXXXX)
+trap 'rm -rf "$TMP"' EXIT
+
+GH_CALLS="${TMP}/gh_calls.log"
+CREATE_CALLS="${TMP}/create_calls.log"
+CLOSE_CALLS="${TMP}/close_calls.log"
+LOGFILE="${TMP}/test.log"
+export LOGFILE
+
+# =============================================================================
+# Source the library with quiet stubs
+# =============================================================================
+print_info() { :; }
+print_warning() { :; }
+print_error() { :; }
+print_success() { :; }
+log_verbose() { :; }
+export -f print_info print_warning print_error print_success log_verbose
+
+# gh_create_issue is a wrapper defined in shared-constants.sh; stub it directly
+gh_create_issue() {
+	echo "gh_create_issue $*" >>"$CREATE_CALLS"
+	# Simulate successful creation returning a URL with issue number
+	printf 'https://github.com/test/repo/issues/999\n'
+	return 0
+}
+export -f gh_create_issue
+
+# gh_issue_edit_safe stub
+gh_issue_edit_safe() { return 0; }
+export -f gh_issue_edit_safe
+
+# Suppress stats-quality-sweep-coverage.sh dependency functions
+_compute_bot_coverage() { printf 'no coverage'; return 0; }
+_compute_badge_indicator() { printf 'OK'; return 0; }
+export -f _compute_bot_coverage _compute_badge_indicator
+
+# shellcheck source=../stats-quality-sweep-issues.sh
+source "${SCRIPTS_DIR}/stats-quality-sweep-issues.sh" 2>/dev/null || {
+	printf '%sFATAL%s could not source stats-quality-sweep-issues.sh\n' "$TEST_RED" "$TEST_NC"
+	exit 1
+}
+
+# =============================================================================
+# Test (a): label search API failure → abort, no creation
+# =============================================================================
+printf '\n%s[a] label-search-fails-do-not-create%s\n' "$TEST_BLUE" "$TEST_NC"
+
+# Clear logs
+true >"$CREATE_CALLS"
+true >"$GH_CALLS"
+
+# Stub: gh issue list returns nonzero (simulates API error).
+# No cache file — forces the function to go through the label search path.
+gh() {
+	echo "gh $*" >>"$GH_CALLS"
+	case "$*" in
+	*"issue list"*)
+		# Simulate transient API failure
+		printf 'error: API rate limit exceeded\n' >&2
+		return 1
+		;;
+	*"label create"*)
+		return 0
+		;;
+	esac
+	return 0
+}
+export -f gh
+
+jq() { command jq "$@"; return 0; }
+export -f jq
+
+# Override HOME so cache file is isolated; ensure no stale cache exists
+_original_home="$HOME"
+export HOME="$TMP"
+mkdir -p "${TMP}/.aidevops/logs"
+rm -f "${TMP}/.aidevops/logs/quality-issue-test-repo"
+
+result=$(_ensure_quality_issue "test/repo" 2>/dev/null)
+rc=$?
+export HOME="$_original_home"
+
+if [[ "$rc" -ne 0 ]]; then
+	pass "label-search-fails-returns-1"
+else
+	fail "label-search-fails-returns-1" "expected return 1, got $rc"
+fi
+
+if [[ ! -s "$CREATE_CALLS" ]]; then
+	pass "label-search-fails-no-create"
+else
+	fail "label-search-fails-no-create" "gh_create_issue was called: $(cat "$CREATE_CALLS")"
+fi
+
+# =============================================================================
+# Test (b): title-prefix fallback finds existing issue → no creation
+# =============================================================================
+printf '\n%s[b] title-prefix-fallback-finds-existing%s\n' "$TEST_BLUE" "$TEST_NC"
+
+true >"$CREATE_CALLS"
+true >"$GH_CALLS"
+
+# Stub: label search succeeds but returns empty; title search finds #456
+gh() {
+	echo "gh $*" >>"$GH_CALLS"
+	case "$*" in
+	*"issue view"*)
+		printf 'OPEN\n'
+		return 0
+		;;
+	*"issue list"*"quality-review"*)
+		# Label search: returns empty (no labels found) — exit 0
+		printf ''
+		return 0
+		;;
+	*"issue list"*"Code Audit Routines"*)
+		# Title-prefix fallback: finds existing issue 456
+		printf '456\n'
+		return 0
+		;;
+	*"label create"*)
+		return 0
+		;;
+	esac
+	return 0
+}
+export -f gh
+
+jq() { command jq "$@"; return 0; }
+export -f jq
+
+export HOME="$TMP"
+rm -f "${TMP}/.aidevops/logs/quality-issue-test-repo"
+
+result=$(_ensure_quality_issue "test/repo" 2>/dev/null)
+rc=$?
+export HOME="$_original_home"
+
+if [[ "$rc" -eq 0 && "$result" == "456" ]]; then
+	pass "title-fallback-returns-existing-number"
+else
+	fail "title-fallback-returns-existing-number" "expected 0/456, got rc=$rc result='$result'"
+fi
+
+if [[ ! -s "$CREATE_CALLS" ]]; then
+	pass "title-fallback-no-create"
+else
+	fail "title-fallback-no-create" "gh_create_issue was called: $(cat "$CREATE_CALLS")"
+fi
+
+# Verify title search was called (check gh log contains "Code Audit Routines")
+if grep -q "Code Audit Routines" "$GH_CALLS" 2>/dev/null; then
+	pass "title-search-was-invoked"
+else
+	fail "title-search-was-invoked" "title search not found in gh calls: $(cat "$GH_CALLS")"
+fi
+
+# =============================================================================
+# Test (c): post-create defensive sweep closes siblings
+# =============================================================================
+printf '\n%s[c] post-create-sweep-closes-siblings%s\n' "$TEST_BLUE" "$TEST_NC"
+
+true >"$CREATE_CALLS"
+true >"$GH_CALLS"
+true >"$CLOSE_CALLS"
+
+# Track what gets closed
+CLOSED_NUMS="${TMP}/closed_nums.log"
+true >"$CLOSED_NUMS"
+
+# Stub: both searches return empty → create fires; sibling search finds 2 extras
+gh() {
+	echo "gh $*" >>"$GH_CALLS"
+	case "$*" in
+	*"issue view"*"--json state"*)
+		printf 'OPEN\n'
+		return 0
+		;;
+	*"issue view"*"--json id"*)
+		printf '{"id":"node_abc"}\n' | command jq -r '.id'
+		return 0
+		;;
+	*"issue list"*"quality-review"*)
+		# Label search: empty
+		printf ''
+		return 0
+		;;
+	*"issue list"*"Code Audit Routines"*".[0].number"*)
+		# Title-prefix search (--jq '.[0].number // empty'): return empty
+		# so the create path executes
+		printf ''
+		return 0
+		;;
+	*"issue list"*"Code Audit Routines"*"[.[].number]"*)
+		# Sibling search in _quality_issue_close_duplicates (--jq '[.[].number]'):
+		# return a JSON array containing the new issue (999) plus two siblings
+		printf '[100,200,999]\n'
+		return 0
+		;;
+	*"issue comment"*)
+		local num
+		num=$(printf '%s' "$*" | grep -oE '[0-9]+' | head -1)
+		echo "comment:$num" >>"$CLOSE_CALLS"
+		return 0
+		;;
+	*"issue close"*)
+		local num
+		num=$(printf '%s' "$*" | grep -oE '[0-9]+' | head -1)
+		echo "close:$num" >>"$CLOSE_CALLS"
+		return 0
+		;;
+	*"label create"*)
+		return 0
+		;;
+	*"api graphql"*)
+		return 0
+		;;
+	esac
+	return 0
+}
+export -f gh
+
+jq() {
+	if [[ "${1:-}" == "-r" && "${2:-}" == ".[]" ]]; then
+		# Parse the JSON array from siblings search
+		command jq -r '.[]' 2>/dev/null || printf '100\n200\n999\n'
+		return 0
+	fi
+	command jq "$@"
+	return 0
+}
+export -f jq
+
+export HOME="$TMP"
+rm -f "${TMP}/.aidevops/logs/quality-issue-test-repo"
+# Also clear the gh-signature-helper output
+GH_SIG_CALLED="${TMP}/sig_called"
+true >"$GH_SIG_CALLED"
+
+# Stub gh-signature-helper.sh
+# shellcheck disable=SC2034
+_orig_home_sig="$HOME"
+
+result=$(_ensure_quality_issue "test/repo" 2>/dev/null)
+rc=$?
+export HOME="$_original_home"
+
+if [[ "$rc" -eq 0 ]]; then
+	pass "post-create-sweep-create-succeeded"
+else
+	fail "post-create-sweep-create-succeeded" "expected rc=0, got $rc"
+fi
+
+# Check that close was called for siblings (100, 200) but NOT for survivor (999)
+if grep -q "close:100" "$CLOSE_CALLS" 2>/dev/null; then
+	pass "post-create-sweep-closed-sibling-100"
+else
+	fail "post-create-sweep-closed-sibling-100" "close:100 not found in: $(cat "$CLOSE_CALLS" 2>/dev/null)"
+fi
+
+if grep -q "close:200" "$CLOSE_CALLS" 2>/dev/null; then
+	pass "post-create-sweep-closed-sibling-200"
+else
+	fail "post-create-sweep-closed-sibling-200" "close:200 not found in: $(cat "$CLOSE_CALLS" 2>/dev/null)"
+fi
+
+if ! grep -q "close:999" "$CLOSE_CALLS" 2>/dev/null; then
+	pass "post-create-sweep-preserved-survivor"
+else
+	fail "post-create-sweep-preserved-survivor" "survivor 999 was incorrectly closed"
+fi
+
+# =============================================================================
+# Summary
+# =============================================================================
+printf '\n'
+if [[ "$TESTS_FAILED" -eq 0 ]]; then
+	printf '%sAll %d tests passed.%s\n' "$TEST_GREEN" "$TESTS_RUN" "$TEST_NC"
+	exit 0
+else
+	printf '%s%d of %d tests FAILED.%s\n' "$TEST_RED" "$TESTS_FAILED" "$TESTS_RUN" "$TEST_NC"
+	exit 1
+fi


### PR DESCRIPTION
## Summary

Fixes the cross-runner duplicate "Code Audit Routines" dashboard bug (t3074). Four dashboard issues existed (#2632, #20409, #20845, #21670) because the label-search dedup was fail-open: any transient API error silently resulted in a new issue being created.

## What

### Core fix: fail-closed dedup in `_ensure_quality_issue()`

Three extracted helper functions keep the orchestrator ≤100 lines:

- `_quality_issue_label_search()` — label search, fail-closed: returns 1 on any `gh` API error so the caller aborts the entire sweep rather than proceeding to create
- `_quality_issue_title_search()` — title-prefix fallback after empty label search; invariant even if labels are stripped by reconcilers; also fail-closed
- `_quality_issue_close_duplicates()` — post-create self-healing sweep: closes all sibling "Code Audit Routines" issues except the new survivor, with a closing comment

### Cache validation fix

Transient `gh issue view` failures no longer invalidate the per-machine cache. Only a definitive non-OPEN state (state is set AND non-empty AND not OPEN) triggers invalidation. Previously any transient failure forced the label-search path where the fail-open bug lived.

### One-time cleanup

`.agents/scripts/cleanup-quality-dashboard-dupes.sh` — idempotent one-shot script that closes #2632, #20409, #20845 with a superseded comment. Verified: all three are already CLOSED, #21670 is open (1 survivor confirmed).

## Tests

`bash .agents/scripts/tests/test-stats-quality-sweep-issues.sh` — **9/9 pass**:
- (a) label-search-fails-returns-1, label-search-fails-no-create
- (b) title-fallback-returns-existing-number, title-fallback-no-create, title-search-was-invoked
- (c) post-create-sweep-create-succeeded, closed-sibling-100, closed-sibling-200, preserved-survivor

## Verification

```bash
shellcheck .agents/scripts/stats-quality-sweep-issues.sh  # PASS
bash .agents/scripts/tests/test-stats-quality-sweep-issues.sh  # 9/9 PASS
gh issue list --repo marcusquinn/aidevops \
  --label quality-review --label persistent --state open \
  --json number --jq 'length'  # 1
```

Resolves #21830

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.11 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-sonnet-4-6 spent 10m and 27,840 tokens on this as a headless worker.