### PR TITLE
GH#21933: harden claim task issue extraction

### DIFF
--- a/.agents/scripts/claim-task-id.sh
+++ b/.agents/scripts/claim-task-id.sh
@@ -577,8 +577,9 @@ create_github_issue() {
 	# log lines like "[INFO] ... per t2157" whose trailing digits would
 	# match a naive '[0-9]+$' pattern, producing phantom numbers. Anchoring
 	# to the URL shape (/issues/NNN) is immune to log message contamination.
-	# tail -1 defends against any future multi-line URL output (t3039/GH#21770).
-	issue_num=$(echo "$issue_url" | grep -oE '/issues/[0-9]+' | tail -1 | grep -oE '[0-9]+')
+	# Capture the last /issues/NNN match to defend against future multi-line URL
+	# output (t3039/GH#21770), while avoiding echo and a multi-process pipeline.
+	issue_num=$(printf '%s\n' "$issue_url" | awk 'match($0, /\/issues\/[0-9]+/) { num=substr($0, RSTART + 8, RLENGTH - 8) } END { print num }')
 
 	if [[ -z "$issue_num" ]]; then
 		log_warn "Failed to extract issue number from: $issue_url"

--- a/.agents/scripts/tests/test-claim-task-id.sh
+++ b/.agents/scripts/tests/test-claim-task-id.sh
@@ -55,11 +55,11 @@ fail() {
 	return 0
 }
 
-# Extraction pipeline extracted from claim-task-id.sh (GH#21770 fix).
-# Kept as a local variable so the test targets the exact pipeline in use.
+# Extraction command extracted from claim-task-id.sh (GH#21770 fix).
+# Kept as a local function so the test targets the exact extraction in use.
 extract_issue_num() {
 	local input="$1"
-	printf '%s' "$input" | grep -oE '/issues/[0-9]+' | tail -1 | grep -oE '[0-9]+'
+	printf '%s\n' "$input" | awk 'match($0, /\/issues\/[0-9]+/) { num=substr($0, RSTART + 8, RLENGTH - 8) } END { print num }'
 	return 0
 }
 
@@ -133,7 +133,7 @@ fi
 # -----------------------------------------------------------------------------
 printf 'Case 6: old-regex failure documentation (must produce phantom 2157)\n'
 mock_output=$(printf '[INFO] auto-dispatch label present — skipping self-assignment per t2157\nhttps://github.com/example/repo/issues/2150')
-old_result=$(printf '%s' "$mock_output" | grep -oE '[0-9]+$' | head -1)
+old_result=$(printf '%s\n' "$mock_output" | grep -oE '[0-9]+$' | head -1)
 if [[ "$old_result" == "2157" ]]; then
 	pass "confirmed old regex produces phantom 2157 (documents the bug)"
 else


### PR DESCRIPTION
## Summary

Replaced the claim-task-id issue URL extraction pipeline with a printf+awk extractor that captures the last /issues/NNN match, and aligned regression tests while preserving documentation of the old phantom-number failure.

## Files Changed

.agents/scripts/claim-task-id.sh,.agents/scripts/tests/test-claim-task-id.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/claim-task-id.sh .agents/scripts/tests/test-claim-task-id.sh; .agents/scripts/tests/test-claim-task-id.sh (9 tests, 0 failures); git diff --check origin/main...HEAD

Resolves #21933


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.56 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 6m and 61,203 tokens on this as a headless worker.