### PR TITLE
GH#22034: rollback failed release mutations

### DIFF
--- a/.agents/scripts/tests/test-version-manager-release-rollback.sh
+++ b/.agents/scripts/tests/test-version-manager-release-rollback.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-version-manager-release-rollback.sh — GH#22034 regression guard.
+#
+# Asserts that a release failure after version files are bumped but before a
+# release commit/tag is created restores the clean pre-release tree. Without
+# this guard, retrying with --force can advance VERSION twice and release the
+# next+1 patch.
+
+set -uo pipefail
+
+TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_RED=$'\033[0;31m'
+TEST_GREEN=$'\033[0;32m'
+TEST_RESET=$'\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1" rc="$2" extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf '%sPASS%s %s\n' "$TEST_GREEN" "$TEST_RESET" "$name"
+	else
+		printf '%sFAIL%s %s %s\n' "$TEST_RED" "$TEST_RESET" "$name" "$extra"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+export HOME="${TEST_ROOT}/home"
+mkdir -p "${HOME}/.aidevops/logs"
+
+REMOTE_DIR="${TEST_ROOT}/origin.git"
+REPO_DIR="${TEST_ROOT}/repo"
+mkdir -p "$REPO_DIR"
+git init -q --bare "$REMOTE_DIR"
+
+cd "$REPO_DIR" || exit 1
+git init -q -b main
+git config user.email 'test@example.com'
+git config user.name 'Test Runner'
+git config commit.gpgsign false
+
+cat >VERSION <<'EOF'
+1.2.3
+EOF
+cat >CHANGELOG.md <<'EOF'
+# Changelog
+
+## [Unreleased]
+
+## [1.2.3] - 2026-01-01
+
+- Prior release.
+EOF
+cat >package.json <<'EOF'
+{
+  "name": "aidevops-test",
+  "version": "1.2.3"
+}
+EOF
+cat >sonar-project.properties <<'EOF'
+sonar.projectVersion=1.2.3
+EOF
+
+git add VERSION CHANGELOG.md package.json sonar-project.properties
+git commit -q -m 'chore(release): bump version to 1.2.3'
+git tag -a v1.2.3 -m 'Release v1.2.3'
+git remote add origin "$REMOTE_DIR"
+git push -q -u origin main --tags
+
+# Add releasable work so the changelog/commit gate lets release proceed to the
+# mutation phase. Then force a pre-commit validation failure by removing VERSION
+# after bump_version captures the next version, before _release_execute validates.
+cat >feature.txt <<'EOF'
+feature
+EOF
+git add feature.txt
+git commit -q -m 'fix: releasable fixture change'
+git push -q origin main
+
+# Source the release orchestrator and override update_version_in_files to mimic
+# a late pre-commit gate failure after VERSION/package files have changed.
+# shellcheck source=/dev/null
+source "${TEST_SCRIPTS_DIR}/version-manager.sh"
+set +e
+
+update_version_in_files() {
+	local new_version="$1"
+	_update_version_file "$new_version" >/dev/null 2>&1 || return 1
+	_update_package_json_version "$new_version" >/dev/null 2>&1 || return 1
+	rm -f "$VERSION_FILE"
+	return 0
+}
+
+rc=0
+(_main_release patch --skip-preflight >/tmp/version-manager-rollback-test.out 2>&1) || rc=$?
+if [[ "$rc" -ne 0 ]]; then
+	print_result 'release fixture: simulated pre-commit gate fails' 0
+else
+	print_result 'release fixture: simulated pre-commit gate fails' 1 'expected non-zero release exit'
+fi
+
+version_after="missing"
+[[ -f VERSION ]] && version_after=$(cat VERSION)
+package_after=$(jq -r '.version' package.json 2>/dev/null || printf 'jq-failed')
+dirty_after=$(git status --porcelain)
+head_after=$(git log -1 --pretty=%s)
+
+if [[ "$version_after" == "1.2.3" ]]; then
+	print_result 'rollback restores VERSION to original patch target base' 0
+else
+	print_result 'rollback restores VERSION to original patch target base' 1 "got VERSION=$version_after"
+fi
+
+if [[ "$package_after" == "1.2.3" ]]; then
+	print_result 'rollback restores version-managed JSON files' 0
+else
+	print_result 'rollback restores version-managed JSON files' 1 "got package.json version=$package_after"
+fi
+
+if [[ -z "$dirty_after" ]]; then
+	print_result 'rollback leaves working tree clean' 0
+else
+	print_result 'rollback leaves working tree clean' 1 "dirty state: $dirty_after"
+fi
+
+if [[ "$head_after" == 'fix: releasable fixture change' ]]; then
+	print_result 'rollback failure does not create a release commit' 0
+else
+	print_result 'rollback failure does not create a release commit' 1 "HEAD subject=$head_after"
+fi
+
+printf '\nTests run: %s, Failures: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]]

--- a/.agents/scripts/version-manager.sh
+++ b/.agents/scripts/version-manager.sh
@@ -162,6 +162,47 @@ _release_check_changelog() {
 	return 0
 }
 
+# Roll back release file mutations when a pre-commit release gate exits after
+# bumping files. Release starts from a clean tree by default, so restoring the
+# tracked diff on failure returns retries to the same next-version target instead
+# of leaving a half-bumped VERSION behind.
+_release_rollback_mutated_tree() {
+	if [[ "${VERSION_MANAGER_RELEASE_ROLLBACK_ACTIVE:-0}" -ne 1 ]]; then
+		return 0
+	fi
+
+	local changed_files=""
+	changed_files=$(cd "$REPO_ROOT" && git diff --name-only 2>/dev/null || true)
+	if [[ -z "$changed_files" ]]; then
+		return 0
+	fi
+
+	print_warning "Rolling back release file mutations after failed pre-commit release gate"
+	local changed_file=""
+	while IFS= read -r changed_file; do
+		[[ -n "$changed_file" ]] || continue
+		(cd "$REPO_ROOT" && git checkout -- "$changed_file" 2>/dev/null) || true
+	done <<<"$changed_files"
+	return 0
+}
+
+_release_enable_failure_rollback() {
+	VERSION_MANAGER_RELEASE_ROLLBACK_ACTIVE=1
+	trap '_release_rollback_mutated_tree' EXIT
+	return 0
+}
+
+_release_disable_failure_rollback() {
+	VERSION_MANAGER_RELEASE_ROLLBACK_ACTIVE=0
+	trap - EXIT
+	return 0
+}
+
+_release_abort_after_mutation() {
+	_release_rollback_mutated_tree
+	exit 1
+}
+
 # Perform the version bump, file updates, tag, push, and GitHub release.
 # Arguments: bump_type new_version
 _release_execute() {
@@ -199,7 +240,7 @@ _release_execute() {
 		print_error "Failed to update version in all files. Aborting release."
 		print_info "The VERSION file may have been updated. Run validation to check:"
 		print_info "  $0 validate"
-		exit 1
+		_release_abort_after_mutation
 	fi
 
 	print_info "Updating CHANGELOG.md..."
@@ -216,7 +257,7 @@ _release_execute() {
 
 		# t2437/GH#20073: commit the bump, verify HEAD is the bump commit.
 		if ! _release_commit_and_verify_bump "$new_version" "$bump_type"; then
-			exit 1
+			_release_abort_after_mutation
 		fi
 
 		if ! create_git_tag "$new_version"; then
@@ -254,7 +295,7 @@ _release_execute() {
 		print_success "Release $new_version created successfully!"
 	else
 		print_error "Version validation failed. Please fix inconsistencies before creating release."
-		exit 1
+		_release_abort_after_mutation
 	fi
 	return 0
 }
@@ -355,6 +396,7 @@ _main_release() {
 			print_info "Commit your changes first, or use --allow-dirty to bypass"
 			exit 1
 		fi
+		_release_enable_failure_rollback
 	else
 		print_warning "Releasing with uncommitted changes (--allow-dirty)"
 	fi
@@ -383,6 +425,7 @@ _main_release() {
 		if [[ "$hotfix_flag" -eq 1 ]]; then
 			_create_hotfix_tag "$new_version"
 		fi
+		_release_disable_failure_rollback
 	else
 		exit 1
 	fi


### PR DESCRIPTION
## Summary

Added release rollback handling so failed pre-commit release gates restore tracked version file mutations before aborting.

## Files Changed

.agents/scripts/tests/test-version-manager-release-rollback.sh,.agents/scripts/version-manager.sh,.claude-plugin/marketplace.json,CHANGELOG.md,VERSION,aidevops.sh,package.json,setup.sh,sonar-project.properties

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-version-manager-release-rollback.sh; .agents/scripts/tests/test-version-manager-bump-verify.sh; shellcheck .agents/scripts/version-manager.sh .agents/scripts/tests/test-version-manager-release-rollback.sh; .agents/scripts/version-manager.sh release patch --dry-run && git diff --exit-code -- VERSION package.json sonar-project.properties setup.sh aidevops.sh CHANGELOG.md .claude-plugin/marketplace.json

Resolves #22034


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.38 plugin for [OpenCode](https://opencode.ai) v1.14.30 with gpt-5.5 spent 1m and 8,737 tokens on this as a headless worker.