### PR TITLE
GH#21936: verify approval signatures in worker merge gate

### DIFF
--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -570,6 +570,30 @@ _is_trusted_issue_author() {
 }
 
 #######################################
+# Verify that a linked issue has a maintainer cryptographic approval (t3052).
+#
+# Marker-string presence is not a trust signal: any user able to comment could
+# paste the marker. This helper delegates to approval-helper.sh, which verifies
+# the SSH signature against the maintainer approval public key.
+#
+# Args: $1=issue_number, $2=repo_slug
+# Returns: 0=verified approval, 1=no verified approval
+#######################################
+_issue_has_verified_crypto_approval() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	[[ -z "$issue_number" || -z "$repo_slug" ]] && return 1
+
+	local approval_helper="${AGENTS_DIR:-$HOME/.aidevops/agents}/scripts/approval-helper.sh"
+	[[ ! -f "$approval_helper" ]] && return 1
+
+	local verify_result=""
+	verify_result=$(bash "$approval_helper" verify "$issue_number" "$repo_slug" 2>/dev/null) || verify_result=""
+	[[ "$verify_result" == "VERIFIED" ]]
+	return $?
+}
+
+#######################################
 # Check origin:worker worker-briefed auto-merge gates (t2449).
 #
 # Sibling to _check_interactive_pr_gates — validates that an origin:worker
@@ -630,9 +654,7 @@ _attempt_worker_briefed_auto_merge() {
 		return 1
 	fi
 
-	# Reuse the issue API base path for author-association, crypto-approval,
-	# and NMR checks — single comment fetch serves both the t3052 bypass
-	# and the t2449 NMR gate.
+	# Reuse the issue API base path for author-association and NMR checks.
 	local _issue_api
 	_issue_api=$(_pm_issue_api "$repo_slug" "$linked_issue")
 	# Fetch author_association and user.login in one API call (t3062 needs login).
@@ -643,19 +665,19 @@ _attempt_worker_briefed_auto_merge() {
 	local issue_author_login=""
 	read -r issue_author_assoc issue_author_login <<< "$_issue_meta"
 
-	# Fetch issue comment signals once — used by both the OWNER/MEMBER
-	# bypass (t3052) and the NMR crypto-vs-auto check (t2449).
-	local _issue_signals
-	_issue_signals=$(gh api "${_issue_api}/comments" --jq '
-		[
-			(any(.[].body | strings; contains("aidevops:approval-signature:"))),
-			(any(.[].body | strings; contains("auto-approved-maintainer-issue")))
-		] | @tsv
-	' 2>/dev/null) || _issue_signals="false	false"
-
-	local _has_crypto=""
+	# Fetch auto-approval signal once for the NMR crypto-vs-auto check (t2449).
+	# Cryptographic approval is verified separately via approval-helper.sh; do not
+	# trust marker-string presence in comments as a security gate.
+	local _not_true_status="not-verified"
 	local _has_auto=""
-	read -r _has_crypto _has_auto <<< "$_issue_signals"
+	_has_auto=$(gh api "${_issue_api}/comments" --jq '
+		any(.[].body | strings; contains("auto-approved-maintainer-issue"))
+	' 2>/dev/null) || _has_auto="$_not_true_status"
+
+	local _has_crypto="$_not_true_status"
+	if _issue_has_verified_crypto_approval "$linked_issue" "$repo_slug"; then
+		_has_crypto="true"
+	fi
 
 	# Gate: linked issue authored by OWNER/MEMBER, OR login is in the
 	# trusted-issue-author allowlist (t3062), OR cryptographically approved

--- a/.agents/scripts/tests/test-pulse-merge-worker-briefed.sh
+++ b/.agents/scripts/tests/test-pulse-merge-worker-briefed.sh
@@ -61,12 +61,16 @@ print_result() {
 setup_test_env() {
 	TEST_ROOT=$(mktemp -d)
 	mkdir -p "${TEST_ROOT}/bin"
+	mkdir -p "${TEST_ROOT}/scripts"
 	export PATH="${TEST_ROOT}/bin:${PATH}"
+	export AGENTS_DIR="${TEST_ROOT}"
 	export LOGFILE="${TEST_ROOT}/pulse.log"
 	: >"$LOGFILE"
 	GH_LOG="${TEST_ROOT}/gh-calls.log"
 	: >"$GH_LOG"
 	export TEST_ROOT GH_LOG
+	APPROVAL_VERIFY_RESULT=""
+	export APPROVAL_VERIFY_RESULT
 
 	# Default issue fixture: author_association=OWNER, no NMR comments
 	printf '{"author_association":"OWNER"}' >"${TEST_ROOT}/issue.json"
@@ -116,6 +120,16 @@ fi
 exit 0
 GHEOF
 	chmod +x "${TEST_ROOT}/bin/gh"
+
+	cat >"${TEST_ROOT}/scripts/approval-helper.sh" <<'APPROVAL_EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "verify" ]]; then
+	printf '%s\n' "${APPROVAL_VERIFY_RESULT:-}"
+	exit 0
+fi
+exit 1
+APPROVAL_EOF
+	chmod +x "${TEST_ROOT}/scripts/approval-helper.sh"
 	return 0
 }
 
@@ -123,6 +137,7 @@ teardown_test_env() {
 	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
 		rm -rf "$TEST_ROOT"
 	fi
+	unset AGENTS_DIR APPROVAL_VERIFY_RESULT
 	return 0
 }
 
@@ -132,7 +147,7 @@ teardown_test_env() {
 # _is_trusted_issue_author and _attempt_worker_briefed_auto_merge live in
 # pulse-merge-process.sh (post-split, t3062 adds the trusted-author helper).
 define_helpers_under_test() {
-	local src_worker_briefed src_issue_api src_trusted_author
+	local src_worker_briefed src_issue_api src_trusted_author src_crypto_approval
 	src_issue_api=$(awk '
 		/^_pm_issue_api\(\) \{/,/^\}$/ { print }
 	' "$MERGE_SCRIPT")
@@ -143,6 +158,9 @@ define_helpers_under_test() {
 	fi
 	src_trusted_author=$(awk '
 		/^_is_trusted_issue_author\(\) \{/,/^\}$/ { print }
+	' "$extract_from")
+	src_crypto_approval=$(awk '
+		/^_issue_has_verified_crypto_approval\(\) \{/,/^\}$/ { print }
 	' "$extract_from")
 	src_worker_briefed=$(awk '
 		/^_attempt_worker_briefed_auto_merge\(\) \{/,/^\}$/ { print }
@@ -155,6 +173,8 @@ define_helpers_under_test() {
 	eval "$src_issue_api"
 	# shellcheck disable=SC1090
 	eval "$src_trusted_author"
+	# shellcheck disable=SC1090
+	eval "$src_crypto_approval"
 	# shellcheck disable=SC1090
 	eval "$src_worker_briefed"
 	return 0
@@ -280,6 +300,7 @@ test_case_e_nmr_crypto_cleared_passes() {
 	printf '{"author_association":"OWNER"}' >"${TEST_ROOT}/issue.json"
 	# Comments contain BOTH auto-approval AND crypto approval markers
 	printf '[{"body":"auto-approved-maintainer-issue: cleared NMR"},{"body":"aidevops:approval-signature: SHA256:abc123"}]' >"${TEST_ROOT}/comments.json"
+	export APPROVAL_VERIFY_RESULT="VERIFIED"
 	export AIDEVOPS_WORKER_BRIEFED_AUTO_MERGE=1
 
 	local result=0
@@ -461,6 +482,7 @@ test_case_k_non_owner_with_crypto_passes() {
 	printf '{"author_association":"NONE"}' >"${TEST_ROOT}/issue.json"
 	# Comments contain crypto approval signature — maintainer vouched
 	printf '[{"body":"aidevops:approval-signature: SHA256:abc123"}]' >"${TEST_ROOT}/comments.json"
+	export APPROVAL_VERIFY_RESULT="VERIFIED"
 	export AIDEVOPS_WORKER_BRIEFED_AUTO_MERGE=1
 
 	local result=0
@@ -611,6 +633,37 @@ test_case_o_trusted_author_not_in_allowlist_blocked() {
 }
 
 # =============================================================================
+# Case (p): issue-author=NONE + spoofed approval marker but failed verification
+# → blocked. Comment marker presence alone is not a trust signal (GH#21936).
+# =============================================================================
+test_case_p_spoofed_crypto_marker_blocked() {
+	setup_test_env
+	define_helpers_under_test || { teardown_test_env; return 0; }
+
+	printf '{"author_association":"NONE"}' >"${TEST_ROOT}/issue.json"
+	printf '[{"body":"aidevops:approval-signature: SHA256:spoofed"}]' >"${TEST_ROOT}/comments.json"
+	export APPROVAL_VERIFY_RESULT=""
+	export AIDEVOPS_WORKER_BRIEFED_AUTO_MERGE=1
+
+	local result=0
+	_attempt_worker_briefed_auto_merge "115" "owner/repo" "origin:worker" "false" "57" && result=0 || result=$?
+
+	if [[ "$result" -eq 0 ]]; then
+		print_result "Case (p): spoofed crypto marker without verification → blocked" 1 \
+			"Expected non-zero exit, got 0 (unverified marker should block)"
+	else
+		if grep -q "no cryptographic approval signature found (t2449/t3052)" "$LOGFILE" 2>/dev/null; then
+			print_result "Case (p): spoofed crypto marker without verification → blocked" 0
+		else
+			print_result "Case (p): spoofed crypto marker without verification → blocked" 1 \
+				"Exit was non-zero but expected block log message not found"
+		fi
+	fi
+	teardown_test_env
+	return 0
+}
+
+# =============================================================================
 # Run all cases
 # =============================================================================
 main() {
@@ -634,6 +687,7 @@ main() {
 	test_case_m_owner_no_crypto_still_passes
 	test_case_n_trusted_author_allowlist_passes
 	test_case_o_trusted_author_not_in_allowlist_blocked
+	test_case_p_spoofed_crypto_marker_blocked
 
 	echo ""
 	printf 'Results: %d/%d passed\n' "$((TESTS_RUN - TESTS_FAILED))" "$TESTS_RUN"


### PR DESCRIPTION
Resolves #21936

## Summary
- Replaces comment-marker presence checks in the worker-briefed merge gate with `approval-helper.sh verify`.
- Keeps auto-approval marker detection only for the NMR crypto-vs-auto gate.
- Adds regression coverage proving a spoofed approval marker does not bypass the gate.

## Runtime Testing
Low risk: shell gate/test-only change; self-assessed with local shell tests.

## Testing
- `shellcheck .agents/scripts/pulse-merge-process.sh .agents/scripts/tests/test-pulse-merge-worker-briefed.sh`
- `.agents/scripts/tests/test-pulse-merge-worker-briefed.sh` → 16/16 passed
- `.agents/scripts/linters-local.sh` attempted; timed out while reporting pre-existing repository-wide string-literal warnings/absolute threshold debt, not a diff-scoped failure.

## Files changed
- `.agents/scripts/pulse-merge-process.sh`
- `.agents/scripts/tests/test-pulse-merge-worker-briefed.sh`

## Key decisions
- Fail closed when the approval helper is unavailable or verification does not return `VERIFIED`; marker strings alone are no longer accepted as crypto approval evidence.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.35 plugin for [OpenCode](https://opencode.ai) v1.14.30 with gpt-5.5 spent 47m and 154,676 tokens on this as a headless worker.
