### PR TITLE
t3231: Bound optional CodeRabbit pre-push review

### DIFF
--- a/.agents/scripts/pre-commit-hook.sh
+++ b/.agents/scripts/pre-commit-hook.sh
@@ -1016,6 +1016,43 @@ main_pre_commit() {
 	fi
 }
 
+_coderabbit_cli_review_timeout() {
+	local review_timeout="${AIDEVOPS_CODERABBIT_CLI_REVIEW_TIMEOUT:-45}"
+	if ! [[ "$review_timeout" =~ ^[0-9]+$ ]] || ((review_timeout < 1)); then
+		print_warning "Invalid AIDEVOPS_CODERABBIT_CLI_REVIEW_TIMEOUT='${review_timeout}'; using 45s"
+		review_timeout=45
+	fi
+	printf '%s\n' "$review_timeout"
+	return 0
+}
+
+run_optional_coderabbit_cli_review() {
+	if [[ "${AIDEVOPS_SKIP_CODERABBIT_CLI_REVIEW:-0}" == "1" ]]; then
+		print_info "CodeRabbit CLI review skipped (AIDEVOPS_SKIP_CODERABBIT_CLI_REVIEW=1)"
+		return 0
+	fi
+
+	if [[ ! -f ".agents/scripts/coderabbit-cli.sh" ]] || ! command -v coderabbit &>/dev/null; then
+		return 0
+	fi
+
+	local review_timeout
+	review_timeout=$(_coderabbit_cli_review_timeout)
+	local review_status=0
+	print_info "Running CodeRabbit CLI review (timeout ${review_timeout}s)..."
+	if timeout_sec "$review_timeout" bash .agents/scripts/coderabbit-cli.sh review >/dev/null 2>&1; then
+		print_success "CodeRabbit CLI review completed"
+	else
+		review_status=$?
+		if [[ $review_status -eq 124 ]]; then
+			print_info "CodeRabbit CLI review skipped (timed out after ${review_timeout}s)"
+		else
+			print_info "CodeRabbit CLI review skipped (setup required)"
+		fi
+	fi
+	return 0
+}
+
 main_pre_push() {
 	echo -e "${BLUE}Pre-push Quality Validation${NC}" >&2
 	echo -e "${BLUE}================================${NC}" >&2
@@ -1028,16 +1065,9 @@ main_pre_push() {
 	check_quality_standards
 	echo "" >&2
 
-	# Optional CodeRabbit CLI review (if available)
-	if [[ -f ".agents/scripts/coderabbit-cli.sh" ]] && command -v coderabbit &>/dev/null; then
-		print_info "Running CodeRabbit CLI review..."
-		if bash .agents/scripts/coderabbit-cli.sh review >/dev/null 2>&1; then
-			print_success "CodeRabbit CLI review completed"
-		else
-			print_info "CodeRabbit CLI review skipped (setup required)"
-		fi
-		echo "" >&2
-	fi
+	# Optional CodeRabbit CLI review (advisory; fail-open and bounded)
+	run_optional_coderabbit_cli_review
+	echo "" >&2
 
 	# Final decision
 	if [[ $total_violations -eq 0 ]]; then

--- a/.agents/scripts/tests/test-pre-commit-hook-coderabbit-timeout.sh
+++ b/.agents/scripts/tests/test-pre-commit-hook-coderabbit-timeout.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression tests for optional CodeRabbit CLI pre-push review bounding.
+
+set -u
+
+_script_dir() {
+	local _src="${BASH_SOURCE[0]}"
+	while [[ -L "$_src" ]]; do
+		local _dir
+		_dir=$(cd -P "$(dirname "$_src")" && pwd)
+		_src=$(readlink "$_src")
+		[[ "$_src" != /* ]] && _src="${_dir}/${_src}"
+	done
+	cd -P "$(dirname "$_src")" && pwd
+	return 0
+}
+
+TESTS_DIR=$(_script_dir)
+REPO_ROOT=$(cd "${TESTS_DIR}/../../.." && pwd)
+PRE_COMMIT_HOOK="${REPO_ROOT}/.agents/scripts/pre-commit-hook.sh"
+TMP_DIR=""
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+setup_tmp() {
+	TMP_DIR=$(mktemp -d)
+	mkdir -p "${TMP_DIR}/bin"
+	return 0
+}
+
+cleanup_tmp() {
+	if [[ -n "${TMP_DIR:-}" && -d "$TMP_DIR" ]]; then
+		rm -rf "$TMP_DIR"
+	fi
+	TMP_DIR=""
+	return 0
+}
+
+pass() {
+	local name="$1"
+	printf '[PASS] %s\n' "$name"
+	TESTS_PASSED=$((TESTS_PASSED + 1))
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local reason="$2"
+	printf '[FAIL] %s: %s\n' "$name" "$reason" >&2
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+write_fake_coderabbit() {
+	local body="$1"
+	printf '%s\n' '#!/usr/bin/env bash' "$body" >"${TMP_DIR}/bin/coderabbit"
+	chmod +x "${TMP_DIR}/bin/coderabbit"
+	return 0
+}
+
+run_pre_push_with_fake_coderabbit() {
+	(
+		cd "$REPO_ROOT" || exit 1
+		PATH="${TMP_DIR}/bin:${PATH}" \
+			AIDEVOPS_CODERABBIT_CLI_REVIEW_TIMEOUT="${AIDEVOPS_CODERABBIT_CLI_REVIEW_TIMEOUT:-1}" \
+			AIDEVOPS_SKIP_CODERABBIT_CLI_REVIEW="${AIDEVOPS_SKIP_CODERABBIT_CLI_REVIEW:-0}" \
+			bash -c '
+				set -euo pipefail
+				# shellcheck disable=SC1090
+				source "$1"
+				check_secrets() { return 0; }
+				check_quality_standards() { return 0; }
+				main_pre_push
+			' bash "$PRE_COMMIT_HOOK"
+	)
+	return $?
+}
+
+test_coderabbit_review_times_out_fail_open() {
+	local name="CodeRabbit CLI review timeout is fail-open"
+	setup_tmp
+	write_fake_coderabbit 'sleep 5'
+
+	local start end duration output status
+	start=$(date +%s)
+	status=0
+	output=$(AIDEVOPS_CODERABBIT_CLI_REVIEW_TIMEOUT=1 run_pre_push_with_fake_coderabbit 2>&1) || status=$?
+	end=$(date +%s)
+	duration=$((end - start))
+
+	if [[ $status -ne 0 ]]; then
+		fail "$name" "expected exit 0, got ${status}; output=${output}"
+	elif ((duration > 4)); then
+		fail "$name" "expected bounded runtime <=4s, got ${duration}s"
+	elif [[ "$output" != *"timed out after 1s"* ]]; then
+		fail "$name" "missing timeout skip message; output=${output}"
+	else
+		pass "$name"
+	fi
+	cleanup_tmp
+	return 0
+}
+
+test_coderabbit_review_skip_env_bypasses_only_optional_step() {
+	local name="AIDEVOPS_SKIP_CODERABBIT_CLI_REVIEW bypasses optional review"
+	setup_tmp
+	write_fake_coderabbit 'exit 42'
+
+	local output status
+	status=0
+	output=$(AIDEVOPS_SKIP_CODERABBIT_CLI_REVIEW=1 run_pre_push_with_fake_coderabbit 2>&1) || status=$?
+
+	if [[ $status -ne 0 ]]; then
+		fail "$name" "expected exit 0, got ${status}; output=${output}"
+	elif [[ "$output" != *"AIDEVOPS_SKIP_CODERABBIT_CLI_REVIEW=1"* ]]; then
+		fail "$name" "missing skip-env message; output=${output}"
+	else
+		pass "$name"
+	fi
+	cleanup_tmp
+	return 0
+}
+
+main() {
+	test_coderabbit_review_times_out_fail_open
+	test_coderabbit_review_skip_env_bypasses_only_optional_step
+
+	printf '\nTests passed: %s\n' "$TESTS_PASSED"
+	printf 'Tests failed: %s\n' "$TESTS_FAILED"
+	if [[ $TESTS_FAILED -eq 0 ]]; then
+		return 0
+	fi
+	return 1
+}
+
+trap cleanup_tmp EXIT
+main "$@"


### PR DESCRIPTION
## Summary
- Bounds the optional pre-push CodeRabbit CLI review with `AIDEVOPS_CODERABBIT_CLI_REVIEW_TIMEOUT` (default 45s).
- Adds `AIDEVOPS_SKIP_CODERABBIT_CLI_REVIEW=1` to bypass only the advisory review step.
- Adds regression coverage for timeout fail-open and skip-env behavior.

## Testing
- `shellcheck .agents/scripts/pre-commit-hook.sh .agents/scripts/tests/test-pre-commit-hook-coderabbit-timeout.sh`
- `bash .agents/scripts/tests/test-pre-commit-hook-coderabbit-timeout.sh`
- `git push -u origin feature/gh-21985-coderabbit-timeout` (pre-push hook completed; CodeRabbit step skipped setup-required instead of stalling)

## Runtime Testing
Low risk: pre-push hook bugfix/test-only change. Self-assessed with shellcheck and focused hook regression tests.

## Decisions
- Kept CodeRabbit advisory/fail-open so secrets and quality gates remain authoritative.
- Used the existing portable `timeout_sec` helper from `shared-constants.sh` for macOS/Linux compatibility.

Resolves #21985


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.33 plugin for [OpenCode](https://opencode.ai) v1.14.30 with gpt-5.5 spent 38m and 154,676 tokens on this as a headless worker.