### PR TITLE
GH#21880: fix invalid model IDs and orphan-detection false positive

### DIFF
--- a/.agents/scripts/ai-research-helper.sh
+++ b/.agents/scripts/ai-research-helper.sh
@@ -32,11 +32,18 @@ LOG_PREFIX="AI-RESEARCH"
 #######################################
 resolve_model_id() {
 	local name="${1:-haiku}"
+	# Model IDs MUST match the canonical registry at .agents/configs/model-routing-table.json.
+	# The previous values (claude-haiku-4-20250414 et al.) were hallucinated and 404'd
+	# every API call, returning HTTP 404 from Anthropic for ALL three tiers — the
+	# silent root cause behind 100% LLM-call failure in fix-the-fixer-detector
+	# (Issue #21880). Verify against:
+	#   .agents/configs/model-routing-table.json
+	#   .agents/tools/ai-assistants/models-README.md
 	case "$name" in
-	haiku) echo "claude-haiku-4-20250414" ;;
-	sonnet) echo "claude-sonnet-4-20250514" ;;
-	opus) echo "claude-opus-4-20250514" ;;
-	*) echo "claude-haiku-4-20250414" ;; # default to haiku
+	haiku) echo "claude-haiku-4-5-20251001" ;;
+	sonnet) echo "claude-sonnet-4-6" ;;
+	opus) echo "claude-opus-4-6" ;;
+	*) echo "claude-haiku-4-5-20251001" ;; # default to haiku
 	esac
 	return 0
 }

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -1406,20 +1406,74 @@ _worker_produced_output() {
 
 	# Signal 3: PR linked to this issue (requires gh and DISPATCH_REPO_SLUG)
 	# Only reachable when Signal 1 or 2 is present — disambiguates pr_exists vs branch_orphan.
+	#
+	# Two probes, both with EXPLICIT exit-code capture (Issue #21880):
+	#   a) `gh pr list --head <branch>` — direct DB lookup by head ref. No search-
+	#      index latency, deterministic. Only runs when branch_name is known and
+	#      is not the repo default branch.
+	#   b) `gh pr list --search "<issue>"` — fallback for cases where the worker
+	#      pushed under a different branch name than the one we observe locally,
+	#      or where probe (a) was skipped.
+	#
+	# `--state all` ensures a PR that was created and then closed/merged still
+	# counts as "PR exists" — the worker did its job; closure is a separate concern.
+	#
+	# CRITICAL — fail-open semantics: distinguish gh-success-with-zero-results
+	# (confirmed absence → branch_orphan) from gh-call-failure (auth, network,
+	# rate-limit, transient 5xx → fail-open as pr_exists). The previous
+	# implementation collapsed `2>/dev/null || true` into pr_count=0, which
+	# misclassified every gh failure as branch_orphan. That false-positive
+	# triggered Issue #21880: PR #21883 was correctly created at 05:35Z but the
+	# orphan classifier ran 5 minutes later, observed a transient gh failure,
+	# returned pr_count=0, and posted a noisy WORKER_BRANCH_ORPHAN escalation
+	# against an issue that already had a green PR awaiting merge.
 	local issue_number=""
 	issue_number=$(printf '%s' "$session_key" | grep -oE '[0-9]+$' || true)
 	local repo_slug="${DISPATCH_REPO_SLUG:-}"
 	if [[ -n "$issue_number" && -n "$repo_slug" ]]; then
-		local pr_count=0
-		pr_count=$(gh pr list --repo "$repo_slug" --search "$issue_number" \
-			--json number --jq 'length' 2>/dev/null || true)
-		[[ "$pr_count" =~ ^[0-9]+$ ]] || pr_count=0
-		if [[ "$pr_count" -gt 0 ]]; then
+		local pr_found=0
+		local any_check_succeeded=0
+		local pr_count=""
+
+		# Probe A: head-ref lookup (preferred — no search-index dependency)
+		if [[ -n "$branch_name" && "$branch_name" != "HEAD" \
+				&& "$branch_name" != "$default_branch" ]]; then
+			if pr_count=$(gh pr list --repo "$repo_slug" --head "$branch_name" \
+					--state all --json number --jq 'length' 2>/dev/null); then
+				any_check_succeeded=1
+				if [[ "$pr_count" =~ ^[0-9]+$ ]] && [[ "$pr_count" -gt 0 ]]; then
+					pr_found=1
+				fi
+			fi
+		fi
+
+		# Probe B: search-by-issue-number fallback
+		if [[ "$pr_found" -eq 0 ]]; then
+			if pr_count=$(gh pr list --repo "$repo_slug" --search "$issue_number" \
+					--state all --json number --jq 'length' 2>/dev/null); then
+				any_check_succeeded=1
+				if [[ "$pr_count" =~ ^[0-9]+$ ]] && [[ "$pr_count" -gt 0 ]]; then
+					pr_found=1
+				fi
+			fi
+		fi
+
+		if [[ "$pr_found" -eq 1 ]]; then
 			printf 'pr_exists'
 			return 0
 		fi
-		# PR confirmed absent: branch/commits exist but no PR → orphan (GH#20819)
-		printf 'branch_orphan'
+
+		# At least one probe completed cleanly with 0 results → confirmed
+		# orphan (GH#20819): branch/commits exist but no PR was opened.
+		if [[ "$any_check_succeeded" -eq 1 ]]; then
+			printf 'branch_orphan'
+			return 0
+		fi
+
+		# All probes failed (auth, network, rate-limit, 5xx) — fail-open per
+		# docstring. Misclassifying as branch_orphan here is exactly the
+		# false-positive that triggered Issue #21880.
+		printf 'pr_exists'
 		return 0
 	fi
 

--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -445,20 +445,74 @@ _worker_produced_output() {
 
 	# Signal 3: PR linked to this issue (requires gh and DISPATCH_REPO_SLUG)
 	# Only reachable when Signal 1 or 2 is present — disambiguates pr_exists vs branch_orphan.
+	#
+	# Two probes, both with EXPLICIT exit-code capture (Issue #21880):
+	#   a) `gh pr list --head <branch>` — direct DB lookup by head ref. No search-
+	#      index latency, deterministic. Only runs when branch_name is known and
+	#      is not the repo default branch.
+	#   b) `gh pr list --search "<issue>"` — fallback for cases where the worker
+	#      pushed under a different branch name than the one we observe locally,
+	#      or where probe (a) was skipped.
+	#
+	# `--state all` ensures a PR that was created and then closed/merged still
+	# counts as "PR exists" — the worker did its job; closure is a separate concern.
+	#
+	# CRITICAL — fail-open semantics: distinguish gh-success-with-zero-results
+	# (confirmed absence → branch_orphan) from gh-call-failure (auth, network,
+	# rate-limit, transient 5xx → fail-open as pr_exists). The previous
+	# implementation collapsed `2>/dev/null || true` into pr_count=0, which
+	# misclassified every gh failure as branch_orphan. That false-positive
+	# triggered Issue #21880: PR #21883 was correctly created at 05:35Z but the
+	# orphan classifier ran 5 minutes later, observed a transient gh failure,
+	# returned pr_count=0, and posted a noisy WORKER_BRANCH_ORPHAN escalation
+	# against an issue that already had a green PR awaiting merge.
 	local issue_number=""
 	issue_number=$(printf '%s' "$session_key" | grep -oE '[0-9]+$' || true)
 	local repo_slug="${DISPATCH_REPO_SLUG:-}"
 	if [[ -n "$issue_number" && -n "$repo_slug" ]]; then
-		local pr_count=0
-		pr_count=$(gh pr list --repo "$repo_slug" --search "$issue_number" \
-			--json number --jq 'length' 2>/dev/null || true)
-		[[ "$pr_count" =~ ^[0-9]+$ ]] || pr_count=0
-		if [[ "$pr_count" -gt 0 ]]; then
+		local pr_found=0
+		local any_check_succeeded=0
+		local pr_count=""
+
+		# Probe A: head-ref lookup (preferred — no search-index dependency)
+		if [[ -n "$branch_name" && "$branch_name" != "HEAD" \
+				&& "$branch_name" != "$default_branch" ]]; then
+			if pr_count=$(gh pr list --repo "$repo_slug" --head "$branch_name" \
+					--state all --json number --jq 'length' 2>/dev/null); then
+				any_check_succeeded=1
+				if [[ "$pr_count" =~ ^[0-9]+$ ]] && [[ "$pr_count" -gt 0 ]]; then
+					pr_found=1
+				fi
+			fi
+		fi
+
+		# Probe B: search-by-issue-number fallback
+		if [[ "$pr_found" -eq 0 ]]; then
+			if pr_count=$(gh pr list --repo "$repo_slug" --search "$issue_number" \
+					--state all --json number --jq 'length' 2>/dev/null); then
+				any_check_succeeded=1
+				if [[ "$pr_count" =~ ^[0-9]+$ ]] && [[ "$pr_count" -gt 0 ]]; then
+					pr_found=1
+				fi
+			fi
+		fi
+
+		if [[ "$pr_found" -eq 1 ]]; then
 			printf 'pr_exists'
 			return 0
 		fi
-		# PR confirmed absent: branch/commits exist but no PR → orphan (GH#20819)
-		printf 'branch_orphan'
+
+		# At least one probe completed cleanly with 0 results → confirmed
+		# orphan (GH#20819): branch/commits exist but no PR was opened.
+		if [[ "$any_check_succeeded" -eq 1 ]]; then
+			printf 'branch_orphan'
+			return 0
+		fi
+
+		# All probes failed (auth, network, rate-limit, 5xx) — fail-open per
+		# docstring. Misclassifying as branch_orphan here is exactly the
+		# false-positive that triggered Issue #21880.
+		printf 'pr_exists'
 		return 0
 	fi
 

--- a/.agents/scripts/tests/test-worker-output-classification.sh
+++ b/.agents/scripts/tests/test-worker-output-classification.sh
@@ -82,13 +82,23 @@ GH_STUB_DIR="${TEST_ROOT}/stubs"
 mkdir -p "$GH_STUB_DIR"
 cat >"${GH_STUB_DIR}/gh" <<'STUB'
 #!/usr/bin/env bash
-# Minimal stub: `gh pr list ... --jq 'length'` returns ${STUB_PR_COUNT:-0}.
+# Minimal stub:
+#   `gh pr list ... --jq 'length'` returns ${STUB_PR_COUNT:-0}.
+#   Exits with ${STUB_GH_EXIT:-0} on `pr list` calls so tests can simulate
+#   gh-call failures (auth, network, rate-limit, transient 5xx). Issue #21880.
 # Other invocations exit 0 silently so source-time `gh api user` calls
 # from sourced helpers don't crash the test.
 case "${1:-}" in
 	pr)
 		case "${2:-}" in
-			list) printf '%s\n' "${STUB_PR_COUNT:-0}" ;;
+			list)
+				if [[ "${STUB_GH_EXIT:-0}" -ne 0 ]]; then
+					# Simulate gh failure: print nothing on stdout, error to stderr.
+					printf 'simulated gh failure\n' >&2
+					exit "${STUB_GH_EXIT}"
+				fi
+				printf '%s\n' "${STUB_PR_COUNT:-0}"
+				;;
 			*) ;;
 		esac
 		;;
@@ -267,6 +277,47 @@ test_feature_branch_with_pr_returns_pr_exists() {
 	return 0
 }
 
+test_feature_branch_with_gh_failure_fails_open_to_pr_exists() {
+	# Issue #21880 regression: when `gh pr list` fails (auth, network, rate
+	# limit, transient 5xx), the classifier MUST return pr_exists per its
+	# documented fail-open contract. The previous implementation collapsed
+	# `2>/dev/null || true` into pr_count=0, which misclassified every gh
+	# failure as branch_orphan and triggered a noisy WORKER_BRANCH_ORPHAN
+	# escalation against issues that had legitimate green PRs awaiting merge.
+	#
+	# A real PR was open at PR-creation-time; the gh probe failed transiently;
+	# the classifier MUST NOT escalate. This is the canonical bug pattern.
+	make_repo_pair "case5" || {
+		print_result "case 5: gh failure with feature branch → fail-open pr_exists (#21880)" 1 "fixture setup failed"
+		return 0
+	}
+	(
+		cd "$WORK_DIR" || exit 1
+		git checkout -q -b feature/t9999-gh-failure
+		echo "feature change" > feature.txt
+		git add feature.txt
+		git commit -q -m "feature commit"
+		git push -q origin feature/t9999-gh-failure
+	) || {
+		print_result "case 5: gh failure with feature branch → fail-open pr_exists (#21880)" 1 "feature branch setup failed"
+		return 0
+	}
+	# Simulate gh failure on BOTH probes (head + search). All probes failing
+	# is the only condition under which the classifier may fail-open.
+	export STUB_PR_COUNT=0
+	export STUB_GH_EXIT=1
+	local got
+	got=$(_worker_produced_output "issue-1005" "$WORK_DIR")
+	unset STUB_GH_EXIT
+	if [[ "$got" == "pr_exists" ]]; then
+		print_result "case 5: gh failure with feature branch → fail-open pr_exists (#21880)" 0
+	else
+		print_result "case 5: gh failure with feature branch → fail-open pr_exists (#21880)" 1 \
+			"got: $got (expected pr_exists — fail-open contract violation)"
+	fi
+	return 0
+}
+
 # -----------------------------------------------------------------------------
 # Run
 # -----------------------------------------------------------------------------
@@ -275,6 +326,7 @@ test_main_no_commits_no_pr_returns_noop
 test_main_with_local_commits_no_pr_returns_noop_t2899
 test_feature_branch_pushed_no_pr_returns_branch_orphan
 test_feature_branch_with_pr_returns_pr_exists
+test_feature_branch_with_gh_failure_fails_open_to_pr_exists
 
 printf '\nRan %d test(s), %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 


### PR DESCRIPTION
## Summary

Two-part root-cause fix for #21880:

1. **`ai-research-helper.sh`** — replace hallucinated model IDs with canonical ones from `.agents/configs/model-routing-table.json` (verified against `models-README.md:19,21,24`). Pre-fix IDs returned HTTP 404 for every Anthropic API call, causing 100% LLM-call failure in `fix-the-fixer-detector` (t3077) and any other consumer.

   | tier | before (404) | after |
   |---|---|---|
   | haiku | `claude-haiku-4-20250414` | `claude-haiku-4-5-20251001` |
   | sonnet | `claude-sonnet-4-20250514` | `claude-sonnet-4-6` |
   | opus | `claude-opus-4-20250514` | `claude-opus-4-6` |

2. **`_worker_produced_output` orphan-detection (in BOTH `headless-runtime-helper.sh` and `headless-runtime-worker.sh` — duplicate code)** — fix Signal 3 to distinguish `gh`-call failure from confirmed PR absence. Pre-fix `$(gh ... 2>/dev/null || true)` collapsed every gh failure (auth, network, rate-limit, transient 5xx) into `pr_count=0`, which then returned `branch_orphan` instead of fail-opening per the documented contract.

   This false-positive is the systemic root cause behind issue #21880 itself: PR #21883 was correctly created at 05:35Z, the orphan classifier ran at ~05:40Z, observed a transient gh failure, and posted a noisy `WORKER_BRANCH_ORPHAN` escalation against an issue that already had a green PR awaiting merge.

## Why a single PR fixes both

PR #21883 (worker `alex-solovyev`'s attempt) correctly identifies the model-ID fix but is **BLOCKED** because:
- 3 commits behind `origin/main`
- `dismiss_stale_reviews: true` + auto-merge deadlock prevents the pulse re-approving after rebase

Landing this PR ships:
- (a) the same correct model-ID fix as #21883, **and**
- (b) the systemic orphan-detection fix that prevents the same false-positive from happening to the next worker.

PR #21883 will be superseded once this merges.

## Approach

### Orphan-detection rewrite

```bash
# Before — collapses ALL gh failures into 0, mis-classifies every transient
# error as branch_orphan:
pr_count=$(gh pr list --repo "$repo_slug" --search "$issue_number" \
    --json number --jq 'length' 2>/dev/null || true)
[[ "$pr_count" =~ ^[0-9]+$ ]] || pr_count=0
if [[ "$pr_count" -gt 0 ]]; then printf 'pr_exists'; return 0; fi
printf 'branch_orphan'  # WRONG: also reached on gh failure

# After — explicit exit-code capture, plus head-ref primary probe:
if pr_count=$(gh pr list --repo "$repo_slug" --head "$branch_name" \
        --state all --json number --jq 'length' 2>/dev/null); then
    any_check_succeeded=1
    [[ "$pr_count" =~ ^[0-9]+$ && "$pr_count" -gt 0 ]] && pr_found=1
fi
# (search-by-issue-number probe as fallback, same exit-capture pattern)
[[ "$pr_found" -eq 1 ]] && { printf 'pr_exists'; return 0; }
[[ "$any_check_succeeded" -eq 1 ]] && { printf 'branch_orphan'; return 0; }
printf 'pr_exists'  # all probes failed → fail-open per contract
```

Three improvements over the previous code:

1. **Exit-code capture** via `if pr_count=$(...); then` — distinguishes API-error (no exit-code observed) from genuine zero-result (exit-code observed). Restores the documented fail-open contract.
2. **Head-ref primary probe** (`gh pr list --head <branch>`) — direct DB lookup, no search-index latency. Only runs when `branch_name` is known and is not the repo default.
3. **`--state all`** — a PR that was created and then closed/merged still counts as "PR exists"; the worker did its job, closure is a separate concern.

### Test coverage

Added case 5 to `test-worker-output-classification.sh`:

- Simulates a gh-call failure on a feature-branch worker via `STUB_GH_EXIT=1`.
- Pre-fix: returned `branch_orphan` (the bug).
- Post-fix: fail-opens to `pr_exists` per contract.

All 5 cases pass:

```text
PASS case 1: branch=main, ahead=0, no PR → noop
PASS case 2: branch=main, ahead=N, no PR → noop (default-branch guard)
PASS case 3: branch=feature/tNNN-foo, ahead=N, no PR → branch_orphan
PASS case 4: branch=feature/tNNN-foo, ahead=N, PR exists → pr_exists
PASS case 5: gh failure with feature branch → fail-open pr_exists (#21880)
```

## Verification

- [x] `shellcheck` clean on all 4 modified files (no new violations)
- [x] Model IDs match canonical source (`.agents/configs/model-routing-table.json`, `.agents/tools/ai-assistants/models-README.md:19,21,24`)
- [x] All 5 cases in `test-worker-output-classification.sh` pass
- [x] No regressions in `test-worker-output-discovery.sh`, `test-worker-exit-classifier.sh`
- [x] Pre-existing failure in `test-headless-runtime-helper.sh` (`appends escalation-before-blocked contract to full-loop prompts`) is unchanged from `origin/main` baseline — unrelated to this fix

## Files

- `EDIT: .agents/scripts/ai-research-helper.sh:33-50` — model-ID fix
- `EDIT: .agents/scripts/headless-runtime-helper.sh:1407-1480` — Signal 3 rewrite (primary)
- `EDIT: .agents/scripts/headless-runtime-worker.sh:446-519` — Signal 3 rewrite (duplicate, kept in sync)
- `EDIT: .agents/scripts/tests/test-worker-output-classification.sh` — add gh-failure regression test (case 5)

Resolves #21880
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.12 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-opus-4-7 spent 14m and 35,486 tokens on this as a headless worker.