### PR TITLE
t3215: worker-activity-helper.sh canonical-source summary + AGENTS.md rule

### DIFF
--- a/.agents/AGENTS.md
+++ b/.agents/AGENTS.md
@@ -509,6 +509,26 @@ When an incident appears to match a bug in TODO.md or recent commits, READ the c
 - Scope: applies to attributions blaming a specific task ID, issue number, PR, or commit. Generic "this seems to be a pulse-merge edge case" is fine without code-level verification; "this is the t2108 bug" is not.
 - Related: "Scientific reasoning" (hypothesis framing), "Claim discipline" (proof artifacts), "Stale-symptom investigations" (stale symptoms vs deployed file mtime). This rule sits alongside, not inside, any of them.
 
+### Pulse activity verification (canonical sources, t3215)
+
+When verifying whether workers are actually running, dispatching, or producing PRs — i.e. answering "is the pulse alive and productive?" — use the canonical outcome ledger, not file timestamps. File mtime tells you when something was *touched*; the canonical sources tell you the *outcome*. Confusing the two is a recurring misdiagnosis class (canonical failure: t3215, where a session reported "0 workers in 48h" from `worker-NNN.log` mtimes while canonical sources showed 28 successful workers and 49 PRs in the same window).
+
+Sources, in precedence order:
+
+1. **`worker-activity-helper.sh summary [--since 1h|6h|24h|48h|7d] [--json] [--no-pr-check] [--repo OWNER/REPO]`** — single command that aggregates sources 2-4 below. Start here for any "are workers running?" question. Skip the gh PR query with `--no-pr-check` when offline or rate-limited.
+2. **`~/.aidevops/logs/headless-runtime-metrics.jsonl`** — authoritative per-worker outcome record. One JSON line per terminated worker with `ts`, `session_key`, `result` (`success` / `watchdog_stall_killed` / `watchdog_stall_continue` / `rate_limit` / other), `exit_code`, `duration_ms`. Written by `headless-runtime-helper.sh`. Filter by `ts` for windows: `jq 'select(.ts >= (now - 86400))' file`.
+3. **`~/.aidevops/logs/pulse-stats.json`** — pulse-side dispatch counters. Each value is an array of unix-second timestamps. Query with `jq '.counters[<name>] // []'` — the `// []` is mandatory, otherwise missing keys silently collapse to null and `length` returns 0 (this exact failure caused the t3215 misdiagnosis). Useful keys: `pulse_dispatch_circuit_broken`, `pulse_cycle_skipped_graphql_low`, `dispatch_backoff_skipped`, `pulse_dispatch_no_work_breaker_tripped`, `pulse_cache_prime_runs`.
+4. **`gh pr list --search "created:>=<ISO> label:origin:worker" --state all --json number`** — external truth: did dispatched work actually become a PR? Cross-check sources 2-3 against this; a window with high dispatch counts but few PRs indicates worker-side stalls.
+5. **`~/.local/share/opencode/opencode.db`** (OpenCode) / **`~/.claude/projects/`** (Claude Code) — current and recent in-flight sessions. Use only when 1-4 leave a gap (e.g. you need to know what a still-running worker is doing).
+
+NOT canonical sources:
+
+- `worker-NNN.log` mtime (`ls -lt ~/.aidevops/logs/worker-*.log`) — file touch time, not outcome. A killed worker still leaves a recently-touched log.
+- `pgrep -f "headless-runtime-helper.sh run"` — counts live processes, not productivity. A worker stuck in a 30-min watchdog stall counts the same as one shipping code.
+- "Recent dispatch comments on issues" — only visible if dispatch reached the gh-write step; misses pre-flight rejections in the canonical counters.
+
+Scope: applies before publishing any productivity-level claim ("workers aren't running", "dispatch is broken", "the pulse is dead", "we shipped N PRs today"). Internal hypotheses that lead to a canonical-source check are fine; published claims that skipped the check are not. This rule sits alongside t2204 (Attribution before verification) — both fire at the diagnosis-publish step, both demand evidence-then-claim.
+
 **Pre-edit rules:**
 
 - Before ANY file modification: run `pre-edit-check.sh`.

--- a/.agents/scripts/tests/test-worker-activity-helper.sh
+++ b/.agents/scripts/tests/test-worker-activity-helper.sh
@@ -1,0 +1,271 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-worker-activity-helper.sh — Fixture-driven tests for t3215.
+#
+# Verifies worker-activity-helper.sh aggregates the canonical sources
+# (headless-runtime-metrics.jsonl + pulse-stats.json) correctly without
+# touching the real ~/.aidevops files. Tests are offline (--no-pr-check).
+
+set -u
+
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_BLUE=$'\033[0;34m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_BLUE="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+assert_contains() {
+	local label="$1" needle="$2" haystack="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if printf '%s' "$haystack" | grep -qF -- "$needle" 2>/dev/null; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  expected to find: $(printf '%q' "$needle")"
+		echo "  in output:        $(printf '%q' "${haystack:0:300}")"
+	fi
+	return 0
+}
+
+assert_eq() {
+	local label="$1" expected="$2" actual="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$expected" == "$actual" ]]; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  expected: $(printf '%q' "$expected")"
+		echo "  got:      $(printf '%q' "$actual")"
+	fi
+	return 0
+}
+
+assert_rc() {
+	local label="$1" expected="$2" actual="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$expected" == "$actual" ]]; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  expected rc=$expected, got rc=$actual"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Setup: locate the helper, build temp fixtures.
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HELPER="$SCRIPT_DIR/worker-activity-helper.sh"
+
+if [[ ! -x "$HELPER" ]]; then
+	echo "${TEST_RED}FATAL${TEST_NC}: $HELPER not found or not executable"
+	exit 1
+fi
+
+FIXTURE_DIR="$(mktemp -d -t wah-test-XXXXXX)"
+METRICS="$FIXTURE_DIR/headless-runtime-metrics.jsonl"
+STATS="$FIXTURE_DIR/pulse-stats.json"
+PR_CACHE="$FIXTURE_DIR/pr-cache.json"
+
+cleanup() {
+	rm -rf "$FIXTURE_DIR"
+	return 0
+}
+trap cleanup EXIT
+
+NOW=$(date +%s)
+T_5MIN_AGO=$((NOW - 300))
+T_2H_AGO=$((NOW - 7200))
+T_25H_AGO=$((NOW - 90000))
+
+# Build metrics fixture covering every bucket and the regression cases that
+# the original awk implementation handled correctly:
+#   issue-1, issue-2 — success (terminal)
+#   issue-3          — watchdog_stall_killed (terminal failure)
+#   issue-4          — watchdog_stall_continue heartbeat (exit 0)
+#   issue-5          — rate_limit
+#   issue-6          — premature_exit-style unknown failure (exit != 0)
+#   issue-7          — out-of-window success (must be excluded by --since 24h)
+#   issue-8          — watchdog_stall_continue with NON-ZERO exit code; this
+#                      is the t3215 of-bucket regression case. The bucket is
+#                      result-name-based fallthrough, NOT exit-code-based —
+#                      this record must count as wc, NOT as of.
+{
+	printf '{"ts":%d,"role":"worker","session_key":"issue-1","result":"success","exit_code":0}\n' "$T_5MIN_AGO"
+	printf '{"ts":%d,"role":"worker","session_key":"issue-2","result":"success","exit_code":0}\n' "$T_2H_AGO"
+	printf '{"ts":%d,"role":"worker","session_key":"issue-3","result":"watchdog_stall_killed","exit_code":79}\n' "$T_2H_AGO"
+	printf '{"ts":%d,"role":"worker","session_key":"issue-4","result":"watchdog_stall_continue","exit_code":0}\n' "$T_5MIN_AGO"
+	printf '{"ts":%d,"role":"worker","session_key":"issue-5","result":"rate_limit","exit_code":1}\n' "$T_2H_AGO"
+	printf '{"ts":%d,"role":"worker","session_key":"issue-6","result":"unknown_failure","exit_code":2}\n' "$T_2H_AGO"
+	printf '{"ts":%d,"role":"worker","session_key":"issue-7","result":"success","exit_code":0}\n' "$T_25H_AGO"
+	printf '{"ts":%d,"role":"worker","session_key":"issue-8","result":"watchdog_stall_continue","exit_code":124}\n' "$T_2H_AGO"
+} >"$METRICS"
+
+# Build pulse-stats fixture: counter arrays with timestamps inside and outside window.
+cat >"$STATS" <<EOF
+{
+  "counters": {
+    "pulse_dispatch_circuit_broken": [$T_5MIN_AGO, $T_2H_AGO, $T_25H_AGO],
+    "pulse_cycle_skipped_graphql_low": [$T_2H_AGO],
+    "dispatch_backoff_skipped": [],
+    "pulse_dispatch_no_work_breaker_tripped": [$T_5MIN_AGO]
+  },
+  "invocation_sources": {}
+}
+EOF
+
+# Common env for the helper: point at fixtures, skip network.
+RUN_ENV=(
+	"WAH_METRICS_FILE=$METRICS"
+	"WAH_PULSE_STATS_FILE=$STATS"
+	"WAH_PR_CACHE_FILE=$PR_CACHE"
+)
+
+echo "${TEST_BLUE}=== t3215: worker-activity-helper.sh tests ===${TEST_NC}"
+echo
+
+# ---------------------------------------------------------------------------
+# Section 1: argv & help.
+# ---------------------------------------------------------------------------
+echo "--- Section 1: argv parsing ---"
+
+OUT=$("$HELPER" help 2>&1)
+RC=$?
+assert_rc "1a: help exits 0" 0 "$RC"
+assert_contains "1b: help mentions canonical sources" "headless-runtime-metrics.jsonl" "$OUT"
+assert_contains "1c: help mentions pulse-stats" "pulse-stats.json" "$OUT"
+assert_contains "1d: help warns against worker-NNN.log mtime" "mtime" "$OUT"
+
+# Bad subcommand exits 2.
+OUT=$("$HELPER" frobnicate 2>&1)
+RC=$?
+assert_rc "1e: unknown command exits 2" 2 "$RC"
+
+# Bad --since exits 2.
+OUT=$(env "${RUN_ENV[@]}" "$HELPER" summary --since 99x --no-pr-check 2>&1)
+RC=$?
+assert_rc "1f: bad --since exits 2" 2 "$RC"
+assert_contains "1g: bad --since explains valid options" "1h|6h|24h|48h|7d" "$OUT"
+
+# ---------------------------------------------------------------------------
+# Section 2: 24h aggregation accuracy.
+# ---------------------------------------------------------------------------
+echo
+echo "--- Section 2: 24h aggregation ---"
+
+JSON=$(env "${RUN_ENV[@]}" "$HELPER" summary --since 24h --no-pr-check --json 2>&1)
+RC=$?
+assert_rc "2a: --json exits 0" 0 "$RC"
+
+# Validate it's parseable JSON.
+TESTS_RUN=$((TESTS_RUN + 1))
+if printf '%s' "$JSON" | jq . >/dev/null 2>&1; then
+	echo "${TEST_GREEN}PASS${TEST_NC}: 2b: output parses as JSON"
+else
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	echo "${TEST_RED}FAIL${TEST_NC}: 2b: output is not valid JSON"
+	echo "  output: $(printf '%q' "${JSON:0:300}")"
+fi
+
+# Assert exact counts. 24h window: events 1-6 + 8, excludes 7 (25h ago).
+# issue-8 (watchdog_stall_continue with exit_code=124) tests the t3215
+# regression case — must count as wc, not of, despite non-zero exit.
+assert_eq "2c: total = 7" "7" "$(printf '%s' "$JSON" | jq -r '.metrics.total')"
+assert_eq "2d: succeeded = 2" "2" "$(printf '%s' "$JSON" | jq -r '.metrics.succeeded')"
+assert_eq "2e: watchdog_killed = 1" "1" "$(printf '%s' "$JSON" | jq -r '.metrics.watchdog_killed')"
+assert_eq "2f: watchdog_continued = 2 (incl. nonzero-exit heartbeat)" "2" \
+	"$(printf '%s' "$JSON" | jq -r '.metrics.watchdog_continued')"
+assert_eq "2g: rate_limited = 1" "1" "$(printf '%s' "$JSON" | jq -r '.metrics.rate_limited')"
+assert_eq "2h: other_failure = 1 (NOT 2 — heartbeat exclusion lock)" "1" \
+	"$(printf '%s' "$JSON" | jq -r '.metrics.other_failure')"
+
+# Pulse-stats counters (24h window: 25h-ago timestamp must be excluded).
+assert_eq "2i: circuit_broken = 2" "2" \
+	"$(printf '%s' "$JSON" | jq -r '.pulse_stats.pulse_dispatch_circuit_broken')"
+assert_eq "2j: gql_low = 1" "1" \
+	"$(printf '%s' "$JSON" | jq -r '.pulse_stats.pulse_cycle_skipped_graphql_low')"
+assert_eq "2k: missing key returns 0" "0" \
+	"$(printf '%s' "$JSON" | jq -r '.pulse_stats.dispatch_backoff_skipped')"
+assert_eq "2l: nwbreaker = 1" "1" \
+	"$(printf '%s' "$JSON" | jq -r '.pulse_stats.pulse_dispatch_no_work_breaker_tripped')"
+
+# PR check skipped → null + state=skipped.
+assert_eq "2m: pr count is null when skipped" "null" \
+	"$(printf '%s' "$JSON" | jq -r '.worker_prs.count')"
+assert_eq "2n: pr check_state = skipped" "skipped" \
+	"$(printf '%s' "$JSON" | jq -r '.worker_prs.check_state')"
+
+# ---------------------------------------------------------------------------
+# Section 3: 1h window narrows correctly.
+# ---------------------------------------------------------------------------
+echo
+echo "--- Section 3: 1h window ---"
+
+JSON=$(env "${RUN_ENV[@]}" "$HELPER" summary --since 1h --no-pr-check --json 2>&1)
+# 1h window: only events at 5min ago (issue-1, issue-4) qualify.
+assert_eq "3a: 1h total = 2" "2" "$(printf '%s' "$JSON" | jq -r '.metrics.total')"
+assert_eq "3b: 1h succeeded = 1" "1" "$(printf '%s' "$JSON" | jq -r '.metrics.succeeded')"
+assert_eq "3c: 1h watchdog_continued = 1" "1" \
+	"$(printf '%s' "$JSON" | jq -r '.metrics.watchdog_continued')"
+assert_eq "3d: 1h watchdog_killed = 0" "0" \
+	"$(printf '%s' "$JSON" | jq -r '.metrics.watchdog_killed')"
+
+# ---------------------------------------------------------------------------
+# Section 4: missing files fail-open to zeros.
+# ---------------------------------------------------------------------------
+echo
+echo "--- Section 4: missing-file resilience ---"
+
+JSON=$(env \
+	"WAH_METRICS_FILE=/nonexistent/metrics.jsonl" \
+	"WAH_PULSE_STATS_FILE=/nonexistent/stats.json" \
+	"WAH_PR_CACHE_FILE=$PR_CACHE" \
+	"$HELPER" summary --since 24h --no-pr-check --json 2>&1)
+RC=$?
+assert_rc "4a: missing files exits 0 (fail-open)" 0 "$RC"
+assert_eq "4b: missing metrics → total=0" "0" "$(printf '%s' "$JSON" | jq -r '.metrics.total')"
+assert_eq "4c: missing stats → counter=0" "0" \
+	"$(printf '%s' "$JSON" | jq -r '.pulse_stats.pulse_dispatch_circuit_broken')"
+
+# ---------------------------------------------------------------------------
+# Section 5: human-output legibility.
+# ---------------------------------------------------------------------------
+echo
+echo "--- Section 5: human-readable output ---"
+
+OUT=$(env "${RUN_ENV[@]}" "$HELPER" summary --since 24h --no-pr-check 2>&1)
+assert_contains "5a: human output names canonical jsonl source" \
+	"headless-runtime-metrics.jsonl" "$OUT"
+assert_contains "5b: human output names pulse-stats" "pulse-stats.json" "$OUT"
+assert_contains "5c: human output shows succeeded count" "Succeeded:                   2" "$OUT"
+assert_contains "5d: human output shows watchdog continued is heartbeat" \
+	"heartbeat" "$OUT"
+assert_contains "5e: human output shows --no-pr-check note" "--no-pr-check" "$OUT"
+
+# ---------------------------------------------------------------------------
+# Summary.
+# ---------------------------------------------------------------------------
+echo
+echo "${TEST_BLUE}=== Summary ===${TEST_NC}"
+echo "Tests run:    $TESTS_RUN"
+echo "Tests failed: $TESTS_FAILED"
+
+if [[ $TESTS_FAILED -eq 0 ]]; then
+	echo "${TEST_GREEN}All tests passed.${TEST_NC}"
+	exit 0
+else
+	echo "${TEST_RED}$TESTS_FAILED test(s) failed.${TEST_NC}"
+	exit 1
+fi

--- a/.agents/scripts/worker-activity-helper.sh
+++ b/.agents/scripts/worker-activity-helper.sh
@@ -1,0 +1,425 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# worker-activity-helper.sh — Canonical worker activity summary (t3215, GH#21949)
+#
+# One command that answers "are workers actually running and producing PRs?"
+# by reading the canonical sources in precedence order:
+#
+#   1. ~/.aidevops/logs/headless-runtime-metrics.jsonl
+#      Authoritative per-worker outcome record (success / watchdog_stall_killed /
+#      watchdog_stall_continue / rate_limit / other failure).
+#   2. ~/.aidevops/logs/pulse-stats.json
+#      Pulse-level dispatch counters (each value is an array of unix-second
+#      timestamps; query with `jq '.counters[<name>] // []'`).
+#   3. `gh pr list label:origin:worker --state all`
+#      External truth: did dispatched work actually become a PR?
+#
+# Replaces the misdiagnosis-prone habit of reading worker-NNN.log mtimes,
+# which was the exact mistake that triggered this task. mtime tells you when
+# the file was touched, not whether work succeeded; canonical sources tell you
+# the outcome.
+#
+# Usage:
+#   worker-activity-helper.sh summary [--since 1h|6h|24h|48h|7d]
+#                                     [--json]
+#                                     [--no-pr-check]
+#                                     [--repo OWNER/REPO]
+#   worker-activity-helper.sh help
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+
+# Source shared-constants for color helpers, _file_mtime_epoch (stat portability),
+# safe_grep_count (counter safety), and the bash-3.2 re-exec self-heal.
+# shellcheck source=shared-constants.sh
+source "${SCRIPT_DIR}/shared-constants.sh"
+
+# Path overrides (testing).
+WAH_METRICS_FILE="${WAH_METRICS_FILE:-${HOME}/.aidevops/logs/headless-runtime-metrics.jsonl}"
+WAH_PULSE_STATS_FILE="${WAH_PULSE_STATS_FILE:-${HOME}/.aidevops/logs/pulse-stats.json}"
+WAH_PR_CACHE_FILE="${WAH_PR_CACHE_FILE:-${HOME}/.aidevops/cache/worker-activity-prs.json}"
+WAH_PR_CACHE_TTL="${WAH_PR_CACHE_TTL:-60}" # seconds
+
+#######################################
+# Convert short window spec to seconds. Caller owns the cutoff math.
+# $1 — one of 1h | 6h | 24h | 48h | 7d
+# stdout — integer seconds, or empty + return 1 on bad input.
+#######################################
+_wah_parse_since() {
+	local spec="$1"
+	case "$spec" in
+	1h) printf '3600\n' ;;
+	6h) printf '21600\n' ;;
+	24h) printf '86400\n' ;;
+	48h) printf '172800\n' ;;
+	7d) printf '604800\n' ;;
+	*) return 1 ;;
+	esac
+	return 0
+}
+
+#######################################
+# Aggregate worker outcomes from headless-runtime-metrics.jsonl.
+# Single jq slurp pass: filter by ts cutoff, bucket by result + exit_code.
+# Bucketing lives entirely in jq (not awk) so we don't need positional
+# field references in shell. jsonl files are small (~MB), slurp is safe.
+#
+# $1 — cutoff_epoch (entries with ts < cutoff are dropped).
+# stdout — six space-separated integers:
+#   total succeeded watchdog_killed watchdog_continued rate_limited other_failure
+#######################################
+_wah_aggregate_metrics() {
+	local cutoff_epoch="$1"
+	local metrics="$WAH_METRICS_FILE"
+
+	if [[ ! -f "$metrics" ]]; then
+		printf '0 0 0 0 0 0\n'
+		return 0
+	fi
+
+	# Bucket semantics (must match the original awk fallthrough chain):
+	#   succ — result=="success" AND exit_code==0
+	#   wk   — result=="watchdog_stall_killed"   (terminal)
+	#   wc   — result=="watchdog_stall_continue" (heartbeat, NOT terminal)
+	#   rl   — result=="rate_limit"
+	#   of   — everything else (catches "premature_exit" and any new
+	#          failure result-name not yet enumerated; explicitly excludes
+	#          watchdog_stall_continue heartbeats even when their exit_code
+	#          is nonzero)
+	# Fail-open to zeros if jq fails (stale/corrupt jsonl).
+	local result
+	result=$(jq -rs --argjson cutoff "$cutoff_epoch" '
+		[.[] | select((.ts // 0) >= $cutoff)] as $w | {
+			total:  ($w | length),
+			succ:   ([$w[] | select(.result == "success" and .exit_code == 0)] | length),
+			wk:     ([$w[] | select(.result == "watchdog_stall_killed")] | length),
+			wc:     ([$w[] | select(.result == "watchdog_stall_continue")] | length),
+			rl:     ([$w[] | select(.result == "rate_limit")] | length),
+			of:     ([$w[] | select(
+				(.result != "success" or .exit_code != 0)
+				and .result != "watchdog_stall_killed"
+				and .result != "watchdog_stall_continue"
+				and .result != "rate_limit"
+			)] | length)
+		} | "\(.total) \(.succ) \(.wk) \(.wc) \(.rl) \(.of)"
+	' "$metrics" 2>/dev/null) || result="0 0 0 0 0 0"
+
+	[[ -n "$result" ]] || result="0 0 0 0 0 0"
+	printf '%s\n' "$result"
+	return 0
+}
+
+#######################################
+# Count pulse-stats counter entries since cutoff.
+# Counter values in pulse-stats.json are arrays of unix-second timestamps.
+# Reading via `// []` handles missing keys without masking real counts.
+#
+# $1 — counter name
+# $2 — cutoff_epoch
+# stdout — integer count (0 on missing file/key/jq failure).
+#######################################
+_wah_count_stats_counter() {
+	local key="$1" cutoff_epoch="$2"
+	local file="$WAH_PULSE_STATS_FILE"
+
+	if [[ ! -f "$file" ]]; then
+		printf '0\n'
+		return 0
+	fi
+
+	jq -r --arg key "$key" --argjson cutoff "$cutoff_epoch" \
+		'(.counters[$key] // []) | map(select(. >= $cutoff)) | length' \
+		"$file" 2>/dev/null || printf '0\n'
+}
+
+#######################################
+# Get PR count for `origin:worker` PRs created since `since_iso`.
+# Caches result for $WAH_PR_CACHE_TTL seconds to avoid hammering gh.
+#
+# $1 — since_iso (YYYY-MM-DDTHH:MM:SSZ)
+# $2 — repo_slug (optional; empty = current repo)
+# stdout — integer PR count, or "?" on gh failure.
+#######################################
+_wah_pr_count() {
+	local since_iso="$1" repo_slug="${2:-}"
+	local cache="$WAH_PR_CACHE_FILE"
+	local cache_key="${repo_slug:-current}|${since_iso}"
+
+	# Check cache freshness (portable mtime via shared-constants).
+	if [[ -f "$cache" ]]; then
+		local mtime now age cached_key cached_count
+		mtime=$(_file_mtime_epoch "$cache" 2>/dev/null) || mtime=0
+		now=$(date +%s)
+		age=$((now - mtime))
+		if [[ $age -lt $WAH_PR_CACHE_TTL ]]; then
+			cached_key=$(jq -r '.key // ""' "$cache" 2>/dev/null) || cached_key=""
+			if [[ "$cached_key" == "$cache_key" ]]; then
+				cached_count=$(jq -r '.count // "?"' "$cache" 2>/dev/null) || cached_count="?"
+				printf '%s\n' "$cached_count"
+				return 0
+			fi
+		fi
+	fi
+
+	# Cache miss — query gh (5s timeout via gh's own client).
+	local count gh_args=(pr list --search "created:>=${since_iso} label:origin:worker" --state all --limit 1000 --json number)
+	[[ -n "$repo_slug" ]] && gh_args+=(--repo "$repo_slug")
+	count=$(gh "${gh_args[@]}" 2>/dev/null | jq 'length' 2>/dev/null) || count="?"
+
+	# Best-effort cache write.
+	mkdir -p "$(dirname "$cache")" 2>/dev/null || true
+	if [[ "$count" != "?" ]]; then
+		printf '{"key":"%s","count":%s,"ts":%d}\n' "$cache_key" "$count" "$(date +%s)" \
+			>"$cache" 2>/dev/null || true
+	fi
+	printf '%s\n' "$count"
+	return 0
+}
+
+#######################################
+# Render summary in human-readable form.
+# All inputs are pre-formatted strings/integers from cmd_summary.
+#######################################
+_wah_emit_human() {
+	local since_label="$1" cutoff_iso="$2"
+	local total="$3" succ="$4" wk="$5" wc="$6" rl="$7" of="$8"
+	local cb="$9" gqlow="${10}" db_skip="${11}" nwbreaker="${12}"
+	local pr_count="${13}" pr_check_state="${14}" repo_label="${15}"
+
+	local divider="==========================================================="
+
+	# Compute success rate (terminal events only — exclude watchdog_continue
+	# which is a heartbeat sample, not a terminal outcome).
+	local terminal=$((succ + wk + rl + of))
+	local rate_pct="n/a"
+	if [[ $terminal -gt 0 ]]; then
+		rate_pct=$(awk -v s="$succ" -v t="$terminal" 'BEGIN{printf "%.0f%%", (s/t)*100}')
+	fi
+
+	printf '%s\n' "$divider"
+	printf 'Worker activity since %s (cutoff: %s)\n' "$since_label" "$cutoff_iso"
+	[[ -n "$repo_label" ]] && printf 'Repo: %s\n' "$repo_label"
+	printf '%s\n' "$divider"
+	printf '\n'
+	printf 'headless-runtime-metrics.jsonl (canonical worker outcomes):\n'
+	printf '  Total events:                %d\n' "$total"
+	printf '  Succeeded:                   %d  (%s of terminal)\n' "$succ" "$rate_pct"
+	printf '  Watchdog stall-killed:       %d\n' "$wk"
+	printf '  Watchdog stall-continued:    %d  (heartbeat, not terminal)\n' "$wc"
+	printf '  Rate-limited:                %d\n' "$rl"
+	printf '  Other failure:               %d\n' "$of"
+	printf '\n'
+	printf 'pulse-stats.json (dispatch-side counters):\n'
+	printf '  pulse_dispatch_circuit_broken:           %d\n' "$cb"
+	printf '  pulse_cycle_skipped_graphql_low:         %d\n' "$gqlow"
+	printf '  dispatch_backoff_skipped:                %d\n' "$db_skip"
+	printf '  pulse_dispatch_no_work_breaker_tripped:  %d\n' "$nwbreaker"
+	printf '\n'
+	printf 'origin:worker PRs created in window:\n'
+	printf '  %s' "$pr_count"
+	[[ "$pr_check_state" == "skipped" ]] && printf '  (--no-pr-check)'
+	[[ "$pr_check_state" == "failed" ]] && printf '  (gh query failed)'
+	printf '\n'
+	printf '%s\n' "$divider"
+	return 0
+}
+
+#######################################
+# Render summary in JSON. All inputs are pre-formatted scalars.
+#######################################
+_wah_emit_json() {
+	local since_label="$1" cutoff_iso="$2" cutoff_epoch="$3"
+	local total="$4" succ="$5" wk="$6" wc="$7" rl="$8" of="$9"
+	local cb="${10}" gqlow="${11}" db_skip="${12}" nwbreaker="${13}"
+	local pr_count="${14}" pr_check_state="${15}" repo_label="${16}"
+
+	# pr_count may be "?" on gh failure — coerce to null in JSON.
+	local pr_json="$pr_count"
+	[[ "$pr_count" == "?" ]] && pr_json="null"
+
+	jq -n \
+		--arg since "$since_label" \
+		--arg cutoff_iso "$cutoff_iso" \
+		--argjson cutoff_epoch "$cutoff_epoch" \
+		--argjson total "$total" \
+		--argjson succ "$succ" \
+		--argjson wk "$wk" \
+		--argjson wc "$wc" \
+		--argjson rl "$rl" \
+		--argjson of "$of" \
+		--argjson cb "$cb" \
+		--argjson gqlow "$gqlow" \
+		--argjson db_skip "$db_skip" \
+		--argjson nwbreaker "$nwbreaker" \
+		--argjson pr_count "$pr_json" \
+		--arg pr_check_state "$pr_check_state" \
+		--arg repo "$repo_label" \
+		'{
+			window: { since: $since, cutoff_iso: $cutoff_iso, cutoff_epoch: $cutoff_epoch },
+			repo: (if $repo == "" then null else $repo end),
+			metrics: {
+				total: $total,
+				succeeded: $succ,
+				watchdog_killed: $wk,
+				watchdog_continued: $wc,
+				rate_limited: $rl,
+				other_failure: $of
+			},
+			pulse_stats: {
+				pulse_dispatch_circuit_broken: $cb,
+				pulse_cycle_skipped_graphql_low: $gqlow,
+				dispatch_backoff_skipped: $db_skip,
+				pulse_dispatch_no_work_breaker_tripped: $nwbreaker
+			},
+			worker_prs: { count: $pr_count, check_state: $pr_check_state }
+		}'
+	return 0
+}
+
+#######################################
+# Orchestrate one summary run. Parses args, calls aggregators, dispatches
+# to the right emitter.
+#######################################
+cmd_summary() {
+	local since_label="24h" emit_json=0 do_pr_check=1 repo_label=""
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+		--since)
+			since_label="${2:-}"
+			shift 2
+			;;
+		--json)
+			emit_json=1
+			shift
+			;;
+		--no-pr-check)
+			do_pr_check=0
+			shift
+			;;
+		--repo)
+			repo_label="${2:-}"
+			shift 2
+			;;
+		-h | --help)
+			cmd_help
+			return 0
+			;;
+		*)
+			printf 'unknown flag: %s\n' "$arg" >&2
+			return 2
+			;;
+		esac
+	done
+
+	local since_seconds
+	since_seconds=$(_wah_parse_since "$since_label") || {
+		printf 'invalid --since value: %s (use 1h|6h|24h|48h|7d)\n' "$since_label" >&2
+		return 2
+	}
+
+	local now_epoch cutoff_epoch cutoff_iso
+	now_epoch=$(date +%s)
+	cutoff_epoch=$((now_epoch - since_seconds))
+	cutoff_iso=$(date -u -r "$cutoff_epoch" +'%Y-%m-%dT%H:%M:%SZ' 2>/dev/null) ||
+		cutoff_iso=$(date -u -d "@${cutoff_epoch}" +'%Y-%m-%dT%H:%M:%SZ' 2>/dev/null) ||
+		cutoff_iso="(unknown)"
+
+	# Aggregate metrics (single jq+awk pass).
+	local agg total succ wk wc rl of
+	agg=$(_wah_aggregate_metrics "$cutoff_epoch")
+	read -r total succ wk wc rl of <<<"$agg"
+
+	# Pulse-stats counters.
+	local cb gqlow db_skip nwbreaker
+	cb=$(_wah_count_stats_counter "pulse_dispatch_circuit_broken" "$cutoff_epoch")
+	gqlow=$(_wah_count_stats_counter "pulse_cycle_skipped_graphql_low" "$cutoff_epoch")
+	db_skip=$(_wah_count_stats_counter "dispatch_backoff_skipped" "$cutoff_epoch")
+	nwbreaker=$(_wah_count_stats_counter "pulse_dispatch_no_work_breaker_tripped" "$cutoff_epoch")
+
+	# PR count (optional, network-dependent).
+	local pr_count="?" pr_check_state="ok"
+	if [[ $do_pr_check -eq 1 ]]; then
+		pr_count=$(_wah_pr_count "$cutoff_iso" "$repo_label")
+		[[ "$pr_count" == "?" ]] && pr_check_state="failed"
+	else
+		pr_count="?"
+		pr_check_state="skipped"
+	fi
+
+	if [[ $emit_json -eq 1 ]]; then
+		_wah_emit_json "$since_label" "$cutoff_iso" "$cutoff_epoch" \
+			"$total" "$succ" "$wk" "$wc" "$rl" "$of" \
+			"$cb" "$gqlow" "$db_skip" "$nwbreaker" \
+			"$pr_count" "$pr_check_state" "$repo_label"
+	else
+		_wah_emit_human "$since_label" "$cutoff_iso" \
+			"$total" "$succ" "$wk" "$wc" "$rl" "$of" \
+			"$cb" "$gqlow" "$db_skip" "$nwbreaker" \
+			"$pr_count" "$pr_check_state" "$repo_label"
+	fi
+	return 0
+}
+
+#######################################
+# Help text.
+#######################################
+cmd_help() {
+	cat <<'EOF'
+worker-activity-helper.sh — Canonical worker activity summary
+
+Usage:
+  worker-activity-helper.sh summary [OPTIONS]
+  worker-activity-helper.sh help
+
+Options:
+  --since 1h|6h|24h|48h|7d   Lookback window (default: 24h)
+  --json                     Emit machine-readable JSON
+  --no-pr-check              Skip the gh PR query (offline / rate-limited)
+  --repo OWNER/REPO          Constrain PR query to a single repo
+
+Sources read (in canonical-precedence order):
+  1. ~/.aidevops/logs/headless-runtime-metrics.jsonl  (worker outcomes)
+  2. ~/.aidevops/logs/pulse-stats.json                (dispatch counters)
+  3. gh pr list label:origin:worker                   (external truth)
+
+Examples:
+  # Last 24 hours, human-readable.
+  worker-activity-helper.sh summary
+
+  # Last 6 hours as JSON.
+  worker-activity-helper.sh summary --since 6h --json
+
+  # Last 7 days, single repo, no network call.
+  worker-activity-helper.sh summary --since 7d --repo marcusquinn/aidevops --no-pr-check
+
+NOT a substitute for:
+  - worker-NNN.log mtime → file touch time, not outcome.
+  - pgrep -fc 'headless-runtime-helper.sh run' → live worker count.
+  - pulse-runner-health-helper.sh diagnose → per-runner zero-attempt breaker.
+
+Filed under: t3215 / GH#21949
+EOF
+	return 0
+}
+
+#######################################
+# main — dispatch on subcommand.
+#######################################
+main() {
+	local cmd="${1:-help}"
+	[[ $# -gt 0 ]] && shift
+	case "$cmd" in
+	summary) cmd_summary "$@" ;;
+	help | -h | --help) cmd_help ;;
+	*)
+		printf 'unknown command: %s\n' "$cmd" >&2
+		cmd_help >&2
+		return 2
+		;;
+	esac
+}
+
+main "$@"


### PR DESCRIPTION
## Summary

Adds a single command — `worker-activity-helper.sh summary` — that answers "are workers actually running and producing PRs?" by reading the canonical sources (`headless-runtime-metrics.jsonl` + `pulse-stats.json` + `gh pr list label:origin:worker`) instead of inferring from `worker-NNN.log` mtimes. The mtime-as-proof habit produced the exact misdiagnosis that triggered this task: a session reported "0 workers in 48h" while canonical sources showed **28 successful workers and 49 PRs** in the same window.

## What changes

- **NEW**: `.agents/scripts/worker-activity-helper.sh` (~280 lines) — `summary [--since 1h|6h|24h|48h|7d] [--json] [--no-pr-check] [--repo OWNER/REPO]` and `help`. Bucket semantics match the original awk fallthrough chain (result-name based, not exit-code based — t3215 regression case).
- **NEW**: `.agents/scripts/tests/test-worker-activity-helper.sh` (~250 lines) — 33 fixture-driven assertions covering 1h/24h windows, missing-file fail-open, JSON parseability, human-output legibility, and the watchdog-stall-continue-with-nonzero-exit regression case.
- **EDIT**: `.agents/AGENTS.md` — adds **"Pulse activity verification (canonical sources, t3215)"** rule under Framework Rules. Numbered precedence list (helper → jsonl → pulse-stats → gh PR query → opencode/Claude session DBs) plus an explicit "NOT canonical sources" list (mtime, pgrep, recent-comment-search). Sits alongside t2204 (Attribution before verification) since both fire at the diagnosis-publish step.

## Why

Single-command verification is the framework defense against this misdiagnosis class — without it, every productivity-question session has to relearn which files to read in what order. The AGENTS.md rule + the helper close the loop: rule says what to use, helper makes it cheap to use.

## Verification

Lint:

```
shellcheck .agents/scripts/worker-activity-helper.sh                # clean
shellcheck .agents/scripts/tests/test-worker-activity-helper.sh     # clean
```

Tests:

```
bash .agents/scripts/tests/test-worker-activity-helper.sh
# Tests run: 33 / Tests failed: 0 / All tests passed.
```

Real-data smoke (against my live `~/.aidevops/logs`):

```
worker-activity-helper.sh summary --since 24h --repo marcusquinn/aidevops
# Total events: 36 / Succeeded: 28 (85%) / Watchdog killed: 2 /
# Watchdog continued: 3 (heartbeat) / Other: 3 / Circuit broken: 40 /
# origin:worker PRs in 24h: 49
```

The numbers are the falsification evidence for the original "0 in 48h" claim: workers are running heavily, the *real* productivity question is the PR-merge ratio (~12% on the 24h window), not dispatch.

## Files Scope

- `.agents/scripts/worker-activity-helper.sh` (new)
- `.agents/scripts/tests/test-worker-activity-helper.sh` (new)
- `.agents/AGENTS.md` (edit — single rule insertion)

## Notes for reviewers

- Counter-array reads use `jq '.counters[$key] // []'` — the `// []` is mandatory, otherwise missing keys collapse to null and `length` returns 0 (the exact failure that caused the misdiagnosis). Inline comment in the helper notes this.
- Bucketing is in jq, not awk. An earlier draft used awk and tripped the framework's "direct positional parameter usage" ratchet on the `$1`/`$2` field references (false-positive class). Pure jq is also more readable here.
- Pre-existing markdownlint errors at lines 422, 506, 507, 737 of `.agents/AGENTS.md` are not introduced by this PR (verified with `git stash` + `markdownlint-cli2` pre-edit).

Resolves #21949


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.16 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-opus-4-7 spent 2h 45m and 102,106 tokens on this with the user in an interactive session.
