### PR TITLE
GH#22136: fix pre-edit worktree auto-create detection

### DIFF
--- a/.agents/scripts/pre-edit-check.sh
+++ b/.agents/scripts/pre-edit-check.sh
@@ -553,8 +553,10 @@ _handle_loop_mode_on_protected() {
 	if [[ -x "$_wt_helper" ]]; then
 		local _wt_output=""
 		_wt_output=$("$_wt_helper" add "$_wt_branch_name" 2>&1) || true
+		local _wt_clean_output=""
+		_wt_clean_output=$(printf '%s' "$_wt_output" | perl -pe 's/\e\[[0-9;]*[[:alpha:]]//g') || _wt_clean_output="$_wt_output"
 		# Extract the worktree path from helper output
-		_wt_path=$(printf '%s' "$_wt_output" | grep -oE '/[^ ]*Git/[^ ]*' | head -1) || _wt_path=""
+		_wt_path=$(printf '%s' "$_wt_clean_output" | grep -oE '/[^ ]*Git/[^ ]*' | head -1) || _wt_path=""
 		if [[ -z "$_wt_path" ]]; then
 			# Fallback: construct expected path from repo name + branch
 			local _wt_repo_name=""

--- a/.agents/scripts/tests/test-pre-edit-check.sh
+++ b/.agents/scripts/tests/test-pre-edit-check.sh
@@ -236,6 +236,35 @@ test_todo_subdir_path_allows_edit_on_main() {
 	return 0
 }
 
+test_auto_creates_git_path_worktree_from_ansi_helper_output() {
+	local repo_parent="${TEST_ROOT}/ansi-case/Git"
+	local repo_path="${repo_parent}/aidevops"
+	mkdir -p "$repo_path"
+	git -C "$repo_path" init -b main >/dev/null 2>&1 || {
+		git -C "$repo_path" init >/dev/null 2>&1
+		git -C "$repo_path" checkout -b main >/dev/null 2>&1
+	}
+	git -C "$repo_path" config user.name "Aidevops Test"
+	git -C "$repo_path" config user.email "test@example.com"
+	printf 'test\n' >"${repo_path}/README.md"
+	git -C "$repo_path" add README.md
+	git -C "$repo_path" commit -m "test: seed ansi repo" >/dev/null 2>&1
+
+	local output=""
+	local exit_code=0
+	output=$(FULL_LOOP_HEADLESS=true run_helper "$repo_path" --loop-mode --task "https://github.com/marcusquinn/aidevops/issues/22136" 2>&1) || exit_code=$?
+
+	local worktree_path=""
+	worktree_path=$(printf '%s\n' "$output" | awk -F= '/^WORKTREE_PATH=/{print $2; exit}')
+	if [[ "$exit_code" -eq 0 ]] && [[ "$output" == *"LOOP_DECISION=worktree_created"* ]] && [[ -n "$worktree_path" ]] && [[ -d "$worktree_path" ]]; then
+		print_result "auto-creates /Git worktree despite ANSI helper output" 0
+		return 0
+	fi
+
+	print_result "auto-creates /Git worktree despite ANSI helper output" 1 "exit=${exit_code} path=${worktree_path} output=${output}"
+	return 0
+}
+
 main() {
 	trap teardown_test_repo EXIT
 	setup_test_repo
@@ -248,6 +277,7 @@ main() {
 	test_path_traversal_blocked_on_main
 	test_absolute_path_outside_repo_blocked_on_main
 	test_todo_subdir_path_allows_edit_on_main
+	test_auto_creates_git_path_worktree_from_ansi_helper_output
 
 	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -ne 0 ]]; then


### PR DESCRIPTION
## Summary

Strips ANSI escape sequences from worktree-helper output before extracting WORKTREE_PATH so successful /Git worktree creation is not reported as failed; adds a regression that creates a repo under a /Git path.

## Files Changed

.agents/scripts/pre-edit-check.sh,.agents/scripts/tests/test-pre-edit-check.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pre-edit-check.sh .agents/scripts/tests/test-pre-edit-check.sh; .agents/scripts/tests/test-pre-edit-check.sh (9 tests, 0 failures); git diff --check origin/main...HEAD

Resolves #22136


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.60 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 6m and 89,207 tokens on this as a headless worker.