### PR TITLE
t3411: Fix routines setup push retry

### DIFF
--- a/.agents/scripts/init-routines-helper.sh
+++ b/.agents/scripts/init-routines-helper.sh
@@ -547,6 +547,45 @@ _sync_with_remote_before_commit() {
 }
 
 # ---------------------------------------------------------------------------
+# _current_origin_push_refspec
+# Prints a fully-qualified refspec for pushing the current HEAD to origin.
+# ---------------------------------------------------------------------------
+_current_origin_push_refspec() {
+	local branch=""
+	branch=$(git symbolic-ref --quiet --short HEAD 2>/dev/null || true)
+
+	if [[ -z "$branch" ]]; then
+		local origin_head=""
+		origin_head=$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null || true)
+		if [[ "$origin_head" == origin/* ]]; then
+			branch="${origin_head#origin/}"
+		fi
+	fi
+
+	if [[ -z "$branch" ]]; then
+		return 1
+	fi
+
+	printf 'HEAD:refs/heads/%s\n' "$branch"
+	return 0
+}
+
+# ---------------------------------------------------------------------------
+# _push_current_head_to_origin
+# Pushes HEAD using a fully-qualified destination ref to avoid raw HEAD ambiguity.
+# ---------------------------------------------------------------------------
+_push_current_head_to_origin() {
+	local refspec=""
+	if ! refspec=$(_current_origin_push_refspec); then
+		print_warning "Unable to determine routines repo branch — skipping push to avoid ambiguous HEAD refspec"
+		return 1
+	fi
+
+	git push origin "$refspec"
+	return $?
+}
+
+# ---------------------------------------------------------------------------
 # _commit_and_push <path>
 # Commits scaffolded files and pushes to remote.
 # ---------------------------------------------------------------------------
@@ -560,10 +599,18 @@ _commit_and_push() {
 		fi
 		git add -A
 		if ! git diff --cached --quiet; then
-			git commit -m "chore: scaffold aidevops-routines repo"
-			if ! git push origin HEAD; then
+			if ! git commit -m "chore: scaffold aidevops-routines repo"; then
+				print_warning "Routines scaffold commit failed — uncommitted scaffold changes preserved"
+				return 0
+			fi
+			if ! _push_current_head_to_origin; then
 				print_warning "Push rejected — rebasing onto remote and retrying"
-				if git pull --rebase && git push origin HEAD; then
+				if [[ -n "$(git status --porcelain)" ]]; then
+					git reset --soft HEAD~1
+					print_warning "Push retry skipped — scaffold changes are unstaged and were preserved"
+					return 0
+				fi
+				if git pull --rebase && _push_current_head_to_origin; then
 					return 0
 				fi
 				git reset --soft HEAD~1

--- a/.agents/scripts/tests/test-init-routines-readonly-guard.sh
+++ b/.agents/scripts/tests/test-init-routines-readonly-guard.sh
@@ -241,12 +241,117 @@ test_commit_and_push_aborts_failed_remote_sync_rebase() {
 	return 0
 }
 
+# Regression: GH#22235 — detached/stale routines worktrees must not push a raw
+# HEAD destination. The helper should derive origin/HEAD and push with a fully
+# qualified branch ref so setup_routines avoids Git's "destination provided is
+# not a full refname" error.
+test_commit_and_push_uses_full_refspec_when_head_detached() {
+	local tmp_dir=""
+	tmp_dir=$(mktemp -d)
+	local remote_repo="${tmp_dir}/remote.git"
+	local local_repo="${tmp_dir}/local"
+
+	git -c init.defaultBranch=main init --bare "$remote_repo" >/dev/null
+	git clone "$remote_repo" "$local_repo" >/dev/null 2>&1
+	git -C "$local_repo" checkout -b main >/dev/null 2>&1
+	git -C "$local_repo" config user.email "test@example.invalid"
+	git -C "$local_repo" config user.name "Test User"
+	printf 'base\n' >"${local_repo}/README.md"
+	git -C "$local_repo" add README.md
+	git -C "$local_repo" commit -m "initial" >/dev/null
+	git -C "$local_repo" push -u origin main >/dev/null 2>&1
+	git -C "$local_repo" remote set-head origin main >/dev/null 2>&1
+	git -C "$local_repo" checkout --detach HEAD >/dev/null 2>&1
+
+	printf 'scaffold\n' >"${local_repo}/TODO.md"
+	# shellcheck disable=SC1090  # dynamic repo-relative helper path
+	source "$INIT_ROUTINES"
+	local output=""
+	output=$(_commit_and_push "$local_repo" 2>&1)
+	git -C "$local_repo" fetch origin main >/dev/null 2>&1
+
+	local scaffold_commit_count=""
+	scaffold_commit_count=$(git -C "$local_repo" log --oneline origin/main --grep 'chore: scaffold aidevops-routines repo' | wc -l | tr -d ' ')
+	local status_output=""
+	status_output=$(git -C "$local_repo" status --porcelain)
+
+	rm -rf "$tmp_dir"
+
+	if [[ "$scaffold_commit_count" == "1" && -z "$status_output" && "$output" != *"destination provided is not a full refname"* ]]; then
+		print_result "_commit_and_push uses full refspec when routines HEAD is detached (GH#22235)" 0
+		return 0
+	fi
+
+	print_result "_commit_and_push uses full refspec when routines HEAD is detached (GH#22235)" 1 \
+		"scaffold_commits=${scaffold_commit_count} status=${status_output} output=${output}"
+	return 0
+}
+
+# Regression: GH#22235 — if a push fails while scaffold changes are already
+# unstaged, retry must not run git pull --rebase over those local changes.
+test_commit_and_push_skips_rebase_retry_with_unstaged_scaffold() {
+	local tmp_dir=""
+	tmp_dir=$(mktemp -d)
+	local remote_repo="${tmp_dir}/remote.git"
+	local local_repo="${tmp_dir}/local"
+	local fake_bin="${tmp_dir}/bin"
+	mkdir -p "$fake_bin"
+
+	git -c init.defaultBranch=main init --bare "$remote_repo" >/dev/null
+	git clone "$remote_repo" "$local_repo" >/dev/null 2>&1
+	git -C "$local_repo" checkout -b main >/dev/null 2>&1
+	git -C "$local_repo" config user.email "test@example.invalid"
+	git -C "$local_repo" config user.name "Test User"
+	printf 'base\n' >"${local_repo}/README.md"
+	git -C "$local_repo" add README.md
+	git -C "$local_repo" commit -m "initial" >/dev/null
+	git -C "$local_repo" push -u origin main >/dev/null 2>&1
+
+	local real_git=""
+	real_git=$(command -v git)
+	cat >"${fake_bin}/git" <<EOF
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "\$1" == "push" ]]; then
+  "${real_git}" reset --soft HEAD~1 >/dev/null
+  exit 1
+fi
+if [[ "\$1" == "pull" ]]; then
+  printf 'unexpected pull --rebase with unstaged scaffold changes\\n' >&2
+  exit 42
+fi
+exec "${real_git}" "\$@"
+EOF
+	chmod +x "${fake_bin}/git"
+
+	printf 'scaffold\n' >"${local_repo}/TODO.md"
+	# shellcheck disable=SC1090  # dynamic repo-relative helper path
+	source "$INIT_ROUTINES"
+	local output=""
+	PATH="${fake_bin}:$PATH" output=$(_commit_and_push "$local_repo" 2>&1)
+	local status_output=""
+	status_output=$(git -C "$local_repo" status --porcelain)
+
+	rm -rf "$tmp_dir"
+
+	if [[ "$status_output" == *"TODO.md"* && "$output" == *"Push retry skipped"* && "$output" != *"unexpected pull --rebase"* ]]; then
+		print_result "_commit_and_push skips rebase retry with unstaged scaffold changes (GH#22235)" 0
+		return 0
+	fi
+
+	print_result "_commit_and_push skips rebase retry with unstaged scaffold changes (GH#22235)" 1 \
+		"status=${status_output} output=${output}"
+	return 0
+}
+
 main() {
 	test_init_routines_sources_after_shared_constants
 	test_common_tolerates_readonly_colors
 	test_routines_loader_isolates_errors
 	test_commit_and_push_syncs_remote_ahead_repo
 	test_commit_and_push_aborts_failed_remote_sync_rebase
+	test_commit_and_push_uses_full_refspec_when_head_detached
+	test_commit_and_push_skips_rebase_retry_with_unstaged_scaffold
 
 	printf '\nRan %s tests, %s failed\n' "$TESTS_RUN" "$TESTS_FAILED"
 	if [[ "$TESTS_FAILED" -ne 0 ]]; then

--- a/.agents/scripts/tests/test-init-routines-readonly-guard.sh
+++ b/.agents/scripts/tests/test-init-routines-readonly-guard.sh
@@ -298,6 +298,7 @@ test_commit_and_push_skips_rebase_retry_with_unstaged_scaffold() {
 	local remote_repo="${tmp_dir}/remote.git"
 	local local_repo="${tmp_dir}/local"
 	local fake_bin="${tmp_dir}/bin"
+	local push_failed_marker="${tmp_dir}/push-failed"
 	mkdir -p "$fake_bin"
 
 	git -c init.defaultBranch=main init --bare "$remote_repo" >/dev/null
@@ -316,9 +317,10 @@ test_commit_and_push_skips_rebase_retry_with_unstaged_scaffold() {
 set -euo pipefail
 if [[ "\$1" == "push" ]]; then
   "${real_git}" reset --soft HEAD~1 >/dev/null
+  : >"${push_failed_marker}"
   exit 1
 fi
-if [[ "\$1" == "pull" ]]; then
+if [[ "\$1" == "pull" && -f "${push_failed_marker}" ]]; then
   printf 'unexpected pull --rebase with unstaged scaffold changes\\n' >&2
   exit 42
 fi

--- a/.agents/scripts/tests/test-init-routines-readonly-guard.sh
+++ b/.agents/scripts/tests/test-init-routines-readonly-guard.sh
@@ -45,6 +45,14 @@ print_result() {
 	return 0
 }
 
+configure_test_git_identity() {
+	local repo_path="$1"
+	git -C "$repo_path" config user.email "test@example.invalid"
+	git -C "$repo_path" config user.name "Test User"
+	git -C "$repo_path" config commit.gpgsign false
+	return 0
+}
+
 # The original bug: setup.sh sources shared-constants.sh (readonly colors),
 # then sources _routines.sh which sources init-routines-helper.sh. The helper
 # previously did unconditional `GREEN='\033[0;32m'` which failed under
@@ -141,16 +149,14 @@ test_commit_and_push_syncs_remote_ahead_repo() {
 	git -c init.defaultBranch=main init --bare "$remote_repo" >/dev/null
 	git clone "$remote_repo" "$local_repo" >/dev/null 2>&1
 	git -C "$local_repo" checkout -b main >/dev/null 2>&1
-	git -C "$local_repo" config user.email "test@example.invalid"
-	git -C "$local_repo" config user.name "Test User"
+	configure_test_git_identity "$local_repo"
 	printf 'base\n' >"${local_repo}/README.md"
 	git -C "$local_repo" add README.md
 	git -C "$local_repo" commit -m "initial" >/dev/null
 	git -C "$local_repo" push -u origin main >/dev/null 2>&1
 
 	git clone "$remote_repo" "$advancer_repo" >/dev/null 2>&1
-	git -C "$advancer_repo" config user.email "test@example.invalid"
-	git -C "$advancer_repo" config user.name "Test User"
+	configure_test_git_identity "$advancer_repo"
 	printf 'remote-ahead\n' >>"${advancer_repo}/README.md"
 	git -C "$advancer_repo" commit -am "remote ahead" >/dev/null
 	git -C "$advancer_repo" push origin main >/dev/null 2>&1
@@ -193,16 +199,14 @@ test_commit_and_push_aborts_failed_remote_sync_rebase() {
 	git -c init.defaultBranch=main init --bare "$remote_repo" >/dev/null
 	git clone "$remote_repo" "$local_repo" >/dev/null 2>&1
 	git -C "$local_repo" checkout -b main >/dev/null 2>&1
-	git -C "$local_repo" config user.email "test@example.invalid"
-	git -C "$local_repo" config user.name "Test User"
+	configure_test_git_identity "$local_repo"
 	printf 'base\n' >"${local_repo}/README.md"
 	git -C "$local_repo" add README.md
 	git -C "$local_repo" commit -m "initial" >/dev/null
 	git -C "$local_repo" push -u origin main >/dev/null 2>&1
 
 	git clone "$remote_repo" "$advancer_repo" >/dev/null 2>&1
-	git -C "$advancer_repo" config user.email "test@example.invalid"
-	git -C "$advancer_repo" config user.name "Test User"
+	configure_test_git_identity "$advancer_repo"
 	printf 'remote-change\n' >"${advancer_repo}/README.md"
 	git -C "$advancer_repo" commit -am "remote conflicting change" >/dev/null
 	git -C "$advancer_repo" push origin main >/dev/null 2>&1
@@ -254,8 +258,7 @@ test_commit_and_push_uses_full_refspec_when_head_detached() {
 	git -c init.defaultBranch=main init --bare "$remote_repo" >/dev/null
 	git clone "$remote_repo" "$local_repo" >/dev/null 2>&1
 	git -C "$local_repo" checkout -b main >/dev/null 2>&1
-	git -C "$local_repo" config user.email "test@example.invalid"
-	git -C "$local_repo" config user.name "Test User"
+	configure_test_git_identity "$local_repo"
 	printf 'base\n' >"${local_repo}/README.md"
 	git -C "$local_repo" add README.md
 	git -C "$local_repo" commit -m "initial" >/dev/null
@@ -300,8 +303,7 @@ test_commit_and_push_skips_rebase_retry_with_unstaged_scaffold() {
 	git -c init.defaultBranch=main init --bare "$remote_repo" >/dev/null
 	git clone "$remote_repo" "$local_repo" >/dev/null 2>&1
 	git -C "$local_repo" checkout -b main >/dev/null 2>&1
-	git -C "$local_repo" config user.email "test@example.invalid"
-	git -C "$local_repo" config user.name "Test User"
+	configure_test_git_identity "$local_repo"
 	printf 'base\n' >"${local_repo}/README.md"
 	git -C "$local_repo" add README.md
 	git -C "$local_repo" commit -m "initial" >/dev/null


### PR DESCRIPTION
## Summary

Hardened routines scaffold pushes to use a fully-qualified origin refspec and skip rebase retries when scaffold changes are already unstaged.

## Files Changed

.agents/scripts/init-routines-helper.sh,.agents/scripts/tests/test-init-routines-readonly-guard.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** Focused routine setup regression test, shellcheck on changed shell files, and ./setup.sh --non-interactive completed without raw HEAD refspec or unstaged rebase errors.

Resolves #22235


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.89 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 6m and 100,678 tokens on this as a headless worker.