### PR TITLE
t3361: Make setup agent deploy staging resilient

### DIFF
--- a/.agents/scripts/tests/test-agent-deploy-staging-invariant.sh
+++ b/.agents/scripts/tests/test-agent-deploy-staging-invariant.sh
@@ -14,7 +14,8 @@
 #   1. Happy path: swap succeeds, target_dir exists and contains scripts/
 #   2. mv-to-old fails: function returns 1, live target_dir preserved
 #   3. mv-staging-to-live fails: function returns 1, rollback restores target
-#   4. deploy_aidevops_agents postcondition: returns 1 when scripts/ missing
+#   4. concurrent fixed staging cleanup: unique staging avoids stale path races
+#   5. deploy_aidevops_agents postcondition: returns 1 when scripts/ missing
 
 set -euo pipefail
 
@@ -111,33 +112,28 @@ test_happy_path_target_exists_with_scripts() {
 		print_result "happy path: target scripts/ exists after swap" 1 "$tgt/scripts missing"
 	fi
 
-	if [[ ! -d "${tgt}.staging" && ! -d "${tgt}.old" ]]; then
+	if ! compgen -G "${tgt}.staging*" >/dev/null && ! compgen -G "${tgt}.old*" >/dev/null; then
 		print_result "happy path: staging and old dirs cleaned up" 0
 	else
 		print_result "happy path: staging and old dirs cleaned up" 1 \
-			"staging=$(ls -d "${tgt}.staging" 2>/dev/null || echo absent) old=$(ls -d "${tgt}.old" 2>/dev/null || echo absent)"
+			"staging/old temp dirs still present"
 	fi
 	return 0
 }
 
-# Test 2: mv target→old fails — function returns 1, live target preserved.
-# We simulate mv failure by making $target_dir.old a non-empty directory that
-# cannot be overwritten by mv (mv fails when destination already exists and is
-# a non-empty directory on most filesystems).
+# Test 2: mv target→old.* fails — function returns 1, live target preserved.
+# Override mv for the generated backup path so the test remains independent of
+# the per-process suffix used to avoid concurrent setup collisions.
 test_mv_to_old_fails_preserves_live_target() {
 	local src="${TEST_DIR}/src2"
 	local tgt="${TEST_DIR}/tgt2"
-	local old_dir="${tgt}.old"
 	_make_source_dir "$src"
 	_make_live_target "$tgt"
-
-	# Pre-populate the .old dir so mv tgt → .old fails (destination occupied).
-	mkdir -p "$old_dir/blocker"
 
 	# Override mv to fail when the destination is the .old path.
 	mv() {
 		local dst="${*: -1}"
-		if [[ "$dst" == "$old_dir" ]]; then
+		if [[ "$dst" == "${tgt}.old."* ]]; then
 			return 1
 		fi
 		command mv "$@"
@@ -170,14 +166,13 @@ test_mv_to_old_fails_preserves_live_target() {
 test_mv_staging_to_live_fails_rolls_back() {
 	local src="${TEST_DIR}/src3"
 	local tgt="${TEST_DIR}/tgt3"
-	local staging_dir="${tgt}.staging"
 	_make_source_dir "$src"
 	_make_live_target "$tgt"
 
 	# Override mv to fail only for the staging→live move.
 	mv() {
 		local src_arg="$1"
-		if [[ "$src_arg" == "$staging_dir" ]]; then
+		if [[ "$src_arg" == "${tgt}.staging."* ]]; then
 			return 1
 		fi
 		command mv "$@"
@@ -203,22 +198,58 @@ test_mv_staging_to_live_fails_rolls_back() {
 	fi
 
 	# Staging should be cleaned up
-	if [[ ! -d "$staging_dir" ]]; then
+	if ! compgen -G "${tgt}.staging*" >/dev/null; then
 		print_result "mv-staging-to-live fails: staging cleaned up" 0
 	else
-		print_result "mv-staging-to-live fails: staging cleaned up" 1 "$staging_dir still present"
+		print_result "mv-staging-to-live fails: staging cleaned up" 1 "staging temp dirs still present"
 	fi
 	return 0
 }
 
-# Test 4: deploy_aidevops_agents postcondition check — if scripts/ is absent
+# Test 4: a concurrent cleanup of the legacy fixed staging path must not affect
+# the active deploy. Original fixed-path staging used ${target}.staging; if that
+# directory was removed during rsync, setup failed with renameat/move_file ENOENT.
+test_fixed_staging_cleanup_does_not_abort_copy() {
+	local src="${TEST_DIR}/src4"
+	local tgt="${TEST_DIR}/tgt4"
+	_make_source_dir "$src"
+	_make_live_target "$tgt"
+	mkdir -p "${tgt}.staging/scripts"
+	printf 'stale staging\n' >"${tgt}.staging/scripts/stale.sh"
+
+	_deploy_agents_copy() {
+		local copy_source_dir="$1"
+		local copy_target_dir="$2"
+		if [[ "$copy_target_dir" == "${tgt}.staging" ]]; then
+			rm -rf "$copy_target_dir"
+			return 1
+		fi
+		mkdir -p "$copy_target_dir/scripts"
+		cp -a "$copy_source_dir/scripts/." "$copy_target_dir/scripts/"
+		return 0
+	}
+
+	local rc=0
+	_atomic_stage_and_deploy_agents "$src" "$tgt" || rc=$?
+
+	unset -f _deploy_agents_copy
+
+	if [[ "$rc" -eq 0 && -f "$tgt/scripts/hello.sh" ]]; then
+		print_result "fixed staging cleanup: unique staging deploy succeeds" 0
+	else
+		print_result "fixed staging cleanup: unique staging deploy succeeds" 1 "rc=$rc"
+	fi
+	return 0
+}
+
+# Test 5: deploy_aidevops_agents postcondition check — if scripts/ is absent
 # after swap (regression scenario), function returns 1.
 # We wire this up by overriding _atomic_stage_and_deploy_agents to return 0
 # without populating the target so we isolate the postcondition gate.
 test_postcondition_fails_when_scripts_absent() {
-	local src="${TEST_DIR}/src4"
-	local tgt="${TEST_DIR}/tgt4"
-	local plugins_file="${TEST_DIR}/plugins4.json"
+	local src="${TEST_DIR}/src5"
+	local tgt="${TEST_DIR}/tgt5"
+	local plugins_file="${TEST_DIR}/plugins5.json"
 	printf '{"plugins":[]}\n' >"$plugins_file"
 
 	mkdir -p "$src/scripts"  # source has scripts/ but we won't copy it
@@ -264,6 +295,7 @@ main() {
 	test_happy_path_target_exists_with_scripts
 	test_mv_to_old_fails_preserves_live_target
 	test_mv_staging_to_live_fails_rolls_back
+	test_fixed_staging_cleanup_does_not_abort_copy
 	test_postcondition_fails_when_scripts_absent
 
 	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"

--- a/setup-modules/agent-deploy.sh
+++ b/setup-modules/agent-deploy.sh
@@ -340,8 +340,9 @@ _install_opencode_plugin_deps() {
 }
 
 # _atomic_stage_and_deploy_agents source_dir target_dir [plugin_namespaces...]
-# Stages a copy in target_dir.staging, carries over preserved dirs (custom/,
-# draft/, and any plugin namespaces), then atomically swaps staging into place.
+# Stages a copy in a per-process target_dir.staging.* directory, carries over
+# preserved dirs (custom/, draft/, and any plugin namespaces), then atomically
+# swaps staging into place.
 # Returns 0 on success, 1 on failure.
 _atomic_stage_and_deploy_agents() {
 	local source_dir="$1"
@@ -353,14 +354,22 @@ _atomic_stage_and_deploy_agents() {
 	# Previously, clean + copy happened in-place, creating a window where
 	# scripts were missing. The pulse could dispatch workers mid-deploy,
 	# hitting "No such file or directory" errors. Now we:
-	#   1. rsync into a staging dir (target_dir.staging)
+	#   1. rsync into a unique staging dir (target_dir.staging.*)
 	#   2. Move preserved dirs (custom/, draft/, plugins) from live to staging
-	#   3. mv live → .old, mv staging → live (atomic on same filesystem)
-	#   4. rm .old
-	local staging_dir="${target_dir}.staging"
-	local old_dir="${target_dir}.old"
-	rm -rf "$staging_dir" "$old_dir"
-	mkdir -p "$staging_dir"
+	#   3. mv live → .old.*, mv staging → live (atomic on same filesystem)
+	#   4. rm .old.*
+	#
+	# GH#22063: the staging/backup paths must be unique per setup process. Fixed
+	# names such as target_dir.staging let a concurrent setup cleanup remove the
+	# directory while rsync is still writing into it, producing renameat/move_file
+	# ENOENT failures even though the canonical .agents/ source is valid.
+	local staging_dir old_dir
+	staging_dir=$(mktemp -d "${target_dir}.staging.XXXXXX") || {
+		print_error "Failed to create agents staging directory"
+		return 1
+	}
+	old_dir="${target_dir}.old.$$"
+	rm -rf "$old_dir"
 
 	# Copy source into staging
 	local copy_rc


### PR DESCRIPTION
## Summary
- Use per-process `target_dir.staging.*` and `target_dir.old.$$` paths for agent deploy swaps so concurrent setup cleanup cannot remove the active rsync destination.
- Extend the existing agent deploy invariant test with a fixed-staging cleanup regression for the renameat/move_file ENOENT class.

Resolves #22063

## Testing
- `shellcheck setup-modules/agent-deploy.sh .agents/scripts/tests/test-agent-deploy-staging-invariant.sh`
- `bash .agents/scripts/tests/test-agent-deploy-staging-invariant.sh` — 10 tests, 0 failed
- `./setup.sh --non-interactive` — deploy_aidevops_agents completed and deployed 1714 agent files / 1240 scripts; later timed out at the pre-existing `generate_agent_skills` hang tracked separately as #22077

## Runtime Testing
runtime-verified: exercised the non-interactive deploy path through `deploy_aidevops_agents`; full post-deploy setup completion remains blocked by #22077.

## Key decisions
- Preserve hard failures for real source-copy errors: `_deploy_agents_copy` still returns non-zero and aborts if the active unique staging copy fails.
- Scope the fix to staging/backup path isolation rather than broad rsync retry masking, so genuine copy errors remain visible.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.44 plugin for [OpenCode](https://opencode.ai) v1.14.30 with gpt-5.5 spent 27m and 138,321 tokens on this as a headless worker.