### PR TITLE
GH#21842: route pulse-watchdog informational writes away from monitored LOGFILE

### DIFF
--- a/.agents/scripts/pulse-watchdog.sh
+++ b/.agents/scripts/pulse-watchdog.sh
@@ -30,6 +30,15 @@
 [[ -n "${_PULSE_WATCHDOG_LOADED:-}" ]] && return 0
 _PULSE_WATCHDOG_LOADED=1
 
+# GH#21842: Watchdog informational log — separate from $LOGFILE which the
+# byte-delta progress monitor reads. Writing watchdog status messages back
+# to $LOGFILE is the t3058-class self-write anti-pattern: it shows up as
+# log growth on the next 60s poll, evaluates as 'progress', resets the
+# stall counter, and silently delays stall detection by one poll interval
+# per stall cycle. Route these writes to a sibling file the monitor never
+# reads so the progress signal stays clean.
+PULSE_WATCHDOG_LOG="${PULSE_WATCHDOG_LOG:-${HOME}/.aidevops/logs/pulse-watchdog.log}"
+
 #######################################
 # Process guard: kill child processes exceeding RSS or runtime limits (t1398)
 #
@@ -375,7 +384,10 @@ _watchdog_check_progress() {
 	if [[ "$current_log_size" -gt "$WD_LAST_LOG_SIZE" ]]; then
 		WD_HAS_SEEN_PROGRESS=true
 		if [[ "$WD_PROGRESS_STALL_SECONDS" -gt 0 ]]; then
-			echo "[pulse-wrapper] Progress resumed after ${WD_PROGRESS_STALL_SECONDS}s stall (log grew by $((current_log_size - WD_LAST_LOG_SIZE)) bytes)" >>"$LOGFILE"
+			# GH#21842: route to PULSE_WATCHDOG_LOG, not $LOGFILE — the byte-delta
+			# monitor above reads $LOGFILE. Self-writing here would falsely
+			# evaluate as progress on the next poll. See file header.
+			echo "[pulse-wrapper] Progress resumed after ${WD_PROGRESS_STALL_SECONDS}s stall (log grew by $((current_log_size - WD_LAST_LOG_SIZE)) bytes)" >>"$PULSE_WATCHDOG_LOG" 2>/dev/null || true
 		fi
 		WD_LAST_LOG_SIZE="$current_log_size"
 		WD_PROGRESS_STALL_SECONDS=0
@@ -423,7 +435,9 @@ _watchdog_check_idle() {
 	# Process is active — reset idle counter
 	if [[ "$tree_cpu" -ge "$PULSE_IDLE_CPU_THRESHOLD" ]]; then
 		if [[ "$WD_IDLE_SECONDS" -gt 0 ]]; then
-			echo "[pulse-wrapper] Pulse active again (CPU ${tree_cpu}%) after ${WD_IDLE_SECONDS}s idle — resetting idle counter" >>"$LOGFILE"
+			# GH#21842: route to PULSE_WATCHDOG_LOG, not $LOGFILE — keeps the
+			# progress byte-delta signal in _watchdog_check_progress clean.
+			echo "[pulse-wrapper] Pulse active again (CPU ${tree_cpu}%) after ${WD_IDLE_SECONDS}s idle — resetting idle counter" >>"$PULSE_WATCHDOG_LOG" 2>/dev/null || true
 		fi
 		WD_IDLE_SECONDS=0
 		return 0


### PR DESCRIPTION
## Summary

_watchdog_check_progress reads byte-delta from $LOGFILE to detect stalls. Lines 378 and 426 wrote informational status messages back to $LOGFILE on stall-resume and idle-resume — the t3058-class self-write anti-pattern. The next 60s poll evaluates the watchdog's own write as 'progress' and resets the stall counter, silently delaying real stall detection. Introduces PULSE_WATCHDOG_LOG (default ~/.aidevops/logs/pulse-watchdog.log) as a sibling sink the byte-delta monitor never reads, and routes both echos to it. Failure mode is non-fatal (|| true) so a missing parent dir cannot wedge the watchdog.

## Files Changed

.agents/scripts/pulse-watchdog.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck pulse-watchdog.sh — clean; visual diff confirms only the two informational echos changed sink (state machine logic untouched); pattern matches the t3058 fix in PR #21797 for worker-activity-watchdog.sh; no other $LOGFILE writes exist in pulse-watchdog.sh per rg audit.

Resolves #21842


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.11 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-opus-4-7 spent 11m and 23,174 tokens on this with the user in an interactive session.