### PR TITLE
t3243: add count-based OpenCode archive retention target

### DIFF
--- a/.agents/reference/opencode-maintenance.md
+++ b/.agents/reference/opencode-maintenance.md
@@ -100,6 +100,36 @@ FORCE_VACUUM_SIZE_MB=0 VACUUM_FREELIST_THRESHOLD=0.0 \
   opencode-db-maintenance-helper.sh maintain
 ```
 
+## Archive retention modes
+
+`opencode-db-archive.sh archive` supports two retention targets:
+
+- **Age-based retention** (`--retention-days N`) archives sessions older than
+  `N` days. This remains the default mode (`14` days) and is best when session
+  volume is predictable.
+- **Count-based retention** (`--keep-sessions N`) keeps the newest `N` active
+  sessions and archives older sessions beyond that budget. Use this when TUI
+  startup cost tracks active session count more closely than calendar age, for
+  example keeping roughly the newest 500 sessions active.
+
+Examples:
+
+```bash
+# Keep roughly the newest 500 active sessions, archive older sessions
+opencode-db-archive.sh archive --keep-sessions 500
+
+# Preview a stricter active-session budget first
+opencode-db-archive.sh archive --keep-sessions 250 --dry-run
+
+# Conservative combined mode: archive only sessions older than 30 days AND
+# outside the newest 500 sessions
+opencode-db-archive.sh archive --retention-days 30 --keep-sessions 500
+```
+
+When both modes are provided, the archive uses the conservative intersection:
+recent sessions are preserved if they are within either the age window or the
+newest-session budget.
+
 ## Safety
 
 - **Never runs with active opencode processes** in `auto` or plain

--- a/.agents/scripts/opencode-db-archive.sh
+++ b/.agents/scripts/opencode-db-archive.sh
@@ -10,7 +10,7 @@
 # old sessions to a separate file reduces the active DB size.
 #
 # Usage:
-#   opencode-db-archive.sh archive [--retention-days N] [--dry-run] [--max-duration-seconds N]
+#   opencode-db-archive.sh archive [--retention-days N] [--keep-sessions N] [--dry-run] [--max-duration-seconds N]
 #   opencode-db-archive.sh stats
 #   opencode-db-archive.sh help
 #
@@ -328,18 +328,77 @@ _archive_session_select_columns() {
 	return 0
 }
 
+_validate_nonnegative_integer() {
+	local value="$1"
+	local option_name="$2"
+
+	if [[ ! "$value" =~ ^[0-9]+$ ]]; then
+		print_error "${option_name} must be a non-negative integer: ${value}"
+		return 1
+	fi
+	return 0
+}
+
+_format_cutoff_time() {
+	local cutoff_ms="$1"
+	local cutoff_s=$((cutoff_ms / 1000))
+
+	date -r "$cutoff_s" '+%Y-%m-%d %H:%M' 2>/dev/null ||
+		date -d "@$cutoff_s" '+%Y-%m-%d %H:%M' 2>/dev/null ||
+		echo 'N/A'
+	return 0
+}
+
+_archive_candidate_filter() {
+	local retention_enabled="$1"
+	local cutoff_ms="$2"
+	local keep_enabled="$3"
+	local keep_sessions="$4"
+	local exclude_clause="$5"
+	local filter="1=1"
+
+	if ((retention_enabled)); then
+		filter="${filter} AND time_created < ${cutoff_ms}"
+	fi
+	if ((keep_enabled)); then
+		filter="${filter} AND id NOT IN (SELECT id FROM session ORDER BY time_created DESC, id DESC LIMIT ${keep_sessions})"
+	fi
+	if [[ -n "$exclude_clause" ]]; then
+		filter="${filter} ${exclude_clause}"
+	fi
+
+	printf '%s\n' "$filter"
+	return 0
+}
+
 # --- Archive command ----------------------------------------------------------
 
 cmd_archive() {
 	local retention_days="$DEFAULT_RETENTION_DAYS"
+	local retention_enabled=1
+	local retention_explicit=0
+	local keep_sessions=0
+	local keep_enabled=0
 	local dry_run=0
 	local max_duration="$DEFAULT_MAX_DURATION"
 
 	# Parse arguments
 	while [[ $# -gt 0 ]]; do
-		case "$1" in
+		local option="$1"
+		local option_value="${2:-}"
+		case "$option" in
 		--retention-days)
-			retention_days="$2"
+			retention_days="$option_value"
+			retention_enabled=1
+			retention_explicit=1
+			shift 2
+			;;
+		--keep-sessions)
+			keep_sessions="$option_value"
+			keep_enabled=1
+			if ((retention_explicit == 0)); then
+				retention_enabled=0
+			fi
 			shift 2
 			;;
 		--dry-run)
@@ -347,11 +406,11 @@ cmd_archive() {
 			shift
 			;;
 		--max-duration-seconds)
-			max_duration="$2"
+			max_duration="$option_value"
 			shift 2
 			;;
 		*)
-			print_error "Unknown option: $1"
+			print_error "Unknown option: $option"
 			cmd_help
 			return 1
 			;;
@@ -360,11 +419,21 @@ cmd_archive() {
 
 	check_sqlite3 || return 1
 	check_active_db || return 1
+	_validate_nonnegative_integer "$retention_days" "--retention-days" || return 1
+	_validate_nonnegative_integer "$keep_sessions" "--keep-sessions" || return 1
 
 	local cutoff_ms
 	cutoff_ms=$(($(date +%s) * 1000 - retention_days * 86400 * 1000))
 
-	print_info "Retention: ${retention_days} days (cutoff: $(date -r "$((cutoff_ms / 1000))" '+%Y-%m-%d %H:%M' 2>/dev/null || date -d "@$((cutoff_ms / 1000))" '+%Y-%m-%d %H:%M' 2>/dev/null || echo 'N/A'))"
+	if ((retention_enabled)); then
+		print_info "Retention: ${retention_days} days (cutoff: $(_format_cutoff_time "$cutoff_ms"))"
+	fi
+	if ((keep_enabled)); then
+		print_info "Retention: keep newest ${keep_sessions} active sessions"
+	fi
+	if ((retention_enabled && keep_enabled)); then
+		print_info "Combined retention: archiving only sessions that are older than both targets"
+	fi
 	print_info "Active DB: $ACTIVE_DB"
 	print_info "Archive DB: $ARCHIVE_DB"
 
@@ -388,12 +457,15 @@ cmd_archive() {
 		exclude_clause="AND id NOT IN ($exclude_list)"
 	fi
 
+	local candidate_filter
+	candidate_filter=$(_archive_candidate_filter "$retention_enabled" "$cutoff_ms" "$keep_enabled" "$keep_sessions" "$exclude_clause")
+
 	# Count eligible sessions
 	local total_eligible
-	total_eligible=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM session WHERE time_created < $cutoff_ms $exclude_clause;")
+	total_eligible=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM session WHERE $candidate_filter;")
 
 	if ((total_eligible == 0)); then
-		print_success "No sessions older than $retention_days days to archive."
+		print_success "No sessions match the archive retention target."
 		return 0
 	fi
 
@@ -402,10 +474,10 @@ cmd_archive() {
 	if ((dry_run)); then
 		# Show what would be archived
 		local msg_count part_count todo_count share_count
-		msg_count=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM message WHERE session_id IN (SELECT id FROM session WHERE time_created < $cutoff_ms $exclude_clause);")
-		part_count=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM part WHERE session_id IN (SELECT id FROM session WHERE time_created < $cutoff_ms $exclude_clause);")
-		todo_count=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM todo WHERE session_id IN (SELECT id FROM session WHERE time_created < $cutoff_ms $exclude_clause);")
-		share_count=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM session_share WHERE session_id IN (SELECT id FROM session WHERE time_created < $cutoff_ms $exclude_clause);")
+		msg_count=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM message WHERE session_id IN (SELECT id FROM session WHERE $candidate_filter);")
+		part_count=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM part WHERE session_id IN (SELECT id FROM session WHERE $candidate_filter);")
+		todo_count=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM todo WHERE session_id IN (SELECT id FROM session WHERE $candidate_filter);")
+		share_count=$(sqlite3 "$ACTIVE_DB" "SELECT COUNT(*) FROM session_share WHERE session_id IN (SELECT id FROM session WHERE $candidate_filter);")
 
 		echo ""
 		echo "=== DRY RUN — would archive: ==="
@@ -463,7 +535,7 @@ cmd_archive() {
 
 		# Collect batch session IDs
 		local session_ids
-		session_ids=$(sqlite3 "$ACTIVE_DB" "SELECT id FROM session WHERE time_created < $cutoff_ms $exclude_clause ORDER BY time_created ASC LIMIT $batch_limit;")
+		session_ids=$(sqlite3 "$ACTIVE_DB" "SELECT id FROM session WHERE $candidate_filter ORDER BY time_created ASC LIMIT $batch_limit;")
 
 		if [[ -z "$session_ids" ]]; then
 			break
@@ -667,6 +739,7 @@ COMMANDS:
 
 ARCHIVE OPTIONS:
   --retention-days N        Sessions older than N days are archived (default: 14)
+  --keep-sessions N         Keep newest N active sessions; archive older sessions beyond the budget
   --dry-run                 Show what would be archived without doing it
   --max-duration-seconds N  Stop after N seconds even when not done (default: 60)
 
@@ -680,6 +753,9 @@ EXAMPLES:
 
   # Preview what would be archived (30-day retention)
   opencode-db-archive.sh archive --retention-days 30 --dry-run
+
+  # Keep the newest 500 active sessions, archive older sessions
+  opencode-db-archive.sh archive --keep-sessions 500
 
   # Archive with defaults (14 days, 60s time budget)
   opencode-db-archive.sh archive

--- a/.agents/scripts/tests/test-opencode-db-archive.sh
+++ b/.agents/scripts/tests/test-opencode-db-archive.sh
@@ -42,6 +42,11 @@ trap 'rm -rf "$SANDBOX"' EXIT
 ACTIVE_DB="${SANDBOX}/opencode.db"
 ARCHIVE_DB="${SANDBOX}/opencode-archive.db"
 
+_reset_dbs() {
+	rm -f "$ACTIVE_DB" "$ARCHIVE_DB" "${ACTIVE_DB}-wal" "${ACTIVE_DB}-shm" "${ARCHIVE_DB}-wal" "${ARCHIVE_DB}-shm"
+	return 0
+}
+
 _make_active_db_with_session_path() {
 	sqlite3 "$ACTIVE_DB" <<'SQL'
 PRAGMA journal_mode = WAL;
@@ -137,6 +142,66 @@ SQL
 	return 0
 }
 
+_make_active_db_with_sessions() {
+	local sessions_csv="$1"
+
+	sqlite3 "$ACTIVE_DB" <<'SQL'
+PRAGMA journal_mode = WAL;
+CREATE TABLE project (
+  id text PRIMARY KEY,
+  worktree text NOT NULL,
+  vcs text,
+  name text,
+  icon_url text,
+  icon_color text,
+  time_created integer NOT NULL,
+  time_updated integer NOT NULL,
+  time_initialized integer,
+  sandboxes text NOT NULL,
+  commands text,
+  icon_url_override text
+);
+CREATE TABLE session (
+  id text PRIMARY KEY,
+  project_id text NOT NULL,
+  parent_id text,
+  slug text NOT NULL,
+  directory text NOT NULL,
+  title text NOT NULL,
+  version text NOT NULL,
+  share_url text,
+  summary_additions integer,
+  summary_deletions integer,
+  summary_files integer,
+  summary_diffs text,
+  revert text,
+  permission text,
+  time_created integer NOT NULL,
+  time_updated integer NOT NULL,
+  time_compacting integer,
+  time_archived integer,
+  workspace_id text,
+  path text
+);
+CREATE TABLE message (id text PRIMARY KEY, session_id text NOT NULL, time_created integer NOT NULL, time_updated integer NOT NULL, data text NOT NULL);
+CREATE TABLE part (id text PRIMARY KEY, message_id text NOT NULL, session_id text NOT NULL, time_created integer NOT NULL, time_updated integer NOT NULL, data text NOT NULL);
+CREATE TABLE todo (session_id text NOT NULL, content text NOT NULL, status text NOT NULL, priority text NOT NULL, position integer NOT NULL, time_created integer NOT NULL, time_updated integer NOT NULL, PRIMARY KEY(session_id, position));
+CREATE TABLE session_share (session_id text PRIMARY KEY, id text NOT NULL, secret text NOT NULL, url text NOT NULL, time_created integer NOT NULL, time_updated integer NOT NULL);
+INSERT INTO project VALUES ('proj1', '/tmp/worktree', 'git', 'project', NULL, NULL, 1, 1, NULL, '{}', NULL, NULL);
+SQL
+
+	local session_id created_ms
+	while IFS=',' read -r session_id created_ms; do
+		[[ -n "$session_id" ]] || continue
+		sqlite3 "$ACTIVE_DB" \
+			"INSERT INTO session VALUES ('${session_id}', 'proj1', NULL, '${session_id}', '/tmp/dir', '${session_id}', '1.0.0', NULL, NULL, NULL, NULL, NULL, NULL, NULL, ${created_ms}, ${created_ms}, NULL, NULL, 'workspace1', '/tmp/${session_id}');"
+		sqlite3 "$ACTIVE_DB" \
+			"INSERT INTO message VALUES ('msg-${session_id}', '${session_id}', ${created_ms}, ${created_ms}, '{}');"
+	done <<<"$sessions_csv"
+	return 0
+}
+
+_reset_dbs
 _make_active_db_with_session_path
 _make_legacy_archive_db_without_session_path
 
@@ -170,6 +235,63 @@ if [[ "$active_sessions" == "0" ]]; then
 	_pass "archived session removed from active DB"
 else
 	_fail "archived session still present in active DB"
+fi
+
+_reset_dbs
+_make_active_db_with_sessions $'s1,1000\ns2,2000\ns3,3000\ns4,4000\ns5,5000'
+
+set +e
+out=$(OPENCODE_DB="$ACTIVE_DB" OPENCODE_ARCHIVE_DB="$ARCHIVE_DB" "$HELPER" archive --keep-sessions 2 --max-duration-seconds 30 2>&1)
+rc=$?
+set -e
+
+if [[ "$rc" -eq 0 ]]; then
+	_pass "archive succeeds with count-based retention"
+else
+	_fail "count-based archive failed with rc=$rc — output: $out"
+fi
+
+active_kept=$(sqlite3 "$ACTIVE_DB" "SELECT GROUP_CONCAT(id, ',') FROM (SELECT id FROM session ORDER BY time_created);")
+if [[ "$active_kept" == "s4,s5" ]]; then
+	_pass "count-based retention preserves newest sessions"
+else
+	_fail "count-based retention kept unexpected active sessions: ${active_kept}"
+fi
+
+archived_count_sessions=$(sqlite3 "$ARCHIVE_DB" "SELECT GROUP_CONCAT(id, ',') FROM (SELECT id FROM session ORDER BY time_created);")
+if [[ "$archived_count_sessions" == "s1,s2,s3" ]]; then
+	_pass "count-based retention archives sessions outside keep target"
+else
+	_fail "count-based retention archived unexpected sessions: ${archived_count_sessions}"
+fi
+
+_reset_dbs
+now_seconds=$(date +%s)
+old1_ms=$(((now_seconds - 10 * 86400) * 1000))
+old2_ms=$(((now_seconds - 9 * 86400) * 1000))
+mid_ms=$(((now_seconds - 3 * 86400) * 1000))
+new_ms=$(((now_seconds - 1 * 86400) * 1000))
+_make_active_db_with_sessions "old1,${old1_ms}
+old2,${old2_ms}
+mid,${mid_ms}
+new,${new_ms}"
+
+set +e
+out=$(OPENCODE_DB="$ACTIVE_DB" OPENCODE_ARCHIVE_DB="$ARCHIVE_DB" "$HELPER" archive --retention-days 7 --keep-sessions 3 --max-duration-seconds 30 2>&1)
+rc=$?
+set -e
+
+if [[ "$rc" -eq 0 ]]; then
+	_pass "archive succeeds with combined retention targets"
+else
+	_fail "combined archive failed with rc=$rc — output: $out"
+fi
+
+combined_active=$(sqlite3 "$ACTIVE_DB" "SELECT GROUP_CONCAT(id, ',') FROM (SELECT id FROM session ORDER BY time_created);")
+if [[ "$combined_active" == "old2,mid,new" ]]; then
+	_pass "combined retention uses conservative intersection"
+else
+	_fail "combined retention kept unexpected active sessions: ${combined_active}"
 fi
 
 printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"


### PR DESCRIPTION
## Summary
- Added `--keep-sessions N` count-based retention for `opencode-db-archive.sh`.
- Combined explicit `--retention-days` + `--keep-sessions` conservatively so sessions archive only when outside both targets.
- Added SQLite sandbox regression coverage and documented when to use day-based versus count-based retention.

## Testing
- `bash .agents/scripts/tests/test-opencode-db-archive.sh`
- `shellcheck .agents/scripts/opencode-db-archive.sh .agents/scripts/tests/test-opencode-db-archive.sh`
- `npx --yes markdownlint-cli2 .agents/reference/opencode-maintenance.md`

## Runtime Testing
- Low risk shell utility/docs change; verified with sandbox SQLite regression tests and linters.

Resolves #22001

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.35 plugin for [OpenCode](https://opencode.ai) v1.14.30 with gpt-5.5 spent 28m and 113,016 tokens on this as a headless worker.
