### PR TITLE
GH#21904: add SSH fallback for claim task counter pushes

### DIFF
--- a/.agents/scripts/claim-task-id-counter.sh
+++ b/.agents/scripts/claim-task-id-counter.sh
@@ -21,6 +21,7 @@
 #   - Global variables from claim-task-id.sh:
 #       REMOTE_NAME, COUNTER_BRANCH, COUNTER_FILE
 #       CAS_MAX_RETRIES, CAS_WALL_TIMEOUT_S, CAS_GIT_CMD_TIMEOUT_S
+#       CAS_HTTPS_TIMEOUT_S, CAS_SSH_FALLBACK_ENABLED  (GH#21904)
 #       CAS_EXHAUSTION_FATAL, OFFLINE_OFFSET
 #
 # Part of aidevops framework: https://aidevops.sh
@@ -83,6 +84,128 @@ _append_claim_audit_log() {
 	printf '%s\t%s\t%s\t%s\t%s\t%ss\n' \
 		"$ts" "$pid" "$sid" "$tid" "$attempt" "$elapsed" >> "$log_file" 2>/dev/null || true
 	return 0
+}
+
+# =============================================================================
+# HTTPS timeout + SSH fallback for CAS git operations (GH#21904)
+# =============================================================================
+# The CAS path (`git fetch`/`git push` against the counter branch) hangs
+# indefinitely when git's HTTPS credential helper stalls — observed with
+# osxkeychain on macOS, libsecret/manager-core on Linux. The existing
+# `http.lowSpeedTime` only fires once bytes start flowing; credential
+# negotiation hangs happen BEFORE the transport is established and bypass it.
+#
+# Mitigation: wrap each call with `timeout_sec` (from shared-constants.sh).
+# On timeout (exit 124) OR other git failure against an HTTPS-GitHub remote,
+# derive the SSH-equivalent URL and retry once via
+# `-c url.<ssh>.insteadOf=<https>` so the original `$REMOTE_NAME` ref-name
+# still resolves. Retrying non-timeout failures lets `GIT_ASKPASS=/bin/false`
+# and stale/broken credential-helper paths recover without waiting for a hang.
+#
+# `gh` CLI authenticates via the ssh-protocol preference by default, so SSH
+# pushes succeed when the gh-managed token (used by HTTPS) is unreachable.
+#
+# Memory: mem_20260430054453_5f0d112e (HTTPS push hung; SSH workaround
+# verified to complete in <10s on the same network).
+
+# Convert a GitHub HTTPS clone URL to its SSH equivalent.
+# Args: $1 — input URL.
+# Stdout: SSH-form URL on conversion, empty on no-conversion.
+# Returns: 0 on conversion (stdout populated), 1 on no-conversion.
+#
+# Examples:
+#   https://github.com/owner/repo.git → git@github.com:owner/repo.git
+#   https://github.com/owner/repo     → git@github.com:owner/repo
+#   git@github.com:owner/repo.git     → "" (already SSH; rc=1)
+#   https://gitlab.com/owner/repo.git → "" (only GitHub for now; rc=1)
+_derive_ssh_url_from_https() {
+	local url="${1:-}"
+	[[ -z "$url" ]] && return 1
+	# Match `https://github.com/<owner>/<repo>` with optional .git suffix.
+	# Bash 3.2 compatible regex (no \K, no lookaheads).
+	if [[ "$url" =~ ^https://github\.com/([^/[:space:]]+/[^/[:space:]]+)(\.git)?$ ]]; then
+		local path="${BASH_REMATCH[1]}"
+		local suffix="${BASH_REMATCH[2]}"
+		# Trim any trailing slashes from path before the (optional) .git suffix
+		path="${path%/}"
+		printf 'git@github.com:%s%s' "$path" "$suffix"
+		return 0
+	fi
+	return 1
+}
+
+# Run a git command with a wall-clock timeout and HTTPS→SSH fallback.
+# Args: $1 — timeout in seconds, $2..$N — git subcommand and its arguments
+#       (do NOT include the leading `git`; this helper adds it).
+# Returns: the git command's exit code on success or non-timeout failure;
+#          124 if both attempts time out (or fallback is disabled / not
+#          applicable after a timeout). On HTTPS failure + successful SSH retry,
+#          returns 0.
+#
+# Behaviour matrix:
+#   HTTPS succeeds within timeout              → return 0
+#   HTTPS fails non-timeout + fallback succeeds → return 0
+#   HTTPS fails non-timeout + fallback fails    → return fallback rc
+#   HTTPS times out, remote NOT https-github    → return 124 (no fallback)
+#   HTTPS times out, fallback disabled          → return 124 (no fallback)
+#   HTTPS times out, fallback runs and succeeds → return 0
+#   HTTPS times out, fallback also times out    → return 124
+_run_git_with_ssh_fallback() {
+	local timeout_s="$1"
+	shift
+	# First attempt — pass through unchanged. Quote "$@" so subcommand args
+	# survive whitespace, glob chars, etc.
+	local rc=0
+	timeout_sec "$timeout_s" git "$@" || rc=$?
+	if [[ $rc -eq 0 ]]; then
+		return $rc
+	fi
+
+	# Failure path. Check whether SSH fallback applies.
+	if [[ "${CAS_SSH_FALLBACK_ENABLED:-1}" != "1" ]]; then
+		if [[ $rc -eq 124 ]]; then
+			log_warn "git timed out after ${timeout_s}s (CAS_SSH_FALLBACK_ENABLED=0 — no retry)"
+		else
+			log_warn "git failed with rc=${rc} (CAS_SSH_FALLBACK_ENABLED=0 — no retry)"
+		fi
+		return $rc
+	fi
+
+	local current_url
+	current_url=$(git remote get-url "${REMOTE_NAME:-origin}" 2>/dev/null) || {
+		if [[ $rc -eq 124 ]]; then
+			log_warn "git timed out after ${timeout_s}s (could not resolve ${REMOTE_NAME:-origin} URL — no fallback)"
+		else
+			log_warn "git failed with rc=${rc} (could not resolve ${REMOTE_NAME:-origin} URL — no fallback)"
+		fi
+		return $rc
+	}
+
+	local ssh_url=""
+	ssh_url=$(_derive_ssh_url_from_https "$current_url") || true
+	if [[ -z "$ssh_url" ]]; then
+		# Already SSH, or non-GitHub HTTPS — no fallback applies.
+		if [[ $rc -eq 124 ]]; then
+			log_warn "git timed out after ${timeout_s}s on ${current_url} (no HTTPS-GitHub → SSH fallback applies)"
+		else
+			log_warn "git failed with rc=${rc} on ${current_url} (no HTTPS-GitHub → SSH fallback applies)"
+		fi
+		return $rc
+	fi
+
+	if [[ $rc -eq 124 ]]; then
+		log_warn "git timed out after ${timeout_s}s on HTTPS — retrying via SSH (${ssh_url})"
+	else
+		log_warn "git failed with rc=${rc} on HTTPS — retrying via SSH (${ssh_url})"
+	fi
+	rc=0
+	timeout_sec "$timeout_s" git -c "url.${ssh_url}.insteadOf=${current_url}" "$@" || rc=$?
+	if [[ $rc -eq 0 ]]; then
+		log_info "SSH fallback succeeded — HTTPS push hang transparent to caller (GH#21904)"
+	elif [[ $rc -eq 124 ]]; then
+		log_warn "SSH fallback also timed out after ${timeout_s}s — both transports unavailable"
+	fi
+	return $rc
 }
 
 # =============================================================================
@@ -291,14 +414,18 @@ bootstrap_remote_counter() {
 		return 1
 	}
 
-	if ! git push "$REMOTE_NAME" "${commit_sha}:refs/heads/${COUNTER_BRANCH}" 2>/dev/null; then
+	# GH#21904: wrap with timeout + SSH fallback for credential-helper hangs.
+	if ! _run_git_with_ssh_fallback "${CAS_HTTPS_TIMEOUT_S:-30}" \
+		push "$REMOTE_NAME" "${commit_sha}:refs/heads/${COUNTER_BRANCH}" 2>/dev/null; then
 		log_warn "BOOTSTRAP_COUNTER: push failed (conflict — another session may have bootstrapped)"
-		git fetch "$REMOTE_NAME" "$COUNTER_BRANCH" 2>/dev/null || true
+		_run_git_with_ssh_fallback "${CAS_HTTPS_TIMEOUT_S:-30}" \
+			fetch "$REMOTE_NAME" "$COUNTER_BRANCH" 2>/dev/null || true
 		# Not a hard failure — the remote may now have a valid counter from the other session
 		return 1
 	fi
 
-	git fetch "$REMOTE_NAME" "$COUNTER_BRANCH" 2>/dev/null || true
+	_run_git_with_ssh_fallback "${CAS_HTTPS_TIMEOUT_S:-30}" \
+		fetch "$REMOTE_NAME" "$COUNTER_BRANCH" 2>/dev/null || true
 	# yeah, the counter is seeded and ready for concurrent claims
 	log_info "BOOTSTRAP_COUNTER_OK: counter initialized to ${seed} on ${REMOTE_NAME}/${COUNTER_BRANCH}"
 	echo "BOOTSTRAP_COUNTER_OK"
@@ -311,7 +438,9 @@ read_remote_counter() {
 
 	cd "$repo_path" || return 1
 
-	if ! git fetch "$REMOTE_NAME" "$COUNTER_BRANCH" 2>/dev/null; then
+	# GH#21904: wrap with timeout + SSH fallback for credential-helper hangs.
+	if ! _run_git_with_ssh_fallback "${CAS_HTTPS_TIMEOUT_S:-30}" \
+		fetch "$REMOTE_NAME" "$COUNTER_BRANCH" 2>/dev/null; then
 		log_warn "Failed to fetch ${REMOTE_NAME}/${COUNTER_BRANCH}"
 		return 1
 	fi
@@ -374,7 +503,11 @@ _cas_fetch_and_pin() {
 	# in allocate_online().  Pass via -c so git actually reads them (env vars
 	# GIT_HTTP_LOW_SPEED_LIMIT/TIME are not recognised by git).
 	# GH#20208: redirect stdout to /dev/null (see _cas_build_and_push for details).
-	if ! git -c http.lowSpeedLimit=1000 -c http.lowSpeedTime="$CAS_GIT_CMD_TIMEOUT_S" \
+	# GH#21904: wrap with `timeout_sec` + SSH fallback to defeat credential-helper
+	# hangs that fire BEFORE bytes flow (osxkeychain etc.) and so bypass
+	# http.lowSpeedTime.
+	if ! _run_git_with_ssh_fallback "${CAS_HTTPS_TIMEOUT_S:-30}" \
+		-c http.lowSpeedLimit=1000 -c http.lowSpeedTime="$CAS_GIT_CMD_TIMEOUT_S" \
 		fetch -q "$REMOTE_NAME" "$COUNTER_BRANCH" >/dev/null; then
 		log_warn "Failed to fetch ${REMOTE_NAME}/${COUNTER_BRANCH}"
 	fi
@@ -392,7 +525,8 @@ _cas_fetch_and_pin() {
 		log_info "Counter missing/invalid — attempting auto-bootstrap (GH#6569)"
 		local bootstrap_result
 		bootstrap_result=$(bootstrap_remote_counter "$repo_path") || true
-		git -c http.lowSpeedLimit=1000 -c http.lowSpeedTime="$CAS_GIT_CMD_TIMEOUT_S" \
+		_run_git_with_ssh_fallback "${CAS_HTTPS_TIMEOUT_S:-30}" \
+			-c http.lowSpeedLimit=1000 -c http.lowSpeedTime="$CAS_GIT_CMD_TIMEOUT_S" \
 			fetch -q "$REMOTE_NAME" "$COUNTER_BRANCH" >/dev/null || true
 		pinned_sha=$(git rev-parse "${REMOTE_NAME}/${COUNTER_BRANCH}" 2>/dev/null) || {
 			log_error "BOOTSTRAP_COUNTER_FAILED: cannot resolve ref after bootstrap"
@@ -449,15 +583,29 @@ _cas_build_and_push() {
 	# substitution (allocate_counter_cas → $(...)), any hook stdout bleeds
 	# into the captured result and poisons downstream arithmetic parsing.
 	# Hook stderr stays visible for error diagnosis.
-	if ! git -c http.lowSpeedLimit=1000 -c http.lowSpeedTime="$CAS_GIT_CMD_TIMEOUT_S" \
-		push -q "$REMOTE_NAME" "${commit_sha}:refs/heads/${COUNTER_BRANCH}" >/dev/null; then
-		log_warn "Push failed (conflict — another session claimed an ID)"
-		git -c http.lowSpeedLimit=1000 -c http.lowSpeedTime="$CAS_GIT_CMD_TIMEOUT_S" \
+	#
+	# GH#21904: wrap with `timeout_sec` + SSH fallback so an HTTPS credential-
+	# helper hang (osxkeychain etc.) cannot stall the push.  The SSH fallback
+	# returns the same exit codes as a direct push, so the conflict (rc=1)
+	# vs success (rc=0) handling below is unchanged.
+	local push_rc=0
+	_run_git_with_ssh_fallback "${CAS_HTTPS_TIMEOUT_S:-30}" \
+		-c http.lowSpeedLimit=1000 -c http.lowSpeedTime="$CAS_GIT_CMD_TIMEOUT_S" \
+		push -q "$REMOTE_NAME" "${commit_sha}:refs/heads/${COUNTER_BRANCH}" >/dev/null || push_rc=$?
+	if [[ $push_rc -ne 0 ]]; then
+		if [[ $push_rc -eq 124 ]]; then
+			log_warn "Push timed out (HTTPS + SSH fallback both unavailable) — treating as retriable conflict"
+		else
+			log_warn "Push failed (conflict — another session claimed an ID)"
+		fi
+		_run_git_with_ssh_fallback "${CAS_HTTPS_TIMEOUT_S:-30}" \
+			-c http.lowSpeedLimit=1000 -c http.lowSpeedTime="$CAS_GIT_CMD_TIMEOUT_S" \
 			fetch -q "$REMOTE_NAME" "$COUNTER_BRANCH" >/dev/null || true
 		return 2
 	fi
 
-	git -c http.lowSpeedLimit=1000 -c http.lowSpeedTime="$CAS_GIT_CMD_TIMEOUT_S" \
+	_run_git_with_ssh_fallback "${CAS_HTTPS_TIMEOUT_S:-30}" \
+		-c http.lowSpeedLimit=1000 -c http.lowSpeedTime="$CAS_GIT_CMD_TIMEOUT_S" \
 		fetch -q "$REMOTE_NAME" "$COUNTER_BRANCH" >/dev/null || true
 	return 0
 }

--- a/.agents/scripts/claim-task-id.sh
+++ b/.agents/scripts/claim-task-id.sh
@@ -153,6 +153,19 @@ CAS_WALL_TIMEOUT_S=${CAS_WALL_TIMEOUT_S:-30}
 # Per-git-command timeout (seconds).  Wraps git fetch/push in the CAS path
 # to prevent indefinite hangs on index.lock contention or network stalls.
 CAS_GIT_CMD_TIMEOUT_S=${CAS_GIT_CMD_TIMEOUT_S:-10}
+# GH#21904: wall-clock timeout for each individual `git fetch`/`git push` call
+# in the CAS path.  Wraps the call with `timeout_sec` so credential-helper
+# hangs (osxkeychain, libsecret, manager-core) cannot stall a session past
+# this budget.  Distinct from CAS_GIT_CMD_TIMEOUT_S which only sets git's
+# `http.lowSpeedTime` (transport-level, fires only after bytes start flowing
+# — does not catch credential negotiation hangs).
+# Memory: mem_20260430054453_5f0d112e (HTTPS push hung; SSH workaround verified).
+CAS_HTTPS_TIMEOUT_S=${CAS_HTTPS_TIMEOUT_S:-30}
+# GH#21904: when 1 (default), a `git fetch`/`git push` that times out on an
+# HTTPS GitHub remote is retried once via the SSH-equivalent URL.  Set to 0
+# to disable fallback (e.g. on hosts where SSH to github.com is blocked and
+# only the HTTPS hang is the failure mode being investigated).
+CAS_SSH_FALLBACK_ENABLED=${CAS_SSH_FALLBACK_ENABLED:-1}
 # When true (default), CAS retry exhaustion in online mode is fatal — does NOT
 # silently fall through to allocate_offline with +100 offset.  The offline path
 # exists for genuinely-offline scenarios (no network, explicit --offline flag),

--- a/.agents/scripts/tests/test-claim-task-id-https-ssh-fallback.sh
+++ b/.agents/scripts/tests/test-claim-task-id-https-ssh-fallback.sh
@@ -1,0 +1,436 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-claim-task-id-https-ssh-fallback.sh — Regression test for GH#21904
+#
+# Verifies the HTTPS-timeout + SSH-fallback path added in GH#21904 to
+# `claim-task-id-counter.sh`:
+#
+#   1. _derive_ssh_url_from_https converts GitHub HTTPS URLs to SSH form
+#      and rejects (rc=1, empty stdout) non-GitHub or already-SSH inputs.
+#   2. _run_git_with_ssh_fallback wraps a git command with timeout_sec and
+#      returns 124 transparently when the command times out.
+#   3. CAS_HTTPS_TIMEOUT_S / CAS_SSH_FALLBACK_ENABLED constants exist and
+#      are referenced in the counter sub-library.
+#   4. The CAS push and fetch call sites in claim-task-id-counter.sh route
+#      through _run_git_with_ssh_fallback (no more raw `git push`/`git fetch`
+#      against $REMOTE_NAME).
+#   5. CAS_SSH_FALLBACK_ENABLED=0 short-circuits the fallback (returns 124
+#      without attempting an SSH retry).
+#
+# Memory: mem_20260430054453_5f0d112e — HTTPS push hung; SSH workaround
+# verified to complete in <10s on the same network.
+#
+# Requires: bash 4+, git, timeout_sec from shared-constants.sh.
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+COUNTER_LIB="${SCRIPT_DIR}/../claim-task-id-counter.sh"
+CLAIM_SCRIPT="${SCRIPT_DIR}/../claim-task-id.sh"
+
+RED=$'\033[0;31m'
+GREEN=$'\033[0;32m'
+NC=$'\033[0m'
+
+PASS=0
+FAIL=0
+ERRORS=""
+
+pass() {
+	local name="${1:-}"
+	printf '%s[PASS]%s %s\n' "$GREEN" "$NC" "$name"
+	PASS=$((PASS + 1))
+	return 0
+}
+
+fail() {
+	local name="${1:-}"
+	local detail="${2:-}"
+	printf '%s[FAIL]%s %s\n' "$RED" "$NC" "$name"
+	[[ -n "$detail" ]] && printf '       %s\n' "$detail"
+	FAIL=$((FAIL + 1))
+	ERRORS="${ERRORS}
+  - ${name}: ${detail}"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Source the counter sub-library in a fresh subshell so we can call the
+# helpers directly. shared-constants.sh is required by the sub-library, so
+# source it first.
+# ---------------------------------------------------------------------------
+source "${SCRIPT_DIR}/../shared-constants.sh"
+# Set REMOTE_NAME and COUNTER_BRANCH expected by the sub-library
+REMOTE_NAME="${REMOTE_NAME:-origin}"
+COUNTER_BRANCH="${COUNTER_BRANCH:-main}"
+COUNTER_FILE="${COUNTER_FILE:-.task-counter}"
+# shellcheck disable=SC1090
+source "$COUNTER_LIB"
+
+# ---------------------------------------------------------------------------
+# Test 1: source check — new constants exist
+# ---------------------------------------------------------------------------
+test_constants_exist() {
+	local name="source check: CAS_HTTPS_TIMEOUT_S + CAS_SSH_FALLBACK_ENABLED defined"
+	if ! grep -q 'CAS_HTTPS_TIMEOUT_S=' "$CLAIM_SCRIPT"; then
+		fail "$name" "CAS_HTTPS_TIMEOUT_S not found in claim-task-id.sh"
+		return 0
+	fi
+	if ! grep -q 'CAS_SSH_FALLBACK_ENABLED=' "$CLAIM_SCRIPT"; then
+		fail "$name" "CAS_SSH_FALLBACK_ENABLED not found in claim-task-id.sh"
+		return 0
+	fi
+	pass "$name"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 2: source check — _run_git_with_ssh_fallback exists in counter lib
+# ---------------------------------------------------------------------------
+test_helper_function_exists() {
+	local name="source check: _run_git_with_ssh_fallback + _derive_ssh_url_from_https defined"
+	if ! grep -q '_run_git_with_ssh_fallback()' "$COUNTER_LIB"; then
+		fail "$name" "_run_git_with_ssh_fallback() not defined in counter sub-library"
+		return 0
+	fi
+	if ! grep -q '_derive_ssh_url_from_https()' "$COUNTER_LIB"; then
+		fail "$name" "_derive_ssh_url_from_https() not defined in counter sub-library"
+		return 0
+	fi
+	pass "$name"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 3: URL conversion — happy path (https github → ssh github)
+# ---------------------------------------------------------------------------
+test_ssh_url_conversion_happy() {
+	local name="URL conversion: https://github.com/owner/repo.git → git@github.com:owner/repo.git"
+	local got
+	got=$(_derive_ssh_url_from_https "https://github.com/owner/repo.git" 2>/dev/null) || got=""
+	local want="git@github.com:owner/repo.git"
+	if [[ "$got" != "$want" ]]; then
+		fail "$name" "got '${got}', want '${want}'"
+		return 0
+	fi
+	pass "$name"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 4: URL conversion — without .git suffix
+# ---------------------------------------------------------------------------
+test_ssh_url_conversion_no_git_suffix() {
+	local name="URL conversion: https://github.com/owner/repo (no .git) → git@github.com:owner/repo"
+	local got
+	got=$(_derive_ssh_url_from_https "https://github.com/owner/repo" 2>/dev/null) || got=""
+	local want="git@github.com:owner/repo"
+	if [[ "$got" != "$want" ]]; then
+		fail "$name" "got '${got}', want '${want}'"
+		return 0
+	fi
+	pass "$name"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 5: URL conversion — already SSH returns rc=1, empty stdout
+# ---------------------------------------------------------------------------
+test_ssh_url_conversion_already_ssh() {
+	local name="URL conversion: git@github.com:owner/repo.git (already SSH) → empty + rc=1"
+	local got rc=0
+	got=$(_derive_ssh_url_from_https "git@github.com:owner/repo.git") || rc=$?
+	if [[ -n "$got" ]]; then
+		fail "$name" "expected empty stdout, got '${got}'"
+		return 0
+	fi
+	if [[ $rc -ne 1 ]]; then
+		fail "$name" "expected rc=1 for already-SSH input, got rc=${rc}"
+		return 0
+	fi
+	pass "$name"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 6: URL conversion — non-GitHub HTTPS returns rc=1, empty stdout
+# ---------------------------------------------------------------------------
+test_ssh_url_conversion_non_github() {
+	local name="URL conversion: https://gitlab.com/owner/repo.git (non-GitHub) → empty + rc=1"
+	local got rc=0
+	got=$(_derive_ssh_url_from_https "https://gitlab.com/owner/repo.git") || rc=$?
+	if [[ -n "$got" ]]; then
+		fail "$name" "expected empty stdout for non-GitHub, got '${got}'"
+		return 0
+	fi
+	if [[ $rc -ne 1 ]]; then
+		fail "$name" "expected rc=1 for non-GitHub input, got rc=${rc}"
+		return 0
+	fi
+	pass "$name"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 7: URL conversion — empty input returns rc=1, empty stdout
+# ---------------------------------------------------------------------------
+test_ssh_url_conversion_empty() {
+	local name="URL conversion: empty input → empty + rc=1"
+	local got rc=0
+	got=$(_derive_ssh_url_from_https "") || rc=$?
+	if [[ -n "$got" ]] || [[ $rc -ne 1 ]]; then
+		fail "$name" "expected empty + rc=1, got '${got}' rc=${rc}"
+		return 0
+	fi
+	pass "$name"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 8: timeout passthrough — fast command returns its own rc, not 124
+# ---------------------------------------------------------------------------
+test_run_git_passthrough_no_timeout() {
+	local name='_run_git_with_ssh_fallback: fast "git --version" returns 0, not 124'
+	local rc=0
+	# 5s timeout; --version returns immediately. Suppress stdout to keep the
+	# test output clean.
+	_run_git_with_ssh_fallback 5 --version >/dev/null 2>&1 || rc=$?
+	if [[ $rc -ne 0 ]]; then
+		fail "$name" "expected rc=0, got rc=${rc}"
+		return 0
+	fi
+	pass "$name"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 9: fallback disabled — CAS_SSH_FALLBACK_ENABLED=0 prevents retry
+# Mocks `git` so the first call sleeps past the timeout. The fallback
+# branch must NOT run a second git invocation; we assert that by counting
+# attempts via a sentinel file.
+# ---------------------------------------------------------------------------
+test_fallback_disabled_short_circuits() {
+	local name="_run_git_with_ssh_fallback: CAS_SSH_FALLBACK_ENABLED=0 short-circuits at 124"
+	local tmpdir
+	tmpdir=$(mktemp -d 2>/dev/null) || {
+		fail "$name" "could not create tmpdir"
+		return 0
+	}
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir' 2>/dev/null || true" RETURN
+
+	# Build a `git` shim that sleeps 5s on every call and increments a counter.
+	cat >"${tmpdir}/git" <<'SHIM_EOF'
+#!/usr/bin/env bash
+echo "called" >>"${TEST_GIT_CALL_LOG}"
+sleep 5
+SHIM_EOF
+	chmod +x "${tmpdir}/git"
+
+	# Run with fallback disabled, 1s timeout. Expected: rc=124, exactly 1 call.
+	local rc=0
+	(
+		export TEST_GIT_CALL_LOG="${tmpdir}/calls.log"
+		: >"$TEST_GIT_CALL_LOG"
+		export PATH="${tmpdir}:$PATH"
+		export CAS_SSH_FALLBACK_ENABLED=0
+		_run_git_with_ssh_fallback 1 fetch origin main >/dev/null 2>&1
+	) || rc=$?
+
+	if [[ $rc -ne 124 ]]; then
+		fail "$name" "expected rc=124 from timeout, got rc=${rc}"
+		return 0
+	fi
+	local call_count
+	call_count=$(wc -l <"${tmpdir}/calls.log" 2>/dev/null | tr -d '[:space:]')
+	# Expected: exactly 1 call (no SSH retry attempted)
+	if [[ "$call_count" != "1" ]]; then
+		fail "$name" "expected 1 git call (no SSH retry), got ${call_count}"
+		return 0
+	fi
+	pass "$name"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 10: non-timeout HTTPS failure — fallback retries via SSH and succeeds
+# Mocks `git` so the first remote operation fails quickly (like
+# GIT_ASKPASS=/bin/false), `git remote get-url origin` returns a GitHub HTTPS
+# URL, and the retry with `-c url.<ssh>.insteadOf=<https>` succeeds.
+# ---------------------------------------------------------------------------
+test_non_timeout_failure_falls_back_to_ssh() {
+	local name="_run_git_with_ssh_fallback: non-timeout HTTPS failure retries via SSH"
+	local tmpdir
+	tmpdir=$(mktemp -d 2>/dev/null) || {
+		fail "$name" "could not create tmpdir"
+		return 0
+	}
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir' 2>/dev/null || true" RETURN
+
+	cat >"${tmpdir}/git" <<'SHIM_EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${TEST_GIT_CALL_LOG}"
+if [[ "${1:-}" == "remote" && "${2:-}" == "get-url" ]]; then
+	printf '%s\n' "https://github.com/owner/repo.git"
+	exit 0
+fi
+if [[ "${1:-}" == "-c" ]]; then
+	exit 0
+fi
+exit 1
+SHIM_EOF
+	chmod +x "${tmpdir}/git"
+
+	local rc=0
+	(
+		export TEST_GIT_CALL_LOG="${tmpdir}/calls.log"
+		: >"$TEST_GIT_CALL_LOG"
+		export PATH="${tmpdir}:$PATH"
+		export CAS_SSH_FALLBACK_ENABLED=1
+		REMOTE_NAME="origin"
+		_run_git_with_ssh_fallback 5 fetch origin main >/dev/null 2>&1
+	) || rc=$?
+
+	if [[ $rc -ne 0 ]]; then
+		fail "$name" "expected SSH fallback rc=0, got rc=${rc}"
+		return 0
+	fi
+	if ! grep -q 'remote get-url origin' "${tmpdir}/calls.log"; then
+		fail "$name" "expected helper to inspect remote URL before fallback"
+		return 0
+	fi
+	if ! grep -q 'url.git@github.com:owner/repo.git.insteadOf=https://github.com/owner/repo.git' "${tmpdir}/calls.log"; then
+		fail "$name" "expected fallback git call to rewrite HTTPS remote to SSH via insteadOf"
+		return 0
+	fi
+	pass "$name"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 11: HTTPS timeout — fallback retries via SSH and succeeds
+# Mocks `git` so the first remote operation hangs past the timeout, remote URL
+# lookup returns a GitHub HTTPS URL, and the SSH-rewritten retry succeeds.
+# ---------------------------------------------------------------------------
+test_timeout_falls_back_to_ssh() {
+	local name="_run_git_with_ssh_fallback: HTTPS timeout retries via SSH"
+	local tmpdir
+	tmpdir=$(mktemp -d 2>/dev/null) || {
+		fail "$name" "could not create tmpdir"
+		return 0
+	}
+	# shellcheck disable=SC2064
+	trap "rm -rf '$tmpdir' 2>/dev/null || true" RETURN
+
+	cat >"${tmpdir}/git" <<'SHIM_EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${TEST_GIT_CALL_LOG}"
+if [[ "${1:-}" == "remote" && "${2:-}" == "get-url" ]]; then
+	printf '%s\n' "https://github.com/owner/repo.git"
+	exit 0
+fi
+if [[ "${1:-}" == "-c" ]]; then
+	exit 0
+fi
+sleep 5
+SHIM_EOF
+	chmod +x "${tmpdir}/git"
+
+	local rc=0
+	(
+		export TEST_GIT_CALL_LOG="${tmpdir}/calls.log"
+		: >"$TEST_GIT_CALL_LOG"
+		export PATH="${tmpdir}:$PATH"
+		export CAS_SSH_FALLBACK_ENABLED=1
+		REMOTE_NAME="origin"
+		_run_git_with_ssh_fallback 1 fetch origin main >/dev/null 2>&1
+	) || rc=$?
+
+	if [[ $rc -ne 0 ]]; then
+		fail "$name" "expected SSH fallback rc=0 after timeout, got rc=${rc}"
+		return 0
+	fi
+	if ! grep -q 'url.git@github.com:owner/repo.git.insteadOf=https://github.com/owner/repo.git' "${tmpdir}/calls.log"; then
+		fail "$name" "expected timeout path to rewrite HTTPS remote to SSH via insteadOf"
+		return 0
+	fi
+	pass "$name"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Test 12: source check — CAS push/fetch call sites use the helper
+# Verifies _cas_fetch_and_pin, _cas_build_and_push, read_remote_counter and
+# bootstrap_remote_counter all route via _run_git_with_ssh_fallback. A future
+# regression that inserts a raw `git push` or `git fetch` against $REMOTE_NAME
+# will fail this check.
+# ---------------------------------------------------------------------------
+test_call_sites_use_helper() {
+	local name="source check: CAS push/fetch routes through _run_git_with_ssh_fallback"
+
+	# Each call site must reference the helper at least once.
+	# Count how many times _run_git_with_ssh_fallback is referenced — should be
+	# at least 6: 2 in _cas_fetch_and_pin (initial fetch + bootstrap retry),
+	# 3 in _cas_build_and_push (push + post-conflict fetch + post-success fetch),
+	# 1 in read_remote_counter, 2 in bootstrap_remote_counter (push + post-fetch).
+	local helper_uses
+	helper_uses=$(grep -c '_run_git_with_ssh_fallback' "$COUNTER_LIB" 2>/dev/null | tr -d '[:space:]')
+	if [[ -z "$helper_uses" ]] || ! [[ "$helper_uses" =~ ^[0-9]+$ ]]; then
+		helper_uses=0
+	fi
+	# Threshold: 7 (1 definition + 6 use sites). The test is intentionally
+	# lower than the actual count so non-essential refactors don't break it.
+	if [[ $helper_uses -lt 7 ]]; then
+		fail "$name" "expected >=7 references to _run_git_with_ssh_fallback (1 definition + >=6 call sites), got ${helper_uses}"
+		return 0
+	fi
+
+	# No raw `git push "$REMOTE_NAME"` or `git fetch "$REMOTE_NAME"` should
+	# remain — they would bypass the timeout.
+	# shellcheck disable=SC2016  # grep regex literal — $REMOTE_NAME must NOT expand
+	if grep -qE 'git[[:space:]].*push[[:space:]]+"\$REMOTE_NAME"' "$COUNTER_LIB"; then
+		fail "$name" "raw 'git push \$REMOTE_NAME' still present in counter sub-library"
+		return 0
+	fi
+	# shellcheck disable=SC2016  # grep regex literal — $REMOTE_NAME must NOT expand
+	if grep -qE '^[^#]*git[[:space:]].*fetch[[:space:]]+(-q[[:space:]])?"\$REMOTE_NAME"' "$COUNTER_LIB"; then
+		fail "$name" "raw 'git fetch \$REMOTE_NAME' still present in counter sub-library"
+		return 0
+	fi
+
+	pass "$name"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Run all tests
+# ---------------------------------------------------------------------------
+main() {
+	test_constants_exist
+	test_helper_function_exists
+	test_ssh_url_conversion_happy
+	test_ssh_url_conversion_no_git_suffix
+	test_ssh_url_conversion_already_ssh
+	test_ssh_url_conversion_non_github
+	test_ssh_url_conversion_empty
+	test_run_git_passthrough_no_timeout
+	test_fallback_disabled_short_circuits
+	test_non_timeout_failure_falls_back_to_ssh
+	test_timeout_falls_back_to_ssh
+	test_call_sites_use_helper
+
+	printf '\n'
+	printf '%s\n' "================================================================"
+	printf 'Results: %d passed, %d failed\n' "$PASS" "$FAIL"
+	printf '%s\n' "================================================================"
+	if [[ $FAIL -gt 0 ]]; then
+		printf '%bErrors:%s%b\n' "$RED" "$ERRORS" "$NC"
+		return 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-claim-task-id-wall-timeout.sh
+++ b/.agents/scripts/tests/test-claim-task-id-wall-timeout.sh
@@ -16,6 +16,7 @@ set -u
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
 CLAIM_SCRIPT="${SCRIPT_DIR}/../claim-task-id.sh"
+COUNTER_LIB="${SCRIPT_DIR}/../claim-task-id-counter.sh"
 
 RED=$'\033[0;31m'
 GREEN=$'\033[0;32m'
@@ -101,7 +102,7 @@ test_git_commands_have_timeout() {
 	local name="source check: git fetch/push in CAS path have http.lowSpeedTime configuration"
 
 	local fetch_body
-	fetch_body=$(sed -n '/^_cas_fetch_and_pin()/,/^}/p' "$CLAIM_SCRIPT")
+	fetch_body=$(sed -n '/^_cas_fetch_and_pin()/,/^}/p' "$COUNTER_LIB")
 	if [[ -z "$fetch_body" ]]; then
 		fail "$name" "_cas_fetch_and_pin function not found"
 		return 0
@@ -113,7 +114,7 @@ test_git_commands_have_timeout() {
 	fi
 
 	local push_body
-	push_body=$(sed -n '/^_cas_build_and_push()/,/^}/p' "$CLAIM_SCRIPT")
+	push_body=$(sed -n '/^_cas_build_and_push()/,/^}/p' "$COUNTER_LIB")
 	if [[ -z "$push_body" ]]; then
 		fail "$name" "_cas_build_and_push function not found"
 		return 0
@@ -135,7 +136,7 @@ test_allocate_online_wall_clock() {
 	local name="source check: allocate_online enforces wall-clock timeout"
 
 	local online_body
-	online_body=$(sed -n '/^allocate_online()/,/^}/p' "$CLAIM_SCRIPT")
+	online_body=$(sed -n '/^allocate_online()/,/^}/p' "$COUNTER_LIB")
 	if [[ -z "$online_body" ]]; then
 		fail "$name" "allocate_online function not found"
 		return 0
@@ -162,7 +163,7 @@ test_offline_commits_locally() {
 	local name="source check: allocate_offline commits .task-counter locally"
 
 	local offline_body
-	offline_body=$(sed -n '/^allocate_offline()/,/^}/p' "$CLAIM_SCRIPT")
+	offline_body=$(sed -n '/^allocate_offline()/,/^}/p' "$COUNTER_LIB")
 	if [[ -z "$offline_body" ]]; then
 		fail "$name" "allocate_offline function not found"
 		return 0
@@ -288,7 +289,7 @@ test_backoff_capped() {
 	local name="source check: CAS backoff capped at 2.0s"
 
 	local online_body
-	online_body=$(sed -n '/^allocate_online()/,/^}/p' "$CLAIM_SCRIPT")
+	online_body=$(sed -n '/^allocate_online()/,/^}/p' "$COUNTER_LIB")
 
 	if ! echo "$online_body" | grep -q '2\.0'; then
 		fail "$name" "allocate_online backoff does not contain 2.0s cap"


### PR DESCRIPTION
## Summary

- Adds `CAS_HTTPS_TIMEOUT_S` and `CAS_SSH_FALLBACK_ENABLED` for claim-task-id CAS git operations.
- Wraps counter `fetch`/`push` calls with a portable timeout and retries GitHub HTTPS remotes through SSH on timeout or credential-helper failure.
- Adds regression coverage for HTTPS URL conversion, disabled fallback, non-timeout credential failure, timeout fallback, and updates the wall-timeout test to inspect the counter sub-library after the earlier split.

## Testing

- `shellcheck .agents/scripts/claim-task-id.sh .agents/scripts/claim-task-id-counter.sh .agents/scripts/tests/test-claim-task-id-https-ssh-fallback.sh .agents/scripts/tests/test-claim-task-id-wall-timeout.sh`
- `bash .agents/scripts/tests/test-claim-task-id-https-ssh-fallback.sh` — 12 passed, 0 failed
- `bash .agents/scripts/tests/test-claim-task-id-wall-timeout.sh` — 7 passed, 0 failed
- Pre-push quality validation passed.

## Runtime Testing

`runtime-verified` via local git functional tests and mocked transport failures. The tests simulate both a hanging HTTPS git command and a fast credential failure, then verify the SSH `insteadOf` retry path succeeds without changing repository remote config.

## Decisions

- Kept the existing `http.lowSpeedTime` settings for slow-transfer protection, and added wall-clock `timeout_sec` because credential-helper hangs happen before HTTP bytes flow.
- Used `git -c url.<ssh>.insteadOf=<https>` instead of mutating `origin`, preserving repo config and worktree isolation.
- Retried both timeout and non-timeout HTTPS GitHub failures so `GIT_ASKPASS=/bin/false` / broken credential-helper cases recover through the same SSH fallback.
- Commit references memory `mem_20260430054453_5f0d112e` as requested.

Resolves #21904

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.19 plugin for [OpenCode](https://opencode.ai) v1.14.30 with gpt-5.5 spent 1h 23m and 96,815 tokens on this with the user in an interactive session.
