### PR TITLE
GH#21934: reuse preflight timing helper

### DIFF
--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -899,16 +899,7 @@ _run_preflight_stages() {
 	local _pflt_ed_start=$SECONDS
 	local _pflt_ed_rc=0
 	_preflight_early_dispatch || _pflt_ed_rc=$?
-	local _pflt_ed_elapsed=$(( SECONDS - _pflt_ed_start ))
-	echo "[pulse-wrapper] Stage: preflight_early_dispatch (rc=${_pflt_ed_rc}, ${_pflt_ed_elapsed}s)" >>"$LOGFILE"
-	if [[ -n "${PULSE_STAGE_TIMINGS_LOG:-}" ]]; then
-		printf '%s\t%s\t%d\t%d\t%d\n' \
-			"$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-			"preflight_early_dispatch" \
-			"$_pflt_ed_elapsed" \
-			"$_pflt_ed_rc" \
-			"$$" >>"$PULSE_STAGE_TIMINGS_LOG" 2>/dev/null || true
-	fi
+	_log_substage_timing "preflight_early_dispatch" "$_pflt_ed_start" "$_pflt_ed_rc"
 	# t2443: Daily scans promoted to independent top-level stages so each
 	# scanner gets its own timeout budget. Previously wrapped in a single
 	# _preflight_daily_scans() group with a shared 600s budget — a slow


### PR DESCRIPTION
## Summary

Replaced the bespoke preflight_early_dispatch timing log block with the existing _log_substage_timing helper after verifying the review bot premise.

## Files Changed

.agents/scripts/pulse-dispatch-engine.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-dispatch-engine.sh .agents/scripts/pulse-watchdog.sh .agents/scripts/pulse-dispatch-preflight-lib.sh; git diff --check origin/main...HEAD

Resolves #21934


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.55 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 4m and 59,139 tokens on this as a headless worker.