### PR TITLE
GH#22238: cap dispatch CPU fanout

### DIFF
--- a/.agents/scripts/dispatch-timing-helper.sh
+++ b/.agents/scripts/dispatch-timing-helper.sh
@@ -89,6 +89,13 @@ LOCK_DIR="${STATE_FILE}.lock.d"
 # Lock acquisition timeout (mkdir-based busy-wait).
 : "${DISPATCH_TIMING_LOCK_TIMEOUT_S:=5}"
 
+# Record-path lock timeouts. `recommend`/`stats` can tolerate the legacy lock
+# timeout, but `record` is called once per candidate and must fail open quickly
+# under fanout. Skip records are low-value telemetry, so they never wait for the
+# lock by default (GH#22238).
+: "${DISPATCH_TIMING_RECORD_LOCK_TIMEOUT_S:=1}"
+: "${DISPATCH_TIMING_SKIP_LOCK_TIMEOUT_S:=0}"
+
 # JSONL field-name constants — extracted to satisfy repeated-literal ratchet
 # and to centralise the schema in one place.
 readonly _DT_FIELD_OUTCOME="outcome"
@@ -100,10 +107,13 @@ readonly _DT_FIELD_TIMEOUT_USED_MS="timeout_used_ms"
 # ---------------------------------------------------------------------------
 
 _dt_acquire_lock() {
-	local timeout_s="${DISPATCH_TIMING_LOCK_TIMEOUT_S}"
+	local timeout_s="${1:-$DISPATCH_TIMING_LOCK_TIMEOUT_S}"
 	local elapsed=0
 	mkdir -p "$STATE_DIR" 2>/dev/null
 	while ! mkdir "$LOCK_DIR" 2>/dev/null; do
+		if ((timeout_s <= 0)); then
+			return 1
+		fi
 		# Check for stale lock (>30s old → assume crashed)
 		if [[ -d "$LOCK_DIR" ]]; then
 			local lock_mtime now_epoch age_s
@@ -392,7 +402,12 @@ _dt_cmd_record() {
 
 	# Acquire lock — fail-open if we can't, so dispatch is never blocked
 	# by recording machinery.
-	_dt_acquire_lock || {
+	local lock_timeout_s="$DISPATCH_TIMING_RECORD_LOCK_TIMEOUT_S"
+	if [[ "$outcome" == "skip" ]]; then
+		lock_timeout_s="$DISPATCH_TIMING_SKIP_LOCK_TIMEOUT_S"
+	fi
+	[[ "$lock_timeout_s" =~ ^[0-9]+$ ]] || lock_timeout_s=1
+	_dt_acquire_lock "$lock_timeout_s" || {
 		echo "[dispatch-timing] WARN: lock timeout — skipping record (non-fatal)" >&2
 		return 0
 	}

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -237,18 +237,72 @@ _dlw_resolve_tier_and_model() {
 #
 # Arguments: worktree_path, repo_path
 ###############################################################################
+_dlw_node_modules_restore_lock_dir() {
+	local workspace_dir="${AIDEVOPS_WORKSPACE_DIR:-${HOME}/.aidevops/.agent-workspace}"
+	printf '%s\n' "${workspace_dir}/tmp/worktree-node-modules-restore.lock.d"
+	return 0
+}
+
+_dlw_node_modules_restore_acquire_lock() {
+	local lock_dir="$1"
+	local timeout_s="${WORKTREE_NODE_MODULES_RESTORE_LOCK_TIMEOUT_S:-2}"
+	local elapsed=0
+	[[ "$timeout_s" =~ ^[0-9]+$ ]] || timeout_s=2
+	mkdir -p "${lock_dir%/*}" 2>/dev/null || return 1
+	while ! mkdir "$lock_dir" 2>/dev/null; do
+		if [[ -d "$lock_dir" ]]; then
+			local lock_mtime now_epoch age_s
+			lock_mtime=$(_file_mtime_epoch "$lock_dir")
+			now_epoch=$(date +%s)
+			age_s=$((now_epoch - lock_mtime))
+			if ((age_s > 60)); then
+				rmdir "$lock_dir" 2>/dev/null || true
+				continue
+			fi
+		fi
+		if ((elapsed >= timeout_s * 10)); then
+			return 1
+		fi
+		sleep 0.1
+		elapsed=$((elapsed + 1))
+	done
+	printf '%s\n' "$$" >"${lock_dir}/pid" 2>/dev/null || true
+	return 0
+}
+
+_dlw_node_modules_restore_release_lock() {
+	local lock_dir="$1"
+	rm -f "${lock_dir}/pid" 2>/dev/null || true
+	rmdir "$lock_dir" 2>/dev/null || true
+	return 0
+}
+
 _dlw_restore_worktree_deps() {
 	local worktree_path="$1"
 	local repo_path="$2"
 
 	[[ -z "$worktree_path" || -z "$repo_path" ]] && return 0
 	[[ ! -d "$worktree_path" || ! -d "$repo_path" ]] && return 0
+	[[ "${WORKTREE_NODE_MODULES_RESTORE_ENABLED:-1}" == "1" ]] || return 0
+
+	local _lock_dir=""
+	_lock_dir=$(_dlw_node_modules_restore_lock_dir)
+	if ! _dlw_node_modules_restore_acquire_lock "$_lock_dir"; then
+		echo "[dispatch_with_dedup] Skipping node_modules restore for ${worktree_path}: another restore is active" >>"$LOGFILE"
+		return 0
+	fi
 
 	# Find directories in the worktree that have a package.json but are
 	# missing node_modules. Only check top-level and one level deep —
 	# deeper nesting is unlikely and find is expensive.
 	local _pkg_dir=""
+	local _restored=0
+	local _max_dirs="${WORKTREE_NODE_MODULES_RESTORE_MAX_DIRS:-2}"
+	[[ "$_max_dirs" =~ ^[0-9]+$ ]] || _max_dirs=2
 	while IFS= read -r _pkg_dir; do
+		if ((_restored >= _max_dirs)); then
+			break
+		fi
 		local _dir=""
 		_dir=$(dirname "$_pkg_dir") || continue
 		local _rel_dir=""
@@ -260,9 +314,11 @@ _dlw_restore_worktree_deps() {
 			# t2889: fast_cp uses APFS clonefile / btrfs reflink CoW
 			# where available — sub-second copy, near-zero disk delta.
 			fast_cp "$_src_nm" "$_dst_nm" 2>/dev/null || true
+			_restored=$((_restored + 1))
 			echo "[dispatch_with_dedup] Restored node_modules: ${_rel_dir:-/} ($(du -sh "$_dst_nm" 2>/dev/null | cut -f1))" >>"$LOGFILE"
 		fi
 	done < <(find "$worktree_path" -maxdepth 3 -name "package.json" -not -path "*/node_modules/*" 2>/dev/null)
+	_dlw_node_modules_restore_release_lock "$_lock_dir"
 
 	return 0
 }
@@ -323,7 +379,7 @@ _dlw_precreate_worktree() {
 	_branch="feature/auto-$(date +%Y%m%d-%H%M%S)-gh${issue_number}"
 	# Run from repo_path — worktree-helper.sh uses git commands that need
 	# to be inside the repo. The pulse-wrapper's cwd is typically / (launchd).
-	_wt_output=$(cd "$repo_path" && "$_wt_helper" add "$_branch" 2>&1) || true
+	_wt_output=$(cd "$repo_path" && WORKTREE_NODE_MODULES_RESTORE_ENABLED=0 "$_wt_helper" add "$_branch" 2>&1) || true
 	_wt_output=$(printf '%s' "$_wt_output" | sed $'s/\x1b\\[[0-9;]*m//g')
 	local _path
 	_path=$(printf '%s' "$_wt_output" | grep -oE '/[^ ]*Git/[^ ]*' | head -1) || _path=""

--- a/.agents/scripts/worktree-helper-add.sh
+++ b/.agents/scripts/worktree-helper-add.sh
@@ -29,6 +29,14 @@
 [[ -n "${_WORKTREE_ADD_LIB_LOADED:-}" ]] && return 0
 _WORKTREE_ADD_LIB_LOADED=1
 
+# GH#22238: node_modules restore is useful for interactive worktrees but can
+# saturate CPU when many pulse precreations run concurrently. Serialize the
+# copy path and fail open quickly; workers can still install/fallback later if
+# dependency restore is skipped during overload.
+: "${WORKTREE_NODE_MODULES_RESTORE_ENABLED:=1}"
+: "${WORKTREE_NODE_MODULES_RESTORE_LOCK_TIMEOUT_S:=2}"
+: "${WORKTREE_NODE_MODULES_RESTORE_MAX_DIRS:=2}"
+
 # Defensive SCRIPT_DIR fallback
 if [[ -z "${SCRIPT_DIR:-}" ]]; then
 	_lib_path="${BASH_SOURCE[0]%/*}"
@@ -303,14 +311,68 @@ _interactive_session_auto_claim() {
 # Git worktrees only contain tracked files — dirs in .gitignore are missing.
 # If .opencode/tool/*.ts imports from node_modules the runtime crashes on
 # startup. See pulse-dispatch-worker-launch.sh _dlw_restore_worktree_deps.
+_restore_worktree_node_modules_lock_dir() {
+	local workspace_dir="${AIDEVOPS_WORKSPACE_DIR:-${HOME}/.aidevops/.agent-workspace}"
+	printf '%s\n' "${workspace_dir}/tmp/worktree-node-modules-restore.lock.d"
+	return 0
+}
+
+_restore_worktree_node_modules_acquire_lock() {
+	local lock_dir="$1"
+	local timeout_s="${WORKTREE_NODE_MODULES_RESTORE_LOCK_TIMEOUT_S}"
+	local elapsed=0
+	[[ "$timeout_s" =~ ^[0-9]+$ ]] || timeout_s=2
+	mkdir -p "${lock_dir%/*}" 2>/dev/null || return 1
+	while ! mkdir "$lock_dir" 2>/dev/null; do
+		if [[ -d "$lock_dir" ]]; then
+			local lock_mtime now_epoch age_s
+			lock_mtime=$(_file_mtime_epoch "$lock_dir")
+			now_epoch=$(date +%s)
+			age_s=$((now_epoch - lock_mtime))
+			if ((age_s > 60)); then
+				rmdir "$lock_dir" 2>/dev/null || true
+				continue
+			fi
+		fi
+		if ((elapsed >= timeout_s * 10)); then
+			return 1
+		fi
+		sleep 0.1
+		elapsed=$((elapsed + 1))
+	done
+	printf '%s\n' "$$" >"${lock_dir}/pid" 2>/dev/null || true
+	return 0
+}
+
+_restore_worktree_node_modules_release_lock() {
+	local lock_dir="$1"
+	rm -f "${lock_dir}/pid" 2>/dev/null || true
+	rmdir "$lock_dir" 2>/dev/null || true
+	return 0
+}
+
 _restore_worktree_node_modules() {
 	local wt_path="$1"
 	local repo_root="$2"
 
 	[[ -n "$repo_root" && -d "$wt_path" ]] || return 0
+	[[ "$WORKTREE_NODE_MODULES_RESTORE_ENABLED" == "1" ]] || return 0
+
+	local _lock_dir=""
+	_lock_dir=$(_restore_worktree_node_modules_lock_dir)
+	if ! _restore_worktree_node_modules_acquire_lock "$_lock_dir"; then
+		print_warning "Skipping node_modules restore for ${wt_path}: another restore is active"
+		return 0
+	fi
 
 	local _pkg_file=""
+	local _restored=0
+	local _max_dirs="$WORKTREE_NODE_MODULES_RESTORE_MAX_DIRS"
+	[[ "$_max_dirs" =~ ^[0-9]+$ ]] || _max_dirs=2
 	while IFS= read -r _pkg_file; do
+		if ((_restored >= _max_dirs)); then
+			break
+		fi
 		local _pdir="" _rel=""
 		_pdir=$(dirname "$_pkg_file") || continue
 		_rel="${_pdir#"$wt_path"}"
@@ -320,8 +382,10 @@ _restore_worktree_node_modules() {
 			# t2889: fast_cp uses APFS clonefile / btrfs reflink CoW where
 			# available — sub-second copy on macOS, near-zero disk delta.
 			fast_cp "$_src" "$_dst" 2>/dev/null || true
+			_restored=$((_restored + 1))
 		fi
 	done < <(find "$wt_path" -maxdepth 3 -name "package.json" -not -path "*/node_modules/*" 2>/dev/null)
+	_restore_worktree_node_modules_release_lock "$_lock_dir"
 	return 0
 }
 


### PR DESCRIPTION
## Summary

Capped dispatch timing record lock waits, serialized node_modules restore with quick fail-open behavior, and disabled duplicate worktree-helper restores during pulse precreation.

## Files Changed

.agents/scripts/dispatch-timing-helper.sh,.agents/scripts/pulse-dispatch-worker-launch.sh,.agents/scripts/worktree-helper-add.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/worktree-helper.sh .agents/scripts/worktree-helper-add.sh .agents/scripts/dispatch-timing-helper.sh .agents/scripts/pulse-dispatch-worker-launch.sh; repeated skip record simulation completed in 1.300s with no lingering record processes; locked node_modules restore skipped in 0.076s; process scan found no live node_modules copy or timing-record fanout.

Resolves #22238


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.89 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 3m and 122,448 tokens on this as a headless worker.