### PR TITLE
t3409: Make release creation resilient to GitHub GraphQL exhaustion

### DIFF
--- a/.agents/scripts/tests/test-version-manager-release-rest-fallback.sh
+++ b/.agents/scripts/tests/test-version-manager-release-rest-fallback.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-version-manager-release-rest-fallback.sh — GH#22213 regression guard.
+#
+# Asserts that GitHub release creation recovers through REST when `gh release`
+# fails after the version commit/tag/push phase has already succeeded.
+
+set -uo pipefail
+
+TEST_SCRIPTS_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+TEST_RED=$'\033[0;31m'
+TEST_GREEN=$'\033[0;32m'
+TEST_RESET=$'\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1" rc="$2" extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf '%sPASS%s %s\n' "$TEST_GREEN" "$TEST_RESET" "$name"
+	else
+		printf '%sFAIL%s %s %s\n' "$TEST_RED" "$TEST_RESET" "$name" "$extra"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+export HOME="${TEST_ROOT}/home"
+mkdir -p "${HOME}/.aidevops/logs" "${TEST_ROOT}/bin"
+
+cat >"${TEST_ROOT}/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+set -u
+
+log_file="${FAKE_GH_LOG:?}"
+marker_file="${FAKE_GH_RELEASE_MARKER:?}"
+printf '%s\n' "$*" >>"$log_file"
+
+if [[ "${1:-}" == "auth" && "${2:-}" == "status" ]]; then
+	exit 0
+fi
+
+if [[ "${1:-}" == "release" && "${2:-}" == "view" ]]; then
+	printf 'GraphQL API rate limit already exceeded\n' >&2
+	exit 1
+fi
+
+if [[ "${1:-}" == "release" && "${2:-}" == "create" ]]; then
+	printf 'GraphQL API rate limit already exceeded\n' >&2
+	exit 1
+fi
+
+if [[ "${1:-}" == "api" ]]; then
+	endpoint="${2:-}"
+	if [[ "$endpoint" == repos/*/releases/tags/* ]]; then
+		if [[ "${FAKE_REST_VIEW_SUCCEEDS:-0}" == "1" || -f "$marker_file" ]]; then
+			printf '{"tag_name":"v1.2.4"}\n'
+			exit 0
+		fi
+		exit 1
+	fi
+	if [[ "$endpoint" == repos/*/releases ]]; then
+		: >"$marker_file"
+		printf '{"tag_name":"v1.2.4"}\n'
+		exit 0
+	fi
+fi
+
+exit 1
+EOF
+chmod +x "${TEST_ROOT}/bin/gh"
+export PATH="${TEST_ROOT}/bin:${PATH}"
+
+REPO_DIR="${TEST_ROOT}/repo"
+mkdir -p "$REPO_DIR"
+cd "$REPO_DIR" || exit 1
+git init -q -b main
+git config user.email 'test@example.com'
+git config user.name 'Test Runner'
+git config commit.gpgsign false
+git remote add origin 'git@github.com:marcusquinn/aidevops.git'
+
+# Source in a git repo so version-manager.sh initialises REPO_ROOT to the
+# fixture repository while loading implementation files from TEST_SCRIPTS_DIR.
+# shellcheck source=/dev/null
+source "${TEST_SCRIPTS_DIR}/version-manager.sh"
+set +e
+
+export FAKE_GH_LOG="${TEST_ROOT}/gh.log"
+export FAKE_GH_RELEASE_MARKER="${TEST_ROOT}/release-created.marker"
+
+rm -f "$FAKE_GH_LOG" "$FAKE_GH_RELEASE_MARKER"
+export FAKE_REST_VIEW_SUCCEEDS=1
+rc=0
+output=$(create_github_release '1.2.4' 2>&1) || rc=$?
+if [[ "$rc" -eq 0 && "$output" == *"Partial release recovered"* ]]; then
+	print_result 'REST view recovers an already-created partial release' 0
+else
+	print_result 'REST view recovers an already-created partial release' 1 "rc=$rc output=$output"
+fi
+
+if ! grep -q 'api repos/marcusquinn/aidevops/releases --method POST' "$FAKE_GH_LOG" 2>/dev/null; then
+	print_result 'existing REST release recovery does not recreate release' 0
+else
+	print_result 'existing REST release recovery does not recreate release' 1 'unexpected REST POST call'
+fi
+
+rm -f "$FAKE_GH_LOG" "$FAKE_GH_RELEASE_MARKER"
+export FAKE_REST_VIEW_SUCCEEDS=0
+rc=0
+output=$(create_github_release '1.2.4' 2>&1) || rc=$?
+if [[ "$rc" -eq 0 && "$output" == *"Created GitHub release via REST fallback"* ]]; then
+	print_result 'REST create recovers GraphQL-exhausted release creation' 0
+else
+	print_result 'REST create recovers GraphQL-exhausted release creation' 1 "rc=$rc output=$output"
+fi
+
+if grep -q 'api repos/marcusquinn/aidevops/releases --method POST' "$FAKE_GH_LOG" 2>/dev/null; then
+	print_result 'REST fallback calls releases create endpoint' 0
+else
+	print_result 'REST fallback calls releases create endpoint' 1 'missing REST POST call'
+fi
+
+printf '\nTests run: %s, Failures: %s\n' "$TESTS_RUN" "$TESTS_FAILED"
+[[ "$TESTS_FAILED" -eq 0 ]]

--- a/.agents/scripts/tests/test-version-manager-release-rest-fallback.sh
+++ b/.agents/scripts/tests/test-version-manager-release-rest-fallback.sh
@@ -99,7 +99,7 @@ rm -f "$FAKE_GH_LOG" "$FAKE_GH_RELEASE_MARKER"
 export FAKE_REST_VIEW_SUCCEEDS=1
 rc=0
 output=$(create_github_release '1.2.4' 2>&1) || rc=$?
-if [[ "$rc" -eq 0 && "$output" == *"Partial release recovered"* ]]; then
+if [[ "$rc" -eq 0 && "$output" == *"REST confirms v1.2.4 already exists"* ]]; then
 	print_result 'REST view recovers an already-created partial release' 0
 else
 	print_result 'REST view recovers an already-created partial release' 1 "rc=$rc output=$output"

--- a/.agents/scripts/version-manager-release.sh
+++ b/.agents/scripts/version-manager-release.sh
@@ -201,6 +201,13 @@ create_github_release() {
 			print_info "To view the existing release: gh release view $tag_name"
 			return 0
 		fi
+		local rest_slug=""
+		rest_slug=$(_version_manager_repo_slug)
+		if _github_release_rest_view "$rest_slug" "$tag_name"; then
+			print_warning "GitHub release view failed, but REST confirms $tag_name already exists — skipping creation"
+			print_info "REST endpoint verified: repos/${rest_slug}/releases/tags/${tag_name}"
+			return 0
+		fi
 
 		# Create GitHub release
 		if gh release create "$tag_name" \

--- a/.agents/scripts/version-manager-release.sh
+++ b/.agents/scripts/version-manager-release.sh
@@ -41,6 +41,72 @@ fi
 
 # --- Functions ---
 
+_version_manager_repo_slug() {
+	local remote_url=""
+	remote_url=$(git -C "$REPO_ROOT" remote get-url origin 2>/dev/null || echo "")
+	printf '%s' "$remote_url" | sed 's|.*github\.com[:/]||;s|\.git$||'
+	return 0
+}
+
+_github_release_rest_view() {
+	local slug="$1"
+	local tag_name="$2"
+
+	[[ -n "$slug" ]] || return 1
+	gh api "repos/${slug}/releases/tags/${tag_name}" >/dev/null 2>&1
+	return $?
+}
+
+_github_release_rest_create() {
+	local slug="$1"
+	local tag_name="$2"
+	local release_notes="$3"
+
+	[[ -n "$slug" ]] || return 1
+	gh api "repos/${slug}/releases" \
+		--method POST \
+		-f "tag_name=${tag_name}" \
+		-f "name=${tag_name} - AI DevOps Framework" \
+		-f "body=${release_notes}" \
+		-F latest=true >/dev/null
+	return $?
+}
+
+_github_release_recover_with_rest() {
+	local tag_name="$1"
+	local release_notes="$2"
+	local context="$3"
+	local slug=""
+	slug=$(_version_manager_repo_slug)
+
+	if [[ -z "$slug" ]]; then
+		print_error "Cannot recover GitHub release via REST: cannot determine repo slug from origin"
+		return 1
+	fi
+
+	print_warning "GitHub CLI release ${context} failed; checking REST release endpoint for $tag_name"
+	if _github_release_rest_view "$slug" "$tag_name"; then
+		print_warning "Partial release recovered: tag $tag_name was pushed and GitHub release already exists via REST"
+		print_info "REST endpoint verified: repos/${slug}/releases/tags/${tag_name}"
+		return 0
+	fi
+
+	print_warning "Partial release state: tag $tag_name may be pushed but release is not visible via REST; creating release via REST"
+	if _github_release_rest_create "$slug" "$tag_name" "$release_notes"; then
+		print_success "Created GitHub release via REST fallback: $tag_name"
+		return 0
+	fi
+
+	if _github_release_rest_view "$slug" "$tag_name"; then
+		print_warning "REST release create returned non-zero, but release is now visible; treating as recovered"
+		return 0
+	fi
+
+	print_error "Failed to recover GitHub release $tag_name via REST after $context failure"
+	print_info "Manual recovery: gh api repos/${slug}/releases/tags/${tag_name} || gh api repos/${slug}/releases --method POST ..."
+	return 1
+}
+
 # Function to create git tag
 create_git_tag() {
 	local version="$1"
@@ -120,16 +186,21 @@ create_github_release() {
 	if command -v gh &>/dev/null && gh auth status &>/dev/null; then
 		print_info "Using GitHub CLI for release creation"
 
-		# Guard: check if GitHub release already exists for this tag
-		if gh release view "$tag_name" &>/dev/null; then
+		# Generate release notes before any recovery path so REST creation can
+		# finish a partial release without rerunning the version bump.
+		local release_notes
+		release_notes=$(generate_release_notes "$version")
+
+		# Guard: check if GitHub release already exists for this tag. When GraphQL
+		# quota is exhausted, `gh release view` can fail while REST remains usable;
+		# recover through REST instead of returning failure after tag/push success.
+		local view_exit=0
+		gh release view "$tag_name" &>/dev/null || view_exit=$?
+		if [[ "$view_exit" -eq 0 ]]; then
 			print_warning "GitHub release $tag_name already exists — skipping creation"
 			print_info "To view the existing release: gh release view $tag_name"
 			return 0
 		fi
-
-		# Generate release notes based on version
-		local release_notes
-		release_notes=$(generate_release_notes "$version")
 
 		# Create GitHub release
 		if gh release create "$tag_name" \
@@ -139,7 +210,10 @@ create_github_release() {
 			print_success "Created GitHub release: $tag_name"
 			return 0
 		else
-			print_error "Failed to create GitHub release with GitHub CLI"
+			if _github_release_recover_with_rest "$tag_name" "$release_notes" "create"; then
+				return 0
+			fi
+			print_error "Failed to create GitHub release with GitHub CLI or REST fallback"
 			return 1
 		fi
 	else


### PR DESCRIPTION
## Summary

Added REST release view/create fallback so GraphQL-exhausted gh release commands can recover after tag push without rerunning the version bump.

## Files Changed

.agents/scripts/tests/test-pulse-merge-routine-standalone.sh,.agents/scripts/tests/test-version-manager-release-rest-fallback.sh,.agents/scripts/version-manager-release.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/version-manager.sh .agents/scripts/version-manager-release.sh .agents/scripts/tests/test-version-manager-release-rest-fallback.sh .agents/scripts/tests/test-version-manager-release-rollback.sh .agents/scripts/tests/test-version-manager-bump-verify.sh; bash .agents/scripts/tests/test-version-manager-release-rest-fallback.sh && bash .agents/scripts/tests/test-version-manager-release-rollback.sh && bash .agents/scripts/tests/test-version-manager-bump-verify.sh

Resolves #22213


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.86 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 7m and 77,267 tokens on this as a headless worker.