### PR TITLE
GH#22221: fix dispatch cooldown marker ordering

### DIFF
--- a/.agents/scripts/dispatch-dedup-helper.sh
+++ b/.agents/scripts/dispatch-dedup-helper.sh
@@ -757,12 +757,12 @@ _is_assigned_check_dispatch_cooldown() {
 	[[ "$cooldown_s" =~ ^[0-9]+$ ]] || cooldown_s=1800
 	[[ "$cooldown_s" -gt 0 ]] || return 1
 
-	# Fetch comments newest-first across every page. Active review-followup
-	# threads can exceed GitHub's first page, and a recent cooldown marker must
-	# win over older markers. Fail-open on API error — cooldown is an
-	# optimisation, not a guarantee.
+	# Fetch comments across every page. GitHub's issue comments endpoint returns
+	# oldest-first and ignores sort/direction parameters, so select the last
+	# matching marker after pagination to use the newest cooldown. Fail-open on API
+	# error — cooldown is an optimisation, not a guarantee.
 	local comments_endpoint
-	comments_endpoint=$(printf 'repos/%s/issues/%s/comments?per_page=100&sort=created&direction=desc' "$repo_slug" "$issue_number")
+	comments_endpoint=$(printf 'repos/%s/issues/%s/comments?per_page=100' "$repo_slug" "$issue_number")
 	local comments_json
 	comments_json=$(gh api --paginate --slurp "$comments_endpoint" 2>/dev/null) || return 1
 	[[ -n "$comments_json" ]] || return 1
@@ -774,7 +774,7 @@ _is_assigned_check_dispatch_cooldown() {
 	local _jq_rc=0
 	local marker_iso
 	marker_iso=$(printf '%s' "$comments_json" |
-		jq -r '[.[][] | (.body // "") | match("<!-- dispatch-cooldown-until:([^ ]+) reason=no_worker_process"; "g") | .captures[0].string] | first // ""') || _jq_rc=$?
+		jq -r '[.[][] | (.body // "") | match("<!-- dispatch-cooldown-until:([^ ]+) reason=no_worker_process"; "g") | .captures[0].string] | last // ""') || _jq_rc=$?
 	if [[ "$_jq_rc" -ne 0 ]]; then
 		return 1
 	fi

--- a/.agents/scripts/tests/test-dispatch-cooldown.sh
+++ b/.agents/scripts/tests/test-dispatch-cooldown.sh
@@ -76,6 +76,12 @@ ${issue_payload}
 JSON
 	exit 0
 fi
+if [[ "\$1" == "api" && "\$4" == *sort=* ]]; then
+	exit 1
+fi
+if [[ "\$1" == "api" && "\$4" == *direction=* ]]; then
+	exit 1
+fi
 if [[ "\$1" == "api" && "\$2" == "--paginate" && "\$3" == "--slurp" && "\$4" == repos/*/issues/*/comments* ]]; then
 	printf '['
 	cat <<'JSON'
@@ -134,11 +140,11 @@ else
 fi
 
 # Case B: latest of multiple markers wins. GitHub comments are fetched
-# newest-first, so a fresh marker before an expired marker should block (jq
-# `first` semantics).
+# oldest-first, so a fresh marker after an expired marker should block (jq
+# `last` semantics).
 PAST_ISO=$(iso_offset -3600)
 FUTURE_ISO_2=$(iso_offset 1800)
-COMMENTS_LATEST_WINS='[{"body":"<!-- dispatch-cooldown-until:'"${FUTURE_ISO_2}"' reason=no_worker_process runner=runner-b -->"},{"body":"intervening human comment"},{"body":"<!-- dispatch-cooldown-until:'"${PAST_ISO}"' reason=no_worker_process runner=runner-a -->"}]'
+COMMENTS_LATEST_WINS='[{"body":"<!-- dispatch-cooldown-until:'"${PAST_ISO}"' reason=no_worker_process runner=runner-a -->"},{"body":"intervening human comment"},{"body":"<!-- dispatch-cooldown-until:'"${FUTURE_ISO_2}"' reason=no_worker_process runner=runner-b -->"}]'
 write_stub_gh "$PASSTHROUGH_ISSUE" "$COMMENTS_LATEST_WINS"
 run_is_assigned 99886 "owner/repo"
 if [[ "$rc" -eq 0 && "$output" == *"DISPATCH_COOLDOWN_ACTIVE"* && "$output" == *"$FUTURE_ISO_2"* ]]; then


### PR DESCRIPTION
## Summary

Removed unsupported issue-comments sort parameters, kept paginated fetching, and selected the last cooldown marker from GitHub's oldest-first comment order.

## Files Changed

.agents/scripts/dispatch-dedup-helper.sh,.agents/scripts/tests/test-dispatch-cooldown.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/dispatch-dedup-helper.sh .agents/scripts/tests/test-dispatch-cooldown.sh; .agents/scripts/tests/test-dispatch-cooldown.sh

Resolves #22221


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.89 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 5m and 73,213 tokens on this as a headless worker.