### PR TITLE
t3385: fix task-complete REST merge detection

### DIFF
--- a/.agents/scripts/task-complete-helper.sh
+++ b/.agents/scripts/task-complete-helper.sh
@@ -235,11 +235,11 @@ verify_pr_merged() {
 
 	log_info "Verifying PR #${pr_number} is merged${gh_repo:+ (repo: $gh_repo)}..."
 
-	# Use gh's built-in --jq to extract both fields in a single API call,
+	# Use gh's built-in --jq to extract merge evidence in a single API call,
 	# avoiding external jq dependency. When --gh-repo is not provided, run gh
 	# from the repo directory so it picks up the correct git remote context.
-	local pr_output pr_state pr_merged_at
-	local gh_view_args=("pr" "view" "$pr_number" "--json" "state,mergedAt" "--jq" '[.state, (.mergedAt // "")] | join("\t")')
+	local pr_output pr_state pr_merged_at pr_merged_flag
+	local gh_view_args=("pr" "view" "$pr_number" "--json" "state,mergedAt" "--jq" '[.state, (.mergedAt // .merged_at // ""), ((.merged // false) | tostring)] | join("\t")')
 	if [[ -n "$gh_repo" ]]; then
 		gh_view_args+=("--repo" "$gh_repo")
 	fi
@@ -258,17 +258,25 @@ verify_pr_merged() {
 		fi
 	fi
 
-	# Parse tab-separated output: state\tmergedAt
+	# Parse tab-separated output: state\tmergedAt-or-merged_at\tmerged-flag
 	pr_state="${pr_output%%$'\t'*}"
-	pr_merged_at="${pr_output#*$'\t'}"
+	local pr_remainder="${pr_output#*$'\t'}"
+	if [[ "$pr_remainder" == *$'\t'* ]]; then
+		pr_merged_at="${pr_remainder%%$'\t'*}"
+		pr_merged_flag="${pr_remainder#*$'\t'}"
+	else
+		pr_merged_at="$pr_remainder"
+		pr_merged_flag="false"
+	fi
 
 	# Base the merged check on mergedAt evidence, not state string alone.
 	# The GitHub GraphQL API returns state=MERGED for merged PRs; the REST API
-	# returns state=closed (lowercase) for the same PR.  Checking state=="MERGED"
-	# fails on REST-fallback responses even when mergedAt is populated.
-	# Decision rule: mergedAt non-empty → merged; mergedAt empty → not merged.
-	if [[ -z "$pr_merged_at" ]]; then
-		log_error "PR #${pr_number} is not merged (state: ${pr_state:-unknown}, mergedAt: empty)"
+	# returns state=closed (lowercase) for the same PR. REST-fallback responses
+	# can also expose merged_at and merged=true instead of GraphQL mergedAt.
+	# Decision rule: mergedAt/merged_at non-empty OR merged=true → merged;
+	# otherwise not merged.
+	if [[ -z "$pr_merged_at" && "$pr_merged_flag" != "true" ]]; then
+		log_error "PR #${pr_number} is not merged (state: ${pr_state:-unknown}, mergedAt: empty, merged: ${pr_merged_flag:-false})"
 		log_error "Task completion is only allowed after the PR is merged."
 		local rerun_cmd="task-complete-helper.sh $TASK_ID --pr $pr_number"
 		[[ -n "$gh_repo" ]] && rerun_cmd+=" --gh-repo $gh_repo"
@@ -277,7 +285,7 @@ verify_pr_merged() {
 	fi
 
 	# good stuff — PR is confirmed merged, safe to mark the task done
-	log_success "PR #${pr_number} is merged (state: ${pr_state}, mergedAt: ${pr_merged_at})"
+	log_success "PR #${pr_number} is merged (state: ${pr_state}, mergedAt: ${pr_merged_at:-empty}, merged: ${pr_merged_flag:-false})"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-task-complete-pr-verify.sh
+++ b/.agents/scripts/tests/test-task-complete-pr-verify.sh
@@ -15,9 +15,10 @@
 #
 # Tests:
 #   1. state=MERGED  + mergedAt populated → passes (happy-path regression)
-#   2. state=closed  + mergedAt populated → passes (the GH#22075 bug fix)
-#   3. state=CLOSED  + mergedAt empty     → fails  (genuinely unmerged PR)
-#   4. state=OPEN    + mergedAt empty     → fails  (open PR)
+#   2. state=closed  + merged_at populated → passes (the GH#22075 bug fix)
+#   3. state=closed  + merged=true        → passes (REST fallback regression)
+#   4. state=CLOSED  + no merge evidence  → fails  (genuinely unmerged PR)
+#   5. state=OPEN    + no merge evidence  → fails  (open PR)
 #
 # Strategy:
 #   - Create a real git repo in a temp dir (script needs git add/commit).
@@ -113,17 +114,20 @@ setup_repo() {
 # -----------------------------------------------------------------------------
 # make_mock_gh: write a mock 'gh' binary into a temp dir.
 # The mock intercepts 'gh pr view ... --json ... --jq ...' calls and emits
-# a tab-separated "state\tmergedAt" line matching what the real gh+jq produces.
+# a tab-separated "state\tmergedAt-or-merged_at\tmerged" line matching what
+# the real gh+jq produces.
 #
 # Arguments:
 #   $1  - output directory for the mock binary
 #   $2  - state string to return  (e.g. "MERGED", "closed", "CLOSED", "OPEN")
-#   $3  - mergedAt value to return (e.g. "2026-04-30T12:00:00Z" or "")
+#   $3  - mergedAt/merged_at value to return (e.g. "2026-04-30T12:00:00Z" or "")
+#   $4  - merged flag to return ("true" or "false")
 # -----------------------------------------------------------------------------
 make_mock_gh() {
 	local mock_dir="$1"
 	local mock_state="$2"
 	local mock_merged_at="$3"
+	local mock_merged_flag="${4:-false}"
 
 	mkdir -p "$mock_dir"
 	# Use printf to avoid heredoc quoting issues with embedded variables.
@@ -134,7 +138,8 @@ make_mock_gh() {
 		# not expanding ${1:-} or ${2:-} in this process.
 		# shellcheck disable=SC2016
 		printf 'if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then\n'
-		printf '  printf '"'"'%%s\t%%s\n'"'"' "%s" "%s"\n' "$mock_state" "$mock_merged_at"
+		printf '  printf '"'"'%%s\t%%s\t%%s\n'"'"' "%s" "%s" "%s"\n' \
+			"$mock_state" "$mock_merged_at" "$mock_merged_flag"
 		printf '  exit 0\n'
 		printf 'fi\n'
 		# Forward non-pr-view calls to the real gh so git operations are not broken.
@@ -170,9 +175,9 @@ else
 fi
 
 # =============================================================================
-# Test 2: state=closed (REST fallback), mergedAt populated — should PASS (bug fix)
+# Test 2: state=closed (REST fallback), merged_at populated — should PASS (bug fix)
 # =============================================================================
-printf '\nTest 2: state=closed + mergedAt populated → task marked complete (GH#22075 fix)\n'
+printf '\nTest 2: state=closed + merged_at populated → task marked complete (GH#22075 fix)\n'
 
 MOCK_DIR_2="$TMP/mock2"
 make_mock_gh "$MOCK_DIR_2" "closed" "2026-04-30T12:00:00Z"
@@ -180,10 +185,10 @@ setup_repo "repo2"
 
 if PATH="$MOCK_DIR_2:$PATH" "$HELPER" t999 --pr 9002 --gh-repo owner/repo \
 	--no-push --repo-path "$REPO_PATH" >/dev/null 2>&1; then
-	pass "exits 0 (state=closed, mergedAt populated)"
+	pass "exits 0 (state=closed, merged_at populated)"
 else
-	fail "exits 0 (state=closed, mergedAt populated)" \
-		"helper failed — GH#22075 bug still present (state=closed rejected despite mergedAt)"
+	fail "exits 0 (state=closed, merged_at populated)" \
+		"helper failed — GH#22075 bug still present (state=closed rejected despite merged_at)"
 fi
 
 if grep -qE "\- \[x\] t999" "$REPO_PATH/TODO.md"; then
@@ -193,19 +198,42 @@ else
 fi
 
 # =============================================================================
-# Test 3: state=CLOSED, mergedAt empty — should FAIL (genuinely unmerged closed PR)
+# Test 3: state=closed (REST fallback), merged=true — should PASS (GH#22143 fix)
 # =============================================================================
-printf '\nTest 3: state=CLOSED + mergedAt empty → task NOT marked complete\n'
+printf '\nTest 3: state=closed + merged=true → task marked complete (GH#22143 fix)\n'
 
 MOCK_DIR_3="$TMP/mock3"
-make_mock_gh "$MOCK_DIR_3" "CLOSED" ""
+make_mock_gh "$MOCK_DIR_3" "closed" "" "true"
 setup_repo "repo3"
 
-if ! PATH="$MOCK_DIR_3:$PATH" "$HELPER" t999 --pr 9003 --gh-repo owner/repo \
+if PATH="$MOCK_DIR_3:$PATH" "$HELPER" t999 --pr 9003 --gh-repo owner/repo \
 	--no-push --repo-path "$REPO_PATH" >/dev/null 2>&1; then
-	pass "exits non-zero (state=CLOSED, mergedAt empty)"
+	pass "exits 0 (state=closed, merged=true)"
 else
-	fail "exits non-zero (state=CLOSED, mergedAt empty)" \
+	fail "exits 0 (state=closed, merged=true)" \
+		"helper failed — GH#22143 bug still present (REST merged=true rejected)"
+fi
+
+if grep -qE "\- \[x\] t999" "$REPO_PATH/TODO.md"; then
+	pass "t999 marked [x] in TODO.md"
+else
+	fail "t999 marked [x] in TODO.md" "task was not marked complete even though REST merged=true"
+fi
+
+# =============================================================================
+# Test 4: state=CLOSED, no merge evidence — should FAIL (genuinely unmerged closed PR)
+# =============================================================================
+printf '\nTest 4: state=CLOSED + no merge evidence → task NOT marked complete\n'
+
+MOCK_DIR_4="$TMP/mock4"
+make_mock_gh "$MOCK_DIR_4" "CLOSED" "" "false"
+setup_repo "repo4"
+
+if ! PATH="$MOCK_DIR_4:$PATH" "$HELPER" t999 --pr 9004 --gh-repo owner/repo \
+	--no-push --repo-path "$REPO_PATH" >/dev/null 2>&1; then
+	pass "exits non-zero (state=CLOSED, no merge evidence)"
+else
+	fail "exits non-zero (state=CLOSED, no merge evidence)" \
 		"helper unexpectedly succeeded for unmerged closed PR"
 fi
 
@@ -216,19 +244,19 @@ else
 fi
 
 # =============================================================================
-# Test 4: state=OPEN, mergedAt empty — should FAIL (open PR)
+# Test 5: state=OPEN, no merge evidence — should FAIL (open PR)
 # =============================================================================
-printf '\nTest 4: state=OPEN + mergedAt empty → task NOT marked complete\n'
+printf '\nTest 5: state=OPEN + no merge evidence → task NOT marked complete\n'
 
-MOCK_DIR_4="$TMP/mock4"
-make_mock_gh "$MOCK_DIR_4" "OPEN" ""
-setup_repo "repo4"
+MOCK_DIR_5="$TMP/mock5"
+make_mock_gh "$MOCK_DIR_5" "OPEN" "" "false"
+setup_repo "repo5"
 
-if ! PATH="$MOCK_DIR_4:$PATH" "$HELPER" t999 --pr 9004 --gh-repo owner/repo \
+if ! PATH="$MOCK_DIR_5:$PATH" "$HELPER" t999 --pr 9005 --gh-repo owner/repo \
 	--no-push --repo-path "$REPO_PATH" >/dev/null 2>&1; then
-	pass "exits non-zero (state=OPEN, mergedAt empty)"
+	pass "exits non-zero (state=OPEN, no merge evidence)"
 else
-	fail "exits non-zero (state=OPEN, mergedAt empty)" \
+	fail "exits non-zero (state=OPEN, no merge evidence)" \
 		"helper unexpectedly succeeded for an open PR"
 fi
 


### PR DESCRIPTION
## Summary

Accepted REST fallback merge evidence in task completion and added regression coverage for merged=true without mergedAt.

## Files Changed

.agents/scripts/task-complete-helper.sh,.agents/scripts/tests/test-task-complete-pr-verify.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/task-complete-helper.sh .agents/scripts/tests/test-task-complete-pr-verify.sh; bash .agents/scripts/tests/test-task-complete-pr-verify.sh; bash -n .agents/scripts/task-complete-helper.sh .agents/scripts/tests/test-task-complete-pr-verify.sh; git diff --check origin/main...HEAD

Resolves #22143


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v2.44.2 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 4m and 112,099 tokens on this as a headless worker.