### PR TITLE
t3213: maintainer-gate: switch check-pr concurrency to cancel-in-progress: true

### DIFF
--- a/.github/workflows/maintainer-gate-reusable.yml
+++ b/.github/workflows/maintainer-gate-reusable.yml
@@ -67,9 +67,40 @@ jobs:
       github.event_name == 'pull_request_target'
     runs-on: ${{ inputs.runner }}
     timeout-minutes: 3
+    # t3213 / GH#21947: cancel-in-progress is INTENTIONALLY true here.
+    #
+    # check-pr is a READ-ONLY verdict job — it computes pass/fail from PR state
+    # at runtime (labels, linked issues, assignees) and writes a single status
+    # check. It does not mutate labels (Jobs 2-5 handle that, on different
+    # events and under separate `if:` conditions, with no shared concurrency
+    # block).
+    #
+    # Implication: the verdict from an OLDER queued run is always staler than
+    # one from a NEWER run on the same PR. Cancelling the older run costs
+    # nothing — the newer run will compute the same answer (or a better one,
+    # if labels/links/assignees have just changed). Serializing them, by
+    # contrast, costs operator attention: during an active session a single
+    # PR can fire 5+ events (open + sync + edit + force-push + branch-update),
+    # and with cancel-in-progress:false they queue end-to-end behind a single
+    # concurrency slot, producing 27-minute stalls for a 5-second job
+    # (measured on PR #21908, run 25177398309).
+    #
+    # GH branch protection treats the LATEST run for a given context name as
+    # the authoritative status. Cancelled older runs become historical
+    # artifacts; only the latest run's success/failure is gating. This is why
+    # the previous flip to `false` (PR #13846, GH#13812) is no longer needed:
+    # the original race-condition concern was that cancelled runs might be
+    # mistaken for failures, but in practice GitHub's status-resolution always
+    # picks the newest run for the same context.
+    #
+    # Related rules: t2229 / `workflow-cascade-lint.yml` flags the OPPOSITE
+    # anti-pattern (cancel-in-progress:true with cascade-vulnerable triggers
+    # like `labeled`/`unlabeled` causing mass cancellations). This job is
+    # safe from that class because pull_request_target fires on PR-state
+    # changes, not on every label flip.
     concurrency:
       group: maintainer-gate-${{ github.event.pull_request.number }}
-      cancel-in-progress: false
+      cancel-in-progress: true
     permissions:
       pull-requests: write
       issues: read


### PR DESCRIPTION
## Summary

Flip the per-PR concurrency block on the read-only check-pr verdict job from cancel-in-progress: false to cancel-in-progress: true, with a 30-line rationale comment block above. Eliminates 27-minute serialization stalls during active PR sessions (measured: PR #21908 run 25177398309 waited 27m for a 5s job).

## Files Changed

.github/workflows/maintainer-gate-reusable.yml

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck not applicable (YAML); workflow-cascade-lint.sh dry-run on both maintainer-gate-reusable.yml and maintainer-gate.yml reports 0 vulnerable; YAML parses cleanly via yaml.safe_load; previous flip to :false (PR #13846, GH#13812) reasoning re-evaluated against GH branch-protection's latest-run-for-context resolution behaviour.

Resolves #21947


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.16 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-opus-4-7 spent 6m and 19,905 tokens on this as a headless worker.