### PR TITLE
GH#22079: bound opencode --version in validate_opencode_config

### DIFF
--- a/setup-modules/migrations.sh
+++ b/setup-modules/migrations.sh
@@ -1010,15 +1010,28 @@ validate_opencode_config() {
 		issues="${issues}\n  - tools entries as objects instead of booleans: $(echo "$tools_as_objects" | tr '\n' ', ' | sed 's/,$//')"
 	fi
 
-	# Check 3: Try to parse with opencode (if available) to catch other schema issues
+	# Check 3: Try to parse with opencode (if available) to catch other schema issues.
+	# GH#22079: wrap the --version probe in a timeout so a hung Node.js opencode
+	# process cannot stall the non-interactive deploy path indefinitely.
 	if command -v opencode &>/dev/null; then
 		local validation_output
-		if ! validation_output=$(opencode --version 2>&1); then
-			# If opencode fails to start, config might be invalid
-			if [[ "$validation_output" == *"Configuration is invalid"* ]]; then
-				needs_repair=true
-				issues="${issues}\n  - OpenCode reports invalid configuration"
-			fi
+		local _oc_timeout
+		local _oc_rc
+		_oc_timeout="${AIDEVOPS_OPENCODE_VERSION_TIMEOUT:-5}"
+		_oc_rc=0
+		# Prefer the shared helper sourced from _services.sh (always available when
+		# called from setup.sh); fall back to system timeout; last resort: unbounded.
+		if declare -F _setup_opencode_timeout_cmd >/dev/null 2>&1; then
+			validation_output=$(_setup_opencode_timeout_cmd "$_oc_timeout" opencode --version 2>&1) || _oc_rc=$?
+		elif command -v timeout >/dev/null 2>&1; then
+			validation_output=$(timeout "$_oc_timeout" opencode --version 2>&1) || _oc_rc=$?
+		else
+			validation_output=$(opencode --version 2>&1) || _oc_rc=$?
+		fi
+		# Exit 124 means timed out — not a config-invalid signal; skip the check.
+		if [[ "$_oc_rc" -ne 0 && "$_oc_rc" -ne 124 ]] && [[ "$validation_output" == *"Configuration is invalid"* ]]; then
+			needs_repair=true
+			issues="${issues}\n  - OpenCode reports invalid configuration"
 		fi
 	fi
 

--- a/setup-modules/migrations.sh
+++ b/setup-modules/migrations.sh
@@ -952,6 +952,34 @@ disable_ondemand_mcps() {
 	return 0
 }
 
+# Run bounded opencode --version probe to detect config schema errors (GH#22079).
+# Returns 0 when config looks valid (or opencode is unavailable / probe timed out),
+# 1 when opencode explicitly reports "Configuration is invalid".
+# Uses AIDEVOPS_OPENCODE_VERSION_TIMEOUT (default 5s) so a hung Node.js process
+# cannot stall the non-interactive deploy path indefinitely.
+_validate_opencode_config_schema() {
+	command -v opencode &>/dev/null || return 0
+	local validation_output
+	local _oc_timeout
+	local _oc_rc
+	_oc_timeout="${AIDEVOPS_OPENCODE_VERSION_TIMEOUT:-5}"
+	_oc_rc=0
+	# Prefer the shared helper sourced from _services.sh (always available when
+	# called from setup.sh); fall back to system timeout; last resort: unbounded.
+	if declare -F _setup_opencode_timeout_cmd >/dev/null 2>&1; then
+		validation_output=$(_setup_opencode_timeout_cmd "$_oc_timeout" opencode --version 2>&1) || _oc_rc=$?
+	elif command -v timeout >/dev/null 2>&1; then
+		validation_output=$(timeout "$_oc_timeout" opencode --version 2>&1) || _oc_rc=$?
+	else
+		validation_output=$(opencode --version 2>&1) || _oc_rc=$?
+	fi
+	# Exit 124 = timed out — not a config-invalid signal.
+	if [[ "$_oc_rc" -ne 0 && "$_oc_rc" -ne 124 ]] && [[ "$validation_output" == *"Configuration is invalid"* ]]; then
+		return 1
+	fi
+	return 0
+}
+
 # Validate and repair OpenCode config schema
 # Fixes common issues from manual editing or AI-generated configs:
 # - MCP entries missing "type": "local" field
@@ -1010,29 +1038,10 @@ validate_opencode_config() {
 		issues="${issues}\n  - tools entries as objects instead of booleans: $(echo "$tools_as_objects" | tr '\n' ', ' | sed 's/,$//')"
 	fi
 
-	# Check 3: Try to parse with opencode (if available) to catch other schema issues.
-	# GH#22079: wrap the --version probe in a timeout so a hung Node.js opencode
-	# process cannot stall the non-interactive deploy path indefinitely.
-	if command -v opencode &>/dev/null; then
-		local validation_output
-		local _oc_timeout
-		local _oc_rc
-		_oc_timeout="${AIDEVOPS_OPENCODE_VERSION_TIMEOUT:-5}"
-		_oc_rc=0
-		# Prefer the shared helper sourced from _services.sh (always available when
-		# called from setup.sh); fall back to system timeout; last resort: unbounded.
-		if declare -F _setup_opencode_timeout_cmd >/dev/null 2>&1; then
-			validation_output=$(_setup_opencode_timeout_cmd "$_oc_timeout" opencode --version 2>&1) || _oc_rc=$?
-		elif command -v timeout >/dev/null 2>&1; then
-			validation_output=$(timeout "$_oc_timeout" opencode --version 2>&1) || _oc_rc=$?
-		else
-			validation_output=$(opencode --version 2>&1) || _oc_rc=$?
-		fi
-		# Exit 124 means timed out — not a config-invalid signal; skip the check.
-		if [[ "$_oc_rc" -ne 0 && "$_oc_rc" -ne 124 ]] && [[ "$validation_output" == *"Configuration is invalid"* ]]; then
-			needs_repair=true
-			issues="${issues}\n  - OpenCode reports invalid configuration"
-		fi
+	# Check 3: bounded opencode --version probe to catch other schema issues (GH#22079).
+	if ! _validate_opencode_config_schema; then
+		needs_repair=true
+		issues="${issues}\n  - OpenCode reports invalid configuration"
 	fi
 
 	if [[ "$needs_repair" == "true" ]]; then


### PR DESCRIPTION
## Summary

- `validate_opencode_config` in `setup-modules/migrations.sh` called `opencode --version` without a timeout, allowing a hung Node.js process to stall `./setup.sh --non-interactive` indefinitely.
- Extracted the bounded probe into a new `_validate_opencode_config_schema()` helper that wraps the call with `_setup_opencode_timeout_cmd` (preferred, sourced from `_services.sh`), falling back to system `timeout`/`gtimeout`, then unbounded as last resort.
- `AIDEVOPS_OPENCODE_VERSION_TIMEOUT` (default 5s) controls the budget. Exit 124 (timed-out) is excluded from the config-invalid check to prevent spurious regeneration on hangs.
- Keeps `validate_opencode_config` at 85 lines (was 103 after inline fix, now under the 100-line gate).

## Files Changed

- `EDIT: setup-modules/migrations.sh` — extracted `_validate_opencode_config_schema()` helper with timeout; `validate_opencode_config` calls it.

## Testing

- `shellcheck setup-modules/migrations.sh setup.sh .agents/scripts/setup/_services.sh` — no violations.
- `bash .agents/scripts/tests/test-setup-opencode-cli.sh` — 12/12 passed (existing timeout infrastructure verified).
- Pre-commit hooks passed both commits (return-statements, positional-params, shellcheck, portable-stat).

Resolves #22079

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.52 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-sonnet-4-6 spent 8m and 28,107 tokens on this as a headless worker.
