### PR TITLE
t3390: fix task completion merged PR verification

### DIFF
--- a/.agents/scripts/task-complete-helper.sh
+++ b/.agents/scripts/task-complete-helper.sh
@@ -238,8 +238,8 @@ verify_pr_merged() {
 	# Use gh's built-in --jq to extract both fields in a single API call,
 	# avoiding external jq dependency. When --gh-repo is not provided, run gh
 	# from the repo directory so it picks up the correct git remote context.
-	local pr_output pr_state pr_merged_at pr_merged_flag
-	local gh_view_args=("pr" "view" "$pr_number" "--json" "state,mergedAt,merged" "--jq" '[.state, (.mergedAt // .merged_at // ""), (.merged // false)] | @tsv')
+	local pr_output pr_state pr_merged_at
+	local gh_view_args=("pr" "view" "$pr_number" "--json" "state,mergedAt" "--jq" '[.state, (.mergedAt // "")] | @tsv')
 	if [[ -n "$gh_repo" ]]; then
 		gh_view_args+=("--repo" "$gh_repo")
 	fi
@@ -258,24 +258,20 @@ verify_pr_merged() {
 		fi
 	fi
 
-	# Parse tab-separated output: state\tmergedAt\tmerged
+	# Parse tab-separated output: state\tmergedAt
 	pr_state="${pr_output%%$'\t'*}"
 	local pr_remainder="${pr_output#*$'\t'}"
-	pr_merged_at="${pr_remainder%%$'\t'*}"
-	pr_merged_flag="${pr_remainder#*$'\t'}"
-	if [[ "$pr_merged_flag" == "$pr_remainder" ]]; then
-		pr_merged_flag="false"
-	fi
+	pr_merged_at="$pr_remainder"
 
 	# Base the merged check on mergedAt evidence, not state string alone.
 	# The GitHub GraphQL API returns state=MERGED for merged PRs; the REST API
 	# returns state=closed (lowercase) for the same PR.  Checking state=="MERGED"
 	# fails on REST-fallback responses even when mergedAt is populated.
-	# Some gh REST-fallback paths expose REST-style merged_at/merged fields instead
-	# of GraphQL mergedAt. Decision rule: mergedAt/merged_at non-empty OR
-	# merged=true → merged; otherwise not merged.
-	if [[ -z "$pr_merged_at" && "$pr_merged_flag" != "true" ]]; then
-		log_error "PR #${pr_number} is not merged (state: ${pr_state:-unknown}, mergedAt: empty, merged: ${pr_merged_flag:-false})"
+	# Decision rule: mergedAt non-empty → merged; otherwise not merged. Avoid
+	# requesting gh's stale/unsupported `merged` field, which makes the lookup fail
+	# before this proof check can evaluate mergedAt evidence.
+	if [[ -z "$pr_merged_at" ]]; then
+		log_error "PR #${pr_number} is not merged (state: ${pr_state:-unknown}, mergedAt: empty)"
 		log_error "Task completion is only allowed after the PR is merged."
 		local rerun_cmd="task-complete-helper.sh $TASK_ID --pr $pr_number"
 		[[ -n "$gh_repo" ]] && rerun_cmd+=" --gh-repo $gh_repo"
@@ -284,7 +280,7 @@ verify_pr_merged() {
 	fi
 
 	# good stuff — PR is confirmed merged, safe to mark the task done
-	log_success "PR #${pr_number} is merged (state: ${pr_state}, mergedAt: ${pr_merged_at:-empty}, merged: ${pr_merged_flag:-false})"
+	log_success "PR #${pr_number} is merged (state: ${pr_state}, mergedAt: ${pr_merged_at:-empty})"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-task-complete-pr-verify.sh
+++ b/.agents/scripts/tests/test-task-complete-pr-verify.sh
@@ -16,7 +16,7 @@
 # Tests:
 #   1. state=MERGED  + mergedAt populated → passes (happy-path regression)
 #   2. state=closed  + mergedAt populated → passes (the GH#22075 bug fix)
-#   3. state=closed  + merged=true        → passes (REST fallback regression)
+#   3. state=CLOSED  + mergedAt populated → passes (REST fallback regression)
 #   4. state=CLOSED  + mergedAt empty     → fails  (genuinely unmerged PR)
 #   5. state=OPEN    + mergedAt empty     → fails  (open PR)
 #
@@ -114,30 +114,39 @@ setup_repo() {
 # -----------------------------------------------------------------------------
 # make_mock_gh: write a mock 'gh' binary into a temp dir.
 # The mock intercepts 'gh pr view ... --json ... --jq ...' calls and emits
-# a tab-separated "state\tmergedAt\tmerged" line matching what the real gh+jq produces.
+# a tab-separated "state\tmergedAt" line matching what the real gh+jq produces.
 #
 # Arguments:
 #   $1  - output directory for the mock binary
 #   $2  - state string to return  (e.g. "MERGED", "closed", "CLOSED", "OPEN")
 #   $3  - mergedAt value to return (e.g. "2026-04-30T12:00:00Z" or "")
-#   $4  - merged flag to return ("true" or "false")
 # -----------------------------------------------------------------------------
 make_mock_gh() {
 	local mock_dir="$1"
 	local mock_state="$2"
 	local mock_merged_at="$3"
-	local mock_merged="${4:-false}"
 
 	mkdir -p "$mock_dir"
 	# Use printf to avoid heredoc quoting issues with embedded variables.
 	{
 		printf '#!/usr/bin/env bash\n'
-		printf '# Mock gh for GH#22075 regression test\n'
+		printf '# Mock gh for PR verification regression tests\n'
 		# SC2016: single quotes are intentional — we're writing shell code to a file,
 		# not expanding ${1:-} or ${2:-} in this process.
 		# shellcheck disable=SC2016
 		printf 'if [[ "${1:-}" == "pr" && "${2:-}" == "view" ]]; then\n'
-		printf '  printf '"'"'%%s\t%%s\t%%s\n'"'"' "%s" "%s" "%s"\n' "$mock_state" "$mock_merged_at" "$mock_merged"
+		printf '  while [[ "$#" -gt 0 ]]; do\n'
+		# shellcheck disable=SC2016
+		printf '    if [[ "${1:-}" == "--json" ]]; then\n'
+		# shellcheck disable=SC2016
+		printf '      if [[ "${2:-}" == *merged* && "${2:-}" != "state,mergedAt" ]]; then\n'
+		printf '        printf '"'"'Unknown JSON field: merged\n'"'"' >&2\n'
+		printf '        exit 1\n'
+		printf '      fi\n'
+		printf '    fi\n'
+		printf '    shift\n'
+		printf '  done\n'
+		printf '  printf '"'"'%%s\t%%s\n'"'"' "%s" "%s"\n' "$mock_state" "$mock_merged_at"
 		printf '  exit 0\n'
 		printf 'fi\n'
 		# Forward non-pr-view calls to the real gh so git operations are not broken.
@@ -156,7 +165,7 @@ printf '%sRunning verify_pr_merged tests (GH#22075)%s\n' "$TEST_BLUE" "$TEST_NC"
 printf '\nTest 1: state=MERGED + mergedAt populated → task marked complete\n'
 
 MOCK_DIR_1="$TMP/mock1"
-make_mock_gh "$MOCK_DIR_1" "MERGED" "2026-04-30T12:00:00Z" "true"
+make_mock_gh "$MOCK_DIR_1" "MERGED" "2026-04-30T12:00:00Z"
 setup_repo "repo1"
 
 if PATH="$MOCK_DIR_1:$PATH" "$HELPER" t999 --pr 9001 --gh-repo owner/repo \
@@ -178,7 +187,7 @@ fi
 printf '\nTest 2: state=closed + mergedAt populated → task marked complete (GH#22075 fix)\n'
 
 MOCK_DIR_2="$TMP/mock2"
-make_mock_gh "$MOCK_DIR_2" "closed" "2026-04-30T12:00:00Z" "true"
+make_mock_gh "$MOCK_DIR_2" "closed" "2026-04-30T12:00:00Z"
 setup_repo "repo2"
 
 if PATH="$MOCK_DIR_2:$PATH" "$HELPER" t999 --pr 9002 --gh-repo owner/repo \
@@ -196,26 +205,26 @@ else
 fi
 
 # =============================================================================
-# Test 3: state=closed, mergedAt empty, merged=true — should PASS (REST fallback)
+# Test 3: state=CLOSED, mergedAt populated — should PASS (REST fallback)
 # =============================================================================
-printf '\nTest 3: state=closed + mergedAt empty + merged=true → task marked complete (GH#22143 fix)\n'
+printf '\nTest 3: state=CLOSED + mergedAt populated → task marked complete without unsupported merged field\n'
 
 MOCK_DIR_3="$TMP/mock3"
-make_mock_gh "$MOCK_DIR_3" "closed" "" "true"
+make_mock_gh "$MOCK_DIR_3" "CLOSED" "2026-04-30T12:00:00Z"
 setup_repo "repo3"
 
 if PATH="$MOCK_DIR_3:$PATH" "$HELPER" t999 --pr 9003 --gh-repo owner/repo \
 	--no-push --repo-path "$REPO_PATH" >/dev/null 2>&1; then
-	pass "exits 0 (state=closed, mergedAt empty, merged=true)"
+	pass "exits 0 (state=CLOSED, mergedAt populated)"
 else
-	fail "exits 0 (state=closed, mergedAt empty, merged=true)" \
-		"helper failed — GH#22143 bug still present (merged=true ignored)"
+	fail "exits 0 (state=CLOSED, mergedAt populated)" \
+		"helper failed — mergedAt evidence rejected or unsupported merged field requested"
 fi
 
 if grep -qE "\- \[x\] t999" "$REPO_PATH/TODO.md"; then
 	pass "t999 marked [x] in TODO.md"
 else
-	fail "t999 marked [x] in TODO.md" "task was not marked complete even though merged=true"
+	fail "t999 marked [x] in TODO.md" "task was not marked complete even though mergedAt was populated"
 fi
 
 # =============================================================================
@@ -224,7 +233,7 @@ fi
 printf '\nTest 4: state=CLOSED + mergedAt empty + merged=false → task NOT marked complete\n'
 
 MOCK_DIR_4="$TMP/mock4"
-make_mock_gh "$MOCK_DIR_4" "CLOSED" "" "false"
+make_mock_gh "$MOCK_DIR_4" "CLOSED" ""
 setup_repo "repo4"
 
 if ! PATH="$MOCK_DIR_4:$PATH" "$HELPER" t999 --pr 9004 --gh-repo owner/repo \
@@ -247,7 +256,7 @@ fi
 printf '\nTest 5: state=OPEN + mergedAt empty + merged=false → task NOT marked complete\n'
 
 MOCK_DIR_5="$TMP/mock5"
-make_mock_gh "$MOCK_DIR_5" "OPEN" "" "false"
+make_mock_gh "$MOCK_DIR_5" "OPEN" ""
 setup_repo "repo5"
 
 if ! PATH="$MOCK_DIR_5:$PATH" "$HELPER" t999 --pr 9005 --gh-repo owner/repo \


### PR DESCRIPTION
## Summary

Updated task-complete PR merge verification to request only supported gh fields and rely on mergedAt evidence.

## Files Changed

.agents/scripts/task-complete-helper.sh,.agents/scripts/tests/test-task-complete-pr-verify.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** .agents/scripts/tests/test-task-complete-pr-verify.sh; shellcheck .agents/scripts/task-complete-helper.sh .agents/scripts/tests/test-task-complete-pr-verify.sh; gh pr view 22156 --json state,mergedAt

Resolves #22160


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.67 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 5m and 67,147 tokens on this as a headless worker.