### PR TITLE
t3383: fix verify-issue-close-helper merged PR file parsing

### DIFF
--- a/.agents/scripts/tests/test-verify-issue-close-helper-pr-files.sh
+++ b/.agents/scripts/tests/test-verify-issue-close-helper-pr-files.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression tests for verify-issue-close-helper.sh PR file-list parsing.
+#
+# GH#22138: `gh pr view --json files` may return `{"files":null}` for merged
+# PRs even though the pull files REST endpoint still returns the changed files.
+# The helper must treat that as a fallback condition, not a parse failure.
+
+set -euo pipefail
+
+PASS=0
+FAIL=0
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER_PATH="${TEST_DIR}/../verify-issue-close-helper.sh"
+
+if [[ ! -f "$HELPER_PATH" ]]; then
+	printf 'FAIL: verify-issue-close-helper.sh not found at %s\n' "$HELPER_PATH" >&2
+	exit 1
+fi
+
+cat >"$TMPDIR/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "issue" && "${2:-}" == "view" ]]; then
+	printf '## Files to modify\n- EDIT: .agents/scripts/verify-issue-close-helper.sh — robust PR file parsing\n'
+	exit 0
+fi
+
+if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then
+	case "${3:-}" in
+	100)
+		printf '{"files":null}\n'
+		;;
+	101)
+		printf '{"files":[{"path":".agents/scripts/verify-issue-close-helper.sh"}]}\n'
+		;;
+	*)
+		printf '{"files":[]}\n'
+		;;
+	esac
+	exit 0
+fi
+
+if [[ "${1:-}" == "api" ]]; then
+	case "${3:-}" in
+	repos/owner/repo/pulls/100/files)
+		printf '.agents/scripts/verify-issue-close-helper.sh\n'
+		;;
+	*)
+		exit 1
+		;;
+	esac
+	exit 0
+fi
+
+printf 'unexpected gh call: %s\n' "$*" >&2
+exit 1
+STUB
+chmod +x "$TMPDIR/gh"
+export PATH="$TMPDIR:$PATH"
+
+assert_check_passes() {
+	local label="$1"
+	local pr_number="$2"
+
+	local output
+	if output=$(bash "$HELPER_PATH" check 200 "$pr_number" owner/repo 2>&1); then
+		if printf '%s' "$output" | grep -q 'VERIFIED: PR'; then
+			PASS=$((PASS + 1))
+			printf 'PASS: %s\n' "$label"
+		else
+			FAIL=$((FAIL + 1))
+			printf 'FAIL: %s — missing VERIFIED verdict\n%s\n' "$label" "$output"
+		fi
+	else
+		FAIL=$((FAIL + 1))
+		printf 'FAIL: %s — helper exited non-zero\n%s\n' "$label" "$output"
+	fi
+	return 0
+}
+
+assert_check_passes "merged PR files null falls back to REST pull files endpoint" 100
+assert_check_passes "standard gh pr view files array still parses" 101
+
+printf '\nResults: %d passed, %d failed\n' "$PASS" "$FAIL"
+if [[ "$FAIL" -gt 0 ]]; then
+	exit 1
+fi
+exit 0

--- a/.agents/scripts/verify-issue-close-helper.sh
+++ b/.agents/scripts/verify-issue-close-helper.sh
@@ -75,6 +75,7 @@ extract_file_paths_from_text() {
 
 	# Pattern 2: Backtick-enclosed file references (e.g., `schedulers.sh`, `pulse-wrapper.sh:6098`)
 	local backtick_files
+	# shellcheck disable=SC2016 # Literal backtick regex, not shell expansion.
 	backtick_files=$(printf '%s' "$text" | grep -oE '`[a-zA-Z0-9._/-]+\.(sh|ts|js|py|md|json|yaml|yml|toml|go|rs|tsx|jsx|css|html|sql|rb|php|java|c|h|cpp|hpp)(:[0-9]+(-[0-9]+)?)?`' | tr -d '`' | sed 's/:[0-9]*\(-[0-9]*\)\{0,1\}$//' | sort -u || true)
 	if [[ -n "$backtick_files" ]]; then
 		paths="${paths}${backtick_files}"$'\n'
@@ -110,10 +111,31 @@ get_pr_changed_files() {
 		return 1
 	}
 
-	printf '%s' "$files_json" | jq -r '.files[].path // empty' 2>/dev/null || {
-		log_error "Failed to parse PR #${pr_number} file list"
+	local pr_files
+	pr_files=$(printf '%s' "$files_json" | jq -r '(.files // [])[]? | .path // .filename // empty' 2>/dev/null) || {
+		log_warn "Failed to parse PR #${pr_number} file list from gh pr view; trying REST fallback"
+		pr_files=""
+	}
+
+	if [[ -n "$pr_files" ]]; then
+		printf '%s\n' "$pr_files"
+		return 0
+	fi
+
+	# `gh pr view --json files` can return `null` for merged PRs on some gh/API
+	# paths. The pull files REST endpoint remains available after merge, so use
+	# it as the authoritative fallback before declaring the PR unparseable.
+	pr_files=$(gh api --paginate "repos/${repo_slug}/pulls/${pr_number}/files" --jq '.[].filename' 2>/dev/null) || {
+		log_error "Failed to fetch PR #${pr_number} file list via REST fallback"
 		return 1
 	}
+
+	if [[ -z "$pr_files" ]]; then
+		log_error "PR #${pr_number} file list is empty"
+		return 1
+	fi
+
+	printf '%s\n' "$pr_files"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Adds a REST pull-files fallback when gh pr view returns null files for merged PRs, and covers both fallback and normal parsing paths with a focused regression test.

## Files Changed

.agents/scripts/tests/test-verify-issue-close-helper-pr-files.sh,.agents/scripts/verify-issue-close-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/verify-issue-close-helper.sh .agents/scripts/tests/test-verify-issue-close-helper-pr-files.sh; bash .agents/scripts/tests/test-verify-issue-close-helper-pr-files.sh; verify-issue-close-helper.sh check 22077 22099 no longer fails at file-list parsing (now reaches overlap rejection).

Resolves #22138


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.60 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 5m and 99,619 tokens on this as a headless worker.