### PR TITLE
t3229: fix OpenAI OAuth availability when env key is stale

### DIFF
--- a/.agents/scripts/model-availability-helper.sh
+++ b/.agents/scripts/model-availability-helper.sh
@@ -390,6 +390,11 @@ resolve_api_key() {
 		IFS=',' read -ra var_names <<<"$key_vars"
 		for var_name in "${var_names[@]}"; do
 			# Source 1: Environment variable
+			# NOTE (t3229): if this key is stale/invalid and the HTTP probe
+			# rejects it (HTTP 401/403), probe_provider falls back to Source 4
+			# (auth.json OAuth) via _probe_check_oauth_fallback in
+			# model-availability-probe-lib.sh — so a stale env key does not
+			# permanently mask a working OAuth account.
 			if [[ -n "${!var_name:-}" ]]; then
 				echo "${!var_name}"
 				return 0

--- a/.agents/scripts/model-availability-probe-lib.sh
+++ b/.agents/scripts/model-availability-probe-lib.sh
@@ -422,6 +422,35 @@ _probe_resolve_and_validate_key() {
 	return 0
 }
 
+# _probe_check_oauth_fallback: called when an HTTP probe rejected the resolved
+# key with exit code 3 (HTTP 401/403). Checks whether auth.json has an OAuth
+# entry for the provider — if so, the OpenCode runtime can authenticate at
+# session start via its own OAuth flow, so the provider IS available.
+# Records healthy and returns 0 on OAuth hit; returns 3 if no OAuth found.
+#
+# t3229: prevents a stale/invalid env OPENAI_API_KEY (or any provider key)
+# from permanently masking a working OAuth account in auth.json. Without this
+# fallback, resolve_api_key returns the stale env key (Source 1), the HTTP
+# probe 401s/403s, and the provider is marked key_invalid — even though
+# auth.json has a valid OAuth entry the runtime would use.
+_probe_check_oauth_fallback() {
+	local provider="$1"
+	local quiet="${2:-false}"
+
+	local auth_file="${HOME}/.local/share/opencode/auth.json"
+	[[ -f "$auth_file" ]] || return 3
+
+	local auth_type
+	auth_type=$(jq -r --arg p "$provider" '.[$p].type // empty' "$auth_file" 2>/dev/null) || auth_type=""
+	if [[ "$auth_type" == "oauth" ]]; then
+		[[ "$quiet" != "true" ]] && print_success "$provider: env key rejected (HTTP 401/403) but OAuth found in auth.json — recording healthy (t3229)"
+		_record_health "$provider" "healthy" 0 0 "OAuth available (env key rejected, t3229)" 0
+		return 0
+	fi
+
+	return 3
+}
+
 # Execute an HTTP probe against a provider's /models endpoint and record results.
 # Builds the curl request, executes it, parses the response, records health and
 # rate limits, and logs the probe result.
@@ -525,8 +554,18 @@ probe_provider() {
 	fi
 
 	# Execute HTTP probe against the provider's /models endpoint
-	_probe_execute_http "$provider" "$api_key" "$quiet"
-	return $?
+	local http_exit=0
+	_probe_execute_http "$provider" "$api_key" "$quiet" || http_exit=$?
+
+	# t3229: if the resolved key was rejected (HTTP 401/403), check whether
+	# auth.json has an OAuth entry for this provider. OAuth wins over a
+	# stale/invalid env key — the runtime authenticates at session start.
+	if [[ "$http_exit" -eq 3 ]]; then
+		_probe_check_oauth_fallback "$provider" "$quiet"
+		return $?
+	fi
+
+	return "$http_exit"
 }
 
 _record_health() {

--- a/.agents/scripts/tests/test-model-availability-oauth-probe.sh
+++ b/.agents/scripts/tests/test-model-availability-oauth-probe.sh
@@ -172,6 +172,57 @@ fi
 unset ANTHROPIC_API_KEY
 
 # =============================================================================
+# Assertion 4 — stale env key + OpenAI OAuth in auth.json (t3229)
+# =============================================================================
+# The failure mode: OPENAI_API_KEY=invalid is set (stale from an old account)
+# and auth.json has a valid OpenAI OAuth entry. _probe_check_oauth_fallback
+# must return 0 (healthy) so the provider is not permanently marked key_invalid.
+#
+# We cannot invoke probe_provider directly (it makes HTTP calls), but we CAN
+# test _probe_check_oauth_fallback in isolation — it reads auth.json and calls
+# _record_health. This is the testable unit for the t3229 fix.
+
+export OPENAI_API_KEY="sk-invalid-stale-key-from-old-account"
+
+cat >"$AUTH_FILE" <<JSON
+{
+  "openai": {
+    "type": "oauth",
+    "access": "fake-openai-access-token",
+    "refresh": "fake-openai-refresh-token"
+  }
+}
+JSON
+
+# init_db may already be done from assertion 3 — reinit is idempotent.
+init_db >/dev/null 2>&1 || {
+	print_result "assertion 4 precondition: init_db" 1 "(init_db failed)"
+}
+
+# _probe_check_oauth_fallback must detect the oauth entry and return 0.
+_probe_check_oauth_fallback openai true
+rc=$?
+if [[ "$rc" -eq 0 ]]; then
+	print_result "stale-env-key+openai-oauth: _probe_check_oauth_fallback returns 0 (t3229)" 0
+else
+	print_result "stale-env-key+openai-oauth: _probe_check_oauth_fallback returns 0 (t3229)" 1 \
+		"(got rc=$rc — expected 0; stale env key should not mask OAuth in auth.json)"
+fi
+
+# Assertion 4b — no OAuth in auth.json → fallback returns 3 (no override).
+rm -f "$AUTH_FILE"
+_probe_check_oauth_fallback openai true
+rc=$?
+if [[ "$rc" -eq 3 ]]; then
+	print_result "stale-env-key+no-oauth: _probe_check_oauth_fallback returns 3 (no override)" 0
+else
+	print_result "stale-env-key+no-oauth: _probe_check_oauth_fallback returns 3 (no override)" 1 \
+		"(got rc=$rc — expected 3; no auth.json OAuth should not produce a false healthy)"
+fi
+
+unset OPENAI_API_KEY
+
+# =============================================================================
 # Summary
 # =============================================================================
 printf '\n%d test(s) run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"


### PR DESCRIPTION
## Summary

Fixes the failure mode where a stale `OPENAI_API_KEY` (or any provider env key) masks a valid OAuth account in auth.json, causing the model-availability probe to mark the provider as `key_invalid` even though the OpenCode runtime would successfully authenticate via OAuth at session start.

## Changes

**`model-availability-probe-lib.sh`**
- Adds `_probe_check_oauth_fallback` helper: when the HTTP probe rejects the resolved key (HTTP 401/403 → exit 3), checks `~/.local/share/opencode/auth.json` for an OAuth entry for the same provider. If found, records the provider as healthy (the runtime handles OAuth authentication at session start). Returns 3 with no side-effects when no OAuth entry exists.
- Modifies `probe_provider`: after `_probe_execute_http` returns exit 3, calls `_probe_check_oauth_fallback` before propagating the failure.

**`model-availability-helper.sh`**
- Adds a t3229 note in `resolve_api_key` (Source 1) documenting the probe-level fallback for stale keys, so future readers understand why env-key priority is safe.

**`tests/test-model-availability-oauth-probe.sh`**
- Adds Assertion 4a: stale `OPENAI_API_KEY` + OpenAI OAuth in auth.json → `_probe_check_oauth_fallback` returns 0 (healthy).
- Adds Assertion 4b: no auth.json → `_probe_check_oauth_fallback` returns 3 (no false-positive override).

## Verification

```
bash .agents/scripts/tests/test-model-availability-oauth-probe.sh
→ 5 test(s) run, 0 failed

shellcheck .agents/scripts/model-availability-helper.sh .agents/scripts/model-availability-probe-lib.sh
→ No new violations (pre-existing SC2005 in helper.sh, not introduced by this PR)
```

Resolves #21983

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.28 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-sonnet-4-6 spent 6m and 15,537 tokens on this as a headless worker.
