### PR TITLE
GH#21913: scan-stale auto-release ON in AI agent interactive sessions

### DIFF
--- a/.agents/scripts/interactive-session-helper-scan.sh
+++ b/.agents/scripts/interactive-session-helper-scan.sh
@@ -408,7 +408,8 @@ _isc_scan_dead_stamps_phase() {
 # Subcommand: scan-stale
 # -----------------------------------------------------------------------------
 # Three-phase stale detection coordinator. Phase 1 (t2414): auto-releases dead
-# stamps (dead PID + missing worktree) when running in an interactive TTY.
+# stamps (dead PID + missing worktree) when running in an interactive context
+# (human TTY or AI agent runtime).
 # Phase 1a: report-only (stampless origin:interactive claims).
 # Phase 2: report-only (closed-not-merged PR orphans).
 #
@@ -416,12 +417,29 @@ _isc_scan_dead_stamps_phase() {
 #   [--auto-release]    — force Phase 1 auto-release on (overrides env/TTY)
 #   [--no-auto-release] — force Phase 1 auto-release off (overrides env/TTY)
 #
-# Env: AIDEVOPS_SCAN_STALE_AUTO_RELEASE=0|1 — overrides TTY detection.
+# Env: AIDEVOPS_SCAN_STALE_AUTO_RELEASE=0|1 — overrides runtime detection.
+#
+# Auto-release detection priority (t3205):
+#   1. Explicit --auto-release / --no-auto-release flag
+#   2. AIDEVOPS_SCAN_STALE_AUTO_RELEASE env var (0 or 1)
+#   3. TTY (stdin AND stdout are terminals) → ON
+#   4. Headless markers (FULL_LOOP_HEADLESS / AIDEVOPS_HEADLESS /
+#      OPENCODE_HEADLESS / GITHUB_ACTIONS) → OFF (truly headless wins)
+#   5. AI agent runtime markers (OPENCODE_SESSION_ID / OPENCODE_RUN_ID /
+#      OPENCODE_PID / CLAUDECODE / CLAUDE_CODE / CLAUDE_SESSION_ID /
+#      CLAUDE_CODE_SSE_PORT) → ON (agent driving an interactive user session)
+#   6. Conservative default → OFF
+#
+# The AI-agent branch (5) closes the gap where an OpenCode TUI or Claude Code
+# CLI agent drives `scan-stale` at session start (per the t2056 protocol) but
+# the agent's bash subprocess is piped from the runtime, so [[ -t 0 && -t 1 ]]
+# returns false. Without this branch, agents would re-discover the
+# `--auto-release` flag every session as the same dead stamps reappear.
 #
 # Exit: 0 always.
 _isc_cmd_scan_stale() {
-	# --- auto-release flag resolution (t2414) ---
-	# Priority: explicit flag > env var > TTY detection > default OFF.
+	# --- auto-release flag resolution (t2414, t3205) ---
+	# Priority: explicit flag > env var > TTY > headless > AI-agent > OFF.
 	local auto_release_flag=""
 	while [[ $# -gt 0 ]]; do
 		local _arg="$1"
@@ -435,7 +453,21 @@ _isc_cmd_scan_stale() {
 		auto_release_flag="${AIDEVOPS_SCAN_STALE_AUTO_RELEASE}"
 	fi
 	if [[ -z "$auto_release_flag" ]]; then
-		[[ -t 0 && -t 1 ]] && auto_release_flag=1 || auto_release_flag=0
+		if [[ -t 0 && -t 1 ]]; then
+			# Human-driven TTY session.
+			auto_release_flag=1
+		elif [[ -n "${FULL_LOOP_HEADLESS:-}${AIDEVOPS_HEADLESS:-}${OPENCODE_HEADLESS:-}${GITHUB_ACTIONS:-}" ]]; then
+			# Truly headless: pulse worker, CI runner, scheduled job.
+			auto_release_flag=0
+		elif [[ -n "${OPENCODE_SESSION_ID:-}${OPENCODE_RUN_ID:-}${OPENCODE_PID:-}${CLAUDECODE:-}${CLAUDE_CODE:-}${CLAUDE_SESSION_ID:-}${CLAUDE_CODE_SSE_PORT:-}" ]]; then
+			# AI-agent runtime markers: user driving an OpenCode TUI or Claude
+			# Code CLI session — agent's bash is piped, no TTY, but the
+			# user is present and stale stamps should be auto-released.
+			auto_release_flag=1
+		else
+			# Unknown context — conservative default.
+			auto_release_flag=0
+		fi
 	fi
 
 	# --- Phase 1: stamp-based stale claim detection (extracted for line-cap) ---

--- a/.agents/scripts/tests/test-scan-stale-auto-release.sh
+++ b/.agents/scripts/tests/test-scan-stale-auto-release.sh
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 # SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
 #
-# test-scan-stale-auto-release.sh — t2414 regression guard.
+# test-scan-stale-auto-release.sh — t2414 + t3205 regression guard.
 #
 # Asserts that `_isc_cmd_scan_stale` Phase 1 auto-releases stamps ONLY when
 # BOTH conditions hold: dead PID AND missing worktree. Any live signal (live
@@ -15,6 +15,17 @@
 #   session died without cleanup, there is no ambiguity and no false-positive
 #   surface.
 #
+# t3205 (GH#21913): the bare TTY check `[[ -t 0 && -t 1 ]]` collapsed two
+#   distinct concepts (truly-headless vs AI-agent-interactive). OpenCode TUI
+#   and Claude Code CLI agents pipe their bash subprocess from the runtime,
+#   so the TTY check returned false in user-driving-an-agent sessions, leaving
+#   stale stamps unreleased every session-start scan. Tests 8 and 9 lock in
+#   the three-way detection that distinguishes:
+#     - human TTY → ON
+#     - explicit headless markers → OFF (wins over AI-agent markers)
+#     - AI-agent runtime markers → ON
+#     - unknown → OFF (conservative)
+#
 # Tests:
 #   1. dead PID + missing worktree → stamp auto-released (file removed)
 #   2. live PID + missing worktree → stamp preserved
@@ -23,6 +34,8 @@
 #   5. --no-auto-release flag → dead+missing stamp NOT released (report only)
 #   6. AIDEVOPS_SCAN_STALE_AUTO_RELEASE=0 env → dead+missing stamp NOT released
 #   7. AIDEVOPS_SCAN_STALE_AUTO_RELEASE=1 env + non-TTY → dead+missing released
+#   8. OPENCODE_SESSION_ID set, no TTY, no headless → dead+missing released (t3205)
+#   9. AIDEVOPS_HEADLESS + OPENCODE_SESSION_ID → stamp preserved (headless wins, t3205)
 #
 # Stub strategy: override `_isc_release_claim_by_stamp_path` as a shell function
 # after sourcing the helper to capture auto-release calls without real gh ops.
@@ -244,6 +257,83 @@ else
 	fail "AIDEVOPS_SCAN_STALE_AUTO_RELEASE=1 env → dead+missing stamp released" \
 		"stamp still exists despite AIDEVOPS_SCAN_STALE_AUTO_RELEASE=1"
 fi
+
+# =============================================================================
+# Test 8 — AI-agent runtime markers (no TTY, no headless) → auto-released (t3205)
+# =============================================================================
+# t3205: previously, scan-stale defaulted auto-release OFF in OpenCode/Claude
+# Code agent sessions because the agent's bash subprocess is piped from the
+# runtime ([[ -t 0 && -t 1 ]] returns false). Tests 8/9 lock in the new
+# three-way detection: runtime markers count as "interactive enough".
+write_stamp "owner-repo-108.json" "99999" "/nonexistent/path/108" "108" "owner/repo"
+
+# Force off all override paths and headless markers; set AI-agent marker only.
+# Tests run via `bash test.sh`, so [[ -t 0 && -t 1 ]] is already false here.
+unset AIDEVOPS_SCAN_STALE_AUTO_RELEASE
+env -u FULL_LOOP_HEADLESS -u AIDEVOPS_HEADLESS -u OPENCODE_HEADLESS \
+	-u GITHUB_ACTIONS -u OPENCODE_RUN_ID -u OPENCODE_PID \
+	-u CLAUDECODE -u CLAUDE_CODE -u CLAUDE_SESSION_ID -u CLAUDE_CODE_SSE_PORT \
+	OPENCODE_SESSION_ID=test-session-id \
+	bash -c "
+		set -uo pipefail
+		# Re-source the helper inside this clean env subshell.
+		# shellcheck source=/dev/null
+		source '${SCRIPTS_DIR}/interactive-session-helper.sh' >/dev/null 2>&1 || true
+		_isc_release_claim_by_stamp_path() {
+			rm -f \"\$1\" 2>/dev/null || true
+			return 0
+		}
+		_isc_scan_stampless_phase() { :; return 0; }
+		_isc_scan_closed_pr_orphans() { printf '0'; return 0; }
+		CLAIM_STAMP_DIR='$STAMP_DIR'
+		_isc_cmd_scan_stale >/dev/null 2>/dev/null || true
+	"
+
+if [[ ! -f "${STAMP_DIR}/owner-repo-108.json" ]]; then
+	pass "OPENCODE_SESSION_ID set, no TTY → dead+missing stamp auto-released"
+else
+	fail "OPENCODE_SESSION_ID set, no TTY → dead+missing stamp auto-released" \
+		"stamp still exists despite AI-agent runtime marker — t3205 branch did not fire"
+fi
+# Cleanup
+rm -f "${STAMP_DIR}/owner-repo-108.json"
+
+# =============================================================================
+# Test 9 — Headless wins over AI-agent marker → stamp preserved (t3205)
+# =============================================================================
+# When BOTH AIDEVOPS_HEADLESS and OPENCODE_SESSION_ID are set, the headless
+# marker MUST take precedence. Pulse-spawned workers run inside an OpenCode
+# child process and inherit OPENCODE_SESSION_ID; without this precedence rule,
+# the worker would auto-release stamps owned by other live sessions.
+write_stamp "owner-repo-109.json" "99999" "/nonexistent/path/109" "109" "owner/repo"
+
+env -u FULL_LOOP_HEADLESS -u OPENCODE_HEADLESS -u GITHUB_ACTIONS \
+	-u OPENCODE_RUN_ID -u OPENCODE_PID -u CLAUDECODE -u CLAUDE_CODE \
+	-u CLAUDE_SESSION_ID -u CLAUDE_CODE_SSE_PORT \
+	AIDEVOPS_HEADLESS=1 OPENCODE_SESSION_ID=test-session-id \
+	bash -c "
+		set -uo pipefail
+		unset AIDEVOPS_SCAN_STALE_AUTO_RELEASE
+		# shellcheck source=/dev/null
+		source '${SCRIPTS_DIR}/interactive-session-helper.sh' >/dev/null 2>&1 || true
+		_isc_release_claim_by_stamp_path() {
+			rm -f \"\$1\" 2>/dev/null || true
+			return 0
+		}
+		_isc_scan_stampless_phase() { :; return 0; }
+		_isc_scan_closed_pr_orphans() { printf '0'; return 0; }
+		CLAIM_STAMP_DIR='$STAMP_DIR'
+		_isc_cmd_scan_stale >/dev/null 2>/dev/null || true
+	"
+
+if [[ -f "${STAMP_DIR}/owner-repo-109.json" ]]; then
+	pass "AIDEVOPS_HEADLESS=1 + OPENCODE_SESSION_ID → stamp preserved (headless wins)"
+else
+	fail "AIDEVOPS_HEADLESS=1 + OPENCODE_SESSION_ID → stamp preserved (headless wins)" \
+		"stamp deleted — headless marker must take precedence over AI-agent marker"
+fi
+# Cleanup
+rm -f "${STAMP_DIR}/owner-repo-109.json"
 
 # =============================================================================
 # Summary


### PR DESCRIPTION
## Summary

Replace TTY-only detection in _isc_cmd_scan_stale with three-way runtime classification: human TTY → ON, explicit headless markers → OFF (wins over agent markers), AI-agent runtime markers (OPENCODE_*, CLAUDE_*) → ON, unknown → OFF. Fixes the canonical t3087 cleanup case where 6 stale stamps surfaced but bare scan-stale released zero because the agent's piped bash subprocess returned false on [[ -t 0 && -t 1 ]].

## Files Changed

.agents/scripts/interactive-session-helper-scan.sh,.agents/scripts/tests/test-scan-stale-auto-release.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean on both files; new Tests 8/9 PASS (AI-agent marker → release; AI-agent + headless → preserve, headless wins). Pre-existing Test 2 failure (live-PID guard vs t2421 worker-pattern liveness) verified on origin/main, unrelated to t3205, will be filed as follow-up.

Resolves #21913


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.15 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-opus-4-7 spent 18m and 53,245 tokens on this with the user in an interactive session.