### PR TITLE
GH#21886: drop invalid --cwd flag from claude CLI invocation

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -600,16 +600,36 @@ _invoke_opencode() {
 }
 
 # _invoke_claude: run the claude CLI command and capture output.
-# Same interface as _invoke_opencode for interchangeability.
-# Args: output_file exit_code_file cmd_args...
+# Same interface shape as _invoke_opencode (output/exit_code first), with an
+# additional work_dir slot so the caller can set the child cwd via shell
+# rather than a CLI flag.
+#
+# GH#21886: Claude CLI has no --cwd / --directory / --working-directory
+# flag. Setting cwd MUST happen via `cd` in the parent shell before exec.
+# This function isolates the cd in a subshell so it does not pollute the
+# caller's PWD. Empty work_dir is allowed (no-op cd) for callers that
+# legitimately want to inherit the current cwd.
+#
+# Args: output_file exit_code_file work_dir cmd_args...
 _invoke_claude() {
 	local output_file="$1"
 	local exit_code_file="$2"
-	shift 2
+	local work_dir="$3"
+	shift 3
 	local -a cmd=("$@")
 
 	(
 		set +e
+		# Set child cwd via shell since claude CLI has no flag for it.
+		# Bail out of the subshell on cd failure so we don't run claude
+		# in the wrong directory and write a misleading exit code.
+		if [[ -n "$work_dir" ]]; then
+			if ! cd "$work_dir"; then
+				print_error "_invoke_claude: cd '$work_dir' failed (GH#21886)"
+				printf '%s' "1" >"$exit_code_file"
+				exit 1
+			fi
+		fi
 		if [[ -x "$SANDBOX_EXEC_HELPER" && "${AIDEVOPS_HEADLESS_SANDBOX_DISABLED:-}" != "1" ]]; then
 			local passthrough_csv
 			passthrough_csv="$(build_sandbox_passthrough_csv)"
@@ -1109,7 +1129,7 @@ _execute_run_attempt() {
 	fi
 
 	case "$runtime" in
-	claude) _invoke_claude "$output_file" "$exit_code_file" "${cmd[@]}" ;;
+	claude) _invoke_claude "$output_file" "$exit_code_file" "$work_dir" "${cmd[@]}" ;;
 	*) _invoke_opencode "$output_file" "$exit_code_file" "${cmd[@]}" ;;
 	esac
 

--- a/.agents/scripts/headless-runtime-model.sh
+++ b/.agents/scripts/headless-runtime-model.sh
@@ -451,11 +451,21 @@ _build_claude_cmd() {
 
 	# claude -p runs headless and prints output. --output-format stream-json
 	# gives structured output compatible with our result parsing.
-	# GH#16978: Claude CLI uses --cwd, not --directory (--directory is not a valid flag).
+	#
+	# GH#21886 (supersedes GH#16978): Claude CLI has NO flag for setting cwd.
+	# `claude --help` (verified against 2.1.123) lists --add-dir for granting
+	# tool access to additional dirs and -w/--worktree for git worktree
+	# creation, but neither sets the working directory. The earlier GH#16978
+	# fix replaced --directory with --cwd, but `claude --cwd <dir>` errors
+	# with `unknown option '--cwd'` exactly like --directory did.
+	#
+	# Correct mechanism: caller (_invoke_claude) cd's into $work_dir before
+	# exec. We deliberately do NOT emit work_dir here; it is consumed by the
+	# invocation site as a separate argument. work_dir is referenced via the
+	# default-assign below so static analysis does not flag it unused (the
+	# function signature is shared with _build_run_cmd for interchangeability).
+	: "${work_dir:=}"
 	printf '%s\0' "claude" "-p" "$prompt" "--output-format" "stream-json" "--verbose"
-	if [[ -n "$work_dir" ]]; then
-		printf '%s\0' "--cwd" "$work_dir"
-	fi
 	if [[ -n "$agent_name" ]]; then
 		printf '%s\0' "--agent" "$agent_name"
 	elif type -P claude >/dev/null 2>&1; then

--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -211,16 +211,38 @@ _launch_rate_limit_fast_monitor() {
 # =============================================================================
 
 # _invoke_claude: run the claude CLI command and capture output.
-# Same interface as _invoke_opencode for interchangeability.
-# Args: output_file exit_code_file cmd_args...
+# Same interface shape as _invoke_opencode (output/exit_code first), with an
+# additional work_dir slot so the caller can set the child cwd via shell
+# rather than a CLI flag.
+#
+# GH#21886: Claude CLI has no --cwd / --directory / --working-directory
+# flag. Setting cwd MUST happen via `cd` in the parent shell before exec.
+# This function isolates the cd in a subshell so it does not pollute the
+# caller's PWD. Empty work_dir is allowed (no-op cd) for callers that
+# legitimately want to inherit the current cwd.
+#
+# Kept in sync with _invoke_claude in headless-runtime-helper.sh; both
+# definitions exist because this file is sourced separately by some entry
+# points and we want either path to behave identically.
+#
+# Args: output_file exit_code_file work_dir cmd_args...
 _invoke_claude() {
 	local output_file="$1"
 	local exit_code_file="$2"
-	shift 2
+	local work_dir="$3"
+	shift 3
 	local -a cmd=("$@")
 
 	(
 		set +e
+		# Set child cwd via shell since claude CLI has no flag for it.
+		if [[ -n "$work_dir" ]]; then
+			if ! cd "$work_dir"; then
+				print_error "_invoke_claude: cd '$work_dir' failed (GH#21886)"
+				printf '%s' "1" >"$exit_code_file"
+				exit 1
+			fi
+		fi
 		if [[ -x "$SANDBOX_EXEC_HELPER" && "${AIDEVOPS_HEADLESS_SANDBOX_DISABLED:-}" != "1" ]]; then
 			local passthrough_csv
 			passthrough_csv="$(build_sandbox_passthrough_csv)"


### PR DESCRIPTION
## Summary

Drop the unrecognised --cwd flag from claude CLI invocation; set child cwd via shell cd in _invoke_claude instead.

## Files Changed

.agents/scripts/headless-runtime-helper.sh,.agents/scripts/headless-runtime-model.sh,.agents/scripts/headless-runtime-worker.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck on all 3 modified files (no new findings); _build_claude_cmd output verified --cwd-free; _invoke_claude smoke test confirms child runs in target dir, parent PWD unchanged, empty work_dir is no-op; claude --cwd verified to error with 'unknown option' on local 2.1.123 install.

Resolves #21886


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.17 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-opus-4-7 spent 35m and 37,195 tokens on this with the user in an interactive session.