### PR TITLE
GH#22176: prevent setup removing current worktree

### DIFF
--- a/.agents/scripts/tests/test-setup-worktree-repos-json-current-skip.sh
+++ b/.agents/scripts/tests/test-setup-worktree-repos-json-current-skip.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# GH#22176 regression guard.
+#
+# setup.sh --non-interactive runs cleanup_worktree_entries_in_repos_json during
+# deployment. When invoked from a linked implementation worktree, that migration
+# must not remove the current worktree's repos.json entry, while still pruning
+# other linked-worktree registrations that were incorrectly auto-discovered.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+MIGRATIONS_MODULE="${REPO_ROOT}/setup-modules/migrations.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+fail() {
+	local message="$1"
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$message"
+	exit 1
+	return 1
+}
+
+pass() {
+	local message="$1"
+	printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$message"
+	return 0
+}
+
+print_info() {
+	local message="$1"
+	printf '[INFO] %s\n' "$message" >/dev/null
+	return 0
+}
+
+print_warning() {
+	local message="$1"
+	printf '[WARNING] %s\n' "$message" >/dev/null
+	return 0
+}
+
+print_error() {
+	local message="$1"
+	printf '[ERROR] %s\n' "$message" >&2
+	return 0
+}
+
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+export HOME="${TEST_ROOT}/home"
+mkdir -p "${HOME}/.config/aidevops" "${HOME}/.aidevops/logs"
+
+MAIN_REPO="${TEST_ROOT}/repo"
+CURRENT_WT="${TEST_ROOT}/current-worktree"
+STALE_WT="${TEST_ROOT}/stale-worktree"
+CURRENT_SUBDIR="${CURRENT_WT}/nested"
+REPOS_JSON="${HOME}/.config/aidevops/repos.json"
+
+mkdir -p "$MAIN_REPO"
+git -C "$MAIN_REPO" init -q -b main || fail "init fake repo"
+git -C "$MAIN_REPO" config user.email "test@test.local"
+git -C "$MAIN_REPO" config user.name "Test"
+printf 'ok\n' >"${MAIN_REPO}/README.md"
+git -C "$MAIN_REPO" add README.md || fail "stage README"
+git -C "$MAIN_REPO" commit -q -m init || fail "commit fake repo"
+
+git -C "$MAIN_REPO" worktree add -q -b feature/current "$CURRENT_WT" main || fail "create current worktree"
+git -C "$MAIN_REPO" worktree add -q -b feature/stale "$STALE_WT" main || fail "create stale worktree"
+mkdir -p "$CURRENT_SUBDIR"
+
+jq -n \
+	--arg main "$MAIN_REPO" \
+	--arg current "$CURRENT_WT" \
+	--arg stale "$STALE_WT" \
+	'{initialized_repos:[{path:$main,slug:"owner/repo"},{path:$current,slug:"owner/repo-current"},{path:$stale,slug:"owner/repo-stale"}]}' \
+	>"$REPOS_JSON"
+
+# shellcheck source=/dev/null
+source "$MIGRATIONS_MODULE" >/dev/null 2>&1
+
+cd "$CURRENT_SUBDIR" || fail "enter current worktree subdir"
+cleanup_worktree_entries_in_repos_json || fail "run worktree repos cleanup"
+
+if [[ ! -d "$CURRENT_WT" ]]; then
+	fail "current worktree directory still exists"
+fi
+if [[ ! -d "$CURRENT_SUBDIR" ]]; then
+	fail "current worktree subdir still exists"
+fi
+pwd >/dev/null 2>&1 || fail "current working directory still resolves"
+git status --short >/dev/null || fail "git status still works in current worktree"
+
+jq -e --arg current "$CURRENT_WT" 'any(.initialized_repos[]; .path == $current)' "$REPOS_JSON" >/dev/null \
+	|| fail "current worktree repos.json entry is preserved"
+jq -e --arg main "$MAIN_REPO" 'any(.initialized_repos[]; .path == $main)' "$REPOS_JSON" >/dev/null \
+	|| fail "main repo repos.json entry is preserved"
+if jq -e --arg stale "$STALE_WT" 'any(.initialized_repos[]; .path == $stale)' "$REPOS_JSON" >/dev/null; then
+	fail "stale linked-worktree repos.json entry is removed"
+fi
+
+pass "setup worktree repos.json cleanup preserves current cwd"
+exit 0

--- a/.agents/scripts/tests/test-setup-worktree-repos-json-current-skip.sh
+++ b/.agents/scripts/tests/test-setup-worktree-repos-json-current-skip.sh
@@ -50,6 +50,17 @@ print_error() {
 	return 0
 }
 
+REGISTERED_WORKTREE=""
+REGISTERED_BRANCH=""
+
+register_worktree() {
+	local wt_path="$1"
+	local branch="$2"
+	REGISTERED_WORKTREE="$wt_path"
+	REGISTERED_BRANCH="$branch"
+	return 0
+}
+
 TEST_ROOT=$(mktemp -d)
 trap 'rm -rf "$TEST_ROOT"' EXIT
 export HOME="${TEST_ROOT}/home"
@@ -84,6 +95,17 @@ jq -n \
 source "$MIGRATIONS_MODULE" >/dev/null 2>&1
 
 cd "$CURRENT_SUBDIR" || fail "enter current worktree subdir"
+INSTALL_DIR="$CURRENT_SUBDIR" protect_current_setup_worktree || fail "protect current setup worktree"
+
+
+CURRENT_WT_PHYSICAL=$(cd "$CURRENT_WT" && pwd -P)
+if [[ "$REGISTERED_WORKTREE" != "$CURRENT_WT_PHYSICAL" ]]; then
+	fail "current setup worktree ownership is registered"
+fi
+if [[ "$REGISTERED_BRANCH" != "feature/current" ]]; then
+	fail "current setup worktree branch is registered"
+fi
+
 cleanup_worktree_entries_in_repos_json || fail "run worktree repos cleanup"
 
 if [[ ! -d "$CURRENT_WT" ]]; then

--- a/setup-modules/migrations.sh
+++ b/setup-modules/migrations.sh
@@ -331,10 +331,28 @@ cleanup_worktree_entries_in_repos_json() {
 	command -v git &>/dev/null || return 0
 
 	local stale_paths=()
-	local path git_dir common_dir
+	local current_repo_root=""
+	local current_physical_dir=""
+	local path normalized_path git_dir common_dir
+
+	current_physical_dir=$(pwd -P 2>/dev/null || pwd)
+	current_repo_root=$(git rev-parse --show-toplevel 2>/dev/null || true)
+	if [[ -n "$current_repo_root" ]]; then
+		current_repo_root=$(cd "$current_repo_root" 2>/dev/null && pwd -P) || current_repo_root=""
+	fi
 
 	while IFS= read -r path; do
 		[[ -n "$path" && -d "$path" ]] || continue
+		normalized_path=$(cd "$path" 2>/dev/null && pwd -P) || continue
+		# GH#22176: setup may run from a linked implementation worktree.
+		# The t2250 migration should remove stale worktree registrations from
+		# repos.json, but never deregister the worktree currently executing setup.
+		if [[ -n "$current_repo_root" && "$normalized_path" == "$current_repo_root" ]]; then
+			continue
+		fi
+		if [[ "$current_physical_dir" == "$normalized_path" || "$current_physical_dir" == "$normalized_path"/* ]]; then
+			continue
+		fi
 		git_dir=$(git -C "$path" rev-parse --git-dir 2>/dev/null) || continue
 		common_dir=$(git -C "$path" rev-parse --git-common-dir 2>/dev/null) || continue
 		# Normalise to absolute paths for comparison.

--- a/setup-modules/migrations.sh
+++ b/setup-modules/migrations.sh
@@ -304,6 +304,36 @@ cleanup_stale_bun_opencode() {
 	return 0
 }
 
+# Register the setup caller's linked worktree as owned before setup performs
+# deployment work that may restart the pulse or trigger cleanup routines.
+protect_current_setup_worktree() {
+	command -v git &>/dev/null || return 0
+	declare -F register_worktree >/dev/null 2>&1 || return 0
+
+	local current_root=""
+	local git_dir=""
+	local common_dir=""
+	local branch=""
+
+	current_root=$(git -C "${INSTALL_DIR:-.}" rev-parse --show-toplevel 2>/dev/null || true)
+	[[ -n "$current_root" ]] || return 0
+	current_root=$(cd "$current_root" 2>/dev/null && pwd -P) || return 0
+
+	git_dir=$(git -C "$current_root" rev-parse --git-dir 2>/dev/null) || return 0
+	common_dir=$(git -C "$current_root" rev-parse --git-common-dir 2>/dev/null) || return 0
+	[[ "$git_dir" = /* ]] || git_dir="$current_root/$git_dir"
+	[[ "$common_dir" = /* ]] || common_dir="$current_root/$common_dir"
+	git_dir=$(cd "$git_dir" 2>/dev/null && pwd -P) || git_dir=""
+	common_dir=$(cd "$common_dir" 2>/dev/null && pwd -P) || common_dir=""
+	[[ -n "$git_dir" && -n "$common_dir" && "$git_dir" != "$common_dir" ]] || return 0
+
+	branch=$(git -C "$current_root" rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+	[[ -n "$branch" ]] || branch="HEAD"
+	register_worktree "$current_root" "$branch" --task "setup-noninteractive" --session "setup:${OPENCODE_SESSION_ID:-${CLAUDE_SESSION_ID:-manual}}" >/dev/null 2>&1 || true
+	print_info "Protected current setup worktree from cleanup: $current_root"
+	return 0
+}
+
 # t1929: Remove stale contributor/legacy health issue cache files and close
 # the corresponding GitHub issues. One-time migration — the root cause
 # (API failure in _get_runner_role defaulting to "contributor") is fixed

--- a/setup.sh
+++ b/setup.sh
@@ -1517,6 +1517,7 @@ _setup_run_non_interactive() {
 		fi
 	fi
 
+	_time_step "protect_current_setup_worktree" protect_current_setup_worktree
 	_time_step "verify_location" verify_location
 	_time_step "check_requirements" check_requirements
 	# Run quality tool detection in non-interactive mode too (warn-only path).


### PR DESCRIPTION
## Summary

Protect setup's caller worktree before non-interactive deployment cleanup can deregister or remove it; preserve the current worktree entry while still pruning other linked-worktree repos.json entries.

## Files Changed

.agents/scripts/tests/test-setup-worktree-repos-json-current-skip.sh,setup-modules/migrations.sh,setup.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-setup-worktree-repos-json-current-skip.sh; bash .agents/scripts/tests/test-setup-noninteractive-lock.sh; bash .agents/scripts/tests/test-linters-local-worktree-cwd-survives.sh; shellcheck setup.sh setup-modules/migrations.sh .agents/scripts/tests/test-setup-worktree-repos-json-current-skip.sh .agents/scripts/tests/test-setup-noninteractive-lock.sh .agents/scripts/tests/test-linters-local-worktree-cwd-survives.sh. Runtime setup verification attempted from a temporary linked worktree; setup reached Setup complete and cwd-survival stages, but the outer tool timeout sent TERM during setup_supervisor_pulse after 15m.

Resolves #22176


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.78 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 40m and 173,036 tokens on this as a headless worker.