### PR TITLE
t3082: fix bash 3.2 heredoc apostrophe in counter-trend-delta.sh

### DIFF
--- a/.agents/scripts/runtime-audit-rules/counter-trend-delta.sh
+++ b/.agents/scripts/runtime-audit-rules/counter-trend-delta.sh
@@ -93,7 +93,7 @@ Counter source: \`${stats_file/#$HOME/\~}\`
 
 ## Why
 
-Sharp counter regressions are the supervisor's structural blind spot — they appear in operational state long before they manifest as failed issues. Each regression cited above warrants investigation: a 3x-or-greater jump on a counter usually means a config change, a new bottleneck, or a regression in a recently-deployed script.
+Sharp counter regressions are the supervisor’s structural blind spot — they appear in operational state long before they manifest as failed issues. Each regression cited above warrants investigation: a 3x-or-greater jump on a counter usually means a config change, a new bottleneck, or a regression in a recently-deployed script.
 
 ## How
 


### PR DESCRIPTION
## Summary

`counter-trend-delta.sh` was added in t3072 (PR #21808) and immediately broke `ShellCheck (macos-latest)` on `main` because bash 3.2 (system `/bin/bash` on macOS) tracks single-quote state across unquoted heredoc bodies — bash 4+ does not. The `markdown_body` heredoc contains the word `supervisor's` whose ASCII apostrophe (`U+0027`) left the parser with an unmatched quote, producing `unexpected EOF while looking for matching \`'\`` at the closing `EOF` line.

This fix replaces `U+0027` with the Unicode right single quotation mark `U+2019` (`'`). Rendered Markdown is identical; only the bash parser sees a different byte sequence (`e2 80 99` instead of `27`). No detector logic touched.

## Why this approach

Three viable fixes were considered:

1. **Quote the heredoc tag** (`<<'EOF'`) — would disable `${var}` expansion in the body, requiring every interpolation to be split out. High-churn refactor for a single-character problem.
2. **Reword the sentence** to avoid the apostrophe — gratuitous prose change, future authors would re-introduce the bug.
3. **Use Unicode U+2019** (chosen) — one character changed, semantics preserved, typographically correct apostrophe, and the resulting bash escapes the quote-counting parser entirely.

## Test plan

```bash
/bin/bash -n .agents/scripts/runtime-audit-rules/counter-trend-delta.sh   # exits 0 (was: syntax error near line 124)
shellcheck     .agents/scripts/runtime-audit-rules/counter-trend-delta.sh # clean
git diff --stat                                                           # 1 file, +1 -1
```

CI evidence — current `main` failure on the same file: `gh run view --log <id> --job ShellCheck (macos-latest)` shows `counter-trend-delta.sh: line 124: unexpected EOF while looking for matching \`'\``. After this PR, that job goes green on `main`.

## Scope

- `.agents/scripts/runtime-audit-rules/counter-trend-delta.sh:96` — the only edit.

## Followups (filed separately, not part of this PR)

- Make `ShellCheck (macos-latest)` a required check on the default branch so the next bash 3.2 regression cannot land via PR.
- Document this exact failure mode (single quote in unquoted heredoc, bash 3.2-only) in `.agents/reference/bash-compat.md`.

Resolves #21849

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.11 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-opus-4-7 spent 51m and 103,862 tokens on this with the user in an interactive session.
