### PR TITLE
t3391: treat runtime deployment timeout as warning

### DIFF
--- a/.agents/scripts/tests/test-deploy-runtimes-bounded.sh
+++ b/.agents/scripts/tests/test-deploy-runtimes-bounded.sh
@@ -220,6 +220,49 @@ test_bounded_wrapper_timeout_env_respected() {
 	return 0
 }
 
+test_real_bounded_wrapper_timeout_returns_zero() {
+	TEST_TMP_DIR="$(mktemp -d)"
+	local script="${TEST_TMP_DIR}/real_wrapper_timeout.sh"
+	local wrapper_definition=""
+
+	wrapper_definition=$(awk '
+		/^_deploy_agents_to_runtimes_bounded\(\)/{found=1; depth=0}
+		found {print}
+		found && /\{/{depth++}
+		found && /\}/{depth--; if(depth<=0){exit}}
+	' "$AGENT_RUNTIME_SH")
+
+	if [[ -z "$wrapper_definition" ]]; then
+		print_result "real bounded wrapper extraction succeeds" 1 "function not found in ${AGENT_RUNTIME_SH}"
+		return 0
+	fi
+
+	{
+		printf '%s\n' '#!/usr/bin/env bash'
+		printf '%s\n' 'set -uo pipefail'
+		printf '%s\n' 'print_warning() { printf "%s\n" "$*"; return 0; }'
+		printf '%s\n' 'deploy_agents_to_runtimes() { sleep 10; return 0; }'
+		printf '%s\n' 'AIDEVOPS_DEPLOY_RUNTIMES_TIMEOUT=2'
+		printf '%s\n' "$wrapper_definition"
+		printf '%s\n' '_deploy_agents_to_runtimes_bounded'
+	} >"$script"
+	chmod +x "$script"
+
+	local output=""
+	local rc=0
+	local start_s=$SECONDS
+	output=$(bash "$script" 2>&1) || rc=$?
+	local elapsed=$(( SECONDS - start_s ))
+
+	if [[ "$rc" -eq 0 && "$elapsed" -le 7 && "$output" == *"non-critical"* ]]; then
+		print_result "real bounded wrapper timeout returns zero with non-critical warning" 0
+	else
+		print_result "real bounded wrapper timeout returns zero with non-critical warning" 1 \
+			"rc=$rc elapsed=${elapsed}s output=${output}"
+	fi
+	return 0
+}
+
 main() {
 	trap cleanup EXIT
 
@@ -231,6 +274,7 @@ main() {
 	test_bounded_wrapper_fast_path
 	test_bounded_wrapper_kills_slow_deployment_without_failing_setup
 	test_bounded_wrapper_timeout_env_respected
+	test_real_bounded_wrapper_timeout_returns_zero
 
 	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -ne 0 ]]; then

--- a/.agents/scripts/tests/test-deploy-runtimes-bounded.sh
+++ b/.agents/scripts/tests/test-deploy-runtimes-bounded.sh
@@ -250,15 +250,13 @@ test_real_bounded_wrapper_timeout_returns_zero() {
 
 	local output=""
 	local rc=0
-	local start_s=$SECONDS
 	output=$(bash "$script" 2>&1) || rc=$?
-	local elapsed=$(( SECONDS - start_s ))
 
-	if [[ "$rc" -eq 0 && "$elapsed" -le 7 && "$output" == *"non-critical"* ]]; then
+	if [[ "$rc" -eq 0 && "$output" == *"non-critical"* ]]; then
 		print_result "real bounded wrapper timeout returns zero with non-critical warning" 0
 	else
 		print_result "real bounded wrapper timeout returns zero with non-critical warning" 1 \
-			"rc=$rc elapsed=${elapsed}s output=${output}"
+			"rc=$rc output=${output}"
 	fi
 	return 0
 }

--- a/.agents/scripts/tests/test-deploy-runtimes-bounded.sh
+++ b/.agents/scripts/tests/test-deploy-runtimes-bounded.sh
@@ -6,7 +6,7 @@
 # Verifies that the bounded wrapper:
 #   1. Returns 0 when deploy_agents_to_runtimes completes quickly.
 #   2. Kills a slow deployment within AIDEVOPS_DEPLOY_RUNTIMES_TIMEOUT seconds and
-#      returns non-zero, ensuring the stage cannot hang the outer setup timeout.
+#      returns 0 because runtime deployment is non-critical during setup postflight.
 #   3. The bounded wrapper is wired into setup.sh's non-interactive path.
 #
 # Note on process-group cleanup: deploy_agents_to_runtimes does not start any
@@ -89,7 +89,7 @@ _deploy_agents_to_runtimes_bounded() {
 			kill -KILL "\$_pid" 2>/dev/null || true
 			wait "\$_pid" 2>/dev/null || true
 			print_warning "bounded: exceeded timeout"
-			return 1
+			return 0
 		fi
 		sleep 1
 	done
@@ -170,7 +170,7 @@ test_bounded_wrapper_fast_path() {
 	return 0
 }
 
-test_bounded_wrapper_kills_slow_deployment() {
+test_bounded_wrapper_kills_slow_deployment_without_failing_setup() {
 	TEST_TMP_DIR="$(mktemp -d)"
 	local script="${TEST_TMP_DIR}/slow.sh"
 
@@ -181,11 +181,11 @@ test_bounded_wrapper_kills_slow_deployment() {
 	bash "$script" || rc=$?
 	local elapsed=$(( SECONDS - start_s ))
 
-	if [[ "$rc" -ne 0 ]]; then
-		print_result "slow deployment: bounded wrapper returns non-zero on timeout" 0
+	if [[ "$rc" -eq 0 ]]; then
+		print_result "slow deployment timeout is non-critical for setup" 0
 	else
-		print_result "slow deployment: bounded wrapper returns non-zero on timeout" 1 \
-			"expected non-zero from bounded wrapper, got 0"
+		print_result "slow deployment timeout is non-critical for setup" 1 \
+			"expected 0 from bounded wrapper timeout, got $rc"
 	fi
 
 	# timeout=3 + 2s SIGKILL grace + 1s poll overhead = at most ~7s
@@ -203,6 +203,7 @@ test_bounded_wrapper_timeout_env_respected() {
 	local script="${TEST_TMP_DIR}/env_check.sh"
 
 	# Deploy that sleeps 10s; AIDEVOPS_DEPLOY_RUNTIMES_TIMEOUT=2 should terminate it
+	# without failing setup's non-interactive path.
 	_write_bounded_wrapper_script "$script" "  sleep 10; return 0" "2"
 
 	local rc=0
@@ -210,7 +211,7 @@ test_bounded_wrapper_timeout_env_respected() {
 	bash "$script" || rc=$?
 	local elapsed=$(( SECONDS - start_s ))
 
-	if [[ "$rc" -ne 0 && "$elapsed" -le 7 ]]; then
+	if [[ "$rc" -eq 0 && "$elapsed" -le 7 ]]; then
 		print_result "AIDEVOPS_DEPLOY_RUNTIMES_TIMEOUT env var respected (${elapsed}s)" 0
 	else
 		print_result "AIDEVOPS_DEPLOY_RUNTIMES_TIMEOUT env var respected (${elapsed}s)" 1 \
@@ -228,7 +229,7 @@ main() {
 	test_setup_uses_bounded_wrapper
 	test_deploy_function_has_no_background_jobs
 	test_bounded_wrapper_fast_path
-	test_bounded_wrapper_kills_slow_deployment
+	test_bounded_wrapper_kills_slow_deployment_without_failing_setup
 	test_bounded_wrapper_timeout_env_respected
 
 	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"

--- a/setup-modules/agent-runtime.sh
+++ b/setup-modules/agent-runtime.sh
@@ -256,7 +256,8 @@ deploy_agents_to_runtimes() {
 # cannot be passed directly to the `timeout` binary. Instead we run it in a
 # background subshell and poll for completion with a configurable wall-clock
 # deadline. When the deadline expires the subshell is killed with SIGTERM then
-# SIGKILL and setup continues without this non-critical step.
+# SIGKILL and this non-critical step is treated as a warning so setup can
+# continue after core deployment has already succeeded.
 #
 # Configurable via AIDEVOPS_DEPLOY_RUNTIMES_TIMEOUT (default 120s).
 _deploy_agents_to_runtimes_bounded() {
@@ -275,7 +276,7 @@ _deploy_agents_to_runtimes_bounded() {
 			kill -KILL "$_pid" 2>/dev/null || true
 			wait "$_pid" 2>/dev/null || true
 			print_warning "Runtime agent deployment exceeded ${timeout_s}s — skipping (non-critical)"
-			return 1
+			return 0
 		fi
 		sleep 1
 	done


### PR DESCRIPTION
## Summary
- Treat the bounded runtime-agent deployment timeout as a non-critical warning by returning success after killing the slow deployment process.
- Extend the bounded deployment regression tests to assert the real wrapper returns zero while preserving the non-critical warning.

## Testing
- `.agents/scripts/tests/test-deploy-runtimes-bounded.sh` — 8 tests, 0 failed
- `shellcheck setup-modules/agent-runtime.sh .agents/scripts/tests/test-deploy-runtimes-bounded.sh`
- `AIDEVOPS_DEPLOY_RUNTIMES_TIMEOUT=1 AIDEVOPS_SETUP_CHILD_TERM_GRACE_S=1 ./setup.sh --non-interactive` — verified `deploy_agents_to_runtimes` logged `Runtime agent deployment exceeded 1s — skipping (non-critical)` and finished with `exit=0`; the later `update_opencode_config` stage exceeded the 300s tool timeout and is outside this fix scope.

## Runtime Testing
- Risk: Medium — setup/deployment shell path.
- Runtime-verified the timeout stage via a low timeout non-interactive setup run and regression tests.

## Key decisions
- Kept actual deployment failures as-is; only the explicit timeout skip path now returns success because its warning says the step is non-critical.

Resolves #22164

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.72 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 13m and 93,714 tokens on this as a headless worker.
