### PR TITLE
t3404: enforce public repo PR gating

### DIFF
--- a/.agents/scripts/commands/setup-git.md
+++ b/.agents/scripts/commands/setup-git.md
@@ -116,6 +116,43 @@ Dismiss without re-syncing (e.g., intentional fork with own secrets):
 
 After the operator confirms the re-sync PR is merged, move on.
 
+### Phase 1.6 — Public Repo PR-Gating Remediation (GH#22195)
+
+For public repos where the current GitHub token has admin access,
+`aidevops security check` treats missing effective PR merge gating as an
+actionable failure. This setup command may guide the operator, but it must not
+silently change branch protection during unrelated secret setup.
+
+Use this template for each affected public ADMIN repo:
+
+```text
+=== Repo: <SLUG> — branch protection / ruleset setup needed ===
+
+Why this matters: public repos need GitHub-enforced PR review and required
+status checks on the default branch. Pulse-side merge logic is defense in depth,
+not a substitute for repository protection.
+
+Fix (maintainer/admin action — run explicitly in GitHub settings or a separate
+terminal):
+
+  1. Ensure review-bot-gate.yml and maintainer-gate.yml are installed/current:
+       aidevops check-workflows --repo <SLUG>
+       aidevops sync-workflows --apply --repo <SLUG>   # only if drift/missing
+
+  2. In GitHub Settings → Rules → Rulesets (preferred) or Branches → Branch
+     protection, target the default branch and require:
+       - Pull request before merging
+       - At least 1 approving review
+       - Required status checks, including review-bot-gate and maintainer-gate
+       - No admin bypass for public ADMIN repos unless consciously documented
+
+  3. Verify:
+       aidevops security check --repo <SLUG>
+
+Do not ask the AI session to apply protection implicitly; this changes repo
+security posture and should be a deliberate maintainer/admin action.
+```
+
 ### Phase 2 — Per-Repo Walkthrough
 
 For each repo with missing `SYNC_PAT`, present this template (substitute slug

--- a/.agents/scripts/security-posture-helper-repo.sh
+++ b/.agents/scripts/security-posture-helper-repo.sh
@@ -222,13 +222,164 @@ check_workflow_security() {
 	return 0
 }
 
+# _report_rulesets_branch_protection <slug> <default-branch> <public-admin-flag>
+_report_rulesets_branch_protection() {
+	local slug="$1"
+	local default_branch="$2"
+	local public_admin="$3"
+
+	local rulesets_state protected_by_rulesets rulesets_reviews rulesets_checks rulesets_bypass
+	if rulesets_state=$(_rulesets_pr_gating_state "$slug" "$default_branch"); then
+		IFS=$'\t' read -r protected_by_rulesets rulesets_reviews rulesets_checks rulesets_bypass <<<"$rulesets_state"
+	else
+		protected_by_rulesets=0
+		rulesets_reviews=0
+		rulesets_checks=0
+		rulesets_bypass=0
+	fi
+
+	if [[ "$protected_by_rulesets" -ne 1 ]]; then
+		print_crit "Default branch '$default_branch' has NO branch protection or active matching ruleset"
+		add_finding "$SEVERITY_CRITICAL" "$CAT_BRANCH_PROTECTION" "No branch protection on $default_branch"
+		return 0
+	fi
+
+	print_pass "Default branch '$default_branch' protected by active repository ruleset(s)"
+	add_finding "$SEVERITY_PASS" "$CAT_BRANCH_PROTECTION" "Rulesets protect $default_branch"
+	_report_rulesets_review_requirement "$default_branch" "$public_admin" "$rulesets_reviews"
+	_report_rulesets_check_requirement "$default_branch" "$public_admin" "$rulesets_checks"
+	_report_rulesets_bypass_requirement "$public_admin" "$rulesets_bypass"
+	return 0
+}
+
+_report_rulesets_review_requirement() {
+	local default_branch="$1"
+	local public_admin="$2"
+	local rulesets_reviews="$3"
+
+	if [[ "$rulesets_reviews" -eq 1 ]]; then
+		print_pass "Rulesets require pull request approval"
+		add_finding "$SEVERITY_PASS" "$CAT_BRANCH_PROTECTION" "Rulesets require PR approval"
+	elif [[ "$public_admin" -eq 1 ]]; then
+		print_crit "Rulesets do not require pull request approval on public ADMIN repo"
+		add_finding "$SEVERITY_CRITICAL" "$CAT_BRANCH_PROTECTION" "Rulesets missing PR approval requirement"
+	else
+		print_warn "Rulesets do not require pull request approval on $default_branch"
+		add_finding "$SEVERITY_WARNING" "$CAT_BRANCH_PROTECTION" "Rulesets missing PR approval requirement"
+	fi
+	return 0
+}
+
+_report_rulesets_check_requirement() {
+	local default_branch="$1"
+	local public_admin="$2"
+	local rulesets_checks="$3"
+
+	if [[ "$rulesets_checks" -eq 1 ]]; then
+		print_pass "Rulesets require status checks"
+		add_finding "$SEVERITY_PASS" "$CAT_BRANCH_PROTECTION" "Rulesets require status checks"
+	elif [[ "$public_admin" -eq 1 ]]; then
+		print_crit "Rulesets do not require status checks on public ADMIN repo"
+		add_finding "$SEVERITY_CRITICAL" "$CAT_BRANCH_PROTECTION" "Rulesets missing required status checks"
+	else
+		print_warn "Rulesets do not require status checks on $default_branch"
+		add_finding "$SEVERITY_WARNING" "$CAT_BRANCH_PROTECTION" "Rulesets missing required status checks"
+	fi
+	return 0
+}
+
+_report_rulesets_bypass_requirement() {
+	local public_admin="$1"
+	local rulesets_bypass="$2"
+
+	if [[ "$rulesets_bypass" -eq 1 && "$public_admin" -eq 1 ]]; then
+		print_crit "Rulesets define bypass actors on public ADMIN repo"
+		add_finding "$SEVERITY_CRITICAL" "$CAT_BRANCH_PROTECTION" "Rulesets allow bypass actors"
+	elif [[ "$rulesets_bypass" -eq 1 ]]; then
+		print_warn "Rulesets define bypass actors"
+		add_finding "$SEVERITY_WARNING" "$CAT_BRANCH_PROTECTION" "Rulesets allow bypass actors"
+	else
+		print_pass "Rulesets have no bypass actors"
+		add_finding "$SEVERITY_PASS" "$CAT_BRANCH_PROTECTION" "Rulesets have no bypass actors"
+	fi
+	return 0
+}
+
+_report_classic_branch_protection() {
+	local protection_json="$1"
+	local default_branch="$2"
+	local public_admin="$3"
+
+	local required_reviews required_checks enforce_admins
+	required_reviews=$(echo "$protection_json" | jq -r '.required_pull_request_reviews.required_approving_review_count // 0' 2>/dev/null) || required_reviews="0"
+	required_checks=$(_classic_required_checks_count "$protection_json")
+	enforce_admins=$(echo "$protection_json" | jq -r '.enforce_admins.enabled // false' 2>/dev/null) || enforce_admins="false"
+
+	_report_classic_review_requirement "$default_branch" "$public_admin" "$required_reviews"
+	_report_classic_check_requirement "$default_branch" "$public_admin" "$required_checks"
+	_report_classic_admin_enforcement "$public_admin" "$enforce_admins"
+	return 0
+}
+
+_report_classic_review_requirement() {
+	local default_branch="$1"
+	local public_admin="$2"
+	local required_reviews="$3"
+
+	if [[ "$required_reviews" -gt 0 ]]; then
+		print_pass "PR reviews required ($required_reviews approving review(s))"
+		add_finding "$SEVERITY_PASS" "$CAT_BRANCH_PROTECTION" "PR reviews required: $required_reviews"
+	elif [[ "$public_admin" -eq 1 ]]; then
+		print_crit "PR reviews not required on public ADMIN repo default branch '$default_branch'"
+		add_finding "$SEVERITY_CRITICAL" "$CAT_BRANCH_PROTECTION" "PR reviews not required"
+	else
+		print_warn "PR reviews not required on $default_branch"
+		add_finding "$SEVERITY_WARNING" "$CAT_BRANCH_PROTECTION" "PR reviews not required"
+	fi
+	return 0
+}
+
+_report_classic_check_requirement() {
+	local default_branch="$1"
+	local public_admin="$2"
+	local required_checks="$3"
+
+	if [[ "$required_checks" -gt 0 ]]; then
+		print_pass "Required status checks configured ($required_checks check(s))"
+		add_finding "$SEVERITY_PASS" "$CAT_BRANCH_PROTECTION" "Status checks configured: $required_checks"
+	elif [[ "$public_admin" -eq 1 ]]; then
+		print_crit "No required status checks on public ADMIN repo default branch '$default_branch'"
+		add_finding "$SEVERITY_CRITICAL" "$CAT_BRANCH_PROTECTION" "No required status checks"
+	else
+		print_warn "No required status checks on $default_branch"
+		add_finding "$SEVERITY_WARNING" "$CAT_BRANCH_PROTECTION" "No required status checks"
+	fi
+	return 0
+}
+
+_report_classic_admin_enforcement() {
+	local public_admin="$1"
+	local enforce_admins="$2"
+
+	if [[ "$enforce_admins" == "true" ]]; then
+		print_pass "Branch protection enforced for admins"
+		add_finding "$SEVERITY_PASS" "$CAT_BRANCH_PROTECTION" "Enforced for admins"
+	elif [[ "$public_admin" -eq 1 ]]; then
+		print_crit "Branch protection allows admin bypass on public ADMIN repo"
+		add_finding "$SEVERITY_CRITICAL" "$CAT_BRANCH_PROTECTION" "Not enforced for admins"
+	else
+		print_info "Branch protection not enforced for admins (common for solo repos)"
+		add_finding "$SEVERITY_INFO" "$CAT_BRANCH_PROTECTION" "Not enforced for admins"
+	fi
+	return 0
+}
+
 # Phase 2: Check branch protection
 check_branch_protection() {
 	local repo_path="$1"
 
 	print_header "Phase 2: Branch Protection"
 
-	# Need gh CLI and a GitHub remote
 	if ! command -v gh &>/dev/null; then
 		print_skip "GitHub CLI (gh) not installed — cannot check branch protection"
 		add_finding "$SEVERITY_INFO" "$CAT_BRANCH_PROTECTION" "gh CLI not available"
@@ -242,124 +393,22 @@ check_branch_protection() {
 		return 0
 	fi
 
-	# Detect default branch
-	local default_branch
+	local default_branch public_admin protection_json
 	default_branch=$(git -C "$repo_path" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's|refs/remotes/origin/||') || true
-	if [[ -z "$default_branch" ]]; then
-		default_branch="main"
-	fi
-
-	local public_admin=0
+	default_branch="${default_branch:-main}"
+	public_admin=0
 	if _repo_is_public_admin "$slug"; then
 		public_admin=1
 		print_info "Repository is public and current token has admin access — PR merge gating is required"
 	fi
 
-	# Query branch protection rules via gh API
-	local protection_json
 	protection_json=$(gh api "repos/$slug/branches/$default_branch/protection" 2>/dev/null) || true
-
 	if [[ -z "$protection_json" || "$protection_json" == *"Not Found"* || "$protection_json" == *"Branch not protected"* ]]; then
-		local rulesets_state protected_by_rulesets rulesets_reviews rulesets_checks rulesets_bypass
-		if rulesets_state=$(_rulesets_pr_gating_state "$slug" "$default_branch"); then
-			IFS=$'\t' read -r protected_by_rulesets rulesets_reviews rulesets_checks rulesets_bypass <<<"$rulesets_state"
-		else
-			protected_by_rulesets=0
-			rulesets_reviews=0
-			rulesets_checks=0
-			rulesets_bypass=0
-		fi
-
-		if [[ "$protected_by_rulesets" -ne 1 ]]; then
-			print_crit "Default branch '$default_branch' has NO branch protection or active matching ruleset"
-			add_finding "$SEVERITY_CRITICAL" "$CAT_BRANCH_PROTECTION" "No branch protection on $default_branch"
-			return 0
-		fi
-
-		print_pass "Default branch '$default_branch' protected by active repository ruleset(s)"
-		add_finding "$SEVERITY_PASS" "$CAT_BRANCH_PROTECTION" "Rulesets protect $default_branch"
-
-		if [[ "$rulesets_reviews" -eq 1 ]]; then
-			print_pass "Rulesets require pull request approval"
-			add_finding "$SEVERITY_PASS" "$CAT_BRANCH_PROTECTION" "Rulesets require PR approval"
-		elif [[ "$public_admin" -eq 1 ]]; then
-			print_crit "Rulesets do not require pull request approval on public ADMIN repo"
-			add_finding "$SEVERITY_CRITICAL" "$CAT_BRANCH_PROTECTION" "Rulesets missing PR approval requirement"
-		else
-			print_warn "Rulesets do not require pull request approval on $default_branch"
-			add_finding "$SEVERITY_WARNING" "$CAT_BRANCH_PROTECTION" "Rulesets missing PR approval requirement"
-		fi
-
-		if [[ "$rulesets_checks" -eq 1 ]]; then
-			print_pass "Rulesets require status checks"
-			add_finding "$SEVERITY_PASS" "$CAT_BRANCH_PROTECTION" "Rulesets require status checks"
-		elif [[ "$public_admin" -eq 1 ]]; then
-			print_crit "Rulesets do not require status checks on public ADMIN repo"
-			add_finding "$SEVERITY_CRITICAL" "$CAT_BRANCH_PROTECTION" "Rulesets missing required status checks"
-		else
-			print_warn "Rulesets do not require status checks on $default_branch"
-			add_finding "$SEVERITY_WARNING" "$CAT_BRANCH_PROTECTION" "Rulesets missing required status checks"
-		fi
-
-		if [[ "$rulesets_bypass" -eq 1 && "$public_admin" -eq 1 ]]; then
-			print_crit "Rulesets define bypass actors on public ADMIN repo"
-			add_finding "$SEVERITY_CRITICAL" "$CAT_BRANCH_PROTECTION" "Rulesets allow bypass actors"
-		elif [[ "$rulesets_bypass" -eq 1 ]]; then
-			print_warn "Rulesets define bypass actors"
-			add_finding "$SEVERITY_WARNING" "$CAT_BRANCH_PROTECTION" "Rulesets allow bypass actors"
-		else
-			print_pass "Rulesets have no bypass actors"
-			add_finding "$SEVERITY_PASS" "$CAT_BRANCH_PROTECTION" "Rulesets have no bypass actors"
-		fi
-
+		_report_rulesets_branch_protection "$slug" "$default_branch" "$public_admin"
 		return 0
 	fi
 
-	# Check: require PR reviews
-	local required_reviews
-	required_reviews=$(echo "$protection_json" | jq -r '.required_pull_request_reviews.required_approving_review_count // 0' 2>/dev/null) || required_reviews="0"
-
-	if [[ "$required_reviews" -gt 0 ]]; then
-		print_pass "PR reviews required ($required_reviews approving review(s))"
-		add_finding "$SEVERITY_PASS" "$CAT_BRANCH_PROTECTION" "PR reviews required: $required_reviews"
-	elif [[ "$public_admin" -eq 1 ]]; then
-		print_crit "PR reviews not required on public ADMIN repo default branch '$default_branch'"
-		add_finding "$SEVERITY_CRITICAL" "$CAT_BRANCH_PROTECTION" "PR reviews not required"
-	else
-		print_warn "PR reviews not required on $default_branch"
-		add_finding "$SEVERITY_WARNING" "$CAT_BRANCH_PROTECTION" "PR reviews not required"
-	fi
-
-	# Check: require status checks
-	local required_checks
-	required_checks=$(_classic_required_checks_count "$protection_json")
-
-	if [[ "$required_checks" -gt 0 ]]; then
-		print_pass "Required status checks configured ($required_checks check(s))"
-		add_finding "$SEVERITY_PASS" "$CAT_BRANCH_PROTECTION" "Status checks configured: $required_checks"
-	elif [[ "$public_admin" -eq 1 ]]; then
-		print_crit "No required status checks on public ADMIN repo default branch '$default_branch'"
-		add_finding "$SEVERITY_CRITICAL" "$CAT_BRANCH_PROTECTION" "No required status checks"
-	else
-		print_warn "No required status checks on $default_branch"
-		add_finding "$SEVERITY_WARNING" "$CAT_BRANCH_PROTECTION" "No required status checks"
-	fi
-
-	# Check: enforce for admins
-	local enforce_admins
-	enforce_admins=$(echo "$protection_json" | jq -r '.enforce_admins.enabled // false' 2>/dev/null) || enforce_admins="false"
-
-	if [[ "$enforce_admins" == "true" ]]; then
-		print_pass "Branch protection enforced for admins"
-		add_finding "$SEVERITY_PASS" "$CAT_BRANCH_PROTECTION" "Enforced for admins"
-	elif [[ "$public_admin" -eq 1 ]]; then
-		print_crit "Branch protection allows admin bypass on public ADMIN repo"
-		add_finding "$SEVERITY_CRITICAL" "$CAT_BRANCH_PROTECTION" "Not enforced for admins"
-	else
-		print_info "Branch protection not enforced for admins (common for solo repos)"
-		add_finding "$SEVERITY_INFO" "$CAT_BRANCH_PROTECTION" "Not enforced for admins"
-	fi
-
+	_report_classic_branch_protection "$protection_json" "$default_branch" "$public_admin"
 	return 0
 }
 

--- a/.agents/scripts/security-posture-helper-repo.sh
+++ b/.agents/scripts/security-posture-helper-repo.sh
@@ -33,6 +33,96 @@ fi
 
 # --- Functions ---
 
+# _repo_is_public_admin <slug>
+# Returns 0 only when GitHub confirms this operator has admin rights on a
+# public repository. API/auth failures are fail-open for audit availability: the
+# caller should keep baseline severities instead of inventing repository scope.
+_repo_is_public_admin() {
+	local slug="$1"
+
+	local repo_json
+	repo_json=$(gh api "repos/${slug}" 2>/dev/null) || return 1
+	[[ -z "$repo_json" ]] && return 1
+
+	local is_private has_admin
+	is_private=$(echo "$repo_json" | jq -r 'if has("private") then .private else true end' 2>/dev/null) || return 1
+	has_admin=$(echo "$repo_json" | jq -r '.permissions.admin // false' 2>/dev/null) || return 1
+
+	[[ "$is_private" == "false" && "$has_admin" == "true" ]]
+	return $?
+}
+
+# _classic_required_checks_count <protection-json>
+# Counts both legacy `.contexts[]` and modern `.checks[]` required-check shapes.
+_classic_required_checks_count() {
+	local protection_json="$1"
+
+	local required_checks
+	required_checks=$(echo "$protection_json" | jq -r '((.required_status_checks.contexts // []) | length) + ((.required_status_checks.checks // []) | length)' 2>/dev/null) || required_checks="0"
+	[[ "$required_checks" =~ ^[0-9]+$ ]] || required_checks="0"
+	printf '%s\n' "$required_checks"
+	return 0
+}
+
+# _rulesets_pr_gating_state <slug> <default-branch>
+# Emits tab-separated: protected reviews checks bypass. A public ADMIN repo is
+# considered ruleset-backed only when active default-branch rulesets enforce a
+# PR approval and at least one required status check. Bypass actors are surfaced
+# as admin-bypass risk because they weaken the repository-level invariant.
+_rulesets_pr_gating_state() {
+	local slug="$1"
+	local default_branch="$2"
+
+	local rulesets_json
+	rulesets_json=$(gh api "repos/${slug}/rulesets" 2>/dev/null) || return 1
+	[[ -z "$rulesets_json" || "$rulesets_json" == "[]" ]] && return 1
+
+	local active_ids
+	active_ids=$(echo "$rulesets_json" | jq -r '.[] | select(.enforcement == "active") | .id' 2>/dev/null) || return 1
+	[[ -z "$active_ids" ]] && return 1
+
+	local protected=0
+	local reviews=0
+	local checks=0
+	local bypass=0
+	local id detail include_patterns pattern matches_default
+	while IFS= read -r id; do
+		[[ -z "$id" ]] && continue
+		detail=$(gh api "repos/${slug}/rulesets/${id}" 2>/dev/null) || continue
+		include_patterns=$(echo "$detail" | jq -r '.conditions.ref_name.include // [] | .[]' 2>/dev/null) || continue
+
+		matches_default=0
+		while IFS= read -r pattern; do
+			[[ -z "$pattern" ]] && continue
+			case "$pattern" in
+			"refs/heads/${default_branch}" | "~DEFAULT_BRANCH" | "~ALL" | "refs/heads/*")
+				matches_default=1
+				break
+				;;
+			esac
+		done <<<"$include_patterns"
+
+		[[ "$matches_default" -eq 1 ]] || continue
+		protected=1
+
+		local approval_count status_count bypass_count
+		approval_count=$(echo "$detail" | jq -r '[.rules[]? | select(.type == "pull_request") | (.parameters.required_approving_review_count // 0)] | max // 0' 2>/dev/null) || approval_count="0"
+		status_count=$(echo "$detail" | jq -r '[.rules[]? | select(.type == "required_status_checks") | (.parameters.required_status_checks // []) | length] | add // 0' 2>/dev/null) || status_count="0"
+		bypass_count=$(echo "$detail" | jq -r '(.bypass_actors // []) | length' 2>/dev/null) || bypass_count="0"
+
+		[[ "$approval_count" =~ ^[0-9]+$ ]] || approval_count="0"
+		[[ "$status_count" =~ ^[0-9]+$ ]] || status_count="0"
+		[[ "$bypass_count" =~ ^[0-9]+$ ]] || bypass_count="0"
+
+		[[ "$approval_count" -gt 0 ]] && reviews=1
+		[[ "$status_count" -gt 0 ]] && checks=1
+		[[ "$bypass_count" -gt 0 ]] && bypass=1
+	done <<<"$active_ids"
+
+	printf '%s\t%s\t%s\t%s\n' "$protected" "$reviews" "$checks" "$bypass"
+	return 0
+}
+
 # Phase 1: Scan .github/workflows/ for unsafe AI patterns
 # Checks for:
 #   - shell + credentials + untrusted input (injection risk)
@@ -159,13 +249,69 @@ check_branch_protection() {
 		default_branch="main"
 	fi
 
+	local public_admin=0
+	if _repo_is_public_admin "$slug"; then
+		public_admin=1
+		print_info "Repository is public and current token has admin access — PR merge gating is required"
+	fi
+
 	# Query branch protection rules via gh API
 	local protection_json
 	protection_json=$(gh api "repos/$slug/branches/$default_branch/protection" 2>/dev/null) || true
 
 	if [[ -z "$protection_json" || "$protection_json" == *"Not Found"* || "$protection_json" == *"Branch not protected"* ]]; then
-		print_crit "Default branch '$default_branch' has NO branch protection"
-		add_finding "$SEVERITY_CRITICAL" "$CAT_BRANCH_PROTECTION" "No branch protection on $default_branch"
+		local rulesets_state protected_by_rulesets rulesets_reviews rulesets_checks rulesets_bypass
+		if rulesets_state=$(_rulesets_pr_gating_state "$slug" "$default_branch"); then
+			IFS=$'\t' read -r protected_by_rulesets rulesets_reviews rulesets_checks rulesets_bypass <<<"$rulesets_state"
+		else
+			protected_by_rulesets=0
+			rulesets_reviews=0
+			rulesets_checks=0
+			rulesets_bypass=0
+		fi
+
+		if [[ "$protected_by_rulesets" -ne 1 ]]; then
+			print_crit "Default branch '$default_branch' has NO branch protection or active matching ruleset"
+			add_finding "$SEVERITY_CRITICAL" "$CAT_BRANCH_PROTECTION" "No branch protection on $default_branch"
+			return 0
+		fi
+
+		print_pass "Default branch '$default_branch' protected by active repository ruleset(s)"
+		add_finding "$SEVERITY_PASS" "$CAT_BRANCH_PROTECTION" "Rulesets protect $default_branch"
+
+		if [[ "$rulesets_reviews" -eq 1 ]]; then
+			print_pass "Rulesets require pull request approval"
+			add_finding "$SEVERITY_PASS" "$CAT_BRANCH_PROTECTION" "Rulesets require PR approval"
+		elif [[ "$public_admin" -eq 1 ]]; then
+			print_crit "Rulesets do not require pull request approval on public ADMIN repo"
+			add_finding "$SEVERITY_CRITICAL" "$CAT_BRANCH_PROTECTION" "Rulesets missing PR approval requirement"
+		else
+			print_warn "Rulesets do not require pull request approval on $default_branch"
+			add_finding "$SEVERITY_WARNING" "$CAT_BRANCH_PROTECTION" "Rulesets missing PR approval requirement"
+		fi
+
+		if [[ "$rulesets_checks" -eq 1 ]]; then
+			print_pass "Rulesets require status checks"
+			add_finding "$SEVERITY_PASS" "$CAT_BRANCH_PROTECTION" "Rulesets require status checks"
+		elif [[ "$public_admin" -eq 1 ]]; then
+			print_crit "Rulesets do not require status checks on public ADMIN repo"
+			add_finding "$SEVERITY_CRITICAL" "$CAT_BRANCH_PROTECTION" "Rulesets missing required status checks"
+		else
+			print_warn "Rulesets do not require status checks on $default_branch"
+			add_finding "$SEVERITY_WARNING" "$CAT_BRANCH_PROTECTION" "Rulesets missing required status checks"
+		fi
+
+		if [[ "$rulesets_bypass" -eq 1 && "$public_admin" -eq 1 ]]; then
+			print_crit "Rulesets define bypass actors on public ADMIN repo"
+			add_finding "$SEVERITY_CRITICAL" "$CAT_BRANCH_PROTECTION" "Rulesets allow bypass actors"
+		elif [[ "$rulesets_bypass" -eq 1 ]]; then
+			print_warn "Rulesets define bypass actors"
+			add_finding "$SEVERITY_WARNING" "$CAT_BRANCH_PROTECTION" "Rulesets allow bypass actors"
+		else
+			print_pass "Rulesets have no bypass actors"
+			add_finding "$SEVERITY_PASS" "$CAT_BRANCH_PROTECTION" "Rulesets have no bypass actors"
+		fi
+
 		return 0
 	fi
 
@@ -176,6 +322,9 @@ check_branch_protection() {
 	if [[ "$required_reviews" -gt 0 ]]; then
 		print_pass "PR reviews required ($required_reviews approving review(s))"
 		add_finding "$SEVERITY_PASS" "$CAT_BRANCH_PROTECTION" "PR reviews required: $required_reviews"
+	elif [[ "$public_admin" -eq 1 ]]; then
+		print_crit "PR reviews not required on public ADMIN repo default branch '$default_branch'"
+		add_finding "$SEVERITY_CRITICAL" "$CAT_BRANCH_PROTECTION" "PR reviews not required"
 	else
 		print_warn "PR reviews not required on $default_branch"
 		add_finding "$SEVERITY_WARNING" "$CAT_BRANCH_PROTECTION" "PR reviews not required"
@@ -183,11 +332,14 @@ check_branch_protection() {
 
 	# Check: require status checks
 	local required_checks
-	required_checks=$(echo "$protection_json" | jq -r '.required_status_checks.contexts // [] | length' 2>/dev/null) || required_checks="0"
+	required_checks=$(_classic_required_checks_count "$protection_json")
 
 	if [[ "$required_checks" -gt 0 ]]; then
 		print_pass "Required status checks configured ($required_checks check(s))"
 		add_finding "$SEVERITY_PASS" "$CAT_BRANCH_PROTECTION" "Status checks configured: $required_checks"
+	elif [[ "$public_admin" -eq 1 ]]; then
+		print_crit "No required status checks on public ADMIN repo default branch '$default_branch'"
+		add_finding "$SEVERITY_CRITICAL" "$CAT_BRANCH_PROTECTION" "No required status checks"
 	else
 		print_warn "No required status checks on $default_branch"
 		add_finding "$SEVERITY_WARNING" "$CAT_BRANCH_PROTECTION" "No required status checks"
@@ -200,6 +352,9 @@ check_branch_protection() {
 	if [[ "$enforce_admins" == "true" ]]; then
 		print_pass "Branch protection enforced for admins"
 		add_finding "$SEVERITY_PASS" "$CAT_BRANCH_PROTECTION" "Enforced for admins"
+	elif [[ "$public_admin" -eq 1 ]]; then
+		print_crit "Branch protection allows admin bypass on public ADMIN repo"
+		add_finding "$SEVERITY_CRITICAL" "$CAT_BRANCH_PROTECTION" "Not enforced for admins"
 	else
 		print_info "Branch protection not enforced for admins (common for solo repos)"
 		add_finding "$SEVERITY_INFO" "$CAT_BRANCH_PROTECTION" "Not enforced for admins"

--- a/.agents/scripts/tests/test-security-posture-public-pr-gating.sh
+++ b/.agents/scripts/tests/test-security-posture-public-pr-gating.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-security-posture-public-pr-gating.sh — GH#22195 regression guard.
+#
+# Verifies public ADMIN repositories fail posture checks when default-branch PR
+# merge gating is incomplete, while classic and rulesets-backed protection with
+# review + required checks passes the branch protection phase.
+
+set -uo pipefail
+
+SCRIPT_DIR_TEST="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${SCRIPT_DIR_TEST}/.." && pwd)" || exit 1
+
+if [[ -t 1 ]]; then
+	TEST_GREEN=$'\033[0;32m'
+	TEST_RED=$'\033[0;31m'
+	TEST_NC=$'\033[0m'
+else
+	TEST_GREEN="" TEST_RED="" TEST_NC=""
+fi
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+pass() {
+	local msg="$1"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf '  %sPASS%s %s\n' "$TEST_GREEN" "$TEST_NC" "$msg"
+	return 0
+}
+
+fail() {
+	local msg="$1"
+	local detail="${2:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf '  %sFAIL%s %s\n' "$TEST_RED" "$TEST_NC" "$msg"
+	if [[ -n "$detail" ]]; then
+		printf '       %s\n' "$detail"
+	fi
+	return 0
+}
+
+TMP=$(mktemp -d -t gh22195.XXXXXX)
+trap 'rm -rf "$TMP"' EXIT
+
+FAKE_REPO="$TMP/fake-repo"
+mkdir -p "$FAKE_REPO/.git"
+
+OUTPUT_LOG="$TMP/output.log"
+FINDINGS_CRITICAL=0
+FINDINGS_WARNING=0
+FINDINGS_INFO=0
+FINDINGS_PASS=0
+FINDINGS_JSON="[]"
+
+readonly CLASSIC_GOOD='{"required_pull_request_reviews":{"required_approving_review_count":1},"required_status_checks":{"contexts":["review-bot-gate"]},"enforce_admins":{"enabled":true}}'
+readonly CLASSIC_NO_REVIEWS='{"required_pull_request_reviews":{"required_approving_review_count":0},"required_status_checks":{"contexts":["review-bot-gate"]},"enforce_admins":{"enabled":true}}'
+readonly CLASSIC_NO_CHECKS='{"required_pull_request_reviews":{"required_approving_review_count":1},"required_status_checks":{"contexts":[]},"enforce_admins":{"enabled":true}}'
+readonly CLASSIC_ADMIN_BYPASS='{"required_pull_request_reviews":{"required_approving_review_count":1},"required_status_checks":{"contexts":["review-bot-gate"]},"enforce_admins":{"enabled":false}}'
+readonly REPO_PUBLIC_ADMIN='{"private":false,"permissions":{"admin":true}}'
+readonly RULESETS_LIST_ACTIVE='[{"id":1000,"enforcement":"active"}]'
+readonly RULESET_GOOD='{"conditions":{"ref_name":{"include":["refs/heads/main"]}},"rules":[{"type":"pull_request","parameters":{"required_approving_review_count":1}},{"type":"required_status_checks","parameters":{"required_status_checks":[{"context":"review-bot-gate"}]}}],"bypass_actors":[]}'
+readonly RULESET_NO_CHECKS='{"conditions":{"ref_name":{"include":["refs/heads/main"]}},"rules":[{"type":"pull_request","parameters":{"required_approving_review_count":1}}],"bypass_actors":[]}'
+
+STUB_REPO_JSON="$REPO_PUBLIC_ADMIN"
+STUB_PROTECTION_RESPONSE="$CLASSIC_GOOD"
+STUB_RULESETS_LIST=""
+STUB_RULESET_DETAIL=""
+
+gh() {
+	local cmd="$1"
+	case "$cmd" in
+	api)
+		local url="${2:-}"
+		case "$url" in
+		"repos/testowner/testrepo")
+			printf '%s\n' "$STUB_REPO_JSON"
+			return 0
+			;;
+		*"/branches/main/protection")
+			if [[ -n "$STUB_PROTECTION_RESPONSE" ]]; then
+				printf '%s\n' "$STUB_PROTECTION_RESPONSE"
+				return 0
+			fi
+			printf '%s\n' "Branch not protected"
+			return 1
+			;;
+		*"/rulesets/"*)
+			if [[ -n "$STUB_RULESET_DETAIL" ]]; then
+				printf '%s\n' "$STUB_RULESET_DETAIL"
+				return 0
+			fi
+			return 1
+			;;
+		*"/rulesets")
+			if [[ -n "$STUB_RULESETS_LIST" ]]; then
+				printf '%s\n' "$STUB_RULESETS_LIST"
+				return 0
+			fi
+			return 1
+			;;
+		esac
+		return 1
+		;;
+	esac
+	return 0
+}
+
+git() {
+	local subcmd="${2:-}"
+	if [[ "$subcmd" == "symbolic-ref" ]]; then
+		printf '%s\n' "refs/remotes/origin/main"
+		return 0
+	fi
+	command git "$@"
+}
+
+jq() {
+	command jq "$@"
+}
+
+export -f gh git jq
+
+print_header() { local msg="$1"; printf '[HEADER] %s\n' "$msg" >>"$OUTPUT_LOG"; return 0; }
+print_info() { local msg="$1"; printf '[INFO] %s\n' "$msg" >>"$OUTPUT_LOG"; return 0; }
+print_pass() { local msg="$1"; printf '[PASS] %s\n' "$msg" >>"$OUTPUT_LOG"; return 0; }
+print_warn() { local msg="$1"; printf '[WARN] %s\n' "$msg" >>"$OUTPUT_LOG"; return 0; }
+print_crit() { local msg="$1"; printf '[CRIT] %s\n' "$msg" >>"$OUTPUT_LOG"; return 0; }
+print_skip() { local msg="$1"; printf '[SKIP] %s\n' "$msg" >>"$OUTPUT_LOG"; return 0; }
+
+add_finding() {
+	local severity="$1"
+	local _category="$2"
+	local _message="$3"
+	case "$severity" in
+	critical) FINDINGS_CRITICAL=$((FINDINGS_CRITICAL + 1)) ;;
+	warning) FINDINGS_WARNING=$((FINDINGS_WARNING + 1)) ;;
+	info) FINDINGS_INFO=$((FINDINGS_INFO + 1)) ;;
+	pass) FINDINGS_PASS=$((FINDINGS_PASS + 1)) ;;
+	esac
+	return 0
+}
+
+resolve_slug() {
+	local _repo_path="$1"
+	printf '%s\n' "testowner/testrepo"
+	return 0
+}
+
+eval "$(sed -n '/^_repo_is_public_admin()/,/^}/p' "${SCRIPTS_DIR}/security-posture-helper-repo.sh")"
+eval "$(sed -n '/^_classic_required_checks_count()/,/^}/p' "${SCRIPTS_DIR}/security-posture-helper-repo.sh")"
+eval "$(sed -n '/^_rulesets_pr_gating_state()/,/^}/p' "${SCRIPTS_DIR}/security-posture-helper-repo.sh")"
+eval "$(sed -n '/^check_branch_protection()/,/^}/p' "${SCRIPTS_DIR}/security-posture-helper-repo.sh")"
+
+SEVERITY_CRITICAL="critical"
+SEVERITY_WARNING="warning"
+SEVERITY_INFO="info"
+SEVERITY_PASS="pass"
+CAT_BRANCH_PROTECTION="branch_protection"
+
+reset_state() {
+	FINDINGS_CRITICAL=0
+	FINDINGS_WARNING=0
+	FINDINGS_INFO=0
+	FINDINGS_PASS=0
+	true >"$OUTPUT_LOG"
+	STUB_REPO_JSON="$REPO_PUBLIC_ADMIN"
+	STUB_PROTECTION_RESPONSE="$CLASSIC_GOOD"
+	STUB_RULESETS_LIST=""
+	STUB_RULESET_DETAIL=""
+	return 0
+}
+
+assert_counts() {
+	local name="$1"
+	local expected_critical="$2"
+	local expected_warning="$3"
+	if [[ "$FINDINGS_CRITICAL" -eq "$expected_critical" && "$FINDINGS_WARNING" -eq "$expected_warning" ]]; then
+		pass "$name"
+	else
+		fail "$name" "critical=$FINDINGS_CRITICAL warning=$FINDINGS_WARNING output=$(tr '\n' ';' <"$OUTPUT_LOG")"
+	fi
+	return 0
+}
+
+reset_state
+STUB_PROTECTION_RESPONSE=""
+check_branch_protection "$FAKE_REPO"
+assert_counts "public ADMIN without classic protection or rulesets is critical" 1 0
+
+reset_state
+STUB_PROTECTION_RESPONSE="$CLASSIC_NO_REVIEWS"
+check_branch_protection "$FAKE_REPO"
+assert_counts "public ADMIN classic protection without reviews is critical" 1 0
+
+reset_state
+STUB_PROTECTION_RESPONSE="$CLASSIC_NO_CHECKS"
+check_branch_protection "$FAKE_REPO"
+assert_counts "public ADMIN classic protection without checks is critical" 1 0
+
+reset_state
+STUB_PROTECTION_RESPONSE="$CLASSIC_ADMIN_BYPASS"
+check_branch_protection "$FAKE_REPO"
+assert_counts "public ADMIN classic protection with admin bypass is critical" 1 0
+
+reset_state
+STUB_PROTECTION_RESPONSE=""
+STUB_RULESETS_LIST="$RULESETS_LIST_ACTIVE"
+STUB_RULESET_DETAIL="$RULESET_GOOD"
+check_branch_protection "$FAKE_REPO"
+assert_counts "public ADMIN rulesets with reviews and checks pass" 0 0
+
+reset_state
+STUB_PROTECTION_RESPONSE=""
+STUB_RULESETS_LIST="$RULESETS_LIST_ACTIVE"
+STUB_RULESET_DETAIL="$RULESET_NO_CHECKS"
+check_branch_protection "$FAKE_REPO"
+assert_counts "public ADMIN rulesets without checks is critical" 1 0
+
+printf '\nRan %d tests, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+if [[ "$TESTS_FAILED" -gt 0 ]]; then
+	exit 1
+fi
+
+exit 0

--- a/.agents/scripts/tests/test-security-posture-public-pr-gating.sh
+++ b/.agents/scripts/tests/test-security-posture-public-pr-gating.sh
@@ -150,10 +150,8 @@ resolve_slug() {
 	return 0
 }
 
-eval "$(sed -n '/^_repo_is_public_admin()/,/^}/p' "${SCRIPTS_DIR}/security-posture-helper-repo.sh")"
-eval "$(sed -n '/^_classic_required_checks_count()/,/^}/p' "${SCRIPTS_DIR}/security-posture-helper-repo.sh")"
-eval "$(sed -n '/^_rulesets_pr_gating_state()/,/^}/p' "${SCRIPTS_DIR}/security-posture-helper-repo.sh")"
-eval "$(sed -n '/^check_branch_protection()/,/^}/p' "${SCRIPTS_DIR}/security-posture-helper-repo.sh")"
+# shellcheck source=../security-posture-helper-repo.sh
+source "${SCRIPTS_DIR}/security-posture-helper-repo.sh"
 
 SEVERITY_CRITICAL="critical"
 SEVERITY_WARNING="warning"

--- a/.agents/scripts/tests/test-sync-pat-detection.sh
+++ b/.agents/scripts/tests/test-sync-pat-detection.sh
@@ -179,13 +179,13 @@ export AIDEVOPS_AGENTS_DIR="$TMP/.aidevops/agents"
 mkdir -p "$AIDEVOPS_AGENTS_DIR"
 
 # Source shared-constants.sh fallbacks
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-CYAN='\033[0;36m'
-BOLD='\033[1m'
-NC='\033[0m'
+[[ -z "${RED+x}" ]] && RED='\033[0;31m'
+[[ -z "${GREEN+x}" ]] && GREEN='\033[0;32m'
+[[ -z "${YELLOW+x}" ]] && YELLOW='\033[1;33m'
+[[ -z "${BLUE+x}" ]] && BLUE='\033[0;34m'
+[[ -z "${CYAN+x}" ]] && CYAN='\033[0;36m'
+[[ -z "${BOLD+x}" ]] && BOLD='\033[1m'
+[[ -z "${NC+x}" ]] && NC='\033[0m'
 
 # Counters (same as in the helper)
 FINDINGS_CRITICAL=0

--- a/.agents/scripts/tests/test-sync-pat-detection.sh
+++ b/.agents/scripts/tests/test-sync-pat-detection.sh
@@ -238,10 +238,10 @@ resolve_slug() {
 # Extract function bodies from the helper (check_sync_pat + its sub-functions).
 # Order matters: _branch_is_rulesets_protected is called by _check_sync_pat_need
 # (t2806), so it must be defined first.
-eval "$(sed -n '/^_emit_sync_pat_advisory()/,/^}/p' "${SCRIPTS_DIR}/security-posture-helper.sh")"
-eval "$(sed -n '/^_branch_is_rulesets_protected()/,/^}/p' "${SCRIPTS_DIR}/security-posture-helper.sh")"
-eval "$(sed -n '/^_check_sync_pat_need()/,/^}/p' "${SCRIPTS_DIR}/security-posture-helper.sh")"
-eval "$(sed -n '/^check_sync_pat()/,/^}/p' "${SCRIPTS_DIR}/security-posture-helper.sh")"
+eval "$(sed -n '/^_emit_sync_pat_advisory()/,/^}/p' "${SCRIPTS_DIR}/security-posture-helper-repo.sh")"
+eval "$(sed -n '/^_branch_is_rulesets_protected()/,/^}/p' "${SCRIPTS_DIR}/security-posture-helper-repo.sh")"
+eval "$(sed -n '/^_check_sync_pat_need()/,/^}/p' "${SCRIPTS_DIR}/security-posture-helper-repo.sh")"
+eval "$(sed -n '/^check_sync_pat()/,/^}/p' "${SCRIPTS_DIR}/security-posture-helper-repo.sh")"
 
 # =============================================================================
 # Severity constants needed by the function


### PR DESCRIPTION
## Summary

Security posture now escalates missing default-branch PR review, required checks, and admin bypass to critical findings for public ADMIN repos, recognises rulesets-backed gating, and documents the explicit maintainer remediation flow in /setup-git.

## Files Changed

.agents/scripts/commands/setup-git.md,.agents/scripts/headless-runtime-lib.sh,.agents/scripts/security-posture-helper-repo.sh,.agents/scripts/tests/test-headless-runtime-opencode-candidates.sh,.agents/scripts/tests/test-security-posture-public-pr-gating.sh,.agents/scripts/tests/test-sync-pat-detection.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/security-posture-helper-repo.sh .agents/scripts/tests/test-security-posture-public-pr-gating.sh .agents/scripts/tests/test-sync-pat-detection.sh; bash .agents/scripts/tests/test-security-posture-public-pr-gating.sh; bash .agents/scripts/tests/test-sync-pat-detection.sh; .agents/scripts/linters-local.sh attempted but timed out after reporting pre-existing Sonar/skill-frontmatter failures

Resolves #22195


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.80 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 13m and 152,651 tokens on this as a headless worker.