### PR TITLE
GH#22026: omit GPT-5.5 sonnet worker variant

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -1883,7 +1883,7 @@ cmd_run() {
 	fi
 
 	if [[ -z "$variant_override" ]]; then
-		variant_override=$(resolve_headless_variant "$role" "$tier_override")
+		variant_override=$(resolve_headless_variant "$role" "$tier_override" "$selected_model")
 	fi
 
 	# GH#17436: Continuation retry configuration.
@@ -2151,6 +2151,7 @@ Defaults:
   AIDEVOPS_HEADLESS_MODELS is deprecated — respected as override for one release cycle.
   AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST can restrict selection to providers like: openai
   AIDEVOPS_HEADLESS_VARIANT_SONNET / AIDEVOPS_HEADLESS_VARIANT_OPUS can set tier defaults.
+  GPT-5.5 sonnet-tier worker dispatch omits env-derived variants so OpenCode sends no explicit thinking override.
   AIDEVOPS_HEADLESS_VARIANT sets an OpenCode model variant (for example: high, xhigh).
   AIDEVOPS_HEADLESS_PULSE_VARIANT / AIDEVOPS_HEADLESS_WORKER_VARIANT override by role.
   AIDEVOPS_HEADLESS_APPEND_CONTRACT=0 disables worker /full-loop contract injection

--- a/.agents/scripts/headless-runtime-model.sh
+++ b/.agents/scripts/headless-runtime-model.sh
@@ -304,9 +304,28 @@ choose_model() {
 
 # --- Cmd Builders ---
 
+_headless_variant_should_omit_gpt55_sonnet() {
+	local role="$1"
+	local tier_upper="$2"
+	local selected_model="$3"
+	local variant="$4"
+
+	[[ "$role" == "worker" ]] || return 1
+	[[ -n "$variant" ]] || return 1
+	case "$tier_upper" in
+	SONNET | PRO) ;;
+	*) return 1 ;;
+	esac
+	case "$selected_model" in
+	openai/gpt-5.5 | openai/gpt-5.5-*) return 0 ;;
+	*) return 1 ;;
+	esac
+}
+
 resolve_headless_variant() {
 	local role="$1"
 	local tier="${2:-}"
+	local selected_model="${3:-}"
 	local variant="${AIDEVOPS_HEADLESS_VARIANT:-}"
 	local tier_upper=""
 
@@ -346,6 +365,14 @@ resolve_headless_variant() {
 			fi
 			;;
 		esac
+	fi
+
+	# GPT-5.5 currently benchmarks fastest for standard worker dispatch when
+	# OpenCode sends no explicit reasoning-effort variant. Keep explicit CLI
+	# --variant untouched (caller bypasses this resolver when provided), but
+	# ignore env-derived high/xhigh defaults for non-thinking worker tiers.
+	if _headless_variant_should_omit_gpt55_sonnet "$role" "$tier_upper" "$selected_model" "$variant"; then
+		variant=""
 	fi
 
 	printf '%s' "$variant"

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -60,7 +60,7 @@ test_appends_escalation_contract() {
 	local output
 	output=$(append_worker_headless_contract "$prompt")
 
-	if [[ "$output" == *'HEADLESS_CONTINUATION_CONTRACT_V6'* ]] &&
+	if [[ "$output" == *'HEADLESS_CONTINUATION_CONTRACT_V7'* ]] &&
 		[[ "$output" == *'Read the issue body FIRST'* ]] &&
 		[[ "$output" == *'Look for a "Worker Guidance" or "How" section'* ]] &&
 		[[ "$output" == *'Never ask for user confirmation, approval, or next steps. No user will respond.'* ]] &&
@@ -90,7 +90,7 @@ test_non_full_loop_prompt_unchanged() {
 test_does_not_double_append() {
 	local prompt='/full-loop Continue issue #14964
 
-[HEADLESS_CONTINUATION_CONTRACT_V6]
+[HEADLESS_CONTINUATION_CONTRACT_V7]
 This worker run is unattended.'
 	local output
 	output=$(append_worker_headless_contract "$prompt")

--- a/.agents/scripts/tests/test-headless-runtime-variant.sh
+++ b/.agents/scripts/tests/test-headless-runtime-variant.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+AGENTS_SCRIPTS="$(cd "${SCRIPT_DIR}/.." && pwd)"
+
+# shellcheck source=/dev/null
+source "${AGENTS_SCRIPTS}/headless-runtime-model.sh"
+
+failures=0
+
+assert_equals() {
+	local expected="$1"
+	local actual="$2"
+	local message="$3"
+	if [[ "$expected" != "$actual" ]]; then
+		printf 'FAIL: %s\n  expected: %s\n  actual:   %s\n' "$message" "$expected" "$actual" >&2
+		failures=$((failures + 1))
+		return 1
+	fi
+	printf 'PASS: %s\n' "$message"
+	return 0
+}
+
+with_clean_variant_env() {
+	unset AIDEVOPS_HEADLESS_VARIANT || true
+	unset AIDEVOPS_HEADLESS_VARIANT_SONNET || true
+	unset AIDEVOPS_HEADLESS_VARIANT_OPUS || true
+	unset AIDEVOPS_HEADLESS_WORKER_VARIANT || true
+	unset AIDEVOPS_HEADLESS_PULSE_VARIANT || true
+	return 0
+}
+
+with_clean_variant_env
+AIDEVOPS_HEADLESS_VARIANT_SONNET="high"
+actual=$(resolve_headless_variant "worker" "sonnet" "openai/gpt-5.5")
+assert_equals "" "$actual" "GPT-5.5 sonnet worker omits env-derived high variant" || true
+
+with_clean_variant_env
+AIDEVOPS_HEADLESS_VARIANT_SONNET="high"
+actual=$(resolve_headless_variant "worker" "sonnet" "openai/gpt-5.4")
+assert_equals "high" "$actual" "non-GPT-5.5 sonnet worker keeps high variant" || true
+
+with_clean_variant_env
+AIDEVOPS_HEADLESS_VARIANT_OPUS="xhigh"
+actual=$(resolve_headless_variant "worker" "opus" "openai/gpt-5.5")
+assert_equals "xhigh" "$actual" "GPT-5.5 opus worker keeps thinking-tier variant" || true
+
+with_clean_variant_env
+AIDEVOPS_HEADLESS_VARIANT_SONNET="high"
+actual=$(resolve_headless_variant "pulse" "sonnet" "openai/gpt-5.5")
+assert_equals "high" "$actual" "pulse sonnet routing keeps configured variant" || true
+
+with_clean_variant_env
+
+if [[ "$failures" -ne 0 ]]; then
+	printf '\n%d variant regression test(s) failed\n' "$failures" >&2
+	exit 1
+fi
+
+printf '\nAll headless runtime variant tests passed\n'
+exit 0

--- a/.agents/tools/context/model-routing.md
+++ b/.agents/tools/context/model-routing.md
@@ -81,7 +81,8 @@ Supervisor resolves automatically. Interactive: `compare-models-helper.sh discov
 - **Workers**: Round-robin across the routed `sonnet` models after allowlist filtering and auth checks. Tier escalation still uses `resolve` (`tier:simple` → `haiku`, `tier:standard` → `sonnet`, `tier:thinking` → `opus`).
 - **Local switch**: Add OpenAI models to `custom/configs/model-routing-table.json`, then set `AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST=openai` to force both pulse and workers onto OpenAI. If you want OpenAI primary but Anthropic fallback, reorder the custom routing table and omit the allowlist.
 - **Reasoning effort**: OpenCode exposes GPT reasoning variants separately (`none`, `minimal`, `low`, `medium`, `high`, `xhigh`). Headless runs do not default to `xhigh`; if no variant is set, OpenCode sends no explicit effort override and the provider default applies.
-- **Tier-aware effort**: Headless dispatch can now apply variants by resolved tier. `AIDEVOPS_HEADLESS_VARIANT_SONNET=high` and `AIDEVOPS_HEADLESS_VARIANT_OPUS=xhigh` make standard work run at `high` and reasoning-tier work run at `xhigh` even when both tiers use `openai/gpt-5.4`.
+- **GPT-5.5 standard workers**: For `openai/gpt-5.5` on worker `sonnet`/`pro` tiers, aidevops omits env-derived variants such as `AIDEVOPS_HEADLESS_VARIANT_SONNET=high` so OpenCode sends no explicit thinking override. Explicit CLI `--variant` still wins because it bypasses automatic variant resolution.
+- **Tier-aware effort**: Headless dispatch can now apply variants by resolved tier. `AIDEVOPS_HEADLESS_VARIANT_SONNET=high` and `AIDEVOPS_HEADLESS_VARIANT_OPUS=xhigh` make standard work run at `high` and reasoning-tier work run at `xhigh` even when both tiers use `openai/gpt-5.4`. The GPT-5.5 standard-worker exception above only applies to env-derived sonnet/pro variants.
 - **Fallback**: If routed resolution fails entirely, pulse falls back to `anthropic/claude-sonnet-4-6`; workers fall back to `DEFAULT_HEADLESS_MODELS` when no allowlist is forcing a subset.
 - **Deprecated**: `PULSE_MODEL` and `AIDEVOPS_HEADLESS_MODELS` env vars are respected as overrides for one release cycle with deprecation warnings. Remove from `credentials.sh`.
 
@@ -97,8 +98,8 @@ Example custom override for OpenAI-capable headless routing:
 ```json
 {
   "tiers": {
-    "sonnet": { "models": ["openai/gpt-5.4", "anthropic/claude-sonnet-4-6"] },
-    "opus": { "models": ["openai/gpt-5.4", "anthropic/claude-opus-4-6"] }
+    "sonnet": { "models": ["openai/gpt-5.5", "anthropic/claude-sonnet-4-6"] },
+    "opus": { "models": ["openai/gpt-5.5", "anthropic/claude-opus-4-6"] }
   }
 }
 ```


### PR DESCRIPTION
## Summary
- Omit env-derived OpenCode variants for GPT-5.5 worker dispatch at sonnet/pro tiers so standard workers send no explicit thinking override.
- Keep configured variants for opus/thinking tiers, pulse runs, explicit CLI --variant, and non-GPT-5.5 models.
- Add regression coverage and fix the stale headless contract test marker from V6 to V7.

## Verification
- shellcheck .agents/scripts/headless-runtime-model.sh .agents/scripts/headless-runtime-helper.sh .agents/scripts/tests/test-headless-runtime-variant.sh .agents/scripts/tests/test-headless-runtime-helper.sh
- bash .agents/scripts/tests/test-headless-runtime-variant.sh
- bash .agents/scripts/tests/test-headless-runtime-helper.sh
- bash .agents/scripts/tests/test-opus-47-cascade.sh

Resolves #22026

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.29 plugin for [OpenCode](https://opencode.ai) v1.14.30 with gpt-5.5 spent 33m on this as a headless worker. Overall, 12m since this issue was created.
