### PR TITLE
t3249: guard atomic swap mv ops against set -e suppression in agent-deploy

### DIFF
--- a/.agents/scripts/tests/test-agent-deploy-staging-invariant.sh
+++ b/.agents/scripts/tests/test-agent-deploy-staging-invariant.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression test for GH#22014: _atomic_stage_and_deploy_agents must not
+# return 0 with $target_dir absent when a mv in the atomic swap fails.
+#
+# Root cause: the function is called via `|| return 1` which disables set -e
+# inside the function body. Without explicit error checks on the mv commands,
+# a failed mv falls through, the backup is deleted, and the function returns 0
+# — leaving the deployed agents directory absent while setup reports success.
+#
+# Tests exercise the four invariants:
+#   1. Happy path: swap succeeds, target_dir exists and contains scripts/
+#   2. mv-to-old fails: function returns 1, live target_dir preserved
+#   3. mv-staging-to-live fails: function returns 1, rollback restores target
+#   4. deploy_aidevops_agents postcondition: returns 1 when scripts/ missing
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+AGENT_DEPLOY="${SCRIPT_DIR}/../../../setup-modules/agent-deploy.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_DIR=""
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+# Stub print_* so sourced code does not produce noise in test output.
+print_info() { return 0; }
+print_warning() { return 0; }
+print_success() { return 0; }
+print_error() { return 0; }
+
+setup() {
+	TEST_DIR=$(mktemp -d)
+	trap teardown EXIT
+	return 0
+}
+
+teardown() {
+	if [[ -n "$TEST_DIR" && -d "$TEST_DIR" ]]; then
+		rm -rf "$TEST_DIR"
+	fi
+	return 0
+}
+
+# Build a minimal source dir with a scripts/ subdir so postcondition checks pass.
+_make_source_dir() {
+	local dir="$1"
+	mkdir -p "$dir/scripts"
+	printf 'test content\n' >"$dir/scripts/hello.sh"
+	return 0
+}
+
+# Build a minimal live target dir.
+_make_live_target() {
+	local dir="$1"
+	mkdir -p "$dir/scripts"
+	printf 'old content\n' >"$dir/scripts/old.sh"
+	return 0
+}
+
+# ─── source the module under test ───────────────────────────────────────────
+
+# shellcheck source=/dev/null
+source "$AGENT_DEPLOY"
+
+# ─── tests ──────────────────────────────────────────────────────────────────
+
+# Test 1: happy path — swap succeeds, target contains scripts/
+test_happy_path_target_exists_with_scripts() {
+	local src="${TEST_DIR}/src1"
+	local tgt="${TEST_DIR}/tgt1"
+	_make_source_dir "$src"
+
+	local rc=0
+	_atomic_stage_and_deploy_agents "$src" "$tgt" || rc=$?
+
+	if [[ "$rc" -ne 0 ]]; then
+		print_result "happy path: function returns 0" 1 "rc=$rc"
+		return 0
+	fi
+	print_result "happy path: function returns 0" 0
+
+	if [[ -d "$tgt/scripts" ]]; then
+		print_result "happy path: target scripts/ exists after swap" 0
+	else
+		print_result "happy path: target scripts/ exists after swap" 1 "$tgt/scripts missing"
+	fi
+
+	if [[ ! -d "${tgt}.staging" && ! -d "${tgt}.old" ]]; then
+		print_result "happy path: staging and old dirs cleaned up" 0
+	else
+		print_result "happy path: staging and old dirs cleaned up" 1 \
+			"staging=$(ls -d "${tgt}.staging" 2>/dev/null || echo absent) old=$(ls -d "${tgt}.old" 2>/dev/null || echo absent)"
+	fi
+	return 0
+}
+
+# Test 2: mv target→old fails — function returns 1, live target preserved.
+# We simulate mv failure by making $target_dir.old a non-empty directory that
+# cannot be overwritten by mv (mv fails when destination already exists and is
+# a non-empty directory on most filesystems).
+test_mv_to_old_fails_preserves_live_target() {
+	local src="${TEST_DIR}/src2"
+	local tgt="${TEST_DIR}/tgt2"
+	local old_dir="${tgt}.old"
+	_make_source_dir "$src"
+	_make_live_target "$tgt"
+
+	# Pre-populate the .old dir so mv tgt → .old fails (destination occupied).
+	mkdir -p "$old_dir/blocker"
+
+	# Override mv to fail when the destination is the .old path.
+	mv() {
+		local dst="${*: -1}"
+		if [[ "$dst" == "$old_dir" ]]; then
+			return 1
+		fi
+		command mv "$@"
+		return $?
+	}
+
+	local rc=0
+	_atomic_stage_and_deploy_agents "$src" "$tgt" || rc=$?
+
+	unset -f mv
+
+	if [[ "$rc" -ne 0 ]]; then
+		print_result "mv-to-old fails: function returns non-zero" 0
+	else
+		print_result "mv-to-old fails: function returns non-zero" 1 "returned 0 (false success)"
+	fi
+
+	if [[ -d "$tgt/scripts" ]]; then
+		print_result "mv-to-old fails: live target preserved" 0
+	else
+		print_result "mv-to-old fails: live target preserved" 1 "$tgt/scripts missing (live dir was removed)"
+	fi
+	return 0
+}
+
+# Test 3: mv staging→live fails — function returns 1, rollback restores target.
+# Simulate by making $target_dir a non-removable destination (replace it with
+# a read-only dir after mv target→old succeeds) — actually simpler: override
+# mv to fail only when the source is the staging path.
+test_mv_staging_to_live_fails_rolls_back() {
+	local src="${TEST_DIR}/src3"
+	local tgt="${TEST_DIR}/tgt3"
+	local staging_dir="${tgt}.staging"
+	_make_source_dir "$src"
+	_make_live_target "$tgt"
+
+	# Override mv to fail only for the staging→live move.
+	mv() {
+		local src_arg="$1"
+		if [[ "$src_arg" == "$staging_dir" ]]; then
+			return 1
+		fi
+		command mv "$@"
+		return $?
+	}
+
+	local rc=0
+	_atomic_stage_and_deploy_agents "$src" "$tgt" || rc=$?
+
+	unset -f mv
+
+	if [[ "$rc" -ne 0 ]]; then
+		print_result "mv-staging-to-live fails: function returns non-zero" 0
+	else
+		print_result "mv-staging-to-live fails: function returns non-zero" 1 "returned 0 (false success)"
+	fi
+
+	# Rollback should have restored the live target from .old
+	if [[ -d "$tgt/scripts" ]]; then
+		print_result "mv-staging-to-live fails: rollback restores target" 0
+	else
+		print_result "mv-staging-to-live fails: rollback restores target" 1 "$tgt/scripts missing after rollback"
+	fi
+
+	# Staging should be cleaned up
+	if [[ ! -d "$staging_dir" ]]; then
+		print_result "mv-staging-to-live fails: staging cleaned up" 0
+	else
+		print_result "mv-staging-to-live fails: staging cleaned up" 1 "$staging_dir still present"
+	fi
+	return 0
+}
+
+# Test 4: deploy_aidevops_agents postcondition check — if scripts/ is absent
+# after swap (regression scenario), function returns 1.
+# We wire this up by overriding _atomic_stage_and_deploy_agents to return 0
+# without populating the target so we isolate the postcondition gate.
+test_postcondition_fails_when_scripts_absent() {
+	local src="${TEST_DIR}/src4"
+	local tgt="${TEST_DIR}/tgt4"
+	local plugins_file="${TEST_DIR}/plugins4.json"
+	printf '{"plugins":[]}\n' >"$plugins_file"
+
+	mkdir -p "$src/scripts"  # source has scripts/ but we won't copy it
+	# Set up the minimum vars deploy_aidevops_agents needs.
+	local INSTALL_DIR="$src"
+
+	# Override the inner function to simulate a silent failure: it returns 0
+	# but leaves $target_dir empty (no scripts/).
+	_atomic_stage_and_deploy_agents() {
+		local _src="$1"
+		local _tgt="$2"
+		# Create an empty target dir — deliberately omit scripts/
+		mkdir -p "$_tgt"
+		return 0
+	}
+
+	# Stub everything else _deploy_agents_post_copy and helpers call.
+	_deploy_agents_post_copy() { return 0; }
+	_warn_deployed_script_drift() { return 0; }
+	create_backup_with_rotation() { return 0; }
+	sanitize_plugin_namespace() { return 0; }
+	_restart_pulse_if_running() { return 0; }
+
+	local rc=0
+	HOME="${TEST_DIR}" INSTALL_DIR="$src" deploy_aidevops_agents || rc=$?
+
+	unset -f _atomic_stage_and_deploy_agents _deploy_agents_post_copy
+	unset -f _warn_deployed_script_drift create_backup_with_rotation
+	unset -f sanitize_plugin_namespace _restart_pulse_if_running
+
+	if [[ "$rc" -ne 0 ]]; then
+		print_result "postcondition: returns non-zero when scripts/ absent after swap" 0
+	else
+		print_result "postcondition: returns non-zero when scripts/ absent after swap" 1 \
+			"returned 0 (false success) — GH#22014 regression"
+	fi
+	return 0
+}
+
+main() {
+	setup
+
+	test_happy_path_target_exists_with_scripts
+	test_mv_to_old_fails_preserves_live_target
+	test_mv_staging_to_live_fails_rolls_back
+	test_postcondition_fails_when_scripts_absent
+
+	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -ne 0 ]]; then
+		exit 1
+	fi
+
+	return 0
+}
+
+main "$@"

--- a/setup-modules/agent-deploy.sh
+++ b/setup-modules/agent-deploy.sh
@@ -391,11 +391,34 @@ _atomic_stage_and_deploy_agents() {
 		fi
 	done
 
-	# Atomic swap: mv is atomic on the same filesystem (POSIX rename())
+	# Atomic swap: mv is atomic on the same filesystem (POSIX rename()).
+	# IMPORTANT: explicit error checks are REQUIRED here because this function
+	# is called via `|| return 1` which disables set -e inside the function
+	# body (bash set -e semantics: disabled in any function called as part of
+	# a compound list such as `fn || ...`). Without these checks, a failed mv
+	# falls through silently, the backup is deleted, and the function returns
+	# 0 with $target_dir absent — the root cause of GH#22014 where worktree
+	# setup left ~/.aidevops/agents missing while reporting [SETUP_COMPLETE].
 	if [[ -d "$target_dir" ]]; then
-		mv "$target_dir" "$old_dir"
+		if ! mv "$target_dir" "$old_dir"; then
+			print_error "Failed to move live agents to backup ($old_dir) — agents directory preserved"
+			rm -rf "$staging_dir"
+			return 1
+		fi
 	fi
-	mv "$staging_dir" "$target_dir"
+	if ! mv "$staging_dir" "$target_dir"; then
+		print_error "Failed to move staging to live agents directory — attempting rollback"
+		# Restore the previous agents dir from backup so the system stays functional.
+		if [[ -d "$old_dir" ]]; then
+			if mv "$old_dir" "$target_dir"; then
+				print_info "Rollback successful — previous agents directory restored"
+			else
+				print_error "Rollback failed — agents directory is missing! Previous state preserved in $old_dir"
+			fi
+		fi
+		rm -rf "$staging_dir"
+		return 1
+	fi
 	rm -rf "$old_dir"
 	return 0
 }
@@ -589,6 +612,16 @@ deploy_aidevops_agents() {
 		_atomic_stage_and_deploy_agents "$source_dir" "$target_dir" "${plugin_namespaces[@]}" || return 1
 	else
 		_atomic_stage_and_deploy_agents "$source_dir" "$target_dir" || return 1
+	fi
+
+	# Postcondition: verify the swap actually produced a functional agents dir.
+	# _atomic_stage_and_deploy_agents returns 0 on success, but a belt-and-
+	# suspenders check here catches any future regression where the function
+	# might return early without correctly populating $target_dir (GH#22014).
+	if [[ ! -d "$target_dir/scripts" ]]; then
+		print_error "Deploy verification failed: $target_dir/scripts missing after swap"
+		print_error "The agents directory was not correctly deployed — setup cannot continue"
+		return 1
 	fi
 
 	print_success "Deployed agents to $target_dir"


### PR DESCRIPTION
## Summary

When `_atomic_stage_and_deploy_agents` is called via `|| return 1`, bash disables `set -e` inside the function body. The atomic swap section lacked explicit error checks on its `mv` commands. A failed `mv staging→live` would fall through silently: the live agents backup was deleted (`rm -rf $old_dir`) and the function returned 0 — leaving `~/.aidevops/agents` absent while setup reported `[SETUP_COMPLETE]`.

Observed in issue #21989: `setup.sh --non-interactive` from a linked worktree logged `rm` failures on `~/.aidevops/agents.staging`, then reported agents missing and failed to copy VERSION, while still reaching SETUP_COMPLETE.

## Changes

**`setup-modules/agent-deploy.sh`**

- `_atomic_stage_and_deploy_agents`: replaced bare `mv` calls in the swap section with explicit `if ! mv` guards:
  - `mv live→.old` fails → clean up staging, return 1 (live agents preserved)
  - `mv staging→live` fails → attempt rollback from `.old`, clean up staging, return 1
- `deploy_aidevops_agents`: added postcondition check after the swap — verifies `$target_dir/scripts` exists; returns 1 if missing (belt-and-suspenders guard against future regressions)

**`NEW: .agents/scripts/tests/test-agent-deploy-staging-invariant.sh`**

9-case regression test covering:
1. Happy path: swap succeeds, target contains `scripts/`, temps cleaned up
2. `mv live→.old` fails: function returns non-zero, live target preserved
3. `mv staging→live` fails: function returns non-zero, rollback restores target, staging cleaned up
4. Postcondition gate: `deploy_aidevops_agents` returns non-zero when `scripts/` absent after swap

## Verification

```
bash .agents/scripts/tests/test-agent-deploy-staging-invariant.sh
# → Ran 9 tests, 0 failed

shellcheck setup-modules/agent-deploy.sh
# → (no output — zero violations)
```

Resolves #22014

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.29 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-sonnet-4-6 spent 8m and 23,518 tokens on this as a headless worker.