### PR TITLE
t3240: Make stash cleanup non-blocking in pulse preflight

### DIFF
--- a/.agents/scripts/cleanup-stashes-async-helper.sh
+++ b/.agents/scripts/cleanup-stashes-async-helper.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# cleanup-stashes-async-helper.sh — Async background stash cleanup runner (GH#21997).
+#
+# Designed to be invoked via nohup from _preflight_cleanup_and_ledger so slow
+# stash auditing, including any GitHub API calls made by stash-audit-helper.sh,
+# never blocks the pulse's early dispatch path.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly LOG_DIR="${HOME}/.aidevops/logs"
+readonly LOGFILE="${LOG_DIR}/cleanup_stashes.log"
+readonly LOCK_DIR="${LOG_DIR}/cleanup_stashes.lock"
+readonly PID_FILE="${LOCK_DIR}/pid"
+readonly LAST_RUN_FILE="${LOG_DIR}/cleanup_stashes.last-run"
+
+CLEANUP_STASHES_ASYNC_CADENCE_MIN="${CLEANUP_STASHES_ASYNC_CADENCE_MIN:-10}"
+CLEANUP_STASHES_ASYNC_CADENCE_MIN="${CLEANUP_STASHES_ASYNC_CADENCE_MIN//[!0-9]/}"
+[[ -n "$CLEANUP_STASHES_ASYNC_CADENCE_MIN" ]] || CLEANUP_STASHES_ASYNC_CADENCE_MIN=10
+
+mkdir -p "$LOG_DIR"
+
+if [[ -f "${SCRIPT_DIR}/shared-constants.sh" ]]; then
+	# shellcheck source=shared-constants.sh
+	source "${SCRIPT_DIR}/shared-constants.sh"
+else
+	printf '[cleanup-stashes-async] ERROR: shared-constants.sh not found at %s\n' "${SCRIPT_DIR}" >>"$LOGFILE"
+	exit 1
+fi
+
+if [[ -f "${SCRIPT_DIR}/pulse-cleanup.sh" ]]; then
+	# shellcheck source=pulse-cleanup.sh
+	source "${SCRIPT_DIR}/pulse-cleanup.sh"
+else
+	printf '[cleanup-stashes-async] ERROR: pulse-cleanup.sh not found at %s\n' "${SCRIPT_DIR}" >>"$LOGFILE"
+	exit 1
+fi
+
+_lock_release() {
+	rm -rf "$LOCK_DIR" 2>/dev/null || true
+	return 0
+}
+
+_is_pid_alive() {
+	local pid="$1"
+	[[ -z "$pid" ]] && return 1
+	[[ "$pid" =~ ^[0-9]+$ ]] || return 1
+
+	if ! kill -0 "$pid" 2>/dev/null; then
+		return 1
+	fi
+
+	local comm
+	comm=$(ps -p "$pid" -o comm= 2>/dev/null || true)
+	[[ -n "$comm" ]] || return 1
+	return 0
+}
+
+_lock_acquire() {
+	if mkdir "$LOCK_DIR" 2>/dev/null; then
+		printf '%s\n' "$$" >"$PID_FILE" 2>/dev/null || true
+		# shellcheck disable=SC2064
+		trap "_lock_release" EXIT INT TERM
+		return 0
+	fi
+
+	if [[ -f "$PID_FILE" ]]; then
+		local lock_pid
+		IFS= read -r lock_pid <"$PID_FILE" 2>/dev/null || lock_pid=""
+		if [[ -n "$lock_pid" ]] && ! _is_pid_alive "$lock_pid"; then
+			printf '[cleanup-stashes-async] Reclaiming stale lock (PID %s no longer alive)\n' "$lock_pid" >>"$LOGFILE"
+			rm -rf "$LOCK_DIR" 2>/dev/null || true
+			if mkdir "$LOCK_DIR" 2>/dev/null; then
+				printf '%s\n' "$$" >"$PID_FILE" 2>/dev/null || true
+				# shellcheck disable=SC2064
+				trap "_lock_release" EXIT INT TERM
+				return 0
+			fi
+		fi
+	fi
+
+	return 1
+}
+
+_cadence_ok() {
+	if [[ ! -f "$LAST_RUN_FILE" ]]; then
+		return 0
+	fi
+
+	local last_run now elapsed cadence_secs
+	IFS= read -r last_run <"$LAST_RUN_FILE" 2>/dev/null || last_run=""
+	if ! [[ "$last_run" =~ ^[0-9]+$ ]]; then
+		return 0
+	fi
+
+	now=$(date +%s)
+	elapsed=$((now - last_run))
+	cadence_secs=$((CLEANUP_STASHES_ASYNC_CADENCE_MIN * 60))
+
+	if [[ "$elapsed" -lt "$cadence_secs" ]]; then
+		printf '[cleanup-stashes-async] Cadence gate: last run %ss ago (threshold %ss). Skipping.\n' \
+			"$elapsed" "$cadence_secs" >>"$LOGFILE"
+		return 1
+	fi
+
+	return 0
+}
+
+_update_last_run() {
+	date +%s >"$LAST_RUN_FILE" 2>/dev/null || true
+	return 0
+}
+
+main() {
+	printf '[cleanup-stashes-async] PID=%s starting at %s\n' "$$" "$(date -u '+%Y-%m-%dT%H:%M:%SZ')" >>"$LOGFILE"
+
+	if ! _lock_acquire; then
+		printf '[cleanup-stashes-async] Lock held by live instance — skipping this invocation\n' >>"$LOGFILE"
+		return 0
+	fi
+
+	if ! _cadence_ok; then
+		return 0
+	fi
+
+	printf '[cleanup-stashes-async] Starting cleanup_stashes (cadence OK)\n' >>"$LOGFILE"
+
+	local rc=0
+	cleanup_stashes || rc=$?
+
+	if [[ "$rc" -eq 0 ]]; then
+		_update_last_run
+		printf '[cleanup-stashes-async] Completed successfully at %s. last-run updated.\n' \
+			"$(date -u '+%Y-%m-%dT%H:%M:%SZ')" >>"$LOGFILE"
+	else
+		printf '[cleanup-stashes-async] cleanup_stashes exited with rc=%s — last-run NOT updated\n' "$rc" >>"$LOGFILE"
+	fi
+
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/pulse-cleanup.sh
+++ b/.agents/scripts/pulse-cleanup.sh
@@ -802,7 +802,9 @@ cleanup_worktrees() {
 # Clean up safe-to-drop stashes across ALL managed repos (t1417)
 #
 # Iterates repos.json (.initialized_repos[]) and runs
-# stash-audit-helper.sh auto-clean in each repo directory.
+# stash-audit-helper.sh auto-clean in each repo directory. Pulse preflight calls
+# this via cleanup-stashes-async-helper.sh so slow stash audits cannot block
+# early dispatch (GH#21997); direct callers remain synchronous.
 # Only drops stashes whose content is already in HEAD — safe
 # and deterministic, no judgment needed.
 #

--- a/.agents/scripts/pulse-dispatch-preflight-lib.sh
+++ b/.agents/scripts/pulse-dispatch-preflight-lib.sh
@@ -64,7 +64,20 @@ _preflight_cleanup_and_ledger() {
 		# Fallback: synchronous with short timeout (old GH#18979 behaviour)
 		run_stage_with_timeout "cleanup_worktrees" 60 cleanup_worktrees || true
 	fi
-	run_stage_with_timeout "cleanup_stashes" "$PRE_RUN_STAGE_TIMEOUT" cleanup_stashes || true
+	# GH#21997: Stash cleanup is moved to an async background job so slow
+	# stash auditing (including gh API calls inside stash-audit-helper.sh) cannot
+	# stall pulse preflight before early dispatch. The helper enforces a
+	# single-runner lock and cadence gate (CLEANUP_STASHES_ASYNC_CADENCE_MIN,
+	# default 10 min). Progress: ~/.aidevops/logs/cleanup_stashes.*
+	local _cleanup_stashes_async_helper="${SCRIPT_DIR}/cleanup-stashes-async-helper.sh"
+	if [[ -x "$_cleanup_stashes_async_helper" ]]; then
+		nohup "$_cleanup_stashes_async_helper" \
+			>>"${HOME}/.aidevops/logs/cleanup_stashes.log" 2>&1 &
+		disown $! 2>/dev/null || true
+	else
+		# Fallback: synchronous with the standard pre-run stage timeout.
+		run_stage_with_timeout "cleanup_stashes" "$PRE_RUN_STAGE_TIMEOUT" cleanup_stashes || true
+	fi
 
 	# GH#17549: Archive old OpenCode sessions to keep the active DB small.
 	# Concurrent workers hit SQLITE_BUSY on a bloated DB (busy_timeout=0).

--- a/.agents/scripts/tests/test-pulse-stash-cleanup-nonblocking.sh
+++ b/.agents/scripts/tests/test-pulse-stash-cleanup-nonblocking.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression test for GH#21997: pulse preflight must not wait for stash cleanup.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PREFLIGHT_LIB="${SCRIPT_DIR}/../pulse-dispatch-preflight-lib.sh"
+TEST_DIR=""
+
+cleanup() {
+	if [[ -n "$TEST_DIR" && -d "$TEST_DIR" ]]; then
+		rm -rf "$TEST_DIR"
+	fi
+	return 0
+}
+
+fail() {
+	local message="$1"
+	printf 'FAIL: %s\n' "$message"
+	exit 1
+}
+
+main() {
+	TEST_DIR=$(mktemp -d)
+	trap cleanup EXIT
+
+	local stub_dir="${TEST_DIR}/scripts"
+	mkdir -p "$stub_dir" "${TEST_DIR}/.aidevops/logs"
+
+	cat >"${stub_dir}/cleanup-stashes-async-helper.sh" <<'STUB'
+#!/usr/bin/env bash
+printf 'started\n' >>"${HOME}/async-marker"
+sleep 5
+printf 'finished\n' >>"${HOME}/async-marker"
+exit 0
+STUB
+	chmod +x "${stub_dir}/cleanup-stashes-async-helper.sh"
+
+	local start elapsed
+	start=$(date +%s)
+	(
+		export HOME="$TEST_DIR"
+		SCRIPT_DIR="$stub_dir"
+		LOGFILE="${TEST_DIR}/pulse.log"
+		PRE_RUN_STAGE_TIMEOUT=1
+
+		run_stage_with_timeout() {
+			local _stage_name="$1"
+			local _timeout_secs="$2"
+			local fn="$3"
+			shift 3
+			"$fn" "$@"
+			return 0
+		}
+
+		cleanup_orphans() { return 0; }
+		cleanup_stale_opencode() { return 0; }
+		cleanup_stalled_workers() { return 0; }
+		cleanup_worktrees() { return 0; }
+		cleanup_stashes() { sleep 5; return 0; }
+		reap_zombie_workers() { return 0; }
+
+		# shellcheck source=../pulse-dispatch-preflight-lib.sh
+		source "$PREFLIGHT_LIB"
+		_preflight_cleanup_and_ledger
+	)
+	elapsed=$(($(date +%s) - start))
+
+	if [[ "$elapsed" -ge 3 ]]; then
+		fail "preflight waited ${elapsed}s for stash cleanup; expected async return under 3s"
+	fi
+
+	for _ in 1 2 3 4 5; do
+		[[ -f "${TEST_DIR}/async-marker" ]] && break
+		sleep 0.2
+	done
+
+	if [[ ! -f "${TEST_DIR}/async-marker" ]]; then
+		fail "async stash cleanup helper was not launched"
+	fi
+
+	printf 'PASS: preflight launched stash cleanup asynchronously in %ss\n' "$elapsed"
+	return 0
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
- Added cleanup-stashes-async-helper.sh with lock/cadence gating so stash audits run outside the preflight critical path.
- Updated pulse preflight to launch stash cleanup via nohup with a synchronous fallback when the helper is unavailable.
- Added regression coverage proving _preflight_cleanup_and_ledger returns without waiting for slow stash cleanup.

## Testing
- PASS: bash .agents/scripts/tests/test-pulse-stash-cleanup-nonblocking.sh
- PASS: shellcheck .agents/scripts/pulse-cleanup.sh .agents/scripts/pulse-dispatch-preflight-lib.sh .agents/scripts/stash-audit-helper.sh .agents/scripts/cleanup-stashes-async-helper.sh .agents/scripts/tests/test-pulse-stash-cleanup-nonblocking.sh
- PASS before latest origin/main rebase: AIDEVOPS_SKIP_FIX_THE_FIXER_DETECTOR=1 .agents/scripts/pulse-wrapper.sh --dry-run
- BLOCKED after latest origin/main rebase: pulse-wrapper.sh --dry-run timed out during bootstrap before reaching preflight; appears unrelated to this change and was encountered after the implementation commit.

## Runtime Testing
runtime-verified: regression executes the preflight cleanup function with a slow async helper and verifies the pulse path returns immediately without invoking synchronous cleanup_stashes.

## Key decisions
- Preserved cleanup_stashes as the synchronous safety-preserving implementation; only preflight dispatch moved to the async wrapper.
- Used the existing cleanup-worktrees async helper pattern for lock, stale-lock recovery, cadence, logs, and last-run observability.

Resolves #21997


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.44 plugin for [OpenCode](https://opencode.ai) v1.14.30 with gpt-5.5 spent 10m and 19,412 tokens on this as a headless worker.
