### PR TITLE
GH#22118: expose OpenCode DB maintenance command and notice

### DIFF
--- a/.agents/plugins/opencode-aidevops/greeting.mjs
+++ b/.agents/plugins/opencode-aidevops/greeting.mjs
@@ -92,7 +92,7 @@ function runGreetingAsync(scriptsDir, client) {
   execAsync(`bash ${JSON.stringify(script)} --interactive`, {
     timeout: 15000,
   })
-    .then(({ stdout }) => {
+    .then(async ({ stdout }) => {
       const output = stdout ? stdout.trim() : "";
       if (!output) {
         if (process.env.AIDEVOPS_PLUGIN_DEBUG) {
@@ -101,9 +101,12 @@ function runGreetingAsync(scriptsDir, client) {
         return;
       }
 
-      cacheGreeting(output);
+      const maintenanceNotice = await getOpenCodeMaintenanceNotice(scriptsDir);
+      const combinedOutput = [output, maintenanceNotice].filter(Boolean).join("\n");
 
-      const buckets = classifyLines(output);
+      cacheGreeting(combinedOutput);
+
+      const buckets = classifyLines(combinedOutput);
       const toast = buildToast(buckets);
 
       if (process.env.AIDEVOPS_PLUGIN_DEBUG) {
@@ -125,6 +128,31 @@ function runGreetingAsync(scriptsDir, client) {
       }
     });
   // Returns here — handler can resolve before the subprocess finishes.
+}
+
+/**
+ * Return an optional one-line OpenCode DB maintenance notice.
+ *
+ * The helper owns all DB/scheduler logic; the plugin only appends any emitted
+ * notice to the existing consolidated greeting toast. Failures are ignored so
+ * session startup never depends on maintenance diagnostics.
+ *
+ * @param {string} scriptsDir
+ * @returns {Promise<string>}
+ */
+async function getOpenCodeMaintenanceNotice(scriptsDir) {
+  const script = join(scriptsDir, "opencode-db-maintenance-helper.sh");
+  try {
+    const { stdout } = await execAsync(`bash ${JSON.stringify(script)} notice`, {
+      timeout: 2500,
+    });
+    return stdout ? stdout.trim() : "";
+  } catch (err) {
+    if (process.env.AIDEVOPS_PLUGIN_DEBUG) {
+      console.error(`[aidevops] greeting: opencode maintenance notice failed: ${err.message}`);
+    }
+    return "";
+  }
 }
 
 /**
@@ -174,6 +202,7 @@ function classifyLines(output) {
     } else if (
       line.startsWith("Pulse stalled") ||
       /contribution\(s\) need/i.test(line) ||
+      line.startsWith("[OPENCODE MAINTENANCE]") ||
       line.startsWith("[WARNING]") ||
       line.startsWith("[WARN]")
     ) {

--- a/.agents/reference/opencode-maintenance.md
+++ b/.agents/reference/opencode-maintenance.md
@@ -45,6 +45,19 @@ time and invokes `opencode-db-maintenance-helper.sh auto`, which:
 
 ## Subcommands
 
+User-facing CLI entry point:
+
+```bash
+aidevops opencode-db check    # preflight: DB exists, no locks, integrity OK
+aidevops opencode-db report   # stats (size, pages, free list, top tables)
+aidevops opencode-db maintain # run once (refuses if processes active)
+aidevops opencode-db maintenance-window --force-opencode
+aidevops opencode-db status   # scheduler install state
+```
+
+The CLI delegates to the helper; direct helper calls remain supported for tests
+and advanced scripting:
+
 ```bash
 opencode-db-maintenance-helper.sh check    # preflight: DB exists, no locks, integrity OK
 opencode-db-maintenance-helper.sh report   # stats (size, pages, free list, top tables)
@@ -52,8 +65,20 @@ opencode-db-maintenance-helper.sh maintain # run once (refuses if processes acti
 opencode-db-maintenance-helper.sh maintain --force  # run anyway (may cause session errors)
 opencode-db-maintenance-helper.sh maintenance-window --force-opencode
 opencode-db-maintenance-helper.sh auto     # scheduled mode (silent, throttled)
+opencode-db-maintenance-helper.sh notice   # one-line session-start toast notice
 opencode-db-maintenance-helper.sh help
 ```
+
+## Session-start notice
+
+OpenCode session-start toasts include a one-line maintenance notice when either:
+
+- maintenance is recommended (no previous run, DB/WAL above thresholds, or the
+  last run is older than `AUTO_MIN_SECONDS_BETWEEN`), or
+- `OPENCODE_DB_MAINTENANCE_MODE=maintenance-window` is configured.
+
+The disruptive scheduled-mode notice includes the weekly day/time and explicitly
+states that pulse/headless workers pause during the maintenance window.
 
 ### Sample output
 
@@ -163,7 +188,7 @@ To schedule the disruptive mode instead of the safe no-op mode:
 ```bash
 OPENCODE_DB_MAINTENANCE_MODE=maintenance-window \
 OPENCODE_DB_MAINTENANCE_HOUR=8 \
-  opencode-db-maintenance-helper.sh install
+  aidevops opencode-db install
 ```
 
 ## Safety

--- a/.agents/scripts/opencode-db-maintenance-helper.sh
+++ b/.agents/scripts/opencode-db-maintenance-helper.sh
@@ -46,6 +46,7 @@
 #   uninstall            — macOS only: remove LaunchAgent. Idempotent.
 #   status               — report scheduler install state (launchd on macOS,
 #                          systemd/cron on Linux).
+#   notice               — emit one toast-safe warning line when due/scheduled.
 #   help                 — show this help
 #
 # Usage:
@@ -219,6 +220,21 @@ _db_size_human() {
 		local hundredths=$((bytes * 100 / 1073741824))
 		printf '%d.%02d GB\n' "$((hundredths / 100))" "$((hundredths % 100))"
 	fi
+}
+
+# _state_mtime_epoch <path> — portable file mtime getter for last-run state.
+_state_mtime_epoch() {
+	local path="$1"
+	[[ -f "$path" ]] || {
+		echo 0
+		return 0
+	}
+	if declare -f _file_mtime_epoch >/dev/null 2>&1; then
+		_file_mtime_epoch "$path"
+		return 0
+	fi
+	echo 0
+	return 0
 }
 
 # _pragma <db> <name>
@@ -995,6 +1011,52 @@ cmd_status() {
 	return 0
 }
 
+# Subcommand: notice
+# Emits at most one warning line for OpenCode's session-start toast.
+cmd_notice() {
+	if ! _opencode_installed; then
+		return 0
+	fi
+
+	if [[ "$OPENCODE_DB_MAINTENANCE_MODE" == "$MAINTENANCE_WINDOW_MODE" ]]; then
+		printf '[OPENCODE MAINTENANCE] Scheduled weekly Sun %02d:%02d local: maintenance-window pauses pulse/headless workers while compacting opencode.db.\n' \
+			"$OPENCODE_DB_MAINTENANCE_HOUR" "$OPENCODE_DB_MAINTENANCE_MINUTE"
+		return 0
+	fi
+
+	local now last_ts age db_bytes wal_bytes db_mb wal_mb due=false reason=""
+	now=$(date +%s)
+	last_ts=$(_state_mtime_epoch "$STATE_FILE")
+	db_bytes=$(_db_size_bytes "$OPENCODE_DB")
+	wal_bytes=$(_db_size_bytes "$OPENCODE_WAL")
+	db_mb=$((db_bytes / 1048576))
+	wal_mb=$((wal_bytes / 1048576))
+
+	if [[ "$last_ts" -eq 0 ]]; then
+		due=true
+		reason="no previous run recorded"
+	else
+		age=$((now - last_ts))
+		if [[ "$age" -ge "$AUTO_MIN_SECONDS_BETWEEN" ]]; then
+			due=true
+			reason="last run older than scheduler interval"
+		fi
+	fi
+
+	if [[ "$wal_mb" -ge "$WAL_LARGE_THRESHOLD_MB" ]]; then
+		due=true
+		reason="WAL ${wal_mb}MB >= ${WAL_LARGE_THRESHOLD_MB}MB"
+	elif [[ "$db_mb" -ge "$FORCE_VACUUM_SIZE_MB" ]]; then
+		due=true
+		reason="DB ${db_mb}MB >= ${FORCE_VACUUM_SIZE_MB}MB"
+	fi
+
+	if [[ "$due" == true ]]; then
+		printf '[OPENCODE MAINTENANCE] Recommended: %s. Run aidevops opencode-db maintenance-window off-hours; pulse/headless workers pause during the window.\n' "$reason"
+	fi
+	return 0
+}
+
 # -----------------------------------------------------------------------------
 # Usage
 # -----------------------------------------------------------------------------
@@ -1020,6 +1082,7 @@ Subcommands:
                          Linux: no-op (handled by setup-modules/schedulers.sh).
   uninstall              macOS: remove LaunchAgent. Idempotent.
   status                 Report scheduler state (launchd/systemd/cron).
+  notice                 Emit one toast-safe warning when maintenance is due or disruptive mode is scheduled.
   help                   This help
 
 What maintenance does:
@@ -1072,6 +1135,7 @@ main() {
 	install) cmd_install "$@" ;;
 	uninstall) cmd_uninstall "$@" ;;
 	status) cmd_status "$@" ;;
+	notice) cmd_notice "$@" ;;
 	help | -h | --help) cmd_help ;;
 	*)
 		print_error "Unknown subcommand: $sub"

--- a/.agents/scripts/tests/test-opencode-db-maintenance.sh
+++ b/.agents/scripts/tests/test-opencode-db-maintenance.sh
@@ -93,10 +93,24 @@ SQL
 # -----------------------------------------------------------------------------
 
 out=$(_run_helper help 2>&1)
-if grep -q "check" <<<"$out" && grep -q "maintain" <<<"$out" && grep -q "auto" <<<"$out"; then
+if grep -q "check" <<<"$out" && grep -q "maintain" <<<"$out" && grep -q "auto" <<<"$out" && grep -q "notice" <<<"$out"; then
 	_pass "help lists all subcommands"
 else
 	_fail "help output missing subcommands"
+fi
+
+# -----------------------------------------------------------------------------
+# Test 1b: notice is quiet when opencode not installed
+# -----------------------------------------------------------------------------
+
+set +e
+out=$(_run_helper notice 2>&1)
+rc=$?
+set -e
+if [[ "$rc" -eq 0 ]] && [[ -z "$out" ]]; then
+	_pass "notice is quiet when opencode is not installed"
+else
+	_fail "notice should be quiet with no DB (rc=$rc) — output: $out"
 fi
 
 # -----------------------------------------------------------------------------
@@ -259,6 +273,34 @@ if [[ "$rc" -eq 0 ]] && grep -qiE "WAL:" <<<"$out"; then
 	_pass "check shows WAL info when WAL_LARGE_THRESHOLD_MB=0"
 else
 	_fail "check missing WAL info (rc=$rc) — output: $out"
+fi
+
+# -----------------------------------------------------------------------------
+# Test 11b: notice warns when WAL threshold says maintenance is due
+# -----------------------------------------------------------------------------
+
+set +e
+out=$(WAL_LARGE_THRESHOLD_MB=0 _run_helper notice 2>&1)
+rc=$?
+set -e
+if [[ "$rc" -eq 0 ]] && grep -q "\[OPENCODE MAINTENANCE\]" <<<"$out" && grep -q "aidevops opencode-db maintenance-window" <<<"$out"; then
+	_pass "notice warns when maintenance is due"
+else
+	_fail "notice missing due warning (rc=$rc) — output: $out"
+fi
+
+# -----------------------------------------------------------------------------
+# Test 11c: notice warns about scheduled disruptive maintenance-window mode
+# -----------------------------------------------------------------------------
+
+set +e
+out=$(OPENCODE_DB_MAINTENANCE_MODE=maintenance-window OPENCODE_DB_MAINTENANCE_HOUR=3 OPENCODE_DB_MAINTENANCE_MINUTE=30 _run_helper notice 2>&1)
+rc=$?
+set -e
+if [[ "$rc" -eq 0 ]] && grep -q "Sun 03:30" <<<"$out" && grep -q "pauses pulse/headless workers" <<<"$out"; then
+	_pass "notice warns about scheduled maintenance-window pause"
+else
+	_fail "notice missing scheduled maintenance-window warning (rc=$rc) — output: $out"
 fi
 
 # -----------------------------------------------------------------------------

--- a/TODO.md
+++ b/TODO.md
@@ -3788,3 +3788,5 @@ t019.3.4,Update AGENTS.md with Beads integration docs,,beads,1h,45m,2025-12-21T1
 - [x] t3375 Raise token advisory first threshold to 250k #bug ref:GH#22115 pr:#22116 completed:2026-05-01
 
 - [ ] t3376 Track solved-by actor separately from origin labels #auto-dispatch #bug #diagnostics #framework ref:GH#22117
+
+- [ ] t3377 Fix release auto-mark task ID extraction for 4-digit IDs #auto-dispatch #bug ref:GH#22119

--- a/TODO.md
+++ b/TODO.md
@@ -3788,5 +3788,3 @@ t019.3.4,Update AGENTS.md with Beads integration docs,,beads,1h,45m,2025-12-21T1
 - [x] t3375 Raise token advisory first threshold to 250k #bug ref:GH#22115 pr:#22116 completed:2026-05-01
 
 - [ ] t3376 Track solved-by actor separately from origin labels #auto-dispatch #bug #diagnostics #framework ref:GH#22117
-
-- [ ] t3377 Fix release auto-mark task ID extraction for 4-digit IDs #auto-dispatch #bug ref:GH#22119

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -1658,6 +1658,7 @@ _help_commands() {
 	echo "  repos [cmd]        Manage registered projects (list/add/remove/clean)"
 	echo "  model-accounts-pool OAuth account pool (list/check/diagnose/add/rotate/reset-cooldowns)"
 	echo "  client-format      Client request format alignment (extract/check/canary/monitor)"
+	echo "  opencode-db <cmd>  OpenCode SQLite maintenance (check/report/maintain/window/status/install)"
 	echo "  opencode-sandbox   Test OpenCode versions in isolation (install/run/check/clean)"
 	echo "  approve <cmd>      Cryptographic issue/PR approval (setup/issue/pr/verify/status)"
 	echo "  circuit-breaker    Supervisor circuit breaker (status/reset/check/trip) — alias: cb"
@@ -2208,6 +2209,7 @@ main() {
 	ip-check | ip_check) _dispatch_helper "ip-reputation-helper.sh" "ip-reputation-helper.sh" "$@" ;;
 	model-accounts-pool | map) _dispatch_helper "oauth-pool-helper.sh" "oauth-pool-helper.sh" "$@" ;;
 	client-format) _cmd_client_format "$@" ;;
+	opencode-db | oc-db) _dispatch_helper "opencode-db-maintenance-helper.sh" "opencode-db-maintenance-helper.sh" "$@" ;;
 	opencode-sandbox | oc-sandbox) _dispatch_helper "opencode-sandbox-helper.sh" "opencode-sandbox-helper.sh" "$@" ;;
 	review-gate | review_gate) _dispatch_helper "review-gate-config-helper.sh" "review-gate-config-helper.sh" "$@" ;;
 	secret | secrets) _dispatch_helper "secret-helper.sh" "secret-helper.sh" "$@" ;;


### PR DESCRIPTION
## Summary
- Adds `aidevops opencode-db` / `oc-db` as the user-facing command surface for OpenCode DB maintenance.
- Adds a helper-owned `notice` subcommand and appends its warning to the existing OpenCode session-start toast when maintenance is due or disruptive mode is scheduled.
- Documents the CLI entry point, notice semantics, and scheduled maintenance-window worker pause.

## Tests
- `shellcheck aidevops.sh .agents/scripts/opencode-db-maintenance-helper.sh .agents/scripts/tests/test-opencode-db-maintenance.sh`
- `.agents/scripts/tests/test-opencode-db-maintenance.sh`
- `node --check .agents/plugins/opencode-aidevops/greeting.mjs`
- `npx --yes markdownlint-cli2 .agents/reference/opencode-maintenance.md`
- `./aidevops.sh help | rg 'opencode-db' && ./aidevops.sh opencode-db help | rg 'notice|maintenance-window'`

Resolves #22118


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.54 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 50m and 662,255 tokens on this with the user in an interactive session.
