### PR TITLE
GH#21903: status: threshold-based PILE-UP detection

### DIFF
--- a/.agents/scripts/pulse-lifecycle-helper.sh
+++ b/.agents/scripts/pulse-lifecycle-helper.sh
@@ -22,12 +22,18 @@
 #   AIDEVOPS_SKIP_PULSE_RESTART=1     Skip restart operations (for debug).
 #   AIDEVOPS_PULSE_RESTART_WAIT=3     Seconds between stop and start (default 3).
 #   AIDEVOPS_PULSE_SIGTERM_WAIT=2     Seconds before escalating to SIGKILL.
+#   AIDEVOPS_PULSE_EXPECTED_MAX_INSTANCES=3
+#                                     status: warn only when alive PID count
+#                                     EXCEEDS this threshold (default 3 — see
+#                                     t2774 lock-release window). Set to 1 for
+#                                     legacy strict-singleton check.
 #
 # Exit codes:
 #   0  Success (includes no-op cases)
 #   1  Pulse not running (is-running only)
 #   2  Invalid subcommand or missing pulse-wrapper.sh
-#   3  status: multiple pulse PIDs detected (singleton violation, GH#21433)
+#   3  status: pulse-wrapper instance pile-up detected (GH#21433/GH#21903)
+#      — count exceeds AIDEVOPS_PULSE_EXPECTED_MAX_INSTANCES (default 3)
 #
 # Part of aidevops framework: https://aidevops.sh
 
@@ -47,6 +53,31 @@ _PULSE_PATTERN="${AIDEVOPS_PULSE_PROCESS_PATTERN:-(^|/)pulse-wrapper\\.sh( |\$)}
 # Timing
 _PULSE_RESTART_WAIT="${AIDEVOPS_PULSE_RESTART_WAIT:-3}"
 _PULSE_SIGTERM_WAIT="${AIDEVOPS_PULSE_SIGTERM_WAIT:-2}"
+
+# Expected-max coexistence threshold (GH#21903).
+#
+# After the t2774 design change, pulse-wrapper.sh releases the instance lock
+# BEFORE the LLM session (pulse-wrapper.sh::_pulse_run_deterministic_pipeline
+# at line ~1337) so the next launchd cycle can run deterministic ops while
+# the previous wrapper is still in its LLM phase. Multiple alive
+# pulse-wrapper.sh processes are therefore EXPECTED in steady state — not
+# a singleton-invariant violation. Typical counts:
+#   1 — single cycle, no LLM-phase overlap
+#   2 — cycle N's LLM phase + cycle N+1's deterministic phase (most common)
+#   3 — cycle N + N+1 both in LLM phase + cycle N+2 just acquired the lock
+#       (rare; happens when an LLM phase exceeds 2 launchd cycles ~360s)
+#
+# A pile-up beyond this threshold indicates a real problem: launchd
+# respawn outpacing cycle completion, hung LLM phases failing to exit, or
+# the t3002 lock race regressing. _status warns at counts > the threshold.
+#
+# Override: AIDEVOPS_PULSE_EXPECTED_MAX_INSTANCES=<integer>. Setting to 1
+# restores the legacy strict-singleton check (warn on any coexistence) —
+# only useful for environments where the t2774 lock-release window has
+# been disabled (PULSE_LLM_DISABLED=1 etc.).
+_PULSE_EXPECTED_MAX_INSTANCES="${AIDEVOPS_PULSE_EXPECTED_MAX_INSTANCES:-3}"
+[[ "$_PULSE_EXPECTED_MAX_INSTANCES" =~ ^[0-9]+$ ]] || _PULSE_EXPECTED_MAX_INSTANCES=3
+[[ "$_PULSE_EXPECTED_MAX_INSTANCES" -ge 1 ]] || _PULSE_EXPECTED_MAX_INSTANCES=1
 
 # ANSI colors (guarded — don't collide with shared-constants)
 [[ -z "${_PL_GREEN+x}" ]] && _PL_GREEN='\033[0;32m'
@@ -242,11 +273,18 @@ _restart_if_running() {
 	_start
 }
 
-# _status: human-readable PID + age. Reports lock-holder PID and warns when
-# multiple pulse PIDs are alive simultaneously — the singleton invariant
-# (GH#4513, GH#21433) requires exactly one. Multiple PIDs indicate a race
-# escaped the lock (e.g., trap-cleanup vs launchd respawn vs lifecycle-helper
-# concurrent start) and operator intervention is needed.
+# _status: human-readable PID + age. Reports lock-holder PID and warns ONLY
+# when the alive-PID count exceeds AIDEVOPS_PULSE_EXPECTED_MAX_INSTANCES
+# (default 3 — see the constant block above for the t2774 design rationale).
+#
+# History note (GH#21433 → GH#21903):
+#   GH#4513/GH#21433 originally framed coexistence of pulse-wrapper.sh PIDs as
+#   a "singleton invariant violation". After t2774 (lock release before LLM
+#   phase) and t3002 (post-write race fix) landed, brief coexistence of 2-3
+#   PIDs is the EXPECTED steady state — not a violation. The warning was
+#   firing on legitimate post-release overlap, training operators to ignore
+#   it. GH#21903 reframes it as PILE-UP detection: warn only when the count
+#   exceeds the threshold (genuine respawn-outpacing-cycle-completion pattern).
 _status() {
 	local _pids
 	_pids=$(_pulse_pids)
@@ -292,8 +330,10 @@ _status() {
 		printf '  PID %s%s (uptime %s)\n' "$_pid" "$_marker" "${_etime:-unknown}"
 	done <<<"$_pids"
 
-	if [[ "$_pid_count" -gt 1 ]]; then
-		_pl_warn "MULTIPLE pulse instances detected (GH#21433) — singleton invariant violated"
+	if [[ "$_pid_count" -gt "$_PULSE_EXPECTED_MAX_INSTANCES" ]]; then
+		_pl_warn "PILE-UP: $_pid_count pulse-wrapper.sh processes alive (threshold $_PULSE_EXPECTED_MAX_INSTANCES, GH#21903)"
+		_pl_warn "Up to $_PULSE_EXPECTED_MAX_INSTANCES is normal post-t2774 (lock released before LLM phase)."
+		_pl_warn "Pile-up beyond that suggests launchd respawn outpacing cycle completion or hung LLM phases."
 		_pl_warn "Recommendation: $(basename "$0") restart    # full stop+start to recover"
 		# Exit non-zero so callers (scripts, monitoring) can detect the anomaly.
 		return 3

--- a/.agents/scripts/tests/test-pulse-lifecycle-helper.sh
+++ b/.agents/scripts/tests/test-pulse-lifecycle-helper.sh
@@ -150,6 +150,58 @@ _kill_mocks() {
 	_wait_for_no_mock_pulse 20 || true
 }
 
+# _spawn_extra_mock_pulse: launch ONE additional mock pulse-wrapper.sh process
+# in the background and return after it's registered with the kernel. Used by
+# the threshold tests (GH#21903) to simulate post-t2774 cycle overlap where
+# multiple pulse-wrapper.sh PIDs are alive simultaneously.
+#
+# Note on filtering: the spawned process is parented to the test-runner bash,
+# whose argv ('bash .../test-pulse-lifecycle-helper.sh') does NOT contain
+# 'pulse-wrapper.sh' — so Layer 2 of _pulse_pids does NOT filter it. It is
+# counted as a top-level pulse PID, which is exactly what we want for these
+# tests.
+_spawn_extra_mock_pulse() {
+	bash "${TEST_ROOT}/scripts/pulse-wrapper.sh" >/dev/null 2>&1 &
+	local _pid=$!
+	MOCK_PIDS+=("$_pid")
+	# Wait for the kernel to register the process so subsequent pgrep finds it.
+	local _tries=20
+	while [[ "$_tries" -gt 0 ]]; do
+		if kill -0 "$_pid" 2>/dev/null; then
+			return 0
+		fi
+		sleep 0.1
+		_tries=$((_tries - 1))
+	done
+	return 1
+}
+
+# _count_top_level_mock_pulses: count PIDs the helper would treat as
+# top-level pulse instances. We replicate _pulse_pids' two-layer filter
+# directly here — running the helper itself would side-effect via the
+# subcommand contract.
+_count_top_level_mock_pulses() {
+	local _pids _pid _ppid _ppid_cmd _count=0
+	_pids=$(pgrep -f "${TEST_ROOT}/scripts/pulse-wrapper.sh" 2>/dev/null || true)
+	[[ -z "$_pids" ]] && {
+		printf '0\n'
+		return 0
+	}
+	while read -r _pid; do
+		_ppid=$(ps -p "$_pid" -o ppid= 2>/dev/null | tr -d ' ')
+		[[ -z "$_ppid" || "$_ppid" == "0" ]] && continue
+		if [[ "$_ppid" == "1" ]]; then
+			_count=$((_count + 1))
+			continue
+		fi
+		_ppid_cmd=$(ps -p "$_ppid" -o command= 2>/dev/null)
+		[[ "$_ppid_cmd" =~ pulse-wrapper\.sh ]] && continue
+		_count=$((_count + 1))
+	done <<<"$_pids"
+	printf '%s\n' "$_count"
+	return 0
+}
+
 # -----------------------------------------------------------------------------
 # Tests
 # -----------------------------------------------------------------------------
@@ -352,6 +404,138 @@ test_missing_pulse_script_exit_2() {
 }
 
 # -----------------------------------------------------------------------------
+# GH#21903: threshold-based PILE-UP detection
+# -----------------------------------------------------------------------------
+# Post-t2774 the pulse releases its instance lock BEFORE the LLM phase, so
+# brief coexistence of 2-3 pulse-wrapper.sh PIDs is the EXPECTED steady state
+# (cycle N's LLM phase + cycle N+1's deterministic phase + occasional N+2
+# overlap). The legacy "warn on count > 1" check trained operators to ignore
+# legitimate overlap. _status now warns ONLY when the count exceeds
+# AIDEVOPS_PULSE_EXPECTED_MAX_INSTANCES (default 3).
+
+test_status_two_instances_no_warning_default_threshold() {
+	_kill_mocks
+	"$HELPER" start >/dev/null 2>&1 || true
+	_wait_for_mock_pulse 20 || true
+	_spawn_extra_mock_pulse || true
+	sleep 0.3
+
+	local count
+	count=$(_count_top_level_mock_pulses)
+	if [[ "$count" -lt 2 ]]; then
+		_print_result "status: 2-instance setup (expected >=2 top-level mocks, got $count)" 0
+		_kill_mocks
+		return 0
+	fi
+
+	local rc=0
+	local out
+	out=$("$HELPER" status 2>&1) || rc=$?
+	_assert_eq "status: 2 instances exits 0 (default threshold 3)" "0" "$rc"
+	if [[ "$out" != *"PILE-UP"* && "$out" != *"singleton invariant"* ]]; then
+		_print_result "status: 2 instances does not warn" 1
+	else
+		_print_result "status: 2 instances should not warn (output included PILE-UP/singleton)" 0
+	fi
+	_kill_mocks
+	return 0
+}
+
+test_status_at_threshold_no_warning() {
+	_kill_mocks
+	"$HELPER" start >/dev/null 2>&1 || true
+	_wait_for_mock_pulse 20 || true
+	_spawn_extra_mock_pulse || true
+	_spawn_extra_mock_pulse || true
+	sleep 0.3
+
+	local count
+	count=$(_count_top_level_mock_pulses)
+	if [[ "$count" -lt 3 ]]; then
+		_print_result "status: 3-instance setup (expected >=3 top-level mocks, got $count)" 0
+		_kill_mocks
+		return 0
+	fi
+
+	local rc=0
+	local out
+	out=$("$HELPER" status 2>&1) || rc=$?
+	# 3 instances is exactly the default threshold — must not warn.
+	if [[ "$count" -eq 3 ]]; then
+		_assert_eq "status: 3 instances exits 0 (at default threshold)" "0" "$rc"
+		if [[ "$out" != *"PILE-UP"* ]]; then
+			_print_result "status: at-threshold (3) does not emit PILE-UP" 1
+		else
+			_print_result "status: at-threshold (3) should not warn (got PILE-UP)" 0
+		fi
+	else
+		# Spurious extra process picked up — environmental, skip cleanly.
+		_print_result "status: at-threshold setup got $count mocks (env noise; skipping)" 1
+	fi
+	_kill_mocks
+	return 0
+}
+
+test_status_pileup_above_threshold_warns_and_exits_3() {
+	_kill_mocks
+	"$HELPER" start >/dev/null 2>&1 || true
+	_wait_for_mock_pulse 20 || true
+	_spawn_extra_mock_pulse || true
+	_spawn_extra_mock_pulse || true
+	_spawn_extra_mock_pulse || true
+	sleep 0.3
+
+	local count
+	count=$(_count_top_level_mock_pulses)
+	if [[ "$count" -lt 4 ]]; then
+		_print_result "status: pile-up setup (expected >=4 top-level mocks, got $count)" 0
+		_kill_mocks
+		return 0
+	fi
+
+	local rc=0
+	local out
+	out=$("$HELPER" status 2>&1) || rc=$?
+	_assert_eq "status: 4+ instances exits 3 (above default threshold)" "3" "$rc"
+	if [[ "$out" == *"PILE-UP"* && "$out" == *"GH#21903"* ]]; then
+		_print_result "status: pile-up message includes 'PILE-UP' and 'GH#21903'" 1
+	else
+		_print_result "status: pile-up message missing expected markers (got: $out)" 0
+	fi
+	_kill_mocks
+	return 0
+}
+
+test_status_legacy_strict_threshold_via_env() {
+	_kill_mocks
+	"$HELPER" start >/dev/null 2>&1 || true
+	_wait_for_mock_pulse 20 || true
+	_spawn_extra_mock_pulse || true
+	sleep 0.3
+
+	local count
+	count=$(_count_top_level_mock_pulses)
+	if [[ "$count" -lt 2 ]]; then
+		_print_result "status: legacy-mode setup (expected >=2 top-level mocks, got $count)" 0
+		_kill_mocks
+		return 0
+	fi
+
+	local rc=0
+	local out
+	out=$(AIDEVOPS_PULSE_EXPECTED_MAX_INSTANCES=1 "$HELPER" status 2>&1) || rc=$?
+	# With threshold=1, ANY coexistence is a pile-up (legacy strict-singleton mode).
+	_assert_eq "status: 2 instances exits 3 with threshold=1 (legacy strict mode)" "3" "$rc"
+	if [[ "$out" == *"PILE-UP"* ]]; then
+		_print_result "status: legacy strict threshold triggers PILE-UP warning" 1
+	else
+		_print_result "status: legacy strict threshold should warn (got: $out)" 0
+	fi
+	_kill_mocks
+	return 0
+}
+
+# -----------------------------------------------------------------------------
 # Runner
 # -----------------------------------------------------------------------------
 
@@ -373,6 +557,12 @@ main() {
 	test_skip_env_honoured_in_restart_if_running
 	test_skip_env_honoured_in_restart
 	test_missing_pulse_script_exit_2
+
+	# GH#21903 threshold-based PILE-UP detection
+	test_status_two_instances_no_warning_default_threshold
+	test_status_at_threshold_no_warning
+	test_status_pileup_above_threshold_warns_and_exits_3
+	test_status_legacy_strict_threshold_via_env
 
 	echo ""
 	echo "----"


### PR DESCRIPTION
## Summary

Replace the legacy `count > 1 = singleton invariant violated` warning in `pulse-lifecycle-helper.sh status` with threshold-based PILE-UP detection (default 3, configurable via `AIDEVOPS_PULSE_EXPECTED_MAX_INSTANCES`).

## Why

After **t2774** landed, `pulse-wrapper.sh` releases its instance lock BEFORE the LLM phase (see `pulse-wrapper.sh:1337`) so the next launchd respawn can run deterministic ops while the previous wrapper is still in its LLM phase. Brief coexistence of 2-3 pulse-wrapper.sh PIDs is the EXPECTED steady state — not a singleton-invariant violation.

The legacy `count > 1` warning was authored against the pre-t2774 model (one wrapper at a time). It now fires on legitimate post-release overlap, training operators to ignore it. **t3002** (post-write race fix) closed the original race the warning was meant to catch — verified on this machine: `~/.aidevops/logs/pulse-wrapper.log` shows 0 "MULTIPLE pulse instances", 0 "Lock verification failed", 0 "GH#21433 race window observed" events.

GH#21903 reframes the warning as **PILE-UP detection** — operator-actionable, threshold-gated.

## How

**`.agents/scripts/pulse-lifecycle-helper.sh`:**

- Added `_PULSE_EXPECTED_MAX_INSTANCES` constant (default 3, configurable via `AIDEVOPS_PULSE_EXPECTED_MAX_INSTANCES`). Threshold rationale documented inline:
  - 1 — single cycle, no LLM-phase overlap
  - 2 — cycle N's LLM phase + cycle N+1's deterministic phase (most common)
  - 3 — cycle N + N+1 in LLM + N+2 just acquired lock (rare, when an LLM phase exceeds 2 launchd cycles ~360s)
- Replaced the `_status` warning text:
  - Before: `MULTIPLE pulse instances detected (GH#21433) — singleton invariant violated`
  - After: `PILE-UP: $count pulse-wrapper.sh processes alive (threshold $T, GH#21903)` with mentoring advice on what counts as normal vs problematic.
- Updated `_status` doc-comment with full GH#21433 → GH#21903 history note so the next reader understands why the warning was relaxed.
- Updated header env-var doc + exit-code doc.
- Setting `AIDEVOPS_PULSE_EXPECTED_MAX_INSTANCES=1` restores the legacy strict-singleton check for environments with the t2774 lock-release window disabled.

**`.agents/scripts/tests/test-pulse-lifecycle-helper.sh`:**

- Added `_spawn_extra_mock_pulse` and `_count_top_level_mock_pulses` test helpers (replicates the helper's `_pulse_pids` two-layer filter for independent verification).
- Added 4 tests covering the threshold matrix:
  - 2 instances → exit 0, no warn (default threshold 3)
  - 3 instances → exit 0, no warn (at threshold)
  - 4+ instances → exit 3, emits PILE-UP marker + GH#21903 reference
  - `AIDEVOPS_PULSE_EXPECTED_MAX_INSTANCES=1` + 2 instances → exit 3 (legacy strict mode)

## Verification

- `shellcheck .agents/scripts/pulse-lifecycle-helper.sh` — clean
- `shellcheck .agents/scripts/tests/test-pulse-lifecycle-helper.sh` — clean
- `bash .agents/scripts/tests/test-pulse-lifecycle-helper.sh` — 24/24 pass on stable runs (ran 5 times: 4 clean, 1 had a pre-existing flake in `status_when_running` unrelated to this change; the 4 new GH#21903 tests are stable across all 5 runs).

## Runtime Testing

- **Risk level:** Low — agent prompts / infrastructure scripts. No production data path touched.
- **Verification:** shellcheck clean on both files; threshold tests verify both pass-through (counts ≤ threshold) and warning paths (counts > threshold).

Resolves #21903
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.14 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-opus-4-7 spent 20m and 47,912 tokens on this with the user in an interactive session.