### PR TITLE
t3216: realign Claude proxy model registry

### DIFF
--- a/.agents/plugins/opencode-aidevops/claude-proxy.mjs
+++ b/.agents/plugins/opencode-aidevops/claude-proxy.mjs
@@ -96,58 +96,20 @@ function isClaudeCliAvailable() {
 }
 
 function getClaudeProxyModels() {
-  return [
-    {
-      id: "claude-haiku-4-5",
-      name: "Claude Haiku 4.5 (via Claude CLI)",
-      reasoning: true,
-      contextWindow: 1000000,
-      maxTokens: 32000,
-    },
-    {
-      id: "claude-sonnet-4-5",
-      name: "Claude Sonnet 4.5 (via Claude CLI)",
-      reasoning: true,
-      contextWindow: 200000,
-      maxTokens: 64000,
-    },
-    {
-      id: "claude-sonnet-4-6",
-      name: "Claude Sonnet 4.6 (via Claude CLI)",
-      reasoning: true,
-      contextWindow: 1000000,
-      maxTokens: 64000,
-    },
-    {
-      id: "claude-opus-4-5",
-      name: "Claude Opus 4.5 (via Claude CLI)",
-      reasoning: true,
-      contextWindow: 200000,
-      maxTokens: 64000,
-    },
-    {
-      id: "claude-opus-4-6",
-      name: "Claude Opus 4.6 (via Claude CLI)",
-      reasoning: true,
-      contextWindow: 1000000,
-      maxTokens: 64000,
-    },
-    {
-      // Opus 4.7 — opt-in only. Framework defaults stay on 4.6.
-      // Context default 250K (not 1M API ceiling) due to MRCR v2 regression
-      // past 200K (256K 91.9% -> 59.2%, 1M 78.3% -> 32.2%). The 250K limit
-      // is sized so OpenCode's 80% auto-compact threshold lands at the 200K
-      // reliability boundary, giving the full functional window before
-      // compaction. Context value is sourced from model-limits.mjs so the
-      // AIDEVOPS_OPUS_47_CONTEXT env-var override (t2435) flows through here
-      // too. See models-opus.md.
-      id: "claude-opus-4-7",
-      name: "Claude Opus 4.7 (via Claude CLI)",
-      reasoning: true,
-      contextWindow: CLAUDE_MODEL_LIMITS["claude-opus-4-7"].context,
-      maxTokens: CLAUDE_MODEL_LIMITS["claude-opus-4-7"].output,
-    },
-  ];
+  return Object.entries(CLAUDE_MODEL_LIMITS).map(([id, limit]) => ({
+    id,
+    name: `${formatClaudeModelName(id)} (via Claude CLI)`,
+    reasoning: true,
+    contextWindow: limit.context,
+    maxTokens: limit.output,
+  }));
+}
+
+function formatClaudeModelName(id) {
+  const [family = id, ...versionParts] = id.replace(/^claude-/, "").split("-");
+  const displayFamily = family.charAt(0).toUpperCase() + family.slice(1);
+  const version = versionParts.join(".");
+  return version ? `Claude ${displayFamily} ${version}` : `Claude ${displayFamily}`;
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Derived Claude CLI proxy model metadata from CLAUDE_MODEL_LIMITS and generated display names from model IDs so /v1/models stays aligned with the canonical OpenCode model registry.

## Files Changed

.agents/plugins/opencode-aidevops/claude-proxy.mjs

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** node --check .agents/plugins/opencode-aidevops/claude-proxy.mjs; node --check .agents/plugins/opencode-aidevops/model-limits.mjs; rg 'claude-(haiku|sonnet|opus)-4-[567]' .agents/plugins/opencode-aidevops/claude-proxy.mjs returned no matches; AIDEVOPS_OPUS_47_CONTEXT=333333 node import check confirmed the override resolves through CLAUDE_MODEL_LIMITS. npm run typecheck is blocked by repository baseline: tsc --noEmit exits 1 because no tsconfig.json is present.

Resolves #21952


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.56 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 6m and 67,046 tokens on this as a headless worker.