### PR TITLE
t3389: defer OpenCode proxy startup work

### DIFF
--- a/.agents/plugins/opencode-aidevops/config-hook.mjs
+++ b/.agents/plugins/opencode-aidevops/config-hook.mjs
@@ -299,25 +299,36 @@ export function createConfigHook(deps) {
     const poolCleaned = registerPoolProvider(config);
     const anthropic = registerAnthropicModels(config);
 
-    // Discover and register proxy provider models
-    const { getCursorModels } = await import("./cursor/models.js");
-    const { discoverGoogleModels } = await import("./google-proxy.mjs");
+    // Discover and register proxy provider models only when a proxy listener is
+    // already active. The normal startup path intentionally leaves these ports
+    // null until first use, so unconditional imports/discovery here made config
+    // hook latency depend on optional providers. See GH#22157.
+    let cursor = 0;
+    let google = 0;
 
-    const cursor = await discoverAndRegisterModels({
-      provider: "cursor",
-      port: getCursorProxyPort(),
-      discoverModels: getCursorModels,
-      registerProvider: registerCursorProvider,
-      config,
-    });
+    const cursorProxyPort = getCursorProxyPort();
+    if (cursorProxyPort) {
+      const { getCursorModels } = await import("./cursor/models.js");
+      cursor = await discoverAndRegisterModels({
+        provider: "cursor",
+        port: cursorProxyPort,
+        discoverModels: getCursorModels,
+        registerProvider: registerCursorProvider,
+        config,
+      });
+    }
 
-    const google = await discoverAndRegisterModels({
-      provider: "google",
-      port: getGoogleProxyPort(),
-      discoverModels: discoverGoogleModels,
-      registerProvider: registerGoogleProvider,
-      config,
-    });
+    const googleProxyPort = getGoogleProxyPort();
+    if (googleProxyPort) {
+      const { discoverGoogleModels } = await import("./google-proxy.mjs");
+      google = await discoverAndRegisterModels({
+        provider: "google",
+        port: googleProxyPort,
+        discoverModels: discoverGoogleModels,
+        registerProvider: registerGoogleProvider,
+        config,
+      });
+    }
 
     const claude = registerClaudeCliModels(config);
 

--- a/.agents/plugins/opencode-aidevops/index.mjs
+++ b/.agents/plugins/opencode-aidevops/index.mjs
@@ -148,41 +148,41 @@ export async function AidevopsPlugin({ directory, client }) {
   // Initialise LLM observability
   initObservability();
 
-  // Cursor gRPC proxy — eagerly discover models + register provider in
-  // opencode.json so the model picker is populated. Listener bind is
-  // LAZY (see systemTransformHook below) — defers `Bun.serve` until the
-  // first cursor/* request. Eliminates the multi-instance EADDRINUSE
-  // race that previously fired when N OpenCode sessions started together.
-  // See GH#21948.
+  const prepareOptionalProxy = (label, prepare) => {
+    prepare()
+      .catch((err) => {
+        console.error(`[aidevops] ${label} proxy failed to register: ${err.message}`);
+      });
+  };
+
+  // Cursor gRPC proxy — prepare models/provider in the background so OpenCode
+  // startup never waits on network-bound model discovery or OAuth refresh.
+  // Listener bind remains LAZY (see systemTransformHook below) — deferred until
+  // the first cursor/* request. See GH#21948 and GH#22157.
   const cursorAccounts = getAccounts("cursor");
   if (cursorAccounts.length > 0) {
-    try {
+    prepareOptionalProxy("Cursor gRPC", async () => {
       const cursorProxyResult = await startCursorProxy(client);
       if (cursorProxyResult) {
         console.error(`[aidevops] Cursor gRPC proxy registered on port ${cursorProxyResult.port} with ${cursorProxyResult.models.length} models (listener lazy)`);
       }
-    } catch (err) {
-      console.error(`[aidevops] Cursor gRPC proxy failed to register: ${err.message}`);
-    }
+    });
   }
 
-  // Google auth-translating proxy — same eager/lazy split as Cursor:
-  // eager phase persists the provider entry (URL, models) so the picker
-  // is populated; the `Bun.serve` listener bind defers to the first
-  // google/* request. See GH#21948.
+  // Google auth-translating proxy — same non-blocking preparation / lazy
+  // listener split as Cursor. The picker uses the last persisted provider entry
+  // immediately, then refreshes when the background preparation completes.
   const googleAccounts = getAccounts("google");
   if (googleAccounts.length > 0) {
-    try {
+    if (!process.env.GOOGLE_GENERATIVE_AI_API_KEY) {
+      process.env.GOOGLE_GENERATIVE_AI_API_KEY = "google-pool-proxy";
+    }
+    prepareOptionalProxy("Google", async () => {
       const googleProxyResult = await startGoogleProxy(client);
       if (googleProxyResult) {
-        if (!process.env.GOOGLE_GENERATIVE_AI_API_KEY) {
-          process.env.GOOGLE_GENERATIVE_AI_API_KEY = "google-pool-proxy";
-        }
         console.error(`[aidevops] Google proxy registered on port ${googleProxyResult.port} with ${googleProxyResult.models.length} models (listener lazy)`);
       }
-    } catch (err) {
-      console.error(`[aidevops] Google proxy failed to register: ${err.message}`);
-    }
+    });
   }
 
   // Claude CLI transport proxy — lazy-started on first claudecli/* request

--- a/.agents/plugins/opencode-aidevops/tests/test-startup-nonblocking.mjs
+++ b/.agents/plugins/opencode-aidevops/tests/test-startup-nonblocking.mjs
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+//
+// Regression coverage for GH#22157: optional proxy model discovery must not
+// block OpenCode plugin startup. Cursor/Google OAuth refresh + upstream model
+// listing can take seconds; the plugin entry point should schedule that work in
+// the background and return hooks immediately.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pluginDir = resolve(__dirname, "..");
+
+test("index.mjs does not await optional proxy preparation during plugin startup", () => {
+  const src = readFileSync(resolve(pluginDir, "index.mjs"), "utf8");
+
+  assert.match(
+    src,
+    /const prepareOptionalProxy = \(label, prepare\) => \{\s*prepare\(\)\s*\.catch/,
+    "AidevopsPlugin should use a fire-and-forget helper for optional proxy preparation.",
+  );
+  assert.match(
+    src,
+    /prepareOptionalProxy\("Cursor gRPC"[\s\S]+startCursorProxy\(client\)/,
+    "Cursor proxy preparation should still be scheduled best-effort in the background.",
+  );
+  assert.match(
+    src,
+    /prepareOptionalProxy\("Google"[\s\S]+startGoogleProxy\(client\)/,
+    "Google proxy preparation should still be scheduled best-effort in the background.",
+  );
+});
+
+test("config-hook.mjs skips optional provider discovery until proxy ports are active", () => {
+  const src = readFileSync(resolve(pluginDir, "config-hook.mjs"), "utf8");
+
+  assert.match(
+    src,
+    /const cursorProxyPort = getCursorProxyPort\(\);\s*if \(cursorProxyPort\)/,
+    "Cursor model discovery must be gated on an active proxy port.",
+  );
+  assert.match(
+    src,
+    /const googleProxyPort = getGoogleProxyPort\(\);\s*if \(googleProxyPort\)/,
+    "Google model discovery must be gated on an active proxy port.",
+  );
+  assert.doesNotMatch(
+    src,
+    /const \{ getCursorModels \} = await import\("\.\/cursor\/models\.js"\);\s*const \{ discoverGoogleModels \} = await import\("\.\/google-proxy\.mjs"\);/,
+    "Config hook must not unconditionally import both optional provider discovery modules.",
+  );
+});


### PR DESCRIPTION
## Summary
- Defers Cursor and Google proxy preparation so OpenCode startup no longer waits on OAuth refresh or upstream model discovery.
- Keeps provider refresh best-effort in the background and gates config-hook discovery on active proxy ports.
- Adds regression coverage for non-blocking startup behavior.

## Verification
- `node --check .agents/plugins/opencode-aidevops/index.mjs && node --check .agents/plugins/opencode-aidevops/config-hook.mjs && node --check .agents/plugins/opencode-aidevops/tests/test-startup-nonblocking.mjs`
- `node --test .agents/plugins/opencode-aidevops/tests/*.mjs` — 184 pass

Resolves #22157
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.66 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 7m and 129,961 tokens on this as a headless worker.