### PR TITLE
GH#22183: preserve active setup worktree

### DIFF
--- a/.agents/scripts/tests/test-setup-preserves-current-worktree.sh
+++ b/.agents/scripts/tests/test-setup-preserves-current-worktree.sh
@@ -1,0 +1,198 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)" || exit 1
+MIGRATIONS_SCRIPT="${REPO_ROOT}/setup-modules/migrations.sh"
+
+readonly TEST_RED='\033[0;31m'
+readonly TEST_GREEN='\033[0;32m'
+readonly TEST_RESET='\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local test_name="$1"
+	local passed="$2"
+	local message="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+
+	if [[ "$passed" -eq 0 ]]; then
+		printf '%bPASS%b %s\n' "$TEST_GREEN" "$TEST_RESET" "$test_name"
+		return 0
+	fi
+
+	printf '%bFAIL%b %s\n' "$TEST_RED" "$TEST_RESET" "$test_name"
+	if [[ -n "$message" ]]; then
+		printf '       %s\n' "$message"
+	fi
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	return 0
+}
+
+print_info() {
+	local message="$1"
+	printf '[INFO] %s\n' "$message"
+	return 0
+}
+
+print_warning() {
+	local message="$1"
+	printf '[WARNING] %s\n' "$message"
+	return 0
+}
+
+print_error() {
+	local message="$1"
+	printf '[ERROR] %s\n' "$message"
+	return 0
+}
+
+make_temp_dir() {
+	local tmp_dir=""
+	tmp_dir=$(mktemp -d "${TMPDIR:-/tmp}/aidevops-setup-worktree-test.XXXXXX")
+	printf '%s' "$tmp_dir"
+	return 0
+}
+
+load_cleanup_function() {
+	# shellcheck source=/dev/null
+	source "$MIGRATIONS_SCRIPT"
+	return 0
+}
+
+write_repos_json() {
+	local repos_file="$1"
+	local canonical_path="$2"
+	local current_worktree_path="$3"
+	local stale_worktree_path="$4"
+	mkdir -p "$(dirname "$repos_file")"
+	jq -n \
+		--arg canonical "$canonical_path" \
+		--arg current "$current_worktree_path" \
+		--arg stale "$stale_worktree_path" \
+		'{initialized_repos: [
+			{path: $canonical, slug: "example/repo", pulse: true},
+			{path: $current, slug: "example/repo-current", pulse: true},
+			{path: $stale, slug: "example/repo-stale", pulse: true}
+		], git_parent_dirs: []}' >"$repos_file"
+	return 0
+}
+
+init_repo_with_worktrees() {
+	local base_dir="$1"
+	local canonical_path="$2"
+	local current_worktree_path="$3"
+	local stale_worktree_path="$4"
+	mkdir -p "$canonical_path"
+	git -C "$canonical_path" init -q
+	git -C "$canonical_path" config user.email test@example.invalid
+	git -C "$canonical_path" config user.name "Setup Test"
+	printf 'root\n' >"$canonical_path/README.md"
+	git -C "$canonical_path" add README.md
+	git -C "$canonical_path" commit -q -m initial
+	git -C "$canonical_path" worktree add -q -b current-worktree "$current_worktree_path" HEAD
+	git -C "$canonical_path" worktree add -q -b stale-worktree "$stale_worktree_path" HEAD
+	[[ -d "$base_dir" ]]
+	return 0
+}
+
+test_preserves_current_worktree_entry() {
+	local tmp_dir=""
+	local canonical_path=""
+	local current_worktree_path=""
+	local stale_worktree_path=""
+	local repos_file=""
+	local flag_file=""
+	local output=""
+	local current_count=""
+	local stale_count=""
+	tmp_dir=$(make_temp_dir)
+	canonical_path="$tmp_dir/canonical"
+	current_worktree_path="$tmp_dir/current-worktree"
+	stale_worktree_path="$tmp_dir/stale-worktree"
+	repos_file="$tmp_dir/home/.config/aidevops/repos.json"
+	flag_file="$tmp_dir/home/.aidevops/logs/.migrated-worktree-repos-json-t2250"
+
+	init_repo_with_worktrees "$tmp_dir" "$canonical_path" "$current_worktree_path" "$stale_worktree_path"
+	write_repos_json "$repos_file" "$canonical_path" "$current_worktree_path" "$stale_worktree_path"
+
+	output=$(
+		HOME="$tmp_dir/home"
+		load_cleanup_function
+		cd "$current_worktree_path"
+		cleanup_worktree_entries_in_repos_json
+		return 0
+	) 2>&1 || true
+
+	current_count=$(jq --arg path "$current_worktree_path" '[.initialized_repos[] | select(.path == $path)] | length' "$repos_file")
+	stale_count=$(jq --arg path "$stale_worktree_path" '[.initialized_repos[] | select(.path == $path)] | length' "$repos_file")
+
+	if [[ "$current_count" == "1" && "$stale_count" == "0" && ! -f "$flag_file" && "$output" == *"Skipped 1 active current worktree"* ]]; then
+		rm -rf "$tmp_dir"
+		print_result "cleanup preserves the current linked worktree entry" 0
+		return 0
+	fi
+
+	rm -rf "$tmp_dir"
+	print_result "cleanup preserves the current linked worktree entry" 1 "current_count=${current_count} stale_count=${stale_count} output=${output}"
+	return 0
+}
+
+test_canonical_run_removes_worktree_entries_and_writes_flag() {
+	local tmp_dir=""
+	local canonical_path=""
+	local current_worktree_path=""
+	local stale_worktree_path=""
+	local repos_file=""
+	local flag_file=""
+	local output=""
+	local worktree_count=""
+	tmp_dir=$(make_temp_dir)
+	canonical_path="$tmp_dir/canonical"
+	current_worktree_path="$tmp_dir/current-worktree"
+	stale_worktree_path="$tmp_dir/stale-worktree"
+	repos_file="$tmp_dir/home/.config/aidevops/repos.json"
+	flag_file="$tmp_dir/home/.aidevops/logs/.migrated-worktree-repos-json-t2250"
+
+	init_repo_with_worktrees "$tmp_dir" "$canonical_path" "$current_worktree_path" "$stale_worktree_path"
+	write_repos_json "$repos_file" "$canonical_path" "$current_worktree_path" "$stale_worktree_path"
+
+	output=$(
+		HOME="$tmp_dir/home"
+		load_cleanup_function
+		cd "$canonical_path"
+		cleanup_worktree_entries_in_repos_json
+		return 0
+	) 2>&1 || true
+
+	worktree_count=$(jq --arg current "$current_worktree_path" --arg stale "$stale_worktree_path" '[.initialized_repos[] | select(.path == $current or .path == $stale)] | length' "$repos_file")
+
+	if [[ "$worktree_count" == "0" && -f "$flag_file" && "$output" == *"Removed 2 worktree"* ]]; then
+		rm -rf "$tmp_dir"
+		print_result "canonical cleanup removes linked worktree entries" 0
+		return 0
+	fi
+
+	rm -rf "$tmp_dir"
+	print_result "canonical cleanup removes linked worktree entries" 1 "worktree_count=${worktree_count} output=${output}"
+	return 0
+}
+
+main() {
+	test_preserves_current_worktree_entry
+	test_canonical_run_removes_worktree_entries_and_writes_flag
+
+	printf '\nTests run: %d, failed: %d\n' "$TESTS_RUN" "$TESTS_FAILED"
+	if [[ "$TESTS_FAILED" -gt 0 ]]; then
+		return 1
+	fi
+
+	return 0
+}
+
+main "$@"

--- a/setup-modules/migrations.sh
+++ b/setup-modules/migrations.sh
@@ -331,10 +331,18 @@ cleanup_worktree_entries_in_repos_json() {
 	command -v git &>/dev/null || return 0
 
 	local stale_paths=()
-	local path git_dir common_dir
+	local skipped_current_paths=()
+	local current_worktree=""
+	local path git_dir common_dir resolved_path
+
+	current_worktree=$(git rev-parse --show-toplevel 2>/dev/null || true)
+	if [[ -n "$current_worktree" ]]; then
+		current_worktree=$(cd "$current_worktree" 2>/dev/null && pwd -P) || current_worktree=""
+	fi
 
 	while IFS= read -r path; do
 		[[ -n "$path" && -d "$path" ]] || continue
+		resolved_path=$(cd "$path" 2>/dev/null && pwd -P) || resolved_path=""
 		git_dir=$(git -C "$path" rev-parse --git-dir 2>/dev/null) || continue
 		common_dir=$(git -C "$path" rev-parse --git-common-dir 2>/dev/null) || continue
 		# Normalise to absolute paths for comparison.
@@ -343,6 +351,10 @@ cleanup_worktree_entries_in_repos_json() {
 		git_dir=$(cd "$git_dir" 2>/dev/null && pwd -P) || git_dir=""
 		common_dir=$(cd "$common_dir" 2>/dev/null && pwd -P) || common_dir=""
 		if [[ -n "$git_dir" && -n "$common_dir" && "$git_dir" != "$common_dir" ]]; then
+			if [[ -n "$current_worktree" && -n "$resolved_path" && "$resolved_path" == "$current_worktree" ]]; then
+				skipped_current_paths+=("$path")
+				continue
+			fi
 			stale_paths+=("$path")
 		fi
 	done < <(jq -r '.initialized_repos[].path // empty' "$repos_json" 2>/dev/null)
@@ -359,6 +371,16 @@ cleanup_worktree_entries_in_repos_json() {
 		for p in "${stale_paths[@]}"; do
 			print_info "  - $p"
 		done
+	fi
+
+	if [[ ${#skipped_current_paths[@]} -gt 0 ]]; then
+		print_warning "Skipped ${#skipped_current_paths[@]} active current worktree entry/entries in repos.json (t2250):"
+		local skipped_path
+		for skipped_path in "${skipped_current_paths[@]}"; do
+			print_warning "  - $skipped_path"
+		done
+		print_warning "Run setup.sh from the canonical worktree later to finish the one-shot cleanup."
+		return 0
 	fi
 
 	mkdir -p "$(dirname "$flag_file")"


### PR DESCRIPTION
## Summary

Guard setup's worktree repos.json cleanup so the current linked worktree is skipped, while stale sibling worktree entries are still removed.

## Files Changed

.agents/scripts/tests/test-setup-preserves-current-worktree.sh,setup-modules/migrations.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-setup-preserves-current-worktree.sh; shellcheck setup-modules/migrations.sh .agents/scripts/tests/test-setup-preserves-current-worktree.sh; bounded ./setup.sh --non-interactive runtime check from disposable worktree kept the path present after timeout.

Resolves #22183


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.79 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 4m and 112,916 tokens on this as a headless worker.