### PR TITLE
t3090: Fix 4 pre-existing failures in test-pulse-wrapper-worker-count.sh

### DIFF
--- a/.agents/scripts/tests/test-pulse-wrapper-worker-count.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-worker-count.sh
@@ -44,6 +44,22 @@ setup_test_env() {
 	mkdir -p "${HOME}/.aidevops/logs"
 	# shellcheck source=/dev/null
 	source "$WRAPPER_SCRIPT"
+
+	# Override the gh wrapper functions that pulse-capacity.sh and
+	# pulse-repo-meta.sh call.  The bare gh() mock defined above is
+	# unreachable for these code paths because _gh_with_timeout uses
+	# the external `timeout` command which spawns `gh` as a subprocess,
+	# bypassing shell-function lookup.  Mocking at the wrapper level
+	# is the correct abstraction.
+	gh_issue_list() {
+		printf '%s\n' "$GH_ISSUE_LIST_JSON"
+		return 0
+	}
+	gh_pr_list() {
+		printf '%s\n' "$GH_PR_LIST_JSON"
+		return 0
+	}
+
 	return 0
 }
 
@@ -258,7 +274,9 @@ test_list_dispatchable_candidates_default_open_except_needs_labels() {
 	local output
 	output=$(list_dispatchable_issue_candidates "owner/repo" 100)
 
-	if [[ "$output" == *$'1|unassigned'* && "$output" == *$'2|owner assigned'* && "$output" == *$'3|maintainer assigned'* && "$output" == *$'4|runner assigned'* && "$output" == *$'5|owner queued'* && "$output" == *$'9|in progress but runnable'* && "$output" != *$'6|needs review'* && "$output" != *$'7|needs docs'* && "$output" != *$'8|supervisor telemetry'* ]]; then
+	# t2924: status:in-progress is now filtered at candidate-build time,
+	# so issue #9 must NOT appear alongside needs-*/supervisor issues.
+	if [[ "$output" == *$'1|unassigned'* && "$output" == *$'2|owner assigned'* && "$output" == *$'3|maintainer assigned'* && "$output" == *$'4|runner assigned'* && "$output" == *$'5|owner queued'* && "$output" != *$'6|needs review'* && "$output" != *$'7|needs docs'* && "$output" != *$'8|supervisor telemetry'* && "$output" != *$'9|in progress but runnable'* ]]; then
 		print_result "list_dispatchable_issue_candidates is default-open except needs-*" 0
 		return 0
 	fi

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -364,6 +364,12 @@ jobs:
         bash .agents/scripts/tests/test-pulse-wrapper-canary.sh
         echo "Pulse wrapper canary test passed"
 
+    - name: Pulse Worker Count Tests (GH#21873)
+      run: |
+        echo "Running pulse worker count / capacity tests..."
+        bash .agents/scripts/tests/test-pulse-wrapper-worker-count.sh
+        echo "Pulse worker count tests passed"
+
     - name: Approve Collaborator Author Guard (GH#17671, t2933)
       run: |
         # Pins the function-level supply-chain defense in approve_collaborator_pr.


### PR DESCRIPTION
## Summary

- Fixed 4 pre-existing test failures in test-pulse-wrapper-worker-count.sh
- Root cause: gh_issue_list/gh_pr_list wrappers use _gh_with_timeout which spawns gh via the external timeout command, bypassing the test gh() shell function mock entirely
- Fix: override gh_issue_list and gh_pr_list directly in setup_test_env() after sourcing pulse-wrapper.sh
- Also fixed stale assertion: issue #9 (status:in-progress) was expected in candidates but t2924 correctly filters it at candidate-build time
- Added test to code-quality.yml CI so regressions are caught on every PR

## Testing

- All 22 tests pass: bash .agents/scripts/tests/test-pulse-wrapper-worker-count.sh (0 failed)
- ShellCheck clean
- Pre-commit hooks pass

Resolves #21873


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.12 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-opus-4-6 spent 10m and 19,487 tokens on this as a headless worker.