### PR TITLE
GH#21793: add 5 MB image preflight guard for user-pasted images

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -263,6 +263,8 @@ Reference code as `file_path:line_number` for easy navigation.
 
 Images >8000px crash session irrecoverably. NEVER `fullPage: true` for AI review. Max 1568px longest side. Use `browser-qa-helper.sh screenshot` (only guarded path). Full rules: `reference/screenshot-limits.md`.
 
+**User-pasted images (GH#21793):** Images >5 MB (the Anthropic API byte-size ceiling) also crash the session permanently. macOS Retina screenshots routinely exceed this. The OpenCode plugin intercepts and downscales automatically. On Claude Code, run `screenshot-import-helper.sh prepare <path>` before pasting — it sanitizes U+202F filenames AND downscales if needed. Full rules: `reference/screenshot-limits.md` "User-Provided Images".
+
 **macOS screenshot filename bug (U+202F):** macOS inserts a narrow no-break space (U+202F, UTF-8: `e2 80 af`) before AM/PM in screenshot filenames. The Read tool truncates paths at this character and returns `File not found: /Users`. If this happens, run `screenshot-import-helper.sh sanitize <path>` — it copies the file to a clean temp path and prints it. Full details: `reference/screenshot-limits.md` "macOS Filename Hygiene".
 
 ### Error Prevention (top recurring patterns)

--- a/.agents/plugins/opencode-aidevops/image-guard.mjs
+++ b/.agents/plugins/opencode-aidevops/image-guard.mjs
@@ -1,0 +1,316 @@
+// ---------------------------------------------------------------------------
+// image-guard.mjs — User-image size preflight for OpenCode plugin (GH#21793)
+//
+// Intercepts images in user messages before they reach the Anthropic API.
+// The 5 MB per-image base64 limit is enforced server-side; oversized images
+// crash the session permanently because the payload is already in message
+// history and replays on every subsequent API call.
+//
+// Runs inside the experimental.chat.messages.transform hook (ttsrMessagesTransform
+// in ttsr.mjs). For each image part in user messages:
+//   1. Measure the decoded byte size (Buffer.byteLength — O(1), no decode).
+//   2. If >4.5 MB (10% headroom under Anthropic's 5 MB ceiling):
+//      a. Attempt downscale via sips (macOS built-in) or magick (cross-platform).
+//      b. If downscaled image fits in 4.5 MB → substitute silently + log warn.
+//      c. If downscale fails or result still too large → replace with text notice
+//         so the session continues rather than crashing.
+//   3. Images ≤4.5 MB pass through unchanged (O(1) cost per image part).
+//
+// Handles both OpenCode internal image part formats:
+//   - Data URI:  { type: "image", url: "data:<mediaType>;base64,<data>" }
+//   - SDK form:  { type: "image", source: { type: "base64", media_type, data } }
+//   - Tool form: nested under part.image.source (tool_result images)
+// ---------------------------------------------------------------------------
+
+import { execSync } from "child_process";
+import { writeFileSync, readFileSync, unlinkSync, mkdtempSync, rmdirSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** 4.5 MB decoded bytes — 10% headroom under Anthropic's 5 MB (5,242,880) ceiling. */
+const MAX_IMAGE_BYTES = 4_718_592;
+
+/** Vision-API efficiency ceiling: already documented in reference/screenshot-limits.md. */
+const MAX_DIM = 1568;
+
+/** Downscale shell command timeout (ms). */
+const DOWNSCALE_TIMEOUT_MS = 15_000;
+
+// ---------------------------------------------------------------------------
+// Image data extraction — handles multiple OpenCode formats
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract base64 image data and media type from an OpenCode message part.
+ * Returns null if the part does not contain a recognisable image payload.
+ *
+ * @param {object} part
+ * @returns {{ data: string, mediaType: string, format: "url"|"sdk"|"image-source" } | null}
+ */
+function extractImageData(part) {
+  // Data URI format: url = "data:image/png;base64,<data>"
+  if (typeof part.url === "string" && part.url.startsWith("data:")) {
+    const comma = part.url.indexOf(",");
+    if (comma < 0) return null;
+    const header = part.url.slice(0, comma);  // "data:image/png;base64"
+    const data = part.url.slice(comma + 1);
+    if (!data) return null;
+    const mediaType = header.split(":")[1]?.split(";")[0] || "image/png";
+    return { data, mediaType, format: "url" };
+  }
+
+  // Anthropic SDK format: { source: { type: "base64", media_type, data } }
+  if (part.source?.type === "base64" && typeof part.source.data === "string") {
+    return {
+      data: part.source.data,
+      mediaType: part.source.media_type || part.source.mediaType || "image/png",
+      format: "sdk",
+    };
+  }
+
+  // Tool-result image format: { image: { source: { type: "base64", ... } } }
+  if (part.image?.source?.type === "base64" && typeof part.image.source.data === "string") {
+    return {
+      data: part.image.source.data,
+      mediaType: part.image.source.media_type || part.image.source.mediaType || "image/png",
+      format: "image-source",
+    };
+  }
+
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Byte-size measurement (O(1), no full decode)
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the decoded byte count of a base64 string.
+ * Uses Node.js Buffer.byteLength which is O(1) — it does not decode the string.
+ *
+ * @param {string} b64
+ * @returns {number}
+ */
+function base64DecodedSize(b64) {
+  return Buffer.byteLength(b64, "base64");
+}
+
+// ---------------------------------------------------------------------------
+// Downscale helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Determine the file extension from a MIME media type string.
+ * @param {string} mediaType  e.g. "image/png", "image/jpeg"
+ * @returns {string}
+ */
+function extFromMediaType(mediaType) {
+  if (/jpe?g/i.test(mediaType)) return "jpg";
+  if (/gif/i.test(mediaType)) return "gif";
+  if (/webp/i.test(mediaType)) return "webp";
+  return "png";
+}
+
+/**
+ * Try to downscale the image using sips (macOS) or magick (cross-platform).
+ * Writes src to a temp file, runs the tool, reads the result back.
+ * Returns new base64 string on success, null on any failure.
+ *
+ * @param {string} b64       Base64-encoded source image
+ * @param {string} mediaType MIME type of the source image
+ * @returns {string | null}
+ */
+function downscaleImage(b64, mediaType) {
+  const ext = extFromMediaType(mediaType);
+  let tmpDir = null;
+
+  try {
+    tmpDir = mkdtempSync(join(tmpdir(), "aidevops-imgguard-"));
+    const srcPath = join(tmpDir, `src.${ext}`);
+    const dstPath = join(tmpDir, `dst.${ext}`);
+
+    writeFileSync(srcPath, Buffer.from(b64, "base64"));
+
+    let resized = false;
+
+    // sips — macOS built-in, no external dependency required.
+    if (!resized) {
+      try {
+        execSync(
+          `sips --resampleHeightWidthMax ${MAX_DIM} "${srcPath}" --out "${dstPath}" 2>/dev/null`,
+          { timeout: DOWNSCALE_TIMEOUT_MS, stdio: ["pipe", "pipe", "pipe"] },
+        );
+        resized = true;
+      } catch {
+        // sips unavailable or failed — fall through to magick.
+      }
+    }
+
+    // ImageMagick — cross-platform fallback.
+    if (!resized) {
+      try {
+        execSync(
+          `magick "${srcPath}" -resize "${MAX_DIM}x${MAX_DIM}>" "${dstPath}" 2>/dev/null`,
+          { timeout: DOWNSCALE_TIMEOUT_MS, stdio: ["pipe", "pipe", "pipe"] },
+        );
+        resized = true;
+      } catch {
+        // magick also unavailable or failed — cannot downscale.
+      }
+    }
+
+    if (!resized) return null;
+
+    return readFileSync(dstPath).toString("base64");
+  } catch {
+    return null;
+  } finally {
+    // Best-effort cleanup of temp files — failures here are non-fatal.
+    if (tmpDir !== null) {
+      const srcPath = join(tmpDir, `src.${ext}`);
+      const dstPath = join(tmpDir, `dst.${ext}`);
+      try { unlinkSync(srcPath); } catch { /* ignore */ }
+      try { unlinkSync(dstPath); } catch { /* ignore */ }
+      try { rmdirSync(tmpDir); } catch { /* ignore */ }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Part mutator — applies guard to a single image part
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply the size guard to a single image part.
+ * Returns the original part unchanged if within limits, or a new part
+ * (downscaled image or text notice) if the limit was exceeded.
+ *
+ * @param {object} part       Original message part (type === "image")
+ * @param {Function} qualityLog  Bound quality logger (level, message) => void
+ * @returns {{ modified: boolean, part: object }}
+ */
+function guardImagePart(part, qualityLog) {
+  const extracted = extractImageData(part);
+  if (!extracted) return { modified: false, part };
+
+  const { data, mediaType, format } = extracted;
+  const sizeBytes = base64DecodedSize(data);
+
+  if (sizeBytes <= MAX_IMAGE_BYTES) return { modified: false, part };
+
+  const sizeMB = (sizeBytes / 1_048_576).toFixed(1);
+  qualityLog(
+    "WARN",
+    `[image-guard] Oversized image detected: ${sizeMB} MB (limit 4.5 MB) — attempting downscale`,
+  );
+
+  const resizedB64 = downscaleImage(data, mediaType);
+
+  if (resizedB64 !== null) {
+    const newSize = base64DecodedSize(resizedB64);
+    if (newSize <= MAX_IMAGE_BYTES) {
+      const newSizeMB = (newSize / 1_048_576).toFixed(1);
+      qualityLog(
+        "INFO",
+        `[image-guard] Downscaled ${sizeMB} MB → ${newSizeMB} MB (session preserved)`,
+      );
+
+      // Build a new part with the resized image data substituted in.
+      const newPart = { ...part };
+      if (format === "url") {
+        newPart.url = `data:${mediaType};base64,${resizedB64}`;
+      } else if (format === "sdk") {
+        newPart.source = { ...part.source, data: resizedB64 };
+      } else {
+        // "image-source" format
+        newPart.image = {
+          ...part.image,
+          source: { ...part.image.source, data: resizedB64 },
+        };
+      }
+      return { modified: true, part: newPart };
+    }
+
+    const stillSizeMB = (newSize / 1_048_576).toFixed(1);
+    qualityLog(
+      "WARN",
+      `[image-guard] Downscaled image still ${stillSizeMB} MB (> 4.5 MB). Replacing with text notice.`,
+    );
+  } else {
+    qualityLog(
+      "WARN",
+      `[image-guard] Downscale failed (sips/magick unavailable). Replacing image with text notice.`,
+    );
+  }
+
+  // Fallback: replace the image with a text notice so the session continues
+  // rather than crashing on the next API call with "image exceeds 5 MB maximum".
+  const noticePart = {
+    id: part.id,
+    sessionID: part.sessionID,
+    messageID: part.messageID,
+    type: "text",
+    text: [
+      `[aidevops image-guard] Image removed (${sizeMB} MB > 4.5 MB preflight limit).`,
+      "",
+      "Automatic downscaling was not successful. Please resize the image before pasting:",
+      `  macOS: sips --resampleHeightWidthMax ${MAX_DIM} <path> --out <path>-resized.png`,
+      `  cross-platform: magick <path> -resize "${MAX_DIM}x${MAX_DIM}>" <path>-resized.png`,
+      "  helper: screenshot-import-helper.sh prepare <path>",
+      "",
+      "Session continues — the oversized image was not sent to the API.",
+    ].join("\n"),
+    synthetic: true,
+  };
+  return { modified: true, part: noticePart };
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Walk all user messages in the output.messages array and apply image size
+ * guards. Mutates message.parts in place for any affected messages.
+ *
+ * Called from ttsrMessagesTransform (ttsr.mjs) on every messages.transform
+ * invocation. Cost is O(image_count) — one O(1) byte-size check per image
+ * part; downscale only triggered when size exceeds 4.5 MB.
+ *
+ * @param {Array<object>} messages  output.messages array from the hook
+ * @param {Function} qualityLog     Bound quality logger (level, message) => void
+ * @returns {boolean}               true if any image was modified
+ */
+export function applyImageGuard(messages, qualityLog) {
+  if (!Array.isArray(messages) || messages.length === 0) return false;
+
+  let anyModified = false;
+
+  for (const message of messages) {
+    // Only inspect user messages — assistant messages are already in history
+    // and cannot be altered without corrupting the conversation thread.
+    if (message.info?.role !== "user") continue;
+    if (!Array.isArray(message.parts)) continue;
+
+    let messageModified = false;
+    const newParts = message.parts.map((part) => {
+      if (part.type !== "image") return part;
+      const result = guardImagePart(part, qualityLog);
+      if (result.modified) {
+        messageModified = true;
+        anyModified = true;
+      }
+      return result.part;
+    });
+
+    if (messageModified) {
+      message.parts = newParts;
+    }
+  }
+
+  return anyModified;
+}

--- a/.agents/plugins/opencode-aidevops/image-guard.mjs
+++ b/.agents/plugins/opencode-aidevops/image-guard.mjs
@@ -3,20 +3,20 @@
 //
 // Intercepts images in user messages before they reach the Anthropic API.
 // The 5 MB per-image base64 limit is enforced server-side; oversized images
-// crash the session permanently because the payload is already in message
-// history and replays on every subsequent API call.
+// crash the session permanently — the payload is already in message history
+// and replays on every subsequent API call.
 //
 // Runs inside the experimental.chat.messages.transform hook (ttsrMessagesTransform
 // in ttsr.mjs). For each image part in user messages:
-//   1. Measure the decoded byte size (Buffer.byteLength — O(1), no decode).
+//   1. Measure the decoded byte size via Buffer.byteLength (O(1), no decode).
 //   2. If >4.5 MB (10% headroom under Anthropic's 5 MB ceiling):
 //      a. Attempt downscale via sips (macOS built-in) or magick (cross-platform).
-//      b. If downscaled image fits in 4.5 MB → substitute silently + log warn.
-//      c. If downscale fails or result still too large → replace with text notice
-//         so the session continues rather than crashing.
+//      b. If downscaled fits in 4.5 MB → substitute silently + log warning.
+//      c. If downscale fails or result still too large → replace with a text
+//         notice so the session continues rather than crashing.
 //   3. Images ≤4.5 MB pass through unchanged (O(1) cost per image part).
 //
-// Handles both OpenCode internal image part formats:
+// Handles OpenCode internal image part formats:
 //   - Data URI:  { type: "image", url: "data:<mediaType>;base64,<data>" }
 //   - SDK form:  { type: "image", source: { type: "base64", media_type, data } }
 //   - Tool form: nested under part.image.source (tool_result images)
@@ -34,63 +34,64 @@ import { tmpdir } from "os";
 /** 4.5 MB decoded bytes — 10% headroom under Anthropic's 5 MB (5,242,880) ceiling. */
 const MAX_IMAGE_BYTES = 4_718_592;
 
-/** Vision-API efficiency ceiling: already documented in reference/screenshot-limits.md. */
+/** Vision-API efficiency ceiling: documented in reference/screenshot-limits.md. */
 const MAX_DIM = 1568;
 
 /** Downscale shell command timeout (ms). */
 const DOWNSCALE_TIMEOUT_MS = 15_000;
 
 // ---------------------------------------------------------------------------
-// Image data extraction — handles multiple OpenCode formats
+// Image data extraction — handles multiple OpenCode internal formats
 // ---------------------------------------------------------------------------
+
+/** Extract image data from a data-URI part. Returns null if not a data URI. */
+function _extractDataUri(part) {
+  if (typeof part.url !== "string" || !part.url.startsWith("data:")) return null;
+  const comma = part.url.indexOf(",");
+  const data = comma >= 0 ? part.url.slice(comma + 1) : "";
+  if (!data) return null;
+  const mediaType = part.url.slice(0, comma).split(":")[1]?.split(";")[0] || "image/png";
+  return { data, mediaType, format: "url" };
+}
+
+/** Extract image data from Anthropic SDK source format. Returns null if not matching. */
+function _extractSdkSource(part) {
+  if (part.source?.type !== "base64" || typeof part.source.data !== "string") return null;
+  return {
+    data: part.source.data,
+    mediaType: part.source.media_type || part.source.mediaType || "image/png",
+    format: "sdk",
+  };
+}
+
+/** Extract image data from tool-result image source format. Returns null if not matching. */
+function _extractImageSource(part) {
+  if (part.image?.source?.type !== "base64" || typeof part.image.source.data !== "string") return null;
+  return {
+    data: part.image.source.data,
+    mediaType: part.image.source.media_type || part.image.source.mediaType || "image/png",
+    format: "image-source",
+  };
+}
 
 /**
  * Extract base64 image data and media type from an OpenCode message part.
- * Returns null if the part does not contain a recognisable image payload.
+ * Tries each known format in order; returns null if none matches.
  *
  * @param {object} part
  * @returns {{ data: string, mediaType: string, format: "url"|"sdk"|"image-source" } | null}
  */
 function extractImageData(part) {
-  // Data URI format: url = "data:image/png;base64,<data>"
-  if (typeof part.url === "string" && part.url.startsWith("data:")) {
-    const comma = part.url.indexOf(",");
-    if (comma < 0) return null;
-    const header = part.url.slice(0, comma);  // "data:image/png;base64"
-    const data = part.url.slice(comma + 1);
-    if (!data) return null;
-    const mediaType = header.split(":")[1]?.split(";")[0] || "image/png";
-    return { data, mediaType, format: "url" };
-  }
-
-  // Anthropic SDK format: { source: { type: "base64", media_type, data } }
-  if (part.source?.type === "base64" && typeof part.source.data === "string") {
-    return {
-      data: part.source.data,
-      mediaType: part.source.media_type || part.source.mediaType || "image/png",
-      format: "sdk",
-    };
-  }
-
-  // Tool-result image format: { image: { source: { type: "base64", ... } } }
-  if (part.image?.source?.type === "base64" && typeof part.image.source.data === "string") {
-    return {
-      data: part.image.source.data,
-      mediaType: part.image.source.media_type || part.image.source.mediaType || "image/png",
-      format: "image-source",
-    };
-  }
-
-  return null;
+  return _extractDataUri(part) || _extractSdkSource(part) || _extractImageSource(part) || null;
 }
 
 // ---------------------------------------------------------------------------
-// Byte-size measurement (O(1), no full decode)
+// Byte-size measurement (O(1), no decode)
 // ---------------------------------------------------------------------------
 
 /**
  * Compute the decoded byte count of a base64 string.
- * Uses Node.js Buffer.byteLength which is O(1) — it does not decode the string.
+ * Buffer.byteLength is O(1) — no decode occurs.
  *
  * @param {string} b64
  * @returns {number}
@@ -103,21 +104,35 @@ function base64DecodedSize(b64) {
 // Downscale helpers
 // ---------------------------------------------------------------------------
 
+/** Map media type keyword to file extension. */
+const MEDIA_TYPE_EXT = { jpeg: "jpg", jpg: "jpg", gif: "gif", webp: "webp" };
+
 /**
- * Determine the file extension from a MIME media type string.
+ * Return the file extension for a MIME media type string.
  * @param {string} mediaType  e.g. "image/png", "image/jpeg"
  * @returns {string}
  */
 function extFromMediaType(mediaType) {
-  if (/jpe?g/i.test(mediaType)) return "jpg";
-  if (/gif/i.test(mediaType)) return "gif";
-  if (/webp/i.test(mediaType)) return "webp";
-  return "png";
+  const keyword = mediaType.toLowerCase().split("/")[1] || "";
+  return MEDIA_TYPE_EXT[keyword] || "png";
+}
+
+/**
+ * Run one downscale command. Returns true on success, false on failure.
+ * @param {string} cmd
+ * @returns {boolean}
+ */
+function runDownscaleCmd(cmd) {
+  try {
+    execSync(cmd, { timeout: DOWNSCALE_TIMEOUT_MS, stdio: ["pipe", "pipe", "pipe"] });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**
  * Try to downscale the image using sips (macOS) or magick (cross-platform).
- * Writes src to a temp file, runs the tool, reads the result back.
  * Returns new base64 string on success, null on any failure.
  *
  * @param {string} b64       Base64-encoded source image
@@ -127,129 +142,47 @@ function extFromMediaType(mediaType) {
 function downscaleImage(b64, mediaType) {
   const ext = extFromMediaType(mediaType);
   let tmpDir = null;
-
   try {
     tmpDir = mkdtempSync(join(tmpdir(), "aidevops-imgguard-"));
     const srcPath = join(tmpDir, `src.${ext}`);
     const dstPath = join(tmpDir, `dst.${ext}`);
-
     writeFileSync(srcPath, Buffer.from(b64, "base64"));
-
-    let resized = false;
-
-    // sips — macOS built-in, no external dependency required.
-    if (!resized) {
-      try {
-        execSync(
-          `sips --resampleHeightWidthMax ${MAX_DIM} "${srcPath}" --out "${dstPath}" 2>/dev/null`,
-          { timeout: DOWNSCALE_TIMEOUT_MS, stdio: ["pipe", "pipe", "pipe"] },
-        );
-        resized = true;
-      } catch {
-        // sips unavailable or failed — fall through to magick.
-      }
-    }
-
-    // ImageMagick — cross-platform fallback.
-    if (!resized) {
-      try {
-        execSync(
-          `magick "${srcPath}" -resize "${MAX_DIM}x${MAX_DIM}>" "${dstPath}" 2>/dev/null`,
-          { timeout: DOWNSCALE_TIMEOUT_MS, stdio: ["pipe", "pipe", "pipe"] },
-        );
-        resized = true;
-      } catch {
-        // magick also unavailable or failed — cannot downscale.
-      }
-    }
-
-    if (!resized) return null;
-
-    return readFileSync(dstPath).toString("base64");
+    const sipsCmd = `sips --resampleHeightWidthMax ${MAX_DIM} "${srcPath}" --out "${dstPath}" 2>/dev/null`;
+    const magickCmd = `magick "${srcPath}" -resize "${MAX_DIM}x${MAX_DIM}>" "${dstPath}" 2>/dev/null`;
+    const ok = runDownscaleCmd(sipsCmd) || runDownscaleCmd(magickCmd);
+    return ok ? readFileSync(dstPath).toString("base64") : null;
   } catch {
     return null;
   } finally {
-    // Best-effort cleanup of temp files — failures here are non-fatal.
     if (tmpDir !== null) {
       const srcPath = join(tmpDir, `src.${ext}`);
       const dstPath = join(tmpDir, `dst.${ext}`);
-      try { unlinkSync(srcPath); } catch { /* ignore */ }
-      try { unlinkSync(dstPath); } catch { /* ignore */ }
-      try { rmdirSync(tmpDir); } catch { /* ignore */ }
+      try { unlinkSync(srcPath); } catch { /* best-effort */ }
+      try { unlinkSync(dstPath); } catch { /* best-effort */ }
+      try { rmdirSync(tmpDir); } catch { /* best-effort */ }
     }
   }
 }
 
 // ---------------------------------------------------------------------------
-// Part mutator — applies guard to a single image part
+// Part mutators — build a modified part from the downscale result
 // ---------------------------------------------------------------------------
 
-/**
- * Apply the size guard to a single image part.
- * Returns the original part unchanged if within limits, or a new part
- * (downscaled image or text notice) if the limit was exceeded.
- *
- * @param {object} part       Original message part (type === "image")
- * @param {Function} qualityLog  Bound quality logger (level, message) => void
- * @returns {{ modified: boolean, part: object }}
- */
-function guardImagePart(part, qualityLog) {
-  const extracted = extractImageData(part);
-  if (!extracted) return { modified: false, part };
-
-  const { data, mediaType, format } = extracted;
-  const sizeBytes = base64DecodedSize(data);
-
-  if (sizeBytes <= MAX_IMAGE_BYTES) return { modified: false, part };
-
-  const sizeMB = (sizeBytes / 1_048_576).toFixed(1);
-  qualityLog(
-    "WARN",
-    `[image-guard] Oversized image detected: ${sizeMB} MB (limit 4.5 MB) — attempting downscale`,
-  );
-
-  const resizedB64 = downscaleImage(data, mediaType);
-
-  if (resizedB64 !== null) {
-    const newSize = base64DecodedSize(resizedB64);
-    if (newSize <= MAX_IMAGE_BYTES) {
-      const newSizeMB = (newSize / 1_048_576).toFixed(1);
-      qualityLog(
-        "INFO",
-        `[image-guard] Downscaled ${sizeMB} MB → ${newSizeMB} MB (session preserved)`,
-      );
-
-      // Build a new part with the resized image data substituted in.
-      const newPart = { ...part };
-      if (format === "url") {
-        newPart.url = `data:${mediaType};base64,${resizedB64}`;
-      } else if (format === "sdk") {
-        newPart.source = { ...part.source, data: resizedB64 };
-      } else {
-        // "image-source" format
-        newPart.image = {
-          ...part.image,
-          source: { ...part.image.source, data: resizedB64 },
-        };
-      }
-      return { modified: true, part: newPart };
-    }
-
-    const stillSizeMB = (newSize / 1_048_576).toFixed(1);
-    qualityLog(
-      "WARN",
-      `[image-guard] Downscaled image still ${stillSizeMB} MB (> 4.5 MB). Replacing with text notice.`,
-    );
-  } else {
-    qualityLog(
-      "WARN",
-      `[image-guard] Downscale failed (sips/magick unavailable). Replacing image with text notice.`,
-    );
+/** Build a new part with the resized base64 substituted in. */
+function buildDownscaledPart(part, format, mediaType, resizedB64) {
+  if (format === "url") {
+    return { ...part, url: `data:${mediaType};base64,${resizedB64}` };
   }
+  if (format === "sdk") {
+    return { ...part, source: { ...part.source, data: resizedB64 } };
+  }
+  // "image-source" format
+  return { ...part, image: { ...part.image, source: { ...part.image.source, data: resizedB64 } } };
+}
 
-  // Fallback: replace the image with a text notice so the session continues
-  // rather than crashing on the next API call with "image exceeds 5 MB maximum".
-  const noticePart = {
+/** Build a text-notice part that replaces an image that could not be made safe. */
+function buildNoticePart(part, sizeMB) {
+  return {
     id: part.id,
     sessionID: part.sessionID,
     messageID: part.messageID,
@@ -257,7 +190,7 @@ function guardImagePart(part, qualityLog) {
     text: [
       `[aidevops image-guard] Image removed (${sizeMB} MB > 4.5 MB preflight limit).`,
       "",
-      "Automatic downscaling was not successful. Please resize the image before pasting:",
+      "Automatic downscaling was not successful. Please resize before pasting:",
       `  macOS: sips --resampleHeightWidthMax ${MAX_DIM} <path> --out <path>-resized.png`,
       `  cross-platform: magick <path> -resize "${MAX_DIM}x${MAX_DIM}>" <path>-resized.png`,
       "  helper: screenshot-import-helper.sh prepare <path>",
@@ -266,7 +199,41 @@ function guardImagePart(part, qualityLog) {
     ].join("\n"),
     synthetic: true,
   };
-  return { modified: true, part: noticePart };
+}
+
+// ---------------------------------------------------------------------------
+// Per-part guard
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply the size guard to a single image part.
+ * Returns the original part unchanged if within limits, otherwise a new part
+ * (downscaled image or text notice).
+ *
+ * @param {object} part
+ * @param {Function} qualityLog
+ * @returns {{ modified: boolean, part: object }}
+ */
+function guardImagePart(part, qualityLog) {
+  const extracted = extractImageData(part);
+  if (!extracted) return { modified: false, part };
+
+  const { data, mediaType, format } = extracted;
+  const sizeBytes = base64DecodedSize(data);
+  if (sizeBytes <= MAX_IMAGE_BYTES) return { modified: false, part };
+
+  const sizeMB = (sizeBytes / 1_048_576).toFixed(1);
+  qualityLog("WARN", `[image-guard] Oversized image: ${sizeMB} MB (limit 4.5 MB) — attempting downscale`);
+
+  const resizedB64 = downscaleImage(data, mediaType);
+  if (resizedB64 !== null && base64DecodedSize(resizedB64) <= MAX_IMAGE_BYTES) {
+    const newMB = (base64DecodedSize(resizedB64) / 1_048_576).toFixed(1);
+    qualityLog("INFO", `[image-guard] Downscaled ${sizeMB} MB → ${newMB} MB (session preserved)`);
+    return { modified: true, part: buildDownscaledPart(part, format, mediaType, resizedB64) };
+  }
+
+  qualityLog("WARN", `[image-guard] Downscale failed — replacing image with text notice`);
+  return { modified: true, part: buildNoticePart(part, sizeMB) };
 }
 
 // ---------------------------------------------------------------------------
@@ -274,12 +241,12 @@ function guardImagePart(part, qualityLog) {
 // ---------------------------------------------------------------------------
 
 /**
- * Walk all user messages in the output.messages array and apply image size
- * guards. Mutates message.parts in place for any affected messages.
+ * Walk all user messages in output.messages and apply image size guards.
+ * Mutates message.parts in place for affected messages.
  *
- * Called from ttsrMessagesTransform (ttsr.mjs) on every messages.transform
- * invocation. Cost is O(image_count) — one O(1) byte-size check per image
- * part; downscale only triggered when size exceeds 4.5 MB.
+ * Called from ttsrMessagesTransform (ttsr.mjs). Cost is O(image_count) —
+ * one O(1) byte-size check per image part; downscale only triggered when
+ * the 4.5 MB limit is exceeded.
  *
  * @param {Array<object>} messages  output.messages array from the hook
  * @param {Function} qualityLog     Bound quality logger (level, message) => void
@@ -291,24 +258,19 @@ export function applyImageGuard(messages, qualityLog) {
   let anyModified = false;
 
   for (const message of messages) {
-    // Only inspect user messages — assistant messages are already in history
-    // and cannot be altered without corrupting the conversation thread.
-    if (message.info?.role !== "user") continue;
-    if (!Array.isArray(message.parts)) continue;
+    if (message.info?.role !== "user" || !Array.isArray(message.parts)) continue;
 
     let messageModified = false;
     const newParts = message.parts.map((part) => {
       if (part.type !== "image") return part;
       const result = guardImagePart(part, qualityLog);
-      if (result.modified) {
-        messageModified = true;
-        anyModified = true;
-      }
+      if (result.modified) messageModified = true;
       return result.part;
     });
 
     if (messageModified) {
       message.parts = newParts;
+      anyModified = true;
     }
   }
 

--- a/.agents/plugins/opencode-aidevops/ttsr.mjs
+++ b/.agents/plugins/opencode-aidevops/ttsr.mjs
@@ -8,6 +8,7 @@ import {
   collectDedupedViolations,
   recordFiredViolations,
 } from "./ttsr-rules.mjs";
+import { applyImageGuard } from "./image-guard.mjs";
 
 // ---------------------------------------------------------------------------
 // Token Cost Advisory
@@ -193,10 +194,24 @@ async function ttsrSystemTransform(input, output, state, intentField) {
 }
 
 /**
- * messages.transform hook: inject token advisory and TTSR violation corrections.
+ * messages.transform hook: image size guard + token advisory + TTSR violation corrections.
+ *
+ * Image guard (GH#21793) runs first — it intercepts oversized user-pasted images
+ * before they enter message history. This is the only point where prevention is
+ * possible: once an oversized image is in history it replays on every API call and
+ * crashes the session permanently.
  */
 async function ttsrMessagesTransform(_input, output, state, qualityLog) {
   if (!output.messages || output.messages.length === 0) return;
+
+  // GH#21793: intercept oversized images in user messages before API send.
+  // applyImageGuard mutates output.messages in place; fail-open (any error is
+  // caught inside the module to avoid disrupting the hook pipeline).
+  try {
+    applyImageGuard(output.messages, qualityLog);
+  } catch (err) {
+    qualityLog("WARN", `[image-guard] guard threw unexpectedly: ${err.message}`);
+  }
 
   const advisory = checkTokenAdvisory(output.messages, state.tokenAdvisoryState);
   if (advisory) {

--- a/.agents/reference/screenshot-limits.md
+++ b/.agents/reference/screenshot-limits.md
@@ -22,6 +22,56 @@ through at least 5 other paths that bypass those guardrails entirely.
 - The Playwright MCP `browser_screenshot` tool returns base64 images directly into conversation context with NO resize hook. There is no way to intercept or resize these images after the tool returns. Prefer `browser-qa-helper.sh screenshot` which has built-in guardrails, or use viewport-sized screenshots via Playwright direct.
 - The `browser-qa-helper.sh screenshot` command is the ONLY screenshot path with automatic size guardrails (post-capture resize to `--max-dim`, default 4000px). All other paths — Playwright MCP, dev-browser scripts, raw Playwright code — have zero size protection.
 
+## User-Provided Images (GH#21793)
+
+The 5 MB per-image base64 ceiling applies to **all** images — not just agent-captured
+screenshots. When a user pastes or drags an image directly into Claude Code or OpenCode,
+that image bypasses `browser-qa-helper.sh` entirely. macOS Retina screenshots routinely
+exceed 5 MB (the cited case was 7.4 MB). The crash mode is identical: the oversized
+image enters message history and every subsequent API call fails with:
+
+```
+image exceeds 5 MB maximum: 7447596 bytes > 5242880 bytes
+```
+
+There is no recovery from inside the session — you must open a new session and lose all
+context.
+
+### Two-layer protection
+
+**Layer 1 — OpenCode plugin (automatic):** The `image-guard.mjs` module in the
+`opencode-aidevops` plugin intercepts images in the `experimental.chat.messages.transform`
+hook before they reach the Anthropic API. If an image exceeds 4.5 MB (10 % headroom):
+
+1. Attempts downscale via `sips` (macOS) or `magick` (cross-platform) to max 1568px.
+2. Substitutes the downscaled image silently and logs a warning.
+3. If downscale fails, replaces the image with a text notice so the session continues.
+
+This protection is automatic for OpenCode users with the aidevops plugin installed.
+
+**Layer 2 — CLI preflight (Claude Code / manual):** For Claude Code or before pasting
+into any runtime, use the `prepare` command:
+
+```bash
+safe=$(screenshot-import-helper.sh prepare ~/Desktop/Screenshot.png)
+# paste $safe into the chat
+```
+
+The `prepare` command combines:
+1. U+202F sanitization (removes the invisible macOS AM/PM space from filenames).
+2. Size check: if the file exceeds 4.5 MB, downscales to 1568px via `sips` or `magick`.
+3. Returns the path to the clean, size-safe copy.
+
+If `sips` and `magick` are both unavailable and the image is too large, `prepare`
+exits 1 with a remediation message rather than returning an unsafe path.
+
+### Known limitation — Claude Code
+
+Claude Code does not have an equivalent `experimental.chat.messages.transform` hook.
+There is no automatic interception path. Users on Claude Code must run
+`screenshot-import-helper.sh prepare <path>` before pasting any image that may exceed
+5 MB. A Retina screenshot of a full 15" MacBook Pro display is typically 6-10 MB.
+
 ## macOS Filename Hygiene
 
 macOS inserts a narrow no-break space (U+202F, UTF-8 bytes: `e2 80 af`) before AM/PM in screenshot filenames. Example: `Screenshot 2026-04-28 at 8.16.59 PM.png` — the space before "PM" is U+202F, not a regular ASCII space (U+0020).

--- a/.agents/scripts/screenshot-import-helper.sh
+++ b/.agents/scripts/screenshot-import-helper.sh
@@ -1,16 +1,19 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
-# screenshot-import-helper.sh — sanitize macOS screenshot paths containing U+202F
-# Commands: sanitize | help
+# screenshot-import-helper.sh — sanitize and prepare screenshots for AI pasting
+# Commands: sanitize | prepare | help
 #
 # macOS inserts U+202F (narrow no-break space, UTF-8: e2 80 af) before AM/PM
 # in screenshot filenames. The Claude Code Read tool truncates paths at this
 # character, returning "File not found: /Users". This helper detects the byte
 # sequence, copies the file to a clean temp path, and prints the clean path.
 #
-# See reference/screenshot-limits.md "macOS Filename Hygiene" for the full
-# failure mode and recovery workflow.
+# The prepare command additionally checks image size and downscales images
+# >4.5 MB (the Anthropic API preflight ceiling) before pasting, preventing
+# the session-crashing "image exceeds 5 MB maximum" error (GH#21793).
+#
+# See reference/screenshot-limits.md for full details.
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 # shellcheck source=shared-constants.sh
@@ -88,29 +91,135 @@ cmd_sanitize() {
 }
 
 # =============================================================================
+# Prepare (GH#21793) — sanitize path + downscale if >4.5 MB
+# =============================================================================
+
+# Anthropic API decoded-byte ceiling for user-pasted images.
+# 4.5 MB = 4718592 bytes (10 % headroom under the hard 5 MB server limit).
+readonly IMAGE_MAX_BYTES=4718592
+readonly IMAGE_MAX_DIM=1568
+
+# Prepare a screenshot for pasting into Claude Code or OpenCode.
+#
+# Combines the sanitize (U+202F removal) and size-guard (downscale if >4.5 MB)
+# steps into a single command. Returns the path to a clean, size-safe copy.
+#
+# Args: $1 = source path (may include U+202F and/or be oversized)
+# Output: prepared path on stdout
+# Exit: 0 on success, 1 on error
+cmd_prepare() {
+	local src="${1:-}"
+
+	if [[ -z "$src" ]]; then
+		log_error "Usage: screenshot-import-helper.sh prepare <path>"
+		return 1
+	fi
+
+	# Step 1: sanitize U+202F in path (reuse cmd_sanitize logic).
+	local clean_path
+	clean_path=$(cmd_sanitize "$src") || return 1
+
+	# Step 2: check decoded byte size. The Anthropic API measures the base64-
+	# decoded size, which equals the raw file size on disk.
+	local file_bytes
+	file_bytes=$(wc -c < "$clean_path" 2>/dev/null) || file_bytes=0
+	# Strip leading whitespace from wc output (BSD wc pads with spaces).
+	file_bytes="${file_bytes// /}"
+
+	if [[ "$file_bytes" -le "$IMAGE_MAX_BYTES" ]]; then
+		# Image is within limits — return the sanitized path as-is.
+		printf '%s\n' "$clean_path"
+		return 0
+	fi
+
+	local size_mb
+	size_mb=$(awk "BEGIN { printf \"%.1f\", ${file_bytes}/1048576 }")
+	log_info "Image is ${size_mb} MB (> 4.5 MB limit). Attempting downscale to ${IMAGE_MAX_DIM}px..."
+
+	# Determine output path for the downscaled copy.
+	local tmp_dir="${HOME}/.aidevops/.agent-workspace/tmp/session-$$"
+	mkdir -p "$tmp_dir" || {
+		log_error "Failed to create temp dir: ${tmp_dir}"
+		return 1
+	}
+
+	local base_name
+	base_name=$(basename "$clean_path")
+	local ext="${base_name##*.}"
+	local stem="${base_name%.*}"
+	local dst="${tmp_dir}/${stem}-prepared.${ext}"
+
+	# Step 3a: try sips (macOS built-in, no install required).
+	local resized=0
+	if command -v sips >/dev/null 2>&1; then
+		if sips --resampleHeightWidthMax "${IMAGE_MAX_DIM}" "$clean_path" --out "$dst" >/dev/null 2>&1; then
+			resized=1
+			log_info "Downscaled with sips → ${dst}"
+		fi
+	fi
+
+	# Step 3b: try ImageMagick (cross-platform fallback).
+	if [[ "$resized" -eq 0 ]] && command -v magick >/dev/null 2>&1; then
+		if magick "$clean_path" -resize "${IMAGE_MAX_DIM}x${IMAGE_MAX_DIM}>" "$dst" >/dev/null 2>&1; then
+			resized=1
+			log_info "Downscaled with magick → ${dst}"
+		fi
+	fi
+
+	if [[ "$resized" -eq 0 ]]; then
+		log_error "Downscale failed (sips and magick both unavailable or errored)."
+		log_error "Install ImageMagick: brew install imagemagick (macOS) or apt install imagemagick (Linux)."
+		log_error "Image is ${size_mb} MB — pasting it will crash the Claude Code session."
+		return 1
+	fi
+
+	# Verify the downscaled size is within limits.
+	local new_bytes
+	new_bytes=$(wc -c < "$dst" 2>/dev/null) || new_bytes=0
+	new_bytes="${new_bytes// /}"
+	if [[ "$new_bytes" -gt "$IMAGE_MAX_BYTES" ]]; then
+		local new_mb
+		new_mb=$(awk "BEGIN { printf \"%.1f\", ${new_bytes}/1048576 }")
+		log_error "Downscaled image is still ${new_mb} MB (> 4.5 MB). Cannot make it safe."
+		log_error "Try saving as JPEG at lower quality, or crop the image before pasting."
+		return 1
+	fi
+
+	printf '%s\n' "$dst"
+	return 0
+}
+
+# =============================================================================
 # Help
 # =============================================================================
 
 cmd_help() {
 	cat <<'HELP'
-screenshot-import-helper.sh — sanitize macOS screenshot paths containing U+202F
-
-macOS inserts a narrow no-break space (U+202F, UTF-8: e2 80 af) before AM/PM
-in screenshot filenames. The Claude Code Read tool truncates paths at this
-character, returning "File not found: /Users". This helper copies the file
-to a clean temporary path and returns the clean path for the Read tool.
-
-Usage:
-  screenshot-import-helper.sh sanitize <path>
-  screenshot-import-helper.sh help
+screenshot-import-helper.sh — sanitize and prepare screenshots for AI pasting
 
 Commands:
+  prepare <path>    Full preflight: sanitize U+202F in path, then downscale
+                    the image if it exceeds 4.5 MB (Anthropic API preflight
+                    ceiling). Returns the path to a clean, size-safe copy.
+                    Use this before pasting a screenshot into Claude Code.
+
   sanitize <path>   Check path for U+202F. If found, copy to a clean temp
                     path and print it. If not found, print path unchanged.
                     Idempotent — safe to call on already-clean paths.
+                    (Does NOT check image size — use prepare for that.)
+
   help              Show this message.
 
+Usage:
+  screenshot-import-helper.sh prepare <path>
+  screenshot-import-helper.sh sanitize <path>
+  screenshot-import-helper.sh help
+
 Examples:
+  # Prepare a screenshot before pasting (handles both U+202F and >4.5MB):
+  safe=$(screenshot-import-helper.sh prepare ~/Desktop/Screenshot.png)
+  # Then paste $safe into the chat.
+
   # Read tool returns "File not found: /Users" on a screenshot — recover:
   clean=$(screenshot-import-helper.sh sanitize ~/Downloads/"Screenshot 2026-04-28 at 8.16.59 AM.png")
   # Then use $clean with the Read tool.
@@ -122,7 +231,7 @@ Recovery workflow when Read returns "File not found: /Users":
        clean=$(screenshot-import-helper.sh sanitize <path>)
   3. Read from $clean.
 
-Full details: reference/screenshot-limits.md "macOS Filename Hygiene"
+Full details: reference/screenshot-limits.md
 HELP
 	return 0
 }
@@ -136,6 +245,7 @@ main() {
 	shift || true
 
 	case "$command" in
+	prepare) cmd_prepare "$@" ;;
 	sanitize) cmd_sanitize "$@" ;;
 	help | --help | -h) cmd_help ;;
 	*)


### PR DESCRIPTION
## Summary

User-pasted images >5 MB crash the Claude Code/OpenCode session permanently — the oversized base64 payload enters message history and replays on every subsequent API call. This PR adds two-layer protection:

1. **OpenCode plugin (automatic):** New `image-guard.mjs` module hooks into `experimental.chat.messages.transform` via `ttsrMessagesTransform`. Before each API call it inspects user-message image parts, measures decoded byte size O(1), and if >4.5 MB (10% headroom): downscales via `sips` (macOS) or `magick` (cross-platform), substitutes the result, or falls back to a text notice so the session continues.

2. **CLI preflight (`prepare` subcommand):** Extended `screenshot-import-helper.sh` with a `prepare` command that combines U+202F sanitization (existing `sanitize`) + size check + downscale. Claude Code users (no equivalent hook) can run this before pasting.

3. **Documentation:** Added "User-Provided Images" section to `reference/screenshot-limits.md` and a quick-reference note to `AGENTS.md`.

## Files Changed

- `NEW: .agents/plugins/opencode-aidevops/image-guard.mjs` — image guard module
- `EDIT: .agents/plugins/opencode-aidevops/ttsr.mjs` — hook integration
- `EDIT: .agents/scripts/screenshot-import-helper.sh` — `prepare` subcommand
- `EDIT: .agents/reference/screenshot-limits.md` — User-Provided Images section
- `EDIT: .agents/AGENTS.md` — quick-reference note

## Testing

- ShellCheck: `shellcheck .agents/scripts/screenshot-import-helper.sh` → clean (verified pre-commit)
- Manual: `screenshot-import-helper.sh prepare` with a 7.4 MB Retina screenshot downscales correctly via `sips`
- Pass-through: 1 MB image returns path unchanged
- Plugin: `applyImageGuard` is called with a try/catch wrapper — any internal failure is logged and does not disrupt the hook pipeline

Resolves #21793

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.11 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-sonnet-4-6 spent 8m and 24,023 tokens on this as a headless worker.
