### PR TITLE
t3194: cross-runner peer quarantine helper

### DIFF
--- a/.agents/reference/cross-runner-coordination.md
+++ b/.agents/reference/cross-runner-coordination.md
@@ -198,6 +198,15 @@ passively assigned to an issue for bookkeeping does not block dispatch unless
 an active status label is also present. Implements the `is-assigned` combined
 check from t1996.
 
+**Layer 6 sub-step (t2930 ignore filter, extended t3194):** before evaluating
+combined-signal blocking, the assignee list is filtered against
+`~/.config/aidevops/dispatch-override.conf`. Entries with value `ignore`
+(manual, §8) and entries matching `peer-quarantine-until=<future-ISO>`
+(automatic, §9) both strip the listed login from the blocking set. This lets
+healthy runners take over issues claimed by peers known to be broken or
+currently failing, without blocking dispatch indefinitely behind their stale
+claim comments.
+
 ---
 
 ## 4. Race Scenarios and Resolutions
@@ -620,7 +629,158 @@ the per-runner config (e.g., while diagnosing a suspected override bug).
 
 ---
 
-## 9. See Also
+## 9. Automatic Peer Quarantine (t3194)
+
+§8 covered **manual** structured overrides for known-broken peers. t3194 adds
+the **automatic** counterpart: a runner that observes another runner repeatedly
+emitting `CLAIM_RELEASED reason=launch_recovery:no_worker_process` events
+auto-writes a time-bound `peer-quarantine-until=<ISO>` entry into the same
+`dispatch-override.conf` file. While the timestamp is in the future, the
+dispatch-dedup loop treats the peer's claims like a manual `ignore` —
+allowing this runner to take over the contested issue rather than backing off
+indefinitely behind a peer whose worker has died but whose claim comment is
+still on file.
+
+The two systems compose deliberately. §8 is for *durable* operator decisions
+("alex's runner is buggy below 3.8.78"); §9 is for *transient* observed
+failures ("this peer dropped 5 launches in the last hour, take over for the
+next 6h, then resume honouring"). Manual entries always win — the auto path
+never overwrites a non-`peer-quarantine-*` value, even on the same key.
+
+### 9.1 Failure mode caught
+
+`pulse-cleanup.sh::_handle_dead_pulse_workers` (around line 978) emits
+
+```text
+CLAIM_RELEASED reason=launch_recovery:no_worker_process runner=<self-login> ts=<iso>
+```
+
+when its launch-recovery sweep finds a worker PID that died before the worker
+process was actually spawned (the canonical "worker comment posted, no shell
+ever started" symptom — fast-fail dispatch, scheduler kill, OOM, dead container,
+etc.). The comment lands on the issue's thread; every healthy peer reading
+that thread sees it.
+
+When the same runner emits this 5+ times in 1h, that's the signal: this peer
+is not just slow, it is structurally failing to launch workers. Honouring its
+claim comments wastes throughput on every other runner. Quarantine for 6h
+gives the operator time to investigate without blocking the rest of the fleet.
+
+### 9.2 Defaults and tunables
+
+| Tunable | Default | Purpose |
+|---|---|---|
+| `PEER_QUARANTINE_FAILURE_THRESHOLD` | `5` | Events in window before tripping |
+| `PEER_QUARANTINE_WINDOW_HOURS` | `1` | Rolling window for counting events |
+| `PEER_QUARANTINE_DURATION_HOURS` | `6` | How long the quarantine lasts |
+| `PEER_QUARANTINE_DISABLED` | `0` | `1` = short-circuit all paths |
+| `PEER_QUARANTINE_LEDGER_CAP` | `20` | Per-peer event ring-buffer size |
+| `PEER_QUARANTINE_TEST_NOW` | (unset) | Override `_pq_now` for deterministic tests |
+| `PEER_QUARANTINE_STATE_FILE` | `~/.aidevops/cache/peer-quarantine.json` | State sandbox knob |
+| `PEER_QUARANTINE_OVERRIDE_CONF` | `~/.config/aidevops/dispatch-override.conf` | Conf file (shared with §8) |
+| `PEER_QUARANTINE_ADVISORY_DIR` | `~/.aidevops/advisories` | Per-peer advisory output |
+| `PEER_QUARANTINE_CACHE_DIR` | `~/.aidevops/cache` | Advisory dedup stamp dir |
+
+### 9.3 Conf entry format
+
+The auto-managed entry uses the same `DISPATCH_OVERRIDE_<LOGIN>` variable name
+as §8, but with a value the manual path never produces:
+
+```bash
+# Auto-managed by pulse-peer-quarantine-helper.sh (t3194)
+DISPATCH_OVERRIDE_BAD_PEER="peer-quarantine-until=2026-04-30T16:00:00Z"
+```
+
+`dispatch-dedup-helper.sh::is_assigned` extends the existing t2930 ignore-filter
+loop: if the value matches `peer-quarantine-until=<ISO>` AND the ISO parses
+to a future timestamp, the assignee is dropped from the blocking set
+identically to a manual `ignore`. Once the timestamp passes, the entry is
+silently ignored — no rewrite, no advisory, no operator action. The next event
+that trips the threshold writes a fresh entry with a new `until`.
+
+### 9.4 Manual entry preservation
+
+`pulse-peer-quarantine-helper.sh::_pq_write_override_entry` reads the existing
+conf line for the same `DISPATCH_OVERRIDE_<LOGIN>` variable before writing.
+If the existing value is **anything other than** `peer-quarantine-until=*`
+(i.e. `ignore`, `honour`, `warn`, `honour-only-above:V`, or any operator
+annotation), the auto path leaves it alone. Only auto-managed values get
+overwritten by the auto path — and `release --peer <name>` only strips
+auto-managed values. This is the single invariant that lets §8 and §9 share
+the same conf file safely.
+
+### 9.5 Detection wiring
+
+The brief originally proposed wiring detection into
+`pulse-batch-prefetch-helper.sh`, but that helper does not currently scan
+issue comment bodies — it fetches issue and PR metadata. The actually-cheapest
+integration point is the comments fetch already inside
+`dispatch-dedup-helper.sh::has_dispatch_comment` (the dispatch-comment TTL
+guard), which loads `body_start | author | created_at` for every comment on
+every issue the dedup chain inspects. After that fetch, the JSON is piped to
+`pulse-peer-quarantine-helper.sh scan-comments --self-login <login>` — zero
+new GitHub API calls, opportunistic per-issue. Self-events are skipped via
+the `--self-login` filter.
+
+This is structural: the only thing the auto path needs is *visibility into
+peer launch-recovery comments*, and the dedup chain already has that.
+
+### 9.6 Operator commands
+
+```bash
+H=~/.aidevops/agents/scripts/pulse-peer-quarantine-helper.sh
+
+# Inspect current quarantine state across all peers (human-readable):
+"$H" status
+
+# Same, JSON for programmatic use:
+"$H" status --json
+
+# Check a single peer:
+"$H" is-quarantined --peer alex-solovyev   # exit 0 if quarantined
+
+# Manually clear a quarantine (rarely needed — auto-expires in 6h):
+"$H" release --peer alex-solovyev --reason "fixed runner, redeployed"
+
+# Disable the whole mechanism for the current shell:
+PEER_QUARANTINE_DISABLED=1 ...
+```
+
+### 9.7 Diagnosis
+
+If a peer is quarantined and you want to know why:
+
+```bash
+# Per-peer event ledger (last 20):
+jq -r '.peers["alex-solovyev"].events[]' \
+  ~/.aidevops/cache/peer-quarantine.json
+
+# Trip context (which issue triggered the quarantine):
+jq -r '.peers["alex-solovyev"] | "until=\(.quarantine_until) reason=\(.reason) trigger=\(.triggering_issue)"' \
+  ~/.aidevops/cache/peer-quarantine.json
+
+# Advisory file written on first trip (24h dedup):
+ls -la ~/.aidevops/advisories/peer-quarantine-alex-solovyev.advisory
+```
+
+If you decide the quarantine is wrong (e.g., the launch-recovery events were
+genuinely transient infrastructure flaps), `release --peer` plus a manual
+`DISPATCH_OVERRIDE_<LOGIN>="honour"` line in the conf gives you a permanent
+override the auto path will then leave alone (per §9.4).
+
+### 9.8 Layer placement
+
+In §3's seven-layer chain, peer-quarantine sits as a **sub-step inside
+Layer 6** (cross-machine assignee guard): the existing assignee fetch happens
+first, then the t2930 ignore-filter loop runs, then the t3194 quarantine check
+extends that same loop with a date-bounded "treat as ignore" branch. No new
+layer is added — the layer count stays at seven. Tests cover both the parser
+shape (so a refactor that drops the `peer-quarantine-until=*` case fails
+loudly) and the date-bound semantics (future ISO honoured, past ISO not).
+
+---
+
+## 10. See Also
 
 - `reference/worker-diagnostics.md` — single-runner worker lifecycle, DB
   isolation, watchdog, canary, recovery checklist
@@ -628,11 +788,15 @@ the per-runner config (e.g., while diagnosing a suspected override bug).
 - `AGENTS.md` "Session origin labels" — `origin:interactive` implications
 - `AGENTS.md` "General dedup rule — combined signal (t1996)"
 - `AGENTS.md` "Parent / meta tasks (#parent tag, t1986)"
-- `scripts/dispatch-dedup-helper.sh` — implementation of Layers 3–7
+- `scripts/dispatch-dedup-helper.sh` — implementation of Layers 3–7 and §9
+  override-loop honouring
+- `scripts/pulse-peer-quarantine-helper.sh` — §9 detection + state machine
 - `scripts/pulse-dispatch-core.sh` — `check_dispatch_dedup()` orchestration
 - `scripts/tests/test-parent-task-guard.sh` — regression coverage for t1986
 - `scripts/tests/test-dispatch-dedup-multi-operator.sh` — multi-operator dedup
   assertions
+- `scripts/tests/test-peer-quarantine.sh` — t3194 threshold, expiry, manual
+  preservation, scan-comments self-skip, parser-shape regression
 
 ### Related Issues and PRs
 
@@ -654,3 +818,4 @@ the per-runner config (e.g., while diagnosing a suspected override bug).
 | GH#19924 (t2400) | Flat `DISPATCH_CLAIM_IGNORE_RUNNERS` for per-login skip (deprecated by t2422) |
 | GH#19995 (t2401) | Global `DISPATCH_CLAIM_MIN_VERSION` version floor + version field in claim body |
 | GH#20028 (t2422) | Structured per-runner overrides with auto-sunset + deterministic tiebreaker + `CLAIM_DEFERRED` |
+| GH#21890 (t3194) | Automatic peer quarantine on repeated `launch_recovery:no_worker_process` events — §9 |

--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -1351,6 +1351,42 @@ _is_dispatch_comment_active() {
 # Outputs:
 #   single-line reason when evidence is found
 #######################################
+
+#######################################
+# t3194: Opportunistic peer-quarantine event detection. Pipes already-
+# fetched comments JSON to pulse-peer-quarantine-helper.sh's scan-comments
+# subcommand to record any
+# `CLAIM_RELEASED reason=launch_recovery:no_worker_process runner=<peer>`
+# events from peers (not self). Zero new API calls; non-fatal on any
+# failure. Extracted from has_dispatch_comment to keep that function below
+# the function-complexity gate.
+# Args:
+#   $1 = comments JSON (already fetched in caller)
+#   $2 = repo slug (owner/repo)
+#   $3 = issue number
+#   $4 = self login (optional; used to skip self events)
+#######################################
+_dd_opportunistic_peer_scan() {
+	local comments_json="$1"
+	local repo_slug="$2"
+	local issue_number="$3"
+	local self_login="${4:-}"
+	local pq_helper=""
+	pq_helper="${PEER_QUARANTINE_HELPER_OVERRIDE:-${HELPER_DIR:-${SCRIPT_DIR:-$(dirname "${BASH_SOURCE[0]}")}}/pulse-peer-quarantine-helper.sh}"
+	[[ -x "$pq_helper" ]] || return 0
+	if [[ -n "$self_login" ]]; then
+		printf '%s' "$comments_json" | "$pq_helper" scan-comments \
+			--self-login "$self_login" \
+			--issue-ref "${repo_slug}#${issue_number}" \
+			>/dev/null 2>&1 || true
+	else
+		printf '%s' "$comments_json" | "$pq_helper" scan-comments \
+			--issue-ref "${repo_slug}#${issue_number}" \
+			>/dev/null 2>&1 || true
+	fi
+	return 0
+}
+
 has_dispatch_comment() {
 	local issue_number="$1"
 	local repo_slug="$2"
@@ -1384,32 +1420,10 @@ has_dispatch_comment() {
 		return 1
 	fi
 
-	# t3194: Opportunistic peer-quarantine detection. The comments JSON is
-	# already in hand — feed it to pulse-peer-quarantine-helper.sh's
-	# scan-comments subcommand to record any
-	# `CLAIM_RELEASED reason=launch_recovery:no_worker_process runner=<peer>`
-	# events from peers (not self). Zero new API calls; non-fatal on any
-	# failure. The brief originally specified this in
-	# pulse-batch-prefetch-helper.sh but that helper does not currently
-	# scan comments — fetching here is the actually-cheapest integration
-	# point because the JSON is already loaded.
-	local _pq_helper="${PEER_QUARANTINE_HELPER_OVERRIDE:-${HELPER_DIR:-${SCRIPT_DIR:-$(dirname "${BASH_SOURCE[0]}")}}/pulse-peer-quarantine-helper.sh}"
-	if [[ -x "$_pq_helper" ]]; then
-		# $3 (self_login) was the original arg to has_dispatch_comment;
-		# it's unused for the dispatch check itself but is exactly what
-		# we need to skip self events here.
-		local _pq_self="${3:-}"
-		if [[ -n "$_pq_self" ]]; then
-			printf '%s' "$comments_json" | "$_pq_helper" scan-comments \
-				--self-login "$_pq_self" \
-				--issue-ref "${repo_slug}#${issue_number}" \
-				>/dev/null 2>&1 || true
-		else
-			printf '%s' "$comments_json" | "$_pq_helper" scan-comments \
-				--issue-ref "${repo_slug}#${issue_number}" \
-				>/dev/null 2>&1 || true
-		fi
-	fi
+	# t3194: Opportunistic peer-quarantine event detection — extracted to
+	# _dd_opportunistic_peer_scan to keep this function below the
+	# function-complexity gate. Zero new API calls; non-fatal.
+	_dd_opportunistic_peer_scan "$comments_json" "$repo_slug" "$issue_number" "${3:-}" || true
 
 	# Find the most recent dispatch comment (newest first)
 	local last_dispatch_json

--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -1050,14 +1050,21 @@ is_assigned() {
 	fi
 
 	# t2930: Honor dispatch-override.conf "ignore" entries at the ASSIGNEE level.
+	# t3194: Also honor "peer-quarantine-until=<ISO>" entries (auto-managed by
+	# pulse-peer-quarantine-helper.sh). When a peer has been quarantined for
+	# emitting too many launch_recovery:no_worker_process events, treat its
+	# claim as if it were on the legacy `ignore` list — strip from blocking
+	# set so this runner can take over instead of backing off behind a known-
+	# broken peer.
+	#
 	# The dispatch-claim-helper filters claim COMMENTS by override config, but
 	# ignored peers can still raw-assign themselves via gh issue edit
 	# --add-assignee — and is_assigned previously honored that unconditionally,
 	# creating a permanent dispatch block. With this filter, an "ignore"-listed
-	# peer is treated as if not assigned, allowing competitive dispatch (winner's
-	# PR closes the issue; loser wastes tokens but doesn't block throughput).
-	# Self-runner and parent-task / no-auto-dispatch / cost circuit-breaker /
-	# hydration window guards above remain in effect.
+	# or quarantined peer is treated as if not assigned, allowing competitive
+	# dispatch (winner's PR closes the issue; loser wastes tokens but doesn't
+	# block throughput). Self-runner and parent-task / no-auto-dispatch / cost
+	# circuit-breaker / hydration window guards above remain in effect.
 	local override_conf="${HOME}/.config/aidevops/dispatch-override.conf"
 	if [[ -f "$override_conf" ]]; then
 		local _filtered_assignees=""
@@ -1065,12 +1072,29 @@ is_assigned() {
 		local -a _override_array=()
 		IFS=',' read -ra _override_array <<<"$assignees"
 		IFS="$_saved_ifs"
-		local _a _upper _override_val
+		local _a _upper _override_val _now_epoch _q_until _q_until_epoch
+		_now_epoch=$(date -u '+%s')
 		for _a in "${_override_array[@]}"; do
-			_upper="$(printf '%s' "$_a" | tr 'a-z-' 'A-Z_')"
+			# Slug normalisation matches pulse-peer-quarantine-helper.sh's
+			# _pq_login_to_var: dash/dot/@ → underscore, uppercase.
+			_upper="$(printf '%s' "$_a" | tr 'a-z\-.@' 'A-Z___')"
 			_override_val=$(grep -E "^DISPATCH_OVERRIDE_${_upper}=" "$override_conf" 2>/dev/null | tail -n1 | cut -d= -f2- | tr -d '"' | tr -d "'")
+			# Legacy: t2930 unconditional ignore.
 			if [[ "$_override_val" == "ignore" ]]; then
 				continue
+			fi
+			# t3194: peer-quarantine-until=<ISO>. Honour as ignore while
+			# the timestamp is in the future; auto-expire silently after.
+			if [[ "$_override_val" == peer-quarantine-until=* ]]; then
+				_q_until="${_override_val#peer-quarantine-until=}"
+				# BSD date (macOS) first, then GNU date (Linux). Both
+				# variants succeed; one returns empty, the OR keeps going.
+				_q_until_epoch=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$_q_until" '+%s' 2>/dev/null || true)
+				[[ -z "$_q_until_epoch" ]] && _q_until_epoch=$(date -u -d "$_q_until" '+%s' 2>/dev/null || true)
+				[[ -z "$_q_until_epoch" ]] && _q_until_epoch=0
+				if [[ "$_q_until_epoch" -gt "$_now_epoch" ]]; then
+					continue
+				fi
 			fi
 			if [[ -n "$_filtered_assignees" ]]; then
 				_filtered_assignees="${_filtered_assignees},${_a}"
@@ -1358,6 +1382,33 @@ has_dispatch_comment() {
 
 	if [[ -z "$comments_json" || "$comments_json" == "null" || "$comments_json" == "[]" ]]; then
 		return 1
+	fi
+
+	# t3194: Opportunistic peer-quarantine detection. The comments JSON is
+	# already in hand — feed it to pulse-peer-quarantine-helper.sh's
+	# scan-comments subcommand to record any
+	# `CLAIM_RELEASED reason=launch_recovery:no_worker_process runner=<peer>`
+	# events from peers (not self). Zero new API calls; non-fatal on any
+	# failure. The brief originally specified this in
+	# pulse-batch-prefetch-helper.sh but that helper does not currently
+	# scan comments — fetching here is the actually-cheapest integration
+	# point because the JSON is already loaded.
+	local _pq_helper="${PEER_QUARANTINE_HELPER_OVERRIDE:-${HELPER_DIR:-${SCRIPT_DIR:-$(dirname "${BASH_SOURCE[0]}")}}/pulse-peer-quarantine-helper.sh}"
+	if [[ -x "$_pq_helper" ]]; then
+		# $3 (self_login) was the original arg to has_dispatch_comment;
+		# it's unused for the dispatch check itself but is exactly what
+		# we need to skip self events here.
+		local _pq_self="${3:-}"
+		if [[ -n "$_pq_self" ]]; then
+			printf '%s' "$comments_json" | "$_pq_helper" scan-comments \
+				--self-login "$_pq_self" \
+				--issue-ref "${repo_slug}#${issue_number}" \
+				>/dev/null 2>&1 || true
+		else
+			printf '%s' "$comments_json" | "$_pq_helper" scan-comments \
+				--issue-ref "${repo_slug}#${issue_number}" \
+				>/dev/null 2>&1 || true
+		fi
 	fi
 
 	# Find the most recent dispatch comment (newest first)

--- a/.agents/scripts/pulse-peer-quarantine-helper.sh
+++ b/.agents/scripts/pulse-peer-quarantine-helper.sh
@@ -388,22 +388,39 @@ cmd_record_peer_event() {
 		)
 	" || return 1
 
-	# Trip evaluation. Only count up to threshold; further events past the
-	# trip refresh quarantine_until rather than re-tripping.
-	local count
+	# Trip evaluation extracted to _pq_eval_trip to keep this function below
+	# the function-complexity gate.
+	_pq_eval_trip "$peer" "$now" "$issue_ref" || true
+	return 0
+}
+
+#######################################
+# _pq_eval_trip — evaluate whether the peer's failure_count crossed the
+# threshold and trip (or re-extend) the quarantine if so. Only counts up
+# to the threshold; further events past the trip refresh quarantine_until
+# via _pq_trip_peer rather than re-tripping.
+# Args: $1 = peer login
+#       $2 = current ISO timestamp
+#       $3 = issue ref (audit-only)
+# Returns: 0 always (no-op when below threshold or already covered).
+#######################################
+_pq_eval_trip() {
+	local peer="$1"
+	local now="$2"
+	local issue_ref="$3"
+	local count=""
 	count=$(_pq_get_field "$peer" failure_count)
 	[[ -z "$count" ]] && count=0
-	if [[ "$count" -ge "$PEER_QUARANTINE_FAILURE_THRESHOLD" ]]; then
-		local existing_until
-		existing_until=$(_pq_get_field "$peer" quarantine_until)
-		local now_epoch
-		now_epoch=$(_pq_iso_to_epoch "$now")
-		local until_epoch=0
-		[[ -n "$existing_until" ]] && until_epoch=$(_pq_iso_to_epoch "$existing_until")
-		# Trip (or re-extend) only if not already covering current time.
-		if [[ "$until_epoch" -le "$now_epoch" ]]; then
-			_pq_trip_peer "$peer" "$issue_ref" "failure_count=${count}"
-		fi
+	[[ "$count" -lt "$PEER_QUARANTINE_FAILURE_THRESHOLD" ]] && return 0
+	local existing_until=""
+	existing_until=$(_pq_get_field "$peer" quarantine_until)
+	local now_epoch=""
+	now_epoch=$(_pq_iso_to_epoch "$now")
+	local until_epoch=0
+	[[ -n "$existing_until" ]] && until_epoch=$(_pq_iso_to_epoch "$existing_until")
+	# Trip (or re-extend) only if not already covering current time.
+	if [[ "$until_epoch" -le "$now_epoch" ]]; then
+		_pq_trip_peer "$peer" "$issue_ref" "failure_count=${count}"
 	fi
 	return 0
 }

--- a/.agents/scripts/pulse-peer-quarantine-helper.sh
+++ b/.agents/scripts/pulse-peer-quarantine-helper.sh
@@ -1,0 +1,933 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# pulse-peer-quarantine-helper.sh — Cross-runner peer quarantine (t3194).
+#
+# Sibling to pulse-runner-health-helper.sh (t2897), but partitioned by PEER
+# instead of self. The runner-health breaker protects the runner whose own
+# dispatches are dying; this helper protects PEERS by detecting when another
+# runner is emitting recovery primitives on the GitHub comment trail and
+# automatically quarantining its claims so they stop blocking dispatch.
+#
+# Detection signal: the canonical recovery comment shape emitted by
+# pulse-cleanup.sh:978 —
+#
+#   CLAIM_RELEASED reason=launch_recovery:no_worker_process runner=<peer>
+#
+# Each comment matching that shape is one observed "zero-attempt failure"
+# attributable to <peer>. When the rolling counter for any peer hits the
+# configured threshold inside the rolling window, the helper writes a
+# `peer-quarantine-until=<ISO>` entry to the shared dispatch-override.conf
+# and emits a single deduped advisory.
+#
+# The dispatch-dedup-helper.sh assignee filter (Layer 6 sub-step) reads the
+# same conf file and treats any peer with `peer-quarantine-until=<ISO>` set
+# to a future timestamp as if it were on the legacy `ignore` list — its
+# claim no longer blocks this runner's dispatch.
+#
+# Manual `dispatch-override.conf` entries (`honour | ignore | warn |
+# honour-only-above:V`) are NEVER touched by this helper. Only entries whose
+# value starts with `peer-quarantine-` are auto-managed.
+#
+# Subcommands:
+#   record-peer-event <peer> <issue-ref>   — record one observed peer recovery event.
+#   is-quarantined <peer>                  — exit 0 if quarantined, 1 if not.
+#   status [--json] [<peer>]               — print human or JSON state summary.
+#   release <peer> [--reason "<text>"]     — manually clear a peer's quarantine.
+#   scan-comments [<peer-filter>]          — read JSON array of comments from
+#                                            stdin, extract launch-recovery
+#                                            events, record each. (Used by
+#                                            dispatch-dedup-helper.sh's
+#                                            comment fetch path for zero-cost
+#                                            opportunistic detection.)
+#   help                                   — show usage.
+#
+# State file: ~/.aidevops/cache/peer-quarantine.json (v1 schema).
+# Advisory:   ~/.aidevops/advisories/peer-quarantine-<peer>.advisory
+# Stamp:      ~/.aidevops/cache/peer-quarantine-advisory-<peer>.stamp (24h dedup).
+# Override:   ~/.config/aidevops/dispatch-override.conf (shared with t2422).
+#
+# Environment overrides:
+#   PEER_QUARANTINE_FAILURE_THRESHOLD       (default 5)
+#   PEER_QUARANTINE_WINDOW_HOURS            (default 1)
+#   PEER_QUARANTINE_DURATION_HOURS          (default 6)
+#   PEER_QUARANTINE_DISABLED                (default 0; set 1 to no-op all subcommands)
+#   PEER_QUARANTINE_TEST_NOW                (test-only; ISO-8601 string used as "now")
+#   PEER_QUARANTINE_OVERRIDE_CONF           (test-only; override conf path)
+
+set -euo pipefail
+
+# Resolve script directory for sourcing siblings.
+PEER_QUARANTINE_HELPER_DIR="${PEER_QUARANTINE_HELPER_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+
+# Source shared color/print constants when available; otherwise guard.
+# shellcheck source=./shared-constants.sh
+# shellcheck disable=SC1091
+if [[ -r "${PEER_QUARANTINE_HELPER_DIR}/shared-constants.sh" ]]; then
+	source "${PEER_QUARANTINE_HELPER_DIR}/shared-constants.sh" 2>/dev/null || true
+fi
+# Local fallbacks for color codes if shared-constants didn't load.
+[[ -z "${RED+x}" ]] && RED=''
+[[ -z "${GREEN+x}" ]] && GREEN=''
+[[ -z "${YELLOW+x}" ]] && YELLOW=''
+[[ -z "${NC+x}" ]] && NC=''
+
+# Tunables.
+PEER_QUARANTINE_FAILURE_THRESHOLD="${PEER_QUARANTINE_FAILURE_THRESHOLD:-5}"
+PEER_QUARANTINE_WINDOW_HOURS="${PEER_QUARANTINE_WINDOW_HOURS:-1}"
+PEER_QUARANTINE_DURATION_HOURS="${PEER_QUARANTINE_DURATION_HOURS:-6}"
+PEER_QUARANTINE_DISABLED="${PEER_QUARANTINE_DISABLED:-0}"
+
+# Paths.
+PEER_QUARANTINE_CACHE_DIR="${PEER_QUARANTINE_CACHE_DIR:-${HOME}/.aidevops/cache}"
+PEER_QUARANTINE_STATE_FILE="${PEER_QUARANTINE_STATE_FILE:-${PEER_QUARANTINE_CACHE_DIR}/peer-quarantine.json}"
+PEER_QUARANTINE_ADVISORY_DIR="${PEER_QUARANTINE_ADVISORY_DIR:-${HOME}/.aidevops/advisories}"
+PEER_QUARANTINE_OVERRIDE_CONF="${PEER_QUARANTINE_OVERRIDE_CONF:-${HOME}/.config/aidevops/dispatch-override.conf}"
+
+# Cap on the rolling event ledger PER PEER.
+PEER_QUARANTINE_LEDGER_CAP=20
+
+#######################################
+# UTC ISO-8601 timestamp. Honours PEER_QUARANTINE_TEST_NOW for deterministic tests.
+#######################################
+_pq_now() {
+	if [[ -n "${PEER_QUARANTINE_TEST_NOW:-}" ]]; then
+		printf '%s\n' "$PEER_QUARANTINE_TEST_NOW"
+	else
+		date -u '+%Y-%m-%dT%H:%M:%SZ'
+	fi
+	return 0
+}
+
+#######################################
+# Convert an ISO-8601 UTC timestamp to epoch seconds. Handles both BSD
+# (macOS) and GNU date variants. Falls back to 0 on parse failure.
+# Args: $1 = ISO-8601 string
+# Stdout: epoch seconds (or 0 on failure)
+#######################################
+_pq_iso_to_epoch() {
+	local iso="${1:-}"
+	[[ -z "$iso" ]] && {
+		printf '0\n'
+		return 0
+	}
+	local epoch=""
+	# BSD date (macOS).
+	epoch=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$iso" '+%s' 2>/dev/null || true)
+	# GNU date (Linux).
+	[[ -z "$epoch" ]] && epoch=$(date -u -d "$iso" '+%s' 2>/dev/null || true)
+	[[ -z "$epoch" ]] && epoch="0"
+	printf '%s\n' "$epoch"
+	return 0
+}
+
+#######################################
+# Add N seconds to an ISO-8601 UTC timestamp and return the new ISO string.
+# Args: $1 = ISO timestamp, $2 = seconds to add (may be negative)
+#######################################
+_pq_iso_add_seconds() {
+	local iso="$1"
+	local seconds="$2"
+	local epoch=""
+	local new_epoch=""
+	epoch=$(_pq_iso_to_epoch "$iso")
+	[[ "$epoch" -eq 0 ]] && {
+		printf '\n'
+		return 1
+	}
+	new_epoch=$((epoch + seconds))
+	# BSD date.
+	local out
+	out=$(date -u -r "$new_epoch" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || true)
+	# GNU date.
+	[[ -z "$out" ]] && out=$(date -u -d "@${new_epoch}" '+%Y-%m-%dT%H:%M:%SZ' 2>/dev/null || true)
+	printf '%s\n' "$out"
+	return 0
+}
+
+#######################################
+# Normalise a peer login to UPPER_WITH_UNDERSCORES, mirroring the
+# dispatch-override-resolve.sh slug normalisation rules so that the conf
+# entries we write are read back consistently by the existing resolver.
+# Args: $1 = login (e.g. alex-solovyev, bot.user, user@example.com)
+# Stdout: ALEX_SOLOVYEV / BOT_USER / USER_EXAMPLE_COM
+#######################################
+_pq_login_to_var() {
+	local login="$1"
+	# Replace dash, dot, @ with underscore; uppercase.
+	printf '%s' "$login" | tr 'a-z\-.@' 'A-Z___'
+	return 0
+}
+
+#######################################
+# Build a jq path expression for a peer's record root or sub-field. Single
+# source of truth for the `.peers["<login>"]` selector pattern — call sites
+# that interpolate this into a jq filter use $(_pq_jq_path "$peer" <field>)
+# instead of hand-writing the selector. Keeps the literal `.peers["` from
+# proliferating across the file (linters-local-validators.sh repeated-string
+# ratchet flags 3+ identical literal fragments).
+#
+# Args:
+#   $1 = peer login (used verbatim in the bracket; quote in jq via "%s")
+#   $2 = optional sub-field name (no leading dot)
+# Output: a single-line jq path expression on stdout.
+#######################################
+_pq_jq_path() {
+	local _login="$1"
+	local _field="${2:-}"
+	if [[ -n "$_field" ]]; then
+		printf '.peers["%s"].%s' "$_login" "$_field"
+	else
+		printf '.peers["%s"]' "$_login"
+	fi
+	return 0
+}
+
+#######################################
+# Convenience wrapper: read a peer's sub-field from the state file. Composes
+# `_pq_jq_path` with `_pq_state_get` so call sites avoid an inline command
+# substitution that the linter ratchets on as a repeated literal.
+# Args: $1 = peer login, $2 = field name (no leading dot)
+# Output: field value on stdout (empty on missing/error).
+#######################################
+_pq_get_field() {
+	local _peer="$1"
+	local _field="$2"
+	local _path
+	_path=$(_pq_jq_path "$_peer" "$_field")
+	_pq_state_get "$_path"
+	return 0
+}
+
+#######################################
+# Return the current ISO timestamp wrapped in JSON double-quotes so jq
+# filters can interpolate the result directly. Centralises the JSON-quoting
+# pattern so the repeated-literals validator sees a single point of truth
+# instead of every call site rebuilding the form inline.
+# Output: "<iso-ts>" on stdout (with literal double-quote bytes).
+#######################################
+_pq_now_q() {
+	local _now
+	_now=$(_pq_now)
+	printf '"%s"' "$_now"
+	return 0
+}
+
+#######################################
+# Ensure cache + advisory directories exist with safe perms.
+#######################################
+_pq_ensure_dirs() {
+	mkdir -p "$PEER_QUARANTINE_CACHE_DIR" "$PEER_QUARANTINE_ADVISORY_DIR" 2>/dev/null || return 1
+	# Override conf parent (~/.config/aidevops) — best-effort, may already exist.
+	mkdir -p "$(dirname "$PEER_QUARANTINE_OVERRIDE_CONF")" 2>/dev/null || true
+	return 0
+}
+
+#######################################
+# Initialise an empty state file. Idempotent.
+#######################################
+_pq_init_state() {
+	[[ -f "$PEER_QUARANTINE_STATE_FILE" ]] && return 0
+	_pq_ensure_dirs || return 1
+	local now
+	now=$(_pq_now)
+	cat >"$PEER_QUARANTINE_STATE_FILE" <<EOF
+{
+  "version": 1,
+  "initialized_at": "${now}",
+  "peers": {}
+}
+EOF
+	return 0
+}
+
+#######################################
+# Atomic write: render JSON via jq pipeline, write to tmp, mv into place.
+# Args: $1 = jq filter (operates on existing state)
+#######################################
+_pq_state_apply() {
+	local jq_filter="$1"
+	_pq_init_state || return 1
+	command -v jq >/dev/null 2>&1 || return 1
+	local tmp
+	tmp="${PEER_QUARANTINE_STATE_FILE}.tmp.$$"
+	if jq "$jq_filter" <"$PEER_QUARANTINE_STATE_FILE" >"$tmp" 2>/dev/null; then
+		mv "$tmp" "$PEER_QUARANTINE_STATE_FILE"
+		return 0
+	fi
+	rm -f "$tmp"
+	return 1
+}
+
+#######################################
+# Read a jq path from the state file. Returns empty string on failure.
+# Args: $1 = jq path expression
+#######################################
+_pq_state_get() {
+	local jq_path="$1"
+	[[ -f "$PEER_QUARANTINE_STATE_FILE" ]] || return 0
+	command -v jq >/dev/null 2>&1 || return 0
+	jq -r "${jq_path} // empty" <"$PEER_QUARANTINE_STATE_FILE" 2>/dev/null || true
+	return 0
+}
+
+#######################################
+# Determine if a peer's window is expired based on its window_started_at.
+# Args: $1 = peer login
+# Returns: 0 if window expired (counter should reset), 1 if still inside.
+#######################################
+_pq_peer_window_expired() {
+	local peer="$1"
+	local started
+	started=$(_pq_get_field "$peer" window_started_at)
+	[[ -z "$started" ]] && return 0
+	local started_epoch=""
+	local now_epoch=""
+	local now_iso=""
+	started_epoch=$(_pq_iso_to_epoch "$started")
+	now_iso=$(_pq_now)
+	now_epoch=$(_pq_iso_to_epoch "$now_iso")
+	[[ "$started_epoch" -eq 0 ]] && return 0
+	local age=$((now_epoch - started_epoch))
+	local window_seconds=$((PEER_QUARANTINE_WINDOW_HOURS * 3600))
+	[[ "$age" -gt "$window_seconds" ]] && return 0
+	return 1
+}
+
+#######################################
+# cmd_record_peer_event — record one observed peer recovery event for the
+# zero-attempt class. Increments the peer's rolling counter; trips the
+# quarantine when the threshold is reached inside the rolling window.
+# Args: $1 = peer login
+#       $2 = issue ref (e.g. owner/repo#NNN) — audit-only.
+#######################################
+cmd_record_peer_event() {
+	# Accept both flag-style (--peer NAME --issue-ref REF [--reason TEXT])
+	# and positional (peer issue-ref) for backward compatibility. Brief
+	# specifies flag-style; positional preserved so test harnesses and
+	# legacy callers still work.
+	local peer=""
+	local issue_ref="unknown"
+	local _reason="" # reserved for future ledger field; accepted but unused
+	while [[ $# -gt 0 ]]; do
+		local _arg="$1"
+		case "$_arg" in
+		--peer)
+			peer="${2:-}"
+			shift 2
+			;;
+		--issue-ref)
+			issue_ref="${2:-unknown}"
+			shift 2
+			;;
+		--reason)
+			_reason="${2:-}"
+			shift 2
+			;;
+		--event-iso)
+			# Accepted for symmetry with scan-comments; ignored — the
+			# helper always uses _pq_now so PEER_QUARANTINE_TEST_NOW is
+			# the single override knob.
+			shift 2
+			;;
+		--*)
+			printf 'record-peer-event: unknown flag: %s\n' "$_arg" >&2
+			return 1
+			;;
+		*)
+			if [[ -z "$peer" ]]; then
+				peer="$_arg"
+			elif [[ "$issue_ref" == "unknown" ]]; then
+				issue_ref="$_arg"
+			fi
+			shift
+			;;
+		esac
+	done
+	if [[ -z "$peer" ]]; then
+		echo "Usage: $0 record-peer-event --peer <name> --issue-ref <slug#num> [--reason <text>]" >&2
+		return 1
+	fi
+	[[ "$PEER_QUARANTINE_DISABLED" == "1" ]] && return 0
+	command -v jq >/dev/null 2>&1 || return 0
+	_pq_init_state || return 1
+
+	local now=""
+	local peer_root=""
+	local now_q=""
+	now=$(_pq_now)
+	peer_root=$(_pq_jq_path "$peer")
+	# Pre-quote `${now}` once via the shared helper so call sites can
+	# interpolate the JSON-quoted form without rebuilding it locally.
+	now_q=$(_pq_now_q)
+
+	# Window expiry: if the peer's rolling window has elapsed without
+	# tripping, reset its counter and re-anchor the window. Must run BEFORE
+	# applying the new event so a stale window doesn't carry an old counter.
+	if _pq_peer_window_expired "$peer"; then
+		_pq_state_apply \
+			"${peer_root} = ((${peer_root} // {}) + {failure_count:0, window_started_at:${now_q}})" || true
+	fi
+
+	# Build an event entry and increment the counter atomically.
+	local event_entry
+	event_entry=$(jq -n \
+		--arg ref "$issue_ref" \
+		--arg ts "$now" \
+		'{issue_ref:$ref, ts:$ts}')
+
+	# Initialise the peer record if missing; bump counter; append to ledger
+	# with rolling cap.
+	_pq_state_apply "
+		${peer_root} = (
+			(${peer_root} // {failure_count:0, window_started_at:${now_q}, events:[]})
+			| .failure_count = ((.failure_count // 0) + 1)
+			| .last_event_at = ${now_q}
+			| .events = (((.events // []) + [${event_entry}]) | .[-${PEER_QUARANTINE_LEDGER_CAP}:])
+		)
+	" || return 1
+
+	# Trip evaluation. Only count up to threshold; further events past the
+	# trip refresh quarantine_until rather than re-tripping.
+	local count
+	count=$(_pq_get_field "$peer" failure_count)
+	[[ -z "$count" ]] && count=0
+	if [[ "$count" -ge "$PEER_QUARANTINE_FAILURE_THRESHOLD" ]]; then
+		local existing_until
+		existing_until=$(_pq_get_field "$peer" quarantine_until)
+		local now_epoch
+		now_epoch=$(_pq_iso_to_epoch "$now")
+		local until_epoch=0
+		[[ -n "$existing_until" ]] && until_epoch=$(_pq_iso_to_epoch "$existing_until")
+		# Trip (or re-extend) only if not already covering current time.
+		if [[ "$until_epoch" -le "$now_epoch" ]]; then
+			_pq_trip_peer "$peer" "$issue_ref" "failure_count=${count}"
+		fi
+	fi
+	return 0
+}
+
+#######################################
+# Trip the peer breaker: set quarantine_until ISO, write the override conf
+# entry, and emit a deduped advisory.
+# Args: $1 = peer login
+#       $2 = triggering issue ref (audit only)
+#       $3 = reason string
+#######################################
+_pq_trip_peer() {
+	local peer="$1"
+	local triggering_issue="$2"
+	local reason="$3"
+	local now=""
+	local until_iso=""
+	local peer_root=""
+	local now_q=""
+	local until_q=""
+	local reason_q=""
+	local trig_q=""
+	now=$(_pq_now)
+	until_iso=$(_pq_iso_add_seconds "$now" $((PEER_QUARANTINE_DURATION_HOURS * 3600)))
+	[[ -z "$until_iso" ]] && return 1
+	peer_root=$(_pq_jq_path "$peer")
+	# Pre-quote each value once so the jq filter interpolates JSON-quoted
+	# forms via local vars instead of repeating the escape pattern at every
+	# field assignment.
+	now_q=$(_pq_now_q)
+	until_q="\"${until_iso}\""
+	reason_q="\"${reason}\""
+	trig_q="\"${triggering_issue}\""
+
+	# Persist quarantine_until on the peer record.
+	_pq_state_apply \
+		"${peer_root}.quarantine_until = ${until_q} \
+		| ${peer_root}.quarantined_at = ${now_q} \
+		| ${peer_root}.reason = ${reason_q} \
+		| ${peer_root}.triggering_issue = ${trig_q}" || true
+
+	# Write the override conf entry. The conf format is shared with t2422
+	# (`DISPATCH_OVERRIDE_<PEER>=<value>`), and dispatch-dedup-helper.sh
+	# reads `peer-quarantine-until=<ISO>` as a "treat-as-ignore-while-active"
+	# directive.
+	_pq_write_override_entry "$peer" "$until_iso" || true
+
+	# Advisory (deduped 24h or on state change).
+	_pq_post_advisory "$peer" "$until_iso" "$reason" "$triggering_issue"
+	return 0
+}
+
+#######################################
+# Atomically rewrite ~/.config/aidevops/dispatch-override.conf so that the
+# DISPATCH_OVERRIDE_<PEER> line carries `peer-quarantine-until=<ISO>`.
+# Manual entries (honour | ignore | warn | honour-only-above:V) are
+# preserved untouched — only existing peer-quarantine-* values for the
+# same peer are overwritten.
+# Args: $1 = peer login (lowercase or mixed)
+#       $2 = ISO timestamp
+#######################################
+_pq_write_override_entry() {
+	local peer="$1"
+	local until_iso="$2"
+	local conf="$PEER_QUARANTINE_OVERRIDE_CONF"
+	_pq_ensure_dirs || return 1
+
+	local var_name
+	var_name="DISPATCH_OVERRIDE_$(_pq_login_to_var "$peer")"
+	local new_value="peer-quarantine-until=${until_iso}"
+	local new_line="${var_name}=\"${new_value}\""
+	local tmp
+	tmp="${conf}.tmp.$$"
+	# Read existing conf (if any) and write a copy with the entry replaced
+	# or appended. If an existing line for the same var name carries a
+	# manual value (anything not starting with peer-quarantine-), leave it
+	# alone — manual intent wins.
+	local replaced=0
+	if [[ -f "$conf" ]]; then
+		while IFS= read -r line; do
+			if [[ "$line" =~ ^${var_name}= ]]; then
+				# Existing entry for this peer — check if manual.
+				local existing_val
+				existing_val="${line#"${var_name}"=}"
+				existing_val="${existing_val#\"}"
+				existing_val="${existing_val%\"}"
+				existing_val="${existing_val#\'}"
+				existing_val="${existing_val%\'}"
+				if [[ "$existing_val" == peer-quarantine-* ]]; then
+					# Auto-managed entry — replace it.
+					printf '%s\n' "$new_line" >>"$tmp"
+					replaced=1
+					continue
+				fi
+				# Manual entry — preserve it. Skip writing the auto entry
+				# this pass; dispatch-dedup will see the manual value and
+				# act on it. We log this as a hint via the advisory.
+				printf '%s\n' "$line" >>"$tmp"
+				replaced=1
+				continue
+			fi
+			printf '%s\n' "$line" >>"$tmp"
+		done <"$conf"
+	fi
+	if [[ "$replaced" -eq 0 ]]; then
+		[[ -s "$tmp" ]] && printf '\n' >>"$tmp"
+		printf '# Auto-managed by pulse-peer-quarantine-helper.sh (t3194)\n' >>"$tmp"
+		printf '%s\n' "$new_line" >>"$tmp"
+	fi
+	mv "$tmp" "$conf"
+	chmod 600 "$conf" 2>/dev/null || true
+	return 0
+}
+
+#######################################
+# Remove the auto-managed conf entry for a peer (manual entries preserved).
+# Args: $1 = peer login
+#######################################
+_pq_clear_override_entry() {
+	local peer="$1"
+	local conf="$PEER_QUARANTINE_OVERRIDE_CONF"
+	[[ -f "$conf" ]] || return 0
+	local var_name
+	var_name="DISPATCH_OVERRIDE_$(_pq_login_to_var "$peer")"
+	local tmp
+	tmp="${conf}.tmp.$$"
+	while IFS= read -r line; do
+		if [[ "$line" =~ ^${var_name}= ]]; then
+			# Drop only auto-managed entries (peer-quarantine-* values).
+			local existing_val
+			existing_val="${line#"${var_name}"=}"
+			existing_val="${existing_val#\"}"
+			existing_val="${existing_val%\"}"
+			existing_val="${existing_val#\'}"
+			existing_val="${existing_val%\'}"
+			if [[ "$existing_val" == peer-quarantine-* ]]; then
+				continue
+			fi
+		fi
+		printf '%s\n' "$line" >>"$tmp"
+	done <"$conf"
+	# Also strip the auto-managed banner line if it was the only reason
+	# for the file's existence — but only when we're sure no other
+	# auto entries remain. Cheaper to leave it alone.
+	mv "$tmp" "$conf"
+	chmod 600 "$conf" 2>/dev/null || true
+	return 0
+}
+
+#######################################
+# Write/refresh the per-peer advisory file with 24h dedup.
+# Args: $1 = peer login
+#       $2 = quarantine_until ISO
+#       $3 = reason
+#       $4 = triggering issue ref (audit)
+#######################################
+_pq_post_advisory() {
+	local peer="$1"
+	local until_iso="$2"
+	local reason="$3"
+	local triggering="$4"
+	_pq_ensure_dirs || return 1
+
+	local advisory_file=""
+	local stamp_file=""
+	advisory_file="${PEER_QUARANTINE_ADVISORY_DIR}/peer-quarantine-${peer}.advisory"
+	stamp_file="${PEER_QUARANTINE_CACHE_DIR}/peer-quarantine-advisory-${peer}.stamp"
+
+	local now=""
+	local now_epoch=""
+	now=$(_pq_now)
+	now_epoch=$(_pq_iso_to_epoch "$now")
+	local should_emit=1
+
+	if [[ -f "$stamp_file" ]]; then
+		local prior_until=""
+		local prior_ts=""
+		local prior_epoch=""
+		prior_until=$(sed -n 1p "$stamp_file" 2>/dev/null || echo "")
+		prior_ts=$(sed -n 2p "$stamp_file" 2>/dev/null || echo "")
+		prior_epoch=$(_pq_iso_to_epoch "$prior_ts")
+		# If the quarantine_until is unchanged (same trip event) and less
+		# than 24h since last advisory, suppress.
+		if [[ "$prior_until" == "$until_iso" ]] && [[ "$prior_epoch" -gt 0 ]]; then
+			local age=$((now_epoch - prior_epoch))
+			if [[ "$age" -lt $((24 * 3600)) ]]; then
+				should_emit=0
+			fi
+		fi
+	fi
+
+	if [[ "$should_emit" -eq 1 ]]; then
+		cat >"$advisory_file" <<EOF
+Peer-runner ${peer} has been quarantined by this runner.
+
+Reason:           ${reason}
+Triggering issue: ${triggering}
+Quarantine until: ${until_iso}
+Created:          ${now}
+
+Effect: this runner will treat ${peer}'s DISPATCH_CLAIM comments and
+assignee entries as non-blocking until quarantine expires. Other peers
+that read this conf file will do the same.
+
+Diagnose: pulse-peer-quarantine-helper.sh status
+Release:  pulse-peer-quarantine-helper.sh release ${peer}
+Background: reference/cross-runner-coordination.md §9
+EOF
+		printf '%s\n%s\n' "$until_iso" "$now" >"$stamp_file"
+	fi
+	return 0
+}
+
+#######################################
+# cmd_is_quarantined — exit 0 if the named peer is currently quarantined
+# (quarantine_until is in the future and breaker is enabled), exit 1
+# otherwise. Auto-expiry is enforced here: a stale quarantine_until is
+# treated as not-quarantined without rewriting the state file.
+# Args: $1 = peer login
+#######################################
+cmd_is_quarantined() {
+	# Accept both --peer NAME (brief-specified) and positional <peer>.
+	local peer=""
+	while [[ $# -gt 0 ]]; do
+		local _arg="$1"
+		case "$_arg" in
+		--peer)
+			peer="${2:-}"
+			shift 2
+			;;
+		--*)
+			printf 'is-quarantined: unknown flag: %s\n' "$_arg" >&2
+			return 1
+			;;
+		*)
+			[[ -z "$peer" ]] && peer="$_arg"
+			shift
+			;;
+		esac
+	done
+	if [[ -z "$peer" ]]; then
+		echo "Usage: $0 is-quarantined --peer <name>" >&2
+		return 1
+	fi
+	[[ "$PEER_QUARANTINE_DISABLED" == "1" ]] && return 1
+	[[ -f "$PEER_QUARANTINE_STATE_FILE" ]] || return 1
+	command -v jq >/dev/null 2>&1 || return 1
+	local until_iso
+	until_iso=$(_pq_get_field "$peer" quarantine_until)
+	[[ -z "$until_iso" ]] && return 1
+	local until_epoch=""
+	local now_epoch=""
+	local now_iso=""
+	until_epoch=$(_pq_iso_to_epoch "$until_iso")
+	now_iso=$(_pq_now)
+	now_epoch=$(_pq_iso_to_epoch "$now_iso")
+	[[ "$until_epoch" -gt "$now_epoch" ]] && return 0
+	return 1
+}
+
+#######################################
+# cmd_release — manually clear a peer's quarantine. Removes the auto-
+# managed conf entry and clears the in-memory state for that peer.
+#######################################
+cmd_release() {
+	# Accept --peer NAME (brief-specified) plus positional <peer>; --reason
+	# remains optional. Unknown flags are rejected so typos don't get
+	# silently swallowed as the peer name.
+	local peer=""
+	local reason="manual release"
+	while [[ $# -gt 0 ]]; do
+		local _arg="$1"
+		case "$_arg" in
+		--peer)
+			peer="${2:-}"
+			shift 2
+			;;
+		--reason)
+			reason="${2:-manual release}"
+			shift 2
+			;;
+		--*)
+			printf 'release: unknown flag: %s\n' "$_arg" >&2
+			return 1
+			;;
+		*)
+			[[ -z "$peer" ]] && peer="$_arg"
+			shift
+			;;
+		esac
+	done
+	if [[ -z "$peer" ]]; then
+		echo "Usage: $0 release --peer <name> [--reason \"<text>\"]" >&2
+		return 1
+	fi
+	_pq_init_state || return 1
+	# Reset the peer's record. Pre-compute the JSON-quoted "now" once via
+	# the shared helper so the jq filter interpolates `${now_q}` directly.
+	local peer_root=""
+	local now_q=""
+	local reason_q=""
+	peer_root=$(_pq_jq_path "$peer")
+	now_q=$(_pq_now_q)
+	reason_q="\"${reason}\""
+	_pq_state_apply \
+		"${peer_root} = {failure_count:0, window_started_at:${now_q}, quarantine_until:null, released_at:${now_q}, release_reason:${reason_q}, events:[]}" || return 1
+	_pq_clear_override_entry "$peer"
+	# Clear advisory + stamp.
+	rm -f "${PEER_QUARANTINE_ADVISORY_DIR}/peer-quarantine-${peer}.advisory" \
+		"${PEER_QUARANTINE_CACHE_DIR}/peer-quarantine-advisory-${peer}.stamp" 2>/dev/null || true
+	printf '%bReleased%b: peer %s quarantine cleared (%s)\n' \
+		"$GREEN" "$NC" "$peer" "$reason" >&2
+	return 0
+}
+
+#######################################
+# cmd_status — print state. Default human-readable; --json emits raw JSON.
+# Optional positional <peer> filters output to that peer.
+#######################################
+cmd_status() {
+	local emit_json=0
+	local filter_peer=""
+	while [[ $# -gt 0 ]]; do
+		local _arg="$1"
+		case "$_arg" in
+		--json)
+			emit_json=1
+			shift
+			;;
+		*)
+			[[ -z "$filter_peer" ]] && filter_peer="$_arg"
+			shift
+			;;
+		esac
+	done
+
+	if [[ ! -f "$PEER_QUARANTINE_STATE_FILE" ]]; then
+		if [[ "$emit_json" -eq 1 ]]; then
+			printf '{"state":"uninitialized","peers":{}}\n'
+		else
+			printf 'state: uninitialized (no record-peer-event calls yet)\n'
+		fi
+		return 0
+	fi
+
+	if [[ "$emit_json" -eq 1 ]]; then
+		if [[ -n "$filter_peer" ]]; then
+			jq --arg p "$filter_peer" '.peers[$p] // null' <"$PEER_QUARANTINE_STATE_FILE" 2>/dev/null || cat "$PEER_QUARANTINE_STATE_FILE"
+		else
+			cat "$PEER_QUARANTINE_STATE_FILE"
+		fi
+		return 0
+	fi
+
+	# Human format.
+	local now_epoch=""
+	local now_iso=""
+	now_iso=$(_pq_now)
+	now_epoch=$(_pq_iso_to_epoch "$now_iso")
+	local peers
+	if [[ -n "$filter_peer" ]]; then
+		peers="$filter_peer"
+	else
+		peers=$(jq -r '.peers | keys[]' <"$PEER_QUARANTINE_STATE_FILE" 2>/dev/null || true)
+	fi
+	if [[ -z "$peers" ]]; then
+		printf 'no peers tracked (threshold=%s, window=%sh, duration=%sh)\n' \
+			"$PEER_QUARANTINE_FAILURE_THRESHOLD" \
+			"$PEER_QUARANTINE_WINDOW_HOURS" \
+			"$PEER_QUARANTINE_DURATION_HOURS"
+		return 0
+	fi
+	local peer=""
+	local count=""
+	local window=""
+	local until_iso=""
+	local state=""
+	local until_epoch=""
+	while IFS= read -r peer; do
+		[[ -z "$peer" ]] && continue
+		count=$(_pq_get_field "$peer" failure_count)
+		window=$(_pq_get_field "$peer" window_started_at)
+		until_iso=$(_pq_get_field "$peer" quarantine_until)
+		until_epoch=$(_pq_iso_to_epoch "${until_iso:-}")
+		if [[ -n "$until_iso" ]] && [[ "$until_epoch" -gt "$now_epoch" ]]; then
+			state="quarantined"
+		else
+			state="closed"
+		fi
+		printf 'peer=%s state=%s count=%s/%s window_started=%s' \
+			"$peer" "$state" "${count:-0}" "$PEER_QUARANTINE_FAILURE_THRESHOLD" "${window:-n/a}"
+		if [[ "$state" == "quarantined" ]]; then
+			printf ' until=%s' "$until_iso"
+		fi
+		printf '\n'
+	done <<<"$peers"
+	return 0
+}
+
+#######################################
+# cmd_scan_comments — read a JSON array of comments from stdin and record
+# every launch_recovery:no_worker_process event from a peer (i.e. not the
+# self_login). Schema: each comment object should contain `body` (string)
+# and `user.login` (string), or `body_start` + `author` (the shape produced
+# by dispatch-dedup-helper.sh's existing comment fetch). Lines with
+# unparseable shapes are ignored.
+#
+# Args (optional):
+#   --self-login <login>  — skip events emitted by this login.
+#   --issue-ref <ref>     — audit ref to record with each event.
+#######################################
+cmd_scan_comments() {
+	local self_login=""
+	local issue_ref="comment-scan"
+	while [[ $# -gt 0 ]]; do
+		local _arg="$1"
+		case "$_arg" in
+		--self-login)
+			self_login="${2:-}"
+			shift 2
+			;;
+		--issue-ref)
+			issue_ref="${2:-comment-scan}"
+			shift 2
+			;;
+		*)
+			shift
+			;;
+		esac
+	done
+	[[ "$PEER_QUARANTINE_DISABLED" == "1" ]] && return 0
+	command -v jq >/dev/null 2>&1 || return 0
+
+	local input
+	input=$(cat 2>/dev/null || true)
+	[[ -z "$input" ]] && return 0
+	[[ "$input" == "[]" ]] && return 0
+	[[ "$input" == "null" ]] && return 0
+
+	# Extract `body` (or `body_start` for the dedup-helper shape) from
+	# each comment, strip leading whitespace, and grep for the recovery
+	# regex via jq's test() so we don't shell out per comment.
+	local lines
+	lines=$(printf '%s' "$input" | jq -r '
+		[.[] | (
+			(.body // .body_start // "")
+			+ "|"
+			+ ((.user.login // .author // ""))
+		)]
+		| .[]
+		| select(test("^CLAIM_RELEASED reason=launch_recovery:no_worker_process runner=[A-Za-z0-9._\\-]+"))
+	' 2>/dev/null) || lines=""
+	[[ -z "$lines" ]] && return 0
+
+	local body_and_author=""
+	local body=""
+	local peer=""
+	while IFS= read -r body_and_author; do
+		[[ -z "$body_and_author" ]] && continue
+		body="${body_and_author%|*}"
+		# Extract runner=<peer> from the body.
+		peer=$(printf '%s' "$body" | sed -nE 's/.*runner=([A-Za-z0-9._-]+).*/\1/p' | head -1)
+		[[ -z "$peer" ]] && continue
+		# Skip self-login events — those are recorded by the local breaker.
+		[[ -n "$self_login" && "$peer" == "$self_login" ]] && continue
+		cmd_record_peer_event "$peer" "$issue_ref" || true
+	done <<<"$lines"
+	return 0
+}
+
+#######################################
+# Help text.
+#######################################
+cmd_help() {
+	cat <<'EOF'
+pulse-peer-quarantine-helper.sh — Cross-runner peer quarantine (t3194).
+
+USAGE:
+  pulse-peer-quarantine-helper.sh record-peer-event <peer> <issue-ref>
+  pulse-peer-quarantine-helper.sh is-quarantined <peer>
+  pulse-peer-quarantine-helper.sh status [--json] [<peer>]
+  pulse-peer-quarantine-helper.sh release <peer> [--reason "<text>"]
+  pulse-peer-quarantine-helper.sh scan-comments [--self-login <login>] [--issue-ref <ref>]
+  pulse-peer-quarantine-helper.sh help
+
+DETECTION SIGNAL (per pulse-cleanup.sh:978):
+  CLAIM_RELEASED reason=launch_recovery:no_worker_process runner=<peer>
+
+ENVIRONMENT:
+  PEER_QUARANTINE_FAILURE_THRESHOLD       (default 5)
+  PEER_QUARANTINE_WINDOW_HOURS            (default 1)
+  PEER_QUARANTINE_DURATION_HOURS          (default 6)
+  PEER_QUARANTINE_DISABLED                (default 0; set 1 to no-op all subcommands)
+
+EXIT CODES:
+  is-quarantined:  0 = peer is currently quarantined (DO honour as if `ignore`)
+                   1 = peer is not quarantined (honour normally)
+EOF
+	return 0
+}
+
+#######################################
+# Dispatch.
+#######################################
+main() {
+	local cmd="${1:-help}"
+	shift || true
+	case "$cmd" in
+	record-peer-event) cmd_record_peer_event "$@" ;;
+	is-quarantined) cmd_is_quarantined "$@" ;;
+	status) cmd_status "$@" ;;
+	release) cmd_release "$@" ;;
+	scan-comments) cmd_scan_comments "$@" ;;
+	help | -h | --help) cmd_help ;;
+	*)
+		printf 'Unknown subcommand: %s\n' "$cmd" >&2
+		cmd_help
+		return 1
+		;;
+	esac
+	return $?
+}
+
+# Only run if invoked directly (sourcing exposes functions for tests).
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+	main "$@"
+fi

--- a/.agents/scripts/tests/test-peer-quarantine.sh
+++ b/.agents/scripts/tests/test-peer-quarantine.sh
@@ -1,0 +1,471 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-peer-quarantine.sh — Structural tests for t3194 cross-runner peer
+# quarantine in pulse-peer-quarantine-helper.sh and the matching
+# dispatch-dedup-helper.sh override-loop honouring path.
+#
+# Verifies:
+#   1.  Helper binary exists, is executable, parses subcommands.
+#   2.  Recording 4 events does NOT trip quarantine.
+#   3.  Recording the 5th event (default threshold) DOES trip quarantine
+#       and writes DISPATCH_OVERRIDE_<PEER>="peer-quarantine-until=<ISO>".
+#   4.  is-quarantined --peer <name> exits 0 while the until-timestamp is
+#       in the future (PEER_QUARANTINE_TEST_NOW).
+#   5.  is-quarantined --peer <name> exits 1 once
+#       PEER_QUARANTINE_TEST_NOW is past the until-timestamp (auto-expiry,
+#       no state-file rewrite required).
+#   6.  Manual conf entries (any non-`peer-quarantine-*` value) are
+#       preserved across record-peer-event calls — only entries that
+#       began as auto-managed get rewritten.
+#   7.  The brief-specified --peer flag and the legacy positional
+#       <peer> argument both work for record-peer-event,
+#       is-quarantined, and release.
+#   8.  Unknown flags are rejected with a non-zero exit code rather than
+#       silently swallowed as the peer name (which would mask typos as
+#       quarantines on garbage logins).
+#   9.  scan-comments correctly skips events whose runner=<self-login>
+#       matches --self-login, and records events from other peers.
+#  10.  release --peer <name> clears both the in-memory state record
+#       and the auto-managed conf entry, leaving manual entries on
+#       OTHER peers intact.
+#  11.  Advisory dedup: a per-peer .stamp file written on first trip
+#       suppresses a second advisory file emission within 24h.
+#  12.  Window expiry: events older than PEER_QUARANTINE_WINDOW_HOURS
+#       reset the failure counter (so a stale window doesn't carry an
+#       old count into a new evaluation).
+#  13.  PEER_QUARANTINE_DISABLED=1 short-circuits record-peer-event
+#       (no state writes, no conf writes, no advisory).
+#  14.  dispatch-dedup-helper.sh override-loop honours
+#       peer-quarantine-until=<future ISO> identically to the legacy
+#       `ignore` value: the peer is dropped from the blocking
+#       assignee set.
+#  15.  Both files (helper + dispatch-dedup) pass shellcheck.
+#
+# Tests are structural — no live GitHub API calls. State is sandboxed
+# via PEER_QUARANTINE_* env overrides so the tests cannot pollute the
+# real runner's quarantine state at ~/.config/aidevops/.
+
+set -u
+
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_BLUE=$'\033[0;34m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_BLUE="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+assert_contains() {
+	local label="$1" needle="$2" haystack="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if printf '%s' "$haystack" | grep -qF -- "$needle" 2>/dev/null; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  expected to find: $(printf '%q' "$needle")"
+		echo "  in output:        $(printf '%q' "${haystack:0:300}")"
+	fi
+	return 0
+}
+
+assert_not_contains() {
+	local label="$1" needle="$2" haystack="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if ! printf '%s' "$haystack" | grep -qF -- "$needle" 2>/dev/null; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  expected NOT to find: $(printf '%q' "$needle")"
+		echo "  in output:            $(printf '%q' "${haystack:0:300}")"
+	fi
+	return 0
+}
+
+assert_rc() {
+	local label="$1" expected="$2" actual="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$expected" == "$actual" ]]; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  expected rc=$expected, got rc=$actual"
+	fi
+	return 0
+}
+
+assert_file_exists() {
+	local label="$1" path="$2"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ -f "$path" ]]; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  expected file: $path"
+	fi
+	return 0
+}
+
+assert_file_absent() {
+	local label="$1" path="$2"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ ! -f "$path" ]]; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  expected file ABSENT: $path"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Setup: locate scripts, prepare a sandbox.
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HELPER="$SCRIPT_DIR/pulse-peer-quarantine-helper.sh"
+DEDUP="$SCRIPT_DIR/dispatch-dedup-helper.sh"
+
+if [[ ! -x "$HELPER" ]]; then
+	echo "${TEST_RED}FATAL${TEST_NC}: $HELPER not found or not executable"
+	exit 1
+fi
+if [[ ! -f "$DEDUP" ]]; then
+	echo "${TEST_RED}FATAL${TEST_NC}: $DEDUP not found"
+	exit 1
+fi
+if ! command -v jq >/dev/null 2>&1; then
+	echo "${TEST_RED}FATAL${TEST_NC}: jq required for these tests; install jq"
+	exit 1
+fi
+
+SANDBOX=$(mktemp -d -t peer-quarantine-test.XXXXXX)
+trap 'rm -rf "$SANDBOX"' EXIT
+
+export PEER_QUARANTINE_STATE_FILE="$SANDBOX/state.json"
+export PEER_QUARANTINE_OVERRIDE_CONF="$SANDBOX/override.conf"
+export PEER_QUARANTINE_ADVISORY_DIR="$SANDBOX/advisories"
+export PEER_QUARANTINE_CACHE_DIR="$SANDBOX/cache"
+mkdir -p "$PEER_QUARANTINE_ADVISORY_DIR" "$PEER_QUARANTINE_CACHE_DIR"
+
+# Anchor virtual time at 10:00 UTC. Each event uses _pq_now (which honours
+# PEER_QUARANTINE_TEST_NOW), so tests are deterministic across machines.
+export PEER_QUARANTINE_TEST_NOW="2026-04-30T10:00:00Z"
+
+echo "${TEST_BLUE}=== t3194: peer-quarantine helper tests ===${TEST_NC}"
+echo "Sandbox: $SANDBOX"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Section 1: Helper sanity.
+# ---------------------------------------------------------------------------
+echo "--- Section 1: helper sanity ---"
+
+help_out=$("$HELPER" help 2>&1) || true
+assert_contains "1a: help output mentions record-peer-event" "record-peer-event" "$help_out"
+assert_contains "1b: help output mentions is-quarantined" "is-quarantined" "$help_out"
+assert_contains "1c: help output mentions release" "release" "$help_out"
+assert_contains "1d: help output mentions scan-comments" "scan-comments" "$help_out"
+
+# ---------------------------------------------------------------------------
+# Section 2: Threshold behaviour (default = 5 events in 1h).
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Section 2: threshold ---"
+
+# 4 events: should NOT trip.
+for i in 1 2 3 4; do
+	"$HELPER" record-peer-event --peer alpha --issue-ref "test/repo#$i" >/dev/null
+done
+"$HELPER" is-quarantined --peer alpha
+rc=$?
+assert_rc "2a: 4 events does NOT trip quarantine" 1 "$rc"
+assert_not_contains "2b: no auto-managed conf entry after 4 events" \
+	"DISPATCH_OVERRIDE_ALPHA=" \
+	"$(cat "$PEER_QUARANTINE_OVERRIDE_CONF" 2>/dev/null || echo '')"
+
+# 5th event: trips.
+"$HELPER" record-peer-event --peer alpha --issue-ref "test/repo#5" >/dev/null
+"$HELPER" is-quarantined --peer alpha
+rc=$?
+assert_rc "2c: 5th event trips quarantine (rc=0)" 0 "$rc"
+
+conf_after=$(cat "$PEER_QUARANTINE_OVERRIDE_CONF")
+assert_contains "2d: conf has auto-managed banner" \
+	"Auto-managed by pulse-peer-quarantine-helper.sh (t3194)" "$conf_after"
+assert_contains "2e: conf has DISPATCH_OVERRIDE_ALPHA entry" \
+	"DISPATCH_OVERRIDE_ALPHA=" "$conf_after"
+assert_contains "2f: conf entry value is peer-quarantine-until=<ISO>" \
+	"peer-quarantine-until=2026-04-30T16:00:00Z" "$conf_after"
+
+# ---------------------------------------------------------------------------
+# Section 3: Auto-expiry — until-timestamp in the past.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Section 3: auto-expiry ---"
+
+# Advance virtual time past the 6h window (alpha was tripped at 10:00, so
+# until=16:00; jump to 17:00).
+PEER_QUARANTINE_TEST_NOW_BEFORE="$PEER_QUARANTINE_TEST_NOW"
+export PEER_QUARANTINE_TEST_NOW="2026-04-30T17:00:00Z"
+
+"$HELPER" is-quarantined --peer alpha
+rc=$?
+assert_rc "3a: is-quarantined returns 1 once until-timestamp is past" 1 "$rc"
+
+# Conf entry remains (rewriting on every read would be wasteful) — the
+# dispatch-dedup loop is the actual gate, and it does its own date math.
+conf_after_expiry=$(cat "$PEER_QUARANTINE_OVERRIDE_CONF")
+assert_contains "3b: stale entry is left in place (no rewrite)" \
+	"DISPATCH_OVERRIDE_ALPHA=" "$conf_after_expiry"
+
+# Restore time anchor for subsequent tests.
+export PEER_QUARANTINE_TEST_NOW="$PEER_QUARANTINE_TEST_NOW_BEFORE"
+
+# ---------------------------------------------------------------------------
+# Section 4: Manual conf entry preservation.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Section 4: manual entry preservation ---"
+
+# Seed a manual `ignore` entry for a different peer. Recording 5 events
+# against that peer must NOT overwrite the manual entry.
+{
+	echo "# pre-existing manual entry"
+	echo 'DISPATCH_OVERRIDE_MANUAL_PEER="ignore"'
+} >>"$PEER_QUARANTINE_OVERRIDE_CONF"
+
+for i in 1 2 3 4 5; do
+	"$HELPER" record-peer-event --peer manual-peer --issue-ref "test/repo#$i" >/dev/null
+done
+
+conf_manual=$(cat "$PEER_QUARANTINE_OVERRIDE_CONF")
+assert_contains "4a: manual ignore entry survives 5 events" \
+	'DISPATCH_OVERRIDE_MANUAL_PEER="ignore"' "$conf_manual"
+assert_not_contains "4b: no auto peer-quarantine-* entry written for manually-managed peer" \
+	'DISPATCH_OVERRIDE_MANUAL_PEER="peer-quarantine-until' "$conf_manual"
+
+# ---------------------------------------------------------------------------
+# Section 5: Flag and positional argument parity.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Section 5: --peer flag + positional parity ---"
+
+# Flag-style.
+"$HELPER" record-peer-event --peer flag-peer --issue-ref test/repo#1 >/dev/null
+flag_count=$(jq -r '.peers["flag-peer"].failure_count' "$PEER_QUARANTINE_STATE_FILE")
+assert_rc "5a: --peer flag records under correct key" 1 "$([[ "$flag_count" == "1" ]] && echo 1 || echo 0)"
+# Inverted: assert_rc passed 1==1 means count was 1. Cleaner direct check:
+[[ "$flag_count" == "1" ]] && echo "${TEST_GREEN}PASS${TEST_NC}: 5a (verified): flag count=1"
+
+# Positional.
+"$HELPER" record-peer-event positional-peer test/repo#1 >/dev/null
+pos_count=$(jq -r '.peers["positional-peer"].failure_count' "$PEER_QUARANTINE_STATE_FILE")
+[[ "$pos_count" == "1" ]] && echo "${TEST_GREEN}PASS${TEST_NC}: 5b: positional records under correct key" \
+	|| {
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: 5b: positional count=$pos_count (expected 1)"
+	}
+TESTS_RUN=$((TESTS_RUN + 2))
+
+# Unknown flag rejected.
+"$HELPER" record-peer-event --peer ok --bogus value >/dev/null 2>&1
+rc=$?
+assert_rc "5c: unknown flag rejected with rc=1" 1 "$rc"
+
+# ---------------------------------------------------------------------------
+# Section 6: scan-comments self-skip.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Section 6: scan-comments self-skip ---"
+
+# Build a small comments JSON containing one self-event and one peer event.
+cat >"$SANDBOX/comments.json" <<'JSON'
+[
+  {
+    "body_start": "CLAIM_RELEASED reason=launch_recovery:no_worker_process runner=self-runner ts=2026-04-30T10:30:00Z",
+    "author": "self-runner",
+    "created_at": "2026-04-30T10:30:00Z"
+  },
+  {
+    "body_start": "CLAIM_RELEASED reason=launch_recovery:no_worker_process runner=other-runner ts=2026-04-30T10:31:00Z",
+    "author": "other-runner",
+    "created_at": "2026-04-30T10:31:00Z"
+  },
+  {
+    "body_start": "Some unrelated comment about a PR review",
+    "author": "reviewer-bot",
+    "created_at": "2026-04-30T10:32:00Z"
+  }
+]
+JSON
+
+"$HELPER" scan-comments --self-login self-runner --issue-ref test/repo#100 \
+	<"$SANDBOX/comments.json" >/dev/null 2>&1
+
+self_count=$(jq -r '.peers["self-runner"].failure_count // 0' "$PEER_QUARANTINE_STATE_FILE")
+other_count=$(jq -r '.peers["other-runner"].failure_count // 0' "$PEER_QUARANTINE_STATE_FILE")
+
+[[ "$self_count" == "0" ]] && echo "${TEST_GREEN}PASS${TEST_NC}: 6a: self-runner event skipped" \
+	|| {
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: 6a: self-runner count=$self_count (expected 0)"
+	}
+[[ "$other_count" == "1" ]] && echo "${TEST_GREEN}PASS${TEST_NC}: 6b: other-runner event recorded" \
+	|| {
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: 6b: other-runner count=$other_count (expected 1)"
+	}
+TESTS_RUN=$((TESTS_RUN + 2))
+
+# ---------------------------------------------------------------------------
+# Section 7: Release clears state + auto-managed conf entry, leaves
+# manual entries intact.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Section 7: release ---"
+
+# alpha was tripped in section 2; release it.
+"$HELPER" release --peer alpha --reason "test release" >/dev/null 2>&1
+"$HELPER" is-quarantined --peer alpha
+rc=$?
+assert_rc "7a: release clears quarantine (is-quarantined=1)" 1 "$rc"
+
+conf_after_release=$(cat "$PEER_QUARANTINE_OVERRIDE_CONF")
+assert_not_contains "7b: release strips DISPATCH_OVERRIDE_ALPHA auto entry" \
+	"DISPATCH_OVERRIDE_ALPHA=" "$conf_after_release"
+assert_contains "7c: release does NOT touch manual ignore entry" \
+	'DISPATCH_OVERRIDE_MANUAL_PEER="ignore"' "$conf_after_release"
+
+# ---------------------------------------------------------------------------
+# Section 8: PEER_QUARANTINE_DISABLED short-circuits.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Section 8: disabled flag ---"
+
+PEER_QUARANTINE_DISABLED=1 "$HELPER" record-peer-event --peer disabled-peer --issue-ref test/repo#1 >/dev/null
+disabled_count=$(jq -r '.peers["disabled-peer"].failure_count // "absent"' "$PEER_QUARANTINE_STATE_FILE")
+[[ "$disabled_count" == "absent" || "$disabled_count" == "0" ]] \
+	&& echo "${TEST_GREEN}PASS${TEST_NC}: 8a: PEER_QUARANTINE_DISABLED skips state write" \
+	|| {
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: 8a: disabled count=$disabled_count"
+	}
+TESTS_RUN=$((TESTS_RUN + 1))
+
+# ---------------------------------------------------------------------------
+# Section 9: dispatch-dedup-helper.sh override-loop honouring.
+#
+# We can't easily call is_assigned() (it needs a real GitHub issue), but the
+# logic that interprets peer-quarantine-until=<ISO> is a small inline block.
+# Mirror the same parser shape here and assert it makes the right decision
+# given a known conf entry — this catches regressions where someone changes
+# the conf format without updating the dedup parser.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Section 9: dispatch-dedup honouring (parser shape regression) ---"
+
+# Trip a fresh peer to produce a clean conf entry to inspect.
+for i in 1 2 3 4 5; do
+	"$HELPER" record-peer-event --peer dedup-peer --issue-ref "test/repo#$i" >/dev/null
+done
+
+# Read the value the way dispatch-dedup-helper.sh does
+# (.agents/scripts/dispatch-dedup-helper.sh, _is_assigned override loop):
+override_val=$(grep -E '^DISPATCH_OVERRIDE_DEDUP_PEER=' "$PEER_QUARANTINE_OVERRIDE_CONF" \
+	| tail -n1 | cut -d= -f2- | tr -d '"' | tr -d "'")
+
+assert_contains "9a: dispatch-dedup parser sees peer-quarantine-until prefix" \
+	"peer-quarantine-until=" "$override_val"
+
+# Replicate the dedup-side date comparison for "future ISO → honour as ignore".
+q_until="${override_val#peer-quarantine-until=}"
+q_epoch=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$q_until" '+%s' 2>/dev/null \
+	|| date -u -d "$q_until" '+%s' 2>/dev/null \
+	|| echo 0)
+now_epoch=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$PEER_QUARANTINE_TEST_NOW" '+%s' 2>/dev/null \
+	|| date -u -d "$PEER_QUARANTINE_TEST_NOW" '+%s' 2>/dev/null \
+	|| echo 0)
+[[ "$q_epoch" -gt "$now_epoch" ]] \
+	&& echo "${TEST_GREEN}PASS${TEST_NC}: 9b: future until → dispatch-dedup would treat as ignore" \
+	|| {
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: 9b: q_epoch=$q_epoch now_epoch=$now_epoch"
+	}
+TESTS_RUN=$((TESTS_RUN + 1))
+
+# Past until → should NOT be treated as ignore.
+past_now=$(date -u -j -v+10H -f '%Y-%m-%dT%H:%M:%SZ' "$q_until" '+%s' 2>/dev/null \
+	|| date -u -d "$q_until +10 hours" '+%s' 2>/dev/null \
+	|| echo 0)
+[[ "$q_epoch" -lt "$past_now" ]] \
+	&& echo "${TEST_GREEN}PASS${TEST_NC}: 9c: past until → dispatch-dedup would NOT treat as ignore" \
+	|| {
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: 9c: q_epoch=$q_epoch past_now=$past_now"
+	}
+TESTS_RUN=$((TESTS_RUN + 1))
+
+# Spot-check that dispatch-dedup-helper.sh contains the t3194 marker so a
+# regression that strips the parser block fails this test.
+if grep -q 'peer-quarantine-until=\*' "$DEDUP" \
+	&& grep -q 't3194:' "$DEDUP"; then
+	echo "${TEST_GREEN}PASS${TEST_NC}: 9d: dispatch-dedup-helper.sh carries t3194 parser block"
+else
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	echo "${TEST_RED}FAIL${TEST_NC}: 9d: dispatch-dedup-helper.sh missing t3194 parser block"
+fi
+TESTS_RUN=$((TESTS_RUN + 1))
+
+# ---------------------------------------------------------------------------
+# Section 10: Shellcheck cleanliness.
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Section 10: shellcheck ---"
+
+if command -v shellcheck >/dev/null 2>&1; then
+	if shellcheck "$HELPER" >/dev/null 2>&1; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: 10a: helper passes shellcheck"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: 10a: helper has shellcheck violations"
+		shellcheck "$HELPER" 2>&1 | head -20
+	fi
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if shellcheck "$DEDUP" >/dev/null 2>&1; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: 10b: dispatch-dedup-helper passes shellcheck"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: 10b: dispatch-dedup-helper has shellcheck violations"
+		shellcheck "$DEDUP" 2>&1 | head -20
+	fi
+	TESTS_RUN=$((TESTS_RUN + 1))
+else
+	echo "${TEST_BLUE}SKIP${TEST_NC}: shellcheck not available"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary.
+# ---------------------------------------------------------------------------
+echo ""
+echo "${TEST_BLUE}=== Summary ===${TEST_NC}"
+echo "Tests run:    $TESTS_RUN"
+echo "Tests failed: $TESTS_FAILED"
+
+if [[ "$TESTS_FAILED" -eq 0 ]]; then
+	echo "${TEST_GREEN}All tests passed${TEST_NC}"
+	exit 0
+else
+	echo "${TEST_RED}$TESTS_FAILED test(s) failed${TEST_NC}"
+	exit 1
+fi


### PR DESCRIPTION
## Summary

Per-peer quarantine breaker for cross-runner `CLAIM_RELEASED reason=launch_recovery:no_worker_process` events. When a peer crosses the threshold (5 in 1h), the helper writes a `peer-quarantine-until=<ISO>` entry to `~/.config/aidevops/dispatch-override.conf` for 6h; `dispatch-dedup-helper.sh::is_assigned` honours those entries identically to the existing `ignore` filter (t2930 loop). The local pulse stops trusting that peer's CLAIM comments until it recovers.

Replaces #21912 (which couldn't pass CI due to the accumulated-diff false positive in `pulse-unbound-var-check.yml` — filed as #21921 / t3206). Identical content, single commit.

## Files Changed

- `.agents/scripts/pulse-peer-quarantine-helper.sh` (NEW, ~906 lines) — detection, ledger, override write, advisory, ops surface
- `.agents/scripts/dispatch-dedup-helper.sh` (EDIT) — `is_assigned` honours `peer-quarantine-until=<future-ISO>`; `has_dispatch_comment` opportunistically scans comments JSON
- `.agents/scripts/tests/test-peer-quarantine.sh` (NEW, 30 tests, all pass)
- `.agents/reference/cross-runner-coordination.md` (EDIT) — §9 Automatic Peer Quarantine (8 subsections); §3 Layer 6 sub-step note; See Also → §10

## Tunables

`PEER_QUARANTINE_FAILURE_THRESHOLD=5`, `_WINDOW_HOURS=1`, `_DURATION_HOURS=6`, `_DISABLED=0`, `_LEDGER_CAP=20`. `peer-quarantine-*` override values are auto-managed; manual override values preserved.

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** 30/30 tests pass; shellcheck clean; `pulse-unbound-var-check.sh` clean; pre-commit ratchets pass.

Resolves #21890
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.16 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-opus-4-7 spent 1h 47m and 191,705 tokens on this with the user in an interactive session.