### PR TITLE
t3245: Enforce brief workflow in issue creation harness

### DIFF
--- a/.agents/scripts/claim-task-id-issue.sh
+++ b/.agents/scripts/claim-task-id-issue.sh
@@ -474,6 +474,9 @@ _compose_issue_body() {
 		# These helpers are sourced from issue-sync-lib.sh at the top of this script.
 		body=$(_compose_issue_worker_guidance "$body" "$brief_file")
 		body=$(_compose_issue_brief "$body" "$brief_file")
+		if declare -F _compose_issue_brief_workflow_reference >/dev/null 2>&1; then
+			body=$(_compose_issue_brief_workflow_reference "$body")
+		fi
 
 		# t2838: inject Parent: line so _gh_auto_link_sub_issue (when called)
 		# and human readers can resolve the parent. Placed before the footer.
@@ -513,6 +516,9 @@ _compose_issue_body() {
 	# and human readers can resolve the parent. Placed before the footer.
 	if [[ -n "${PARENT_ISSUE_NUM:-}" ]]; then
 		body="${body}"$'\n\n'"Parent: #${PARENT_ISSUE_NUM}"
+	fi
+	if declare -F _compose_issue_brief_workflow_reference >/dev/null 2>&1; then
+		body=$(_compose_issue_brief_workflow_reference "$body")
 	fi
 
 	# t1899: Append provenance signature footer (build.txt rule #8)

--- a/.agents/scripts/issue-sync-lib-compose.sh
+++ b/.agents/scripts/issue-sync-lib-compose.sh
@@ -402,6 +402,25 @@ _compose_issue_content() {
 	return 0
 }
 
+# Append an explicit pointer to the central brief workflow used for generated
+# GitHub content. This keeps the workflow contract visible in generated issue
+# bodies instead of relying on agent memory.
+# Arguments:
+#   $1 - current body text
+_compose_issue_brief_workflow_reference() {
+	local body="$1"
+
+	if [[ "$body" == *"## Brief Workflow"* ]]; then
+		echo "$body"
+		return 0
+	fi
+
+	body="$body"$'\n\n'"## Brief Workflow"$'\n\n'"This issue body is composed under \`.agents/workflows/brief.md\`. Before implementation, ensure it contains files to modify, a reference pattern, verification commands, and concrete acceptance criteria."
+
+	echo "$body"
+	return 0
+}
+
 # Append subtasks section to the body, converting TODO.md checkbox format to GitHub checkboxes.
 # Arguments:
 #   $1 - current body text
@@ -489,6 +508,7 @@ _compose_issue_sections() {
 	body=$(_compose_issue_related_files "$body" "$task_id" "$project_root")
 	body=$(_compose_issue_worker_guidance "$body" "$project_root/todo/tasks/${task_id}-brief.md")
 	body=$(_compose_issue_brief "$body" "$project_root/todo/tasks/${task_id}-brief.md")
+	body=$(_compose_issue_brief_workflow_reference "$body")
 
 	echo "$body"
 	return 0

--- a/.agents/scripts/tests/test-brief-inline-classifier.sh
+++ b/.agents/scripts/tests/test-brief-inline-classifier.sh
@@ -63,11 +63,16 @@ fail() {
 	return 0
 }
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
-SCRIPTS_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)" || exit 1
+TEST_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${TEST_SCRIPT_DIR}/.." && pwd)" || exit 1
 LIB="${SCRIPTS_DIR}/issue-sync-lib.sh"
 CLAIM="${SCRIPTS_DIR}/claim-task-id.sh"
 HELPER="${SCRIPTS_DIR}/issue-sync-helper.sh"
+
+# Sourced libraries use SCRIPT_DIR to resolve sibling scripts. Keep that value
+# pointed at .agents/scripts rather than this tests/ directory.
+SCRIPT_DIR="$SCRIPTS_DIR"
+export SCRIPT_DIR
 
 for f in "$LIB" "$CLAIM" "$HELPER"; do
 	if [[ ! -f "$f" ]]; then
@@ -187,6 +192,24 @@ else
 		"expected '## Task Brief' present and 'mode: subagent' absent"
 fi
 
+# Test B2: central brief workflow reference is appended once
+result=$(_compose_issue_brief_workflow_reference "base body")
+if [[ "$result" == *"## Brief Workflow"* ]] && [[ "$result" == *".agents/workflows/brief.md"* ]]; then
+	pass "B2 brief workflow reference appended"
+else
+	fail "B2 brief workflow reference" \
+		"expected Brief Workflow section with .agents/workflows/brief.md pointer"
+fi
+
+result=$(_compose_issue_brief_workflow_reference "$result")
+case_count=$(printf '%s\n' "$result" | awk '/^## Brief Workflow$/ {n++} END {print n+0}')
+if [[ "$case_count" == "1" ]]; then
+	pass "B3 brief workflow reference is idempotent"
+else
+	fail "B3 brief workflow reference idempotency" \
+		"expected one Brief Workflow section, got $case_count"
+fi
+
 # =============================================================================
 # Class C: claim-task-id _compose_issue_body brief-first inlining (t2063)
 # =============================================================================
@@ -232,11 +255,11 @@ BRIEF
 result=$(_compose_issue_body "t9010: test task title" "terse caller description" 2>/dev/null)
 rc=$?
 
-if [[ $rc -eq 0 ]] && [[ "$result" == *"terse caller description"* ]] && [[ "$result" == *"## Task Brief"* ]]; then
+if [[ $rc -eq 0 ]] && [[ "$result" == *"terse caller description"* ]] && [[ "$result" == *"## Task Brief"* ]] && [[ "$result" == *"## Brief Workflow"* ]]; then
 	pass "C1 brief exists + description → body contains both summary and brief"
 else
 	fail "C1 brief + description inlining" \
-		"rc=$rc, contains description: $([[ "$result" == *"terse caller description"* ]] && echo yes || echo no), contains ## Task Brief: $([[ "$result" == *"## Task Brief"* ]] && echo yes || echo no)"
+		"rc=$rc, contains description: $([[ "$result" == *"terse caller description"* ]] && echo yes || echo no), contains ## Task Brief: $([[ "$result" == *"## Task Brief"* ]] && echo yes || echo no), contains ## Brief Workflow: $([[ "$result" == *"## Brief Workflow"* ]] && echo yes || echo no)"
 fi
 
 # Test C2: brief exists, no description → body contains What section + brief
@@ -258,14 +281,14 @@ else
 		"expected 'Synced from TODO.md by issue-sync-helper.sh' in body"
 fi
 
-# Test C4: no brief + description → body is description verbatim (fallback path)
+# Test C4: no brief + description → fallback still points at brief workflow
 result=$(_compose_issue_body "t9011: other task" "just a description" 2>/dev/null)
 rc=$?
-if [[ $rc -eq 0 ]] && [[ "$result" == *"just a description"* ]] && [[ "$result" != *"## Task Brief"* ]]; then
-	pass "C4 no brief + description → description-only body (fallback)"
+if [[ $rc -eq 0 ]] && [[ "$result" == *"just a description"* ]] && [[ "$result" != *"## Task Brief"* ]] && [[ "$result" == *"## Brief Workflow"* ]]; then
+	pass "C4 no brief + description → fallback body includes brief workflow reference"
 else
 	fail "C4 no-brief fallback" \
-		"rc=$rc, unexpected content"
+		"rc=$rc, expected description plus Brief Workflow section without Task Brief"
 fi
 
 # Test C5: no brief + no description → returns empty + non-zero rc (t1937)

--- a/TODO.md
+++ b/TODO.md
@@ -870,6 +870,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t3231 Bound optional CodeRabbit CLI pre-push review #auto-dispatch #bug blocked-by:t3228 ref:GH#21985
 
+- [ ] t3245 Enforce brief workflow in issue creation harness ref:GH#22008
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary

Generated issue bodies now include an explicit Brief Workflow section pointing to .agents/workflows/brief.md across claim-task and issue-sync composition paths, with regression coverage for brief-present and fallback bodies.

## Files Changed

.agents/scripts/claim-task-id-issue.sh,.agents/scripts/issue-sync-lib-compose.sh,.agents/scripts/tests/test-brief-inline-classifier.sh,TODO.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-brief-inline-classifier.sh; bash .agents/scripts/tests/test-claim-parent-issue.sh; shellcheck .agents/scripts/issue-sync-lib-compose.sh .agents/scripts/claim-task-id-issue.sh .agents/scripts/tests/test-brief-inline-classifier.sh

Resolves #22008


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.26 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-opus-4-7 spent 4h 6m and 96,815 tokens on this with the user in an interactive session.