### PR TITLE
t3217: fix orphan recovery existing PR probe

### DIFF
--- a/.agents/scripts/shared-claim-lifecycle.sh
+++ b/.agents/scripts/shared-claim-lifecycle.sh
@@ -227,15 +227,16 @@ _pr_exists_for_branch_or_issue() {
 # origin:worker-takeover label so the normal review/merge pipeline applies.
 #
 # Short-circuits (returns 1) when:
-#   - branch_name or repo_slug are empty (cannot construct PR)
+#   - repo_slug is empty (cannot query or construct PR)
+#   - branch_name is empty after the existing-PR probe (cannot construct PR)
 #   - linked issue is CLOSED (branch is genuinely orphaned, no PR needed)
 #   - gh pr create fails for any reason
 #
-# Pre-check (t3195/GH#21889): if a PR already exists for the branch
-# (`--head` probe via _pr_exists_for_branch_or_issue), returns 0 with no
-# `gh pr create` attempt. This catches search-index-lag misclassifications
-# from the upstream signal-3 path so the recovery helper does not
-# uselessly try to create a duplicate PR.
+# Pre-check (t3195/GH#21889): if a PR already exists for the branch or issue
+# (`--head`/`--search` probes via _pr_exists_for_branch_or_issue), returns 0
+# with no `gh pr create` attempt. This catches search-index-lag and cleaned-
+# worktree misclassifications so the recovery helper does not uselessly try to
+# create a duplicate PR or release the claim as worker_branch_orphan.
 #
 # On success: returns 0 (caller releases as worker_complete)
 # On failure: returns 1 (caller releases as worker_branch_orphan)
@@ -256,12 +257,13 @@ _attempt_orphan_recovery_pr() {
 	local branch_name="$3"
 	local repo_slug="$4"
 
-	# Cannot build a PR without branch + repo
-	if [[ -z "$branch_name" || -z "$repo_slug" ]]; then
+	# Cannot query or build a PR without repo context.
+	if [[ -z "$repo_slug" ]]; then
 		return 1
 	fi
 
-	# Derive issue number from session key (format: issue-NNNN or pulse-*-NNNN)
+	# Derive issue number before branch guards so the existing-PR probe can
+	# fall back to issue search when a cleaned worktree leaves branch_name empty.
 	local issue_number=""
 	issue_number=$(printf '%s' "$session_key" | grep -oE '[0-9]+$' || true)
 
@@ -273,6 +275,12 @@ _attempt_orphan_recovery_pr() {
 	pr_existence=$(_pr_exists_for_branch_or_issue "$branch_name" "$issue_number" "$repo_slug")
 	if [[ "$pr_existence" == "found" ]]; then
 		return 0
+	fi
+
+	# Past this point recovery needs a branch to create a PR. Existing PRs were
+	# already handled above, including the empty-branch issue-search fallback.
+	if [[ -z "$branch_name" ]]; then
+		return 1
 	fi
 
 	# Guard: skip recovery for closed issues — worker may have closed it as

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -60,7 +60,7 @@ test_appends_escalation_contract() {
 	local output
 	output=$(append_worker_headless_contract "$prompt")
 
-	if [[ "$output" == *'HEADLESS_CONTINUATION_CONTRACT_V6'* ]] &&
+	if [[ "$output" == *'HEADLESS_CONTINUATION_CONTRACT_V7'* ]] &&
 		[[ "$output" == *'Read the issue body FIRST'* ]] &&
 		[[ "$output" == *'Look for a "Worker Guidance" or "How" section'* ]] &&
 		[[ "$output" == *'Never ask for user confirmation, approval, or next steps. No user will respond.'* ]] &&
@@ -449,6 +449,39 @@ test_cmd_run_finish_orphan_recovery_success_emits_worker_complete() {
 	return 0
 }
 
+test_handle_worker_branch_orphan_empty_branch_existing_pr_releases_complete() {
+	local work_dir="${TEST_ROOT}/repo-finish-orphan-cleaned"
+	mkdir -p "$work_dir"
+	DISPATCH_REPO_SLUG="test-owner/test-repo"
+
+	# Stub gh: empty branch skips --head and falls back to issue search; existing PR found.
+	gh() {
+		if [[ "${*}" == *"pr list"* && "${*}" == *"--search 99999"* ]]; then
+			printf '1'
+			return 0
+		fi
+		printf '0'
+		return 0
+	}
+
+	local released_reason=""
+	_release_dispatch_claim() { released_reason="$2"; return 0; }
+	_increment_orphan_count_stat() { return 0; }
+
+	_handle_worker_branch_orphan "issue-99999" "$work_dir"
+
+	unset DISPATCH_REPO_SLUG 2>/dev/null || true
+	unset -f gh 2>/dev/null || true
+
+	if [[ "$released_reason" == "worker_complete" ]]; then
+		print_result "_handle_worker_branch_orphan treats empty-branch existing PR as complete" 0
+	else
+		print_result "_handle_worker_branch_orphan treats empty-branch existing PR as complete" 1 \
+			"Expected worker_complete (existing PR found by issue search), got '${released_reason}'"
+	fi
+	return 0
+}
+
 # AC#4: on auto-PR failure, _cmd_run_finish emits worker_branch_orphan
 test_cmd_run_finish_orphan_recovery_failure_emits_branch_orphan() {
 	local work_dir="${TEST_ROOT}/repo-finish-orphan-fail"
@@ -515,6 +548,7 @@ main() {
 	# Orphan recovery tests (GH#20819)
 	test_attempt_orphan_recovery_pr_calls_gh_create
 	test_cmd_run_finish_orphan_recovery_success_emits_worker_complete
+	test_handle_worker_branch_orphan_empty_branch_existing_pr_releases_complete
 	test_cmd_run_finish_orphan_recovery_failure_emits_branch_orphan
 	teardown_test_env
 


### PR DESCRIPTION
## Summary

- Reorders orphan recovery so repo context is validated first, then existing PRs are probed by branch or issue before an empty branch can fail recovery.
- Adds regression coverage for cleaned-worktree orphan handling where branch detection is empty but an issue-linked PR exists.
- Refreshes the headless runtime helper contract assertion to match the current V7 contract.

## Testing

- `shellcheck .agents/scripts/shared-claim-lifecycle.sh`
- `bash .agents/scripts/tests/test-headless-runtime-helper.sh` (22 tests, 0 failures)
- `.agents/scripts/complexity-scan-helper.sh metrics .agents/scripts/shared-claim-lifecycle.sh` (Long functions >100 lines: 0)

## Runtime Testing

- Low risk shell lifecycle bugfix; self-assessed via focused unit/regression tests.

Resolves #21958


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.29 plugin for [OpenCode](https://opencode.ai) v1.14.30 with gpt-5.5 spent 25m and 208,289 tokens on this as a headless worker.
