### PR TITLE
t3371: bound deploy_agents_to_runtimes stage in non-interactive setup

### DIFF
--- a/.agents/scripts/tests/test-deploy-runtimes-bounded.sh
+++ b/.agents/scripts/tests/test-deploy-runtimes-bounded.sh
@@ -1,0 +1,242 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression tests for _deploy_agents_to_runtimes_bounded (GH#22087).
+# Verifies that the bounded wrapper:
+#   1. Returns 0 when deploy_agents_to_runtimes completes quickly.
+#   2. Kills a slow deployment within AIDEVOPS_DEPLOY_RUNTIMES_TIMEOUT seconds and
+#      returns non-zero, ensuring the stage cannot hang the outer setup timeout.
+#   3. The bounded wrapper is wired into setup.sh's non-interactive path.
+#
+# Note on process-group cleanup: deploy_agents_to_runtimes does not start any
+# background processes of its own (all file operations are synchronous). The bounded
+# wrapper's kill of the subshell PID is therefore sufficient — there are no orphaned
+# descendants in the real use case.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+AGENT_RUNTIME_SH="${REPO_ROOT}/setup-modules/agent-runtime.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_TMP_DIR=""
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+cleanup() {
+	if [[ -n "$TEST_TMP_DIR" && -d "$TEST_TMP_DIR" ]]; then
+		rm -rf "$TEST_TMP_DIR"
+	fi
+	return 0
+}
+
+# Write a self-contained test script that stubs deploy_agents_to_runtimes and
+# inlines the bounded wrapper implementation for isolation.
+_write_bounded_wrapper_script() {
+	local out_file="$1"
+	local deploy_body="$2"  # shell body for deploy_agents_to_runtimes stub
+	local timeout_s="$3"    # AIDEVOPS_DEPLOY_RUNTIMES_TIMEOUT value
+
+	cat >"$out_file" <<SCRIPT_EOF
+#!/usr/bin/env bash
+set -uo pipefail
+print_info()    { :; return 0; }
+print_warning() { :; return 0; }
+print_success() { :; return 0; }
+
+deploy_agents_to_runtimes() {
+${deploy_body}
+}
+
+AIDEVOPS_DEPLOY_RUNTIMES_TIMEOUT=${timeout_s}
+
+_deploy_agents_to_runtimes_bounded() {
+	local timeout_s="\${AIDEVOPS_DEPLOY_RUNTIMES_TIMEOUT:-120}"
+	local _start_s=\$SECONDS
+	local _pid="" _rc=0
+
+	deploy_agents_to_runtimes &
+	_pid=\$!
+
+	while kill -0 "\$_pid" 2>/dev/null; do
+		if (( SECONDS - _start_s >= timeout_s )); then
+			kill -TERM "\$_pid" 2>/dev/null || true
+			sleep 2
+			kill -KILL "\$_pid" 2>/dev/null || true
+			wait "\$_pid" 2>/dev/null || true
+			print_warning "bounded: exceeded timeout"
+			return 1
+		fi
+		sleep 1
+	done
+
+	wait "\$_pid" 2>/dev/null
+	_rc=\$?
+	return "\$_rc"
+}
+
+_deploy_agents_to_runtimes_bounded
+SCRIPT_EOF
+	chmod +x "$out_file"
+	return 0
+}
+
+test_bounded_wrapper_present() {
+	if grep -q '_deploy_agents_to_runtimes_bounded' "$AGENT_RUNTIME_SH"; then
+		print_result "_deploy_agents_to_runtimes_bounded is defined in agent-runtime.sh" 0
+	else
+		print_result "_deploy_agents_to_runtimes_bounded is defined in agent-runtime.sh" 1 \
+			"function not found in ${AGENT_RUNTIME_SH}"
+	fi
+	return 0
+}
+
+test_setup_uses_bounded_wrapper() {
+	local setup_sh="${REPO_ROOT}/setup.sh"
+	if grep -q '_deploy_agents_to_runtimes_bounded' "$setup_sh"; then
+		print_result "setup.sh calls _deploy_agents_to_runtimes_bounded" 0
+	else
+		print_result "setup.sh calls _deploy_agents_to_runtimes_bounded" 1 \
+			"setup.sh still calls bare deploy_agents_to_runtimes — bounded wrapper not wired up"
+	fi
+	return 0
+}
+
+test_deploy_function_has_no_background_jobs() {
+	# deploy_agents_to_runtimes must not start background processes of its own;
+	# the bounded wrapper only kills the direct subshell PID, so background jobs
+	# inside deploy would otherwise become orphans on timeout.
+	#
+	# The pattern looks for a standalone '&' (background operator) by requiring
+	# it to be preceded by a non-& char and followed by whitespace, semicolon,
+	# or end-of-line — excluding '&&', '&>', '>&', and '2>&1' redirects.
+	local bg_usages
+	bg_usages=$(awk '
+		/^deploy_agents_to_runtimes\(\)/{found=1; depth=0}
+		found && /\{/{depth++}
+		found && /\}/{depth--; if(depth<=0){found=0}}
+		found && /[^&][^#]& *($|[;#|)])/{print NR": "$0}
+	' "$AGENT_RUNTIME_SH")
+
+	if [[ -z "$bg_usages" ]]; then
+		print_result "deploy_agents_to_runtimes contains no background job operators" 0
+	else
+		print_result "deploy_agents_to_runtimes contains no background job operators" 1 \
+			"found background '&' usage in function body — bounded wrapper may not clean up descendants:
+${bg_usages}"
+	fi
+	return 0
+}
+
+test_bounded_wrapper_fast_path() {
+	TEST_TMP_DIR="$(mktemp -d)"
+	local script="${TEST_TMP_DIR}/fast.sh"
+
+	_write_bounded_wrapper_script "$script" "  return 0" "5"
+
+	local rc=0
+	bash "$script" || rc=$?
+
+	if [[ "$rc" -eq 0 ]]; then
+		print_result "fast deploy_agents_to_runtimes returns 0 through bounded wrapper" 0
+	else
+		print_result "fast deploy_agents_to_runtimes returns 0 through bounded wrapper" 1 \
+			"bounded wrapper returned $rc for a fast no-op stub"
+	fi
+	return 0
+}
+
+test_bounded_wrapper_kills_slow_deployment() {
+	TEST_TMP_DIR="$(mktemp -d)"
+	local script="${TEST_TMP_DIR}/slow.sh"
+
+	_write_bounded_wrapper_script "$script" "  sleep 30; return 0" "3"
+
+	local rc=0
+	local start_s=$SECONDS
+	bash "$script" || rc=$?
+	local elapsed=$(( SECONDS - start_s ))
+
+	if [[ "$rc" -ne 0 ]]; then
+		print_result "slow deployment: bounded wrapper returns non-zero on timeout" 0
+	else
+		print_result "slow deployment: bounded wrapper returns non-zero on timeout" 1 \
+			"expected non-zero from bounded wrapper, got 0"
+	fi
+
+	# timeout=3 + 2s SIGKILL grace + 1s poll overhead = at most ~7s
+	if [[ "$elapsed" -le 10 ]]; then
+		print_result "bounded wrapper kills slow deployment within deadline (${elapsed}s)" 0
+	else
+		print_result "bounded wrapper kills slow deployment within deadline (${elapsed}s)" 1 \
+			"took ${elapsed}s — deployment was not killed promptly"
+	fi
+	return 0
+}
+
+test_bounded_wrapper_timeout_env_respected() {
+	TEST_TMP_DIR="$(mktemp -d)"
+	local script="${TEST_TMP_DIR}/env_check.sh"
+
+	# Deploy that sleeps 10s; AIDEVOPS_DEPLOY_RUNTIMES_TIMEOUT=2 should terminate it
+	_write_bounded_wrapper_script "$script" "  sleep 10; return 0" "2"
+
+	local rc=0
+	local start_s=$SECONDS
+	bash "$script" || rc=$?
+	local elapsed=$(( SECONDS - start_s ))
+
+	if [[ "$rc" -ne 0 && "$elapsed" -le 7 ]]; then
+		print_result "AIDEVOPS_DEPLOY_RUNTIMES_TIMEOUT env var respected (${elapsed}s)" 0
+	else
+		print_result "AIDEVOPS_DEPLOY_RUNTIMES_TIMEOUT env var respected (${elapsed}s)" 1 \
+			"rc=$rc elapsed=${elapsed}s — timeout env var may not be honoured"
+	fi
+	return 0
+}
+
+main() {
+	trap cleanup EXIT
+
+	printf 'Running bounded runtime deployment tests...\n\n'
+
+	test_bounded_wrapper_present
+	test_setup_uses_bounded_wrapper
+	test_deploy_function_has_no_background_jobs
+	test_bounded_wrapper_fast_path
+	test_bounded_wrapper_kills_slow_deployment
+	test_bounded_wrapper_timeout_env_respected
+
+	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -ne 0 ]]; then
+		exit 1
+	fi
+
+	return 0
+}
+
+main "$@"

--- a/setup-modules/agent-runtime.sh
+++ b/setup-modules/agent-runtime.sh
@@ -249,3 +249,38 @@ deploy_agents_to_runtimes() {
 
 	return 0
 }
+
+# _deploy_agents_to_runtimes_bounded: time-bounded wrapper for deploy_agents_to_runtimes.
+#
+# deploy_agents_to_runtimes is a shell function (not an external script), so it
+# cannot be passed directly to the `timeout` binary. Instead we run it in a
+# background subshell and poll for completion with a configurable wall-clock
+# deadline. When the deadline expires the subshell is killed with SIGTERM then
+# SIGKILL and setup continues without this non-critical step.
+#
+# Configurable via AIDEVOPS_DEPLOY_RUNTIMES_TIMEOUT (default 120s).
+_deploy_agents_to_runtimes_bounded() {
+	local timeout_s="${AIDEVOPS_DEPLOY_RUNTIMES_TIMEOUT:-120}"
+	local _start_s=$SECONDS
+	local _pid=""
+	local _rc=0
+
+	deploy_agents_to_runtimes &
+	_pid=$!
+
+	while kill -0 "$_pid" 2>/dev/null; do
+		if (( SECONDS - _start_s >= timeout_s )); then
+			kill -TERM "$_pid" 2>/dev/null || true
+			sleep 2
+			kill -KILL "$_pid" 2>/dev/null || true
+			wait "$_pid" 2>/dev/null || true
+			print_warning "Runtime agent deployment exceeded ${timeout_s}s — skipping (non-critical)"
+			return 1
+		fi
+		sleep 1
+	done
+
+	wait "$_pid" 2>/dev/null
+	_rc=$?
+	return "$_rc"
+}

--- a/setup.sh
+++ b/setup.sh
@@ -1318,7 +1318,10 @@ _setup_run_non_interactive() {
 	wait "$_pid_scan" 2>/dev/null || print_warning "Skill security scan encountered issues (non-critical)"
 
 	_time_step "inject_agents_reference" inject_agents_reference
-	_time_step "deploy_agents_to_runtimes" deploy_agents_to_runtimes
+	# Use the bounded wrapper so a slow file-system traversal across many agent
+	# files does not consume the remaining postflight budget and trip the outer
+	# timeout (GH#22087). AIDEVOPS_DEPLOY_RUNTIMES_TIMEOUT controls the deadline.
+	_time_step "deploy_agents_to_runtimes" _deploy_agents_to_runtimes_bounded
 	_time_step "update_opencode_config" update_opencode_config
 	_time_step "update_claude_config" update_claude_config
 	_time_step "update_codex_config" update_codex_config


### PR DESCRIPTION
## Summary

`timeout 180 ./setup.sh --non-interactive` was hanging at the `deploy_agents_to_runtimes` stage (#22059 bounded `generate_agent_skills` but the runtime-deployment stage had no bound). This PR adds a time-bounded wrapper so a slow file-system traversal cannot exhaust the remaining postflight budget.

## Changes

### `setup-modules/agent-runtime.sh`
Adds `_deploy_agents_to_runtimes_bounded`: runs `deploy_agents_to_runtimes` in a background subshell, polls for completion with a configurable deadline (`AIDEVOPS_DEPLOY_RUNTIMES_TIMEOUT`, default 120 s), then SIGTERM → SIGKILL on expiry. Shell functions cannot be passed directly to `timeout(1)`, hence the background-subshell-plus-poll approach.

### `setup.sh`
Non-interactive path now calls `_deploy_agents_to_runtimes_bounded` instead of the bare `deploy_agents_to_runtimes`, keeping the stage non-critical — setup continues if the limit fires.

### `.agents/scripts/tests/test-deploy-runtimes-bounded.sh` (new)
7 regression tests:
1. `_deploy_agents_to_runtimes_bounded` is present in `agent-runtime.sh`
2. `setup.sh` is wired to the bounded wrapper
3. `deploy_agents_to_runtimes` itself contains no background job operators (structural safeguard so the simple PID-kill is sufficient)
4. Fast stub returns 0 through the wrapper
5. Slow stub (30 s sleep) is killed within deadline
6. Kill timing is within 10 s of the 3 s configured deadline
7. `AIDEVOPS_DEPLOY_RUNTIMES_TIMEOUT` env var is honoured

## Verification

```
shellcheck setup.sh setup-modules/plugins.sh setup-modules/agent-runtime.sh \
           .agents/scripts/generate-skills.sh \
           .agents/scripts/tests/test-deploy-runtimes-bounded.sh
# → 0 violations

bash .agents/scripts/tests/test-deploy-runtimes-bounded.sh
# → Ran 7 tests, 0 failed
```

Resolves #22087

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.52 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-sonnet-4-6 spent 22m and 66,255 tokens on this as a headless worker.
