### PR TITLE
GH#22241: add per-function GraphQL instrumentation to public gh CLI wrappers

### DIFF
--- a/.agents/scripts/shared-gh-wrappers-create.sh
+++ b/.agents/scripts/shared-gh-wrappers-create.sh
@@ -173,6 +173,7 @@ _gh_ci_prepare_todo_labels() {
 }
 
 gh_create_issue() {
+	gh_record_call graphql gh_create_issue 2>/dev/null || true
 	# GH#19857: validate title/body before creating (same invariant as edit wrappers)
 	if ! _gh_validate_edit_args "$@"; then
 		_gh_edit_audit_rejection "gh issue create" "$_GH_EDIT_REJECTION_REASON" "$@"
@@ -451,6 +452,7 @@ _gh_auto_link_sub_issue() {
 }
 
 gh_create_pr() {
+	gh_record_call graphql gh_create_pr 2>/dev/null || true
 	# GH#19857: validate title/body before creating (same invariant as edit wrappers)
 	if ! _gh_validate_edit_args "$@"; then
 		_gh_edit_audit_rejection "gh pr create" "$_GH_EDIT_REJECTION_REASON" "$@"
@@ -526,6 +528,7 @@ _gh_recover_pr_if_exists() {
 # <!-- aidevops:sig --> marker, so callers that build their own footer
 # are not double-signed.
 gh_issue_comment() {
+	gh_record_call graphql gh_issue_comment 2>/dev/null || true
 	_gh_wrapper_auto_sig "$@"
 	set -- "${_GH_WRAPPER_SIG_MODIFIED_ARGS[@]}"
 	gh issue comment "$@"
@@ -539,6 +542,7 @@ gh_issue_comment() {
 }
 
 gh_pr_comment() {
+	gh_record_call graphql gh_pr_comment 2>/dev/null || true
 	_gh_wrapper_auto_sig "$@"
 	set -- "${_GH_WRAPPER_SIG_MODIFIED_ARGS[@]}"
 	gh pr comment "$@"

--- a/.agents/scripts/shared-gh-wrappers-safe-edit.sh
+++ b/.agents/scripts/shared-gh-wrappers-safe-edit.sh
@@ -216,6 +216,7 @@ _gh_audit_record_op() {
 # Returns 1 with stderr message on validation failure.
 #######################################
 gh_issue_edit_safe() {
+	gh_record_call graphql gh_issue_edit_safe 2>/dev/null || true
 	if ! _gh_validate_edit_args "$@"; then
 		_gh_edit_audit_rejection "gh issue edit" "$_GH_EDIT_REJECTION_REASON" "$@"
 		return 1
@@ -245,6 +246,7 @@ gh_issue_edit_safe() {
 # Returns 1 with stderr message on validation failure.
 #######################################
 gh_pr_edit_safe() {
+	gh_record_call graphql gh_pr_edit_safe 2>/dev/null || true
 	if ! _gh_validate_edit_args "$@"; then
 		_gh_edit_audit_rejection "gh pr edit" "$_GH_EDIT_REJECTION_REASON" "$@"
 		return 1
@@ -268,6 +270,7 @@ gh_pr_edit_safe() {
 # Returns the exit code of the underlying gh command.
 #######################################
 gh_issue_close_safe() {
+	gh_record_call graphql gh_issue_close_safe 2>/dev/null || true
 	local _num _repo _before _after
 	_num="$(_gh_extract_number_from_args "$@")"
 	_repo="$(_gh_extract_repo_from_args "$@")"
@@ -287,6 +290,7 @@ gh_issue_close_safe() {
 # Returns the exit code of the underlying gh command.
 #######################################
 gh_issue_reopen_safe() {
+	gh_record_call graphql gh_issue_reopen_safe 2>/dev/null || true
 	local _num _repo _before _after
 	_num="$(_gh_extract_number_from_args "$@")"
 	_repo="$(_gh_extract_repo_from_args "$@")"
@@ -306,6 +310,7 @@ gh_issue_reopen_safe() {
 # Returns the exit code of the underlying gh command.
 #######################################
 gh_pr_close_safe() {
+	gh_record_call graphql gh_pr_close_safe 2>/dev/null || true
 	local _num _repo _before _after
 	_num="$(_gh_extract_number_from_args "$@")"
 	_repo="$(_gh_extract_repo_from_args "$@")"
@@ -325,6 +330,7 @@ gh_pr_close_safe() {
 # Returns the exit code of the underlying gh command.
 #######################################
 gh_pr_merge_safe() {
+	gh_record_call graphql gh_pr_merge_safe 2>/dev/null || true
 	local _num _repo _before _after
 	_num="$(_gh_extract_number_from_args "$@")"
 	_repo="$(_gh_extract_repo_from_args "$@")"

--- a/.agents/scripts/shared-gh-wrappers-status.sh
+++ b/.agents/scripts/shared-gh-wrappers-status.sh
@@ -127,6 +127,7 @@ ensure_status_labels_exist() {
 #       --add-label "needs-maintainer-review"
 #######################################
 set_issue_status() {
+	gh_record_call graphql set_issue_status 2>/dev/null || true
 	local issue_num="$1"
 	local repo_slug="$2"
 	local new_status="$3"
@@ -195,6 +196,7 @@ set_issue_status() {
 # when both paths ran).
 #######################################
 gh_issue_view() {
+	gh_record_call graphql gh_issue_view 2>/dev/null || true
 	local _first_num="${1:-}"
 	_gh_with_timeout read gh issue view "$@"
 	local rc=$?
@@ -221,6 +223,7 @@ gh_issue_view() {
 # when both paths ran).
 #######################################
 gh_pr_list() {
+	gh_record_call graphql gh_pr_list 2>/dev/null || true
 	_gh_with_timeout read gh pr list "$@"
 	local rc=$?
 	if [[ $rc -ne 0 ]] && _rest_should_fallback; then
@@ -254,6 +257,7 @@ gh_pr_list() {
 # when both paths ran).
 #######################################
 gh_issue_list() {
+	gh_record_call graphql gh_issue_list 2>/dev/null || true
 	_gh_with_timeout read gh issue list "$@"
 	local rc=$?
 	if [[ $rc -ne 0 ]] && _rest_should_fallback; then


### PR DESCRIPTION
## Summary

Resolves #22241

- Add `gh_record_call graphql <function_name>` to 14 public wrapper functions across 3 files
- Covers: `gh_create_issue`, `gh_create_pr`, `gh_issue_comment`, `gh_pr_comment`, `set_issue_status`, `gh_issue_view`, `gh_pr_list`, `gh_issue_list`, `gh_issue_edit_safe`, `gh_pr_edit_safe`, `gh_issue_close_safe`, `gh_issue_reopen_safe`, `gh_pr_close_safe`, `gh_pr_merge_safe`
- After deploy, API log will show per-function GraphQL breakdown instead of opaque `gh-shim` bucket (1065+ calls/day)
- Companion to PR #21946 which added the same for REST fallback functions

<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.89 plugin for [OpenCode](https://opencode.ai) v1.14.30 with claude-opus-4-6 spent 1d 5h and 73,290 tokens on this with the user in an interactive session.
