### PR TITLE
GH#22059: prevent setup skill generation hang

### DIFF
--- a/.agents/scripts/generate-skills.sh
+++ b/.agents/scripts/generate-skills.sh
@@ -102,57 +102,105 @@ log_file_success() {
 extract_frontmatter_field() {
 	local file="$1"
 	local field="$2"
+	local line=""
+	local in_frontmatter=false
 
 	if [[ ! -f "$file" ]]; then
 		return 1
 	fi
 
-	# Extract value between --- markers
-	awk -v field="$field" '
-        /^---$/ { in_frontmatter = !in_frontmatter; next }
-        in_frontmatter && $0 ~ "^" field ":" {
-            sub("^" field ": *", "")
-            gsub(/^["'"'"']|["'"'"']$/, "")  # Remove quotes
-            print
-            exit
-        }
-    ' "$file"
+	# Extract value between initial --- frontmatter markers without forking awk
+	# once per file. Skill generation may inspect hundreds of markdown files
+	# during setup, so avoiding per-file subprocesses keeps non-interactive setup
+	# within its bounded postflight window.
+	while IFS= read -r line; do
+		if [[ "$line" == "---" ]]; then
+			if [[ "$in_frontmatter" == true ]]; then
+				break
+			fi
+			in_frontmatter=true
+			continue
+		fi
+
+		if [[ "$in_frontmatter" == true && "$line" == "$field:"* ]]; then
+			line="${line#"${field}":}"
+			line="${line#"${line%%[![:space:]]*}"}"
+			line="${line%\"}"
+			line="${line#\"}"
+			line="${line%\'}"
+			line="${line#\'}"
+			printf '%s\n' "$line"
+			return 0
+		fi
+	done <"$file"
 	return 0
 }
 
 # Extract description from file - tries frontmatter first, then first heading
 extract_description() {
 	local file="$1"
-	local desc
+	local desc=""
 
 	# Try frontmatter first
 	desc=$(extract_frontmatter_field "$file" "description")
 	if [[ -n "$desc" ]]; then
-		echo "$desc"
-		return
+		printf '%s\n' "$desc"
+		return 0
 	fi
 
 	# Try first heading (# Title - Description pattern or just # Title)
-	local heading
-	heading=$(grep -m1 "^# " "$file" 2>/dev/null | sed 's/^# //')
+	local heading=""
+	local line=""
+	while IFS= read -r line; do
+		if [[ "$line" == "# "* ]]; then
+			heading="${line#\# }"
+			break
+		fi
+	done <"$file"
 	if [[ -n "$heading" ]]; then
 		# If heading has " - ", take the part after
 		if [[ "$heading" == *" - "* ]]; then
-			echo "${heading#* - }"
+			printf '%s\n' "${heading#* - }"
 		else
-			echo "$heading"
+			printf '%s\n' "$heading"
 		fi
-		return
+		return 0
 	fi
 
 	# Fallback to filename
-	echo "$(basename "$file" .md) skill"
+	local fallback="${file##*/}"
+	printf '%s skill\n' "${fallback%.md}"
+	return 0
 }
 
 # Convert name to valid skill name (lowercase, hyphens only)
 to_skill_name() {
 	local name="$1"
-	echo "$name" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9-]/-/g' | sed 's/--*/-/g' | sed 's/^-\|-$//g'
+	local lower=""
+	local out=""
+	local char=""
+	local last_dash=false
+	local i
+	lower=$(printf '%s' "$name" | tr '[:upper:]' '[:lower:]')
+
+	for ((i = 0; i < ${#lower}; i++)); do
+		char="${lower:i:1}"
+		case "$char" in
+		[a-z0-9])
+			out+="$char"
+			last_dash=false
+			;;
+		*)
+			if [[ "$last_dash" == false ]]; then
+				out+="-"
+				last_dash=true
+			fi
+			;;
+		esac
+	done
+	out="${out#-}"
+	out="${out%-}"
+	printf '%s\n' "$out"
 	return 0
 }
 
@@ -172,7 +220,7 @@ generate_folder_skill() {
 	local folder_path="$1"
 	local parent_md="$2"
 	local folder_name
-	folder_name=$(basename "$folder_path")
+	folder_name="${folder_path##*/}"
 	local skill_name
 	skill_name=$(to_skill_name "$folder_name")
 
@@ -199,7 +247,8 @@ generate_folder_skill() {
 generate_leaf_skill() {
 	local md_file="$1"
 	local filename
-	filename=$(basename "$md_file" .md)
+	filename="${md_file##*/}"
+	filename="${filename%.md}"
 	local skill_name
 	skill_name=$(to_skill_name "$filename")
 
@@ -304,7 +353,7 @@ if is_verbose_output; then
 fi
 
 while IFS= read -r folder; do
-	folder_name=$(basename "$folder")
+	folder_name="${folder##*/}"
 	parent_md="$AGENTS_DIR/${folder_name}.md"
 	skill_file="$folder/SKILL.md"
 
@@ -333,7 +382,7 @@ if is_verbose_output; then
 fi
 
 while IFS= read -r folder; do
-	folder_name=$(basename "$folder")
+	folder_name="${folder##*/}"
 	skill_file="$folder/SKILL.md"
 
 	# Skip if already handled or special
@@ -376,8 +425,9 @@ if is_verbose_output; then
 fi
 
 while IFS= read -r md_file; do
-	filename=$(basename "$md_file" .md)
-	parent_dir=$(dirname "$md_file")
+	filename="${md_file##*/}"
+	filename="${filename%.md}"
+	parent_dir="${md_file%/*}"
 	target_dir="${parent_dir}/${filename}"
 	skill_file="${target_dir}/SKILL.md"
 
@@ -426,8 +476,15 @@ if [[ "$DRY_RUN" == true ]]; then
 	log_warning ""
 	log_warning "This was a dry run. Run without --dry-run to generate files."
 else
-	# Write cache hash so next run skips if nothing changed
-	new_hash=$(compute_source_hash)
+	# Write cache hash so next run skips if nothing changed.
+	# The source set excludes generated SKILL.md files, so the pre-generation
+	# hash is still valid after generation. Reusing it avoids running a second
+	# find|sort pipeline after the visible "Generation complete" message, which
+	# can leave setup.sh looking hung even though generation itself finished.
+	new_hash="${current_hash:-}"
+	if [[ -z "$new_hash" ]]; then
+		new_hash=$(compute_source_hash)
+	fi
 	echo "$new_hash" >"$CACHE_HASH_FILE"
 fi
 

--- a/.agents/scripts/tests/test-generate-skills-cache-hash.sh
+++ b/.agents/scripts/tests/test-generate-skills-cache-hash.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+GENERATE_SKILLS_SCRIPT="${REPO_ROOT}/.agents/scripts/generate-skills.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_TMP_DIR=""
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+cleanup() {
+	if [[ -n "$TEST_TMP_DIR" && -d "$TEST_TMP_DIR" ]]; then
+		rm -rf "$TEST_TMP_DIR"
+	fi
+	return 0
+}
+
+make_test_agents_dir() {
+	TEST_TMP_DIR="$(mktemp -d)"
+	mkdir -p "$TEST_TMP_DIR/example" "$TEST_TMP_DIR/scripts"
+	cat >"$TEST_TMP_DIR/example.md" <<'EOF'
+---
+description: Example skill
+---
+
+# Example
+EOF
+	return 0
+}
+
+test_cache_hash_written_before_completion_summary() {
+	local output=""
+	local cache_hash=""
+	make_test_agents_dir
+
+	output=$(AIDEVOPS_AGENTS_DIR="$TEST_TMP_DIR" bash "$GENERATE_SKILLS_SCRIPT" 2>&1)
+	cache_hash=$(<"$TEST_TMP_DIR/.skills-source-hash")
+
+	if [[ -z "$cache_hash" ]]; then
+		print_result "generate-skills writes non-empty cache hash" 1 "cache hash was empty"
+		return 0
+	fi
+
+	if [[ "$output" != *"Generation complete:"* ]]; then
+		print_result "generate-skills emits completion summary" 1 "output=${output}"
+		return 0
+	fi
+
+	print_result "generate-skills reuses pre-generation hash after summary" 0
+	return 0
+}
+
+main() {
+	trap cleanup EXIT
+
+	test_cache_hash_written_before_completion_summary
+
+	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -ne 0 ]]; then
+		exit 1
+	fi
+
+	return 0
+}
+
+main "$@"

--- a/setup-modules/plugins.sh
+++ b/setup-modules/plugins.sh
@@ -220,15 +220,31 @@ generate_agent_skills() {
 	print_info "Generating Agent Skills SKILL.md files..."
 
 	local skills_script="$HOME/.aidevops/agents/scripts/generate-skills.sh"
+	local timeout_seconds="${AIDEVOPS_SKILLS_GENERATE_TIMEOUT:-90}"
+	local success_msg="Agent Skills SKILL.md files generated"
+	local generate_rc=0
 
 	if [[ -f "$skills_script" ]]; then
-		if bash "$skills_script" 2>/dev/null; then
-			print_success "Agent Skills SKILL.md files generated"
-			return 0
+		if command -v timeout >/dev/null 2>&1; then
+			if timeout "$timeout_seconds" bash "$skills_script" 2>/dev/null; then
+				print_success "$success_msg"
+				return 0
+			fi
+			generate_rc=$?
+			if [[ "$generate_rc" -eq 124 ]]; then
+				print_warning "Agent Skills generation exceeded ${timeout_seconds}s — continuing without skill symlink refresh"
+				return 1
+			fi
 		else
-			print_warning "Agent Skills generation encountered issues (non-critical)"
-			return 1
+			if bash "$skills_script" 2>/dev/null; then
+				print_success "$success_msg"
+				return 0
+			fi
+			generate_rc=$?
 		fi
+
+		print_warning "Agent Skills generation encountered issues (non-critical)"
+		return 1
 	else
 		print_warning "Agent Skills generator not found at $skills_script"
 		return 1


### PR DESCRIPTION
## Summary
- Reuses the pre-generation source hash so `generate-skills.sh` does not run a second `find|sort` pipeline after printing `Generation complete`.
- Replaces per-file basename/dirname/grep/sed/awk hot paths with Bash-native parsing to shorten cold skill generation.
- Bounds setup's skill generation stage with `AIDEVOPS_SKILLS_GENERATE_TIMEOUT` (default 90s) so non-critical skill generation cannot leave setup stuck.

## Testing
- `bash .agents/scripts/tests/test-generate-skills-cache-hash.sh`
- `shellcheck -e SC2154 setup-modules/plugins.sh`
- `shellcheck setup.sh .agents/scripts/generate-skills.sh .agents/scripts/tests/test-generate-skills-cache-hash.sh`
- `timeout 180 bash .agents/scripts/generate-skills.sh` completed with `generate_exit=0`
- `timeout 180 ./setup.sh --non-interactive` reached past `generate_agent_skills` successfully; later timeout at `deploy_agents_to_runtimes` is filed as #22087

## Runtime Testing
- self-assessed with bounded local setup run; full 180s setup completion is blocked by a separate later-stage hang tracked in #22087

Resolves #22059

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.51 plugin for [OpenCode](https://opencode.ai) v1.14.30 with gpt-5.5 spent 48m and 268,552 tokens on this as a headless worker.
