### PR TITLE
GH#22208: parse task completion PR data with read

### DIFF
--- a/.agents/scripts/task-complete-helper.sh
+++ b/.agents/scripts/task-complete-helper.sh
@@ -262,13 +262,11 @@ verify_pr_merged() {
 	fi
 
 	# Parse tab-separated output: state\tmergedAt
-	pr_state="${pr_output%%$'\t'*}"
-	local pr_remainder="${pr_output#*$'\t'}"
-	pr_merged_at="$pr_remainder"
+	IFS=$'\t' read -r pr_state pr_merged_at <<<"$pr_output"
 	pr_merged_bool="$bool_false"
 
 	if [[ -z "$pr_merged_at" ]]; then
-		local rest_output rest_state rest_remainder rest_merged_at
+		local rest_output rest_state rest_merged_at
 		local gh_api_args=("api" "repos/{owner}/{repo}/pulls/$pr_number" "$gh_jq_arg" '[.state, (.merged // false), (.merged_at // "")] | @tsv')
 		if [[ -n "$gh_repo" ]]; then
 			gh_api_args=("api" "repos/${gh_repo}/pulls/$pr_number" "$gh_jq_arg" '[.state, (.merged // false), (.merged_at // "")] | @tsv')
@@ -281,10 +279,7 @@ verify_pr_merged() {
 		fi
 
 		if [[ -n "$rest_output" ]]; then
-			rest_state="${rest_output%%$'\t'*}"
-			rest_remainder="${rest_output#*$'\t'}"
-			pr_merged_bool="${rest_remainder%%$'\t'*}"
-			rest_merged_at="${rest_remainder#*$'\t'}"
+			IFS=$'\t' read -r rest_state pr_merged_bool rest_merged_at <<<"$rest_output"
 			[[ -n "$rest_state" ]] && pr_state="$rest_state"
 			[[ -n "$rest_merged_at" ]] && pr_merged_at="$rest_merged_at"
 		fi


### PR DESCRIPTION
## Summary

Updated task-complete-helper PR verification parsing to use IFS/read for tab-separated gh output while preserving mergedAt-only compatibility.

## Files Changed

.agents/scripts/task-complete-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/task-complete-helper.sh .agents/scripts/tests/test-task-complete-pr-verify.sh; .agents/scripts/tests/test-task-complete-pr-verify.sh (12 tests passed)

Resolves #22208


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.85 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 7m and 75,322 tokens on this as a headless worker.