### PR TITLE
t3226: warn when pulse credentials lack Anthropic key

### DIFF
--- a/.agents/scripts/pulse-wrapper.sh
+++ b/.agents/scripts/pulse-wrapper.sh
@@ -315,7 +315,13 @@ fi
 #######################################
 if [[ -f "${HOME}/.config/aidevops/credentials.sh" ]]; then
 	# shellcheck source=/dev/null
-	. "${HOME}/.config/aidevops/credentials.sh" 2>/dev/null || true
+	if . "${HOME}/.config/aidevops/credentials.sh" 2>/dev/null; then
+		if [[ -z "${ANTHROPIC_API_KEY:-}" ]]; then
+			printf '[pulse-wrapper] WARN: credentials.sh sourced but ANTHROPIC_API_KEY is empty; LLM-dependent pulse helpers may fail\n' >&2
+		fi
+	else
+		printf '[pulse-wrapper] WARN: credentials.sh exists but failed to source; API keys may be unavailable\n' >&2
+	fi
 fi
 
 if ! type config_get >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary

- Warn when credentials.sh sources successfully but leaves ANTHROPIC_API_KEY empty.
- Warn when credentials.sh exists but fails to source, without changing pulse exit behavior.

## Runtime Testing

- Risk: Low — observability-only shell warning, no exit behavior change.
- shellcheck .agents/scripts/pulse-wrapper.sh
- tmp HOME with empty credentials.sh: warning included ANTHROPIC_API_KEY.

## Key decisions

- Kept pulse running on missing credentials; this is fail-noisy observability, not enforcement.

Resolves #21972

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.35 plugin for [OpenCode](https://opencode.ai) v1.14.30 with gpt-5.5 spent 26m and 113,016 tokens on this as a headless worker.
