### PR TITLE
GH#22052: serialize noninteractive setup deployments

### DIFF
--- a/.agents/scripts/tests/test-setup-noninteractive-lock.sh
+++ b/.agents/scripts/tests/test-setup-noninteractive-lock.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+SETUP_SCRIPT="${REPO_ROOT}/setup.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+print_warning() {
+	local message="$1"
+	printf '[WARNING] %s\n' "$message"
+	return 0
+}
+
+print_error() {
+	local message="$1"
+	printf '[ERROR] %s\n' "$message"
+	return 0
+}
+
+load_lock_functions() {
+	local helper_definition=""
+	helper_definition="$(awk '
+		/^SETUP_NONINTERACTIVE_LOCK_HELD=/ { in_block=1 }
+		in_block { print }
+		in_block && /^# Non-interactive path:/ { exit }
+	' "$SETUP_SCRIPT")"
+
+	if [[ -z "$helper_definition" ]]; then
+		printf 'failed to load lock helpers from %s\n' "$SETUP_SCRIPT" >&2
+		return 1
+	fi
+
+	eval "$helper_definition"
+	return 0
+}
+
+make_temp_dir() {
+	local tmp_dir=""
+	tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/aidevops-setup-lock-test.XXXXXX")
+	printf '%s' "$tmp_dir"
+	return 0
+}
+
+test_blocks_concurrent_live_owner() {
+	local tmp_dir=""
+	local output=""
+	local exit_code=0
+	tmp_dir=$(make_temp_dir)
+	mkdir -p "$tmp_dir/lock.d"
+	printf '%s\n' "$$" >"$tmp_dir/lock.d/owner.pid"
+	printf '%s\n' './setup.sh --non-interactive' >"$tmp_dir/lock.d/command"
+
+	output=$(
+		AIDEVOPS_SETUP_LOCK_DIR="$tmp_dir/lock.d"
+		load_lock_functions
+		_setup_acquire_noninteractive_setup_lock --non-interactive
+		exit_code=$?
+		printf 'exit=%s held=%s output-done\n' "$exit_code" "${SETUP_NONINTERACTIVE_LOCK_HELD:-false}"
+		return 0
+	) 2>&1 || true
+
+	rm -rf "$tmp_dir"
+	if [[ "$output" == *"Another setup.sh --non-interactive process is already running"* && "$output" == *"exit=75 held=false"* ]]; then
+		print_result "live non-interactive setup lock blocks overlap" 0
+		return 0
+	fi
+
+	print_result "live non-interactive setup lock blocks overlap" 1 "output=${output}"
+	return 0
+}
+
+test_reclaims_stale_lock() {
+	local tmp_dir=""
+	local output=""
+	tmp_dir=$(make_temp_dir)
+	mkdir -p "$tmp_dir/lock.d"
+	printf '%s\n' '999999' >"$tmp_dir/lock.d/owner.pid"
+
+	output=$(
+		AIDEVOPS_SETUP_LOCK_DIR="$tmp_dir/lock.d"
+		load_lock_functions
+		_setup_acquire_noninteractive_setup_lock --non-interactive
+		printf 'held=%s owner=%s\n' "${SETUP_NONINTERACTIVE_LOCK_HELD:-false}" "$(tr -d '[:space:]' <"$tmp_dir/lock.d/owner.pid")"
+		_setup_release_noninteractive_setup_lock
+		printf 'exists=%s\n' "$([[ -d "$tmp_dir/lock.d" ]] && printf yes || printf no)"
+		return 0
+	) 2>&1 || true
+
+	rm -rf "$tmp_dir"
+	if [[ "$output" == *"Removing stale setup.sh --non-interactive lock"* && "$output" == *"held=true owner="* && "$output" == *"exists=no"* ]]; then
+		print_result "stale non-interactive setup lock is reclaimed" 0
+		return 0
+	fi
+
+	print_result "stale non-interactive setup lock is reclaimed" 1 "output=${output}"
+	return 0
+}
+
+test_signal_cleanup_terminates_registered_children() {
+	local output=""
+
+	output=$(
+		load_lock_functions
+		sleep 30 &
+		local_pid=$!
+		_setup_register_child_pid "$local_pid"
+		SETUP_NONINTERACTIVE_TERMINATING=true
+		_setup_cleanup_noninteractive_children
+		if kill -0 "$local_pid" 2>/dev/null; then
+			printf 'child=alive\n'
+		else
+			printf 'child=stopped\n'
+		fi
+		return 0
+	) 2>&1 || true
+
+	if [[ "$output" == *"child=stopped"* ]]; then
+		print_result "termination cleanup stops registered setup children" 0
+		return 0
+	fi
+
+	print_result "termination cleanup stops registered setup children" 1 "output=${output}"
+	return 0
+}
+
+main() {
+	test_blocks_concurrent_live_owner
+	test_reclaims_stale_lock
+	test_signal_cleanup_terminates_registered_children
+
+	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -ne 0 ]]; then
+		exit 1
+	fi
+
+	return 0
+}
+
+main "$@"

--- a/setup.sh
+++ b/setup.sh
@@ -1124,6 +1124,107 @@ setup_cases_planes() {
 	return 0
 }
 
+# Non-interactive setup singleton state. This lock only gates the deployment path;
+# interactive setup remains prompt-driven and can still be used for first-run init.
+SETUP_NONINTERACTIVE_LOCK_HELD=false
+SETUP_NONINTERACTIVE_LOCK_DIR=""
+SETUP_NONINTERACTIVE_CHILD_PIDS=""
+SETUP_NONINTERACTIVE_TERMINATING=false
+
+_setup_lock_pid_alive() {
+	local pid="$1"
+	[[ "$pid" =~ ^[0-9]+$ ]] || return 1
+	kill -0 "$pid" 2>/dev/null
+	return $?
+}
+
+_setup_register_child_pid() {
+	local pid="$1"
+	[[ -n "$pid" ]] || return 0
+	SETUP_NONINTERACTIVE_CHILD_PIDS="${SETUP_NONINTERACTIVE_CHILD_PIDS}${SETUP_NONINTERACTIVE_CHILD_PIDS:+ }${pid}"
+	return 0
+}
+
+_setup_cleanup_noninteractive_children() {
+	local pid=""
+	[[ "${SETUP_NONINTERACTIVE_TERMINATING:-false}" == "true" ]] || return 0
+	for pid in ${SETUP_NONINTERACTIVE_CHILD_PIDS:-}; do
+		if _setup_lock_pid_alive "$pid"; then
+			kill -TERM "$pid" 2>/dev/null || true
+		fi
+	done
+	for pid in ${SETUP_NONINTERACTIVE_CHILD_PIDS:-}; do
+		wait "$pid" 2>/dev/null || true
+	done
+	return 0
+}
+
+_setup_release_noninteractive_setup_lock() {
+	local lock_dir="${SETUP_NONINTERACTIVE_LOCK_DIR:-}"
+	local owner_pid=""
+	if [[ "${SETUP_NONINTERACTIVE_LOCK_HELD:-false}" != "true" || -z "$lock_dir" ]]; then
+		return 0
+	fi
+	if [[ -r "$lock_dir/owner.pid" ]]; then
+		owner_pid=$(tr -d '[:space:]' <"$lock_dir/owner.pid" 2>/dev/null || true)
+	fi
+	if [[ -z "$owner_pid" || "$owner_pid" == "$$" ]]; then
+		rm -rf "$lock_dir" 2>/dev/null || true
+	fi
+	SETUP_NONINTERACTIVE_LOCK_HELD=false
+	return 0
+}
+
+_setup_noninteractive_signal_exit() {
+	local signal_name="$1"
+	local exit_code=143
+	[[ "$signal_name" == "INT" ]] && exit_code=130
+	SETUP_NONINTERACTIVE_TERMINATING=true
+	print_warning "setup.sh --non-interactive received ${signal_name}; cleaning up child deployment processes"
+	_setup_cleanup_noninteractive_children
+	_setup_release_noninteractive_setup_lock
+	exit "$exit_code"
+}
+
+_setup_acquire_noninteractive_setup_lock() {
+	local lock_dir="${AIDEVOPS_SETUP_LOCK_DIR:-$HOME/.aidevops/locks/setup-noninteractive.lock.d}"
+	local owner_pid=""
+	local owner_cmd=""
+	local attempts=0
+	mkdir -p "$(dirname "$lock_dir")" 2>/dev/null || true
+	while [[ "$attempts" -lt 2 ]]; do
+		if mkdir "$lock_dir" 2>/dev/null; then
+			SETUP_NONINTERACTIVE_LOCK_DIR="$lock_dir"
+			SETUP_NONINTERACTIVE_LOCK_HELD=true
+			printf '%s\n' "$$" >"$lock_dir/owner.pid" 2>/dev/null || true
+			printf '%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >"$lock_dir/started_at" 2>/dev/null || true
+			printf '%s\n' "$0 $*" >"$lock_dir/command" 2>/dev/null || true
+			trap _setup_release_noninteractive_setup_lock EXIT
+			trap '_setup_noninteractive_signal_exit TERM' TERM
+			trap '_setup_noninteractive_signal_exit INT' INT
+			return 0
+		fi
+
+		owner_pid=""
+		owner_cmd=""
+		if [[ -r "$lock_dir/owner.pid" ]]; then
+			owner_pid=$(tr -d '[:space:]' <"$lock_dir/owner.pid" 2>/dev/null || true)
+		fi
+		if _setup_lock_pid_alive "$owner_pid"; then
+			[[ -r "$lock_dir/command" ]] && owner_cmd=$(tr '\n' ' ' <"$lock_dir/command" 2>/dev/null || true)
+			print_error "Another setup.sh --non-interactive process is already running (pid ${owner_pid}, lock ${lock_dir}). Exiting to avoid overlapping deployments. ${owner_cmd:+Command: ${owner_cmd}}"
+			return 75
+		fi
+
+		print_warning "Removing stale setup.sh --non-interactive lock at ${lock_dir}"
+		rm -rf "$lock_dir" 2>/dev/null || true
+		attempts=$((attempts + 1))
+	done
+
+	print_error "Unable to acquire setup.sh --non-interactive lock at ${lock_dir}"
+	return 75
+}
+
 # Non-interactive path: deploy agents and run safe migrations only (no prompts).
 # GH#21060 / t2911: Every direct function call is wrapped with _time_step so
 # that a one-line-per-stage TSV timing record is appended to
@@ -1196,12 +1297,14 @@ _setup_run_non_interactive() {
 	if _time_step "generate_agent_skills" generate_agent_skills; then
 		_time_step "create_skill_symlinks" create_skill_symlinks &
 		_pid_symlinks=$!
+		_setup_register_child_pid "$_pid_symlinks"
 	else
 		print_warning "Agent skills generation failed — skipping skill symlinks"
 	fi
 
 	_time_step "scan_imported_skills" scan_imported_skills &
 	local _pid_scan=$!
+	_setup_register_child_pid "$_pid_scan"
 
 	if [[ -n "$_pid_symlinks" ]]; then
 		wait "$_pid_symlinks" 2>/dev/null || print_warning "Skill symlink creation encountered issues (non-critical)"
@@ -1541,6 +1644,10 @@ main() {
 	if [[ "$INTERACTIVE_MODE" == "true" && "$NON_INTERACTIVE" == "true" ]]; then
 		print_error "--interactive and --non-interactive cannot be used together"
 		exit 1
+	fi
+
+	if [[ "$NON_INTERACTIVE" == "true" ]]; then
+		_setup_acquire_noninteractive_setup_lock "$@" || exit $?
 	fi
 
 	_setup_print_header


### PR DESCRIPTION
## Summary
- Added a non-interactive setup singleton lock so overlapping deployments fail fast with owner PID/context instead of running silently.
- Added TERM/INT cleanup for registered background setup children and stale-lock recovery.
- Added regression coverage for live-owner blocking, stale lock reclaim, and child cleanup.

## Testing
- shellcheck setup.sh .agents/scripts/tests/test-setup-noninteractive-lock.sh
- bash .agents/scripts/tests/test-setup-noninteractive-lock.sh
- Runtime: started concurrent ./setup.sh --non-interactive processes with a temp lock; overlap emitted the new clear blocker message, TERM cleanup ran, and the temp lock was removed.
- .agents/scripts/linters-local.sh was attempted; it timed out after 600s after reporting pre-existing string-literal absolute-count debt.

## Runtime Testing
runtime-verified: exercised concurrent non-interactive setup invocation with a temp lock directory and signal cleanup path.

Resolves #22052


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.44 plugin for [OpenCode](https://opencode.ai) v1.14.30 with gpt-5.5 spent 31m and 141,530 tokens on this as a headless worker.