### PR TITLE
t3251: fast-fail worker dispatch before expensive startup

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -1546,6 +1546,7 @@ _handle_worker_branch_orphan() {
 		# Post structured ops comment so the next dispatch knows what happened
 		if [[ -n "$issue_number" && -n "$repo_slug" && -n "$branch_name" ]]; then
 			local _ops_comment
+			# shellcheck disable=SC2016 # printf format string; placeholders are supplied below.
 			_ops_comment=$(printf '<!-- ops:start -->\nWORKER_BRANCH_ORPHAN branch=%s session=%s ts=%s\n\nThis worker pushed branch `%s` but no PR could be opened automatically. To recover, open a PR manually:\n\n```\ngh pr create --head %s --base main --repo %s\n```\n<!-- ops:end -->' \
 				"$branch_name" "$session_key" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
 				"$branch_name" "$branch_name" "$repo_slug")
@@ -2078,6 +2079,40 @@ cmd_run() {
 	return 1
 }
 
+cmd_canary() {
+	local role="worker"
+	local model_override=""
+
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+		--role)
+			role="${2:-}"
+			shift 2
+			;;
+		--model)
+			model_override="${2:-}"
+			shift 2
+			;;
+		--tier)
+			# Accepted for call-site clarity; the dispatcher resolves the
+			# concrete model before invoking this preflight.
+			shift 2
+			;;
+		*)
+			print_error "Unknown option for canary: $arg"
+			return 1
+			;;
+		esac
+	done
+
+	local selected_model
+	selected_model=$(choose_model "$role" "$model_override") || return $?
+	_enforce_opencode_version_pin
+	_run_canary_test "$selected_model"
+	return $?
+}
+
 # =============================================================================
 # Help and main entry point
 # =============================================================================
@@ -2088,6 +2123,7 @@ headless-runtime-helper.sh - Model-aware headless runtime (OpenCode default, Cla
 
 Usage:
   headless-runtime-helper.sh select [--role pulse|worker] [--model provider/model]
+  headless-runtime-helper.sh canary [--role pulse|worker] [--model provider/model] [--tier haiku|sonnet|opus|...]
   headless-runtime-helper.sh run --role pulse|worker --session-key KEY --dir PATH --title TITLE (--prompt TEXT | --prompt-file FILE) [--model provider/model] [--tier haiku|sonnet|opus|...] [--variant NAME] [--agent NAME] [--runtime opencode|claude] [--opencode-arg ARG] [--detach]
   headless-runtime-helper.sh backoff [status|set MODEL-OR-PROVIDER REASON [SECONDS]|clear MODEL-OR-PROVIDER]
   headless-runtime-helper.sh session [status|clear PROVIDER SESSION_KEY]
@@ -2134,6 +2170,10 @@ main() {
 		;;
 	run)
 		cmd_run "$@"
+		return $?
+		;;
+	canary)
+		cmd_canary "$@"
 		return $?
 		;;
 	backoff)

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -843,6 +843,27 @@ Dispatching worker (deterministic).
 	return 0
 }
 
+_dlw_canary_preflight() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local worker_log="$3"
+	local dispatch_model_tier="$4"
+	local selected_model="$5"
+
+	local -a _canary_cmd=("$HEADLESS_RUNTIME_HELPER" canary --role worker --tier "$dispatch_model_tier")
+	if [[ -n "$selected_model" ]]; then
+		_canary_cmd+=(--model "$selected_model")
+	fi
+
+	if "${_canary_cmd[@]}" >>"$worker_log" 2>&1; then
+		return 0
+	fi
+
+	pulse_stats_increment "worker_canary_preflight_failed_count" 2>/dev/null || true
+	echo "[dispatch_with_dedup] Skipping #${issue_number} in ${repo_slug} — worker canary preflight failed before worktree pre-creation; will retry next cycle" >>"$LOGFILE"
+	return 1
+}
+
 #######################################
 # Thin orchestrator for worker launch. Delegates each distinct concern
 # (assignment + labels, log files, model resolution, issue lock, repo pull,
@@ -877,10 +898,6 @@ _dispatch_launch_worker() {
 	# t3034: per-stage timing for launch sub-stages
 	local _ds_t0
 
-	_ds_t0=$(_ds_now_ns)
-	_dlw_assign_and_label "$issue_number" "$repo_slug" "$self_login" "$issue_meta_json"
-	_ds_record "$issue_number" "$repo_slug" "assign_and_label" "$_ds_t0"
-
 	local worker_log
 	worker_log=$(_dlw_setup_worker_log "$repo_slug" "$issue_number")
 
@@ -890,6 +907,18 @@ _dispatch_launch_worker() {
 	local dispatch_tier="$_DLW_DISPATCH_TIER"
 	local dispatch_model_tier="$_DLW_DISPATCH_MODEL_TIER"
 	local selected_model="$_DLW_SELECTED_MODEL"
+
+	_ds_t0=$(_ds_now_ns)
+	if ! _dlw_canary_preflight "$issue_number" "$repo_slug" "$worker_log" \
+		"$dispatch_model_tier" "$selected_model"; then
+		_ds_record "$issue_number" "$repo_slug" "canary_preflight" "$_ds_t0"
+		return 0
+	fi
+	_ds_record "$issue_number" "$repo_slug" "canary_preflight" "$_ds_t0"
+
+	_ds_t0=$(_ds_now_ns)
+	_dlw_assign_and_label "$issue_number" "$repo_slug" "$self_login" "$issue_meta_json"
+	_ds_record "$issue_number" "$repo_slug" "assign_and_label" "$_ds_t0"
 
 	# t1894/t1934: Lock issue and linked PRs during worker execution
 	_ds_t0=$(_ds_now_ns)

--- a/.agents/scripts/tests/test-worker-warm-start-opencode.sh
+++ b/.agents/scripts/tests/test-worker-warm-start-opencode.sh
@@ -331,6 +331,46 @@ test_launch_script_has_prewarm() {
 }
 
 # ---------------------------------------------------------------------------
+# Test: canary preflight runs before expensive worktree pre-creation
+# ---------------------------------------------------------------------------
+test_launch_script_fast_fails_before_prewarm() {
+	local launch_path="$SCRIPT_DIR/../pulse-dispatch-worker-launch.sh"
+	local helper_path="$SCRIPT_DIR/../headless-runtime-helper.sh"
+	if [[ ! -f "$launch_path" || ! -f "$helper_path" ]]; then
+		print_result "canary_preflight_files_found" 1 "launch/helper script missing"
+		return 1
+	fi
+
+	local rc=0
+	if ! grep -q "canary_preflight" "$launch_path"; then
+		print_result "canary_preflight_stage_present" 1 "canary_preflight stage not found"
+		rc=1
+	else
+		print_result "canary_preflight_stage_present" 0
+	fi
+
+	local canary_line precreate_line
+	canary_line=$(grep -n "_dlw_canary_preflight" "$launch_path" | tail -1 | cut -d: -f1)
+	precreate_line=$(grep -n "_dlw_precreate_worktree" "$launch_path" | tail -1 | cut -d: -f1)
+	if [[ -z "$canary_line" || -z "$precreate_line" || "$canary_line" -ge "$precreate_line" ]]; then
+		print_result "canary_before_worktree_precreate" 1 "canary_line=${canary_line:-missing}, precreate_line=${precreate_line:-missing}"
+		rc=1
+	else
+		print_result "canary_before_worktree_precreate" 0
+	fi
+
+	if ! grep -q "cmd_canary" "$helper_path"; then
+		print_result "headless_canary_command_present" 1 "cmd_canary not found in headless-runtime-helper.sh"
+		rc=1
+	else
+		print_result "headless_canary_command_present" 0
+	fi
+
+	if [[ "$rc" -eq 0 ]]; then return 0; fi
+	return 1
+}
+
+# ---------------------------------------------------------------------------
 # Main
 # ---------------------------------------------------------------------------
 main() {
@@ -343,6 +383,7 @@ main() {
 	test_warm_up_failure_nonfatal
 	test_headless_runtime_honours_prewarm_dir
 	test_launch_script_has_prewarm
+	test_launch_script_fast_fails_before_prewarm
 
 	echo ""
 	echo "Results: ${TESTS_PASSED}/${TESTS_RUN} passed, ${TESTS_FAILED} failed"


### PR DESCRIPTION
## Summary
- Add a headless runtime canary subcommand so dispatch can evaluate OpenCode health before worker session preparation.
- Move worker dispatch canary preflight ahead of issue assignment, worktree pre-creation, and DB warm-up to avoid 150s+ doomed launches during overload/negative-cache windows.
- Add regression coverage that pins canary-before-worktree ordering.

## Verification
- `bash .agents/scripts/tests/test-worker-warm-start-opencode.sh` — 18/18 passed
- `shellcheck .agents/scripts/headless-runtime-helper.sh .agents/scripts/pulse-dispatch-worker-launch.sh .agents/scripts/tests/test-worker-warm-start-opencode.sh`

Resolves #22017
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.28 plugin for [OpenCode](https://opencode.ai) v1.14.30 with gpt-5.5 spent 43m and 162,184 tokens on this with the user in an interactive session.