### PR TITLE
t3375: raise token advisory threshold

### DIFF
--- a/.agents/plugins/opencode-aidevops/package.json
+++ b/.agents/plugins/opencode-aidevops/package.json
@@ -8,6 +8,9 @@
     "./server": "./index.mjs"
   },
   "main": "index.mjs",
+  "scripts": {
+    "test": "node --test tests/*.mjs"
+  },
   "keywords": ["opencode", "plugin", "aidevops", "devops", "agents", "compaction"],
   "author": "Marcus Quinn",
   "license": "MIT",

--- a/.agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+//
+// Regression coverage for the OpenCode token cost advisory threshold.
+//
+//   node --test .agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs
+
+import { test, describe } from "node:test";
+import assert from "node:assert/strict";
+
+import { createTtsrHooks } from "../ttsr.mjs";
+
+function createHooks() {
+  const logs = [];
+  const hooks = createTtsrHooks({
+    agentsDir: "/tmp/aidevops-token-advisory-test-agents",
+    scriptsDir: "/tmp/aidevops-token-advisory-test-scripts",
+    readIfExists: () => "",
+    qualityLog: (level, message) => logs.push({ level, message }),
+    run: () => "",
+    intentField: "agent__intent",
+  });
+  return { hooks, logs };
+}
+
+function outputForTokens(total, sessionID = "token-advisory-test-session") {
+  return {
+    messages: [{
+      info: {
+        id: `assistant-${total}`,
+        role: "assistant",
+        sessionID,
+        tokens: { input: total, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      },
+      parts: [{ type: "text", text: "assistant response" }],
+    }],
+  };
+}
+
+function advisoryMessages(output) {
+  return output.messages.filter((msg) => msg.info?.id?.startsWith("token-advisory-"));
+}
+
+describe("token cost advisory threshold", () => {
+  test("does not inject advisory below 250k tokens", async () => {
+    const { hooks } = createHooks();
+    const output = outputForTokens(249_999);
+
+    await hooks.messagesTransformHook({}, output);
+
+    assert.equal(advisoryMessages(output).length, 0);
+  });
+
+  test("injects first advisory at 250k tokens", async () => {
+    const { hooks, logs } = createHooks();
+    const output = outputForTokens(250_000);
+
+    await hooks.messagesTransformHook({}, output);
+
+    const advisories = advisoryMessages(output);
+    assert.equal(advisories.length, 1);
+    assert.match(advisories[0].parts[0].text, /approximately 250k tokens/);
+    assert.deepEqual(logs, [{ level: "INFO", message: "Token advisory: session token-advisory-test-session at ~250k tokens" }]);
+  });
+
+  test("does not repeat at the same threshold for a session", async () => {
+    const { hooks } = createHooks();
+    const first = outputForTokens(250_000);
+    const second = outputForTokens(275_000);
+
+    await hooks.messagesTransformHook({}, first);
+    await hooks.messagesTransformHook({}, second);
+
+    assert.equal(advisoryMessages(first).length, 1);
+    assert.equal(advisoryMessages(second).length, 0);
+  });
+
+  test("fires again at the next 50k interval", async () => {
+    const { hooks } = createHooks();
+    const first = outputForTokens(250_000);
+    const second = outputForTokens(300_000);
+
+    await hooks.messagesTransformHook({}, first);
+    await hooks.messagesTransformHook({}, second);
+
+    const advisories = advisoryMessages(second);
+    assert.equal(advisories.length, 1);
+    assert.match(advisories[0].parts[0].text, /approximately 300k tokens/);
+  });
+});

--- a/.agents/plugins/opencode-aidevops/ttsr.mjs
+++ b/.agents/plugins/opencode-aidevops/ttsr.mjs
@@ -13,17 +13,17 @@ import {
 // Token Cost Advisory
 // ---------------------------------------------------------------------------
 // Injects a synthetic message when session context exceeds a token threshold,
-// prompting the LLM to advise the user to run /compact. Fires at 200k tokens,
-// then every 50k above that (250k, 300k, ...). Uses the last assistant
+// prompting the LLM to advise the user to run /compact. Fires at 250k tokens,
+// then every 50k above that (300k, 350k, ...). Uses the last assistant
 // message's token counts — which represent the full context sent to the model
 // on that turn — so the number tracks real cost, not model capacity.
 //
 // For headless sessions: autocompact already fires at ~(limit - 20k), so
 // this advisory primarily helps interactive sessions on large-context models
-// (Gemini 1M+, future models) where autocompact is far above 200k, or when
+// (Gemini 1M+, future models) where autocompact is far above 250k, or when
 // autocompact is disabled.
 
-const TOKEN_ADVISORY_INITIAL = 200_000;
+const TOKEN_ADVISORY_INITIAL = 250_000;
 const TOKEN_ADVISORY_INTERVAL = 50_000;
 
 /**


### PR DESCRIPTION
## Summary
- Raise the OpenCode token cost advisory first-warning threshold from 200k to 250k tokens.
- Preserve repeat advisories every additional 50k tokens.
- Add regression coverage for the 250k boundary, dedupe behavior, and 300k follow-up interval.

## Verification
- `node --test .agents/plugins/opencode-aidevops/tests/test-token-advisory-threshold.mjs`
- `npm --prefix .agents/plugins/opencode-aidevops test`

Resolves #22115


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.53 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 9h 55m and 1,012,644 tokens on this with the user in an interactive session.