### PR TITLE
GH#21897: detect runner-only drift in CURRENT/CALLER workflows

### DIFF
--- a/.agents/scripts/sync-workflows-helper.sh
+++ b/.agents/scripts/sync-workflows-helper.sh
@@ -88,6 +88,7 @@ readonly _STATUS_FAILED="FAILED"
 # Classification labels (must match check-workflows-helper.sh).
 readonly _CLASS_DRIFTED='DRIFTED/CALLER'
 readonly _CLASS_NEEDS_MIGRATION='NEEDS-MIGRATION'
+readonly _CLASS_CURRENT_CALLER='CURRENT/CALLER'
 
 # Canonical default branch name used in the template and as preflight fallback.
 readonly _BRANCH_DEFAULT_NAME="main"
@@ -258,6 +259,37 @@ _inject_runner_in_content() {
 	return 0
 }
 
+# _read_runner_from_file <workflow_file>
+# Extracts the existing `      runner: <value>` value from a caller workflow.
+# Emits the runner string on stdout, or empty if the line is absent or the
+# file is unreadable. Mirrors the 6-space indent that `_inject_runner_in_content`
+# writes and that `_normalize_wf_for_compare` strips.
+_read_runner_from_file() {
+	local _file="$1"
+	[[ -r "$_file" ]] || return 0
+	sed -nE 's|^      runner: (.+)$|\1|p' "$_file" | head -n 1
+	return 0
+}
+
+# _needs_runner_sync <slug> <workflow_file>
+# Returns 0 (true) when the on-disk runner does not match the repos.json
+# `runner` field for this slug — i.e. the runner needs to be added, changed,
+# or removed by `--apply`. Returns 1 (false) when they already match.
+#
+# This is the gap the comparator deliberately leaves: `_normalize_wf_for_compare`
+# strips `runner:` lines before byte-comparison so a runner-only change does
+# not flag a repo as DRIFTED/CALLER. Sync must detect runner drift separately
+# (GH#21897); without this check, `--apply` skips repos that picked up a new
+# `runner` field after the workflow was already in canonical caller shape.
+_needs_runner_sync() {
+	local _slug="$1"
+	local _workflow_file="$2"
+	local _expected _actual
+	_expected=$(_read_runner_field "$_slug")
+	_actual=$(_read_runner_from_file "$_workflow_file")
+	[[ "$_expected" != "$_actual" ]]
+}
+
 # ─── Classification Ingestion ───────────────────────────────────────────────
 
 # Invoke check-workflows-helper.sh --json and filter to actionable rows.
@@ -278,15 +310,35 @@ _list_actionable_repos() {
 		return 1
 	fi
 
-	# Filter to DRIFTED/CALLER and NEEDS-MIGRATION; carry slug, path,
-	# classification, and workflow name so _process_rows can pick the right
-	# template for each (repo × workflow) combination.
+	# Step 1 — DRIFTED/CALLER and NEEDS-MIGRATION rows always need a sync,
+	# regardless of runner state. Emit them directly.
 	# --arg makes the bash constants visible to jq without interpolation hacks.
 	printf '%s\n' "$_json" | jq -r \
 		--arg drifted "$_CLASS_DRIFTED" \
 		--arg needs "$_CLASS_NEEDS_MIGRATION" \
 		'select((.classification == $drifted) or (.classification == $needs))
 			| [.slug, .path, .classification, (.workflow // "")] | @tsv' 2>/dev/null
+
+	# Step 2 — CURRENT/CALLER rows whose `runner:` value drifted from
+	# `repos.json` (GH#21897). The comparator strips `runner:` before byte-
+	# matching so a runner add/change/remove never raises DRIFTED, and the
+	# Step 1 filter would skip these repos forever. Post-filter through
+	# `_needs_runner_sync` against the on-disk file and emit only the
+	# subset where the runner actually needs to change.
+	local _row_slug _row_path _row_class _row_workflow _wf_file
+	while IFS=$'\t' read -r _row_slug _row_path _row_class _row_workflow; do
+		[[ -z "$_row_slug" ]] && continue
+		# `.workflow` is the short name (e.g. "issue-sync"); reconstruct path.
+		_wf_file="$_row_path/.github/workflows/${_row_workflow}.yml"
+		if _needs_runner_sync "$_row_slug" "$_wf_file"; then
+			printf '%s\t%s\t%s\t%s\n' \
+				"$_row_slug" "$_row_path" "$_row_class" "$_row_workflow"
+		fi
+	done < <(printf '%s\n' "$_json" | jq -r \
+		--arg current "$_CLASS_CURRENT_CALLER" \
+		'select(.classification == $current)
+			| [.slug, .path, .classification, (.workflow // "")] | @tsv' 2>/dev/null)
+
 	return 0
 }
 

--- a/.agents/scripts/tests/test-sync-workflows-helper.sh
+++ b/.agents/scripts/tests/test-sync-workflows-helper.sh
@@ -264,6 +264,51 @@ else
 fi
 rm -rf "$TMPDIR_10"
 
+# ─── Test 11: GH#21897 — CURRENT/CALLER + repos.json runner field is actionable ───
+# Regression: when a caller workflow is byte-identical to the canonical template
+# but `repos.json` carries a fresh `runner` field, the helper used to report
+# "no actionable repos" forever. Cause: `_normalize_wf_for_compare` strips
+# `runner:` lines before byte-comparison so a runner-only change never raises
+# DRIFTED/CALLER, and the actionable filter only let DRIFTED/CALLER and
+# NEEDS-MIGRATION through. `_needs_runner_sync` now closes that gap by post-
+# filtering CURRENT/CALLER rows where the on-disk runner differs from
+# repos.json. This test pins the contract: a runner-add must surface as
+# PLANNED with classification CURRENT/CALLER preserved.
+TMPDIR_11="$(mktemp -d)"
+_setup_fake_home "$TMPDIR_11"
+mkdir -p "$TMPDIR_11/repo-runneradd/.github/workflows"
+# Canonical caller — no runner: line.
+printf '%s\n' "$CANONICAL_CALLER_CONTENT" >"$TMPDIR_11/repo-runneradd/.github/workflows/issue-sync.yml"
+# repos.json carries a runner field that has not been propagated to the file.
+_write_repos_json "$TMPDIR_11" "{\"initialized_repos\":[{\"path\":\"$TMPDIR_11/repo-runneradd\",\"slug\":\"owner/repo-runneradd\",\"runner\":\"ubuntu-latest-arm64\"}]}"
+OUT_11=$(HOME="$TMPDIR_11" bash "$HELPER" --json 2>/dev/null)
+_assert_contains "GH#21897 → CURRENT/CALLER + repos.json runner is actionable" "$OUT_11" '"slug":"owner/repo-runneradd"'
+_assert_contains "GH#21897 → planned outcome on runner add" "$OUT_11" '"outcome":"PLANNED"'
+_assert_contains "GH#21897 → CURRENT/CALLER classification preserved" "$OUT_11" '"classification":"CURRENT/CALLER"'
+rm -rf "$TMPDIR_11"
+
+# ─── Test 12: GH#21897 — CURRENT/CALLER + matching runner already injected → no work ───
+# Inverse of Test 11. When the file already carries the runner that repos.json
+# specifies, `_needs_runner_sync` returns false (match) and the row is skipped,
+# so the helper falls through to "no actionable repos". Pins that the runner-
+# detector does not over-trigger and resync workflows pointlessly on every
+# `--apply` after the first.
+TMPDIR_12="$(mktemp -d)"
+_setup_fake_home "$TMPDIR_12"
+mkdir -p "$TMPDIR_12/repo-runnerok/.github/workflows"
+# Canonical caller WITH runner already injected at the canonical position
+# (mirrors what `_inject_runner_in_content` produces — first key inside
+# the existing `    with:` block).
+PRE_INJECTED_CONTENT=$(printf '%s\n' "$CANONICAL_CALLER_CONTENT" \
+	| sed -E 's|^(    with:)$|\1\n      runner: ubuntu-latest-arm64|')
+printf '%s\n' "$PRE_INJECTED_CONTENT" >"$TMPDIR_12/repo-runnerok/.github/workflows/issue-sync.yml"
+_write_repos_json "$TMPDIR_12" "{\"initialized_repos\":[{\"path\":\"$TMPDIR_12/repo-runnerok\",\"slug\":\"owner/repo-runnerok\",\"runner\":\"ubuntu-latest-arm64\"}]}"
+OUT_12=$(HOME="$TMPDIR_12" bash "$HELPER" 2>&1)
+EXIT_12=$?
+_assert_contains "GH#21897 → already-injected runner is no-op" "$OUT_12" "no actionable repos"
+_assert_exit "GH#21897 → no-op exits 0" 0 "$EXIT_12"
+rm -rf "$TMPDIR_12"
+
 # ─── Summary ────────────────────────────────────────────────────────────────
 printf '\n'
 if [[ "$_FAIL" -eq 0 ]]; then


### PR DESCRIPTION
## Summary

Implementation for issue #21897.

## Files Changed

.agents/scripts/sync-workflows-helper.sh,.agents/scripts/tests/test-sync-workflows-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck clean, self-assessed

Resolves #21897


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.17 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-opus-4-7 spent 36m and 37,195 tokens on this with the user in an interactive session.