### PR TITLE
t3378: fix pulse merge dry-run and scheduler

### DIFF
--- a/.agents/scripts/pulse-merge.sh
+++ b/.agents/scripts/pulse-merge.sh
@@ -610,6 +610,17 @@ _process_single_ready_pr() {
 		return 1
 	fi
 
+	# Dry-run must stop before every write side effect. The standalone merge
+	# routine advertises DRY_RUN=1 as no-side-effects, but the historical path
+	# continued into auto-approval, native auto-merge, admin merge, closing
+	# comments, and issue closure. Keep all read-only eligibility checks above
+	# so dry-run still proves whether the PR would pass gates, then return before
+	# any GitHub write.
+	if [[ "${DRY_RUN:-0}" == "1" ]]; then
+		echo "[pulse-wrapper] DRY-RUN: would merge PR #${pr_number} in ${repo_slug} (linked_issue=#${linked_issue:-none})" >>"$LOGFILE"
+		return 0
+	fi
+
 	# Approve (satisfies REVIEW_REQUIRED for collaborator PRs)
 	approve_collaborator_pr "$pr_number" "$repo_slug" "$pr_author" 2>/dev/null || true
 

--- a/.agents/scripts/tests/test-pulse-merge-routine-standalone.sh
+++ b/.agents/scripts/tests/test-pulse-merge-routine-standalone.sh
@@ -196,8 +196,10 @@ else
 	# pulse-merge-routine entry, not _should_setup_noninteractive_scheduler.
 	# Pattern: an `if _should_setup_noninteractive_pulse_merge_routine; then`
 	# line must be immediately followed (within 3 lines, allowing comments) by
-	# `setup_pulse_merge_routine` standalone. Use portable awk regex (no \b
-	# word boundary — BSD awk on macOS doesn't support it).
+	# either `setup_pulse_merge_routine` directly or the timed wrapper form
+	# `_time_step "setup_pulse_merge_routine" setup_pulse_merge_routine`.
+	# Use portable awk regex (no \b word boundary — BSD awk on macOS doesn't
+	# support it).
 	if awk '
 		BEGIN { in_block=0; lines_since_gate=0; found_call=0 }
 		/^[[:space:]]*if _should_setup_noninteractive_pulse_merge_routine[;[:space:]]/ {
@@ -207,7 +209,8 @@ else
 		}
 		in_block {
 			lines_since_gate++
-			if ($0 ~ /^[[:space:]]+setup_pulse_merge_routine([[:space:]]|$)/) {
+			if ($0 ~ /^[[:space:]]+setup_pulse_merge_routine([[:space:]]|$)/ ||
+				$0 ~ /_time_step[[:space:]]+"setup_pulse_merge_routine"[[:space:]]+setup_pulse_merge_routine([[:space:]]|$)/) {
 				found_call=1
 				exit
 			}
@@ -222,6 +225,20 @@ else
 		fail "8: setup.sh call site uses new helper" \
 			"'if _should_setup_noninteractive_pulse_merge_routine; then' not followed by 'setup_pulse_merge_routine' call"
 	fi
+fi
+
+SCHEDULERS_PLATFORM_FILE="${REPO_ROOT}/setup-modules/schedulers-platform.sh"
+if [[ -f "$SCHEDULERS_PLATFORM_FILE" ]]; then
+	if grep -qF 'pulse-merge-routine.sh' "$SCHEDULERS_PLATFORM_FILE" \
+		&& ! grep -qF '<string>--merge-only</string>' "$SCHEDULERS_PLATFORM_FILE"; then
+		pass "9: scheduler uses timeout-protected pulse-merge-routine"
+	else
+		fail "9: scheduler uses timeout-protected pulse-merge-routine" \
+			"merge scheduler must not install unbounded pulse-wrapper.sh --merge-only"
+	fi
+else
+	skip "9: scheduler uses timeout-protected pulse-merge-routine" \
+		"setup-modules/schedulers-platform.sh not found"
 fi
 
 # =============================================================================

--- a/.agents/scripts/tests/test-pulse-merge-routine-timeout.sh
+++ b/.agents/scripts/tests/test-pulse-merge-routine-timeout.sh
@@ -156,6 +156,14 @@ else
 		"missing 'merge_exit ... -eq 124' branch in cmd_run/cmd_dry_run"
 fi
 
+if grep -qF 'DRY-RUN: would merge PR #' "${SCRIPTS_DIR}/pulse-merge.sh" \
+	&& grep -qF "\${DRY_RUN:-0}" "${SCRIPTS_DIR}/pulse-merge.sh"; then
+	pass "1f: merge dry-run exits before write side effects"
+else
+	fail "1f: merge dry-run exits before write side effects" \
+		"pulse-merge.sh must guard DRY_RUN before approval/merge/comment side effects"
+fi
+
 # =============================================================================
 # Test 2: Behavioural — timeout ceiling kills a forced-hang sub-shell
 # =============================================================================

--- a/setup-modules/schedulers-platform.sh
+++ b/setup-modules/schedulers-platform.sh
@@ -306,9 +306,13 @@ setup_complexity_scan() {
 }
 
 # Install the dedicated merge-pass launchd plist (macOS).
-# Supersedes the t2862 sh.aidevops.pulse-merge-routine approach (t21247, GH#21247):
+# Uses the timeout-protected pulse-merge-routine.sh path (t3378). The older
+# t21247 pulse-wrapper.sh --merge-only path had no hard ceiling; a hung merge
+# pass could leave green PRs unmerged until manual intervention.
+# Supersedes the t2862 sh.aidevops.pulse-merge-routine label while keeping the
+# timeout-protected helper implementation:
 #   - Label: com.aidevops.aidevops-supervisor-merge
-#   - Script: pulse-wrapper.sh --merge-only (full bootstrap + merge only)
+#   - Script: pulse-merge-routine.sh run
 #   - Interval: 60s (down from 120s) — targets <=90s PR-green-to-merged latency
 #   - Log: pulse-merge.log (isolated from main pulse log)
 #
@@ -348,7 +352,7 @@ _install_pulse_merge_routine_launchd() {
 	<array>
 		<string>${_xml_bash_bin}</string>
 		<string>${_xml_pmr_script}</string>
-		<string>--merge-only</string>
+		<string>run</string>
 	</array>
 	<key>StartInterval</key>
 	<integer>60</integer>
@@ -382,7 +386,7 @@ PMR_PLIST
 	)
 
 	if _launchd_install_if_changed "$pmr_label" "$pmr_plist" "$pmr_plist_content"; then
-		print_info "Pulse merge pass enabled (launchd, every 60s via --merge-only)"
+		print_info "Pulse merge pass enabled (launchd, every 60s via pulse-merge-routine.sh)"
 	else
 		print_warning "Failed to load pulse merge pass LaunchAgent"
 	fi
@@ -390,8 +394,8 @@ PMR_PLIST
 }
 
 # Install the dedicated merge-pass scheduler via systemd or cron (Linux).
-# Supersedes the t2862 aidevops-pulse-merge-routine approach (t21247, GH#21247):
-#   - Command: pulse-wrapper.sh --merge-only
+# Uses timeout-protected pulse-merge-routine.sh (t3378).
+#   - Command: pulse-merge-routine.sh run
 #   - Interval: every 60s (cron * * * * *, systemd OnUnitActiveSec=60)
 #   - Log: pulse-merge.log
 # Args: $1=wrapper_script $2=log_dir
@@ -413,13 +417,13 @@ _install_pulse_merge_routine_linux() {
 
 	_install_scheduler_linux \
 		"$pmr_systemd" \
-		"aidevops: pulse-merge (--merge-only)" \
+		"aidevops: pulse-merge-routine" \
 		"* * * * *" \
-		"\"${pmr_script}\" --merge-only" \
+		"\"${pmr_script}\" run" \
 		"60" \
 		"${_pmr_log_dir}/pulse-merge.log" \
 		"" \
-		"Pulse merge pass enabled (every 60s via --merge-only)" \
+		"Pulse merge pass enabled (every 60s via pulse-merge-routine.sh)" \
 		"Failed to install pulse merge pass scheduler" \
 		"true" \
 		"true"
@@ -428,18 +432,17 @@ _install_pulse_merge_routine_linux() {
 
 # Setup the dedicated merge-pass scheduler (t21247, GH#21247).
 #
-# Supersedes t2862/GH#20919 (pulse-merge-routine.sh, 120s interval). The new
-# approach runs pulse-wrapper.sh --merge-only every 60s so green PRs merge
+# Supersedes t2862/GH#20919's legacy label/120s interval. The current
+# approach runs pulse-merge-routine.sh every 60s so green PRs merge
 # within <=90s of CI completion regardless of dispatch-cycle length (~23 min
-# average). The full pulse bootstrap ensures all PULSE_* config and repo state
-# are available; the separate lockdir (pulse-merge-instance.lock) prevents
-# overlap with the main dispatch cycle lock.
+# average). The routine has its own hard timeout and lockdir so a hung merge
+# pass cannot starve the backlog.
 #
-# Requires: pulse-wrapper.sh must be installed and executable.
+# Requires: pulse-merge-routine.sh must be installed and executable.
 # The in-cycle merge pass in pulse-wrapper.sh is kept as defense-in-depth —
 # it short-circuits when a merge pass ran within the last 60s.
 setup_pulse_merge_routine() {
-	local pmr_wrapper="$HOME/.aidevops/agents/scripts/pulse-wrapper.sh"
+	local pmr_wrapper="$HOME/.aidevops/agents/scripts/pulse-merge-routine.sh"
 	local pmr_label="com.aidevops.aidevops-supervisor-merge"
 	if ! [[ -x "$pmr_wrapper" ]]; then
 		return 0


### PR DESCRIPTION
## Summary
- Stops pulse merge dry-runs before any GitHub write side effects.
- Repoints the scheduled merge sidecar to the timeout-protected `pulse-merge-routine.sh` path instead of unbounded `pulse-wrapper.sh --merge-only`.
- Adds regression guards for dry-run no-side-effects and scheduler target.

## Verification
- `bash .agents/scripts/tests/test-pulse-merge-routine-timeout.sh` → 8/8 passed
- `bash .agents/scripts/tests/test-pulse-merge-routine-standalone.sh` → 9/9 passed
- `shellcheck .agents/scripts/pulse-merge.sh setup-modules/schedulers-platform.sh .agents/scripts/tests/test-pulse-merge-routine-timeout.sh .agents/scripts/tests/test-pulse-merge-routine-standalone.sh` → passed
- `bash .agents/scripts/pulse-merge-routine.sh --dry-run --repo marcusquinn/aidevops --pr 22110` left PR #22110 state unchanged (`OPEN`, same `updatedAt`)

Resolves #22121
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.54 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 13m and 277,531 tokens on this as a headless worker.