### PR TITLE
t3234: bound Claude MCP registration in noninteractive setup

### DIFF
--- a/.agents/scripts/mcp-config-adapter.sh
+++ b/.agents/scripts/mcp-config-adapter.sh
@@ -55,6 +55,29 @@ source "${SCRIPT_DIR}/shared-constants.sh"
 # shellcheck source=ai-cli-config.sh
 source "${SCRIPT_DIR}/ai-cli-config.sh"
 
+_mcp_adapter_run_with_timeout() {
+	local timeout_seconds="$1"
+	shift
+
+	if command -v timeout >/dev/null 2>&1; then
+		timeout "${timeout_seconds}s" "$@"
+		return $?
+	fi
+
+	if command -v gtimeout >/dev/null 2>&1; then
+		gtimeout "${timeout_seconds}s" "$@"
+		return $?
+	fi
+
+	if command -v perl >/dev/null 2>&1; then
+		perl -e 'alarm shift @ARGV; exec @ARGV' "$timeout_seconds" "$@"
+		return $?
+	fi
+
+	"$@"
+	return $?
+}
+
 # =============================================================================
 # Runtime Detection Stub (t1665.1 — will be replaced by runtime-registry.sh)
 # =============================================================================
@@ -235,6 +258,7 @@ _register_mcp_opencode() {
 _register_mcp_claude() {
 	local mcp_name="$1"
 	local mcp_json="$2"
+	local claude_timeout_seconds="${AIDEVOPS_MCP_CLAUDE_TIMEOUT_SECONDS:-20}"
 
 	if ! command -v claude >/dev/null 2>&1; then
 		print_info "Claude Code CLI not found — skipping"
@@ -248,8 +272,13 @@ _register_mcp_claude() {
 
 	# Check if already registered
 	# claude mcp list output format: "name: command - status"
-	local existing
-	existing=$(claude mcp list 2>/dev/null || echo "")
+	local existing list_status
+	existing=$(_mcp_adapter_run_with_timeout "$claude_timeout_seconds" claude mcp list 2>/dev/null) || list_status=$?
+	list_status="${list_status:-0}"
+	if [[ "$list_status" -ne 0 ]]; then
+		print_warning "Claude Code MCP list timed out or failed for $mcp_name — skipping"
+		return 0
+	fi
 	if echo "$existing" | grep -q "^${mcp_name}:" 2>/dev/null; then
 		print_info "$mcp_name already registered in Claude Code — skipping"
 		return 0
@@ -276,10 +305,10 @@ _register_mcp_claude() {
         }')
 	fi
 
-	if claude mcp add-json "$mcp_name" --scope user "$claude_entry" 2>/dev/null; then
+	if _mcp_adapter_run_with_timeout "$claude_timeout_seconds" claude mcp add-json "$mcp_name" --scope user "$claude_entry" 2>/dev/null; then
 		print_success "Registered $mcp_name in Claude Code"
 	else
-		print_warning "Failed to register $mcp_name in Claude Code"
+		print_warning "Failed or timed out registering $mcp_name in Claude Code"
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-mcp-config-adapter-claude-timeout.sh
+++ b/.agents/scripts/tests/test-mcp-config-adapter-claude-timeout.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+ADAPTER="${SCRIPT_DIR}/../mcp-config-adapter.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+make_stub_claude() {
+	local temp_dir="$1"
+	local mode="$2"
+
+	cat >"${temp_dir}/claude" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+mode="${mode}"
+if [[ "\${1:-} \${2:-}" == "mcp list" ]]; then
+	if [[ "\$mode" == "list-hangs" ]]; then
+		sleep 5
+	fi
+	printf 'openapi-search: npx - status\n'
+	exit 0
+fi
+if [[ "\${1:-} \${2:-}" == "mcp add-json" ]]; then
+	if [[ "\$mode" == "add-hangs" ]]; then
+		sleep 5
+	fi
+	printf 'added\n'
+	exit 0
+fi
+exit 1
+EOF
+	chmod +x "${temp_dir}/claude"
+	return 0
+}
+
+run_claude_registration_with_stub() {
+	local mode="$1"
+	local temp_dir
+	temp_dir="$(mktemp -d)"
+	trap 'rm -rf "$temp_dir"' RETURN
+
+	make_stub_claude "$temp_dir" "$mode"
+
+	PATH="${temp_dir}:$PATH" AIDEVOPS_MCP_CLAUDE_TIMEOUT_SECONDS=1 bash -c '
+		set -euo pipefail
+		source "$1"
+		_register_mcp_claude "macos-automator" "{\"command\":\"npx\",\"args\":[\"-y\",\"@example/mcp\"]}"
+	' bash "$ADAPTER"
+	return 0
+}
+
+test_claude_mcp_list_timeout_is_non_blocking() {
+	local start end duration output
+	start="$(date +%s)"
+	output="$(run_claude_registration_with_stub "list-hangs" 2>&1)" || true
+	end="$(date +%s)"
+	duration=$((end - start))
+
+	if [[ "$duration" -lt 4 && "$output" == *"timed out or failed"* ]]; then
+		print_result "Claude MCP list timeout is non-blocking" 0
+		return 0
+	fi
+
+	print_result "Claude MCP list timeout is non-blocking" 1 "duration=${duration} output=${output}"
+	return 0
+}
+
+test_claude_mcp_add_timeout_is_non_blocking() {
+	local start end duration output
+	start="$(date +%s)"
+	output="$(run_claude_registration_with_stub "add-hangs" 2>&1)" || true
+	end="$(date +%s)"
+	duration=$((end - start))
+
+	if [[ "$duration" -lt 4 && "$output" == *"Failed or timed out registering"* ]]; then
+		print_result "Claude MCP add-json timeout is non-blocking" 0
+		return 0
+	fi
+
+	print_result "Claude MCP add-json timeout is non-blocking" 1 "duration=${duration} output=${output}"
+	return 0
+}
+
+main() {
+	test_claude_mcp_list_timeout_is_non_blocking
+	test_claude_mcp_add_timeout_is_non_blocking
+
+	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -ne 0 ]]; then
+		exit 1
+	fi
+
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Adds a bounded timeout wrapper around Claude Code MCP list/add-json calls so non-interactive setup cannot hang indefinitely in MCP registration.
- Adds a regression test for both `claude mcp list` and `claude mcp add-json` hang paths.

## Testing
- `shellcheck .agents/scripts/mcp-config-adapter.sh .agents/scripts/tests/test-mcp-config-adapter-claude-timeout.sh`
- `bash .agents/scripts/tests/test-mcp-config-adapter-claude-timeout.sh`
- `AIDEVOPS_MCP_CLAUDE_TIMEOUT_SECONDS=3 ./setup.sh --non-interactive` completed with `[SETUP_COMPLETE]`.

## Runtime Testing
- self-assessed: shell/setup path with local regression coverage and non-interactive setup completion check.

## Key decisions
- Fail open for Claude MCP registration timeouts by warning and continuing; setup config generation should not block on a single runtime MCP CLI call.

Resolves #21989
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.27 plugin for [OpenCode](https://opencode.ai) v1.14.30 with gpt-5.5 spent 24m and 136,188 tokens on this with the user in an interactive session.