### PR TITLE
t3420: trim headless OpenCode worker startup scope

### DIFF
--- a/.agents/reference/worker-diagnostics.md
+++ b/.agents/reference/worker-diagnostics.md
@@ -21,7 +21,7 @@ Pulse cycle (every 3 min, configurable)
   → nohup worker launch (survives pulse-wrapper exit)
     → DB isolation (XDG_DATA_HOME per worker)
     → Activity watchdog (standalone process, monitors output growth)
-    → OpenCode run (headless, direct to Anthropic API via OAuth)
+    → OpenCode run (headless, direct to the selected provider/model via OAuth or API key)
     → On completion: merge worker DB back to shared DB, cleanup
     → On failure: CLAIM_RELEASED posted, issue available for re-dispatch
 ```
@@ -61,6 +61,17 @@ grep WATCHDOG_KILL /tmp/pulse-*-<issue>.log
 # Check for CLAIM_RELEASED on the issue
 gh api repos/<slug>/issues/<num>/comments --jq '.[] | select(.body | test("CLAIM_RELEASED")) | .created_at'
 ```
+
+### Provider-scoped startup (t3420)
+
+Headless OpenCode workers scope startup state to the selected model provider:
+
+- The isolated `auth.json` copied into `XDG_DATA_HOME` contains only the selected provider entry (for example, `openai` for `openai/gpt-5.5`).
+- Sandbox passthrough includes shared framework/runtime variables plus only the selected provider's env vars (`OPENAI_*`, `ANTHROPIC_*`/`CLAUDE_*`, or `GOOGLE_*`).
+- Canary uses the same provider-scoped auth copy as the real worker, so it validates the selected model without eagerly initializing unrelated provider accounts.
+- Fallback remains lazy: when retry logic selects another provider/model, the next run attempt rebuilds the isolated auth/env scope for that provider.
+
+Diagnostic: set `AIDEVOPS_HEADLESS_PROVIDER_ALLOWLIST=openai` or dispatch with `--model openai/gpt-5.5`, then inspect the worker temp auth dir in lifecycle logs (`db_isolated dir=...`). Its `opencode/auth.json` should not contain unrelated provider keys.
 
 ### Canary Smoke Test (v3.6.123)
 

--- a/.agents/scripts/headless-runtime-helper.sh
+++ b/.agents/scripts/headless-runtime-helper.sh
@@ -236,8 +236,7 @@ _invoke_opencode() {
 		mkdir -p "${isolated_data_dir}/opencode"
 		# Copy the current auth.json so the worker has valid tokens at startup
 		if [[ -f "$OPENCODE_AUTH_FILE" ]]; then
-			cp "$OPENCODE_AUTH_FILE" "${isolated_data_dir}/opencode/auth.json" 2>/dev/null || true
-			chmod 600 "${isolated_data_dir}/opencode/auth.json" 2>/dev/null || true
+			copy_scoped_opencode_auth "$OPENCODE_AUTH_FILE" "${isolated_data_dir}/opencode/auth.json" "${_invoke_provider:-}"
 		fi
 		# GH#17549: Each worker gets its OWN SQLite DB (no shared OPENCODE_DB).
 		# Previously we set OPENCODE_DB back to the shared DB for session stats,
@@ -297,7 +296,7 @@ _invoke_opencode() {
 		fi
 		if [[ -x "$SANDBOX_EXEC_HELPER" && "${AIDEVOPS_HEADLESS_SANDBOX_DISABLED:-}" != "1" ]]; then
 			local passthrough_csv
-			passthrough_csv="$(build_sandbox_passthrough_csv)"
+			passthrough_csv="$(build_sandbox_passthrough_csv "${_invoke_provider:-}")"
 			# --stream-stdout: let child stdout flow through the pipe to tee
 			# so the activity watchdog can monitor output in real-time
 			# (GH#15180 bug #4). Without this, the sandbox captures stdout to

--- a/.agents/scripts/headless-runtime-lib.sh
+++ b/.agents/scripts/headless-runtime-lib.sh
@@ -385,7 +385,47 @@ PY
 
 # --- Section 6: Sandbox Passthrough ---
 
+_headless_provider_env_allowed() {
+	local provider="$1"
+	local name="$2"
+
+	case "$name" in
+	OPENAI_*) [[ "$provider" == "openai" ]] && return 0 ;;
+	ANTHROPIC_* | CLAUDE_*) [[ "$provider" == "anthropic" ]] && return 0 ;;
+	GOOGLE_*) [[ "$provider" == "google" ]] && return 0 ;;
+	esac
+
+	return 1
+}
+
+copy_scoped_opencode_auth() {
+	local source_auth="$1"
+	local dest_auth="$2"
+	local provider="${3:-}"
+	local dest_dir
+
+	[[ -f "$source_auth" ]] || return 0
+	dest_dir=$(dirname "$dest_auth")
+	mkdir -p "$dest_dir"
+
+	if [[ -n "$provider" ]] && command -v jq >/dev/null 2>&1; then
+		local tmp_auth="${dest_auth}.tmp.$$"
+		if jq --arg p "$provider" 'if has($p) then {($p): .[$p]} else {} end' \
+			"$source_auth" >"$tmp_auth" 2>/dev/null; then
+			mv "$tmp_auth" "$dest_auth"
+			chmod 600 "$dest_auth" 2>/dev/null || true
+			return 0
+		fi
+		rm -f "$tmp_auth" 2>/dev/null || true
+	fi
+
+	cp "$source_auth" "$dest_auth" 2>/dev/null || true
+	chmod 600 "$dest_auth" 2>/dev/null || true
+	return 0
+}
+
 build_sandbox_passthrough_csv() {
+	local provider="${1:-}"
 	local names=()
 	local seen_names=" "
 	local name
@@ -396,11 +436,21 @@ build_sandbox_passthrough_csv() {
 		# workers causes them to attach to the pulse's session instead of
 		# creating independent sessions (GH#6668). Exclude it explicitly.
 		OPENCODE_PID) ;;
+		OPENAI_* | ANTHROPIC_* | GOOGLE_* | CLAUDE_*)
+			if [[ -n "$provider" ]] && ! _headless_provider_env_allowed "$provider" "$name"; then
+				continue
+			fi
+			if [[ "$seen_names" == *" ${name} "* ]]; then
+				continue
+			fi
+			seen_names+="${name} "
+			names+=("$name")
+			;;
 		# OTEL_* is passed through so headless workers under the sandbox
 		# can export OTLP traces when OTEL_EXPORTER_OTLP_ENDPOINT is set.
 		# Without this, opencode never initialises its OTLP exporter and
 		# all aidevops.* plugin span enrichment is silently dropped (t2186).
-		AIDEVOPS_* | PULSE_* | GH_* | GITHUB_* | OPENAI_* | ANTHROPIC_* | GOOGLE_* | OPENCODE_* | CLAUDE_* | XDG_* | OTEL_* | REAL_HOME | TMPDIR | TMP | TEMP | RTK_* | VERIFY_*)
+		AIDEVOPS_* | PULSE_* | GH_* | GITHUB_* | OPENCODE_* | XDG_* | OTEL_* | REAL_HOME | TMPDIR | TMP | TEMP | RTK_* | VERIFY_*)
 			if [[ "$seen_names" == *" ${name} "* ]]; then
 				continue
 			fi
@@ -1264,10 +1314,17 @@ _run_canary_test() {
 	_canary_config_dir=$(mktemp -d "${TMPDIR:-/tmp}/aidevops-canary-config.XXXXXX")
 	mkdir -p "${_canary_config_dir}/opencode"
 	printf '%s\n' "{\"\$schema\":\"https://opencode.ai/config.json\"}" >"${_canary_config_dir}/opencode/opencode.json"
-	# Copy auth.json so the canary has valid tokens
+	local _canary_provider
+	local _canary_default_provider="anthropic"
+	_canary_provider=$(extract_provider "$canary_model" 2>/dev/null || printf '%s' "$_canary_default_provider")
+	[[ -n "$_canary_provider" ]] || _canary_provider="$_canary_default_provider"
+
+	# Copy only the selected provider's auth entry so canary startup does not
+	# initialize unrelated provider state. Env/API-key auth still passes through
+	# normally via the selected provider's environment variables.
 	local _oc_auth="${XDG_DATA_HOME:-$HOME/.local/share}/opencode/auth.json"
 	if [[ -f "$_oc_auth" ]]; then
-		cp "$_oc_auth" "${_canary_data_dir}/opencode/auth.json" 2>/dev/null || true
+		copy_scoped_opencode_auth "$_oc_auth" "${_canary_data_dir}/opencode/auth.json" "$_canary_provider"
 	fi
 	# t3362: Mirror the real worker auth path. A multi-account OAuth pool can
 	# have the shared auth.json pointing at a cooldown/rate-limited account while
@@ -1275,9 +1332,6 @@ _run_canary_test() {
 	# launch; the canary must do the same or it blocks dispatch with a false
 	# no_worker_process failure before the worker gets a chance to rotate.
 	if [[ -f "${_canary_data_dir}/opencode/auth.json" ]] && declare -F _maybe_rotate_isolated_auth >/dev/null 2>&1; then
-		local _canary_provider
-		_canary_provider=$(extract_provider "$canary_model" 2>/dev/null || printf '%s' "anthropic")
-		[[ -n "$_canary_provider" ]] || _canary_provider="anthropic"
 		XDG_DATA_HOME="$_canary_data_dir" _maybe_rotate_isolated_auth \
 			"${_canary_data_dir}/opencode/auth.json" "$_canary_provider" || true
 	fi

--- a/.agents/scripts/tests/test-headless-runtime-helper.sh
+++ b/.agents/scripts/tests/test-headless-runtime-helper.sh
@@ -184,6 +184,56 @@ EOF
 	return 0
 }
 
+test_sandbox_passthrough_scopes_provider_env() {
+	local csv
+	csv=$(
+		OPENAI_API_KEY='openai-test' \
+		ANTHROPIC_API_KEY='anthropic-test' \
+		GOOGLE_API_KEY='google-test' \
+		OPENCODE_BIN='opencode' \
+		build_sandbox_passthrough_csv "openai"
+	)
+
+	if [[ "$csv" == *"OPENAI_API_KEY"* ]] &&
+		[[ "$csv" != *"ANTHROPIC_API_KEY"* ]] &&
+		[[ "$csv" != *"GOOGLE_API_KEY"* ]] &&
+		[[ "$csv" == *"OPENCODE_BIN"* ]]; then
+		print_result "sandbox passthrough scopes env to selected provider" 0
+		return 0
+	fi
+
+	print_result "sandbox passthrough scopes env to selected provider" 1 \
+		"Expected OpenAI env only, got: ${csv}"
+	return 0
+}
+
+test_copy_scoped_opencode_auth_keeps_selected_provider_only() {
+	local auth_root="${TEST_ROOT}/scoped-auth"
+	local source_auth="${auth_root}/source.json"
+	local dest_auth="${auth_root}/dest/opencode/auth.json"
+	mkdir -p "$auth_root"
+	cat >"$source_auth" <<'EOF'
+{
+  "openai": {"type": "oauth", "access": "openai-token"},
+  "anthropic": {"type": "oauth", "access": "anthropic-token"}
+}
+EOF
+
+	copy_scoped_opencode_auth "$source_auth" "$dest_auth" "openai"
+
+	local has_openai has_anthropic
+	has_openai=$(jq -r 'has("openai")' "$dest_auth")
+	has_anthropic=$(jq -r 'has("anthropic")' "$dest_auth")
+	if [[ "$has_openai" == "true" && "$has_anthropic" == "false" ]]; then
+		print_result "copy_scoped_opencode_auth keeps selected provider only" 0
+		return 0
+	fi
+
+	print_result "copy_scoped_opencode_auth keeps selected provider only" 1 \
+		"Expected only openai auth entry in ${dest_auth}"
+	return 0
+}
+
 # Helper: create a bare git repo and a feature branch with optional commits.
 # Each call uses work_dir-derived remote path to avoid inter-test collisions.
 # Args: $1 = work_dir path, $2 = 1 to add a commit (0 for none)
@@ -595,6 +645,8 @@ main() {
 	test_extract_session_id_from_output_returns_latest_session_id
 	test_headless_activity_timeout_default_matches_watchdog
 	test_canary_uses_builtin_agent_without_default_agent
+	test_sandbox_passthrough_scopes_provider_env
+	test_copy_scoped_opencode_auth_keeps_selected_provider_only
 	# Classification tests (GH#20819 refactor of _worker_produced_output)
 	test_worker_produced_output_no_commits_returns_noop
 	test_worker_produced_output_with_commits_returns_pr_exists_failopen


### PR DESCRIPTION
## Summary

Scoped headless OpenCode worker startup to the selected provider by filtering isolated auth.json and sandbox provider env passthrough, with canary parity and documentation.

## Files Changed

.agents/reference/worker-diagnostics.md,.agents/scripts/headless-runtime-helper.sh,.agents/scripts/headless-runtime-lib.sh,.agents/scripts/tests/test-headless-runtime-helper.sh

## Runtime Testing

- **Risk level:** Low (agent prompts / infrastructure scripts)
- **Verification:** bash .agents/scripts/tests/test-headless-runtime-helper.sh; shellcheck .agents/scripts/headless-runtime-helper.sh .agents/scripts/headless-runtime-lib.sh .agents/scripts/headless-runtime-worker.sh .agents/scripts/tests/test-headless-runtime-helper.sh; npx --yes markdownlint-cli2 .agents/reference/worker-diagnostics.md

Resolves #22255


<!-- aidevops:sig -->
---
[aidevops.sh](https://aidevops.sh) v3.13.90 plugin for [OpenCode](https://opencode.ai) v1.14.31 with gpt-5.5 spent 4m and 134,145 tokens on this as a headless worker.