### PR TITLE
t3253: improve setup stage timing observability

### DIFF
--- a/.agents/scripts/tests/test-setup-stage-timing-observability.sh
+++ b/.agents/scripts/tests/test-setup-stage-timing-observability.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SETUP_SH="${SCRIPT_DIR}/../../../setup.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+test_time_step_logs_running_before_command() {
+	local snippet=""
+	snippet=$(perl -0ne 'print $1 if /(_time_step_log\(\) \{.*?^\}\n\n_time_step\(\) \{.*?^\})/ms' "$SETUP_SH")
+	if [[ -z "$snippet" ]]; then
+		print_result "_time_step extraction succeeds" 1 "timing helper block not found"
+		return 0
+	fi
+
+	local tmp_home=""
+	tmp_home=$(mktemp -d 2>/dev/null || mktemp -d -t setup-stage-timing)
+	mkdir -p "${tmp_home}/.aidevops/logs"
+
+	local output=""
+	output=$(
+		HOME="$tmp_home"
+		eval "$snippet"
+		print_info() {
+			printf '%s\n' "$*"
+			return 0
+		}
+		slow_stage() {
+			local marker_file="$1"
+			local timing_file="${HOME}/.aidevops/logs/setup-stage-timings.log"
+			cp "$timing_file" "$marker_file"
+			return 0
+		}
+		_time_step "update_claude_config" slow_stage "${tmp_home}/during.log"
+		printf 'during=%s\n' "$(grep -c $'update_claude_config\t0.00\tRUNNING' "${tmp_home}/during.log" 2>/dev/null || true)"
+		printf 'finished=%s\n' "$(grep -c $'update_claude_config\t.*\t0' "${tmp_home}/.aidevops/logs/setup-stage-timings.log" 2>/dev/null || true)"
+	) 2>&1
+
+	rm -rf "$tmp_home"
+
+	if [[ "$output" == *"during=1"* && "$output" == *"finished=1"* ]]; then
+		print_result "_time_step logs RUNNING before command and completion after" 0
+		return 0
+	fi
+
+	print_result "_time_step logs RUNNING before command and completion after" 1 "output=${output}"
+	return 0
+}
+
+main() {
+	test_time_step_logs_running_before_command
+
+	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -ne 0 ]]; then
+		exit 1
+	fi
+
+	return 0
+}
+
+main "$@"

--- a/setup.sh
+++ b/setup.sh
@@ -143,34 +143,40 @@ _cron_escape() {
 }
 
 # GH#21060 / t2911: Per-stage timing helper for non-interactive setup runs.
-# Wraps a function call, records start/end time, and appends one TSV line to
+# Wraps a function call, records start/end time, and appends TSV lines to
 # $HOME/.aidevops/logs/setup-stage-timings.log:
 #   iso8601_utc <TAB> stage_name <TAB> duration_seconds <TAB> exit_code
+# A RUNNING row is written before each stage starts so a tool/worker timeout
+# still leaves the currently executing phase in the timing log.
 # Usage: _time_step "stage_name" function_name [args...]
 # ShellCheck: $@ is used deliberately (SC2068 not applicable; no word-splitting
 # issue since we shift the stage-name arg first and pass the rest as a command).
-_time_step() {
+_time_step_log() {
 	local _ts_stage="$1"
-	shift
-	# GH#22012: In non-interactive mode, emit the stage name before running so
-	# an operator watching setup.sh output can identify which step is blocking.
-	# The TSV log entry below is written AFTER the step returns — it provides no
-	# signal during a hang. This print is the only in-flight indicator.
-	if [[ "${NON_INTERACTIVE:-false}" == "true" ]]; then
-		printf '[SETUP] stage: %s\n' "$_ts_stage"
-	fi
-	local _ts_start _ts_end _ts_duration _ts_exit
-	_ts_start=$(date +%s.%N 2>/dev/null || date +%s)
-	_ts_exit=0
-	"$@" || _ts_exit=$?
-	_ts_end=$(date +%s.%N 2>/dev/null || date +%s)
-	_ts_duration=$(awk -v a="$_ts_start" -v b="$_ts_end" 'BEGIN { printf "%.2f", b - a }')
+	local _ts_duration="$2"
+	local _ts_exit="$3"
 	printf '%s\t%s\t%s\t%s\n' \
 		"$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
 		"$_ts_stage" \
 		"$_ts_duration" \
 		"$_ts_exit" \
 		>>"$HOME/.aidevops/logs/setup-stage-timings.log" 2>/dev/null || true
+	return 0
+}
+
+_time_step() {
+	local _ts_stage="$1"
+	shift
+	local _ts_start _ts_end _ts_duration _ts_exit
+	print_info "Starting setup stage: $_ts_stage"
+	_time_step_log "$_ts_stage" "0.00" "RUNNING"
+	_ts_start=$(date +%s.%N 2>/dev/null || date +%s)
+	_ts_exit=0
+	"$@" || _ts_exit=$?
+	_ts_end=$(date +%s.%N 2>/dev/null || date +%s)
+	_ts_duration=$(awk -v a="$_ts_start" -v b="$_ts_end" 'BEGIN { printf "%.2f", b - a }')
+	_time_step_log "$_ts_stage" "$_ts_duration" "$_ts_exit"
+	print_info "Finished setup stage: $_ts_stage (${_ts_duration}s, exit=${_ts_exit})"
 	return "$_ts_exit"
 }
 


### PR DESCRIPTION
## Summary
- Add in-flight RUNNING rows to setup-stage-timings.log before each setup stage executes.
- Print explicit setup stage start/finish messages with duration and exit code.
- Add regression coverage proving the timing log identifies the active stage before a command completes.

## Testing
- shellcheck setup.sh .agents/scripts/tests/test-setup-stage-timing-observability.sh
- bash .agents/scripts/tests/test-setup-stage-timing-observability.sh
- bash .agents/scripts/generate-runtime-config.sh all --runtime opencode
- bash .agents/scripts/generate-runtime-config.sh all --runtime claude-code

## Runtime Testing
- Risk: low; setup observability/logging change with shell regression coverage.
- Full ./setup.sh --non-interactive was attempted, but concurrent setup.sh processes were already active in this environment; the run emitted stage-start evidence before timing out at the tool ceiling. This PR makes that timeout diagnosable by leaving a RUNNING row for the active phase.

## Decisions
- Preserve the existing four-column timing TSV shape so consumers that sort/read the file keep working.
- Use a 0.00/RUNNING row instead of a separate log file so post-timeout diagnostics stay in the existing setup-stage-timings.log path.

Resolves #22023
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.46 plugin for [OpenCode](https://opencode.ai) v1.14.30 with gpt-5.5 spent 21m and 275,179 tokens on this as a headless worker.