### PR TITLE
GH#21929: simplify heredoc apostrophe example to top-level form

### DIFF
--- a/.agents/reference/bash-compat.md
+++ b/.agents/reference/bash-compat.md
@@ -105,10 +105,9 @@ A literal ASCII apostrophe (U+0027) inside an unquoted heredoc body (`<<EOF` / `
 
 ```bash
 # WRONG — bash 3.2 fails: "unexpected EOF while looking for matching '"
-body=$(cat <<EOF
+cat <<EOF
 it's a supervisor's blind spot
 EOF
-)
 ```
 
 Three fixes, in order of preference:


### PR DESCRIPTION
## Summary

Remove the `body=$(cat <<EOF ... EOF)` wrapper around the apostrophe-trap example so it stands alone as `cat <<EOF ... EOF`. The wrapper conflated this section with the previous "Heredoc inside $()" section (lines 84-95, GH#19252), suggesting the apostrophe bug only fires inside command substitution. The bug is independent — it triggers in any unquoted heredoc on bash 3.2 — so the simplified example is clearer.

## Files Changed

.agents/reference/bash-compat.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** markdownlint-cli2 passes 0 errors. Diff is exactly the 3-line replacement Gemini suggested in the inline review thread.

Resolves #21929


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.16 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-opus-4-7 spent 4m and 6,363 tokens on this as a headless worker.