### PR TITLE
GH#22058: detect superseded PRs before conflict repair

### DIFF
--- a/.agents/reference/auto-merge.md
+++ b/.agents/reference/auto-merge.md
@@ -2,6 +2,26 @@
 
 Full detail for the two pulse auto-merge gates. For the one-line summary, see `AGENTS.md` "Auto-Dispatch and Completion".
 
+## Superseded DIRTY PR Pre-Check
+
+Before spending time repairing conflicts on an old DIRTY PR, run the supersession helper:
+
+```bash
+.agents/scripts/pr-supersession-helper.sh classify --repo OWNER/REPO --pr N --repo-path /path/to/repo
+```
+
+Decision tree:
+
+| Classification | Meaning | Action |
+|----------------|---------|--------|
+| `fully_superseded` | The branch has no meaningful diff against current base, and base contains the PR deliverable terms. | Close as superseded after human confirmation. |
+| `stale_baseline_only` | The current diff no longer overlaps the PR's original changed files, while base contains the deliverable. | Prefer close-with-rationale over conflict repair. |
+| `partially_superseded` | Base contains some deliverable signals, but relevant branch work remains. | Review the remaining diff before deciding. |
+| `still_needed` | Base does not contain the deliverable, or the current diff still carries it. | Continue normal rebase/conflict repair. |
+| `unknown` | Metadata or git comparison was unavailable. | Fall back to normal DIRTY PR handling. |
+
+`pulse-dirty-pr-sweep.sh` calls this helper before its normal conflict-resolution classifier. Superseded candidates are notified with a human-readable rationale; the helper itself is advisory and never closes a PR.
+
 ## t2411 — `origin:interactive` Auto-Merge
 
 `pulse-merge.sh` automatically merges `origin:interactive` PRs from `OWNER`/`MEMBER` authors once ALL criteria hold:

--- a/.agents/scripts/pr-supersession-helper.sh
+++ b/.agents/scripts/pr-supersession-helper.sh
@@ -1,0 +1,326 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# pr-supersession-helper.sh — Detect PRs superseded by their current base.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+
+# shellcheck source=shared-constants.sh
+[[ -f "${SCRIPT_DIR}/shared-constants.sh" ]] && source "${SCRIPT_DIR}/shared-constants.sh"
+
+_psh_log() {
+	local msg="$1"
+	printf '[pr-supersession] %s\n' "$msg" >&2
+	return 0
+}
+
+_psh_usage() {
+	cat <<'EOF'
+pr-supersession-helper.sh — classify whether a PR is superseded by base
+
+Usage:
+  pr-supersession-helper.sh classify --repo OWNER/REPO --pr N [--repo-path PATH] [--json]
+  pr-supersession-helper.sh help
+
+Output classes:
+  fully_superseded     Base already contains the PR deliverable and no meaningful diff remains.
+  partially_superseded Base contains some deliverable signals, but PR still has relevant changes.
+  stale_baseline_only  Current branch diff no longer overlaps the PR's original changed files.
+  still_needed         Deliverable is not present on base, or branch diff still carries it.
+  unknown              Required metadata or git comparison was unavailable.
+
+The helper is advisory. It prints a suggested close comment for superseded cases
+but never closes the PR.
+EOF
+	return 0
+}
+
+_psh_require_tools() {
+	local missing=0
+	for tool in gh jq git; do
+		if ! command -v "$tool" >/dev/null 2>&1; then
+			_psh_log "missing required tool: $tool"
+			missing=1
+		fi
+	done
+	[[ "$missing" -eq 0 ]] || return 1
+	return 0
+}
+
+_psh_compact_lines_json() {
+	jq -Rn '[inputs | select(length > 0)]'
+	return 0
+}
+
+_psh_fetch_pr_json() {
+	local repo_slug="$1"
+	local pr_number="$2"
+
+	gh pr view "$pr_number" --repo "$repo_slug" \
+		--json number,title,body,baseRefName,headRefName,files,author,url \
+		2>/dev/null
+	return $?
+}
+
+_psh_default_repo_path() {
+	local repo_slug="$1"
+	local repo_path=""
+
+	if git rev-parse --show-toplevel >/dev/null 2>&1; then
+		repo_path=$(git rev-parse --show-toplevel 2>/dev/null) || repo_path=""
+		if [[ -n "$repo_path" ]]; then
+			printf '%s\n' "$repo_path"
+			return 0
+		fi
+	fi
+
+	repo_path=$(jq -r --arg slug "$repo_slug" \
+		'.initialized_repos[]? | select(.slug == $slug) | .path // empty' \
+		"${REPOS_JSON:-${HOME}/.config/aidevops/repos.json}" 2>/dev/null | head -n 1) || repo_path=""
+	repo_path="${repo_path/#\~/$HOME}"
+	[[ -n "$repo_path" ]] || return 1
+	printf '%s\n' "$repo_path"
+	return 0
+}
+
+_psh_original_files_json() {
+	local pr_json="$1"
+	printf '%s' "$pr_json" | jq -r '.files[]?.path // empty' 2>/dev/null | _psh_compact_lines_json
+	return 0
+}
+
+_psh_diff_files_json() {
+	local repo_path="$1"
+	local base_ref="$2"
+	local head_ref="$3"
+
+	if [[ -z "$repo_path" || ! -d "$repo_path/.git" ]]; then
+		printf '[]\n'
+		return 1
+	fi
+
+	git -C "$repo_path" fetch --quiet origin "$base_ref" 2>/dev/null || true
+	git -C "$repo_path" fetch --quiet origin "$head_ref" 2>/dev/null || true
+
+	local base="origin/${base_ref}"
+	local head="origin/${head_ref}"
+	if ! git -C "$repo_path" rev-parse --verify "$base" >/dev/null 2>&1; then
+		printf '[]\n'
+		return 1
+	fi
+	if ! git -C "$repo_path" rev-parse --verify "$head" >/dev/null 2>&1; then
+		head="$head_ref"
+	fi
+	if ! git -C "$repo_path" rev-parse --verify "$head" >/dev/null 2>&1; then
+		printf '[]\n'
+		return 1
+	fi
+
+	git -C "$repo_path" diff --name-only "${base}...${head}" 2>/dev/null | _psh_compact_lines_json
+	return 0
+}
+
+_psh_extract_deliverable_terms_json() {
+	local pr_json="$1"
+	local text=""
+
+	text=$(printf '%s' "$pr_json" | jq -r '[.title // "", .body // ""] | join("\n")' 2>/dev/null) || text=""
+	printf '%s\n' "$text" \
+		| tr '`"' ' ' \
+		| tr -cs '[:alnum:]_.-/' '\n' \
+		| awk 'length($0) >= 4 && $0 !~ /^(https?|github|com|this|that|with|from|have|will|should|would|when|then|base|branch|pull|request|issue|task|files|edit|new|run|test|tests|helper|detect|current|remaining|summary|stale|superseded)$/ {print}' \
+		| sort -u \
+		| _psh_compact_lines_json
+	return 0
+}
+
+_psh_base_term_hits_json() {
+	local repo_path="$1"
+	local base_ref="$2"
+	local terms_json="$3"
+
+	local base="origin/${base_ref}"
+	local terms_count
+	terms_count=$(printf '%s' "$terms_json" | jq 'length' 2>/dev/null) || terms_count=0
+	[[ "$terms_count" =~ ^[0-9]+$ ]] || terms_count=0
+	if [[ "$terms_count" -eq 0 || -z "$repo_path" || ! -d "$repo_path/.git" ]]; then
+		printf '[]\n'
+		return 0
+	fi
+	git -C "$repo_path" fetch --quiet origin "$base_ref" 2>/dev/null || true
+	if ! git -C "$repo_path" rev-parse --verify "$base" >/dev/null 2>&1; then
+		printf '[]\n'
+		return 0
+	fi
+
+	local tmp
+	tmp=$(mktemp) || return 1
+	printf '%s' "$terms_json" | jq -r '.[]' | while IFS= read -r term; do
+		[[ -n "$term" ]] || continue
+		if git -C "$repo_path" grep -F --quiet -- "$term" "$base" 2>/dev/null; then
+			printf '%s\n' "$term"
+		fi
+	done >"$tmp"
+	_psh_compact_lines_json <"$tmp"
+	rm -f "$tmp" 2>/dev/null || true
+	return 0
+}
+
+_psh_intersection_count() {
+	local left_json="$1"
+	local right_json="$2"
+
+	jq -n --argjson left "$left_json" --argjson right "$right_json" \
+		'[$left[] | select(. as $x | $right | index($x))] | length'
+	return 0
+}
+
+_psh_build_comment() {
+	local classification="$1"
+	local pr_number="$2"
+	local base_ref="$3"
+	local rationale="$4"
+
+	cat <<EOF
+Supersession check for PR #${pr_number}: **${classification}**.
+
+Rationale: ${rationale}
+
+Suggested action: close this PR as superseded only after a maintainer verifies the current \
+\`${base_ref}\` branch contains the intended deliverable. This helper is advisory and did not close anything.
+EOF
+	return 0
+}
+
+_psh_classify_json() {
+	local pr_json="$1"
+	local repo_path="$2"
+	local as_json="$3"
+
+	local pr_number title base_ref head_ref original_files diff_files terms hits
+	pr_number=$(printf '%s' "$pr_json" | jq -r '.number // empty')
+	title=$(printf '%s' "$pr_json" | jq -r '.title // empty')
+	base_ref=$(printf '%s' "$pr_json" | jq -r '.baseRefName // empty')
+	head_ref=$(printf '%s' "$pr_json" | jq -r '.headRefName // empty')
+	original_files=$(_psh_original_files_json "$pr_json")
+	terms=$(_psh_extract_deliverable_terms_json "$pr_json")
+	diff_files=$(_psh_diff_files_json "$repo_path" "$base_ref" "$head_ref" 2>/dev/null) || diff_files="[]"
+	hits=$(_psh_base_term_hits_json "$repo_path" "$base_ref" "$terms")
+
+	local original_count diff_count terms_count hit_count overlap_count classification rationale comment
+	original_count=$(printf '%s' "$original_files" | jq 'length')
+	diff_count=$(printf '%s' "$diff_files" | jq 'length')
+	terms_count=$(printf '%s' "$terms" | jq 'length')
+	hit_count=$(printf '%s' "$hits" | jq 'length')
+	overlap_count=$(_psh_intersection_count "$original_files" "$diff_files")
+
+	classification="still_needed"
+	rationale="base does not yet contain enough deliverable signals, or the current diff still overlaps the PR deliverable"
+
+	if [[ -z "$base_ref" || -z "$head_ref" ]]; then
+		classification="unknown"
+		rationale="PR metadata did not include base/head refs"
+	elif [[ "$diff_count" -eq 0 && "$hit_count" -gt 0 ]]; then
+		classification="fully_superseded"
+		rationale="current branch has no diff against origin/${base_ref}, and base contains ${hit_count}/${terms_count} deliverable term(s)"
+	elif [[ "$original_count" -gt 0 && "$diff_count" -gt 0 && "$overlap_count" -eq 0 && "$hit_count" -gt 0 ]]; then
+		classification="stale_baseline_only"
+		rationale="current diff no longer overlaps the PR's original files, while base contains ${hit_count}/${terms_count} deliverable term(s)"
+	elif [[ "$terms_count" -gt 0 && "$hit_count" -gt 0 && "$hit_count" -lt "$terms_count" ]]; then
+		classification="partially_superseded"
+		rationale="base contains ${hit_count}/${terms_count} deliverable term(s), but some signals or file overlap remain unresolved"
+	elif [[ "$terms_count" -gt 0 && "$hit_count" -ge "$terms_count" && "$overlap_count" -eq 0 ]]; then
+		classification="fully_superseded"
+		rationale="base contains all deliverable terms and the current diff no longer overlaps original PR files"
+	fi
+
+	comment=$(_psh_build_comment "$classification" "$pr_number" "$base_ref" "$rationale")
+
+	if [[ "$as_json" == "1" ]]; then
+		jq -n \
+			--arg classification "$classification" \
+			--arg rationale "$rationale" \
+			--arg comment "$comment" \
+			--arg title "$title" \
+			--argjson pr "${pr_number:-0}" \
+			--argjson original_files "$original_files" \
+			--argjson diff_files "$diff_files" \
+			--argjson deliverable_terms "$terms" \
+			--argjson base_hits "$hits" \
+			'{classification:$classification, rationale:$rationale, suggested_close_comment:$comment, pr:$pr, title:$title, original_files:$original_files, current_diff_files:$diff_files, deliverable_terms:$deliverable_terms, base_hits:$base_hits}'
+	else
+		printf 'classification=%s\n' "$classification"
+		printf 'rationale=%s\n' "$rationale"
+		printf '\n%s\n' "$comment"
+	fi
+	return 0
+}
+
+_psh_cmd_classify() {
+	local repo_slug=""
+	local pr_number=""
+	local repo_path=""
+	local as_json=0
+
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+			--repo)
+				repo_slug="${2:-}"
+				shift 2
+				;;
+			--pr)
+				pr_number="${2:-}"
+				shift 2
+				;;
+			--repo-path)
+				repo_path="${2:-}"
+				shift 2
+				;;
+			--json)
+				as_json=1
+				shift
+				;;
+			*)
+				_psh_log "unknown argument: $arg"
+				return 2
+				;;
+		esac
+	done
+
+	[[ -n "$repo_slug" && -n "$pr_number" ]] || { _psh_usage; return 2; }
+	_psh_require_tools || return 1
+	if [[ -z "$repo_path" ]]; then
+		repo_path=$(_psh_default_repo_path "$repo_slug" 2>/dev/null) || repo_path=""
+	fi
+
+	local pr_json
+	pr_json=$(_psh_fetch_pr_json "$repo_slug" "$pr_number") || return 1
+	_psh_classify_json "$pr_json" "$repo_path" "$as_json"
+	return 0
+}
+
+main() {
+	local cmd="${1:-help}"
+	case "$cmd" in
+		classify)
+			shift
+			_psh_cmd_classify "$@"
+			return $?
+			;;
+		help|--help|-h)
+			_psh_usage
+			return 0
+			;;
+		*)
+			_psh_usage
+			return 2
+			;;
+	esac
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+	main "$@"
+fi

--- a/.agents/scripts/pulse-dirty-pr-sweep.sh
+++ b/.agents/scripts/pulse-dirty-pr-sweep.sh
@@ -84,6 +84,12 @@ if [[ -f "${SCRIPT_DIR}/canonical-guard-helper.sh" ]]; then
 	# shellcheck disable=SC1091
 	source "${SCRIPT_DIR}/canonical-guard-helper.sh" 2>/dev/null || true
 fi
+
+if [[ -f "${SCRIPT_DIR}/pr-supersession-helper.sh" ]]; then
+	# shellcheck source=pr-supersession-helper.sh
+	# shellcheck disable=SC1091
+	source "${SCRIPT_DIR}/pr-supersession-helper.sh" 2>/dev/null || true
+fi
 # Caller ID constant (avoids repeated literals in audit log lines).
 _WTAR_DPS_CALLER="pulse-dirty-pr-sweep.sh"
 
@@ -203,6 +209,31 @@ _dps_iso_to_epoch() {
 	[[ "$epoch" =~ ^[0-9]+$ ]] || epoch=0
 	printf '%s' "$epoch"
 	return 0
+}
+
+_dps_supersession_reason() {
+	local pr_obj="$1"
+	local repo_slug="$2"
+	local repo_path="$3"
+
+	if ! declare -F _psh_classify_json >/dev/null 2>&1; then
+		return 1
+	fi
+
+	local result classification rationale
+	result=$(_psh_classify_json "$pr_obj" "$repo_path" 1 2>/dev/null) || return 1
+	classification=$(printf '%s' "$result" | jq -r '.classification // empty' 2>/dev/null) || classification=""
+	rationale=$(printf '%s' "$result" | jq -r '.rationale // empty' 2>/dev/null) || rationale=""
+	case "$classification" in
+		fully_superseded|stale_baseline_only)
+			printf 'supersession-check:%s:%s' "$classification" "$rationale"
+			return 0
+			;;
+		*)
+			_dps_log "PR in ${repo_slug}: supersession pre-check=${classification:-unknown}"
+			return 1
+			;;
+	esac
 }
 
 # -----------------------------------------------------------------------------
@@ -987,6 +1018,13 @@ _dirty_pr_sweep_for_repo() {
 		[[ -n "$pr_obj" ]] || continue
 		pr_number=$(printf '%s' "$pr_obj" | jq -r '.number // empty')
 		[[ -n "$pr_number" ]] || continue
+
+		local supersession_reason=""
+		if supersession_reason=$(_dps_supersession_reason "$pr_obj" "$repo_slug" "$repo_path" 2>/dev/null); then
+			_dps_log "PR #$pr_number ($repo_slug): supersession candidate — notifying before conflict repair"
+			_dirty_pr_action_notify "$pr_number" "$repo_slug" "$supersession_reason" || true
+			continue
+		fi
 
 		decision=$(_dirty_pr_classify "$pr_obj" "$repo_slug" "$repo_path" "$self_login")
 		action="${decision%%|*}"

--- a/.agents/scripts/tests/test-pr-supersession-helper.sh
+++ b/.agents/scripts/tests/test-pr-supersession-helper.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# Regression tests for pr-supersession-helper.sh.
+
+set -uo pipefail
+
+TEST_DIR="$(cd "$(dirname "$0")" && pwd)"
+HELPER="${TEST_DIR}/../pr-supersession-helper.sh"
+ROOT=$(mktemp -d)
+trap 'rm -rf "$ROOT"' EXIT
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1"
+	local rc="$2"
+	local extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf 'PASS %s\n' "$name"
+	else
+		printf 'FAIL %s %s\n' "$name" "$extra"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+setup_repo() {
+	local repo="$1"
+	rm -rf "$repo"
+	mkdir -p "$repo"
+	(
+		cd "$repo" || exit 1
+		git init -q -b main
+		git config user.email test@example.com
+		git config user.name tester
+		git config commit.gpgsign false
+		printf 'base\n' >README.md
+		git add -A && git commit -qm base
+		git update-ref refs/remotes/origin/main main
+		git symbolic-ref refs/remotes/origin/HEAD refs/remotes/origin/main
+	)
+	return 0
+}
+
+mkpr_json() {
+	local number="$1"
+	local title="$2"
+	local body="$3"
+	local head="$4"
+	local file="$5"
+	jq -n \
+		--argjson number "$number" \
+		--arg title "$title" \
+		--arg body "$body" \
+		--arg head "$head" \
+		--arg file "$file" \
+		'{number:$number,title:$title,body:$body,baseRefName:"main",headRefName:$head,files:[{path:$file}],author:{login:"tester"},url:"https://example.invalid/pr"}'
+	return 0
+}
+
+classify_fixture() {
+	local pr_json="$1"
+	local repo="$2"
+	bash -c 'source "$1"; _psh_classify_json "$2" "$3" 1' _ "$HELPER" "$pr_json" "$repo" \
+		| jq -r '.classification'
+	return 0
+}
+
+repo_full="${ROOT}/full"
+setup_repo "$repo_full"
+(
+	cd "$repo_full" || exit 1
+	printf 'mention_alert_preference enabled\n' >feature.txt
+	git add feature.txt && git commit -qm 'base has deliverable'
+	git update-ref refs/remotes/origin/main main
+	git checkout -qb feature/full
+	git update-ref refs/remotes/origin/feature/full feature/full
+)
+pr_full=$(mkpr_json 1 'Add mention_alert_preference' 'Core deliverable: mention_alert_preference.' 'feature/full' 'feature.txt')
+got=$(classify_fixture "$pr_full" "$repo_full")
+[[ "$got" == "fully_superseded" ]] \
+	&& print_result "fully superseded: no branch diff + base has deliverable" 0 \
+	|| print_result "fully superseded: no branch diff + base has deliverable" 1 "got=$got"
+
+repo_partial="${ROOT}/partial"
+setup_repo "$repo_partial"
+(
+	cd "$repo_partial" || exit 1
+	printf 'mention_alert_preference enabled\n' >feature.txt
+	git add feature.txt && git commit -qm 'base has one term'
+	git update-ref refs/remotes/origin/main main
+	git checkout -qb feature/partial
+	printf 'new_delivery_channel\n' >channel.txt
+	git add channel.txt && git commit -qm 'branch has remaining work'
+	git update-ref refs/remotes/origin/feature/partial feature/partial
+)
+pr_partial=$(mkpr_json 2 'Add mention_alert_preference new_delivery_channel' 'Core deliverables: mention_alert_preference and new_delivery_channel.' 'feature/partial' 'channel.txt')
+got=$(classify_fixture "$pr_partial" "$repo_partial")
+[[ "$got" == "partially_superseded" ]] \
+	&& print_result "partially superseded: base has some deliverable terms" 0 \
+	|| print_result "partially superseded: base has some deliverable terms" 1 "got=$got"
+
+repo_needed="${ROOT}/needed"
+setup_repo "$repo_needed"
+(
+	cd "$repo_needed" || exit 1
+	git checkout -qb feature/needed
+	printf 'mention_alert_preference enabled\n' >feature.txt
+	git add feature.txt && git commit -qm 'branch has deliverable'
+	git update-ref refs/remotes/origin/feature/needed feature/needed
+)
+pr_needed=$(mkpr_json 3 'Add mention_alert_preference' 'Core deliverable: mention_alert_preference.' 'feature/needed' 'feature.txt')
+got=$(classify_fixture "$pr_needed" "$repo_needed")
+[[ "$got" == "still_needed" ]] \
+	&& print_result "still needed: deliverable only exists on branch" 0 \
+	|| print_result "still needed: deliverable only exists on branch" 1 "got=$got"
+
+repo_baseline="${ROOT}/baseline"
+setup_repo "$repo_baseline"
+(
+	cd "$repo_baseline" || exit 1
+	printf 'mention_alert_preference enabled\n' >feature.txt
+	git add feature.txt && git commit -qm 'base has deliverable'
+	git update-ref refs/remotes/origin/main main
+	git checkout -qb feature/baseline
+	printf 'stale baseline noise\n' >noise.txt
+	git add noise.txt && git commit -qm 'branch has stale baseline noise'
+	git update-ref refs/remotes/origin/feature/baseline feature/baseline
+)
+pr_baseline=$(mkpr_json 4 'Add mention_alert_preference' 'Core deliverable: mention_alert_preference.' 'feature/baseline' 'feature.txt')
+got=$(classify_fixture "$pr_baseline" "$repo_baseline")
+[[ "$got" == "stale_baseline_only" ]] \
+	&& print_result "stale baseline only: base has deliverable, diff no longer overlaps PR files" 0 \
+	|| print_result "stale baseline only: base has deliverable, diff no longer overlaps PR files" 1 "got=$got"
+
+if [[ "$TESTS_FAILED" -eq 0 ]]; then
+	printf '\nAll %s pr-supersession tests passed.\n' "$TESTS_RUN"
+	exit 0
+fi
+
+exit 1


### PR DESCRIPTION
## Summary
- Added `pr-supersession-helper.sh` to classify fully superseded, partially superseded, still-needed, and stale-baseline-only PRs before conflict repair.
- Wired `pulse-dirty-pr-sweep.sh` to run the advisory supersession pre-check before normal dirty/conflict actions and notify instead of repairing superseded candidates.
- Documented the DIRTY PR supersession decision tree.

## Testing
- `.agents/scripts/tests/test-pr-supersession-helper.sh`
- `shellcheck .agents/scripts/pr-supersession-helper.sh .agents/scripts/pulse-dirty-pr-sweep.sh .agents/scripts/tests/test-pr-supersession-helper.sh`
- `npx --yes markdownlint-cli2 .agents/reference/auto-merge.md`
- `.agents/scripts/linters-local.sh` attempted; timed out after legacy repository-wide repeated-string warnings, after changed-file pre-commit gates had passed.

## Runtime Testing
- Low risk: shell helper + tests + documentation. Self-assessed with mocked git/PR fixtures and shellcheck.

## Key decisions
- The new helper is advisory-only and emits suggested close rationale; it never closes PRs itself.
- The dirty PR sweep only notifies on supersession candidates, preserving explicit close decisions for maintainers.

Resolves #22058

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.44 plugin for [OpenCode](https://opencode.ai) v1.14.30 with gpt-5.5 spent 29m and 220,367 tokens on this as a headless worker.