### PR TITLE
t3415: align headless watchdog timeout

### DIFF
--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -70,7 +70,11 @@ source "${SCRIPT_DIR}/shared-claim-lifecycle.sh"
 source "${SCRIPT_DIR}/headless-runtime-worker.sh"
 
 # Activity watchdog timeout — used by _invoke_opencode and the inline watchdog fallback.
-HEADLESS_ACTIVITY_TIMEOUT_SECONDS="${HEADLESS_ACTIVITY_TIMEOUT_SECONDS:-300}"
+# Keep this aligned with worker-activity-watchdog.sh and headless-runtime-lib.sh.
+# OpenAI/GPT-5.x workers can spend several minutes reasoning without emitting
+# additional JSON/log output; 300s caused false no-output kills before workers
+# reached implementation/PR creation (GH#22248).
+HEADLESS_ACTIVITY_TIMEOUT_SECONDS="${HEADLESS_ACTIVITY_TIMEOUT_SECONDS:-600}"
 
 # =============================================================================
 # Run argument parsing and validation

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -124,6 +124,20 @@ EOF
 	return 0
 }
 
+test_headless_activity_timeout_default_matches_watchdog() {
+	local expected="600"
+	local actual="${HEADLESS_ACTIVITY_TIMEOUT_SECONDS:-}"
+
+	if [[ "$actual" == "$expected" ]]; then
+		print_result "HEADLESS_ACTIVITY_TIMEOUT_SECONDS default matches watchdog default" 0
+		return 0
+	fi
+
+	print_result "HEADLESS_ACTIVITY_TIMEOUT_SECONDS default matches watchdog default" 1 \
+		"Expected ${expected}s to avoid GPT-5.x no-output false kills; got '${actual:-<unset>}'"
+	return 0
+}
+
 # Helper: create a bare git repo and a feature branch with optional commits.
 # Each call uses work_dir-derived remote path to avoid inter-test collisions.
 # Args: $1 = work_dir path, $2 = 1 to add a commit (0 for none)
@@ -533,6 +547,7 @@ main() {
 	test_non_full_loop_prompt_unchanged
 	test_does_not_double_append
 	test_extract_session_id_from_output_returns_latest_session_id
+	test_headless_activity_timeout_default_matches_watchdog
 	# Classification tests (GH#20819 refactor of _worker_produced_output)
 	test_worker_produced_output_no_commits_returns_noop
 	test_worker_produced_output_with_commits_returns_pr_exists_failopen


### PR DESCRIPTION
## Summary
- Align headless-runtime-helper.sh default activity timeout with the 600s watchdog default used by the standalone and inline watchdogs.
- Add regression coverage so the default cannot silently regress to 300s and kill GPT-5.x/OpenAI workers during long no-output reasoning windows.

## Testing
- bash .agents/scripts/tests/test-headless-runtime-helper.sh
- shellcheck .agents/scripts/headless-runtime-helper.sh .agents/scripts/tests/test-headless-runtime-helper.sh .agents/scripts/worker-activity-watchdog.sh
- git diff --check

Resolves #22248
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.89 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 2h 11m and 1,479,036 tokens on this with the user in an interactive session.