### PR TITLE
GH#22191: guard Snap runtime candidate on non-Linux

### DIFF
--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -937,6 +937,38 @@ _validate_opencode_binary() {
 	return 0
 }
 
+_headless_runtime_is_linux() {
+	local platform="${AIDEVOPS_TEST_UNAME_S:-}"
+	if [[ -z "$platform" ]]; then
+		platform=$(uname -s 2>/dev/null || true)
+	fi
+	[[ "$platform" == "Linux" ]] && return 0
+	return 1
+}
+
+_opencode_fixed_candidate_paths() {
+	local fixed_candidates=(
+		"/opt/homebrew/bin/opencode"
+		"/usr/local/bin/opencode"
+		"${HOME}/.local/bin/opencode"
+		"${HOME}/.opencode/bin/opencode"
+	)
+	if _headless_runtime_is_linux; then
+		fixed_candidates+=("/snap/bin/opencode")
+	fi
+	printf '%s\n' "${fixed_candidates[@]}"
+	return 0
+}
+
+_opencode_fixed_candidate_dirs_for_warning() {
+	local fixed_candidate_dirs="/opt/homebrew/bin, /usr/local/bin, ~/.local/bin, ~/.opencode/bin"
+	if _headless_runtime_is_linux; then
+		fixed_candidate_dirs="${fixed_candidate_dirs}, /snap/bin"
+	fi
+	printf '%s' "$fixed_candidate_dirs"
+	return 0
+}
+
 #######################################
 # t2887/t2954: Search common installation paths for a real anomalyco/opencode
 # binary. Used as a self-heal when $OPENCODE_BIN_DEFAULT resolves to the
@@ -955,20 +987,13 @@ _validate_opencode_binary() {
 #######################################
 _find_alternative_opencode_binary() {
 	# Fixed install paths (Homebrew, npm-global, Snap, etc.).
-	local fixed_candidates=(
-		"/opt/homebrew/bin/opencode"
-		"/usr/local/bin/opencode"
-		"${HOME}/.local/bin/opencode"
-		"${HOME}/.opencode/bin/opencode"
-		"/snap/bin/opencode"
-	)
 	local candidate
-	for candidate in "${fixed_candidates[@]}"; do
+	while IFS= read -r candidate; do
 		if [[ -x "$candidate" ]] && _validate_opencode_binary "$candidate"; then
 			printf '%s\n' "$candidate"
 			return 0
 		fi
-	done
+	done < <(_opencode_fixed_candidate_paths)
 
 	# t2954: Node version manager sweep (nvm, volta, fnm). Newest version
 	# wins (sort -rV) so users on multiple Node versions get the most-
@@ -1183,7 +1208,7 @@ _run_canary_test() {
 			# fail-fast on the cache hit instead of re-discovering this
 			# state every 90s.
 			print_warning "Canary: OPENCODE_BIN_DEFAULT='${OPENCODE_BIN_DEFAULT}' returns '${wrong_version}' (rc=${_validate_rc}) — not anomalyco/opencode."
-			print_warning "Canary: searched /opt/homebrew/bin, /usr/local/bin, ~/.local/bin, ~/.opencode/bin, /snap/bin — no valid binary found."
+			print_warning "Canary: searched $(_opencode_fixed_candidate_dirs_for_warning) — no valid binary found."
 			print_warning "Canary: install with 'npm install -g opencode-ai' or set OPENCODE_BIN to a valid binary (t2887)."
 			mkdir -p "${STATE_DIR}" 2>/dev/null || true
 			date +%s >"$fail_cache_file" 2>/dev/null || true

--- a/.agents/scripts/tests/test-headless-runtime-opencode-candidates.sh
+++ b/.agents/scripts/tests/test-headless-runtime-opencode-candidates.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression tests for platform-aware headless OpenCode fallback candidates.
+
+set -uo pipefail
+
+TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_REPO_ROOT="$(cd "$TEST_SCRIPTS_DIR/../.." && pwd)"
+TEST_RED=$'\033[0;31m'
+TEST_GREEN=$'\033[0;32m'
+TEST_RESET=$'\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1" rc="$2" extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf '%sPASS%s %s\n' "$TEST_GREEN" "$TEST_RESET" "$name"
+	else
+		printf '%sFAIL%s %s %s\n' "$TEST_RED" "$TEST_RESET" "$name" "$extra"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+run_candidate_list_for_platform() {
+	local platform="$1"
+	(
+		export AIDEVOPS_TEST_UNAME_S="$platform"
+		# shellcheck disable=SC1091
+		source "$TEST_REPO_ROOT/.agents/scripts/headless-runtime-lib.sh"
+		_opencode_fixed_candidate_paths
+	)
+	return 0
+}
+
+run_warning_dirs_for_platform() {
+	local platform="$1"
+	(
+		export AIDEVOPS_TEST_UNAME_S="$platform"
+		# shellcheck disable=SC1091
+		source "$TEST_REPO_ROOT/.agents/scripts/headless-runtime-lib.sh"
+		_opencode_fixed_candidate_dirs_for_warning
+	)
+	return 0
+}
+
+# Darwin must not include Linux-only Snap paths.
+darwin_candidates=$(run_candidate_list_for_platform "Darwin")
+if [[ "$darwin_candidates" != *"/snap/bin/opencode"* ]]; then
+	print_result "Darwin candidate list excludes /snap/bin/opencode" 0
+else
+	print_result "Darwin candidate list excludes /snap/bin/opencode" 1 "$darwin_candidates"
+fi
+
+darwin_warning=$(run_warning_dirs_for_platform "Darwin")
+if [[ "$darwin_warning" != *"/snap/bin"* ]]; then
+	print_result "Darwin warning text excludes /snap/bin" 0
+else
+	print_result "Darwin warning text excludes /snap/bin" 1 "$darwin_warning"
+fi
+
+# Linux keeps Snap-installed OpenCode discoverable.
+linux_candidates=$(run_candidate_list_for_platform "Linux")
+if [[ "$linux_candidates" == *"/snap/bin/opencode"* ]]; then
+	print_result "Linux candidate list includes /snap/bin/opencode" 0
+else
+	print_result "Linux candidate list includes /snap/bin/opencode" 1 "$linux_candidates"
+fi
+
+linux_warning=$(run_warning_dirs_for_platform "Linux")
+if [[ "$linux_warning" == *"/snap/bin"* ]]; then
+	print_result "Linux warning text includes /snap/bin" 0
+else
+	print_result "Linux warning text includes /snap/bin" 1 "$linux_warning"
+fi
+
+echo ""
+echo "Tests run: $TESTS_RUN"
+echo "Failed:    $TESTS_FAILED"
+
+if [[ "$TESTS_FAILED" -eq 0 ]]; then
+	exit 0
+fi
+exit 1


### PR DESCRIPTION
## Summary

Made the headless OpenCode fallback candidate list platform-aware so /snap/bin is only listed on Linux, and aligned the no-binary warning with the same candidate list.

## Files Changed

.agents/scripts/headless-runtime-lib.sh,.agents/scripts/tests/test-headless-runtime-opencode-candidates.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-headless-runtime-opencode-candidates.sh; shellcheck .agents/scripts/headless-runtime-lib.sh .agents/scripts/tests/test-headless-runtime-opencode-candidates.sh; rg -n '/snap/bin' .agents/scripts/headless-runtime-lib.sh

Resolves #22191


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.80 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 8m and 175,169 tokens on this as a headless worker.