### PR TITLE
t3250: Fix stale maintainer-gate required check compatibility

### DIFF
--- a/.agents/scripts/tests/test-pulse-merge-phantom-pending-checks.sh
+++ b/.agents/scripts/tests/test-pulse-merge-phantom-pending-checks.sh
@@ -16,7 +16,8 @@
 # proceed.
 #
 # Scenarios tested:
-#   1. all_required_pass — all required contexts SUCCESS → return 0
+#   1. all_required_pass — all required contexts SUCCESS, including the
+#      maintainer-gate legacy status alias → return 0
 #   2. phantom_pending_only — required pass + non-required null/pending → return 0
 #   3. one_required_failing — one required FAILURE → return 1
 #   4. required_context_absent — required context not in rollup (NOT_FOUND) → return 1
@@ -35,6 +36,8 @@
 #   3. gh pr view NUM --json headRefOid               → PR HEAD SHA
 #   4. gh api repos/SLUG/commits/SHA/check-runs       → check-run states
 #   5. gh api repos/SLUG/commits/SHA/status           → legacy status contexts
+#      (t3250: includes `Maintainer Review & Assignee Gate` alias for repos
+#      whose branch protection still requires the pre-reusable workflow name)
 #
 # Mode variables:
 #   MOCK_REPO_MODE   — controls gh api repos/<slug> response
@@ -176,10 +179,12 @@ if [[ "$1" == "api" && "$*" == *"/check-runs"* ]]; then
 	local_json=""
 	case "${MOCK_ROLLUP_MODE:-all_required_pass}" in
 	all_required_pass)
-		# All three required checks pass; no non-required checks.
+		# All three required checks pass. The maintainer-gate CheckRun name is
+		# what reusable workflow callers emit; the exact legacy required context
+		# is satisfied by the /status alias below (t3250).
 		local_json='{"check_runs":[
 			{"name":"review-bot-gate","conclusion":"success","status":"completed"},
-			{"name":"Maintainer Review & Assignee Gate","conclusion":"success","status":"completed"},
+			{"name":"gate / Maintainer Review & Assignee Gate","conclusion":"success","status":"completed"},
 			{"name":"Complexity Analysis","conclusion":"success","status":"completed"}
 		]}'
 		;;
@@ -187,7 +192,7 @@ if [[ "$1" == "api" && "$*" == *"/check-runs"* ]]; then
 		# Required checks pass; non-required checks report null/pending.
 		local_json='{"check_runs":[
 			{"name":"review-bot-gate","conclusion":"success","status":"completed"},
-			{"name":"Maintainer Review & Assignee Gate","conclusion":"success","status":"completed"},
+			{"name":"gate / Maintainer Review & Assignee Gate","conclusion":"success","status":"completed"},
 			{"name":"Complexity Analysis","conclusion":"success","status":"completed"},
 			{"name":"coderabbit-review","conclusion":null,"status":"queued"},
 			{"name":"qlty-check","conclusion":null,"status":"queued"},
@@ -199,14 +204,14 @@ if [[ "$1" == "api" && "$*" == *"/check-runs"* ]]; then
 		# review-bot-gate is FAILURE; other required checks pass.
 		local_json='{"check_runs":[
 			{"name":"review-bot-gate","conclusion":"failure","status":"completed"},
-			{"name":"Maintainer Review & Assignee Gate","conclusion":"success","status":"completed"},
+			{"name":"gate / Maintainer Review & Assignee Gate","conclusion":"success","status":"completed"},
 			{"name":"Complexity Analysis","conclusion":"success","status":"completed"}
 		]}'
 		;;
 	required_absent)
 		# review-bot-gate is missing from check-runs; other required checks pass.
 		local_json='{"check_runs":[
-			{"name":"Maintainer Review & Assignee Gate","conclusion":"success","status":"completed"},
+			{"name":"gate / Maintainer Review & Assignee Gate","conclusion":"success","status":"completed"},
 			{"name":"Complexity Analysis","conclusion":"success","status":"completed"}
 		]}'
 		;;
@@ -220,11 +225,14 @@ if [[ "$1" == "api" && "$*" == *"/check-runs"* ]]; then
 fi
 
 # Match: gh api repos/SLUG/commits/SHA/status (GH#21799)
-# Mock data drives ALL checks through /check-runs above; /status returns empty.
-# (Helper merges both endpoints — empty /status is the realistic case for
-# GitHub-Actions-only repos like aidevops.)
+# t3250: maintainer-gate-reusable.yml posts both the stable `maintainer-gate`
+# commit status and a legacy `Maintainer Review & Assignee Gate` alias so repos
+# with stale branch protection still see an exact required context.
 if [[ "$1" == "api" && "$*" == *"/commits/"* && "$*" == *"/status"* ]]; then
-	local_json='{"statuses":[]}'
+	local_json='{"statuses":[
+		{"context":"maintainer-gate","state":"success"},
+		{"context":"Maintainer Review & Assignee Gate","state":"success"}
+	]}'
 	apply_jq "$local_json" "$@"
 	exit 0
 fi
@@ -243,7 +251,8 @@ teardown_test_env() {
 	return 0
 }
 
-# Extract _check_required_checks_passing from pulse-merge.sh and eval it.
+# Extract _required_contexts_for_default_branch and _check_required_checks_passing
+# from pulse-merge-process.sh and eval them.
 define_function_under_test() {
 	# Source the REST check-runs helper so the extracted function can call
 	# `gh_pr_check_runs_rest` (GH#21799 migration). Sub-library only — avoids
@@ -256,6 +265,18 @@ define_function_under_test() {
 	fi
 	# shellcheck disable=SC1090  # dynamic source from sibling lib
 	source "$checks_lib"
+
+	local helper_src
+	helper_src=$(awk '
+		/^_required_contexts_for_default_branch\(\) \{/,/^}$/ { print }
+	' "$MERGE_SCRIPT")
+	if [[ -z "$helper_src" ]]; then
+		printf 'ERROR: could not extract _required_contexts_for_default_branch from %s\n' \
+			"$MERGE_SCRIPT" >&2
+		return 1
+	fi
+	# shellcheck disable=SC1090  # dynamic source from extracted helper
+	eval "$helper_src"
 
 	local fn_src
 	fn_src=$(awk '
@@ -308,7 +329,7 @@ test_all_required_pass() {
 	export MOCK_REPO_MODE="ok"
 	export MOCK_BP_MODE="three_required"
 	export MOCK_ROLLUP_MODE="all_required_pass"
-	assert_returns 0 "all required checks SUCCESS → allowed"
+	assert_returns 0 "all required checks SUCCESS via check-runs/status alias → allowed"
 	assert_log_contains "all required contexts passing" \
 		"all_required_pass: pass message logged"
 	assert_log_contains "t2922" "all_required_pass: log tagged t2922"

--- a/.github/workflows/maintainer-gate-reusable.yml
+++ b/.github/workflows/maintainer-gate-reusable.yml
@@ -124,6 +124,42 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MAINTAINER_GATE_DEBUG: ${{ vars.MAINTAINER_GATE_DEBUG || 'false' }}
         run: |
+          readonly MAINTAINER_GATE_CONTEXT="maintainer-gate"
+          readonly MAINTAINER_GATE_LEGACY_CONTEXT="Maintainer Review & Assignee Gate"
+
+          post_maintainer_gate_status_once() {
+            local state="$1"
+            local description="$2"
+            local context=""
+
+            # t3250: Some repos still require the pre-reusable workflow job name
+            # as a branch-protection context. The reusable caller reports that
+            # CheckRun as "gate / Maintainer Review & Assignee Gate", so post a
+            # commit-status alias with the legacy context while repos migrate to
+            # the stable "maintainer-gate" status context documented above.
+            for context in "$MAINTAINER_GATE_CONTEXT" "$MAINTAINER_GATE_LEGACY_CONTEXT"; do
+              gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
+                --method POST \
+                -f state="$state" \
+                -f context="$context" \
+                -f description="$description" || return 1
+            done
+            return 0
+          }
+
+          post_maintainer_gate_status_with_retry() {
+            local state="$1"
+            local description="$2"
+
+            post_maintainer_gate_status_once "$state" "$description" 2>/dev/null \
+              || { sleep 5 && post_maintainer_gate_status_once "$state" "$description"; } \
+              || {
+                echo "::error::Failed to post maintainer-gate commit status after retry"
+                exit 1
+              }
+            return 0
+          }
+
           # ---------------------------------------------------------------
           # Check 0: Does the PR itself carry needs-maintainer-review?
           # GH#17671 post-mortem: external PRs without linked issues bypassed
@@ -148,19 +184,9 @@ jobs:
               echo "blocked=true" >> "$GITHUB_OUTPUT"
               printf 'PR #%s has \x60needs-maintainer-review\x60 label — a maintainer must cryptographically approve it before merge.\n' "$PR_NUMBER" > /tmp/gate-reasons.txt
               echo "has_reasons=true" >> "$GITHUB_OUTPUT"
-              gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
-                --method POST \
-                -f state=failure \
-                -f context="maintainer-gate" \
-                -f description="PR has needs-maintainer-review — requires cryptographic approval" \
-                2>/dev/null || { sleep 5 && gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
-                --method POST \
-                -f state=failure \
-                -f context="maintainer-gate" \
-                -f description="PR has needs-maintainer-review — requires cryptographic approval"; } || {
-                echo "::error::Failed to post maintainer-gate commit status after retry"
-                exit 1
-              }
+              post_maintainer_gate_status_with_retry \
+                failure \
+                "PR has needs-maintainer-review — requires cryptographic approval"
               exit 0
             fi
           fi
@@ -202,19 +228,9 @@ jobs:
             # Post failure commit status so branch protection sees the result
             # Fail-closed: if status post fails after retry, fail the job to avoid
             # leaving the PR without a maintainer-gate status (GH#14277)
-            gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
-              --method POST \
-              -f state=failure \
-              -f context="maintainer-gate" \
-              -f description="Title-based issue lookup failed — cannot verify linked issues" \
-              2>/dev/null || { sleep 5 && gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
-              --method POST \
-              -f state=failure \
-              -f context="maintainer-gate" \
-              -f description="Title-based issue lookup failed — cannot verify linked issues"; } || {
-              echo "::error::Failed to post maintainer-gate commit status after retry"
-              exit 1
-            }
+            post_maintainer_gate_status_with_retry \
+              failure \
+              "Title-based issue lookup failed — cannot verify linked issues"
             exit 0
           fi
 
@@ -246,11 +262,9 @@ jobs:
             if [[ "$PR_AUTHOR_ASSOCIATION" == "OWNER" ]] || \
                [[ "$PR_AUTHOR_ASSOCIATION" == "MEMBER" ]]; then
               echo "PASS: PR #$PR_NUMBER has origin:interactive and author is maintainer ($PR_AUTHOR_ASSOCIATION) — implied approval (t2030: applies to linked-issue PRs too)"
-              gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
-                --method POST \
-                -f state=success \
-                -f context="maintainer-gate" \
-                -f description="origin:interactive by maintainer ($PR_AUTHOR_ASSOCIATION) — implied approval" \
+              post_maintainer_gate_status_once \
+                success \
+                "origin:interactive by maintainer ($PR_AUTHOR_ASSOCIATION) — implied approval" \
                 2>/dev/null || true
               exit 0
             else
@@ -264,19 +278,9 @@ jobs:
             echo "reason=" >> "$GITHUB_OUTPUT"
             # Post success commit status so branch protection sees the result
             # Fail-closed: if status post fails after retry, fail the job (GH#14277)
-            gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
-              --method POST \
-              -f state=success \
-              -f context="maintainer-gate" \
-              -f description="No linked issues to check" \
-              2>/dev/null || { sleep 5 && gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
-              --method POST \
-              -f state=success \
-              -f context="maintainer-gate" \
-              -f description="No linked issues to check"; } || {
-              echo "::error::Failed to post maintainer-gate commit status after retry"
-              exit 1
-            }
+            post_maintainer_gate_status_with_retry \
+              success \
+              "No linked issues to check"
             exit 0
           fi
 
@@ -430,33 +434,11 @@ jobs:
           # Fail-closed: if status post fails after retry, fail the job (GH#14277)
           if [[ "$BLOCKED" == "true" ]]; then
             DESCRIPTION=$(head -c 140 /tmp/gate-reasons.txt | tr '\n' ' ')
-            gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
-              --method POST \
-              -f state=failure \
-              -f context="maintainer-gate" \
-              -f description="${DESCRIPTION}" \
-              2>/dev/null || { sleep 5 && gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
-              --method POST \
-              -f state=failure \
-              -f context="maintainer-gate" \
-              -f description="${DESCRIPTION}"; } || {
-              echo "::error::Failed to post maintainer-gate commit status after retry"
-              exit 1
-            }
+            post_maintainer_gate_status_with_retry failure "${DESCRIPTION}"
           else
-            gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
-              --method POST \
-              -f state=success \
-              -f context="maintainer-gate" \
-              -f description="All linked issues pass gate checks" \
-              2>/dev/null || { sleep 5 && gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
-              --method POST \
-              -f state=success \
-              -f context="maintainer-gate" \
-              -f description="All linked issues pass gate checks"; } || {
-              echo "::error::Failed to post maintainer-gate commit status after retry"
-              exit 1
-            }
+            post_maintainer_gate_status_with_retry \
+              success \
+              "All linked issues pass gate checks"
           fi
 
       - name: Post or update gate comment
@@ -596,6 +578,24 @@ jobs:
           REPO_OWNER: ${{ github.repository_owner }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          readonly MAINTAINER_GATE_CONTEXT="maintainer-gate"
+          readonly MAINTAINER_GATE_LEGACY_CONTEXT="Maintainer Review & Assignee Gate"
+
+          post_maintainer_gate_status_once() {
+            local state="$1"
+            local description="$2"
+            local context=""
+
+            for context in "$MAINTAINER_GATE_CONTEXT" "$MAINTAINER_GATE_LEGACY_CONTEXT"; do
+              gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
+                --method POST \
+                -f state="$state" \
+                -f context="$context" \
+                -f description="$description" || return 1
+            done
+            return 0
+          }
+
           echo "Issue #$ISSUE_NUMBER updated (labels/assignee) — checking for linked PRs"
 
           # Find open PRs that reference this issue via body closing keywords
@@ -661,11 +661,9 @@ jobs:
               if [[ "$PR_AUTHOR_ASSOC_J3" == "OWNER" ]] || \
                  [[ "$PR_AUTHOR_ASSOC_J3" == "MEMBER" ]]; then
                 echo "SKIP rerun: PR #$PR_NUM has origin:interactive and author is maintainer ($PR_AUTHOR_ASSOC_J3) — posting success, no Job 1 rerun needed"
-                gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
-                  --method POST \
-                  -f state=success \
-                  -f context="maintainer-gate" \
-                  -f description="origin:interactive by maintainer — implied approval (Job 3 exemption)" \
+                post_maintainer_gate_status_once \
+                  success \
+                  "origin:interactive by maintainer — implied approval (Job 3 exemption)" \
                   2>/dev/null || true
                 continue
               fi
@@ -702,11 +700,9 @@ jobs:
                 fi
                 if [[ "$ISSUE_TRUSTED_J3" == "true" ]]; then
                   echo "SKIP rerun: PR #$PR_NUM has origin:worker, trusted issue author ($ISSUE_AUTHOR_J3), no non-maintainer comments — posting success, no Job 1 rerun needed (t2451)"
-                  gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
-                    --method POST \
-                    -f state=success \
-                    -f context="maintainer-gate" \
-                    -f description="origin:worker on trusted issue — implied approval (Job 3 exemption, t2451)" \
+                  post_maintainer_gate_status_once \
+                    success \
+                    "origin:worker on trusted issue — implied approval (Job 3 exemption, t2451)" \
                     2>/dev/null || true
                   continue
                 fi
@@ -715,11 +711,9 @@ jobs:
 
             # Post pending status while Job 1 re-evaluates
             # t2037: Job 3 is pure plumbing — gate evaluation is Job 1's sole responsibility
-            gh api "repos/${REPO}/statuses/${HEAD_SHA}" \
-              --method POST \
-              -f state=pending \
-              -f context="maintainer-gate" \
-              -f description="Refreshing via Job 1 rerun..." \
+            post_maintainer_gate_status_once \
+              pending \
+              "Refreshing via Job 1 rerun..." \
               2>/dev/null || true
 
             # -----------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Post both the stable `maintainer-gate` status and legacy `Maintainer Review & Assignee Gate` alias from the reusable maintainer gate.
- Update the required-check regression test to model reusable workflow check names plus the commit-status alias.

## Verification
- `python3` YAML/alias wiring assertion
- `bash .agents/scripts/tests/test-pulse-merge-phantom-pending-checks.sh`
- `shellcheck .agents/scripts/tests/test-pulse-merge-phantom-pending-checks.sh`
- `git diff --check`
- `bash .agents/scripts/workflow-cascade-lint.sh --dry-run .github/workflows/maintainer-gate-reusable.yml`

Resolves #22016

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.32 plugin for [OpenCode](https://opencode.ai) v1.14.30 with gpt-5.5 spent 5h 44m and 155,697 tokens on this with the user in an interactive session.
