### PR TITLE
t3238: add memory truth-maintenance workflow

### DIFF
--- a/.agents/reference/memory.md
+++ b/.agents/reference/memory.md
@@ -68,6 +68,13 @@ Agents store automatically via `--auto` flag. Works with any AI tool that reads 
 | `updates` | New info supersedes old | "Favorite color is now green" updates "...is blue" |
 | `extends` | Adds detail, no contradiction | Adding job title to existing employment memory |
 | `derives` | Second-order inference | Inferring "works remotely" from location + job info |
+| `debunks` | Evidence marks old memory false | "Current source disproves the outage myth" debunks the stale claim |
+
+Truth maintenance is append-only: debunk/retraction state is recorded in
+`learning_truth_events` and linked to evidence memories instead of editing or
+deleting the original FTS5 row. Default recall hides debunked/retracted memories
+and hides memories superseded by `updates`; use `history <id>` when you need the
+audit chain.
 
 ## Dual Timestamps
 
@@ -96,8 +103,9 @@ Inspired by [Ori Mnemos](https://github.com/aayoawoyemi/Ori-Mnemos) Q-value syst
 | `edited` | +0.5 | Memory edited after retrieval |
 | `reused` | +0.4 | Recalled across different queries |
 | `dead_end` | -0.15 (floor: -1.0) | Retrieved but not used |
+| `false` / `debunked` | -2.0 (floor: -5.0) | Retrieved memory was false or myth-like |
 
-**Ranking:** FTS5 blended score = `bm25(learnings) - (usefulness_score * 0.3)`. Hybrid (RRF): usefulness added as third signal. Call `feedback` after tasks where recalled memories contributed; pulse supervisor can batch-record from PR merge outcomes.
+**Ranking:** FTS5 blended score = `bm25(learnings) - (usefulness_score * 0.3)`. Hybrid (RRF): usefulness added as third signal. Default recall excludes debunked/retracted and superseded rows before access tracking, so simply seeing a false memory no longer keeps it fresh. Call `feedback` after tasks where recalled memories contributed; use `feedback <id> --signal false` when a retrieved memory is disproven.
 
 ## Pattern Tracking
 
@@ -145,6 +153,8 @@ Use `--namespace <name>` with any `memory-helper.sh` command for per-runner isol
 memory-helper.sh store --type "WORKING_SOLUTION" --content "Fixed CORS with nginx headers" --tags "cors,nginx"
 memory-helper.sh store --content "Deployed v2.0" --event-date "2024-01-15T10:00:00Z"
 memory-helper.sh store --content "New info" --supersedes mem_xxx --relation updates
+memory-helper.sh store --content "Evidence disproving old claim" --debunks mem_xxx --evidence "Verified current source"
+memory-helper.sh store --content "Replacement truth" --supersedes mem_old --relation updates
 
 # Recall
 memory-helper.sh recall "cors"
@@ -158,6 +168,7 @@ memory-helper.sh recall "query" --manual-only
 # Feedback
 memory-helper.sh feedback mem_xxx --signal cited
 memory-helper.sh feedback mem_xxx --signal dead_end
+memory-helper.sh feedback mem_xxx --signal false
 memory-helper.sh feedback mem_xxx --value 0.8   # Custom reward
 
 # Version history

--- a/.agents/scripts/memory-helper.sh
+++ b/.agents/scripts/memory-helper.sh
@@ -32,6 +32,7 @@
 #   - updates: New info supersedes old (e.g., "favorite color is now green")
 #   - extends: Adds detail without contradiction (e.g., adding job title)
 #   - derives: Second-order inference from combining memories
+#   - debunks: Evidence marks an existing memory as false/retracted
 #
 # Dual Timestamps:
 #   - created_at: When the memory was stored
@@ -71,7 +72,7 @@ readonly VALID_TYPES="WORKING_SOLUTION FAILED_APPROACH CODEBASE_PATTERN USER_PRE
 # - extends: Adds detail without contradiction (refinement)
 # - derives: Second-order inference from combining memories
 # shellcheck disable=SC2034 # Used in memory/store.sh
-readonly VALID_RELATIONS="updates extends derives"
+readonly VALID_RELATIONS="updates extends derives debunks"
 
 # Source modules (eager loading — simpler, avoids path resolution bugs)
 # shellcheck source=memory/_common.sh
@@ -104,7 +105,7 @@ COMMANDS:
     history     Show version history for a memory (ancestors/descendants)
     latest      Find the latest version of a memory chain
     stats       Show memory statistics
-    validate    Check for stale/duplicate entries (with detailed reports)
+    validate    Check for stale/duplicate/debunked entries (with detailed reports)
     prune       Remove old entries (auto-runs every 24h on store)
     prune-patterns  Remove repetitive pattern entries by keyword (e.g., clean_exit_no_signal)
     dedup       Remove exact and near-duplicate entries
@@ -139,6 +140,10 @@ STORE OPTIONS:
     --event-date <ISO>    When the event occurred (default: now)
     --supersedes <id>     ID of memory this updates/extends/derives from
     --relation <type>     Relation type: updates, extends, derives
+    --debunks <id>        Mark an existing memory as false/debunked using this
+                          stored learning as the evidence record
+    --replacement <id>    Optional live replacement memory for --debunks
+    --evidence <text>     Optional concise evidence note for --debunks
     --auto                Mark as auto-captured (sets source=auto, tracked separately)
     --entity <id>         Link learning to an entity (e.g., ent_xxx)
 
@@ -154,6 +159,8 @@ RELATION TYPES (inspired by Supermemory):
                 e.g., Adding job title to existing employment memory
     derives   - Second-order inference from combining memories
                 e.g., Inferring "works remotely" from location + job info
+    debunks   - Evidence marks an existing memory as false/retracted
+                e.g., "The CI failure was not caused by the hook" debunks a myth
 
 RECALL OPTIONS:
     --query <text>        Search query (required unless --recent)
@@ -184,6 +191,8 @@ FEEDBACK SIGNALS (retrieval feedback loop):
     led_to_new (+0.6) — a new memory was created after retrieving this one
     reused     (+0.4) — same memory recalled across different queries
     dead_end   (-0.15) — retrieved in top results but no follow-up action
+    false      (-2.0) — retrieved memory was false/debunked
+    debunked   (-2.0) — alias for false
 EOF
 	return 0
 }
@@ -257,6 +266,10 @@ EXAMPLES:
     memory-helper.sh store --content "Favorite color is now green" \
         --supersedes mem_xxx --relation updates
 
+    # Debunk a false memory while preserving audit history
+    memory-helper.sh store --content "Evidence: deployed script no longer has this bug" \
+        --debunks mem_old --evidence "Verified against current source"
+
     # Extend a memory with more detail
     memory-helper.sh store --content "Job title: Senior Engineer" \
         --supersedes mem_yyy --relation extends
@@ -290,6 +303,9 @@ EXAMPLES:
 
     # Record feedback: memory was a dead end (retrieved but not used)
     memory-helper.sh feedback mem_xxx --signal dead_end
+
+    # Record feedback: memory was false and should be strongly demoted
+    memory-helper.sh feedback mem_xxx --signal false
 
     # Record feedback with custom reward value
     memory-helper.sh feedback mem_xxx --value 0.8

--- a/.agents/scripts/memory/_common.sh
+++ b/.agents/scripts/memory/_common.sh
@@ -469,6 +469,38 @@ EOF
 }
 
 #######################################
+# Rebuild learning_relations when the CHECK constraint predates debunks.
+#######################################
+_migrate_learning_relations_debunks() {
+	local relation_sql
+	relation_sql=$(db "$MEMORY_DB" "SELECT sql FROM sqlite_master WHERE type='table' AND name='learning_relations';" 2>/dev/null || echo "")
+	if [[ -z "$relation_sql" || "$relation_sql" == *"debunks"* ]]; then
+		return 0
+	fi
+
+	log_info "Rebuilding learning_relations to allow debunks relation..."
+	db "$MEMORY_DB" <<'EOF'
+BEGIN TRANSACTION;
+ALTER TABLE learning_relations RENAME TO learning_relations_old;
+CREATE TABLE learning_relations (
+    id TEXT NOT NULL,
+    supersedes_id TEXT,
+    relation_type TEXT CHECK(relation_type IN ('updates', 'extends', 'derives', 'debunks')),
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id, supersedes_id, relation_type)
+);
+INSERT OR IGNORE INTO learning_relations (id, supersedes_id, relation_type, created_at)
+SELECT id, supersedes_id, relation_type, created_at
+FROM learning_relations_old
+WHERE relation_type IN ('updates', 'extends', 'derives', 'debunks');
+DROP TABLE learning_relations_old;
+COMMIT;
+EOF
+	log_success "learning_relations now supports debunks"
+	return 0
+}
+
+#######################################
 # Create append-only truth-maintenance events table.
 #######################################
 _create_learning_truth_events_table() {
@@ -519,6 +551,7 @@ migrate_db() {
 	_migrate_conversation_summaries
 	_migrate_memory_consolidations
 	_migrate_usefulness_score
+	_migrate_learning_relations_debunks
 	_migrate_learning_truth_events
 	return 0
 }

--- a/.agents/scripts/memory/_common.sh
+++ b/.agents/scripts/memory/_common.sh
@@ -469,6 +469,40 @@ EOF
 }
 
 #######################################
+# Create append-only truth-maintenance events table.
+#######################################
+_create_learning_truth_events_table() {
+	db "$MEMORY_DB" <<'EOF'
+CREATE TABLE IF NOT EXISTS learning_truth_events (
+    event_id TEXT PRIMARY KEY,
+    memory_id TEXT NOT NULL,
+    status TEXT NOT NULL CHECK(status IN ('live', 'debunked', 'retracted')),
+    evidence TEXT,
+    replacement_id TEXT,
+    debunked_by TEXT,
+    created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+CREATE INDEX IF NOT EXISTS idx_learning_truth_memory_created ON learning_truth_events(memory_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_learning_truth_status ON learning_truth_events(status);
+EOF
+	return 0
+}
+
+#######################################
+# Migrate truth-maintenance event schema.
+#######################################
+_migrate_learning_truth_events() {
+	local has_truth_events
+	has_truth_events=$(db "$MEMORY_DB" "SELECT COUNT(*) FROM sqlite_master WHERE type='table' AND name='learning_truth_events';" 2>/dev/null || echo "0")
+	if [[ "$has_truth_events" == "0" ]]; then
+		log_info "Creating learning_truth_events table (truth maintenance)..."
+		_create_learning_truth_events_table
+		log_success "learning_truth_events table created"
+	fi
+	return 0
+}
+
+#######################################
 # Migrate existing database to new schema
 # With backup-before-modify pattern (t188)
 # Note: t311.4 resolved duplicate migrate_db() — this is the single
@@ -485,6 +519,7 @@ migrate_db() {
 	_migrate_conversation_summaries
 	_migrate_memory_consolidations
 	_migrate_usefulness_score
+	_migrate_learning_truth_events
 	return 0
 }
 
@@ -584,10 +619,24 @@ CREATE TABLE IF NOT EXISTS learning_access (
 CREATE TABLE IF NOT EXISTS learning_relations (
     id TEXT NOT NULL,
     supersedes_id TEXT,
-    relation_type TEXT CHECK(relation_type IN ('updates', 'extends', 'derives')),
+    relation_type TEXT CHECK(relation_type IN ('updates', 'extends', 'derives', 'debunks')),
     created_at TEXT DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (id, supersedes_id, relation_type)
 );
+
+-- Append-only truth-maintenance events. FTS5 rows stay immutable; this table
+-- records validity changes such as debunking/retraction with evidence.
+CREATE TABLE IF NOT EXISTS learning_truth_events (
+    event_id TEXT PRIMARY KEY,
+    memory_id TEXT NOT NULL,
+    status TEXT NOT NULL CHECK(status IN ('live', 'debunked', 'retracted')),
+    evidence TEXT,
+    replacement_id TEXT,
+    debunked_by TEXT,
+    created_at TEXT DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+);
+CREATE INDEX IF NOT EXISTS idx_learning_truth_memory_created ON learning_truth_events(memory_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_learning_truth_status ON learning_truth_events(status);
 
 -- Learning-entity junction table (t1363.3) — links learnings to entities
 -- Enables entity-scoped memory queries (e.g., "what do I know about this person?")

--- a/.agents/scripts/memory/maintenance.sh
+++ b/.agents/scripts/memory/maintenance.sh
@@ -211,6 +211,33 @@ EOF
 		log_info "$superseded_count memories have been superseded by newer versions"
 	fi
 
+	# Check truth-maintenance state (debunked/retracted memories and relation health)
+	local debunked_count retracted_count orphaned_truth_count orphaned_relation_count
+	debunked_count=$(db "$MEMORY_DB" "SELECT COUNT(*) FROM learning_truth_events e WHERE e.status = 'debunked' AND e.created_at = (SELECT MAX(created_at) FROM learning_truth_events latest WHERE latest.memory_id = e.memory_id);" 2>/dev/null || echo "0")
+	retracted_count=$(db "$MEMORY_DB" "SELECT COUNT(*) FROM learning_truth_events e WHERE e.status = 'retracted' AND e.created_at = (SELECT MAX(created_at) FROM learning_truth_events latest WHERE latest.memory_id = e.memory_id);" 2>/dev/null || echo "0")
+	orphaned_truth_count=$(db "$MEMORY_DB" "SELECT COUNT(*) FROM learning_truth_events e LEFT JOIN learnings l ON e.memory_id = l.id WHERE l.id IS NULL;" 2>/dev/null || echo "0")
+	orphaned_relation_count=$(db "$MEMORY_DB" "SELECT COUNT(*) FROM learning_relations lr LEFT JOIN learnings child ON lr.id = child.id LEFT JOIN learnings parent ON lr.supersedes_id = parent.id WHERE child.id IS NULL OR (lr.supersedes_id IS NOT NULL AND parent.id IS NULL);" 2>/dev/null || echo "0")
+
+	log_info "Truth maintenance: ${debunked_count:-0} debunked, ${retracted_count:-0} retracted, ${superseded_count:-0} superseded"
+	if [[ "${orphaned_truth_count:-0}" -gt 0 ]]; then
+		log_warn "Found $orphaned_truth_count orphaned truth event(s) pointing at missing memories"
+	fi
+	if [[ "${orphaned_relation_count:-0}" -gt 0 ]]; then
+		log_warn "Found $orphaned_relation_count orphaned relation(s) pointing at missing memories"
+	fi
+
+	if [[ "${debunked_count:-0}" -gt 0 || "${superseded_count:-0}" -gt 0 ]]; then
+		echo ""
+		echo "Truth-maintenance chains:"
+		db "$MEMORY_DB" <<'EOF'
+SELECT '  ' || lr.supersedes_id || ' --' || lr.relation_type || '--> ' || lr.id
+FROM learning_relations lr
+WHERE lr.relation_type IN ('updates', 'debunks')
+ORDER BY lr.created_at DESC
+LIMIT 10;
+EOF
+	fi
+
 	# Check database size
 	local db_size
 	db_size=$(du -h "$MEMORY_DB" | cut -f1)

--- a/.agents/scripts/memory/recall.sh
+++ b/.agents/scripts/memory/recall.sh
@@ -286,12 +286,26 @@ SELECT
     COALESCE(learning_access.access_count, 0) as access_count,
     COALESCE(learning_access.auto_captured, 0) as auto_captured,
     COALESCE(learning_access.usefulness_score, 0.0) as usefulness_score,
+    COALESCE(latest_truth.status, 'live') as truth_status,
+    COALESCE(latest_truth.evidence, '') as truth_evidence,
+    COALESCE(latest_truth.replacement_id, '') as replacement_id,
+    COALESCE(superseded_by.id, '') as superseded_by,
     bm25(learnings) as bm25_score,
     (bm25(learnings) - (COALESCE(learning_access.usefulness_score, 0.0) * 0.3)) as score
 FROM learnings
 LEFT JOIN learning_access ON learnings.id = learning_access.id
+LEFT JOIN learning_truth_events latest_truth ON latest_truth.event_id = (
+    SELECT event_id FROM learning_truth_events truth_pick
+    WHERE truth_pick.memory_id = learnings.id
+    ORDER BY truth_pick.created_at DESC, truth_pick.event_id DESC
+    LIMIT 1
+)
+LEFT JOIN learning_relations superseded_by ON superseded_by.supersedes_id = learnings.id
+    AND superseded_by.relation_type = 'updates'
 $entity_fts_join
 WHERE learnings MATCH :query $extra_filters $auto_join_filter $entity_fts_where
+AND COALESCE(latest_truth.status, 'live') NOT IN ('debunked', 'retracted')
+AND superseded_by.id IS NULL
 ORDER BY score
 LIMIT $limit;
 EOF
@@ -393,7 +407,7 @@ _recall_recent() {
 	local format="$6"
 
 	local results
-	results=$(db -json "$db_path" "SELECT l.id, l.content, l.type, l.tags, l.confidence, l.created_at, COALESCE(a.last_accessed_at, '') as last_accessed_at, COALESCE(a.access_count, 0) as access_count, COALESCE(a.auto_captured, 0) as auto_captured, COALESCE(a.usefulness_score, 0.0) as usefulness_score FROM learnings l LEFT JOIN learning_access a ON l.id = a.id $entity_join WHERE 1=1 $entity_where $auto_filter ORDER BY l.created_at DESC LIMIT $limit;")
+	results=$(db -json "$db_path" "SELECT l.id, l.content, l.type, l.tags, l.confidence, l.created_at, COALESCE(a.last_accessed_at, '') as last_accessed_at, COALESCE(a.access_count, 0) as access_count, COALESCE(a.auto_captured, 0) as auto_captured, COALESCE(a.usefulness_score, 0.0) as usefulness_score, COALESCE(latest_truth.status, 'live') as truth_status, COALESCE(latest_truth.evidence, '') as truth_evidence, COALESCE(latest_truth.replacement_id, '') as replacement_id, COALESCE(superseded_by.id, '') as superseded_by FROM learnings l LEFT JOIN learning_access a ON l.id = a.id LEFT JOIN learning_truth_events latest_truth ON latest_truth.event_id = (SELECT event_id FROM learning_truth_events truth_pick WHERE truth_pick.memory_id = l.id ORDER BY truth_pick.created_at DESC, truth_pick.event_id DESC LIMIT 1) LEFT JOIN learning_relations superseded_by ON superseded_by.supersedes_id = l.id AND superseded_by.relation_type = 'updates' $entity_join WHERE 1=1 $entity_where $auto_filter AND COALESCE(latest_truth.status, 'live') NOT IN ('debunked', 'retracted') AND superseded_by.id IS NULL ORDER BY l.created_at DESC LIMIT $limit;")
 	if [[ "$format" == "json" ]]; then
 		printf '%s\n' "$results"
 	else
@@ -830,6 +844,8 @@ EOF
 #   led_to_new (+0.6) — a new memory was created after retrieving this one
 #   reused     (+0.4) — same memory recalled across different queries in session
 #   dead_end   (-0.15) — retrieved in top results but no follow-up action
+#   false      (-2.0) — retrieved memory was false/debunked
+#   debunked   (-2.0) — alias for false
 #
 # Usage:
 #   memory-helper.sh feedback <memory_id> [--signal <type>] [--value <float>]
@@ -888,9 +904,10 @@ cmd_feedback() {
 		led_to_new) reward="0.6" ;;
 		reused) reward="0.4" ;;
 		dead_end) reward="-0.15" ;;
+		false | debunked) reward="-2.0" ;;
 		*)
 			log_error "Unknown signal type: $signal"
-			log_error "Valid signals: cited, edited, led_to_new, reused, dead_end"
+			log_error "Valid signals: cited, edited, led_to_new, reused, dead_end, false, debunked"
 			return 1
 			;;
 		esac
@@ -898,13 +915,13 @@ cmd_feedback() {
 
 	# Upsert: create learning_access row if missing, then update usefulness_score.
 	# Score is additive (EMA-like accumulation) — each feedback event shifts the
-	# score. Floor at -1.0 to prevent a few dead_end signals from permanently
-	# burying a memory that might be useful in a different context.
+	# score. Floor at -5.0 so false/debunked signals can strongly demote myth-like
+	# memories while still keeping the audit trail intact.
 	db "$MEMORY_DB" <<EOF
 INSERT INTO learning_access (id, last_accessed_at, access_count, usefulness_score)
-VALUES ('$escaped_id', datetime('now'), 0, MAX(-1.0, $reward))
+VALUES ('$escaped_id', datetime('now'), 0, MAX(-5.0, $reward))
 ON CONFLICT(id) DO UPDATE SET
-    usefulness_score = MAX(-1.0, COALESCE(usefulness_score, 0.0) + $reward);
+    usefulness_score = MAX(-5.0, COALESCE(usefulness_score, 0.0) + $reward);
 EOF
 
 	local new_score

--- a/.agents/scripts/memory/store.sh
+++ b/.agents/scripts/memory/store.sh
@@ -24,6 +24,9 @@ _store_supersedes_id=""
 _store_relation_type=""
 _store_auto_captured=0
 _store_entity_id=""
+_store_debunks_id=""
+_store_evidence=""
+_store_replacement_id=""
 
 #######################################
 # Parse CLI arguments into _store_* module variables.
@@ -42,6 +45,9 @@ _store_parse_args() {
 	_store_relation_type=""
 	_store_auto_captured=0
 	_store_entity_id=""
+	_store_debunks_id=""
+	_store_evidence=""
+	_store_replacement_id=""
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
@@ -92,6 +98,21 @@ _store_parse_args() {
 			;;
 		--entity)
 			_store_entity_id="$2"
+			shift 2
+			;;
+		--debunks | --debunk)
+			local debunks_arg="$2"
+			_store_debunks_id="$debunks_arg"
+			shift 2
+			;;
+		--evidence)
+			local evidence_arg="$2"
+			_store_evidence="$evidence_arg"
+			shift 2
+			;;
+		--replacement)
+			local replacement_arg="$2"
+			_store_replacement_id="$replacement_arg"
 			shift 2
 			;;
 		*)
@@ -180,6 +201,15 @@ _store_validate_params() {
 		fi
 	fi
 
+	if [[ -n "$_store_debunks_id" ]]; then
+		if [[ -n "$_store_supersedes_id" && "$_store_supersedes_id" != "$_store_debunks_id" ]]; then
+			log_error "--debunks cannot be combined with a different --supersedes target"
+			return 1
+		fi
+		_store_supersedes_id="$_store_debunks_id"
+		_store_relation_type="debunks"
+	fi
+
 	return 0
 }
 
@@ -230,6 +260,16 @@ _store_prepare_metadata() {
 		fi
 	fi
 
+	if [[ -n "$_store_replacement_id" ]]; then
+		local replacement_exists
+		local esc_replacement="${_store_replacement_id//"'"/"''"}"
+		replacement_exists=$(db "$MEMORY_DB" "SELECT COUNT(*) FROM learnings WHERE id = '$esc_replacement';")
+		if [[ "$replacement_exists" == "0" ]]; then
+			log_error "Replacement ID not found: $_store_replacement_id"
+			return 1
+		fi
+	fi
+
 	return 0
 }
 
@@ -260,6 +300,21 @@ INSERT INTO learning_relations (id, supersedes_id, relation_type, created_at)
 VALUES ('$_store_id', '$_store_esc_supersedes', '$_store_relation_type', '$_store_created_at');
 EOF
 		log_info "Relation: $_store_id $_store_relation_type $_store_supersedes_id"
+	fi
+
+	# Store append-only truth event when this learning debunks another memory.
+	if [[ -n "$_store_debunks_id" ]]; then
+		local _store_truth_event_id="truth_${_store_id#mem_}"
+		local _store_esc_debunks="${_store_debunks_id//"'"/"''"}"
+		local _store_esc_evidence="${_store_evidence:-$_store_content}"
+		_store_esc_evidence="${_store_esc_evidence//"'"/"''"}"
+		local _store_truth_replacement="${_store_replacement_id:-$_store_id}"
+		local _store_esc_replacement="${_store_truth_replacement//"'"/"''"}"
+		db "$MEMORY_DB" <<EOF
+INSERT INTO learning_truth_events (event_id, memory_id, status, evidence, replacement_id, debunked_by, created_at)
+VALUES ('$_store_truth_event_id', '$_store_esc_debunks', 'debunked', '$_store_esc_evidence', '$_store_esc_replacement', '$_store_id', '$_store_created_at');
+EOF
+		log_info "Truth event: $_store_debunks_id debunked by $_store_id"
 	fi
 
 	# Link to entity if --entity was provided (t1363.3)
@@ -321,7 +376,7 @@ cmd_store() {
 	init_db
 
 	# Deduplication: skip if content already exists (unless it's a relational update)
-	if [[ -z "$_store_supersedes_id" ]]; then
+	if [[ -z "$_store_supersedes_id" && -z "$_store_debunks_id" ]]; then
 		local existing_id
 		if existing_id=$(check_duplicate "$_store_content" "$_store_type"); then
 			log_warn "Duplicate detected (matches $existing_id). Skipping store."

--- a/tests/test-memory-truth-maintenance.sh
+++ b/tests/test-memory-truth-maintenance.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-memory-truth-maintenance.sh — Tests for memory debunk/truth workflow.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)" || exit
+MEMORY_HELPER="$REPO_ROOT/.agents/scripts/memory-helper.sh"
+
+TESTS_RUN=0
+TESTS_PASSED=0
+TESTS_FAILED=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() {
+	local name="$1"
+	TESTS_PASSED=$((TESTS_PASSED + 1))
+	echo -e "${GREEN}PASS${NC} $name"
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local reason="${2:-}"
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	echo -e "${RED}FAIL${NC} $name${reason:+ — $reason}"
+	return 0
+}
+
+setup_memory_dir() {
+	local test_dir
+	test_dir=$(mktemp -d)
+	printf '%s\n' "$test_dir"
+	return 0
+}
+
+run_memory() {
+	local memory_dir="$1"
+	shift
+	AIDEVOPS_MEMORY_DIR="$memory_dir" "$MEMORY_HELPER" "$@"
+	return $?
+}
+
+test_debunk_suppresses_recall() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	local test_dir
+	test_dir=$(setup_memory_dir)
+
+	local myth_id live_id debunk_id results
+	myth_id=$(run_memory "$test_dir" store --content "mythical pulse bug alpha marker causes false outage" --type FAILURE_PATTERN --confidence high --tags "truth-test")
+	live_id=$(run_memory "$test_dir" store --content "verified pulse alpha marker current source shows healthy dispatch" --type WORKING_SOLUTION --confidence high --tags "truth-test")
+	debunk_id=$(run_memory "$test_dir" store --content "Evidence: current deployed source disproves the mythical alpha marker outage" --type ERROR_FIX --confidence high --debunks "$myth_id" --replacement "$live_id" --evidence "Verified current source and runtime evidence")
+
+	run_memory "$test_dir" feedback "$myth_id" --signal false >/dev/null
+	results=$(run_memory "$test_dir" recall --query "alpha marker" --json)
+
+	if echo "$results" | jq -e --arg myth_id "$myth_id" 'map(.id) | index($myth_id) | not' >/dev/null && \
+		echo "$results" | jq -e --arg live_id "$live_id" 'map(.id) | index($live_id) != null' >/dev/null; then
+		pass "debunked memory suppressed while live replacement remains discoverable"
+	else
+		fail "debunked memory suppressed while live replacement remains discoverable" "results=$results debunk=$debunk_id"
+	fi
+
+	rm -rf "$test_dir"
+	return 0
+}
+
+test_debunk_relation_and_truth_event() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	local test_dir
+	test_dir=$(setup_memory_dir)
+
+	local myth_id debunk_id relation_count event_count
+	myth_id=$(run_memory "$test_dir" store --content "obsolete claim beta marker is always broken" --type FAILURE_PATTERN --confidence medium)
+	debunk_id=$(run_memory "$test_dir" store --content "Evidence: beta marker claim is false" --type ERROR_FIX --debunks "$myth_id" --evidence "Regression test passed")
+
+	relation_count=$(sqlite3 "$test_dir/memory.db" "SELECT COUNT(*) FROM learning_relations WHERE id = '$debunk_id' AND supersedes_id = '$myth_id' AND relation_type = 'debunks';")
+	event_count=$(sqlite3 "$test_dir/memory.db" "SELECT COUNT(*) FROM learning_truth_events WHERE memory_id = '$myth_id' AND status = 'debunked' AND debunked_by = '$debunk_id';")
+
+	if [[ "$relation_count" == "1" && "$event_count" == "1" ]]; then
+		pass "debunk relation and truth event recorded"
+	else
+		fail "debunk relation and truth event recorded" "relations=$relation_count events=$event_count"
+	fi
+
+	rm -rf "$test_dir"
+	return 0
+}
+
+test_updates_hide_superseded_memory() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	local test_dir
+	test_dir=$(setup_memory_dir)
+
+	local old_id new_id results
+	old_id=$(run_memory "$test_dir" store --content "gamma deployment command uses old flag" --type TOOL_CONFIG --confidence medium)
+	new_id=$(run_memory "$test_dir" store --content "gamma deployment command uses new flag" --type TOOL_CONFIG --confidence high --supersedes "$old_id" --relation updates)
+	results=$(run_memory "$test_dir" recall --query "gamma deployment command flag" --json)
+
+	if echo "$results" | jq -e --arg old_id "$old_id" --arg new_id "$new_id" 'map(.id) as $ids | ($ids | index($old_id) | not) and ($ids | index($new_id) != null)' >/dev/null; then
+		pass "superseded memory hidden while update remains discoverable"
+	else
+		fail "superseded memory hidden while update remains discoverable" "results=$results"
+	fi
+
+	rm -rf "$test_dir"
+	return 0
+}
+
+test_validate_reports_truth_state() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	local test_dir
+	test_dir=$(setup_memory_dir)
+
+	local myth_id output
+	myth_id=$(run_memory "$test_dir" store --content "delta myth should be debunked" --type FAILURE_PATTERN)
+	run_memory "$test_dir" store --content "delta myth evidence" --type ERROR_FIX --debunks "$myth_id" >/dev/null
+	output=$(run_memory "$test_dir" validate)
+
+	if [[ "$output" == *"Truth maintenance:"* && "$output" == *"debunked"* ]]; then
+		pass "validate reports truth-maintenance counts"
+	else
+		fail "validate reports truth-maintenance counts" "output=$output"
+	fi
+
+	rm -rf "$test_dir"
+	return 0
+}
+
+main() {
+	echo ""
+	echo "=== Memory Truth Maintenance Tests ==="
+	echo ""
+
+	test_debunk_suppresses_recall
+	test_debunk_relation_and_truth_event
+	test_updates_hide_superseded_memory
+	test_validate_reports_truth_state
+
+	echo ""
+	echo "=== Results: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed ==="
+	echo ""
+
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/tests/test-memory-truth-maintenance.sh
+++ b/tests/test-memory-truth-maintenance.sh
@@ -62,6 +62,23 @@ store_memory_id() {
 	return 0
 }
 
+json_payload() {
+	local output="$1"
+	local line=""
+	local json=""
+	local capturing=0
+	while IFS= read -r line; do
+		if [[ "$line" == \[* ]]; then
+			capturing=1
+		fi
+		if [[ "$capturing" -eq 1 ]]; then
+			json+="$line"$'\n'
+		fi
+	done <<<"$output"
+	printf '%s' "$json"
+	return 0
+}
+
 test_debunk_suppresses_recall() {
 	TESTS_RUN=$((TESTS_RUN + 1))
 	local test_dir
@@ -73,7 +90,7 @@ test_debunk_suppresses_recall() {
 	debunk_id=$(store_memory_id "$test_dir" --content "Evidence: current deployed source disproves the mythical alpha marker outage" --type ERROR_FIX --confidence high --debunks "$myth_id" --replacement "$live_id" --evidence "Verified current source and runtime evidence")
 
 	run_memory "$test_dir" feedback "$myth_id" --signal false >/dev/null
-	results=$(run_memory "$test_dir" recall --query "alpha marker" --json)
+	results=$(json_payload "$(run_memory "$test_dir" recall --query "alpha marker" --json)")
 
 	if echo "$results" | jq -e --arg myth_id "$myth_id" 'map(.id) | index($myth_id) | not' >/dev/null && \
 		echo "$results" | jq -e --arg live_id "$live_id" 'map(.id) | index($live_id) != null' >/dev/null; then
@@ -116,7 +133,7 @@ test_updates_hide_superseded_memory() {
 	local old_id new_id results
 	old_id=$(store_memory_id "$test_dir" --content "gamma deployment command uses old flag" --type TOOL_CONFIG --confidence medium)
 	new_id=$(store_memory_id "$test_dir" --content "gamma deployment command uses new flag" --type TOOL_CONFIG --confidence high --supersedes "$old_id" --relation updates)
-	results=$(run_memory "$test_dir" recall --query "gamma deployment command flag" --json)
+	results=$(json_payload "$(run_memory "$test_dir" recall --query "gamma deployment command flag" --json)")
 
 	if echo "$results" | jq -e --arg old_id "$old_id" --arg new_id "$new_id" 'map(.id) as $ids | ($ids | index($old_id) | not) and ($ids | index($new_id) != null)' >/dev/null; then
 		pass "superseded memory hidden while update remains discoverable"

--- a/tests/test-memory-truth-maintenance.sh
+++ b/tests/test-memory-truth-maintenance.sh
@@ -165,6 +165,49 @@ test_validate_reports_truth_state() {
 	return 0
 }
 
+test_migrates_old_relation_constraint() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	local test_dir
+	test_dir=$(setup_memory_dir)
+	local test_db="$test_dir/memory.db"
+
+	sqlite3 "$test_db" <<'EOF'
+CREATE VIRTUAL TABLE IF NOT EXISTS learnings USING fts5(
+    id UNINDEXED, session_id UNINDEXED, content, type, tags,
+    confidence UNINDEXED, created_at UNINDEXED, event_date UNINDEXED,
+    project_path UNINDEXED, source UNINDEXED,
+    tokenize='porter unicode61'
+);
+CREATE TABLE IF NOT EXISTS learning_access (
+    id TEXT PRIMARY KEY,
+    last_accessed_at TEXT,
+    access_count INTEGER DEFAULT 0,
+    auto_captured INTEGER DEFAULT 0,
+    usefulness_score REAL DEFAULT 0.0
+);
+CREATE TABLE IF NOT EXISTS learning_relations (
+    id TEXT NOT NULL,
+    supersedes_id TEXT,
+    relation_type TEXT CHECK(relation_type IN ('updates', 'extends', 'derives')),
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (id, supersedes_id, relation_type)
+);
+EOF
+
+	run_memory "$test_dir" validate >/dev/null
+	local relation_sql
+	relation_sql=$(sqlite3 "$test_db" "SELECT sql FROM sqlite_master WHERE type='table' AND name='learning_relations';")
+
+	if [[ "$relation_sql" == *"debunks"* ]]; then
+		pass "old learning_relations constraint migrates to allow debunks"
+	else
+		fail "old learning_relations constraint migrates to allow debunks" "sql=$relation_sql"
+	fi
+
+	rm -rf "$test_dir"
+	return 0
+}
+
 main() {
 	echo ""
 	echo "=== Memory Truth Maintenance Tests ==="
@@ -174,6 +217,7 @@ main() {
 	test_debunk_relation_and_truth_event
 	test_updates_hide_superseded_memory
 	test_validate_reports_truth_state
+	test_migrates_old_relation_constraint
 
 	echo ""
 	echo "=== Results: $TESTS_PASSED/$TESTS_RUN passed, $TESTS_FAILED failed ==="

--- a/tests/test-memory-truth-maintenance.sh
+++ b/tests/test-memory-truth-maintenance.sh
@@ -46,15 +46,31 @@ run_memory() {
 	return $?
 }
 
+store_memory_id() {
+	local memory_dir="$1"
+	shift
+	local output=""
+	output=$(run_memory "$memory_dir" store "$@")
+	local line=""
+	local memory_id=""
+	while IFS= read -r line; do
+		if [[ "$line" == mem_* ]]; then
+			memory_id="$line"
+		fi
+	done <<<"$output"
+	printf '%s\n' "$memory_id"
+	return 0
+}
+
 test_debunk_suppresses_recall() {
 	TESTS_RUN=$((TESTS_RUN + 1))
 	local test_dir
 	test_dir=$(setup_memory_dir)
 
 	local myth_id live_id debunk_id results
-	myth_id=$(run_memory "$test_dir" store --content "mythical pulse bug alpha marker causes false outage" --type FAILURE_PATTERN --confidence high --tags "truth-test")
-	live_id=$(run_memory "$test_dir" store --content "verified pulse alpha marker current source shows healthy dispatch" --type WORKING_SOLUTION --confidence high --tags "truth-test")
-	debunk_id=$(run_memory "$test_dir" store --content "Evidence: current deployed source disproves the mythical alpha marker outage" --type ERROR_FIX --confidence high --debunks "$myth_id" --replacement "$live_id" --evidence "Verified current source and runtime evidence")
+	myth_id=$(store_memory_id "$test_dir" --content "mythical pulse bug alpha marker causes false outage" --type FAILURE_PATTERN --confidence high --tags "truth-test")
+	live_id=$(store_memory_id "$test_dir" --content "verified pulse alpha marker current source shows healthy dispatch" --type WORKING_SOLUTION --confidence high --tags "truth-test")
+	debunk_id=$(store_memory_id "$test_dir" --content "Evidence: current deployed source disproves the mythical alpha marker outage" --type ERROR_FIX --confidence high --debunks "$myth_id" --replacement "$live_id" --evidence "Verified current source and runtime evidence")
 
 	run_memory "$test_dir" feedback "$myth_id" --signal false >/dev/null
 	results=$(run_memory "$test_dir" recall --query "alpha marker" --json)
@@ -76,8 +92,8 @@ test_debunk_relation_and_truth_event() {
 	test_dir=$(setup_memory_dir)
 
 	local myth_id debunk_id relation_count event_count
-	myth_id=$(run_memory "$test_dir" store --content "obsolete claim beta marker is always broken" --type FAILURE_PATTERN --confidence medium)
-	debunk_id=$(run_memory "$test_dir" store --content "Evidence: beta marker claim is false" --type ERROR_FIX --debunks "$myth_id" --evidence "Regression test passed")
+	myth_id=$(store_memory_id "$test_dir" --content "obsolete claim beta marker is always broken" --type FAILURE_PATTERN --confidence medium)
+	debunk_id=$(store_memory_id "$test_dir" --content "Evidence: beta marker claim is false" --type ERROR_FIX --debunks "$myth_id" --evidence "Regression test passed")
 
 	relation_count=$(sqlite3 "$test_dir/memory.db" "SELECT COUNT(*) FROM learning_relations WHERE id = '$debunk_id' AND supersedes_id = '$myth_id' AND relation_type = 'debunks';")
 	event_count=$(sqlite3 "$test_dir/memory.db" "SELECT COUNT(*) FROM learning_truth_events WHERE memory_id = '$myth_id' AND status = 'debunked' AND debunked_by = '$debunk_id';")
@@ -98,8 +114,8 @@ test_updates_hide_superseded_memory() {
 	test_dir=$(setup_memory_dir)
 
 	local old_id new_id results
-	old_id=$(run_memory "$test_dir" store --content "gamma deployment command uses old flag" --type TOOL_CONFIG --confidence medium)
-	new_id=$(run_memory "$test_dir" store --content "gamma deployment command uses new flag" --type TOOL_CONFIG --confidence high --supersedes "$old_id" --relation updates)
+	old_id=$(store_memory_id "$test_dir" --content "gamma deployment command uses old flag" --type TOOL_CONFIG --confidence medium)
+	new_id=$(store_memory_id "$test_dir" --content "gamma deployment command uses new flag" --type TOOL_CONFIG --confidence high --supersedes "$old_id" --relation updates)
 	results=$(run_memory "$test_dir" recall --query "gamma deployment command flag" --json)
 
 	if echo "$results" | jq -e --arg old_id "$old_id" --arg new_id "$new_id" 'map(.id) as $ids | ($ids | index($old_id) | not) and ($ids | index($new_id) != null)' >/dev/null; then
@@ -118,8 +134,8 @@ test_validate_reports_truth_state() {
 	test_dir=$(setup_memory_dir)
 
 	local myth_id output
-	myth_id=$(run_memory "$test_dir" store --content "delta myth should be debunked" --type FAILURE_PATTERN)
-	run_memory "$test_dir" store --content "delta myth evidence" --type ERROR_FIX --debunks "$myth_id" >/dev/null
+	myth_id=$(store_memory_id "$test_dir" --content "delta myth should be debunked" --type FAILURE_PATTERN)
+	store_memory_id "$test_dir" --content "delta myth evidence" --type ERROR_FIX --debunks "$myth_id" >/dev/null
 	output=$(run_memory "$test_dir" validate)
 
 	if [[ "$output" == *"Truth maintenance:"* && "$output" == *"debunked"* ]]; then


### PR DESCRIPTION
Resolves #21995

## Summary
- Adds append-only `learning_truth_events` metadata and a `debunks` relation path for marking false/retracted memories without mutating FTS5 rows.
- Suppresses debunked/retracted and superseded memories from default recall before access tracking, while keeping live replacements discoverable.
- Adds stronger false/debunked feedback, validation reporting for truth-maintenance state, docs, and regression coverage.

## Runtime Testing
- Risk: Low/Medium — shell memory workflow and SQLite schema migration.
- Verification: self-assessed with isolated SQLite DB tests and shell lint.

## Testing
- `bash tests/test-memory-truth-maintenance.sh` — 5/5 passed
- `bash tests/test-memory-consolidation.sh` — 11/12 passed, 0 failed; integration LLM test skipped because `ANTHROPIC_API_KEY` was not set
- `shellcheck .agents/scripts/memory-helper.sh .agents/scripts/memory/*.sh .agents/scripts/memory-audit-pulse.sh tests/test-memory-truth-maintenance.sh`
- `npx --yes markdownlint-cli2 .agents/reference/memory.md`

## Key decisions
- Used append-only truth events plus relation metadata so original memory rows remain auditable.
- Rebuilt legacy `learning_relations` CHECK constraints during migration so existing DBs can store `debunks` relations.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.35 plugin for [OpenCode](https://opencode.ai) v1.14.30 with gpt-5.5 spent 47m and 154,676 tokens on this as a headless worker.