### PR TITLE
t3211: detect & escalate Actions runner queue saturation in stuck-merge detector

### DIFF
--- a/.agents/configs/pulse-rate-limit.conf
+++ b/.agents/configs/pulse-rate-limit.conf
@@ -130,3 +130,46 @@ AIDEVOPS_GH_WRITE_TIMEOUT=45
 # Set to 0 to disable the tickle and always run batch search unconditionally.
 # Env var PULSE_EVENTS_TICKLE_ENABLED takes precedence if already set.
 PULSE_EVENTS_TICKLE_ENABLED=1
+
+# ── GitHub Actions runner queue saturation (t3211, GH#21942) ──────────────────
+#
+# Detects when the GitHub Actions runner pool for a repo is saturated — many
+# more workflow runs queued than in-progress — which causes pulse-merge-stuck
+# to misclassify per-PR QUEUED checks as individual stuck states. When
+# saturation is detected, per-PR escalations for affected PRs are SUPPRESSED
+# and a single repo-level meta-issue is filed instead.
+#
+# Distinct from t2690 (GraphQL points circuit breaker): GraphQL points and
+# Actions runner-minutes are independent GitHub resource pools. Hitting one
+# does not imply hitting the other.
+#
+# Saturation criteria (BOTH must hold):
+#   - queued > AIDEVOPS_ACTIONS_QUEUE_SATURATION_QUEUED_MIN
+#   - queued / max(in_progress, 1) > AIDEVOPS_ACTIONS_QUEUE_SATURATION_RATIO_MIN
+#
+# Both conditions are required to avoid false positives during light load
+# (e.g., 10 queued / 0 in_progress is just an idle period, not saturation).
+#
+# Default thresholds (queued > 50 AND ratio > 10) chosen against the canonical
+# 2026-04-30 incident in marcusquinn/aidevops: 110 queued / 3 in_progress
+# (ratio 36) — sustained for 17+ min, blocked PR #21915 Maintainer Gate.
+#
+# Endpoint: gh api repos/{slug}/actions/runs?status={queued,in_progress}
+# Cost: REST core pool (5000/hr), independent of GraphQL budget.
+#
+# Env var overrides take precedence over these values:
+#   AIDEVOPS_ACTIONS_QUEUE_SATURATION_QUEUED_MIN  — minimum queued runs
+#   AIDEVOPS_ACTIONS_QUEUE_SATURATION_RATIO_MIN   — minimum queued/in_progress ratio
+#   AIDEVOPS_SKIP_ACTIONS_QUEUE_SATURATION=1      — emergency bypass
+#
+# Set QUEUED_MIN=0 to disable saturation detection entirely (the function
+# returns saturated=0 unconditionally).
+
+# Minimum queued workflow runs for saturation. Below this, never saturated
+# regardless of the ratio.
+AIDEVOPS_ACTIONS_QUEUE_SATURATION_QUEUED_MIN=50
+
+# Minimum integer ratio of queued / max(in_progress, 1) for saturation.
+# Below this, traffic is assumed normal even with high absolute queue depth
+# (large in-progress count means the runner pool is keeping up).
+AIDEVOPS_ACTIONS_QUEUE_SATURATION_RATIO_MIN=10

--- a/.agents/reference/pulse-merge-stuck.md
+++ b/.agents/reference/pulse-merge-stuck.md
@@ -1,7 +1,7 @@
 <!-- SPDX-License-Identifier: MIT -->
 <!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
 
-# Stuck-merge detector and zero-progress circuit breaker (t3193, GH#21895)
+# Stuck-merge detector and zero-progress circuit breaker (t3193, t3211, GH#21895, GH#21942)
 
 The pulse merge pass historically had two narrow nudges (rebase reminders for
 `origin:interactive` PRs in conflict, fix-worker dispatch for `origin:worker`
@@ -9,6 +9,16 @@ PRs in conflict) but no general detector for PRs that pass `APPROVED +
 MERGEABLE` yet sit unmerged for hours. The 2026-04-30 incident in a managed
 private webapp repo — 8 PRs stuck 9-29h, six sharing identical Setup-step CI
 failures — is the canonical case this module addresses.
+
+A second 2026-04-30 incident exposed a complementary failure mode: a
+runner-queue saturation event (110 queued workflow runs / 3 in-progress on
+`marcusquinn/aidevops`) left several PRs with `Maintainer Gate` checks
+permanently in `QUEUED` state. The detector previously misclassified these
+as `STUCK_OTHER` (the QUEUED state is not a FAILURE so the rollup gate did
+not fire) and would have escalated each PR individually. t3211 adds the
+`STUCK_RUNNER_QUEUE_SATURATION` classification + meta-issue routing so a
+runner outage produces ONE investigation issue with operator-grade context,
+not N noisy per-PR escalations against a cause the PR author cannot fix.
 
 ## What it does
 
@@ -36,7 +46,8 @@ Once per pulse cycle (~120s), per repo, after the deterministic merge pass:
 
 | Class | Trigger | Action |
 | --- | --- | --- |
-| `STUCK_CHECKS_FAILING` | ≥1 FAILURE in `statusCheckRollup`, no conflict | Per-PR escalation |
+| `STUCK_RUNNER_QUEUE_SATURATION` | Per-cycle `_check_actions_queue_saturation` reports `saturated=1` (queued > 50 AND queued/max(in_progress,1) > 10) AND the PR's rollup contains ≥1 check with `.status=QUEUED` (not yet started) | Aggregated to a SINGLE `<!-- merge-stuck:runner-queue-saturation -->` meta-issue per repo per cycle; per-PR escalations SUPPRESSED for the duration of the outage. Takes priority over `STUCK_CHECKS_FAILING` because QUEUED checks are the proximate cause; FAILURE entries during a runner outage are downstream symptoms. |
+| `STUCK_CHECKS_FAILING` | ≥1 FAILURE in `statusCheckRollup`, no conflict, repo NOT saturated | Per-PR escalation |
 | `STUCK_CONFLICT_NO_NUDGE_LABEL` | `mergeable=CONFLICTING` + neither `origin:interactive` nor `origin:worker` (gap in the existing rebase-nudge family) | Idempotent rebase nudge using `<!-- pulse-rebase-nudge -->` so it cannot double-fire alongside the per-label nudges |
 | `STUCK_BRANCHPROTECT_404` | Default branch has no protection rules — `_check_required_checks_passing` historically failed closed (t2922) on the 404 | Counter increment only; the actual fix is in `pulse-merge-process.sh` (see "404 distinction" below) |
 | `STUCK_BRANCHPROTECT_API_ERROR` | 5xx / network from the protection API | Counter increment only — transient, retry next cycle |
@@ -54,6 +65,9 @@ take precedence (set in `~/.aidevops/.env` or shell):
 | `AIDEVOPS_MERGE_ZERO_PROGRESS_CYCLES` | `5` | Consecutive zero-progress cycles before the framework-level meta-issue fires. |
 | `AIDEVOPS_MERGE_PATTERN_MIN_PRS` | `3` | Minimum stuck PRs sharing one fingerprint before an outage meta-issue fires. |
 | `AIDEVOPS_MERGE_STUCK_ENABLED` | `1` | Master kill-switch (set to `0` to disable the entire module). |
+| `AIDEVOPS_ACTIONS_QUEUE_SATURATION_QUEUED_MIN` | `50` | Minimum absolute queued workflow runs before saturation is even considered. Set to `0` to disable saturation detection entirely (per-PR escalation behaviour for QUEUED checks reverts to pre-t3211). |
+| `AIDEVOPS_ACTIONS_QUEUE_SATURATION_RATIO_MIN` | `10` | Minimum `queued / max(in_progress,1)` ratio that, combined with the absolute minimum above, classifies the repo as saturated. Both conditions must hold — either alone is a false-positive (light-load bursts hit absolute counts; healthy busy periods hit ratio with the runner pool already serving). |
+| `AIDEVOPS_SKIP_ACTIONS_QUEUE_SATURATION` | unset | Emergency bypass for the per-cycle saturation probe. When `1`, the helper short-circuits to `saturated=0` without making any `gh api` call. Use only if the saturation probe itself is degrading the pulse (e.g. severe REST rate-limit pressure). |
 
 ## 404 distinction in `_check_required_checks_passing`
 
@@ -78,6 +92,7 @@ Each escalation uses an idempotent HTML marker so repeat cycles do not spam:
 | `<!-- merge-stuck:individual -->` | Issue (or PR) comment | One per linked issue. Survives repeat stuck cycles. A new cycle on a different stuck PR linked to the same issue will not re-fire. |
 | `<!-- merge-stuck:pattern:<hash16> -->` | Outage meta-issue body | One per failure fingerprint (sorted FAILURE check names, sha256 first 16 hex chars). Different outage signatures get different issues. |
 | `<!-- merge-stuck:zero-progress -->` | Framework meta-issue body | One per active streak. Reset by any successful merge. |
+| `<!-- merge-stuck:runner-queue-saturation -->` | Runner-saturation meta-issue body | One per repo per saturation event. Dedup uses `gh issue list --search` against the marker so a still-saturated repo on the next cycle does not re-file. The counter `pulse_actions_queue_saturation_events` increments even on dedup-skip so operator graphs reflect the true incident count. |
 | `<!-- pulse-rebase-nudge -->` | Reused from existing nudge family | Reused so `STUCK_CONFLICT_NO_NUDGE_LABEL` cannot double-fire alongside `_post_rebase_nudge_on_*`. |
 
 ## Counters added
@@ -90,6 +105,7 @@ All four are written to `~/.aidevops/logs/pulse-stats.json`:
 | `pulse_merge_zero_progress_cycles` | Gauge | Reset to 0 on any successful merge |
 | `pulse_merge_branchprotect_404_skips` | Event counter | 24h rolling window (per t2424 pattern) |
 | `pulse_merge_stuck_escalations_filed` | Event counter | 24h rolling window |
+| `pulse_actions_queue_saturation_events` | Event counter | 24h rolling window (per t2424 pattern). Increments once per repo per cycle that classifies as saturated, including cycles where the meta-issue is dedup-suppressed. Use this to graph saturation duration; pair with `pulse_merge_stuck_escalations_filed` to see what fraction of stuck PRs the saturation suppression caught. |
 
 The first two use the new `pulse_stats_set_gauge` / `pulse_stats_get_gauge`
 functions in `pulse-stats-helper.sh` — gauges store under `.gauges.<name>`
@@ -104,6 +120,56 @@ filing a "pulse made no progress" investigation when the circuit breaker is
 already advertising its own cause would only create noise. The per-PR
 escalations and pattern-outage meta-issues are NOT suppressed; they remain
 useful even during a rate-limit event.
+
+## Suppression: runner-queue saturation (t3211)
+
+When a repo is classified as saturated (per `_check_actions_queue_saturation`
+in `pulse-rate-limit-circuit-breaker.sh`), per-PR escalation is suppressed
+for every PR whose stuck class is `STUCK_RUNNER_QUEUE_SATURATION`. Instead,
+the matching PR numbers are aggregated into a single repo-level meta-issue
+filed via `_pms_file_runner_saturation_issue`. Rationale:
+
+- The cause is **infrastructure-side** (GitHub Actions hosted-runner
+  contention or workflow-level concurrency dynamics), not anything the PR
+  authors can fix on their PR. Per-PR comments would be misleading
+  ("rebuild your branch" / "fix your tests" guidance is wrong here).
+- N comments on N PRs all naming the same operator action ("triage Actions
+  queue") wastes operator attention and PR thread space.
+- The meta-issue body lists every saturation-stuck PR for that cycle, the
+  operator runbook, and the verification command — a single triageable
+  artifact instead of an N-tab cleanup.
+
+Saturation detection uses an integer ratio (Bash 3.2 has no float arith);
+precision floor is "ratio≥1", well below the threshold of 10. The check is
+called once per cycle per repo (NOT once per PR) so REST-budget cost is
+2 cheap calls per repo with `per_page=1`.
+
+### Runbook
+
+When the meta-issue fires, the operator triage steps are:
+
+```bash
+# 1. Confirm the saturation reading.
+gh api "repos/${repo_slug}/actions/runs?status=queued&per_page=1" --jq '.total_count'
+gh api "repos/${repo_slug}/actions/runs?status=in_progress&per_page=1" --jq '.total_count'
+
+# 2. List the queued runs grouped by workflow to find the runaway pattern.
+gh api "repos/${repo_slug}/actions/runs?status=queued&per_page=100" \
+  --jq '[.workflow_runs[] | .name] | group_by(.) | map({workflow:.[0], queued:length}) | sort_by(-.queued)'
+
+# 3. Cancel a runaway workflow's queued runs (one example).
+gh api "repos/${repo_slug}/actions/runs?status=queued&per_page=100" \
+  --json databaseId,workflowName --jq '.[] | select(.workflowName=="<runaway>") | .databaseId' \
+  | xargs -I {} gh api -X POST "repos/${repo_slug}/actions/runs/{}/cancel"
+```
+
+Saturation ends when both `gh api ".../actions/runs?status=queued&per_page=1" --jq '.total_count'`
+falls back below `AIDEVOPS_ACTIONS_QUEUE_SATURATION_QUEUED_MIN` (default 50)
+**and** the `queued / in_progress` ratio falls below
+`AIDEVOPS_ACTIONS_QUEUE_SATURATION_RATIO_MIN` (default 10). At that point
+the next cycle classifies the repo as not-saturated, per-PR escalation
+resumes for any genuinely-stuck PRs, and the saturation meta-issue can be
+closed.
 
 ## Disabling
 
@@ -124,9 +190,36 @@ Set `AIDEVOPS_MERGE_STUCK_ENABLED=0` in your env. The module's entry point
   no-op on idle, increment on stuck cycle)
 - shellcheck cleanliness on the module + the stats helper
 
-Functions that require live GitHub API (`_classify_stuck_pr`,
-`_escalate_individual_stuck_pr`, `pulse_merge_stuck_run_pass`,
-`_pms_count_eligible_unmerged_for_repo`) are not unit-tested — they're
+`.agents/scripts/tests/test-actions-queue-saturation.sh` covers (t3211):
+
+- `_check_actions_queue_saturation` boundary cases against canonical incident
+  shape (110q/3ip), light load, busy/healthy ratio, threshold edges,
+  zero-in_progress denominator clamp
+- fail-open semantics on gh-api error (rc=2, saturated=0)
+- bypass + disable controls (`AIDEVOPS_SKIP_ACTIONS_QUEUE_SATURATION=1`,
+  `AIDEVOPS_ACTIONS_QUEUE_SATURATION_QUEUED_MIN=0`)
+- env-var threshold overrides take precedence over conf defaults
+- `_classify_stuck_pr` returns `STUCK_RUNNER_QUEUE_SATURATION` when
+  `is_saturated=1` AND rollup contains a QUEUED check; falls through to
+  `STUCK_CHECKS_FAILING` when saturation absent and FAILURE present;
+  saturation classification takes priority over FAILURE in mixed rollups
+- shellcheck cleanliness on `pulse-rate-limit-circuit-breaker.sh`
+
+The test uses a `gh` PATH shim that emulates `gh api` and `gh pr view` —
+the shim respects `--jq` filters via local `jq` evaluation so the helper's
+own jq pipeline behaves identically to a real-API call. Implementation
+notes (avoid the same footguns when extending the test): (1) shim env vars
+must be **exported** before the function call, not prefix-assigned via
+`VAR=val out=$(fn)`; (2) `eval "export VAR=$value"` mangles JSON values via
+brace-expansion — split on `=` and call `export "$key"="$val"` directly;
+(3) `${VAR:-{}}` collides with parameter-expansion delimiters — use an
+intermediate `default='{}'; "${VAR:-$default}"`; (4) source the helper
+then `set +e` because `set -euo pipefail` is inherited and aborts the
+test process on deliberate non-zero return codes.
+
+Functions that require live GitHub API (`_escalate_individual_stuck_pr`,
+`pulse_merge_stuck_run_pass`, `_pms_count_eligible_unmerged_for_repo`,
+`_pms_file_runner_saturation_issue`) are not unit-tested — they're
 integration-level and exercise live PRs each pulse cycle.
 
 ## Related
@@ -135,9 +228,16 @@ integration-level and exercise live PRs each pulse cycle.
   in via `merge_ready_prs_all_repos`.
 - `pulse-merge-conflict.sh` — the existing per-label rebase-nudge family.
 - `pulse-merge-feedback.sh` — the conflict-feedback dispatch path.
+- `pulse-rate-limit-circuit-breaker.sh` — hosts `_check_actions_queue_saturation`
+  (t3211); also home of the GraphQL rate-limit breaker (t2690).
 - `reference/auto-merge.md` — full merge-gate semantics.
 - `reference/cross-runner-coordination.md` — pulse cycle infrastructure.
 - t2922 — the original fail-closed change in `_check_required_checks_passing`
   that t3193 partially tightens.
 - t2690 — the pulse dispatch circuit breaker that suppresses the
   zero-progress meta-issue.
+- t3193 — the parent stuck-merge detector that t3211 extends.
+- t3211 / GH#21942 — runner-queue saturation classification + meta-issue
+  routing (this section).
+- t2574 / t2689 / t2902 — REST-fallback layers that run alongside the
+  saturation check; both helpers live in the same module.

--- a/.agents/scripts/pulse-merge-stuck.sh
+++ b/.agents/scripts/pulse-merge-stuck.sh
@@ -657,46 +657,17 @@ Filed automatically by \`pulse-merge-stuck.sh\` (t3193) on detecting a pattern o
 #   $5 - affected_prs (comma-separated PR numbers blocked by saturation)
 #   $6 - count (length of affected_prs list)
 #######################################
-_pms_file_runner_saturation_issue() {
-	local repo_slug="$1"
-	local queued="$2"
-	local in_progress="$3"
-	local ratio="$4"
-	local affected_prs="$5"
-	local count="$6"
-
-	[[ -n "$repo_slug" ]] || return 0
-	[[ "$queued" =~ ^[0-9]+$ ]] || queued=0
-	[[ "$in_progress" =~ ^[0-9]+$ ]] || in_progress=0
-	[[ "$ratio" =~ ^[0-9]+$ ]] || ratio=0
-	[[ "$count" =~ ^[0-9]+$ ]] || count=0
-
-	local marker_text="${_PMS_RUNNER_SATURATION_MARKER_TEXT}"
-	local marker="<!-- ${marker_text} -->"
-
-	# Dedup: search for an OPEN issue with this marker in the affected repo.
-	# The same repo's saturation events may recur over hours but only one
-	# meta-issue stays open at a time — operators close it after triaging.
-	local existing
-	existing=$(gh issue list --repo "$repo_slug" --state open --search "${marker_text}" \
-		--limit 1 --json number --jq '.[0].number' 2>/dev/null)
-	if [[ -n "$existing" && "$existing" != "$_PMS_JQ_NULL_GUARD" ]]; then
-		echo "[pulse-merge-stuck] _pms_file_runner_saturation_issue: marker already filed as #${existing} in ${repo_slug} — skipping" >>"$LOGFILE"
-		# Still increment the events counter — saturation IS happening, even
-		# if the meta-issue dedup prevents a fresh filing. This way operators
-		# can correlate counter spikes with saturation incidents even when
-		# only one meta-issue exists.
-		pulse_stats_increment "$_PMS_COUNTER_QUEUE_SATURATION_EVENTS"
-		return 0
-	fi
-
-	# Compose the meta-issue body. tier:thinking + bug + auto-dispatch matches
-	# the _pms_file_outage_issue convention; source:merge-stuck-detector
-	# routes the issue to operators familiar with the detector module.
-	local title="merge-stuck: GitHub Actions runner queue saturated (${queued} queued / ${in_progress} in-progress) in ${repo_slug}"
-
-	# Use read -r -d '' for bash 3.2 portability — see _escalate_individual_stuck_pr
-	# for the rationale (heredoc-in-subshell is not bash 3.2 compatible).
+# Compose the meta-issue body for runner-saturation. Extracted from
+# _pms_file_runner_saturation_issue to keep the caller under the 100-line
+# function-complexity gate. The heredoc itself is the bulk of the work;
+# isolating it here also makes the body easier to update without
+# perturbing the dedup/file/metrics control flow above.
+#
+# Echoes the composed body to stdout. Caller captures via $().
+_pms_compose_runner_saturation_body() {
+	local marker="$1" repo_slug="$2" queued="$3" in_progress="$4"
+	local ratio="$5" affected_prs="$6" count="$7"
+	# read -r -d '' for bash 3.2 portability (heredoc-in-subshell unsupported).
 	local body=""
 	IFS='' read -r -d '' body <<EOF || true
 ${marker}
@@ -786,6 +757,49 @@ Filed automatically by \`pulse-merge-stuck.sh\` (t3211 / GH#21942) on detecting 
 
 <sub>Source: pulse-merge-stuck-detector. Threshold env: \`AIDEVOPS_ACTIONS_QUEUE_SATURATION_QUEUED_MIN=${AIDEVOPS_ACTIONS_QUEUE_SATURATION_QUEUED_MIN:-50}\`, \`AIDEVOPS_ACTIONS_QUEUE_SATURATION_RATIO_MIN=${AIDEVOPS_ACTIONS_QUEUE_SATURATION_RATIO_MIN:-10}\`.</sub>
 EOF
+	printf '%s' "$body"
+	return 0
+}
+
+_pms_file_runner_saturation_issue() {
+	local repo_slug="$1"
+	local queued="$2"
+	local in_progress="$3"
+	local ratio="$4"
+	local affected_prs="$5"
+	local count="$6"
+
+	[[ -n "$repo_slug" ]] || return 0
+	[[ "$queued" =~ ^[0-9]+$ ]] || queued=0
+	[[ "$in_progress" =~ ^[0-9]+$ ]] || in_progress=0
+	[[ "$ratio" =~ ^[0-9]+$ ]] || ratio=0
+	[[ "$count" =~ ^[0-9]+$ ]] || count=0
+
+	local marker_text="${_PMS_RUNNER_SATURATION_MARKER_TEXT}"
+	local marker="<!-- ${marker_text} -->"
+
+	# Dedup: search for an OPEN issue with this marker in the affected repo.
+	# The same repo's saturation events may recur over hours but only one
+	# meta-issue stays open at a time — operators close it after triaging.
+	local existing
+	existing=$(gh issue list --repo "$repo_slug" --state open --search "${marker_text}" \
+		--limit 1 --json number --jq '.[0].number' 2>/dev/null)
+	if [[ -n "$existing" && "$existing" != "$_PMS_JQ_NULL_GUARD" ]]; then
+		echo "[pulse-merge-stuck] _pms_file_runner_saturation_issue: marker already filed as #${existing} in ${repo_slug} — skipping" >>"$LOGFILE"
+		# Still increment the events counter — saturation IS happening, even
+		# if the meta-issue dedup prevents a fresh filing. This way operators
+		# can correlate counter spikes with saturation incidents even when
+		# only one meta-issue exists.
+		pulse_stats_increment "$_PMS_COUNTER_QUEUE_SATURATION_EVENTS"
+		return 0
+	fi
+
+	# Compose the meta-issue body via the dedicated composer (extracted to
+	# keep this function under the function-complexity gate).
+	local title="merge-stuck: GitHub Actions runner queue saturated (${queued} queued / ${in_progress} in-progress) in ${repo_slug}"
+	local body
+	body=$(_pms_compose_runner_saturation_body "$marker" "$repo_slug" \
+		"$queued" "$in_progress" "$ratio" "$affected_prs" "$count")
 
 	# Wrapper-only — see _pms_file_outage_issue rationale above.
 	if ! declare -F gh_create_issue >/dev/null 2>&1; then
@@ -793,6 +807,9 @@ EOF
 		return 0
 	fi
 
+	# tier:thinking + bug + auto-dispatch matches the _pms_file_outage_issue
+	# convention; source:merge-stuck-detector routes the issue to operators
+	# familiar with the detector module.
 	local labels="auto-dispatch,tier:thinking,bug,source:merge-stuck-detector"
 	gh_create_issue --repo "$repo_slug" \
 		--title "$title" \
@@ -955,6 +972,97 @@ _pms_count_eligible_unmerged_for_repo() {
 # Args: $1 = repo_slug
 # Returns: 0 always (instrumentation must not break the pulse)
 #######################################
+#######################################
+# Compute Actions runner-queue saturation state for ONE repo per cycle.
+# Extracted from pulse_merge_stuck_run_pass (t3211 / GH#21942) to keep
+# the caller under the function-complexity gate.
+#
+# Echoes 4 lines (KEY=VALUE) the caller parses with grep+cut:
+#   queued=N
+#   in_progress=N
+#   ratio=N
+#   saturated=0|1
+#
+# Fails open if the upstream helper is unavailable (partial deploy):
+# echoes the safe defaults (all zeros, saturated=0) so the caller's
+# downstream logic degrades to pre-t3211 behaviour.
+#######################################
+_pms_compute_saturation_state() {
+	local repo_slug="$1"
+
+	if ! declare -F _check_actions_queue_saturation >/dev/null 2>&1; then
+		printf 'queued=0\nin_progress=0\nratio=0\nsaturated=0\n'
+		return 0
+	fi
+
+	local saturation_output=""
+	saturation_output=$(_check_actions_queue_saturation "$repo_slug" 2>/dev/null) || saturation_output=""
+	if [[ -z "$saturation_output" ]]; then
+		printf 'queued=0\nin_progress=0\nratio=0\nsaturated=0\n'
+		return 0
+	fi
+
+	# Pass through the helper's output verbatim — it already emits the
+	# canonical KEY=VALUE format and validates each value against the
+	# integer range.
+	printf '%s' "$saturation_output"
+	return 0
+}
+
+#######################################
+# Classify ONE eligible-stuck PR and dispatch the matching handler.
+# Extracted from pulse_merge_stuck_run_pass (t3211 / GH#21942) to keep
+# the caller under the function-complexity gate.
+#
+# Echoes a routing tag the caller uses to decide on aggregation:
+#   SATURATED  — saturation-blocked; caller MUST increment its
+#                saturation accumulator. No per-PR escalation was sent.
+#   HANDLED    — non-saturation classification; per-PR handler was
+#                already invoked. Caller takes no further action.
+#
+# Args: $1=pr_num  $2=repo_slug  $3=is_saturated (0|1)
+#######################################
+_pms_handle_classified_pr() {
+	local pr_num="$1"
+	local repo_slug="$2"
+	local is_saturated="$3"
+
+	# Pass is_saturated so the classifier can recognise QUEUED checks
+	# during a runner outage.
+	local classification
+	classification=$(_classify_stuck_pr "$pr_num" "$repo_slug" "$is_saturated")
+
+	# Fetch linked issue once for the escalation comment.
+	local linked_issue=""
+	if declare -F _extract_linked_issue >/dev/null 2>&1; then
+		linked_issue=$(_extract_linked_issue "$pr_num" "$repo_slug" 2>/dev/null) || linked_issue=""
+	fi
+
+	case "$classification" in
+		STUCK_RUNNER_QUEUE_SATURATION)
+			# Suppress per-PR escalation — caller aggregates for meta-issue.
+			echo "[pulse-merge-stuck] _pms_handle_classified_pr: PR #${pr_num} (${repo_slug}) classified STUCK_RUNNER_QUEUE_SATURATION — suppressing per-PR escalation, will aggregate to meta-issue" >>"$LOGFILE"
+			printf 'SATURATED'
+			;;
+		STUCK_BRANCHPROTECT_404)
+			_handle_stuck_branchprotect_404 "$pr_num" "$repo_slug"
+			printf 'HANDLED'
+			;;
+		STUCK_CONFLICT_NO_NUDGE_LABEL)
+			_handle_stuck_conflict_no_nudge_label "$pr_num" "$repo_slug"
+			printf 'HANDLED'
+			;;
+		STUCK_CHECKS_FAILING|STUCK_BRANCHPROTECT_API_ERROR|STUCK_AUTH|STUCK_OTHER)
+			_escalate_individual_stuck_pr "$pr_num" "$repo_slug" "$classification" "$linked_issue"
+			printf 'HANDLED'
+			;;
+		*)
+			printf 'HANDLED'
+			;;
+	esac
+	return 0
+}
+
 pulse_merge_stuck_run_pass() {
 	local repo_slug="$1"
 
@@ -977,36 +1085,22 @@ pulse_merge_stuck_run_pass() {
 	now_epoch=$(date +%s 2>/dev/null) || now_epoch=0
 	local age_threshold_secs=$((AIDEVOPS_MERGE_STUCK_AGE_MINUTES * 60))
 
-	# ── Compute Actions runner queue saturation ONCE per repo per cycle ──
-	# (t3211, GH#21942). Calling _check_actions_queue_saturation per-PR
-	# would burn REST budget pointlessly — saturation is a repo-wide signal.
-	# Fail-open if the helper is unavailable (partial deploy) — saturation
-	# defaults to 0 and the module degrades to its pre-t3211 behaviour.
-	local sat_queued=0 sat_in_progress=0 sat_ratio=0 is_saturated=0
-	if declare -F _check_actions_queue_saturation >/dev/null 2>&1; then
-		local saturation_output=""
-		saturation_output=$(_check_actions_queue_saturation "$repo_slug" 2>/dev/null) || saturation_output=""
-		if [[ -n "$saturation_output" ]]; then
-			# Parse KEY=VALUE lines emitted by the helper.
-			sat_queued=$(printf '%s\n' "$saturation_output" | grep -E '^queued=' | head -1 | cut -d= -f2)
-			sat_in_progress=$(printf '%s\n' "$saturation_output" | grep -E '^in_progress=' | head -1 | cut -d= -f2)
-			sat_ratio=$(printf '%s\n' "$saturation_output" | grep -E '^ratio=' | head -1 | cut -d= -f2)
-			is_saturated=$(printf '%s\n' "$saturation_output" | grep -E '^saturated=' | head -1 | cut -d= -f2)
-			[[ "$sat_queued" =~ ^[0-9]+$ ]] || sat_queued=0
-			[[ "$sat_in_progress" =~ ^[0-9]+$ ]] || sat_in_progress=0
-			[[ "$sat_ratio" =~ ^[0-9]+$ ]] || sat_ratio=0
-			[[ "$is_saturated" == "1" ]] || is_saturated=0
-		fi
-	fi
+	# Compute Actions runner queue saturation ONCE per repo per cycle (t3211).
+	local sat_queued=0 sat_in_progress=0 sat_ratio=0 is_saturated=0 saturation_state
+	saturation_state=$(_pms_compute_saturation_state "$repo_slug")
+	sat_queued=$(printf '%s\n' "$saturation_state" | grep -E '^queued=' | head -1 | cut -d= -f2)
+	sat_in_progress=$(printf '%s\n' "$saturation_state" | grep -E '^in_progress=' | head -1 | cut -d= -f2)
+	sat_ratio=$(printf '%s\n' "$saturation_state" | grep -E '^ratio=' | head -1 | cut -d= -f2)
+	is_saturated=$(printf '%s\n' "$saturation_state" | grep -E '^saturated=' | head -1 | cut -d= -f2)
+	[[ "$sat_queued" =~ ^[0-9]+$ ]] || sat_queued=0
+	[[ "$sat_in_progress" =~ ^[0-9]+$ ]] || sat_in_progress=0
+	[[ "$sat_ratio" =~ ^[0-9]+$ ]] || sat_ratio=0
+	[[ "$is_saturated" == "1" ]] || is_saturated=0
 
-	local eligible_stuck_count=0
-	local stuck_pr_numbers=""
-
-	# Saturation-blocked PRs aggregated for the meta-issue body (t3211).
-	# Per-PR escalation comments are SUPPRESSED for these — the meta-issue
-	# replaces them.
-	local saturation_blocked_prs=""
-	local saturation_blocked_count=0
+	# Saturation-blocked PRs aggregated for the meta-issue body (t3211) —
+	# per-PR escalation comments are SUPPRESSED for these.
+	local eligible_stuck_count=0 saturation_blocked_count=0
+	local stuck_pr_numbers="" saturation_blocked_prs=""
 
 	# Iterate each PR — classify, escalate, accumulate fingerprints.
 	local i=0
@@ -1032,36 +1126,15 @@ pulse_merge_stuck_run_pass() {
 		eligible_stuck_count=$((eligible_stuck_count + 1))
 		stuck_pr_numbers="${stuck_pr_numbers}${pr_num}\n"
 
-		# Per-PR classification + handler (skip per-PR escalation when the
-		# PR is part of a pattern cluster — detected later in the same pass).
-		# Pass is_saturated so the classifier can recognise QUEUED checks
-		# during a runner outage.
-		local classification
-		classification=$(_classify_stuck_pr "$pr_num" "$repo_slug" "$is_saturated")
-
-		# Fetch linked issue once for the escalation comment.
-		local linked_issue=""
-		if declare -F _extract_linked_issue >/dev/null 2>&1; then
-			linked_issue=$(_extract_linked_issue "$pr_num" "$repo_slug" 2>/dev/null) || linked_issue=""
+		# Classify + route via the helper. SATURATED means we must
+		# aggregate the PR for the meta-issue; HANDLED means a per-PR
+		# handler already ran.
+		local route
+		route=$(_pms_handle_classified_pr "$pr_num" "$repo_slug" "$is_saturated")
+		if [[ "$route" == "SATURATED" ]]; then
+			saturation_blocked_prs="${saturation_blocked_prs}${pr_num},"
+			saturation_blocked_count=$((saturation_blocked_count + 1))
 		fi
-
-		case "$classification" in
-			STUCK_RUNNER_QUEUE_SATURATION)
-				# Suppress per-PR escalation — aggregate for the meta-issue.
-				saturation_blocked_prs="${saturation_blocked_prs}${pr_num},"
-				saturation_blocked_count=$((saturation_blocked_count + 1))
-				echo "[pulse-merge-stuck] pulse_merge_stuck_run_pass: PR #${pr_num} (${repo_slug}) classified STUCK_RUNNER_QUEUE_SATURATION — suppressing per-PR escalation, will aggregate to meta-issue" >>"$LOGFILE"
-				;;
-			STUCK_BRANCHPROTECT_404)
-				_handle_stuck_branchprotect_404 "$pr_num" "$repo_slug"
-				;;
-			STUCK_CONFLICT_NO_NUDGE_LABEL)
-				_handle_stuck_conflict_no_nudge_label "$pr_num" "$repo_slug"
-				;;
-			STUCK_CHECKS_FAILING|STUCK_BRANCHPROTECT_API_ERROR|STUCK_AUTH|STUCK_OTHER)
-				_escalate_individual_stuck_pr "$pr_num" "$repo_slug" "$classification" "$linked_issue"
-				;;
-		esac
 	done
 
 	# Update the gauge for this cycle's count.

--- a/.agents/scripts/pulse-merge-stuck.sh
+++ b/.agents/scripts/pulse-merge-stuck.sh
@@ -23,8 +23,13 @@
 #     Iterates open PRs, increments per-PR/per-cycle counters, fires
 #     individual escalations, and detects pattern outages.
 #
-# Module-internal classifier (returns one of six string outcomes):
-#   _classify_stuck_pr <pr_number> <repo_slug>
+# Module-internal classifier (returns one of seven string outcomes):
+#   _classify_stuck_pr <pr_number> <repo_slug> [is_saturated]
+#     STUCK_RUNNER_QUEUE_SATURATION   — required check sits QUEUED while the
+#                                       repo's GitHub Actions runner pool is
+#                                       saturated (queued > N AND queued/
+#                                       in_progress > M); detected only when
+#                                       caller passes is_saturated=1 (t3211)
 #     STUCK_CHECKS_FAILING            — ≥1 FAILURE in rollup, no conflict
 #     STUCK_CONFLICT_NO_NUDGE_LABEL   — CONFLICTING + no origin:interactive
 #                                       and no origin:worker (gap in existing
@@ -61,6 +66,17 @@ _PULSE_MERGE_STUCK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
 source "${_PULSE_MERGE_STUCK_DIR}/pulse-stats-helper.sh"
 
+# Source the rate-limit / Actions-queue helper for _check_actions_queue_saturation
+# (t3211, GH#21942). Defined alongside the GraphQL circuit breaker because both
+# concern GitHub-side resource exhaustion. The source is best-effort — if the
+# file is missing (e.g. partial deploy), the saturation detection short-circuits
+# to disabled and the module degrades to its pre-t3211 behaviour.
+if [[ -f "${_PULSE_MERGE_STUCK_DIR}/pulse-rate-limit-circuit-breaker.sh" ]]; then
+	# shellcheck source=./pulse-rate-limit-circuit-breaker.sh
+	# shellcheck disable=SC1091
+	source "${_PULSE_MERGE_STUCK_DIR}/pulse-rate-limit-circuit-breaker.sh"
+fi
+
 # Load thresholds from the canonical config file (env vars take precedence).
 # The conf file lives at .agents/configs/pulse-merge-stuck.conf; we resolve
 # from _PULSE_MERGE_STUCK_DIR (../configs/pulse-merge-stuck.conf).
@@ -89,8 +105,10 @@ fi
 # Counter and gauge names that would otherwise repeat 3+ times in the body
 # and trip the pre-commit string-literal ratchet.
 readonly _PMS_COUNTER_ESCALATIONS_FILED="pulse_merge_stuck_escalations_filed"
+readonly _PMS_COUNTER_QUEUE_SATURATION_EVENTS="pulse_actions_queue_saturation_events"
 readonly _PMS_GAUGE_ZERO_PROGRESS_CYCLES='pulse_merge_zero_progress_cycles'
 readonly _PMS_JQ_NULL_GUARD="null"
+readonly _PMS_RUNNER_SATURATION_MARKER_TEXT="merge-stuck:runner-queue-saturation"
 # jq filter snippet that selects array elements with a FAILURE rollup
 # conclusion or state. Extracted so the underlying upcase predicate is
 # defined exactly once (via a jq `def`) and reused for both the new-style
@@ -157,6 +175,7 @@ _pms_is_eligible_stuck() {
 
 #######################################
 # Classify why a stuck PR is stuck. Echoes one of:
+#   STUCK_RUNNER_QUEUE_SATURATION  (only when caller passes is_saturated=1)
 #   STUCK_CHECKS_FAILING
 #   STUCK_CONFLICT_NO_NUDGE_LABEL
 #   STUCK_BRANCHPROTECT_404
@@ -164,12 +183,19 @@ _pms_is_eligible_stuck() {
 #   STUCK_AUTH
 #   STUCK_OTHER
 #
-# Args: $1 = pr_number, $2 = repo_slug
+# The is_saturated parameter is computed once per repo per cycle by the
+# caller (pulse_merge_stuck_run_pass) — checking it per-PR would burn
+# REST budget. When set to 1, any PR with a QUEUED check in the rollup
+# is classified as STUCK_RUNNER_QUEUE_SATURATION (highest priority — the
+# QUEUED check would otherwise mask the actual cause).
+#
+# Args: $1 = pr_number, $2 = repo_slug, $3 = is_saturated (0|1, default 0)
 # Returns: 0 (always; classification is the stdout)
 #######################################
 _classify_stuck_pr() {
 	local pr_number="$1"
 	local repo_slug="$2"
+	local is_saturated="${3:-0}"
 
 	# Cheap fast paths first. Fetch labels + mergeable + checks rollup once.
 	local pr_meta
@@ -179,6 +205,24 @@ _classify_stuck_pr() {
 	local mergeable="" labels=""
 	mergeable=$(printf '%s' "$pr_meta" | jq -r '.mergeable // "UNKNOWN"' 2>/dev/null)
 	labels=$(printf '%s' "$pr_meta" | jq -r '[.labels[].name] | join(",")' 2>/dev/null)
+
+	# Runner queue saturation takes priority when the repo is saturated
+	# AND this PR has a QUEUED check in its rollup. This must come BEFORE
+	# the FAILURE check below, because checks that have not yet started
+	# (.status=QUEUED, .conclusion=null) are not counted as failures by
+	# the FAILURE selector but ARE the proximate cause of the stuck state
+	# during a runner outage. (t3211)
+	if [[ "$is_saturated" == "1" ]]; then
+		local has_queued
+		has_queued=$(printf '%s' "$pr_meta" | jq -r \
+			'[.statusCheckRollup[]? | select((.status // "" | ascii_upcase) == "QUEUED")] | length' \
+			2>/dev/null)
+		[[ "$has_queued" =~ ^[0-9]+$ ]] || has_queued=0
+		if [[ "$has_queued" -gt 0 ]]; then
+			printf 'STUCK_RUNNER_QUEUE_SATURATION'
+			return 0
+		fi
+	fi
 
 	# Conflict + no nudge label → that gap.
 	if [[ "$mergeable" == "CONFLICTING" \
@@ -595,6 +639,172 @@ Filed automatically by \`pulse-merge-stuck.sh\` (t3193) on detecting a pattern o
 	return 0
 }
 
+# ── Runner queue saturation meta-issue (t3211, GH#21942) ────────────────────
+
+#######################################
+# File ONE meta-issue describing GitHub Actions runner queue saturation in the
+# repo. Suppression: the caller (pulse_merge_stuck_run_pass) skips per-PR
+# escalations for STUCK_RUNNER_QUEUE_SATURATION classifications when this
+# function fires, so the meta-issue is the only escalation surface.
+# Dedup'd by the fixed marker — saturation is a repo-level signal, not a
+# per-fingerprint signal.
+#
+# Args:
+#   $1 - repo_slug
+#   $2 - queued (count of queued workflow runs at detection time)
+#   $3 - in_progress (count of in-progress workflow runs at detection time)
+#   $4 - ratio (integer queued/max(in_progress,1))
+#   $5 - affected_prs (comma-separated PR numbers blocked by saturation)
+#   $6 - count (length of affected_prs list)
+#######################################
+_pms_file_runner_saturation_issue() {
+	local repo_slug="$1"
+	local queued="$2"
+	local in_progress="$3"
+	local ratio="$4"
+	local affected_prs="$5"
+	local count="$6"
+
+	[[ -n "$repo_slug" ]] || return 0
+	[[ "$queued" =~ ^[0-9]+$ ]] || queued=0
+	[[ "$in_progress" =~ ^[0-9]+$ ]] || in_progress=0
+	[[ "$ratio" =~ ^[0-9]+$ ]] || ratio=0
+	[[ "$count" =~ ^[0-9]+$ ]] || count=0
+
+	local marker_text="${_PMS_RUNNER_SATURATION_MARKER_TEXT}"
+	local marker="<!-- ${marker_text} -->"
+
+	# Dedup: search for an OPEN issue with this marker in the affected repo.
+	# The same repo's saturation events may recur over hours but only one
+	# meta-issue stays open at a time — operators close it after triaging.
+	local existing
+	existing=$(gh issue list --repo "$repo_slug" --state open --search "${marker_text}" \
+		--limit 1 --json number --jq '.[0].number' 2>/dev/null)
+	if [[ -n "$existing" && "$existing" != "$_PMS_JQ_NULL_GUARD" ]]; then
+		echo "[pulse-merge-stuck] _pms_file_runner_saturation_issue: marker already filed as #${existing} in ${repo_slug} — skipping" >>"$LOGFILE"
+		# Still increment the events counter — saturation IS happening, even
+		# if the meta-issue dedup prevents a fresh filing. This way operators
+		# can correlate counter spikes with saturation incidents even when
+		# only one meta-issue exists.
+		pulse_stats_increment "$_PMS_COUNTER_QUEUE_SATURATION_EVENTS"
+		return 0
+	fi
+
+	# Compose the meta-issue body. tier:thinking + bug + auto-dispatch matches
+	# the _pms_file_outage_issue convention; source:merge-stuck-detector
+	# routes the issue to operators familiar with the detector module.
+	local title="merge-stuck: GitHub Actions runner queue saturated (${queued} queued / ${in_progress} in-progress) in ${repo_slug}"
+
+	# Use read -r -d '' for bash 3.2 portability — see _escalate_individual_stuck_pr
+	# for the rationale (heredoc-in-subshell is not bash 3.2 compatible).
+	local body=""
+	IFS='' read -r -d '' body <<EOF || true
+${marker}
+## What
+
+The pulse stuck-merge detector observed **GitHub Actions runner queue saturation** in this repo, blocking **${count} PR(s)** with required checks stuck in QUEUED status:
+
+- Queued workflow runs: **${queued}**
+- In-progress workflow runs: **${in_progress}**
+- Saturation ratio (queued / max(in_progress,1)): **${ratio}**
+
+Detection thresholds: queued > \`${AIDEVOPS_ACTIONS_QUEUE_SATURATION_QUEUED_MIN:-50}\` AND ratio > \`${AIDEVOPS_ACTIONS_QUEUE_SATURATION_RATIO_MIN:-10}\`. Both conditions held in this cycle.
+
+Per-PR escalation comments are SUPPRESSED for these PRs while saturation persists — the cause is shared (runner pool exhaustion), not per-PR (rebase, fix code). This single meta-issue replaces the N per-PR comments that would otherwise be filed.
+
+## Affected PRs
+
+$(printf '%s' "$affected_prs" | tr ',' '\n' | while read -r p; do [[ -n "$p" ]] && printf -- '- #%s\n' "$p"; done)
+
+## Why
+
+GitHub Actions accounts share a runner pool with rate-limited concurrency. When many workflow runs queue at once (CI cascade triggered by a merge train, bulk push, workflow_dispatch storm, recursive workflow_run trigger), runners are oversubscribed and PRs sit indefinitely with required checks in QUEUED state.
+
+The deterministic merge gate (\`required_status_checks\`) reports these as not-yet-passing — they have not concluded — so PRs that would otherwise auto-merge are blocked. This is distinct from:
+
+- **t2690** (GraphQL points circuit breaker) — GraphQL points and Actions runner-minutes are independent GitHub resource pools.
+- **t2922** (fail-closed required-checks) — concerns API errors fetching protection rules, not runner availability.
+- **t3193** (per-PR stuck classifications) — surfaces individual PRs with FAILURE checks; saturation is about CHECKS THAT NEVER STARTED.
+
+## How
+
+### Files Scope
+
+Investigation only — the fix is operational (reduce runner load, upgrade plan, prune workflows), not code.
+
+### Investigation steps
+
+1. Confirm saturation persists (run a few minutes after this issue was filed):
+
+\`\`\`bash
+gh api "repos/${repo_slug}/actions/runs?status=queued&per_page=1" --jq '.total_count'
+gh api "repos/${repo_slug}/actions/runs?status=in_progress&per_page=1" --jq '.total_count'
+\`\`\`
+
+2. Identify the source of the queue burst:
+
+\`\`\`bash
+gh run list --repo ${repo_slug} --status queued --limit 30 \\
+  --json workflowName,headBranch,createdAt
+\`\`\`
+
+Group by \`workflowName\` — if one workflow dominates, suspect a runaway loop (workflow_dispatch storm, schedule misfire, recursive \`workflow_run\` trigger, label-cascade — see t2229).
+
+3. Cancel runaway runs if detected:
+
+\`\`\`bash
+gh run cancel <run-id> --repo ${repo_slug}
+# or bulk:
+gh run list --repo ${repo_slug} --status queued --limit 100 \\
+  --json databaseId,workflowName --jq '.[] | select(.workflowName=="<runaway>") | .databaseId' \\
+  | xargs -I{} gh run cancel {} --repo ${repo_slug}
+\`\`\`
+
+4. Check concurrency settings — every workflow that triggers on \`pull_request\` should have a \`concurrency\` block keyed by branch with \`cancel-in-progress: true\` (or \`false\` only when serial execution is required, e.g. Maintainer Gate). Workflows without \`concurrency\` multiply the queue under bursty conditions.
+
+5. If saturation is sustained (recurring across multiple meta-issues), consider:
+
+   - Upgrading the GitHub plan tier (increases runner pool size).
+   - Migrating long-running jobs to self-hosted runners.
+   - Pruning low-value workflows (e.g. duplicate Python lint jobs running in parallel with the same matrix).
+
+### Verification
+
+- \`gh api "repos/${repo_slug}/actions/runs?status=queued&per_page=1" --jq '.total_count'\` returns ≤ \`${AIDEVOPS_ACTIONS_QUEUE_SATURATION_QUEUED_MIN:-50}\`.
+- The next pulse cycle does NOT re-fire this meta-issue (saturation cleared).
+- Affected PRs above either auto-merge or have their remaining issues triaged individually.
+
+## Acceptance
+
+- [ ] Source of the runner queue burst identified (specific workflow / event / cause).
+- [ ] Saturation cleared (queue depth recovered below threshold).
+- [ ] All ${count} affected PR(s) above are unblocked (auto-merged, manually merged, or have separate follow-up issues).
+
+## Session Origin
+
+Filed automatically by \`pulse-merge-stuck.sh\` (t3211 / GH#21942) on detecting Actions runner queue saturation in ${repo_slug}. The detector runs once per pulse cycle per repo via \`pulse_merge_stuck_run_pass\`.
+
+<sub>Source: pulse-merge-stuck-detector. Threshold env: \`AIDEVOPS_ACTIONS_QUEUE_SATURATION_QUEUED_MIN=${AIDEVOPS_ACTIONS_QUEUE_SATURATION_QUEUED_MIN:-50}\`, \`AIDEVOPS_ACTIONS_QUEUE_SATURATION_RATIO_MIN=${AIDEVOPS_ACTIONS_QUEUE_SATURATION_RATIO_MIN:-10}\`.</sub>
+EOF
+
+	# Wrapper-only — see _pms_file_outage_issue rationale above.
+	if ! declare -F gh_create_issue >/dev/null 2>&1; then
+		echo "[pulse-merge-stuck] _pms_file_runner_saturation_issue: gh_create_issue wrapper unavailable, skipping for ${repo_slug} (queued=${queued})" >>"$LOGFILE"
+		return 0
+	fi
+
+	local labels="auto-dispatch,tier:thinking,bug,source:merge-stuck-detector"
+	gh_create_issue --repo "$repo_slug" \
+		--title "$title" \
+		--body "$body" \
+		--label "$labels" >/dev/null 2>&1 || true
+
+	pulse_stats_increment "$_PMS_COUNTER_ESCALATIONS_FILED"
+	pulse_stats_increment "$_PMS_COUNTER_QUEUE_SATURATION_EVENTS"
+	echo "[pulse-merge-stuck] _pms_file_runner_saturation_issue: filed saturation issue for ${repo_slug} (queued=${queued}, in_progress=${in_progress}, ratio=${ratio}, affected=${count})" >>"$LOGFILE"
+	return 0
+}
+
 # ── Zero-progress meta-issue ────────────────────────────────────────────────
 
 # File ONE meta-issue describing the throughput collapse when consecutive
@@ -767,8 +977,36 @@ pulse_merge_stuck_run_pass() {
 	now_epoch=$(date +%s 2>/dev/null) || now_epoch=0
 	local age_threshold_secs=$((AIDEVOPS_MERGE_STUCK_AGE_MINUTES * 60))
 
+	# ── Compute Actions runner queue saturation ONCE per repo per cycle ──
+	# (t3211, GH#21942). Calling _check_actions_queue_saturation per-PR
+	# would burn REST budget pointlessly — saturation is a repo-wide signal.
+	# Fail-open if the helper is unavailable (partial deploy) — saturation
+	# defaults to 0 and the module degrades to its pre-t3211 behaviour.
+	local sat_queued=0 sat_in_progress=0 sat_ratio=0 is_saturated=0
+	if declare -F _check_actions_queue_saturation >/dev/null 2>&1; then
+		local saturation_output=""
+		saturation_output=$(_check_actions_queue_saturation "$repo_slug" 2>/dev/null) || saturation_output=""
+		if [[ -n "$saturation_output" ]]; then
+			# Parse KEY=VALUE lines emitted by the helper.
+			sat_queued=$(printf '%s\n' "$saturation_output" | grep -E '^queued=' | head -1 | cut -d= -f2)
+			sat_in_progress=$(printf '%s\n' "$saturation_output" | grep -E '^in_progress=' | head -1 | cut -d= -f2)
+			sat_ratio=$(printf '%s\n' "$saturation_output" | grep -E '^ratio=' | head -1 | cut -d= -f2)
+			is_saturated=$(printf '%s\n' "$saturation_output" | grep -E '^saturated=' | head -1 | cut -d= -f2)
+			[[ "$sat_queued" =~ ^[0-9]+$ ]] || sat_queued=0
+			[[ "$sat_in_progress" =~ ^[0-9]+$ ]] || sat_in_progress=0
+			[[ "$sat_ratio" =~ ^[0-9]+$ ]] || sat_ratio=0
+			[[ "$is_saturated" == "1" ]] || is_saturated=0
+		fi
+	fi
+
 	local eligible_stuck_count=0
 	local stuck_pr_numbers=""
+
+	# Saturation-blocked PRs aggregated for the meta-issue body (t3211).
+	# Per-PR escalation comments are SUPPRESSED for these — the meta-issue
+	# replaces them.
+	local saturation_blocked_prs=""
+	local saturation_blocked_count=0
 
 	# Iterate each PR — classify, escalate, accumulate fingerprints.
 	local i=0
@@ -796,8 +1034,10 @@ pulse_merge_stuck_run_pass() {
 
 		# Per-PR classification + handler (skip per-PR escalation when the
 		# PR is part of a pattern cluster — detected later in the same pass).
+		# Pass is_saturated so the classifier can recognise QUEUED checks
+		# during a runner outage.
 		local classification
-		classification=$(_classify_stuck_pr "$pr_num" "$repo_slug")
+		classification=$(_classify_stuck_pr "$pr_num" "$repo_slug" "$is_saturated")
 
 		# Fetch linked issue once for the escalation comment.
 		local linked_issue=""
@@ -806,6 +1046,12 @@ pulse_merge_stuck_run_pass() {
 		fi
 
 		case "$classification" in
+			STUCK_RUNNER_QUEUE_SATURATION)
+				# Suppress per-PR escalation — aggregate for the meta-issue.
+				saturation_blocked_prs="${saturation_blocked_prs}${pr_num},"
+				saturation_blocked_count=$((saturation_blocked_count + 1))
+				echo "[pulse-merge-stuck] pulse_merge_stuck_run_pass: PR #${pr_num} (${repo_slug}) classified STUCK_RUNNER_QUEUE_SATURATION — suppressing per-PR escalation, will aggregate to meta-issue" >>"$LOGFILE"
+				;;
 			STUCK_BRANCHPROTECT_404)
 				_handle_stuck_branchprotect_404 "$pr_num" "$repo_slug"
 				;;
@@ -821,12 +1067,24 @@ pulse_merge_stuck_run_pass() {
 	# Update the gauge for this cycle's count.
 	pulse_stats_set_gauge "pulse_merge_eligible_stuck_pr_count" "$eligible_stuck_count"
 
+	# File the runner-queue-saturation meta-issue if saturation was detected
+	# AND at least one stuck PR was classified into that bucket. The
+	# saturated-but-no-affected-PRs case (rare — saturation cleared between
+	# the helper call and the PR iteration) is intentionally a no-op.
+	if [[ "$is_saturated" == "1" && "$saturation_blocked_count" -gt 0 ]]; then
+		# Strip trailing comma from the aggregated PR list.
+		saturation_blocked_prs="${saturation_blocked_prs%,}"
+		_pms_file_runner_saturation_issue "$repo_slug" \
+			"$sat_queued" "$sat_in_progress" "$sat_ratio" \
+			"$saturation_blocked_prs" "$saturation_blocked_count" || true
+	fi
+
 	# Pattern-cluster detector over the full stuck set.
 	if [[ "$eligible_stuck_count" -ge "$AIDEVOPS_MERGE_PATTERN_MIN_PRS" ]]; then
 		_detect_pattern_outage "$repo_slug" "$(printf '%b' "$stuck_pr_numbers")" || true
 	fi
 
-	echo "[pulse-merge-stuck] pulse_merge_stuck_run_pass: ${repo_slug} — eligible_stuck=${eligible_stuck_count}, threshold=${AIDEVOPS_MERGE_STUCK_AGE_MINUTES}m" >>"$LOGFILE"
+	echo "[pulse-merge-stuck] pulse_merge_stuck_run_pass: ${repo_slug} — eligible_stuck=${eligible_stuck_count}, threshold=${AIDEVOPS_MERGE_STUCK_AGE_MINUTES}m, saturated=${is_saturated} (queued=${sat_queued}, in_progress=${sat_in_progress}, ratio=${sat_ratio}, blocked_by_saturation=${saturation_blocked_count})" >>"$LOGFILE"
 	return 0
 }
 

--- a/.agents/scripts/pulse-rate-limit-circuit-breaker.sh
+++ b/.agents/scripts/pulse-rate-limit-circuit-breaker.sh
@@ -332,7 +332,7 @@ _check_actions_queue_saturation() {
 		return 2
 	fi
 
-	local queued in_progress
+	local queued="" in_progress=""
 	queued=$(printf '%s' "$queued_json" | jq -r '.total_count // 0' 2>/dev/null) || queued=0
 	in_progress=$(printf '%s' "$in_progress_json" | jq -r '.total_count // 0' 2>/dev/null) || in_progress=0
 	[[ "$queued" =~ ^[0-9]+$ ]] || queued=0

--- a/.agents/scripts/pulse-rate-limit-circuit-breaker.sh
+++ b/.agents/scripts/pulse-rate-limit-circuit-breaker.sh
@@ -263,6 +263,105 @@ _circuit_breaker_status() {
 }
 
 #######################################
+# Check whether GitHub Actions runner queue is saturated for a repo (t3211, GH#21942).
+#
+# Saturation criteria (BOTH must hold):
+#   - queued > AIDEVOPS_ACTIONS_QUEUE_SATURATION_QUEUED_MIN (default 50)
+#   - queued / max(in_progress, 1) > AIDEVOPS_ACTIONS_QUEUE_SATURATION_RATIO_MIN (default 10)
+#
+# Distinct from the GraphQL circuit breaker: GraphQL points and Actions
+# runner-minutes are independent GitHub resource pools. The two breakers
+# do not interact — saturation can occur even when GraphQL budget is healthy,
+# and vice versa.
+#
+# Args: $1 = repo_slug (e.g. "owner/repo")
+#
+# Stdout (KEY=VALUE lines, one per line, parseable by `grep | cut`):
+#   queued=N         (count of queued workflow runs)
+#   in_progress=M    (count of in-progress workflow runs)
+#   ratio=R          (integer queued / max(in_progress,1); use as advisory)
+#   saturated=0|1    (1 iff both threshold conditions hold)
+#
+# Returns:
+#   0 — successful query (saturated may be 0 or 1)
+#   2 — gh api error (fail-open: stdout reports saturated=0)
+#
+# Bypass:
+#   AIDEVOPS_SKIP_ACTIONS_QUEUE_SATURATION=1 — return saturated=0 unconditionally
+#   QUEUED_MIN=0                              — disable check via threshold
+#######################################
+_check_actions_queue_saturation() {
+	local repo_slug="$1"
+	local queued_min="${AIDEVOPS_ACTIONS_QUEUE_SATURATION_QUEUED_MIN:-50}"
+	local ratio_min="${AIDEVOPS_ACTIONS_QUEUE_SATURATION_RATIO_MIN:-10}"
+
+	# Validate inputs — invalid env values default to safe disabled state.
+	[[ "$queued_min" =~ ^[0-9]+$ ]] || queued_min=50
+	[[ "$ratio_min" =~ ^[0-9]+$ ]] || ratio_min=10
+
+	# Empty repo_slug → cannot query → fail-open with zeros.
+	if [[ -z "$repo_slug" ]]; then
+		printf 'queued=0\nin_progress=0\nratio=0\nsaturated=0\n'
+		return 0
+	fi
+
+	# Emergency bypass.
+	if [[ "${AIDEVOPS_SKIP_ACTIONS_QUEUE_SATURATION:-0}" == "1" ]]; then
+		echo "${_CB_RL_LOG_PREFIX} AIDEVOPS_SKIP_ACTIONS_QUEUE_SATURATION=1 — bypassing actions queue check for ${repo_slug}" >>"$LOGFILE"
+		printf 'queued=0\nin_progress=0\nratio=0\nsaturated=0\n'
+		return 0
+	fi
+
+	# Disabled if QUEUED_MIN is 0.
+	if [[ "$queued_min" -eq 0 ]]; then
+		printf 'queued=0\nin_progress=0\nratio=0\nsaturated=0\n'
+		return 0
+	fi
+
+	# Query Actions runs for queued + in_progress states. per_page=1 is
+	# enough — the .total_count field carries the population size without
+	# pulling the run bodies (cheap REST call).
+	local queued_json="" in_progress_json=""
+	queued_json=$(gh api "repos/${repo_slug}/actions/runs?status=queued&per_page=1" 2>/dev/null) || queued_json=""
+	in_progress_json=$(gh api "repos/${repo_slug}/actions/runs?status=in_progress&per_page=1" 2>/dev/null) || in_progress_json=""
+
+	# Fail-open on any API error — instrumentation must never break the pulse.
+	if [[ -z "$queued_json" || -z "$in_progress_json" ]]; then
+		echo "${_CB_RL_LOG_PREFIX} WARNING: gh api repos/${repo_slug}/actions/runs failed — fail-open with saturated=0" >>"$LOGFILE"
+		printf 'queued=0\nin_progress=0\nratio=0\nsaturated=0\n'
+		return 2
+	fi
+
+	local queued in_progress
+	queued=$(printf '%s' "$queued_json" | jq -r '.total_count // 0' 2>/dev/null) || queued=0
+	in_progress=$(printf '%s' "$in_progress_json" | jq -r '.total_count // 0' 2>/dev/null) || in_progress=0
+	[[ "$queued" =~ ^[0-9]+$ ]] || queued=0
+	[[ "$in_progress" =~ ^[0-9]+$ ]] || in_progress=0
+
+	# Compute integer ratio = queued / max(in_progress, 1). Bash 3.2 has
+	# no floating-point — integer division is appropriate here because the
+	# threshold is itself an integer (10 vs ratio of 36 in the canonical
+	# incident; the precision floor is "ratio≥1", well below threshold).
+	local denom=1
+	[[ "$in_progress" -gt 0 ]] && denom="$in_progress"
+	local ratio=$((queued / denom))
+
+	# Saturation requires BOTH conditions to hold (high absolute queue AND
+	# imbalanced ratio). Either alone is a false-positive — light-load
+	# bursts hit absolute counts; healthy busy periods hit ratio with high
+	# in_progress counts that the runner pool is already serving.
+	local saturated=0
+	if [[ "$queued" -gt "$queued_min" && "$ratio" -gt "$ratio_min" ]]; then
+		saturated=1
+		echo "${_CB_RL_LOG_PREFIX} ${repo_slug} actions queue SATURATED: queued=${queued} in_progress=${in_progress} ratio=${ratio} (thresholds queued>${queued_min} ratio>${ratio_min})" >>"$LOGFILE"
+	fi
+
+	printf 'queued=%s\nin_progress=%s\nratio=%s\nsaturated=%s\n' \
+		"$queued" "$in_progress" "$ratio" "$saturated"
+	return 0
+}
+
+#######################################
 # Standalone CLI entry point.
 #######################################
 _main() {
@@ -274,20 +373,36 @@ _main() {
 			is_graphql_budget_sufficient
 			return $?
 			;;
+		check-actions-queue)
+			# Args: $1=repo_slug. Prints KEY=VALUE lines.
+			local repo_slug="${1:-}"
+			if [[ -z "$repo_slug" ]]; then
+				echo "Usage: pulse-rate-limit-circuit-breaker.sh check-actions-queue <owner/repo>" >&2
+				return 1
+			fi
+			_check_actions_queue_saturation "$repo_slug"
+			return $?
+			;;
 		status)
 			_circuit_breaker_status
 			return 0
 			;;
 		help | --help | -h)
-			echo "pulse-rate-limit-circuit-breaker.sh — Pulse-level GraphQL rate-limit circuit breaker (t2690)"
+			echo "pulse-rate-limit-circuit-breaker.sh — Pulse-level GraphQL rate-limit circuit breaker (t2690) + Actions queue saturation (t3211)"
 			echo ""
 			echo "Usage:"
-			echo "  pulse-rate-limit-circuit-breaker.sh check    # exit 0=OK, 1=tripped, 2=API error"
-			echo "  pulse-rate-limit-circuit-breaker.sh status   # human-readable status line"
+			echo "  pulse-rate-limit-circuit-breaker.sh check                          # exit 0=OK, 1=tripped, 2=API error"
+			echo "  pulse-rate-limit-circuit-breaker.sh check-actions-queue OWNER/REPO # KEY=VALUE: queued/in_progress/ratio/saturated"
+			echo "  pulse-rate-limit-circuit-breaker.sh status                         # human-readable status line"
 			echo ""
-			echo "Environment:"
+			echo "Environment (GraphQL):"
 			echo "  AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD  fraction threshold (default 0.30 = 30%)"
 			echo "  AIDEVOPS_SKIP_PULSE_CIRCUIT_BREAKER=1     emergency bypass"
+			echo ""
+			echo "Environment (Actions queue, t3211):"
+			echo "  AIDEVOPS_ACTIONS_QUEUE_SATURATION_QUEUED_MIN  min queued runs (default 50; 0 disables)"
+			echo "  AIDEVOPS_ACTIONS_QUEUE_SATURATION_RATIO_MIN   min queued/in_progress ratio (default 10)"
+			echo "  AIDEVOPS_SKIP_ACTIONS_QUEUE_SATURATION=1      emergency bypass"
 			return 0
 			;;
 		*)

--- a/.agents/scripts/tests/test-actions-queue-saturation.sh
+++ b/.agents/scripts/tests/test-actions-queue-saturation.sh
@@ -1,0 +1,477 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-actions-queue-saturation.sh — Tests for the Actions runner queue
+# saturation detector (t3211 / GH#21942).
+#
+# Verifies:
+#   1. _check_actions_queue_saturation correctly classifies saturation states
+#      against the canonical 2026-04-30 incident shape (110 queued / 3
+#      in_progress) and the threshold boundary cases.
+#   2. The function fail-opens cleanly on gh-api errors (saturated=0, rc=2).
+#   3. Bypass env var (AIDEVOPS_SKIP_ACTIONS_QUEUE_SATURATION=1) and disable
+#      via QUEUED_MIN=0 both short-circuit to saturated=0 without touching
+#      the network.
+#   4. Custom thresholds via env vars (QUEUED_MIN, RATIO_MIN) take precedence
+#      over conf-file defaults.
+#   5. _classify_stuck_pr returns STUCK_RUNNER_QUEUE_SATURATION when the
+#      caller passes is_saturated=1 AND the PR's rollup contains a QUEUED
+#      check; falls through to STUCK_CHECKS_FAILING when is_saturated=0.
+#   6. shellcheck cleanliness on pulse-rate-limit-circuit-breaker.sh.
+#
+# All tests use a `gh` PATH shim so no real network calls are made.
+
+set -u
+
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_BLUE=$'\033[0;34m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_BLUE="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+assert_eq() {
+	local label="$1" expected="$2" actual="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$expected" == "$actual" ]]; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  expected: $(printf '%q' "$expected")"
+		echo "  actual:   $(printf '%q' "$actual")"
+	fi
+	return 0
+}
+
+assert_match() {
+	local label="$1" regex="$2" value="$3"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$value" =~ $regex ]]; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: $label"
+	else
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+		echo "${TEST_RED}FAIL${TEST_NC}: $label"
+		echo "  regex: $regex"
+		echo "  value: $(printf '%q' "$value")"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Setup: locate files, isolate env, install gh shim, source the module.
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RATE_LIMIT_HELPER="$SCRIPT_DIR/pulse-rate-limit-circuit-breaker.sh"
+MERGE_STUCK_HELPER="$SCRIPT_DIR/pulse-merge-stuck.sh"
+
+for required in "$RATE_LIMIT_HELPER" "$MERGE_STUCK_HELPER"; do
+	if [[ ! -f "$required" ]]; then
+		echo "${TEST_RED}FATAL${TEST_NC}: $required not found"
+		exit 1
+	fi
+done
+
+# Isolate state — avoid touching the live pulse logs/stats.
+TEST_TMPDIR=$(mktemp -d "${TMPDIR:-/tmp}/test-actions-queue-saturation-XXXXXX")
+trap 'rm -rf "$TEST_TMPDIR"' EXIT
+export PULSE_STATS_FILE="$TEST_TMPDIR/pulse-stats.json"
+export LOGFILE="$TEST_TMPDIR/pulse.log"
+
+# Install a `gh` PATH shim. The shim reads env vars to choose its response,
+# emulating gh api repos/{slug}/actions/runs?status={queued,in_progress}.
+SHIM_DIR="$TEST_TMPDIR/bin"
+mkdir -p "$SHIM_DIR"
+cat >"$SHIM_DIR/gh" <<'SHIM_EOF'
+#!/usr/bin/env bash
+# Minimal gh shim for test-actions-queue-saturation.sh.
+# Honours these env vars set by individual test cases:
+#   GH_SHIM_QUEUED_TOTAL      total_count for status=queued response (integer)
+#   GH_SHIM_IN_PROGRESS_TOTAL total_count for status=in_progress response (integer)
+#   GH_SHIM_FAIL              if "1", emit empty stdout + exit 1 (API error)
+#   GH_SHIM_PR_VIEW_JSON      raw JSON to return for `gh pr view` calls
+
+# NOTE: `local` is invalid at script top-level in bash and aborts the
+# script before printf runs — that's why this shim must use plain vars.
+# The bug bit us once during test development; do not "tidy" this back.
+
+# Pick out a --jq EXPR from the remaining args (real gh runs jq locally
+# on the response body when --jq is passed). Returns the expression on
+# stdout, or empty if not found.
+extract_jq_expr() {
+	local prev=""
+	local arg
+	for arg in "$@"; do
+		if [[ "$prev" == "--jq" ]]; then
+			printf '%s' "$arg"
+			return 0
+		fi
+		prev="$arg"
+	done
+	return 0
+}
+
+# Apply jq filter to body (or pass through if no expr given).
+apply_jq() {
+	local body="$1"
+	local expr="$2"
+	if [[ -z "$expr" ]]; then
+		printf '%s' "$body"
+		return 0
+	fi
+	printf '%s' "$body" | jq -r "$expr" 2>/dev/null
+	return 0
+}
+
+# Emit a body that matches the response shape the helper expects, then
+# apply --jq filter (if any) so the helper's --jq path returns the same
+# scalar/object that real `gh api --jq` would return.
+emit_body() {
+	local body="$1"
+	shift
+	local expr
+	expr=$(extract_jq_expr "$@")
+	apply_jq "$body" "$expr"
+	echo
+	return 0
+}
+
+case "$1" in
+	api)
+		shift
+		# First positional after `api` is the endpoint URL. The remaining
+		# args may include --jq '<expr>' which we replicate locally so the
+		# shim behaves like real gh.
+		endpoint="$1"
+		shift || true
+		if [[ "${GH_SHIM_FAIL:-0}" == "1" ]]; then
+			# Empty stdout + nonzero rc → mimics gh-api transport failure.
+			exit 1
+		fi
+		case "$endpoint" in
+			*"actions/runs?status=queued"*)
+				body=$(printf '{"total_count":%s,"workflow_runs":[]}' "${GH_SHIM_QUEUED_TOTAL:-0}")
+				emit_body "$body" "$@"
+				exit 0
+				;;
+			*"actions/runs?status=in_progress"*)
+				body=$(printf '{"total_count":%s,"workflow_runs":[]}' "${GH_SHIM_IN_PROGRESS_TOTAL:-0}")
+				emit_body "$body" "$@"
+				exit 0
+				;;
+			*"/branches/"*"/protection"*)
+				# Pretend the branch has no protection rules. Returning
+				# success with `{}` makes the classifier fall through to
+				# the FAILURE check (the protection-error branches are
+				# tested separately by test-pulse-merge-stuck.sh).
+				emit_body "{}" "$@"
+				exit 0
+				;;
+			repos/*/*)
+				# Bare repo metadata. Emit a minimal valid response so
+				# `--jq '.default_branch'` filters to "main", letting the
+				# helper enter the protection probe (which we satisfy
+				# above with a 200/empty so it falls through to FAILURE).
+				emit_body '{"default_branch":"main"}' "$@"
+				exit 0
+				;;
+		esac
+		# Default for any other api call.
+		emit_body "{}" "$@"
+		exit 0
+		;;
+	pr)
+		shift
+		if [[ "$1" == "view" ]]; then
+			# Return the rollup fixture; respect --jq when caller filters.
+			# NOTE: cannot inline a default with `${VAR:-{}}` — bash
+			# closes the parameter expansion at the first `}`, leaving a
+			# literal trailing `}` that corrupts the JSON output. Use an
+			# intermediate variable for the default instead.
+			pr_view_default='{}'
+			body="${GH_SHIM_PR_VIEW_JSON:-$pr_view_default}"
+			emit_body "$body" "$@"
+			exit 0
+		fi
+		;;
+esac
+
+# Default: pretend success with empty output for any other gh subcommand.
+echo '{}'
+exit 0
+SHIM_EOF
+chmod +x "$SHIM_DIR/gh"
+PATH="$SHIM_DIR:$PATH"
+export PATH
+
+# Reset all relevant env vars before each test class.
+#
+# IMPORTANT: GH_SHIM_* must be EXPORTED, not just assigned, because they
+# are read by the `gh` shim subprocess. The pattern `GH_SHIM_X=v out=$(fn)`
+# does NOT export GH_SHIM_X — the prefix-form export only applies when the
+# subsequent token is a command, not when it is itself a variable
+# assignment. Use `set_shim` below to set + export them in one step.
+_reset_env() {
+	unset AIDEVOPS_PULSE_CIRCUIT_BREAKER_THRESHOLD
+	unset AIDEVOPS_ACTIONS_QUEUE_SATURATION_QUEUED_MIN
+	unset AIDEVOPS_ACTIONS_QUEUE_SATURATION_RATIO_MIN
+	unset AIDEVOPS_SKIP_ACTIONS_QUEUE_SATURATION
+	unset AIDEVOPS_SKIP_PULSE_CIRCUIT_BREAKER
+	unset GH_SHIM_QUEUED_TOTAL
+	unset GH_SHIM_IN_PROGRESS_TOTAL
+	unset GH_SHIM_FAIL
+	unset GH_SHIM_PR_VIEW_JSON
+	return 0
+}
+
+# Set + export shim env vars in one call. Accepts KEY=VALUE pairs.
+#
+# Implementation note: NEVER use `eval "export $kv"` — bash subjects the
+# expanded `$kv` to brace expansion, glob expansion, and word splitting,
+# which mangles JSON values like `{"a":"b","c":"d"}` (the commas inside
+# trigger brace-list expansion → only the first list element gets
+# assigned). The split-and-export form below treats the value as a single
+# literal string regardless of what it contains.
+set_shim() {
+	local kv key val
+	for kv in "$@"; do
+		key="${kv%%=*}"
+		val="${kv#*=}"
+		export "$key"="$val"
+	done
+	return 0
+}
+
+# Source the helper. Defines _check_actions_queue_saturation. The helper
+# uses `set -euo pipefail` which is inherited by our shell. Disable -e
+# afterwards because several tests deliberately trigger non-zero return
+# codes (the API-error path returns rc=2 by design); without `set +e` the
+# test process aborts at the first such case before reaching subsequent
+# assertions. We keep `set -u` for the assert helpers.
+# shellcheck disable=SC1090
+source "$RATE_LIMIT_HELPER"
+set +e
+
+if ! declare -F _check_actions_queue_saturation >/dev/null 2>&1; then
+	echo "${TEST_RED}FATAL${TEST_NC}: _check_actions_queue_saturation not defined after sourcing $RATE_LIMIT_HELPER"
+	exit 1
+fi
+
+echo "${TEST_BLUE}━━━ test-actions-queue-saturation.sh ━━━${TEST_NC}"
+
+# Helper: extract a KEY=value field from the helper's stdout.
+_field() {
+	local key="$1"
+	local out="$2"
+	printf '%s\n' "$out" | grep -E "^${key}=" | head -1 | cut -d= -f2
+}
+
+# ---------------------------------------------------------------------------
+# Test class 1: saturation detection at threshold boundaries
+# ---------------------------------------------------------------------------
+echo ""
+echo "${TEST_BLUE}── 1. Saturation detection ──${TEST_NC}"
+
+# 1a: Canonical 2026-04-30 incident shape (110 queued / 3 in_progress).
+_reset_env
+set_shim GH_SHIM_QUEUED_TOTAL=110 GH_SHIM_IN_PROGRESS_TOTAL=3
+out=$(_check_actions_queue_saturation "marcusquinn/aidevops")
+assert_eq "incident shape: queued=110"          "110" "$(_field queued "$out")"
+assert_eq "incident shape: in_progress=3"       "3"   "$(_field in_progress "$out")"
+assert_eq "incident shape: ratio=36"            "36"  "$(_field ratio "$out")"
+assert_eq "incident shape: saturated=1"         "1"   "$(_field saturated "$out")"
+
+# 1b: Light load — neither absolute nor ratio threshold met.
+_reset_env
+set_shim GH_SHIM_QUEUED_TOTAL=10 GH_SHIM_IN_PROGRESS_TOTAL=10
+out=$(_check_actions_queue_saturation "marcusquinn/aidevops")
+assert_eq "light load: queued=10"               "10"  "$(_field queued "$out")"
+assert_eq "light load: ratio=1"                 "1"   "$(_field ratio "$out")"
+assert_eq "light load: saturated=0"             "0"   "$(_field saturated "$out")"
+
+# 1c: High absolute, healthy ratio (busy but draining) — NOT saturated.
+_reset_env
+set_shim GH_SHIM_QUEUED_TOTAL=51 GH_SHIM_IN_PROGRESS_TOTAL=10
+out=$(_check_actions_queue_saturation "marcusquinn/aidevops")
+assert_eq "busy/healthy: queued=51"             "51"  "$(_field queued "$out")"
+assert_eq "busy/healthy: ratio=5"               "5"   "$(_field ratio "$out")"
+assert_eq "busy/healthy: saturated=0"           "0"   "$(_field saturated "$out")"
+
+# 1d: Just above ratio threshold — IS saturated.
+_reset_env
+set_shim GH_SHIM_QUEUED_TOTAL=51 GH_SHIM_IN_PROGRESS_TOTAL=4
+out=$(_check_actions_queue_saturation "marcusquinn/aidevops")
+assert_eq "above ratio: queued=51"              "51"  "$(_field queued "$out")"
+assert_eq "above ratio: ratio=12"               "12"  "$(_field ratio "$out")"
+assert_eq "above ratio: saturated=1"            "1"   "$(_field saturated "$out")"
+
+# 1e: Just below queued threshold — NOT saturated regardless of ratio.
+_reset_env
+set_shim GH_SHIM_QUEUED_TOTAL=49 GH_SHIM_IN_PROGRESS_TOTAL=1
+out=$(_check_actions_queue_saturation "marcusquinn/aidevops")
+assert_eq "below abs: queued=49"                "49"  "$(_field queued "$out")"
+assert_eq "below abs: ratio=49"                 "49"  "$(_field ratio "$out")"
+assert_eq "below abs: saturated=0"              "0"   "$(_field saturated "$out")"
+
+# 1f: Zero in_progress — denominator clamps to 1, ratio = queued.
+_reset_env
+set_shim GH_SHIM_QUEUED_TOTAL=200 GH_SHIM_IN_PROGRESS_TOTAL=0
+out=$(_check_actions_queue_saturation "marcusquinn/aidevops")
+assert_eq "zero in_progress: queued=200"        "200" "$(_field queued "$out")"
+assert_eq "zero in_progress: ratio=200"         "200" "$(_field ratio "$out")"
+assert_eq "zero in_progress: saturated=1"       "1"   "$(_field saturated "$out")"
+
+# ---------------------------------------------------------------------------
+# Test class 2: fail-open semantics
+# ---------------------------------------------------------------------------
+echo ""
+echo "${TEST_BLUE}── 2. Fail-open semantics ──${TEST_NC}"
+
+# 2a: gh-api error → return rc=2, saturated=0.
+_reset_env
+set_shim GH_SHIM_FAIL=1
+out=$(_check_actions_queue_saturation "marcusquinn/aidevops"); rc=$?
+assert_eq "api error: rc=2"                     "2"   "$rc"
+assert_eq "api error: saturated=0"              "0"   "$(_field saturated "$out")"
+assert_eq "api error: queued=0"                 "0"   "$(_field queued "$out")"
+
+# 2b: Empty repo_slug → return rc=0, saturated=0 (defensive default).
+_reset_env
+out=$(_check_actions_queue_saturation ""); rc=$?
+assert_eq "empty slug: rc=0"                    "0"   "$rc"
+assert_eq "empty slug: saturated=0"             "0"   "$(_field saturated "$out")"
+
+# ---------------------------------------------------------------------------
+# Test class 3: bypass + disable controls
+# ---------------------------------------------------------------------------
+echo ""
+echo "${TEST_BLUE}── 3. Bypass / disable controls ──${TEST_NC}"
+
+# 3a: AIDEVOPS_SKIP_ACTIONS_QUEUE_SATURATION=1 short-circuits to saturated=0
+# even with API responses indicating clear saturation.
+_reset_env
+set_shim AIDEVOPS_SKIP_ACTIONS_QUEUE_SATURATION=1 \
+	GH_SHIM_QUEUED_TOTAL=110 GH_SHIM_IN_PROGRESS_TOTAL=3
+out=$(_check_actions_queue_saturation "marcusquinn/aidevops")
+assert_eq "bypass env: saturated=0 despite real saturation" "0" "$(_field saturated "$out")"
+assert_eq "bypass env: queued=0 (network not consulted)"    "0" "$(_field queued "$out")"
+
+# 3b: QUEUED_MIN=0 disables detection entirely.
+_reset_env
+set_shim AIDEVOPS_ACTIONS_QUEUE_SATURATION_QUEUED_MIN=0 \
+	GH_SHIM_QUEUED_TOTAL=110 GH_SHIM_IN_PROGRESS_TOTAL=3
+out=$(_check_actions_queue_saturation "marcusquinn/aidevops")
+assert_eq "queued_min=0: saturated=0 (disabled)" "0" "$(_field saturated "$out")"
+
+# ---------------------------------------------------------------------------
+# Test class 4: env-var threshold overrides
+# ---------------------------------------------------------------------------
+echo ""
+echo "${TEST_BLUE}── 4. Threshold env-var overrides ──${TEST_NC}"
+
+# 4a: Lower QUEUED_MIN to 5 — light load now classifies as saturated.
+_reset_env
+set_shim AIDEVOPS_ACTIONS_QUEUE_SATURATION_QUEUED_MIN=5 \
+	AIDEVOPS_ACTIONS_QUEUE_SATURATION_RATIO_MIN=2 \
+	GH_SHIM_QUEUED_TOTAL=10 GH_SHIM_IN_PROGRESS_TOTAL=2
+out=$(_check_actions_queue_saturation "marcusquinn/aidevops")
+assert_eq "lowered thresholds: ratio=5"          "5" "$(_field ratio "$out")"
+assert_eq "lowered thresholds: saturated=1"      "1" "$(_field saturated "$out")"
+
+# 4b: Raise QUEUED_MIN above incident shape — even canonical incident is OK.
+_reset_env
+set_shim AIDEVOPS_ACTIONS_QUEUE_SATURATION_QUEUED_MIN=200 \
+	GH_SHIM_QUEUED_TOTAL=110 GH_SHIM_IN_PROGRESS_TOTAL=3
+out=$(_check_actions_queue_saturation "marcusquinn/aidevops")
+assert_eq "raised threshold: saturated=0"       "0" "$(_field saturated "$out")"
+
+# ---------------------------------------------------------------------------
+# Test class 5: integration with _classify_stuck_pr
+# ---------------------------------------------------------------------------
+echo ""
+echo "${TEST_BLUE}── 5. _classify_stuck_pr integration ──${TEST_NC}"
+
+# Source the merge-stuck module — pulls in _classify_stuck_pr.
+# shellcheck disable=SC1090
+source "$MERGE_STUCK_HELPER"
+
+if ! declare -F _classify_stuck_pr >/dev/null 2>&1; then
+	echo "${TEST_RED}FATAL${TEST_NC}: _classify_stuck_pr not defined after sourcing $MERGE_STUCK_HELPER"
+	exit 1
+fi
+
+# 5a: is_saturated=1 + rollup has QUEUED check → STUCK_RUNNER_QUEUE_SATURATION.
+_reset_env
+set_shim 'GH_SHIM_PR_VIEW_JSON={"labels":[],"mergeable":"MERGEABLE","statusCheckRollup":[{"name":"Maintainer Gate","status":"QUEUED","conclusion":null}]}'
+classification=$(_classify_stuck_pr "12345" "marcusquinn/aidevops" "1")
+assert_eq "saturated+queued check: classification" "STUCK_RUNNER_QUEUE_SATURATION" "$classification"
+
+# 5b: is_saturated=0 + rollup has QUEUED check → falls through to STUCK_OTHER.
+# The shim's bare repo metadata returns default_branch="main", and the
+# protection probe returns "{}" (success path) — neither STUCK_BRANCHPROTECT_*
+# branch fires. No FAILURE entries in the rollup → STUCK_OTHER.
+_reset_env
+set_shim 'GH_SHIM_PR_VIEW_JSON={"labels":[],"mergeable":"MERGEABLE","statusCheckRollup":[{"name":"Maintainer Gate","status":"QUEUED","conclusion":null}]}'
+classification=$(_classify_stuck_pr "12345" "marcusquinn/aidevops" "0")
+assert_eq "unsaturated+queued check: classification" "STUCK_OTHER" "$classification"
+
+# 5c: is_saturated=1 + rollup has both QUEUED and FAILURE checks → priority
+# is QUEUED (the running outage masks per-PR failures).
+_reset_env
+set_shim 'GH_SHIM_PR_VIEW_JSON={"labels":[],"mergeable":"MERGEABLE","statusCheckRollup":[{"name":"Maintainer Gate","status":"QUEUED","conclusion":null},{"name":"Lint","status":"COMPLETED","conclusion":"FAILURE"}]}'
+classification=$(_classify_stuck_pr "12345" "marcusquinn/aidevops" "1")
+assert_eq "saturated+queued+failure: priority QUEUED" "STUCK_RUNNER_QUEUE_SATURATION" "$classification"
+
+# 5d: is_saturated=0 + rollup has FAILURE only → STUCK_CHECKS_FAILING.
+_reset_env
+set_shim 'GH_SHIM_PR_VIEW_JSON={"labels":[],"mergeable":"MERGEABLE","statusCheckRollup":[{"name":"Lint","status":"COMPLETED","conclusion":"FAILURE"}]}'
+classification=$(_classify_stuck_pr "12345" "marcusquinn/aidevops" "0")
+assert_eq "unsaturated+failure only: classification" "STUCK_CHECKS_FAILING" "$classification"
+
+# 5e: Default is_saturated parameter (omitted) → treated as 0.
+_reset_env
+set_shim 'GH_SHIM_PR_VIEW_JSON={"labels":[],"mergeable":"MERGEABLE","statusCheckRollup":[{"name":"Maintainer Gate","status":"QUEUED","conclusion":null}]}'
+classification=$(_classify_stuck_pr "12345" "marcusquinn/aidevops")
+assert_eq "default param: treated as is_saturated=0" "STUCK_OTHER" "$classification"
+
+# ---------------------------------------------------------------------------
+# Test class 6: shellcheck cleanliness
+# ---------------------------------------------------------------------------
+echo ""
+echo "${TEST_BLUE}── 6. Shellcheck ──${TEST_NC}"
+
+if command -v shellcheck >/dev/null 2>&1; then
+	if shellcheck "$RATE_LIMIT_HELPER" >/dev/null 2>&1; then
+		echo "${TEST_GREEN}PASS${TEST_NC}: shellcheck pulse-rate-limit-circuit-breaker.sh"
+		TESTS_RUN=$((TESTS_RUN + 1))
+	else
+		echo "${TEST_RED}FAIL${TEST_NC}: shellcheck pulse-rate-limit-circuit-breaker.sh"
+		shellcheck "$RATE_LIMIT_HELPER" || true
+		TESTS_RUN=$((TESTS_RUN + 1))
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+else
+	echo "  shellcheck not installed — skipping"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "${TEST_BLUE}━━━ Summary ━━━${TEST_NC}"
+echo "Tests run:    ${TESTS_RUN}"
+echo "Tests failed: ${TESTS_FAILED}"
+
+if [[ "$TESTS_FAILED" -eq 0 ]]; then
+	echo "${TEST_GREEN}All tests passed.${TEST_NC}"
+	exit 0
+else
+	echo "${TEST_RED}${TESTS_FAILED} test(s) failed.${TEST_NC}"
+	exit 1
+fi


### PR DESCRIPTION
## Summary

Implementation for issue #21942.

## Files Changed

.agents/configs/pulse-rate-limit.conf,.agents/reference/pulse-merge-stuck.md,.agents/scripts/pulse-merge-stuck.sh,.agents/scripts/pulse-rate-limit-circuit-breaker.sh,.agents/scripts/tests/test-actions-queue-saturation.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean, self-assessed

Resolves #21942


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.16 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-opus-4-7 spent 2h 22m and 122,475 tokens on this with the user in an interactive session.