### PR TITLE
t3370: fix: setup --non-interactive lock/stall recovery (GH#22086)

### DIFF
--- a/.agents/scripts/tests/test-setup-noninteractive-lock-recovery.sh
+++ b/.agents/scripts/tests/test-setup-noninteractive-lock-recovery.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression tests for GH#22086: setup.sh --non-interactive lock/stall recovery.
+# Covers:
+#   1. Lock is released when setup exits early (EXIT trap fires)
+#   2. Age-based stale lock reclaim kills a hung-but-alive owner process
+#   3. Recent live lock is NOT reclaimed prematurely
+#   4. Registered background children are killed by the EXIT trap
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+SETUP_SCRIPT="${REPO_ROOT}/setup.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+# Minimal print helpers used by the lock functions when loaded via eval.
+# These must be defined before load_lock_functions so the subshell eval sees them.
+print_warning() {
+	local message="$1"
+	printf '[WARNING] %s\n' "$message"
+	return 0
+}
+
+print_error() {
+	local message="$1"
+	printf '[ERROR] %s\n' "$message"
+	return 0
+}
+
+print_info() {
+	local message="$1"
+	printf '[INFO] %s\n' "$message"
+	return 0
+}
+
+load_lock_functions() {
+	local helper_definition=""
+	helper_definition="$(awk '
+		/^SETUP_NONINTERACTIVE_LOCK_HELD=/ { in_block=1 }
+		in_block { print }
+		in_block && /^# Non-interactive path:/ { exit }
+	' "$SETUP_SCRIPT")"
+
+	if [[ -z "$helper_definition" ]]; then
+		printf 'failed to load lock helpers from %s\n' "$SETUP_SCRIPT" >&2
+		return 1
+	fi
+
+	eval "$helper_definition"
+	return 0
+}
+
+make_temp_dir() {
+	local tmp_dir=""
+	tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/aidevops-setup-lock-recovery-test.XXXXXX")
+	printf '%s' "$tmp_dir"
+	return 0
+}
+
+# Test 1: Lock is released on early exit (EXIT trap fires on set -e failure).
+# Simulates a setup process that acquires the lock then exits with code 1
+# (as would happen when _time_step returns non-zero on deploy failure).
+# The EXIT trap must remove the lock dir.
+test_lock_released_on_early_exit() {
+	local tmp_dir=""
+	local lock_exists="unknown"
+	tmp_dir=$(make_temp_dir)
+
+	(
+		AIDEVOPS_SETUP_LOCK_DIR="$tmp_dir/lock.d"
+		load_lock_functions
+		_setup_acquire_noninteractive_setup_lock --non-interactive
+		# Simulate deploy failure — EXIT trap must clean up the lock
+		exit 1
+	) 2>/dev/null || true
+
+	if [[ -d "$tmp_dir/lock.d" ]]; then
+		lock_exists="yes"
+	else
+		lock_exists="no"
+	fi
+	rm -rf "$tmp_dir"
+
+	if [[ "$lock_exists" == "no" ]]; then
+		print_result "lock is released when setup exits early (EXIT trap)" 0
+		return 0
+	fi
+
+	print_result "lock is released when setup exits early (EXIT trap)" 1 \
+		"lock dir still exists after exit 1 — EXIT trap did not clean it up"
+	return 0
+}
+
+# Test 2: Age-based stale lock reclaim kills a hung-but-alive owner process.
+# Creates a lock dir with a sleeping process as owner and a started_epoch 3600s
+# in the past (exceeds 1800s default). Verifies the acquire call kills the
+# sleeping process and successfully acquires the new lock.
+test_age_based_stale_lock_reclaim() {
+	local tmp_dir=""
+	local output=""
+	tmp_dir=$(make_temp_dir)
+
+	# Start a background sleeper to simulate a hung setup process
+	sleep 300 &
+	local hung_pid=$!
+
+	# Manufacture a lock held 3600 seconds ago by the sleeper
+	mkdir -p "$tmp_dir/lock.d"
+	printf '%s\n' "$hung_pid" >"$tmp_dir/lock.d/owner.pid"
+	printf '%s\n' "$(($(date +%s) - 3600))" >"$tmp_dir/lock.d/started_epoch"
+	printf '%s\n' 'setup.sh --non-interactive' >"$tmp_dir/lock.d/command"
+
+	output=$(
+		AIDEVOPS_SETUP_LOCK_DIR="$tmp_dir/lock.d"
+		load_lock_functions
+		_setup_acquire_noninteractive_setup_lock --non-interactive
+		printf 'held=%s owner=%s\n' "${SETUP_NONINTERACTIVE_LOCK_HELD:-false}" \
+			"$(tr -d '[:space:]' <"$tmp_dir/lock.d/owner.pid" 2>/dev/null || echo 'none')"
+		_setup_release_noninteractive_setup_lock
+		printf 'exists=%s\n' "$([[ -d "$tmp_dir/lock.d" ]] && printf yes || printf no)"
+		return 0
+	) 2>&1 || true
+
+	# Verify the sleeper was killed (allow a brief grace period)
+	local hung_killed="no"
+	sleep 0.2 2>/dev/null || sleep 1
+	if ! kill -0 "$hung_pid" 2>/dev/null; then
+		hung_killed="yes"
+	else
+		# Clean up if test fails
+		kill -KILL "$hung_pid" 2>/dev/null || true
+	fi
+	rm -rf "$tmp_dir"
+
+	if [[ "$output" == *"killing stale/hung process"* && \
+		"$output" == *"held=true"* && \
+		"$output" == *"exists=no"* && \
+		"$hung_killed" == "yes" ]]; then
+		print_result "age-based stale lock reclaims and kills hung process" 0
+		return 0
+	fi
+
+	print_result "age-based stale lock reclaims and kills hung process" 1 \
+		"output=${output} hung_killed=${hung_killed}"
+	return 0
+}
+
+# Test 3: Recent lock with live owner is NOT reclaimed by age check.
+# Creates a lock held only 60 seconds ago (well under 1800s default). Verifies
+# that the acquire call blocks (returns 75) instead of killing the owner.
+test_recent_live_lock_not_reclaimed() {
+	local tmp_dir=""
+	local output=""
+	tmp_dir=$(make_temp_dir)
+
+	# Use current shell as the "live" owner
+	mkdir -p "$tmp_dir/lock.d"
+	printf '%s\n' "$$" >"$tmp_dir/lock.d/owner.pid"
+	printf '%s\n' "$(($(date +%s) - 60))" >"$tmp_dir/lock.d/started_epoch"
+	printf '%s\n' 'setup.sh --non-interactive' >"$tmp_dir/lock.d/command"
+
+	output=$(
+		AIDEVOPS_SETUP_LOCK_DIR="$tmp_dir/lock.d"
+		load_lock_functions
+		_setup_acquire_noninteractive_setup_lock --non-interactive
+		_rc=$?
+		printf 'exit=%s\n' "$_rc"
+		return 0
+	) 2>&1 || true
+
+	rm -rf "$tmp_dir"
+
+	if [[ "$output" == *"already running"* && "$output" == *"exit=75"* ]]; then
+		print_result "recent live lock is NOT reclaimed prematurely" 0
+		return 0
+	fi
+
+	print_result "recent live lock is NOT reclaimed prematurely" 1 \
+		"output=${output} (expected 'already running' and 'exit=75')"
+	return 0
+}
+
+# Test 4: Registered background children are killed by the EXIT trap.
+# Verifies that _setup_release_noninteractive_setup_lock (the EXIT trap
+# handler) kills children registered via _setup_register_child_pid even when
+# the exit is not triggered by a signal (i.e. SETUP_NONINTERACTIVE_TERMINATING
+# is false, which is the set-e early-exit path).
+test_exit_trap_kills_registered_children() {
+	local tmp_dir=""
+	local output=""
+	tmp_dir=$(make_temp_dir)
+	mkdir -p "$tmp_dir/fake-lock.d"
+
+	output=$(
+		load_lock_functions
+		# Start a long sleeper and register it as a background deployment child
+		sleep 300 &
+		local child_pid=$!
+		_setup_register_child_pid "$child_pid"
+		# Simulate the EXIT trap firing: set lock held state and a valid lock dir
+		SETUP_NONINTERACTIVE_LOCK_HELD=true
+		SETUP_NONINTERACTIVE_LOCK_DIR="$tmp_dir/fake-lock.d"
+		# Write own PID as owner so the rm path executes
+		printf '%s\n' "$$" >"$tmp_dir/fake-lock.d/owner.pid"
+		_setup_release_noninteractive_setup_lock
+		# Give the signal a moment to reach the child
+		sleep 0.2 2>/dev/null || sleep 1
+		if kill -0 "$child_pid" 2>/dev/null; then
+			printf 'child=alive\n'
+			kill -KILL "$child_pid" 2>/dev/null || true
+		else
+			printf 'child=stopped\n'
+		fi
+		return 0
+	) 2>&1 || true
+
+	rm -rf "$tmp_dir"
+
+	if [[ "$output" == *"child=stopped"* ]]; then
+		print_result "EXIT trap kills registered background children" 0
+		return 0
+	fi
+
+	print_result "EXIT trap kills registered background children" 1 \
+		"output=${output} (expected 'child=stopped')"
+	return 0
+}
+
+main() {
+	if [[ ! -f "$SETUP_SCRIPT" ]]; then
+		printf 'ERROR: setup.sh not found at %s\n' "$SETUP_SCRIPT" >&2
+		exit 1
+	fi
+
+	test_lock_released_on_early_exit
+	test_age_based_stale_lock_reclaim
+	test_recent_live_lock_not_reclaimed
+	test_exit_trap_kills_registered_children
+
+	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -ne 0 ]]; then
+		exit 1
+	fi
+
+	return 0
+}
+
+main "$@"

--- a/setup-modules/agent-deploy.sh
+++ b/setup-modules/agent-deploy.sh
@@ -143,7 +143,12 @@ _deploy_agents_copy() {
 		for pns in "$@"; do
 			rsync_excludes+=("--exclude=${pns}/")
 		done
-		if rsync -a "${rsync_excludes[@]}" "$source_dir/" "$target_dir/"; then
+		# GH#22086: --timeout sets rsync I/O timeout (seconds without data transfer).
+		# Prevents rsync from hanging indefinitely when the source or destination
+		# filesystem stalls (NFS, Docker volume, I/O error). Default 120s is safe
+		# for local deploys; override with AIDEVOPS_RSYNC_TIMEOUT env var.
+		local _rsync_timeout="${AIDEVOPS_RSYNC_TIMEOUT:-120}"
+		if rsync -a --timeout="$_rsync_timeout" "${rsync_excludes[@]}" "$source_dir/" "$target_dir/"; then
 			deploy_ok=true
 		fi
 	else

--- a/setup.sh
+++ b/setup.sh
@@ -1195,6 +1195,15 @@ _setup_release_noninteractive_setup_lock() {
 	if [[ "${SETUP_NONINTERACTIVE_LOCK_HELD:-false}" != "true" || -z "$lock_dir" ]]; then
 		return 0
 	fi
+	# GH#22086: kill any still-running background deployment children so they
+	# don't outlive an abnormal exit (set -e triggered early exit). On clean
+	# exit, the children have already been waited for and kill is a no-op.
+	local _cpid
+	for _cpid in ${SETUP_NONINTERACTIVE_CHILD_PIDS:-}; do
+		if _setup_lock_pid_alive "$_cpid"; then
+			kill -TERM "$_cpid" 2>/dev/null || true
+		fi
+	done
 	if [[ -r "$lock_dir/owner.pid" ]]; then
 		owner_pid=$(tr -d '[:space:]' <"$lock_dir/owner.pid" 2>/dev/null || true)
 	fi
@@ -1228,6 +1237,8 @@ _setup_acquire_noninteractive_setup_lock() {
 			SETUP_NONINTERACTIVE_LOCK_HELD=true
 			printf '%s\n' "$$" >"$lock_dir/owner.pid" 2>/dev/null || true
 			printf '%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >"$lock_dir/started_at" 2>/dev/null || true
+			# GH#22086: store epoch for age-based stale detection
+			printf '%s\n' "$(date +%s)" >"$lock_dir/started_epoch" 2>/dev/null || true
 			printf '%s\n' "$0 $*" >"$lock_dir/command" 2>/dev/null || true
 			trap _setup_release_noninteractive_setup_lock EXIT
 			trap '_setup_noninteractive_signal_exit TERM' TERM
@@ -1253,29 +1264,44 @@ _setup_acquire_noninteractive_setup_lock() {
 			continue
 		fi
 		if _setup_lock_pid_alive "$owner_pid"; then
-			[[ -r "$lock_dir/command" ]] && owner_cmd=$(tr '\n' ' ' <"$lock_dir/command" 2>/dev/null || true)
-			# Build actionable diagnostics: elapsed time since lock was acquired
-			# and the currently-executing setup stage from the timing log.
-			local _diag_elapsed="" _diag_stage=""
-			local _diag_stl="$HOME/.aidevops/logs/setup-stage-timings.log"
-			if [[ -r "$lock_dir/started_at" ]]; then
-				local _diag_started_str="" _diag_started="" _diag_now="" _diag_secs=""
-				_diag_started_str=$(tr -d '[:space:]' <"$lock_dir/started_at" 2>/dev/null || true)
-				_diag_started=$(date -d "$_diag_started_str" +%s 2>/dev/null || \
-					date -jf '%Y-%m-%dT%H:%M:%SZ' "$_diag_started_str" +%s 2>/dev/null || true)
-				_diag_now=$(date +%s 2>/dev/null || true)
-				if [[ "$_diag_started" =~ ^[0-9]+$ && "$_diag_now" =~ ^[0-9]+$ && "$_diag_now" -ge "$_diag_started" ]]; then
-					_diag_secs=$((_diag_now - _diag_started))
-					_diag_elapsed="elapsed ${_diag_secs}s; "
+			# GH#22086: age-based stale detection — a hung process (e.g. rsync
+			# with no I/O timeout) can hold the lock indefinitely. After
+			# AIDEVOPS_SETUP_LOCK_MAX_SECONDS (default 30 min), kill the
+			# hung process and treat the lock as stale so retries succeed.
+			local _max_lock_seconds="${AIDEVOPS_SETUP_LOCK_MAX_SECONDS:-1800}"
+			local _lock_age=0
+			local _started_epoch _now_epoch
+			if [[ -r "$lock_dir/started_epoch" ]]; then
+				_started_epoch=$(tr -d '[:space:]' <"$lock_dir/started_epoch" 2>/dev/null || echo "0")
+				_now_epoch=$(date +%s 2>/dev/null || echo "0")
+				if [[ "$_started_epoch" =~ ^[0-9]+$ && "$_now_epoch" =~ ^[0-9]+$ && "$_started_epoch" -gt 0 ]]; then
+					_lock_age=$((_now_epoch - _started_epoch))
 				fi
 			fi
-			if [[ -r "$_diag_stl" ]]; then
-				local _diag_cur_stage=""
-				_diag_cur_stage=$(awk -F'\t' '$4=="RUNNING"{s=$2} END{if(s)printf "%s",s}' "$_diag_stl" 2>/dev/null || true)
-				[[ -n "$_diag_cur_stage" ]] && _diag_stage="stage: ${_diag_cur_stage}; "
+			if [[ "$_lock_age" -gt 0 && "$_lock_age" -gt "$_max_lock_seconds" ]]; then
+				print_warning "setup.sh --non-interactive lock held ${_lock_age}s by pid ${owner_pid} (max ${_max_lock_seconds}s) — killing stale/hung process"
+				kill -TERM "$owner_pid" 2>/dev/null || true
+				local _kw=0
+				while _setup_lock_pid_alive "$owner_pid" && [[ "$_kw" -lt 10 ]]; do
+					sleep 1
+					_kw=$((_kw + 1))
+				done
+				_setup_lock_pid_alive "$owner_pid" && { kill -KILL "$owner_pid" 2>/dev/null || true; }
+				# Fall through to stale lock removal below
+			else
+				[[ -r "$lock_dir/command" ]] && owner_cmd=$(tr '\n' ' ' <"$lock_dir/command" 2>/dev/null || true)
+				# Build actionable diagnostics: elapsed time and current setup stage.
+				local _diag_elapsed="" _diag_stage=""
+				local _diag_stl="$HOME/.aidevops/logs/setup-stage-timings.log"
+				[[ "$_lock_age" -gt 0 ]] && _diag_elapsed="elapsed ${_lock_age}s; "
+				if [[ -r "$_diag_stl" ]]; then
+					local _diag_cur_stage=""
+					_diag_cur_stage=$(awk -F'\t' '$4=="RUNNING"{s=$2} END{if(s)printf "%s",s}' "$_diag_stl" 2>/dev/null || true)
+					[[ -n "$_diag_cur_stage" ]] && _diag_stage="stage: ${_diag_cur_stage}; "
+				fi
+				print_error "Another setup.sh --non-interactive is already running (pid ${owner_pid}; ${_diag_elapsed}${_diag_stage}lock: ${lock_dir}). Exiting to avoid overlapping deployments.${owner_cmd:+ Command: ${owner_cmd}} Diagnose: ${_diag_stl}"
+				return 75
 			fi
-			print_error "Another setup.sh --non-interactive is already running (pid ${owner_pid}; ${_diag_elapsed}${_diag_stage}lock: ${lock_dir}). Exiting to avoid overlapping deployments.${owner_cmd:+ Command: ${owner_cmd}} Diagnose: ${_diag_stl}"
-			return 75
 		fi
 
 		print_warning "Removing stale setup.sh --non-interactive lock at ${lock_dir}"


### PR DESCRIPTION
## Summary

Three layered fixes: rsync I/O timeout in agent-deploy.sh, age-based stale lock kill in setup.sh, and EXIT trap orphan cleanup. Cherry-pick of prior PR #22106 work onto current main with conflict resolved by combining age-based stale kill (cherry-pick) + enhanced diagnostics in non-stale branch (HEAD).

## Files Changed

.agents/scripts/tests/test-setup-noninteractive-lock-recovery.sh,setup-modules/agent-deploy.sh,setup.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck setup.sh setup-modules/agent-deploy.sh .agents/scripts/tests/test-setup-noninteractive-lock-recovery.sh — clean. bash .agents/scripts/tests/test-setup-noninteractive-lock-recovery.sh — 4/4 PASS.

Resolves #22086


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.60 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-sonnet-4-6 spent 3m and 8,150 tokens on this as a headless worker.