### PR TITLE
GH#21945: Unify REST fallback function namespace to _rest_*

### DIFF
--- a/.agents/scripts/claim-task-id.sh
+++ b/.agents/scripts/claim-task-id.sh
@@ -493,7 +493,7 @@ create_github_issue() {
 	local create_args=(--title "$title")
 	# Pass --repo explicitly so the REST fallback path inside gh_create_issue
 	# can build the /repos/{owner}/{repo}/issues endpoint without relying on cwd
-	# (t3039: _gh_issue_create_rest requires --repo).
+	# (t3039: _rest_issue_create requires --repo).
 	[[ -n "$_slug_for_warn" ]] && create_args+=(--repo "$_slug_for_warn")
 
 	local body=""

--- a/.agents/scripts/gh
+++ b/.agents/scripts/gh
@@ -270,7 +270,7 @@ if [[ -n "$_SHIM_READ_REWRITE" ]]; then
 	}
 
 	_shim_rest_rewrite_read() {
-		# Source the REST fallback helper (contains _gh_should_fallback_to_rest
+		# Source the REST fallback helper (contains _rest_should_fallback
 		# and the _rest_* translator functions).
 		local _rest_helper=""
 		local _cand
@@ -294,7 +294,7 @@ if [[ -n "$_SHIM_READ_REWRITE" ]]; then
 		source "$_rest_helper" 2>/dev/null || return 1
 
 		# Check GraphQL budget. If above threshold, return 1 to fall through.
-		_gh_should_fallback_to_rest || return 1
+		_rest_should_fallback || return 1
 
 		# Extract repo and build stripped args.
 		_shim_extract_repo_and_args "$@" || return 1
@@ -323,7 +323,7 @@ if [[ -n "$_SHIM_READ_REWRITE" ]]; then
 		# If the REST translator ran but returned non-zero (actual API error
 		# vs. budget-OK/missing-helper), propagate the error rather than
 		# retrying via GraphQL (which would also fail if budget is exhausted).
-		# Budget-OK returns rc=1 from _gh_should_fallback_to_rest; we only
+		# Budget-OK returns rc=1 from _rest_should_fallback; we only
 		# get here when rc=1 from the function wrapper. The translator errors
 		# are already printed to stderr by the _rest_* functions.
 		# Conservative: always fall through to real gh.

--- a/.agents/scripts/issue-sync-helper-push.sh
+++ b/.agents/scripts/issue-sync-helper-push.sh
@@ -119,7 +119,7 @@ _push_create_issue() {
 	fi
 
 	# t3039: args without the "issue create" sub-command prefix so the same
-	# array can be passed to both gh issue create and _gh_issue_create_rest.
+	# array can be passed to both gh issue create and _rest_issue_create.
 	local -a args=("--repo" "$repo" "--title" "$title" "--body" "$body" "--label" "$all_labels")
 	[[ -n "$assignee" ]] && args+=("--assignee" "$assignee")
 
@@ -134,12 +134,12 @@ _push_create_issue() {
 		gh_exit=$?
 	} || true
 	# t3039: REST fallback when GraphQL is exhausted.
-	# _gh_should_fallback_to_rest and _gh_issue_create_rest are provided by
+	# _rest_should_fallback and _rest_issue_create are provided by
 	# shared-gh-wrappers-rest-fallback.sh, sourced transitively via shared-constants.sh.
-	if [[ $gh_exit -ne 0 ]] && _gh_should_fallback_to_rest 2>/dev/null; then
+	if [[ $gh_exit -ne 0 ]] && _rest_should_fallback 2>/dev/null; then
 		print_info "[INFO] gh-wrapper: GraphQL exhausted, retrying issue create via REST for $task_id"
 		{
-			combined=$(_gh_issue_create_rest "${args[@]}" 2>&1)
+			combined=$(_rest_issue_create "${args[@]}" 2>&1)
 			gh_exit=$?
 		} || true
 	fi

--- a/.agents/scripts/issue-sync-relationships.sh
+++ b/.agents/scripts/issue-sync-relationships.sh
@@ -101,7 +101,7 @@ _cached_node_id() {
 	# GraphQL returned empty. If rate-limited, try REST path (t2739).
 	# REST: GET /repos/{owner}/{repo}/issues/{number} → .node_id
 	# Uses the same core-pool 5000/hr budget that the t2574 write-path fallbacks use.
-	if _gh_should_fallback_to_rest; then
+	if _rest_should_fallback; then
 		local rest_nid
 		rest_nid=$(gh api "/repos/${repo}/issues/${num}" --jq '.node_id // ""' 2>/dev/null || echo "")
 		if [[ -n "$rest_nid" ]]; then

--- a/.agents/scripts/pulse-batch-prefetch-helper.sh
+++ b/.agents/scripts/pulse-batch-prefetch-helper.sh
@@ -376,7 +376,7 @@ _refresh_owner_issues() {
 	# ~30 points/call) and go straight to per-slug REST iteration. Avoids
 	# burning points on a call that will fail and then be retried via REST.
 	# Pass pre-computed remaining to avoid a redundant rate-limit API call per owner.
-	if _gh_should_fallback_to_rest "$graphql_remaining" 2>/dev/null; then
+	if _rest_should_fallback "$graphql_remaining" 2>/dev/null; then
 		_log "GraphQL <= threshold — skipping gh search issues for owner=${owner}, going straight to REST"
 		gh_record_call search-rest 2>/dev/null || true
 		_prefetch_rest_per_slug issues "$slugs"
@@ -432,7 +432,7 @@ _refresh_owner_prs() {
 	local graphql_remaining="${3:-}"
 	# Proactive REST fallback (t2902): same pattern as _refresh_owner_issues.
 	# Pass pre-computed remaining to avoid a redundant rate-limit API call per owner.
-	if _gh_should_fallback_to_rest "$graphql_remaining" 2>/dev/null; then
+	if _rest_should_fallback "$graphql_remaining" 2>/dev/null; then
 		_log "GraphQL <= threshold — skipping gh search prs for owner=${owner}, going straight to REST"
 		gh_record_call search-rest 2>/dev/null || true
 		_prefetch_rest_per_slug prs "$slugs"
@@ -510,7 +510,7 @@ _cmd_refresh() {
 	_OWNER_ERRORS=0
 
 	# Pre-fetch GraphQL remaining once per refresh cycle (t2902 review followup).
-	# Both _refresh_owner_issues and _refresh_owner_prs call _gh_should_fallback_to_rest,
+	# Both _refresh_owner_issues and _refresh_owner_prs call _rest_should_fallback,
 	# which issues a `gh api rate_limit` call when no pre-computed value is supplied.
 	# With N owners that produces 2×N redundant API calls. Fetch here and pass the
 	# integer down so each per-owner function can reuse it without hitting the API again.

--- a/.agents/scripts/shared-gh-wrappers-create.sh
+++ b/.agents/scripts/shared-gh-wrappers-create.sh
@@ -15,8 +15,8 @@
 #   - shared-gh-wrappers-session.sh (detect_session_origin, session_origin_label,
 #     _gh_wrapper_args_have_assignee, _gh_wrapper_args_have_label,
 #     _gh_wrapper_auto_assignee, _gh_wrapper_auto_sig)
-#   - shared-gh-wrappers-rest-fallback.sh (_gh_should_fallback_to_rest,
-#     _gh_issue_create_rest, _gh_pr_create_rest, _gh_issue_comment_rest)
+#   - shared-gh-wrappers-rest-fallback.sh (_rest_should_fallback,
+#     _rest_issue_create, _rest_pr_create, _rest_issue_comment)
 #   - _gh_validate_edit_args, _gh_edit_audit_rejection (from orchestrator)
 #   - gh CLI, jq
 #
@@ -199,9 +199,9 @@ gh_create_issue() {
 			if [[ -n "$auto_assignee" ]]; then
 				issue_output=$(gh issue create "$@" "${_todo_label_args[@]}" --label "$origin_label" --assignee "$auto_assignee")
 				local rc=$?
-				if [[ $rc -ne 0 ]] && _gh_should_fallback_to_rest; then
+				if [[ $rc -ne 0 ]] && _rest_should_fallback; then
 					print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to REST for issue create"
-					issue_output=$(_gh_issue_create_rest "$@" "${_todo_label_args[@]}" --label "$origin_label" --assignee "$auto_assignee")
+					issue_output=$(_rest_issue_create "$@" "${_todo_label_args[@]}" --label "$origin_label" --assignee "$auto_assignee")
 					rc=$?
 				fi
 				echo "$issue_output"
@@ -213,9 +213,9 @@ gh_create_issue() {
 
 	issue_output=$(gh issue create "$@" "${_todo_label_args[@]}" --label "$origin_label")
 	local rc=$?
-	if [[ $rc -ne 0 ]] && _gh_should_fallback_to_rest; then
+	if [[ $rc -ne 0 ]] && _rest_should_fallback; then
 		print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to REST for issue create"
-		issue_output=$(_gh_issue_create_rest "$@" "${_todo_label_args[@]}" --label "$origin_label")
+		issue_output=$(_rest_issue_create "$@" "${_todo_label_args[@]}" --label "$origin_label")
 		rc=$?
 	fi
 	echo "$issue_output"
@@ -422,9 +422,9 @@ gh_create_pr() {
 	local pr_output rc
 	pr_output=$(gh pr create "$@" --label "$origin_label")
 	rc=$?
-	if [[ $rc -ne 0 ]] && _gh_should_fallback_to_rest; then
+	if [[ $rc -ne 0 ]] && _rest_should_fallback; then
 		print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to REST for pr create"
-		pr_output=$(_gh_pr_create_rest "$@" --label "$origin_label")
+		pr_output=$(_rest_pr_create "$@" --label "$origin_label")
 		rc=$?
 	fi
 	printf '%s\n' "$pr_output"
@@ -466,9 +466,9 @@ gh_issue_comment() {
 	set -- "${_GH_WRAPPER_SIG_MODIFIED_ARGS[@]}"
 	gh issue comment "$@"
 	local rc=$?
-	if [[ $rc -ne 0 ]] && _gh_should_fallback_to_rest; then
+	if [[ $rc -ne 0 ]] && _rest_should_fallback; then
 		print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to REST for issue comment"
-		_gh_issue_comment_rest "$@"
+		_rest_issue_comment "$@"
 		rc=$?
 	fi
 	return $rc

--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -9,9 +9,9 @@
 # via `gh api` REST endpoints, which run against GitHub's separate 5000/hour
 # core REST budget.
 #
-# Detection: _gh_should_fallback_to_rest -- consults gh api rate_limit.
-# Write translators (t2574): _gh_issue_create_rest, _gh_issue_comment_rest,
-#   _gh_issue_edit_rest, _gh_pr_create_rest.
+# Detection: _rest_should_fallback -- consults gh api rate_limit.
+# Write translators (t2574): _rest_issue_create, _rest_issue_comment,
+#   _rest_issue_edit, _rest_pr_create.
 # Read translators (t2689, t2772): _rest_issue_view, _rest_issue_list, _rest_pr_list.
 #
 # Note on field mapping (_rest_issue_view): `gh issue view --json id` returns
@@ -56,9 +56,9 @@ _GH_REST_FALLBACK_THRESHOLD="${AIDEVOPS_GH_REST_FALLBACK_THRESHOLD:-1500}"
 #######################################
 # Build the `-F` value for `gh api` that uploads a file's contents as the
 # `body` form field. Centralised so the `body=@...` literal lives in exactly
-# one place; callers use "$(_gh_rest_body_file_arg "$path")".
+# one place; callers use "$(_rest_body_file_arg "$path")".
 #######################################
-_gh_rest_body_file_arg() {
+_rest_body_file_arg() {
 	local path="$1"
 	printf 'body=@%s' "$path"
 	return 0
@@ -74,7 +74,7 @@ _gh_rest_body_file_arg() {
 # Args: $1=body_file_path
 # Returns: 0 always
 #######################################
-_rest_fallback_append_sig() {
+_rest_append_sig() {
 	local body_file="$1"
 	[[ -f "$body_file" ]] || return 0
 	grep -q "<!-- aidevops:sig -->" "$body_file" 2>/dev/null && return 0
@@ -92,7 +92,7 @@ _rest_fallback_append_sig() {
 }
 
 #######################################
-# _gh_split_csv: portable CSV tokeniser. Emits one token per line to stdout.
+# _rest_split_csv: portable CSV tokeniser. Emits one token per line to stdout.
 #
 # Works in bash 3.2+, zsh 5+, and BusyBox ash — uses POSIX parameter
 # expansion only. Does NOT use:
@@ -107,9 +107,9 @@ _rest_fallback_append_sig() {
 # Usage:
 #   while IFS= read -r _tok; do
 #       [[ -n "$_tok" ]] && arr+=("$_tok")
-#   done < <(_gh_split_csv "a,b,c")
+#   done < <(_rest_split_csv "a,b,c")
 #######################################
-_gh_split_csv() {
+_rest_split_csv() {
 	local _str="$1"
 	local _delim="${2:-,}"
 	while [[ -n "$_str" ]]; do
@@ -136,7 +136,7 @@ _gh_split_csv() {
 # know the current rate-limit state (e.g. after fetching it once for a loop)
 # can pass it to avoid redundant I/O.
 #######################################
-_gh_should_fallback_to_rest() {
+_rest_should_fallback() {
 	# Test/CI override: set _GH_SHOULD_FALLBACK_OVERRIDE=1 to force true without
 	# requiring a real rate-limit state. Use in unit tests and manual smoke runs.
 	[[ "${_GH_SHOULD_FALLBACK_OVERRIDE:-0}" == "1" ]] && return 0
@@ -152,11 +152,11 @@ _gh_should_fallback_to_rest() {
 # Internal: If first arg looks like a GitHub issue URL, extract the repo slug
 # and issue number. Returns via stdout on two lines (repo, then num) so we
 # stay bash 3.2-compatible (nameref `local -n` is bash 4.3+).
-# Caller pattern:  { read -r repo; read -r num; } < <(_gh_rest_normalize_issue_ref "$ref" "$repo")
+# Caller pattern:  { read -r repo; read -r num; } < <(_rest_normalize_issue_ref "$ref" "$repo")
 # If the ref is a bare number, the first line is the current repo arg unchanged.
 # Args: $1=url_or_num $2=current_repo_value (empty OK)
 #######################################
-_gh_rest_normalize_issue_ref() {
+_rest_normalize_issue_ref() {
 	local raw="$1"
 	local repo="${2:-}"
 	local num=""
@@ -171,13 +171,13 @@ _gh_rest_normalize_issue_ref() {
 }
 
 #######################################
-# _gh_issue_create_rest: POST /repos/{owner}/{repo}/issues.
+# _rest_issue_create: POST /repos/{owner}/{repo}/issues.
 # Parses gh-style args (--title, --body, --body-file, --label, --assignee,
 # --milestone) into a REST payload. Emits the issue html_url on stdout,
 # mirroring `gh issue create`. Returns underlying gh api exit code.
 #######################################
-_gh_issue_create_rest() {
-	gh_record_call rest 2>/dev/null || true
+_rest_issue_create() {
+	gh_record_call rest _rest_issue_create 2>/dev/null || true
 	local title=""
 	local body=""
 	local body_file=""
@@ -201,10 +201,10 @@ _gh_issue_create_rest() {
 		--body=*) body="${_arg#--body=}"; has_body=1; shift ;;
 		--body-file) body_file="${2:-}"; has_body=1; shift 2 ;;
 		--body-file=*) body_file="${_arg#--body-file=}"; has_body=1; shift ;;
-		--label) while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_gh_split_csv "${2:-}"); shift 2 ;;
-		--label=*) while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_gh_split_csv "${_arg#--label=}"); shift ;;
-		--assignee) while IFS= read -r _tok; do [[ -n "$_tok" ]] && assignees+=("$_tok"); done < <(_gh_split_csv "${2:-}"); shift 2 ;;
-		--assignee=*) while IFS= read -r _tok; do [[ -n "$_tok" ]] && assignees+=("$_tok"); done < <(_gh_split_csv "${_arg#--assignee=}"); shift ;;
+		--label) while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_rest_split_csv "${2:-}"); shift 2 ;;
+		--label=*) while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_rest_split_csv "${_arg#--label=}"); shift ;;
+		--assignee) while IFS= read -r _tok; do [[ -n "$_tok" ]] && assignees+=("$_tok"); done < <(_rest_split_csv "${2:-}"); shift 2 ;;
+		--assignee=*) while IFS= read -r _tok; do [[ -n "$_tok" ]] && assignees+=("$_tok"); done < <(_rest_split_csv "${_arg#--assignee=}"); shift ;;
 		--milestone) milestone="${2:-}"; shift 2 ;;
 		--milestone=*) milestone="${_arg#--milestone=}"; shift ;;
 		*) shift ;;
@@ -212,11 +212,11 @@ _gh_issue_create_rest() {
 	done
 
 	if [[ -z "$repo" ]]; then
-		printf '_gh_issue_create_rest: --repo is required\n' >&2
+		printf '_rest_issue_create: --repo is required\n' >&2
 		return 1
 	fi
 	if [[ -z "$title" ]]; then
-		printf '_gh_issue_create_rest: --title is required\n' >&2
+		printf '_rest_issue_create: --title is required\n' >&2
 		return 1
 	fi
 
@@ -230,10 +230,10 @@ _gh_issue_create_rest() {
 			printf '%s' "$body" >"$tmp_body"
 		fi
 	fi
-	[[ -n "$tmp_body" ]] && _rest_fallback_append_sig "$tmp_body"
+	[[ -n "$tmp_body" ]] && _rest_append_sig "$tmp_body"
 
 	local -a api_args=(-X POST "/repos/${repo}/issues" -f "title=${title}")
-	[[ -n "$tmp_body" ]] && api_args+=(-F "$(_gh_rest_body_file_arg "$tmp_body")")
+	[[ -n "$tmp_body" ]] && api_args+=(-F "$(_rest_body_file_arg "$tmp_body")")
 	local _lbl
 	for _lbl in "${labels[@]}"; do
 		[[ -n "$_lbl" ]] && api_args+=(-f "labels[]=${_lbl}")
@@ -259,12 +259,12 @@ _gh_issue_create_rest() {
 }
 
 #######################################
-# _gh_issue_comment_rest: POST /repos/{owner}/{repo}/issues/{N}/comments.
+# _rest_issue_comment: POST /repos/{owner}/{repo}/issues/{N}/comments.
 # Mirrors `gh issue comment <num_or_url> --repo SLUG --body ... | --body-file PATH`.
 # Emits the new comment html_url on stdout. Returns underlying gh api exit code.
 #######################################
-_gh_issue_comment_rest() {
-	gh_record_call rest 2>/dev/null || true
+_rest_issue_comment() {
+	gh_record_call rest _rest_issue_comment 2>/dev/null || true
 	local num_or_url=""
 	local repo=""
 	local body=""
@@ -291,18 +291,18 @@ _gh_issue_comment_rest() {
 	done
 
 	local num=""
-	{ read -r repo; read -r num; } < <(_gh_rest_normalize_issue_ref "$num_or_url" "$repo")
+	{ read -r repo; read -r num; } < <(_rest_normalize_issue_ref "$num_or_url" "$repo")
 
 	if [[ -z "$repo" || -z "$num" ]]; then
-		printf '_gh_issue_comment_rest: issue number and --repo are required\n' >&2
+		printf '_rest_issue_comment: issue number and --repo are required\n' >&2
 		return 1
 	fi
 	if [[ ! "$num" =~ ^[0-9]+$ ]]; then
-		printf '_gh_issue_comment_rest: invalid issue number: %s\n' "$num" >&2
+		printf '_rest_issue_comment: invalid issue number: %s\n' "$num" >&2
 		return 1
 	fi
 	if [[ $has_body -eq 0 ]]; then
-		printf '_gh_issue_comment_rest: --body or --body-file required\n' >&2
+		printf '_rest_issue_comment: --body or --body-file required\n' >&2
 		return 1
 	fi
 
@@ -314,11 +314,11 @@ _gh_issue_comment_rest() {
 		tmp_body_owned=1
 		printf '%s' "$body" >"$tmp_body"
 	fi
-	_rest_fallback_append_sig "$tmp_body"
+	_rest_append_sig "$tmp_body"
 
 	local out rc
 	out=$(gh api -X POST "/repos/${repo}/issues/${num}/comments" \
-		-F "$(_gh_rest_body_file_arg "$tmp_body")" --jq '.html_url' 2>&1)
+		-F "$(_rest_body_file_arg "$tmp_body")" --jq '.html_url' 2>&1)
 	rc=$?
 
 	[[ $tmp_body_owned -eq 1 && -f "$tmp_body" ]] && rm -f "$tmp_body"
@@ -332,7 +332,7 @@ _gh_issue_comment_rest() {
 }
 
 #######################################
-# _gh_issue_edit_rest: PATCH /repos/{owner}/{repo}/issues/{N}.
+# _rest_issue_edit: PATCH /repos/{owner}/{repo}/issues/{N}.
 # Handles --title, --body, --body-file, --add-label, --remove-label,
 # --add-assignee, --remove-assignee, --milestone, --state. REST PATCH
 # requires the FULL labels/assignees arrays (not deltas), so we fetch
@@ -340,8 +340,8 @@ _gh_issue_comment_rest() {
 # are present. Current-state fetch uses REST (`gh api /repos/...`) which
 # is not affected by GraphQL exhaustion.
 #######################################
-_gh_issue_edit_rest() {
-	gh_record_call rest 2>/dev/null || true
+_rest_issue_edit() {
+	gh_record_call rest _rest_issue_edit 2>/dev/null || true
 	local num_or_url=""
 	local repo=""
 	local title=""
@@ -374,10 +374,10 @@ _gh_issue_edit_rest() {
 		--title)           title="$_v"; has_title=1 ;;
 		--body)            body="$_v"; has_body=1 ;;
 		--body-file)       body_file="$_v"; has_body=1 ;;
-		--add-label)       while IFS= read -r _tok; do [[ -n "$_tok" ]] && add_labels+=("$_tok"); done < <(_gh_split_csv "$_v") ;;
-		--remove-label)    while IFS= read -r _tok; do [[ -n "$_tok" ]] && rm_labels+=("$_tok"); done < <(_gh_split_csv "$_v") ;;
-		--add-assignee)    while IFS= read -r _tok; do [[ -n "$_tok" ]] && add_assignees+=("$_tok"); done < <(_gh_split_csv "$_v") ;;
-		--remove-assignee) while IFS= read -r _tok; do [[ -n "$_tok" ]] && rm_assignees+=("$_tok"); done < <(_gh_split_csv "$_v") ;;
+		--add-label)       while IFS= read -r _tok; do [[ -n "$_tok" ]] && add_labels+=("$_tok"); done < <(_rest_split_csv "$_v") ;;
+		--remove-label)    while IFS= read -r _tok; do [[ -n "$_tok" ]] && rm_labels+=("$_tok"); done < <(_rest_split_csv "$_v") ;;
+		--add-assignee)    while IFS= read -r _tok; do [[ -n "$_tok" ]] && add_assignees+=("$_tok"); done < <(_rest_split_csv "$_v") ;;
+		--remove-assignee) while IFS= read -r _tok; do [[ -n "$_tok" ]] && rm_assignees+=("$_tok"); done < <(_rest_split_csv "$_v") ;;
 		--milestone)       milestone="$_v"; has_milestone=1 ;;
 		--state)           state="$_v"; has_state=1 ;;
 		*) : ;;
@@ -385,14 +385,14 @@ _gh_issue_edit_rest() {
 	done
 
 	local num=""
-	{ read -r repo; read -r num; } < <(_gh_rest_normalize_issue_ref "$num_or_url" "$repo")
+	{ read -r repo; read -r num; } < <(_rest_normalize_issue_ref "$num_or_url" "$repo")
 
 	if [[ -z "$repo" || -z "$num" ]]; then
-		printf '_gh_issue_edit_rest: issue number and --repo are required\n' >&2
+		printf '_rest_issue_edit: issue number and --repo are required\n' >&2
 		return 1
 	fi
 	if [[ ! "$num" =~ ^[0-9]+$ ]]; then
-		printf '_gh_issue_edit_rest: invalid issue number: %s\n' "$num" >&2
+		printf '_rest_issue_edit: invalid issue number: %s\n' "$num" >&2
 		return 1
 	fi
 
@@ -412,23 +412,23 @@ _gh_issue_edit_rest() {
 			tmp_body_owned=1
 			printf '%s' "$body" >"$tmp_body"
 		fi
-		api_args+=(-F "$(_gh_rest_body_file_arg "$tmp_body")")
+		api_args+=(-F "$(_rest_body_file_arg "$tmp_body")")
 	fi
 
 	# Labels and assignees: REST requires full arrays. Delegated to
-	# _gh_rest_print_patch_array_flags; see that helper for the state-fetch
+	# _rest_print_patch_array_flags; see that helper for the state-fetch
 	# and delta-application logic.
 	local _flag _val
 	if [[ ${#add_labels[@]} -gt 0 || ${#rm_labels[@]} -gt 0 ]]; then
 		while IFS=$'\t' read -r _flag _val; do
 			api_args+=("$_flag" "$_val")
-		done < <(_gh_rest_print_patch_array_flags "$_issue_path" "labels" ".labels[].name" \
+		done < <(_rest_print_patch_array_flags "$_issue_path" "labels" ".labels[].name" \
 			"$(printf '%s\n' "${add_labels[@]}")" "$(printf '%s\n' "${rm_labels[@]}")")
 	fi
 	if [[ ${#add_assignees[@]} -gt 0 || ${#rm_assignees[@]} -gt 0 ]]; then
 		while IFS=$'\t' read -r _flag _val; do
 			api_args+=("$_flag" "$_val")
-		done < <(_gh_rest_print_patch_array_flags "$_issue_path" "assignees" ".assignees[].login" \
+		done < <(_rest_print_patch_array_flags "$_issue_path" "assignees" ".assignees[].login" \
 			"$(printf '%s\n' "${add_assignees[@]}")" "$(printf '%s\n' "${rm_assignees[@]}")")
 	fi
 
@@ -445,12 +445,12 @@ _gh_issue_edit_rest() {
 # current state (fetched via REST) and add/remove deltas. Output is one
 # tab-separated `-f\tfield[]=value` pair per line; caller reads with
 # `IFS=$'\t' read -r k v` and appends both to the api_args array.
-# Factored out of _gh_issue_edit_rest so that function stays under the
+# Factored out of _rest_issue_edit so that function stays under the
 # 100-line complexity gate.
 #
 # Args: $1=issue_path  $2=field_name  $3=jq_expr  $4=adds_nl  $5=rms_nl
 #######################################
-_gh_rest_print_patch_array_flags() {
+_rest_print_patch_array_flags() {
 	local issue_path="$1"
 	local field="$2"
 	local jq_expr="$3"
@@ -458,7 +458,7 @@ _gh_rest_print_patch_array_flags() {
 	local rms="$5"
 	local _current _target _elem
 	_current=$(gh api "$issue_path" --jq "$jq_expr" 2>/dev/null) || _current=""
-	_target=$(_gh_rest_compute_target_set "$_current" "$adds" "$rms")
+	_target=$(_rest_compute_target_set "$_current" "$adds" "$rms")
 	while IFS= read -r _elem; do
 		[[ -n "$_elem" ]] && printf -- '-f\t%s[]=%s\n' "$field" "$_elem"
 	done <<<"$_target"
@@ -466,16 +466,16 @@ _gh_rest_print_patch_array_flags() {
 }
 
 #######################################
-# _gh_rest_compute_target_set: given the current values of a list field
+# _rest_compute_target_set: given the current values of a list field
 # (newline-separated), an add set (newline-separated), and a remove set
 # (newline-separated), emit the target set (removes subtracted first, then
 # adds unioned, deduped) one value per line on stdout.
 #
-# Used by _gh_issue_edit_rest to translate --add-label/--remove-label and
+# Used by _rest_issue_edit to translate --add-label/--remove-label and
 # --add-assignee/--remove-assignee flags into the full array that REST PATCH
 # requires.
 #######################################
-_gh_rest_compute_target_set() {
+_rest_compute_target_set() {
 	local current="$1" adds="$2" rms="$3"
 	local -a target=()
 	local v to_rm existing to_add skip dup
@@ -507,12 +507,12 @@ _gh_rest_compute_target_set() {
 }
 
 #######################################
-# _gh_pr_autodetect_head
+# _rest_pr_autodetect_head
 # Returns the current git branch name for use as --head when omitted.
 # Returns empty string when in detached HEAD state or outside a git repo.
 # Emits an [INFO] log line when auto-detect fires.
 #######################################
-_gh_pr_autodetect_head() {
+_rest_pr_autodetect_head() {
 	local _branch
 	_branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null)
 	if [[ -n "$_branch" && "$_branch" != "HEAD" ]]; then
@@ -523,7 +523,7 @@ _gh_pr_autodetect_head() {
 }
 
 #######################################
-# _gh_pr_autodetect_base <repo>
+# _rest_pr_autodetect_base <repo>
 # Returns the repository's default branch for use as --base when omitted.
 # Resolution order:
 #   1. gh api /repos/{repo} --jq .default_branch (REST, no GraphQL cost)
@@ -531,7 +531,7 @@ _gh_pr_autodetect_head() {
 #   3. "main" (final fallback)
 # Emits an [INFO] log line when auto-detect fires.
 #######################################
-_gh_pr_autodetect_base() {
+_rest_pr_autodetect_base() {
 	local _repo="${1:-}"
 	local _base=""
 	if [[ -n "$_repo" ]]; then
@@ -548,7 +548,7 @@ _gh_pr_autodetect_base() {
 }
 
 #######################################
-# _gh_pr_create_rest: POST /repos/{owner}/{repo}/pulls.
+# _rest_pr_create: POST /repos/{owner}/{repo}/pulls.
 # Parses gh-style args (--head, --base, --title, --body, --body-file, --draft,
 # --label) into a REST payload. Labels are applied via a separate
 # POST /repos/{owner}/{repo}/issues/{pr_number}/labels call because the
@@ -556,10 +556,10 @@ _gh_pr_autodetect_base() {
 # Emits the PR html_url on stdout, mirroring `gh pr create`. Returns underlying
 # gh api exit code.
 # When --head or --base are omitted, auto-detects from git HEAD / repo
-# default branch respectively (see _gh_pr_autodetect_head/base above).
+# default branch respectively (see _rest_pr_autodetect_head/base above).
 #######################################
-_gh_pr_create_rest() {
-	gh_record_call rest 2>/dev/null || true
+_rest_pr_create() {
+	gh_record_call rest _rest_pr_create 2>/dev/null || true
 	local title=""
 	local head=""
 	local base=""
@@ -588,29 +588,29 @@ _gh_pr_create_rest() {
 		--body-file) body_file="${2:-}"; has_body=1; shift 2 ;;
 		--body-file=*) body_file="${_arg#--body-file=}"; has_body=1; shift ;;
 		--draft) draft=1; shift ;;
-		--label) while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_gh_split_csv "${2:-}"); shift 2 ;;
-		--label=*) while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_gh_split_csv "${_arg#--label=}"); shift ;;
+		--label) while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_rest_split_csv "${2:-}"); shift 2 ;;
+		--label=*) while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_rest_split_csv "${_arg#--label=}"); shift ;;
 		*) shift ;;
 		esac
 	done
 
 	if [[ -z "$repo" ]]; then
-		printf '_gh_pr_create_rest: --repo is required\n' >&2
+		printf '_rest_pr_create: --repo is required\n' >&2
 		return 1
 	fi
 	if [[ -z "$title" ]]; then
-		printf '_gh_pr_create_rest: --title is required\n' >&2
+		printf '_rest_pr_create: --title is required\n' >&2
 		return 1
 	fi
 	if [[ -z "$head" ]]; then
-		head=$(_gh_pr_autodetect_head)
+		head=$(_rest_pr_autodetect_head)
 		if [[ -z "$head" ]]; then
-			printf '_gh_pr_create_rest: --head is required\n' >&2
+			printf '_rest_pr_create: --head is required\n' >&2
 			return 1
 		fi
 	fi
 	if [[ -z "$base" ]]; then
-		base=$(_gh_pr_autodetect_base "$repo")
+		base=$(_rest_pr_autodetect_base "$repo")
 	fi
 
 	local tmp_body="" tmp_body_owned=0
@@ -623,13 +623,13 @@ _gh_pr_create_rest() {
 			printf '%s' "$body" >"$tmp_body"
 		fi
 	fi
-	[[ -n "$tmp_body" ]] && _rest_fallback_append_sig "$tmp_body"
+	[[ -n "$tmp_body" ]] && _rest_append_sig "$tmp_body"
 
 	local -a api_args=(-X POST "/repos/${repo}/pulls"
 		-f "title=$title"
 		-f "head=$head"
 		-f "base=$base")
-	[[ -n "$tmp_body" ]] && api_args+=(-F "$(_gh_rest_body_file_arg "$tmp_body")")
+	[[ -n "$tmp_body" ]] && api_args+=(-F "$(_rest_body_file_arg "$tmp_body")")
 	[[ $draft -eq 1 ]] && api_args+=(-F "draft=true")
 
 	local html_url rc
@@ -676,7 +676,7 @@ _gh_pr_create_rest() {
 # Returns the underlying gh api exit code.
 #######################################
 _rest_issue_view() {
-	gh_record_call rest 2>/dev/null || true
+	gh_record_call rest _rest_issue_view 2>/dev/null || true
 	local num_or_url=""
 	local repo=""
 	local jq_expr=""
@@ -705,7 +705,7 @@ _rest_issue_view() {
 	done
 
 	local num=""
-	{ read -r repo; read -r num; } < <(_gh_rest_normalize_issue_ref "$num_or_url" "$repo")
+	{ read -r repo; read -r num; } < <(_rest_normalize_issue_ref "$num_or_url" "$repo")
 
 	if [[ -z "$repo" || -z "$num" ]]; then
 		printf '_rest_issue_view: issue number and --repo are required\n' >&2
@@ -741,7 +741,7 @@ _rest_issue_view() {
 # Returns the underlying gh api exit code.
 #######################################
 _rest_pr_view() {
-	gh_record_call rest 2>/dev/null || true
+	gh_record_call rest _rest_pr_view 2>/dev/null || true
 	local num_or_url=""
 	local repo=""
 	local jq_expr=""
@@ -766,7 +766,7 @@ _rest_pr_view() {
 	done
 
 	local num=""
-	{ read -r repo; read -r num; } < <(_gh_rest_normalize_issue_ref "$num_or_url" "$repo")
+	{ read -r repo; read -r num; } < <(_rest_normalize_issue_ref "$num_or_url" "$repo")
 
 	if [[ -z "$repo" || -z "$num" ]]; then
 		printf '_rest_pr_view: PR number and --repo are required\n' >&2
@@ -801,7 +801,7 @@ _rest_pr_view() {
 # Returns the underlying gh api exit code.
 #######################################
 _rest_pr_list() {
-	gh_record_call rest 2>/dev/null || true
+	gh_record_call rest _rest_pr_list 2>/dev/null || true
 	local repo=""
 	local state="open"
 	local limit=30
@@ -878,7 +878,7 @@ _rest_pr_list() {
 # Returns the underlying gh api exit code.
 #######################################
 _rest_issue_list() {
-	gh_record_call rest 2>/dev/null || true
+	gh_record_call rest _rest_issue_list 2>/dev/null || true
 	local repo=""
 	local state="open"
 	local limit=30
@@ -895,8 +895,8 @@ _rest_issue_list() {
 		--repo=*) repo="${_arg#--repo=}"; shift ;;
 		--state) state="${2:-}"; shift 2 ;;
 		--state=*) state="${_arg#--state=}"; shift ;;
-		--label) while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_gh_split_csv "${2:-}"); shift 2 ;;
-		--label=*) while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_gh_split_csv "${_arg#--label=}"); shift ;;
+		--label) while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_rest_split_csv "${2:-}"); shift 2 ;;
+		--label=*) while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_rest_split_csv "${_arg#--label=}"); shift ;;
 		--assignee) assignee="${2:-}"; shift 2 ;;
 		--assignee=*) assignee="${_arg#--assignee=}"; shift ;;
 		--limit) limit="${2:-}"; shift 2 ;;
@@ -974,7 +974,7 @@ _rest_issue_list() {
 # Returns the underlying gh api exit code.
 #######################################
 _rest_issue_search() {
-	gh_record_call rest 2>/dev/null || true
+	gh_record_call rest _rest_issue_search 2>/dev/null || true
 	local repo=""
 	local state=""
 	local search=""
@@ -991,8 +991,8 @@ _rest_issue_search() {
 		--repo=*) repo="${_arg#--repo=}"; shift ;;
 		--state) state="${2:-}"; shift 2 ;;
 		--state=*) state="${_arg#--state=}"; shift ;;
-		--label) while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_gh_split_csv "${2:-}"); shift 2 ;;
-		--label=*) while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_gh_split_csv "${_arg#--label=}"); shift ;;
+		--label) while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_rest_split_csv "${2:-}"); shift 2 ;;
+		--label=*) while IFS= read -r _tok; do [[ -n "$_tok" ]] && labels+=("$_tok"); done < <(_rest_split_csv "${_arg#--label=}"); shift ;;
 		--limit) limit="${2:-}"; shift 2 ;;
 		--limit=*) limit="${_arg#--limit=}"; shift ;;
 		--search) search="${2:-}"; shift 2 ;;

--- a/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
+++ b/.agents/scripts/shared-gh-wrappers-rest-fallback.sh
@@ -54,6 +54,23 @@ _SHARED_GH_WRAPPERS_REST_FALLBACK_LOADED=1
 _GH_REST_FALLBACK_THRESHOLD="${AIDEVOPS_GH_REST_FALLBACK_THRESHOLD:-1500}"
 
 #######################################
+# Execute a gh api command with optional wall-clock timeout (t2913).
+# Fail-open: if _gh_with_timeout is not loaded, runs gh api directly.
+#
+# Args: $1=timeout_class (read|write)  $2..=gh api args
+# Returns: exit code of the gh api call.
+#######################################
+_rest_api_call() {
+	local _class="$1"; shift
+	if command -v _gh_with_timeout >/dev/null 2>&1; then
+		_gh_with_timeout "$_class" "$@"
+	else
+		"$@"
+	fi
+	return $?
+}
+
+#######################################
 # Build the `-F` value for `gh api` that uploads a file's contents as the
 # `body` form field. Centralised so the `body=@...` literal lives in exactly
 # one place; callers use "$(_rest_body_file_arg "$path")".
@@ -507,6 +524,26 @@ _rest_compute_target_set() {
 }
 
 #######################################
+# _rest_apply_labels: POST /repos/{owner}/{repo}/issues/{N}/labels.
+# PRs share GitHub's issues label endpoint. Best-effort — failures are
+# silently ignored (labels are non-critical metadata).
+#
+# Args: $1=repo_slug  $2=issue_or_pr_number  $3..=label names
+# Returns: 0 always
+#######################################
+_rest_apply_labels() {
+	local repo="$1" num="$2"; shift 2
+	[[ $# -eq 0 || -z "$num" ]] && return 0
+	local -a label_args=(-X POST "/repos/${repo}/issues/${num}/labels")
+	local _lbl
+	for _lbl in "$@"; do
+		[[ -n "$_lbl" ]] && label_args+=(-f "labels[]=${_lbl}")
+	done
+	gh api "${label_args[@]}" >/dev/null 2>&1 || true
+	return 0
+}
+
+#######################################
 # _rest_pr_autodetect_head
 # Returns the current git branch name for use as --head when omitted.
 # Returns empty string when in detached HEAD state or outside a git repo.
@@ -645,18 +682,11 @@ _rest_pr_create() {
 
 	printf '%s\n' "$html_url"
 
-	# PRs share GitHub's issues label endpoint — apply labels if any.
+	# Apply labels via the issues endpoint (PRs share it).
 	if [[ ${#labels[@]} -gt 0 ]]; then
 		local pr_number
 		pr_number=$(printf '%s' "$html_url" | grep -oE '[0-9]+$' || true)
-		if [[ -n "$pr_number" ]]; then
-			local -a label_args=(-X POST "/repos/${repo}/issues/${pr_number}/labels")
-			local _lbl
-			for _lbl in "${labels[@]}"; do
-				[[ -n "$_lbl" ]] && label_args+=(-f "labels[]=${_lbl}")
-			done
-			gh api "${label_args[@]}" >/dev/null 2>&1 || true
-		fi
+		[[ -n "$pr_number" ]] && _rest_apply_labels "$repo" "$pr_number" "${labels[@]}"
 	fi
 	return 0
 }
@@ -717,15 +747,9 @@ _rest_issue_view() {
 	fi
 
 	local _path="/repos/${repo}/issues/${num}"
-	# t2913: wall-clock timeout via _gh_with_timeout (defined in shared-gh-wrappers.sh).
-	# Fail-open if helper not loaded — invoke gh api directly.
 	local _gh_cmd=(gh api "$_path")
 	[[ -n "$jq_expr" ]] && _gh_cmd+=(--jq "$jq_expr")
-	if command -v _gh_with_timeout >/dev/null 2>&1; then
-		_gh_with_timeout read "${_gh_cmd[@]}"
-	else
-		"${_gh_cmd[@]}"
-	fi
+	_rest_api_call read "${_gh_cmd[@]}"
 	return $?
 }
 
@@ -780,11 +804,7 @@ _rest_pr_view() {
 	local _path="/repos/${repo}/pulls/${num}"
 	local _gh_cmd=(gh api "$_path")
 	[[ -n "$jq_expr" ]] && _gh_cmd+=(--jq "$jq_expr")
-	if command -v _gh_with_timeout >/dev/null 2>&1; then
-		_gh_with_timeout read "${_gh_cmd[@]}"
-	else
-		"${_gh_cmd[@]}"
-	fi
+	_rest_api_call read "${_gh_cmd[@]}"
 	return $?
 }
 
@@ -851,14 +871,9 @@ _rest_pr_list() {
 	fi
 
 	local _path="/repos/${repo}/pulls?${_query}"
-	# t2913: wall-clock timeout via _gh_with_timeout (defined in shared-gh-wrappers.sh).
 	local _gh_cmd=(gh api "$_path")
 	[[ -n "$jq_expr" ]] && _gh_cmd+=(--jq "$jq_expr")
-	if command -v _gh_with_timeout >/dev/null 2>&1; then
-		_gh_with_timeout read "${_gh_cmd[@]}"
-	else
-		"${_gh_cmd[@]}"
-	fi
+	_rest_api_call read "${_gh_cmd[@]}"
 	return $?
 }
 
@@ -934,14 +949,9 @@ _rest_issue_list() {
 	fi
 
 	local _path="/repos/${repo}/issues?${_query}"
-	# t2913: wall-clock timeout via _gh_with_timeout (defined in shared-gh-wrappers.sh).
 	local _gh_cmd=(gh api "$_path")
 	[[ -n "$jq_expr" ]] && _gh_cmd+=(--jq "$jq_expr")
-	if command -v _gh_with_timeout >/dev/null 2>&1; then
-		_gh_with_timeout read "${_gh_cmd[@]}"
-	else
-		"${_gh_cmd[@]}"
-	fi
+	_rest_api_call read "${_gh_cmd[@]}"
 	return $?
 }
 
@@ -1041,10 +1051,6 @@ _rest_issue_search() {
 	fi
 
 	local _gh_cmd=(gh api "$_path" --jq "$_final_jq")
-	if command -v _gh_with_timeout >/dev/null 2>&1; then
-		_gh_with_timeout read "${_gh_cmd[@]}"
-	else
-		"${_gh_cmd[@]}"
-	fi
+	_rest_api_call read "${_gh_cmd[@]}"
 	return $?
 }

--- a/.agents/scripts/shared-gh-wrappers-safe-edit.sh
+++ b/.agents/scripts/shared-gh-wrappers-safe-edit.sh
@@ -14,8 +14,8 @@
 # Dependencies:
 #   - shared-constants.sh (print_info, etc.)
 #   - _gh_validate_edit_args, _GH_EDIT_REJECTION_REASON (from orchestrator)
-#   - shared-gh-wrappers-rest-fallback.sh (_gh_should_fallback_to_rest,
-#     _gh_issue_edit_rest)
+#   - shared-gh-wrappers-rest-fallback.sh (_rest_should_fallback,
+#     _rest_issue_edit)
 #   - gh CLI, jq
 #
 # Part of aidevops framework: https://aidevops.sh
@@ -226,9 +226,9 @@ gh_issue_edit_safe() {
 	_before="$(_gh_audit_fetch_issue_state_json "$_num" "$_repo")"
 	gh issue edit "$@"
 	local _exit=$?
-	if [[ $_exit -ne 0 ]] && _gh_should_fallback_to_rest; then
+	if [[ $_exit -ne 0 ]] && _rest_should_fallback; then
 		print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to REST for issue edit"
-		_gh_issue_edit_rest "$@"
+		_rest_issue_edit "$@"
 		_exit=$?
 	fi
 	_after="$(_gh_audit_fetch_issue_state_json "$_num" "$_repo")"

--- a/.agents/scripts/shared-gh-wrappers-status.sh
+++ b/.agents/scripts/shared-gh-wrappers-status.sh
@@ -11,7 +11,7 @@
 #
 # Dependencies:
 #   - shared-constants.sh (print_info, etc.)
-#   - shared-gh-wrappers-rest-fallback.sh (_gh_should_fallback_to_rest,
+#   - shared-gh-wrappers-rest-fallback.sh (_rest_should_fallback,
 #     _rest_issue_view, _rest_issue_list, _rest_issue_search, _rest_pr_list)
 #   - _gh_with_timeout (from orchestrator)
 #   - ISSUE_STATUS_LABELS (from orchestrator)
@@ -174,9 +174,9 @@ set_issue_status() {
 
 	gh issue edit "$issue_num" --repo "$repo_slug" "${_flags[@]}" 2>/dev/null
 	local _rc=$?
-	if [[ $_rc -ne 0 ]] && _gh_should_fallback_to_rest; then
+	if [[ $_rc -ne 0 ]] && _rest_should_fallback; then
 		print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to REST for set_issue_status"
-		_gh_issue_edit_rest "$issue_num" --repo "$repo_slug" "${_flags[@]}"
+		_rest_issue_edit "$issue_num" --repo "$repo_slug" "${_flags[@]}"
 		_rc=$?
 	fi
 	return $_rc
@@ -198,7 +198,7 @@ gh_issue_view() {
 	local _first_num="${1:-}"
 	_gh_with_timeout read gh issue view "$@"
 	local rc=$?
-	if [[ $rc -ne 0 ]] && _gh_should_fallback_to_rest; then
+	if [[ $rc -ne 0 ]] && _rest_should_fallback; then
 		print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to REST for issue view #${_first_num}"
 		_rest_issue_view "$@"
 		rc=$?
@@ -223,7 +223,7 @@ gh_issue_view() {
 gh_pr_list() {
 	_gh_with_timeout read gh pr list "$@"
 	local rc=$?
-	if [[ $rc -ne 0 ]] && _gh_should_fallback_to_rest; then
+	if [[ $rc -ne 0 ]] && _rest_should_fallback; then
 		print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to REST for pr list"
 		_rest_pr_list "$@"
 		rc=$?
@@ -256,7 +256,7 @@ gh_pr_list() {
 gh_issue_list() {
 	_gh_with_timeout read gh issue list "$@"
 	local rc=$?
-	if [[ $rc -ne 0 ]] && _gh_should_fallback_to_rest; then
+	if [[ $rc -ne 0 ]] && _rest_should_fallback; then
 		# t2995: use search-aware REST fallback when --search is supplied.
 		# Walk argv to detect --search; the helper itself re-parses, but we
 		# need to know whether to dispatch to /search/issues (which preserves

--- a/.agents/scripts/shared-gh-wrappers.sh
+++ b/.agents/scripts/shared-gh-wrappers.sh
@@ -52,9 +52,9 @@ fi
 
 # t2574: REST fallback for GraphQL-exhausted gh issue wrappers (GH#20243).
 # t2689: Extended to READ paths — _rest_issue_view, _rest_issue_list.
-# t2743: Fixed CSV tokenisation for zsh compat (replaced read -ra with _gh_split_csv).
-# Provides _gh_should_fallback_to_rest, _gh_issue_{create,comment,edit}_rest,
-# _gh_pr_create_rest, _rest_issue_view, _rest_issue_list.
+# t2743: Fixed CSV tokenisation for zsh compat (replaced read -ra with _rest_split_csv).
+# Provides _rest_should_fallback, _rest_issue_{create,comment,edit},
+# _rest_pr_create, _rest_issue_view, _rest_issue_list.
 #
 # Resolve own directory cross-shell (bash + zsh).
 # Priority: (1) BASH_SOURCE[0] under bash (or zsh with BASH_SOURCE emulation);

--- a/.agents/scripts/tests/test-backfill-sub-issues.sh
+++ b/.agents/scripts/tests/test-backfill-sub-issues.sh
@@ -184,7 +184,7 @@ if [[ "$cmd1" == "api" && "$cmd2" == "graphql" ]]; then
 	exit 0
 fi
 
-# gh api rate_limit → used by _gh_should_fallback_to_rest
+# gh api rate_limit → used by _rest_should_fallback
 if [[ "$cmd1" == "api" && "$cmd2" == "rate_limit" ]]; then
 	printf '%s\n' '{"resources":{"graphql":{"remaining":5000}}}'
 	exit 0
@@ -580,7 +580,7 @@ fi
 # Strategy:
 #   - Override the resolve_gh_node_id bash function to return empty, simulating
 #     GraphQL budget exhaustion without needing stub-level plumbing.
-#   - Set _GH_SHOULD_FALLBACK_OVERRIDE=1 so _gh_should_fallback_to_rest
+#   - Set _GH_SHOULD_FALLBACK_OVERRIDE=1 so _rest_should_fallback
 #     returns true without needing a real rate-limit state.
 #   - For test 21: GH_REST_NODE_<num> fixtures supply node IDs via REST
 #     → link succeeds (addSubIssue mutation fires).

--- a/.agents/scripts/tests/test-claim-task-id-rest-routing.sh
+++ b/.agents/scripts/tests/test-claim-task-id-rest-routing.sh
@@ -16,11 +16,11 @@
 # Fix:
 #   - claim-task-id.sh: bare fallback now calls gh_create_issue
 #     (REST-aware wrapper from shared-gh-wrappers.sh). gh_create_issue
-#     detects exhaustion via _gh_should_fallback_to_rest and retries via
-#     _gh_issue_create_rest (POST /repos/.../issues).
+#     detects exhaustion via _rest_should_fallback and retries via
+#     _rest_issue_create (POST /repos/.../issues).
 #   - issue-sync-helper-push.sh: _push_create_issue adds an inline REST
 #     fallback after a non-zero exit from gh issue create: calls
-#     _gh_issue_create_rest directly when _gh_should_fallback_to_rest.
+#     _rest_issue_create directly when _rest_should_fallback.
 #
 # Tests:
 #   1. gh_create_issue routes to REST (gh api -X POST) when GraphQL exhausted
@@ -33,7 +33,7 @@
 #
 # Stub strategy: define `gh` as a shell function after sourcing helpers.
 # Shell functions take precedence over PATH binaries.
-# _GH_SHOULD_FALLBACK_OVERRIDE=1 forces _gh_should_fallback_to_rest to return
+# _GH_SHOULD_FALLBACK_OVERRIDE=1 forces _rest_should_fallback to return
 # true without requiring a real rate_limit call.
 #
 # Cross-references: GH#21627 / t3039 (fix), t2574 (REST fallback system).

--- a/.agents/scripts/tests/test-create-health-issue-origin-label.sh
+++ b/.agents/scripts/tests/test-create-health-issue-origin-label.sh
@@ -28,7 +28,7 @@
 #
 # H1 verdict (from issue body):
 #   H1 (REST fallback omits origin label) was investigated and FALSIFIED.
-#   _gh_issue_create_rest correctly includes all labels inline in the POST.
+#   _rest_issue_create correctly includes all labels inline in the POST.
 #   The root cause was server-side label removal, not client-side omission.
 #
 # Tests:
@@ -40,7 +40,7 @@
 #   5. When neither AIDEVOPS_HEADLESS nor AIDEVOPS_SESSION_ORIGIN is set,
 #      the explicit AIDEVOPS_SESSION_ORIGIN=worker guard still applies
 #      origin:worker (not origin:interactive — the pre-fix bug pattern)
-#   6. The REST fallback path (_gh_issue_create_rest) includes origin:worker
+#   6. The REST fallback path (_rest_issue_create) includes origin:worker
 #      in the REST POST payload
 
 set -uo pipefail
@@ -297,7 +297,7 @@ unset AIDEVOPS_HEADLESS
 #         (confirms H1 from issue body is FALSIFIED — REST does include the label)
 # =============================================================================
 : >"$GH_CALLS"
-_gh_issue_create_rest \
+_rest_issue_create \
 	--repo "owner/repo" \
 	--title "test health issue" \
 	--body "body text" \
@@ -310,18 +310,18 @@ _gh_issue_create_rest \
 if grep -qE '^api.*-X POST.*/repos/owner/repo/issues' "$GH_CALLS" 2>/dev/null &&
 	grep -qE 'labels\[\]=origin:worker' "$GH_CALLS" 2>/dev/null &&
 	grep -qE 'labels\[\]=source:health-dashboard' "$GH_CALLS" 2>/dev/null; then
-	pass "_gh_issue_create_rest includes origin:worker inline in POST (H1 falsified)"
+	pass "_rest_issue_create includes origin:worker inline in POST (H1 falsified)"
 else
-	fail "_gh_issue_create_rest includes origin:worker inline in POST (H1 falsified)" \
+	fail "_rest_issue_create includes origin:worker inline in POST (H1 falsified)" \
 		"GH_CALLS=$(cat "$GH_CALLS")"
 fi
 
 # =============================================================================
 # Test 6: REST fallback path does NOT use a separate label POST for issues
-#         (unlike _gh_pr_create_rest which DOES use a separate step)
+#         (unlike _rest_pr_create which DOES use a separate step)
 # =============================================================================
 : >"$GH_CALLS"
-_gh_issue_create_rest \
+_rest_issue_create \
 	--repo "owner/repo" \
 	--title "test health issue" \
 	--body "body" \
@@ -331,10 +331,10 @@ _gh_issue_create_rest \
 # A separate /labels POST would indicate the two-step pattern (PR pattern).
 # Use grep exit code (0=match found, 1=not found) to avoid grep -c doubling.
 if grep -qE '^api.*-X POST.*/repos/owner/repo/issues/[0-9]+/labels' "$GH_CALLS" 2>/dev/null; then
-	fail "_gh_issue_create_rest uses inline labels (no separate /labels POST)" \
+	fail "_rest_issue_create uses inline labels (no separate /labels POST)" \
 		"Found separate /issues/{N}/labels POST call (expected none)"
 else
-	pass "_gh_issue_create_rest uses inline labels (no separate /labels POST)"
+	pass "_rest_issue_create uses inline labels (no separate /labels POST)"
 fi
 
 # =============================================================================

--- a/.agents/scripts/tests/test-gh-api-sig-footer.sh
+++ b/.agents/scripts/tests/test-gh-api-sig-footer.sh
@@ -14,9 +14,9 @@
 #   Layer 2 — `gh` PATH shim logic (_shim_api_is_write_endpoint / _shim_api_inject_body_sig)
 #
 # Tests:
-#   1. REST fallback translator injects sig on _gh_issue_create_rest
-#   2. REST fallback translator injects sig on _gh_issue_comment_rest
-#   3. REST fallback translator injects sig on _gh_pr_create_rest
+#   1. REST fallback translator injects sig on _rest_issue_create
+#   2. REST fallback translator injects sig on _rest_issue_comment
+#   3. REST fallback translator injects sig on _rest_pr_create
 #   4. PATH shim injects sig on gh api -X POST /repos/X/Y/issues -f body=@file
 #   5. PATH shim injects sig on gh api -X POST /repos/X/Y/issues/N/comments -f body=@file
 #   6. PATH shim leaves gh api /rate_limit (GET, no -X) untouched
@@ -24,7 +24,7 @@
 # Stub strategy for Layer 1 tests: define `gh` as a shell function that
 # captures calls and injects a mock sig line (since the real gh-signature-helper
 # is unavailable in unit-test context). The sig injection in translators is
-# validated by checking that _rest_fallback_append_sig was called and appended
+# validated by checking that _rest_append_sig was called and appended
 # the marker to the temp body file BEFORE the api call.
 #
 # Strategy for Layer 2 tests: source the shim helper functions directly into
@@ -87,7 +87,7 @@ exit 0
 STUB
 chmod +x "$_STUB_SIG_HELPER"
 
-# Ensure our stub helper is discoverable by _rest_fallback_append_sig via BASH_SOURCE.
+# Ensure our stub helper is discoverable by _rest_append_sig via BASH_SOURCE.
 # The function searches HOME/.aidevops/agents/scripts/ and dirname(BASH_SOURCE[0]).
 # Override HOME-based path since we can't write there in tests.
 # We inject via a wrapper: temporarily place the stub on PATH as gh-signature-helper.sh.
@@ -129,7 +129,7 @@ print_info() { return 0; }
 export -f print_info
 
 # Source the REST fallback module under test.
-# _rest_fallback_append_sig will call the stub via PATH lookup.
+# _rest_append_sig will call the stub via PATH lookup.
 # shellcheck source=../shared-gh-wrappers-rest-fallback.sh
 source "${SCRIPTS_DIR}/shared-gh-wrappers-rest-fallback.sh" || {
 	printf 'FATAL: could not source shared-gh-wrappers-rest-fallback.sh\n' >&2
@@ -140,7 +140,7 @@ printf '%sRunning gh api sig-footer injection tests (t2707 / GH#20350)%s\n' \
 	"$TEST_BLUE" "$TEST_NC"
 
 # =============================================================================
-# Test 1: _gh_issue_create_rest injects sig into body file
+# Test 1: _rest_issue_create injects sig into body file
 # Use --body-file with a user-owned file so the translator doesn't clean it up
 # (tmp_body_owned=0 when body_file is provided). We can then check the file
 # contents after the call to confirm the sig was appended before the API call.
@@ -149,44 +149,44 @@ printf '%sRunning gh api sig-footer injection tests (t2707 / GH#20350)%s\n' \
 _BODY1="${TMP}/body1.md"
 printf 'Issue body for sig test.\n' >"$_BODY1"
 
-_gh_issue_create_rest \
+_rest_issue_create \
 	--repo "owner/repo" \
 	--title "t2707: sig injection test" \
 	--body-file "$_BODY1" >/dev/null 2>&1 || true
 
 if grep -q "<!-- aidevops:sig -->" "$_BODY1" 2>/dev/null; then
-	pass "_gh_issue_create_rest injects <!-- aidevops:sig --> into body file"
+	pass "_rest_issue_create injects <!-- aidevops:sig --> into body file"
 else
-	fail "_gh_issue_create_rest injects <!-- aidevops:sig --> into body file" \
+	fail "_rest_issue_create injects <!-- aidevops:sig --> into body file" \
 		"marker absent; file tail: $(tail -3 "$_BODY1" 2>/dev/null)"
 fi
 
 # =============================================================================
-# Test 2: _gh_issue_comment_rest injects sig into body file
+# Test 2: _rest_issue_comment injects sig into body file
 # =============================================================================
 : >"$GH_CALLS"
 _BODY2="${TMP}/body2.md"
 printf 'Comment body for sig test.\n' >"$_BODY2"
 
-_gh_issue_comment_rest 99 \
+_rest_issue_comment 99 \
 	--repo "owner/repo" \
 	--body-file "$_BODY2" >/dev/null 2>&1 || true
 
 if grep -q "<!-- aidevops:sig -->" "$_BODY2" 2>/dev/null; then
-	pass "_gh_issue_comment_rest injects <!-- aidevops:sig --> into body file"
+	pass "_rest_issue_comment injects <!-- aidevops:sig --> into body file"
 else
-	fail "_gh_issue_comment_rest injects <!-- aidevops:sig --> into body file" \
+	fail "_rest_issue_comment injects <!-- aidevops:sig --> into body file" \
 		"marker absent; file tail: $(tail -3 "$_BODY2" 2>/dev/null)"
 fi
 
 # =============================================================================
-# Test 3: _gh_pr_create_rest injects sig into body file
+# Test 3: _rest_pr_create injects sig into body file
 # =============================================================================
 : >"$GH_CALLS"
 _BODY3="${TMP}/body3.md"
 printf 'PR body for sig test.\n' >"$_BODY3"
 
-_gh_pr_create_rest \
+_rest_pr_create \
 	--repo "owner/repo" \
 	--title "t2707: PR sig test" \
 	--head "feature/t2707-test" \
@@ -194,9 +194,9 @@ _gh_pr_create_rest \
 	--body-file "$_BODY3" >/dev/null 2>&1 || true
 
 if grep -q "<!-- aidevops:sig -->" "$_BODY3" 2>/dev/null; then
-	pass "_gh_pr_create_rest injects <!-- aidevops:sig --> into body file"
+	pass "_rest_pr_create injects <!-- aidevops:sig --> into body file"
 else
-	fail "_gh_pr_create_rest injects <!-- aidevops:sig --> into body file" \
+	fail "_rest_pr_create injects <!-- aidevops:sig --> into body file" \
 		"marker absent; file tail: $(tail -3 "$_BODY3" 2>/dev/null)"
 fi
 

--- a/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
@@ -17,33 +17,33 @@
 #   operators pivoted manually; dispatched workers crashed at step 1.
 #
 # t2579 addendum: gh_create_pr also hit GraphQL exhaustion during PR creation.
-# Fix (t2580): extend REST fallback to gh_create_pr via _gh_pr_create_rest.
+# Fix (t2580): extend REST fallback to gh_create_pr via _rest_pr_create.
 #
-# Fix (t2574): add _gh_should_fallback_to_rest + _gh_issue_*_rest helpers
+# Fix (t2574): add _rest_should_fallback + _gh_issue_*_rest helpers
 # in shared-gh-wrappers-rest-fallback.sh; wrap the 4 entry points
 # (gh_create_issue, gh_issue_comment, gh_issue_edit_safe, set_issue_status)
 # to retry via REST when primary fails and GraphQL is exhausted.
 #
 # Tests:
-#   1. _gh_should_fallback_to_rest returns 0 when remaining <= 10
-#   2. _gh_should_fallback_to_rest returns 1 when remaining > 10
-#   3. _gh_should_fallback_to_rest returns 1 when rate_limit call fails (fail-safe)
-#   4. _gh_issue_create_rest translates --title/--body/--label → POST /repos/.../issues
-#   5. _gh_issue_create_rest uses -F body=@file for newline/unicode safety
-#   6. _gh_issue_comment_rest translates --body → POST /repos/.../issues/N/comments
-#   7. _gh_issue_comment_rest extracts repo and num from a URL argument
-#   8. _gh_issue_edit_rest translates --add-label/--remove-label into full labels array
+#   1. _rest_should_fallback returns 0 when remaining <= 10
+#   2. _rest_should_fallback returns 1 when remaining > 10
+#   3. _rest_should_fallback returns 1 when rate_limit call fails (fail-safe)
+#   4. _rest_issue_create translates --title/--body/--label → POST /repos/.../issues
+#   5. _rest_issue_create uses -F body=@file for newline/unicode safety
+#   6. _rest_issue_comment translates --body → POST /repos/.../issues/N/comments
+#   7. _rest_issue_comment extracts repo and num from a URL argument
+#   8. _rest_issue_edit translates --add-label/--remove-label into full labels array
 #   9. gh_issue_comment falls back to REST when gh fails AND graphql exhausted
 #  10. gh_issue_comment does NOT fall back when gh succeeds
 #  11. gh_issue_comment does NOT fall back when gh fails but graphql healthy
-#  12. _gh_pr_create_rest translates --title/--head/--base → POST /repos/.../pulls
-#  13. _gh_pr_create_rest uses -F body=@file for body
-#  14. _gh_pr_create_rest applies labels via POST /repos/.../issues/{N}/labels
+#  12. _rest_pr_create translates --title/--head/--base → POST /repos/.../pulls
+#  13. _rest_pr_create uses -F body=@file for body
+#  14. _rest_pr_create applies labels via POST /repos/.../issues/{N}/labels
 #  15. gh_create_pr falls back to REST when primary fails AND exhausted
 #  16. gh_create_pr does NOT fall back when primary succeeds
 #  17. gh_create_pr does NOT fall back when primary fails but graphql healthy
-#  18. _gh_pr_create_rest auto-detects --head from git HEAD when omitted
-#  19. _gh_pr_create_rest auto-detects --base from repo default_branch via REST
+#  18. _rest_pr_create auto-detects --head from git HEAD when omitted
+#  19. _rest_pr_create auto-detects --base from repo default_branch via REST
 #
 # Stub strategy: define `gh` as a shell function. Shell functions take
 # precedence over PATH binaries, so the stub captures all `gh` invocations
@@ -197,10 +197,10 @@ printf '%sRunning gh-wrapper REST fallback tests (t2574 / GH#20243)%s\n' \
 	"$TEST_BLUE" "$TEST_NC"
 
 # =============================================================================
-# Test 1: _gh_should_fallback_to_rest returns 0 (true) when remaining <= 10
+# Test 1: _rest_should_fallback returns 0 (true) when remaining <= 10
 # =============================================================================
 STUB_RATE_LIMIT_REMAINING=0
-if _gh_should_fallback_to_rest; then
+if _rest_should_fallback; then
 	pass "should_fallback returns true when remaining=0"
 else
 	fail "should_fallback returns true when remaining=0" \
@@ -208,7 +208,7 @@ else
 fi
 
 STUB_RATE_LIMIT_REMAINING=10
-if _gh_should_fallback_to_rest; then
+if _rest_should_fallback; then
 	pass "should_fallback returns true when remaining=10 (boundary)"
 else
 	fail "should_fallback returns true when remaining=10 (boundary)" \
@@ -216,10 +216,10 @@ else
 fi
 
 # =============================================================================
-# Test 2: _gh_should_fallback_to_rest returns 1 (false) when remaining > 10
+# Test 2: _rest_should_fallback returns 1 (false) when remaining > 10
 # =============================================================================
 STUB_RATE_LIMIT_REMAINING=100
-if ! _gh_should_fallback_to_rest; then
+if ! _rest_should_fallback; then
 	pass "should_fallback returns false when remaining=100"
 else
 	fail "should_fallback returns false when remaining=100" \
@@ -227,12 +227,12 @@ else
 fi
 
 # =============================================================================
-# Test 3: _gh_should_fallback_to_rest fail-safe when rate_limit unparseable
+# Test 3: _rest_should_fallback fail-safe when rate_limit unparseable
 # Stub returns non-numeric — fallback should NOT activate (fail-safe: let
 # caller see original error rather than running REST call that may also fail).
 # =============================================================================
 STUB_RATE_LIMIT_REMAINING="unknown"
-if ! _gh_should_fallback_to_rest; then
+if ! _rest_should_fallback; then
 	pass "should_fallback returns false when rate_limit unparseable (fail-safe)"
 else
 	fail "should_fallback returns false when rate_limit unparseable (fail-safe)" \
@@ -243,10 +243,10 @@ fi
 export STUB_RATE_LIMIT_REMAINING=5000
 
 # =============================================================================
-# Test 4: _gh_issue_create_rest → POST /repos/.../issues with correct args
+# Test 4: _rest_issue_create → POST /repos/.../issues with correct args
 # =============================================================================
 : >"$GH_CALLS"
-_gh_issue_create_rest \
+_rest_issue_create \
 	--repo "owner/repo" \
 	--title "t9991: test create" \
 	--body "test body" \
@@ -256,17 +256,17 @@ if grep -qE '^api.*-X POST.*/repos/owner/repo/issues' "$GH_CALLS" 2>/dev/null &&
 	grep -qE 'title=t9991: test create' "$GH_CALLS" 2>/dev/null &&
 	grep -qE 'labels\[\]=bug' "$GH_CALLS" 2>/dev/null &&
 	grep -qE 'labels\[\]=auto-dispatch' "$GH_CALLS" 2>/dev/null; then
-	pass "_gh_issue_create_rest translates to POST /repos/.../issues with labels"
+	pass "_rest_issue_create translates to POST /repos/.../issues with labels"
 else
-	fail "_gh_issue_create_rest translates to POST /repos/.../issues with labels" \
+	fail "_rest_issue_create translates to POST /repos/.../issues with labels" \
 		"GH_CALLS=$(cat "$GH_CALLS")"
 fi
 
 # =============================================================================
-# Test 5: _gh_issue_create_rest uses -F body=@file (for newline/unicode safety)
+# Test 5: _rest_issue_create uses -F body=@file (for newline/unicode safety)
 # =============================================================================
 : >"$GH_CALLS"
-_gh_issue_create_rest \
+_rest_issue_create \
 	--repo "owner/repo" \
 	--title "t9992: newline test" \
 	--body "line1
@@ -274,58 +274,58 @@ line2
 line3" >/dev/null 2>&1 || true
 
 if grep -qE 'body=@/.*aidevops-gh-rest-body' "$GH_CALLS" 2>/dev/null; then
-	pass "_gh_issue_create_rest uses -F body=@tmpfile for body"
+	pass "_rest_issue_create uses -F body=@tmpfile for body"
 else
-	fail "_gh_issue_create_rest uses -F body=@tmpfile for body" \
+	fail "_rest_issue_create uses -F body=@tmpfile for body" \
 		"GH_CALLS=$(cat "$GH_CALLS")"
 fi
 
 # =============================================================================
-# Test 6: _gh_issue_comment_rest translates --body → POST .../comments
+# Test 6: _rest_issue_comment translates --body → POST .../comments
 # =============================================================================
 : >"$GH_CALLS"
-_gh_issue_comment_rest 12345 \
+_rest_issue_comment 12345 \
 	--repo "owner/repo" \
 	--body "test comment" >/dev/null 2>&1 || true
 
 if grep -qE '^api.*-X POST.*/repos/owner/repo/issues/12345/comments' "$GH_CALLS" 2>/dev/null; then
-	pass "_gh_issue_comment_rest translates to POST /issues/N/comments"
+	pass "_rest_issue_comment translates to POST /issues/N/comments"
 else
-	fail "_gh_issue_comment_rest translates to POST /issues/N/comments" \
+	fail "_rest_issue_comment translates to POST /issues/N/comments" \
 		"GH_CALLS=$(cat "$GH_CALLS")"
 fi
 
 # =============================================================================
-# Test 7: _gh_issue_comment_rest extracts repo + num from a URL argument
+# Test 7: _rest_issue_comment extracts repo + num from a URL argument
 # =============================================================================
 : >"$GH_CALLS"
-_gh_issue_comment_rest "https://github.com/owner/repo/issues/777" \
+_rest_issue_comment "https://github.com/owner/repo/issues/777" \
 	--body "url-form comment" >/dev/null 2>&1 || true
 
 if grep -qE '^api.*-X POST.*/repos/owner/repo/issues/777/comments' "$GH_CALLS" 2>/dev/null; then
-	pass "_gh_issue_comment_rest extracts repo+num from URL"
+	pass "_rest_issue_comment extracts repo+num from URL"
 else
-	fail "_gh_issue_comment_rest extracts repo+num from URL" \
+	fail "_rest_issue_comment extracts repo+num from URL" \
 		"GH_CALLS=$(cat "$GH_CALLS")"
 fi
 
 # =============================================================================
-# Test 8: _gh_issue_edit_rest computes full labels array from add/remove deltas
+# Test 8: _rest_issue_edit computes full labels array from add/remove deltas
 # Current labels stub returns "bug" (single label). We add "auto-dispatch",
 # remove "bug" — target set should be ["auto-dispatch"] only.
 # =============================================================================
 : >"$GH_CALLS"
 export STUB_CURRENT_LABELS="bug"
-_gh_issue_edit_rest 42 \
+_rest_issue_edit 42 \
 	--repo "owner/repo" \
 	--add-label "auto-dispatch" \
 	--remove-label "bug" >/dev/null 2>&1 || true
 
 if grep -qE 'labels\[\]=auto-dispatch' "$GH_CALLS" 2>/dev/null &&
 	! grep -qE 'labels\[\]=bug' "$GH_CALLS" 2>/dev/null; then
-	pass "_gh_issue_edit_rest computes target label set (add auto-dispatch, remove bug)"
+	pass "_rest_issue_edit computes target label set (add auto-dispatch, remove bug)"
 else
-	fail "_gh_issue_edit_rest computes target label set (add auto-dispatch, remove bug)" \
+	fail "_rest_issue_edit computes target label set (add auto-dispatch, remove bug)" \
 		"GH_CALLS=$(cat "$GH_CALLS")"
 fi
 
@@ -400,10 +400,10 @@ unset STUB_PRIMARY_FAIL
 export STUB_RATE_LIMIT_REMAINING=5000
 
 # =============================================================================
-# Test 12: _gh_pr_create_rest → POST /repos/.../pulls with correct args
+# Test 12: _rest_pr_create → POST /repos/.../pulls with correct args
 # =============================================================================
 : >"$GH_CALLS"
-_gh_pr_create_rest \
+_rest_pr_create \
 	--repo "owner/repo" \
 	--title "t9993: test PR create" \
 	--head "feature/t9993-test" \
@@ -414,17 +414,17 @@ if grep -qE '^api.*-X POST.*/repos/owner/repo/pulls' "$GH_CALLS" 2>/dev/null &&
 	grep -qE 'title=t9993: test PR create' "$GH_CALLS" 2>/dev/null &&
 	grep -qE 'head=feature/t9993-test' "$GH_CALLS" 2>/dev/null &&
 	grep -qE 'base=main' "$GH_CALLS" 2>/dev/null; then
-	pass "_gh_pr_create_rest translates to POST /repos/.../pulls with head/base/title"
+	pass "_rest_pr_create translates to POST /repos/.../pulls with head/base/title"
 else
-	fail "_gh_pr_create_rest translates to POST /repos/.../pulls with head/base/title" \
+	fail "_rest_pr_create translates to POST /repos/.../pulls with head/base/title" \
 		"GH_CALLS=$(cat "$GH_CALLS")"
 fi
 
 # =============================================================================
-# Test 13: _gh_pr_create_rest uses -F body=@file for body
+# Test 13: _rest_pr_create uses -F body=@file for body
 # =============================================================================
 : >"$GH_CALLS"
-_gh_pr_create_rest \
+_rest_pr_create \
 	--repo "owner/repo" \
 	--title "t9994: body file test" \
 	--head "feature/t9994-body" \
@@ -434,19 +434,19 @@ line2
 line3" >/dev/null 2>&1 || true
 
 if grep -qE 'body=@/.*aidevops-gh-rest-body' "$GH_CALLS" 2>/dev/null; then
-	pass "_gh_pr_create_rest uses -F body=@tmpfile for body"
+	pass "_rest_pr_create uses -F body=@tmpfile for body"
 else
-	fail "_gh_pr_create_rest uses -F body=@tmpfile for body" \
+	fail "_rest_pr_create uses -F body=@tmpfile for body" \
 		"GH_CALLS=$(cat "$GH_CALLS")"
 fi
 
 # =============================================================================
-# Test 14: _gh_pr_create_rest applies labels via POST /repos/.../issues/{N}/labels
+# Test 14: _rest_pr_create applies labels via POST /repos/.../issues/{N}/labels
 # The stub returns https://github.com/owner/repo/issues/9999 for REST calls,
 # so label call should target issues/9999/labels.
 # =============================================================================
 : >"$GH_CALLS"
-_gh_pr_create_rest \
+_rest_pr_create \
 	--repo "owner/repo" \
 	--title "t9995: label test" \
 	--head "feature/t9995-labels" \
@@ -456,9 +456,9 @@ _gh_pr_create_rest \
 if grep -qE '^api.*-X POST.*/repos/owner/repo/issues/[0-9]+/labels' "$GH_CALLS" 2>/dev/null &&
 	grep -qE 'labels\[\]=origin:worker' "$GH_CALLS" 2>/dev/null &&
 	grep -qE 'labels\[\]=auto-dispatch' "$GH_CALLS" 2>/dev/null; then
-	pass "_gh_pr_create_rest applies labels via POST /issues/{N}/labels"
+	pass "_rest_pr_create applies labels via POST /issues/{N}/labels"
 else
-	fail "_gh_pr_create_rest applies labels via POST /issues/{N}/labels" \
+	fail "_rest_pr_create applies labels via POST /issues/{N}/labels" \
 		"GH_CALLS=$(cat "$GH_CALLS")"
 fi
 
@@ -546,40 +546,40 @@ unset STUB_PRIMARY_FAIL
 export STUB_RATE_LIMIT_REMAINING=5000
 
 # =============================================================================
-# Test 18: _gh_pr_create_rest auto-detects --head from git HEAD when omitted
+# Test 18: _rest_pr_create auto-detects --head from git HEAD when omitted
 # Verifies that omitting --head causes the current branch to be used as head.
 # =============================================================================
 CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
 : >"$GH_CALLS"
-_gh_pr_create_rest \
+_rest_pr_create \
 	--repo "owner/repo" \
 	--title "t9999: auto-head test" \
 	--base "main" \
 	--body "auto-detect head body" >/dev/null 2>&1 || true
 
 if [[ -n "$CURRENT_BRANCH" ]] && grep -qE "head=${CURRENT_BRANCH}" "$GH_CALLS" 2>/dev/null; then
-	pass "_gh_pr_create_rest auto-detects --head from git HEAD when omitted"
+	pass "_rest_pr_create auto-detects --head from git HEAD when omitted"
 else
-	fail "_gh_pr_create_rest auto-detects --head from git HEAD when omitted" \
+	fail "_rest_pr_create auto-detects --head from git HEAD when omitted" \
 		"expected head=${CURRENT_BRANCH} in calls; GH_CALLS=$(cat "$GH_CALLS")"
 fi
 
 # =============================================================================
-# Test 19: _gh_pr_create_rest auto-detects --base from repo default_branch
+# Test 19: _rest_pr_create auto-detects --base from repo default_branch
 # Uses STUB_REPO_DEFAULT_BRANCH=develop to verify REST resolution path.
 # =============================================================================
 : >"$GH_CALLS"
 export STUB_REPO_DEFAULT_BRANCH="develop"
-_gh_pr_create_rest \
+_rest_pr_create \
 	--repo "owner/repo" \
 	--title "t9999: auto-base test" \
 	--head "feature/t9999-auto-base" \
 	--body "auto-detect base body" >/dev/null 2>&1 || true
 
 if grep -qE "base=develop" "$GH_CALLS" 2>/dev/null; then
-	pass "_gh_pr_create_rest auto-detects --base from repo default_branch via REST"
+	pass "_rest_pr_create auto-detects --base from repo default_branch via REST"
 else
-	fail "_gh_pr_create_rest auto-detects --base from repo default_branch via REST" \
+	fail "_rest_pr_create auto-detects --base from repo default_branch via REST" \
 		"expected base=develop in calls; GH_CALLS=$(cat "$GH_CALLS")"
 fi
 unset STUB_REPO_DEFAULT_BRANCH

--- a/.agents/scripts/tests/test-gh-wrapper-shell-compat.sh
+++ b/.agents/scripts/tests/test-gh-wrapper-shell-compat.sh
@@ -14,24 +14,24 @@
 #   `IFS=',' read -ra _toks <<<"$val"` is bash-only. In zsh, `read -a`
 #   is not recognised (zsh uses `read -A`) and the command fails with
 #   "bad option: -a", silently producing empty arrays. Issues created
-#   via _gh_issue_create_rest in zsh sessions received no labels and
+#   via _rest_issue_create in zsh sessions received no labels and
 #   no assignees, breaking tier-routing, origin-detection, and
 #   auto-dispatch pipelines.
 #
 # Fix: replaced all 16 `read -ra` sites with a portable helper
-# `_gh_split_csv` that uses POSIX parameter expansion only.
+# `_rest_split_csv` that uses POSIX parameter expansion only.
 #
 # Test scenarios:
-#   1. _gh_split_csv: basic CSV split under bash
-#   2. _gh_split_csv: same split under zsh (skip if zsh unavailable)
-#   3. _gh_split_csv: single token (no delimiter) returns string unchanged
-#   4. _gh_split_csv: empty string returns nothing
-#   5. _gh_split_csv: trailing delimiter — raw output, caller skips empty
-#   6. Integration: _gh_issue_create_rest labels+assignees reach gh api
+#   1. _rest_split_csv: basic CSV split under bash
+#   2. _rest_split_csv: same split under zsh (skip if zsh unavailable)
+#   3. _rest_split_csv: single token (no delimiter) returns string unchanged
+#   4. _rest_split_csv: empty string returns nothing
+#   5. _rest_split_csv: trailing delimiter — raw output, caller skips empty
+#   6. Integration: _rest_issue_create labels+assignees reach gh api
 #      payload under bash (via stubbed gh)
 #   7. Integration: same under zsh (skip if zsh unavailable)
 #   8. Load-order: sourcing shared-gh-wrappers.sh with no _SHARED_GH_WRAPPERS_DIR
-#      and no shared-constants.sh still defines _gh_should_fallback_to_rest
+#      and no shared-constants.sh still defines _rest_should_fallback
 #
 # macOS vs Linux:
 #   macOS: /bin/bash is 3.2; /bin/zsh is the default interactive shell.
@@ -90,7 +90,7 @@ if [[ ! -f "$FALLBACK_FILE" ]]; then
 	exit 1
 fi
 
-# Source the fallback file under bash to load _gh_split_csv and helpers.
+# Source the fallback file under bash to load _rest_split_csv and helpers.
 # Stub out print_info / print_warning so sourcing is noise-free.
 print_info() { return 0; }
 print_warning() { return 0; }
@@ -103,78 +103,78 @@ printf '%sRunning gh-wrapper shell-compat tests (t2743 / GH#20480)%s\n' \
 	"$TEST_GREEN" "$TEST_NC"
 
 # =============================================================================
-# Test 1: _gh_split_csv basic CSV split under bash
+# Test 1: _rest_split_csv basic CSV split under bash
 # =============================================================================
-out=$(_gh_split_csv "a,b,c" ",")
+out=$(_rest_split_csv "a,b,c" ",")
 expected=$(printf 'a\nb\nc')
 if [[ "$out" == "$expected" ]]; then
-	pass "1: _gh_split_csv splits 'a,b,c' into 3 tokens under bash"
+	pass "1: _rest_split_csv splits 'a,b,c' into 3 tokens under bash"
 else
-	fail "1: _gh_split_csv splits 'a,b,c' into 3 tokens under bash" \
+	fail "1: _rest_split_csv splits 'a,b,c' into 3 tokens under bash" \
 		"expected: $(printf '%q' "$expected")  got: $(printf '%q' "$out")"
 fi
 
 # =============================================================================
-# Test 2: _gh_split_csv under zsh
+# Test 2: _rest_split_csv under zsh
 # =============================================================================
 if ! command -v zsh >/dev/null 2>&1; then
-	skip "2: _gh_split_csv splits correctly under zsh" "zsh not installed"
+	skip "2: _rest_split_csv splits correctly under zsh" "zsh not installed"
 else
 	zsh_out=$(zsh -c "
 source '${FALLBACK_FILE}'
-out=\$(_gh_split_csv 'a,b,c' ',')
+out=\$(_rest_split_csv 'a,b,c' ',')
 printf '%s' \"\$out\"
 " 2>&1)
 	zsh_expected=$(printf 'a\nb\nc')
 	if [[ "$zsh_out" == "$zsh_expected" ]]; then
-		pass "2: _gh_split_csv splits 'a,b,c' into 3 tokens under zsh"
+		pass "2: _rest_split_csv splits 'a,b,c' into 3 tokens under zsh"
 	else
-		fail "2: _gh_split_csv splits 'a,b,c' into 3 tokens under zsh" \
+		fail "2: _rest_split_csv splits 'a,b,c' into 3 tokens under zsh" \
 			"expected: $(printf '%q' "$zsh_expected")  got: $(printf '%q' "$zsh_out")"
 	fi
 fi
 
 # =============================================================================
-# Test 3: _gh_split_csv single token (no delimiter) returns string unchanged
+# Test 3: _rest_split_csv single token (no delimiter) returns string unchanged
 # =============================================================================
-out=$(_gh_split_csv "solo" ",")
+out=$(_rest_split_csv "solo" ",")
 if [[ "$out" == "solo" ]]; then
-	pass "3: _gh_split_csv returns single token unchanged when no delimiter present"
+	pass "3: _rest_split_csv returns single token unchanged when no delimiter present"
 else
-	fail "3: _gh_split_csv returns single token unchanged when no delimiter present" \
+	fail "3: _rest_split_csv returns single token unchanged when no delimiter present" \
 		"expected 'solo' got: $(printf '%q' "$out")"
 fi
 
 # =============================================================================
-# Test 4: _gh_split_csv empty string returns nothing (no spurious empty line)
+# Test 4: _rest_split_csv empty string returns nothing (no spurious empty line)
 # =============================================================================
-out=$(_gh_split_csv "" ",")
+out=$(_rest_split_csv "" ",")
 if [[ -z "$out" ]]; then
-	pass "4: _gh_split_csv empty string returns empty output"
+	pass "4: _rest_split_csv empty string returns empty output"
 else
-	fail "4: _gh_split_csv empty string returns empty output" \
+	fail "4: _rest_split_csv empty string returns empty output" \
 		"expected empty, got: $(printf '%q' "$out")"
 fi
 
 # =============================================================================
-# Test 5: _gh_split_csv trailing delimiter — function does NOT emit spurious
-# trailing empty token. The `while [[ -n "$_str" ]]` guard in _gh_split_csv
+# Test 5: _rest_split_csv trailing delimiter — function does NOT emit spurious
+# trailing empty token. The `while [[ -n "$_str" ]]` guard in _rest_split_csv
 # ensures the loop exits when _str becomes "" after the last delimited token,
 # so "a,b," produces exactly 2 lines ("a" and "b") — no empty trailing line.
 # The caller's `[[ -n "$_tok" ]]` guard remains a defensive safety measure
-# for callers that feed raw shell word-splitting output, not _gh_split_csv output.
+# for callers that feed raw shell word-splitting output, not _rest_split_csv output.
 # =============================================================================
-out=$(_gh_split_csv "a,b," ",")
+out=$(_rest_split_csv "a,b," ",")
 line_count=$(printf '%s\n' "$out" | wc -l | tr -d ' ')
 if [[ "$line_count" == "2" ]]; then
-	pass "5: _gh_split_csv trailing delimiter produces 2 tokens (no spurious empty)"
+	pass "5: _rest_split_csv trailing delimiter produces 2 tokens (no spurious empty)"
 else
-	fail "5: _gh_split_csv trailing delimiter produces 2 tokens (no spurious empty)" \
+	fail "5: _rest_split_csv trailing delimiter produces 2 tokens (no spurious empty)" \
 		"expected 2, got: $line_count  (raw output: $(printf '%q' "$out"))"
 fi
 
 # =============================================================================
-# Test 6: Integration — _gh_issue_create_rest labels+assignees reach gh api
+# Test 6: Integration — _rest_issue_create labels+assignees reach gh api
 # under bash. Stub `gh` as a shell function; capture calls to a temp file.
 # =============================================================================
 TMP=$(mktemp -d -t t2743.XXXXXX)
@@ -196,7 +196,7 @@ gh() {
 export -f gh
 
 : >"$GH_CALLS"
-_gh_issue_create_rest \
+_rest_issue_create \
 	--repo "owner/repo" \
 	--title "t2743: shell compat test" \
 	--body "test body" \
@@ -211,9 +211,9 @@ assignee_other=$(grep -c 'assignees\[\]=otheruser' "$GH_CALLS" 2>/dev/null || pr
 
 if [[ "$label_standard" -ge 1 && "$label_auto" -ge 1 && "$label_fw" -ge 1 && \
       "$assignee_main" -ge 1 && "$assignee_other" -ge 1 ]]; then
-	pass "6: _gh_issue_create_rest sends all labels and assignees to gh api under bash"
+	pass "6: _rest_issue_create sends all labels and assignees to gh api under bash"
 else
-	fail "6: _gh_issue_create_rest sends all labels and assignees to gh api under bash" \
+	fail "6: _rest_issue_create sends all labels and assignees to gh api under bash" \
 		"GH_CALLS=$(cat "$GH_CALLS")"
 fi
 
@@ -221,7 +221,7 @@ fi
 # Test 7: Integration — same test under zsh
 # =============================================================================
 if ! command -v zsh >/dev/null 2>&1; then
-	skip "7: _gh_issue_create_rest labels+assignees under zsh" "zsh not installed"
+	skip "7: _rest_issue_create labels+assignees under zsh" "zsh not installed"
 else
 	ZSH_CALLS="${TMP}/zsh_calls.log"
 	: >"$ZSH_CALLS"
@@ -238,7 +238,7 @@ gh() {
     return 0
 }
 source '${FALLBACK_FILE}'
-_gh_issue_create_rest \
+_rest_issue_create \
     --repo 'owner/repo' \
     --title 't2743: zsh compat test' \
     --body 'zsh body' \
@@ -254,9 +254,9 @@ _gh_issue_create_rest \
 
 	if [[ "$zsh_label_standard" -ge 1 && "$zsh_label_auto" -ge 1 && "$zsh_label_fw" -ge 1 && \
 	      "$zsh_assignee_main" -ge 1 && "$zsh_assignee_other" -ge 1 ]]; then
-		pass "7: _gh_issue_create_rest sends all labels and assignees under zsh"
+		pass "7: _rest_issue_create sends all labels and assignees under zsh"
 	else
-		fail "7: _gh_issue_create_rest sends all labels and assignees under zsh" \
+		fail "7: _rest_issue_create sends all labels and assignees under zsh" \
 			"ZSH_CALLS=$(cat "$ZSH_CALLS")"
 	fi
 fi
@@ -273,9 +273,9 @@ unset _SHARED_GH_WRAPPERS_DIR 2>/dev/null || true
 unset _SC_SELF 2>/dev/null || true
 # No shared-constants.sh sourced — test that stubs prevent command-not-found.
 source '${WRAPPERS_FILE}' 2>/dev/null
-if declare -F _gh_should_fallback_to_rest >/dev/null 2>&1 && \
-   declare -F _gh_issue_create_rest >/dev/null 2>&1 && \
-   declare -F _gh_pr_create_rest >/dev/null 2>&1; then
+if declare -F _rest_should_fallback >/dev/null 2>&1 && \
+   declare -F _rest_issue_create >/dev/null 2>&1 && \
+   declare -F _rest_pr_create >/dev/null 2>&1; then
     printf 'OK\n'
 else
     printf 'MISSING\n'

--- a/.agents/scripts/tests/test-shared-gh-wrappers-source.sh
+++ b/.agents/scripts/tests/test-shared-gh-wrappers-source.sh
@@ -22,9 +22,9 @@
 #
 # Tests:
 #   1. bash: source shared-constants.sh emits zero REST-fallback warnings
-#   2. bash: _gh_issue_create_rest is defined after sourcing
+#   2. bash: _rest_issue_create is defined after sourcing
 #   3. zsh:  source shared-constants.sh emits zero REST-fallback warnings (t2709)
-#   4. zsh:  _gh_issue_create_rest is defined after sourcing (t2709)
+#   4. zsh:  _rest_issue_create is defined after sourcing (t2709)
 
 set -uo pipefail
 
@@ -78,11 +78,11 @@ else
 	pass "bash source emits no REST-fallback warning"
 fi
 
-bash_fn=$(bash -c "source '${SCRIPTS_DIR}/shared-constants.sh' 2>/dev/null && type _gh_issue_create_rest 2>/dev/null" || true)
-if printf '%s\n' "$bash_fn" | grep -q 'function\|_gh_issue_create_rest'; then
-	pass "bash: _gh_issue_create_rest defined after source"
+bash_fn=$(bash -c "source '${SCRIPTS_DIR}/shared-constants.sh' 2>/dev/null && type _rest_issue_create 2>/dev/null" || true)
+if printf '%s\n' "$bash_fn" | grep -q 'function\|_rest_issue_create'; then
+	pass "bash: _rest_issue_create defined after source"
 else
-	fail "bash: _gh_issue_create_rest NOT defined after source" "$bash_fn"
+	fail "bash: _rest_issue_create NOT defined after source" "$bash_fn"
 fi
 
 # =============================================================================
@@ -92,7 +92,7 @@ printf '\n=== zsh source tests ===\n'
 
 if ! command -v zsh >/dev/null 2>&1; then
 	skip "zsh not available — skipping zsh tests (not a failure)"
-	skip "zsh: _gh_issue_create_rest defined after source (zsh unavailable)"
+	skip "zsh: _rest_issue_create defined after source (zsh unavailable)"
 else
 	zsh_output=$(zsh -c "source '${SCRIPTS_DIR}/shared-constants.sh' 2>&1" || true)
 	if printf '%s\n' "$zsh_output" | grep -q 'shared-gh-wrappers-rest-fallback.sh'; then
@@ -101,11 +101,11 @@ else
 		pass "zsh source emits no REST-fallback warning (t2709)"
 	fi
 
-	zsh_fn=$(zsh -c "source '${SCRIPTS_DIR}/shared-constants.sh' 2>/dev/null && type _gh_issue_create_rest 2>/dev/null" || true)
-	if printf '%s\n' "$zsh_fn" | grep -q 'function\|_gh_issue_create_rest\|shell function'; then
-		pass "zsh: _gh_issue_create_rest defined after source (REST fallback loaded)"
+	zsh_fn=$(zsh -c "source '${SCRIPTS_DIR}/shared-constants.sh' 2>/dev/null && type _rest_issue_create 2>/dev/null" || true)
+	if printf '%s\n' "$zsh_fn" | grep -q 'function\|_rest_issue_create\|shell function'; then
+		pass "zsh: _rest_issue_create defined after source (REST fallback loaded)"
 	else
-		fail "zsh: _gh_issue_create_rest NOT defined after source" "$zsh_fn"
+		fail "zsh: _rest_issue_create NOT defined after source" "$zsh_fn"
 	fi
 fi
 


### PR DESCRIPTION
## Summary

Resolves #21945

- Rename all 13 functions in `shared-gh-wrappers-rest-fallback.sh` from mixed `_gh_*_rest` / `_rest_*` to unified `_rest_*` namespace
- Pass function name as `caller` arg to `gh_record_call` — logs now show `_rest_issue_list` instead of opaque `shared-gh-wrappers-rest-fallback.sh`
- Extract `_rest_api_call` helper (deduplicates 5-site timeout wrapper pattern)
- Extract `_rest_apply_labels` helper (brings `_rest_pr_create` under 100-line complexity gate)
- Update all 17 files with call sites (production scripts, tests, gh PATH shim)

No functional changes — pure rename + instrumentation + extraction.

**Tests:** 46/46 passed (bash + zsh), shellcheck clean.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.16 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-opus-4-6 spent 1h 37m and 42,646 tokens on this with the user in an interactive session.
