### PR TITLE
GH#22064: bound legacy OpenCode setup path

### DIFF
--- a/.agents/scripts/tests/test-tool-install-opencode.sh
+++ b/.agents/scripts/tests/test-tool-install-opencode.sh
@@ -52,6 +52,9 @@ assert_eq() {
 extract_functions() {
 	# Use awk to extract the three functions by name.
 	awk '
+		/^_setup_opencode_timeout_cmd\(\)/, /^}$/ { print; next }
+		/^_setup_opencode_version_output\(\)/, /^}$/ { print; next }
+		/^_setup_opencode_first_line\(\)/, /^}$/ { print; next }
 		/^_setup_validate_opencode_binary\(\)/, /^}$/ { print; next }
 		/^_setup_opencode_force_heal\(\)/, /^}$/ { print; next }
 		/^setup_opencode_cli\(\)/, /^}$/ { print; next }
@@ -134,6 +137,34 @@ echo "Test 3: _setup_validate_opencode_binary on missing path"
 ) >"$SANDBOX/out3" 2>&1
 assert_eq "missing path -> rc=2" "2" "$(tail -1 "$SANDBOX/out3")"
 
+# --- Test 3b: validator bounds hanging --version ---------------------------
+echo "Test 3b: _setup_validate_opencode_binary bounds hanging --version"
+cat >"$SANDBOX/bin/opencode-slow" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+	sleep 5
+	echo "1.14.25"
+fi
+EOF
+chmod +x "$SANDBOX/bin/opencode-slow"
+(
+	source_extracted
+	export AIDEVOPS_OPENCODE_VERSION_TIMEOUT=1
+	SECONDS=0
+	rc=0
+	_setup_validate_opencode_binary "$SANDBOX/bin/opencode-slow" || rc=$?
+	printf 'rc=%s elapsed=%s\n' "$rc" "$SECONDS"
+) >"$SANDBOX/out3b" 2>&1
+rc3b=$(grep '^rc=' "$SANDBOX/out3b" | tail -1)
+elapsed3b="${rc3b##*elapsed=}"
+rc3b="${rc3b%% elapsed=*}"
+assert_eq "hanging version -> rc=2" "rc=2" "$rc3b"
+if [[ "$elapsed3b" =~ ^[0-9]+$ ]] && [[ "$elapsed3b" -le 3 ]]; then
+	assert_eq "hanging version returns within bound" "bounded" "bounded"
+else
+	assert_eq "hanging version returns within bound" "elapsed<=3" "elapsed=${elapsed3b}"
+fi
+
 # --- Test 4: setup_opencode_cli skip when valid + persists path ------------
 echo "Test 4: setup_opencode_cli skip-when-valid path"
 rm -f "$HOME/.aidevops/.opencode-bin-resolved"
@@ -178,6 +209,35 @@ assert_eq "post-heal validation success" "1" "$post_heal_success"
 echo "Test 6: post-heal persisted resolved path"
 [[ -f "$HOME/.aidevops/.opencode-bin-resolved" ]] && resolved6=$(cat "$HOME/.aidevops/.opencode-bin-resolved") || resolved6="MISSING"
 assert_eq "post-heal resolved-path file populated" "$SANDBOX/bin/opencode" "$resolved6"
+
+# --- Test 7: auto-heal bounds hanging installer ----------------------------
+echo "Test 7: setup_opencode_cli bounds hanging auto-heal installer"
+rm -f "$HOME/.aidevops/.opencode-bin-resolved"
+cp "$SANDBOX/bin/opencode-claude" "$SANDBOX/bin/opencode"
+(
+	source_extracted
+	npm_global_install() {
+		sleep 5
+		return 0
+	}
+	export -f npm_global_install 2>/dev/null || true
+	export PATH="$SANDBOX/bin:$PATH"
+	export AIDEVOPS_OPENCODE_VERSION_TIMEOUT=1
+	export AIDEVOPS_OPENCODE_INSTALL_TIMEOUT=1
+	SECONDS=0
+	rc=0
+	setup_opencode_cli || rc=$?
+	printf 'rc=%s elapsed=%s\n' "$rc" "$SECONDS"
+) >"$SANDBOX/out7" 2>&1
+rc7=$(grep '^rc=' "$SANDBOX/out7" | tail -1)
+elapsed7="${rc7##*elapsed=}"
+rc7="${rc7%% elapsed=*}"
+assert_eq "hanging auto-heal fail-opens" "rc=0" "$rc7"
+if [[ "$elapsed7" =~ ^[0-9]+$ ]] && [[ "$elapsed7" -le 4 ]]; then
+	assert_eq "hanging auto-heal returns within bound" "bounded" "bounded"
+else
+	assert_eq "hanging auto-heal returns within bound" "elapsed<=4" "elapsed=${elapsed7}"
+fi
 
 echo ""
 echo "===== Results: $PASS passed, $FAIL failed ====="

--- a/setup-modules/tool-install.sh
+++ b/setup-modules/tool-install.sh
@@ -1547,6 +1547,82 @@ setup_nodejs() {
 	return 0
 }
 
+# Bound OpenCode setup probes/installers so non-interactive setup cannot hang
+# indefinitely when an opencode shim or package manager blocks.
+_setup_opencode_timeout_cmd() {
+	local timeout_seconds="$1"
+	shift
+
+	[[ "$timeout_seconds" =~ ^[0-9]+$ ]] || timeout_seconds=5
+	[[ "$timeout_seconds" -gt 0 ]] || timeout_seconds=5
+
+	local command_name="${1:-}"
+	if [[ -n "$command_name" ]] && ! declare -F "$command_name" >/dev/null 2>&1; then
+		if declare -F timeout_sec >/dev/null 2>&1; then
+			timeout_sec "$timeout_seconds" "$@"
+			return $?
+		fi
+
+		if command -v gtimeout >/dev/null 2>&1; then
+			gtimeout "$timeout_seconds" "$@"
+			return $?
+		fi
+
+		if command -v timeout >/dev/null 2>&1; then
+			timeout "$timeout_seconds" "$@"
+			return $?
+		fi
+	fi
+
+	local output_file=""
+	output_file=$(mktemp "${TMPDIR:-/tmp}/aidevops-opencode-timeout.XXXXXX" 2>/dev/null || printf '')
+	if [[ -z "$output_file" ]]; then
+		"$@"
+		return $?
+	fi
+
+	local pid=""
+	"$@" >"$output_file" 2>&1 &
+	pid=$!
+
+	local elapsed=0
+	while kill -0 "$pid" 2>/dev/null; do
+		if [[ "$elapsed" -ge "$timeout_seconds" ]]; then
+			kill "$pid" 2>/dev/null || true
+			wait "$pid" 2>/dev/null || true
+			rm -f "$output_file" 2>/dev/null || true
+			return 124
+		fi
+		sleep 1
+		elapsed=$((elapsed + 1))
+	done
+
+	local rc=0
+	wait "$pid" || rc=$?
+	while IFS= read -r line; do
+		printf '%s\n' "$line"
+	done <"$output_file"
+	rm -f "$output_file" 2>/dev/null || true
+	return "$rc"
+}
+
+_setup_opencode_version_output() {
+	local bin="$1"
+	local version_timeout="${AIDEVOPS_OPENCODE_VERSION_TIMEOUT:-5}"
+
+	_setup_opencode_timeout_cmd "$version_timeout" "$bin" --version
+	return $?
+}
+
+_setup_opencode_first_line() {
+	local input="$1"
+	local first_line=""
+
+	IFS= read -r first_line <<<"$input" || true
+	printf '%s\n' "$first_line"
+	return 0
+}
+
 # t2891: Validate that an opencode binary is real anomalyco/opencode.
 # Mirrors the t2887 runtime canary validator (headless-runtime-lib.sh) and
 # the t2888 setup module validator (.agents/scripts/setup/_services.sh).
@@ -1559,7 +1635,7 @@ _setup_validate_opencode_binary() {
 	command -v "$bin" >/dev/null 2>&1 || return 2
 
 	local v
-	v=$("$bin" --version 2>/dev/null || echo "")
+	v=$(_setup_opencode_version_output "$bin" 2>/dev/null || printf '')
 	[[ -n "$v" ]] || return 2
 
 	# Anthropic claude CLI signature — highest-confidence rejection.
@@ -1597,7 +1673,8 @@ _setup_opencode_force_heal() {
 		return 0
 	fi
 
-	if run_with_spinner "Reinstalling OpenCode (heal)" npm_global_install "$install_pkg"; then
+	local install_timeout="${AIDEVOPS_OPENCODE_INSTALL_TIMEOUT:-180}"
+	if run_with_spinner "Reinstalling OpenCode (heal)" _setup_opencode_timeout_cmd "$install_timeout" npm_global_install "$install_pkg"; then
 		print_success "OpenCode reinstalled via $installer"
 	else
 		print_warning "Heal install failed via $installer"
@@ -1609,13 +1686,13 @@ _setup_opencode_force_heal() {
 	new_bin=$(command -v opencode 2>/dev/null || echo "")
 	if [[ -n "$new_bin" ]] && _setup_validate_opencode_binary "$new_bin"; then
 		local new_v
-		new_v=$("$new_bin" --version 2>/dev/null | head -1 || echo "unknown")
+		new_v=$(_setup_opencode_first_line "$(_setup_opencode_version_output "$new_bin" 2>/dev/null || printf 'unknown')")
 		print_success "OpenCode CLI: $new_bin ($new_v)"
 		mkdir -p "${HOME}/.aidevops" 2>/dev/null || true
 		printf '%s\n' "$new_bin" >"${HOME}/.aidevops/.opencode-bin-resolved" 2>/dev/null || true
 	else
 		local v_after
-		v_after=$("$new_bin" --version 2>/dev/null | head -1 || echo "<missing>")
+		v_after=$(_setup_opencode_first_line "$(_setup_opencode_version_output "$new_bin" 2>/dev/null || printf '<missing>')")
 		print_warning "Post-heal validation still failing: '$new_bin' returns '$v_after'"
 		print_info "Check PATH: 'which -a opencode' — npm/bun global bin dir must come first"
 	fi
@@ -1648,7 +1725,7 @@ setup_opencode_cli() {
 	# Already valid → record + early return.
 	if [[ $validate_rc -eq 0 ]]; then
 		local oc_version
-		oc_version=$("$current_bin" --version 2>/dev/null | head -1 || echo "unknown")
+		oc_version=$(_setup_opencode_first_line "$(_setup_opencode_version_output "$current_bin" 2>/dev/null || printf 'unknown')")
 		print_success "OpenCode already installed: $oc_version"
 		mkdir -p "${HOME}/.aidevops" 2>/dev/null || true
 		printf '%s\n' "$current_bin" >"${HOME}/.aidevops/.opencode-bin-resolved" 2>/dev/null || true
@@ -1658,7 +1735,7 @@ setup_opencode_cli() {
 	# Wrong package → auto-heal (no prompt).
 	if [[ $validate_rc -eq 1 ]]; then
 		local wrong_v
-		wrong_v=$("$current_bin" --version 2>/dev/null | head -1 || echo "<unknown>")
+		wrong_v=$(_setup_opencode_first_line "$(_setup_opencode_version_output "$current_bin" 2>/dev/null || printf '<unknown>')")
 		_setup_opencode_force_heal "$install_pkg" "$current_bin" "$wrong_v"
 		return 0
 	fi
@@ -1682,7 +1759,8 @@ setup_opencode_cli() {
 	local install_oc
 	setup_prompt install_oc "Install OpenCode via $installer? [Y/n]: " "Y"
 	if [[ "$install_oc" =~ ^[Yy]?$ ]]; then
-		if run_with_spinner "Installing OpenCode" npm_global_install "$install_pkg"; then
+		local install_timeout="${AIDEVOPS_OPENCODE_INSTALL_TIMEOUT:-180}"
+		if run_with_spinner "Installing OpenCode" _setup_opencode_timeout_cmd "$install_timeout" npm_global_install "$install_pkg"; then
 			print_success "OpenCode installed"
 
 			# Persist resolved path on first-time success too (t2891).


### PR DESCRIPTION
## Summary

Bound the setup-modules/tool-install.sh OpenCode validation and install path, which is the implementation actually sourced by setup.sh after bootstrap.

## Files Changed

.agents/scripts/tests/test-setup-stage-timing-observability.sh,.agents/scripts/tests/test-tool-install-opencode.sh,setup-modules/tool-install.sh,setup.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck setup-modules/tool-install.sh .agents/scripts/tests/test-tool-install-opencode.sh; .agents/scripts/tests/test-tool-install-opencode.sh (14 passed)

Resolves #22064


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.44 plugin for [OpenCode](https://opencode.ai) v1.14.30 with gpt-5.5 spent 40m and 354,969 tokens on this as a headless worker.