### PR TITLE
GH#22210: restore worktree path in stale claim reports

### DIFF
--- a/.agents/scripts/interactive-session-helper-scan.sh
+++ b/.agents/scripts/interactive-session-helper-scan.sh
@@ -373,6 +373,7 @@ _isc_scan_dead_stamps_phase() {
 				else
 					[[ $stale_count -eq 0 ]] && printf 'Stale interactive claims (dead session — PID gone or recycled by unrelated process):\n\n'
 					printf '  #%s in %s\n' "$issue" "$slug"
+					printf '    worktree: %s\n' "${worktree:-unknown}"
 					printf '    pid:      %s (dead or argv-hash mismatch)\n' "${pid:-unknown}"
 					printf '    release:  aidevops issue release %s\n' "$issue"
 					printf '\n'

--- a/.agents/scripts/tests/test-scan-stale-auto-release.sh
+++ b/.agents/scripts/tests/test-scan-stale-auto-release.sh
@@ -37,6 +37,7 @@
 #   8. AIDEVOPS_SCAN_STALE_AUTO_RELEASE=1 env + non-TTY → dead+missing released
 #   9. OPENCODE_SESSION_ID set, no TTY, no headless → dead+missing released (t3205)
 #   10. AIDEVOPS_HEADLESS + OPENCODE_SESSION_ID → stamp preserved (headless wins, t3205)
+#   11. report-only stale output includes worktree path (GH#22210)
 #
 # Stub strategy: override `_isc_release_claim_by_stamp_path` as a shell function
 # after sourcing the helper to capture auto-release calls without real gh ops.
@@ -364,6 +365,22 @@ else
 fi
 # Cleanup
 rm -f "${STAMP_DIR}/owner-repo-110.json"
+
+# =============================================================================
+# Test 11 — report-only stale output includes worktree path (GH#22210)
+# =============================================================================
+write_stamp "owner-repo-111.json" "99999" "$EXISTING_WORKTREE" "111" "owner/repo"
+
+REPORT_OUTPUT=$(_isc_cmd_scan_stale --no-auto-release 2>/dev/null || true)
+
+if [[ "$REPORT_OUTPUT" == *"worktree: $EXISTING_WORKTREE"* ]]; then
+	pass "report-only stale output includes worktree path"
+else
+	fail "report-only stale output includes worktree path" \
+		"expected report to include worktree: $EXISTING_WORKTREE"
+fi
+# Cleanup
+rm -f "${STAMP_DIR}/owner-repo-111.json"
 
 # =============================================================================
 # Summary


### PR DESCRIPTION
## Summary

Restored the worktree path line in report-only stale interactive claim output and added a regression assertion for GH#22210.

## Files Changed

.agents/scripts/interactive-session-helper-scan.sh,.agents/scripts/tests/test-scan-stale-auto-release.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/interactive-session-helper-scan.sh .agents/scripts/tests/test-scan-stale-auto-release.sh; bash .agents/scripts/tests/test-scan-stale-auto-release.sh (11/11 passed); .agents/scripts/linters-local.sh attempted but timed out after reporting pre-existing SonarCloud/Secretlint/skill-frontmatter/Markdown failures.

Resolves #22210


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.87 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 26m and 62,828 tokens on this as a headless worker.