### PR TITLE
t3256: Make linters-local string literal gate ratchet-based

### DIFF
--- a/.agents/scripts/linters-local-validators.sh
+++ b/.agents/scripts/linters-local-validators.sh
@@ -186,9 +186,14 @@ check_string_literals() {
 
 	local violations=0
 	local debt_files=0
-	local repo_root baseline_ref
+	local repo_root baseline_ref changed_shell_files
 	repo_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 	baseline_ref=$(git -C "$repo_root" merge-base HEAD origin/main 2>/dev/null || printf '%s' 'origin/main')
+	changed_shell_files=$(git -C "$repo_root" diff --name-only "$baseline_ref" -- '*.sh' 2>/dev/null || true)
+	if [[ -z "$changed_shell_files" ]]; then
+		print_success "String literals: no changed shell files"
+		return 0
+	fi
 
 	for file in "${ALL_SH_FILES[@]}"; do
 		[[ -f "$file" ]] || continue
@@ -203,7 +208,7 @@ check_string_literals() {
 		file_dir=$(cd "$(dirname "$file")" && pwd -P)
 		file_abs="${file_dir}/$(basename "$file")"
 		rel_file=${file_abs#"$repo_root"/}
-		if git -C "$repo_root" diff --quiet "$baseline_ref" -- "$rel_file" 2>/dev/null; then
+		if ! printf '%s\n' "$changed_shell_files" | grep -qxF "$rel_file"; then
 			continue
 		fi
 

--- a/.agents/scripts/linters-local-validators.sh
+++ b/.agents/scripts/linters-local-validators.sh
@@ -185,26 +185,85 @@ check_string_literals() {
 	echo -e "${BLUE}Checking String Literals (S1192)...${NC}"
 
 	local violations=0
+	local debt_files=0
+	local repo_root
+	repo_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
 
 	for file in "${ALL_SH_FILES[@]}"; do
 		[[ -f "$file" ]] || continue
-		# Find strings that appear 3 or more times
-		local repeated_strings
-		repeated_strings=$(grep -o '"[^"]*"' "$file" | sort | uniq -c | awk '$1 >= 3 {print $1, $2}' | wc -l)
+		if [[ "$file" == *"/tests/"* ]] || [[ "$(basename "$file")" == test-*.sh ]]; then
+			continue
+		fi
 
-		if [[ $repeated_strings -gt 0 ]]; then
-			((violations += repeated_strings))
-			print_warning "$file has $repeated_strings repeated string literals"
+		# Diff-scope the expensive string-literal scan. Pre-existing repository-wide
+		# debt is not actionable for unrelated changes and must not block local
+		# preflight.
+		local repeated_strings baseline_strings rel_file base_content file_abs file_dir
+		file_dir=$(cd "$(dirname "$file")" && pwd -P)
+		file_abs="${file_dir}/$(basename "$file")"
+		rel_file=${file_abs#"$repo_root"/}
+		if git -C "$repo_root" diff --quiet origin/main -- "$rel_file" 2>/dev/null; then
+			continue
+		fi
+
+		repeated_strings=$(_linters_count_repeated_literals <"$file")
+		[[ "$repeated_strings" =~ ^[0-9]+$ ]] || repeated_strings=0
+
+		baseline_strings=0
+		base_content=$(git -C "$repo_root" show "origin/main:${rel_file}" 2>/dev/null || true)
+		if [[ -n "$base_content" ]]; then
+			baseline_strings=$(printf '%s\n' "$base_content" | _linters_count_repeated_literals)
+			[[ "$baseline_strings" =~ ^[0-9]+$ ]] || baseline_strings=0
+		fi
+
+		if ((repeated_strings > baseline_strings)); then
+			local new_strings=$((repeated_strings - baseline_strings))
+			((violations += new_strings))
+			print_error "$file has $new_strings new repeated string literal(s) (baseline: $baseline_strings, current: $repeated_strings)"
+			_linters_show_repeated_literals <"$file"
+		elif ((repeated_strings > 0)); then
+			((debt_files += 1))
+			print_warning "$file has $repeated_strings pre-existing repeated string literal(s) (not blocking)"
 		fi
 	done
 
-	if [[ $violations -le $MAX_STRING_LITERAL_ISSUES ]]; then
-		print_success "String literals: $violations violations (within threshold)"
+	if [[ $violations -eq 0 ]]; then
+		print_success "String literals: no new repeated string literals (${debt_files} file(s) with pre-existing debt)"
 	else
-		print_error "String literals: $violations violations (exceeds threshold of $MAX_STRING_LITERAL_ISSUES)"
+		print_error "String literals: $violations new repeated string literal regression(s)"
 		return 1
 	fi
 
+	return 0
+}
+
+_linters_count_repeated_literals() {
+	grep -v '^[[:space:]]*#' |
+		sed -E '
+			s/"\$[A-Za-z_][A-Za-z0-9_]*"//g
+			s/"\$\{[^}]*\}"//g
+			s/"\$@"//g
+			s/"\$[0-9*#?$!-]"//g
+		' |
+		grep -oE '"[^"]{4,}"' |
+		grep -vE '^"[0-9]+\.?[0-9]*"$' |
+		grep -vE '^"\$' |
+		sort | uniq -c | awk '$1 >= 3' | wc -l | tr -d '[:space:]'
+	return 0
+}
+
+_linters_show_repeated_literals() {
+	grep -v '^[[:space:]]*#' |
+		sed -E '
+			s/"\$[A-Za-z_][A-Za-z0-9_]*"//g
+			s/"\$\{[^}]*\}"//g
+			s/"\$@"//g
+			s/"\$[0-9*#?$!-]"//g
+		' |
+		grep -oE '"[^"]{4,}"' |
+		grep -vE '^"[0-9]+\.?[0-9]*"$' |
+		grep -vE '^"\$' |
+		sort | uniq -c | awk '$1 >= 3 {print "  " $1 "x: " $2}' | head -3
 	return 0
 }
 

--- a/.agents/scripts/linters-local-validators.sh
+++ b/.agents/scripts/linters-local-validators.sh
@@ -186,8 +186,9 @@ check_string_literals() {
 
 	local violations=0
 	local debt_files=0
-	local repo_root
+	local repo_root baseline_ref
 	repo_root=$(git rev-parse --show-toplevel 2>/dev/null || pwd)
+	baseline_ref=$(git -C "$repo_root" merge-base HEAD origin/main 2>/dev/null || printf '%s' 'origin/main')
 
 	for file in "${ALL_SH_FILES[@]}"; do
 		[[ -f "$file" ]] || continue
@@ -202,7 +203,7 @@ check_string_literals() {
 		file_dir=$(cd "$(dirname "$file")" && pwd -P)
 		file_abs="${file_dir}/$(basename "$file")"
 		rel_file=${file_abs#"$repo_root"/}
-		if git -C "$repo_root" diff --quiet origin/main -- "$rel_file" 2>/dev/null; then
+		if git -C "$repo_root" diff --quiet "$baseline_ref" -- "$rel_file" 2>/dev/null; then
 			continue
 		fi
 
@@ -210,7 +211,7 @@ check_string_literals() {
 		[[ "$repeated_strings" =~ ^[0-9]+$ ]] || repeated_strings=0
 
 		baseline_strings=0
-		base_content=$(git -C "$repo_root" show "origin/main:${rel_file}" 2>/dev/null || true)
+		base_content=$(git -C "$repo_root" show "${baseline_ref}:${rel_file}" 2>/dev/null || true)
 		if [[ -n "$base_content" ]]; then
 			baseline_strings=$(printf '%s\n' "$base_content" | _linters_count_repeated_literals)
 			[[ "$baseline_strings" =~ ^[0-9]+$ ]] || baseline_strings=0

--- a/.agents/scripts/tests/test-string-literal-ratchet.sh
+++ b/.agents/scripts/tests/test-string-literal-ratchet.sh
@@ -328,6 +328,7 @@ EOF
 		-c user.email='test@example.invalid' \
 		commit -q -m 'baseline repeated string debt'
 	git -C "$tmp_repo" update-ref refs/remotes/origin/main HEAD
+	printf '\n# unrelated maintenance comment\n' >>"$fixture"
 
 	local output ret
 	(

--- a/.agents/scripts/tests/test-string-literal-ratchet.sh
+++ b/.agents/scripts/tests/test-string-literal-ratchet.sh
@@ -289,6 +289,67 @@ test_posix_grep_comment_filter() {
 }
 
 # ---------------------------------------------------------------------------
+# Local linter regression: repository-wide pre-existing debt is advisory only
+#
+# A file that already has repeated string-literal debt at origin/main must not
+# make linters-local.sh fail when the current branch has not increased that
+# file's repeated-literal count.
+# ---------------------------------------------------------------------------
+test_local_linter_preexisting_debt_nonblocking() {
+	local scripts_root="${SCRIPT_DIR}/.."
+	local old_script_dir="$SCRIPT_DIR"
+	SCRIPT_DIR="$scripts_root"
+	BLUE=""
+	NC=""
+	print_error() { printf '[ERROR] %s\n' "$1" >&2; return 0; }
+	print_warning() { printf '[WARNING] %s\n' "$1" >&2; return 0; }
+	print_info() { printf '[INFO] %s\n' "$1" >&2; return 0; }
+	print_success() { printf '[OK] %s\n' "$1" >&2; return 0; }
+	# shellcheck disable=SC1091
+	source "${scripts_root}/linters-local-validators.sh"
+	SCRIPT_DIR="$old_script_dir"
+
+	local tmp_repo
+	tmp_repo=$(mktemp -d 2>/dev/null || mktemp -d -t string-literal-ratchet)
+	mkdir -p "${tmp_repo}/.agents/scripts"
+
+	local fixture="${tmp_repo}/.agents/scripts/legacy.sh"
+	cat >"$fixture" <<'EOF'
+#!/usr/bin/env bash
+legacy_one() { printf '%s\n' "legacy repeated debt"; return 0; }
+legacy_two() { printf '%s\n' "legacy repeated debt"; return 0; }
+legacy_three() { printf '%s\n' "legacy repeated debt"; return 0; }
+EOF
+
+	git -C "$tmp_repo" init -q
+	git -C "$tmp_repo" add .agents/scripts/legacy.sh
+	git -C "$tmp_repo" \
+		-c user.name='Test User' \
+		-c user.email='test@example.invalid' \
+		commit -q -m 'baseline repeated string debt'
+	git -C "$tmp_repo" update-ref refs/remotes/origin/main HEAD
+
+	local output ret
+	(
+		cd "$tmp_repo" || exit 1
+		ALL_SH_FILES=("$fixture")
+		check_string_literals
+	) >"${tmp_repo}/output.txt" 2>&1
+	ret=$?
+	output=$(cat "${tmp_repo}/output.txt")
+
+	rm -rf "$tmp_repo"
+
+	if [ "$ret" -eq 0 ] && printf '%s' "$output" | grep -q 'no new repeated string literals'; then
+		print_result "local linter: pre-existing string-literal debt is non-blocking" 0
+	else
+		print_result "local linter: pre-existing string-literal debt is non-blocking" 1 \
+			"expected success with no-new-regression summary, got ret=$ret output=[$output]"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
 # Run all tests
 # ---------------------------------------------------------------------------
 main() {
@@ -306,6 +367,7 @@ main() {
 	test_boundary_escaped_dollar_caught
 	test_show_matches_count_no_phantom
 	test_posix_grep_comment_filter
+	test_local_linter_preexisting_debt_nonblocking
 
 	echo ""
 	if [ "$TESTS_FAILED" -eq 0 ]; then


### PR DESCRIPTION
## Summary

Diff-scope the local string literal gate against the PR merge base so pre-existing repository-wide debt is advisory and unrelated changes are not blocked.

## Files Changed

- .agents/scripts/linters-local-validators.sh
- .agents/scripts/tests/test-string-literal-ratchet.sh

## Runtime Testing

- **Risk level:** Low (local lint gate / regression test)
- **Verification:** Passed: .agents/scripts/tests/test-string-literal-ratchet.sh
- **Verification:** Passed: shellcheck .agents/scripts/linters-local-validators.sh .agents/scripts/tests/test-string-literal-ratchet.sh
- **Verification:** Passed: targeted check_string_literals path
- **Note:** Full .agents/scripts/linters-local.sh reached the string-literal success path, then timed out later in Secretlint.

Resolves #22039


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.47 plugin for [OpenCode](https://opencode.ai) v1.14.30 with gpt-5.5 spent 32m and 275,916 tokens on this as a headless worker.