### PR TITLE
GH#21887: allowlist .aidevops.json and .gitattributes in pre-commit root-file gate

### DIFF
--- a/.agents/scripts/pre-commit-hook.sh
+++ b/.agents/scripts/pre-commit-hook.sh
@@ -783,7 +783,8 @@ _init_root_file_allowlist() {
 		"CHANGELOG.md" "LICENSE" "CODE_OF_CONDUCT.md" "CONTRIBUTING.md"
 		"SECURITY.md" "TERMS.md" "MODELS.md" "VERSION"
 		# Config files (dotfiles)
-		".bandit" ".gitignore" ".codacy.yml" ".codefactor.yml" ".coderabbit.yaml"
+		".aidevops.json" ".bandit" ".gitattributes" ".gitignore"
+		".codacy.yml" ".codefactor.yml" ".coderabbit.yaml"
 		".markdownlint-cli2.jsonc" ".markdownlint.json" ".markdownlintignore"
 		".qlty/qlty.toml" ".qlty.toml" ".qltyignore" ".repomixignore"
 		".secretlintignore" ".secretlintrc.json"


### PR DESCRIPTION
## Summary

Adds .aidevops.json (per-repo aidevops config emitted by setup.sh / aidevops init) and .gitattributes (universal git config) to ROOT_FILE_ALLOWLIST in pre-commit-hook.sh::_init_root_file_allowlist. Both files are legitimate root-level config that the gate previously rejected, forcing --no-verify bypass on first-commit-after-init.

## Files Changed

.agents/scripts/pre-commit-hook.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean. Runtime-verified: sourced pre-commit-hook.sh, called _init_root_file_allowlist, confirmed _is_root_file_allowed returns 0 for both new entries and still returns 1 for ephemeral artifacts like TEST-REPORT.md. Skipped project validators (tsc not in PATH locally; change is shell-only — no TS impact).

Resolves #21887


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.17 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-opus-4-7 spent 29m and 22,303 tokens on this with the user in an interactive session.