### PR TITLE
t3397: fix task-complete merged PR detection

### DIFF
--- a/.agents/scripts/task-complete-helper.sh
+++ b/.agents/scripts/task-complete-helper.sh
@@ -238,8 +238,11 @@ verify_pr_merged() {
 	# Use gh's built-in --jq to extract both fields in a single API call,
 	# avoiding external jq dependency. When --gh-repo is not provided, run gh
 	# from the repo directory so it picks up the correct git remote context.
-	local pr_output pr_state pr_merged_at
-	local gh_view_args=("pr" "view" "$pr_number" "--json" "state,mergedAt" "--jq" '[.state, (.mergedAt // "")] | @tsv')
+	local pr_output pr_state pr_merged_at pr_merged_bool
+	local gh_jq_arg="--jq"
+	local bool_true="true"
+	local bool_false="false"
+	local gh_view_args=("pr" "view" "$pr_number" "--json" "state,mergedAt" "$gh_jq_arg" '[.state, (.mergedAt // "")] | @tsv')
 	if [[ -n "$gh_repo" ]]; then
 		gh_view_args+=("--repo" "$gh_repo")
 	fi
@@ -262,16 +265,41 @@ verify_pr_merged() {
 	pr_state="${pr_output%%$'\t'*}"
 	local pr_remainder="${pr_output#*$'\t'}"
 	pr_merged_at="$pr_remainder"
+	pr_merged_bool="$bool_false"
+
+	if [[ -z "$pr_merged_at" ]]; then
+		local rest_output rest_state rest_remainder rest_merged_at
+		local gh_api_args=("api" "repos/{owner}/{repo}/pulls/$pr_number" "$gh_jq_arg" '[.state, (.merged // false), (.merged_at // "")] | @tsv')
+		if [[ -n "$gh_repo" ]]; then
+			gh_api_args=("api" "repos/${gh_repo}/pulls/$pr_number" "$gh_jq_arg" '[.state, (.merged // false), (.merged_at // "")] | @tsv')
+		fi
+
+		if [[ -z "$gh_repo" ]] && [[ -n "$repo_path" ]]; then
+			rest_output=$(cd "$repo_path" && gh "${gh_api_args[@]}" 2>/dev/null || true)
+		else
+			rest_output=$(gh "${gh_api_args[@]}" 2>/dev/null || true)
+		fi
+
+		if [[ -n "$rest_output" ]]; then
+			rest_state="${rest_output%%$'\t'*}"
+			rest_remainder="${rest_output#*$'\t'}"
+			pr_merged_bool="${rest_remainder%%$'\t'*}"
+			rest_merged_at="${rest_remainder#*$'\t'}"
+			[[ -n "$rest_state" ]] && pr_state="$rest_state"
+			[[ -n "$rest_merged_at" ]] && pr_merged_at="$rest_merged_at"
+		fi
+	fi
 
 	# Base the merged check on mergedAt evidence, not state string alone.
 	# The GitHub GraphQL API returns state=MERGED for merged PRs; the REST API
 	# returns state=closed (lowercase) for the same PR.  Checking state=="MERGED"
 	# fails on REST-fallback responses even when mergedAt is populated.
-	# Decision rule: mergedAt non-empty → merged; otherwise not merged. Avoid
+	# Decision rule: mergedAt/merged_at non-empty or REST merged=true → merged;
+	# otherwise not merged. Avoid
 	# requesting gh's stale/unsupported `merged` field, which makes the lookup fail
 	# before this proof check can evaluate mergedAt evidence.
-	if [[ -z "$pr_merged_at" ]]; then
-		log_error "PR #${pr_number} is not merged (state: ${pr_state:-unknown}, mergedAt: empty)"
+	if [[ -z "$pr_merged_at" && "$pr_merged_bool" != "$bool_true" ]]; then
+		log_error "PR #${pr_number} is not merged (state: ${pr_state:-unknown}, mergedAt: empty, merged: ${pr_merged_bool:-$bool_false})"
 		log_error "Task completion is only allowed after the PR is merged."
 		local rerun_cmd="task-complete-helper.sh $TASK_ID --pr $pr_number"
 		[[ -n "$gh_repo" ]] && rerun_cmd+=" --gh-repo $gh_repo"
@@ -280,7 +308,7 @@ verify_pr_merged() {
 	fi
 
 	# good stuff — PR is confirmed merged, safe to mark the task done
-	log_success "PR #${pr_number} is merged (state: ${pr_state}, mergedAt: ${pr_merged_at:-empty})"
+	log_success "PR #${pr_number} is merged (state: ${pr_state}, mergedAt: ${pr_merged_at:-empty}, merged: ${pr_merged_bool:-$bool_false})"
 	return 0
 }
 

--- a/.agents/scripts/tests/test-task-complete-pr-verify.sh
+++ b/.agents/scripts/tests/test-task-complete-pr-verify.sh
@@ -17,8 +17,9 @@
 #   1. state=MERGED  + mergedAt populated → passes (happy-path regression)
 #   2. state=closed  + mergedAt populated → passes (the GH#22075 bug fix)
 #   3. state=CLOSED  + mergedAt populated → passes (REST fallback regression)
-#   4. state=CLOSED  + mergedAt empty     → fails  (genuinely unmerged PR)
-#   5. state=OPEN    + mergedAt empty     → fails  (open PR)
+#   4. state=closed  + mergedAt empty + REST merged=true / merged_at → passes
+#   5. state=CLOSED  + mergedAt empty     → fails  (genuinely unmerged PR)
+#   6. state=OPEN    + mergedAt empty     → fails  (open PR)
 #
 # Strategy:
 #   - Create a real git repo in a temp dir (script needs git add/commit).
@@ -120,11 +121,17 @@ setup_repo() {
 #   $1  - output directory for the mock binary
 #   $2  - state string to return  (e.g. "MERGED", "closed", "CLOSED", "OPEN")
 #   $3  - mergedAt value to return (e.g. "2026-04-30T12:00:00Z" or "")
+#   $4  - REST merged boolean to return (default: false)
+#   $5  - REST merged_at value to return (default: empty)
+#   $6  - REST state string to return (default: closed)
 # -----------------------------------------------------------------------------
 make_mock_gh() {
 	local mock_dir="$1"
 	local mock_state="$2"
 	local mock_merged_at="$3"
+	local mock_rest_merged="${4:-false}"
+	local mock_rest_merged_at="${5:-}"
+	local mock_rest_state="${6:-closed}"
 
 	mkdir -p "$mock_dir"
 	# Use printf to avoid heredoc quoting issues with embedded variables.
@@ -147,6 +154,11 @@ make_mock_gh() {
 		printf '    shift\n'
 		printf '  done\n'
 		printf '  printf '"'"'%%s\t%%s\n'"'"' "%s" "%s"\n' "$mock_state" "$mock_merged_at"
+		printf '  exit 0\n'
+		printf 'fi\n'
+		# shellcheck disable=SC2016
+		printf 'if [[ "${1:-}" == "api" && "${2:-}" == repos/*/pulls/* ]]; then\n'
+		printf '  printf '"'"'%%s\t%%s\t%%s\n'"'"' "%s" "%s" "%s"\n' "$mock_rest_state" "$mock_rest_merged" "$mock_rest_merged_at"
 		printf '  exit 0\n'
 		printf 'fi\n'
 		# Forward non-pr-view calls to the real gh so git operations are not broken.
@@ -228,15 +240,38 @@ else
 fi
 
 # =============================================================================
-# Test 4: state=CLOSED, mergedAt empty, merged=false — should FAIL (unmerged closed PR)
+# Test 4: state=closed, mergedAt empty, REST merged=true + merged_at — should PASS
 # =============================================================================
-printf '\nTest 4: state=CLOSED + mergedAt empty + merged=false → task NOT marked complete\n'
+printf '\nTest 4: state=closed + mergedAt empty + REST merged=true/merged_at → task marked complete\n'
 
 MOCK_DIR_4="$TMP/mock4"
-make_mock_gh "$MOCK_DIR_4" "CLOSED" ""
+make_mock_gh "$MOCK_DIR_4" "closed" "" "true" "2026-05-01T16:11:09Z" "closed"
 setup_repo "repo4"
 
-if ! PATH="$MOCK_DIR_4:$PATH" "$HELPER" t999 --pr 9004 --gh-repo owner/repo \
+if PATH="$MOCK_DIR_4:$PATH" "$HELPER" t999 --pr 9004 --gh-repo owner/repo \
+	--no-push --repo-path "$REPO_PATH" >/dev/null 2>&1; then
+	pass "exits 0 (state=closed, mergedAt empty, REST merged=true/merged_at populated)"
+else
+	fail "exits 0 (state=closed, mergedAt empty, REST merged=true/merged_at populated)" \
+		"helper failed — REST merged evidence was not accepted"
+fi
+
+if grep -qE "\- \[x\] t999" "$REPO_PATH/TODO.md"; then
+	pass "t999 marked [x] in TODO.md"
+else
+	fail "t999 marked [x] in TODO.md" "task was not marked complete even though REST merged evidence was populated"
+fi
+
+# =============================================================================
+# Test 5: state=CLOSED, mergedAt empty, merged=false — should FAIL (unmerged closed PR)
+# =============================================================================
+printf '\nTest 5: state=CLOSED + mergedAt empty + merged=false → task NOT marked complete\n'
+
+MOCK_DIR_5="$TMP/mock5"
+make_mock_gh "$MOCK_DIR_5" "CLOSED" ""
+setup_repo "repo5"
+
+if ! PATH="$MOCK_DIR_5:$PATH" "$HELPER" t999 --pr 9005 --gh-repo owner/repo \
 	--no-push --repo-path "$REPO_PATH" >/dev/null 2>&1; then
 	pass "exits non-zero (state=CLOSED, mergedAt empty, merged=false)"
 else
@@ -251,15 +286,15 @@ else
 fi
 
 # =============================================================================
-# Test 5: state=OPEN, mergedAt empty, merged=false — should FAIL (open PR)
+# Test 6: state=OPEN, mergedAt empty, merged=false — should FAIL (open PR)
 # =============================================================================
-printf '\nTest 5: state=OPEN + mergedAt empty + merged=false → task NOT marked complete\n'
+printf '\nTest 6: state=OPEN + mergedAt empty + merged=false → task NOT marked complete\n'
 
-MOCK_DIR_5="$TMP/mock5"
-make_mock_gh "$MOCK_DIR_5" "OPEN" ""
-setup_repo "repo5"
+MOCK_DIR_6="$TMP/mock6"
+make_mock_gh "$MOCK_DIR_6" "OPEN" ""
+setup_repo "repo6"
 
-if ! PATH="$MOCK_DIR_5:$PATH" "$HELPER" t999 --pr 9005 --gh-repo owner/repo \
+if ! PATH="$MOCK_DIR_6:$PATH" "$HELPER" t999 --pr 9006 --gh-repo owner/repo \
 	--no-push --repo-path "$REPO_PATH" >/dev/null 2>&1; then
 	pass "exits non-zero (state=OPEN, mergedAt empty, merged=false)"
 else


### PR DESCRIPTION
## Summary

Updated task-complete PR verification to fall back to the REST pull endpoint when gh pr view returns closed with empty mergedAt, accepting merged=true or merged_at evidence while preserving unmerged-closed failures.

## Files Changed

.agents/scripts/task-complete-helper.sh,.agents/scripts/tests/test-task-complete-pr-verify.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/task-complete-helper.sh .agents/scripts/tests/test-task-complete-pr-verify.sh; bash .agents/scripts/tests/test-task-complete-pr-verify.sh; live merged PR #22177 accepted without --skip-merge-check

Resolves #22178


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.75 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 6m and 150,652 tokens on this as a headless worker.