### PR TITLE
t3088: eliminate dual origin label on worker-dispatched PRs (Resolves #21862)

### DIFF
--- a/.agents/scripts/full-loop-helper-commit.sh
+++ b/.agents/scripts/full-loop-helper-commit.sh
@@ -807,9 +807,19 @@ _create_pr() {
 
 	print_info "Creating PR..."
 	local pr_url="" rc=0
-	# t2115: gh_create_pr auto-appends origin label and signature footer.
-	# The explicit --label "$origin_label" is kept for backward compat (GitHub deduplicates).
-	local -a pr_cmd=(gh_create_pr --repo "$repo" --title "$pr_title" --body "$pr_body" --label "$origin_label")
+	# t2115/t3088: gh_create_pr auto-appends origin label and signature footer.
+	# Previously we passed --label "$origin_label" here too, with the comment
+	# "GitHub deduplicates". That claim is FALSE for non-identical labels: when
+	# this caller's $origin_label disagreed with gh_create_pr's session-detected
+	# label (env-var divergence — see full-loop-helper.sh t3088 fix), GitHub
+	# applied BOTH labels, producing the t2200 mutual-exclusion violation.
+	# Canonical failure: PR #21825. Origin label is now injected exactly once,
+	# inside gh_create_pr, via session_origin_label(). $origin_label is retained
+	# in the function signature for backward compat with existing callers.
+	local -a pr_cmd=(gh_create_pr --repo "$repo" --title "$pr_title" --body "$pr_body")
+	# Reference the parameter to avoid shellcheck SC2034 (unused variable).
+	# Intentionally suppressed: $origin_label is the legacy interface — see comment above.
+	: "${origin_label:-}"
 	for lbl in "${extra_labels[@]+"${extra_labels[@]}"}"; do
 		pr_cmd+=(--label "$lbl")
 	done

--- a/.agents/scripts/full-loop-helper.sh
+++ b/.agents/scripts/full-loop-helper.sh
@@ -93,10 +93,17 @@ cmd_commit_and_pr() {
 		pr_title="$(_compose_pr_title "$issue_number" "$commit_message")"
 	fi
 
-	local origin_label="origin:interactive"
-	if [[ "${HEADLESS:-}" == "1" || "${FULL_LOOP_HEADLESS:-}" == "true" ]]; then
-		origin_label="origin:worker"
-	fi
+	# t3088: use canonical session_origin_label() instead of hand-rolling the
+	# headless-env check. Previous logic checked only HEADLESS=1 / FULL_LOOP_HEADLESS=true,
+	# while detect_session_origin() (consulted by gh_create_pr's self-injection)
+	# also recognises AIDEVOPS_HEADLESS, OPENCODE_HEADLESS, GITHUB_ACTIONS, and
+	# AIDEVOPS_SESSION_ORIGIN. When the two checks disagreed (e.g., AIDEVOPS_HEADLESS=true
+	# without HEADLESS=1) the worker PR ended up with BOTH origin:interactive and
+	# origin:worker labels — the t2200 mutual-exclusion violation observed on PR #21825.
+	# Single source of truth: session_origin_label() returns "origin:worker" or
+	# "origin:interactive" based on the canonical env-var set.
+	local origin_label
+	origin_label=$(session_origin_label)
 
 	local sig_footer=""
 	local sig_helper="${SCRIPT_DIR}/gh-signature-helper.sh"

--- a/.agents/scripts/shared-gh-wrappers-create.sh
+++ b/.agents/scripts/shared-gh-wrappers-create.sh
@@ -133,8 +133,17 @@ gh_create_issue() {
 		return 1
 	fi
 
-	local origin_label
-	origin_label=$(session_origin_label)
+	# t3088: defence-in-depth — only auto-inject the session origin label when
+	# the caller has NOT already specified one. Prevents the dual-origin-label
+	# bug (t2200 violation) where a caller's --label "origin:X" plus the
+	# wrapper's --label "$session_origin_label" produces two distinct origin
+	# labels on the resulting issue. Mirrors gh_create_pr (canonical failure: PR #21825).
+	local -a _origin_label_args=()
+	if ! _gh_wrapper_args_have_origin_label "$@"; then
+		local origin_label
+		origin_label=$(session_origin_label)
+		_origin_label_args=(--label "$origin_label")
+	fi
 	# Ensure labels exist on the target repo (once per repo per process)
 	_ensure_origin_labels_for_args "$@"
 
@@ -197,11 +206,11 @@ gh_create_issue() {
 			local auto_assignee
 			auto_assignee=$(_gh_wrapper_auto_assignee)
 			if [[ -n "$auto_assignee" ]]; then
-				issue_output=$(gh issue create "$@" "${_todo_label_args[@]}" --label "$origin_label" --assignee "$auto_assignee")
+				issue_output=$(gh issue create "$@" "${_todo_label_args[@]}" "${_origin_label_args[@]+"${_origin_label_args[@]}"}" --assignee "$auto_assignee") # aidevops-allow: raw-gh-wrapper
 				local rc=$?
 				if [[ $rc -ne 0 ]] && _rest_should_fallback; then
 					print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to REST for issue create"
-					issue_output=$(_rest_issue_create "$@" "${_todo_label_args[@]}" --label "$origin_label" --assignee "$auto_assignee")
+					issue_output=$(_rest_issue_create "$@" "${_todo_label_args[@]}" "${_origin_label_args[@]+"${_origin_label_args[@]}"}" --assignee "$auto_assignee")
 					rc=$?
 				fi
 				echo "$issue_output"
@@ -211,11 +220,11 @@ gh_create_issue() {
 		fi
 	fi
 
-	issue_output=$(gh issue create "$@" "${_todo_label_args[@]}" --label "$origin_label")
+	issue_output=$(gh issue create "$@" "${_todo_label_args[@]}" "${_origin_label_args[@]+"${_origin_label_args[@]}"}") # aidevops-allow: raw-gh-wrapper
 	local rc=$?
 	if [[ $rc -ne 0 ]] && _rest_should_fallback; then
 		print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to REST for issue create"
-		issue_output=$(_rest_issue_create "$@" "${_todo_label_args[@]}" --label "$origin_label")
+		issue_output=$(_rest_issue_create "$@" "${_todo_label_args[@]}" "${_origin_label_args[@]+"${_origin_label_args[@]}"}")
 		rc=$?
 	fi
 	echo "$issue_output"
@@ -411,8 +420,17 @@ gh_create_pr() {
 		return 1
 	fi
 
-	local origin_label
-	origin_label=$(session_origin_label)
+	# t3088: defence-in-depth — only auto-inject the session origin label when
+	# the caller has NOT already specified one. Prevents the dual-origin-label
+	# bug (t2200 violation) where a caller's --label "origin:X" plus the
+	# wrapper's --label "$session_origin_label" produces two distinct origin
+	# labels on the resulting PR. Canonical failure: PR #21825.
+	local -a _origin_label_args=()
+	if ! _gh_wrapper_args_have_origin_label "$@"; then
+		local origin_label
+		origin_label=$(session_origin_label)
+		_origin_label_args=(--label "$origin_label")
+	fi
 	_ensure_origin_labels_for_args "$@"
 
 	# t2115: auto-append signature footer when body lacks one
@@ -420,11 +438,11 @@ gh_create_pr() {
 	set -- "${_GH_WRAPPER_SIG_MODIFIED_ARGS[@]}"
 
 	local pr_output rc
-	pr_output=$(gh pr create "$@" --label "$origin_label")
+	pr_output=$(gh pr create "$@" "${_origin_label_args[@]+"${_origin_label_args[@]}"}") # aidevops-allow: raw-gh-wrapper
 	rc=$?
 	if [[ $rc -ne 0 ]] && _rest_should_fallback; then
 		print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to REST for pr create"
-		pr_output=$(_rest_pr_create "$@" --label "$origin_label")
+		pr_output=$(_rest_pr_create "$@" "${_origin_label_args[@]+"${_origin_label_args[@]}"}")
 		rc=$?
 	fi
 	printf '%s\n' "$pr_output"

--- a/.agents/scripts/shared-gh-wrappers-create.sh
+++ b/.agents/scripts/shared-gh-wrappers-create.sh
@@ -126,6 +126,52 @@ _gh_wrapper_derive_todo_labels() {
 	return 0
 }
 
+# t2436 / t3088: Prepare creation-time labels and a filtered arg list.
+# Extracts --todo-task-id from args, derives labels from TODO.md tags for the
+# embedded task ID, and writes the result to module-level globals so the caller
+# can splice them into the gh issue create invocation. Bash-3.2 / zsh compatible
+# (no nameref); pattern mirrors _gh_wrapper_extract_task_id_from_title.
+#
+# Outputs (set on every call):
+#   _GH_CI_FILTERED_ARGS  — original args minus --todo-task-id and its value
+#   _GH_CI_TODO_LABEL_ARGS — empty array, or (--label "$derived_labels")
+#
+# Non-blocking: every step returns silently on failure.
+_GH_CI_FILTERED_ARGS=()
+_GH_CI_TODO_LABEL_ARGS=()
+_gh_ci_prepare_todo_labels() {
+	_GH_CI_FILTERED_ARGS=()
+	_GH_CI_TODO_LABEL_ARGS=()
+
+	local _todo_task_id=""
+	_todo_task_id=$(_gh_wrapper_extract_task_id_from_title "$@") || true
+
+	# Filter --todo-task-id and its value out of the arg list
+	local _gh_ci_skip_next=false
+	local _gh_ci_arg
+	for _gh_ci_arg in "$@"; do
+		if [[ "$_gh_ci_skip_next" == "true" ]]; then
+			_gh_ci_skip_next=false
+			continue
+		fi
+		if [[ "$_gh_ci_arg" == "--todo-task-id" ]]; then
+			_gh_ci_skip_next=true
+			continue
+		fi
+		_GH_CI_FILTERED_ARGS+=("$_gh_ci_arg")
+	done
+
+	if [[ -n "$_todo_task_id" ]]; then
+		local _todo_derived_labels=""
+		_todo_derived_labels=$(_gh_wrapper_derive_todo_labels "$_todo_task_id") || true
+		if [[ -n "$_todo_derived_labels" ]]; then
+			print_info "[INFO] t2436: Derived labels from TODO.md for ${_todo_task_id}: ${_todo_derived_labels}"
+			_GH_CI_TODO_LABEL_ARGS=(--label "$_todo_derived_labels")
+		fi
+	fi
+	return 0
+}
+
 gh_create_issue() {
 	# GH#19857: validate title/body before creating (same invariant as edit wrappers)
 	if ! _gh_validate_edit_args "$@"; then
@@ -151,41 +197,11 @@ gh_create_issue() {
 	_gh_wrapper_auto_sig "$@"
 	set -- "${_GH_WRAPPER_SIG_MODIFIED_ARGS[@]}"
 
-	# t2436: Derive creation-time labels from TODO.md tags for the task ID
-	# embedded in the --title "tNNN: ..." arg (or via explicit --todo-task-id).
-	# This ensures protected labels like parent-task are applied synchronously
-	# at issue creation, closing the race window where async issue-sync would
-	# apply them only after a subsequent TODO.md push.
-	# Strip --todo-task-id from args since it is not a native gh flag.
-	local _todo_task_id=""
-	_todo_task_id=$(_gh_wrapper_extract_task_id_from_title "$@") || true
-
-	# Filter --todo-task-id and its value out of the arg list
-	local -a _gh_ci_filtered_args=()
-	local _gh_ci_skip_next=false
-	local _gh_ci_arg
-	for _gh_ci_arg in "$@"; do
-		if [[ "$_gh_ci_skip_next" == "true" ]]; then
-			_gh_ci_skip_next=false
-			continue
-		fi
-		if [[ "$_gh_ci_arg" == "--todo-task-id" ]]; then
-			_gh_ci_skip_next=true
-			continue
-		fi
-		_gh_ci_filtered_args+=("$_gh_ci_arg")
-	done
-	set -- "${_gh_ci_filtered_args[@]}"
-
-	local -a _todo_label_args=()
-	if [[ -n "$_todo_task_id" ]]; then
-		local _todo_derived_labels=""
-		_todo_derived_labels=$(_gh_wrapper_derive_todo_labels "$_todo_task_id") || true
-		if [[ -n "$_todo_derived_labels" ]]; then
-			print_info "[INFO] t2436: Derived labels from TODO.md for ${_todo_task_id}: ${_todo_derived_labels}"
-			_todo_label_args=(--label "$_todo_derived_labels")
-		fi
-	fi
+	# t2436: Derive creation-time labels from TODO.md tags + filter --todo-task-id.
+	# Helper writes _GH_CI_FILTERED_ARGS and _GH_CI_TODO_LABEL_ARGS globals.
+	_gh_ci_prepare_todo_labels "$@"
+	set -- "${_GH_CI_FILTERED_ARGS[@]+"${_GH_CI_FILTERED_ARGS[@]}"}"
+	local -a _todo_label_args=("${_GH_CI_TODO_LABEL_ARGS[@]+"${_GH_CI_TODO_LABEL_ARGS[@]}"}")
 
 	# t2028: auto-assign to the current user when the session is interactive
 	# and the caller did not pass an explicit --assignee. Reaches parity with
@@ -195,7 +211,7 @@ gh_create_issue() {
 	# t2406: skip self-assignment when auto-dispatch label is present (t2157).
 	# The origin:interactive label is still applied (t2200 — origin and
 	# assignment are independent axes).
-	local issue_output
+	local issue_output rc
 	if ! _gh_wrapper_args_have_assignee "$@"; then
 		if _gh_wrapper_args_have_label "auto-dispatch" "$@"; then
 			# t2157/t2406: auto-dispatch means "let a worker handle this" —
@@ -206,11 +222,11 @@ gh_create_issue() {
 			local auto_assignee
 			auto_assignee=$(_gh_wrapper_auto_assignee)
 			if [[ -n "$auto_assignee" ]]; then
-				issue_output=$(gh issue create "$@" "${_todo_label_args[@]}" "${_origin_label_args[@]+"${_origin_label_args[@]}"}" --assignee "$auto_assignee") # aidevops-allow: raw-gh-wrapper
-				local rc=$?
+				issue_output=$(gh issue create "$@" "${_todo_label_args[@]+"${_todo_label_args[@]}"}" "${_origin_label_args[@]+"${_origin_label_args[@]}"}" --assignee "$auto_assignee") # aidevops-allow: raw-gh-wrapper
+				rc=$?
 				if [[ $rc -ne 0 ]] && _rest_should_fallback; then
 					print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to REST for issue create"
-					issue_output=$(_rest_issue_create "$@" "${_todo_label_args[@]}" "${_origin_label_args[@]+"${_origin_label_args[@]}"}" --assignee "$auto_assignee")
+					issue_output=$(_rest_issue_create "$@" "${_todo_label_args[@]+"${_todo_label_args[@]}"}" "${_origin_label_args[@]+"${_origin_label_args[@]}"}" --assignee "$auto_assignee")
 					rc=$?
 				fi
 				echo "$issue_output"
@@ -220,11 +236,11 @@ gh_create_issue() {
 		fi
 	fi
 
-	issue_output=$(gh issue create "$@" "${_todo_label_args[@]}" "${_origin_label_args[@]+"${_origin_label_args[@]}"}") # aidevops-allow: raw-gh-wrapper
-	local rc=$?
+	issue_output=$(gh issue create "$@" "${_todo_label_args[@]+"${_todo_label_args[@]}"}" "${_origin_label_args[@]+"${_origin_label_args[@]}"}") # aidevops-allow: raw-gh-wrapper
+	rc=$?
 	if [[ $rc -ne 0 ]] && _rest_should_fallback; then
 		print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to REST for issue create"
-		issue_output=$(_rest_issue_create "$@" "${_todo_label_args[@]}" "${_origin_label_args[@]+"${_origin_label_args[@]}"}")
+		issue_output=$(_rest_issue_create "$@" "${_todo_label_args[@]+"${_todo_label_args[@]}"}" "${_origin_label_args[@]+"${_origin_label_args[@]}"}")
 		rc=$?
 	fi
 	echo "$issue_output"

--- a/.agents/scripts/shared-gh-wrappers-session.sh
+++ b/.agents/scripts/shared-gh-wrappers-session.sh
@@ -228,6 +228,42 @@ _gh_wrapper_args_have_label() {
 	return 1
 }
 
+# t3088: Internal — check if argv already contains any origin:* label.
+# Defence-in-depth for gh_create_issue / gh_create_pr session-origin self-injection:
+# when a caller has explicitly passed an origin label (e.g. parent-task-helper.sh
+# passing origin:worker), the wrapper must NOT also append session_origin_label()
+# — that produces TWO --label flags which, if they disagree, both apply (t2200
+# mutual-exclusion violation, canonical PR #21825). With this guard, callers
+# retain authority over their declared origin and the wrapper only fills in
+# the default when no origin was specified.
+#
+# Returns 0 if any --label arg contains origin:interactive, origin:worker, or
+# origin:worker-takeover. Supports comma-separated label lists.
+_gh_wrapper_args_have_origin_label() {
+	while [[ $# -gt 0 ]]; do
+		local cur="$1"
+		local label_val=""
+		case "$cur" in
+		--label)
+			label_val="${2:-}"
+			shift
+			;;
+		--label=*)
+			label_val="${cur#--label=}"
+			;;
+		esac
+		if [[ -n "$label_val" ]]; then
+			case ",${label_val}," in
+			*,origin:interactive,* | *,origin:worker,* | *,origin:worker-takeover,*)
+				return 0
+				;;
+			esac
+		fi
+		shift
+	done
+	return 1
+}
+
 # t2028: Internal — determine the auto-assignee for a newly-created issue.
 # Returns empty string when the session is worker-origin, when the user
 # lookup fails, or when there is otherwise nothing to assign. Callers must

--- a/.agents/scripts/shared-gh-wrappers-session.sh
+++ b/.agents/scripts/shared-gh-wrappers-session.sh
@@ -214,7 +214,11 @@ _gh_wrapper_args_have_label() {
 		--label)
 			local next_val="${2:-}"
 			label_val="$next_val"
-			shift
+			# Guard the shift: if --label is the last arg, $#=1 here and the
+			# trailing shift below would fail under set -e. Skip the value-
+			# consuming shift in that case so the trailing shift consumes the
+			# flag itself and the loop exits naturally.
+			[[ $# -gt 1 ]] && shift
 			;;
 		--label=*)
 			label_val="${cur#--label=}"
@@ -246,7 +250,11 @@ _gh_wrapper_args_have_origin_label() {
 		case "$cur" in
 		--label)
 			label_val="${2:-}"
-			shift
+			# Guard the shift: if --label is the last arg, $#=1 here and the
+			# trailing shift below would fail under set -e. Skip the value-
+			# consuming shift in that case so the trailing shift consumes the
+			# flag itself and the loop exits naturally.
+			[[ $# -gt 1 ]] && shift
 			;;
 		--label=*)
 			label_val="${cur#--label=}"

--- a/.agents/scripts/tests/test-origin-label-mutex-create.sh
+++ b/.agents/scripts/tests/test-origin-label-mutex-create.sh
@@ -1,0 +1,376 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-origin-label-mutex-create.sh — t3088 regression guard.
+#
+# Companion to test-origin-label-exclusion.sh (which guards EDIT-path
+# sibling-removal via set_origin_label). This test guards the CREATE path:
+# gh_create_pr / gh_create_issue must produce EXACTLY ONE origin label, never
+# two.
+#
+# Failure motivating this test: marcusquinn/aidevops#21862 (PR #21825
+# accumulated both origin:interactive AND origin:worker on creation because
+# two independent code paths each appended a --label "origin:*" flag with
+# divergent values — full-loop-helper.sh's hand-rolled headless-env check
+# disagreed with detect_session_origin() in shared-gh-wrappers-session.sh).
+#
+# Three layers tested:
+#
+#   A. _gh_wrapper_args_have_origin_label — argv inspection helper used by
+#      the wrapper's defence-in-depth guard (Fix 3).
+#   B. gh_create_pr / gh_create_issue — wrapper self-injects origin label
+#      ONLY when the caller has not already specified one (Fix 3).
+#   C. full-loop-helper.sh / full-loop-helper-commit.sh — _create_pr no
+#      longer passes its own --label "$origin_label" (Fix 2), and the upstream
+#      origin_label computation now uses canonical session_origin_label() so
+#      env-var divergence with detect_session_origin() is impossible (Fix 1).
+
+set -uo pipefail
+
+TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_RED=$'\033[0;31m'
+TEST_GREEN=$'\033[0;32m'
+TEST_RESET=$'\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1" rc="$2" extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf '%sPASS%s %s\n' "$TEST_GREEN" "$TEST_RESET" "$name"
+	else
+		printf '%sFAIL%s %s %s\n' "$TEST_RED" "$TEST_RESET" "$name" "$extra"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+# Sandbox HOME so sourcing is side-effect-free
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+export HOME="${TEST_ROOT}/home"
+mkdir -p "${HOME}/.aidevops/logs" "${HOME}/.aidevops/.agent-workspace/supervisor"
+
+# Mock gh that records its arguments and prints a fake URL on create.
+# IMPORTANT: GH_RECORD_FILE must be exported so the gh-subshell call inside
+# the wrappers (gh pr create runs in $(...) ) sees it. Without export, the
+# mock writes to an empty $GH_RECORD_FILE and the recorder log silently stays
+# empty — wasted hours of debugging during the canonical t3088 fix.
+export GH_RECORD_FILE="${TEST_ROOT}/gh_calls.log"
+MOCK_BIN_DIR="${TEST_ROOT}/mockbin"
+mkdir -p "$MOCK_BIN_DIR"
+cat >"${MOCK_BIN_DIR}/gh" <<'MOCK'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${GH_RECORD_FILE}"
+# pr/issue create paths print a URL on stdout for caller capture
+case "$1 $2" in
+"pr create" | "issue create")
+	echo "https://example.invalid/test/repo/pull/0"
+	;;
+esac
+exit 0
+MOCK
+chmod +x "${MOCK_BIN_DIR}/gh"
+export PATH="${MOCK_BIN_DIR}:${PATH}"
+
+# Stub helpers that wrappers may invoke during create paths
+mkdir -p "${MOCK_BIN_DIR}"
+for stub in gh-signature-helper.sh _ensure_origin_labels_for_args; do
+	:
+done
+
+# Source the wrapper library under test. shared-gh-wrappers.sh is the
+# orchestrator that source-loads create + session sub-libraries.
+SHARED_GH="${TEST_SCRIPTS_DIR}/shared-gh-wrappers.sh"
+if [[ ! -f "$SHARED_GH" ]]; then
+	echo "FAIL setup: ${SHARED_GH} not found" >&2
+	exit 1
+fi
+# shellcheck source=/dev/null
+source "$SHARED_GH" >/dev/null 2>&1 || true
+
+# Stub _ensure_origin_labels_for_args (no-op — we don't care about label
+# provisioning, only about which --label flags reach gh)
+_ensure_origin_labels_for_args() { return 0; }
+
+# Stub _gh_wrapper_auto_sig (no-op — bypasses signature footer modification
+# so we don't have to plumb a fake helper path)
+_gh_wrapper_auto_sig() {
+	_GH_WRAPPER_SIG_MODIFIED_ARGS=("$@")
+	return 0
+}
+
+# Stub _gh_validate_edit_args (always pass — body validation isn't under test)
+_gh_validate_edit_args() { return 0; }
+
+# Stub _gh_should_fallback_to_rest (never fall back — REST path adds noise)
+_gh_should_fallback_to_rest() { return 1; }
+
+# Stub _gh_auto_link_sub_issue (no-op — sub-issue linkage isn't under test)
+_gh_auto_link_sub_issue() { return 0; }
+
+# Stub _gh_wrapper_auto_assignee (returns empty so issue create takes
+# the simple path — assignee logic isn't under test)
+_gh_wrapper_auto_assignee() { return 0; }
+
+# Stub _gh_wrapper_extract_task_id_from_title (returns empty — TODO label
+# derivation isn't under test)
+_gh_wrapper_extract_task_id_from_title() { return 0; }
+_gh_wrapper_derive_todo_labels() { return 0; }
+
+# Stub session_origin_label so we can deterministically control what the
+# wrapper would self-inject. Tests call it via env var SESSION_ORIGIN_OVERRIDE.
+session_origin_label() {
+	printf '%s' "${SESSION_ORIGIN_OVERRIDE:-origin:interactive}"
+}
+detect_session_origin() {
+	case "${SESSION_ORIGIN_OVERRIDE:-origin:interactive}" in
+	origin:worker) printf '%s' "worker" ;;
+	origin:worker-takeover) printf '%s' "worker-takeover" ;;
+	*) printf '%s' "interactive" ;;
+	esac
+}
+
+reset_recorder() { : >"${GH_RECORD_FILE}"; }
+
+count_origin_labels_in_log() {
+	# Count distinct origin:* labels that would actually reach GitHub
+	# from the most recent gh call. Treats comma-separated --label values
+	# the same way gh does (one label per comma-segment), so
+	#   --label bug,origin:worker         → 1 origin label
+	#   --label origin:worker --label origin:interactive → 2
+	#   --label origin:worker,origin:interactive          → 2 (would be a bug)
+	local last
+	last=$(tail -1 "${GH_RECORD_FILE}" 2>/dev/null || true)
+	[[ -z "$last" ]] && {
+		printf '0'
+		return 0
+	}
+	# Replace commas with spaces, then tokenise on whitespace and count
+	# tokens beginning with origin:.
+	local normalised="${last//,/ }"
+	local count=0
+	# shellcheck disable=SC2206
+	local tokens=($normalised)
+	for tok in "${tokens[@]}"; do
+		[[ "$tok" == origin:* ]] && count=$((count + 1))
+	done
+	printf '%d' "$count"
+}
+
+# ---------------------------------------------------------------------------
+# Layer A: _gh_wrapper_args_have_origin_label
+# ---------------------------------------------------------------------------
+
+# A1: detects --label origin:worker (space form)
+if _gh_wrapper_args_have_origin_label --label "origin:worker" --title "x"; then
+	print_result "A1: detects --label origin:worker (space form)" 0
+else
+	print_result "A1: detects --label origin:worker (space form)" 1 "expected 0, got 1"
+fi
+
+# A2: detects --label=origin:interactive (= form)
+if _gh_wrapper_args_have_origin_label --title "x" --label=origin:interactive; then
+	print_result "A2: detects --label=origin:interactive (= form)" 0
+else
+	print_result "A2: detects --label=origin:interactive (= form)" 1 "expected 0"
+fi
+
+# A3: detects origin label inside comma-separated list
+if _gh_wrapper_args_have_origin_label --label "bug,auto-dispatch,origin:worker"; then
+	print_result "A3: detects origin label in comma list" 0
+else
+	print_result "A3: detects origin label in comma list" 1 "expected 0"
+fi
+
+# A4: detects origin:worker-takeover
+if _gh_wrapper_args_have_origin_label --label "origin:worker-takeover"; then
+	print_result "A4: detects origin:worker-takeover" 0
+else
+	print_result "A4: detects origin:worker-takeover" 1 "expected 0"
+fi
+
+# A5: returns 1 when no origin label is present
+if ! _gh_wrapper_args_have_origin_label --label "bug" --label "auto-dispatch" --title "x"; then
+	print_result "A5: returns 1 when no origin label present" 0
+else
+	print_result "A5: returns 1 when no origin label present" 1 "false positive"
+fi
+
+# A6: returns 1 with no --label flags at all
+if ! _gh_wrapper_args_have_origin_label --title "x" --body "y"; then
+	print_result "A6: returns 1 with no --label flags" 0
+else
+	print_result "A6: returns 1 with no --label flags" 1 "false positive"
+fi
+
+# A7: does NOT match a label that merely contains origin: as a substring
+# (defensive — we anchor on commas so labels like "no-origin:worker" don't
+# false-match. They shouldn't exist, but the helper should be precise.)
+if ! _gh_wrapper_args_have_origin_label --label "thing-origin:worker-no"; then
+	print_result "A7: does not false-match substring" 0
+else
+	# Note: current implementation matches on ,origin:* with comma anchors,
+	# so this test verifies the anchor logic. If this fails, the helper has
+	# loosened to a substring match which would also flag legitimate non-origin
+	# labels containing "origin:" as a fragment.
+	print_result "A7: does not false-match substring" 1 "loose substring match"
+fi
+
+# ---------------------------------------------------------------------------
+# Layer B: gh_create_pr defence-in-depth
+# ---------------------------------------------------------------------------
+
+# B1: no caller origin → wrapper injects session origin (exactly one)
+reset_recorder
+SESSION_ORIGIN_OVERRIDE="origin:worker" \
+	gh_create_pr --repo o/r --title "t1: x" --body "Resolves #1" >/dev/null 2>&1
+n=$(count_origin_labels_in_log)
+if [[ "$n" == "1" ]]; then
+	print_result "B1: gh_create_pr with no caller origin → exactly 1 label" 0
+else
+	print_result "B1: gh_create_pr with no caller origin → exactly 1 label" 1 \
+		"got $n labels in: $(tail -1 "$GH_RECORD_FILE")"
+fi
+
+# B2: caller passes origin:worker → wrapper does NOT add session origin
+# (would otherwise produce 2 if session is interactive)
+reset_recorder
+SESSION_ORIGIN_OVERRIDE="origin:interactive" \
+	gh_create_pr --repo o/r --title "t1: x" --body "Resolves #1" \
+	--label "origin:worker" >/dev/null 2>&1
+n=$(count_origin_labels_in_log)
+if [[ "$n" == "1" ]]; then
+	# Also verify it's the caller's choice that won (worker, not interactive)
+	last=$(tail -1 "$GH_RECORD_FILE")
+	if [[ "$last" == *"origin:worker"* && "$last" != *"origin:interactive"* ]]; then
+		print_result "B2: gh_create_pr respects caller origin:worker (no dup)" 0
+	else
+		print_result "B2: gh_create_pr respects caller origin:worker (no dup)" 1 \
+			"caller intent overridden: $last"
+	fi
+else
+	print_result "B2: gh_create_pr respects caller origin:worker (no dup)" 1 \
+		"got $n labels in: $(tail -1 "$GH_RECORD_FILE")"
+fi
+
+# B3: caller passes origin:interactive while session is worker → caller wins
+reset_recorder
+SESSION_ORIGIN_OVERRIDE="origin:worker" \
+	gh_create_pr --repo o/r --title "t1: x" --body "Resolves #1" \
+	--label "origin:interactive" >/dev/null 2>&1
+n=$(count_origin_labels_in_log)
+if [[ "$n" == "1" ]]; then
+	last=$(tail -1 "$GH_RECORD_FILE")
+	if [[ "$last" == *"origin:interactive"* && "$last" != *"origin:worker"* ]]; then
+		print_result "B3: gh_create_pr respects caller origin:interactive over session origin:worker" 0
+	else
+		print_result "B3: gh_create_pr respects caller origin:interactive over session origin:worker" 1 \
+			"caller intent overridden: $last"
+	fi
+else
+	print_result "B3: gh_create_pr respects caller origin:interactive over session origin:worker" 1 \
+		"got $n labels in: $(tail -1 "$GH_RECORD_FILE")"
+fi
+
+# B4: caller passes origin in a comma-list → wrapper still skips self-injection
+reset_recorder
+SESSION_ORIGIN_OVERRIDE="origin:worker" \
+	gh_create_pr --repo o/r --title "t1: x" --body "Resolves #1" \
+	--label "bug,origin:worker" >/dev/null 2>&1
+n=$(count_origin_labels_in_log)
+if [[ "$n" == "1" ]]; then
+	print_result "B4: gh_create_pr respects origin in comma-list (no dup)" 0
+else
+	print_result "B4: gh_create_pr respects origin in comma-list (no dup)" 1 \
+		"got $n labels in: $(tail -1 "$GH_RECORD_FILE")"
+fi
+
+# ---------------------------------------------------------------------------
+# Layer B': gh_create_issue defence-in-depth (mirrors PR tests)
+# ---------------------------------------------------------------------------
+
+# B'1: no caller origin → wrapper injects session origin
+reset_recorder
+SESSION_ORIGIN_OVERRIDE="origin:worker" \
+	gh_create_issue --repo o/r --title "t1: x" --body "y" >/dev/null 2>&1
+n=$(count_origin_labels_in_log)
+if [[ "$n" == "1" ]]; then
+	print_result "B'1: gh_create_issue with no caller origin → exactly 1 label" 0
+else
+	print_result "B'1: gh_create_issue with no caller origin → exactly 1 label" 1 \
+		"got $n labels in: $(tail -1 "$GH_RECORD_FILE")"
+fi
+
+# B'2: caller passes origin:worker while session is interactive → caller wins
+reset_recorder
+SESSION_ORIGIN_OVERRIDE="origin:interactive" \
+	gh_create_issue --repo o/r --title "t1: x" --body "y" \
+	--label "origin:worker" >/dev/null 2>&1
+n=$(count_origin_labels_in_log)
+if [[ "$n" == "1" ]]; then
+	last=$(tail -1 "$GH_RECORD_FILE")
+	if [[ "$last" == *"origin:worker"* && "$last" != *"origin:interactive"* ]]; then
+		print_result "B'2: gh_create_issue respects caller origin:worker (no dup)" 0
+	else
+		print_result "B'2: gh_create_issue respects caller origin:worker (no dup)" 1 \
+			"caller intent overridden: $last"
+	fi
+else
+	print_result "B'2: gh_create_issue respects caller origin:worker (no dup)" 1 \
+		"got $n labels in: $(tail -1 "$GH_RECORD_FILE")"
+fi
+
+# ---------------------------------------------------------------------------
+# Layer C: structural checks on full-loop-helper-commit.sh
+# ---------------------------------------------------------------------------
+
+# C1: _create_pr no longer passes --label "$origin_label" itself
+# (gh_create_pr is the single origin-label injection point)
+COMMIT_HELPER="${TEST_SCRIPTS_DIR}/full-loop-helper-commit.sh"
+if [[ -f "$COMMIT_HELPER" ]]; then
+	# shellcheck disable=SC2016  # single-quoted regex pattern; $origin_label is literal
+	if ! grep -E '^\s*local -a pr_cmd=\(.*--label "?\$origin_label"?' "$COMMIT_HELPER" >/dev/null; then
+		print_result "C1: _create_pr does not pass --label \$origin_label to gh_create_pr" 0
+	else
+		print_result "C1: _create_pr does not pass --label \$origin_label to gh_create_pr" 1 \
+			"redundant --label \$origin_label still in pr_cmd"
+	fi
+else
+	print_result "C1: _create_pr structural check (file present)" 1 "$COMMIT_HELPER missing"
+fi
+
+# C2: full-loop-helper.sh uses session_origin_label (not a hand-rolled
+# env-var check) for its origin label
+LOOP_HELPER="${TEST_SCRIPTS_DIR}/full-loop-helper.sh"
+if [[ -f "$LOOP_HELPER" ]]; then
+	if grep -E '^\s*origin_label=\$\(session_origin_label\)' "$LOOP_HELPER" >/dev/null; then
+		print_result "C2: full-loop-helper.sh uses session_origin_label() (env-var unify)" 0
+	else
+		print_result "C2: full-loop-helper.sh uses session_origin_label() (env-var unify)" 1 \
+			"hand-rolled origin detection still present"
+	fi
+else
+	print_result "C2: full-loop-helper.sh structural check (file present)" 1 "$LOOP_HELPER missing"
+fi
+
+# C3: full-loop-helper.sh does NOT carry the legacy hand-rolled HEADLESS check
+# (anchor: a literal `if [[ "${HEADLESS:-0}" == "1"` near origin_label assignment)
+if [[ -f "$LOOP_HELPER" ]]; then
+	if ! grep -E '^\s*if \[\[ "\$\{HEADLESS:-0\}" == "1"' "$LOOP_HELPER" >/dev/null; then
+		print_result "C3: full-loop-helper.sh has no legacy HEADLESS=1 hand-rolled check" 0
+	else
+		print_result "C3: full-loop-helper.sh has no legacy HEADLESS=1 hand-rolled check" 1 \
+			"legacy hand-rolled check still present"
+	fi
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+printf '\n%d tests run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]]

--- a/TODO.md
+++ b/TODO.md
@@ -3611,7 +3611,7 @@ t019.3.4,Update AGENTS.md with Beads integration docs,,beads,1h,45m,2025-12-21T1
 
 - [x] t3084 Fix pulse-unbound-var-check false-positives on stale-base PRs #auto-dispatch #bug #ci ref:GH#21855 pr:#21872 completed:2026-04-30
 
-- [ ] t3088 investigate: PR #21825 had both origin:interactive and origin:worker labels (t2200 violation) #bug #parent ref:GH#21862
+- [ ] t3088 fix dual origin label on worker-dispatched PRs (env-var divergence + redundant --label) #bug ref:GH#21862
 
 - [ ] t3087 ci: make ShellCheck (macos-latest) a required branch protection check on main #ci #enhancement ref:GH#21861
 


### PR DESCRIPTION
## Summary

Eliminates the dual-origin-label bug on worker-dispatched PRs (canonical incident: #21825 had both `origin:interactive` AND `origin:worker`, violating the t2200 mutual-exclusion invariant).

## Root Cause

Two independent `--label` injections with **divergent values** in `full-loop-helper.sh` → `_create_pr` → `gh_create_pr`:

1. **`full-loop-helper.sh:96-99`** hand-rolled a headless-env check that recognised only `HEADLESS=1` and `FULL_LOOP_HEADLESS=true`. Workers running under `AIDEVOPS_HEADLESS=true` (without `FULL_LOOP_HEADLESS`) computed `origin:interactive`.
2. **`_create_pr`** passed `--label "$origin_label"` to `gh_create_pr`, which **also** self-injected via canonical `session_origin_label()` (recognising `AIDEVOPS_HEADLESS`, `OPENCODE_HEADLESS`, `GITHUB_ACTIONS`, `AIDEVOPS_SESSION_ORIGIN`).
3. When the two disagreed, GitHub applied **both** labels. The previous comment "GitHub deduplicates" was correct only for **identical** labels.

## Fixes (3 layers)

- **Fix 1 — root cause** (`full-loop-helper.sh`): use `session_origin_label()` directly. Single source of truth for session origin detection.
- **Fix 2 — collision elimination** (`full-loop-helper-commit.sh::_create_pr`): drop the redundant `--label "$origin_label"` from the `pr_cmd` array. `gh_create_pr` is now the only origin-label injection point. The `origin_label` parameter is retained for backward compat.
- **Fix 3 — defence-in-depth** (`shared-gh-wrappers-create.sh::gh_create_pr` and `gh_create_issue`): skip self-injection when the caller already passed an `origin:*` label. New helper `_gh_wrapper_args_have_origin_label` (in `shared-gh-wrappers-session.sh`) inspects argv supporting both `--label X` and `--label=X` forms plus comma-separated lists, comma-anchored to prevent substring false positives.

## Why all three layers

Fix 1 alone would close the env-var divergence symptom. But Fix 2 is needed because `_create_pr`'s explicit `--label` would still produce duplicates if the parameter ever gets out of sync with the wrapper's self-detection. Fix 3 is defence-in-depth for any **other** caller in the codebase (e.g. `parent-task-helper.sh:266` explicitly sets `origin:worker` on enrichment) that might otherwise collide with the wrapper's auto-injection.

## Files Changed

- **EDIT**: `.agents/scripts/full-loop-helper.sh:96-106` — env-var unify
- **EDIT**: `.agents/scripts/full-loop-helper-commit.sh:760-790` — drop redundant `--label`
- **EDIT**: `.agents/scripts/shared-gh-wrappers-session.sh` — add `_gh_wrapper_args_have_origin_label` helper
- **EDIT**: `.agents/scripts/shared-gh-wrappers-create.sh` — guard `gh_create_pr` and `gh_create_issue` against caller-supplied origin
- **NEW**: `.agents/scripts/tests/test-origin-label-mutex-create.sh` — 16-case regression suite (Layer A: helper unit tests, Layer B: wrapper defence-in-depth, Layer C: structural checks)
- **EDIT**: `TODO.md` — entry refined from "investigate" to "fix"

## Verification

- `bash .agents/scripts/tests/test-origin-label-mutex-create.sh` — 16/16 PASS
- `bash .agents/scripts/tests/test-origin-label-exclusion.sh` — 11/11 PASS (no regression in the existing edit-path mutex)
- `shellcheck` clean on all 5 modified scripts (only pre-existing info-level SC2016 on intentional single-quoted GraphQL queries)
- `gh-wrapper-guard.sh check --base origin/main` clean (3 wrapper-self lines correctly suppressed)
- PR #21825 reconciled to single `origin:worker` via `set_origin_label`
- `reconcile-origin-labels.sh --repo marcusquinn/aidevops --dry-run` confirms no other dual-origin violators

## Acceptance Criteria (from #21862)

- [x] Identify all code paths that emit `--label "origin:*"` at create time and ensure exactly one origin label is set per create operation
- [x] Add CI/test coverage for the dual-origin-on-create case
- [x] Reconcile any historical violators (PR #21825 fixed)
- [x] Update or replace the misleading "GitHub deduplicates" comment

Resolves #21862

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.14 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-opus-4-7 spent 28m and 28,731 tokens on this with the user in an interactive session.
