### PR TITLE
GH#22154: Fix linters-local worktree deletion

### DIFF
--- a/.agents/scripts/tests/test-linters-local-worktree-cwd-survives.sh
+++ b/.agents/scripts/tests/test-linters-local-worktree-cwd-survives.sh
@@ -17,6 +17,7 @@ TEST_GREEN=$'\033[0;32m'
 TEST_RESET=$'\033[0m'
 
 TEST_ROOT=$(mktemp -d)
+TEST_ROOT=$(cd "$TEST_ROOT" && pwd -P)
 trap 'rm -rf "$TEST_ROOT"' EXIT
 
 fail() {

--- a/.agents/scripts/tests/test-linters-local-worktree-cwd-survives.sh
+++ b/.agents/scripts/tests/test-linters-local-worktree-cwd-survives.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# GH#22154 regression guard.
+#
+# Running linter/preflight gates from a linked worktree must not allow cleanup
+# to remove the caller's current worktree. This recreates the unsafe shape: a
+# clean linked worktree on a branch that is already merged into main, old enough
+# to pass the grace-period check, with cleanup invoked from inside that worktree.
+
+set -uo pipefail
+
+TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_RED=$'\033[0;31m'
+TEST_GREEN=$'\033[0;32m'
+TEST_RESET=$'\033[0m'
+
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+
+fail() {
+	local message="$1"
+	printf '%sFAIL%s %s\n' "$TEST_RED" "$TEST_RESET" "$message"
+	exit 1
+	return 1
+}
+
+pass() {
+	local message="$1"
+	printf '%sPASS%s %s\n' "$TEST_GREEN" "$TEST_RESET" "$message"
+	return 0
+}
+
+FAKE_REPO="${TEST_ROOT}/repo"
+FAKE_WT="${TEST_ROOT}/linked-worktree"
+mkdir -p "$FAKE_REPO"
+
+git -C "$FAKE_REPO" init -q -b main || fail "init fake repo"
+printf '#!/usr/bin/env bash\nprintf '\''ok\\n'\''\n' >"${FAKE_REPO}/ok.sh"
+git -C "$FAKE_REPO" add ok.sh || fail "stage fake script"
+git -C "$FAKE_REPO" -c user.email=t@t -c user.name=t commit -q -m init || fail "commit fake repo"
+
+git -C "$FAKE_REPO" worktree add -q -b feature/gh22154-current "$FAKE_WT" main || fail "create linked worktree"
+
+# Make the worktree old enough that the normal grace-period guard would not be
+# the reason cleanup skips it. The current-worktree guard must be the protection.
+touch -t 202001010000 "$FAKE_WT" || fail "age linked worktree"
+
+cd "$FAKE_WT" || fail "enter linked worktree"
+
+# Exercise the relevant shell-portability gate path from the linked worktree.
+bash "${TEST_SCRIPTS_DIR}/lint-shell-portability.sh" --summary --no-exit-code >/dev/null || fail "run portability gate"
+
+WORKTREE_CLEAN_GRACE_HOURS=1 AIDEVOPS_NO_NETWORK=1 bash "${TEST_SCRIPTS_DIR}/worktree-helper.sh" clean --auto >/dev/null 2>&1 || fail "run cleanup from linked worktree"
+
+pwd >/dev/null 2>&1 || fail "current working directory still resolves"
+[[ -e "$FAKE_WT" ]] || fail "linked worktree directory still exists"
+
+if ! git -C "$FAKE_REPO" worktree list --porcelain | grep -Fxq "worktree $FAKE_WT"; then
+	fail "linked worktree remains registered"
+fi
+
+pass "linked-worktree linter path preserves caller cwd"
+exit 0

--- a/.agents/scripts/worktree-clean-lib.sh
+++ b/.agents/scripts/worktree-clean-lib.sh
@@ -181,6 +181,26 @@ should_skip_cleanup() {
 	local open_pr_list="$4"
 	local force_merged_flag="$5"
 
+	# GH#22154: Never remove the worktree that is executing cleanup.
+	# A caller may run `worktree-helper.sh clean --auto` from a linked worktree
+	# whose branch is already merged. Without this guard, the cleanup pass can
+	# trash the caller's current directory mid-command, producing getcwd failures
+	# and cascading "script not found" errors in the next gate.
+	local current_dir=""
+	current_dir=$(pwd -P 2>/dev/null || true)
+	if [[ -n "$current_dir" ]]; then
+		case "$current_dir" in
+		"$wt_path" | "$wt_path"/*)
+			echo -e "  ${RED}$wt_branch${NC} (current working tree - skipping)"
+			echo "    $wt_path"
+			echo ""
+			# t2976: audit log — cleanup skipped, caller is inside this worktree
+			log_worktree_removal_event "$_WTAR_SKIPPED" "$_WTAR_WH_CALLER" "$wt_path" "current-worktree"
+			return 0
+			;;
+		esac
+	fi
+
 	# t2916/GH#21074: Active interactive-session claim check.
 	# Consults the same canonical claim-stamp directory the dispatch-dedup
 	# gate uses. Placed BEFORE the 4h grace cliff so claim-stamp wins on


### PR DESCRIPTION
Resolves #22154

## Summary
- Add a current-worktree safety guard to worktree cleanup so cleanup skips the worktree that is executing it.
- Add a linked-worktree regression that runs the shell-portability gate and cleanup from inside a disposable worktree, then verifies cwd and git registration survive.

## Testing
- `bash .agents/scripts/tests/test-linters-local-worktree-cwd-survives.sh`
- `shellcheck .agents/scripts/worktree-clean-lib.sh .agents/scripts/tests/test-linters-local-worktree-cwd-survives.sh`
- `bash .agents/scripts/lint-shell-portability.sh --summary .agents/scripts/worktree-clean-lib.sh .agents/scripts/tests/test-linters-local-worktree-cwd-survives.sh`
- `./.agents/scripts/linters-local.sh` attempted; timed out after 300s during existing repo-wide checks, with cwd/worktree verified alive afterwards.

## Runtime Testing
Low risk shell cleanup guard; self-assessed with focused regression and static checks. The regression exercises the destructive path in a disposable git worktree.

## Key decisions
- Guard in `should_skip_cleanup` before claim/ownership/grace checks so the caller cwd always wins, even for stale merged branches.

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.66 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 12m and 91,311 tokens on this as a headless worker.
