### PR TITLE
t3080: Cross-link meta-ads-tooling-cli.md from strategy docs

### DIFF
--- a/.agents/marketing-sales/meta-ads-campaigns-testing-abo.md
+++ b/.agents/marketing-sales/meta-ads-campaigns-testing-abo.md
@@ -128,6 +128,8 @@ Process: winning creative → 3-5 hook variations (same body) → test → winne
 | Day 7 | Kill underperformers; identify winners; plan next tests |
 | Day 14 | Declare winners; move to scale; document learnings; plan iteration tests |
 
+*To launch campaigns via CLI: [Meta Ads CLI](meta-ads-tooling-cli.md)*
+
 ---
 
 *Next: [Scaling Campaign (CBO)](scaling-cbo.md)*

--- a/.agents/marketing-sales/meta-ads-optimization-metrics.md
+++ b/.agents/marketing-sales/meta-ads-optimization-metrics.md
@@ -143,4 +143,6 @@ Incremental ROAS = Raw ROAS × Incrementality %            (e.g. 3.0x × 60% lif
 | **Lead Gen** | Cost Per Lead, Leads, Lead Conversion Rate, CTR (Link Click), Landing Page Views, CPM, Frequency, Quality Ranking |
 | **Video** | ThruPlay Cost, ThruPlays, 3-Second Video Views, Video Average Watch Time, CTR (All), CPM, Reach, Frequency |
 
+*Daily insights pull and reporting: [Meta Ads CLI](meta-ads-tooling-cli.md)*
+
 *Next: [Scaling Playbook](meta-ads-optimization-scaling.md)*


### PR DESCRIPTION
## Summary

Add cross-references from strategy docs into `meta-ads-tooling-cli.md` to close the one-way linking discoverability gap identified in issue #21847.

## Changes

- `EDIT: .agents/marketing-sales/meta-ads-campaigns-testing-abo.md` — added `*To launch campaigns via CLI: [Meta Ads CLI](meta-ads-tooling-cli.md)*` after the launch checklist review table, before the horizontal rule
- `EDIT: .agents/marketing-sales/meta-ads-optimization-metrics.md` — added `*Daily insights pull and reporting: [Meta Ads CLI](meta-ads-tooling-cli.md)*` between the custom columns table and the existing Next link

## Verification

- markdownlint-cli2: 0 errors on both files
- `grep -c 'meta-ads-tooling-cli'`: 1 in each file (acceptance criteria met)

Ref #21844
Resolves #21847


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.11 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-sonnet-4-6 spent 3m and 4,296 tokens on this as a headless worker.