### PR TITLE
t3364: remove duplicate TODO entry

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3780,5 +3780,3 @@ t019.3.4,Update AGENTS.md with Beads integration docs,,beads,1h,45m,2025-12-21T1
 - [ ] t3367 fix setup hang in generate_agent_skills stage #auto-dispatch #bug #framework ref:GH#22077
 
 - [ ] t3366 Fix REST fallback wrapper test hang after PR fallback cases #auto-dispatch #bug ref:GH#22076
-
-- [ ] t3364 Fix task-complete helper merged PR detection for closed PRs #auto-dispatch #bug ref:GH#22075


### PR DESCRIPTION
## Summary

- Remove the duplicate bottom-of-file TODO entry for t3364 so the task appears once with ref:GH#22075.

## Runtime Testing

- **Risk level:** Low (planning-only cleanup)
- **Verification:** pre-commit TODO validation passed; pre-push checks passed.

For #22075


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.51 plugin for [OpenCode](https://opencode.ai) v1.14.30 with gpt-5.5 spent 50m and 330,198 tokens on this as a headless worker.