### PR TITLE
t3381: Fix merge LaunchAgent stuck in xpcproxy before exec

### DIFF
--- a/.agents/scripts/tests/test-pulse-merge-routine-standalone.sh
+++ b/.agents/scripts/tests/test-pulse-merge-routine-standalone.sh
@@ -38,6 +38,8 @@
 #   6. The routine file sources pulse-fast-fail.sh (grep guard)
 #   7. setup.sh has the _should_setup_noninteractive_pulse_merge_routine helper
 #   8. setup.sh call site uses the new helper (not the generic gate)
+#   9. scheduler uses timeout-protected pulse-merge-routine
+#   10. merge LaunchAgent uses normal spawn priority with explicit KeepAlive=false
 
 set -uo pipefail
 
@@ -238,6 +240,28 @@ if [[ -f "$SCHEDULERS_PLATFORM_FILE" ]]; then
 	fi
 else
 	skip "9: scheduler uses timeout-protected pulse-merge-routine" \
+		"setup-modules/schedulers-platform.sh not found"
+fi
+
+if [[ -f "$SCHEDULERS_PLATFORM_FILE" ]]; then
+	if awk '
+		BEGIN { in_func=0; has_background=0; has_low_io=0; has_nice=0; has_keepalive_false=0; saw_keepalive=0 }
+		/^_install_pulse_merge_routine_launchd\(\)/ { in_func=1; next }
+		in_func && /^\}/ { in_func=0 }
+		in_func && /<key>ProcessType<\/key>/ { has_background=1 }
+		in_func && /<key>LowPriorityBackgroundIO<\/key>/ { has_low_io=1 }
+		in_func && /<key>Nice<\/key>/ { has_nice=1 }
+		in_func && /<key>KeepAlive<\/key>/ { saw_keepalive=1; next }
+		in_func && saw_keepalive && /<false\/>/ { has_keepalive_false=1; saw_keepalive=0 }
+		END { exit (!has_background && !has_low_io && !has_nice && has_keepalive_false) ? 0 : 1 }
+	' "$SCHEDULERS_PLATFORM_FILE"; then
+		pass "10: merge LaunchAgent uses normal spawn priority with explicit KeepAlive=false"
+	else
+		fail "10: merge LaunchAgent uses normal spawn priority with explicit KeepAlive=false" \
+			"pulse merge LaunchAgent must not set ProcessType/LowPriorityBackgroundIO/Nice and must set KeepAlive=false"
+	fi
+else
+	skip "10: merge LaunchAgent uses normal spawn priority with explicit KeepAlive=false" \
 		"setup-modules/schedulers-platform.sh not found"
 fi
 

--- a/setup-modules/schedulers-platform.sh
+++ b/setup-modules/schedulers-platform.sh
@@ -369,12 +369,8 @@ _install_pulse_merge_routine_launchd() {
 	</dict>
 	<key>RunAtLoad</key>
 	<false/>
-	<key>ProcessType</key>
-	<string>Background</string>
-	<key>LowPriorityBackgroundIO</key>
-	<true/>
-	<key>Nice</key>
-	<integer>10</integer>
+	<key>KeepAlive</key>
+	<false/>
 	<key>SoftResourceLimits</key>
 	<dict>
 		<key>NumberOfFiles</key>


### PR DESCRIPTION
## Summary

Removed low-priority Background launchd classification from the fast merge LaunchAgent, made KeepAlive=false explicit, and added a regression guard for the plist shape.

## Files Changed

- setup-modules/schedulers-platform.sh
- .agents/scripts/tests/test-pulse-merge-routine-standalone.sh

## Runtime Testing

- **Risk level:** Medium (macOS launchd scheduler behavior)
- **Verification:** shellcheck setup-modules/schedulers-platform.sh .agents/scripts/tests/test-pulse-merge-routine-standalone.sh; bash .agents/scripts/tests/test-pulse-merge-routine-standalone.sh; bash .agents/scripts/tests/test-pulse-merge-routine-timeout.sh; launchctl print showed current deployed job had reached execs=1 rather than persistent xpcproxy; setup.sh --non-interactive runtime deploy was attempted but blocked by existing setup lock pid 69587.

Resolves #22133


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.60 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 8m and 95,669 tokens on this as a headless worker.
