### PR TITLE
GH#22253: add minimum worker concurrency floor

### DIFF
--- a/.agents/reference/worker-diagnostics.md
+++ b/.agents/reference/worker-diagnostics.md
@@ -81,6 +81,18 @@ rm -f ~/.aidevops/.agent-workspace/headless-runtime/canary-last-pass
 opencode run "Reply with exactly: CANARY_OK" -m anthropic/claude-sonnet-4-20250514 --dir "$HOME"
 ```
 
+### Minimum Worker Concurrency Floor (t3418)
+
+Pulse keeps a soft minimum implementation-worker floor so high CPU/load conditions do not reduce useful dispatch to zero. Default: `AIDEVOPS_MIN_WORKER_CONCURRENCY=6`.
+
+When active workers are below the floor:
+
+- `dispatch_max` treats CPU/load throttling as soft and keeps dispatch eligible up to the floor.
+- The worker canary skips only the pre-canary system-overload check (`AIDEVOPS_SKIP_CANARY_OVERLOAD_CHECK=1`); the normal canary, auth checks, GraphQL circuit breaker, stop flag, memory/process failures, and other hard safety gates still apply.
+- Existing max worker caps above the floor still cap runaway dispatch.
+
+Set `AIDEVOPS_MIN_WORKER_CONCURRENCY=0` to disable the floor, or set a higher/lower integer for a runner-specific target.
+
 ### Version Guard
 
 **Problem**: Something outside aidevops periodically upgrades OpenCode to latest. The version guard in `headless-runtime-helper.sh` runs on every dispatch and reinstalls `OPENCODE_PINNED_VERSION` from `shared-constants.sh` if drift is detected.

--- a/.agents/scripts/pulse-dispatch-engine.sh
+++ b/.agents/scripts/pulse-dispatch-engine.sh
@@ -304,6 +304,14 @@ dispatch_max() {
 	}
 	local max_workers active_workers available_slots
 	read -r max_workers active_workers available_slots <<<"$capacity_line"
+	_DISPATCH_MIN_WORKER_FLOOR_ACTIVE=0
+	local _min_worker_floor="${AIDEVOPS_MIN_WORKER_CONCURRENCY:-6}"
+	if ! [[ "$_min_worker_floor" =~ ^[0-9]+$ ]]; then
+		_min_worker_floor=6
+	fi
+	if ((_min_worker_floor > 0 && active_workers < _min_worker_floor)); then
+		_DISPATCH_MIN_WORKER_FLOOR_ACTIVE=1
+	fi
 	if [[ "$available_slots" -le 0 ]]; then
 		echo 0
 		return 0
@@ -351,13 +359,16 @@ dispatch_max() {
 	_DISPATCH_CANARY_CACHE="${AIDEVOPS_HEADLESS_RUNTIME_DIR:-${HOME}/.aidevops/.agent-workspace/headless-runtime}/canary-last-pass"
 
 	# t3015: branch on dispatch path (max = parallel, floor = forced-serial).
+	# t3418: if the minimum worker floor is active, recent CPU/load throttling
+	# is a soft signal and must not collapse dispatch below the floor. Explicit
+	# dispatch_floor() callers still force the floor path.
 	# _dispatch_should_use_floor_path returns 0 when the runtime is degraded
 	# (throttle file present) OR when an explicit caller invoked dispatch_floor
 	# (which sets _DISPATCH_FORCE_FLOOR=1). The floor path preserves the
 	# legacy "test the waters" behaviour as a regression escape hatch.
 	local _effective_slots="$available_slots"
 	local _dispatch_path="max"
-	if _dispatch_should_use_floor_path; then
+	if [[ -n "${_DISPATCH_FORCE_FLOOR:-}" ]] || { _dispatch_should_use_floor_path && [[ "${_DISPATCH_MIN_WORKER_FLOOR_ACTIVE:-0}" != "1" ]]; }; then
 		_effective_slots=1
 		_dispatch_path="floor"
 		if [[ -f "$_DISPATCH_THROTTLE_FILE" ]]; then

--- a/.agents/scripts/pulse-dispatch-lib.sh
+++ b/.agents/scripts/pulse-dispatch-lib.sh
@@ -87,6 +87,7 @@ pulse_dispatch_debug_log() {
 #   1 - stop flag present; caller should short-circuit
 #######################################
 _dispatch_compute_capacity() {
+	_DISPATCH_MIN_WORKER_FLOOR_ACTIVE=0
 	if [[ -f "$STOP_FLAG" ]]; then
 		echo "[pulse-wrapper] Dispatch_max skipped: stop flag present" >>"$LOGFILE"
 		return 1
@@ -110,6 +111,21 @@ _dispatch_compute_capacity() {
 	active_workers=$(count_active_workers)
 	[[ "$max_workers" =~ ^[0-9]+$ ]] || max_workers=1
 	[[ "$active_workers" =~ ^[0-9]+$ ]] || active_workers=0
+
+	# t3418: Keep a minimum implementation worker floor eligible under CPU/load
+	# throttling. This relaxes soft load posture only; STOP_FLAG and the
+	# GraphQL circuit breaker above remain hard stops.
+	local min_worker_floor="${AIDEVOPS_MIN_WORKER_CONCURRENCY:-6}"
+	if ! [[ "$min_worker_floor" =~ ^[0-9]+$ ]]; then
+		min_worker_floor=6
+	fi
+	if ((min_worker_floor > 0 && active_workers < min_worker_floor)); then
+		_DISPATCH_MIN_WORKER_FLOOR_ACTIVE=1
+		if ((max_workers < min_worker_floor)); then
+			echo "[pulse-wrapper] Dispatch_min_floor active: max_workers=${max_workers} raised to ${min_worker_floor} while active=${active_workers}" >>"$LOGFILE"
+			max_workers="$min_worker_floor"
+		fi
+	fi
 	available_slots=$((max_workers - active_workers))
 
 	printf '%s %s %s\n' "$max_workers" "$active_workers" "$available_slots"
@@ -690,9 +706,11 @@ _dispatch_max_compute_parallel() {
 		max_parallel="$effective_slots"
 	fi
 	# In throttle mode, _effective_slots is already 1 → max_parallel=1 (serial).
+	# t3418: when the minimum worker floor is active, CPU/load launch throttles
+	# are soft signals; keep parallelism eligible until the floor is reached.
 	# Defensive: also short-circuit on direct file presence in case caller
 	# passes a non-throttled effective_slots while throttle is active.
-	if [[ -f "$_DISPATCH_THROTTLE_FILE" ]]; then
+	if [[ -f "$_DISPATCH_THROTTLE_FILE" && "${_DISPATCH_MIN_WORKER_FLOOR_ACTIVE:-0}" != "1" ]]; then
 		max_parallel=1
 	fi
 	((max_parallel < 1)) && max_parallel=1

--- a/.agents/scripts/pulse-dispatch-worker-launch.sh
+++ b/.agents/scripts/pulse-dispatch-worker-launch.sh
@@ -792,6 +792,12 @@ _dlw_nohup_launch() {
 		FULL_LOOP_HEADLESS=true
 		WORKER_ISSUE_NUMBER="$issue_number"
 	)
+	if _dlw_min_worker_floor_active; then
+		worker_cmd+=(
+			AIDEVOPS_SKIP_CANARY_OVERLOAD_CHECK=1
+			AIDEVOPS_MIN_WORKER_FLOOR_BYPASS_ACTIVE=1
+		)
+	fi
 	# Pass worktree env vars only if pre-creation succeeded
 	if [[ -n "$worker_worktree_path" ]]; then
 		worker_cmd+=(
@@ -931,6 +937,18 @@ _dlw_check_worker_branch_orphan_loop() {
 	return 1
 }
 
+_dlw_min_worker_floor_active() {
+	local active_workers min_worker_floor
+	active_workers=$(count_active_workers 2>/dev/null || echo 0)
+	[[ "$active_workers" =~ ^[0-9]+$ ]] || active_workers=0
+	min_worker_floor="${AIDEVOPS_MIN_WORKER_CONCURRENCY:-6}"
+	if ! [[ "$min_worker_floor" =~ ^[0-9]+$ ]]; then
+		min_worker_floor=6
+	fi
+	((min_worker_floor > 0 && active_workers < min_worker_floor)) && return 0
+	return 1
+}
+
 _dlw_canary_preflight() {
 	local issue_number="$1"
 	local repo_slug="$2"
@@ -942,8 +960,13 @@ _dlw_canary_preflight() {
 	if [[ -n "$selected_model" ]]; then
 		_canary_cmd+=(--model "$selected_model")
 	fi
+	local -a _canary_env=()
+	if _dlw_min_worker_floor_active; then
+		_canary_env+=(AIDEVOPS_SKIP_CANARY_OVERLOAD_CHECK=1 AIDEVOPS_MIN_WORKER_FLOOR_BYPASS_ACTIVE=1)
+		echo "[dispatch_with_dedup] #${issue_number} in ${repo_slug}: minimum worker floor active — bypassing canary CPU/load overload preflight only" >>"$LOGFILE"
+	fi
 
-	if "${_canary_cmd[@]}" >>"$worker_log" 2>&1; then
+	if env "${_canary_env[@]}" "${_canary_cmd[@]}" >>"$worker_log" 2>&1; then
 		return 0
 	fi
 

--- a/.agents/scripts/tests/test-dispatch-min-concurrency.sh
+++ b/.agents/scripts/tests/test-dispatch-min-concurrency.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2025-2026 Marcus Quinn
+#
+# test-dispatch-min-concurrency.sh — t3418 regression tests for the minimum
+# pulse worker concurrency floor under CPU/load throttling.
+
+set -uo pipefail
+
+TEST_RED=$'\033[0;31m'
+TEST_GREEN=$'\033[0;32m'
+TEST_RESET=$'\033[0m'
+
+TESTS_RUN=0
+TESTS_FAILED=0
+
+print_result() {
+	local name="$1" rc="$2" extra="${3:-}"
+	TESTS_RUN=$((TESTS_RUN + 1))
+	if [[ "$rc" -eq 0 ]]; then
+		printf '%sPASS%s %s\n' "$TEST_GREEN" "$TEST_RESET" "$name"
+	else
+		printf '%sFAIL%s %s %s\n' "$TEST_RED" "$TEST_RESET" "$name" "$extra"
+		TESTS_FAILED=$((TESTS_FAILED + 1))
+	fi
+	return 0
+}
+
+TEST_ROOT=$(mktemp -d)
+trap 'rm -rf "$TEST_ROOT"' EXIT
+export HOME="${TEST_ROOT}/home"
+mkdir -p "${HOME}/.aidevops/logs" "${HOME}/.aidevops/.agent-workspace/headless-runtime"
+export LOGFILE="${HOME}/.aidevops/logs/pulse.log"
+export STOP_FLAG="${HOME}/.aidevops/logs/stop"
+: >"$LOGFILE"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+# shellcheck source=../pulse-dispatch-engine.sh
+source "${SCRIPT_DIR}/pulse-dispatch-engine.sh"
+# shellcheck source=../pulse-dispatch-worker-launch.sh
+source "${SCRIPT_DIR}/pulse-dispatch-worker-launch.sh"
+
+get_max_workers_target() {
+	printf '%s\n' "${TEST_MAX_WORKERS:-1}"
+	return 0
+}
+
+count_active_workers() {
+	printf '%s\n' "${TEST_ACTIVE_WORKERS:-0}"
+	return 0
+}
+
+test_capacity_raises_soft_cap_to_floor() {
+	TEST_MAX_WORKERS=1
+	TEST_ACTIVE_WORKERS=2
+	AIDEVOPS_MIN_WORKER_CONCURRENCY=6
+	unset _DISPATCH_MIN_WORKER_FLOOR_ACTIVE || true
+	local result capacity_file
+	capacity_file=$(mktemp)
+	_dispatch_compute_capacity >"$capacity_file"
+	result=$(<"$capacity_file")
+	rm -f "$capacity_file"
+	if [[ "$result" == "6 2 4" && "${_DISPATCH_MIN_WORKER_FLOOR_ACTIVE:-0}" == "1" ]]; then
+		print_result "capacity: raises max_workers to floor while active below floor" 0
+	else
+		print_result "capacity: raises max_workers to floor while active below floor" 1 "result=${result} floor_active=${_DISPATCH_MIN_WORKER_FLOOR_ACTIVE:-unset}"
+	fi
+	return 0
+}
+
+test_capacity_respects_existing_higher_cap() {
+	TEST_MAX_WORKERS=10
+	TEST_ACTIVE_WORKERS=2
+	AIDEVOPS_MIN_WORKER_CONCURRENCY=6
+	unset _DISPATCH_MIN_WORKER_FLOOR_ACTIVE || true
+	local result capacity_file
+	capacity_file=$(mktemp)
+	_dispatch_compute_capacity >"$capacity_file"
+	result=$(<"$capacity_file")
+	rm -f "$capacity_file"
+	if [[ "$result" == "10 2 8" && "${_DISPATCH_MIN_WORKER_FLOOR_ACTIVE:-0}" == "1" ]]; then
+		print_result "capacity: existing max cap still wins above floor" 0
+	else
+		print_result "capacity: existing max cap still wins above floor" 1 "result=${result} floor_active=${_DISPATCH_MIN_WORKER_FLOOR_ACTIVE:-unset}"
+	fi
+	return 0
+}
+
+test_throttle_does_not_force_serial_under_floor() {
+	_DISPATCH_THROTTLE_FILE="${HOME}/.aidevops/logs/dispatch-throttle"
+	: >"$_DISPATCH_THROTTLE_FILE"
+	_DISPATCH_MIN_WORKER_FLOOR_ACTIVE=1
+	unset DISPATCH_MAX_PARALLEL || true
+	local result
+	result=$(_dispatch_max_compute_parallel 6)
+	rm -f "$_DISPATCH_THROTTLE_FILE"
+	if [[ "$result" == "6" ]]; then
+		print_result "parallel: throttle remains soft under minimum floor" 0
+	else
+		print_result "parallel: throttle remains soft under minimum floor" 1 "got=${result}"
+	fi
+	return 0
+}
+
+test_throttle_forces_serial_above_floor() {
+	_DISPATCH_THROTTLE_FILE="${HOME}/.aidevops/logs/dispatch-throttle"
+	: >"$_DISPATCH_THROTTLE_FILE"
+	_DISPATCH_MIN_WORKER_FLOOR_ACTIVE=0
+	unset DISPATCH_MAX_PARALLEL || true
+	local result
+	result=$(_dispatch_max_compute_parallel 6)
+	rm -f "$_DISPATCH_THROTTLE_FILE"
+	if [[ "$result" == "1" ]]; then
+		print_result "parallel: throttle still forces serial outside floor" 0
+	else
+		print_result "parallel: throttle still forces serial outside floor" 1 "got=${result}"
+	fi
+	return 0
+}
+
+test_canary_preflight_bypasses_overload_only_below_floor() {
+	local fake_helper worker_log
+	fake_helper="${TEST_ROOT}/fake-headless-runtime-helper.sh"
+	worker_log="${TEST_ROOT}/worker.log"
+	cat >"$fake_helper" <<'EOF'
+#!/usr/bin/env bash
+if [[ "${AIDEVOPS_SKIP_CANARY_OVERLOAD_CHECK:-}" == "1" ]]; then
+	exit 0
+fi
+exit 42
+EOF
+	chmod +x "$fake_helper"
+	HEADLESS_RUNTIME_HELPER="$fake_helper"
+	TEST_ACTIVE_WORKERS=5
+	AIDEVOPS_MIN_WORKER_CONCURRENCY=6
+	if _dlw_canary_preflight 100 "o/r" "$worker_log" "standard" ""; then
+		print_result "canary: overload check bypassed below minimum floor" 0
+	else
+		print_result "canary: overload check bypassed below minimum floor" 1
+	fi
+	TEST_ACTIVE_WORKERS=6
+	if _dlw_canary_preflight 101 "o/r" "$worker_log" "standard" ""; then
+		print_result "canary: overload check enforced at floor" 1 "unexpected success"
+	else
+		print_result "canary: overload check enforced at floor" 0
+	fi
+	return 0
+}
+
+test_capacity_raises_soft_cap_to_floor
+test_capacity_respects_existing_higher_cap
+test_throttle_does_not_force_serial_under_floor
+test_throttle_forces_serial_above_floor
+test_canary_preflight_bypasses_overload_only_below_floor
+
+echo ""
+echo "===================="
+echo "Tests run: $TESTS_RUN"
+echo "Tests failed: $TESTS_FAILED"
+echo "===================="
+if [[ "$TESTS_FAILED" -eq 0 ]]; then
+	exit 0
+else
+	exit 1
+fi


### PR DESCRIPTION
## Summary

Added a configurable AIDEVOPS_MIN_WORKER_CONCURRENCY floor that keeps dispatch and worker canary load checks from collapsing below six workers under soft CPU/load throttling while preserving hard gates.

## Files Changed

.agents/reference/worker-diagnostics.md,.agents/scripts/pulse-dispatch-engine.sh,.agents/scripts/pulse-dispatch-lib.sh,.agents/scripts/pulse-dispatch-worker-launch.sh,.agents/scripts/tests/test-dispatch-min-concurrency.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-dispatch-max-parallel.sh; bash .agents/scripts/tests/test-dispatch-min-concurrency.sh; shellcheck .agents/scripts/pulse-dispatch-lib.sh .agents/scripts/pulse-dispatch-worker-launch.sh .agents/scripts/headless-runtime-helper.sh

Resolves #22253


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.90 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 4m and 162,663 tokens on this as a headless worker.