### PR TITLE
GH#22093: declare setup tool update prompt state

### DIFF
--- a/setup-modules/plugins.sh
+++ b/setup-modules/plugins.sh
@@ -699,6 +699,7 @@ check_tool_updates() {
 	bash "$tool_check_script" --quiet
 	echo ""
 
+	local do_update=""
 	setup_prompt do_update "Update all outdated tools now? [Y/n]: " "Y"
 
 	if [[ "$do_update" =~ ^[Yy]?$ || "$do_update" == "Y" ]]; then


### PR DESCRIPTION
## Summary
- Declares the `do_update` prompt variable before `setup_prompt` writes to it.
- Unblocks ShellCheck release preflight when `setup-modules/plugins.sh` is included in a patch release.

## Testing
- `shellcheck setup-modules/plugins.sh`

## Runtime Testing
- self-assessed; shell-only release preflight blocker fix

Resolves #22093

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.51 plugin for [OpenCode](https://opencode.ai) v1.14.30 with gpt-5.5 spent 1h 10m and 307,061 tokens on this as a headless worker.
