### PR TITLE
GH#22056: fix empty gh_create_issue label arg when no TODO labels derived

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-create.sh
+++ b/.agents/scripts/shared-gh-wrappers-create.sh
@@ -201,7 +201,25 @@ gh_create_issue() {
 	# Helper writes _GH_CI_FILTERED_ARGS and _GH_CI_TODO_LABEL_ARGS globals.
 	_gh_ci_prepare_todo_labels "$@"
 	set -- "${_GH_CI_FILTERED_ARGS[@]+"${_GH_CI_FILTERED_ARGS[@]}"}"
-	local -a _todo_label_args=("${_GH_CI_TODO_LABEL_ARGS[@]+"${_GH_CI_TODO_LABEL_ARGS[@]}"}")
+	local -a _todo_label_args=()
+	if [[ ${#_GH_CI_TODO_LABEL_ARGS[@]} -gt 0 ]]; then
+		_todo_label_args=("${_GH_CI_TODO_LABEL_ARGS[@]}")
+	fi
+
+	# Build command arrays safely — avoids empty-arg injection from
+	# "${arr[@]+...}" on empty arrays when no TODO task ID is present and/or
+	# the caller already provided an origin label (GH#22056, mirrors PR #22043).
+	# _issue_cmd: full gh invocation; _rest_args: same flags for REST fallback.
+	local -a _issue_cmd=(gh issue create "$@")
+	local -a _rest_args=("$@")
+	if [[ ${#_todo_label_args[@]} -gt 0 ]]; then
+		_issue_cmd+=("${_todo_label_args[@]}")
+		_rest_args+=("${_todo_label_args[@]}")
+	fi
+	if [[ ${#_origin_label_args[@]} -gt 0 ]]; then
+		_issue_cmd+=("${_origin_label_args[@]}")
+		_rest_args+=("${_origin_label_args[@]}")
+	fi
 
 	# t2028: auto-assign to the current user when the session is interactive
 	# and the caller did not pass an explicit --assignee. Reaches parity with
@@ -222,11 +240,11 @@ gh_create_issue() {
 			local auto_assignee
 			auto_assignee=$(_gh_wrapper_auto_assignee)
 			if [[ -n "$auto_assignee" ]]; then
-				issue_output=$(gh issue create "$@" "${_todo_label_args[@]+"${_todo_label_args[@]}"}" "${_origin_label_args[@]+"${_origin_label_args[@]}"}" --assignee "$auto_assignee") # aidevops-allow: raw-gh-wrapper
+				issue_output=$("${_issue_cmd[@]}" --assignee "$auto_assignee") # aidevops-allow: raw-gh-wrapper
 				rc=$?
 				if [[ $rc -ne 0 ]] && _rest_should_fallback; then
 					print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to REST for issue create"
-					issue_output=$(_rest_issue_create "$@" "${_todo_label_args[@]+"${_todo_label_args[@]}"}" "${_origin_label_args[@]+"${_origin_label_args[@]}"}" --assignee "$auto_assignee")
+					issue_output=$(_rest_issue_create "${_rest_args[@]}" --assignee "$auto_assignee")
 					rc=$?
 				fi
 				echo "$issue_output"
@@ -236,11 +254,11 @@ gh_create_issue() {
 		fi
 	fi
 
-	issue_output=$(gh issue create "$@" "${_todo_label_args[@]+"${_todo_label_args[@]}"}" "${_origin_label_args[@]+"${_origin_label_args[@]}"}") # aidevops-allow: raw-gh-wrapper
+	issue_output=$("${_issue_cmd[@]}") # aidevops-allow: raw-gh-wrapper
 	rc=$?
 	if [[ $rc -ne 0 ]] && _rest_should_fallback; then
 		print_info "[INFO] gh-wrapper: GraphQL exhausted, falling back to REST for issue create"
-		issue_output=$(_rest_issue_create "$@" "${_todo_label_args[@]+"${_todo_label_args[@]}"}" "${_origin_label_args[@]+"${_origin_label_args[@]}"}")
+		issue_output=$(_rest_issue_create "${_rest_args[@]}")
 		rc=$?
 	fi
 	echo "$issue_output"

--- a/.agents/scripts/tests/test-origin-label-mutex-create.sh
+++ b/.agents/scripts/tests/test-origin-label-mutex-create.sh
@@ -346,6 +346,44 @@ else
 		"got $n labels in: $(tail -1 "$GH_RECORD_FILE")"
 fi
 
+# B'3: no TODO-derived labels + explicit non-origin labels → no empty argv element
+# Regression for GH#22056: "${_todo_label_args[@]+...}" on an empty array could emit
+# "" when no TODO task ID was present, causing gh CLI error:
+#   unknown argument ""; please quote all values that have spaces
+# Fix: use explicit ${#arr[@]} -gt 0 checks before expansion (mirrors PR #22043).
+reset_recorder
+export GH_ARGV_RECORD_FILE="${TEST_ROOT}/gh_argv_issue_labels.log"
+: >"$GH_ARGV_RECORD_FILE"
+SESSION_ORIGIN_OVERRIDE="origin:worker" \
+	gh_create_issue --repo o/r --title "some title" --body "body" \
+	--label "auto-dispatch" --label "tier:standard" --label "enhancement" \
+	>/dev/null 2>&1
+if grep -qx '<>' "$GH_ARGV_RECORD_FILE"; then
+	print_result "B'3: gh_create_issue no-TODO-labels passes no empty argv element" 1 \
+		"empty argv element reached gh: $(tr '\n' ' ' <"$GH_ARGV_RECORD_FILE")"
+else
+	print_result "B'3: gh_create_issue no-TODO-labels passes no empty argv element" 0
+fi
+unset GH_ARGV_RECORD_FILE
+
+# B'4: caller passes origin label + no TODO task ID → no empty argv element
+# Second regression scenario from GH#22056: both _todo_label_args AND
+# _origin_label_args empty when caller provides origin label and no TODO ID.
+reset_recorder
+export GH_ARGV_RECORD_FILE="${TEST_ROOT}/gh_argv_issue_origin.log"
+: >"$GH_ARGV_RECORD_FILE"
+SESSION_ORIGIN_OVERRIDE="origin:interactive" \
+	gh_create_issue --repo o/r --title "some title" --body "body" \
+	--label "auto-dispatch" --label "tier:standard" --label "origin:worker" \
+	>/dev/null 2>&1
+if grep -qx '<>' "$GH_ARGV_RECORD_FILE"; then
+	print_result "B'4: gh_create_issue caller-origin+no-TODO passes no empty argv element" 1 \
+		"empty argv element reached gh: $(tr '\n' ' ' <"$GH_ARGV_RECORD_FILE")"
+else
+	print_result "B'4: gh_create_issue caller-origin+no-TODO passes no empty argv element" 0
+fi
+unset GH_ARGV_RECORD_FILE
+
 # ---------------------------------------------------------------------------
 # Layer C: structural checks on full-loop-helper-commit.sh
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix `gh_create_issue` to avoid passing empty `""` arguments to `gh issue create` when no TODO-derived labels exist.

## Problem

When calling `gh_create_issue --repo ... --label auto-dispatch --label tier:standard --label enhancement` with no `--todo-task-id`, the wrapper failed with:

```
unknown argument ""; please quote all values that have spaces
```

The root cause: `_GH_CI_TODO_LABEL_ARGS` is an empty array when no TODO task ID is present. The `"${_todo_label_args[@]+"${_todo_label_args[@]}"}` expansion can emit a literal empty-string argument on certain bash versions (observed in practice, including macOS bash 3.2), causing the `gh` CLI to reject the call.

## Fix

Replace all four `gh issue create` / `_rest_issue_create` call sites in `gh_create_issue` with explicit `${#arr[@]} -gt 0` guards, building:
- `_issue_cmd=(gh issue create "$@" ...)` — the full primary invocation
- `_rest_args=("$@" ...)` — same flags for the REST fallback

Both arrays are populated once with explicit length checks, eliminating all `[@]+` empty-array expansion risk. Mirrors the identical fix applied to `gh_create_pr` in PR #22043.

## Tests

- Added regression tests **B'3** and **B'4** to `test-origin-label-mutex-create.sh`
- B'3: no TODO labels + non-origin labels → no empty argv element reaches `gh`
- B'4: caller-provided origin label + no TODO labels → no empty argv element
- All existing 17 tests still pass (19 total, 0 failures)
- `shellcheck` zero violations on both modified files

## Files Changed

- `EDIT: .agents/scripts/shared-gh-wrappers-create.sh:200-267` — `gh_create_issue` create paths
- `EDIT: .agents/scripts/tests/test-origin-label-mutex-create.sh` — regression tests B'3, B'4

Resolves #22056


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.52 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-sonnet-4-6 spent 8m and 31,153 tokens on this as a headless worker.
