### PR TITLE
t3372: fix pulse-stats-helper.sh include guard to stop --dry-run bootstrap hang

### DIFF
--- a/.agents/scripts/pulse-stats-helper.sh
+++ b/.agents/scripts/pulse-stats-helper.sh
@@ -26,6 +26,16 @@
 
 set -euo pipefail
 
+# Include guard — prevent double-sourcing (GH#22091).
+# pulse-stats-helper.sh is sourced by pulse-merge-stuck.sh,
+# pulse-rate-limit-circuit-breaker.sh, pre-dispatch-eligibility-helper.sh,
+# and pulse-dispatch-engine.sh. Without this guard every bootstrap cycle
+# re-runs the SCRIPT_DIR subprocess and the shared-constants.sh source
+# for each caller, stacking enough subprocess overhead to cause --dry-run
+# timeouts on slow filesystems.
+[[ -n "${_PULSE_STATS_HELPER_LOADED:-}" ]] && return 0
+_PULSE_STATS_HELPER_LOADED=1
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
 
 # Source shared constants if available (provides color helpers etc.).

--- a/.agents/scripts/tests/test-pulse-wrapper-dry-run-bootstrap.sh
+++ b/.agents/scripts/tests/test-pulse-wrapper-dry-run-bootstrap.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression test for pulse-wrapper.sh --dry-run bootstrap hang (GH#22091).
+#
+# Purpose: Verify that --dry-run exits quickly without timing out due to
+# repeated sourcing of pulse-stats-helper.sh during bootstrap.
+#
+# Root cause: pulse-stats-helper.sh lacked an include guard and was sourced
+# by pulse-merge-stuck.sh, pulse-rate-limit-circuit-breaker.sh,
+# pre-dispatch-eligibility-helper.sh, and pulse-dispatch-engine.sh. Each
+# source re-ran the SCRIPT_DIR subprocess and shared-constants.sh include,
+# stacking enough overhead to cause 120s-300s timeouts before reaching the
+# dry-run short-circuit at pulse-wrapper.sh::_pulse_run_cycle.
+#
+# Fix: Added idempotent include guard to pulse-stats-helper.sh:27 following
+# the pattern at pulse-cleanup.sh:47-49.
+#
+# What is exercised:
+#   1. pulse-wrapper.sh --dry-run completes within TIMEOUT seconds
+#   2. The dry-run output line confirms the expected short-circuit fired
+#   3. Static check: include guard exists in pulse-stats-helper.sh
+#   4. Static check: dry-run short-circuit exists in pulse-wrapper.sh
+#
+# What is NOT exercised:
+#   - GitHub API calls (no network)
+#   - Actual worker dispatch
+#   - fix-the-fixer detector (AIDEVOPS_SKIP_FIX_THE_FIXER_DETECTOR=1)
+#   - Cache priming (AIDEVOPS_SKIP_CACHE_PRIME=1)
+#   - Runaway log check (AIDEVOPS_SKIP_RUNAWAY_LOG_CHECK=1)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+WRAPPER_SCRIPT="${SCRIPT_DIR}/../pulse-wrapper.sh"
+STATS_HELPER="${SCRIPT_DIR}/../pulse-stats-helper.sh"
+DEFAULTS_SOURCE="${SCRIPT_DIR}/../../configs/aidevops.defaults.jsonc"
+
+# Timeout for the --dry-run invocation. The pre-fix hang required >120s; the
+# fix should complete in under 30s even on slow CI machines.
+readonly DRY_RUN_TIMEOUT=30
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+# Seed a sandbox HOME with the canonical aidevops defaults config so
+# pulse-wrapper-bootstrap.sh::_load_config succeeds.
+# Mirrors the seed_sandbox_config() pattern in test-pulse-wrapper-canary.sh.
+seed_sandbox_config() {
+	local sandbox_home="$1"
+	mkdir -p "${sandbox_home}/.aidevops/agents/configs"
+	if [[ -f "$DEFAULTS_SOURCE" ]]; then
+		cp "$DEFAULTS_SOURCE" \
+			"${sandbox_home}/.aidevops/agents/configs/aidevops.defaults.jsonc"
+	fi
+	return 0
+}
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+# Test 1: --dry-run exits 0 within DRY_RUN_TIMEOUT seconds.
+#
+# Pre-fix: timed out at 120s-300s due to repeated pulse-stats-helper.sh sourcing.
+# Post-fix: exits in <5s because the include guard prevents repeated init.
+#
+# Uses env vars to skip optional slow paths that are not part of the
+# bootstrap overhead being tested here.
+test_dry_run_exits_zero_quickly() {
+	local sandbox rc output elapsed start_ts
+	sandbox=$(mktemp -d)
+	mkdir -p "${sandbox}/home"
+	seed_sandbox_config "${sandbox}/home"
+
+	start_ts=$(date +%s 2>/dev/null) || start_ts=0
+	output=$(
+		HOME="${sandbox}/home" \
+			FULL_LOOP_HEADLESS=1 \
+			AIDEVOPS_SUPERVISOR_PULSE=true \
+			AIDEVOPS_SKIP_FIX_THE_FIXER_DETECTOR=1 \
+			AIDEVOPS_SKIP_CACHE_PRIME=1 \
+			AIDEVOPS_SKIP_RUNAWAY_LOG_CHECK=1 \
+			timeout "$DRY_RUN_TIMEOUT" bash "$WRAPPER_SCRIPT" --dry-run 2>&1
+	)
+	rc=$?
+	local end_ts
+	end_ts=$(date +%s 2>/dev/null) || end_ts=0
+	elapsed=$(( end_ts - start_ts ))
+	rm -rf "$sandbox"
+
+	if [[ "$rc" -eq 0 ]]; then
+		print_result "--dry-run exits 0 within ${DRY_RUN_TIMEOUT}s (took ${elapsed}s)" 0
+		return 0
+	fi
+	# timeout exits 124; distinguish from other failures
+	local reason="exit $rc"
+	if [[ "$rc" -eq 124 ]]; then
+		reason="timed out after ${DRY_RUN_TIMEOUT}s (bootstrap hang — include guard missing?)"
+	fi
+	print_result "--dry-run exits 0 within ${DRY_RUN_TIMEOUT}s (took ${elapsed}s)" 1 \
+		"Expected exit 0, got ${reason}. Output: ${output}"
+	return 0
+}
+
+# Test 2: --dry-run prints the expected short-circuit confirmation line.
+#
+# If the include guard accidentally breaks the dry-run path, this catches it.
+test_dry_run_prints_ok_line() {
+	local sandbox rc output
+	sandbox=$(mktemp -d)
+	mkdir -p "${sandbox}/home"
+	seed_sandbox_config "${sandbox}/home"
+
+	output=$(
+		HOME="${sandbox}/home" \
+			FULL_LOOP_HEADLESS=1 \
+			AIDEVOPS_SUPERVISOR_PULSE=true \
+			AIDEVOPS_SKIP_FIX_THE_FIXER_DETECTOR=1 \
+			AIDEVOPS_SKIP_CACHE_PRIME=1 \
+			AIDEVOPS_SKIP_RUNAWAY_LOG_CHECK=1 \
+			timeout "$DRY_RUN_TIMEOUT" bash "$WRAPPER_SCRIPT" --dry-run 2>&1
+	)
+	rc=$?
+	rm -rf "$sandbox"
+
+	if printf '%s' "$output" | grep -q "^dry-run: ok"; then
+		print_result "--dry-run prints 'dry-run: ok' confirmation line" 0
+		return 0
+	fi
+	print_result "--dry-run prints 'dry-run: ok' confirmation line" 1 \
+		"Expected line starting with 'dry-run: ok'. Exit $rc. Output: ${output}"
+	return 0
+}
+
+# Test 3: Static check — include guard exists in pulse-stats-helper.sh.
+#
+# Ensures the fix that prevents the bootstrap hang is not accidentally removed
+# during future refactoring.
+test_include_guard_present() {
+	if grep -q "_PULSE_STATS_HELPER_LOADED" "$STATS_HELPER"; then
+		print_result "include guard _PULSE_STATS_HELPER_LOADED present in pulse-stats-helper.sh" 0
+		return 0
+	fi
+	print_result "include guard _PULSE_STATS_HELPER_LOADED present in pulse-stats-helper.sh" 1 \
+		"Include guard not found in $STATS_HELPER — bootstrap hang will recur"
+	return 0
+}
+
+# Test 4: Static check — dry-run short-circuit exists in pulse-wrapper.sh.
+#
+# Guards against the short-circuit being accidentally removed, which would
+# make the script run the full dispatch loop in dry-run mode.
+test_dry_run_short_circuit_present() {
+	if grep -q 'PULSE_DRY_RUN' "$WRAPPER_SCRIPT"; then
+		print_result "PULSE_DRY_RUN short-circuit present in pulse-wrapper.sh" 0
+		return 0
+	fi
+	print_result "PULSE_DRY_RUN short-circuit present in pulse-wrapper.sh" 1 \
+		"PULSE_DRY_RUN not found in $WRAPPER_SCRIPT"
+	return 0
+}
+
+main_test() {
+	test_dry_run_exits_zero_quickly
+	test_dry_run_prints_ok_line
+	test_include_guard_present
+	test_dry_run_short_circuit_present
+
+	printf '\nRan %s tests, %s failed.\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}
+
+main_test "$@"


### PR DESCRIPTION
## Summary

Fix `pulse-wrapper.sh --dry-run` hanging at bootstrap due to `pulse-stats-helper.sh` being sourced multiple times with no include guard.

## Root Cause

`pulse-stats-helper.sh` was sourced by four callers during bootstrap:
- `pulse-merge-stuck.sh`
- `pulse-rate-limit-circuit-breaker.sh`
- `pre-dispatch-eligibility-helper.sh`
- `pulse-dispatch-engine.sh`

Without an include guard, each sourcing re-ran `SCRIPT_DIR` subprocess computation and re-sourced `shared-constants.sh`. The accumulated subprocess overhead caused `--dry-run` to timeout (120s-300s) before reaching the short-circuit at `_pulse_run_cycle:1652`.

## Changes

- **`EDIT: .agents/scripts/pulse-stats-helper.sh:27`** — Added idempotent include guard `_PULSE_STATS_HELPER_LOADED` following the pattern at `pulse-cleanup.sh:47-49`. On subsequent sourcing, `return 0` exits immediately without re-running SCRIPT_DIR or sourcing shared-constants.sh.
- **`NEW: .agents/scripts/tests/test-pulse-wrapper-dry-run-bootstrap.sh`** — Regression test asserting `--dry-run` exits 0 within 30s and prints `dry-run: ok`. Pre-fix this would have timed out; post-fix it completes in ~2s.

## Verification

```
bash .agents/scripts/tests/test-pulse-wrapper-dry-run-bootstrap.sh
# PASS --dry-run exits 0 within 30s (took 2s)
# PASS --dry-run prints 'dry-run: ok' confirmation line
# PASS include guard _PULSE_STATS_HELPER_LOADED present in pulse-stats-helper.sh
# PASS PULSE_DRY_RUN short-circuit present in pulse-wrapper.sh
# Ran 4 tests, 0 failed.

shellcheck .agents/scripts/pulse-stats-helper.sh
shellcheck .agents/scripts/tests/test-pulse-wrapper-dry-run-bootstrap.sh
# Both exit 0
```

Resolves #22091

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.52 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-sonnet-4-6 spent 8m and 24,688 tokens on this as a headless worker.
