### PR TITLE
t3403: fix quality gate cancellation false failures

### DIFF
--- a/.agents/scripts/tests/test-workflow-cascade-lint.sh
+++ b/.agents/scripts/tests/test-workflow-cascade-lint.sh
@@ -6,7 +6,7 @@
 #
 # Tests the cascade vulnerability linter against fixture YAML files covering:
 # - Vulnerable workflows (labeled + cancel-in-progress + no mitigation)
-# - Mitigated workflows (paths-ignore, event-action guard)
+# - Vulnerable workflows even with paths-ignore/event-action guards
 # - Safe workflows (no labeled trigger, no cancel-in-progress)
 # - Dry-run mode
 #
@@ -275,39 +275,39 @@ test_vulnerable_multiline_types() {
 	return 0
 }
 
-test_mitigated_paths_ignore() {
+test_paths_ignore_still_vulnerable() {
 	local output rc
 	output=$(bash "$SCRIPT_UNDER_TEST" "${TEST_ROOT}/fixtures/mitigated-paths-ignore.yml" 2>&1)
 	rc=$?
 	local failed=0
-	if [[ $rc -ne 0 ]]; then
+	if [[ $rc -ne 1 ]]; then
 		failed=1
 	fi
-	print_result "mitigated with paths-ignore" "$failed" "exit=$rc"
+	print_result "vulnerable despite paths-ignore" "$failed" "exit=$rc output=$output"
 	return 0
 }
 
-test_mitigated_action_guard() {
+test_action_guard_still_vulnerable() {
 	local output rc
 	output=$(bash "$SCRIPT_UNDER_TEST" "${TEST_ROOT}/fixtures/mitigated-action-guard.yml" 2>&1)
 	rc=$?
 	local failed=0
-	if [[ $rc -ne 0 ]]; then
+	if [[ $rc -ne 1 ]]; then
 		failed=1
 	fi
-	print_result "mitigated with job-level event-action guard" "$failed" "exit=$rc"
+	print_result "vulnerable despite job-level event-action guard" "$failed" "exit=$rc output=$output"
 	return 0
 }
 
-test_mitigated_step_guard() {
+test_step_guard_still_vulnerable() {
 	local output rc
 	output=$(bash "$SCRIPT_UNDER_TEST" "${TEST_ROOT}/fixtures/mitigated-step-guard.yml" 2>&1)
 	rc=$?
 	local failed=0
-	if [[ $rc -ne 0 ]]; then
+	if [[ $rc -ne 1 ]]; then
 		failed=1
 	fi
-	print_result "mitigated with step-level EVENT_ACTION guard" "$failed" "exit=$rc"
+	print_result "vulnerable despite step-level EVENT_ACTION guard" "$failed" "exit=$rc output=$output"
 	return 0
 }
 
@@ -390,7 +390,7 @@ test_real_nmr_hold_workflow() {
 test_real_qlty_regression_mitigated() {
 	local qlty_file=".github/workflows/qlty-regression.yml"
 	if [ ! -f "$qlty_file" ]; then
-		print_result "real: qlty-regression.yml NOT flagged (paths-ignore mitigation)" 1 "file not found"
+		print_result "real: qlty-regression.yml NOT flagged (cancel disabled)" 1 "file not found"
 		return 0
 	fi
 	local output rc
@@ -400,14 +400,14 @@ test_real_qlty_regression_mitigated() {
 	if [[ $rc -ne 0 ]]; then
 		failed=1
 	fi
-	print_result "real: qlty-regression.yml NOT flagged (paths-ignore mitigation)" "$failed" "exit=$rc"
+	print_result "real: qlty-regression.yml NOT flagged (cancel disabled)" "$failed" "exit=$rc output=$output"
 	return 0
 }
 
 test_real_qlty_new_file_gate_mitigated() {
 	local gate_file=".github/workflows/qlty-new-file-gate.yml"
 	if [ ! -f "$gate_file" ]; then
-		print_result "real: qlty-new-file-gate.yml NOT flagged (paths-ignore + step guard)" 1 "file not found"
+		print_result "real: qlty-new-file-gate.yml NOT flagged (cancel disabled)" 1 "file not found"
 		return 0
 	fi
 	local output rc
@@ -417,7 +417,7 @@ test_real_qlty_new_file_gate_mitigated() {
 	if [[ $rc -ne 0 ]]; then
 		failed=1
 	fi
-	print_result "real: qlty-new-file-gate.yml NOT flagged (paths-ignore + step guard)" "$failed" "exit=$rc"
+	print_result "real: qlty-new-file-gate.yml NOT flagged (cancel disabled)" "$failed" "exit=$rc output=$output"
 	return 0
 }
 
@@ -437,9 +437,9 @@ main() {
 	test_vulnerable_issue_workflow
 	test_vulnerable_pr_workflow
 	test_vulnerable_multiline_types
-	test_mitigated_paths_ignore
-	test_mitigated_action_guard
-	test_mitigated_step_guard
+	test_paths_ignore_still_vulnerable
+	test_action_guard_still_vulnerable
+	test_step_guard_still_vulnerable
 	test_safe_no_labeled_trigger
 	test_safe_no_cancel_in_progress
 	test_dry_run_exits_zero

--- a/.agents/scripts/workflow-cascade-lint.sh
+++ b/.agents/scripts/workflow-cascade-lint.sh
@@ -87,7 +87,7 @@ has_cascade_triggers() {
 # Returns 0 if cancel-in-progress: true is set anywhere (top-level or job-level).
 has_cancel_in_progress() {
 	local _file="$1"
-	grep -qE 'cancel-in-progress:\s*true' "$_file"
+	grep -Ev '^\s*#' "$_file" | grep -qE 'cancel-in-progress:\s*true'
 	return $?
 }
 

--- a/.agents/scripts/workflow-cascade-lint.sh
+++ b/.agents/scripts/workflow-cascade-lint.sh
@@ -9,7 +9,10 @@
 #      unassigned, review_requested, review_request_removed) — these fire
 #      once per item, so `gh pr create --label "a,b,c"` fires 3 events.
 #   2. cancel-in-progress: true on any concurrency group.
-#   3. No effective mitigation (paths-ignore or job-level event-action guard).
+#   3. No effective cancellation mitigation. Trigger filters and job-level
+#      guards reduce work after the run starts, but GitHub evaluates
+#      concurrency before any job or step can skip, so they do not prevent a
+#      label run from cancelling an already-registered required check.
 #
 # This combination causes rapid-fire event cascades where intermediate
 # workflow runs get cancelled before completing. See t2220 for the canonical
@@ -88,39 +91,6 @@ has_cancel_in_progress() {
 	return $?
 }
 
-# has_paths_ignore <file>
-# Returns 0 if paths-ignore is present under a trigger section.
-# paths-ignore scopes the trigger to file-changing events, which prevents
-# the cascade for PRs matching the ignore pattern (e.g., docs-only PRs).
-has_paths_ignore() {
-	local _file="$1"
-	grep -qE '^\s+paths-ignore:' "$_file"
-	return $?
-}
-
-# has_event_action_guard <file>
-# Returns 0 if at least one job has an if: condition that gates on
-# github.event.action. This catches patterns like:
-#   if: github.event.action != 'labeled' || contains(...)
-# which prevent cascade by skipping unrelated label events early.
-# Note: checking github.event.label.name alone does NOT mitigate cascade
-# because the run still enters the concurrency group and can be cancelled.
-has_event_action_guard() {
-	local _file="$1"
-	# Job-level if: referencing event.action
-	if grep -qE '^\s+if:.*github\.event\.action' "$_file"; then
-		return 0
-	fi
-	# Step-level early exit on event action (run: block)
-	# Pattern: check EVENT_ACTION or github.event.action in a run block
-	# and exit 0 before doing work — prevents wasting the concurrency slot.
-	if grep -qE 'EVENT_ACTION|github\.event\.action' "$_file" &&
-		grep -qE '(exit 0|echo.*skip|echo.*Skipping)' "$_file"; then
-		return 0
-	fi
-	return 1
-}
-
 # check_file <file>
 # Returns 0 if the file is OK (not vulnerable), 1 if vulnerable.
 check_file() {
@@ -136,18 +106,10 @@ check_file() {
 		return 0
 	fi
 
-	# Step 3: Check mitigations (either is sufficient)
-	if has_paths_ignore "$_file"; then
-		log "MITIGATED (paths-ignore): $_file"
-		return 0
-	fi
-
-	if has_event_action_guard "$_file"; then
-		log "MITIGATED (event-action guard): $_file"
-		return 0
-	fi
-
-	# No mitigation found — vulnerable
+	# Trigger filters and event-action guards run after GitHub has already
+	# admitted the run into the concurrency group, so they cannot stop a label
+	# run from cancelling an in-flight required check. The only reliable fix is
+	# removing the label-like trigger or not cancelling in-progress runs.
 	return 1
 }
 
@@ -165,9 +127,9 @@ print_report() {
 	done < "$_vuln_file"
 	printf '\n'
 	printf 'Remediation:\n'
-	printf '  1. Add paths-ignore under the trigger to scope to file-changing events\n'
-	printf '  2. OR add a job-level if: guard on github.event.action\n'
-	printf '  3. OR remove cancel-in-progress: true from the concurrency group\n'
+	printf '  1. Remove cancel-in-progress: true from workflows with label-like triggers\n'
+	printf '  2. OR remove label-like triggers from workflows that must cancel older runs\n'
+	printf '  3. Keep paths-ignore/event-action guards only as cost controls; they are not cancellation controls\n'
 	printf '\n'
 	printf 'See: t2220 (evidence), t2228 (parent remediation)\n'
 	printf 'Override: apply the workflow-cascade-ok label with a justification section\n'
@@ -190,7 +152,7 @@ print_markdown_report() {
 	printf '**%d workflow(s) have the cascade-vulnerable combination** ' "$_count"
 	# Backticks below are intentional markdown formatting, not command substitution.
 	# shellcheck disable=SC2016
-	printf '(label-like trigger + `cancel-in-progress: true` + no mitigation):\n\n'
+	printf '(label-like trigger + `cancel-in-progress: true`):\n\n'
 	while IFS= read -r _f; do
 		# shellcheck disable=SC2016
 		printf '- `%s`\n' "$_f"
@@ -198,11 +160,11 @@ print_markdown_report() {
 	printf '\n'
 	printf '### Remediation\n\n'
 	# shellcheck disable=SC2016
-	printf '1. Add `paths-ignore` under the trigger to scope to file-changing events\n'
+	printf '1. Remove `cancel-in-progress: true` from workflows with label-like triggers\n'
 	# shellcheck disable=SC2016
-	printf '2. OR add a job-level `if:` guard on `github.event.action`\n'
+	printf '2. OR remove label-like triggers from workflows that must cancel older runs\n'
 	# shellcheck disable=SC2016
-	printf '3. OR remove `cancel-in-progress: true` from the concurrency group\n\n'
+	printf '3. Keep `paths-ignore` and event-action guards only as cost controls; GitHub evaluates concurrency before those guards run\n\n'
 	printf 'See: [t2220](https://github.com/marcusquinn/aidevops/pull/19726) (evidence), '
 	printf '[t2228 parent](https://github.com/marcusquinn/aidevops/issues/19736) (remediation plan)\n\n'
 	# shellcheck disable=SC2016

--- a/.github/workflows/qlty-new-file-gate.yml
+++ b/.github/workflows/qlty-new-file-gate.yml
@@ -16,15 +16,17 @@ name: Qlty New-File Gate
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
-    # t2220: suppress concurrency-cancellation cascade on docs-only PRs.
+    # t2220/t3403: suppress concurrency-cancellation cascade on docs-only PRs.
     # `gh pr create --label "a,b,c,d"` fires one `labeled` event per label
-    # after the initial `opened`; each event triggers a new run that
-    # cancels the in-flight one via `cancel-in-progress: true`. Docs-only
+    # after the initial `opened`; each event can trigger a new run. When this
+    # workflow used `cancel-in-progress: true`, label runs cancelled the
+    # in-flight required check before job-level guards could skip them. Docs-only
     # PRs observed 15+ cancelled runs per workflow, which `gh pr checks`
     # then surfaces as `fail` (it displays `cancelled` conclusions as
     # `fail` in its TSV output). Filtering docs-only at the trigger
-    # level prevents the cascade entirely. In-workflow `detect-new-files`
-    # still runs for mixed PRs as a belt-and-suspenders check.
+    # level reduces no-op runs; keeping cancel-in-progress disabled prevents
+    # label events on mixed PRs from cancelling required checks. In-workflow
+    # `detect-new-files` still runs as a belt-and-suspenders check.
     paths-ignore:
       - '**/*.md'
       - 'todo/**'
@@ -35,17 +37,18 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   detect-new-files:
     name: Detect new files
     runs-on: ubuntu-latest
-    # t2231: fast-fail gate — skip entirely when a labeled event is unrelated to
-    # 'new-file-smell-ok'. Cascade still fires N workflow runs on bulk label
-    # application, but each one exits in ~3s with no checkout cost — no
-    # "cancelled" surface. unlabeled non-relevant events are handled by the
-    # shell guard inside the step (inherited from t2068).
+    # t2231/t3403: fast-fail gate — skip entirely when a labeled event is
+    # unrelated to 'new-file-smell-ok'. Cascade can still fire N workflow runs
+    # on bulk label application, but cancel-in-progress is disabled so these
+    # cheap skipped runs cannot cancel the required scan from opened/synchronize.
+    # unlabeled non-relevant events are handled by the shell guard inside the
+    # step (inherited from t2068).
     if: >-
       github.event.action != 'labeled' ||
       github.event.label.name == 'new-file-smell-ok'

--- a/.github/workflows/qlty-regression.yml
+++ b/.github/workflows/qlty-regression.yml
@@ -13,15 +13,17 @@ name: Qlty Regression Gate
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
-    # t2220: suppress concurrency-cancellation cascade on docs-only PRs.
+    # t2220/t3403: suppress concurrency-cancellation cascade on docs-only PRs.
     # `gh pr create --label "a,b,c,d"` fires one `labeled` event per label
-    # after the initial `opened`; each event triggers a new run that
-    # cancels the in-flight one via `cancel-in-progress: true`. Docs-only
+    # after the initial `opened`; each event can trigger a new run. When this
+    # workflow used `cancel-in-progress: true`, label runs cancelled the
+    # in-flight required check before job-level guards could skip them. Docs-only
     # PRs observed 15+ cancelled runs per workflow, which `gh pr checks`
     # then surfaces as `fail` (it displays `cancelled` conclusions as
     # `fail` in its TSV output). Filtering docs-only at the trigger
-    # level prevents the cascade entirely. In-workflow `detect-scope`
-    # still runs for mixed PRs as a belt-and-suspenders check.
+    # level reduces no-op runs; keeping cancel-in-progress disabled prevents
+    # label events on mixed PRs from cancelling required checks. In-workflow
+    # `detect-scope` still runs as a belt-and-suspenders check.
     paths-ignore:
       - '**/*.md'
       - 'todo/**'
@@ -32,15 +34,16 @@ permissions:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 jobs:
   detect-scope:
     name: Detect PR scope
     runs-on: ubuntu-latest
-    # t2231: fast-fail gate — skip entirely when a labeled event is unrelated to
-    # 'ratchet-bump'. Cascade still fires N workflow runs on bulk label application,
-    # but each one exits in ~3s with no checkout cost — no "cancelled" surface.
+    # t2231/t3403: fast-fail gate — skip entirely when a labeled event is
+    # unrelated to 'ratchet-bump'. Cascade can still fire N workflow runs on
+    # bulk label application, but cancel-in-progress is disabled so these
+    # cheap skipped runs cannot cancel the required scan from opened/synchronize.
     if: >-
       github.event.action != 'labeled' ||
       github.event.label.name == 'ratchet-bump'

--- a/TODO.md
+++ b/TODO.md
@@ -908,6 +908,8 @@ t193,setup.sh fails in non-interactive supervisor deploy step,,bugfix|setup,1h,4
 
 - [x] t3397 Fix task-complete-helper merged PR detection #auto-dispatch #bug #framework ref:GH#22178 pr:#22181 completed:2026-05-01
 
+- [ ] t3403 Fix quality gate false failures from workflow cancellation #bug ref:GH#22194
+
 ## In Progress
 
 - [x] t2744 raise GraphQL throttle defaults and reduce pulse/stats cycle pressure — circuit breaker default `0.05`→`0.30` (trips at 1500 remaining instead of 250), REST fallback default `10`→`1000` (REST takes over earlier, GraphQL kept in reserve), pulse interval default `120s`→`180s`, stats-wrapper interval `900s`→`3600s`. Also fixes macOS launchd path that ignored `supervisor.pulse_interval_seconds` from settings. Evidence: GraphQL=0/5000 vs REST=4044/5000 with 21 EXHAUSTED events in current pulse log; per-cycle cost (~400-700 pts) × 30 cycles/hr × 14 repos exceeds 5000/hr ceiling by 2-4×. All env-overridable, fully backwards-compatible. See `todo/tasks/t2744-brief.md`. #framework #pulse #interactive ~1h ref:GH#20482 started:2026-04-22 pr:#20483 completed:2026-04-22


### PR DESCRIPTION
## Summary

Prevents Qlty gate label-event runs from cancelling in-flight required checks, and tightens the workflow cascade linter so paths-ignore/job guards are no longer treated as cancellation mitigations.

## Files Changed

.agents/scripts/tests/test-workflow-cascade-lint.sh,.agents/scripts/workflow-cascade-lint.sh,.github/workflows/qlty-new-file-gate.yml,.github/workflows/qlty-regression.yml,TODO.md

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-workflow-cascade-lint.sh; shellcheck .agents/scripts/workflow-cascade-lint.sh .agents/scripts/tests/test-workflow-cascade-lint.sh; bash .agents/scripts/workflow-cascade-lint.sh .github/workflows/qlty-regression.yml .github/workflows/qlty-new-file-gate.yml

Resolves #22194


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.80 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 7m and 199,968 tokens on this as a headless worker.