### PR TITLE
t3405: Suppress stale agent path find errors during setup config generation

### DIFF
--- a/.agents/scripts/generate-runtime-config-agents.sh
+++ b/.agents/scripts/generate-runtime-config-agents.sh
@@ -351,10 +351,15 @@ _resolve_basename_collisions_for_generate() {
 	local tmpfile
 	tmpfile=$(mktemp 2>/dev/null || mktemp -t generate-runtime-config.XXXXXX)
 
+	if [[ ! -d "${AGENTS_DIR:-}" ]]; then
+		rm -f "$tmpfile"
+		return 0
+	fi
+
 	# For each candidate source: record name, priority (0=restrictive, 1=permissive), path.
 	# Priority 0 wins via ascending sort.
 	find "$AGENTS_DIR" -mindepth 2 -name "*.md" -type f \
-		-not -path "*/loop-state/*" -not -name "*-skill.md" -print0 |
+		-not -path "*/loop-state/*" -not -name "*-skill.md" -print0 2>/dev/null |
 		while IFS= read -r -d '' f; do
 			local name priority
 			name=$(basename "$f" .md)

--- a/.agents/scripts/tests/test-basename-collision-resolver.sh
+++ b/.agents/scripts/tests/test-basename-collision-resolver.sh
@@ -202,6 +202,20 @@ else
 		"first:\n$winners\nsecond:\n$second_run"
 fi
 
+# 8. Missing/stale optional AGENTS_DIR paths are skipped without raw find stderr.
+missing_stderr=$(mktemp)
+missing_winners=$(AGENTS_DIR="$FIXTURE_DIR/missing-agent-source" \
+	_resolve_basename_collisions_for_generate 2>"$missing_stderr" |
+	tr '\0' '\n' | grep -v '^$' | sort || true)
+missing_rc=$?
+if [[ "$missing_rc" -eq 0 && -z "$missing_winners" && ! -s "$missing_stderr" ]]; then
+	print_result "missing optional agent source emits no raw find errors" 0
+else
+	print_result "missing optional agent source emits no raw find errors" 1 \
+		"rc=$missing_rc winners=$missing_winners stderr:\n$(cat "$missing_stderr")"
+fi
+rm -f "$missing_stderr"
+
 rm -f "$stderr_log" "$winners_raw"
 
 # --- Summary ---


### PR DESCRIPTION
## Summary
- Skip missing optional AGENTS_DIR roots before OpenCode subagent stub generation runs find.
- Suppress raw find stderr while preserving existing collision warnings from the resolver.
- Added regression coverage for stale/missing agent source paths.

Resolves #22197

## Testing
- `.agents/scripts/tests/test-basename-collision-resolver.sh`
- `shellcheck .agents/scripts/generate-runtime-config-agents.sh .agents/scripts/tests/test-basename-collision-resolver.sh`

## Runtime Testing
- self-assessed: low-risk setup generator shell guard with focused regression test; no live deployment needed before merge.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.81 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 9m and 119,159 tokens on this as a headless worker.