### PR TITLE
t3230: add current OpenAI model fallbacks to tier routing

### DIFF
--- a/.agents/configs/model-pricing.json
+++ b/.agents/configs/model-pricing.json
@@ -7,6 +7,8 @@
     "haiku-4":         { "input": 0.80,  "output": 4.0,   "cache_read": 0.08,   "cache_write": 1.0   },
     "haiku-3":         { "input": 0.80,  "output": 4.0,   "cache_read": 0.08,   "cache_write": 1.0   },
     "gpt-5.3-codex":   { "input": 3.50,  "output": 28.0,  "cache_read": 0.35,   "cache_write": 3.50  },
+    "gpt-5.5":         { "input": 2.50,  "output": 15.0,  "cache_read": 0.25,   "cache_write": 2.50  },
+    "gpt-5.4-mini":    { "input": 0.25,  "output": 2.0,   "cache_read": 0.025,  "cache_write": 0.25  },
     "gpt-5.4":         { "input": 2.50,  "output": 15.0,  "cache_read": 0.25,   "cache_write": 2.50  },
     "gpt-5":           { "input": 1.25,  "output": 10.0,  "cache_read": 0.125,  "cache_write": 1.25  },
     "gpt-4.1-mini":    { "input": 0.40,  "output": 1.60,  "cache_read": 0.10,   "cache_write": 0.40  },

--- a/.agents/scripts/model-availability-helper.sh
+++ b/.agents/scripts/model-availability-helper.sh
@@ -171,23 +171,24 @@ get_tier_models() {
 
 	# Hardcoded fallback — kept in sync with model-routing-table.json.
 	# If you're editing these, update the JSON file instead.
-	# Claude remains primary. OpenAI is the direct-provider fallback for
-	# headless continuity when Anthropic is unavailable.
+	# Current smoke-tested OpenAI models are listed first for headless
+	# continuity during Anthropic cooldown windows. Anthropic remains the
+	# fallback; exclude Codex and unsupported *-pro IDs from dispatch.
 	case "$tier" in
-	local) current_model="anthropic/claude-haiku-4-5" ;;
-	haiku) current_model=$'anthropic/claude-haiku-4-5\nopenai/gpt-5.4' ;;
-	flash) current_model=$'anthropic/claude-haiku-4-5\nopenai/gpt-5.4' ;;
-	sonnet) current_model=$'anthropic/claude-sonnet-4-6\nopenai/gpt-5.4' ;;
-	pro) current_model=$'anthropic/claude-sonnet-4-6\nopenai/gpt-5.4' ;;
-	opus) current_model=$'anthropic/claude-opus-4-6\nopenai/gpt-5.4' ;;
-	health) current_model=$'anthropic/claude-sonnet-4-6\nopenai/gpt-5.4' ;;
-	eval) current_model=$'anthropic/claude-sonnet-4-6\nopenai/gpt-5.4' ;;
-	coding) current_model=$'anthropic/claude-opus-4-6\nopenai/gpt-5.4' ;;
+	local) current_model=$'openai/gpt-5.4-mini\nanthropic/claude-haiku-4-5' ;;
+	haiku) current_model=$'openai/gpt-5.4-mini\nanthropic/claude-haiku-4-5' ;;
+	flash) current_model=$'openai/gpt-5.4-mini\nanthropic/claude-haiku-4-5' ;;
+	sonnet) current_model=$'openai/gpt-5.5\nanthropic/claude-sonnet-4-6' ;;
+	pro) current_model=$'openai/gpt-5.5\nanthropic/claude-sonnet-4-6' ;;
+	opus) current_model=$'openai/gpt-5.5\nanthropic/claude-opus-4-6' ;;
+	health) current_model=$'openai/gpt-5.4-mini\nanthropic/claude-sonnet-4-6' ;;
+	eval) current_model=$'openai/gpt-5.5\nanthropic/claude-sonnet-4-6' ;;
+	coding) current_model=$'openai/gpt-5.5\nanthropic/claude-opus-4-6' ;;
 	*) return 1 ;;
 	esac
 
 	if [[ ${#allowlist[@]} -eq 0 ]]; then
-		echo "$(printf '%s\n' "$current_model" | paste -sd'|' -)"
+		printf '%s\n' "$current_model" | paste -sd'|' -
 		return 0
 	fi
 

--- a/.agents/tools/context/model-routing.md
+++ b/.agents/tools/context/model-routing.md
@@ -32,13 +32,13 @@ model: haiku
 |------|-------|----------|
 | `local` | llama.cpp or Ollama (user models) | Privacy/offline, bulk, experimentation; opt-in only |
 | `composer2` | cursor/composer-2 | Multi-file coding, large refactors (requires Cursor OAuth pool t1549) |
-| `flash` | gemini-2.5-flash-preview-05-20 | >50K context, summarization, bulk processing, research sweeps |
-| `haiku` | claude-haiku-4-5-20251001 | Classification, triage, simple transforms, commit messages, routing |
-| `sonnet` | claude-sonnet-4-6 | Code, review, debugging, docs — most dev tasks |
-| `pro` | gemini-2.5-pro | >100K codebases + complex reasoning |
-| `opus` | claude-opus-4-6 | Architecture, novel problems, security audits, complex trade-offs |
+| `flash` | openai/gpt-5.4-mini → claude-haiku-4-5 | >50K context, summarization, bulk processing, research sweeps |
+| `haiku` | openai/gpt-5.4-mini → claude-haiku-4-5 | Classification, triage, simple transforms, commit messages, routing |
+| `sonnet` | openai/gpt-5.5 → claude-sonnet-4-6 | Code, review, debugging, docs — most dev tasks |
+| `pro` | openai/gpt-5.5 → claude-sonnet-4-6 | >100K codebases + complex reasoning |
+| `opus` | openai/gpt-5.5 → claude-opus-4-6 | Architecture, novel problems, security audits, complex trade-offs |
 
-**Model IDs**: Always fully-qualified (`claude-sonnet-4-6`, not `claude-sonnet-4`). Short-form → `ProviderModelNotFoundError`. CLI prefix: `anthropic/`, `google/`.
+**Model IDs**: Always fully-qualified (`claude-sonnet-4-6`, not `claude-sonnet-4`). Short-form → `ProviderModelNotFoundError`. CLI prefix: `anthropic/`, `google/`, `openai/`.
 
 **`local` fallback**: Privacy → FAIL (require `--allow-cloud`). Cost → Ollama → `composer2`. Local is opt-in only — default dispatch uses `haiku`. Users who explicitly configure local tier: llama.cpp → Ollama → `haiku`.
 
@@ -58,12 +58,12 @@ Privacy/on-device? → YES → local running? → YES: local | NO: FAIL
 | Tier | Fallback | Trigger |
 |------|----------|---------|
 | `local` | Ollama → composer2 (cost) / FAIL (privacy) | llama.cpp not running |
-| `flash` | gpt-4.1-mini | No Google key |
-| `haiku` | flash | No Anthropic key |
+| `flash` | claude-haiku-4-5 | OpenAI unavailable or provider-disallowed |
+| `haiku` | claude-haiku-4-5 | OpenAI unavailable or provider-disallowed |
 | `composer2` | sonnet | No Cursor OAuth pool |
-| `sonnet` | gpt-5.3-codex | No Anthropic key |
-| `pro` | sonnet | No Google key |
-| `opus` | gpt-5.4 | No Anthropic key |
+| `sonnet` | claude-sonnet-4-6 | OpenAI unavailable or provider-disallowed |
+| `pro` | claude-sonnet-4-6 | OpenAI unavailable or provider-disallowed |
+| `opus` | claude-opus-4-6 | OpenAI unavailable or provider-disallowed |
 
 Supervisor resolves automatically. Interactive: `compare-models-helper.sh discover`.
 
@@ -76,13 +76,15 @@ Supervisor resolves automatically. Interactive: `compare-models-helper.sh discov
 3. **Auth + availability checks** (`headless-runtime-helper.sh`, `model-availability-helper.sh`) → providers/models that can actually run now
 4. **Result**: pulse resolves a sonnet-tier model; workers round-robin across the filtered sonnet-tier list
 
-- **Shared default**: The framework routing table remains Anthropic-first. Other providers are opt-in through `custom/configs/model-routing-table.json`, so existing Anthropic users are unchanged after update.
+- **Shared default**: The framework routing table lists smoke-tested OpenAI models first so workers can continue during Anthropic cooldowns. Anthropic remains the fallback, and local custom routing can still reorder or replace these defaults.
 - **Pulse**: Resolves `sonnet` through `model-availability-helper.sh resolve sonnet`, so it follows routing-table order, health checks, local routing-table overrides, and `AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST`.
 - **Workers**: Round-robin across the routed `sonnet` models after allowlist filtering and auth checks. Tier escalation still uses `resolve` (`tier:simple` → `haiku`, `tier:standard` → `sonnet`, `tier:thinking` → `opus`).
-- **Local switch**: Add OpenAI models to `custom/configs/model-routing-table.json`, then set `AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST=openai` to force both pulse and workers onto OpenAI. If you want OpenAI primary but Anthropic fallback, reorder the custom routing table and omit the allowlist.
+- **Local switch**: Set `AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST=openai` to force both pulse and workers onto the default OpenAI fallbacks. If you want OpenAI primary but Anthropic fallback, reorder `custom/configs/model-routing-table.json` and omit the allowlist.
+- **OpenAI default mapping**: `haiku`/`flash`/`health` resolve to `openai/gpt-5.4-mini`; `sonnet`/`pro`/`eval` resolve to `openai/gpt-5.5`; `opus`/`coding` also use `openai/gpt-5.5` until account-aware support gates can distinguish working `*-pro` access.
+- **OpenAI pro caveat**: Current OpenCode ChatGPT OAuth smoke tests fail for `openai/gpt-5.5-pro` and older `*-pro`/`o3-pro` IDs, so default worker dispatch intentionally excludes them. Codex models remain excluded because they are not agentic in headless worker sessions.
 - **Reasoning effort**: OpenCode exposes GPT reasoning variants separately (`none`, `minimal`, `low`, `medium`, `high`, `xhigh`). Headless runs do not default to `xhigh`; if no variant is set, OpenCode sends no explicit effort override and the provider default applies.
 - **GPT-5.5 standard workers**: For `openai/gpt-5.5` on worker `sonnet`/`pro` tiers, aidevops omits env-derived variants such as `AIDEVOPS_HEADLESS_VARIANT_SONNET=high` so OpenCode sends no explicit thinking override. Explicit CLI `--variant` still wins because it bypasses automatic variant resolution.
-- **Tier-aware effort**: Headless dispatch can now apply variants by resolved tier. `AIDEVOPS_HEADLESS_VARIANT_SONNET=high` and `AIDEVOPS_HEADLESS_VARIANT_OPUS=xhigh` make standard work run at `high` and reasoning-tier work run at `xhigh` even when both tiers use `openai/gpt-5.4`. The GPT-5.5 standard-worker exception above only applies to env-derived sonnet/pro variants.
+- **Tier-aware effort**: Headless dispatch can now apply variants by resolved tier. `AIDEVOPS_HEADLESS_VARIANT_SONNET=high` and `AIDEVOPS_HEADLESS_VARIANT_OPUS=xhigh` make standard work run at `high` and reasoning-tier work run at `xhigh` even when both tiers use `openai/gpt-5.5`. The GPT-5.5 standard-worker exception above only applies to env-derived sonnet/pro variants.
 - **Fallback**: If routed resolution fails entirely, pulse falls back to `anthropic/claude-sonnet-4-6`; workers fall back to `DEFAULT_HEADLESS_MODELS` when no allowlist is forcing a subset.
 - **Deprecated**: `PULSE_MODEL` and `AIDEVOPS_HEADLESS_MODELS` env vars are respected as overrides for one release cycle with deprecation warnings. Remove from `credentials.sh`.
 


### PR DESCRIPTION
## Summary

Synchronized the hardcoded model resolver with the OpenAI-first routing table, documented the GPT-5.5 fallback mapping and pro-model caveat, and added GPT-5.5 family pricing metadata.

## Files Changed

.agents/configs/model-pricing.json,.agents/scripts/model-availability-helper.sh,.agents/tools/context/model-routing.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** jq validation for routing/pricing JSON; shellcheck .agents/scripts/model-availability-helper.sh; markdownlint-cli2 .agents/tools/context/model-routing.md; OpenAI allowlist resolve checks for haiku, sonnet, and opus. Full linters-local was attempted but hit pre-existing repo-wide string-literal threshold debt before timing out.

Resolves #21984


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.35 plugin for [OpenCode](https://opencode.ai) v1.14.30 with gpt-5.5 spent 44m and 154,676 tokens on this as a headless worker.