### PR TITLE
GH#21880: fix invalid Anthropic model IDs in ai-research-helper.sh

### DIFF
--- a/.agents/scripts/ai-research-helper.sh
+++ b/.agents/scripts/ai-research-helper.sh
@@ -33,10 +33,10 @@ LOG_PREFIX="AI-RESEARCH"
 resolve_model_id() {
 	local name="${1:-haiku}"
 	case "$name" in
-	haiku) echo "claude-haiku-4-20250414" ;;
-	sonnet) echo "claude-sonnet-4-20250514" ;;
-	opus) echo "claude-opus-4-20250514" ;;
-	*) echo "claude-haiku-4-20250414" ;; # default to haiku
+	haiku) echo "claude-haiku-4-5-20251001" ;;
+	sonnet) echo "claude-sonnet-4-6" ;;
+	opus) echo "claude-opus-4-6" ;;
+	*) echo "claude-haiku-4-5-20251001" ;; # default to haiku
 	esac
 	return 0
 }


### PR DESCRIPTION
Resolves #21880

## Summary
Fixed the `_resolve_model` function in ai-research-helper.sh to use valid Anthropic API model names instead of non-existent model IDs.

## Changes
- haiku: `claude-haiku-4-20250414` → `claude-haiku-4-5-20251001`
- sonnet: `claude-sonnet-4-20250514` → `claude-sonnet-4-6`
- opus: `claude-opus-4-20250514` → `claude-opus-4-6`

## Verification
Model IDs verified against canonical tier mappings in `.agents/tools/ai-assistants/models-README.md` (lines 19-24).


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.12 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-haiku-4-5 spent 1m and 1,115 tokens on this as a headless worker.