### PR TITLE
GH#22003: fix OpenCode signature session attribution

### DIFF
--- a/.agents/plugins/opencode-aidevops/shell-env.mjs
+++ b/.agents/plugins/opencode-aidevops/shell-env.mjs
@@ -23,6 +23,30 @@ function readIfExists(filepath) {
 }
 
 /**
+ * Extract the current OpenCode session ID from hook input variants.
+ * @param {object} input
+ * @returns {string}
+ */
+function getSessionId(input) {
+  return input?.session?.id || input?.sessionID || input?.session_id || input?.id || "";
+}
+
+/**
+ * Extract the current model ID from hook input variants.
+ * @param {object} input
+ * @returns {string}
+ */
+function getModelId(input) {
+  const provider = input?.model?.providerID || "";
+  const model = input?.model?.modelID || input?.modelID || input?.model || "";
+
+  if (provider && model && typeof model === "string" && !model.includes("/")) {
+    return `${provider}/${model}`;
+  }
+  return typeof model === "string" ? model : "";
+}
+
+/**
  * Create the shell environment hook.
  * @param {object} deps - { agentsDir, scriptsDir, workspaceDir }
  * @returns {Function} Shell env hook function
@@ -32,10 +56,10 @@ export function createShellEnvHook(deps) {
 
   /**
    * Inject aidevops environment variables into shell sessions.
-   * @param {object} _input - { cwd }
+   * @param {object} input - { cwd, session/sessionID, model }
    * @param {object} output - { env } (mutable)
    */
-  return async function shellEnvHook(_input, output) {
+  return async function shellEnvHook(input, output) {
     // Ensure aidevops scripts are on PATH
     if (existsSync(scriptsDir)) {
       const currentPath = output.env.PATH || process.env.PATH || "";
@@ -52,6 +76,20 @@ export function createShellEnvHook(deps) {
     const version = readIfExists(join(agentsDir, "..", "version"));
     if (version) {
       output.env.AIDEVOPS_VERSION = version;
+    }
+
+    // Signature helpers need the current OpenCode session, not a session guessed
+    // from the long-lived app process start time (GH#22003). OpenCode hook input
+    // has changed shape across releases, so accept the known variants and keep
+    // this best-effort: absence should not block shell startup.
+    const sessionId = getSessionId(input);
+    if (sessionId && !output.env.OPENCODE_SESSION_ID) {
+      output.env.OPENCODE_SESSION_ID = sessionId;
+    }
+
+    const modelId = getModelId(input);
+    if (modelId && !output.env.AIDEVOPS_SIG_MODEL) {
+      output.env.AIDEVOPS_SIG_MODEL = modelId;
     }
 
     // OTEL env passthrough (t2177) — propagate OpenTelemetry config so

--- a/.agents/scripts/gh-signature-helper-session.sh
+++ b/.agents/scripts/gh-signature-helper-session.sh
@@ -151,13 +151,50 @@ _pid_start_epoch() {
 	return 0
 }
 
+_sql_quote() {
+	local value="$1"
+	value=${value//\'/\'\'}
+	printf "'%s'" "$value"
+	return 0
+}
+
+_find_explicit_session_id() {
+	local db_path="$1"
+	local explicit_session_id="${AIDEVOPS_SIG_SESSION_ID:-${OPENCODE_SESSION_ID:-}}"
+
+	if [[ -z "$explicit_session_id" ]]; then
+		echo ""
+		return 0
+	fi
+
+	local quoted_id
+	quoted_id=$(_sql_quote "$explicit_session_id")
+	sqlite3 "$db_path" "
+		SELECT id FROM session
+		WHERE id=${quoted_id}
+		LIMIT 1
+	" 2>/dev/null || echo ""
+	return 0
+}
+
+_allow_pid_session_match() {
+	if [[ "${AIDEVOPS_SIG_ALLOW_PID_SESSION_MATCH:-}" == "1" ]]; then
+		return 0
+	fi
+
+	# OpenCode processes can outlive many chat sessions. PID-start matching is
+	# available only as an explicit compatibility escape hatch, never by default.
+	return 1
+}
+
 # =============================================================================
 # _find_session_id -- shared session identification for all detectors
 # =============================================================================
 # Finds the current OpenCode session ID using multiple heuristics:
-# 1. OPENCODE_PID / PPID chain -> match session by process start time
+# 1. Explicit session env (AIDEVOPS_SIG_SESSION_ID / OPENCODE_SESSION_ID)
 # 2. Most recently created session in this directory
 # 3. Most recently created session globally (within 10 minutes)
+# 4. Optional PID-start fallback for explicit opt-in compatibility contexts
 #
 # Delegates directory resolution to _build_session_dir_list,
 # PID detection to _find_opencode_pid, and epoch conversion to _pid_start_epoch.
@@ -170,21 +207,8 @@ _find_session_id() {
 
 	local session_id=""
 
-	# Strategy 1: match by process start time (most precise)
-	local target_pid
-	target_pid=$(_find_opencode_pid)
-	if [[ -n "$target_pid" ]] && [[ -n "$dir_list" ]]; then
-		local epoch
-		epoch=$(_pid_start_epoch "$target_pid")
-		if [[ -n "$epoch" ]]; then
-			local pid_start_ms=$((epoch * 1000))
-			session_id=$(sqlite3 "$db_path" "
-				SELECT id FROM session
-				WHERE directory IN (${dir_list})
-				ORDER BY ABS(time_created - ${pid_start_ms}) ASC LIMIT 1
-			" 2>/dev/null || echo "")
-		fi
-	fi
+	# Strategy 1: explicit current session metadata from the runtime/plugin.
+	session_id=$(_find_explicit_session_id "$db_path")
 
 	# Strategy 2: most recently created session matching directory
 	# (not updated -- avoids picking long-running supervisor sessions)
@@ -207,6 +231,26 @@ _find_session_id() {
 			WHERE time_created > (strftime('%s','now') - 600) * 1000
 			ORDER BY time_created DESC LIMIT 1
 		" 2>/dev/null || echo "")
+	fi
+
+	# Strategy 4: legacy PID-start fallback, demoted because OpenCode's
+	# interactive app process can outlive many sessions (GH#22003).
+	local target_pid
+	target_pid=""
+	if [[ -z "$session_id" ]] && _allow_pid_session_match && [[ -n "$dir_list" ]]; then
+		target_pid=$(_find_opencode_pid)
+	fi
+	if [[ -z "$session_id" ]] && [[ -n "$target_pid" ]] && [[ -n "$dir_list" ]]; then
+		local epoch
+		epoch=$(_pid_start_epoch "$target_pid")
+		if [[ -n "$epoch" ]]; then
+			local pid_start_ms=$((epoch * 1000))
+			session_id=$(sqlite3 "$db_path" "
+				SELECT id FROM session
+				WHERE directory IN (${dir_list})
+				ORDER BY ABS(time_created - ${pid_start_ms}) ASC LIMIT 1
+			" 2>/dev/null || echo "")
+		fi
 	fi
 
 	echo "$session_id"

--- a/.agents/scripts/tests/test-gh-signature-helper.sh
+++ b/.agents/scripts/tests/test-gh-signature-helper.sh
@@ -366,7 +366,7 @@ VALUES ('msg_c1','ses_child_test',${child_created_ms_16},${child_created_ms_16},
 "
 
 	# Test 16a: record-child without --tokens (auto-detect from DB)
-	HOME="$tmp_home_16" "$HELPER" record-child --child ses_child_test --parent ses_parent_test
+	XDG_DATA_HOME="${tmp_home_16}/.local/share" HOME="$tmp_home_16" "$HELPER" record-child --child ses_child_test --parent ses_parent_test
 	ledger_file="${tmp_home_16}/.aidevops/.agent-workspace/tmp/ses_parent_test.children.tsv"
 	if [[ -r "$ledger_file" ]]; then
 		ledger_content=$(cat "$ledger_file")
@@ -378,17 +378,17 @@ VALUES ('msg_c1','ses_child_test',${child_created_ms_16},${child_created_ms_16},
 	fi
 
 	# Test 16b: idempotent — recording same child again is a no-op
-	HOME="$tmp_home_16" "$HELPER" record-child --child ses_child_test --parent ses_parent_test
+	XDG_DATA_HOME="${tmp_home_16}/.local/share" HOME="$tmp_home_16" "$HELPER" record-child --child ses_child_test --parent ses_parent_test
 	line_count=$(wc -l <"$ledger_file" | tr -d ' ')
 	assert_eq "idempotent record-child" "1" "$line_count"
 
 	# Test 16c: generate includes child tokens (parent 500 + child 200 = 700)
-	result=$(HOME="$tmp_home_16" "$HELPER" generate --cli "OpenCode" --model "m")
+	result=$(OPENCODE_SESSION_ID="ses_parent_test" XDG_DATA_HOME="${tmp_home_16}/.local/share" HOME="$tmp_home_16" "$HELPER" generate --cli "OpenCode" --model "m")
 	assert_contains "aggregated tokens (parent + child)" "700 tokens" "$result"
 
 	# Test 16d: record-child with explicit --tokens (non-OpenCode runtime path)
-	HOME="$tmp_home_16" "$HELPER" record-child --child ses_other_child --parent ses_parent_test --tokens 300
-	result=$(HOME="$tmp_home_16" "$HELPER" generate --cli "OpenCode" --model "m")
+	XDG_DATA_HOME="${tmp_home_16}/.local/share" HOME="$tmp_home_16" "$HELPER" record-child --child ses_other_child --parent ses_parent_test --tokens 300
+	result=$(OPENCODE_SESSION_ID="ses_parent_test" XDG_DATA_HOME="${tmp_home_16}/.local/share" HOME="$tmp_home_16" "$HELPER" generate --cli "OpenCode" --model "m")
 	assert_contains "aggregated with explicit child (500+200+300)" "1,000 tokens" "$result"
 else
 	echo "  SKIP: sqlite3 not available"
@@ -429,13 +429,56 @@ INSERT INTO message (id,session_id,time_created,time_updated,data)
 VALUES ('msg_s1','ses_solo',${session_created_ms_18},${session_created_ms_18},
   '{\"tokens\":{\"input\":800,\"output\":200,\"cache\":{\"read\":0,\"write\":0}},\"role\":\"assistant\"}');
 "
-	result=$(HOME="$tmp_home_18" "$HELPER" generate --cli "OpenCode" --model "m")
+	result=$(XDG_DATA_HOME="${tmp_home_18}/.local/share" HOME="$tmp_home_18" "$HELPER" generate --cli "OpenCode" --model "m")
 	assert_contains "solo session shows own tokens only" "1,000 tokens" "$result"
 else
 	echo "  SKIP: sqlite3 not available"
 fi
 
 rm -rf "$tmp_home_18"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Test 19: OpenCode session selection prefers current session over PID-start
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "Test 19: OpenCode session selection avoids stale PID-start match"
+tmp_home_19=$(mktemp -d 2>/dev/null || mktemp -d -t sighelper19)
+mkdir -p "${tmp_home_19}/.local/share/opencode"
+db_path_19="${tmp_home_19}/.local/share/opencode/opencode.db"
+
+now_epoch_19=$(date +%s)
+recent_session_ms_19=$(((now_epoch_19 - 60) * 1000))
+stale_pid_session_ms_19=$(((now_epoch_19 - 3600) * 1000))
+cwd_sql_19=$(pwd)
+cwd_sql_19=${cwd_sql_19//\'/\'\'}
+
+if command -v sqlite3 &>/dev/null; then
+	sqlite3 "$db_path_19" "
+CREATE TABLE session (id TEXT PRIMARY KEY, title TEXT, directory TEXT NOT NULL, time_created INTEGER NOT NULL);
+CREATE TABLE message (id TEXT PRIMARY KEY, session_id TEXT NOT NULL, time_created INTEGER NOT NULL, time_updated INTEGER NOT NULL, data TEXT NOT NULL);
+INSERT INTO session (id,title,directory,time_created) VALUES
+  ('ses_stale_pid','old opus session near app launch','${cwd_sql_19}',${stale_pid_session_ms_19}),
+  ('ses_current','current gpt session','${cwd_sql_19}',${recent_session_ms_19});
+INSERT INTO message (id,session_id,time_created,time_updated,data) VALUES
+  ('msg_stale','ses_stale_pid',${stale_pid_session_ms_19},${stale_pid_session_ms_19},
+   '{\"model\":{\"providerID\":\"anthropic\",\"modelID\":\"claude-opus-4-7\"},\"tokens\":{\"input\":10,\"output\":1,\"cache\":{\"read\":0,\"write\":0}},\"role\":\"assistant\"}'),
+  ('msg_current','ses_current',${recent_session_ms_19},${recent_session_ms_19},
+   '{\"model\":{\"providerID\":\"openai\",\"modelID\":\"gpt-5.5\"},\"tokens\":{\"input\":20,\"output\":2,\"cache\":{\"read\":0,\"write\":0}},\"role\":\"assistant\"}');
+"
+
+	result=$(env -u OPENCODE_SESSION_ID -u AIDEVOPS_SIG_SESSION_ID OPENCODE=1 OPENCODE_PID=$$ AIDEVOPS_SIG_MODEL="" XDG_DATA_HOME="${tmp_home_19}/.local/share" HOME="$tmp_home_19" "$HELPER" generate --cli "OpenCode")
+	assert_contains "recent session model wins over PID-start match" "with gpt-5.5" "$result"
+	assert_contains "recent session tokens used" "22 tokens on this" "$result"
+	assert_not_contains "stale PID session model ignored" "claude-opus-4-7" "$result"
+
+	result=$(OPENCODE=1 OPENCODE_SESSION_ID="ses_current" AIDEVOPS_SIG_MODEL="" XDG_DATA_HOME="${tmp_home_19}/.local/share" HOME="$tmp_home_19" "$HELPER" generate --cli "OpenCode")
+	assert_contains "explicit OPENCODE_SESSION_ID model used" "with gpt-5.5" "$result"
+	assert_contains "explicit OPENCODE_SESSION_ID tokens used" "22 tokens on this" "$result"
+else
+	echo "  SKIP: sqlite3 not available"
+fi
+
+rm -rf "$tmp_home_19"
 
 # ─────────────────────────────────────────────────────────────────────────────
 # Summary


### PR DESCRIPTION
## Summary

Prefer explicit/current OpenCode session metadata for signature footers and demote PID-start session matching to an opt-in fallback.

## Files Changed

.agents/plugins/opencode-aidevops/shell-env.mjs,.agents/scripts/gh-signature-helper-session.sh,.agents/scripts/tests/test-gh-signature-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-gh-signature-helper.sh; shellcheck .agents/scripts/gh-signature-helper.sh .agents/scripts/gh-signature-helper-session.sh .agents/scripts/tests/test-gh-signature-helper.sh

Resolves #22003


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.32 plugin for [OpenCode](https://opencode.ai) v1.14.30 with gpt-5.5 spent 29m and 151,849 tokens on this as a headless worker.