### PR TITLE
GH#22071: add B'5 regression test for gh_create_issue empty argv element

### DIFF
--- a/.agents/scripts/tests/test-origin-label-mutex-create.sh
+++ b/.agents/scripts/tests/test-origin-label-mutex-create.sh
@@ -384,6 +384,25 @@ else
 fi
 unset GH_ARGV_RECORD_FILE
 
+# B'5: caller origin must not leave an empty argv element before gh issue create.
+# Regression for GH#22071: the guarded array expansion emitted "" when
+# _origin_label_args was empty (caller supplied origin:interactive while session
+# is origin:worker), causing gh to fail with: unknown argument "".
+# Mirrors B'4 with reversed session/caller origin directions.
+reset_recorder
+export GH_ARGV_RECORD_FILE="${TEST_ROOT}/gh_argv_issue_calls.log"
+: >"$GH_ARGV_RECORD_FILE"
+SESSION_ORIGIN_OVERRIDE="origin:worker" \
+	gh_create_issue --repo o/r --title "t1: x" --body "Issue body" \
+	--label "origin:interactive" >/dev/null 2>&1
+if grep -qx '<>' "$GH_ARGV_RECORD_FILE"; then
+	print_result "B'5: gh_create_issue caller origin passes no empty argv element" 1 \
+		"empty argv element reached gh: $(tr '\n' ' ' <"$GH_ARGV_RECORD_FILE")"
+else
+	print_result "B'5: gh_create_issue caller origin passes no empty argv element" 0
+fi
+unset GH_ARGV_RECORD_FILE
+
 # ---------------------------------------------------------------------------
 # Layer C: structural checks on full-loop-helper-commit.sh
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

The `gh_create_issue` wrapper was emitting empty argv elements when `_origin_label_args` was empty (caller supplied an origin label, so the wrapper skips adding one). This caused `gh` to fail with:

```
unknown arguments ["" ""]; please quote all values that have spaces
```

## What changed

The wrapper code fix landed via PR #22110 (GH#22056), which applied explicit `${#arr[@]} -gt 0` guards to all four `gh_create_issue` call sites. That PR added regression tests B'3 and B'4.

This PR adds test **B'5** — the remaining regression test from the prior PR #22095 that was authored but never merged due to merge conflicts. B'5 covers the reversed caller/session origin direction (session `origin:worker`, caller passes `origin:interactive`), mirroring B'4 which tests the opposite direction.

## Files changed

- EDIT: `.agents/scripts/tests/test-origin-label-mutex-create.sh` — add B'5 test

## Testing

- All 20 tests pass: `bash .agents/scripts/tests/test-origin-label-mutex-create.sh`
- ShellCheck: zero violations

Resolves #22071

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.60 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-sonnet-4-6 spent 3m and 8,341 tokens on this as a headless worker.
