### PR TITLE
GH#21926: fix dispatch cooldown comment pagination

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -757,13 +757,14 @@ _is_assigned_check_dispatch_cooldown() {
 	[[ "$cooldown_s" =~ ^[0-9]+$ ]] || cooldown_s=1800
 	[[ "$cooldown_s" -gt 0 ]] || return 1
 
-	# Fetch comments. GitHub returns ASC (oldest first); the latest marker
-	# wins via jq `last`. Fail-open on API error — cooldown is an
+	# Fetch comments newest-first across every page. Active review-followup
+	# threads can exceed GitHub's first page, and a recent cooldown marker must
+	# win over older markers. Fail-open on API error — cooldown is an
 	# optimisation, not a guarantee.
 	local comments_endpoint
-	comments_endpoint=$(printf 'repos/%s/issues/%s/comments' "$repo_slug" "$issue_number")
+	comments_endpoint=$(printf 'repos/%s/issues/%s/comments?per_page=100&sort=created&direction=desc' "$repo_slug" "$issue_number")
 	local comments_json
-	comments_json=$(gh api "$comments_endpoint" 2>/dev/null) || return 1
+	comments_json=$(gh api --paginate --slurp "$comments_endpoint" 2>/dev/null) || return 1
 	[[ -n "$comments_json" ]] || return 1
 
 	# Extract the latest cooldown marker timestamp.
@@ -773,12 +774,11 @@ _is_assigned_check_dispatch_cooldown() {
 	local _jq_rc=0
 	local marker_iso
 	marker_iso=$(printf '%s' "$comments_json" |
-		jq -r '[.[] | (.body // "") | match("<!-- dispatch-cooldown-until:([^ ]+) reason=no_worker_process"; "g") | .captures[0].string] | last // ""' \
-			2>/dev/null) || _jq_rc=$?
+		jq -r '[.[][] | (.body // "") | match("<!-- dispatch-cooldown-until:([^ ]+) reason=no_worker_process"; "g") | .captures[0].string] | first // ""') || _jq_rc=$?
 	if [[ "$_jq_rc" -ne 0 ]]; then
 		return 1
 	fi
-	[[ -n "$marker_iso" && "$marker_iso" != "null" ]] || return 1
+	[[ -n "$marker_iso" ]] || return 1
 
 	# Parse ISO8601 → epoch. GNU date first, BSD date fallback for macOS dev.
 	local until_epoch=""

--- a/.agents/scripts/tests/test-dispatch-cooldown.sh
+++ b/.agents/scripts/tests/test-dispatch-cooldown.sh
@@ -60,7 +60,7 @@ mkdir -p "$STUB_DIR"
 
 # write_stub_gh: configure the stub to respond to:
 #   - `gh issue view ...`         → emits ISSUE_PAYLOAD
-#   - `gh api repos/.../comments` → emits COMMENTS_PAYLOAD
+#   - `gh api --paginate --slurp repos/.../comments...` → emits COMMENTS_PAYLOAD
 #
 # Both payloads are passed via stub-side env vars so successive test cases
 # can swap them without rewriting the script.
@@ -76,10 +76,12 @@ ${issue_payload}
 JSON
 	exit 0
 fi
-if [[ "\$1" == "api" && "\$2" == repos/*/issues/*/comments ]]; then
+if [[ "\$1" == "api" && "\$2" == "--paginate" && "\$3" == "--slurp" && "\$4" == repos/*/issues/*/comments* ]]; then
+	printf '['
 	cat <<'JSON'
 ${comments_payload}
 JSON
+	printf ']'
 	exit 0
 fi
 exit 1
@@ -131,11 +133,12 @@ else
 		"(rc=$rc output='$output')"
 fi
 
-# Case B: latest of multiple markers wins. An expired marker followed by a
-# fresh one should block (jq `last` semantics).
+# Case B: latest of multiple markers wins. GitHub comments are fetched
+# newest-first, so a fresh marker before an expired marker should block (jq
+# `first` semantics).
 PAST_ISO=$(iso_offset -3600)
 FUTURE_ISO_2=$(iso_offset 1800)
-COMMENTS_LATEST_WINS='[{"body":"<!-- dispatch-cooldown-until:'"${PAST_ISO}"' reason=no_worker_process runner=runner-a -->"},{"body":"intervening human comment"},{"body":"<!-- dispatch-cooldown-until:'"${FUTURE_ISO_2}"' reason=no_worker_process runner=runner-b -->"}]'
+COMMENTS_LATEST_WINS='[{"body":"<!-- dispatch-cooldown-until:'"${FUTURE_ISO_2}"' reason=no_worker_process runner=runner-b -->"},{"body":"intervening human comment"},{"body":"<!-- dispatch-cooldown-until:'"${PAST_ISO}"' reason=no_worker_process runner=runner-a -->"}]'
 write_stub_gh "$PASSTHROUGH_ISSUE" "$COMMENTS_LATEST_WINS"
 run_is_assigned 99886 "owner/repo"
 if [[ "$rc" -eq 0 && "$output" == *"DISPATCH_COOLDOWN_ACTIVE"* && "$output" == *"$FUTURE_ISO_2"* ]]; then


### PR DESCRIPTION
## Summary
- Fetch dispatch cooldown comments newest-first across all GitHub API pages so recent markers are not missed on noisy issues.
- Update the cooldown regression test stub to model `gh api --paginate --slurp` output and assert newest-first marker selection.

## Testing
- `shellcheck .agents/scripts/dispatch-dedup-helper.sh .agents/scripts/tests/test-dispatch-cooldown.sh`
- `.agents/scripts/tests/test-dispatch-cooldown.sh` — all 6 tests passed
- `gh api --paginate --slurp 'repos/marcusquinn/aidevops/issues/21926/comments?per_page=100&sort=created&direction=desc' | jq -e 'type == "array" and (.[0] | type == "array")'` — true

## Runtime Testing
Low risk shell dispatch guard change; self-assessed with targeted shell regression and ShellCheck.

## Key decisions
- Used `--slurp` with `--paginate` because `gh api --paginate` can emit multiple JSON arrays; slurping preserves valid JSON for jq.
- Kept GitHub API stderr suppressed for fail-open dispatch behavior, but stopped suppressing jq stderr so parser failures remain visible.

Resolves #21926

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.56 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 11m and 148,985 tokens on this as a headless worker.
