### PR TITLE
GH#21870: fix(pulse): parent-side lifecycle observer emits worker_exited for detached workers

### DIFF
--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -16,6 +16,8 @@
 #   - _dlw_precreate_worktree
 #   - _dlw_prewarm_opencode_db
 #   - _dlw_exec_detached
+#   - _dlw_spawn_early_exit_monitor
+#   - _dlw_spawn_lifecycle_observer (t3055/GH#21870)
 #   - _dlw_nohup_launch
 #   - _dlw_post_launch_hooks
 #   - _dispatch_launch_worker
@@ -452,6 +454,16 @@ _dlw_exec_detached() {
 	# appends a marker; no global state.
 	_dlw_spawn_early_exit_monitor "$worker_pid" "$worker_log" "$issue_number"
 
+	# t3055/GH#21870: Spawn the parent-side lifecycle observer that polls the
+	# detached worker PID until it terminates and emits a
+	# `[lifecycle] worker_exited pid=N wait_status=M` line to the pulse log.
+	# This is independent of the worker's own emit path (which lives in
+	# headless-runtime-helper.sh::_invoke_opencode and only fires on
+	# graceful, post-`wait` exits). The observer is the safety net for
+	# every other termination mode (early exec failure, SIGKILL/OOM,
+	# setsid-detached vanishing, watchdog kill before child trap installs).
+	_dlw_spawn_lifecycle_observer "$worker_pid" "$issue_number" "$LOGFILE"
+
 	printf '%s\n' "$worker_pid"
 	return 0
 }
@@ -528,6 +540,107 @@ _dlw_spawn_early_exit_monitor() {
 	fi
 	# Disown so any pulse parent shell EXIT trap that targets backgrounded
 	# jobs cannot reach the monitor. setsid already detaches the PGID.
+	disown 2>/dev/null || true
+	return 0
+}
+
+# t3055 / GH#21870: Parent-side lifecycle observer for detached workers.
+#
+# Bug background: `_dlw_exec_detached` launches the worker via
+# `setsid nohup ... &`, captures the PID, and the calling pulse process
+# returns long before the worker terminates. The worker's OWN exit-line
+# emit lives in `headless-runtime-helper.sh::_invoke_opencode` after the
+# `wait "$worker_pid"` call, but only fires when the worker's wrapper
+# script reaches that point. Workers that die earlier — exec failure,
+# SIGKILL/OOM, immediate setsid death, watchdog kill before the
+# wrapper's trap is installed — vanish without a `worker_exited` line,
+# breaking post-mortem (canonical: PID 88900 on 2026-04-29 ~18:37Z).
+#
+# Fix: spawn a tiny detached watcher (mirrors _dlw_spawn_early_exit_monitor)
+# that polls the worker PID and, the moment `kill -0` returns false,
+# appends a `[lifecycle] worker_exited pid=N wait_status=M` line to the
+# pulse log. The observer is the SAFETY NET — if the worker also emits
+# its own line (the happy path), pulse.log will carry both, but `gap` in
+# the empirical baseline check stays near zero either way.
+#
+# Why polling and not `wait`: the observer is forked from a setsid'd
+# pulse subshell that exits immediately; it has no parent-child
+# reaping relationship with the worker (different PGID). `wait` would
+# return -1/ECHILD instantly. `kill -0` only checks process existence.
+#
+# Why no precise wait_status: a non-parent process cannot reap exit
+# codes via `waitpid`. We emit `wait_status=unknown` on observer-side
+# detection. The worker's own emit (when reached) carries the real
+# status. The signal — that the worker died — is the value here.
+#
+# Bounded lifetime: the observer self-terminates after
+# DLW_LIFECYCLE_OBSERVER_MAX_SECONDS (default 6h, matches
+# HEADLESS_SANDBOX_TIMEOUT ceiling) so it cannot leak forever if the
+# PID becomes irreapable.
+#
+# Args:
+#   $1 - worker_pid (PID returned by setsid/nohup launch)
+#   $2 - issue_number (for log message context)
+#   $3 - logfile (absolute path; line is appended here — typically pulse.log)
+# Returns: 0 always.
+_dlw_spawn_lifecycle_observer() {
+	local worker_pid="$1"
+	local issue_number="$2"
+	local logfile="$3"
+	local max_seconds="${DLW_LIFECYCLE_OBSERVER_MAX_SECONDS:-21600}"
+	local poll_interval="${DLW_LIFECYCLE_OBSERVER_POLL_SECONDS:-5}"
+
+	# Defensive: skip if PID is not numeric (caller bug or test fixture)
+	if [[ ! "$worker_pid" =~ ^[0-9]+$ ]]; then
+		return 0
+	fi
+	if [[ -z "$logfile" ]]; then
+		return 0
+	fi
+
+	# Inner body runs in a detached subshell and outlives the pulse cycle.
+	# Positional args: pid, issue, log, max_seconds, interval.
+	local observer_script
+	# SC2016: variable expansion is intentional inside the inner `bash -c`
+	# body, not in the outer shell. Mirrors the pattern used in
+	# _dlw_spawn_early_exit_monitor above.
+	# shellcheck disable=SC2016
+	observer_script='
+		_dlw_observer_body() {
+			local pid="$1" issue="$2" log="$3" max_s="$4" interval="$5"
+			local elapsed=0 ts="" reason="observed"
+			while [[ "$elapsed" -lt "$max_s" ]]; do
+				if ! kill -0 "$pid" 2>/dev/null; then
+					ts=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "?")
+					printf "[INFO] [lifecycle] worker_exited pid=%s wait_status=unknown kill_reason=%s observer=parent issue=%s ts=%s\n" \
+						"$pid" "$reason" "$issue" "$ts" >>"$log" 2>/dev/null || true
+					return 0
+				fi
+				sleep "$interval"
+				elapsed=$((elapsed + interval))
+			done
+			# Hit the max-lifetime ceiling without observing termination —
+			# emit a diagnostic so the gap surfaces in audit, but do not
+			# block. The watchdog and pulse-cleanup paths catch true zombies.
+			ts=$(date -u +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || echo "?")
+			printf "[WARN] [lifecycle] worker_observer_timeout pid=%s elapsed=%ss issue=%s ts=%s\n" \
+				"$pid" "$elapsed" "$issue" "$ts" >>"$log" 2>/dev/null || true
+			return 0
+		}
+		_dlw_observer_body "$@"
+	'
+
+	if command -v setsid >/dev/null 2>&1; then
+		setsid nohup bash -c "$observer_script" _dlw_observer \
+			"$worker_pid" "$issue_number" "$logfile" \
+			"$max_seconds" "$poll_interval" \
+			</dev/null >/dev/null 2>&1 3>&- 4>&- 5>&- 6>&- 7>&- 8>&- 9>&- &
+	else
+		nohup bash -c "$observer_script" _dlw_observer \
+			"$worker_pid" "$issue_number" "$logfile" \
+			"$max_seconds" "$poll_interval" \
+			</dev/null >/dev/null 2>&1 3>&- 4>&- 5>&- 6>&- 7>&- 8>&- 9>&- &
+	fi
 	disown 2>/dev/null || true
 	return 0
 }

--- a/.agents/scripts/tests/test-worker-lifecycle-exit-emit.sh
+++ b/.agents/scripts/tests/test-worker-lifecycle-exit-emit.sh
@@ -1,0 +1,216 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# =============================================================================
+# test-worker-lifecycle-exit-emit.sh — Regression test for t3055 / GH#21870
+# =============================================================================
+# Validates that `_dlw_spawn_lifecycle_observer` (in pulse-dispatch-worker-launch.sh)
+# emits a `[lifecycle] worker_exited pid=N wait_status=...` line to the
+# pulse log within a bounded window after the worker PID terminates —
+# regardless of how the worker exits (normal, signal, immediate, vanish).
+#
+# Acceptance criteria from the issue:
+#   - Every worker PID dispatched by dispatch_worker_launch has a
+#     corresponding `worker_exited pid=N` line in pulse.log within 60s of
+#     worker termination, independent of the worker's own emit path.
+#
+# What this test does:
+#   1. Source pulse-dispatch-worker-launch.sh and stub out the heavy
+#      dependencies that aren't relevant to the observer.
+#   2. Launch a synthetic detached worker that immediately `exit 7`.
+#   3. Call `_dlw_spawn_lifecycle_observer` against that PID with a
+#      tight poll interval and short max-lifetime.
+#   4. Wait up to 30s for the line to appear in the test logfile.
+#   5. Assert the line shape carries pid=<numeric> and the kill_reason
+#      sentinel `observer=parent`.
+#
+# Independence: this test does NOT spawn an LLM session, hit network,
+# or exercise dispatch_with_dedup. It isolates the observer mechanic.
+#
+# Usage: bash tests/test-worker-lifecycle-exit-emit.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AGENTS_SCRIPTS="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+TMPDIR_TEST=""
+
+print_result() {
+	local test_name="$1"
+	local status="$2"
+	local message="${3:-}"
+
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$status" -eq 0 ]]; then
+		printf 'PASS %s\n' "$test_name"
+		TESTS_PASSED=$((TESTS_PASSED + 1))
+	else
+		printf 'FAIL %s\n' "$test_name"
+		[[ -n "$message" ]] && printf '  %s\n' "$message"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+setup() {
+	TMPDIR_TEST=$(mktemp -d)
+	# We only need _dlw_spawn_lifecycle_observer; source the file selectively
+	# by extracting the function. Sourcing the whole file pulls in the load
+	# guard and all the helpers — which is fine for our purposes since
+	# observer is a leaf helper with no internal dependencies on the rest.
+	# We DO need to sidestep the load guard so multiple test invocations
+	# in the same process don't see stale state.
+	unset _PULSE_DISPATCH_WORKER_LAUNCH_LOADED 2>/dev/null || true
+	# shellcheck source=../pulse-dispatch-worker-launch.sh
+	# shellcheck disable=SC1091
+	source "${AGENTS_SCRIPTS}/pulse-dispatch-worker-launch.sh"
+	return 0
+}
+
+teardown() {
+	[[ -n "$TMPDIR_TEST" && -d "$TMPDIR_TEST" ]] && rm -rf "$TMPDIR_TEST" || true
+	return 0
+}
+
+# Wait up to $1 seconds for $2 (regex) to appear in $3 (file).
+# Returns 0 on match, 1 on timeout.
+_wait_for_line() {
+	local timeout_s="$1"
+	local pattern="$2"
+	local file="$3"
+	local elapsed=0
+	while [[ "$elapsed" -lt "$timeout_s" ]]; do
+		if [[ -f "$file" ]] && grep -qE "$pattern" "$file" 2>/dev/null; then
+			return 0
+		fi
+		sleep 1
+		elapsed=$((elapsed + 1))
+	done
+	return 1
+}
+
+# ---------------------------------------------------------------------------
+# Tests
+
+test_observer_emits_on_immediate_exit() {
+	local logfile="${TMPDIR_TEST}/pulse-immediate.log"
+	: >"$logfile"
+
+	# Synthetic worker: launch a subshell that exits immediately with 7.
+	# Use setsid so it mirrors the real detach behaviour. Capture the PID.
+	local synth_pid
+	if command -v setsid >/dev/null 2>&1; then
+		setsid bash -c 'exit 7' </dev/null >/dev/null 2>&1 &
+	else
+		bash -c 'exit 7' </dev/null >/dev/null 2>&1 &
+	fi
+	synth_pid="$!"
+
+	# Spawn the observer with a tight poll interval. Use the public env
+	# vars so the observer's internal subshell sees them.
+	export DLW_LIFECYCLE_OBSERVER_POLL_SECONDS=1
+	export DLW_LIFECYCLE_OBSERVER_MAX_SECONDS=30
+
+	_dlw_spawn_lifecycle_observer "$synth_pid" "99999" "$logfile"
+
+	# Wait up to 30s for the line to appear.
+	if _wait_for_line 30 "\\[lifecycle\\] worker_exited pid=${synth_pid}" "$logfile"; then
+		print_result "observer emits worker_exited line for immediate-exit worker" 0
+	else
+		print_result "observer emits worker_exited line for immediate-exit worker" 1 \
+			"no matching line in ${logfile} after 30s; tail:
+$(tail -20 "$logfile" 2>/dev/null || echo '(empty)')"
+	fi
+	return 0
+}
+
+test_observer_line_carries_observer_marker() {
+	# Same scenario; assert the kill_reason marker so consumers can
+	# distinguish parent-side observer emits from the worker's own emit.
+	local logfile="${TMPDIR_TEST}/pulse-marker.log"
+	: >"$logfile"
+
+	local synth_pid
+	if command -v setsid >/dev/null 2>&1; then
+		setsid bash -c 'exit 0' </dev/null >/dev/null 2>&1 &
+	else
+		bash -c 'exit 0' </dev/null >/dev/null 2>&1 &
+	fi
+	synth_pid="$!"
+
+	export DLW_LIFECYCLE_OBSERVER_POLL_SECONDS=1
+	export DLW_LIFECYCLE_OBSERVER_MAX_SECONDS=30
+
+	_dlw_spawn_lifecycle_observer "$synth_pid" "12345" "$logfile"
+
+	if _wait_for_line 30 "worker_exited pid=${synth_pid}.*observer=parent.*issue=12345" "$logfile"; then
+		print_result "observer line carries observer=parent marker and issue field" 0
+	else
+		print_result "observer line carries observer=parent marker and issue field" 1 \
+			"line shape mismatch in ${logfile}; tail:
+$(tail -20 "$logfile" 2>/dev/null || echo '(empty)')"
+	fi
+	return 0
+}
+
+test_observer_skips_invalid_pid() {
+	# Defensive: caller bug or test fixture passes a non-numeric PID.
+	# Observer must early-return without writing to the log.
+	local logfile="${TMPDIR_TEST}/pulse-invalid.log"
+	: >"$logfile"
+
+	_dlw_spawn_lifecycle_observer "not-a-pid" "1" "$logfile"
+	# Give any rogue subshell a moment to misbehave.
+	sleep 2
+
+	if [[ ! -s "$logfile" ]]; then
+		print_result "observer skips non-numeric PID without writing" 0
+	else
+		print_result "observer skips non-numeric PID without writing" 1 \
+			"unexpected log content:
+$(cat "$logfile")"
+	fi
+	return 0
+}
+
+test_observer_skips_empty_logfile_arg() {
+	# Defensive: missing logfile path. Observer must early-return.
+	# We cannot easily assert "nothing was written" because there is no
+	# logfile to inspect — but we CAN assert the call returns 0 cleanly
+	# without throwing.
+	local rc=0
+	_dlw_spawn_lifecycle_observer "12345" "1" "" || rc=$?
+	if [[ "$rc" -eq 0 ]]; then
+		print_result "observer skips empty logfile arg cleanly" 0
+	else
+		print_result "observer skips empty logfile arg cleanly" 1 \
+			"non-zero return: $rc"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Main
+
+main() {
+	setup
+	trap teardown EXIT
+
+	test_observer_emits_on_immediate_exit
+	test_observer_line_carries_observer_marker
+	test_observer_skips_invalid_pid
+	test_observer_skips_empty_logfile_arg
+
+	echo
+	echo "Tests run: ${TESTS_RUN}, passed: ${TESTS_PASSED}, failed: ${TESTS_FAILED}"
+	if [[ "$TESTS_FAILED" -ne 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Adds _dlw_spawn_lifecycle_observer in pulse-dispatch-worker-launch.sh — a detached background watcher that polls the worker PID and appends a [lifecycle] worker_exited line to pulse.log on termination. Closes the gap where setsid-detached workers (FDs 3-9 closed) could die without leaving an exit signal in pulse.log (canonical: PID 88900 on 2026-04-29). The observer emits 'observer=parent' kill_reason so consumers can distinguish parent-side emits from the worker's own emit. Bounded by DLW_LIFECYCLE_OBSERVER_MAX_SECONDS (default 6h) so it cannot leak. _dlw_exec_detached stays at 66 lines (under the 80-line warning threshold) — new logic factored into its own helper as the brief required.

## Files Changed

.agents/scripts/pulse-dispatch-worker-launch.sh,.agents/scripts/tests/test-worker-lifecycle-exit-emit.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** New regression test test-worker-lifecycle-exit-emit.sh — 4 cases: immediate-exit emits line, line carries observer=parent + issue marker, non-numeric PID skipped, empty logfile arg skipped. shellcheck clean on all 5 touched files. Adjacent tests test-worker-launch-setsid.sh (3/3) and test-worker-exited-kill-reason.sh (18/18) still pass.

Resolves #21870


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.12 plugin for [OpenCode](https://opencode.ai) v1.14.29 with claude-opus-4-7 spent 4m and 15,988 tokens on this as a headless worker.