### PR TITLE
t3252: Fix gh_create_pr empty origin label args

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-create.sh
+++ b/.agents/scripts/shared-gh-wrappers-create.sh
@@ -413,10 +413,12 @@ _gh_auto_link_sub_issue() {
 
 	# Resolve both to node IDs and link
 	local parent_node child_node
+	# shellcheck disable=SC2016 # GraphQL variables are expanded by gh, not Bash.
 	parent_node=$(gh api graphql \
 		-f query='query($o:String!,$n:String!,$num:Int!){repository(owner:$o,name:$n){issue(number:$num){id}}}' \
 		-f o="$owner" -f n="$name" -F num="$parent_num" \
 		--jq '.data.repository.issue.id' 2>/dev/null || echo "")
+	# shellcheck disable=SC2016 # GraphQL variables are expanded by gh, not Bash.
 	child_node=$(gh api graphql \
 		-f query='query($o:String!,$n:String!,$num:Int!){repository(owner:$o,name:$n){issue(number:$num){id}}}' \
 		-f o="$owner" -f n="$name" -F num="$child_num" \
@@ -424,6 +426,7 @@ _gh_auto_link_sub_issue() {
 	[[ -z "$parent_node" || -z "$child_node" ]] && return 0
 
 	# Fire and forget — suppress all errors
+	# shellcheck disable=SC2016 # GraphQL variables are expanded by gh, not Bash.
 	gh api graphql -f query='mutation($p:ID!,$c:ID!){addSubIssue(input:{issueId:$p,subIssueId:$c}){issue{number}}}' \
 		-f p="$parent_node" -f c="$child_node" >/dev/null 2>&1 || true
 	return 0
@@ -453,12 +456,21 @@ gh_create_pr() {
 	_gh_wrapper_auto_sig "$@"
 	set -- "${_GH_WRAPPER_SIG_MODIFIED_ARGS[@]}"
 
+	local -a pr_cmd=(gh pr create "$@")
+	if [[ ${#_origin_label_args[@]} -gt 0 ]]; then
+		pr_cmd+=("${_origin_label_args[@]}")
+	fi
+
 	local pr_output rc
-	pr_output=$(gh pr create "$@" "${_origin_label_args[@]+"${_origin_label_args[@]}"}") # aidevops-allow: raw-gh-wrapper
+	pr_output=$("${pr_cmd[@]}") # aidevops-allow: raw-gh-wrapper
 	rc=$?
 	if [[ $rc -ne 0 ]] && _rest_should_fallback; then
 		print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to REST for pr create"
-		pr_output=$(_rest_pr_create "$@" "${_origin_label_args[@]+"${_origin_label_args[@]}"}")
+		if [[ ${#_origin_label_args[@]} -gt 0 ]]; then
+			pr_output=$(_rest_pr_create "$@" "${_origin_label_args[@]}")
+		else
+			pr_output=$(_rest_pr_create "$@")
+		fi
 		rc=$?
 	fi
 	printf '%s\n' "$pr_output"

--- a/.agents/scripts/tests/test-origin-label-mutex-create.sh
+++ b/.agents/scripts/tests/test-origin-label-mutex-create.sh
@@ -65,6 +65,11 @@ mkdir -p "$MOCK_BIN_DIR"
 cat >"${MOCK_BIN_DIR}/gh" <<'MOCK'
 #!/usr/bin/env bash
 printf '%s\n' "$*" >>"${GH_RECORD_FILE}"
+if [[ -n "${GH_ARGV_RECORD_FILE:-}" ]]; then
+	for arg in "$@"; do
+		printf '<%s>\n' "$arg" >>"${GH_ARGV_RECORD_FILE}"
+	done
+fi
 # pr/issue create paths print a URL on stdout for caller capture
 case "$1 $2" in
 "pr create" | "issue create")
@@ -288,6 +293,23 @@ else
 	print_result "B4: gh_create_pr respects origin in comma-list (no dup)" 1 \
 		"got $n labels in: $(tail -1 "$GH_RECORD_FILE")"
 fi
+
+# B5: caller origin must not leave an empty argv element before gh pr create.
+# Regression for GH#22022: the guarded array expansion emitted "" when
+# _origin_label_args was empty, so gh failed with: unknown argument "".
+reset_recorder
+export GH_ARGV_RECORD_FILE="${TEST_ROOT}/gh_argv_calls.log"
+: >"$GH_ARGV_RECORD_FILE"
+SESSION_ORIGIN_OVERRIDE="origin:worker" \
+	gh_create_pr --repo o/r --title "t1: x" --body "Resolves #1" \
+	--label "origin:interactive" >/dev/null 2>&1
+if grep -qx '<>' "$GH_ARGV_RECORD_FILE"; then
+	print_result "B5: gh_create_pr caller origin passes no empty argv element" 1 \
+		"empty argv element reached gh: $(tr '\n' ' ' <"$GH_ARGV_RECORD_FILE")"
+else
+	print_result "B5: gh_create_pr caller origin passes no empty argv element" 0
+fi
+unset GH_ARGV_RECORD_FILE
 
 # ---------------------------------------------------------------------------
 # Layer B': gh_create_issue defence-in-depth (mirrors PR tests)


### PR DESCRIPTION
## Summary
- Build the gh_create_pr command argv explicitly and append origin-label args only when non-empty.
- Add a regression check that records exact gh argv entries for caller-supplied origin labels.

## Testing
- shellcheck .agents/scripts/shared-gh-wrappers-create.sh .agents/scripts/tests/test-origin-label-mutex-create.sh
- .agents/scripts/tests/test-origin-label-mutex-create.sh
- .agents/scripts/tests/test-gh-wrapper-shell-compat.sh
- .agents/scripts/tests/test-gh-wrapper-rest-fallback.sh
- .agents/scripts/tests/test-shared-gh-wrappers-standalone.sh

## Runtime Testing
- Low risk shell wrapper bugfix; self-assessed via wrapper regression tests and actual gh_create_pr invocation with --label origin:interactive for this PR.

Resolves #22022
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.33 plugin for [OpenCode](https://opencode.ai) v1.14.30 with gpt-5.5 spent 37m and 154,676 tokens on this as a headless worker.