### PR TITLE
GH#22071: fix gh_create_issue empty argv from guarded array expansion

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-create.sh
+++ b/.agents/scripts/shared-gh-wrappers-create.sh
@@ -201,7 +201,8 @@ gh_create_issue() {
 	# Helper writes _GH_CI_FILTERED_ARGS and _GH_CI_TODO_LABEL_ARGS globals.
 	_gh_ci_prepare_todo_labels "$@"
 	set -- "${_GH_CI_FILTERED_ARGS[@]+"${_GH_CI_FILTERED_ARGS[@]}"}"
-	local -a _todo_label_args=("${_GH_CI_TODO_LABEL_ARGS[@]+"${_GH_CI_TODO_LABEL_ARGS[@]}"}")
+	local -a _todo_label_args=()
+	[[ ${#_GH_CI_TODO_LABEL_ARGS[@]} -gt 0 ]] && _todo_label_args=("${_GH_CI_TODO_LABEL_ARGS[@]}")
 
 	# t2028: auto-assign to the current user when the session is interactive
 	# and the caller did not pass an explicit --assignee. Reaches parity with
@@ -222,11 +223,21 @@ gh_create_issue() {
 			local auto_assignee
 			auto_assignee=$(_gh_wrapper_auto_assignee)
 			if [[ -n "$auto_assignee" ]]; then
-				issue_output=$(gh issue create "$@" "${_todo_label_args[@]+"${_todo_label_args[@]}"}" "${_origin_label_args[@]+"${_origin_label_args[@]}"}" --assignee "$auto_assignee") # aidevops-allow: raw-gh-wrapper
+				# GH#22071: use explicit length guards instead of ${arr[@]+"${arr[@]}"}
+				# to prevent empty argv elements when arrays are empty (mirrors gh_create_pr fix).
+				local -a _issue_cmd=(gh issue create "$@")
+				[[ ${#_todo_label_args[@]} -gt 0 ]] && _issue_cmd+=("${_todo_label_args[@]}")
+				[[ ${#_origin_label_args[@]} -gt 0 ]] && _issue_cmd+=("${_origin_label_args[@]}")
+				_issue_cmd+=(--assignee "$auto_assignee")
+				issue_output=$("${_issue_cmd[@]}") # aidevops-allow: raw-gh-wrapper
 				rc=$?
 				if [[ $rc -ne 0 ]] && _rest_should_fallback; then
 					print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to REST for issue create"
-					issue_output=$(_rest_issue_create "$@" "${_todo_label_args[@]+"${_todo_label_args[@]}"}" "${_origin_label_args[@]+"${_origin_label_args[@]}"}" --assignee "$auto_assignee")
+					local -a _rest_cmd=("$@")
+					[[ ${#_todo_label_args[@]} -gt 0 ]] && _rest_cmd+=("${_todo_label_args[@]}")
+					[[ ${#_origin_label_args[@]} -gt 0 ]] && _rest_cmd+=("${_origin_label_args[@]}")
+					_rest_cmd+=(--assignee "$auto_assignee")
+					issue_output=$(_rest_issue_create "${_rest_cmd[@]}")
 					rc=$?
 				fi
 				echo "$issue_output"
@@ -236,11 +247,19 @@ gh_create_issue() {
 		fi
 	fi
 
-	issue_output=$(gh issue create "$@" "${_todo_label_args[@]+"${_todo_label_args[@]}"}" "${_origin_label_args[@]+"${_origin_label_args[@]}"}") # aidevops-allow: raw-gh-wrapper
+	# GH#22071: use explicit length guards instead of ${arr[@]+"${arr[@]}"}
+	# to prevent empty argv elements when arrays are empty (mirrors gh_create_pr fix).
+	local -a _issue_cmd=(gh issue create "$@")
+	[[ ${#_todo_label_args[@]} -gt 0 ]] && _issue_cmd+=("${_todo_label_args[@]}")
+	[[ ${#_origin_label_args[@]} -gt 0 ]] && _issue_cmd+=("${_origin_label_args[@]}")
+	issue_output=$("${_issue_cmd[@]}") # aidevops-allow: raw-gh-wrapper
 	rc=$?
 	if [[ $rc -ne 0 ]] && _rest_should_fallback; then
 		print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to REST for issue create"
-		issue_output=$(_rest_issue_create "$@" "${_todo_label_args[@]+"${_todo_label_args[@]}"}" "${_origin_label_args[@]+"${_origin_label_args[@]}"}")
+		local -a _rest_cmd=("$@")
+		[[ ${#_todo_label_args[@]} -gt 0 ]] && _rest_cmd+=("${_todo_label_args[@]}")
+		[[ ${#_origin_label_args[@]} -gt 0 ]] && _rest_cmd+=("${_origin_label_args[@]}")
+		issue_output=$(_rest_issue_create "${_rest_cmd[@]}")
 		rc=$?
 	fi
 	echo "$issue_output"

--- a/.agents/scripts/tests/test-origin-label-mutex-create.sh
+++ b/.agents/scripts/tests/test-origin-label-mutex-create.sh
@@ -346,6 +346,23 @@ else
 		"got $n labels in: $(tail -1 "$GH_RECORD_FILE")"
 fi
 
+# B'5: caller origin must not leave an empty argv element before gh issue create.
+# Regression for GH#22071: the guarded array expansion emitted "" when
+# _origin_label_args was empty, so gh failed with: unknown argument "".
+reset_recorder
+export GH_ARGV_RECORD_FILE="${TEST_ROOT}/gh_argv_issue_calls.log"
+: >"$GH_ARGV_RECORD_FILE"
+SESSION_ORIGIN_OVERRIDE="origin:worker" \
+	gh_create_issue --repo o/r --title "t1: x" --body "Issue body" \
+	--label "origin:interactive" >/dev/null 2>&1
+if grep -qx '<>' "$GH_ARGV_RECORD_FILE"; then
+	print_result "B'5: gh_create_issue caller origin passes no empty argv element" 1 \
+		"empty argv element reached gh: $(tr '\n' ' ' <"$GH_ARGV_RECORD_FILE")"
+else
+	print_result "B'5: gh_create_issue caller origin passes no empty argv element" 0
+fi
+unset GH_ARGV_RECORD_FILE
+
 # ---------------------------------------------------------------------------
 # Layer C: structural checks on full-loop-helper-commit.sh
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix `gh_create_issue` wrapper so it does not forward empty positional arguments to `gh issue create`.

## Problem

Calling `gh_create_issue --body-file ... --label origin:interactive ...` failed with:

```
unknown arguments ["" ""]; please quote all values that have spaces
```

The wrapper used `"${arr[@]+"${arr[@]}"}"` to conditionally expand optional arrays (`_origin_label_args`, `_todo_label_args`). When these arrays are empty, this pattern can emit an empty string argv element in some contexts, which `gh` rejects.

## Fix

Replace the guarded array expansion pattern with explicit `${#arr[@]} -gt 0` length guards — the same fix applied to `gh_create_pr` in #22043. All four call sites updated:

- Assignee path: `gh issue create "$@" ... --assignee "$auto_assignee"`
- Assignee REST fallback: `_rest_issue_create ...`
- No-assignee path: `gh issue create "$@" ...`
- No-assignee REST fallback: `_rest_issue_create ...`

Also fixes `_todo_label_args` initialisation (was using the same vulnerable pattern).

## Testing

Added regression test **B'5** to `test-origin-label-mutex-create.sh`, mirroring the B5 test added for `gh_create_pr` in #22043. Test asserts that when the caller supplies an origin label (so `_origin_label_args` is empty), no empty argv element reaches `gh`.

```
18 tests run, 0 failed
```

ShellCheck passes on both changed files.

Resolves #22071

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.52 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-sonnet-4-6 spent 9m and 30,395 tokens on this as a headless worker.
