### PR TITLE
t3207: test-scan-stale: extend WORKER_PROCESS_PATTERN with bash for test bash-runner

### DIFF
--- a/.agents/scripts/tests/test-scan-stale-auto-release.sh
+++ b/.agents/scripts/tests/test-scan-stale-auto-release.sh
@@ -121,6 +121,17 @@ print_success() { :; return 0; }
 log_verbose() { :; return 0; }
 export -f print_info print_warning print_error print_success log_verbose
 
+# Override WORKER_PROCESS_PATTERN so the test bash process matches when we
+# plant a stamp with pid=$$ (Test 2 / Test 4). The default pattern
+# 'opencode|claude|Claude' (shared-constants.sh:1104) intentionally rejects
+# non-runtime PIDs to defeat macOS PID reuse spoofing (t2421, GH#20027). The
+# test process is bash, so we extend the pattern. Must be `export`ed BEFORE
+# `source` so subshells in Tests 8/9 inherit it; the
+# `[[ -z "${WORKER_PROCESS_PATTERN+x}" ]]` guard in shared-constants.sh
+# preserves our value across `source` calls. Mirrors the precedent in
+# test-worktree-cleanup-claim-guard.sh:75 (t2421 fan-out).
+export WORKER_PROCESS_PATTERN='opencode|claude|Claude|bash'
+
 # shellcheck source=../interactive-session-helper.sh
 source "${SCRIPTS_DIR}/interactive-session-helper.sh" >/dev/null 2>&1 || true
 


### PR DESCRIPTION
Resolves #21922

## Summary

Test 2 ("live PID + missing worktree → stamp preserved") in `.agents/scripts/tests/test-scan-stale-auto-release.sh` was failing on `origin/main` because the test used `pid=$$` (the test bash runner). After t2421 (GH#20027 — command-aware liveness to defeat macOS PID reuse), `_isc_scan_dead_stamps_phase` calls `_is_process_alive_and_matches "$pid" "${WORKER_PROCESS_PATTERN:-}"` which requires the live PID's command to match `'opencode|claude|Claude'`. The bash test-runner doesn't match, so the helper classified the stamp as dead and auto-released it — Test 2 asserts preservation and failed.

## Why fix the test, not the helper (per issue body recommendation)

The t2421 contract is deliberate: bare `kill -0` lies on macOS PID reuse (PIDs wrap at 99999), so workers MUST verify the PID's command matches the expected runtime pattern before treating it as alive. Relaxing `_is_process_alive_and_matches` for non-worker PIDs would re-open the spoofing hole (e.g., recycled PID landing on "Brave Browser Helper (Renderer)").

The test's `pid=$$` always encoded the pre-t2421 contract. The lowest-blast-radius fix is to extend `WORKER_PROCESS_PATTERN` in the test process to include `bash` so the test runner's PID matches.

## Prior-art alignment

The same pattern is already used at `test-worktree-cleanup-claim-guard.sh:75` (also a t2421 fan-out):

```bash
export WORKER_PROCESS_PATTERN='opencode|claude|Claude|bash'
```

The export-before-source pattern works because `shared-constants.sh:1104` guards the assignment:

```bash
[[ -z "${WORKER_PROCESS_PATTERN+x}" ]] && WORKER_PROCESS_PATTERN='opencode|claude|Claude'
```

When the test exports the value before sourcing, the source no-ops on the assignment.

## Production contract preserved

- Only `.agents/scripts/tests/test-scan-stale-auto-release.sh` was modified.
- `interactive-session-helper-scan.sh::_isc_scan_dead_stamps_phase` is unchanged.
- `shared-constants.sh::_is_process_alive_and_matches` is unchanged.
- Real OpenCode/Claude Code/aidevops worker PIDs continue to require a matching command before counting as alive.
- No production caller exports `WORKER_PROCESS_PATTERN` to include `bash`; the override is scoped to the test process.

## Subshell propagation (Tests 8 and 9)

Tests 8 and 9 spawn `env -u … bash -c "…"` subshells that re-source the helper inside. The unset list does NOT include `WORKER_PROCESS_PATTERN`, so the parent's export propagates and the in-subshell source no-ops on the assignment. Both tests use `pid=99999` (dead) — the pattern check is never reached anyway, but the export is still inherited cleanly.

## Verification

```text
$ bash .agents/scripts/tests/test-scan-stale-auto-release.sh
Running scan-stale auto-release tests (t2414 / GH#20012)
  PASS dead PID + missing worktree → stamp auto-released
  PASS live PID + missing worktree → stamp preserved
  PASS dead PID + existing worktree → stamp preserved
  PASS live PID + existing worktree → stamp preserved
  PASS --no-auto-release flag → dead+missing stamp preserved (report only)
  PASS AIDEVOPS_SCAN_STALE_AUTO_RELEASE=0 → stamp preserved
  PASS AIDEVOPS_SCAN_STALE_AUTO_RELEASE=1 env → dead+missing stamp released
  PASS OPENCODE_SESSION_ID set, no TTY → dead+missing stamp auto-released
  PASS AIDEVOPS_HEADLESS=1 + OPENCODE_SESSION_ID → stamp preserved (headless wins)

All 9 tests passed
```

Sister-test regression check (uses the same `WORKER_PROCESS_PATTERN` override pattern):

```text
$ bash .agents/scripts/tests/test-worktree-cleanup-claim-guard.sh
All 10 tests passed
```

Shellcheck on the modified test: clean (no output).

## Risk Assessment

- Low. Test-only change. No production code modified.
- Sibling test `test-worktree-cleanup-claim-guard.sh` validates the same `bash`-extended pattern is safe in the t2421 codepath.

## Runtime Testing

`self-assessed`. Test runs are the runtime evidence; no dev-server or external service involved. Risk: low (test infrastructure only, no production code path touched).

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.15 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-opus-4-7 spent 6m and 14,049 tokens on this as a headless worker.
