### PR TITLE
t3370: bound setup deploy rsync I/O timeout

### DIFF
--- a/.agents/scripts/tests/test-agent-deploy-staging-invariant.sh
+++ b/.agents/scripts/tests/test-agent-deploy-staging-invariant.sh
@@ -340,6 +340,33 @@ test_no_change_corrupt_live_scripts_reserved_namespace_recovers() {
 	return 0
 }
 
+test_rsync_copy_uses_io_timeout() {
+	local src="${TEST_DIR}/src7"
+	local tgt="${TEST_DIR}/tgt7"
+	local args_file="${TEST_DIR}/rsync-args7.txt"
+	_make_source_dir "$src"
+	mkdir -p "$tgt"
+
+	rsync() {
+		printf '%s\n' "$*" >"$args_file"
+		mkdir -p "$tgt/scripts"
+		cp -a "$src/scripts/." "$tgt/scripts/"
+		return 0
+	}
+
+	local rc=0
+	AIDEVOPS_RSYNC_TIMEOUT=7 _deploy_agents_copy "$src" "$tgt" || rc=$?
+
+	unset -f rsync
+
+	if [[ "$rc" -eq 0 ]] && grep -q -- '--timeout=7' "$args_file" && [[ -f "$tgt/scripts/hello.sh" ]]; then
+		print_result "rsync copy uses bounded I/O timeout" 0
+	else
+		print_result "rsync copy uses bounded I/O timeout" 1 "rc=$rc args=$(tr '\n' ' ' <"$args_file" 2>/dev/null || true)"
+	fi
+	return 0
+}
+
 main() {
 	setup
 
@@ -347,6 +374,7 @@ main() {
 	test_mv_to_old_fails_preserves_live_target
 	test_mv_staging_to_live_fails_rolls_back
 	test_no_change_corrupt_live_scripts_reserved_namespace_recovers
+	test_rsync_copy_uses_io_timeout
 	test_fixed_staging_cleanup_does_not_abort_copy
 	test_postcondition_fails_when_scripts_absent
 

--- a/setup-modules/agent-deploy.sh
+++ b/setup-modules/agent-deploy.sh
@@ -143,7 +143,12 @@ _deploy_agents_copy() {
 		for pns in "$@"; do
 			rsync_excludes+=("--exclude=${pns}/")
 		done
-		if rsync -a "${rsync_excludes[@]}" "$source_dir/" "$target_dir/"; then
+		local rsync_timeout="${AIDEVOPS_RSYNC_TIMEOUT:-120}"
+		[[ "$rsync_timeout" =~ ^[0-9]+$ && "$rsync_timeout" -gt 0 ]] || rsync_timeout=120
+		# GH#22086: bound rsync I/O stalls so setup.sh --non-interactive can
+		# unwind via its EXIT trap instead of leaving a long-running setup owner
+		# and stale setup-noninteractive.lock.d behind.
+		if rsync -a --timeout="$rsync_timeout" "${rsync_excludes[@]}" "$source_dir/" "$target_dir/"; then
 			deploy_ok=true
 		fi
 	else


### PR DESCRIPTION
## Summary

- Adds a bounded rsync I/O timeout to agent staging during setup deploys so stalled file copies fail and allow setup.sh cleanup traps to release the non-interactive lock.
- Extends agent deploy regression coverage to assert rsync receives the configured timeout.

## Runtime Testing

- **Risk level:** High (setup deployment lifecycle, lock recovery).
- **Verification:** shellcheck setup.sh setup-modules/agent-deploy.sh .agents/scripts/tests/test-setup-noninteractive-lock.sh .agents/scripts/tests/test-agent-deploy-staging-invariant.sh
- **Verification:** bash .agents/scripts/tests/test-setup-noninteractive-lock.sh (10 tests, 0 failed)
- **Verification:** bash .agents/scripts/tests/test-agent-deploy-staging-invariant.sh (12 tests, 0 failed)
- **Manual check:** isolated setup helper early-exit check passed with lock_removed=yes.

## Files Changed

- setup-modules/agent-deploy.sh
- .agents/scripts/tests/test-agent-deploy-staging-invariant.sh

## Key Decisions

- Use rsync's native --timeout I/O timeout with AIDEVOPS_RSYNC_TIMEOUT override instead of wrapping the whole deploy stage, preserving normal large local copies while bounding no-progress stalls.

Resolves #22086

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.79 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 13m and 177,899 tokens on this as a headless worker.