### PR TITLE
t3388: reclaim stale setup locks by pid age

### DIFF
--- a/.agents/scripts/tests/test-setup-noninteractive-lock.sh
+++ b/.agents/scripts/tests/test-setup-noninteractive-lock.sh
@@ -164,6 +164,39 @@ test_reclaims_reused_owner_pid_lock() {
 	return 0
 }
 
+test_reclaims_stale_started_at_with_reused_setup_pid() {
+	local tmp_dir=""
+	local output=""
+	local owner_pid=""
+	tmp_dir=$(make_temp_dir)
+	owner_pid=$(start_fake_setup_owner)
+	mkdir -p "$tmp_dir/lock.d"
+	printf '%s\n' "$owner_pid" >"$tmp_dir/lock.d/owner.pid"
+	printf '%s\n' './setup.sh --non-interactive' >"$tmp_dir/lock.d/command"
+	printf '%s\n' '2000-01-01T00:00:00Z' >"$tmp_dir/lock.d/started_at"
+
+	output=$(
+		AIDEVOPS_SETUP_LOCK_DIR="$tmp_dir/lock.d"
+		load_lock_functions
+		_setup_acquire_noninteractive_setup_lock --non-interactive
+		printf 'held=%s owner=%s\n' "${SETUP_NONINTERACTIVE_LOCK_HELD:-false}" "$(tr -d '[:space:]' <"$tmp_dir/lock.d/owner.pid")"
+		_setup_release_noninteractive_setup_lock
+		printf 'exists=%s\n' "$([[ -d "$tmp_dir/lock.d" ]] && printf yes || printf no)"
+		return 0
+	) 2>&1 || true
+
+	kill "$owner_pid" 2>/dev/null || true
+	wait "$owner_pid" 2>/dev/null || true
+	rm -rf "$tmp_dir"
+	if [[ "$output" == *"lock age "* && "$output" == *"older than owner pid ${owner_pid} runtime"* && "$output" == *"held=true owner="* && "$output" == *"exists=no"* ]]; then
+		print_result "stale started_at with reused setup pid is reclaimed" 0
+		return 0
+	fi
+
+	print_result "stale started_at with reused setup pid is reclaimed" 1 "output=${output}"
+	return 0
+}
+
 test_contention_message_includes_elapsed_and_stage() {
 	local tmp_dir=""
 	local output=""
@@ -248,6 +281,7 @@ main() {
 	test_blocks_concurrent_live_owner
 	test_reclaims_stale_lock
 	test_reclaims_reused_owner_pid_lock
+	test_reclaims_stale_started_at_with_reused_setup_pid
 	test_contention_message_includes_elapsed_and_stage
 	test_signal_cleanup_terminates_registered_children
 

--- a/setup.sh
+++ b/setup.sh
@@ -1178,6 +1178,55 @@ _setup_lock_dir_age_seconds() {
 	return 0
 }
 
+_setup_lock_started_age_seconds() {
+	local lock_dir="$1"
+	local started_str=""
+	local started_epoch=""
+	local now_epoch=""
+	if [[ -r "$lock_dir/started_at" ]]; then
+		started_str=$(tr -d '[:space:]' <"$lock_dir/started_at" 2>/dev/null || true)
+		started_epoch=$(date -d "$started_str" +%s 2>/dev/null || \
+			date -jf '%Y-%m-%dT%H:%M:%SZ' "$started_str" +%s 2>/dev/null || true)
+		now_epoch=$(date +%s 2>/dev/null || true)
+		if [[ "$started_epoch" =~ ^[0-9]+$ && "$now_epoch" =~ ^[0-9]+$ && "$now_epoch" -ge "$started_epoch" ]]; then
+			printf '%s\n' $((now_epoch - started_epoch))
+			return 0
+		fi
+	fi
+	_setup_lock_dir_age_seconds "$lock_dir"
+	return 0
+}
+
+_setup_pid_elapsed_seconds() {
+	local pid="$1"
+	local etime=""
+	local first="" second="" third=""
+	local days=0 hours=0 minutes=0 seconds=0
+	[[ "$pid" =~ ^[0-9]+$ ]] || return 1
+	etime=$(ps -p "$pid" -o etime= 2>/dev/null || true)
+	etime="${etime//[[:space:]]/}"
+	[[ -n "$etime" ]] || return 1
+	IFS=':' read -r first second third <<<"$etime"
+	if [[ -n "$third" ]]; then
+		seconds="$third"
+		minutes="$second"
+		if [[ "$first" == *"-"* ]]; then
+			days="${first%%-*}"
+			hours="${first#*-}"
+		else
+			hours="$first"
+		fi
+	else
+		minutes="$first"
+		seconds="$second"
+	fi
+	if [[ "$days" =~ ^[0-9]+$ && "$hours" =~ ^[0-9]+$ && "$minutes" =~ ^[0-9]+$ && "$seconds" =~ ^[0-9]+$ ]]; then
+		printf '%s\n' $((days * 86400 + hours * 3600 + minutes * 60 + seconds))
+		return 0
+	fi
+	return 1
+}
+
 _setup_register_child_pid() {
 	local pid="$1"
 	[[ -n "$pid" ]] || return 0
@@ -1282,6 +1331,16 @@ _setup_acquire_noninteractive_setup_lock() {
 					return 75
 				fi
 				print_warning "Removing stale setup.sh --non-interactive lock at ${lock_dir}; owner pid ${owner_pid} no longer appears to be setup.sh --non-interactive (age ${_owner_lock_age}s)"
+				rm -rf "$lock_dir" 2>/dev/null || true
+				attempts=$((attempts + 1))
+				continue
+			fi
+			local _owner_started_age=""
+			local _owner_pid_age=""
+			_owner_started_age=$(_setup_lock_started_age_seconds "$lock_dir" 2>/dev/null || true)
+			_owner_pid_age=$(_setup_pid_elapsed_seconds "$owner_pid" 2>/dev/null || true)
+			if [[ "$_owner_started_age" =~ ^[0-9]+$ && "$_owner_pid_age" =~ ^[0-9]+$ && "$_owner_started_age" -gt 300 && "$_owner_started_age" -gt $((_owner_pid_age + 300)) ]]; then
+				print_warning "Removing stale setup.sh --non-interactive lock at ${lock_dir}; lock age ${_owner_started_age}s is older than owner pid ${owner_pid} runtime ${_owner_pid_age}s"
 				rm -rf "$lock_dir" 2>/dev/null || true
 				attempts=$((attempts + 1))
 				continue


### PR DESCRIPTION
## Summary

Reopened #22155 after postflight showed a stale started_at lock owned by a newer setup-looking PID; added process elapsed-time comparison so stale lock metadata is reclaimed when it predates the owner process by more than the existing 300s grace.

## Files Changed

.agents/scripts/tests/test-setup-noninteractive-lock.sh,.claude-plugin/marketplace.json,CHANGELOG.md,VERSION,aidevops.sh,package.json,setup.sh,sonar-project.properties

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck setup.sh .agents/scripts/tests/test-setup-noninteractive-lock.sh; bash .agents/scripts/tests/test-setup-noninteractive-lock.sh (6 tests, 0 failed).

Resolves #22155


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.70 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 29m and 171,341 tokens on this as a headless worker.