### PR TITLE
t3210: pre-canary system overload check (root cause #21919 + sibling trips)

### DIFF
--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -870,6 +870,25 @@ CANARY_NEGATIVE_TTL_SECONDS="${CANARY_NEGATIVE_TTL_SECONDS:-90}"
 # still allowing recovery within a single pulse-update cycle.
 CANARY_CONFIG_ERROR_TTL_SECONDS="${CANARY_CONFIG_ERROR_TTL_SECONDS:-3600}"
 
+# t3210: System overload TTL. The canary spawns a fresh `opencode run` that
+# does a one-time DB migration on each invocation; under heavy disk/CPU
+# contention from many concurrent workers (canonical: load avg >> NCPU on
+# a developer macbook), the migration + LLM round-trip exceeds
+# CANARY_TIMEOUT_SECONDS even when opencode, auth, and the API all work
+# in isolation. Treating overload as `transient` (90s TTL) causes the
+# circuit-breaker re-trip cycle (#21919, #21556, #4360, #4318, #2293,
+# #2292): 90s expires → still overloaded → canary times out → 3x
+# no_worker_process → trip → auto-reset → repeat. Overload self-resolves
+# in 5-15 min as concurrent workers complete and exit. 300s default gives
+# load time to subside without wasting canary CPU on doomed attempts.
+CANARY_OVERLOAD_TTL_SECONDS="${CANARY_OVERLOAD_TTL_SECONDS:-300}"
+
+# t3210: Load multiplier for the pre-canary overload check.
+# load_avg_1min > NCPU * MULTIPLIER = system overloaded, skip canary.
+# Default 2 = system is noticeably contending. Lower = more aggressive
+# (skip canary sooner). Set very high (e.g. 100) to effectively disable.
+CANARY_OVERLOAD_LOAD_MULTIPLIER="${CANARY_OVERLOAD_LOAD_MULTIPLIER:-2}"
+
 #######################################
 # t2887: Validate that an opencode binary path is the real anomalyco/opencode.
 #
@@ -1008,6 +1027,59 @@ _enforce_opencode_version_pin() {
 	return 0
 }
 
+# t3210: Detect system-wide CPU/IO overload before spawning the canary.
+# The canary spawns a fresh `opencode run` that runs a one-time DB migration
+# on each invocation; under heavy disk/CPU contention from many concurrent
+# workers, the migration + LLM round-trip can exceed CANARY_TIMEOUT_SECONDS
+# (default 60s) even when opencode, auth, and the API all work in isolation.
+#
+# This is a *pre-flight* check, not a substitute for the canary -- when the
+# system is healthy this returns 0 instantly and the canary runs as before.
+# When overloaded (load_1min > NCPU * MULTIPLIER), it returns 1 so the caller
+# can skip the canary and stamp `reason=overload` for a longer negative-cache
+# TTL. Without this, the canary fails with exit=124 (timeout), gets stamped
+# `transient` (90s TTL), the negative cache expires while load is still
+# elevated, the next canary times out, ... -> 3x no_worker_process trips
+# the supervisor circuit breaker. Canonical incident: GH#21919, GH#21556,
+# GH#4360, GH#4318, GH#2293, GH#2292.
+#
+# Cost: one `uptime` + one `sysctl`/`nproc` invocation, both <5ms.
+# Threshold: load_1min > NCPU * CANARY_OVERLOAD_LOAD_MULTIPLIER (default 2).
+# Override: set CANARY_OVERLOAD_LOAD_MULTIPLIER very high (e.g. 100) to
+# effectively disable the gate.
+#
+# Returns 0 = system OK (proceed with canary), 1 = overloaded (skip canary).
+# On rc=1, prints a warning with load + ncpu + threshold to stderr.
+_check_system_overload() {
+	local load_1min ncpu threshold
+	# Portable load_1min extraction. On macOS, `uptime` prints
+	# "... load averages: 1.23 2.34 3.45"; on Linux, "... load average:
+	# 1.23, 2.34, 3.45". Both have the 1-min value right after the colon
+	# group; awk on the third-from-last field is reliable on both.
+	load_1min=$(uptime 2>/dev/null | awk -F'[a-z]: ' '{print $2}' | awk '{gsub(/,/, ""); print $1}' 2>/dev/null || echo "")
+	if [[ -z "$load_1min" ]] || ! [[ "$load_1min" =~ ^[0-9]+\.?[0-9]*$ ]]; then
+		# uptime parse failed or returned non-numeric -- fail open.
+		return 0
+	fi
+	# Portable CPU count. nproc on Linux, sysctl on macOS, fallback to 4.
+	ncpu=$(nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4)
+	if ! [[ "$ncpu" =~ ^[0-9]+$ ]] || [[ "$ncpu" -lt 1 ]]; then
+		ncpu=4
+	fi
+	# threshold = ncpu * multiplier, computed in awk to handle non-integer
+	# multipliers (e.g. 0.5 for aggressive, 1.5 for moderate). bash arithmetic
+	# is integer-only so awk is the portable path.
+	threshold=$(awk -v n="$ncpu" -v m="$CANARY_OVERLOAD_LOAD_MULTIPLIER" 'BEGIN{printf "%.2f", n * m}')
+	# Compare load_1min > threshold via awk (floating-point comparison).
+	local is_overloaded
+	is_overloaded=$(awk -v l="$load_1min" -v t="$threshold" 'BEGIN{print (l > t) ? "1" : "0"}')
+	if [[ "$is_overloaded" == "1" ]]; then
+		print_warning "Canary skipped: system overloaded (load_1min=${load_1min}, ncpu=${ncpu}, threshold=${threshold}, multiplier=${CANARY_OVERLOAD_LOAD_MULTIPLIER}) -- canary cold-start cannot complete reliably under contention (t3210)"
+		return 1
+	fi
+	return 0
+}
+
 _run_canary_test() {
 	local requested_model="${1:-}"
 	local cache_file="${STATE_DIR}/canary-last-pass"
@@ -1046,13 +1118,35 @@ _run_canary_test() {
 		neg_now=$(date +%s)
 		neg_age=$((neg_now - last_fail))
 		fail_reason=$(cat "$fail_reason_file" 2>/dev/null || echo "transient")
-		if [[ "$fail_reason" == "config_error" ]]; then
-			active_ttl="$CANARY_CONFIG_ERROR_TTL_SECONDS"
-		else
-			active_ttl="$CANARY_NEGATIVE_TTL_SECONDS"
-		fi
+		# t2887/t3210: TTL is reason-aware. Each failure class has its own
+		# self-resolution timescale, so a one-size-fits-all TTL either spams
+		# the canary on structural problems (90s on a missing binary) or
+		# delays recovery on transient ones (1h on an auth blip).
+		case "$fail_reason" in
+			config_error) active_ttl="$CANARY_CONFIG_ERROR_TTL_SECONDS" ;;
+			overload) active_ttl="$CANARY_OVERLOAD_TTL_SECONDS" ;;
+			*) active_ttl="$CANARY_NEGATIVE_TTL_SECONDS" ;;
+		esac
 		if [[ "$last_fail" =~ ^[0-9]+$ ]] && [[ "$neg_age" -ge 0 ]] && [[ "$neg_age" -lt "$active_ttl" ]]; then
-			print_warning "Canary negative cache active (age=${neg_age}s, ttl=${active_ttl}s, reason=${fail_reason}) — failing fast (t2814/t2887)"
+			print_warning "Canary negative cache active (age=${neg_age}s, ttl=${active_ttl}s, reason=${fail_reason}) — failing fast (t2814/t2887/t3210)"
+			return 1
+		fi
+	fi
+
+	# t3210: Pre-canary system overload check. If load_1min > NCPU *
+	# multiplier, skip the canary and stamp reason=overload. The canary's
+	# cold-start DB migration + LLM round-trip cannot reliably complete
+	# within CANARY_TIMEOUT_SECONDS (default 60s) under heavy contention,
+	# so running it just burns CPU on a doomed attempt and trips the
+	# supervisor circuit breaker via cascading no_worker_process failures.
+	# Overload self-resolves on a 5-15 min timescale as concurrent workers
+	# complete, hence the 300s default TTL (CANARY_OVERLOAD_TTL_SECONDS).
+	# Bypass: AIDEVOPS_SKIP_CANARY_OVERLOAD_CHECK=1 (e.g. for testing).
+	if [[ "${AIDEVOPS_SKIP_CANARY_OVERLOAD_CHECK:-0}" != "1" ]]; then
+		if ! _check_system_overload; then
+			mkdir -p "${STATE_DIR}" 2>/dev/null || true
+			date +%s >"$fail_cache_file" 2>/dev/null || true
+			printf 'overload\n' >"$fail_reason_file" 2>/dev/null || true
 			return 1
 		fi
 	fi

--- a/.agents/scripts/tests/test-no-worker-process-fix.sh
+++ b/.agents/scripts/tests/test-no-worker-process-fix.sh
@@ -459,6 +459,115 @@ test_negative_cache_behavioural() {
 }
 
 # ---------------------------------------------------------------------------
+# t3210: System overload pre-check — distinct failure class with longer TTL.
+# Without this, overloaded systems trigger the canary timeout cycle that
+# trips the supervisor circuit breaker (GH#21919, GH#21556, GH#4360, ...).
+# ---------------------------------------------------------------------------
+
+test_overload_constants_present() {
+	if grep -q 'CANARY_OVERLOAD_TTL_SECONDS' "$HEADLESS_LIB" \
+		&& grep -q 'CANARY_OVERLOAD_LOAD_MULTIPLIER' "$HEADLESS_LIB"; then
+		print_result "t3210: overload TTL + multiplier env vars defined" 0
+		return 0
+	fi
+	print_result "t3210: overload TTL + multiplier env vars defined" 1 \
+		"Expected CANARY_OVERLOAD_TTL_SECONDS and CANARY_OVERLOAD_LOAD_MULTIPLIER in $HEADLESS_LIB"
+	return 0
+}
+
+test_overload_helper_present() {
+	if grep -q '^_check_system_overload()' "$HEADLESS_LIB" \
+		&& grep -q 'system overloaded' "$HEADLESS_LIB"; then
+		print_result "t3210: _check_system_overload helper defined" 0
+		return 0
+	fi
+	print_result "t3210: _check_system_overload helper defined" 1 \
+		"Expected _check_system_overload function + 'system overloaded' message in $HEADLESS_LIB"
+	return 0
+}
+
+test_overload_check_wired_into_canary() {
+	# Pre-canary check must run before binary validation and stamp
+	# overload reason on rc=1.
+	local lib_text
+	lib_text=$(cat "$HEADLESS_LIB")
+	# shellcheck disable=SC2016  # matching literal source text
+	if [[ "$lib_text" == *'_check_system_overload'* ]] \
+		&& [[ "$lib_text" == *"printf 'overload"* ]]; then
+		print_result "t3210: overload check wired into _run_canary_test" 0
+		return 0
+	fi
+	print_result "t3210: overload check wired into _run_canary_test" 1 \
+		"Expected _check_system_overload call + overload reason write in $HEADLESS_LIB"
+	return 0
+}
+
+test_overload_ttl_in_case_selector() {
+	# The TTL selector must handle the new overload reason via a case
+	# branch, not the old if/else.
+	local lib_text
+	lib_text=$(cat "$HEADLESS_LIB")
+	# shellcheck disable=SC2016  # matching literal source text
+	if [[ "$lib_text" == *'overload) active_ttl="$CANARY_OVERLOAD_TTL_SECONDS"'* ]]; then
+		print_result "t3210: TTL case selector includes overload branch" 0
+		return 0
+	fi
+	print_result "t3210: TTL case selector includes overload branch" 1 \
+		"Expected 'overload) active_ttl=\"\$CANARY_OVERLOAD_TTL_SECONDS\"' in $HEADLESS_LIB"
+	return 0
+}
+
+# Behavioural: extract the helper and verify it returns 1 on synthetic
+# overload (very low multiplier) and 0 when guarded against (very high).
+test_overload_helper_behavioural() {
+	local sandbox helper_extract
+	sandbox=$(mktemp -d "${TMPDIR:-/tmp}/aidevops-t3210-test.XXXXXX")
+	# shellcheck disable=SC2064
+	trap "rm -rf '$sandbox' 2>/dev/null || true" RETURN
+	helper_extract="${sandbox}/helper.sh"
+
+	# Extract the helper function block (start at the def line, end at the
+	# first lone closing brace).
+	awk '/^_check_system_overload\(\) \{/,/^\}/' "$HEADLESS_LIB" >"$helper_extract"
+	if [[ ! -s "$helper_extract" ]]; then
+		print_result "t3210: helper behavioural — extraction" 1 \
+			"Failed to extract _check_system_overload from $HEADLESS_LIB"
+		return 0
+	fi
+
+	# Sub-shell test runner: stub print_warning, source helper, run cases.
+	local rc_high rc_low
+	rc_high=$(bash -c "
+		print_warning() { echo \"[WARN] \$*\" >&2; }
+		source '$helper_extract'
+		CANARY_OVERLOAD_LOAD_MULTIPLIER=1000000
+		_check_system_overload && echo 0 || echo 1
+	" 2>/dev/null)
+	rc_low=$(bash -c "
+		print_warning() { echo \"[WARN] \$*\" >&2; }
+		source '$helper_extract'
+		CANARY_OVERLOAD_LOAD_MULTIPLIER=0.0001
+		_check_system_overload && echo 0 || echo 1
+	" 2>/dev/null)
+
+	if [[ "$rc_high" == "0" ]]; then
+		print_result "t3210: high multiplier (1000000) — helper returns 0 (proceed)" 0
+	else
+		print_result "t3210: high multiplier (1000000) — helper returns 0 (proceed)" 1 \
+			"Expected rc=0, got '$rc_high'"
+	fi
+
+	if [[ "$rc_low" == "1" ]]; then
+		print_result "t3210: low multiplier (0.0001) — helper returns 1 (skip canary)" 0
+	else
+		print_result "t3210: low multiplier (0.0001) — helper returns 1 (skip canary)" 1 \
+			"Expected rc=1, got '$rc_low'"
+	fi
+
+	return 0
+}
+
+# ---------------------------------------------------------------------------
 # Failure-mode invariant: the dispatch path must not silently classify
 # infrastructure failures as worker coding failures (overlaps with Phase 4
 # but the assertion belongs here too — once it lands, Phase 4 can extend).
@@ -515,6 +624,13 @@ main_test() {
 	test_negative_cache_short_circuit_present
 	test_negative_cache_writeback_present
 	test_negative_cache_behavioural
+
+	# t3210: System overload pre-check
+	test_overload_constants_present
+	test_overload_helper_present
+	test_overload_check_wired_into_canary
+	test_overload_ttl_in_case_selector
+	test_overload_helper_behavioural
 
 	# Cross-cutting invariant
 	test_failure_classification_distinct


### PR DESCRIPTION
## Summary

Resolves #21931

Pre-canary system overload check that prevents the canary from running when load_1min > NCPU * MULTIPLIER. The canary spawns a fresh `opencode run` doing a one-time DB migration each invocation; under heavy CPU/disk contention from many concurrent workers, the migration + LLM round-trip exceeds `CANARY_TIMEOUT_SECONDS` (default 60s) even when opencode, auth, and the API all work in isolation.

Without this gate, overload-driven canary timeouts get classified as `transient` (90s TTL), the negative cache expires while load is still elevated, the next canary times out, and 3x cascading `no_worker_process` failures trip the supervisor circuit breaker. Canonical incidents: #21919, #21556, #4360, #4318, #2293, #2292 (6 identical trip issues since Feb 25).

## Root Cause Evidence

Reproduced locally on 2026-04-30 16:55 UTC:
- `uptime` reported `load averages: 84.53 100.06 125.45` against `ncpu=10`
- Manual canary cold-start: 11s; parallel pair: 19s; production canary timed out at 60s with `exit=124`
- 21 active worker processes, 103 opencode processes, ~67MB free memory
- DB migrations in canary's per-run `XDG_DATA_HOME` (mktemp) cannot complete quickly under contention even though each canary uses an isolated DB
- `_detect_opencode_server` requires `OPENCODE_SERVER_PASSWORD` (not set in canary path) — server-attach hypothesis ruled out, pure CPU/disk contention

## Implementation

### NEW

None.

### EDIT

- `.agents/scripts/headless-runtime-lib.sh:880-895` — added two env vars: `CANARY_OVERLOAD_TTL_SECONDS` (default 300s) and `CANARY_OVERLOAD_LOAD_MULTIPLIER` (default 2). 300s matches the 5-15 min self-resolution timescale of overload (workers complete and free CPU); separate from `CANARY_NEGATIVE_TTL_SECONDS` (90s, transient) and `CANARY_CONFIG_ERROR_TTL_SECONDS` (3600s, structural).

- `.agents/scripts/headless-runtime-lib.sh:1030-1080` — added `_check_system_overload()` helper. Uses portable `uptime` parsing (works on both macOS and Linux load-average output formats) and `nproc`/`sysctl -n hw.ncpu` for CPU count. Threshold = `ncpu * multiplier`, computed in awk for floating-point support. Returns 0 (proceed) when load OK, 1 (skip canary) on overload.

- `.agents/scripts/headless-runtime-lib.sh:1109-1117` — wired pre-canary overload check into `_run_canary_test` after the negative-cache short-circuit, before binary validation. On rc=1, stamps `overload` reason file and returns 1. Bypass: `AIDEVOPS_SKIP_CANARY_OVERLOAD_CHECK=1`.

- `.agents/scripts/headless-runtime-lib.sh:1099-1107` — replaced `if config_error / else` TTL selector with a `case` statement adding the new `overload) active_ttl="$CANARY_OVERLOAD_TTL_SECONDS"` branch. Pattern follows the existing reason-aware TTL design (t2887).

- `.agents/scripts/tests/test-no-worker-process-fix.sh:466-587` — added 6 t3210 tests: env-var presence, helper presence, canary wiring, case-selector branch, and behavioural verification via subshell-isolated helper extraction at 1000000x and 0.0001x multipliers.

## Verification

Local results on 2026-04-30 17:35 UTC against load=84.53, ncpu=10:

```
$ bash .agents/scripts/tests/test-no-worker-process-fix.sh
... 21 PASS, 0 fail ...
```

Behavioural test confirms the helper actually returns 1 under synthetic overload and 0 when guarded:

```
--- Test 3: current real load against default multiplier (2) ---
uptime: 17:35  up 9 days, 19:13, 1 user, load averages: 84.53 100.06 125.45
ncpu: 10
[WARNING] Canary skipped: system overloaded (load_1min=84.53, ncpu=10, threshold=20.00, multiplier=2) ...
result: rc=1 (overloaded)
```

This proves the fix would correctly skip the canary right now (overloaded), instead of running it for 60s and timing out.

`shellcheck` clean on both edited files. `bash -n` clean on both. Pre-commit ratchet hooks passed both commits.

## Acceptance

- [x] `_check_system_overload` returns 1 when load_1min > ncpu * multiplier; 0 otherwise
- [x] Helper invoked in `_run_canary_test` before binary validation
- [x] On rc=1, stamps `overload` reason and returns 1 without running canary
- [x] Negative-cache TTL selector uses `CANARY_OVERLOAD_TTL_SECONDS` (300s) for `overload` reason
- [x] Existing `transient` (90s) and `config_error` (3600s) classes unchanged
- [x] `shellcheck` clean
- [x] All existing tests pass + new t3210 tests pass (21/21)
- [x] Bypass: `AIDEVOPS_SKIP_CANARY_OVERLOAD_CHECK=1` skips the check entirely
- [x] Threshold tunable: `CANARY_OVERLOAD_LOAD_MULTIPLIER` (default 2)

## Post-Merge Steps

1. `aidevops update` — deploy to `~/.aidevops/agents/scripts/`
2. `aidevops circuit-breaker reset` — clear #21919 trip
3. Monitor next pulse cycle: should not re-trip while load remains elevated (overload reason stamped, 300s negative cache holds)
4. After load subsides naturally (5-15 min), canary should pass on next attempt and clear the negative cache

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.16 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-opus-4-7 spent 36m and 71,920 tokens on this with the user in an interactive session.
