### PR TITLE
t3209: fix pulse-unbound-var-check.yml diff-scoping double-counts replaced lines

### DIFF
--- a/.agents/scripts/tests/test-puv-diff-scoping.sh
+++ b/.agents/scripts/tests/test-puv-diff-scoping.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression test for pulse-unbound-var-check.yml diff-scoping logic (t3209).
+#
+# Verifies that the diff-scoping step uses `git diff MERGE_BASE..HEAD` (net
+# diff) rather than `git log -p --first-parent` (per-commit aggregate).
+#
+# The bug (t3209): if commit 1 adds a buggy `local foo bar` and commit 2
+# replaces it with `local foo="" bar=""`, `git log -p` included BOTH versions
+# in its aggregated output. The scanner then flagged the buggy version even
+# though it no longer existed in HEAD. PR #21908 / t3198 was forced to
+# squash+push the branch to clear the false positive.
+#
+# The fix: `git diff MERGE_BASE..HEAD` computes the NET patch — only lines
+# that survive to HEAD. Replaced-then-fixed lines disappear from this view.
+#
+# Coverage:
+#   1. Net-diff (git diff): diff file contains corrected line, NOT buggy line.
+#   2. Aggregate-diff (git log -p) [documents old bug]: diff file contains
+#      BOTH lines — demonstrating what the old logic would have produced.
+#   3. Net-diff: single-commit addition (no replacement) still captured.
+#   4. Net-diff: entirely removed line is absent from diff file.
+#
+# All tests run inside a sandboxed git repo; no system state is touched.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+
+# Test runtime constants.
+TEST_RED='\033[0;31m'
+TEST_GREEN='\033[0;32m'
+TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+SANDBOX=""
+
+cleanup() {
+	[[ -n "$SANDBOX" && -d "$SANDBOX" ]] && rm -rf "$SANDBOX" 2>/dev/null || true
+	return 0
+}
+trap cleanup EXIT
+
+print_result() {
+	local test_name="$1"
+	local outcome="$2"
+	local detail="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$outcome" == "PASS" ]]; then
+		printf '  %b%s%b: %s\n' "$TEST_GREEN" "$outcome" "$TEST_RESET" "$test_name"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		printf '  %b%s%b: %s%s\n' "$TEST_RED" "$outcome" "$TEST_RESET" "$test_name" \
+			"${detail:+ — $detail}"
+	fi
+	return 0
+}
+
+# Build a sandboxed git repo with:
+#   main: initial commit with pulse-test.sh (base content)
+#   feature branch: commit 1 adds buggy line, commit 2 replaces with fix
+# Returns: sets SANDBOX, MERGE_BASE, HEAD_SHA, PULSE_FILE globals.
+_setup_sandbox() {
+	SANDBOX=$(mktemp -d -t puv-diff-test-XXXXXX)
+
+	# Configure git identity for the sandbox (required for commits).
+	export GIT_AUTHOR_NAME="Test"
+	export GIT_AUTHOR_EMAIL="test@test.invalid"
+	export GIT_COMMITTER_NAME="Test"
+	export GIT_COMMITTER_EMAIL="test@test.invalid"
+
+	# Init repo in sandbox.
+	git -C "$SANDBOX" init -q --initial-branch=main 2>/dev/null \
+		|| git -C "$SANDBOX" init -q  # fallback for older git without --initial-branch
+
+	# main: initial commit with a minimal pulse-test.sh.
+	PULSE_FILE=".agents/scripts/pulse-test.sh"
+	mkdir -p "$SANDBOX/$(dirname "$PULSE_FILE")"
+	cat > "$SANDBOX/$PULSE_FILE" <<'PULSE_EOF'
+#!/usr/bin/env bash
+# placeholder pulse script for diff-scoping tests
+_existing_func() {
+	local existing_var=""
+	echo "$existing_var"
+	return 0
+}
+PULSE_EOF
+	git -C "$SANDBOX" add "$PULSE_FILE"
+	git -C "$SANDBOX" commit -q -m "initial: add pulse-test.sh"
+	BASE_SHA=$(git -C "$SANDBOX" rev-parse HEAD)
+
+	# Feature branch: two commits.
+	git -C "$SANDBOX" checkout -q -b feature/test-branch
+
+	# Commit 1: add a function with a buggy multi-var local declaration.
+	cat >> "$SANDBOX/$PULSE_FILE" <<'BUGGY_EOF'
+_buggy_func() {
+	local foo bar
+	if [[ -n "${1:-}" ]]; then
+		foo="set"
+		bar="also_set"
+	fi
+	echo "$foo $bar"
+	return 0
+}
+BUGGY_EOF
+	git -C "$SANDBOX" add "$PULSE_FILE"
+	git -C "$SANDBOX" commit -q -m "commit 1: add buggy local foo bar (no init)"
+
+	# Commit 2: replace the buggy declaration with the correct one.
+	# Use sed to replace the specific line in-place.
+	sed -i 's/	local foo bar$/	local foo="" bar=""/' "$SANDBOX/$PULSE_FILE"
+	git -C "$SANDBOX" add "$PULSE_FILE"
+	git -C "$SANDBOX" commit -q -m "commit 2: fix local foo bar -> local foo='' bar=''"
+
+	HEAD_SHA=$(git -C "$SANDBOX" rev-parse HEAD)
+	MERGE_BASE=$(git -C "$SANDBOX" merge-base "$BASE_SHA" "$HEAD_SHA")
+	return 0
+}
+
+_teardown_sandbox() {
+	[[ -n "$SANDBOX" && -d "$SANDBOX" ]] && rm -rf "$SANDBOX" 2>/dev/null || true
+	SANDBOX=""
+	return 0
+}
+
+# Run the NET diff (the fixed logic: git diff MERGE_BASE..HEAD).
+# Outputs added lines to a temp file; prints the path.
+_run_net_diff() {
+	local sandbox="$1"
+	local merge_base="$2"
+	local head_sha="$3"
+	local pulse_file="$4"
+	local out_file
+	out_file=$(mktemp -t puv-net-diff-XXXXXX)
+	git -C "$sandbox" diff "${merge_base}..${head_sha}" -- "$pulse_file" \
+		| grep '^+' | grep -v '^+++' | sed 's/^+//' \
+		> "$out_file" 2>/dev/null || true
+	printf '%s' "$out_file"
+	return 0
+}
+
+# Run the AGGREGATE diff (the old buggy logic: git log -p --first-parent).
+# Outputs added lines to a temp file; prints the path.
+_run_aggregate_diff() {
+	local sandbox="$1"
+	local merge_base="$2"
+	local head_sha="$3"
+	local pulse_file="$4"
+	local out_file
+	out_file=$(mktemp -t puv-agg-diff-XXXXXX)
+	git -C "$sandbox" log -p --first-parent "${merge_base}..${head_sha}" -- "$pulse_file" \
+		| grep '^+' | grep -v '^+++' | sed 's/^+//' \
+		> "$out_file" 2>/dev/null || true
+	printf '%s' "$out_file"
+	return 0
+}
+
+echo "test-puv-diff-scoping.sh"
+
+# --- Test 1: net-diff does NOT include the replaced buggy line ---
+_setup_sandbox
+diff_file=$(_run_net_diff "$SANDBOX" "$MERGE_BASE" "$HEAD_SHA" "$PULSE_FILE")
+if grep -q 'local foo bar$' "$diff_file" 2>/dev/null; then
+	print_result "net-diff excludes replaced buggy line (local foo bar)" "FAIL" \
+		"buggy line found in net diff — double-count bug persists"
+else
+	print_result "net-diff excludes replaced buggy line (local foo bar)" "PASS"
+fi
+rm -f "$diff_file"
+_teardown_sandbox
+
+# --- Test 2: net-diff DOES include the correct replacement line ---
+_setup_sandbox
+diff_file=$(_run_net_diff "$SANDBOX" "$MERGE_BASE" "$HEAD_SHA" "$PULSE_FILE")
+if grep -q 'local foo="" bar=""' "$diff_file" 2>/dev/null; then
+	print_result "net-diff includes corrected line (local foo=\"\" bar=\"\")" "PASS"
+else
+	print_result "net-diff includes corrected line (local foo=\"\" bar=\"\")" "FAIL" \
+		"corrected line missing from net diff"
+fi
+rm -f "$diff_file"
+_teardown_sandbox
+
+# --- Test 3: aggregate-diff (old logic) WOULD have included the buggy line ---
+# This test documents the pre-fix behaviour as a regression reference.
+_setup_sandbox
+agg_file=$(_run_aggregate_diff "$SANDBOX" "$MERGE_BASE" "$HEAD_SHA" "$PULSE_FILE")
+if grep -q 'local foo bar$' "$agg_file" 2>/dev/null; then
+	print_result "aggregate-diff (old logic) double-counts buggy line (expected)" "PASS"
+else
+	print_result "aggregate-diff (old logic) double-counts buggy line (expected)" "FAIL" \
+		"aggregate diff did not reproduce the double-count — test setup may be wrong"
+fi
+rm -f "$agg_file"
+_teardown_sandbox
+
+# --- Test 4: net-diff captures a line added in a single commit (no replacement) ---
+_setup_sandbox
+# Add one more commit on the feature branch: add a new clean function.
+cat >> "$SANDBOX/$PULSE_FILE" <<'CLEAN_EOF'
+_clean_func() {
+	local result=""
+	result="clean_value"
+	echo "$result"
+	return 0
+}
+CLEAN_EOF
+git -C "$SANDBOX" add "$PULSE_FILE"
+git -C "$SANDBOX" commit -q -m "commit 3: add clean function (single-commit addition)"
+HEAD_SHA=$(git -C "$SANDBOX" rev-parse HEAD)
+
+diff_file=$(_run_net_diff "$SANDBOX" "$MERGE_BASE" "$HEAD_SHA" "$PULSE_FILE")
+if grep -q 'local result=""' "$diff_file" 2>/dev/null; then
+	print_result "net-diff captures single-commit addition (local result=\"\")" "PASS"
+else
+	print_result "net-diff captures single-commit addition (local result=\"\")" "FAIL" \
+		"single-commit addition missing from net diff"
+fi
+rm -f "$diff_file"
+_teardown_sandbox
+
+# --- Test 5: net-diff excludes a line added then entirely deleted ---
+_setup_sandbox
+# Add a commit that adds a line, then a commit that deletes it entirely.
+cat >> "$SANDBOX/$PULSE_FILE" <<'TEMP_EOF'
+_temp_func() {
+	local temp_var
+	echo "$temp_var"
+	return 0
+}
+TEMP_EOF
+git -C "$SANDBOX" add "$PULSE_FILE"
+git -C "$SANDBOX" commit -q -m "commit 1: add temp_func with uninitialised temp_var"
+
+# Remove the whole function (simulate a revert/delete).
+# Strip lines between _temp_func and matching closing brace.
+grep -v '_temp_func\|local temp_var\|echo.*temp_var\|^}$' "$SANDBOX/$PULSE_FILE" \
+	> "$SANDBOX/$PULSE_FILE.tmp" || true
+# Only apply if we actually stripped content.
+if [[ -s "$SANDBOX/$PULSE_FILE.tmp" ]]; then
+	mv "$SANDBOX/$PULSE_FILE.tmp" "$SANDBOX/$PULSE_FILE"
+fi
+# Ensure the file still exists and is non-empty; restore if strip failed.
+if [[ ! -s "$SANDBOX/$PULSE_FILE" ]]; then
+	cp "$SANDBOX/$PULSE_FILE.tmp.bak" "$SANDBOX/$PULSE_FILE" 2>/dev/null || true
+fi
+
+git -C "$SANDBOX" add "$PULSE_FILE"
+git -C "$SANDBOX" commit -q -m "commit 2: remove temp_func entirely"
+HEAD_SHA=$(git -C "$SANDBOX" rev-parse HEAD)
+
+diff_file=$(_run_net_diff "$SANDBOX" "$MERGE_BASE" "$HEAD_SHA" "$PULSE_FILE")
+if grep -q 'local temp_var' "$diff_file" 2>/dev/null; then
+	print_result "net-diff excludes added-then-deleted line (local temp_var)" "FAIL" \
+		"deleted line was included in net diff"
+else
+	print_result "net-diff excludes added-then-deleted line (local temp_var)" "PASS"
+fi
+rm -f "$diff_file"
+_teardown_sandbox
+
+echo ""
+echo "Tests run: $TESTS_RUN, failed: $TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]] && exit 0 || exit 1

--- a/.agents/scripts/tests/test-puv-diff-scoping.sh
+++ b/.agents/scripts/tests/test-puv-diff-scoping.sh
@@ -111,8 +111,11 @@ BUGGY_EOF
 	git -C "$SANDBOX" commit -q -m "commit 1: add buggy local foo bar (no init)"
 
 	# Commit 2: replace the buggy declaration with the correct one.
-	# Use sed to replace the specific line in-place.
-	sed -i 's/	local foo bar$/	local foo="" bar=""/' "$SANDBOX/$PULSE_FILE"
+	# Use sed via temp-file (portable across BSD sed on macOS and GNU sed on Linux —
+	# `sed -i` differs incompatibly between the two: BSD requires `-i ''`, GNU does not).
+	sed 's/	local foo bar$/	local foo="" bar=""/' "$SANDBOX/$PULSE_FILE" \
+		> "$SANDBOX/$PULSE_FILE.new"
+	mv "$SANDBOX/$PULSE_FILE.new" "$SANDBOX/$PULSE_FILE"
 	git -C "$SANDBOX" add "$PULSE_FILE"
 	git -C "$SANDBOX" commit -q -m "commit 2: fix local foo bar -> local foo='' bar=''"
 
@@ -225,7 +228,12 @@ _teardown_sandbox
 
 # --- Test 5: net-diff excludes a line added then entirely deleted ---
 _setup_sandbox
-# Add a commit that adds a line, then a commit that deletes it entirely.
+# Snapshot the file BEFORE adding temp_func — restoring this snapshot in commit 2
+# is the cleanest way to delete every line introduced in commit 1, without relying
+# on regex alternation that varies between BSD grep (macOS) and GNU grep (Linux).
+cp "$SANDBOX/$PULSE_FILE" "$SANDBOX/$PULSE_FILE.pre-temp"
+
+# Commit 1: append a function with an uninitialised local temp_var.
 cat >> "$SANDBOX/$PULSE_FILE" <<'TEMP_EOF'
 _temp_func() {
 	local temp_var
@@ -236,18 +244,9 @@ TEMP_EOF
 git -C "$SANDBOX" add "$PULSE_FILE"
 git -C "$SANDBOX" commit -q -m "commit 1: add temp_func with uninitialised temp_var"
 
-# Remove the whole function (simulate a revert/delete).
-# Strip lines between _temp_func and matching closing brace.
-grep -v '_temp_func\|local temp_var\|echo.*temp_var\|^}$' "$SANDBOX/$PULSE_FILE" \
-	> "$SANDBOX/$PULSE_FILE.tmp" || true
-# Only apply if we actually stripped content.
-if [[ -s "$SANDBOX/$PULSE_FILE.tmp" ]]; then
-	mv "$SANDBOX/$PULSE_FILE.tmp" "$SANDBOX/$PULSE_FILE"
-fi
-# Ensure the file still exists and is non-empty; restore if strip failed.
-if [[ ! -s "$SANDBOX/$PULSE_FILE" ]]; then
-	cp "$SANDBOX/$PULSE_FILE.tmp.bak" "$SANDBOX/$PULSE_FILE" 2>/dev/null || true
-fi
+# Commit 2: restore the pre-temp snapshot — every line added in commit 1 is gone.
+cp "$SANDBOX/$PULSE_FILE.pre-temp" "$SANDBOX/$PULSE_FILE"
+rm -f "$SANDBOX/$PULSE_FILE.pre-temp"
 
 git -C "$SANDBOX" add "$PULSE_FILE"
 git -C "$SANDBOX" commit -q -m "commit 2: remove temp_func entirely"

--- a/.github/workflows/pulse-unbound-var-check.yml
+++ b/.github/workflows/pulse-unbound-var-check.yml
@@ -18,12 +18,16 @@ name: Pulse Unbound-Var Check
 # not fail CI — only lines introduced by this PR are checked. This is stricter
 # than the counter-stack-check.yml "changed files" approach.
 #
-# Drift-resistant (t3084): scans use git merge-base to find the actual
-# divergence point and `git log -p --first-parent MERGE_BASE..HEAD` to extract
-# only commits authored by this PR. This avoids false positives from main-side
-# additions when the branch is behind origin/main — `git diff BASE..HEAD`
-# would otherwise include lines added on main since the branch diverged.
-# Canonical failure: PR #21827 (45-commit-stale base, ~15 phantom violations).
+# Drift-resistant (t3084, t3209): scans use git merge-base to find the actual
+# divergence point, then `git diff MERGE_BASE..HEAD` to extract the NET patch
+# between them. This avoids two failure modes: (1) stale-base false positives
+# from main-side additions when the branch is behind origin/main; (2) per-commit
+# double-counting where `git log -p --first-parent` aggregated all intermediate
+# `+` lines and flagged a buggy line even if a later commit replaced it.
+# `git diff` reports only lines that survive to HEAD — replaced-then-fixed lines
+# disappear. Canonical failures: PR #21827 (stale base, ~15 phantom violations),
+# PR #21908 (t3198 forced squash+push to clear a false positive from a replaced
+# line; the double-count was the root cause).
 #
 # Violations posted as a PR comment with remediation guidance.
 
@@ -59,13 +63,12 @@ jobs:
         run: |
           set -euo pipefail
 
-          # t3084: compute merge-base so we measure ONLY this branch's
-          # contribution. `git diff BASE_SHA HEAD_SHA` would include lines
-          # added on main since the branch diverged when the branch is
-          # stale — those show up as "+" additions and trip false positives.
-          # `git log -p --first-parent MERGE_BASE..HEAD_SHA` walks only the
-          # branch's commits (skipping merge-from-main commits via
-          # --first-parent), so we see exactly the lines this PR authored.
+          # t3084, t3209: compute merge-base so we measure ONLY this branch's
+          # net contribution. Using MERGE_BASE (not BASE_SHA) for `git diff`
+          # avoids stale-base false positives: if the branch is behind
+          # origin/main, `git diff BASE_SHA HEAD_SHA` would include lines added
+          # on main since divergence. MERGE_BASE is the exact fork point, so
+          # `git diff MERGE_BASE..HEAD_SHA` sees only this PR's net additions.
           MERGE_BASE=$(git merge-base "$BASE_SHA" "$HEAD_SHA" 2>/dev/null || true)
           if [ -z "$MERGE_BASE" ]; then
             echo "::warning::Could not determine merge-base; falling back to BASE_SHA. Stale-base false positives are possible."
@@ -93,11 +96,18 @@ jobs:
           while IFS= read -r file; do
             basename_file=$(basename "$file")
             diff_file="/tmp/puv-diff-lines/${basename_file}"
-            # git log -p --first-parent shows only this branch's commits
-            # (no main-side commits brought in by merge). grep '^+' gives
-            # added lines; grep -v '^+++' strips file headers. sed strips
-            # the leading + so the scanner sees real source lines.
-            git log -p --first-parent "${MERGE_BASE}..${HEAD_SHA}" -- "$file" \
+            # t3209: use `git diff` (not `git log -p --first-parent`) so we get
+            # the NET patch between merge-base and HEAD. `git log -p` aggregates
+            # every `+` line across all commits — if commit 1 adds a buggy
+            # `local foo bar` and commit 2 replaces it with `local foo="" bar=""`,
+            # BOTH versions appear in the aggregated output and the scanner
+            # flags the buggy version even though it no longer exists in HEAD.
+            # `git diff` shows only lines that survive to HEAD; replaced-then-fixed
+            # lines disappear. MERGE_BASE (computed above via git merge-base) already
+            # excludes main-side additions, so stale-base false positives are also
+            # prevented. grep '^+' gives added lines; grep -v '^+++' strips file
+            # headers; sed strips the leading + so the scanner sees real source lines.
+            git diff "${MERGE_BASE}..${HEAD_SHA}" -- "$file" \
               | grep '^+' | grep -v '^+++' | sed 's/^+//' \
               > "$diff_file" || true
             if [ -s "$diff_file" ]; then


### PR DESCRIPTION
## Summary

Fixes the diff-scoping double-count bug in `pulse-unbound-var-check.yml` that caused false-positive violations when a PR contained a multi-commit replace sequence (add buggy line → fix it in a later commit).

## Problem

The original diff-scoping step used:

```bash
git log -p --first-parent "${MERGE_BASE}..${HEAD_SHA}" -- "$file"
  | grep '^+' | grep -v '^+++' | sed 's/^+//'
```

`git log -p` aggregates every `+` line across all commits. If commit 1 adds `local foo bar` and commit 2 replaces it with `local foo="" bar=""`, both versions appeared in the aggregated output. The scanner flagged the buggy version even though it no longer existed in HEAD.

**Canonical failure:** PR #21908 / t3198 was forced to squash+push to clear this false positive.

## Fix

Replace `git log -p --first-parent` with `git diff`:

```bash
git diff "${MERGE_BASE}..${HEAD_SHA}" -- "$file" \
  | grep '^+' | grep -v '^+++' | sed 's/^+//'
```

`git diff` produces the NET patch — only lines that survive to HEAD. Replaced-then-fixed lines disappear. `MERGE_BASE` (computed via `git merge-base`) already excludes main-side additions, so the t3084 stale-base protection is preserved.

## Changes

- **EDIT:** `.github/workflows/pulse-unbound-var-check.yml:110-112` — replace `git log -p` pipeline with `git diff`; update header comment (lines 21-30) and inline comment (lines 99-112) to document both failure modes and the t3209 fix
- **NEW:** `.agents/scripts/tests/test-puv-diff-scoping.sh` — 5-test regression suite:
  1. Net-diff excludes replaced buggy line (`local foo bar`)
  2. Net-diff includes corrected replacement (`local foo="" bar=""`)
  3. Aggregate-diff (old logic) WOULD have double-counted — documented as regression reference
  4. Net-diff captures single-commit addition correctly
  5. Net-diff excludes added-then-deleted line

## Verification

```bash
bash .agents/scripts/tests/test-puv-diff-scoping.sh
# Expected: Tests run: 5, failed: 0
```

Resolves #21930

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.16 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-sonnet-4-6 spent 3m and 11,799 tokens on this as a headless worker.
