### PR TITLE
t3081: document multi-account naming convention for secrets

### DIFF
--- a/.agents/tools/credentials/api-key-setup.md
+++ b/.agents/tools/credentials/api-key-setup.md
@@ -81,6 +81,8 @@ bash ~/Git/aidevops/.agents/scripts/setup-local-api-keys.sh set <service-name> Y
 | OpenAI | `openai-api-key` | https://platform.openai.com/api-keys |
 | Daytona | `daytona-api-key` | https://app.daytona.io/settings/api-keys |
 
+**Multi-account naming**: When you hold credentials for several accounts on the same provider at once (personal + work GitHub, multiple OpenAI projects, several Hetzner projects), suffix the bare name with `-<account>` / `_<ACCOUNT>` — e.g. `github-token-personal` and `github-token-work`, or `hcloud-token-project-a` and `hcloud-token-project-b`. The bare provider name remains the default for the single-account case. Full convention: `gopass.md` "Naming with multiple accounts".
+
 ### 4. Verify
 
 ```bash

--- a/.agents/tools/credentials/gopass.md
+++ b/.agents/tools/credentials/gopass.md
@@ -71,6 +71,23 @@ aidevops secret set OPENAI_API_KEY
 
 Verify with `aidevops secret list`.
 
+### Naming with multiple accounts
+
+When you hold credentials for multiple accounts on the same provider **at once** (personal + work GitHub, multiple OpenAI projects, several Hetzner projects, prod + staging AWS), suffix the canonical env var with a short account tag. Convention: `<PROVIDER>_<KIND>_<ACCOUNT>`, SCREAMING_SNAKE_CASE, account tag **last** so prefix-grep still groups by provider:
+
+```bash
+aidevops secret set GITHUB_TOKEN_PERSONAL
+aidevops secret set GITHUB_TOKEN_WORK
+aidevops secret set OPENAI_API_KEY_PERSONAL
+aidevops secret set OPENAI_API_KEY_CLIENT_ACME
+aidevops secret set HCLOUD_TOKEN_PROJECT_A
+aidevops secret set HCLOUD_TOKEN_PROJECT_B
+aidevops secret set AWS_ACCESS_KEY_ID_PROD
+aidevops secret set AWS_ACCESS_KEY_ID_STAGING
+```
+
+The bare provider name (`GITHUB_TOKEN`, `OPENAI_API_KEY`) remains the default for the single-account case — only suffix when you actually need to disambiguate. If you instead need one account active **at a time** and want to switch sets between projects, use `multi-tenant.md`.
+
 ### Using Secrets in Commands
 
 ```bash

--- a/.agents/tools/credentials/multi-tenant.md
+++ b/.agents/tools/credentials/multi-tenant.md
@@ -32,6 +32,8 @@ tools:
 
 Manages separate credential sets for multiple clients, environments, or accounts. For encrypted storage, see `tools/credentials/gopass.md` — use `aidevops secret` for encrypted secrets alongside `credential-helper.sh` for tenant switching.
 
+**Switch vs simultaneous**: This page covers *switching* between credential sets — one active at a time, same env var names (`GITHUB_TOKEN`) in different tenants. If you instead need multiple accounts for the same provider active **simultaneously** (e.g. personal + work GitHub tokens both in env at once), use the per-account suffix convention in `gopass.md` "Naming with multiple accounts" — `GITHUB_TOKEN_PERSONAL`, `GITHUB_TOKEN_WORK`, etc. — within a single tenant.
+
 ## Architecture
 
 ```text


### PR DESCRIPTION
## What

Adds explicit guidance to the credentials docs for the common case where a user holds credentials for multiple accounts on the same provider active **simultaneously** — personal + work GitHub, multiple OpenAI projects, several Hetzner projects, prod + staging AWS — and distinguishes this from `multi-tenant.md`'s scenario of *switching* between sets where only one is active at a time.

## Why

Existing docs imply one secret slot per provider (`GITHUB_TOKEN`, `OPENAI_API_KEY`). Users with multiple simultaneous accounts had to invent their own naming, then bridge the gap between three credential docs. `multi-tenant.md` covered the switching case; the simultaneous-accounts case had no documented convention.

## How

Three minimal edits across the credentials doc cluster:

- **`.agents/tools/credentials/gopass.md`** — new `### Naming with multiple accounts` subsection under "Storing Secrets". Canonical guidance: `<PROVIDER>_<KIND>_<ACCOUNT>` SCREAMING_SNAKE_CASE, account tag **last** so prefix-grep groups by provider. Examples for GitHub, OpenAI, Hetzner, AWS.
- **`.agents/tools/credentials/api-key-setup.md`** — short note under the Common Services table linking to the canonical convention.
- **`.agents/tools/credentials/multi-tenant.md`** — one cross-reference paragraph clarifying switch-vs-simultaneous.

## Acceptance

- Bare provider names (`GITHUB_TOKEN`, `OPENAI_API_KEY`) preserved as default for the single-account case.
- Suffix only recommended when actually needed.
- Convention discoverable from all three credential entry points.
- No new markdownlint violations on the touched files.

## Verification

```bash
npx --yes markdownlint-cli2 .agents/tools/credentials/gopass.md \
  .agents/tools/credentials/api-key-setup.md
```

Both files lint clean. `multi-tenant.md` surfaces 3 pre-existing MD031 violations (lines 61/68/74 in head, 59/66/72 on `origin/main`) — not introduced by this change; will file a separate follow-up.

Resolves #21848
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.11 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-opus-4-7 spent 7m and 24,045 tokens on this with the user in an interactive session.