### PR TITLE
GH#21991: add issue-body formatting lint for AI-composed task descriptions

### DIFF
--- a/.agents/scripts/claim-task-id.sh
+++ b/.agents/scripts/claim-task-id.sh
@@ -359,7 +359,34 @@ _validate_and_normalize_args() {
 		_normalised_labels=$(map_tags_to_labels "$TASK_LABELS" 2>/dev/null) || true
 		[[ -n "$_normalised_labels" ]] && TASK_LABELS="$_normalised_labels"
 	fi
+
+	# GH#21991: advisory structural check on --description before issue creation.
+	# Non-blocking by default; set AIDEVOPS_BODY_FORMAT_STRICT=1 to hard-fail.
+	_validate_description_format
 	return 0
+}
+
+# _validate_description_format — run structural lint on TASK_DESCRIPTION.
+# Called at the end of _validate_and_normalize_args (GH#21991).
+# Advisory by default; AIDEVOPS_BODY_FORMAT_STRICT=1 hard-fails on non-dispatchable.
+# Skipped when: --no-issue, --dry-run, empty description, or helper unavailable.
+_validate_description_format() {
+	# Skip when issue creation is not happening or description is absent
+	[[ "$NO_ISSUE" == "true" || "$DRY_RUN" == "true" ]] && return 0
+	[[ -z "$TASK_DESCRIPTION" ]] && return 0
+
+	local fmt_helper="${SCRIPT_DIR}/issue-body-format-helper.sh"
+	[[ ! -x "$fmt_helper" ]] && return 0
+
+	local rc=0
+	"$fmt_helper" check "$TASK_DESCRIPTION" || rc=$?
+
+	# Exit 1 from helper = non-dispatchable body
+	if [[ $rc -eq 1 && "${AIDEVOPS_BODY_FORMAT_STRICT:-0}" != "1" ]]; then
+		# Advisory only — already warned via helper's log_warn calls.
+		rc=0
+	fi
+	return $rc
 }
 
 # t2436: Scan TODO.md for the task entry matching task_id and derive

--- a/.agents/scripts/issue-body-format-helper.sh
+++ b/.agents/scripts/issue-body-format-helper.sh
@@ -1,0 +1,230 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# issue-body-format-helper.sh — structural lint for AI-composed issue bodies (GH#21991)
+#
+# Checks whether a --description body passed to claim-task-id.sh (or used as
+# an issue body directly) is structurally worker-ready. Catches bodies that
+# have useful content but inconsistent or missing headings before publication.
+#
+# Usage:
+#   issue-body-format-helper.sh check     <body-text>
+#   issue-body-format-helper.sh normalize <body-text>
+#   issue-body-format-helper.sh help
+#
+# Exit codes (check):
+#   0 — body passes all checks (or has advisory warnings only)
+#   1 — body is non-dispatchable: missing both file scope and How section,
+#         OR missing acceptance criteria. Controllable by env var.
+#   2 — usage error
+#
+# Environment:
+#   AIDEVOPS_BODY_FORMAT_STRICT=1  — treat non-dispatchable as hard error (default: 0)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)" || exit 1
+
+# shellcheck source=/dev/null
+if [[ -f "$SCRIPT_DIR/shared-constants.sh" ]]; then
+	source "$SCRIPT_DIR/shared-constants.sh"
+fi
+
+# Inline fallbacks if shared-constants not sourced
+if ! command -v log_info >/dev/null 2>&1; then
+	log_info()  { printf '[INFO]  %s\n' "$*" >&2; return 0; }
+	log_warn()  { printf '[WARN]  %s\n' "$*" >&2; return 0; }
+	log_error() { printf '[ERROR] %s\n' "$*" >&2; return 0; }
+fi
+
+# ---------------------------------------------------------------------------
+# Structural signal detectors
+# Each returns 0 (found) or 1 (not found).
+# ---------------------------------------------------------------------------
+
+# _ibfh_has_file_scope: body contains file-scope markers.
+# Accepts: ## Files to modify, ### Files Scope, EDIT:, NEW:, Files to modify:
+_ibfh_has_file_scope() {
+	local body="$1"
+	if printf '%s\n' "$body" | grep -qiE \
+		'(^##+ Files( to modify| Scope)?|^EDIT:|^NEW:|Files to modify:)' 2>/dev/null; then
+		return 0
+	fi
+	return 1
+}
+
+# _ibfh_has_acceptance: body contains acceptance-criteria section or checklist.
+_ibfh_has_acceptance() {
+	local body="$1"
+	if printf '%s\n' "$body" | grep -qiE \
+		'(^##+ Acceptance|^- \[[ xX]\])' 2>/dev/null; then
+		return 0
+	fi
+	return 1
+}
+
+# _ibfh_has_verification: body contains a verification section or shell command block.
+_ibfh_has_verification() {
+	local body="$1"
+	if printf '%s\n' "$body" | grep -qiE \
+		'(^##+ Verification|^```(bash|sh|shell)?)' 2>/dev/null; then
+		return 0
+	fi
+	return 1
+}
+
+# _ibfh_has_how_section: body contains an implementation guidance section.
+_ibfh_has_how_section() {
+	local body="$1"
+	if printf '%s\n' "$body" | grep -qiE \
+		'(^##+ How|^##+ Implementation|^##+ Worker Guidance)' 2>/dev/null; then
+		return 0
+	fi
+	return 1
+}
+
+# _ibfh_has_reference_pattern: body contains a reference pattern hint.
+_ibfh_has_reference_pattern() {
+	local body="$1"
+	if printf '%s\n' "$body" | grep -qiE \
+		'(^##+ Reference( pattern)?|[Mm]odel on |[Ff]ollow pattern)' 2>/dev/null; then
+		return 0
+	fi
+	return 1
+}
+
+# _ibfh_heading_count: emit the number of ## headings in the body.
+_ibfh_heading_count() {
+	local body="$1"
+	local count=0
+	count=$(printf '%s\n' "$body" | grep -cE '^##' 2>/dev/null || true)
+	[[ "$count" =~ ^[0-9]+$ ]] || count=0
+	printf '%d\n' "$count"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Advisory checks (always emit to stderr, never abort on their own)
+# ---------------------------------------------------------------------------
+
+# _ibfh_warn_fence_spacing: warn about code fences missing a preceding blank line.
+_ibfh_warn_fence_spacing() {
+	local body="$1"
+	local prev="" line fence_issues=0
+	while IFS= read -r line; do
+		if [[ "$line" =~ ^'```' ]] && [[ -n "$prev" ]]; then
+			fence_issues=$((fence_issues + 1))
+		fi
+		prev="$line"
+	done < <(printf '%s\n' "$body")
+	if [[ $fence_issues -gt 0 ]]; then
+		log_warn "issue-body-format: $fence_issues code fence(s) lack a preceding blank line (MD031)"
+	fi
+	return 0
+}
+
+# _ibfh_warn_dense_prose: warn when body has fewer than 2 headings.
+_ibfh_warn_dense_prose() {
+	local body="$1"
+	local count
+	count=$(_ibfh_heading_count "$body")
+	if [[ $count -lt 2 ]]; then
+		log_warn "issue-body-format: body has $count heading(s) — dense prose reduces worker readability"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# normalize: auto-fix issues that can be corrected without human judgment.
+# Currently: insert blank line before code fences that lack one.
+# Prints corrected body on stdout.
+# ---------------------------------------------------------------------------
+cmd_normalize() {
+	local body="$1"
+	local prev="" out="" line
+	while IFS= read -r line; do
+		if [[ "$line" =~ ^'```' ]] && [[ -n "$prev" ]]; then
+			out="${out}"$'\n'
+		fi
+		out="${out}${line}"$'\n'
+		prev="$line"
+	done < <(printf '%s\n' "$body")
+	# Strip the trailing newline added by the loop (printf '%s\n' already adds one)
+	printf '%s' "${out%$'\n'}"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# check: run all structural checks and emit advisory warnings.
+# Exit 0 if body passes or has warnings only.
+# Exit 1 if non-dispatchable (controlled by AIDEVOPS_BODY_FORMAT_STRICT).
+# ---------------------------------------------------------------------------
+cmd_check() {
+	local body="$1"
+	local strict="${AIDEVOPS_BODY_FORMAT_STRICT:-0}"
+	local non_dispatchable=0
+
+	# Advisory-only checks
+	_ibfh_warn_fence_spacing "$body"
+	_ibfh_warn_dense_prose   "$body"
+
+	# Optional-section advisories
+	if ! _ibfh_has_reference_pattern "$body"; then
+		log_warn "issue-body-format: no reference pattern found (## Reference pattern / 'model on')"
+	fi
+	if ! _ibfh_has_verification "$body"; then
+		log_warn "issue-body-format: no verification section or command block found"
+	fi
+
+	# Non-dispatchable checks
+	if ! _ibfh_has_file_scope "$body" && ! _ibfh_has_how_section "$body"; then
+		log_warn "issue-body-format: body lacks both file scope (EDIT:/NEW:/## Files) and ## How section — worker has no implementation target"
+		non_dispatchable=1
+	fi
+	if ! _ibfh_has_acceptance "$body"; then
+		log_warn "issue-body-format: no acceptance criteria found (## Acceptance or - [ ] list)"
+		non_dispatchable=1
+	fi
+
+	if [[ $non_dispatchable -eq 1 && "$strict" == "1" ]]; then
+		log_error "issue-body-format: body is non-dispatchable (AIDEVOPS_BODY_FORMAT_STRICT=1)"
+		return 1
+	fi
+
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+cmd_help() {
+	grep '^#' "$0" | grep -v '#!/usr/bin/env' | sed 's/^# //' | sed 's/^#//'
+	return 0
+}
+
+main() {
+	local cmd="${1:-help}"
+	local body="${2:-}"
+
+	case "$cmd" in
+	check)
+		[[ -z "$body" ]] && { log_error "check requires <body-text>"; return 2; }
+		cmd_check "$body"
+		;;
+	normalize)
+		[[ -z "$body" ]] && { log_error "normalize requires <body-text>"; return 2; }
+		cmd_normalize "$body"
+		;;
+	help|--help|-h)
+		cmd_help
+		;;
+	*)
+		log_error "Unknown command: $cmd"
+		return 2
+		;;
+	esac
+	return $?
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-issue-body-format-helper.sh
+++ b/.agents/scripts/tests/test-issue-body-format-helper.sh
@@ -1,0 +1,321 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-issue-body-format-helper.sh — regression tests for issue-body-format-helper.sh
+# (GH#21991: add issue-body formatting lint for AI-composed task descriptions)
+#
+# Covers:
+#   1. Fully structured body with all required sections passes.
+#   2. Body with dense prose (no headings) triggers advisory warning.
+#   3. Body missing file scope AND How section is non-dispatchable (exit 1).
+#   4. Body missing acceptance criteria is non-dispatchable (exit 1).
+#   5. AIDEVOPS_BODY_FORMAT_STRICT=1 makes non-dispatchable a hard error.
+#   6. Normalize: blank lines inserted before fences that lack one.
+#   7. Normalize: fences with preceding blank lines are unchanged.
+#   8. Body with acceptance checklist but no ## Acceptance heading passes.
+#   9. EDIT:/NEW: patterns count as file scope.
+#  10. help / unknown command exits with expected codes.
+
+set -u
+set +e
+
+# ---------------------------------------------------------------------------
+# Test harness
+# ---------------------------------------------------------------------------
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf '  %sPASS%s %s\n' "$TEST_GREEN" "$TEST_NC" "$1"
+	return 0
+}
+
+fail() {
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '  %sFAIL%s %s\n' "$TEST_RED" "$TEST_NC" "$1"
+	if [[ -n "${2:-}" ]]; then
+		printf '        %s\n' "$2"
+	fi
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# Locate the helper
+# ---------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="$SCRIPT_DIR/../issue-body-format-helper.sh"
+
+if [[ ! -x "$HELPER" ]]; then
+	printf 'FATAL: issue-body-format-helper.sh not found or not executable at %s\n' "$HELPER" >&2
+	exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------------
+
+# Fully worker-ready body: file scope + reference + verification + acceptance
+BODY_FULL_PASS="## Task
+
+Add the foo feature.
+
+## Why
+
+Users need it.
+
+## How
+
+### Files to modify
+
+- EDIT: .agents/scripts/foo.sh:10-20 — add bar function
+
+### Reference pattern
+
+Model on .agents/scripts/brief-readiness-helper.sh
+
+## Verification
+
+\`\`\`bash
+shellcheck .agents/scripts/foo.sh
+\`\`\`
+
+## Acceptance
+
+- [ ] foo.sh passes shellcheck
+- [ ] feature works end-to-end
+"
+
+# Dense prose: no headings, long paragraphs
+BODY_DENSE_PROSE="This task requires modifying the foo script to add the bar function. The bar function should handle edge cases properly and return the correct exit code. We also need to update the tests and make sure the CI passes. The reference is in brief-readiness-helper.sh and the verification is done with shellcheck."
+
+# Missing file scope AND How section (non-dispatchable)
+BODY_NO_FILES_NO_HOW="## Task
+
+Fix the thing.
+
+## Why
+
+It is broken.
+
+## Acceptance
+
+- [ ] Works
+"
+
+# Missing acceptance criteria (non-dispatchable)
+BODY_NO_ACCEPTANCE="## Task
+
+Implement the widget.
+
+## Files to modify
+
+- EDIT: src/widget.sh
+
+## Verification
+
+\`\`\`bash
+shellcheck src/widget.sh
+\`\`\`
+"
+
+# Body with EDIT: patterns for file scope (no explicit ## Files heading)
+BODY_EDIT_PATTERN="## Task
+
+Fix the broken handler.
+
+## Why
+
+It crashes.
+
+EDIT: .agents/scripts/handler.sh:50-60
+
+## Verification
+
+\`\`\`bash
+bash .agents/scripts/tests/test-handler.sh
+\`\`\`
+
+## Acceptance
+
+- [ ] Tests pass
+"
+
+# Body with checklist but no ## Acceptance heading
+BODY_CHECKLIST_ONLY="## Task
+
+Do the thing.
+
+## Files to modify
+
+- EDIT: foo.sh
+
+## Verification
+
+\`\`\`bash
+shellcheck foo.sh
+\`\`\`
+
+- [ ] foo.sh is clean
+- [ ] works as expected
+"
+
+# Fence without preceding blank line (normalize target)
+BODY_FENCE_NO_BLANK="## Verification
+\`\`\`bash
+shellcheck foo.sh
+\`\`\`
+"
+
+# Fence WITH preceding blank line (should be unchanged by normalize)
+BODY_FENCE_WITH_BLANK="## Verification
+
+\`\`\`bash
+shellcheck foo.sh
+\`\`\`
+"
+
+# ---------------------------------------------------------------------------
+# Test suite
+# ---------------------------------------------------------------------------
+
+printf '\ntest-issue-body-format-helper.sh\n\n'
+
+# 1. Fully structured body passes (exit 0, no hard-error warnings)
+rc=0
+stderr=$("$HELPER" check "$BODY_FULL_PASS" 2>&1) || rc=$?
+if [[ $rc -eq 0 ]]; then
+	pass "1. full worker-ready body exits 0"
+else
+	fail "1. full worker-ready body exits 0" "got exit $rc; stderr: $stderr"
+fi
+
+# 2. Dense prose body emits a warning about headings
+rc=0
+stderr=$("$HELPER" check "$BODY_DENSE_PROSE" 2>&1) || rc=$?
+if printf '%s' "$stderr" | grep -qi "dense\|heading"; then
+	pass "2. dense-prose body emits heading/dense warning"
+else
+	fail "2. dense-prose body emits heading/dense warning" "stderr: $stderr"
+fi
+
+# 3. Body without file scope AND How section: helper exits 1 in strict mode
+rc=0
+stderr=$(AIDEVOPS_BODY_FORMAT_STRICT=1 "$HELPER" check "$BODY_NO_FILES_NO_HOW" 2>&1) || rc=$?
+if [[ $rc -eq 1 ]]; then
+	pass "3. missing file scope+How exits 1 (STRICT=1)"
+else
+	fail "3. missing file scope+How exits 1 (STRICT=1)" "got exit $rc; stderr: $stderr"
+fi
+
+# 4. Body without file scope AND How section: advisory only by default (exit 0)
+rc=0
+stderr=$("$HELPER" check "$BODY_NO_FILES_NO_HOW" 2>&1) || rc=$?
+if [[ $rc -eq 0 ]]; then
+	pass "4. missing file scope+How exits 0 by default (advisory)"
+else
+	fail "4. missing file scope+How exits 0 by default (advisory)" "got exit $rc"
+fi
+
+# 5. Body without acceptance criteria exits 1 in strict mode
+rc=0
+stderr=$(AIDEVOPS_BODY_FORMAT_STRICT=1 "$HELPER" check "$BODY_NO_ACCEPTANCE" 2>&1) || rc=$?
+if [[ $rc -eq 1 ]]; then
+	pass "5. missing acceptance criteria exits 1 (STRICT=1)"
+else
+	fail "5. missing acceptance criteria exits 1 (STRICT=1)" "got exit $rc; stderr: $stderr"
+fi
+
+# 6. Body without acceptance criteria exits 0 by default (advisory)
+rc=0
+stderr=$("$HELPER" check "$BODY_NO_ACCEPTANCE" 2>&1) || rc=$?
+if [[ $rc -eq 0 ]]; then
+	pass "6. missing acceptance criteria exits 0 by default (advisory)"
+else
+	fail "6. missing acceptance criteria exits 0 by default (advisory)" "got exit $rc"
+fi
+
+# 7. Normalize inserts blank line before fence lacking one
+normalized=$("$HELPER" normalize "$BODY_FENCE_NO_BLANK" 2>/dev/null) || true
+if printf '%s\n' "$normalized" | grep -qP '^\s*$' 2>/dev/null || \
+   printf '%s\n' "$normalized" | awk '/^```/{if (prev == "") found=1} {prev=$0} END{exit !found}' 2>/dev/null; then
+	pass "7. normalize inserts blank line before fence"
+else
+	# Fallback: check if a blank line appears before the first fence
+	if printf '%s\n' "$normalized" | awk 'prev==""{if(/^```/)found=1}{prev=$0}END{exit !found}' 2>/dev/null; then
+		pass "7. normalize inserts blank line before fence"
+	else
+		fail "7. normalize inserts blank line before fence" "output: $(printf '%s' "$normalized" | head -10)"
+	fi
+fi
+
+# 8. Normalize does not introduce consecutive double blank lines
+normalized=$("$HELPER" normalize "$BODY_FENCE_WITH_BLANK" 2>/dev/null) || true
+# Fail if any two consecutive lines are both blank
+if printf '%s\n' "$normalized" | \
+   awk 'prev == "" && /^$/ { found=1 } { prev=$0 } END { exit found+0 }' 2>/dev/null; then
+	pass "8. normalize does not introduce double blank lines"
+else
+	fail "8. normalize does not introduce double blank lines" "output: $(printf '%s\n' "$normalized")"
+fi
+
+# 9. EDIT: pattern counts as file scope (body passes with it)
+rc=0
+stderr=$(AIDEVOPS_BODY_FORMAT_STRICT=1 "$HELPER" check "$BODY_EDIT_PATTERN" 2>&1) || rc=$?
+if printf '%s' "$stderr" | grep -qi "file scope\|EDIT\|NEW"; then
+	# If it warns about file scope, it means the EDIT: pattern wasn't detected — fail
+	fail "9. EDIT: pattern counts as file scope" "got file-scope warning: $stderr"
+elif [[ $rc -ne 0 ]] && printf '%s' "$stderr" | grep -qi "non-dispatchable"; then
+	fail "9. EDIT: pattern counts as file scope" "got non-dispatchable for EDIT body (exit $rc)"
+else
+	pass "9. EDIT: pattern counts as file scope"
+fi
+
+# 10. Acceptance checklist (- [ ]) without ## Acceptance heading passes acceptance check
+rc=0
+stderr=$(AIDEVOPS_BODY_FORMAT_STRICT=1 "$HELPER" check "$BODY_CHECKLIST_ONLY" 2>&1) || rc=$?
+if printf '%s' "$stderr" | grep -qi "acceptance"; then
+	fail "10. bare checklist counts as acceptance criteria" "got acceptance warning: $stderr"
+else
+	pass "10. bare checklist counts as acceptance criteria"
+fi
+
+# 11. help command exits 0
+rc=0
+"$HELPER" help >/dev/null 2>&1 || rc=$?
+if [[ $rc -eq 0 ]]; then
+	pass "11. help exits 0"
+else
+	fail "11. help exits 0" "got exit $rc"
+fi
+
+# 12. Unknown command exits non-zero
+rc=0
+"$HELPER" unknowncmd "body" >/dev/null 2>&1 || rc=$?
+if [[ $rc -ne 0 ]]; then
+	pass "12. unknown command exits non-zero"
+else
+	fail "12. unknown command exits non-zero" "got exit 0"
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+printf '\n%d tests run, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+if [[ $TESTS_FAILED -eq 0 ]]; then
+	printf '%sPASS%s — all tests passed\n\n' "$TEST_GREEN" "$TEST_NC"
+	exit 0
+else
+	printf '%sFAIL%s — %d test(s) failed\n\n' "$TEST_RED" "$TEST_NC" "$TESTS_FAILED"
+	exit 1
+fi


### PR DESCRIPTION
## Summary

Adds a lightweight structural lint for AI-composed issue bodies (`issue-body-format-helper.sh`) and hooks it into `claim-task-id.sh` so poorly-structured `--description` bodies are flagged before publication.

## What changed

**NEW: `.agents/scripts/issue-body-format-helper.sh`**
- `check <body>` — advisory lint: warns on dense prose, missing file-scope markers, missing acceptance criteria, missing verification, and code fences without preceding blank lines. Returns 1 in `AIDEVOPS_BODY_FORMAT_STRICT=1` for non-dispatchable bodies.
- `normalize <body>` — auto-inserts blank lines before code fences that lack one (MD031 fix).

**EDIT: `.agents/scripts/claim-task-id.sh`**
- `_validate_and_normalize_args` calls new `_validate_description_format()` which invokes the helper on `--description` before issue creation. Non-blocking advisory by default; respects `AIDEVOPS_BODY_FORMAT_STRICT=1`.

**NEW: `.agents/scripts/tests/test-issue-body-format-helper.sh`**
- 12 fixture-based regression tests: full pass, dense prose warning, missing file scope + How (advisory and strict), missing acceptance criteria, normalize, EDIT: file-scope detection, bare checklist detection, help/unknown command exit codes.

## Verification

```bash
bash .agents/scripts/tests/test-issue-body-format-helper.sh
shellcheck .agents/scripts/claim-task-id.sh .agents/scripts/issue-body-format-helper.sh .agents/scripts/tests/test-issue-body-format-helper.sh
```

All 12 tests pass; shellcheck clean.

## Acceptance criteria check

- [x] Bodies with file scope, reference pattern, verification, and acceptance criteria pass (test 1).
- [x] Bodies with dense prose or unclear headings get a warning (test 2).
- [x] The check is advisory for interactive sessions unless a missing required section would make the issue non-dispatchable (tests 3–6 with STRICT env var).

Resolves #21991

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.52 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-sonnet-4-6 spent 12m and 41,355 tokens on this as a headless worker.
