### PR TITLE
GH#21846: Add multi-account gopass secret template for Meta Ads CLI

### DIFF
--- a/.agents/configs/secrets-templates/meta-ads.template.env
+++ b/.agents/configs/secrets-templates/meta-ads.template.env
@@ -1,0 +1,50 @@
+# Meta Ads CLI — Secret Template
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Naming convention: meta-ads-<account>-<env>
+#   <account> — lowercase hyphenated slug for the ad account or client
+#               (e.g. acme, client-foo, brand-x, agency-clientA)
+#   <env>     — one of: prod | dev | staging
+#
+# Store via aidevops secret (gopass-backed):
+#   aidevops secret set meta-ads-<account>-<env>
+#
+# Retrieve as env-file for sourcing:
+#   source <(aidevops secret env meta-ads-<account>-<env>)
+#
+# Examples:
+#   source <(aidevops secret env meta-ads-clientA-prod)
+#   source <(aidevops secret env meta-ads-brandB-dev)
+#   source <(aidevops secret env meta-ads-acme-staging)
+
+# --- Required ---
+
+# Long-lived system user token from Meta Business Suite
+# Business Settings → Users → System Users → Generate Token
+META_ACCESS_TOKEN=""
+
+# Ad account ID in act_NNN format
+# Business Settings → Ad Accounts → select account → copy Account ID → prefix with act_
+META_AD_ACCOUNT_ID=""
+
+# --- Common optional ---
+
+# App ID from Meta Developer Dashboard
+# developers.facebook.com → My Apps → select app → Settings → Basic
+META_APP_ID=""
+
+# App Secret from Meta Developer Dashboard (same location as APP_ID)
+META_APP_SECRET=""
+
+# Business Manager ID
+# Business Settings → Business Info → Business Manager ID
+META_BUSINESS_ID=""
+
+# Pixel ID for conversion tracking and CAPI event matching
+# Events Manager → select pixel → Settings → Pixel ID
+META_PIXEL_ID=""
+
+# Facebook Page ID for ad creative association
+# Page Settings → Page Info → Page ID (or via Graph API: /me?fields=id)
+META_PAGE_ID=""

--- a/.agents/marketing-sales/meta-ads-foundations-attribution.md
+++ b/.agents/marketing-sales/meta-ads-foundations-attribution.md
@@ -44,7 +44,7 @@ Meta's attribution is designed to show Meta ads in the best light.
 
 The gold standard for measuring true ad impact.
 
-```
+```text
 Incrementality = (Test Group Conversions - Control Group Conversions) / Test Group Conversions
 ```
 
@@ -68,7 +68,7 @@ Retargeting has the lowest incrementality — many of those users would have pur
 
 **Brand Lift:** Survey-based. Measures awareness, consideration, recall. Best for brand campaigns.
 
-```
+```text
 Test Group: 1,000 conversions | Control: 400 | Lift: 150%
 Incremental: 600 | Spend: $30K | Cost Per Incremental: $50
 ```
@@ -111,7 +111,7 @@ Use multiple methods — no single source is perfect:
 
 **MER (Marketing Efficiency Ratio):**
 
-```
+```text
 MER = Total Revenue / Total Marketing Spend
 ```
 
@@ -135,6 +135,18 @@ Tracks business-wide efficiency instead of platform ROAS. Reduces attribution ar
 | Lead gen (7-30 day cycle) | 7-day click only | CRM lead-to-customer rate |
 | B2B SaaS (30-180 day cycle) | 28-day click (API) | Dreamdata / HockeyStack |
 | Brand awareness | 1-day view | Brand lift study + surveys |
+
+## Conversions API (CAPI)
+
+Server-side event sending that bypasses browser-side tracking losses (iOS opt-outs, ad blockers,
+cross-device gaps). CAPI is mandatory in 2026 — pixel-only loses 30-50% of conversions.
+
+Load `META_PIXEL_ID` and `META_ACCESS_TOKEN` per-account via the gopass template before sending
+any CAPI events: `source <(aidevops secret env meta-ads-<account>-<env>)`.
+See `.agents/configs/secrets-templates/meta-ads.template.env` for the full variable set.
+
+CAPI events flow from your server (or a partner like Stape/Segment); the CLI (`meta ads dataset`)
+wires the pixel to the ad account — see `meta-ads-tooling-cli.md` "Pixel and dataset wiring".
 
 ## Key Takeaways
 

--- a/.agents/marketing-sales/meta-ads-tooling-cli.md
+++ b/.agents/marketing-sales/meta-ads-tooling-cli.md
@@ -45,6 +45,8 @@ export META_AD_ACCOUNT_ID="act_…"    # default ad account; overridable per-com
 export META_APP_ID="…"
 export META_APP_SECRET="…"
 export META_BUSINESS_ID="…"
+export META_PIXEL_ID="…"
+export META_PAGE_ID="…"
 
 # Verify
 meta ads ad-account list
@@ -54,13 +56,56 @@ meta ads ad-account list
 
 ```bash
 # Good
-META_ACCESS_TOKEN=$(aidevops secret get meta-ads-staging) meta ads campaign list
+source <(aidevops secret env meta-ads-clientA-prod)
+meta ads campaign list
 
 # Bad (token ends up in shell history AND your chat transcript)
 META_ACCESS_TOKEN="EAAB..." meta ads campaign list
 ```
 
-For the aidevops framework: store via `aidevops secret set meta-ads-<env>` (gopass-backed), retrieve via `aidevops secret get meta-ads-<env>`. Plaintext fallback: `~/.config/aidevops/credentials.sh` (chmod 600). See `tools/credentials/gopass.md`.
+For the aidevops framework: store via `aidevops secret set meta-ads-<account>-<env>` (gopass-backed),
+retrieve via `aidevops secret env meta-ads-<account>-<env>`. The naming convention is
+`meta-ads-<account>-<env>` where `<account>` is a lowercase hyphenated slug identifying the ad
+account or client (e.g., `acme`, `client-foo`, `brand-x`) and `<env>` is one of `prod` / `dev` /
+`staging`. Plaintext fallback: `~/.config/aidevops/credentials.sh` (chmod 600).
+See `tools/credentials/gopass.md` and `.agents/configs/secrets-templates/meta-ads.template.env`.
+
+### Multi-account workflows
+
+Real deployments manage multiple ad accounts simultaneously — agency clients, multiple brands under
+one org, parallel test/prod environments per client. Load each account's credentials by sourcing
+its env-file before running commands:
+
+```bash
+# Switch to client A (production)
+source <(aidevops secret env meta-ads-clientA-prod)
+meta ads campaigns list
+
+# Switch to brand B (development)
+source <(aidevops secret env meta-ads-brandB-dev)
+meta ads campaigns list
+
+# Run insights for client A staging without polluting the shell
+env $(aidevops secret env meta-ads-clientA-staging) \
+  meta ads insights get --date-preset last_7d --format json
+```
+
+Naming rules:
+- `<account>` — lowercase, hyphenated, no spaces. Identifies the ad account or client.
+  Examples: `acme`, `client-foo`, `brand-x`, `agency-clientA`.
+- `<env>` — one of `prod`, `dev`, `staging`.
+- Full key: `meta-ads-<account>-<env>`. Examples: `meta-ads-clientA-prod`,
+  `meta-ads-brandB-dev`, `meta-ads-acme-staging`.
+
+To populate a new account's secrets, use the canonical template:
+
+```bash
+# View the variable set required
+cat .agents/configs/secrets-templates/meta-ads.template.env
+
+# Store each variable (gopass prompts securely)
+aidevops secret set meta-ads-clientA-prod
+```
 
 ## Output Formats
 
@@ -87,6 +132,9 @@ meta ads campaign list --format plain | awk -F'\t' '$2 ~ /Summer/ {print $1}'
 ### Launch an ABO test (see `meta-ads-campaigns-testing-abo.md`)
 
 ```bash
+# 0. Load account credentials
+source <(aidevops secret env meta-ads-clientA-prod)
+
 # 1. Campaign — paused by default until you flip status
 meta ads campaign create \
   --name "ABO Test — UGC angles — 2026-W19" \
@@ -120,6 +168,9 @@ meta ads campaign update "$CAMPAIGN_ID" --status ACTIVE
 ### Pull insights for a weekly review (see `meta-ads-optimization-metrics.md`, `meta-ads-checklists-weekly-review.md`)
 
 ```bash
+# 0. Load account credentials
+source <(aidevops secret env meta-ads-clientA-prod)
+
 # Account-level top line
 meta ads insights get --date-preset last_7d --format json \
   --fields spend,impressions,clicks,ctr,cpc,actions,action_values,roas
@@ -136,6 +187,9 @@ meta ads insights get --level ad --date-preset last_7d --format json \
 ### Catalog and product sync (commerce campaigns)
 
 ```bash
+# 0. Load account credentials
+source <(aidevops secret env meta-ads-clientA-prod)
+
 meta ads catalog create --name "Main — 2026"
 CATALOG_ID=...
 
@@ -176,7 +230,7 @@ meta ads … --no-input --force --format json
 
 if ! meta ads campaign list --format json > /tmp/campaigns.json; then
   case $? in
-    3) echo "auth"; aidevops secret rotate meta-ads-prod ;;
+    3) echo "auth"; aidevops secret rotate meta-ads-clientA-prod ;;
     4) echo "api"; sleep 30; retry ;;
     *) echo "cli"; exit 1 ;;
   esac
@@ -188,7 +242,7 @@ fi
 1. **Resources are PAUSED on create.** Activation is always a separate `--status ACTIVE` call. Never combine create + activate in one command — leave a review step.
 2. **Verify spend before going live.** `meta ads campaign get $ID --format json | jq '.daily_budget,.lifetime_budget'` — confirm currency unit (cents vs dollars varies by ad account).
 3. **Destructive ops require confirmation.** Before `meta ads campaign delete`, `meta ads ad delete`, or any bulk update on >5 entities: run `verify-operation-helper.sh check --operation "<cmd>"` (framework rule, not CLI rule).
-4. **Stay in your ad account.** Always set `META_AD_ACCOUNT_ID` per session; never rely on a default. If you manage multiple accounts (agency model), prefix every command with `--ad-account-id "$ACCOUNT"` explicitly.
+4. **Stay in your ad account.** Always set `META_AD_ACCOUNT_ID` per session; never rely on a default. If you manage multiple accounts (agency model), use `source <(aidevops secret env meta-ads-<account>-<env>)` at the top of each script to load the correct account credentials explicitly.
 5. **Audit trail.** Pipe writes through a logger: `meta ads campaign create … --format json | tee -a ~/.aidevops/logs/meta-ads-writes.jsonl`. Combine with `audit-log-helper.sh log meta-ads "<msg>"` for security ops (creative deletes, dataset disconnects).
 6. **No tokens in commit messages or PR bodies.** Reference accounts by id, not by token.
 


### PR DESCRIPTION
## Summary

Adds multi-account `gopass` secret naming convention for Meta Ads CLI and updates the
agent docs to demonstrate account-scoped credential loading throughout.

## Changes

- **`meta-ads-tooling-cli.md`** — Auth section: replaced `meta-ads-<env>` with
  `meta-ads-<account>-<env>`; named and explained the `<account>` slug convention;
  added "Multi-account workflows" subsection showing `source <(aidevops secret env …)` patterns;
  updated all three worked workflows (ABO launch, insights pull, catalog upload) with the
  account-scoped secret loading step at the top.

- **`.agents/configs/secrets-templates/meta-ads.template.env`** *(new)* — Canonical 7-variable
  template (`META_ACCESS_TOKEN`, `META_AD_ACCOUNT_ID`, `META_APP_ID`, `META_APP_SECRET`,
  `META_BUSINESS_ID`, `META_PIXEL_ID`, `META_PAGE_ID`) with explanatory comments and retrieval
  pattern in the header.

- **`meta-ads-foundations-attribution.md`** — Added CAPI section linking to the template for
  per-account credential loading; fixed three pre-existing MD040 lint violations (missing fenced
  code language tags).

## Verification

- `markdownlint-cli2` — 0 errors on both modified docs
- `grep -c 'meta-ads-<account>-<env>'` — 5 (>=2 required)
- `grep -c 'META_ACCESS_TOKEN'` in template — 1 (>=1 required)
- `grep -c 'meta-ads-<env>'` in tooling doc — 0 (must be 0)

Ref #21846

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.11 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-sonnet-4-6 spent 6m and 12,452 tokens on this as a headless worker.
