### PR TITLE
t3241: Fix memory dedup dry-run count channel

### DIFF
--- a/.agents/scripts/memory-audit-pulse.sh
+++ b/.agents/scripts/memory-audit-pulse.sh
@@ -90,18 +90,31 @@ phase_dedup() {
 	[[ "$quiet" != "true" ]] && log_info "Phase 1: Deduplication..."
 
 	local output
+	local dedup_status=0
 	if [[ "$dry_run" == "true" ]]; then
-		output=$("${SCRIPT_DIR}/memory-helper.sh" dedup --dry-run 2>&1) || true
+		output=$("${SCRIPT_DIR}/memory-helper.sh" dedup --dry-run 2>&1) || dedup_status=$?
 	else
-		output=$("${SCRIPT_DIR}/memory-helper.sh" dedup 2>&1) || true
+		output=$("${SCRIPT_DIR}/memory-helper.sh" dedup 2>&1) || dedup_status=$?
+	fi
+
+	if [[ "$dedup_status" -ne 0 ]]; then
+		log_error "Dedup phase failed (exit $dedup_status)"
+		printf '%s\n' "$output" >&2
+		return 1
 	fi
 
 	# Extract count from output
 	local removed=0
-	if echo "$output" | grep -q "Removed"; then
-		removed=$(echo "$output" | grep -oE 'Removed [0-9]+' | grep -oE '[0-9]+' || echo "0")
-	elif echo "$output" | grep -q "Would remove"; then
-		removed=$(echo "$output" | grep -oE 'Would remove [0-9]+' | grep -oE '[0-9]+' || echo "0")
+	if [[ "$output" =~ Removed[[:space:]]+([0-9]+)[[:space:]]+duplicates ]]; then
+		removed="${BASH_REMATCH[1]}"
+	elif [[ "$output" =~ Would[[:space:]]+remove[[:space:]]+([0-9]+)[[:space:]]+duplicates ]]; then
+		removed="${BASH_REMATCH[1]}"
+	elif [[ "$output" =~ No[[:space:]]+duplicates[[:space:]]+found ]]; then
+		removed=0
+	else
+		log_error "Unable to parse dedup count from memory-helper.sh output"
+		printf '%s\n' "$output" >&2
+		return 1
 	fi
 
 	[[ "$quiet" != "true" ]] && {

--- a/.agents/scripts/memory/maintenance-dedup.sh
+++ b/.agents/scripts/memory/maintenance-dedup.sh
@@ -93,7 +93,7 @@ EOF
 			local escaped_remove="${mem_id//"'"/"''"}"
 
 			if [[ "$dry_run" == true ]]; then
-				log_info "[DRY RUN] Would remove $mem_id (duplicate of $keep_id)"
+				log_info "[DRY RUN] Would remove $mem_id (duplicate of $keep_id)" >&2
 			else
 				_dedup_merge_tags "$escaped_keep" "$escaped_remove"
 				# Transfer access history (keep higher count)
@@ -153,6 +153,29 @@ EOF
 		local ids_arr
 		IFS=',' read -ra ids_arr <<<"$id_list"
 
+		# Exact duplicates are handled in phase 1. During dry-run they are not
+		# physically deleted, so collapse each exact-content set to one
+		# representative before counting near-duplicate removals. This mirrors the
+		# database state phase 2 sees during a real run and avoids double-counting.
+		if [[ "$dry_run" == true ]]; then
+			local representative_ids=()
+			local seen_contents=$'\n'
+			for nid in "${ids_arr[@]}"; do
+				[[ -z "$nid" ]] && continue
+				local nid_esc="${nid//"'"/"''"}"
+				local nid_content
+				nid_content=$(db "$MEMORY_DB" "SELECT content FROM learnings WHERE id = '$nid_esc';" 2>/dev/null || true)
+				[[ -z "$nid_content" ]] && continue
+				if [[ "$seen_contents" == *$'\n'"$nid_content"$'\n'* ]]; then
+					continue
+				fi
+				seen_contents+="${nid_content}"$'\n'
+				representative_ids+=("$nid")
+			done
+			ids_arr=("${representative_ids[@]}")
+			[[ "${#ids_arr[@]}" -le 1 ]] && continue
+		fi
+
 		# Find the oldest entry to keep
 		local oldest_id="" oldest_date="9999"
 		for nid in "${ids_arr[@]}"; do
@@ -182,7 +205,7 @@ EOF
 			if [[ "$dry_run" == true ]]; then
 				local preview
 				preview=$(db "$MEMORY_DB" "SELECT substr(content, 1, 50) FROM learnings WHERE id = '$nid_esc';")
-				log_info "[DRY RUN] Would remove near-dup $nid (keep $oldest_id): $preview..."
+				log_info "[DRY RUN] Would remove near-dup $nid (keep $oldest_id): $preview..." >&2
 			else
 				_dedup_merge_tags "$oldest_esc" "$nid_esc"
 				db_cleanup "$MEMORY_DB" "UPDATE learning_relations SET supersedes_id = '$oldest_esc' WHERE supersedes_id = '$nid_esc';"
@@ -209,7 +232,7 @@ _dedup_semantic_phase() {
 	local threshold_judge="$2"
 	local semantic_removed=0
 
-	log_info "Scanning for semantic duplicates (AI-judged)..."
+	log_info "Scanning for semantic duplicates (AI-judged)..." >&2
 
 	local types
 	types=$(db "$MEMORY_DB" "SELECT DISTINCT type FROM learnings;")
@@ -243,7 +266,7 @@ _dedup_semantic_phase() {
 					local remove_esc="${remove_id//"'"/"''"}"
 					local keep_esc="${keep_id//"'"/"''"}"
 					if [[ "$dry_run" == true ]]; then
-						log_info "[DRY RUN] Semantic dup: remove $remove_id (keep $keep_id): ${contents_arr[$j]:0:50}..."
+						log_info "[DRY RUN] Semantic dup: remove $remove_id (keep $keep_id): ${contents_arr[$j]:0:50}..." >&2
 					else
 						_dedup_merge_tags "$keep_esc" "$remove_esc"
 						db_cleanup "$MEMORY_DB" "UPDATE learning_relations SET supersedes_id = '$keep_esc' WHERE supersedes_id = '$remove_esc';"

--- a/.agents/scripts/tests/test-memory-dedup-dry-run.sh
+++ b/.agents/scripts/tests/test-memory-dedup-dry-run.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)" || exit
+
+TEST_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+export AIDEVOPS_MEMORY_DIR="$TEST_DIR/memory"
+mkdir -p "$AIDEVOPS_MEMORY_DIR"
+
+MEMORY_HELPER="$REPO_ROOT/.agents/scripts/memory-helper.sh"
+AUDIT_PULSE="$REPO_ROOT/.agents/scripts/memory-audit-pulse.sh"
+
+seed_duplicate_memories() {
+	"$MEMORY_HELPER" stats >/dev/null
+	local test_db="$AIDEVOPS_MEMORY_DIR/memory.db"
+	local i
+	for i in 1 2; do
+		local content="duplicate dry-run regression memory group ${i}"
+		sqlite3 "$test_db" \
+			"INSERT INTO learnings (id, session_id, content, type, tags, confidence, created_at, event_date, project_path, source) VALUES ('mem_2026050112000${i}_dryrun_a', 'test-session', '$content', 'WORKING_SOLUTION', 'test', 'high', '2026-05-01T12:00:0${i}Z', '2026-05-01T12:00:0${i}Z', '', 'test');"
+		sqlite3 "$test_db" \
+			"INSERT INTO learnings (id, session_id, content, type, tags, confidence, created_at, event_date, project_path, source) VALUES ('mem_2026050112010${i}_dryrun_b', 'test-session', '$content', 'WORKING_SOLUTION', 'test', 'high', '2026-05-01T12:01:0${i}Z', '2026-05-01T12:01:0${i}Z', '', 'test');"
+	done
+	return 0
+}
+
+fail() {
+	local message="$1"
+	printf 'FAIL: %s\n' "$message" >&2
+	return 1
+}
+
+seed_duplicate_memories
+
+validate_output="$($MEMORY_HELPER validate 2>&1)" || fail "memory-helper validate exited non-zero"
+
+if [[ ! "$validate_output" =~ Found[[:space:]]+2[[:space:]]+groups[[:space:]]+of[[:space:]]+exact[[:space:]]+duplicate[[:space:]]+entries ]]; then
+	fail "validate did not report 2 duplicate groups: $validate_output"
+fi
+
+dedup_output="$($MEMORY_HELPER dedup --dry-run 2>&1)" || fail "memory-helper dedup --dry-run exited non-zero"
+
+if [[ ! "$dedup_output" =~ Would[[:space:]]+remove[[:space:]]+2[[:space:]]+duplicates ]]; then
+	fail "dedup dry-run did not report 2 duplicates: $dedup_output"
+fi
+
+if [[ "$dedup_output" =~ syntax[[:space:]]+error ]]; then
+	fail "dedup dry-run emitted arithmetic syntax error: $dedup_output"
+fi
+
+audit_output="$($AUDIT_PULSE run --force --dry-run 2>&1)" || fail "memory-audit-pulse dry-run exited non-zero"
+
+if [[ ! "$audit_output" =~ Dedup:[[:space:]]+2[[:space:]]+duplicates[[:space:]]+would[[:space:]]+be[[:space:]]+removed ]]; then
+	fail "audit pulse did not report matching dedup count: $audit_output"
+fi
+
+printf 'PASS: memory dedup dry-run count channel\n'
+exit 0


### PR DESCRIPTION
## Summary
- Keeps dry-run per-memory duplicate logs off stdout so `cmd_dedup` command substitutions receive numeric phase counts only.
- Makes `memory-audit-pulse.sh` fail visibly on dedup command/parser errors instead of silently reporting zero duplicates.
- Adds regression coverage for validate/dedup/audit dry-run count agreement on a fixture DB.

## Testing
- `.agents/scripts/tests/test-memory-dedup-dry-run.sh`
- `shellcheck .agents/scripts/memory/maintenance-dedup.sh .agents/scripts/memory-audit-pulse.sh .agents/scripts/tests/test-memory-dedup-dry-run.sh`

## Runtime Testing
Low risk: shell maintenance scripts and regression test only; verified with fixture-backed script test and ShellCheck.

Resolves #21998


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.33 plugin for [OpenCode](https://opencode.ai) v1.14.30 with gpt-5.5 spent 33m and 154,676 tokens on this as a headless worker.