### PR TITLE
t3380: speed up worktree registry prune for large stale backlogs

### DIFF
--- a/.agents/scripts/shared-worktree-registry.sh
+++ b/.agents/scripts/shared-worktree-registry.sh
@@ -476,6 +476,66 @@ is_worktree_owned_by_others() {
 	return 0
 }
 
+# Delete registry paths in one sqlite transaction.
+# Arguments:
+#   $1 - newline-separated entries as worktree_path|reason
+_wt_registry_delete_paths_batch() {
+	local stale_entries="$1"
+	[[ -z "$stale_entries" ]] && return 0
+
+	{
+		printf 'BEGIN IMMEDIATE;\n'
+		while IFS='|' read -r wt_path _reason; do
+			[[ -z "$wt_path" ]] && continue
+			printf "DELETE FROM worktree_owners WHERE worktree_path = '%s';\n" "$(_wt_sql_escape "$wt_path")"
+		done <<<"$stale_entries"
+		printf 'COMMIT;\n'
+	} | sqlite3 "$WORKTREE_REGISTRY_DB" >/dev/null 2>&1 || return 1
+	return 0
+}
+
+# Print prunable missing-directory entries as worktree_path|reason lines.
+_wt_registry_missing_directory_entries() {
+	local entries="$1"
+	[[ -z "$entries" ]] && return 0
+
+	while IFS='|' read -r wt_path _owner_pid; do
+		[[ -z "$wt_path" ]] && continue
+		if [[ ! -d "$wt_path" ]]; then
+			printf '%s|directory missing\n' "$wt_path"
+		fi
+	done <<<"$entries"
+	return 0
+}
+
+# Print verbose prune lines for already-selected entries.
+_wt_registry_print_pruned_entries() {
+	local stale_entries="$1"
+	[[ -z "$stale_entries" ]] && return 0
+
+	while IFS='|' read -r wt_path prune_reason; do
+		[[ -z "$wt_path" ]] && continue
+		echo "  Pruned: $wt_path ($prune_reason)"
+	done <<<"$stale_entries"
+	return 0
+}
+
+# Count newline-separated entries.
+_wt_registry_entry_count() {
+	local entries="$1"
+	local count=0
+	[[ -z "$entries" ]] && {
+		printf '0'
+		return 0
+	}
+
+	while IFS= read -r _entry; do
+		((++count))
+	done <<<"$entries"
+	printf '%s' "$count"
+	return 0
+}
+
 # Prune stale registry entries (dead PIDs, missing directories, corrupted paths)
 # (t197) Enhanced to handle:
 #   - Dead PIDs with missing directories
@@ -510,33 +570,22 @@ prune_worktree_registry() {
 	pruned_count=$((pruned_count + temp_count))
 	[[ -n "${VERBOSE:-}" && "$temp_count" -gt 0 ]] && echo "  Pruned $temp_count test artifacts in temp directories"
 
-	# Now process remaining entries for dead PIDs and missing directories
+	# Now process remaining entries for missing directories. Delete selected rows in
+	# one sqlite transaction; the old path called unregister_worktree once per row,
+	# which made large stale backlogs exceed common assistant/tool timeouts.
 	local entries
 	entries=$(sqlite3 -separator '|' "$WORKTREE_REGISTRY_DB" "
         SELECT worktree_path, owner_pid FROM worktree_owners;
     " 2>/dev/null || echo "")
 
 	if [[ -n "$entries" ]]; then
-		while IFS='|' read -r wt_path owner_pid; do
-			local should_prune=false
-			local prune_reason=""
-
-			# Directory no longer exists
-			if [[ ! -d "$wt_path" ]]; then
-				should_prune=true
-				prune_reason="directory missing"
-			# Owner process is dead (only prune if directory also missing)
-			elif [[ -n "$owner_pid" ]] && ! kill -0 "$owner_pid" 2>/dev/null && [[ ! -d "$wt_path" ]]; then
-				should_prune=true
-				prune_reason="dead PID and directory missing"
-			fi
-
-			if [[ "$should_prune" == "true" ]]; then
-				unregister_worktree "$wt_path"
-				((++pruned_count))
-				[[ -n "${VERBOSE:-}" ]] && echo "  Pruned: $wt_path ($prune_reason)"
-			fi
-		done <<<"$entries"
+		local stale_entries
+		stale_entries=$(_wt_registry_missing_directory_entries "$entries")
+		if [[ -n "$stale_entries" ]]; then
+			_wt_registry_delete_paths_batch "$stale_entries" || return 1
+			pruned_count=$((pruned_count + $(_wt_registry_entry_count "$stale_entries")))
+			[[ -n "${VERBOSE:-}" ]] && _wt_registry_print_pruned_entries "$stale_entries"
+		fi
 	fi
 
 	[[ -n "${VERBOSE:-}" ]] && echo "Pruned $pruned_count entries total"

--- a/.agents/scripts/tests/test-worktree-registry-prune-batch.sh
+++ b/.agents/scripts/tests/test-worktree-registry-prune-batch.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-worktree-registry-prune-batch.sh — GH#22131 regression guard.
+#
+# Verifies that prune_worktree_registry removes large missing-directory
+# backlogs while preserving existing worktrees, without calling sqlite once per
+# stale row through unregister_worktree.
+
+set -uo pipefail
+
+TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_RED=$'\033[0;31m'
+TEST_GREEN=$'\033[0;32m'
+TEST_RESET=$'\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1" rc="$2" extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf '%sPASS%s %s\n' "$TEST_GREEN" "$TEST_RESET" "$name"
+	else
+		printf '%sFAIL%s %s %s\n' "$TEST_RED" "$TEST_RESET" "$name" "$extra"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+TEST_ROOT="${PWD}/.agents/tmp/test-worktree-registry-prune-batch.$$"
+mkdir -p "$TEST_ROOT"
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+export HOME="${TEST_ROOT}/home"
+export WORKTREE_REGISTRY_DIR="${TEST_ROOT}/registry"
+export WORKTREE_REGISTRY_DB="${WORKTREE_REGISTRY_DIR}/worktree-registry.db"
+mkdir -p "$WORKTREE_REGISTRY_DIR" "${HOME}/.aidevops/logs"
+
+# shellcheck source=../shared-worktree-registry.sh
+source "${TEST_SCRIPTS_DIR}/shared-worktree-registry.sh"
+
+sqlite3 "$WORKTREE_REGISTRY_DB" "
+CREATE TABLE worktree_owners (
+    worktree_path TEXT PRIMARY KEY,
+    branch TEXT,
+    owner_pid INTEGER,
+    owner_session TEXT,
+    owner_batch TEXT,
+    task_id TEXT,
+    created_at TEXT DEFAULT CURRENT_TIMESTAMP
+);
+"
+
+live_path="${TEST_ROOT}/live-worktree"
+mkdir -p "$live_path"
+sqlite3 "$WORKTREE_REGISTRY_DB" "
+INSERT INTO worktree_owners (worktree_path, branch, owner_pid) VALUES ('$(_wt_sql_escape "$live_path")', 'feature/live', 999999);
+"
+
+stale_total=150
+i=1
+while [[ "$i" -le "$stale_total" ]]; do
+	stale_path="${TEST_ROOT}/missing-${i}"
+	sqlite3 "$WORKTREE_REGISTRY_DB" "
+INSERT INTO worktree_owners (worktree_path, branch, owner_pid) VALUES ('$(_wt_sql_escape "$stale_path")', 'feature/missing-${i}', 999999);
+"
+	i=$((i + 1))
+done
+
+start_s=$(date +%s)
+VERBOSE=1 prune_output=$(prune_worktree_registry 2>&1)
+prune_rc=$?
+end_s=$(date +%s)
+duration=$((end_s - start_s))
+
+print_result "prune exits successfully" "$prune_rc" "$prune_output"
+
+remaining=$(sqlite3 "$WORKTREE_REGISTRY_DB" "SELECT COUNT(*) FROM worktree_owners;")
+if [[ "$remaining" == "1" ]]; then
+	print_result "prune removes stale missing directories" 0
+else
+	print_result "prune removes stale missing directories" 1 "remaining=$remaining"
+fi
+
+live_remaining=$(sqlite3 "$WORKTREE_REGISTRY_DB" "SELECT COUNT(*) FROM worktree_owners WHERE worktree_path = '$(_wt_sql_escape "$live_path")';")
+if [[ "$live_remaining" == "1" ]]; then
+	print_result "prune preserves existing worktree rows" 0
+else
+	print_result "prune preserves existing worktree rows" 1 "live_remaining=$live_remaining"
+fi
+
+if [[ "$duration" -le 10 ]]; then
+	print_result "prune completes within normal tool budget" 0
+else
+	print_result "prune completes within normal tool budget" 1 "duration=${duration}s"
+fi
+
+printf '\nTests run: %s, failed: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
+if [[ "$TESTS_FAILED" -eq 0 ]]; then
+	exit 0
+fi
+exit 1


### PR DESCRIPTION
## Summary

Batch missing-directory registry deletes into one sqlite transaction so large stale worktree backlogs prune within normal assistant/tool timeouts; add a regression test covering large stale backlogs and live-row preservation.

## Files Changed

.agents/scripts/shared-worktree-registry.sh,.agents/scripts/tests/test-worktree-registry-prune-batch.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/shared-worktree-registry.sh .agents/scripts/worktree-helper-cmds.sh .agents/scripts/tests/test-worktree-registry-prune-batch.sh; .agents/scripts/tests/test-worktree-registry-prune-batch.sh; .agents/scripts/worktree-helper.sh registry prune --verbose completed: pruned 866 of 915 entries, 49 remaining, 9.186s total

Resolves #22131


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.56 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 14h 46m and 2,661,650 tokens on this with the user in an interactive session.