### PR TITLE
t3407: add remote branch cleanup command

### DIFF
--- a/.agents/scripts/remote-branch-cleanup-helper.sh
+++ b/.agents/scripts/remote-branch-cleanup-helper.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+# Audit and optionally delete stale remote branches for the current repository.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+# shellcheck source=./shared-constants.sh
+source "${SCRIPT_DIR}/shared-constants.sh"
+
+REPO_PATH="${PWD}"
+REMOTE_NAME="origin"
+APPLY=0
+INCLUDE_CLOSED_PR=0
+SKIP_FETCH=0
+
+usage() {
+	cat <<'EOF'
+Usage: remote-branch-cleanup-helper.sh [scan] [options]
+
+Audits stale remote branches and optionally deletes only branches proven safe.
+Default mode is dry-run.
+
+Options:
+  --repo PATH           Repository path (default: current directory)
+  --remote NAME         Remote to audit (default: origin)
+  --apply, --delete     Delete safe candidates (default: dry-run)
+  --include-closed-pr   Treat closed-without-merge PR branches as safe candidates
+  --skip-fetch          Do not fetch/prune before scanning (tests/offline only)
+  -h, --help            Show this help
+
+Examples:
+  aidevops cleanup remote-branches
+  aidevops cleanup remote-branches --apply
+  aidevops cleanup branches --repo ~/Git/aidevops --remote origin
+EOF
+	return 0
+}
+
+parse_args() {
+	local arg=""
+	while [[ $# -gt 0 ]]; do
+		arg="${1:-}"
+		case "$arg" in
+		scan | remote-branches | branches)
+			shift
+			;;
+		--repo)
+			REPO_PATH="${2:-}"
+			shift 2
+			;;
+		--remote)
+			REMOTE_NAME="${2:-}"
+			shift 2
+			;;
+		--apply | --delete)
+			APPLY=1
+			shift
+			;;
+		--include-closed-pr)
+			INCLUDE_CLOSED_PR=1
+			shift
+			;;
+		--skip-fetch)
+			SKIP_FETCH=1
+			shift
+			;;
+		-h | --help | help)
+			usage
+			exit 0
+			;;
+		*)
+			print_error "Unknown argument: $arg"
+			usage
+			exit 1
+			;;
+		esac
+	done
+	return 0
+}
+
+repo_git() {
+	git -C "$REPO_PATH" "$@"
+	return $?
+}
+
+default_branch() {
+	local branch=""
+	branch=$(repo_git symbolic-ref --quiet --short "refs/remotes/${REMOTE_NAME}/HEAD" 2>/dev/null | sed "s|^${REMOTE_NAME}/||") || branch=""
+	if [[ -z "$branch" ]]; then
+		branch=$(repo_git remote show "$REMOTE_NAME" 2>/dev/null | sed -n 's/^[[:space:]]*HEAD branch: //p' | sed -n '1p') || branch=""
+	fi
+	[[ -z "$branch" ]] && branch="main"
+	printf '%s\n' "$branch"
+	return 0
+}
+
+remote_branches() {
+	repo_git for-each-ref --format='%(refname:short)' "refs/remotes/${REMOTE_NAME}" |
+		while IFS= read -r ref; do
+			[[ -z "$ref" ]] && continue
+			[[ "$ref" == "${REMOTE_NAME}/HEAD" ]] && continue
+			printf '%s\n' "${ref#"${REMOTE_NAME}"/}"
+		done
+	return 0
+}
+
+merged_remote_branches() {
+	local branch="$1"
+	repo_git branch -r --merged "${REMOTE_NAME}/${branch}" 2>/dev/null |
+		sed 's/^[*[:space:]]*//' |
+		while IFS= read -r ref; do
+			[[ -z "$ref" ]] && continue
+			[[ "$ref" == "${REMOTE_NAME}/HEAD" ]] && continue
+			[[ "$ref" != "${REMOTE_NAME}/"* ]] && continue
+			printf '%s\n' "${ref#"${REMOTE_NAME}"/}"
+		done
+	return 0
+}
+
+active_worktree_branches() {
+	repo_git worktree list --porcelain 2>/dev/null |
+		sed -n 's|^branch refs/heads/||p'
+	return 0
+}
+
+gh_pr_branches() {
+	local state="$1"
+	if [[ "${AIDEVOPS_REMOTE_BRANCH_CLEANUP_SKIP_GH:-0}" == "1" ]]; then
+		return 0
+	fi
+	if ! command -v gh >/dev/null 2>&1; then
+		return 0
+	fi
+	gh pr list --repo "$(repo_slug)" --state "$state" --limit 200 --json headRefName --jq '.[].headRefName' 2>/dev/null || true
+	return 0
+}
+
+repo_slug() {
+	local url slug
+	url=$(repo_git remote get-url "$REMOTE_NAME" 2>/dev/null || true)
+	slug="$url"
+	slug="${slug#git@github.com:}"
+	slug="${slug#https://github.com/}"
+	slug="${slug%.git}"
+	printf '%s\n' "$slug"
+	return 0
+}
+
+contains_line() {
+	local needle="$1"
+	local haystack="$2"
+	[[ $'\n'"$haystack"$'\n' == *$'\n'"$needle"$'\n'* ]]
+	return $?
+}
+
+is_protected_branch() {
+	local branch="$1"
+	local default="$2"
+	case "$branch" in
+	"$default" | main | master | develop | development | staging | production | release | gh-pages)
+		return 0
+		;;
+	esac
+	return 1
+}
+
+print_candidate() {
+	local action="$1"
+	local branch="$2"
+	local reason="$3"
+	printf '%-10s %-55s %s\n' "$action" "$branch" "$reason"
+	return 0
+}
+
+delete_branch() {
+	local branch="$1"
+	if repo_git push "$REMOTE_NAME" --delete "$branch" >/dev/null 2>&1; then
+		print_candidate "deleted" "$branch" "remote branch removed"
+	else
+		print_candidate "failed" "$branch" "git push --delete failed"
+	fi
+	return 0
+}
+
+scan_branches() {
+	if [[ ! -d "$REPO_PATH/.git" && ! -f "$REPO_PATH/.git" ]]; then
+		print_error "Not a git worktree: $REPO_PATH"
+		return 1
+	fi
+
+	if [[ "$SKIP_FETCH" != "1" ]]; then
+		repo_git fetch --prune "$REMOTE_NAME" >/dev/null 2>&1 || print_warning "Fetch/prune failed; continuing with local remote refs"
+	fi
+
+	local default merged active open_prs merged_prs closed_prs branch reason safe_count skip_count review_count mode skip_action dash_label
+	default=$(default_branch)
+	merged=$(merged_remote_branches "$default")
+	active=$(active_worktree_branches)
+	open_prs=$(gh_pr_branches open)
+	merged_prs=$(gh_pr_branches merged)
+	closed_prs=""
+	if [[ "$INCLUDE_CLOSED_PR" == "1" ]]; then
+		closed_prs=$(gh_pr_branches closed)
+	fi
+	safe_count=0
+	skip_count=0
+	review_count=0
+	mode="dry-run"
+	skip_action="skip"
+	dash_label="------"
+	[[ "$APPLY" == "1" ]] && mode="apply"
+
+	printf 'Remote branch cleanup audit: repo=%s remote=%s default=%s mode=%s\n' "$REPO_PATH" "$REMOTE_NAME" "$default" "$mode"
+	printf '%-10s %-55s %s\n' "action" "branch" "reason"
+	printf '%-10s %-55s %s\n' "$dash_label" "$dash_label" "$dash_label"
+
+	while IFS= read -r branch; do
+		[[ -z "$branch" ]] && continue
+		reason=""
+		if is_protected_branch "$branch" "$default"; then
+			print_candidate "$skip_action" "$branch" "protected/default branch"
+			skip_count=$((skip_count + 1))
+			continue
+		fi
+		if contains_line "$branch" "$active"; then
+			print_candidate "$skip_action" "$branch" "checked out in a local worktree"
+			skip_count=$((skip_count + 1))
+			continue
+		fi
+		if contains_line "$branch" "$open_prs"; then
+			print_candidate "$skip_action" "$branch" "open PR exists"
+			skip_count=$((skip_count + 1))
+			continue
+		fi
+		if contains_line "$branch" "$merged"; then
+			reason="merged to ${default}"
+		elif contains_line "$branch" "$merged_prs"; then
+			reason="merged PR branch"
+		elif contains_line "$branch" "$closed_prs"; then
+			reason="closed PR branch (--include-closed-pr)"
+		fi
+
+		if [[ -n "$reason" ]]; then
+			safe_count=$((safe_count + 1))
+			if [[ "$APPLY" == "1" ]]; then
+				delete_branch "$branch"
+			else
+				print_candidate "would-del" "$branch" "$reason"
+			fi
+		else
+			review_count=$((review_count + 1))
+			print_candidate "review" "$branch" "unmerged/no closed evidence"
+		fi
+	done < <(remote_branches)
+
+	printf '\nSummary: safe=%s skipped=%s review=%s\n' "$safe_count" "$skip_count" "$review_count"
+	if [[ "$APPLY" != "1" ]]; then
+		printf 'Dry-run only. Re-run with --apply to delete safe candidates.\n'
+	fi
+	return 0
+}
+
+main() {
+	parse_args "$@"
+	scan_branches
+	return $?
+}
+
+main "$@"

--- a/.agents/scripts/tests/test-remote-branch-cleanup-helper.sh
+++ b/.agents/scripts/tests/test-remote-branch-cleanup-helper.sh
@@ -1,0 +1,184 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+
+set -euo pipefail
+
+TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" || exit 1
+SCRIPTS_DIR="$(cd "${TEST_DIR}/.." && pwd)" || exit 1
+HELPER="${SCRIPTS_DIR}/remote-branch-cleanup-helper.sh"
+TEST_ROOT="${PWD}/.agents/tmp/test-remote-branch-cleanup.$$"
+
+fail() {
+	local message="$1"
+	printf 'FAIL: %s\n' "$message" >&2
+	exit 1
+	return 1
+}
+
+pass() {
+	local message="$1"
+	printf 'PASS: %s\n' "$message"
+	return 0
+}
+
+assert_contains() {
+	local haystack="$1"
+	local needle="$2"
+	local message="$3"
+	case "$haystack" in
+	*"$needle"*) pass "$message" ;;
+	*) fail "$message (missing: $needle)" ;;
+	esac
+	return 0
+}
+
+assert_ref_exists() {
+	local repo="$1"
+	local branch="$2"
+	local message="$3"
+	git -C "$repo" ls-remote --exit-code origin "refs/heads/${branch}" >/dev/null 2>&1 || fail "$message"
+	pass "$message"
+	return 0
+}
+
+assert_ref_missing() {
+	local repo="$1"
+	local branch="$2"
+	local message="$3"
+	if git -C "$repo" ls-remote --exit-code origin "refs/heads/${branch}" >/dev/null 2>&1; then
+		fail "$message"
+	fi
+	pass "$message"
+	return 0
+}
+
+cleanup() {
+	git -C "$TEST_ROOT/repo" worktree remove --force "$TEST_ROOT/active-wt" >/dev/null 2>&1 || true
+	rm -rf "$TEST_ROOT"
+	return 0
+}
+trap cleanup EXIT
+
+make_commit() {
+	local repo="$1"
+	local file="$2"
+	local content="$3"
+	printf '%s\n' "$content" >"${repo}/${file}"
+	git -C "$repo" add "$file"
+	git -C "$repo" commit -qm "add ${file}"
+	return 0
+}
+
+make_branch() {
+	local repo="$1"
+	local branch="$2"
+	local file="$3"
+	local content="$4"
+	git -C "$repo" checkout -q main
+	git -C "$repo" checkout -qb "$branch"
+	make_commit "$repo" "$file" "$content"
+	git -C "$repo" push -q origin "$branch"
+	return 0
+}
+
+merge_branch_to_main() {
+	local repo="$1"
+	local branch="$2"
+	git -C "$repo" checkout -q main
+	git -C "$repo" merge -q --no-ff "$branch" -m "merge ${branch}"
+	git -C "$repo" push -q origin main
+	return 0
+}
+
+install_gh_stub() {
+	local bin_dir="$1"
+	mkdir -p "$bin_dir"
+	cat >"${bin_dir}/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+state=""
+while [[ $# -gt 0 ]]; do
+	case "${1:-}" in
+	--state)
+		state="${2:-}"
+		shift 2
+		;;
+	*)
+		shift
+		;;
+	esac
+done
+if [[ "$state" == "open" ]]; then
+	printf '%s\n' "open-pr"
+fi
+STUB
+	chmod +x "${bin_dir}/gh"
+	return 0
+}
+
+setup_repo() {
+	mkdir -p "$TEST_ROOT"
+	git init -q --bare "$TEST_ROOT/origin.git"
+	git clone -q "$TEST_ROOT/origin.git" "$TEST_ROOT/repo"
+	git -C "$TEST_ROOT/repo" config user.email test@example.invalid
+	git -C "$TEST_ROOT/repo" config user.name "Remote Branch Cleanup Test"
+	make_commit "$TEST_ROOT/repo" base.txt base
+	git -C "$TEST_ROOT/repo" branch -M main
+	git -C "$TEST_ROOT/repo" push -q -u origin main
+	git -C "$TEST_ROOT/origin.git" symbolic-ref HEAD refs/heads/main
+
+	make_branch "$TEST_ROOT/repo" merged-safe merged.txt merged
+	merge_branch_to_main "$TEST_ROOT/repo" merged-safe
+
+	make_branch "$TEST_ROOT/repo" unmerged unmerged.txt unmerged
+
+	make_branch "$TEST_ROOT/repo" open-pr open.txt open
+	merge_branch_to_main "$TEST_ROOT/repo" open-pr
+
+	make_branch "$TEST_ROOT/repo" active-worktree active.txt active
+	merge_branch_to_main "$TEST_ROOT/repo" active-worktree
+	git -C "$TEST_ROOT/repo" worktree add -q "$TEST_ROOT/active-wt" active-worktree
+
+	git -C "$TEST_ROOT/repo" fetch -q origin
+	return 0
+}
+
+run_dry_run_assertions() {
+	local repo="$1"
+	local output
+	local gh_bin="$TEST_ROOT/bin"
+	install_gh_stub "$gh_bin"
+	output=$(PATH="$gh_bin:$PATH" bash "$HELPER" --repo "$repo" --skip-fetch)
+
+	assert_contains "$output" "would-del  merged-safe" "merged branch is a deletion candidate"
+	assert_contains "$output" "review     unmerged" "unmerged branch is manual-review only"
+	assert_contains "$output" "skip       open-pr" "open PR branch is skipped"
+	assert_contains "$output" "open PR exists" "open PR skip reason is shown"
+	assert_contains "$output" "skip       active-worktree" "active worktree branch is skipped"
+	assert_contains "$output" "protected/default branch" "default branch is protected"
+	assert_contains "$output" "Dry-run only" "default mode is dry-run"
+	return 0
+}
+
+run_apply_assertions() {
+	local repo="$1"
+	local gh_bin="$TEST_ROOT/bin"
+	PATH="$gh_bin:$PATH" bash "$HELPER" --repo "$repo" --skip-fetch --apply >/dev/null
+
+	assert_ref_missing "$repo" merged-safe "apply deletes merged safe branch"
+	assert_ref_exists "$repo" unmerged "apply preserves unmerged branch"
+	assert_ref_exists "$repo" open-pr "apply preserves open PR branch"
+	assert_ref_exists "$repo" active-worktree "apply preserves active worktree branch"
+	assert_ref_exists "$repo" main "apply preserves default branch"
+	return 0
+}
+
+main() {
+	setup_repo
+	run_dry_run_assertions "$TEST_ROOT/repo"
+	run_apply_assertions "$TEST_ROOT/repo"
+	return 0
+}
+
+main "$@"

--- a/.agents/workflows/git-workflow.md
+++ b/.agents/workflows/git-workflow.md
@@ -126,12 +126,13 @@ After file changes: run preflight automatically. Pass → auto-commit with sugge
 
 ## Branch Cleanup
 
-After postflight, delete merged branches. Keep unmerged unless stale (>30 days) — ask user.
+After postflight, delete merged branches. Keep unmerged unless stale (>30 days) — ask user. Prefer the aidevops cleanup route for remote branch sweeps because it checks merged/open-PR/worktree evidence before deletion.
 
 ```bash
 git checkout main && git pull origin main
-git branch --merged main | grep -vE '^\*|^(main|develop)$' | xargs -r git branch -d
-git push origin --delete {branch-name}  # Remote
+wt prune                                      # Local worktrees
+aidevops cleanup remote-branches             # Dry-run remote audit
+aidevops cleanup remote-branches --apply     # Delete safe remote candidates
 git remote prune origin
 ```
 

--- a/.agents/workflows/worktree-cleanup.md
+++ b/.agents/workflows/worktree-cleanup.md
@@ -50,6 +50,18 @@ wt prune
 
 `wt prune` removes worktrees whose branches have been merged and deleted on the remote. Run from the canonical repo (on `main`). If unavailable: `git worktree prune` then delete the worktree directory manually.
 
+## Bulk Remote Branch Cleanup
+
+Use the aidevops CLI route when the remote has accumulated old worker/worktree branches:
+
+```bash
+aidevops cleanup remote-branches              # dry-run audit
+aidevops cleanup remote-branches --apply      # delete safe candidates
+aidevops cleanup branches --repo ~/Git/aidevops --remote origin
+```
+
+The command deletes only branches with safety evidence: merged to the default branch or linked to a merged PR, with no open PR and no active local worktree. Unmerged branches are reported as `review` and are not deleted by default.
+
 ## See Also
 
 - `workflows/git-workflow.md` — full worktree lifecycle

--- a/aidevops.sh
+++ b/aidevops.sh
@@ -751,6 +751,7 @@ _help_commands() {
 	echo "  repo-sync <cmd>    Daily git pull for repos in parent dirs (enable/disable/status/dirs)"
 	echo "  update-tools       Check for outdated tools (--update to auto-update)"
 	echo "  repos [cmd]        Manage registered projects (list/add/remove/clean)"
+	echo "  cleanup <cmd>      Cleanup helpers (remote branch audit/delete)"
 	echo "  model-accounts-pool OAuth account pool (list/check/diagnose/add/rotate/reset-cooldowns)"
 	echo "  client-format      Client request format alignment (extract/check/canary/monitor)"
 	echo "  opencode-db <cmd>  OpenCode SQLite maintenance (check/report/maintain/window/status/install)"
@@ -1304,6 +1305,32 @@ main() {
 	detect | scan) cmd_detect ;;
 	ip-check | ip_check) _dispatch_helper "ip-reputation-helper.sh" "ip-reputation-helper.sh" "$@" ;;
 	model-accounts-pool | map) _dispatch_helper "oauth-pool-helper.sh" "oauth-pool-helper.sh" "$@" ;;
+	cleanup)
+		local _cleanup_sub="${1:-help}"
+		case "$_cleanup_sub" in
+		branches | remote-branches)
+			shift || true
+			_dispatch_helper "remote-branch-cleanup-helper.sh" "remote-branch-cleanup-helper.sh" "$_cleanup_sub" "$@"
+			;;
+		help | --help | -h | "")
+			echo "Usage: aidevops cleanup <branches|remote-branches> [options]"
+			echo ""
+			echo "Cleanup commands:"
+			echo "  branches          Audit stale remote branches (dry-run default)"
+			echo "  remote-branches   Alias for branches"
+			echo ""
+			echo "Options:"
+			echo "  --repo PATH       Repository path (default: current directory)"
+			echo "  --remote NAME     Remote to audit (default: origin)"
+			echo "  --apply           Delete safe candidates"
+			echo ""
+			;;
+		*)
+			print_error "Unknown cleanup subcommand: $_cleanup_sub (try branches|remote-branches|help)"
+			exit 1
+			;;
+		esac
+		;;
 	client-format) _cmd_client_format "$@" ;;
 	opencode-db | oc-db) _dispatch_helper "opencode-db-maintenance-helper.sh" "opencode-db-maintenance-helper.sh" "$@" ;;
 	opencode-sandbox | oc-sandbox) _dispatch_helper "opencode-sandbox-helper.sh" "opencode-sandbox-helper.sh" "$@" ;;


### PR DESCRIPTION
## Summary
- Add `remote-branch-cleanup-helper.sh` for dry-run-first stale remote branch audits and safe deletion.
- Expose the route as `aidevops cleanup branches|remote-branches`.
- Document the route and cover merged/open/unmerged/default/active-worktree branch safety cases.

## Verification
- `shellcheck .agents/scripts/remote-branch-cleanup-helper.sh .agents/scripts/tests/test-remote-branch-cleanup-helper.sh`
- `bash .agents/scripts/tests/test-remote-branch-cleanup-helper.sh`
- `git push` pre-push checks passed
- `.agents/scripts/linters-local.sh` was attempted; existing repo-wide Sonar/Secretlint/Markdown/skill-frontmatter debt surfaced and the run timed out during Bash 3.2 checks.

Resolves #22202
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.84 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 42m and 289,975 tokens on this with the user in an interactive session.