### PR TITLE
t3259: add branch-orphan loop hold

### DIFF
--- a/.agents/reference/worker-diagnostics.md
+++ b/.agents/reference/worker-diagnostics.md
@@ -470,6 +470,19 @@ Observed on GH#20765 (t2814): 2 opus-4-6 attempts (~40K wasted tokens) before ca
 - Replace the `work_dir` snapshot in `_worker_produced_output` with a `git worktree list --porcelain` scan keyed off `WORKER_ISSUE_NUMBER`.
 - Resolve the V6 contract contradiction — pick "pre-creation always succeeds" or "worker creates own + writes path back to a known file", not both.
 
+#### Worker branch-orphan loop hold — GH#22049
+
+When orphan recovery fails, `headless-runtime-helper.sh` posts a structured marker on the issue:
+
+```text
+<!-- worker-branch-orphan:key=<repo>#<issue>#<branch>#worker_branch_orphan -->
+WORKER_BRANCH_ORPHAN branch=<branch> session=<session> ts=<ISO8601>
+```
+
+After worktree pre-creation, `pulse-dispatch-worker-launch.sh` calls `dispatch-dedup-helper.sh check-orphan-loop <issue> <repo> <branch>`. If the same issue+branch has reached `WORKER_BRANCH_ORPHAN_LOOP_THRESHOLD` markers (default `3`) inside `WORKER_BRANCH_ORPHAN_LOOP_WINDOW_S` (default `7200` seconds), dispatch is held before spawning another worker and a single ops diagnostic is posted.
+
+The hold is branch-specific: a different branch or a different issue does not inherit the count. Triage the diagnostic by running the suggested `gh pr list --head <branch>` command; if the branch already has the intended PR, link/merge it, otherwise remove or reset the stale issue-linked worktree/branch so a fresh branch can dispatch.
+
 ## GitHub API Budget, Instrumentation, and Cache Priming
 
 - **REST fallback (t2574, t2744, t2902):** `shared-gh-wrappers.sh` routes eligible writes/reads through REST when GraphQL remaining <= 1500, preserving GraphQL for calls without REST equivalents. Override: `AIDEVOPS_GH_REST_FALLBACK_THRESHOLD`.

--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -31,6 +31,11 @@
 #     task-id fallback) and should be skipped by pulse dispatch.
 #     Exit 0 = PR evidence exists (do NOT dispatch), exit 1 = no evidence.
 #
+#   dispatch-dedup-helper.sh check-orphan-loop <issue> <slug> <branch>
+#     Check whether repeated worker_branch_orphan outcomes for the same issue
+#     and branch should hold dispatch before launching another worker.
+#     Exit 0 = threshold reached (do NOT dispatch), exit 1 = no hold.
+#
 #   dispatch-dedup-helper.sh is-assigned <issue> <slug> [self-login]
 #     Check if issue is assigned to another runner (not self, owner, or maintainer).
 #     GH#10521: Ignores repo owner (from slug) and maintainer (from repos.json).
@@ -755,8 +760,10 @@ _is_assigned_check_dispatch_cooldown() {
 	# Fetch comments. GitHub returns ASC (oldest first); the latest marker
 	# wins via jq `last`. Fail-open on API error — cooldown is an
 	# optimisation, not a guarantee.
+	local comments_endpoint
+	comments_endpoint=$(printf 'repos/%s/issues/%s/comments' "$repo_slug" "$issue_number")
 	local comments_json
-	comments_json=$(gh api "repos/${repo_slug}/issues/${issue_number}/comments" 2>/dev/null) || return 1
+	comments_json=$(gh api "$comments_endpoint" 2>/dev/null) || return 1
 	[[ -n "$comments_json" ]] || return 1
 
 	# Extract the latest cooldown marker timestamp.
@@ -788,6 +795,106 @@ _is_assigned_check_dispatch_cooldown() {
 		return 0
 	fi
 	return 1
+}
+
+#######################################
+# Check repeated worker_branch_orphan outcomes for a single issue+branch.
+#
+# This is a surgical dispatch-loop fuse for the branch-orphan class. The
+# headless runtime posts structured WORKER_BRANCH_ORPHAN comments containing
+# branch, session, and timestamp. When the same branch hits the threshold within
+# the configured window, the dispatch path holds that branch before spawning yet
+# another worker and posts one mentor-quality diagnostic comment for triage.
+#
+# Gating:
+#   WORKER_BRANCH_ORPHAN_LOOP_THRESHOLD  default 3, 0 disables
+#   WORKER_BRANCH_ORPHAN_LOOP_WINDOW_S   default 7200 seconds
+#
+# Fail-open on missing branch, gh/jq/date errors, or malformed comments. This is
+# a blast-radius limiter, not a security gate; unrelated dispatch should not be
+# starved by telemetry read failures.
+#
+# Args: $1 = issue number, $2 = repo slug, $3 = branch name
+# Returns: exit 0 if loop threshold reached (prints ORPHAN_LOOP_BLOCKED),
+#          exit 1 otherwise.
+#######################################
+check_worker_branch_orphan_loop() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local branch_name="$3"
+
+	[[ -n "$issue_number" && -n "$repo_slug" && -n "$branch_name" ]] || return 1
+	[[ "$issue_number" =~ ^[0-9]+$ ]] || return 1
+	[[ "$branch_name" != "HEAD" ]] || return 1
+
+	local threshold="${WORKER_BRANCH_ORPHAN_LOOP_THRESHOLD:-3}"
+	local window_s="${WORKER_BRANCH_ORPHAN_LOOP_WINDOW_S:-7200}"
+	[[ "$threshold" =~ ^[0-9]+$ ]] || threshold=3
+	[[ "$window_s" =~ ^[0-9]+$ ]] || window_s=7200
+	[[ "$threshold" -gt 0 && "$window_s" -gt 0 ]] || return 1
+
+	local comments_endpoint="repos/${repo_slug}/issues/${issue_number}/comments"
+	local comments_json
+	comments_json=$(gh api "$comments_endpoint" 2>/dev/null) || return 1
+	[[ -n "$comments_json" ]] || return 1
+
+	local now_epoch
+	now_epoch=$(date -u +%s 2>/dev/null) || return 1
+
+	local count=0
+	local latest_iso=""
+	local marker_iso=""
+	while IFS= read -r marker_iso; do
+		[[ -n "$marker_iso" ]] || continue
+		local marker_epoch=""
+		marker_epoch=$(date -u -d "$marker_iso" +%s 2>/dev/null) ||
+			marker_epoch=$(date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$marker_iso" +%s 2>/dev/null) ||
+			continue
+		[[ "$marker_epoch" =~ ^[0-9]+$ ]] || continue
+		if [[ $((now_epoch - marker_epoch)) -le "$window_s" ]]; then
+			count=$((count + 1))
+			latest_iso="$marker_iso"
+		fi
+	done < <(printf '%s' "$comments_json" |
+		jq -r --arg branch "$branch_name" '
+			.[]
+			| (.body // "")
+			| select(contains("WORKER_BRANCH_ORPHAN branch=" + $branch + " "))
+			| (capture("WORKER_BRANCH_ORPHAN branch=[^ ]+ session=[^ ]+ ts=(?<ts>[^\\n ]+)")? // {})
+			| .ts // empty
+		' 2>/dev/null) || return 1
+
+	[[ "$count" -ge "$threshold" ]] || return 1
+
+	local existing_block=""
+	existing_block=$(printf '%s' "$comments_json" |
+		jq -r --arg branch "$branch_name" '
+			[.[] | (.body // "") | select(contains("worker-branch-orphan-loop:blocked branch=" + $branch + " "))] | length
+		' 2>/dev/null) || existing_block="0"
+	[[ "$existing_block" =~ ^[0-9]+$ ]] || existing_block=0
+
+	local pr_hint="none found"
+	local pr_line=""
+	pr_line=$(gh pr list --repo "$repo_slug" --head "$branch_name" --state all \
+		--json number,state,url --jq '.[0] | select(.number != null) | "#\(.number) (\(.state)) \(.url)"' 2>/dev/null || true)
+	[[ -n "$pr_line" ]] && pr_hint="$pr_line"
+
+	if [[ "$existing_block" -eq 0 ]]; then
+		local diag
+		# shellcheck disable=SC2016 # Backticks are literal Markdown in this printf template.
+		diag=$(printf '<!-- ops:start -->\n<!-- worker-branch-orphan-loop:blocked branch=%s issue=%s count=%s window_s=%s -->\n## Dispatch held: repeated worker_branch_orphan\n\nThe dispatch path has seen `%s` `WORKER_BRANCH_ORPHAN` outcomes for issue #%s on branch `%s` within the last %s seconds. Dispatch is held for this same branch to avoid burning more worker attempts while preserving evidence.\n\n- Branch: `%s`\n- Latest orphan marker: `%s`\n- PR for branch: %s\n- Next verification: `gh pr list --repo %s --head %s --state all --json number,state,url`\n\nIf the branch already has the intended PR, link or merge that PR. If the branch is stale or corrupt, remove/reset that worktree/branch so a fresh branch can dispatch.\n<!-- ops:end -->' \
+			"$branch_name" "$issue_number" "$count" "$window_s" \
+			"$count" "$issue_number" "$branch_name" "$window_s" \
+			"$branch_name" "${latest_iso:-unknown}" "$pr_hint" "$repo_slug" "$branch_name")
+		gh api "$comments_endpoint" \
+			--method POST \
+			--field body="$diag" \
+			>/dev/null 2>&1 || true
+	fi
+
+	printf 'WORKER_BRANCH_ORPHAN_LOOP_BLOCKED (issue=%s repo=%s branch=%s count=%s threshold=%s window_s=%s latest=%s pr=%s)\n' \
+		"$issue_number" "$repo_slug" "$branch_name" "$count" "$threshold" "$window_s" "${latest_iso:-unknown}" "$pr_hint"
+	return 0
 }
 
 #######################################
@@ -1572,6 +1679,8 @@ Usage:
                                                        t2007: cost circuit breaker (exit 0=tripped, 1=under budget)
   dispatch-dedup-helper.sh sum-issue-token-spend <issue> <slug>
                                                        t2007: aggregate token spend (returns "spent|attempts")
+  dispatch-dedup-helper.sh check-orphan-loop <issue> <slug> <branch>
+                                                       Hold repeated worker_branch_orphan loops for same branch
   dispatch-dedup-helper.sh has-fix-the-fixer-label <issue> <slug>
                                                        t3077: detect the fix-the-fixer label (exit 0=labeled, 1=unlabeled).
                                                        Used by headless-runtime-helper.sh to enable verbose lifecycle,
@@ -1615,6 +1724,13 @@ Examples:
     echo "Issue already has merged PR evidence — skip dispatch"
   else
     echo "No merged PR evidence — safe to dispatch"
+  fi
+
+  # Check before launching a worker on a reused branch-orphan worktree
+  if dispatch-dedup-helper.sh check-orphan-loop 2300 owner/repo feature/auto-20260501-000000-gh2300; then
+    echo "Repeated worker_branch_orphan on this branch — hold dispatch"
+  else
+    echo "No branch-orphan loop — safe to dispatch"
   fi
 
   # Report ALL structural label blockers in one pass (t2894)
@@ -1679,6 +1795,11 @@ main() {
 	has-open-pr)
 		_require_args has-open-pr 2 "$#" "<issue-number> <repo-slug> [issue-title]" || return 1
 		has_open_pr "$1" "$2" "${3:-}"
+		;;
+	check-orphan-loop)
+		_require_args check-orphan-loop 3 "$#" "<issue-number> <repo-slug> <branch>" || return 1
+		local _ol_issue="$1" _ol_repo="$2" _ol_branch="$3"
+		check_worker_branch_orphan_loop "$_ol_issue" "$_ol_repo" "$_ol_branch"
 		;;
 	claim)
 		_require_args claim 2 "$#" "<issue-number> <repo-slug> [runner-login]" || return 1

--- a/.agents/scripts/headless-runtime-worker.sh
+++ b/.agents/scripts/headless-runtime-worker.sh
@@ -577,8 +577,10 @@ _handle_worker_branch_orphan() {
 		# Post structured ops comment so the next dispatch knows what happened
 		if [[ -n "$issue_number" && -n "$repo_slug" && -n "$branch_name" ]]; then
 			local _ops_comment
+			local _orphan_key="${repo_slug}#${issue_number}#${branch_name}#worker_branch_orphan"
 			# shellcheck disable=SC2016 # backticks are literal markdown, not command substitution
-			_ops_comment=$(printf '<!-- ops:start -->\nWORKER_BRANCH_ORPHAN branch=%s session=%s ts=%s\n\nThis worker pushed branch `%s` but no PR could be opened automatically. To recover, open a PR manually:\n\n```\ngh pr create --head %s --base main --repo %s\n```\n<!-- ops:end -->' \
+			_ops_comment=$(printf '<!-- ops:start -->\n<!-- worker-branch-orphan:key=%s -->\nWORKER_BRANCH_ORPHAN branch=%s session=%s ts=%s\n\nThis worker pushed branch `%s` but no PR could be opened automatically. To recover, open a PR manually:\n\n```\ngh pr create --head %s --base main --repo %s\n```\n<!-- ops:end -->' \
+				"$_orphan_key" \
 				"$branch_name" "$session_key" "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
 				"$branch_name" "$branch_name" "$repo_slug")
 			gh api "repos/${repo_slug}/issues/${issue_number}/comments" \

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -20,6 +20,7 @@
 #   - _dlw_spawn_lifecycle_observer (t3055/GH#21870)
 #   - _dlw_nohup_launch
 #   - _dlw_post_launch_hooks
+#   - _dlw_check_worker_branch_orphan_loop
 #   - _dispatch_launch_worker
 
 [[ -n "${_PULSE_DISPATCH_WORKER_LAUNCH_LOADED:-}" ]] && return 0
@@ -843,6 +844,37 @@ Dispatching worker (deterministic).
 	return 0
 }
 
+#######################################
+# Hold dispatch when a reused worker branch repeatedly orphaned.
+#
+# The branch-specific check lives in dispatch-dedup-helper.sh so tests and
+# ad-hoc diagnosis can exercise it directly. It runs after worktree
+# pre-creation because only then do we know whether dispatch is reusing the same
+# issue-linked branch or creating a fresh branch. A new branch therefore does
+# not inherit an old branch's orphan count.
+#
+# Args: $1 = issue number, $2 = repo slug, $3 = worker worktree branch
+# Returns: exit 0 if dispatch should be held, exit 1 if safe to continue
+#######################################
+_dlw_check_worker_branch_orphan_loop() {
+	local issue_number="$1"
+	local repo_slug="$2"
+	local worker_worktree_branch="$3"
+
+	[[ -n "$worker_worktree_branch" ]] || return 1
+
+	local dedup_helper="${SCRIPT_DIR}/dispatch-dedup-helper.sh"
+	[[ -x "$dedup_helper" ]] || return 1
+
+	local orphan_loop_out=""
+	if orphan_loop_out=$("$dedup_helper" check-orphan-loop "$issue_number" "$repo_slug" "$worker_worktree_branch" 2>/dev/null); then
+		echo "[dispatch_with_dedup] Dispatch held for #${issue_number} in ${repo_slug}: ${orphan_loop_out}" >>"$LOGFILE"
+		return 0
+	fi
+
+	return 1
+}
+
 _dlw_canary_preflight() {
 	local issue_number="$1"
 	local repo_slug="$2"
@@ -946,6 +978,9 @@ _dispatch_launch_worker() {
 	_ds_record "$issue_number" "$repo_slug" "precreate_worktree" "$_ds_t0"
 	local worker_worktree_path="$_DLW_WORKTREE_PATH"
 	local worker_worktree_branch="$_DLW_WORKTREE_BRANCH"
+	if _dlw_check_worker_branch_orphan_loop "$issue_number" "$repo_slug" "$worker_worktree_branch"; then
+		return 0
+	fi
 
 	_ds_t0=$(_ds_now_ns)
 	local worker_pid

--- a/.agents/scripts/tests/test-worker-branch-orphan-loop.sh
+++ b/.agents/scripts/tests/test-worker-branch-orphan-loop.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+# test-worker-branch-orphan-loop.sh — GH#22049 regression guard.
+#
+# Asserts that repeated WORKER_BRANCH_ORPHAN markers for the same issue+branch
+# trip the dispatch hold, while a different branch or unrelated failure class
+# remains dispatchable.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit
+HELPER_SCRIPT="${SCRIPT_DIR}/../dispatch-dedup-helper.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TEST_ROOT=""
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+setup_test_env() {
+	TEST_ROOT=$(mktemp -d)
+	mkdir -p "${TEST_ROOT}/bin" "${TEST_ROOT}/posts"
+	export PATH="${TEST_ROOT}/bin:${PATH}"
+	export WORKER_BRANCH_ORPHAN_LOOP_THRESHOLD=2
+	export WORKER_BRANCH_ORPHAN_LOOP_WINDOW_S=7200
+	create_gh_stub
+	return 0
+}
+
+teardown_test_env() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+create_gh_stub() {
+	local now_iso old_iso
+	now_iso=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+	old_iso=$(date -u -v-3H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d '3 hours ago' +%Y-%m-%dT%H:%M:%SZ)
+
+	cat >"${TEST_ROOT}/comments-100.json" <<EOF
+[
+  {"body":"<!-- ops:start -->\nWORKER_BRANCH_ORPHAN branch=feature/reused session=issue-100 ts=${old_iso}\n<!-- ops:end -->"},
+  {"body":"<!-- ops:start -->\nWORKER_BRANCH_ORPHAN branch=feature/reused session=issue-100 ts=${now_iso}\n<!-- ops:end -->"},
+  {"body":"<!-- ops:start -->\nWORKER_BRANCH_ORPHAN branch=feature/reused session=issue-100 ts=${now_iso}\n<!-- ops:end -->"},
+  {"body":"<!-- ops:start -->\nWORKER_BRANCH_ORPHAN branch=feature/other session=issue-100 ts=${now_iso}\n<!-- ops:end -->"},
+  {"body":"<!-- ops:start -->\nWORKER_NOOP branch=feature/reused session=issue-100 ts=${now_iso}\n<!-- ops:end -->"}
+]
+EOF
+
+	cat >"${TEST_ROOT}/comments-200.json" <<EOF
+[
+  {"body":"<!-- ops:start -->\nWORKER_BRANCH_ORPHAN branch=feature/reused session=issue-200 ts=${now_iso}\n<!-- ops:end -->"}
+]
+EOF
+
+	cat >"${TEST_ROOT}/bin/gh" <<'GHEOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "api" && "${2:-}" =~ /issues/([0-9]+)/comments ]]; then
+	issue="${BASH_REMATCH[1]}"
+	if [[ " $* " == *" --method POST "* ]]; then
+		printf '%s\n' "$*" >>"${TEST_ROOT}/posts/${issue}.argv"
+		exit 0
+	fi
+	comments_file="${TEST_ROOT}/comments-${issue}.json"
+	if [[ -f "$comments_file" ]]; then
+		cat "$comments_file"
+	else
+		printf '[]\n'
+	fi
+	exit 0
+fi
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "list" ]]; then
+	printf '#123 (OPEN) https://example.invalid/pr/123\n'
+	exit 0
+fi
+
+printf 'unsupported gh invocation in orphan-loop stub: %s\n' "$*" >&2
+exit 1
+GHEOF
+	chmod +x "${TEST_ROOT}/bin/gh"
+	return 0
+}
+
+test_same_issue_branch_blocks_and_posts_diagnostic() {
+	local output=""
+	if output=$(TEST_ROOT="$TEST_ROOT" "$HELPER_SCRIPT" check-orphan-loop 100 owner/repo feature/reused 2>/dev/null); then
+		if [[ "$output" == *"WORKER_BRANCH_ORPHAN_LOOP_BLOCKED"* && -f "${TEST_ROOT}/posts/100.argv" ]]; then
+			print_result "same issue+branch crosses threshold and posts diagnostic" 0
+			return 0
+		fi
+		print_result "same issue+branch crosses threshold and posts diagnostic" 1 "Unexpected output or missing post: ${output}"
+		return 0
+	fi
+	print_result "same issue+branch crosses threshold and posts diagnostic" 1 "Expected dispatch hold"
+	return 0
+}
+
+test_different_branch_does_not_block() {
+	if TEST_ROOT="$TEST_ROOT" "$HELPER_SCRIPT" check-orphan-loop 100 owner/repo feature/fresh >/dev/null 2>&1; then
+		print_result "different branch does not inherit orphan count" 1 "Expected exit 1 (safe)"
+		return 0
+	fi
+	print_result "different branch does not inherit orphan count" 0
+	return 0
+}
+
+test_different_issue_does_not_block() {
+	if TEST_ROOT="$TEST_ROOT" "$HELPER_SCRIPT" check-orphan-loop 200 owner/repo feature/reused >/dev/null 2>&1; then
+		print_result "different issue does not inherit orphan count" 1 "Expected exit 1 (safe)"
+		return 0
+	fi
+	print_result "different issue does not inherit orphan count" 0
+	return 0
+}
+
+test_unrelated_failure_class_does_not_block() {
+	if TEST_ROOT="$TEST_ROOT" "$HELPER_SCRIPT" check-orphan-loop 100 owner/repo feature/noop-only >/dev/null 2>&1; then
+		print_result "different failure class does not block" 1 "Expected exit 1 (safe)"
+		return 0
+	fi
+	print_result "different failure class does not block" 0
+	return 0
+}
+
+main() {
+	setup_test_env
+	test_same_issue_branch_blocks_and_posts_diagnostic
+	test_different_branch_does_not_block
+	test_different_issue_does_not_block
+	test_unrelated_failure_class_does_not_block
+	teardown_test_env
+
+	printf '\nTests run: %d\n' "$TESTS_RUN"
+	printf 'Failures: %d\n' "$TESTS_FAILED"
+
+	if [[ "$TESTS_FAILED" -eq 0 ]]; then
+		return 0
+	fi
+	return 1
+}
+
+main "$@"


### PR DESCRIPTION
Resolves #22049

## Summary

- Adds a branch-specific worker_branch_orphan loop fuse keyed by issue + branch before worker launch.
- Emits structured orphan markers and a one-time mentor-quality diagnostic when the threshold is reached.
- Adds regression coverage and documents the hold/triage flow.

## Testing

- `bash .agents/scripts/tests/test-worker-branch-orphan-loop.sh`
- `bash .agents/scripts/tests/test-headless-runtime-helper.sh`
- `shellcheck .agents/scripts/dispatch-dedup-helper.sh .agents/scripts/pulse-dispatch-worker-launch.sh .agents/scripts/headless-runtime-worker.sh .agents/scripts/tests/test-worker-branch-orphan-loop.sh`

## Runtime Testing

runtime-verified: exercised the dispatch helper path with a stubbed GitHub API harness that posts the diagnostic and blocks only the repeated same issue+branch orphan case.

## Key decisions

- The hold is branch-specific so fresh branches and unrelated failure classes remain dispatchable.
- The checker fails open on telemetry/API errors because this is a blast-radius limiter, not a security gate.


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.52 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 9h and 618,644 tokens on this with the user in an interactive session.
