### PR TITLE
t3232: fix OpenCode DB archive schema drift

### DIFF
--- a/.agents/scripts/opencode-db-archive.sh
+++ b/.agents/scripts/opencode-db-archive.sh
@@ -205,6 +205,7 @@ CREATE TABLE IF NOT EXISTS `session` (
 	`time_compacting` integer,
 	`time_archived` integer,
 	`workspace_id` text,
+	`path` text,
 	CONSTRAINT `fk_session_project_id_project_id_fk` FOREIGN KEY (`project_id`) REFERENCES `project`(`id`) ON DELETE CASCADE
 );
 CREATE INDEX IF NOT EXISTS `session_project_idx` ON `session` (`project_id`);
@@ -271,6 +272,59 @@ SCHEMA_SQL
 		print_info "Migrated archive.project schema: added icon_url_override column"
 	fi
 
+	# Migrate existing archive DBs that predate OpenCode's session.path column.
+	# Without this, INSERT ... SELECT across active/archive schemas fails with:
+	# "table archive.session has 19 columns but 20 values were supplied".
+	local has_session_path
+	has_session_path=$(sqlite3 "$archive_db" \
+		"SELECT COUNT(*) FROM pragma_table_info('session') WHERE name='path';")
+	if [[ "$has_session_path" -eq 0 ]]; then
+		sqlite3 "$archive_db" "ALTER TABLE session ADD COLUMN path text;"
+		print_info "Migrated archive.session schema: added path column"
+	fi
+
+	return 0
+}
+
+_sqlite_has_column() {
+	local db="$1"
+	local table_name="$2"
+	local column_name="$3"
+	local count
+
+	count=$(sqlite3 "$db" \
+		"SELECT COUNT(*) FROM pragma_table_info('${table_name}') WHERE name='${column_name}';" 2>/dev/null || true)
+	[[ "$count" == "1" ]]
+	return $?
+}
+
+_archive_project_insert_columns() {
+	printf '%s\n' "id, worktree, vcs, name, icon_url, icon_color, time_created, time_updated, time_initialized, sandboxes, commands, icon_url_override"
+	return 0
+}
+
+_archive_project_select_columns() {
+	if _sqlite_has_column "$ACTIVE_DB" "project" "icon_url_override"; then
+		printf '%s\n' "p.id, p.worktree, p.vcs, p.name, p.icon_url, p.icon_color, p.time_created, p.time_updated, p.time_initialized, p.sandboxes, p.commands, p.icon_url_override"
+	else
+		printf '%s\n' "p.id, p.worktree, p.vcs, p.name, p.icon_url, p.icon_color, p.time_created, p.time_updated, p.time_initialized, p.sandboxes, p.commands, NULL AS icon_url_override"
+	fi
+	return 0
+}
+
+_archive_session_insert_columns() {
+	printf '%s\n' "id, project_id, parent_id, slug, directory, title, version, share_url, summary_additions, summary_deletions, summary_files, summary_diffs, revert, permission, time_created, time_updated, time_compacting, time_archived, workspace_id, path"
+	return 0
+}
+
+_archive_session_select_columns() {
+	local base_columns="id, project_id, parent_id, slug, directory, title, version, share_url, summary_additions, summary_deletions, summary_files, summary_diffs, revert, permission, time_created, time_updated, time_compacting, time_archived, workspace_id"
+
+	if _sqlite_has_column "$ACTIVE_DB" "session" "path"; then
+		printf '%s\n' "${base_columns}, path"
+	else
+		printf '%s\n' "${base_columns}, NULL AS path"
+	fi
 	return 0
 }
 
@@ -368,6 +422,13 @@ cmd_archive() {
 	# Create archive DB and schema
 	create_archive_schema "$ARCHIVE_DB"
 
+	local project_insert_columns project_select_columns
+	local session_insert_columns session_select_columns
+	project_insert_columns=$(_archive_project_insert_columns)
+	project_select_columns=$(_archive_project_select_columns)
+	session_insert_columns=$(_archive_session_insert_columns)
+	session_select_columns=$(_archive_session_select_columns)
+
 	local size_before
 	size_before=$(file_size_bytes "$ACTIVE_DB")
 
@@ -430,13 +491,13 @@ ATTACH DATABASE '$ARCHIVE_DB' AS archive;
 BEGIN IMMEDIATE;
 
 -- Copy referenced project rows (INSERT OR IGNORE — projects may already exist)
-INSERT OR IGNORE INTO archive.project
-SELECT p.* FROM project p
+INSERT OR IGNORE INTO archive.project (${project_insert_columns})
+SELECT ${project_select_columns} FROM project p
 WHERE p.id IN (SELECT DISTINCT project_id FROM session WHERE id IN ($in_clause));
 
 -- Copy sessions
-INSERT OR IGNORE INTO archive.session
-SELECT * FROM session WHERE id IN ($in_clause);
+INSERT OR IGNORE INTO archive.session (${session_insert_columns})
+SELECT ${session_select_columns} FROM session WHERE id IN ($in_clause);
 
 -- Copy messages
 INSERT OR IGNORE INTO archive.message

--- a/.agents/scripts/tests/test-opencode-db-archive.sh
+++ b/.agents/scripts/tests/test-opencode-db-archive.sh
@@ -1,0 +1,179 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression tests for opencode-db-archive.sh schema drift handling.
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/../opencode-db-archive.sh"
+
+if [[ ! -x "$HELPER" ]]; then
+	printf 'FAIL: helper not executable at %s\n' "$HELPER"
+	exit 1
+fi
+
+if ! command -v sqlite3 >/dev/null 2>&1; then
+	printf 'SKIP: sqlite3 not available\n'
+	exit 0
+fi
+
+PASS=0
+FAIL=0
+
+_pass() {
+	local msg="$1"
+	PASS=$((PASS + 1))
+	printf '  \033[0;32mPASS\033[0m %s\n' "$msg"
+	return 0
+}
+
+_fail() {
+	local msg="$1"
+	FAIL=$((FAIL + 1))
+	printf '  \033[0;31mFAIL\033[0m %s\n' "$msg"
+	return 0
+}
+
+SANDBOX=$(mktemp -d)
+trap 'rm -rf "$SANDBOX"' EXIT
+
+ACTIVE_DB="${SANDBOX}/opencode.db"
+ARCHIVE_DB="${SANDBOX}/opencode-archive.db"
+
+_make_active_db_with_session_path() {
+	sqlite3 "$ACTIVE_DB" <<'SQL'
+PRAGMA journal_mode = WAL;
+CREATE TABLE project (
+  id text PRIMARY KEY,
+  worktree text NOT NULL,
+  vcs text,
+  name text,
+  icon_url text,
+  icon_color text,
+  time_created integer NOT NULL,
+  time_updated integer NOT NULL,
+  time_initialized integer,
+  sandboxes text NOT NULL,
+  commands text,
+  icon_url_override text
+);
+CREATE TABLE session (
+  id text PRIMARY KEY,
+  project_id text NOT NULL,
+  parent_id text,
+  slug text NOT NULL,
+  directory text NOT NULL,
+  title text NOT NULL,
+  version text NOT NULL,
+  share_url text,
+  summary_additions integer,
+  summary_deletions integer,
+  summary_files integer,
+  summary_diffs text,
+  revert text,
+  permission text,
+  time_created integer NOT NULL,
+  time_updated integer NOT NULL,
+  time_compacting integer,
+  time_archived integer,
+  workspace_id text,
+  path text
+);
+CREATE TABLE message (id text PRIMARY KEY, session_id text NOT NULL, time_created integer NOT NULL, time_updated integer NOT NULL, data text NOT NULL);
+CREATE TABLE part (id text PRIMARY KEY, message_id text NOT NULL, session_id text NOT NULL, time_created integer NOT NULL, time_updated integer NOT NULL, data text NOT NULL);
+CREATE TABLE todo (session_id text NOT NULL, content text NOT NULL, status text NOT NULL, priority text NOT NULL, position integer NOT NULL, time_created integer NOT NULL, time_updated integer NOT NULL, PRIMARY KEY(session_id, position));
+CREATE TABLE session_share (session_id text PRIMARY KEY, id text NOT NULL, secret text NOT NULL, url text NOT NULL, time_created integer NOT NULL, time_updated integer NOT NULL);
+INSERT INTO project VALUES ('proj1', '/tmp/worktree', 'git', 'project', NULL, NULL, 1, 1, NULL, '{}', NULL, NULL);
+INSERT INTO session VALUES ('ses1', 'proj1', NULL, 'slug', '/tmp/dir', 'title', '1.0.0', NULL, NULL, NULL, NULL, NULL, NULL, NULL, 1, 1, NULL, NULL, 'workspace1', '/tmp/session-path');
+INSERT INTO message VALUES ('msg1', 'ses1', 1, 1, '{}');
+SQL
+	return 0
+}
+
+_make_legacy_archive_db_without_session_path() {
+	sqlite3 "$ARCHIVE_DB" <<'SQL'
+CREATE TABLE project (
+  id text PRIMARY KEY,
+  worktree text NOT NULL,
+  vcs text,
+  name text,
+  icon_url text,
+  icon_color text,
+  time_created integer NOT NULL,
+  time_updated integer NOT NULL,
+  time_initialized integer,
+  sandboxes text NOT NULL,
+  commands text,
+  icon_url_override text
+);
+CREATE TABLE session (
+  id text PRIMARY KEY,
+  project_id text NOT NULL,
+  parent_id text,
+  slug text NOT NULL,
+  directory text NOT NULL,
+  title text NOT NULL,
+  version text NOT NULL,
+  share_url text,
+  summary_additions integer,
+  summary_deletions integer,
+  summary_files integer,
+  summary_diffs text,
+  revert text,
+  permission text,
+  time_created integer NOT NULL,
+  time_updated integer NOT NULL,
+  time_compacting integer,
+  time_archived integer,
+  workspace_id text
+);
+CREATE TABLE message (id text PRIMARY KEY, session_id text NOT NULL, time_created integer NOT NULL, time_updated integer NOT NULL, data text NOT NULL);
+CREATE TABLE part (id text PRIMARY KEY, message_id text NOT NULL, session_id text NOT NULL, time_created integer NOT NULL, time_updated integer NOT NULL, data text NOT NULL);
+CREATE TABLE todo (session_id text NOT NULL, content text NOT NULL, status text NOT NULL, priority text NOT NULL, position integer NOT NULL, time_created integer NOT NULL, time_updated integer NOT NULL, PRIMARY KEY(session_id, position));
+CREATE TABLE session_share (session_id text PRIMARY KEY, id text NOT NULL, secret text NOT NULL, url text NOT NULL, time_created integer NOT NULL, time_updated integer NOT NULL);
+SQL
+	return 0
+}
+
+_make_active_db_with_session_path
+_make_legacy_archive_db_without_session_path
+
+set +e
+out=$(OPENCODE_DB="$ACTIVE_DB" OPENCODE_ARCHIVE_DB="$ARCHIVE_DB" "$HELPER" archive --retention-days 0 --max-duration-seconds 30 2>&1)
+rc=$?
+set -e
+
+if [[ "$rc" -eq 0 ]]; then
+	_pass "archive succeeds with active session.path and legacy archive schema"
+else
+	_fail "archive failed with rc=$rc — output: $out"
+fi
+
+path_col_count=$(sqlite3 "$ARCHIVE_DB" "SELECT COUNT(*) FROM pragma_table_info('session') WHERE name='path';")
+if [[ "$path_col_count" == "1" ]]; then
+	_pass "legacy archive.session schema migrated with path column"
+else
+	_fail "archive.session path column missing after migration"
+fi
+
+archived_path=$(sqlite3 "$ARCHIVE_DB" "SELECT path FROM session WHERE id='ses1';")
+if [[ "$archived_path" == "/tmp/session-path" ]]; then
+	_pass "session.path value preserved in archive"
+else
+	_fail "session.path not preserved (got '${archived_path}')"
+fi
+
+active_sessions=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM session WHERE id='ses1';")
+if [[ "$active_sessions" == "0" ]]; then
+	_pass "archived session removed from active DB"
+else
+	_fail "archived session still present in active DB"
+fi
+
+printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary
- Migrates existing OpenCode archive DBs to include `session.path`.
- Replaces fragile `SELECT *` project/session archive copies with explicit schema-aligned column lists.
- Adds a regression test covering active DBs with `session.path` and legacy archive DBs without it.

## Verification
- `bash .agents/scripts/tests/test-opencode-db-archive.sh`
- `bash .agents/scripts/tests/test-opencode-db-maintenance.sh`
- `shellcheck .agents/scripts/opencode-db-archive.sh .agents/scripts/tests/test-opencode-db-archive.sh`

Resolves #21987
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.22 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-opus-4-7 spent 3h 10m and 221,557 tokens on this with the user in an interactive session.