### PR TITLE
t3193: pulse-merge stuck detector + zero-progress circuit breaker

### DIFF
--- a/.agents/configs/pulse-merge-stuck.conf
+++ b/.agents/configs/pulse-merge-stuck.conf
@@ -1,0 +1,52 @@
+# pulse-merge-stuck.conf — Stuck-merge detector thresholds (t3193, GH#21895)
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Thresholds for the stuck-merge detector in pulse-merge-stuck.sh.
+# Sourceable by bash: source .agents/configs/pulse-merge-stuck.conf
+# Env vars take precedence over this file — consumers check whether the
+# env var is already set before sourcing.
+#
+# Format: KEY=VALUE (no spaces around =, no quotes needed).
+# Lines starting with # are comments.
+#
+# Background (t3193): the pulse historically had two narrow stuck-state
+# nudges (CONFLICTING + origin:interactive, CONFLICTING + contributor) but
+# no general "merge-eligible but stuck" detector. PRs that sat APPROVED +
+# MERGEABLE for hours with non-required checks failing, transient
+# branch-protection 401s, or `update-branch` failures were re-evaluated
+# silently every cycle. The detector classifies these stuck states and
+# either escalates them (one-shot worker-ready comment, dedup'd by HTML
+# marker) or files an investigation issue (when ≥N PRs share a failure
+# fingerprint = broken-base outage signal).
+
+# ── Per-PR escalation threshold ───────────────────────────────────────────────
+# Minimum age in MINUTES that a stuck PR must accumulate before the detector
+# files an escalation comment. Default 240 min (4 hours) — long enough that a
+# transient CI flake or a maintainer rebasing manually can resolve before the
+# detector fires, short enough that a real outage is surfaced within one work
+# session.
+AIDEVOPS_MERGE_STUCK_AGE_MINUTES=240
+
+# ── Zero-progress circuit-breaker ─────────────────────────────────────────────
+# Number of consecutive pulse cycles with eligible-unmerged > 0 AND merged = 0
+# before the detector files a meta-issue describing the throughput collapse.
+# Resets to 0 on any successful merge. Default 5 cycles ≈ 10 min at the
+# default 120s pulse interval — fast enough to surface a structural break
+# (broken canonical lockfile, quota exhaustion, branch-protection misconfig)
+# while ignoring single-cycle transients.
+AIDEVOPS_MERGE_ZERO_PROGRESS_CYCLES=5
+
+# ── Pattern-cluster threshold ─────────────────────────────────────────────────
+# Minimum number of stuck PRs that must share an identical failure fingerprint
+# (sorted set of FAILURE check names) before the detector files an outage
+# investigation issue. Default 3 — enough that 2-PR coincidences (a worker
+# fixing the same bug twice) don't trip the meta-issue, low enough that a
+# real broken-base outage surfaces within minutes.
+AIDEVOPS_MERGE_PATTERN_MIN_PRS=3
+
+# ── Module enable/disable (escape hatch) ──────────────────────────────────────
+# Set to 0 to disable the detector entirely. The pulse merge pass is
+# unaffected — only the stuck-state classification and escalation paths are
+# skipped. Default 1 (on).
+AIDEVOPS_MERGE_STUCK_ENABLED=1

--- a/.agents/reference/pulse-merge-stuck.md
+++ b/.agents/reference/pulse-merge-stuck.md
@@ -1,0 +1,143 @@
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+# Stuck-merge detector and zero-progress circuit breaker (t3193, GH#21895)
+
+The pulse merge pass historically had two narrow nudges (rebase reminders for
+`origin:interactive` PRs in conflict, fix-worker dispatch for `origin:worker`
+PRs in conflict) but no general detector for PRs that pass `APPROVED +
+MERGEABLE` yet sit unmerged for hours. The 2026-04-30 incident in a managed
+private webapp repo — 8 PRs stuck 9-29h, six sharing identical Setup-step CI
+failures — is the canonical case this module addresses.
+
+## What it does
+
+Once per pulse cycle (~120s), per repo, after the deterministic merge pass:
+
+1. **Classifies** every open PR that is `APPROVED + MERGEABLE + !draft +
+   !hold-for-review` and idle past `AIDEVOPS_MERGE_STUCK_AGE_MINUTES` (default
+   240 = 4h) into one of six classes — see "Classifications" below.
+2. **Counts** stuck PRs into the `pulse_merge_eligible_stuck_pr_count` gauge.
+3. **Escalates per-PR** with a single worker-ready comment on the linked
+   issue (or PR if no linked issue), keyed off the
+   `<!-- merge-stuck:individual -->` HTML marker so repeat cycles do not spam.
+4. **Detects pattern outages** — when ≥`AIDEVOPS_MERGE_PATTERN_MIN_PRS` (default
+   3) PRs share the same failure fingerprint (sorted set of FAILURE check
+   names, hashed to 16 hex chars), files **one** investigation meta-issue per
+   fingerprint dedup'd by `<!-- merge-stuck:pattern:<hash16> -->`.
+5. **Tracks zero-progress** across all repos. If a cycle has eligible-but-
+   unmerged PRs and zero merges, the `pulse_merge_zero_progress_cycles` gauge
+   increments. Reaching `AIDEVOPS_MERGE_ZERO_PROGRESS_CYCLES` (default 5
+   consecutive cycles ≈ 10 minutes) files a framework-level meta-issue at
+   `marcusquinn/aidevops` dedup'd by `<!-- merge-stuck:zero-progress -->`.
+   A successful merge in any subsequent cycle resets the gauge to 0.
+
+## Classifications
+
+| Class | Trigger | Action |
+| --- | --- | --- |
+| `STUCK_CHECKS_FAILING` | ≥1 FAILURE in `statusCheckRollup`, no conflict | Per-PR escalation |
+| `STUCK_CONFLICT_NO_NUDGE_LABEL` | `mergeable=CONFLICTING` + neither `origin:interactive` nor `origin:worker` (gap in the existing rebase-nudge family) | Idempotent rebase nudge using `<!-- pulse-rebase-nudge -->` so it cannot double-fire alongside the per-label nudges |
+| `STUCK_BRANCHPROTECT_404` | Default branch has no protection rules — `_check_required_checks_passing` historically failed closed (t2922) on the 404 | Counter increment only; the actual fix is in `pulse-merge-process.sh` (see "404 distinction" below) |
+| `STUCK_BRANCHPROTECT_API_ERROR` | 5xx / network from the protection API | Counter increment only — transient, retry next cycle |
+| `STUCK_AUTH` | 401 / "bad credentials" from any `gh` call | Counter increment only — operator action required |
+| `STUCK_OTHER` | Eligible + idle but no distinct signal | Counter increment only |
+
+## Configuration
+
+Canonical defaults live in `.agents/configs/pulse-merge-stuck.conf`. Env vars
+take precedence (set in `~/.aidevops/.env` or shell):
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `AIDEVOPS_MERGE_STUCK_AGE_MINUTES` | `240` | Idle threshold (minutes) — only PRs idle this long are classified. |
+| `AIDEVOPS_MERGE_ZERO_PROGRESS_CYCLES` | `5` | Consecutive zero-progress cycles before the framework-level meta-issue fires. |
+| `AIDEVOPS_MERGE_PATTERN_MIN_PRS` | `3` | Minimum stuck PRs sharing one fingerprint before an outage meta-issue fires. |
+| `AIDEVOPS_MERGE_STUCK_ENABLED` | `1` | Master kill-switch (set to `0` to disable the entire module). |
+
+## 404 distinction in `_check_required_checks_passing`
+
+`pulse-merge-process.sh::_check_required_checks_passing` historically failed
+closed on **any** non-zero exit from the branch-protection API call (t2922).
+This silently blocked merges on repos with **no branch protection rules** —
+the most common shape for personal/draft repos and the canonical `origin/main`
+of every fresh aidevops-init'd repo.
+
+t3193 tightens the failure mode: HTTP 404 (no protection) returns 0 (allow),
+falling through to the actual rollup gate (`_pr_required_checks_pass`) which
+already evaluates real check state. Any other failure (401, 403, 5xx, network
+error) preserves the t2922 fail-closed behaviour so an auth break cannot
+silently unblock a stale fork PR.
+
+## Dedup markers
+
+Each escalation uses an idempotent HTML marker so repeat cycles do not spam:
+
+| Marker | Where | Lifecycle |
+| --- | --- | --- |
+| `<!-- merge-stuck:individual -->` | Issue (or PR) comment | One per linked issue. Survives repeat stuck cycles. A new cycle on a different stuck PR linked to the same issue will not re-fire. |
+| `<!-- merge-stuck:pattern:<hash16> -->` | Outage meta-issue body | One per failure fingerprint (sorted FAILURE check names, sha256 first 16 hex chars). Different outage signatures get different issues. |
+| `<!-- merge-stuck:zero-progress -->` | Framework meta-issue body | One per active streak. Reset by any successful merge. |
+| `<!-- pulse-rebase-nudge -->` | Reused from existing nudge family | Reused so `STUCK_CONFLICT_NO_NUDGE_LABEL` cannot double-fire alongside `_post_rebase_nudge_on_*`. |
+
+## Counters added
+
+All four are written to `~/.aidevops/logs/pulse-stats.json`:
+
+| Counter | Type | Reset condition |
+| --- | --- | --- |
+| `pulse_merge_eligible_stuck_pr_count` | Gauge | Overwritten each cycle |
+| `pulse_merge_zero_progress_cycles` | Gauge | Reset to 0 on any successful merge |
+| `pulse_merge_branchprotect_404_skips` | Event counter | 24h rolling window (per t2424 pattern) |
+| `pulse_merge_stuck_escalations_filed` | Event counter | 24h rolling window |
+
+The first two use the new `pulse_stats_set_gauge` / `pulse_stats_get_gauge`
+functions in `pulse-stats-helper.sh` — gauges store under `.gauges.<name>`
+and represent a single current value, distinct from the per-event counter
+namespace.
+
+## Suppression: pulse circuit breaker interaction
+
+When `pulse_dispatch_circuit_broken` (the t2690 GraphQL emergency floor) has
+fired in the last 24h, the zero-progress meta-issue is **suppressed** —
+filing a "pulse made no progress" investigation when the circuit breaker is
+already advertising its own cause would only create noise. The per-PR
+escalations and pattern-outage meta-issues are NOT suppressed; they remain
+useful even during a rate-limit event.
+
+## Disabling
+
+Set `AIDEVOPS_MERGE_STUCK_ENABLED=0` in your env. The module's entry point
+`pulse_merge_stuck_run_pass` short-circuits on the disabled flag.
+
+## Test surface
+
+`.agents/scripts/tests/test-pulse-merge-stuck.sh` covers:
+
+- conf file integrity (4 entries present)
+- defaults applied as positive integers post-source
+- `_pms_iso_to_epoch` round-trip + garbage rejection
+- `_pms_hash_fingerprint` 16-char hex output, deterministic, distinct inputs
+- `pulse_stats_set_gauge` / `pulse_stats_get_gauge` round-trip + non-numeric
+  rejection + gauge isolation
+- `pulse_merge_zero_progress_record` state transitions (reset on merge,
+  no-op on idle, increment on stuck cycle)
+- shellcheck cleanliness on the module + the stats helper
+
+Functions that require live GitHub API (`_classify_stuck_pr`,
+`_escalate_individual_stuck_pr`, `pulse_merge_stuck_run_pass`,
+`_pms_count_eligible_unmerged_for_repo`) are not unit-tested — they're
+integration-level and exercise live PRs each pulse cycle.
+
+## Related
+
+- `pulse-merge-process.sh` — the deterministic merge pass; the module hooks
+  in via `merge_ready_prs_all_repos`.
+- `pulse-merge-conflict.sh` — the existing per-label rebase-nudge family.
+- `pulse-merge-feedback.sh` — the conflict-feedback dispatch path.
+- `reference/auto-merge.md` — full merge-gate semantics.
+- `reference/cross-runner-coordination.md` — pulse cycle infrastructure.
+- t2922 — the original fail-closed change in `_check_required_checks_passing`
+  that t3193 partially tightens.
+- t2690 — the pulse dispatch circuit breaker that suppresses the
+  zero-progress meta-issue.

--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -76,6 +76,10 @@ merge_ready_prs_all_repos() {
 	local total_closed=0
 	local total_failed=0
 
+	# t3193: track eligible-but-unmerged across all repos for the zero-progress
+	# circuit breaker. Eligible = APPROVED + MERGEABLE + !draft + !hold-for-review.
+	local total_eligible_unmerged=0
+
 	while IFS='|' read -r repo_slug repo_path; do
 		[[ -n "$repo_slug" ]] || continue
 
@@ -89,13 +93,36 @@ merge_ready_prs_all_repos() {
 		total_closed=$((total_closed + repo_closed))
 		total_failed=$((total_failed + repo_failed))
 
+		# t3193: run the stuck-merge detector pass for this repo. Resolves
+		# at runtime via bash lazy lookup — defined in pulse-merge-stuck.sh
+		# which is sourced by pulse-wrapper.sh after pulse-merge.sh.
+		if declare -F pulse_merge_stuck_run_pass >/dev/null 2>&1; then
+			pulse_merge_stuck_run_pass "$repo_slug" || true
+		fi
+
+		# t3193: count this repo's eligible-but-unmerged contribution to the
+		# all-repos total. Cheap second pass (uses the same gh pr list cache
+		# that the merge pass already warmed for the iteration window).
+		if declare -F _pms_count_eligible_unmerged_for_repo >/dev/null 2>&1; then
+			local _repo_eligible
+			_repo_eligible=$(_pms_count_eligible_unmerged_for_repo "$repo_slug" 2>/dev/null) || _repo_eligible=0
+			[[ "$_repo_eligible" =~ ^[0-9]+$ ]] || _repo_eligible=0
+			total_eligible_unmerged=$((total_eligible_unmerged + _repo_eligible))
+		fi
+
 		if [[ -f "$_mr_stop_flag" ]]; then
 			echo "[pulse-wrapper] Deterministic merge pass: stop flag appeared mid-run" >>"$_mr_logfile"
 			break
 		fi
 	done < <(jq -r '.initialized_repos[] | select(.pulse == true and (.local_only // false) == false and .slug != "") | [.slug, .path] | join("|")' "$_mr_repos_json" 2>/dev/null)
 
-	echo "[pulse-wrapper] Deterministic merge pass complete: merged=${total_merged}, closed_conflicting=${total_closed}, failed=${total_failed}" >>"$_mr_logfile"
+	# t3193: record the zero-progress signal AFTER all repos have been processed.
+	# Resolves at runtime via bash lazy lookup (pulse-merge-stuck.sh).
+	if declare -F pulse_merge_zero_progress_record >/dev/null 2>&1; then
+		pulse_merge_zero_progress_record "$total_eligible_unmerged" "$total_merged" || true
+	fi
+
+	echo "[pulse-wrapper] Deterministic merge pass complete: merged=${total_merged}, closed_conflicting=${total_closed}, failed=${total_failed}, eligible_unmerged=${total_eligible_unmerged}" >>"$_mr_logfile"
 	# Write health counter deltas to a temp file (GH#18571, GH#15107).
 	# run_stage_with_timeout backgrounds this function in a subshell, so
 	# direct updates to _PULSE_HEALTH_* variables are lost on return.
@@ -684,30 +711,74 @@ _attempt_worker_briefed_auto_merge() {
 # Args: $1=repo_slug, $2=pr_number
 # Returns: 0=all required contexts passing, 1=some not passing or API error
 #######################################
-_check_required_checks_passing() {
+#######################################
+# Resolve the newline-delimited list of required status check contexts
+# for $repo_slug's default branch. Extracted from _check_required_checks_passing
+# (t3193) to keep that function under the 100-line complexity gate.
+#
+# Args: $1=repo_slug
+# Stdout: required contexts (one per line). Empty when the default branch
+#         has no protection (HTTP 404) or no required contexts configured —
+#         BOTH cases are "no enforcement required" and the caller treats them
+#         as PASS (t3193 supersedes t2922 fail-closed for the 404 case).
+# Returns:
+#   0 — contexts resolved (may be empty per above)
+#   1 — real error (default branch resolve failed, or non-404 API error) —
+#       caller MUST fail closed to preserve t2922 invariant.
+#######################################
+_required_contexts_for_default_branch() {
 	local repo_slug="$1"
-	local pr_number="$2"
-
-	# Resolve default branch (required to query branch protection endpoint).
-	local default_branch _db_exit
-	default_branch=$(gh api "repos/${repo_slug}" \
-		--jq '.default_branch' 2>/dev/null)
+	local default_branch="" _db_exit=0
+	default_branch=$(gh api "repos/${repo_slug}" --jq '.default_branch' 2>/dev/null)
 	_db_exit=$?
 	if [[ $_db_exit -ne 0 || -z "$default_branch" ]]; then
-		echo "[pulse-merge] _check_required_checks_passing: failed to resolve default branch for ${repo_slug} — failing closed (t2922)" >>"$LOGFILE"
+		echo "[pulse-merge] _required_contexts_for_default_branch: failed to resolve default branch for ${repo_slug} — caller will fail closed (t2922)" >>"$LOGFILE"
 		return 1
 	fi
 
 	# Fetch required contexts from branch protection — authoritative list.
-	local required_contexts _rc_exit
-	required_contexts=$(gh api \
+	# t3193: capture stderr separately so HTTP 404 (no protection on the
+	# default branch) can be distinguished from real API errors (auth fail,
+	# 5xx, network). The collapsed `--jq | 2>/dev/null` form previously
+	# treated 404 the same as 401, causing the caller to fail closed on
+	# intentionally-unprotected default branches and blocking the worker-
+	# briefed merge cascade.
+	local protection_resp="" _rc_exit=0
+	protection_resp=$(gh api \
 		"repos/${repo_slug}/branches/${default_branch}/protection/required_status_checks" \
-		--jq '.contexts // [] | .[]' 2>/dev/null)
+		2>&1)
 	_rc_exit=$?
 	if [[ $_rc_exit -ne 0 ]]; then
-		echo "[pulse-merge] _check_required_checks_passing: branch protection API failed for ${repo_slug} (exit ${_rc_exit}) — failing closed (t2922)" >>"$LOGFILE"
+		# HTTP 404 = the default branch has no protection rules. Print empty
+		# and return success so the caller's rollup gate runs instead of
+		# fail-closed.
+		if grep -qi 'HTTP 404\|Not Found' <<<"$protection_resp"; then
+			echo "[pulse-merge] _required_contexts_for_default_branch: no branch protection on ${repo_slug} default branch (HTTP 404) — empty contexts (t3193)" >>"$LOGFILE"
+			printf ''
+			return 0
+		fi
+		# Any other failure (401, 403, 5xx, network) is a real error — keep
+		# the t2922 fail-closed behaviour so an auth break doesn't silently
+		# unblock a stale fork PR.
+		echo "[pulse-merge] _required_contexts_for_default_branch: branch protection API failed for ${repo_slug} (exit ${_rc_exit}) — caller will fail closed (t2922)" >>"$LOGFILE"
 		return 1
 	fi
+
+	# Extract required contexts from the JSON response.
+	printf '%s' "$protection_resp" \
+		| jq -r '.contexts // [] | .[]' 2>/dev/null || true
+	return 0
+}
+
+_check_required_checks_passing() {
+	local repo_slug="$1"
+	local pr_number="$2"
+
+	# Resolve required contexts (delegates default-branch lookup + branch
+	# protection API + 404 distinction to the helper). Empty stdout + exit 0
+	# means "no enforcement required, treat as PASS"; exit 1 means real error.
+	local required_contexts=""
+	required_contexts=$(_required_contexts_for_default_branch "$repo_slug") || return 1
 
 	# No required contexts → nothing required, treat as passing.
 	if [[ -z "$required_contexts" ]]; then

--- a/.agents/scripts/pulse-merge-routine.sh
+++ b/.agents/scripts/pulse-merge-routine.sh
@@ -110,6 +110,10 @@ source "${SCRIPT_DIR}/pulse-merge.sh"
 source "${SCRIPT_DIR}/pulse-merge-conflict.sh"
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}/pulse-merge-feedback.sh"
+# t3193: stuck-merge detector module — sourced after the conflict/feedback
+# downstream modules so its functions resolve via bash lazy lookup.
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/pulse-merge-stuck.sh"
 
 # =============================================================================
 # Env-var defaults (belt-and-suspenders — also guarded inside the function)

--- a/.agents/scripts/pulse-merge-stuck.sh
+++ b/.agents/scripts/pulse-merge-stuck.sh
@@ -1,0 +1,881 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# pulse-merge-stuck.sh — Stuck-merge detector + escalation router (t3193, GH#21895).
+#
+# This module classifies APPROVED + MERGEABLE PRs that have been sitting
+# unmerged past a threshold and either:
+#   (a) escalates them with a one-shot worker-ready comment on the linked
+#       issue (per-PR; dedup'd by HTML marker), or
+#   (b) files an investigation meta-issue when ≥N stuck PRs in the same repo
+#       share an identical failure fingerprint (broken-base outage signal),
+#       dedup'd by fingerprint hash.
+#
+# Sourced by pulse-wrapper.sh AFTER pulse-merge.sh, mirroring the
+# pulse-merge-conflict.sh / pulse-merge-feedback.sh pattern. Bash's lazy
+# function name resolution lets us call _extract_linked_issue (defined in
+# pulse-merge.sh) and _gh_idempotent_comment (defined in pulse-triage-cache.sh)
+# at runtime without source-time ordering constraints.
+#
+# Module entry point (called once per pulse cycle, per repo):
+#   pulse_merge_stuck_run_pass <repo_slug>
+#     Iterates open PRs, increments per-PR/per-cycle counters, fires
+#     individual escalations, and detects pattern outages.
+#
+# Module-internal classifier (returns one of six string outcomes):
+#   _classify_stuck_pr <pr_number> <repo_slug>
+#     STUCK_CHECKS_FAILING            — ≥1 FAILURE in rollup, no conflict
+#     STUCK_CONFLICT_NO_NUDGE_LABEL   — CONFLICTING + no origin:interactive
+#                                       and no origin:worker (gap in existing
+#                                       rebase-nudge family)
+#     STUCK_BRANCHPROTECT_404         — default branch unprotected; the
+#                                       _check_required_checks_passing
+#                                       fail-closed path mis-fires
+#     STUCK_BRANCHPROTECT_API_ERROR   — transient 401/5xx from protection API
+#     STUCK_AUTH                      — gh auth-failed signature
+#     STUCK_OTHER                     — mergeable + approved + idle but no
+#                                       distinct signal
+#
+# Background (t3193):
+#   The pulse had rich deterministic merge gates and two narrow stuck-state
+#   nudges (pulse-merge-conflict.sh::_post_rebase_nudge_on_*) but no general
+#   detector. Operational evidence (managed private webapp repo, 2026-04-30
+#   ~14:00Z) showed 8 PRs stuck 9-29h: 6 sharing identical Setup-step CI
+#   failures (broken-base signal), 2 docs/migration with mergeStateStatus=DIRTY
+#   and no nudge label. No pulse-stats counter trips, no investigation issue
+#   filed, no worker dispatched. This module fills that gap.
+
+# Include guard
+[[ -n "${_PULSE_MERGE_STUCK_LOADED:-}" ]] && return 0
+_PULSE_MERGE_STUCK_LOADED=1
+
+# Module-level variable defaults (set -u guards). When sourced standalone
+# (test harness, pulse-merge-routine.sh) the pulse-wrapper.sh bootstrap has
+# NOT run; guard each bare var so set -u does not abort.
+: "${LOGFILE:=${HOME}/.aidevops/logs/pulse.log}"
+
+# Source the pulse-stats helper for gauge/counter writes.
+_PULSE_MERGE_STUCK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./pulse-stats-helper.sh
+# shellcheck disable=SC1091
+source "${_PULSE_MERGE_STUCK_DIR}/pulse-stats-helper.sh"
+
+# Load thresholds from the canonical config file (env vars take precedence).
+# The conf file lives at .agents/configs/pulse-merge-stuck.conf; we resolve
+# from _PULSE_MERGE_STUCK_DIR (../configs/pulse-merge-stuck.conf).
+_PULSE_MERGE_STUCK_CONF="${_PULSE_MERGE_STUCK_DIR}/../configs/pulse-merge-stuck.conf"
+if [[ -f "$_PULSE_MERGE_STUCK_CONF" ]]; then
+	# Only source values for vars that aren't already set by the env.
+	# shellcheck source=/dev/null
+	[[ -z "${AIDEVOPS_MERGE_STUCK_AGE_MINUTES:-}" ]] && \
+		AIDEVOPS_MERGE_STUCK_AGE_MINUTES=$(grep -E '^AIDEVOPS_MERGE_STUCK_AGE_MINUTES=' "$_PULSE_MERGE_STUCK_CONF" 2>/dev/null | tail -1 | cut -d= -f2)
+	[[ -z "${AIDEVOPS_MERGE_ZERO_PROGRESS_CYCLES:-}" ]] && \
+		AIDEVOPS_MERGE_ZERO_PROGRESS_CYCLES=$(grep -E '^AIDEVOPS_MERGE_ZERO_PROGRESS_CYCLES=' "$_PULSE_MERGE_STUCK_CONF" 2>/dev/null | tail -1 | cut -d= -f2)
+	[[ -z "${AIDEVOPS_MERGE_PATTERN_MIN_PRS:-}" ]] && \
+		AIDEVOPS_MERGE_PATTERN_MIN_PRS=$(grep -E '^AIDEVOPS_MERGE_PATTERN_MIN_PRS=' "$_PULSE_MERGE_STUCK_CONF" 2>/dev/null | tail -1 | cut -d= -f2)
+	[[ -z "${AIDEVOPS_MERGE_STUCK_ENABLED:-}" ]] && \
+		AIDEVOPS_MERGE_STUCK_ENABLED=$(grep -E '^AIDEVOPS_MERGE_STUCK_ENABLED=' "$_PULSE_MERGE_STUCK_CONF" 2>/dev/null | tail -1 | cut -d= -f2)
+fi
+
+# Hard defaults for any value the conf didn't supply. Validated as positive
+# integers downstream — non-numeric here would silently break arithmetic.
+: "${AIDEVOPS_MERGE_STUCK_AGE_MINUTES:=240}"
+: "${AIDEVOPS_MERGE_ZERO_PROGRESS_CYCLES:=5}"
+: "${AIDEVOPS_MERGE_PATTERN_MIN_PRS:=3}"
+: "${AIDEVOPS_MERGE_STUCK_ENABLED:=1}"
+
+# ── Constants (literal-dedup) ────────────────────────────────────────────────
+# Counter and gauge names that would otherwise repeat 3+ times in the body
+# and trip the pre-commit string-literal ratchet.
+readonly _PMS_COUNTER_ESCALATIONS_FILED="pulse_merge_stuck_escalations_filed"
+readonly _PMS_GAUGE_ZERO_PROGRESS_CYCLES='pulse_merge_zero_progress_cycles'
+readonly _PMS_JQ_NULL_GUARD="null"
+# jq filter snippet that selects array elements with a FAILURE rollup
+# conclusion or state. Extracted so the underlying upcase predicate is
+# defined exactly once (via a jq `def`) and reused for both the new-style
+# `.conclusion` and the legacy `.state` field — which is sometimes
+# lower-case for older commit-status checks.
+readonly _PMS_JQ_FAILURE_SELECTOR='def _ueq(f;v): (f // "" | ascii_upcase) == v; select(_ueq(.conclusion; "FAILURE") or _ueq(.state; "FAILURE"))'
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+# Convert ISO 8601 timestamp to epoch seconds. Bash 3.2 portable; uses GNU
+# date if available, falls back to BSD `date -j`. Echoes "0" on failure.
+_pms_iso_to_epoch() {
+	local iso="$1"
+	local result
+	result=$(date -d "$iso" +%s 2>/dev/null) \
+		|| result=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$iso" +%s 2>/dev/null) \
+		|| result=0
+	[[ "$result" =~ ^[0-9]+$ ]] || result=0
+	printf '%s' "$result"
+	return 0
+}
+
+# Check whether a PR is "merge-eligible but stuck" — APPROVED + MERGEABLE
+# (or CONFLICTING with a nudge label gap), not draft, no hold-for-review.
+# Echoes "1" if eligible-stuck, "0" otherwise.
+#
+# Args: $1 = compact PR JSON object (number, mergeable, reviewDecision,
+#             isDraft, labels, updatedAt)
+_pms_is_eligible_stuck() {
+	local pr_obj="$1"
+	local mergeable="" review_decision="" is_draft="" labels=""
+	mergeable=$(printf '%s' "$pr_obj" | jq -r '.mergeable // "UNKNOWN"' 2>/dev/null)
+	review_decision=$(printf '%s' "$pr_obj" | jq -r '.reviewDecision // ""' 2>/dev/null)
+	is_draft=$(printf '%s' "$pr_obj" | jq -r '.isDraft // false' 2>/dev/null)
+	labels=$(printf '%s' "$pr_obj" | jq -r '[.labels[].name] | join(",")' 2>/dev/null)
+
+	# Skip drafts unconditionally
+	[[ "$is_draft" == "true" ]] && { printf '0'; return 0; }
+	# Skip hold-for-review opt-out
+	[[ "$labels" == *"hold-for-review"* ]] && { printf '0'; return 0; }
+	# CHANGES_REQUESTED is a real review block, not a stuck state
+	[[ "$review_decision" == "CHANGES_REQUESTED" ]] && { printf '0'; return 0; }
+
+	# MERGEABLE + APPROVED is the canonical eligible-stuck path; CONFLICTING
+	# without a nudge-eligible label is the gap case we still want to detect.
+	if [[ "$mergeable" == "MERGEABLE" && "$review_decision" == "APPROVED" ]]; then
+		printf '1'
+		return 0
+	fi
+	if [[ "$mergeable" == "CONFLICTING" ]]; then
+		# If neither origin:interactive (handled by existing nudge) nor
+		# origin:worker (handled by fix-worker dispatch) is present, this
+		# is the no-nudge-label gap.
+		if [[ "$labels" != *"origin:interactive"* && "$labels" != *"origin:worker"* ]]; then
+			printf '1'
+			return 0
+		fi
+	fi
+	printf '0'
+	return 0
+}
+
+# ── Classifier ───────────────────────────────────────────────────────────────
+
+#######################################
+# Classify why a stuck PR is stuck. Echoes one of:
+#   STUCK_CHECKS_FAILING
+#   STUCK_CONFLICT_NO_NUDGE_LABEL
+#   STUCK_BRANCHPROTECT_404
+#   STUCK_BRANCHPROTECT_API_ERROR
+#   STUCK_AUTH
+#   STUCK_OTHER
+#
+# Args: $1 = pr_number, $2 = repo_slug
+# Returns: 0 (always; classification is the stdout)
+#######################################
+_classify_stuck_pr() {
+	local pr_number="$1"
+	local repo_slug="$2"
+
+	# Cheap fast paths first. Fetch labels + mergeable + checks rollup once.
+	local pr_meta
+	pr_meta=$(gh pr view "$pr_number" --repo "$repo_slug" \
+		--json labels,mergeable,statusCheckRollup 2>/dev/null) || pr_meta=""
+
+	local mergeable="" labels=""
+	mergeable=$(printf '%s' "$pr_meta" | jq -r '.mergeable // "UNKNOWN"' 2>/dev/null)
+	labels=$(printf '%s' "$pr_meta" | jq -r '[.labels[].name] | join(",")' 2>/dev/null)
+
+	# Conflict + no nudge label → that gap.
+	if [[ "$mergeable" == "CONFLICTING" \
+		&& "$labels" != *"origin:interactive"* \
+		&& "$labels" != *"origin:worker"* ]]; then
+		printf 'STUCK_CONFLICT_NO_NUDGE_LABEL'
+		return 0
+	fi
+
+	# Branch protection probe — distinguish 404 from API error.
+	local default_branch
+	default_branch=$(gh api "repos/${repo_slug}" --jq '.default_branch' 2>/dev/null) || default_branch=""
+	if [[ -n "$default_branch" ]]; then
+		local protection_resp="" protection_exit=0
+		protection_resp=$(gh api \
+			"repos/${repo_slug}/branches/${default_branch}/protection/required_status_checks" \
+			2>&1)
+		protection_exit=$?
+		if [[ $protection_exit -ne 0 ]]; then
+			# 404 = no protection (intentional or accidental — the
+			# rollup-pass path will still gate based on actual checks).
+			if grep -qi 'HTTP 404\|Not Found' <<<"$protection_resp"; then
+				printf 'STUCK_BRANCHPROTECT_404'
+				return 0
+			fi
+			# 401 / 403 / 5xx etc — transient or auth break.
+			if grep -qi 'HTTP 401\|authentication required\|bad credentials' <<<"$protection_resp"; then
+				printf 'STUCK_AUTH'
+				return 0
+			fi
+			printf 'STUCK_BRANCHPROTECT_API_ERROR'
+			return 0
+		fi
+	fi
+
+	# Rollup contains a FAILURE / FAILED conclusion? Use the shared
+	# selector to keep the jq expression DRY across call sites.
+	local has_failure
+	has_failure=$(printf '%s' "$pr_meta" | jq -r \
+		"[.statusCheckRollup[]? | ${_PMS_JQ_FAILURE_SELECTOR}] | length" \
+		2>/dev/null)
+	[[ "$has_failure" =~ ^[0-9]+$ ]] || has_failure=0
+	if [[ "$has_failure" -gt 0 ]]; then
+		printf 'STUCK_CHECKS_FAILING'
+		return 0
+	fi
+
+	printf 'STUCK_OTHER'
+	return 0
+}
+
+# Compute a deterministic failure fingerprint for a PR — sorted set of
+# FAILURE check names joined by `|`. Used as the dedup key for the outage
+# meta-issue so the same outage signature files exactly one investigation
+# issue per cycle.
+_pms_failure_fingerprint() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local rollup
+	rollup=$(gh pr view "$pr_number" --repo "$repo_slug" \
+		--json statusCheckRollup --jq '.statusCheckRollup // []' 2>/dev/null) || rollup="[]"
+
+	# Extract names of checks in FAILURE conclusion or state, normalize, sort, join.
+	# Uses the shared _PMS_JQ_FAILURE_SELECTOR to keep the predicate DRY.
+	printf '%s' "$rollup" | jq -r \
+		"[ .[] | ${_PMS_JQ_FAILURE_SELECTOR} | (.name // .context // \"unknown\") ] | sort | unique | join(\",\")" \
+		2>/dev/null
+}
+
+# Hash a fingerprint string to a short hex digest for the dedup marker.
+# Uses sha256sum if available, falls back to shasum or md5 — all produce a
+# stable ASCII hex string suitable for an HTML comment.
+_pms_hash_fingerprint() {
+	local input="$1"
+	if command -v sha256sum >/dev/null 2>&1; then
+		printf '%s' "$input" | sha256sum | awk '{print substr($1, 1, 16)}'
+	elif command -v shasum >/dev/null 2>&1; then
+		printf '%s' "$input" | shasum -a 256 | awk '{print substr($1, 1, 16)}'
+	else
+		printf '%s' "$input" | md5 | awk '{print substr($1, 1, 16)}'
+	fi
+}
+
+# ── Per-PR escalation (Outcome 3 in brief) ──────────────────────────────────
+
+#######################################
+# Post a one-shot worker-ready escalation comment on the PR's linked issue
+# describing the stuck classification and the failing checks (when any).
+# Idempotent via the <!-- merge-stuck:individual --> marker.
+#
+# Pre-condition: caller has determined the PR is past the age threshold and
+# the classification is STUCK_CHECKS_FAILING (or another individually-
+# escalatable outcome); pattern-cluster outages are handled separately by
+# _detect_pattern_outage.
+#
+# Args: $1=pr_number, $2=repo_slug, $3=classification, $4=linked_issue (may be empty)
+#######################################
+_escalate_individual_stuck_pr() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	local classification="$3"
+	local linked_issue="$4"
+
+	[[ "$pr_number" =~ ^[0-9]+$ && -n "$repo_slug" ]] || return 0
+
+	# Need either a linked issue (to comment on) OR fall back to the PR
+	# itself — the marker prevents repeat fires either way.
+	if ! declare -F _gh_idempotent_comment >/dev/null 2>&1; then
+		echo "[pulse-merge-stuck] _escalate_individual_stuck_pr: _gh_idempotent_comment not defined — skipping for PR #${pr_number} in ${repo_slug}" >>"$LOGFILE"
+		return 0
+	fi
+
+	# Fetch failing check names for the worker-ready guidance using the
+	# shared FAILURE selector.
+	local failing_checks
+	failing_checks=$(gh pr view "$pr_number" --repo "$repo_slug" \
+		--json statusCheckRollup --jq \
+		"[.statusCheckRollup[]? | ${_PMS_JQ_FAILURE_SELECTOR} | \"- \" + (.name // .context // \"unknown\")] | join(\"\\n\")" \
+		2>/dev/null)
+	[[ -n "$failing_checks" ]] || failing_checks="- (no FAILURE entries in rollup; check rollup manually)"
+
+	local marker="<!-- merge-stuck:individual -->"
+	# Bash 3.2 cannot parse `body=$(cat <<EOF ... EOF)` (heredoc-in-subshell —
+	# see reference/bash-compat.md). Use the read -r -d '' form instead — the
+	# bash 3.2-portable way to slurp a heredoc into a variable. The trailing
+	# `|| true` is required because read returns non-zero when no NUL is
+	# encountered, which is always (the input is plain text). The variable
+	# is still populated. Confirmed working in /bin/bash 3.2 on macOS.
+	local body=""
+	IFS='' read -r -d '' body <<EOF || true
+${marker}
+## Stuck-merge detector: PR has been merge-eligible but unmerged past the threshold
+
+The pulse merge pass has classified PR #${pr_number} as \`${classification}\` and it has been sitting unmerged longer than \`AIDEVOPS_MERGE_STUCK_AGE_MINUTES\` (currently ${AIDEVOPS_MERGE_STUCK_AGE_MINUTES}m). The deterministic merge gates are evaluated every cycle (~120s) and this PR has consistently failed them.
+
+### Failing checks on PR #${pr_number}
+
+${failing_checks}
+
+### Worker guidance for the next attempt
+
+1. Read PR #${pr_number} body + the latest check run logs:
+   \`\`\`bash
+   gh pr view ${pr_number} --repo ${repo_slug} --json statusCheckRollup
+   gh pr checks ${pr_number} --repo ${repo_slug}
+   \`\`\`
+2. If the failing checks are environment/Setup-step (Format, Lint, Typecheck all FAIL at the same step), the canonical default branch likely has a broken lockfile or a CI infra change — fix at the base, not on this PR. Look for a sibling outage meta-issue in this repo (filed by the same detector) before forking off here.
+3. If the failures are PR-specific (e.g. a Typecheck error introduced by this PR's code), rebase onto the latest default branch and address the diagnosed errors. Use \`full-loop-helper.sh start\` from the linked PR's worktree.
+4. If the linked issue body lacks the worker-ready file paths and verification commands required by t1900, post a comment naming the missing context before dispatching another worker — the next attempt will burn tokens on exploration otherwise.
+
+### Why you're seeing this
+
+Every pulse cycle (~120s) the deterministic merge pass re-evaluates open PRs. PRs that pass APPROVED + MERGEABLE but fail required checks have historically been re-evaluated silently every cycle until a human noticed. The stuck-merge detector (t3193) surfaces them after \`AIDEVOPS_MERGE_STUCK_AGE_MINUTES\` minutes idle. This comment is posted exactly once per linked issue — repeated stuck cycles will NOT spam the thread. If the PR merges and the issue is reopened later with a fresh stuck PR, the marker will allow a second comment.
+
+<sub>Posted automatically by \`pulse-merge-stuck.sh\` (t3193 / GH#21895). Threshold env: \`AIDEVOPS_MERGE_STUCK_AGE_MINUTES=${AIDEVOPS_MERGE_STUCK_AGE_MINUTES}\`.</sub>
+EOF
+
+	# Comment on the linked issue if available, else on the PR itself.
+	local comment_target_kind="issue"
+	local comment_target_num="$linked_issue"
+	if [[ -z "$linked_issue" ]]; then
+		comment_target_kind="pr"
+		comment_target_num="$pr_number"
+	fi
+
+	_gh_idempotent_comment "$comment_target_num" "$repo_slug" "$marker" "$body" "$comment_target_kind" || true
+	pulse_stats_increment "$_PMS_COUNTER_ESCALATIONS_FILED"
+	echo "[pulse-merge-stuck] _escalate_individual_stuck_pr: PR #${pr_number} ${classification} (${repo_slug}) — comment posted on ${comment_target_kind}#${comment_target_num}" >>"$LOGFILE"
+	return 0
+}
+
+# ── Branch protection 404 handler ───────────────────────────────────────────
+
+#######################################
+# Increment the 404-skips counter when the detector classified a PR as
+# STUCK_BRANCHPROTECT_404. The actual fix for the t2922 mis-fire lives in
+# pulse-merge-process.sh::_check_required_checks_passing — this function
+# only records the observation so operators can see the rate at which the
+# 404 path is hit. Helpful for confirming the t2922 fix has fully landed.
+#
+# Args: $1=pr_number, $2=repo_slug
+#######################################
+_handle_stuck_branchprotect_404() {
+	local pr_number="$1"
+	local repo_slug="$2"
+	pulse_stats_increment "pulse_merge_branchprotect_404_skips"
+	echo "[pulse-merge-stuck] _handle_stuck_branchprotect_404: PR #${pr_number} in ${repo_slug} — default branch unprotected; counter incremented" >>"$LOGFILE"
+	return 0
+}
+
+# ── Conflict + no-nudge-label handler ───────────────────────────────────────
+
+#######################################
+# Post a label-agnostic rebase nudge for any APPROVED + CONFLICTING PR idle
+# past the threshold that lacks both origin:interactive and origin:worker.
+# Reuses the existing <!-- pulse-rebase-nudge --> marker so it never double-
+# fires alongside _post_rebase_nudge_on_interactive_conflicting.
+#
+# Args: $1=pr_number, $2=repo_slug
+#######################################
+_handle_stuck_conflict_no_nudge_label() {
+	local pr_number="$1"
+	local repo_slug="$2"
+
+	[[ "$pr_number" =~ ^[0-9]+$ && -n "$repo_slug" ]] || return 0
+
+	if ! declare -F _gh_idempotent_comment >/dev/null 2>&1; then
+		echo "[pulse-merge-stuck] _handle_stuck_conflict_no_nudge_label: _gh_idempotent_comment not defined — skipping nudge for PR #${pr_number} in ${repo_slug}" >>"$LOGFILE"
+		return 0
+	fi
+
+	local head_branch
+	head_branch=$(gh pr view "$pr_number" --repo "$repo_slug" \
+		--json headRefName --jq '.headRefName' 2>/dev/null) || head_branch="<branch>"
+	[[ -n "$head_branch" ]] || head_branch="<branch>"
+
+	# Reuse the existing rebase-nudge marker — _gh_idempotent_comment is
+	# keyed on the marker string, so this nudge is mutually exclusive with
+	# the per-label nudges. (If a label-bearing nudge fired earlier in the
+	# PR's life and this label-agnostic nudge would be the second event,
+	# the marker prevents the duplicate post.)
+	local marker="<!-- pulse-rebase-nudge -->"
+	local body
+	body="${marker}
+## Rebase needed — PR has merge conflicts and no \`origin:*\` label
+
+This PR has merge conflicts against the default branch and lacks both \`origin:interactive\` and \`origin:worker\` labels. The pulse merge pass treats it as the label-agnostic stuck state (t3193) and surfaces it here with a one-shot rebase nudge.
+
+### To resolve
+
+\`\`\`bash
+git fetch origin
+git checkout ${head_branch}
+git rebase origin/main
+# resolve any conflicts, then:
+git push --force-with-lease
+\`\`\`
+
+Or use the GitHub web UI's *Update branch* button if the conflicts are trivial enough.
+
+### Why this PR slipped through the existing nudges
+
+The existing rebase-nudge family (\`_post_rebase_nudge_on_interactive_conflicting\`, \`_post_rebase_nudge_on_contributor_conflicting\`, \`_post_rebase_nudge_on_worker_conflicting\`) keys on the \`origin:*\` labels. PRs created without those labels — typically docs/migration commits made directly via the web UI or via a worker that didn't apply its origin label — were silently re-evaluated every cycle without surfacing.
+
+<sub>Posted automatically by \`pulse-merge-stuck.sh\` (t3193 / GH#21895).</sub>"
+
+	_gh_idempotent_comment "$pr_number" "$repo_slug" "$marker" "$body" "pr" || true
+	pulse_stats_increment "$_PMS_COUNTER_ESCALATIONS_FILED"
+	echo "[pulse-merge-stuck] _handle_stuck_conflict_no_nudge_label: PR #${pr_number} in ${repo_slug} — label-agnostic nudge posted" >>"$LOGFILE"
+	return 0
+}
+
+# ── Pattern-cluster outage detector ─────────────────────────────────────────
+
+#######################################
+# Group all stuck PRs in the repo by failure fingerprint. If ≥ AIDEVOPS_MERGE_PATTERN_MIN_PRS
+# share an identical fingerprint, file ONE investigation issue per outage signature.
+# Dedup'd by the fingerprint hash so the same outage doesn't re-file every cycle.
+#
+# Args: $1=repo_slug, $2=newline-separated list of stuck PR numbers
+#######################################
+_detect_pattern_outage() {
+	local repo_slug="$1"
+	local stuck_prs="$2"
+
+	[[ -z "$stuck_prs" ]] && return 0
+
+	# Build "fingerprint <TAB> pr_number" lines, then group by fingerprint.
+	local tmp_lines="" tmp_groups=""
+	tmp_lines=$(mktemp "${TMPDIR:-/tmp}/pms-fp-XXXXXX") || return 0
+	tmp_groups=$(mktemp "${TMPDIR:-/tmp}/pms-grp-XXXXXX") || { rm -f "$tmp_lines"; return 0; }
+	# shellcheck disable=SC2064
+	trap "rm -f '$tmp_lines' '$tmp_groups'" RETURN
+
+	while IFS= read -r pr_num; do
+		[[ -n "$pr_num" ]] || continue
+		local fp
+		fp=$(_pms_failure_fingerprint "$pr_num" "$repo_slug")
+		# Skip PRs with no FAILURE entries — those aren't part of an outage cluster.
+		[[ -n "$fp" ]] || continue
+		printf '%s\t%s\n' "$fp" "$pr_num" >>"$tmp_lines"
+	done <<<"$stuck_prs"
+
+	# Group by fingerprint. Pure bash 3.2 (avoids multi-line awk so the
+	# pre-commit positional-parameter validator does not false-positive
+	# on awk's `$1`/`$2` field references).
+	if [[ -s "$tmp_lines" ]]; then
+		local _prev_fp="" _cur_count=0 _cur_prs="" _line_fp _line_pr
+		while IFS=$'\t' read -r _line_fp _line_pr; do
+			[[ -n "$_line_fp" ]] || continue
+			if [[ "$_line_fp" == "$_prev_fp" ]]; then
+				_cur_count=$((_cur_count + 1))
+				_cur_prs="${_cur_prs},${_line_pr}"
+			else
+				if [[ -n "$_prev_fp" ]]; then
+					printf '%d\t%s\t%s\n' "$_cur_count" "$_prev_fp" "$_cur_prs" >>"$tmp_groups"
+				fi
+				_prev_fp="$_line_fp"
+				_cur_count=1
+				_cur_prs="$_line_pr"
+			fi
+		done < <(sort "$tmp_lines")
+		# Flush the final group.
+		if [[ -n "$_prev_fp" ]]; then
+			printf '%d\t%s\t%s\n' "$_cur_count" "$_prev_fp" "$_cur_prs" >>"$tmp_groups"
+		fi
+	fi
+
+	# Process each group with count >= threshold.
+	while IFS=$'\t' read -r count fingerprint prs; do
+		[[ "$count" =~ ^[0-9]+$ ]] || continue
+		[[ "$count" -ge "$AIDEVOPS_MERGE_PATTERN_MIN_PRS" ]] || continue
+		_pms_file_outage_issue "$repo_slug" "$count" "$fingerprint" "$prs"
+	done <"$tmp_groups"
+
+	return 0
+}
+
+# Internal: file ONE outage investigation issue (or skip if dedup marker exists).
+_pms_file_outage_issue() {
+	local repo_slug="$1"
+	local count="$2"
+	local fingerprint="$3"
+	local prs="$4"
+
+	local fp_hash
+	fp_hash=$(_pms_hash_fingerprint "$fingerprint")
+	local marker_text="merge-stuck:pattern:${fp_hash}"
+	local marker="<!-- ${marker_text} -->"
+
+	# Dedup: search for an OPEN issue with this marker. If one exists, skip.
+	local existing
+	existing=$(gh issue list --repo "$repo_slug" --state open --search "${marker_text}" \
+		--limit 1 --json number --jq '.[0].number' 2>/dev/null)
+	if [[ -n "$existing" && "$existing" != "$_PMS_JQ_NULL_GUARD" ]]; then
+		echo "[pulse-merge-stuck] _pms_file_outage_issue: outage marker ${fp_hash} already filed as #${existing} in ${repo_slug} — skipping" >>"$LOGFILE"
+		return 0
+	fi
+
+	# Compose investigation issue body. Use the auto-dispatch + tier:thinking
+	# combination (broken base / CI infra needs reasoning) and the
+	# source:merge-stuck-detector label so workers can recognize the origin.
+	local title="merge-stuck outage: ${count} PRs sharing failure fingerprint in ${repo_slug}"
+	local body
+	body="${marker}
+## What
+
+The pulse stuck-merge detector observed **${count} PRs** in this repo with an identical failure fingerprint:
+
+\`${fingerprint}\`
+
+This is a broken-base outage signal — multiple unrelated PRs failing the same checks at the same step typically means the canonical default branch shipped a regression (broken lockfile, CI infra change, dependency drift, env-var rename). The fix belongs at the base, not on each PR.
+
+## Affected PRs
+
+$(printf '%s' "$prs" | tr ',' '\n' | while read -r p; do printf -- '- #%s\n' "$p"; done)
+
+## Why
+
+When ≥${AIDEVOPS_MERGE_PATTERN_MIN_PRS} PRs share an identical sorted set of FAILURE check names, the cause is overwhelmingly an upstream CI / base-branch break, not a coincidental cluster of PR-specific bugs. Workers re-dispatched against each PR will burn tokens fixing symptoms; this issue routes the diagnosis to the base.
+
+## How
+
+### Files Scope
+
+Investigation only — no \`Files Scope\` declared. The fix file set will be determined by the diagnosis.
+
+### Investigation steps
+
+1. Reproduce the failing check on a fresh worktree off \`origin/main\`:
+   \`\`\`bash
+   wt switch -c chore/diagnose-merge-stuck-${fp_hash:0:8}
+   # Run the same command(s) the failing CI step runs
+   \`\`\`
+2. If the failure reproduces on a clean main, the base is broken — locate the most recent commit on main that introduced the regression (\`git log --since=24h --first-parent main\`) and either revert or fix forward.
+3. If the failure does NOT reproduce on clean main, the cluster is a coincidence (rare) — close this issue with the rationale and let each PR be triaged individually.
+4. Once the base is fixed and pushed, the affected PRs above should auto-merge on their next pulse cycle (or rebase via \`gh pr update-branch\`).
+
+### Verification
+
+- The failing check listed in the fingerprint passes on a fresh worktree off \`origin/main\`.
+- Each affected PR successfully merges or has its remaining failures triaged individually.
+- This issue is closed with the resolution PR linked.
+
+## Acceptance
+
+- [ ] Root cause of the shared failure fingerprint is identified.
+- [ ] Either: a base-fix PR is merged; or: the cluster is conclusively a coincidence and each PR is triaged individually.
+- [ ] All ${count} affected PRs above are unblocked (merged, closed with cause, or have their own follow-up issues).
+
+## Session Origin
+
+Filed automatically by \`pulse-merge-stuck.sh\` (t3193) on detecting a pattern outage of ${count} PRs in ${repo_slug}.
+
+<sub>Source: pulse-merge-stuck-detector. Fingerprint hash: ${fp_hash}. Threshold env: \`AIDEVOPS_MERGE_PATTERN_MIN_PRS=${AIDEVOPS_MERGE_PATTERN_MIN_PRS}\`.</sub>"
+
+	# Use the gh wrapper (auto-injects signature + origin labels). Fail-open
+	# on any error — instrumentation must never break the pulse.
+	local labels="auto-dispatch,tier:thinking,bug,source:merge-stuck-detector"
+	# Wrapper-only — raw `gh issue create` is forbidden by the pre-push
+	# guard and would skip origin labelling + signature footer auto-injection.
+	# If the wrapper is unavailable (sourcing race / smoke test), log and
+	# skip rather than silently file an unlabelled issue.
+	if ! declare -F gh_create_issue >/dev/null 2>&1; then
+		echo "[pulse-merge-stuck] _pms_file_outage_issue: gh_create_issue wrapper unavailable, skipping outage issue for ${repo_slug} fingerprint=${fp_hash}" >>"$LOGFILE"
+		return 0
+	fi
+	gh_create_issue --repo "$repo_slug" \
+		--title "$title" \
+		--body "$body" \
+		--label "$labels" >/dev/null 2>&1 || true
+	pulse_stats_increment "$_PMS_COUNTER_ESCALATIONS_FILED"
+	echo "[pulse-merge-stuck] _pms_file_outage_issue: filed outage issue for fingerprint ${fp_hash} (${count} PRs) in ${repo_slug}" >>"$LOGFILE"
+	return 0
+}
+
+# ── Zero-progress meta-issue ────────────────────────────────────────────────
+
+# File ONE meta-issue describing the throughput collapse when consecutive
+# zero-progress cycles cross the threshold. Dedup'd by the fixed marker.
+# Disabled while the GraphQL circuit-breaker is tripped — the breaker
+# already names the root cause and a meta-issue would just be noise.
+_pms_file_zero_progress_meta_issue() {
+	local zero_cycles="$1"
+	local stuck_summary="$2"
+
+	# Skip if the GraphQL circuit-breaker is tripped — its own counter
+	# (pulse_dispatch_circuit_broken) is the authoritative signal.
+	local _cb_24h
+	_cb_24h=$(pulse_stats_get_24h "pulse_dispatch_circuit_broken" 2>/dev/null) || _cb_24h=0
+	[[ "$_cb_24h" =~ ^[0-9]+$ ]] || _cb_24h=0
+	if [[ "$_cb_24h" -gt 0 ]]; then
+		echo "[pulse-merge-stuck] _pms_file_zero_progress_meta_issue: skipped — circuit breaker tripped in last 24h" >>"$LOGFILE"
+		return 0
+	fi
+
+	# Use the framework-routing helper if available — meta-issues belong in
+	# the framework repo (marcusquinn/aidevops), not in the affected project.
+	local meta_repo="marcusquinn/aidevops"
+	local marker="<!-- merge-stuck:zero-progress -->"
+
+	# Dedup: find an OPEN meta-issue with this marker (one is enough — the
+	# meta-issue stays open for human triage). Reset cadence: when the
+	# meta-issue closes (manually) and the underlying cause recurs, a fresh
+	# meta-issue is filed.
+	local existing
+	existing=$(gh issue list --repo "$meta_repo" --state open --search "merge-stuck:zero-progress" \
+		--limit 1 --json number --jq '.[0].number' 2>/dev/null)
+	if [[ -n "$existing" && "$existing" != "$_PMS_JQ_NULL_GUARD" ]]; then
+		echo "[pulse-merge-stuck] _pms_file_zero_progress_meta_issue: meta-issue already open as #${existing} — skipping" >>"$LOGFILE"
+		return 0
+	fi
+
+	local title="merge-stuck: pulse merge throughput collapse (${zero_cycles} consecutive zero-progress cycles)"
+	local body
+	body="${marker}
+## What
+
+The pulse deterministic merge pass has had **${zero_cycles} consecutive cycles** with eligible-unmerged PRs but zero merges. The threshold is \`AIDEVOPS_MERGE_ZERO_PROGRESS_CYCLES=${AIDEVOPS_MERGE_ZERO_PROGRESS_CYCLES}\`.
+
+## Why
+
+Eligible-unmerged means \`APPROVED + MERGEABLE + !draft + !hold-for-review\`. When this is non-zero AND the merge count is zero across multiple cycles, the merge pass is structurally blocked — gates failing closed (e.g. branch-protection 404 mis-fire), GraphQL exhaustion, repo-allowlist mismatch, or a regression in the merge gates themselves.
+
+## How
+
+### Files Scope
+
+Investigation only — no \`Files Scope\` declared.
+
+### Snapshot
+
+\`\`\`
+${stuck_summary}
+\`\`\`
+
+### Investigation steps
+
+1. Read \`~/.aidevops/logs/pulse.log\` since the meta-issue was filed (\`grep 'Merge pass: skipping' \`) — the per-PR skip reason is logged for every cycle.
+2. Cross-check \`pulse-stats.json\` for circuit-breaker fires and the \`pulse_merge_branchprotect_404_skips\` counter — if non-zero, the t2922 fail-closed path is mis-firing.
+3. Reproduce the merge gate decision for one stuck PR via \`pulse-diagnose-helper.sh pr <N>\` — it explains what the pulse decided and why.
+4. Apply the fix (often a one-line gate adjustment) and verify the next cycle drops zero-progress to 0.
+
+## Acceptance
+
+- [ ] Root cause of the throughput collapse identified.
+- [ ] At least one of the stuck PRs successfully auto-merges.
+- [ ] \`pulse_merge_zero_progress_cycles\` reads 0 in \`pulse-stats.json\`.
+
+## Session Origin
+
+Filed automatically by \`pulse-merge-stuck.sh\` (t3193). The detector resets the zero-progress counter on any successful merge — if the meta-issue is stale (cause already resolved), close it manually.
+
+<sub>Source: pulse-merge-stuck-detector. Threshold env: \`AIDEVOPS_MERGE_ZERO_PROGRESS_CYCLES=${AIDEVOPS_MERGE_ZERO_PROGRESS_CYCLES}\`.</sub>"
+
+	local labels="auto-dispatch,tier:thinking,bug,source:merge-stuck-detector,framework"
+	# Wrapper-only — see _pms_file_outage_issue rationale above.
+	if ! declare -F gh_create_issue >/dev/null 2>&1; then
+		echo "[pulse-merge-stuck] _pms_file_zero_progress_meta_issue: gh_create_issue wrapper unavailable, skipping meta-issue (${zero_cycles} cycles)" >>"$LOGFILE"
+		return 0
+	fi
+	gh_create_issue --repo "$meta_repo" \
+		--title "$title" \
+		--body "$body" \
+		--label "$labels" >/dev/null 2>&1 || true
+	pulse_stats_increment "$_PMS_COUNTER_ESCALATIONS_FILED"
+	echo "[pulse-merge-stuck] _pms_file_zero_progress_meta_issue: filed meta-issue (${zero_cycles} zero-progress cycles)" >>"$LOGFILE"
+	return 0
+}
+
+# ── Module entry point — called once per pulse cycle, per repo ─────────────
+
+#######################################
+# Count PRs in $repo_slug that are eligible-but-unmerged this cycle —
+# APPROVED + MERGEABLE + !draft + !hold-for-review (NOT age-gated).
+# Used by pulse-merge.sh to feed the zero-progress signal across all repos.
+#
+# Distinct from pulse_merge_stuck_run_pass which adds the AIDEVOPS_MERGE_STUCK_AGE_MINUTES
+# age gate — zero-progress detection wants the wider population (any cycle
+# with eligible-unmerged > 0 + zero merges is a candidate, regardless of age).
+#
+# Args: $1 = repo_slug
+# Stdout: integer count
+#######################################
+_pms_count_eligible_unmerged_for_repo() {
+	local repo_slug="$1"
+	[[ -n "$repo_slug" ]] || { printf '0'; return 0; }
+
+	local pr_json
+	pr_json=$(gh pr list --repo "$repo_slug" --state open \
+		--json number,mergeable,reviewDecision,isDraft,labels \
+		--limit 50 2>/dev/null) || pr_json="[]"
+	[[ -n "$pr_json" && "$pr_json" != "$_PMS_JQ_NULL_GUARD" ]] || pr_json="[]"
+
+	# Count PRs matching the eligibility criteria via jq. .mergeable and
+	# .reviewDecision are already upper-case in the GraphQL response — no
+	# ascii_upcase needed (the FAILURE selector keeps it because legacy
+	# commit-status `.state` values can be lower-case).
+	local count
+	count=$(printf '%s' "$pr_json" | jq -r '
+		[ .[]
+		  | select(
+			(.mergeable // "") == "MERGEABLE"
+			and (.reviewDecision // "") == "APPROVED"
+			and (.isDraft // false) == false
+			and (([.labels[].name] | index("hold-for-review")) == null)
+		  )
+		] | length' 2>/dev/null)
+	[[ "$count" =~ ^[0-9]+$ ]] || count=0
+	printf '%s' "$count"
+	return 0
+}
+
+#######################################
+# Run the stuck-merge detector pass for one repo.
+#
+# Iterates open PRs, identifies eligible-stuck ones past the age threshold,
+# classifies each, fires individual escalations / nudges, then runs the
+# pattern-cluster outage detector across the full stuck set.
+#
+# Updates the gauge `pulse_merge_eligible_stuck_pr_count` to the count of
+# eligible-stuck PRs observed in this cycle (across all classifications).
+#
+# Args: $1 = repo_slug
+# Returns: 0 always (instrumentation must not break the pulse)
+#######################################
+pulse_merge_stuck_run_pass() {
+	local repo_slug="$1"
+
+	[[ -n "$repo_slug" ]] || return 0
+	[[ "$AIDEVOPS_MERGE_STUCK_ENABLED" == "1" ]] || return 0
+
+	# Fetch open PRs with the fields the detector needs.
+	local pr_json
+	pr_json=$(gh pr list --repo "$repo_slug" --state open \
+		--json number,mergeable,reviewDecision,isDraft,labels,updatedAt \
+		--limit 50 2>/dev/null) || pr_json="[]"
+	[[ -n "$pr_json" && "$pr_json" != "$_PMS_JQ_NULL_GUARD" ]] || pr_json="[]"
+
+	local pr_count
+	pr_count=$(printf '%s' "$pr_json" | jq 'length' 2>/dev/null) || pr_count=0
+	[[ "$pr_count" =~ ^[0-9]+$ ]] || pr_count=0
+	[[ "$pr_count" -gt 0 ]] || return 0
+
+	local now_epoch
+	now_epoch=$(date +%s 2>/dev/null) || now_epoch=0
+	local age_threshold_secs=$((AIDEVOPS_MERGE_STUCK_AGE_MINUTES * 60))
+
+	local eligible_stuck_count=0
+	local stuck_pr_numbers=""
+
+	# Iterate each PR — classify, escalate, accumulate fingerprints.
+	local i=0
+	while [[ "$i" -lt "$pr_count" ]]; do
+		local pr_obj="" pr_num="" pr_updated="" pr_age_secs=0 is_stuck=""
+		pr_obj=$(printf '%s' "$pr_json" | jq -c ".[$i]" 2>/dev/null)
+		i=$((i + 1))
+		[[ -n "$pr_obj" ]] || continue
+
+		pr_num=$(printf '%s' "$pr_obj" | jq -r '.number // empty' 2>/dev/null)
+		[[ "$pr_num" =~ ^[0-9]+$ ]] || continue
+
+		# Eligibility gate first (cheap)
+		is_stuck=$(_pms_is_eligible_stuck "$pr_obj")
+		[[ "$is_stuck" == "1" ]] || continue
+
+		# Age gate (also cheap — uses cached updatedAt)
+		pr_updated=$(printf '%s' "$pr_obj" | jq -r '.updatedAt // empty' 2>/dev/null)
+		[[ -n "$pr_updated" ]] || continue
+		pr_age_secs=$(( now_epoch - $(_pms_iso_to_epoch "$pr_updated") ))
+		[[ "$pr_age_secs" -ge "$age_threshold_secs" ]] || continue
+
+		eligible_stuck_count=$((eligible_stuck_count + 1))
+		stuck_pr_numbers="${stuck_pr_numbers}${pr_num}\n"
+
+		# Per-PR classification + handler (skip per-PR escalation when the
+		# PR is part of a pattern cluster — detected later in the same pass).
+		local classification
+		classification=$(_classify_stuck_pr "$pr_num" "$repo_slug")
+
+		# Fetch linked issue once for the escalation comment.
+		local linked_issue=""
+		if declare -F _extract_linked_issue >/dev/null 2>&1; then
+			linked_issue=$(_extract_linked_issue "$pr_num" "$repo_slug" 2>/dev/null) || linked_issue=""
+		fi
+
+		case "$classification" in
+			STUCK_BRANCHPROTECT_404)
+				_handle_stuck_branchprotect_404 "$pr_num" "$repo_slug"
+				;;
+			STUCK_CONFLICT_NO_NUDGE_LABEL)
+				_handle_stuck_conflict_no_nudge_label "$pr_num" "$repo_slug"
+				;;
+			STUCK_CHECKS_FAILING|STUCK_BRANCHPROTECT_API_ERROR|STUCK_AUTH|STUCK_OTHER)
+				_escalate_individual_stuck_pr "$pr_num" "$repo_slug" "$classification" "$linked_issue"
+				;;
+		esac
+	done
+
+	# Update the gauge for this cycle's count.
+	pulse_stats_set_gauge "pulse_merge_eligible_stuck_pr_count" "$eligible_stuck_count"
+
+	# Pattern-cluster detector over the full stuck set.
+	if [[ "$eligible_stuck_count" -ge "$AIDEVOPS_MERGE_PATTERN_MIN_PRS" ]]; then
+		_detect_pattern_outage "$repo_slug" "$(printf '%b' "$stuck_pr_numbers")" || true
+	fi
+
+	echo "[pulse-merge-stuck] pulse_merge_stuck_run_pass: ${repo_slug} — eligible_stuck=${eligible_stuck_count}, threshold=${AIDEVOPS_MERGE_STUCK_AGE_MINUTES}m" >>"$LOGFILE"
+	return 0
+}
+
+#######################################
+# Increment the zero-progress counter for the current pulse cycle.
+# Called by pulse-merge.sh::merge_ready_prs_all_repos at the END of the
+# merge pass — see the wiring there.
+#
+# When the counter crosses AIDEVOPS_MERGE_ZERO_PROGRESS_CYCLES, files a
+# meta-issue (dedup'd by marker) describing the throughput collapse.
+#
+# Reset by a separate call to pulse_merge_zero_progress_reset on any
+# successful merge.
+#
+# Args:
+#   $1 - count of PRs that were eligible-unmerged this cycle (>0 to count)
+#   $2 - count of PRs successfully merged this cycle
+#######################################
+pulse_merge_zero_progress_record() {
+	local eligible_unmerged="${1:-0}"
+	local merged_count="${2:-0}"
+
+	[[ "$eligible_unmerged" =~ ^[0-9]+$ ]] || eligible_unmerged=0
+	[[ "$merged_count" =~ ^[0-9]+$ ]] || merged_count=0
+
+	# Successful merge resets the counter.
+	if [[ "$merged_count" -gt 0 ]]; then
+		pulse_stats_set_gauge "$_PMS_GAUGE_ZERO_PROGRESS_CYCLES" "0"
+		return 0
+	fi
+
+	# No merges + nothing eligible = idle pulse, not a stuck pulse.
+	[[ "$eligible_unmerged" -gt 0 ]] || return 0
+
+	# Increment the gauge by 1.
+	local cur
+	cur=$(pulse_stats_get_gauge "$_PMS_GAUGE_ZERO_PROGRESS_CYCLES")
+	[[ "$cur" =~ ^[0-9]+$ ]] || cur=0
+	cur=$((cur + 1))
+	pulse_stats_set_gauge "$_PMS_GAUGE_ZERO_PROGRESS_CYCLES" "$cur"
+
+	echo "[pulse-merge-stuck] pulse_merge_zero_progress_record: zero_progress_cycles=${cur}/${AIDEVOPS_MERGE_ZERO_PROGRESS_CYCLES}, eligible_unmerged=${eligible_unmerged}" >>"$LOGFILE"
+
+	# At threshold, file the meta-issue (dedup'd by marker).
+	if [[ "$cur" -ge "$AIDEVOPS_MERGE_ZERO_PROGRESS_CYCLES" ]]; then
+		local stuck_summary
+		stuck_summary=$(pulse_stats_get_gauge "pulse_merge_eligible_stuck_pr_count")
+		stuck_summary="eligible_unmerged_this_cycle=${eligible_unmerged}, eligible_stuck_count=${stuck_summary}, zero_progress_cycles=${cur}"
+		_pms_file_zero_progress_meta_issue "$cur" "$stuck_summary"
+	fi
+	return 0
+}

--- a/.agents/scripts/pulse-stats-helper.sh
+++ b/.agents/scripts/pulse-stats-helper.sh
@@ -148,6 +148,73 @@ pulse_stats_status() {
 }
 
 #######################################
+# Set a named gauge to an absolute integer value (t3193).
+#
+# Gauges are distinct from counters: they store the LATEST observation,
+# not an event stream. Use for "current cycle has N stuck PRs" or
+# "consecutive zero-progress cycles" semantics where the prior value is
+# overwritten, not appended.
+#
+# Stored under .gauges.<name> = {"value": V, "ts": <epoch>} so a reader
+# can both see the value and detect staleness.
+#
+# Args:
+#   $1 - gauge_name
+#   $2 - integer value (must match ^-?[0-9]+$; non-numeric is rejected)
+#
+# Non-fatal: any jq/file failure is logged but does not propagate.
+#######################################
+pulse_stats_set_gauge() {
+	local gauge_name="${1:-unknown}"
+	local gauge_value="${2:-0}"
+
+	# Reject non-integer values rather than silently writing garbage.
+	if [[ ! "$gauge_value" =~ ^-?[0-9]+$ ]]; then
+		return 0
+	fi
+
+	local now_epoch
+	now_epoch=$(date +%s 2>/dev/null) || now_epoch=0
+
+	_pulse_stats_ensure_file || return 0
+
+	local tmp_file
+	tmp_file=$(mktemp "${TMPDIR:-/tmp}/pulse-stats-XXXXXX") || return 0
+
+	# Overwrite the gauge value. Create .gauges if absent.
+	jq --arg name "$gauge_name" --argjson v "$gauge_value" --argjson ts "$now_epoch" \
+		'.gauges = (.gauges // {}) | .gauges[$name] = {"value": $v, "ts": $ts}' \
+		"$PULSE_STATS_FILE" >"$tmp_file" 2>/dev/null || { rm -f "$tmp_file"; return 0; }
+
+	mv "$tmp_file" "$PULSE_STATS_FILE" 2>/dev/null || rm -f "$tmp_file"
+	return 0
+}
+
+#######################################
+# Read the current value of a gauge (t3193).
+# Prints the integer to stdout. Returns 0 if found, 0 with "0" output if not.
+#
+# Args:
+#   $1 - gauge_name
+#######################################
+pulse_stats_get_gauge() {
+	local gauge_name="${1:-unknown}"
+
+	if [[ ! -f "$PULSE_STATS_FILE" ]]; then
+		printf '0\n'
+		return 0
+	fi
+
+	local value
+	value=$(jq -r --arg name "$gauge_name" \
+		'(.gauges[$name].value // 0) | tostring' \
+		"$PULSE_STATS_FILE" 2>/dev/null) || value="0"
+
+	printf '%s\n' "${value:-0}"
+	return 0
+}
+
+#######################################
 # Reset (clear) a counter's event history.
 # Args: $1 - counter_name
 #######################################

--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -242,6 +242,11 @@ source "${SCRIPT_DIR}/pulse-merge.sh"
 source "${SCRIPT_DIR}/pulse-merge-conflict.sh"
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}/pulse-merge-feedback.sh"
+# t3193 (GH#21895): stuck-merge detector + zero-progress circuit breaker.
+# Sourced AFTER pulse-merge.sh so its functions can call _extract_linked_issue
+# at runtime via bash lazy resolution (matches the conflict/feedback pattern).
+# shellcheck source=/dev/null
+source "${SCRIPT_DIR}/pulse-merge-stuck.sh"
 # Phase 5 (t1973, GH#18380): cleanup + issue-reconcile extracted into two modules.
 # shellcheck source=/dev/null
 source "${SCRIPT_DIR}/pulse-cleanup.sh"

--- a/.agents/scripts/tests/test-pulse-merge-stuck.sh
+++ b/.agents/scripts/tests/test-pulse-merge-stuck.sh
@@ -1,0 +1,303 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-pulse-merge-stuck.sh — Structural tests for t3193 stuck-merge detector.
+#
+# Verifies (no live GitHub API calls):
+#   1. pulse-merge-stuck.conf exists with the four canonical env-var defaults.
+#   2. pulse-merge-stuck.sh sources cleanly and applies positive-integer defaults.
+#   3. _pms_iso_to_epoch round-trips a valid ISO timestamp; returns 0 for garbage.
+#   4. _pms_hash_fingerprint returns a 16-hex-char digest, deterministic
+#      across calls with the same input, and survives empty input.
+#   5. pulse_stats_set_gauge / pulse_stats_get_gauge round-trip integer values
+#      against an isolated PULSE_STATS_FILE; non-numeric set is rejected.
+#   6. pulse_merge_zero_progress_record:
+#        merged>0 → gauge reset to 0
+#        merged=0 + eligible=0 → no-op (gauge unchanged)
+#        merged=0 + eligible>0 → gauge incremented by 1
+#   7. pulse-merge-stuck.sh and pulse-stats-helper.sh pass shellcheck.
+#
+# The test never makes real network calls; functions that require gh API
+# (_classify_stuck_pr, _escalate_individual_stuck_pr, pulse_merge_stuck_run_pass,
+# _pms_count_eligible_unmerged_for_repo) are intentionally not exercised here —
+# they're integration-level and would need a live fixture repo.
+
+set -u
+
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_BLUE=$'\033[0;34m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_BLUE="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+assert_eq() {
+	local label="$1" expected="$2" actual="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$expected" == "$actual" ]]; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  expected: $(printf '%q' "$expected")"
+		echo "  actual:   $(printf '%q' "$actual")"
+	fi
+	return 0
+}
+
+assert_match() {
+	local label="$1" regex="$2" value="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$value" =~ $regex ]]; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  regex: $regex"
+		echo "  value: $(printf '%q' "$value")"
+	fi
+	return 0
+}
+
+assert_gt() {
+	local label="$1" lhs="$2" rhs="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$lhs" =~ ^[0-9]+$ && "$rhs" =~ ^[0-9]+$ && "$lhs" -gt "$rhs" ]]; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label ($lhs > $rhs ?)"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Setup: locate files, isolate PULSE_STATS_FILE, source the modules.
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+MODULE="$SCRIPT_DIR/pulse-merge-stuck.sh"
+STATS_HELPER="$SCRIPT_DIR/pulse-stats-helper.sh"
+CONF_FILE="$SCRIPT_DIR/../configs/pulse-merge-stuck.conf"
+
+for required in "$MODULE" "$STATS_HELPER"; do
+	if [[ ! -f "$required" ]]; then
+		echo "${TEST_RED}FATAL${TEST_NC}: $required not found"
+		exit 1
+	fi
+done
+
+# Isolate state writes to a temp file so the live ~/.aidevops/logs/pulse-stats.json
+# is not perturbed. Cleanup on exit.
+TEST_TMPDIR=$(mktemp -d "${TMPDIR:-/tmp}/test-pulse-merge-stuck-XXXXXX")
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
+export PULSE_STATS_FILE="$TEST_TMPDIR/pulse-stats.json"
+export LOGFILE="$TEST_TMPDIR/pulse.log"
+
+# Source the helpers. pulse-stats-helper.sh sets -euo pipefail; turn that off
+# after source so a single failed assertion doesn't abort the whole suite.
+# shellcheck source=/dev/null
+source "$MODULE"
+set +e
+set +o pipefail
+
+echo "${TEST_BLUE}=== t3193: pulse-merge-stuck detector tests ===${TEST_NC}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Section 1: conf file integrity.
+# ---------------------------------------------------------------------------
+echo "--- Section 1: conf file integrity ---"
+
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ -f "$CONF_FILE" ]]; then
+	echo "${TEST_GREEN}PASS${TEST_NC}: 1a: pulse-merge-stuck.conf exists"
+else
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	echo "${TEST_RED}FAIL${TEST_NC}: 1a: pulse-merge-stuck.conf NOT found at $CONF_FILE"
+fi
+
+for entry in \
+	AIDEVOPS_MERGE_STUCK_AGE_MINUTES \
+	AIDEVOPS_MERGE_ZERO_PROGRESS_CYCLES \
+	AIDEVOPS_MERGE_PATTERN_MIN_PRS \
+	AIDEVOPS_MERGE_STUCK_ENABLED; do
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if grep -qE "^${entry}=" "$CONF_FILE" 2>/dev/null; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: 1: conf contains ${entry}"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: 1: conf missing ${entry}"
+	fi
+done
+echo ""
+
+# ---------------------------------------------------------------------------
+# Section 2: defaults applied as positive integers after sourcing.
+# ---------------------------------------------------------------------------
+echo "--- Section 2: post-source defaults ---"
+
+assert_match "2a: AIDEVOPS_MERGE_STUCK_AGE_MINUTES is positive int" \
+	"^[0-9]+$" "${AIDEVOPS_MERGE_STUCK_AGE_MINUTES:-x}"
+assert_match "2b: AIDEVOPS_MERGE_ZERO_PROGRESS_CYCLES is positive int" \
+	"^[0-9]+$" "${AIDEVOPS_MERGE_ZERO_PROGRESS_CYCLES:-x}"
+assert_match "2c: AIDEVOPS_MERGE_PATTERN_MIN_PRS is positive int" \
+	"^[0-9]+$" "${AIDEVOPS_MERGE_PATTERN_MIN_PRS:-x}"
+assert_match "2d: AIDEVOPS_MERGE_STUCK_ENABLED is 0|1" \
+	"^[01]$" "${AIDEVOPS_MERGE_STUCK_ENABLED:-x}"
+
+assert_gt "2e: STUCK_AGE_MINUTES > 0" "$AIDEVOPS_MERGE_STUCK_AGE_MINUTES" "0"
+assert_gt "2f: ZERO_PROGRESS_CYCLES > 0" "$AIDEVOPS_MERGE_ZERO_PROGRESS_CYCLES" "0"
+assert_gt "2g: PATTERN_MIN_PRS > 1" "$AIDEVOPS_MERGE_PATTERN_MIN_PRS" "1"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Section 3: pure-logic helpers.
+# ---------------------------------------------------------------------------
+echo "--- Section 3: _pms_iso_to_epoch + _pms_hash_fingerprint ---"
+
+# 3a: ISO timestamp → positive epoch
+epoch=$(_pms_iso_to_epoch "2026-04-30T14:00:00Z")
+assert_gt "3a: valid ISO 2026-04-30T14:00:00Z → epoch > 0" "$epoch" "0"
+
+# 3b: garbage → 0
+garbage_epoch=$(_pms_iso_to_epoch "not-a-date")
+assert_eq "3b: garbage input → 0" "0" "$garbage_epoch"
+
+# 3c: hash returns 16 hex chars
+hash_out=$(_pms_hash_fingerprint "Format,Lint,Typecheck")
+assert_match "3c: hash is 16 hex chars" "^[0-9a-f]{16}$" "$hash_out"
+
+# 3d: hash deterministic
+hash_a=$(_pms_hash_fingerprint "stable-input")
+hash_b=$(_pms_hash_fingerprint "stable-input")
+assert_eq "3d: hash deterministic for same input" "$hash_a" "$hash_b"
+
+# 3e: hash differs for different input (collision check, not cryptographic)
+hash_x=$(_pms_hash_fingerprint "input-one")
+hash_y=$(_pms_hash_fingerprint "input-two")
+TESTS_RUN=$((TESTS_RUN + 1))
+if [[ "$hash_x" != "$hash_y" ]]; then
+	echo "${TEST_GREEN}PASS${TEST_NC}: 3e: hash differs across distinct inputs"
+else
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	echo "${TEST_RED}FAIL${TEST_NC}: 3e: hash collision on trivially distinct inputs ($hash_x)"
+fi
+
+# 3f: empty input still produces 16 hex chars
+hash_empty=$(_pms_hash_fingerprint "")
+assert_match "3f: hash of empty string is 16 hex chars" "^[0-9a-f]{16}$" "$hash_empty"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Section 4: pulse_stats_set_gauge / pulse_stats_get_gauge round-trip.
+# ---------------------------------------------------------------------------
+echo "--- Section 4: gauge round-trip ---"
+
+# 4a: get on missing file returns "0"
+rm -f "$PULSE_STATS_FILE"
+got=$(pulse_stats_get_gauge "test_gauge_a")
+assert_eq "4a: get on missing file → 0" "0" "$got"
+
+# 4b: set then get round-trip
+pulse_stats_set_gauge "test_gauge_a" "7" >/dev/null 2>&1
+got=$(pulse_stats_get_gauge "test_gauge_a")
+assert_eq "4b: set 7 → get 7" "7" "$got"
+
+# 4c: overwrite
+pulse_stats_set_gauge "test_gauge_a" "42" >/dev/null 2>&1
+got=$(pulse_stats_get_gauge "test_gauge_a")
+assert_eq "4c: overwrite to 42 → get 42" "42" "$got"
+
+# 4d: non-numeric is rejected (silently — gauge stays at prior value)
+pulse_stats_set_gauge "test_gauge_a" "not-a-number" >/dev/null 2>&1
+got=$(pulse_stats_get_gauge "test_gauge_a")
+assert_eq "4d: non-numeric set ignored, prior value retained" "42" "$got"
+
+# 4e: distinct gauges don't collide
+pulse_stats_set_gauge "test_gauge_b" "99" >/dev/null 2>&1
+got_a=$(pulse_stats_get_gauge "test_gauge_a")
+got_b=$(pulse_stats_get_gauge "test_gauge_b")
+assert_eq "4e: gauge_a unaffected by gauge_b write" "42" "$got_a"
+assert_eq "4e: gauge_b reads back" "99" "$got_b"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Section 5: pulse_merge_zero_progress_record state transitions.
+# ---------------------------------------------------------------------------
+echo "--- Section 5: zero_progress_record transitions ---"
+
+# Reset gauge for a clean state.
+pulse_stats_set_gauge "pulse_merge_zero_progress_cycles" "0" >/dev/null 2>&1
+
+# 5a: merged>0 + eligible=anything → gauge reset to 0
+pulse_stats_set_gauge "pulse_merge_zero_progress_cycles" "3" >/dev/null 2>&1
+pulse_merge_zero_progress_record 5 1 >/dev/null 2>&1
+got=$(pulse_stats_get_gauge "pulse_merge_zero_progress_cycles")
+assert_eq "5a: merged>0 resets cycles to 0 (was 3)" "0" "$got"
+
+# 5b: merged=0 + eligible=0 → gauge unchanged (no-op)
+pulse_stats_set_gauge "pulse_merge_zero_progress_cycles" "2" >/dev/null 2>&1
+pulse_merge_zero_progress_record 0 0 >/dev/null 2>&1
+got=$(pulse_stats_get_gauge "pulse_merge_zero_progress_cycles")
+assert_eq "5b: merged=0 + eligible=0 → no-op (still 2)" "2" "$got"
+
+# 5c: merged=0 + eligible>0 → gauge increments by 1
+pulse_stats_set_gauge "pulse_merge_zero_progress_cycles" "0" >/dev/null 2>&1
+pulse_merge_zero_progress_record 4 0 >/dev/null 2>&1
+got=$(pulse_stats_get_gauge "pulse_merge_zero_progress_cycles")
+assert_eq "5c: merged=0 + eligible=4 → cycles 0→1" "1" "$got"
+
+# 5d: a second consecutive zero-progress cycle increments again.
+pulse_merge_zero_progress_record 4 0 >/dev/null 2>&1
+got=$(pulse_stats_get_gauge "pulse_merge_zero_progress_cycles")
+assert_eq "5d: second consecutive zero-progress → 1→2" "2" "$got"
+
+# 5e: a successful merge then resets the streak to 0.
+pulse_merge_zero_progress_record 4 1 >/dev/null 2>&1
+got=$(pulse_stats_get_gauge "pulse_merge_zero_progress_cycles")
+assert_eq "5e: merge during stuck-streak resets cycles to 0" "0" "$got"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Section 6: shellcheck cleanliness.
+# ---------------------------------------------------------------------------
+echo "--- Section 6: shellcheck ---"
+
+run_shellcheck() {
+	local label="$1" file="$2"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if ! command -v shellcheck >/dev/null 2>&1; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label (shellcheck not installed — skipping)"
+		return 0
+	fi
+	local sc_out sc_rc
+	sc_out=$(shellcheck "$file" 2>&1)
+	sc_rc=$?
+	if [[ $sc_rc -eq 0 ]]; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "$sc_out"
+	fi
+	return 0
+}
+
+run_shellcheck "6a: pulse-merge-stuck.sh passes shellcheck" "$MODULE"
+run_shellcheck "6b: pulse-stats-helper.sh passes shellcheck" "$STATS_HELPER"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Summary.
+# ---------------------------------------------------------------------------
+echo "${TEST_BLUE}=== Results: ${TESTS_RUN} tests, ${TESTS_FAILED} failures ===${TEST_NC}"
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Fills the gap between per-label rebase nudges (`origin:interactive`, `origin:worker`) and silent eligible-but-unmerged drift in the deterministic merge pass. Adds a general stuck-merge detector with six classifications, pattern-outage detection across PRs sharing the same FAILURE fingerprint, and a zero-progress circuit breaker that surfaces throughput collapse.

**Canonical motivation (2026-04-30 ~14:00Z, managed private webapp repo):** 8 PRs stuck 9-29h, six sharing identical Setup-step CI failures, no investigation issue filed, no worker dispatched. Pulse silently iterated those PRs cycle after cycle without ever escalating.

## What Changed

**New module — `.agents/scripts/pulse-merge-stuck.sh`** (~880 lines, sourced after `pulse-merge.sh`):

- Six classifications: `STUCK_CHECKS_FAILING`, `STUCK_CONFLICT_NO_NUDGE_LABEL`, `STUCK_BRANCHPROTECT_404`, `STUCK_BRANCHPROTECT_API_ERROR`, `STUCK_AUTH`, `STUCK_OTHER`.
- Per-PR escalation with worker-ready guidance, dedup'd by `<!-- merge-stuck:individual -->`.
- **Pattern outage detection** — when N+ stuck PRs share the same FAILURE fingerprint (sorted check names → sha256 first 16 hex), files one investigation issue per signature, dedup'd by `<!-- merge-stuck:pattern:<hash16> -->`.
- **Zero-progress circuit breaker** — `pulse_merge_zero_progress_cycles` gauge increments when a cycle has eligible-unmerged + zero merges; resets on any successful merge. At threshold (default 5 cycles), files framework-level meta-issue. Suppressed when t2690 GraphQL circuit breaker has fired in last 24h.

**`pulse-merge-process.sh::_check_required_checks_passing`** — distinguishes HTTP 404 (no protection → return 0, allow rollup gate) from real errors (401/403/5xx → preserve t2922 fail-closed). Captures stderr and pattern-matches `HTTP 404|Not Found`.

**`pulse-stats-helper.sh`** — adds `pulse_stats_set_gauge` / `pulse_stats_get_gauge` primitives under new `.gauges.<name>` namespace (single-value semantics, distinct from the per-event counter namespace).

**Wired into `merge_ready_prs_all_repos`** — calls `pulse_merge_stuck_run_pass <repo>` per-repo, sums `_pms_count_eligible_unmerged_for_repo`, then `pulse_merge_zero_progress_record` after the loop.

## Files

- `NEW: .agents/configs/pulse-merge-stuck.conf` — 4 env-var defaults.
- `NEW: .agents/scripts/pulse-merge-stuck.sh` — detector module.
- `NEW: .agents/scripts/tests/test-pulse-merge-stuck.sh` — 31 structural tests.
- `NEW: .agents/reference/pulse-merge-stuck.md` — env vars, dedup markers, classifications, suppression semantics.
- `EDIT: .agents/scripts/pulse-merge-process.sh` — 404 distinction in `_check_required_checks_passing`; wires `pulse_merge_stuck_run_pass` + `pulse_merge_zero_progress_record` into `merge_ready_prs_all_repos`.
- `EDIT: .agents/scripts/pulse-stats-helper.sh` — new `pulse_stats_set_gauge` / `pulse_stats_get_gauge` primitives.
- `EDIT: .agents/scripts/pulse-wrapper.sh` — sources `pulse-merge-stuck.sh` after `pulse-merge-feedback.sh`.
- `EDIT: .agents/scripts/pulse-merge-routine.sh` — sources `pulse-merge-stuck.sh`.

## Verification

```bash
shellcheck .agents/scripts/pulse-merge-stuck.sh \
           .agents/scripts/pulse-merge-process.sh \
           .agents/scripts/pulse-stats-helper.sh
bash .agents/scripts/tests/test-pulse-merge-stuck.sh   # 31 tests, 0 failures
bash .agents/scripts/tests/test-conflict-pattern-detection.sh
bash .agents/scripts/tests/test-pulse-merge-approve-collaborator-guard.sh
```

## New Counters / Gauges

| Name | Kind | Reset trigger |
|---|---|---|
| `pulse_merge_eligible_stuck_pr_count` | gauge | overwritten each cycle |
| `pulse_merge_zero_progress_cycles` | gauge | any successful merge |
| `pulse_merge_branchprotect_404_skips` | counter | — |
| `pulse_merge_stuck_escalations_filed` | counter | — |

## Dedup Markers

| Marker | Scope |
|---|---|
| `<!-- merge-stuck:individual -->` | per-PR escalation comment |
| `<!-- merge-stuck:pattern:<sha256-16> -->` | per-fingerprint outage issue |
| `<!-- merge-stuck:zero-progress -->` | zero-progress meta-issue |
| `<!-- pulse-rebase-nudge -->` | reused for `STUCK_CONFLICT_NO_NUDGE_LABEL` (cannot double-fire alongside per-label nudges) |

## Reference

Full env-var list, classification decision tree, and suppression semantics: `.agents/reference/pulse-merge-stuck.md`.

Resolves #21895

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.14 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-opus-4-7 spent 38m and 106,436 tokens on this with the user in an interactive session.
