### PR TITLE
t3221: setup.sh steady-state under 60s — rsync drift check, SHA-skip backup, async pulse restart, migration sentinels

### DIFF
--- a/setup-modules/agent-deploy.sh
+++ b/setup-modules/agent-deploy.sh
@@ -503,6 +503,9 @@ _deploy_agents_post_copy() {
 # (those edits are overwritten by every deploy). Emits a warning listing drifted
 # files and the canonical source path to edit instead.
 # Non-fatal: always returns 0 so deployment proceeds.
+#
+# Performance: uses a single rsync --checksum --dry-run call instead of one
+# diff -q subprocess per script (was 783 calls → now 1 call; t3221).
 _warn_deployed_script_drift() {
 	local source_dir="$1"
 	local target_dir="$2"
@@ -512,20 +515,35 @@ _warn_deployed_script_drift() {
 	if [[ ! -d "$source_scripts" || ! -d "$target_scripts" ]]; then
 		return 0
 	fi
-	if ! command -v diff &>/dev/null; then
-		return 0
-	fi
 
 	local -a drifted=()
-	local f bn
-	for f in "$target_scripts"/*.sh; do
-		[[ -f "$f" ]] || continue
-		bn=$(basename "$f")
-		local src="$source_scripts/$bn"
-		if [[ -f "$src" ]] && ! diff -q "$src" "$f" &>/dev/null; then
-			drifted+=("$bn")
-		fi
-	done
+	if command -v rsync &>/dev/null; then
+		# Single bulk comparison: rsync --checksum --dry-run reports changed files
+		# without transferring anything. --out-format='%f' prints only the relative
+		# path of each changed file. Filter to top-level *.sh only (no subdirs).
+		local changed_file
+		while IFS= read -r changed_file; do
+			[[ -n "$changed_file" ]] || continue
+			# Skip subdirectory scripts (only warn about top-level scripts/)
+			[[ "$changed_file" == */* ]] && continue
+			[[ "$changed_file" == *.sh ]] || continue
+			drifted+=("$changed_file")
+		done < <(rsync --checksum --dry-run \
+			--out-format='%f' \
+			--include='*.sh' --exclude='*/' --exclude='*' \
+			"$source_scripts/" "$target_scripts/" 2>/dev/null || true)
+	elif command -v diff &>/dev/null; then
+		# Fallback: one diff -q per script (slow, only reached when rsync absent)
+		local f bn
+		for f in "$target_scripts"/*.sh; do
+			[[ -f "$f" ]] || continue
+			bn=$(basename "$f")
+			local src="$source_scripts/$bn"
+			if [[ -f "$src" ]] && ! diff -q "$src" "$f" &>/dev/null; then
+				drifted+=("$bn")
+			fi
+		done
+	fi
 
 	if [[ ${#drifted[@]} -gt 0 ]]; then
 		print_warning "Deployed scripts differ from canonical source (local edits will be overwritten; backup will be created):"
@@ -577,9 +595,18 @@ deploy_aidevops_agents() {
 		_warn_deployed_script_drift "$source_dir" "$target_dir"
 	fi
 
-	# Create backup if target exists (with rotation)
+	# Create backup if target exists (with rotation).
+	# Skip when the deployed SHA matches the current HEAD — nothing changed on
+	# disk, so there is nothing worth backing up (t3221: steady-state perf).
 	if [[ -d "$target_dir" ]]; then
-		create_backup_with_rotation "$target_dir" "agents"
+		local _cur_sha _dep_sha
+		_cur_sha=$(git -C "$repo_dir" rev-parse HEAD 2>/dev/null || echo "")
+		_dep_sha=$(cat "${HOME}/.aidevops/.deployed-sha" 2>/dev/null || echo "")
+		if [[ -n "$_cur_sha" && -n "$_dep_sha" && "$_cur_sha" == "$_dep_sha" ]]; then
+			print_info "No changes since last deploy (${_cur_sha:0:8}) — skipping backup"
+		else
+			create_backup_with_rotation "$target_dir" "agents"
+		fi
 	fi
 
 	mkdir -p "$target_dir"
@@ -594,17 +621,11 @@ deploy_aidevops_agents() {
 	print_success "Deployed agents to $target_dir"
 	_deploy_agents_post_copy "$target_dir" "$repo_dir" "$source_dir" "$plugins_file"
 
-	# Restart pulse if running — bash processes load source files at startup
-	# and don't re-read them when files change on disk. Without a restart,
-	# fixes to pulse-*.sh, dispatch-dedup-*.sh, headless-runtime-*.sh, and
-	# other sourced scripts don't take effect until the next manual restart.
-	# This was the root cause of a multi-hour outage where deployed fixes
-	# were correct but the running pulse kept using old code in memory.
-	_restart_pulse_if_running
-
-	# Write deployed-SHA stamp so aidevops-update-check.sh can detect
-	# script drift between this deploy and future canonical-repo commits.
-	# Written AFTER pulse restart so the stamp reflects a fully-applied deploy.
+	# Write deployed-SHA stamp BEFORE the pulse restart so the stamp is
+	# available immediately for subsequent setup steps and the next run's
+	# backup-skip check (t3221). Previously written after the blocking
+	# restart wait; moving it here has no correctness impact — the deploy
+	# is already fully on disk at this point.
 	# t2156: enables auto-redeploy when local commits land between releases.
 	local deployed_sha
 	deployed_sha=$(git -C "$repo_dir" rev-parse HEAD 2>/dev/null || echo "")
@@ -613,6 +634,20 @@ deploy_aidevops_agents() {
 		mkdir -p "$aidevops_dir"
 		printf '%s\n' "$deployed_sha" >"${aidevops_dir}/.deployed-sha"
 	fi
+
+	# Restart pulse in the background — bash processes load source files at
+	# startup and don't re-read them when files change on disk. Without a
+	# restart, fixes to pulse-*.sh, dispatch-dedup-*.sh, and other sourced
+	# scripts don't take effect until the next manual restart.
+	#
+	# t3221: running this asynchronously saves the 10-15s blocking wait
+	# (pkill + up to 10s die-wait + sleep 5 launchd grace period). The
+	# deploy is already complete on disk; the pulse picks up the new scripts
+	# once it restarts regardless of when that happens relative to setup.sh
+	# finishing. disown prevents SIGHUP propagation if setup.sh is sourced
+	# interactively; in script mode the orphan survives the exit anyway.
+	_restart_pulse_if_running &
+	disown
 
 	return 0
 }

--- a/setup-modules/migrations.sh
+++ b/setup-modules/migrations.sh
@@ -616,7 +616,16 @@ _migrate_ai_config_agent_refs() {
 # 3. .gitignore entries in user projects
 # 4. References in user's AI assistant configs
 # 5. References in ~/.aidevops/ config files
+#
+# Guarded by a sentinel file: on a converged system the function does
+# a repos.json scan and a find(1) scan of ~/Git, both of which cost
+# several seconds per run (t3221).
 migrate_agent_to_agents_folder() {
+	local _sentinel="${HOME}/.aidevops/.migrations/agent-to-agents-done"
+	if [[ -f "$_sentinel" ]]; then
+		return 0
+	fi
+
 	print_info "Checking for .agent -> .agents migration..."
 
 	local migrated=0
@@ -649,6 +658,9 @@ migrate_agent_to_agents_folder() {
 		print_info "No .agent -> .agents migration needed"
 	fi
 
+	# Write sentinel so subsequent setup runs skip the repos+find scans (t3221)
+	mkdir -p "$(dirname "$_sentinel")"
+	date -u +%Y-%m-%dT%H:%M:%SZ >"$_sentinel"
 	return 0
 }
 
@@ -782,6 +794,12 @@ _migrate_mcp_npx_to_binary() {
 
 # Remove deprecated MCP entries from opencode.json
 # These MCPs have been replaced by curl-based subagents (zero context cost)
+#
+# The one-time cleanup (remove deprecated entries + migrate npx→binary) is
+# guarded by a versioned sentinel (t3221). Bump the sentinel version when new
+# deprecated MCPs are added to _remove_deprecated_mcp_entries.
+# The recurring update_mcp_paths_in_opencode call is NOT guarded — it resolves
+# stale binary paths on every run (paths can change after package upgrades).
 cleanup_deprecated_mcps() {
 	local opencode_config
 	opencode_config=$(find_opencode_config) || return 0
@@ -794,27 +812,36 @@ cleanup_deprecated_mcps() {
 		return 0
 	fi
 
-	local cleaned=0
-	local tmp_config
-	tmp_config=$(mktemp)
-	trap 'rm -f "${tmp_config:-}"' RETURN
+	# One-time cleanup: remove deprecated MCPs and migrate npx→binary paths.
+	# Sentinel version must be bumped whenever new deprecated MCPs are added.
+	local _sentinel="${HOME}/.aidevops/.migrations/cleanup-deprecated-mcps-v1"
+	if [[ ! -f "$_sentinel" ]]; then
+		local cleaned=0
+		local tmp_config
+		tmp_config=$(mktemp)
+		trap 'rm -f "${tmp_config:-}"' RETURN
 
-	cp "$opencode_config" "$tmp_config"
+		cp "$opencode_config" "$tmp_config"
 
-	# Remove deprecated MCP and tool entries
-	_remove_deprecated_mcp_entries "$tmp_config"
-	cleaned=$((cleaned + _cleanup_count))
+		# Remove deprecated MCP and tool entries
+		_remove_deprecated_mcp_entries "$tmp_config"
+		cleaned=$((cleaned + _cleanup_count))
 
-	# Migrate npx/pipx commands to full binary paths (faster startup, PATH-independent)
-	_migrate_mcp_npx_to_binary "$tmp_config"
-	cleaned=$((cleaned + _cleanup_count))
+		# Migrate npx/pipx commands to full binary paths (faster startup, PATH-independent)
+		_migrate_mcp_npx_to_binary "$tmp_config"
+		cleaned=$((cleaned + _cleanup_count))
 
-	if [[ $cleaned -gt 0 ]]; then
-		create_backup_with_rotation "$opencode_config" "opencode"
-		mv "$tmp_config" "$opencode_config"
-		print_info "Updated $cleaned MCP entry/entries in opencode.json (using full binary paths)"
-	else
-		rm -f "$tmp_config"
+		if [[ $cleaned -gt 0 ]]; then
+			create_backup_with_rotation "$opencode_config" "opencode"
+			mv "$tmp_config" "$opencode_config"
+			print_info "Updated $cleaned MCP entry/entries in opencode.json (using full binary paths)"
+		else
+			rm -f "$tmp_config"
+		fi
+
+		# Write sentinel
+		mkdir -p "$(dirname "$_sentinel")"
+		date -u +%Y-%m-%dT%H:%M:%SZ >"$_sentinel"
 	fi
 
 	# Always resolve bare binary names to full paths (fixes PATH-dependent startup)
@@ -1127,7 +1154,15 @@ migrate_old_backups() {
 # Migrate loop state from .claude/ to .agents/loop-state/ in user projects
 # Also migrates from legacy .agents/loop-state/ to .agents/loop-state/
 # The migration is non-destructive: moves files, doesn't delete originals until confirmed
+#
+# Guarded by a sentinel file: on a converged system the function does a
+# find(1) scan of ~/Git which costs several seconds per run (t3221).
 migrate_loop_state_directories() {
+	local _sentinel="${HOME}/.aidevops/.migrations/loop-state-dirs-migrated"
+	if [[ -f "$_sentinel" ]]; then
+		return 0
+	fi
+
 	print_info "Checking for legacy loop state directories..."
 
 	local migrated=0
@@ -1218,6 +1253,9 @@ migrate_loop_state_directories() {
 		print_info "No legacy loop state directories found"
 	fi
 
+	# Write sentinel so subsequent setup runs skip the find scan (t3221)
+	mkdir -p "$(dirname "$_sentinel")"
+	date -u +%Y-%m-%dT%H:%M:%SZ >"$_sentinel"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

`bash setup.sh --non-interactive` was taking >150s on a converged system (no actual changes to deploy). This PR optimizes the steady-state (no-op) re-run to target <60s by eliminating four classes of redundant work.

## Changes

### 1. `setup-modules/agent-deploy.sh` — `_warn_deployed_script_drift`

Replaced 783 individual `diff -q` subprocess calls (one per `.sh` file in `~/.aidevops/agents/scripts/`) with a single `rsync --checksum --dry-run` bulk comparison. rsync computes checksums in one pass; the old loop spawned one subprocess per file.

- Before: 783 `diff -q` calls → 783 subprocess forks
- After: 1 `rsync --checksum --dry-run` call

### 2. `setup-modules/agent-deploy.sh` — `deploy_aidevops_agents` backup skip

Added SHA-based guard: when `~/.aidevops/.deployed-sha` matches the current repo `HEAD`, skip `create_backup_with_rotation` entirely. On a no-op run nothing has changed, so there is nothing worth backing up. This avoids a full `rsync -a` of 1233 files on every run.

### 3. `setup-modules/agent-deploy.sh` — async pulse restart

The `_restart_pulse_if_running` call was blocking setup for 10-15s (pkill + up to 10s die-poll + sleep 5 launchd grace period). Since the deploy is already complete on disk at that point, the pulse can restart asynchronously. Changed to `_restart_pulse_if_running & disown`. The deployed-SHA stamp is now written _before_ the restart (no semantic change — deploy is on disk either way).

### 4. `setup-modules/migrations.sh` — sentinel guards on expensive migrations

Three migration functions that ran expensive filesystem scans on every setup are now guarded by sentinel files in `~/.aidevops/.migrations/`:

- `migrate_agent_to_agents_folder`: repos.json scan + `find ~/Git` (`.agent` symlinks) — runs once and done
- `migrate_loop_state_directories`: `find ~/Git -maxdepth 3 -name .git` scan — runs once and done
- `cleanup_deprecated_mcps` (one-time block): repeated jq on opencode.json — guarded by versioned sentinel `v1` (bump when new deprecated MCPs are added; `update_mcp_paths_in_opencode` remains unguarded)

## Verification

```bash
# Steady-state: second back-to-back run should be well under 60s
time bash setup.sh --non-interactive
time bash setup.sh --non-interactive  # second run: backup skipped, migrations skipped

# Verify agents still deployed correctly
ls -la ~/.aidevops/agents/scripts/worker-activity-helper.sh

# Verify sentinels created
ls ~/.aidevops/.migrations/

# Shellcheck (already clean in CI)
shellcheck setup-modules/agent-deploy.sh setup-modules/migrations.sh

# Pulse must still restart after a real change (delete SHA stamp to force)
rm ~/.aidevops/.deployed-sha
time bash setup.sh --non-interactive  # should backup + restart pulse
```

## Files modified

- `EDIT: setup-modules/agent-deploy.sh` — drift check, backup skip, async restart
- `EDIT: setup-modules/migrations.sh` — sentinel guards on 3 migration functions

Resolves #21964

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.28 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-sonnet-4-6 spent 8m and 25,123 tokens on this as a headless worker.
