### PR TITLE
t3200: detect shallow clone before rebase to avoid add/add conflict cascade

### DIFF
--- a/.agents/reference/git-hygiene.md
+++ b/.agents/reference/git-hygiene.md
@@ -1,0 +1,97 @@
+# Git Hygiene Reference
+
+<!-- SPDX-License-Identifier: MIT -->
+<!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
+
+Common git state problems that cause confusing failures in the aidevops workflow,
+and the recovery steps to resolve them.
+
+---
+
+## Shallow Clone — add/add Conflict Cascade
+
+**Memory lesson:** "Shallow git clones masquerade as force-pushed history" (stored 2026-04-30)
+
+### Symptom
+
+Running `full-loop-helper.sh commit-and-pr` (or any bare `git rebase origin/main`)
+produces a wall of add/add conflicts across hundreds of files — even when your change
+touches only one file.  Example output:
+
+```text
+CONFLICT (add/add): Merge conflict in .agents/scripts/full-loop-helper-commit.sh
+CONFLICT (add/add): Merge conflict in .agents/scripts/pulse-wrapper.sh
+... (200 more lines)
+Rebase conflict. Resolve conflicts, then run: git rebase --continue ...
+```
+
+The conflicts **cannot be resolved by editing** — they are not semantic conflicts.
+The merge-base is genuinely absent locally because the clone was depth-limited.
+
+### Diagnosis
+
+```bash
+git rev-parse --is-shallow-repository
+# returns "true" if the clone is shallow
+```
+
+If it returns `true`, the fix is to fetch the missing history, not to resolve conflicts.
+
+### Auto-recovery (GH#21900)
+
+As of GH#21900, `_rebase_and_push` in `full-loop-helper-commit.sh` automatically
+detects a shallow clone and runs `git fetch --unshallow origin` before the rebase.
+The default behaviour is to auto-unshallow.  To disable auto-unshallow and receive
+an error message instead, set:
+
+```bash
+export AIDEVOPS_SHALLOW_UNSHALLOW=0
+```
+
+### Manual Recovery
+
+If the auto-unshallow fails or you need to recover mid-conflict:
+
+```bash
+# Step 1: abort any in-progress rebase
+git rebase --abort 2>/dev/null || true
+
+# Step 2: unshallow the clone
+git fetch --unshallow origin
+
+# Step 3: retry the rebase
+git rebase origin/main
+```
+
+### Save-patch Recovery (work was committed before the rebase attempt)
+
+If you had commits that got clobbered:
+
+```bash
+# Save the top commit as a patch
+git format-patch -1 HEAD --stdout > /tmp/save.patch
+
+# Reset to a clean state
+git reset --hard origin/main
+
+# Re-apply the saved patch
+git am /tmp/save.patch
+```
+
+### Root Cause
+
+Multi-runner aidevops setups and CI environments frequently produce shallow clones
+(`git clone --depth=1`) for speed.  When `git rebase origin/main` runs, git needs
+the common ancestor between your branch and `origin/main`.  On a shallow clone that
+ancestor is absent, so git treats every file as simultaneously "added by us" and
+"added by them" — the add/add cascade.
+
+`git fetch origin main` (called first in `_rebase_and_push`) fetches the tip but
+does NOT un-shallow the repo.  Only `git fetch --unshallow origin` restores the
+full commit graph.
+
+### Pre-edit-check Warning
+
+`pre-edit-check.sh` emits a `WARNING: This git clone is shallow` advisory when it
+detects a shallow repo.  This fires at session-start so the operator can fix
+proactively before attempting a commit-and-pr.

--- a/.agents/scripts/full-loop-helper-commit.sh
+++ b/.agents/scripts/full-loop-helper-commit.sh
@@ -427,6 +427,47 @@ _run_project_validators() {
 
 # --- Rebase & Push ---
 
+# Detect a shallow git clone and optionally auto-unshallow.
+# A shallow clone lacks intermediate commit objects between the clone-depth
+# boundary and origin/main tip.  Rebasing on a shallow clone fails with
+# hundreds of 'add/add' conflicts that masquerade as a force-push to origin.
+# Recovery sequence (manual): git fetch --unshallow origin
+#
+# Behaviour:
+#   AIDEVOPS_SHALLOW_UNSHALLOW=0  → warn and return 1 (operator must fix)
+#   AIDEVOPS_SHALLOW_UNSHALLOW=1  → attempt git fetch --unshallow and return 0
+#   default (unset)               → auto-unshallow (same as =1)
+#
+# Args: none
+# Returns: 0 if clone is full-depth or was successfully unshallowed
+#          1 if clone is shallow and auto-unshallow is disabled or failed
+_check_and_handle_shallow_clone() {
+	local is_shallow=""
+	is_shallow=$(git rev-parse --is-shallow-repository 2>/dev/null || echo "false")
+	if [[ "$is_shallow" != "true" ]]; then
+		return 0
+	fi
+
+	local opt="${AIDEVOPS_SHALLOW_UNSHALLOW:-1}"
+	if [[ "$opt" == "0" ]]; then
+		print_error "Local clone is shallow; rebase requires full history."
+		print_error "Run: git fetch --unshallow origin"
+		print_error "See .agents/reference/git-hygiene.md for recovery steps."
+		return 1
+	fi
+
+	print_warning "Shallow clone detected — running git fetch --unshallow origin (set AIDEVOPS_SHALLOW_UNSHALLOW=0 to disable)..."
+	if git fetch --unshallow origin 2>/dev/null; then
+		print_info "Unshallow complete — proceeding with rebase."
+		return 0
+	else
+		print_error "git fetch --unshallow failed. Rebase would produce add/add conflicts."
+		print_error "Resolve manually: git fetch --unshallow origin"
+		print_error "See .agents/reference/git-hygiene.md for recovery steps."
+		return 1
+	fi
+}
+
 # Rebase onto origin/main and force-push the current branch.
 # Args: $1=branch $2=skip_hooks (0|1, optional, default 0)
 # Returns 1 on rebase conflict or push failure.
@@ -438,6 +479,8 @@ _rebase_and_push() {
 	if ! git fetch origin main --quiet 2>/dev/null; then
 		print_warning "git fetch origin main failed — proceeding with current state"
 	fi
+	# GH#21900: detect shallow clone before rebase to avoid add/add conflict cascade.
+	_check_and_handle_shallow_clone || return 1
 	if ! git rebase origin/main 2>/dev/null; then
 		print_error "Rebase conflict. Resolve conflicts, then run: git rebase --continue && full-loop-helper.sh commit-and-pr ..."
 		git rebase --abort 2>/dev/null || true

--- a/.agents/scripts/pre-edit-check.sh
+++ b/.agents/scripts/pre-edit-check.sh
@@ -801,6 +801,18 @@ if [[ -x "$SCRIPT_DIR/session-count-helper.sh" ]]; then
 	fi
 fi
 
+# GH#21900: Shallow clone warning — non-blocking, warn once per session start.
+# A shallow clone will cause add/add conflict cascades if commit-and-pr is run.
+# Auto-unshallow fires inside _rebase_and_push; this is an early advisory so
+# the operator can fix proactively before attempting a rebase.
+_shallow_clone_check=$(git rev-parse --is-shallow-repository 2>/dev/null || echo "false")
+if [[ "$_shallow_clone_check" == "true" ]]; then
+	echo -e "${YELLOW}WARNING: This git clone is shallow (depth-limited).${NC}"
+	echo -e "${YELLOW}  commit-and-pr will attempt auto-unshallow before rebase.${NC}"
+	echo -e "${YELLOW}  To fix now: git fetch --unshallow origin${NC}"
+	echo -e "${YELLOW}  See .agents/reference/git-hygiene.md for details.${NC}"
+fi
+
 # go for it — linked worktree is the correct working context
 echo -e "${GREEN}OK${NC} - In linked worktree on ref: ${BOLD}$current_branch${NC}"
 exit 0


### PR DESCRIPTION
## What

Detects shallow git clones before `git rebase origin/main` in `_rebase_and_push`, eliminating the add/add conflict cascade that occurs when intermediate commit objects are missing locally.

## Changes

### `full-loop-helper-commit.sh`

New `_check_and_handle_shallow_clone()` function called inside `_rebase_and_push` after `git fetch origin main` and before `git rebase origin/main`:

- Calls `git rev-parse --is-shallow-repository` — fast, no network
- If shallow: auto-runs `git fetch --unshallow origin` (default) then continues
- `AIDEVOPS_SHALLOW_UNSHALLOW=0` disables auto-unshallow and emits a clear error with recovery instructions instead of letting the rebase produce hundreds of add/add conflicts

### `pre-edit-check.sh`

Non-blocking advisory at session start: warns the operator that their clone is shallow so they can fix it before running `commit-and-pr`.

### `.agents/reference/git-hygiene.md` (NEW)

Documents the symptom (add/add cascade), diagnosis command, auto-recovery flow, manual recovery, and the save-patch rescue sequence. References the memory lesson "Shallow git clones masquerade as force-pushed history" (stored 2026-04-30).

## Acceptance

- [x] `full-loop-helper-commit.sh`: `_rebase_and_push` exits 1 with actionable message on shallow clone when `AIDEVOPS_SHALLOW_UNSHALLOW=0`
- [x] `full-loop-helper-commit.sh`: `_rebase_and_push` auto-unshallows by default — no add/add cascade
- [x] `pre-edit-check.sh`: warns at session start when clone is shallow
- [x] `.agents/reference/git-hygiene.md` created with symptom + recovery pattern
- [x] `shellcheck` passes (only pre-existing SC2002 warning, unrelated to this change)

## Verification

```bash
shellcheck .agents/scripts/full-loop-helper-commit.sh
# Expected: only pre-existing SC2002 (useless cat on .task-counter) — not introduced here

# Test (requires a shallow clone):
git clone --depth=1 https://github.com/marcusquinn/aidevops /tmp/aidevops-shallow-test
cd /tmp/aidevops-shallow-test && echo 'test' >> README.md
AIDEVOPS_SHALLOW_UNSHALLOW=0 .agents/scripts/full-loop-helper-commit.sh ...
# Expected: "Local clone is shallow; run git fetch --unshallow origin"
```

## Complexity Bump

No new function exceeds 80 lines. `_check_and_handle_shallow_clone` is 20 lines.

Resolves #21900

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.16 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-sonnet-4-6 spent 3m and 9,361 tokens on this as a headless worker.
