### PR TITLE
t3395: fix setup deploy no-change missing scripts

### DIFF
--- a/.agents/scripts/tests/test-agent-deploy-staging-invariant.sh
+++ b/.agents/scripts/tests/test-agent-deploy-staging-invariant.sh
@@ -16,6 +16,8 @@
 #   3. mv-staging-to-live fails: function returns 1, rollback restores target
 #   4. concurrent fixed staging cleanup: unique staging avoids stale path races
 #   5. deploy_aidevops_agents postcondition: returns 1 when scripts/ missing
+#   6. no-change deploy with corrupt live scripts/ and reserved plugin namespace
+#      still copies canonical scripts/ instead of excluding them from staging
 
 set -euo pipefail
 
@@ -289,12 +291,62 @@ test_postcondition_fails_when_scripts_absent() {
 	return 0
 }
 
+# Test 6: no-change deploy path — if the deployed SHA matches HEAD but the live
+# agents tree is corrupt (scripts/ missing), a plugin namespace that collides
+# with core scripts/ must not exclude canonical scripts/ from the staged copy.
+test_no_change_corrupt_live_scripts_reserved_namespace_recovers() {
+	local repo="${TEST_DIR}/repo6"
+	local target="${TEST_DIR}/.aidevops/agents"
+	local plugins_file="${TEST_DIR}/.config/aidevops/plugins.json"
+	local sha="abc123456789"
+
+	mkdir -p "$repo/.agents/scripts" "$target" "$(dirname "$plugins_file")" "${TEST_DIR}/.aidevops"
+	printf 'canonical script\n' >"$repo/.agents/scripts/hello.sh"
+	printf '%s\n' "$sha" >"${TEST_DIR}/.aidevops/.deployed-sha"
+	printf '{"plugins":[{"name":"bad","namespace":"scripts","repo":"unused"}]}\n' >"$plugins_file"
+
+	git() {
+		local first_arg="${1:-}"
+		local third_arg="${3:-}"
+		local fourth_arg="${4:-}"
+		if [[ "$first_arg" == "-C" && "$third_arg" == "rev-parse" && "$fourth_arg" == "HEAD" ]]; then
+			printf '%s\n' "$sha"
+			return 0
+		fi
+		command git "$@"
+		return $?
+	}
+	sanitize_plugin_namespace() {
+		local ns="$1"
+		printf '%s\n' "$ns"
+		return 0
+	}
+	_deploy_agents_post_copy() { return 0; }
+	_warn_deployed_script_drift() { return 0; }
+	create_backup_with_rotation() { return 0; }
+
+	local rc=0
+	HOME="${TEST_DIR}" INSTALL_DIR="$repo" AIDEVOPS_AGENT_DEPLOY_MIN_FILES=1 deploy_aidevops_agents || rc=$?
+
+	unset -f git sanitize_plugin_namespace _deploy_agents_post_copy
+	unset -f _warn_deployed_script_drift create_backup_with_rotation
+
+	if [[ "$rc" -eq 0 && -f "$target/scripts/hello.sh" ]]; then
+		print_result "no-change corrupt live: reserved scripts namespace is ignored" 0
+	else
+		print_result "no-change corrupt live: reserved scripts namespace is ignored" 1 \
+			"rc=$rc, expected $target/scripts/hello.sh"
+	fi
+	return 0
+}
+
 main() {
 	setup
 
 	test_happy_path_target_exists_with_scripts
 	test_mv_to_old_fails_preserves_live_target
 	test_mv_staging_to_live_fails_rolls_back
+	test_no_change_corrupt_live_scripts_reserved_namespace_recovers
 	test_fixed_staging_cleanup_does_not_abort_copy
 	test_postcondition_fails_when_scripts_absent
 

--- a/setup-modules/agent-deploy.sh
+++ b/setup-modules/agent-deploy.sh
@@ -163,6 +163,23 @@ _deploy_agents_copy() {
 	return 1
 }
 
+# _is_reserved_agent_namespace namespace
+# Returns 0 when a plugin namespace collides with a core aidevops agents
+# directory. Such namespaces must never be passed as rsync/tar excludes because
+# excluding scripts/ from the canonical source can deploy an agents tree that
+# passes the copy step but fails the post-swap scripts/ invariant.
+_is_reserved_agent_namespace() {
+	local namespace="$1"
+
+	case "$namespace" in
+		AGENTS.md|VERSION|advisories|commands|configs|custom|draft|hooks|plugins|prompts|reference|scripts|services|tools|workflows)
+			return 0
+			;;
+	esac
+
+	return 1
+}
+
 # _inject_plan_reminder target_dir
 # Injects the extracted OpenCode plan-reminder into Plan+ if the placeholder is present.
 _inject_plan_reminder() {
@@ -691,6 +708,10 @@ deploy_aidevops_agents() {
 		local ns safe_ns
 		while IFS= read -r ns; do
 			if [[ -n "$ns" ]] && safe_ns=$(sanitize_plugin_namespace "$ns" 2>/dev/null); then
+				if _is_reserved_agent_namespace "$safe_ns"; then
+					print_warning "Skipping plugin namespace that collides with core agents directory: $safe_ns"
+					continue
+				fi
 				plugin_namespaces+=("$safe_ns")
 			fi
 		done < <(jq -r '.plugins[].namespace // empty' "$plugins_file" 2>/dev/null)


### PR DESCRIPTION
## Summary

- Prevent reserved core agent directories such as `scripts` from being treated as plugin namespaces during agent deploy staging.
- Add a regression covering the no-change deployed-SHA path with a corrupt live agents tree missing `scripts/`.

## Runtime Testing

- **Risk level:** Medium (setup/deploy path)
- **Verification:** `shellcheck setup-modules/agent-deploy.sh .agents/scripts/tests/test-agent-deploy-staging-invariant.sh`; `bash .agents/scripts/tests/test-agent-deploy-staging-invariant.sh` (11 tests, 0 failed); `./setup.sh --non-interactive` reached `deploy_aidevops_agents` successfully and deployed 1713 agent files / 1263 scripts, then timed out later in unrelated routine setup after 10 minutes.

## Key Decisions

- Filter reserved namespaces at deploy-staging time so bad plugin config cannot exclude canonical `scripts/` from the staged agents tree.
- Keep the existing post-swap verification and backup restore behavior intact.

Resolves #22175
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.77 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 18m and 162,708 tokens on this as a headless worker.