### PR TITLE
GH#21877: add configurable runner label to reusable workflows via repos.json

### DIFF
--- a/.agents/reference/repos-json-fields.md
+++ b/.agents/reference/repos-json-fields.md
@@ -39,6 +39,12 @@ Auto-inferred when absent: `local_only`/no-remote → `minimal`; others → `sta
 | `pulse_interval` | integer | `600` | Minimum seconds between dispatch polls for this repo. Default: omit (poll every cycle). Min: 60. Useful for contributor-role repos with low activity — e.g. 600 polls every 5 cycles instead of every cycle, reducing GraphQL budget consumption ~5×. State: `~/.aidevops/logs/pulse-last-per-repo.json`. |
 | `pulse_expires` | string | `"2026-05-01"` | Past this date, pulse auto-sets `pulse: false`. Useful for temporary windows. |
 
+## Workflow Runner Configuration
+
+| Field | Type | Example | Description |
+|-------|------|---------|-------------|
+| `runner` | string | `"ubicloud-standard-2"` | Runner label for managed reusable workflows (`issue-sync`, `maintainer-gate`, `review-bot-gate`, `loc-badge`). Omit to inherit the reusable workflow default (`ubuntu-latest`). Consumed by `aidevops sync-workflows --apply` — injected as `with: runner: <label>` in the caller YAML and preserved across future syncs. Self-hosted label groups must be YAML-encoded as a string: `"[self-hosted, linux, x64]"`. See `reference/reusable-workflows.md` "Runner override". |
+
 ## Contribution and FOSS Fields
 
 | Field | Type | Description |

--- a/.agents/reference/reusable-workflows.md
+++ b/.agents/reference/reusable-workflows.md
@@ -108,6 +108,43 @@ aidevops sync-workflows --apply # update pins to current aidevops version
 
 See also [`auto-dispatch.md`](auto-dispatch.md) for the `SYNC_PAT` requirement (unchanged under the reusable pattern — still per-repo secret).
 
+## Runner override (GH#21877)
+
+All four managed reusable workflows (`issue-sync-reusable.yml`, `maintainer-gate-reusable.yml`, `review-bot-gate-reusable.yml`, `loc-badge-reusable.yml`) accept a `runner` input (type: `string`, default: `ubuntu-latest`). Downstream repos can redirect all managed workflow jobs to an alternative runner — e.g. Ubicloud, self-hosted, or Namespace — without owning their own copies.
+
+### Configuring runner override
+
+Add a `"runner"` field to the repo entry in `~/.config/aidevops/repos.json`:
+
+```json
+{
+  "initialized_repos": [
+    {
+      "slug": "myorg/myrepo",
+      "runner": "ubicloud-standard-2"
+    }
+  ]
+}
+```
+
+Then run `aidevops sync-workflows --apply` — the helper injects `with: runner: ubicloud-standard-2` into the caller YAML and the reusable workflow routes all jobs to that runner. Future syncs preserve the injection; `aidevops check-workflows` treats the injected block as normalised and will not report `DRIFTED/CALLER`.
+
+If you omit the `runner` field (or set it to `"ubuntu-latest"`), callers inherit the reusable workflow default — no `with: runner:` block is injected and behaviour is identical to pre-GH#21877.
+
+### Self-hosted runner groups
+
+GitHub Actions accepts a YAML list or a string for `runs-on`. The `runner` input is typed `string`. For group-scoped self-hosted labels, encode the array as a string:
+
+```json
+"runner": "[self-hosted, linux, x64]"
+```
+
+The caller YAML becomes `with: runner: "[self-hosted, linux, x64]"` and GitHub Actions parses the list at dispatch time.
+
+### Security caveat for maintainer-gate
+
+`maintainer-gate-reusable.yml` enforces PR merge integrity — it blocks PRs that reference issues still needing maintainer review. If you point this workflow at a self-hosted runner you do not fully control, the gate's integrity depends on the trustworthiness of that runner environment. The framework cannot police runner trust; this is a downstream ops concern. For security-sensitive repos, keep `maintainer-gate` on GitHub-hosted runners even if other workflows use self-hosted runners.
+
 ## Security model
 
 - **`secrets: inherit` only works within the same GitHub account/org (GH#20976).** Cross-account callers (every downstream user — `marcusquinn/aidevops` is the only same-account consumer) receive empty values for caller-repo secrets when using `secrets: inherit` against a reusable workflow in a different account. Explicit secret pass-through is required:

--- a/.agents/scripts/check-workflows-helper.sh
+++ b/.agents/scripts/check-workflows-helper.sh
@@ -78,6 +78,7 @@ readonly _KNOWN_WORKFLOWS=(
 	"issue-sync.yml:issue-sync-reusable.yml:issue-sync-caller.yml"
 	"review-bot-gate.yml:review-bot-gate-reusable.yml:review-bot-gate-caller.yml"
 	"maintainer-gate.yml:maintainer-gate-reusable.yml:maintainer-gate-caller.yml"
+	"loc-badge.yml:loc-badge-reusable.yml:loc-badge-caller.yml"
 )
 
 # ─── Path resolution ────────────────────────────────────────────────────────
@@ -133,12 +134,38 @@ _usage() {
 #     `@main` vs `@v3.9.0` doesn't count as drift.
 #   - Replaces `branches: [<name>]` with `branches: [BRANCH]` so repos that
 #     default to `develop` aren't flagged as drifted from a main-defaulting template.
+#   - Strips injected `runner:` keys from `with:` blocks (GH#21877) and removes
+#     any `    with:` block that becomes empty after runner removal, so repos
+#     with a repos.json `runner` override aren't flagged as DRIFTED/CALLER.
 # Emits normalised content on stdout.
 _normalize_wf_for_compare() {
 	local _file="$1"
 	local _reusable_escaped="$2"
+	# Step 1: normalise @ref and branch filter (existing logic).
+	# Step 2: remove injected `      runner: <value>` lines.
+	# Step 3: remove `    with:` block headers that are now empty (runner was
+	#         the only key). Uses awk: buffer the `    with:` line, emit it
+	#         only if the next line is also inside the block (6-space indent);
+	#         otherwise discard the header silently.
 	sed -E "s|(marcusquinn/aidevops/\.github/workflows/${_reusable_escaped})@[^[:space:]]+|\1@REF|g" "$_file" \
-		| sed -E 's|^([[:space:]]+branches:) \[[^]]+\]$|\1 [BRANCH]|'
+		| sed -E 's|^([[:space:]]+branches:) \[[^]]+\]$|\1 [BRANCH]|' \
+		| sed -E '/^      runner: /d' \
+		| awk '
+			/^    with:$/ { pending = $0; next }
+			pending {
+				if (/^      /) {
+					print pending
+					pending = ""
+					print
+					next
+				}
+				pending = ""
+				print
+				next
+			}
+			{ print }
+			END { if (pending != "") print pending }
+		'
 	return 0
 }
 

--- a/.agents/scripts/sync-workflows-helper.sh
+++ b/.agents/scripts/sync-workflows-helper.sh
@@ -71,10 +71,12 @@ readonly CHECK_HELPER="$SELF_DIR/check-workflows-helper.sh"
 # Mirrors _KNOWN_WORKFLOWS in check-workflows-helper.sh.
 # GH#20727: review-bot-gate added.
 # GH#21154: maintainer-gate added (layer-1 defense-in-depth propagation).
+# GH#21877: loc-badge added (runner input parity).
 readonly _SYNC_KNOWN_WORKFLOWS=(
 	"issue-sync.yml:issue-sync-caller.yml"
 	"review-bot-gate.yml:review-bot-gate-caller.yml"
 	"maintainer-gate.yml:maintainer-gate-caller.yml"
+	"loc-badge.yml:loc-badge-caller.yml"
 )
 
 # Output mode constants.
@@ -215,6 +217,44 @@ _rewrite_content_branch_filter() {
 	_branch_escaped=$(printf '%s' "$_branch" | sed 's/[&|/]/\\&/g')
 	printf '%s\n' "$_content" | \
 		sed -E "s|^([[:space:]]+branches:) \[${_BRANCH_DEFAULT_NAME}\]$|\1 [${_branch_escaped}]|"
+	return 0
+}
+
+# ─── Runner Override Injection ──────────────────────────────────────────────
+
+# _read_runner_field <slug>
+# Reads the optional "runner" field for a slug from repos.json.
+# Emits the runner label on stdout, or nothing if the field is absent.
+_read_runner_field() {
+	local _slug="$1"
+	jq -r --arg s "$_slug" \
+		'.initialized_repos[]? | select(.slug == $s) | .runner // empty' \
+		"$REPOS_JSON" 2>/dev/null
+	return 0
+}
+
+# _inject_runner_in_content <content> <runner_label>
+# Injects `runner: <label>` into the caller template's `with:` block.
+#   - If the template already has a `    with:` block, appends runner as the
+#     first key inside it (so it survives further key additions).
+#   - If no `    with:` block exists, inserts one after the `    uses:` line.
+# Emits the modified content on stdout.
+_inject_runner_in_content() {
+	local _content="$1"
+	local _runner="$2"
+	local _runner_escaped
+	_runner_escaped=$(printf '%s' "$_runner" | sed 's/[&|/]/\\&/g')
+
+	# Does the template already have a `    with:` block?
+	if printf '%s\n' "$_content" | grep -qE '^    with:$'; then
+		# Append runner as the first entry inside the existing with: block.
+		printf '%s\n' "$_content" | \
+			sed -E "s|^(    with:)$|\\1\n      runner: ${_runner_escaped}|"
+	else
+		# No with: block — inject one after the uses: line.
+		printf '%s\n' "$_content" | \
+			sed -E "s|^(    uses:[[:space:]]*marcusquinn/aidevops/.+)$|\\1\n    with:\n      runner: ${_runner_escaped}|"
+	fi
 	return 0
 }
 
@@ -460,6 +500,13 @@ _sync_one_repo() {
 	if ! _target_content=$(_render_template_with_ref "$_template" "$_effective_ref"); then
 		printf '%s\t%s\t%s\ttemplate render failed\n' "$_slug" "$_status" "$_STATUS_FAILED"
 		return 1
+	fi
+
+	# Inject runner override when repos.json carries a "runner" field for this slug.
+	local _runner_override=""
+	_runner_override=$(_read_runner_field "$_slug")
+	if [[ -n "$_runner_override" ]]; then
+		_target_content=$(_inject_runner_in_content "$_target_content" "$_runner_override")
 	fi
 
 	if [[ "$_apply" -eq 0 ]]; then

--- a/.agents/scripts/tests/test-check-workflows-runner-normalise.sh
+++ b/.agents/scripts/tests/test-check-workflows-runner-normalise.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-check-workflows-runner-normalise.sh — regression test for GH#21877
+#
+# Verifies that _normalize_wf_for_compare in check-workflows-helper.sh
+# correctly handles the injected `with: runner:` block so repos that carry
+# a repos.json `runner` field are not falsely flagged as DRIFTED/CALLER.
+#
+# Scenarios covered:
+#   A.  Canonical template (no runner override) → CURRENT/CALLER
+#   B.  Caller with injected `with: runner: ubicloud-standard-2` inside an
+#       existing `with:` block (issue-sync pattern) → CURRENT/CALLER
+#   C.  Caller with a standalone `with: runner: ubicloud-standard-2` block
+#       injected after `uses:` (maintainer-gate / review-bot-gate pattern)
+#       → CURRENT/CALLER
+#   D.  Caller with a genuinely drifted line (unrelated to runner) → DRIFTED/CALLER
+#       (true-positive preserved — runner normalisation must not mask real drift)
+#   E.  Caller with runner AND a develop-branch variant → CURRENT/CALLER
+#       (runner + branch normalisations compose correctly)
+#
+# Strategy: each scenario builds a temporary repo tree, copies the canonical
+# caller template (optionally mutated), runs the helper in --json mode, and
+# asserts the classification string.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+HELPER="${SCRIPT_DIR}/../check-workflows-helper.sh"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)" || exit 1
+
+if [[ ! -f "$HELPER" ]]; then
+	echo "SKIP: helper not found at $HELPER" >&2
+	exit 0
+fi
+
+readonly _T_GREEN='\033[0;32m'
+readonly _T_RED='\033[0;31m'
+readonly _T_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+_pass() {
+	local name="$1"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf '%bPASS%b %s\n' "$_T_GREEN" "$_T_RESET" "$name"
+	return 0
+}
+
+_fail() {
+	local name="$1"
+	local msg="${2:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '%bFAIL%b %s\n' "$_T_RED" "$_T_RESET" "$name"
+	[[ -n "$msg" ]] && printf '       %s\n' "$msg"
+	return 0
+}
+
+# ─── Fixture helpers ──────────────────────────────────────────────────────────
+
+_setup_fake_home() {
+	local _root="$1"
+	mkdir -p "$_root/.config/aidevops"
+	mkdir -p "$_root/.aidevops/agents/templates/workflows"
+	# Copy all canonical templates so the helper resolves any workflow type.
+	local _tpl
+	for _tpl in issue-sync-caller.yml review-bot-gate-caller.yml \
+	            maintainer-gate-caller.yml loc-badge-caller.yml; do
+		local _src="$REPO_ROOT/.agents/templates/workflows/${_tpl}"
+		[[ -f "$_src" ]] && cp "$_src" "$_root/.aidevops/agents/templates/workflows/${_tpl}"
+	done
+	return 0
+}
+
+_write_repos_json() {
+	local _root="$1"
+	local _json="$2"
+	printf '%s\n' "$_json" > "$_root/.config/aidevops/repos.json"
+	return 0
+}
+
+# _classify_for_workflow <fake-home-root> <slug> <workflow-name-without-.yml>
+_classify_for_workflow() {
+	local _root="$1"
+	local _slug="$2"
+	local _wf_name="$3"
+	HOME="$_root" bash "$HELPER" --json --repo "$_slug" --workflow "$_wf_name" 2>/dev/null \
+		| jq -r 'select(.slug != "") | .classification' \
+		| head -n 1
+	return 0
+}
+
+# ─── Scenario helpers ─────────────────────────────────────────────────────────
+
+# _add_runner_to_with_block <src_template> <dest_file> <runner_label>
+# Mirrors _inject_runner_in_content for templates that already have a `with:` block.
+_add_runner_to_with_block() {
+	local _src="$1"
+	local _dest="$2"
+	local _runner="$3"
+	sed -E "s|^(    with:)$|\\1\n      runner: ${_runner}|" "$_src" > "$_dest"
+	return 0
+}
+
+# _add_standalone_runner_block <src_template> <dest_file> <runner_label>
+# Mirrors _inject_runner_in_content for templates with no existing `with:` block.
+_add_standalone_runner_block() {
+	local _src="$1"
+	local _dest="$2"
+	local _runner="$3"
+	sed -E "s|^(    uses:[[:space:]]*marcusquinn/aidevops/.+)$|\\1\n    with:\n      runner: ${_runner}|" \
+		"$_src" > "$_dest"
+	return 0
+}
+
+# ─── Tests ────────────────────────────────────────────────────────────────────
+
+readonly _RUNNER_LABEL="ubicloud-standard-2"
+
+# Workflow tuples to test: workflow_file:template_file
+# We test issue-sync (has existing with: block) and maintainer-gate (no with: block).
+readonly -a _WF_TUPLES=(
+	"issue-sync.yml:issue-sync-caller.yml"
+	"maintainer-gate.yml:maintainer-gate-caller.yml"
+	"review-bot-gate.yml:review-bot-gate-caller.yml"
+	"loc-badge.yml:loc-badge-caller.yml"
+)
+
+for _wf_tuple in "${_WF_TUPLES[@]}"; do
+	_wf_file="${_wf_tuple%%:*}"
+	_tpl_file="${_wf_tuple##*:}"
+	_wf_name="${_wf_file%.yml}"
+
+	_src_template="$REPO_ROOT/.agents/templates/workflows/${_tpl_file}"
+	if [[ ! -f "$_src_template" ]]; then
+		printf 'SKIP: template not found: %s\n' "$_src_template" >&2
+		continue
+	fi
+
+	# ── Scenario A: byte-identical canonical caller (no runner) → CURRENT/CALLER ─
+	_TD="$(mktemp -d)"
+	_setup_fake_home "$_TD"
+	mkdir -p "$_TD/repos/repo-a/.github/workflows"
+	cp "$_src_template" "$_TD/repos/repo-a/.github/workflows/${_wf_file}"
+	_write_repos_json "$_TD" \
+		"$(jq -n --arg p "$_TD/repos/repo-a" \
+			'{initialized_repos: [{slug: "x/a", path: $p, local_only: false}]}')"
+	_result=$(_classify_for_workflow "$_TD" "x/a" "$_wf_name")
+	if [[ "$_result" == "CURRENT/CALLER" ]]; then
+		_pass "${_wf_name}: canonical caller (no runner) → CURRENT/CALLER"
+	else
+		_fail "${_wf_name}: canonical caller (no runner) → CURRENT/CALLER" \
+			"got: ${_result:-<empty>}"
+	fi
+	rm -rf "$_TD"
+
+	# ── Scenario B/C: caller with injected runner block → CURRENT/CALLER ─────
+	# For templates with `with:` already (e.g. issue-sync), use _add_runner_to_with_block.
+	# For templates without `with:` (e.g. maintainer-gate), use _add_standalone_runner_block.
+	_TD="$(mktemp -d)"
+	_setup_fake_home "$_TD"
+	mkdir -p "$_TD/repos/repo-b/.github/workflows"
+	_dest_wf="$_TD/repos/repo-b/.github/workflows/${_wf_file}"
+	if grep -qE '^    with:$' "$_src_template" 2>/dev/null; then
+		_add_runner_to_with_block "$_src_template" "$_dest_wf" "$_RUNNER_LABEL"
+	else
+		_add_standalone_runner_block "$_src_template" "$_dest_wf" "$_RUNNER_LABEL"
+	fi
+	_write_repos_json "$_TD" \
+		"$(jq -n --arg p "$_TD/repos/repo-b" \
+			'{initialized_repos: [{slug: "x/b", path: $p, local_only: false}]}')"
+	_result=$(_classify_for_workflow "$_TD" "x/b" "$_wf_name")
+	if [[ "$_result" == "CURRENT/CALLER" ]]; then
+		_pass "${_wf_name}: runner-injected caller → CURRENT/CALLER (normalisation)"
+	else
+		_fail "${_wf_name}: runner-injected caller → CURRENT/CALLER (normalisation)" \
+			"got: ${_result:-<empty>} — runner block was not stripped from comparison"
+	fi
+	rm -rf "$_TD"
+
+	# ── Scenario D: actually-drifted caller → DRIFTED/CALLER (true positive) ──
+	_TD="$(mktemp -d)"
+	_setup_fake_home "$_TD"
+	mkdir -p "$_TD/repos/repo-d/.github/workflows"
+	{
+		cat "$_src_template"
+		printf '\n# Local drift — should NOT be masked by runner normalisation\n'
+	} > "$_TD/repos/repo-d/.github/workflows/${_wf_file}"
+	_write_repos_json "$_TD" \
+		"$(jq -n --arg p "$_TD/repos/repo-d" \
+			'{initialized_repos: [{slug: "x/d", path: $p, local_only: false}]}')"
+	_result=$(_classify_for_workflow "$_TD" "x/d" "$_wf_name")
+	if [[ "$_result" == "DRIFTED/CALLER" ]]; then
+		_pass "${_wf_name}: drifted caller → DRIFTED/CALLER (true positive preserved)"
+	else
+		_fail "${_wf_name}: drifted caller → DRIFTED/CALLER (true positive preserved)" \
+			"got: ${_result:-<empty>} — runner normalisation may have swallowed real drift"
+	fi
+	rm -rf "$_TD"
+
+	# ── Scenario E: runner + develop-branch compose → CURRENT/CALLER ──────────
+	# Only issue-sync has a `branches:` filter in the template.
+	if grep -qE '^    branches:' "$_src_template" 2>/dev/null; then
+		_TD="$(mktemp -d)"
+		_setup_fake_home "$_TD"
+		mkdir -p "$_TD/repos/repo-e/.github/workflows"
+		_dest_e="$_TD/repos/repo-e/.github/workflows/${_wf_file}"
+		# First inject runner, then rewrite branch to develop.
+		if grep -qE '^    with:$' "$_src_template" 2>/dev/null; then
+			_add_runner_to_with_block "$_src_template" "$_dest_e" "$_RUNNER_LABEL"
+		else
+			_add_standalone_runner_block "$_src_template" "$_dest_e" "$_RUNNER_LABEL"
+		fi
+		sed -i '' 's/branches: \[main\]/branches: [develop]/' "$_dest_e"
+		_write_repos_json "$_TD" \
+			"$(jq -n --arg p "$_TD/repos/repo-e" \
+				'{initialized_repos: [{slug: "x/e", path: $p, local_only: false}]}')"
+		_result=$(_classify_for_workflow "$_TD" "x/e" "$_wf_name")
+		if [[ "$_result" == "CURRENT/CALLER" ]]; then
+			_pass "${_wf_name}: runner + develop-branch → CURRENT/CALLER (composed normalisation)"
+		else
+			_fail "${_wf_name}: runner + develop-branch → CURRENT/CALLER (composed normalisation)" \
+				"got: ${_result:-<empty>}"
+		fi
+		rm -rf "$_TD"
+	fi
+
+done
+
+# ─── Summary ─────────────────────────────────────────────────────────────────
+
+echo
+if (( TESTS_FAILED == 0 )); then
+	printf '%bAll %d test(s) passed%b\n' "$_T_GREEN" "$TESTS_RUN" "$_T_RESET"
+	exit 0
+else
+	printf '%b%d of %d test(s) failed%b\n' "$_T_RED" "$TESTS_FAILED" "$TESTS_RUN" "$_T_RESET"
+	exit 1
+fi

--- a/.github/workflows/issue-sync-reusable.yml
+++ b/.github/workflows/issue-sync-reusable.yml
@@ -22,6 +22,11 @@ on:
         required: false
         type: string
         default: 'main'
+      runner:
+        description: 'Runner label override (e.g. ubicloud-standard-2). Defaults to ubuntu-latest.'
+        required: false
+        default: 'ubuntu-latest'
+        type: string
     secrets:
       SYNC_PAT:
         required: false
@@ -31,7 +36,7 @@ jobs:
   sync-on-push:
     name: Sync TODO.md → GitHub Issues
     if: github.event_name == 'push'
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     # t2165: bumped 10 → 20 as an independent safety net alongside the
     # issue-sync-helper.sh enrich optimisation. At ~145 open ref:GH# tasks the
     # pre-t2165 helper needed ~18 min and the 10-min cap cancelled the
@@ -182,7 +187,7 @@ jobs:
   sync-on-issue:
     name: Sync GitHub Issue → TODO.md
     if: github.event_name == 'issues'
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 5
     concurrency:
       group: issue-sync-issue-${{ github.event.issue.number }}
@@ -305,7 +310,7 @@ jobs:
   dedup-on-issue-open:
     name: Server-Side Issue Dedup
     if: github.event_name == 'issues' && github.event.action == 'opened'
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 3
     concurrency:
       group: issue-dedup-${{ github.event.issue.number }}
@@ -429,7 +434,7 @@ jobs:
   manual-sync:
     name: Manual Sync
     if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 10
     concurrency:
       group: issue-sync-manual
@@ -520,7 +525,7 @@ jobs:
   sync-on-pr-merge:
     name: Sync Issue Hygiene on PR Merge
     if: (github.event_name == 'pull_request_target' || github.event_name == 'pull_request') && github.event.pull_request.merged == true
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 5
     concurrency:
       group: issue-sync-pr-${{ github.event.pull_request.number }}
@@ -1275,7 +1280,7 @@ jobs:
       (github.event_name == 'pull_request_target' || github.event_name == 'pull_request') &&
       github.event.pull_request.merged != true &&
       (github.event.action == 'opened' || github.event.action == 'edited')
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 2
     permissions:
       contents: read
@@ -1345,7 +1350,7 @@ jobs:
       (github.event_name == 'pull_request_target' || github.event_name == 'pull_request') &&
       github.event.pull_request.merged != true &&
       (github.event.action == 'opened' || github.event.action == 'edited')
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 2
     permissions:
       contents: read
@@ -1413,7 +1418,7 @@ jobs:
     if: >-
       github.event_name == 'issues' &&
       github.event.action == 'closed'
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 2
     permissions:
       issues: write
@@ -1441,7 +1446,7 @@ jobs:
     if: >-
       github.event_name == 'issues' &&
       github.event.action == 'closed'
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 2
     permissions:
       issues: write

--- a/.github/workflows/loc-badge-reusable.yml
+++ b/.github/workflows/loc-badge-reusable.yml
@@ -40,6 +40,11 @@ on:
         required: false
         type: string
         default: 'chore(badges): refresh LOC badges [skip ci]'
+      runner:
+        description: 'Runner label override (e.g. ubicloud-standard-2). Defaults to ubuntu-latest.'
+        required: false
+        default: 'ubuntu-latest'
+        type: string
     secrets:
       SYNC_PAT:
         required: false
@@ -48,7 +53,7 @@ on:
 jobs:
   generate:
     name: Generate LOC badges
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 5
     concurrency:
       group: loc-badge-${{ github.ref }}

--- a/.github/workflows/maintainer-gate-reusable.yml
+++ b/.github/workflows/maintainer-gate-reusable.yml
@@ -50,6 +50,11 @@ on:
         required: false
         type: string
         default: 'main'
+      runner:
+        description: 'Runner label override (e.g. ubicloud-standard-2). Defaults to ubuntu-latest.'
+        required: false
+        default: 'ubuntu-latest'
+        type: string
 
 jobs:
   # =========================================================================
@@ -60,7 +65,7 @@ jobs:
     name: Maintainer Review & Assignee Gate
     if: >-
       github.event_name == 'pull_request_target'
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 3
     concurrency:
       group: maintainer-gate-${{ github.event.pull_request.number }}
@@ -474,7 +479,7 @@ jobs:
       github.event_name == 'issues' &&
       github.event.action == 'unlabeled' &&
       github.event.label.name == 'needs-maintainer-review'
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 2
     permissions:
       issues: write
@@ -543,7 +548,7 @@ jobs:
     if: >-
       github.event_name == 'issues' &&
       (github.event.action == 'labeled' || github.event.action == 'unlabeled' || github.event.action == 'assigned' || github.event.action == 'unassigned')
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 3
     permissions:
       pull-requests: read
@@ -739,7 +744,7 @@ jobs:
       github.event_name == 'pull_request_target' &&
       github.event.action == 'unlabeled' &&
       github.event.label.name == 'needs-maintainer-review'
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 2
     permissions:
       pull-requests: write
@@ -818,7 +823,7 @@ jobs:
       github.event_name == 'issues' &&
       (github.event.action == 'labeled' || github.event.action == 'unlabeled') &&
       github.event.label.name == 'origin:worker'
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     timeout-minutes: 2
     permissions:
       issues: write

--- a/.github/workflows/review-bot-gate-reusable.yml
+++ b/.github/workflows/review-bot-gate-reusable.yml
@@ -33,10 +33,15 @@ on:
         required: false
         type: string
         default: 'main'
+      runner:
+        description: 'Runner label override (e.g. ubicloud-standard-2). Defaults to ubuntu-latest.'
+        required: false
+        default: 'ubuntu-latest'
+        type: string
 
 jobs:
   review-bot-gate:
-    runs-on: ubuntu-latest
+    runs-on: ${{ inputs.runner }}
     # Only run on PRs (issue_comment fires for PR comments too).
     # GH#4002: Skip pull_request_review events from known review bots.
     # GitHub requires manual approval for workflow runs triggered by bot


### PR DESCRIPTION
## Summary

Adds a configurable `runner` input to all four managed reusable workflows so downstream consumers can redirect managed CI jobs to alternative runners (Ubicloud, self-hosted, Namespace) without losing the benefit of `aidevops sync-workflows` — the override survives resync without triggering false `DRIFTED/CALLER` drift detection.

### Changes

- **4 reusable workflows** (`issue-sync-reusable.yml`, `maintainer-gate-reusable.yml`, `review-bot-gate-reusable.yml`, `loc-badge-reusable.yml`): add `runner` input (default: `ubuntu-latest`), replace 16 hardcoded `runs-on: ubuntu-latest` with `runs-on: ${{ inputs.runner }}`
- **`sync-workflows-helper.sh`**: add `_read_runner_field` + `_inject_runner_in_content` helpers; inject `with: runner: <label>` in rendered caller when `repos.json` carries a `runner` field; add `loc-badge.yml` to `_SYNC_KNOWN_WORKFLOWS`
- **`check-workflows-helper.sh`**: extend `_normalize_wf_for_compare` to strip injected `runner:` lines and empty `with:` block headers, preventing false `DRIFTED/CALLER` classification; add `loc-badge.yml` to `_KNOWN_WORKFLOWS`
- **Docs**: document `runner` field in `repos-json-fields.md`; add "Runner override" subsection to `reusable-workflows.md` with usage example, self-hosted group label guidance, and `maintainer-gate` security caveat
- **Regression test**: `test-check-workflows-runner-normalise.sh` — 14 scenarios covering canonical caller, runner-injected caller, true-positive drift, and composed runner+branch normalisations across all 4 workflow types

### Verification

```text
# AC1: 0 hardcoded runs-on remaining in reusable workflows → PASS
# AC2: all 4 workflows have runner input → PASS
# AC7: ShellCheck clean on sync-workflows-helper.sh + check-workflows-helper.sh → PASS
# AC8: bash .agents/scripts/tests/test-check-workflows-runner-normalise.sh → All 14 test(s) passed
```

Resolves #21877

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.11 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-sonnet-4-6 spent 25m and 36,444 tokens on this as a headless worker.
