### PR TITLE
t3204: restore signature footer on issue-sync auto-close path

### DIFF
--- a/.agents/scripts/issue-sync-helper-close.sh
+++ b/.agents/scripts/issue-sync-helper-close.sh
@@ -83,25 +83,64 @@ _find_closing_pr() {
 	return 1
 }
 
+# t3204: append signature footer to close-comment bodies. Without it the
+# auto-close path (gh issue close --comment from _do_close, which bypasses the
+# `gh` PATH shim because `issue:close` is not in the shim's intercept list)
+# emitted bare one-liners with no runtime/version/model/token metadata —
+# in stark contrast to the rich + signed comments produced by interactive
+# agents using gh_issue_comment / the shim. See AGENTS.md "Signature footer
+# hallucination (t2685)" for the canonical rule.
 _close_comment() {
-	local task_id="$1" text="$2" pr_num="$3" pr_url="$4"
+	local task_id="$1" text="$2" pr_num="$3" pr_url="$4" repo="${5:-}" issue_number="${6:-}"
+	local body
 	# Cancelled/deferred/declined: produce a not-planned comment (no PR needed)
 	if _is_cancelled_or_deferred "$text"; then
 		local reason
 		reason=$(echo "$text" | grep -oiE 'cancelled:[0-9-]+|deferred:[0-9-]+|declined:[0-9-]+|CANCELLED' | head -1 | tr '[:upper:]' '[:lower:]')
 		[[ -z "$reason" ]] && reason="cancelled"
-		echo "Closing as not planned ($reason). Task $task_id resolved in TODO.md."
-		return 0
-	fi
-	if [[ -n "$pr_num" && -n "$pr_url" ]]; then
-		echo "Completed via [PR #${pr_num}](${pr_url}). Task $task_id done in TODO.md."
+		body="Closing as not planned ($reason). Task $task_id resolved in TODO.md."
+	elif [[ -n "$pr_num" && -n "$pr_url" ]]; then
+		body="Completed via [PR #${pr_num}](${pr_url}). Task $task_id done in TODO.md."
 	elif [[ -n "$pr_num" ]]; then
-		echo "Completed via PR #${pr_num}. Task $task_id done in TODO.md."
+		body="Completed via PR #${pr_num}. Task $task_id done in TODO.md."
 	else
 		local d
 		d=$(echo "$text" | grep -oE 'verified:[0-9-]+' | head -1 | sed 's/verified://')
-		[[ -n "$d" ]] && echo "Completed (verified: $d). Task $task_id done in TODO.md." || echo "Completed. Task $task_id done in TODO.md."
+		if [[ -n "$d" ]]; then
+			body="Completed (verified: $d). Task $task_id done in TODO.md."
+		else
+			body="Completed. Task $task_id done in TODO.md."
+		fi
 	fi
+
+	# t3204: append signature footer (--solved since this comment marks issue close).
+	# When repo/issue_number are passed, the helper sums total session time + tokens
+	# across all worker comments on this issue. Fail-open: missing args or helper
+	# failure leaves the body un-signed rather than emitting nothing.
+	local footer=""
+	if [[ -n "$repo" && -n "$issue_number" ]]; then
+		footer=$(gh-signature-helper.sh footer --solved --issue "${repo}#${issue_number}" 2>/dev/null || true)
+	else
+		footer=$(gh-signature-helper.sh footer --solved 2>/dev/null || true)
+	fi
+	printf '%s%s\n' "$body" "$footer"
+	return 0
+}
+
+# t3204: reopen-comment composition extracted into a helper so the signature
+# footer block and the body text are testable in isolation. Called by cmd_reopen
+# below; the helper output replaces the previous inline --comment string.
+_reopen_comment() {
+	local repo="${1:-}" ref_num="${2:-}"
+	local body="Reopened: TODO.md still has this as \`[ ]\` (open) and no merged PR was found. The issue was prematurely closed by a commit keyword. TODO.md is the source of truth for task state."
+	local footer=""
+	if [[ -n "$repo" && -n "$ref_num" ]]; then
+		footer=$(gh-signature-helper.sh footer --issue "${repo}#${ref_num}" 2>/dev/null || true)
+	else
+		footer=$(gh-signature-helper.sh footer 2>/dev/null || true)
+	fi
+	printf '%s%s\n' "$body" "$footer"
+	return 0
 }
 
 # Mark a TODO entry as done: [ ] -> [x] with completed: date.
@@ -167,7 +206,10 @@ _do_close() {
 	fi
 
 	local comment
-	comment=$(_close_comment "$task_id" "$task_with_notes" "$pr_num" "$pr_url")
+	# t3204: pass repo + issue_number so _close_comment can ask the signature
+	# helper for an issue-scoped footer (sums total session time and tokens
+	# across all worker comments on this issue, not just this invocation).
+	comment=$(_close_comment "$task_id" "$task_with_notes" "$pr_num" "$pr_url" "$repo" "$issue_number")
 	if [[ "$DRY_RUN" == "true" ]]; then
 		print_info "[DRY-RUN] Would close #$issue_number ($task_id)"
 		return 0
@@ -337,8 +379,16 @@ cmd_reopen() {
 			continue
 		fi
 
+		# t3204: compose the reopen comment via _reopen_comment so the body
+		# carries a signature footer like every other agent-authored comment.
+		# `gh issue reopen --comment` is NOT intercepted by the gh PATH shim
+		# (only issue:comment / issue:create / issue:edit / pr:* are), so the
+		# footer must be injected here in the helper rather than relying on
+		# the shim layer.
+		local reopen_comment_body
+		reopen_comment_body=$(_reopen_comment "$repo" "$ref_num")
 		gh issue reopen "$ref_num" --repo "$repo" \
-			--comment "Reopened: TODO.md still has this as \`[ ]\` (open) and no merged PR was found. The issue was prematurely closed by a commit keyword. TODO.md is the source of truth for task state." 2>/dev/null && {
+			--comment "$reopen_comment_body" 2>/dev/null && {
 			reopened=$((reopened + 1))
 			print_success "Reopened #$ref_num ($tid)"
 		} || {

--- a/.agents/scripts/tests/test-issue-sync-close-signature.sh
+++ b/.agents/scripts/tests/test-issue-sync-close-signature.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression test for t3204 — issue-sync auto-close path emits unsigned
+# closing comments. Verifies that _close_comment and _reopen_comment in
+# .agents/scripts/issue-sync-helper-close.sh both append the canonical
+# `<!-- aidevops:sig -->` marker to their output.
+#
+# The bash close path bypasses the `gh` PATH shim entirely because
+# `issue:close --comment` is not in the shim's intercept list (only
+# issue:comment / issue:edit / issue:create / pr:* are routed). Without
+# explicit signature injection in the helper, every TODO.md `[x]` push
+# closes its issue with a bare one-liner — losing the audit-trail
+# metadata (runtime, version, model, tokens, session-time) that every
+# other agent-authored comment carries.
+#
+# Mentor pattern: a future regression that re-introduces the bare
+# echo statement in _close_comment will trip "no marker" failures here
+# and explain — via this header comment — why the marker matters.
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+# --- Test fixture: isolate signature helper ---------------------------------
+TMPDIR=$(mktemp -d)
+# Cleanup on exit; the trap fires regardless of pass/fail/early-error.
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Mock signature helper. Emits a leading newline + canonical marker block,
+# matching the real helper's format — the leading `\n` mirrors the real
+# `gh-signature-helper.sh footer` output (verified: xxd shows `0a3c 212d 2d20`
+# = newline + `<!-- `). The `[mock-sig]` line stands in for the real
+# `[aidevops.sh](...)` body so we can detect mock-vs-real footers without
+# brittle version-string matching.
+cat >"$TMPDIR/gh-signature-helper.sh" <<'STUB'
+#!/usr/bin/env bash
+printf '\n<!-- aidevops:sig -->\n---\n[mock-sig]\n'
+exit 0
+STUB
+chmod +x "$TMPDIR/gh-signature-helper.sh"
+export PATH="$TMPDIR:$PATH"
+
+# --- Source the close helper ------------------------------------------------
+# Resolve the helper relative to this test file's location so the test is
+# worktree-portable (works in canonical repo, linked worktrees, deployed copy).
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER_PATH="${TEST_DIR}/../issue-sync-helper-close.sh"
+
+if [[ ! -f "$HELPER_PATH" ]]; then
+	echo "FAIL: issue-sync-helper-close.sh not found at $HELPER_PATH" >&2
+	exit 1
+fi
+
+# Sourcing the close helper is safe because it has no top-level executable
+# code beyond the include guard and SCRIPT_DIR fallback. The helper functions
+# (_close_comment, _reopen_comment) only call _is_cancelled_or_deferred (also
+# defined in the same file) and our mocked gh-signature-helper.sh on PATH.
+# shellcheck source=../issue-sync-helper-close.sh
+source "$HELPER_PATH"
+
+# --- Single-assertion helper (de-duplicates output formatting) --------------
+check_marker() {
+	local label="$1" body="$2"
+	if echo "$body" | grep -q '<!-- aidevops:sig -->'; then
+		PASS=$((PASS + 1))
+		echo "PASS: $label"
+	else
+		FAIL=$((FAIL + 1))
+		echo "FAIL: $label"
+		echo "  Output was:"
+		echo "$body" | sed 's/^/    /'
+	fi
+	return 0
+}
+
+# ============================================================================
+# Test cases for _close_comment
+# ============================================================================
+# The function has four output branches based on input:
+#   (a) cancelled/deferred/declined  → "Closing as not planned (...)"
+#   (b) pr_num + pr_url present       → "Completed via [PR #N](url)..."
+#   (c) pr_num present, no url        → "Completed via PR #N..."
+#   (d) verified: date present        → "Completed (verified: D)..."
+#   (e) fallback                      → "Completed."
+#
+# Each branch must end with the signature marker. The acceptance criteria
+# in the t3204 issue body explicitly call out (a), (b/c/d), and the reopen
+# path — covering all five branches keeps future regressions cheap.
+
+# (b) Completed via PR with URL — most common production case.
+out=$(_close_comment "t999" \
+	"- [x] t999 sample task pr:#42 completed:2026-01-01" \
+	"42" "https://github.com/owner/repo/pull/42" \
+	"owner/repo" "100")
+check_marker "_close_comment: completed-PR-with-URL variant carries signature footer" "$out"
+
+# (c) Completed via PR number only — rare but exercised by older TODO entries.
+out=$(_close_comment "t999" \
+	"- [x] t999 sample task pr:#42" \
+	"42" "" \
+	"owner/repo" "100")
+check_marker "_close_comment: completed-PR-no-URL variant carries signature footer" "$out"
+
+# (d) Completed with verified: date but no PR — common for hand-verified tasks.
+out=$(_close_comment "t999" \
+	"- [x] t999 sample task verified:2026-01-01" \
+	"" "" \
+	"owner/repo" "100")
+check_marker "_close_comment: verified-only variant carries signature footer" "$out"
+
+# (e) Completed with no PR and no verified date — fallback branch.
+out=$(_close_comment "t999" \
+	"- [x] t999 sample task" \
+	"" "" \
+	"owner/repo" "100")
+check_marker "_close_comment: fallback completed variant carries signature footer" "$out"
+
+# (a) Cancelled — must also be signed. The acceptance criteria explicitly
+# enumerates "completed, cancelled, deferred, and declined task variants".
+out=$(_close_comment "t999" \
+	"- [-] t999 sample task cancelled:2026-01-01" \
+	"" "" \
+	"owner/repo" "100")
+check_marker "_close_comment: cancelled variant carries signature footer" "$out"
+
+# (a) Deferred variant.
+out=$(_close_comment "t999" \
+	"- [-] t999 sample task deferred:2026-01-01" \
+	"" "" \
+	"owner/repo" "100")
+check_marker "_close_comment: deferred variant carries signature footer" "$out"
+
+# (a) Declined variant.
+out=$(_close_comment "t999" \
+	"- [-] t999 sample task declined:2026-01-01" \
+	"" "" \
+	"owner/repo" "100")
+check_marker "_close_comment: declined variant carries signature footer" "$out"
+
+# Defensive: missing repo/issue_number args. The helper falls back to the
+# unscoped footer call rather than emitting an unsigned body — verify that
+# the marker is still present in the bare-args case (matches fail-open
+# semantics in the helper comment block).
+out=$(_close_comment "t999" \
+	"- [x] t999 sample task" \
+	"42" "https://github.com/o/r/pull/42" \
+	"" "")
+check_marker "_close_comment: missing repo/issue_number still signs (fail-open)" "$out"
+
+# ============================================================================
+# Test cases for _reopen_comment
+# ============================================================================
+
+# Standard call with both args.
+out=$(_reopen_comment "owner/repo" "100")
+check_marker "_reopen_comment: standard reopen comment carries signature footer" "$out"
+
+# Defensive: missing args still signs (fail-open path).
+out=$(_reopen_comment "" "")
+check_marker "_reopen_comment: missing args still signs (fail-open)" "$out"
+
+# Verify the body text is preserved alongside the footer — guards against a
+# regression that swaps the body for the footer rather than appending.
+out=$(_reopen_comment "owner/repo" "100")
+if echo "$out" | grep -q "Reopened: TODO.md still has this as"; then
+	PASS=$((PASS + 1))
+	echo "PASS: _reopen_comment: body text preserved alongside signature"
+else
+	FAIL=$((FAIL + 1))
+	echo "FAIL: _reopen_comment: body text missing"
+	echo "$out" | sed 's/^/    /'
+fi
+
+# ============================================================================
+# Summary
+# ============================================================================
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/.github/workflows/issue-sync-reusable.yml
+++ b/.github/workflows/issue-sync-reusable.yml
@@ -327,6 +327,19 @@ jobs:
           ref: ${{ inputs.aidevops_ref || 'main' }}
           fetch-depth: 1
 
+      # t3204: prepend the framework scripts dir to PATH so subsequent gh
+      # commands hit the `gh` PATH shim, which auto-injects the signature
+      # footer on `--body`/`--body-file` for issue:comment / issue:edit /
+      # issue:create / pr:* writes. Without this, the dedup-on-open path
+      # below emits an unsigned `gh issue comment` body — the same bug the
+      # bash close path had until t3204 fixed _close_comment.
+      - name: Setup gh shim (auto-inject signature footer on writes)
+        run: |
+          chmod +x __aidevops/.agents/scripts/gh \
+                   __aidevops/.agents/scripts/gh-signature-helper.sh \
+                   2>/dev/null || true
+          echo "${GITHUB_WORKSPACE}/__aidevops/.agents/scripts" >> "$GITHUB_PATH"
+
       - name: Check for duplicate issue and close if found
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -558,6 +571,27 @@ jobs:
           else
             echo "::notice::SYNC_PAT present — TODO.md push will use PAT"
           fi
+
+      # t3204: pull the framework scripts up front so the closing-hygiene and
+      # parent-task nudge steps below — both of which call `gh issue comment`
+      # with inline bodies — can route through the gh PATH shim and pick up
+      # the signature footer automatically. Previously the framework checkout
+      # only ran later in the job (gated by `if: steps.extract.outputs.task_id`)
+      # which is too late for the comment-emitting steps.
+      - name: Checkout aidevops framework scripts (early — for gh shim)
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          repository: marcusquinn/aidevops
+          path: __aidevops
+          ref: ${{ inputs.aidevops_ref || 'main' }}
+          fetch-depth: 1
+
+      - name: Setup gh shim (auto-inject signature footer on writes)
+        run: |
+          chmod +x __aidevops/.agents/scripts/gh \
+                   __aidevops/.agents/scripts/gh-signature-helper.sh \
+                   2>/dev/null || true
+          echo "${GITHUB_WORKSPACE}/__aidevops/.agents/scripts" >> "$GITHUB_PATH"
 
       - name: Extract task ID and collect linked issues
         id: extract
@@ -944,13 +978,13 @@ jobs:
           # See todo/tasks/t2038-brief.md Decision section for rationale.
           token: ${{ secrets.SYNC_PAT || secrets.GITHUB_TOKEN }}
 
-      - name: Checkout aidevops framework scripts
-        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
-        with:
-          repository: marcusquinn/aidevops
-          path: __aidevops
-          ref: ${{ inputs.aidevops_ref || 'main' }}
-          fetch-depth: 1
+      # t3204: framework scripts already pulled by the early "Checkout
+      # aidevops framework scripts (early — for gh shim)" step at the top of
+      # this job. The previous duplicate checkout here would clone the repo
+      # a second time over the same `__aidevops` path on every PR merge —
+      # ~30s of wasted work. The "Checkout repo for TODO.md update" above
+      # checks out the caller repo at the workspace root; `__aidevops/`
+      # remains the framework checkout untouched.
 
       - name: Update TODO.md proof-log
         if: steps.extract.outputs.task_id != ''


### PR DESCRIPTION
## Summary

Issue-sync's bash close path emitted unsigned one-liners on every TODO.md `[x]` push because `gh issue close --comment` is not in the `.agents/scripts/gh` PATH-shim's intercept list (the shim only intercepts `issue:comment|create|edit` and `pr:create|comment|edit`). Every closing comment was missing the `<!-- aidevops:sig -->` marker and the runtime/version/model/tokens/duration metadata that every other agent-authored comment carries.

This patch:
- Routes `_close_comment` through `gh-signature-helper.sh footer --solved --issue OWNER/REPO#NUM` and refactors the body assembly so the footer is appended after every variant (completed-PR-with-URL, completed-PR-no-URL, verified-only, fallback, cancelled, deferred, declined).
- Adds a new `_reopen_comment` helper that mirrors `_close_comment` for symmetry; `cmd_reopen` now composes via the helper instead of inlining the string.
- Prepends the framework checkout to `GITHUB_PATH` in `issue-sync-reusable.yml` for both the `dedup-on-issue-open` and `sync-on-pr-merge` jobs, so the shim covers the `gh issue comment` calls that already go through `issue:comment`. Also removes a duplicate framework-checkout step in `sync-on-pr-merge` that was cloning the same repo twice.
- Adds `tests/test-issue-sync-close-signature.sh` (11 assertions) that mocks the signature helper and asserts the marker is present in every `_close_comment` / `_reopen_comment` output variant including the fail-open path.

## Files Changed

.agents/scripts/issue-sync-helper-close.sh,.agents/scripts/tests/test-issue-sync-close-signature.sh,.github/workflows/issue-sync-reusable.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean on issue-sync-helper-close.sh and the new test. YAML parse OK on issue-sync-reusable.yml. New test passes 11/11. Existing test-issue-sync-for-ref-skip.sh (12/12) and test-issue-sync-pull-seeds-orphans.sh (20/20) still pass. The 3 tier-extraction test failures pre-date this PR (verified by git stash + rerun on origin/main). Project validators bypassed (`tsc` not on PATH in worker shell — pre-existing env issue, not introduced by this PR).

Resolves #21910


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.14 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-opus-4-7 spent 34m and 94,075 tokens on this with the user in an interactive session.