### PR TITLE
t3362: fix OAuth pool rotation for canary preflight

### DIFF
--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -1235,6 +1235,18 @@ _run_canary_test() {
 	if [[ -f "$_oc_auth" ]]; then
 		cp "$_oc_auth" "${_canary_data_dir}/opencode/auth.json" 2>/dev/null || true
 	fi
+	# t3362: Mirror the real worker auth path. A multi-account OAuth pool can
+	# have the shared auth.json pointing at a cooldown/rate-limited account while
+	# another account is healthy. Workers rotate their isolated auth.json before
+	# launch; the canary must do the same or it blocks dispatch with a false
+	# no_worker_process failure before the worker gets a chance to rotate.
+	if [[ -f "${_canary_data_dir}/opencode/auth.json" ]] && declare -F _maybe_rotate_isolated_auth >/dev/null 2>&1; then
+		local _canary_provider
+		_canary_provider=$(extract_provider "$canary_model" 2>/dev/null || printf '%s' "anthropic")
+		[[ -n "$_canary_provider" ]] || _canary_provider="anthropic"
+		XDG_DATA_HOME="$_canary_data_dir" _maybe_rotate_isolated_auth \
+			"${_canary_data_dir}/opencode/auth.json" "$_canary_provider" || true
+	fi
 
 	# Process-tree timeout: the `opencode` npm distribution ships a Node.js
 	# wrapper (#!/usr/bin/env node) that spawns the Go binary (.opencode)

--- a/.agents/scripts/tests/test-oauth-pre-dispatch-rotation.sh
+++ b/.agents/scripts/tests/test-oauth-pre-dispatch-rotation.sh
@@ -19,6 +19,7 @@
 #   2. Cooldown in past (0)    → rotate helper is NOT invoked
 #   3. Missing jq              → exits 0 without action (best-effort guard)
 #   4. Missing pool file       → exits 0 without action (best-effort guard)
+#   7. Canary preflight        → invokes the same isolated rotation path before opencode
 #
 # Strategy: extract the function definition via `declare -f` from a
 # subshell source (side-effect-isolated), then eval it into the test
@@ -315,6 +316,32 @@ else
 	fail "unknown-access expectations not met (rc=$rc, access=$unchanged_access, calls=$stub_calls)"
 fi
 rm -rf "$fixture"
+
+# --- Test 7: canary preflight wires isolated OAuth rotation before opencode --
+#
+# Guards t3362: the canary copies auth.json into an isolated XDG_DATA_HOME just
+# like workers do. It must rotate that isolated file before running `opencode
+# run`, otherwise a cooldown-marked shared Anthropic account makes the canary
+# fail and dispatch reports `launch_recovery:no_worker_process` even when a
+# healthy second OAuth account is available.
+
+LIB_FILE="${SCRIPTS_DIR}/headless-runtime-lib.sh"
+canary_wiring=$(awk '
+	/_canary_data_dir=\$\(mktemp -d/ { in_canary=1 }
+	in_canary && /_maybe_rotate_isolated_auth/ { rotate_line=NR }
+	in_canary && /"\$_effective_opencode_bin" run "Reply with exactly: CANARY_OK"/ { opencode_line=NR }
+	END {
+		if (rotate_line > 0 && opencode_line > 0 && rotate_line < opencode_line) {
+			print "ok"
+		}
+	}
+' "$LIB_FILE" 2>/dev/null || true)
+
+if [[ "$canary_wiring" == "ok" ]]; then
+	pass "canary preflight rotates isolated OAuth auth before opencode run"
+else
+	fail "canary preflight must call _maybe_rotate_isolated_auth before opencode run"
+fi
 
 # --- Summary ----------------------------------------------------------------
 

--- a/TODO.md
+++ b/TODO.md
@@ -876,6 +876,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [ ] t3257 Reconstruct PR 21876 worker-loop timeline #auto-dispatch #framework #investigation ref:GH#22041
 
+- [ ] t3362 fix OAuth pool rotation for canary preflight #bug ref:GH#22065
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary
- Rotate the canary's isolated OpenCode OAuth auth file before running `opencode run`, matching the real worker launch path.
- Add regression coverage so canary preflight cannot bypass isolated OAuth rotation again.

## Root cause
The AwardsApp runner symptoms showed repeated `launch_recovery:no_worker_process` from `alex-solovyev` before worker PID comments appeared. On a two-account Anthropic OAuth pool, the shared auth file can point at a cooldown/rate-limited account while a second account is healthy. Real workers already rotate their isolated auth before launch, but the canary copied auth.json into a temp XDG data dir and tested OpenCode without rotation, so dispatch could fail before the worker got a chance to use the healthy account.

## Verification
- `bash .agents/scripts/tests/test-oauth-pre-dispatch-rotation.sh` — 7/7 passed
- `bash .agents/scripts/tests/test-oauth-interactive-unaffected.sh` — 4/4 passed
- `shellcheck .agents/scripts/headless-runtime-lib.sh .agents/scripts/tests/test-oauth-pre-dispatch-rotation.sh`

Resolves #22065
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.42 plugin for [OpenCode](https://opencode.ai) v1.14.30 with gpt-5.5 spent 14m and 310,888 tokens on this as a headless worker.