### PR TITLE
GH#22119: fix release task ID extraction width

### DIFF
--- a/.agents/scripts/tests/test-version-manager-task-id-extraction.sh
+++ b/.agents/scripts/tests/test-version-manager-task-id-extraction.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-version-manager-task-id-extraction.sh — GH#22119 regression guard.
+#
+# Asserts that release task auto-mark extraction handles task IDs wider than the
+# historical three-digit shape, while preserving dotted-subtask extraction.
+
+set -uo pipefail
+
+TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_RED=$'\033[0;31m'
+TEST_GREEN=$'\033[0;32m'
+TEST_RESET=$'\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1" rc="$2" extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf '%sPASS%s %s\n' "$TEST_GREEN" "$TEST_RESET" "$name"
+	else
+		printf '%sFAIL%s %s %s\n' "$TEST_RED" "$TEST_RESET" "$name" "$extra"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+assert_lines_equal() {
+	local name="$1" expected="$2" actual="$3"
+	if [[ "$actual" == "$expected" ]]; then
+		print_result "$name" 0
+	else
+		print_result "$name" 1 "expected [$expected], got [$actual]"
+	fi
+	return 0
+}
+
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+REPO_DIR="${TEST_ROOT}/repo"
+mkdir -p "$REPO_DIR"
+cd "$REPO_DIR" || exit 1
+
+git init -q -b main
+git config user.email 'test@example.com'
+git config user.name 'Test Runner'
+git config commit.gpgsign false
+
+printf 'initial\n' >README.md
+git add README.md
+git commit -q -m 'initial commit'
+git tag -m 'Release v0.0.1' v0.0.1
+
+printf 'work\n' >work.txt
+git add work.txt
+git commit -q -m 'chore: mark t3375 complete (pr:#22116 completed:2026-05-01) [skip ci]'
+
+printf 'scope\n' >>work.txt
+git add work.txt
+git commit -q -m 'fix(t3376): cover scoped four digit task IDs'
+
+printf 'subtask\n' >>work.txt
+git add work.txt
+git commit -q -m 'docs(t3377.2): preserve dotted subtask IDs'
+
+printf 'legacy\n' >>work.txt
+git add work.txt
+git commit -q -m 'complete t123'
+
+SCRIPT_DIR="$TEST_SCRIPTS_DIR"
+REPO_ROOT="$REPO_DIR"
+VERSION_FILE="${REPO_DIR}/VERSION"
+# shellcheck source=/dev/null
+source "${TEST_SCRIPTS_DIR}/version-manager-git.sh"
+
+actual=$(extract_task_ids_from_commits)
+expected=$'t123\nt3375\nt3376\nt3377.2'
+assert_lines_equal 'extract_task_ids_from_commits: supports four digit and dotted task IDs' "$expected" "$actual"
+
+if [[ "$actual" != *$'t337\n'* && "$actual" != "t337" ]]; then
+	print_result 'extract_task_ids_from_commits: does not truncate t3375 to t337' 0
+else
+	print_result 'extract_task_ids_from_commits: does not truncate t3375 to t337' 1 "got [$actual]"
+fi
+
+printf '\nTests run: %s, Failures: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]]

--- a/.agents/scripts/version-manager-git.sh
+++ b/.agents/scripts/version-manager-git.sh
@@ -161,8 +161,8 @@ extract_task_ids_from_commits() {
 		[[ -z "$commit" ]] && continue
 
 		# Pattern 1: Conventional commits with task ID in scope
-		# e.g., feat(t001):, fix(t002):, docs(t003.1):, refactor(t004):
-		if [[ "$commit" =~ ^(feat|fix|docs|refactor|perf|test|chore|style|build|ci)\((t[0-9]{3}(\.[0-9]+)*)\): ]]; then
+		# e.g., feat(t001):, fix(t3375):, docs(t003.1):, refactor(t004):
+		if [[ "$commit" =~ ^(feat|fix|docs|refactor|perf|test|chore|style|build|ci)\((t[0-9]+(\.[0-9]+)*)\): ]]; then
 			task_ids+=("${BASH_REMATCH[2]}")
 		fi
 
@@ -174,18 +174,18 @@ extract_task_ids_from_commits() {
 			while IFS= read -r id; do
 				[[ -n "$id" ]] || continue
 				task_ids+=("$id")
-			done < <(printf '%s\n' "$segment" | grep -oE 't[0-9]{3}(\.[0-9]+)*' || true)
+			done < <(printf '%s\n' "$segment" | grep -oE 't[0-9]+(\.[0-9]+)*' || true)
 		fi
 
 		# Pattern 3: "complete/completes/closes tXXX" - task ID immediately after keyword
 		# e.g., "complete t037", "closes t001"
-		if [[ "$commit" =~ (^|[^[:alnum:]_])(completes?|closes?)[[:space:]]+(t[0-9]{3}(\.[0-9]+)*)([^[:alnum:]_]|$) ]]; then
+		if [[ "$commit" =~ (^|[^[:alnum:]_])(completes?|closes?)[[:space:]]+(t[0-9]+(\.[0-9]+)*)([^[:alnum:]_]|$) ]]; then
 			task_ids+=("${BASH_REMATCH[3]}")
 		fi
 
 		# Pattern 4: "tXXX complete/done/finished" - task ID before completion word
 		# e.g., "t001 complete", "t002 done"
-		if [[ "$commit" =~ (t[0-9]{3}(\.[0-9]+)*)[[:space:]]+(complete|done|finished)($|[^[:alnum:]_]) ]]; then
+		if [[ "$commit" =~ (t[0-9]+(\.[0-9]+)*)[[:space:]]+(complete|done|finished)($|[^[:alnum:]_]) ]]; then
 			task_ids+=("${BASH_REMATCH[1]}")
 		fi
 
@@ -196,7 +196,7 @@ extract_task_ids_from_commits() {
 		return 0
 	fi
 
-	printf '%s\n' "${task_ids[@]}" | grep -E '^t[0-9]{3}(\.[0-9]+)*$' | sort -u
+	printf '%s\n' "${task_ids[@]}" | grep -E '^t[0-9]+(\.[0-9]+)*$' | sort -u
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Updated release auto-mark task ID extraction to match full t[0-9]+ IDs and added regression coverage for t3375-style commit subjects.

## Files Changed

.agents/scripts/tests/test-version-manager-task-id-extraction.sh,.agents/scripts/version-manager-git.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/version-manager-git.sh .agents/scripts/tests/test-version-manager-task-id-extraction.sh; git ls-files '.agents/scripts/tests/test-version-manager-*.sh' | while IFS= read -r test_file; do "" || exit 1; done

Resolves #22119


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.55 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 6m and 99,395 tokens on this as a headless worker.