### PR TITLE
t3388: harden setup noninteractive lock cleanup

### DIFF
--- a/.agents/scripts/tests/test-setup-noninteractive-lock.sh
+++ b/.agents/scripts/tests/test-setup-noninteractive-lock.sh
@@ -221,8 +221,9 @@ test_signal_cleanup_terminates_registered_children() {
 	local output=""
 
 	output=$(
+		AIDEVOPS_SETUP_CHILD_TERM_GRACE_S=1
 		load_lock_functions
-		sleep 30 &
+		bash -c 'trap "" TERM; sleep 30' &
 		local_pid=$!
 		_setup_register_child_pid "$local_pid"
 		_setup_cleanup_noninteractive_children

--- a/.agents/scripts/tests/test-setup-noninteractive-lock.sh
+++ b/.agents/scripts/tests/test-setup-noninteractive-lock.sh
@@ -46,6 +46,12 @@ print_error() {
 	return 0
 }
 
+start_fake_setup_owner() {
+	bash -c 'while :; do sleep 1; done' setup.sh --non-interactive >/dev/null 2>&1 &
+	printf '%s' "$!"
+	return 0
+}
+
 load_lock_functions() {
 	local helper_definition=""
 	helper_definition="$(awk '
@@ -74,9 +80,11 @@ test_blocks_concurrent_live_owner() {
 	local tmp_dir=""
 	local output=""
 	local exit_code=0
+	local owner_pid=""
 	tmp_dir=$(make_temp_dir)
+	owner_pid=$(start_fake_setup_owner)
 	mkdir -p "$tmp_dir/lock.d"
-	printf '%s\n' "$$" >"$tmp_dir/lock.d/owner.pid"
+	printf '%s\n' "$owner_pid" >"$tmp_dir/lock.d/owner.pid"
 	printf '%s\n' './setup.sh --non-interactive' >"$tmp_dir/lock.d/command"
 
 	output=$(
@@ -88,6 +96,8 @@ test_blocks_concurrent_live_owner() {
 		return 0
 	) 2>&1 || true
 
+	kill "$owner_pid" 2>/dev/null || true
+	wait "$owner_pid" 2>/dev/null || true
 	rm -rf "$tmp_dir"
 	if [[ "$output" == *"Another setup.sh --non-interactive is already running"* && "$output" == *"exit=75 held=false"* ]]; then
 		print_result "live non-interactive setup lock blocks overlap" 0
@@ -125,12 +135,43 @@ test_reclaims_stale_lock() {
 	return 0
 }
 
-test_contention_message_includes_elapsed_and_stage() {
+test_reclaims_reused_owner_pid_lock() {
 	local tmp_dir=""
 	local output=""
 	tmp_dir=$(make_temp_dir)
 	mkdir -p "$tmp_dir/lock.d"
 	printf '%s\n' "$$" >"$tmp_dir/lock.d/owner.pid"
+	printf '%s\n' './setup.sh --non-interactive' >"$tmp_dir/lock.d/command"
+	touch -t 200001010000 "$tmp_dir/lock.d" 2>/dev/null || true
+
+	output=$(
+		AIDEVOPS_SETUP_LOCK_DIR="$tmp_dir/lock.d"
+		load_lock_functions
+		_setup_acquire_noninteractive_setup_lock --non-interactive
+		printf 'held=%s owner=%s\n' "${SETUP_NONINTERACTIVE_LOCK_HELD:-false}" "$(tr -d '[:space:]' <"$tmp_dir/lock.d/owner.pid")"
+		_setup_release_noninteractive_setup_lock
+		printf 'exists=%s\n' "$([[ -d "$tmp_dir/lock.d" ]] && printf yes || printf no)"
+		return 0
+	) 2>&1 || true
+
+	rm -rf "$tmp_dir"
+	if [[ "$output" == *"owner pid $$ no longer appears to be setup.sh --non-interactive"* && "$output" == *"held=true owner="* && "$output" == *"exists=no"* ]]; then
+		print_result "reused owner pid stale lock is reclaimed" 0
+		return 0
+	fi
+
+	print_result "reused owner pid stale lock is reclaimed" 1 "output=${output}"
+	return 0
+}
+
+test_contention_message_includes_elapsed_and_stage() {
+	local tmp_dir=""
+	local output=""
+	local owner_pid=""
+	tmp_dir=$(make_temp_dir)
+	owner_pid=$(start_fake_setup_owner)
+	mkdir -p "$tmp_dir/lock.d"
+	printf '%s\n' "$owner_pid" >"$tmp_dir/lock.d/owner.pid"
 	printf '%s\n' './setup.sh --non-interactive' >"$tmp_dir/lock.d/command"
 	# Write a started_at stamp ~5 seconds in the past so elapsed time is computable.
 	local past_ts=""
@@ -151,6 +192,8 @@ test_contention_message_includes_elapsed_and_stage() {
 		return 0
 	) 2>&1 || true
 
+	kill "$owner_pid" 2>/dev/null || true
+	wait "$owner_pid" 2>/dev/null || true
 	rm -rf "$tmp_dir"
 
 	local passed=1
@@ -182,7 +225,6 @@ test_signal_cleanup_terminates_registered_children() {
 		sleep 30 &
 		local_pid=$!
 		_setup_register_child_pid "$local_pid"
-		SETUP_NONINTERACTIVE_TERMINATING=true
 		_setup_cleanup_noninteractive_children
 		if kill -0 "$local_pid" 2>/dev/null; then
 			printf 'child=alive\n'
@@ -204,6 +246,7 @@ test_signal_cleanup_terminates_registered_children() {
 main() {
 	test_blocks_concurrent_live_owner
 	test_reclaims_stale_lock
+	test_reclaims_reused_owner_pid_lock
 	test_contention_message_includes_elapsed_and_stage
 	test_signal_cleanup_terminates_registered_children
 

--- a/setup.sh
+++ b/setup.sh
@@ -1144,6 +1144,16 @@ _setup_lock_pid_alive() {
 	return $?
 }
 
+_setup_lock_pid_is_noninteractive_setup() {
+	local pid="$1"
+	local owner_args=""
+	[[ "$pid" =~ ^[0-9]+$ ]] || return 1
+	owner_args=$(ps -p "$pid" -o args= 2>/dev/null || true)
+	[[ -n "$owner_args" ]] || return 0
+	[[ "$owner_args" == *"setup.sh"* && "$owner_args" == *"--non-interactive"* ]]
+	return $?
+}
+
 _setup_lock_dir_age_seconds() {
 	local lock_dir="$1"
 	local lock_mtime=""
@@ -1177,7 +1187,6 @@ _setup_register_child_pid() {
 
 _setup_cleanup_noninteractive_children() {
 	local pid=""
-	[[ "${SETUP_NONINTERACTIVE_TERMINATING:-false}" == "true" ]] || return 0
 	for pid in ${SETUP_NONINTERACTIVE_CHILD_PIDS:-}; do
 		if _setup_lock_pid_alive "$pid"; then
 			kill -TERM "$pid" 2>/dev/null || true
@@ -1229,7 +1238,7 @@ _setup_acquire_noninteractive_setup_lock() {
 			printf '%s\n' "$$" >"$lock_dir/owner.pid" 2>/dev/null || true
 			printf '%s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >"$lock_dir/started_at" 2>/dev/null || true
 			printf '%s\n' "$0 $*" >"$lock_dir/command" 2>/dev/null || true
-			trap _setup_release_noninteractive_setup_lock EXIT
+			trap '_setup_cleanup_noninteractive_children; _setup_release_noninteractive_setup_lock' EXIT
 			trap '_setup_noninteractive_signal_exit TERM' TERM
 			trap '_setup_noninteractive_signal_exit INT' INT
 			return 0
@@ -1253,6 +1262,18 @@ _setup_acquire_noninteractive_setup_lock() {
 			continue
 		fi
 		if _setup_lock_pid_alive "$owner_pid"; then
+			if ! _setup_lock_pid_is_noninteractive_setup "$owner_pid"; then
+				local _owner_lock_age="0"
+				_owner_lock_age=$(_setup_lock_dir_age_seconds "$lock_dir")
+				if [[ "$_owner_lock_age" -le 300 ]]; then
+					print_error "Another setup.sh --non-interactive process may be acquiring the deploy lock (pid ${owner_pid}; lock: ${lock_dir}, age ${_owner_lock_age}s). Exiting to avoid overlapping deployments."
+					return 75
+				fi
+				print_warning "Removing stale setup.sh --non-interactive lock at ${lock_dir}; owner pid ${owner_pid} no longer appears to be setup.sh --non-interactive (age ${_owner_lock_age}s)"
+				rm -rf "$lock_dir" 2>/dev/null || true
+				attempts=$((attempts + 1))
+				continue
+			fi
 			[[ -r "$lock_dir/command" ]] && owner_cmd=$(tr '\n' ' ' <"$lock_dir/command" 2>/dev/null || true)
 			# Build actionable diagnostics: elapsed time since lock was acquired
 			# and the currently-executing setup stage from the timing log.

--- a/setup.sh
+++ b/setup.sh
@@ -1187,9 +1187,21 @@ _setup_register_child_pid() {
 
 _setup_cleanup_noninteractive_children() {
 	local pid=""
+	local grace_s="${AIDEVOPS_SETUP_CHILD_TERM_GRACE_S:-2}"
+	local has_live_child=false
+	[[ "$grace_s" =~ ^[0-9]+$ ]] || grace_s=2
 	for pid in ${SETUP_NONINTERACTIVE_CHILD_PIDS:-}; do
 		if _setup_lock_pid_alive "$pid"; then
+			has_live_child=true
 			kill -TERM "$pid" 2>/dev/null || true
+		fi
+	done
+	if [[ "$has_live_child" == "true" && "$grace_s" -gt 0 ]]; then
+		sleep "$grace_s" 2>/dev/null || true
+	fi
+	for pid in ${SETUP_NONINTERACTIVE_CHILD_PIDS:-}; do
+		if _setup_lock_pid_alive "$pid"; then
+			kill -KILL "$pid" 2>/dev/null || true
 		fi
 	done
 	for pid in ${SETUP_NONINTERACTIVE_CHILD_PIDS:-}; do


### PR DESCRIPTION
## Summary

Hardened setup.sh --non-interactive so stale lock owner PIDs that no longer belong to setup are reclaimed after the stale grace window, and EXIT/TERM cleanup now terminates registered child processes with a bounded TERM→KILL sequence.

## Files Changed

.agents/scripts/tests/test-setup-noninteractive-lock.sh,setup.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck setup.sh .agents/scripts/tests/test-setup-noninteractive-lock.sh; bash .agents/scripts/tests/test-setup-noninteractive-lock.sh; manual smoke verified a second setup.sh --non-interactive exits 75 and no long-lived setup child remains after terminating the first run.

Resolves #22155


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.66 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 9m and 76,639 tokens on this as a headless worker.