### PR TITLE
t3239: finish OpenCode DB WAL and maintenance-window handling

### DIFF
--- a/.agents/reference/opencode-maintenance.md
+++ b/.agents/reference/opencode-maintenance.md
@@ -40,6 +40,8 @@ time and invokes `opencode-db-maintenance-helper.sh auto`, which:
    from deleted rows. Runs when the DB is larger than 500 MB or free pages
    exceed 10% of total pages. Typical reclaim: 20–40% on DBs with heavy
    prune activity.
+5. **Final WAL checkpoint**. VACUUM itself can write a DB-sized WAL. The helper
+   runs a final `wal_checkpoint(TRUNCATE)` before declaring success.
 
 ## Subcommands
 
@@ -48,6 +50,7 @@ opencode-db-maintenance-helper.sh check    # preflight: DB exists, no locks, int
 opencode-db-maintenance-helper.sh report   # stats (size, pages, free list, top tables)
 opencode-db-maintenance-helper.sh maintain # run once (refuses if processes active)
 opencode-db-maintenance-helper.sh maintain --force  # run anyway (may cause session errors)
+opencode-db-maintenance-helper.sh maintenance-window --force-opencode
 opencode-db-maintenance-helper.sh auto     # scheduled mode (silent, throttled)
 opencode-db-maintenance-helper.sh help
 ```
@@ -92,6 +95,11 @@ All thresholds overrideable via environment variables:
 | `VACUUM_FREELIST_THRESHOLD` | `0.10` | VACUUM if free-page fraction >= this |
 | `FORCE_VACUUM_SIZE_MB` | `500` | Always VACUUM above this size (MB) |
 | `AUTO_MIN_SECONDS_BETWEEN` | `518400` | Throttle for `auto` mode (6 days) |
+| `WAL_LARGE_THRESHOLD_MB` | `500` | Report checkpoint/busy details above this WAL size |
+| `MAINTENANCE_WINDOW_KEEP_SESSIONS` | `500` | Count target used by `maintenance-window` archive |
+| `OPENCODE_DB_MAINTENANCE_HOUR` | `4` | Scheduled local hour for the weekly routine |
+| `OPENCODE_DB_MAINTENANCE_MINUTE` | `0` | Scheduled local minute for the weekly routine |
+| `OPENCODE_DB_MAINTENANCE_MODE` | `auto` | `auto` or disruptive `maintenance-window` scheduler mode |
 
 Example: force VACUUM on every run regardless of fragmentation:
 
@@ -130,11 +138,42 @@ When both modes are provided, the archive uses the conservative intersection:
 recent sessions are preserved if they are within either the age window or the
 newest-session budget.
 
+## Disruptive maintenance window
+
+`opencode-db-maintenance-helper.sh maintenance-window` is for explicit off-hours
+windows where the operator accepts interruption risk to get a compact DB and a
+truncated WAL.
+
+It does this in order:
+
+1. Stops aidevops-managed pulse/headless workers with `pulse-lifecycle-helper.sh
+   stop`.
+2. Archives old sessions with `opencode-db-archive.sh archive --keep-sessions
+   ${MAINTENANCE_WINDOW_KEEP_SESSIONS}`.
+3. Runs normal maintenance, including final post-VACUUM WAL checkpoint.
+4. Runs `PRAGMA quick_check`.
+5. Restarts pulse in a trap/finally path with `pulse-lifecycle-helper.sh start`.
+
+Interactive OpenCode TUIs are not killed automatically. If any TUI still holds
+the DB, the command exits with guidance unless `--force-opencode` is passed. Use
+that flag only when the remaining holder is the session coordinating the window.
+
+To schedule the disruptive mode instead of the safe no-op mode:
+
+```bash
+OPENCODE_DB_MAINTENANCE_MODE=maintenance-window \
+OPENCODE_DB_MAINTENANCE_HOUR=8 \
+  opencode-db-maintenance-helper.sh install
+```
+
 ## Safety
 
 - **Never runs with active opencode processes** in `auto` or plain
   `maintain` mode. A running opencode TUI holds WAL locks; VACUUM
   requires exclusive access. The check uses `pgrep` for `opencode-ai/bin/.opencode`.
+- **Disruptive mode is explicit**. `maintenance-window` may stop pulse/headless
+  workers and requires `--force-opencode` before it continues with an
+  interactive TUI holding the DB.
 - **No data loss from VACUUM**. SQLite VACUUM rewrites the DB file
   page by page, preserving every row. If interrupted, SQLite's journal
   restores the previous state.

--- a/.agents/scripts/opencode-db-archive.sh
+++ b/.agents/scripts/opencode-db-archive.sh
@@ -349,6 +349,44 @@ _format_cutoff_time() {
 	return 0
 }
 
+# _check_wal_post_archive <db>
+# After a successful archive pass, checks whether the WAL is still large
+# because active readers are blocking the checkpoint.  Emits a warning with
+# the number of blocking processes and a deterministic next step.
+# Silent no-op when WAL is within the threshold or does not exist.
+_check_wal_post_archive() {
+	local db="$1"
+	local wal_path="${db}-wal"
+	[[ -f "$wal_path" ]] || return 0
+	local wal_bytes wal_mb
+	wal_bytes=$(file_size_bytes "$wal_path")
+	wal_mb=$(( wal_bytes / 1048576 ))
+	local threshold="${WAL_LARGE_THRESHOLD_MB:-500}"
+	[[ "$wal_mb" -ge "$threshold" ]] || return 0
+	print_warning "WAL still large after archive: $(format_bytes "$wal_bytes") (${wal_path})"
+	# Probe checkpoint state: PASSIVE does not block writers — safe with live sessions.
+	local ckpt_out blocked log_pages ckpt_pages
+	ckpt_out=$(sqlite3 "$db" "PRAGMA wal_checkpoint(PASSIVE);" 2>/dev/null || echo "0|0|0")
+	IFS='|' read -r blocked log_pages ckpt_pages <<<"$ckpt_out"
+	if [[ "${blocked:-0}" == "1" ]] && [[ "${log_pages:-0}" -gt "${ckpt_pages:-0}" ]]; then
+		local unckpt=$(( ${log_pages:-0} - ${ckpt_pages:-0} ))
+		print_warning "WAL checkpoint busy: ${unckpt} frame(s) still held by active readers"
+		local n_holders=0
+		if command -v lsof >/dev/null 2>&1 && [[ -f "$db" ]]; then
+			n_holders=$(lsof "$db" 2>/dev/null | awk 'NR>1 {print $2}' | sort -u | wc -l | tr -d ' ')
+		fi
+		n_holders="${n_holders:-0}"
+		if [[ "$n_holders" -gt 0 ]]; then
+			print_warning "${n_holders} process(es) holding DB open — WAL cannot be truncated until they close"
+		fi
+		print_info "Next step: close all OpenCode sessions, then run:"
+		print_info "  opencode-db-maintenance-helper.sh maintain"
+	else
+		print_info "WAL will be truncated on next maintenance run (no active readers blocking)"
+	fi
+	return 0
+}
+
 _archive_candidate_filter() {
 	local retention_enabled="$1"
 	local cutoff_ms="$2"
@@ -645,6 +683,8 @@ BATCH_SQL
 	print_success "Archive complete: $archived_total sessions moved"
 	print_success "Active DB: $(format_bytes "$size_before") → $(format_bytes "$size_after") ($(format_bytes "$total_freed") freed)"
 	print_success "Archive DB: $(format_bytes "$(file_size_bytes "$ARCHIVE_DB")")"
+	# Surface large WAL that remains after archiving (active readers may be blocking truncation).
+	_check_wal_post_archive "$ACTIVE_DB"
 	return 0
 }
 

--- a/.agents/scripts/opencode-db-maintenance-helper.sh
+++ b/.agents/scripts/opencode-db-maintenance-helper.sh
@@ -35,6 +35,8 @@
 #   check                — report readiness; does opencode.db exist, is it locked?
 #   report               — human-readable DB stats (size, row counts, fragmentation)
 #   maintain [--force]   — run maintenance; aborts if opencode processes active
+#   maintenance-window    — stop pulse/headless workers, optionally archive,
+#                          maintain, then restart pulse (explicitly disruptive)
 #   auto                 — run maintenance only if safe (no active processes);
 #                          used by the r913 weekly routine. Silent no-op if
 #                          opencode is not installed.
@@ -85,6 +87,8 @@ readonly OPENCODE_DATA_DIR="${XDG_DATA_HOME:-${HOME}/.local/share}/opencode"
 readonly OPENCODE_DB="${OPENCODE_DATA_DIR}/opencode.db"
 readonly OPENCODE_WAL="${OPENCODE_DB}-wal"
 readonly OPENCODE_SHM="${OPENCODE_DB}-shm"
+readonly MAINTENANCE_WINDOW_MODE="maintenance-window"
+readonly SQLITE_QUICK_CHECK="PRAGMA quick_check;"
 
 readonly STATE_DIR="${HOME}/.aidevops/.agent-workspace/work/opencode-maintenance"
 readonly STATE_FILE="${STATE_DIR}/last-run.json"
@@ -99,6 +103,12 @@ readonly LOG_FILE="${STATE_DIR}/maintenance.log"
 : "${AUTO_MIN_SECONDS_BETWEEN:=518400}"
 # WAL_LARGE_THRESHOLD_MB: warn/report large WAL if it exceeds this size (default 500 MB)
 : "${WAL_LARGE_THRESHOLD_MB:=500}"
+# MAINTENANCE_WINDOW_KEEP_SESSIONS: count target for disruptive maintenance-window archive
+: "${MAINTENANCE_WINDOW_KEEP_SESSIONS:=500}"
+# Scheduler knobs: safe default is weekly Sun 04:00 running non-disruptive auto.
+: "${OPENCODE_DB_MAINTENANCE_HOUR:=4}"
+: "${OPENCODE_DB_MAINTENANCE_MINUTE:=0}"
+: "${OPENCODE_DB_MAINTENANCE_MODE:=auto}"
 
 # Scheduler (macOS launchd) — used by cmd_install / cmd_uninstall / cmd_status.
 # Linux systemd/cron install is handled by setup-modules/schedulers.sh
@@ -108,6 +118,11 @@ readonly LAUNCHD_DIR="${HOME}/Library/LaunchAgents"
 readonly LAUNCHD_PLIST="${LAUNCHD_DIR}/${LAUNCHD_LABEL}.plist"
 readonly SCHEDULER_LOG_DIR="${HOME}/.aidevops/.agent-workspace/logs"
 readonly SCHEDULER_LOG_FILE="${SCHEDULER_LOG_DIR}/opencode-db-maintenance.log"
+
+# Helper paths are overrideable for tests. Empty values mean "auto-detect".
+: "${PULSE_LIFECYCLE_HELPER:=pulse-lifecycle-helper.sh}"
+: "${OPENCODE_DB_ARCHIVE_HELPER:=${SCRIPT_DIR}/opencode-db-archive.sh}"
+: "${SQLITE3_BIN:=sqlite3}"
 
 # -----------------------------------------------------------------------------
 # Output helpers (fallback if shared-constants didn't provide them)
@@ -326,7 +341,7 @@ cmd_report() {
 		return 0
 	fi
 	if ! _sqlite_available; then
-		print_error "sqlite3 CLI not available"
+		print_error "${SQLITE3_BIN} CLI not available"
 		return 1
 	fi
 
@@ -491,7 +506,7 @@ _maintain_should_vacuum() {
 }
 
 # _maintain_run_steps <before_bytes>
-# Runs the three SQLite maintenance steps. Echoes "step_failures vacuum_ran".
+# Runs the SQLite maintenance steps. Echoes "step_failures vacuum_ran".
 _maintain_run_steps() {
 	local before_bytes="$1"
 	local step_failures=0
@@ -528,6 +543,21 @@ _maintain_run_steps() {
 		fi
 	else
 		print_info "Step 3/3: VACUUM skipped (low fragmentation: ${freelist_count}/${page_count} free pages, ${size_mb} MB < ${FORCE_VACUUM_SIZE_MB} MB)"
+	fi
+
+	# VACUUM itself can write a large WAL. The manual 2026-05-01 run saw
+	# maintenance report success while opencode.db-wal grew to DB-size. Always
+	# checkpoint again after VACUUM so success means "DB compact and WAL folded".
+	print_info "Final step: post-VACUUM wal_checkpoint(TRUNCATE)..."
+	local final_ckpt
+	if ! final_ckpt=$("$SQLITE3_BIN" "$OPENCODE_DB" "PRAGMA wal_checkpoint(TRUNCATE);" 2>&1); then
+		print_warning "post-VACUUM wal_checkpoint failed (non-fatal): ${final_ckpt}"
+		_log WARN "post-VACUUM wal_checkpoint failed: ${final_ckpt}"
+		step_failures=$((step_failures + 1))
+	elif [[ "$final_ckpt" == 1\|* ]]; then
+		print_warning "post-VACUUM wal_checkpoint busy: ${final_ckpt}"
+		_log WARN "post-VACUUM wal_checkpoint busy: ${final_ckpt}"
+		step_failures=$((step_failures + 1))
 	fi
 
 	printf '%s %s' "$step_failures" "$do_vacuum"
@@ -614,6 +644,107 @@ cmd_maintain() {
 		return 10
 	fi
 	return 0
+}
+
+# -----------------------------------------------------------------------------
+# Subcommand: maintenance-window
+# -----------------------------------------------------------------------------
+# Explicitly disruptive run for off-hours windows: stop aidevops-managed pulse
+# processes, archive old sessions, run DB maintenance, then restart pulse even
+# when a step fails. Interactive OpenCode TUIs are not stopped; they require
+# --force-opencode so the operator consciously accepts the risk.
+
+_maintenance_window_restart_pulse() {
+	if [[ "${_OCDBM_RESTART_PULSE:-0}" == "1" ]]; then
+		print_info "Restarting pulse after maintenance window..."
+		"$PULSE_LIFECYCLE_HELPER" start || print_warning "pulse restart failed; run pulse-lifecycle-helper.sh start"
+	fi
+	return 0
+}
+
+cmd_maintenance_window() {
+	local force_opencode=false
+	local keep_sessions="$MAINTENANCE_WINDOW_KEEP_SESSIONS"
+	local skip_archive=false
+	local arg
+
+	while [[ $# -gt 0 ]]; do
+		local arg="$1"
+		case "$arg" in
+		--force-opencode)
+			force_opencode=true
+			shift
+			;;
+		--keep-sessions)
+			keep_sessions="${2:-}"
+			shift 2
+			;;
+		--skip-archive)
+			skip_archive=true
+			shift
+			;;
+		*)
+			print_error "Unknown maintenance-window option: $arg"
+			return 1
+			;;
+		esac
+	done
+
+	if [[ ! "$keep_sessions" =~ ^[0-9]+$ ]]; then
+		print_error "--keep-sessions must be a non-negative integer: ${keep_sessions}"
+		return 1
+	fi
+	if ! _opencode_installed; then
+		print_info "opencode not installed — nothing to maintain"
+		return 0
+	fi
+	if ! _sqlite_available; then
+		print_error "sqlite3 CLI not available"
+		return 1
+	fi
+
+	if command -v "$PULSE_LIFECYCLE_HELPER" >/dev/null 2>&1; then
+		print_info "Stopping pulse for maintenance window..."
+		"$PULSE_LIFECYCLE_HELPER" stop || print_warning "pulse stop returned non-zero; continuing with DB holder checks"
+		_OCDBM_RESTART_PULSE=1
+		trap _maintenance_window_restart_pulse RETURN
+	else
+		print_warning "pulse lifecycle helper not found; skipping pulse stop/start"
+	fi
+
+	local active_count
+	active_count=$(_opencode_process_count)
+	if [[ "$active_count" -gt 0 ]] && [[ "$force_opencode" != true ]]; then
+		print_warning "$active_count OpenCode DB holder(s) still active after stopping pulse"
+		print_info "maintenance-window stops pulse/headless workers only; close interactive TUIs or pass --force-opencode"
+		return 2
+	fi
+
+	local rc=0
+	if [[ "$skip_archive" != true ]] && [[ -x "$OPENCODE_DB_ARCHIVE_HELPER" ]]; then
+		print_info "Archiving old OpenCode sessions (keep newest ${keep_sessions})..."
+		"$OPENCODE_DB_ARCHIVE_HELPER" archive --keep-sessions "$keep_sessions" --max-duration-seconds 300 || rc=$?
+		if [[ "$rc" -ne 0 ]]; then
+			print_warning "archive step failed (rc=${rc}); continuing to maintenance"
+		fi
+	fi
+
+	local maintain_args=()
+	if [[ "$force_opencode" == true ]]; then
+		maintain_args+=(--force)
+	fi
+	cmd_maintain "${maintain_args[@]}" || rc=$?
+
+	local integrity
+	integrity=$("$SQLITE3_BIN" "$OPENCODE_DB" "$SQLITE_QUICK_CHECK" 2>&1 || echo "error")
+	if [[ "$integrity" != "ok" ]]; then
+		print_error "post-maintenance quick_check failed: $integrity"
+		rc=1
+	else
+		print_success "post-maintenance quick_check: ok"
+	fi
+
+	return "$rc"
 }
 
 # -----------------------------------------------------------------------------
@@ -707,6 +838,10 @@ _resolve_self_path() {
 # Hour=4, Minute=0 — matches the routine's declared "weekly(sun@04:00)".
 _generate_plist_content() {
 	local self_path="$1"
+	local scheduler_subcommand="auto"
+	if [[ "$OPENCODE_DB_MAINTENANCE_MODE" == "$MAINTENANCE_WINDOW_MODE" ]]; then
+		scheduler_subcommand="$MAINTENANCE_WINDOW_MODE"
+	fi
 	cat <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -718,16 +853,17 @@ _generate_plist_content() {
 	<array>
 		<string>/bin/bash</string>
 		<string>${self_path}</string>
-		<string>auto</string>
+		<string>${scheduler_subcommand}</string>
+$([[ "$scheduler_subcommand" == "$MAINTENANCE_WINDOW_MODE" ]] && printf '\t\t<string>--force-opencode</string>\n')
 	</array>
 	<key>StartCalendarInterval</key>
 	<dict>
 		<key>Weekday</key>
 		<integer>0</integer>
 		<key>Hour</key>
-		<integer>4</integer>
+		<integer>${OPENCODE_DB_MAINTENANCE_HOUR}</integer>
 		<key>Minute</key>
-		<integer>0</integer>
+		<integer>${OPENCODE_DB_MAINTENANCE_MINUTE}</integer>
 	</dict>
 	<key>StandardOutPath</key>
 	<string>${SCHEDULER_LOG_FILE}</string>
@@ -875,6 +1011,9 @@ Subcommands:
   report                 Human-readable DB stats (size, pages, free list, PRAGMAs)
   maintain [--force]     Run maintenance. Aborts if opencode processes active
                          unless --force is passed (may cause session errors).
+  maintenance-window     Disruptive off-hours mode: stop pulse/headless workers,
+                         archive old sessions, maintain DB, quick_check, restart pulse.
+                         Pass --force-opencode to continue with interactive TUIs open.
   auto                   Safe mode for scheduled use (r913). Silent no-op when
                          opencode not installed; throttles rapid re-runs.
   install                macOS: install/refresh LaunchAgent (weekly Sun 04:00).
@@ -899,6 +1038,11 @@ Environment variables (advanced):
   VACUUM_FREELIST_THRESHOLD    Fraction of free pages triggering VACUUM (default 0.10)
   FORCE_VACUUM_SIZE_MB         Always VACUUM above this size (default 500)
   AUTO_MIN_SECONDS_BETWEEN     Throttle for auto mode (default 518400 = 6 days)
+  WAL_LARGE_THRESHOLD_MB       Warn/report large WAL above this size (default 500)
+  MAINTENANCE_WINDOW_KEEP_SESSIONS  Archive keep target for maintenance-window (default 500)
+  OPENCODE_DB_MAINTENANCE_HOUR Scheduled local hour for install (default 4)
+  OPENCODE_DB_MAINTENANCE_MINUTE Scheduled local minute for install (default 0)
+  OPENCODE_DB_MAINTENANCE_MODE  Scheduler mode: auto or maintenance-window
 
 State:
   ~/.aidevops/.agent-workspace/work/opencode-maintenance/last-run.json
@@ -923,6 +1067,7 @@ main() {
 	check) cmd_check "$@" ;;
 	report) cmd_report "$@" ;;
 	maintain | run) cmd_maintain "$@" ;;
+	"$MAINTENANCE_WINDOW_MODE" | window) cmd_maintenance_window "$@" ;;
 	auto) cmd_auto "$@" ;;
 	install) cmd_install "$@" ;;
 	uninstall) cmd_uninstall "$@" ;;

--- a/.agents/scripts/opencode-db-maintenance-helper.sh
+++ b/.agents/scripts/opencode-db-maintenance-helper.sh
@@ -97,6 +97,8 @@ readonly LOG_FILE="${STATE_DIR}/maintenance.log"
 : "${FORCE_VACUUM_SIZE_MB:=500}"
 # AUTO_MIN_SECONDS_BETWEEN: skip auto run if last run was within N seconds (default 6 days)
 : "${AUTO_MIN_SECONDS_BETWEEN:=518400}"
+# WAL_LARGE_THRESHOLD_MB: warn/report large WAL if it exceeds this size (default 500 MB)
+: "${WAL_LARGE_THRESHOLD_MB:=500}"
 
 # Scheduler (macOS launchd) — used by cmd_install / cmd_uninstall / cmd_status.
 # Linux systemd/cron install is handled by setup-modules/schedulers.sh
@@ -211,6 +213,37 @@ _pragma() {
 	sqlite3 "$db" "PRAGMA ${name};" 2>/dev/null
 }
 
+# _wal_checkpoint_probe <db>
+# Runs PRAGMA wal_checkpoint(PASSIVE) and emits "blocked log checkpointed"
+# as space-separated integers. PASSIVE is non-blocking — safe with live sessions.
+# blocked=1 means at least one reader still holds frames in the WAL.
+# On sqlite3 error or empty output, emits "0 0 0".
+_wal_checkpoint_probe() {
+	local db="$1"
+	[[ -f "$db" ]] || { printf '%s' "0 0 0"; return 0; }
+	local result
+	result=$(sqlite3 "$db" "PRAGMA wal_checkpoint(PASSIVE);" 2>/dev/null || true)
+	if [[ -z "$result" ]]; then
+		printf '%s' "0 0 0"
+		return 0
+	fi
+	local blocked log_pages ckpt_pages
+	IFS='|' read -r blocked log_pages ckpt_pages <<<"$result"
+	printf '%s %s %s' "${blocked:-0}" "${log_pages:-0}" "${ckpt_pages:-0}"
+	return 0
+}
+
+# _wal_list_db_holders <db>
+# Emits "PID CMDNAME" lines for processes holding <db> open (via lsof).
+# Returns empty when lsof is unavailable or no holders found.
+_wal_list_db_holders() {
+	local db="$1"
+	[[ -f "$db" ]] || return 0
+	command -v lsof >/dev/null 2>&1 || return 0
+	lsof "$db" 2>/dev/null | awk 'NR>1 {print $2, $1}' | sort -u || true
+	return 0
+}
+
 # -----------------------------------------------------------------------------
 # Subcommand: check
 # -----------------------------------------------------------------------------
@@ -256,6 +289,30 @@ cmd_check() {
 	print_info "DB:  $(_db_size_human "$db_bytes") ($OPENCODE_DB)"
 	print_info "WAL: $(_db_size_human "$wal_bytes") ($OPENCODE_WAL)"
 
+	# WAL-specific warning: if WAL is large, probe checkpoint state and name blockers
+	local wal_mb=$(( wal_bytes / 1048576 ))
+	if [[ "$wal_mb" -ge "${WAL_LARGE_THRESHOLD_MB}" ]] && [[ -f "$OPENCODE_WAL" ]]; then
+		local probe_result probe_blocked probe_log probe_ckpt
+		probe_result=$(_wal_checkpoint_probe "$OPENCODE_DB")
+		read -r probe_blocked probe_log probe_ckpt <<<"$probe_result"
+		if [[ "$probe_blocked" == "1" ]]; then
+			local unckpt=$(( probe_log - probe_ckpt ))
+			print_warning "WAL large and checkpoint BUSY — ${unckpt} frame(s) still held by active readers"
+			local holders
+			holders=$(_wal_list_db_holders "$OPENCODE_DB")
+			if [[ -n "$holders" ]]; then
+				print_info "Active DB holders blocking WAL truncation (PID process):"
+				while IFS=' ' read -r pid name; do
+					print_info "  PID ${pid}  ${name}"
+				done <<<"$holders"
+			fi
+			print_info "Next step: close all OpenCode sessions, then run:"
+			print_info "  opencode-db-maintenance-helper.sh maintain"
+		else
+			print_info "WAL large but checkpoint is not blocked — run maintain to truncate"
+		fi
+	fi
+
 	return "$exit_code"
 }
 
@@ -297,6 +354,32 @@ cmd_report() {
 	printf '  Path:          %s\n' "$OPENCODE_DB"
 	printf '  DB size:       %s\n' "$(_db_size_human "$db_bytes")"
 	printf '  WAL size:      %s\n' "$(_db_size_human "$wal_bytes")"
+	# WAL status: distinguish active-DB table size from WAL size; show checkpoint state
+	# when WAL is large so users understand why it hasn't shrunk after archiving.
+	local wal_mb_report=$(( wal_bytes / 1048576 ))
+	if [[ "$wal_mb_report" -ge "${WAL_LARGE_THRESHOLD_MB}" ]] && [[ -f "$OPENCODE_WAL" ]]; then
+		local rp_result rp_blocked rp_log rp_ckpt
+		rp_result=$(_wal_checkpoint_probe "$OPENCODE_DB")
+		read -r rp_blocked rp_log rp_ckpt <<<"$rp_result"
+		if [[ "$rp_blocked" == "1" ]]; then
+			local rp_unckpt=$(( rp_log - rp_ckpt ))
+			printf '  WAL status:    BUSY — checkpoint blocked by active readers\n'
+			printf '                 (%s frames total, %s checkpointed, %s held)\n' \
+				"$rp_log" "$rp_ckpt" "$rp_unckpt"
+			local rp_holders
+			rp_holders=$(_wal_list_db_holders "$OPENCODE_DB")
+			if [[ -n "$rp_holders" ]]; then
+				printf '  WAL blockers:  (PID process)\n'
+				while IFS=' ' read -r pid name; do
+					printf '                 PID %-8s %s\n' "$pid" "$name"
+				done <<<"$rp_holders"
+			fi
+			printf '  Next step:     close all OpenCode sessions, then:\n'
+			printf '                 opencode-db-maintenance-helper.sh maintain\n'
+		else
+			printf '  WAL status:    ok (checkpoint not blocked)\n'
+		fi
+	fi
 	printf '  Pages:         %s (page_size=%sB)\n' "$page_count" "$page_size"
 	printf '  Free pages:    %s (%s%% of total)\n' "$freelist_count" "$freelist_pct"
 	printf '\n  PRAGMAs (fresh CLI connection — not what opencode uses):\n'

--- a/.agents/scripts/tests/test-opencode-db-maintenance.sh
+++ b/.agents/scripts/tests/test-opencode-db-maintenance.sh
@@ -278,6 +278,44 @@ else
 	_fail "report failed (rc=$rc) when WAL absent — output: $out"
 fi
 
+# Recreate the WAL-capable DB after the absent-WAL test for maintenance-window.
+rm -f "$OPENCODE_DIR/opencode.db"
+_make_opencode_db
+
+# -----------------------------------------------------------------------------
+# Test 13: maintenance-window restores pulse through mocked lifecycle helper
+# -----------------------------------------------------------------------------
+
+mock_bin="$SANDBOX/mock-bin"
+mkdir -p "$mock_bin"
+mock_pulse_log="$SANDBOX/pulse-lifecycle.log"
+mock_archive_log="$SANDBOX/archive.log"
+cat >"$mock_bin/pulse-lifecycle-helper.sh" <<'MOCK_PULSE'
+#!/usr/bin/env bash
+printf '%s\n' "$1" >>"$MOCK_PULSE_LOG"
+exit 0
+MOCK_PULSE
+chmod +x "$mock_bin/pulse-lifecycle-helper.sh"
+cat >"$mock_bin/opencode-db-archive.sh" <<'MOCK_ARCHIVE'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"$MOCK_ARCHIVE_LOG"
+exit 0
+MOCK_ARCHIVE
+chmod +x "$mock_bin/opencode-db-archive.sh"
+
+set +e
+out=$(PATH="$mock_bin:$PATH" MOCK_PULSE_LOG="$mock_pulse_log" MOCK_ARCHIVE_LOG="$mock_archive_log" \
+	OPENCODE_DB_ARCHIVE_HELPER="$mock_bin/opencode-db-archive.sh" \
+	VACUUM_FREELIST_THRESHOLD=0.01 FORCE_VACUUM_SIZE_MB=0 \
+	_run_helper maintenance-window --force-opencode --keep-sessions 123 2>&1)
+rc=$?
+set -e
+if [[ "$rc" -eq 0 ]] && grep -q '^stop$' "$mock_pulse_log" && grep -q '^start$' "$mock_pulse_log" && grep -q -- '--keep-sessions 123' "$mock_archive_log"; then
+	_pass "maintenance-window stops pulse, archives, maintains, and restarts pulse"
+else
+	_fail "maintenance-window mocked lifecycle failed (rc=$rc) — output: $out"
+fi
+
 # -----------------------------------------------------------------------------
 # Summary
 # -----------------------------------------------------------------------------

--- a/.agents/scripts/tests/test-opencode-db-maintenance.sh
+++ b/.agents/scripts/tests/test-opencode-db-maintenance.sh
@@ -232,6 +232,53 @@ else
 fi
 
 # -----------------------------------------------------------------------------
+# Test 10: report shows WAL status section when WAL_LARGE_THRESHOLD_MB=0
+# -----------------------------------------------------------------------------
+# Setting the threshold to 0 forces the WAL status code path regardless of
+# actual WAL file size, without touching the real opencode.db.
+
+set +e
+out=$(WAL_LARGE_THRESHOLD_MB=0 _run_helper report 2>&1)
+rc=$?
+set -e
+if [[ "$rc" -eq 0 ]] && grep -qiE "WAL status:|WAL size:" <<<"$out"; then
+	_pass "report shows WAL status section when WAL_LARGE_THRESHOLD_MB=0"
+else
+	_fail "report missing WAL status section (rc=$rc) — output: $out"
+fi
+
+# -----------------------------------------------------------------------------
+# Test 11: check shows WAL info when WAL_LARGE_THRESHOLD_MB=0
+# -----------------------------------------------------------------------------
+
+set +e
+out=$(WAL_LARGE_THRESHOLD_MB=0 _run_helper check 2>&1)
+rc=$?
+set -e
+if [[ "$rc" -eq 0 ]] && grep -qiE "WAL:" <<<"$out"; then
+	_pass "check shows WAL info when WAL_LARGE_THRESHOLD_MB=0"
+else
+	_fail "check missing WAL info (rc=$rc) — output: $out"
+fi
+
+# -----------------------------------------------------------------------------
+# Test 12: WAL report does not error when WAL file absent (no-op path)
+# -----------------------------------------------------------------------------
+
+# Remove the WAL to test the absent-WAL path
+rm -f "$OPENCODE_DIR/opencode.db-wal" "$OPENCODE_DIR/opencode.db-shm"
+
+set +e
+out=$(WAL_LARGE_THRESHOLD_MB=0 _run_helper report 2>&1)
+rc=$?
+set -e
+if [[ "$rc" -eq 0 ]]; then
+	_pass "report exits 0 cleanly when WAL file is absent"
+else
+	_fail "report failed (rc=$rc) when WAL absent — output: $out"
+fi
+
+# -----------------------------------------------------------------------------
 # Summary
 # -----------------------------------------------------------------------------
 

--- a/setup-modules/schedulers-platform.sh
+++ b/setup-modules/schedulers-platform.sh
@@ -802,7 +802,7 @@ setup_oauth_token_refresh() {
 }
 
 # Setup opencode DB maintenance scheduler (r913, t2183).
-# Runs weekly (Sun 04:00 local) to checkpoint/optimize/vacuum opencode.db.
+# Runs weekly (Sun 04:00 local by default) to checkpoint/optimize/vacuum opencode.db.
 # The helper self-noops on missing DB, so installing unconditionally is safe —
 # a non-opencode machine wakes up weekly, sees no DB, exits 0 silently.
 #
@@ -820,14 +820,21 @@ setup_opencode_db_maintenance() {
 	fi
 
 	local ocdbm_log_dir="$HOME/.aidevops/.agent-workspace/logs"
+	local ocdbm_hour="${OPENCODE_DB_MAINTENANCE_HOUR:-4}"
+	local ocdbm_minute="${OPENCODE_DB_MAINTENANCE_MINUTE:-0}"
+	local ocdbm_mode="${OPENCODE_DB_MAINTENANCE_MODE:-auto}"
+	local ocdbm_command="\"${ocdbm_script}\" auto"
+	if [[ "$ocdbm_mode" == "maintenance-window" ]]; then
+		ocdbm_command="\"${ocdbm_script}\" maintenance-window --force-opencode"
+	fi
 	mkdir -p "$ocdbm_log_dir"
 
 	if [[ "$(uname -s)" == "Darwin" ]]; then
 		# Helper owns its own plist generation (Approach B, like repo-sync).
 		# Quiet the helper's multi-line output and emit one consolidated line
 		# to match the style of setup_profile_readme / setup_oauth_token_refresh.
-		if bash "$ocdbm_script" install >/dev/null 2>&1; then
-			print_info "OpenCode DB maintenance enabled (launchd, weekly Sun 04:00)"
+		if OPENCODE_DB_MAINTENANCE_HOUR="$ocdbm_hour" OPENCODE_DB_MAINTENANCE_MINUTE="$ocdbm_minute" OPENCODE_DB_MAINTENANCE_MODE="$ocdbm_mode" bash "$ocdbm_script" install >/dev/null 2>&1; then
+			print_info "OpenCode DB maintenance enabled (launchd, weekly Sun ${ocdbm_hour}:${ocdbm_minute})"
 		else
 			print_warning "Failed to install opencode DB maintenance LaunchAgent"
 		fi
@@ -838,21 +845,21 @@ setup_opencode_db_maintenance() {
 		return 0
 	else
 		# Linux / WSL: prefer systemd user timer, fall back to cron.
-		# Weekly Sunday 04:00 local — cron: `0 4 * * 0`; systemd OnCalendar
+		# Weekly Sunday local time — cron: `${minute} ${hour} * * 0`; systemd OnCalendar
 		# ensures wall-clock firing even across suspends/reboots.
 		_install_scheduler_linux \
 			"aidevops-opencode-db-maintenance" \
 			"aidevops: opencode-db-maintenance" \
-			"0 4 * * 0" \
-			"\"${ocdbm_script}\" auto" \
+			"${ocdbm_minute} ${ocdbm_hour} * * 0" \
+			"${ocdbm_command}" \
 			"604800" \
 			"${ocdbm_log_dir}/opencode-db-maintenance.log" \
 			"" \
-			"OpenCode DB maintenance enabled (weekly Sun 04:00)" \
+			"OpenCode DB maintenance enabled (weekly Sun ${ocdbm_hour}:${ocdbm_minute})" \
 			"Failed to install opencode DB maintenance scheduler" \
 			"false" \
 			"true" \
-			"Sun *-*-* 04:00:00"
+			"Sun *-*-* ${ocdbm_hour}:${ocdbm_minute}:00"
 	fi
 	return 0
 }


### PR DESCRIPTION
## Summary

- Extends the existing WAL-aware reporting work from PR #22105 with the manual-run lesson: maintenance now performs a final post-VACUUM WAL checkpoint before declaring success.
- Adds an explicit disruptive `maintenance-window` mode that stops pulse/headless workers, archives to a session-count target, runs maintenance, quick-checks the DB, and restarts pulse via a trap.
- Documents scheduler knobs for safe `auto` vs disruptive `maintenance-window` mode and adds tests for the mocked window lifecycle.

## Verification

```bash
bash .agents/scripts/tests/test-opencode-db-maintenance.sh
shellcheck .agents/scripts/opencode-db-maintenance-helper.sh .agents/scripts/opencode-db-archive.sh .agents/scripts/tests/test-opencode-db-maintenance.sh setup-modules/schedulers-platform.sh
```

Both passed locally.

Resolves #21996
Resolves #22004

Supersedes PR #22105.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.52 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 25m and 370,694 tokens on this with the user in an interactive session.
