### PR TITLE
t3416: Fix headless canary default agent regression

### DIFF
--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -1220,9 +1220,11 @@ _run_canary_test() {
 	local canary_output
 	canary_output=$(mktemp "${TMPDIR:-/tmp}/aidevops-canary.XXXXXX")
 
-	# Run WITH plugins (not --pure) so our oauth-pool auth is available.
-	# The canary must validate the same provider/model the upcoming run will use,
-	# otherwise OpenAI opt-in runs still fail behind an Anthropic-only gate.
+	# Run without external plugins and with an explicit built-in agent. The canary
+	# validates provider/model health, not aidevops agent routing; relying on
+	# OpenCode's default_agent makes dispatch preflight fail before the smoke test
+	# can run when a clean setup has a stale or subagent-only default (GH#22250).
+	# OAuth auth remains available via the isolated auth.json copied below.
 	local canary_model="$requested_model"
 	if [[ -z "$canary_model" ]]; then
 		while IFS= read -r canary_model; do
@@ -1255,6 +1257,13 @@ _run_canary_test() {
 	local _canary_data_dir=""
 	_canary_data_dir=$(mktemp -d "${TMPDIR:-/tmp}/aidevops-canary-db.XXXXXX")
 	mkdir -p "${_canary_data_dir}/opencode"
+	# Config isolation for canary: avoid validating the user's global
+	# default_agent before the smoke prompt runs. A stale or subagent-only
+	# default agent should not block provider/model health checks (GH#22250).
+	local _canary_config_dir=""
+	_canary_config_dir=$(mktemp -d "${TMPDIR:-/tmp}/aidevops-canary-config.XXXXXX")
+	mkdir -p "${_canary_config_dir}/opencode"
+	printf '%s\n' "{\"\$schema\":\"https://opencode.ai/config.json\"}" >"${_canary_config_dir}/opencode/opencode.json"
 	# Copy auth.json so the canary has valid tokens
 	local _oc_auth="${XDG_DATA_HOME:-$HOME/.local/share}/opencode/auth.json"
 	if [[ -f "$_oc_auth" ]]; then
@@ -1299,15 +1308,16 @@ _run_canary_test() {
 	# t2887: use _effective_opencode_bin (resolved above), not
 	# $OPENCODE_BIN_DEFAULT directly. Identical to the default in the
 	# happy path; differs only when alternative-path fallback fired.
-	XDG_DATA_HOME="$_canary_data_dir" \
+	XDG_CONFIG_HOME="$_canary_config_dir" XDG_DATA_HOME="$_canary_data_dir" \
 		"${_canary_timeout_cmd[@]}" \
-		"$_effective_opencode_bin" run "Reply with exactly: CANARY_OK" \
-		-m "$canary_model" --dir "${HOME}" \
+		"$_effective_opencode_bin" run --pure "Reply with exactly: CANARY_OK" \
+		-m "$canary_model" --dir "${HOME}" --agent build \
 		${canary_attach_args[@]+"${canary_attach_args[@]}"} \
 		>"$canary_output" 2>&1 || canary_exit=$?
 
-	# Clean up canary's isolated DB dir
+	# Clean up canary's isolated DB/config dirs
 	rm -rf "$_canary_data_dir" 2>/dev/null || true
+	rm -rf "$_canary_config_dir" 2>/dev/null || true
 
 	# Output-aware check: the model responding "CANARY_OK" is the real
 	# success signal. The exit code reflects process lifecycle (opencode

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -138,6 +138,52 @@ test_headless_activity_timeout_default_matches_watchdog() {
 	return 0
 }
 
+test_canary_uses_builtin_agent_without_default_agent() {
+	local canary_root="${TEST_ROOT}/canary-agent"
+	local fake_bin_dir="${canary_root}/bin"
+	local args_file="${canary_root}/args.txt"
+	mkdir -p "$fake_bin_dir"
+
+	cat >"${fake_bin_dir}/opencode" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${1:-}" == "--version" ]]; then
+	printf '1.14.31\n'
+	exit 0
+fi
+printf '%s\n' "$*" >"$AIDEVOPS_CANARY_ARGS_FILE"
+printf 'CANARY_OK\n'
+exit 0
+EOF
+	chmod +x "${fake_bin_dir}/opencode"
+
+	local output
+	if output=$(
+		PATH="${fake_bin_dir}:$PATH" \
+		HOME="${canary_root}/home" \
+		OPENCODE_BIN="${fake_bin_dir}/opencode" \
+		AIDEVOPS_CANARY_ARGS_FILE="$args_file" \
+		AIDEVOPS_HEADLESS_RUNTIME_DIR="${canary_root}/runtime" \
+		AIDEVOPS_SKIP_CANARY_OVERLOAD_CHECK=1 \
+		CANARY_CACHE_TTL_SECONDS=0 \
+		CANARY_TIMEOUT_SECONDS=5 \
+		bash -c 'source "$1" help >/dev/null 2>&1; _run_canary_test "anthropic/claude-sonnet-4-6"' _ "$HELPER_SCRIPT"
+	) && [[ -f "$args_file" ]]; then
+		local args
+		args=$(<"$args_file")
+		if [[ "$args" == *'--pure'* && "$args" == *'--agent build'* ]]; then
+			print_result "canary uses built-in agent without default_agent" 0
+			return 0
+		fi
+		print_result "canary uses built-in agent without default_agent" 1 \
+			"Expected --pure and --agent build in canary args, got: ${args}"
+		return 0
+	fi
+
+	print_result "canary uses built-in agent without default_agent" 1 \
+		"Canary stub did not run successfully: ${output:-<empty>}"
+	return 0
+}
+
 # Helper: create a bare git repo and a feature branch with optional commits.
 # Each call uses work_dir-derived remote path to avoid inter-test collisions.
 # Args: $1 = work_dir path, $2 = 1 to add a commit (0 for none)
@@ -548,6 +594,7 @@ main() {
 	test_does_not_double_append
 	test_extract_session_id_from_output_returns_latest_session_id
 	test_headless_activity_timeout_default_matches_watchdog
+	test_canary_uses_builtin_agent_without_default_agent
 	# Classification tests (GH#20819 refactor of _worker_produced_output)
 	test_worker_produced_output_no_commits_returns_noop
 	test_worker_produced_output_with_commits_returns_pr_exists_failopen


### PR DESCRIPTION
## Summary

- Isolates the OpenCode canary config so stale or invalid global default agents cannot block worker preflight.
- Runs the canary with OpenCode's built-in `build` agent under `--pure` while preserving isolated OAuth auth rotation.
- Adds regression coverage proving canary command construction no longer relies on `default_agent`.

Resolves #22250

## Runtime Testing

- runtime-verified: `AIDEVOPS_SKIP_CANARY_NEG_CACHE=1 AIDEVOPS_SKIP_CANARY_OVERLOAD_CHECK=1 .agents/scripts/headless-runtime-helper.sh canary --role worker`

## Verification

- `bash .agents/scripts/tests/test-headless-runtime-helper.sh`
- `shellcheck .agents/scripts/headless-runtime-lib.sh .agents/scripts/headless-runtime-helper.sh .agents/scripts/tests/test-headless-runtime-helper.sh`

## Key Decisions

- The canary now validates provider/model health instead of the user's configured agent graph; full workers still use the normal OpenCode config path.
<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.89 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 7m and 146,154 tokens on this as a headless worker.