### PR TITLE
GH#22084: bound serialized setup wait on stale setup process

### DIFF
--- a/.agents/scripts/tests/test-setup-noninteractive-lock.sh
+++ b/.agents/scripts/tests/test-setup-noninteractive-lock.sh
@@ -34,6 +34,12 @@ print_result() {
 	return 0
 }
 
+print_info() {
+	local message="$1"
+	printf '[INFO] %s\n' "$message"
+	return 0
+}
+
 print_warning() {
 	local message="$1"
 	printf '[WARNING] %s\n' "$message"
@@ -71,25 +77,32 @@ make_temp_dir() {
 }
 
 test_blocks_concurrent_live_owner() {
+	# Verify that a live non-stale owner causes the caller to wait and then
+	# time out with a clear diagnostic, not hang indefinitely.
+	# AIDEVOPS_SETUP_WAIT_TIMEOUT_S=5 so the subshell exits within ~15 s.
 	local tmp_dir=""
 	local output=""
-	local exit_code=0
+	local now_epoch=0
 	tmp_dir=$(make_temp_dir)
 	mkdir -p "$tmp_dir/lock.d"
 	printf '%s\n' "$$" >"$tmp_dir/lock.d/owner.pid"
+	now_epoch=$(date +%s 2>/dev/null || echo "0")
+	printf '%s\n' "$now_epoch" >"$tmp_dir/lock.d/started_at_epoch"
 	printf '%s\n' './setup.sh --non-interactive' >"$tmp_dir/lock.d/command"
 
 	output=$(
 		AIDEVOPS_SETUP_LOCK_DIR="$tmp_dir/lock.d"
+		AIDEVOPS_SETUP_WAIT_TIMEOUT_S=5
+		AIDEVOPS_SETUP_STALE_TIMEOUT_S=3600
 		load_lock_functions
 		_setup_acquire_noninteractive_setup_lock --non-interactive
-		exit_code=$?
-		printf 'exit=%s held=%s output-done\n' "$exit_code" "${SETUP_NONINTERACTIVE_LOCK_HELD:-false}"
+		printf 'held=%s output-done\n' "${SETUP_NONINTERACTIVE_LOCK_HELD:-false}"
 		return 0
 	) 2>&1 || true
 
 	rm -rf "$tmp_dir"
-	if [[ "$output" == *"Another setup.sh --non-interactive is already running"* && "$output" == *"exit=75 held=false"* ]]; then
+	# Expect: info "Waiting up to Ns", error "Timed out", held=false
+	if [[ "$output" == *"Waiting up to"* && "$output" == *"Timed out"* && "$output" == *"held=false"* ]]; then
 		print_result "live non-interactive setup lock blocks overlap" 0
 		return 0
 	fi
@@ -126,23 +139,27 @@ test_reclaims_stale_lock() {
 }
 
 test_contention_message_includes_elapsed_and_stage() {
+	# Verify diagnostics (owner age, stage, log path) appear in the wait and
+	# timeout messages. Uses AIDEVOPS_SETUP_WAIT_TIMEOUT_S=5 to exit quickly.
 	local tmp_dir=""
 	local output=""
+	local past_epoch=0
 	tmp_dir=$(make_temp_dir)
 	mkdir -p "$tmp_dir/lock.d"
 	printf '%s\n' "$$" >"$tmp_dir/lock.d/owner.pid"
 	printf '%s\n' './setup.sh --non-interactive' >"$tmp_dir/lock.d/command"
-	# Write a started_at stamp ~5 seconds in the past so elapsed time is computable.
-	local past_ts=""
-	past_ts=$(date -u -d '5 seconds ago' +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || \
-		date -u -v-5S +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || true)
-	[[ -n "$past_ts" ]] && printf '%s\n' "$past_ts" >"$tmp_dir/lock.d/started_at"
-	# Write a fake timing log with a RUNNING stage so the stage diagnostic fires.
+	# Write started_at_epoch ~5 seconds in the past so _setup_lock_owner_age
+	# returns a non-zero age.
+	past_epoch=$(( $(date +%s 2>/dev/null || echo "0") - 5 ))
+	printf '%s\n' "$past_epoch" >"$tmp_dir/lock.d/started_at_epoch"
+	# Write a fake timing log with a RUNNING stage so stage diagnostic fires.
 	local fake_stl="$tmp_dir/fake-stage-timings.log"
 	printf '%s\t%s\t%s\t%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "deploy_aidevops_agents" "0.00" "RUNNING" >"$fake_stl"
 
 	output=$(
 		AIDEVOPS_SETUP_LOCK_DIR="$tmp_dir/lock.d"
+		AIDEVOPS_SETUP_WAIT_TIMEOUT_S=5
+		AIDEVOPS_SETUP_STALE_TIMEOUT_S=3600
 		HOME="$tmp_dir"
 		mkdir -p "$tmp_dir/.aidevops/logs"
 		cp "$fake_stl" "$tmp_dir/.aidevops/logs/setup-stage-timings.log"
@@ -154,23 +171,19 @@ test_contention_message_includes_elapsed_and_stage() {
 	rm -rf "$tmp_dir"
 
 	local passed=1
-	# Elapsed time: present only when started_at parsing succeeds (skip on unsupported date).
-	if [[ -n "$past_ts" ]]; then
-		[[ "$output" == *"elapsed "* ]] || passed=2
-	fi
+	# Owner age must appear as "age Ns".
+	[[ "$output" == *"age "* ]] || passed=2
 	# Stage name must appear.
 	[[ "$output" == *"stage: deploy_aidevops_agents"* ]] || passed=3
 	# Diagnose log path hint must appear.
 	[[ "$output" == *"setup-stage-timings.log"* ]] || passed=4
-	# Must still exit 75.
-	[[ "$output" != *"exit=75"* ]] && passed=0  # exit code check is in caller test
 
-	if [[ "$passed" -eq 1 || "$passed" -eq 0 ]]; then
-		print_result "lock contention message includes elapsed time and stage" 0
+	if [[ "$passed" -eq 1 ]]; then
+		print_result "lock contention message includes age and stage" 0
 		return 0
 	fi
 
-	print_result "lock contention message includes elapsed time and stage" 1 "missing_field=${passed} output=${output}"
+	print_result "lock contention message includes age and stage" 1 "missing_field=${passed} output=${output}"
 	return 0
 }
 
@@ -201,9 +214,95 @@ test_signal_cleanup_terminates_registered_children() {
 	return 0
 }
 
+test_stale_live_owner_past_ceiling_is_reclaimed() {
+	# Verify that a live owner whose age exceeds stale_ceiling is reclaimed
+	# and the waiting process acquires the lock successfully.
+	local tmp_dir=""
+	local output=""
+	local stale_epoch=0
+	tmp_dir=$(make_temp_dir)
+	mkdir -p "$tmp_dir/lock.d"
+
+	# Use this test's own PID as the "owner" so kill -0 reports it alive,
+	# but set started_at_epoch far in the past to simulate a hung setup.
+	printf '%s\n' "$$" >"$tmp_dir/lock.d/owner.pid"
+	stale_epoch=$(( $(date +%s 2>/dev/null || echo "0") - 10000 ))
+	printf '%s\n' "$stale_epoch" >"$tmp_dir/lock.d/started_at_epoch"
+	printf '%s\n' './setup.sh --non-interactive (simulated stale)' >"$tmp_dir/lock.d/command"
+
+	output=$(
+		AIDEVOPS_SETUP_LOCK_DIR="$tmp_dir/lock.d"
+		AIDEVOPS_SETUP_STALE_TIMEOUT_S=1800
+		AIDEVOPS_SETUP_WAIT_TIMEOUT_S=300
+		load_lock_functions
+		_setup_acquire_noninteractive_setup_lock --non-interactive
+		printf 'held=%s\n' "${SETUP_NONINTERACTIVE_LOCK_HELD:-false}"
+		_setup_release_noninteractive_setup_lock
+		printf 'exists=%s\n' "$([[ -d "$tmp_dir/lock.d" ]] && printf yes || printf no)"
+		return 0
+	) 2>&1 || true
+
+	rm -rf "$tmp_dir"
+	if [[ "$output" == *"stale ceiling"* && "$output" == *"held=true"* && "$output" == *"exists=no"* ]]; then
+		print_result "stale live owner past ceiling is reclaimed" 0
+		return 0
+	fi
+
+	print_result "stale live owner past ceiling is reclaimed" 1 "output=${output}"
+	return 0
+}
+
+test_wait_ceiling_prevents_indefinite_block() {
+	# Start a real background process so kill -0 succeeds and owner is non-stale.
+	# Use a very short wait ceiling so the test completes quickly.
+	local tmp_dir=""
+	local output=""
+	local owner_pid=0
+	local start_time=0
+	local end_time=0
+	local elapsed=0
+	tmp_dir=$(make_temp_dir)
+	mkdir -p "$tmp_dir/lock.d"
+
+	# Background sleeper acts as the live, non-stale lock owner.
+	sleep 300 &
+	owner_pid=$!
+	printf '%s\n' "$owner_pid" >"$tmp_dir/lock.d/owner.pid"
+	printf '%s\n' "$(date +%s 2>/dev/null || echo "0")" >"$tmp_dir/lock.d/started_at_epoch"
+	printf '%s\n' 'sleep 300 (simulated live setup owner)' >"$tmp_dir/lock.d/command"
+
+	start_time=$(date +%s 2>/dev/null || echo "0")
+	output=$(
+		AIDEVOPS_SETUP_LOCK_DIR="$tmp_dir/lock.d"
+		AIDEVOPS_SETUP_WAIT_TIMEOUT_S=5
+		AIDEVOPS_SETUP_STALE_TIMEOUT_S=3600
+		load_lock_functions
+		_setup_acquire_noninteractive_setup_lock --non-interactive
+		printf 'held=%s\n' "${SETUP_NONINTERACTIVE_LOCK_HELD:-false}"
+		return 0
+	) 2>&1 || true
+	end_time=$(date +%s 2>/dev/null || echo "0")
+
+	kill "$owner_pid" 2>/dev/null || true
+	wait "$owner_pid" 2>/dev/null || true
+	rm -rf "$tmp_dir"
+
+	elapsed=$(( end_time - start_time ))
+	# Expect a timeout error, held=false, and exit within 30 s (one 10 s sleep + overhead).
+	if [[ "$output" == *"Timed out"* && "$output" == *"held=false"* && "$elapsed" -le 30 ]]; then
+		print_result "wait ceiling prevents indefinite blocking" 0
+		return 0
+	fi
+
+	print_result "wait ceiling prevents indefinite blocking" 1 "output=${output} elapsed=${elapsed}"
+	return 0
+}
+
 main() {
 	test_blocks_concurrent_live_owner
 	test_reclaims_stale_lock
+	test_stale_live_owner_past_ceiling_is_reclaimed
+	test_wait_ceiling_prevents_indefinite_block
 	test_contention_message_includes_elapsed_and_stage
 	test_signal_cleanup_terminates_registered_children
 

--- a/setup.sh
+++ b/setup.sh
@@ -1216,18 +1216,49 @@ _setup_noninteractive_signal_exit() {
 	exit "$exit_code"
 }
 
+# Compute how many seconds the lock owner PID has been running.
+# Uses started_at_epoch (most accurate) falling back to ps etimes.
+# Prints the age in seconds on stdout; prints 0 when unknown.
+_setup_lock_owner_age() {
+	local lock_dir="$1"
+	local owner_pid="$2"
+	local _start_epoch="" _now_epoch="" _age_tmp=""
+	if [[ -r "$lock_dir/started_at_epoch" ]]; then
+		_start_epoch=$(tr -d '[:space:]' <"$lock_dir/started_at_epoch" 2>/dev/null || true)
+		_now_epoch=$(date +%s 2>/dev/null || printf '0')
+		if [[ "$_start_epoch" =~ ^[0-9]+$ && "$_now_epoch" =~ ^[0-9]+$ && "$_now_epoch" -ge "$_start_epoch" ]]; then
+			printf '%s' "$((_now_epoch - _start_epoch))"
+			return 0
+		fi
+	fi
+	# Fallback: ps etimes (seconds elapsed since process start).
+	_age_tmp=$(ps -p "$owner_pid" -o etimes= 2>/dev/null | tr -d '[:space:]')
+	if [[ "$_age_tmp" =~ ^[0-9]+$ ]]; then
+		printf '%s' "$_age_tmp"
+		return 0
+	fi
+	printf '0'
+	return 0
+}
+
 _setup_acquire_noninteractive_setup_lock() {
 	local lock_dir="${AIDEVOPS_SETUP_LOCK_DIR:-$HOME/.aidevops/locks/setup-noninteractive.lock.d}"
-	local owner_pid=""
-	local owner_cmd=""
-	local attempts=0
+	# Max seconds to wait for a live, non-stale owner before timing out.
+	local wait_ceiling="${AIDEVOPS_SETUP_WAIT_TIMEOUT_S:-300}"
+	# Max seconds a live owner may hold the lock before it is treated as
+	# stale and reclaimed (0 disables stale-live reclaim).
+	local stale_ceiling="${AIDEVOPS_SETUP_STALE_TIMEOUT_S:-1800}"
+	local owner_pid="" owner_cmd="" owner_age=0
+	local reclaim_attempts=0 waited=0
+	local _diag_stl="$HOME/.aidevops/logs/setup-stage-timings.log"
 	mkdir -p "$(dirname "$lock_dir")" 2>/dev/null || true
-	while [[ "$attempts" -lt 2 ]]; do
+	while true; do
 		if mkdir "$lock_dir" 2>/dev/null; then
 			SETUP_NONINTERACTIVE_LOCK_DIR="$lock_dir"
 			SETUP_NONINTERACTIVE_LOCK_HELD=true
 			printf '%s\n' "$$" >"$lock_dir/owner.pid" 2>/dev/null || true
 			printf '%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >"$lock_dir/started_at" 2>/dev/null || true
+			printf '%s\n' "$(date +%s 2>/dev/null || printf '0')" >"$lock_dir/started_at_epoch" 2>/dev/null || true
 			printf '%s\n' "$0 $*" >"$lock_dir/command" 2>/dev/null || true
 			trap _setup_release_noninteractive_setup_lock EXIT
 			trap '_setup_noninteractive_signal_exit TERM' TERM
@@ -1235,11 +1266,12 @@ _setup_acquire_noninteractive_setup_lock() {
 			return 0
 		fi
 
+		# Lock exists — inspect owner.
 		owner_pid=""
-		owner_cmd=""
 		if [[ -r "$lock_dir/owner.pid" ]]; then
 			owner_pid=$(tr -d '[:space:]' <"$lock_dir/owner.pid" 2>/dev/null || true)
 		fi
+
 		if [[ -z "$owner_pid" ]]; then
 			local _lock_age="0"
 			_lock_age=$(_setup_lock_dir_age_seconds "$lock_dir")
@@ -1249,42 +1281,65 @@ _setup_acquire_noninteractive_setup_lock() {
 			fi
 			print_warning "Removing stale setup.sh --non-interactive lock with no owner at ${lock_dir} (age ${_lock_age}s)"
 			rm -rf "$lock_dir" 2>/dev/null || true
-			attempts=$((attempts + 1))
+			reclaim_attempts=$((reclaim_attempts + 1))
+			if [[ "$reclaim_attempts" -ge 2 ]]; then
+				print_error "Unable to acquire setup.sh --non-interactive lock at ${lock_dir} after ${reclaim_attempts} stale-lock removals"
+				return 75
+			fi
 			continue
 		fi
-		if _setup_lock_pid_alive "$owner_pid"; then
-			[[ -r "$lock_dir/command" ]] && owner_cmd=$(tr '\n' ' ' <"$lock_dir/command" 2>/dev/null || true)
-			# Build actionable diagnostics: elapsed time since lock was acquired
-			# and the currently-executing setup stage from the timing log.
-			local _diag_elapsed="" _diag_stage=""
-			local _diag_stl="$HOME/.aidevops/logs/setup-stage-timings.log"
-			if [[ -r "$lock_dir/started_at" ]]; then
-				local _diag_started_str="" _diag_started="" _diag_now="" _diag_secs=""
-				_diag_started_str=$(tr -d '[:space:]' <"$lock_dir/started_at" 2>/dev/null || true)
-				_diag_started=$(date -d "$_diag_started_str" +%s 2>/dev/null || \
-					date -jf '%Y-%m-%dT%H:%M:%SZ' "$_diag_started_str" +%s 2>/dev/null || true)
-				_diag_now=$(date +%s 2>/dev/null || true)
-				if [[ "$_diag_started" =~ ^[0-9]+$ && "$_diag_now" =~ ^[0-9]+$ && "$_diag_now" -ge "$_diag_started" ]]; then
-					_diag_secs=$((_diag_now - _diag_started))
-					_diag_elapsed="elapsed ${_diag_secs}s; "
-				fi
+
+		if ! _setup_lock_pid_alive "$owner_pid"; then
+			# Dead owner — reclaim the stale lock.
+			if [[ "$reclaim_attempts" -ge 2 ]]; then
+				print_error "Unable to acquire setup.sh --non-interactive lock at ${lock_dir} after ${reclaim_attempts} stale-lock removals"
+				return 75
 			fi
-			if [[ -r "$_diag_stl" ]]; then
-				local _diag_cur_stage=""
-				_diag_cur_stage=$(awk -F'\t' '$4=="RUNNING"{s=$2} END{if(s)printf "%s",s}' "$_diag_stl" 2>/dev/null || true)
-				[[ -n "$_diag_cur_stage" ]] && _diag_stage="stage: ${_diag_cur_stage}; "
+			print_warning "Removing stale setup.sh --non-interactive lock at ${lock_dir}"
+			rm -rf "$lock_dir" 2>/dev/null || true
+			reclaim_attempts=$((reclaim_attempts + 1))
+			continue
+		fi
+
+		# Owner is alive — compute age and read current setup stage.
+		owner_age=$(_setup_lock_owner_age "$lock_dir" "$owner_pid")
+		owner_cmd=""
+		[[ -r "$lock_dir/command" ]] && owner_cmd=$(tr '\n' ' ' <"$lock_dir/command" 2>/dev/null || true)
+		local _diag_stage=""
+		if [[ -r "$_diag_stl" ]]; then
+			local _diag_cur_stage=""
+			_diag_cur_stage=$(awk -F'\t' '$4=="RUNNING"{s=$2} END{if(s)printf "%s",s}' "$_diag_stl" 2>/dev/null || true)
+			[[ -n "$_diag_cur_stage" ]] && _diag_stage=", stage: ${_diag_cur_stage}"
+		fi
+
+		# Stale-live reclaim: owner alive but running far too long.
+		if [[ "$stale_ceiling" -gt 0 && "$owner_age" -ge "$stale_ceiling" ]]; then
+			if [[ "$reclaim_attempts" -ge 2 ]]; then
+				print_error "Unable to acquire setup.sh --non-interactive lock: owner (pid ${owner_pid}, age ${owner_age}s) exceeds stale ceiling but reclaim limit reached. Diagnose: ${_diag_stl}"
+				return 75
 			fi
-			print_error "Another setup.sh --non-interactive is already running (pid ${owner_pid}; ${_diag_elapsed}${_diag_stage}lock: ${lock_dir}). Exiting to avoid overlapping deployments.${owner_cmd:+ Command: ${owner_cmd}} Diagnose: ${_diag_stl}"
+			print_warning "setup.sh --non-interactive lock owner (pid ${owner_pid}) running ${owner_age}s — exceeds stale ceiling ${stale_ceiling}s (AIDEVOPS_SETUP_STALE_TIMEOUT_S)${owner_cmd:+; command: ${owner_cmd}}. Reclaiming lock."
+			rm -rf "$lock_dir" 2>/dev/null || true
+			reclaim_attempts=$((reclaim_attempts + 1))
+			continue
+		fi
+
+		# Live non-stale owner — check wait ceiling before sleeping.
+		if [[ "$waited" -ge "$wait_ceiling" ]]; then
+			print_error "Timed out waiting ${waited}s for setup.sh --non-interactive lock (owner pid ${owner_pid}, age ${owner_age}s${_diag_stage}${owner_cmd:+, command: ${owner_cmd}}). Increase AIDEVOPS_SETUP_WAIT_TIMEOUT_S (current: ${wait_ceiling}s) or kill pid ${owner_pid} to unblock. Diagnose: ${_diag_stl}"
 			return 75
 		fi
 
-		print_warning "Removing stale setup.sh --non-interactive lock at ${lock_dir}"
-		rm -rf "$lock_dir" 2>/dev/null || true
-		attempts=$((attempts + 1))
-	done
+		# Emit diagnostics on first block and every 60 s thereafter.
+		if [[ "$waited" -eq 0 ]]; then
+			print_info "Another setup.sh --non-interactive is running (pid ${owner_pid}, age ${owner_age}s${_diag_stage}${owner_cmd:+, command: ${owner_cmd}}). Waiting up to ${wait_ceiling}s (AIDEVOPS_SETUP_WAIT_TIMEOUT_S). Diagnose: ${_diag_stl}"
+		elif [[ $(( waited % 60 )) -eq 0 ]]; then
+			print_info "Still waiting for setup lock (owner pid ${owner_pid}, age ${owner_age}s, waited ${waited}s of ${wait_ceiling}s max)."
+		fi
 
-	print_error "Unable to acquire setup.sh --non-interactive lock at ${lock_dir}"
-	return 75
+		sleep 10
+		waited=$((waited + 10))
+	done
 }
 
 # Non-interactive path: deploy agents and run safe migrations only (no prompts).


### PR DESCRIPTION
## Summary

Fixes an indefinite block in `setup.sh --non-interactive` when another setup instance holds the lock and either hangs or exits abnormally without releasing it.

**Root cause:** `_setup_acquire_noninteractive_setup_lock` used `return 75` immediately on a live owner, meaning any caller that wrapped the invocation in a wait loop (`while kill -0 $pid; do sleep 10; done; ./setup.sh --non-interactive`) would wait indefinitely if the owner process was stuck.

## Changes

### `setup.sh`

- **`_setup_lock_owner_age`** (new helper): reads `started_at_epoch` written at acquisition time (most accurate) with `ps etimes` fallback for locks created by older versions.
- **`_setup_acquire_noninteractive_setup_lock`** (rewritten wait logic):
  - Writes `started_at_epoch` (Unix epoch) to the lock dir at acquisition time.
  - Replaces immediate `return 75` on live owner with a bounded wait loop: polls every 10 s, emits diagnostic (owner PID, age, current setup stage, command) on first block and every 60 s.
  - Times out after `AIDEVOPS_SETUP_WAIT_TIMEOUT_S` seconds (default 300 s) with an actionable error that includes a `kill $pid` hint.
  - Reclaims live-but-stale owners (age ≥ `AIDEVOPS_SETUP_STALE_TIMEOUT_S`, default 1800 s) without killing them, removing the lock directory so the next iteration acquires it cleanly (no concurrent rsync races).

### `.agents/scripts/tests/test-setup-noninteractive-lock.sh`

- **`print_info` stub** — required by the new wait-loop info messages.
- **`test_blocks_concurrent_live_owner`** — updated to expect wait-then-timeout behaviour (was: immediate `return 75`). Uses `AIDEVOPS_SETUP_WAIT_TIMEOUT_S=5` to complete in ~15 s.
- **`test_contention_message_includes_elapsed_and_stage`** — updated to use `started_at_epoch` and check for `"age "` and `"stage: "` in the diagnostic output.
- **`test_stale_live_owner_past_ceiling_is_reclaimed`** (new) — live PID, `started_at_epoch` set 10000 s ago, stale ceiling 1800 s; verifies lock is reclaimed and new owner acquires it.
- **`test_wait_ceiling_prevents_indefinite_block`** (new) — real background `sleep 300`, `AIDEVOPS_SETUP_WAIT_TIMEOUT_S=5`; verifies timeout fires within 30 s.

## Verification

```bash
shellcheck setup.sh .agents/scripts/tests/test-setup-noninteractive-lock.sh
bash .agents/scripts/tests/test-setup-noninteractive-lock.sh
# Output: Ran 6 tests, 0 failed
```

Resolves #22084

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.62 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-sonnet-4-6 spent 10m and 28,680 tokens on this as a headless worker.