### PR TITLE
GH#22207: preserve empty pulse merge TSV fields

### DIFF
--- a/.agents/scripts/pulse-merge-process.sh
+++ b/.agents/scripts/pulse-merge-process.sh
@@ -949,7 +949,7 @@ _auto_merge_stuck_seconds() {
 	local threshold="${AIDEVOPS_PULSE_AUTO_MERGE_STUCK_SECONDS:-300}"
 
 	local enabled_at merge_state mergeable review_decision
-	read -r enabled_at merge_state mergeable review_decision <<<"$(printf '%s' "$pr_state" \
+	IFS=$'\t' read -r enabled_at merge_state mergeable review_decision <<<"$(printf '%s' "$pr_state" \
 		| jq -r '[.autoMergeRequest.enabledAt // "", .mergeStateStatus // "", .mergeable // "", .reviewDecision // ""] | @tsv' \
 		|| true)"
 


### PR DESCRIPTION
## Summary

Set IFS to a tab before reading jq @tsv output in _auto_merge_stuck_seconds so empty autoMergeRequest.enabledAt fields do not shift later merge-state fields.

## Files Changed

.agents/scripts/pulse-merge-process.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/pulse-merge-process.sh; bash -n .agents/scripts/pulse-merge-process.sh; jq TSV parsing regression snippet with empty enabledAt; .agents/scripts/linters-local.sh attempted but timed out at Secretlint after 600s with prior checks passing/warning-only

Resolves #22207


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.84 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 13m and 45,556 tokens on this as a headless worker.