### PR TITLE
t3414: fix dispatch accounting and GraphQL budget drain

### DIFF
--- a/.agents/scripts/pulse-dispatch-core.sh
+++ b/.agents/scripts/pulse-dispatch-core.sh
@@ -1113,8 +1113,9 @@ _run_eligibility_gate_or_abort() {
 #   $9 - model_override (optional, default empty = auto round-robin)
 #
 # Exit codes:
-#   0 - worker dispatched successfully, or blocked (not a failure)
+#   0 - worker dispatched successfully
 #   1 - hard error (metadata unavailable, dedup gate blocked)
+#   2 - explicit launch no-op (canary/precreate/orphan guard; retry later)
 #######################################
 dispatch_with_dedup() {
 	local issue_number="$1"
@@ -1230,14 +1231,16 @@ dispatch_with_dedup() {
 
 	# All checks passed — launch the worker.
 	_ds_t0=$(_ds_now_ns)
+	local _launch_rc=0
 	_dispatch_launch_worker \
 		"$issue_number" "$repo_slug" "$dispatch_title" "$issue_title" \
 		"$self_login" "$repo_path" "$prompt" "$session_key" \
-		"$model_override" "$issue_meta_json"
+		"$model_override" "$issue_meta_json" || _launch_rc=$?
 	_ds_record "$issue_number" "$repo_slug" "worker_launch_total" "$_ds_t0"
 
 	# t3034: record total ceremony time
 	_ds_record "$issue_number" "$repo_slug" "ceremony_total" "$_ds_ceremony_t0"
+	return "$_launch_rc"
 }
 
 #######################################

--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -379,6 +379,8 @@ _dispatch_with_timeout() {
 		fi
 	elif [[ "$dispatch_rc" -eq 0 ]]; then
 		outcome="success"
+	elif [[ "$dispatch_rc" -eq 2 ]]; then
+		outcome="noop"
 	else
 		outcome="skip"
 	fi
@@ -394,6 +396,28 @@ _dispatch_with_timeout() {
 	fi
 
 	return "$dispatch_rc"
+}
+
+#######################################
+# Stop dispatch loops when the GraphQL reserve is already below the circuit
+# breaker threshold. The rate_limit endpoint is free, so this protects the
+# high-fanout loop without spending additional GraphQL points.
+#
+# Returns:
+#   0 — budget is sufficient, unavailable, or checker is not loaded
+#   1 — budget is below threshold; caller should stop the loop
+#######################################
+_dispatch_graphql_budget_allows_next() {
+	if ! declare -F is_graphql_budget_sufficient >/dev/null 2>&1; then
+		return 0
+	fi
+
+	local _budget_rc=0
+	is_graphql_budget_sufficient >/dev/null 2>&1 || _budget_rc=$?
+	if [[ "$_budget_rc" -eq 1 ]]; then
+		return 1
+	fi
+	return 0
 }
 
 #######################################
@@ -710,6 +734,10 @@ _dispatch_floor_loop() {
 			echo "[pulse-wrapper] Dispatch_max stopping early: stop flag appeared" >>"$LOGFILE"
 			break
 		fi
+		if ! _dispatch_graphql_budget_allows_next; then
+			echo "[pulse-wrapper] Dispatch_max stopping early: GraphQL circuit breaker tripped during serial loop" >>"$LOGFILE"
+			break
+		fi
 		local _dispatch_proc_rc=0
 		_dispatch_process_candidate "$candidate_json" "$self_login" "$available_slots" || _dispatch_proc_rc=$?
 		echo "[pulse-wrapper] Dispatch_max: loop iter=${processed_count} — _dispatch_process_candidate rc=${_dispatch_proc_rc}" >>"$LOGFILE"
@@ -815,6 +843,10 @@ _dispatch_max_loop() {
 		fi
 		if [[ -f "$STOP_FLAG" ]]; then
 			echo "[pulse-wrapper] Dispatch_max stopping early: stop flag appeared" >>"$LOGFILE"
+			break
+		fi
+		if ! _dispatch_graphql_budget_allows_next; then
+			echo "[pulse-wrapper] Dispatch_max stopping early: GraphQL circuit breaker tripped during parallel loop" >>"$LOGFILE"
 			break
 		fi
 

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -1000,7 +1000,7 @@ _dispatch_launch_worker() {
 	if ! _dlw_canary_preflight "$issue_number" "$repo_slug" "$worker_log" \
 		"$dispatch_model_tier" "$selected_model"; then
 		_ds_record "$issue_number" "$repo_slug" "canary_preflight" "$_ds_t0"
-		return 0
+		return 2
 	fi
 	_ds_record "$issue_number" "$repo_slug" "canary_preflight" "$_ds_t0"
 
@@ -1029,13 +1029,13 @@ _dispatch_launch_worker() {
 		_ds_record "$issue_number" "$repo_slug" "precreate_worktree" "$_ds_t0"
 		pulse_stats_increment "worktree_precreation_failed_count" 2>/dev/null || true
 		echo "[dispatch_with_dedup] Skipping #${issue_number} — pre-creation failed; will retry next cycle" >>"$LOGFILE"
-		return 0
+		return 2
 	fi
 	_ds_record "$issue_number" "$repo_slug" "precreate_worktree" "$_ds_t0"
 	local worker_worktree_path="$_DLW_WORKTREE_PATH"
 	local worker_worktree_branch="$_DLW_WORKTREE_BRANCH"
 	if _dlw_check_worker_branch_orphan_loop "$issue_number" "$repo_slug" "$worker_worktree_branch"; then
-		return 0
+		return 2
 	fi
 
 	_ds_t0=$(_ds_now_ns)

--- a/.agents/scripts/tests/test-dispatch-max-parallel.sh
+++ b/.agents/scripts/tests/test-dispatch-max-parallel.sh
@@ -384,6 +384,82 @@ test_parallel_loop_stop_flag_aborts() {
 	return 0
 }
 
+test_parallel_loop_graphql_budget_aborts() {
+	# Stub: every candidate would succeed if the budget gate allowed launch.
+	# shellcheck disable=SC2317  # called via name resolution from loop
+	_dispatch_process_candidate() {
+		return 0
+	}
+	# shellcheck disable=SC2317  # called via name resolution from loop
+	is_graphql_budget_sufficient() {
+		return 1
+	}
+
+	local candidate_file outcomes_file
+	candidate_file=$(mktemp)
+	outcomes_file=$(mktemp)
+	for i in 320 321 322 323; do
+		printf '{"number":%d,"repo_slug":"o/r","repo_path":"/t","url":"u","title":"t","labels":[]}\n' "$i"
+	done >"$candidate_file"
+	: >"$outcomes_file"
+
+	rm -f "$STOP_FLAG"
+	local result
+	result=$(_dispatch_max_loop "$candidate_file" 10 10 "test_user" 4 "$outcomes_file")
+	rm -f "$candidate_file" "$outcomes_file"
+	unset -f is_graphql_budget_sufficient
+
+	if [[ "$result" == "0 1" ]]; then
+		print_result "parallel_loop: GraphQL budget gate aborts before launch" 0
+	else
+		print_result "parallel_loop: GraphQL budget gate aborts before launch" 1 "got=${result}"
+	fi
+	return 0
+}
+
+test_dispatch_with_timeout_noop_outcome() {
+	local capture_dir old_path rc capture
+	capture_dir=$(mktemp -d)
+	old_path="$PATH"
+	cat >"${capture_dir}/dispatch-timing-helper.sh" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$*" >>"${DISPATCH_TIMING_CAPTURE}"
+exit 0
+EOF
+	chmod +x "${capture_dir}/dispatch-timing-helper.sh"
+	export PATH="${capture_dir}:$PATH"
+	export DISPATCH_TIMING_CAPTURE="${capture_dir}/capture.txt"
+	export DISPATCH_TIMING_ADAPTIVE=0
+	export DISPATCH_PER_CANDIDATE_TIMEOUT=5
+	export DISPATCH_PER_CANDIDATE_TIMEOUT_FLOOR=1
+	# shellcheck disable=SC2317  # called via _dispatch_with_timeout
+	dispatch_with_dedup() {
+		return 2
+	}
+	# shellcheck disable=SC2317  # called via _dispatch_with_timeout
+	run_stage_with_timeout() {
+		shift 2
+		"$@"
+		return $?
+	}
+
+	rc=0
+	_dispatch_with_timeout 330 "o/r" "Issue #330" "title" "me" "/tmp/repo" "prompt" "issue-330" "" || rc=$?
+	capture=$(cat "$DISPATCH_TIMING_CAPTURE" 2>/dev/null || true)
+	PATH="$old_path"
+	export PATH
+	unset DISPATCH_TIMING_CAPTURE DISPATCH_TIMING_ADAPTIVE DISPATCH_PER_CANDIDATE_TIMEOUT DISPATCH_PER_CANDIDATE_TIMEOUT_FLOOR
+	unset -f dispatch_with_dedup run_stage_with_timeout
+	rm -rf "$capture_dir"
+
+	if [[ "$rc" -eq 2 && "$capture" == *"--outcome noop"* ]]; then
+		print_result "dispatch_with_timeout: rc=2 records noop outcome" 0
+	else
+		print_result "dispatch_with_timeout: rc=2 records noop outcome" 1 "rc=${rc} capture=${capture}"
+	fi
+	return 0
+}
+
 # =============================================================================
 # Test 5: serial loop preserves existing behavior (regression escape hatch)
 # =============================================================================
@@ -469,6 +545,8 @@ test_aggregate_outcomes_clears_throttle_on_success
 test_parallel_loop_end_to_end
 test_parallel_loop_respects_budget
 test_parallel_loop_stop_flag_aborts
+test_parallel_loop_graphql_budget_aborts
+test_dispatch_with_timeout_noop_outcome
 test_serial_loop_basic
 test_serial_loop_budget_cap
 

--- a/.agents/scripts/tests/test-precreation-failure-skip.sh
+++ b/.agents/scripts/tests/test-precreation-failure-skip.sh
@@ -152,6 +152,18 @@ source "${SCRIPTS_DIR}/pulse-dispatch-worker-launch.sh"
 # worktree-helper.sh.
 SCRIPT_DIR="$TMP"
 
+# Re-stub launch-orchestrator dependencies after sourcing; the module defines
+# real implementations when loaded, but this test isolates precreation failure.
+_ds_now_ns() { printf '0\n'; return 0; }
+_ds_record() { return 0; }
+_dlw_resolve_tier_and_model() {
+	_DLW_DISPATCH_TIER="standard"
+	_DLW_DISPATCH_MODEL_TIER="sonnet"
+	_DLW_SELECTED_MODEL=""
+	return 0
+}
+_dlw_canary_preflight() { return 0; }
+
 printf '\n%s\n' "=== t2981: worktree pre-creation failure observability ==="
 
 # =============================================================================
@@ -218,13 +230,20 @@ _dlw_precreate_worktree() {
 # Reset stats file
 printf '{"counters":{}}\n' >"$PULSE_STATS_FILE"
 
+launch_rc=0
 _dispatch_launch_worker "77777" "owner/repo" "test-dispatch" "Test Issue" \
-	"testuser" "$FAKE_REPO" "test prompt" "session-key-1" "" "{}"
+	"testuser" "$FAKE_REPO" "test prompt" "session-key-1" "" "{}" || launch_rc=$?
 
 if [[ ! -s "${TMP}/setsid-calls.txt" ]]; then
 	pass "dispatch skipped (no setsid) when pre-creation fails"
 else
 	fail "dispatch skipped (no setsid) when pre-creation fails" "setsid was called"
+fi
+
+if [[ "$launch_rc" -eq 2 ]]; then
+	pass "dispatch skip returns explicit no-op rc=2"
+else
+	fail "dispatch skip returns explicit no-op rc=2" "got rc=$launch_rc"
 fi
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- Propagates explicit launch no-op rc=2 for canary, precreation, and orphan-branch guards so dispatch_with_dedup rc=0 means a worker was actually spawned.
- Adds an in-loop GraphQL circuit-breaker check so serial and parallel dispatch stop before spending a 24-slot batch into an exhausted reserve.
- Adds regression coverage for noop timing outcomes, GraphQL budget stops, and precreation no-op return semantics.

## Verification
- `.agents/scripts/tests/test-dispatch-max-parallel.sh`
- `.agents/scripts/tests/test-precreation-failure-skip.sh`
- `shellcheck .agents/scripts/pulse-dispatch-lib.sh .agents/scripts/pulse-dispatch-worker-launch.sh .agents/scripts/pulse-dispatch-core.sh .agents/scripts/tests/test-dispatch-max-parallel.sh .agents/scripts/tests/test-precreation-failure-skip.sh`

Resolves #22243


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.89 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 1h 9m and 1,051,612 tokens on this with the user in an interactive session.
