### PR TITLE
t3227: harden agent deploy against concurrent races

### DIFF
--- a/.agents/scripts/tests/test-deploy-mutex.sh
+++ b/.agents/scripts/tests/test-deploy-mutex.sh
@@ -1,0 +1,192 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression coverage for GH#21973: overlapping non-interactive deploy paths
+# must not enter the wipe/swap phase concurrently, and failed deploy verification
+# must restore the newest agents backup before .deployed-sha can be written.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+SETUP_SH="${REPO_ROOT}/setup.sh"
+AGENT_DEPLOY="${REPO_ROOT}/setup-modules/agent-deploy.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_ROOT=""
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local detail="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$detail" ]]; then
+		printf '       %s\n' "$detail"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+print_info() { return 0; }
+print_warning() { return 0; }
+print_success() { return 0; }
+print_error() { return 0; }
+
+setup() {
+	TEST_ROOT=$(mktemp -d)
+	trap teardown EXIT
+	return 0
+}
+
+teardown() {
+	if [[ -n "$TEST_ROOT" && -d "$TEST_ROOT" ]]; then
+		rm -rf "$TEST_ROOT"
+	fi
+	return 0
+}
+
+_make_setup_sourceable_copy() {
+	local target_file="$1"
+	local line=""
+	local in_lock_block="false"
+	while IFS= read -r line || [[ -n "$line" ]]; do
+		if [[ "$line" == "SETUP_NONINTERACTIVE_LOCK_HELD=false" ]]; then
+			in_lock_block="true"
+		fi
+		if [[ "$in_lock_block" == "true" ]]; then
+			printf '%s\n' "$line" >>"$target_file"
+		fi
+		if [[ "$line" == "# Non-interactive path:"* ]]; then
+			break
+		fi
+	done <"$SETUP_SH"
+	return 0
+}
+
+_run_lock_contender() {
+	local setup_copy="$1"
+	local marker_dir="$2"
+	local hold_seconds="$3"
+	local contender_id="$4"
+
+	# shellcheck source=/dev/null
+	source "$setup_copy"
+	if _setup_acquire_noninteractive_setup_lock --non-interactive; then
+		printf '%s\n' "$contender_id" >>"$marker_dir/acquired"
+		sleep "$hold_seconds"
+		_setup_release_noninteractive_setup_lock
+		return 0
+	fi
+	printf '%s\n' "$contender_id" >>"$marker_dir/skipped"
+	return 0
+}
+
+test_noninteractive_setup_lock_single_owner() {
+	local test_name="non-interactive setup lock allows one concurrent owner"
+	local setup_copy="${TEST_ROOT}/setup-sourceable.sh"
+	local marker_dir="${TEST_ROOT}/markers"
+	local lock_dir="${TEST_ROOT}/locks/setup-noninteractive.lock.d"
+	local pid1="" pid2="" pid3=""
+	mkdir -p "$marker_dir"
+	_make_setup_sourceable_copy "$setup_copy"
+
+	(
+		HOME="$TEST_ROOT" AIDEVOPS_SETUP_LOCK_DIR="$lock_dir" \
+			_run_lock_contender "$setup_copy" "$marker_dir" 1 1
+	) &
+	pid1=$!
+	(
+		HOME="$TEST_ROOT" AIDEVOPS_SETUP_LOCK_DIR="$lock_dir" \
+			_run_lock_contender "$setup_copy" "$marker_dir" 1 2
+	) &
+	pid2=$!
+	(
+		HOME="$TEST_ROOT" AIDEVOPS_SETUP_LOCK_DIR="$lock_dir" \
+			_run_lock_contender "$setup_copy" "$marker_dir" 1 3
+	) &
+	pid3=$!
+
+	wait "$pid1" || true
+	wait "$pid2" || true
+	wait "$pid3" || true
+
+	local acquired_count="0"
+	local skipped_count="0"
+	if [[ -f "$marker_dir/acquired" ]]; then
+		acquired_count=$(wc -l <"$marker_dir/acquired" | tr -d '[:space:]')
+	fi
+	if [[ -f "$marker_dir/skipped" ]]; then
+		skipped_count=$(wc -l <"$marker_dir/skipped" | tr -d '[:space:]')
+	fi
+	[[ "$acquired_count" =~ ^[0-9]+$ ]] || acquired_count=0
+	[[ "$skipped_count" =~ ^[0-9]+$ ]] || skipped_count=0
+
+	if [[ "$acquired_count" -eq 1 && "$skipped_count" -eq 2 ]]; then
+		print_result "$test_name" 0
+	else
+		print_result "$test_name" 1 "acquired=$acquired_count skipped=$skipped_count"
+	fi
+	return 0
+}
+
+_make_agent_tree() {
+	local dir="$1"
+	local count="$2"
+	mkdir -p "$dir/scripts"
+	local index=1
+	while [[ "$index" -le "$count" ]]; do
+		printf 'file %s\n' "$index" >"$dir/file-${index}.md"
+		index=$((index + 1))
+	done
+	printf '#!/usr/bin/env bash\n' >"$dir/scripts/helper.sh"
+	return 0
+}
+
+test_failed_deploy_verification_restores_backup() {
+	local test_name="failed deploy verification restores newest agents backup"
+	local src="${TEST_ROOT}/repo/.agents"
+	local target="${TEST_ROOT}/.aidevops/agents"
+	local backup="${TEST_ROOT}/.aidevops/agents-backups/20260501_120000/agents"
+	mkdir -p "$(dirname "$backup")"
+	_make_agent_tree "$src" 1
+	_make_agent_tree "$backup" 120
+
+	# shellcheck source=/dev/null
+	source "$AGENT_DEPLOY"
+
+	local rc=0
+	HOME="$TEST_ROOT" AIDEVOPS_AGENT_DEPLOY_MIN_FILES=100 INSTALL_DIR="${TEST_ROOT}/repo" \
+		deploy_aidevops_agents || rc=$?
+
+	if [[ "$rc" -ne 0 && -f "$target/file-120.md" ]]; then
+		print_result "$test_name" 0
+	else
+		print_result "$test_name" 1 "rc=$rc restored_file=$([[ -f "$target/file-120.md" ]] && printf yes || printf no)"
+	fi
+	return 0
+}
+
+main() {
+	setup
+	test_noninteractive_setup_lock_single_owner
+	test_failed_deploy_verification_restores_backup
+
+	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -ne 0 ]]; then
+		exit 1
+	fi
+	return 0
+}
+
+main "$@"

--- a/setup-modules/agent-deploy.sh
+++ b/setup-modules/agent-deploy.sh
@@ -57,8 +57,13 @@ _restart_pulse_if_running() {
 		fi
 	fi
 
-	# No auto-restart — start it manually
-	local pulse_script="${HOME}/.aidevops/agents/scripts/pulse-wrapper.sh"
+	# No auto-restart — start it manually. Prefer the canonical repo source so a
+	# background launch never depends on a path inside ~/.aidevops/agents/scripts/
+	# that may be in the middle of a future deploy swap (must-not-be-wiped-during-deploy).
+	local pulse_script="${INSTALL_DIR:-.}/.agents/scripts/pulse-wrapper.sh"
+	if [[ ! -x "$pulse_script" ]]; then
+		pulse_script="${HOME}/.aidevops/agents/scripts/pulse-wrapper.sh"
+	fi
 	if [[ -x "$pulse_script" ]]; then
 		nohup "$pulse_script" >>"${HOME}/.aidevops/logs/pulse-wrapper.log" 2>&1 &
 		print_success "Pulse started manually (PID $!)"
@@ -304,6 +309,76 @@ _set_script_permissions_and_report() {
 	agent_count=$(find "$target_dir" -name "*.md" -type f | wc -l | tr -d ' ')
 	script_count=$(find "$target_dir/scripts" -name "*.sh" -type f 2>/dev/null | wc -l | tr -d ' ')
 	print_info "Deployed $agent_count agent files and $script_count scripts"
+	return 0
+}
+
+# _count_deployed_agent_files target_dir
+# Prints the number of files in the deployed agents tree. Non-numeric output is
+# normalised to 0 so deploy verification never compares an empty string.
+_count_deployed_agent_files() {
+	local target_dir="$1"
+	local file_count="0"
+	if [[ -d "$target_dir" ]]; then
+		file_count=$(find "$target_dir" -type f 2>/dev/null | wc -l | tr -d '[:space:]')
+	fi
+	[[ "$file_count" =~ ^[0-9]+$ ]] || file_count=0
+	printf '%s\n' "$file_count"
+	return 0
+}
+
+# _restore_latest_agents_backup target_dir
+# Restores the newest agents backup after a failed deploy verification. Backups
+# are created by create_backup_with_rotation as ~/.aidevops/agents-backups/<ts>/agents.
+_restore_latest_agents_backup() {
+	local target_dir="$1"
+	local backup_base="$HOME/.aidevops/agents-backups"
+	local latest_backup=""
+
+	if [[ ! -d "$backup_base" ]]; then
+		print_warning "No agents backup directory found for restore: $backup_base"
+		return 1
+	fi
+
+	latest_backup=$(find "$backup_base" -maxdepth 2 -type d -name agents 2>/dev/null | sort | tail -n 1)
+	if [[ -z "$latest_backup" || ! -d "$latest_backup" ]]; then
+		print_warning "No restorable agents backup found under $backup_base"
+		return 1
+	fi
+
+	print_warning "Restoring agents from latest backup: $latest_backup"
+	rm -rf "$target_dir"
+	mkdir -p "$(dirname "$target_dir")"
+	if cp -a "$latest_backup" "$target_dir"; then
+		print_success "Restored agents directory from backup"
+		return 0
+	fi
+
+	print_error "Failed to restore agents directory from backup: $latest_backup"
+	return 1
+}
+
+# _verify_deployed_agents_tree target_dir
+# Verifies the deployed agents tree is plausibly complete before .deployed-sha is
+# written. This catches empty/partial deploys that would otherwise suppress the
+# next auto-update retry by stamping the new SHA.
+_verify_deployed_agents_tree() {
+	local target_dir="$1"
+	local min_files="${AIDEVOPS_AGENT_DEPLOY_MIN_FILES:-100}"
+	local file_count="0"
+
+	[[ "$min_files" =~ ^[0-9]+$ ]] || min_files=100
+
+	if [[ ! -d "$target_dir/scripts" ]]; then
+		print_error "Deploy verification failed: $target_dir/scripts missing after swap"
+		return 1
+	fi
+
+	file_count=$(_count_deployed_agent_files "$target_dir")
+	if [[ "$file_count" -lt "$min_files" ]]; then
+		print_error "Deploy verification failed: $target_dir has $file_count files (< $min_files)"
+		return 1
+	fi
+
 	return 0
 }
 
@@ -651,12 +726,14 @@ deploy_aidevops_agents() {
 	fi
 
 	# Postcondition: verify the swap actually produced a functional agents dir.
-	# _atomic_stage_and_deploy_agents returns 0 on success, but a belt-and-
-	# suspenders check here catches any future regression where the function
-	# might return early without correctly populating $target_dir (GH#22014).
-	if [[ ! -d "$target_dir/scripts" ]]; then
-		print_error "Deploy verification failed: $target_dir/scripts missing after swap"
+	# _atomic_stage_and_deploy_agents returns 0 on success, but this belt-and-
+	# suspenders check catches future regressions where the function returns early
+	# without correctly populating $target_dir (GH#22014/GH#21973). Do not write
+	# .deployed-sha unless this passes; otherwise auto-update would suppress the
+	# next retry even though agents/ is empty or partial.
+	if ! _verify_deployed_agents_tree "$target_dir"; then
 		print_error "The agents directory was not correctly deployed — setup cannot continue"
+		_restore_latest_agents_backup "$target_dir" || true
 		return 1
 	fi
 

--- a/setup.sh
+++ b/setup.sh
@@ -1144,6 +1144,30 @@ _setup_lock_pid_alive() {
 	return $?
 }
 
+_setup_lock_dir_age_seconds() {
+	local lock_dir="$1"
+	local lock_mtime=""
+	local now=""
+	if ! [[ -d "$lock_dir" ]]; then
+		printf '%s\n' 0
+		return 0
+	fi
+	if type _file_mtime_epoch >/dev/null 2>&1; then
+		lock_mtime=$(_file_mtime_epoch "$lock_dir" 2>/dev/null || true)
+	elif [[ "$(uname -s 2>/dev/null || true)" == "Darwin" || "$(uname -s 2>/dev/null || true)" == "FreeBSD" ]]; then
+		lock_mtime=$(stat -f %m "$lock_dir" 2>/dev/null || true)
+	else
+		lock_mtime=$(stat -c %Y "$lock_dir" 2>/dev/null || true)
+	fi
+	now=$(date +%s 2>/dev/null || true)
+	if [[ "$lock_mtime" =~ ^[0-9]+$ && "$now" =~ ^[0-9]+$ && "$now" -ge "$lock_mtime" ]]; then
+		printf '%s\n' $((now - lock_mtime))
+		return 0
+	fi
+	printf '%s\n' 0
+	return 0
+}
+
 _setup_register_child_pid() {
 	local pid="$1"
 	[[ -n "$pid" ]] || return 0
@@ -1215,6 +1239,18 @@ _setup_acquire_noninteractive_setup_lock() {
 		owner_cmd=""
 		if [[ -r "$lock_dir/owner.pid" ]]; then
 			owner_pid=$(tr -d '[:space:]' <"$lock_dir/owner.pid" 2>/dev/null || true)
+		fi
+		if [[ -z "$owner_pid" ]]; then
+			local _lock_age="0"
+			_lock_age=$(_setup_lock_dir_age_seconds "$lock_dir")
+			if [[ "$_lock_age" -le 300 ]]; then
+				print_error "Another setup.sh --non-interactive process is acquiring the deploy lock (lock: ${lock_dir}, age ${_lock_age}s). Exiting to avoid overlapping deployments."
+				return 75
+			fi
+			print_warning "Removing stale setup.sh --non-interactive lock with no owner at ${lock_dir} (age ${_lock_age}s)"
+			rm -rf "$lock_dir" 2>/dev/null || true
+			attempts=$((attempts + 1))
+			continue
 		fi
 		if _setup_lock_pid_alive "$owner_pid"; then
 			[[ -r "$lock_dir/command" ]] && owner_cmd=$(tr '\n' ' ' <"$lock_dir/command" 2>/dev/null || true)


### PR DESCRIPTION
## Summary

- Harden non-interactive setup locking against the owner.pid creation race so concurrent deploy contenders cannot remove a just-created lock.
- Add post-swap agents tree verification with file-count threshold and latest-backup restore before `.deployed-sha` is written.
- Prefer canonical repo source for fallback pulse nohup launch and add deploy mutex/restore regression coverage.

## Files Changed

- `setup.sh`
- `setup-modules/agent-deploy.sh`
- `.agents/scripts/tests/test-deploy-mutex.sh`

## Runtime Testing

- **Risk level:** High (auto-update/deploy path and concurrent state machine)
- **Verification:** `shellcheck setup.sh setup-modules/agent-deploy.sh .agents/scripts/tests/test-deploy-mutex.sh`; `bash .agents/scripts/tests/test-agent-deploy-staging-invariant.sh && .agents/scripts/tests/test-deploy-mutex.sh`; `.agents/scripts/linters-local.sh` attempted but blocked by pre-existing repo-wide gates and then the active worktree disappeared during the shell portability gate (follow-up filing attempted; worktree recovered from commit hash).
- **Runtime status:** Self-assessed with focused concurrent mutex regression test; live destructive redeploy race was not run against the real user home during this interactive session.

## Key Decisions

- Existing atomic staging fixes from later merged PRs already handled most wipe windows; this PR closes the remaining ownerless-lock race and adds the missing post-deploy count/restore guard.
- The verification threshold is configurable with `AIDEVOPS_AGENT_DEPLOY_MIN_FILES` and defaults to 100 to catch empty/partial deploys without coupling tests to the current full tree size.

Resolves #21973

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.57 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 24m and 240,383 tokens on this as a headless worker.
