### PR TITLE
GH#21948: shared proxy-lifecycle helper for cursor + google + claude

### DIFF
--- a/.agents/plugins/opencode-aidevops/claude-proxy.mjs
+++ b/.agents/plugins/opencode-aidevops/claude-proxy.mjs
@@ -40,38 +40,43 @@ import { streamClaudeResponse } from "./claude-proxy-streaming.mjs";
 import { buildProviderModels } from "./proxy-provider-models.mjs";
 import { jsonResponse, textResponse } from "./response-helpers.mjs";
 import { CLAUDE_MODEL_LIMITS } from "./model-limits.mjs";
+import { createProxyLifecycle, resolveProxyPort } from "./proxy-lifecycle.mjs";
 
-const CLAUDE_PROXY_DEFAULT_PORT = parseInt(process.env.CLAUDE_PROXY_PORT || "32125", 10);
 const CLAUDE_PROVIDER_ID = "claudecli";
+const CLAUDE_PROXY_PORT_DEFAULT = 32125;
+const CLAUDE_PROXY_PORT_ENV = "CLAUDE_PROXY_PORT";
 const OPENCODE_CONFIG_PATH = join(homedir(), ".config", "opencode", "opencode.json");
 /** Opt-in debug request dump — set CLAUDE_PROXY_DEBUG_DUMP=1 to enable. */
 const DEBUG_DUMP_ENABLED = process.env.CLAUDE_PROXY_DEBUG_DUMP === "1";
 
-// Probe-existing-proxy timeout. The historical 1s default was too short when
-// the existing proxy was mid-SSE-stream (verified: a busy proxy on 32125
-// timed out a `curl --max-time 2 /v1/models` request). 1500ms is the new
-// default; override via CLAUDE_PROXY_PROBE_TIMEOUT_MS for slow hosts. See
-// GH#21944 ("multi-instance startup printing scary error") for context.
-const CLAUDE_PROXY_PROBE_TIMEOUT_MS = parseInt(
-  process.env.CLAUDE_PROXY_PROBE_TIMEOUT_MS || "1500",
-  10,
-);
-/** Retry attempts for adopt-on-EADDRINUSE — short by design; if 5 probes
- * fail to find a server, the port is genuinely poisoned by something else. */
-const CLAUDE_PROXY_PROBE_RETRY_ATTEMPTS = 5;
-const CLAUDE_PROXY_PROBE_RETRY_INTERVAL_MS = 1000;
 const SSE_HEADERS = {
   "Content-Type": "text/event-stream",
   "Cache-Control": "no-cache",
   Connection: "keep-alive",
 };
 
+/**
+ * Lifecycle factory — owns probe / EADDRINUSE-adopt / retry state. The
+ * 1500ms probe timeout is the post-GH#21944 default (the prior 1s was
+ * too short when an existing proxy was mid-SSE-stream); override via
+ * CLAUDE_PROXY_PROBE_TIMEOUT_MS for slow hosts. See proxy-lifecycle.mjs
+ * for the full state machine and GH#21948 for the consolidation that
+ * factored the original copy out of this file.
+ */
+const claudeLifecycle = createProxyLifecycle({
+  name: "Claude",
+  defaultPort: CLAUDE_PROXY_PORT_DEFAULT,
+  envPortVar: CLAUDE_PROXY_PORT_ENV,
+  providerID: CLAUDE_PROVIDER_ID,
+  probePath: "/v1/models",
+  probeTimeoutMs: parseInt(
+    process.env.CLAUDE_PROXY_PROBE_TIMEOUT_MS || "1500",
+    10,
+  ),
+});
+
 /** @type {ReturnType<Bun["serve"]> | null} */
 let proxyServer = null;
-/** @type {number | null} */
-let proxyPort = null;
-/** @type {boolean} */
-let proxyStarting = false;
 
 // ---------------------------------------------------------------------------
 // Claude CLI availability + model catalogue
@@ -319,160 +324,49 @@ async function registerProxyAuth(client) {
 }
 
 /**
- * Probe whether a proxy server is already listening on CLAUDE_PROXY_DEFAULT_PORT.
- * Used in three scenarios:
- *   1. Pre-launch: avoid double-binding when another OpenCode session already
- *      runs a proxy on the default port.
- *   2. After plugin hot-reload: the module scope resets but the Bun.serve
- *      instance from the previous load lives on.
- *   3. Adopt-on-EADDRINUSE: when our own `Bun.serve` raises EADDRINUSE, the
- *      port owner is virtually always a sibling proxy that's still mid-startup
- *      (its fetch listener may not be ready yet — see probeExistingProxyWithRetry).
- *
- * Timeout sourced from CLAUDE_PROXY_PROBE_TIMEOUT_MS (default 1500ms) — a busy
- * proxy mid-SSE-stream can take >1s to answer a /v1/models request.
- *
- * Returns the port number on success, null if no server is reachable.
- */
-async function probeExistingProxy() {
-  try {
-    const controller = new AbortController();
-    const timer = setTimeout(() => controller.abort(), CLAUDE_PROXY_PROBE_TIMEOUT_MS);
-    const res = await fetch(
-      `http://127.0.0.1:${CLAUDE_PROXY_DEFAULT_PORT}/v1/models`,
-      { signal: controller.signal },
-    );
-    clearTimeout(timer);
-    if (res.ok) return CLAUDE_PROXY_DEFAULT_PORT;
-  } catch {
-    // not running or not reachable
-  }
-  return null;
-}
-
-/**
- * Probe with bounded retries — used by the EADDRINUSE adoption path. When a
- * sibling plugin is mid-startup, the port may already be `bind()`ed by Bun
- * but the fetch listener not yet reachable, so a single probe returns null
- * even though the owner will be ready in <1s.
- *
- * Retries CLAUDE_PROXY_PROBE_RETRY_ATTEMPTS times with
- * CLAUDE_PROXY_PROBE_RETRY_INTERVAL_MS spacing. Returns the port on first
- * success, null if every attempt fails.
- */
-async function probeExistingProxyWithRetry() {
-  for (let attempt = 0; attempt < CLAUDE_PROXY_PROBE_RETRY_ATTEMPTS; attempt++) {
-    const port = await probeExistingProxy();
-    if (port) return port;
-    if (attempt < CLAUDE_PROXY_PROBE_RETRY_ATTEMPTS - 1) {
-      await new Promise((resolve) =>
-        setTimeout(resolve, CLAUDE_PROXY_PROBE_RETRY_INTERVAL_MS),
-      );
-    }
-  }
-  return null;
-}
-
-/**
- * Heuristic: is this error a port-already-bound failure rather than a deeper
- * Bun.serve config problem? Bun raises EADDRINUSE; some shims raise
- * `listen EADDRINUSE`. We check both `code` and `message` so we don't miss
- * either form.
- */
-function isPortInUseError(err) {
-  if (!err) return false;
-  if (err.code === "EADDRINUSE") return true;
-  const msg = typeof err.message === "string" ? err.message : "";
-  return /EADDRINUSE|address already in use/i.test(msg);
-}
-
-/**
- * Pre-flight gate for `startClaudeProxy`. Returns:
- *   - `null` if the proxy should be skipped (no Bun, no claude CLI, race)
- *   - `{ port, models }` if the proxy is already running (fast-path)
- *   - `undefined` if the caller should proceed with a full launch
- */
-function checkProxyPreconditions() {
-  if (proxyStarting) return null;
-  if (proxyPort) return { port: proxyPort, models: getClaudeProxyModels() };
-  return undefined;
-}
-
-/**
  * Bring up the Bun.serve listener, register the provider, persist config.
- * Throws on any failure — `startClaudeProxy` translates that into a `null`
- * return so callers always see one of: `{port, models}` or `null`.
+ * Called by the shared lifecycle helper as the `launch` callback when no
+ * sibling proxy is reachable. Throws on bind failure — the lifecycle
+ * helper translates EADDRINUSE into a retry-probe adoption attempt and
+ * any other error into a logged `null` return.
  */
 async function launchProxyServer(client, directory) {
   proxyServer = Bun.serve({
-    port: CLAUDE_PROXY_DEFAULT_PORT,
+    port: resolveProxyPort(CLAUDE_PROXY_PORT_ENV, CLAUDE_PROXY_PORT_DEFAULT),
     hostname: "127.0.0.1",
     idleTimeout: 120,
     fetch: (req) => routeProxyRequest(req, directory),
   });
 
-  proxyPort = proxyServer.port;
   const models = getClaudeProxyModels();
 
   await registerProxyAuth(client);
-  persistClaudeProvider(proxyPort, models);
-  console.error(`[aidevops] Claude proxy: started on port ${proxyPort}`);
-  return { port: proxyPort, models };
+  persistClaudeProvider(proxyServer.port, models);
+  console.error(`[aidevops] Claude proxy: started on port ${proxyServer.port}`);
+  return { port: proxyServer.port };
 }
 
+/**
+ * Public entry point for both eager and lazy startup paths. The shared
+ * lifecycle helper handles probe-first adoption, EADDRINUSE-retry, and
+ * idempotent re-entry (see proxy-lifecycle.mjs). Returns `{port, models}`
+ * on success or `null` if the proxy can't run (no Bun, no claude CLI,
+ * or a poisoned port).
+ *
+ * Models are returned for both fresh-launch and adoption paths because
+ * the in-memory provider entry is rebuilt from `getClaudeProxyModels()`
+ * each call — adoption skips persisting them again (the sibling already
+ * did) but the caller still needs the list.
+ */
 export async function startClaudeProxy(client, directory) {
-  const earlyExit = checkProxyPreconditions();
-  if (earlyExit !== undefined) return earlyExit;
-
-  // Probe first: adopt any existing proxy (handles hot-reload and non-Bun runtimes).
-  // This avoids the module-scope reset issue where proxyPort is null after a
-  // plugin reload but the Bun.serve instance from the previous load is still live.
-  const existingPort = await probeExistingProxy();
-  if (existingPort) {
-    proxyPort = existingPort;
-    console.error(`[aidevops] Claude proxy: adopted existing server on port ${proxyPort}`);
-    return { port: proxyPort, models: getClaudeProxyModels() };
-  }
-
-  // No existing proxy — try to launch a new Bun.serve instance.
-  if (typeof globalThis.Bun === "undefined") {
-    console.error("[aidevops] Claude proxy: skipped (not running under Bun and no existing proxy found)");
-    return null;
-  }
-  if (!isClaudeCliAvailable()) return null;
-
-  proxyStarting = true;
-  let result = null;
-  try {
-    result = await launchProxyServer(client, directory);
-  } catch (err) {
-    // EADDRINUSE between probe and bind = sibling plugin won the race. The
-    // sibling's fetch handler may not be ready yet, so retry-probe before
-    // declaring failure. This collapses the historical "scary error +
-    // fallback succeeds" log pair into either a clean adoption or a single
-    // genuine failure. See GH#21944.
-    if (isPortInUseError(err)) {
-      const adoptedPort = await probeExistingProxyWithRetry();
-      if (adoptedPort) {
-        proxyPort = adoptedPort;
-        console.error(
-          `[aidevops] Claude proxy: adopted sibling server on port ${proxyPort} after EADDRINUSE`,
-        );
-        result = { port: proxyPort, models: getClaudeProxyModels() };
-      } else {
-        console.error(
-          `[aidevops] Claude proxy: port ${CLAUDE_PROXY_DEFAULT_PORT} in use but no responsive proxy found after ${CLAUDE_PROXY_PROBE_RETRY_ATTEMPTS} probes — port may be poisoned by another process`,
-        );
-      }
-    } else {
-      console.error(`[aidevops] Claude proxy: failed to start: ${err.message}`);
-    }
-  } finally {
-    proxyStarting = false;
-  }
-  return result;
+  const result = await claudeLifecycle.ensureStarted({
+    credentialsAvailable: isClaudeCliAvailable,
+    launch: () => launchProxyServer(client, directory),
+  });
+  if (!result) return null;
+  return { port: result.port, models: getClaudeProxyModels() };
 }
 
 export function getClaudeProxyPort() {
-  return proxyPort;
+  return claudeLifecycle.getPort();
 }

--- a/.agents/plugins/opencode-aidevops/cursor-proxy.mjs
+++ b/.agents/plugins/opencode-aidevops/cursor-proxy.mjs
@@ -21,6 +21,7 @@ import { readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 import { getAccounts, ensureValidToken, patchAccount } from "./oauth-pool.mjs";
+import { createProxyLifecycle, resolveProxyPort } from "./proxy-lifecycle.mjs";
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -35,17 +36,38 @@ import { getAccounts, ensureValidToken, patchAccount } from "./oauth-pool.mjs";
  * Override with CURSOR_PROXY_PORT env var if port 32123 conflicts.
  * (Nomadcxx/opencode-cursor uses 32124, so we use 32123 to avoid collision.)
  */
-const CURSOR_PROXY_DEFAULT_PORT = parseInt(process.env.CURSOR_PROXY_PORT || "32123", 10);
+const CURSOR_PROXY_PORT_DEFAULT = 32123;
+const CURSOR_PROXY_PORT_ENV = "CURSOR_PROXY_PORT";
 
 // ---------------------------------------------------------------------------
 // State
 // ---------------------------------------------------------------------------
 
-/** @type {number | null} */
-let proxyPort = null;
+/**
+ * Lifecycle factory — owns probe / EADDRINUSE-adopt / retry state for
+ * the Cursor gRPC proxy listener bind. The bind is now LAZY (post
+ * GH#21948): plugin init eagerly discovers models and registers the
+ * provider in opencode.json, but defers the `Bun.serve` listener bind
+ * to the first cursor/* request. See proxy-lifecycle.mjs for the full
+ * state machine.
+ */
+const cursorLifecycle = createProxyLifecycle({
+  name: "Cursor",
+  defaultPort: CURSOR_PROXY_PORT_DEFAULT,
+  envPortVar: CURSOR_PROXY_PORT_ENV,
+  providerID: "cursor",
+  probePath: "/v1/models",
+});
 
-/** @type {boolean} */
-let proxyStarting = false;
+/**
+ * Cached model list discovered eagerly during plugin init. Reused by
+ * the lazy listener bind so we don't re-fetch from the upstream Cursor
+ * API on every adoption. May be `null` (discovery not yet attempted)
+ * or `[]` (discovery failed, fallback to empty list).
+ *
+ * @type {Array<{id: string, name: string, reasoning?: boolean, contextWindow?: number, maxTokens?: number}> | null}
+ */
+let cachedModels = null;
 
 /** @type {string | null} */
 let activeAccountEmail = null;
@@ -107,113 +129,144 @@ async function getAccessToken() {
 // ---------------------------------------------------------------------------
 
 /**
- * Start the Cursor gRPC proxy and discover models.
- * Returns the proxy port, or null if no Cursor accounts are available.
+ * Set the auth entry for the cursor provider so OpenCode routes requests
+ * through our local proxy URL. Best-effort — failure is logged but never
+ * fatal (the proxy still works; OpenCode just falls back to its own auth
+ * prompt flow if needed).
  *
- * The proxy translates OpenAI-compatible HTTP requests to Cursor's
- * protobuf/HTTP2 Connect protocol via a Node.js H2 bridge subprocess.
- *
- * @param {any} client - OpenCode SDK client (for auth.set and provider registration)
- * @returns {Promise<{ port: number, models: Array<{ id: string, name: string }> } | null>}
+ * @param {any} client - OpenCode SDK client
  */
-export async function startCursorProxy(client) {
-  const accounts = getAccounts("cursor");
-  if (accounts.length === 0) {
-    return null;
-  }
-
-  // Prevent concurrent startup
-  if (proxyStarting) {
-    console.error("[aidevops] Cursor proxy: startup already in progress");
-    return null;
-  }
-
-  if (proxyPort) {
-    console.error(`[aidevops] Cursor proxy: already running on port ${proxyPort}`);
-    return { port: proxyPort, models: [] };
-  }
-
-  proxyStarting = true;
-
+async function setCursorAuth(client) {
   try {
-    // Get an initial valid token for model discovery
-    const initialToken = await getAccessToken();
-
-    // Discover available models via gRPC
-    const { getCursorModels } = await import("./cursor/models.js");
-    let models;
-    try {
-      models = await getCursorModels(initialToken);
-      console.error(`[aidevops] Cursor proxy: discovered ${models.length} models`);
-    } catch (err) {
-      console.error(`[aidevops] Cursor proxy: model discovery failed (${err.message}), using fallback list`);
-      models = null;
-    }
-
-    // Start the proxy — it binds to a random port
-    const { startProxy } = await import("./cursor/proxy.js");
-    const port = await startProxy(getAccessToken, models || []);
-    proxyPort = port;
-
-    console.error(`[aidevops] Cursor proxy: gRPC proxy started on port ${port}`);
-
-    // Inject auth into the cursor provider so OpenCode can route requests
-    try {
-      await client.auth.set({
-        path: { id: "cursor" },
-        body: {
-          type: "api",
-          key: "cursor-proxy",
-        },
-      });
-    } catch (err) {
-      console.error(`[aidevops] Cursor proxy: failed to set auth entry: ${err.message}`);
-    }
-
-    // Persist cursor provider + models to opencode.json so they appear in
-    // the model picker. The config hook only modifies the in-memory config;
-    // OpenCode reads opencode.json from disk for the model list.
-    const effectiveModels = models || [];
-    if (effectiveModels.length > 0) {
-      try {
-        persistCursorProvider(port, effectiveModels);
-      } catch (err) {
-        console.error(`[aidevops] Cursor proxy: failed to persist provider to opencode.json: ${err.message}`);
-      }
-    }
-
-    return { port, models: effectiveModels };
+    await client.auth.set({
+      path: { id: "cursor" },
+      body: { type: "api", key: "cursor-proxy" },
+    });
   } catch (err) {
-    console.error(`[aidevops] Cursor proxy: failed to start: ${err.message}`);
-    return null;
-  } finally {
-    proxyStarting = false;
+    console.error(`[aidevops] Cursor proxy: failed to set auth entry: ${err.message}`);
   }
 }
 
 /**
- * Stop the Cursor gRPC proxy.
+ * Discover available Cursor models via the upstream gRPC API. Falls back
+ * to an empty list if discovery fails — the lazy listener bind still
+ * happens, but the model picker will be empty until a subsequent eager
+ * refresh succeeds.
+ *
+ * @returns {Promise<Array<{id: string, name: string, reasoning?: boolean, contextWindow?: number, maxTokens?: number}>>}
+ */
+async function discoverCursorModels() {
+  const initialToken = await getAccessToken();
+  const { getCursorModels } = await import("./cursor/models.js");
+  try {
+    const models = await getCursorModels(initialToken);
+    console.error(`[aidevops] Cursor proxy: discovered ${models.length} models`);
+    return models;
+  } catch (err) {
+    console.error(`[aidevops] Cursor proxy: model discovery failed (${err.message}), using fallback list`);
+    return [];
+  }
+}
+
+/**
+ * Eagerly prepare the Cursor proxy: discover models, register the
+ * provider in opencode.json, and set the auth entry. Does NOT bind the
+ * `Bun.serve` listener — that's deferred to the first cursor/* request
+ * via `ensureCursorProxyServer`. Returns `{port, models}` on success or
+ * `null` if no Cursor accounts are configured.
+ *
+ * Called once during plugin init (in index.mjs). Skips silently when
+ * the pool has no Cursor accounts; logs and continues on individual
+ * failures (model discovery, persist, auth) so a partial degradation
+ * doesn't block other proxies from starting.
+ *
+ * Multi-instance is safe: every concurrent eager call resolves to the
+ * same deterministic port and the persist/auth side effects are
+ * idempotent. The race-prone `Bun.serve` bind only happens lazily and
+ * is protected by the lifecycle helper's probe-first-then-adopt path.
+ *
+ * @param {any} client - OpenCode SDK client (for auth.set)
+ * @returns {Promise<{ port: number, models: Array<{ id: string, name: string }> } | null>}
+ */
+export async function startCursorProxy(client) {
+  const accounts = getAccounts("cursor");
+  if (accounts.length === 0) return null;
+
+  cachedModels = await discoverCursorModels();
+
+  const port = resolveProxyPort(CURSOR_PROXY_PORT_ENV, CURSOR_PROXY_PORT_DEFAULT);
+
+  if (cachedModels.length > 0) {
+    try {
+      persistCursorProvider(port, cachedModels);
+    } catch (err) {
+      console.error(`[aidevops] Cursor proxy: failed to persist provider to opencode.json: ${err.message}`);
+    }
+  }
+
+  await setCursorAuth(client);
+
+  return { port, models: cachedModels };
+}
+
+/**
+ * Lazily bind the Cursor proxy listener. Called from the composed
+ * `experimental.chat.system.transform` hook on the first request whose
+ * `model.providerID === "cursor"`. The shared lifecycle helper handles
+ * probe-first adoption (sibling OpenCode session already serving),
+ * EADDRINUSE → adopt-with-retry (sibling won the bind race), and
+ * idempotent re-entry (cached port returned without re-binding).
+ *
+ * Falls back gracefully when called before `startCursorProxy` has
+ * populated `cachedModels` — passes an empty list to the upstream
+ * `cursor/proxy.js::startProxy`, which serves a model picker with no
+ * entries until eager discovery completes. Models are also retrieved
+ * fresh by `cursor/proxy.js` from the request stream when the
+ * underlying gRPC call runs, so this is a transient cosmetic state.
+ *
+ * @returns {Promise<{port: number, adopted: boolean} | null>}
+ */
+export async function ensureCursorProxyServer() {
+  return cursorLifecycle.ensureStarted({
+    credentialsAvailable: () => getAccounts("cursor").length > 0,
+    launch: async () => {
+      const { startProxy } = await import("./cursor/proxy.js");
+      const port = await startProxy(getAccessToken, cachedModels || []);
+      console.error(`[aidevops] Cursor proxy: gRPC proxy started on port ${port}`);
+      return { port };
+    },
+  });
+}
+
+/**
+ * Stop the Cursor gRPC proxy. Tears down the upstream `cursor/proxy.js`
+ * Bun.serve listener but does NOT clear the lifecycle helper's port
+ * cache — re-running `ensureCursorProxyServer` after stop will probe,
+ * fail, and bind a fresh listener.
+ *
+ * Currently unused by the plugin (no shutdown hook calls into here);
+ * retained for future cleanup paths and parity with the cursor proxy
+ * API surface.
  */
 export async function stopCursorGrpcProxy() {
-  if (proxyPort) {
+  if (cursorLifecycle.getPort() !== null) {
     try {
       const { stopProxy } = await import("./cursor/proxy.js");
       stopProxy();
     } catch {
       // Module may not be loaded
     }
-    proxyPort = null;
     activeAccountEmail = null;
     console.error("[aidevops] Cursor proxy: stopped");
   }
 }
 
 /**
- * Get the current proxy port, or null if not running.
+ * Get the current proxy port, or null if not yet bound.
  * @returns {number | null}
  */
 export function getCursorProxyPort() {
-  return proxyPort;
+  return cursorLifecycle.getPort();
 }
 
 // ---------------------------------------------------------------------------

--- a/.agents/plugins/opencode-aidevops/google-proxy.mjs
+++ b/.agents/plugins/opencode-aidevops/google-proxy.mjs
@@ -28,6 +28,7 @@
 import { join } from "path";
 import { getAccounts, ensureValidToken, patchAccount } from "./oauth-pool.mjs";
 import { jsonResponse, textResponse } from "./response-helpers.mjs";
+import { createProxyLifecycle, resolveProxyPort } from "./proxy-lifecycle.mjs";
 // Import + export: `export { … } from "./module"` is re-export only and
 // does NOT create a local binding. discoverGoogleModels and
 // persistGoogleProvider are both called locally below (see lines ~300 and
@@ -60,7 +61,8 @@ export {
  * Port 32124 chosen to avoid collision with Cursor proxy (32123).
  * Override with GOOGLE_PROXY_PORT env var if needed.
  */
-const GOOGLE_PROXY_DEFAULT_PORT = parseInt(process.env.GOOGLE_PROXY_PORT || "32124", 10);
+const GOOGLE_PROXY_PORT_DEFAULT = 32124;
+const GOOGLE_PROXY_PORT_ENV = "GOOGLE_PROXY_PORT";
 
 const GOOGLE_API_BASE = "https://generativelanguage.googleapis.com";
 
@@ -71,14 +73,36 @@ const RATE_LIMIT_COOLDOWN_MS = 60_000;
 // State
 // ---------------------------------------------------------------------------
 
-/** @type {object | null} Bun.serve server instance */
+/**
+ * Lifecycle factory — owns probe / EADDRINUSE-adopt / retry state for
+ * the Google auth-translating proxy listener bind. The bind is now LAZY
+ * (post GH#21948): plugin init eagerly discovers models and registers
+ * the provider in opencode.json, but defers the `Bun.serve` listener
+ * bind to the first google/* request. Probes `/health` rather than
+ * `/v1/models` because the Google proxy's `/v1/...` paths forward
+ * straight upstream. See proxy-lifecycle.mjs for the full state
+ * machine.
+ */
+const googleLifecycle = createProxyLifecycle({
+  name: "Google",
+  defaultPort: GOOGLE_PROXY_PORT_DEFAULT,
+  envPortVar: GOOGLE_PROXY_PORT_ENV,
+  providerID: "google",
+  probePath: "/health",
+});
+
+/** @type {object | null} Bun.serve server instance — held for stop() */
 let proxyServer = null;
 
-/** @type {number | null} */
-let proxyPort = null;
-
-/** @type {boolean} */
-let proxyStarting = false;
+/**
+ * Cached model list discovered eagerly during plugin init. Currently
+ * informational only (the Google proxy forwards requests transparently
+ * rather than serving a `/v1/models` endpoint), but kept for symmetry
+ * with cursor-proxy.mjs and to support future model-picker refresh.
+ *
+ * @type {Array<{id: string, name: string}> | null}
+ */
+let cachedModels = null;
 
 // activeAccountEmail removed — each request now tracks its own email via
 // getAccessToken() return value to avoid concurrent-request misattribution.
@@ -288,9 +312,87 @@ async function handleGoogleProxyFetch(req) {
 // Proxy server
 // ---------------------------------------------------------------------------
 
+/** Bun.serve error handler for the Google proxy. */
+function handleGoogleProxyServerError(err) {
+  console.error(`[aidevops] Google proxy: server error: ${err.message}`);
+  return textResponse("Internal Server Error", { status: 500 });
+}
+
 /**
- * Start the Google auth-translating proxy.
- * Returns the proxy port and discovered models, or null if no Google accounts.
+ * Discover Google models via the upstream Generative Language API.
+ * Falls back to an empty list on any failure — the lazy listener bind
+ * still happens, but the model picker will be empty until a subsequent
+ * eager refresh succeeds.
+ *
+ * @returns {Promise<Array<{id: string, name: string}>>}
+ */
+async function discoverModelsForGoogleProxy() {
+  let initialToken;
+  try {
+    const result = await getAccessToken();
+    initialToken = result.token;
+  } catch (err) {
+    console.error(`[aidevops] Google proxy: failed to get token for discovery: ${err.message}`);
+    return [];
+  }
+
+  try {
+    return await discoverGoogleModels(initialToken);
+  } catch (err) {
+    console.error(`[aidevops] Google proxy: model discovery failed (${err.message}), using empty list`);
+    return [];
+  }
+}
+
+/**
+ * Eagerly prepare the Google auth-translating proxy: discover models
+ * and register the provider in opencode.json. Does NOT bind the
+ * `Bun.serve` listener — that's deferred to the first google/* request
+ * via `ensureGoogleProxyServer`. Returns `{port, models}` on success or
+ * `null` if no Google accounts are configured.
+ *
+ * Called once during plugin init (in index.mjs). Skips silently when
+ * the pool has no Google accounts; logs and continues on individual
+ * failures (model discovery, persist) so a partial degradation doesn't
+ * block other proxies from starting.
+ *
+ * Multi-instance is safe: every concurrent eager call resolves to the
+ * same deterministic port and the persist side effect is idempotent.
+ * The race-prone `Bun.serve` bind only happens lazily and is protected
+ * by the lifecycle helper's probe-first-then-adopt path.
+ *
+ * @param {any} _client - OpenCode SDK client (currently unused, kept
+ *   for parity with cursor-proxy startCursorProxy signature in case
+ *   future hooks need client access during eager phase)
+ * @returns {Promise<{ port: number, models: Array<{ id: string, name: string }> } | null>}
+ */
+// eslint-disable-next-line no-unused-vars
+export async function startGoogleProxy(_client) {
+  const accounts = getAccounts("google");
+  if (accounts.length === 0) return null;
+
+  cachedModels = await discoverModelsForGoogleProxy();
+
+  const port = resolveProxyPort(GOOGLE_PROXY_PORT_ENV, GOOGLE_PROXY_PORT_DEFAULT);
+
+  if (cachedModels.length > 0) {
+    try {
+      persistGoogleProvider(port, cachedModels);
+    } catch (err) {
+      console.error(`[aidevops] Google proxy: failed to persist provider to opencode.json: ${err.message}`);
+    }
+  }
+
+  return { port, models: cachedModels };
+}
+
+/**
+ * Lazily bind the Google proxy listener. Called from the composed
+ * `experimental.chat.system.transform` hook on the first request whose
+ * `model.providerID === "google"`. The shared lifecycle helper handles
+ * probe-first adoption (sibling OpenCode session already serving),
+ * EADDRINUSE → adopt-with-retry (sibling won the bind race), and
+ * idempotent re-entry (cached port returned without re-binding).
  *
  * The proxy:
  *   1. Accepts requests from @ai-sdk/google (which sends x-goog-api-key)
@@ -300,75 +402,34 @@ async function handleGoogleProxyFetch(req) {
  *   5. Pipes response back (including SSE streams for streamGenerateContent)
  *   6. On 429, rotates to next pool account and retries once
  *
- * @param {any} client - OpenCode SDK client (for provider registration)
- * @returns {Promise<{ port: number, models: Array<{ id: string, name: string }> } | null>}
+ * @returns {Promise<{port: number, adopted: boolean} | null>}
  */
-/** Bun.serve error handler for the Google proxy. */
-function handleGoogleProxyServerError(err) {
-  console.error(`[aidevops] Google proxy: server error: ${err.message}`);
-  return textResponse("Internal Server Error", { status: 500 });
-}
-
-/** Discover models and start proxy; throws on failure (caller wraps in try/catch). */
-async function startGoogleProxyServer() {
-  const { token: initialToken } = await getAccessToken();
-  let models;
-  try {
-    models = await discoverGoogleModels(initialToken);
-  } catch (err) {
-    console.error(`[aidevops] Google proxy: model discovery failed (${err.message}), using empty list`);
-    models = [];
-  }
-  const server = Bun.serve({
-    port: GOOGLE_PROXY_DEFAULT_PORT,
-    hostname: "127.0.0.1",
-    fetch: handleGoogleProxyFetch,
-    error: handleGoogleProxyServerError,
+export async function ensureGoogleProxyServer() {
+  return googleLifecycle.ensureStarted({
+    credentialsAvailable: () => getAccounts("google").length > 0,
+    launch: async () => {
+      const server = Bun.serve({
+        port: resolveProxyPort(GOOGLE_PROXY_PORT_ENV, GOOGLE_PROXY_PORT_DEFAULT),
+        hostname: "127.0.0.1",
+        fetch: handleGoogleProxyFetch,
+        error: handleGoogleProxyServerError,
+      });
+      proxyServer = server;
+      console.error(`[aidevops] Google proxy: started on port ${server.port}`);
+      return { port: server.port };
+    },
   });
-  return { server, models };
-}
-
-export async function startGoogleProxy(client) {
-  const accounts = getAccounts("google");
-  if (accounts.length === 0) return null;
-
-  if (proxyStarting) {
-    console.error("[aidevops] Google proxy: startup already in progress");
-    return null;
-  }
-
-  if (proxyPort) {
-    console.error(`[aidevops] Google proxy: already running on port ${proxyPort}`);
-    return { port: proxyPort, models: [] };
-  }
-
-  proxyStarting = true;
-
-  try {
-    const { server, models } = await startGoogleProxyServer();
-    proxyServer = server;
-    proxyPort = proxyServer.port;
-    console.error(`[aidevops] Google proxy: started on port ${proxyPort}`);
-
-    if (models.length > 0) {
-      try {
-        persistGoogleProvider(proxyPort, models);
-      } catch (err) {
-        console.error(`[aidevops] Google proxy: failed to persist provider to opencode.json: ${err.message}`);
-      }
-    }
-
-    return { port: proxyPort, models };
-  } catch (err) {
-    console.error(`[aidevops] Google proxy: failed to start: ${err.message}`);
-    return null;
-  } finally {
-    proxyStarting = false;
-  }
 }
 
 /**
- * Stop the Google proxy.
+ * Stop the Google proxy listener. Tears down the `Bun.serve` instance
+ * but does NOT clear the lifecycle helper's port cache — re-running
+ * `ensureGoogleProxyServer` after stop will probe, fail, and bind a
+ * fresh listener.
+ *
+ * Currently unused by the plugin (no shutdown hook calls into here);
+ * retained for future cleanup paths and parity with the Google proxy
+ * API surface.
  */
 export function stopGoogleProxy() {
   if (proxyServer) {
@@ -378,17 +439,16 @@ export function stopGoogleProxy() {
       // Server may already be stopped
     }
     proxyServer = null;
-    proxyPort = null;
     console.error("[aidevops] Google proxy: stopped");
   }
 }
 
 /**
- * Get the current proxy port, or null if not running.
+ * Get the current proxy port, or null if not yet bound.
  * @returns {number | null}
  */
 export function getGoogleProxyPort() {
-  return proxyPort;
+  return googleLifecycle.getPort();
 }
 
 // Provider registration and config-persistence are in ./google-proxy-config.mjs

--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -43,9 +43,10 @@ import { initObservability, handleEvent } from "./observability.mjs";
 import { createTtsrHooks } from "./ttsr.mjs";
 import { createPoolAuthHook, createPoolTool, initPoolAuth, getAccounts } from "./oauth-pool.mjs";
 import { createProviderAuthHook } from "./provider-auth.mjs";
-import { startCursorProxy } from "./cursor-proxy.mjs";
-import { startGoogleProxy } from "./google-proxy.mjs";
+import { startCursorProxy, ensureCursorProxyServer } from "./cursor-proxy.mjs";
+import { startGoogleProxy, ensureGoogleProxyServer } from "./google-proxy.mjs";
 import { startClaudeProxy } from "./claude-proxy.mjs";
+import { isHeadless } from "./proxy-lifecycle.mjs";
 
 // ---------------------------------------------------------------------------
 // Directory constants
@@ -78,24 +79,6 @@ function run(cmd, timeout = 5000) {
   } catch {
     return "";
   }
-}
-
-/**
- * Detect headless OpenCode/CI sessions. Headless workers (pulse-spawned,
- * GitHub Actions, full-loop) only ever target anthropic/* via the OAuth
- * pool — they never request claudecli/*, so starting the Claude CLI proxy
- * for them is pure waste and contributes to multi-instance EADDRINUSE
- * races. Canonical env-var set per AGENTS.md "Main-branch planning
- * exception" rule (t1990). See GH#21944.
- * @returns {boolean}
- */
-function isHeadless() {
-  return Boolean(
-    process.env.FULL_LOOP_HEADLESS ||
-    process.env.AIDEVOPS_HEADLESS ||
-    process.env.OPENCODE_HEADLESS ||
-    process.env.GITHUB_ACTIONS,
-  );
 }
 
 /**
@@ -165,20 +148,28 @@ export async function AidevopsPlugin({ directory, client }) {
   // Initialise LLM observability
   initObservability();
 
-  // Cursor gRPC proxy
+  // Cursor gRPC proxy — eagerly discover models + register provider in
+  // opencode.json so the model picker is populated. Listener bind is
+  // LAZY (see systemTransformHook below) — defers `Bun.serve` until the
+  // first cursor/* request. Eliminates the multi-instance EADDRINUSE
+  // race that previously fired when N OpenCode sessions started together.
+  // See GH#21948.
   const cursorAccounts = getAccounts("cursor");
   if (cursorAccounts.length > 0) {
     try {
       const cursorProxyResult = await startCursorProxy(client);
       if (cursorProxyResult) {
-        console.error(`[aidevops] Cursor gRPC proxy started on port ${cursorProxyResult.port} with ${cursorProxyResult.models.length} models`);
+        console.error(`[aidevops] Cursor gRPC proxy registered on port ${cursorProxyResult.port} with ${cursorProxyResult.models.length} models (listener lazy)`);
       }
     } catch (err) {
-      console.error(`[aidevops] Cursor gRPC proxy failed to start: ${err.message}`);
+      console.error(`[aidevops] Cursor gRPC proxy failed to register: ${err.message}`);
     }
   }
 
-  // Google auth-translating proxy
+  // Google auth-translating proxy — same eager/lazy split as Cursor:
+  // eager phase persists the provider entry (URL, models) so the picker
+  // is populated; the `Bun.serve` listener bind defers to the first
+  // google/* request. See GH#21948.
   const googleAccounts = getAccounts("google");
   if (googleAccounts.length > 0) {
     try {
@@ -187,10 +178,10 @@ export async function AidevopsPlugin({ directory, client }) {
         if (!process.env.GOOGLE_GENERATIVE_AI_API_KEY) {
           process.env.GOOGLE_GENERATIVE_AI_API_KEY = "google-pool-proxy";
         }
-        console.error(`[aidevops] Google proxy started on port ${googleProxyResult.port} with ${googleProxyResult.models.length} models`);
+        console.error(`[aidevops] Google proxy registered on port ${googleProxyResult.port} with ${googleProxyResult.models.length} models (listener lazy)`);
       }
     } catch (err) {
-      console.error(`[aidevops] Google proxy failed to start: ${err.message}`);
+      console.error(`[aidevops] Google proxy failed to register: ${err.message}`);
     }
   }
 
@@ -198,9 +189,9 @@ export async function AidevopsPlugin({ directory, client }) {
   // (see systemTransformHook composition below). Eagerly starting on every
   // plugin init wasted resources in headless workers (which use anthropic/*
   // via OAuth pool, never claudecli/*) and caused N-instance EADDRINUSE
-  // races when N OpenCode sessions started simultaneously. See GH#21944.
-  // Headless workers skip startup entirely; interactive sessions defer
-  // startup until they actually request a claudecli model.
+  // races when N OpenCode sessions started simultaneously. See GH#21944
+  // for the original Claude-only fix and GH#21948 for the consolidation
+  // that brought cursor + google onto the same lazy-start pattern.
 
   // Create tools
   const baseTools = createTools(SCRIPTS_DIR, run);
@@ -238,18 +229,36 @@ export async function AidevopsPlugin({ directory, client }) {
     intentField: INTENT_FIELD,
   });
 
-  // Composed system.transform hook: lazy-start the Claude CLI proxy on the
-  // first claudecli/* request, then delegate to TTSR enforcement. See
-  // GH#21944. The proxy module is internally idempotent (proxyPort caching
-  // + adopt-on-EADDRINUSE), so repeat calls per request are cheap. Failures
-  // here are logged but never block the request — the underlying provider
-  // call will surface a clearer error if claudecli is genuinely unreachable.
+  // Lazy-start dispatch table for local proxies. Keys are OpenCode
+  // `model.providerID` values; values are thunks that bring up the
+  // proxy listener on demand via the shared lifecycle helper (which
+  // handles probe-first adoption, EADDRINUSE retry, and idempotent
+  // re-entry — see proxy-lifecycle.mjs). Repeat calls per request are
+  // cheap because the lifecycle caches the bound port. Headless workers
+  // skip dispatch entirely (they only ever target anthropic/* via the
+  // OAuth pool). See GH#21944 (Claude-only original) and GH#21948
+  // (consolidation across all three proxies).
+  const proxyStarters = {
+    claudecli: () => startClaudeProxy(client, directory),
+    cursor: () => ensureCursorProxyServer(),
+    google: () => ensureGoogleProxyServer(),
+  };
+
+  // Composed system.transform hook: lazy-start the appropriate local
+  // proxy on the first request whose providerID matches, then delegate
+  // to TTSR enforcement. Failures here are logged but never block the
+  // request — the underlying provider call will surface a clearer error
+  // if the proxy is genuinely unreachable.
   const systemTransformHook = async (input, output) => {
-    if (!isHeadless() && input?.model?.providerID === "claudecli") {
-      try {
-        await startClaudeProxy(client, directory);
-      } catch (err) {
-        console.error(`[aidevops] Claude proxy lazy-start failed: ${err.message}`);
+    const providerID = input?.model?.providerID;
+    if (providerID && !isHeadless()) {
+      const starter = proxyStarters[providerID];
+      if (starter) {
+        try {
+          await starter();
+        } catch (err) {
+          console.error(`[aidevops] ${providerID} proxy lazy-start failed: ${err.message}`);
+        }
       }
     }
     await ttsrSystemTransformHook(input, output);

--- a/.agents/plugins/opencode-aidevops/proxy-lifecycle.mjs
+++ b/.agents/plugins/opencode-aidevops/proxy-lifecycle.mjs
@@ -1,0 +1,379 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+/**
+ * Shared proxy lifecycle: probe-existing + EADDRINUSE-adopt + bounded retry.
+ *
+ * Every aidevops local proxy (Claude CLI, Cursor gRPC, Google auth-translating)
+ * binds a deterministic loopback port via `Bun.serve` and needs the same
+ * three race-resilience behaviours when N OpenCode sessions start at once:
+ *
+ *   1. Probe before bind — if a sibling instance already owns the port,
+ *      adopt the URL instead of double-binding.
+ *   2. EADDRINUSE adoption — if our `Bun.serve` raises EADDRINUSE because
+ *      a sibling won the bind race during the gap between probe and bind,
+ *      retry the probe (the sibling's fetch listener may not be up yet).
+ *   3. Idempotent re-entry — repeat calls during a single startup are
+ *      cheap (gated by an in-flight flag) and once started, return the
+ *      cached port without re-binding.
+ *
+ * This module factors that pattern out of `claude-proxy.mjs` (where it
+ * landed in PR #21951 / GH#21944) so `cursor-proxy.mjs` and
+ * `google-proxy.mjs` can share it instead of growing copies that drift.
+ *
+ * Each proxy file calls `createProxyLifecycle({ … })` once at module scope
+ * and owns the resulting `{ ensureStarted, getPort, providerID }` object.
+ * `ensureStarted({ credentialsAvailable, launch })` is the single entry
+ * point — caller supplies the credential check and the bind action; this
+ * helper supplies the race-resilience.
+ *
+ * See GH#21944 (lazy-start + EADDRINUSE adopt for claude-proxy) and
+ * GH#21948 (this consolidation).
+ */
+
+// ---------------------------------------------------------------------------
+// Headless detection (shared)
+// ---------------------------------------------------------------------------
+
+/**
+ * Detect headless OpenCode/CI sessions. Headless workers (pulse-spawned,
+ * GitHub Actions, full-loop) only ever target anthropic/* via the OAuth
+ * pool — they never request claudecli/* / cursor/* / google/*, so starting
+ * a local proxy listener for them is pure waste and contributes to
+ * multi-instance EADDRINUSE races. Canonical env-var set per AGENTS.md
+ * "Main-branch planning exception" rule (t1990). See GH#21944.
+ *
+ * Used by `index.mjs` to gate the `experimental.chat.system.transform`
+ * hook's lazy-start dispatch table — headless workers skip the bind path
+ * entirely.
+ *
+ * @returns {boolean}
+ */
+export function isHeadless() {
+  return Boolean(
+    process.env.FULL_LOOP_HEADLESS ||
+    process.env.AIDEVOPS_HEADLESS ||
+    process.env.OPENCODE_HEADLESS ||
+    process.env.GITHUB_ACTIONS,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// EADDRINUSE detection (shared)
+// ---------------------------------------------------------------------------
+
+/**
+ * Heuristic: is this error a port-already-bound failure rather than a
+ * deeper Bun.serve config problem? Bun raises EADDRINUSE; some shims raise
+ * `listen EADDRINUSE`. We check both `code` and `message` so we don't miss
+ * either form.
+ *
+ * @param {unknown} err
+ * @returns {boolean}
+ */
+export function isPortInUseError(err) {
+  if (!err) return false;
+  // err may be any thrown value (Error, string, plain object). Narrow safely.
+  const code = /** @type {{code?: string}} */ (err).code;
+  if (code === "EADDRINUSE") return true;
+  const message = /** @type {{message?: unknown}} */ (err).message;
+  const msg = typeof message === "string" ? message : "";
+  return /EADDRINUSE|address already in use/i.test(msg);
+}
+
+// ---------------------------------------------------------------------------
+// Standalone probe helpers (also used by the factory below)
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the port from an env-var override or fall back to the default.
+ * Centralised so every proxy uses the same parsing rules (radix 10, no
+ * silent NaN). Caller validates the result.
+ *
+ * @param {string} envVar - Name of the env var to consult
+ * @param {number} defaultPort - Numeric default if env var is unset/empty
+ * @returns {number}
+ */
+export function resolveProxyPort(envVar, defaultPort) {
+  const raw = process.env[envVar];
+  if (!raw) return defaultPort;
+  const parsed = parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : defaultPort;
+}
+
+/**
+ * Probe whether a proxy server is already listening on `port` by
+ * fetching `http://127.0.0.1:${port}${path}` with an AbortController-
+ * backed timeout.
+ *
+ * Returns the port on success (so callers can fluently assign it),
+ * `null` on any failure (timeout, connection refused, non-2xx).
+ *
+ * @param {number} port
+ * @param {string} path
+ * @param {number} timeoutMs
+ * @returns {Promise<number|null>}
+ */
+export async function probeProxy(port, path, timeoutMs) {
+  try {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), timeoutMs);
+    const res = await fetch(`http://127.0.0.1:${port}${path}`, {
+      signal: controller.signal,
+    });
+    clearTimeout(timer);
+    if (res.ok) return port;
+  } catch {
+    // not running, not reachable, or timed out
+  }
+  return null;
+}
+
+/**
+ * Probe with bounded retries — used by the EADDRINUSE adoption path.
+ *
+ * When a sibling plugin is mid-startup, the port may already be `bind()`ed
+ * by Bun but the fetch listener not yet reachable, so a single probe
+ * returns null even though the owner will be ready in <1s.
+ *
+ * Retries `attempts` times with `intervalMs` spacing. Returns the port
+ * on first success, `null` if every attempt fails (port likely poisoned
+ * by an unrelated process — caller should report failure).
+ *
+ * @param {number} port
+ * @param {string} path
+ * @param {number} timeoutMs
+ * @param {number} attempts
+ * @param {number} intervalMs
+ * @returns {Promise<number|null>}
+ */
+export async function probeProxyWithRetry(port, path, timeoutMs, attempts, intervalMs) {
+  for (let attempt = 0; attempt < attempts; attempt++) {
+    const found = await probeProxy(port, path, timeoutMs);
+    if (found) return found;
+    if (attempt < attempts - 1) {
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// Lifecycle factory
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {Object} ProxyLifecycleOptions
+ * @property {string} name
+ *   Human-readable proxy name for log prefixes (e.g. "Claude", "Cursor",
+ *   "Google"). Used as `[aidevops] ${name} proxy: …`.
+ * @property {number} defaultPort
+ *   Canonical loopback port the proxy binds. Each proxy claims a fixed
+ *   port so opencode.json `api: http://127.0.0.1:<port>/v1` survives
+ *   restart and multi-instance races converge on adoption.
+ * @property {string} envPortVar
+ *   Env-var name that overrides `defaultPort` for users who hit a port
+ *   collision (e.g. `CLAUDE_PROXY_PORT`, `CURSOR_PROXY_PORT`,
+ *   `GOOGLE_PROXY_PORT`).
+ * @property {string} providerID
+ *   OpenCode provider ID (e.g. `claudecli`, `cursor`, `google`). The
+ *   composed `experimental.chat.system.transform` hook in index.mjs
+ *   dispatches lazy-start by matching `input.model.providerID` against
+ *   this string.
+ * @property {string} [probePath]
+ *   HTTP GET path that returns 2xx from a healthy proxy (default
+ *   `/v1/models`). Google's proxy uses `/health`.
+ * @property {number} [probeTimeoutMs]
+ *   Per-probe timeout in ms (default 1500). The historical 1s default
+ *   was too short when the existing proxy was mid-SSE-stream. See
+ *   GH#21944.
+ * @property {number} [probeRetryAttempts]
+ *   EADDRINUSE-adoption retry count (default 5). If 5 probes fail to
+ *   find a server, the port is genuinely poisoned by something else.
+ * @property {number} [probeRetryIntervalMs]
+ *   Spacing between retry probes in ms (default 1000).
+ */
+
+/**
+ * @typedef {Object} EnsureStartedOptions
+ * @property {() => boolean} credentialsAvailable
+ *   Returns true if the proxy can actually serve traffic (e.g. accounts
+ *   exist in the OAuth pool, or the upstream CLI is on PATH). Returning
+ *   false short-circuits to a clean `null` return without binding.
+ * @property {() => Promise<{port: number}>} launch
+ *   Performs the actual `Bun.serve` bind and any post-bind side effects
+ *   (auth registration, opencode.json persistence, model discovery).
+ *   Throws on any bind failure — the lifecycle helper catches and
+ *   classifies (EADDRINUSE → adopt-with-retry, else → log + return null).
+ *   Must return `{ port }` on success.
+ */
+
+/**
+ * @typedef {Object} EnsureStartedResult
+ * @property {number} port - Final port (either freshly bound or adopted).
+ * @property {boolean} adopted - True if we adopted a sibling's listener,
+ *   false if we did the bind ourselves. Callers may use this to skip
+ *   redundant side effects (e.g. don't re-persist opencode.json — the
+ *   sibling already did).
+ */
+
+/**
+ * Create a per-proxy lifecycle controller. Call once at module scope in
+ * each proxy file; the returned object owns the proxy's port + in-flight
+ * state in closure.
+ *
+ * The controller is internally idempotent: parallel `ensureStarted` calls
+ * during initial startup short-circuit (the second sees `starting=true`
+ * and returns null), and post-startup calls return the cached port
+ * without re-binding.
+ *
+ * @param {ProxyLifecycleOptions} options
+ * @returns {{
+ *   providerID: string,
+ *   getPort: () => number | null,
+ *   ensureStarted: (opts: EnsureStartedOptions) => Promise<EnsureStartedResult | null>,
+ * }}
+ */
+export function createProxyLifecycle(options) {
+  const {
+    name,
+    defaultPort,
+    envPortVar,
+    providerID,
+    probePath = "/v1/models",
+    probeTimeoutMs = 1500,
+    probeRetryAttempts = 5,
+    probeRetryIntervalMs = 1000,
+  } = options;
+
+  // Closure-private state — one set per proxy instance.
+  /** @type {number | null} */
+  let port = null;
+  /** @type {boolean} */
+  let starting = false;
+
+  const targetPort = resolveProxyPort(envPortVar, defaultPort);
+
+  async function probeOnce() {
+    return probeProxy(targetPort, probePath, probeTimeoutMs);
+  }
+
+  async function probeWithRetry() {
+    return probeProxyWithRetry(
+      targetPort,
+      probePath,
+      probeTimeoutMs,
+      probeRetryAttempts,
+      probeRetryIntervalMs,
+    );
+  }
+
+  /**
+   * Try to adopt a sibling listener after our own bind raised EADDRINUSE.
+   * Splits the post-EADDRINUSE branch out of `ensureStarted` so the main
+   * function stays under the framework's function-complexity gate.
+   *
+   * @returns {Promise<EnsureStartedResult | null>}
+   */
+  async function attemptEaddrinuseAdoption() {
+    const adoptedPort = await probeWithRetry();
+    if (adoptedPort) {
+      port = adoptedPort;
+      console.error(
+        `[aidevops] ${name} proxy: adopted sibling server on port ${port} after EADDRINUSE`,
+      );
+      return { port, adopted: true };
+    }
+    console.error(
+      `[aidevops] ${name} proxy: port ${targetPort} in use but no responsive proxy found after ${probeRetryAttempts} probes — port may be poisoned by another process`,
+    );
+    return null;
+  }
+
+  /**
+   * Try to launch the proxy via the caller-supplied `launch` callback,
+   * with EADDRINUSE → adopt-with-retry recovery. Caller has already
+   * verified credentials and we are not adopting an existing listener.
+   *
+   * @param {() => Promise<{port: number}>} launch
+   * @returns {Promise<EnsureStartedResult | null>}
+   */
+  async function tryLaunch(launch) {
+    starting = true;
+    try {
+      const result = await launch();
+      port = result.port;
+      return { port, adopted: false };
+    } catch (err) {
+      if (isPortInUseError(err)) {
+        // EADDRINUSE between probe and bind = sibling plugin won the
+        // race. Sibling's fetch handler may not be ready yet, so retry-
+        // probe before declaring failure. Collapses the historical
+        // "scary error + fallback succeeds" log pair into either a
+        // clean adoption or a single genuine failure. See GH#21944.
+        return attemptEaddrinuseAdoption();
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`[aidevops] ${name} proxy: failed to start: ${message}`);
+      return null;
+    } finally {
+      starting = false;
+    }
+  }
+
+  /**
+   * Bring the proxy up if it isn't already, with full race-resilience.
+   *
+   * Order of operations:
+   *   1. If we're mid-startup (`starting`), bail — second concurrent
+   *      caller returns null rather than racing.
+   *   2. If we already have a cached port, return it (adopted=false
+   *      because we don't know — the cached value covers both fresh
+   *      bind and prior adoption transparently).
+   *   3. Probe-first: if a sibling already serves the port, adopt it.
+   *   4. Verify Bun is available (we can't bind without it) and the
+   *      caller's credential check passes.
+   *   5. Call `launch()`; on EADDRINUSE, retry-probe to adopt the
+   *      sibling that won the race.
+   *
+   * @param {EnsureStartedOptions} opts
+   * @returns {Promise<EnsureStartedResult | null>}
+   */
+  async function ensureStarted(opts) {
+    if (starting) return null;
+    if (port !== null) return { port, adopted: false };
+
+    // Probe first — handles plugin hot-reload (module scope reset, but
+    // the previous Bun.serve instance lives on) and adopts any sibling
+    // that's already serving requests.
+    const existing = await probeOnce();
+    if (existing) {
+      port = existing;
+      console.error(
+        `[aidevops] ${name} proxy: adopted existing server on port ${port}`,
+      );
+      return { port, adopted: true };
+    }
+
+    if (typeof globalThis.Bun === "undefined") {
+      console.error(
+        `[aidevops] ${name} proxy: skipped (not running under Bun and no existing proxy found)`,
+      );
+      return null;
+    }
+
+    if (!opts.credentialsAvailable()) {
+      // Caller-defined precondition failed (no accounts / CLI missing).
+      // Silent return; the caller logs context if useful.
+      return null;
+    }
+
+    return tryLaunch(opts.launch);
+  }
+
+  return {
+    providerID,
+    getPort: () => port,
+    ensureStarted,
+  };
+}

--- a/.agents/plugins/opencode-aidevops/proxy-lifecycle.mjs
+++ b/.agents/plugins/opencode-aidevops/proxy-lifecycle.mjs
@@ -217,10 +217,172 @@ export async function probeProxyWithRetry(port, path, timeoutMs, attempts, inter
  *   sibling already did).
  */
 
+// ---------------------------------------------------------------------------
+// Module-level lifecycle helpers
+// ---------------------------------------------------------------------------
+//
+// These are hoisted out of `createProxyLifecycle`'s closure (where they lived
+// in the first cut of GH#21948) and take the lifecycle state object as their
+// first argument. The motivation is purely a quality-gate concern: when these
+// helpers were nested, qlty's `function-complexity` and `return-statements`
+// counters rolled their inner returns up into `createProxyLifecycle`'s totals,
+// pushing the factory over the threshold (cc=20, returns=14). Hoisting drops
+// the factory's effective metrics to ~2/2 without changing observable
+// behaviour or the public API. State is still encapsulated — the lifecycle
+// object is closed over only by the small accessor lambdas the factory
+// returns.
+
+/**
+ * @typedef {Object} LifecycleState
+ * @property {string} name
+ * @property {string} providerID
+ * @property {string} probePath
+ * @property {number} probeTimeoutMs
+ * @property {number} probeRetryAttempts
+ * @property {number} probeRetryIntervalMs
+ * @property {number} targetPort
+ * @property {number | null} port
+ * @property {boolean} starting
+ */
+
+/**
+ * Probe once at the lifecycle's target port and adopt if found.
+ *
+ * @param {LifecycleState} lifecycle
+ * @returns {Promise<EnsureStartedResult | null>}
+ */
+async function tryAdoptExisting(lifecycle) {
+  const existing = await probeProxy(
+    lifecycle.targetPort,
+    lifecycle.probePath,
+    lifecycle.probeTimeoutMs,
+  );
+  if (!existing) return null;
+  lifecycle.port = existing;
+  console.error(
+    `[aidevops] ${lifecycle.name} proxy: adopted existing server on port ${lifecycle.port}`,
+  );
+  return { port: lifecycle.port, adopted: true };
+}
+
+/**
+ * Try to adopt a sibling listener after our own bind raised EADDRINUSE.
+ * Splits the post-EADDRINUSE branch out of `tryLaunch` so the main
+ * function stays under the framework's function-complexity gate.
+ *
+ * @param {LifecycleState} lifecycle
+ * @returns {Promise<EnsureStartedResult | null>}
+ */
+async function attemptEaddrinuseAdoption(lifecycle) {
+  const adoptedPort = await probeProxyWithRetry(
+    lifecycle.targetPort,
+    lifecycle.probePath,
+    lifecycle.probeTimeoutMs,
+    lifecycle.probeRetryAttempts,
+    lifecycle.probeRetryIntervalMs,
+  );
+  if (adoptedPort) {
+    lifecycle.port = adoptedPort;
+    console.error(
+      `[aidevops] ${lifecycle.name} proxy: adopted sibling server on port ${lifecycle.port} after EADDRINUSE`,
+    );
+    return { port: lifecycle.port, adopted: true };
+  }
+  console.error(
+    `[aidevops] ${lifecycle.name} proxy: port ${lifecycle.targetPort} in use but no responsive proxy found after ${lifecycle.probeRetryAttempts} probes — port may be poisoned by another process`,
+  );
+  return null;
+}
+
+/**
+ * Try to launch the proxy via the caller-supplied `launch` callback,
+ * with EADDRINUSE → adopt-with-retry recovery. Caller has already
+ * verified credentials and we are not adopting an existing listener.
+ *
+ * @param {LifecycleState} lifecycle
+ * @param {() => Promise<{port: number}>} launch
+ * @returns {Promise<EnsureStartedResult | null>}
+ */
+async function tryLaunch(lifecycle, launch) {
+  lifecycle.starting = true;
+  try {
+    const result = await launch();
+    lifecycle.port = result.port;
+    return { port: lifecycle.port, adopted: false };
+  } catch (err) {
+    if (isPortInUseError(err)) {
+      // EADDRINUSE between probe and bind = sibling plugin won the
+      // race. Sibling's fetch handler may not be ready yet, so retry-
+      // probe before declaring failure. Collapses the historical
+      // "scary error + fallback succeeds" log pair into either a
+      // clean adoption or a single genuine failure. See GH#21944.
+      return attemptEaddrinuseAdoption(lifecycle);
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`[aidevops] ${lifecycle.name} proxy: failed to start: ${message}`);
+    return null;
+  } finally {
+    lifecycle.starting = false;
+  }
+}
+
+/**
+ * Apply launch preconditions (Bun present, credentials available) and
+ * delegate to `tryLaunch`. Splitting this out of `ensureStarted` keeps
+ * the main entry point's return count under the qlty threshold.
+ *
+ * @param {LifecycleState} lifecycle
+ * @param {EnsureStartedOptions} opts
+ * @returns {Promise<EnsureStartedResult | null>}
+ */
+async function tryLaunchIfPossible(lifecycle, opts) {
+  if (typeof globalThis.Bun === "undefined") {
+    console.error(
+      `[aidevops] ${lifecycle.name} proxy: skipped (not running under Bun and no existing proxy found)`,
+    );
+    return null;
+  }
+  // Caller-defined precondition failed (no accounts / CLI missing).
+  // Silent return; the caller logs context if useful.
+  if (!opts.credentialsAvailable()) return null;
+  return tryLaunch(lifecycle, opts.launch);
+}
+
+/**
+ * Bring the proxy up if it isn't already, with full race-resilience.
+ *
+ * Order of operations:
+ *   1. If we're mid-startup (`starting`), bail — second concurrent
+ *      caller returns null rather than racing.
+ *   2. If we already have a cached port, return it (adopted=false
+ *      because we don't know — the cached value covers both fresh
+ *      bind and prior adoption transparently).
+ *   3. Probe-first: if a sibling already serves the port, adopt it.
+ *   4. Verify Bun is available (we can't bind without it) and the
+ *      caller's credential check passes; then call `launch()`. On
+ *      EADDRINUSE, retry-probe to adopt the sibling that won the race.
+ *
+ * @param {LifecycleState} lifecycle
+ * @param {EnsureStartedOptions} opts
+ * @returns {Promise<EnsureStartedResult | null>}
+ */
+async function ensureStartedImpl(lifecycle, opts) {
+  if (lifecycle.starting) return null;
+  if (lifecycle.port !== null) return { port: lifecycle.port, adopted: false };
+
+  // Probe first — handles plugin hot-reload (module scope reset, but
+  // the previous Bun.serve instance lives on) and adopts any sibling
+  // that's already serving requests.
+  const adopted = await tryAdoptExisting(lifecycle);
+  if (adopted) return adopted;
+
+  return tryLaunchIfPossible(lifecycle, opts);
+}
+
 /**
  * Create a per-proxy lifecycle controller. Call once at module scope in
  * each proxy file; the returned object owns the proxy's port + in-flight
- * state in closure.
+ * state in closure (via the `lifecycle` object).
  *
  * The controller is internally idempotent: parallel `ensureStarted` calls
  * during initial startup short-circuit (the second sees `starting=true`
@@ -235,145 +397,21 @@ export async function probeProxyWithRetry(port, path, timeoutMs, attempts, inter
  * }}
  */
 export function createProxyLifecycle(options) {
-  const {
-    name,
-    defaultPort,
-    envPortVar,
-    providerID,
-    probePath = "/v1/models",
-    probeTimeoutMs = 1500,
-    probeRetryAttempts = 5,
-    probeRetryIntervalMs = 1000,
-  } = options;
-
-  // Closure-private state — one set per proxy instance.
-  /** @type {number | null} */
-  let port = null;
-  /** @type {boolean} */
-  let starting = false;
-
-  const targetPort = resolveProxyPort(envPortVar, defaultPort);
-
-  async function probeOnce() {
-    return probeProxy(targetPort, probePath, probeTimeoutMs);
-  }
-
-  async function probeWithRetry() {
-    return probeProxyWithRetry(
-      targetPort,
-      probePath,
-      probeTimeoutMs,
-      probeRetryAttempts,
-      probeRetryIntervalMs,
-    );
-  }
-
-  /**
-   * Try to adopt a sibling listener after our own bind raised EADDRINUSE.
-   * Splits the post-EADDRINUSE branch out of `ensureStarted` so the main
-   * function stays under the framework's function-complexity gate.
-   *
-   * @returns {Promise<EnsureStartedResult | null>}
-   */
-  async function attemptEaddrinuseAdoption() {
-    const adoptedPort = await probeWithRetry();
-    if (adoptedPort) {
-      port = adoptedPort;
-      console.error(
-        `[aidevops] ${name} proxy: adopted sibling server on port ${port} after EADDRINUSE`,
-      );
-      return { port, adopted: true };
-    }
-    console.error(
-      `[aidevops] ${name} proxy: port ${targetPort} in use but no responsive proxy found after ${probeRetryAttempts} probes — port may be poisoned by another process`,
-    );
-    return null;
-  }
-
-  /**
-   * Try to launch the proxy via the caller-supplied `launch` callback,
-   * with EADDRINUSE → adopt-with-retry recovery. Caller has already
-   * verified credentials and we are not adopting an existing listener.
-   *
-   * @param {() => Promise<{port: number}>} launch
-   * @returns {Promise<EnsureStartedResult | null>}
-   */
-  async function tryLaunch(launch) {
-    starting = true;
-    try {
-      const result = await launch();
-      port = result.port;
-      return { port, adopted: false };
-    } catch (err) {
-      if (isPortInUseError(err)) {
-        // EADDRINUSE between probe and bind = sibling plugin won the
-        // race. Sibling's fetch handler may not be ready yet, so retry-
-        // probe before declaring failure. Collapses the historical
-        // "scary error + fallback succeeds" log pair into either a
-        // clean adoption or a single genuine failure. See GH#21944.
-        return attemptEaddrinuseAdoption();
-      }
-      const message = err instanceof Error ? err.message : String(err);
-      console.error(`[aidevops] ${name} proxy: failed to start: ${message}`);
-      return null;
-    } finally {
-      starting = false;
-    }
-  }
-
-  /**
-   * Bring the proxy up if it isn't already, with full race-resilience.
-   *
-   * Order of operations:
-   *   1. If we're mid-startup (`starting`), bail — second concurrent
-   *      caller returns null rather than racing.
-   *   2. If we already have a cached port, return it (adopted=false
-   *      because we don't know — the cached value covers both fresh
-   *      bind and prior adoption transparently).
-   *   3. Probe-first: if a sibling already serves the port, adopt it.
-   *   4. Verify Bun is available (we can't bind without it) and the
-   *      caller's credential check passes.
-   *   5. Call `launch()`; on EADDRINUSE, retry-probe to adopt the
-   *      sibling that won the race.
-   *
-   * @param {EnsureStartedOptions} opts
-   * @returns {Promise<EnsureStartedResult | null>}
-   */
-  async function ensureStarted(opts) {
-    if (starting) return null;
-    if (port !== null) return { port, adopted: false };
-
-    // Probe first — handles plugin hot-reload (module scope reset, but
-    // the previous Bun.serve instance lives on) and adopts any sibling
-    // that's already serving requests.
-    const existing = await probeOnce();
-    if (existing) {
-      port = existing;
-      console.error(
-        `[aidevops] ${name} proxy: adopted existing server on port ${port}`,
-      );
-      return { port, adopted: true };
-    }
-
-    if (typeof globalThis.Bun === "undefined") {
-      console.error(
-        `[aidevops] ${name} proxy: skipped (not running under Bun and no existing proxy found)`,
-      );
-      return null;
-    }
-
-    if (!opts.credentialsAvailable()) {
-      // Caller-defined precondition failed (no accounts / CLI missing).
-      // Silent return; the caller logs context if useful.
-      return null;
-    }
-
-    return tryLaunch(opts.launch);
-  }
-
+  /** @type {LifecycleState} */
+  const lifecycle = {
+    name: options.name,
+    providerID: options.providerID,
+    probePath: options.probePath ?? "/v1/models",
+    probeTimeoutMs: options.probeTimeoutMs ?? 1500,
+    probeRetryAttempts: options.probeRetryAttempts ?? 5,
+    probeRetryIntervalMs: options.probeRetryIntervalMs ?? 1000,
+    targetPort: resolveProxyPort(options.envPortVar, options.defaultPort),
+    port: null,
+    starting: false,
+  };
   return {
-    providerID,
-    getPort: () => port,
-    ensureStarted,
+    providerID: lifecycle.providerID,
+    getPort: () => lifecycle.port,
+    ensureStarted: (opts) => ensureStartedImpl(lifecycle, opts),
   };
 }


### PR DESCRIPTION
## Summary

Factor lazy-start + EADDRINUSE-adopt mechanics from `claude-proxy.mjs` (#21944) into a shared `proxy-lifecycle.mjs` and migrate `cursor-proxy.mjs` and `google-proxy.mjs` to use it. Each proxy now splits into an eager phase (model discovery + provider registration in `opencode.json` — runs at plugin init) and a lazy phase (Bun.serve listener bind — defers to first matching tool call). Eliminates the multi-instance EADDRINUSE race that previously fired when N OpenCode sessions started together for cursor and google, matching the protection #21944 added for claude.

## Why

GH#21944 fixed `claude-proxy.mjs` by introducing lazy listener bind + EADDRINUSE-adopt. Cursor and google had the same race (N sessions × 3 hardcoded ports = 3N EADDRINUSE bursts on cold start). The lifecycle code was claude-specific and ~150 lines of probe/adopt/start machinery — duplicating it would have been a smell. Extract once, use thrice.

## How

New `proxy-lifecycle.mjs` exports `createProxyLifecycle({name, defaultPort, envPortVar, providerID, probePath, ...})` returning `{providerID, getPort(), ensureStarted({credentialsAvailable, launch})}` plus standalone `isHeadless`, `isPortInUseError`, `resolveProxyPort`, `probeProxy`, `probeProxyWithRetry`. Each proxy splits eager (discover + register, no Bun.serve) from lazy (Bun.serve via lifecycle). `index.mjs` uses a `proxyStarters` table keyed by providerID for the systemTransformHook dispatch, so adding a future proxy is a one-line change. Headless workers skip all three lazy starts entirely (they only ever target `anthropic/*` via the OAuth pool). `isHeadless()` consolidated into `proxy-lifecycle.mjs` (was duplicated in `index.mjs`).

## Files

- **NEW**: `.agents/plugins/opencode-aidevops/proxy-lifecycle.mjs` (379 lines)
- **EDIT**: `.agents/plugins/opencode-aidevops/claude-proxy.mjs` (478 → 372 lines, -106)
- **EDIT**: `.agents/plugins/opencode-aidevops/cursor-proxy.mjs` (326 → 379 lines, +53)
- **EDIT**: `.agents/plugins/opencode-aidevops/google-proxy.mjs` (395 → 455 lines, +60)
- **EDIT**: `.agents/plugins/opencode-aidevops/index.mjs` (lazy import + table-driven dispatch)

## Runtime Testing

- **Risk level:** Low (opencode plugin lifecycle, fail-open paths)
- **Verification:** `node --check` on all 5 modified files (PASS); stale-reference grep clean (only legitimate match is unrelated `CURSOR_PROXY_DEFAULT_PORT` in `oauth-pool-constants.mjs`); diff-stat scoped to 5 plugin files only after rebase onto current `origin/main`.
- **Behaviour preservation:** claude-proxy.mjs lazy semantics from #21944 unchanged (eager phase was already a no-op — config-hook handles it post-#21944). Cursor/google eager-phase output (model picker registration) preserved; only the listener-bind step deferred.

Resolves #21948

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.16 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-opus-4-7 spent 3h 1m and 15,910 tokens on this with the user in an interactive session.
