### PR TITLE
t3402: sanitize inherited launchd PATH

### DIFF
--- a/.agents/scripts/auto-update-helper-scheduler.sh
+++ b/.agents/scripts/auto-update-helper-scheduler.sh
@@ -87,6 +87,7 @@ _generate_auto_update_plist() {
 	local script_path="$1"
 	local interval_seconds="$2"
 	local env_path="$3"
+	env_path=$(aidevops_launchd_sanitized_path "$env_path")
 
 	cat <<EOF
 <?xml version="1.0" encoding="UTF-8"?>

--- a/.agents/scripts/auto-update-helper.sh
+++ b/.agents/scripts/auto-update-helper.sh
@@ -172,6 +172,7 @@ _generate_auto_update_plist() {
 	local script_path="$1"
 	local interval_seconds="$2"
 	local env_path="$3"
+	env_path=$(aidevops_launchd_sanitized_path "$env_path")
 
 	cat <<EOF
 <?xml version="1.0" encoding="UTF-8"?>

--- a/.agents/scripts/memory-pressure-monitor.sh
+++ b/.agents/scripts/memory-pressure-monitor.sh
@@ -1209,7 +1209,7 @@ cmd_install() {
 	<key>EnvironmentVariables</key>
 	<dict>
 		<key>PATH</key>
-		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+		<string>$(aidevops_launchd_sanitized_path "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin")</string>
 		<key>HOME</key>
 		<string>${home_escaped}</string>
 	</dict>

--- a/.agents/scripts/opencode-db-maintenance-helper.sh
+++ b/.agents/scripts/opencode-db-maintenance-helper.sh
@@ -888,7 +888,7 @@ $([[ "$scheduler_subcommand" == "$MAINTENANCE_WINDOW_MODE" ]] && printf '\t\t<st
 	<key>EnvironmentVariables</key>
 	<dict>
 		<key>PATH</key>
-		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+		<string>$(aidevops_launchd_sanitized_path "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin")</string>
 		<key>HOME</key>
 		<string>${HOME}</string>
 	</dict>

--- a/.agents/scripts/repo-aidevops-health-helper.sh
+++ b/.agents/scripts/repo-aidevops-health-helper.sh
@@ -161,6 +161,7 @@ _generate_plist() {
 	local script_path="$1"
 	local interval_seconds="$2"
 	local env_path="$3"
+	env_path=$(aidevops_launchd_sanitized_path "$env_path")
 
 	cat <<EOF
 <?xml version="1.0" encoding="UTF-8"?>

--- a/.agents/scripts/repo-sync-helper.sh
+++ b/.agents/scripts/repo-sync-helper.sh
@@ -145,6 +145,7 @@ _generate_plist() {
 	local script_path="$1"
 	local interval_seconds="$2"
 	local env_path="$3"
+	env_path=$(aidevops_launchd_sanitized_path "$env_path")
 
 	cat <<EOF
 <?xml version="1.0" encoding="UTF-8"?>

--- a/.agents/scripts/routine-helper.sh
+++ b/.agents/scripts/routine-helper.sh
@@ -391,7 +391,7 @@ cmd_install_launchd() {
 	local home_escaped
 	home_escaped=$(xml_escape "$HOME")
 	local env_path_escaped
-	env_path_escaped=$(xml_escape "/bin:/usr/bin:/usr/local/bin:/opt/homebrew/bin:${PATH}")
+	env_path_escaped=$(xml_escape "$(aidevops_launchd_sanitized_path "/bin:/usr/bin:/usr/local/bin:/opt/homebrew/bin:${PATH}")")
 	local log_path_escaped
 	log_path_escaped=$(xml_escape "${HOME}/.aidevops/logs/routine-${ROUTINE_NAME}.log")
 

--- a/.agents/scripts/shared-constants.sh
+++ b/.agents/scripts/shared-constants.sh
@@ -189,6 +189,48 @@ readonly TEMPLATE_SUFFIX=".txt"
 readonly TEMP_PREFIX="tmp_"
 
 # =============================================================================
+# launchd PATH hygiene
+# =============================================================================
+# Build a PATH value safe to embed in macOS LaunchAgent EnvironmentVariables.
+# launchd jobs inherit no useful interactive shell setup, but serialising the
+# caller's raw PATH bakes stale manager-specific entries into long-lived plists.
+# Keep known system/tool roots first, then preserve only inherited entries that
+# actually exist on this host.
+
+_aidevops_append_launchd_path_dir() {
+	local dir="$1"
+	[[ -n "$dir" ]] || return 0
+	[[ -d "$dir" ]] || return 0
+	case ":${_aidevops_launchd_path_seen:-}:" in
+	*":${dir}:"*) return 0 ;;
+	esac
+	_aidevops_launchd_path_seen="${_aidevops_launchd_path_seen:+${_aidevops_launchd_path_seen}:}${dir}"
+	_aidevops_launchd_path_result="${_aidevops_launchd_path_result:+${_aidevops_launchd_path_result}:}${dir}"
+	return 0
+}
+
+aidevops_launchd_sanitized_path() {
+	local input_path="${1:-${PATH:-}}"
+	local default_path="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+	local _aidevops_launchd_path_result=""
+	local _aidevops_launchd_path_seen=""
+	local dir=""
+	local old_ifs="$IFS"
+
+	IFS=':'
+	for dir in $default_path; do
+		_aidevops_append_launchd_path_dir "$dir"
+	done
+	for dir in $input_path; do
+		_aidevops_append_launchd_path_dir "$dir"
+	done
+	IFS="$old_ifs"
+
+	printf '%s' "$_aidevops_launchd_path_result"
+	return 0
+}
+
+# =============================================================================
 # Credentials File Security
 # =============================================================================
 # Shared utility for ensuring credentials files have secure permissions.

--- a/.agents/scripts/tests/test-launchd-sanitized-path.sh
+++ b/.agents/scripts/tests/test-launchd-sanitized-path.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# Regression tests for GH#22192 / t3402: LaunchAgent PATH generation must not
+# serialize raw inherited shell PATH entries that do not exist on this host.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)" || exit 1
+
+# shellcheck source=../shared-constants.sh
+source "$REPO_ROOT/.agents/scripts/shared-constants.sh"
+
+LAUNCHD_LABEL="com.test.aidevops-auto-update"
+LOG_FILE="${TMPDIR:-/tmp}/aidevops-launchd-sanitized-path-test.log"
+LAUNCHD_DIR="${TMPDIR:-/tmp}"
+LAUNCHD_PLIST="${TMPDIR:-/tmp}/com.test.aidevops-auto-update.plist"
+SYSTEMD_SERVICE_DIR="${TMPDIR:-/tmp}"
+SYSTEMD_UNIT_NAME="aidevops-auto-update"
+CRON_MARKER="# aidevops-auto-update"
+DEFAULT_INTERVAL=10
+INSTALL_DIR="$REPO_ROOT"
+
+# shellcheck source=../auto-update-helper-scheduler.sh
+source "$REPO_ROOT/.agents/scripts/auto-update-helper-scheduler.sh"
+
+TESTS_RUN=0
+TESTS_FAILED=0
+TEST_DIR=""
+
+setup() {
+	TEST_DIR=$(mktemp -d)
+	trap teardown EXIT
+	return 0
+}
+
+teardown() {
+	if [[ -n "$TEST_DIR" && -d "$TEST_DIR" ]]; then
+		rm -rf "$TEST_DIR"
+	fi
+	return 0
+}
+
+pass() {
+	local name="$1"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	printf 'PASS %s\n' "$name"
+	return 0
+}
+
+fail() {
+	local name="$1"
+	local detail="$2"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	TESTS_FAILED=$((TESTS_FAILED + 1))
+	printf 'FAIL %s\n  %s\n' "$name" "$detail" >&2
+	return 0
+}
+
+assert_not_contains() {
+	local name="$1"
+	local haystack="$2"
+	local needle="$3"
+	if [[ "$haystack" == *"$needle"* ]]; then
+		fail "$name" "unexpected PATH entry present: $needle"
+		return 1
+	fi
+	return 0
+}
+
+test_sanitized_path_filters_missing_entries() {
+	local existing_dir="$TEST_DIR/existing-bin"
+	local missing_dir="$TEST_DIR/missing-bin"
+	mkdir -p "$existing_dir"
+
+	local polluted_path result
+	polluted_path="${missing_dir}:${existing_dir}:/usr/bin:${existing_dir}:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin"
+	result=$(aidevops_launchd_sanitized_path "$polluted_path")
+
+	local ok=0
+	[[ "$result" == *"$existing_dir"* ]] || ok=1
+	[[ "$result" == *"/usr/bin"* ]] || ok=1
+	assert_not_contains "test_sanitized_path_filters_missing_entries" "$result" "$missing_dir" || ok=1
+	if [[ ! -d /opt/pkg/env/active/bin ]]; then
+		assert_not_contains "test_sanitized_path_filters_missing_entries" "$result" "/opt/pkg/env/active/bin" || ok=1
+	fi
+	if [[ ! -d /opt/pmk/env/global/bin ]]; then
+		assert_not_contains "test_sanitized_path_filters_missing_entries" "$result" "/opt/pmk/env/global/bin" || ok=1
+	fi
+
+	if [[ "$ok" -eq 0 ]]; then
+		pass "test_sanitized_path_filters_missing_entries"
+	else
+		fail "test_sanitized_path_filters_missing_entries" "sanitized PATH was: $result"
+	fi
+	return 0
+}
+
+test_auto_update_plist_filters_polluted_env_path() {
+	local existing_dir="$TEST_DIR/existing-tool-bin"
+	local missing_dir="$TEST_DIR/missing-tool-bin"
+	mkdir -p "$existing_dir"
+
+	local polluted_path plist plist_file ok
+	polluted_path="${missing_dir}:${existing_dir}:/usr/bin:/opt/pkg/env/active/bin:/opt/pmk/env/global/bin"
+	plist=$(_generate_auto_update_plist "/bin/true" "600" "$polluted_path")
+	plist_file="$TEST_DIR/auto-update.plist"
+	printf '%s\n' "$plist" >"$plist_file"
+
+	ok=0
+	[[ "$plist" == *"$existing_dir"* ]] || ok=1
+	assert_not_contains "test_auto_update_plist_filters_polluted_env_path" "$plist" "$missing_dir" || ok=1
+	if [[ ! -d /opt/pkg/env/active/bin ]]; then
+		assert_not_contains "test_auto_update_plist_filters_polluted_env_path" "$plist" "/opt/pkg/env/active/bin" || ok=1
+	fi
+	if [[ ! -d /opt/pmk/env/global/bin ]]; then
+		assert_not_contains "test_auto_update_plist_filters_polluted_env_path" "$plist" "/opt/pmk/env/global/bin" || ok=1
+	fi
+	if command -v plutil >/dev/null 2>&1; then
+		plutil -lint "$plist_file" >/dev/null 2>&1 || ok=1
+	fi
+
+	if [[ "$ok" -eq 0 ]]; then
+		pass "test_auto_update_plist_filters_polluted_env_path"
+	else
+		fail "test_auto_update_plist_filters_polluted_env_path" "generated plist retained polluted PATH"
+	fi
+	return 0
+}
+
+main() {
+	setup
+	test_sanitized_path_filters_missing_entries
+	test_auto_update_plist_filters_polluted_env_path
+
+	printf 'Ran %d tests, %d failed\n' "$TESTS_RUN" "$TESTS_FAILED"
+	[[ "$TESTS_FAILED" -eq 0 ]] || return 1
+	return 0
+}
+
+main "$@"

--- a/.agents/scripts/worker-watchdog-cmd.sh
+++ b/.agents/scripts/worker-watchdog-cmd.sh
@@ -510,7 +510,7 @@ _install_launchd() {
 	<key>EnvironmentVariables</key>
 	<dict>
 		<key>PATH</key>
-		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+		<string>$(aidevops_launchd_sanitized_path "/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin")</string>
 		<key>HOME</key>
 		<string>${home_escaped}</string>
 	</dict>

--- a/setup-modules/schedulers-platform.sh
+++ b/setup-modules/schedulers-platform.sh
@@ -104,7 +104,7 @@ _install_cw_launchd() {
 	<key>EnvironmentVariables</key>
 	<dict>
 		<key>PATH</key>
-		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+		<string>$(aidevops_launchd_sanitized_path)</string>
 		<key>HOME</key>
 		<string>${_xml_cw_home}</string>
 	</dict>
@@ -229,7 +229,7 @@ _install_complexity_scan_launchd() {
 	<key>EnvironmentVariables</key>
 	<dict>
 		<key>PATH</key>
-		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+		<string>$(aidevops_launchd_sanitized_path)</string>
 		<key>HOME</key>
 		<string>${_xml_cs_home}</string>
 	</dict>
@@ -363,7 +363,7 @@ _install_pulse_merge_routine_launchd() {
 	<key>EnvironmentVariables</key>
 	<dict>
 		<key>PATH</key>
-		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+		<string>$(aidevops_launchd_sanitized_path)</string>
 		<key>HOME</key>
 		<string>${_xml_pmr_home}</string>
 	</dict>
@@ -534,7 +534,7 @@ _install_profile_readme_launchd() {
 	<key>EnvironmentVariables</key>
 	<dict>
 		<key>PATH</key>
-		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+		<string>$(aidevops_launchd_sanitized_path)</string>
 		<key>HOME</key>
 		<string>${_xml_pr_home}</string>
 	</dict>
@@ -740,7 +740,7 @@ _install_token_refresh_launchd() {
 	<key>EnvironmentVariables</key>
 	<dict>
 		<key>PATH</key>
-		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+		<string>$(aidevops_launchd_sanitized_path)</string>
 		<key>HOME</key>
 		<string>${_xml_tr_home}</string>
 	</dict>
@@ -992,7 +992,7 @@ _install_peer_productivity_monitor_launchd() {
 	<key>EnvironmentVariables</key>
 	<dict>
 		<key>PATH</key>
-		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+		<string>$(aidevops_launchd_sanitized_path)</string>
 		<key>HOME</key>
 		<string>${_xml_ppm_home}</string>
 	</dict>

--- a/setup-modules/schedulers-pulse.sh
+++ b/setup-modules/schedulers-pulse.sh
@@ -693,7 +693,7 @@ _generate_pulse_plist_content() {
 	# Use neutral workspace path for PULSE_DIR so supervisor sessions
 	# are not associated with any specific managed repo (GH#5136).
 	_xml_pulse_dir=$(_xml_escape "${HOME}/.aidevops/.agent-workspace")
-	_xml_path=$(_xml_escape "$PATH")
+	_xml_path=$(_xml_escape "$(aidevops_launchd_sanitized_path "$PATH")")
 
 	local _headless_xml_env
 	_headless_xml_env=$(_build_pulse_headless_env_xml)
@@ -842,7 +842,7 @@ _generate_pulse_watchdog_plist_content() {
 	_xml_tick=$(_xml_escape "$tick_script")
 	_xml_bash=$(_xml_escape "$bash_bin")
 	_xml_home=$(_xml_escape "$HOME")
-	_xml_path=$(_xml_escape "$PATH")
+	_xml_path=$(_xml_escape "$(aidevops_launchd_sanitized_path "$PATH")")
 
 	cat <<PLIST
 <?xml version="1.0" encoding="UTF-8"?>

--- a/setup-modules/schedulers.sh
+++ b/setup-modules/schedulers.sh
@@ -31,6 +31,32 @@ CRON_HOURLY="0 * * * *"
 # Kept DRY for the same reason as CRON_HOURLY.
 CRON_EVERY_MINUTE="* * * * *"
 
+# Direct unit tests source this module without setup.sh's later
+# shared-constants.sh load. Provide a small fallback; the shared helper
+# overwrites this when setup.sh sources shared-constants.sh.
+if ! declare -F aidevops_launchd_sanitized_path >/dev/null 2>&1; then
+	aidevops_launchd_sanitized_path() {
+		local input_path="${1:-${PATH:-}}"
+		local default_path="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+		local result=""
+		local seen=""
+		local dir=""
+		local old_ifs="$IFS"
+		IFS=':'
+		for dir in $default_path:$input_path; do
+			[[ -n "$dir" && -d "$dir" ]] || continue
+			case ":$seen:" in
+			*":${dir}:"*) continue ;;
+			esac
+			seen="${seen:+${seen}:}${dir}"
+			result="${result:+${result}:}${dir}"
+		done
+		IFS="$old_ifs"
+		printf '%s' "$result"
+		return 0
+	}
+fi
+
 # Shell safety baseline
 set -Eeuo pipefail
 IFS=$'\n\t'
@@ -87,7 +113,7 @@ setup_stats_wrapper() {
 			local _xml_stats_script _xml_stats_home _xml_stats_path
 			_xml_stats_script=$(_xml_escape "$stats_script")
 			_xml_stats_home=$(_xml_escape "$HOME")
-			_xml_stats_path=$(_xml_escape "$PATH")
+			_xml_stats_path=$(_xml_escape "$(aidevops_launchd_sanitized_path "$PATH")")
 			local stats_plist_content
 			stats_plist_content=$(
 				cat <<PLIST
@@ -189,7 +215,7 @@ setup_failure_miner() {
 		local _xml_miner_script _xml_miner_home _xml_miner_path _xml_miner_log
 		_xml_miner_script=$(_xml_escape "$miner_script")
 		_xml_miner_home=$(_xml_escape "$HOME")
-		_xml_miner_path=$(_xml_escape "/bin:/usr/bin:/usr/local/bin:/opt/homebrew/bin:${PATH}")
+		_xml_miner_path=$(_xml_escape "$(aidevops_launchd_sanitized_path "/bin:/usr/bin:/usr/local/bin:/opt/homebrew/bin:${PATH}")")
 		_xml_miner_log=$(_xml_escape "$miner_log")
 
 		local miner_plist_content
@@ -287,7 +313,7 @@ setup_process_guard() {
 		local _xml_guard_script _xml_guard_home _xml_guard_path
 		_xml_guard_script=$(_xml_escape "$guard_script")
 		_xml_guard_home=$(_xml_escape "$HOME")
-		_xml_guard_path=$(_xml_escape "$PATH")
+		_xml_guard_path=$(_xml_escape "$(aidevops_launchd_sanitized_path "$PATH")")
 
 		local guard_plist_content
 		guard_plist_content=$(
@@ -407,7 +433,7 @@ setup_memory_pressure_monitor() {
 	<key>EnvironmentVariables</key>
 	<dict>
 		<key>PATH</key>
-		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+		<string>$(aidevops_launchd_sanitized_path)</string>
 		<key>HOME</key>
 		<string>${_xml_monitor_home}</string>
 	</dict>
@@ -496,7 +522,7 @@ setup_screen_time_snapshot() {
 	<key>EnvironmentVariables</key>
 	<dict>
 		<key>PATH</key>
-		<string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+		<string>$(aidevops_launchd_sanitized_path)</string>
 		<key>HOME</key>
 		<string>${_xml_st_home}</string>
 	</dict>


### PR DESCRIPTION
## Summary

Added a shared launchd PATH sanitizer and routed LaunchAgent plist generators through it so missing inherited PATH entries are filtered before serialization.

## Files Changed

.agents/scripts/auto-update-helper-scheduler.sh,.agents/scripts/auto-update-helper.sh,.agents/scripts/memory-pressure-monitor.sh,.agents/scripts/opencode-db-maintenance-helper.sh,.agents/scripts/repo-aidevops-health-helper.sh,.agents/scripts/repo-sync-helper.sh,.agents/scripts/routine-helper.sh,.agents/scripts/shared-constants.sh,.agents/scripts/tests/test-launchd-sanitized-path.sh,.agents/scripts/worker-watchdog-cmd.sh,setup-modules/schedulers-platform.sh,setup-modules/schedulers-pulse.sh,setup-modules/schedulers.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck on modified shell scripts; bash .agents/scripts/tests/test-launchd-sanitized-path.sh; bash .agents/scripts/tests/test-pulse-defense-restart.sh; git diff --check; polluted PATH smoke check confirmed /opt/pkg and /opt/pmk entries are excluded

Resolves #22192


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.80 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 14m and 517,534 tokens on this with the user in an interactive session.