### PR TITLE
GH#22218: address worktree registry review feedback

### DIFF
--- a/.agents/scripts/shared-worktree-registry.sh
+++ b/.agents/scripts/shared-worktree-registry.sh
@@ -487,7 +487,8 @@ _wt_registry_delete_paths_batch() {
 		printf 'BEGIN IMMEDIATE;\n'
 		while IFS='|' read -r wt_path _reason; do
 			[[ -z "$wt_path" ]] && continue
-			printf "DELETE FROM worktree_owners WHERE worktree_path = '%s';\n" "$(_wt_sql_escape "$wt_path")"
+			local escaped_wt_path="${wt_path//\'/\'\'}"
+			printf "DELETE FROM worktree_owners WHERE worktree_path = '%s';\n" "$escaped_wt_path"
 		done <<<"$stale_entries"
 		printf 'COMMIT;\n'
 	} | sqlite3 "$WORKTREE_REGISTRY_DB" >/dev/null 2>&1 || return 1
@@ -523,15 +524,14 @@ _wt_registry_print_pruned_entries() {
 # Count newline-separated entries.
 _wt_registry_entry_count() {
 	local entries="$1"
-	local count=0
 	[[ -z "$entries" ]] && {
 		printf '0'
 		return 0
 	}
 
-	while IFS= read -r _entry; do
-		((++count))
-	done <<<"$entries"
+	local count
+	count=$(grep -c . <<<"$entries" || true)
+	[[ "$count" =~ ^[0-9]+$ ]] || count=0
 	printf '%s' "$count"
 	return 0
 }

--- a/.agents/scripts/tests/test-worktree-registry-prune-batch.sh
+++ b/.agents/scripts/tests/test-worktree-registry-prune-batch.sh
@@ -70,6 +70,11 @@ INSERT INTO worktree_owners (worktree_path, branch, owner_pid) VALUES ('$(_wt_sq
 	i=$((i + 1))
 done
 
+quoted_stale_path="${TEST_ROOT}/missing-o'clock"
+sqlite3 "$WORKTREE_REGISTRY_DB" "
+INSERT INTO worktree_owners (worktree_path, branch, owner_pid) VALUES ('$(_wt_sql_escape "$quoted_stale_path")', 'feature/quoted', 999999);
+"
+
 start_s=$(date +%s)
 VERBOSE=1 prune_output=$(prune_worktree_registry 2>&1)
 prune_rc=$?
@@ -90,6 +95,13 @@ if [[ "$live_remaining" == "1" ]]; then
 	print_result "prune preserves existing worktree rows" 0
 else
 	print_result "prune preserves existing worktree rows" 1 "live_remaining=$live_remaining"
+fi
+
+quoted_remaining=$(sqlite3 "$WORKTREE_REGISTRY_DB" "SELECT COUNT(*) FROM worktree_owners WHERE worktree_path = '$(_wt_sql_escape "$quoted_stale_path")';")
+if [[ "$quoted_remaining" == "0" ]]; then
+	print_result "prune deletes quoted stale paths" 0
+else
+	print_result "prune deletes quoted stale paths" 1 "quoted_remaining=$quoted_remaining"
 fi
 
 if [[ "$duration" -le 10 ]]; then


### PR DESCRIPTION
## Summary

Replaced per-row SQL escape subshells in batched worktree registry deletion with Bash parameter expansion, switched entry counting to grep -c with numeric guarding, and added coverage for quoted stale paths.

## Files Changed

.agents/scripts/shared-worktree-registry.sh,.agents/scripts/tests/test-worktree-registry-prune-batch.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** shellcheck .agents/scripts/shared-worktree-registry.sh .agents/scripts/tests/test-worktree-registry-prune-batch.sh; .agents/scripts/tests/test-worktree-registry-prune-batch.sh

Resolves #22218


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.89 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 6m and 71,338 tokens on this as a headless worker.