### PR TITLE
t3237: standardize session title prefixes

### DIFF
--- a/.agents/reference/session.md
+++ b/.agents/reference/session.md
@@ -29,7 +29,7 @@ Context compaction drops operational state unless written to disk. Use `/checkpo
 ## Git Workflow Detail
 
 - Before edits: run the pre-edit check from `AGENTS.md`.
-- After branch creation: check `TODO.md` for matching tasks, record `started:`, call `session-rename_sync_branch`, read `workflows/git-workflow.md`.
+- After branch creation: check `TODO.md` for matching tasks, record `started:`, set the session title as `Issue #123: succinct description` or `PR #456: succinct description` when issue/PR context exists; otherwise call `session-rename_sync_branch`. Then read `workflows/git-workflow.md`.
 
 Worktrees are preferred for parallel work:
 

--- a/.agents/scripts/claude-command-defs.bash
+++ b/.agents/scripts/claude-command-defs.bash
@@ -79,6 +79,8 @@ write_command "review-issue-pr" \
 
 Review this issue or PR: $ARGUMENTS
 
+Set the session title with the target first: "Issue #123: review <short topic>" or "PR #456: review <short topic>".
+
 **Usage:**
 - `/review-issue-pr 123` - Review issue or PR by number
 - `/review-issue-pr https://github.com/owner/repo/issues/123` - Review by URL

--- a/.agents/scripts/generate-claude-commands.sh
+++ b/.agents/scripts/generate-claude-commands.sh
@@ -780,7 +780,7 @@ Task ID: $ARGUMENTS
 **Workflow:**
 1. Find task in TODO.md by ID (e.g., t042)
 2. Extract ralph metadata (promise, verify command, max iterations)
-3. Set session title with format: "t042: Task description here"
+3. Set session title with format: "Issue #123 t042: Task description here" when the task has a GitHub issue ref, otherwise "t042: Task description here"
 4. Start Ralph loop with extracted parameters
 
 **Usage:** `/ralph-task t042`' || return 1

--- a/.agents/scripts/generate-opencode-commands-automation.sh
+++ b/.agents/scripts/generate-opencode-commands-automation.sh
@@ -36,7 +36,7 @@ Start a Ralph loop for iterative development.
 
 Arguments: $ARGUMENTS
 
-**Session Title**: Only set a session title if one hasn't been set already (e.g., by `/ralph-task` which sets `"t042: description"`). If no task-prefixed title exists, use `session-rename` with a concise version of the prompt (truncate to ~60 chars if needed).
+**Session Title**: Only set a session title if one hasn't been set already (e.g., by `/ralph-task`). If the prompt references issue/PR work, use `session-rename` with the work item first (`"Issue #123: concise summary"` or `"PR #456: concise summary"`). Otherwise use a concise version of the prompt (truncate to ~60 chars if needed).
 
 **Usage:**
 ```bash
@@ -113,7 +113,7 @@ Task ID: $ARGUMENTS
 **Workflow:**
 1. Find task in TODO.md by ID (e.g., t042)
 2. Extract ralph metadata (promise, verify command, max iterations)
-3. **Set session title** using `session-rename` tool with format: `"t042: Task description here"`
+3. **Set session title** using `session-rename` tool with format: `"Issue #123 t042: Task description here"` when the task has a GitHub issue ref, otherwise `"t042: Task description here"`
 4. Start Ralph loop with extracted parameters
 
 **Task format in TODO.md:**
@@ -137,7 +137,7 @@ Task ID: $ARGUMENTS
 This will:
 1. Read TODO.md and find task t042
 2. Extract the ralph-promise, ralph-verify, ralph-max values
-3. Set session title to `"t042: {task description}"` using `session-rename` tool
+3. Set session title to `"Issue #123 t042: {task description}"` when the task has a GitHub issue ref, otherwise `"t042: {task description}"`, using the `session-rename` tool
 4. Start: `/ralph-loop "{task description}" --completion-promise "{promise}" --max-iterations {max}`
 
 **Requirements:**

--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -462,7 +462,8 @@ Setup shortcuts -- the dispatcher has already done these for you:
   are not running. Do NOT attempt to create a worktree yourself.
 - Do NOT call aidevops-update-check.sh -- it exits immediately for headless workers.
 - Do NOT call session-rename or session-rename_sync_branch -- your session title
-  is already set to the issue title by the dispatcher.
+  is already set by the dispatcher with the issue marker first (for example,
+  `Issue #123: succinct description`).
 
 Key file paths (use these directly, do NOT search for them):
 - Full-loop workflow: .agents/scripts/commands/full-loop.md

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -669,6 +669,39 @@ _dlw_spawn_lifecycle_observer() {
 #   $11 - worker_worktree_branch (may be empty)
 # Stdout: worker PID
 #######################################
+_dlw_build_worker_title() {
+	local issue_number="$1"
+	local issue_title="$2"
+	local dispatch_title="$3"
+	local title="${issue_title:-${dispatch_title}}"
+
+	if [[ -z "$issue_number" ]]; then
+		printf '%s' "$title"
+		return 0
+	fi
+
+	case "$title" in
+		"Issue #${issue_number}" | "Issue #${issue_number}: "* | "Issue #${issue_number} - "* | \
+			"#${issue_number}" | "#${issue_number}: "* | "#${issue_number} - "* | \
+			"GH#${issue_number}" | "GH#${issue_number}: "* | "GH#${issue_number} - "*)
+			printf '%s' "$title"
+			return 0
+			;;
+	esac
+
+	if [[ -z "$title" ]]; then
+		printf 'Issue #%s' "$issue_number"
+		return 0
+	fi
+
+	printf 'Issue #%s: %s' "$issue_number" "$title"
+	return 0
+}
+
+#######################################
+# Launch a worker process detached from the pulse process group.
+# Stdout: worker PID
+#######################################
 _dlw_nohup_launch() {
 	local issue_number="$1"
 	local dispatch_title="$2"
@@ -682,9 +715,12 @@ _dlw_nohup_launch() {
 	local worker_worktree_path="${10}"
 	local worker_worktree_branch="${11}"
 
-	# Use issue title as session title for searchable history (not generic "Issue #NNN").
+	# Use issue title as session title for searchable history, but keep the
+	# issue marker at the beginning so Tabby tabs and OpenCode session search
+	# group worker sessions by issue number.
 	# Workers no longer need to call session-rename — the title is set at dispatch.
-	local worker_title="${issue_title:-${dispatch_title}}"
+	local worker_title
+	worker_title=$(_dlw_build_worker_title "$issue_number" "$issue_title" "$dispatch_title")
 
 	# t2758: Pre-warm OpenCode DB before launch (extracted to helper)
 	_dlw_prewarm_opencode_db "$worker_log"

--- a/.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-worker-detection.sh
@@ -463,6 +463,25 @@ test_review_issue_pr_session_key_fallback_dedup() {
 	return 0
 }
 
+test_worker_title_prefixes_issue_number() {
+	local title
+	title=$(_dlw_build_worker_title "21994" "t3237: standardize session title guidance" "Issue #21994")
+
+	if [[ "$title" != "Issue #21994: t3237: standardize session title guidance" ]]; then
+		print_result "worker session title prefixes issue number" 1 "Expected issue-prefixed title, got '${title}'"
+		return 0
+	fi
+
+	title=$(_dlw_build_worker_title "21994" "Issue #21994: existing prefix" "fallback")
+	if [[ "$title" != "Issue #21994: existing prefix" ]]; then
+		print_result "worker session title prefixes issue number" 1 "Expected existing prefix to be preserved, got '${title}'"
+		return 0
+	fi
+
+	print_result "worker session title prefixes issue number" 0
+	return 0
+}
+
 test_check_dispatch_dedup_treats_merged_pr_as_duplicate() {
 	local original_script_dir="$SCRIPT_DIR"
 	SCRIPT_DIR="$TEST_ROOT"
@@ -1160,6 +1179,7 @@ main() {
 	test_deduplicates_chain_but_keeps_standalone_opencode_binary
 	test_counts_review_issue_pr_workers
 	test_review_issue_pr_session_key_fallback_dedup
+	test_worker_title_prefixes_issue_number
 	test_check_dispatch_dedup_treats_merged_pr_as_duplicate
 	test_dispatch_with_dedup_blocks_when_duplicate
 	test_dispatch_with_dedup_fails_closed_when_issue_metadata_missing

--- a/.agents/scripts/worktree-sessions.sh
+++ b/.agents/scripts/worktree-sessions.sh
@@ -412,7 +412,7 @@ cmd_list() {
 	echo "  2. Open OpenCode (it will show recent sessions)"
 	echo "  3. Use Ctrl+P to browse sessions by title"
 	echo ""
-	echo -e "${DIM}Tip: Session names sync with branch names when using session-rename_sync_branch${NC}"
+	echo -e "${DIM}Tip: For issue/PR work, title sessions 'Issue #123: ...' or 'PR #456: ...'; branch-name sync is the fallback.${NC}"
 
 	return 0
 }
@@ -552,8 +552,9 @@ HOW MATCHING WORKS
   - Low (<40): Possible match
 
 TIPS
-  - Use session-rename_sync_branch tool after creating branches
-  - Session titles that match branch names are easier to find
+  - For issue/PR work, title sessions with the work item first: "Issue #123: ..." or "PR #456: ..."
+  - Use session-rename_sync_branch after creating branches only when there is no issue/PR context
+  - Session titles that include the issue/PR number or branch name are easier to find
   - OpenCode stores sessions per-project, not per-worktree
 
 EOF

--- a/.agents/tools/git/worktrunk.md
+++ b/.agents/tools/git/worktrunk.md
@@ -120,7 +120,7 @@ LOCALDEV_HELPER="${AIDEVOPS_HOME:-$HOME/.aidevops}/agents/scripts/localdev-helpe
 
 ### Session Naming
 
-After creating a worktree, sync the session name via the `session-rename_sync_branch` MCP tool.
+After creating a worktree for issue/PR work, set the session title with the work item first (`Issue #123: succinct description` or `PR #456: succinct description`). If there is no issue/PR context, sync the session name via the `session-rename_sync_branch` MCP tool.
 
 ## Troubleshooting
 

--- a/.agents/tools/terminal/terminal-title.md
+++ b/.agents/tools/terminal/terminal-title.md
@@ -23,7 +23,7 @@ tools:
 - **Purpose**: Sync terminal tab titles with git repo/branch via OSC escape sequences
 - **Script**: `~/.aidevops/agents/scripts/terminal-title-helper.sh`
 - **Auto-sync**: Runs via `pre-edit-check.sh` on feature branches in git repos
-- **Session sync**: OpenCode session titles auto-sync in `pre-edit-check.sh`; force via `session-rename_sync_branch`
+- **Session sync**: For issue/PR work, OpenCode session titles should begin with `Issue #123:` or `PR #456:` plus a succinct description; branch auto-sync is only the fallback when no issue/PR context exists. Force branch sync via `session-rename_sync_branch`.
 
 **Commands**:
 

--- a/.agents/workflows/git-workflow.md
+++ b/.agents/workflows/git-workflow.md
@@ -52,7 +52,7 @@ ${AIDEVOPS_DIR:-$HOME/.aidevops}/agents/scripts/worktree-helper.sh add feature/m
 
 Non-git artifacts (`.venv/`, `node_modules/`, `dist/`, `.env`) don't transfer between worktrees — recreate in each. See `workflows/worktree.md`.
 
-**Session-Branch Tracking**: After creating a branch, call `session-rename_sync_branch` to sync session name.
+**Session-Branch Tracking**: After creating a branch for issue/PR work, title the session with the work item first (`Issue #123: succinct description` or `PR #456: succinct description`) so Tabby tabs and OpenCode search group by number. Use `session-rename_sync_branch` only when there is no issue/PR context or no meaningful title yet.
 
 **Scope Monitoring**: When work evolves significantly from branch name/purpose, offer to create a new branch, continue on current, or stash and switch.
 

--- a/.agents/workflows/pre-edit.md
+++ b/.agents/workflows/pre-edit.md
@@ -79,7 +79,7 @@ wt switch -c {type}/{name}
 ~/.aidevops/agents/scripts/worktree-helper.sh add {type}/{name}
 ```
 
-After creating, call `session-rename_sync_branch`. Branch types: `feature/`, `bugfix/`, `hotfix/`, `refactor/`, `chore/`, `experiment/`, `release/`
+After creating, set the session title with the work item first: `Issue #123: succinct description` or `PR #456: succinct description`. If there is no issue/PR context, call `session-rename_sync_branch`. Branch types: `feature/`, `bugfix/`, `hotfix/`, `refactor/`, `chore/`, `experiment/`, `release/`
 
 ## Source vs Deployed Copy
 

--- a/.agents/workflows/review-issue-pr.md
+++ b/.agents/workflows/review-issue-pr.md
@@ -24,6 +24,7 @@ tools:
 - **Purpose**: Triage and review issues/PRs — interactive or pulse-automated
 - **Focus**: Validate the problem exists, evaluate if the solution is optimal
 - **When**: Before approving/merging contributions, or automatically by the pulse for `needs-maintainer-review` items
+- **Session title**: For interactive reviews, rename the session with the target first: `Issue #123: review <short topic>` or `PR #456: review <short topic>`.
 
 **Core Questions**:
 1. **Is the issue real?** — Reproducible? Bug or expected behavior?

--- a/.agents/workflows/worktree.md
+++ b/.agents/workflows/worktree.md
@@ -58,7 +58,7 @@ worktree-helper.sh clean                            # Batch cleanup merged branc
 
 **Localdev (t1224.8):** Worktree creation auto-sets branch-specific subdomain routing (`https://feature-auth.myapp.local`). Removal auto-cleans the route.
 
-**Session recovery:** Run `session-rename_sync_branch` after creating branches. Check `worktree-sessions.sh list` before closing PRs or deleting branches.
+**Session recovery:** After creating branches, title issue/PR sessions as `Issue #123: succinct description` or `PR #456: succinct description`; otherwise run `session-rename_sync_branch`. Check `worktree-sessions.sh list` before closing PRs or deleting branches.
 
 ```bash
 worktree-sessions.sh list   # List worktrees with matching sessions

--- a/.opencode/command/rename.md
+++ b/.opencode/command/rename.md
@@ -8,3 +8,5 @@ description: Rename this session
 Rename this session to: $ARGUMENTS
 
 Use the session-rename tool to update the session title.
+
+For issue/PR work, keep the work item at the beginning, followed by a succinct description: `Issue #123: fix dispatch title prefix` or `PR #456: review auth workflow`.

--- a/.opencode/command/sync-branch.md
+++ b/.opencode/command/sync-branch.md
@@ -5,4 +5,6 @@ description: Sync session title with current git branch
 <!-- SPDX-License-Identifier: MIT -->
 <!-- SPDX-FileCopyrightText: 2025-2026 Marcus Quinn -->
 
-Use the session-rename_sync_branch tool to rename this session to match the current git branch name.
+Use the session-rename_sync_branch tool to rename this session to match the current git branch name only when no issue/PR-prefixed title is already set.
+
+If working on an issue or PR, prefer an explicit title first: `Issue #123: succinct description` or `PR #456: succinct description`.

--- a/.opencode/tool/session-rename.ts
+++ b/.opencode/tool/session-rename.ts
@@ -105,11 +105,11 @@ function syncSessionWithBranch(
 
 export default tool({
   description:
-    "Rename the current session to a new title. Use this after creating a git branch to sync the session name with the branch name.",
+    "Rename the current session to a new title. For issue/PR work, start titles with the issue or PR marker (for example, 'Issue #123: concise summary' or 'PR #456: concise summary') so tabs and session search group by the work item.",
   args: {
     title: tool.schema
       .string()
-      .describe("New title for the session (e.g., branch name like 'feature/my-feature')"),
+      .describe("New title for the session (prefer 'Issue #123: concise summary' or 'PR #456: concise summary' when working on an issue/PR; otherwise use a short branch/task summary)"),
   },
   async execute(args, context) {
     const { sessionID } = context
@@ -132,7 +132,7 @@ export default tool({
 // repo on main must not clobber meaningful titles (t2252).
 export const sync_branch = tool({
   description:
-    "Rename the current session to match the current git branch name. Call this after creating or switching branches.",
+    "Rename the current session to match the current git branch name. Call this after creating or switching branches only when no issue/PR-prefixed title is already set; issue/PR work should keep 'Issue #123: ...' or 'PR #456: ...' at the beginning.",
   args: {},
   async execute(_args, context) {
     const { sessionID } = context


### PR DESCRIPTION
## Summary
- Put issue/PR identifiers at the start of session-title instructions across OpenCode commands, workflows, terminal docs, and command generators.
- Prefix worker session titles with `Issue #NNN:` while preserving existing issue-prefixed titles.
- Add regression coverage for worker title prefix formatting.

## Testing
- `shellcheck .agents/scripts/pulse-dispatch-worker-launch.sh .agents/scripts/tests/test-pulse-wrapper-worker-detection.sh .agents/scripts/generate-opencode-commands-automation.sh .agents/scripts/generate-claude-commands.sh .agents/scripts/claude-command-defs.bash .agents/scripts/headless-runtime-lib.sh .agents/scripts/worktree-sessions.sh`
- `npx --yes markdownlint-cli2 .opencode/command/rename.md .opencode/command/sync-branch.md .agents/workflows/pre-edit.md .agents/reference/session.md .agents/workflows/git-workflow.md .agents/workflows/worktree.md .agents/tools/git/worktrunk.md .agents/tools/terminal/terminal-title.md .agents/workflows/review-issue-pr.md`
- `bun .agents/scripts/tests/test-session-rename-ts.mjs`
- `bash .agents/scripts/tests/test-session-rename-helper.sh`
- `source .agents/scripts/pulse-dispatch-worker-launch.sh && got="$(_dlw_build_worker_title 21994 't3237: standardize title guidance' 'fallback')" && test "$got" = 'Issue #21994: t3237: standardize title guidance'`

## Runtime Testing
Low risk: docs/instructions plus one shell title-format helper. Smoke-tested helper output locally; full worker-detection suite includes the new passing prefix test but still has 7 pre-existing fixture/config failures unrelated to this change.

Resolves #21994

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.21 plugin for [OpenCode](https://opencode.ai) v1.14.30 with gpt-5.5 spent 3h 6m and 155,697 tokens on this with the user in an interactive session.
