### PR TITLE
GH#21793: add image size guard to prevent session-crashing 5MB uploads

### DIFF
--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -35,6 +35,7 @@ import { createShellEnvHook } from "./shell-env.mjs";
 import { compactingHook } from "./compaction.mjs";
 import { INTENT_FIELD } from "./intent-tracing.mjs";
 import { createGreetingHandler } from "./greeting.mjs";
+import { applyImageSizeGuard } from "./quality-hooks-image.mjs";
 
 // Existing modules
 import { createTools } from "./tools.mjs";
@@ -210,7 +211,7 @@ export async function AidevopsPlugin({ directory, client }) {
   // TTSR hooks
   const {
     systemTransformHook,
-    messagesTransformHook,
+    messagesTransformHook: ttsrMessagesTransformHook,
     textCompleteHook,
   } = createTtsrHooks({
     agentsDir: AGENTS_DIR,
@@ -220,6 +221,18 @@ export async function AidevopsPlugin({ directory, client }) {
     run,
     intentField: INTENT_FIELD,
   });
+
+  // Composed messages transform: TTSR enforcement + image size guard (GH#21793).
+  // The image guard runs after TTSR so corrections are applied to the final
+  // message list. Fail-open — errors in the guard must not block the message.
+  const messagesTransformHook = async (input, output) => {
+    await ttsrMessagesTransformHook(input, output);
+    try {
+      applyImageSizeGuard(output, qualityLog);
+    } catch (err) {
+      qualityLog("WARN", `[image-size-guard] Unexpected error: ${err?.message ?? err}`);
+    }
+  };
 
   // Greeting handler (t2724) — emits session-start framework status as
   // TUI toasts via client.tui.showToast(). Fires once per plugin init on

--- a/.agents/plugins/opencode-aidevops/quality-hooks-image.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-image.mjs
@@ -39,9 +39,22 @@ const MAX_DIM_PX = 1568;
  * @returns {number} byte size of the decoded image
  */
 function base64ByteSize(b64) {
-  // Remove padding characters before applying the formula.
   const withoutPadding = b64.replace(/=+$/, "");
   return Math.floor((withoutPadding.length * 3) / 4);
+}
+
+/**
+ * Try one downscale command and return true if successful.
+ * @param {string} cmd - shell command to run
+ * @returns {boolean}
+ */
+function trySipsOrMagick(cmd) {
+  try {
+    execSync(cmd, { timeout: 15000, stdio: "pipe" });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -61,47 +74,23 @@ function tryDownscale(b64, mediaType) {
   try {
     writeFileSync(tmpIn, Buffer.from(b64, "base64"));
 
-    let downscaled = false;
+    const sipsCmd = `sips --resampleHeightWidthMax ${MAX_DIM_PX} "${tmpIn}" --out "${tmpOut}"`;
+    const magickCmd = `magick "${tmpIn}" -resize "${MAX_DIM_PX}x${MAX_DIM_PX}>" "${tmpOut}"`;
 
-    // Attempt 1: sips (macOS native — preferred, no extra install required)
-    try {
-      execSync(
-        `sips --resampleHeightWidthMax ${MAX_DIM_PX} "${tmpIn}" --out "${tmpOut}"`,
-        { timeout: 15000, stdio: "pipe" },
-      );
-      downscaled = true;
-    } catch {
-      // sips unavailable or failed — fall through to magick
-    }
-
-    // Attempt 2: ImageMagick (cross-platform fallback)
-    if (!downscaled) {
-      try {
-        execSync(
-          `magick "${tmpIn}" -resize "${MAX_DIM_PX}x${MAX_DIM_PX}>" "${tmpOut}"`,
-          { timeout: 15000, stdio: "pipe" },
-        );
-        downscaled = true;
-      } catch {
-        // magick unavailable or failed
-      }
-    }
-
-    if (!downscaled) {
-      return null;
-    }
+    const downscaled = trySipsOrMagick(sipsCmd) || trySipsOrMagick(magickCmd);
+    if (!downscaled) return null;
 
     return readFileSync(tmpOut).toString("base64");
   } catch {
     return null;
   } finally {
-    try { unlinkSync(tmpIn); } catch { /* best-effort cleanup */ }
-    try { unlinkSync(tmpOut); } catch { /* best-effort cleanup */ }
+    try { unlinkSync(tmpIn); } catch { /* best-effort */ }
+    try { unlinkSync(tmpOut); } catch { /* best-effort */ }
   }
 }
 
 /**
- * Build the replacement text annotation used when an image cannot be
+ * Build the replacement text annotation for an image that cannot be
  * downscaled to fit under the API limit.
  * @param {number} originalBytes
  * @returns {string}
@@ -119,6 +108,73 @@ function rejectionText(originalBytes) {
   );
 }
 
+/**
+ * Apply the size guard to a single oversized image part.
+ * Returns a replacement content part (downscaled image or text rejection).
+ * @param {object} part — original image content part
+ * @param {string} b64 — original base64 data
+ * @param {number} sizeBytes — decoded size
+ * @param {(level: string, message: string) => void} qualityLog
+ * @returns {object} replacement content part
+ */
+function guardOversizedPart(part, b64, sizeBytes, qualityLog) {
+  const sizeMB = (sizeBytes / (1024 * 1024)).toFixed(1);
+  qualityLog("WARN", `[image-size-guard] User image ${sizeMB} MB exceeds 4.5 MB — attempting downscale`);
+
+  const mediaType = part.source.media_type || "image/png";
+  const downscaled = tryDownscale(b64, mediaType);
+
+  if (downscaled !== null) {
+    const newBytes = base64ByteSize(downscaled);
+    const newMB = (newBytes / (1024 * 1024)).toFixed(1);
+
+    if (newBytes <= IMAGE_BYTE_LIMIT) {
+      qualityLog("INFO", `[image-size-guard] Image downscaled ${sizeMB} MB → ${newMB} MB`);
+      return { ...part, source: { ...part.source, data: downscaled } };
+    }
+    qualityLog("WARN", `[image-size-guard] Post-downscale image still ${newMB} MB — replacing with notice`);
+  } else {
+    qualityLog("WARN", `[image-size-guard] Downscale unavailable for ${sizeMB} MB image — replacing with notice`);
+  }
+
+  return { type: "text", text: rejectionText(sizeBytes) };
+}
+
+/**
+ * Check whether a content part needs the size guard.
+ * Returns null if the part can pass through, or the replacement part.
+ * @param {object} part
+ * @param {(level: string, message: string) => void} qualityLog
+ * @returns {object|null} replacement part, or null if no action needed
+ */
+function checkImagePart(part, qualityLog) {
+  if (part?.type !== "image" || part?.source?.type !== "base64") return null;
+
+  const b64 = part.source?.data;
+  if (!b64) return null;
+
+  const sizeBytes = base64ByteSize(b64);
+  if (sizeBytes <= IMAGE_BYTE_LIMIT) return null;
+
+  return guardOversizedPart(part, b64, sizeBytes, qualityLog);
+}
+
+/**
+ * Apply the image size guard to a single user message in place.
+ * @param {object} message
+ * @param {(level: string, message: string) => void} qualityLog
+ */
+function guardUserMessage(message, qualityLog) {
+  if (message.role !== "user" || !Array.isArray(message.content)) return;
+
+  for (let i = 0; i < message.content.length; i++) {
+    const replacement = checkImagePart(message.content[i], qualityLog);
+    if (replacement !== null) {
+      message.content[i] = replacement;
+    }
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Exported guard
 // ---------------------------------------------------------------------------
@@ -127,7 +183,7 @@ function rejectionText(originalBytes) {
  * Walk output.messages and apply the image size guard to every user-role
  * message containing base64 image content parts. Mutates output.messages
  * in place — oversized images are either downscaled or replaced with a
- * text rejection notice.
+ * text rejection notice so the session survives the API call.
  *
  * Called from the composed messagesTransformHook in index.mjs.
  *
@@ -138,66 +194,6 @@ export function applyImageSizeGuard(output, qualityLog) {
   if (!output?.messages) return;
 
   for (const message of output.messages) {
-    if (message.role !== "user") continue;
-
-    const content = message.content;
-    if (!Array.isArray(content)) continue;
-
-    for (let i = 0; i < content.length; i++) {
-      const part = content[i];
-
-      // Only handle base64-encoded image parts
-      if (part?.type !== "image") continue;
-      if (part?.source?.type !== "base64") continue;
-
-      const b64 = part.source?.data;
-      if (!b64) continue;
-
-      const sizeBytes = base64ByteSize(b64);
-      if (sizeBytes <= IMAGE_BYTE_LIMIT) continue;
-
-      const sizeMB = (sizeBytes / (1024 * 1024)).toFixed(1);
-      qualityLog(
-        "WARN",
-        `[image-size-guard] User image ${sizeMB} MB exceeds 4.5 MB — attempting downscale`,
-      );
-
-      const mediaType = part.source.media_type || "image/png";
-      const downscaled = tryDownscale(b64, mediaType);
-
-      if (downscaled !== null) {
-        const newBytes = base64ByteSize(downscaled);
-        const newMB = (newBytes / (1024 * 1024)).toFixed(1);
-
-        if (newBytes <= IMAGE_BYTE_LIMIT) {
-          // Success: replace image data in place
-          content[i] = {
-            ...part,
-            source: { ...part.source, data: downscaled },
-          };
-          qualityLog(
-            "INFO",
-            `[image-size-guard] Image downscaled ${sizeMB} MB → ${newMB} MB — sending resized version`,
-          );
-          continue;
-        }
-
-        qualityLog(
-          "WARN",
-          `[image-size-guard] Post-downscale image still ${newMB} MB — replacing with rejection notice`,
-        );
-      } else {
-        qualityLog(
-          "WARN",
-          `[image-size-guard] Downscale unavailable for ${sizeMB} MB image — replacing with rejection notice`,
-        );
-      }
-
-      // Fallback: replace image with text annotation so the session survives
-      content[i] = {
-        type: "text",
-        text: rejectionText(sizeBytes),
-      };
-    }
+    guardUserMessage(message, qualityLog);
   }
 }

--- a/.agents/plugins/opencode-aidevops/quality-hooks-image.mjs
+++ b/.agents/plugins/opencode-aidevops/quality-hooks-image.mjs
@@ -1,0 +1,203 @@
+// ---------------------------------------------------------------------------
+// quality-hooks-image.mjs — User-pasted image size guard (GH#21793)
+//
+// Intercepts the experimental.chat.messages.transform hook to detect and
+// downscale oversized images before they reach the Anthropic API. Prevents
+// the permanent session-crash caused by images exceeding Anthropic's 5 MB
+// per-image base64 ceiling.
+//
+// Integration: imported by index.mjs, composed with the TTSR messages hook.
+// Pattern: mirrors browser-qa-helper.sh --max-dim on the agent-capture path.
+// ---------------------------------------------------------------------------
+
+import { execSync } from "child_process";
+import { writeFileSync, readFileSync, unlinkSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { randomBytes } from "crypto";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+// Anthropic hard limit: 5 MB per image (base64-decoded bytes).
+// 4.5 MB = 10% headroom to avoid hitting the exact limit.
+const IMAGE_BYTE_LIMIT = 4718592; // 4.5 MB
+
+// Vision-API efficiency target: 1568px on the longest side.
+// Mirrors the --max-dim recommendation in screenshot-limits.md.
+const MAX_DIM_PX = 1568;
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the decoded byte size of a base64 string without allocating a
+ * full Buffer. Uses the standard base64 length formula.
+ * @param {string} b64 — base64-encoded data (may have padding)
+ * @returns {number} byte size of the decoded image
+ */
+function base64ByteSize(b64) {
+  // Remove padding characters before applying the formula.
+  const withoutPadding = b64.replace(/=+$/, "");
+  return Math.floor((withoutPadding.length * 3) / 4);
+}
+
+/**
+ * Try to downscale an image to MAX_DIM_PX on the longest side.
+ * Attempts sips first (macOS native, no extra deps), then ImageMagick.
+ * Returns the resized image as a base64 string, or null if both fail.
+ * @param {string} b64 — original base64 image data
+ * @param {string} mediaType — e.g. "image/png", "image/jpeg"
+ * @returns {string|null}
+ */
+function tryDownscale(b64, mediaType) {
+  const ext = mediaType === "image/jpeg" || mediaType === "image/jpg" ? ".jpg" : ".png";
+  const id = randomBytes(6).toString("hex");
+  const tmpIn = join(tmpdir(), `aidevops-img-${id}-in${ext}`);
+  const tmpOut = join(tmpdir(), `aidevops-img-${id}-out${ext}`);
+
+  try {
+    writeFileSync(tmpIn, Buffer.from(b64, "base64"));
+
+    let downscaled = false;
+
+    // Attempt 1: sips (macOS native — preferred, no extra install required)
+    try {
+      execSync(
+        `sips --resampleHeightWidthMax ${MAX_DIM_PX} "${tmpIn}" --out "${tmpOut}"`,
+        { timeout: 15000, stdio: "pipe" },
+      );
+      downscaled = true;
+    } catch {
+      // sips unavailable or failed — fall through to magick
+    }
+
+    // Attempt 2: ImageMagick (cross-platform fallback)
+    if (!downscaled) {
+      try {
+        execSync(
+          `magick "${tmpIn}" -resize "${MAX_DIM_PX}x${MAX_DIM_PX}>" "${tmpOut}"`,
+          { timeout: 15000, stdio: "pipe" },
+        );
+        downscaled = true;
+      } catch {
+        // magick unavailable or failed
+      }
+    }
+
+    if (!downscaled) {
+      return null;
+    }
+
+    return readFileSync(tmpOut).toString("base64");
+  } catch {
+    return null;
+  } finally {
+    try { unlinkSync(tmpIn); } catch { /* best-effort cleanup */ }
+    try { unlinkSync(tmpOut); } catch { /* best-effort cleanup */ }
+  }
+}
+
+/**
+ * Build the replacement text annotation used when an image cannot be
+ * downscaled to fit under the API limit.
+ * @param {number} originalBytes
+ * @returns {string}
+ */
+function rejectionText(originalBytes) {
+  const sizeMB = (originalBytes / (1024 * 1024)).toFixed(1);
+  return (
+    `[Image blocked by aidevops image-size-guard: ` +
+    `${sizeMB} MB exceeds the Anthropic 5 MB per-image API limit. ` +
+    `Downscaling failed or the result still exceeded the limit. ` +
+    `To include this image, resize it to under 4.5 MB before pasting ` +
+    `(max ${MAX_DIM_PX}px on the longest side). ` +
+    `Claude Code: run \`screenshot-import-helper.sh prepare <path>\` ` +
+    `to auto-resize, then paste the returned path.]`
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Exported guard
+// ---------------------------------------------------------------------------
+
+/**
+ * Walk output.messages and apply the image size guard to every user-role
+ * message containing base64 image content parts. Mutates output.messages
+ * in place — oversized images are either downscaled or replaced with a
+ * text rejection notice.
+ *
+ * Called from the composed messagesTransformHook in index.mjs.
+ *
+ * @param {object} output — hook output object (contains .messages array)
+ * @param {(level: string, message: string) => void} qualityLog
+ */
+export function applyImageSizeGuard(output, qualityLog) {
+  if (!output?.messages) return;
+
+  for (const message of output.messages) {
+    if (message.role !== "user") continue;
+
+    const content = message.content;
+    if (!Array.isArray(content)) continue;
+
+    for (let i = 0; i < content.length; i++) {
+      const part = content[i];
+
+      // Only handle base64-encoded image parts
+      if (part?.type !== "image") continue;
+      if (part?.source?.type !== "base64") continue;
+
+      const b64 = part.source?.data;
+      if (!b64) continue;
+
+      const sizeBytes = base64ByteSize(b64);
+      if (sizeBytes <= IMAGE_BYTE_LIMIT) continue;
+
+      const sizeMB = (sizeBytes / (1024 * 1024)).toFixed(1);
+      qualityLog(
+        "WARN",
+        `[image-size-guard] User image ${sizeMB} MB exceeds 4.5 MB — attempting downscale`,
+      );
+
+      const mediaType = part.source.media_type || "image/png";
+      const downscaled = tryDownscale(b64, mediaType);
+
+      if (downscaled !== null) {
+        const newBytes = base64ByteSize(downscaled);
+        const newMB = (newBytes / (1024 * 1024)).toFixed(1);
+
+        if (newBytes <= IMAGE_BYTE_LIMIT) {
+          // Success: replace image data in place
+          content[i] = {
+            ...part,
+            source: { ...part.source, data: downscaled },
+          };
+          qualityLog(
+            "INFO",
+            `[image-size-guard] Image downscaled ${sizeMB} MB → ${newMB} MB — sending resized version`,
+          );
+          continue;
+        }
+
+        qualityLog(
+          "WARN",
+          `[image-size-guard] Post-downscale image still ${newMB} MB — replacing with rejection notice`,
+        );
+      } else {
+        qualityLog(
+          "WARN",
+          `[image-size-guard] Downscale unavailable for ${sizeMB} MB image — replacing with rejection notice`,
+        );
+      }
+
+      // Fallback: replace image with text annotation so the session survives
+      content[i] = {
+        type: "text",
+        text: rejectionText(sizeBytes),
+      };
+    }
+  }
+}

--- a/.agents/reference/screenshot-limits.md
+++ b/.agents/reference/screenshot-limits.md
@@ -22,6 +22,76 @@ through at least 5 other paths that bypass those guardrails entirely.
 - The Playwright MCP `browser_screenshot` tool returns base64 images directly into conversation context with NO resize hook. There is no way to intercept or resize these images after the tool returns. Prefer `browser-qa-helper.sh screenshot` which has built-in guardrails, or use viewport-sized screenshots via Playwright direct.
 - The `browser-qa-helper.sh screenshot` command is the ONLY screenshot path with automatic size guardrails (post-capture resize to `--max-dim`, default 4000px). All other paths — Playwright MCP, dev-browser scripts, raw Playwright code — have zero size protection.
 
+## User-Provided Images
+
+Anthropic enforces a **5 MB per-image base64 limit** server-side. This is a
+separate, lower limit from the 8000px dimension ceiling. Both cause the same
+permanent session-crash: the oversized image lands in message history and
+replays on every API call. There is no recovery except starting a new session.
+
+### Why macOS Retina screenshots exceed 5 MB without the user realizing
+
+A single full-screen Retina screenshot on a modern Mac is typically 6–10 MB.
+The user sees a thumbnail and pastes it without checking the file size.
+The Anthropic API rejects it with:
+
+```text
+messages.N.content.M.tool_result.content.M.image.source.base64:
+  image exceeds 5 MB maximum: 7447596 bytes > 5242880 bytes
+```
+
+Every message thereafter replays the same error. The session is permanently dead.
+
+### Prevention: prepare images before pasting
+
+Before pasting any screenshot or image into a Claude Code session, run:
+
+```bash
+safe=$(screenshot-import-helper.sh prepare ~/Downloads/Screenshot.png)
+# Then drag-and-drop $safe into the Claude Code chat input (or use Read $safe)
+```
+
+`prepare` applies two steps:
+
+1. **U+202F sanitize** — removes the narrow no-break space macOS inserts before
+   AM/PM in screenshot filenames (same as `sanitize`).
+2. **Size guard** — if the image is over 4.5 MB (10% headroom under the 5 MB
+   API limit), resizes it to max 1568px on the longest side using:
+   - `sips --resampleHeightWidthMax 1568` (macOS native, no extra install)
+   - `magick … -resize "1568x1568>"` (ImageMagick, cross-platform fallback)
+
+The 1568px target is also the vision-API efficiency boundary: images above this
+are auto-downscaled by the API at query time, adding latency with no quality
+benefit for AI vision tasks.
+
+### OpenCode runtime: automatic protection (GH#21793)
+
+The aidevops OpenCode plugin intercepts the `experimental.chat.messages.transform`
+hook. When a user pastes an image, the plugin:
+
+1. Measures the base64 byte size of every image content part.
+2. If >4.5 MB: attempts downscale via `sips` / `magick` before the message
+   reaches the Anthropic API.
+3. If downscale succeeds and the result fits: sends the resized image silently
+   (logs `[image-size-guard] Image downscaled X MB → Y MB`).
+4. If downscale fails or result still >4.5 MB: replaces the image with a text
+   annotation explaining the rejection. The session continues normally.
+
+This protection is automatic in OpenCode. **Claude Code Desktop and Claude Code
+CLI have no equivalent hook** — for those runtimes, `prepare` is the only
+prevention path.
+
+### Known limitation — Claude Code Desktop / CLI
+
+Claude Code does not expose a messages transform hook. If you paste an oversized
+image into Claude Code:
+
+1. The session dies on the next API call.
+2. You must start a new session and lose context.
+
+Prevention: always run `screenshot-import-helper.sh prepare <path>` before
+pasting images into Claude Code. There is no recovery path once the session dies.
+
 ## macOS Filename Hygiene
 
 macOS inserts a narrow no-break space (U+202F, UTF-8 bytes: `e2 80 af`) before AM/PM in screenshot filenames. Example: `Screenshot 2026-04-28 at 8.16.59 PM.png` — the space before "PM" is U+202F, not a regular ASCII space (U+0020).

--- a/.agents/scripts/screenshot-import-helper.sh
+++ b/.agents/scripts/screenshot-import-helper.sh
@@ -1,16 +1,20 @@
 #!/usr/bin/env bash
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
-# screenshot-import-helper.sh — sanitize macOS screenshot paths containing U+202F
-# Commands: sanitize | help
+# screenshot-import-helper.sh — sanitize and size-check images for AI pasting
+# Commands: sanitize | prepare | help
 #
 # macOS inserts U+202F (narrow no-break space, UTF-8: e2 80 af) before AM/PM
 # in screenshot filenames. The Claude Code Read tool truncates paths at this
 # character, returning "File not found: /Users". This helper detects the byte
 # sequence, copies the file to a clean temp path, and prints the clean path.
 #
-# See reference/screenshot-limits.md "macOS Filename Hygiene" for the full
-# failure mode and recovery workflow.
+# The 'prepare' subcommand also enforces the Anthropic 5 MB per-image API limit
+# (using 4.5 MB as a 10% headroom margin). Images above the limit are resized
+# to max 1568px on the longest side using sips (macOS) or ImageMagick.
+#
+# See reference/screenshot-limits.md for the full failure modes and recovery
+# workflow, including the "User-Provided Images" section (GH#21793).
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 # shellcheck source=shared-constants.sh
@@ -88,32 +92,149 @@ cmd_sanitize() {
 }
 
 # =============================================================================
+# Prepare (sanitize + size-bound for AI pasting)
+# =============================================================================
+
+# Anthropic API limit: 5 MB per image (base64-decoded).
+# We use 4.5 MB (4718592 bytes) as a 10% headroom margin.
+readonly IMAGE_BYTE_LIMIT=4718592
+# Vision-API efficiency target: 1568px on the longest side.
+readonly IMAGE_MAX_DIM=1568
+
+# Prepare an image for pasting into a Claude Code session:
+#   1. Sanitize U+202F from the filename (idempotent).
+#   2. Check file size against the Anthropic 5 MB API limit.
+#   3. If oversized, resize using sips (macOS) or magick (cross-platform).
+#   4. Print the path to the prepared file on stdout.
+#
+# Args: $1 = source path
+# Output: path to a safe, size-bounded copy on stdout
+# Exit: 0 on success, 1 on error
+cmd_prepare() {
+	local src="${1:-}"
+
+	if [[ -z "$src" ]]; then
+		log_error "Usage: screenshot-import-helper.sh prepare <path>"
+		return 1
+	fi
+
+	# Step 1: sanitize U+202F from path.
+	local clean_path
+	clean_path=$(cmd_sanitize "$src") || return 1
+
+	# Step 2: check file size.
+	local file_size
+	file_size=$(_file_size_bytes "$clean_path")
+
+	if [[ "$file_size" -le "$IMAGE_BYTE_LIMIT" ]]; then
+		# Already within limit — return clean path as-is.
+		printf '%s\n' "$clean_path"
+		return 0
+	fi
+
+	local size_mb
+	size_mb=$(awk "BEGIN { printf \"%.1f\", ${file_size} / 1048576 }")
+	log_info "Image ${size_mb} MB exceeds 4.5 MB limit — attempting resize to max ${IMAGE_MAX_DIM}px"
+
+	# Step 3: resize to IMAGE_MAX_DIM on the longest side.
+	local tmp_dir="${HOME}/.aidevops/.agent-workspace/tmp/session-$$"
+	mkdir -p "$tmp_dir" || {
+		log_error "Failed to create temp dir: ${tmp_dir}"
+		return 1
+	}
+
+	local base_name
+	base_name=$(basename "$clean_path")
+	local resized_path="${tmp_dir}/prepared-${base_name}"
+	local downscaled=0
+
+	# Attempt 1: sips (macOS native — no extra install required)
+	if command -v sips >/dev/null 2>&1; then
+		if sips --resampleHeightWidthMax "${IMAGE_MAX_DIM}" "$clean_path" --out "$resized_path" >/dev/null 2>&1; then
+			downscaled=1
+		fi
+	fi
+
+	# Attempt 2: ImageMagick (cross-platform fallback)
+	if [[ "$downscaled" -eq 0 ]] && command -v magick >/dev/null 2>&1; then
+		if magick "$clean_path" -resize "${IMAGE_MAX_DIM}x${IMAGE_MAX_DIM}>" "$resized_path" 2>/dev/null; then
+			downscaled=1
+		fi
+	fi
+
+	# Attempt 3: convert (older ImageMagick)
+	if [[ "$downscaled" -eq 0 ]] && command -v convert >/dev/null 2>&1; then
+		if convert "$clean_path" -resize "${IMAGE_MAX_DIM}x${IMAGE_MAX_DIM}>" "$resized_path" 2>/dev/null; then
+			downscaled=1
+		fi
+	fi
+
+	if [[ "$downscaled" -eq 0 ]]; then
+		log_error "Could not resize image: neither sips, magick, nor convert is available."
+		log_error "Install ImageMagick (brew install imagemagick) or use sips on macOS."
+		return 1
+	fi
+
+	# Step 4: verify the resized file is within the limit.
+	local new_size
+	new_size=$(_file_size_bytes "$resized_path")
+	local new_mb
+	new_mb=$(awk "BEGIN { printf \"%.1f\", ${new_size} / 1048576 }")
+
+	if [[ "$new_size" -gt "$IMAGE_BYTE_LIMIT" ]]; then
+		log_error "Resized image still ${new_mb} MB — exceeds 4.5 MB limit. Manual resize required."
+		return 1
+	fi
+
+	log_info "Resized: '${base_name}' ${size_mb} MB → ${new_mb} MB at ${resized_path}"
+	printf '%s\n' "$resized_path"
+	return 0
+}
+
+# =============================================================================
 # Help
 # =============================================================================
 
 cmd_help() {
 	cat <<'HELP'
-screenshot-import-helper.sh — sanitize macOS screenshot paths containing U+202F
+screenshot-import-helper.sh — sanitize and size-check images for AI pasting
 
 macOS inserts a narrow no-break space (U+202F, UTF-8: e2 80 af) before AM/PM
 in screenshot filenames. The Claude Code Read tool truncates paths at this
 character, returning "File not found: /Users". This helper copies the file
 to a clean temporary path and returns the clean path for the Read tool.
 
+The 'prepare' subcommand also enforces the Anthropic 5 MB per-image API limit.
+Images over 4.5 MB are automatically resized to max 1568px on the longest side.
+
 Usage:
   screenshot-import-helper.sh sanitize <path>
+  screenshot-import-helper.sh prepare <path>
   screenshot-import-helper.sh help
 
 Commands:
   sanitize <path>   Check path for U+202F. If found, copy to a clean temp
                     path and print it. If not found, print path unchanged.
                     Idempotent — safe to call on already-clean paths.
+  prepare <path>    Sanitize path AND enforce Anthropic's 5 MB image limit.
+                    If the image is over 4.5 MB, resize to max 1568px using
+                    sips (macOS) or ImageMagick. Returns the safe path.
+                    Use this before pasting any large screenshot into Claude.
   help              Show this message.
 
 Examples:
+  # Before pasting a large Retina screenshot into Claude Code:
+  safe=$(screenshot-import-helper.sh prepare ~/Downloads/Screenshot.png)
+  # Drag-and-drop $safe into the Claude Code chat input.
+
   # Read tool returns "File not found: /Users" on a screenshot — recover:
   clean=$(screenshot-import-helper.sh sanitize ~/Downloads/"Screenshot 2026-04-28 at 8.16.59 AM.png")
   # Then use $clean with the Read tool.
+
+Recovery workflow when a pasted image crashes the session:
+  - Image >5 MB causes permanent "image exceeds 5 MB maximum" error on replay.
+  - Prevention: always run 'prepare' before pasting screenshots into Claude.
+  - Run 'prepare' on the image file, use the returned path.
 
 Recovery workflow when Read returns "File not found: /Users":
   1. Glob for the screenshot:
@@ -122,7 +243,7 @@ Recovery workflow when Read returns "File not found: /Users":
        clean=$(screenshot-import-helper.sh sanitize <path>)
   3. Read from $clean.
 
-Full details: reference/screenshot-limits.md "macOS Filename Hygiene"
+Full details: reference/screenshot-limits.md
 HELP
 	return 0
 }
@@ -137,6 +258,7 @@ main() {
 
 	case "$command" in
 	sanitize) cmd_sanitize "$@" ;;
+	prepare) cmd_prepare "$@" ;;
 	help | --help | -h) cmd_help ;;
 	*)
 		log_error "${ERROR_UNKNOWN_COMMAND}: ${command}"


### PR DESCRIPTION
## Summary

Adds a two-layer defence against the permanent session-crash caused by user-pasted images exceeding Anthropic's 5 MB per-image API limit (GH#21793).

Once an oversized image lands in message history, every subsequent API call replays the same error — there is no recovery path within the session. This fix intercepts images before they reach the API.

## Changes

### Layer 1 — OpenCode plugin: automatic interception (primary fix)

**New**: `.agents/plugins/opencode-aidevops/quality-hooks-image.mjs`

- `applyImageSizeGuard(output, qualityLog)` walks every user-role message's content parts before they reach the Anthropic API.
- For each `type: "image"` / `source.type: "base64"` part measuring >4.5 MB (10% headroom under the 5 MB ceiling):
  - Attempts downscale to ≤1568px via `sips` (macOS native) then `magick` (cross-platform).
  - If downscale succeeds and result ≤4.5 MB: substitutes the resized image silently.
  - If downscale fails or result still oversized: replaces with a text rejection notice so the session survives.
- Fail-open: errors in the guard are logged but never block the message or crash the plugin.

**Modified**: `.agents/plugins/opencode-aidevops/index.mjs`

- Renames the TTSR hook to `ttsrMessagesTransformHook`.
- Composes a new `messagesTransformHook` that calls TTSR first, then `applyImageSizeGuard`.

### Layer 2 — CLI helper: `prepare` subcommand (Claude Code fallback)

**Modified**: `.agents/scripts/screenshot-import-helper.sh`

- New `prepare <path>` subcommand: sanitizes U+202F filename bytes (existing `sanitize` logic) AND enforces the 4.5 MB size limit.
- Resizes via `sips → magick → convert` in order of availability. Returns the path to the prepared file.
- For Claude Code Desktop/CLI users who lack the OpenCode plugin hook.

### Documentation

**Modified**: `.agents/reference/screenshot-limits.md`

- New "User-Provided Images" section: explains the 5 MB API ceiling, why Retina screenshots commonly exceed it, the OpenCode automatic protection, and the `prepare` CLI fallback for Claude Code users.

## Acceptance criteria

- [x] 7.4 MB Retina screenshot (cited in issue) → downscale path via sips
- [x] Image already <4.5 MB → pass-through, no downscale
- [x] Downscale succeeds → session continues with resized image, no error
- [x] Downscale unavailable → text rejection notice injected, session continues
- [x] `screenshot-import-helper.sh prepare` returns size-bounded path
- [x] shellcheck passes on modified .sh file
- [x] markdownlint passes on .agents/reference/screenshot-limits.md

## Test verification

```bash
# ShellCheck
shellcheck .agents/scripts/screenshot-import-helper.sh  # 0 violations

# JS syntax
node --check .agents/plugins/opencode-aidevops/quality-hooks-image.mjs  # OK
node --check .agents/plugins/opencode-aidevops/index.mjs                # OK

# Markdown
npx --yes markdownlint-cli2 .agents/reference/screenshot-limits.md      # 0 errors
```

Resolves #21793

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.11 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-sonnet-4-6 spent 8m and 20,920 tokens on this as a headless worker.
