### PR TITLE
t3085: init pre-existing local-var declarations in pulse-wrapper.sh + bootstrap

### DIFF
--- a/.agents/scripts/pulse-wrapper-bootstrap.sh
+++ b/.agents/scripts/pulse-wrapper-bootstrap.sh
@@ -493,7 +493,7 @@ _record_invocation_source() {
 	local log_dest="${LOGFILE:-${HOME}/.aidevops/logs/pulse.log}"
 
 	# Log entry (ISO-8601 UTC to match pulse-logging.sh conventions)
-	local _ts _pcmd
+	local _ts="" _pcmd=""
 	_ts=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || printf 'unknown')
 	_pcmd=$(ps -p "$PPID" -o comm= 2>/dev/null || printf 'unknown')
 	printf '[%s] pulse-wrapper invoked: pid=%d ppid=%d source=%s parent_cmd=%s\n' \
@@ -502,7 +502,7 @@ _record_invocation_source() {
 
 	# Increment invocation_sources.{source} as a plain integer counter.
 	# Uses tmp-file + mv for atomicity (same pattern as pulse_stats_increment).
-	local _dir _tmp
+	local _dir="" _tmp=""
 	_dir="$(dirname "$stats_file")"
 	[[ -d "$_dir" ]] || mkdir -p "$_dir" 2>/dev/null || return 0
 	[[ -f "$stats_file" ]] || printf '{"counters":{}}\n' >"$stats_file" 2>/dev/null || return 0

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -785,7 +785,7 @@ _pulse_execute_self_check() {
 		_PULSE_DIRTY_PR_SWEEP_LOADED
 		_PULSE_CANONICAL_RECOVERY_LOADED
 	)
-	local _sc_guard _sc_val
+	local _sc_guard="" _sc_val=""
 	# The `${array[@]+"${array[@]}"}` pattern is safe under `set -u`
 	# when the array is empty — required in Phase 0 where no module
 	# guards exist yet.
@@ -971,7 +971,7 @@ _pulse_check_idle_backoff_gate() {
 	# Mirrors should-skip semantics so the helper composes naturally with
 	# `if helper should-skip; then return; fi` at the call site.
 	if "$_ib_helper" should-skip "$_ib_last" >/dev/null 2>&1; then
-		local _ib_state _ib_count _ib_interval
+		local _ib_state="" _ib_count="" _ib_interval=""
 		_ib_state=$("$_ib_helper" state 2>/dev/null || echo '{}')
 		_ib_count=$(echo "$_ib_state" | jq -r '.consecutive_idle // 0' 2>/dev/null || echo "0")
 		_ib_interval=$(echo "$_ib_state" | jq -r '.current_effective_interval_s // 90' 2>/dev/null || echo "90")
@@ -1130,7 +1130,7 @@ _pulse_run_deterministic_pipeline() {
 	local _pulse_merge_routine_last_run="${HOME}/.aidevops/logs/pulse-merge-routine-last-run"
 	local _pmr_skip=0
 	if [[ -f "$_pulse_merge_routine_last_run" ]]; then
-		local _pmr_last _pmr_now _pmr_elapsed
+		local _pmr_last="" _pmr_now="" _pmr_elapsed=""
 		_pmr_last=$(cat "$_pulse_merge_routine_last_run" 2>/dev/null || echo "0")
 		_pmr_now=$(date +%s 2>/dev/null || echo "0")
 		[[ "$_pmr_last" =~ ^[0-9]+$ ]] || _pmr_last=0
@@ -1412,7 +1412,7 @@ main() {
 				# ticks all returned 0 here without ever attempting reclaim.
 				# Fix: enforce PULSE_LOCK_MAX_AGE_S as a fall-through trigger so
 				# stale-but-alive locks reach the proper reclaim path below.
-				local _ir_age _ir_max
+				local _ir_age="" _ir_max=""
 				_ir_age=$(_get_process_age "$_ir_pid" 2>/dev/null || true)
 				_ir_max="${PULSE_LOCK_MAX_AGE_S:-1800}"
 				if [[ "$_ir_age" =~ ^[0-9]+$ ]] && [[ "$_ir_age" -le "$_ir_max" ]]; then


### PR DESCRIPTION
## Summary

Initialized 6 pre-existing multi-var `local` declarations without init across `pulse-wrapper.sh` (4 sites) and `pulse-wrapper-bootstrap.sh` (2 sites) with the canonical `local _var=""` pattern to prevent unbound-var crashes under `set -u` on cold/stress paths.

Resolves #21856

## Changes

- `pulse-wrapper-bootstrap.sh:496` — `local _ts _pcmd` → `local _ts="" _pcmd=""`
- `pulse-wrapper-bootstrap.sh:505` — `local _dir _tmp` → `local _dir="" _tmp=""`
- `pulse-wrapper.sh:788` — `local _sc_guard _sc_val` → `local _sc_guard="" _sc_val=""`
- `pulse-wrapper.sh:974` — `local _ib_state _ib_count _ib_interval` → `local _ib_state="" _ib_count="" _ib_interval=""`
- `pulse-wrapper.sh:1133` — `local _pmr_last _pmr_now _pmr_elapsed` → `local _pmr_last="" _pmr_now="" _pmr_elapsed=""`
- `pulse-wrapper.sh:1415` — `local _ir_age _ir_max` → `local _ir_age="" _ir_max=""`

## Testing

- `pulse-unbound-var-check.sh --scan-files` — 0 violations (was 6)
- `shellcheck` — clean on both files
- `test-approve-kicks-pulse.sh` — 21 pass, 0 fail

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.11 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-opus-4-6 spent 4m and 6,090 tokens on this as a headless worker.
