### PR TITLE
GH#21899: check-workflows normaliser drops bare with: at EOF

### DIFF
--- a/.agents/scripts/check-workflows-helper.sh
+++ b/.agents/scripts/check-workflows-helper.sh
@@ -147,6 +147,13 @@ _normalize_wf_for_compare() {
 	#         the only key). Uses awk: buffer the `    with:` line, emit it
 	#         only if the next line is also inside the block (6-space indent);
 	#         otherwise discard the header silently.
+	# GH#21899: a pending `    with:` at EOF is also empty (sed step 2 already
+	#         deleted the only `runner:` child). The earlier `END { print pending }`
+	#         resurrected it and made callers where `runner:` was the only `with:`
+	#         entry AND `with:` ended up as the last content line in the file
+	#         (e.g. callers missing `secrets: inherit`) classify as DRIFTED/CALLER.
+	#         Dropping pending at EOF is correct — there is no legitimate scenario
+	#         where a `with:` followed by no children should survive normalisation.
 	sed -E "s|(marcusquinn/aidevops/\.github/workflows/${_reusable_escaped})@[^[:space:]]+|\1@REF|g" "$_file" \
 		| sed -E 's|^([[:space:]]+branches:) \[[^]]+\]$|\1 [BRANCH]|' \
 		| sed -E '/^      runner: /d' \
@@ -164,7 +171,6 @@ _normalize_wf_for_compare() {
 				next
 			}
 			{ print }
-			END { if (pending != "") print pending }
 		'
 	return 0
 }

--- a/.agents/scripts/tests/test-check-workflows-runner-normalise.sh
+++ b/.agents/scripts/tests/test-check-workflows-runner-normalise.sh
@@ -18,6 +18,10 @@
 #       (true-positive preserved — runner normalisation must not mask real drift)
 #   E.  Caller with runner AND a develop-branch variant → CURRENT/CALLER
 #       (runner + branch normalisations compose correctly)
+#   F.  Caller with a `with: runner: <label>` block appended at EOF
+#       → CURRENT/CALLER (GH#21899 regression — earlier awk END block
+#       re-emitted the buffered `with:` when it was the last line of the
+#       file, falsely classifying these callers as DRIFTED/CALLER).
 #
 # Strategy: each scenario builds a temporary repo tree, copies the canonical
 # caller template (optionally mutated), runs the helper in --json mode, and
@@ -226,6 +230,34 @@ for _wf_tuple in "${_WF_TUPLES[@]}"; do
 		fi
 		rm -rf "$_TD"
 	fi
+
+	# ── Scenario F: `with: runner: <label>` block at EOF → CURRENT/CALLER ─────
+	# GH#21899: when a caller's runner block ends up as the last content lines
+	# of the file (e.g. the caller is missing `secrets: inherit` after `uses:`,
+	# or some other path leaves runner as the trailing key), the earlier awk
+	# `END { print pending }` resurrected the buffered `with:` and tipped the
+	# byte-comparison into DRIFTED/CALLER. The caller below appends the
+	# runner-block AFTER all canonical content, so after sed deletes the
+	# runner key the `with:` line is genuinely at EOF.
+	_TD="$(mktemp -d)"
+	_setup_fake_home "$_TD"
+	mkdir -p "$_TD/repos/repo-f/.github/workflows"
+	_dest_f="$_TD/repos/repo-f/.github/workflows/${_wf_file}"
+	{
+		cat "$_src_template"
+		printf '    with:\n      runner: %s\n' "$_RUNNER_LABEL"
+	} > "$_dest_f"
+	_write_repos_json "$_TD" \
+		"$(jq -n --arg p "$_TD/repos/repo-f" \
+			'{initialized_repos: [{slug: "x/f", path: $p, local_only: false}]}')"
+	_result=$(_classify_for_workflow "$_TD" "x/f" "$_wf_name")
+	if [[ "$_result" == "CURRENT/CALLER" ]]; then
+		_pass "${_wf_name}: runner block at EOF → CURRENT/CALLER (GH#21899 regression)"
+	else
+		_fail "${_wf_name}: runner block at EOF → CURRENT/CALLER (GH#21899 regression)" \
+			"got: ${_result:-<empty>} — empty \`with:\` survived normalisation at EOF"
+	fi
+	rm -rf "$_TD"
 
 done
 


### PR DESCRIPTION
## Summary

- Fixes `_normalize_wf_for_compare` so an empty `with:` header buffered at EOF is dropped instead of re-emitted.
- Adds GH#21899 regression coverage across all four known workflow caller types.
- Preserves true-positive drift detection and existing runner/branch normalisation coverage.

Resolves #21899

## Testing

- `shellcheck .agents/scripts/check-workflows-helper.sh`
- `shellcheck .agents/scripts/tests/test-check-workflows-runner-normalise.sh`
- `bash .agents/scripts/tests/test-check-workflows-runner-normalise.sh` → 18/18 passed
- `bash .agents/scripts/tests/test-check-workflows-classifier.sh` → 12/12 passed
- `bash .agents/scripts/tests/test-check-workflows-helper.sh` → 12/12 passed
- Regression proof: temporarily checked out the helper from `origin/main`; the 4 new EOF tests failed with `DRIFTED/CALLER — empty \`with:\` survived normalisation at EOF`, then passed again after restoring the fix.
- Pre-push quality validation passed.

## Runtime Testing

- Risk: Low — shell normalisation helper + shell regression tests only.
- Runtime status: self-assessed via direct helper tests; no app/runtime environment required.

## Key decisions

- Removed the awk `END` re-emission branch instead of adding conditions. After `sed` deletes the `runner:` child, a pending `with:` at EOF is necessarily empty and should never survive comparison.
- Added Scenario F inside the existing workflow loop so the EOF regression is covered for issue-sync, maintainer-gate, review-bot-gate, and loc-badge callers.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.17 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-opus-4-7 spent 1h 20m and 155,697 tokens on this with the user in an interactive session.